### PR TITLE
fix(web): address React Doctor state and accessibility findings

### DIFF
--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
   type ReactNode,
 } from 'react'
@@ -109,8 +110,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     })
   }, [refreshAup])
 
+  const value = useMemo(
+    () => ({ phase, aup, error, connecting, connect, acceptAup, logout }),
+    [phase, aup, error, connecting, connect, acceptAup, logout],
+  )
+
   return (
-    <Ctx.Provider value={{ phase, aup, error, connecting, connect, acceptAup, logout }}>
+    <Ctx.Provider value={value}>
       {children}
     </Ctx.Provider>
   )

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -120,7 +120,10 @@ export function MobileSidebar({ open, onClose }: { open: boolean; onClose: () =>
 
   return (
     <div className={cn('fixed inset-0 z-40 md:hidden', !open && 'pointer-events-none')} aria-hidden={!open}>
-      <div
+      <button
+        type="button"
+        aria-label="Close menu"
+        tabIndex={open ? undefined : -1}
         onClick={onClose}
         className={cn(
           'absolute inset-0 bg-black/50 transition-opacity motion-reduce:transition-none',

--- a/web/src/pages/EngagementDetail.tsx
+++ b/web/src/pages/EngagementDetail.tsx
@@ -38,7 +38,7 @@ import {
   Wrench,
   X,
 } from 'lucide-react'
-import { Fragment, lazy, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { Fragment, lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import {
   Button,
@@ -264,7 +264,7 @@ export function EngagementDetail() {
         {tab === 'threats' && <ThreatModelTab engagementId={id} />}
         {tab === 'recon' && <ReconTab eng={eng} onGoTab={setTab} />}
         {tab === 'agent' && <AgentTab engagementId={id} />}
-        {tab === 'evidence' && <EvidenceTab engagementId={id} />}
+        {tab === 'evidence' && <EvidenceTab key={id} engagementId={id} />}
         {tab === 'settings' && <SettingsTab eng={eng} onUpdated={setEng} />}
       </div>
     </div>
@@ -4129,18 +4129,16 @@ function EvidenceTab({ engagementId }: { engagementId: string }) {
   const [ledger, setLedger] = useState<EvidenceLedger | null>(null)
   const [err, setErr] = useState<string | null>(null)
 
-  function reload() {
+  const reload = useCallback(() => {
     api
       .evidenceLedger(engagementId)
       .then(setLedger)
       .catch((e) => setErr(e instanceof Error ? e.message : 'Failed to load evidence'))
-  }
-  useEffect(() => {
-    setLedger(null)
-    setErr(null)
-    reload()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [engagementId])
+
+  useEffect(() => {
+    reload()
+  }, [reload])
 
   if (err) return <ErrorState message={err} />
   if (ledger === null) return <Spinner label="Loading evidence…" />


### PR DESCRIPTION
## Summary

Fixes targeted React Doctor state and accessibility findings in the web dashboard. This reduces avoidable rerenders, improves mobile sidebar keyboard/screen-reader behavior, and removes stale Evidence tab state resets when switching engagements.

## Changes

- Memoize `AuthContext` provider value to avoid rerendering all auth consumers on every provider render.
- Convert mobile sidebar backdrop from clickable `div` to native `button` with explicit `type` and accessible label.
- Remove hidden mobile backdrop from tab order when sidebar is closed.
- Remount `EvidenceTab` by engagement id so ledger/error state resets naturally on engagement changes.
- Stabilize `EvidenceTab` reload with `useCallback` and remove manual effect state reset plus exhaustive-deps suppression.

## Verification

- `pnpm typecheck`
- React Doctor scan for targeted React findings
- Docker API health check
- Browser E2E/perf pass

## Checklist

- [x] `make build vet test typecheck` passes
- [x] `cd web && pnpm build` passes (if the dashboard changed)
- [ ] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets
      out of logs, deterministic reports, append-only evidence) — see CONTRIBUTING.md
- [ ] Documentation updated if needed