### PR TITLE
feat(sast): broaden pattern-SAST with 9 new rules + per-rule language gate

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -32,11 +32,12 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifest"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavencoord"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/nvd"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/osv"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownadvisory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/risk"
-	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/sast"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/syft"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo"
@@ -290,6 +291,9 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	}
 	if jvmReachOn {
 		sca.SetJVMReachability(jvmreach.New())
+	}
+	if cfg.SASTEnabled {
+		sca.SetSASTAnalyzer(sast.New()) // deterministic pattern-SAST (CI-friendly)
 	}
 	if cfg.SecretScanEnabled {
 		sca.SetSecretScanner(secretscan.New()) // deterministic, redacted secret scan (CI-friendly)

--- a/internal/infrastructure/tools/sast/analyzer.go
+++ b/internal/infrastructure/tools/sast/analyzer.go
@@ -146,6 +146,7 @@ func readSourceLines(path string) []string {
 // scanLines applies rules to an already-read source file.
 func (a *Analyzer) scanLines(rel string, lines []string, project projectContext) []ports.SASTRawFinding {
 	var hits []ports.SASTRawFinding
+	ext := strings.ToLower(filepath.Ext(rel))
 	for i, text := range lines {
 		line := i + 1
 		if len(text) > maxLineBytes {
@@ -153,6 +154,9 @@ func (a *Analyzer) scanLines(rel string, lines []string, project projectContext)
 		}
 		for ri := range a.rules {
 			r := &a.rules[ri]
+			if !r.appliesTo(ext) {
+				continue // language-gated rule on a non-matching file type
+			}
 			if r.re.MatchString(text) && !r.skip(text) {
 				h := ports.SASTRawFinding{
 					File: rel, Line: line, RuleID: r.id, CWE: r.cwe,

--- a/internal/infrastructure/tools/sast/analyzer_test.go
+++ b/internal/infrastructure/tools/sast/analyzer_test.go
@@ -119,6 +119,7 @@ func TestRuleCorpus(t *testing.T) {
 		rule string
 		tp   []string // must be flagged by `rule`
 		fp   []string // must NOT be flagged by `rule`
+		file string   // fixture filename (default case.go); set for language-gated rules
 	}{
 		{
 			rule: "weak-hash-md5",
@@ -260,19 +261,75 @@ func TestRuleCorpus(t *testing.T) {
 			tp:   []string{`await prisma.user.update({ where: { id }, data: req.body })`, `User.create(params)`},
 			fp:   []string{`await prisma.user.update({ where: { id }, data: { name, phone } })`},
 		},
+		{
+			rule: "xxe-insecure-xml-parsing",
+			tp:   []string{`parser = etree.XMLParser(resolve_entities=True)`, `libxml_disable_entity_loader(false);`, `dbf.setExpandEntityReferences(true);`},
+			fp:   []string{`parser = etree.XMLParser(resolve_entities=False)`, `dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`},
+		},
+		{
+			rule: "dynamic-code-eval",
+			tp:   []string{`result = eval("run_" + req.body.cmd)`, `eval($_GET["code"])`, `value = eval(input("expr: "))`},
+			fp:   []string{`const total = eval("2 + 2")`, `// eval of user input is dangerous`},
+		},
+		{
+			rule: "dom-xss-inner-html",
+			tp:   []string{"el.innerHTML = `<h1>${req.query.name}</h1>`", `container.innerHTML = location.hash`, `document.write(location.search)`, `list.innerHTML += req.body.html`},
+			fp:   []string{`el.innerHTML = ""`, `el.innerHTML = sanitize(userInput)`, "el.innerHTML = `<b>${count}</b>`"},
+		},
+		{
+			rule: "nosql-injection-request",
+			tp:   []string{`db.users.find(req.body)`, `User.findOne({ $where: "this.n == 1" })`, `col.find({ user: req.query.user })`},
+			fp:   []string{`db.users.find({ _id: ObjectId(id) })`, `User.findOne({ email: safeEmail })`},
+		},
+		{
+			rule: "open-redirect-user-url",
+			tp:   []string{`res.redirect(req.query.next)`, `response.sendRedirect(request.getParameter("url"))`, `http.Redirect(w, r, r.URL.Query().Get("next"), 302)`},
+			fp:   []string{`res.redirect("/login")`, `res.redirect(302, "/dashboard")`, "res.redirect(`${req.protocol}://${req.hostname}/dashboard`)"},
+		},
+		{
+			rule: "insecure-randomness-security-context",
+			tp:   []string{`const token = Math.random().toString(36)`, `otp = random.randint(1000, 9999)`, `$salt = mt_rand();`},
+			fp:   []string{`const offset = Math.random() * width`, `jitter = random.random() * 0.5`},
+		},
+		{
+			rule: "weak-rsa-key-size",
+			tp:   []string{`rsa.GenerateKey(rand.Reader, 1024)`, `new RSAKeyGenParameterSpec(512, RSAKeyGenParameterSpec.F4)`},
+			fp:   []string{`rsa.GenerateKey(rand.Reader, 2048)`, `new RSAKeyGenParameterSpec(2048, F4)`, `bufferPool.initialize(1024)`},
+		},
+		{
+			rule: "world-writable-permissions",
+			tp:   []string{`os.Chmod(path, 0777)`, `os.WriteFile(p, data, 0o777)`, `os.chmod(path, 0777)`},
+			fp:   []string{`os.Chmod(path, 0644)`, `os.WriteFile(p, data, 0600)`, `os.WriteFile(p, data, 0644) // was 0777`},
+		},
+		{
+			rule: "unsafe-c-string-function",
+			file: "case.c",
+			tp:   []string{`gets(buf);`, `strcpy(dest, src);`, `strcat(path, suffix);`},
+			fp:   []string{`strncpy(dest, src, sizeof(dest));`, `snprintf(buf, sizeof(buf), "%s", s);`, `// strcpy is unsafe`},
+		},
+		{
+			// The same C names in a non-C file (e.g. Ruby gets, PHP vsprintf) must NOT be flagged (ext gate).
+			rule: "unsafe-c-string-function",
+			file: "case.rb",
+			fp:   []string{`line = gets(chomp: true)`, `out = vsprintf(fmt, args)`},
+		},
 	}
 
 	for _, c := range corpus {
+		fname := c.file
+		if fname == "" {
+			fname = "case.go"
+		}
 		for _, tp := range c.tp {
 			root := t.TempDir()
-			writeFile(t, root, "case.go", tp+"\n")
+			writeFile(t, root, fname, tp+"\n")
 			if len(findingsByRule(t, root)[c.rule]) == 0 {
 				t.Errorf("%s: true-positive %q was NOT flagged", c.rule, tp)
 			}
 		}
 		for _, fp := range c.fp {
 			root := t.TempDir()
-			writeFile(t, root, "case.go", fp+"\n")
+			writeFile(t, root, fname, fp+"\n")
 			if n := len(findingsByRule(t, root)[c.rule]); n > 0 {
 				t.Errorf("%s: false-positive %q was wrongly flagged (%d hits)", c.rule, fp, n)
 			}

--- a/internal/infrastructure/tools/sast/patterns.go
+++ b/internal/infrastructure/tools/sast/patterns.go
@@ -8,7 +8,9 @@ import (
 )
 
 // rule is one deterministic pattern check: a regex over a source line plus the finding metadata it
-// yields. skipFn is an optional false-positive filter (e.g. drop env-ref "secrets").
+// yields. skipFn is an optional false-positive filter (e.g. drop env-ref "secrets"). exts, when non-nil,
+// restricts the rule to those file extensions (lower-case, dot-prefixed) so a language-specific idiom
+// (e.g. a C string function) can't false-positive on a same-named safe function in another language.
 type rule struct {
 	id       string
 	cwe      string
@@ -17,9 +19,20 @@ type rule struct {
 	desc     string
 	re       *regexp.Regexp
 	skipFn   func(line string) bool
+	exts     map[string]bool
 }
 
 func (r *rule) skip(line string) bool { return r.skipFn != nil && r.skipFn(line) }
+
+// appliesTo reports whether the rule runs on a file with the given (lower-case) extension. A nil exts
+// means language-agnostic (every file).
+func (r *rule) appliesTo(ext string) bool { return r.exts == nil || r.exts[ext] }
+
+// cSourceExts are the C/C++/Objective-C source and header extensions that the C-specific rules gate on.
+var cSourceExts = map[string]bool{
+	".c": true, ".h": true, ".cc": true, ".cpp": true, ".cxx": true, ".hpp": true, ".hh": true,
+	".hxx": true, ".m": true, ".mm": true,
+}
 
 // placeholderSecret drops obvious non-secrets (env refs, templating, placeholders) so the
 // hardcoded-credential rule stays high-signal — deterministic findings are publishable directly
@@ -261,6 +274,71 @@ func builtinRules() []rule {
 			desc:   "Passing an entire request body into create/update/model constructors can allow privilege or ownership field overwrite. Whitelist assignable fields explicitly.",
 			re:     regexp.MustCompile(`(?i)(\.(create|update)\s*\([^;\n]*(data\s*:\s*req\.body|req\.body)|new\s+\w+\s*\(\s*req\.body|\b[A-Z]\w*\.create\s*\(\s*params|update_attributes\s*\(\s*params)`),
 			skipFn: commentOnlyLine,
+		},
+		{
+			id: "xxe-insecure-xml-parsing", cwe: "CWE-611", severity: shared.SeverityHigh, title: "XML parser resolves external entities (XXE)",
+			desc:   "An XML parser is explicitly configured to resolve external entities or expand DTDs, enabling XXE (file read, SSRF, DoS). Disable DOCTYPE/external-entity processing on the parser.",
+			re:     regexp.MustCompile(`(?i)(resolve_entities\s*=\s*True|libxml_disable_entity_loader\s*\(\s*false|setExpandEntityReferences\s*\(\s*true|\bLIBXML_NOENT\b|setFeature\s*\(\s*["'][^"']*(external-general-entities|load-external-dtd)["']\s*,\s*true)`),
+			skipFn: commentOnlyLine,
+		},
+		{
+			id: "dynamic-code-eval", cwe: "CWE-95", severity: shared.SeverityCritical, title: "Dynamic code evaluation of untrusted input",
+			desc:   "eval() runs its argument as code. When request-controlled or externally-read data reaches it this is remote code execution; parse the value explicitly instead of evaluating it.",
+			re:     regexp.MustCompile(`(?i)\beval\s*\(\s*[^)\n]*(req\.|request\.|params\[|\$_(GET|POST|REQUEST)|\binput\s*\()`),
+			skipFn: commentOnlyLine,
+		},
+		{
+			id: "dom-xss-inner-html", cwe: "CWE-79", severity: shared.SeverityHigh, title: "DOM sink assigns untrusted data to innerHTML",
+			desc: "Assigning request-, location-, or template-derived data to innerHTML/outerHTML (or document.write) executes markup in the page (DOM XSS). Use textContent or sanitize before insertion.",
+			// A bare ${...} is NOT a marker (benign ${count} is not XSS); a template interpolation only counts
+			// when it carries a taint source. \+?= also catches the innerHTML += append form.
+			re:     regexp.MustCompile(`(?i)(\.(inner|outer)HTML\s*\+?=\s*[^;\n]*(req\.|request\.|params\[|location\.(hash|search|href|pathname)|document\.(URL|referrer|cookie)|window\.name|\$\{[^}]*(req\.|location\.|document\.|params\[))|document\.write\s*\(\s*[^)\n]*(location\.|document\.(URL|referrer)|req\.|params\[|\$\{[^}]*(req\.|location\.|document\.)))`),
+			skipFn: commentOnlyLine,
+		},
+		{
+			id: "nosql-injection-request", cwe: "CWE-943", severity: shared.SeverityHigh, title: "NoSQL query built from request data",
+			desc:   "A MongoDB query passes request data (or a $where JavaScript predicate) straight into the filter, allowing NoSQL operator injection. Cast/validate fields and never pass req.body as a filter.",
+			re:     regexp.MustCompile(`(?i)(\.(find|findOne|findOneAndUpdate|updateOne|updateMany|deleteOne|deleteMany|count|aggregate)\s*\(\s*(req\.(body|query|params)|\{[^}\n]*(\$where|req\.(body|query|params)))|\$where\s*:\s*["'` + "`" + `])`),
+			skipFn: commentOnlyLine,
+		},
+		{
+			id: "open-redirect-user-url", cwe: "CWE-601", severity: shared.SeverityMedium, title: "Redirect target is request-controlled",
+			desc: "A redirect appears to use a request-controlled destination, enabling open redirect (phishing, token leakage). Redirect to a fixed allowlist or validate against a same-origin allowlist.",
+			// The request markers are the USER-controlled subset only (query/params/body/url/headers/cookies),
+			// so a canonical-host redirect built from server-derived req.protocol/req.hostname is not flagged.
+			re:     regexp.MustCompile(`(?i)(res\.redirect|response\.redirect|sendRedirect|http\.Redirect|c\.Redirect)\s*\(\s*[^;\n]*(req\.(query|params|body|originalUrl|url|headers|cookies)|params\[|r\.URL|\$_(GET|POST|REQUEST)|c\.Query|getParameter)`),
+			skipFn: commentOnlyLine,
+		},
+		{
+			id: "insecure-randomness-security-context", cwe: "CWE-338", severity: shared.SeverityMedium, title: "Weak PRNG used in a security context",
+			desc:   "A non-cryptographic PRNG (Math.random, random.*, mt_rand, math/rand) appears to generate a token, OTP, salt, or session value. Use a CSPRNG (crypto.randomBytes, secrets, crypto/rand).",
+			re:     regexp.MustCompile(`(?i)((token|otp|nonce|salt|secret|session|csrf|password|passwd|apikey|api_key|verification|reset)\b[^\n]{0,50}(Math\.random\s*\(|random\.(random|randint|choice|getrandbits)\s*\(|mt_rand\s*\(|\bmath/rand\b)|(Math\.random\s*\(|random\.(random|randint|choice|getrandbits)\s*\(|mt_rand\s*\(|\bmath/rand\b)[^\n]{0,50}(token|otp|nonce|salt|secret|session|csrf|password|passwd|apikey|api_key|verification|reset)\b)`),
+			skipFn: commentOnlyLine,
+		},
+		{
+			id: "weak-rsa-key-size", cwe: "CWE-326", severity: shared.SeverityMedium, title: "RSA key size below 2048 bits",
+			desc: "An RSA key is generated with 512 or 1024 bits, which is factorable. Generate at least 2048-bit RSA (3072+ preferred) or use an elliptic-curve key.",
+			// RSA-specific constructors only (Go rsa.GenerateKey, Java RSAKeyGenParameterSpec, Python/Ruby
+			// RSA.generate, openssl genrsa). A bare `.initialize(1024)` is deliberately excluded — it false-
+			// positives on buffer/pool sizing.
+			re:     regexp.MustCompile(`(?i)(rsa\.GenerateKey\s*\([^,\n]+,\s*(512|1024)\b|RSAKeyGenParameterSpec\s*\(\s*(512|1024)\b|RSA\.generate\s*\(\s*(512|1024)\b|genrsa\b[^\n]*\b(512|1024)\b)`),
+			skipFn: commentOnlyLine,
+		},
+		{
+			id: "world-writable-permissions", cwe: "CWE-732", severity: shared.SeverityMedium, title: "World-writable file or directory permissions",
+			desc: "A file or directory is created world-writable (0777), letting any local user tamper with it. Use least-privilege modes (0600/0640 for files, 0700/0750 for directories).",
+			// The gap is bounded and stops at ')' so it can't reach a 0777 mentioned in a trailing comment.
+			re:     regexp.MustCompile(`(?i)((os\.(Chmod|Mkdir|MkdirAll)|os\.WriteFile|ioutil\.WriteFile|os\.chmod)\s*\([^;)\n]{0,40}0o?777\b|\bchmod\s*\(\s*["']?0?777|\bchmod\s+(-R\s+)?0?777\b)`),
+			skipFn: commentOnlyLine,
+		},
+		{
+			id: "unsafe-c-string-function", cwe: "CWE-676", severity: shared.SeverityMedium, title: "Unsafe C string function (buffer overflow risk)",
+			desc: "gets/strcpy/strcat/vsprintf write without a bound and are classic buffer-overflow sources. Use the size-bounded variants (fgets, strncpy/strlcpy, strncat/strlcat, vsnprintf).",
+			// Gated to C/C++/ObjC files (exts) AND anchored with (^|[^.\w]) so the same names as safe functions
+			// in other languages (Ruby gets, PHP vsprintf) can never produce a finding.
+			re:     regexp.MustCompile(`(^|[^.\w])(gets|strcpy|strcat|vsprintf)\s*\(`),
+			skipFn: commentOnlyLine,
+			exts:   cSourceExts,
 		},
 	}
 }


### PR DESCRIPTION
## Broaden pattern-SAST (SonarQube-class rules) + per-rule language gate

Widens the owned pattern-SAST engine with 9 new deterministic rules, moving coverage toward a SonarQube/Semgrep-class rule set. This is roadmap item 4 of the learn-from-Trivy-build-native line (after the secret scanner, the misconfig scanner, and the Ubuntu OVAL ingester).

Each rule emits an ungated, directly publishable `Kind=sast` finding, so every pattern is precision-biased: a match requires a taint marker or an inherently-unsafe construct, never a bare keyword.

### New rules

| Rule | CWE | Severity | Languages |
| --- | --- | --- | --- |
| XXE via external-entity config | 611 | High | Java, Python, PHP |
| Dynamic `eval` of untrusted input | 95 | Critical | JS, PHP, Python |
| DOM XSS via innerHTML / document.write | 79 | High | JS |
| NoSQL injection from request data | 943 | High | JS (Mongo) |
| Open redirect to request-controlled URL | 601 | Medium | JS, Java, Go |
| Weak PRNG in a security context | 338 | Medium | JS, Python, PHP, Go |
| RSA key size below 2048 | 326 | Medium | Go, Java, Python |
| World-writable permissions | 732 | Medium | Go, shell |
| Unsafe C string function | 676 | Medium | C / C++ / ObjC |

### Per-rule language gate

Adds an optional `rule.exts` allowlist so a language-specific idiom cannot false-positive on a same-named safe function in another language. The C string rule runs only on C/C++/Objective-C files, so Ruby `gets` and PHP `vsprintf` are never flagged. The mechanism is reusable for future language-specific rules.

### CLI wiring

Wires the SAST analyzer into `synapse-cli` behind `SYNAPSE_SAST_ENABLED`, matching the API and the sibling secret and misconfig scanners, so the CLI can dogfood SAST.

### Precision

Every rule ships with true-positive and false-positive corpus cases. The false-positive cases include the safe idioms the tightened markers must not flag: a canonical-host redirect built from server-derived `req.protocol`/`req.hostname`, a benign template interpolation `${count}`, a `0777` mentioned only in a trailing comment, and the C function names used in a non-C file.

### Reviews

Reviewed for Go idioms and clean-architecture consistency (rule shape, unique kebab-case ids, CLI wiring parity, no dependency-rule issue) and for the project safety rules (ReDoS, gating, LLM boundary, secret exposure, and false-positive quality on a publishable engine). No security-boundary, ReDoS, gating, or secret issues were found. All false-positive findings from review are fixed in this PR: the C-string language gate, dropping the over-broad `.initialize` branch from the RSA rule, narrowing the open-redirect markers to the user-controlled request subset, pairing the DOM-XSS `${` marker with a taint source, symmetric keyword handling in the weak-PRNG rule, and bounding the world-writable gap so it cannot reach a trailing comment.

Taint/dataflow SAST and additional languages remain follow-ups; this is the tier-1 (deterministic, per-line) broadening.
