### PR TITLE
feat(misconfig): add CloudFormation template scanning

### DIFF
--- a/internal/infrastructure/tools/misconfig/cloudformation.go
+++ b/internal/infrastructure/tools/misconfig/cloudformation.go
@@ -1,0 +1,203 @@
+package misconfig
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// cfnSecretKeyRe matches property names that conventionally hold a secret. Only the KEY is ever emitted
+// in a finding, never the value (golden-rule-3: a scanner must not copy a secret into its output).
+var cfnSecretKeyRe = regexp.MustCompile(`(?i)(password|secret|token|api[_-]?key|access[_-]?key|private[_-]?key)`)
+
+// scanCloudFormation parses an AWS CloudFormation template (YAML or JSON, both of which are valid YAML)
+// and flags insecure resource settings. It walks the resource tree via yaml.Node so CloudFormation
+// short-form intrinsics (!Ref, !Sub, !GetAtt, ...) are tolerated: a tagged scalar keeps its value and
+// simply does not match a literal check. Best-effort: a parse error or an unexpected shape is a per-file
+// skip, never a scan failure.
+func scanCloudFormation(rel string, data []byte) []ports.MisconfigRawFinding {
+	// Refuse pathologically deep documents before decoding, matching the Kubernetes path: yaml.v3 recurses
+	// per nesting level with no depth cap, so a crafted deep document would overflow the goroutine stack.
+	if maxFlowDepth(data) > maxNestDepth {
+		return nil
+	}
+	var root yaml.Node
+	if err := yaml.NewDecoder(bytes.NewReader(data)).Decode(&root); err != nil {
+		return nil // empty or malformed: skip this file
+	}
+	doc := documentRoot(&root)
+	resources := mapValue(doc, "Resources")
+	if resources == nil || resources.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	var out []ports.MisconfigRawFinding
+	for i := 0; i+1 < len(resources.Content); i += 2 {
+		logicalID := resources.Content[i].Value
+		res := resources.Content[i+1]
+		if res.Kind != yaml.MappingNode {
+			continue
+		}
+		typeNode := mapValue(res, "Type")
+		if typeNode == nil || typeNode.Kind != yaml.ScalarNode {
+			continue
+		}
+		out = append(out, cfnResourceRules(rel, res.Line, logicalID, typeNode.Value, mapValue(res, "Properties"))...)
+	}
+	return out
+}
+
+func cfnResourceRules(rel string, resLine int, logicalID, resType string, props *yaml.Node) []ports.MisconfigRawFinding {
+	var out []ports.MisconfigRawFinding
+	resource := "CloudFormation " + clip(resType) + " " + clip(logicalID)
+	add := func(rule, title string, sev shared.Severity, atLine int, desc string) {
+		if atLine <= 0 {
+			atLine = resLine
+		}
+		out = append(out, ports.MisconfigRawFinding{
+			File: rel, Line: atLine, RuleID: rule, Title: title, Severity: sev, Resource: resource, Description: desc,
+		})
+	}
+
+	switch resType {
+	case "AWS::S3::Bucket":
+		if acl := mapValue(props, "AccessControl"); acl != nil {
+			if v, ok := literalScalar(acl); ok && (v == "PublicRead" || v == "PublicReadWrite") {
+				add("cloudformation-public-bucket-acl", "S3 bucket granted a public ACL", shared.SeverityHigh, acl.Line,
+					"AccessControl is "+clip(v)+", which exposes the bucket publicly. Remove the public ACL, block public access, and use a bucket policy scoped to specific principals.")
+			}
+		}
+		if mapValue(props, "BucketEncryption") == nil {
+			add("cloudformation-s3-no-encryption", "S3 bucket without default encryption", shared.SeverityMedium, resLine,
+				"No BucketEncryption is configured, so objects are not encrypted at rest by default. Add a BucketEncryption block (SSE-S3 or SSE-KMS).")
+		}
+	case "AWS::RDS::DBInstance":
+		enc := mapValue(props, "StorageEncrypted")
+		if v, ok := literalScalar(enc); enc == nil || (ok && v != "true") {
+			add("cloudformation-rds-unencrypted", "RDS instance storage not encrypted", shared.SeverityMedium, resLine,
+				"StorageEncrypted is not true, so the database volume is unencrypted at rest. Set StorageEncrypted: true (and a KMS key where policy requires one).")
+		}
+	case "AWS::EC2::SecurityGroup":
+		for _, ing := range seqItems(mapValue(props, "SecurityGroupIngress")) {
+			cidr, ok := literalScalar(mapValue(ing, "CidrIp"))
+			cidr6, ok6 := literalScalar(mapValue(ing, "CidrIpv6"))
+			if (ok && cidr == "0.0.0.0/0") || (ok6 && cidr6 == "::/0") {
+				add("cloudformation-open-security-group", "Security group open to the entire internet", shared.SeverityMedium, ing.Line,
+					"An ingress rule allows 0.0.0.0/0 (or ::/0), exposing the port to the whole internet. Restrict CidrIp to the specific ranges that need access.")
+				break // one finding per group is enough
+			}
+		}
+	case "AWS::IAM::Policy", "AWS::IAM::ManagedPolicy", "AWS::IAM::Role":
+		for _, pd := range cfnPolicyDocuments(props) {
+			flagged := false
+			for _, st := range seqItems(mapValue(pd, "Statement")) {
+				if eff, ok := literalScalar(mapValue(st, "Effect")); ok && !strings.EqualFold(eff, "Allow") {
+					continue
+				}
+				if wildcardLeaf(mapValue(st, "Action")) || wildcardLeaf(mapValue(st, "Resource")) {
+					add("cloudformation-iam-wildcard", "IAM policy grants a wildcard action or resource", shared.SeverityMedium, st.Line,
+						"An Allow statement uses \"*\" for Action or Resource, granting overly broad permissions. Scope both to the minimum required.")
+					flagged = true
+					break
+				}
+			}
+			if flagged {
+				break
+			}
+		}
+	}
+
+	// A plaintext secret can appear on any resource; scan the top-level Properties keys.
+	if props != nil && props.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(props.Content); i += 2 {
+			key := props.Content[i].Value
+			val := props.Content[i+1]
+			if !cfnSecretKeyRe.MatchString(key) {
+				continue
+			}
+			v, ok := literalScalar(val)
+			if !ok || v == "" || strings.HasPrefix(v, "{{resolve:") {
+				continue // an intrinsic, a parameter, or a dynamic reference: not a hardcoded secret
+			}
+			add("cloudformation-plaintext-secret", "Hardcoded secret in a resource property", shared.SeverityHigh, val.Line,
+				"Property "+clip(key)+" holds a plaintext literal. Use a dynamic reference to Secrets Manager or SSM Parameter Store, or a NoEcho parameter, instead of an inline secret.")
+		}
+	}
+	return out
+}
+
+// documentRoot unwraps a yaml document node to its single content node.
+func documentRoot(n *yaml.Node) *yaml.Node {
+	if n != nil && n.Kind == yaml.DocumentNode && len(n.Content) == 1 {
+		return n.Content[0]
+	}
+	return n
+}
+
+// mapValue returns the value node for key in a mapping node, or nil.
+func mapValue(m *yaml.Node, key string) *yaml.Node {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// seqItems returns the items of a sequence node, or nil for anything else.
+func seqItems(n *yaml.Node) []*yaml.Node {
+	if n == nil || n.Kind != yaml.SequenceNode {
+		return nil
+	}
+	return n.Content
+}
+
+// literalScalar returns the value of a plain scalar node. It returns ("", false) for a missing node, a
+// non-scalar, or a CloudFormation short-form intrinsic (!Ref, !Sub, !GetAtt, ...): those carry a single
+// "!"-prefixed tag, unlike the core "!!" tags, so they are not treated as literals.
+func literalScalar(n *yaml.Node) (string, bool) {
+	if n == nil || n.Kind != yaml.ScalarNode {
+		return "", false
+	}
+	if strings.HasPrefix(n.Tag, "!") && !strings.HasPrefix(n.Tag, "!!") {
+		return "", false
+	}
+	return n.Value, true
+}
+
+// cfnPolicyDocuments gathers the inline policy documents on an IAM resource: a direct PolicyDocument
+// (AWS::IAM::Policy / ManagedPolicy) and each PolicyDocument under Policies (AWS::IAM::Role). The role's
+// AssumeRolePolicyDocument is intentionally skipped: trust policies routinely use broad principals.
+func cfnPolicyDocuments(props *yaml.Node) []*yaml.Node {
+	var docs []*yaml.Node
+	if pd := mapValue(props, "PolicyDocument"); pd != nil {
+		docs = append(docs, pd)
+	}
+	for _, p := range seqItems(mapValue(props, "Policies")) {
+		if pd := mapValue(p, "PolicyDocument"); pd != nil {
+			docs = append(docs, pd)
+		}
+	}
+	return docs
+}
+
+// wildcardLeaf reports whether a node is the literal "*" or a sequence containing it.
+func wildcardLeaf(n *yaml.Node) bool {
+	if v, ok := literalScalar(n); ok {
+		return v == "*"
+	}
+	for _, it := range seqItems(n) {
+		if v, ok := literalScalar(it); ok && v == "*" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/tools/misconfig/cloudformation.go
+++ b/internal/infrastructure/tools/misconfig/cloudformation.go
@@ -22,8 +22,9 @@ var cfnSecretKeyRe = regexp.MustCompile(`(?i)(password|secret|token|api[_-]?key|
 // skip, never a scan failure.
 func scanCloudFormation(rel string, data []byte) []ports.MisconfigRawFinding {
 	// Refuse pathologically deep documents before decoding, matching the Kubernetes path: yaml.v3 recurses
-	// per nesting level with no depth cap, so a crafted deep document would overflow the goroutine stack.
-	if maxFlowDepth(data) > maxNestDepth {
+	// per nesting level with no depth cap, so a crafted deep document (flow or compact block) would overflow
+	// the goroutine stack. tooDeepYAML makes that a per-file skip.
+	if tooDeepYAML(data) {
 		return nil
 	}
 	var root yaml.Node
@@ -83,6 +84,8 @@ func cfnResourceRules(rel string, resLine int, logicalID, resType string, props 
 				"StorageEncrypted is not true, so the database volume is unencrypted at rest. Set StorageEncrypted: true (and a KMS key where policy requires one).")
 		}
 	case "AWS::EC2::SecurityGroup":
+		// Covers the inline ingress list. Standalone AWS::EC2::SecurityGroupIngress resources and egress
+		// rules are not yet checked.
 		for _, ing := range seqItems(mapValue(props, "SecurityGroupIngress")) {
 			cidr, ok := literalScalar(mapValue(ing, "CidrIp"))
 			cidr6, ok6 := literalScalar(mapValue(ing, "CidrIpv6"))
@@ -99,7 +102,7 @@ func cfnResourceRules(rel string, resLine int, logicalID, resType string, props 
 				if eff, ok := literalScalar(mapValue(st, "Effect")); ok && !strings.EqualFold(eff, "Allow") {
 					continue
 				}
-				if wildcardLeaf(mapValue(st, "Action")) || wildcardLeaf(mapValue(st, "Resource")) {
+				if hasWildcard(mapValue(st, "Action"), true) || hasWildcard(mapValue(st, "Resource"), false) {
 					add("cloudformation-iam-wildcard", "IAM policy grants a wildcard action or resource", shared.SeverityMedium, st.Line,
 						"An Allow statement uses \"*\" for Action or Resource, granting overly broad permissions. Scope both to the minimum required.")
 					flagged = true
@@ -189,13 +192,18 @@ func cfnPolicyDocuments(props *yaml.Node) []*yaml.Node {
 	return docs
 }
 
-// wildcardLeaf reports whether a node is the literal "*" or a sequence containing it.
-func wildcardLeaf(n *yaml.Node) bool {
+// hasWildcard reports whether a policy leaf (a scalar or a sequence of scalars) is a wildcard. For an
+// action, a service-scoped wildcard like "s3:*" also counts; for a resource only a bare "*" does, since a
+// resource ARN ending in "*" (e.g. "arn:aws:s3:::bucket/*") is common, legitimate scoping.
+func hasWildcard(n *yaml.Node, serviceScope bool) bool {
+	match := func(v string) bool {
+		return v == "*" || (serviceScope && strings.HasSuffix(v, ":*"))
+	}
 	if v, ok := literalScalar(n); ok {
-		return v == "*"
+		return match(v)
 	}
 	for _, it := range seqItems(n) {
-		if v, ok := literalScalar(it); ok && v == "*" {
+		if v, ok := literalScalar(it); ok && match(v) {
 			return true
 		}
 	}

--- a/internal/infrastructure/tools/misconfig/cloudformation_test.go
+++ b/internal/infrastructure/tools/misconfig/cloudformation_test.go
@@ -1,0 +1,136 @@
+package misconfig
+
+import "testing"
+
+func TestCloudFormationInsecure(t *testing.T) {
+	tmpl := `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Data:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: PublicRead
+  Db:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      Engine: postgres
+      StorageEncrypted: false
+      MasterUserPassword: hunter2super
+  Sg:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: open
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 0.0.0.0/0
+  Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: broad
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: "*"
+            Resource: "*"
+`
+	got := ruleIDs(scan(t, map[string]string{"stack.yaml": tmpl}))
+	for _, want := range []string{
+		"cloudformation-public-bucket-acl",
+		"cloudformation-s3-no-encryption",
+		"cloudformation-rds-unencrypted",
+		"cloudformation-plaintext-secret",
+		"cloudformation-open-security-group",
+		"cloudformation-iam-wildcard",
+	} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("expected CloudFormation rule %q, got %v", want, keys(got))
+		}
+	}
+}
+
+func TestCloudFormationSecure(t *testing.T) {
+	// A hardened stack: encrypted + private bucket, encrypted DB with a dynamic-reference secret, scoped
+	// ingress, and a scoped IAM statement.
+	tmpl := `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Data:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
+  Db:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      Engine: postgres
+      StorageEncrypted: true
+      MasterUserPassword: "{{resolve:secretsmanager:db:SecretString:password}}"
+  Sg:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: scoped
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 10.0.0.0/8
+  Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: scoped
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: s3:GetObject
+            Resource: arn:aws:s3:::data/*
+`
+	if got := scan(t, map[string]string{"stack.yaml": tmpl}); len(got) != 0 {
+		t.Errorf("hardened CloudFormation should yield no findings, got %+v", got)
+	}
+}
+
+func TestCloudFormationJSON(t *testing.T) {
+	// JSON is valid YAML, so the same walker handles a JSON template. Also confirms the .json content sniff.
+	tmpl := `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Data": { "Type": "AWS::S3::Bucket", "Properties": { "AccessControl": "PublicReadWrite" } }
+  }
+}`
+	got := ruleIDs(scan(t, map[string]string{"stack.json": tmpl}))
+	if _, ok := got["cloudformation-public-bucket-acl"]; !ok {
+		t.Errorf("JSON template public ACL not flagged, got %v", keys(got))
+	}
+}
+
+func TestCloudFormationIntrinsicsTolerated(t *testing.T) {
+	// A value supplied via a short-form intrinsic (!Ref) is not a literal, so it must not trip a literal
+	// check, and the template must still parse (the bucket still gets the no-encryption finding).
+	tmpl := `AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  Acl:
+    Type: String
+Resources:
+  Data:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: !Ref Acl
+  Db:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      StorageEncrypted: true
+      MasterUserPassword: !Ref DbSecret
+`
+	got := ruleIDs(scan(t, map[string]string{"stack.yaml": tmpl}))
+	if _, ok := got["cloudformation-public-bucket-acl"]; ok {
+		t.Errorf("!Ref AccessControl must not be flagged as a public literal ACL")
+	}
+	if _, ok := got["cloudformation-plaintext-secret"]; ok {
+		t.Errorf("!Ref secret must not be flagged as a plaintext secret")
+	}
+	if _, ok := got["cloudformation-s3-no-encryption"]; !ok {
+		t.Errorf("template with intrinsics must still parse and flag the unencrypted bucket, got %v", keys(got))
+	}
+}

--- a/internal/infrastructure/tools/misconfig/cloudformation_test.go
+++ b/internal/infrastructure/tools/misconfig/cloudformation_test.go
@@ -1,6 +1,37 @@
 package misconfig
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCloudFormationDepthBombSkipped(t *testing.T) {
+	// A compact block-nesting bomb ("- - - ... x", one line, linear bytes) would overflow yaml.v3's
+	// recursive parser. The pre-decode depth guard must make it a per-file skip (nil), never a crash.
+	bomb := append(bytes.Repeat([]byte("- "), 300000), 'x')
+	if got := scanCloudFormation("bomb.yaml", bomb); got != nil {
+		t.Fatalf("compact-nesting bomb should be skipped, got %d findings", len(got))
+	}
+}
+
+func TestCloudFormationActionServiceWildcard(t *testing.T) {
+	// A service-scoped action wildcard ("s3:*") is flagged even though the resource ARN ending in "*" is
+	// legitimate scoping and on its own is not.
+	tmpl := `Resources:
+  P:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: "s3:*"
+            Resource: "arn:aws:s3:::bucket/*"
+`
+	got := ruleIDs(scan(t, map[string]string{"p.yaml": tmpl}))
+	if _, ok := got["cloudformation-iam-wildcard"]; !ok {
+		t.Errorf("service-scoped action wildcard s3:* should be flagged, got %v", keys(got))
+	}
+}
 
 func TestCloudFormationInsecure(t *testing.T) {
 	tmpl := `AWSTemplateFormatVersion: "2010-09-09"

--- a/internal/infrastructure/tools/misconfig/kubernetes.go
+++ b/internal/infrastructure/tools/misconfig/kubernetes.go
@@ -115,7 +115,7 @@ func scanKubernetes(rel string, data []byte) []ports.MisconfigRawFinding {
 	// Refuse pathologically deep documents BEFORE decoding: yaml.v3 recurses per nesting level with no
 	// depth cap, so a crafted deep document would overflow the goroutine stack (an unrecoverable fatal),
 	// not merely return an error. This keeps a malformed file a per-file skip, per the port contract.
-	if maxFlowDepth(data) > maxNestDepth {
+	if tooDeepYAML(data) {
 		return nil
 	}
 	dec := yaml.NewDecoder(bytes.NewReader(data))
@@ -422,10 +422,17 @@ func firstKeyLineDepth(node *yaml.Node, key string, depth int) int {
 	return 0
 }
 
+// tooDeepYAML reports whether data nests deeper than maxNestDepth in a way that could overflow yaml.v3's
+// recursive parser. It covers both linear-cost forms: flow collections ('['/'{') and compact block chains
+// ("- - - x"). Indented block nesting is not checked because it costs ~O(depth^2) bytes, so the file-size
+// cap already bounds it well below a stack-overflowing depth.
+func tooDeepYAML(data []byte) bool {
+	return maxFlowDepth(data) > maxNestDepth || maxBlockChainDepth(data) > maxNestDepth
+}
+
 // maxFlowDepth returns the deepest nesting of YAML flow collections ('[' and '{') in data, ignoring
 // brackets inside quoted scalars and comments. It is a cheap linear pre-scan so a deep untrusted document
-// is rejected before it reaches the recursive yaml.v3 parser. (Block-style nesting is naturally bounded
-// by the file-size cap, since each level costs a line of indentation.)
+// is rejected before it reaches the recursive yaml.v3 parser.
 func maxFlowDepth(data []byte) int {
 	var depth, maxd int
 	var inSingle, inDouble bool
@@ -475,6 +482,41 @@ func maxFlowDepth(data []byte) int {
 			}
 		}
 		prev = b
+	}
+	return maxd
+}
+
+// maxBlockChainDepth returns the longest run of compact block-collection indicators ("- " or "? ") at the
+// start of a line, after leading whitespace. Compact block nesting like "- - - - x" is a single line whose
+// nesting depth equals that run and costs only ~2 bytes per level, so unlike indented block nesting it is
+// NOT bounded by the file-size cap. Only leading indicator runs are counted, so a dash inside a scalar
+// value does not inflate the result. yaml.v3 recurses per level, so this is capped alongside maxFlowDepth.
+func maxBlockChainDepth(data []byte) int {
+	maxd, i, n := 0, 0, len(data)
+	for i < n {
+		for i < n && (data[i] == ' ' || data[i] == '\t') { // leading indentation
+			i++
+		}
+		chain := 0
+		for i+1 < n && (data[i] == '-' || data[i] == '?') && (data[i+1] == ' ' || data[i+1] == '\t') {
+			chain++
+			i += 2
+			for i < n && (data[i] == ' ' || data[i] == '\t') {
+				i++
+			}
+		}
+		if chain > maxd {
+			maxd = chain
+			if maxd > maxNestDepth {
+				return maxd // early out: already past the cap
+			}
+		}
+		for i < n && data[i] != '\n' { // advance to the next line
+			i++
+		}
+		if i < n {
+			i++
+		}
 	}
 	return maxd
 }

--- a/internal/infrastructure/tools/misconfig/scanner.go
+++ b/internal/infrastructure/tools/misconfig/scanner.go
@@ -1,7 +1,7 @@
 // Package misconfig is an owned, deterministic infrastructure-as-code / config scanner over a prepared
 // workspace. It flags insecure settings in Dockerfiles, Kubernetes manifests, Helm charts (rendered via
-// `helm template`), and Terraform (HCL) with first-party Go checks — no external policy engine (no
-// OPA/Rego). Explicit-insecure settings are flagged as high/medium; recommended-hardening that is absent
+// `helm template`), Terraform (HCL), and CloudFormation (YAML/JSON) with first-party Go checks — no
+// external policy engine (no OPA/Rego). Explicit-insecure settings are flagged as high/medium; recommended-hardening that is absent
 // (KSV/CIS/tfsec baseline: runAsNonRoot, dropped capabilities, encryption, resource limits, ...) is
 // flagged as low/medium, so coverage matches comprehensive scanners while the highs stay legible.
 //
@@ -69,6 +69,7 @@ const (
 	cfgDockerfile
 	cfgKubernetes
 	cfgTerraform
+	cfgCloudFormation
 )
 
 // ScanConfigs walks root, classifies each regular file, and returns located misconfig findings.
@@ -111,7 +112,7 @@ func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.Misconf
 			return nil
 		}
 		kind := classifyName(d.Name())
-		if kind == cfgNone && !maybeYAML(d.Name()) {
+		if kind == cfgNone && !maybeYAML(d.Name()) && !maybeCFN(d.Name()) {
 			return nil
 		}
 		if count >= maxFiles {
@@ -127,11 +128,16 @@ func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.Misconf
 			return nil
 		}
 		if kind == cfgNone {
-			// A .yaml/.yml file is only a Kubernetes manifest if it declares apiVersion + kind.
-			if !looksKubernetes(data) {
+			// Decide by content: a Kubernetes manifest declares apiVersion + kind; a CloudFormation
+			// template declares AWSTemplateFormatVersion or a Resources map of AWS:: types.
+			switch {
+			case looksKubernetes(data):
+				kind = cfgKubernetes
+			case looksCloudFormation(data):
+				kind = cfgCloudFormation
+			default:
 				return nil
 			}
-			kind = cfgKubernetes
 		}
 		rel := strings.TrimPrefix(strings.TrimPrefix(path, root), string(os.PathSeparator))
 		switch kind {
@@ -141,6 +147,8 @@ func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.Misconf
 			out = append(out, scanKubernetes(rel, data)...)
 		case cfgTerraform:
 			out = append(out, scanTerraform(rel, data)...)
+		case cfgCloudFormation:
+			out = append(out, scanCloudFormation(rel, data)...)
 		}
 		return nil
 	})
@@ -168,11 +176,25 @@ func maybeYAML(name string) bool {
 	return ext == ".yaml" || ext == ".yml"
 }
 
+// maybeCFN lets a .json or .template file through to the content sniff, since CloudFormation templates
+// are commonly written in either (YAML .yaml/.yml is already covered by maybeYAML).
+func maybeCFN(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".json" || ext == ".template"
+}
+
 // looksKubernetes is a cheap pre-filter so we only parse YAML that declares a Kubernetes object, not
 // every CI/compose/config YAML in the tree.
 func looksKubernetes(data []byte) bool {
 	t := string(data)
 	return strings.Contains(t, "apiVersion:") && strings.Contains(t, "kind:")
+}
+
+// looksCloudFormation is a cheap pre-filter for a CloudFormation template: it declares the format version
+// or a Resources map whose entries carry AWS:: types. Specific enough to skip an ordinary JSON/YAML file.
+func looksCloudFormation(data []byte) bool {
+	t := string(data)
+	return strings.Contains(t, "AWSTemplateFormatVersion") || (strings.Contains(t, "Resources") && strings.Contains(t, "AWS::"))
 }
 
 func isBinary(data []byte) bool {

--- a/internal/infrastructure/tools/misconfig/scanner.go
+++ b/internal/infrastructure/tools/misconfig/scanner.go
@@ -184,7 +184,8 @@ func maybeCFN(name string) bool {
 }
 
 // looksKubernetes is a cheap pre-filter so we only parse YAML that declares a Kubernetes object, not
-// every CI/compose/config YAML in the tree.
+// every CI/compose/config YAML in the tree. It matches the YAML form `apiVersion:` (colon-attached), so a
+// JSON-authored manifest (`"apiVersion":`) is intentionally not treated as Kubernetes here.
 func looksKubernetes(data []byte) bool {
 	t := string(data)
 	return strings.Contains(t, "apiVersion:") && strings.Contains(t, "kind:")


### PR DESCRIPTION
Closes #71.

## What

Adds AWS CloudFormation to the IaC misconfig scanner, alongside Dockerfile, Kubernetes, Helm and Terraform.

A `.yaml`/`.yml`/`.json`/`.template` file is classified as CloudFormation by content (`AWSTemplateFormatVersion`, or a `Resources` map of `AWS::` types), so it is not confused with a Kubernetes manifest or an ordinary JSON file.

## How

The parser walks the resource tree via `yaml.Node`. That parses both YAML and JSON with one path, and tolerates CloudFormation short-form intrinsics (`!Ref`, `!Sub`, `!GetAtt`): a tagged scalar keeps its value and simply does not match a literal check. The same pre-decode depth guard as the Kubernetes path keeps a crafted deep document a per-file skip. No external policy engine, no new dependency.

## Rules

- `cloudformation-public-bucket-acl` (high): S3 `AccessControl: PublicRead`/`PublicReadWrite`.
- `cloudformation-s3-no-encryption` (medium): S3 bucket with no `BucketEncryption`.
- `cloudformation-rds-unencrypted` (medium): RDS `StorageEncrypted` not true.
- `cloudformation-open-security-group` (medium): ingress `CidrIp` `0.0.0.0/0` (or `::/0`).
- `cloudformation-iam-wildcard` (medium): an Allow statement with `Action`/`Resource` `*`.
- `cloudformation-plaintext-secret` (high): a password/secret/token property with a literal value. Emits only the property key, never the value.

## Verified end to end

Ran `synapse-cli scan --json` on a template with a public bucket and an open security group: the `cloudformation-*` findings appear with the correct file:line and severity, and the gate fires. Table-driven tests cover insecure, hardened (zero findings), JSON, and intrinsic-tolerated cases. Build, vet, the full misconfig suite, and `-race` are green.
