### PR TITLE
feat(sbom): capture JAR artifact SHA-1 from the workspace (+ synapse-cli --json)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gradleresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/grype"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ignorefile"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarchecksum"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarhash"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarlicense"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jvmreach"
@@ -453,7 +454,8 @@ func main() {
 		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil)))
 	scaService.SetImportedSBOMStore(importedSBOMStore)
 	scaService.SetSBOMEnricher(manifest.New())
-	scaService.SetMavenCoordResolver(mavencoord.New()) // recover real Maven coords from JAR pom.properties (offline) before license lookup
+	scaService.SetMavenCoordResolver(mavencoord.New())   // recover real Maven coords from JAR pom.properties (offline) before license lookup
+	scaService.SetJarChecksumResolver(jarchecksum.New()) // capture JAR artifact SHA-1 from the workspace (Syft omits it from CycloneDX)
 	// SHA-1 coordinate recovery for shaded/metadata-less JARs: offline trivy-java-db-format
 	// index first (if configured), online Maven Central as the fallback. Best-effort.
 	var jhResolvers []ports.JarHashResolver

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gradleresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/grype"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ignorefile"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarchecksum"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarhash"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarlicense"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jvmreach"
@@ -73,7 +75,7 @@ func main() {
 
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
-	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
+	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
 	fmt.Fprintln(os.Stderr, "      --image    treat the argument as a container image reference (pulled via crane) instead of a local path")
 	fmt.Fprintln(os.Stderr, "      --offline  skip the live OSV.dev source; detect with Grype's offline DB only (air-gapped / fast)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
@@ -94,6 +96,7 @@ func runScan() {
 	ignoreUnfixed := false
 	image := false
 	offline := false
+	jsonOut := false
 	for i := 3; i < len(os.Args); i++ {
 		switch {
 		case os.Args[i] == "--fail-on" && i+1 < len(os.Args):
@@ -111,6 +114,8 @@ func runScan() {
 			image = true
 		case os.Args[i] == "--offline":
 			offline = true
+		case os.Args[i] == "--json":
+			jsonOut = true
 		default:
 			fmt.Fprintf(os.Stderr, "synapse-cli: unknown or incomplete option %q\n", os.Args[i])
 			os.Exit(2)
@@ -129,7 +134,7 @@ func runScan() {
 		fmt.Fprintf(os.Stderr, "synapse-cli: %v (mode want full|vulnerabilities|licenses; detection-priority want comprehensive|precise)\n", err)
 		os.Exit(2)
 	}
-	if err := run(os.Args[2], failOn, mode, priority, ignoreUnfixed, image, offline); err != nil {
+	if err := run(os.Args[2], failOn, mode, priority, ignoreUnfixed, image, offline, jsonOut); err != nil {
 		fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 		os.Exit(1)
 	}
@@ -207,7 +212,7 @@ func (stderrAudit) Record(_ context.Context, e ports.AuditEntry) error {
 
 var _ ports.AuditLogger = stderrAudit{}
 
-func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfixed, image, offline bool) error {
+func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfixed, image, offline, jsonOut bool) error {
 	// An image target is an OCI reference (acquired via crane → OCI layout); a local
 	// target is a filesystem path that must be absolute for the scope check.
 	target := strings.TrimSpace(path)
@@ -250,7 +255,8 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil)),
 	)
 	sca.SetSBOMEnricher(manifest.New())
-	sca.SetMavenCoordResolver(mavencoord.New()) // recover real Maven coords from JAR pom.properties (offline) before license lookup
+	sca.SetMavenCoordResolver(mavencoord.New())   // recover real Maven coords from JAR pom.properties (offline) before license lookup
+	sca.SetJarChecksumResolver(jarchecksum.New()) // capture JAR artifact SHA-1 from the workspace (Syft omits it from CycloneDX)
 	// SHA-1 coordinate recovery for shaded/metadata-less JARs: offline trivy-java-db index
 	// (SYNAPSE_JARHASH_DB_PATH) first, online Maven Central (SYNAPSE_JARHASH_ONLINE_ENABLED) as fallback.
 	var jhResolvers []ports.JarHashResolver
@@ -356,7 +362,17 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		return fmt.Errorf("scan: %w", err)
 	}
 
-	printReport(target, res)
+	if jsonOut {
+		// Machine-readable full scan result (for CI / tooling / cross-scanner comparison), to stdout so the
+		// human report never mixes in. The --fail-on gate below still sets the exit code.
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(res); err != nil {
+			return fmt.Errorf("encode json result: %w", err)
+		}
+	} else {
+		printReport(target, res)
+	}
 
 	gate := shared.SeverityRank(failOn)
 	accepted := res.SuppressedKeys() // .synapseignore/VEX accepted-risk: reported + sealed, but exempt from the gate

--- a/internal/infrastructure/tools/jarchecksum/resolver.go
+++ b/internal/infrastructure/tools/jarchecksum/resolver.go
@@ -1,0 +1,166 @@
+// Package jarchecksum captures the artifact SHA-1 of JVM components by hashing the JAR files in the prepared
+// workspace. Syft computes a JAR digest but omits it from its CycloneDX output, so a Syft-produced SBOM
+// carries no checksum for its JAR components — leaving the SBOM checksum quality element at zero and starving
+// JarHashResolver, which needs a SHA-1 as input for shaded-JAR coordinate recovery.
+//
+// This resolver walks the workspace once, streams a SHA-1 over each JAR file (the standard Maven artifact
+// SHA-1, matching the `.jar.sha1` sidecar and the coordinate indexes JarHashResolver queries), and sets
+// Component.SHA1 + a Checksums entry in place for components that name that JAR and carry no SHA-1 yet. It
+// only ever READS files (no exec, no network), skips symlinks (an untrusted workspace could point one out of
+// tree), and is bounded against pathological inputs.
+package jarchecksum
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec // artifact SHA-1 is the Maven identity form (matches .jar.sha1 + jarhash indexes), not a security primitive
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxJARs     = 20000     // bound the workspace walk (total workspace size is already capped upstream)
+	maxJARBytes = 512 << 20 // never stream-hash a file larger than this (defensive)
+)
+
+// Resolver hashes workspace JARs to fill in missing component SHA-1s.
+type Resolver struct{}
+
+// New returns a resolver.
+func New() *Resolver { return &Resolver{} }
+
+var _ ports.JarChecksumResolver = (*Resolver)(nil)
+
+// Resolve sets Component.SHA1 + a SHA1 Checksums entry for each JVM component whose JAR is present under
+// wsDir and that has no SHA-1 yet. Matching is by JAR file name (the component Location's base name), so it
+// is exact for a normal dependency set; a base name that appears at two different paths is left unmatched
+// (never guessed). Returns the number of components whose SHA-1 was set.
+func (r *Resolver) Resolve(ctx context.Context, wsDir string, comps []sbom.Component) int {
+	if strings.TrimSpace(wsDir) == "" {
+		return 0
+	}
+	// Only walk if at least one component actually needs a SHA-1 and looks like a JAR — avoids the file I/O
+	// entirely for non-JVM scans.
+	need := false
+	for i := range comps {
+		if comps[i].SHA1 == "" && isJARName(filepath.Base(comps[i].Location)) {
+			need = true
+			break
+		}
+	}
+	if !need {
+		return 0
+	}
+
+	byName, ambiguous := hashWorkspaceJARs(ctx, wsDir)
+	set := 0
+	for i := range comps {
+		c := &comps[i]
+		if c.SHA1 != "" {
+			continue
+		}
+		name := filepath.Base(strings.TrimSpace(c.Location))
+		if name == "" || ambiguous[name] {
+			continue
+		}
+		if h := byName[name]; h != "" {
+			c.SHA1 = h
+			if !hasSHA1Checksum(c.Checksums) { // don't duplicate a SHA1 the producer already recorded in Checksums
+				c.Checksums = append(c.Checksums, sbom.Checksum{Algorithm: "SHA1", Value: h})
+			}
+			set++
+		}
+	}
+	return set
+}
+
+// hashWorkspaceJARs walks wsDir and returns base-name -> lowercase-hex SHA-1 for each JAR. A base name seen
+// at two paths with different digests is marked ambiguous and dropped (we never guess which file a component
+// refers to).
+func hashWorkspaceJARs(ctx context.Context, wsDir string) (byName map[string]string, ambiguous map[string]bool) {
+	byName = map[string]string{}
+	ambiguous = map[string]bool{}
+	count := 0
+	_ = filepath.WalkDir(wsDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable entry: skip, never fatal
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !d.Type().IsRegular() { // skip symlinks etc. — an untrusted workspace must not hash a link out of tree
+			return nil
+		}
+		if !isJARName(d.Name()) {
+			return nil
+		}
+		if count >= maxJARs {
+			return filepath.SkipAll
+		}
+		count++
+		h, ok := fileSHA1(path)
+		if !ok {
+			return nil
+		}
+		name := d.Name()
+		if ambiguous[name] {
+			return nil
+		}
+		if prev, seen := byName[name]; seen {
+			if prev != h { // same file name, different bytes at two paths → can't attribute; drop
+				ambiguous[name] = true
+				delete(byName, name)
+			}
+			return nil
+		}
+		byName[name] = h
+		return nil
+	})
+	return byName, ambiguous
+}
+
+// fileSHA1 streams a SHA-1 over the file, refusing an over-large file. Returns "" on any error.
+func fileSHA1(path string) (string, bool) {
+	fi, err := os.Lstat(path)
+	if err != nil || !fi.Mode().IsRegular() || fi.Size() > maxJARBytes {
+		return "", false
+	}
+	// O_NOFOLLOW closes the Lstat->Open TOCTOU: if the regular file were swapped for a symlink between the
+	// stat above and this open, the open fails rather than following the link out of the untrusted workspace.
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0) //nolint:gosec // bounded workspace walk, regular-file re-verified, O_NOFOLLOW-guarded
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = f.Close() }()
+	h := sha1.New() //nolint:gosec // Maven artifact identity, not a security hash
+	if _, err := io.Copy(h, io.LimitReader(f, maxJARBytes)); err != nil {
+		return "", false
+	}
+	return hex.EncodeToString(h.Sum(nil)), true
+}
+
+// hasSHA1Checksum reports whether the list already carries a SHA-1 digest.
+func hasSHA1Checksum(cks []sbom.Checksum) bool {
+	for _, c := range cks {
+		if strings.EqualFold(c.Algorithm, "SHA1") {
+			return true
+		}
+	}
+	return false
+}
+
+// isJARName reports whether a file name is a Java archive.
+func isJARName(name string) bool {
+	n := strings.ToLower(name)
+	return strings.HasSuffix(n, ".jar") || strings.HasSuffix(n, ".war") || strings.HasSuffix(n, ".ear")
+}

--- a/internal/infrastructure/tools/jarchecksum/resolver_test.go
+++ b/internal/infrastructure/tools/jarchecksum/resolver_test.go
@@ -1,0 +1,116 @@
+package jarchecksum
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec // test computes the expected artifact SHA-1 to match the resolver
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+func sha1hex(b []byte) string {
+	h := sha1.Sum(b) //nolint:gosec // artifact identity, not a security hash
+	return hex.EncodeToString(h[:])
+}
+
+func writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveCapturesJarSHA1(t *testing.T) {
+	ws := t.TempDir()
+	content := []byte("PK\x03\x04 fake jar bytes for hashing")
+	writeFile(t, filepath.Join(ws, "commons-collections-3.2.1.jar"), content)
+	want := sha1hex(content)
+
+	comps := []sbom.Component{
+		{Name: "commons-collections", Version: "3.2.1", PURL: "pkg:maven/commons-collections/commons-collections@3.2.1", Location: "/commons-collections-3.2.1.jar"},
+	}
+	n := (&Resolver{}).Resolve(context.Background(), ws, comps)
+	if n != 1 {
+		t.Fatalf("want 1 component checksummed, got %d", n)
+	}
+	if comps[0].SHA1 != want {
+		t.Errorf("SHA1 = %q, want %q (the jar file's real digest)", comps[0].SHA1, want)
+	}
+	if len(comps[0].Checksums) != 1 || comps[0].Checksums[0].Algorithm != "SHA1" || comps[0].Checksums[0].Value != want {
+		t.Errorf("Checksums = %+v, want [{SHA1 %s}]", comps[0].Checksums, want)
+	}
+}
+
+func TestResolveDoesNotOverrideExistingSHA1(t *testing.T) {
+	ws := t.TempDir()
+	writeFile(t, filepath.Join(ws, "x-1.0.jar"), []byte("bytes"))
+	comps := []sbom.Component{{Name: "x", Version: "1.0", Location: "/x-1.0.jar", SHA1: "preexisting"}}
+	if n := (&Resolver{}).Resolve(context.Background(), ws, comps); n != 0 {
+		t.Errorf("must not touch a component that already has a SHA1, set %d", n)
+	}
+	if comps[0].SHA1 != "preexisting" || len(comps[0].Checksums) != 0 {
+		t.Errorf("existing SHA1 must survive, got %q / %+v", comps[0].SHA1, comps[0].Checksums)
+	}
+}
+
+func TestResolveSkipsMissingJarAndNonJar(t *testing.T) {
+	ws := t.TempDir()
+	writeFile(t, filepath.Join(ws, "present-1.0.jar"), []byte("here"))
+	comps := []sbom.Component{
+		{Name: "absent", Version: "1.0", Location: "/absent-1.0.jar"},      // no such file
+		{Name: "npmpkg", Version: "1.0", Location: "/node_modules/lodash"}, // not a jar
+		{Name: "present", Version: "1.0", Location: "/present-1.0.jar"},    // has a jar
+	}
+	n := (&Resolver{}).Resolve(context.Background(), ws, comps)
+	if n != 1 {
+		t.Fatalf("only the present jar should be checksummed, got %d", n)
+	}
+	if comps[0].SHA1 != "" || comps[1].SHA1 != "" {
+		t.Error("absent/non-jar components must stay without a SHA1")
+	}
+	if comps[2].SHA1 == "" {
+		t.Error("the present jar's component must get a SHA1")
+	}
+}
+
+func TestResolveAmbiguousBasenameSkipped(t *testing.T) {
+	ws := t.TempDir()
+	// Same file name at two paths with DIFFERENT bytes: we can't attribute a component to one, so skip.
+	writeFile(t, filepath.Join(ws, "a", "dup-1.0.jar"), []byte("aaa"))
+	writeFile(t, filepath.Join(ws, "b", "dup-1.0.jar"), []byte("bbb"))
+	comps := []sbom.Component{{Name: "dup", Version: "1.0", Location: "/dup-1.0.jar"}}
+	if n := (&Resolver{}).Resolve(context.Background(), ws, comps); n != 0 {
+		t.Errorf("an ambiguous jar base name must be skipped (never guessed), set %d", n)
+	}
+	if comps[0].SHA1 != "" {
+		t.Error("ambiguous base name must not set a SHA1")
+	}
+}
+
+func TestResolveSkipsSymlink(t *testing.T) {
+	ws := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret-1.0.jar")
+	writeFile(t, outside, []byte("out of tree"))
+	link := filepath.Join(ws, "secret-1.0.jar")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	comps := []sbom.Component{{Name: "secret", Version: "1.0", Location: "/secret-1.0.jar"}}
+	if n := (&Resolver{}).Resolve(context.Background(), ws, comps); n != 0 {
+		t.Errorf("a symlinked jar must NOT be hashed (could point out of the workspace), set %d", n)
+	}
+}
+
+func TestResolveNoJARComponentsNoWalk(t *testing.T) {
+	ws := t.TempDir()
+	comps := []sbom.Component{{Name: "npmpkg", Version: "1.0", Location: "/pkg", PURL: "pkg:npm/pkg@1.0"}}
+	if n := (&Resolver{}).Resolve(context.Background(), ws, comps); n != 0 {
+		t.Errorf("a non-JVM component set must be a no-op, set %d", n)
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -980,6 +980,16 @@ type MavenCoordResolver interface {
 	Resolve(ctx context.Context, wsDir string, comps []sbom.Component) int
 }
 
+// JarChecksumResolver captures the artifact SHA-1 of each JVM component's JAR by hashing the file in the
+// prepared workspace, when the SBOM generator supplied none (Syft computes a JAR digest but omits it from
+// its CycloneDX output). It sets Component.SHA1 + a Checksums entry IN PLACE for components that have a JAR
+// on disk and no existing SHA-1, and returns the count set. This both feeds the SBOM checksum quality
+// element and unblocks JarHashResolver (which needs a SHA-1 as input). Deterministic, offline, read-only,
+// bounded, and symlink-guarded; best-effort — an unreadable JAR is skipped, never fatal.
+type JarChecksumResolver interface {
+	Resolve(ctx context.Context, wsDir string, comps []sbom.Component) int
+}
+
 // JarHashResolver recovers the Maven coordinate of a JVM component that carries NO usable in-file
 // identity — a shaded / relocated / renamed JAR whose pom.properties was stripped, which MavenCoordResolver
 // therefore cannot fix — by looking its artifact SHA-1 up against a coordinate index.

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -57,6 +57,7 @@ type Service struct {
 	licEnricher    ports.LicenseEnricher
 	sbomEnricher   ports.SBOMEnricher            // optional manifest enrichment (gem edges, maven/gradle deps, pnpm scope)
 	licCoord       ports.MavenCoordResolver      // optional: recover real Maven coords from JAR pom.properties before license lookup
+	jarChecksum    ports.JarChecksumResolver     // optional: capture JAR artifact SHA-1 from the workspace (Syft omits it from CycloneDX)
 	jarHash        ports.JarHashResolver         // optional: recover coords of shaded/metadata-less JARs via SHA-1
 	licFile        ports.LicenseFileResolver     // optional offline license-text fallback from JAR LICENSE files
 	sastAnalyzer   ports.SASTAnalyzer            // optional deterministic pattern-SAST over the live workspace
@@ -102,6 +103,11 @@ func (s *Service) SetSBOMEnricher(e ports.SBOMEnricher) { s.sbomEnricher = e }
 // offline) that runs before registry license enrichment, so a mis-derived JAR groupId
 // doesn't make the deps.dev lookup 404 → "unknown". Best-effort; nil disables it.
 func (s *Service) SetMavenCoordResolver(r ports.MavenCoordResolver) { s.licCoord = r }
+
+// SetJarChecksumResolver configures optional JAR artifact-SHA-1 capture from the prepared workspace, filling
+// in a checksum Syft's CycloneDX output omits (deterministic, offline, read-only). It runs before the SHA-1
+// coordinate recovery, which needs that checksum as input.
+func (s *Service) SetJarChecksumResolver(r ports.JarChecksumResolver) { s.jarChecksum = r }
 
 // SetJarHashResolver configures optional SHA-1 coordinate recovery for shaded/metadata-less JARs
 // an egress call to Maven Central, so it's opt-in + best-effort. nil disables it.
@@ -1485,6 +1491,14 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		} else {
 			trace.succeed(step, "Dependency graph resolution completed", map[string]int{"components": countComponents(doc), "resolved_edges": resolved})
 		}
+	}
+	// Capture each JAR's artifact SHA-1 from the workspace (Syft computes it but omits it from CycloneDX),
+	// BEFORE the SHA-1 coordinate recovery below (which needs it) and so the SBOM carries a checksum. Offline,
+	// read-only, best-effort.
+	if s.jarChecksum != nil {
+		step = trace.start(stageSBOM, "jar-checksum", "jar-sha1", "Capture JAR artifact SHA-1 from the workspace", map[string]int{"components": countComponents(doc)})
+		n := s.jarChecksum.Resolve(ctx, ws.Dir, doc.Components)
+		trace.succeed(step, "JAR checksum capture completed", map[string]int{"checksummed": n})
 	}
 	// Recover the coordinate of a shaded / metadata-less JAR from its SHA-1, BEFORE detection,
 	// so its CVEs are looked up (a JAR with no resolvable coordinate is otherwise skipped by every source).


### PR DESCRIPTION
feat(sbom): capture JAR artifact SHA-1 from the workspace (+ synapse-cli --json)

Syft computes a JAR's digest but omits it from its CycloneDX output, so a Syft-produced SBOM
carried no checksum for JAR components: the SBOM checksum quality element read 0/100 on Java
projects, and JarHashResolver (shaded-JAR coordinate recovery) was starved of the SHA-1 it
needs as input. A new jarchecksum resolver walks the prepared workspace once, streams a SHA-1
over each JAR file (the standard Maven artifact SHA-1, matching the .jar.sha1 sidecar), and
sets Component.SHA1 + a Checksums entry for components that name that JAR and have no SHA-1
yet. It runs before the SHA-1 coordinate recovery so that feature is unblocked too.

Read-only, offline, deterministic, bounded (maxJARs + a per-file size cap), and symlink-guarded
(an untrusted workspace must not hash a link out of tree). Matching is by JAR file name; a name
seen at two paths with different bytes is left unmatched (never guessed). Best-effort: an
unreadable JAR is skipped, never fatal.

Also adds `synapse-cli scan --json` (the full ScanResult as machine-readable output, for CI /
tooling / cross-scanner comparison), mirroring what other scanners provide.

Verified head-to-head against Trivy on a Spring Boot project (34 transitive jars): the captured
SHA-1s match the jar files and Maven Central exactly, and the SBOM checksum element goes 0 to
100/100.
