### PR TITLE
fix(misconfig): handle a comment inside a Dockerfile RUN continuation

### DIFF
--- a/internal/infrastructure/tools/misconfig/dockerfile.go
+++ b/internal/infrastructure/tools/misconfig/dockerfile.go
@@ -164,8 +164,17 @@ func parseDockerfile(src string) []instruction {
 		for strings.HasSuffix(strings.TrimRight(full, " \t"), `\`) && i+1 < len(lines) {
 			full = strings.TrimSuffix(strings.TrimRight(full, " \t"), `\`)
 			i++
-			full += " " + strings.TrimSpace(strings.TrimRight(lines[i], "\r"))
+			next := strings.TrimSpace(strings.TrimRight(lines[i], "\r"))
+			if strings.HasPrefix(next, "#") {
+				// A full-line comment inside a continuation. Docker strips comments before joining
+				// continuations, so skip it and keep the continuation open instead of ending the
+				// instruction early (which would drop the real commands that follow the comment).
+				full += ` \`
+				continue
+			}
+			full += " " + next
 		}
+		full = strings.TrimSuffix(strings.TrimRight(full, " \t"), `\`) // drop a dangling trailing backslash
 		i++
 		cmd, args := splitInstruction(full)
 		if cmd == "" {

--- a/internal/infrastructure/tools/misconfig/dockerfile_test.go
+++ b/internal/infrastructure/tools/misconfig/dockerfile_test.go
@@ -1,0 +1,28 @@
+package misconfig
+
+import "testing"
+
+func TestDockerfileCommentInsideContinuation(t *testing.T) {
+	// A full-line comment inside a backslash continuation must not end the RUN early. The apt cleanup
+	// that follows the comment is still part of the same RUN, so apt-no-clean must NOT fire.
+	df := "FROM debian:bookworm-slim\n" +
+		"RUN apt-get update \\\n" +
+		"    && apt-get install -y --no-install-recommends curl \\\n" +
+		"    # resolve JAVA_HOME wherever java actually points\n" +
+		"    && rm -rf /var/lib/apt/lists/*\n"
+	got := ruleIDs(scan(t, map[string]string{"Dockerfile": df}))
+	if _, ok := got["dockerfile-apt-no-clean"]; ok {
+		t.Errorf("apt cleanup after an inline comment must be recognized; got %v", keys(got))
+	}
+}
+
+func TestDockerfileAptNoCleanStillFlagged(t *testing.T) {
+	// The rule must still catch a genuine apt install with no cleanup.
+	df := "FROM debian:bookworm-slim\n" +
+		"RUN apt-get update \\\n" +
+		"    && apt-get install -y curl\n"
+	got := ruleIDs(scan(t, map[string]string{"Dockerfile": df}))
+	if _, ok := got["dockerfile-apt-no-clean"]; !ok {
+		t.Errorf("apt install without cleanup should still be flagged; got %v", keys(got))
+	}
+}


### PR DESCRIPTION
A full-line comment between backslash continuations ended the RUN early (the comment text got appended to args and stopped the join), dropping the commands after it. That produced a false `dockerfile-apt-no-clean` on a RUN that does clean `/var/lib/apt/lists` after an inline comment (our own `deploy/Dockerfile` hit this during a self-scan). Docker strips comments before joining continuations, so skip a mid-continuation comment and keep the continuation open; also drop a dangling trailing backslash. Tests: comment-in-continuation is not flagged, a genuine no-cleanup still is. Verified against the real deploy/Dockerfile (the false positive is gone).