### PR TITLE
feat(sca): native IaC/misconfig scanner (Dockerfile + Kubernetes)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -56,6 +56,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownsbom"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/risk"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/sast"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/syft"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/taintcallgraph"
@@ -531,6 +532,10 @@ func main() {
 	if cfg.SecretScanEnabled {
 		scaService.SetSecretScanner(secretscan.New()) // deterministic, redacted secret scan in the scan pipeline
 		log.Info("secret scanning ENABLED (hardcoded credentials; matches redacted)")
+	}
+	if cfg.MisconfigEnabled {
+		scaService.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan in the scan pipeline
+		log.Info("misconfig scanning ENABLED (Dockerfile + Kubernetes manifests)")
 	}
 	aupService := aupuc.NewService(aupStore, auditLog, clock, cfg.AUPVersion)
 	exportService := exportuc.NewService(findingRepo, clock, buildinfo.App())

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/osv"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownadvisory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/risk"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/syft"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo"
@@ -285,6 +286,9 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	}
 	if cfg.SecretScanEnabled {
 		sca.SetSecretScanner(secretscan.New()) // deterministic, redacted secret scan (CI-friendly)
+	}
+	if cfg.MisconfigEnabled {
+		sca.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan (CI-friendly)
 	}
 	// JAR-embedded licenses + workspace LICENSE files for every ecosystem.
 	sca.SetLicenseFileResolver(licensefile.NewChain(jarlicense.New(), licensefile.New()))

--- a/internal/domain/finding/finding.go
+++ b/internal/domain/finding/finding.go
@@ -44,6 +44,7 @@ const (
 	KindManual       Kind = "manual"
 	KindSAST         Kind = "sast"       // first-party source-code issue (SAST)
 	KindSecret       Kind = "secret"     // a hardcoded secret found in source (deterministic; ungated)
+	KindMisconfig    Kind = "misconfig"  // an insecure IaC/config setting (deterministic; ungated)
 	KindDAST         Kind = "dast"       // runtime app issue (DAST; deferred)
 	KindThreat       Kind = "threat"     // threat-model item
 	KindHypothesis   Kind = "hypothesis" // AI-proposed attack-chain hypothesis linking findings (gated until human-verified)
@@ -52,7 +53,7 @@ const (
 // Valid reports whether k is a known finding kind.
 func (k Kind) Valid() bool {
 	switch k {
-	case KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindSecret, KindDAST, KindThreat, KindHypothesis:
+	case KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindSecret, KindMisconfig, KindDAST, KindThreat, KindHypothesis:
 		return true
 	}
 	return false

--- a/internal/domain/finding/finding_test.go
+++ b/internal/domain/finding/finding_test.go
@@ -16,7 +16,7 @@ func TestStatusValid(t *testing.T) {
 }
 
 func TestKindValid(t *testing.T) {
-	for _, k := range []Kind{KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindSecret, KindDAST, KindThreat} {
+	for _, k := range []Kind{KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindSecret, KindMisconfig, KindDAST, KindThreat} {
 		if !k.Valid() {
 			t.Errorf("Kind %q should be valid", k)
 		}

--- a/internal/infrastructure/tools/misconfig/dockerfile.go
+++ b/internal/infrastructure/tools/misconfig/dockerfile.go
@@ -1,0 +1,217 @@
+package misconfig
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// pipeToShell matches a download piped straight into a shell (curl ... | sh, wget ... | bash) — a common
+// remote-code-execution pattern in image builds.
+var pipeToShell = regexp.MustCompile(`(?i)\b(?:curl|wget)\b[^|]*\|\s*(?:sudo\s+)?(?:ba)?sh\b`)
+
+// instruction is one logical Dockerfile instruction with its starting line (backslash continuations joined).
+type instruction struct {
+	cmd  string // upper-cased, e.g. "FROM"
+	args string // the remainder of the logical line
+	line int    // 1-indexed line of the instruction start
+}
+
+// scanDockerfile runs the owned Dockerfile checks and returns located findings.
+func scanDockerfile(rel string, data []byte) []ports.MisconfigRawFinding {
+	instrs := parseDockerfile(string(data))
+	var out []ports.MisconfigRawFinding
+
+	// Track build stages so multi-stage builds are judged by their FINAL stage (an early builder stage
+	// running as root is fine). A new FROM opens a stage; USER within it sets that stage's user.
+	stageNames := map[string]bool{}
+	var lastUserLine, lastFromLine int
+	lastUserRoot := true // no USER yet ⇒ root
+	haveStage := false
+
+	for _, in := range instrs {
+		switch in.cmd {
+		case "FROM":
+			// New stage: reset the per-stage user state.
+			haveStage = true
+			lastFromLine = in.line
+			lastUserLine = 0
+			lastUserRoot = true
+			img, alias := parseFrom(in.args)
+			if alias != "" {
+				stageNames[strings.ToLower(alias)] = true
+			}
+			if r, ok := checkBaseImageTag(img, stageNames, rel, in.line); ok {
+				out = append(out, r)
+			}
+		case "USER":
+			lastUserLine = in.line
+			lastUserRoot = isRootUser(in.args)
+		case "ADD":
+			if r, ok := checkAddRemote(in.args, rel, in.line); ok {
+				out = append(out, r)
+			}
+		case "RUN":
+			if pipeToShell.MatchString(in.args) {
+				out = append(out, ports.MisconfigRawFinding{
+					File: rel, Line: in.line, RuleID: "dockerfile-run-pipe-shell",
+					Title: "Remote script piped to a shell", Severity: shared.SeverityHigh,
+					Resource:    "Dockerfile RUN",
+					Description: "A RUN step downloads a script and pipes it directly into a shell (e.g. curl ... | sh), executing unverified remote code at build time. Download to a file, verify a checksum or signature, then run it.",
+				})
+			}
+		}
+	}
+
+	// Final-stage user check: if the last stage runs as root (explicit root USER, or no USER at all),
+	// flag it. Point at the offending USER line, or the final FROM when none was set.
+	if haveStage && lastUserRoot {
+		line := lastUserLine
+		desc := "The final build stage sets USER root (or 0), so the container runs as root. Add a non-root USER as the last USER instruction."
+		if lastUserLine == 0 {
+			line = lastFromLine
+			desc = "No USER instruction, so the container runs as root by default. Add a non-root USER (e.g. a dedicated app user) before the entrypoint."
+		}
+		out = append(out, ports.MisconfigRawFinding{
+			File: rel, Line: line, RuleID: "dockerfile-run-as-root",
+			Title: "Container runs as root", Severity: shared.SeverityHigh,
+			Resource: "Dockerfile USER", Description: desc,
+		})
+	}
+	return out
+}
+
+// checkBaseImageTag flags a FROM that pins no immutable version: no tag, an explicit :latest, and no
+// @sha256 digest. It skips `scratch`, ARG-templated refs, and references to a previous local stage.
+func checkBaseImageTag(img string, stageNames map[string]bool, rel string, line int) (ports.MisconfigRawFinding, bool) {
+	if img == "" || img == "scratch" || strings.Contains(img, "$") {
+		return ports.MisconfigRawFinding{}, false
+	}
+	if stageNames[strings.ToLower(img)] {
+		return ports.MisconfigRawFinding{}, false // FROM a prior build stage, not a registry image
+	}
+	if strings.Contains(img, "@sha256:") {
+		return ports.MisconfigRawFinding{}, false // digest-pinned
+	}
+	tag := imageTag(img)
+	if tag != "" && tag != "latest" {
+		return ports.MisconfigRawFinding{}, false // an explicit non-latest tag
+	}
+	return ports.MisconfigRawFinding{
+		File: rel, Line: line, RuleID: "dockerfile-image-no-tag",
+		Title: "Base image is not version-pinned", Severity: shared.SeverityMedium,
+		Resource:    "Dockerfile FROM " + clip(img),
+		Description: "The base image uses no tag or :latest, so builds are not reproducible and can silently pull a changed or vulnerable image. Pin an explicit version tag, ideally with an @sha256 digest.",
+	}, true
+}
+
+// checkAddRemote flags ADD with a remote (http/https) source; COPY, or a verified download in a RUN
+// step, is preferred.
+func checkAddRemote(args, rel string, line int) (ports.MisconfigRawFinding, bool) {
+	for _, f := range fields(args) {
+		if strings.HasPrefix(f, "http://") || strings.HasPrefix(f, "https://") {
+			return ports.MisconfigRawFinding{
+				File: rel, Line: line, RuleID: "dockerfile-add-remote-url",
+				Title: "ADD fetches a remote URL", Severity: shared.SeverityMedium,
+				Resource:    "Dockerfile ADD",
+				Description: "ADD with a remote URL downloads over the network with no integrity check and does not cache well. Use a RUN step that downloads and verifies a checksum, or COPY a vendored file.",
+			}, true
+		}
+	}
+	return ports.MisconfigRawFinding{}, false
+}
+
+// parseDockerfile splits source into logical instructions, joining backslash line-continuations and
+// skipping comments and blank lines. The reported line is where the instruction starts.
+func parseDockerfile(src string) []instruction {
+	lines := strings.Split(src, "\n")
+	var out []instruction
+	i := 0
+	for i < len(lines) {
+		raw := strings.TrimRight(lines[i], "\r")
+		trimmed := strings.TrimSpace(raw)
+		startLine := i + 1
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			i++
+			continue
+		}
+		// Join continuations: a trailing backslash continues onto the next line.
+		full := trimmed
+		for strings.HasSuffix(strings.TrimRight(full, " \t"), `\`) && i+1 < len(lines) {
+			full = strings.TrimSuffix(strings.TrimRight(full, " \t"), `\`)
+			i++
+			full += " " + strings.TrimSpace(strings.TrimRight(lines[i], "\r"))
+		}
+		i++
+		cmd, args := splitInstruction(full)
+		if cmd == "" {
+			continue
+		}
+		out = append(out, instruction{cmd: strings.ToUpper(cmd), args: strings.TrimSpace(args), line: startLine})
+	}
+	return out
+}
+
+func splitInstruction(line string) (cmd, args string) {
+	line = strings.TrimSpace(line)
+	sp := strings.IndexAny(line, " \t")
+	if sp < 0 {
+		return line, ""
+	}
+	return line[:sp], line[sp+1:]
+}
+
+// parseFrom returns the image reference and the optional stage alias ("... AS name").
+func parseFrom(args string) (img, alias string) {
+	f := fields(args)
+	// Drop --platform=... and similar flags.
+	rest := make([]string, 0, len(f))
+	for _, tok := range f {
+		if strings.HasPrefix(tok, "--") {
+			continue
+		}
+		rest = append(rest, tok)
+	}
+	if len(rest) == 0 {
+		return "", ""
+	}
+	img = rest[0]
+	for j := 1; j+1 < len(rest); j++ {
+		if strings.EqualFold(rest[j], "AS") {
+			alias = rest[j+1]
+			break
+		}
+	}
+	return img, alias
+}
+
+// imageTag returns the tag portion of an image ref (after the last ':' that is not part of a registry
+// host:port), or "" when untagged. A '/' after the last ':' means the colon was a port, not a tag.
+func imageTag(img string) string {
+	if strings.Contains(img, "@") {
+		img = img[:strings.Index(img, "@")]
+	}
+	c := strings.LastIndex(img, ":")
+	if c < 0 {
+		return ""
+	}
+	if strings.Contains(img[c:], "/") {
+		return "" // the colon belonged to a registry host:port
+	}
+	return img[c+1:]
+}
+
+func isRootUser(args string) bool {
+	u := strings.TrimSpace(args)
+	if i := strings.IndexAny(u, " \t"); i >= 0 {
+		u = u[:i]
+	}
+	if c := strings.IndexByte(u, ':'); c >= 0 { // strip :group
+		u = u[:c]
+	}
+	return u == "" || u == "root" || u == "0"
+}
+
+func fields(s string) []string { return strings.Fields(s) }

--- a/internal/infrastructure/tools/misconfig/kubernetes.go
+++ b/internal/infrastructure/tools/misconfig/kubernetes.go
@@ -1,0 +1,305 @@
+package misconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// dangerousCaps are Linux capabilities that grant broad host control; adding any of them (or ALL)
+// effectively removes the container boundary.
+var dangerousCaps = set("ALL", "SYS_ADMIN", "NET_ADMIN", "NET_RAW", "SYS_PTRACE",
+	"SYS_MODULE", "SYS_BOOT", "DAC_READ_SEARCH", "SYS_RAWIO")
+
+// maxNestDepth bounds YAML flow-collection nesting before we decode. yaml.v3 has no recursion-depth
+// limit, so a deeply-nested untrusted document (e.g. millions of '[') can overflow the parser's stack —
+// a FATAL error that recover() cannot catch. Real manifests nest < ~30 deep; 200 is generous headroom.
+const maxNestDepth = 200
+
+// maxLocatorDepth bounds the best-effort line locator's recursion (defense-in-depth; the pre-decode
+// depth guard already keeps trees shallow).
+const maxLocatorDepth = 1000
+
+// k8sDoc is the slice of a Kubernetes object we inspect. A workload (Deployment, StatefulSet, ...) nests
+// the pod under spec.template.spec; a bare Pod uses spec directly — podSpec() resolves both.
+type k8sDoc struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name      string `yaml:"name"`
+		Namespace string `yaml:"namespace"`
+	} `yaml:"metadata"`
+	Spec k8sSpec `yaml:"spec"`
+}
+
+type k8sSpec struct {
+	HostNetwork    bool           `yaml:"hostNetwork"`
+	HostPID        bool           `yaml:"hostPID"`
+	HostIPC        bool           `yaml:"hostIPC"`
+	Containers     []k8sContainer `yaml:"containers"`
+	InitContainers []k8sContainer `yaml:"initContainers"`
+	Volumes        []k8sVolume    `yaml:"volumes"`
+	Template       *struct {
+		Spec k8sSpec `yaml:"spec"`
+	} `yaml:"template"`
+}
+
+type k8sVolume struct {
+	Name     string `yaml:"name"`
+	HostPath *struct {
+		Path string `yaml:"path"`
+	} `yaml:"hostPath"`
+}
+
+type k8sContainer struct {
+	Name            string     `yaml:"name"`
+	Image           string     `yaml:"image"`
+	SecurityContext *ctnSecCtx `yaml:"securityContext"`
+}
+
+type ctnSecCtx struct {
+	Privileged               *bool `yaml:"privileged"`
+	RunAsNonRoot             *bool `yaml:"runAsNonRoot"`
+	RunAsUser                *int  `yaml:"runAsUser"`
+	AllowPrivilegeEscalation *bool `yaml:"allowPrivilegeEscalation"`
+	Capabilities             *struct {
+		Add []string `yaml:"add"`
+	} `yaml:"capabilities"`
+}
+
+// podSpec resolves the effective pod spec: a workload's spec.template.spec, or the object's own spec.
+func (s k8sSpec) podSpec() k8sSpec {
+	if s.Template != nil {
+		return s.Template.Spec
+	}
+	return s
+}
+
+// scanKubernetes decodes every YAML document in data and returns located misconfig findings. Best-effort:
+// a document that decodes but does not fit our shape (or has no kind) is skipped and later documents are
+// still scanned; a YAML *stream* syntax error halts parsing of the rest of THIS file (prior findings are
+// kept), because yaml.v3 cannot reliably resume mid-stream. Either way the overall scan never fails.
+func scanKubernetes(rel string, data []byte) []ports.MisconfigRawFinding {
+	var out []ports.MisconfigRawFinding
+	// Refuse pathologically deep documents BEFORE decoding: yaml.v3 recurses per nesting level with no
+	// depth cap, so a crafted deep document would overflow the goroutine stack (an unrecoverable fatal),
+	// not merely return an error. This keeps a malformed file a per-file skip, per the port contract.
+	if maxFlowDepth(data) > maxNestDepth {
+		return nil
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	for {
+		var node yaml.Node
+		if err := dec.Decode(&node); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return out // stream syntax error: stop this file, keep prior findings
+		}
+		var doc k8sDoc
+		if err := node.Decode(&doc); err != nil || doc.Kind == "" {
+			continue // not a manifest we recognise; try the next document
+		}
+		out = append(out, checkK8sDoc(rel, doc, &node)...)
+	}
+	return out
+}
+
+func checkK8sDoc(rel string, doc k8sDoc, node *yaml.Node) []ports.MisconfigRawFinding {
+	spec := doc.Spec.podSpec()
+	res := clip(doc.Kind)
+	if doc.Metadata.Name != "" {
+		res += "/" + clip(doc.Metadata.Name)
+	}
+	docLine := firstKeyLine(node, "kind")
+	var out []ports.MisconfigRawFinding
+	add := func(rule, title, desc string, sev shared.Severity, key string) {
+		line := firstKeyLine(node, key)
+		if line == 0 {
+			line = docLine
+		}
+		out = append(out, ports.MisconfigRawFinding{
+			File: rel, Line: line, RuleID: rule, Title: title, Severity: sev, Resource: res, Description: desc,
+		})
+	}
+
+	if spec.HostNetwork {
+		add("kubernetes-host-network", "Pod shares the host network namespace",
+			"hostNetwork: true lets the pod see and bind host interfaces, bypassing network policy and exposing host services. Remove hostNetwork unless the workload is a node-level agent that genuinely needs it.",
+			shared.SeverityHigh, "hostNetwork")
+	}
+	if spec.HostPID {
+		add("kubernetes-host-pid", "Pod shares the host PID namespace",
+			"hostPID: true lets the pod see and signal all host processes. Remove it unless strictly required.",
+			shared.SeverityHigh, "hostPID")
+	}
+	if spec.HostIPC {
+		add("kubernetes-host-ipc", "Pod shares the host IPC namespace",
+			"hostIPC: true shares host inter-process-communication with the pod, a container-escape aid. Remove it unless strictly required.",
+			shared.SeverityHigh, "hostIPC")
+	}
+	for _, v := range spec.Volumes {
+		if v.HostPath != nil {
+			add("kubernetes-host-path", "Volume mounts a host path",
+				fmt.Sprintf("Volume %q mounts hostPath %q from the node filesystem; a compromised container can read or tamper with host files. Use a PersistentVolumeClaim or emptyDir instead.", clip(v.Name), clip(v.HostPath.Path)),
+				shared.SeverityMedium, "hostPath")
+		}
+	}
+
+	all := append(append([]k8sContainer{}, spec.Containers...), spec.InitContainers...)
+	for _, c := range all {
+		sc := c.SecurityContext
+		if sc == nil {
+			continue
+		}
+		cres := res + " container=" + clip(c.Name)
+		if sc.Privileged != nil && *sc.Privileged {
+			out = append(out, k8sContainerFinding(rel, node, cres, "kubernetes-privileged",
+				"Privileged container", shared.SeverityHigh, "privileged",
+				"securityContext.privileged: true gives the container near-root access to the host (all devices, all capabilities). Drop privileged and grant only the specific capabilities the workload needs.", docLine))
+		}
+		if sc.AllowPrivilegeEscalation != nil && *sc.AllowPrivilegeEscalation {
+			out = append(out, k8sContainerFinding(rel, node, cres, "kubernetes-allow-priv-escalation",
+				"Privilege escalation allowed", shared.SeverityMedium, "allowPrivilegeEscalation",
+				"securityContext.allowPrivilegeEscalation: true lets a process gain more privileges than its parent (e.g. via setuid). Set it to false.", docLine))
+		}
+		if runsAsRoot(sc) {
+			out = append(out, k8sContainerFinding(rel, node, cres, "kubernetes-run-as-root",
+				"Container runs as root", shared.SeverityMedium, "runAsUser",
+				"The container is configured to run as root (runAsUser: 0 or runAsNonRoot: false). Set runAsNonRoot: true and a non-zero runAsUser.", docLine))
+		}
+		if sc.Capabilities != nil {
+			for _, capName := range sc.Capabilities.Add {
+				if dangerousCaps[strings.ToUpper(strings.TrimSpace(capName))] {
+					out = append(out, k8sContainerFinding(rel, node, cres, "kubernetes-dangerous-capability",
+						"Dangerous Linux capability added", shared.SeverityHigh, "capabilities",
+						fmt.Sprintf("securityContext.capabilities.add includes %q, which grants broad host control and can enable container escape. Drop it and add only least-privilege capabilities.", clip(capName)), docLine))
+					break
+				}
+			}
+		}
+	}
+	return out
+}
+
+// runsAsRoot reports an EXPLICIT root configuration only (runAsUser 0, or runAsNonRoot false) — an unset
+// securityContext is left alone to keep false positives low.
+func runsAsRoot(sc *ctnSecCtx) bool {
+	if sc.RunAsUser != nil && *sc.RunAsUser == 0 {
+		return true
+	}
+	if sc.RunAsNonRoot != nil && !*sc.RunAsNonRoot {
+		return true
+	}
+	return false
+}
+
+func k8sContainerFinding(rel string, node *yaml.Node, resource, rule, title string, sev shared.Severity, key, desc string, fallback int) ports.MisconfigRawFinding {
+	line := firstKeyLine(node, key)
+	if line == 0 {
+		line = fallback
+	}
+	return ports.MisconfigRawFinding{
+		File: rel, Line: line, RuleID: rule, Title: title, Severity: sev, Resource: resource, Description: desc,
+	}
+}
+
+// firstKeyLine returns the 1-indexed line of the first mapping key whose name equals key, searched
+// depth-first. It is a best-effort locator for the finding, not a precise scope resolver; 0 = not found.
+func firstKeyLine(node *yaml.Node, key string) int {
+	return firstKeyLineDepth(node, key, 0)
+}
+
+func firstKeyLineDepth(node *yaml.Node, key string, depth int) int {
+	if node == nil || depth > maxLocatorDepth {
+		return 0
+	}
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, c := range node.Content {
+			if l := firstKeyLineDepth(c, key, depth+1); l != 0 {
+				return l
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			k, v := node.Content[i], node.Content[i+1]
+			if k.Value == key {
+				return k.Line
+			}
+			if l := firstKeyLineDepth(v, key, depth+1); l != 0 {
+				return l
+			}
+		}
+	case yaml.SequenceNode:
+		for _, c := range node.Content {
+			if l := firstKeyLineDepth(c, key, depth+1); l != 0 {
+				return l
+			}
+		}
+	}
+	return 0
+}
+
+// maxFlowDepth returns the deepest nesting of YAML flow collections ('[' and '{') in data, ignoring
+// brackets inside quoted scalars and comments. It is a cheap linear pre-scan so a deep untrusted document
+// is rejected before it reaches the recursive yaml.v3 parser. (Block-style nesting is naturally bounded
+// by the file-size cap, since each level costs a line of indentation.)
+func maxFlowDepth(data []byte) int {
+	var depth, maxd int
+	var inSingle, inDouble bool
+	var prev byte
+	for i := 0; i < len(data); i++ {
+		b := data[i]
+		switch {
+		case inDouble:
+			if b == '\\' { // skip an escaped char inside a double-quoted scalar
+				i++
+				prev = 0
+				continue
+			}
+			if b == '"' {
+				inDouble = false
+			}
+		case inSingle:
+			if b == '\'' {
+				inSingle = false
+			}
+		default:
+			switch b {
+			case '"':
+				inDouble = true
+			case '\'':
+				inSingle = true
+			case '#': // a comment runs to end of line only when '#' begins a token
+				if prev == 0 || prev == ' ' || prev == '\t' || prev == '\n' || prev == '\r' {
+					for i < len(data) && data[i] != '\n' {
+						i++
+					}
+					prev = '\n'
+					continue
+				}
+			case '[', '{':
+				depth++
+				if depth > maxd {
+					maxd = depth
+					if maxd > maxNestDepth {
+						return maxd // early out: already past the cap
+					}
+				}
+			case ']', '}':
+				if depth > 0 {
+					depth--
+				}
+			}
+		}
+		prev = b
+	}
+	return maxd
+}

--- a/internal/infrastructure/tools/misconfig/scanner.go
+++ b/internal/infrastructure/tools/misconfig/scanner.go
@@ -1,0 +1,174 @@
+// Package misconfig is an owned, deterministic infrastructure-as-code / config scanner over a prepared
+// workspace. It flags insecure Dockerfile and Kubernetes-manifest settings with first-party Go checks —
+// no external policy engine (no OPA/Rego) and no network. Checks are chosen to be high-signal and
+// low-false-positive: a rule fires only on an explicit insecure setting, never on an unset default.
+//
+// It is READ-ONLY: it classifies files by name/content, parses them, and returns located findings. A
+// parse or read error is a per-file skip, never a scan failure. Results become ungated Kind=misconfig
+// findings (deterministic, publishable like SCA).
+package misconfig
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxFiles     = 50000   // bound the number of config files scanned
+	maxEntries   = 1000000 // bound the total tree entries walked (huge non-config tree DoS guard)
+	maxFileBytes = 5 << 20 // skip files larger than 5 MiB (manifests are small)
+	sniffBytes   = 8 << 10 // read this much to decide binary-or-text
+	maxValueLen  = 256     // cap an untrusted config value embedded in a finding
+)
+
+// Scanner implements ports.MisconfigScanner with an owned ruleset.
+type Scanner struct {
+	skipDirs map[string]bool
+}
+
+var _ ports.MisconfigScanner = (*Scanner)(nil)
+
+// New returns a scanner with the default configuration.
+func New() *Scanner {
+	return &Scanner{
+		skipDirs: set(".git", "node_modules", "vendor", "dist", "build", "target", ".idea",
+			".gradle", ".venv", "venv", "__pycache__", "bin"),
+	}
+}
+
+// Name identifies the source on findings.
+func (s *Scanner) Name() string { return "synapse-misconfig" }
+
+// configKind is the recognised config-file type for a path.
+type configKind int
+
+const (
+	cfgNone configKind = iota
+	cfgDockerfile
+	cfgKubernetes
+)
+
+// ScanConfigs walks root, classifies each regular file, and returns located misconfig findings.
+// Best-effort: an unreadable or unparsable file is skipped.
+func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.MisconfigRawFinding, error) {
+	var out []ports.MisconfigRawFinding
+	count := 0  // config files actually scanned
+	walked := 0 // total tree entries visited
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		walked++
+		if walked > maxEntries {
+			return filepath.SkipAll // a pathologically large tree: stop walking regardless of file type
+		}
+		if d.IsDir() {
+			if s.skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Only read regular files: never follow a symlink out of the (untrusted) workspace, so a planted
+		// link cannot pull an out-of-root file into the scan.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		kind := classifyName(d.Name())
+		if kind == cfgNone && !maybeYAML(d.Name()) {
+			return nil
+		}
+		if count >= maxFiles {
+			return filepath.SkipAll
+		}
+		count++
+		info, e := d.Info()
+		if e != nil || info.Size() == 0 || info.Size() > maxFileBytes {
+			return nil
+		}
+		data, e := os.ReadFile(path)
+		if e != nil || isBinary(data) {
+			return nil
+		}
+		if kind == cfgNone {
+			// A .yaml/.yml file is only a Kubernetes manifest if it declares apiVersion + kind.
+			if !looksKubernetes(data) {
+				return nil
+			}
+			kind = cfgKubernetes
+		}
+		rel := strings.TrimPrefix(strings.TrimPrefix(path, root), string(os.PathSeparator))
+		switch kind {
+		case cfgDockerfile:
+			out = append(out, scanDockerfile(rel, data)...)
+		case cfgKubernetes:
+			out = append(out, scanKubernetes(rel, data)...)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return out, fmt.Errorf("misconfig scan: %w", walkErr) // e.g. context cancellation
+	}
+	return out, nil
+}
+
+// classifyName recognises a Dockerfile by conventional names; YAML is decided later by content.
+func classifyName(name string) configKind {
+	if name == "Dockerfile" || name == "Containerfile" ||
+		strings.HasPrefix(name, "Dockerfile.") ||
+		strings.HasSuffix(strings.ToLower(name), ".dockerfile") {
+		return cfgDockerfile
+	}
+	return cfgNone
+}
+
+func maybeYAML(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// looksKubernetes is a cheap pre-filter so we only parse YAML that declares a Kubernetes object, not
+// every CI/compose/config YAML in the tree.
+func looksKubernetes(data []byte) bool {
+	t := string(data)
+	return strings.Contains(t, "apiVersion:") && strings.Contains(t, "kind:")
+}
+
+func isBinary(data []byte) bool {
+	n := len(data)
+	if n > sniffBytes {
+		n = sniffBytes
+	}
+	for i := 0; i < n; i++ {
+		if data[i] == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func set(items ...string) map[string]bool {
+	m := make(map[string]bool, len(items))
+	for _, it := range items {
+		m[it] = true
+	}
+	return m
+}
+
+// clip bounds an untrusted config value before it is embedded in a finding, so a crafted manifest or
+// Dockerfile cannot push a multi-MB string into the finding, the hash-chained evidence seal, or the
+// report. It trims to a whole-UTF-8 boundary so the finding text stays valid.
+func clip(s string) string {
+	if len(s) <= maxValueLen {
+		return s
+	}
+	return strings.ToValidUTF8(s[:maxValueLen], "") + "…"
+}

--- a/internal/infrastructure/tools/misconfig/scanner_test.go
+++ b/internal/infrastructure/tools/misconfig/scanner_test.go
@@ -1,0 +1,318 @@
+package misconfig
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// scan writes files into a temp root and runs the scanner over it.
+func scan(t *testing.T, files map[string]string) []ports.MisconfigRawFinding {
+	t.Helper()
+	root := t.TempDir()
+	for name, body := range files {
+		p := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := New().ScanConfigs(context.Background(), root)
+	if err != nil {
+		t.Fatalf("ScanConfigs: %v", err)
+	}
+	return got
+}
+
+func ruleIDs(fs []ports.MisconfigRawFinding) map[string]ports.MisconfigRawFinding {
+	m := make(map[string]ports.MisconfigRawFinding, len(fs))
+	for _, f := range fs {
+		m[f.RuleID] = f
+	}
+	return m
+}
+
+func TestDockerfileInsecure(t *testing.T) {
+	df := `FROM ubuntu:latest
+ADD https://example.com/app.tar.gz /app/
+RUN curl -sSL https://get.example.com/install.sh | sh
+EXPOSE 8080
+`
+	got := ruleIDs(scan(t, map[string]string{"Dockerfile": df}))
+	for _, want := range []string{"dockerfile-image-no-tag", "dockerfile-add-remote-url", "dockerfile-run-pipe-shell", "dockerfile-run-as-root"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("expected rule %q on insecure Dockerfile, got rules %v", want, keys(got))
+		}
+	}
+	if got["dockerfile-image-no-tag"].Line != 1 {
+		t.Errorf("image-no-tag should be on FROM line 1, got %d", got["dockerfile-image-no-tag"].Line)
+	}
+	if got["dockerfile-run-pipe-shell"].Line != 3 {
+		t.Errorf("pipe-to-shell should be on RUN line 3, got %d", got["dockerfile-run-pipe-shell"].Line)
+	}
+}
+
+func TestDockerfileSecureNoFindings(t *testing.T) {
+	// Pinned digest, explicit non-root USER, COPY instead of ADD, no pipe-to-shell.
+	df := `FROM debian:12@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+RUN useradd -r app
+COPY ./bin/app /usr/local/bin/app
+USER app
+ENTRYPOINT ["app"]
+`
+	if got := scan(t, map[string]string{"Dockerfile": df}); len(got) != 0 {
+		t.Errorf("secure Dockerfile should yield no findings, got %+v", got)
+	}
+}
+
+func TestDockerfileMultiStageJudgesFinalStage(t *testing.T) {
+	// The builder stage runs as root (fine); the final stage pins a tag AND sets a non-root user, so
+	// there should be no run-as-root finding and no no-tag finding.
+	df := `FROM golang:1.26 AS builder
+WORKDIR /src
+RUN go build -o app .
+
+FROM gcr.io/distroless/base:nonroot
+COPY --from=builder /src/app /app
+USER 65532
+ENTRYPOINT ["/app"]
+`
+	got := ruleIDs(scan(t, map[string]string{"Dockerfile": df}))
+	if _, bad := got["dockerfile-run-as-root"]; bad {
+		t.Error("multi-stage final stage sets a non-root USER; run-as-root must not fire")
+	}
+	// golang:1.26 and distroless:nonroot are both tagged → no no-tag finding.
+	if _, bad := got["dockerfile-image-no-tag"]; bad {
+		t.Errorf("both stages are tagged; image-no-tag must not fire, got %+v", got)
+	}
+}
+
+func TestDockerfileNoUserIsRoot(t *testing.T) {
+	df := "FROM alpine:3.20\nRUN echo hi\n"
+	got := ruleIDs(scan(t, map[string]string{"Dockerfile": df}))
+	if _, ok := got["dockerfile-run-as-root"]; !ok {
+		t.Error("Dockerfile with no USER must flag run-as-root")
+	}
+}
+
+func TestKubernetesInsecure(t *testing.T) {
+	manifest := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      hostNetwork: true
+      volumes:
+        - name: hostroot
+          hostPath:
+            path: /
+      containers:
+        - name: app
+          image: myapp:1.0
+          securityContext:
+            privileged: true
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+`
+	got := ruleIDs(scan(t, map[string]string{"deploy.yaml": manifest}))
+	for _, want := range []string{
+		"kubernetes-host-network", "kubernetes-host-path", "kubernetes-privileged",
+		"kubernetes-run-as-root", "kubernetes-allow-priv-escalation", "kubernetes-dangerous-capability",
+	} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("expected rule %q on insecure Deployment, got %v", want, keys(got))
+		}
+	}
+	if got["kubernetes-privileged"].Severity != shared.SeverityHigh {
+		t.Errorf("privileged should be High, got %s", got["kubernetes-privileged"].Severity)
+	}
+	if r := got["kubernetes-privileged"].Resource; r == "" || r[:10] != "Deployment" {
+		t.Errorf("resource should name the Deployment + container, got %q", r)
+	}
+}
+
+func TestKubernetesHardenedNoFindings(t *testing.T) {
+	manifest := `apiVersion: v1
+kind: Pod
+metadata:
+  name: safe
+spec:
+  containers:
+    - name: app
+      image: myapp:1.0
+      securityContext:
+        privileged: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+`
+	if got := scan(t, map[string]string{"pod.yaml": manifest}); len(got) != 0 {
+		t.Errorf("hardened Pod should yield no findings, got %+v", got)
+	}
+}
+
+func TestKubernetesUnsetSecurityContextIsQuiet(t *testing.T) {
+	// No securityContext at all: we deliberately do NOT flag defaults (low-FP policy).
+	manifest := `apiVersion: v1
+kind: Pod
+metadata:
+  name: plain
+spec:
+  containers:
+    - name: app
+      image: myapp:1.0
+`
+	if got := scan(t, map[string]string{"pod.yaml": manifest}); len(got) != 0 {
+		t.Errorf("pod with no securityContext must stay quiet, got %+v", got)
+	}
+}
+
+func TestNonKubernetesYAMLSkipped(t *testing.T) {
+	// A CI/compose YAML with no apiVersion+kind must not be parsed as a manifest.
+	ci := "jobs:\n  build:\n    steps:\n      - run: make\n"
+	if got := scan(t, map[string]string{".github/workflows/ci.yml": ci}); len(got) != 0 {
+		t.Errorf("non-Kubernetes YAML must be skipped, got %+v", got)
+	}
+}
+
+func TestMultiDocYAML(t *testing.T) {
+	manifest := `apiVersion: v1
+kind: Pod
+metadata:
+  name: a
+spec:
+  containers:
+    - name: c
+      image: x:1
+      securityContext:
+        privileged: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: b
+spec:
+  hostPID: true
+  containers:
+    - name: c
+      image: x:1
+`
+	got := scan(t, map[string]string{"multi.yaml": manifest})
+	rules := ruleIDs(got)
+	if _, ok := rules["kubernetes-privileged"]; !ok {
+		t.Error("first doc's privileged container must be flagged")
+	}
+	if _, ok := rules["kubernetes-host-pid"]; !ok {
+		t.Error("second doc's hostPID must be flagged")
+	}
+}
+
+func TestSkipsVendorDir(t *testing.T) {
+	df := "FROM ubuntu\nRUN echo hi\n"
+	got := scan(t, map[string]string{"vendor/some/Dockerfile": df, "node_modules/x/Dockerfile": df})
+	if len(got) != 0 {
+		t.Errorf("Dockerfiles under vendored dirs must be skipped, got %+v", got)
+	}
+}
+
+func TestScanIgnoresSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	root := t.TempDir()
+	// An insecure Dockerfile OUTSIDE the scanned root.
+	outside := filepath.Join(t.TempDir(), "Dockerfile")
+	if err := os.WriteFile(outside, []byte("FROM ubuntu:latest\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink inside the root pointing at it must not be followed.
+	if err := os.Symlink(outside, filepath.Join(root, "Dockerfile")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	got, err := New().ScanConfigs(context.Background(), root)
+	if err != nil {
+		t.Fatalf("ScanConfigs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("a symlink out of the workspace must not be scanned, got %+v", got)
+	}
+}
+
+func TestContextCancelled(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM ubuntu\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := New().ScanConfigs(ctx, root); err == nil {
+		t.Error("a cancelled context must surface an error, not a silent empty result")
+	}
+}
+
+func TestDeeplyNestedYAMLIsSkippedNotCrash(t *testing.T) {
+	// A crafted manifest that passes the looksKubernetes pre-filter and is small on disk but nests flow
+	// collections far deeper than any real manifest. It must be skipped (returns cleanly), never overflow
+	// the yaml.v3 parser stack (an unrecoverable fatal).
+	var b strings.Builder
+	b.WriteString("apiVersion: v1\nkind: Pod\nx: ")
+	for i := 0; i < 100000; i++ {
+		b.WriteByte('[')
+	}
+	got := scan(t, map[string]string{"bomb.yaml": b.String()})
+	if len(got) != 0 {
+		t.Errorf("a pathologically deep document must be skipped, got %+v", got)
+	}
+}
+
+func TestNormalNestingStillScans(t *testing.T) {
+	// Sanity: the depth guard must not reject a manifest with ordinary flow style.
+	manifest := `apiVersion: v1
+kind: Pod
+metadata:
+  name: flowy
+spec:
+  containers:
+    - {name: app, image: "x:1", securityContext: {privileged: true}}
+`
+	if got := ruleIDs(scan(t, map[string]string{"pod.yaml": manifest})); got["kubernetes-privileged"].RuleID == "" {
+		t.Error("ordinary flow-style manifest must still be scanned and flagged")
+	}
+}
+
+func TestUntrustedValuesAreClipped(t *testing.T) {
+	long := strings.Repeat("A", 5000)
+	manifest := "apiVersion: v1\nkind: Pod\nmetadata:\n  name: " + long +
+		"\nspec:\n  volumes:\n    - name: v\n      hostPath:\n        path: /" + long + "\n"
+	got := scan(t, map[string]string{"pod.yaml": manifest})
+	for _, f := range got {
+		if len(f.Resource) > maxValueLen*3 { // Kind + '/' + clipped name, all bounded
+			t.Errorf("Resource not clipped: %d bytes", len(f.Resource))
+		}
+		if len(f.Description) > maxValueLen*6 {
+			t.Errorf("Description embeds an unclipped value: %d bytes", len(f.Description))
+		}
+	}
+}
+
+func keys(m map[string]ports.MisconfigRawFinding) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -162,6 +162,9 @@ type Config struct {
 	// SecretScanEnabled turns on the deterministic secret scanner in the scan pipeline; off by default.
 	// It reads workspace files and redacts every match, so nothing sensitive reaches logs or the report.
 	SecretScanEnabled bool
+	// MisconfigEnabled turns on the deterministic IaC/config misconfig scanner (Dockerfile, Kubernetes
+	// manifests) in the scan pipeline; off by default. Read-only, first-party checks, no policy engine.
+	MisconfigEnabled bool
 	// OwnedAdvisoryEnabled wires the owned advisory DetectionSource: match the SBOM
 	// against the owned normalized-advisory store (offline, reproducible) ALONGSIDE live OSV/Grype. Off by
 	// default; opt-in. An empty store yields no findings (a harmless no-op) until the advisory ingester
@@ -304,6 +307,7 @@ func Load() Config {
 		JudgmentsEnabled:       getbool("SYNAPSE_JUDGMENTS_ENABLED", false),
 		SASTEnabled:            getbool("SYNAPSE_SAST_ENABLED", false),
 		SecretScanEnabled:      getbool("SYNAPSE_SECRET_SCAN_ENABLED", false),
+		MisconfigEnabled:       getbool("SYNAPSE_MISCONFIG_ENABLED", false),
 		OwnedAdvisoryEnabled:   getbool("SYNAPSE_OWNED_ADVISORY", false),
 		ReachabilityEnabled:    getbool("SYNAPSE_REACHABILITY_ENABLED", false),
 		CrossCheckEnabled:      getbool("SYNAPSE_CROSSCHECK_ENABLED", false),

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -848,6 +848,27 @@ type SecretScanner interface {
 	ScanFiles(ctx context.Context, root string) ([]SecretRawFinding, error)
 }
 
+// MisconfigRawFinding is one insecure infrastructure-as-code / config setting located at file:line, tied
+// to the resource it applies to (e.g. "Deployment/api" or "Dockerfile").
+type MisconfigRawFinding struct {
+	File        string // path relative to the scanned source root
+	Line        int    // 1-indexed (best-effort; the resource/instruction line)
+	RuleID      string // e.g. "kubernetes-privileged"
+	Title       string // human title, e.g. "Privileged container"
+	Severity    shared.Severity
+	Resource    string // what it applies to, e.g. "Deployment/api" or "Dockerfile FROM"
+	Description string // what is wrong + how to fix
+}
+
+// MisconfigScanner detects insecure IaC/config (Dockerfile, Kubernetes manifests, ...) in a prepared
+// workspace with owned, deterministic checks (no external policy engine). READ-ONLY and best-effort: a
+// parse or walk error is a per-file skip, never a scan failure. Results become ungated Kind=misconfig
+// findings.
+type MisconfigScanner interface {
+	Name() string
+	ScanConfigs(ctx context.Context, root string) ([]MisconfigRawFinding, error)
+}
+
 // RiskResult is the output of risk enrichment: vulns annotated with KEV + EPSS,
 // plus the data-source versions (for reproducibility provenance).
 type RiskResult struct {

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -256,6 +256,49 @@ func secretDescription(sr ports.SecretRawFinding) string {
 		sr.Category, sr.RuleID, sr.Match)
 }
 
+// buildMisconfigFindings turns insecure IaC/config settings into ungated Kind=misconfig findings
+// (deterministic, publishable like SCA). Each is a first-party presence fact located at file:line.
+func buildMisconfigFindings(engagementID shared.ID, raws []ports.MisconfigRawFinding, now time.Time, minSeverity shared.Severity) []finding.Finding {
+	min := shared.SeverityRank(minSeverity)
+	out := make([]finding.Finding, 0, len(raws))
+	for _, mr := range raws {
+		if mr.Severity != shared.SeverityUnknown && shared.SeverityRank(mr.Severity) < min {
+			continue
+		}
+		// Dedup on rule+file+line so a re-scan updates in place (1:1).
+		dedup := "misconfig:" + mr.RuleID + ":" + mr.File + ":" + strconv.Itoa(mr.Line)
+		scope := sbom.ClassifyScope(mr.File, "")
+		out = append(out, finding.Finding{
+			ID:           findingID(engagementID, dedup),
+			EngagementID: engagementID,
+			Title:        fmt.Sprintf("%s (%s:%d)", mr.Title, mr.File, mr.Line),
+			Description:  misconfigDescription(mr),
+			Severity:     mr.Severity,
+			Sources:      []string{"synapse-misconfig"},
+			Confidence:   vulnerability.ConfidenceForSources(1),
+			Class:        finding.ClassFirstParty,
+			Scope:        scope,
+			// Reachability/Impact are left empty on purpose: a misconfiguration is a static PRESENCE fact
+			// in a config file, not a reachable-code weakness, so the SAST scope+severity impact model
+			// does not apply.
+			Priority: sastPriority(mr.Severity),
+			Status:   finding.StatusOpen,
+			Kind:     finding.KindMisconfig,
+			DedupKey: dedup,
+			Audit:    shared.Audit{CreatedAt: now, UpdatedAt: now},
+		})
+	}
+	return out
+}
+
+func misconfigDescription(mr ports.MisconfigRawFinding) string {
+	res := strings.TrimSpace(mr.Resource)
+	if res != "" {
+		return fmt.Sprintf("%s [%s]. %s", res, mr.RuleID, mr.Description)
+	}
+	return fmt.Sprintf("[%s] %s", mr.RuleID, mr.Description)
+}
+
 func sastDescription(sr ports.SASTRawFinding) string {
 	desc := strings.TrimSpace(sr.Description)
 	proof := []string{}

--- a/internal/usecase/sca/misconfig_findings_test.go
+++ b/internal/usecase/sca/misconfig_findings_test.go
@@ -1,0 +1,50 @@
+package sca
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestBuildMisconfigFindings(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	raws := []ports.MisconfigRawFinding{
+		{File: "Dockerfile", Line: 1, RuleID: "dockerfile-run-as-root", Title: "Container runs as root", Severity: shared.SeverityHigh, Resource: "Dockerfile USER", Description: "runs as root"},
+		{File: "k8s/pod.yaml", Line: 12, RuleID: "kubernetes-privileged", Title: "Privileged container", Severity: shared.SeverityHigh, Resource: "Pod/api container=app", Description: "privileged"},
+		{File: "info.yaml", Line: 3, RuleID: "low-note", Title: "low", Severity: shared.SeverityLow, Description: "note"},
+	}
+
+	// minSeverity=medium must drop the low finding.
+	got := buildMisconfigFindings("eng-1", raws, now, shared.SeverityMedium)
+	if len(got) != 2 {
+		t.Fatalf("want 2 findings (low dropped by threshold), got %d", len(got))
+	}
+	for _, f := range got {
+		if f.Kind != finding.KindMisconfig {
+			t.Errorf("finding %q must be Kind=misconfig, got %q", f.Title, f.Kind)
+		}
+		if f.Class != finding.ClassFirstParty {
+			t.Errorf("misconfig must be first-party, got %q", f.Class)
+		}
+		if f.ProposedBy != "" || f.RequiresEvidenceGate() {
+			t.Errorf("misconfig is deterministic → must be ungated/publishable, finding %q gated", f.Title)
+		}
+		if f.DedupKey == "" || f.EngagementID != "eng-1" {
+			t.Errorf("finding %q missing dedup/engagement wiring", f.Title)
+		}
+	}
+
+	// Ungated findings survive the publishability gate with a zero evidence score.
+	if pub := finding.Publishable(got); len(pub) != 2 {
+		t.Errorf("all misconfig findings must be publishable, got %d/2", len(pub))
+	}
+
+	// Re-scan idempotency: same raws → same finding IDs (dedup upsert in place).
+	again := buildMisconfigFindings("eng-1", raws, now, shared.SeverityMedium)
+	if again[0].ID != got[0].ID || again[1].ID != got[1].ID {
+		t.Error("re-scan must produce stable finding IDs for in-place upsert")
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -60,6 +60,7 @@ type Service struct {
 	licFile        ports.LicenseFileResolver     // optional offline license-text fallback from JAR LICENSE files
 	sastAnalyzer   ports.SASTAnalyzer            // optional deterministic pattern-SAST over the live workspace
 	secretScanner  ports.SecretScanner           // optional deterministic secret scan over the live workspace
+	misconfig      ports.MisconfigScanner        // optional deterministic IaC/config misconfig scan over the live workspace
 	reachability   ports.ReachabilityRecorder    // optional deterministic Tier-2 reachability proof
 	correlation    ports.CorrelationRecorder     // optional cross-check disagreement → judgment minter
 	sbomGen2       ports.SBOMGenerator           // optional 2nd SBOM producer for the cross-check
@@ -111,6 +112,10 @@ func (s *Service) SetSASTAnalyzer(a ports.SASTAnalyzer) { s.sastAnalyzer = a }
 
 // SetSecretScanner configures the optional deterministic secret scanner. nil ⇒ no secret scanning.
 func (s *Service) SetSecretScanner(sc ports.SecretScanner) { s.secretScanner = sc }
+
+// SetMisconfigScanner configures the optional deterministic IaC/config misconfig scanner.
+// nil ⇒ no misconfig scanning. A setter keeps the existing NewService call sites unchanged.
+func (s *Service) SetMisconfigScanner(m ports.MisconfigScanner) { s.misconfig = m }
 
 // SetReachability configures the optional deterministic Tier-2 reachability prover. nil ⇒ no
 // reachability judgments. Best-effort + opt-in: a no-coverage/un-buildable target leaves the prior
@@ -1575,6 +1580,13 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 			return nil, fmt.Errorf("scan secrets: %w", serr)
 		}
 		result.Findings = append(result.Findings, buildSecretFindings(engagementID, secretRaws, now, s.minSeverity)...)
+	}
+	if opts.scansVulnerabilities() && s.misconfig != nil {
+		misRaws, merr := s.misconfig.ScanConfigs(ctx, ws.Dir)
+		if merr != nil {
+			return nil, fmt.Errorf("scan misconfig: %w", merr)
+		}
+		result.Findings = append(result.Findings, buildMisconfigFindings(engagementID, misRaws, now, s.minSeverity)...)
 	}
 	result.MinSeverity = s.minSeverity
 	result.VulnsBelowThreshold = countBelowThreshold(vulns, s.minSeverity)


### PR DESCRIPTION
## Native IaC / misconfiguration scanner

Adds a first-party scanner that flags insecure infrastructure-as-code settings in a scanned workspace. It is owned and deterministic: plain Go checks over parsed config, with no external policy engine (no OPA/Rego) and no network access. Results become ungated `Kind=misconfig` findings, publishable like SCA findings. The whole feature is opt-in behind `SYNAPSE_MISCONFIG_ENABLED` (off by default).

### What it checks

Dockerfile:
- Container runs as root in the final build stage (no `USER`, or last `USER` is root/0). Multi-stage builds are judged by the final stage, so a root builder stage does not trip it.
- Base image is not version-pinned (no tag or `:latest`, and no `@sha256` digest).
- `ADD` fetches a remote URL (prefer a verified download or `COPY`).
- A remote script is piped straight into a shell (`curl ... | sh`).

Kubernetes manifests:
- Privileged container.
- Shared host namespaces (`hostNetwork`, `hostPID`, `hostIPC`).
- `hostPath` volume.
- Explicit run-as-root (`runAsUser: 0` or `runAsNonRoot: false`).
- `allowPrivilegeEscalation: true`.
- Dangerous Linux capabilities added (`ALL`, `SYS_ADMIN`, `NET_ADMIN`, ...).

Workloads (Deployment, StatefulSet, and similar) are resolved through `spec.template.spec`; bare Pods use `spec` directly. Checks fire only on an explicit insecure setting, never on an unset default, to keep false positives low.

### Safety

- Read-only, bounded walk with a regular-file guard, so a planted symlink cannot pull an out-of-workspace file (for example `/etc/shadow`) into the scan.
- A linear pre-decode flow-depth guard rejects deeply-nested YAML before it reaches the recursive parser, so a crafted document cannot overflow the stack and crash the scan.
- Every untrusted config value (image name, hostPath, resource and container names) is clipped before it enters a finding, the hash-chained evidence seal, or the report.
- No shell or command execution anywhere in the path; it is pure parsing.
- A malformed or unreadable file is a per-file skip, never a scan failure; context cancellation is honored.

### How it fits

Mirrors the existing secret-scanner and pattern-SAST slices: a `ports.MisconfigScanner` interface, an infra adapter under `internal/infrastructure/tools/misconfig`, a `buildMisconfigFindings` step in the SCA pipeline, and wiring behind a setter in `synapse-api` and `synapse-cli`.

### Testing

- Unit tests cover every rule, hardened inputs that must stay quiet, multi-stage Dockerfiles, multi-document YAML, non-Kubernetes YAML that must be ignored, the symlink guard, context cancellation, the deep-nesting guard, and value clipping.
- End-to-end via the CLI: with the flag off the scan reports zero misconfig findings; with the flag on it reports the expected findings with correct file and line references.
- `go build`, `go vet`, and the affected package tests pass.

### Reviews

Reviewed for clean-architecture compliance (dependency rule, port assertion, idioms) and for the project safety rules (untrusted-input handling, symlink and DoS surfaces, no execution, no secret leakage, ungated semantics). The one medium-severity item found in review (deeply-nested YAML recursion) and two low-severity items (value bloat, walk bound) are fixed in this PR.
