### PR TITLE
docs: GitLab CI + Jenkins recipes and a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Synapse is under active development and has not cut a tagged release yet. The
+capabilities below are already shipped on `main`.
+
+### Added
+
+- **SCA (software composition analysis).** First-party SBOM generation across many
+  lockfile ecosystems, advisory matching against OSV/GHSA/CSAF, and severity/risk
+  prioritisation (CISA KEV, EPSS, CVSS). Vulnerabilities at or above a threshold become
+  findings.
+- **SAST (static analysis).** First-party source-code pattern rules across common
+  languages, covering weaknesses such as weak crypto, hardcoded credentials, injection,
+  insecure TLS, XPath injection, ReDoS, and insecure temporary files.
+- **Secret scanning.** Detection of hardcoded credentials and key material (AWS keys,
+  private keys, generic credential assignments) with placeholder/env-reference filtering.
+- **IaC misconfiguration scanning.** Owned checks for Dockerfile, Kubernetes, Helm,
+  Terraform, and CloudFormation.
+- **SARIF output.** `synapse-cli scan --sarif` emits a SARIF 2.1.0 report for GitHub code
+  scanning and other SARIF consumers, with a file and line for SAST, secret, and misconfig
+  findings.
+- **CLI merge gate.** `synapse-cli scan . --fail-on <severity>` exits non-zero when a
+  finding at or above the threshold is present, for use in CI pipelines.
+
+[Unreleased]: https://github.com/KKloudTarus/synapse-ce/commits/main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ If a change would weaken any of these, please open an issue to discuss first.
 - Include tests for new behavior.
 - Ensure `make build vet test typecheck` and `cd web && pnpm build` pass.
 - Use clear, conventional commit messages (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`).
+- For a user-visible change, add an entry under the `Unreleased` section of [`CHANGELOG.md`](CHANGELOG.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The only required variable is `SYNAPSE_API_TOKEN`. See the
 
 Full documentation lives in [`docs/guide/`](docs/guide/README.md): introduction, installation,
 quickstart, features, configuration, CLI, architecture, deployment, and the security model.
+See [`CHANGELOG.md`](CHANGELOG.md) for what has changed.
 
 ## Roadmap
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -94,4 +94,72 @@ Or emit SARIF and upload it to the GitHub Security tab, while still failing the 
 The report lands in the repository's Code scanning alerts, with each SAST, secret and misconfig
 finding annotated on its exact source line.
 
+## GitLab CI
+
+The same gate as a GitLab job. `make tools` installs syft and grype, `make build` produces
+`./bin/synapse-cli`, and a non-zero exit from the scan fails the pipeline:
+
+```yaml
+synapse-scan:
+  stage: test
+  image: golang:1.26
+  script:
+    - make tools
+    - make build
+    - ./bin/synapse-cli scan . --fail-on high
+```
+
+To publish to the GitLab SAST report so findings show in the merge-request widget, emit SARIF and
+keep it as an artifact (GitLab reads SARIF as a `sast` report):
+
+```yaml
+synapse-scan:
+  stage: test
+  image: golang:1.26
+  script:
+    - make tools
+    - make build
+    - ./bin/synapse-cli scan . --sarif --fail-on high > gl-sast-report.sarif
+  artifacts:
+    when: always
+    reports:
+      sast: gl-sast-report.sarif
+```
+
+## Jenkins
+
+A declarative pipeline stage. The scan's exit code fails the stage on a finding at or above the
+threshold:
+
+```groovy
+pipeline {
+  agent { docker { image 'golang:1.26' } }
+  stages {
+    stage('Synapse scan') {
+      steps {
+        sh 'make tools'
+        sh 'make build'
+        sh './bin/synapse-cli scan . --fail-on high'
+      }
+    }
+  }
+}
+```
+
+To keep the SARIF report as a build artifact (for a platform or plugin that ingests SARIF), let the
+scan step record its exit code, archive the report, then fail the build explicitly:
+
+```groovy
+stage('Synapse scan') {
+  steps {
+    sh 'make tools && make build'
+    script {
+      def rc = sh(returnStatus: true, script: './bin/synapse-cli scan . --sarif --fail-on high > synapse.sarif')
+      archiveArtifacts artifacts: 'synapse.sarif', allowEmptyArchive: true
+      if (rc != 0) { error("Synapse found a finding at or above the fail-on threshold") }
+    }
+  }
+}
+```
+
 Next: [Architecture](architecture.md)


### PR DESCRIPTION
Docs-only. Covers two good-first-issues.

**#57 CI examples** in `docs/guide/cli.md`: GitLab CI and Jenkins declarative-pipeline recipes alongside the existing GitHub Actions one. Each has a plain `--fail-on high` gate plus a SARIF-artifact variant (GitLab `sast` report, Jenkins `archiveArtifacts` with an explicit exit-code check so the report is kept even when the gate fails).

**#73 CHANGELOG**: a new `CHANGELOG.md` in Keep a Changelog format with an `Unreleased` section listing the shipped capabilities (SCA, SAST, secret scanning, IaC misconfig, SARIF output, CLI gate), linked from the README. `CONTRIBUTING.md` now notes the convention to add an entry for a user-visible change.

No code, no dependency change.

Closes #57
Closes #73
