### PR TITLE
feat: add conanfile.txt dependency parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **SCA.** Added OwnSBOM support for exact Conan dependencies declared in `conanfile.txt`.
 - **SCA (software composition analysis).** First-party SBOM generation across many
   lockfile ecosystems, advisory matching against OSV/GHSA/CSAF, and severity/risk
   prioritisation (CISA KEV, EPSS, CVSS). Vulnerabilities at or above a threshold become

--- a/internal/infrastructure/tools/ownsbom/conan.go
+++ b/internal/infrastructure/tools/ownsbom/conan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -22,7 +23,7 @@ type Conan struct{}
 func (Conan) Ecosystem() string { return "conan" }
 
 // Markers are the lockfile basenames Conan claims.
-func (Conan) Markers() []string { return []string{"conan.lock"} }
+func (Conan) Markers() []string { return []string{"conan.lock", "conanfile.txt"} }
 
 // conanLock covers both lockfile shapes: the 2.x top-level reference lists and the 1.x graph_lock nodes.
 type conanLock struct {
@@ -41,6 +42,12 @@ type conanLock struct {
 func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
+	}
+	if strings.ToLower(filepath.Base(in.Path)) == "conanfile.txt" {
+		if _, ok := readManifestFile(filepath.Join(in.Dir, "conan.lock")); ok {
+			return nil, nil, nil // lockfile takes precedence
+		}
+		return parseConanTxt(ctx, in)
 	}
 	var lock conanLock
 	if err := json.Unmarshal(in.Content, &lock); err != nil {

--- a/internal/infrastructure/tools/ownsbom/conan_txt.go
+++ b/internal/infrastructure/tools/ownsbom/conan_txt.go
@@ -1,0 +1,97 @@
+package ownsbom
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// parseConanTxt parses the conanfile.txt manifest. It supports exact dependencies under
+// [requires], [tool_requires], and [test_requires] sections. Version ranges and
+// unknown sections are safely ignored. It is fail-soft for individual malformed lines
+// but fail-loud on IO or scanner errors.
+func parseConanTxt(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	set := newComponentSet()
+	sc := bufio.NewScanner(bytes.NewReader(in.Content))
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+
+	var currentScope string
+
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+
+		// Handle comments properly: only treat '#' as comment if it's at the start or preceded by whitespace.
+		// Conan uses '#' for recipe revisions (e.g., zlib/1.2.13#revision), which must not be truncated here.
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if idx := strings.Index(line, " #"); idx >= 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		if idx := strings.Index(line, "\t#"); idx >= 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.ToLower(line[1 : len(line)-1])
+			dirScope := sbom.ClassifyScope(in.Path, "")
+
+			switch section {
+			case "requires":
+				currentScope = dirScope // path defaults
+			case "tool_requires":
+				if sbom.IsBackgroundScope(dirScope) {
+					currentScope = dirScope
+				} else {
+					currentScope = sbom.ScopeDevelopment
+				}
+			case "test_requires":
+				currentScope = sbom.ScopeTest
+			default:
+				currentScope = "" // entering an ignored section
+			}
+			continue
+		}
+
+		if currentScope != "" {
+			// Ignore version ranges (e.g., poco/[>1.0 <2.0]). SBOM needs resolved versions.
+			if strings.ContainsAny(line, "[<>~^]") {
+				continue
+			}
+
+			name, version := parseConanRef(line)
+			if name == "" || version == "" {
+				continue // skip malformed lines fail-soft
+			}
+
+			set.add(sbom.Component{
+				Name:     name,
+				Version:  version,
+				PURL:     "pkg:conan/" + name + "@" + version,
+				Location: in.Path,
+				Scope:    currentScope,
+			})
+		}
+	}
+
+	if err := sc.Err(); err != nil {
+		return nil, nil, fmt.Errorf("scan conanfile.txt: %w", err)
+	}
+
+	comps := set.components()
+	sort.Slice(comps, func(i, j int) bool { return comps[i].PURL < comps[j].PURL })
+	return comps, nil, nil
+}

--- a/internal/infrastructure/tools/ownsbom/conan_txt_test.go
+++ b/internal/infrastructure/tools/ownsbom/conan_txt_test.go
@@ -1,0 +1,183 @@
+package ownsbom
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+func TestConanMarkers(t *testing.T) {
+	markers := Conan{}.Markers()
+	hasLock := false
+	hasTxt := false
+	for _, m := range markers {
+		if m == "conan.lock" {
+			hasLock = true
+		}
+		if m == "conanfile.txt" {
+			hasTxt = true
+		}
+	}
+	if !hasLock || !hasTxt {
+		t.Errorf("Conan parser missing markers, got: %v", markers)
+	}
+}
+
+const conanfileTxtFullFixture = `
+# this is a comment
+[options]
+openssl/*:shared=True
+
+[requires]
+zlib/1.3.1
+openssl/3.2.1
+poco/[>1.0 <2.0]
+boost/1.85.0@company/stable
+zlib/1.2.13#revision1
+zlib/1.3.1 # inline comment
+invalid-reference
+openssl/
+	# indented comment
+
+[tool_requires]
+cmake/3.29.0
+
+[test_requires]
+gtest/1.14.0
+
+[generators]
+CMakeDeps
+`
+
+func TestConanTxtParse(t *testing.T) {
+	ctx := context.Background()
+	in := ParseInput{Path: "conanfile.txt", Content: []byte(conanfileTxtFullFixture)}
+
+	comps, deps, err := Conan{}.Parse(ctx, in)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if deps != nil {
+		t.Errorf("expected no deps, got %v", deps)
+	}
+
+	byPURL := make(map[string]sbom.Component)
+	for _, c := range comps {
+		byPURL[c.PURL] = c
+	}
+
+	if len(comps) != 6 {
+		t.Fatalf("expected 6 components, got %d: %+v", len(comps), comps)
+	}
+
+	expecteds := []struct {
+		purl    string
+		version string
+		scope   string
+	}{
+		{"pkg:conan/zlib@1.3.1", "1.3.1", sbom.ScopeProduction},
+		{"pkg:conan/openssl@3.2.1", "3.2.1", sbom.ScopeProduction},
+		{"pkg:conan/boost@1.85.0", "1.85.0", sbom.ScopeProduction},
+		{"pkg:conan/zlib@1.2.13", "1.2.13", sbom.ScopeProduction}, // Recipe revision is accepted but omitted from the normalized version and PURL.
+		{"pkg:conan/cmake@3.29.0", "3.29.0", sbom.ScopeDevelopment},
+		{"pkg:conan/gtest@1.14.0", "1.14.0", sbom.ScopeTest},
+	}
+
+	for _, e := range expecteds {
+		c, ok := byPURL[e.purl]
+		if !ok {
+			t.Errorf("missing expected component %s", e.purl)
+			continue
+		}
+		if c.Version != e.version {
+			t.Errorf("expected version %s, got %s", e.version, c.Version)
+		}
+		if c.Scope != e.scope {
+			t.Errorf("expected scope %s, got %s", e.scope, c.Scope)
+		}
+	}
+
+	// Verify deterministic sorting
+	for i := 1; i < len(comps); i++ {
+		if comps[i-1].PURL > comps[i].PURL {
+			t.Errorf("components not sorted: %s > %s", comps[i-1].PURL, comps[i].PURL)
+		}
+	}
+}
+
+func TestConanTxtContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := Conan{}.Parse(ctx, ParseInput{Path: "conanfile.txt", Content: []byte("[requires]\nzlib/1.3.1")})
+	if err == nil {
+		t.Errorf("expected context error, got nil")
+	}
+}
+
+func TestConanRegistryGenerate(t *testing.T) {
+	dir := t.TempDir()
+	conanTxt := `[requires]
+zlib/1.3.1`
+
+	// Create a conanfile.txt file in temp dir
+	if err := os.WriteFile(filepath.Join(dir, "conanfile.txt"), []byte(conanTxt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+
+	doc, err := reg.Generate(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if len(doc.Components) != 1 {
+		t.Fatalf("expected 1 component, got %d", len(doc.Components))
+	}
+	if doc.Components[0].PURL != "pkg:conan/zlib@1.3.1" {
+		t.Errorf("expected pkg:conan/zlib@1.3.1, got %s", doc.Components[0].PURL)
+	}
+}
+
+func TestConanTxtLockfilePrecedence(t *testing.T) {
+	dir := t.TempDir()
+	conanTxt := `[requires]
+duplicate/1.0.0
+manifest_only/2.0.0`
+	conanLock := `{
+  "version": "0.5",
+  "requires": [
+    "lockfile_only/3.0.0"
+  ]
+}`
+
+	if err := os.WriteFile(filepath.Join(dir, "conanfile.txt"), []byte(conanTxt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "conan.lock"), []byte(conanLock), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+
+	doc, err := reg.Generate(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	// Should only parse the lockfile. The manifest components should be absent.
+	if len(doc.Components) != 1 {
+		t.Fatalf("expected exactly 1 component from lockfile, got %d: %+v", len(doc.Components), doc.Components)
+	}
+	if doc.Components[0].PURL != "pkg:conan/lockfile_only@3.0.0" {
+		t.Errorf("expected lockfile component pkg:conan/lockfile_only@3.0.0, got %s", doc.Components[0].PURL)
+	}
+}

--- a/internal/infrastructure/tools/ownsbom/registry.go
+++ b/internal/infrastructure/tools/ownsbom/registry.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// ownsbomVersion identifies this producer in SBOM provenance. Bump when parser behavior changes.
-	ownsbomVersion = "ownsbom/0.2.0"
+	ownsbomVersion = "ownsbom/0.3.0"
 	// maxManifestBytes caps a single manifest read so a hostile/corrupt repo cannot OOM the scan with an
 	// absurd file. Real manifests are KB–low-MB; exceeding this is malicious or wrong, so it fails loud.
 	maxManifestBytes = 64 << 20


### PR DESCRIPTION
## Summary

Add first-party OwnSBOM support for exact Conan dependencies declared in `conanfile.txt`.

Projects that use Conan but do not commit a resolved `conan.lock` can now have their direct C/C++ dependencies included in the generated SBOM.

## Changes

* Extend the existing Conan parser to recognize both `conan.lock` and `conanfile.txt`.
* Parse exact package references from:

  * `[requires]`
  * `[tool_requires]`
  * `[test_requires]`
* Map requirement sections to production, development, and test scopes.
* Ignore unresolved version ranges and unsupported sections.
* Support Conan references containing user/channel and recipe revisions while normalizing the resulting PURL to `pkg:conan/<name>@<version>`.
* Prefer `conan.lock` when both the lockfile and `conanfile.txt` are present.
* Deduplicate and sort components to preserve deterministic SBOM output.
* Add parser, registry auto-discovery, context cancellation, and lockfile-precedence tests.
* Update the OwnSBOM generator version and changelog.

## Non-goals

* Parsing `conanfile.py`.
* Resolving version ranges.
* Resolving transitive dependencies from the manifest.
* Replacing or changing the existing `conan.lock` parser.

## Testing

The following checks were run locally:

```bash
go test ./internal/infrastructure/tools/ownsbom -run 'TestConan.*' -count=1 -v
go test ./internal/infrastructure/tools/ownsbom -count=1
go test ./... -count=1
go build ./...
go vet ./...
CGO_ENABLED=0 go build ./cmd/...
golangci-lint run

cd web
pnpm install --frozen-lockfile
pnpm run typecheck
pnpm build
```

## Checklist

* [x] `make build vet test typecheck` passes
* [x] `cd web && pnpm build` passes
* [x] Tests added for the new behavior
* [x] Preserves the project safety invariants
* [x] `CHANGELOG.md` updated
* [x] No new dependencies introduced
