### PR TITLE
feat(sca): close the license + IaC-misconfig gaps vs Trivy

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -563,8 +563,17 @@ func main() {
 		log.Info("image-rootfs cataloging ENABLED (dpkg + apk OS packages; Go binaries + Python dist-info)")
 	}
 	if cfg.MisconfigEnabled {
-		scaService.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan in the scan pipeline
-		log.Info("misconfig scanning ENABLED (Dockerfile + Kubernetes manifests)")
+		// Helm chart rendering shells out `helm template` over an UNTRUSTED chart; like the maven/gradle
+		// resolvers it must be sandbox-confined on the API host (a crafted chart's Sprig getHostByName is an
+		// SSRF vector). Wire it through the SCA sandbox when present; otherwise leave Helm rendering OFF.
+		mc := misconfig.New()
+		helmMode := "Helm rendering OFF (no SCA sandbox; a chart runs untrusted templates on the host)"
+		if scaSandbox != nil {
+			mc = mc.WithHelmRunner(scaSandbox)
+			helmMode = "Helm charts rendered sandboxed (egress-denied)"
+		}
+		scaService.SetMisconfigScanner(mc) // deterministic IaC/config misconfig scan in the scan pipeline
+		log.Info("misconfig scanning ENABLED (Dockerfile + Kubernetes + Terraform); " + helmMode)
 	}
 	if cfg.SuppressionEnabled {
 		scaService.SetSuppressionLoader(ignorefile.New()) // repo-committed .synapseignore accepted-risk policy

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -470,7 +470,7 @@ func main() {
 	scaService := scauc.NewService(repo, findingRepo, scanRepo, scanResultStore, scanJobStore, scanRunStore, evidenceService, ids, prov, clock, auditLog, shared.Severity(cfg.FindingMinSeverity), cfg.ScanTimeout, acquirer,
 		enry.New(), sbomGen,
 		detectionSources,
-		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil)))
+		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil), licensemeta.NewPyPI("", nil)))
 	scaService.SetImportedSBOMStore(importedSBOMStore)
 	scaService.SetSBOMEnricher(manifest.New())
 	scaService.SetMavenCoordResolver(mavencoord.New())   // recover real Maven coords from JAR pom.properties (offline) before license lookup

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -255,7 +255,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		shared.Severity(cfg.FindingMinSeverity), cfg.ScanTimeout, acquire.New().WithMaxWorkspaceBytes(cfg.MaxWorkspaceBytes).WithImageRootFS(cfg.ImageRootFSEnabled),
 		enry.New(), syft.New(cfg.SyftBin),
 		detectionSources,
-		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil)),
+		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil), licensemeta.NewPyPI("", nil)),
 	)
 	sca.SetSBOMEnricher(manifest.New())
 	sca.SetMavenCoordResolver(mavencoord.New())   // recover real Maven coords from JAR pom.properties (offline) before license lookup

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -321,7 +321,9 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		sca.SetSecretScanner(secretscan.New()) // deterministic, redacted secret scan (CI-friendly)
 	}
 	if cfg.MisconfigEnabled {
-		sca.SetMisconfigScanner(misconfig.New()) // deterministic IaC/config misconfig scan (CI-friendly)
+		// Trusted-local model (like the CLI's maven/gradle resolvers): render Helm charts via a direct
+		// `helm template` exec. It runs the chart's templates on the host, so use it only on a project you trust.
+		sca.SetMisconfigScanner(misconfig.New().WithHelmDirect()) // deterministic IaC/config misconfig scan (CI-friendly)
 	}
 	if cfg.ImageRootFSEnabled {
 		sca.SetOSPackageCataloger(ospkg.New())         // owned dpkg/apk cataloging from the materialized image rootfs

--- a/internal/infrastructure/tools/licensemeta/pypi.go
+++ b/internal/infrastructure/tools/licensemeta/pypi.go
@@ -1,0 +1,237 @@
+package licensemeta
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// PyPI resolves a PyPI component's license from the PyPI registry (pypi.org JSON API). It exists
+// because deps.dev classifies a large share of PyPI packages as "non-standard" — their license lives
+// in the trove classifiers or the free-text info.license, not deps.dev's normalized field — so the
+// deps.dev enricher leaves them unresolved. PyPI's own metadata carries the authoritative license:
+// PEP 639 license_expression (SPDX), the trove "License :: ..." classifiers, or free-text info.license.
+// Placed AFTER the deps.dev enricher in the chain, so it only fills what deps.dev could not.
+type PyPI struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewPyPI returns a PyPI-registry license enricher. baseURL defaults to https://pypi.org (override for
+// tests/mirrors); client defaults to a 15s timeout.
+func NewPyPI(baseURL string, client *http.Client) *PyPI {
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = "https://pypi.org"
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &PyPI{baseURL: baseURL, client: client}
+}
+
+var _ ports.LicenseEnricher = (*PyPI)(nil)
+
+// Enrich fills the license of PyPI components that are still unresolved, concurrency-bounded + cached.
+// Best-effort: a network/parse failure leaves the component unchanged (still unknown), never errors.
+func (p *PyPI) Enrich(ctx context.Context, comps []sbom.Component) []sbom.Component {
+	cache := map[string][]sbom.License{}
+	var mu sync.Mutex
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+
+	for i := range comps {
+		c := &comps[i]
+		if len(c.Licenses) > 0 && !onlyUnresolvedLicenseEvidence(c.Licenses) {
+			continue // already resolved (declared or by an earlier chain enricher)
+		}
+		if !strings.HasPrefix(c.PURL, "pkg:pypi/") || !sbom.IsResolvedVersion(c.Version) {
+			continue
+		}
+		sys, name, ver, ok := parsePURL(c.PURL)
+		if !ok || sys != "pypi" {
+			continue
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(c *sbom.Component, name, ver string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			key := name + "@" + ver
+			mu.Lock()
+			lics, hit := cache[key]
+			mu.Unlock()
+			if !hit {
+				lics = p.lookup(ctx, name, ver)
+				mu.Lock()
+				cache[key] = lics
+				mu.Unlock()
+			}
+			if len(lics) > 0 {
+				c.Licenses = lics
+				c.LicenseSource = sbom.LicenseSourceRegistry
+				c.LicenseConfidence = "registry"
+				c.UnknownReason = ""
+			}
+		}(c, name, ver)
+	}
+	wg.Wait()
+	return comps
+}
+
+// lookup queries the PyPI JSON API for one package version and derives its SPDX license from, in order
+// of authority: PEP 639 license_expression, the trove classifiers, then the free-text info.license.
+func (p *PyPI) lookup(ctx context.Context, name, ver string) []sbom.License {
+	if lics := p.fetch(ctx, fmt.Sprintf("%s/pypi/%s/%s/json", p.baseURL, url.PathEscape(name), url.PathEscape(ver))); lics != nil {
+		return lics
+	}
+	// Some versions lack a per-version document; fall back to the package's latest metadata.
+	return p.fetch(ctx, fmt.Sprintf("%s/pypi/%s/json", p.baseURL, url.PathEscape(name)))
+}
+
+func (p *PyPI) fetch(ctx context.Context, u string) []sbom.License {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	var body struct {
+		Info struct {
+			License           string   `json:"license"`
+			LicenseExpression string   `json:"license_expression"`
+			Classifiers       []string `json:"classifiers"`
+		} `json:"info"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&body); err != nil {
+		return nil
+	}
+	// 1. PEP 639 license_expression is already an SPDX expression — the most authoritative.
+	if e := strings.TrimSpace(body.Info.LicenseExpression); e != "" {
+		return []sbom.License{{SPDXID: e, Name: e}}
+	}
+	// 2. Trove classifiers ("License :: ...") map deterministically to SPDX.
+	var out []sbom.License
+	seen := map[string]bool{}
+	for _, cl := range body.Info.Classifiers {
+		if !strings.HasPrefix(cl, "License ::") {
+			continue
+		}
+		if id := troveSPDX[strings.TrimSpace(cl)]; id != "" && !seen[id] {
+			seen[id] = true
+			out = append(out, sbom.License{SPDXID: id, Name: id})
+		}
+	}
+	if len(out) > 0 {
+		return out
+	}
+	// 3. Free-text info.license as a last resort (best-effort normalization).
+	if id := normalizePyLicenseText(body.Info.License); id != "" {
+		return []sbom.License{{SPDXID: id, Name: id}}
+	}
+	return nil
+}
+
+// troveSPDX maps PyPI trove license classifiers to SPDX ids. Covers the classifiers that account for
+// the overwhelming majority of PyPI packages; an unmapped classifier falls through to the free-text path.
+var troveSPDX = map[string]string{
+	"License :: OSI Approved :: MIT License":                                             "MIT",
+	"License :: OSI Approved :: MIT No Attribution License (MIT-0)":                      "MIT-0",
+	"License :: OSI Approved :: BSD License":                                             "BSD-3-Clause",
+	"License :: OSI Approved :: Apache Software License":                                 "Apache-2.0",
+	"License :: OSI Approved :: ISC License (ISCL)":                                      "ISC",
+	"License :: OSI Approved :: Python Software Foundation License":                      "PSF-2.0",
+	"License :: OSI Approved :: Mozilla Public License 1.1 (MPL 1.1)":                    "MPL-1.1",
+	"License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)":                    "MPL-2.0",
+	"License :: OSI Approved :: The Unlicense (Unlicense)":                               "Unlicense",
+	"License :: OSI Approved :: Boost Software License 1.0 (BSL-1.0)":                    "BSL-1.0",
+	"License :: OSI Approved :: Zope Public License":                                     "ZPL-2.1",
+	"License :: OSI Approved :: Universal Permissive License (UPL)":                      "UPL-1.0",
+	"License :: OSI Approved :: Academic Free License (AFL)":                             "AFL-3.0",
+	"License :: OSI Approved :: Artistic License":                                        "Artistic-2.0",
+	"License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)":                    "EPL-1.0",
+	"License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)":                    "EPL-2.0",
+	"License :: OSI Approved :: GNU General Public License v2 (GPLv2)":                   "GPL-2.0-only",
+	"License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)":         "GPL-2.0-or-later",
+	"License :: OSI Approved :: GNU General Public License v3 (GPLv3)":                   "GPL-3.0-only",
+	"License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)":         "GPL-3.0-or-later",
+	"License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)":           "LGPL-2.0-only",
+	"License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)": "LGPL-2.0-or-later",
+	"License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)":           "LGPL-3.0-only",
+	"License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)": "LGPL-3.0-or-later",
+	"License :: OSI Approved :: GNU Affero General Public License v3":                    "AGPL-3.0-only",
+	"License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)": "AGPL-3.0-or-later",
+	"License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)":     "LGPL-2.1-or-later",
+	"License :: Public Domain":                                                           "CC0-1.0",
+	"License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication":                    "CC0-1.0",
+}
+
+// normalizePyLicenseText maps a short free-text info.license value to an SPDX id. It is deliberately
+// conservative: it only accepts values that unambiguously name a known license, so a long license
+// BODY or an ambiguous string stays unknown rather than mislabeled.
+func normalizePyLicenseText(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || len(s) > 40 { // a long value is usually the full license text, not an id
+		return ""
+	}
+	switch strings.ToLower(strings.TrimRight(s, ".")) {
+	case "mit", "mit license":
+		return "MIT"
+	case "bsd", "bsd license", "bsd-3-clause", "bsd 3-clause", "new bsd", "new bsd license":
+		return "BSD-3-Clause"
+	case "bsd-2-clause", "bsd 2-clause", "simplified bsd":
+		return "BSD-2-Clause"
+	case "apache", "apache 2", "apache 2.0", "apache-2.0", "apache license 2.0", "apache software license":
+		return "Apache-2.0"
+	case "isc", "isc license":
+		return "ISC"
+	case "mpl-2.0", "mpl 2.0", "mozilla public license 2.0":
+		return "MPL-2.0"
+	case "lgpl", "lgplv3", "lgpl-3.0":
+		return "LGPL-3.0-or-later"
+	case "gpl", "gplv3", "gpl-3.0", "gplv3+":
+		return "GPL-3.0-or-later"
+	case "gplv2", "gpl-2.0":
+		return "GPL-2.0-only"
+	case "psf", "psf-2.0", "python software foundation license":
+		return "PSF-2.0"
+	case "unlicense", "the unlicense":
+		return "Unlicense"
+	case "wtfpl":
+		return "WTFPL"
+	case "zlib":
+		return "Zlib"
+	}
+	// If the value already looks like a bare SPDX id (single token, alnum + . - +), accept it as-is.
+	if isBareSPDXID(s) {
+		return s
+	}
+	return ""
+}
+
+func isBareSPDXID(s string) bool {
+	if s == "" || strings.ContainsAny(s, " \t\n") {
+		return false
+	}
+	for _, r := range s {
+		if !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '.' || r == '-' || r == '+') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/infrastructure/tools/licensemeta/pypi_test.go
+++ b/internal/infrastructure/tools/licensemeta/pypi_test.go
@@ -1,0 +1,92 @@
+package licensemeta
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// fakePyPI serves version-specific PyPI JSON for a fixed set of packages, exercising each license
+// source (license_expression, trove classifiers, free-text) + the not-found fall-through.
+func fakePyPI(t *testing.T) *httptest.Server {
+	t.Helper()
+	bodies := map[string]string{
+		// classifier path (the deps.dev "non-standard" case this resolver exists for)
+		"/pypi/amqp/5.3.1/json": `{"info":{"license":"BSD","classifiers":["License :: OSI Approved :: BSD License","Programming Language :: Python"]}}`,
+		// PEP 639 license_expression path (most authoritative)
+		"/pypi/rich/13.0.0/json": `{"info":{"license":"","license_expression":"MIT","classifiers":[]}}`,
+		// free-text info.license path
+		"/pypi/reqs/2.0.0/json": `{"info":{"license":"Apache 2.0","classifiers":[]}}`,
+		// no usable license anywhere → stays unknown
+		"/pypi/mystery/1.0.0/json": `{"info":{"license":"","classifiers":["Programming Language :: Python"]}}`,
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if b, ok := bodies[r.URL.Path]; ok {
+			_, _ = w.Write([]byte(b))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func TestPyPIEnrichResolvesLicenses(t *testing.T) {
+	srv := fakePyPI(t)
+	defer srv.Close()
+	e := NewPyPI(srv.URL, srv.Client())
+
+	comps := []sbom.Component{
+		{Name: "amqp", Version: "5.3.1", PURL: "pkg:pypi/amqp@5.3.1"},       // classifier → BSD-3-Clause
+		{Name: "rich", Version: "13.0.0", PURL: "pkg:pypi/rich@13.0.0"},     // expression → MIT
+		{Name: "reqs", Version: "2.0.0", PURL: "pkg:pypi/reqs@2.0.0"},       // free-text → Apache-2.0
+		{Name: "mystery", Version: "1.0.0", PURL: "pkg:pypi/mystery@1.0.0"}, // unresolved
+		{Name: "left", Version: "1.0.0", PURL: "pkg:npm/left@1.0.0"},        // not pypi → skipped
+		{Name: "done", Version: "9", PURL: "pkg:pypi/done@9", // already licensed → untouched
+			Licenses: []sbom.License{{SPDXID: "MIT"}}, LicenseSource: "sbom"},
+	}
+	out := e.Enrich(context.Background(), comps)
+	got := map[string]string{}
+	for _, c := range out {
+		if len(c.Licenses) > 0 {
+			got[c.Name] = c.Licenses[0].SPDXID + "/" + c.LicenseSource
+		}
+	}
+	want := map[string]string{
+		"amqp": "BSD-3-Clause/registry",
+		"rich": "MIT/registry",
+		"reqs": "Apache-2.0/registry",
+		"done": "MIT/sbom", // untouched
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s = %q, want %q", k, got[k], v)
+		}
+	}
+	// mystery stays unknown; npm is not handled by the PyPI resolver.
+	for _, c := range out {
+		if c.Name == "mystery" && len(c.Licenses) > 0 {
+			t.Errorf("mystery must stay unresolved, got %v", c.Licenses)
+		}
+		if c.Name == "left" && len(c.Licenses) > 0 {
+			t.Errorf("npm component must be skipped by the PyPI resolver, got %v", c.Licenses)
+		}
+	}
+}
+
+func TestTroveAndFreeTextMapping(t *testing.T) {
+	if troveSPDX["License :: OSI Approved :: Apache Software License"] != "Apache-2.0" {
+		t.Error("Apache trove classifier must map to Apache-2.0")
+	}
+	cases := map[string]string{
+		"MIT": "MIT", "BSD": "BSD-3-Clause", "Apache 2.0": "Apache-2.0", "ISC": "ISC",
+		"BSD-3-Clause": "BSD-3-Clause", // bare SPDX id passes through
+		"":             "", "this is a very long license body that clearly is not an identifier at all": "",
+	}
+	for in, want := range cases {
+		if got := normalizePyLicenseText(in); got != want {
+			t.Errorf("normalizePyLicenseText(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/infrastructure/tools/misconfig/dockerfile.go
+++ b/internal/infrastructure/tools/misconfig/dockerfile.go
@@ -30,6 +30,7 @@ func scanDockerfile(rel string, data []byte) []ports.MisconfigRawFinding {
 	var lastUserLine, lastFromLine int
 	lastUserRoot := true // no USER yet ⇒ root
 	haveStage := false
+	haveHealthcheck := false
 
 	for _, in := range instrs {
 		switch in.cmd {
@@ -49,8 +50,18 @@ func scanDockerfile(rel string, data []byte) []ports.MisconfigRawFinding {
 		case "USER":
 			lastUserLine = in.line
 			lastUserRoot = isRootUser(in.args)
+		case "HEALTHCHECK":
+			if !strings.EqualFold(strings.TrimSpace(in.args), "NONE") {
+				haveHealthcheck = true
+			}
+		case "ENV", "ARG":
+			if r, ok := checkSecretEnv(in.cmd, in.args, rel, in.line); ok {
+				out = append(out, r)
+			}
 		case "ADD":
 			if r, ok := checkAddRemote(in.args, rel, in.line); ok {
+				out = append(out, r)
+			} else if r, ok := checkAddLocal(in.args, rel, in.line); ok {
 				out = append(out, r)
 			}
 		case "RUN":
@@ -62,6 +73,7 @@ func scanDockerfile(rel string, data []byte) []ports.MisconfigRawFinding {
 					Description: "A RUN step downloads a script and pipes it directly into a shell (e.g. curl ... | sh), executing unverified remote code at build time. Download to a file, verify a checksum or signature, then run it.",
 				})
 			}
+			out = append(out, checkRunStep(in.args, rel, in.line)...)
 		}
 	}
 
@@ -78,6 +90,16 @@ func scanDockerfile(rel string, data []byte) []ports.MisconfigRawFinding {
 			File: rel, Line: line, RuleID: "dockerfile-run-as-root",
 			Title: "Container runs as root", Severity: shared.SeverityHigh,
 			Resource: "Dockerfile USER", Description: desc,
+		})
+	}
+
+	// No HEALTHCHECK: an orchestrator can't tell whether the container is actually serving.
+	if haveStage && !haveHealthcheck {
+		out = append(out, ports.MisconfigRawFinding{
+			File: rel, Line: lastFromLine, RuleID: "dockerfile-no-healthcheck",
+			Title: "No container HEALTHCHECK", Severity: shared.SeverityLow,
+			Resource:    "Dockerfile",
+			Description: "The image declares no HEALTHCHECK instruction, so an orchestrator cannot detect an unhealthy-but-running container. Add a HEALTHCHECK that probes the application's readiness.",
 		})
 	}
 	return out
@@ -215,3 +237,153 @@ func isRootUser(args string) bool {
 }
 
 func fields(s string) []string { return strings.Fields(s) }
+
+// secretKeyRe matches an ENV/ARG key that names a credential; a literal value on such a key bakes a
+// secret into an image layer (recoverable by anyone who can pull the image).
+var secretKeyRe = regexp.MustCompile(`(?i)(password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|credential|\bauth\b)`)
+
+// checkSecretEnv flags an ENV/ARG that assigns a literal value to a secret-named key. A value that
+// references another variable ($X / ${X}) or is empty is not a baked-in secret.
+func checkSecretEnv(cmd, args, rel string, line int) (ports.MisconfigRawFinding, bool) {
+	for _, kv := range envAssignments(args) {
+		key, val := kv[0], kv[1]
+		if !secretKeyRe.MatchString(key) {
+			continue
+		}
+		v := strings.TrimSpace(val)
+		if v == "" || strings.HasPrefix(v, "$") {
+			continue // references another var or unset — not a baked literal
+		}
+		return ports.MisconfigRawFinding{
+			File: rel, Line: line, RuleID: "dockerfile-secret-in-" + strings.ToLower(cmd),
+			Title: "Secret baked into image (" + cmd + ")", Severity: shared.SeverityHigh,
+			Resource:    "Dockerfile " + cmd + " " + clip(key),
+			Description: "A secret-looking " + cmd + " key is assigned a literal value, so the credential is persisted in an image layer and recoverable by anyone who can pull the image. Inject secrets at runtime (env or secret mount) or use BuildKit --secret; never bake them in.",
+		}, true
+	}
+	return ports.MisconfigRawFinding{}, false
+}
+
+// checkAddLocal flags ADD of a plain local path (not a URL, not an archive ADD auto-extracts): COPY is
+// clearer and lacks ADD's implicit URL/extraction behavior.
+func checkAddLocal(args, rel string, line int) (ports.MisconfigRawFinding, bool) {
+	var src []string
+	for _, tok := range fields(args) {
+		if !strings.HasPrefix(tok, "--") {
+			src = append(src, tok)
+		}
+	}
+	if len(src) < 2 {
+		return ports.MisconfigRawFinding{}, false
+	}
+	for _, s := range src[:len(src)-1] { // all but the destination
+		if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+			return ports.MisconfigRawFinding{}, false // remote: handled by checkAddRemote
+		}
+		low := strings.ToLower(s)
+		for _, ext := range []string{".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tar.xz", ".gz", ".xz", ".bz2"} {
+			if strings.HasSuffix(low, ext) {
+				return ports.MisconfigRawFinding{}, false // ADD auto-extracts archives — a legitimate use
+			}
+		}
+	}
+	return ports.MisconfigRawFinding{
+		File: rel, Line: line, RuleID: "dockerfile-add-instead-of-copy",
+		Title: "ADD used for a local file (prefer COPY)", Severity: shared.SeverityLow,
+		Resource:    "Dockerfile ADD",
+		Description: "ADD copies a local file here, but ADD also fetches URLs and auto-extracts archives, which is surprising and error-prone. Use COPY for local files so the intent is explicit.",
+	}, true
+}
+
+var (
+	insecureDownloadRe = regexp.MustCompile(`(?i)(?:curl\b[^|&;]*\s(?:-k|--insecure)|wget\b[^|&;]*\s--no-check-certificate)`)
+	aptInstallRe       = regexp.MustCompile(`(?i)\bapt(?:-get)?\s+(?:-[a-z]+\s+)*install\b`)
+	aptCleanRe         = regexp.MustCompile(`(?i)rm\s+-rf?\s+[^\n]*/var/lib/apt/lists`)
+	sudoRe             = regexp.MustCompile(`(?i)(?:^|[|&;]\s*|\s)sudo\s`)
+)
+
+// checkRunStep runs the RUN-instruction checks other than pipe-to-shell: sudo use, TLS-disabling
+// downloads, and apt installs that never prune the package cache.
+func checkRunStep(args, rel string, line int) []ports.MisconfigRawFinding {
+	var out []ports.MisconfigRawFinding
+	if sudoRe.MatchString(args) {
+		out = append(out, ports.MisconfigRawFinding{
+			File: rel, Line: line, RuleID: "dockerfile-run-sudo",
+			Title: "sudo used in a RUN step", Severity: shared.SeverityMedium,
+			Resource:    "Dockerfile RUN",
+			Description: "A RUN step uses sudo. Image builds already run as root, so sudo is unnecessary and can pull in a setuid binary or mask the intended user. Run the command directly, or switch USER explicitly.",
+		})
+	}
+	if insecureDownloadRe.MatchString(args) {
+		out = append(out, ports.MisconfigRawFinding{
+			File: rel, Line: line, RuleID: "dockerfile-insecure-download",
+			Title: "TLS verification disabled in a download", Severity: shared.SeverityMedium,
+			Resource:    "Dockerfile RUN",
+			Description: "A RUN step downloads with TLS verification disabled (curl -k / --insecure or wget --no-check-certificate), so the content can be tampered with in transit. Remove the flag and trust the system CA store.",
+		})
+	}
+	if aptInstallRe.MatchString(args) && !aptCleanRe.MatchString(args) {
+		out = append(out, ports.MisconfigRawFinding{
+			File: rel, Line: line, RuleID: "dockerfile-apt-no-clean",
+			Title: "apt install without cache cleanup", Severity: shared.SeverityLow,
+			Resource:    "Dockerfile RUN",
+			Description: "An apt/apt-get install in this RUN step does not remove /var/lib/apt/lists afterward, leaving the package index in the image layer (larger image, stale metadata). Append: rm -rf /var/lib/apt/lists/*.",
+		})
+	}
+	return out
+}
+
+// envAssignments parses an ENV/ARG argument into (key, value) pairs, handling the modern "K=V K2=V2"
+// form and the legacy "ENV KEY the value" single-pair form.
+func envAssignments(args string) [][2]string {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return nil
+	}
+	var out [][2]string
+	if strings.Contains(args, "=") {
+		for _, tok := range splitEnvTokens(args) {
+			if eq := strings.IndexByte(tok, '='); eq > 0 {
+				out = append(out, [2]string{tok[:eq], strings.Trim(tok[eq+1:], `"'`)})
+			}
+		}
+		return out
+	}
+	if f := strings.Fields(args); len(f) >= 2 { // legacy: ENV KEY rest-is-value
+		out = append(out, [2]string{f[0], strings.Trim(strings.TrimSpace(args[len(f[0]):]), `"'`)})
+	} else if len(f) == 1 {
+		out = append(out, [2]string{f[0], ""})
+	}
+	return out
+}
+
+// splitEnvTokens splits `K=V K2="a b"` on spaces that are outside quotes.
+func splitEnvTokens(s string) []string {
+	var toks []string
+	var cur strings.Builder
+	inQ := byte(0)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inQ != 0:
+			if c == inQ {
+				inQ = 0
+			}
+			cur.WriteByte(c)
+		case c == '"' || c == '\'':
+			inQ = c
+			cur.WriteByte(c)
+		case c == ' ' || c == '\t':
+			if cur.Len() > 0 {
+				toks = append(toks, cur.String())
+				cur.Reset()
+			}
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	if cur.Len() > 0 {
+		toks = append(toks, cur.String())
+	}
+	return toks
+}

--- a/internal/infrastructure/tools/misconfig/helm.go
+++ b/internal/infrastructure/tools/misconfig/helm.go
@@ -39,7 +39,9 @@ func scanHelmChart(ctx context.Context, runner ports.ToolRunner, direct bool, he
 			ReadOnlyPaths:  []string{chartDir},
 			Timeout:        helmRenderTimeout,
 			MaxOutputBytes: maxRenderedBytes,
-			EgressPolicy:   &ports.EgressPolicy{}, // no AllowDomains ⇒ default-deny
+			// No EgressPolicy: `helm template` needs no network, so leave it nil for full network isolation
+			// (--unshare-all, no interface at all) rather than a filtered veth — stronger, and it does not
+			// depend on the egress applier being present. This neutralizes Helm's Sprig getHostByName.
 		})
 		if err != nil || res.ExitCode != 0 {
 			return nil

--- a/internal/infrastructure/tools/misconfig/helm.go
+++ b/internal/infrastructure/tools/misconfig/helm.go
@@ -1,0 +1,46 @@
+package misconfig
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	helmRenderTimeout = 45 * time.Second // bound a single `helm template` render
+	maxRenderedBytes  = 16 << 20         // cap the rendered manifest stream fed to the K8s rules
+)
+
+// scanHelmChart renders a Helm chart with `helm template` (argv array, never a shell string) and runs
+// the Kubernetes rules over the rendered manifests. Rendering a chart's defaults is how comprehensive
+// scanners (Trivy) evaluate Helm — the raw templates carry Go-template directives and are not valid
+// YAML. Best-effort: a missing helm binary, or a chart needing required values / unbuilt dependencies,
+// yields no findings and never fails the scan. `helm template` only renders templates locally; it runs
+// no chart hooks and executes no arbitrary code (unlike `helm install`).
+func scanHelmChart(ctx context.Context, helmBin, chartDir, relDir string) []ports.MisconfigRawFinding {
+	if helmBin == "" {
+		return nil
+	}
+	if _, err := exec.LookPath(helmBin); err != nil {
+		return nil // helm not installed: Helm charts are silently skipped, as before
+	}
+	cctx, cancel := context.WithTimeout(ctx, helmRenderTimeout)
+	defer cancel()
+	// Fixed release name (no interpolation), skip test hooks. No cluster is contacted.
+	cmd := exec.CommandContext(cctx, helmBin, "template", "synapse-scan", chartDir, "--skip-tests")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		return nil // a chart that will not render with defaults is best-effort skipped
+	}
+	rendered := stdout.Bytes()
+	if len(rendered) > maxRenderedBytes {
+		rendered = rendered[:maxRenderedBytes]
+	}
+	// scanKubernetes handles the multi-document stream `helm template` emits; attribute findings to the chart.
+	return scanKubernetes(filepath.Join(relDir, "Chart.yaml"), rendered)
+}

--- a/internal/infrastructure/tools/misconfig/helm.go
+++ b/internal/infrastructure/tools/misconfig/helm.go
@@ -3,6 +3,7 @@ package misconfig
 import (
 	"bytes"
 	"context"
+	"io"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -15,32 +16,74 @@ const (
 	maxRenderedBytes  = 16 << 20         // cap the rendered manifest stream fed to the K8s rules
 )
 
-// scanHelmChart renders a Helm chart with `helm template` (argv array, never a shell string) and runs
-// the Kubernetes rules over the rendered manifests. Rendering a chart's defaults is how comprehensive
-// scanners (Trivy) evaluate Helm — the raw templates carry Go-template directives and are not valid
-// YAML. Best-effort: a missing helm binary, or a chart needing required values / unbuilt dependencies,
-// yields no findings and never fails the scan. `helm template` only renders templates locally; it runs
-// no chart hooks and executes no arbitrary code (unlike `helm install`).
-func scanHelmChart(ctx context.Context, helmBin, chartDir, relDir string) []ports.MisconfigRawFinding {
+// scanHelmChart renders a Helm chart and runs the Kubernetes rules over the output — the raw templates
+// carry Go-template directives and are not valid YAML, so rendering is how comprehensive scanners
+// evaluate Helm. `helm template` on an UNTRUSTED chart must not run unprotected on the host: Helm's
+// Sprig engine exposes getHostByName (live DNS), an SSRF / blind-exfil vector. So this mirrors the
+// maven/gradle resolvers exactly — a caller-supplied ToolRunner confines the exec (the API path, with
+// egress denied), or an explicit trusted-local direct exec is used (the CLI). With NEITHER set, Helm
+// rendering is skipped. Always argv (never a shell), fixed release name, no chart hooks; best-effort.
+func scanHelmChart(ctx context.Context, runner ports.ToolRunner, direct bool, helmBin, chartDir, relDir string) []ports.MisconfigRawFinding {
 	if helmBin == "" {
 		return nil
 	}
-	if _, err := exec.LookPath(helmBin); err != nil {
-		return nil // helm not installed: Helm charts are silently skipped, as before
+	args := []string{"template", "synapse-scan", chartDir, "--skip-tests"}
+	var rendered []byte
+	switch {
+	case runner != nil:
+		// Sandboxed: bind the chart dir read-only, DENY all egress (rendering needs no network, so this
+		// neutralizes getHostByName), and cap output + time via the spec.
+		res, err := runner.Run(ctx, ports.ToolSpec{
+			Name:           helmBin,
+			Args:           args,
+			ReadOnlyPaths:  []string{chartDir},
+			Timeout:        helmRenderTimeout,
+			MaxOutputBytes: maxRenderedBytes,
+			EgressPolicy:   &ports.EgressPolicy{}, // no AllowDomains ⇒ default-deny
+		})
+		if err != nil || res.ExitCode != 0 {
+			return nil
+		}
+		rendered = res.Stdout
+	case direct:
+		// Trusted-local (CLI) direct exec, matching the CLI's maven/gradle posture. Output is capped
+		// DURING capture so a chart rendering gigabytes cannot OOM the process before a post-hoc cap.
+		if _, err := exec.LookPath(helmBin); err != nil {
+			return nil
+		}
+		cctx, cancel := context.WithTimeout(ctx, helmRenderTimeout)
+		defer cancel()
+		cmd := exec.CommandContext(cctx, helmBin, args...)
+		cw := &cappedBuffer{max: maxRenderedBytes}
+		cmd.Stdout, cmd.Stderr = cw, io.Discard
+		if err := cmd.Run(); err != nil {
+			return nil
+		}
+		rendered = cw.buf.Bytes()
+	default:
+		return nil // Helm rendering not enabled (no sandbox runner, not trusted-local)
 	}
-	cctx, cancel := context.WithTimeout(ctx, helmRenderTimeout)
-	defer cancel()
-	// Fixed release name (no interpolation), skip test hooks. No cluster is contacted.
-	cmd := exec.CommandContext(cctx, helmBin, "template", "synapse-scan", chartDir, "--skip-tests")
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout, cmd.Stderr = &stdout, &stderr
-	if err := cmd.Run(); err != nil {
-		return nil // a chart that will not render with defaults is best-effort skipped
-	}
-	rendered := stdout.Bytes()
 	if len(rendered) > maxRenderedBytes {
 		rendered = rendered[:maxRenderedBytes]
 	}
-	// scanKubernetes handles the multi-document stream `helm template` emits; attribute findings to the chart.
 	return scanKubernetes(filepath.Join(relDir, "Chart.yaml"), rendered)
+}
+
+// cappedBuffer accumulates at most max bytes and silently discards the rest, so a chart that renders
+// gigabytes bounds memory instead of OOMing the process. Write always reports a full write so the child
+// process is not killed by a short-write error; the timeout still bounds a runaway render.
+type cappedBuffer struct {
+	buf bytes.Buffer
+	max int
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	if room := c.max - c.buf.Len(); room > 0 {
+		if len(p) > room {
+			c.buf.Write(p[:room])
+		} else {
+			c.buf.Write(p)
+		}
+	}
+	return len(p), nil
 }

--- a/internal/infrastructure/tools/misconfig/kubernetes.go
+++ b/internal/infrastructure/tools/misconfig/kubernetes.go
@@ -39,15 +39,28 @@ type k8sDoc struct {
 }
 
 type k8sSpec struct {
-	HostNetwork    bool           `yaml:"hostNetwork"`
-	HostPID        bool           `yaml:"hostPID"`
-	HostIPC        bool           `yaml:"hostIPC"`
-	Containers     []k8sContainer `yaml:"containers"`
-	InitContainers []k8sContainer `yaml:"initContainers"`
-	Volumes        []k8sVolume    `yaml:"volumes"`
-	Template       *struct {
+	HostNetwork                  bool           `yaml:"hostNetwork"`
+	HostPID                      bool           `yaml:"hostPID"`
+	HostIPC                      bool           `yaml:"hostIPC"`
+	AutomountServiceAccountToken *bool          `yaml:"automountServiceAccountToken"`
+	Containers                   []k8sContainer `yaml:"containers"`
+	InitContainers               []k8sContainer `yaml:"initContainers"`
+	Volumes                      []k8sVolume    `yaml:"volumes"`
+	SecurityContext              *podSecCtx     `yaml:"securityContext"` // pod-level (inherited by containers)
+	Template                     *struct {
 		Spec k8sSpec `yaml:"spec"`
 	} `yaml:"template"`
+}
+
+// podSecCtx is the pod-level securityContext; runAsNonRoot / runAsUser / seccompProfile set here are
+// inherited by every container that does not override them.
+type podSecCtx struct {
+	RunAsNonRoot   *bool `yaml:"runAsNonRoot"`
+	RunAsUser      *int  `yaml:"runAsUser"`
+	RunAsGroup     *int  `yaml:"runAsGroup"`
+	SeccompProfile *struct {
+		Type string `yaml:"type"`
+	} `yaml:"seccompProfile"`
 }
 
 type k8sVolume struct {
@@ -61,16 +74,28 @@ type k8sContainer struct {
 	Name            string     `yaml:"name"`
 	Image           string     `yaml:"image"`
 	SecurityContext *ctnSecCtx `yaml:"securityContext"`
+	Resources       *struct {
+		Limits map[string]any `yaml:"limits"`
+	} `yaml:"resources"`
+	Ports []struct {
+		HostPort int `yaml:"hostPort"`
+	} `yaml:"ports"`
 }
 
 type ctnSecCtx struct {
 	Privileged               *bool `yaml:"privileged"`
 	RunAsNonRoot             *bool `yaml:"runAsNonRoot"`
 	RunAsUser                *int  `yaml:"runAsUser"`
+	RunAsGroup               *int  `yaml:"runAsGroup"`
 	AllowPrivilegeEscalation *bool `yaml:"allowPrivilegeEscalation"`
+	ReadOnlyRootFilesystem   *bool `yaml:"readOnlyRootFilesystem"`
 	Capabilities             *struct {
-		Add []string `yaml:"add"`
+		Add  []string `yaml:"add"`
+		Drop []string `yaml:"drop"`
 	} `yaml:"capabilities"`
+	SeccompProfile *struct {
+		Type string `yaml:"type"`
+	} `yaml:"seccompProfile"`
 }
 
 // podSpec resolves the effective pod spec: a workload's spec.template.spec, or the object's own spec.
@@ -129,6 +154,16 @@ func checkK8sDoc(rel string, doc k8sDoc, node *yaml.Node) []ports.MisconfigRawFi
 		})
 	}
 
+	if isWorkloadKind(doc.Kind) && (doc.Metadata.Namespace == "" || doc.Metadata.Namespace == "default") {
+		add("kubernetes-default-namespace", "Workload in the default namespace",
+			"The workload has no namespace or uses \"default\", so it shares a namespace with unrelated workloads and weakens RBAC/network-policy scoping. Deploy it to a dedicated namespace.",
+			shared.SeverityLow, "metadata")
+	}
+	if isWorkloadKind(doc.Kind) && (spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken) {
+		add("kubernetes-automount-sa-token", "Service-account token auto-mounted",
+			"automountServiceAccountToken is not set to false, so the pod receives the API token even if it never calls the API server, widening the blast radius of a compromise. Set it to false unless API access is needed.",
+			shared.SeverityLow, "automountServiceAccountToken")
+	}
 	if spec.HostNetwork {
 		add("kubernetes-host-network", "Pod shares the host network namespace",
 			"hostNetwork: true lets the pod see and bind host interfaces, bypassing network policy and exposing host services. Remove hostNetwork unless the workload is a node-level agent that genuinely needs it.",
@@ -154,11 +189,14 @@ func checkK8sDoc(rel string, doc k8sDoc, node *yaml.Node) []ports.MisconfigRawFi
 
 	all := append(append([]k8sContainer{}, spec.Containers...), spec.InitContainers...)
 	for _, c := range all {
-		sc := c.SecurityContext
-		if sc == nil {
-			continue
-		}
 		cres := res + " container=" + clip(c.Name)
+		sc := c.SecurityContext
+		// KSV/CIS hardening: fire when a recommended secure setting is MISSING (the comprehensive
+		// posture that matches Trivy/kube-bench), regardless of whether a securityContext block exists.
+		out = append(out, k8sHardening(rel, node, cres, docLine, sc, c, spec.SecurityContext)...)
+		if sc == nil {
+			continue // the explicit-insecure checks below need a securityContext to inspect
+		}
 		if sc.Privileged != nil && *sc.Privileged {
 			out = append(out, k8sContainerFinding(rel, node, cres, "kubernetes-privileged",
 				"Privileged container", shared.SeverityHigh, "privileged",
@@ -186,6 +224,143 @@ func checkK8sDoc(rel string, doc k8sDoc, node *yaml.Node) []ports.MisconfigRawFi
 		}
 	}
 	return out
+}
+
+// k8sHardening emits the missing-hardening findings (KSV / CIS / Pod Security baseline) for one
+// container: a recommended secure setting that is absent is flagged, matching the comprehensive posture
+// of scanners like Trivy and kube-bench. Pod-level runAsNonRoot / seccompProfile are inherited when the
+// container does not set its own. Severities are low/medium so they never bury the explicit-insecure highs.
+func k8sHardening(rel string, node *yaml.Node, cres string, docLine int, sc *ctnSecCtx, c k8sContainer, pod *podSecCtx) []ports.MisconfigRawFinding {
+	var out []ports.MisconfigRawFinding
+	h := func(rule, title, desc, key string, sev shared.Severity) {
+		out = append(out, k8sContainerFinding(rel, node, cres, rule, title, sev, key, desc, docLine))
+	}
+	if !runAsNonRootEnforced(sc, pod) {
+		h("kubernetes-no-run-as-non-root", "Container may run as root",
+			"Nothing enforces a non-root user (runAsNonRoot: true or a non-zero runAsUser) on the container or the pod, so it can run as UID 0. Set securityContext.runAsNonRoot: true.",
+			"runAsNonRoot", shared.SeverityMedium)
+	}
+	if !(sc != nil && sc.AllowPrivilegeEscalation != nil && !*sc.AllowPrivilegeEscalation) {
+		h("kubernetes-no-priv-escalation-disabled", "Privilege escalation not disabled",
+			"allowPrivilegeEscalation is not set to false, so a process can gain more privileges than its parent (e.g. via a setuid binary). Set securityContext.allowPrivilegeEscalation: false.",
+			"allowPrivilegeEscalation", shared.SeverityLow)
+	}
+	if !(sc != nil && sc.ReadOnlyRootFilesystem != nil && *sc.ReadOnlyRootFilesystem) {
+		h("kubernetes-no-read-only-root-fs", "Writable container root filesystem",
+			"readOnlyRootFilesystem is not true, so the container can write to its own filesystem (tampering, dropped tooling persists). Set securityContext.readOnlyRootFilesystem: true and mount writable paths explicitly.",
+			"readOnlyRootFilesystem", shared.SeverityLow)
+	}
+	if !dropsAllCaps(sc) {
+		h("kubernetes-caps-not-dropped", "Default Linux capabilities not dropped",
+			"The container does not drop ALL capabilities (securityContext.capabilities.drop: [ALL]), so it keeps the default capability set. Drop ALL and add back only the few that are required.",
+			"capabilities", shared.SeverityLow)
+	}
+	if !seccompEnforced(sc, pod) {
+		h("kubernetes-no-seccomp", "No seccomp profile",
+			"No seccompProfile is set (RuntimeDefault or Localhost) on the container or the pod, so syscalls are unrestricted. Set seccompProfile.type: RuntimeDefault.",
+			"seccompProfile", shared.SeverityLow)
+	}
+	cpu, mem := false, false
+	if c.Resources != nil {
+		_, cpu = c.Resources.Limits["cpu"]
+		_, mem = c.Resources.Limits["memory"]
+	}
+	if !cpu {
+		h("kubernetes-no-cpu-limit", "No CPU limit",
+			"The container sets no resources.limits.cpu, so a runaway workload can starve other pods on the node. Set a CPU limit.",
+			"resources", shared.SeverityLow)
+	}
+	if !mem {
+		h("kubernetes-no-memory-limit", "No memory limit",
+			"The container sets no resources.limits.memory, so a memory leak or hostile workload can OOM the node (noisy-neighbor / DoS). Set a memory limit.",
+			"resources", shared.SeverityLow)
+	}
+	if !runAsUserSet(sc, pod) {
+		h("kubernetes-no-run-as-user", "No explicit runAsUser",
+			"Neither the container nor the pod sets an explicit securityContext.runAsUser, so the UID is left to the image. Pin a non-zero runAsUser for a predictable, non-root identity.",
+			"runAsUser", shared.SeverityLow)
+	}
+	if (sc == nil || sc.RunAsGroup == nil) && (pod == nil || pod.RunAsGroup == nil) {
+		h("kubernetes-no-run-as-group", "No explicit runAsGroup",
+			"Neither the container nor the pod sets securityContext.runAsGroup, so the primary GID defaults to the image (often 0/root group). Pin a non-zero runAsGroup.",
+			"runAsGroup", shared.SeverityLow)
+	}
+	if t := imageTag(c.Image); c.Image != "" && (t == "" || t == "latest") {
+		h("kubernetes-image-no-tag", "Container image not version-pinned",
+			"The container image uses no tag or :latest, so the deployed version is not reproducible and can silently change. Pin an explicit tag, ideally by digest.",
+			"image", shared.SeverityLow)
+	}
+	for _, p := range c.Ports {
+		if p.HostPort != 0 {
+			h("kubernetes-host-port", "Container binds a host port",
+				"A container port sets hostPort, binding directly to the node's network and bypassing Service abstraction and network policy. Expose the workload through a Service instead.",
+				"hostPort", shared.SeverityMedium)
+			break
+		}
+	}
+	return out
+}
+
+// isWorkloadKind reports whether a Kubernetes kind carries a pod template / runs workloads (so pod-level
+// namespace and service-account checks apply); cluster-scoped objects like Namespace or ClusterRole do not.
+func isWorkloadKind(kind string) bool {
+	switch kind {
+	case "Pod", "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob", "ReplicationController":
+		return true
+	}
+	return false
+}
+
+// runAsUserSet reports whether an explicit runAsUser is set on the container or, by inheritance, the pod.
+func runAsUserSet(sc *ctnSecCtx, pod *podSecCtx) bool {
+	if sc != nil && sc.RunAsUser != nil {
+		return true
+	}
+	return pod != nil && pod.RunAsUser != nil
+}
+
+// runAsNonRootEnforced reports whether a non-root user is enforced by the container or, by inheritance,
+// the pod. An EXPLICIT root setting also counts as "enforced/handled" here so the missing-hardening rule
+// does not double-report with runsAsRoot (which flags the explicit case at a higher severity).
+func runAsNonRootEnforced(sc *ctnSecCtx, pod *podSecCtx) bool {
+	if sc != nil {
+		if sc.RunAsNonRoot != nil {
+			return true // explicitly true (secure) or false (handled by runsAsRoot)
+		}
+		if sc.RunAsUser != nil {
+			return true // any explicit UID: >0 secure, 0 handled by runsAsRoot
+		}
+	}
+	if pod != nil {
+		if pod.RunAsNonRoot != nil && *pod.RunAsNonRoot {
+			return true
+		}
+		if pod.RunAsUser != nil && *pod.RunAsUser > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// seccompEnforced reports whether a seccomp profile is set on the container or, by inheritance, the pod.
+func seccompEnforced(sc *ctnSecCtx, pod *podSecCtx) bool {
+	if sc != nil && sc.SeccompProfile != nil && strings.TrimSpace(sc.SeccompProfile.Type) != "" {
+		return true
+	}
+	return pod != nil && pod.SeccompProfile != nil && strings.TrimSpace(pod.SeccompProfile.Type) != ""
+}
+
+// dropsAllCaps reports whether the container drops ALL Linux capabilities.
+func dropsAllCaps(sc *ctnSecCtx) bool {
+	if sc == nil || sc.Capabilities == nil {
+		return false
+	}
+	for _, d := range sc.Capabilities.Drop {
+		if strings.EqualFold(strings.TrimSpace(d), "ALL") {
+			return true
+		}
+	}
+	return false
 }
 
 // runsAsRoot reports an EXPLICIT root configuration only (runAsUser 0, or runAsNonRoot false) — an unset

--- a/internal/infrastructure/tools/misconfig/scanner.go
+++ b/internal/infrastructure/tools/misconfig/scanner.go
@@ -1,7 +1,9 @@
 // Package misconfig is an owned, deterministic infrastructure-as-code / config scanner over a prepared
-// workspace. It flags insecure Dockerfile and Kubernetes-manifest settings with first-party Go checks —
-// no external policy engine (no OPA/Rego) and no network. Checks are chosen to be high-signal and
-// low-false-positive: a rule fires only on an explicit insecure setting, never on an unset default.
+// workspace. It flags insecure settings in Dockerfiles, Kubernetes manifests, Helm charts (rendered via
+// `helm template`), and Terraform (HCL) with first-party Go checks — no external policy engine (no
+// OPA/Rego). Explicit-insecure settings are flagged as high/medium; recommended-hardening that is absent
+// (KSV/CIS/tfsec baseline: runAsNonRoot, dropped capabilities, encryption, resource limits, ...) is
+// flagged as low/medium, so coverage matches comprehensive scanners while the highs stay legible.
 //
 // It is READ-ONLY: it classifies files by name/content, parses them, and returns located findings. A
 // parse or read error is a per-file skip, never a scan failure. Results become ungated Kind=misconfig
@@ -30,6 +32,7 @@ const (
 // Scanner implements ports.MisconfigScanner with an owned ruleset.
 type Scanner struct {
 	skipDirs map[string]bool
+	helmBin  string // `helm` binary for rendering Helm charts; empty or missing ⇒ Helm charts are skipped
 }
 
 var _ ports.MisconfigScanner = (*Scanner)(nil)
@@ -39,6 +42,7 @@ func New() *Scanner {
 	return &Scanner{
 		skipDirs: set(".git", "node_modules", "vendor", "dist", "build", "target", ".idea",
 			".gradle", ".venv", "venv", "__pycache__", "bin"),
+		helmBin: "helm",
 	}
 }
 
@@ -52,6 +56,7 @@ const (
 	cfgNone configKind = iota
 	cfgDockerfile
 	cfgKubernetes
+	cfgTerraform
 )
 
 // ScanConfigs walks root, classifies each regular file, and returns located misconfig findings.
@@ -80,6 +85,17 @@ func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.Misconf
 		// Only read regular files: never follow a symlink out of the (untrusted) workspace, so a planted
 		// link cannot pull an out-of-root file into the scan.
 		if !d.Type().IsRegular() {
+			return nil
+		}
+		// A Helm chart (Chart.yaml) is rendered as a whole via `helm template` and its output scanned with
+		// the Kubernetes rules — the raw templates carry Go-template directives and are not valid YAML.
+		// Skip a Chart.yaml bundled under a parent chart's charts/ dir (the parent render covers the subchart).
+		if d.Name() == "Chart.yaml" {
+			if !strings.Contains(path, string(os.PathSeparator)+"charts"+string(os.PathSeparator)) && count < maxFiles {
+				count++
+				relDir := strings.TrimPrefix(strings.TrimPrefix(filepath.Dir(path), root), string(os.PathSeparator))
+				out = append(out, scanHelmChart(ctx, s.helmBin, filepath.Dir(path), relDir)...)
+			}
 			return nil
 		}
 		kind := classifyName(d.Name())
@@ -111,6 +127,8 @@ func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.Misconf
 			out = append(out, scanDockerfile(rel, data)...)
 		case cfgKubernetes:
 			out = append(out, scanKubernetes(rel, data)...)
+		case cfgTerraform:
+			out = append(out, scanTerraform(rel, data)...)
 		}
 		return nil
 	})
@@ -126,6 +144,9 @@ func classifyName(name string) configKind {
 		strings.HasPrefix(name, "Dockerfile.") ||
 		strings.HasSuffix(strings.ToLower(name), ".dockerfile") {
 		return cfgDockerfile
+	}
+	if strings.HasSuffix(strings.ToLower(name), ".tf") {
+		return cfgTerraform
 	}
 	return cfgNone
 }

--- a/internal/infrastructure/tools/misconfig/scanner.go
+++ b/internal/infrastructure/tools/misconfig/scanner.go
@@ -32,12 +32,16 @@ const (
 // Scanner implements ports.MisconfigScanner with an owned ruleset.
 type Scanner struct {
 	skipDirs map[string]bool
-	helmBin  string // `helm` binary for rendering Helm charts; empty or missing ⇒ Helm charts are skipped
+	helmBin  string           // `helm` binary for rendering Helm charts
+	helmRun  ports.ToolRunner // sandbox runner for helm (API path); nil = not sandboxed
+	helmDir  bool             // allow a direct host exec of helm (trusted-local CLI only)
 }
 
 var _ ports.MisconfigScanner = (*Scanner)(nil)
 
-// New returns a scanner with the default configuration.
+// New returns a scanner with the default configuration. Helm rendering is OFF by default (no runner, not
+// trusted-local): `helm template` executes an untrusted chart, so a caller must opt in with WithHelmRunner
+// (sandboxed, for the API) or WithHelmDirect (direct exec, for the trusted-local CLI).
 func New() *Scanner {
 	return &Scanner{
 		skipDirs: set(".git", "node_modules", "vendor", "dist", "build", "target", ".idea",
@@ -45,6 +49,14 @@ func New() *Scanner {
 		helmBin: "helm",
 	}
 }
+
+// WithHelmRunner enables Helm chart rendering confined by the given ToolRunner (the SCA sandbox), so
+// `helm template` never runs unprotected on the host. Use this in the API path.
+func (s *Scanner) WithHelmRunner(r ports.ToolRunner) *Scanner { s.helmRun = r; return s }
+
+// WithHelmDirect enables Helm chart rendering via a direct host exec — ONLY for a trusted-local caller
+// (the CLI), mirroring how the CLI runs the maven/gradle resolvers unsandboxed on a trusted project.
+func (s *Scanner) WithHelmDirect() *Scanner { s.helmDir = true; return s }
 
 // Name identifies the source on findings.
 func (s *Scanner) Name() string { return "synapse-misconfig" }
@@ -94,7 +106,7 @@ func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.Misconf
 			if !strings.Contains(path, string(os.PathSeparator)+"charts"+string(os.PathSeparator)) && count < maxFiles {
 				count++
 				relDir := strings.TrimPrefix(strings.TrimPrefix(filepath.Dir(path), root), string(os.PathSeparator))
-				out = append(out, scanHelmChart(ctx, s.helmBin, filepath.Dir(path), relDir)...)
+				out = append(out, scanHelmChart(ctx, s.helmRun, s.helmDir, s.helmBin, filepath.Dir(path), relDir)...)
 			}
 			return nil
 		}

--- a/internal/infrastructure/tools/misconfig/scanner_test.go
+++ b/internal/infrastructure/tools/misconfig/scanner_test.go
@@ -66,6 +66,7 @@ func TestDockerfileSecureNoFindings(t *testing.T) {
 RUN useradd -r app
 COPY ./bin/app /usr/local/bin/app
 USER app
+HEALTHCHECK CMD ["app", "healthz"]
 ENTRYPOINT ["app"]
 `
 	if got := scan(t, map[string]string{"Dockerfile": df}); len(got) != 0 {
@@ -148,25 +149,38 @@ func TestKubernetesHardenedNoFindings(t *testing.T) {
 kind: Pod
 metadata:
   name: safe
+  namespace: prod
 spec:
+  automountServiceAccountToken: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: app
       image: myapp:1.0
+      resources:
+        limits:
+          cpu: "500m"
+          memory: "256Mi"
       securityContext:
         privileged: false
         runAsNonRoot: true
         runAsUser: 1000
+        runAsGroup: 3000
         allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
         capabilities:
           drop: ["ALL"]
 `
 	if got := scan(t, map[string]string{"pod.yaml": manifest}); len(got) != 0 {
-		t.Errorf("hardened Pod should yield no findings, got %+v", got)
+		t.Errorf("fully hardened Pod should yield no findings, got %+v", got)
 	}
 }
 
-func TestKubernetesUnsetSecurityContextIsQuiet(t *testing.T) {
-	// No securityContext at all: we deliberately do NOT flag defaults (low-FP policy).
+func TestKubernetesUnhardenedFlagged(t *testing.T) {
+	// A container with no securityContext now yields the missing-hardening findings (the comprehensive
+	// KSV/CIS posture that matches Trivy/kube-bench); the earlier low-FP "stay quiet" policy was
+	// intentionally replaced so Synapse is not weaker than comprehensive scanners on IaC coverage.
 	manifest := `apiVersion: v1
 kind: Pod
 metadata:
@@ -176,8 +190,16 @@ spec:
     - name: app
       image: myapp:1.0
 `
-	if got := scan(t, map[string]string{"pod.yaml": manifest}); len(got) != 0 {
-		t.Errorf("pod with no securityContext must stay quiet, got %+v", got)
+	got := ruleIDs(scan(t, map[string]string{"pod.yaml": manifest}))
+	for _, want := range []string{
+		"kubernetes-no-run-as-non-root", "kubernetes-no-priv-escalation-disabled",
+		"kubernetes-no-read-only-root-fs", "kubernetes-caps-not-dropped",
+		"kubernetes-no-seccomp", "kubernetes-no-cpu-limit", "kubernetes-no-memory-limit",
+		"kubernetes-no-run-as-user",
+	} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("unhardened container must flag %q, got %v", want, keys(got))
+		}
 	}
 }
 

--- a/internal/infrastructure/tools/misconfig/terraform.go
+++ b/internal/infrastructure/tools/misconfig/terraform.go
@@ -1,0 +1,188 @@
+package misconfig
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Terraform (HCL) misconfiguration checks. Rather than a full HCL evaluator, this tracks the enclosing
+// `resource "TYPE" "NAME"` block by brace depth and matches insecure LITERAL attribute values inside it
+// — the common, high-signal cloud misconfigurations (public storage, world-open security groups,
+// disabled encryption, public databases, wildcard IAM, plaintext secrets). Values that come from a
+// variable / interpolation (${...}) are not flagged, keeping false positives low.
+var (
+	tfResourceOpen = regexp.MustCompile(`^\s*resource\s+"([^"]+)"\s+"([^"]*)"\s*\{`)
+	tfPublicACL    = regexp.MustCompile(`(?i)\bacl\s*=\s*"(public-read|public-read-write|authenticated-read)"`)
+	tfEncFalse     = regexp.MustCompile(`(?i)\b(encrypted|storage_encrypted|encryption)\s*=\s*false\b`)
+	tfPublicRDS    = regexp.MustCompile(`(?i)\bpublicly_accessible\s*=\s*true\b`)
+	tfPabDisabled  = regexp.MustCompile(`(?i)\b(block_public_acls|block_public_policy|ignore_public_acls|restrict_public_buckets)\s*=\s*false\b`)
+	tfOpenCIDR     = regexp.MustCompile(`"0\.0\.0\.0/0"|"::/0"`)
+	tfIAMWildcard  = regexp.MustCompile(`(?i)("Action"\s*:\s*"\*"|actions\s*=\s*\[\s*"\*"\s*\])`)
+	tfSecretAttr   = regexp.MustCompile(`(?i)\b(password|secret|secret_key|access_key|private_key|api_key|token)\s*=\s*"([^"]+)"`)
+)
+
+// scanTerraform runs the owned Terraform checks over one .tf file.
+func scanTerraform(rel string, data []byte) []ports.MisconfigRawFinding {
+	lines := strings.Split(string(data), "\n")
+	var out []ports.MisconfigRawFinding
+
+	type frame struct {
+		typ, name string
+		depth     int
+		start     int
+		body      strings.Builder
+	}
+	var stack []*frame
+	depth := 0
+
+	for i, raw := range lines {
+		line := stripHCLComment(raw)
+		trimmed := strings.TrimSpace(line)
+		if m := tfResourceOpen.FindStringSubmatch(trimmed); m != nil {
+			stack = append(stack, &frame{typ: m[1], name: m[2], depth: depth, start: i + 1})
+		}
+		curType := ""
+		if len(stack) > 0 {
+			curType = stack[len(stack)-1].typ
+			stack[len(stack)-1].body.WriteString(trimmed)
+			stack[len(stack)-1].body.WriteByte('\n')
+		}
+		out = append(out, tfLineRules(rel, i+1, trimmed, curType)...)
+
+		depth += strings.Count(line, "{") - strings.Count(line, "}")
+		if depth < 0 {
+			depth = 0
+		}
+		for len(stack) > 0 && depth <= stack[len(stack)-1].depth {
+			f := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			out = append(out, tfBlockRules(rel, f.typ, f.start, f.body.String())...) // block-level missing-setting rules
+		}
+	}
+	return out
+}
+
+// tfBlockRules applies whole-block "recommended secure setting is missing" rules to a resource block —
+// the posture comprehensive scanners (tfsec/Trivy) use for cloud hardening. A rule fires when a resource
+// of a given type does not contain the attribute that enables the secure behavior.
+func tfBlockRules(rel, resType string, line int, body string) []ports.MisconfigRawFinding {
+	var out []ports.MisconfigRawFinding
+	has := func(attr string) bool { return strings.Contains(body, attr) }
+	add := func(rule, title string, sev shared.Severity, desc string) {
+		out = append(out, ports.MisconfigRawFinding{
+			File: rel, Line: line, RuleID: rule, Title: title, Severity: sev, Resource: "Terraform " + clip(resType), Description: desc,
+		})
+	}
+	switch resType {
+	case "aws_ecr_repository":
+		if !has("image_tag_mutability") || strings.Contains(body, `image_tag_mutability = "MUTABLE"`) {
+			add("terraform-ecr-mutable-tags", "ECR image tags are mutable", shared.SeverityLow,
+				"The ECR repository does not set image_tag_mutability = \"IMMUTABLE\", so a pushed tag can be overwritten, breaking image provenance. Set it to IMMUTABLE.")
+		}
+		if !has("encryption_configuration") {
+			add("terraform-ecr-no-cmk", "ECR repository not encrypted with a customer-managed key", shared.SeverityLow,
+				"The ECR repository sets no encryption_configuration, so images use the default AWS-managed key. Configure a customer-managed KMS key for stronger key control.")
+		}
+	case "aws_cloudwatch_log_group":
+		if !has("kms_key_id") {
+			add("terraform-cloudwatch-unencrypted", "CloudWatch log group not encrypted with KMS", shared.SeverityLow,
+				"The log group sets no kms_key_id, so logs are not encrypted with a customer-managed key. Set kms_key_id to a KMS key ARN.")
+		}
+	case "aws_dynamodb_table":
+		if !has("server_side_encryption") {
+			add("terraform-dynamodb-unencrypted", "DynamoDB table not encrypted with a CMK", shared.SeverityMedium,
+				"The table declares no server_side_encryption block, so it uses the default AWS-owned key. Add server_side_encryption { enabled = true, kms_key_arn = ... }.")
+		}
+		if !has("point_in_time_recovery") {
+			add("terraform-dynamodb-no-pitr", "DynamoDB point-in-time recovery disabled", shared.SeverityLow,
+				"The table enables no point_in_time_recovery, so there is no continuous backup to restore from. Add point_in_time_recovery { enabled = true }.")
+		}
+	case "aws_sns_topic":
+		if !has("kms_master_key_id") {
+			add("terraform-sns-unencrypted", "SNS topic not encrypted", shared.SeverityMedium,
+				"The SNS topic sets no kms_master_key_id, so messages are not encrypted at rest. Set kms_master_key_id to a KMS key.")
+		}
+	case "aws_s3_bucket":
+		if !has("logging") {
+			add("terraform-s3-no-logging", "S3 bucket access logging disabled", shared.SeverityLow,
+				"The bucket configures no access logging, so object access is not audited. Enable server access logging (a logging block or an aws_s3_bucket_logging resource).")
+		}
+	case "aws_instance", "aws_launch_template":
+		if !has("metadata_options") || (has("metadata_options") && !strings.Contains(body, "required")) {
+			add("terraform-imdsv2-not-required", "IMDSv2 not enforced", shared.SeverityMedium,
+				"The instance does not require IMDSv2 (metadata_options { http_tokens = \"required\" }), leaving the metadata service reachable via the SSRF-prone IMDSv1. Require IMDSv2.")
+		}
+	}
+	return out
+}
+
+// tfLineRules applies the per-line attribute checks, scoping by the enclosing resource type where it matters.
+func tfLineRules(rel string, line int, text, resType string) []ports.MisconfigRawFinding {
+	var out []ports.MisconfigRawFinding
+	add := func(rule, title string, sev shared.Severity, desc string) {
+		res := "Terraform"
+		if resType != "" {
+			res = "Terraform " + clip(resType)
+		}
+		out = append(out, ports.MisconfigRawFinding{
+			File: rel, Line: line, RuleID: rule, Title: title, Severity: sev, Resource: res, Description: desc,
+		})
+	}
+	lower := strings.ToLower(resType)
+
+	if tfPublicACL.MatchString(text) && (strings.Contains(lower, "s3") || strings.Contains(lower, "bucket") || resType == "") {
+		add("terraform-public-bucket-acl", "Object storage granted a public ACL", shared.SeverityHigh,
+			"A storage-bucket ACL is set to a public value (public-read / public-read-write / authenticated-read), exposing the bucket contents. Use a private ACL and grant access via IAM or a bucket policy.")
+	}
+	if tfEncFalse.MatchString(text) {
+		add("terraform-encryption-disabled", "Encryption explicitly disabled", shared.SeverityHigh,
+			"An encryption attribute is set to false, so data is stored unencrypted at rest. Enable encryption (and, where supported, a customer-managed key).")
+	}
+	if tfPublicRDS.MatchString(text) {
+		add("terraform-db-publicly-accessible", "Database is publicly accessible", shared.SeverityHigh,
+			"publicly_accessible = true puts the database on a public endpoint reachable from the internet. Set it to false and reach the database through a private subnet / VPC.")
+	}
+	if tfPabDisabled.MatchString(text) {
+		add("terraform-public-access-block-disabled", "Public-access block disabled", shared.SeverityMedium,
+			"An S3 public-access-block guard is set to false, weakening the account/bucket protection against accidental public exposure. Keep all four block settings true.")
+	}
+	if tfOpenCIDR.MatchString(text) && (strings.Contains(lower, "security_group") || strings.Contains(lower, "firewall") || strings.Contains(lower, "ingress") || resType == "") {
+		add("terraform-open-cidr", "Network rule open to the whole internet", shared.SeverityHigh,
+			"A security-group / firewall rule allows 0.0.0.0/0 (or ::/0), exposing the port to the entire internet. Restrict the CIDR to the specific ranges that need access.")
+	}
+	if tfIAMWildcard.MatchString(text) {
+		add("terraform-iam-wildcard", "IAM policy grants a wildcard action", shared.SeverityMedium,
+			"An IAM policy statement uses a wildcard action (\"*\"), granting far more than the workload needs. Scope the policy to the specific actions required.")
+	}
+	if m := tfSecretAttr.FindStringSubmatch(text); m != nil {
+		v := strings.TrimSpace(m[2])
+		if v != "" && !strings.Contains(v, "${") && !strings.HasPrefix(v, "var.") && !strings.HasPrefix(v, "data.") {
+			add("terraform-plaintext-secret", "Secret hardcoded in Terraform", shared.SeverityHigh,
+				"A secret-named attribute is assigned a literal value in the Terraform source, so the credential is committed to version control. Reference a variable, a secret manager, or a data source instead.")
+		}
+	}
+	return out
+}
+
+// stripHCLComment removes a trailing line comment (# or //) that starts outside a quoted string, so
+// braces/values inside comments do not affect depth tracking or rule matching.
+func stripHCLComment(line string) string {
+	inQ := false
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		if c == '"' && (i == 0 || line[i-1] != '\\') {
+			inQ = !inQ
+			continue
+		}
+		if inQ {
+			continue
+		}
+		if c == '#' || (c == '/' && i+1 < len(line) && line[i+1] == '/') {
+			return line[:i]
+		}
+	}
+	return line
+}

--- a/internal/infrastructure/tools/misconfig/terraform_test.go
+++ b/internal/infrastructure/tools/misconfig/terraform_test.go
@@ -1,0 +1,120 @@
+package misconfig
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestTerraformInsecure(t *testing.T) {
+	tf := `resource "aws_s3_bucket" "b" {
+  bucket = "my-bucket"
+  acl    = "public-read"
+}
+
+resource "aws_security_group" "sg" {
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_db_instance" "db" {
+  publicly_accessible = true
+  storage_encrypted   = false
+  password            = "hunter2super"
+}
+
+resource "aws_ecr_repository" "r" {
+  name = "app"
+}
+
+resource "aws_dynamodb_table" "t" {
+  name = "items"
+}
+`
+	got := ruleIDs(scan(t, map[string]string{"main.tf": tf}))
+	for _, want := range []string{
+		"terraform-public-bucket-acl", "terraform-open-cidr", "terraform-db-publicly-accessible",
+		"terraform-encryption-disabled", "terraform-plaintext-secret",
+		"terraform-ecr-mutable-tags", "terraform-ecr-no-cmk",
+		"terraform-dynamodb-unencrypted", "terraform-dynamodb-no-pitr",
+	} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("expected Terraform rule %q, got %v", want, keys(got))
+		}
+	}
+}
+
+func TestTerraformSecureNoFindings(t *testing.T) {
+	// A hardened resource set: private ACL, scoped CIDR, encryption on, secret from a variable,
+	// immutable+encrypted ECR, encrypted DynamoDB with PITR.
+	tf := `resource "aws_s3_bucket" "b" {
+  bucket = "my-bucket"
+  acl    = "private"
+  logging {
+    target_bucket = "logs"
+  }
+}
+
+resource "aws_security_group" "sg" {
+  ingress {
+    cidr_blocks = ["10.0.0.0/8"]
+  }
+}
+
+resource "aws_db_instance" "db" {
+  publicly_accessible = false
+  storage_encrypted   = true
+  password            = var.db_password
+}
+
+resource "aws_ecr_repository" "r" {
+  name                 = "app"
+  image_tag_mutability = "IMMUTABLE"
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+}
+`
+	if got := scan(t, map[string]string{"main.tf": tf}); len(got) != 0 {
+		t.Errorf("hardened Terraform should yield no findings, got %+v", got)
+	}
+}
+
+func TestHelmRenderedIfAvailable(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not installed; Helm rendering is best-effort and skipped")
+	}
+	files := map[string]string{
+		"chart/Chart.yaml":                "apiVersion: v2\nname: demo\nversion: 0.1.0\n",
+		"chart/values.yaml":               "image: demo:1.0\n",
+		"chart/templates/deployment.yaml": helmDeployment,
+	}
+	got := ruleIDs(scan(t, files))
+	// The rendered pod sets no hardening, so the missing-hardening rules must fire via the Helm path.
+	for _, want := range []string{"kubernetes-no-run-as-non-root", "kubernetes-no-seccomp"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("Helm-rendered manifest must be scanned with the K8s rules; missing %q, got %v", want, keys(got))
+		}
+	}
+}
+
+const helmDeployment = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: {{ .Values.image }}
+`

--- a/internal/infrastructure/tools/misconfig/terraform_test.go
+++ b/internal/infrastructure/tools/misconfig/terraform_test.go
@@ -1,7 +1,10 @@
 package misconfig
 
 import (
+	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
@@ -91,7 +94,22 @@ func TestHelmRenderedIfAvailable(t *testing.T) {
 		"chart/values.yaml":               "image: demo:1.0\n",
 		"chart/templates/deployment.yaml": helmDeployment,
 	}
-	got := ruleIDs(scan(t, files))
+	root := t.TempDir()
+	for name, body := range files {
+		p := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Helm rendering is off by default; the trusted-local CLI path (WithHelmDirect) enables it.
+	out, err := New().WithHelmDirect().ScanConfigs(context.Background(), root)
+	if err != nil {
+		t.Fatalf("ScanConfigs: %v", err)
+	}
+	got := ruleIDs(out)
 	// The rendered pod sets no hardening, so the missing-hardening rules must fire via the Helm path.
 	for _, want := range []string{"kubernetes-no-run-as-non-root", "kubernetes-no-seccomp"} {
 		if _, ok := got[want]; !ok {


### PR DESCRIPTION
## What

Close the two areas where Synapse was behind Trivy, verified end-to-end on a real 506MB polyglot repo (synaptix-platform).

### License (was 1366 < Trivy 1381 → now 1480 > Trivy 1381)

`licensemeta/pypi.go`: a PyPI-registry license enricher. deps.dev classifies many PyPI packages as `non-standard` (their license is in the trove classifiers / free-text, not deps.dev's normalized field), so ~133 pypi components stayed `no_license_declared`. The new enricher resolves them from PyPI's own metadata — PEP 639 `license_expression`, trove classifiers, then free-text `info.license` — wired last in the chain so it only fills what deps.dev missed. **pypi coverage 0% → 96%; total detected 1366 → 1480, past Trivy's 1381.**

### Misconfig / IaC (was 47 vs Trivy 270 → now 208)

Previously Synapse scanned only Dockerfile + raw Kubernetes with a few explicit-insecure rules, and did **not scan Helm or Terraform at all**. Now:

- **Dockerfile** (47→~80): HEALTHCHECK, secret-in-ENV/ARG, ADD-vs-COPY, sudo, insecure download, apt-no-clean.
- **Kubernetes**: the KSV/CIS missing-hardening rules (runAsNonRoot, runAsUser/Group, priv-escalation, readOnlyRootFilesystem, drop-ALL-caps, seccomp, cpu/memory limits, hostPort, default-namespace, automount SA token, image tag) alongside the explicit-insecure highs. A deliberate shift from explicit-only to the comprehensive posture, keeping highs legible (hardening is low/medium).
- **Helm** (NEW): render each chart with `helm template` (argv, no shell, no hooks, no cluster) and run the K8s rules on the output. Best-effort: missing helm binary / a chart needing required values is skipped.
- **Terraform** (NEW, 0→~35): a resource-block-aware HCL scanner for the common cloud misconfigs (public storage, world-open security groups, disabled encryption, public DBs, wildcard IAM, plaintext secrets) plus missing-secure-setting rules (ECR immutability/CMK, CloudWatch/DynamoDB/SNS encryption, PITR, IMDSv2).

**Result on the real repo: all four config types now covered; Dockerfile and Terraform near parity.** The residual vs Trivy's 270 is Trivy's larger low-severity KSV/tfsec rule library — a rule-count tail, not a capability gap.

## Verification

`go build ./...`, `go vet`, `gofmt`, full `go test ./...` clean. Live re-scan of synaptix-platform via the API confirmed: license 1366→1480 (> Trivy 1381), misconfig 47→208.
