### PR TITLE
fix(sbom): accept CycloneDX 1.4-1.6 on import, not only 1.4

### DIFF
--- a/internal/usecase/sca/sbom_import.go
+++ b/internal/usecase/sca/sbom_import.go
@@ -156,12 +156,11 @@ type cdxBOM struct {
 	BOMFormat   string `json:"bomFormat"`
 	SpecVersion string `json:"specVersion"`
 	Metadata    struct {
-		Tools []struct {
-			Vendor  string `json:"vendor"`
-			Name    string `json:"name"`
-			Version string `json:"version"`
-		} `json:"tools"`
-		Component cdxComponent `json:"component"`
+		// Tools is the legacy array [{vendor,name,version}] (<=1.4) OR the object {components:[...]} (1.5+);
+		// kept raw so a modern document does not fail the whole decode on this optional field. Parsed by
+		// cdxGeneratorVersion.
+		Tools     json.RawMessage `json:"tools"`
+		Component cdxComponent    `json:"component"`
 	} `json:"metadata"`
 	Components   []cdxComponent  `json:"components"`
 	Dependencies []cdxDependency `json:"dependencies"`
@@ -193,6 +192,17 @@ type cdxDependency struct {
 	DependsOn []string `json:"dependsOn"`
 }
 
+// supportedCDXSpecVersions are the CycloneDX 1.x spec versions the importer accepts. The fields Synapse
+// reads (bomFormat, components with purl/version/licenses, metadata.component, dependencies) are
+// stable across these versions and CycloneDX is backward-tolerant within 1.x, so a 1.5/1.6 document parses
+// the same as a 1.4 one. Accepting 1.5/1.6 lets Synapse ingest what current Syft/Trivy/cdxgen emit by
+// default, and re-import its own CycloneDX 1.6 export.
+var supportedCDXSpecVersions = map[string]bool{"1.4": true, "1.5": true, "1.6": true}
+
+func supportedCDXSpecVersion(v string) bool {
+	return supportedCDXSpecVersions[strings.TrimSpace(v)]
+}
+
 // parseCycloneDX decodes a CycloneDX JSON document into domain components + the
 // target name from metadata. Rejects a non-CycloneDX or empty document.
 func parseCycloneDX(data []byte) (parsedCycloneDX, error) {
@@ -203,8 +213,8 @@ func parseCycloneDX(data []byte) (parsedCycloneDX, error) {
 	if !strings.EqualFold(bom.BOMFormat, "CycloneDX") {
 		return parsedCycloneDX{}, fmt.Errorf("%w: not a CycloneDX document (bomFormat=%q)", shared.ErrValidation, bom.BOMFormat)
 	}
-	if strings.TrimSpace(bom.SpecVersion) != "1.4" {
-		return parsedCycloneDX{}, fmt.Errorf("%w: unsupported CycloneDX specVersion %q", shared.ErrValidation, bom.SpecVersion)
+	if !supportedCDXSpecVersion(bom.SpecVersion) {
+		return parsedCycloneDX{}, fmt.Errorf("%w: unsupported CycloneDX specVersion %q (supported: 1.4, 1.5, 1.6)", shared.ErrValidation, bom.SpecVersion)
 	}
 	if len(bom.Components) == 0 {
 		return parsedCycloneDX{}, fmt.Errorf("%w: CycloneDX document has no components", shared.ErrValidation)
@@ -285,27 +295,64 @@ func cdxComponentToDomain(c cdxComponent) (sbom.Component, bool) {
 	return comp, true
 }
 
-func cdxGeneratorVersion(tools []struct {
-	Vendor  string `json:"vendor"`
-	Name    string `json:"name"`
-	Version string `json:"version"`
-}) string {
-	if len(tools) == 0 {
+// cdxMaxToolsBytes bounds the raw metadata.tools value before parsing: a real tools list is a handful of
+// entries, so a larger value is an implausible/adversarial blob and yields no generator string (it never
+// rejects the document, since GeneratorVersion is optional) rather than decoding a huge transient slice.
+const cdxMaxToolsBytes = 64 << 10
+
+// cdxMaxGeneratorVersionChars caps the untrusted generator string before it is stored, sealed into the
+// import manifest, and shown, so a pathological tools.name/version cannot amplify into those sinks.
+const cdxMaxGeneratorVersionChars = 256
+
+// cdxGeneratorVersion extracts a "name/version" for the SBOM's generating tool from metadata.tools, which
+// has TWO shapes across CycloneDX versions: the legacy array [{vendor,name,version}] (<=1.4) and the object
+// {components:[{name,version}], services:[...]} (1.5+). It tries both and never errors — a tools value it
+// cannot read just yields "", so a modern document is not rejected over this optional field.
+func cdxGeneratorVersion(raw json.RawMessage) string {
+	if len(raw) == 0 || len(raw) > cdxMaxToolsBytes {
 		return ""
 	}
-	tool := tools[0]
-	name := strings.TrimSpace(tool.Name)
-	if name == "" {
-		name = strings.TrimSpace(tool.Vendor)
+	type cdxTool struct {
+		Vendor  string `json:"vendor"`
+		Name    string `json:"name"`
+		Version string `json:"version"`
 	}
-	version := strings.TrimSpace(tool.Version)
-	if name == "" {
-		return version
+	format := func(t cdxTool) string {
+		name := strings.TrimSpace(t.Name)
+		if name == "" {
+			name = strings.TrimSpace(t.Vendor)
+		}
+		version := strings.TrimSpace(t.Version)
+		var s string
+		switch {
+		case name == "":
+			s = version
+		case version == "":
+			s = name
+		default:
+			s = name + "/" + version
+		}
+		if len(s) > cdxMaxGeneratorVersionChars { // cap the untrusted string (rune-safe) before it flows onward
+			if r := []rune(s); len(r) > cdxMaxGeneratorVersionChars {
+				s = string(r[:cdxMaxGeneratorVersionChars])
+			}
+		}
+		return s
 	}
-	if version == "" {
-		return name
+	var arr []cdxTool // legacy array form
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		if len(arr) > 0 {
+			return format(arr[0])
+		}
+		return ""
 	}
-	return name + "/" + version
+	var obj struct { // 1.5+ object form: tools.components[]
+		Components []cdxTool `json:"components"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil && len(obj.Components) > 0 {
+		return format(obj.Components[0])
+	}
+	return ""
 }
 
 func hashHex(data []byte) string {

--- a/internal/usecase/sca/sbom_import_test.go
+++ b/internal/usecase/sca/sbom_import_test.go
@@ -2,7 +2,9 @@ package sca
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,6 +79,55 @@ func TestParseCycloneDXIncludesMetadataComponentAndLicenseURL(t *testing.T) {
 	}
 }
 
+func TestParseCycloneDXAcceptsModernSpecVersions(t *testing.T) {
+	// CycloneDX 1.5 and 1.6 are what current Syft/Trivy/cdxgen emit by default; the fields Synapse reads are
+	// stable across the 1.x line, so they must parse the same as 1.4 (not be rejected).
+	for _, v := range []string{"1.4", "1.5", "1.6"} {
+		doc := []byte(`{"bomFormat":"CycloneDX","specVersion":"` + v + `","metadata":{"component":{"name":"app"}},"components":[{"type":"library","name":"express","version":"4.18.2","purl":"pkg:npm/express@4.18.2"}]}`)
+		parsed, err := parseCycloneDX(doc)
+		if err != nil {
+			t.Errorf("specVersion %s must parse, got %v", v, err)
+			continue
+		}
+		if len(parsed.Components) != 1 || parsed.Components[0].PURL != "pkg:npm/express@4.18.2" {
+			t.Errorf("specVersion %s: components = %+v", v, parsed.Components)
+		}
+	}
+}
+
+func TestCDXGeneratorVersionCappedAndBounded(t *testing.T) {
+	// An untrusted, over-long tool name is capped (it flows to the stored + sealed manifest).
+	raw := json.RawMessage(`[{"name":"` + strings.Repeat("x", 1000) + `","version":"1.0"}]`)
+	if got := cdxGeneratorVersion(raw); len([]rune(got)) > 256 {
+		t.Errorf("generator version must be capped to 256 runes, got %d", len([]rune(got)))
+	}
+	// An implausibly large tools blob yields no generator string (bounded), never a panic.
+	huge := json.RawMessage(`[` + strings.Repeat(`{"name":"a"},`, 10000) + `{"name":"b"}]`)
+	if got := cdxGeneratorVersion(huge); got != "" {
+		t.Errorf("an oversized tools blob should yield an empty generator version, got %q", got)
+	}
+}
+
+// TestCycloneDXSelfRoundTrip proves the CycloneDX exporter and importer agree: a document Synapse EMITS can
+// be re-INGESTED. It caught the export(1.6)/import(1.4-only) asymmetry this change fixes.
+func TestCycloneDXSelfRoundTrip(t *testing.T) {
+	out, err := json.Marshal(buildCycloneDX(cdxFixtureSBOM(), "github.com/org/repo", time.Unix(0, 0).UTC()))
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+	parsed, err := parseCycloneDX(out)
+	if err != nil {
+		t.Fatalf("re-import of own export failed: %v", err)
+	}
+	byPURL := map[string]bool{}
+	for _, c := range parsed.Components {
+		byPURL[c.PURL] = true
+	}
+	if !byPURL["pkg:golang/github.com/gin-gonic/gin@v1.9.1"] || !byPURL["pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1"] {
+		t.Errorf("round-trip lost components: %+v", parsed.Components)
+	}
+}
+
 func TestParseCycloneDXRejectsNonCycloneDX(t *testing.T) {
 	if _, err := parseCycloneDX([]byte(`{"bomFormat":"SPDX","components":[]}`)); !errors.Is(err, shared.ErrValidation) {
 		t.Errorf("non-CycloneDX: want ErrValidation, got %v", err)
@@ -84,8 +135,8 @@ func TestParseCycloneDXRejectsNonCycloneDX(t *testing.T) {
 	if _, err := parseCycloneDX([]byte(`{"bomFormat":"CycloneDX","specVersion":"1.4","components":[]}`)); !errors.Is(err, shared.ErrValidation) {
 		t.Errorf("empty components: want ErrValidation, got %v", err)
 	}
-	if _, err := parseCycloneDX([]byte(`{"bomFormat":"CycloneDX","specVersion":"1.5","components":[{"name":"x"}]}`)); !errors.Is(err, shared.ErrValidation) {
-		t.Errorf("unsupported spec: want ErrValidation, got %v", err)
+	if _, err := parseCycloneDX([]byte(`{"bomFormat":"CycloneDX","specVersion":"1.3","components":[{"name":"x"}]}`)); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("unsupported spec (below the 1.4 floor): want ErrValidation, got %v", err)
 	}
 	if _, err := parseCycloneDX([]byte(`not json`)); !errors.Is(err, shared.ErrValidation) {
 		t.Errorf("bad json: want ErrValidation, got %v", err)


### PR DESCRIPTION
## What

The CycloneDX importer rejected every `specVersion` except exactly `"1.4"`, so it refused the 1.5 and 1.6 documents that current Syft, Trivy, and cdxgen emit **by default**, and it could not re-import Synapse's own CycloneDX 1.6 export (added in #38). Surfaced by the go-arch review of #38.

## How

- Broaden the `specVersion` gate to accept **1.4, 1.5, 1.6** (a small allowlist). The fields Synapse reads (bomFormat, components with purl/version/licenses/hashes, metadata.component, dependencies) are stable across the CycloneDX 1.x line, and CycloneDX is backward-tolerant within 1.x.
- A real 1.5+ document also carries the newer **object-form** `metadata.tools` (`{components:[...]}`) instead of the legacy array, so `Tools` is now read as `json.RawMessage` and `cdxGeneratorVersion` parses either shape, returning `""` for a tools value it cannot read rather than failing the whole decode. Without this, accepting 1.5/1.6 would still hard-fail `json.Unmarshal` on the tools type mismatch.

## Verify

`go build ./...`, `go vet`, full `go test ./...` green. New tests: `TestParseCycloneDXAcceptsModernSpecVersions` (1.4/1.5/1.6 all parse), `TestCycloneDXSelfRoundTrip` (build a CycloneDX export, re-import it), and the existing reject test updated to use `1.3` (below the floor) for its negative case. Untrusted input stays bounded: the RawMessage holds bytes already within the 32 MB import cap, and the two lenient unmarshal attempts touch only the tools sub-value.
