### PR TITLE
feat(sbom): add CycloneDX component.scope + evidence to the exporter

### DIFF
--- a/internal/usecase/sca/cyclonedx.go
+++ b/internal/usecase/sca/cyclonedx.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
@@ -36,18 +37,48 @@ type cdxOutTools struct {
 }
 
 type cdxOutComponent struct {
-	Type     string          `json:"type"`
-	BOMRef   string          `json:"bom-ref,omitempty"`
-	Name     string          `json:"name"`
-	Version  string          `json:"version,omitempty"`
-	PURL     string          `json:"purl,omitempty"`
-	Supplier *cdxOutOrg      `json:"supplier,omitempty"`
-	Licenses []cdxOutLicense `json:"licenses,omitempty"`
-	Hashes   []cdxOutHash    `json:"hashes,omitempty"`
+	Type       string           `json:"type"`
+	BOMRef     string           `json:"bom-ref,omitempty"`
+	Name       string           `json:"name"`
+	Version    string           `json:"version,omitempty"`
+	PURL       string           `json:"purl,omitempty"`
+	Scope      string           `json:"scope,omitempty"` // required|excluded|"" (never optional) — see cdxScope
+	Supplier   *cdxOutOrg       `json:"supplier,omitempty"`
+	Licenses   []cdxOutLicense  `json:"licenses,omitempty"`
+	Hashes     []cdxOutHash     `json:"hashes,omitempty"`
+	Evidence   *cdxOutEvidence  `json:"evidence,omitempty"`
+	Properties []cdxOutProperty `json:"properties,omitempty"`
 }
 
 type cdxOutOrg struct {
 	Name string `json:"name"`
+}
+
+// cdxOutEvidence carries how Synapse identified a component: identity (the coordinate + technique) and
+// occurrences (where it was found). It projects stored facts only — no fabricated signals.
+type cdxOutEvidence struct {
+	Identity    []cdxOutIdentity   `json:"identity,omitempty"`
+	Occurrences []cdxOutOccurrence `json:"occurrences,omitempty"`
+}
+
+type cdxOutIdentity struct {
+	Field   string                 `json:"field"` // e.g. "purl"
+	Methods []cdxOutIdentityMethod `json:"methods,omitempty"`
+}
+
+type cdxOutIdentityMethod struct {
+	Technique  string  `json:"technique"`
+	Confidence float64 `json:"confidence"` // 0..1
+	Value      string  `json:"value,omitempty"`
+}
+
+type cdxOutOccurrence struct {
+	Location string `json:"location"`
+}
+
+type cdxOutProperty struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // cdxOutLicense is a CycloneDX license choice: an SPDX id when known, else a free-text name (mutually exclusive).
@@ -118,13 +149,16 @@ func buildCycloneDX(doc *sbom.SBOM, target string, created time.Time) cdxOutDoc 
 	for i, c := range comps {
 		ref := cdxBOMRef(c, i)
 		cc := cdxOutComponent{
-			Type:     "library",
-			BOMRef:   ref,
-			Name:     c.Name,
-			Version:  c.Version,
-			PURL:     c.PURL,
-			Licenses: cdxLicenses(c),
-			Hashes:   cdxHashes(c),
+			Type:       "library",
+			BOMRef:     ref,
+			Name:       c.Name,
+			Version:    c.Version,
+			PURL:       c.PURL,
+			Scope:      cdxScope(c.Scope),
+			Licenses:   cdxLicenses(c),
+			Hashes:     cdxHashes(c),
+			Evidence:   cdxEvidence(c),
+			Properties: cdxProperties(c),
 		}
 		// Resolve via SupplierOr (not the raw field) so the export derives the supplier from the PURL namespace
 		// for producers/merge paths that leave Supplier empty, matching the SPDX exporters and the scorer.
@@ -166,6 +200,55 @@ func cdxDependencies(deps []sbom.Dependency, valid map[string]bool) []cdxOutDepe
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Ref < out[j].Ref })
 	return out
+}
+
+// cdxScope maps a domain component scope to the CycloneDX component.scope enum. Production code is required
+// (runtime); development and the non-shipping background scopes (test/example/fixture/benchmark/docs) are
+// excluded from the deployed artifact — this lets a consumer deprioritize dev-only vulnerabilities. It is the
+// inverse of the import mapping in sbom.ClassifyScope ("required"->production, "excluded"->development).
+// Unknown/unset yields "" so no scope is asserted.
+func cdxScope(scope string) string {
+	switch {
+	case scope == sbom.ScopeProduction:
+		return "required"
+	case scope == sbom.ScopeDevelopment || sbom.IsBackgroundScope(scope):
+		return "excluded"
+	default:
+		return ""
+	}
+}
+
+// cdxEvidence projects how Synapse identified a component: an occurrence at its Location, and — only for a
+// source-tree component (no container LayerID) with a PURL — a purl identity via the manifest-analysis
+// technique at full confidence. Every producer sets a source component's Location to the manifest/lockfile it
+// was read from, so the coordinate is a deterministic manifest read (not a guess), which is why confidence is
+// 1. An image-layer component (LayerID set) was cataloged from a layer by other means, so it gets the
+// occurrence fact WITHOUT an unfounded manifest-analysis claim. A component with no Location gets no evidence.
+// Returns nil when there is nothing to assert. (When per-technique image cataloging lands, derive the
+// technique for LayerID-bearing components rather than omitting identity.)
+func cdxEvidence(c sbom.Component) *cdxOutEvidence {
+	loc := strings.TrimSpace(c.Location)
+	if loc == "" {
+		return nil
+	}
+	ev := &cdxOutEvidence{Occurrences: []cdxOutOccurrence{{Location: loc}}}
+	if c.PURL != "" && c.LayerID == "" {
+		ev.Identity = []cdxOutIdentity{{
+			Field:   "purl",
+			Methods: []cdxOutIdentityMethod{{Technique: "manifest-analysis", Confidence: 1, Value: c.PURL}},
+		}}
+	}
+	return ev
+}
+
+// cdxProperties surfaces Synapse-specific analysis as CycloneDX namespaced properties: the coarse JVM
+// reachability verdict when one was computed. Deterministic, stored-fact only.
+func cdxProperties(c sbom.Component) []cdxOutProperty {
+	var props []cdxOutProperty
+	if r := strings.TrimSpace(c.Reachability); r != "" {
+		props = append(props, cdxOutProperty{Name: "synapse:reachability", Value: r})
+	}
+	return props
 }
 
 // cdxLicenses renders a component's licenses as CycloneDX license choices: an SPDX id when known, else a

--- a/internal/usecase/sca/cyclonedx_test.go
+++ b/internal/usecase/sca/cyclonedx_test.go
@@ -95,6 +95,58 @@ func TestCDXDanglingDependencyEdgeDropped(t *testing.T) {
 	}
 }
 
+func TestCDXEvidenceScopeAndProperties(t *testing.T) {
+	doc := &sbom.SBOM{Components: []sbom.Component{
+		{Name: "prod", Version: "1", PURL: "pkg:npm/prod@1", Scope: sbom.ScopeProduction, Location: "package.json", Reachability: sbom.ReachabilityReachable},
+		{Name: "dev", Version: "1", PURL: "pkg:npm/dev@1", Scope: sbom.ScopeDevelopment, Location: "package.json"},
+		{Name: "testdep", Version: "1", PURL: "pkg:npm/testdep@1", Scope: sbom.ScopeTest},
+		{Name: "bare", Version: "1", PURL: "pkg:npm/bare@1"},                                                                   // no scope / no location
+		{Name: "imglib", Version: "1", PURL: "pkg:deb/debian/imglib@1", Location: "/usr/lib/imglib.so", LayerID: "sha256:abc"}, // image-layer component
+	}}
+	d := buildCycloneDX(doc, "t", time.Unix(0, 0).UTC())
+	by := map[string]cdxOutComponent{}
+	for _, c := range d.Components {
+		by[c.Name] = c
+	}
+	// production -> required, with an occurrence + purl identity (manifest-analysis) and a reachability property.
+	prod := by["prod"]
+	if prod.Scope != "required" {
+		t.Errorf("prod scope = %q, want required", prod.Scope)
+	}
+	if prod.Evidence == nil || len(prod.Evidence.Occurrences) != 1 || prod.Evidence.Occurrences[0].Location != "package.json" {
+		t.Fatalf("prod occurrences = %+v", prod.Evidence)
+	}
+	if len(prod.Evidence.Identity) != 1 || prod.Evidence.Identity[0].Field != "purl" || len(prod.Evidence.Identity[0].Methods) != 1 ||
+		prod.Evidence.Identity[0].Methods[0].Technique != "manifest-analysis" || prod.Evidence.Identity[0].Methods[0].Confidence != 1 {
+		t.Errorf("prod identity = %+v", prod.Evidence.Identity)
+	}
+	if len(prod.Properties) != 1 || prod.Properties[0].Name != "synapse:reachability" || prod.Properties[0].Value != "reachable" {
+		t.Errorf("prod properties = %+v", prod.Properties)
+	}
+	// development and background(test) both -> excluded (non-shipping).
+	if by["dev"].Scope != "excluded" {
+		t.Errorf("dev scope = %q, want excluded", by["dev"].Scope)
+	}
+	if by["testdep"].Scope != "excluded" {
+		t.Errorf("test scope = %q, want excluded", by["testdep"].Scope)
+	}
+	// bare: unknown scope is not asserted, and no Location -> no evidence.
+	if by["bare"].Scope != "" {
+		t.Errorf("bare scope should be omitted, got %q", by["bare"].Scope)
+	}
+	if by["bare"].Evidence != nil || len(by["bare"].Properties) != 0 {
+		t.Errorf("bare (no location, no reachability) should have no evidence/properties, got %+v / %+v", by["bare"].Evidence, by["bare"].Properties)
+	}
+	// image-layer component: keeps the occurrence fact but makes NO manifest-analysis identity claim.
+	img := by["imglib"]
+	if img.Evidence == nil || len(img.Evidence.Occurrences) != 1 || img.Evidence.Occurrences[0].Location != "/usr/lib/imglib.so" {
+		t.Fatalf("imglib should keep its occurrence, got %+v", img.Evidence)
+	}
+	if len(img.Evidence.Identity) != 0 {
+		t.Errorf("an image-layer component (LayerID set) must not claim manifest-analysis identity, got %+v", img.Evidence.Identity)
+	}
+}
+
 func TestCDXHashesAlgorithmMapping(t *testing.T) {
 	c := sbom.Component{Checksums: []sbom.Checksum{
 		{Algorithm: "sha-256", Value: strings.Repeat("a", 64)},       // -> SHA-256 (hyphenated, normalized input)


### PR DESCRIPTION
## What

PR-B of the CycloneDX work (#38 was the core exporter). Adds the identity/scope signals that make Synapse's CycloneDX more than a bare component list, all deterministic projections of stored data.

- **`component.scope`**: maps the domain scope to the CycloneDX enum (production to `required`; development and the non-shipping background scopes to `excluded`), the inverse of the import mapping in `sbom.ClassifyScope`. Lets a consumer deprioritize dev-only vulnerabilities. Unknown scope is not asserted.
- **`evidence.occurrences`**: the manifest `Location` where the component was found.
- **`evidence.identity`**: a `purl` identity via the `manifest-analysis` technique at full confidence, emitted **only when a Location justifies it** (a lockfile/manifest states the exact coordinate deterministically, so it is not a guess). A component with no Location gets no identity rather than an unfounded technique claim.
- **`properties`**: the coarse JVM reachability verdict as `synapse:reachability`, when computed.

## Design note (evidence integrity)

For a tool whose value is evidence integrity, I did not fabricate a per-component identity confidence or a technique the data cannot support. Identity is emitted only where a manifest occurrence exists, and confidence is `1` because manifest/lockfile identification is deterministic (not heuristic). No signal is invented.

## Verify

`go build ./...`, `go vet`, full `go test ./...` green. New test `TestCDXEvidenceScopeAndProperties` (production to required + full evidence + reachability property; development and test to excluded; a bare component asserts no scope and no evidence). The existing `TestCycloneDXSelfRoundTrip` still passes (the importer ignores fields it does not read).
