### PR TITLE
feat(misconfig): Terraform unencrypted EBS + disabled S3 versioning rules

### DIFF
--- a/internal/infrastructure/tools/misconfig/terraform.go
+++ b/internal/infrastructure/tools/misconfig/terraform.go
@@ -37,6 +37,7 @@ func scanTerraform(rel string, data []byte) []ports.MisconfigRawFinding {
 	}
 	var stack []*frame
 	depth := 0
+	sawEnabledVersioning := false
 
 	for i, raw := range lines {
 		line := stripHCLComment(raw)
@@ -60,7 +61,29 @@ func scanTerraform(rel string, data []byte) []ports.MisconfigRawFinding {
 			f := stack[len(stack)-1]
 			stack = stack[:len(stack)-1]
 			out = append(out, tfBlockRules(rel, f.typ, f.start, f.body.String())...) // block-level missing-setting rules
+			if f.typ == "aws_s3_bucket_versioning" && strings.Contains(f.body.String(), `"Enabled"`) {
+				sawEnabledVersioning = true
+			}
 		}
+	}
+	// Provider v4+ manages versioning in a separate aws_s3_bucket_versioning resource, so an aws_s3_bucket
+	// block legitimately omits an inline versioning block. When the file has an Enabled versioning resource,
+	// drop the bucket-origin "no versioning" finding to avoid a false positive on the modern split style.
+	if sawEnabledVersioning {
+		out = filterOutBucketVersioning(out)
+	}
+	return out
+}
+
+// filterOutBucketVersioning removes terraform-s3-no-versioning findings that originate from an
+// aws_s3_bucket block (as opposed to an aws_s3_bucket_versioning resource).
+func filterOutBucketVersioning(in []ports.MisconfigRawFinding) []ports.MisconfigRawFinding {
+	out := in[:0]
+	for _, f := range in {
+		if f.RuleID == "terraform-s3-no-versioning" && f.Resource == "Terraform aws_s3_bucket" {
+			continue
+		}
+		out = append(out, f)
 	}
 	return out
 }

--- a/internal/infrastructure/tools/misconfig/terraform.go
+++ b/internal/infrastructure/tools/misconfig/terraform.go
@@ -105,10 +105,29 @@ func tfBlockRules(rel, resType string, line int, body string) []ports.MisconfigR
 			add("terraform-sns-unencrypted", "SNS topic not encrypted", shared.SeverityMedium,
 				"The SNS topic sets no kms_master_key_id, so messages are not encrypted at rest. Set kms_master_key_id to a KMS key.")
 		}
+	case "aws_ebs_volume":
+		// A missing `encrypted` leaves the volume unencrypted at rest (the AWS default). An explicit
+		// `encrypted = false` is already caught by the line-level terraform-encryption-disabled rule, so
+		// only the absent-attribute case is handled here to avoid a duplicate finding.
+		if !has("encrypted") {
+			add("terraform-ebs-unencrypted", "EBS volume not encrypted at rest", shared.SeverityMedium,
+				"The aws_ebs_volume sets no encrypted = true, so the volume is unencrypted at rest. Set encrypted = true (and kms_key_id for a customer-managed key).")
+		}
 	case "aws_s3_bucket":
 		if !has("logging") {
 			add("terraform-s3-no-logging", "S3 bucket access logging disabled", shared.SeverityLow,
 				"The bucket configures no access logging, so object access is not audited. Enable server access logging (a logging block or an aws_s3_bucket_logging resource).")
+		}
+		if !has("versioning") {
+			add("terraform-s3-no-versioning", "S3 bucket versioning not enabled", shared.SeverityLow,
+				"The bucket enables no versioning, so an overwritten or deleted object cannot be recovered, weakening resilience against accidental loss and ransomware. Add a versioning block (or an aws_s3_bucket_versioning resource) with status = \"Enabled\".")
+		}
+	case "aws_s3_bucket_versioning":
+		// The modern split resource. Anything other than an Enabled status (Suspended, Disabled, or an
+		// unset status) leaves versioning off.
+		if !strings.Contains(body, `"Enabled"`) {
+			add("terraform-s3-no-versioning", "S3 bucket versioning not enabled", shared.SeverityLow,
+				"The aws_s3_bucket_versioning resource does not set status = \"Enabled\" (it is Suspended, Disabled, or unset), so object versions are not retained. Set versioning_configuration { status = \"Enabled\" }.")
 		}
 	case "aws_instance", "aws_launch_template":
 		if !has("metadata_options") || (has("metadata_options") && !strings.Contains(body, "required")) {

--- a/internal/infrastructure/tools/misconfig/terraform_test.go
+++ b/internal/infrastructure/tools/misconfig/terraform_test.go
@@ -107,6 +107,31 @@ resource "aws_ecr_repository" "r" {
 	}
 }
 
+func TestTerraformS3VersioningSplitStyle(t *testing.T) {
+	// Provider v4+ style: the bucket omits an inline versioning block and versioning is set on a
+	// separate aws_s3_bucket_versioning resource. An Enabled split resource must suppress the
+	// bucket-origin "no versioning" false positive.
+	tf := `resource "aws_s3_bucket" "b" {
+  bucket = "my-bucket"
+  acl    = "private"
+  logging {
+    target_bucket = "logs"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "v" {
+  bucket = aws_s3_bucket.b.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+`
+	got := ruleIDs(scan(t, map[string]string{"main.tf": tf}))
+	if _, ok := got["terraform-s3-no-versioning"]; ok {
+		t.Errorf("split-style Enabled versioning must not flag terraform-s3-no-versioning, got %v", keys(got))
+	}
+}
+
 func TestHelmRenderedIfAvailable(t *testing.T) {
 	if _, err := exec.LookPath("helm"); err != nil {
 		t.Skip("helm not installed; Helm rendering is best-effort and skipped")

--- a/internal/infrastructure/tools/misconfig/terraform_test.go
+++ b/internal/infrastructure/tools/misconfig/terraform_test.go
@@ -35,6 +35,18 @@ resource "aws_ecr_repository" "r" {
 resource "aws_dynamodb_table" "t" {
   name = "items"
 }
+
+resource "aws_ebs_volume" "v" {
+  availability_zone = "us-east-1a"
+  size              = 20
+}
+
+resource "aws_s3_bucket_versioning" "v" {
+  bucket = aws_s3_bucket.b.id
+  versioning_configuration {
+    status = "Suspended"
+  }
+}
 `
 	got := ruleIDs(scan(t, map[string]string{"main.tf": tf}))
 	for _, want := range []string{
@@ -42,6 +54,7 @@ resource "aws_dynamodb_table" "t" {
 		"terraform-encryption-disabled", "terraform-plaintext-secret",
 		"terraform-ecr-mutable-tags", "terraform-ecr-no-cmk",
 		"terraform-dynamodb-unencrypted", "terraform-dynamodb-no-pitr",
+		"terraform-ebs-unencrypted", "terraform-s3-no-versioning",
 	} {
 		if _, ok := got[want]; !ok {
 			t.Errorf("expected Terraform rule %q, got %v", want, keys(got))
@@ -58,6 +71,15 @@ func TestTerraformSecureNoFindings(t *testing.T) {
   logging {
     target_bucket = "logs"
   }
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_ebs_volume" "v" {
+  availability_zone = "us-east-1a"
+  size              = 20
+  encrypted         = true
 }
 
 resource "aws_security_group" "sg" {


### PR DESCRIPTION
Two new whole-block Terraform posture rules in `tfBlockRules`, following the existing `terraform-dynamodb-unencrypted` / `terraform-s3-no-logging` templates.

| Rule id | Severity | Fires when |
|---|---|---|
| `terraform-ebs-unencrypted` | medium | `aws_ebs_volume` has no `encrypted = true` (unencrypted at rest, the AWS default) |
| `terraform-s3-no-versioning` | low | `aws_s3_bucket` has no `versioning` block, or an `aws_s3_bucket_versioning` resource whose status is not `"Enabled"` (Suspended, Disabled, or unset) |

### Precision

- `encrypted = false` on an EBS volume is already caught by the line-level `terraform-encryption-disabled` rule, so the EBS rule only fires on the *absent* attribute to avoid a duplicate finding.
- Insecure and secure fixtures are added to `terraform_test.go`; the hardened set now includes `versioning { enabled = true }` and an `encrypted = true` volume so it stays clean.

`make build vet test` green.

Closes #55
Closes #69
