### PR TITLE
feat(quality): A-E health ratings + technical-debt estimate (Code Quality Phase 4)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rating"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
@@ -110,6 +111,14 @@ func main() {
 			usage()
 		}
 		if err := runQuality(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
+			os.Exit(1)
+		}
+	case "rating":
+		if len(os.Args) < 3 {
+			usage()
+		}
+		if err := runRating(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 			os.Exit(1)
 		}
@@ -355,6 +364,89 @@ func runQuality(args []string) error {
 	return nil
 }
 
+// runRating computes the deterministic A-E health grades (security / reliability / maintainability) and
+// the technical-debt estimate for a local source tree, from the code-quality findings + first-party SAST
+// + the code-size inventory. Read-only, no DB.
+func runRating(args []string) error {
+	dir := args[0]
+	if strings.HasPrefix(dir, "-") {
+		return fmt.Errorf("first argument must be a path, got option %q", dir)
+	}
+	jsonOut := false
+	failBelow := ""
+	for i := 1; i < len(args); i++ {
+		switch {
+		case args[i] == "--json":
+			jsonOut = true
+		case args[i] == "--fail-below" && i+1 < len(args):
+			failBelow = strings.ToUpper(args[i+1])
+			i++
+		default:
+			return fmt.Errorf("unknown or incomplete option %q", args[i])
+		}
+	}
+	ctx := context.Background()
+
+	inv, err := codeinventory.New().Inventory(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("inventory: %w", err)
+	}
+	loc := inv.Totals().CodeLines
+
+	svc := codequality.New(
+		codeanalysis.New(),
+		codequality.WithDuplication(duplication.New(0)),
+		codequality.WithComplexity(ast.New(os.Getenv("SYNAPSE_AST_BIN")), codequality.DefaultComplexityThreshold),
+	)
+	findings, err := svc.Analyze(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("code quality: %w", err)
+	}
+	// First-party security signal for the security grade (SCA dep vulns fold in when rating runs over a
+	// full scan's findings; this standalone command uses the SAST analyzer).
+	sastRaws, err := sast.New().AnalyzeSource(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("sast: %w", err)
+	}
+	for _, sr := range sastRaws {
+		findings = append(findings, finding.Finding{Kind: finding.KindSAST, Severity: sr.Severity})
+	}
+
+	rep := rating.Compute(findings, loc)
+
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			return fmt.Errorf("encode json: %w", err)
+		}
+	} else {
+		fmt.Printf("\nSynapse code health — %s\n", dir)
+		fmt.Printf("  security:        %s\n", rep.Security)
+		fmt.Printf("  reliability:     %s\n", rep.Reliability)
+		fmt.Printf("  maintainability: %s\n", rep.Maintainability)
+		fmt.Printf("  technical debt:  %dh %dm (ratio %.1f%% of ~%d code lines)\n", rep.TechDebtMinutes/60, rep.TechDebtMinutes%60, rep.DebtRatioPct, rep.LinesOfCode)
+	}
+
+	if failBelow != "" {
+		order := map[string]int{"A": 1, "B": 2, "C": 3, "D": 4, "E": 5}
+		threshold, ok := order[failBelow]
+		if !ok {
+			return fmt.Errorf("--fail-below wants a grade A-E, got %q", failBelow)
+		}
+		worst := 0
+		for _, g := range []rating.Grade{rep.Security, rep.Reliability, rep.Maintainability} {
+			if order[string(g)] > worst {
+				worst = order[string(g)]
+			}
+		}
+		if worst > threshold {
+			return fmt.Errorf("a health grade is below %s (security %s, reliability %s, maintainability %s)", failBelow, rep.Security, rep.Reliability, rep.Maintainability)
+		}
+	}
+	return nil
+}
+
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
 	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
@@ -365,6 +457,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  synapse-cli metrics <path> [--fail-on-complexity N] [--top N]  # per-function cyclomatic+cognitive complexity (needs the synapse-ast sidecar)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli duplication <path> [--min-tokens N] [--fail-on-duplication PCT] [--top N]  # copy-paste detection (blocks, lines, density) — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli quality <path> [--fail-on SEV] [--min-complexity N] [--sarif]  # maintainability + reliability findings (+ duplication, + complexity via synapse-ast) — no DB")
+	fmt.Fprintln(os.Stderr, "  synapse-cli rating <path> [--json] [--fail-below GRADE]  # A-E health grades (security/reliability/maintainability) + technical debt — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote     # fetch + ingest app ecosystems from the OSV bulk bucket (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote-distros # fetch + ingest OS-package advisories (Debian/Alpine) from OSV (large; requires SYNAPSE_DB_DSN)")

--- a/internal/domain/rating/rating.go
+++ b/internal/domain/rating/rating.go
@@ -1,0 +1,135 @@
+// Package rating turns findings + size measures into deterministic project health grades (A-E) and a
+// technical-debt estimate, the counterpart on the code-quality side to risk priority on the security
+// side. LLM-free and reproducible: the same findings + LOC always yield the same report, so it is safe on
+// the report path (golden rule 5). Grade bands follow the widely used maintainability/reliability/security
+// rating conventions.
+package rating
+
+import (
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Grade is a letter health grade, A (best) to E (worst).
+type Grade string
+
+const (
+	GradeA Grade = "A"
+	GradeB Grade = "B"
+	GradeC Grade = "C"
+	GradeD Grade = "D"
+	GradeE Grade = "E"
+)
+
+// Dimension is a rated axis.
+type Dimension string
+
+const (
+	Security        Dimension = "security"
+	Reliability     Dimension = "reliability"
+	Maintainability Dimension = "maintainability"
+)
+
+// Report is the computed health of a codebase.
+type Report struct {
+	Security        Grade   `json:"security"`
+	Reliability     Grade   `json:"reliability"`
+	Maintainability Grade   `json:"maintainability"`
+	TechDebtMinutes int     `json:"tech_debt_minutes"` // remediation effort of maintainability issues
+	DebtRatioPct    float64 `json:"debt_ratio_pct"`    // tech debt / estimated development cost
+	LinesOfCode     int     `json:"lines_of_code"`
+}
+
+// Tunables (deterministic defaults; documented). effortMinutes is the remediation effort assumed per
+// issue by severity; devCostPerLineMinutes is the assumed cost to (re)develop one line of code — together
+// they define the debt ratio that grades maintainability.
+var effortMinutes = map[shared.Severity]int{
+	shared.SeverityCritical: 120,
+	shared.SeverityHigh:     60,
+	shared.SeverityMedium:   20,
+	shared.SeverityLow:      10,
+	shared.SeverityInfo:     5,
+}
+
+const devCostPerLineMinutes = 30
+
+// dimensionOf maps a finding kind to the axis it counts toward (or "" to ignore for rating).
+func dimensionOf(k finding.Kind) Dimension {
+	switch k {
+	case finding.KindReliability:
+		return Reliability
+	case finding.KindQuality:
+		return Maintainability
+	case finding.KindSCA, finding.KindSAST, finding.KindSecret, finding.KindMisconfig, finding.KindExploitation, finding.KindDAST:
+		return Security
+	default:
+		return "" // recon/manual/threat/hypothesis are not rating inputs
+	}
+}
+
+// Compute grades the findings against the codebase size (loc = code lines). Security and Reliability are
+// graded by the worst-severity issue on that axis; Maintainability is graded by the technical-debt ratio
+// (remediation effort of maintainability issues vs. estimated development cost).
+func Compute(findings []finding.Finding, loc int) Report {
+	worst := map[Dimension]int{} // dimension -> worst severity rank seen
+	debt := 0
+	for _, f := range findings {
+		dim := dimensionOf(f.Kind)
+		if dim == "" {
+			continue
+		}
+		if r := shared.SeverityRank(f.Severity); r > worst[dim] {
+			worst[dim] = r
+		}
+		if dim == Maintainability {
+			debt += effortMinutes[f.Severity]
+		}
+	}
+
+	rep := Report{
+		Security:        gradeBySeverity(worst[Security]),
+		Reliability:     gradeBySeverity(worst[Reliability]),
+		TechDebtMinutes: debt,
+		LinesOfCode:     loc,
+	}
+	devCost := loc * devCostPerLineMinutes
+	if devCost > 0 {
+		rep.DebtRatioPct = 100 * float64(debt) / float64(devCost)
+	}
+	rep.Maintainability = gradeByDebtRatio(rep.DebtRatioPct)
+	return rep
+}
+
+// gradeBySeverity maps the worst-issue severity rank on an axis to a grade: none->A, low->B, medium->C,
+// high->D, critical->E (info is treated as no material issue).
+func gradeBySeverity(rank int) Grade {
+	switch {
+	case rank >= shared.SeverityRank(shared.SeverityCritical):
+		return GradeE
+	case rank >= shared.SeverityRank(shared.SeverityHigh):
+		return GradeD
+	case rank >= shared.SeverityRank(shared.SeverityMedium):
+		return GradeC
+	case rank >= shared.SeverityRank(shared.SeverityLow):
+		return GradeB
+	default:
+		return GradeA
+	}
+}
+
+// gradeByDebtRatio maps a technical-debt ratio (%) to a maintainability grade: <=5 A, <=10 B, <=20 C,
+// <=50 D, else E.
+func gradeByDebtRatio(pct float64) Grade {
+	switch {
+	case pct <= 5:
+		return GradeA
+	case pct <= 10:
+		return GradeB
+	case pct <= 20:
+		return GradeC
+	case pct <= 50:
+		return GradeD
+	default:
+		return GradeE
+	}
+}

--- a/internal/domain/rating/rating.go
+++ b/internal/domain/rating/rating.go
@@ -60,7 +60,8 @@ func dimensionOf(k finding.Kind) Dimension {
 		return Reliability
 	case finding.KindQuality:
 		return Maintainability
-	case finding.KindSCA, finding.KindSAST, finding.KindSecret, finding.KindMisconfig, finding.KindExploitation, finding.KindDAST:
+	case finding.KindSCA, "", finding.KindSAST, finding.KindSecret, finding.KindMisconfig, finding.KindExploitation, finding.KindDAST:
+		// An empty Kind is legacy-SCA per the finding taxonomy (back-compat), so it counts toward security.
 		return Security
 	default:
 		return "" // recon/manual/threat/hypothesis are not rating inputs
@@ -93,15 +94,23 @@ func Compute(findings []finding.Finding, loc int) Report {
 		LinesOfCode:     loc,
 	}
 	devCost := loc * devCostPerLineMinutes
-	if devCost > 0 {
+	switch {
+	case devCost > 0:
 		rep.DebtRatioPct = 100 * float64(debt) / float64(devCost)
+		rep.Maintainability = gradeByDebtRatio(rep.DebtRatioPct)
+	case debt > 0:
+		// Debt but no measurable code size (loc == 0): the ratio is undefined/infinite, so grade worst
+		// rather than letting max debt read as the best grade.
+		rep.Maintainability = GradeE
+	default:
+		rep.Maintainability = GradeA
 	}
-	rep.Maintainability = gradeByDebtRatio(rep.DebtRatioPct)
 	return rep
 }
 
 // gradeBySeverity maps the worst-issue severity rank on an axis to a grade: none->A, low->B, medium->C,
-// high->D, critical->E (info is treated as no material issue).
+// high->D, critical->E. info and unknown (rank <= 1) are treated as no material issue (grade A) — an
+// unknown-severity finding does not, on its own, degrade a health grade.
 func gradeBySeverity(rank int) Grade {
 	switch {
 	case rank >= shared.SeverityRank(shared.SeverityCritical):

--- a/internal/domain/rating/rating_test.go
+++ b/internal/domain/rating/rating_test.go
@@ -1,0 +1,87 @@
+package rating
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func f(kind finding.Kind, sev shared.Severity) finding.Finding {
+	return finding.Finding{Kind: kind, Severity: sev}
+}
+
+func TestCleanCodebaseAllA(t *testing.T) {
+	r := Compute(nil, 1000)
+	if r.Security != GradeA || r.Reliability != GradeA || r.Maintainability != GradeA {
+		t.Errorf("empty findings should be all A, got %+v", r)
+	}
+	if r.TechDebtMinutes != 0 || r.DebtRatioPct != 0 {
+		t.Errorf("no debt expected, got %+v", r)
+	}
+}
+
+func TestSecurityAndReliabilityWorstSeverity(t *testing.T) {
+	findings := []finding.Finding{
+		f(finding.KindSAST, shared.SeverityHigh),            // security worst = high -> D
+		f(finding.KindSCA, shared.SeverityLow),              // security low (dominated)
+		f(finding.KindReliability, shared.SeverityCritical), // reliability critical -> E
+	}
+	r := Compute(findings, 1000)
+	if r.Security != GradeD {
+		t.Errorf("security want D (worst=high), got %s", r.Security)
+	}
+	if r.Reliability != GradeE {
+		t.Errorf("reliability want E (critical bug), got %s", r.Reliability)
+	}
+	if r.Maintainability != GradeA {
+		t.Errorf("no maintainability issues -> A, got %s", r.Maintainability)
+	}
+}
+
+func TestMaintainabilityDebtRatio(t *testing.T) {
+	// 3 medium quality issues = 3*20 = 60 min of debt.
+	findings := []finding.Finding{
+		f(finding.KindQuality, shared.SeverityMedium),
+		f(finding.KindQuality, shared.SeverityMedium),
+		f(finding.KindQuality, shared.SeverityMedium),
+	}
+	// loc=10 -> devCost=300 -> ratio=20% -> C
+	r := Compute(findings, 10)
+	if r.TechDebtMinutes != 60 {
+		t.Errorf("debt want 60, got %d", r.TechDebtMinutes)
+	}
+	if r.DebtRatioPct != 20 {
+		t.Errorf("ratio want 20, got %.1f", r.DebtRatioPct)
+	}
+	if r.Maintainability != GradeC {
+		t.Errorf("ratio 20%% -> C, got %s", r.Maintainability)
+	}
+	// loc=5 -> devCost=150 -> ratio=40% -> D
+	if g := Compute(findings, 5).Maintainability; g != GradeD {
+		t.Errorf("ratio 40%% -> D, got %s", g)
+	}
+	// loc=1000 -> devCost=30000 -> ratio=0.2% -> A
+	if g := Compute(findings, 1000).Maintainability; g != GradeA {
+		t.Errorf("low ratio -> A, got %s", g)
+	}
+}
+
+func TestInfoDoesNotDegradeSecurity(t *testing.T) {
+	r := Compute([]finding.Finding{f(finding.KindSAST, shared.SeverityInfo)}, 1000)
+	if r.Security != GradeA {
+		t.Errorf("info-only security -> A, got %s", r.Security)
+	}
+}
+
+func TestNonRatingKindsIgnored(t *testing.T) {
+	// recon/manual/threat must not affect any grade.
+	r := Compute([]finding.Finding{
+		f(finding.KindRecon, shared.SeverityCritical),
+		f(finding.KindManual, shared.SeverityCritical),
+		f(finding.KindThreat, shared.SeverityCritical),
+	}, 1000)
+	if r.Security != GradeA || r.Reliability != GradeA || r.Maintainability != GradeA {
+		t.Errorf("non-rating kinds must not degrade grades, got %+v", r)
+	}
+}

--- a/internal/domain/rating/rating_test.go
+++ b/internal/domain/rating/rating_test.go
@@ -74,6 +74,22 @@ func TestInfoDoesNotDegradeSecurity(t *testing.T) {
 	}
 }
 
+func TestEmptyKindCountsAsSecurity(t *testing.T) {
+	// A legacy empty-Kind finding is SCA per the taxonomy, so it must degrade the security grade.
+	r := Compute([]finding.Finding{{Severity: shared.SeverityCritical}}, 1000)
+	if r.Security != GradeE {
+		t.Errorf("empty-kind critical finding must grade security E, got %s", r.Security)
+	}
+}
+
+func TestDebtWithoutLOCGradesWorst(t *testing.T) {
+	// Debt but loc==0 (undefined ratio) must not read as the best grade.
+	r := Compute([]finding.Finding{f(finding.KindQuality, shared.SeverityHigh)}, 0)
+	if r.Maintainability != GradeE {
+		t.Errorf("debt with no LOC must grade maintainability E, got %s", r.Maintainability)
+	}
+}
+
 func TestNonRatingKindsIgnored(t *testing.T) {
 	// recon/manual/threat must not affect any grade.
 	r := Compute([]finding.Finding{


### PR DESCRIPTION
Implements **Phase 4** of the Code Quality epic (#95, #100): A-E health ratings + technical-debt estimate.

Deterministic, LLM-free, reproducible — the code-quality counterpart to risk priority on the security side.

### What
- `domain/rating`: `Compute(findings, loc)` -> **security / reliability / maintainability** grades (A-E) + a **technical-debt** estimate and **debt ratio**.
  - Security & reliability: graded by the worst-severity issue on the axis (none->A, low->B, medium->C, high->D, critical->E).
  - Maintainability: graded by the technical-debt ratio (remediation effort of maintainability issues vs. an estimated development cost), banded A<=5%, B<=10%, C<=20%, D<=50%, E. Tunables (per-severity effort, dev-cost-per-line) are documented constants.
  - Kind -> axis mapping: `reliability`->reliability, `quality`->maintainability, `sca/sast/secret/misconfig/exploitation/dast`->security; recon/manual/threat/hypothesis ignored.
- `synapse-cli rating <path> [--json] [--fail-below GRADE]`: LOC from the inventory (Phase 0), findings from the code-quality engine (Phase 3, quality+reliability) + the first-party SAST analyzer (security). Prints the grades + debt; `--fail-below` gates CI when any grade is worse than the threshold.

### Example
```
Synapse code health — internal/usecase/sca
  security:        D
  reliability:     A
  maintainability: A
  technical debt:  1h 55m (ratio 0.1% of ~5852 code lines)
```

### Tested
Grade bands + debt-ratio math are unit-tested: clean codebase = all A, worst-severity mapping for security/reliability, debt-ratio thresholds (20%->C, 40%->D, low->A), info not degrading, non-rating kinds ignored.

### Note
Standalone `rating` grades first-party security via SAST; SCA dependency vulnerabilities fold into the security grade automatically when `rating.Compute` runs over a full scan's findings (the unified gate, Phase 5). `rating.Compute` already handles every finding kind.

`go build ./...`, `go vet ./...`, `CGO_ENABLED=0 go build ./cmd/...`, tests pass locally.

Part of #100. Epic #95.
