### PR TITLE
feat(sca): detection-priority precise mode (needs-verify queue for uncorroborated vulns)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -73,7 +73,7 @@ func main() {
 
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
-	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed]")
+	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
 	fmt.Fprintln(os.Stderr, "      --image    treat the argument as a container image reference (pulled via crane) instead of a local path")
 	fmt.Fprintln(os.Stderr, "      --offline  skip the live OSV.dev source; detect with Grype's offline DB only (air-gapped / fast)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
@@ -90,6 +90,7 @@ func runScan() {
 	}
 	failOn := shared.Severity("high")
 	mode := scauc.ScanModeFull
+	priority := ""
 	ignoreUnfixed := false
 	image := false
 	offline := false
@@ -100,6 +101,9 @@ func runScan() {
 			i++
 		case os.Args[i] == "--mode" && i+1 < len(os.Args):
 			mode = os.Args[i+1]
+			i++
+		case os.Args[i] == "--detection-priority" && i+1 < len(os.Args):
+			priority = os.Args[i+1]
 			i++
 		case os.Args[i] == "--ignore-unfixed":
 			ignoreUnfixed = true
@@ -118,11 +122,14 @@ func runScan() {
 		fmt.Fprintf(os.Stderr, "synapse-cli: invalid --fail-on %q (want critical|high|medium|low|info)\n", failOn)
 		os.Exit(2)
 	}
-	if _, err := scauc.NormalizeScanOptions(scauc.ScanOptions{Mode: mode}); err != nil {
-		fmt.Fprintf(os.Stderr, "synapse-cli: invalid --mode %q (want full|vulnerabilities|licenses)\n", mode)
+	if priority == "" { // resolve the configured default here so an invalid env value gets this same exit-2 message
+		priority = os.Getenv("SYNAPSE_DETECTION_PRIORITY")
+	}
+	if _, err := scauc.NormalizeScanOptions(scauc.ScanOptions{Mode: mode, DetectionPriority: priority}); err != nil {
+		fmt.Fprintf(os.Stderr, "synapse-cli: %v (mode want full|vulnerabilities|licenses; detection-priority want comprehensive|precise)\n", err)
 		os.Exit(2)
 	}
-	if err := run(os.Args[2], failOn, mode, ignoreUnfixed, image, offline); err != nil {
+	if err := run(os.Args[2], failOn, mode, priority, ignoreUnfixed, image, offline); err != nil {
 		fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 		os.Exit(1)
 	}
@@ -200,7 +207,7 @@ func (stderrAudit) Record(_ context.Context, e ports.AuditEntry) error {
 
 var _ ports.AuditLogger = stderrAudit{}
 
-func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image, offline bool) error {
+func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfixed, image, offline bool) error {
 	// An image target is an OCI reference (acquired via crane → OCI layout); a local
 	// target is a filesystem path that must be absolute for the scope check.
 	target := strings.TrimSpace(path)
@@ -213,6 +220,9 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	}
 	ctx := context.Background()
 	cfg := config.Load()
+	if priority == "" { // the --detection-priority flag falls back to the configured default
+		priority = cfg.DetectionPriority
+	}
 	clock := idgen.SystemClock{}
 	ids := idgen.RandomID{}
 
@@ -340,7 +350,7 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 		return fmt.Errorf("register ephemeral engagement: %w", err)
 	}
 
-	res, err := sca.ScanWithOptions(ctx, "synapse-cli", eng.ID, ports.AcquireRequest{Kind: acqKind, Value: target}, scauc.ScanOptions{Mode: mode})
+	res, err := sca.ScanWithOptions(ctx, "synapse-cli", eng.ID, ports.AcquireRequest{Kind: acqKind, Value: target}, scauc.ScanOptions{Mode: mode, DetectionPriority: priority})
 	if err != nil {
 		return fmt.Errorf("scan: %w", err)
 	}
@@ -348,10 +358,11 @@ func run(path string, failOn shared.Severity, mode string, ignoreUnfixed, image,
 	printReport(target, res)
 
 	gate := shared.SeverityRank(failOn)
-	accepted := res.SuppressedKeys() // .synapseignore accepted-risk: reported + sealed, but exempt from the gate
+	accepted := res.SuppressedKeys() // .synapseignore/VEX accepted-risk: reported + sealed, but exempt from the gate
+	verify := res.NeedsVerifyKeys()  // precise-mode needs-verify: lower-confidence, exempt from the gate too
 	over := 0
 	for _, f := range res.Findings {
-		if accepted[f.DedupKey] {
+		if accepted[f.DedupKey] || verify[f.DedupKey] {
 			continue
 		}
 		if shared.SeverityRank(f.Severity) >= gate {
@@ -442,6 +453,12 @@ func printReport(target string, res *scauc.ScanResult) {
 	}
 	for _, id := range res.MalformedSuppressions {
 		fmt.Printf("  ! .synapseignore rule %q has an UNPARSEABLE exp: date — not applied (fail-safe). Fix it to YYYY-MM-DD\n", id)
+	}
+	if n := len(res.NeedsVerification); n > 0 {
+		fmt.Printf("  needs-verify (precise): %d single-source vuln(s) quarantined — still reported + sealed, exempt from --fail-on\n", n)
+		for _, v := range res.NeedsVerification {
+			fmt.Printf("    - %s\n", v.Title)
+		}
 	}
 	for _, f := range res.Findings {
 		kev := ""

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -175,6 +175,10 @@ type Config struct {
 	// ComplianceEnabled attaches the owned AppSec-baseline benchmark (per-control PASS/FAIL over the scan's
 	// findings, LLM-free) to each scan result; off by default.
 	ComplianceEnabled bool
+	// DetectionPriority is the default vulnerability detection priority: "comprehensive" (default; every
+	// detected vuln is actionable) or "precise" (single-source, non-KEV vulns are quarantined into a
+	// needs-verify queue — reported + sealed, exempt from the --fail-on gate). Empty = comprehensive.
+	DetectionPriority string
 	// ScanCacheEnabled turns on the content+version-addressed generated-SBOM cache; off by default. A hit on
 	// an unchanged tree skips the cataloging step; a producer version bump invalidates the entry.
 	ScanCacheEnabled bool
@@ -329,6 +333,7 @@ func Load() Config {
 		SuppressionEnabled:     getbool("SYNAPSE_SUPPRESSION_ENABLED", false),
 		VEXEnabled:             getbool("SYNAPSE_VEX_ENABLED", false),
 		ComplianceEnabled:      getbool("SYNAPSE_COMPLIANCE_ENABLED", false),
+		DetectionPriority:      os.Getenv("SYNAPSE_DETECTION_PRIORITY"),
 		ScanCacheEnabled:       getbool("SYNAPSE_SCAN_CACHE_ENABLED", false),
 		ScanCacheDir:           os.Getenv("SYNAPSE_SCAN_CACHE_DIR"),
 		OwnedAdvisoryEnabled:   getbool("SYNAPSE_OWNED_ADVISORY", false),

--- a/internal/usecase/sca/detectionpriority_test.go
+++ b/internal/usecase/sca/detectionpriority_test.go
@@ -1,0 +1,66 @@
+package sca
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestApplyDetectionPriority(t *testing.T) {
+	res := &ScanResult{
+		Findings: []finding.Finding{
+			{ID: "single", Title: "single-source CVE", DedupKey: "vuln:CVE-1:a:1", Severity: shared.SeverityHigh, Sources: []string{"osv"}},
+			{ID: "multi", Title: "corroborated CVE", DedupKey: "vuln:CVE-2:b:1", Severity: shared.SeverityHigh, Sources: []string{"osv", "grype"}},
+			{ID: "kev", Title: "KEV CVE", DedupKey: "vuln:CVE-3:c:1", Severity: shared.SeverityHigh, Sources: []string{"osv"}, KEV: true},
+			{ID: "sast", Title: "SAST hit", DedupKey: "sast:rule:file:1", Severity: shared.SeverityHigh, Sources: []string{"synapse-pattern-sast"}, Kind: finding.KindSAST},
+		},
+	}
+	applyDetectionPriority(res, DetectionPrecise)
+
+	// CRITICAL: nothing is removed — all findings stay reported/sealed.
+	if len(res.Findings) != 4 {
+		t.Fatalf("detection-priority must NOT remove findings, got %d", len(res.Findings))
+	}
+	// Only the single-source, non-KEV VULN finding is quarantined.
+	if len(res.NeedsVerification) != 1 || res.NeedsVerification[0].DedupKey != "vuln:CVE-1:a:1" {
+		t.Fatalf("only the single-source non-KEV vuln must be quarantined, got %+v", res.NeedsVerification)
+	}
+	keys := res.NeedsVerifyKeys()
+	if !keys["vuln:CVE-1:a:1"] {
+		t.Error("the single-source vuln must be gate-exempt")
+	}
+	// Corroborated (multi-source), KEV, and deterministic first-party (SAST) stay actionable.
+	for _, k := range []string{"vuln:CVE-2:b:1", "vuln:CVE-3:c:1", "sast:rule:file:1"} {
+		if keys[k] {
+			t.Errorf("%s must stay actionable (corroborated/KEV/first-party), not quarantined", k)
+		}
+	}
+}
+
+func TestApplyDetectionPriorityComprehensiveIsNoop(t *testing.T) {
+	res := &ScanResult{Findings: []finding.Finding{{ID: "x", DedupKey: "vuln:CVE-1:a:1", Sources: []string{"osv"}}}}
+	applyDetectionPriority(res, DetectionComprehensive)
+	if len(res.NeedsVerification) != 0 {
+		t.Error("comprehensive mode must quarantine nothing")
+	}
+	applyDetectionPriority(res, "") // empty defaults to comprehensive behavior (no-op)
+	if len(res.NeedsVerification) != 0 {
+		t.Error("empty priority must behave as comprehensive (no-op)")
+	}
+}
+
+func TestNormalizeScanOptionsDetectionPriority(t *testing.T) {
+	// Empty defaults to comprehensive.
+	if o, err := normalizeScanOptions(ScanOptions{Mode: "full"}); err != nil || o.DetectionPriority != DetectionComprehensive {
+		t.Errorf("empty priority must default to comprehensive, got %q err=%v", o.DetectionPriority, err)
+	}
+	// Explicit precise is preserved (case-insensitive).
+	if o, err := normalizeScanOptions(ScanOptions{Mode: "full", DetectionPriority: "PRECISE"}); err != nil || o.DetectionPriority != DetectionPrecise {
+		t.Errorf("precise must normalize, got %q err=%v", o.DetectionPriority, err)
+	}
+	// An unknown priority is rejected.
+	if _, err := normalizeScanOptions(ScanOptions{Mode: "full", DetectionPriority: "bogus"}); err == nil {
+		t.Error("an unknown detection priority must be rejected")
+	}
+}

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -496,6 +496,51 @@ func applyVEX(res *ScanResult, doc vex.Document) {
 	}
 }
 
+// NeedsVerifyFinding marks a vuln finding the precise detection-priority quarantined as lower-confidence
+// (a single, uncorroborated detection source, and not KEV). The finding STAYS in Findings (reported +
+// evidence-sealed); this only labels it needs-verify and exempts it from the --fail-on gate — the
+// "quarantine into a verify queue, don't drop" alternative to Trivy dropping imprecise matches.
+type NeedsVerifyFinding struct {
+	DedupKey string `json:"dedup_key"`
+	Title    string `json:"title"`
+	Reason   string `json:"reason"`
+}
+
+// applyDetectionPriority, in precise mode, quarantines single-source (uncorroborated) non-KEV vuln findings
+// into res.NeedsVerification WITHOUT removing them. KEV (actively exploited), multi-source (corroborated),
+// and non-vuln findings (deterministic SAST/secret/misconfig/license) always stay actionable. Comprehensive
+// mode is a no-op. Deterministic; nothing is removed, so nothing is hidden — only the gate is exempted.
+func applyDetectionPriority(res *ScanResult, priority string) {
+	if res == nil || priority != DetectionPrecise {
+		return
+	}
+	verified := res.SuppressedKeys() // already-accepted findings aren't re-labeled needs-verify
+	for _, f := range res.Findings {
+		if !strings.HasPrefix(f.DedupKey, "vuln:") { // only advisory-vuln findings; first-party stays actionable
+			continue
+		}
+		if f.KEV || len(f.Sources) > 1 || verified[f.DedupKey] { // KEV + corroborated + accepted stay as-is
+			continue
+		}
+		res.NeedsVerification = append(res.NeedsVerification, NeedsVerifyFinding{
+			DedupKey: f.DedupKey, Title: f.Title,
+			Reason: "≤1 detection source (uncorroborated) — verify before acting",
+		})
+	}
+}
+
+// NeedsVerifyKeys returns the dedup keys a CI gate should exempt from --fail-on (the needs-verify queue).
+func (r *ScanResult) NeedsVerifyKeys() map[string]bool {
+	if len(r.NeedsVerification) == 0 {
+		return nil
+	}
+	m := make(map[string]bool, len(r.NeedsVerification))
+	for _, n := range r.NeedsVerification {
+		m[n.DedupKey] = true
+	}
+	return m
+}
+
 // SuppressedKeys returns the dedup keys a CI gate should exempt from --fail-on (the accepted-risk set).
 func (r *ScanResult) SuppressedKeys() map[string]bool {
 	if len(r.SuppressedFindings) == 0 {

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -337,7 +337,11 @@ type ScanResult struct {
 	// Compliance is the owned AppSec-baseline benchmark re-projected onto this scan's findings (per-control
 	// PASS/FAIL, LLM-free); nil unless compliance is enabled. Computed over ALL findings (an accepted-risk
 	// finding still fails its control — compliance reflects what is present, not the CI-gate decision).
-	Compliance               *compliance.Report       `json:"compliance,omitempty"`
+	Compliance *compliance.Report `json:"compliance,omitempty"`
+	// NeedsVerification lists vuln findings the precise detection-priority quarantined as lower-confidence
+	// (single uncorroborated source, non-KEV): still reported + sealed, but exempt from the --fail-on gate.
+	// nil in comprehensive mode. Recall is retained; only the lower-confidence set is separated.
+	NeedsVerification        []NeedsVerifyFinding     `json:"needs_verification,omitempty"`
 	ToolVersions             map[string]string        `json:"tool_versions"`
 	VulnDBSnapshot           string                   `json:"vuln_db_snapshot"`
 	Completeness             ports.Completeness       `json:"completeness"`
@@ -362,8 +366,20 @@ const (
 	ScanModeLicenses        = "licenses"
 )
 
+const (
+	// DetectionComprehensive is the default: every detected vulnerability at/above the floor is an
+	// actionable finding (current behavior). DetectionPrecise raises the ACTIONABLE bar — a single-source,
+	// uncorroborated, non-KEV vulnerability finding is quarantined into a needs-verify queue (still reported
+	// + evidence-sealed, just exempt from the --fail-on gate) rather than dropped, so recall is retained
+	// with the lower-confidence set clearly separated. KEV + multi-source findings are never quarantined.
+	DetectionComprehensive = "comprehensive"
+	DetectionPrecise       = "precise"
+)
+
 type ScanOptions struct {
 	Mode string `json:"mode"`
+	// DetectionPriority selects comprehensive (default) or precise; see the Detection* consts.
+	DetectionPriority string `json:"detection_priority,omitempty"`
 }
 
 func normalizeScanOptions(opts ScanOptions) (ScanOptions, error) {
@@ -374,9 +390,19 @@ func normalizeScanOptions(opts ScanOptions) (ScanOptions, error) {
 	switch mode {
 	case ScanModeFull, ScanModeVulnerabilities, ScanModeLicenses:
 		opts.Mode = mode
-		return opts, nil
 	default:
 		return ScanOptions{}, fmt.Errorf("%w: unknown scan mode %q", shared.ErrValidation, opts.Mode)
+	}
+	prio := strings.ToLower(strings.TrimSpace(opts.DetectionPriority))
+	if prio == "" {
+		prio = DetectionComprehensive
+	}
+	switch prio {
+	case DetectionComprehensive, DetectionPrecise:
+		opts.DetectionPriority = prio
+		return opts, nil
+	default:
+		return ScanOptions{}, fmt.Errorf("%w: unknown detection priority %q (want comprehensive|precise)", shared.ErrValidation, opts.DetectionPriority)
 	}
 }
 
@@ -1264,8 +1290,10 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 			}
 		}
 	}
-	// Compute compliance over the FINAL findings — AFTER any partial-rescan merge restores prior security
-	// findings — so a control can never falsely PASS against a finding the merged result actually carries.
+	// Run over the FINAL findings (after any partial-rescan merge): quarantine lower-confidence vulns into
+	// the needs-verify queue (precise mode), then compute compliance — both must see the merged set so
+	// derived data can never go stale/false-clean.
+	applyDetectionPriority(result, opts.DetectionPriority)
 	s.attachCompliance(result)
 	if s.results != nil {
 		if data, mErr := json.Marshal(result); mErr == nil {
@@ -1804,8 +1832,10 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 			}
 		}
 	}
-	// Compute compliance over the FINAL findings — AFTER any partial-rescan merge restores prior security
-	// findings — so a control can never falsely PASS against a finding the merged result actually carries.
+	// Run over the FINAL findings (after any partial-rescan merge): quarantine lower-confidence vulns into
+	// the needs-verify queue (precise mode), then compute compliance — both must see the merged set so
+	// derived data can never go stale/false-clean.
+	applyDetectionPriority(result, opts.DetectionPriority)
 	s.attachCompliance(result)
 	if s.results != nil {
 		if data, mErr := json.Marshal(result); mErr == nil {


### PR DESCRIPTION
## Detection-priority: precise mode with a needs-verify queue

Adds a scan option `comprehensive` (default) or `precise`. This is Trivy's `--detection-priority`, reframed for a judgment-gated platform, and the fourth mechanism built from the second-pass Trivy evaluation (after suppression, in-scan VEX, and compliance-spec).

### What it does

`comprehensive` (the default, unchanged) treats every detected vulnerability at or above the severity floor as an actionable finding. `precise` raises the actionable bar: a single-source, uncorroborated, non-KEV vulnerability finding is quarantined into a needs-verify queue.

A quarantined finding is annotated and exempted from the CI `--fail-on` gate, but it stays in the result: reported in every deliverable, persisted, and evidence-sealed like any other. Nothing is removed, so a quarantined finding can never be hidden from a report or the tamper-evident chain. This reuses the same annotate-not-remove surface as `.synapseignore` and in-scan VEX.

Compared with Trivy, which drops imprecise matches, precise keeps full recall and simply separates the lower-confidence set into a verify queue, so an analyst can review it rather than having it silently gone.

### The safety invariants

- KEV findings (a CVE on CISA's Known Exploited Vulnerabilities list, actively exploited) are never quarantined. They stay actionable and keep tripping the gate.
- Multi-source (corroborated) findings are never quarantined.
- Only advisory-vulnerability findings are eligible. The deterministic first-party findings (SAST, secret, misconfig) and license findings are never quarantined.
- The default is `comprehensive`, so an existing deployment's gate is unchanged unless an operator opts into `precise`.

### The confidence signal

Corroboration across detection sources is the signal: a vulnerability found by two or more sources (for example OSV and Grype and the owned advisory store) is trusted; one found by a single source is routed to verify. Precise is therefore meaningful when multiple sources are configured; with a single source, nothing can be corroborated, which the mode reflects honestly rather than pretending otherwise.

### Wiring

`--detection-priority comprehensive|precise` on the CLI, defaulting to `SYNAPSE_DETECTION_PRIORITY`. The `--fail-on` gate exempts the needs-verify set, and the CLI surfaces the quarantined findings. The option is validated in `NormalizeScanOptions`. Deterministic, with no LLM, exec, or network in the path.

### Testing

- `applyDetectionPriority`: a single-source non-KEV vuln is quarantined; a multi-source, a KEV, and a first-party SAST finding all stay actionable; nothing is removed; the gate-exemption key set is exactly the quarantined set; comprehensive and empty priority are no-ops.
- `NormalizeScanOptions`: empty defaults to comprehensive, precise normalizes case-insensitively, an unknown value is rejected.
- End to end via the CLI on a real CVE: comprehensive fails `--fail-on high` (the CVE is corroborated by OSV and Grype); offline (Grype-only, single source) with precise quarantines it into needs-verify and exits 0; an invalid priority is rejected.
- `go build`, `go vet`, and the affected package tests pass; no SCA regression.

### Reviews

Reviewed for clean-architecture compliance (pure usecase/domain post-processing, no port needed, consistent with the sibling annotate-not-remove helpers) and for the project safety rules. The security review's central questions were whether a quarantined vuln can be hidden (no, by construction: annotate-not-remove, retained and sealed) and whether KEV is ever quarantined (no, it is explicitly excluded).
