### PR TITLE
feat(sca): owned OS-package cataloging (dpkg/apk) from the image rootfs

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/nvd"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ospkg"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/osv"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownadvisory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownsbom"
@@ -537,6 +538,10 @@ func main() {
 	if cfg.SecretScanEnabled {
 		scaService.SetSecretScanner(secretscan.New()) // deterministic, redacted secret scan in the scan pipeline
 		log.Info("secret scanning ENABLED (hardcoded credentials; matches redacted)")
+	}
+	if cfg.ImageRootFSEnabled {
+		scaService.SetOSPackageCataloger(ospkg.New()) // owned dpkg/apk cataloging from the materialized image rootfs
+		log.Info("image-rootfs OS-package cataloging ENABLED (dpkg + apk)")
 	}
 	if cfg.MisconfigEnabled {
 		scaService.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan in the scan pipeline

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/nvd"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ospkg"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/osv"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownadvisory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/risk"
@@ -319,6 +320,9 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	}
 	if cfg.MisconfigEnabled {
 		sca.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan (CI-friendly)
+	}
+	if cfg.ImageRootFSEnabled {
+		sca.SetOSPackageCataloger(ospkg.New()) // owned dpkg/apk cataloging from the materialized image rootfs
 	}
 	if cfg.SuppressionEnabled {
 		sca.SetSuppressionLoader(ignorefile.New()) // repo-committed .synapseignore accepted-risk policy (CI-friendly)

--- a/internal/infrastructure/tools/ospkg/cataloger.go
+++ b/internal/infrastructure/tools/ospkg/cataloger.go
@@ -1,0 +1,306 @@
+// Package ospkg catalogs installed OS packages from a materialized image root filesystem: Debian/Ubuntu dpkg
+// (/var/lib/dpkg/status) and Alpine apk (/lib/apk/db/installed), with the distro release read from
+// /etc/os-release. It is the OWNED (detection-independent) alternative to relying on the SBOM generator for
+// OS packages, and emits components tagged with a Syft-style "distro" qualifier so the existing advisory
+// matcher keys them to the right OS ecosystem. It only READS the rootfs (already assembled within the
+// workspace); the databases are UNTRUSTED, so: reads are streamed + bounded (size, line, and package caps)
+// and cancellable, every leaf is regular-file-guarded (no symlink follow out of the rootfs), package
+// name/version are percent-encoded into the PURL (so a crafted value cannot make the PURL ambiguous or
+// smuggle a qualifier) while the raw values are kept for advisory matching, and the distro tag is applied
+// ONLY for a release the matcher can key (a lying/garbled os-release yields an UNRESOLVED result, warned
+// upstream, never a silent zero-match).
+package ospkg
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxDBBytes    = 64 << 20  // total bytes read from one DB (bomb guard)
+	maxDBLine     = 1 << 20   // max single line (a long Description); a longer line abandons the DB
+	maxLines      = 5_000_000 // total lines scanned per DB (blank-line-flood guard)
+	maxPackages   = 200_000   // emitted-package cap per DB
+	maxFieldChars = 512       // clip an over-long name/version (rune-safe) before it enters a PURL
+)
+
+// debianFamilyIDs are the dpkg os-release IDs the advisory matcher can key (osDistroEcosystem handles Debian +
+// Ubuntu); only these get a distro tag, so any other/garbled/mismatched ID yields an unresolved result.
+var debianFamilyIDs = map[string]bool{"debian": true, "ubuntu": true}
+
+// Cataloger implements ports.OSPackageCataloger over a materialized image rootfs.
+type Cataloger struct{}
+
+// New returns an OS-package cataloger.
+func New() *Cataloger { return &Cataloger{} }
+
+var _ ports.OSPackageCataloger = (*Cataloger)(nil)
+
+// Catalog reads the OS-package databases under rootfsDir. Best-effort per ecosystem (an absent/unreadable DB
+// contributes nothing); returns an error only on context cancellation. DistroResolved is false when packages
+// were emitted but the release could not be keyed to an advisory ecosystem.
+func (Cataloger) Catalog(ctx context.Context, rootfsDir string) (ports.OSPackageResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.OSPackageResult{}, err
+	}
+	if strings.TrimSpace(rootfsDir) == "" {
+		return ports.OSPackageResult{}, nil
+	}
+	id, versionID := osRelease(rootfsDir)
+	res := ports.OSPackageResult{DistroResolved: true}
+
+	// dpkg (Debian family): resolvable only when os-release ID is debian/ubuntu, else emit with no distro tag.
+	debNS, debTag := "debian", ""
+	if debianFamilyIDs[id] && versionID != "" {
+		debNS, debTag = id, id+"-"+versionID
+	}
+	comps, err := parseOSDB(ctx, filepath.Join(rootfsDir, "var/lib/dpkg/status"), dpkgFieldKeys, dpkgExtract, "deb", debNS, debTag)
+	if err != nil {
+		return ports.OSPackageResult{}, err
+	}
+	if len(comps) > 0 {
+		res.Components = append(res.Components, comps...)
+		if debTag == "" {
+			res.DistroResolved = false
+		}
+	}
+
+	// apk (Alpine): resolvable only when os-release ID is alpine.
+	apkTag := ""
+	if id == "alpine" && versionID != "" {
+		apkTag = "alpine-" + versionID
+	}
+	comps, err = parseOSDB(ctx, filepath.Join(rootfsDir, "lib/apk/db/installed"), apkFieldKeys, apkExtract, "apk", "alpine", apkTag)
+	if err != nil {
+		return ports.OSPackageResult{}, err
+	}
+	if len(comps) > 0 {
+		res.Components = append(res.Components, comps...)
+		if apkTag == "" {
+			res.DistroResolved = false
+		}
+	}
+	return res, nil
+}
+
+// dpkgFieldKeys / apkFieldKeys are the ONLY stanza keys each parser reads. parseOSDB stores only these, so a
+// stanza with millions of distinct junk keys cannot grow the per-stanza map (keeps memory O(1) per stanza).
+var (
+	dpkgFieldKeys = map[string]bool{"Package": true, "Status": true, "Version": true, "Architecture": true}
+	apkFieldKeys  = map[string]bool{"P": true, "V": true, "A": true}
+)
+
+// dpkgExtract pulls (name, version, arch) from a dpkg stanza; only "install ok installed" is present.
+func dpkgExtract(f map[string]string) (name, version, arch string, ok bool) {
+	if !strings.Contains(f["Status"], "install ok installed") {
+		return "", "", "", false
+	}
+	return f["Package"], f["Version"], f["Architecture"], true
+}
+
+// apkExtract pulls (name, version, arch) from an apk stanza (single-letter keys).
+func apkExtract(f map[string]string) (name, version, arch string, ok bool) {
+	return f["P"], f["V"], f["A"], true
+}
+
+// parseOSDB streams a Debian/apk control DB (stanzas separated by a blank line, "Key: Value" lines) into
+// components. Streaming keeps memory O(1) per stanza; the size/line/package caps + periodic ctx check bound a
+// hostile DB. A missing/irregular/symlinked path or an over-long line yields no components (best-effort).
+func parseOSDB(ctx context.Context, path string, fieldKeys map[string]bool, extract func(map[string]string) (string, string, string, bool), typ, namespace, tag string) ([]sbom.Component, error) {
+	fi, err := os.Lstat(path) // regular-file guard: never follow a symlinked DB out of the rootfs
+	if err != nil || !fi.Mode().IsRegular() {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(io.LimitReader(f, maxDBBytes))
+	sc.Buffer(make([]byte, 0, 64*1024), maxDBLine)
+	var out []sbom.Component
+	cur := map[string]string{}
+	lines := 0
+	flush := func() {
+		defer func() { cur = map[string]string{} }()
+		if len(cur) == 0 || len(out) >= maxPackages { // keep maxPackages an exact upper bound
+			return
+		}
+		if name, version, arch, ok := extract(cur); ok {
+			if c, ok := osComponent(typ, namespace, name, version, arch, tag); ok {
+				out = append(out, c)
+			}
+		}
+	}
+	for sc.Scan() {
+		lines++
+		if lines > maxLines || len(out) >= maxPackages {
+			break
+		}
+		if lines&0x3fff == 0 { // ~every 16k lines: honor cancellation of a large parse
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		line := strings.TrimRight(sc.Text(), "\r")
+		if line == "" { // stanza boundary
+			flush()
+			continue
+		}
+		if line[0] == ' ' || line[0] == '\t' { // continuation line (dpkg multi-line value): not a field we read
+			continue
+		}
+		i := strings.IndexByte(line, ':')
+		if i <= 0 {
+			continue
+		}
+		// Store ONLY the keys the extractor reads, so a stanza of millions of junk keys can't grow the map.
+		if key := strings.TrimSpace(line[:i]); fieldKeys[key] && cur[key] == "" {
+			cur[key] = strings.TrimSpace(line[i+1:])
+		}
+	}
+	flush()
+	// A scanner error (e.g. a line over maxDBLine) abandons the DB rather than emitting a partial/odd set.
+	if sc.Err() != nil {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// osComponent builds an OS-package component with a spec-encoded PURL. The name/version are percent-encoded
+// into the PURL (so an attacker-authored value cannot make the name/version boundary ambiguous or inject a
+// qualifier) but kept RAW in Name/Version, which is what the advisory matcher compares. Returns ok=false when
+// the name/version is empty or carries a control character. The distro qualifier is set only for a resolvable
+// release, so a match is attempted only against a real OS ecosystem.
+func osComponent(typ, namespace, name, version, arch, tag string) (sbom.Component, bool) {
+	name, version = cleanField(name), cleanField(version)
+	if name == "" || version == "" {
+		return sbom.Component{}, false
+	}
+	purl := "pkg:" + typ + "/" + namespace + "/" + purlEncode(name) + "@" + purlEncode(version)
+	var q []string
+	if a := cleanField(arch); a != "" {
+		q = append(q, "arch="+purlEncode(a))
+	}
+	if tag != "" {
+		q = append(q, "distro="+purlEncode(tag))
+	}
+	if len(q) > 0 {
+		purl += "?" + strings.Join(q, "&")
+	}
+	return sbom.Component{Name: name, Version: version, PURL: purl, Scope: sbom.ScopeProduction}, true
+}
+
+// osRelease reads <rootfs>/etc/os-release (falling back to /usr/lib/os-release) and returns the lowercased
+// distro ID and VERSION_ID, both validated to clean tokens (so a crafted os-release cannot inject into a
+// distro qualifier). Either is "" when unavailable/invalid.
+func osRelease(rootfsDir string) (id, versionID string) {
+	data := readBounded(filepath.Join(rootfsDir, "etc/os-release"), 64<<10)
+	if len(data) == 0 {
+		data = readBounded(filepath.Join(rootfsDir, "usr/lib/os-release"), 64<<10)
+	}
+	if len(data) == 0 {
+		return "", ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		k, v, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		v = strings.Trim(strings.TrimSpace(v), `"'`)
+		switch k {
+		case "ID":
+			id = strings.ToLower(strings.TrimSpace(v))
+		case "VERSION_ID":
+			versionID = v
+		}
+	}
+	if !isCleanToken(id) {
+		id = ""
+	}
+	if !isCleanToken(versionID) {
+		versionID = ""
+	}
+	return id, versionID
+}
+
+// cleanField trims a field, rejects it if it carries a control character (a line-parsed value should not),
+// and rune-safe-clips it to maxFieldChars.
+func cleanField(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return ""
+		}
+	}
+	if len(s) > maxFieldChars {
+		r := []rune(s)
+		if len(r) > maxFieldChars {
+			s = string(r[:maxFieldChars])
+		}
+	}
+	return s
+}
+
+// purlEncode percent-encodes a PURL segment: RFC 3986 unreserved bytes pass through, every other byte becomes
+// %XX (byte-wise, so multibyte UTF-8 is encoded canonically). This makes the emitted PURL unambiguous + free
+// of injected separators/qualifiers regardless of the attacker-authored input.
+func purlEncode(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '.' || c == '_' || c == '~' {
+			b.WriteByte(c)
+		} else {
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}
+
+// isCleanToken reports whether an os-release ID / VERSION_ID is a safe distro-tag token (alphanumeric, dot,
+// dash, underscore, <=64 chars).
+func isCleanToken(s string) bool {
+	if s == "" || len(s) > 64 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// readBounded reads a small regular file up to max bytes (for the tiny os-release; the large package DBs are
+// streamed by parseOSDB). Missing/irregular/symlink path or error → nil.
+func readBounded(path string, max int64) []byte {
+	fi, err := os.Lstat(path)
+	if err != nil || !fi.Mode().IsRegular() {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(io.LimitReader(f, max))
+	if err != nil {
+		return nil
+	}
+	return data
+}

--- a/internal/infrastructure/tools/ospkg/cataloger_test.go
+++ b/internal/infrastructure/tools/ospkg/cataloger_test.go
@@ -1,0 +1,211 @@
+package ospkg
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/distro"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+func writeRootfs(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, content := range files {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func byName(comps []sbom.Component) map[string]sbom.Component {
+	m := map[string]sbom.Component{}
+	for _, c := range comps {
+		m[c.Name] = c
+	}
+	return m
+}
+
+func distroQualifier(purl string) string {
+	i := strings.IndexByte(purl, '?')
+	if i < 0 {
+		return ""
+	}
+	for _, kv := range strings.Split(purl[i+1:], "&") {
+		if v, ok := strings.CutPrefix(kv, "distro="); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestCatalogDebian(t *testing.T) {
+	rootfs := writeRootfs(t, map[string]string{
+		"etc/os-release": "PRETTY_NAME=\"Debian GNU/Linux 12\"\nID=debian\nVERSION_ID=\"12\"\n",
+		"var/lib/dpkg/status": "Package: bash\nStatus: install ok installed\nVersion: 5.1-2+deb12u1\nArchitecture: amd64\n\n" +
+			"Package: coreutils\nStatus: install ok installed\nVersion: 9.1-1\nArchitecture: amd64\n\n" +
+			"Package: halfconf\nStatus: install ok half-configured\nVersion: 1.0\nArchitecture: amd64\n",
+	})
+	res, err := New().Catalog(context.Background(), rootfs)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	if len(res.Components) != 2 || !res.DistroResolved { // halfconf skipped; debian-12 resolves
+		t.Fatalf("want 2 installed deb packages + resolved distro, got %d / resolved=%v: %+v", len(res.Components), res.DistroResolved, res.Components)
+	}
+	bash := byName(res.Components)["bash"]
+	// The version's '+' is percent-encoded in the PURL (%2B); Name/Version keep the RAW value for matching.
+	if bash.Version != "5.1-2+deb12u1" || bash.PURL != "pkg:deb/debian/bash@5.1-2%2Bdeb12u1?arch=amd64&distro=debian-12" {
+		t.Errorf("bash = %+v; want raw version + a percent-encoded PURL with distro=debian-12", bash)
+	}
+	if bash.Scope != sbom.ScopeProduction {
+		t.Errorf("OS packages should be production scope, got %q", bash.Scope)
+	}
+	if _, ok := byName(res.Components)["halfconf"]; ok {
+		t.Error("a half-configured (not installed) package must be skipped")
+	}
+}
+
+func TestCatalogAlpine(t *testing.T) {
+	rootfs := writeRootfs(t, map[string]string{
+		"etc/os-release":       "NAME=\"Alpine Linux\"\nID=alpine\nVERSION_ID=3.18.12\n",
+		"lib/apk/db/installed": "P:busybox\nV:1.36.1-r0\nA:x86_64\n\nP:musl\nV:1.2.4-r2\nA:x86_64\n",
+	})
+	res, err := New().Catalog(context.Background(), rootfs)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	if len(res.Components) != 2 || !res.DistroResolved {
+		t.Fatalf("want 2 apk packages + resolved distro, got %d / %v: %+v", len(res.Components), res.DistroResolved, res.Components)
+	}
+	if p := byName(res.Components)["busybox"].PURL; p != "pkg:apk/alpine/busybox@1.36.1-r0?arch=x86_64&distro=alpine-3.18.12" {
+		t.Errorf("busybox PURL = %q; want the Syft-style apk PURL with distro=alpine-3.18.12", p)
+	}
+}
+
+func TestCatalogNoOSRelease(t *testing.T) {
+	// A dpkg DB with no os-release: packages still emit (namespace debian) but with NO distro qualifier, and
+	// DistroResolved is false so the pipeline warns rather than presenting a clean OS posture.
+	rootfs := writeRootfs(t, map[string]string{
+		"var/lib/dpkg/status": "Package: bash\nStatus: install ok installed\nVersion: 5.1-2\nArchitecture: amd64\n",
+	})
+	res, err := New().Catalog(context.Background(), rootfs)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	if len(res.Components) != 1 || res.Components[0].PURL != "pkg:deb/debian/bash@5.1-2?arch=amd64" {
+		t.Errorf("without os-release, want a deb PURL with no distro qualifier, got %+v", res.Components)
+	}
+	if res.DistroResolved {
+		t.Error("without a resolvable os-release, DistroResolved must be false")
+	}
+}
+
+func TestCatalogMismatchedOSRelease(t *testing.T) {
+	// A dpkg DB but an os-release claiming ID=alpine (a lying/mismatched image): the deb packages must NOT be
+	// tagged alpine, so they get no distro qualifier and DistroResolved is false (never a silent zero-match).
+	rootfs := writeRootfs(t, map[string]string{
+		"etc/os-release":      "ID=alpine\nVERSION_ID=3.18\n",
+		"var/lib/dpkg/status": "Package: bash\nStatus: install ok installed\nVersion: 5.1\nArchitecture: amd64\n",
+	})
+	res, err := New().Catalog(context.Background(), rootfs)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	if len(res.Components) != 1 || distroQualifier(res.Components[0].PURL) != "" || res.DistroResolved {
+		t.Errorf("a dpkg DB with an alpine os-release must not be tagged; want no distro qualifier + unresolved, got %+v resolved=%v", res.Components, res.DistroResolved)
+	}
+}
+
+func TestCatalogEmptyRootfs(t *testing.T) {
+	res, err := New().Catalog(context.Background(), t.TempDir())
+	if err != nil || len(res.Components) != 0 {
+		t.Errorf("an empty rootfs must yield no components + no error, got %d / %v", len(res.Components), err)
+	}
+	if res, _ := New().Catalog(context.Background(), ""); len(res.Components) != 0 {
+		t.Error("an empty rootfs path must yield no components")
+	}
+}
+
+func TestCatalogEncodesHostileFields(t *testing.T) {
+	// PURL-breaking characters in a package name/version are percent-encoded (not dropped, not smuggled) so the
+	// PURL stays unambiguous; a control character drops the package; a garbled os-release yields no distro tag.
+	rootfs := writeRootfs(t, map[string]string{
+		"etc/os-release": "ID=deb?ian\nVERSION_ID=12\n", // '?' -> not a clean token -> no distro tag
+		"var/lib/dpkg/status": "Package: ev@il\nStatus: install ok installed\nVersion: 1?0\nArchitecture: amd64\n\n" +
+			"Package: nul\x00name\nStatus: install ok installed\nVersion: 1.0\nArchitecture: amd64\n\n" +
+			"Package: good\nStatus: install ok installed\nVersion: 2.0\nArchitecture: amd64\n",
+	})
+	res, err := New().Catalog(context.Background(), rootfs)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	by := byName(res.Components)
+	if _, ok := by["nul\x00name"]; ok {
+		t.Error("a control-character package name must be dropped")
+	}
+	// ev@il / 1?0 are kept but percent-encoded; the only literal '?' is the qualifier separator.
+	evil := by["ev@il"]
+	if evil.PURL != "pkg:deb/debian/ev%40il@1%3F0?arch=amd64" {
+		t.Errorf("hostile name/version must be percent-encoded (unambiguous PURL), got %q", evil.PURL)
+	}
+	if strings.Count(evil.PURL, "?") != 1 || strings.Contains(strings.SplitN(evil.PURL, "?", 2)[0], "@1") == false {
+		// sanity: exactly one '?' (the qualifier separator) and the name/version boundary is a single literal '@'
+		t.Errorf("PURL structure ambiguous: %q", evil.PURL)
+	}
+	if res.DistroResolved {
+		t.Error("a garbled os-release ID must yield DistroResolved=false")
+	}
+}
+
+func TestCatalogSkipsSymlinkedDB(t *testing.T) {
+	// Defense-in-depth: a symlinked DB path (the assembler skips symlink entries, so it should not occur) must
+	// not be read/followed out of the rootfs.
+	rootfs := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootfs, "var/lib/dpkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/etc/passwd", filepath.Join(rootfs, "var/lib/dpkg/status")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	res, err := New().Catalog(context.Background(), rootfs)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	if len(res.Components) != 0 {
+		t.Errorf("a symlinked dpkg DB must not be read, got %+v", res.Components)
+	}
+}
+
+func TestCatalogDistroTagRoundTrips(t *testing.T) {
+	// Lock the tag ospkg emits to the domain SSOT (distro.ParseTag), so a delimiter/format change here cannot
+	// silently desync OS-advisory matching.
+	cases := []struct{ id, verID, dbPath, dbContent, wantID, wantVer string }{
+		{"debian", "12", "var/lib/dpkg/status", "Package: bash\nStatus: install ok installed\nVersion: 5.1\nArchitecture: amd64\n", "debian", "12"},
+		{"ubuntu", "22.04", "var/lib/dpkg/status", "Package: bash\nStatus: install ok installed\nVersion: 5.1\nArchitecture: amd64\n", "ubuntu", "22.04"},
+		{"alpine", "3.18.12", "lib/apk/db/installed", "P:busybox\nV:1.36\nA:x86_64\n", "alpine", "3.18"},
+	}
+	for _, tc := range cases {
+		rootfs := writeRootfs(t, map[string]string{
+			"etc/os-release": "ID=" + tc.id + "\nVERSION_ID=" + tc.verID + "\n",
+			tc.dbPath:        tc.dbContent,
+		})
+		res, err := New().Catalog(context.Background(), rootfs)
+		if err != nil || len(res.Components) != 1 || !res.DistroResolved {
+			t.Fatalf("%s: catalog: %v / resolved=%v / %+v", tc.id, err, res.DistroResolved, res.Components)
+		}
+		tag := distroQualifier(res.Components[0].PURL)
+		rel, ok := distro.ParseTag(tag)
+		if !ok || rel.ID != tc.wantID || rel.Version != tc.wantVer {
+			t.Errorf("%s: emitted tag %q -> ParseTag %+v ok=%v; want %s/%s", tc.id, tag, rel, ok, tc.wantID, tc.wantVer)
+		}
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -514,6 +514,7 @@ type Workspace struct {
 	// targets. Owned parsers read it for on-disk OS-package DBs + /etc/os-release. Dir stays the OCI layout
 	// (what syft scans); RootFS is the walkable tree. Both live under the same cleaned-up temp dir.
 	RootFS string
+	// (see OSPackageCataloger for how RootFS is consumed.)
 	// RootFSNote records why rootfs materialization was skipped for an image target (unsupported layer
 	// compression, a hostile layer the hardening refused, a malformed layout) when extraction was enabled but
 	// failed. Empty on success or when not enabled. Rootfs is best-effort — a failure never aborts the scan —
@@ -521,6 +522,27 @@ type Workspace struct {
 	// "not analyzed", never as "no OS packages".
 	RootFSNote string
 	Cleanup    func() error
+}
+
+// OSPackageResult is the outcome of OS-package cataloging: the components plus whether their distro release
+// resolved to an advisory-matchable ecosystem. DistroResolved is false when the OS DB was read but the release
+// could not be keyed (/etc/os-release absent, garbled, or inconsistent with the DB family) — so the pipeline
+// surfaces a completeness warning instead of the packages silently matching zero OS advisories (a falsely-clean
+// OS posture). DistroResolved is meaningful only when Components is non-empty.
+type OSPackageResult struct {
+	Components     []sbom.Component
+	DistroResolved bool
+}
+
+// OSPackageCataloger reads a materialized image root filesystem (Workspace.RootFS) and returns the installed
+// OS packages — Debian/Ubuntu dpkg (/var/lib/dpkg/status) and Alpine apk (/lib/apk/db/installed) — as SBOM
+// components, each tagged (when the release resolves) with a Syft-style distro qualifier
+// (distro=debian-12/ubuntu-22.04/alpine-3.18.12, from /etc/os-release) so the existing advisory matcher keys
+// them to the right OS ecosystem. It is the owned (detection-independent) alternative to relying on the
+// generator for OS packages. An empty result means "OS not analyzed", never "no OS packages" (a hostile image
+// can legitimately yield an empty rootfs).
+type OSPackageCataloger interface {
+	Catalog(ctx context.Context, rootfsDir string) (OSPackageResult, error)
 }
 
 // Completeness signals how trustworthy a scan's results are: whether dependency

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -63,6 +63,7 @@ type Service struct {
 	sastAnalyzer   ports.SASTAnalyzer            // optional deterministic pattern-SAST over the live workspace
 	secretScanner  ports.SecretScanner           // optional deterministic secret scan over the live workspace
 	misconfig      ports.MisconfigScanner        // optional deterministic IaC/config misconfig scan over the live workspace
+	osPkgCataloger ports.OSPackageCataloger      // optional owned OS-package cataloging (dpkg/apk) from an image rootfs
 	suppression    ports.SuppressionLoader       // optional repo-committed .synapseignore accepted-risk policy
 	vexLoader      ports.VEXLoader               // optional in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
 	complianceOn   bool                          // when set, attach the AppSec-baseline compliance report to a scan
@@ -124,6 +125,10 @@ func (s *Service) SetSASTAnalyzer(a ports.SASTAnalyzer) { s.sastAnalyzer = a }
 
 // SetSecretScanner configures the optional deterministic secret scanner. nil ⇒ no secret scanning.
 func (s *Service) SetSecretScanner(sc ports.SecretScanner) { s.secretScanner = sc }
+
+// SetOSPackageCataloger configures optional owned OS-package cataloging (dpkg/apk) from a materialized image
+// rootfs (Workspace.RootFS). nil ⇒ no owned OS cataloging. It only runs when a rootfs was materialized.
+func (s *Service) SetOSPackageCataloger(c ports.OSPackageCataloger) { s.osPkgCataloger = c }
 
 // SetSBOMCache configures the optional generated-SBOM cache. nil ⇒ always regenerate. Best-effort: a cache
 // miss or error never affects correctness, only whether the cataloging step is skipped.
@@ -520,6 +525,65 @@ func countComponents(doc *sbom.SBOM) int {
 		return 0
 	}
 	return len(doc.Components)
+}
+
+// mergeOSComponents adds owned OS-package components not already present, so owned cataloging fills the gap
+// under the owned producer WITHOUT duplicating OS packages the generator already cataloged from the image
+// layout. The dedup key is PURL-type + lowercased name@version + arch: including the type prevents a same
+// name@version NON-OS package (which a hostile image could plant) from masking an OS package's advisories,
+// and including the arch keeps a multiarch pair (libc6:amd64 + :i386, same version) distinct — while still
+// matching the generator's own deb/apk entry (same type+arch) so it is not double-counted. Returns the number
+// added.
+func mergeOSComponents(doc *sbom.SBOM, osComps []sbom.Component) int {
+	if doc == nil || len(osComps) == 0 {
+		return 0
+	}
+	key := func(c sbom.Component) string {
+		return purlType(c.PURL) + "|" + strings.ToLower(c.Name) + "@" + c.Version + "|" + purlArch(c.PURL)
+	}
+	have := make(map[string]bool, len(doc.Components))
+	for _, c := range doc.Components {
+		have[key(c)] = true
+	}
+	added := 0
+	for _, c := range osComps {
+		k := key(c)
+		if have[k] {
+			continue
+		}
+		have[k] = true
+		doc.Components = append(doc.Components, c)
+		added++
+	}
+	return added
+}
+
+// purlType returns a PURL's package type ("pkg:deb/..." -> "deb"), or "" if absent. A minimal read-only
+// subset for the OS-package dedup key (the full PURL parser lives in the advisory infra, which usecase cannot
+// import).
+func purlType(purl string) string {
+	s := strings.TrimPrefix(purl, "pkg:")
+	if s == purl { // no "pkg:" prefix
+		return ""
+	}
+	if i := strings.IndexByte(s, '/'); i > 0 {
+		return s[:i]
+	}
+	return ""
+}
+
+// purlArch returns a PURL's "arch" qualifier value, or "" if absent.
+func purlArch(purl string) string {
+	i := strings.IndexByte(purl, '?')
+	if i < 0 {
+		return ""
+	}
+	for _, kv := range strings.Split(purl[i+1:], "&") {
+		if v, ok := strings.CutPrefix(kv, "arch="); ok {
+			return v
+		}
+	}
+	return ""
 }
 
 func buildComponentLicenseAudit(comps []sbom.Component, findings []ports.LicenseFinding) []ComponentLicenseAudit {
@@ -1419,6 +1483,24 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		s.sbomEnricher.Enrich(ctx, ws.Dir, doc)
 		trace.succeed(step, "SBOM enrichment completed", map[string]int{"components_before": before, "components": countComponents(doc)})
 	}
+	// Owned OS-package cataloging (dpkg/apk) from a materialized image rootfs: detection-independent OS
+	// packages, added BEFORE detection so they get advisory-matched. Best-effort, and deduped by name@version
+	// so it fills the gap under the owned producer WITHOUT duplicating OS packages the generator already
+	// cataloged from the image layout. A non-image target / disabled or failed extraction leaves RootFS empty,
+	// so this is a no-op there.
+	osPkgsAdded, osDistroUnresolved := 0, false
+	if s.osPkgCataloger != nil && ws.RootFS != "" {
+		before := countComponents(doc)
+		step = trace.start(stageSBOM, "os-package-catalog", "ospkg-cataloger", "Catalog OS packages from image rootfs", map[string]int{"components": before})
+		if osRes, oerr := s.osPkgCataloger.Catalog(ctx, ws.RootFS); oerr != nil {
+			trace.fail(step, oerr) // surface (never swallow) a cancellation/error rather than reporting success
+		} else {
+			osPkgsAdded = mergeOSComponents(doc, osRes.Components)
+			// no-silent-gap: packages cataloged but the release could not be keyed to an ecosystem → warn below.
+			osDistroUnresolved = osPkgsAdded > 0 && !osRes.DistroResolved
+			trace.succeed(step, "OS-package cataloging completed", map[string]int{"os_packages_added": osPkgsAdded})
+		}
+	}
 	// Resolve the FULL Maven dependency tree via `mvn dependency:list` (best-effort + opt-in): a from-source
 	// Maven scan otherwise sees only the direct starters with UNKNOWN (parent-BOM-managed) versions and no
 	// transitive tree, so it under-reports vs a build-artifact scan. When it resolves, replace syft's
@@ -1646,6 +1728,19 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 			sourceWarnings = append(sourceWarnings, fmt.Sprintf(
 				"Gradle dependency resolution failed — transitive tree NOT captured (result INCOMPLETE): %v", gradleResolveErr))
 		}
+	}
+	// An image target whose rootfs could not be assembled means OS packages were NOT owned-cataloged; surface
+	// it (never silent) so an absent OS-package set reads as "not analyzed", not "no OS packages".
+	if ws.RootFSNote != "" {
+		sourceWarnings = append(sourceWarnings, fmt.Sprintf(
+			"image rootfs NOT materialized — OS packages NOT owned-cataloged (result may under-report OS vulns): %s", ws.RootFSNote))
+	}
+	// OS packages were cataloged but their distro release could not be resolved (os-release absent/garbled, or
+	// inconsistent with the package DB), so they matched NO OS advisories — surface it so this never reads as
+	// a clean OS posture (a hostile image cannot suppress its own OS vulns by lying in /etc/os-release).
+	if osDistroUnresolved {
+		sourceWarnings = append(sourceWarnings, fmt.Sprintf(
+			"%d OS package(s) cataloged but the distro release could not be resolved (/etc/os-release absent, garbled, or inconsistent with the package database) — OS advisories were NOT matched", osPkgsAdded))
 	}
 	for _, src := range s.sources {
 		p, ok := src.(ports.SourceProvenance)


### PR DESCRIPTION
## What

PR-2 of rootfs-extraction (PR #41 was the extractor). Consumes the materialized image rootfs to catalog installed OS packages the **detection-independent** way, turning rootfs-extraction from dormant into a real capability.

`internal/infrastructure/tools/ospkg` reads:
- Debian/Ubuntu **dpkg** `/var/lib/dpkg/status` (only `install ok installed` packages)
- Alpine **apk** `/lib/apk/db/installed`
- the distro release from `/etc/os-release`

and emits SBOM components tagged with a **Syft-style distro qualifier** (`distro=debian-12` / `ubuntu-22.04` / `alpine-3.18.12`), so the **existing** advisory matcher (`osDistroEcosystem` + the dpkg/apk version comparators from the OVAL work) keys them to the right OS ecosystem with no matcher change.

## Wiring

`ports.OSPackageCataloger`: the scan pipeline catalogs from `Workspace.RootFS` after SBOM generation and **before detection** (so OS packages get advisory-matched + license-scanned), merging deduped by `name@version`. This fills the gap under the owned producer **without** duplicating the OS packages the generator already catalogs from the image layout (a no-op under Syft, additive under `ownsbom`). Best-effort: a catalog error never fails the scan. Gated on `SYNAPSE_IMAGE_ROOTFS_ENABLED` at both composition roots.

## Untrusted-input hardening

The rootfs is derived from an untrusted image, so: every DB read is **bounded** (64 MB + 200k-package caps) and **regular-file guarded** (`Lstat`, so a symlinked DB is never followed out of the rootfs); package name/version are **sanitized** (dropped if they carry PURL-breaking characters `?#& /`); os-release `ID`/`VERSION_ID` are **validated** before entering the distro qualifier.

## Fail-open trap closed

When the rootfs was NOT materialized (extraction disabled/failed), the pipeline surfaces a **SourceWarning** ("image rootfs NOT materialized — OS packages NOT owned-cataloged"), so an absent OS-package set reads as "not analyzed", never "no OS packages → clean" (the exact trap the PR #41 security review flagged).

## Verify

`go build ./...`, `go vet ./...`, full `go test ./...` green. 6 cataloger tests over synthetic rootfs dirs: Debian (installed-only + PURL), Alpine, no-os-release (no distro qualifier), empty rootfs, hostile-field sanitization, symlinked-DB guard. rpm (binary DB) deferred.
