### PR TITLE
fix(sbom): emit correct SPDX 3.0 hash-algorithm names for SHA-3 and BLAKE2b

### DIFF
--- a/internal/usecase/sca/spdx3.go
+++ b/internal/usecase/sca/spdx3.go
@@ -13,7 +13,8 @@ import (
 )
 
 // spdx3Hashes renders a component's integrity digests as SPDX 3.0 Hash elements, reusing the SPDX 2.x
-// normalization (hex value, one per algorithm) and lowercasing the algorithm per the SPDX 3.0 vocabulary.
+// normalization (hex value, one per algorithm) and mapping the canonical algorithm name to the SPDX 3.0.1
+// HashAlgorithm vocabulary (which is not a plain lower-casing for the SHA-3 and BLAKE2b families).
 func spdx3Hashes(c sbom.Component) []spdx3Hash {
 	cks := spdxChecksums(c)
 	if len(cks) == 0 {
@@ -21,9 +22,27 @@ func spdx3Hashes(c sbom.Component) []spdx3Hash {
 	}
 	out := make([]spdx3Hash, 0, len(cks))
 	for _, ck := range cks {
-		out = append(out, spdx3Hash{Type: "Hash", Algorithm: strings.ToLower(ck.Algorithm), HashValue: ck.ChecksumValue})
+		out = append(out, spdx3Hash{Type: "Hash", Algorithm: spdx3HashAlg(ck.Algorithm), HashValue: ck.ChecksumValue})
 	}
 	return out
+}
+
+// spdx3HashAlgOverrides maps a canonical (SPDX 2.3-style) algorithm name to its SPDX 3.0.1 HashAlgorithm
+// token for the families whose 3.0 spelling is NOT a plain lower-casing: the SHA-3 family uses an underscore
+// (sha3_256, not sha3-256) and the BLAKE2b family uses no separator (blake2b256, not blake2b-256).
+var spdx3HashAlgOverrides = map[string]string{
+	"SHA3-256": "sha3_256", "SHA3-384": "sha3_384", "SHA3-512": "sha3_512",
+	"BLAKE2b-256": "blake2b256", "BLAKE2b-384": "blake2b384", "BLAKE2b-512": "blake2b512",
+}
+
+// spdx3HashAlg returns the SPDX 3.0.1 HashAlgorithm token for a canonical algorithm name. Most names
+// lower-case cleanly (SHA256 -> sha256, MD5 -> md5, ADLER32 -> adler32); the SHA-3 / BLAKE2b families use the
+// explicit overrides above.
+func spdx3HashAlg(canonical string) string {
+	if n, ok := spdx3HashAlgOverrides[canonical]; ok {
+		return n
+	}
+	return strings.ToLower(canonical)
 }
 
 // SPDX 3.0.1 minimal JSON-LD projection (CRA-aligned target format) of the stored
@@ -67,11 +86,11 @@ type spdx3Package struct {
 	PackageVersion string      `json:"software_packageVersion,omitempty"`
 	PackageURL     string      `json:"software_packageUrl,omitempty"`
 	SuppliedBy     string      `json:"suppliedBy,omitempty"`    // IRI of the supplier Agent (NTIA supplier element); SPDX 3.0 models it as a link
-	VerifiedUsing  []spdx3Hash `json:"verifiedUsing,omitempty"` // integrity digests, SPDX 3.0 Hash elements (lowercase algorithm, hex value)
+	VerifiedUsing  []spdx3Hash `json:"verifiedUsing,omitempty"` // integrity digests, SPDX 3.0 Hash elements (SPDX 3.0.1 HashAlgorithm token, hex value)
 	CopyrightText  string      `json:"software_copyrightText"`
 }
 
-// spdx3Hash is an SPDX 3.0 Hash integrity method: a lowercase algorithm name + a hex digest.
+// spdx3Hash is an SPDX 3.0 Hash integrity method: an SPDX 3.0.1 HashAlgorithm token + a hex digest.
 type spdx3Hash struct {
 	Type      string `json:"type"`
 	Algorithm string `json:"algorithm"`

--- a/internal/usecase/sca/spdx3_test.go
+++ b/internal/usecase/sca/spdx3_test.go
@@ -132,3 +132,20 @@ func pkgSuppliedBy(p *spdx3Package) string {
 	}
 	return p.SuppliedBy
 }
+
+func TestSPDX3HashAlg(t *testing.T) {
+	// Every canonical (SPDX 2.3-style) algorithm name the domain gate can emit must map to a valid SPDX 3.0.1
+	// HashAlgorithm token: most lower-case cleanly, but the SHA-3 family takes an underscore and BLAKE2b drops
+	// the separator. This covers all 15 names, so an override typo or a fallback regression is caught.
+	cases := map[string]string{
+		"SHA1": "sha1", "SHA224": "sha224", "SHA256": "sha256", "SHA384": "sha384", "SHA512": "sha512",
+		"SHA3-256": "sha3_256", "SHA3-384": "sha3_384", "SHA3-512": "sha3_512",
+		"BLAKE2b-256": "blake2b256", "BLAKE2b-384": "blake2b384", "BLAKE2b-512": "blake2b512",
+		"MD2": "md2", "MD4": "md4", "MD5": "md5", "ADLER32": "adler32",
+	}
+	for in, want := range cases {
+		if got := spdx3HashAlg(in); got != want {
+			t.Errorf("spdx3HashAlg(%q) = %q, want %q for the SPDX 3.0.1 vocabulary", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

The SPDX 3.0 exporter (`spdx3Hashes`) built a component's `HashAlgorithm` token by lower-casing the canonical (SPDX 2.3-style) algorithm name. That is right for most families but wrong for two:

- SHA-3: SPDX 3.0.1 wants `sha3_256`, we emitted `sha3-256`.
- BLAKE2b: SPDX 3.0.1 wants `blake2b256`, we emitted `blake2b-256`.

So those digests were serialized with non-conformant algorithm tokens in the SPDX 3.0 output.

Surfaced by the go-arch review of #35 as a pre-existing bug (out of that PR's diff), fixed here.

## How

`spdx3HashAlg(canonical)` maps the canonical name to the SPDX 3.0.1 `HashAlgorithm` vocabulary: an explicit override table for the SHA-3 and BLAKE2b families, and the plain lower-case path for the rest (`SHA256` to `sha256`, `MD5` to `md5`, `ADLER32` to `adler32`, ...). SPDX 2.3 output is unchanged.

## Blast radius

Small in practice: real lockfiles almost never carry SHA-3 or BLAKE2b digests (npm/Cargo/Composer/PyPI use SHA-1/256/512). But the SBOM model can carry them, and now the 3.0 output is conformant for the full set.

## Verify

`go build ./...`, `go vet`, full `go test ./...` green; new `TestSPDX3HashAlg` covers the mapping.
