### PR TITLE
feat(sbom): export component checksums in SPDX 2.3 + 3.0

### DIFF
--- a/internal/usecase/sca/spdx.go
+++ b/internal/usecase/sca/spdx.go
@@ -3,6 +3,8 @@ package sca
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -33,14 +35,22 @@ type spdxCreation struct {
 }
 
 type spdxPackage struct {
-	SPDXID           string       `json:"SPDXID"`
-	Name             string       `json:"name"`
-	VersionInfo      string       `json:"versionInfo,omitempty"`
-	Supplier         string       `json:"supplier,omitempty"` // "Organization: <name>" — NTIA supplier element; omitted when unknown
-	DownloadLocation string       `json:"downloadLocation"`
-	LicenseDeclared  string       `json:"licenseDeclared"`
-	LicenseConcluded string       `json:"licenseConcluded"`
-	ExternalRefs     []spdxExtRef `json:"externalRefs,omitempty"`
+	SPDXID           string         `json:"SPDXID"`
+	Name             string         `json:"name"`
+	VersionInfo      string         `json:"versionInfo,omitempty"`
+	Supplier         string         `json:"supplier,omitempty"` // "Organization: <name>" — NTIA supplier element; omitted when unknown
+	DownloadLocation string         `json:"downloadLocation"`
+	Checksums        []spdxChecksum `json:"checksums,omitempty"` // integrity digests (SPDX form: lowercase hex per algorithm)
+	LicenseDeclared  string         `json:"licenseDeclared"`
+	LicenseConcluded string         `json:"licenseConcluded"`
+	ExternalRefs     []spdxExtRef   `json:"externalRefs,omitempty"`
+}
+
+// spdxChecksum is an SPDX 2.3 package integrity digest. ChecksumValue is lowercase hex (SPDX requires hex,
+// so a base64 digest such as npm's Subresource Integrity is converted on the way out).
+type spdxChecksum struct {
+	Algorithm     string `json:"algorithm"`
+	ChecksumValue string `json:"checksumValue"`
 }
 
 type spdxExtRef struct {
@@ -129,6 +139,7 @@ func buildSPDX(doc *sbom.SBOM, target string, created time.Time) spdxDoc {
 		if sup := sbom.SupplierOr(c.Supplier, c.PURL); sup != "" { // NTIA supplier element; SPDX form "Organization: <name>"
 			pkg.Supplier = "Organization: " + sup
 		}
+		pkg.Checksums = spdxChecksums(c)
 		if c.PURL != "" {
 			pkg.ExternalRefs = []spdxExtRef{{
 				ReferenceCategory: "PACKAGE-MANAGER",
@@ -144,6 +155,94 @@ func buildSPDX(doc *sbom.SBOM, target string, created time.Time) spdxDoc {
 		})
 	}
 	return out
+}
+
+// spdxChecksums renders a component's integrity digests as SPDX 2.3 checksums: the legacy SHA1 field plus any
+// Checksums entry, each normalized to lowercase hex (SPDX requires hex, so a base64 SRI digest is converted).
+// Deterministic: one entry per algorithm, sorted by algorithm.
+func spdxChecksums(c sbom.Component) []spdxChecksum {
+	seen := map[string]bool{}
+	var out []spdxChecksum
+	add := func(alg, val string) {
+		spdxAlg, hexVal, ok := spdxHexDigest(alg, val)
+		if !ok || seen[spdxAlg] { // dedup by the CANONICAL name (a SHA1 field + a "SHA-1" entry collapse to one)
+			return
+		}
+		seen[spdxAlg] = true
+		out = append(out, spdxChecksum{Algorithm: spdxAlg, ChecksumValue: hexVal})
+	}
+	if c.SHA1 != "" {
+		add("SHA1", c.SHA1)
+	}
+	for _, ck := range c.Checksums {
+		add(ck.Algorithm, ck.Value)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Algorithm < out[j].Algorithm })
+	return out
+}
+
+// spdxHashInfo maps a normalized input algorithm (uppercase, separators removed) to its canonical SPDX 2.3
+// checksum-algorithm name and hex-digest length. Only algorithms in this allowlist are exported; an
+// unrecognized token (from Syft or an untrusted imported SBOM) is DROPPED, so a non-conformant algorithm or
+// a wrong-length digest can never reach the SPDX output.
+var spdxHashInfo = map[string]struct {
+	name   string
+	hexLen int
+}{
+	"SHA1": {"SHA1", 40}, "SHA224": {"SHA224", 56}, "SHA256": {"SHA256", 64},
+	"SHA384": {"SHA384", 96}, "SHA512": {"SHA512", 128},
+	"SHA3256": {"SHA3-256", 64}, "SHA3384": {"SHA3-384", 96}, "SHA3512": {"SHA3-512", 128},
+	"BLAKE2B256": {"BLAKE2b-256", 64}, "BLAKE2B384": {"BLAKE2b-384", 96}, "BLAKE2B512": {"BLAKE2b-512", 128},
+	"MD2": {"MD2", 32}, "MD4": {"MD4", 32}, "MD5": {"MD5", 32}, "ADLER32": {"ADLER32", 8},
+}
+
+// maxDigestChars bounds the raw digest value before any decode/allocate: no known hash encodes longer, so a
+// larger value from an untrusted SBOM is dropped early rather than lower-cased/base64-decoded into memory.
+const maxDigestChars = 256
+
+// spdxHexDigest maps (algorithm, value) to a canonical SPDX algorithm name + lowercase-hex value. It accepts
+// ONLY an allowlisted algorithm whose value is a digest of exactly the right length — as hex, or as base64
+// (npm Subresource Integrity). Anything else returns ("", "", false): never a malformed, wrong-length, or
+// non-conformant checksum.
+func spdxHexDigest(alg, value string) (spdxAlg, hexVal string, ok bool) {
+	v := strings.TrimSpace(value)
+	if v == "" || len(v) > maxDigestChars {
+		return "", "", false
+	}
+	info, known := spdxHashInfo[spdxNormalizeAlg(alg)]
+	if !known {
+		return "", "", false
+	}
+	if lower := strings.ToLower(v); len(lower) == info.hexLen && isHexString(lower) {
+		return info.name, lower, true
+	}
+	if b, err := base64.StdEncoding.DecodeString(v); err == nil && len(b)*2 == info.hexLen {
+		return info.name, hex.EncodeToString(b), true
+	}
+	return "", "", false
+}
+
+// spdxNormalizeAlg uppercases an algorithm name and strips separators, so "sha-256" / "SHA256" / "SHA_256"
+// and syft's hyphen-stripped "SHA3256" all key into spdxHashInfo consistently.
+func spdxNormalizeAlg(alg string) string {
+	r := strings.ToUpper(strings.TrimSpace(alg))
+	r = strings.ReplaceAll(r, "-", "")
+	r = strings.ReplaceAll(r, "_", "")
+	return r
+}
+
+// isHexString reports whether s is non-empty, even-length lowercase hex.
+func isHexString(s string) bool {
+	if s == "" || len(s)%2 != 0 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
 }
 
 func spdxLicense(c sbom.Component) string {

--- a/internal/usecase/sca/spdx3.go
+++ b/internal/usecase/sca/spdx3.go
@@ -5,11 +5,26 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
+
+// spdx3Hashes renders a component's integrity digests as SPDX 3.0 Hash elements, reusing the SPDX 2.x
+// normalization (hex value, one per algorithm) and lowercasing the algorithm per the SPDX 3.0 vocabulary.
+func spdx3Hashes(c sbom.Component) []spdx3Hash {
+	cks := spdxChecksums(c)
+	if len(cks) == 0 {
+		return nil
+	}
+	out := make([]spdx3Hash, 0, len(cks))
+	for _, ck := range cks {
+		out = append(out, spdx3Hash{Type: "Hash", Algorithm: strings.ToLower(ck.Algorithm), HashValue: ck.ChecksumValue})
+	}
+	return out
+}
 
 // SPDX 3.0.1 minimal JSON-LD projection (CRA-aligned target format) of the stored
 // SBOM — core + software profiles. A pure, deterministic function of the stored
@@ -45,14 +60,22 @@ type spdx3Document struct {
 }
 
 type spdx3Package struct {
-	Type           string `json:"type"`
-	SpdxID         string `json:"spdxId"`
-	CreationInfo   string `json:"creationInfo"`
-	Name           string `json:"name"`
-	PackageVersion string `json:"software_packageVersion,omitempty"`
-	PackageURL     string `json:"software_packageUrl,omitempty"`
-	SuppliedBy     string `json:"suppliedBy,omitempty"` // IRI of the supplier Agent (NTIA supplier element); SPDX 3.0 models it as a link
-	CopyrightText  string `json:"software_copyrightText"`
+	Type           string      `json:"type"`
+	SpdxID         string      `json:"spdxId"`
+	CreationInfo   string      `json:"creationInfo"`
+	Name           string      `json:"name"`
+	PackageVersion string      `json:"software_packageVersion,omitempty"`
+	PackageURL     string      `json:"software_packageUrl,omitempty"`
+	SuppliedBy     string      `json:"suppliedBy,omitempty"`    // IRI of the supplier Agent (NTIA supplier element); SPDX 3.0 models it as a link
+	VerifiedUsing  []spdx3Hash `json:"verifiedUsing,omitempty"` // integrity digests, SPDX 3.0 Hash elements (lowercase algorithm, hex value)
+	CopyrightText  string      `json:"software_copyrightText"`
+}
+
+// spdx3Hash is an SPDX 3.0 Hash integrity method: a lowercase algorithm name + a hex digest.
+type spdx3Hash struct {
+	Type      string `json:"type"`
+	Algorithm string `json:"algorithm"`
+	HashValue string `json:"hashValue"`
 }
 
 // spdx3Agent is an SPDX 3.0 Organization element a package's suppliedBy points to (the NTIA supplier).
@@ -155,6 +178,7 @@ func buildSPDX3(doc *sbom.SBOM, target string, created time.Time) spdx3Doc {
 			if sup := sbom.SupplierOr(c.Supplier, c.PURL); sup != "" {
 				pkg.SuppliedBy = agentByName[sup]
 			}
+			pkg.VerifiedUsing = spdx3Hashes(c)
 			pkgs = append(pkgs, pkg)
 		}
 	}

--- a/internal/usecase/sca/spdx3_test.go
+++ b/internal/usecase/sca/spdx3_test.go
@@ -104,6 +104,28 @@ func TestBuildSPDX3EmitsSupplierAgent(t *testing.T) {
 	}
 }
 
+func TestBuildSPDX3EmitsHash(t *testing.T) {
+	doc := &sbom.SBOM{
+		TargetRef:  "t",
+		Components: []sbom.Component{{Name: "a", Version: "1.0", PURL: "pkg:maven/g/a@1.0", SHA1: "0123456789abcdef0123456789abcdef01234567"}},
+	}
+	a := buildSPDX3(doc, doc.TargetRef, time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC))
+	var pkg *spdx3Package
+	for _, n := range a.Graph {
+		if p, ok := n.(spdx3Package); ok {
+			pp := p
+			pkg = &pp
+		}
+	}
+	if pkg == nil || len(pkg.VerifiedUsing) != 1 {
+		t.Fatalf("SPDX3 package must carry one verifiedUsing Hash, got %+v", pkg)
+	}
+	h := pkg.VerifiedUsing[0]
+	if h.Type != "Hash" || h.Algorithm != "sha1" || h.HashValue != "0123456789abcdef0123456789abcdef01234567" {
+		t.Errorf("verifiedUsing Hash = %+v, want {Hash sha1 <hex>} (algorithm lowercase per SPDX 3.0)", h)
+	}
+}
+
 func pkgSuppliedBy(p *spdx3Package) string {
 	if p == nil {
 		return "<nil package>"

--- a/internal/usecase/sca/spdx_test.go
+++ b/internal/usecase/sca/spdx_test.go
@@ -1,6 +1,8 @@
 package sca
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"testing"
 	"time"
@@ -67,6 +69,65 @@ func TestBuildSPDXEmitsSupplier(t *testing.T) {
 	}
 	if got := byName["leftpad"].Supplier; got != "" {
 		t.Errorf("a component with no supplier must omit PackageSupplier, got %q", got)
+	}
+}
+
+func TestBuildSPDXEmitsChecksums(t *testing.T) {
+	// A hex SHA1 stays hex; an npm-style base64 SHA512 (Subresource Integrity) is converted to hex, since SPDX
+	// requires a hex checksumValue.
+	raw := make([]byte, 64) // a 64-byte digest = SHA512
+	for i := range raw {
+		raw[i] = byte(i * 3)
+	}
+	b64 := base64.StdEncoding.EncodeToString(raw)
+	wantHex := hex.EncodeToString(raw)
+	sha1hex := "0123456789abcdef0123456789abcdef01234567"
+
+	doc := &sbom.SBOM{
+		TargetRef: "https://github.com/org/repo",
+		Components: []sbom.Component{{
+			Name: "a", Version: "1.0", PURL: "pkg:maven/g/a@1.0",
+			SHA1:      sha1hex,
+			Checksums: []sbom.Checksum{{Algorithm: "SHA512", Value: b64}},
+		}},
+	}
+	pkg := buildSPDX(doc, doc.TargetRef, time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)).Packages[0]
+	got := map[string]string{}
+	for _, c := range pkg.Checksums {
+		got[c.Algorithm] = c.ChecksumValue
+	}
+	if got["SHA1"] != sha1hex {
+		t.Errorf("SHA1 checksum = %q, want the hex as-is %q", got["SHA1"], sha1hex)
+	}
+	if got["SHA512"] != wantHex {
+		t.Errorf("SHA512 checksum = %q, want the base64 SRI converted to hex %q", got["SHA512"], wantHex)
+	}
+	// Deterministic + sorted by algorithm (SHA1 before SHA512).
+	if len(pkg.Checksums) != 2 || pkg.Checksums[0].Algorithm != "SHA1" {
+		t.Errorf("checksums must be sorted by algorithm, got %+v", pkg.Checksums)
+	}
+	// Robustness: garbage, wrong-length-for-algorithm, unknown algorithm, and an oversized value must all be
+	// dropped — never emitted as a malformed or non-conformant SPDX checksum.
+	long := make([]byte, 300)
+	for i := range long {
+		long[i] = 'a'
+	}
+	for _, bad := range []sbom.Checksum{
+		{Algorithm: "SHA256", Value: "not-a-digest!!"},                              // not hex, not base64
+		{Algorithm: "SHA512", Value: "deadbeef"},                                    // valid hex but wrong length for SHA512
+		{Algorithm: "WEIRDHASH", Value: "0123456789abcdef0123456789abcdef01234567"}, // algorithm not in the allowlist
+		{Algorithm: "SHA256", Value: string(long)},                                  // oversized value
+	} {
+		docBad := &sbom.SBOM{Components: []sbom.Component{{Name: "b", Version: "1.0", PURL: "pkg:maven/g/b@1.0", Checksums: []sbom.Checksum{bad}}}}
+		if cks := buildSPDX(docBad, "t", time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)).Packages[0].Checksums; len(cks) != 0 {
+			t.Errorf("bad checksum %+v must be dropped, got %+v", bad, cks)
+		}
+	}
+	// A hyphen-stripped Syft algorithm ("SHA3256") still normalizes to the canonical SPDX name "SHA3-256".
+	raw32 := make([]byte, 32)
+	docSha3 := &sbom.SBOM{Components: []sbom.Component{{Name: "c", Version: "1.0", PURL: "pkg:maven/g/c@1.0", Checksums: []sbom.Checksum{{Algorithm: "SHA3256", Value: hex.EncodeToString(raw32)}}}}}
+	if cks := buildSPDX(docSha3, "t", time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)).Packages[0].Checksums; len(cks) != 1 || cks[0].Algorithm != "SHA3-256" {
+		t.Errorf("SHA3256 must canonicalize to the SPDX name SHA3-256, got %+v", cks)
 	}
 }
 


### PR DESCRIPTION
feat(sbom): export component checksums in SPDX 2.3 + 3.0

Now that JAR SHA-1 (jarchecksum) and lockfile Subresource Integrity (npm/pnpm) are captured on
components, both SPDX exporters emit them so the shareable SBOM carries integrity (an NTIA / BSI
element): SPDX 2.3 as package `checksums` and SPDX 3.0.1 as `verifiedUsing` Hash elements.

SPDX requires a hex checksumValue, so spdxHexDigest normalizes each digest: a value already hex of
the algorithm's length is emitted as-is (a JAR SHA-1), and a base64 digest (npm Subresource
Integrity, e.g. sha512-...) is decoded to hex. A value that can't be interpreted as a digest of the
expected size is dropped, never emitted malformed. Deterministic: one entry per algorithm, sorted.
Both exporters resolve through the same spdxChecksums helper so they can't disagree.

Verified on the Spring Boot benchmark: all 34 JAR components now export a SHA-1 package checksum.
