### PR TITLE
feat(sbom): add NTIA-2025 + OWASP SCVS L1/L2 compliance profiles

### DIFF
--- a/internal/domain/sbom/quality.go
+++ b/internal/domain/sbom/quality.go
@@ -88,6 +88,21 @@ var complianceProfiles = []complianceProfile{
 	{id: "ntia-2021", name: "NTIA 2021 minimum elements", required: []string{
 		"ntia-supplier", "ntia-name", "ntia-version", "ntia-uniqid", "ntia-dependencies", "ntia-author", "ntia-timestamp",
 	}},
+	// NTIA 2025 (CISA's refreshed minimum elements) keeps the 2021 seven and adds a per-component cryptographic
+	// hash, mapped here to the checksum element (the other 2025 additions — lifecycle phase, generation tooling
+	// context — are not yet scored, so this profile covers the data-field subset Synapse can verify today).
+	{id: "ntia-2025", name: "NTIA 2025 minimum elements (verifiable data-field subset)", required: []string{
+		"ntia-supplier", "ntia-name", "ntia-version", "ntia-uniqid", "ntia-dependencies", "ntia-author", "ntia-timestamp", "sem-checksum",
+	}},
+	// OWASP SCVS Level 1 (inventory assurance): every component is identified by name, version, and a unique
+	// identifier (PURL), and carries a license.
+	{id: "scvs-l1", name: "OWASP SCVS Level 1 (inventory)", required: []string{
+		"ntia-name", "ntia-version", "ntia-uniqid", "sem-license",
+	}},
+	// OWASP SCVS Level 2 adds integrity + provenance to L1: a component checksum and a supplier.
+	{id: "scvs-l2", name: "OWASP SCVS Level 2 (integrity)", required: []string{
+		"ntia-name", "ntia-version", "ntia-uniqid", "sem-license", "sem-checksum", "ntia-supplier",
+	}},
 	{id: "vuln-lookup", name: "Vulnerability lookup readiness", required: []string{
 		"ntia-name", "ntia-version", "ntia-uniqid",
 	}},

--- a/internal/domain/sbom/quality_test.go
+++ b/internal/domain/sbom/quality_test.go
@@ -275,6 +275,42 @@ func TestQualityComplianceProfiles(t *testing.T) {
 	}
 }
 
+func TestComplianceProfilesReferenceRealElements(t *testing.T) {
+	// Every element ID a profile requires must actually be produced by the scorer; a typo would make the
+	// profile perpetually FAIL and silently mislead. Guard against drift.
+	ids := map[string]bool{}
+	for _, e := range Quality(SBOM{Source: "s", Components: []Component{fullComponent()}}).Elements {
+		ids[e.ID] = true
+	}
+	for _, p := range complianceProfiles {
+		for _, id := range p.required {
+			if !ids[id] {
+				t.Errorf("profile %q requires element %q, which the scorer does not produce", p.id, id)
+			}
+		}
+	}
+}
+
+func TestNTIA2025AndSCVSRequireChecksum(t *testing.T) {
+	// A fully-described SBOM WITHOUT a component checksum passes NTIA-2021 + SCVS L1, but fails NTIA-2025
+	// (which adds the component-hash element) and SCVS L2 (which adds integrity).
+	comp := fullComponent()
+	comp.SHA1 = ""
+	comp.Checksums = nil
+	doc := SBOM{Source: "synapse", Components: []Component{comp}, Dependencies: []Dependency{{Ref: "gin"}}}
+	doc.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	met := map[string]bool{}
+	for _, p := range Quality(doc).Profiles {
+		met[p.ID] = p.Met
+	}
+	if !met["ntia-2021"] || !met["scvs-l1"] {
+		t.Errorf("a checksumless-but-complete SBOM should pass NTIA-2021 + SCVS L1, got %+v", met)
+	}
+	if met["ntia-2025"] || met["scvs-l2"] {
+		t.Errorf("NTIA-2025 + SCVS L2 require a component checksum; a checksumless SBOM must FAIL them, got %+v", met)
+	}
+}
+
 func TestNTIAProfileMatchesNTIAMet(t *testing.T) {
 	// The ntia-2021 profile requires exactly the NTIA elements at the same threshold as NTIAMet, so the two
 	// must never disagree. This guard fails loudly if a future NTIA element is added to the scorer but not the


### PR DESCRIPTION
feat(sbom): add NTIA-2025 + OWASP SCVS L1/L2 compliance profiles

Extends the compliance-profile framework with three more citable per-standard PASS/FAIL lenses
over the scored SBOM-quality elements: NTIA 2025 (the 2021 minimum elements plus a per-component
hash), OWASP SCVS Level 1 (inventory: name, version, unique id, license), and SCVS Level 2 (L1
plus a component checksum and a supplier). Each maps only to elements the scorer already produces;
a guard test fails if a profile references an element that does not exist, so the table can't
drift out of sync with the scorer.

These become meaningful now that component checksums are captured (jarchecksum + lockfile SRI): on
the Spring Boot benchmark SCVS Level 2 PASSES because the jar SHA-1s are present. Pure,
deterministic, LLM-free, advisory-only, purely additive.
