### PR TITLE
feat(sca): content+version-addressed SBOM cache (Version-keyed invalidation)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/acquire"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/cache/sbomcache"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/ebpf"
 	egressinfra "github.com/KKloudTarus/synapse-ce/internal/infrastructure/egress"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/llm/openai"
@@ -50,13 +51,13 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifest"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavencoord"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/nvd"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/osv"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownadvisory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownsbom"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/risk"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/sast"
-	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/syft"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/taintcallgraph"
@@ -536,6 +537,12 @@ func main() {
 	if cfg.MisconfigEnabled {
 		scaService.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan in the scan pipeline
 		log.Info("misconfig scanning ENABLED (Dockerfile + Kubernetes manifests)")
+	}
+	if cfg.ScanCacheEnabled {
+		if dir := cfg.ResolveScanCacheDir(); dir != "" {
+			scaService.SetSBOMCache(sbomcache.New(dir)) // content+version-addressed generated-SBOM cache
+			log.Info("SBOM cache ENABLED", "dir", dir)
+		}
 	}
 	aupService := aupuc.NewService(aupStore, auditLog, clock, cfg.AUPVersion)
 	exportService := exportuc.NewService(findingRepo, clock, buildinfo.App())

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/acquire"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/cache/sbomcache"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/enry"
@@ -300,6 +301,11 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	}
 	if cfg.MisconfigEnabled {
 		sca.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan (CI-friendly)
+	}
+	if cfg.ScanCacheEnabled {
+		if dir := cfg.ResolveScanCacheDir(); dir != "" {
+			sca.SetSBOMCache(sbomcache.New(dir)) // content+version-addressed generated-SBOM cache (CI-friendly)
+		}
 	}
 	// JAR-embedded licenses + workspace LICENSE files for every ecosystem.
 	sca.SetLicenseFileResolver(licensefile.NewChain(jarlicense.New(), licensefile.New()))

--- a/internal/infrastructure/cache/sbomcache/cache.go
+++ b/internal/infrastructure/cache/sbomcache/cache.go
@@ -1,0 +1,217 @@
+// Package sbomcache is a filesystem-backed, content-addressed cache of generated SBOMs. It implements the
+// analyzer-version cache-invalidation idea (learned from Trivy): the cache key folds together a cheap
+// digest of the workspace CONTENT and the SBOM producer VERSION, so an unchanged tree re-scanned with the
+// same producer reuses the cataloged SBOM, and a producer bump makes every prior entry a miss.
+//
+// The workspace digest is metadata-based (path + size + mtime), which is deliberately CHEAPER than reading
+// and hashing every byte — the whole point is to be faster than the Syft cataloging pass it replaces. That
+// matches Trivy's filesystem-cache posture: a content edit that preserves BOTH size and mtime (pathological;
+// editors and git checkouts always bump mtime) is the only stale case, and it is bounded by the fact that a
+// producer version bump always invalidates. The cache is opt-in.
+package sbomcache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxDigestFiles = 300000 // cap the metadata walk; a larger tree skips caching rather than stalling
+	maxCacheFiles  = 512    // bound the cache directory; oldest entries are pruned past this
+)
+
+// Cache stores generated SBOMs under a root directory, one JSON file per key.
+type Cache struct {
+	root string
+}
+
+var _ ports.SBOMCache = (*Cache)(nil)
+
+// New returns a cache rooted at dir. The directory is created lazily on the first Store.
+func New(dir string) *Cache { return &Cache{root: dir} }
+
+// envelope preserves SBOM.Raw (which is json:"-" on the domain type) alongside the SBOM, so a cache hit
+// hands a downstream detector the EXACT original producer document rather than a lossy reconstruction.
+type envelope struct {
+	SBOM *sbom.SBOM `json:"sbom"`
+	Raw  []byte     `json:"raw,omitempty"`
+}
+
+// Load returns the cached SBOM for (dir, producerVersion) when present. Any miss reason (no version,
+// uncomputable digest, absent/corrupt file) returns ok=false with no error, so the caller just regenerates.
+func (c *Cache) Load(ctx context.Context, dir, producerVersion string) (*sbom.SBOM, bool, error) {
+	key := c.key(ctx, dir, producerVersion)
+	if key == "" {
+		return nil, false, nil
+	}
+	data, err := os.ReadFile(filepath.Join(c.root, key+".json"))
+	if err != nil {
+		return nil, false, nil // miss (not found / unreadable) — never fatal
+	}
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil || env.SBOM == nil {
+		return nil, false, nil // a corrupt entry is a miss, not a failure
+	}
+	env.SBOM.Raw = env.Raw // restore the non-serialized original document
+	return env.SBOM, true, nil
+}
+
+// Store caches doc for (dir, producerVersion). Best-effort: an uncomputable key or a write error is
+// returned but the caller ignores it (the scan already has its SBOM).
+func (c *Cache) Store(ctx context.Context, dir, producerVersion string, doc *sbom.SBOM) error {
+	if doc == nil {
+		return nil
+	}
+	key := c.key(ctx, dir, producerVersion)
+	if key == "" {
+		return nil
+	}
+	if err := os.MkdirAll(c.root, 0o755); err != nil {
+		return fmt.Errorf("sbom cache: mkdir: %w", err)
+	}
+	data, err := json.Marshal(envelope{SBOM: doc, Raw: doc.Raw})
+	if err != nil {
+		return fmt.Errorf("sbom cache: marshal: %w", err)
+	}
+	dst := filepath.Join(c.root, key+".json")
+	tmp, err := os.CreateTemp(c.root, key+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("sbom cache: temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("sbom cache: write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("sbom cache: close: %w", err)
+	}
+	if err := os.Rename(tmpName, dst); err != nil { // atomic publish
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("sbom cache: rename: %w", err)
+	}
+	c.prune()
+	return nil
+}
+
+// key folds the workspace content digest with the producer version. Returns "" (no caching) when the
+// producer version is unknown — never serve an SBOM that can't be soundly version-keyed.
+func (c *Cache) key(ctx context.Context, dir, producerVersion string) string {
+	if strings.TrimSpace(producerVersion) == "" {
+		return ""
+	}
+	digest := workspaceMetaDigest(ctx, dir)
+	if digest == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(digest + "\x00" + producerVersion))
+	return hex.EncodeToString(sum[:])
+}
+
+// workspaceMetaDigest is a cheap, order-independent fingerprint of the tree: sorted (relpath, size,
+// mtime) over regular files, skipping .git. Returns "" if the tree is too large to fingerprint cheaply
+// (then the scan just runs uncached) or on context cancellation.
+func workspaceMetaDigest(ctx context.Context, dir string) string {
+	var lines []string
+	count := 0
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil // never follow a symlink out of the tree
+		}
+		if count++; count > maxDigestFiles {
+			return errTooLarge
+		}
+		info, e := d.Info()
+		if e != nil {
+			return nil
+		}
+		rel := strings.TrimPrefix(strings.TrimPrefix(path, dir), string(os.PathSeparator))
+		lines = append(lines, rel+"\x00"+strconv.FormatInt(info.Size(), 10)+"\x00"+strconv.FormatInt(info.ModTime().UnixNano(), 10))
+		return nil
+	})
+	if err != nil {
+		return "" // too large, cancelled, or a walk error → skip caching
+	}
+	if len(lines) == 0 {
+		return "" // empty or missing tree: nothing to key on, and every empty tree would collide → skip
+	}
+	sort.Strings(lines)
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+// errTooLarge stops the digest walk once the tree exceeds the cheap-fingerprint cap.
+var errTooLarge = errors.New("workspace too large to fingerprint")
+
+// staleTmpAge is how old an orphaned temp file must be before prune reclaims it; the margin avoids racing a
+// concurrent in-flight Store's temp.
+const staleTmpAge = time.Hour
+
+// prune reclaims crash-orphaned temp files and keeps the cache directory bounded by deleting the oldest
+// entries once it exceeds maxCacheFiles. Best-effort: any error is ignored (an over-full cache is a
+// performance issue, not a correctness one).
+func (c *Cache) prune() {
+	entries, err := os.ReadDir(c.root)
+	if err != nil {
+		return
+	}
+	type ent struct {
+		name  string
+		mtime int64
+	}
+	now := time.Now()
+	files := make([]ent, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil {
+			continue
+		}
+		switch {
+		case strings.HasSuffix(e.Name(), ".tmp"):
+			// A temp orphaned by a crash between CreateTemp and Rename; only reclaim once it's clearly stale.
+			if now.Sub(info.ModTime()) > staleTmpAge {
+				_ = os.Remove(filepath.Join(c.root, e.Name()))
+			}
+		case strings.HasSuffix(e.Name(), ".json"):
+			files = append(files, ent{e.Name(), info.ModTime().UnixNano()})
+		}
+	}
+	if len(files) <= maxCacheFiles {
+		return
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].mtime < files[j].mtime }) // oldest first
+	for _, f := range files[:len(files)-maxCacheFiles] {
+		_ = os.Remove(filepath.Join(c.root, f.name))
+	}
+}

--- a/internal/infrastructure/cache/sbomcache/cache_test.go
+++ b/internal/infrastructure/cache/sbomcache/cache_test.go
@@ -1,0 +1,137 @@
+package sbomcache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+func write(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sampleSBOM() *sbom.SBOM {
+	return &sbom.SBOM{
+		ID: "s1", Source: "syft", GeneratorVersion: "1.45.1",
+		Components: []sbom.Component{{Name: "lodash", Version: "4.0.0", PURL: "pkg:npm/lodash@4.0.0"}},
+		Raw:        []byte(`{"bomFormat":"CycloneDX"}`),
+	}
+}
+
+func TestStoreLoadRoundTripPreservesRaw(t *testing.T) {
+	ws := t.TempDir()
+	write(t, ws, "go.mod", "module x\n")
+	c := New(t.TempDir())
+	ctx := context.Background()
+
+	if err := c.Store(ctx, ws, "syft-1.45.1", sampleSBOM()); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	got, ok, err := c.Load(ctx, ws, "syft-1.45.1")
+	if err != nil || !ok {
+		t.Fatalf("want a cache hit, got ok=%v err=%v", ok, err)
+	}
+	if len(got.Components) != 1 || got.Components[0].Name != "lodash" {
+		t.Errorf("components not round-tripped: %+v", got.Components)
+	}
+	// Raw is json:"-" on the domain type; the cache MUST preserve it so a hit still gives Grype the exact SBOM.
+	if string(got.Raw) != `{"bomFormat":"CycloneDX"}` {
+		t.Errorf("Raw not preserved: %q", string(got.Raw))
+	}
+	// Whole-graph guard: a cache hit must be behaviorally identical to a fresh generate, or detection could
+	// silently differ. This deep-equal fails loudly if a future SBOM field is added with json:"-" (like Raw)
+	// or as an unexported field and is NOT taught to the cache envelope.
+	if !reflect.DeepEqual(sampleSBOM(), got) {
+		t.Errorf("cache hit is not deep-equal to the original SBOM:\n orig=%+v\n  got=%+v", sampleSBOM(), got)
+	}
+}
+
+func TestProducerVersionChangeInvalidates(t *testing.T) {
+	ws := t.TempDir()
+	write(t, ws, "go.mod", "module x\n")
+	c := New(t.TempDir())
+	ctx := context.Background()
+	_ = c.Store(ctx, ws, "syft-1.45.1", sampleSBOM())
+
+	if _, ok, _ := c.Load(ctx, ws, "syft-1.46.0"); ok {
+		t.Error("a producer version bump must invalidate the entry (cache miss)")
+	}
+	if _, ok, _ := c.Load(ctx, ws, "syft-1.45.1"); !ok {
+		t.Error("the same producer version must still hit")
+	}
+}
+
+func TestContentChangeInvalidates(t *testing.T) {
+	ws := t.TempDir()
+	write(t, ws, "go.mod", "module x\n")
+	c := New(t.TempDir())
+	ctx := context.Background()
+	_ = c.Store(ctx, ws, "v1", sampleSBOM())
+
+	// Change a file's content (and thus size + mtime) → the metadata digest changes → miss.
+	time.Sleep(2 * time.Millisecond)
+	write(t, ws, "go.mod", "module x\nrequire y v1.0.0\n")
+	if _, ok, _ := c.Load(ctx, ws, "v1"); ok {
+		t.Error("a changed workspace must invalidate the entry (cache miss)")
+	}
+}
+
+func TestEmptyProducerVersionNeverCaches(t *testing.T) {
+	ws := t.TempDir()
+	write(t, ws, "go.mod", "module x\n")
+	c := New(t.TempDir())
+	ctx := context.Background()
+
+	if err := c.Store(ctx, ws, "", sampleSBOM()); err != nil {
+		t.Fatalf("Store with empty version must be a no-op, got %v", err)
+	}
+	if _, ok, _ := c.Load(ctx, ws, ""); ok {
+		t.Error("an unversioned entry must never be served")
+	}
+}
+
+func TestLoadMissOnAbsent(t *testing.T) {
+	ws := t.TempDir()
+	write(t, ws, "go.mod", "module x\n")
+	if _, ok, err := New(t.TempDir()).Load(context.Background(), ws, "v1"); ok || err != nil {
+		t.Errorf("a never-stored workspace must miss cleanly, ok=%v err=%v", ok, err)
+	}
+}
+
+func TestSymlinkNotFollowed(t *testing.T) {
+	ws := t.TempDir()
+	write(t, ws, "go.mod", "module x\n")
+	// A symlink to an out-of-tree file must be skipped by the digest walk (never followed), not fatal.
+	outside := filepath.Join(t.TempDir(), "secret")
+	_ = os.WriteFile(outside, []byte("x"), 0o644)
+	if err := os.Symlink(outside, filepath.Join(ws, "link")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	c := New(t.TempDir())
+	ctx := context.Background()
+	if err := c.Store(ctx, ws, "v1", sampleSBOM()); err != nil {
+		t.Fatalf("Store with a symlink present must succeed: %v", err)
+	}
+	if _, ok, _ := c.Load(ctx, ws, "v1"); !ok {
+		t.Error("digest must compute (symlink skipped) and hit")
+	}
+}
+
+func TestCancelledContextMisses(t *testing.T) {
+	ws := t.TempDir()
+	write(t, ws, "go.mod", "module x\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// A cancelled context yields an uncomputable digest → a clean miss, never a panic or error.
+	if _, ok, err := New(t.TempDir()).Load(ctx, ws, "v1"); ok || err != nil {
+		t.Errorf("cancelled Load must miss cleanly, ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -165,6 +166,14 @@ type Config struct {
 	// MisconfigEnabled turns on the deterministic IaC/config misconfig scanner (Dockerfile, Kubernetes
 	// manifests) in the scan pipeline; off by default. Read-only, first-party checks, no policy engine.
 	MisconfigEnabled bool
+	// ScanCacheEnabled turns on the content+version-addressed generated-SBOM cache; off by default. A hit on
+	// an unchanged tree skips the cataloging step; a producer version bump invalidates the entry.
+	ScanCacheEnabled bool
+	// ScanCacheDir is where cached SBOMs live when ScanCacheEnabled. Empty ⇒ a "synapse-sbom" subdir of the
+	// OS user cache dir. It MUST be operator-owned and not writable by untrusted users: an attacker who can
+	// write there and compute a scan's content+producer key could pre-seed a lossy SBOM (a silent
+	// false-negative). The default per-user cache dir satisfies this.
+	ScanCacheDir string
 	// OwnedAdvisoryEnabled wires the owned advisory DetectionSource: match the SBOM
 	// against the owned normalized-advisory store (offline, reproducible) ALONGSIDE live OSV/Grype. Off by
 	// default; opt-in. An empty store yields no findings (a harmless no-op) until the advisory ingester
@@ -308,6 +317,8 @@ func Load() Config {
 		SASTEnabled:            getbool("SYNAPSE_SAST_ENABLED", false),
 		SecretScanEnabled:      getbool("SYNAPSE_SECRET_SCAN_ENABLED", false),
 		MisconfigEnabled:       getbool("SYNAPSE_MISCONFIG_ENABLED", false),
+		ScanCacheEnabled:       getbool("SYNAPSE_SCAN_CACHE_ENABLED", false),
+		ScanCacheDir:           os.Getenv("SYNAPSE_SCAN_CACHE_DIR"),
 		OwnedAdvisoryEnabled:   getbool("SYNAPSE_OWNED_ADVISORY", false),
 		ReachabilityEnabled:    getbool("SYNAPSE_REACHABILITY_ENABLED", false),
 		CrossCheckEnabled:      getbool("SYNAPSE_CROSSCHECK_ENABLED", false),
@@ -427,6 +438,19 @@ func getbool(key string, def bool) bool {
 		}
 	}
 	return def
+}
+
+// ResolveScanCacheDir returns the SBOM cache directory, defaulting to a "synapse-sbom" subdir of the OS
+// user cache dir when SYNAPSE_SCAN_CACHE_DIR is unset. Empty only when no cache dir can be determined.
+func (c Config) ResolveScanCacheDir() string {
+	if c.ScanCacheDir != "" {
+		return c.ScanCacheDir
+	}
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(base, "synapse-sbom")
 }
 
 func getduration(key string, def time.Duration) time.Duration {

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -557,6 +557,21 @@ type SBOMGenerator interface {
 	Generate(ctx context.Context, targetRef string) (*sbom.SBOM, error)
 }
 
+// SBOMCache is an optional content-addressed cache of GENERATED (pre-enrichment) SBOMs. The key is derived
+// from the workspace CONTENT plus the producer VERSION, so an unchanged source re-scanned with the same
+// producer reuses the SBOM (skipping the expensive cataloging step), while a producer version bump
+// invalidates the entry — Trivy's analyzer-version cache-invalidation model. The implementation owns the
+// key derivation (it walks dir) so filesystem I/O stays in the infrastructure layer; the usecase only
+// supplies the pure producerVersion string. It preserves SBOM.Raw (which is json:"-") so a cache hit still
+// hands a downstream detector (Grype) the EXACT original document, not a lossy reconstruction. Best-effort:
+// an empty producerVersion, an uncomputable key, or any cache error is a silent miss, NEVER a scan failure.
+type SBOMCache interface {
+	// Load returns the cached SBOM for (dir, producerVersion) when present + fresh; ok=false on a miss.
+	Load(ctx context.Context, dir, producerVersion string) (*sbom.SBOM, bool, error)
+	// Store caches doc for (dir, producerVersion). A store failure is non-fatal to the caller.
+	Store(ctx context.Context, dir, producerVersion string, doc *sbom.SBOM) error
+}
+
 // ReachabilitySubject is one finding to assess for reachability: its id (the judgment subject) + the
 // advisory's affected symbols ("importPath.Symbol"). Lives here (not in a usecase) so a producer like the
 // SCA pipeline can feed the reachability recorder without importing the reachproof use case.

--- a/internal/usecase/sca/sbomcache_test.go
+++ b/internal/usecase/sca/sbomcache_test.go
@@ -1,0 +1,28 @@
+package sca
+
+import "testing"
+
+func TestSBOMProducerVersion(t *testing.T) {
+	// No versions known → empty → the cache stays off (never serve an unversioned SBOM).
+	if got := sbomProducerVersion(nil); got != "" {
+		t.Errorf("nil map: want empty, got %q", got)
+	}
+	if got := sbomProducerVersion(map[string]string{"kev-catalog": "2026.07.01"}); got != "" {
+		t.Errorf("only non-producer versions: want empty, got %q", got)
+	}
+
+	base := map[string]string{"syft": "1.45.1", "go-enry": "v2.9.6", "synapse": "v0.1.0"}
+	v1 := sbomProducerVersion(base)
+	if v1 == "" {
+		t.Fatal("a populated producer map must yield a non-empty version")
+	}
+	// A producer bump changes the key; a KEV/EPSS DB change (not a producer) must NOT.
+	bumped := map[string]string{"syft": "1.46.0", "go-enry": "v2.9.6", "synapse": "v0.1.0"}
+	if sbomProducerVersion(bumped) == v1 {
+		t.Error("a syft version bump must change the producer version")
+	}
+	withKEV := map[string]string{"syft": "1.45.1", "go-enry": "v2.9.6", "synapse": "v0.1.0", "kev-catalog": "2026.08.01"}
+	if sbomProducerVersion(withKEV) != v1 {
+		t.Error("a non-producer DB version must NOT change the producer version (no over-invalidation)")
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -64,6 +64,7 @@ type Service struct {
 	reachability   ports.ReachabilityRecorder    // optional deterministic Tier-2 reachability proof
 	correlation    ports.CorrelationRecorder     // optional cross-check disagreement → judgment minter
 	sbomGen2       ports.SBOMGenerator           // optional 2nd SBOM producer for the cross-check
+	sbomCache      ports.SBOMCache               // optional content+version-addressed cache of the generated SBOM
 	sbomCrossCheck ports.SBOMCrossCheckRecorder  // optional SBOM-producer disagreement → judgment minter
 	taint          ports.TaintScanner            // optional deterministic taint-analysis → gated CapSAST proposals
 	graphResolver  ports.DependencyGraphResolver // optional transitive-edge resolver (Go via `go mod graph`)
@@ -112,6 +113,33 @@ func (s *Service) SetSASTAnalyzer(a ports.SASTAnalyzer) { s.sastAnalyzer = a }
 
 // SetSecretScanner configures the optional deterministic secret scanner. nil ⇒ no secret scanning.
 func (s *Service) SetSecretScanner(sc ports.SecretScanner) { s.secretScanner = sc }
+
+// SetSBOMCache configures the optional generated-SBOM cache. nil ⇒ always regenerate. Best-effort: a cache
+// miss or error never affects correctness, only whether the cataloging step is skipped.
+func (s *Service) SetSBOMCache(c ports.SBOMCache) { s.sbomCache = c }
+
+// sbomProducerVersion is the SBOM-producer identity used as the cache-invalidation version: the versions of
+// the components that determine SBOM OUTPUT — the syft binary, the language classifier, and the synapse
+// binary that carries the owned parsers/enrichers. It deliberately excludes advisory/KEV/EPSS DB versions
+// (they don't change the generated SBOM). Empty when no producer version is known, which keeps the cache
+// off rather than serving an SBOM that can't be soundly version-keyed.
+func sbomProducerVersion(tv map[string]string) string {
+	if tv == nil {
+		return ""
+	}
+	v := tv["syft"] + "\x00" + tv["go-enry"] + "\x00" + tv["synapse"]
+	if strings.Trim(v, "\x00") == "" {
+		return ""
+	}
+	return v
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
 
 // SetMisconfigScanner configures the optional deterministic IaC/config misconfig scanner.
 // nil ⇒ no misconfig scanning. A setter keeps the existing NewService call sites unchanged.
@@ -1232,12 +1260,30 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	stage, pct = stageSBOM, 35
 	report(stage, pct, trace.snapshot())
 	step = trace.start(stageSBOM, "sbom-generation", "sbom", "Generate SBOM", nil)
-	doc, err := s.sbomGen.Generate(ctx, ws.Dir)
-	if err != nil {
-		trace.fail(step, err)
-		return nil, fmt.Errorf("generate sbom: %w", err)
+	// Content+version-addressed cache (opt-in): on an unchanged tree scanned with the same producer, reuse
+	// the cataloged SBOM and skip generation; a producer version bump makes the key miss (Trivy's
+	// analyzer-version invalidation). Best-effort — a miss/error just regenerates.
+	producerVer := sbomProducerVersion(s.prov.ToolVersions)
+	var doc *sbom.SBOM
+	cacheHit := false
+	if s.sbomCache != nil {
+		if cached, ok, _ := s.sbomCache.Load(ctx, ws.Dir, producerVer); ok && cached != nil {
+			doc, cacheHit = cached, true
+		}
 	}
-	trace.succeed(step, "SBOM generated", map[string]int{"components": countComponents(doc), "dependencies": len(doc.Dependencies)})
+	if doc == nil {
+		doc, err = s.sbomGen.Generate(ctx, ws.Dir)
+		if err != nil {
+			trace.fail(step, err)
+			return nil, fmt.Errorf("generate sbom: %w", err)
+		}
+		if s.sbomCache != nil {
+			// Store re-fingerprints ws.Dir; this assumes the generator did NOT mutate the workspace (Syft +
+			// the owned parsers read only), so the stored key matches the next clean scan's Load key.
+			_ = s.sbomCache.Store(ctx, ws.Dir, producerVer, doc) // best-effort; a store error never fails the scan
+		}
+	}
+	trace.succeed(step, "SBOM generated", map[string]int{"components": countComponents(doc), "dependencies": len(doc.Dependencies), "cache_hit": boolToInt(cacheHit)})
 	// SBOM producer cross-check: when a 2nd producer is configured, diff the two RAW
 	// component sets — BEFORE enrichment, so it compares the PRODUCERS themselves, not a shared post-process —
 	// and record components only one producer emitted as ungated CapCorrelation judgments for human review.


### PR DESCRIPTION
## Content + version-addressed SBOM cache

Adds an opt-in cache of the generated SBOM, so an unchanged workspace re-scanned with the same producer reuses the cataloged SBOM instead of re-running the producer. This is roadmap item 5, the last of the learn-from-Trivy-build-native line (after the secret scanner, the misconfig scanner, the Ubuntu OVAL ingester, and the SAST broadening).

### The idea (learned from Trivy)

The cache key folds two things: a cheap fingerprint of the workspace content, and the SBOM producer version. So an unchanged tree scanned with the same producer is a hit, and a producer version bump makes every prior entry a miss. That is Trivy's analyzer-version cache-invalidation model: results are keyed by the tool version that produced them, so a tool change can never serve a stale result.

### What it caches, and why that is safe

- It caches the pre-enrichment SBOM (the pure output of the producer), keyed by content plus producer version. Enrichment and detection still run on a hit, so their (network-dependent) results are never cached.
- The producer version comes only from the components that determine SBOM output (the producer binary, the language classifier, and the synapse binary that carries the owned parsers). Advisory, KEV, and EPSS database versions are excluded, so a database refresh does not needlessly invalidate.
- SBOM.Raw is the producer's original document and is `json:"-"` on the domain type, but a downstream detector consumes it for the exact SBOM. The cache preserves it in an envelope, so a hit hands the detector the identical document a fresh generate would. A deep-equal round-trip test guards this invariant against any future field added with `json:"-"`.

### Performance and safety

- The workspace fingerprint is metadata-based (path, size, mtime), deliberately cheaper than reading every byte, so computing the key is faster than the cataloging pass it replaces. This matches Trivy's filesystem-cache posture: the only stale case is an edit that preserves both size and mtime, which is bounded by the producer-version invalidation and is why the feature is opt-in.
- The digest walk is read-only and bounded: it never follows a symlink, a tree past the file cap simply skips caching, and context cancellation is honored.
- Everything is best-effort: an empty producer version, an uncomputable key, or any cache error is a silent miss that never fails or alters a scan. Writes are atomic (temp file plus rename), the cache directory is bounded, and crash-orphaned temp files are reclaimed.

### Wiring

Behind `SYNAPSE_SCAN_CACHE_ENABLED` (with `SYNAPSE_SCAN_CACHE_DIR`, defaulting to a per-user cache directory) in both synapse-api and synapse-cli, matching the sibling secret and misconfig scanners.

### Testing

- Cache unit tests: store/load round-trip with a deep-equal assertion, producer-version-bump invalidation, content-change invalidation, empty-version never caches, symlink not followed, cancelled-context clean miss. Race-detector clean.
- A producer-version test locks in that a producer bump changes the key while a KEV/EPSS database change does not.
- End to end via the CLI: scan a target twice with the cache on and the second scan reuses the SBOM (one cache entry, same components); change the content and a new entry is keyed.
- `go build`, `go vet`, and the affected package tests pass.

### Reviews

Reviewed for clean-architecture compliance (the new infrastructure package implements the port, the usecase depends only on the port, the concrete package is imported only by the composition roots) and for the project safety rules. The security review found no golden-rule, exec, network, or secret issues, and confirmed the load-bearing property that a cache hit is behaviorally identical to a fresh generate. Its low-severity hardening notes (reclaim crash-orphaned temp files, document that the cache directory must be operator-owned) are addressed in this PR, along with the go-arch notes.

Caching the enriched SBOM or the whole scan result keyed additionally by the detection database snapshot is a possible follow-up; the database versions are per-request, so they cannot key an upfront cache the way the producer version can.
