### PR TITLE
test(sandbox): gate privileged live integration tests behind an opt-in

### DIFF
--- a/internal/infrastructure/sandbox/binintegrity_integration_test.go
+++ b/internal/infrastructure/sandbox/binintegrity_integration_test.go
@@ -20,6 +20,7 @@ import (
 // TestBinaryIntegrityRefusesTamper proves F5: once a tool binary is pinned (TOFU on first
 // run), replacing it makes the next run be REFUSED before exec.
 func TestBinaryIntegrityRefusesTamper(t *testing.T) {
+	requireSandboxIntegration(t)
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not installed")
 	}

--- a/internal/infrastructure/sandbox/cgroup_integration_test.go
+++ b/internal/infrastructure/sandbox/cgroup_integration_test.go
@@ -39,6 +39,7 @@ int main(int argc,char**argv){
 // TestCgroupContainsForkBomb proves F3: pids.max bounds a fork bomb on the egress path
 // (the privileged path that touches hostile networks). Needs bwrap + gcc + cgroup write.
 func TestCgroupContainsBombs(t *testing.T) {
+	requireSandboxIntegration(t)
 	for _, b := range []string{"bwrap", "gcc"} {
 		if _, err := exec.LookPath(b); err != nil {
 			t.Skipf("%s not installed", b)

--- a/internal/infrastructure/sandbox/connlog_integration_test.go
+++ b/internal/infrastructure/sandbox/connlog_integration_test.go
@@ -19,6 +19,7 @@ import (
 // labels each allowed/denied against the scope. Needs Linux + bwrap + curl + CAP_NET_ADMIN
 // + cgroup-bpf (run with sudo on a real host); skips otherwise.
 func TestSandboxEgressConnectLog(t *testing.T) {
+	requireSandboxIntegration(t)
 	if runtime.GOOS != "linux" {
 		t.Skip("sandbox/eBPF are Linux-only")
 	}

--- a/internal/infrastructure/sandbox/credleak_integration_test.go
+++ b/internal/infrastructure/sandbox/credleak_integration_test.go
@@ -19,6 +19,7 @@ import (
 // TestCredentialLeakChannels behaviorally probes Part 4: a tool that ECHOES an injected
 // secret raw vs base64 vs hex — which channels does the redaction chokepoint catch?
 func TestCredentialLeakChannels(t *testing.T) {
+	requireSandboxIntegration(t)
 	for _, b := range []string{"bwrap", "base64", "xxd", "sh"} {
 		if _, err := exec.LookPath(b); err != nil {
 			t.Skipf("%s not installed", b)

--- a/internal/infrastructure/sandbox/integration_gate_internal_test.go
+++ b/internal/infrastructure/sandbox/integration_gate_internal_test.go
@@ -1,0 +1,15 @@
+package sandbox
+
+import (
+	"os"
+	"testing"
+)
+
+// requireSandboxIntegration mirrors the external-package gate for the internal (package sandbox)
+// integration tests. See integration_gate_test.go for the rationale.
+func requireSandboxIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv("SYNAPSE_SANDBOX_INTEGRATION") == "" {
+		t.Skip("privileged sandbox integration test: set SYNAPSE_SANDBOX_INTEGRATION=1 on a sandbox-capable host")
+	}
+}

--- a/internal/infrastructure/sandbox/integration_gate_test.go
+++ b/internal/infrastructure/sandbox/integration_gate_test.go
@@ -1,0 +1,20 @@
+package sandbox_test
+
+import (
+	"os"
+	"testing"
+)
+
+// requireSandboxIntegration skips a privileged sandbox integration test unless it is explicitly enabled.
+// These tests assert real kernel isolation (mount/user/network namespaces via bubblewrap, egress filtering,
+// and cgroup v2 limits), which needs a host that provides all of it: a delegated, writable cgroup subtree
+// plus the ability to enforce netns egress. A typical CI runner or an unprivileged container (for example a
+// dev workspace running as a non-root user without cgroup delegation) has bubblewrap but cannot enforce
+// those controls, so the tests would fail spuriously rather than validate anything. Run them with
+// SYNAPSE_SANDBOX_INTEGRATION=1 on a validated Linux host (the sandbox-host validation environment).
+func requireSandboxIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv("SYNAPSE_SANDBOX_INTEGRATION") == "" {
+		t.Skip("privileged sandbox integration test: set SYNAPSE_SANDBOX_INTEGRATION=1 on a sandbox-capable host")
+	}
+}

--- a/internal/infrastructure/sandbox/redteam_integration_test.go
+++ b/internal/infrastructure/sandbox/redteam_integration_test.go
@@ -124,6 +124,7 @@ func buildRedteam(t *testing.T) string {
 }
 
 func TestRedTeamIsolated(t *testing.T) {
+	requireSandboxIntegration(t)
 	bin := buildRedteam(t)
 	// Plant a host secret + a worker-env canary, then run ISOLATED (no egress).
 	_ = os.MkdirAll("/root/.ssh", 0o700)
@@ -146,6 +147,7 @@ func TestRedTeamIsolated(t *testing.T) {
 }
 
 func TestRedTeamEgress(t *testing.T) {
+	requireSandboxIntegration(t)
 	bin := buildRedteam(t)
 	sb, err := sandbox.NewRunner(60*time.Second, 64<<20, 1<<30, 256)
 	if err != nil {

--- a/internal/infrastructure/sandbox/rootfs_integration_test.go
+++ b/internal/infrastructure/sandbox/rootfs_integration_test.go
@@ -18,6 +18,7 @@ import (
 // a tool cannot reach $HOME secrets (~/.ssh etc.) — the path is absent — while the OS tree
 // it needs (/etc, /usr) is present. Run as root (sudo) so $HOME=/root.
 func TestSandboxHidesHostSecrets(t *testing.T) {
+	requireSandboxIntegration(t)
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not installed")
 	}

--- a/internal/infrastructure/sandbox/runner_integration_test.go
+++ b/internal/infrastructure/sandbox/runner_integration_test.go
@@ -21,6 +21,7 @@ import (
 // capabilities, and NO network egress (the fresh netns). It needs bubblewrap + bash, so
 // it skips on hosts without them (e.g. macOS dev) and runs on the Linux test box.
 func TestSandboxIsolationLive(t *testing.T) {
+	requireSandboxIntegration(t)
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bubblewrap not installed — sandbox integration test skipped")
 	}
@@ -70,6 +71,7 @@ echo PROBE_DONE
 
 // TestSandboxCapNetRawGranted proves naabu's CAP_NET_RAW is re-added (and only it).
 func TestSandboxCapNetRawGranted(t *testing.T) {
+	requireSandboxIntegration(t)
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bubblewrap not installed")
 	}
@@ -100,6 +102,7 @@ func TestSandboxCapNetRawGranted(t *testing.T) {
 // secret never appears in the child's cmdline, and a secret the tool echoes is REDACTED
 // from the captured output.
 func TestSandboxSecretInjection(t *testing.T) {
+	requireSandboxIntegration(t)
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bubblewrap not installed")
 	}
@@ -175,6 +178,7 @@ printf 'CMDLINE='; tr '\0' ' ' < /proc/self/cmdline; echo
 // sandboxed tool reaches an in-scope address but an out-of-scope one is dropped, while
 // bwrap's isolation still holds. Needs Linux + bwrap + bash + ip/iptables + sudo.
 func TestSandboxEgressEnforced(t *testing.T) {
+	requireSandboxIntegration(t)
 	for _, bin := range []string{"bwrap", "bash", "ip", "iptables", "sudo"} {
 		if _, err := exec.LookPath(bin); err != nil {
 			t.Skipf("%s not available", bin)
@@ -229,6 +233,7 @@ echo caps=$(grep CapEff /proc/self/status | awk '{print $2}')
 // /etc/hosts (with NO DNS egress) — so the tool resolves + reaches the in-scope domain
 // but cannot resolve (or reach) an out-of-scope one.
 func TestSandboxEgressDomainPinning(t *testing.T) {
+	requireSandboxIntegration(t)
 	for _, bin := range []string{"bwrap", "bash", "ip", "iptables", "sudo", "getent"} {
 		if _, err := exec.LookPath(bin); err != nil {
 			t.Skipf("%s not available", bin)

--- a/internal/infrastructure/sandbox/seccomp_integration_test.go
+++ b/internal/infrastructure/sandbox/seccomp_integration_test.go
@@ -41,6 +41,7 @@ int main(){
 // dangerous syscalls the audit named return EPERM, while an allowlisted one (getpid)
 // works and a real Go tool (syft) still runs. Needs bwrap + gcc + syft (a real Linux host).
 func TestSeccompDeniesDangerousSyscalls(t *testing.T) {
+	requireSandboxIntegration(t)
 	for _, b := range []string{"bwrap", "gcc"} {
 		if _, err := exec.LookPath(b); err != nil {
 			t.Skipf("%s not installed", b)
@@ -79,6 +80,7 @@ func TestSeccompDeniesDangerousSyscalls(t *testing.T) {
 
 // TestSeccompAllowsRealTool proves the allowlist is complete enough to run a real Go tool.
 func TestSeccompAllowsRealTool(t *testing.T) {
+	requireSandboxIntegration(t)
 	for _, b := range []string{"bwrap", "syft"} {
 		if _, err := exec.LookPath(b); err != nil {
 			t.Skipf("%s not installed", b)


### PR DESCRIPTION
The sandbox integration tests assert real kernel isolation (namespaces via bubblewrap, egress filtering, cgroup v2 limits). They already skip when bubblewrap is absent (GitHub-hosted runners), but a runner that HAS bubblewrap yet lacks cgroup delegation / netns egress (an unprivileged container or a non-root dev workspace, e.g. a self-hosted runner) ran them and failed spuriously. Gate them behind `SYNAPSE_SANDBOX_INTEGRATION=1` so they skip by default and run only on a sandbox-capable host (the P3 validation environment). No production behavior change; verified they skip without the env and the package builds on linux and macOS.