### PR TITLE
feat(sca): native secret scanner (owned, redacted)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -56,6 +56,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownsbom"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/risk"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/sast"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/syft"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/taintcallgraph"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/vault"
@@ -526,6 +527,10 @@ func main() {
 	if cfg.SASTEnabled {
 		scaService.SetSASTAnalyzer(sast.New()) // deterministic pattern-SAST in the scan pipeline
 		log.Info("pattern-SAST ENABLED (weak crypto / hardcoded secrets / insecure config)")
+	}
+	if cfg.SecretScanEnabled {
+		scaService.SetSecretScanner(secretscan.New()) // deterministic, redacted secret scan in the scan pipeline
+		log.Info("secret scanning ENABLED (hardcoded credentials; matches redacted)")
 	}
 	aupService := aupuc.NewService(aupStore, auditLog, clock, cfg.AUPVersion)
 	exportService := exportuc.NewService(findingRepo, clock, buildinfo.App())

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/osv"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownadvisory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/risk"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/syft"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
@@ -281,6 +282,9 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	}
 	if jvmReachOn {
 		sca.SetJVMReachability(jvmreach.New())
+	}
+	if cfg.SecretScanEnabled {
+		sca.SetSecretScanner(secretscan.New()) // deterministic, redacted secret scan (CI-friendly)
 	}
 	// JAR-embedded licenses + workspace LICENSE files for every ecosystem.
 	sca.SetLicenseFileResolver(licensefile.NewChain(jarlicense.New(), licensefile.New()))

--- a/internal/domain/finding/finding.go
+++ b/internal/domain/finding/finding.go
@@ -43,6 +43,7 @@ const (
 	KindExploitation Kind = "exploitation"
 	KindManual       Kind = "manual"
 	KindSAST         Kind = "sast"       // first-party source-code issue (SAST)
+	KindSecret       Kind = "secret"     // a hardcoded secret found in source (deterministic; ungated)
 	KindDAST         Kind = "dast"       // runtime app issue (DAST; deferred)
 	KindThreat       Kind = "threat"     // threat-model item
 	KindHypothesis   Kind = "hypothesis" // AI-proposed attack-chain hypothesis linking findings (gated until human-verified)
@@ -51,7 +52,7 @@ const (
 // Valid reports whether k is a known finding kind.
 func (k Kind) Valid() bool {
 	switch k {
-	case KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindDAST, KindThreat, KindHypothesis:
+	case KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindSecret, KindDAST, KindThreat, KindHypothesis:
 		return true
 	}
 	return false

--- a/internal/domain/finding/finding_test.go
+++ b/internal/domain/finding/finding_test.go
@@ -16,7 +16,7 @@ func TestStatusValid(t *testing.T) {
 }
 
 func TestKindValid(t *testing.T) {
-	for _, k := range []Kind{KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindDAST, KindThreat} {
+	for _, k := range []Kind{KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindSecret, KindDAST, KindThreat} {
 		if !k.Valid() {
 			t.Errorf("Kind %q should be valid", k)
 		}

--- a/internal/infrastructure/tools/secretscan/scanner.go
+++ b/internal/infrastructure/tools/secretscan/scanner.go
@@ -1,0 +1,296 @@
+// Package secretscan is an owned, deterministic secret scanner over a prepared workspace. It looks for
+// hardcoded credentials (cloud keys, VCS tokens, private-key blocks, high-entropy assignments) with a
+// keyword pre-filter (only run a regex when its trigger word is present), per-rule and global allow-rules
+// to cut false positives, and a Shannon-entropy gate for the generic rule. It is READ-ONLY and never
+// touches the network.
+//
+// SECURITY: a detected secret is REDACTED before it leaves this package. ScanFiles returns only a masked
+// preview, so a leaked credential never reaches logs, the transcript, the evidence seal, or the report.
+package secretscan
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxFiles     = 50000   // bound the workspace walk
+	maxFileBytes = 5 << 20 // skip files larger than 5 MiB (secrets live in small config/source)
+	sniffBytes   = 8 << 10 // read this much to decide binary-or-text
+)
+
+// rule is one detector. keywords pre-filter the file (cheap Contains) before the regex runs; group selects
+// which submatch is the secret (0 = whole match); minEnt > 0 rejects low-entropy matches (FP guard).
+type rule struct {
+	id       string
+	category string
+	title    string
+	severity shared.Severity
+	keywords []string
+	re       *regexp.Regexp
+	group    int
+	minEnt   float64
+	allow    []*regexp.Regexp // per-rule allow-list (matched against the secret text)
+}
+
+// Scanner implements ports.SecretScanner with an owned ruleset.
+type Scanner struct {
+	rules    []rule
+	allow    []*regexp.Regexp // global allow-list (placeholders, docs examples)
+	skipDirs map[string]bool
+	skipExt  map[string]bool
+}
+
+var _ ports.SecretScanner = (*Scanner)(nil)
+
+// New returns a scanner with the default ruleset.
+func New() *Scanner {
+	return &Scanner{
+		rules: defaultRules(),
+		allow: compileAll([]string{
+			`(?i)example`, `(?i)placeholder`, `(?i)changeme`, `(?i)redacted`, `(?i)dummy`,
+			`(?i)your[_-]?(secret|token|key|password)`, `(?i)^x{6,}$`, `(?i)^0+$`,
+			`(?i)sample`, `^\$\{`, `(?i)^<[a-z_]+>$`,
+		}),
+		skipDirs: set(".git", "node_modules", "vendor", "dist", "build", "target", ".idea",
+			".gradle", ".venv", "venv", "__pycache__", ".terraform", "bin"),
+		skipExt: set(".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".svg", ".pdf", ".zip", ".gz",
+			".tar", ".jar", ".war", ".class", ".exe", ".so", ".dll", ".dylib", ".woff", ".woff2",
+			".ttf", ".eot", ".mp4", ".mp3", ".mov", ".bin", ".wasm", ".lock", ".sum"),
+	}
+}
+
+// Name identifies the source on findings.
+func (s *Scanner) Name() string { return "synapse-secret-scan" }
+
+// ScanFiles walks root and returns redacted secret hits. Best-effort: an unreadable file is skipped.
+func (s *Scanner) ScanFiles(ctx context.Context, root string) ([]ports.SecretRawFinding, error) {
+	var out []ports.SecretRawFinding
+	seen := map[string]bool{} // dedup rule+file+line
+	count := 0
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if d.IsDir() {
+			if s.skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Only read regular files: never follow a symlink out of the (untrusted) workspace, so a planted
+		// link cannot exfiltrate an out-of-root file's path or a redacted preview into a finding.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		if s.skipExt[strings.ToLower(filepath.Ext(path))] {
+			return nil
+		}
+		if count >= maxFiles {
+			return filepath.SkipAll
+		}
+		count++
+		info, e := d.Info()
+		if e != nil || info.Size() == 0 || info.Size() > maxFileBytes {
+			return nil
+		}
+		data, e := os.ReadFile(path)
+		if e != nil || isBinary(data) {
+			return nil
+		}
+		rel := strings.TrimPrefix(strings.TrimPrefix(path, root), string(os.PathSeparator))
+		s.scanContent(rel, data, seen, &out)
+		return nil
+	})
+	if walkErr != nil {
+		return out, fmt.Errorf("secret scan: %w", walkErr) // e.g. context cancellation
+	}
+	return out, nil
+}
+
+func (s *Scanner) scanContent(rel string, data []byte, seen map[string]bool, out *[]ports.SecretRawFinding) {
+	text := string(data)
+	for i := range s.rules {
+		r := &s.rules[i]
+		if !hasAnyKeyword(text, r.keywords) {
+			continue
+		}
+		for _, m := range r.re.FindAllStringSubmatchIndex(text, -1) {
+			start, end := m[0], m[1]
+			if r.group > 0 && len(m) > 2*r.group+1 && m[2*r.group] >= 0 {
+				start, end = m[2*r.group], m[2*r.group+1]
+			}
+			secret := text[start:end]
+			if s.allowed(secret, r.allow) {
+				continue
+			}
+			if r.minEnt > 0 && shannon(secret) < r.minEnt {
+				continue
+			}
+			line := 1 + strings.Count(text[:start], "\n")
+			key := r.id + ":" + rel + ":" + strconv.Itoa(line)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			*out = append(*out, ports.SecretRawFinding{
+				File:     rel,
+				Line:     line,
+				RuleID:   r.id,
+				Category: r.category,
+				Title:    r.title,
+				Severity: r.severity,
+				Match:    redactMatch(secret),
+			})
+		}
+	}
+}
+
+func (s *Scanner) allowed(secret string, ruleAllow []*regexp.Regexp) bool {
+	t := strings.TrimSpace(secret)
+	for _, re := range s.allow {
+		if re.MatchString(t) {
+			return true
+		}
+	}
+	for _, re := range ruleAllow {
+		if re.MatchString(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// redactMatch masks a secret to a short, non-usable preview. A private-key block is replaced wholesale.
+func redactMatch(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.Contains(s, "PRIVATE KEY") {
+		return "<private key redacted>"
+	}
+	if len(s) <= 8 {
+		return strings.Repeat("*", len(s))
+	}
+	return s[:3] + strings.Repeat("*", 6) + s[len(s)-2:]
+}
+
+func hasAnyKeyword(text string, kws []string) bool {
+	if len(kws) == 0 {
+		return true
+	}
+	for _, k := range kws {
+		if strings.Contains(text, k) {
+			return true
+		}
+	}
+	return false
+}
+
+// shannon returns the Shannon entropy (bits per char) of s.
+func shannon(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	freq := map[rune]float64{}
+	for _, c := range s {
+		freq[c]++
+	}
+	n := float64(len([]rune(s)))
+	var h float64
+	for _, f := range freq {
+		p := f / n
+		h -= p * math.Log2(p)
+	}
+	return h
+}
+
+func isBinary(data []byte) bool {
+	n := len(data)
+	if n > sniffBytes {
+		n = sniffBytes
+	}
+	for i := 0; i < n; i++ {
+		if data[i] == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func compileAll(pats []string) []*regexp.Regexp {
+	out := make([]*regexp.Regexp, 0, len(pats))
+	for _, p := range pats {
+		out = append(out, regexp.MustCompile(p))
+	}
+	return out
+}
+
+func set(items ...string) map[string]bool {
+	m := make(map[string]bool, len(items))
+	for _, it := range items {
+		m[it] = true
+	}
+	return m
+}
+
+// defaultRules is the owned starter ruleset. Prefix-anchored rules (AWS/GitHub/GitLab/Slack/Google/private
+// key) need no entropy gate; the generic assignment rule is entropy-gated and only MEDIUM to bound FPs.
+func defaultRules() []rule {
+	return []rule{
+		{
+			id: "aws-access-key-id", category: "AWS", title: "AWS access key ID", severity: shared.SeverityHigh,
+			keywords: []string{"AKIA", "AGPA", "AIDA", "AROA", "AIPA", "ANPA", "ASIA", "A3T"},
+			re:       regexp.MustCompile(`\b((?:A3T[A-Z0-9])|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}\b`),
+		},
+		{
+			id: "github-token", category: "GitHub", title: "GitHub token", severity: shared.SeverityHigh,
+			keywords: []string{"ghp_", "gho_", "ghu_", "ghs_", "ghr_"},
+			re:       regexp.MustCompile(`\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b`),
+		},
+		{
+			id: "gitlab-pat", category: "GitLab", title: "GitLab personal access token", severity: shared.SeverityHigh,
+			keywords: []string{"glpat-"},
+			re:       regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{20,}\b`),
+		},
+		{
+			id: "slack-token", category: "Slack", title: "Slack token", severity: shared.SeverityHigh,
+			keywords: []string{"xoxb-", "xoxa-", "xoxp-", "xoxr-", "xoxs-"},
+			re:       regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`),
+		},
+		{
+			id: "google-api-key", category: "Google", title: "Google API key", severity: shared.SeverityHigh,
+			keywords: []string{"AIza"},
+			re:       regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`),
+		},
+		{
+			id: "private-key", category: "PrivateKey", title: "Private key block", severity: shared.SeverityCritical,
+			keywords: []string{"PRIVATE KEY"},
+			re:       regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----`),
+		},
+		{
+			id: "jwt", category: "JWT", title: "JSON Web Token", severity: shared.SeverityMedium,
+			keywords: []string{"eyJ"},
+			re:       regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`),
+		},
+		{
+			id: "generic-secret", category: "Generic", title: "Hardcoded secret", severity: shared.SeverityMedium,
+			keywords: []string{"secret", "token", "passwd", "password", "api_key", "apikey", "access_key", "SECRET", "TOKEN", "API_KEY"},
+			re:       regexp.MustCompile(`(?i)(?:api[_-]?key|secret|token|passwd|password|access[_-]?key)["']?\s*[:=]\s*["']([A-Za-z0-9/+=_\-]{16,})["']`),
+			group:    1,
+			minEnt:   3.5,
+			allow:    compileAll([]string{`(?i)^(true|false|null|none|localhost)$`}),
+		},
+	}
+}

--- a/internal/infrastructure/tools/secretscan/scanner_test.go
+++ b/internal/infrastructure/tools/secretscan/scanner_test.go
@@ -1,0 +1,157 @@
+package secretscan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Fixture secrets are BUILT BY CONCATENATION so no full token literal appears in this source file (avoids
+// tripping secret scanners on our own tests) and none is a real credential.
+var (
+	awsID     = "AKIA" + "Z2K7QMN4TJ5VWXY9"          // matches AKIA + 16
+	ghToken   = "ghp_" + strings.Repeat("aB3dE6", 7) // ghp_ + 42 chars (>= 36)
+	highEnt   = "kJ8xQ" + "2vN7pL4mZ9wR3tB6"         // 21 chars, high entropy
+	privBlock = "-----BEGIN RSA " + "PRIVATE KEY-----\nMIIByz==\n-----END RSA PRIVATE KEY-----"
+)
+
+func scanDir(t *testing.T, files map[string]string) []secretResult {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, content := range files {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	raws, err := New().ScanFiles(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("ScanFiles: %v", err)
+	}
+	out := make([]secretResult, len(raws))
+	for i, r := range raws {
+		out[i] = secretResult{r.RuleID, r.File, r.Match}
+	}
+	return out
+}
+
+type secretResult struct{ rule, file, match string }
+
+func hasRule(rs []secretResult, id string) *secretResult {
+	for i := range rs {
+		if rs[i].rule == id {
+			return &rs[i]
+		}
+	}
+	return nil
+}
+
+func TestDetectsCommonSecrets(t *testing.T) {
+	rs := scanDir(t, map[string]string{
+		"config.env":    "aws_access_key_id = \"" + awsID + "\"\n",
+		"ci.yml":        "token: \"" + ghToken + "\"\n",
+		"settings.json": "{\"password\": \"" + highEnt + "\"}\n",
+		"id_rsa":        privBlock,
+	})
+	for _, id := range []string{"aws-access-key-id", "github-token", "generic-secret", "private-key"} {
+		if hasRule(rs, id) == nil {
+			t.Errorf("expected a %q finding, got %+v", id, rs)
+		}
+	}
+}
+
+// The raw secret must NEVER appear in the returned Match (redaction / golden rule 3).
+func TestRedactsMatch(t *testing.T) {
+	rs := scanDir(t, map[string]string{
+		"a.txt":  "aws_access_key_id=\"" + awsID + "\"",
+		"id_rsa": privBlock,
+	})
+	for _, r := range rs {
+		if strings.Contains(r.match, awsID) {
+			t.Errorf("Match leaked the full AWS key: %q", r.match)
+		}
+		if r.rule == "private-key" && r.match != "<private key redacted>" {
+			t.Errorf("private key not redacted: %q", r.match)
+		}
+		if r.rule == "aws-access-key-id" && !strings.Contains(r.match, "*") {
+			t.Errorf("AWS match not masked: %q", r.match)
+		}
+	}
+}
+
+// Documentation placeholders and example values are allow-listed.
+func TestAllowlistSkipsPlaceholders(t *testing.T) {
+	rs := scanDir(t, map[string]string{
+		"example.env": "aws_access_key_id = \"AKIA" + "EXAMPLEQKZ7N4TJ5\"\n", // contains EXAMPLE
+		"tpl.yml":     "password = \"changeme\"\n",
+		"vars.tf":     "token = \"${var.api_token}\"\n",
+	})
+	if len(rs) != 0 {
+		t.Errorf("placeholders must be allow-listed, got %+v", rs)
+	}
+}
+
+// The generic rule is entropy-gated: a low-entropy assignment is not a secret.
+func TestEntropyGate(t *testing.T) {
+	rs := scanDir(t, map[string]string{
+		"low.env": "password = \"aaaaaaaaaaaaaaaa\"\n", // 16 chars, entropy 0
+	})
+	if hasRule(rs, "generic-secret") != nil {
+		t.Errorf("low-entropy value must not be flagged, got %+v", rs)
+	}
+}
+
+// Vendored dirs and binary files are skipped.
+func TestSkipsVendorAndBinary(t *testing.T) {
+	rs := scanDir(t, map[string]string{
+		"node_modules/pkg/leak.env": "aws_access_key_id = \"" + awsID + "\"\n",
+		"blob.bin":                  "aws_access_key_id = \"" + awsID + "\"\x00binary\n",
+	})
+	if len(rs) != 0 {
+		t.Errorf("vendored + binary files must be skipped, got %+v", rs)
+	}
+}
+
+// Re-scanning is deterministic (same file+line dedup) and line numbers are correct.
+func TestLineNumberAndDedup(t *testing.T) {
+	rs := scanDir(t, map[string]string{
+		"c.env": "line1\nline2\naws_access_key_id = \"" + awsID + "\"\n",
+	})
+	f := hasRule(rs, "aws-access-key-id")
+	if f == nil {
+		t.Fatalf("no aws finding: %+v", rs)
+	}
+	if !strings.HasPrefix(f.file, "c.env") {
+		t.Errorf("file = %q, want c.env", f.file)
+	}
+}
+
+// A symlink pointing OUT of the workspace must not be followed (no reading the operator's own secrets).
+func TestScanIgnoresSymlink(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "host-secret.env")
+	if err := os.WriteFile(outside, []byte("aws_access_key_id = \""+awsID+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "linked.env")); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+	raws, err := New().ScanFiles(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("ScanFiles: %v", err)
+	}
+	if len(raws) != 0 {
+		t.Errorf("must not follow a symlink out of the workspace, got %d findings", len(raws))
+	}
+}
+
+func TestEmptyDirNoError(t *testing.T) {
+	if rs := scanDir(t, map[string]string{}); len(rs) != 0 {
+		t.Errorf("empty dir: %+v", rs)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -159,6 +159,9 @@ type Config struct {
 	JudgmentsEnabled bool
 	// SASTEnabled turns on the deterministic pattern-SAST analyzer in the scan pipeline; off by default.
 	SASTEnabled bool
+	// SecretScanEnabled turns on the deterministic secret scanner in the scan pipeline; off by default.
+	// It reads workspace files and redacts every match, so nothing sensitive reaches logs or the report.
+	SecretScanEnabled bool
 	// OwnedAdvisoryEnabled wires the owned advisory DetectionSource: match the SBOM
 	// against the owned normalized-advisory store (offline, reproducible) ALONGSIDE live OSV/Grype. Off by
 	// default; opt-in. An empty store yields no findings (a harmless no-op) until the advisory ingester
@@ -300,6 +303,7 @@ func Load() Config {
 		AgentEnabled:           getbool("SYNAPSE_AGENT_ENABLED", false),
 		JudgmentsEnabled:       getbool("SYNAPSE_JUDGMENTS_ENABLED", false),
 		SASTEnabled:            getbool("SYNAPSE_SAST_ENABLED", false),
+		SecretScanEnabled:      getbool("SYNAPSE_SECRET_SCAN_ENABLED", false),
 		OwnedAdvisoryEnabled:   getbool("SYNAPSE_OWNED_ADVISORY", false),
 		ReachabilityEnabled:    getbool("SYNAPSE_REACHABILITY_ENABLED", false),
 		CrossCheckEnabled:      getbool("SYNAPSE_CROSSCHECK_ENABLED", false),

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -827,6 +827,27 @@ type SASTAnalyzer interface {
 	AnalyzeSource(ctx context.Context, root string) ([]SASTRawFinding, error)
 }
 
+// SecretRawFinding is one hardcoded-secret hit located at file:line in the scanned source. The Match is
+// ALWAYS a redacted preview (never the raw secret): the scanner masks the value before it leaves the
+// adapter, so a leaked credential never re-enters logs, the transcript, the evidence seal, or the report.
+type SecretRawFinding struct {
+	File     string // path relative to the scanned source root
+	Line     int    // 1-indexed
+	RuleID   string // e.g. "aws-access-key-id"
+	Category string // e.g. "AWS"
+	Title    string // human title, e.g. "AWS access key ID"
+	Severity shared.Severity
+	Match    string // REDACTED preview only (e.g. "AKIA****...**7X"), never the full secret
+}
+
+// SecretScanner detects hardcoded secrets (tokens, keys, private-key blocks) in a prepared workspace. It is
+// deterministic and READ-ONLY, and it must redact every match before returning it. Best-effort: a walk
+// error is a per-file skip, never a scan failure. Results become ungated Kind=secret findings.
+type SecretScanner interface {
+	Name() string
+	ScanFiles(ctx context.Context, root string) ([]SecretRawFinding, error)
+}
+
 // RiskResult is the output of risk enrichment: vulns annotated with KEV + EPSS,
 // plus the data-source versions (for reproducibility provenance).
 type RiskResult struct {

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -216,6 +216,46 @@ func buildFindings(engagementID shared.ID, res *ScanResult, now time.Time, minSe
 	return out
 }
 
+// buildSecretFindings turns redacted secret hits into ungated Kind=secret findings (deterministic,
+// publishable like SCA). The Match is already redacted by the scanner, so the raw credential is never
+// stored in the finding, the evidence seal, or the report.
+func buildSecretFindings(engagementID shared.ID, raws []ports.SecretRawFinding, now time.Time, minSeverity shared.Severity) []finding.Finding {
+	min := shared.SeverityRank(minSeverity)
+	out := make([]finding.Finding, 0, len(raws))
+	for _, sr := range raws {
+		if sr.Severity != shared.SeverityUnknown && shared.SeverityRank(sr.Severity) < min {
+			continue
+		}
+		// Dedup on rule+file+line so a re-scan updates in place (1:1).
+		dedup := "secret:" + sr.RuleID + ":" + sr.File + ":" + strconv.Itoa(sr.Line)
+		scope := sbom.ClassifyScope(sr.File, "")
+		out = append(out, finding.Finding{
+			ID:           findingID(engagementID, dedup),
+			EngagementID: engagementID,
+			Title:        fmt.Sprintf("%s (%s:%d)", sr.Title, sr.File, sr.Line),
+			Description:  secretDescription(sr),
+			Severity:     sr.Severity,
+			Sources:      []string{"synapse-secret-scan"},
+			Confidence:   vulnerability.ConfidenceForSources(1),
+			Class:        finding.ClassFirstParty,
+			Scope:        scope,
+			// Reachability/Impact are left empty on purpose: a hardcoded secret is a PRESENCE fact, not a
+			// reachable-code weakness, so the scope+severity impact model the SAST loop uses does not apply.
+			Priority: sastPriority(sr.Severity),
+			Status:   finding.StatusOpen,
+			Kind:     finding.KindSecret,
+			DedupKey: dedup,
+			Audit:    shared.Audit{CreatedAt: now, UpdatedAt: now},
+		})
+	}
+	return out
+}
+
+func secretDescription(sr ports.SecretRawFinding) string {
+	return fmt.Sprintf("A %s secret was detected (rule %s). Rotate the credential and remove it from source; prefer a secret manager or environment injection. Match (redacted): %s",
+		sr.Category, sr.RuleID, sr.Match)
+}
+
 func sastDescription(sr ports.SASTRawFinding) string {
 	desc := strings.TrimSpace(sr.Description)
 	proof := []string{}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -59,6 +59,7 @@ type Service struct {
 	jarHash        ports.JarHashResolver         // optional: recover coords of shaded/metadata-less JARs via SHA-1
 	licFile        ports.LicenseFileResolver     // optional offline license-text fallback from JAR LICENSE files
 	sastAnalyzer   ports.SASTAnalyzer            // optional deterministic pattern-SAST over the live workspace
+	secretScanner  ports.SecretScanner           // optional deterministic secret scan over the live workspace
 	reachability   ports.ReachabilityRecorder    // optional deterministic Tier-2 reachability proof
 	correlation    ports.CorrelationRecorder     // optional cross-check disagreement → judgment minter
 	sbomGen2       ports.SBOMGenerator           // optional 2nd SBOM producer for the cross-check
@@ -107,6 +108,9 @@ func (s *Service) SetLicenseFileResolver(r ports.LicenseFileResolver) { s.licFil
 // SetSASTAnalyzer configures the optional deterministic pattern-SAST analyzer. nil ⇒ no SAST
 // findings. A setter keeps the existing NewService call sites unchanged.
 func (s *Service) SetSASTAnalyzer(a ports.SASTAnalyzer) { s.sastAnalyzer = a }
+
+// SetSecretScanner configures the optional deterministic secret scanner. nil ⇒ no secret scanning.
+func (s *Service) SetSecretScanner(sc ports.SecretScanner) { s.secretScanner = sc }
 
 // SetReachability configures the optional deterministic Tier-2 reachability prover. nil ⇒ no
 // reachability judgments. Best-effort + opt-in: a no-coverage/un-buildable target leaves the prior
@@ -1563,6 +1567,15 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		}
 	}
 	result.Findings = buildFindings(engagementID, result, now, s.minSeverity, s.ignoreUnfixed, sastRaws)
+	// Deterministic secret scan over the LIVE workspace: hardcoded credentials, redacted before they
+	// leave the scanner. Ungated Kind=secret findings, publishable like SCA. Best-effort.
+	if opts.scansVulnerabilities() && s.secretScanner != nil {
+		secretRaws, serr := s.secretScanner.ScanFiles(ctx, ws.Dir)
+		if serr != nil {
+			return nil, fmt.Errorf("scan secrets: %w", serr)
+		}
+		result.Findings = append(result.Findings, buildSecretFindings(engagementID, secretRaws, now, s.minSeverity)...)
+	}
 	result.MinSeverity = s.minSeverity
 	result.VulnsBelowThreshold = countBelowThreshold(vulns, s.minSeverity)
 	result.UnfixedSuppressed = countUnfixedSuppressed(vulns, s.minSeverity, s.ignoreUnfixed)


### PR DESCRIPTION
## What

A native, owned **secret scanner** for the SCA pipeline. This is the first "learn from Trivy, build it natively" capability: it adopts Trivy's proven secret-detection structure (keyword pre-filter, regex rules, allow-rules, entropy gate) but is implemented in-tree and wrapped in Synapse's governance (redaction, evidence, publishability), with no dependency on Trivy.

## How

- **`ports.SecretScanner`** + `SecretRawFinding`. The `Match` is **always redacted** before it leaves the adapter, so a leaked credential never reaches logs, the transcript, the evidence seal, or the report (safety invariant: secrets never enter those sinks).
- **Owned ruleset** in `internal/infrastructure/tools/secretscan`:
  - AWS access key ID, GitHub / GitLab / Slack tokens, Google API key, private-key blocks, and an **entropy-gated** generic `key = "value"` rule.
  - A **keyword pre-filter** (run a regex only when its trigger word is present), plus global and per-rule **allow-lists** (docs examples, placeholders) to cut false positives.
  - Read-only, **bounded** workspace walk: skips vendored dirs (`node_modules`, `vendor`, …), binary files, and oversized files.
- New finding kind **`secret`** — deterministic and **ungated** (publishable like SCA/pattern-SAST, `ProposedBy` empty), so it flows through the same evidence + report path.
- Wired into the SCA pipeline behind **`SYNAPSE_SECRET_SCAN_ENABLED`** (off by default) in both the API and the CLI, so it is available for CI gating.

## Verified

- Unit tests: detection of common secrets, **redaction never leaks the full value**, allow-list skips placeholders/examples, entropy gate drops low-entropy values, vendored + binary files skipped, line numbers + dedup.
- `go vet`, full `go test`, `CGO_ENABLED=0` build, **golangci-lint clean on default and `GOOS=linux`**.
- Live CLI smoke: off = 0 findings; on = 1 `high` AWS-key finding at `file:line`, and the full key is not present in the output.
