### PR TITLE
feat(sbom): capture yarn.lock integrity (both producers)

### DIFF
--- a/internal/infrastructure/tools/manifest/enricher.go
+++ b/internal/infrastructure/tools/manifest/enricher.go
@@ -114,18 +114,19 @@ type lockChecksumParser interface {
 }
 
 // checksumLockParsers maps a lockfile name to the owned parser that extracts its per-artifact integrity, for
-// the ecosystems whose parsers capture Checksums today (npm/pnpm Subresource Integrity, Cargo + Pipfile
+// the ecosystems whose parsers capture Checksums today (npm/pnpm/yarn Subresource Integrity, Cargo + Pipfile
 // hashes). More slot in here as their owned parsers gain checksum capture.
 var checksumLockParsers = map[string]lockChecksumParser{
 	"package-lock.json": ownsbom.NPM{},
 	"pnpm-lock.yaml":    ownsbom.Pnpm{},
+	"yarn.lock":         ownsbom.Yarn{},
 	"cargo.lock":        ownsbom.Cargo{},
 	"pipfile.lock":      ownsbom.Pipfile{},
 }
 
 // attachChecksums fills in a lockfile integrity digest for each generator component that has none, matched by
-// name@version. It never overwrites a digest the generator already supplied (SHA1 or Checksums). Returns the
-// number of components given a checksum.
+// the PURL-aware ComponentID. It never overwrites a digest the generator already supplied (SHA1 or Checksums).
+// Returns the number of components given a checksum.
 func attachChecksums(doc *sbom.SBOM, byID map[string][]sbom.Checksum) int {
 	if len(byID) == 0 {
 		return 0

--- a/internal/infrastructure/tools/ownsbom/yarn.go
+++ b/internal/infrastructure/tools/ownsbom/yarn.go
@@ -35,6 +35,7 @@ func (Yarn) Markers() []string { return []string{"yarn.lock"} }
 // claims (for edge resolution), and the direct deps from its dependencies: block.
 type yarnEntry struct {
 	name, version string
+	integrity     string    // the `integrity` Subresource Integrity value (Yarn v1), when present
 	descriptors   []string  // full `name@range` specs from the key line(s)
 	deps          []yarnDep // direct deps from the dependencies: block
 }
@@ -96,6 +97,10 @@ func (Yarn) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 			inDeps, depsIndent = true, indent
 		case strings.HasPrefix(line, "version ") || strings.HasPrefix(line, "version:"):
 			cur.version = strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "version")), `:" `)
+		case strings.HasPrefix(line, "integrity "):
+			// Yarn v1 records a Subresource Integrity value ("integrity sha512-<b64>"); Yarn Berry's
+			// `checksum:` is an internal cache hash, not an artifact digest, so it is intentionally not captured.
+			cur.integrity = strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "integrity")), `:" `)
 		}
 	}
 	if err := sc.Err(); err != nil {
@@ -125,7 +130,7 @@ func (Yarn) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 			scope = sbom.ScopeDevelopment
 		}
 		ref := yarnPURL(e.name, e.version)
-		set.add(sbom.Component{Name: e.name, Version: e.version, PURL: ref, Location: in.Path, Scope: scope})
+		set.add(sbom.Component{Name: e.name, Version: e.version, PURL: ref, Location: in.Path, Scope: scope, Checksums: parseSubresourceIntegrity(e.integrity)})
 		seen := map[string]bool{ref: true} // drop self-edges + duplicate targets
 		var on []string
 		for _, d := range e.deps {

--- a/internal/infrastructure/tools/ownsbom/yarn_test.go
+++ b/internal/infrastructure/tools/ownsbom/yarn_test.go
@@ -63,6 +63,10 @@ func TestYarnV1(t *testing.T) {
 	if c := byName["@babel/core"]; c.Version != "7.23.0" || c.PURL != "pkg:npm/%40babel/core@7.23.0" {
 		t.Errorf("@babel/core = %+v, want 7.23.0 / pkg:npm/%%40babel/core@7.23.0", c)
 	}
+	// the Yarn v1 `integrity` SRI line is captured as a component Checksum
+	if ck := byName["@babel/core"].Checksums; len(ck) != 1 || ck[0].Algorithm != "SHA512" || ck[0].Value != "abc" {
+		t.Errorf("@babel/core checksum = %+v, want [{SHA512 abc}]", ck)
+	}
 	// dev-scope from the companion package.json [devDependencies]
 	if c := byName["mocha"]; c.Scope != sbom.ScopeDevelopment {
 		t.Errorf("mocha must be dev-scoped via companion package.json: %+v", c)


### PR DESCRIPTION
feat(sbom): capture yarn.lock integrity (both producers)

Adds Yarn v1 `integrity` (Subresource Integrity) capture to the owned yarn parser, reusing
parseSubresourceIntegrity, and registers yarn.lock in the manifest enricher's checksum-parser map
so the digest lands on both the owned-producer SBOM and Syft-produced components (via the
enricher). Yarn Berry's `checksum:` is an internal cache hash, not an artifact digest, so it is
intentionally not captured.
