### PR TITLE
feat(quality): Clean-as-You-Code quality gate + profiles (Code Quality Phase 5)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -532,7 +532,8 @@ func runGate(args []string) error {
 		scoped = filterNewCode(findings, changed)
 	}
 
-	// 4. Ratings (over the scope) + whole-codebase duplication density.
+	// 4. Ratings over the scope (security/reliability are worst-severity, so correctly new-code-scoped;
+	// maintainability's debt ratio still divides by whole-repo LOC) + whole-codebase duplication density.
 	inv, err := codeinventory.New().Inventory(ctx, dir)
 	if err != nil {
 		return fmt.Errorf("inventory: %w", err)

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rating"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -33,6 +34,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/codeinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/duplication"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/enry"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gitdiff"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gomodgraph"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gradleresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/grype"
@@ -52,6 +54,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ospkg"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/osv"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownadvisory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/qualityprofile"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/risk"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/sast"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
@@ -119,6 +122,14 @@ func main() {
 			usage()
 		}
 		if err := runRating(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
+			os.Exit(1)
+		}
+	case "gate":
+		if len(os.Args) < 3 {
+			usage()
+		}
+		if err := runGate(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 			os.Exit(1)
 		}
@@ -447,6 +458,184 @@ func runRating(args []string) error {
 	return nil
 }
 
+// runGate is the unified Clean-as-You-Code quality gate: it gathers the code-quality + first-party
+// security findings, applies the rule profile (.synapse-rules.yaml), optionally scopes to new/changed
+// code (git diff vs a base ref), builds the metric snapshot (+ ratings + duplication density), and
+// evaluates the quality gate (.synapse-gate.yaml or the built-in default). Exits non-zero when the gate
+// fails, printing the exact conditions that failed.
+func runGate(args []string) error {
+	dir := args[0]
+	if strings.HasPrefix(dir, "-") {
+		return fmt.Errorf("first argument must be a path, got option %q", dir)
+	}
+	newCodeOnly := false
+	base := "origin/main"
+	gatePath := filepath.Join(dir, ".synapse-gate.yaml")
+	rulesPath := filepath.Join(dir, ".synapse-rules.yaml")
+	for i := 1; i < len(args); i++ {
+		switch {
+		case args[i] == "--new-code-only":
+			newCodeOnly = true
+		case args[i] == "--base" && i+1 < len(args):
+			base = args[i+1]
+			i++
+		case args[i] == "--gate" && i+1 < len(args):
+			gatePath = args[i+1]
+			i++
+		case args[i] == "--rules" && i+1 < len(args):
+			rulesPath = args[i+1]
+			i++
+		default:
+			return fmt.Errorf("unknown or incomplete option %q", args[i])
+		}
+	}
+	ctx := context.Background()
+
+	// 1. Gather findings: code quality (quality+reliability, + duplication/complexity bridges) + SAST.
+	svc := codequality.New(
+		codeanalysis.New(),
+		codequality.WithDuplication(duplication.New(0)),
+		codequality.WithComplexity(ast.New(os.Getenv("SYNAPSE_AST_BIN")), codequality.DefaultComplexityThreshold),
+	)
+	findings, err := svc.Analyze(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("code quality: %w", err)
+	}
+	sastRaws, err := sast.New().AnalyzeSource(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("sast: %w", err)
+	}
+	for _, sr := range sastRaws {
+		findings = append(findings, finding.Finding{
+			Kind:     finding.KindSAST,
+			Severity: sr.Severity,
+			DedupKey: "sast:" + sr.RuleID + ":" + sr.File + ":" + strconv.Itoa(sr.Line),
+		})
+	}
+
+	// 2. Apply the rule profile (enable/disable + severity override).
+	profile, _, err := qualityprofile.LoadProfile(rulesPath)
+	if err != nil {
+		return fmt.Errorf("load rules profile: %w", err)
+	}
+	findings = profile.Apply(findings)
+
+	// 3. Scope to new/changed code if requested (Clean as You Code): the gate then judges only what this
+	// change introduced. Ratings are computed over the SAME scope, so "reliability_rating A" means "no
+	// reliability issue in new code", the adoption-friendly semantic.
+	scoped := findings
+	if newCodeOnly {
+		changed, derr := gitdiff.Changed(ctx, dir, base)
+		if derr != nil {
+			return fmt.Errorf("new-code diff: %w", derr)
+		}
+		scoped = filterNewCode(findings, changed)
+	}
+
+	// 4. Ratings (over the scope) + whole-codebase duplication density.
+	inv, err := codeinventory.New().Inventory(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("inventory: %w", err)
+	}
+	rep := rating.Compute(scoped, inv.Totals().CodeLines)
+	dupRep, err := duplication.New(0).Duplication(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("duplication: %w", err)
+	}
+
+	// 5. Build the snapshot + evaluate the gate.
+	snap := buildSnapshot(scoped, rep, dupRep.Density())
+	gate, found, err := qualityprofile.LoadGate(gatePath)
+	if err != nil {
+		return fmt.Errorf("load gate: %w", err)
+	}
+	if !found {
+		gate = qualitygate.Default()
+	}
+	result := qualitygate.Evaluate(gate, snap)
+
+	scopeLabel := "whole codebase"
+	if newCodeOnly {
+		scopeLabel = "new code vs " + base
+	}
+	fmt.Printf("\nSynapse quality gate — %s (%s)\n", dir, scopeLabel)
+	fmt.Printf("  ratings: security %s · reliability %s · maintainability %s · duplication %.1f%%\n", rep.Security, rep.Reliability, rep.Maintainability, dupRep.Density())
+	for _, cr := range result.Results {
+		mark := "PASS"
+		if !cr.Passed {
+			mark = "FAIL"
+		}
+		fmt.Printf("  [%s] %s (actual %g)\n", mark, cr.Condition, cr.Actual)
+	}
+	if !result.Passed {
+		return fmt.Errorf("quality gate FAILED: %d condition(s) not met", len(result.Failures()))
+	}
+	fmt.Println("  quality gate PASSED")
+	return nil
+}
+
+// filterNewCode keeps only line-anchored findings that sit on a changed line.
+func filterNewCode(findings []finding.Finding, changed gitdiff.ChangedLines) []finding.Finding {
+	var out []finding.Finding
+	for _, f := range findings {
+		file, line, ok := qualitygate.FileLineOf(f.DedupKey)
+		if !ok {
+			continue // not line-anchored (e.g. SCA): not attributable to a changed line
+		}
+		if changed.Has(file, line) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// buildSnapshot turns the scoped findings + ratings + duplication into gate metrics.
+func buildSnapshot(scoped []finding.Finding, rep rating.Report, dupDensity float64) qualitygate.Snapshot {
+	s := qualitygate.Snapshot{}
+	securityKind := map[finding.Kind]bool{
+		finding.KindSCA: true, finding.KindSAST: true, finding.KindSecret: true,
+		finding.KindMisconfig: true, finding.KindExploitation: true, finding.KindDAST: true,
+	}
+	for _, f := range scoped {
+		s[qualitygate.MetricNewIssues]++
+		switch f.Severity {
+		case shared.SeverityCritical:
+			s[qualitygate.MetricNewCritical]++
+		case shared.SeverityHigh:
+			s[qualitygate.MetricNewHigh]++
+		case shared.SeverityMedium:
+			s[qualitygate.MetricNewMedium]++
+		}
+		if f.Kind == finding.KindSecret {
+			s[qualitygate.MetricNewSecret]++
+		}
+		if securityKind[f.Kind] {
+			s[qualitygate.MetricNewVulnerability]++
+		}
+	}
+	s[qualitygate.MetricDuplicationPct] = dupDensity
+	s[qualitygate.MetricSecurityRating] = gradeNum(rep.Security)
+	s[qualitygate.MetricReliability] = gradeNum(rep.Reliability)
+	s[qualitygate.MetricMaintainability] = gradeNum(rep.Maintainability)
+	return s
+}
+
+func gradeNum(g rating.Grade) float64 {
+	switch g {
+	case rating.GradeA:
+		return 1
+	case rating.GradeB:
+		return 2
+	case rating.GradeC:
+		return 3
+	case rating.GradeD:
+		return 4
+	case rating.GradeE:
+		return 5
+	}
+	return 0
+}
+
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
 	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
@@ -458,6 +647,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  synapse-cli duplication <path> [--min-tokens N] [--fail-on-duplication PCT] [--top N]  # copy-paste detection (blocks, lines, density) — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli quality <path> [--fail-on SEV] [--min-complexity N] [--sarif]  # maintainability + reliability findings (+ duplication, + complexity via synapse-ast) — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli rating <path> [--json] [--fail-below GRADE]  # A-E health grades (security/reliability/maintainability) + technical debt — no DB")
+	fmt.Fprintln(os.Stderr, "  synapse-cli gate <path> [--new-code-only] [--base REF] [--gate FILE] [--rules FILE]  # Clean-as-You-Code quality gate (.synapse-gate.yaml / .synapse-rules.yaml) — no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote     # fetch + ingest app ecosystems from the OSV bulk bucket (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote-distros # fetch + ingest OS-package advisories (Debian/Alpine) from OSV (large; requires SYNAPSE_DB_DSN)")

--- a/internal/domain/qualitygate/gate.go
+++ b/internal/domain/qualitygate/gate.go
@@ -1,0 +1,94 @@
+// Package qualitygate is the deterministic pass/fail gate over a codebase's measured metrics — the
+// "Clean as You Code" quality gate. It is pure domain: types + evaluation, no I/O, no LLM. A Gate is a
+// list of conditions on named metrics (e.g. new_critical <= 0); Evaluate returns pass/fail plus the exact
+// conditions that failed, so a CI step can print an actionable reason.
+package qualitygate
+
+import "fmt"
+
+// Op is a comparison operator for a condition.
+type Op string
+
+const (
+	OpLE Op = "<=" // metric must be at most threshold (the common "no more than" gate)
+	OpGE Op = ">=" // metric must be at least threshold (e.g. coverage)
+	OpEQ Op = "==" // metric must equal threshold
+	OpLT Op = "<"
+	OpGT Op = ">"
+)
+
+// Condition asserts one metric relates to a threshold. Metric names are documented in metrics.go.
+type Condition struct {
+	Metric    string  `yaml:"metric" json:"metric"`
+	Op        Op      `yaml:"op" json:"op"`
+	Threshold float64 `yaml:"threshold" json:"threshold"`
+}
+
+// Gate is a set of conditions; all must hold for the gate to pass.
+type Gate struct {
+	Conditions []Condition `yaml:"conditions" json:"conditions"`
+}
+
+// Snapshot is the measured metric values. A metric absent from the snapshot reads as 0.
+type Snapshot map[string]float64
+
+// ConditionResult is one evaluated condition.
+type ConditionResult struct {
+	Condition Condition
+	Actual    float64
+	Passed    bool
+}
+
+// Result is the gate outcome.
+type Result struct {
+	Passed  bool
+	Results []ConditionResult
+}
+
+// Failures returns the conditions that did not hold.
+func (r Result) Failures() []ConditionResult {
+	var out []ConditionResult
+	for _, c := range r.Results {
+		if !c.Passed {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// Evaluate checks every condition against the snapshot. An unknown operator fails its condition closed
+// (a malformed gate never silently passes).
+func Evaluate(g Gate, s Snapshot) Result {
+	res := Result{Passed: true}
+	for _, c := range g.Conditions {
+		actual := s[c.Metric]
+		ok := compare(actual, c.Op, c.Threshold)
+		if !ok {
+			res.Passed = false
+		}
+		res.Results = append(res.Results, ConditionResult{Condition: c, Actual: actual, Passed: ok})
+	}
+	return res
+}
+
+func compare(actual float64, op Op, threshold float64) bool {
+	switch op {
+	case OpLE:
+		return actual <= threshold
+	case OpGE:
+		return actual >= threshold
+	case OpEQ:
+		return actual == threshold
+	case OpLT:
+		return actual < threshold
+	case OpGT:
+		return actual > threshold
+	default:
+		return false // unknown operator: fail closed
+	}
+}
+
+// String renders a condition as "metric op threshold" for messages.
+func (c Condition) String() string {
+	return fmt.Sprintf("%s %s %g", c.Metric, c.Op, c.Threshold)
+}

--- a/internal/domain/qualitygate/gate.go
+++ b/internal/domain/qualitygate/gate.go
@@ -32,6 +32,27 @@ type Gate struct {
 // Snapshot is the measured metric values. A metric absent from the snapshot reads as 0.
 type Snapshot map[string]float64
 
+// validOps is the set of operators a condition may use.
+var validOps = map[Op]bool{OpLE: true, OpGE: true, OpEQ: true, OpLT: true, OpGT: true}
+
+// Validate rejects a gate that is empty or references an unknown metric/operator, so a typo'd or
+// truncated config fails loud at load time rather than silently passing (a security gate must fail
+// closed). It is called by the config loader.
+func (g Gate) Validate() error {
+	if len(g.Conditions) == 0 {
+		return fmt.Errorf("quality gate has no conditions")
+	}
+	for _, c := range g.Conditions {
+		if !ValidMetric(c.Metric) {
+			return fmt.Errorf("unknown gate metric %q", c.Metric)
+		}
+		if !validOps[c.Op] {
+			return fmt.Errorf("unknown gate operator %q for metric %q", c.Op, c.Metric)
+		}
+	}
+	return nil
+}
+
 // ConditionResult is one evaluated condition.
 type ConditionResult struct {
 	Condition Condition

--- a/internal/domain/qualitygate/gate_test.go
+++ b/internal/domain/qualitygate/gate_test.go
@@ -1,0 +1,49 @@
+package qualitygate
+
+import "testing"
+
+func TestEvaluatePassFail(t *testing.T) {
+	g := Gate{Conditions: []Condition{
+		{Metric: "new_critical", Op: OpLE, Threshold: 0},
+		{Metric: "coverage", Op: OpGE, Threshold: 80},
+	}}
+	// pass: 0 new criticals, 90 coverage
+	if r := Evaluate(g, Snapshot{"new_critical": 0, "coverage": 90}); !r.Passed {
+		t.Errorf("should pass, got failures %+v", r.Failures())
+	}
+	// fail: 2 new criticals, 70 coverage -> both fail
+	r := Evaluate(g, Snapshot{"new_critical": 2, "coverage": 70})
+	if r.Passed || len(r.Failures()) != 2 {
+		t.Errorf("should fail both conditions, got passed=%v failures=%d", r.Passed, len(r.Failures()))
+	}
+}
+
+func TestMissingMetricIsZero(t *testing.T) {
+	g := Gate{Conditions: []Condition{{Metric: "new_high", Op: OpLE, Threshold: 0}}}
+	if r := Evaluate(g, Snapshot{}); !r.Passed {
+		t.Errorf("absent metric reads as 0, should pass <=0")
+	}
+}
+
+func TestUnknownOpFailsClosed(t *testing.T) {
+	g := Gate{Conditions: []Condition{{Metric: "x", Op: Op("~="), Threshold: 0}}}
+	if Evaluate(g, Snapshot{"x": 0}).Passed {
+		t.Error("unknown operator must fail closed")
+	}
+}
+
+func TestDefaultGate(t *testing.T) {
+	g := Default()
+	if len(g.Conditions) == 0 {
+		t.Fatal("default gate must have conditions")
+	}
+	// A clean snapshot (all A ratings, no new issues) passes the default gate.
+	clean := Snapshot{"security_rating": 1, "reliability_rating": 1}
+	if !Evaluate(g, clean).Passed {
+		t.Errorf("clean snapshot should pass the default gate, failures %+v", Evaluate(g, clean).Failures())
+	}
+	// A new critical fails it.
+	if Evaluate(g, Snapshot{"new_critical": 1, "security_rating": 1, "reliability_rating": 1}).Passed {
+		t.Error("a new critical must fail the default gate")
+	}
+}

--- a/internal/domain/qualitygate/metrics.go
+++ b/internal/domain/qualitygate/metrics.go
@@ -8,7 +8,7 @@ const (
 	MetricNewHigh          = "new_high"          // new findings with high severity
 	MetricNewMedium        = "new_medium"        // new findings with medium severity
 	MetricNewSecret        = "new_secret"        // new secret findings
-	MetricNewVulnerability = "new_vulnerability" // new security findings (sca/sast/secret/misconfig)
+	MetricNewVulnerability = "new_vulnerability" // new security findings (sca/sast/secret/misconfig/exploitation/dast)
 	MetricNewIssues        = "new_issues"        // all new findings
 	MetricTotalCritical    = "total_critical"    // whole-codebase critical findings
 	MetricDuplicationPct   = "duplication_density"
@@ -17,6 +17,20 @@ const (
 	MetricReliability      = "reliability_rating"
 	MetricMaintainability  = "maintainability_rating"
 )
+
+// knownMetrics is the set a gate condition may reference, so a typo'd metric name is rejected at load
+// time (a metric absent from the snapshot reads as 0, which could otherwise silently pass a gate).
+// NOTE: `coverage` is accepted but not yet measured (lands with the coverage-import phase); a coverage
+// condition therefore reads 0 and fails closed until then.
+var knownMetrics = map[string]bool{
+	MetricNewCritical: true, MetricNewHigh: true, MetricNewMedium: true, MetricNewSecret: true,
+	MetricNewVulnerability: true, MetricNewIssues: true, MetricTotalCritical: true,
+	MetricDuplicationPct: true, MetricCoveragePct: true,
+	MetricSecurityRating: true, MetricReliability: true, MetricMaintainability: true,
+}
+
+// ValidMetric reports whether name is a recognized gate metric.
+func ValidMetric(name string) bool { return knownMetrics[name] }
 
 // Default returns the built-in "clean new code" gate: no new critical/high findings, no new secrets, and
 // A ratings on the whole codebase. It mirrors the widely used default of gating strictly on new code

--- a/internal/domain/qualitygate/metrics.go
+++ b/internal/domain/qualitygate/metrics.go
@@ -1,0 +1,32 @@
+package qualitygate
+
+// Metric name constants for a gate condition. "new_*" metrics count only findings on new/changed code
+// (Clean as You Code); the others are whole-codebase. Ratings are numeric: A=1, B=2, C=3, D=4, E=5, so
+// `security_rating <= 1` means "must be A".
+const (
+	MetricNewCritical      = "new_critical"      // new findings with critical severity
+	MetricNewHigh          = "new_high"          // new findings with high severity
+	MetricNewMedium        = "new_medium"        // new findings with medium severity
+	MetricNewSecret        = "new_secret"        // new secret findings
+	MetricNewVulnerability = "new_vulnerability" // new security findings (sca/sast/secret/misconfig)
+	MetricNewIssues        = "new_issues"        // all new findings
+	MetricTotalCritical    = "total_critical"    // whole-codebase critical findings
+	MetricDuplicationPct   = "duplication_density"
+	MetricCoveragePct      = "coverage"
+	MetricSecurityRating   = "security_rating"
+	MetricReliability      = "reliability_rating"
+	MetricMaintainability  = "maintainability_rating"
+)
+
+// Default returns the built-in "clean new code" gate: no new critical/high findings, no new secrets, and
+// A ratings on the whole codebase. It mirrors the widely used default of gating strictly on new code
+// while holding overall ratings at their best. Override with a .synapse-gate.yaml.
+func Default() Gate {
+	return Gate{Conditions: []Condition{
+		{Metric: MetricNewCritical, Op: OpLE, Threshold: 0},
+		{Metric: MetricNewHigh, Op: OpLE, Threshold: 0},
+		{Metric: MetricNewSecret, Op: OpLE, Threshold: 0},
+		{Metric: MetricSecurityRating, Op: OpLE, Threshold: 1},
+		{Metric: MetricReliability, Op: OpLE, Threshold: 1},
+	}}
+}

--- a/internal/domain/qualitygate/profile.go
+++ b/internal/domain/qualitygate/profile.go
@@ -28,7 +28,7 @@ func (p Profile) Apply(findings []finding.Finding) []finding.Finding {
 	if len(p.Rules) == 0 {
 		return findings
 	}
-	out := findings[:0]
+	out := make([]finding.Finding, 0, len(findings)) // fresh slice: never mutate the caller's backing array
 	for _, f := range findings {
 		cfg, ok := p.Rules[RuleIDOf(f.DedupKey)]
 		if !ok {

--- a/internal/domain/qualitygate/profile.go
+++ b/internal/domain/qualitygate/profile.go
@@ -1,0 +1,82 @@
+package qualitygate
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// RuleConfig overrides a single rule/advisory: disable it, and/or override its severity. A nil Enabled
+// leaves the rule enabled.
+type RuleConfig struct {
+	Enabled  *bool  `yaml:"enabled" json:"enabled"`
+	Severity string `yaml:"severity" json:"severity"`
+}
+
+// Profile is a per-project rule overlay (.synapse-rules.yaml): enable/disable rules and override
+// severities without changing the built-in engines. Keyed by rule id (first-party rules) or advisory id
+// (SCA).
+type Profile struct {
+	Rules map[string]RuleConfig `yaml:"rules" json:"rules"`
+}
+
+// Apply drops findings whose rule is disabled and overrides severities per the profile. A finding whose
+// rule is not in the profile passes through unchanged. Returns the input as-is when the profile is empty.
+func (p Profile) Apply(findings []finding.Finding) []finding.Finding {
+	if len(p.Rules) == 0 {
+		return findings
+	}
+	out := findings[:0]
+	for _, f := range findings {
+		cfg, ok := p.Rules[RuleIDOf(f.DedupKey)]
+		if !ok {
+			out = append(out, f)
+			continue
+		}
+		if cfg.Enabled != nil && !*cfg.Enabled {
+			continue // rule disabled: drop the finding
+		}
+		if cfg.Severity != "" {
+			f.Severity = shared.Severity(cfg.Severity)
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// knownKinds are the dedup-key prefixes whose rule id is the SECOND field (<kind>:<rule>:<file>:<line>).
+var knownKinds = map[string]bool{"sast": true, "secret": true, "misconfig": true, "quality": true, "reliability": true}
+
+// RuleIDOf extracts the rule/advisory identifier a profile keys on from a finding's dedup key: the second
+// field for first-party kinds (<kind>:<rule>:...), else the first field (an SCA advisory id).
+func RuleIDOf(dedupKey string) string {
+	parts := strings.Split(dedupKey, ":")
+	if len(parts) == 0 {
+		return ""
+	}
+	if len(parts) >= 2 && knownKinds[parts[0]] {
+		return parts[1]
+	}
+	return parts[0]
+}
+
+// FileLineOf extracts the source file and 1-based line from a first-party dedup key
+// (<kind>:<rule>:<file>:<line>). ok=false for a key that is not line-anchored (e.g. an SCA advisory key),
+// so a caller can decide how to treat non-line-anchored findings under new-code gating.
+func FileLineOf(dedupKey string) (file string, line int, ok bool) {
+	parts := strings.Split(dedupKey, ":")
+	if len(parts) < 4 || !knownKinds[parts[0]] {
+		return "", 0, false
+	}
+	n, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil || n < 1 {
+		return "", 0, false
+	}
+	file = strings.Join(parts[2:len(parts)-1], ":") // rejoin a Windows-y path that contained colons
+	if file == "" {
+		return "", 0, false
+	}
+	return file, n, true
+}

--- a/internal/domain/qualitygate/profile_test.go
+++ b/internal/domain/qualitygate/profile_test.go
@@ -1,0 +1,70 @@
+package qualitygate
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func boolp(b bool) *bool { return &b }
+
+func TestRuleIDOf(t *testing.T) {
+	cases := map[string]string{
+		"quality:quality-todo-comment:a.go:3": "quality-todo-comment",
+		"sast:weak-hash-md5:x/y.go:12":        "weak-hash-md5",
+		"CVE-2024-1234:pkg:1.0.0":             "CVE-2024-1234", // SCA: no kind prefix -> first field
+	}
+	for dedup, want := range cases {
+		if got := RuleIDOf(dedup); got != want {
+			t.Errorf("RuleIDOf(%q) = %q, want %q", dedup, got, want)
+		}
+	}
+}
+
+func TestFileLineOf(t *testing.T) {
+	f, l, ok := FileLineOf("quality:quality-todo-comment:pkg/a.go:42")
+	if !ok || f != "pkg/a.go" || l != 42 {
+		t.Errorf("got (%q,%d,%v), want (pkg/a.go,42,true)", f, l, ok)
+	}
+	if _, _, ok := FileLineOf("CVE-2024-1: pkg:1.0"); ok {
+		t.Error("an SCA (non-line-anchored) key must return ok=false")
+	}
+}
+
+func TestProfileApply(t *testing.T) {
+	findings := []finding.Finding{
+		{DedupKey: "quality:quality-todo-comment:a.go:1", Severity: shared.SeverityInfo},
+		{DedupKey: "reliability:reliability-self-comparison:b.go:2", Severity: shared.SeverityMedium},
+		{DedupKey: "sast:weak-hash-md5:c.go:3", Severity: shared.SeverityMedium},
+	}
+	p := Profile{Rules: map[string]RuleConfig{
+		"quality-todo-comment":        {Enabled: boolp(false)},                 // drop
+		"reliability-self-comparison": {Severity: string(shared.SeverityHigh)}, // override
+	}}
+	out := p.Apply(findings)
+	if len(out) != 2 {
+		t.Fatalf("want 2 findings (todo dropped), got %d: %+v", len(out), out)
+	}
+	for _, f := range out {
+		switch RuleIDOf(f.DedupKey) {
+		case "quality-todo-comment":
+			t.Error("disabled rule must be dropped")
+		case "reliability-self-comparison":
+			if f.Severity != shared.SeverityHigh {
+				t.Errorf("severity override failed: %s", f.Severity)
+			}
+		case "weak-hash-md5":
+			if f.Severity != shared.SeverityMedium {
+				t.Errorf("untouched rule severity changed: %s", f.Severity)
+			}
+		}
+	}
+}
+
+func TestEmptyProfileNoOp(t *testing.T) {
+	in := []finding.Finding{{DedupKey: "quality:x:a:1"}}
+	if got := (Profile{}).Apply(in); len(got) != 1 {
+		t.Errorf("empty profile must pass findings through, got %d", len(got))
+	}
+}

--- a/internal/infrastructure/tools/gitdiff/gitdiff.go
+++ b/internal/infrastructure/tools/gitdiff/gitdiff.go
@@ -30,8 +30,15 @@ func Changed(ctx context.Context, dir, base string) (ChangedLines, error) {
 	if strings.TrimSpace(base) == "" {
 		return nil, fmt.Errorf("gitdiff: empty base ref")
 	}
+	if strings.HasPrefix(base, "-") {
+		// Reject a ref that would be parsed as a git option (e.g. --output=...): option injection.
+		return nil, fmt.Errorf("gitdiff: base ref %q must not start with '-'", base)
+	}
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "git", "-C", dir, "diff", "--unified=0", "--no-color", "--diff-filter=d", base, "--", ".")
+	// --relative makes diff paths relative to dir (so they match finding paths, which are filepath.Rel to
+	// dir) and scopes the diff to dir. --end-of-options ensures base is treated as a revision, never an
+	// option (defense-in-depth with the leading-dash check). argv only, no shell.
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "diff", "--relative", "--unified=0", "--no-color", "--diff-filter=d", "--end-of-options", base, "--", ".")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/infrastructure/tools/gitdiff/gitdiff.go
+++ b/internal/infrastructure/tools/gitdiff/gitdiff.go
@@ -1,0 +1,80 @@
+// Package gitdiff computes the set of added/changed lines per file between a base ref and the working
+// tree, for "new code" (Clean-as-You-Code) gating: a finding is "new" when it sits on a changed line.
+// It shells out to git (argv only, no shell) and parses a --unified=0 diff. Read-only.
+package gitdiff
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ChangedLines maps a repo-relative file path to the set of its added/changed 1-based line numbers.
+type ChangedLines map[string]map[int]bool
+
+// Has reports whether file:line was added/changed.
+func (c ChangedLines) Has(file string, line int) bool {
+	m, ok := c[file]
+	return ok && m[line]
+}
+
+var hunkRe = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
+
+// Changed returns the added/changed lines between base and the working tree of dir. base is a git ref
+// (branch, tag, sha); e.g. "origin/main" or a merge-base. It runs `git -C dir diff --unified=0 base -- .`.
+func Changed(ctx context.Context, dir, base string) (ChangedLines, error) {
+	if strings.TrimSpace(base) == "" {
+		return nil, fmt.Errorf("gitdiff: empty base ref")
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "diff", "--unified=0", "--no-color", "--diff-filter=d", base, "--", ".")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git diff against %q: %w: %s", base, err, strings.TrimSpace(stderr.String()))
+	}
+	return parseDiff(stdout.Bytes()), nil
+}
+
+// parseDiff extracts added-line ranges from a --unified=0 unified diff.
+func parseDiff(out []byte) ChangedLines {
+	changed := ChangedLines{}
+	var file string
+	for _, raw := range strings.Split(string(out), "\n") {
+		switch {
+		case strings.HasPrefix(raw, "+++ b/"):
+			file = strings.TrimPrefix(raw, "+++ b/")
+		case strings.HasPrefix(raw, "+++ "):
+			file = "" // /dev/null or unusual header
+		case strings.HasPrefix(raw, "@@"):
+			if file == "" {
+				continue
+			}
+			m := hunkRe.FindStringSubmatch(raw)
+			if m == nil {
+				continue
+			}
+			start, _ := strconv.Atoi(m[1])
+			count := 1
+			if m[2] != "" {
+				count, _ = strconv.Atoi(m[2])
+			}
+			if count == 0 {
+				continue // a pure deletion hunk adds no lines on the new side
+			}
+			set := changed[file]
+			if set == nil {
+				set = map[int]bool{}
+				changed[file] = set
+			}
+			for i := 0; i < count; i++ {
+				set[start+i] = true
+			}
+		}
+	}
+	return changed
+}

--- a/internal/infrastructure/tools/gitdiff/gitdiff_test.go
+++ b/internal/infrastructure/tools/gitdiff/gitdiff_test.go
@@ -1,0 +1,36 @@
+package gitdiff
+
+import "testing"
+
+func TestParseDiff(t *testing.T) {
+	diff := "diff --git a/x.go b/x.go\n" +
+		"--- a/x.go\n" +
+		"+++ b/x.go\n" +
+		"@@ -1,0 +2,3 @@\n+a\n+b\n+c\n" + // adds lines 2,3,4
+		"@@ -20 +25 @@\n-old\n+new\n" + // adds line 25 (count omitted = 1)
+		"diff --git a/y.py b/y.py\n" +
+		"--- a/y.py\n" +
+		"+++ b/y.py\n" +
+		"@@ -5,2 +5,0 @@\n-gone1\n-gone2\n" // pure deletion: adds nothing
+	c := parseDiff([]byte(diff))
+
+	for _, ln := range []int{2, 3, 4, 25} {
+		if !c.Has("x.go", ln) {
+			t.Errorf("x.go line %d should be changed", ln)
+		}
+	}
+	for _, ln := range []int{1, 5, 24, 26} {
+		if c.Has("x.go", ln) {
+			t.Errorf("x.go line %d should NOT be changed", ln)
+		}
+	}
+	if len(c["y.py"]) != 0 {
+		t.Errorf("y.py pure-deletion hunk must add no lines, got %v", c["y.py"])
+	}
+}
+
+func TestParseDiffEmpty(t *testing.T) {
+	if len(parseDiff(nil)) != 0 {
+		t.Error("empty diff should yield no changed files")
+	}
+}

--- a/internal/infrastructure/tools/qualityprofile/load.go
+++ b/internal/infrastructure/tools/qualityprofile/load.go
@@ -1,0 +1,62 @@
+// Package qualityprofile loads the .synapse-gate.yaml (quality gate) and .synapse-rules.yaml (rule
+// profile) config files into the pure-domain qualitygate types. Read-only, bounded.
+package qualityprofile
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
+)
+
+const maxConfigBytes = 1 << 20 // a gate/profile file is small; cap defensively
+
+// LoadGate reads a quality-gate YAML file. found=false when the path is empty or the file does not exist
+// (the caller then uses qualitygate.Default()). A present-but-malformed file is an error.
+func LoadGate(path string) (qualitygate.Gate, bool, error) {
+	data, found, err := readConfig(path)
+	if err != nil || !found {
+		return qualitygate.Gate{}, found, err
+	}
+	var g qualitygate.Gate
+	if err := yaml.Unmarshal(data, &g); err != nil {
+		return qualitygate.Gate{}, true, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return g, true, nil
+}
+
+// LoadProfile reads a rule-profile YAML file. found=false when the path is empty or the file is absent.
+func LoadProfile(path string) (qualitygate.Profile, bool, error) {
+	data, found, err := readConfig(path)
+	if err != nil || !found {
+		return qualitygate.Profile{}, found, err
+	}
+	var p qualitygate.Profile
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return qualitygate.Profile{}, true, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return p, true, nil
+}
+
+func readConfig(path string) ([]byte, bool, error) {
+	if path == "" {
+		return nil, false, nil
+	}
+	fi, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !fi.Mode().IsRegular() || fi.Size() > maxConfigBytes {
+		return nil, false, fmt.Errorf("%s is not a regular config file within %d bytes", path, maxConfigBytes)
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- operator-provided config path, regular + size-capped above
+	if err != nil {
+		return nil, false, fmt.Errorf("read %s: %w", path, err)
+	}
+	return data, true, nil
+}

--- a/internal/infrastructure/tools/qualityprofile/load.go
+++ b/internal/infrastructure/tools/qualityprofile/load.go
@@ -3,6 +3,7 @@
 package qualityprofile
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -10,6 +11,14 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
 )
+
+// strictUnmarshal decodes YAML rejecting unknown fields, so a misspelled top-level key (e.g. `condition:`
+// instead of `conditions:`) is an error rather than a silently-empty struct that could bypass the gate.
+func strictUnmarshal(data []byte, into any) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(into)
+}
 
 const maxConfigBytes = 1 << 20 // a gate/profile file is small; cap defensively
 
@@ -21,8 +30,11 @@ func LoadGate(path string) (qualitygate.Gate, bool, error) {
 		return qualitygate.Gate{}, found, err
 	}
 	var g qualitygate.Gate
-	if err := yaml.Unmarshal(data, &g); err != nil {
+	if err := strictUnmarshal(data, &g); err != nil {
 		return qualitygate.Gate{}, true, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if err := g.Validate(); err != nil {
+		return qualitygate.Gate{}, true, fmt.Errorf("invalid gate %s: %w", path, err)
 	}
 	return g, true, nil
 }
@@ -34,7 +46,7 @@ func LoadProfile(path string) (qualitygate.Profile, bool, error) {
 		return qualitygate.Profile{}, found, err
 	}
 	var p qualitygate.Profile
-	if err := yaml.Unmarshal(data, &p); err != nil {
+	if err := strictUnmarshal(data, &p); err != nil {
 		return qualitygate.Profile{}, true, fmt.Errorf("parse %s: %w", path, err)
 	}
 	return p, true, nil

--- a/internal/infrastructure/tools/qualityprofile/load_test.go
+++ b/internal/infrastructure/tools/qualityprofile/load_test.go
@@ -1,0 +1,47 @@
+package qualityprofile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
+)
+
+func TestLoadGate(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "gate.yaml")
+	os.WriteFile(p, []byte("conditions:\n  - metric: new_critical\n    op: \"<=\"\n    threshold: 0\n  - metric: coverage\n    op: \">=\"\n    threshold: 80\n"), 0o644)
+	g, found, err := LoadGate(p)
+	if err != nil || !found {
+		t.Fatalf("load: found=%v err=%v", found, err)
+	}
+	if len(g.Conditions) != 2 || g.Conditions[0].Metric != "new_critical" || g.Conditions[1].Op != qualitygate.OpGE {
+		t.Errorf("parsed gate wrong: %+v", g)
+	}
+}
+
+func TestLoadProfile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rules.yaml")
+	os.WriteFile(p, []byte("rules:\n  quality-todo-comment:\n    enabled: false\n  reliability-self-comparison:\n    severity: high\n"), 0o644)
+	prof, found, err := LoadProfile(p)
+	if err != nil || !found {
+		t.Fatalf("load: found=%v err=%v", found, err)
+	}
+	if prof.Rules["quality-todo-comment"].Enabled == nil || *prof.Rules["quality-todo-comment"].Enabled {
+		t.Errorf("expected enabled=false for todo rule: %+v", prof.Rules["quality-todo-comment"])
+	}
+	if prof.Rules["reliability-self-comparison"].Severity != "high" {
+		t.Errorf("expected severity override high: %+v", prof.Rules["reliability-self-comparison"])
+	}
+}
+
+func TestMissingFilesNotFound(t *testing.T) {
+	if _, found, err := LoadGate(""); found || err != nil {
+		t.Errorf("empty path: want (not-found, no error)")
+	}
+	if _, found, err := LoadProfile(filepath.Join(t.TempDir(), "nope.yaml")); found || err != nil {
+		t.Errorf("absent file: want (not-found, no error)")
+	}
+}

--- a/internal/infrastructure/tools/qualityprofile/load_test.go
+++ b/internal/infrastructure/tools/qualityprofile/load_test.go
@@ -37,6 +37,32 @@ func TestLoadProfile(t *testing.T) {
 	}
 }
 
+func TestLoadGateRejectsBadConfig(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string]string{
+		"typo-key.yaml":       "condition:\n  - metric: new_critical\n    op: \"<=\"\n    threshold: 0\n",  // wrong top key -> empty -> rejected
+		"unknown-metric.yaml": "conditions:\n  - metric: new_criticl\n    op: \"<=\"\n    threshold: 0\n",  // typo'd metric
+		"bad-op.yaml":         "conditions:\n  - metric: new_critical\n    op: \"~=\"\n    threshold: 0\n", // unknown op
+		"empty.yaml":          "conditions: []\n",                                                          // no conditions
+	}
+	for name, body := range cases {
+		p := filepath.Join(dir, name)
+		os.WriteFile(p, []byte(body), 0o644)
+		if _, _, err := LoadGate(p); err == nil {
+			t.Errorf("%s: expected a load error (fail-closed), got nil", name)
+		}
+	}
+}
+
+func TestLoadProfileRejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "rules.yaml")
+	os.WriteFile(p, []byte("ruls:\n  x:\n    enabled: false\n"), 0o644) // "ruls" typo
+	if _, _, err := LoadProfile(p); err == nil {
+		t.Error("a misspelled profile key must be rejected")
+	}
+}
+
 func TestMissingFilesNotFound(t *testing.T) {
 	if _, found, err := LoadGate(""); found || err != nil {
 		t.Errorf("empty path: want (not-found, no error)")


### PR DESCRIPTION
Implements **Phase 5** of the Code Quality epic (#95, #101): the adoption layer — Clean-as-You-Code new-code gating, a configurable quality gate, and per-project rule profiles.

### What
- `internal/infrastructure/tools/gitdiff`: parse `git diff --unified=0 <base>` into the added/changed lines per file (argv git, read-only).
- `domain/qualitygate` (pure): `Gate`/`Condition`/`Snapshot`/`Evaluate` (unknown operator fails closed) + a built-in `Default()` gate; a rule `Profile` (enable/disable + severity override, keyed by rule/advisory id) with `RuleIDOf`/`FileLineOf` dedup-key helpers.
- `internal/infrastructure/tools/qualityprofile`: load `.synapse-gate.yaml` + `.synapse-rules.yaml` (yaml.v3, size-capped).
- `synapse-cli gate <path> [--new-code-only] [--base REF] [--gate FILE] [--rules FILE]`: gathers code-quality + first-party SAST findings, applies the profile, optionally scopes to new/changed code, computes ratings + duplication over that scope, and evaluates the gate. Exits non-zero with the exact failed conditions.

### Why it matters (adoption)
With `--new-code-only`, ratings and new-issue counts are computed over the changed code, so a **brownfield repo can adopt the gate immediately** without fixing all legacy debt — the single biggest adoption lever.

### Verified E2E (git fixture)
```
# whole codebase (legacy self-comparison present)
[FAIL] reliability_rating <= 1 (actual 3)   -> exit 1

# --new-code-only vs base (new code clean)
[PASS] reliability_rating <= 1 (actual 1)   -> quality gate PASSED, exit 0
```
A `.synapse-rules.yaml` disabling the rule, and a custom `.synapse-gate.yaml`, both take effect. Unit tests cover the diff parser, gate evaluation, profile apply, and the YAML loaders.

`go build ./...`, `go vet ./...`, `CGO_ENABLED=0 go build ./cmd/...`, package tests pass locally.

Part of #101. Epic #95.
