### PR TITLE
feat(sbom): NTIA minimum-elements + semantic SBOM quality score

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -417,6 +417,18 @@ func printReport(target string, res *scauc.ScanResult) {
 			fmt.Printf("    %-12s %d/%d resolved\n", c.Ecosystem, c.Resolved, c.Components)
 		}
 	}
+	if q := res.SBOMQuality; len(q.Elements) > 0 { // NTIA + semantic describe-quality of the SBOM (distinct from coverage)
+		mark := "NTIA minimum elements present"
+		if !q.NTIAMet {
+			mark = "! NTIA GAPS"
+		}
+		fmt.Printf("  sbom quality: %d/100 (NTIA %d/100) — %s\n", q.Score, q.NTIAScore, mark)
+		for _, e := range q.Elements { // surface each thin dimension so the gap is actionable, not just a number
+			if e.Score < 100 && e.Detail != "" {
+				fmt.Printf("    %-26s %3d/100 — %s\n", e.Label, e.Score, e.Detail)
+			}
+		}
+	}
 	fmt.Printf("  vulnerabilities: %d", len(res.Vulnerabilities))
 	if counts := countVulnSeverity(res); counts != "" {
 		fmt.Printf(" (%s)", counts)

--- a/internal/domain/sbom/quality.go
+++ b/internal/domain/sbom/quality.go
@@ -1,0 +1,292 @@
+package sbom
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SBOM QUALITY scoring — a first-class, surfaced measure of how well a PRODUCED SBOM describes its
+// components, scored against the NTIA "minimum elements" (NTIA 2021, the baseline EO 14028 / EU CRA
+// consumers increasingly require) plus a few CycloneDX/SPDX semantic-quality checks. It is deliberately
+// DISTINCT from Completeness: Completeness judges scan COVERAGE ("did we capture the dependencies");
+// QualityReport judges the DOCUMENT ("are the captured components described well enough to act on, share,
+// or satisfy a regulatory minimum"). A thin SBOM that omits suppliers or checksums is a supply-chain risk
+// even when coverage is perfect, so — per Synapse's "no silent gap" posture — that shortfall is measured
+// and reported rather than assumed away. The scorer is pure + deterministic (no I/O, sorted output):
+// same SBOM ⇒ same report.
+//
+// This is Synapse's own take on what interlynk's `sbomqs` does; the checks are reimplemented over the
+// native domain model, not delegated to any external tool.
+
+// QualityCategory groups the scored elements.
+const (
+	QualityCategoryNTIA     = "ntia"     // an NTIA-2021 minimum element
+	QualityCategorySemantic = "semantic" // a CycloneDX/SPDX describe-quality check beyond the NTIA floor
+)
+
+// NTIAThreshold is the per-element score (0..100) at or above which an NTIA minimum element is treated as
+// satisfied for the SBOM as a whole. It is intentionally strict-but-not-perfect: a handful of components
+// missing a field should visibly lower the element, but one un-decodable PURL should not fail an otherwise
+// complete SBOM. Callers wanting a hard gate compare QualityReport.NTIAScore against their own bar.
+const NTIAThreshold = 90
+
+// QualityElement is one scored quality dimension. For component-level checks, Present/Total are component
+// counts; for document-level checks (author, timestamp, dependency relationships) Total is 1 and Present is
+// 0 or 1. Score is round(100*Present/Total), or 0 when Total is 0 (an empty SBOM describes nothing).
+type QualityElement struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	Category string `json:"category"`
+	Present  int    `json:"present"`
+	Total    int    `json:"total"`
+	Score    int    `json:"score"`            // 0..100 for this element
+	Detail   string `json:"detail,omitempty"` // short, human explanation when Score < 100
+}
+
+// QualityReport is the overall SBOM-quality verdict: a blended 0..100 Score (NTIA weighted over semantic),
+// an NTIA-only sub-score, whether every NTIA element clears NTIAThreshold, and the per-element breakdown so
+// exactly which dimension is thin stays visible. A caller reads QualityReport from ScanResult.SBOMQuality;
+// gate on len(Elements) > 0 to tell "not computed" (a recon-only / nil-SBOM run) from a real 0 score.
+type QualityReport struct {
+	// Score is a HUMAN HEADLINE only. A hard gate MUST key off NTIAMet / NTIAScore, never Score: Score blends
+	// in semantic quality, so on its own it must never read "passing" while a mandatory NTIA element is
+	// absent. It is therefore clamped below NTIAThreshold whenever NTIAMet is false.
+	Score     int              `json:"score"`      // blended 0..100 (NTIA 70% + semantic 30%), clamped < NTIAThreshold when !NTIAMet
+	NTIAScore int              `json:"ntia_score"` // mean of the NTIA element scores, 0..100
+	NTIAMet   bool             `json:"ntia_met"`   // every NTIA element Score >= NTIAThreshold
+	Elements  []QualityElement `json:"elements"`
+	Summary   string           `json:"summary"`
+}
+
+// Quality scores an SBOM against the NTIA minimum elements and semantic-quality checks. Pure + deterministic.
+func Quality(s SBOM) QualityReport {
+	n := len(s.Components)
+	// Component-level tallies (single pass).
+	var withSupplier, withName, withVersionField, withPURL, withLicense, withSPDXLicense, withChecksum int
+	for _, c := range s.Components {
+		if SupplierFromPURL(c.PURL) != "" {
+			withSupplier++
+		}
+		if strings.TrimSpace(c.Name) != "" {
+			withName++
+		}
+		if strings.TrimSpace(c.Version) != "" { // NTIA "version" = the field is populated; pinned-ness is Completeness's job
+			withVersionField++
+		}
+		if strings.TrimSpace(c.PURL) != "" {
+			withPURL++
+		}
+		if len(c.Licenses) > 0 {
+			withLicense++
+			for _, l := range c.Licenses {
+				if strings.TrimSpace(l.SPDXID) != "" {
+					withSPDXLicense++
+					break
+				}
+			}
+		}
+		if strings.TrimSpace(c.SHA1) != "" {
+			withChecksum++
+		}
+	}
+
+	comp := func(id, label, category string, present int, missingHint string) QualityElement {
+		e := QualityElement{ID: id, Label: label, Category: category, Present: present, Total: n, Score: ratioScore(present, n)}
+		if e.Score < 100 {
+			if n == 0 {
+				e.Detail = "SBOM has no components to describe"
+			} else {
+				e.Detail = fmt.Sprintf("%d of %d components %s", n-present, n, missingHint)
+			}
+		}
+		return e
+	}
+	doc := func(id, label string, ok bool, missing string) QualityElement {
+		e := QualityElement{ID: id, Label: label, Category: QualityCategoryNTIA, Present: b2i(ok), Total: 1, Score: b2i(ok) * 100}
+		if !ok {
+			e.Detail = missing
+		}
+		return e
+	}
+
+	elements := []QualityElement{
+		// NTIA minimum elements (NTIA 2021).
+		comp("ntia-supplier", "Supplier name", QualityCategoryNTIA, withSupplier, "have no resolvable supplier (no PURL namespace)"),
+		comp("ntia-name", "Component name", QualityCategoryNTIA, withName, "have no name"),
+		comp("ntia-version", "Version", QualityCategoryNTIA, withVersionField, "have no version"),
+		comp("ntia-uniqid", "Unique identifier (PURL)", QualityCategoryNTIA, withPURL, "have no PURL"),
+		doc("ntia-dependencies", "Dependency relationships", len(s.Dependencies) > 0,
+			"the SBOM expresses no dependency-graph relationships (a flat component list)"),
+		doc("ntia-author", "Author of SBOM data", strings.TrimSpace(s.Source) != "", "the SBOM records no author/generator"),
+		doc("ntia-timestamp", "Timestamp", !s.Audit.CreatedAt.IsZero(), "the SBOM records no creation timestamp"),
+		// Semantic quality beyond the NTIA floor.
+		comp("sem-license", "License present", QualityCategorySemantic, withLicense, "have no license"),
+		comp("sem-license-spdx", "License is an SPDX id", QualityCategorySemantic, withSPDXLicense, "have no SPDX-valid license id"),
+		comp("sem-checksum", "Checksum (SHA-1)", QualityCategorySemantic, withChecksum, "have no checksum"),
+	}
+	sort.SliceStable(elements, func(i, j int) bool {
+		if elements[i].Category != elements[j].Category {
+			return elements[i].Category < elements[j].Category // "ntia" before "semantic"
+		}
+		return elements[i].ID < elements[j].ID
+	})
+
+	r := QualityReport{Elements: elements}
+	r.NTIAScore, r.NTIAMet = ntiaScore(elements)
+	// semantic checks are always present in the fixed element list above; the hasSem guard is kept so a
+	// future rubric change that drops them can't divide by zero.
+	if semScore, hasSem := categoryMean(elements, QualityCategorySemantic); hasSem {
+		r.Score = roundDiv(r.NTIAScore*70+semScore*30, 100)
+	} else {
+		r.Score = r.NTIAScore
+	}
+	// The blended headline must never read "passing" while a mandatory NTIA element is absent: clamp it below
+	// the threshold whenever NTIAMet is false, so a gate that (wrongly) keys off Score still can't be fooled
+	// by strong semantic quality masking a missing minimum element. NTIAScore/NTIAMet carry the full truth.
+	if !r.NTIAMet && r.Score >= NTIAThreshold {
+		r.Score = NTIAThreshold - 1
+	}
+	r.Summary = qualitySummary(r)
+	return r
+}
+
+// ntiaScore returns the mean of the NTIA element scores and whether every one clears NTIAThreshold.
+func ntiaScore(elements []QualityElement) (score int, met bool) {
+	mean, has := categoryMean(elements, QualityCategoryNTIA)
+	met = has
+	for _, e := range elements {
+		if e.Category == QualityCategoryNTIA && e.Score < NTIAThreshold {
+			met = false
+		}
+	}
+	return mean, met
+}
+
+// categoryMean averages the element scores in a category; has is false when the category has no elements.
+func categoryMean(elements []QualityElement, category string) (mean int, has bool) {
+	sum, count := 0, 0
+	for _, e := range elements {
+		if e.Category == category {
+			sum += e.Score
+			count++
+		}
+	}
+	if count == 0 {
+		return 0, false
+	}
+	return roundDiv(sum, count), true
+}
+
+func qualitySummary(r QualityReport) string {
+	if r.NTIAMet {
+		return fmt.Sprintf("SBOM quality %d/100 (NTIA %d/100 — all minimum elements present).", r.Score, r.NTIAScore)
+	}
+	// Name the weakest NTIA elements so the shortfall is actionable, not just a number.
+	var weak []string
+	for _, e := range r.Elements {
+		if e.Category == QualityCategoryNTIA && e.Score < NTIAThreshold {
+			weak = append(weak, e.Label)
+		}
+	}
+	return fmt.Sprintf("SBOM quality %d/100 (NTIA %d/100 — below the %d threshold on: %s).",
+		r.Score, r.NTIAScore, NTIAThreshold, strings.Join(weak, ", "))
+}
+
+// SupplierFromPURL derives a component's supplier from its PURL namespace — the segment(s) between the PURL
+// type and the package name (a Maven groupId, an npm scope, a GitHub org, a Docker image owner, ...), which
+// the PURL spec defines as "a name prefix such as a Maven groupId, a Docker image owner, a GitHub user or
+// organization". It is a conservative, deterministic attribution: a PURL with no namespace (e.g. a bare npm
+// package like "pkg:npm/leftpad@1.0.0") yields "" rather than a guess. Used to score the NTIA supplier
+// element without inventing data.
+func SupplierFromPURL(purl string) string {
+	p := strings.TrimSpace(purl)
+	const prefix = "pkg:"
+	if !strings.HasPrefix(p, prefix) {
+		return ""
+	}
+	rest := p[len(prefix):]
+	// Drop the type: "type/namespace.../name@version" -> "namespace.../name@version".
+	slash := strings.IndexByte(rest, '/')
+	if slash <= 0 {
+		return "" // no "/" after type => no namespace, just a bare name
+	}
+	rest = rest[slash+1:]
+	// Strip qualifiers / version / subpath so they can't leak into the namespace.
+	for _, sep := range []byte{'@', '?', '#'} {
+		if i := strings.IndexByte(rest, sep); i >= 0 {
+			rest = rest[:i]
+		}
+	}
+	last := strings.LastIndexByte(rest, '/')
+	if last <= 0 {
+		return "" // only a name, no namespace
+	}
+	return purlDecode(rest[:last])
+}
+
+// purlDecode percent-decodes the small set of escapes a PURL namespace realistically carries (notably
+// "%40" for the "@" in an npm scope), without pulling in net/url for a hot, pure path.
+func purlDecode(s string) string {
+	if !strings.ContainsRune(s, '%') {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '%' && i+2 < len(s) {
+			if h, ok := hexByte(s[i+1], s[i+2]); ok {
+				b.WriteByte(h)
+				i += 2
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func hexByte(a, b byte) (byte, bool) {
+	hi, ok1 := hexNibble(a)
+	lo, ok2 := hexNibble(b)
+	if !ok1 || !ok2 {
+		return 0, false
+	}
+	return hi<<4 | lo, true
+}
+
+func hexNibble(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}
+
+// ratioScore is floor(100*present/total), or 0 when total is 0. Floor (not round) so an element can never
+// round UP across NTIAThreshold: 89.9% coverage scores 89, staying honestly below a 90 bar rather than
+// clearing it, which keeps the NTIAMet gate exact (no ~0.5% of slack).
+func ratioScore(present, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	return present * 100 / total // integer division truncates toward zero == floor for non-negative inputs
+}
+
+// roundDiv divides with round-half-up (non-negative inputs).
+func roundDiv(a, b int) int {
+	if b == 0 {
+		return 0
+	}
+	return (a + b/2) / b
+}
+
+func b2i(ok bool) int {
+	if ok {
+		return 1
+	}
+	return 0
+}

--- a/internal/domain/sbom/quality_test.go
+++ b/internal/domain/sbom/quality_test.go
@@ -1,0 +1,188 @@
+package sbom
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSupplierFromPURL(t *testing.T) {
+	cases := map[string]string{
+		"pkg:maven/org.apache.commons/commons-lang3@3.12.0": "org.apache.commons", // Maven groupId
+		"pkg:npm/%40angular/core@17.0.0":                    "@angular",           // npm scope, percent-decoded
+		"pkg:golang/github.com/gin-gonic/gin@v1.9.1":        "github.com/gin-gonic",
+		"pkg:npm/leftpad@1.0.0":                             "", // bare name, no namespace => no guess
+		"pkg:pypi/requests@2.31.0":                          "", // pypi has no namespace
+		"":                                                  "",
+		"not-a-purl":                                        "",
+		"pkg:":                                              "",
+		"pkg:deb/debian/curl@7.88.1?arch=amd64":             "debian", // qualifiers stripped
+	}
+	for in, want := range cases {
+		if got := SupplierFromPURL(in); got != want {
+			t.Errorf("SupplierFromPURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func fullComponent() Component {
+	return Component{
+		Name:     "gin",
+		Version:  "v1.9.1",
+		PURL:     "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+		Licenses: []License{{Name: "MIT", SPDXID: "MIT"}},
+		SHA1:     "0123456789abcdef0123456789abcdef01234567",
+	}
+}
+
+func TestQualityFullSBOMMeetsNTIA(t *testing.T) {
+	doc := SBOM{
+		Source:       "synapse",
+		Components:   []Component{fullComponent()},
+		Dependencies: []Dependency{{Ref: "gin", DependsOn: []string{}}},
+	}
+	doc.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+
+	r := Quality(doc)
+	if !r.NTIAMet {
+		t.Fatalf("a fully-described SBOM must meet NTIA, got %d/100 not met: %s", r.NTIAScore, r.Summary)
+	}
+	if r.NTIAScore != 100 {
+		t.Errorf("NTIAScore = %d, want 100", r.NTIAScore)
+	}
+	if r.Score != 100 {
+		t.Errorf("blended Score = %d, want 100 (all semantic present too)", r.Score)
+	}
+	if !strings.Contains(r.Summary, "all minimum elements present") {
+		t.Errorf("summary should confirm NTIA met, got %q", r.Summary)
+	}
+}
+
+func TestQualityThinSBOMSurfacesGaps(t *testing.T) {
+	// Names only: no supplier (no PURL), no version, no PURL, no license, no checksum,
+	// no dependency graph. Author + timestamp present at the doc level.
+	doc := SBOM{
+		Source:     "synapse",
+		Components: []Component{{Name: "mystery"}, {Name: "other"}},
+	}
+	doc.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+
+	r := Quality(doc)
+	if r.NTIAMet {
+		t.Fatal("a names-only SBOM must NOT meet NTIA")
+	}
+	byID := map[string]QualityElement{}
+	for _, e := range r.Elements {
+		byID[e.ID] = e
+	}
+	if byID["ntia-name"].Score != 100 {
+		t.Errorf("both components are named, want name score 100, got %d", byID["ntia-name"].Score)
+	}
+	for _, id := range []string{"ntia-supplier", "ntia-version", "ntia-uniqid", "sem-license", "sem-checksum"} {
+		if byID[id].Score != 0 {
+			t.Errorf("%s should score 0 for a names-only SBOM, got %d", id, byID[id].Score)
+		}
+		if byID[id].Detail == "" {
+			t.Errorf("%s below 100 must carry an explanatory Detail", id)
+		}
+	}
+	if byID["ntia-dependencies"].Score != 0 {
+		t.Errorf("a flat list has no dependency relationships, want 0, got %d", byID["ntia-dependencies"].Score)
+	}
+	if byID["ntia-author"].Score != 100 || byID["ntia-timestamp"].Score != 100 {
+		t.Error("author + timestamp are present at the doc level and must score 100")
+	}
+	if !strings.Contains(r.Summary, "Supplier name") || !strings.Contains(r.Summary, "below the") {
+		t.Errorf("summary should name the weak NTIA elements, got %q", r.Summary)
+	}
+}
+
+func TestQualityPartialRatio(t *testing.T) {
+	// One of two components fully described, the other bare — element scores should be 50.
+	doc := SBOM{
+		Source:     "synapse",
+		Components: []Component{fullComponent(), {Name: "bare"}},
+	}
+	doc.Audit.CreatedAt = time.Now().UTC()
+	r := Quality(doc)
+	byID := map[string]QualityElement{}
+	for _, e := range r.Elements {
+		byID[e.ID] = e
+	}
+	if got := byID["ntia-supplier"].Score; got != 50 {
+		t.Errorf("supplier present on 1 of 2 components, want 50, got %d", got)
+	}
+	if got := byID["sem-license"].Score; got != 50 {
+		t.Errorf("license present on 1 of 2, want 50, got %d", got)
+	}
+	if !strings.Contains(byID["ntia-supplier"].Detail, "1 of 2 components") {
+		t.Errorf("detail should quantify the gap, got %q", byID["ntia-supplier"].Detail)
+	}
+}
+
+func TestQualityScoreClampedWhenNTIAUnmet(t *testing.T) {
+	// A component fully described EXCEPT supplier (a bare-namespace PURL): every semantic check passes, so
+	// the raw blend lands at the threshold — but a missing NTIA minimum element must keep the headline Score
+	// visibly below NTIAThreshold so a gate that (wrongly) keys off Score can't read it as passing.
+	doc := SBOM{
+		Source: "synapse",
+		Components: []Component{{
+			Name:     "requests",
+			Version:  "2.31.0",
+			PURL:     "pkg:pypi/requests@2.31.0", // pypi has no namespace => supplier unresolved
+			Licenses: []License{{Name: "Apache-2.0", SPDXID: "Apache-2.0"}},
+			SHA1:     "0123456789abcdef0123456789abcdef01234567",
+		}},
+		Dependencies: []Dependency{{Ref: "requests"}},
+	}
+	doc.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+
+	r := Quality(doc)
+	if r.NTIAMet {
+		t.Fatal("a supplier-less SBOM must not meet NTIA")
+	}
+	if r.Score >= NTIAThreshold {
+		t.Errorf("Score must be clamped below NTIAThreshold (%d) when NTIA is unmet, got %d", NTIAThreshold, r.Score)
+	}
+}
+
+func TestQualityEmptySBOMScoresZeroNotPanic(t *testing.T) {
+	r := Quality(SBOM{}) // no source, no timestamp, no components
+	if r.Score != 0 {
+		t.Errorf("an empty SBOM should score 0, got %d", r.Score)
+	}
+	if r.NTIAMet {
+		t.Error("an empty SBOM cannot meet NTIA")
+	}
+	// Component-level elements must report the empty case explicitly, not silently pass.
+	for _, e := range r.Elements {
+		if e.Total == 0 && e.Detail == "" {
+			t.Errorf("component element %s over an empty SBOM must carry a Detail", e.ID)
+		}
+	}
+}
+
+func TestQualityDeterministicOrder(t *testing.T) {
+	doc := SBOM{Source: "synapse", Components: []Component{fullComponent()}}
+	doc.Audit.CreatedAt = time.Now().UTC()
+	first := Quality(doc)
+	var ids []string
+	for _, e := range first.Elements {
+		ids = append(ids, e.ID)
+	}
+	joined := strings.Join(ids, "|")
+	for i := 0; i < 5; i++ {
+		got := Quality(doc)
+		var gotIDs []string
+		for _, e := range got.Elements {
+			gotIDs = append(gotIDs, e.ID)
+		}
+		if strings.Join(gotIDs, "|") != joined {
+			t.Fatal("element order must be deterministic")
+		}
+	}
+	// NTIA category must sort before semantic.
+	if !strings.HasPrefix(first.Elements[0].Category, QualityCategoryNTIA) {
+		t.Errorf("first element should be NTIA, got %q", first.Elements[0].Category)
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -359,6 +359,13 @@ type ScanResult struct {
 	// ecosystem, so a thin / partially-resolved ecosystem is VISIBLE rather than hidden behind the single
 	// global Completeness number ("no silent gap").
 	Coverage []sbom.EcosystemCoverage `json:"coverage"`
+	// SBOMQuality scores the produced SBOM against the NTIA minimum elements + semantic-quality checks —
+	// how well the components are DESCRIBED (supplier, unique id, checksum, license, dependency graph, ...),
+	// distinct from Completeness (which judges scan COVERAGE). Surfaced so a thin, hard-to-share, or
+	// non-regulation-minimum SBOM is a visible signal rather than a silent assumption. A consumer gates on
+	// len(.Elements) > 0 (a nil-SBOM / recon-only run leaves it zero-valued = "not computed", not "graded 0"),
+	// and any hard pass/fail gate keys off .NTIAMet / .NTIAScore, never the blended .Score.
+	SBOMQuality sbom.QualityReport `json:"sbom_quality"`
 	// ReproDigest is a stable content fingerprint of the reproducible output: same target + pinned
 	// producer + pinned advisory/DB snapshot ⇒ same digest. Excludes timestamps + per-run metadata.
 	ReproDigest string                 `json:"repro_digest"`
@@ -1257,6 +1264,7 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 	trace.succeed(step, "Findings derived", map[string]int{"vulnerabilities": len(vulns), "licenses": len(lics), "findings": len(result.Findings)})
 	result.DebugEvents = trace.snapshot()
 	result.Coverage = sbom.CoverageByEcosystem(*result.SBOM)
+	result.SBOMQuality = sbom.Quality(*result.SBOM)
 	result.ReproDigest = ReproDigest(result)
 
 	if opts.scansVulnerabilities() && s.correlation != nil {
@@ -1746,6 +1754,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	result.DebugEvents = trace.snapshot()
 	if result.SBOM != nil {
 		result.Coverage = sbom.CoverageByEcosystem(*result.SBOM) // per-ecosystem coverage breakdown
+		result.SBOMQuality = sbom.Quality(*result.SBOM)          // NTIA + semantic describe-quality of the SBOM
 	}
 
 	// Deterministic Tier-2 reachability proof, best-effort + opt-in: prove which findings' affected


### PR DESCRIPTION
## What

Adds a native **SBOM quality score** graded against the NTIA 2021 minimum elements plus
semantic-quality checks, surfaced on the scan result and in the CLI. Learned from
interlynk's `sbomqs`, reimplemented over Synapse's own `domain/sbom` model (no external
tool, no LLM, no network).

## Why

`Completeness` already judges scan **coverage** ("did we capture the dependencies").
Nothing judged the **document** itself: are the captured components described well enough
to act on, share, or satisfy a regulatory minimum (EO 14028 / EU CRA)? A thin SBOM shipped
silently, which contradicts the no-silent-gap posture the rest of the pipeline holds. This
makes that axis visible.

## What it scores

- **NTIA minimum elements**: supplier, component name, version, unique id (PURL), dependency
  relationships, author, timestamp.
- **Semantic**: license present, license is an SPDX id, checksum (SHA-1).

Per element: `Present/Total` with a round 0..100 score and, when below 100, a short Detail
naming the gap. Overall = NTIA weighted 70% over semantic 30%; `NTIAScore` and an `NTIAMet`
boolean are reported **separately** so the blend can never mask a failing NTIA element.
`SupplierFromPURL` derives the supplier from the PURL namespace (a Maven groupId, an npm
scope, a GitHub org) and returns empty rather than guessing when there is no namespace.

## Properties

- Pure + deterministic (sorted output, no `time.Now` in the domain fn): same SBOM gives the
  same report. The new `ScanResult.SBOMQuality` field is not part of `ReproDigest`.
- An empty SBOM scores 0 (not a vacuous 100); every below-threshold element carries a Detail.

## Dogfooding

Scoring Synapse's own SBOM already flags real gaps: no creation timestamp, no component
checksums, and suppliers missing on components without a PURL namespace. A follow-up
populates those fields and emits supplier into the SPDX/CycloneDX output, and extends the
rubric toward the fuller sbomqs categories + per-profile pass/fail tables (NTIA-2025, SCVS).

## Test

`go test ./internal/domain/sbom/ ./internal/usecase/sca/` green; `go build ./...` + `go vet` clean.
New table tests cover a full SBOM (meets NTIA), a thin SBOM (gaps surfaced), partial ratios,
the empty case, `SupplierFromPURL` edge cases, and determinism.
