### PR TITLE
feat(sarif): show the fixed version on SCA results

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -413,7 +413,17 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 			}
 			return ""
 		}
-		out, err := exportuc.MarshalSARIF(res.Findings, res.ToolVersions["synapse"], manifestFor)
+		// Map each vulnerability's dedup key to its fixed version so a code-scanning alert shows the
+		// remediation. Keyed by the same dedup key the finding carries (advisory + component + version),
+		// because different advisories on the same component are fixed in different releases.
+		fixByKey := map[string]string{}
+		for _, v := range res.Vulnerabilities {
+			if v.FixedVersion != "" {
+				fixByKey[vulnerability.DedupKey(v.ID, v.Component, v.Version)] = v.FixedVersion
+			}
+		}
+		fixFor := func(f finding.Finding) string { return fixByKey[f.DedupKey] }
+		out, err := exportuc.MarshalSARIF(res.Findings, res.ToolVersions["synapse"], exportuc.SARIFOptions{Manifest: manifestFor, Fix: fixFor})
 		if err != nil {
 			return fmt.Errorf("encode sarif: %w", err)
 		}

--- a/internal/usecase/export/export_test.go
+++ b/internal/usecase/export/export_test.go
@@ -127,7 +127,7 @@ func TestBuildSARIF(t *testing.T) {
 		}
 		return ""
 	}
-	log := buildSARIF(sampleFindings(), "v1.2.3", manifests)
+	log := buildSARIF(sampleFindings(), "v1.2.3", SARIFOptions{Manifest: manifests})
 	if log.Version != "2.1.0" || log.Schema == "" {
 		t.Fatalf("bad header: %+v", log)
 	}

--- a/internal/usecase/export/sarif.go
+++ b/internal/usecase/export/sarif.go
@@ -172,8 +172,9 @@ func buildSARIF(findings []finding.Finding, version string, opts SARIFOptions) *
 			// consumer separate/deprioritize deps the app never references (priority already reflects it).
 			res.Properties["componentReachability"] = f.ClassReachability
 		}
-		if opts.Fix != nil {
-			// The version that remediates a dependency finding, surfaced both as a property and inline in the
+		if p.component != "" && opts.Fix != nil {
+			// Only dependency (SCA) findings have a fix version; the p.component gate makes that structural
+			// rather than relying on the resolver returning "". Surface it as a property and inline in the
 			// message so a code-scanning alert shows the fix without opening the finding.
 			if fix := opts.Fix(f); fix != "" {
 				res.Properties["fixedVersion"] = fix

--- a/internal/usecase/export/sarif.go
+++ b/internal/usecase/export/sarif.go
@@ -87,7 +87,16 @@ type SARIFLogicalLocation struct {
 	Kind string `json:"kind,omitempty"`
 }
 
-func buildSARIF(findings []finding.Finding, version string, manifestFor func(finding.Finding) string) *SARIFLog {
+// SARIFOptions carries optional per-finding resolvers that enrich SCA results. Both fields are nil-safe.
+type SARIFOptions struct {
+	// Manifest returns the repo-relative manifest/lockfile that declares a dependency finding's
+	// component, so the result gets a physical location a code-scanning UI can annotate. "" when unknown.
+	Manifest func(finding.Finding) string
+	// Fix returns the version that remediates a dependency finding. "" when there is no fix or it is unknown.
+	Fix func(finding.Finding) string
+}
+
+func buildSARIF(findings []finding.Finding, version string, opts SARIFOptions) *SARIFLog {
 	rules := make([]SARIFRule, 0)
 	seen := map[string]bool{}
 	results := make([]SARIFResult, 0, len(findings))
@@ -118,8 +127,8 @@ func buildSARIF(findings []finding.Finding, version string, manifestFor func(fin
 			// location). When the manifest is unknown, emit NO location — a result with no location is a
 			// valid repo-level alert, but a logical-only location is not.
 			manifest := ""
-			if manifestFor != nil {
-				manifest = manifestFor(f)
+			if opts.Manifest != nil {
+				manifest = opts.Manifest(f)
 			}
 			if manifest != "" {
 				locations = []SARIFLocation{{
@@ -162,6 +171,14 @@ func buildSARIF(findings []finding.Finding, version string, manifestFor func(fin
 			// Coarse JVM class-reachability: "reachable" | "unreferenced". Advisory — lets a
 			// consumer separate/deprioritize deps the app never references (priority already reflects it).
 			res.Properties["componentReachability"] = f.ClassReachability
+		}
+		if opts.Fix != nil {
+			// The version that remediates a dependency finding, surfaced both as a property and inline in the
+			// message so a code-scanning alert shows the fix without opening the finding.
+			if fix := opts.Fix(f); fix != "" {
+				res.Properties["fixedVersion"] = fix
+				res.Message.Text = f.Title + " (fixed in " + fix + ")"
+			}
 		}
 		results = append(results, res)
 	}
@@ -239,9 +256,9 @@ func ruleTitle(title string) string {
 // MarshalSARIF renders findings as an indented SARIF 2.1.0 log — the artifact a code-scanning
 // uploader (e.g. GitHub `codeql-action/upload-sarif`) consumes. It is deterministic and templated
 // purely from stored findings: no clock, no LLM (golden rule 5). version is the synapse driver
-// version recorded on the run's tool driver. manifestFor, when non-nil, returns the repo-relative
-// manifest/lockfile path that declares a dependency finding's component so SCA findings get a
-// physical location; return "" when unknown (the finding then becomes a repo-level alert).
-func MarshalSARIF(findings []finding.Finding, version string, manifestFor func(finding.Finding) string) ([]byte, error) {
-	return json.MarshalIndent(buildSARIF(findings, version, manifestFor), "", "  ")
+// version recorded on the run's tool driver. opts carries optional per-finding resolvers: Manifest gives
+// SCA findings a physical location (a repo-relative manifest path), and Fix adds the remediating version.
+// Both are nil-safe; pass the zero SARIFOptions to enrich nothing.
+func MarshalSARIF(findings []finding.Finding, version string, opts SARIFOptions) ([]byte, error) {
+	return json.MarshalIndent(buildSARIF(findings, version, opts), "", "  ")
 }

--- a/internal/usecase/export/sarif_test.go
+++ b/internal/usecase/export/sarif_test.go
@@ -28,7 +28,7 @@ func demoManifests(f finding.Finding) string {
 }
 
 func TestSARIFPhysicalLocationForFirstParty(t *testing.T) {
-	log := buildSARIF(firstPartyFindings(), "v9", demoManifests)
+	log := buildSARIF(firstPartyFindings(), "v9", SARIFOptions{Manifest: demoManifests})
 	byRule := map[string]SARIFResult{}
 	for _, r := range log.Runs[0].Results {
 		byRule[r.RuleID] = r
@@ -88,7 +88,7 @@ func TestSARIFPhysicalLocationForFirstParty(t *testing.T) {
 // location that has only a logicalLocation (GitHub rejects the whole file with "expected a physical
 // location"). Without a manifest resolver, an SCA finding therefore gets NO location, not a logical-only one.
 func TestSARIFNoLogicalOnlyLocation(t *testing.T) {
-	log := buildSARIF(firstPartyFindings(), "v9", nil) // no manifest resolver
+	log := buildSARIF(firstPartyFindings(), "v9", SARIFOptions{}) // no manifest resolver
 	for _, r := range log.Runs[0].Results {
 		for _, loc := range r.Locations {
 			if loc.PhysicalLocation == nil {
@@ -105,7 +105,7 @@ func TestSARIFNoLogicalOnlyLocation(t *testing.T) {
 }
 
 func TestMarshalSARIFValidJSON(t *testing.T) {
-	out, err := MarshalSARIF(firstPartyFindings(), "v9", nil)
+	out, err := MarshalSARIF(firstPartyFindings(), "v9", SARIFOptions{})
 	if err != nil {
 		t.Fatalf("MarshalSARIF: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestRuleTitleStripsLocationMarker(t *testing.T) {
 	}
 
 	// The rule entry uses the generic title; the per-result message keeps the located one.
-	log := buildSARIF(firstPartyFindings(), "v9", nil)
+	log := buildSARIF(firstPartyFindings(), "v9", SARIFOptions{})
 	var found bool
 	for _, r := range log.Runs[0].Tool.Driver.Rules {
 		if r.ID == "weak-crypto-md5" {
@@ -202,13 +202,53 @@ func TestGatedTaintSASTRuleID(t *testing.T) {
 	fs := []finding.Finding{
 		{ID: "t1", Title: "Command injection via tainted flow", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindSAST, DedupKey: "sast:ai:pkg/handler.go.Serve"},
 	}
-	log := buildSARIF(fs, "v9", nil)
+	log := buildSARIF(fs, "v9", SARIFOptions{})
 	r := log.Runs[0].Results[0]
 	if r.RuleID != "synapse-taint-sast" {
 		t.Errorf("gated taint rule id = %q, want synapse-taint-sast", r.RuleID)
 	}
 	if len(r.Locations) != 0 {
 		t.Errorf("gated taint finding should carry no location, got %+v", r.Locations)
+	}
+}
+
+func TestSARIFFixedVersion(t *testing.T) {
+	fix := func(f finding.Finding) string {
+		if f.DedupKey == "vuln:CVE-2020-7471:django:2.2.0" {
+			return "3.9.1"
+		}
+		return "" // the first-party findings have no fix
+	}
+	log := buildSARIF(firstPartyFindings(), "v9", SARIFOptions{Fix: fix})
+	byRule := map[string]SARIFResult{}
+	for _, r := range log.Runs[0].Results {
+		byRule[r.RuleID] = r
+	}
+
+	// The SCA vuln with a known fix carries it as a property and inline in the message.
+	v := byRule["CVE-2020-7471"]
+	if v.Properties["fixedVersion"] != "3.9.1" {
+		t.Errorf("fixedVersion property = %v, want 3.9.1", v.Properties["fixedVersion"])
+	}
+	if v.Message.Text != "CVE-2020-7471 in django@2.2.0 (fixed in 3.9.1)" {
+		t.Errorf("message = %q, want the fix appended", v.Message.Text)
+	}
+
+	// A finding with no fix must not carry a fixedVersion property or a mangled message.
+	sast := byRule["weak-crypto-md5"]
+	if _, ok := sast.Properties["fixedVersion"]; ok {
+		t.Errorf("non-fixable finding should not carry fixedVersion: %+v", sast.Properties)
+	}
+	if sast.Message.Text != "MD5 is a weak hash (app/crypto.go:42)" {
+		t.Errorf("non-fixable message must be unchanged, got %q", sast.Message.Text)
+	}
+
+	// With no Fix resolver, nothing is enriched.
+	plain := buildSARIF(firstPartyFindings(), "v9", SARIFOptions{})
+	for _, r := range plain.Runs[0].Results {
+		if _, ok := r.Properties["fixedVersion"]; ok {
+			t.Errorf("no Fix resolver, but result %q carries fixedVersion", r.RuleID)
+		}
 	}
 }
 

--- a/internal/usecase/export/service.go
+++ b/internal/usecase/export/service.go
@@ -45,9 +45,10 @@ func (s *Service) SARIF(ctx context.Context, engagementID shared.ID) (*SARIFLog,
 	if err != nil {
 		return nil, err
 	}
-	// The store-backed export path has findings only (no SBOM), so no manifest resolver: SCA findings
-	// become repo-level alerts rather than logical-only locations a code-scanning UI would reject.
-	return buildSARIF(fs, s.version, nil), nil
+	// The store-backed export path has findings only (no SBOM), so no resolvers: SCA findings become
+	// repo-level alerts rather than logical-only locations a code-scanning UI would reject, and carry no
+	// inline fix version.
+	return buildSARIF(fs, s.version, SARIFOptions{}), nil
 }
 
 // OpenVEX returns the engagement's vulnerability findings as an OpenVEX document. It


### PR DESCRIPTION
Closes #56.

## What

A GitHub code-scanning alert for a dependency vulnerability now shows the version that fixes it, so a reviewer sees the remediation without opening the finding.

- `fixedVersion` result property (machine-readable).
- Inline in the message: `CVE-2020-7471 in django@2.2.0 (fixed in 2.2.10)`.

## How

`buildSARIF` / `MarshalSARIF` now take a `SARIFOptions` struct that carries the optional per-finding resolvers. This folds the existing manifest resolver and the new fix resolver into one nil-safe value instead of a growing list of same-typed function parameters.

The CLI builds the fix resolver from `res.Vulnerabilities`, keyed by the finding dedup key (`advisory:component:version`) via `vulnerability.DedupKey`, because different advisories on the same component are fixed in different releases. The store-backed API export passes the zero `SARIFOptions` (findings only, no vulnerability list). Deterministic and free of any LLM.

## Verified end to end

Built the CLI and ran `scan --sarif` on a repo with a vulnerable `requirements.txt`: 50 results, 43 SCA alerts carry the correct per-CVE `fixedVersion` and an inline `(fixed in X)` message, and the SAST/misconfig results correctly carry no fix. Tests updated plus a new `TestSARIFFixedVersion`; build, vet, and the export suite (including the golden-rule-5 no-LLM tripwire) are green.
