### PR TITLE
feat(sca): .synapseignore accepted-risk policy (governance-first suppression)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/govulncheck"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gradleresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/grype"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ignorefile"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarhash"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarlicense"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jvmreach"
@@ -537,6 +538,10 @@ func main() {
 	if cfg.MisconfigEnabled {
 		scaService.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan in the scan pipeline
 		log.Info("misconfig scanning ENABLED (Dockerfile + Kubernetes manifests)")
+	}
+	if cfg.SuppressionEnabled {
+		scaService.SetSuppressionLoader(ignorefile.New()) // repo-committed .synapseignore accepted-risk policy
+		log.Info("suppression ENABLED (.synapseignore; suppressed findings retained + surfaced)")
 	}
 	if cfg.ScanCacheEnabled {
 		if dir := cfg.ResolveScanCacheDir(); dir != "" {

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/enry"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gradleresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/grype"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ignorefile"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarhash"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarlicense"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jvmreach"
@@ -302,6 +303,9 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	if cfg.MisconfigEnabled {
 		sca.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan (CI-friendly)
 	}
+	if cfg.SuppressionEnabled {
+		sca.SetSuppressionLoader(ignorefile.New()) // repo-committed .synapseignore accepted-risk policy (CI-friendly)
+	}
 	if cfg.ScanCacheEnabled {
 		if dir := cfg.ResolveScanCacheDir(); dir != "" {
 			sca.SetSBOMCache(sbomcache.New(dir)) // content+version-addressed generated-SBOM cache (CI-friendly)
@@ -337,8 +341,12 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	printReport(target, res)
 
 	gate := shared.SeverityRank(failOn)
+	accepted := res.SuppressedKeys() // .synapseignore accepted-risk: reported + sealed, but exempt from the gate
 	over := 0
 	for _, f := range res.Findings {
+		if accepted[f.DedupKey] {
+			continue
+		}
 		if shared.SeverityRank(f.Severity) >= gate {
 			over++
 		}
@@ -411,6 +419,22 @@ func printReport(target string, res *scauc.ScanResult) {
 	}
 	for _, w := range res.SourceWarnings {
 		fmt.Printf("  ! %s\n", w)
+	}
+	if n := len(res.SuppressedFindings); n > 0 {
+		fmt.Printf("  accepted-risk via .synapseignore: %d (still reported + evidence-sealed; exempt from --fail-on)\n", n)
+		for _, s := range res.SuppressedFindings {
+			reason := s.Reason
+			if reason == "" {
+				reason = "(no reason given)"
+			}
+			fmt.Printf("    - %s  [%s]  %s\n", s.Title, s.RuleID, reason)
+		}
+	}
+	for _, id := range res.ExpiredSuppressions {
+		fmt.Printf("  ! .synapseignore rule %q has EXPIRED — no longer accepted; the finding trips --fail-on again. Refresh or remove it\n", id)
+	}
+	for _, id := range res.MalformedSuppressions {
+		fmt.Printf("  ! .synapseignore rule %q has an UNPARSEABLE exp: date — not applied (fail-safe). Fix it to YYYY-MM-DD\n", id)
 	}
 	for _, f := range res.Findings {
 		kev := ""

--- a/internal/domain/ignore/ignore.go
+++ b/internal/domain/ignore/ignore.go
@@ -1,0 +1,107 @@
+// Package ignore models a repo-committed, declarative finding-suppression policy: the accepted-risk
+// decisions a team version-controls alongside its code — Synapse's take on Trivy's .trivyignore, made
+// governance-first. A rule may carry a reason and an expiry; an expired rule never suppresses (accepted
+// risk is revisited, not permanent); and — enforced by the caller — a suppressed finding is RETAINED and
+// surfaced, never silently dropped. This package is pure (bytes in, decisions out): reading the file and
+// applying the decisions live in the infrastructure + usecase layers.
+package ignore
+
+import (
+	"strings"
+	"time"
+)
+
+// Rule is one suppression: an advisory id (CVE/GHSA) or an exact finding dedup key to accept, with an
+// optional human reason and an optional expiry (zero = never expires).
+type Rule struct {
+	ID      string
+	Reason  string
+	Expires time.Time // zero = never; the rule stops suppressing on this UTC date
+	// Malformed marks a rule whose exp: token was present but unparseable. Such a rule NEVER suppresses
+	// (fail-safe: a date typo must not silently become a permanent acceptance) and is surfaced so it's fixed.
+	Malformed bool
+}
+
+// Set is a parsed suppression policy.
+type Set []Rule
+
+// Parse reads the .synapseignore text format: one rule per line, '#' begins a comment. A rule line is
+//
+//	<id> [exp:YYYY-MM-DD] [# free-text reason]
+//
+// Unparseable lines are skipped (lenient, like Trivy) so a single typo can neither hide a whole policy nor
+// fail a scan. Parsing never errors.
+func Parse(data []byte) Set {
+	var out Set
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		reason := ""
+		if h := strings.IndexByte(line, '#'); h >= 0 { // an inline "# reason"
+			reason = strings.TrimSpace(line[h+1:])
+			line = strings.TrimSpace(line[:h])
+		}
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		r := Rule{ID: fields[0], Reason: reason}
+		for _, f := range fields[1:] {
+			if v, ok := strings.CutPrefix(f, "exp:"); ok {
+				if t, err := time.Parse("2006-01-02", v); err == nil {
+					r.Expires = t
+				} else {
+					r.Malformed = true // a present-but-invalid expiry must NOT default to permanent suppression
+				}
+			}
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// Match returns the first ACTIVE rule whose id equals any of the given identifiers (case-insensitive), and
+// true. An expired OR malformed rule never matches, so the finding re-surfaces. now is the comparison time.
+func (s Set) Match(ids []string, now time.Time) (Rule, bool) {
+	for _, r := range s {
+		if r.Malformed || r.expired(now) {
+			continue
+		}
+		for _, id := range ids {
+			if strings.EqualFold(strings.TrimSpace(id), r.ID) {
+				return r, true
+			}
+		}
+	}
+	return Rule{}, false
+}
+
+// Expired returns the rules that have lapsed as of now, so an operator can be told which accepted-risk
+// decisions need refreshing (surfacing them is the caller's job — this never hides anything).
+func (s Set) Expired(now time.Time) Set {
+	var out Set
+	for _, r := range s {
+		if r.expired(now) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// Malformed returns the rules with an unparseable expiry, so an operator can be told to fix them (they are
+// treated as non-suppressing until fixed).
+func (s Set) Malformed() Set {
+	var out Set
+	for _, r := range s {
+		if r.Malformed {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (r Rule) expired(now time.Time) bool {
+	return !r.Expires.IsZero() && !now.Before(r.Expires)
+}

--- a/internal/domain/ignore/ignore_test.go
+++ b/internal/domain/ignore/ignore_test.go
@@ -1,0 +1,95 @@
+package ignore
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	src := `# accepted risks for this repo
+CVE-2023-1234 exp:2026-12-31 # not exploitable in our config
+CVE-2023-5678
+GHSA-aaaa-bbbb-cccc  # third-party, tracked upstream
+
+   # a blank + comment line above
+badexpiry exp:not-a-date # still a rule, just no expiry
+`
+	set := Parse([]byte(src))
+	if len(set) != 4 {
+		t.Fatalf("want 4 rules, got %d: %+v", len(set), set)
+	}
+	if set[0].ID != "CVE-2023-1234" || set[0].Reason != "not exploitable in our config" || set[0].Expires.IsZero() {
+		t.Errorf("rule 0 mis-parsed: %+v", set[0])
+	}
+	if set[1].ID != "CVE-2023-5678" || set[1].Reason != "" || !set[1].Expires.IsZero() {
+		t.Errorf("rule 1 mis-parsed: %+v", set[1])
+	}
+	if set[2].ID != "GHSA-aaaa-bbbb-cccc" || set[2].Reason != "third-party, tracked upstream" {
+		t.Errorf("rule 2 mis-parsed: %+v", set[2])
+	}
+	if set[3].ID != "badexpiry" || !set[3].Expires.IsZero() || !set[3].Malformed {
+		t.Errorf("an unparseable expiry must be flagged Malformed (fail-safe), not silently permanent: %+v", set[3])
+	}
+}
+
+func TestMalformedExpiryNeverSuppresses(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	set := Parse([]byte("CVE-2023-1 exp:2026-31-12 # month/day typo\nCVE-2023-2\n"))
+	// The malformed rule must NOT match (a date typo can't become a permanent silent acceptance)...
+	if _, ok := set.Match([]string{"CVE-2023-1"}, now); ok {
+		t.Error("a rule with an unparseable expiry must not suppress")
+	}
+	// ...but a well-formed rule still works.
+	if _, ok := set.Match([]string{"CVE-2023-2"}, now); !ok {
+		t.Error("a valid rule alongside a malformed one must still match")
+	}
+	// ...and the malformed rule is surfaced for fixing.
+	m := set.Malformed()
+	if len(m) != 1 || m[0].ID != "CVE-2023-1" {
+		t.Errorf("the malformed rule must be surfaced, got %+v", m)
+	}
+}
+
+func TestMatchCaseInsensitiveAndExpiry(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	set := Parse([]byte("CVE-2023-1234 exp:2026-12-31\nGHSA-old exp:2026-01-01\nGHSA-never\n"))
+
+	// active, exact + case-insensitive match
+	if r, ok := set.Match([]string{"cve-2023-1234"}, now); !ok || r.ID != "CVE-2023-1234" {
+		t.Errorf("active rule must match case-insensitively, got ok=%v r=%+v", ok, r)
+	}
+	// expired rule must NOT match (finding re-surfaces)
+	if _, ok := set.Match([]string{"GHSA-old"}, now); ok {
+		t.Error("an expired rule must not suppress")
+	}
+	// no-expiry rule matches
+	if _, ok := set.Match([]string{"GHSA-never"}, now); !ok {
+		t.Error("a no-expiry rule must match")
+	}
+	// a non-listed id does not match
+	if _, ok := set.Match([]string{"CVE-9999-0000"}, now); ok {
+		t.Error("an unlisted id must not match")
+	}
+	// multiple identifiers: any one matching suppresses (e.g. dedup key OR the CVE)
+	if _, ok := set.Match([]string{"some:dedup:key", "CVE-2023-1234"}, now); !ok {
+		t.Error("a match on any of the finding's identifiers must suppress")
+	}
+}
+
+func TestExpiredSurfacing(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	set := Parse([]byte("A exp:2026-01-01\nB\nC exp:2027-01-01\n"))
+	exp := set.Expired(now)
+	if len(exp) != 1 || exp[0].ID != "A" {
+		t.Errorf("want exactly rule A expired, got %+v", exp)
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	if s := Parse(nil); len(s) != 0 {
+		t.Errorf("empty input must yield an empty set, got %+v", s)
+	}
+	if s := Parse([]byte("# only comments\n\n   \n")); len(s) != 0 {
+		t.Errorf("comment/blank-only input must yield an empty set, got %+v", s)
+	}
+}

--- a/internal/infrastructure/tools/ignorefile/loader.go
+++ b/internal/infrastructure/tools/ignorefile/loader.go
@@ -1,0 +1,43 @@
+// Package ignorefile loads a repo-committed .synapseignore suppression policy from a prepared workspace.
+// It is the thin infrastructure adapter over the pure domain parser (internal/domain/ignore): read the
+// file, hand the bytes to the parser. Reading one fixed file is all it does; the policy semantics live in
+// the domain and the application of the policy lives in the SCA pipeline.
+package ignorefile
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	fileName = ".synapseignore"
+	maxBytes = 1 << 20 // an accepted-risk policy is small; cap the read defensively
+)
+
+// Loader reads <workspace>/.synapseignore.
+type Loader struct{}
+
+var _ ports.SuppressionLoader = (*Loader)(nil)
+
+// New returns a loader.
+func New() *Loader { return &Loader{} }
+
+// Load reads and parses <dir>/.synapseignore. A missing, non-regular, oversized, or unreadable file is a
+// silent empty policy (never a scan failure) — accepted risk that can't be read simply isn't applied.
+func (l *Loader) Load(_ context.Context, dir string) (ignore.Set, error) {
+	path := filepath.Join(dir, fileName)
+	// Lstat + IsRegular: never follow a .synapseignore symlink out of the (untrusted) workspace.
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > maxBytes {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed filename under the prepared workspace, re-verified regular via Lstat
+	if err != nil {
+		return nil, nil
+	}
+	return ignore.Parse(data), nil
+}

--- a/internal/infrastructure/tools/ignorefile/loader_test.go
+++ b/internal/infrastructure/tools/ignorefile/loader_test.go
@@ -1,0 +1,49 @@
+package ignorefile
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".synapseignore"), []byte("CVE-2023-1 # accepted\nGHSA-x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	set, err := New().Load(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(set) != 2 || set[0].ID != "CVE-2023-1" {
+		t.Errorf("want 2 rules parsed, got %+v", set)
+	}
+}
+
+func TestLoadMissingIsEmpty(t *testing.T) {
+	set, err := New().Load(context.Background(), t.TempDir())
+	if err != nil || len(set) != 0 {
+		t.Errorf("a missing .synapseignore must be an empty policy with no error, got set=%+v err=%v", set, err)
+	}
+}
+
+func TestLoadSymlinkNotFollowed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	dir := t.TempDir()
+	// A .synapseignore symlink pointing OUT of the workspace must not be followed.
+	outside := filepath.Join(t.TempDir(), "evil")
+	if err := os.WriteFile(outside, []byte("CVE-2023-1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, ".synapseignore")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	set, err := New().Load(context.Background(), dir)
+	if err != nil || len(set) != 0 {
+		t.Errorf("a symlinked .synapseignore must be ignored (not followed), got set=%+v err=%v", set, err)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -166,6 +166,9 @@ type Config struct {
 	// MisconfigEnabled turns on the deterministic IaC/config misconfig scanner (Dockerfile, Kubernetes
 	// manifests) in the scan pipeline; off by default. Read-only, first-party checks, no policy engine.
 	MisconfigEnabled bool
+	// SuppressionEnabled turns on the repo-committed .synapseignore accepted-risk policy; off by default.
+	// Suppressed findings are always retained + surfaced in the result, never silently dropped.
+	SuppressionEnabled bool
 	// ScanCacheEnabled turns on the content+version-addressed generated-SBOM cache; off by default. A hit on
 	// an unchanged tree skips the cataloging step; a producer version bump invalidates the entry.
 	ScanCacheEnabled bool
@@ -317,6 +320,7 @@ func Load() Config {
 		SASTEnabled:            getbool("SYNAPSE_SAST_ENABLED", false),
 		SecretScanEnabled:      getbool("SYNAPSE_SECRET_SCAN_ENABLED", false),
 		MisconfigEnabled:       getbool("SYNAPSE_MISCONFIG_ENABLED", false),
+		SuppressionEnabled:     getbool("SYNAPSE_SUPPRESSION_ENABLED", false),
 		ScanCacheEnabled:       getbool("SYNAPSE_SCAN_CACHE_ENABLED", false),
 		ScanCacheDir:           os.Getenv("SYNAPSE_SCAN_CACHE_DIR"),
 		OwnedAdvisoryEnabled:   getbool("SYNAPSE_OWNED_ADVISORY", false),

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/importedsbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
@@ -873,6 +874,15 @@ type MisconfigRawFinding struct {
 	Severity    shared.Severity
 	Resource    string // what it applies to, e.g. "Deployment/api" or "Dockerfile FROM"
 	Description string // what is wrong + how to fix
+}
+
+// SuppressionLoader reads a repo-committed suppression policy (.synapseignore) from a prepared workspace.
+// It is READ-ONLY and best-effort: a missing file yields an empty set with no error, and any read/parse
+// issue degrades to fewer rules rather than failing a scan. Applying the policy — and SURFACING every
+// suppressed finding rather than silently dropping it — is the SCA pipeline's job; this only loads the
+// declared accepted-risk decisions.
+type SuppressionLoader interface {
+	Load(ctx context.Context, dir string) (ignore.Set, error)
 }
 
 // MisconfigScanner detects insecure IaC/config (Dockerfile, Kubernetes manifests, ...) in a prepared

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
@@ -415,6 +416,61 @@ func findingID(engagementID shared.ID, dedupKey string) shared.ID {
 // a persisted finding and the two can never drift.
 func vulnDedupKey(v vulnerability.Vulnerability) string {
 	return "vuln:" + v.ID + ":" + v.Component + ":" + v.Version
+}
+
+// SuppressedFinding marks a finding a .synapseignore rule accepts. CRUCIALLY the finding STAYS in the
+// actionable Findings set — reported, persisted, and sealed into the evidence chain like any other, so a
+// suppression can never hide a finding from a deliverable or the tamper-evident record. This record only
+// ADDS an accepted-risk annotation (which rule matched, and why) that a CI --fail-on gate consults to
+// exempt the finding. Governance over Trivy: acceptance suppresses the GATE, not the finding's visibility.
+type SuppressedFinding struct {
+	DedupKey string `json:"dedup_key"` // the accepted finding's key (also its --fail-on gate-exemption key)
+	Title    string `json:"title"`
+	RuleID   string `json:"rule_id"` // the .synapseignore id that matched (a CVE/GHSA or a dedup key)
+	Reason   string `json:"reason,omitempty"`
+}
+
+// applySuppressions ANNOTATES findings matched by the .synapseignore policy as accepted-risk (in
+// SuppressedFindings) without removing them from res.Findings, and records expired + malformed rule ids so
+// they get fixed. A finding matches on its PRIMARY advisory id (its vuln's CVE/GHSA, as printed in the
+// report) or its exact dedup key, so a team can suppress by CVE (the common case) or pin a specific
+// finding. Non-primary aliases are not retained on the vuln, so a rule should list the id as reported.
+// Deterministic; nothing is removed, so nothing can be hidden — only the CI gate is exempted.
+func applySuppressions(res *ScanResult, set ignore.Set, now time.Time) {
+	if res == nil || len(set) == 0 {
+		return
+	}
+	byVuln := make(map[string]vulnerability.Vulnerability, len(res.Vulnerabilities))
+	for _, v := range res.Vulnerabilities {
+		byVuln[vulnDedupKey(v)] = v
+	}
+	for _, f := range res.Findings {
+		ids := []string{f.DedupKey}
+		if v, ok := byVuln[f.DedupKey]; ok && v.ID != "" {
+			ids = append(ids, v.ID)
+		}
+		if rule, matched := set.Match(ids, now); matched {
+			res.SuppressedFindings = append(res.SuppressedFindings, SuppressedFinding{DedupKey: f.DedupKey, Title: f.Title, RuleID: rule.ID, Reason: rule.Reason})
+		}
+	}
+	for _, r := range set.Expired(now) {
+		res.ExpiredSuppressions = append(res.ExpiredSuppressions, r.ID)
+	}
+	for _, r := range set.Malformed() {
+		res.MalformedSuppressions = append(res.MalformedSuppressions, r.ID)
+	}
+}
+
+// SuppressedKeys returns the dedup keys a CI gate should exempt from --fail-on (the accepted-risk set).
+func (r *ScanResult) SuppressedKeys() map[string]bool {
+	if len(r.SuppressedFindings) == 0 {
+		return nil
+	}
+	m := make(map[string]bool, len(r.SuppressedFindings))
+	for _, s := range r.SuppressedFindings {
+		m[s.DedupKey] = true
+	}
+	return m
 }
 
 // reachabilitySubjects builds the per-finding reachability inputs: each PROMOTED finding that maps

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -61,6 +61,7 @@ type Service struct {
 	sastAnalyzer   ports.SASTAnalyzer            // optional deterministic pattern-SAST over the live workspace
 	secretScanner  ports.SecretScanner           // optional deterministic secret scan over the live workspace
 	misconfig      ports.MisconfigScanner        // optional deterministic IaC/config misconfig scan over the live workspace
+	suppression    ports.SuppressionLoader       // optional repo-committed .synapseignore accepted-risk policy
 	reachability   ports.ReachabilityRecorder    // optional deterministic Tier-2 reachability proof
 	correlation    ports.CorrelationRecorder     // optional cross-check disagreement → judgment minter
 	sbomGen2       ports.SBOMGenerator           // optional 2nd SBOM producer for the cross-check
@@ -144,6 +145,10 @@ func boolToInt(b bool) int {
 // SetMisconfigScanner configures the optional deterministic IaC/config misconfig scanner.
 // nil ⇒ no misconfig scanning. A setter keeps the existing NewService call sites unchanged.
 func (s *Service) SetMisconfigScanner(m ports.MisconfigScanner) { s.misconfig = m }
+
+// SetSuppressionLoader configures the optional repo-committed .synapseignore accepted-risk policy loader.
+// nil ⇒ no suppression. Suppressed findings are always retained + surfaced, never silently dropped.
+func (s *Service) SetSuppressionLoader(l ports.SuppressionLoader) { s.suppression = l }
 
 // SetReachability configures the optional deterministic Tier-2 reachability prover. nil ⇒ no
 // reachability judgments. Best-effort + opt-in: a no-coverage/un-buildable target leaves the prior
@@ -292,7 +297,17 @@ type ScanResult struct {
 	UnfixedSuppressed int `json:"unfixed_suppressed"`
 	// SourceWarnings flags a configured detection source that did NOT run (e.g. the Grype
 	// binary/DB is missing), so a silently-degraded source can't masquerade as "0 vulns / clean".
-	SourceWarnings           []string                 `json:"source_warnings,omitempty"`
+	SourceWarnings []string `json:"source_warnings,omitempty"`
+	// SuppressedFindings marks findings accepted by the repo's .synapseignore policy. The findings REMAIN in
+	// Findings (reported, persisted, evidence-sealed — never hidden); this is only an accepted-risk
+	// annotation a CI --fail-on gate consults to exempt them. Acceptance suppresses the GATE, not visibility.
+	SuppressedFindings []SuppressedFinding `json:"suppressed_findings,omitempty"`
+	// ExpiredSuppressions lists .synapseignore rule ids that have lapsed, surfaced so accepted risk gets
+	// revisited rather than lingering — an expired rule no longer suppresses, so its finding re-surfaces.
+	ExpiredSuppressions []string `json:"expired_suppressions,omitempty"`
+	// MalformedSuppressions lists .synapseignore rule ids whose expiry could not be parsed; fail-safe, they
+	// do NOT suppress (a date typo must not become a permanent silent acceptance) and are surfaced to fix.
+	MalformedSuppressions    []string                 `json:"malformed_suppressions,omitempty"`
 	ToolVersions             map[string]string        `json:"tool_versions"`
 	VulnDBSnapshot           string                   `json:"vuln_db_snapshot"`
 	Completeness             ports.Completeness       `json:"completeness"`
@@ -1634,6 +1649,15 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		}
 		result.Findings = append(result.Findings, buildMisconfigFindings(engagementID, misRaws, now, s.minSeverity)...)
 	}
+	// Apply the repo-committed .synapseignore accepted-risk policy. It ANNOTATES matched findings as
+	// accepted-risk (SuppressedFindings) so a CI --fail-on gate can exempt them, but does NOT remove them:
+	// they stay reported, persisted, and evidence-sealed, so an acceptance can never hide a finding from a
+	// deliverable or the tamper-evident record. Expired/malformed rules are surfaced, not applied. Best-effort.
+	if s.suppression != nil {
+		if set, serr := s.suppression.Load(ctx, ws.Dir); serr == nil {
+			applySuppressions(result, set, now)
+		}
+	}
 	result.MinSeverity = s.minSeverity
 	result.VulnsBelowThreshold = countBelowThreshold(vulns, s.minSeverity)
 	result.UnfixedSuppressed = countUnfixedSuppressed(vulns, s.minSeverity, s.ignoreUnfixed)
@@ -2111,13 +2135,22 @@ func (s *Service) sealEvidence(ctx context.Context, actor string, engagementID s
 		keys = append(keys, f.DedupKey)
 	}
 	sort.Strings(keys)
+	// Seal the accepted-risk exemptions too (rule=finding-key pairs), so a .synapseignore decision — which
+	// findings were exempted from the --fail-on gate, by which rule — is itself tamper-evident, not just a
+	// mutable convenience in the results cache. omitempty keeps a suppression-free scan's seal unchanged.
+	var suppressed []string
+	for _, sf := range result.SuppressedFindings {
+		suppressed = append(suppressed, sf.RuleID+"="+sf.DedupKey)
+	}
+	sort.Strings(suppressed)
 	payload := struct {
 		SBOMSHA256 string             `json:"sbom_sha256"`
 		Findings   []string           `json:"findings"`
+		Suppressed []string           `json:"suppressed,omitempty"`
 		Manifest   ports.ScanManifest `json:"manifest"`
 		SealedAt   string             `json:"sealed_at"`
 		Actor      string             `json:"actor"`
-	}{result.Manifest.SBOMSHA256, keys, result.Manifest, now.UTC().Format(time.RFC3339), actor}
+	}{result.Manifest.SBOMSHA256, keys, suppressed, result.Manifest, now.UTC().Format(time.RFC3339), actor}
 	content, err := json.Marshal(payload)
 	if err != nil {
 		return

--- a/internal/usecase/sca/suppress_test.go
+++ b/internal/usecase/sca/suppress_test.go
@@ -1,0 +1,92 @@
+package sca
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+)
+
+func TestApplySuppressions(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	v := vulnerability.Vulnerability{ID: "CVE-2023-1", Component: "lodash", Version: "4.0.0"}
+	res := &ScanResult{
+		Vulnerabilities: []vulnerability.Vulnerability{v},
+		Findings: []finding.Finding{
+			{ID: "f1", Title: "lodash CVE-2023-1", DedupKey: vulnDedupKey(v), Severity: shared.SeverityHigh},
+			{ID: "f2", Title: "keep me", DedupKey: "vuln:CVE-2023-2:x:1", Severity: shared.SeverityHigh},
+			{ID: "f3", Title: "pinned by dedup key", DedupKey: "secret:rule:file:9"},
+		},
+	}
+	// Accept f1 by its CVE, f3 by its exact dedup key; declare an expired rule that matches nothing.
+	set := ignore.Parse([]byte("CVE-2023-1 # accepted, not exploitable\nsecret:rule:file:9 exp:2027-01-01 # pinned\nGHSA-lapsed exp:2026-01-01\n"))
+	applySuppressions(res, set, now)
+
+	// CRITICAL governance property: nothing is removed — all findings stay in the actionable/reported set.
+	if len(res.Findings) != 3 {
+		t.Fatalf("suppression must NOT remove findings (they stay reported + sealed); got %d", len(res.Findings))
+	}
+	if len(res.SuppressedFindings) != 2 {
+		t.Fatalf("want 2 accepted-risk annotations (f1 by CVE, f3 by dedup key), got %d: %+v", len(res.SuppressedFindings), res.SuppressedFindings)
+	}
+	found := false
+	for _, s := range res.SuppressedFindings {
+		if s.DedupKey == vulnDedupKey(v) && s.RuleID == "CVE-2023-1" && s.Reason == "accepted, not exploitable" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("an accepted-risk annotation must carry the finding key + rule id + reason")
+	}
+	// The accepted keys are exactly the gate-exemption set.
+	keys := res.SuppressedKeys()
+	if !keys[vulnDedupKey(v)] || !keys["secret:rule:file:9"] || keys["vuln:CVE-2023-2:x:1"] {
+		t.Errorf("SuppressedKeys must be exactly the accepted set, got %+v", keys)
+	}
+	// An expired rule is surfaced even though it accepted nothing, so the operator knows to refresh it.
+	if len(res.ExpiredSuppressions) != 1 || res.ExpiredSuppressions[0] != "GHSA-lapsed" {
+		t.Errorf("expired rule must be surfaced, got %+v", res.ExpiredSuppressions)
+	}
+}
+
+func TestApplySuppressionsMalformedExpiryIsFailSafe(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	v := vulnerability.Vulnerability{ID: "CVE-2023-1", Component: "lodash", Version: "4.0.0"}
+	res := &ScanResult{
+		Vulnerabilities: []vulnerability.Vulnerability{v},
+		Findings:        []finding.Finding{{ID: "f1", DedupKey: vulnDedupKey(v)}},
+	}
+	// A typo'd expiry must NOT become a permanent acceptance: the rule does not suppress and is surfaced.
+	applySuppressions(res, ignore.Parse([]byte("CVE-2023-1 exp:2026-31-12 # typo month/day\n")), now)
+	if len(res.SuppressedFindings) != 0 {
+		t.Error("a malformed-expiry rule must NOT accept anything (fail-safe)")
+	}
+	if len(res.MalformedSuppressions) != 1 || res.MalformedSuppressions[0] != "CVE-2023-1" {
+		t.Errorf("a malformed rule must be surfaced, got %+v", res.MalformedSuppressions)
+	}
+}
+
+func TestApplySuppressionsEmptyPolicyIsNoop(t *testing.T) {
+	res := &ScanResult{Findings: []finding.Finding{{ID: "f1", DedupKey: "x"}}}
+	applySuppressions(res, nil, time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC))
+	if len(res.Findings) != 1 || len(res.SuppressedFindings) != 0 {
+		t.Errorf("an empty policy must be a no-op, got findings=%d suppressed=%d", len(res.Findings), len(res.SuppressedFindings))
+	}
+}
+
+func TestApplySuppressionsExpiredDoesNotSuppress(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	v := vulnerability.Vulnerability{ID: "CVE-2023-1", Component: "lodash", Version: "4.0.0"}
+	res := &ScanResult{
+		Vulnerabilities: []vulnerability.Vulnerability{v},
+		Findings:        []finding.Finding{{ID: "f1", DedupKey: vulnDedupKey(v)}},
+	}
+	// The rule for this CVE has expired → the finding must re-surface (stay actionable), never suppressed.
+	applySuppressions(res, ignore.Parse([]byte("CVE-2023-1 exp:2026-01-01 # lapsed\n")), now)
+	if len(res.Findings) != 1 || len(res.SuppressedFindings) != 0 {
+		t.Errorf("an expired rule must not suppress; finding must re-surface. findings=%d suppressed=%d", len(res.Findings), len(res.SuppressedFindings))
+	}
+}


### PR DESCRIPTION
## .synapseignore accepted-risk policy (governance-first suppression)

Adds a repo-committed, declarative finding-suppression policy — Synapse's take on Trivy's `.trivyignore`, made governance-first. A team version-controls its accepted-risk decisions alongside its code, and a scan honors them at the CI gate.

This continues the learn-from-Trivy-build-native line after the five native-build items (secret, misconfig, OVAL, SAST, cache). A parallel evaluation of Trivy's remaining mechanisms put suppression-as-code in the top tier, and its headline lesson was the exact design used here: retain-and-mark, never silent deletion, with reason and expiry.

### The file

`.synapseignore` at the repo root, one rule per line, `#` begins a comment:

```
CVE-2023-1234 exp:2026-12-31 # not exploitable in our config, revisit Q4
GHSA-aaaa-bbbb-cccc          # third-party, tracked upstream
secret:my-rule:config.yaml:12   # pinned by exact finding key
```

Each rule is an advisory id (CVE/GHSA) or an exact finding dedup key, with an optional reason and an optional `exp:YYYY-MM-DD` expiry.

### The governance improvement over Trivy

Trivy drops suppressed findings from its output. Synapse does not. Acceptance suppresses the CI `--fail-on` GATE, not the finding's visibility:

- A matched finding STAYS in the result. It is reported in every deliverable, persisted, and sealed into the hash-chained evidence record like any other finding.
- It is only flagged accepted-risk, so the `--fail-on` exit code exempts it, and the CLI surfaces it with its justification.
- Nothing is removed, so an acceptance can never hide a finding from a client report or the tamper-evident chain. `.synapseignore` controls your build gate, never what the client sees.

### Fail-safe by design

- An expired rule stops accepting: its finding trips the gate again and the lapse is surfaced, so accepted risk is revisited rather than lingering.
- A rule with an unparseable expiry is not applied at all, so a date typo can never become a permanent silent acceptance. It is surfaced to be fixed.
- Case-insensitive exact id matching (no substring over-match). Deterministic; no LLM, no exec, no network.

### Layering

A pure `domain/ignore` parser and matcher (stdlib only); a `ports.SuppressionLoader` read from the prepared workspace by an infra loader with a symlink guard (Lstat + regular-file) and a size cap; `applySuppressions` annotates in the SCA pipeline without removing anything; and the CLI `--fail-on` gate consults the accepted-key set. Opt-in via `SYNAPSE_SUPPRESSION_ENABLED`, wired in both `synapse-api` and `synapse-cli`.

### Testing

- Domain: parse (comments, inline reasons, expiry, malformed expiry), case-insensitive exact match, expired-does-not-match, malformed-never-suppresses, expired/malformed surfacing.
- Loader: parse a real file, missing file is an empty policy, a symlinked `.synapseignore` is not followed.
- Pipeline: `applySuppressions` annotates without removing (findings retained), the accepted-key set is exactly the matched set, expired and malformed rules are surfaced, empty policy is a no-op.
- End to end via the CLI on a real CVE: without the file the CVE fails `--fail-on high` (exit 1); accepting it keeps the CVE reported but exits 0 (gate-exempt); a malformed expiry is not applied and the CVE fails again (exit 1).
- `go build`, `go vet`, and the affected package tests pass.

### Reviews

Reviewed for clean-architecture compliance (pure domain, port + infra loader, usecase depends only on the port, concrete package imported only by the composition roots) and for the project safety rules. The security review's central question was whether suppression can silently hide a finding; the answer, by construction, is no — nothing is removed, so every suppressed finding remains in the report, the persisted store, and the evidence seal. An earlier remove-based version did have that hole and a malformed-expiry gap; both are fixed here (the redesign to annotate-not-remove, and the fail-safe expiry), and the review re-confirmed the redesign closes them with no new issue.

The accepted-risk exemption set (which findings were gate-exempted, by which rule) is now also folded into the hash-chained evidence seal, so the decision is itself tamper-evident, not just a mutable convenience in the results cache.

A distinct visual "Accepted Risks" section in the PDF/HTML report, a dedicated audit-log entry per acceptance, and path/PURL scoping of a rule are natural follow-ups; none is required for safety, since nothing is hidden and the acceptance is recorded in both the scan result and the evidence chain.
