### PR TITLE
feat(sbom): compliance-profile PASS/FAIL over the SBOM quality score

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -428,6 +428,9 @@ func printReport(target string, res *scauc.ScanResult) {
 				fmt.Printf("    %-26s %3d/100 — %s\n", e.Label, e.Score, e.Detail)
 			}
 		}
+		for _, p := range q.Profiles { // explicit per-standard PASS/FAIL a regulated buyer can cite
+			fmt.Printf("    %s\n", p.Summary)
+		}
 	}
 	fmt.Printf("  vulnerabilities: %d", len(res.Vulnerabilities))
 	if counts := countVulnSeverity(res); counts != "" {

--- a/internal/domain/sbom/quality.go
+++ b/internal/domain/sbom/quality.go
@@ -56,7 +56,72 @@ type QualityReport struct {
 	NTIAScore int              `json:"ntia_score"` // mean of the NTIA element scores, 0..100
 	NTIAMet   bool             `json:"ntia_met"`   // every NTIA element Score >= NTIAThreshold
 	Elements  []QualityElement `json:"elements"`
-	Summary   string           `json:"summary"`
+	// Profiles projects the scored elements onto named compliance profiles (NTIA 2021, vulnerability-lookup
+	// readiness, ...) as explicit PASS/FAIL with the failing requirements named — the citable governance
+	// artifact a regulated buyer asks for, distinct from the raw score.
+	Profiles []ProfileResult `json:"profiles"`
+	Summary  string          `json:"summary"`
+}
+
+// ProfileResult is a QualityReport projected onto one named compliance profile: whether every required
+// element clears the bar, and the labels of those that did not.
+type ProfileResult struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Met     bool     `json:"met"`
+	Missing []string `json:"missing,omitempty"` // labels of required elements below the profile threshold
+	Summary string   `json:"summary"`
+}
+
+// complianceProfile is a named set of required QualityElement IDs — a regulation or standard's expected
+// subset. Each required element must score >= NTIAThreshold for the profile to be met.
+type complianceProfile struct {
+	id, name string
+	required []string
+}
+
+// complianceProfiles are the built-in, curated profiles. NTIA-2021 is the authoritative minimum-elements
+// baseline (EO 14028); vuln-lookup is the narrower "can every component be matched against an advisory DB"
+// readiness check (name + version + a unique identifier). Both are LLM-free, deterministic tables. More
+// profiles (NTIA-2025, BSI TR-03183-2, OWASP SCVS levels) slot in here as their mappings are curated.
+var complianceProfiles = []complianceProfile{
+	{id: "ntia-2021", name: "NTIA 2021 minimum elements", required: []string{
+		"ntia-supplier", "ntia-name", "ntia-version", "ntia-uniqid", "ntia-dependencies", "ntia-author", "ntia-timestamp",
+	}},
+	{id: "vuln-lookup", name: "Vulnerability lookup readiness", required: []string{
+		"ntia-name", "ntia-version", "ntia-uniqid",
+	}},
+}
+
+// evaluateProfiles projects the scored elements onto the built-in compliance profiles. Deterministic: the
+// profile order and the missing-labels order follow the fixed tables above.
+func evaluateProfiles(elements []QualityElement) []ProfileResult {
+	byID := make(map[string]QualityElement, len(elements))
+	for _, e := range elements {
+		byID[e.ID] = e
+	}
+	out := make([]ProfileResult, 0, len(complianceProfiles))
+	for _, p := range complianceProfiles {
+		pr := ProfileResult{ID: p.id, Name: p.name, Met: true}
+		for _, id := range p.required {
+			e, ok := byID[id]
+			if !ok || e.Score < NTIAThreshold {
+				pr.Met = false
+				if ok {
+					pr.Missing = append(pr.Missing, e.Label)
+				} else {
+					pr.Missing = append(pr.Missing, id)
+				}
+			}
+		}
+		if pr.Met {
+			pr.Summary = fmt.Sprintf("%s: PASS", p.name)
+		} else {
+			pr.Summary = fmt.Sprintf("%s: FAIL (missing: %s)", p.name, strings.Join(pr.Missing, ", "))
+		}
+		out = append(out, pr)
+	}
+	return out
 }
 
 // Quality scores an SBOM against the NTIA minimum elements and semantic-quality checks. Pure + deterministic.
@@ -147,6 +212,7 @@ func Quality(s SBOM) QualityReport {
 	if !r.NTIAMet && r.Score >= NTIAThreshold {
 		r.Score = NTIAThreshold - 1
 	}
+	r.Profiles = evaluateProfiles(elements)
 	r.Summary = qualitySummary(r)
 	return r
 }

--- a/internal/domain/sbom/quality_test.go
+++ b/internal/domain/sbom/quality_test.go
@@ -228,6 +228,79 @@ func TestQualityEmptySBOMScoresZeroNotPanic(t *testing.T) {
 	}
 }
 
+func TestQualityComplianceProfiles(t *testing.T) {
+	profileByID := func(r QualityReport) map[string]ProfileResult {
+		m := map[string]ProfileResult{}
+		for _, p := range r.Profiles {
+			m[p.ID] = p
+		}
+		return m
+	}
+
+	// A fully described SBOM meets both profiles.
+	full := SBOM{Source: "synapse", Components: []Component{fullComponent()}, Dependencies: []Dependency{{Ref: "gin"}}}
+	full.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	fp := profileByID(Quality(full))
+	if !fp["ntia-2021"].Met || !fp["vuln-lookup"].Met {
+		t.Errorf("a full SBOM must pass both profiles, got ntia=%+v vuln=%+v", fp["ntia-2021"], fp["vuln-lookup"])
+	}
+
+	// Supplier-less but otherwise complete: NTIA-2021 fails naming Supplier; vuln-lookup still passes
+	// (name+version+PURL present).
+	noSupplier := SBOM{
+		Source:       "synapse",
+		Components:   []Component{{Name: "requests", Version: "2.31.0", PURL: "pkg:pypi/requests@2.31.0", Licenses: []License{{SPDXID: "Apache-2.0"}}, SHA1: "abc"}},
+		Dependencies: []Dependency{{Ref: "requests"}},
+	}
+	noSupplier.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	np := profileByID(Quality(noSupplier))
+	if np["ntia-2021"].Met {
+		t.Error("a supplier-less SBOM must FAIL NTIA-2021")
+	}
+	if len(np["ntia-2021"].Missing) != 1 || np["ntia-2021"].Missing[0] != "Supplier name" {
+		t.Errorf("NTIA-2021 must name the missing Supplier element, got %v", np["ntia-2021"].Missing)
+	}
+	if !strings.Contains(np["ntia-2021"].Summary, "FAIL") {
+		t.Errorf("failing profile summary must say FAIL, got %q", np["ntia-2021"].Summary)
+	}
+	if !np["vuln-lookup"].Met {
+		t.Error("name+version+PURL present must PASS vuln-lookup readiness even without a supplier")
+	}
+
+	// A bare (name-only) component fails vuln-lookup too.
+	bare := SBOM{Source: "synapse", Components: []Component{{Name: "mystery"}}}
+	bare.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	if profileByID(Quality(bare))["vuln-lookup"].Met {
+		t.Error("a version-less, PURL-less component must FAIL vuln-lookup readiness")
+	}
+}
+
+func TestNTIAProfileMatchesNTIAMet(t *testing.T) {
+	// The ntia-2021 profile requires exactly the NTIA elements at the same threshold as NTIAMet, so the two
+	// must never disagree. This guard fails loudly if a future NTIA element is added to the scorer but not the
+	// profile table (or vice versa).
+	full := SBOM{Source: "synapse", Components: []Component{fullComponent()}, Dependencies: []Dependency{{Ref: "gin"}}}
+	full.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	cases := []SBOM{
+		full,
+		{Source: "synapse", Components: []Component{{Name: "bare"}}}, // fails many NTIA elements
+		{Source: "", Components: []Component{fullComponent()}},       // missing author + timestamp
+		{Components: nil}, // empty
+	}
+	for i, doc := range cases {
+		r := Quality(doc)
+		var ntia ProfileResult
+		for _, p := range r.Profiles {
+			if p.ID == "ntia-2021" {
+				ntia = p
+			}
+		}
+		if ntia.Met != r.NTIAMet {
+			t.Errorf("case %d: ntia-2021 profile Met=%v but NTIAMet=%v — the two must agree", i, ntia.Met, r.NTIAMet)
+		}
+	}
+}
+
 func TestQualityDeterministicOrder(t *testing.T) {
 	doc := SBOM{Source: "synapse", Components: []Component{fullComponent()}}
 	doc.Audit.CreatedAt = time.Now().UTC()


### PR DESCRIPTION
feat(sbom): compliance-profile PASS/FAIL over the SBOM quality score

Projects the scored quality elements onto named compliance profiles, so the report carries an
explicit, citable per-standard verdict rather than only a number. Two built-in profiles: NTIA
2021 minimum elements (the EO 14028 baseline: supplier, name, version, unique id, dependency
relationships, author, timestamp) and Vulnerability lookup readiness (name + version + a unique
identifier, i.e. can every component be matched against an advisory DB). Each reports PASS or
FAIL with the failing requirements named. Deterministic, LLM-free, curated tables; more profiles
(NTIA 2025, BSI TR-03183-2, OWASP SCVS levels) slot into the same table as their mappings are
curated.

Surfaced on QualityReport.Profiles and printed by the CLI. Purely additive: the blended score,
NTIA sub-score, and per-element breakdown are unchanged.

Dogfooding the repo's own SBOM: "NTIA 2021 minimum elements: FAIL (missing: Supplier name)" and
"Vulnerability lookup readiness: PASS".
