### PR TITLE
feat(sbom): capture composer.lock integrity (both producers)

### DIFF
--- a/internal/infrastructure/tools/manifest/enricher.go
+++ b/internal/infrastructure/tools/manifest/enricher.go
@@ -115,13 +115,14 @@ type lockChecksumParser interface {
 
 // checksumLockParsers maps a lockfile name to the owned parser that extracts its per-artifact integrity, for
 // the ecosystems whose parsers capture Checksums today (npm/pnpm/yarn Subresource Integrity, Cargo + Pipfile
-// hashes). More slot in here as their owned parsers gain checksum capture.
+// hashes, Composer dist shasum). More slot in here as their owned parsers gain checksum capture.
 var checksumLockParsers = map[string]lockChecksumParser{
 	"package-lock.json": ownsbom.NPM{},
 	"pnpm-lock.yaml":    ownsbom.Pnpm{},
 	"yarn.lock":         ownsbom.Yarn{},
 	"cargo.lock":        ownsbom.Cargo{},
 	"pipfile.lock":      ownsbom.Pipfile{},
+	"composer.lock":     ownsbom.Composer{},
 }
 
 // attachChecksums fills in a lockfile integrity digest for each generator component that has none, matched by

--- a/internal/infrastructure/tools/ownsbom/composer.go
+++ b/internal/infrastructure/tools/ownsbom/composer.go
@@ -31,6 +31,9 @@ type composerLock struct {
 type composerPkg struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
+	Dist    struct {
+		Shasum string `json:"shasum"` // the distribution artifact's SHA-1 hex (Composer records it per package)
+	} `json:"dist"`
 }
 
 // Parse extracts the resolved PHP packages: "packages" as production, "packages-dev" as development. Each
@@ -52,13 +55,17 @@ func (Composer) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []s
 			if name == "" || version == "" {
 				continue // an entry missing identity is dropped (componentSet would drop it anyway)
 			}
-			set.add(sbom.Component{
+			comp := sbom.Component{
 				Name:     name,
 				Version:  version,
 				PURL:     "pkg:composer/" + name + "@" + version,
 				Location: in.Path,
 				Scope:    scope,
-			})
+			}
+			if s := strings.TrimSpace(p.Dist.Shasum); s != "" {
+				comp.Checksums = []sbom.Checksum{{Algorithm: "SHA1", Value: s}}
+			}
+			set.add(comp)
 		}
 	}
 	add(lock.Packages, baseScope)

--- a/internal/infrastructure/tools/ownsbom/composer_test.go
+++ b/internal/infrastructure/tools/ownsbom/composer_test.go
@@ -9,7 +9,7 @@ import (
 
 const composerLockFixture = `{
   "packages": [
-    {"name": "symfony/console", "version": "v6.3.0"},
+    {"name": "symfony/console", "version": "v6.3.0", "dist": {"type": "zip", "shasum": "0123456789abcdef0123456789abcdef01234567"}},
     {"name": "monolog/monolog", "version": "3.4.0"}
   ],
   "packages-dev": [
@@ -34,6 +34,13 @@ func TestComposerParse(t *testing.T) {
 	}
 	if c := byName["symfony/console"]; c.PURL != "pkg:composer/symfony/console@v6.3.0" {
 		t.Errorf("vendor/package PURL wrong: %+v", c)
+	}
+	// the dist.shasum (SHA-1) is captured as a component Checksum; a package without a dist has none.
+	if ck := byName["symfony/console"].Checksums; len(ck) != 1 || ck[0].Algorithm != "SHA1" || ck[0].Value != "0123456789abcdef0123456789abcdef01234567" {
+		t.Errorf("symfony/console checksum = %+v, want [{SHA1 0123…}]", ck)
+	}
+	if ck := byName["monolog/monolog"].Checksums; len(ck) != 0 {
+		t.Errorf("monolog has no dist.shasum, want no checksum, got %+v", ck)
 	}
 	if c := byName["symfony/console"]; c.Scope == sbom.ScopeDevelopment {
 		t.Errorf("a production package must not be development-scoped: %+v", c)


### PR DESCRIPTION
feat(sbom): capture composer.lock integrity (both producers)

Adds Composer dist.shasum (SHA-1) capture to the owned composer parser and registers composer.lock
in the manifest enricher's checksum-parser map, so PHP components carry integrity on both the
owned-producer SBOM and Syft-produced components. Completes owned-parser checksum coverage for the
common lockfile ecosystems (npm/pnpm/yarn, Cargo, Pipfile, Composer, plus JAR SHA-1); poetry.lock's
version-variant file-hash layout is a separate follow-up.
