### PR TITLE
ci: run the pipeline on a self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+# Runs on a self-hosted runner. Note: this is a PUBLIC repo, so a fork pull request executes on your
+# infrastructure once its workflow run is approved. Keep the runner ephemeral and network-isolated, and
+# keep "require approval for all outside collaborators" on in Settings > Actions.
 permissions:
   contents: read
 
 jobs:
   lint:
     name: Lint (Go)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
 
@@ -29,7 +32,7 @@ jobs:
 
   backend:
     name: Backend (Go)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
 
@@ -53,7 +56,7 @@ jobs:
 
   frontend:
     name: Frontend (web)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: web


### PR DESCRIPTION
Runs the CI jobs (lint, backend, frontend) on a self-hosted runner instead of `ubuntu-latest`.

## Before merging
A self-hosted runner must be registered for the repo (Settings > Actions > Runners), or every workflow run will queue forever waiting for a runner, including this PR's own checks.

## Security note (public repo)
synapse-ce is public and CI runs on `pull_request`, so an approved fork PR will execute on your self-hosted runner. To keep that safe:
- Use an ephemeral runner (fresh VM/container per job) and isolate it from your internal network and any long-lived credentials.
- Keep "Require approval for all outside collaborators" on in Settings > Actions (first-time contributor runs already require approval).
- Consider restricting the runner to a dedicated, disposable environment.

A safer alternative, if you want it later, is a hybrid: self-hosted for `push`/`workflow_dispatch` and GitHub-hosted for `pull_request` from forks. Happy to switch to that.
