### PR TITLE
feat(sbom): stamp SBOM creation time (NTIA timestamp minimum element)

### DIFF
--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -1375,6 +1375,14 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 			_ = s.sbomCache.Store(ctx, ws.Dir, producerVer, doc) // best-effort; a store error never fails the scan
 		}
 	}
+	// Stamp the SBOM's creation time from the scan clock (an NTIA minimum element the producers don't set).
+	// Applied AFTER the cache block so it is the CURRENT scan's time on both a fresh generate and a cache hit
+	// (the cache stores component content, not this per-scan timestamp), and so a cached SBOM never carries a
+	// stale one. Excluded from ReproDigest, so it does not perturb reproducibility.
+	if doc != nil && doc.Audit.CreatedAt.IsZero() {
+		doc.Audit.CreatedAt = now
+		doc.Audit.UpdatedAt = now
+	}
 	trace.succeed(step, "SBOM generated", map[string]int{"components": countComponents(doc), "dependencies": len(doc.Dependencies), "cache_hit": boolToInt(cacheHit)})
 	// SBOM producer cross-check: when a 2nd producer is configured, diff the two RAW
 	// component sets — BEFORE enrichment, so it compares the PRODUCERS themselves, not a shared post-process —

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -178,6 +178,35 @@ func TestScanInScopeRunsAndAudits(t *testing.T) {
 	assertDebugEvent(t, res.DebugEvents, stageLicense, "license-policy", ports.ScanDebugSucceeded)
 }
 
+func TestScanStampsSBOMCreationTime(t *testing.T) {
+	// The producers (fakeSBOM here) return an SBOM with no creation time; the pipeline must stamp it from
+	// the scan clock so the NTIA "timestamp" minimum element is present on Synapse's own SBOM.
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	clkTime := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	svc := newSvc(repo, fakeClock{t: clkTime}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{})
+
+	res, err := svc.Scan(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if res.SBOM == nil {
+		t.Fatal("scan result has no SBOM")
+	}
+	if res.SBOM.Audit.CreatedAt.IsZero() {
+		t.Error("SBOM creation time (NTIA minimum element) must be stamped, got zero")
+	}
+	if !res.SBOM.Audit.CreatedAt.Equal(clkTime) {
+		t.Errorf("SBOM CreatedAt = %v, want scan clock %v", res.SBOM.Audit.CreatedAt, clkTime)
+	}
+	if q := res.SBOMQuality; q.Score > 0 { // and the quality scorer must now credit the timestamp element
+		for _, e := range q.Elements {
+			if e.ID == "ntia-timestamp" && e.Score != 100 {
+				t.Errorf("ntia-timestamp element = %d, want 100 once the SBOM is stamped", e.Score)
+			}
+		}
+	}
+}
+
 func TestScanUsesImportedSBOMWithoutAcquiringTarget(t *testing.T) {
 	store := memory.NewImportedSBOMStore()
 	data := []byte(`{"bomFormat":"CycloneDX","specVersion":"1.4","metadata":{"component":{"name":"product-service"}},"components":[{"name":"pkg","version":"1.0.0","purl":"pkg:npm/pkg@1.0.0","licenses":[{"license":{"id":"MIT"}}]}],"dependencies":[{"ref":"pkg:npm/pkg@1.0.0","dependsOn":[]}]}`)


### PR DESCRIPTION
feat(sbom): stamp SBOM creation time (NTIA timestamp minimum element)

The SBOM producers (owned parsers, Syft) return a document without a creation time, so
Synapse's own SBOM scored 0 on the NTIA "timestamp" minimum element the quality scorer
checks. The scan pipeline now stamps doc.Audit.CreatedAt from the scan clock, after the
SBOM cache block so it is the current scan's time on both a fresh generate and a cache hit
(the cache stores component content, not this per-scan timestamp) and a cached SBOM never
carries a stale one. Excluded from ReproDigest, so reproducibility is unaffected. Imported
SBOMs keep their own recorded creation time.

Dogfooding the repo's own SBOM: the NTIA score rises from 81 to 96 (timestamp 0 to 100).
