### PR TITLE
feat(sbom): capture Cargo + Pipfile artifact checksums

### DIFF
--- a/internal/infrastructure/tools/ownsbom/cargo.go
+++ b/internal/infrastructure/tools/ownsbom/cargo.go
@@ -29,6 +29,7 @@ func (Cargo) Markers() []string { return []string{"Cargo.lock"} }
 // "name version", the version present only to disambiguate when a crate appears at multiple versions).
 type cargoPkg struct {
 	name, version string
+	checksum      string // the [[package]] `checksum` (sha256 hex), when present
 	deps          []string
 }
 
@@ -68,6 +69,8 @@ func (Cargo) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 			cur.name = tomlString(line[len("name = "):])
 		case inPkg && strings.HasPrefix(line, "version = "):
 			cur.version = tomlString(line[len("version = "):])
+		case inPkg && strings.HasPrefix(line, "checksum = "):
+			cur.checksum = tomlString(line[len("checksum = "):])
 		case inPkg && strings.HasPrefix(line, "dependencies = ["):
 			// usually a multi-line array (Cargo's serializer), but may be inline `[…]`/`[]` on this line
 			if rest, closed := strings.CutSuffix(strings.TrimPrefix(line, "dependencies = ["), "]"); closed {
@@ -125,7 +128,11 @@ func (Cargo) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 			scope = sbom.ScopeDevelopment
 		}
 		ref := purlOf(p.name, p.version)
-		set.add(sbom.Component{Name: p.name, Version: p.version, PURL: ref, Location: in.Path, Scope: scope})
+		comp := sbom.Component{Name: p.name, Version: p.version, PURL: ref, Location: in.Path, Scope: scope}
+		if p.checksum != "" { // Cargo.lock records a sha256 hex per crate
+			comp.Checksums = []sbom.Checksum{{Algorithm: "SHA256", Value: p.checksum}}
+		}
+		set.add(comp)
 		seen := map[string]bool{ref: true} // drop duplicate targets + self-edges (parity with the Syft path)
 		var on []string
 		for _, e := range p.deps {

--- a/internal/infrastructure/tools/ownsbom/cargo_test.go
+++ b/internal/infrastructure/tools/ownsbom/cargo_test.go
@@ -23,6 +23,7 @@ dependencies = [
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -102,6 +103,14 @@ func TestCargoParseWithCompanion(t *testing.T) {
 	// resolved version + cargo PURL
 	if c := byName["serde"]; c.Version != "1.0.197" || c.PURL != "pkg:cargo/serde@1.0.197" {
 		t.Errorf("serde = %+v, want 1.0.197 / pkg:cargo/serde@1.0.197", c)
+	}
+	// the [[package]] checksum is captured as a SHA256 component Checksum
+	if ck := byName["serde"].Checksums; len(ck) != 1 || ck[0].Algorithm != "SHA256" || ck[0].Value != "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2" {
+		t.Errorf("serde checksum = %+v, want [{SHA256 3fb1c8…}]", ck)
+	}
+	// a crate without a checksum line stays without one
+	if ck := byName["serde_derive"].Checksums; len(ck) != 0 {
+		t.Errorf("serde_derive has no checksum line, want none, got %+v", ck)
 	}
 	// THE POINT: the companion Cargo.toml scopes dev-deps as development (first parser to exercise
 	// ParseInput.Dir) — across all three declaration forms.

--- a/internal/infrastructure/tools/ownsbom/pipfile.go
+++ b/internal/infrastructure/tools/ownsbom/pipfile.go
@@ -32,7 +32,31 @@ type pipfileLock struct {
 }
 
 type pipfilePkg struct {
-	Version string `json:"version"`
+	Version string   `json:"version"`
+	Hashes  []string `json:"hashes"` // "sha256:<hex>" per acceptable artifact file
+}
+
+// pyHashChecksums converts a Python lockfile hash list ("<alg>:<hex>", e.g. "sha256:abc…", as Pipfile.lock
+// and poetry.lock record one per artifact file) into component Checksums, keeping the FIRST hash of each
+// algorithm (the files share an algorithm but differ per wheel/sdist, and one representative digest is enough
+// for integrity). Malformed entries are skipped; returns nil when none parse.
+func pyHashChecksums(hashes []string) []sbom.Checksum {
+	seen := map[string]bool{}
+	var out []sbom.Checksum
+	for _, h := range hashes {
+		i := strings.IndexByte(h, ':')
+		if i <= 0 || i == len(h)-1 {
+			continue // not "<alg>:<value>"
+		}
+		alg := strings.ToUpper(strings.TrimSpace(h[:i]))
+		val := strings.TrimSpace(h[i+1:])
+		if alg == "" || val == "" || seen[alg] {
+			continue
+		}
+		seen[alg] = true
+		out = append(out, sbom.Checksum{Algorithm: alg, Value: val})
+	}
+	return out
 }
 
 // Parse extracts the resolved Python packages: "default" as production, "develop" as development. Each
@@ -58,11 +82,12 @@ func (Pipfile) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sb
 				continue
 			}
 			set.add(sbom.Component{
-				Name:     name,
-				Version:  version,
-				PURL:     "pkg:pypi/" + name + "@" + version,
-				Location: in.Path,
-				Scope:    scope,
+				Name:      name,
+				Version:   version,
+				PURL:      "pkg:pypi/" + name + "@" + version,
+				Location:  in.Path,
+				Scope:     scope,
+				Checksums: pyHashChecksums(p.Hashes),
 			})
 		}
 	}

--- a/internal/infrastructure/tools/ownsbom/pipfile_test.go
+++ b/internal/infrastructure/tools/ownsbom/pipfile_test.go
@@ -35,6 +35,13 @@ func TestPipfileParse(t *testing.T) {
 	if c := byName["requests"]; c.Version != "2.31.0" || c.PURL != "pkg:pypi/requests@2.31.0" || c.Scope != sbom.ScopeProduction {
 		t.Errorf("requests = %+v, want 2.31.0 / pkg:pypi/requests@2.31.0 / production", c)
 	}
+	// the "sha256:<hex>" hash is captured as a SHA256 component Checksum; a package with no hashes has none.
+	if ck := byName["requests"].Checksums; len(ck) != 1 || ck[0].Algorithm != "SHA256" || ck[0].Value != "x" {
+		t.Errorf("requests checksum = %+v, want [{SHA256 x}]", ck)
+	}
+	if ck := byName["django"].Checksums; len(ck) != 0 {
+		t.Errorf("django has no hashes, want no checksum, got %+v", ck)
+	}
 	// PEP 503 normalization: Django → django.
 	if c := byName["django"]; c.Version != "4.2.0" {
 		t.Errorf("Django must normalize to django @4.2.0, got %+v", c)


### PR DESCRIPTION
feat(sbom): capture Cargo + Pipfile artifact checksums

Extends owned-parser integrity capture (after npm/pnpm) to two more lockfiles: Cargo.lock's
per-crate `checksum` (SHA-256 hex) and Pipfile.lock's per-package `hashes` ("sha256:<hex>", the
first hash per algorithm). Both land on Component.Checksums, so under the owned SBOM producer
these ecosystems now carry integrity for the checksum quality element and the SPDX export. A
shared pyHashChecksums helper parses the "<alg>:<hex>" Python-lockfile form (reusable for
poetry.lock next).
