### PR TITLE
feat(quality): maintainability + reliability findings (Code Quality Phase 3)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ast"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/bincat"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/codeanalysis"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/codeinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/duplication"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/enry"
@@ -59,6 +60,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/advisoryingest"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/codequality"
 	exportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/export"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
@@ -100,6 +102,14 @@ func main() {
 			usage()
 		}
 		if err := runDuplication(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
+			os.Exit(1)
+		}
+	case "quality":
+		if len(os.Args) < 3 {
+			usage()
+		}
+		if err := runQuality(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 			os.Exit(1)
 		}
@@ -263,6 +273,88 @@ func runDuplication(args []string) error {
 	return nil
 }
 
+// runQuality runs the maintainability + reliability rules (plus duplication and, when the synapse-ast
+// sidecar is available, high-complexity) over a local source tree and reports the findings, optionally
+// emitting SARIF or gating on severity.
+func runQuality(args []string) error {
+	dir := args[0]
+	if strings.HasPrefix(dir, "-") {
+		return fmt.Errorf("first argument must be a path, got option %q", dir)
+	}
+	failOn := ""
+	sarifOut := false
+	complexityMin := codequality.DefaultComplexityThreshold
+	for i := 1; i < len(args); i++ {
+		switch {
+		case args[i] == "--fail-on" && i+1 < len(args):
+			failOn = args[i+1]
+			i++
+		case args[i] == "--min-complexity" && i+1 < len(args):
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n < 1 {
+				return fmt.Errorf("--min-complexity wants a positive integer, got %q", args[i+1])
+			}
+			complexityMin = n
+			i++
+		case args[i] == "--sarif":
+			sarifOut = true
+		default:
+			return fmt.Errorf("unknown or incomplete option %q", args[i])
+		}
+	}
+	if failOn != "" {
+		switch shared.Severity(failOn) {
+		case "critical", "high", "medium", "low", "info":
+		default:
+			return fmt.Errorf("invalid --fail-on %q (want critical|high|medium|low|info)", failOn)
+		}
+	}
+
+	svc := codequality.New(
+		codeanalysis.New(),
+		codequality.WithDuplication(duplication.New(0)),
+		codequality.WithComplexity(ast.New(os.Getenv("SYNAPSE_AST_BIN")), complexityMin),
+	)
+	findings, err := svc.Analyze(context.Background(), dir)
+	if err != nil {
+		return fmt.Errorf("quality: %w", err)
+	}
+
+	if sarifOut {
+		out, merr := exportuc.MarshalSARIF(findings, buildinfo.App(), exportuc.SARIFOptions{})
+		if merr != nil {
+			return fmt.Errorf("encode sarif: %w", merr)
+		}
+		if _, werr := os.Stdout.Write(append(out, '\n')); werr != nil {
+			return fmt.Errorf("write sarif: %w", werr)
+		}
+	} else {
+		fmt.Printf("\nSynapse code quality — %s\n", dir)
+		byKind := map[finding.Kind]int{}
+		for _, f := range findings {
+			byKind[f.Kind]++
+		}
+		fmt.Printf("  findings: %d (quality: %d, reliability: %d)\n", len(findings), byKind[finding.KindQuality], byKind[finding.KindReliability])
+		for _, f := range findings {
+			fmt.Printf("    [%-8s %-11s] %s\n", f.Severity, f.Kind, f.Title)
+		}
+	}
+
+	if failOn != "" {
+		gate := shared.SeverityRank(shared.Severity(failOn))
+		over := 0
+		for _, f := range findings {
+			if shared.SeverityRank(f.Severity) >= gate {
+				over++
+			}
+		}
+		if over > 0 {
+			return fmt.Errorf("%d code-quality finding(s) at or above %s", over, failOn)
+		}
+	}
+	return nil
+}
+
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
 	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
@@ -272,6 +364,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  synapse-cli inventory <path>             # per-language code-size inventory (files, code/comment/blank lines, functions) — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli metrics <path> [--fail-on-complexity N] [--top N]  # per-function cyclomatic+cognitive complexity (needs the synapse-ast sidecar)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli duplication <path> [--min-tokens N] [--fail-on-duplication PCT] [--top N]  # copy-paste detection (blocks, lines, density) — no DB")
+	fmt.Fprintln(os.Stderr, "  synapse-cli quality <path> [--fail-on SEV] [--min-complexity N] [--sarif]  # maintainability + reliability findings (+ duplication, + complexity via synapse-ast) — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote     # fetch + ingest app ecosystems from the OSV bulk bucket (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote-distros # fetch + ingest OS-package advisories (Debian/Alpine) from OSV (large; requires SYNAPSE_DB_DSN)")

--- a/internal/domain/finding/finding.go
+++ b/internal/domain/finding/finding.go
@@ -42,18 +42,20 @@ const (
 	KindRecon        Kind = "recon"
 	KindExploitation Kind = "exploitation"
 	KindManual       Kind = "manual"
-	KindSAST         Kind = "sast"       // first-party source-code issue (SAST)
-	KindSecret       Kind = "secret"     // a hardcoded secret found in source (deterministic; ungated)
-	KindMisconfig    Kind = "misconfig"  // an insecure IaC/config setting (deterministic; ungated)
-	KindDAST         Kind = "dast"       // runtime app issue (DAST; deferred)
-	KindThreat       Kind = "threat"     // threat-model item
-	KindHypothesis   Kind = "hypothesis" // AI-proposed attack-chain hypothesis linking findings (gated until human-verified)
+	KindSAST         Kind = "sast"        // first-party source-code issue (SAST)
+	KindSecret       Kind = "secret"      // a hardcoded secret found in source (deterministic; ungated)
+	KindMisconfig    Kind = "misconfig"   // an insecure IaC/config setting (deterministic; ungated)
+	KindDAST         Kind = "dast"        // runtime app issue (DAST; deferred)
+	KindThreat       Kind = "threat"      // threat-model item
+	KindHypothesis   Kind = "hypothesis"  // AI-proposed attack-chain hypothesis linking findings (gated until human-verified)
+	KindQuality      Kind = "quality"     // maintainability / code-smell issue (deterministic; ungated)
+	KindReliability  Kind = "reliability" // likely bug (deterministic; ungated)
 )
 
 // Valid reports whether k is a known finding kind.
 func (k Kind) Valid() bool {
 	switch k {
-	case KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindSecret, KindMisconfig, KindDAST, KindThreat, KindHypothesis:
+	case KindSCA, KindRecon, KindExploitation, KindManual, KindSAST, KindSecret, KindMisconfig, KindDAST, KindThreat, KindHypothesis, KindQuality, KindReliability:
 		return true
 	}
 	return false

--- a/internal/infrastructure/tools/codeanalysis/analyzer.go
+++ b/internal/infrastructure/tools/codeanalysis/analyzer.go
@@ -1,0 +1,132 @@
+// Package codeanalysis is a deterministic, pure-Go maintainability + reliability rule engine: it walks a
+// source tree and flags code smells (Kind=quality) and likely bugs (Kind=reliability) per (file, line),
+// mirroring the SAST pattern analyzer. It NEVER executes the target and reads bounded (skips vendored/
+// binary/oversized files, follows no symlinks). Metric-derived quality signals (complexity, duplication)
+// are layered on top by the codequality usecase.
+package codeanalysis
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	enry "github.com/go-enry/go-enry/v2"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxFileBytes = 1 << 20
+	maxLineBytes = 4096
+	maxFindings  = 2000
+)
+
+var skipDirs = map[string]bool{
+	".git": true, "node_modules": true, "vendor": true, "dist": true, "build": true,
+	".venv": true, "venv": true, "__pycache__": true, "target": true, ".idea": true,
+	".vscode": true, ".tox": true, ".hg": true, ".svn": true,
+}
+
+// Analyzer is the pure-Go maintainability/reliability pattern engine.
+type Analyzer struct{ rules []rule }
+
+// New returns an analyzer with the built-in rule set.
+func New() *Analyzer { return &Analyzer{rules: builtinRules()} }
+
+var _ ports.CodeAnalyzer = (*Analyzer)(nil)
+
+// Analyze walks root and returns deterministic quality/reliability findings, oldest-path first. It honors
+// ctx cancellation and never aborts the whole scan on a single unreadable file.
+func (a *Analyzer) Analyze(ctx context.Context, root string) ([]ports.CodeAnalysisRawFinding, error) {
+	if root == "" {
+		return nil, nil
+	}
+	var out []ports.CodeAnalysisRawFinding
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if d.IsDir() {
+			if path != root && skipDirs[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		if len(out) >= maxFindings {
+			return fs.SkipAll
+		}
+		fi, lerr := os.Lstat(path)
+		if lerr != nil || !fi.Mode().IsRegular() || fi.Size() > maxFileBytes {
+			return nil
+		}
+		content, rerr := os.ReadFile(path) // #nosec G304 -- regular file, size-capped via Lstat above, under the walked root
+		if rerr != nil {
+			return nil
+		}
+		if enry.IsVendor(path) || enry.IsDotFile(path) || enry.IsGenerated(path, content) || enry.IsBinary(content) {
+			return nil
+		}
+		lang := enry.GetLanguage(filepath.Base(path), content)
+		if lang == "" {
+			return nil
+		}
+		switch enry.GetLanguageType(lang) {
+		case enry.Programming, enry.Markup:
+		default:
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		out = append(out, a.scanFile(rel, ext, content)...)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return out, nil
+}
+
+// scanFile applies every applicable rule to each line of one file.
+func (a *Analyzer) scanFile(rel, ext string, content []byte) []ports.CodeAnalysisRawFinding {
+	var out []ports.CodeAnalysisRawFinding
+	sc := bufio.NewScanner(bytes.NewReader(content))
+	sc.Buffer(make([]byte, 0, 64*1024), maxLineBytes*2)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := sc.Text()
+		if len(line) > maxLineBytes {
+			continue // minified/blob line
+		}
+		for i := range a.rules {
+			r := &a.rules[i]
+			if !r.appliesTo(ext) || !r.hit(line) {
+				continue
+			}
+			out = append(out, ports.CodeAnalysisRawFinding{
+				Kind:        r.kind,
+				RuleID:      r.id,
+				CWE:         r.cwe,
+				Severity:    r.severity,
+				Title:       r.title,
+				Description: r.desc,
+				File:        rel,
+				Line:        lineNo,
+			})
+		}
+	}
+	return out
+}

--- a/internal/infrastructure/tools/codeanalysis/patterns.go
+++ b/internal/infrastructure/tools/codeanalysis/patterns.go
@@ -1,0 +1,238 @@
+package codeanalysis
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// kind values for a rule (mirrors finding.KindQuality / finding.KindReliability without importing domain
+// into the pattern table).
+const (
+	kindQuality     = "quality"
+	kindReliability = "reliability"
+)
+
+// rule is one deterministic maintainability/reliability check over a source line. Either re or match is
+// used (match is for checks that need same-token equality, which RE2 cannot express without backrefs).
+// skip filters false positives; exts, when non-nil, restricts the rule to those (lower-case) extensions.
+type rule struct {
+	id       string
+	kind     string
+	cwe      string
+	severity shared.Severity
+	title    string
+	desc     string
+	re       *regexp.Regexp
+	match    func(line string) bool
+	skip     func(line string) bool
+	exts     map[string]bool
+}
+
+func (r *rule) hit(line string) bool {
+	if r.skip != nil && r.skip(line) {
+		return false
+	}
+	if r.match != nil {
+		return r.match(line)
+	}
+	return r.re != nil && r.re.MatchString(line)
+}
+
+func (r *rule) appliesTo(ext string) bool { return r.exts == nil || r.exts[ext] }
+
+// commentOnlyLine reports whether a trimmed line is a pure comment (so code-only rules can skip it).
+func commentOnlyLine(line string) bool {
+	l := strings.TrimSpace(line)
+	return strings.HasPrefix(l, "//") || strings.HasPrefix(l, "#") || strings.HasPrefix(l, "*") ||
+		strings.HasPrefix(l, "/*") || strings.HasPrefix(l, "--")
+}
+
+// looksLikeCode reports whether a comment's body looks like commented-out code (ends in a statement
+// terminator or brace and contains an identifier), not prose.
+var codeTail = regexp.MustCompile(`[A-Za-z0-9_)\]]\s*[;{}]\s*$`)
+
+func commentedOutCode(line string) bool {
+	l := strings.TrimSpace(line)
+	var body string
+	switch {
+	case strings.HasPrefix(l, "//"):
+		body = strings.TrimSpace(l[2:])
+	case strings.HasPrefix(l, "#"):
+		body = strings.TrimSpace(l[1:])
+	default:
+		return false
+	}
+	if body == "" || strings.HasPrefix(body, "!") { // shebang etc.
+		return false
+	}
+	return codeTail.MatchString(body) && strings.ContainsAny(body, "=(")
+}
+
+// stripTrailingComment removes a trailing line comment (// or space-# ) so an assignment with a trailing
+// note still parses. It does not attempt to respect string literals (a rare edge for these checks).
+func stripTrailingComment(l string) string {
+	if i := strings.Index(l, "//"); i >= 0 {
+		l = l[:i]
+	}
+	if i := strings.Index(l, " #"); i >= 0 {
+		l = l[:i]
+	}
+	return l
+}
+
+// selfAssignment reports whether the whole statement is `<ident> = <ident>` (same identifier), e.g.
+// `y = y;` — a no-op. The right side must be ONLY the identifier, so `total = total + 1` does not match.
+func selfAssignment(line string) bool {
+	l := strings.TrimSpace(stripTrailingComment(line))
+	l = strings.TrimSpace(strings.TrimSuffix(l, ";"))
+	idx := findOperator(l, "=")
+	if idx < 0 {
+		return false
+	}
+	lhs := strings.TrimSpace(l[:idx])
+	rhs := strings.TrimSpace(l[idx+1:])
+	return lhs != "" && lhs == rhs && isIdentPath(lhs)
+}
+
+// selfComparison reports whether any `==` (or `!=`) compares an operand to itself, e.g. `if (x == x)` or
+// `a && y.z != y.z`. It inspects the identifier-path operands ADJACENT to each operator, so it works
+// inside a larger expression, not only on a bare statement.
+func selfComparison(line string) bool {
+	for _, op := range []string{"==", "!="} {
+		l := line
+		base := 0
+		for {
+			rel := findOperator(l[base:], op)
+			if rel < 0 {
+				break
+			}
+			idx := base + rel
+			lhs := identBefore(l, idx)
+			rhs := identAfter(l, idx+len(op))
+			if lhs != "" && lhs == rhs && isIdentPath(lhs) {
+				return true
+			}
+			base = idx + len(op)
+		}
+	}
+	return false
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' || b == '.' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// identBefore returns the identifier-path token ending just before idx (skipping spaces).
+func identBefore(s string, idx int) string {
+	j := idx
+	for j > 0 && s[j-1] == ' ' {
+		j--
+	}
+	end := j
+	for j > 0 && isIdentByte(s[j-1]) {
+		j--
+	}
+	return s[j:end]
+}
+
+// identAfter returns the identifier-path token starting just after pos (skipping spaces).
+func identAfter(s string, pos int) string {
+	i := pos
+	for i < len(s) && s[i] == ' ' {
+		i++
+	}
+	start := i
+	for i < len(s) && isIdentByte(s[i]) {
+		i++
+	}
+	return s[start:i]
+}
+
+// findOperator returns the index of a standalone `op` ("=" or "==") that is not part of a longer operator
+// (:=, +=, <=, >=, !=, ==, ===). Returns -1 if none.
+func findOperator(s, op string) int {
+	for i := 0; i+len(op) <= len(s); i++ {
+		if s[i:i+len(op)] != op {
+			continue
+		}
+		prev := byte(' ')
+		if i > 0 {
+			prev = s[i-1]
+		}
+		next := byte(' ')
+		if i+len(op) < len(s) {
+			next = s[i+len(op)]
+		}
+		if op == "=" {
+			if strings.IndexByte("=!<>+-*/%:&|^~", prev) >= 0 || next == '=' {
+				continue // part of ==, :=, +=, etc.
+			}
+		} else { // "=="
+			if prev == '=' || prev == '!' || prev == '<' || prev == '>' || next == '=' {
+				continue // part of ===, !==, <==, >==
+			}
+		}
+		return i
+	}
+	return -1
+}
+
+func isIdentPath(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !(c == '_' || c == '.' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+			return false
+		}
+	}
+	// reject a pure number and a leading digit (not an identifier)
+	if s[0] >= '0' && s[0] <= '9' {
+		return false
+	}
+	return true
+}
+
+// builtinRules is the tier-1 maintainability + reliability rule set. Precision-biased, deterministic; the
+// set grows over time like the SAST rules. Metric-derived rules (complexity, duplication) are added by the
+// codequality usecase, not here.
+func builtinRules() []rule {
+	return []rule{
+		{
+			id: "quality-todo-comment", kind: kindQuality, cwe: "CWE-546", severity: shared.SeverityInfo,
+			title: "Unresolved TODO/FIXME marker",
+			desc:  "A TODO/FIXME/HACK/XXX/BUG marker flags unfinished or known-problematic code left in the tree. Track it in an issue and resolve it.",
+			re:    regexp.MustCompile(`(?i)(//|#|/\*|\*|--)\s*.*\b(TODO|FIXME|HACK|XXX|BUG)\b`),
+		},
+		{
+			id: "quality-commented-out-code", kind: kindQuality, cwe: "", severity: shared.SeverityInfo,
+			title: "Commented-out code",
+			desc:  "A comment appears to contain commented-out code, which rots and confuses readers. Delete it — version control preserves history.",
+			match: commentedOutCode,
+		},
+		{
+			id: "reliability-empty-catch", kind: kindReliability, cwe: "CWE-390", severity: shared.SeverityMedium,
+			title: "Empty exception handler swallows errors",
+			desc:  "An empty catch/except block silently swallows an error, hiding failures and complicating debugging. Handle, log, or rethrow the exception.",
+			re:    regexp.MustCompile(`(catch\s*\([^)]*\)\s*\{\s*\}|except\b[^\n:]*:\s*pass\b)`),
+			skip:  commentOnlyLine,
+		},
+		{
+			id: "reliability-self-assignment", kind: kindReliability, cwe: "CWE-1164", severity: shared.SeverityMedium,
+			title: "Self-assignment has no effect",
+			desc:  "A variable is assigned to itself (x = x), which is a no-op and usually signals a typo or a lost assignment. Fix the intended target.",
+			match: selfAssignment,
+			skip:  commentOnlyLine,
+		},
+		{
+			id: "reliability-self-comparison", kind: kindReliability, cwe: "CWE-571", severity: shared.SeverityMedium,
+			title: "Comparison of a value to itself",
+			desc:  "A value is compared to itself (a == a / a != a), which is constant and usually a typo for a different operand. Fix the comparison.",
+			match: selfComparison,
+			skip:  commentOnlyLine,
+		},
+	}
+}

--- a/internal/infrastructure/tools/codeanalysis/patterns.go
+++ b/internal/infrastructure/tools/codeanalysis/patterns.go
@@ -70,6 +70,38 @@ func commentedOutCode(line string) bool {
 	return codeTail.MatchString(body) && strings.ContainsAny(body, "=(")
 }
 
+// maskStrings replaces the contents of string/char literals ("...", '...', `...`) with spaces, so an
+// operator or identifier INSIDE a string is never matched as code (e.g. log("x == x") is not a
+// self-comparison). Escapes are honored. Length/positions are preserved.
+func maskStrings(l string) string {
+	b := []byte(l)
+	i := 0
+	for i < len(b) {
+		c := b[i]
+		if c == '"' || c == '\'' || c == '`' {
+			b[i] = ' '
+			i++
+			for i < len(b) {
+				if b[i] == '\\' && i+1 < len(b) {
+					b[i], b[i+1] = ' ', ' '
+					i += 2
+					continue
+				}
+				if b[i] == c {
+					b[i] = ' '
+					i++
+					break
+				}
+				b[i] = ' '
+				i++
+			}
+			continue
+		}
+		i++
+	}
+	return string(b)
+}
+
 // stripTrailingComment removes a trailing line comment (// or space-# ) so an assignment with a trailing
 // note still parses. It does not attempt to respect string literals (a rare edge for these checks).
 func stripTrailingComment(l string) string {
@@ -85,7 +117,7 @@ func stripTrailingComment(l string) string {
 // selfAssignment reports whether the whole statement is `<ident> = <ident>` (same identifier), e.g.
 // `y = y;` — a no-op. The right side must be ONLY the identifier, so `total = total + 1` does not match.
 func selfAssignment(line string) bool {
-	l := strings.TrimSpace(stripTrailingComment(line))
+	l := strings.TrimSpace(stripTrailingComment(maskStrings(line)))
 	l = strings.TrimSpace(strings.TrimSuffix(l, ";"))
 	idx := findOperator(l, "=")
 	if idx < 0 {
@@ -100,8 +132,9 @@ func selfAssignment(line string) bool {
 // `a && y.z != y.z`. It inspects the identifier-path operands ADJACENT to each operator, so it works
 // inside a larger expression, not only on a bare statement.
 func selfComparison(line string) bool {
+	masked := maskStrings(line)
 	for _, op := range []string{"==", "!="} {
-		l := line
+		l := masked
 		base := 0
 		for {
 			rel := findOperator(l[base:], op)

--- a/internal/infrastructure/tools/codeanalysis/patterns_test.go
+++ b/internal/infrastructure/tools/codeanalysis/patterns_test.go
@@ -1,0 +1,60 @@
+package codeanalysis
+
+import "testing"
+
+// TestRuleCorpus is the per-rule true/false-positive regression corpus: every true-positive line MUST be
+// flagged by its rule and every false-positive line MUST NOT be. Guards precision as the set grows.
+func TestRuleCorpus(t *testing.T) {
+	rs := builtinRules()
+	rules := map[string]*rule{}
+	for i := range rs {
+		rules[rs[i].id] = &rs[i]
+	}
+	corpus := []struct {
+		id string
+		tp []string
+		fp []string
+	}{
+		{
+			id: "quality-todo-comment",
+			tp: []string{"// TODO: refactor", "# FIXME later", "  * XXX broken", "-- HACK: temporary"},
+			fp: []string{"// a normal explanatory comment", "var todo = 1", "return fixme"},
+		},
+		{
+			id: "quality-commented-out-code",
+			tp: []string{"// x = foo(a);", "# result = compute(b);", "// if (ready) {"},
+			fp: []string{"// this explains the function", "// see https://example.com/docs", "# a plain note"},
+		},
+		{
+			id: "reliability-empty-catch",
+			tp: []string{"} catch (e) {}", "  catch(Exception ex) {}", "except ValueError: pass"},
+			fp: []string{"} catch (e) { log(e); }", "except ValueError: handle()"},
+		},
+		{
+			id: "reliability-self-assignment",
+			tp: []string{"y = y;", "a.b = a.b", "count = count // keep"},
+			fp: []string{"y = y + 1;", "a = b", "x == x", "total = total - 1"},
+		},
+		{
+			id: "reliability-self-comparison",
+			tp: []string{"if (x == x) {", "return a.b != a.b;", "while (i == i)"},
+			fp: []string{"if (x == y) {", "if (a != b) {", "z = z"},
+		},
+	}
+	for _, c := range corpus {
+		r, ok := rules[c.id]
+		if !ok {
+			t.Fatalf("rule %q not found", c.id)
+		}
+		for _, tp := range c.tp {
+			if !r.hit(tp) {
+				t.Errorf("[%s] MISS true-positive: %q", c.id, tp)
+			}
+		}
+		for _, fp := range c.fp {
+			if r.hit(fp) {
+				t.Errorf("[%s] FALSE POSITIVE: %q", c.id, fp)
+			}
+		}
+	}
+}

--- a/internal/infrastructure/tools/codeanalysis/patterns_test.go
+++ b/internal/infrastructure/tools/codeanalysis/patterns_test.go
@@ -33,12 +33,17 @@ func TestRuleCorpus(t *testing.T) {
 		{
 			id: "reliability-self-assignment",
 			tp: []string{"y = y;", "a.b = a.b", "count = count // keep"},
-			fp: []string{"y = y + 1;", "a = b", "x == x", "total = total - 1"},
+			fp: []string{"y = y + 1;", "a = b", "x == x", "total = total - 1", `msg = "y = y"`},
 		},
 		{
 			id: "reliability-self-comparison",
 			tp: []string{"if (x == x) {", "return a.b != a.b;", "while (i == i)"},
-			fp: []string{"if (x == y) {", "if (a != b) {", "z = z"},
+			fp: []string{
+				"if (x == y) {", "if (a != b) {", "z = z",
+				`log.Printf("x == x means equal")`, // operator inside a string, not code
+				`errors.New("id != id not allowed")`,
+				"if strings.Contains(s, `a == a`) {",
+			},
 		},
 	}
 	for _, c := range corpus {

--- a/internal/usecase/codequality/service.go
+++ b/internal/usecase/codequality/service.go
@@ -1,0 +1,131 @@
+// Package codequality assembles the code-quality findings for a source tree: it runs the deterministic
+// maintainability/reliability rule engine and layers on the metric-derived signals (duplication, and
+// complexity when an AST backend is available), mapping everything to first-party finding.Finding values
+// (Kind=quality/reliability, ungated, publishable like SAST). No LLM, no persistence — a read-only
+// producer the CLI (and, later, the scan pipeline + UI) consume.
+package codequality
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// DefaultComplexityThreshold is the cyclomatic complexity above which a function earns a maintainability
+// finding (a widely used "refactor" line). Configurable via WithComplexityThreshold.
+const DefaultComplexityThreshold = 15
+
+// Service produces code-quality findings. analyzer is required; dup and metrics are optional enrichers.
+type Service struct {
+	analyzer      ports.CodeAnalyzer
+	dup           ports.DuplicationScanner
+	metrics       ports.CodeMetricsProvider
+	complexityMin int
+}
+
+// Option configures a Service.
+type Option func(*Service)
+
+// WithDuplication adds duplicated-block maintainability findings.
+func WithDuplication(d ports.DuplicationScanner) Option { return func(s *Service) { s.dup = d } }
+
+// WithComplexity adds high-complexity maintainability findings (functions over threshold), using the AST
+// metrics provider. threshold <= 0 uses DefaultComplexityThreshold.
+func WithComplexity(m ports.CodeMetricsProvider, threshold int) Option {
+	return func(s *Service) {
+		s.metrics = m
+		if threshold > 0 {
+			s.complexityMin = threshold
+		}
+	}
+}
+
+// New returns a Service. analyzer is required.
+func New(analyzer ports.CodeAnalyzer, opts ...Option) *Service {
+	s := &Service{analyzer: analyzer, complexityMin: DefaultComplexityThreshold}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// Analyze returns the code-quality findings for root, sorted deterministically by dedup key.
+func (s *Service) Analyze(ctx context.Context, root string) ([]finding.Finding, error) {
+	var out []finding.Finding
+
+	raws, err := s.analyzer.Analyze(ctx, root)
+	if err != nil {
+		return nil, fmt.Errorf("code analysis: %w", err)
+	}
+	for _, r := range raws {
+		out = append(out, newFinding(r.Kind, r.RuleID, r.CWE, r.Severity, r.Title, r.Description, r.File, r.Line))
+	}
+
+	if s.dup != nil {
+		rep, derr := s.dup.Duplication(ctx, root)
+		if derr != nil {
+			return nil, fmt.Errorf("duplication: %w", derr)
+		}
+		for _, b := range rep.Blocks {
+			if len(b.Occurrences) == 0 {
+				continue
+			}
+			o := b.Occurrences[0] // anchor the finding at the first occurrence
+			title := fmt.Sprintf("Duplicated block (%d tokens, %d places)", b.Tokens, len(b.Occurrences))
+			desc := "This block is duplicated elsewhere; extract it into a shared function/module to avoid divergent edits."
+			out = append(out, newFinding("quality", "quality-duplicated-block", "CWE-1041", shared.SeverityLow, title, desc, o.File, o.StartLine))
+		}
+	}
+
+	if s.metrics != nil {
+		rep, available, merr := s.metrics.Complexity(ctx, root)
+		if merr != nil {
+			return nil, fmt.Errorf("complexity: %w", merr)
+		}
+		if available {
+			for _, f := range rep.OverCyclomatic(s.complexityMin) {
+				title := fmt.Sprintf("High cyclomatic complexity: %d (%s)", f.Cyclomatic, f.Name)
+				desc := fmt.Sprintf("Function %q has cyclomatic complexity %d (cognitive %d), above %d. Break it into smaller units to improve testability and readability.", f.Name, f.Cyclomatic, f.Cognitive, s.complexityMin)
+				out = append(out, newFinding("quality", "quality-high-complexity", "CWE-1120", shared.SeverityMedium, title, desc, f.File, f.Line))
+			}
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].DedupKey < out[j].DedupKey })
+	return out, nil
+}
+
+// newFinding maps a raw code-quality signal to a first-party finding. The DedupKey (<kind>:<rule>:<file>:
+// <line>) is the same shape the SARIF exporter's firstPartyLoc parses, so the finding gets a file:line
+// physical location automatically.
+func newFinding(kind, ruleID, cwe string, sev shared.Severity, title, desc, file string, line int) finding.Finding {
+	dedup := kind + ":" + ruleID + ":" + file + ":" + strconv.Itoa(line)
+	k := finding.KindQuality
+	if kind == "reliability" {
+		k = finding.KindReliability
+	}
+	return finding.Finding{
+		ID:          deterministicID(dedup),
+		Title:       fmt.Sprintf("%s (%s:%d)", title, file, line),
+		Description: desc,
+		Severity:    sev,
+		CWE:         cwe,
+		Sources:     []string{"synapse-codeanalysis"},
+		Class:       finding.ClassFirstParty,
+		Status:      finding.StatusOpen,
+		Kind:        k,
+		DedupKey:    dedup,
+	}
+}
+
+func deterministicID(dedupKey string) shared.ID {
+	sum := sha256.Sum256([]byte("codequality|" + dedupKey))
+	return shared.ID(hex.EncodeToString(sum[:16]))
+}

--- a/internal/usecase/codequality/service.go
+++ b/internal/usecase/codequality/service.go
@@ -104,7 +104,9 @@ func (s *Service) Analyze(ctx context.Context, root string) ([]finding.Finding, 
 
 // newFinding maps a raw code-quality signal to a first-party finding. The DedupKey (<kind>:<rule>:<file>:
 // <line>) is the same shape the SARIF exporter's firstPartyLoc parses, so the finding gets a file:line
-// physical location automatically.
+// physical location automatically. The finding is TRANSIENT (read-only CLI/SARIF producer): EngagementID
+// and Audit are intentionally unset; a future scan/store wiring must populate them (as the SCA first-party
+// builders do) before persisting.
 func newFinding(kind, ruleID, cwe string, sev shared.Severity, title, desc, file string, line int) finding.Finding {
 	dedup := kind + ":" + ruleID + ":" + file + ":" + strconv.Itoa(line)
 	k := finding.KindQuality

--- a/internal/usecase/codequality/service_test.go
+++ b/internal/usecase/codequality/service_test.go
@@ -1,0 +1,120 @@
+package codequality
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeAnalyzer struct {
+	raws []ports.CodeAnalysisRawFinding
+}
+
+func (f fakeAnalyzer) Analyze(context.Context, string) ([]ports.CodeAnalysisRawFinding, error) {
+	return f.raws, nil
+}
+
+type fakeDup struct{ rep measure.DuplicationReport }
+
+func (f fakeDup) Duplication(context.Context, string) (measure.DuplicationReport, error) {
+	return f.rep, nil
+}
+
+type fakeMetrics struct {
+	rep       measure.ComplexityReport
+	available bool
+}
+
+func (f fakeMetrics) Complexity(context.Context, string) (measure.ComplexityReport, bool, error) {
+	return f.rep, f.available, nil
+}
+
+func byRule(fs []finding.Finding) map[string]finding.Finding {
+	m := map[string]finding.Finding{}
+	for _, f := range fs {
+		// dedup key is <kind>:<rule>:<file>:<line>; index by rule id (2nd field)
+		parts := strings.SplitN(f.DedupKey, ":", 3)
+		if len(parts) >= 2 {
+			m[parts[1]] = f
+		}
+	}
+	return m
+}
+
+func TestServiceMapsAndBridges(t *testing.T) {
+	analyzer := fakeAnalyzer{raws: []ports.CodeAnalysisRawFinding{
+		{Kind: "quality", RuleID: "quality-todo-comment", CWE: "CWE-546", Severity: shared.SeverityInfo, Title: "TODO", File: "a.go", Line: 3},
+		{Kind: "reliability", RuleID: "reliability-empty-catch", CWE: "CWE-390", Severity: shared.SeverityMedium, Title: "Empty catch", File: "b.js", Line: 9},
+	}}
+	dup := fakeDup{rep: measure.DuplicationReport{Blocks: []measure.DuplicationBlock{
+		{Tokens: 120, Occurrences: []measure.CodeRange{{File: "x.go", StartLine: 10, EndLine: 20}, {File: "y.go", StartLine: 30, EndLine: 40}}},
+	}}}
+	metrics := fakeMetrics{available: true, rep: measure.ComplexityReport{Functions: []measure.FunctionComplexity{
+		{File: "c.py", Line: 5, Name: "big", Language: "Python", Cyclomatic: 25, Cognitive: 30},
+		{File: "c.py", Line: 60, Name: "small", Language: "Python", Cyclomatic: 2, Cognitive: 1},
+	}}}
+
+	svc := New(analyzer, WithDuplication(dup), WithComplexity(metrics, 15))
+	fs, err := svc.Analyze(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	m := byRule(fs)
+
+	todo, ok := m["quality-todo-comment"]
+	if !ok || todo.Kind != finding.KindQuality || todo.DedupKey != "quality:quality-todo-comment:a.go:3" {
+		t.Errorf("todo mapping wrong: %+v", todo)
+	}
+	if todo.Class != finding.ClassFirstParty || todo.Status != finding.StatusOpen {
+		t.Errorf("todo class/status wrong: %+v", todo)
+	}
+	ec, ok := m["reliability-empty-catch"]
+	if !ok || ec.Kind != finding.KindReliability {
+		t.Errorf("empty-catch kind wrong: %+v", ec)
+	}
+	dupF, ok := m["quality-duplicated-block"]
+	if !ok || dupF.Kind != finding.KindQuality || !strings.Contains(dupF.Title, "x.go") {
+		t.Errorf("duplication bridge wrong: %+v", dupF)
+	}
+	hc, ok := m["quality-high-complexity"]
+	if !ok || !strings.Contains(hc.Title, "25") {
+		t.Errorf("complexity bridge should flag the cyclomatic-25 function: %+v", hc)
+	}
+	// The cyclomatic-2 function must NOT be flagged.
+	for _, f := range fs {
+		if strings.Contains(f.Title, "small") {
+			t.Errorf("low-complexity function must not be flagged: %+v", f)
+		}
+	}
+}
+
+func TestComplexityUnavailableSkipsBridge(t *testing.T) {
+	svc := New(fakeAnalyzer{}, WithComplexity(fakeMetrics{available: false, rep: measure.ComplexityReport{
+		Functions: []measure.FunctionComplexity{{Name: "x", Cyclomatic: 99}},
+	}}, 15))
+	fs, err := svc.Analyze(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	for _, f := range fs {
+		if strings.Contains(f.DedupKey, "high-complexity") {
+			t.Errorf("unavailable metrics must not produce complexity findings: %+v", f)
+		}
+	}
+}
+
+func TestAnalyzerOnly(t *testing.T) {
+	// No dup/metrics wired: only the rule-engine findings come through.
+	svc := New(fakeAnalyzer{raws: []ports.CodeAnalysisRawFinding{
+		{Kind: "quality", RuleID: "quality-todo-comment", Severity: shared.SeverityInfo, Title: "TODO", File: "a.go", Line: 1},
+	}})
+	fs, err := svc.Analyze(context.Background(), "root")
+	if err != nil || len(fs) != 1 {
+		t.Fatalf("want 1 finding, got %d err=%v", len(fs), err)
+	}
+}

--- a/internal/usecase/export/sarif.go
+++ b/internal/usecase/export/sarif.go
@@ -207,7 +207,7 @@ func buildSARIF(findings []finding.Finding, version string, opts SARIFOptions) *
 func firstPartyLoc(key string) (ruleID, file string, line int, ok bool) {
 	var rest string
 	matched := false
-	for _, kind := range []string{"sast:", "secret:", "misconfig:"} {
+	for _, kind := range []string{"sast:", "secret:", "misconfig:", "quality:", "reliability:"} {
 		if r, has := strings.CutPrefix(key, kind); has {
 			rest, matched = r, true
 			break

--- a/internal/usecase/ports/codeanalysis.go
+++ b/internal/usecase/ports/codeanalysis.go
@@ -1,0 +1,26 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// CodeAnalysisRawFinding is one maintainability ("quality") or likely-bug ("reliability") issue located
+// at a source file:line, before promotion to a finding.Finding. Kind is "quality" or "reliability".
+type CodeAnalysisRawFinding struct {
+	Kind        string // "quality" | "reliability"
+	RuleID      string
+	CWE         string
+	Severity    shared.Severity
+	Title       string
+	Description string
+	File        string // path relative to the scanned root
+	Line        int    // 1-based
+}
+
+// CodeAnalyzer runs deterministic maintainability/reliability rules over a local source tree. It reads the
+// tree only (never executes it) and honors context cancellation.
+type CodeAnalyzer interface {
+	Analyze(ctx context.Context, root string) ([]CodeAnalysisRawFinding, error)
+}


### PR DESCRIPTION
Implements **Phase 3** of the Code Quality epic (#95, #99): maintainability + reliability findings.

A deterministic code-quality surface that emits first-party `finding.Finding` values (ungated, publishable like SAST), combining a pattern rule engine with the metric-derived signals from Phases 1-2.

### What
- `finding.Kind` += `quality` (maintainability) + `reliability` (likely bug). The SARIF exporter's `firstPartyLoc` recognizes the `quality:` / `reliability:` dedup-key prefixes, so these findings get a **file:line** physical location automatically.
- `internal/infrastructure/tools/codeanalysis`: a pure-Go rule engine (mirrors the SAST analyzer), corpus-tested:
  - quality: `quality-todo-comment`, `quality-commented-out-code`
  - reliability: `reliability-empty-catch`, `reliability-self-assignment`, `reliability-self-comparison`
  - Self-assignment/comparison use operand-adjacent matching (RE2 has no backrefs), so `if (x == x)` and `y = y  // note` are caught while `total = total + 1` is not.
- `internal/usecase/codequality`: assembles the findings and layers on **duplicated blocks** (always, Phase 2) and **high-cyclomatic functions** (when the `synapse-ast` sidecar is available, Phase 1) — this is the SonarQube-style tie-in where complexity + duplication feed maintainability.
- `synapse-cli quality <path> [--fail-on SEV] [--min-complexity N] [--sarif]`.

### Tested
- Rule corpus (TP/FP per rule); service mapping + both metric bridges via in-memory fakes; a real run over `internal/usecase/sca` surfaced genuine todo / commented-out / duplicated-block findings; SARIF verified to carry file:line for the new kinds.

### Note
Go function complexity awaits a Go grammar in the sidecar (follow-up); JS/Python/Java complexity works today. Duplication (which drives the strongest maintainability signal here) is language-agnostic and always on.

`go build ./...`, `go vet ./...`, `CGO_ENABLED=0 go build ./cmd/...`, and package tests pass locally.

Part of #99. Epic #95.
