### PR TITLE
feat(sca): in-scan OpenVEX consumption (.synapse.vex.json)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -62,6 +62,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/syft"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/taintcallgraph"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/vexfile"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/vault"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/binregistry"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo"
@@ -542,6 +543,10 @@ func main() {
 	if cfg.SuppressionEnabled {
 		scaService.SetSuppressionLoader(ignorefile.New()) // repo-committed .synapseignore accepted-risk policy
 		log.Info("suppression ENABLED (.synapseignore; suppressed findings retained + surfaced)")
+	}
+	if cfg.VEXEnabled {
+		scaService.SetVEXLoader(vexfile.New()) // in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
+		log.Info("in-scan VEX ENABLED (.synapse.vex.json; not_affected/fixed gate-exempt, still reported + sealed)")
 	}
 	if cfg.ScanCacheEnabled {
 		if dir := cfg.ResolveScanCacheDir(); dir != "" {

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/sast"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/syft"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/vexfile"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
@@ -305,6 +306,9 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	}
 	if cfg.SuppressionEnabled {
 		sca.SetSuppressionLoader(ignorefile.New()) // repo-committed .synapseignore accepted-risk policy (CI-friendly)
+	}
+	if cfg.VEXEnabled {
+		sca.SetVEXLoader(vexfile.New()) // in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions (CI-friendly)
 	}
 	if cfg.ScanCacheEnabled {
 		if dir := cfg.ResolveScanCacheDir(); dir != "" {

--- a/internal/domain/vex/document.go
+++ b/internal/domain/vex/document.go
@@ -1,0 +1,114 @@
+package vex
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Document is the subset of an OpenVEX 0.2 document Synapse CONSUMES: each statement asserts a status for a
+// vulnerability against one or more products. It is the shared parse + match core for BOTH the post-scan
+// VEX apply (usecase/vex) and the in-scan .vex consumption (the SCA pipeline), so the two can never drift.
+type Document struct {
+	Context    string
+	Statements []Statement
+}
+
+// Statement is one VEX assertion.
+type Statement struct {
+	Vulnerability string   // advisory id, e.g. "CVE-2024-1234"
+	Products      []string // product ids, e.g. "pkg:npm/foo@1.0.0" or "foo@1.0.0"
+	Status        string   // OpenVEX status: not_affected | fixed | affected | under_investigation
+	Justification string
+}
+
+// wire mirrors the OpenVEX JSON shape for unmarshalling.
+type wire struct {
+	Context    string `json:"@context"`
+	Statements []struct {
+		Vulnerability struct {
+			Name string `json:"name"`
+		} `json:"vulnerability"`
+		Products []struct {
+			ID string `json:"@id"`
+		} `json:"products"`
+		Status        string `json:"status"`
+		Justification string `json:"justification"`
+	} `json:"statements"`
+}
+
+// Parse decodes an OpenVEX document. It errors on invalid JSON or a non-OpenVEX / empty document, so a
+// caller never silently treats junk as an empty policy.
+func Parse(data []byte) (Document, error) {
+	var w wire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return Document{}, fmt.Errorf("%w: invalid VEX document: %v", shared.ErrValidation, err)
+	}
+	if !strings.Contains(w.Context, "openvex") || len(w.Statements) == 0 {
+		return Document{}, fmt.Errorf("%w: not a non-empty OpenVEX document", shared.ErrValidation)
+	}
+	doc := Document{Context: w.Context}
+	for _, s := range w.Statements {
+		st := Statement{Vulnerability: s.Vulnerability.Name, Status: s.Status, Justification: s.Justification}
+		for _, p := range s.Products {
+			st.Products = append(st.Products, p.ID)
+		}
+		doc.Statements = append(doc.Statements, st)
+	}
+	return doc, nil
+}
+
+// Suppresses reports whether this statement's status asserts "no action needed" (not_affected or fixed) —
+// the two statuses that remove a finding from the actionable set.
+func (s Statement) Suppresses() bool {
+	switch strings.ToLower(strings.TrimSpace(s.Status)) {
+	case "not_affected", "fixed":
+		return true
+	}
+	return false
+}
+
+// MatchesFinding reports whether this statement targets the given finding, identified by its advisory id +
+// component + version (as parsed from the finding's dedup key). A product matches when its component equals
+// the finding's (directly or by PURL name) and its version is absent (matches all versions) or equal.
+func (s Statement) MatchesFinding(advisory, component, version string) bool {
+	if s.Vulnerability == "" || s.Vulnerability != advisory {
+		return false
+	}
+	for _, p := range s.Products {
+		pComp, pVer := splitProduct(p)
+		if !componentMatches(component, pComp) {
+			continue
+		}
+		if pVer == "" || pVer == version {
+			return true
+		}
+	}
+	return false
+}
+
+func splitProduct(id string) (component, version string) {
+	if i := strings.LastIndex(id, "@"); i > 0 {
+		return id[:i], id[i+1:]
+	}
+	return id, ""
+}
+
+// componentMatches matches a finding component to a VEX product component: exact, or the product's
+// path-bounded PURL name segment equals it. Matching the bounded name (not a raw substring) avoids
+// over-matching — a product "pkg:npm/foobar" must NOT match a finding component "foo".
+func componentMatches(findingComp, productComp string) bool {
+	if findingComp == "" || productComp == "" {
+		return false
+	}
+	return findingComp == productComp || purlName(productComp) == findingComp
+}
+
+func purlName(product string) string {
+	if i := strings.LastIndex(product, "/"); i >= 0 {
+		return product[i+1:]
+	}
+	return product
+}

--- a/internal/domain/vex/document_test.go
+++ b/internal/domain/vex/document_test.go
@@ -1,0 +1,73 @@
+package vex
+
+import "testing"
+
+const sampleVEX = `{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "statements": [
+    {"vulnerability": {"name": "CVE-2024-1"}, "products": [{"@id": "pkg:npm/lodash@4.17.21"}], "status": "not_affected", "justification": "vulnerable_code_not_in_execute_path"},
+    {"vulnerability": {"name": "CVE-2024-2"}, "products": [{"@id": "pkg:npm/express"}], "status": "fixed"},
+    {"vulnerability": {"name": "CVE-2024-3"}, "products": [{"@id": "pkg:npm/foo@1.0"}], "status": "affected"}
+  ]
+}`
+
+func TestParse(t *testing.T) {
+	doc, err := Parse([]byte(sampleVEX))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(doc.Statements) != 3 {
+		t.Fatalf("want 3 statements, got %d", len(doc.Statements))
+	}
+	if doc.Statements[0].Vulnerability != "CVE-2024-1" || doc.Statements[0].Justification == "" {
+		t.Errorf("statement 0 mis-parsed: %+v", doc.Statements[0])
+	}
+}
+
+func TestParseRejectsJunk(t *testing.T) {
+	if _, err := Parse([]byte(`{"not": "vex"}`)); err == nil {
+		t.Error("a non-OpenVEX document must error")
+	}
+	if _, err := Parse([]byte(`not json`)); err == nil {
+		t.Error("invalid JSON must error")
+	}
+	if _, err := Parse([]byte(`{"@context":"https://openvex.dev/ns/v0.2.0","statements":[]}`)); err == nil {
+		t.Error("an empty-statements OpenVEX doc must error")
+	}
+}
+
+func TestSuppresses(t *testing.T) {
+	cases := map[string]bool{"not_affected": true, "fixed": true, "affected": false, "under_investigation": false, "": false}
+	for status, want := range cases {
+		if got := (Statement{Status: status}).Suppresses(); got != want {
+			t.Errorf("Suppresses(%q) = %v, want %v", status, got, want)
+		}
+	}
+}
+
+func TestMatchesFinding(t *testing.T) {
+	doc, _ := Parse([]byte(sampleVEX))
+	notAffected, fixed := doc.Statements[0], doc.Statements[1]
+
+	// versioned product: matches the exact component+version, and by PURL name.
+	if !notAffected.MatchesFinding("CVE-2024-1", "lodash", "4.17.21") {
+		t.Error("versioned product must match the exact finding (by PURL name)")
+	}
+	if notAffected.MatchesFinding("CVE-2024-1", "lodash", "3.0.0") {
+		t.Error("a different version must NOT match a versioned product")
+	}
+	if notAffected.MatchesFinding("CVE-2024-9", "lodash", "4.17.21") {
+		t.Error("a different advisory must NOT match")
+	}
+	// versionless product: matches any version of the component.
+	if !fixed.MatchesFinding("CVE-2024-2", "express", "4.18.0") {
+		t.Error("a versionless product must match any version")
+	}
+	if !fixed.MatchesFinding("CVE-2024-2", "express", "3.0.0") {
+		t.Error("a versionless product must match any version (2)")
+	}
+	// wrong component must not match.
+	if fixed.MatchesFinding("CVE-2024-2", "koa", "1.0.0") {
+		t.Error("a different component must NOT match")
+	}
+}

--- a/internal/domain/vex/justification.go
+++ b/internal/domain/vex/justification.go
@@ -1,5 +1,7 @@
-// Package vex holds the OpenVEX domain vocabulary shared by the VEX export (the OpenVEX document) and the
-// AI vex-justification judgment. It is pure reference data — a closed enum, no I/O.
+// Package vex holds the OpenVEX domain vocabulary (the closed justification enum, shared by the VEX export
+// and the AI vex-justification judgment) AND the consume-side parser + product-to-finding matcher
+// (document.go: Parse, Statement.Suppresses, Statement.MatchesFinding) shared by the post-scan VEX apply
+// and the in-scan .vex consumer. Pure: parsing + matching only, no I/O beyond the passed-in bytes.
 package vex
 
 // OpenVexJustification is the CLOSED set of OpenVEX justifications for a not_affected status (per the OpenVEX

--- a/internal/domain/vulnerability/dedup.go
+++ b/internal/domain/vulnerability/dedup.go
@@ -1,0 +1,29 @@
+package vulnerability
+
+import "strings"
+
+// DedupKey is the stable identity key for a vuln finding: "vuln:<advisory>:<component>:<version>". The SCA
+// pipeline builds it and the VEX consumers (post-scan apply + in-scan .vex) parse it, so the format has ONE
+// home and the two can never drift.
+func DedupKey(advisory, component, version string) string {
+	return "vuln:" + advisory + ":" + component + ":" + version
+}
+
+// ParseDedupKey inverts DedupKey. ok=false when key is not a "vuln:"-prefixed key. A component may itself
+// contain ':' (e.g. a Maven group:artifact), so the advisory is the first segment, the version the last,
+// and the component everything between.
+func ParseDedupKey(key string) (advisory, component, version string, ok bool) {
+	rest, found := strings.CutPrefix(key, "vuln:")
+	if !found {
+		return "", "", "", false
+	}
+	parts := strings.Split(rest, ":")
+	switch {
+	case len(parts) >= 3:
+		return parts[0], strings.Join(parts[1:len(parts)-1], ":"), parts[len(parts)-1], true
+	case len(parts) == 2:
+		return parts[0], "", parts[1], true
+	default:
+		return rest, "", "", true
+	}
+}

--- a/internal/domain/vulnerability/dedup_test.go
+++ b/internal/domain/vulnerability/dedup_test.go
@@ -1,0 +1,27 @@
+package vulnerability
+
+import "testing"
+
+func TestDedupKeyRoundTrip(t *testing.T) {
+	cases := []struct{ advisory, component, version string }{
+		{"CVE-2024-1", "lodash", "4.17.21"},
+		{"GHSA-xxxx", "github.com/foo/bar", "v1.2.3"},              // Go module path (slashes)
+		{"CVE-2024-2", "org.apache.commons:commons-lang3", "3.12"}, // Maven group:artifact (multi-colon component)
+	}
+	for _, c := range cases {
+		key := DedupKey(c.advisory, c.component, c.version)
+		a, comp, ver, ok := ParseDedupKey(key)
+		if !ok || a != c.advisory || comp != c.component || ver != c.version {
+			t.Errorf("round-trip %q: got (%q,%q,%q,%v), want (%q,%q,%q,true)", key, a, comp, ver, ok, c.advisory, c.component, c.version)
+		}
+	}
+}
+
+func TestParseDedupKeyNonVuln(t *testing.T) {
+	// A non-"vuln:" key (secret/misconfig/license finding) is not a vuln dedup key.
+	for _, key := range []string{"secret:rule:file:9", "license:MIT", "misconfig:r:f:1", ""} {
+		if _, _, _, ok := ParseDedupKey(key); ok {
+			t.Errorf("ParseDedupKey(%q) must report ok=false for a non-vuln key", key)
+		}
+	}
+}

--- a/internal/infrastructure/tools/vexfile/loader.go
+++ b/internal/infrastructure/tools/vexfile/loader.go
@@ -1,0 +1,50 @@
+// Package vexfile loads an in-repo OpenVEX document (.synapse.vex.json) from a prepared workspace. It is the
+// thin infrastructure adapter over the pure domain parser (internal/domain/vex): read the file, hand the
+// bytes to vex.Parse. Matching statements to findings and applying them (annotate accepted-risk, never
+// remove) is the SCA pipeline's job.
+package vexfile
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vex"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	fileName = ".synapse.vex.json"
+	maxBytes = 8 << 20 // an in-repo VEX doc is small; cap the read defensively
+)
+
+// Loader reads <workspace>/.synapse.vex.json.
+type Loader struct{}
+
+var _ ports.VEXLoader = (*Loader)(nil)
+
+// New returns a loader.
+func New() *Loader { return &Loader{} }
+
+// Load reads and parses <dir>/.synapse.vex.json. A missing or non-regular file is an empty document with no
+// error (nothing to apply). An oversized file, or one that isn't a valid OpenVEX document, returns an error
+// the caller surfaces — so a malformed VEX is visible, and fail-safe (no assertions applied → nothing
+// suppressed).
+func (l *Loader) Load(_ context.Context, dir string) (vex.Document, error) {
+	path := filepath.Join(dir, fileName)
+	// Lstat + IsRegular: never follow a .synapse.vex.json symlink out of the (untrusted) workspace.
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return vex.Document{}, nil // absent or non-regular → empty, no error
+	}
+	if info.Size() > maxBytes {
+		return vex.Document{}, fmt.Errorf("%w: .synapse.vex.json exceeds %d bytes", shared.ErrValidation, maxBytes)
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed filename under the prepared workspace, guarded regular (non-symlink) via the Lstat above
+	if err != nil {
+		return vex.Document{}, fmt.Errorf("read .synapse.vex.json: %w", err) // surfaced as a SourceWarning, not swallowed
+	}
+	return vex.Parse(data)
+}

--- a/internal/infrastructure/tools/vexfile/loader_test.go
+++ b/internal/infrastructure/tools/vexfile/loader_test.go
@@ -1,0 +1,61 @@
+package vexfile
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const doc = `{"@context":"https://openvex.dev/ns/v0.2.0","statements":[{"vulnerability":{"name":"CVE-2024-1"},"products":[{"@id":"pkg:npm/lodash@4.17.21"}],"status":"not_affected"}]}`
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".synapse.vex.json"), []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := New().Load(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Statements) != 1 || got.Statements[0].Vulnerability != "CVE-2024-1" {
+		t.Errorf("want 1 statement CVE-2024-1, got %+v", got)
+	}
+}
+
+func TestLoadMissingIsEmptyNoError(t *testing.T) {
+	got, err := New().Load(context.Background(), t.TempDir())
+	if err != nil || len(got.Statements) != 0 {
+		t.Errorf("a missing .synapse.vex.json must be an empty doc with no error, got doc=%+v err=%v", got, err)
+	}
+}
+
+func TestLoadMalformedSurfacesError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".synapse.vex.json"), []byte(`{"not":"vex"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A present-but-invalid doc surfaces an error (so it's visible), and is fail-safe (nothing applied).
+	if _, err := New().Load(context.Background(), dir); err == nil {
+		t.Error("a malformed .synapse.vex.json must return an error to be surfaced, not silently ignored")
+	}
+}
+
+func TestLoadSymlinkNotFollowed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "evil.json")
+	if err := os.WriteFile(outside, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, ".synapse.vex.json")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	got, err := New().Load(context.Background(), dir)
+	if err != nil || len(got.Statements) != 0 {
+		t.Errorf("a symlinked .synapse.vex.json must not be followed, got doc=%+v err=%v", got, err)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -169,6 +169,9 @@ type Config struct {
 	// SuppressionEnabled turns on the repo-committed .synapseignore accepted-risk policy; off by default.
 	// Suppressed findings are always retained + surfaced in the result, never silently dropped.
 	SuppressionEnabled bool
+	// VEXEnabled turns on consuming an in-repo OpenVEX doc (.synapse.vex.json) at scan time; off by default.
+	// A not_affected/fixed statement gate-exempts the matched finding (still reported + sealed), never removes it.
+	VEXEnabled bool
 	// ScanCacheEnabled turns on the content+version-addressed generated-SBOM cache; off by default. A hit on
 	// an unchanged tree skips the cataloging step; a producer version bump invalidates the entry.
 	ScanCacheEnabled bool
@@ -321,6 +324,7 @@ func Load() Config {
 		SecretScanEnabled:      getbool("SYNAPSE_SECRET_SCAN_ENABLED", false),
 		MisconfigEnabled:       getbool("SYNAPSE_MISCONFIG_ENABLED", false),
 		SuppressionEnabled:     getbool("SYNAPSE_SUPPRESSION_ENABLED", false),
+		VEXEnabled:             getbool("SYNAPSE_VEX_ENABLED", false),
 		ScanCacheEnabled:       getbool("SYNAPSE_SCAN_CACHE_ENABLED", false),
 		ScanCacheDir:           os.Getenv("SYNAPSE_SCAN_CACHE_DIR"),
 		OwnedAdvisoryEnabled:   getbool("SYNAPSE_OWNED_ADVISORY", false),

--- a/internal/usecase/crosscheckjudge/coordinator.go
+++ b/internal/usecase/crosscheckjudge/coordinator.go
@@ -105,5 +105,5 @@ func (c *Coordinator) Record(ctx context.Context, engagementID shared.ID, report
 // (stable dedup). The id is compared for EQUALITY only, never parsed, so the unescaped ":" (which can appear
 // in a Maven component) is harmless — matching the house convention.
 func correlationSubjectID(d vulnerability.CrossCheckItem) shared.ID {
-	return shared.ID("vuln:" + d.AdvisoryID + ":" + d.Component + ":" + d.Version)
+	return shared.ID(vulnerability.DedupKey(d.AdvisoryID, d.Component, d.Version))
 }

--- a/internal/usecase/export/service.go
+++ b/internal/usecase/export/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -134,21 +135,8 @@ type parsedKey struct {
 // parseDedup splits a dedup key. Advisory ids and versions never contain ':',
 // so the component (which may) is the middle join.
 func parseDedup(key string) parsedKey {
-	if rest, ok := strings.CutPrefix(key, "vuln:"); ok {
-		parts := strings.Split(rest, ":")
-		switch {
-		case len(parts) >= 3:
-			return parsedKey{
-				kind:      "vuln",
-				advisory:  parts[0],
-				component: strings.Join(parts[1:len(parts)-1], ":"),
-				version:   parts[len(parts)-1],
-			}
-		case len(parts) == 2:
-			return parsedKey{kind: "vuln", advisory: parts[0], version: parts[1]}
-		default:
-			return parsedKey{kind: "vuln", advisory: rest}
-		}
+	if advisory, component, version, ok := vulnerability.ParseDedupKey(key); ok {
+		return parsedKey{kind: "vuln", advisory: advisory, component: component, version: version}
 	}
 	if rest, ok := strings.CutPrefix(key, "license:"); ok {
 		return parsedKey{kind: "license", advisory: rest}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -19,6 +19,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/threatmodel"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vex"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/writeupdraft"
 )
@@ -883,6 +884,16 @@ type MisconfigRawFinding struct {
 // declared accepted-risk decisions.
 type SuppressionLoader interface {
 	Load(ctx context.Context, dir string) (ignore.Set, error)
+}
+
+// VEXLoader reads an in-repo OpenVEX document (.synapse.vex.json) from a prepared workspace: the
+// machine-readable accepted-risk counterpart to .synapseignore — a maintainer's not_affected/fixed
+// assertions with a justification. READ-ONLY and best-effort: a missing file yields an empty document with
+// no error; a malformed/oversized one returns an error the pipeline surfaces (never a scan failure).
+// Applying it — annotating matched findings accepted-risk on the SAME retain-and-mark surface, never
+// removing them — is the SCA pipeline's job.
+type VEXLoader interface {
+	Load(ctx context.Context, dir string) (vex.Document, error)
 }
 
 // MisconfigScanner detects insecure IaC/config (Dockerfile, Kubernetes manifests, ...) in a prepared

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vex"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -415,7 +416,7 @@ func findingID(engagementID shared.ID, dedupKey string) shared.ID {
 // reachabilitySubjects (which joins back to it) — so the reachability subject's FindingID provably matches
 // a persisted finding and the two can never drift.
 func vulnDedupKey(v vulnerability.Vulnerability) string {
-	return "vuln:" + v.ID + ":" + v.Component + ":" + v.Version
+	return vulnerability.DedupKey(v.ID, v.Component, v.Version)
 }
 
 // SuppressedFinding marks a finding a .synapseignore rule accepts. CRUCIALLY the finding STAYS in the
@@ -458,6 +459,40 @@ func applySuppressions(res *ScanResult, set ignore.Set, now time.Time) {
 	}
 	for _, r := range set.Malformed() {
 		res.MalformedSuppressions = append(res.MalformedSuppressions, r.ID)
+	}
+}
+
+// applyVEX annotates findings that an in-repo OpenVEX not_affected/fixed statement targets as accepted-risk
+// on the SAME retain-and-mark surface as .synapseignore: the finding STAYS in res.Findings (reported +
+// sealed), only exempted from the --fail-on gate, with the VEX justification as the reason. A statement
+// matches by advisory id + component (+ version) via the shared domain/vex matcher. Nothing is removed.
+func applyVEX(res *ScanResult, doc vex.Document) {
+	if res == nil || len(doc.Statements) == 0 {
+		return
+	}
+	accepted := make(map[string]bool, len(res.SuppressedFindings))
+	for _, sf := range res.SuppressedFindings {
+		accepted[sf.DedupKey] = true // don't double-annotate a finding already accepted (.synapseignore or earlier stmt)
+	}
+	for _, st := range doc.Statements {
+		if !st.Suppresses() { // only not_affected / fixed exempt the gate; affected/under_investigation don't
+			continue
+		}
+		for _, f := range res.Findings {
+			if accepted[f.DedupKey] {
+				continue
+			}
+			a, comp, ver, ok := vulnerability.ParseDedupKey(f.DedupKey)
+			if !ok || !st.MatchesFinding(a, comp, ver) {
+				continue
+			}
+			accepted[f.DedupKey] = true
+			reason := "VEX " + st.Status
+			if st.Justification != "" {
+				reason += ": " + st.Justification
+			}
+			res.SuppressedFindings = append(res.SuppressedFindings, SuppressedFinding{DedupKey: f.DedupKey, Title: f.Title, RuleID: st.Vulnerability, Reason: reason})
+		}
 	}
 }
 

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -62,6 +62,7 @@ type Service struct {
 	secretScanner  ports.SecretScanner           // optional deterministic secret scan over the live workspace
 	misconfig      ports.MisconfigScanner        // optional deterministic IaC/config misconfig scan over the live workspace
 	suppression    ports.SuppressionLoader       // optional repo-committed .synapseignore accepted-risk policy
+	vexLoader      ports.VEXLoader               // optional in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
 	reachability   ports.ReachabilityRecorder    // optional deterministic Tier-2 reachability proof
 	correlation    ports.CorrelationRecorder     // optional cross-check disagreement → judgment minter
 	sbomGen2       ports.SBOMGenerator           // optional 2nd SBOM producer for the cross-check
@@ -149,6 +150,11 @@ func (s *Service) SetMisconfigScanner(m ports.MisconfigScanner) { s.misconfig = 
 // SetSuppressionLoader configures the optional repo-committed .synapseignore accepted-risk policy loader.
 // nil ⇒ no suppression. Suppressed findings are always retained + surfaced, never silently dropped.
 func (s *Service) SetSuppressionLoader(l ports.SuppressionLoader) { s.suppression = l }
+
+// SetVEXLoader configures the optional in-repo OpenVEX (.synapse.vex.json) loader. nil ⇒ no in-scan VEX.
+// A not_affected/fixed statement annotates the matched finding accepted-risk on the same retain-and-mark
+// surface as .synapseignore (gate-exempt, but reported + sealed), never removed.
+func (s *Service) SetVEXLoader(l ports.VEXLoader) { s.vexLoader = l }
 
 // SetReachability configures the optional deterministic Tier-2 reachability prover. nil ⇒ no
 // reachability judgments. Best-effort + opt-in: a no-coverage/un-buildable target leaves the prior
@@ -1656,6 +1662,16 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	if s.suppression != nil {
 		if set, serr := s.suppression.Load(ctx, ws.Dir); serr == nil {
 			applySuppressions(result, set, now)
+		}
+	}
+	// In-repo OpenVEX (.synapse.vex.json): a not_affected/fixed statement annotates the matched finding
+	// accepted-risk on the SAME surface (gate-exempt, still reported + sealed). A malformed doc is surfaced,
+	// not silently ignored, and fail-safe (nothing suppressed).
+	if s.vexLoader != nil {
+		if doc, verr := s.vexLoader.Load(ctx, ws.Dir); verr != nil {
+			result.SourceWarnings = append(result.SourceWarnings, "in-repo VEX (.synapse.vex.json) was not applied (unreadable or not a valid OpenVEX document)")
+		} else {
+			applyVEX(result, doc)
 		}
 	}
 	result.MinSeverity = s.minSeverity

--- a/internal/usecase/sca/vex_test.go
+++ b/internal/usecase/sca/vex_test.go
@@ -1,0 +1,61 @@
+package sca
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vex"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+)
+
+func TestApplyVEX(t *testing.T) {
+	v1 := vulnerability.Vulnerability{ID: "CVE-2024-1", Component: "lodash", Version: "4.17.21"}
+	v2 := vulnerability.Vulnerability{ID: "CVE-2024-2", Component: "express", Version: "4.18.0"}
+	res := &ScanResult{
+		Vulnerabilities: []vulnerability.Vulnerability{v1, v2},
+		Findings: []finding.Finding{
+			{ID: "f1", Title: "lodash CVE-2024-1", DedupKey: vulnDedupKey(v1)},
+			{ID: "f2", Title: "express CVE-2024-2", DedupKey: vulnDedupKey(v2)},
+		},
+	}
+	doc, err := vex.Parse([]byte(`{
+      "@context":"https://openvex.dev/ns/v0.2.0",
+      "statements":[
+        {"vulnerability":{"name":"CVE-2024-1"},"products":[{"@id":"pkg:npm/lodash@4.17.21"}],"status":"not_affected","justification":"vulnerable_code_not_in_execute_path"},
+        {"vulnerability":{"name":"CVE-2024-2"},"products":[{"@id":"pkg:npm/express@4.18.0"}],"status":"affected"}
+      ]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyVEX(res, doc)
+
+	// not_affected → f1 accepted; affected → f2 stays actionable.
+	if len(res.Findings) != 2 {
+		t.Fatalf("VEX must NOT remove findings (retain-and-mark), got %d", len(res.Findings))
+	}
+	if len(res.SuppressedFindings) != 1 || res.SuppressedFindings[0].DedupKey != vulnDedupKey(v1) {
+		t.Fatalf("want exactly f1 accepted (not_affected), got %+v", res.SuppressedFindings)
+	}
+	sf := res.SuppressedFindings[0]
+	if sf.RuleID != "CVE-2024-1" || sf.Reason != "VEX not_affected: vulnerable_code_not_in_execute_path" {
+		t.Errorf("accepted-risk annotation must carry the CVE + VEX justification, got %+v", sf)
+	}
+	// f2 (affected) is NOT gate-exempt.
+	if res.SuppressedKeys()[vulnDedupKey(v2)] {
+		t.Error("an 'affected' statement must not exempt a finding")
+	}
+}
+
+func TestApplyVEXDoesNotDoubleAnnotate(t *testing.T) {
+	v1 := vulnerability.Vulnerability{ID: "CVE-2024-1", Component: "lodash", Version: "4.17.21"}
+	res := &ScanResult{
+		Vulnerabilities:    []vulnerability.Vulnerability{v1},
+		Findings:           []finding.Finding{{ID: "f1", DedupKey: vulnDedupKey(v1)}},
+		SuppressedFindings: []SuppressedFinding{{DedupKey: vulnDedupKey(v1), RuleID: "CVE-2024-1", Reason: "already accepted via .synapseignore"}},
+	}
+	doc, _ := vex.Parse([]byte(`{"@context":"https://openvex.dev/ns/v0.2.0","statements":[{"vulnerability":{"name":"CVE-2024-1"},"products":[{"@id":"pkg:npm/lodash"}],"status":"not_affected"}]}`))
+	applyVEX(res, doc)
+	if len(res.SuppressedFindings) != 1 {
+		t.Errorf("a finding already accepted must not be annotated twice, got %d", len(res.SuppressedFindings))
+	}
+}

--- a/internal/usecase/vex/service.go
+++ b/internal/usecase/vex/service.go
@@ -8,12 +8,13 @@ package vex
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vex"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -33,21 +34,6 @@ func NewService(engagements ports.EngagementRepository, findings ports.FindingRe
 	return &Service{engagements: engagements, findings: findings, audit: audit, clock: clock}, nil
 }
 
-// openVEXDoc is the subset of OpenVEX 0.2 Synapse consumes.
-type openVEXDoc struct {
-	Context    string `json:"@context"`
-	Statements []struct {
-		Vulnerability struct {
-			Name string `json:"name"`
-		} `json:"vulnerability"`
-		Products []struct {
-			ID string `json:"@id"`
-		} `json:"products"`
-		Status        string `json:"status"`
-		Justification string `json:"justification"`
-	} `json:"statements"`
-}
-
 // ApplyResult summarizes what an import did.
 type ApplyResult struct {
 	Statements int `json:"statements"` // statements in the document
@@ -60,12 +46,9 @@ type ApplyResult struct {
 // by advisory id + component (+ version when the product carries one); the optimistic
 // version guards each update.
 func (s *Service) Apply(ctx context.Context, actor string, tenantID, engagementID shared.ID, vexJSON []byte) (ApplyResult, error) {
-	var doc openVEXDoc
-	if err := json.Unmarshal(vexJSON, &doc); err != nil {
-		return ApplyResult{}, fmt.Errorf("%w: invalid VEX document: %v", shared.ErrValidation, err)
-	}
-	if !strings.Contains(doc.Context, "openvex") || len(doc.Statements) == 0 {
-		return ApplyResult{}, fmt.Errorf("%w: not a non-empty OpenVEX document", shared.ErrValidation)
+	doc, err := vex.Parse(vexJSON)
+	if err != nil {
+		return ApplyResult{}, err
 	}
 	// Confirm the engagement exists AND belongs to the caller's tenant (404 cross-tenant;
 	// defense-in-depth behind the withEngTenant route wrapper — parity with SBOM import).
@@ -84,40 +67,33 @@ func (s *Service) Apply(ctx context.Context, actor string, tenantID, engagementI
 		if !ok {
 			continue // a status we don't map (e.g. unknown) — leave findings untouched
 		}
-		adv := st.Vulnerability.Name
-		for _, p := range st.Products {
-			prodComp, prodVer := splitProduct(p.ID)
-			for i := range findings {
-				f := &findings[i]
-				a, comp, ver := parseVulnDedup(f.DedupKey)
-				if a != adv || !componentMatches(comp, prodComp) {
-					continue
-				}
-				if prodVer != "" && ver != prodVer {
-					continue
-				}
-				res.Matched++
-				if f.Status == target {
-					continue // already in the asserted state
-				}
-				updated, err := s.findings.UpdateStatus(ctx, engagementID, f.ID, target, f.Version)
-				if err != nil {
-					continue // conflict/not-found: skip this finding, keep applying others
-				}
-				*f = updated
-				res.Applied++
-				_ = s.audit.Record(ctx, ports.AuditEntry{
-					Actor: actor, Action: "finding.vex", Target: f.ID.String(),
-					Metadata: map[string]string{
-						"engagement":    engagementID.String(),
-						"advisory":      adv,
-						"vex_status":    st.Status,
-						"new_status":    string(target),
-						"justification": st.Justification,
-					},
-					At: s.clock.Now(),
-				})
+		for i := range findings {
+			f := &findings[i]
+			a, comp, ver, ok := vulnerability.ParseDedupKey(f.DedupKey)
+			if !ok || !st.MatchesFinding(a, comp, ver) {
+				continue
 			}
+			res.Matched++
+			if f.Status == target {
+				continue // already in the asserted state
+			}
+			updated, err := s.findings.UpdateStatus(ctx, engagementID, f.ID, target, f.Version)
+			if err != nil {
+				continue // conflict/not-found: skip this finding, keep applying others
+			}
+			*f = updated
+			res.Applied++
+			_ = s.audit.Record(ctx, ports.AuditEntry{
+				Actor: actor, Action: "finding.vex", Target: f.ID.String(),
+				Metadata: map[string]string{
+					"engagement":    engagementID.String(),
+					"advisory":      st.Vulnerability,
+					"vex_status":    st.Status,
+					"new_status":    string(target),
+					"justification": st.Justification,
+				},
+				At: s.clock.Now(),
+			})
 		}
 	}
 	return res, nil
@@ -137,51 +113,4 @@ func vexTargetStatus(s string) (finding.Status, bool) {
 	default:
 		return "", false
 	}
-}
-
-// parseVulnDedup extracts (advisory, component, version) from a "vuln:adv:comp:ver"
-// dedup key (the SCA finding identity).
-func parseVulnDedup(key string) (advisory, component, version string) {
-	rest, ok := strings.CutPrefix(key, "vuln:")
-	if !ok {
-		return "", "", ""
-	}
-	parts := strings.Split(rest, ":")
-	switch {
-	case len(parts) >= 3:
-		return parts[0], strings.Join(parts[1:len(parts)-1], ":"), parts[len(parts)-1]
-	case len(parts) == 2:
-		return parts[0], "", parts[1]
-	default:
-		return rest, "", ""
-	}
-}
-
-// splitProduct splits an OpenVEX product @id into component + version on the last
-// '@' (so a PURL "pkg:npm/foo@1.2.3" yields "pkg:npm/foo" + "1.2.3").
-func splitProduct(id string) (component, version string) {
-	if i := strings.LastIndex(id, "@"); i > 0 {
-		return id[:i], id[i+1:]
-	}
-	return id, ""
-}
-
-// componentMatches reports whether a finding's component matches a VEX product
-// component: exact, or the product's PURL package-name segment equals it. Matching
-// the path-bounded name (not a raw substring) avoids over-matching — a product
-// "pkg:npm/foobar" must NOT match a finding component "foo".
-func componentMatches(findingComp, productComp string) bool {
-	if findingComp == "" || productComp == "" {
-		return false
-	}
-	return findingComp == productComp || purlName(productComp) == findingComp
-}
-
-// purlName returns the package-name segment of a product id (the part after the
-// last '/'), so "pkg:npm/lodash" -> "lodash" and "@scope/foo" -> "foo".
-func purlName(product string) string {
-	if i := strings.LastIndex(product, "/"); i >= 0 {
-		return product[i+1:]
-	}
-	return product
 }


### PR DESCRIPTION
## In-scan OpenVEX consumption (.synapse.vex.json)

Adds scan-time consumption of an in-repo OpenVEX document, the machine-readable accepted-risk counterpart to the `.synapseignore` policy shipped in the previous PR. This is the top item from the second-pass Trivy evaluation (Trivy's `--vex`): Synapse already had VEX, but only as a post-scan database triage action; it could not consume a VEX file during a scan. This closes that gap and applies the same governance surface.

### What it does

A `.synapse.vex.json` at the repo root holds a maintainer's OpenVEX statements. During a scan, a `not_affected` or `fixed` statement, matched to a finding by advisory id and component (and version when the product carries one), annotates that finding as accepted-risk.

The governance property is identical to `.synapseignore`: acceptance suppresses the CI `--fail-on` gate, not the finding's visibility. The finding stays in the result, reported in every deliverable, persisted, and sealed into the hash-chained evidence record, and is only exempted from the gate, carrying the VEX justification as its reason. Nothing is removed, so a VEX statement can never hide a finding from a report or the tamper-evident chain. `affected` and `under_investigation` statements never suppress. A malformed or oversized document is surfaced as a source warning and is fail-safe: nothing is suppressed, so the finding still trips the gate.

### The unification (why this is more than a feature)

The codebase previously had the OpenVEX parser and the product-to-finding matcher only inside the post-scan `usecase/vex` package, as private helpers. Rather than copy them, this PR moves them once into a pure `domain/vex` (`Parse`, `Statement.Suppresses`, `Statement.MatchesFinding`) and points both consumers at it: the post-scan apply is refactored to drop its private copy, and the new in-scan path uses the same code. The `vuln:advisory:component:version` dedup-key format, previously built in `usecase/sca` and parsed privately in `usecase/vex`, also gets a single home in `domain/vulnerability` (`DedupKey` + `ParseDedupKey`). So the SCA builder and both VEX consumers now share one definition of each and cannot drift.

### Layering

A pure `domain/vex` document parser and matcher; a `ports.VEXLoader` read from the prepared workspace by an infra loader with a symlink guard and a size cap; `applyVEX` annotates in the SCA pipeline on the shared accepted-risk surface without removing anything. Opt-in via `SYNAPSE_VEX_ENABLED`, wired in both `synapse-api` and `synapse-cli`.

### Testing

- Domain: parse (valid, junk, empty, non-OpenVEX), `Suppresses` per status, `MatchesFinding` (versioned exact, versionless matches all, PURL-name match, wrong advisory/component/version reject).
- Loader: parse a real doc, missing is an empty document with no error, a malformed doc surfaces an error, a symlinked `.synapse.vex.json` is not followed.
- Pipeline: `applyVEX` annotates without removing (findings retained), only `not_affected`/`fixed` exempt, no double-annotation of an already-accepted finding.
- The existing post-scan VEX tests pass unchanged after the refactor, confirming behavior was preserved.
- End to end via the CLI on a real CVE: baseline fails `--fail-on high`; a `not_affected` statement keeps the CVE reported but exits 0 (gate-exempt) with the justification; a malformed doc is surfaced and the CVE fails again.
- `go build`, `go vet`, and the affected package tests pass.

### Reviews

Reviewed for clean-architecture compliance (pure domain, the single-parser and single-key-format unification with no remaining duplicate copies, the port and infra loader, usecase depends only on the port) and for the project safety rules. The security review's central questions were whether a VEX statement can silently hide a finding (no, by construction: `applyVEX` only annotates, never removes, exactly like `.synapseignore`) and whether the `usecase/vex` refactor changed its behavior (no: it still matches the same findings, tenant-checks, and audits every applied change; its tests pass). VEX-sourced acceptances inherit the evidence-seal of the accepted-risk set added in the previous PR.
