### PR TITLE
fix(jarchecksum): securely support native Windows file opening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,27 @@ jobs:
       - name: Build (CGO disabled — distroless parity)
         run: CGO_ENABLED=0 go build ./cmd/...
 
+  backend-windows:
+    name: Backend (Go, Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
   frontend:
     name: Frontend (web)
     runs-on: ubuntu-latest

--- a/internal/infrastructure/tools/jarchecksum/open_nofollow_unix.go
+++ b/internal/infrastructure/tools/jarchecksum/open_nofollow_unix.go
@@ -1,0 +1,23 @@
+//go:build unix
+
+package jarchecksum
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openFileNoFollow opens path without following a final-component symlink.
+func openFileNoFollow(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	f := os.NewFile(uintptr(fd), path)
+	if f == nil {
+		_ = unix.Close(fd)
+		return nil, os.ErrInvalid
+	}
+	return f, nil
+}

--- a/internal/infrastructure/tools/jarchecksum/open_nofollow_windows.go
+++ b/internal/infrastructure/tools/jarchecksum/open_nofollow_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package jarchecksum
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type fileAttributeTagInfo struct {
+	FileAttributes uint32
+	ReparseTag     uint32
+}
+
+// openFileNoFollow opens the final path entry itself and rejects every reparse point.
+func openFileNoFollow(path string) (*os.File, error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	h, err := windows.CreateFile(
+		name,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_SEQUENTIAL_SCAN,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var info fileAttributeTagInfo
+	if err := windows.GetFileInformationByHandleEx(
+		h,
+		windows.FileAttributeTagInfo,
+		(*byte)(unsafe.Pointer(&info)), //nolint:gosec // Win32 requires a FILE_ATTRIBUTE_TAG_INFO output buffer
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(h)
+		return nil, err
+	}
+	if info.FileAttributes&(windows.FILE_ATTRIBUTE_REPARSE_POINT|windows.FILE_ATTRIBUTE_DIRECTORY) != 0 {
+		_ = windows.CloseHandle(h)
+		return nil, os.ErrInvalid
+	}
+	f := os.NewFile(uintptr(h), path)
+	if f == nil {
+		_ = windows.CloseHandle(h)
+		return nil, os.ErrInvalid
+	}
+	return f, nil
+}

--- a/internal/infrastructure/tools/jarchecksum/resolver.go
+++ b/internal/infrastructure/tools/jarchecksum/resolver.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -131,19 +130,23 @@ func hashWorkspaceJARs(ctx context.Context, wsDir string) (byName map[string]str
 
 // fileSHA1 streams a SHA-1 over the file, refusing an over-large file. Returns "" on any error.
 func fileSHA1(path string) (string, bool) {
+	// This is only an early rejection. openFileNoFollow and the opened-handle Stat below are authoritative.
 	fi, err := os.Lstat(path)
 	if err != nil || !fi.Mode().IsRegular() || fi.Size() > maxJARBytes {
 		return "", false
 	}
-	// O_NOFOLLOW closes the Lstat->Open TOCTOU: if the regular file were swapped for a symlink between the
-	// stat above and this open, the open fails rather than following the link out of the untrusted workspace.
-	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0) //nolint:gosec // bounded workspace walk, regular-file re-verified, O_NOFOLLOW-guarded
+	f, err := openFileNoFollow(path)
 	if err != nil {
 		return "", false
 	}
 	defer func() { _ = f.Close() }()
+	fi, err = f.Stat()
+	if err != nil || !fi.Mode().IsRegular() || fi.Size() > maxJARBytes {
+		return "", false
+	}
 	h := sha1.New() //nolint:gosec // Maven artifact identity, not a security hash
-	if _, err := io.Copy(h, io.LimitReader(f, maxJARBytes)); err != nil {
+	n, err := io.Copy(h, io.LimitReader(f, maxJARBytes+1))
+	if err != nil || n > maxJARBytes {
 		return "", false
 	}
 	return hex.EncodeToString(h.Sum(nil)), true

--- a/internal/infrastructure/tools/jarchecksum/resolver_test.go
+++ b/internal/infrastructure/tools/jarchecksum/resolver_test.go
@@ -107,6 +107,41 @@ func TestResolveSkipsSymlink(t *testing.T) {
 	}
 }
 
+func TestFileSHA1RejectsFinalSymlink(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target.jar")
+	writeFile(t, target, []byte("out of tree"))
+	link := filepath.Join(t.TempDir(), "link.jar")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	f, err := openFileNoFollow(link)
+	if err == nil {
+		_ = f.Close()
+		t.Fatal("openFileNoFollow followed a final-component symlink")
+	}
+	if got, ok := fileSHA1(link); ok || got != "" {
+		t.Fatalf("fileSHA1 accepted a final-component symlink: ok=%v, digest=%q", ok, got)
+	}
+}
+
+func TestFileSHA1RejectsOversizedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oversized.jar")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(maxJARBytes + 1); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := fileSHA1(path); ok || got != "" {
+		t.Fatalf("fileSHA1 accepted an oversized file: ok=%v, digest=%q", ok, got)
+	}
+}
+
 func TestResolveNoJARComponentsNoWalk(t *testing.T) {
 	ws := t.TempDir()
 	comps := []sbom.Component{{Name: "npmpkg", Version: "1.0", Location: "/pkg", PURL: "pkg:npm/pkg@1.0"}}

--- a/internal/infrastructure/tools/mavenresolve/resolver_test.go
+++ b/internal/infrastructure/tools/mavenresolve/resolver_test.go
@@ -82,9 +82,13 @@ func TestArgsLocalRepo(t *testing.T) {
 	if hasArg(base.args("/x"), "-Dmaven.repo.local") {
 		t.Error("no localRepo configured ⇒ no -Dmaven.repo.local flag")
 	}
-	withRepo := New("mvn").WithLocalRepo("/cache/.m2")
-	if !contains(withRepo.args("/x"), "-Dmaven.repo.local=/cache/.m2") {
-		t.Errorf("localRepo set ⇒ flag expected, got %v", withRepo.args("/x"))
+	localRepo, err := filepath.Abs(filepath.FromSlash("/cache/.m2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	withRepo := New("mvn").WithLocalRepo(localRepo)
+	if !contains(withRepo.args(filepath.FromSlash("/x")), "-Dmaven.repo.local="+localRepo) {
+		t.Errorf("localRepo set ⇒ flag expected, got %v", withRepo.args(filepath.FromSlash("/x")))
 	}
 	// goal + pom flag always present
 	a := base.args("/proj")
@@ -334,8 +338,8 @@ func TestResolvePartialFailureKeepsResolvedPlusError(t *testing.T) {
 	mkpom(t, filepath.Join(dir, "svcB"))
 	depList := "[INFO]    org.apache.commons:commons-lang3:jar:3.10:compile\n[INFO] BUILD SUCCESS\n"
 	r := New("mvn").WithRunner(fakeRunner{byArgSubstr: map[string]ports.ToolResult{
-		"svcA/pom.xml": {Stdout: []byte(depList)},             // svcA resolves
-		"svcB/pom.xml": {ExitCode: 1, Stderr: []byte("boom")}, // svcB fails
+		filepath.Join("svcA", "pom.xml"): {Stdout: []byte(depList)},             // svcA resolves
+		filepath.Join("svcB", "pom.xml"): {ExitCode: 1, Stderr: []byte("boom")}, // svcB fails
 	}})
 
 	comps, err := r.Resolve(context.Background(), dir)


### PR DESCRIPTION
## Summary

Fixes native Windows compilation for the JAR checksum resolver while preserving its protection against symlink and file-replacement attacks.

The resolver previously passed `syscall.O_NOFOLLOW` directly to `os.OpenFile`. That constant is unavailable in Go's Windows `syscall` package, causing `go build`, `go vet`, and `go test` to fail on Windows.

This PR:

- Adds native Windows CI coverage so future portability regressions are caught.
- Moves secure file opening into platform-specific implementations.
- Preserves `O_NOFOLLOW` behavior on Unix.
- Adds equivalent fail-closed handling for Windows reparse points.
- Revalidates the opened file handle before hashing.

Closes #88.

## Changes

### Native Windows CI

Add a `backend-windows` job to `.github/workflows/ci.yml` using `windows-latest`.

The job runs the repository's standard backend verification commands natively on Windows:

```text
go build ./...
go vet ./...
go test ./...
```

The existing Linux backend job remains unchanged, including its `CGO_ENABLED=0` distroless-parity build.

This ensures future use of Unix-only APIs in shared Go files is detected during pull-request checks.

### Secure platform-specific file opening

Add a Unix implementation using `golang.org/x/sys/unix`:

- Opens files read-only with `O_NOFOLLOW`.
- Uses `O_CLOEXEC` to prevent descriptor inheritance.
- Uses `O_NONBLOCK` so a race-swapped FIFO cannot block during open.

Add a Windows implementation using `golang.org/x/sys/windows`:

- Opens the final path entry with `CreateFile`.
- Uses `FILE_FLAG_OPEN_REPARSE_POINT` so the final entry is opened rather than followed.
- Queries `FileAttributeTagInfo` from the opened handle.
- Rejects all reparse points, including symbolic links, junctions, and mount points.
- Rejects directory handles.
- Transfers accepted handle ownership safely to `os.File`.

### Opened-handle validation

Update the shared checksum path to:

- Keep the existing pre-open `Lstat` as an inexpensive early rejection.
- Revalidate the opened handle with `File.Stat`.
- Require the opened object to remain a regular file.
- Reject the opened file if it exceeds the 512 MiB limit.
- Read at most `maxJARBytes + 1` bytes.
- Reject a file if it grows beyond the size limit while being hashed.

### Tests

Add or update coverage for:

- Regular JAR checksum generation.
- Final-component symbolic-link rejection.
- Oversized sparse JAR rejection.
- Windows and Unix path handling in existing Maven resolver tests.

## Security considerations

This PR does not replace `O_NOFOLLOW` with an unguarded `os.Open` or `filepath.EvalSymlinks`.

On Unix, the existing no-follow protection remains in place.

On Windows, `CreateFile` opens the final path entry with `FILE_FLAG_OPEN_REPARSE_POINT`. The resolver then checks metadata from that opened handle and rejects every entry carrying `FILE_ATTRIBUTE_REPARSE_POINT`.

Post-open file type and size checks are authoritative on both platforms. This protects against a path being replaced between the initial `Lstat` and the secure open.

The workspace walk also continues to reject non-regular directory entries as an earlier defense-in-depth layer.

## Verification

Verified natively on Windows:

```text
go build ./...
go vet ./...
go test ./...
make build vet test
```

Also exercised through the real `synapse-cli scan` path:

- A regular JAR received its expected SHA-1 and checksum entry.
- A 512 MiB + 1 byte sparse JAR was rejected and received no checksum.

Verified in a Linux `golang:1.26.4-bookworm` container:

- The jarchecksum package tests pass.
- The repository builds successfully.
- A regular JAR is hashed through the real CLI scan path.
- A final-component symlink pointing outside the workspace is not hashed.

The jarchecksum test binary was also cross-compiled for Linux and Darwin.

The local Windows account does not have permission to create symbolic links, so the native Windows symlink test skips in that environment. The new Windows CI job will run the complete suite on `windows-latest`; the test retains an explicit skip for environments where symlink creation is unavailable.

## Checklist

- [x] `make build vet test typecheck` passes
  - `make build vet test` passes natively on Windows.
  - Backend changes only; dashboard typecheck is not applicable.
- [x] `cd web && pnpm build` passes (if the dashboard changed)
  - Not applicable; no dashboard files changed.
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets
      out of logs, deterministic reports, append-only evidence) — see CONTRIBUTING.md
- [x] Documentation updated if needed
- [x] Native Windows CI added for build, vet, and test coverage