### PR TITLE
fix(sarif): give SCA findings a physical manifest location

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -398,8 +398,10 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		manifestByComp := map[string]string{}
 		if res.SBOM != nil {
 			for _, c := range res.SBOM.Components {
-				// SBOM Location is workspace-rooted with a leading "/" (Syft's dir-scan convention); a
-				// code-scanning UI wants a repo-relative path, so drop the leading slash.
+				// SBOM Location is often workspace-rooted with a leading "/" (Syft's dir-scan convention);
+				// a code-scanning UI wants a repo-relative path, so drop any leading slash (a no-op when
+				// absent). If two components share name@version, last write wins — any declaring manifest
+				// is fine for the annotation.
 				if loc := strings.TrimPrefix(c.Location, "/"); loc != "" {
 					manifestByComp[c.Name+"@"+c.Version] = loc
 				}

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -16,8 +16,10 @@ import (
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/acquire"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/cache/sbomcache"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
@@ -390,9 +392,26 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	case sarifOut:
 		// SARIF 2.1.0 for a code-scanning uploader (e.g. GitHub codeql-action/upload-sarif), to stdout so
 		// nothing else mixes in. Covers every finding kind (SCA/SAST/secret/misconfig); first-party kinds
-		// carry a file:line physical location. The --fail-on gate below still sets the exit code, so the
-		// same run both annotates and gates.
-		out, err := exportuc.MarshalSARIF(res.Findings, res.ToolVersions["synapse"])
+		// carry a file:line physical location. Map each component@version to the manifest it was found in
+		// so SCA findings get a physical location too (GitHub rejects logical-only locations). The
+		// --fail-on gate below still sets the exit code, so the same run both annotates and gates.
+		manifestByComp := map[string]string{}
+		if res.SBOM != nil {
+			for _, c := range res.SBOM.Components {
+				// SBOM Location is workspace-rooted with a leading "/" (Syft's dir-scan convention); a
+				// code-scanning UI wants a repo-relative path, so drop the leading slash.
+				if loc := strings.TrimPrefix(c.Location, "/"); loc != "" {
+					manifestByComp[c.Name+"@"+c.Version] = loc
+				}
+			}
+		}
+		manifestFor := func(f finding.Finding) string {
+			if _, comp, ver, ok := vulnerability.ParseDedupKey(f.DedupKey); ok {
+				return manifestByComp[comp+"@"+ver]
+			}
+			return ""
+		}
+		out, err := exportuc.MarshalSARIF(res.Findings, res.ToolVersions["synapse"], manifestFor)
 		if err != nil {
 			return fmt.Errorf("encode sarif: %w", err)
 		}

--- a/internal/usecase/export/export_test.go
+++ b/internal/usecase/export/export_test.go
@@ -121,7 +121,13 @@ func TestOpenVEXJustificationFromVexJudgment(t *testing.T) {
 }
 
 func TestBuildSARIF(t *testing.T) {
-	log := buildSARIF(sampleFindings(), "v1.2.3")
+	manifests := func(f finding.Finding) string {
+		if f.DedupKey == "vuln:CVE-2020-7471:django:2.2.0" {
+			return "requirements.txt"
+		}
+		return ""
+	}
+	log := buildSARIF(sampleFindings(), "v1.2.3", manifests)
 	if log.Version != "2.1.0" || log.Schema == "" {
 		t.Fatalf("bad header: %+v", log)
 	}

--- a/internal/usecase/export/sarif.go
+++ b/internal/usecase/export/sarif.go
@@ -87,7 +87,7 @@ type SARIFLogicalLocation struct {
 	Kind string `json:"kind,omitempty"`
 }
 
-func buildSARIF(findings []finding.Finding, version string) *SARIFLog {
+func buildSARIF(findings []finding.Finding, version string, manifestFor func(finding.Finding) string) *SARIFLog {
 	rules := make([]SARIFRule, 0)
 	seen := map[string]bool{}
 	results := make([]SARIFResult, 0, len(findings))
@@ -113,10 +113,20 @@ func buildSARIF(findings []finding.Finding, version string) *SARIFLog {
 			// them under one stable rule id rather than leaking the per-finding anchor as the rule id.
 			ruleID = "synapse-taint-sast"
 		} else if p.component != "" {
-			// SCA: the vulnerable dependency is a logical module, not a source line.
-			locations = []SARIFLocation{{
-				LogicalLocations: []SARIFLogicalLocation{{Name: p.component + "@" + p.version, Kind: "module"}},
-			}}
+			// SCA: point at the manifest/lockfile that declares the vulnerable dependency, so a
+			// code-scanning UI annotates it (GitHub rejects a location that has only a logical/module
+			// location). When the manifest is unknown, emit NO location — a result with no location is a
+			// valid repo-level alert, but a logical-only location is not.
+			manifest := ""
+			if manifestFor != nil {
+				manifest = manifestFor(f)
+			}
+			if manifest != "" {
+				locations = []SARIFLocation{{
+					PhysicalLocation: &SARIFPhysicalLocation{ArtifactLocation: SARIFArtifactLocation{URI: manifest}},
+					LogicalLocations: []SARIFLogicalLocation{{Name: p.component + "@" + p.version, Kind: "module"}},
+				}}
+			}
 		}
 
 		level := sarifLevel(f.Severity)
@@ -229,7 +239,9 @@ func ruleTitle(title string) string {
 // MarshalSARIF renders findings as an indented SARIF 2.1.0 log — the artifact a code-scanning
 // uploader (e.g. GitHub `codeql-action/upload-sarif`) consumes. It is deterministic and templated
 // purely from stored findings: no clock, no LLM (golden rule 5). version is the synapse driver
-// version recorded on the run's tool driver.
-func MarshalSARIF(findings []finding.Finding, version string) ([]byte, error) {
-	return json.MarshalIndent(buildSARIF(findings, version), "", "  ")
+// version recorded on the run's tool driver. manifestFor, when non-nil, returns the repo-relative
+// manifest/lockfile path that declares a dependency finding's component so SCA findings get a
+// physical location; return "" when unknown (the finding then becomes a repo-level alert).
+func MarshalSARIF(findings []finding.Finding, version string, manifestFor func(finding.Finding) string) ([]byte, error) {
+	return json.MarshalIndent(buildSARIF(findings, version, manifestFor), "", "  ")
 }

--- a/internal/usecase/export/sarif_test.go
+++ b/internal/usecase/export/sarif_test.go
@@ -19,8 +19,16 @@ func firstPartyFindings() []finding.Finding {
 	}
 }
 
+// demoManifests resolves the sample SCA finding's component to the manifest that declares it.
+func demoManifests(f finding.Finding) string {
+	if f.DedupKey == "vuln:CVE-2020-7471:django:2.2.0" {
+		return "requirements.txt"
+	}
+	return ""
+}
+
 func TestSARIFPhysicalLocationForFirstParty(t *testing.T) {
-	log := buildSARIF(firstPartyFindings(), "v9")
+	log := buildSARIF(firstPartyFindings(), "v9", demoManifests)
 	byRule := map[string]SARIFResult{}
 	for _, r := range log.Runs[0].Results {
 		byRule[r.RuleID] = r
@@ -59,21 +67,45 @@ func TestSARIFPhysicalLocationForFirstParty(t *testing.T) {
 		}
 	}
 
-	// The SCA vuln keeps a logical module location and never a physical one.
+	// The SCA vuln points at the manifest (physical) so a code-scanning UI can annotate it, and keeps
+	// the module as a companion logical location.
 	v, ok := byRule["CVE-2020-7471"]
 	if !ok {
 		t.Fatal("missing SCA result")
 	}
-	if len(v.Locations) != 1 || v.Locations[0].PhysicalLocation != nil {
-		t.Fatalf("SCA finding must not have a physical location: %+v", v.Locations)
+	if len(v.Locations) != 1 || v.Locations[0].PhysicalLocation == nil {
+		t.Fatalf("SCA finding should carry a manifest physical location: %+v", v.Locations)
+	}
+	if v.Locations[0].PhysicalLocation.ArtifactLocation.URI != "requirements.txt" {
+		t.Errorf("SCA manifest uri = %q, want requirements.txt", v.Locations[0].PhysicalLocation.ArtifactLocation.URI)
 	}
 	if v.Locations[0].LogicalLocations[0].Name != "django@2.2.0" {
 		t.Errorf("SCA module location = %+v", v.Locations[0].LogicalLocations)
 	}
 }
 
+// TestSARIFNoLogicalOnlyLocation guards the GitHub-ingestion invariant: a result must never carry a
+// location that has only a logicalLocation (GitHub rejects the whole file with "expected a physical
+// location"). Without a manifest resolver, an SCA finding therefore gets NO location, not a logical-only one.
+func TestSARIFNoLogicalOnlyLocation(t *testing.T) {
+	log := buildSARIF(firstPartyFindings(), "v9", nil) // no manifest resolver
+	for _, r := range log.Runs[0].Results {
+		for _, loc := range r.Locations {
+			if loc.PhysicalLocation == nil {
+				t.Errorf("result %q has a location without a physicalLocation: %+v", r.RuleID, loc)
+			}
+		}
+	}
+	// The SCA finding specifically must end up with zero locations here.
+	for _, r := range log.Runs[0].Results {
+		if r.RuleID == "CVE-2020-7471" && len(r.Locations) != 0 {
+			t.Errorf("SCA finding with no known manifest should have no location, got %+v", r.Locations)
+		}
+	}
+}
+
 func TestMarshalSARIFValidJSON(t *testing.T) {
-	out, err := MarshalSARIF(firstPartyFindings(), "v9")
+	out, err := MarshalSARIF(firstPartyFindings(), "v9", nil)
 	if err != nil {
 		t.Fatalf("MarshalSARIF: %v", err)
 	}
@@ -144,7 +176,7 @@ func TestRuleTitleStripsLocationMarker(t *testing.T) {
 	}
 
 	// The rule entry uses the generic title; the per-result message keeps the located one.
-	log := buildSARIF(firstPartyFindings(), "v9")
+	log := buildSARIF(firstPartyFindings(), "v9", nil)
 	var found bool
 	for _, r := range log.Runs[0].Tool.Driver.Rules {
 		if r.ID == "weak-crypto-md5" {
@@ -170,7 +202,7 @@ func TestGatedTaintSASTRuleID(t *testing.T) {
 	fs := []finding.Finding{
 		{ID: "t1", Title: "Command injection via tainted flow", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindSAST, DedupKey: "sast:ai:pkg/handler.go.Serve"},
 	}
-	log := buildSARIF(fs, "v9")
+	log := buildSARIF(fs, "v9", nil)
 	r := log.Runs[0].Results[0]
 	if r.RuleID != "synapse-taint-sast" {
 		t.Errorf("gated taint rule id = %q, want synapse-taint-sast", r.RuleID)

--- a/internal/usecase/export/service.go
+++ b/internal/usecase/export/service.go
@@ -45,7 +45,9 @@ func (s *Service) SARIF(ctx context.Context, engagementID shared.ID) (*SARIFLog,
 	if err != nil {
 		return nil, err
 	}
-	return buildSARIF(fs, s.version), nil
+	// The store-backed export path has findings only (no SBOM), so no manifest resolver: SCA findings
+	// become repo-level alerts rather than logical-only locations a code-scanning UI would reject.
+	return buildSARIF(fs, s.version, nil), nil
 }
 
 // OpenVEX returns the engagement's vulnerability findings as an OpenVEX document. It


### PR DESCRIPTION
## Problem

Uploading the CLI's `--sarif` output to GitHub code scanning failed with `Code Scanning could not process the submitted SARIF file: expected a physical location` (once per SCA result). GitHub rejects the whole file when any result has a location that carries only a `logicalLocation`. SCA findings were emitted with a module-only logical location, so the upload was rejected. This was pre-existing in the shared SARIF builder (the API export path had the same limitation); it surfaced now that a real repo is mostly SCA findings.

## Fix

`buildSARIF` takes an optional resolver from a dependency finding to the manifest/lockfile that declares its component.

- SCA finding with a known manifest: physical location at that manifest (`requirements.txt`, `package-lock.json`, ...), module kept as a companion logical location.
- SCA finding with an unknown manifest: no location at all (a valid repo-level alert).
- A logical-only location is never emitted again.

The CLI builds the resolver from the scanned SBOM (`component@version` to `Location`) and strips the workspace-root leading slash so paths are repo-relative. The store-backed API export passes no resolver (it has findings, not an SBOM), so its SCA findings degrade to repo-level alerts rather than being rejected.

## Verification

On a demo repo (Dockerfile + weak crypto + vulnerable `requirements.txt`): 50 results, 0 logical-only locations, URIs are repo-relative (`Dockerfile`, `app/crypto.py`, `requirements.txt`). Tests updated + a new `TestSARIFNoLogicalOnlyLocation` guards the invariant.

Follow-up to #50.
