### PR TITLE
feat(sbom): capture + emit component Supplier (NTIA supplier element)

### DIFF
--- a/internal/domain/sbom/quality.go
+++ b/internal/domain/sbom/quality.go
@@ -65,7 +65,7 @@ func Quality(s SBOM) QualityReport {
 	// Component-level tallies (single pass).
 	var withSupplier, withName, withVersionField, withPURL, withLicense, withSPDXLicense, withChecksum int
 	for _, c := range s.Components {
-		if SupplierFromPURL(c.PURL) != "" {
+		if supplierOf(c) != "" {
 			withSupplier++
 		}
 		if strings.TrimSpace(c.Name) != "" {
@@ -112,7 +112,7 @@ func Quality(s SBOM) QualityReport {
 
 	elements := []QualityElement{
 		// NTIA minimum elements (NTIA 2021).
-		comp("ntia-supplier", "Supplier name", QualityCategoryNTIA, withSupplier, "have no resolvable supplier (no PURL namespace)"),
+		comp("ntia-supplier", "Supplier name", QualityCategoryNTIA, withSupplier, "have no declared or derivable supplier (no supplier field and no PURL namespace)"),
 		comp("ntia-name", "Component name", QualityCategoryNTIA, withName, "have no name"),
 		comp("ntia-version", "Version", QualityCategoryNTIA, withVersionField, "have no version"),
 		comp("ntia-uniqid", "Unique identifier (PURL)", QualityCategoryNTIA, withPURL, "have no PURL"),
@@ -191,6 +191,36 @@ func qualitySummary(r QualityReport) string {
 	}
 	return fmt.Sprintf("SBOM quality %d/100 (NTIA %d/100 — below the %d threshold on: %s).",
 		r.Score, r.NTIAScore, NTIAThreshold, strings.Join(weak, ", "))
+}
+
+// SupplierSource values record how a component's Supplier was obtained (see Component.SupplierSource).
+const (
+	SupplierDeclared = "declared" // asserted by the producer or an imported/untrusted client SBOM
+	SupplierDerived  = "derived"  // deterministically inferred by Synapse from the PURL namespace
+)
+
+// supplierOf returns a component's supplier: the explicitly-captured Supplier when the producer/imported SBOM
+// carried one, else one derived from the PURL namespace. Empty when neither yields one.
+func supplierOf(c Component) string { return SupplierOr(c.Supplier, c.PURL) }
+
+// SupplierOr prefers a producer-declared supplier name, falling back to the PURL-namespace derivation. It is
+// the single home for the "captured, else derived" rule so every producer (Syft, owned parsers, importer),
+// both SPDX exporters, and the scorer agree on how a component's supplier is resolved.
+func SupplierOr(declared, purl string) string {
+	s, _ := SupplierWithSource(declared, purl)
+	return s
+}
+
+// SupplierWithSource resolves a component's supplier AND reports its provenance: a non-blank declared value
+// wins as SupplierDeclared; else the PURL namespace is inferred as SupplierDerived; else ("", "").
+func SupplierWithSource(declared, purl string) (supplier, source string) {
+	if s := strings.TrimSpace(declared); s != "" {
+		return s, SupplierDeclared
+	}
+	if s := SupplierFromPURL(purl); s != "" {
+		return s, SupplierDerived
+	}
+	return "", ""
 }
 
 // SupplierFromPURL derives a component's supplier from its PURL namespace — the segment(s) between the PURL

--- a/internal/domain/sbom/quality_test.go
+++ b/internal/domain/sbom/quality_test.go
@@ -25,6 +25,51 @@ func TestSupplierFromPURL(t *testing.T) {
 	}
 }
 
+func TestSupplierOr(t *testing.T) {
+	// Declared supplier wins; else derive from the PURL namespace; else empty.
+	if got := SupplierOr("Acme Corp", "pkg:pypi/requests@2.31.0"); got != "Acme Corp" {
+		t.Errorf("declared supplier must win, got %q", got)
+	}
+	if got := SupplierOr("  ", "pkg:maven/org.apache.commons/commons-lang3@3.12.0"); got != "org.apache.commons" {
+		t.Errorf("blank declared must fall back to PURL namespace, got %q", got)
+	}
+	if got := SupplierOr("", "pkg:pypi/requests@2.31.0"); got != "" {
+		t.Errorf("no declared + no namespace must be empty, got %q", got)
+	}
+}
+
+func TestSupplierWithSource(t *testing.T) {
+	cases := []struct{ declared, purl, wantSup, wantSrc string }{
+		{"Acme Corp", "pkg:pypi/requests@2.31.0", "Acme Corp", SupplierDeclared},
+		{"", "pkg:maven/org.apache.commons/commons-lang3@3.12.0", "org.apache.commons", SupplierDerived},
+		{"  ", "pkg:npm/%40angular/core@17.0.0", "@angular", SupplierDerived},
+		{"", "pkg:pypi/requests@2.31.0", "", ""},
+	}
+	for _, c := range cases {
+		sup, src := SupplierWithSource(c.declared, c.purl)
+		if sup != c.wantSup || src != c.wantSrc {
+			t.Errorf("SupplierWithSource(%q,%q) = (%q,%q), want (%q,%q)", c.declared, c.purl, sup, src, c.wantSup, c.wantSrc)
+		}
+	}
+}
+
+func TestQualityCreditsExplicitSupplier(t *testing.T) {
+	// A component with NO PURL (so no derivable supplier) but an explicitly-captured Supplier must still
+	// count toward the NTIA supplier element.
+	doc := SBOM{
+		Source:     "synapse",
+		Components: []Component{{Name: "internal-lib", Version: "1.0.0", Supplier: "Acme Corp"}},
+	}
+	doc.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	byID := map[string]QualityElement{}
+	for _, e := range Quality(doc).Elements {
+		byID[e.ID] = e
+	}
+	if byID["ntia-supplier"].Score != 100 {
+		t.Errorf("an explicit Supplier must satisfy the supplier element even with no PURL, got %d", byID["ntia-supplier"].Score)
+	}
+}
+
 func fullComponent() Component {
 	return Component{
 		Name:     "gin",

--- a/internal/domain/sbom/sbom.go
+++ b/internal/domain/sbom/sbom.go
@@ -82,6 +82,17 @@ type Component struct {
 	PURL     string // package URL (purl spec)
 	Licenses []License
 
+	// Supplier is the entity that supplies the component (a Maven groupId, an npm scope, a GitHub org, a
+	// package registry) — the NTIA "supplier name" minimum SBOM element. Captured from the producer/imported
+	// SBOM when it carries one, else derived from the PURL namespace (SupplierFromPURL); empty when neither
+	// yields one (a bare, namespaceless package). Emitted as SPDX PackageSupplier on export.
+	Supplier string `json:",omitempty"`
+	// SupplierSource records HOW Supplier was obtained — SupplierDeclared (asserted by the producer or an
+	// imported/untrusted client SBOM) vs SupplierDerived (deterministically inferred by Synapse from the PURL
+	// namespace) — so a downstream trust decision can tell an authoritative supplier from an echoed or inferred
+	// one (mirrors LicenseSource/LicenseConfidence). Empty when Supplier is empty.
+	SupplierSource string `json:",omitempty"`
+
 	// License provenance: where the license data came from and, when it
 	// is still unknown, why — so coverage is explainable + audit-ready.
 	LicenseSource     string // "sbom" | "registry" | "local-file" | "" (unknown)

--- a/internal/infrastructure/tools/ownsbom/registry.go
+++ b/internal/infrastructure/tools/ownsbom/registry.go
@@ -164,6 +164,7 @@ func (r *Registry) Generate(ctx context.Context, targetRef string) (*sbom.SBOM, 
 				continue
 			}
 			seen[id] = true
+			c.Supplier, c.SupplierSource = sbom.SupplierWithSource(c.Supplier, c.PURL) // lockfiles carry no supplier; derive from the PURL namespace
 			comps = append(comps, c)
 		}
 		deps = append(deps, pdeps...)

--- a/internal/infrastructure/tools/syft/generator.go
+++ b/internal/infrastructure/tools/syft/generator.go
@@ -122,9 +122,15 @@ type cdxComponent struct {
 	Version    string             `json:"version"`
 	PURL       string             `json:"purl"`
 	Scope      string             `json:"scope"` // required | optional | excluded (npm dev -> excluded)
+	Supplier   cdxSupplier        `json:"supplier"`
 	Licenses   []cdxLicenseChoice `json:"licenses"`
 	Properties []cdxProperty      `json:"properties"`
 	Hashes     []cdxHash          `json:"hashes"`
+}
+
+// cdxSupplier is the CycloneDX component.supplier object; only its name is consumed (the NTIA supplier element).
+type cdxSupplier struct {
+	Name string `json:"name"`
 }
 
 type cdxHash struct {
@@ -249,12 +255,15 @@ func parseCycloneDX(data []byte) ([]sbom.Component, []sbom.Dependency, string, e
 			continue // skip entries that don't identify a package
 		}
 		loc, layerID := c.primaryLocation()
+		supplier, supplierSrc := sbom.SupplierWithSource(c.Supplier.Name, c.PURL)
 		comp := sbom.Component{
 			Name: c.Name, Version: c.Version, PURL: c.PURL,
-			Location: loc,
-			Scope:    sbom.ClassifyScope(loc, c.Scope),
-			LayerID:  layerID,
-			SHA1:     c.sha1(),
+			Location:       loc,
+			Scope:          sbom.ClassifyScope(loc, c.Scope),
+			Supplier:       supplier,
+			SupplierSource: supplierSrc,
+			LayerID:        layerID,
+			SHA1:           c.sha1(),
 		}
 		for _, lc := range c.Licenses {
 			switch {

--- a/internal/usecase/sca/sbom_import.go
+++ b/internal/usecase/sca/sbom_import.go
@@ -175,6 +175,9 @@ type cdxComponent struct {
 	PURL     string `json:"purl"`
 	BOMRef   string `json:"bom-ref"`
 	Scope    string `json:"scope"` // CycloneDX scope: required|optional|excluded
+	Supplier struct {
+		Name string `json:"name"`
+	} `json:"supplier"`
 	Licenses []struct {
 		License struct {
 			ID   string `json:"id"`
@@ -257,6 +260,9 @@ func cdxComponentToDomain(c cdxComponent) (sbom.Component, bool) {
 		name = c.Group + ":" + c.Name
 	}
 	comp := sbom.Component{Name: name, Version: c.Version, PURL: c.PURL}
+	// Preserve the client's declared supplier (NTIA element, tagged "declared" as it is untrusted client input);
+	// else derive it from the PURL namespace ("derived").
+	comp.Supplier, comp.SupplierSource = sbom.SupplierWithSource(c.Supplier.Name, c.PURL)
 	// No on-disk location for an imported component; the CycloneDX scope still
 	// classifies dev/excluded (excluded -> development).
 	comp.Scope = sbom.ClassifyScope("", c.Scope)

--- a/internal/usecase/sca/spdx.go
+++ b/internal/usecase/sca/spdx.go
@@ -36,6 +36,7 @@ type spdxPackage struct {
 	SPDXID           string       `json:"SPDXID"`
 	Name             string       `json:"name"`
 	VersionInfo      string       `json:"versionInfo,omitempty"`
+	Supplier         string       `json:"supplier,omitempty"` // "Organization: <name>" — NTIA supplier element; omitted when unknown
 	DownloadLocation string       `json:"downloadLocation"`
 	LicenseDeclared  string       `json:"licenseDeclared"`
 	LicenseConcluded string       `json:"licenseConcluded"`
@@ -122,6 +123,11 @@ func buildSPDX(doc *sbom.SBOM, target string, created time.Time) spdxDoc {
 			DownloadLocation: "NOASSERTION",
 			LicenseDeclared:  lic,
 			LicenseConcluded: lic,
+		}
+		// Resolve via SupplierOr (not the raw field) so the export derives the supplier from the PURL namespace
+		// for producers/merge paths that leave Supplier empty (e.g. the JVM resolver tree) — matching the scorer.
+		if sup := sbom.SupplierOr(c.Supplier, c.PURL); sup != "" { // NTIA supplier element; SPDX form "Organization: <name>"
+			pkg.Supplier = "Organization: " + sup
 		}
 		if c.PURL != "" {
 			pkg.ExternalRefs = []spdxExtRef{{

--- a/internal/usecase/sca/spdx3.go
+++ b/internal/usecase/sca/spdx3.go
@@ -51,7 +51,16 @@ type spdx3Package struct {
 	Name           string `json:"name"`
 	PackageVersion string `json:"software_packageVersion,omitempty"`
 	PackageURL     string `json:"software_packageUrl,omitempty"`
+	SuppliedBy     string `json:"suppliedBy,omitempty"` // IRI of the supplier Agent (NTIA supplier element); SPDX 3.0 models it as a link
 	CopyrightText  string `json:"software_copyrightText"`
+}
+
+// spdx3Agent is an SPDX 3.0 Organization element a package's suppliedBy points to (the NTIA supplier).
+type spdx3Agent struct {
+	Type         string `json:"type"`
+	SpdxID       string `json:"spdxId"`
+	CreationInfo string `json:"creationInfo"`
+	Name         string `json:"name"`
 }
 
 type spdx3Relationship struct {
@@ -101,6 +110,8 @@ func buildSPDX3(doc *sbom.SBOM, target string, created time.Time) spdx3Doc {
 
 	var pkgIDs []string
 	var pkgs []any
+	var agentIDs []string
+	var agents []any
 	if doc != nil {
 		comps := append([]sbom.Component(nil), doc.Components...)
 		sort.SliceStable(comps, func(i, j int) bool {
@@ -109,10 +120,30 @@ func buildSPDX3(doc *sbom.SBOM, target string, created time.Time) spdx3Doc {
 			}
 			return comps[i].Version < comps[j].Version
 		})
+		// Mint one Organization Agent per unique supplier (SupplierOr, so producers/merge paths that left
+		// Supplier empty still get the PURL-derived value — matching SPDX 2.x + the scorer). Sorted for a
+		// deterministic, content-hashed IRI.
+		agentByName := map[string]string{}
+		var supplierNames []string
+		for _, c := range comps {
+			if sup := sbom.SupplierOr(c.Supplier, c.PURL); sup != "" {
+				if _, ok := agentByName[sup]; !ok {
+					agentByName[sup] = "" // placeholder; IRI assigned after sorting
+					supplierNames = append(supplierNames, sup)
+				}
+			}
+		}
+		sort.Strings(supplierNames)
+		for _, sup := range supplierNames {
+			id := spdx3IRIBase + "agent:" + hash12(sup)
+			agentByName[sup] = id
+			agentIDs = append(agentIDs, id)
+			agents = append(agents, spdx3Agent{Type: "Organization", SpdxID: id, CreationInfo: ciID, Name: sup})
+		}
 		for i, c := range comps {
 			id := spdx3IRIBase + "pkg:" + fmt.Sprintf("%d-%s", i, hash12(c.Name+"@"+c.Version+c.PURL))
 			pkgIDs = append(pkgIDs, id)
-			pkgs = append(pkgs, spdx3Package{
+			pkg := spdx3Package{
 				Type:           "software_Package",
 				SpdxID:         id,
 				CreationInfo:   ciID,
@@ -120,7 +151,11 @@ func buildSPDX3(doc *sbom.SBOM, target string, created time.Time) spdx3Doc {
 				PackageVersion: c.Version,
 				PackageURL:     c.PURL,
 				CopyrightText:  "NOASSERTION",
-			})
+			}
+			if sup := sbom.SupplierOr(c.Supplier, c.PURL); sup != "" {
+				pkg.SuppliedBy = agentByName[sup]
+			}
+			pkgs = append(pkgs, pkg)
 		}
 	}
 
@@ -131,9 +166,10 @@ func buildSPDX3(doc *sbom.SBOM, target string, created time.Time) spdx3Doc {
 		Name:               name,
 		ProfileConformance: []string{"core", "software"},
 		RootElement:        pkgIDs,
-		Element:            pkgIDs,
+		Element:            append(append([]string(nil), pkgIDs...), agentIDs...),
 	})
 	graph = append(graph, pkgs...)
+	graph = append(graph, agents...)
 	if len(pkgIDs) > 0 {
 		graph = append(graph, spdx3Relationship{
 			Type:             "Relationship",

--- a/internal/usecase/sca/spdx3_test.go
+++ b/internal/usecase/sca/spdx3_test.go
@@ -60,3 +60,53 @@ func TestBuildSPDX3DeterministicAndValid(t *testing.T) {
 		t.Errorf("first package should be express (sorted), got %+v", a.Graph[2])
 	}
 }
+
+func TestBuildSPDX3EmitsSupplierAgent(t *testing.T) {
+	doc := &sbom.SBOM{
+		TargetRef: "https://github.com/org/repo",
+		Components: []sbom.Component{
+			{Name: "commons-lang3", Version: "3.12.0", PURL: "pkg:maven/org.apache.commons/commons-lang3@3.12.0"},
+		},
+	}
+	a := buildSPDX3(doc, doc.TargetRef, time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC))
+
+	var agent *spdx3Agent
+	var pkg *spdx3Package
+	for _, n := range a.Graph {
+		switch v := n.(type) {
+		case spdx3Agent:
+			ag := v
+			agent = &ag
+		case spdx3Package:
+			p := v
+			pkg = &p
+		}
+	}
+	if agent == nil {
+		t.Fatal("SPDX3 must emit an Organization Agent for the derived supplier")
+	}
+	if agent.Type != "Organization" || agent.Name != "org.apache.commons" {
+		t.Errorf("supplier agent = %+v, want Organization org.apache.commons", agent)
+	}
+	if pkg == nil || pkg.SuppliedBy != agent.SpdxID {
+		t.Errorf("package suppliedBy = %q, want the agent IRI %q", pkgSuppliedBy(pkg), agent.SpdxID)
+	}
+	// The Agent must also be listed among the document's elements.
+	docNode, _ := a.Graph[1].(spdx3Document)
+	found := false
+	for _, e := range docNode.Element {
+		if e == agent.SpdxID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("supplier agent IRI must appear in the SpdxDocument.element list")
+	}
+}
+
+func pkgSuppliedBy(p *spdx3Package) string {
+	if p == nil {
+		return "<nil package>"
+	}
+	return p.SuppliedBy
+}

--- a/internal/usecase/sca/spdx_test.go
+++ b/internal/usecase/sca/spdx_test.go
@@ -49,6 +49,27 @@ func TestBuildSPDXDeterministicAndValid(t *testing.T) {
 	}
 }
 
+func TestBuildSPDXEmitsSupplier(t *testing.T) {
+	doc := &sbom.SBOM{
+		TargetRef: "https://github.com/org/repo",
+		Components: []sbom.Component{
+			{Name: "commons-lang3", Version: "3.12.0", PURL: "pkg:maven/org.apache.commons/commons-lang3@3.12.0", Supplier: "org.apache.commons"},
+			{Name: "leftpad", Version: "1.0.0", PURL: "pkg:npm/leftpad@1.0.0"}, // no supplier
+		},
+	}
+	a := buildSPDX(doc, doc.TargetRef, time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC))
+	byName := map[string]spdxPackage{}
+	for _, p := range a.Packages {
+		byName[p.Name] = p
+	}
+	if got := byName["commons-lang3"].Supplier; got != "Organization: org.apache.commons" {
+		t.Errorf("PackageSupplier = %q, want \"Organization: org.apache.commons\"", got)
+	}
+	if got := byName["leftpad"].Supplier; got != "" {
+		t.Errorf("a component with no supplier must omit PackageSupplier, got %q", got)
+	}
+}
+
 func TestScanTimePinned(t *testing.T) {
 	r := ScanResult{VulnDBSnapshot: "osv.dev@2026-06-21T10:00:00Z"}
 	if got := r.scanTime(); got.Format(time.RFC3339) != "2026-06-21T10:00:00Z" {


### PR DESCRIPTION
feat(sbom): capture + emit component Supplier (NTIA supplier element)

Adds Component.Supplier and threads it end to end so Synapse's SBOMs carry the NTIA
"supplier name" minimum element. Producers populate it: Syft from CycloneDX
component.supplier, the owned parsers by deriving it from the PURL namespace (lockfiles
carry no supplier), and imported client SBOMs keep their declared supplier. The SPDX 2.3
export emits it as PackageSupplier ("Organization: <name>"), omitted when unknown.

One home for the resolution rule: sbom.SupplierOr(declared, purl) prefers a declared
supplier and falls back to the PURL-namespace derivation (SupplierFromPURL). Every
producer uses it, and the quality scorer now credits an explicitly captured supplier even
when a component has no PURL.

SPDX 3.0 models supplier as an Agent element plus a suppliedBy relationship rather than a
string; emitting it there is left as a follow-up.
