### PR TITLE
feat(quality): per-language code inventory (Code Quality Phase 0, slice 1)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -13,10 +13,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
@@ -25,6 +27,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/bincat"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/codeinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/enry"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gomodgraph"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gradleresolve"
@@ -74,9 +77,45 @@ func main() {
 			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 			os.Exit(1)
 		}
+	case "inventory":
+		if len(os.Args) < 3 {
+			usage() // missing <dir> exits 2
+		}
+		if err := runInventory(os.Args[2]); err != nil {
+			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
+			os.Exit(1)
+		}
 	default:
 		usage()
 	}
+}
+
+// runInventory prints a per-language code-size inventory for a local source tree (the Phase-0
+// code-quality surface). Pure-Go, read-only; no engagement/DB needed.
+func runInventory(dir string) error {
+	inv, err := codeinventory.New().Inventory(context.Background(), dir)
+	if err != nil {
+		return fmt.Errorf("inventory: %w", err)
+	}
+	fmt.Printf("\nSynapse code inventory — %s\n", dir)
+	fmt.Printf("  %-16s %8s %10s %10s %8s %10s\n", "language", "files", "code", "comment", "blank", "functions")
+	printInvRow := func(li measure.LanguageInventory) {
+		fn := "n/a"
+		if li.FunctionsKnown {
+			fn = strconv.Itoa(li.Functions)
+		}
+		fmt.Printf("  %-16s %8d %10d %10d %8d %10s\n", li.Language, li.Files, li.CodeLines, li.CommentLines, li.BlankLines, fn)
+	}
+	for _, li := range inv.Languages {
+		printInvRow(li)
+	}
+	if len(inv.Languages) == 0 {
+		fmt.Println("  (no source files detected)")
+		return nil
+	}
+	printInvRow(inv.Totals())
+	fmt.Println("  functions: accurate for Go; other languages land with the multi-language AST phase")
+	return nil
 }
 
 func usage() {
@@ -85,6 +124,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "      --sarif    write a SARIF 2.1.0 report to stdout (for GitHub code-scanning upload); --fail-on still sets the exit code")
 	fmt.Fprintln(os.Stderr, "      --image    treat the argument as a container image reference (pulled via crane) instead of a local path")
 	fmt.Fprintln(os.Stderr, "      --offline  skip the live OSV.dev source; detect with Grype's offline DB only (air-gapped / fast)")
+	fmt.Fprintln(os.Stderr, "  synapse-cli inventory <path>             # per-language code-size inventory (files, code/comment/blank lines, functions) — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote     # fetch + ingest app ecosystems from the OSV bulk bucket (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote-distros # fetch + ingest OS-package advisories (Debian/Alpine) from OSV (large; requires SYNAPSE_DB_DSN)")

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -98,6 +98,10 @@ func runInventory(dir string) error {
 		return fmt.Errorf("inventory: %w", err)
 	}
 	fmt.Printf("\nSynapse code inventory — %s\n", dir)
+	if len(inv.Languages) == 0 {
+		fmt.Println("  (no source files detected)")
+		return nil
+	}
 	fmt.Printf("  %-16s %8s %10s %10s %8s %10s\n", "language", "files", "code", "comment", "blank", "functions")
 	printInvRow := func(li measure.LanguageInventory) {
 		fn := "n/a"
@@ -108,10 +112,6 @@ func runInventory(dir string) error {
 	}
 	for _, li := range inv.Languages {
 		printInvRow(li)
-	}
-	if len(inv.Languages) == 0 {
-		fmt.Println("  (no source files detected)")
-		return nil
 	}
 	printInvRow(inv.Totals())
 	fmt.Println("  functions: accurate for Go; other languages land with the multi-language AST phase")

--- a/internal/domain/measure/inventory.go
+++ b/internal/domain/measure/inventory.go
@@ -1,0 +1,57 @@
+// Package measure holds numeric, non-finding project measures (code size, complexity, duplication,
+// coverage). It is the counterpart to domain/finding for the code-quality ("power tool") capability:
+// a finding is a defect to fix, a measure is a number that describes the codebase. Pure domain — data
+// types + deterministic rollups only, no I/O and no infrastructure types.
+package measure
+
+import "sort"
+
+// LanguageInventory is the code-size inventory for one detected programming/markup language over a
+// source tree. Line counts are exact; Functions is exact only for languages with a first-party parser
+// (Go today) and is 0 where accurate function counting is not yet available (the multi-language AST
+// phase fills the rest), so a 0 means "not counted", never "zero functions found".
+type LanguageInventory struct {
+	Language       string `json:"language"`
+	Files          int    `json:"files"`
+	CodeLines      int    `json:"code_lines"`
+	CommentLines   int    `json:"comment_lines"`
+	BlankLines     int    `json:"blank_lines"`
+	Functions      int    `json:"functions"`
+	FunctionsKnown bool   `json:"functions_known"` // whether Functions is an accurate count for this language
+}
+
+// TotalLines is the sum of code, comment and blank lines.
+func (li LanguageInventory) TotalLines() int { return li.CodeLines + li.CommentLines + li.BlankLines }
+
+// Inventory is a per-language code inventory over a source tree, sorted deterministically by language.
+type Inventory struct {
+	Languages []LanguageInventory `json:"languages"`
+}
+
+// NewInventory builds a sorted Inventory from a per-language accumulation map. Sorting by language name
+// keeps the output stable across runs (Go randomizes map iteration).
+func NewInventory(byLang map[string]LanguageInventory) Inventory {
+	langs := make([]LanguageInventory, 0, len(byLang))
+	for _, li := range byLang {
+		langs = append(langs, li)
+	}
+	sort.Slice(langs, func(i, j int) bool { return langs[i].Language < langs[j].Language })
+	return Inventory{Languages: langs}
+}
+
+// Totals sums the per-language counts into a single row labelled "TOTAL". FunctionsKnown is true only
+// when every language with functions had an accurate count, so the total is not silently understated.
+func (inv Inventory) Totals() LanguageInventory {
+	t := LanguageInventory{Language: "TOTAL", FunctionsKnown: true}
+	for _, li := range inv.Languages {
+		t.Files += li.Files
+		t.CodeLines += li.CodeLines
+		t.CommentLines += li.CommentLines
+		t.BlankLines += li.BlankLines
+		t.Functions += li.Functions
+		if !li.FunctionsKnown {
+			t.FunctionsKnown = false
+		}
+	}
+	return t
+}

--- a/internal/infrastructure/tools/codeinventory/analyzer.go
+++ b/internal/infrastructure/tools/codeinventory/analyzer.go
@@ -1,0 +1,235 @@
+// Package codeinventory is a deterministic, pure-Go code-size inventory: it walks a source tree,
+// classifies each file's language with go-enry, and counts code / comment / blank lines per language,
+// plus functions where a first-party parser exists (Go today, via go/parser). It NEVER executes the
+// target and reads bounded (skips vendored/binary/generated/oversized files, follows no symlinks),
+// mirroring the go-enry and SAST library adapters. It is the Phase-0 producer of the code-quality
+// capability; accurate multi-language function/complexity counting arrives with the AST phase.
+package codeinventory
+
+import (
+	"bytes"
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	enry "github.com/go-enry/go-enry/v2"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxFileBytes = 4 << 20 // skip files larger than 4 MiB (generated/data, not hand-written source)
+	maxFiles     = 200_000 // bound walk time on a hostile/huge tree
+)
+
+// skipDirs are heavy vendored/build trees never worth counting as first-party code.
+var skipDirs = map[string]bool{
+	".git": true, "node_modules": true, "vendor": true, "dist": true, "build": true,
+	".venv": true, "venv": true, "__pycache__": true, "target": true, ".idea": true,
+	".vscode": true, ".tox": true, ".hg": true, ".svn": true,
+}
+
+// Analyzer is the pure-Go code-inventory adapter.
+type Analyzer struct{}
+
+// New returns a new analyzer.
+func New() *Analyzer { return &Analyzer{} }
+
+var _ ports.CodeInventoryScanner = (*Analyzer)(nil)
+
+// Inventory walks root and returns a per-language code-size inventory. It honors ctx cancellation and
+// never aborts the whole walk on a single unreadable file.
+func (a *Analyzer) Inventory(ctx context.Context, root string) (measure.Inventory, error) {
+	if root == "" {
+		return measure.Inventory{}, nil
+	}
+	byLang := map[string]measure.LanguageInventory{}
+	files := 0
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries; don't abort the whole inventory
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if d.IsDir() {
+			if path != root && skipDirs[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() { // never follow symlinks/devices
+			return nil
+		}
+		if files++; files > maxFiles {
+			return io.EOF // stop the walk; bounded
+		}
+		content, ok := readBounded(path)
+		if !ok {
+			return nil
+		}
+		base := filepath.Base(path)
+		if enry.IsVendor(path) || enry.IsDotFile(path) || enry.IsGenerated(path, content) || enry.IsBinary(content) {
+			return nil
+		}
+		lang := enry.GetLanguage(base, content)
+		if lang == "" {
+			return nil
+		}
+		switch enry.GetLanguageType(lang) {
+		case enry.Programming, enry.Markup:
+		default:
+			return nil // skip data/prose/config-only languages for a code inventory
+		}
+
+		code, comment, blank := classifyLines(lang, content)
+		li := byLang[lang]
+		li.Language = lang
+		li.Files++
+		li.CodeLines += code
+		li.CommentLines += comment
+		li.BlankLines += blank
+		if fn, known := countFunctions(lang, content); known {
+			li.Functions += fn
+			li.FunctionsKnown = true
+		}
+		byLang[lang] = li
+		return nil
+	})
+	if walkErr != nil && walkErr != io.EOF {
+		return measure.Inventory{}, walkErr
+	}
+	return measure.NewInventory(byLang), nil
+}
+
+// readBounded reads up to maxFileBytes of a regular file via Lstat (never follows a symlink out of the
+// tree). ok=false on any miss (irregular, oversized, unreadable).
+func readBounded(path string) ([]byte, bool) {
+	fi, err := os.Lstat(path)
+	if err != nil || !fi.Mode().IsRegular() || fi.Size() > maxFileBytes {
+		return nil, false
+	}
+	b, err := os.ReadFile(path) // #nosec G304 -- regular file, size-capped via Lstat above, under the walked root
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}
+
+// commentSyntax describes a language's line- and block-comment delimiters for line classification.
+type commentSyntax struct {
+	line       []string
+	blockStart string
+	blockEnd   string
+}
+
+// syntaxByLang maps a go-enry language name to its comment syntax. Languages absent here have their
+// comment lines counted as code (a conservative, documented default), never miscounted as blank.
+var syntaxByLang = map[string]commentSyntax{
+	"Go":         {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"JavaScript": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"TypeScript": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"TSX":        {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"JSX":        {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"Java":       {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"Kotlin":     {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"Scala":      {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"C":          {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"C++":        {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"C#":         {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"Rust":       {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"Swift":      {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"Dart":       {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"PHP":        {line: []string{"//", "#"}, blockStart: "/*", blockEnd: "*/"},
+	"Python":     {line: []string{"#"}, blockStart: `"""`, blockEnd: `"""`},
+	"Ruby":       {line: []string{"#"}, blockStart: "=begin", blockEnd: "=end"},
+	"Shell":      {line: []string{"#"}},
+	"YAML":       {line: []string{"#"}},
+	"Perl":       {line: []string{"#"}},
+	"SQL":        {line: []string{"--"}},
+	"Lua":        {line: []string{"--"}},
+	"HTML":       {blockStart: "<!--", blockEnd: "-->"},
+	"XML":        {blockStart: "<!--", blockEnd: "-->"},
+}
+
+// classifyLines counts code, comment and blank lines. A blank line is whitespace-only. A line is a
+// comment when it starts with a line-comment token or lies inside a block comment; a line with trailing
+// code before a comment counts as code (standard cloc-style accounting). Deterministic, no allocation
+// beyond the line split.
+func classifyLines(lang string, content []byte) (code, comment, blank int) {
+	syn, hasSyntax := syntaxByLang[lang]
+	inBlock := false
+	lines := bytes.Split(content, []byte("\n"))
+	// A trailing newline terminates the last line rather than starting a new (empty) one; drop that one
+	// phantom empty field so a file ending in "\n" is not counted with an extra blank line.
+	if n := len(lines); n > 0 && len(lines[n-1]) == 0 {
+		lines = lines[:n-1]
+	}
+	for _, raw := range lines {
+		t := strings.TrimSpace(string(raw))
+		if t == "" {
+			blank++
+			continue
+		}
+		if !hasSyntax {
+			code++ // unknown language: count non-blank as code (comments fold into code, never blank)
+			continue
+		}
+		if inBlock {
+			comment++
+			if syn.blockEnd != "" && strings.Contains(t, syn.blockEnd) {
+				inBlock = false
+			}
+			continue
+		}
+		if syn.blockStart != "" && strings.HasPrefix(t, syn.blockStart) {
+			comment++
+			// still open if the block-end does not appear after the opening token on this same line
+			rest := t[len(syn.blockStart):]
+			if syn.blockEnd != "" && !strings.Contains(rest, syn.blockEnd) {
+				inBlock = true
+			}
+			continue
+		}
+		isLineComment := false
+		for _, lc := range syn.line {
+			if strings.HasPrefix(t, lc) {
+				isLineComment = true
+				break
+			}
+		}
+		if isLineComment {
+			comment++
+			continue
+		}
+		code++
+	}
+	return code, comment, blank
+}
+
+// countFunctions returns an accurate function count for languages with a first-party parser. Go uses
+// go/parser (top-level and method FuncDecls). known=false for every other language until the AST phase,
+// so the inventory reports "not counted" rather than a wrong zero.
+func countFunctions(lang string, content []byte) (n int, known bool) {
+	if lang != "Go" {
+		return 0, false
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", content, parser.SkipObjectResolution)
+	if err != nil || f == nil {
+		return 0, false // unparseable (e.g. a fragment): do not claim a count
+	}
+	for _, decl := range f.Decls {
+		if _, ok := decl.(*ast.FuncDecl); ok {
+			n++
+		}
+	}
+	return n, true
+}

--- a/internal/infrastructure/tools/codeinventory/analyzer.go
+++ b/internal/infrastructure/tools/codeinventory/analyzer.go
@@ -51,6 +51,7 @@ func (a *Analyzer) Inventory(ctx context.Context, root string) (measure.Inventor
 		return measure.Inventory{}, nil
 	}
 	byLang := map[string]measure.LanguageInventory{}
+	brokenFuncs := map[string]bool{} // a parser-supported language with an unparseable file: count is unreliable
 	files := 0
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -96,15 +97,26 @@ func (a *Analyzer) Inventory(ctx context.Context, root string) (measure.Inventor
 		li.CodeLines += code
 		li.CommentLines += comment
 		li.BlankLines += blank
-		if fn, known := countFunctions(lang, content); known {
-			li.Functions += fn
-			li.FunctionsKnown = true
+		if fn, supported, ok := countFunctions(lang, content); supported {
+			li.FunctionsKnown = true // the language has a first-party parser
+			if ok {
+				li.Functions += fn
+			} else {
+				brokenFuncs[lang] = true // one file did not parse; the aggregate is an undercount
+			}
 		}
 		byLang[lang] = li
 		return nil
 	})
 	if walkErr != nil && walkErr != io.EOF {
 		return measure.Inventory{}, walkErr
+	}
+	// Downgrade any language with an unparseable file to "not counted", so a reported count is never a
+	// silent undercount (the doc promise: an accurate count, or FunctionsKnown=false).
+	for lang := range brokenFuncs {
+		li := byLang[lang]
+		li.FunctionsKnown = false
+		byLang[lang] = li
 	}
 	return measure.NewInventory(byLang), nil
 }
@@ -162,7 +174,8 @@ var syntaxByLang = map[string]commentSyntax{
 // classifyLines counts code, comment and blank lines. A blank line is whitespace-only. A line is a
 // comment when it starts with a line-comment token or lies inside a block comment; a line with trailing
 // code before a comment counts as code (standard cloc-style accounting). Deterministic, no allocation
-// beyond the line split.
+// beyond the line split. Limitation (Phase 0): a block comment opened AFTER code on the same line
+// (`foo() /* ...`) is not tracked, so its continuation lines count as code; the AST phase removes this.
 func classifyLines(lang string, content []byte) (code, comment, blank int) {
 	syn, hasSyntax := syntaxByLang[lang]
 	inBlock := false
@@ -214,22 +227,23 @@ func classifyLines(lang string, content []byte) (code, comment, blank int) {
 	return code, comment, blank
 }
 
-// countFunctions returns an accurate function count for languages with a first-party parser. Go uses
-// go/parser (top-level and method FuncDecls). known=false for every other language until the AST phase,
-// so the inventory reports "not counted" rather than a wrong zero.
-func countFunctions(lang string, content []byte) (n int, known bool) {
+// countFunctions counts functions for a language with a first-party parser. Go uses go/parser
+// (top-level and method FuncDecls). supported=false for every other language until the AST phase (the
+// caller then reports "not counted", never a wrong zero); ok=false when a supported language's file
+// does not parse, so the caller can downgrade that language's whole count to not-known.
+func countFunctions(lang string, content []byte) (n int, supported, ok bool) {
 	if lang != "Go" {
-		return 0, false
+		return 0, false, false
 	}
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "", content, parser.SkipObjectResolution)
 	if err != nil || f == nil {
-		return 0, false // unparseable (e.g. a fragment): do not claim a count
+		return 0, true, false // supported, but this file did not parse (e.g. a fragment)
 	}
 	for _, decl := range f.Decls {
 		if _, ok := decl.(*ast.FuncDecl); ok {
 			n++
 		}
 	}
-	return n, true
+	return n, true, true
 }

--- a/internal/infrastructure/tools/codeinventory/analyzer_test.go
+++ b/internal/infrastructure/tools/codeinventory/analyzer_test.go
@@ -105,6 +105,25 @@ func TestInventoryMixedTree(t *testing.T) {
 	}
 }
 
+func TestInventoryGoParseFailureDowngrades(t *testing.T) {
+	// A parser-supported language (Go) with even one unparseable file must report FunctionsKnown=false
+	// for that language, so a reported count is never a silent undercount.
+	root := t.TempDir()
+	write(t, root, "ok.go", "package a\nfunc F() {}\nfunc G() {}\n")
+	write(t, root, "broken.go", "package a\nfunc H( {\n") // syntactically invalid
+	inv, err := New().Inventory(context.Background(), root)
+	if err != nil {
+		t.Fatalf("inventory: %v", err)
+	}
+	g := byLang(inv)["Go"]
+	if g.Files != 2 {
+		t.Fatalf("want 2 Go files, got %d", g.Files)
+	}
+	if g.FunctionsKnown {
+		t.Errorf("a Go file that fails to parse must downgrade FunctionsKnown to false; got %+v", g)
+	}
+}
+
 func TestInventoryEmptyRoot(t *testing.T) {
 	inv, err := New().Inventory(context.Background(), t.TempDir())
 	if err != nil {

--- a/internal/infrastructure/tools/codeinventory/analyzer_test.go
+++ b/internal/infrastructure/tools/codeinventory/analyzer_test.go
@@ -1,0 +1,132 @@
+package codeinventory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+)
+
+func write(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func byLang(inv measure.Inventory) map[string]measure.LanguageInventory {
+	m := map[string]measure.LanguageInventory{}
+	for _, li := range inv.Languages {
+		m[li.Language] = li
+	}
+	return m
+}
+
+func TestInventoryMixedTree(t *testing.T) {
+	root := t.TempDir()
+
+	// Go: 2 functions (a func + a method), 1 line comment, 1 block-comment line, 1 blank.
+	write(t, root, "main.go", "package main\n"+ // code
+		"\n"+ // blank
+		"// entry point\n"+ // comment (line)
+		"func main() { println(hello()) }\n"+ // code + func
+		"/* helper */\n"+ // comment (block, single line)
+		"func hello() string { return \"hi\" }\n") // code + func
+
+	// Python: 1 line comment (#), 1 code, 1 blank.
+	write(t, root, "app.py", "# a comment\n"+
+		"x = 1\n"+
+		"\n")
+
+	// JavaScript: 1 block comment spanning 2 lines, 1 code.
+	write(t, root, "web/app.js", "/* multi\n"+
+		"line */\n"+
+		"const a = 1;\n")
+
+	// Vendored dir must be skipped entirely.
+	write(t, root, "node_modules/dep/index.js", "var ignored = true;\n")
+
+	inv, err := New().Inventory(context.Background(), root)
+	if err != nil {
+		t.Fatalf("inventory: %v", err)
+	}
+	m := byLang(inv)
+
+	g, ok := m["Go"]
+	if !ok {
+		t.Fatalf("Go not detected; got %+v", inv.Languages)
+	}
+	if g.Files != 1 || g.CodeLines != 3 || g.CommentLines != 2 || g.BlankLines != 1 {
+		t.Errorf("Go lines wrong: %+v", g)
+	}
+	if !g.FunctionsKnown || g.Functions != 2 {
+		t.Errorf("Go functions wrong: want 2 known, got %d known=%v", g.Functions, g.FunctionsKnown)
+	}
+
+	py, ok := m["Python"]
+	if !ok {
+		t.Fatalf("Python not detected; got %+v", inv.Languages)
+	}
+	if py.CodeLines != 1 || py.CommentLines != 1 || py.BlankLines != 1 {
+		t.Errorf("Python lines wrong: %+v", py)
+	}
+	if py.FunctionsKnown {
+		t.Errorf("Python functions must be reported not-known (no parser yet): %+v", py)
+	}
+
+	js, ok := m["JavaScript"]
+	if !ok {
+		t.Fatalf("JavaScript not detected; got %+v", inv.Languages)
+	}
+	if js.CommentLines != 2 || js.CodeLines != 1 {
+		t.Errorf("JS block-comment classification wrong: %+v", js)
+	}
+
+	// Vendored file excluded from every language tally.
+	for _, li := range inv.Languages {
+		if li.Language == "JavaScript" && li.Files != 1 {
+			t.Errorf("node_modules must be skipped; JS files = %d", li.Files)
+		}
+	}
+
+	// Totals: FunctionsKnown false because Python/JS have no parser yet.
+	tot := inv.Totals()
+	if tot.FunctionsKnown {
+		t.Errorf("totals FunctionsKnown must be false when a language lacks a parser: %+v", tot)
+	}
+	if tot.Files != 3 {
+		t.Errorf("total files want 3 (vendored skipped), got %d", tot.Files)
+	}
+}
+
+func TestInventoryEmptyRoot(t *testing.T) {
+	inv, err := New().Inventory(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("inventory: %v", err)
+	}
+	if len(inv.Languages) != 0 {
+		t.Errorf("empty tree should yield no languages, got %+v", inv.Languages)
+	}
+}
+
+func TestInventoryDeterministicSort(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "a.go", "package a\nfunc F() {}\n")
+	write(t, root, "b.py", "x = 1\n")
+	i1, _ := New().Inventory(context.Background(), root)
+	i2, _ := New().Inventory(context.Background(), root)
+	if len(i1.Languages) != len(i2.Languages) {
+		t.Fatalf("length mismatch")
+	}
+	for i := range i1.Languages {
+		if i1.Languages[i].Language != i2.Languages[i].Language {
+			t.Errorf("order not deterministic at %d: %q vs %q", i, i1.Languages[i].Language, i2.Languages[i].Language)
+		}
+	}
+}

--- a/internal/usecase/ports/codeinventory.go
+++ b/internal/usecase/ports/codeinventory.go
@@ -1,0 +1,15 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+)
+
+// CodeInventoryScanner computes a per-language code-size inventory (files, code/comment/blank lines,
+// and functions where a parser exists) over a local source tree. It is the first producer of the
+// code-quality ("power tool") capability. Implementations read the tree only (never execute it) and
+// must honor context cancellation.
+type CodeInventoryScanner interface {
+	Inventory(ctx context.Context, root string) (measure.Inventory, error)
+}


### PR DESCRIPTION
First producer of the Code Quality capability (epic #95, Phase 0 slice 1 of #96). A pure-Go, read-only per-language code inventory.

### What
| Piece | Role |
|---|---|
| `domain/measure` | `LanguageInventory` + `Inventory` — numeric project measures (the counterpart to `domain/finding`), with a deterministic `Totals` rollup |
| `ports.CodeInventoryScanner` | the producer port |
| `infrastructure/tools/codeinventory` | walks the tree (skips vendored/binary/generated/oversized, follows no symlinks), language via go-enry, counts code/comment/blank lines per language, and functions accurately for Go via `go/parser` |
| `synapse-cli inventory <path>` | prints the per-language inventory; no DB |

Function counts for languages without a first-party parser report `functions_known=false` ("not counted") rather than a wrong zero.

### Example
```
Synapse code inventory — web/src
  language            files       code    comment    blank  functions
  CSS                     1        170          0       13        n/a
  TSX                    15       7049        195      457        n/a
  TypeScript              5       1919        114      222        n/a
  TOTAL                  21       9138        309      692        n/a
```

### Scope note (why this is slice 1)
The tree-sitter-backed multi-language AST sidecar (accurate functions/complexity for every language, sandboxed) is **slice 2** and is deferred deliberately: tree-sitter introduces CGO, which would change the pure-Go cross-platform build, and the sidecar's sandbox only earns its place once C-based grammars parse untrusted source. The `ports.CodeInventoryScanner` seam stays stable across both slices, so slice 2 slots in behind it.

`make build vet test` green; analyzer has a mixed-language fixture test (line classification + Go function count + vendored-dir skip + determinism).

Part of #96 (Phase 0). Epic #95.
