### PR TITLE
feat(sbom): export CycloneDX 1.6 (deterministic, from stored data)

### DIFF
--- a/internal/adapter/httpapi/export_handler.go
+++ b/internal/adapter/httpapi/export_handler.go
@@ -43,6 +43,26 @@ func (rt *Router) exportSPDX(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(body)
 }
 
+// exportCycloneDX renders the engagement's latest scan SBOM as a downloadable CycloneDX 1.6 document
+// (deterministic, from stored data — no LLM in the report path). The SBOM lives with the scan, so it is
+// served by the SCA service.
+func (rt *Router) exportCycloneDX(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "engagement id is required"})
+		return
+	}
+	body, err := rt.sca.CycloneDX(r.Context(), shared.ID(id))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/vnd.cyclonedx+json")
+	w.Header().Set("Content-Disposition", `attachment; filename="synapse-`+safeID(id)+`.cdx.json"`)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
 // applyVEX ingests a client OpenVEX document and applies each statement to the
 // engagement's findings (e.g. not_affected → false positive). CRA-aligned.
 func (rt *Router) applyVEX(w http.ResponseWriter, r *http.Request) {

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -233,6 +233,7 @@ func (rt *Router) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/engagements/{id}/export/sarif", rt.authz(userdom.PermView, rt.withEngTenant(rt.exportSARIF)))
 	mux.HandleFunc("GET /api/v1/engagements/{id}/export/openvex", rt.authz(userdom.PermView, rt.withEngTenant(rt.exportOpenVEX)))
 	mux.HandleFunc("GET /api/v1/engagements/{id}/export/spdx", rt.authz(userdom.PermView, rt.withEngTenant(rt.exportSPDX)))
+	mux.HandleFunc("GET /api/v1/engagements/{id}/export/cyclonedx", rt.authz(userdom.PermView, rt.withEngTenant(rt.exportCycloneDX)))
 	mux.HandleFunc("POST /api/v1/engagements/{id}/vex", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.applyVEX)))
 	mux.HandleFunc("GET /api/v1/engagements/{id}/sbom", rt.authz(userdom.PermView, rt.withEngTenant(rt.importedSBOM)))
 	mux.HandleFunc("POST /api/v1/engagements/{id}/sbom", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.importSBOM)))

--- a/internal/usecase/sca/cyclonedx.go
+++ b/internal/usecase/sca/cyclonedx.go
@@ -1,0 +1,224 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// CycloneDX 1.6 EXPORT document — a pure, deterministic projection of the stored SBOM (templated from data,
+// no LLM), the CycloneDX peer of the SPDX 2.3 / 3.0 exporters. Synapse consumes CycloneDX on import (the
+// cdxBOM/cdxComponent types in sbom_import.go); these cdxOut* types are the distinct EMIT shape, so it emits
+// its own enriched model rather than relaying a generator's bytes.
+type cdxOutDoc struct {
+	BOMFormat    string             `json:"bomFormat"`
+	SpecVersion  string             `json:"specVersion"`
+	Version      int                `json:"version"`
+	Metadata     cdxOutMetadata     `json:"metadata"`
+	Components   []cdxOutComponent  `json:"components,omitempty"`
+	Dependencies []cdxOutDependency `json:"dependencies,omitempty"`
+}
+
+type cdxOutMetadata struct {
+	Timestamp string           `json:"timestamp"`
+	Tools     cdxOutTools      `json:"tools"`
+	Component *cdxOutComponent `json:"component,omitempty"` // the subject of the BOM (the scan target)
+}
+
+// cdxOutTools uses the CycloneDX 1.5+ tools-as-components form (the legacy tools array is deprecated).
+type cdxOutTools struct {
+	Components []cdxOutComponent `json:"components"`
+}
+
+type cdxOutComponent struct {
+	Type     string          `json:"type"`
+	BOMRef   string          `json:"bom-ref,omitempty"`
+	Name     string          `json:"name"`
+	Version  string          `json:"version,omitempty"`
+	PURL     string          `json:"purl,omitempty"`
+	Supplier *cdxOutOrg      `json:"supplier,omitempty"`
+	Licenses []cdxOutLicense `json:"licenses,omitempty"`
+	Hashes   []cdxOutHash    `json:"hashes,omitempty"`
+}
+
+type cdxOutOrg struct {
+	Name string `json:"name"`
+}
+
+// cdxOutLicense is a CycloneDX license choice: an SPDX id when known, else a free-text name (mutually exclusive).
+type cdxOutLicense struct {
+	License *cdxOutLicenseID `json:"license,omitempty"`
+}
+
+type cdxOutLicenseID struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type cdxOutHash struct {
+	Alg     string `json:"alg"`
+	Content string `json:"content"`
+}
+
+type cdxOutDependency struct {
+	Ref       string   `json:"ref"`
+	DependsOn []string `json:"dependsOn,omitempty"`
+}
+
+// CycloneDX returns the engagement's latest scan SBOM as a deterministic CycloneDX 1.6 JSON document.
+// shared.ErrNotFound if no scan has run.
+func (s *Service) CycloneDX(ctx context.Context, engagementID shared.ID) ([]byte, error) {
+	data, err := s.LatestResult(ctx, engagementID)
+	if err != nil {
+		return nil, err
+	}
+	var res ScanResult
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil, fmt.Errorf("decode scan result: %w", err)
+	}
+	doc := buildCycloneDX(res.SBOM, res.Target, res.scanTime())
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal cyclonedx: %w", err)
+	}
+	return out, nil
+}
+
+func buildCycloneDX(doc *sbom.SBOM, target string, created time.Time) cdxOutDoc {
+	name := target
+	if name == "" {
+		name = "synapse-sbom"
+	}
+	out := cdxOutDoc{
+		BOMFormat:   "CycloneDX",
+		SpecVersion: "1.6",
+		Version:     1,
+		Metadata: cdxOutMetadata{
+			Timestamp: created.Format(time.RFC3339),
+			Tools:     cdxOutTools{Components: []cdxOutComponent{{Type: "application", Name: "synapse"}}},
+			Component: &cdxOutComponent{Type: "application", Name: name, BOMRef: "synapse:root:" + hash12(name)},
+		},
+	}
+	if doc == nil {
+		return out
+	}
+	comps := append([]sbom.Component(nil), doc.Components...)
+	sort.SliceStable(comps, func(i, j int) bool {
+		if comps[i].Name != comps[j].Name {
+			return comps[i].Name < comps[j].Name
+		}
+		return comps[i].Version < comps[j].Version
+	})
+	valid := make(map[string]bool, len(comps)) // component bom-refs, so a dependency edge never dangles
+	for i, c := range comps {
+		ref := cdxBOMRef(c, i)
+		cc := cdxOutComponent{
+			Type:     "library",
+			BOMRef:   ref,
+			Name:     c.Name,
+			Version:  c.Version,
+			PURL:     c.PURL,
+			Licenses: cdxLicenses(c),
+			Hashes:   cdxHashes(c),
+		}
+		// Resolve via SupplierOr (not the raw field) so the export derives the supplier from the PURL namespace
+		// for producers/merge paths that leave Supplier empty, matching the SPDX exporters and the scorer.
+		if sup := sbom.SupplierOr(c.Supplier, c.PURL); sup != "" {
+			cc.Supplier = &cdxOutOrg{Name: sup}
+		}
+		out.Components = append(out.Components, cc)
+		valid[ref] = true
+	}
+	out.Dependencies = cdxDependencies(doc.Dependencies, valid)
+	return out
+}
+
+// cdxBOMRef is a stable, unique reference for a component. A PURL already is one (and is what the stored
+// dependency edges key on), so it is used directly; a component with no PURL gets a synthesized ref.
+func cdxBOMRef(c sbom.Component, i int) string {
+	if c.PURL != "" {
+		return c.PURL
+	}
+	return fmt.Sprintf("synapse:comp:%d:%s", i, hash12(c.Name+"@"+c.Version))
+}
+
+// cdxDependencies projects the stored dependency edges (keyed by PURL) onto CycloneDX dependency entries,
+// dropping any endpoint that has no matching component so a bom-ref never dangles. Deterministic: sorted.
+func cdxDependencies(deps []sbom.Dependency, valid map[string]bool) []cdxOutDependency {
+	var out []cdxOutDependency
+	for _, d := range deps {
+		if !valid[d.Ref] {
+			continue
+		}
+		var on []string
+		for _, t := range d.DependsOn {
+			if valid[t] {
+				on = append(on, t)
+			}
+		}
+		sort.Strings(on)
+		out = append(out, cdxOutDependency{Ref: d.Ref, DependsOn: on})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Ref < out[j].Ref })
+	return out
+}
+
+// cdxLicenses renders a component's licenses as CycloneDX license choices: an SPDX id when known, else a
+// free-text name. Empty when the component has no license (CDX omits the array rather than asserting one).
+func cdxLicenses(c sbom.Component) []cdxOutLicense {
+	var out []cdxOutLicense
+	for _, l := range c.Licenses {
+		switch {
+		case l.SPDXID != "":
+			out = append(out, cdxOutLicense{License: &cdxOutLicenseID{ID: l.SPDXID}})
+		case l.Name != "":
+			out = append(out, cdxOutLicense{License: &cdxOutLicenseID{Name: l.Name}})
+		}
+	}
+	return out
+}
+
+// cdxHashAlgorithms maps a canonical (SPDX-style) algorithm name to its CycloneDX 1.6 hashAlg enum spelling.
+// CycloneDX uses hyphenated SHA names (SHA-256, not SHA256) and defines a NARROWER set than Synapse records:
+// SHA-224, MD2, MD4, and ADLER32 have no CycloneDX enum value, so a digest in one of those is dropped on
+// export (never emitted non-conformant), mirroring how the SPDX exporter drops unsupported algorithms.
+var cdxHashAlgorithms = map[string]string{
+	"SHA1": "SHA-1", "SHA256": "SHA-256", "SHA384": "SHA-384", "SHA512": "SHA-512",
+	"SHA3-256": "SHA3-256", "SHA3-384": "SHA3-384", "SHA3-512": "SHA3-512",
+	"BLAKE2b-256": "BLAKE2b-256", "BLAKE2b-384": "BLAKE2b-384", "BLAKE2b-512": "BLAKE2b-512",
+	"MD5": "MD5",
+}
+
+// cdxHashes renders a component's integrity digests as CycloneDX hashes: the legacy SHA1 field plus any
+// Checksums entry, validated + normalized to lowercase hex through the shared domain gate (so the export
+// accepts exactly what the quality scorer counts), then mapped to the CycloneDX algorithm vocabulary.
+// Deterministic: one entry per algorithm, sorted; algorithms outside the CycloneDX enum are dropped.
+func cdxHashes(c sbom.Component) []cdxOutHash {
+	seen := map[string]bool{}
+	var out []cdxOutHash
+	add := func(alg, val string) {
+		name, hexVal, ok := sbom.CanonicalHexDigest(alg, val)
+		if !ok {
+			return
+		}
+		cdxAlg, supported := cdxHashAlgorithms[name]
+		if !supported || seen[cdxAlg] { // dedup by CycloneDX alg (a SHA1 field + a "SHA-1" entry collapse to one)
+			return
+		}
+		seen[cdxAlg] = true
+		out = append(out, cdxOutHash{Alg: cdxAlg, Content: hexVal})
+	}
+	if c.SHA1 != "" {
+		add("SHA1", c.SHA1)
+	}
+	for _, ck := range c.Checksums {
+		add(ck.Algorithm, ck.Value)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Alg < out[j].Alg })
+	return out
+}

--- a/internal/usecase/sca/cyclonedx_test.go
+++ b/internal/usecase/sca/cyclonedx_test.go
@@ -1,0 +1,121 @@
+package sca
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+func cdxFixtureSBOM() *sbom.SBOM {
+	return &sbom.SBOM{
+		Components: []sbom.Component{
+			{
+				Name: "gin", Version: "v1.9.1", PURL: "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+				Licenses:  []sbom.License{{SPDXID: "MIT"}},
+				Checksums: []sbom.Checksum{{Algorithm: "SHA256", Value: strings.Repeat("a", 64)}},
+			},
+			{
+				Name: "log4j-core", Version: "2.14.1", PURL: "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+				Licenses: []sbom.License{{Name: "Apache-2.0"}},
+				SHA1:     strings.Repeat("b", 40),
+			},
+		},
+		Dependencies: []sbom.Dependency{
+			{Ref: "pkg:golang/github.com/gin-gonic/gin@v1.9.1", DependsOn: []string{"pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1"}},
+		},
+	}
+}
+
+func TestBuildCycloneDXDeterministicAndValid(t *testing.T) {
+	created := time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)
+	d := buildCycloneDX(cdxFixtureSBOM(), "github.com/org/repo", created)
+
+	if d.BOMFormat != "CycloneDX" || d.SpecVersion != "1.6" || d.Version != 1 {
+		t.Errorf("doc header = %q/%q/%d, want CycloneDX/1.6/1", d.BOMFormat, d.SpecVersion, d.Version)
+	}
+	if d.Metadata.Timestamp != "2026-07-07T00:00:00Z" {
+		t.Errorf("timestamp = %q, want the scan time (never time.Now)", d.Metadata.Timestamp)
+	}
+	if d.Metadata.Component == nil || d.Metadata.Component.Name != "github.com/org/repo" {
+		t.Errorf("metadata.component must name the scan target, got %+v", d.Metadata.Component)
+	}
+	if len(d.Metadata.Tools.Components) != 1 || d.Metadata.Tools.Components[0].Name != "synapse" {
+		t.Errorf("metadata.tools should list synapse, got %+v", d.Metadata.Tools)
+	}
+	// Components sorted by name: gin before log4j-core.
+	if len(d.Components) != 2 || d.Components[0].Name != "gin" || d.Components[1].Name != "log4j-core" {
+		t.Fatalf("want [gin, log4j-core] sorted, got %+v", d.Components)
+	}
+	gin := d.Components[0]
+	if gin.BOMRef != "pkg:golang/github.com/gin-gonic/gin@v1.9.1" || gin.PURL != gin.BOMRef {
+		t.Errorf("gin bom-ref should be its PURL, got %q", gin.BOMRef)
+	}
+	if gin.Supplier == nil || gin.Supplier.Name == "" {
+		t.Errorf("gin supplier should be derived from the PURL namespace, got %+v", gin.Supplier)
+	}
+	if len(gin.Licenses) != 1 || gin.Licenses[0].License == nil || gin.Licenses[0].License.ID != "MIT" {
+		t.Errorf("gin license should be SPDX id MIT, got %+v", gin.Licenses)
+	}
+	if len(gin.Hashes) != 1 || gin.Hashes[0].Alg != "SHA-256" || gin.Hashes[0].Content != strings.Repeat("a", 64) {
+		t.Errorf("gin hash should be SHA-256, got %+v", gin.Hashes)
+	}
+	log4j := d.Components[1]
+	if len(log4j.Licenses) != 1 || log4j.Licenses[0].License == nil || log4j.Licenses[0].License.Name != "Apache-2.0" {
+		t.Errorf("log4j free-text license should be a name, got %+v", log4j.Licenses)
+	}
+	if len(log4j.Hashes) != 1 || log4j.Hashes[0].Alg != "SHA-1" {
+		t.Errorf("log4j legacy SHA1 should render as SHA-1, got %+v", log4j.Hashes)
+	}
+	// Dependency edge maps by bom-ref (PURL) and drops nothing (both endpoints exist).
+	if len(d.Dependencies) != 1 || d.Dependencies[0].Ref != "pkg:golang/github.com/gin-gonic/gin@v1.9.1" ||
+		len(d.Dependencies[0].DependsOn) != 1 || d.Dependencies[0].DependsOn[0] != "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1" {
+		t.Errorf("dependency edge should map gin -> log4j by bom-ref, got %+v", d.Dependencies)
+	}
+
+	// Deterministic: same input -> byte-identical output.
+	a, _ := json.Marshal(buildCycloneDX(cdxFixtureSBOM(), "github.com/org/repo", created))
+	b, _ := json.Marshal(buildCycloneDX(cdxFixtureSBOM(), "github.com/org/repo", created))
+	if string(a) != string(b) {
+		t.Error("buildCycloneDX must be deterministic")
+	}
+}
+
+func TestCDXDanglingDependencyEdgeDropped(t *testing.T) {
+	doc := &sbom.SBOM{
+		Components:   []sbom.Component{{Name: "a", Version: "1", PURL: "pkg:npm/a@1"}},
+		Dependencies: []sbom.Dependency{{Ref: "pkg:npm/a@1", DependsOn: []string{"pkg:npm/ghost@9"}}},
+	}
+	d := buildCycloneDX(doc, "t", time.Unix(0, 0).UTC())
+	// The edge's target has no component, so dependsOn is emptied (no dangling bom-ref).
+	if len(d.Dependencies) != 1 || len(d.Dependencies[0].DependsOn) != 0 {
+		t.Errorf("an edge to a missing component must be dropped, got %+v", d.Dependencies)
+	}
+}
+
+func TestCDXHashesAlgorithmMapping(t *testing.T) {
+	c := sbom.Component{Checksums: []sbom.Checksum{
+		{Algorithm: "sha-256", Value: strings.Repeat("a", 64)},       // -> SHA-256 (hyphenated, normalized input)
+		{Algorithm: "SHA3-256", Value: strings.Repeat("b", 64)},      // -> SHA3-256
+		{Algorithm: "SHA224", Value: strings.Repeat("c", 56)},        // dropped: no CycloneDX enum value
+		{Algorithm: "ADLER32", Value: strings.Repeat("d", 8)},        // dropped
+		{Algorithm: "MD5", Value: strings.Repeat("e", 32)},           // -> MD5
+		{Algorithm: "SHA512", Value: strings.Repeat("A", 86) + "=="}, // base64 SRI -> SHA-512, hex content
+	}}
+	h := cdxHashes(c)
+	var algs []string
+	for _, x := range h {
+		algs = append(algs, x.Alg)
+	}
+	want := []string{"MD5", "SHA-256", "SHA-512", "SHA3-256"} // sorted; SHA224 + ADLER32 dropped
+	if strings.Join(algs, ",") != strings.Join(want, ",") {
+		t.Errorf("cdx hash algs = %v, want %v", algs, want)
+	}
+	for _, x := range h {
+		if x.Alg == "SHA-512" && x.Content != strings.Repeat("00", 64) {
+			t.Errorf("base64 SRI must decode to lowercase hex, got %q", x.Content)
+		}
+	}
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -220,7 +220,7 @@ async function blobDownload(path: string, fallbackName: string): Promise<void> {
   URL.revokeObjectURL(url)
 }
 
-export async function downloadExport(engagementId: string, format: 'sarif' | 'openvex' | 'spdx'): Promise<void> {
+export async function downloadExport(engagementId: string, format: 'sarif' | 'openvex' | 'spdx' | 'cyclonedx'): Promise<void> {
   const id = encodeURIComponent(engagementId)
   await blobDownload(`/api/v1/engagements/${id}/export/${format}`, `synapse-${engagementId}.${format}.json`)
 }

--- a/web/src/pages/EngagementDetail.tsx
+++ b/web/src/pages/EngagementDetail.tsx
@@ -348,7 +348,7 @@ function EvidenceBadge({ engagementId }: { engagementId: string }) {
 }
 
 function ExportButtons({ engagementId, scan, onChanged }: { engagementId: string; scan: ScanResult | null; onChanged: () => void }) {
-  const [busy, setBusy] = useState<'sarif' | 'openvex' | 'spdx' | 'bundle' | 'sbom' | 'vex' | 'excel' | null>(null)
+  const [busy, setBusy] = useState<'sarif' | 'openvex' | 'spdx' | 'cyclonedx' | 'bundle' | 'sbom' | 'vex' | 'excel' | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [msg, setMsg] = useState<string | null>(null)
   const [building, setBuilding] = useState(false)
@@ -356,7 +356,7 @@ function ExportButtons({ engagementId, scan, onChanged }: { engagementId: string
   const sbomRef = useRef<HTMLInputElement>(null)
   const vexRef = useRef<HTMLInputElement>(null)
 
-  async function run(kind: 'sarif' | 'openvex' | 'spdx' | 'bundle') {
+  async function run(kind: 'sarif' | 'openvex' | 'spdx' | 'cyclonedx' | 'bundle') {
     setBusy(kind)
     setErr(null)
     setMsg(null)
@@ -439,6 +439,9 @@ function ExportButtons({ engagementId, scan, onChanged }: { engagementId: string
         </Button>
         <Button variant="secondary" loading={busy === 'spdx'} onClick={() => run('spdx')} className="px-3 py-1.5" title="SPDX 3.0.1 (CRA-aligned)">
           <Download className="size-4" /> SPDX
+        </Button>
+        <Button variant="secondary" loading={busy === 'cyclonedx'} onClick={() => run('cyclonedx')} className="px-3 py-1.5" title="CycloneDX 1.6">
+          <Download className="size-4" /> CycloneDX
         </Button>
         <Button variant="secondary" loading={busy === 'bundle'} onClick={() => run('bundle')} className="px-3 py-1.5" title="Portable engagement bundle with the evidence chain (re-verified on import)">
           <PackageOpen className="size-4" /> Bundle


### PR DESCRIPTION
## What

Adds a **CycloneDX 1.6 exporter**. Synapse consumed CycloneDX on import and advertised CycloneDX support, but could only export SPDX 2.3 / 3.0.1, SARIF, and OpenVEX. This closes that parity gap so it can emit its own enriched SBOM as CycloneDX, not just relay a generator's bytes.

## How

`internal/usecase/sca/cyclonedx.go` mirrors the SPDX exporters: a pure, deterministic projection of the stored SBOM (no LLM in the report path), byte-reproducible from the pinned scan time. It emits:

- Components: type / name / version / purl / bom-ref.
- Licenses: SPDX id when known, else a free-text name (CDX license choice).
- Hashes: integrity digests via the shared `sbom.CanonicalHexDigest` gate, so the export accepts exactly what the quality scorer validates. CycloneDX defines a narrower algorithm set, so SHA-224, MD2, MD4, and ADLER32 are dropped rather than emitted non-conformant.
- Supplier: via `sbom.SupplierOr` (derives from the PURL namespace when a producer left it blank), matching the SPDX exporters.
- Dependencies: the stored edge graph mapped by bom-ref; an edge to a component absent from the BOM is dropped so a bom-ref never dangles.

Exposed at `GET /api/v1/engagements/{id}/export/cyclonedx` (PermView + tenant scope, mirroring the SPDX route), plus a CycloneDX button in the engagement export bar.

## Notes

- Exporter types are named `cdxOut*` to stay distinct from the importer's `cdx*` parse types in the same package.
- CycloneDX 1.6 is the current stable spec version (broad tool support); the import path already handles newer input independently.

## Verify

Backend: `go build ./...`, `go vet`, full `go test ./...` green. New tests: `TestBuildCycloneDXDeterministicAndValid` (header, sorted components, purl/license/hash/supplier, dependency mapping, byte-determinism), `TestCDXHashesAlgorithmMapping` (SHA-256/SHA3-256/MD5 mapped, SHA-224/ADLER32 dropped, base64 SRI to hex), `TestCDXDanglingDependencyEdgeDropped`. Web typecheck/build verified by the Frontend CI job (the local pnpm toolchain is unavailable in my environment).
