### PR TITLE
feat(sbom): add owned Conda environment parser

### DIFF
--- a/internal/infrastructure/tools/ownsbom/conda.go
+++ b/internal/infrastructure/tools/ownsbom/conda.go
@@ -1,0 +1,232 @@
+package ownsbom
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// Conda is the owned Conda parser: it reads an environment.yml dependencies list into Conda components,
+// plus PyPI components for exact requirements nested under `pip:`. environment.yml is a declaration rather
+// than a solver lock, so plain/ranged Conda entries remain visible without a resolved version. Hand-parsed as
+// a small indented YAML subset, with no third-party YAML or scanner dependency. Components only; edges deferred.
+type Conda struct{}
+
+// Ecosystem identifies this parser's primary package ecosystem.
+func (Conda) Ecosystem() string { return "conda" }
+
+// Markers are the conventional Conda environment manifest basenames.
+func (Conda) Markers() []string { return []string{"environment.yml", "environment.yaml"} }
+
+// Parse extracts direct Conda dependencies and exact pip pins nested below a `- pip:` entry.
+func (Conda) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	scope := sbom.ClassifyScope(in.Path, "")
+	seen := map[string]bool{}
+	var comps []sbom.Component
+	add := func(c sbom.Component) {
+		if c.Name == "" || c.PURL == "" || seen[c.PURL] {
+			return
+		}
+		seen[c.PURL] = true
+		comps = append(comps, c)
+	}
+
+	inDependencies := false
+	inPip := false
+	dependencyIndent := -1
+	pipIndent := -1
+	sc := bufio.NewScanner(bytes.NewReader(in.Content))
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+	for sc.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		raw := stripYAMLComment(sc.Text())
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		indent := leadingIndent(raw)
+		if !inDependencies {
+			if indent == 0 && trimmed == "dependencies:" {
+				inDependencies = true
+			}
+			continue
+		}
+		if indent == 0 && !strings.HasPrefix(trimmed, "-") {
+			break // the next top-level key ends dependencies; an indentationless sequence item remains valid YAML
+		}
+		if !strings.HasPrefix(trimmed, "-") {
+			continue
+		}
+
+		if dependencyIndent < 0 {
+			dependencyIndent = indent
+		}
+		if inPip && indent > pipIndent {
+			if c, ok := pipComponent(yamlListScalar(trimmed), in.Path, scope); ok {
+				add(c)
+			}
+			continue
+		}
+		if inPip && indent <= pipIndent {
+			inPip = false
+		}
+		if indent != dependencyIndent {
+			continue
+		}
+
+		spec := yamlListScalar(trimmed)
+		if spec == "pip:" {
+			inPip = true
+			pipIndent = indent
+			continue
+		}
+		if c, ok := condaComponent(spec, in.Path, scope); ok {
+			add(c)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, nil, fmt.Errorf("scan environment.yml: %w", err)
+	}
+	sort.Slice(comps, func(i, j int) bool { return comps[i].PURL < comps[j].PURL })
+	return comps, nil, nil
+}
+
+func condaComponent(spec, location, scope string) (sbom.Component, bool) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" || strings.ContainsAny(spec, "{}[]") {
+		return sbom.Component{}, false
+	}
+	channel := ""
+	if before, after, ok := strings.Cut(spec, "::"); ok {
+		channel, spec = normalizeCondaQualifier(before), strings.TrimSpace(after)
+		if channel == "" || strings.Contains(spec, "::") {
+			return sbom.Component{}, false
+		}
+	}
+	nameEnd := strings.IndexAny(spec, "=<>!~")
+	if nameEnd < 0 {
+		name := normalizeCondaName(spec)
+		return unresolvedConda(name, channel, location, scope)
+	}
+	name := normalizeCondaName(spec[:nameEnd])
+	if name == "" {
+		return sbom.Component{}, false
+	}
+	if spec[nameEnd] != '=' || strings.ContainsAny(spec[nameEnd:], "<>!~") {
+		return unresolvedConda(name, channel, location, scope)
+	}
+
+	rest := strings.TrimSpace(spec[nameEnd+1:])
+	if strings.HasPrefix(rest, "=") { // tolerate Conda's exact `name==version` form
+		rest = strings.TrimSpace(rest[1:])
+	}
+	parts := strings.SplitN(rest, "=", 2)
+	version := strings.TrimSpace(parts[0])
+	if !sbom.IsResolvedVersion(version) || strings.ContainsAny(version, "*?,| \t") {
+		return unresolvedConda(name, channel, location, scope)
+	}
+	purl := "pkg:conda/" + name + "@" + version
+	qualifiers := make([]string, 0, 2)
+	if len(parts) == 2 {
+		build := normalizeCondaQualifier(parts[1])
+		if build == "" || strings.Contains(parts[1], "=") {
+			return sbom.Component{}, false
+		}
+		qualifiers = append(qualifiers, "build="+url.QueryEscape(build))
+	}
+	if channel != "" {
+		qualifiers = append(qualifiers, "channel="+url.QueryEscape(channel))
+	}
+	if len(qualifiers) > 0 {
+		purl += "?" + strings.Join(qualifiers, "&")
+	}
+	return sbom.Component{Name: name, Version: version, PURL: purl, Location: location, Scope: scope}, true
+}
+
+func unresolvedConda(name, channel, location, scope string) (sbom.Component, bool) {
+	if name == "" {
+		return sbom.Component{}, false
+	}
+	purl := "pkg:conda/" + name
+	if channel != "" {
+		purl += "?channel=" + url.QueryEscape(channel)
+	}
+	return sbom.Component{Name: name, PURL: purl, Location: location, Scope: scope}, true
+}
+
+func normalizeCondaName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" || strings.ContainsAny(name, " /\\:@#?") {
+		return ""
+	}
+	return name
+}
+
+func normalizeCondaQualifier(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.ContainsAny(value, " /\\:@#?&=") {
+		return ""
+	}
+	return value
+}
+
+func pipComponent(spec, location, scope string) (sbom.Component, bool) {
+	if i := strings.IndexByte(spec, ';'); i >= 0 {
+		spec = strings.TrimSpace(spec[:i])
+	}
+	eq := strings.Index(spec, "==")
+	if eq < 0 {
+		return sbom.Component{}, false
+	}
+	name := strings.TrimSpace(spec[:eq])
+	if b := strings.IndexByte(name, '['); b >= 0 {
+		name = strings.TrimSpace(name[:b])
+	}
+	version := strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(spec[eq+2:]), "="))
+	if j := strings.IndexAny(version, " \t,"); j >= 0 {
+		version = version[:j]
+	}
+	if name == "" || !sbom.IsResolvedVersion(version) {
+		return sbom.Component{}, false
+	}
+	name = normalizePyPI(name)
+	return sbom.Component{Name: name, Version: version, PURL: "pkg:pypi/" + name + "@" + version, Location: location, Scope: scope}, true
+}
+
+func yamlListScalar(line string) string {
+	scalar := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "-"))
+	if len(scalar) >= 2 && ((scalar[0] == '"' && scalar[len(scalar)-1] == '"') || (scalar[0] == '\'' && scalar[len(scalar)-1] == '\'')) {
+		return strings.TrimSpace(scalar[1 : len(scalar)-1])
+	}
+	return scalar
+}
+
+func stripYAMLComment(line string) string {
+	var quote byte
+	for i := 0; i < len(line); i++ {
+		switch line[i] {
+		case '\'', '"':
+			if quote == 0 {
+				quote = line[i]
+			} else if quote == line[i] && (line[i] == '\'' || i == 0 || line[i-1] != '\\') {
+				quote = 0
+			}
+		case '#':
+			if quote == 0 && (i == 0 || line[i-1] == ' ' || line[i-1] == '\t') {
+				return strings.TrimRight(line[:i], " \t")
+			}
+		}
+	}
+	return line
+}

--- a/internal/infrastructure/tools/ownsbom/conda_test.go
+++ b/internal/infrastructure/tools/ownsbom/conda_test.go
@@ -1,0 +1,166 @@
+package ownsbom
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+func TestCondaParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name: "conda and nested pip dependencies",
+			content: `name: test
+
+dependencies:
+  - numpy
+  - "python=3.11.9" # declared version
+  - openssl=3.2.1=h5eee18b_1
+  - pip:
+      - Requests_Pkg==2.32.3
+      - urllib3
+  - zlib=1.3.1
+variables:
+  NOT_A_DEPENDENCY: ghost=9.9.9
+`,
+			want: []string{
+				"pkg:conda/numpy",
+				"pkg:conda/openssl@3.2.1?build=h5eee18b_1",
+				"pkg:conda/python@3.11.9",
+				"pkg:conda/zlib@1.3.1",
+				"pkg:pypi/requests-pkg@2.32.3",
+			},
+		},
+		{
+			name: "compact pip indentation",
+			content: `dependencies:
+  - pip:
+    - flask==2.3.3
+  - click=8.1.7
+`,
+			want: []string{"pkg:conda/click@8.1.7", "pkg:pypi/flask@2.3.3"},
+		},
+		{
+			name: "indentationless sequence",
+			content: `dependencies:
+- numpy
+- python=3.11
+- pip:
+  - requests==2.32.3
+`,
+			want: []string{"pkg:conda/numpy", "pkg:conda/python@3.11", "pkg:pypi/requests@2.32.3"},
+		},
+		{
+			name: "channel qualified dependency",
+			content: `dependencies:
+  - conda-forge::numpy=1.26.4=py312_0
+`,
+			want: []string{"pkg:conda/numpy@1.26.4?build=py312_0&channel=conda-forge"},
+		},
+		{
+			name:    "no dependencies block",
+			content: "name: empty\nchannels:\n  - conda-forge\n",
+		},
+		{
+			name: "ranges remain unresolved and deduplicate",
+			content: `dependencies:
+  - numpy>=1.26
+  - numpy=1.26.*
+  - numpy
+`,
+			want: []string{"pkg:conda/numpy"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comps, deps, err := Conda{}.Parse(context.Background(), ParseInput{Path: "environment.yml", Content: []byte(tt.content)})
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if deps != nil {
+				t.Errorf("edges deferred; want nil deps, got %v", deps)
+			}
+			if len(comps) != len(tt.want) {
+				t.Fatalf("components = %+v, want PURLs %v", comps, tt.want)
+			}
+			for i, wantPURL := range tt.want {
+				if comps[i].PURL != wantPURL {
+					t.Errorf("component[%d].PURL = %q, want %q", i, comps[i].PURL, wantPURL)
+				}
+				if comps[i].Location != "environment.yml" || comps[i].Scope != sbom.ScopeProduction {
+					t.Errorf("component[%d] scope/location = %q/%q, want production/environment.yml", i, comps[i].Scope, comps[i].Location)
+				}
+			}
+			if tt.name == "conda and nested pip dependencies" {
+				if comps[0].Name != "numpy" || comps[0].Version != "" {
+					t.Errorf("plain dependency = %+v, want unresolved numpy", comps[0])
+				}
+				if comps[1].Name != "openssl" || comps[1].Version != "3.2.1" {
+					t.Errorf("build-qualified dependency = %+v, want openssl 3.2.1", comps[1])
+				}
+				if comps[4].Name != "requests-pkg" || comps[4].Version != "2.32.3" {
+					t.Errorf("nested pip dependency = %+v, want requests-pkg 2.32.3", comps[4])
+				}
+			}
+		})
+	}
+}
+
+func TestCondaMetadata(t *testing.T) {
+	if got := (Conda{}).Ecosystem(); got != "conda" {
+		t.Fatalf("Ecosystem = %q, want conda", got)
+	}
+	markers := (Conda{}).Markers()
+	if len(markers) != 2 || markers[0] != "environment.yml" || markers[1] != "environment.yaml" {
+		t.Fatalf("Markers = %v, want [environment.yml environment.yaml]", markers)
+	}
+}
+
+func TestCondaParseContextAndScannerErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err := (Conda{}).Parse(ctx, ParseInput{Content: []byte("dependencies:\n  - numpy\n")}); err == nil {
+		t.Fatal("Parse with canceled context returned nil error")
+	}
+
+	oversizedLine := "dependencies:\n  - package=" + strings.Repeat("1", (4<<20)+1)
+	if _, _, err := (Conda{}).Parse(context.Background(), ParseInput{Content: []byte(oversizedLine)}); err == nil {
+		t.Fatal("Parse with an overlong line returned nil error")
+	}
+}
+
+func TestCondaRegistryGenerate(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "environment.yml"), `dependencies:
+  - numpy
+  - pandas=2.2.2=py312_0
+  - pip:
+    - flask==3.0.3
+`)
+
+	reg, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	got, err := reg.Generate(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	want := []string{"pkg:conda/numpy", "pkg:conda/pandas@2.2.2?build=py312_0", "pkg:pypi/flask@3.0.3"}
+	if len(got.Components) != len(want) {
+		t.Fatalf("components = %+v, want PURLs %v", got.Components, want)
+	}
+	for i, wantPURL := range want {
+		if got.Components[i].PURL != wantPURL {
+			t.Errorf("component[%d].PURL = %q, want %q", i, got.Components[i].PURL, wantPURL)
+		}
+	}
+}

--- a/internal/infrastructure/tools/ownsbom/default_test.go
+++ b/internal/infrastructure/tools/ownsbom/default_test.go
@@ -10,15 +10,15 @@ func TestDefaultRegistry(t *testing.T) {
 		t.Fatalf("DefaultRegistry: %v", err)
 	}
 	for _, marker := range []string{
-		"go.mod", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "requirements.txt", "requirements-dev.txt", "poetry.lock", "pipfile.lock", "cargo.lock", "pom.xml", "libs.versions.toml", "gemfile.lock", "composer.lock", "packages.lock.json", "package.resolved", "pubspec.lock", "mix.lock",
+		"go.mod", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "requirements.txt", "requirements-dev.txt", "poetry.lock", "pipfile.lock", "cargo.lock", "pom.xml", "libs.versions.toml", "gemfile.lock", "composer.lock", "packages.lock.json", "package.resolved", "pubspec.lock", "mix.lock", "environment.yml", "environment.yaml",
 	} {
 		if _, ok := reg.byMarker[marker]; !ok {
 			t.Errorf("DefaultRegistry missing marker %q", marker)
 		}
 	}
-	// yarn + pnpm share the npm ecosystem, Pipfile shares pypi, Gradle shares maven, so the distinct set is
-	// cargo/composer/gem/go/hex/maven/npm/nuget/pub/pypi/swift (sorted) — unchanged by the new parsers.
-	want := []string{"cargo", "composer", "gem", "go", "hex", "maven", "npm", "nuget", "pub", "pypi", "swift"}
+	// yarn + pnpm share the npm ecosystem, Pipfile shares pypi, and Gradle shares maven, so the distinct
+	// ecosystem set contains each shared PURL type only once.
+	want := []string{"cargo", "composer", "conda", "gem", "go", "hex", "maven", "npm", "nuget", "pub", "pypi", "swift"}
 	if len(reg.ecos) != len(want) {
 		t.Fatalf("DefaultRegistry ecosystems = %v, want %v", reg.ecos, want)
 	}

--- a/internal/infrastructure/tools/ownsbom/registry.go
+++ b/internal/infrastructure/tools/ownsbom/registry.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// ownsbomVersion identifies this producer in SBOM provenance. Bump when parser behavior changes.
-	ownsbomVersion = "ownsbom/0.1.0"
+	ownsbomVersion = "ownsbom/0.2.0"
 	// maxManifestBytes caps a single manifest read so a hostile/corrupt repo cannot OOM the scan with an
 	// absurd file. Real manifests are KB–low-MB; exceeding this is malicious or wrong, so it fails loud.
 	maxManifestBytes = 64 << 20
@@ -88,11 +88,11 @@ func New(parsers ...EcosystemParser) (*Registry, error) {
 	return r, nil
 }
 
-// DefaultRegistry assembles the owned parsers into a producer covering Go, JS (npm + yarn), Python, Rust,
-// and Java (Maven pom.xml + Gradle libs.versions.toml) — the detection-independent SBOM producer.
+// DefaultRegistry assembles the owned parsers into a producer covering Go, JS (npm + yarn), Python, Conda,
+// Rust, and Java (Maven pom.xml + Gradle libs.versions.toml) — the detection-independent SBOM producer.
 // The parsers claim distinct markers, so New does not error here in practice.
 func DefaultRegistry() (*Registry, error) {
-	return New(GoMod{}, NPM{}, Yarn{}, Pnpm{}, PyPI{}, Poetry{}, Pipfile{}, Cargo{}, Maven{}, Gradle{}, Gem{}, Composer{}, NuGet{}, Swift{}, Dart{}, Elixir{})
+	return New(GoMod{}, NPM{}, Yarn{}, Pnpm{}, PyPI{}, Poetry{}, Pipfile{}, Cargo{}, Maven{}, Gradle{}, Gem{}, Composer{}, NuGet{}, Swift{}, Dart{}, Elixir{}, Conda{})
 }
 
 // Generate walks the target directory, parses every recognized manifest with its EcosystemParser, and


### PR DESCRIPTION
## Summary

Adds a first-party Conda `environment.yml` parser to the owned SBOM registry, closing the Conda coverage gap described in #53.

Conda projects no longer need to rely exclusively on Syft for dependency detection. The parser reads the manifest directly in pure Go and emits:

- `pkg:conda` components for entries under `dependencies:`
- `pkg:pypi` components for exact requirements under a nested `pip:` block

The implementation intentionally supports unresolved declarations such as `numpy` without inventing a version, while preserving resolved Conda artifact information from `name=version=build` entries.

Closes #53.

## Changes

- Add a pure-Go, indentation-aware parser for:
  - `environment.yml`
  - `environment.yaml`
- Parse common Conda dependency forms:
  - `numpy` → `pkg:conda/numpy`
  - `python=3.11.9` → `pkg:conda/python@3.11.9`
  - `openssl=3.2.1=h5eee18b_1` → `pkg:conda/openssl@3.2.1?build=h5eee18b_1`
  - `conda-forge::numpy=1.26.4=py312_0` → `pkg:conda/numpy@1.26.4?build=py312_0&channel=conda-forge`
- Parse exact dependencies from nested `pip:` blocks:
  - `Requests_Pkg==2.32.3` → `pkg:pypi/requests-pkg@2.32.3`
- Preserve plain, ranged, and wildcard Conda declarations as unresolved name-only components instead of assigning misleading versions.
- Support:
  - quoted dependency values
  - trailing YAML comments
  - standard and indentationless YAML sequences
  - common nested-pip indentation styles
  - leaving the pip block when direct Conda dependencies resume
- Normalize nested pip package names using the existing PyPI normalization logic.
- Deduplicate components by PURL and sort output for deterministic SBOM generation.
- Preserve component source location and classified dependency scope.
- Register the parser in `DefaultRegistry`.
- Add both Conda manifest names to the default marker set.
- Bump the owned SBOM producer version to `ownsbom/0.2.0`.
- Add no new module or third-party YAML dependency.

## Why the parser uses local deduplication

The shared `componentSet` intentionally rejects components without a resolved version. Conda environment manifests commonly contain plain declarations such as:

```yaml
dependencies:
  - numpy
```

Dropping those entries would under-report the project inventory. The Conda parser therefore deduplicates locally by PURL, allowing it to retain:

```text
pkg:conda/numpy
```

with an empty version rather than silently omitting the dependency or manufacturing a resolved version.

## Testing

Added table-driven parser coverage for:

- plain Conda dependencies
- pinned `name=version` dependencies
- build-qualified `name=version=build` dependencies
- channel-qualified dependencies
- nested exact pip requirements
- PyPI package-name normalization
- quoted values and trailing comments
- standard and compact pip indentation
- indentationless YAML sequences
- transition from pip entries back to Conda entries
- unresolved ranges and wildcards
- component deduplication
- manifests without a `dependencies:` block
- component scope and source location
- nil dependency edges
- parser metadata and both manifest markers
- canceled contexts
- oversized scanner input
- end-to-end dispatch through `DefaultRegistry().Generate`

Focused parser and registry tests pass:

```text
=== RUN   TestCondaParse
=== RUN   TestCondaParse/conda_and_nested_pip_dependencies
=== RUN   TestCondaParse/compact_pip_indentation
=== RUN   TestCondaParse/indentationless_sequence
=== RUN   TestCondaParse/channel_qualified_dependency
=== RUN   TestCondaParse/no_dependencies_block
=== RUN   TestCondaParse/ranges_remain_unresolved_and_deduplicate
--- PASS: TestCondaParse
--- PASS: TestCondaMetadata
--- PASS: TestCondaParseContextAndScannerErrors
--- PASS: TestCondaRegistryGenerate
--- PASS: TestDefaultRegistry
PASS
ok github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownsbom
```

The registry integration test verifies that this manifest:

```yaml
dependencies:
  - numpy
  - pandas=2.2.2=py312_0
  - pip:
    - flask==3.0.3
```

produces exactly:

```text
pkg:conda/numpy
pkg:conda/pandas@2.2.2?build=py312_0
pkg:pypi/flask@3.0.3
```

A post-review sample also verifies channel and ecosystem handling:

```yaml
dependencies:
- numpy
- conda-forge::pandas=2.2.2=py312_0
- pip:
  - Requests_Pkg==2.32.3
```

Expected component identities:

```text
pkg:conda/numpy
pkg:conda/pandas@2.2.2?build=py312_0&channel=conda-forge
pkg:pypi/requests-pkg@2.32.3
```

The following source-change checks also pass for the Linux target used by CI:

```text
GOOS=linux GOARCH=amd64 go build ./cmd/...
GOOS=linux GOARCH=amd64 go vet ./...
```

No changes were made to `go.mod` or `go.sum`.

## Safety and scope

This is an additive parser-only change under `internal/infrastructure/tools/ownsbom`.

It does not change:

- command execution or argv handling
- server-side authorization or scope enforcement
- secret handling or logging
- evidence storage
- report generation
- Syft behavior
- advisory matching
- CLI or API behavior
- domain types

The parser uses a bounded scanner, checks context cancellation, returns scanner failures instead of silently truncating input, and produces deterministically sorted components.

## Checklist

- [x] Go build and vet pass for the Linux target used by CI
- [x] Focused parser and default-registry tests pass
- [x] Tests added/updated for new behavior
- [x] Sample `environment.yml` produces the expected Conda and PyPI components
- [x] No new dependency added; parsing uses only the Go standard library
- [x] Dashboard unchanged; `cd web && pnpm build` is not applicable
- [x] Preserves the safety invariants described in `CONTRIBUTING.md`
- [x] Documentation changes are not required for this parser-only addition