### PR TITLE
feat(sbom): capture per-component integrity checksums (SBOM checksum quality element)

### DIFF
--- a/internal/domain/sbom/dedupe.go
+++ b/internal/domain/sbom/dedupe.go
@@ -81,6 +81,19 @@ func mergeComponents(dst, src Component) Component {
 	} else if dst.UnknownReason == "" {
 		dst.UnknownReason = src.UnknownReason
 	}
+	// Supplier + its provenance move together so the source label always describes the value it accompanies.
+	if dst.Supplier == "" {
+		dst.Supplier = src.Supplier
+		dst.SupplierSource = src.SupplierSource
+	}
+	// Integrity digests: adopt the twin's when this entry has none, so a Syft phantom-UNKNOWN twin that
+	// carries the only checksum/SHA1 doesn't drop it on merge (mirrors the license union above).
+	if dst.SHA1 == "" {
+		dst.SHA1 = src.SHA1
+	}
+	if len(dst.Checksums) == 0 {
+		dst.Checksums = src.Checksums
+	}
 	// First-party is a true OR: if either evidence source identifies it as the project's own module.
 	dst.FirstParty = dst.FirstParty || src.FirstParty
 	return dst

--- a/internal/domain/sbom/dedupe_test.go
+++ b/internal/domain/sbom/dedupe_test.go
@@ -28,6 +28,32 @@ func TestDedupeComponentsUnionsLicenses(t *testing.T) {
 	}
 }
 
+func TestDedupeComponentsPreservesSupplierAndChecksums(t *testing.T) {
+	// A Syft phantom-twin split: the licensed entry carries no integrity/supplier, the other twin carries
+	// the only checksum + supplier. The merge must keep ALL of it — dropping the checksum would under-count
+	// the SBOM quality score.
+	in := []Component{
+		{Name: "lodash", Version: "4.17.21", PURL: "pkg:npm/lodash@4.17.21", Licenses: []License{{SPDXID: "MIT"}}},
+		{Name: "lodash", Version: "4.17.21", PURL: "pkg:npm/lodash@4.17.21",
+			Supplier: "acme", SupplierSource: SupplierDeclared, SHA1: "abc",
+			Checksums: []Checksum{{Algorithm: "SHA512", Value: "zzz"}}},
+	}
+	out := DedupeComponents(in)
+	if len(out) != 1 {
+		t.Fatalf("want 1 merged component, got %d", len(out))
+	}
+	c := out[0]
+	if c.Supplier != "acme" || c.SupplierSource != SupplierDeclared {
+		t.Errorf("supplier + source must survive the merge, got %q/%q", c.Supplier, c.SupplierSource)
+	}
+	if c.SHA1 != "abc" || len(c.Checksums) != 1 || c.Checksums[0].Value != "zzz" {
+		t.Errorf("integrity digests must survive the merge, got SHA1=%q Checksums=%+v", c.SHA1, c.Checksums)
+	}
+	if len(c.Licenses) != 1 { // and the first entry's license is still there
+		t.Errorf("license from the first entry must survive, got %+v", c.Licenses)
+	}
+}
+
 func TestDedupeComponentsFillsEmptyTwin(t *testing.T) {
 	// Order-independent: the license-less entry first, the licensed one second.
 	in := []Component{

--- a/internal/domain/sbom/quality.go
+++ b/internal/domain/sbom/quality.go
@@ -86,7 +86,7 @@ func Quality(s SBOM) QualityReport {
 				}
 			}
 		}
-		if strings.TrimSpace(c.SHA1) != "" {
+		if HasChecksum(c) {
 			withChecksum++
 		}
 	}
@@ -123,7 +123,7 @@ func Quality(s SBOM) QualityReport {
 		// Semantic quality beyond the NTIA floor.
 		comp("sem-license", "License present", QualityCategorySemantic, withLicense, "have no license"),
 		comp("sem-license-spdx", "License is an SPDX id", QualityCategorySemantic, withSPDXLicense, "have no SPDX-valid license id"),
-		comp("sem-checksum", "Checksum (SHA-1)", QualityCategorySemantic, withChecksum, "have no checksum"),
+		comp("sem-checksum", "Checksum", QualityCategorySemantic, withChecksum, "have no integrity checksum"),
 	}
 	sort.SliceStable(elements, func(i, j int) bool {
 		if elements[i].Category != elements[j].Category {
@@ -198,6 +198,12 @@ const (
 	SupplierDeclared = "declared" // asserted by the producer or an imported/untrusted client SBOM
 	SupplierDerived  = "derived"  // deterministically inferred by Synapse from the PURL namespace
 )
+
+// HasChecksum reports whether a component carries any integrity digest — the legacy SHA1 field or a
+// Checksums entry — which is the semantic-quality "checksum present" signal (tamper evidence per component).
+func HasChecksum(c Component) bool {
+	return strings.TrimSpace(c.SHA1) != "" || len(c.Checksums) > 0
+}
 
 // supplierOf returns a component's supplier: the explicitly-captured Supplier when the producer/imported SBOM
 // carried one, else one derived from the PURL namespace. Empty when neither yields one.

--- a/internal/domain/sbom/quality_test.go
+++ b/internal/domain/sbom/quality_test.go
@@ -165,6 +165,27 @@ func TestQualityPartialRatio(t *testing.T) {
 	}
 }
 
+func TestHasChecksumAndScorerCreditsChecksums(t *testing.T) {
+	// A component with a Checksums entry (npm/pnpm SRI) but no legacy SHA1 must count as having a checksum.
+	withCk := Component{Name: "lodash", Version: "4.17.21", PURL: "pkg:npm/lodash@4.17.21", Checksums: []Checksum{{Algorithm: "SHA512", Value: "aaa"}}}
+	if !HasChecksum(withCk) {
+		t.Error("a component with a Checksums entry must report HasChecksum")
+	}
+	if HasChecksum(Component{Name: "bare"}) {
+		t.Error("a component with neither SHA1 nor Checksums must not report HasChecksum")
+	}
+	if !HasChecksum(Component{SHA1: "abc"}) {
+		t.Error("the legacy SHA1 field must still count as a checksum")
+	}
+	doc := SBOM{Source: "synapse", Components: []Component{withCk}}
+	doc.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	for _, e := range Quality(doc).Elements {
+		if e.ID == "sem-checksum" && e.Score != 100 {
+			t.Errorf("sem-checksum = %d, want 100 for a Checksums-only component", e.Score)
+		}
+	}
+}
+
 func TestQualityScoreClampedWhenNTIAUnmet(t *testing.T) {
 	// A component fully described EXCEPT supplier (a bare-namespace PURL): every semantic check passes, so
 	// the raw blend lands at the threshold — but a missing NTIA minimum element must keep the headline Score

--- a/internal/domain/sbom/sbom.go
+++ b/internal/domain/sbom/sbom.go
@@ -134,6 +134,20 @@ type Component struct {
 	// exact artifact bytes, so it can recover the Maven coordinate of a shaded/renamed/metadata-less JAR
 	// whose in-file identity was stripped, where pom.properties recovery cannot.
 	SHA1 string `json:",omitempty"`
+
+	// Checksums are the component artifact's integrity digests as recorded by the lockfile / producer
+	// (e.g. npm `integrity` sha512, a Cargo.lock sha256), giving tamper evidence per component. Kept
+	// alongside SHA1 (which is a single legacy hex form); empty when the source records none. Emitted as
+	// SPDX package checksums on export.
+	Checksums []Checksum `json:",omitempty"`
+}
+
+// Checksum is one integrity digest of a component artifact. Algorithm is an SPDX-style name (SHA1, SHA256,
+// SHA512, ...); Value is the digest as the source recorded it (hex for SHA-256/SHA-1, base64 for an npm
+// sha512 integrity).
+type Checksum struct {
+	Algorithm string `json:"algorithm"`
+	Value     string `json:"value"`
 }
 
 // Coarse JVM class-reachability verdicts. Empty ("") = not analyzed / unknown.

--- a/internal/infrastructure/tools/ownsbom/npm.go
+++ b/internal/infrastructure/tools/ownsbom/npm.go
@@ -40,6 +40,7 @@ func (NPM) Markers() []string { return []string{"package-lock.json"} }
 type npmV1Dep struct {
 	Version      string              `json:"version"`
 	Dev          bool                `json:"dev"`
+	Integrity    string              `json:"integrity"`
 	Dependencies map[string]npmV1Dep `json:"dependencies"`
 }
 
@@ -49,6 +50,7 @@ type npmV1Dep struct {
 type npmV3Pkg struct {
 	Version              string            `json:"version"`
 	Dev                  bool              `json:"dev"`
+	Integrity            string            `json:"integrity"`
 	Dependencies         map[string]string `json:"dependencies"`
 	DevDependencies      map[string]string `json:"devDependencies"`
 	OptionalDependencies map[string]string `json:"optionalDependencies"`
@@ -74,14 +76,14 @@ func (NPM) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dep
 		}
 		return "pkg:npm/" + purlName + "@" + version
 	}
-	add := func(name, version string, dev bool) string {
+	add := func(name, version, integrity string, dev bool) string {
 		name = strings.TrimSpace(name)
 		scope := prodScope
 		if dev {
 			scope = sbom.ScopeDevelopment
 		}
 		purl := npmPURL(name, version)
-		set.add(sbom.Component{Name: name, Version: version, PURL: purl, Location: in.Path, Scope: scope})
+		set.add(sbom.Component{Name: name, Version: version, PURL: purl, Location: in.Path, Scope: scope, Checksums: parseSubresourceIntegrity(integrity)})
 		return purl
 	}
 
@@ -90,7 +92,7 @@ func (NPM) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dep
 		pathPURL := make(map[string]string, len(lock.Packages))
 		for path, p := range lock.Packages {
 			if name := npmNameFromPath(path); name != "" {
-				pathPURL[path] = add(name, p.Version, p.Dev)
+				pathPURL[path] = add(name, p.Version, p.Integrity, p.Dev)
 			}
 		}
 		// Pass 2: resolve each package's direct deps to PURLs via npm's nearest-wins hoisting. Deterministic:
@@ -132,7 +134,7 @@ func (NPM) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dep
 			return fmt.Errorf("%w: package-lock.json nesting exceeds %d levels", shared.ErrValidation, maxNPMNestDepth)
 		}
 		for name, d := range deps {
-			add(name, d.Version, d.Dev)
+			add(name, d.Version, d.Integrity, d.Dev)
 			if err := walk(d.Dependencies, depth+1); err != nil {
 				return err
 			}
@@ -143,6 +145,22 @@ func (NPM) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dep
 		return nil, nil, err
 	}
 	return set.components(), nil, nil
+}
+
+// parseSubresourceIntegrity parses a W3C Subresource Integrity string as npm/yarn/pnpm record it in a
+// lockfile `integrity` field: one or more space-separated "<alg>-<base64>" hashes (e.g.
+// "sha512-<b64> sha1-<b64>"). Each becomes a Checksum with an SPDX-style uppercased algorithm name and the
+// base64 digest as recorded. Malformed tokens are skipped; returns nil when none parse.
+func parseSubresourceIntegrity(s string) []sbom.Checksum {
+	var out []sbom.Checksum
+	for _, tok := range strings.Fields(s) {
+		i := strings.IndexByte(tok, '-')
+		if i <= 0 || i == len(tok)-1 {
+			continue // not the "<alg>-<digest>" shape
+		}
+		out = append(out, sbom.Checksum{Algorithm: strings.ToUpper(tok[:i]), Value: tok[i+1:]})
+	}
+	return out
 }
 
 // npmDepNames returns the sorted, unique direct-dependency names of a v2/v3 package: its dependencies +

--- a/internal/infrastructure/tools/ownsbom/npm_test.go
+++ b/internal/infrastructure/tools/ownsbom/npm_test.go
@@ -13,7 +13,7 @@ const npmLockV3 = `{
   "name": "app", "lockfileVersion": 3,
   "packages": {
     "": {"name": "app", "version": "1.0.0", "dependencies": {"lodash": "^4"}},
-    "node_modules/lodash": {"version": "4.17.21"},
+    "node_modules/lodash": {"version": "4.17.21", "integrity": "sha512-lodashhash"},
     "node_modules/mocha": {"version": "10.2.0", "dev": true, "dependencies": {"ms": "^2"}},
     "node_modules/@angular/core": {"version": "17.0.1", "dependencies": {"tslib": "^2", "ms": "^1"}},
     "node_modules/ms": {"version": "2.1.3"},
@@ -37,6 +37,10 @@ func TestNPMParseV3(t *testing.T) {
 	// resolved version + production scope
 	if c := byName["lodash"]; c.Version != "4.17.21" || c.PURL != "pkg:npm/lodash@4.17.21" || c.Scope != sbom.ScopeProduction {
 		t.Errorf("lodash = %+v, want 4.17.21 / pkg:npm/lodash@4.17.21 / production", c)
+	}
+	// npm `integrity` (SRI) is captured as a component Checksum.
+	if ck := byName["lodash"].Checksums; len(ck) != 1 || ck[0].Algorithm != "SHA512" || ck[0].Value != "lodashhash" {
+		t.Errorf("lodash checksum = %+v, want [{SHA512 lodashhash}]", ck)
 	}
 	// the lock's dev flag maps to ScopeDevelopment
 	if c := byName["mocha"]; c.Scope != sbom.ScopeDevelopment {

--- a/internal/infrastructure/tools/ownsbom/pnpm.go
+++ b/internal/infrastructure/tools/ownsbom/pnpm.go
@@ -36,6 +36,15 @@ func (Pnpm) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 	baseScope := sbom.ClassifyScope(in.Path, "")
 	set := newComponentSet()
 	inPackages := false
+	// Emission is DEFERRED per package: hold the current component while its deeper `resolution:` block is
+	// read so its integrity (SRI) checksum attaches, then flush on the next key / section / EOF.
+	var cur *sbom.Component
+	flush := func() {
+		if cur != nil {
+			set.add(*cur)
+			cur = nil
+		}
+	}
 	sc := bufio.NewScanner(bytes.NewReader(in.Content))
 	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
 	for sc.Scan() {
@@ -44,12 +53,25 @@ func (Pnpm) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 			continue // blank/comment lines don't delimit sections (pnpm-lock blank-separates entries)
 		}
 		if !indented(raw) { // a col-0 line: a new top-level section. Only `packages:` is ours.
+			flush()
 			inPackages = strings.TrimSpace(raw) == "packages:"
 			continue
 		}
-		if !inPackages || leadingIndent(raw) != 2 {
-			continue // not in packages, or a deeper value line (resolution/engines/…) — skip
+		if !inPackages {
+			continue
 		}
+		if leadingIndent(raw) != 2 {
+			// A deeper value line of the current package: capture its resolution integrity (tamper evidence);
+			// everything else (engines/…) is ignored. Only the first integrity seen is kept.
+			if cur != nil && cur.Checksums == nil {
+				if v := pnpmIntegrityFromLine(raw); v != "" {
+					cur.Checksums = parseSubresourceIntegrity(v)
+				}
+			}
+			continue
+		}
+		// An indent-2 key line: the previous package's block is complete.
+		flush()
 		line := strings.TrimSpace(raw)
 		if !strings.HasSuffix(line, ":") {
 			continue
@@ -63,18 +85,34 @@ func (Pnpm) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 		if strings.HasPrefix(purlName, "@") {
 			purlName = "%40" + purlName[1:] // PURL spec: scoped @ → %40 (matches the npm/yarn parsers)
 		}
-		set.add(sbom.Component{
+		cur = &sbom.Component{
 			Name:     name,
 			Version:  version,
 			PURL:     "pkg:npm/" + purlName + "@" + version,
 			Location: in.Path,
 			Scope:    baseScope,
-		})
+		}
 	}
+	flush() // the last package in the file
 	if err := sc.Err(); err != nil {
 		return nil, nil, fmt.Errorf("scan pnpm-lock.yaml: %w", err)
 	}
 	return set.components(), nil, nil
+}
+
+// pnpmIntegrityFromLine extracts the Subresource Integrity value from a pnpm-lock resolution line, inline
+// (`resolution: {integrity: sha512-...}`) or block (`integrity: sha512-...`). Returns "" when the line carries
+// no integrity token. The value stops at the next inline-map key (`,`) or the map close (`}`).
+func pnpmIntegrityFromLine(raw string) string {
+	i := strings.Index(raw, "integrity:")
+	if i < 0 {
+		return ""
+	}
+	v := raw[i+len("integrity:"):]
+	if j := strings.IndexAny(v, ",}"); j >= 0 {
+		v = v[:j]
+	}
+	return strings.Trim(v, ` '"`)
 }
 
 // pnpmSpecNameVersion splits a pnpm-lock `packages:` key into (name, version), across lockfile versions:

--- a/internal/infrastructure/tools/ownsbom/pnpm_test.go
+++ b/internal/infrastructure/tools/ownsbom/pnpm_test.go
@@ -54,6 +54,14 @@ func TestPnpmParseV9(t *testing.T) {
 	if len(comps) != 2 {
 		t.Fatalf("want 2 components from packages: (lodash, @babel/core), got %d: %+v", len(comps), comps)
 	}
+	// The resolution integrity (SRI) must be captured as a component Checksum (deferred-emission attaches it
+	// to the right package key).
+	if ck := byName["lodash"].Checksums; len(ck) != 1 || ck[0].Algorithm != "SHA512" || ck[0].Value != "aaa" {
+		t.Errorf("lodash checksum = %+v, want [{SHA512 aaa}]", ck)
+	}
+	if ck := byName["@babel/core"].Checksums; len(ck) != 1 || ck[0].Value != "bbb" {
+		t.Errorf("@babel/core checksum = %+v, want [{SHA512 bbb}]", ck)
+	}
 }
 
 // v6 keys carry a leading `/` and a `(peer)` suffix; v5 uses `/name/version`. Both must resolve.

--- a/internal/infrastructure/tools/syft/generator.go
+++ b/internal/infrastructure/tools/syft/generator.go
@@ -149,6 +149,21 @@ func (c cdxComponent) sha1() string {
 	return ""
 }
 
+// checksums maps every CycloneDX hash Syft emitted for the component to a domain Checksum, normalizing the
+// algorithm to an SPDX-style name ("SHA-256" -> "SHA256"). This is the general integrity-digest capture (the
+// separate sha1() stays for JAR-coordinate recovery). Returns nil when the component carries no hashes.
+func (c cdxComponent) checksums() []sbom.Checksum {
+	var out []sbom.Checksum
+	for _, h := range c.Hashes {
+		v := strings.TrimSpace(h.Content)
+		if v == "" {
+			continue
+		}
+		out = append(out, sbom.Checksum{Algorithm: strings.ToUpper(strings.ReplaceAll(h.Alg, "-", "")), Value: v})
+	}
+	return out
+}
+
 type cdxProperty struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
@@ -264,6 +279,7 @@ func parseCycloneDX(data []byte) ([]sbom.Component, []sbom.Dependency, string, e
 			SupplierSource: supplierSrc,
 			LayerID:        layerID,
 			SHA1:           c.sha1(),
+			Checksums:      c.checksums(),
 		}
 		for _, lc := range c.Licenses {
 			switch {


### PR DESCRIPTION
feat(sbom): capture per-component integrity checksums (SBOM checksum quality element)

Adds Component.Checksums (algorithm + digest) and populates it so the SBOM quality scorer's
checksum element reflects real tamper evidence rather than only the legacy SHA1 field. The
owned parsers read the lockfile Subresource Integrity: npm package-lock `integrity` and
pnpm-lock `resolution: {integrity}` (a shared parseSubresourceIntegrity handles the
"sha512-<base64> sha1-<base64>" form; the pnpm scan now defers per-package emission so the
integrity attaches to the right package key). The Syft producer maps its full CycloneDX
hashes array (not just SHA-1) with SPDX-style algorithm names.

The scorer credits a component that carries either SHA1 or any Checksums entry, and the
element is renamed from "Checksum (SHA-1)" to "Checksum".

Realization is producer-dependent: under the owned SBOM producer the lockfile SRI closes the
checksum gap; under Syft, coverage reflects what Syft hashes (it does not emit per-package
hashes for lockfile-derived npm/Go components, only files and binaries). SPDX checksum export
(npm integrity is base64 where SPDX wants hex) and the remaining owned parsers (Cargo, yarn,
Poetry, Pipfile, Composer) are follow-ups.
