### PR TITLE
feat(sast): XPath injection, ReDoS, and insecure temp file rules

### DIFF
--- a/internal/infrastructure/tools/sast/analyzer_test.go
+++ b/internal/infrastructure/tools/sast/analyzer_test.go
@@ -324,6 +324,9 @@ func TestRuleCorpus(t *testing.T) {
 				`nodes := xpath.evaluate("//user[name='admin']")`,
 				`expr := xpath.compile(userQueryConst)`,
 				`if doc.selectNodes("//user") { render() }`,
+				`result = evaluate("total // count + 1")`,  // // inside a constant string, no string-concat
+				`page.evaluate(expr) // TODO: fix + later`, // first arg is not a string literal
+				`out := preEvaluate("//x[@id=" + id)`,      // preEvaluate is not the evaluate sink
 			},
 		},
 		{

--- a/internal/infrastructure/tools/sast/analyzer_test.go
+++ b/internal/infrastructure/tools/sast/analyzer_test.go
@@ -313,6 +313,45 @@ func TestRuleCorpus(t *testing.T) {
 			file: "case.rb",
 			fp:   []string{`line = gets(chomp: true)`, `out = vsprintf(fmt, args)`},
 		},
+		{
+			rule: "xpath-injection",
+			tp: []string{
+				`nodes := xpath.evaluate("//user[name='" + name + "']")`,
+				`doc.selectNodes("//account[@id=" + id + "]")`,
+				`hits = tree.xpath(f"//user[@name='{name}']")`,
+			},
+			fp: []string{
+				`nodes := xpath.evaluate("//user[name='admin']")`,
+				`expr := xpath.compile(userQueryConst)`,
+				`if doc.selectNodes("//user") { render() }`,
+			},
+		},
+		{
+			rule: "redos-vulnerable-regex",
+			tp: []string{
+				`re := regexp.MustCompile("(a+)+$")`,
+				`pat = re.compile(r"(.*)*")`,
+				`const rx = new RegExp("(\\d+)*")`,
+			},
+			fp: []string{
+				`re := regexp.MustCompile("(abc)+")`,
+				`total := (base + tax) * qty`,
+				`pat = re.compile("^[a-z]+$")`,
+			},
+		},
+		{
+			rule: "insecure-temp-file",
+			tp: []string{
+				`f, _ := os.Create("/tmp/app.log")`,
+				`path := "/tmp/session_" + id`,
+				`char *p = tmpnam(buf);`,
+			},
+			fp: []string{
+				`d, _ := os.MkdirTemp("", "synapse")`,
+				`f, _ := os.CreateTemp(dir, "prefix-")`,
+				`tf = tempfile.NamedTemporaryFile()`,
+			},
+		},
 	}
 
 	for _, c := range corpus {

--- a/internal/infrastructure/tools/sast/patterns.go
+++ b/internal/infrastructure/tools/sast/patterns.go
@@ -351,8 +351,13 @@ func builtinRules() []rule {
 		},
 		{
 			id: "xpath-injection", cwe: "CWE-643", severity: shared.SeverityHigh, title: "XPath query built from untrusted input",
-			desc:   "An XPath expression is concatenated or interpolated from untrusted input, allowing XPath injection (authentication bypass, data disclosure). Use a precompiled expression with variable bindings and validate any dynamic value.",
-			re:     regexp.MustCompile(`(?i)((evaluate|selectNodes|selectSingleNode|\.xpath)\s*\([^\n]*//[^\n]*(\+|\$\{|%[sv])|(evaluate|selectNodes|\.xpath)\s*\(\s*f["'` + "`" + `][^\n]*//)`),
+			desc: "An XPath expression is concatenated or interpolated from untrusted input, allowing XPath injection (authentication bypass, data disclosure). Use a precompiled expression with variable bindings and validate any dynamic value.",
+			// Anchored so the XPath (the //... string) must be the sink's first argument: an opening quote
+			// right after "(" pins // inside a string literal, not a // line comment or Python floor division.
+			// A concat marker must sit adjacent to a quote (real string concatenation) or be an ${...}/{name}/%s
+			// interpolation, so a fully constant query like "//user[name='admin']" never fires. \b stops
+			// preEvaluate/deselectNodes substring matches.
+			re:     regexp.MustCompile(`(?i)\b(evaluate|selectNodes|selectSingleNode|xpath)\s*\(\s*f?["'` + "`" + `][^"'` + "`" + `\n]*//[^\n]*(["'` + "`" + `]\s*\+|\+\s*["'` + "`" + `]|\$\{|%[sv]|\{[a-zA-Z_])`),
 			skipFn: commentOnlyLine,
 		},
 		{

--- a/internal/infrastructure/tools/sast/patterns.go
+++ b/internal/infrastructure/tools/sast/patterns.go
@@ -79,6 +79,15 @@ func safePathAccess(line string) bool {
 
 // builtinRules is the tier-1 (cheap, deterministic) rule set: high-signal weaknesses across common
 // languages. Intentionally precision-biased — taint/dataflow + broader coverage is the AI/E39 tier.
+// redosContextRe marks a line that constructs or uses a regular expression, so the ReDoS rule only fires
+// on actual regex text and never on ordinary parenthesised arithmetic like (a + b) * c.
+var redosContextRe = regexp.MustCompile(`(?i)(regexp\.|RegExp|re\.(compile|match|search|fullmatch)|Pattern\.compile|MustCompile|preg_match|\.match\(|\.test\(|=~)`)
+
+// skipUnlessRegexContext skips a line that is a comment or does not look like regex construction.
+func skipUnlessRegexContext(line string) bool {
+	return commentOnlyLine(line) || !redosContextRe.MatchString(line)
+}
+
 func builtinRules() []rule {
 	return []rule{
 		{
@@ -339,6 +348,24 @@ func builtinRules() []rule {
 			re:     regexp.MustCompile(`(^|[^.\w])(gets|strcpy|strcat|vsprintf)\s*\(`),
 			skipFn: commentOnlyLine,
 			exts:   cSourceExts,
+		},
+		{
+			id: "xpath-injection", cwe: "CWE-643", severity: shared.SeverityHigh, title: "XPath query built from untrusted input",
+			desc:   "An XPath expression is concatenated or interpolated from untrusted input, allowing XPath injection (authentication bypass, data disclosure). Use a precompiled expression with variable bindings and validate any dynamic value.",
+			re:     regexp.MustCompile(`(?i)((evaluate|selectNodes|selectSingleNode|\.xpath)\s*\([^\n]*//[^\n]*(\+|\$\{|%[sv])|(evaluate|selectNodes|\.xpath)\s*\(\s*f["'` + "`" + `][^\n]*//)`),
+			skipFn: commentOnlyLine,
+		},
+		{
+			id: "redos-vulnerable-regex", cwe: "CWE-1333", severity: shared.SeverityMedium, title: "Regular expression vulnerable to catastrophic backtracking (ReDoS)",
+			desc:   "A regex nests a quantifier inside a quantified group (e.g. (a+)+, (.*)*), which backtracks exponentially on crafted input and can hang the process. Rewrite without nested quantifiers, anchor the pattern, or use a linear-time engine.",
+			re:     regexp.MustCompile(`\([^()\n]{0,80}[+*][^()\n]{0,80}\)\s*[+*]`),
+			skipFn: skipUnlessRegexContext,
+		},
+		{
+			id: "insecure-temp-file", cwe: "CWE-377", severity: shared.SeverityMedium, title: "Insecure temporary file",
+			desc:   "A predictable temporary path (a hardcoded /tmp/<name>) or an unsafe API (tmpnam/mktemp) invites a symlink or race attack. Use a library that creates the file atomically with a random name (os.CreateTemp, tempfile.NamedTemporaryFile, mkstemp).",
+			re:     regexp.MustCompile(`(?i)(["'` + "`" + `]/tmp/[\w.$+-]+|\btmpnam\s*\(|\btempnam\s*\(|\bmktemp\s*\()`),
+			skipFn: commentOnlyLine,
 		},
 	}
 }


### PR DESCRIPTION
Adds three first-party SAST pattern rules, each with a true/false-positive corpus entry in `analyzer_test.go` so precision is regression-tested.

### Rules

| Rule id | CWE | Severity | Flags |
|---|---|---|---|
| `xpath-injection` | CWE-643 | high | An XPath expression built by string concatenation or interpolation of dynamic input |
| `redos-vulnerable-regex` | CWE-1333 | medium | A nested quantifier inside a quantified group, e.g. `(a+)+`, `(.*)*` |
| `insecure-temp-file` | CWE-377 | medium | A hardcoded `/tmp/<name>` path, or an unsafe `tmpnam`/`mktemp` call |

### Precision notes

- `xpath-injection` stays quiet on a constant query and on a precompiled expression.
- `redos-vulnerable-regex` only fires on lines that actually construct a regex (`regexp.`, `RegExp`, `re.compile`, `MustCompile`, ...), so ordinary parenthesised arithmetic like `(base + tax) * qty` is ignored.
- `insecure-temp-file` stays quiet on the safe APIs `os.CreateTemp`, `os.MkdirTemp` and `tempfile.NamedTemporaryFile`.

`go build ./...`, `go vet`, and the full `sast` package tests pass.

Closes #66
Closes #67
Closes #68
