### PR TITLE
feat(sca): compliance-spec engine + AppSec baseline benchmark

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -548,6 +548,10 @@ func main() {
 		scaService.SetVEXLoader(vexfile.New()) // in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
 		log.Info("in-scan VEX ENABLED (.synapse.vex.json; not_affected/fixed gate-exempt, still reported + sealed)")
 	}
+	if cfg.ComplianceEnabled {
+		scaService.SetComplianceEnabled(true) // attach the AppSec-baseline benchmark (per-control PASS/FAIL)
+		log.Info("compliance report ENABLED (Synapse AppSec Baseline; deterministic, LLM-free)")
+	}
 	if cfg.ScanCacheEnabled {
 		if dir := cfg.ResolveScanCacheDir(); dir != "" {
 			scaService.SetSBOMCache(sbomcache.New(dir)) // content+version-addressed generated-SBOM cache

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -310,6 +310,9 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	if cfg.VEXEnabled {
 		sca.SetVEXLoader(vexfile.New()) // in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions (CI-friendly)
 	}
+	if cfg.ComplianceEnabled {
+		sca.SetComplianceEnabled(true) // attach the AppSec-baseline benchmark (per-control PASS/FAIL)
+	}
 	if cfg.ScanCacheEnabled {
 		if dir := cfg.ResolveScanCacheDir(); dir != "" {
 			sca.SetSBOMCache(sbomcache.New(dir)) // content+version-addressed generated-SBOM cache (CI-friendly)
@@ -446,6 +449,29 @@ func printReport(target string, res *scauc.ScanResult) {
 			kev = " [KEV]"
 		}
 		fmt.Printf("    %-9s risk %5.2f  %s%s\n", f.Severity, f.RiskScore, f.Title, kev)
+	}
+	if c := res.Compliance; c != nil {
+		scope := ""
+		if c.MinSeverity != "" && c.MinSeverity != "info" {
+			scope = " (evaluated over findings ≥ " + c.MinSeverity
+			if c.IgnoreUnfixed {
+				scope += ", unfixed excluded"
+			}
+			scope += ")"
+		} else if c.IgnoreUnfixed {
+			scope = " (unfixed vulns excluded)"
+		}
+		fmt.Printf("\n  compliance: %s v%s — %d/%d controls passing%s\n", c.Title, c.Version, c.Passed, c.Passed+c.Failed, scope)
+		for _, r := range c.Results {
+			status := "PASS"
+			if !r.Passed {
+				status = "FAIL"
+			}
+			fmt.Printf("    [%s] %-14s %s\n", status, r.Control.ID, r.Control.Title)
+			for _, e := range r.Evidence {
+				fmt.Printf("           - %s\n", e)
+			}
+		}
 	}
 	fmt.Println()
 }

--- a/internal/domain/compliance/baseline.go
+++ b/internal/domain/compliance/baseline.go
@@ -1,0 +1,53 @@
+package compliance
+
+// BaselineSpec is the owned "Synapse AppSec Baseline" benchmark: a small, deterministic control set that
+// re-projects Synapse's own findings (pattern-SAST CWEs, secret + misconfig kinds, severity) into
+// auditor-citable pass/fail. It is a STARTER spec that exercises the engine end to end; ingesting a
+// third-party benchmark verbatim (a CIS/PSS YAML, joined by check id) is a follow-up — the engine is the
+// same, only the spec source differs. Each control's join keys trace to what Synapse actually detects, so a
+// FAIL is always backed by a real, listed finding.
+func BaselineSpec() Spec {
+	return Spec{
+		ID:      "synapse-appsec-baseline",
+		Title:   "Synapse AppSec Baseline",
+		Version: "1.0",
+		Controls: []SpecControl{
+			{
+				ID:    "SAB-INJ-1",
+				Title: "No injection weaknesses (SQL, command, code, XSS, NoSQL, XXE, SSTI, LDAP)",
+				CWEs:  []string{"CWE-89", "CWE-78", "CWE-94", "CWE-95", "CWE-79", "CWE-943", "CWE-611", "CWE-1336", "CWE-90", "CWE-643"},
+			},
+			{
+				ID:    "SAB-CRYPTO-1",
+				Title: "No weak cryptography (broken hash/cipher, cert validation, key size, weak PRNG)",
+				CWEs:  []string{"CWE-327", "CWE-295", "CWE-326", "CWE-338", "CWE-916"},
+			},
+			{
+				ID:    "SAB-SECRET-1",
+				Title: "No hardcoded secrets or credentials",
+				CWEs:  []string{"CWE-798"},
+				Kinds: []string{"secret"},
+			},
+			{
+				ID:    "SAB-ACCESS-1",
+				Title: "No access-control, SSRF, path-traversal, or open-redirect gaps",
+				CWEs:  []string{"CWE-22", "CWE-918", "CWE-639", "CWE-601", "CWE-284", "CWE-732"},
+			},
+			{
+				ID:    "SAB-INTEGRITY-1",
+				Title: "No unsafe deserialization or token-integrity failures",
+				CWEs:  []string{"CWE-502", "CWE-347"},
+			},
+			{
+				ID:    "SAB-IAC-1",
+				Title: "No insecure infrastructure-as-code / container configuration",
+				Kinds: []string{"misconfig"},
+			},
+			{
+				ID:          "SAB-SEV-1",
+				Title:       "No critical-severity findings",
+				MinSeverity: "critical",
+			},
+		},
+	}
+}

--- a/internal/domain/compliance/spec.go
+++ b/internal/domain/compliance/spec.go
@@ -1,0 +1,99 @@
+package compliance
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// A Spec is a versioned compliance benchmark: a set of controls, each PASS or FAIL depending on whether any
+// scan finding matches it. It re-projects the deterministic findings onto an auditor-citable pass/fail
+// report (Trivy's compliance-spec idea), purely by a deterministic id/attribute join — NO LLM, so the
+// result is a lookup a human can audit, and it drops straight into the LLM-free report path.
+type Spec struct {
+	ID       string
+	Title    string
+	Version  string
+	Controls []SpecControl
+}
+
+// SpecControl is one benchmark control. It FAILS when any finding matches ANY of its join keys: a mapped
+// CWE, a finding Kind, or a severity at/above MinSeverity. A control with no findings against it PASSES.
+type SpecControl struct {
+	ID          string   // control id as cited, e.g. "SAB-INJ-1"
+	Title       string   // human control title
+	CWEs        []string // FAIL if a finding's CWE is one of these (normalized, "CWE-" tolerated)
+	Kinds       []string // FAIL if a finding's Kind is one of these (e.g. "secret", "misconfig")
+	MinSeverity string   // FAIL if any finding is at/above this severity label; "" disables the severity join
+}
+
+// ControlResult is a control's evaluated status plus the finding titles that failed it (evidence).
+type ControlResult struct {
+	Control  SpecControl
+	Passed   bool
+	Evidence []string // titles of the findings that failed the control (empty when passed)
+}
+
+// Report is the evaluated benchmark: per-control results plus pass/fail tallies. MinSeverity + IgnoreUnfixed
+// record the SCOPE of the finding set it was computed over, so a PASS is never misread as "no weakness of
+// this class at ANY severity" — findings below the floor (and, when IgnoreUnfixed, unfixed vulns) were not
+// in the evaluated set.
+type Report struct {
+	SpecID        string
+	Title         string
+	Version       string
+	MinSeverity   string // the severity floor the evaluated findings were promoted at ("info" = none dropped)
+	IgnoreUnfixed bool   // whether unfixed vulns were excluded from the evaluated set
+	Results       []ControlResult
+	Passed        int
+	Failed        int
+}
+
+// Evaluate joins the findings against the spec and returns the per-control report. Deterministic and
+// order-independent: controls keep their spec order; evidence is sorted. A control matches a finding when
+// the finding's CWE is in Controls.CWEs, its Kind is in Controls.Kinds, or its severity is at/above
+// MinSeverity — the same match a human would make by reading the control's join keys.
+func Evaluate(spec Spec, findings []finding.Finding) Report {
+	rep := Report{SpecID: spec.ID, Title: spec.Title, Version: spec.Version}
+	for _, c := range spec.Controls {
+		var evidence []string
+		for _, f := range findings {
+			if controlMatchesFinding(c, f) {
+				evidence = append(evidence, f.Title)
+			}
+		}
+		sort.Strings(evidence)
+		res := ControlResult{Control: c, Passed: len(evidence) == 0, Evidence: evidence}
+		rep.Results = append(rep.Results, res)
+		if res.Passed {
+			rep.Passed++
+		} else {
+			rep.Failed++
+		}
+	}
+	return rep
+}
+
+func controlMatchesFinding(c SpecControl, f finding.Finding) bool {
+	if fc := normalizeCWE(f.CWE); fc != "" {
+		for _, cwe := range c.CWEs {
+			if normalizeCWE(cwe) == fc {
+				return true
+			}
+		}
+	}
+	for _, k := range c.Kinds {
+		if strings.EqualFold(string(f.Kind), k) {
+			return true
+		}
+	}
+	// A control MinSeverity that isn't a known label ranks 0 and would match EVERY finding (over-match); guard
+	// on a positive threshold so an unrecognized value fail-closes (disables the severity join), matching the
+	// CWE join's fail-to-nothing philosophy for when non-hardcoded specs arrive.
+	if minRank := shared.SeverityRank(shared.Severity(c.MinSeverity)); minRank > 0 && shared.SeverityRank(f.Severity) >= minRank {
+		return true
+	}
+	return false
+}

--- a/internal/domain/compliance/spec_test.go
+++ b/internal/domain/compliance/spec_test.go
@@ -1,0 +1,76 @@
+package compliance
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestEvaluate(t *testing.T) {
+	findings := []finding.Finding{
+		{Title: "SQL injection in login", CWE: "CWE-89", Severity: shared.SeverityHigh, Kind: finding.KindSAST},
+		{Title: "Hardcoded AWS key", Kind: finding.KindSecret, Severity: shared.SeverityCritical},
+		{Title: "Dockerfile runs as root", Kind: finding.KindMisconfig, Severity: shared.SeverityHigh},
+	}
+	rep := Evaluate(BaselineSpec(), findings)
+
+	byID := map[string]ControlResult{}
+	for _, r := range rep.Results {
+		byID[r.Control.ID] = r
+	}
+	// SAB-INJ-1 fails via CWE-89, with the finding title as evidence.
+	if inj := byID["SAB-INJ-1"]; inj.Passed || len(inj.Evidence) != 1 || inj.Evidence[0] != "SQL injection in login" {
+		t.Errorf("SAB-INJ-1 must FAIL on CWE-89 with evidence, got %+v", inj)
+	}
+	// SAB-SECRET-1 fails via Kind=secret.
+	if byID["SAB-SECRET-1"].Passed {
+		t.Error("SAB-SECRET-1 must FAIL on a secret finding")
+	}
+	// SAB-IAC-1 fails via Kind=misconfig.
+	if byID["SAB-IAC-1"].Passed {
+		t.Error("SAB-IAC-1 must FAIL on a misconfig finding")
+	}
+	// SAB-SEV-1 fails via the critical secret finding.
+	if byID["SAB-SEV-1"].Passed {
+		t.Error("SAB-SEV-1 must FAIL when any finding is critical")
+	}
+	// SAB-CRYPTO-1 passes (no crypto CWE present).
+	if !byID["SAB-CRYPTO-1"].Passed {
+		t.Error("SAB-CRYPTO-1 must PASS when no crypto weakness is present")
+	}
+	if rep.Failed < 4 || rep.Passed+rep.Failed != len(rep.Results) {
+		t.Errorf("tally mismatch: passed=%d failed=%d results=%d", rep.Passed, rep.Failed, len(rep.Results))
+	}
+}
+
+func TestEvaluateCleanScanAllPass(t *testing.T) {
+	rep := Evaluate(BaselineSpec(), nil)
+	if rep.Failed != 0 || rep.Passed != len(BaselineSpec().Controls) {
+		t.Errorf("a finding-free scan must pass every control, got passed=%d failed=%d", rep.Passed, rep.Failed)
+	}
+}
+
+func TestBaselineSpecControlIDsUnique(t *testing.T) {
+	seen := map[string]bool{}
+	for _, c := range BaselineSpec().Controls {
+		if c.ID == "" || c.Title == "" {
+			t.Errorf("control has empty id/title: %+v", c)
+		}
+		if seen[c.ID] {
+			t.Errorf("duplicate control id %q", c.ID)
+		}
+		seen[c.ID] = true
+	}
+}
+
+func TestCWENormalizationInJoin(t *testing.T) {
+	// A finding CWE written as a bare number or lower-case must still match a "CWE-89" control key.
+	spec := Spec{ID: "t", Controls: []SpecControl{{ID: "C1", Title: "inj", CWEs: []string{"CWE-89"}}}}
+	for _, cwe := range []string{"89", "cwe-89", "CWE-089"} {
+		rep := Evaluate(spec, []finding.Finding{{Title: "x", CWE: cwe}})
+		if rep.Results[0].Passed {
+			t.Errorf("CWE %q must match control key CWE-89 (normalized)", cwe)
+		}
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -172,6 +172,9 @@ type Config struct {
 	// VEXEnabled turns on consuming an in-repo OpenVEX doc (.synapse.vex.json) at scan time; off by default.
 	// A not_affected/fixed statement gate-exempts the matched finding (still reported + sealed), never removes it.
 	VEXEnabled bool
+	// ComplianceEnabled attaches the owned AppSec-baseline benchmark (per-control PASS/FAIL over the scan's
+	// findings, LLM-free) to each scan result; off by default.
+	ComplianceEnabled bool
 	// ScanCacheEnabled turns on the content+version-addressed generated-SBOM cache; off by default. A hit on
 	// an unchanged tree skips the cataloging step; a producer version bump invalidates the entry.
 	ScanCacheEnabled bool
@@ -325,6 +328,7 @@ func Load() Config {
 		MisconfigEnabled:       getbool("SYNAPSE_MISCONFIG_ENABLED", false),
 		SuppressionEnabled:     getbool("SYNAPSE_SUPPRESSION_ENABLED", false),
 		VEXEnabled:             getbool("SYNAPSE_VEX_ENABLED", false),
+		ComplianceEnabled:      getbool("SYNAPSE_COMPLIANCE_ENABLED", false),
 		ScanCacheEnabled:       getbool("SYNAPSE_SCAN_CACHE_ENABLED", false),
 		ScanCacheDir:           os.Getenv("SYNAPSE_SCAN_CACHE_DIR"),
 		OwnedAdvisoryEnabled:   getbool("SYNAPSE_OWNED_ADVISORY", false),

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/compliance"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/distro"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
@@ -63,6 +64,7 @@ type Service struct {
 	misconfig      ports.MisconfigScanner        // optional deterministic IaC/config misconfig scan over the live workspace
 	suppression    ports.SuppressionLoader       // optional repo-committed .synapseignore accepted-risk policy
 	vexLoader      ports.VEXLoader               // optional in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
+	complianceOn   bool                          // when set, attach the AppSec-baseline compliance report to a scan
 	reachability   ports.ReachabilityRecorder    // optional deterministic Tier-2 reachability proof
 	correlation    ports.CorrelationRecorder     // optional cross-check disagreement → judgment minter
 	sbomGen2       ports.SBOMGenerator           // optional 2nd SBOM producer for the cross-check
@@ -155,6 +157,24 @@ func (s *Service) SetSuppressionLoader(l ports.SuppressionLoader) { s.suppressio
 // A not_affected/fixed statement annotates the matched finding accepted-risk on the same retain-and-mark
 // surface as .synapseignore (gate-exempt, but reported + sealed), never removed.
 func (s *Service) SetVEXLoader(l ports.VEXLoader) { s.vexLoader = l }
+
+// SetComplianceEnabled turns on attaching the owned AppSec-baseline compliance report (per-control
+// PASS/FAIL over the scan's findings) to each scan result. Deterministic + LLM-free; off by default.
+func (s *Service) SetComplianceEnabled(on bool) { s.complianceOn = on }
+
+// attachCompliance computes the AppSec-baseline benchmark over the finalized findings when enabled. It runs
+// over ALL findings (an accepted-risk finding still fails its control — compliance reflects what is present).
+func (s *Service) attachCompliance(result *ScanResult) {
+	if !s.complianceOn || result == nil {
+		return
+	}
+	rep := compliance.Evaluate(compliance.BaselineSpec(), result.Findings)
+	// Record the finding-set scope so a PASS is never misread: a raised floor / --ignore-unfixed drops
+	// findings BEFORE compliance, and this qualifies the result accordingly.
+	rep.MinSeverity = string(result.MinSeverity)
+	rep.IgnoreUnfixed = s.ignoreUnfixed
+	result.Compliance = &rep
+}
 
 // SetReachability configures the optional deterministic Tier-2 reachability prover. nil ⇒ no
 // reachability judgments. Best-effort + opt-in: a no-coverage/un-buildable target leaves the prior
@@ -313,7 +333,11 @@ type ScanResult struct {
 	ExpiredSuppressions []string `json:"expired_suppressions,omitempty"`
 	// MalformedSuppressions lists .synapseignore rule ids whose expiry could not be parsed; fail-safe, they
 	// do NOT suppress (a date typo must not become a permanent silent acceptance) and are surfaced to fix.
-	MalformedSuppressions    []string                 `json:"malformed_suppressions,omitempty"`
+	MalformedSuppressions []string `json:"malformed_suppressions,omitempty"`
+	// Compliance is the owned AppSec-baseline benchmark re-projected onto this scan's findings (per-control
+	// PASS/FAIL, LLM-free); nil unless compliance is enabled. Computed over ALL findings (an accepted-risk
+	// finding still fails its control — compliance reflects what is present, not the CI-gate decision).
+	Compliance               *compliance.Report       `json:"compliance,omitempty"`
 	ToolVersions             map[string]string        `json:"tool_versions"`
 	VulnDBSnapshot           string                   `json:"vuln_db_snapshot"`
 	Completeness             ports.Completeness       `json:"completeness"`
@@ -1239,6 +1263,11 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 				mergeCachedScanResult(result, previous, opts)
 			}
 		}
+	}
+	// Compute compliance over the FINAL findings — AFTER any partial-rescan merge restores prior security
+	// findings — so a control can never falsely PASS against a finding the merged result actually carries.
+	s.attachCompliance(result)
+	if s.results != nil {
 		if data, mErr := json.Marshal(result); mErr == nil {
 			_ = s.results.SaveResult(ctx, engagementID, data)
 		}
@@ -1774,6 +1803,11 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 				mergeCachedScanResult(result, previous, opts)
 			}
 		}
+	}
+	// Compute compliance over the FINAL findings — AFTER any partial-rescan merge restores prior security
+	// findings — so a control can never falsely PASS against a finding the merged result actually carries.
+	s.attachCompliance(result)
+	if s.results != nil {
 		if data, mErr := json.Marshal(result); mErr == nil {
 			_ = s.results.SaveResult(ctx, engagementID, data)
 		}


### PR DESCRIPTION
## Compliance-spec engine + AppSec baseline benchmark

Adds a compliance-benchmark engine that re-projects a scan's findings onto a versioned spec and reports per-control PASS/FAIL. This is Trivy's compliance-spec mechanism (`--compliance`), made to fit Synapse's LLM-free report path. It is the third item built from the second-pass Trivy evaluation, after suppression and in-scan VEX.

### What it does

A `Spec` is a versioned benchmark: a set of controls, each of which FAILS when any finding matches one of its join keys (a mapped CWE, a finding kind, or a severity at or above a threshold). `Evaluate(spec, findings)` returns a per-control report with the failing finding titles as the cited evidence. The join is a pure, deterministic id/attribute lookup, so a PASS or FAIL is an auditable computation a human can trace, never a model output.

It ships an owned "Synapse AppSec Baseline" spec whose controls map to what Synapse actually detects: injection (the SQL/command/code/XSS/NoSQL/XXE/SSTI/LDAP CWEs), cryptography, hardcoded secrets, access control and SSRF, deserialization and token integrity, insecure infrastructure-as-code, and critical severity. The engine is the reusable part; ingesting a third-party benchmark verbatim (a CIS or PSS YAML joined by check id) is a follow-up that only changes the spec source.

### The safety property

Compliance is computed over all findings, including accepted-risk ones. A `.synapseignore` or VEX acceptance exempts a finding from the CI gate but never removes it, so the finding still fails its control. An acceptance can never silently flip a control to PASS. The report reflects what is present in the code, not the team's gate decision.

### Where it sits

The engine lives beside the existing CWE-to-framework mapping in `domain/compliance` and is pure domain (no I/O, so no port). It attaches to the scan result behind `SYNAPSE_COMPLIANCE_ENABLED` in both scan paths before the result is persisted, so the persisted and returned result both carry it, and the CLI renders it as a per-control table. A distinct "Compliance" section in the formal PDF/HTML report is a natural follow-up (the data is on the result).

### Testing

- Domain: `Evaluate` over a mixed finding set (a CWE control fails with evidence, a kind control fails, a severity control fails, an unrelated control passes, tallies are correct); a finding-free scan passes every control; control ids are unique; CWE normalization in the join (a bare number or lower-case still matches).
- End to end via the CLI: a fixture with an XXE, SQL injection, DOM XSS, and an insecure Dockerfile reports "5/7 controls passing" with `SAB-INJ-1` and `SAB-IAC-1` failing, each listing its evidence.
- `go build`, `go vet`, and the affected package tests pass; no SCA regression.

### Reviews

Reviewed for clean-architecture compliance (pure domain, no import cycle with `domain/finding`, no unnecessary port) and for the project safety rules. The security review's central question was whether a control can falsely PASS: it cannot via suppression, since compliance is computed over all findings including accepted-risk ones, and the report path is LLM-free and deterministic.
