### PR TITLE
feat(sca): owned SBOM parsers for renv.lock, Manifest.toml, conan.lock

### DIFF
--- a/internal/infrastructure/tools/ownsbom/conan.go
+++ b/internal/infrastructure/tools/ownsbom/conan.go
@@ -1,0 +1,92 @@
+package ownsbom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// Conan is the owned C/C++ parser: it reads conan.lock — the resolved dependency set produced by the
+// Conan package manager — into conan components. Two lockfile shapes are handled: the Conan 2.x form,
+// which lists reference strings under "requires"/"build_requires"/"python_requires", and the Conan 1.x
+// form, which nests a "graph_lock" whose node "ref" fields carry the same reference strings. A reference
+// is name/version[@user/channel][#recipe_revision]; the name and version are extracted from it. Components
+// only — the 1.x graph edges are deferred. Vendor-neutral (stdlib encoding/json).
+type Conan struct{}
+
+// Ecosystem identifies this parser's package ecosystem.
+func (Conan) Ecosystem() string { return "conan" }
+
+// Markers are the lockfile basenames Conan claims.
+func (Conan) Markers() []string { return []string{"conan.lock"} }
+
+// conanLock covers both lockfile shapes: the 2.x top-level reference lists and the 1.x graph_lock nodes.
+type conanLock struct {
+	Requires       []string `json:"requires"`
+	BuildRequires  []string `json:"build_requires"`
+	PythonRequires []string `json:"python_requires"`
+	GraphLock      struct {
+		Nodes map[string]struct {
+			Ref string `json:"ref"`
+		} `json:"nodes"`
+	} `json:"graph_lock"`
+}
+
+// Parse extracts the resolved Conan packages from a conan.lock across both shapes. Result is sorted by
+// PURL — the 2.x lists are ordered but the 1.x nodes map is not, so sorting keeps output deterministic.
+func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	var lock conanLock
+	if err := json.Unmarshal(in.Content, &lock); err != nil {
+		return nil, nil, fmt.Errorf("parse conan.lock: %w", err)
+	}
+	scope := sbom.ClassifyScope(in.Path, "")
+	set := newComponentSet()
+	add := func(ref string) {
+		name, version := parseConanRef(ref)
+		if name == "" || version == "" {
+			return
+		}
+		set.add(sbom.Component{
+			Name:     name,
+			Version:  version,
+			PURL:     "pkg:conan/" + name + "@" + version,
+			Location: in.Path,
+			Scope:    scope,
+		})
+	}
+	for _, refs := range [][]string{lock.Requires, lock.BuildRequires, lock.PythonRequires} {
+		for _, ref := range refs {
+			add(ref)
+		}
+	}
+	for _, node := range lock.GraphLock.Nodes {
+		add(node.Ref)
+	}
+	comps := set.components()
+	sort.Slice(comps, func(i, j int) bool { return comps[i].PURL < comps[j].PURL })
+	return comps, nil, nil
+}
+
+// parseConanRef splits a Conan reference name/version[@user/channel][#recipe_revision] into its name and
+// version. The version is the segment after the first "/", cut at the first "@" (user/channel) or "#"
+// (recipe revision). Returns empty strings when the ref has no version segment.
+func parseConanRef(ref string) (string, string) {
+	ref = strings.TrimSpace(ref)
+	slash := strings.IndexByte(ref, '/')
+	if slash <= 0 {
+		return "", "" // a bare name with no version is not a resolved component
+	}
+	name := ref[:slash]
+	rest := ref[slash+1:]
+	if i := strings.IndexAny(rest, "@#"); i >= 0 {
+		rest = rest[:i]
+	}
+	return strings.TrimSpace(name), strings.TrimSpace(rest)
+}

--- a/internal/infrastructure/tools/ownsbom/conan_test.go
+++ b/internal/infrastructure/tools/ownsbom/conan_test.go
@@ -1,0 +1,92 @@
+package ownsbom
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// Conan 2.x: reference strings under requires / build_requires / python_requires.
+const conanLockV2Fixture = `{
+  "version": "0.5",
+  "requires": [
+    "zlib/1.2.13#dd1f9f9e73f5c3d0e9e7f5c8a1234567",
+    "openssl/3.1.0@_/_#abcdef"
+  ],
+  "build_requires": [
+    "cmake/3.27.0"
+  ],
+  "python_requires": []
+}`
+
+// Conan 1.x: a graph_lock whose node ref fields carry the same reference strings.
+const conanLockV1Fixture = `{
+  "version": "0.4",
+  "graph_lock": {
+    "nodes": {
+      "0": {"ref": "app/1.0"},
+      "1": {"ref": "boost/1.83.0#rev123"}
+    }
+  }
+}`
+
+func TestConanParseV2(t *testing.T) {
+	comps, deps, err := Conan{}.Parse(context.Background(), ParseInput{Path: "conan.lock", Content: []byte(conanLockV2Fixture)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if deps != nil {
+		t.Errorf("edges not emitted; want nil deps, got %v", deps)
+	}
+	byName := map[string]sbom.Component{}
+	for _, c := range comps {
+		byName[c.Name] = c
+	}
+	if len(comps) != 3 {
+		t.Fatalf("want 3 components (zlib, openssl, cmake), got %d (%+v)", len(comps), comps)
+	}
+	if c := byName["zlib"]; c.PURL != "pkg:conan/zlib@1.2.13" {
+		t.Errorf("zlib PURL wrong (revision must be stripped): %+v", c)
+	}
+	if c := byName["openssl"]; c.Version != "3.1.0" {
+		t.Errorf("openssl version wrong (user/channel + revision must be stripped): %+v", c)
+	}
+}
+
+func TestConanParseV1(t *testing.T) {
+	comps, _, err := Conan{}.Parse(context.Background(), ParseInput{Path: "conan.lock", Content: []byte(conanLockV1Fixture)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	byName := map[string]sbom.Component{}
+	for _, c := range comps {
+		byName[c.Name] = c
+	}
+	if len(comps) != 2 {
+		t.Fatalf("want 2 components (app, boost), got %d (%+v)", len(comps), comps)
+	}
+	if c := byName["boost"]; c.PURL != "pkg:conan/boost@1.83.0" {
+		t.Errorf("boost PURL wrong: %+v", c)
+	}
+}
+
+func TestConanParseDeterministic(t *testing.T) {
+	// The 1.x graph_lock nodes map has no inherent order; the parser sorts by PURL for stable output.
+	c1, _, _ := Conan{}.Parse(context.Background(), ParseInput{Path: "conan.lock", Content: []byte(conanLockV1Fixture)})
+	c2, _, _ := Conan{}.Parse(context.Background(), ParseInput{Path: "conan.lock", Content: []byte(conanLockV1Fixture)})
+	if len(c1) != len(c2) {
+		t.Fatalf("length mismatch %d vs %d", len(c1), len(c2))
+	}
+	for i := range c1 {
+		if c1[i].PURL != c2[i].PURL {
+			t.Errorf("order not deterministic at %d: %q vs %q", i, c1[i].PURL, c2[i].PURL)
+		}
+	}
+}
+
+func TestConanParseMalformed(t *testing.T) {
+	if _, _, err := (Conan{}).Parse(context.Background(), ParseInput{Path: "conan.lock", Content: []byte("{bad")}); err == nil {
+		t.Error("malformed conan.lock must fail loud")
+	}
+}

--- a/internal/infrastructure/tools/ownsbom/default_test.go
+++ b/internal/infrastructure/tools/ownsbom/default_test.go
@@ -10,7 +10,7 @@ func TestDefaultRegistry(t *testing.T) {
 		t.Fatalf("DefaultRegistry: %v", err)
 	}
 	for _, marker := range []string{
-		"go.mod", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "requirements.txt", "requirements-dev.txt", "poetry.lock", "pipfile.lock", "cargo.lock", "pom.xml", "libs.versions.toml", "gemfile.lock", "composer.lock", "packages.lock.json", "package.resolved", "pubspec.lock", "mix.lock", "environment.yml", "environment.yaml",
+		"go.mod", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "requirements.txt", "requirements-dev.txt", "poetry.lock", "pipfile.lock", "cargo.lock", "pom.xml", "libs.versions.toml", "gemfile.lock", "composer.lock", "packages.lock.json", "package.resolved", "pubspec.lock", "mix.lock", "environment.yml", "environment.yaml", "renv.lock", "manifest.toml", "conan.lock",
 	} {
 		if _, ok := reg.byMarker[marker]; !ok {
 			t.Errorf("DefaultRegistry missing marker %q", marker)
@@ -18,7 +18,7 @@ func TestDefaultRegistry(t *testing.T) {
 	}
 	// yarn + pnpm share the npm ecosystem, Pipfile shares pypi, and Gradle shares maven, so the distinct
 	// ecosystem set contains each shared PURL type only once.
-	want := []string{"cargo", "composer", "conda", "gem", "go", "hex", "maven", "npm", "nuget", "pub", "pypi", "swift"}
+	want := []string{"cargo", "composer", "conan", "conda", "cran", "gem", "go", "hex", "julia", "maven", "npm", "nuget", "pub", "pypi", "swift"}
 	if len(reg.ecos) != len(want) {
 		t.Fatalf("DefaultRegistry ecosystems = %v, want %v", reg.ecos, want)
 	}

--- a/internal/infrastructure/tools/ownsbom/julia.go
+++ b/internal/infrastructure/tools/ownsbom/julia.go
@@ -1,0 +1,69 @@
+package ownsbom
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// Julia is the owned Julia parser: it reads Manifest.toml — the resolved dependency set produced by Pkg —
+// into julia components. Both manifest_format 1.0 (top-level [[Name]] array-of-tables) and 2.0
+// ([[deps.Name]]) are handled. A package block carries a `version = "x"`; standard-library packages that
+// ship with Julia have no version and are skipped (they are not registry dependencies to match against an
+// advisory). Hand-parsed (the targeted array-table header + version line), no TOML library, vendor-neutral.
+// Components only — the per-package `deps` edges are deferred.
+type Julia struct{}
+
+// Ecosystem identifies this parser's package ecosystem.
+func (Julia) Ecosystem() string { return "julia" }
+
+// Markers are the lockfile basenames Julia claims.
+func (Julia) Markers() []string { return []string{"Manifest.toml"} }
+
+// Parse extracts the resolved Julia packages from a Manifest.toml. It tracks the current package name from
+// each array-table header ([[Name]] or [[deps.Name]]) and reads its `version`; a block with no version
+// (a bundled standard library) is skipped. Result is sorted by PURL for deterministic output.
+func (Julia) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	scope := sbom.ClassifyScope(in.Path, "")
+	set := newComponentSet()
+
+	curName := ""
+	sc := bufio.NewScanner(bytes.NewReader(in.Content))
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		switch {
+		case strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]"):
+			// An array-table header opens a new package block: [[Name]] (format 1.0) or
+			// [[deps.Name]] (format 2.0). A subsequent version line binds to this name.
+			inner := strings.TrimSpace(line[2 : len(line)-2])
+			curName = strings.TrimPrefix(inner, "deps.")
+			curName = strings.Trim(strings.TrimSpace(curName), `"`)
+		case strings.HasPrefix(line, "["):
+			curName = "" // any other table header ends the package block
+		case curName != "" && strings.HasPrefix(line, "version") && strings.Contains(line, "="):
+			version := tomlString(line[strings.IndexByte(line, '=')+1:])
+			if version == "" {
+				continue
+			}
+			set.add(sbom.Component{
+				Name:     curName,
+				Version:  version,
+				PURL:     "pkg:julia/" + curName + "@" + version,
+				Location: in.Path,
+				Scope:    scope,
+			})
+			curName = "" // one version per package block; avoid a stray later match rebinding it
+		}
+	}
+	comps := set.components()
+	sort.Slice(comps, func(i, j int) bool { return comps[i].PURL < comps[j].PURL })
+	return comps, nil, nil
+}

--- a/internal/infrastructure/tools/ownsbom/julia.go
+++ b/internal/infrastructure/tools/ownsbom/julia.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -62,6 +63,9 @@ func (Julia) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 			})
 			curName = "" // one version per package block; avoid a stray later match rebinding it
 		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, nil, fmt.Errorf("parse Manifest.toml: %w", err)
 	}
 	comps := set.components()
 	sort.Slice(comps, func(i, j int) bool { return comps[i].PURL < comps[j].PURL })

--- a/internal/infrastructure/tools/ownsbom/julia_test.go
+++ b/internal/infrastructure/tools/ownsbom/julia_test.go
@@ -1,0 +1,83 @@
+package ownsbom
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// manifest_format 2.0: packages nest under [[deps.Name]]. Dates (a bundled stdlib) has no version.
+const juliaManifestV2Fixture = `# This file is machine-generated - editing it directly is not advised
+julia_version = "1.9.3"
+manifest_format = "2.0"
+
+[[deps.DataFrames]]
+deps = ["Missings", "PrettyTables"]
+git-tree-sha1 = "04c738083f29f86e62c8afc341f0967d8717bdb8"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "1.6.1"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers"]
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+`
+
+// manifest_format 1.0: packages are top-level [[Name]] array-of-tables.
+const juliaManifestV1Fixture = `[[Example]]
+git-tree-sha1 = "abc"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.3"
+`
+
+func TestJuliaParseFormat2(t *testing.T) {
+	comps, deps, err := Julia{}.Parse(context.Background(), ParseInput{Path: "Manifest.toml", Content: []byte(juliaManifestV2Fixture)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if deps != nil {
+		t.Errorf("edges not emitted; want nil deps, got %v", deps)
+	}
+	byName := map[string]sbom.Component{}
+	for _, c := range comps {
+		byName[c.Name] = c
+	}
+	// DataFrames + JSON = 2; Dates (no version, a bundled stdlib) is dropped.
+	if len(comps) != 2 {
+		t.Fatalf("want 2 components (Dates has no version), got %d (%+v)", len(comps), comps)
+	}
+	if c := byName["DataFrames"]; c.PURL != "pkg:julia/DataFrames@1.6.1" {
+		t.Errorf("DataFrames PURL wrong: %+v", c)
+	}
+	if _, ok := byName["Dates"]; ok {
+		t.Error("a stdlib package with no version must not be emitted")
+	}
+}
+
+func TestJuliaParseFormat1(t *testing.T) {
+	comps, _, err := Julia{}.Parse(context.Background(), ParseInput{Path: "Manifest.toml", Content: []byte(juliaManifestV1Fixture)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(comps) != 1 || comps[0].PURL != "pkg:julia/Example@0.5.3" {
+		t.Fatalf("want Example@0.5.3, got %+v", comps)
+	}
+}
+
+func TestJuliaParseDeterministic(t *testing.T) {
+	c1, _, _ := Julia{}.Parse(context.Background(), ParseInput{Path: "Manifest.toml", Content: []byte(juliaManifestV2Fixture)})
+	c2, _, _ := Julia{}.Parse(context.Background(), ParseInput{Path: "Manifest.toml", Content: []byte(juliaManifestV2Fixture)})
+	if len(c1) != len(c2) {
+		t.Fatalf("length mismatch %d vs %d", len(c1), len(c2))
+	}
+	for i := range c1 {
+		if c1[i].PURL != c2[i].PURL {
+			t.Errorf("order not deterministic at %d: %q vs %q", i, c1[i].PURL, c2[i].PURL)
+		}
+	}
+}

--- a/internal/infrastructure/tools/ownsbom/registry.go
+++ b/internal/infrastructure/tools/ownsbom/registry.go
@@ -92,7 +92,7 @@ func New(parsers ...EcosystemParser) (*Registry, error) {
 // Rust, and Java (Maven pom.xml + Gradle libs.versions.toml) — the detection-independent SBOM producer.
 // The parsers claim distinct markers, so New does not error here in practice.
 func DefaultRegistry() (*Registry, error) {
-	return New(GoMod{}, NPM{}, Yarn{}, Pnpm{}, PyPI{}, Poetry{}, Pipfile{}, Cargo{}, Maven{}, Gradle{}, Gem{}, Composer{}, NuGet{}, Swift{}, Dart{}, Elixir{}, Conda{})
+	return New(GoMod{}, NPM{}, Yarn{}, Pnpm{}, PyPI{}, Poetry{}, Pipfile{}, Cargo{}, Maven{}, Gradle{}, Gem{}, Composer{}, NuGet{}, Swift{}, Dart{}, Elixir{}, Conda{}, Renv{}, Julia{}, Conan{})
 }
 
 // Generate walks the target directory, parses every recognized manifest with its EcosystemParser, and

--- a/internal/infrastructure/tools/ownsbom/registry.go
+++ b/internal/infrastructure/tools/ownsbom/registry.go
@@ -88,9 +88,10 @@ func New(parsers ...EcosystemParser) (*Registry, error) {
 	return r, nil
 }
 
-// DefaultRegistry assembles the owned parsers into a producer covering Go, JS (npm + yarn), Python, Conda,
-// Rust, and Java (Maven pom.xml + Gradle libs.versions.toml) — the detection-independent SBOM producer.
-// The parsers claim distinct markers, so New does not error here in practice.
+// DefaultRegistry assembles the owned parsers into the detection-independent SBOM producer, covering Go,
+// JS (npm/yarn/pnpm), Python (PyPI/Poetry/Pipfile/Conda), Rust, Java (Maven + Gradle), Ruby, PHP,.NET,
+// Swift, Dart, Elixir, R (renv), Julia, and Conan. The parsers claim distinct markers, so New does not
+// error here in practice.
 func DefaultRegistry() (*Registry, error) {
 	return New(GoMod{}, NPM{}, Yarn{}, Pnpm{}, PyPI{}, Poetry{}, Pipfile{}, Cargo{}, Maven{}, Gradle{}, Gem{}, Composer{}, NuGet{}, Swift{}, Dart{}, Elixir{}, Conda{}, Renv{}, Julia{}, Conan{})
 }

--- a/internal/infrastructure/tools/ownsbom/renv.go
+++ b/internal/infrastructure/tools/ownsbom/renv.go
@@ -1,0 +1,68 @@
+package ownsbom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// Renv is the owned R parser: it reads renv.lock — the resolved dependency set produced by the renv
+// package manager — into cran components. renv.lock is JSON with a top-level "Packages" object mapping a
+// package name to a record carrying its "Package" and "Version". Components only — renv records a per-
+// package "Requirements" list, but those edges are deferred. Vendor-neutral (stdlib encoding/json).
+type Renv struct{}
+
+// Ecosystem identifies this parser's package ecosystem.
+func (Renv) Ecosystem() string { return "cran" }
+
+// Markers are the lockfile basenames Renv claims.
+func (Renv) Markers() []string { return []string{"renv.lock"} }
+
+// renvLock is the subset of renv.lock we parse: the resolved package records.
+type renvLock struct {
+	Packages map[string]renvPackage `json:"Packages"`
+}
+
+type renvPackage struct {
+	Package string `json:"Package"` // the canonical package name (authoritative over the map key)
+	Version string `json:"Version"` // the concrete resolved version
+}
+
+// Parse extracts the resolved R packages from a renv.lock. The record's "Package" is preferred over the
+// map key for the name (they normally agree); a record missing a name or version is skipped. Result is
+// sorted by PURL — renv.lock's Packages object has no inherent order, so sorting keeps output deterministic.
+func (Renv) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	var lock renvLock
+	if err := json.Unmarshal(in.Content, &lock); err != nil {
+		return nil, nil, fmt.Errorf("parse renv.lock: %w", err)
+	}
+	scope := sbom.ClassifyScope(in.Path, "")
+	set := newComponentSet()
+	for key, p := range lock.Packages {
+		name := strings.TrimSpace(p.Package)
+		if name == "" {
+			name = strings.TrimSpace(key)
+		}
+		version := strings.TrimSpace(p.Version)
+		if name == "" || version == "" {
+			continue
+		}
+		set.add(sbom.Component{
+			Name:     name,
+			Version:  version,
+			PURL:     "pkg:cran/" + name + "@" + version,
+			Location: in.Path,
+			Scope:    scope,
+		})
+	}
+	comps := set.components()
+	sort.Slice(comps, func(i, j int) bool { return comps[i].PURL < comps[j].PURL })
+	return comps, nil, nil
+}

--- a/internal/infrastructure/tools/ownsbom/renv_test.go
+++ b/internal/infrastructure/tools/ownsbom/renv_test.go
@@ -1,0 +1,77 @@
+package ownsbom
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+const renvLockFixture = `{
+  "R": {
+    "Version": "4.3.1",
+    "Repositories": [
+      {"Name": "CRAN", "URL": "https://cloud.r-project.org"}
+    ]
+  },
+  "Packages": {
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "dplyr": {
+      "Package": "dplyr",
+      "Version": "1.1.3",
+      "Source": "Repository"
+    },
+    "brokenNoVersion": {
+      "Package": "brokenNoVersion"
+    }
+  }
+}`
+
+func TestRenvParse(t *testing.T) {
+	comps, deps, err := Renv{}.Parse(context.Background(), ParseInput{Path: "renv.lock", Content: []byte(renvLockFixture)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if deps != nil {
+		t.Errorf("edges not emitted; want nil deps, got %v", deps)
+	}
+	byName := map[string]sbom.Component{}
+	for _, c := range comps {
+		byName[c.Name] = c
+	}
+	// ggplot2 + dplyr = 2; the record with no Version is dropped.
+	if len(comps) != 2 {
+		t.Fatalf("want 2 components (no-version dropped), got %d (%+v)", len(comps), comps)
+	}
+	if c := byName["ggplot2"]; c.PURL != "pkg:cran/ggplot2@3.4.4" {
+		t.Errorf("ggplot2 PURL wrong: %+v", c)
+	}
+	if _, ok := byName["brokenNoVersion"]; ok {
+		t.Error("a package with no Version must not be emitted")
+	}
+}
+
+func TestRenvParseDeterministic(t *testing.T) {
+	// renv.lock's Packages object has no inherent order; the parser sorts by PURL for stable output.
+	c1, _, _ := Renv{}.Parse(context.Background(), ParseInput{Path: "renv.lock", Content: []byte(renvLockFixture)})
+	c2, _, _ := Renv{}.Parse(context.Background(), ParseInput{Path: "renv.lock", Content: []byte(renvLockFixture)})
+	if len(c1) != len(c2) {
+		t.Fatalf("length mismatch %d vs %d", len(c1), len(c2))
+	}
+	for i := range c1 {
+		if c1[i].PURL != c2[i].PURL {
+			t.Errorf("order not deterministic at %d: %q vs %q", i, c1[i].PURL, c2[i].PURL)
+		}
+	}
+}
+
+func TestRenvParseMalformed(t *testing.T) {
+	if _, _, err := (Renv{}).Parse(context.Background(), ParseInput{Path: "renv.lock", Content: []byte("{bad")}); err == nil {
+		t.Error("malformed renv.lock must fail loud")
+	}
+}


### PR DESCRIPTION
Three new first-party `ownsbom` parsers, each registered in `DefaultRegistry` so a project in these ecosystems gets a first-party SBOM instead of the Syft fallback.

| Parser | Ecosystem | Marker | Notes |
|---|---|---|---|
| `Renv` | `cran` | `renv.lock` | JSON `Packages` object; name from each record's `Package`, `Version` as the concrete version |
| `Julia` | `julia` | `Manifest.toml` | both `manifest_format` 1.0 (`[[Name]]`) and 2.0 (`[[deps.Name]]`); a block with no version (a bundled stdlib) is skipped. Hand-parsed, no TOML library |
| `Conan` | `conan` | `conan.lock` | both the 2.x `requires`/`build_requires`/`python_requires` reference lists and the 1.x `graph_lock` node refs; name/version parsed from `name/version[@user/channel][#revision]` |

Each parser dedups by PURL and sorts output for determinism, mirroring the existing `NuGet` parser. Fixtures cover both format versions where applicable, plus malformed-input fail-loud and determinism tests.

`make build vet test` green. No new dependency.

Closes #63
Closes #64
Closes #65
