### PR TITLE
feat(sbom): capture poetry.lock integrity (v1 + v2 layouts, both producers)

### DIFF
--- a/internal/infrastructure/tools/manifest/enricher.go
+++ b/internal/infrastructure/tools/manifest/enricher.go
@@ -122,6 +122,7 @@ var checksumLockParsers = map[string]lockChecksumParser{
 	"yarn.lock":         ownsbom.Yarn{},
 	"cargo.lock":        ownsbom.Cargo{},
 	"pipfile.lock":      ownsbom.Pipfile{},
+	"poetry.lock":       ownsbom.Poetry{},
 	"composer.lock":     ownsbom.Composer{},
 }
 

--- a/internal/infrastructure/tools/ownsbom/poetry.go
+++ b/internal/infrastructure/tools/ownsbom/poetry.go
@@ -31,37 +31,86 @@ func (Poetry) Markers() []string { return []string{"poetry.lock"} }
 // [package.dependencies] sub-table (resolved to edges in pass 2).
 type poetryPkg struct {
 	name, version, category string
+	hash                    string   // first artifact hash ("sha256:<hex>") from the package's own `files = [...]` (lock v2.0)
 	deps                    []string // raw direct-dependency names from [package.dependencies]
 }
 
-// Parse extracts the resolved packages + their dependency edges from a poetry.lock.
-func (Poetry) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+// Parse extracts the resolved packages + their dependency edges from a poetry.lock. The artifact-hash
+// capture assumes the canonical poetry/tomlkit layout where a files/`[metadata.files]` array's closing `]`
+// is on its own line (it always is); a compact closer just means the hash is not captured, never a mis-attribution.
+func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+	if err := ctx.Err(); err != nil { // honor cancellation before parsing (parity with the sibling parsers)
+		return nil, nil, err
+	}
 	baseScope := sbom.ClassifyScope(in.Path, "")
 
 	// Pass 1: collect the [[package]] blocks (identity + the direct dep names from [package.dependencies];
 	// a dep can reference a package defined later in the file, so edges are resolved in pass 2).
 	var pkgs []poetryPkg
 	var cur poetryPkg
-	inPkg, inDeps := false, false
+	inPkg, inDeps, inFiles := false, false, false
+	// Lock v1 (< 2.0) stores hashes in a trailing [metadata.files] table keyed by package name, not per
+	// package; collect them here and attach in pass 2 to whichever layout the lock used.
+	inMeta := false
+	metaName := ""
+	metaHashes := map[string]string{}
 	flush := func() {
 		if cur.name != "" && cur.version != "" {
 			pkgs = append(pkgs, cur)
 		}
-		cur, inDeps = poetryPkg{}, false
+		cur, inDeps, inFiles = poetryPkg{}, false, false
 	}
 	sc := bufio.NewScanner(bytes.NewReader(in.Content))
 	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
+		// Lock v2.0: the current package's own `files = [ {file=…, hash="sha256:…"} ]` array.
+		if inFiles {
+			if strings.HasPrefix(line, "[") {
+				// An unterminated files array (missing `]`): a new table/[[package]] ends it. Exit and fall
+				// through so the boundary line is handled below — never swallow later packages (no silent gap).
+				inFiles = false
+			} else {
+				if line == "]" {
+					inFiles = false
+				} else if cur.hash == "" {
+					cur.hash = poetryFileHash(line) // keep the first artifact hash; "" if the line has none
+				}
+				continue
+			}
+		}
+		// Lock v1: the trailing [metadata.files] table — `name = [ {file=…, hash="sha256:…"} ]`.
+		if inMeta && !strings.HasPrefix(line, "[") {
+			switch {
+			case metaName == "":
+				if i := strings.IndexByte(line, '='); i > 0 && strings.Contains(line[i:], "[") {
+					metaName = normalizePyPI(strings.Trim(strings.TrimSpace(line[:i]), `"`))
+				}
+			case line == "]":
+				metaName = ""
+			default:
+				if h := poetryFileHash(line); h != "" {
+					if _, ok := metaHashes[metaName]; !ok {
+						metaHashes[metaName] = h
+					}
+				}
+			}
+			continue
+		}
 		switch {
 		case line == "[[package]]":
 			flush() // close the previous package block
-			inPkg = true
+			inPkg, inMeta = true, false
+		case line == "[metadata.files]":
+			flush()
+			inPkg, inMeta, metaName = false, true, ""
 		case line == "[package.dependencies]":
 			inDeps = true // the current package's direct deps follow — stay associated with cur (do NOT flush)
 		case strings.HasPrefix(line, "["): // any other table ([package.extras]/[package.source]/[metadata]/…) ends the block
 			flush()
-			inPkg = false
+			inPkg, inMeta = false, false
+		case inPkg && line == "files = [": // lock v2.0 per-package artifact hashes
+			inFiles = true
 		case inDeps && strings.ContainsRune(line, '='):
 			// a dep entry `name = "constraint"` or `name = {version=…}`: the KEY (before the first =) is the
 			// dep name. A non-package-name key (e.g. a "{" array element) is filtered; an unresolvable name
@@ -102,7 +151,11 @@ func (Poetry) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.
 			scope = sbom.ScopeDevelopment
 		}
 		ref := purlOf(n, p.version)
-		set.add(sbom.Component{Name: n, Version: p.version, PURL: ref, Location: in.Path, Scope: scope})
+		hash := p.hash // lock v2.0 per-package files; fall back to the v1 [metadata.files] table
+		if hash == "" {
+			hash = metaHashes[n]
+		}
+		set.add(sbom.Component{Name: n, Version: p.version, PURL: ref, Location: in.Path, Scope: scope, Checksums: pyHashChecksums([]string{hash})})
 		seen := map[string]bool{ref: true} // drop self-edges + duplicate targets
 		var on []string
 		for _, d := range p.deps {
@@ -121,6 +174,16 @@ func (Poetry) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.
 		}
 	}
 	return set.components(), deps, nil
+}
+
+// poetryFileHash extracts the `hash = "sha256:<hex>"` value from a poetry.lock files-array entry line
+// (`{file = "…", hash = "sha256:…"}`), returning the full "alg:hex" token or "" when the line carries none.
+func poetryFileHash(line string) string {
+	i := strings.Index(line, "hash = ")
+	if i < 0 {
+		return ""
+	}
+	return tomlString(line[i+len("hash = "):])
 }
 
 // isPoetryDepKey reports whether a [package.dependencies] line's key is a package-name token (starts

--- a/internal/infrastructure/tools/ownsbom/poetry_test.go
+++ b/internal/infrastructure/tools/ownsbom/poetry_test.go
@@ -15,6 +15,10 @@ version = "2.31.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
+files = [
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:reqwhlhash"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:reqtarhash"},
+]
 
 [package.dependencies]
 charset-normalizer = ">=2,<4"
@@ -60,6 +64,14 @@ func TestPoetryParse(t *testing.T) {
 	if c := byName["requests"]; c.Version != "2.31.0" || c.PURL != "pkg:pypi/requests@2.31.0" || c.Scope != sbom.ScopeProduction {
 		t.Errorf("requests = %+v, want 2.31.0 / pkg:pypi/requests@2.31.0 / production", c)
 	}
+	// lock v2.0 per-package `files = [...]`: the FIRST artifact hash is captured as a SHA256 Checksum, and the
+	// `[package.dependencies]` block that follows the files array still parses (charset-normalizer edge above).
+	if ck := byName["requests"].Checksums; len(ck) != 1 || ck[0].Algorithm != "SHA256" || ck[0].Value != "reqwhlhash" {
+		t.Errorf("requests checksum = %+v, want [{SHA256 reqwhlhash}]", ck)
+	}
+	if len(byName["pytest"].Checksums) != 0 {
+		t.Errorf("pytest has no files block, want no checksum, got %+v", byName["pytest"].Checksums)
+	}
 	// category "dev" -> development scope; name PEP 503-normalized (Pytest -> pytest)
 	if c := byName["pytest"]; c.Version != "8.0.0" || c.Scope != sbom.ScopeDevelopment {
 		t.Errorf("pytest = %+v, want 8.0.0 / dev / normalized name", c)
@@ -71,6 +83,66 @@ func TestPoetryParse(t *testing.T) {
 	// idna appears only as a sub-table dependency range (no [[package]]) -> not a component
 	if _, ok := byName["idna"]; ok {
 		t.Error("a [package.dependencies] range key (idna) must not be emitted as a component")
+	}
+}
+
+// An unterminated v2 files array (missing `]`) must not swallow the packages that follow it — the next
+// [[package]] boundary ends the array, so no component is silently dropped.
+func TestPoetryParseUnterminatedFilesArray(t *testing.T) {
+	lock := `[[package]]
+name = "first"
+version = "1.0.0"
+files = [
+    {file = "first-1.0.0.tar.gz", hash = "sha256:firsthash"},
+
+[[package]]
+name = "second"
+version = "2.0.0"
+`
+	comps, _, err := Poetry{}.Parse(context.Background(), ParseInput{Path: "poetry.lock", Content: []byte(lock)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	byName := map[string]sbom.Component{}
+	for _, c := range comps {
+		byName[c.Name] = c
+	}
+	if _, ok := byName["second"]; !ok {
+		t.Fatalf("the package after an unterminated files array must still be emitted, got %+v", comps)
+	}
+	if ck := byName["first"].Checksums; len(ck) != 1 || ck[0].Value != "firsthash" {
+		t.Errorf("first should still get its captured hash, got %+v", ck)
+	}
+}
+
+// Lock v1 (< 2.0) stores artifact hashes in a trailing [metadata.files] table keyed by package name, not in
+// each package's own files array. The hash must still be attached to the matching component.
+func TestPoetryParseV1MetadataFiles(t *testing.T) {
+	lock := `[[package]]
+name = "Requests"
+version = "2.31.0"
+category = "main"
+
+[metadata]
+lock-version = "1.1"
+content-hash = "abc"
+
+[metadata.files]
+requests = [
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:v1whlhash"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:v1tarhash"},
+]
+`
+	comps, _, err := Poetry{}.Parse(context.Background(), ParseInput{Path: "poetry.lock", Content: []byte(lock)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d", len(comps))
+	}
+	// The [metadata.files] key "requests" (PEP 503-normalized) matches the "Requests" package; first hash wins.
+	if ck := comps[0].Checksums; len(ck) != 1 || ck[0].Algorithm != "SHA256" || ck[0].Value != "v1whlhash" {
+		t.Errorf("v1 [metadata.files] hash must attach to the component, got %+v", ck)
 	}
 }
 


### PR DESCRIPTION
feat(sbom): capture poetry.lock integrity (v1 + v2 layouts, both producers)

Adds artifact-hash capture to the owned Poetry parser for both lockfile layouts: v2.0's
per-package `files = [{file=…, hash="sha256:…"}]` array and v1's trailing [metadata.files] table
keyed by package name. The first sha256 per package is kept (reusing pyHashChecksums), and
poetry.lock is registered in the manifest enricher's checksum-parser map so the digest lands on
both the owned-producer SBOM and Syft-produced components. Completes owned-parser checksum
coverage for the common lockfile ecosystems (npm/pnpm/yarn, Cargo, Pipfile, Poetry, Composer,
plus JAR SHA-1). Verified against a poetry 1.7 lock (lock-version 2.0).
