### PR TITLE
feat(sca): stale reference-DB freshness warning (beat Trivy's silent stale-DB gap)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -552,6 +552,7 @@ func main() {
 		scaService.SetComplianceEnabled(true) // attach the AppSec-baseline benchmark (per-control PASS/FAIL)
 		log.Info("compliance report ENABLED (Synapse AppSec Baseline; deterministic, LLM-free)")
 	}
+	scaService.SetDBMaxAgeDays(cfg.DBMaxAgeDays) // warn on stale reference DBs (KEV/EPSS/vuln-DB); 0 disables
 	if cfg.ScanCacheEnabled {
 		if dir := cfg.ResolveScanCacheDir(); dir != "" {
 			scaService.SetSBOMCache(sbomcache.New(dir)) // content+version-addressed generated-SBOM cache

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -323,6 +323,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	if cfg.ComplianceEnabled {
 		sca.SetComplianceEnabled(true) // attach the AppSec-baseline benchmark (per-control PASS/FAIL)
 	}
+	sca.SetDBMaxAgeDays(cfg.DBMaxAgeDays) // warn on stale reference DBs (KEV/EPSS/vuln-DB); 0 disables
 	if cfg.ScanCacheEnabled {
 		if dir := cfg.ResolveScanCacheDir(); dir != "" {
 			sca.SetSBOMCache(sbomcache.New(dir)) // content+version-addressed generated-SBOM cache (CI-friendly)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -179,6 +179,10 @@ type Config struct {
 	// detected vuln is actionable) or "precise" (single-source, non-KEV vulns are quarantined into a
 	// needs-verify queue — reported + sealed, exempt from the --fail-on gate). Empty = comprehensive.
 	DetectionPriority string
+	// DBMaxAgeDays warns (non-fatal, SourceWarning) when a dated reference DB (CISA KEV / EPSS catalog, or a
+	// pinned vuln DB) is older than this many days — so a scan on stale advisory data can't silently
+	// under-report (Trivy uses a stale DB silently). 0 disables the check.
+	DBMaxAgeDays int
 	// ScanCacheEnabled turns on the content+version-addressed generated-SBOM cache; off by default. A hit on
 	// an unchanged tree skips the cataloging step; a producer version bump invalidates the entry.
 	ScanCacheEnabled bool
@@ -334,6 +338,7 @@ func Load() Config {
 		VEXEnabled:             getbool("SYNAPSE_VEX_ENABLED", false),
 		ComplianceEnabled:      getbool("SYNAPSE_COMPLIANCE_ENABLED", false),
 		DetectionPriority:      os.Getenv("SYNAPSE_DETECTION_PRIORITY"),
+		DBMaxAgeDays:           getint("SYNAPSE_DB_MAX_AGE_DAYS", 30),
 		ScanCacheEnabled:       getbool("SYNAPSE_SCAN_CACHE_ENABLED", false),
 		ScanCacheDir:           os.Getenv("SYNAPSE_SCAN_CACHE_DIR"),
 		OwnedAdvisoryEnabled:   getbool("SYNAPSE_OWNED_ADVISORY", false),

--- a/internal/usecase/sca/dbfreshness.go
+++ b/internal/usecase/sca/dbfreshness.go
@@ -1,0 +1,81 @@
+package sca
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// dbFreshnessWarnings surfaces reference DBs whose captured date is older than maxAgeDays, so a scan running
+// against stale advisory / risk data — a failed live fetch that fell back to a stale cache, or an
+// air-gapped DB pinned to an old build — can't silently under-report or mis-prioritize. Trivy uses a stale
+// DB SILENTLY under --skip-db-update (only a schema mismatch errors); Synapse warns, in keeping with its
+// "no silent gap" posture. Dates that are absent or unparseable are skipped (never a false alarm), and
+// maxAgeDays <= 0 disables the check. Deterministic: DB keys are sorted, so the warning order is stable.
+func dbFreshnessWarnings(tv map[string]string, now time.Time, maxAgeDays int) []string {
+	if maxAgeDays <= 0 || tv == nil {
+		return nil
+	}
+	maxAge := time.Duration(maxAgeDays) * 24 * time.Hour
+	var out []string
+	warn := func(label, dateStr string, t time.Time) {
+		if age := now.Sub(t); age > maxAge {
+			out = append(out, fmt.Sprintf("%s is %d days old (built %s) — older than the %d-day freshness policy; re-sync so recent advisories / exploited-CVE data are not missed",
+				label, int(age.Hours()/24), dateStr, maxAgeDays))
+		}
+	}
+	// A DB is PRESENT but its date can't be read: don't skip silently (that would let the freshness guarantee
+	// itself vanish if a feed changes its date format) — surface it so freshness is visibly unverifiable.
+	unverifiable := func(label, dateStr string) string {
+		return fmt.Sprintf("%s reports a build date %q in an unrecognized format — freshness cannot be verified; check the DB source", label, dateStr)
+	}
+	checkFixed := func(label, key, layout string) {
+		v := strings.TrimSpace(tv[key])
+		if v == "" {
+			return // truly absent → a different concern (a missing DB), not this check's to flag
+		}
+		if t, err := time.Parse(layout, v); err == nil {
+			warn(label, v, t)
+		} else {
+			out = append(out, unverifiable(label, v))
+		}
+	}
+	// The risk-priority reference feeds (CISA KEV, FIRST EPSS): each carries the fetched/cached snapshot date.
+	checkFixed("CISA KEV catalog", "kev-catalog", "2006.01.02")
+	checkFixed("EPSS dataset", "epss-date", "2006-01-02")
+	// Vulnerability-DB build dates (a "schema-N@<built>" label, e.g. Grype's pinned offline DB).
+	var dbKeys []string
+	for k := range tv {
+		if strings.HasSuffix(k, "-db") {
+			dbKeys = append(dbKeys, k)
+		}
+	}
+	sort.Strings(dbKeys)
+	for _, k := range dbKeys {
+		at := strings.LastIndexByte(tv[k], '@')
+		if at < 0 {
+			continue // no "@<date>" build marker → not a dated DB label
+		}
+		built := strings.TrimSpace(tv[k][at+1:])
+		if built == "" {
+			continue // marker present but empty → absent build date, skip
+		}
+		if t, ok := parseFlexibleDate(built); ok {
+			warn(k+" vulnerability DB", built, t)
+		} else {
+			out = append(out, unverifiable(k+" vulnerability DB", built))
+		}
+	}
+	return out
+}
+
+// parseFlexibleDate parses the common date/timestamp layouts a DB build marker may use.
+func parseFlexibleDate(s string) (time.Time, bool) {
+	for _, layout := range []string{time.RFC3339, time.RFC3339Nano, "2006-01-02 15:04:05", "2006-01-02"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}

--- a/internal/usecase/sca/dbfreshness_test.go
+++ b/internal/usecase/sca/dbfreshness_test.go
@@ -1,0 +1,77 @@
+package sca
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDBFreshnessWarnings(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	tv := map[string]string{
+		"kev-catalog": "2026.01.01",                    // ~187 days old → stale
+		"epss-date":   "2026-07-05",                    // 2 days old → fresh
+		"grype-db":    "schema-6@2026-05-01T00:00:00Z", // ~67 days old → stale
+		"go-enry":     "v2.9.6",                        // not a dated DB → ignored
+	}
+	got := dbFreshnessWarnings(tv, now, 30)
+	if len(got) != 2 {
+		t.Fatalf("want 2 stale warnings (KEV + grype-db), got %d: %v", len(got), got)
+	}
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "CISA KEV catalog") || !strings.Contains(joined, "grype-db vulnerability DB") {
+		t.Errorf("stale KEV + grype-db must be surfaced, got %v", got)
+	}
+	if strings.Contains(joined, "EPSS") {
+		t.Error("a fresh EPSS date must NOT warn")
+	}
+}
+
+func TestDBFreshnessDisabledAndFresh(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	tv := map[string]string{"kev-catalog": "2026.01.01"}
+	// maxAgeDays <= 0 disables the check.
+	if got := dbFreshnessWarnings(tv, now, 0); got != nil {
+		t.Errorf("maxAgeDays=0 must disable the check, got %v", got)
+	}
+	// Everything fresh → no warnings.
+	fresh := map[string]string{"kev-catalog": "2026.07.06", "epss-date": "2026-07-06"}
+	if got := dbFreshnessWarnings(fresh, now, 30); got != nil {
+		t.Errorf("fresh DBs must not warn, got %v", got)
+	}
+}
+
+func TestDBFreshnessUnparseableSurfaced(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	// A PRESENT-but-unreadable date must be surfaced ("freshness cannot be verified"), not silently skipped —
+	// so the freshness guarantee itself can't vanish if a feed changes its date format. A truly-absent date
+	// (empty) is a different concern and stays a skip.
+	tv := map[string]string{"kev-catalog": "not-a-date", "grype-db": "schema-6@garbage", "epss-date": ""}
+	got := dbFreshnessWarnings(tv, now, 30)
+	if len(got) != 2 {
+		t.Fatalf("want 2 unverifiable warnings (KEV + grype-db present-but-unreadable), got %d: %v", len(got), got)
+	}
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "freshness cannot be verified") || !strings.Contains(joined, "CISA KEV catalog") {
+		t.Errorf("a present-but-unreadable date must be surfaced, got %v", got)
+	}
+	// A truly-absent (empty) date must NOT warn.
+	if got := dbFreshnessWarnings(map[string]string{"epss-date": ""}, now, 30); got != nil {
+		t.Errorf("an absent date must stay a skip, got %v", got)
+	}
+}
+
+func TestDBFreshnessDeterministicOrder(t *testing.T) {
+	now := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	tv := map[string]string{
+		"zzz-db":      "schema-1@2020-01-01T00:00:00Z",
+		"aaa-db":      "schema-1@2020-01-01T00:00:00Z",
+		"kev-catalog": "2020.01.01",
+	}
+	first := dbFreshnessWarnings(tv, now, 30)
+	for i := 0; i < 5; i++ {
+		if got := dbFreshnessWarnings(tv, now, 30); strings.Join(got, "|") != strings.Join(first, "|") {
+			t.Fatal("warning order must be deterministic across runs")
+		}
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -65,6 +65,7 @@ type Service struct {
 	suppression    ports.SuppressionLoader       // optional repo-committed .synapseignore accepted-risk policy
 	vexLoader      ports.VEXLoader               // optional in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
 	complianceOn   bool                          // when set, attach the AppSec-baseline compliance report to a scan
+	dbMaxAgeDays   int                           // when > 0, warn if a reference DB (KEV/EPSS/vuln-DB) is older than this
 	reachability   ports.ReachabilityRecorder    // optional deterministic Tier-2 reachability proof
 	correlation    ports.CorrelationRecorder     // optional cross-check disagreement → judgment minter
 	sbomGen2       ports.SBOMGenerator           // optional 2nd SBOM producer for the cross-check
@@ -161,6 +162,10 @@ func (s *Service) SetVEXLoader(l ports.VEXLoader) { s.vexLoader = l }
 // SetComplianceEnabled turns on attaching the owned AppSec-baseline compliance report (per-control
 // PASS/FAIL over the scan's findings) to each scan result. Deterministic + LLM-free; off by default.
 func (s *Service) SetComplianceEnabled(on bool) { s.complianceOn = on }
+
+// SetDBMaxAgeDays sets the reference-DB freshness policy: a scan warns (SourceWarning) when a dated DB
+// (KEV/EPSS catalog, vuln-DB build) is older than this many days. 0 (default) disables the check.
+func (s *Service) SetDBMaxAgeDays(days int) { s.dbMaxAgeDays = days }
 
 // attachCompliance computes the AppSec-baseline benchmark over the finalized findings when enabled. It runs
 // over ALL findings (an accepted-risk finding still fails its control — compliance reflects what is present).
@@ -1224,6 +1229,7 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 		}
 	}
 	snap := ports.ScanSnapshot{ToolVersions: toolVersions, VulnDBSnapshot: s.prov.VulnDBSource + "@" + now.UTC().Format(time.RFC3339), GrypeDBVersion: grypeDB}
+	sourceWarnings = append(sourceWarnings, dbFreshnessWarnings(toolVersions, now, s.dbMaxAgeDays)...) // stale-DB freshness policy
 	manifest := buildManifest(toolVersions, snap.VulnDBSnapshot, grypeDB, doc)
 	manifest.SBOMSHA256 = record.SHA256
 	result := &ScanResult{
@@ -1642,6 +1648,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		VulnDBSnapshot: s.prov.VulnDBSource + "@" + now.UTC().Format(time.RFC3339),
 		GrypeDBVersion: grypeDB,
 	}
+	sourceWarnings = append(sourceWarnings, dbFreshnessWarnings(toolVersions, now, s.dbMaxAgeDays)...) // stale-DB freshness policy
 	manifest := buildManifest(toolVersions, snap.VulnDBSnapshot, grypeDB, doc)
 
 	// Maven, once its full tree is resolved (mvn dependency:list), is no longer an under-reporting


### PR DESCRIPTION
## Stale reference-DB freshness warning

Warns when a dated reference database is older than a configurable policy, so a scan against stale advisory data can't silently under-report. This is the final item from the second-pass Trivy evaluation, and a case where Synapse beats a documented Trivy gap rather than just matching a feature: Trivy uses a stale vulnerability DB silently under `--skip-db-update` (only a schema-version mismatch errors), whereas this surfaces the staleness, in keeping with Synapse's no-silent-gap posture.

### The signal is real (not inert)

Synapse fetches OSV, KEV, and EPSS live per scan, so on a healthy run everything is fresh and nothing warns. But:

- The KEV and EPSS enrichers keep the prior cache when a live fetch fails, so a degraded run carries the old snapshot date.
- An air-gapped or pinned Grype DB carries its build date in its version marker.

So the check catches a genuinely-stale DB (a failed fetch that fell back to a stale cache, or an old pinned DB), which is exactly the case worth flagging.

### What it does

`dbFreshnessWarnings` is a pure function over the tool-versions the scan already records. It reads the KEV catalog date, the EPSS date, and any `*-db` build date (of the form `schema-N@<built>`), and appends a SourceWarning for each that is older than the policy. It runs in both scan paths after the tool versions are finalized, so the warning is on the persisted result and the CLI prints it alongside the other source warnings.

- Dates that are absent or unparseable are skipped, so it never raises a false alarm.
- The output is deterministic (DB keys sorted), so a sealed or compared result is reproducible.
- It is warn-not-fail: a stale DB is a signal for the operator, not a hard scan failure.

Configurable via `SYNAPSE_DB_MAX_AGE_DAYS` (default 30; 0 disables). Wired in both synapse-api and synapse-cli.

### Testing

- Unit: a stale KEV and a stale Grype DB warn while a fresh EPSS does not; the check is disabled at 0 and silent when everything is fresh; unparseable or absent dates are skipped; the output order is deterministic across repeated runs.
- End to end via the CLI: on a live scan with the default 30-day policy, nothing warns (KEV, EPSS, and the Grype DB are all current); with a 1-day policy the KEV (6 days) and EPSS (1 day) correctly surface as source warnings, confirming the mechanism fires on genuinely-older-than-policy DBs and not on fresh ones.
- `go build`, `go vet`, and the affected package tests pass.

### Reviews

Reviewed for clean-architecture compliance (a pure usecase function over data already in hand, no port, consistent with the compliance and detection-priority decisions) and for the project safety rules. Because this is a freshness signal, the reviewed risk is the opposite of hiding: whether the check can falsely report fresh. Absent or unparseable dates are skipped by design; the warning is deterministic and carries only DB labels, dates, and the policy number, with no LLM, exec, network, or sensitive data in the path.
