### PR TITLE
feat(sast): detect LDAP injection

### DIFF
--- a/internal/infrastructure/tools/sast/analyzer_test.go
+++ b/internal/infrastructure/tools/sast/analyzer_test.go
@@ -282,6 +282,22 @@ func TestRuleCorpus(t *testing.T) {
 			fp:   []string{`db.users.find({ _id: ObjectId(id) })`, `User.findOne({ email: safeEmail })`},
 		},
 		{
+			rule: "ldap-injection",
+			tp: []string{
+				`search(base, "(uid=" + user + ")")`,
+				`conn.search(base, f"(uid={request.args['user']})")`,
+				"ldap.search(base, `(&(objectClass=person)(uid=${req.query.user}))`)",
+			},
+			fp: []string{
+				`ldap.search(base, "(uid=service-account)")`,
+				`conn.search(base, f"(uid={escape_filter_chars(user)})")`,
+				`ctx.search(base, "(uid={0})", new Object[]{user}, controls)`,
+				`search(index, "uid=" + req.query.user)`,
+				`logger.info(f"(uid={request.args['user']})")`,
+				`// ldap.search(base, "(uid=" + req.query.user + ")")`,
+			},
+		},
+		{
 			rule: "open-redirect-user-url",
 			tp:   []string{`res.redirect(req.query.next)`, `response.sendRedirect(request.getParameter("url"))`, `http.Redirect(w, r, r.URL.Query().Get("next"), 302)`},
 			fp:   []string{`res.redirect("/login")`, `res.redirect(302, "/dashboard")`, "res.redirect(`${req.protocol}://${req.hostname}/dashboard`)"},

--- a/internal/infrastructure/tools/sast/patterns.go
+++ b/internal/infrastructure/tools/sast/patterns.go
@@ -77,6 +77,12 @@ func safePathAccess(line string) bool {
 	return commentOnlyLine(line) || strings.Contains(l, "path.join(") || strings.Contains(l, "filepath.join(") || strings.Contains(l, "safejoin")
 }
 
+func safeLDAPFilter(line string) bool {
+	l := strings.ToLower(line)
+	return commentOnlyLine(line) || strings.Contains(l, "escape_filter_chars(") ||
+		strings.Contains(l, "escapefilter(") || strings.Contains(l, "ldapencoder.filterencode(")
+}
+
 // builtinRules is the tier-1 (cheap, deterministic) rule set: high-signal weaknesses across common
 // languages. Intentionally precision-biased — taint/dataflow + broader coverage is the AI/E39 tier.
 func builtinRules() []rule {
@@ -300,6 +306,15 @@ func builtinRules() []rule {
 			desc:   "A MongoDB query passes request data (or a $where JavaScript predicate) straight into the filter, allowing NoSQL operator injection. Cast/validate fields and never pass req.body as a filter.",
 			re:     regexp.MustCompile(`(?i)(\.(find|findOne|findOneAndUpdate|updateOne|updateMany|deleteOne|deleteMany|count|aggregate)\s*\(\s*(req\.(body|query|params)|\{[^}\n]*(\$where|req\.(body|query|params)))|\$where\s*:\s*["'` + "`" + `])`),
 			skipFn: commentOnlyLine,
+		},
+		{
+			id: "ldap-injection", cwe: "CWE-90", severity: shared.SeverityHigh, title: "LDAP search filter built from untrusted input",
+			desc: "An LDAP search filter is built from request/user-controlled data without LDAP filter escaping. Escape values per RFC 4515 or use a parameterized LDAP search API.",
+			re: regexp.MustCompile(`(?i)\b((ldap\w*|conn|ctx|dir(ectory)?(context)?|ldaptemplate)\.)?(search|search_s|search_ext)\s*\([^\n]{0,160}(` +
+				`["'][^"'\n]{0,120}\([a-z][\w.-]*\s*(=|~=|>=|<=)[^"'\n]{0,120}["']\s*\+\s*(req\.(body|query|params)|request\.(args|form|values|json)|params\[|\$_(GET|POST|REQUEST)|user(name)?\b|uid\b|input\b|param\b)|` +
+				`f["'][^"'\n]{0,120}\([a-z][\w.-]*\s*(=|~=|>=|<=)[^"'\n]{0,120}\{\s*(req\.|request\.|params\[|user(name)?\b|uid\b|input\b|param\b)|` +
+				"`[^`\\n]{0,120}\\([a-z][\\w.-]*\\s*(=|~=|>=|<=)[^`\\n]{0,120}\\$\\{\\s*(req\\.|request\\.|params\\[|user(name)?\\b|uid\\b|input\\b|param\\b))"),
+			skipFn: safeLDAPFilter,
 		},
 		{
 			id: "open-redirect-user-url", cwe: "CWE-601", severity: shared.SeverityMedium, title: "Redirect target is request-controlled",


### PR DESCRIPTION
## Summary

Adds a first-party, precision-biased SAST rule for LDAP injection
([CWE-90](https://cwe.mitre.org/data/definitions/90.html)).

The new `ldap-injection` rule detects LDAP search filters that are dynamically
constructed through string concatenation or interpolation with potentially
untrusted input. It requires an LDAP search context, a filter-shaped LDAP
assertion, and a taint cue on the same line to keep deterministic findings
high-signal.

The rule deliberately excludes static filters, parameterized searches,
recognized LDAP filter escaping, non-LDAP search strings, and LDAP-shaped text
outside a search sink.

Closes [#54](https://github.com/KKloudTarus/synapse-ce/issues/54).

## Changes

- Added the `ldap-injection` built-in SAST rule:
  - Rule ID: `ldap-injection`
  - Classification: `CWE-90`
  - Severity: `high`
  - Remediation recommends RFC 4515 filter-value escaping or parameterized LDAP
    search APIs.
- Detects unsafe LDAP filter construction using:
  - String concatenation, such as:

    ```javascript
    search(base, "(uid=" + user + ")")
    ```

  - Python f-string interpolation with request-controlled values:

    ```python
    conn.search(base, f"(uid={request.args['user']})")
    ```

  - JavaScript template interpolation, including compound LDAP filters:

    ```javascript
    ldap.search(
      base,
      `(&(objectClass=person)(uid=${req.query.user}))`
    )
    ```

- Requires the following signals on the same source line:
  - An LDAP search operation.
  - A filter-looking LDAP attribute assertion.
  - Dynamic concatenation or interpolation.
  - A direct request/parameter source or a narrowly scoped input-like
    identifier.
- Added a narrow LDAP-specific counter-pattern for recognized filter escaping:
  - `escape_filter_chars(...)`
  - `escapeFilter(...)`
  - `LdapEncoder.filterEncode(...)`
- Keeps the following patterns clean:
  - Static LDAP filters.
  - Parameterized LDAP filters such as JNDI `(uid={0})` searches with a
    separate argument array.
  - Dynamic strings that do not resemble LDAP filters.
  - LDAP-shaped strings used outside an LDAP search sink.
  - Comment-only examples.
- Extended `TestRuleCorpus` with true-positive and false-positive regression
  cases covering each matching gate and counter-pattern.
- Kept the implementation within the existing line-oriented pattern-SAST
  architecture. Multiline and indirect filter construction remain the
  responsibility of the broader taint/dataflow analysis tier.

## Scope and safety

This is a surgical change limited to:

- `internal/infrastructure/tools/sast/patterns.go`
- `internal/infrastructure/tools/sast/analyzer_test.go`

No database schema, API, dashboard, dependency, configuration, or report-format
changes are included.

The change preserves the existing safety invariants:

- No process execution or argv behavior changed.
- No server-side scope-enforcement behavior changed.
- No secrets or request values are logged.
- Findings continue through the existing deterministic scan, deduplication, and
  reporting paths.
- No evidence storage or append-only evidence behavior changed.
- Escaped and parameterized LDAP filters are intentionally excluded to avoid
  publishing low-confidence deterministic findings.

The existing compliance baseline already includes `CWE-90` in the injection
control, so no compliance mapping change was required.

## Testing

Focused checks passed:

```text
go test ./internal/infrastructure/tools/sast/... -run TestRuleCorpus
go test ./internal/infrastructure/tools/sast/...
go vet ./internal/infrastructure/tools/sast/...
```

The complete acceptance suite also passed in a Linux container using
`golang:1.26.4-bookworm`:

```text
make build vet test
```

Native Windows execution is currently blocked by the pre-existing use of the
Unix-only `syscall.O_NOFOLLOW` constant in
`internal/infrastructure/tools/jarchecksum/resolver.go`. This is unrelated to
the LDAP rule; the same full suite passes under Linux Docker.

The dashboard was not changed, so a web build is not required for this PR.

## Checklist

- [x] `make build vet test typecheck` passes
  - `make build vet test typecheck` passes in Linux Docker.
- [ ] `cd web && pnpm build` passes (if the dashboard changed)
  - Not applicable; the dashboard was not changed.
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement,
      secrets out of logs, deterministic reports, append-only evidence) — see
      CONTRIBUTING.md
- [x] Documentation updated if needed
  - No documentation update is required; this is an internal built-in rule
    covered by the existing corpus and rule metadata.