### PR TITLE
feat(cli): add scan --sarif for SARIF 2.1.0 output

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/advisoryingest"
+	exportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/export"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
 )
@@ -78,7 +79,8 @@ func main() {
 
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
-	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
+	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
+	fmt.Fprintln(os.Stderr, "      --sarif    write a SARIF 2.1.0 report to stdout (for GitHub code-scanning upload); --fail-on still sets the exit code")
 	fmt.Fprintln(os.Stderr, "      --image    treat the argument as a container image reference (pulled via crane) instead of a local path")
 	fmt.Fprintln(os.Stderr, "      --offline  skip the live OSV.dev source; detect with Grype's offline DB only (air-gapped / fast)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
@@ -100,6 +102,7 @@ func runScan() {
 	image := false
 	offline := false
 	jsonOut := false
+	sarifOut := false
 	for i := 3; i < len(os.Args); i++ {
 		switch {
 		case os.Args[i] == "--fail-on" && i+1 < len(os.Args):
@@ -119,6 +122,8 @@ func runScan() {
 			offline = true
 		case os.Args[i] == "--json":
 			jsonOut = true
+		case os.Args[i] == "--sarif":
+			sarifOut = true
 		default:
 			fmt.Fprintf(os.Stderr, "synapse-cli: unknown or incomplete option %q\n", os.Args[i])
 			os.Exit(2)
@@ -137,7 +142,11 @@ func runScan() {
 		fmt.Fprintf(os.Stderr, "synapse-cli: %v (mode want full|vulnerabilities|licenses; detection-priority want comprehensive|precise)\n", err)
 		os.Exit(2)
 	}
-	if err := run(os.Args[2], failOn, mode, priority, ignoreUnfixed, image, offline, jsonOut); err != nil {
+	if jsonOut && sarifOut {
+		fmt.Fprintln(os.Stderr, "synapse-cli: choose only one of --json or --sarif")
+		os.Exit(2)
+	}
+	if err := run(os.Args[2], failOn, mode, priority, ignoreUnfixed, image, offline, jsonOut, sarifOut); err != nil {
 		fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 		os.Exit(1)
 	}
@@ -215,7 +224,7 @@ func (stderrAudit) Record(_ context.Context, e ports.AuditEntry) error {
 
 var _ ports.AuditLogger = stderrAudit{}
 
-func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfixed, image, offline, jsonOut bool) error {
+func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfixed, image, offline, jsonOut, sarifOut bool) error {
 	// An image target is an OCI reference (acquired via crane → OCI layout); a local
 	// target is a filesystem path that must be absolute for the scope check.
 	target := strings.TrimSpace(path)
@@ -377,7 +386,20 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		return fmt.Errorf("scan: %w", err)
 	}
 
-	if jsonOut {
+	switch {
+	case sarifOut:
+		// SARIF 2.1.0 for a code-scanning uploader (e.g. GitHub codeql-action/upload-sarif), to stdout so
+		// nothing else mixes in. Covers every finding kind (SCA/SAST/secret/misconfig); first-party kinds
+		// carry a file:line physical location. The --fail-on gate below still sets the exit code, so the
+		// same run both annotates and gates.
+		out, err := exportuc.MarshalSARIF(res.Findings, res.ToolVersions["synapse"])
+		if err != nil {
+			return fmt.Errorf("encode sarif: %w", err)
+		}
+		if _, err := os.Stdout.Write(append(out, '\n')); err != nil {
+			return fmt.Errorf("write sarif: %w", err)
+		}
+	case jsonOut:
 		// Machine-readable full scan result (for CI / tooling / cross-scanner comparison), to stdout so the
 		// human report never mixes in. The --fail-on gate below still sets the exit code.
 		enc := json.NewEncoder(os.Stdout)
@@ -385,7 +407,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		if err := enc.Encode(res); err != nil {
 			return fmt.Errorf("encode json result: %w", err)
 		}
-	} else {
+	default:
 		printReport(target, res)
 	}
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -23,6 +23,7 @@ synapse-cli scan <path|image-ref> [flags]
 | `--ignore-unfixed` | Ignore vulnerabilities that have no fix available. |
 | `--detection-priority comprehensive\|precise` | `comprehensive` (default) reports every match. `precise` moves single-source, non-KEV findings into a needs-verify queue that does not trip `--fail-on`. |
 | `--json` | Print the full scan result as JSON to stdout, for machine consumption in CI. |
+| `--sarif` | Print a SARIF 2.1.0 report to stdout, ready to upload to GitHub code scanning. Covers every finding kind; SAST, secret and misconfig findings carry a file and line so the platform annotates the exact source line. `--fail-on` still sets the exit code. Cannot be combined with `--json`. |
 
 ### Examples
 
@@ -67,6 +68,8 @@ live and offline sources.
 
 ## GitHub Actions
 
+Gate a build on findings:
+
 ```yaml
 - name: SCA scan
   run: |
@@ -74,5 +77,21 @@ live and offline sources.
     make build
     ./bin/synapse-cli scan . --fail-on high
 ```
+
+Or emit SARIF and upload it to the GitHub Security tab, while still failing the build on high findings:
+
+```yaml
+- name: Synapse scan
+  run: ./bin/synapse-cli scan . --sarif --fail-on high > synapse.sarif
+  continue-on-error: true            # let the upload run even when the gate fails the step
+- name: Upload SARIF
+  if: always()
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: synapse.sarif
+```
+
+The report lands in the repository's Code scanning alerts, with each SAST, secret and misconfig
+finding annotated on its exact source line.
 
 Next: [Architecture](architecture.md)

--- a/internal/usecase/export/sarif.go
+++ b/internal/usecase/export/sarif.go
@@ -1,6 +1,8 @@
 package export
 
 import (
+	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -60,7 +62,24 @@ type SARIFResult struct {
 }
 
 type SARIFLocation struct {
-	LogicalLocations []SARIFLogicalLocation `json:"logicalLocations"`
+	// A first-party finding (SAST/secret/misconfig) has a source file:line -> physicalLocation, so a
+	// code-scanning UI annotates the exact line. An SCA finding is about a dependency, not a source
+	// line -> logicalLocation module. Exactly one is set per location.
+	PhysicalLocation *SARIFPhysicalLocation `json:"physicalLocation,omitempty"`
+	LogicalLocations []SARIFLogicalLocation `json:"logicalLocations,omitempty"`
+}
+
+type SARIFPhysicalLocation struct {
+	ArtifactLocation SARIFArtifactLocation `json:"artifactLocation"`
+	Region           *SARIFRegion          `json:"region,omitempty"`
+}
+
+type SARIFArtifactLocation struct {
+	URI string `json:"uri"` // repo-relative path (GitHub matches it against the PR diff)
+}
+
+type SARIFRegion struct {
+	StartLine int `json:"startLine"` // 1-based; SARIF requires >= 1
 }
 
 type SARIFLogicalLocation struct {
@@ -79,17 +98,37 @@ func buildSARIF(findings []finding.Finding, version string) *SARIFLog {
 		if ruleID == "" {
 			ruleID = f.ID.String()
 		}
-		level := sarifLevel(f.Severity)
 
+		var locations []SARIFLocation
+		if rid, file, line, ok := firstPartyLoc(f.DedupKey); ok {
+			// SAST/secret/misconfig: the engine's own rule id + the source file:line it flagged.
+			ruleID = rid
+			phys := &SARIFPhysicalLocation{ArtifactLocation: SARIFArtifactLocation{URI: file}}
+			if line >= 1 {
+				phys.Region = &SARIFRegion{StartLine: line}
+			}
+			locations = []SARIFLocation{{PhysicalLocation: phys}}
+		} else if strings.HasPrefix(f.DedupKey, "sast:ai:") {
+			// A gated taint (E39) SAST finding is judgment-anchored, not file:line-anchored — group
+			// them under one stable rule id rather than leaking the per-finding anchor as the rule id.
+			ruleID = "synapse-taint-sast"
+		} else if p.component != "" {
+			// SCA: the vulnerable dependency is a logical module, not a source line.
+			locations = []SARIFLocation{{
+				LogicalLocations: []SARIFLogicalLocation{{Name: p.component + "@" + p.version, Kind: "module"}},
+			}}
+		}
+
+		level := sarifLevel(f.Severity)
 		if !seen[ruleID] {
 			seen[ruleID] = true
 			rule := SARIFRule{
 				ID:                   ruleID,
-				ShortDescription:     SARIFText{Text: f.Title},
+				ShortDescription:     SARIFText{Text: ruleTitle(f.Title)},
 				DefaultConfiguration: &SARIFConfig{Level: level},
 			}
-			if strings.HasPrefix(p.advisory, "CVE-") {
-				rule.HelpURI = "https://nvd.nist.gov/vuln/detail/" + p.advisory
+			if strings.HasPrefix(ruleID, "CVE-") {
+				rule.HelpURI = "https://nvd.nist.gov/vuln/detail/" + ruleID
 			}
 			rules = append(rules, rule)
 		}
@@ -104,6 +143,7 @@ func buildSARIF(findings []finding.Finding, version string) *SARIFLog {
 				"riskScore": f.RiskScore,
 				"status":    string(f.Status),
 			},
+			Locations: locations,
 		}
 		if f.CVSSVector != "" {
 			res.Properties["cvssVector"] = f.CVSSVector
@@ -112,11 +152,6 @@ func buildSARIF(findings []finding.Finding, version string) *SARIFLog {
 			// Coarse JVM class-reachability: "reachable" | "unreferenced". Advisory — lets a
 			// consumer separate/deprioritize deps the app never references (priority already reflects it).
 			res.Properties["componentReachability"] = f.ClassReachability
-		}
-		if p.component != "" {
-			res.Locations = []SARIFLocation{{
-				LogicalLocations: []SARIFLogicalLocation{{Name: p.component + "@" + p.version, Kind: "module"}},
-			}}
 		}
 		results = append(results, res)
 	}
@@ -134,4 +169,67 @@ func buildSARIF(findings []finding.Finding, version string) *SARIFLog {
 			Results: results,
 		}},
 	}
+}
+
+// firstPartyLoc parses a first-party finding dedup key of the form
+// "<kind>:<ruleID>:<file>:<line>" (kind in sast|secret|misconfig, as written by the SCA
+// finding builders) into the engine rule id and its physical file:line. The rule id and the
+// trailing line never contain ':', so a file path that does is recovered as the middle join.
+// Returns ok=false for any other key (SCA "vuln:...", "license:...") or a malformed one.
+func firstPartyLoc(key string) (ruleID, file string, line int, ok bool) {
+	var rest string
+	matched := false
+	for _, kind := range []string{"sast:", "secret:", "misconfig:"} {
+		if r, has := strings.CutPrefix(key, kind); has {
+			rest, matched = r, true
+			break
+		}
+	}
+	if !matched {
+		return "", "", 0, false
+	}
+	parts := strings.Split(rest, ":")
+	if len(parts) < 3 {
+		return "", "", 0, false
+	}
+	n, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil || n < 1 {
+		return "", "", 0, false
+	}
+	file = strings.Join(parts[1:len(parts)-1], ":")
+	if parts[0] == "" || file == "" {
+		return "", "", 0, false
+	}
+	return parts[0], file, n, true
+}
+
+// ruleTitle strips a trailing " (file:line)" occurrence marker from a first-party finding title so a
+// deduped rule's shortDescription reads generically ("MD5 is a weak hash") instead of embedding one
+// occurrence's location. The per-result message keeps the full, located title. SCA titles (no such
+// suffix) are returned unchanged.
+func ruleTitle(title string) string {
+	if !strings.HasSuffix(title, ")") {
+		return title
+	}
+	open := strings.LastIndex(title, " (")
+	if open < 0 {
+		return title
+	}
+	inner := title[open+2 : len(title)-1] // between the "(" and the trailing ")"
+	colon := strings.LastIndex(inner, ":")
+	if colon < 0 {
+		return title
+	}
+	if _, err := strconv.Atoi(inner[colon+1:]); err != nil {
+		return title // not a "<path>:<line>" marker — leave the title intact
+	}
+	return title[:open]
+}
+
+// MarshalSARIF renders findings as an indented SARIF 2.1.0 log — the artifact a code-scanning
+// uploader (e.g. GitHub `codeql-action/upload-sarif`) consumes. It is deterministic and templated
+// purely from stored findings: no clock, no LLM (golden rule 5). version is the synapse driver
+// version recorded on the run's tool driver.
+func MarshalSARIF(findings []finding.Finding, version string) ([]byte, error) {
+	return json.MarshalIndent(buildSARIF(findings, version), "", "  ")
 }

--- a/internal/usecase/export/sarif_test.go
+++ b/internal/usecase/export/sarif_test.go
@@ -1,0 +1,198 @@
+package export
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// firstPartyFindings mixes the three first-party kinds (SAST/secret/misconfig) that carry a
+// "<kind>:<ruleID>:<file>:<line>" dedup key with an SCA vuln that carries "vuln:...".
+func firstPartyFindings() []finding.Finding {
+	return []finding.Finding{
+		{ID: "s1", Title: "MD5 is a weak hash (app/crypto.go:42)", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindSAST, DedupKey: "sast:weak-crypto-md5:app/crypto.go:42"},
+		{ID: "k1", Title: "Container runs as root (deploy/pod.yaml:17)", Severity: shared.SeverityMedium, Status: finding.StatusOpen, Kind: finding.KindMisconfig, DedupKey: "misconfig:kubernetes-no-run-as-non-root:deploy/pod.yaml:17"},
+		{ID: "x1", Title: "AWS key in source (src/config.ts:8)", Severity: shared.SeverityCritical, Status: finding.StatusOpen, Kind: finding.KindSecret, DedupKey: "secret:aws-access-key:src/config.ts:8"},
+		{ID: "v1", Title: "CVE-2020-7471 in django@2.2.0", Severity: shared.SeverityHigh, Status: finding.StatusOpen, DedupKey: "vuln:CVE-2020-7471:django:2.2.0"},
+	}
+}
+
+func TestSARIFPhysicalLocationForFirstParty(t *testing.T) {
+	log := buildSARIF(firstPartyFindings(), "v9")
+	byRule := map[string]SARIFResult{}
+	for _, r := range log.Runs[0].Results {
+		byRule[r.RuleID] = r
+	}
+
+	// SAST/secret/misconfig -> physical file:line, rule id is the ENGINE rule id (not the whole dedup key).
+	cases := []struct {
+		rule, uri string
+		line      int
+		level     string
+	}{
+		{"weak-crypto-md5", "app/crypto.go", 42, "error"},                   // high -> error
+		{"kubernetes-no-run-as-non-root", "deploy/pod.yaml", 17, "warning"}, // medium -> warning
+		{"aws-access-key", "src/config.ts", 8, "error"},                     // critical -> error
+	}
+	for _, c := range cases {
+		r, ok := byRule[c.rule]
+		if !ok {
+			t.Fatalf("missing result for rule %q; rules present: %v", c.rule, keysOf(byRule))
+		}
+		if len(r.Locations) != 1 || r.Locations[0].PhysicalLocation == nil {
+			t.Fatalf("rule %q: want one physical location, got %+v", c.rule, r.Locations)
+		}
+		phys := r.Locations[0].PhysicalLocation
+		if phys.ArtifactLocation.URI != c.uri {
+			t.Errorf("rule %q: uri = %q, want %q", c.rule, phys.ArtifactLocation.URI, c.uri)
+		}
+		if phys.Region == nil || phys.Region.StartLine != c.line {
+			t.Errorf("rule %q: region = %+v, want startLine %d", c.rule, phys.Region, c.line)
+		}
+		if r.Level != c.level {
+			t.Errorf("rule %q: level = %q, want %q", c.rule, r.Level, c.level)
+		}
+		if r.Locations[0].LogicalLocations != nil {
+			t.Errorf("rule %q: first-party finding must not carry a logical (module) location", c.rule)
+		}
+	}
+
+	// The SCA vuln keeps a logical module location and never a physical one.
+	v, ok := byRule["CVE-2020-7471"]
+	if !ok {
+		t.Fatal("missing SCA result")
+	}
+	if len(v.Locations) != 1 || v.Locations[0].PhysicalLocation != nil {
+		t.Fatalf("SCA finding must not have a physical location: %+v", v.Locations)
+	}
+	if v.Locations[0].LogicalLocations[0].Name != "django@2.2.0" {
+		t.Errorf("SCA module location = %+v", v.Locations[0].LogicalLocations)
+	}
+}
+
+func TestMarshalSARIFValidJSON(t *testing.T) {
+	out, err := MarshalSARIF(firstPartyFindings(), "v9")
+	if err != nil {
+		t.Fatalf("MarshalSARIF: %v", err)
+	}
+	// Must be valid JSON with the SARIF header a GitHub uploader keys on.
+	var log SARIFLog
+	if err := json.Unmarshal(out, &log); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if log.Version != "2.1.0" || log.Schema == "" {
+		t.Errorf("bad SARIF header: version=%q schema=%q", log.Version, log.Schema)
+	}
+	if len(log.Runs) != 1 || len(log.Runs[0].Results) != 4 {
+		t.Fatalf("want 1 run with 4 results, got %d run(s)", len(log.Runs))
+	}
+	// A physical-location result must serialize startLine >= 1 (SARIF requires it).
+	for _, r := range log.Runs[0].Results {
+		if p := firstNonNilPhysical(r.Locations); p != nil && p.Region != nil && p.Region.StartLine < 1 {
+			t.Errorf("result %q has invalid startLine %d", r.RuleID, p.Region.StartLine)
+		}
+	}
+}
+
+func TestFirstPartyLocParsing(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		wantOK bool
+		rule   string
+		file   string
+		line   int
+	}{
+		{"sast", "sast:weak-crypto-md5:app/main.go:42", true, "weak-crypto-md5", "app/main.go", 42},
+		{"secret", "secret:aws-key:a/b/c.env:3", true, "aws-key", "a/b/c.env", 3},
+		{"misconfig", "misconfig:dockerfile-run-sudo:Dockerfile:5", true, "dockerfile-run-sudo", "Dockerfile", 5},
+		{"path-with-colon", "sast:rule:weird:path.go:7", true, "rule", "weird:path.go", 7},
+		{"sca-vuln", "vuln:CVE-2020-7471:django:2.2.0", false, "", "", 0},
+		{"license", "license:GPL-3.0-only", false, "", "", 0},
+		{"non-numeric-line", "sast:rule:file.go:notaline", false, "", "", 0},
+		{"too-few-parts", "sast:rule", false, "", "", 0},
+		{"zero-line", "sast:rule:file.go:0", false, "", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule, file, line, ok := firstPartyLoc(tt.key)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && (rule != tt.rule || file != tt.file || line != tt.line) {
+				t.Errorf("got (%q,%q,%d), want (%q,%q,%d)", rule, file, line, tt.rule, tt.file, tt.line)
+			}
+		})
+	}
+}
+
+func TestRuleTitleStripsLocationMarker(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"MD5 is a weak hash (app/crypto.go:42)", "MD5 is a weak hash"},
+		{"AWS key in source (src/config.ts:8)", "AWS key in source"},
+		{"CVE-2020-7471 in django@2.2.0", "CVE-2020-7471 in django@2.2.0"}, // SCA: no marker, unchanged
+		{"Some title (not a location)", "Some title (not a location)"},     // parenthetical without :line
+		{"Weird (a:b:12)", "Weird"},                                        // path-with-colon marker
+		{"No parens at all", "No parens at all"},
+	}
+	for _, tt := range tests {
+		if got := ruleTitle(tt.in); got != tt.want {
+			t.Errorf("ruleTitle(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+
+	// The rule entry uses the generic title; the per-result message keeps the located one.
+	log := buildSARIF(firstPartyFindings(), "v9")
+	var found bool
+	for _, r := range log.Runs[0].Tool.Driver.Rules {
+		if r.ID == "weak-crypto-md5" {
+			found = true
+			if r.ShortDescription.Text != "MD5 is a weak hash" {
+				t.Errorf("rule shortDescription = %q, want stripped", r.ShortDescription.Text)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("weak-crypto-md5 rule not registered")
+	}
+	for _, res := range log.Runs[0].Results {
+		if res.RuleID == "weak-crypto-md5" && res.Message.Text != "MD5 is a weak hash (app/crypto.go:42)" {
+			t.Errorf("result message = %q, want full located title", res.Message.Text)
+		}
+	}
+}
+
+func TestGatedTaintSASTRuleID(t *testing.T) {
+	// A gated E39 taint finding ("sast:ai:<anchor>") gets a stable rule id and no physical location,
+	// rather than leaking the per-finding anchor as the rule id.
+	fs := []finding.Finding{
+		{ID: "t1", Title: "Command injection via tainted flow", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindSAST, DedupKey: "sast:ai:pkg/handler.go.Serve"},
+	}
+	log := buildSARIF(fs, "v9")
+	r := log.Runs[0].Results[0]
+	if r.RuleID != "synapse-taint-sast" {
+		t.Errorf("gated taint rule id = %q, want synapse-taint-sast", r.RuleID)
+	}
+	if len(r.Locations) != 0 {
+		t.Errorf("gated taint finding should carry no location, got %+v", r.Locations)
+	}
+}
+
+func keysOf(m map[string]SARIFResult) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func firstNonNilPhysical(locs []SARIFLocation) *SARIFPhysicalLocation {
+	for i := range locs {
+		if locs[i].PhysicalLocation != nil {
+			return locs[i].PhysicalLocation
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Adds `synapse-cli scan --sarif`, which writes a SARIF 2.1.0 report to stdout for upload to GitHub code scanning.

- Covers every finding kind. SAST, secret and misconfig findings carry a physical `file:line` location so the platform annotates the exact source line; SCA vulnerabilities keep a logical module location.
- `--fail-on` still runs after the emit, so a single invocation both annotates the PR and gates the merge.
- Reuses the existing SARIF builder that backs the API export path (no duplicate exporter). Adds physical-location projection and an exported `MarshalSARIF`. Deterministic and LLM-free, templated purely from stored findings.
- Cannot be combined with `--json`.

## Usage

```yaml
- name: Synapse scan
  run: ./bin/synapse-cli scan . --sarif --fail-on high > synapse.sarif
  continue-on-error: true
- name: Upload SARIF
  if: always()
  uses: github/codeql-action/upload-sarif@v3
  with:
    sarif_file: synapse.sarif
```

## Tests

New `internal/usecase/export/sarif_test.go`: physical-location mapping for SAST/secret/misconfig, logical location for SCA, `firstPartyLoc` parsing (path-with-colon, malformed, zero-line), generic rule shortDescription stripping, gated-taint rule id, and valid-JSON round-trip. Full smoke on a fixture produces valid SARIF with correct locations and exit code.

## Review

go-arch: dependency rule PASS, no blockers or majors. security-auditor: clean (deterministic, LLM-free, no secret leakage into the report). Two minor polishes applied: generic rule-level shortDescription, and a stable rule id for gated taint findings.
