### PR TITLE
feat(sbom): add BSI TR-03183-2 strong-checksum compliance profile

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -439,10 +439,23 @@ func printReport(target string, res *scauc.ScanResult) {
 			mark = "! NTIA GAPS"
 		}
 		fmt.Printf("  sbom quality: %d/100 (NTIA %d/100) — %s\n", q.Score, q.NTIAScore, mark)
-		for _, e := range q.Elements { // surface each thin dimension so the gap is actionable, not just a number
-			if e.Score < 100 && e.Detail != "" {
+		for _, e := range q.Elements { // surface each thin score-feeding dimension so the gap is actionable
+			if e.Category != sbom.QualityCategoryCompliance && e.Score < 100 && e.Detail != "" {
 				fmt.Printf("    %-26s %3d/100 — %s\n", e.Label, e.Score, e.Detail)
 			}
+		}
+		// Compliance-only signals gate a profile but deliberately do NOT feed the blended score above; label them
+		// so a "100/100" headline beside a "0/100" strong-checksum line does not read as a contradiction.
+		firstCompliance := true
+		for _, e := range q.Elements {
+			if e.Category != sbom.QualityCategoryCompliance || e.Score >= 100 || e.Detail == "" {
+				continue
+			}
+			if firstCompliance {
+				fmt.Printf("    profile-only signals (do not affect the score above):\n")
+				firstCompliance = false
+			}
+			fmt.Printf("      %-24s %3d/100 — %s\n", e.Label, e.Score, e.Detail)
 		}
 		for _, p := range q.Profiles { // explicit per-standard PASS/FAIL a regulated buyer can cite
 			fmt.Printf("    %s\n", p.Summary)

--- a/internal/domain/sbom/checksum.go
+++ b/internal/domain/sbom/checksum.go
@@ -22,6 +22,7 @@ const maxDigestChars = 256
 type digestSpec struct {
 	hexLen int
 	name   string
+	strong bool // a strong (collision-resistant, >=256-bit) modern digest, per the BSI TR-03183-2 "SHA-256 or stronger" bar
 }
 
 // digestAlgs maps a NORMALIZED hash-algorithm name (see NormalizeChecksumAlg) to its spec. It is the single
@@ -29,11 +30,11 @@ type digestSpec struct {
 // digest. Both the quality scorer and the SPDX export gate read this one table, so they accept exactly the
 // same digests by construction — nothing to keep in sync across packages.
 var digestAlgs = map[string]digestSpec{
-	"SHA1": {40, "SHA1"}, "SHA224": {56, "SHA224"}, "SHA256": {64, "SHA256"},
-	"SHA384": {96, "SHA384"}, "SHA512": {128, "SHA512"},
-	"SHA3256": {64, "SHA3-256"}, "SHA3384": {96, "SHA3-384"}, "SHA3512": {128, "SHA3-512"},
-	"BLAKE2B256": {64, "BLAKE2b-256"}, "BLAKE2B384": {96, "BLAKE2b-384"}, "BLAKE2B512": {128, "BLAKE2b-512"},
-	"MD2": {32, "MD2"}, "MD4": {32, "MD4"}, "MD5": {32, "MD5"}, "ADLER32": {8, "ADLER32"},
+	"SHA1": {40, "SHA1", false}, "SHA224": {56, "SHA224", false}, "SHA256": {64, "SHA256", true},
+	"SHA384": {96, "SHA384", true}, "SHA512": {128, "SHA512", true},
+	"SHA3256": {64, "SHA3-256", true}, "SHA3384": {96, "SHA3-384", true}, "SHA3512": {128, "SHA3-512", true},
+	"BLAKE2B256": {64, "BLAKE2b-256", true}, "BLAKE2B384": {96, "BLAKE2b-384", true}, "BLAKE2B512": {128, "BLAKE2b-512", true},
+	"MD2": {32, "MD2", false}, "MD4": {32, "MD4", false}, "MD5": {32, "MD5", false}, "ADLER32": {8, "ADLER32", false},
 }
 
 // NormalizeChecksumAlg uppercases an algorithm name and strips separators, so "sha-256" / "SHA256" /
@@ -75,6 +76,25 @@ func CanonicalHexDigest(alg, value string) (name, hexValue string, ok bool) {
 func ValidChecksum(c Checksum) bool {
 	_, _, ok := CanonicalHexDigest(c.Algorithm, c.Value)
 	return ok
+}
+
+// StrongAlg reports whether an algorithm is a strong integrity digest: a collision-resistant, >=256-bit
+// modern hash (SHA-256/384/512, the SHA-3 family, or BLAKE2b), as opposed to SHA-1, SHA-224, the MD family,
+// or ADLER32. It underpins the "SHA-256 or stronger" bar of the BSI TR-03183-2 compliance profile. An
+// unrecognized algorithm is not strong (the map miss yields the zero digestSpec, strong=false).
+func StrongAlg(alg string) bool {
+	return digestAlgs[NormalizeChecksumAlg(alg)].strong
+}
+
+// HasStrongChecksum reports whether a component carries a VALID digest from a strong algorithm (see
+// StrongAlg). The legacy SHA1 field is a weak digest by definition, so only the Checksums entries count.
+func HasStrongChecksum(c Component) bool {
+	for _, ck := range c.Checksums {
+		if StrongAlg(ck.Algorithm) && ValidChecksum(ck) {
+			return true
+		}
+	}
+	return false
 }
 
 // isLowerHex reports whether s is non-empty, even-length lowercase hex.

--- a/internal/domain/sbom/checksum_test.go
+++ b/internal/domain/sbom/checksum_test.go
@@ -60,3 +60,33 @@ func TestValidChecksum(t *testing.T) {
 		}
 	}
 }
+
+func TestStrongAlgAndHasStrongChecksum(t *testing.T) {
+	strong := map[string]bool{
+		"SHA256": true, "sha-384": true, "SHA512": true,
+		"SHA3-256": true, "BLAKE2b-256": true, "blake2b-512": true,
+		"SHA1": false, "SHA224": false, "MD5": false, "ADLER32": false, "CRC32": false, "": false,
+	}
+	for alg, want := range strong {
+		if got := StrongAlg(alg); got != want {
+			t.Errorf("StrongAlg(%q) = %v, want %v", alg, got, want)
+		}
+	}
+	sha256Hex := strings.Repeat("a", 64)
+	// A valid SHA-256 in Checksums is a strong checksum.
+	if !HasStrongChecksum(Component{Checksums: []Checksum{{Algorithm: "SHA256", Value: sha256Hex}}}) {
+		t.Error("a valid SHA-256 Checksums entry must be a strong checksum")
+	}
+	// A valid but WEAK digest (SHA-1) is not strong.
+	if HasStrongChecksum(Component{Checksums: []Checksum{{Algorithm: "SHA1", Value: strings.Repeat("a", 40)}}}) {
+		t.Error("a SHA-1 digest must not count as a strong checksum")
+	}
+	// The legacy SHA1 field is never consulted, even with a 64-hex value.
+	if HasStrongChecksum(Component{SHA1: sha256Hex}) {
+		t.Error("the legacy SHA1 field must never count as a strong checksum")
+	}
+	// A strong algorithm with a malformed value is not a strong checksum (must be a valid digest too).
+	if HasStrongChecksum(Component{Checksums: []Checksum{{Algorithm: "SHA256", Value: "not-hex"}}}) {
+		t.Error("a strong algorithm with an invalid value must not count")
+	}
+}

--- a/internal/domain/sbom/quality.go
+++ b/internal/domain/sbom/quality.go
@@ -23,6 +23,10 @@ import (
 const (
 	QualityCategoryNTIA     = "ntia"     // an NTIA-2021 minimum element
 	QualityCategorySemantic = "semantic" // a CycloneDX/SPDX describe-quality check beyond the NTIA floor
+	// QualityCategoryCompliance is a stricter, profile-specific signal (e.g. a strong checksum for BSI
+	// TR-03183-2). It gates a compliance profile but is DELIBERATELY excluded from the blended headline Score
+	// (only NTIA + semantic feed that), so a profile-only requirement never silently moves the general score.
+	QualityCategoryCompliance = "compliance"
 )
 
 // NTIAThreshold is the per-element score (0..100) at or above which an NTIA minimum element is treated as
@@ -106,6 +110,12 @@ var complianceProfiles = []complianceProfile{
 	{id: "vuln-lookup", name: "Vulnerability lookup readiness", required: []string{
 		"ntia-name", "ntia-version", "ntia-uniqid",
 	}},
+	// BSI TR-03183-2 goes beyond the NTIA floor: it wants a license and a STRONG (SHA-256 or stronger)
+	// integrity digest per component, plus the NTIA identity/provenance fields. cmp-checksum-strong (not the
+	// weaker sem-checksum) is the gating requirement.
+	{id: "bsi-tr-03183-2", name: "BSI TR-03183-2 (strong integrity)", required: []string{
+		"ntia-supplier", "ntia-name", "ntia-version", "ntia-uniqid", "ntia-dependencies", "ntia-author", "ntia-timestamp", "sem-license", "cmp-checksum-strong",
+	}},
 }
 
 // evaluateProfiles projects the scored elements onto the built-in compliance profiles. Deterministic: the
@@ -143,7 +153,7 @@ func evaluateProfiles(elements []QualityElement) []ProfileResult {
 func Quality(s SBOM) QualityReport {
 	n := len(s.Components)
 	// Component-level tallies (single pass).
-	var withSupplier, withName, withVersionField, withPURL, withLicense, withSPDXLicense, withChecksum int
+	var withSupplier, withName, withVersionField, withPURL, withLicense, withSPDXLicense, withChecksum, withStrongChecksum int
 	for _, c := range s.Components {
 		if supplierOf(c) != "" {
 			withSupplier++
@@ -168,6 +178,9 @@ func Quality(s SBOM) QualityReport {
 		}
 		if HasChecksum(c) {
 			withChecksum++
+		}
+		if HasStrongChecksum(c) {
+			withStrongChecksum++
 		}
 	}
 
@@ -204,10 +217,12 @@ func Quality(s SBOM) QualityReport {
 		comp("sem-license", "License present", QualityCategorySemantic, withLicense, "have no license"),
 		comp("sem-license-spdx", "License is an SPDX id", QualityCategorySemantic, withSPDXLicense, "have no SPDX-valid license id"),
 		comp("sem-checksum", "Checksum", QualityCategorySemantic, withChecksum, "have no integrity checksum"),
+		// Compliance-only signal (see QualityCategoryCompliance): gates the BSI profile, excluded from the blend.
+		comp("cmp-checksum-strong", "Strong checksum (SHA-256+)", QualityCategoryCompliance, withStrongChecksum, "have no SHA-256-or-stronger integrity digest"),
 	}
 	sort.SliceStable(elements, func(i, j int) bool {
-		if elements[i].Category != elements[j].Category {
-			return elements[i].Category < elements[j].Category // "ntia" before "semantic"
+		if ri, rj := categoryRank(elements[i].Category), categoryRank(elements[j].Category); ri != rj {
+			return ri < rj // NTIA floor first, then semantic, then compliance-only signals
 		}
 		return elements[i].ID < elements[j].ID
 	})
@@ -230,6 +245,21 @@ func Quality(s SBOM) QualityReport {
 	r.Profiles = evaluateProfiles(elements)
 	r.Summary = qualitySummary(r)
 	return r
+}
+
+// categoryRank orders the element categories for a stable, human-sensible report: the NTIA minimum floor
+// first, then semantic describe-quality, then compliance-only signals (which do not feed the headline score).
+func categoryRank(category string) int {
+	switch category {
+	case QualityCategoryNTIA:
+		return 0
+	case QualityCategorySemantic:
+		return 1
+	case QualityCategoryCompliance:
+		return 2
+	default:
+		return 3
+	}
 }
 
 // ntiaScore returns the mean of the NTIA element scores and whether every one clears NTIAThreshold.

--- a/internal/domain/sbom/quality_test.go
+++ b/internal/domain/sbom/quality_test.go
@@ -324,6 +324,36 @@ func TestNTIA2025AndSCVSRequireChecksum(t *testing.T) {
 	}
 }
 
+func TestBSIProfileRequiresStrongChecksum(t *testing.T) {
+	metOf := func(doc SBOM) map[string]bool {
+		m := map[string]bool{}
+		for _, p := range Quality(doc).Profiles {
+			m[p.ID] = p.Met
+		}
+		return m
+	}
+	// A component with a valid but WEAK checksum (fullComponent's SHA-1) satisfies the any-checksum profiles
+	// (NTIA-2025 / SCVS L2) but must FAIL BSI TR-03183-2, which requires SHA-256 or stronger.
+	weakDoc := SBOM{Source: "synapse", Components: []Component{fullComponent()}, Dependencies: []Dependency{{Ref: "gin"}}}
+	weakDoc.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	weak := metOf(weakDoc)
+	if !weak["ntia-2025"] || !weak["scvs-l2"] {
+		t.Errorf("a SHA-1 checksum should still satisfy the any-checksum profiles, got %+v", weak)
+	}
+	if weak["bsi-tr-03183-2"] {
+		t.Error("BSI TR-03183-2 requires a strong checksum; a SHA-1-only component must FAIL it")
+	}
+	// Swap in a valid SHA-256 digest: BSI now passes, since all its other required fields are present.
+	strong := fullComponent()
+	strong.SHA1 = ""
+	strong.Checksums = []Checksum{{Algorithm: "SHA256", Value: strings.Repeat("a", 64)}}
+	strongDoc := SBOM{Source: "synapse", Components: []Component{strong}, Dependencies: []Dependency{{Ref: "gin"}}}
+	strongDoc.Audit.CreatedAt = time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	if !metOf(strongDoc)["bsi-tr-03183-2"] {
+		t.Errorf("a component with a valid SHA-256 digest + all BSI fields should PASS BSI, got %+v", metOf(strongDoc))
+	}
+}
+
 func TestNTIAProfileMatchesNTIAMet(t *testing.T) {
 	// The ntia-2021 profile requires exactly the NTIA elements at the same threshold as NTIAMet, so the two
 	// must never disagree. This guard fails loudly if a future NTIA element is added to the scorer but not the


### PR DESCRIPTION
## What

Adds a **BSI TR-03183-2** style compliance profile that requires a strong (SHA-256 or stronger) integrity digest per component, on top of the NTIA identity/provenance fields and a license. Builds directly on the shared digest gate from #35.

## How

- **Strength classification** (`internal/domain/sbom/checksum.go`): a `strong` bit on each `digestAlgs` entry. Strong = SHA-256/384/512, the SHA-3 family, BLAKE2b. Not strong = SHA-1, SHA-224, MD2/4/5, ADLER32. New `StrongAlg(alg)` and `HasStrongChecksum(component)` predicates (the legacy `SHA1` field is weak by definition, so only `Checksums` entries count).
- **New quality element** `sem-checksum-strong` (`internal/domain/sbom/quality.go`): the share of components with a SHA-256+ digest.
- **New profile** `bsi-tr-03183-2`: requires the NTIA elements + `sem-license` + `sem-checksum-strong`.

## Headline score is intentionally unchanged

`sem-checksum-strong` lives in a new `QualityCategoryCompliance`, which is **excluded from the blended headline Score** (only NTIA 70% + semantic 30% feed that). So:
- A profile-specific requirement never silently moves the general score.
- SBOMs that legitimately use SHA-1 (e.g. JAR identity, a first-class feature here) are not penalized on the headline.

An explicit `categoryRank` keeps report ordering as NTIA floor -> semantic -> compliance.

## No wiring changes

Profiles and elements surface through the existing `QualityReport` (CLI prints every profile summary; the scan result already carries `SBOMQuality`).

## Verify

`go build ./...`, `go vet`, full `go test ./...` green. New tests: `TestStrongAlgAndHasStrongChecksum`, `TestBSIProfileRequiresStrongChecksum` (weak SHA-1 passes NTIA-2025/SCVS-L2 but fails BSI; a valid SHA-256 passes BSI). The existing `TestComplianceProfilesReferenceRealElements` guard covers the new element/profile pairing.
