### PR TITLE
chore(vex): mark GO-2026-5932 (x/crypto openpgp) not_affected

### DIFF
--- a/.synapse.vex.json
+++ b/.synapse.vex.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://synapse.kkloudtarus.net/.well-known/vex/synapse-ce",
+  "author": "Synapse maintainers",
+  "role": "document creator",
+  "timestamp": "2026-07-11T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": { "name": "GO-2026-5932" },
+      "products": [ { "@id": "golang.org/x/crypto" } ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "GO-2026-5932 concerns golang.org/x/crypto/openpgp, which Synapse does not import. Only argon2, blake2b and ocsp are used (verified via go list -deps). The advisory has no upstream fix because the package is deprecated."
+    }
+  ]
+}


### PR DESCRIPTION
A self-scan flags GO-2026-5932 on `golang.org/x/crypto`: the advisory is that `golang.org/x/crypto/openpgp` is unmaintained and unsafe. Synapse does not import that package (only `argon2`, `blake2b`, `ocsp`, verified with `go list -deps`), and there is no upstream fix because the package is deprecated. This adds an in-repo OpenVEX `not_affected` statement (`vulnerable_code_not_present`) so a scan retains and seals the finding but exempts it from the gate. The product id carries no version so it holds across future x/crypto bumps. Dogfoods the in-scan VEX feature; verified that the finding becomes accepted-risk.