### PR TITLE
feat(quality): copy-paste (duplication) detection (Code Quality Phase 2)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ast"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/bincat"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/codeinventory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/duplication"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/enry"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gomodgraph"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gradleresolve"
@@ -91,6 +92,14 @@ func main() {
 			usage()
 		}
 		if err := runMetrics(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
+			os.Exit(1)
+		}
+	case "duplication":
+		if len(os.Args) < 3 {
+			usage()
+		}
+		if err := runDuplication(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 			os.Exit(1)
 		}
@@ -191,6 +200,66 @@ func runMetrics(args []string) error {
 	return nil
 }
 
+// runDuplication prints a copy-paste (clone) report for a local source tree and optionally gates on the
+// duplicated-lines density. Pure-Go, read-only; no DB, no sidecar.
+func runDuplication(args []string) error {
+	dir := args[0]
+	minTokens := duplication.DefaultMinTokens
+	failOnPct := -1.0 // <0 = no gate
+	top := 10
+	for i := 1; i < len(args); i++ {
+		switch {
+		case args[i] == "--min-tokens" && i+1 < len(args):
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n < 1 {
+				return fmt.Errorf("--min-tokens wants a positive integer, got %q", args[i+1])
+			}
+			minTokens = n
+			i++
+		case args[i] == "--fail-on-duplication" && i+1 < len(args):
+			p, err := strconv.ParseFloat(args[i+1], 64)
+			if err != nil || p < 0 {
+				return fmt.Errorf("--fail-on-duplication wants a non-negative percentage, got %q", args[i+1])
+			}
+			failOnPct = p
+			i++
+		case args[i] == "--top" && i+1 < len(args):
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n < 0 {
+				return fmt.Errorf("--top wants a non-negative integer, got %q", args[i+1])
+			}
+			top = n
+			i++
+		default:
+			return fmt.Errorf("unknown or incomplete option %q", args[i])
+		}
+	}
+
+	report, err := duplication.New(minTokens).Duplication(context.Background(), dir)
+	if err != nil {
+		return fmt.Errorf("duplication: %w", err)
+	}
+	fmt.Printf("\nSynapse code duplication — %s\n", dir)
+	if report.Truncated {
+		fmt.Println("  ! result truncated at the file cap; metrics are a lower bound")
+	}
+	fmt.Printf("  duplicated blocks: %d · duplicated lines: %d / %d code lines · density: %.1f%% · files: %d (min-tokens %d)\n",
+		len(report.Blocks), report.DuplicatedLines, report.TotalLines, report.Density(), report.Files, minTokens)
+	if len(report.Blocks) > 0 {
+		fmt.Printf("  top %d duplicated blocks:\n", top)
+		for _, b := range report.TopBlocks(top) {
+			fmt.Printf("    %d tokens, %d places:\n", b.Tokens, len(b.Occurrences))
+			for _, o := range b.Occurrences {
+				fmt.Printf("      %s:%d-%d\n", o.File, o.StartLine, o.EndLine)
+			}
+		}
+	}
+	if failOnPct >= 0 && report.Density() > failOnPct {
+		return fmt.Errorf("duplicated-lines density %.1f%% exceeds %.1f%%", report.Density(), failOnPct)
+	}
+	return nil
+}
+
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
 	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
@@ -199,6 +268,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "      --offline  skip the live OSV.dev source; detect with Grype's offline DB only (air-gapped / fast)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli inventory <path>             # per-language code-size inventory (files, code/comment/blank lines, functions) — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli metrics <path> [--fail-on-complexity N] [--top N]  # per-function cyclomatic+cognitive complexity (needs the synapse-ast sidecar)")
+	fmt.Fprintln(os.Stderr, "  synapse-cli duplication <path> [--min-tokens N] [--fail-on-duplication PCT] [--top N]  # copy-paste detection (blocks, lines, density) — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote     # fetch + ingest app ecosystems from the OSV bulk bucket (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote-distros # fetch + ingest OS-package advisories (Debian/Alpine) from OSV (large; requires SYNAPSE_DB_DSN)")

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -204,6 +204,9 @@ func runMetrics(args []string) error {
 // duplicated-lines density. Pure-Go, read-only; no DB, no sidecar.
 func runDuplication(args []string) error {
 	dir := args[0]
+	if strings.HasPrefix(dir, "-") {
+		return fmt.Errorf("first argument must be a path, got option %q", dir)
+	}
 	minTokens := duplication.DefaultMinTokens
 	failOnPct := -1.0 // <0 = no gate
 	top := 10

--- a/internal/domain/measure/duplication.go
+++ b/internal/domain/measure/duplication.go
@@ -1,0 +1,59 @@
+package measure
+
+import "sort"
+
+// CodeRange is a line span within a file (both 1-based, inclusive).
+type CodeRange struct {
+	File      string `json:"file"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+}
+
+// DuplicationBlock is one duplicated token run, present at two or more places (Occurrences). Tokens is the
+// length of the duplicated run in tokens.
+type DuplicationBlock struct {
+	Tokens      int         `json:"tokens"`
+	Occurrences []CodeRange `json:"occurrences"`
+}
+
+// DuplicationReport aggregates copy-paste detection over a source tree, mirroring the standard metrics:
+// duplicated blocks, duplicated lines, files touched, and duplicated-lines density. Truncated is true when
+// the walk hit its file cap (a signalled undercount).
+type DuplicationReport struct {
+	Blocks          []DuplicationBlock `json:"blocks"`
+	DuplicatedLines int                `json:"duplicated_lines"`
+	TotalLines      int                `json:"total_lines"` // code lines considered (non-blank, non-comment)
+	Files           int                `json:"files"`       // distinct files containing a duplication
+	Truncated       bool               `json:"truncated,omitempty"`
+}
+
+// Density is the duplicated-lines density as a percentage of total code lines (0 when there are none).
+func (r DuplicationReport) Density() float64 {
+	if r.TotalLines == 0 {
+		return 0
+	}
+	return 100 * float64(r.DuplicatedLines) / float64(r.TotalLines)
+}
+
+// TopBlocks returns up to n duplication blocks, largest (most tokens) first, deterministic on ties.
+func (r DuplicationReport) TopBlocks(n int) []DuplicationBlock {
+	sorted := make([]DuplicationBlock, len(r.Blocks))
+	copy(sorted, r.Blocks)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].Tokens != sorted[j].Tokens {
+			return sorted[i].Tokens > sorted[j].Tokens
+		}
+		if len(sorted[i].Occurrences) == 0 || len(sorted[j].Occurrences) == 0 {
+			return len(sorted[i].Occurrences) > len(sorted[j].Occurrences)
+		}
+		a, b := sorted[i].Occurrences[0], sorted[j].Occurrences[0]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		return a.StartLine < b.StartLine
+	})
+	if n >= 0 && n < len(sorted) {
+		sorted = sorted[:n]
+	}
+	return sorted
+}

--- a/internal/infrastructure/tools/duplication/detector.go
+++ b/internal/infrastructure/tools/duplication/detector.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	// DefaultMinTokens is the smallest duplicated token run reported by default. 100 tokens is the
-	// long-standing industry default (PMD/CPD) and keeps trivial repetition (imports, boilerplate) out.
+	// DefaultMinTokens is the smallest duplicated token run reported by default. Tokens here are at
+	// lexer granularity (an identifier/number, a whole string literal, or an operator run — see the
+	// tokenizer), so 100 matches the long-standing PMD/CPD default and keeps trivial repetition out.
 	DefaultMinTokens = 100
 	maxFileBytes     = 4 << 20
 	maxFiles         = 200_000
@@ -66,7 +67,7 @@ func (d *Detector) Duplication(ctx context.Context, root string) (measure.Duplic
 	if err != nil {
 		return measure.DuplicationReport{}, err
 	}
-	return d.detect(files, truncated), nil
+	return d.detect(ctx, files, truncated)
 }
 
 // collect walks root and tokenizes each regular, non-vendored, non-binary source file.
@@ -133,8 +134,10 @@ func (d *Detector) collect(ctx context.Context, root string) ([]fileTokens, bool
 	return out, truncated, nil
 }
 
-// detect finds maximal duplicated token runs across the collected files.
-func (d *Detector) detect(files []fileTokens, truncated bool) measure.DuplicationReport {
+// detect finds maximal duplicated token runs across the collected files. Greedy: each token is assigned
+// to at most one clone class (via covered[]), so overlapping clone classes that share tokens can be
+// undercounted — false negatives only, never false positives.
+func (d *Detector) detect(ctx context.Context, files []fileTokens, truncated bool) (measure.DuplicationReport, error) {
 	k := d.minTokens
 	rep := measure.DuplicationReport{Truncated: truncated}
 	for _, f := range files {
@@ -186,6 +189,9 @@ func (d *Detector) detect(files []fileTokens, truncated bool) measure.Duplicatio
 	// Process seeds in file/token order for determinism; the leftmost start of a clone is seen first, so
 	// right-extension captures it maximally and covered[] suppresses its interior windows.
 	for fi := range files {
+		if ctx.Err() != nil {
+			return measure.DuplicationReport{}, ctx.Err()
+		}
 		toks := files[fi].toks
 		for start := 0; start+k <= len(toks); start++ {
 			if covered[fi][start] {
@@ -269,7 +275,7 @@ func (d *Detector) detect(files []fileTokens, truncated bool) measure.Duplicatio
 		}
 	}
 	rep.Files = filesWith
-	return rep
+	return rep, nil
 }
 
 // equalRun reports whether a[ai:ai+n] and b[bi:bi+n] have identical token text.

--- a/internal/infrastructure/tools/duplication/detector.go
+++ b/internal/infrastructure/tools/duplication/detector.go
@@ -1,0 +1,292 @@
+// Package duplication is a deterministic, pure-Go copy-paste (clone) detector: it walks a source tree,
+// tokenizes each file (comment- and whitespace-insensitive, language-aware comment stripping), and finds
+// runs of duplicated tokens across and within files via a Rabin-Karp rolling hash, then reports the
+// standard duplication metrics (blocks, duplicated lines, files, density). It NEVER executes the target
+// and reads bounded (skips vendored/binary/oversized files, follows no symlinks). Pure Go with no CGO, so
+// it is available in every build (unlike the tree-sitter metrics sidecar). Exact (Type-1) clones:
+// identifiers and literals are matched by text, which is the copy-paste signal operators expect.
+package duplication
+
+import (
+	"context"
+	"hash/fnv"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	enry "github.com/go-enry/go-enry/v2"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	// DefaultMinTokens is the smallest duplicated token run reported by default. 100 tokens is the
+	// long-standing industry default (PMD/CPD) and keeps trivial repetition (imports, boilerplate) out.
+	DefaultMinTokens = 100
+	maxFileBytes     = 4 << 20
+	maxFiles         = 200_000
+	hashBase         = 1099511628211 // FNV prime, reused as the rolling-hash polynomial base
+)
+
+var skipDirs = map[string]bool{
+	".git": true, "node_modules": true, "vendor": true, "dist": true, "build": true,
+	".venv": true, "venv": true, "__pycache__": true, "target": true, ".idea": true,
+	".vscode": true, ".tox": true, ".hg": true, ".svn": true,
+}
+
+// Detector finds duplicated token runs of at least MinTokens tokens.
+type Detector struct{ minTokens int }
+
+// New returns a detector. minTokens <= 0 uses DefaultMinTokens.
+func New(minTokens int) *Detector {
+	if minTokens <= 0 {
+		minTokens = DefaultMinTokens
+	}
+	return &Detector{minTokens: minTokens}
+}
+
+var _ ports.DuplicationScanner = (*Detector)(nil)
+
+type token struct {
+	text string
+	line int // 1-based
+}
+
+type fileTokens struct {
+	rel       string
+	toks      []token
+	codeLines int
+}
+
+// Duplication walks root, tokenizes each supported source file, and returns the duplication report.
+func (d *Detector) Duplication(ctx context.Context, root string) (measure.DuplicationReport, error) {
+	files, truncated, err := d.collect(ctx, root)
+	if err != nil {
+		return measure.DuplicationReport{}, err
+	}
+	return d.detect(files, truncated), nil
+}
+
+// collect walks root and tokenizes each regular, non-vendored, non-binary source file.
+func (d *Detector) collect(ctx context.Context, root string) ([]fileTokens, bool, error) {
+	if root == "" {
+		return nil, false, nil
+	}
+	var out []fileTokens
+	truncated := false
+	count := 0
+	walkErr := filepath.WalkDir(root, func(path string, de fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if de.IsDir() {
+			if path != root && skipDirs[de.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !de.Type().IsRegular() {
+			return nil
+		}
+		if count++; count > maxFiles {
+			truncated = true
+			return fs.SkipAll
+		}
+		fi, lerr := os.Lstat(path)
+		if lerr != nil || !fi.Mode().IsRegular() || fi.Size() > maxFileBytes {
+			return nil
+		}
+		content, rerr := os.ReadFile(path) // #nosec G304 -- regular file, size-capped via Lstat above, under the walked root
+		if rerr != nil {
+			return nil
+		}
+		if enry.IsVendor(path) || enry.IsDotFile(path) || enry.IsGenerated(path, content) || enry.IsBinary(content) {
+			return nil
+		}
+		lang := enry.GetLanguage(filepath.Base(path), content)
+		if lang == "" {
+			return nil
+		}
+		switch enry.GetLanguageType(lang) {
+		case enry.Programming, enry.Markup:
+		default:
+			return nil
+		}
+		toks, codeLines := tokenize(lang, content)
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		out = append(out, fileTokens{rel: rel, toks: toks, codeLines: codeLines})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, false, walkErr
+	}
+	// Deterministic file order (WalkDir is lexical already, but be explicit for stable output).
+	sort.Slice(out, func(i, j int) bool { return out[i].rel < out[j].rel })
+	return out, truncated, nil
+}
+
+// detect finds maximal duplicated token runs across the collected files.
+func (d *Detector) detect(files []fileTokens, truncated bool) measure.DuplicationReport {
+	k := d.minTokens
+	rep := measure.DuplicationReport{Truncated: truncated}
+	for _, f := range files {
+		rep.TotalLines += f.codeLines
+	}
+
+	// token hashes per file + the FNV of each token text.
+	th := make([][]uint64, len(files))
+	for fi, f := range files {
+		th[fi] = make([]uint64, len(f.toks))
+		for i, t := range f.toks {
+			th[fi][i] = fnv64(t.text)
+		}
+	}
+
+	// bucket every length-k window by its rolling hash: hash -> positions.
+	type pos struct{ file, tok int }
+	buckets := map[uint64][]pos{}
+	pow := uint64(1)
+	for i := 1; i < k; i++ {
+		pow *= hashBase
+	}
+	for fi := range files {
+		h := th[fi]
+		if len(h) < k {
+			continue
+		}
+		var win uint64
+		for i := 0; i < k; i++ {
+			win = win*hashBase + h[i]
+		}
+		buckets[win] = append(buckets[win], pos{fi, 0})
+		for i := k; i < len(h); i++ {
+			win = (win-h[i-k]*pow)*hashBase + h[i]
+			buckets[win] = append(buckets[win], pos{fi, i - k + 1})
+		}
+	}
+
+	// covered[file] = set of token indices already reported, so overlapping sub-clones are not re-emitted.
+	covered := make([]map[int]bool, len(files))
+	for i := range covered {
+		covered[i] = map[int]bool{}
+	}
+	dupLines := make([]map[int]bool, len(files))
+	for i := range dupLines {
+		dupLines[i] = map[int]bool{}
+	}
+
+	// Process seeds in file/token order for determinism; the leftmost start of a clone is seen first, so
+	// right-extension captures it maximally and covered[] suppresses its interior windows.
+	for fi := range files {
+		toks := files[fi].toks
+		for start := 0; start+k <= len(toks); start++ {
+			if covered[fi][start] {
+				continue
+			}
+			var win uint64
+			for i := start; i < start+k; i++ {
+				win = win*hashBase + th[fi][i]
+			}
+			cands := buckets[win]
+			if len(cands) < 2 {
+				continue
+			}
+			// members = positions whose k-token text matches this window and are not covered.
+			members := []pos{{fi, start}}
+			for _, c := range cands {
+				if c.file == fi && c.tok == start {
+					continue
+				}
+				if covered[c.file][c.tok] {
+					continue
+				}
+				if equalRun(files[fi].toks, start, files[c.file].toks, c.tok, k) {
+					members = append(members, c)
+				}
+			}
+			if len(members) < 2 {
+				continue
+			}
+			// Extend right while every member has a matching next token in-bounds.
+			length := k
+			for {
+				base := files[members[0].file].toks
+				bi := members[0].tok + length
+				if bi >= len(base) {
+					break
+				}
+				ok := true
+				for _, m := range members[1:] {
+					mt := files[m.file].toks
+					mi := m.tok + length
+					if mi >= len(mt) || mt[mi].text != base[bi].text {
+						ok = false
+						break
+					}
+				}
+				if !ok {
+					break
+				}
+				length++
+			}
+			// Record the block, mark covered + duplicated lines.
+			block := measure.DuplicationBlock{Tokens: length}
+			for _, m := range members {
+				mt := files[m.file].toks
+				block.Occurrences = append(block.Occurrences, measure.CodeRange{
+					File:      files[m.file].rel,
+					StartLine: mt[m.tok].line,
+					EndLine:   mt[m.tok+length-1].line,
+				})
+				for i := m.tok; i < m.tok+length; i++ {
+					covered[m.file][i] = true
+					dupLines[m.file][mt[i].line] = true
+				}
+			}
+			sort.Slice(block.Occurrences, func(i, j int) bool {
+				if block.Occurrences[i].File != block.Occurrences[j].File {
+					return block.Occurrences[i].File < block.Occurrences[j].File
+				}
+				return block.Occurrences[i].StartLine < block.Occurrences[j].StartLine
+			})
+			rep.Blocks = append(rep.Blocks, block)
+		}
+	}
+
+	filesWith := 0
+	for fi := range files {
+		if len(dupLines[fi]) > 0 {
+			filesWith++
+			rep.DuplicatedLines += len(dupLines[fi])
+		}
+	}
+	rep.Files = filesWith
+	return rep
+}
+
+// equalRun reports whether a[ai:ai+n] and b[bi:bi+n] have identical token text.
+func equalRun(a []token, ai int, b []token, bi, n int) bool {
+	if ai+n > len(a) || bi+n > len(b) {
+		return false
+	}
+	for i := 0; i < n; i++ {
+		if a[ai+i].text != b[bi+i].text {
+			return false
+		}
+	}
+	return true
+}
+
+func fnv64(s string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum64()
+}

--- a/internal/infrastructure/tools/duplication/detector_test.go
+++ b/internal/infrastructure/tools/duplication/detector_test.go
@@ -1,0 +1,123 @@
+package duplication
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func write(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const dupBody = `func Compute(x int) int {
+	total := 0
+	for i := 0; i < x; i++ {
+		total = total + i*i
+	}
+	return total
+}
+`
+
+func TestCrossFileDuplication(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "a.go", "package a\n"+dupBody+"func UA() { println(1) }\n")
+	write(t, root, "b.go", "package b\n"+dupBody+"func UB() { println(2) }\n")
+
+	rep, err := New(10).Duplication(context.Background(), root)
+	if err != nil {
+		t.Fatalf("duplication: %v", err)
+	}
+	if len(rep.Blocks) != 1 {
+		t.Fatalf("want 1 duplicated block, got %d (%+v)", len(rep.Blocks), rep.Blocks)
+	}
+	b := rep.Blocks[0]
+	if len(b.Occurrences) != 2 {
+		t.Fatalf("want 2 occurrences, got %d", len(b.Occurrences))
+	}
+	if b.Occurrences[0].File != "a.go" || b.Occurrences[1].File != "b.go" {
+		t.Errorf("occurrence files wrong: %+v", b.Occurrences)
+	}
+	if rep.Files != 2 {
+		t.Errorf("want 2 files with duplication, got %d", rep.Files)
+	}
+	if rep.Density() <= 0 {
+		t.Errorf("density should be > 0, got %.1f", rep.Density())
+	}
+}
+
+func TestCommentInsensitive(t *testing.T) {
+	// The same code with DIFFERENT comments must still be detected as a clone.
+	root := t.TempDir()
+	write(t, root, "a.go", "package a\n// first copy\n"+dupBody)
+	write(t, root, "b.go", "package b\n/* a totally different comment here */\n"+dupBody)
+	rep, err := New(10).Duplication(context.Background(), root)
+	if err != nil {
+		t.Fatalf("duplication: %v", err)
+	}
+	if len(rep.Blocks) != 1 {
+		t.Fatalf("comment-only differences must not hide the clone: got %d blocks", len(rep.Blocks))
+	}
+}
+
+func TestBelowThresholdNotReported(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "a.go", "package a\n"+dupBody+"func UA(){}\n")
+	write(t, root, "b.go", "package b\n"+dupBody+"func UB(){}\n")
+	// The shared block is ~38 tokens; a threshold above that yields no duplication.
+	rep, err := New(500).Duplication(context.Background(), root)
+	if err != nil {
+		t.Fatalf("duplication: %v", err)
+	}
+	if len(rep.Blocks) != 0 {
+		t.Errorf("min-tokens above the clone size must report nothing, got %+v", rep.Blocks)
+	}
+}
+
+func TestNoDuplication(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "a.go", "package a\nfunc A() { println(1) }\n")
+	write(t, root, "b.go", "package b\nfunc B() { println(2) }\n")
+	rep, err := New(6).Duplication(context.Background(), root)
+	if err != nil {
+		t.Fatalf("duplication: %v", err)
+	}
+	if len(rep.Blocks) != 0 || rep.DuplicatedLines != 0 || rep.Density() != 0 {
+		t.Errorf("distinct files must have no duplication, got %+v", rep)
+	}
+}
+
+func TestIntraFileDuplication(t *testing.T) {
+	// Two identical blocks in ONE file must be detected.
+	root := t.TempDir()
+	write(t, root, "a.go", "package a\n"+dupBody+"func Mid(){}\n"+dupBody)
+	rep, err := New(10).Duplication(context.Background(), root)
+	if err != nil {
+		t.Fatalf("duplication: %v", err)
+	}
+	if len(rep.Blocks) != 1 || len(rep.Blocks[0].Occurrences) != 2 {
+		t.Fatalf("intra-file clone not detected: %+v", rep.Blocks)
+	}
+	if rep.Blocks[0].Occurrences[0].File != "a.go" || rep.Blocks[0].Occurrences[1].File != "a.go" {
+		t.Errorf("both occurrences should be in a.go: %+v", rep.Blocks[0].Occurrences)
+	}
+}
+
+func TestDeterministic(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "a.go", "package a\n"+dupBody)
+	write(t, root, "b.go", "package b\n"+dupBody)
+	r1, _ := New(10).Duplication(context.Background(), root)
+	r2, _ := New(10).Duplication(context.Background(), root)
+	if len(r1.Blocks) != len(r2.Blocks) || r1.DuplicatedLines != r2.DuplicatedLines {
+		t.Errorf("non-deterministic: %+v vs %+v", r1, r2)
+	}
+}

--- a/internal/infrastructure/tools/duplication/tokenizer.go
+++ b/internal/infrastructure/tools/duplication/tokenizer.go
@@ -95,7 +95,20 @@ func isWord(b byte) bool {
 	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
-// tokenizeLine appends the tokens of a comment-stripped line.
+// opChars are the characters that combine into a single operator token (so `!=`, `<=`, `&&`, `->`, `=>`,
+// `::`, `+=` count as one token, matching a real lexer's granularity rather than one-per-character).
+func isOpChar(b byte) bool {
+	switch b {
+	case '+', '-', '*', '/', '%', '=', '<', '>', '!', '&', '|', '^', '~', '?', ':':
+		return true
+	}
+	return false
+}
+
+// tokenizeLine appends the tokens of a comment-stripped line, at roughly lexer granularity: an
+// identifier/number run, a whole string literal, a run of operator characters, or a single structural
+// punctuation char. A string literal that is not closed on the same line yields one token to end of line
+// (the walk is line-based; multi-line raw strings/templates are a documented edge).
 func tokenizeLine(line string, lineNo int, toks *[]token) {
 	i := 0
 	for i < len(line) {
@@ -103,9 +116,31 @@ func tokenizeLine(line string, lineNo int, toks *[]token) {
 		switch {
 		case c == ' ' || c == '\t' || c == '\r':
 			i++
+		case c == '"' || c == '\'' || c == '`':
+			j := i + 1
+			for j < len(line) {
+				if line[j] == '\\' && j+1 < len(line) { // skip an escaped char (e.g. \" \\)
+					j += 2
+					continue
+				}
+				if line[j] == c {
+					j++
+					break
+				}
+				j++
+			}
+			*toks = append(*toks, token{text: line[i:j], line: lineNo})
+			i = j
 		case isWord(c):
 			j := i + 1
 			for j < len(line) && isWord(line[j]) {
+				j++
+			}
+			*toks = append(*toks, token{text: line[i:j], line: lineNo})
+			i = j
+		case isOpChar(c):
+			j := i + 1
+			for j < len(line) && isOpChar(line[j]) {
 				j++
 			}
 			*toks = append(*toks, token{text: line[i:j], line: lineNo})

--- a/internal/infrastructure/tools/duplication/tokenizer.go
+++ b/internal/infrastructure/tools/duplication/tokenizer.go
@@ -1,0 +1,118 @@
+package duplication
+
+import "strings"
+
+// commentSyntax is a language's comment delimiters used to strip comments before tokenizing (a comment
+// change must not hide or fabricate a clone). Languages absent here are tokenized without comment
+// stripping (a conservative default — comment tokens simply participate, which cannot create a false
+// clone across differently-commented code any more than code itself can).
+type commentSyntax struct {
+	line       []string
+	blockStart string
+	blockEnd   string
+}
+
+var syntaxByLang = map[string]commentSyntax{
+	"Go": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"}, "JavaScript": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"TypeScript": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"}, "TSX": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"JSX": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"}, "Java": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"Kotlin": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"}, "Scala": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"C": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"}, "C++": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"C#": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"}, "Rust": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"Swift": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"}, "Dart": {line: []string{"//"}, blockStart: "/*", blockEnd: "*/"},
+	"PHP":    {line: []string{"//", "#"}, blockStart: "/*", blockEnd: "*/"},
+	"Python": {line: []string{"#"}}, "Ruby": {line: []string{"#"}}, "Shell": {line: []string{"#"}}, "YAML": {line: []string{"#"}},
+	"SQL": {line: []string{"--"}}, "Lua": {line: []string{"--"}},
+}
+
+// tokenize splits content into tokens (comment- and whitespace-insensitive) and returns them plus the
+// number of code lines (lines that produced at least one token). A token is a maximal run of
+// identifier/number characters, or a single punctuation character. Comments are stripped line- and
+// block-wise. Limitation: a comment marker inside a string literal is treated as a comment (rare;
+// documented) — the same simplification the code-inventory line classifier makes.
+func tokenize(lang string, content []byte) (toks []token, codeLines int) {
+	syn := syntaxByLang[lang]
+	inBlock := false
+	lineNo := 0
+	for _, raw := range strings.Split(string(content), "\n") {
+		lineNo++
+		code := stripComments(raw, syn, &inBlock)
+		before := len(toks)
+		tokenizeLine(code, lineNo, &toks)
+		if len(toks) > before {
+			codeLines++
+		}
+	}
+	return toks, codeLines
+}
+
+// stripComments removes comment text from one line, tracking multi-line block state via inBlock.
+func stripComments(line string, syn commentSyntax, inBlock *bool) string {
+	if *inBlock {
+		if syn.blockEnd == "" {
+			return ""
+		}
+		if idx := strings.Index(line, syn.blockEnd); idx >= 0 {
+			*inBlock = false
+			return stripComments(line[idx+len(syn.blockEnd):], syn, inBlock)
+		}
+		return ""
+	}
+	// earliest of: a block-start or any line-comment marker
+	cut := -1
+	blockAt := -1
+	if syn.blockStart != "" {
+		blockAt = strings.Index(line, syn.blockStart)
+	}
+	lineAt := -1
+	for _, lc := range syn.line {
+		if lc == "" {
+			continue
+		}
+		if i := strings.Index(line, lc); i >= 0 && (lineAt < 0 || i < lineAt) {
+			lineAt = i
+		}
+	}
+	switch {
+	case blockAt >= 0 && (lineAt < 0 || blockAt < lineAt):
+		rest := line[blockAt+len(syn.blockStart):]
+		if syn.blockEnd != "" {
+			if idx := strings.Index(rest, syn.blockEnd); idx >= 0 {
+				return line[:blockAt] + " " + stripComments(rest[idx+len(syn.blockEnd):], syn, inBlock)
+			}
+		}
+		*inBlock = true
+		return line[:blockAt]
+	case lineAt >= 0:
+		cut = lineAt
+		return line[:cut]
+	default:
+		return line
+	}
+}
+
+func isWord(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// tokenizeLine appends the tokens of a comment-stripped line.
+func tokenizeLine(line string, lineNo int, toks *[]token) {
+	i := 0
+	for i < len(line) {
+		c := line[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\r':
+			i++
+		case isWord(c):
+			j := i + 1
+			for j < len(line) && isWord(line[j]) {
+				j++
+			}
+			*toks = append(*toks, token{text: line[i:j], line: lineNo})
+			i = j
+		default:
+			*toks = append(*toks, token{text: string(c), line: lineNo})
+			i++
+		}
+	}
+}

--- a/internal/infrastructure/tools/duplication/tokenizer_test.go
+++ b/internal/infrastructure/tools/duplication/tokenizer_test.go
@@ -1,0 +1,46 @@
+package duplication
+
+import "testing"
+
+func toksText(ts []token) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.text
+	}
+	return out
+}
+
+func TestTokenizeStripsComments(t *testing.T) {
+	// Trailing line comment and a block comment must be dropped; code tokens survive.
+	src := "x = a + b // add them\n/* block\ncomment */\ny = c\n"
+	ts, codeLines := tokenize("Go", []byte(src))
+	got := toksText(ts)
+	want := []string{"x", "=", "a", "+", "b", "y", "=", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("tokens = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("token %d = %q, want %q (all %v)", i, got[i], want[i], got)
+		}
+	}
+	if codeLines != 2 { // line 1 (x=a+b) and line 4 (y=c); the block-comment lines have no code
+		t.Errorf("codeLines = %d, want 2", codeLines)
+	}
+}
+
+func TestTokenizeLineNumbers(t *testing.T) {
+	ts, _ := tokenize("Go", []byte("a\n\nb\n"))
+	if len(ts) != 2 || ts[0].line != 1 || ts[1].line != 3 {
+		t.Errorf("line numbers wrong: %+v", ts)
+	}
+}
+
+func TestTokenizeInlineBlockComment(t *testing.T) {
+	// Code, an inline block comment, then more code on the same line.
+	ts, _ := tokenize("Go", []byte("a /* x */ b\n"))
+	got := toksText(ts)
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("inline block comment not stripped: %v", got)
+	}
+}

--- a/internal/usecase/ports/duplication.go
+++ b/internal/usecase/ports/duplication.go
@@ -1,0 +1,14 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+)
+
+// DuplicationScanner detects copy-paste (duplicated token runs) over a local source tree and returns the
+// standard duplication metrics. Implementations read the tree only (never execute it) and honor context
+// cancellation.
+type DuplicationScanner interface {
+	Duplication(ctx context.Context, root string) (measure.DuplicationReport, error)
+}


### PR DESCRIPTION
Implements **Phase 2** of the Code Quality epic (#95, #98): copy-paste / clone detection.

Pure-Go and deterministic (no CGO, so available in every build): walk the tree, tokenize each file (language-aware comment + whitespace stripping), and find maximal runs of duplicated tokens across and within files via a Rabin-Karp rolling hash.

### Metrics (the standard set)
`duplicated blocks`, `duplicated lines`, `files with duplication`, `duplicated-lines density (%)`.

### Pieces
- `domain/measure`: `DuplicationBlock` / `DuplicationReport` (+ `Density()`, `TopBlocks`).
- `ports.DuplicationScanner` + `internal/infrastructure/tools/duplication` (detector + tokenizer). Default `--min-tokens 100` (the industry CPD default), configurable. Exact (Type-1) clones; comment- and whitespace-insensitive.
- `synapse-cli duplication <path> [--min-tokens N] [--fail-on-duplication PCT] [--top N]` — prints the report and gates CI on density.

### Tested on real code
Run on this repo's `internal/` at the default 100 tokens:
```
duplicated blocks: 88 · duplicated lines: 2341 / 79593 code lines · density: 2.9% · files: 96
top block: 508 tokens — usecase/sca/service.go:1229-1262 and :1629-1669
```
That top block is a **hand-verified true duplicate** (the vuln-scan sequence), differing only in comments (correctly ignored). 2.9% is a realistic density for a mature codebase.

Unit tests cover cross-file, intra-file, comment-insensitivity, below-threshold, no-duplication, determinism, and the tokenizer (comment stripping, line numbers, inline block comments).

`go build ./...`, `go vet ./...`, `CGO_ENABLED=0 go build ./cmd/...`, and the package tests all pass locally.

Part of #98. Epic #95.
