### PR TITLE
feat(acquire): materialize image rootfs from the OCI layout (gated foundation)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -120,7 +120,7 @@ func main() {
 
 	clock := idgen.SystemClock{}
 	ids := idgen.RandomID{}
-	acquirer := acquire.New().WithMaxWorkspaceBytes(cfg.MaxWorkspaceBytes)
+	acquirer := acquire.New().WithMaxWorkspaceBytes(cfg.MaxWorkspaceBytes).WithImageRootFS(cfg.ImageRootFSEnabled)
 
 	// Persistence: PostgreSQL when configured, else file + in-memory (dev).
 	var repo ports.EngagementRepository

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -249,7 +249,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	}
 	sca := scauc.NewService(
 		engRepo, memory.NewFindingRepository(), memory.NewScanRepository(), nil, nil, nil, nil, nil, prov, clock, stderrAudit{},
-		shared.Severity(cfg.FindingMinSeverity), cfg.ScanTimeout, acquire.New().WithMaxWorkspaceBytes(cfg.MaxWorkspaceBytes),
+		shared.Severity(cfg.FindingMinSeverity), cfg.ScanTimeout, acquire.New().WithMaxWorkspaceBytes(cfg.MaxWorkspaceBytes).WithImageRootFS(cfg.ImageRootFSEnabled),
 		enry.New(), syft.New(cfg.SyftBin),
 		detectionSources,
 		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil)),

--- a/internal/infrastructure/acquire/acquirer.go
+++ b/internal/infrastructure/acquire/acquirer.go
@@ -37,6 +37,7 @@ type Acquirer struct {
 	egressScoped      bool             // when true, scope egress to the repo/registry host; else host-net sandbox
 	imageTool         string           // crane (go-containerregistry CLI) binary for daemonless image pulls
 	maxWorkspaceBytes int64            // prepared-workspace size cap; <=0 ⇒ the MaxWorkspaceBytes default
+	materializeRootFS bool             // when true, an image pull also assembles the layers into a walkable rootfs
 }
 
 // New returns a new Acquirer.
@@ -58,6 +59,15 @@ func (a *Acquirer) WithMaxWorkspaceBytes(n int64) *Acquirer {
 	if n > 0 {
 		a.maxWorkspaceBytes = n
 	}
+	return a
+}
+
+// WithImageRootFS makes an image pull ALSO materialize the assembled root filesystem from the OCI layout
+// (layers applied with whiteouts) into the workspace, exposed on Workspace.RootFS, so owned parsers can read
+// on-disk OS-package DBs and /etc/os-release. Off by default (extra disk + time); wired from
+// SYNAPSE_IMAGE_ROOTFS_ENABLED at the composition root.
+func (a *Acquirer) WithImageRootFS(enabled bool) *Acquirer {
+	a.materializeRootFS = enabled
 	return a
 }
 
@@ -288,7 +298,21 @@ func (a *Acquirer) acquireImage(ctx context.Context, ref string) (*ports.Workspa
 	// host-side lockfiles to inspect, so the workspace carries just the layout dir. Recover
 	// image metadata (layer stack + build history) from the OCI config for layer attribution
 	// (Epic D) — best-effort: nil if the config is unreadable, never fails the acquisition.
-	return &ports.Workspace{Dir: layout, Image: readImageInfo(layout, ref), Cleanup: cleanup}, nil
+	ws := &ports.Workspace{Dir: layout, Image: readImageInfo(layout, ref), Cleanup: cleanup}
+	// Optionally assemble the layers into a walkable root filesystem (owned OS-package cataloging reads it).
+	// BEST-EFFORT: the rootfs is supplementary — syft still scans the OCI layout in Dir regardless — and the
+	// extractor is fail-closed, so a failure (a hostile layer the hardening refused, an unsupported
+	// compression, a malformed layer) SKIPS the rootfs with a recorded reason rather than aborting the scan.
+	// RootFS is left empty so no partial tree is ever consumed.
+	if a.materializeRootFS {
+		rootfs := filepath.Join(dir, "rootfs")
+		if err := extractOCIRootFS(ctx, layout, rootfs, a.maxWorkspaceBytes); err != nil {
+			ws.RootFSNote = truncate(redactCreds(err.Error()), 200)
+		} else {
+			ws.RootFS = rootfs
+		}
+	}
+	return ws, nil
 }
 
 // registryHosts is the egress allow-list for pulling ref: the registry host, plus the

--- a/internal/infrastructure/acquire/image_metadata.go
+++ b/internal/infrastructure/acquire/image_metadata.go
@@ -86,6 +86,12 @@ type ociManifest struct {
 	Config struct {
 		Digest string `json:"digest"`
 	} `json:"config"`
+	// Layers are the filesystem layers in application order (each a tar, usually gzipped). Used to
+	// materialize the assembled rootfs (extractOCIRootFS); readImageInfo itself does not read them. Only the
+	// digest is needed (the layer compression is sniffed by magic, not trusted from the media type).
+	Layers []struct {
+		Digest string `json:"digest"`
+	} `json:"layers"`
 	selfDigest string // the manifest's own digest (from the index), not in the JSON
 }
 
@@ -125,16 +131,26 @@ func readManifest(layoutDir string) (ociManifest, bool) {
 	return man, true
 }
 
-// readBlobJSON reads + decodes the OCI blob addressed by a "sha256:<hex>" digest
-// from <layoutDir>/blobs/sha256/<hex>. The digest is validated to be a bare
-// algorithm:hex pair so it cannot escape the blobs directory (no path traversal).
-func readBlobJSON[T any](layoutDir, digest string) (T, bool) {
-	var zero T
+// blobPath maps a "sha256:<hex>" digest to its on-disk path <layoutDir>/blobs/<algo>/<hex>, validating the
+// digest is a bare algorithm:hex pair (no separators) so it cannot escape the blobs directory (no traversal).
+func blobPath(layoutDir, digest string) (string, bool) {
 	algo, hex, found := strings.Cut(digest, ":")
 	if !found || algo == "" || hex == "" || strings.ContainsAny(hex, "/\\.") || strings.ContainsAny(algo, "/\\.") {
+		return "", false
+	}
+	return filepath.Join(layoutDir, "blobs", algo, hex), true
+}
+
+// readBlobJSON reads + decodes the OCI blob addressed by a "sha256:<hex>" digest
+// from <layoutDir>/blobs/sha256/<hex>. The digest is validated (see blobPath) so it
+// cannot escape the blobs directory (no path traversal).
+func readBlobJSON[T any](layoutDir, digest string) (T, bool) {
+	var zero T
+	p, ok := blobPath(layoutDir, digest)
+	if !ok {
 		return zero, false
 	}
-	return readJSON[T](filepath.Join(layoutDir, "blobs", algo, hex))
+	return readJSON[T](p)
 }
 
 // readJSON reads + decodes a JSON file, bounded to a sane size. Best-effort: any

--- a/internal/infrastructure/acquire/imagerootfs.go
+++ b/internal/infrastructure/acquire/imagerootfs.go
@@ -1,0 +1,220 @@
+package acquire
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Materializing an image rootfs assembles the layer tars of a pulled OCI layout into a single filesystem
+// tree, so the owned parsers (OS-package DBs, os-release, on-disk artifacts) can read it. Layers are UNTRUSTED
+// (a hostile image is a real threat model), so extraction reuses the same hardening as archive extraction:
+// path traversal is blocked (safeJoin), only regular files + directories are written (symlink / hardlink /
+// device entries are skipped, since a link could redirect a later read/write outside the tree), and the total
+// is bounded across ALL layers (bomb guard). OCI whiteout markers are honored so a deleted file does not
+// reappear from a lower layer. It is FAIL-CLOSED: any refusal returns an error and no unsafe path is written;
+// the caller treats rootfs extraction as best-effort (a failure skips the rootfs, it does not abort the scan).
+const (
+	// whiteoutPrefix marks a deletion: ".wh.<name>" removes <name> from the assembled tree.
+	whiteoutPrefix = ".wh."
+	// whiteoutOpaque clears the marker's parent directory's lower-layer contents.
+	whiteoutOpaque = ".wh..wh..opq"
+)
+
+// rootfsExtractor assembles OCI layers into dest, accumulating the resource caps across ALL layers.
+type rootfsExtractor struct {
+	dest     string
+	maxBytes int64
+	total    int64 // bytes written across all layers (bomb guard)
+	entries  int   // tar entries seen across all layers (bomb guard)
+}
+
+// extractOCIRootFS materializes the assembled root filesystem of the image in the OCI layout at layoutDir into
+// dest, applying each layer tar in order with OCI whiteout semantics. Producers read dest afterward. A
+// malformed layout, a decompression bomb, an unsupported layer compression, or a path-traversal attempt fails
+// closed with an error (the caller skips the rootfs on any error). ctx cancels a large multi-layer extraction.
+// Symlinks are not materialized, so a path behind a symlinked directory will be absent; the target OS-package
+// DBs (/var/lib/dpkg/status, /lib/apk/db/installed) and /etc/os-release are regular files at real paths, so
+// this is sufficient for OS-package cataloging.
+func extractOCIRootFS(ctx context.Context, layoutDir, dest string, maxBytes int64) error {
+	if maxBytes <= 0 {
+		maxBytes = MaxWorkspaceBytes
+	}
+	layers, err := ociLayerBlobs(layoutDir)
+	if err != nil {
+		return err
+	}
+	if len(layers) == 0 {
+		return fmt.Errorf("%w: OCI image has no layers", shared.ErrValidation)
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return fmt.Errorf("create rootfs dir: %w", err)
+	}
+	x := &rootfsExtractor{dest: dest, maxBytes: maxBytes}
+	for _, blob := range layers {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := x.applyLayer(blob); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ociLayerBlobs resolves the layout's image manifest to the ORDERED on-disk paths of its layer blobs. Each
+// layer digest is validated (bare algo:hex) so it cannot escape the blobs directory.
+func ociLayerBlobs(layoutDir string) ([]string, error) {
+	man, ok := readManifest(layoutDir)
+	if !ok {
+		return nil, fmt.Errorf("%w: cannot read OCI image manifest", shared.ErrValidation)
+	}
+	paths := make([]string, 0, len(man.Layers))
+	for _, l := range man.Layers {
+		p, ok := blobPath(layoutDir, l.Digest)
+		if !ok {
+			return nil, fmt.Errorf("%w: invalid layer digest %q", shared.ErrValidation, l.Digest)
+		}
+		paths = append(paths, p)
+	}
+	return paths, nil
+}
+
+// applyLayer opens a layer blob, detects its compression by magic (gzip; zstd is rejected with a clear reason
+// since it is unsupported; anything else is treated as a raw tar), and applies it onto dest.
+func (x *rootfsExtractor) applyLayer(blob string) error {
+	f, err := os.Open(blob)
+	if err != nil {
+		return fmt.Errorf("%w: open layer blob: %v", shared.ErrValidation, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	br := bufio.NewReader(f)
+	magic, _ := br.Peek(4)
+	switch {
+	case len(magic) >= 2 && magic[0] == 0x1f && magic[1] == 0x8b: // gzip
+		gz, gerr := gzip.NewReader(br)
+		if gerr != nil {
+			return fmt.Errorf("%w: layer gzip: %v", shared.ErrValidation, gerr)
+		}
+		defer func() { _ = gz.Close() }()
+		return x.applyTar(tar.NewReader(gz))
+	case len(magic) == 4 && magic[0] == 0x28 && magic[1] == 0xb5 && magic[2] == 0x2f && magic[3] == 0xfd: // zstd
+		return fmt.Errorf("%w: unsupported layer compression (zstd); rootfs not materialized", shared.ErrValidation)
+	default:
+		return x.applyTar(tar.NewReader(br)) // uncompressed tar (garbage bytes surface as a tar error)
+	}
+}
+
+// applyTar extracts one layer's tar stream onto dest with OCI whiteout semantics, reusing the hardened
+// per-entry logic (safeJoin, copyCapped, symlink/special-file omission). Counters accumulate across layers.
+func (x *rootfsExtractor) applyTar(tr *tar.Reader) error {
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("%w: layer tar: %v", shared.ErrValidation, err)
+		}
+		x.entries++
+		if x.entries > maxArchiveEntries {
+			return fmt.Errorf("%w: image layers have too many entries (>%d)", shared.ErrValidation, maxArchiveEntries)
+		}
+		base := filepath.Base(hdr.Name)
+		if strings.HasPrefix(base, whiteoutPrefix) { // a whiteout marker deletes, it is not a real file
+			if err := x.applyWhiteout(hdr.Name, base); err != nil {
+				return err
+			}
+			continue
+		}
+		target, err := safeJoin(x.dest, hdr.Name)
+		if err != nil {
+			return err
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			// A later layer may put a directory where a lower layer wrote a regular file; drop the file first.
+			if fi, e := os.Lstat(target); e == nil && !fi.IsDir() {
+				if err := os.RemoveAll(target); err != nil {
+					return fmt.Errorf("replace file with dir: %w", err)
+				}
+			}
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("mkdir: %w", err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("mkdir: %w", err)
+			}
+			// The reverse: a later layer replaces a directory a lower layer created; drop the dir first.
+			if fi, e := os.Lstat(target); e == nil && fi.IsDir() {
+				if err := os.RemoveAll(target); err != nil {
+					return fmt.Errorf("replace dir with file: %w", err)
+				}
+			}
+			n, err := copyCapped(target, tr, maxArchiveFileBytes)
+			if err != nil {
+				return err
+			}
+			x.total += n
+			if x.total > x.maxBytes {
+				return fmt.Errorf("%w: image rootfs exceeds the %d-byte cap", shared.ErrValidation, x.maxBytes)
+			}
+		default:
+			// symlink / hardlink / device / fifo: skipped (a link could redirect a later read/write outside dest).
+		}
+	}
+	return nil
+}
+
+// applyWhiteout removes what a ".wh." marker deletes. ".wh..wh..opq" clears the marker's parent directory's
+// lower-layer contents (opaque, via clearDir which removes children only — never the directory itself, so a
+// root-level opaque marker cannot delete dest). ".wh.<name>" removes <name> in that directory; a name that
+// resolves to ""/"."/".." is not a valid whiteout target and is skipped, so a crafted marker can neither
+// delete the assembled-tree root nor (with safeJoin) escape it.
+func (x *rootfsExtractor) applyWhiteout(name, base string) error {
+	dir := filepath.Dir(name)
+	if base == whiteoutOpaque {
+		parent, err := safeJoin(x.dest, dir)
+		if err != nil {
+			return err
+		}
+		return clearDir(parent)
+	}
+	victim := strings.TrimPrefix(base, whiteoutPrefix)
+	if victim == "" || victim == "." || victim == ".." {
+		return nil // not a valid whiteout target — never delete the tree root or a traversal target
+	}
+	target, err := safeJoin(x.dest, filepath.Join(dir, victim))
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(target); err != nil {
+		return fmt.Errorf("apply whiteout: %w", err)
+	}
+	return nil
+}
+
+// clearDir removes the direct children of dir (opaque whiteout) without removing dir itself. A missing dir is
+// not an error (the opaque layer can precede the directory's creation in the assembly order).
+func clearDir(dir string) error {
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	for _, e := range ents {
+		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
+			return fmt.Errorf("clear opaque dir: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/infrastructure/acquire/imagerootfs_test.go
+++ b/internal/infrastructure/acquire/imagerootfs_test.go
@@ -1,0 +1,267 @@
+package acquire
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type layerEntry struct {
+	name     string
+	typ      byte
+	body     string
+	linkname string
+}
+
+func reg(name, body string) layerEntry { return layerEntry{name: name, typ: tar.TypeReg, body: body} }
+func dir(name string) layerEntry       { return layerEntry{name: name, typ: tar.TypeDir} }
+
+// addLayer writes a layer tar (gzipped unless raw) as a blob (reusing writeBlob from image_metadata_test.go)
+// and returns its digest.
+func addLayer(t *testing.T, layoutDir string, gzipped bool, entries []layerEntry) string {
+	t.Helper()
+	var buf bytes.Buffer
+	var tw *tar.Writer
+	var gz *gzip.Writer
+	if gzipped {
+		gz = gzip.NewWriter(&buf)
+		tw = tar.NewWriter(gz)
+	} else {
+		tw = tar.NewWriter(&buf)
+	}
+	for _, e := range entries {
+		hdr := &tar.Header{Name: e.name, Typeflag: e.typ, Mode: 0o644}
+		switch e.typ {
+		case tar.TypeDir:
+			hdr.Mode = 0o755
+		case tar.TypeReg:
+			hdr.Size = int64(len(e.body))
+		case tar.TypeSymlink:
+			hdr.Linkname = e.linkname
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if e.typ == tar.TypeReg {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if gz != nil {
+		if err := gz.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return writeBlob(t, layoutDir, buf.Bytes())
+}
+
+// finishLayout writes the image manifest (referencing the layers in order) + index.json.
+func finishLayout(t *testing.T, layoutDir string, layerDigests []string) {
+	t.Helper()
+	cfg := writeBlob(t, layoutDir, []byte(`{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]}}`))
+	var ls strings.Builder
+	for i, d := range layerDigests {
+		if i > 0 {
+			ls.WriteString(",")
+		}
+		fmt.Fprintf(&ls, `{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":%q}`, d)
+	}
+	manifest := fmt.Sprintf(`{"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":%q},"layers":[%s]}`, cfg, ls.String())
+	man := writeBlob(t, layoutDir, []byte(manifest))
+	index := fmt.Sprintf(`{"schemaVersion":2,"manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":%q,"platform":{"os":"linux","architecture":"amd64"}}]}`, man)
+	if err := os.WriteFile(filepath.Join(layoutDir, "index.json"), []byte(index), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func extractToTemp(t *testing.T, layoutDir string) (string, error) {
+	t.Helper()
+	dest := filepath.Join(t.TempDir(), "rootfs")
+	return dest, extractOCIRootFS(context.Background(), layoutDir, dest, MaxWorkspaceBytes)
+}
+
+func mustNotExist(t *testing.T, p string) {
+	t.Helper()
+	if _, err := os.Lstat(p); !os.IsNotExist(err) {
+		t.Errorf("expected %q to be absent, got err=%v", p, err)
+	}
+}
+
+func mustContain(t *testing.T, p, want string) {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %q: %v", p, err)
+	}
+	if string(b) != want {
+		t.Errorf("%q = %q, want %q", p, string(b), want)
+	}
+}
+
+func TestExtractOCIRootFSLayeringAndWhiteout(t *testing.T) {
+	layout := t.TempDir()
+	l1 := addLayer(t, layout, true, []layerEntry{
+		dir("etc/"), reg("etc/os-release", "ID=debian\nVERSION_ID=\"12\"\n"),
+		dir("app/"), reg("app/a.txt", "old"),
+	})
+	l2 := addLayer(t, layout, true, []layerEntry{
+		reg("app/.wh.a.txt", ""), // whiteout: deletes app/a.txt
+		reg("app/b.txt", "new"),
+	})
+	finishLayout(t, layout, []string{l1, l2})
+
+	dest, err := extractToTemp(t, layout)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	mustContain(t, filepath.Join(dest, "etc/os-release"), "ID=debian\nVERSION_ID=\"12\"\n")
+	mustContain(t, filepath.Join(dest, "app/b.txt"), "new")
+	mustNotExist(t, filepath.Join(dest, "app/a.txt")) // whiteout must win over the lower layer
+}
+
+func TestExtractOCIRootFSOpaqueDir(t *testing.T) {
+	layout := t.TempDir()
+	l1 := addLayer(t, layout, true, []layerEntry{dir("d/"), reg("d/old.txt", "old")})
+	l2 := addLayer(t, layout, true, []layerEntry{reg("d/.wh..wh..opq", ""), reg("d/new.txt", "new")})
+	finishLayout(t, layout, []string{l1, l2})
+
+	dest, err := extractToTemp(t, layout)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	mustNotExist(t, filepath.Join(dest, "d/old.txt")) // opaque clears lower-layer contents
+	mustContain(t, filepath.Join(dest, "d/new.txt"), "new")
+}
+
+func TestExtractOCIRootFSRejectsTraversal(t *testing.T) {
+	layout := t.TempDir()
+	l1 := addLayer(t, layout, true, []layerEntry{reg("../escape.txt", "x")})
+	finishLayout(t, layout, []string{l1})
+	if _, err := extractToTemp(t, layout); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("a traversing layer entry must fail with ErrValidation, got %v", err)
+	}
+}
+
+func TestExtractOCIRootFSSkipsSymlink(t *testing.T) {
+	layout := t.TempDir()
+	l1 := addLayer(t, layout, true, []layerEntry{
+		reg("real.txt", "hi"),
+		{name: "link.txt", typ: tar.TypeSymlink, linkname: "/etc/passwd"},
+	})
+	finishLayout(t, layout, []string{l1})
+	dest, err := extractToTemp(t, layout)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	mustContain(t, filepath.Join(dest, "real.txt"), "hi")
+	mustNotExist(t, filepath.Join(dest, "link.txt")) // symlink entry skipped (no redirect out of the tree)
+}
+
+func TestExtractOCIRootFSUncompressedLayer(t *testing.T) {
+	layout := t.TempDir()
+	l1 := addLayer(t, layout, false, []layerEntry{reg("etc/os-release", "ID=alpine\n")}) // raw tar, no gzip
+	finishLayout(t, layout, []string{l1})
+	dest, err := extractToTemp(t, layout)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	mustContain(t, filepath.Join(dest, "etc/os-release"), "ID=alpine\n")
+}
+
+func TestExtractOCIRootFSNoLayers(t *testing.T) {
+	layout := t.TempDir()
+	finishLayout(t, layout, nil)
+	if _, err := extractToTemp(t, layout); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("a layout with no layers must fail with ErrValidation, got %v", err)
+	}
+}
+
+func TestExtractOCIRootFSMissingLayout(t *testing.T) {
+	if _, err := extractToTemp(t, t.TempDir()); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("a layout with no index.json must fail with ErrValidation, got %v", err)
+	}
+}
+
+func TestExtractOCIRootFSRejectsTraversingWhiteout(t *testing.T) {
+	layout := t.TempDir()
+	// A whiteout whose victim escapes the tree ("../secret") must be rejected, not delete outside dest.
+	l1 := addLayer(t, layout, true, []layerEntry{reg("../.wh.secret", "")})
+	finishLayout(t, layout, []string{l1})
+	if _, err := extractToTemp(t, layout); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("a traversing whiteout must fail with ErrValidation, got %v", err)
+	}
+}
+
+func TestExtractOCIRootFSWhiteoutRootVictimSkipped(t *testing.T) {
+	layout := t.TempDir()
+	// A crafted marker ".wh..." trims to victim ".." — not a valid whiteout target. It must be skipped, never
+	// deleting the assembled-tree root; the lower-layer file must survive.
+	l1 := addLayer(t, layout, true, []layerEntry{reg("keep.txt", "x")})
+	l2 := addLayer(t, layout, true, []layerEntry{reg(".wh...", "")})
+	finishLayout(t, layout, []string{l1, l2})
+	dest, err := extractToTemp(t, layout)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	mustContain(t, filepath.Join(dest, "keep.txt"), "x") // root not wiped
+}
+
+func TestExtractOCIRootFSCapsAcrossLayers(t *testing.T) {
+	layout := t.TempDir()
+	l1 := addLayer(t, layout, true, []layerEntry{reg("a.txt", "aaaaaaaa")}) // 8 bytes
+	l2 := addLayer(t, layout, true, []layerEntry{reg("b.txt", "bbbbbbbb")}) // +8 bytes
+	finishLayout(t, layout, []string{l1, l2})
+	dest := filepath.Join(t.TempDir(), "rootfs")
+	// A 10-byte total cap is exceeded only after the SECOND layer, proving the cap accumulates across layers.
+	if err := extractOCIRootFS(context.Background(), layout, dest, 10); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("the byte cap must be enforced across layers, got %v", err)
+	}
+}
+
+func TestExtractOCIRootFSUnsupportedCompression(t *testing.T) {
+	layout := t.TempDir()
+	zstd := writeBlob(t, layout, []byte{0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x01, 0x02}) // zstd magic
+	finishLayout(t, layout, []string{zstd})
+	if _, err := extractToTemp(t, layout); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("a zstd-compressed layer must fail closed with a clear ErrValidation, got %v", err)
+	}
+}
+
+func TestExtractOCIRootFSFileDirTransition(t *testing.T) {
+	// Across layers a path flips kind: "x" is a regular file below and a directory above; "y" is a directory
+	// (with a child) below and a regular file above. The colliding entry is replaced and the surviving entry
+	// stays under dest (both replacement RemoveAlls are safeJoin-bounded).
+	layout := t.TempDir()
+	l1 := addLayer(t, layout, true, []layerEntry{reg("x", "file-first"), dir("y/"), reg("y/child", "below")})
+	l2 := addLayer(t, layout, true, []layerEntry{dir("x/"), reg("x/now-a-dir", "ok"), reg("y", "now-a-file")})
+	finishLayout(t, layout, []string{l1, l2})
+	dest, err := extractToTemp(t, layout)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	mustContain(t, filepath.Join(dest, "x/now-a-dir"), "ok") // file -> dir
+	// y became a regular file, so the replaced directory and its child are gone (a file has no children).
+	mustContain(t, filepath.Join(dest, "y"), "now-a-file") // dir -> file
+}
+
+func TestExtractOCIRootFSGarbageBlob(t *testing.T) {
+	layout := t.TempDir()
+	garbage := writeBlob(t, layout, []byte("this is not a tar or a known compression")) // no known magic
+	finishLayout(t, layout, []string{garbage})
+	if _, err := extractToTemp(t, layout); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("a non-tar garbage blob must fail closed with ErrValidation, got %v", err)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -191,6 +191,10 @@ type Config struct {
 	// write there and compute a scan's content+producer key could pre-seed a lossy SBOM (a silent
 	// false-negative). The default per-user cache dir satisfies this.
 	ScanCacheDir string
+	// ImageRootFSEnabled materializes a container image's assembled root filesystem from the pulled OCI
+	// layout (applying layers + whiteouts), so the owned parsers can read on-disk OS-package DBs and
+	// /etc/os-release. Off by default; extraction is hardened but adds disk + time to an image scan.
+	ImageRootFSEnabled bool
 	// OwnedAdvisoryEnabled wires the owned advisory DetectionSource: match the SBOM
 	// against the owned normalized-advisory store (offline, reproducible) ALONGSIDE live OSV/Grype. Off by
 	// default; opt-in. An empty store yields no findings (a harmless no-op) until the advisory ingester
@@ -341,6 +345,7 @@ func Load() Config {
 		DBMaxAgeDays:           getint("SYNAPSE_DB_MAX_AGE_DAYS", 30),
 		ScanCacheEnabled:       getbool("SYNAPSE_SCAN_CACHE_ENABLED", false),
 		ScanCacheDir:           os.Getenv("SYNAPSE_SCAN_CACHE_DIR"),
+		ImageRootFSEnabled:     getbool("SYNAPSE_IMAGE_ROOTFS_ENABLED", false),
 		OwnedAdvisoryEnabled:   getbool("SYNAPSE_OWNED_ADVISORY", false),
 		ReachabilityEnabled:    getbool("SYNAPSE_REACHABILITY_ENABLED", false),
 		CrossCheckEnabled:      getbool("SYNAPSE_CROSSCHECK_ENABLED", false),

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -508,8 +508,19 @@ type Workspace struct {
 	// layer stack) when the target is an image (acquired as an OCI layout); nil for
 	// source/dir/archive targets. Drives Epic D layer attribution + base-image
 	// estimation. Best-effort: nil if the image config could not be read.
-	Image   *sbom.ImageInfo
-	Cleanup func() error
+	Image *sbom.ImageInfo
+	// RootFS is the assembled root filesystem of an image target, materialized from the OCI layout (layers
+	// applied with whiteouts) when image-rootfs extraction is enabled; empty otherwise and for non-image
+	// targets. Owned parsers read it for on-disk OS-package DBs + /etc/os-release. Dir stays the OCI layout
+	// (what syft scans); RootFS is the walkable tree. Both live under the same cleaned-up temp dir.
+	RootFS string
+	// RootFSNote records why rootfs materialization was skipped for an image target (unsupported layer
+	// compression, a hostile layer the hardening refused, a malformed layout) when extraction was enabled but
+	// failed. Empty on success or when not enabled. Rootfs is best-effort — a failure never aborts the scan —
+	// so the pipeline surfaces this as a warning (never silently) and a consumer treats an absent RootFS as
+	// "not analyzed", never as "no OS packages".
+	RootFSNote string
+	Cleanup    func() error
 }
 
 // Completeness signals how trustworthy a scan's results are: whether dependency


### PR DESCRIPTION
## What

The foundation for container-image **rootfs extraction**. An image target is pulled as a compressed OCI layout that only syft can read; the owned parsers walk the workspace and find nothing, because the OS-package DBs (`/var/lib/dpkg/status`, `/lib/apk/db/installed`), `/etc/os-release`, and on-disk artifacts live inside the compressed layer blobs. This assembles the layers into a walkable root filesystem so the owned stack can read them.

This is the prerequisite that unlocks **owned dpkg/apk OS-package cataloging** and **on-disk binary cataloging** (both follow-up PRs). The advisory/matcher side for those (Debian/Ubuntu/Alpine ecosystems + dpkg/apk/rpm comparators) already exists.

## Security (untrusted layers)

Layers are attacker-controlled, so extraction reuses the exact hardening of the existing archive extractor:
- **Path traversal blocked** (`safeJoin`): `../etc/...` cannot escape the tree.
- **Only regular files + directories written**: symlink / hardlink / device entries are skipped, so no link can redirect a later read/write outside the tree.
- **Bounded across all layers**: per-file cap + total-bytes cap + entry-count cap (bomb guard).
- **OCI whiteouts honored**: `.wh.<name>` deletes, `.wh..wh..opq` clears a directory's lower-layer contents (removal targets are also `safeJoin`-guarded), so a removed file cannot reappear from a lower layer.
- A malformed layout, a bomb, or a traversal attempt **fails closed** with `ErrValidation`.

Reuses the existing OCI manifest parser (`readManifest` + a factored-out `blobPath` digest validation) and the archive primitives (`safeJoin`, `copyCapped`).

## Wiring

Gated behind `SYNAPSE_IMAGE_ROOTFS_ENABLED` (off by default; extraction adds disk + time). When on, `acquireImage` assembles the rootfs into `Workspace.RootFS` alongside the OCI layout in `Dir` (which syft still scans); both live under the same cleaned-up temp dir. No consumer reads `RootFS` yet, that is the next PR.

## Verify

`go build ./...`, `go vet ./...`, full `go test ./...` green. Seven extractor tests with synthetic OCI layouts (real sha256 digests): layering + whiteout, opaque dir, path-traversal rejection, symlink-skip, uncompressed layer, no-layers and missing-index error paths.
