### PR TITLE
feat(sca): owned rpm OS-package cataloging (sqlite rpmdb) from the image rootfs

### DIFF
--- a/internal/infrastructure/tools/ospkg/cataloger.go
+++ b/internal/infrastructure/tools/ospkg/cataloger.go
@@ -111,8 +111,12 @@ func (Cataloger) Catalog(ctx context.Context, rootfsDir string) (ports.OSPackage
 			rpmResolved = rpmMatchableIDs[id] && major != ""
 		}
 	}
-	if comps := rpmComponents(ctx, rootfsDir, rpmNS, rpmTag); len(comps) > 0 {
-		res.Components = append(res.Components, comps...)
+	rpmComps, err := rpmComponents(ctx, rootfsDir, rpmNS, rpmTag)
+	if err != nil { // only a context cancellation; a hostile/malformed DB degrades to no components
+		return ports.OSPackageResult{}, err
+	}
+	if len(rpmComps) > 0 {
+		res.Components = append(res.Components, rpmComps...)
 		if !rpmResolved {
 			res.DistroResolved = false
 		}

--- a/internal/infrastructure/tools/ospkg/cataloger.go
+++ b/internal/infrastructure/tools/ospkg/cataloger.go
@@ -1,6 +1,6 @@
 // Package ospkg catalogs installed OS packages from a materialized image root filesystem: Debian/Ubuntu dpkg
-// (/var/lib/dpkg/status) and Alpine apk (/lib/apk/db/installed), with the distro release read from
-// /etc/os-release. It is the OWNED (detection-independent) alternative to relying on the SBOM generator for
+// (/var/lib/dpkg/status), Alpine apk (/lib/apk/db/installed), and RHEL-family rpm (/var/lib/rpm/rpmdb.sqlite),
+// with the distro release read from /etc/os-release. It is the OWNED (detection-independent) alternative to relying on the SBOM generator for
 // OS packages, and emits components tagged with a Syft-style "distro" qualifier so the existing advisory
 // matcher keys them to the right OS ecosystem. It only READS the rootfs (already assembled within the
 // workspace); the databases are UNTRUSTED, so: reads are streamed + bounded (size, line, and package caps)
@@ -90,19 +90,30 @@ func (Cataloger) Catalog(ctx context.Context, rootfsDir string) (ports.OSPackage
 	}
 
 	// rpm (RHEL/Fedora family, sqlite backend): the distro qualifier is set for any rpm-family id (inventory),
-	// but only the ids osDistroEcosystem keys (Rocky/AlmaLinux/Oracle) count as resolved — RHEL/CentOS/Fedora
-	// use module-qualified or uncertain OSV keys, so they are emitted but flagged unresolved (surfaced upstream,
-	// never a silent zero-match). Berkeley-DB/ndb backends are deferred (the generator covers them).
+	// but only the ids osDistroEcosystem keys (Rocky/AlmaLinux/Oracle) with a non-empty major version count as
+	// resolved — RHEL/CentOS/Fedora use module-qualified or uncertain OSV keys, so they are emitted but flagged
+	// unresolved (surfaced upstream, never a silent zero-match). Berkeley-DB/ndb backends are deferred (the
+	// generator covers them).
 	rpmNS, rpmTag := "rhel", ""
+	rpmResolved := false
 	if id != "" {
 		rpmNS = id
 		if versionID != "" {
 			rpmTag = id + "-" + versionID
+			// Mirror osDistroEcosystem, which keys on the major (VERSION_ID up to the first '.'): a clean-but-
+			// empty major (e.g. VERSION_ID=".3", which isCleanToken admits) maps to nothing. Require a non-empty
+			// major here too, so this resolved flag can never disagree with the mapping — a disagreement would be
+			// exactly the silent zero-match (resolved=true yet ecosystem="") this flag exists to prevent.
+			major := versionID
+			if i := strings.IndexByte(versionID, '.'); i >= 0 {
+				major = versionID[:i]
+			}
+			rpmResolved = rpmMatchableIDs[id] && major != ""
 		}
 	}
-	if comps := rpmComponents(rootfsDir, rpmNS, rpmTag); len(comps) > 0 {
+	if comps := rpmComponents(ctx, rootfsDir, rpmNS, rpmTag); len(comps) > 0 {
 		res.Components = append(res.Components, comps...)
-		if !(rpmMatchableIDs[id] && rpmTag != "") {
+		if !rpmResolved {
 			res.DistroResolved = false
 		}
 	}

--- a/internal/infrastructure/tools/ospkg/cataloger.go
+++ b/internal/infrastructure/tools/ospkg/cataloger.go
@@ -88,8 +88,31 @@ func (Cataloger) Catalog(ctx context.Context, rootfsDir string) (ports.OSPackage
 			res.DistroResolved = false
 		}
 	}
+
+	// rpm (RHEL/Fedora family, sqlite backend): the distro qualifier is set for any rpm-family id (inventory),
+	// but only the ids osDistroEcosystem keys (Rocky/AlmaLinux/Oracle) count as resolved — RHEL/CentOS/Fedora
+	// use module-qualified or uncertain OSV keys, so they are emitted but flagged unresolved (surfaced upstream,
+	// never a silent zero-match). Berkeley-DB/ndb backends are deferred (the generator covers them).
+	rpmNS, rpmTag := "rhel", ""
+	if id != "" {
+		rpmNS = id
+		if versionID != "" {
+			rpmTag = id + "-" + versionID
+		}
+	}
+	if comps := rpmComponents(rootfsDir, rpmNS, rpmTag); len(comps) > 0 {
+		res.Components = append(res.Components, comps...)
+		if !(rpmMatchableIDs[id] && rpmTag != "") {
+			res.DistroResolved = false
+		}
+	}
 	return res, nil
 }
+
+// rpmMatchableIDs are the rpm-family os-release IDs osDistroEcosystem can key to an advisory ecosystem
+// (Rocky/AlmaLinux/Oracle Linux, which OSV keys by "<Name>:<major>"). Others (rhel/centos/fedora/amzn/suse)
+// are cataloged for inventory but flagged unresolved until their ecosystem mapping + advisory feed land.
+var rpmMatchableIDs = map[string]bool{"rocky": true, "almalinux": true, "alma": true, "ol": true, "oracle": true}
 
 // dpkgFieldKeys / apkFieldKeys are the ONLY stanza keys each parser reads. parseOSDB stores only these, so a
 // stanza with millions of distinct junk keys cannot grow the per-stanza map (keeps memory O(1) per stanza).

--- a/internal/infrastructure/tools/ospkg/rpm.go
+++ b/internal/infrastructure/tools/ospkg/rpm.go
@@ -9,7 +9,10 @@ import (
 	"path/filepath"
 	"strconv"
 
-	_ "modernc.org/sqlite" // pure-Go sqlite driver (matches CGO_ENABLED=0), for the RHEL9+/Fedora rpmdb.sqlite
+	// pure-Go sqlite driver (matches CGO_ENABLED=0), for the RHEL9+/Fedora rpmdb.sqlite. NOTE: the crafted-view
+	// non-hang property (see rpmComponents + TestCatalogRPMHostileViewTerminates) is driver-behavior-specific —
+	// re-validate that test on any version bump of this dependency.
+	_ "modernc.org/sqlite"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 )
@@ -19,11 +22,12 @@ import (
 // older Berkeley-DB (/var/lib/rpm/Packages, RHEL<=8/CentOS/AL2) and ndb (openSUSE) backends are DEFERRED —
 // their binary page formats are a larger, riskier parse and the generator already catalogs them from the
 // layout. Everything here treats the DB + header as UNTRUSTED (a hostile image): reads are cancellable
-// (ctx-threaded, plus a watchdog that closes the DB on ctx.Done so even a crafted sqlite that spins inside one
-// driver step is aborted by the scan deadline), bounded (per-blob size filter server-side, total-byte +
-// row-count budgets), and each identity tag latches on its first NON-EMPTY value so a crafted header cannot
-// amplify the per-entry scan; the header parse is fully bounds-checked and the whole sqlite interaction is
-// recover-wrapped so a malformed DB contributes nothing rather than panicking the scan (cf. PR #43).
+// (modernc interrupts the first query step, the loop re-checks ctx between steps, and a best-effort watchdog
+// closes the DB on cancel) and bounded (per-blob size filter server-side + total-byte + row-count budgets);
+// together with the pinned driver returning promptly on a crafted view rather than spinning, those bound a
+// hostile DB. Each identity tag latches on its first NON-EMPTY value so a crafted header cannot amplify the
+// per-entry scan; the header parse is fully bounds-checked and the whole sqlite interaction is recover-wrapped
+// so a malformed DB contributes nothing rather than panicking the scan (cf. PR #43).
 const (
 	maxRPMIndex   = 1 << 16  // index-entry count cap per header
 	maxRPMData    = 64 << 20 // header data-store size cap
@@ -68,11 +72,17 @@ func rpmComponents(ctx context.Context, rootfsDir, namespace, tag string) (out [
 		return nil, nil
 	}
 	defer func() { _ = db.Close() }()
-	// A crafted sqlite (e.g. Packages as a view over a recursive CTE) can spin INSIDE one driver step — where
-	// the pure-Go driver only arms its ctx-interrupt for the first step, so the per-row ctx.Err() below never
-	// gets a turn and the scan's timeout could not otherwise stop it. Closing the DB on ctx.Done aborts an
-	// in-flight step, so this read is genuinely bounded by the scan deadline. done stops the watchdog on a
-	// normal return (defer order: close(done) runs before db.Close, so the watchdog never double-closes).
+	// Best-effort cancellation backstop. Real cancellation of this read comes from (1) modernc arming a
+	// ctx->sqlite3_interrupt watcher for QueryContext's FIRST step and (2) the per-row ctx.Err() check below,
+	// between steps. A spin INSIDE a later rows.Next() step is NOT interruptible by modernc, by stdlib, or by
+	// this close: sql.DB.Close closes an in-use connection only when it is returned and never interrupts a
+	// running step, so this watchdog does not guarantee aborting a mid-step spin (it only unblocks idle work
+	// and prevents new queries). Such a spin is only reachable via a crafted Packages view whose rows the
+	// server-side LENGTH filter rejects internally (so they never reach the loop); the pinned modernc v1.53.0
+	// returns promptly on that shape rather than spinning, which — with the per-blob + total-byte + row-count
+	// bounds below — is what actually bounds a hostile DB. TestCatalogRPMHostileViewTerminates locks that
+	// property; RE-VALIDATE it on any modernc bump. done stops the watchdog on a normal return; defer order
+	// (close(done) before db.Close) means no double-close on the happy path, and db.Close is idempotent anyway.
 	done := make(chan struct{})
 	defer close(done)
 	go func() {

--- a/internal/infrastructure/tools/ospkg/rpm.go
+++ b/internal/infrastructure/tools/ospkg/rpm.go
@@ -19,10 +19,11 @@ import (
 // older Berkeley-DB (/var/lib/rpm/Packages, RHEL<=8/CentOS/AL2) and ndb (openSUSE) backends are DEFERRED —
 // their binary page formats are a larger, riskier parse and the generator already catalogs them from the
 // layout. Everything here treats the DB + header as UNTRUSTED (a hostile image): reads are cancellable
-// (ctx-threaded), bounded (per-blob size filter server-side, total-byte + row-count budgets), and each
-// identity tag is read at most once so a crafted header cannot amplify work; the header parse is fully
-// bounds-checked and the whole sqlite interaction is recover-wrapped so a malformed DB contributes nothing
-// rather than panicking the scan (cf. PR #43).
+// (ctx-threaded, plus a watchdog that closes the DB on ctx.Done so even a crafted sqlite that spins inside one
+// driver step is aborted by the scan deadline), bounded (per-blob size filter server-side, total-byte +
+// row-count budgets), and each identity tag latches on its first NON-EMPTY value so a crafted header cannot
+// amplify the per-entry scan; the header parse is fully bounds-checked and the whole sqlite interaction is
+// recover-wrapped so a malformed DB contributes nothing rather than panicking the scan (cf. PR #43).
 const (
 	maxRPMIndex   = 1 << 16  // index-entry count cap per header
 	maxRPMData    = 64 << 20 // header data-store size cap
@@ -44,32 +45,48 @@ const (
 
 // rpmComponents reads /var/lib/rpm/rpmdb.sqlite and returns one component per installed package. namespace is
 // the PURL namespace (distro id) and tag the distro qualifier (or ""). Best-effort + hardened for an untrusted
-// DB: streamed (one blob at a time), bounded (per-blob size filter + total-byte + row-count budgets),
-// cancellable (ctx), and recover-wrapped so a malformed sqlite yields nil rather than crashing the scan. An
-// absent/non-sqlite DB (a Berkeley-DB/ndb rootfs) → nil; the generator still catalogs those from the layout.
-func rpmComponents(ctx context.Context, rootfsDir, namespace, tag string) (out []sbom.Component) {
+// DB: streamed (one blob at a time), bounded (per-blob size filter + total-byte + row-count budgets), and
+// recover-wrapped so a malformed sqlite yields nil rather than crashing the scan. It is cancellable: an error
+// is returned ONLY on context cancellation (so the pipeline surfaces a timed-out read as a failure, never a
+// silently-truncated success); a hostile-DB read error or panic degrades to (nil, nil). An absent/non-sqlite
+// DB (a Berkeley-DB/ndb rootfs) → (nil, nil); the generator still catalogs those from the layout.
+func rpmComponents(ctx context.Context, rootfsDir, namespace, tag string) (out []sbom.Component, err error) {
 	defer func() {
 		if recover() != nil { // the sqlite file is untrusted; a driver panic must degrade to no components
-			out = nil
+			out, err = nil, nil
 		}
 	}()
 	path := filepath.Join(rootfsDir, "var/lib/rpm/rpmdb.sqlite")
-	fi, err := os.Lstat(path) // regular-file guard: never follow a symlinked DB out of the rootfs
-	if err != nil || !fi.Mode().IsRegular() {
-		return nil
+	fi, statErr := os.Lstat(path) // regular-file guard: never follow a symlinked DB out of the rootfs
+	if statErr != nil || !fi.Mode().IsRegular() {
+		return nil, nil
 	}
 	// mode=ro + immutable=1: the rootfs is static, never written; the path is a fixed suffix of the workspace
 	// dir (no attacker-controlled '?'), so the DSN query cannot be overridden.
-	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
-	if err != nil {
-		return nil
+	db, openErr := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
+	if openErr != nil {
+		return nil, nil
 	}
 	defer func() { _ = db.Close() }()
+	// A crafted sqlite (e.g. Packages as a view over a recursive CTE) can spin INSIDE one driver step — where
+	// the pure-Go driver only arms its ctx-interrupt for the first step, so the per-row ctx.Err() below never
+	// gets a turn and the scan's timeout could not otherwise stop it. Closing the DB on ctx.Done aborts an
+	// in-flight step, so this read is genuinely bounded by the scan deadline. done stops the watchdog on a
+	// normal return (defer order: close(done) runs before db.Close, so the watchdog never double-closes).
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = db.Close()
+		case <-done:
+		}
+	}()
 	// Bound each header server-side (parameterized, no string concatenation) so an oversized row is filtered
-	// before Scan allocates it; the read is cancellable via QueryContext.
-	rows, err := db.QueryContext(ctx, "SELECT blob FROM Packages WHERE LENGTH(blob) > 0 AND LENGTH(blob) <= ?", rpmMaxBlobLen)
-	if err != nil {
-		return nil
+	// before Scan allocates it; the read is cancellable via QueryContext + the watchdog above.
+	rows, queryErr := db.QueryContext(ctx, "SELECT blob FROM Packages WHERE LENGTH(blob) > 0 AND LENGTH(blob) <= ?", rpmMaxBlobLen)
+	if queryErr != nil {
+		return nil, ctx.Err() // ctx.Err() is non-nil iff cancelled → surface; else a hostile-DB error → (nil, nil)
 	}
 	defer func() { _ = rows.Close() }()
 	var total int64
@@ -77,12 +94,12 @@ func rpmComponents(ctx context.Context, rootfsDir, namespace, tag string) (out [
 		if len(out) >= maxPackages || total >= maxDBBytes { // row-count + total-byte budgets (bomb guard)
 			break
 		}
-		if err := ctx.Err(); err != nil {
-			return out
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
 		}
 		var b []byte
-		if err := rows.Scan(&b); err != nil {
-			return out
+		if scanErr := rows.Scan(&b); scanErr != nil {
+			return nil, ctx.Err() // watchdog-close (cancelled) → surface; otherwise a hostile-DB error → (nil, nil)
 		}
 		total += int64(len(b))
 		if name, evr, arch, ok := safeParseRPMHeader(b); ok {
@@ -91,7 +108,10 @@ func rpmComponents(ctx context.Context, rootfsDir, namespace, tag string) (out [
 			}
 		}
 	}
-	return out
+	if rows.Err() != nil {
+		return nil, ctx.Err() // discard partials on a hostile-DB read error (matches parseOSDB); surface a cancel
+	}
+	return out, nil
 }
 
 // safeParseRPMHeader wraps parseRPMHeader in a recover: the bounds checks below should already prevent a
@@ -108,8 +128,9 @@ func safeParseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
 // parseRPMHeader extracts (name, epoch:version-release, arch) from one RPM header blob. Layout: an optional
 // 8-byte lead (magic 8e ad e8 01 + 4 reserved), then nindex (u32 BE) + hsize (u32 BE), then nindex 16-byte
 // index entries (tag, type, offset, count), then an hsize-byte data store. Every offset is bounds-checked in
-// unsigned space (width-independent), and each identity tag is read AT MOST ONCE — so a crafted header with
-// many duplicate tags cannot amplify the per-entry string scan.
+// unsigned space (width-independent), and each identity tag latches on its first NON-EMPTY value — a costly
+// rpmCStr scan only ever returns non-empty (an empty result is O(1)), so a crafted header with many duplicate
+// tags cannot amplify the per-entry string scan.
 func parseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
 	off := 0
 	if len(blob) >= 4 && [4]byte(blob[:4]) == rpmHeaderMagic {

--- a/internal/infrastructure/tools/ospkg/rpm.go
+++ b/internal/infrastructure/tools/ospkg/rpm.go
@@ -2,6 +2,7 @@ package ospkg
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/binary"
 	"os"
@@ -17,14 +18,18 @@ import (
 // /var/lib/rpm/rpmdb.sqlite, whose Packages table holds one binary RPM HEADER blob per installed package. The
 // older Berkeley-DB (/var/lib/rpm/Packages, RHEL<=8/CentOS/AL2) and ndb (openSUSE) backends are DEFERRED —
 // their binary page formats are a larger, riskier parse and the generator already catalogs them from the
-// layout. The header blob is UNTRUSTED (from a hostile image), so parseRPMHeader is fully bounds-checked and
-// wrapped in a recover: a crafted header contributes nothing rather than panicking the scan (cf. PR #43).
+// layout. Everything here treats the DB + header as UNTRUSTED (a hostile image): reads are cancellable
+// (ctx-threaded), bounded (per-blob size filter server-side, total-byte + row-count budgets), and each
+// identity tag is read at most once so a crafted header cannot amplify work; the header parse is fully
+// bounds-checked and the whole sqlite interaction is recover-wrapped so a malformed DB contributes nothing
+// rather than panicking the scan (cf. PR #43).
 const (
-	maxRPMIndex = 1 << 16  // index-entry count cap per header (a real package has a few hundred tags at most)
-	maxRPMData  = 64 << 20 // header data-store size cap
+	maxRPMIndex   = 1 << 16  // index-entry count cap per header
+	maxRPMData    = 64 << 20 // header data-store size cap
+	rpmMaxBlobLen = 12 << 20 // per-header-blob cap (a real RPM header is well under this)
 )
 
-var rpmHeaderMagic = []byte{0x8e, 0xad, 0xe8, 0x01}
+var rpmHeaderMagic = [4]byte{0x8e, 0xad, 0xe8, 0x01}
 
 // RPM header tags + value types (the subset needed for identity).
 const (
@@ -38,28 +43,59 @@ const (
 )
 
 // rpmComponents reads /var/lib/rpm/rpmdb.sqlite and returns one component per installed package. namespace is
-// the PURL namespace (distro id) and tag the distro qualifier (or ""). Best-effort: an absent/unreadable/
-// non-sqlite DB yields nil (Berkeley-DB/ndb rootfs → no owned rpm components; the generator still catalogs them).
-func rpmComponents(rootfsDir, namespace, tag string) []sbom.Component {
-	blobs := rpmSqliteBlobs(filepath.Join(rootfsDir, "var/lib/rpm/rpmdb.sqlite"))
-	var out []sbom.Component
-	for _, blob := range blobs {
-		if len(out) >= maxPackages {
+// the PURL namespace (distro id) and tag the distro qualifier (or ""). Best-effort + hardened for an untrusted
+// DB: streamed (one blob at a time), bounded (per-blob size filter + total-byte + row-count budgets),
+// cancellable (ctx), and recover-wrapped so a malformed sqlite yields nil rather than crashing the scan. An
+// absent/non-sqlite DB (a Berkeley-DB/ndb rootfs) → nil; the generator still catalogs those from the layout.
+func rpmComponents(ctx context.Context, rootfsDir, namespace, tag string) (out []sbom.Component) {
+	defer func() {
+		if recover() != nil { // the sqlite file is untrusted; a driver panic must degrade to no components
+			out = nil
+		}
+	}()
+	path := filepath.Join(rootfsDir, "var/lib/rpm/rpmdb.sqlite")
+	fi, err := os.Lstat(path) // regular-file guard: never follow a symlinked DB out of the rootfs
+	if err != nil || !fi.Mode().IsRegular() {
+		return nil
+	}
+	// mode=ro + immutable=1: the rootfs is static, never written; the path is a fixed suffix of the workspace
+	// dir (no attacker-controlled '?'), so the DSN query cannot be overridden.
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = db.Close() }()
+	// Bound each header server-side (parameterized, no string concatenation) so an oversized row is filtered
+	// before Scan allocates it; the read is cancellable via QueryContext.
+	rows, err := db.QueryContext(ctx, "SELECT blob FROM Packages WHERE LENGTH(blob) > 0 AND LENGTH(blob) <= ?", rpmMaxBlobLen)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+	var total int64
+	for rows.Next() {
+		if len(out) >= maxPackages || total >= maxDBBytes { // row-count + total-byte budgets (bomb guard)
 			break
 		}
-		name, evr, arch, ok := safeParseRPMHeader(blob)
-		if !ok {
-			continue
+		if err := ctx.Err(); err != nil {
+			return out
 		}
-		if c, ok := osComponent("rpm", namespace, name, evr, arch, tag); ok {
-			out = append(out, c)
+		var b []byte
+		if err := rows.Scan(&b); err != nil {
+			return out
+		}
+		total += int64(len(b))
+		if name, evr, arch, ok := safeParseRPMHeader(b); ok {
+			if c, ok := osComponent("rpm", namespace, name, evr, arch, tag); ok {
+				out = append(out, c)
+			}
 		}
 	}
 	return out
 }
 
-// safeParseRPMHeader wraps parseRPMHeader in a recover: a crafted header blob must never panic the scan (the
-// bounds checks below should already prevent it, but this is the belt-and-suspenders guard from PR #43).
+// safeParseRPMHeader wraps parseRPMHeader in a recover: the bounds checks below should already prevent a
+// panic, but this is the belt-and-suspenders guard from PR #43 for an attacker-authored header.
 func safeParseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
 	defer func() {
 		if recover() != nil {
@@ -71,11 +107,12 @@ func safeParseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
 
 // parseRPMHeader extracts (name, epoch:version-release, arch) from one RPM header blob. Layout: an optional
 // 8-byte lead (magic 8e ad e8 01 + 4 reserved), then nindex (u32 BE) + hsize (u32 BE), then nindex 16-byte
-// index entries (tag, type, offset, count), then an hsize-byte data store. Every offset is bounds-checked
-// against the data store, so an attacker-authored blob cannot read out of bounds.
+// index entries (tag, type, offset, count), then an hsize-byte data store. Every offset is bounds-checked in
+// unsigned space (width-independent), and each identity tag is read AT MOST ONCE — so a crafted header with
+// many duplicate tags cannot amplify the per-entry string scan.
 func parseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
 	off := 0
-	if len(blob) >= 4 && bytes.Equal(blob[:4], rpmHeaderMagic) {
+	if len(blob) >= 4 && [4]byte(blob[:4]) == rpmHeaderMagic {
 		off = 8 // skip the 4-byte magic + 4 reserved bytes
 	}
 	if len(blob) < off+8 {
@@ -87,8 +124,7 @@ func parseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
 		return "", "", "", false
 	}
 	idxStart := off + 8
-	dataStart := idxStart + int(nindex)*16
-	// The index block + data store must fit within the blob (the caps above keep the arithmetic in range).
+	dataStart := idxStart + int(nindex)*16 // nindex<=65536 → *16 fits well within int on any target (no overflow)
 	if dataStart < idxStart || dataStart+int(hsize) > len(blob) {
 		return "", "", "", false
 	}
@@ -101,23 +137,23 @@ func parseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
 		offset := binary.BigEndian.Uint32(blob[e+8 : e+12])
 		switch tag {
 		case rpmTagName:
-			if typ == rpmTypeString {
+			if typ == rpmTypeString && name == "" {
 				name = rpmCStr(data, offset)
 			}
 		case rpmTagVersion:
-			if typ == rpmTypeString {
+			if typ == rpmTypeString && version == "" {
 				version = rpmCStr(data, offset)
 			}
 		case rpmTagRelease:
-			if typ == rpmTypeString {
+			if typ == rpmTypeString && release == "" {
 				release = rpmCStr(data, offset)
 			}
 		case rpmTagArch:
-			if typ == rpmTypeString {
+			if typ == rpmTypeString && arch == "" {
 				arch = rpmCStr(data, offset)
 			}
 		case rpmTagEpoch:
-			if typ == rpmTypeInt32 && int(offset)+4 <= len(data) {
+			if typ == rpmTypeInt32 && epoch == "" && uint64(offset)+4 <= uint64(len(data)) {
 				epoch = strconv.FormatUint(uint64(binary.BigEndian.Uint32(data[offset:offset+4])), 10)
 			}
 		}
@@ -135,9 +171,10 @@ func parseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
 	return name, evr, arch, true
 }
 
-// rpmCStr reads the NUL-terminated string at data[off:], bounds-checked.
+// rpmCStr reads the NUL-terminated string at data[off:], bounds-checked in unsigned space (so a >2^31 offset
+// on a 32-bit build cannot sign-wrap past the guard).
 func rpmCStr(data []byte, off uint32) string {
-	if int(off) >= len(data) {
+	if uint64(off) >= uint64(len(data)) {
 		return ""
 	}
 	s := data[off:]
@@ -145,40 +182,4 @@ func rpmCStr(data []byte, off uint32) string {
 		return string(s[:i])
 	}
 	return string(s) // no terminator: bounded by the data store length
-}
-
-// rpmSqliteBlobs opens rpmdb.sqlite read-only + immutable (an untrusted, static file) and returns the header
-// blob of each Packages row, bounded. A missing/irregular path or any driver/query/scan error yields nil
-// (best-effort — the generator still catalogs rpm from the layout).
-func rpmSqliteBlobs(path string) [][]byte {
-	fi, err := os.Lstat(path) // regular-file guard: never follow a symlinked DB out of the rootfs
-	if err != nil || !fi.Mode().IsRegular() {
-		return nil
-	}
-	// immutable=1: the rootfs is static, so skip locking; mode=ro: never write. The path is a fixed suffix of
-	// the workspace dir (no attacker-controlled '?'), so the DSN query cannot be overridden.
-	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
-	if err != nil {
-		return nil
-	}
-	defer func() { _ = db.Close() }()
-	rows, err := db.Query("SELECT blob FROM Packages") // fixed query (no concatenation); row count bounded below
-	if err != nil {
-		return nil
-	}
-	defer func() { _ = rows.Close() }()
-	var out [][]byte
-	for rows.Next() {
-		if len(out) >= maxPackages { // bound the number of packages read (in Go, not via a SQL LIMIT)
-			break
-		}
-		var b []byte
-		if err := rows.Scan(&b); err != nil {
-			return out
-		}
-		if len(b) > 0 && len(b) <= maxDBBytes {
-			out = append(out, b)
-		}
-	}
-	return out // rows.Err() ignored: a partial best-effort read still contributes what it parsed
 }

--- a/internal/infrastructure/tools/ospkg/rpm.go
+++ b/internal/infrastructure/tools/ospkg/rpm.go
@@ -1,0 +1,184 @@
+package ospkg
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	_ "modernc.org/sqlite" // pure-Go sqlite driver (matches CGO_ENABLED=0), for the RHEL9+/Fedora rpmdb.sqlite
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// RPM package cataloging. Modern distros (RHEL 9+/Fedora/AL2023/UBI9) store the package DB as sqlite at
+// /var/lib/rpm/rpmdb.sqlite, whose Packages table holds one binary RPM HEADER blob per installed package. The
+// older Berkeley-DB (/var/lib/rpm/Packages, RHEL<=8/CentOS/AL2) and ndb (openSUSE) backends are DEFERRED —
+// their binary page formats are a larger, riskier parse and the generator already catalogs them from the
+// layout. The header blob is UNTRUSTED (from a hostile image), so parseRPMHeader is fully bounds-checked and
+// wrapped in a recover: a crafted header contributes nothing rather than panicking the scan (cf. PR #43).
+const (
+	maxRPMIndex = 1 << 16  // index-entry count cap per header (a real package has a few hundred tags at most)
+	maxRPMData  = 64 << 20 // header data-store size cap
+)
+
+var rpmHeaderMagic = []byte{0x8e, 0xad, 0xe8, 0x01}
+
+// RPM header tags + value types (the subset needed for identity).
+const (
+	rpmTagName    = 1000
+	rpmTagVersion = 1001
+	rpmTagRelease = 1002
+	rpmTagEpoch   = 1004
+	rpmTagArch    = 1022
+	rpmTypeInt32  = 4
+	rpmTypeString = 6
+)
+
+// rpmComponents reads /var/lib/rpm/rpmdb.sqlite and returns one component per installed package. namespace is
+// the PURL namespace (distro id) and tag the distro qualifier (or ""). Best-effort: an absent/unreadable/
+// non-sqlite DB yields nil (Berkeley-DB/ndb rootfs → no owned rpm components; the generator still catalogs them).
+func rpmComponents(rootfsDir, namespace, tag string) []sbom.Component {
+	blobs := rpmSqliteBlobs(filepath.Join(rootfsDir, "var/lib/rpm/rpmdb.sqlite"))
+	var out []sbom.Component
+	for _, blob := range blobs {
+		if len(out) >= maxPackages {
+			break
+		}
+		name, evr, arch, ok := safeParseRPMHeader(blob)
+		if !ok {
+			continue
+		}
+		if c, ok := osComponent("rpm", namespace, name, evr, arch, tag); ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// safeParseRPMHeader wraps parseRPMHeader in a recover: a crafted header blob must never panic the scan (the
+// bounds checks below should already prevent it, but this is the belt-and-suspenders guard from PR #43).
+func safeParseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
+	defer func() {
+		if recover() != nil {
+			name, evr, arch, ok = "", "", "", false
+		}
+	}()
+	return parseRPMHeader(blob)
+}
+
+// parseRPMHeader extracts (name, epoch:version-release, arch) from one RPM header blob. Layout: an optional
+// 8-byte lead (magic 8e ad e8 01 + 4 reserved), then nindex (u32 BE) + hsize (u32 BE), then nindex 16-byte
+// index entries (tag, type, offset, count), then an hsize-byte data store. Every offset is bounds-checked
+// against the data store, so an attacker-authored blob cannot read out of bounds.
+func parseRPMHeader(blob []byte) (name, evr, arch string, ok bool) {
+	off := 0
+	if len(blob) >= 4 && bytes.Equal(blob[:4], rpmHeaderMagic) {
+		off = 8 // skip the 4-byte magic + 4 reserved bytes
+	}
+	if len(blob) < off+8 {
+		return "", "", "", false
+	}
+	nindex := binary.BigEndian.Uint32(blob[off : off+4])
+	hsize := binary.BigEndian.Uint32(blob[off+4 : off+8])
+	if nindex == 0 || nindex > maxRPMIndex || hsize > maxRPMData {
+		return "", "", "", false
+	}
+	idxStart := off + 8
+	dataStart := idxStart + int(nindex)*16
+	// The index block + data store must fit within the blob (the caps above keep the arithmetic in range).
+	if dataStart < idxStart || dataStart+int(hsize) > len(blob) {
+		return "", "", "", false
+	}
+	data := blob[dataStart : dataStart+int(hsize)]
+	var version, release, epoch string
+	for i := 0; i < int(nindex); i++ {
+		e := idxStart + i*16
+		tag := binary.BigEndian.Uint32(blob[e : e+4])
+		typ := binary.BigEndian.Uint32(blob[e+4 : e+8])
+		offset := binary.BigEndian.Uint32(blob[e+8 : e+12])
+		switch tag {
+		case rpmTagName:
+			if typ == rpmTypeString {
+				name = rpmCStr(data, offset)
+			}
+		case rpmTagVersion:
+			if typ == rpmTypeString {
+				version = rpmCStr(data, offset)
+			}
+		case rpmTagRelease:
+			if typ == rpmTypeString {
+				release = rpmCStr(data, offset)
+			}
+		case rpmTagArch:
+			if typ == rpmTypeString {
+				arch = rpmCStr(data, offset)
+			}
+		case rpmTagEpoch:
+			if typ == rpmTypeInt32 && int(offset)+4 <= len(data) {
+				epoch = strconv.FormatUint(uint64(binary.BigEndian.Uint32(data[offset:offset+4])), 10)
+			}
+		}
+	}
+	if name == "" || version == "" {
+		return "", "", "", false
+	}
+	evr = version
+	if release != "" {
+		evr = version + "-" + release
+	}
+	if epoch != "" && epoch != "0" {
+		evr = epoch + ":" + evr
+	}
+	return name, evr, arch, true
+}
+
+// rpmCStr reads the NUL-terminated string at data[off:], bounds-checked.
+func rpmCStr(data []byte, off uint32) string {
+	if int(off) >= len(data) {
+		return ""
+	}
+	s := data[off:]
+	if i := bytes.IndexByte(s, 0); i >= 0 {
+		return string(s[:i])
+	}
+	return string(s) // no terminator: bounded by the data store length
+}
+
+// rpmSqliteBlobs opens rpmdb.sqlite read-only + immutable (an untrusted, static file) and returns the header
+// blob of each Packages row, bounded. A missing/irregular path or any driver/query/scan error yields nil
+// (best-effort — the generator still catalogs rpm from the layout).
+func rpmSqliteBlobs(path string) [][]byte {
+	fi, err := os.Lstat(path) // regular-file guard: never follow a symlinked DB out of the rootfs
+	if err != nil || !fi.Mode().IsRegular() {
+		return nil
+	}
+	// immutable=1: the rootfs is static, so skip locking; mode=ro: never write. The path is a fixed suffix of
+	// the workspace dir (no attacker-controlled '?'), so the DSN query cannot be overridden.
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro&immutable=1")
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = db.Close() }()
+	rows, err := db.Query("SELECT blob FROM Packages") // fixed query (no concatenation); row count bounded below
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+	var out [][]byte
+	for rows.Next() {
+		if len(out) >= maxPackages { // bound the number of packages read (in Go, not via a SQL LIMIT)
+			break
+		}
+		var b []byte
+		if err := rows.Scan(&b); err != nil {
+			return out
+		}
+		if len(b) > 0 && len(b) <= maxDBBytes {
+			out = append(out, b)
+		}
+	}
+	return out // rows.Err() ignored: a partial best-effort read still contributes what it parsed
+}

--- a/internal/infrastructure/tools/ospkg/rpm_test.go
+++ b/internal/infrastructure/tools/ospkg/rpm_test.go
@@ -1,0 +1,141 @@
+package ospkg
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// rpmTagEntry is one header tag for the test builder.
+type rpmTagEntry struct {
+	tag, typ uint32
+	str      string
+	i32      uint32
+}
+
+// buildRPMHeader encodes tags into an RPM header blob in the exact on-disk layout parseRPMHeader reads:
+// optional [magic(4)+reserved(4)], nindex(u32), hsize(u32), nindex×16-byte index entries, then the data store.
+func buildRPMHeader(t *testing.T, withMagic bool, tags []rpmTagEntry) []byte {
+	t.Helper()
+	var data, index []byte
+	for _, e := range tags {
+		off := uint32(len(data))
+		ent := make([]byte, 16)
+		binary.BigEndian.PutUint32(ent[0:], e.tag)
+		binary.BigEndian.PutUint32(ent[4:], e.typ)
+		binary.BigEndian.PutUint32(ent[8:], off)
+		binary.BigEndian.PutUint32(ent[12:], 1) // count
+		index = append(index, ent...)
+		if e.typ == rpmTypeInt32 {
+			b := make([]byte, 4)
+			binary.BigEndian.PutUint32(b, e.i32)
+			data = append(data, b...)
+		} else {
+			data = append(data, []byte(e.str)...)
+			data = append(data, 0) // NUL terminator
+		}
+	}
+	var buf []byte
+	if withMagic {
+		buf = append(buf, rpmHeaderMagic...)
+		buf = append(buf, 0, 0, 0, 0)
+	}
+	intro := make([]byte, 8)
+	binary.BigEndian.PutUint32(intro[0:], uint32(len(tags)))
+	binary.BigEndian.PutUint32(intro[4:], uint32(len(data)))
+	buf = append(buf, intro...)
+	buf = append(buf, index...)
+	buf = append(buf, data...)
+	return buf
+}
+
+func bashHeader(t *testing.T, epoch uint32) []byte {
+	tags := []rpmTagEntry{
+		{tag: rpmTagName, typ: rpmTypeString, str: "bash"},
+		{tag: rpmTagVersion, typ: rpmTypeString, str: "5.1.8"},
+		{tag: rpmTagRelease, typ: rpmTypeString, str: "9.el9"},
+		{tag: rpmTagEpoch, typ: rpmTypeInt32, i32: epoch},
+		{tag: rpmTagArch, typ: rpmTypeString, str: "x86_64"},
+	}
+	return buildRPMHeader(t, true, tags)
+}
+
+func TestParseRPMHeader(t *testing.T) {
+	name, evr, arch, ok := parseRPMHeader(bashHeader(t, 0))
+	if !ok || name != "bash" || evr != "5.1.8-9.el9" || arch != "x86_64" {
+		t.Errorf("epoch 0: got %q/%q/%q ok=%v; want bash/5.1.8-9.el9/x86_64", name, evr, arch, ok)
+	}
+	// A non-zero epoch prefixes the EVR (matching the rpm comparator's expected "[epoch:]version-release").
+	if _, evr, _, ok := parseRPMHeader(bashHeader(t, 2)); !ok || evr != "2:5.1.8-9.el9" {
+		t.Errorf("epoch 2: evr = %q ok=%v; want 2:5.1.8-9.el9", evr, ok)
+	}
+	// The blob also parses without the 8-byte magic lead (some stores omit it).
+	if name, _, _, ok := parseRPMHeader(buildRPMHeader(t, false, []rpmTagEntry{{tag: rpmTagName, typ: rpmTypeString, str: "zlib"}, {tag: rpmTagVersion, typ: rpmTypeString, str: "1.2"}})); !ok || name != "zlib" {
+		t.Errorf("no-magic header: name = %q ok=%v; want zlib", name, ok)
+	}
+}
+
+func TestParseRPMHeaderRejectsMalformed(t *testing.T) {
+	cases := map[string][]byte{
+		"too short":        {0x8e, 0xad, 0xe8, 0x01},
+		"huge nindex":      append(append([]byte{}, rpmHeaderMagic...), 0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0), // nindex 4B
+		"data beyond blob": append(append([]byte{}, rpmHeaderMagic...), 0, 0, 0, 0, 0, 0, 0, 1, 0x7f, 0xff, 0xff, 0xff), // hsize huge
+		"empty":            {},
+	}
+	for name, blob := range cases {
+		if _, _, _, ok := safeParseRPMHeader(blob); ok {
+			t.Errorf("%s: must be rejected (no panic, ok=false)", name)
+		}
+	}
+	// An in-range index whose string offset is out of the data store yields no name → rejected, never an OOB read.
+	oob := buildRPMHeader(t, true, []rpmTagEntry{{tag: rpmTagName, typ: rpmTypeString, str: "x"}})
+	// corrupt the name entry's offset (bytes at index 16 [after magic+intro=16] +8..+12) to a huge value
+	binary.BigEndian.PutUint32(oob[16+8:16+12], 0xffffff)
+	if _, _, _, ok := safeParseRPMHeader(oob); ok {
+		t.Error("an out-of-range string offset must be rejected, not read OOB")
+	}
+}
+
+func TestCatalogRPMSqlite(t *testing.T) {
+	rootfs := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootfs, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "etc/os-release"), []byte("ID=rocky\nVERSION_ID=\"9.3\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Build a real rpmdb.sqlite (Packages table, one header blob) with the same driver the cataloger uses.
+	dbPath := filepath.Join(rootfs, "var/lib/rpm/rpmdb.sqlite")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("CREATE TABLE Packages (hnum INTEGER PRIMARY KEY, blob BLOB)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("INSERT INTO Packages(blob) VALUES(?)", bashHeader(t, 0)); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+
+	res, err := New().Catalog(context.Background(), rootfs)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	if len(res.Components) != 1 {
+		t.Fatalf("want 1 rpm component, got %d: %+v", len(res.Components), res.Components)
+	}
+	c := res.Components[0]
+	if c.Name != "bash" || c.Version != "5.1.8-9.el9" || c.PURL != "pkg:rpm/rocky/bash@5.1.8-9.el9?arch=x86_64&distro=rocky-9.3" {
+		t.Errorf("rpm component = %+v; want bash / 5.1.8-9.el9 / rocky rpm PURL", c)
+	}
+	if !res.DistroResolved { // rocky is a matchable rpm distro
+		t.Error("a Rocky Linux rpm DB must resolve its distro")
+	}
+}

--- a/internal/infrastructure/tools/ospkg/rpm_test.go
+++ b/internal/infrastructure/tools/ospkg/rpm_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // rpmTagEntry is one header tag for the test builder.
@@ -168,6 +169,49 @@ func TestCatalogHonorsCancellation(t *testing.T) {
 	cancel()
 	if _, err := New().Catalog(ctx, t.TempDir()); err == nil {
 		t.Error("a cancelled context must abort Catalog with an error")
+	}
+}
+
+// TestCatalogRPMHostileViewTerminates guards the property behind the ctx watchdog: a crafted Packages VIEW —
+// here a valid seed row followed by an unbounded recursive CTE of oversized rows the server-side LENGTH filter
+// rejects — must never hang the scan. This modernc version happens to terminate the view on its own (it does
+// not spin inside a single step), so the watchdog is a driver-independent backstop rather than load-bearing
+// here; the test still locks "a hostile Packages view returns within its deadline, never an unbounded hang"
+// (with a 2s ctx: if a future driver spins, the DB-close watchdog aborts it well under the outer guard). The
+// outer guard makes a true hang fail the test instead of stalling the suite; either an error or a best-effort
+// success is acceptable, only a hang is not.
+func TestCatalogRPMHostileViewTerminates(t *testing.T) {
+	rootfs := t.TempDir()
+	dbPath := filepath.Join(rootfs, "var/lib/rpm/rpmdb.sqlite")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("CREATE TABLE seed(blob BLOB)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("INSERT INTO seed(blob) VALUES(?)", bashHeader(t, 0)); err != nil {
+		t.Fatal(err)
+	}
+	// zeroblob keeps LENGTH O(1) with no materialization, so a skip is a pure CPU spin (no OOM even on a
+	// regression); 13MB > rpmMaxBlobLen (12MB) so every CTE row fails the filter.
+	if _, err := db.Exec(`CREATE VIEW Packages AS SELECT blob FROM seed UNION ALL ` +
+		`SELECT zeroblob(13000000) AS blob FROM (WITH RECURSIVE r(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM r) SELECT x FROM r)`); err != nil {
+		t.Fatal(err)
+	}
+	_ = db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resCh := make(chan error, 1)
+	go func() { _, e := New().Catalog(ctx, rootfs); resCh <- e }()
+	select {
+	case <-resCh: // returned (error or best-effort success) — the scan was not hung
+	case <-time.After(30 * time.Second):
+		t.Fatal("Catalog hung on a hostile Packages view: the ctx deadline did not bound the sqlite read")
 	}
 }
 

--- a/internal/infrastructure/tools/ospkg/rpm_test.go
+++ b/internal/infrastructure/tools/ospkg/rpm_test.go
@@ -40,7 +40,7 @@ func buildRPMHeader(t *testing.T, withMagic bool, tags []rpmTagEntry) []byte {
 	}
 	var buf []byte
 	if withMagic {
-		buf = append(buf, rpmHeaderMagic...)
+		buf = append(buf, rpmHeaderMagic[:]...)
 		buf = append(buf, 0, 0, 0, 0)
 	}
 	intro := make([]byte, 8)
@@ -81,8 +81,8 @@ func TestParseRPMHeader(t *testing.T) {
 func TestParseRPMHeaderRejectsMalformed(t *testing.T) {
 	cases := map[string][]byte{
 		"too short":        {0x8e, 0xad, 0xe8, 0x01},
-		"huge nindex":      append(append([]byte{}, rpmHeaderMagic...), 0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0), // nindex 4B
-		"data beyond blob": append(append([]byte{}, rpmHeaderMagic...), 0, 0, 0, 0, 0, 0, 0, 1, 0x7f, 0xff, 0xff, 0xff), // hsize huge
+		"huge nindex":      append(append([]byte{}, rpmHeaderMagic[:]...), 0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0), // nindex 4B
+		"data beyond blob": append(append([]byte{}, rpmHeaderMagic[:]...), 0, 0, 0, 0, 0, 0, 0, 1, 0x7f, 0xff, 0xff, 0xff), // hsize huge
 		"empty":            {},
 	}
 	for name, blob := range cases {
@@ -99,15 +99,17 @@ func TestParseRPMHeaderRejectsMalformed(t *testing.T) {
 	}
 }
 
-func TestCatalogRPMSqlite(t *testing.T) {
+// writeRPMRootfs builds a temp rootfs with the given os-release contents and a rpmdb.sqlite holding one bash
+// header, written with the same driver the cataloger reads with.
+func writeRPMRootfs(t *testing.T, osRelease string) string {
+	t.Helper()
 	rootfs := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(rootfs, "etc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(rootfs, "etc/os-release"), []byte("ID=rocky\nVERSION_ID=\"9.3\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(rootfs, "etc/os-release"), []byte(osRelease), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Build a real rpmdb.sqlite (Packages table, one header blob) with the same driver the cataloger uses.
 	dbPath := filepath.Join(rootfs, "var/lib/rpm/rpmdb.sqlite")
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
 		t.Fatal(err)
@@ -123,7 +125,11 @@ func TestCatalogRPMSqlite(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = db.Close()
+	return rootfs
+}
 
+func TestCatalogRPMSqlite(t *testing.T) {
+	rootfs := writeRPMRootfs(t, "ID=rocky\nVERSION_ID=\"9.3\"\n")
 	res, err := New().Catalog(context.Background(), rootfs)
 	if err != nil {
 		t.Fatalf("catalog: %v", err)
@@ -137,5 +143,47 @@ func TestCatalogRPMSqlite(t *testing.T) {
 	}
 	if !res.DistroResolved { // rocky is a matchable rpm distro
 		t.Error("a Rocky Linux rpm DB must resolve its distro")
+	}
+}
+
+// TestParseRPMHeaderReadsEachTagOnce locks the read-once guard that neutralizes the work-amplification vector:
+// a crafted header can repeat an identity tag many times over a NUL-free data store, but each identity tag is
+// read at most once (first wins), so rpmCStr runs a bounded number of times regardless of nindex.
+func TestParseRPMHeaderReadsEachTagOnce(t *testing.T) {
+	// Two NAME tags: read-once keeps the FIRST ("bash"); a regression to last-wins / re-scan picks "evil".
+	tags := []rpmTagEntry{
+		{tag: rpmTagName, typ: rpmTypeString, str: "bash"},
+		{tag: rpmTagVersion, typ: rpmTypeString, str: "5.1.8"},
+		{tag: rpmTagName, typ: rpmTypeString, str: "evil"},
+	}
+	name, _, _, ok := parseRPMHeader(buildRPMHeader(t, true, tags))
+	if !ok || name != "bash" {
+		t.Errorf("read-once: name = %q ok=%v; want the first NAME (bash), not a later duplicate", name, ok)
+	}
+}
+
+// TestCatalogHonorsCancellation: a cancelled context aborts the catalog rather than reading the rootfs.
+func TestCatalogHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := New().Catalog(ctx, t.TempDir()); err == nil {
+		t.Error("a cancelled context must abort Catalog with an error")
+	}
+}
+
+// TestCatalogRPMUnresolvedMajor: a clean-but-major-less VERSION_ID (".3") still emits the rpm components (for
+// inventory) but flags DistroResolved=false, so the cataloger never claims resolved while osDistroEcosystem
+// would map that release to nothing (the silent-zero-match guard the resolved flag exists to prevent).
+func TestCatalogRPMUnresolvedMajor(t *testing.T) {
+	rootfs := writeRPMRootfs(t, "ID=rocky\nVERSION_ID=\".3\"\n")
+	res, err := New().Catalog(context.Background(), rootfs)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	if len(res.Components) != 1 {
+		t.Fatalf("want the rpm component still emitted for inventory, got %d", len(res.Components))
+	}
+	if res.DistroResolved {
+		t.Error("a VERSION_ID with an empty major must NOT be flagged resolved (osDistroEcosystem maps it to nothing)")
 	}
 }

--- a/internal/infrastructure/tools/ownadvisory/source.go
+++ b/internal/infrastructure/tools/ownadvisory/source.go
@@ -188,6 +188,25 @@ func osDistroEcosystem(purl string) string {
 				return "Alpine:v" + parts[0] + "." + parts[1]
 			}
 		}
+	case "rpm":
+		// The rpm distros OSV keys by "<Name>:<major>". RHEL/CentOS/Fedora use module-qualified or uncertain
+		// keys (e.g. "Red Hat:enterprise_linux:9::baseos"), so they are intentionally NOT mapped here — the
+		// cataloger flags them DistroResolved=false so an unmatched OS-package set is surfaced, never silent.
+		major := ver
+		if i := strings.IndexByte(ver, '.'); i >= 0 {
+			major = ver[:i]
+		}
+		if major == "" {
+			return ""
+		}
+		switch id {
+		case "rocky":
+			return "Rocky Linux:" + major
+		case "almalinux", "alma":
+			return "AlmaLinux:" + major
+		case "ol", "oracle":
+			return "Oracle Linux:" + major
+		}
 	}
 	return ""
 }

--- a/internal/infrastructure/tools/ownadvisory/source_test.go
+++ b/internal/infrastructure/tools/ownadvisory/source_test.go
@@ -106,7 +106,11 @@ func TestOsDistroEcosystem(t *testing.T) {
 		"pkg:apk/alpine/musl@1.2.2-r0?distro=alpine-3.18.12":     "Alpine:v3.18",
 		"pkg:deb/ubuntu/bash@5?distro=ubuntu-22.04":              "Ubuntu:22.04", // mapped: owned OVAL feed keys "Ubuntu:<version>"
 		"pkg:deb/ubuntu/openssl@3?distro=ubuntu-20.04":           "Ubuntu:20.04",
-		"pkg:rpm/redhat/bash@4.4?distro=rhel-9":                  "", // RPM distros deferred
+		"pkg:rpm/rocky/bash@4.4-1?distro=rocky-9.3":              "Rocky Linux:9", // mapped: OSV keys "<Name>:<major>"
+		"pkg:rpm/almalinux/openssl@3?distro=almalinux-8.9":       "AlmaLinux:8",
+		"pkg:rpm/ol/glibc@2?distro=ol-9":                         "Oracle Linux:9",
+		"pkg:rpm/redhat/bash@4.4?distro=rhel-9":                  "", // rhel/centos/fedora: module-qualified/uncertain OSV keys → unmapped (flagged, not silent)
+		"pkg:rpm/fedora/bash@5?distro=fedora-39":                 "",
 		"pkg:deb/debian/openssl@1.1":                             "", // no distro qualifier
 		"pkg:npm/lodash@4.0.0":                                   "", // not an OS package
 	}


### PR DESCRIPTION
## What

Extends the owned OS-package cataloger (dpkg/apk, #42) with **rpm**, completing the OS-package trio. Modern distros (RHEL 9+/Fedora/AL2023/UBI9) store the package DB as **sqlite** at `/var/lib/rpm/rpmdb.sqlite`, whose `Packages` table holds one binary **RPM header** blob per package. `ospkg/rpm.go` parses each header (name / version / release / epoch / arch → the `[epoch:]version-release` EVR the rpm comparator expects) and emits `pkg:rpm` components with a Syft-style distro qualifier.

## Advisory matching

Extends `osDistroEcosystem` to key the rpm distros OSV names as `<Name>:<major>` — **Rocky Linux, AlmaLinux, Oracle Linux**. RHEL/CentOS/Fedora use module-qualified or uncertain OSV keys, so they are cataloged for inventory but flagged `DistroResolved=false`, which surfaces a "distro could not be resolved" SourceWarning rather than a silent zero-match.

Note: rpm vuln **detection already works** on the default path (the generator catalogs rpm from the layout + Grype matches it). This PR adds detection **independence** + owned SBOM inventory for rpm.

## Untrusted-input hardening

The header blob is attacker-controlled, so `parseRPMHeader` is fully **bounds-checked** (nindex/hsize caps; every string/int offset validated against the data store) **and recover-wrapped** (`safeParseRPMHeader`) — a crafted header contributes nothing rather than panicking the scan (the exact class the #43 review flagged for `buildinfo`). The `rpmdb.sqlite` is opened **read-only + immutable** with a bounded row read + a regular-file guard.

## Deferred (noted)

- **Berkeley-DB** (`/var/lib/rpm/Packages`, RHEL≤8/CentOS/AL2) and **ndb** (openSUSE) backends — their binary page formats are a larger, riskier parse and the generator covers them from the layout. The header parser here is the shared core a future BDB/ndb reader reuses.
- **Owned rpm advisory ingestion** — the store's `--remote-distros` is Debian/Alpine today; until it gains Red Hat/Rocky/Alma feeds, rpm matching runs via the default generator+Grype path.

## Verify

`go build ./...`, `go vet`, full `go test ./...` green. Tests: header parse (spec-accurate synthetic blob, epoch prefixing, no-magic variant), malformed-input rejection (huge nindex / OOB offset / truncated → no panic/OOB via the recover), an in-test real `rpmdb.sqlite` → `pkg:rpm/rocky/bash@5.1.8-9.el9`, and the `osDistroEcosystem` rpm mapping (rocky/alma/oracle mapped; rhel/fedora unmapped).
