### PR TITLE
feat(quality): per-function cyclomatic + cognitive complexity (Code Quality Phase 1)

### DIFF
--- a/cmd/synapse-ast/main.go
+++ b/cmd/synapse-ast/main.go
@@ -20,11 +20,20 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 3 || os.Args[1] != "functions" {
-		fmt.Fprintln(os.Stderr, "usage: synapse-ast functions <dir>")
+	if len(os.Args) != 3 || (os.Args[1] != "functions" && os.Args[1] != "metrics") {
+		fmt.Fprintln(os.Stderr, "usage: synapse-ast functions|metrics <dir>")
 		os.Exit(2)
 	}
-	res, err := astwalk.FunctionsFor(context.Background(), os.Args[2])
+	var (
+		out any
+		err error
+	)
+	switch os.Args[1] {
+	case "functions":
+		out, err = astwalk.FunctionsFor(context.Background(), os.Args[2])
+	case "metrics":
+		out, err = astwalk.MetricsFor(context.Background(), os.Args[2])
+	}
 	if errors.Is(err, astwalk.ErrUnavailable) {
 		fmt.Fprintln(os.Stderr, "synapse-ast:", err)
 		os.Exit(3)
@@ -33,7 +42,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "synapse-ast:", err)
 		os.Exit(1)
 	}
-	if err := json.NewEncoder(os.Stdout).Encode(res); err != nil {
+	if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
 		fmt.Fprintln(os.Stderr, "synapse-ast: encode:", err)
 		os.Exit(1)
 	}

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -86,6 +86,14 @@ func main() {
 			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 			os.Exit(1)
 		}
+	case "metrics":
+		if len(os.Args) < 3 {
+			usage()
+		}
+		if err := runMetrics(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
+			os.Exit(1)
+		}
 	default:
 		usage()
 	}
@@ -123,6 +131,66 @@ func runInventory(dir string) error {
 	return nil
 }
 
+// runMetrics prints per-function complexity (cyclomatic + cognitive) hotspots for a local source tree and
+// optionally gates on cyclomatic complexity. Backed by the synapse-ast sidecar; if it is absent or built
+// without the tree-sitter backend, this reports that and (for the gate) does not fail.
+func runMetrics(args []string) error {
+	dir := args[0]
+	failOn := 0 // 0 = no gate
+	top := 10
+	for i := 1; i < len(args); i++ {
+		switch {
+		case args[i] == "--fail-on-complexity" && i+1 < len(args):
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n < 1 {
+				return fmt.Errorf("--fail-on-complexity wants a positive integer, got %q", args[i+1])
+			}
+			failOn = n
+			i++
+		case args[i] == "--top" && i+1 < len(args):
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n < 0 {
+				return fmt.Errorf("--top wants a non-negative integer, got %q", args[i+1])
+			}
+			top = n
+			i++
+		default:
+			return fmt.Errorf("unknown or incomplete option %q", args[i])
+		}
+	}
+
+	astBin := os.Getenv("SYNAPSE_AST_BIN")
+	report, available, err := ast.New(astBin).Complexity(context.Background(), dir)
+	if err != nil {
+		return fmt.Errorf("metrics: %w", err)
+	}
+	fmt.Printf("\nSynapse code complexity — %s\n", dir)
+	if !available {
+		fmt.Println("  the synapse-ast sidecar is unavailable (build it with cgo, or set SYNAPSE_AST_BIN); no complexity computed")
+		return nil
+	}
+	if len(report.Functions) == 0 {
+		fmt.Println("  (no functions detected in supported languages)")
+		return nil
+	}
+	if report.Truncated {
+		fmt.Println("  ! result truncated at the file cap; counts are a lower bound")
+	}
+	fmt.Printf("  functions: %d · highest cyclomatic: %d\n", len(report.Functions), report.MaxCyclomatic())
+	fmt.Printf("  top %d by cyclomatic complexity:\n", top)
+	fmt.Printf("    %-4s %-4s  %-10s %s\n", "cyc", "cog", "language", "function (file:line)")
+	for _, f := range report.TopByCyclomatic(top) {
+		fmt.Printf("    %-4d %-4d  %-10s %s (%s:%d)\n", f.Cyclomatic, f.Cognitive, f.Language, f.Name, f.File, f.Line)
+	}
+	if failOn > 0 {
+		over := report.OverCyclomatic(failOn)
+		if len(over) > 0 {
+			return fmt.Errorf("%d function(s) exceed cyclomatic complexity %d (highest %d)", len(over), failOn, report.MaxCyclomatic())
+		}
+	}
+	return nil
+}
+
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
 	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
@@ -130,6 +198,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "      --image    treat the argument as a container image reference (pulled via crane) instead of a local path")
 	fmt.Fprintln(os.Stderr, "      --offline  skip the live OSV.dev source; detect with Grype's offline DB only (air-gapped / fast)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli inventory <path>             # per-language code-size inventory (files, code/comment/blank lines, functions) — no DB")
+	fmt.Fprintln(os.Stderr, "  synapse-cli metrics <path> [--fail-on-complexity N] [--top N]  # per-function cyclomatic+cognitive complexity (needs the synapse-ast sidecar)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote     # fetch + ingest app ecosystems from the OSV bulk bucket (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote-distros # fetch + ingest OS-package advisories (Debian/Alpine) from OSV (large; requires SYNAPSE_DB_DSN)")

--- a/internal/domain/measure/complexity.go
+++ b/internal/domain/measure/complexity.go
@@ -1,0 +1,69 @@
+package measure
+
+import "sort"
+
+// FunctionComplexity is one function's location + size/complexity measures. Line is 1-based; File is
+// relative to the scanned root. Cyclomatic is McCabe's measure; Cognitive is the nesting-aware
+// readability measure. Both are deterministic (no LLM).
+type FunctionComplexity struct {
+	File       string `json:"file"`
+	Line       int    `json:"line"`
+	Name       string `json:"name"`
+	Language   string `json:"language"`
+	Cyclomatic int    `json:"cyclomatic"`
+	Cognitive  int    `json:"cognitive"`
+}
+
+// ComplexityReport is the per-function complexity over a source tree. Truncated is true when the walk hit
+// its file cap, so the report is a known undercount rather than a silent one.
+type ComplexityReport struct {
+	Functions []FunctionComplexity `json:"functions"`
+	Truncated bool                 `json:"truncated,omitempty"`
+}
+
+// MaxCyclomatic returns the highest cyclomatic complexity across all functions (0 when there are none).
+func (r ComplexityReport) MaxCyclomatic() int {
+	max := 0
+	for _, f := range r.Functions {
+		if f.Cyclomatic > max {
+			max = f.Cyclomatic
+		}
+	}
+	return max
+}
+
+// OverCyclomatic returns the functions whose cyclomatic complexity is strictly greater than threshold,
+// sorted most-complex first (ties broken by file then line for determinism).
+func (r ComplexityReport) OverCyclomatic(threshold int) []FunctionComplexity {
+	var over []FunctionComplexity
+	for _, f := range r.Functions {
+		if f.Cyclomatic > threshold {
+			over = append(over, f)
+		}
+	}
+	sortByComplexity(over)
+	return over
+}
+
+// TopByCyclomatic returns up to n functions with the highest cyclomatic complexity, most-complex first.
+func (r ComplexityReport) TopByCyclomatic(n int) []FunctionComplexity {
+	sorted := make([]FunctionComplexity, len(r.Functions))
+	copy(sorted, r.Functions)
+	sortByComplexity(sorted)
+	if n >= 0 && n < len(sorted) {
+		sorted = sorted[:n]
+	}
+	return sorted
+}
+
+func sortByComplexity(fs []FunctionComplexity) {
+	sort.Slice(fs, func(i, j int) bool {
+		if fs[i].Cyclomatic != fs[j].Cyclomatic {
+			return fs[i].Cyclomatic > fs[j].Cyclomatic
+		}
+		if fs[i].File != fs[j].File {
+			return fs[i].File < fs[j].File
+		}
+		return fs[i].Line < fs[j].Line
+	})
+}

--- a/internal/domain/measure/complexity_test.go
+++ b/internal/domain/measure/complexity_test.go
@@ -1,0 +1,45 @@
+package measure
+
+import "testing"
+
+func sampleReport() ComplexityReport {
+	return ComplexityReport{Functions: []FunctionComplexity{
+		{File: "a.go", Line: 10, Name: "a", Cyclomatic: 3, Cognitive: 2},
+		{File: "b.go", Line: 5, Name: "b", Cyclomatic: 9, Cognitive: 12},
+		{File: "a.go", Line: 20, Name: "c", Cyclomatic: 9, Cognitive: 4},
+		{File: "c.go", Line: 1, Name: "d", Cyclomatic: 1, Cognitive: 0},
+	}}
+}
+
+func TestMaxCyclomatic(t *testing.T) {
+	if got := sampleReport().MaxCyclomatic(); got != 9 {
+		t.Errorf("MaxCyclomatic = %d, want 9", got)
+	}
+	if got := (ComplexityReport{}).MaxCyclomatic(); got != 0 {
+		t.Errorf("empty MaxCyclomatic = %d, want 0", got)
+	}
+}
+
+func TestOverCyclomatic(t *testing.T) {
+	over := sampleReport().OverCyclomatic(3)
+	if len(over) != 2 {
+		t.Fatalf("OverCyclomatic(3) = %d functions, want 2 (%+v)", len(over), over)
+	}
+	// Ties on cyclomatic (both 9) break by file then line: a.go:20 before b.go:5.
+	if over[0].Name != "c" || over[1].Name != "b" {
+		t.Errorf("tie ordering wrong: got %s,%s want c,b", over[0].Name, over[1].Name)
+	}
+	if len(sampleReport().OverCyclomatic(100)) != 0 {
+		t.Errorf("OverCyclomatic(100) should be empty")
+	}
+}
+
+func TestTopByCyclomatic(t *testing.T) {
+	top := sampleReport().TopByCyclomatic(2)
+	if len(top) != 2 || top[0].Cyclomatic != 9 || top[1].Cyclomatic != 9 {
+		t.Errorf("TopByCyclomatic(2) wrong: %+v", top)
+	}
+	if n := len(sampleReport().TopByCyclomatic(100)); n != 4 {
+		t.Errorf("TopByCyclomatic(100) = %d, want all 4", n)
+	}
+}

--- a/internal/infrastructure/tools/ast/provider.go
+++ b/internal/infrastructure/tools/ast/provider.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -42,7 +43,10 @@ func New(bin string) *Provider {
 // read-only. Unlike synapse-callgraph, cgo is NOT disabled: the tree-sitter backend requires it.
 func (p *Provider) WithRunner(r ports.ToolRunner) *Provider { p.runner = r; return p }
 
-var _ ports.ASTProvider = (*Provider)(nil)
+var (
+	_ ports.ASTProvider         = (*Provider)(nil)
+	_ ports.CodeMetricsProvider = (*Provider)(nil)
+)
 
 // FunctionCounts runs `synapse-ast functions <root>` and returns per-language function counts. A sidecar
 // built without the tree-sitter backend exits exitUnavailable, which maps to (nil, false, nil) so the
@@ -51,7 +55,7 @@ func (p *Provider) FunctionCounts(ctx context.Context, root string) (map[string]
 	if strings.TrimSpace(root) == "" {
 		return nil, false, nil
 	}
-	out, exit, err := p.run(ctx, root)
+	out, exit, err := p.run(ctx, "functions", root)
 	if exit == exitUnavailable {
 		return nil, false, nil
 	}
@@ -67,10 +71,34 @@ func (p *Provider) FunctionCounts(ctx context.Context, root string) (map[string]
 	return res.Functions, true, nil
 }
 
+// Complexity runs `synapse-ast metrics <root>` and returns per-function cyclomatic + cognitive complexity.
+// A sidecar built without the tree-sitter backend (or an absent binary) maps to available=false so the
+// caller degrades rather than erroring.
+func (p *Provider) Complexity(ctx context.Context, root string) (measure.ComplexityReport, bool, error) {
+	if strings.TrimSpace(root) == "" {
+		return measure.ComplexityReport{}, false, nil
+	}
+	out, exit, err := p.run(ctx, "metrics", root)
+	if exit == exitUnavailable {
+		return measure.ComplexityReport{}, false, nil
+	}
+	if err != nil {
+		return measure.ComplexityReport{}, false, err
+	}
+	var wire struct {
+		Functions []measure.FunctionComplexity `json:"functions"`
+		Truncated bool                         `json:"truncated"`
+	}
+	if err := json.Unmarshal(out, &wire); err != nil {
+		return measure.ComplexityReport{}, false, fmt.Errorf("parse synapse-ast metrics: %w", err)
+	}
+	return measure.ComplexityReport{Functions: wire.Functions, Truncated: wire.Truncated}, true, nil
+}
+
 // run executes the sidecar (sandboxed when a runner is set, else direct os/exec) and returns stdout, the
 // process exit code, and any error. argv only (no shell).
-func (p *Provider) run(ctx context.Context, root string) ([]byte, int, error) {
-	args := []string{"functions", root}
+func (p *Provider) run(ctx context.Context, cmd, root string) ([]byte, int, error) {
+	args := []string{cmd, root}
 	if p.runner != nil {
 		res, err := p.runner.Run(ctx, ports.ToolSpec{
 			Name:          p.bin,
@@ -88,9 +116,9 @@ func (p *Provider) run(ctx context.Context, root string) ([]byte, int, error) {
 		return res.Stdout, res.ExitCode, nil
 	}
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, p.bin, args...)
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
+	ec := exec.CommandContext(ctx, p.bin, args...)
+	ec.Stderr = &stderr
+	out, err := ec.Output()
 	if err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {

--- a/internal/infrastructure/tools/ast/provider_test.go
+++ b/internal/infrastructure/tools/ast/provider_test.go
@@ -27,3 +27,17 @@ func TestProviderEmptyRoot(t *testing.T) {
 		t.Errorf("empty root: want (unavailable, no error), got available=%v err=%v", available, err)
 	}
 }
+
+func TestComplexityUnavailableWhenBinaryMissing(t *testing.T) {
+	p := New("/nonexistent/synapse-ast-does-not-exist")
+	report, available, err := p.Complexity(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("missing binary must not error, got %v", err)
+	}
+	if available {
+		t.Errorf("missing binary must report available=false")
+	}
+	if len(report.Functions) != 0 {
+		t.Errorf("missing binary must return an empty report, got %+v", report)
+	}
+}

--- a/internal/infrastructure/tools/astwalk/astwalk.go
+++ b/internal/infrastructure/tools/astwalk/astwalk.go
@@ -28,7 +28,7 @@ type Result struct {
 
 // FunctionMetric is one function's size/complexity record. Line is 1-based; File is relative to the walk
 // root. Cyclomatic is McCabe's measure (1 + decision points); Cognitive is the nesting-aware readability
-// measure (see metrics_cgo.go for the exact rules).
+// measure (see parse_cgo.go for the exact rules).
 type FunctionMetric struct {
 	File       string `json:"file"`
 	Line       int    `json:"line"`

--- a/internal/infrastructure/tools/astwalk/astwalk.go
+++ b/internal/infrastructure/tools/astwalk/astwalk.go
@@ -15,14 +15,33 @@ import (
 	enry "github.com/go-enry/go-enry/v2"
 )
 
-// ErrUnavailable is returned by FunctionsFor in a CGO-free build: no grammar backend is compiled in.
+// ErrUnavailable is returned by the FunctionsFor/MetricsFor entry points in a CGO-free build: no grammar
+// backend is compiled in.
 var ErrUnavailable = errors.New("astwalk: tree-sitter backend not available (built without cgo)")
 
-// Result is the sidecar's wire output: accurate function counts keyed by go-enry language name.
+// Result is the `functions` wire output: accurate function counts keyed by go-enry language name.
 // Truncated is set when the file-count cap tripped, so a caller can tell an undercount from a complete one.
 type Result struct {
 	Functions map[string]int `json:"functions"`
 	Truncated bool           `json:"truncated,omitempty"`
+}
+
+// FunctionMetric is one function's size/complexity record. Line is 1-based; File is relative to the walk
+// root. Cyclomatic is McCabe's measure (1 + decision points); Cognitive is the nesting-aware readability
+// measure (see metrics_cgo.go for the exact rules).
+type FunctionMetric struct {
+	File       string `json:"file"`
+	Line       int    `json:"line"`
+	Name       string `json:"name"`
+	Language   string `json:"language"`
+	Cyclomatic int    `json:"cyclomatic"`
+	Cognitive  int    `json:"cognitive"`
+}
+
+// Metrics is the `metrics` wire output: one record per function.
+type Metrics struct {
+	Functions []FunctionMetric `json:"functions"`
+	Truncated bool             `json:"truncated,omitempty"`
 }
 
 const (
@@ -36,18 +55,17 @@ var skipDirs = map[string]bool{
 	".vscode": true, ".tox": true, ".hg": true, ".svn": true,
 }
 
-// walk traverses root and calls parse(language, content) for each regular, non-vendored, non-binary
-// source file, summing the returned per-file function counts by language. It follows no symlinks, bounds
-// file size and count, and honors ctx cancellation, mirroring the codeinventory and enry adapters. parse
-// returns (n, ok); ok=false when the language has no grammar, so that file contributes nothing.
-func walk(ctx context.Context, root string, parse func(lang string, content []byte) (int, bool)) (Result, error) {
-	res := Result{Functions: map[string]int{}}
+// walkSource traverses root and calls visit(rel, language, content) for each regular, non-vendored,
+// non-binary source file (rel is the path relative to root). It follows no symlinks, bounds file size and
+// count, and honors ctx cancellation, mirroring the codeinventory and enry adapters. truncated is true
+// when the file cap tripped (a signalled undercount, not a silent one).
+func walkSource(ctx context.Context, root string, visit func(rel, lang string, content []byte)) (truncated bool, err error) {
 	if root == "" {
-		return res, nil
+		return false, nil
 	}
 	files := 0
-	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
 			return nil
 		}
 		if ctx.Err() != nil {
@@ -63,7 +81,7 @@ func walk(ctx context.Context, root string, parse func(lang string, content []by
 			return nil
 		}
 		if files++; files > maxFiles {
-			res.Truncated = true // signal the undercount rather than silently returning a partial result
+			truncated = true
 			return fs.SkipAll
 		}
 		fi, lerr := os.Lstat(path)
@@ -81,13 +99,15 @@ func walk(ctx context.Context, root string, parse func(lang string, content []by
 		if lang == "" {
 			return nil
 		}
-		if n, ok := parse(lang, content); ok {
-			res.Functions[lang] += n
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
 		}
+		visit(rel, lang, content)
 		return nil
 	})
 	if walkErr != nil {
-		return Result{}, walkErr
+		return false, walkErr
 	}
-	return res, nil
+	return truncated, nil
 }

--- a/internal/infrastructure/tools/astwalk/parse_cgo.go
+++ b/internal/infrastructure/tools/astwalk/parse_cgo.go
@@ -198,38 +198,48 @@ func isBoolOp(n *sitter.Node, sp spec) bool {
 }
 
 // complexity computes (cyclomatic, cognitive) for one function node over its own body, not descending into
-// nested functions (which are separate records). See the package doc for the exact rules.
+// nested functions (which are separate records). See the package doc for the exact rules. Iterative
+// (explicit stack of (node, nestingDepth)) so a pathologically deep expression tree in untrusted source
+// cannot overflow the goroutine stack — matching countType/collectFunctions.
 func complexity(fn *sitter.Node, sp spec) (cyc, cog int) {
 	cyc = 1
-	var rec func(n *sitter.Node, depth int)
-	rec = func(n *sitter.Node, depth int) {
+	type frame struct {
+		n     *sitter.Node
+		depth int
+	}
+	var stack []frame
+	push := func(n *sitter.Node, depth int) {
 		for i := 0; i < int(n.ChildCount()); i++ {
-			c := n.Child(i)
-			ct := c.Type()
-			if sp.funcType[ct] {
-				continue // nested function: its own record, and a nesting boundary
-			}
-			if isBoolOp(c, sp) {
-				cyc++
-				cog++
-				rec(c, depth)
-				continue
-			}
-			if sp.cycDecision[ct] {
-				cyc++
-			}
-			switch {
-			case sp.cogIncrement[ct]:
-				cog += 1 + depth
-				rec(c, depth+1)
-			case sp.cogElse[ct]:
-				cog++
-				rec(c, depth+1)
-			default:
-				rec(c, depth)
-			}
+			stack = append(stack, frame{n.Child(i), depth})
 		}
 	}
-	rec(fn, 0)
+	push(fn, 0) // start with the function's children at nesting depth 0
+	for len(stack) > 0 {
+		f := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		c, ct := f.n, f.n.Type()
+		if sp.funcType[ct] {
+			continue // nested function: its own record, and a nesting boundary — do not descend
+		}
+		if isBoolOp(c, sp) {
+			cyc++
+			cog++
+			push(c, f.depth)
+			continue
+		}
+		if sp.cycDecision[ct] {
+			cyc++
+		}
+		switch {
+		case sp.cogIncrement[ct]:
+			cog += 1 + f.depth
+			push(c, f.depth+1)
+		case sp.cogElse[ct]:
+			cog++
+			push(c, f.depth+1)
+		default:
+			push(c, f.depth)
+		}
+	}
 	return cyc, cog
 }

--- a/internal/infrastructure/tools/astwalk/parse_cgo.go
+++ b/internal/infrastructure/tools/astwalk/parse_cgo.go
@@ -1,8 +1,18 @@
 //go:build cgo
 
-// Package astwalk (cgo build): tree-sitter grammars parse each supported language and count function-like
-// declarations. Grammars are MIT-licensed C, compiled into this binary only; the server and CLI never
-// import this package, they exec the synapse-ast sidecar. Adding a language is one entry in `grammars`.
+// Package astwalk (cgo build): tree-sitter grammars parse each supported language to count functions and
+// compute per-function complexity. Grammars are MIT-licensed C, compiled into this binary only; the server
+// and CLI never import this package, they exec the synapse-ast sidecar. Adding a language is one `specs`
+// entry. Complexity definitions (deterministic, no LLM):
+//
+//   - Cyclomatic (McCabe): 1 + one per decision point (if/elif, each loop, each switch case, catch,
+//     ternary) + one per boolean operator (&& || / and or). Exact.
+//   - Cognitive: starts at 0; each control structure (if, loop, switch, catch, ternary) adds 1 + the
+//     current nesting depth and deepens nesting for its body; each else/elif adds 1 (no depth surcharge)
+//     and deepens nesting; each boolean operator adds 1. Documented deviations from the published
+//     definition: boolean operators are counted per-operator (not per like-operator sequence), Java
+//     `else if` is not folded (its nested if is counted), and a nested function is a separate record
+//     rather than adding nesting to its parent. Refinements are incremental.
 package astwalk
 
 import (
@@ -14,13 +24,6 @@ import (
 	"github.com/smacker/go-tree-sitter/python"
 )
 
-// grammar pairs a tree-sitter language with the set of AST node types that denote a function/method for
-// that language (a set, so multiple forms — declaration, method, arrow, constructor — all count).
-type grammar struct {
-	lang     *sitter.Language
-	funcType map[string]bool
-}
-
 func set(types ...string) map[string]bool {
 	m := make(map[string]bool, len(types))
 	for _, t := range types {
@@ -29,41 +32,115 @@ func set(types ...string) map[string]bool {
 	return m
 }
 
-// grammars maps a go-enry language name to its tree-sitter grammar. Initial set for Phase 0 slice 2;
-// TypeScript/Kotlin/Go/Ruby/C#/etc. are one line each and land incrementally.
-var grammars = map[string]grammar{
-	"Python": {python.GetLanguage(), set("function_definition")},
-	// Note: `function` alone is the *keyword* node nested inside function_declaration/expression, so it
-	// must NOT be in this set (it would double-count). Match the declaration/expression/arrow/method nodes.
-	"JavaScript": {javascript.GetLanguage(), set("function_declaration", "function_expression", "arrow_function", "method_definition", "generator_function_declaration", "generator_function")},
-	"Java":       {java.GetLanguage(), set("method_declaration", "constructor_declaration")},
+// spec is a language's tree-sitter grammar plus the node-type classification the metrics need.
+type spec struct {
+	lang         *sitter.Language
+	funcType     map[string]bool // function/method nodes (a metrics record + a nesting boundary)
+	cycDecision  map[string]bool // nodes each adding 1 to cyclomatic
+	cogIncrement map[string]bool // control structures adding 1+nesting to cognitive and deepening nesting
+	cogElse      map[string]bool // else/elif nodes adding 1 (no surcharge) and deepening nesting
+	// boolOpNode/boolOpToken detect a logical-operator node: either the node type itself (Python
+	// boolean_operator) or a binary node (JS/Java binary_expression) carrying a && / || child token.
+	boolOpNode  map[string]bool
+	boolOpBinry map[string]bool
+}
+
+var boolTokens = set("&&", "||")
+
+var specs = map[string]spec{
+	"Python": {
+		lang:         python.GetLanguage(),
+		funcType:     set("function_definition"),
+		cycDecision:  set("if_statement", "elif_clause", "for_statement", "while_statement", "except_clause", "conditional_expression", "case_clause"),
+		cogIncrement: set("if_statement", "for_statement", "while_statement", "except_clause", "conditional_expression", "case_clause"),
+		cogElse:      set("elif_clause", "else_clause"),
+		boolOpNode:   set("boolean_operator"),
+	},
+	"JavaScript": {
+		lang:         javascript.GetLanguage(),
+		funcType:     set("function_declaration", "function_expression", "arrow_function", "method_definition", "generator_function_declaration", "generator_function"),
+		cycDecision:  set("if_statement", "for_statement", "for_in_statement", "while_statement", "do_statement", "switch_case", "catch_clause", "ternary_expression"),
+		cogIncrement: set("if_statement", "for_statement", "for_in_statement", "while_statement", "do_statement", "switch_statement", "catch_clause", "ternary_expression"),
+		cogElse:      set("else_clause"),
+		boolOpBinry:  set("binary_expression"),
+	},
+	"Java": {
+		lang:         java.GetLanguage(),
+		funcType:     set("method_declaration", "constructor_declaration"),
+		cycDecision:  set("if_statement", "for_statement", "enhanced_for_statement", "while_statement", "do_statement", "switch_label", "catch_clause", "ternary_expression"),
+		cogIncrement: set("if_statement", "for_statement", "enhanced_for_statement", "while_statement", "do_statement", "switch_expression", "catch_clause", "ternary_expression"),
+		cogElse:      set(), // Java `else` is a token inside if_statement, not a node; else-if is a nested if (documented)
+		boolOpBinry:  set("binary_expression"),
+	},
 }
 
 // FunctionsFor parses every supported-language file under root and returns accurate per-language function
 // counts.
 func FunctionsFor(ctx context.Context, root string) (Result, error) {
-	return walk(ctx, root, func(lang string, content []byte) (int, bool) {
-		g, ok := grammars[lang]
+	res := Result{Functions: map[string]int{}}
+	truncated, err := walkSource(ctx, root, func(_ /*rel*/, lang string, content []byte) {
+		sp, ok := specs[lang]
 		if !ok {
-			return 0, false
+			return
 		}
-		p := sitter.NewParser()
-		p.SetLanguage(g.lang)
-		tree, err := p.ParseCtx(ctx, nil, content)
-		if err != nil || tree == nil {
-			return 0, false // unparseable file contributes nothing rather than a wrong count
+		root := parseRoot(ctx, sp, content)
+		if root == nil {
+			return
 		}
-		defer tree.Close()
-		return countNodes(tree.RootNode(), g.funcType), true
+		res.Functions[lang] += countType(root, sp.funcType)
 	})
+	if err != nil {
+		return Result{}, err
+	}
+	res.Truncated = truncated
+	return res, nil
 }
 
-// countNodes returns the number of descendants (inclusive) whose type is in want. Iterative DFS to avoid
-// deep recursion on a hostile tree.
-func countNodes(root *sitter.Node, want map[string]bool) int {
-	if root == nil {
-		return 0
+// MetricsFor parses every supported-language file under root and returns one record per function with its
+// cyclomatic and cognitive complexity.
+func MetricsFor(ctx context.Context, root string) (Metrics, error) {
+	var m Metrics
+	m.Functions = []FunctionMetric{}
+	truncated, err := walkSource(ctx, root, func(rel, lang string, content []byte) {
+		sp, ok := specs[lang]
+		if !ok {
+			return
+		}
+		root := parseRoot(ctx, sp, content)
+		if root == nil {
+			return
+		}
+		for _, fn := range collectFunctions(root, sp) {
+			cyc, cog := complexity(fn, sp)
+			m.Functions = append(m.Functions, FunctionMetric{
+				File:       rel,
+				Line:       int(fn.StartPoint().Row) + 1,
+				Name:       functionName(fn, content),
+				Language:   lang,
+				Cyclomatic: cyc,
+				Cognitive:  cog,
+			})
+		}
+	})
+	if err != nil {
+		return Metrics{}, err
 	}
+	m.Truncated = truncated
+	return m, nil
+}
+
+func parseRoot(ctx context.Context, sp spec, content []byte) *sitter.Node {
+	p := sitter.NewParser()
+	p.SetLanguage(sp.lang)
+	tree, err := p.ParseCtx(ctx, nil, content)
+	if err != nil || tree == nil {
+		return nil
+	}
+	return tree.RootNode()
+}
+
+// countType counts descendants (inclusive) whose type is in want (iterative DFS, hostile-tree safe).
+func countType(root *sitter.Node, want map[string]bool) int {
 	n := 0
 	stack := []*sitter.Node{root}
 	for len(stack) > 0 {
@@ -77,4 +154,82 @@ func countNodes(root *sitter.Node, want map[string]bool) int {
 		}
 	}
 	return n
+}
+
+// collectFunctions returns every function node under root (iterative DFS).
+func collectFunctions(root *sitter.Node, sp spec) []*sitter.Node {
+	var out []*sitter.Node
+	stack := []*sitter.Node{root}
+	for len(stack) > 0 {
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if sp.funcType[node.Type()] {
+			out = append(out, node)
+		}
+		for i := 0; i < int(node.ChildCount()); i++ {
+			stack = append(stack, node.Child(i))
+		}
+	}
+	return out
+}
+
+// functionName returns the function's declared name from src, or "<anonymous>" (arrow/expression functions).
+func functionName(fn *sitter.Node, src []byte) string {
+	if name := fn.ChildByFieldName("name"); name != nil {
+		return name.Content(src)
+	}
+	return "<anonymous>"
+}
+
+// isBoolOp reports whether n is a logical-operator node for the spec (Python boolean_operator, or a JS/Java
+// binary node with a && / || operator token child).
+func isBoolOp(n *sitter.Node, sp spec) bool {
+	if sp.boolOpNode[n.Type()] {
+		return true
+	}
+	if sp.boolOpBinry[n.Type()] {
+		for i := 0; i < int(n.ChildCount()); i++ {
+			if boolTokens[n.Child(i).Type()] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// complexity computes (cyclomatic, cognitive) for one function node over its own body, not descending into
+// nested functions (which are separate records). See the package doc for the exact rules.
+func complexity(fn *sitter.Node, sp spec) (cyc, cog int) {
+	cyc = 1
+	var rec func(n *sitter.Node, depth int)
+	rec = func(n *sitter.Node, depth int) {
+		for i := 0; i < int(n.ChildCount()); i++ {
+			c := n.Child(i)
+			ct := c.Type()
+			if sp.funcType[ct] {
+				continue // nested function: its own record, and a nesting boundary
+			}
+			if isBoolOp(c, sp) {
+				cyc++
+				cog++
+				rec(c, depth)
+				continue
+			}
+			if sp.cycDecision[ct] {
+				cyc++
+			}
+			switch {
+			case sp.cogIncrement[ct]:
+				cog += 1 + depth
+				rec(c, depth+1)
+			case sp.cogElse[ct]:
+				cog++
+				rec(c, depth+1)
+			default:
+				rec(c, depth)
+			}
+		}
+	}
+	rec(fn, 0)
+	return cyc, cog
 }

--- a/internal/infrastructure/tools/astwalk/parse_cgo_test.go
+++ b/internal/infrastructure/tools/astwalk/parse_cgo_test.go
@@ -38,3 +38,59 @@ func TestFunctionsForCGO(t *testing.T) {
 		}
 	}
 }
+
+func TestMetricsForCGO(t *testing.T) {
+	root := t.TempDir()
+	// Expected values are hand-computed per the documented algorithm (see parse_cgo.go package doc).
+	writeFile(t, root, "m.py", "def f(x):\n"+
+		"    if x and y:\n"+
+		"        for i in z:\n"+
+		"            pass\n"+
+		"    elif w:\n"+
+		"        pass\n"+
+		"    else:\n"+
+		"        pass\n"+
+		"    return 1 if x else 2\n")
+	writeFile(t, root, "a.js", "function g(x){\n"+
+		"  if (x && y) { for (;;) {} } else if (z) {}\n"+
+		"  switch (x) { case 1: break; }\n"+
+		"  return x ? 1 : 2;\n"+
+		"}\n")
+	writeFile(t, root, "C.java", "class C {\n"+
+		"  int m(int x) {\n"+
+		"    if (x > 0 && y) { while (true) {} } else if (z) {}\n"+
+		"    return x > 0 ? 1 : 2;\n"+
+		"  }\n"+
+		"}\n")
+
+	m, err := MetricsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("MetricsFor: %v", err)
+	}
+	get := func(name string) (FunctionMetric, bool) {
+		for _, f := range m.Functions {
+			if f.Name == name {
+				return f, true
+			}
+		}
+		return FunctionMetric{}, false
+	}
+	for _, tc := range []struct {
+		name     string
+		cyc, cog int
+		lang     string
+	}{
+		{"f", 6, 7, "Python"},
+		{"g", 7, 10, "JavaScript"},
+		{"m", 6, 7, "Java"},
+	} {
+		f, ok := get(tc.name)
+		if !ok {
+			t.Errorf("function %q not found (all: %+v)", tc.name, m.Functions)
+			continue
+		}
+		if f.Cyclomatic != tc.cyc || f.Cognitive != tc.cog || f.Language != tc.lang {
+			t.Errorf("%s: got cyc=%d cog=%d lang=%s, want cyc=%d cog=%d lang=%s", tc.name, f.Cyclomatic, f.Cognitive, f.Language, tc.cyc, tc.cog, tc.lang)
+		}
+	}
+}

--- a/internal/infrastructure/tools/astwalk/parse_nocgo.go
+++ b/internal/infrastructure/tools/astwalk/parse_nocgo.go
@@ -4,9 +4,13 @@ package astwalk
 
 import "context"
 
-// FunctionsFor is the CGO-free stub: no tree-sitter grammar is compiled in, so the sidecar reports the
-// backend as unavailable and callers fall back to their own counting. This is the build the distroless-
-// parity CI step (`CGO_ENABLED=0 go build ./cmd/...`) compiles.
+// FunctionsFor / MetricsFor are the CGO-free stubs: no tree-sitter grammar is compiled in, so the sidecar
+// reports the backend as unavailable and callers fall back to their own counting. This is the build the
+// distroless-parity CI step (`CGO_ENABLED=0 go build ./cmd/...`) compiles.
 func FunctionsFor(ctx context.Context, root string) (Result, error) {
 	return Result{}, ErrUnavailable
+}
+
+func MetricsFor(ctx context.Context, root string) (Metrics, error) {
+	return Metrics{}, ErrUnavailable
 }

--- a/internal/usecase/ports/astprovider.go
+++ b/internal/usecase/ports/astprovider.go
@@ -1,6 +1,10 @@
 package ports
 
-import "context"
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+)
 
 // ASTProvider computes structural facts over a source tree using a language-aware parser, backed by the
 // sandboxed synapse-ast sidecar (which isolates the CGO tree-sitter grammars out of the server/CLI, the
@@ -11,4 +15,11 @@ import "context"
 // a wrong zero. Implementations read the target only (never execute it) and honor context cancellation.
 type ASTProvider interface {
 	FunctionCounts(ctx context.Context, root string) (counts map[string]int, available bool, err error)
+}
+
+// CodeMetricsProvider computes per-function complexity (cyclomatic + cognitive) over a source tree, via
+// the same sandboxed synapse-ast sidecar. available=false when no AST backend is built/wired, so a caller
+// degrades (e.g. skips the complexity gate) rather than failing.
+type CodeMetricsProvider interface {
+	Complexity(ctx context.Context, root string) (report measure.ComplexityReport, available bool, err error)
 }


### PR DESCRIPTION
Implements **Phase 1** of the Code Quality epic (#95, #97): per-function complexity, built on the Phase-0 `synapse-ast` tree-sitter sidecar.

### What
| Metric | Definition |
|---|---|
| **Cyclomatic** | McCabe: `1 + decision points + boolean operators` (exact) |
| **Cognitive** | nesting-aware: each control structure adds `1 + nesting depth` and deepens nesting; each `else`/`elif` adds 1; each boolean operator adds 1 |

The exact rules and documented deviations (boolean ops counted per-operator; Java `else if` not folded; nested function = separate record) are in the `astwalk` package doc. Node-type sets were verified against the real AST (e.g. so a `switch` counts once for cognitive but each `case` for cyclomatic).

### Pieces
- `astwalk`: shared `walkSource` + `MetricsFor` (behind `//go:build cgo`, with the CGO-free stub).
- `cmd/synapse-ast metrics <dir>` -> per-function JSON records.
- `domain/measure`: `FunctionComplexity` + `ComplexityReport` (`MaxCyclomatic` / `OverCyclomatic` / `TopByCyclomatic`).
- `ports.CodeMetricsProvider` + the `ast` adapter's `Complexity` (absent/CGO-free sidecar -> `available=false`, no error).
- `synapse-cli metrics <path> [--fail-on-complexity N] [--top N]`.

### Example + gate
```
$ synapse-cli metrics ./src --fail-on-complexity 5
  functions: 2 · highest cyclomatic: 7
  top 10 by cyclomatic complexity:
    cyc  cog   language   function (file:line)
    7    10    JavaScript g (a.js:1)
    1    0     JavaScript simple (a.js:6)
# exit 1: 1 function(s) exceed cyclomatic complexity 5
```

### Tests / CI
Complexity values are test-locked against hand-computed fixtures in Python/JavaScript/Java; `measure` rollups and the adapter's unavailable-path are covered. Both `go build ./...` (CGO on) and `CGO_ENABLED=0 go build ./cmd/...` (distroless parity) pass.

Part of #97. Epic #95.
