### PR TITLE
feat(quality): coverage import + PR decoration (Code Quality Phase 7)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/bincat"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/codeanalysis"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/codeinventory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/coverage"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/duplication"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/enry"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gitdiff"
@@ -130,6 +131,14 @@ func main() {
 			usage()
 		}
 		if err := runGate(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
+			os.Exit(1)
+		}
+	case "coverage":
+		if len(os.Args) < 3 {
+			usage()
+		}
+		if err := runCoverage(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 			os.Exit(1)
 		}
@@ -472,6 +481,8 @@ func runGate(args []string) error {
 	base := "origin/main"
 	gatePath := filepath.Join(dir, ".synapse-gate.yaml")
 	rulesPath := filepath.Join(dir, ".synapse-rules.yaml")
+	covPath := ""
+	markdown := false
 	for i := 1; i < len(args); i++ {
 		switch {
 		case args[i] == "--new-code-only":
@@ -484,6 +495,15 @@ func runGate(args []string) error {
 			i++
 		case args[i] == "--rules" && i+1 < len(args):
 			rulesPath = args[i+1]
+			i++
+		case args[i] == "--coverage" && i+1 < len(args):
+			covPath = args[i+1]
+			i++
+		case args[i] == "--format" && i+1 < len(args):
+			if args[i+1] != "markdown" && args[i+1] != "text" {
+				return fmt.Errorf("--format wants text|markdown, got %q", args[i+1])
+			}
+			markdown = args[i+1] == "markdown"
 			i++
 		default:
 			return fmt.Errorf("unknown or incomplete option %q", args[i])
@@ -524,8 +544,10 @@ func runGate(args []string) error {
 	// change introduced. Ratings are computed over the SAME scope, so "reliability_rating A" means "no
 	// reliability issue in new code", the adoption-friendly semantic.
 	scoped := findings
+	var changed gitdiff.ChangedLines
 	if newCodeOnly {
-		changed, derr := gitdiff.Changed(ctx, dir, base)
+		var derr error
+		changed, derr = gitdiff.Changed(ctx, dir, base)
 		if derr != nil {
 			return fmt.Errorf("new-code diff: %w", derr)
 		}
@@ -544,8 +566,30 @@ func runGate(args []string) error {
 		return fmt.Errorf("duplication: %w", err)
 	}
 
-	// 5. Build the snapshot + evaluate the gate.
+	// 5. Coverage (optional): overall line coverage, or coverage on new code when scoping to a diff.
+	coverageMeasured := false
+	var snapCoverage float64
+	if covPath != "" {
+		covRep, lc, cerr := coverage.Parse(covPath)
+		if cerr != nil {
+			return fmt.Errorf("coverage: %w", cerr)
+		}
+		if newCodeOnly && changed != nil {
+			if pct, ok := lc.NewCodePercent(changed); ok {
+				snapCoverage = pct
+				coverageMeasured = true
+			}
+		} else {
+			snapCoverage = covRep.Percent()
+			coverageMeasured = true
+		}
+	}
+
+	// 6. Build the snapshot + evaluate the gate.
 	snap := buildSnapshot(scoped, rep, dupRep.Density())
+	if coverageMeasured {
+		snap[qualitygate.MetricCoveragePct] = snapCoverage
+	}
 	gate, found, err := qualityprofile.LoadGate(gatePath)
 	if err != nil {
 		return fmt.Errorf("load gate: %w", err)
@@ -559,20 +603,98 @@ func runGate(args []string) error {
 	if newCodeOnly {
 		scopeLabel = "new code vs " + base
 	}
-	fmt.Printf("\nSynapse quality gate – %s (%s)\n", dir, scopeLabel)
-	fmt.Printf("  ratings: security %s · reliability %s · maintainability %s · duplication %.1f%%\n", rep.Security, rep.Reliability, rep.Maintainability, dupRep.Density())
-	for _, cr := range result.Results {
-		mark := "PASS"
-		if !cr.Passed {
-			mark = "FAIL"
+	covLabel := "n/a"
+	if coverageMeasured {
+		covLabel = fmt.Sprintf("%.1f%%", snapCoverage)
+	}
+	if markdown {
+		printGateMarkdown(dir, scopeLabel, rep, dupRep.Density(), covLabel, result)
+	} else {
+		fmt.Printf("\nSynapse quality gate – %s (%s)\n", dir, scopeLabel)
+		fmt.Printf("  ratings: security %s · reliability %s · maintainability %s · duplication %.1f%% · coverage %s\n", rep.Security, rep.Reliability, rep.Maintainability, dupRep.Density(), covLabel)
+		for _, cr := range result.Results {
+			mark := "PASS"
+			if !cr.Passed {
+				mark = "FAIL"
+			}
+			fmt.Printf("  [%s] %s (actual %g)\n", mark, cr.Condition, cr.Actual)
 		}
-		fmt.Printf("  [%s] %s (actual %g)\n", mark, cr.Condition, cr.Actual)
 	}
 	if !result.Passed {
 		return fmt.Errorf("quality gate FAILED: %d condition(s) not met", len(result.Failures()))
 	}
-	fmt.Println("  quality gate PASSED")
+	if !markdown {
+		fmt.Println("  quality gate PASSED")
+	}
 	return nil
+}
+
+// runCoverage parses a coverage report (lcov / cobertura / jacoco, auto-detected) and prints the overall
+// line coverage + the least-covered files, optionally gating on a minimum percentage.
+func runCoverage(args []string) error {
+	path := args[0]
+	if strings.HasPrefix(path, "-") {
+		return fmt.Errorf("first argument must be a report file, got option %q", path)
+	}
+	failBelow := -1.0
+	top := 10
+	for i := 1; i < len(args); i++ {
+		switch {
+		case args[i] == "--fail-below" && i+1 < len(args):
+			p, err := strconv.ParseFloat(args[i+1], 64)
+			if err != nil || p < 0 || p > 100 {
+				return fmt.Errorf("--fail-below wants a percentage 0-100, got %q", args[i+1])
+			}
+			failBelow = p
+			i++
+		case args[i] == "--top" && i+1 < len(args):
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n < 0 {
+				return fmt.Errorf("--top wants a non-negative integer, got %q", args[i+1])
+			}
+			top = n
+			i++
+		default:
+			return fmt.Errorf("unknown or incomplete option %q", args[i])
+		}
+	}
+	rep, _, err := coverage.Parse(path)
+	if err != nil {
+		return fmt.Errorf("coverage: %w", err)
+	}
+	fmt.Printf("\nSynapse coverage – %s\n", path)
+	fmt.Printf("  line coverage: %.1f%% (%d/%d lines, %d files)\n", rep.Percent(), rep.CoveredLines, rep.TotalLines, len(rep.Files))
+	least := rep.LeastCovered(top)
+	if len(least) > 0 {
+		fmt.Printf("  least covered:\n")
+		for _, f := range least {
+			fmt.Printf("    %6.1f%%  %s (%d/%d)\n", f.Percent(), f.File, f.CoveredLines, f.TotalLines)
+		}
+	}
+	if failBelow >= 0 && rep.Percent() < failBelow {
+		return fmt.Errorf("line coverage %.1f%% is below %.1f%%", rep.Percent(), failBelow)
+	}
+	return nil
+}
+
+// printGateMarkdown renders the gate result as a Markdown summary suitable for a PR comment (gh pr comment
+// --body-file). Failed conditions are listed first so a reviewer sees the blockers immediately.
+func printGateMarkdown(dir, scope string, rep rating.Report, dupDensity float64, coverage string, result qualitygate.Result) {
+	status := "✅ **Quality gate passed**"
+	if !result.Passed {
+		status = "❌ **Quality gate failed**"
+	}
+	fmt.Printf("## Synapse quality gate\n\n%s _(%s)_\n\n", status, scope)
+	fmt.Printf("| Rating | Grade |\n|---|---|\n| Security | %s |\n| Reliability | %s |\n| Maintainability | %s |\n", rep.Security, rep.Reliability, rep.Maintainability)
+	fmt.Printf("\nDuplication %.1f%% · Coverage %s\n\n", dupDensity, coverage)
+	fmt.Printf("| Condition | Actual | |\n|---|---|---|\n")
+	for _, cr := range result.Results {
+		mark := "✅"
+		if !cr.Passed {
+			mark = "❌"
+		}
+		fmt.Printf("| `%s` | %g | %s |\n", cr.Condition, cr.Actual, mark)
+	}
 }
 
 // filterNewCode keeps only line-anchored findings that sit on a changed line.
@@ -648,7 +770,8 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  synapse-cli duplication <path> [--min-tokens N] [--fail-on-duplication PCT] [--top N]  # copy-paste detection (blocks, lines, density) – no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli quality <path> [--fail-on SEV] [--min-complexity N] [--sarif]  # maintainability + reliability findings (+ duplication, + complexity via synapse-ast) – no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli rating <path> [--json] [--fail-below GRADE]  # A-E health grades (security/reliability/maintainability) + technical debt – no DB")
-	fmt.Fprintln(os.Stderr, "  synapse-cli gate <path> [--new-code-only] [--base REF] [--gate FILE] [--rules FILE]  # Clean-as-You-Code quality gate (.synapse-gate.yaml / .synapse-rules.yaml) – no DB")
+	fmt.Fprintln(os.Stderr, "  synapse-cli gate <path> [--new-code-only] [--base REF] [--gate FILE] [--rules FILE] [--coverage FILE] [--format text|markdown]  # Clean-as-You-Code quality gate")
+	fmt.Fprintln(os.Stderr, "  synapse-cli coverage <lcov|cobertura|jacoco file> [--fail-below PCT] [--top N]  # parse a coverage report (auto-detected)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories <dir>        # ingest a local OSV dump into the owned advisory store (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote     # fetch + ingest app ecosystems from the OSV bulk bucket (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote-distros # fetch + ingest OS-package advisories (Debian/Alpine) from OSV (large; requires SYNAPSE_DB_DSN)")

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -578,6 +578,10 @@ func runGate(args []string) error {
 			if pct, ok := lc.NewCodePercent(changed); ok {
 				snapCoverage = pct
 				coverageMeasured = true
+			} else {
+				// No changed line matched the report (paths differ, or the diff touched no measurable
+				// line). Note it so an operator is not misled by a silently-absent coverage condition.
+				fmt.Fprintln(os.Stderr, "synapse-cli: note: coverage report matched no changed line (check its paths are repo-relative); coverage condition skipped")
 			}
 		} else {
 			snapCoverage = covRep.Percent()

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -162,4 +162,59 @@ stage('Synapse scan') {
 }
 ```
 
+## Code quality gate (Clean as You Code)
+
+Beyond security, `synapse-cli` measures code health and gates on it. The quality gate can score the
+whole codebase or, with `--new-code-only`, just the lines a branch changed, so a legacy repo can adopt
+the gate without fixing all pre-existing debt first.
+
+```bash
+# fail the build if new code introduces a critical/high issue, a new secret, or drops below A ratings
+synapse-cli gate . --new-code-only --base origin/main
+
+# feed a coverage report (lcov / Cobertura / JaCoCo, auto-detected); a .synapse-gate.yaml can then
+# require e.g. `coverage >= 80` on new code
+synapse-cli gate . --new-code-only --base origin/main --coverage coverage.info
+```
+
+A `.synapse-gate.yaml` overrides the built-in gate, and a `.synapse-rules.yaml` enables/disables rules
+or overrides severities:
+
+```yaml
+# .synapse-gate.yaml
+conditions:
+  - metric: new_critical
+    op: "<="
+    threshold: 0
+  - metric: coverage
+    op: ">="
+    threshold: 80
+```
+
+Inspect coverage on its own:
+
+```bash
+synapse-cli coverage coverage.info --fail-below 80
+```
+
+### PR decoration
+
+Post the gate result as a pull-request comment. `--format markdown` prints a ready-to-post summary:
+
+```yaml
+- name: Synapse quality gate
+  run: |
+    make tools && make build
+    ./bin/synapse-cli gate . --new-code-only --base "origin/${{ github.base_ref }}" \
+      --coverage coverage.info --format markdown > gate.md || echo "GATE_FAILED=1" >> "$GITHUB_ENV"
+- name: Comment the gate on the PR
+  if: always()
+  run: gh pr comment "${{ github.event.pull_request.number }}" --body-file gate.md
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+- name: Fail if the gate failed
+  if: env.GATE_FAILED == '1'
+  run: exit 1
+```
+
 Next: [Architecture](architecture.md)

--- a/internal/domain/measure/coverage.go
+++ b/internal/domain/measure/coverage.go
@@ -1,0 +1,74 @@
+package measure
+
+import "sort"
+
+// FileCoverage is one file's line-coverage summary (executable lines only).
+type FileCoverage struct {
+	File         string `json:"file"`
+	CoveredLines int    `json:"covered_lines"`
+	TotalLines   int    `json:"total_lines"`
+}
+
+// Percent is the file's line-coverage percentage (100 when it has no measurable lines).
+func (f FileCoverage) Percent() float64 {
+	if f.TotalLines == 0 {
+		return 100
+	}
+	return 100 * float64(f.CoveredLines) / float64(f.TotalLines)
+}
+
+// CoverageReport is the whole-tree line coverage parsed from a report file (lcov / cobertura / jacoco).
+type CoverageReport struct {
+	Files        []FileCoverage `json:"files"`
+	CoveredLines int            `json:"covered_lines"`
+	TotalLines   int            `json:"total_lines"`
+}
+
+// Percent is the overall line-coverage percentage (0 when nothing is measurable).
+func (r CoverageReport) Percent() float64 {
+	if r.TotalLines == 0 {
+		return 0
+	}
+	return 100 * float64(r.CoveredLines) / float64(r.TotalLines)
+}
+
+// NewCoverageReport builds a sorted, aggregated report from per-file (line -> covered) data. It is the
+// single place the covered/total counts are derived, so the summary and the raw line map never drift.
+func NewCoverageReport(byFile map[string]map[int]bool) CoverageReport {
+	var rep CoverageReport
+	for file, lines := range byFile {
+		fc := FileCoverage{File: file}
+		for _, covered := range lines {
+			fc.TotalLines++
+			if covered {
+				fc.CoveredLines++
+			}
+		}
+		rep.Files = append(rep.Files, fc)
+		rep.TotalLines += fc.TotalLines
+		rep.CoveredLines += fc.CoveredLines
+	}
+	sort.Slice(rep.Files, func(i, j int) bool { return rep.Files[i].File < rep.Files[j].File })
+	return rep
+}
+
+// LeastCovered returns up to n files with the lowest coverage (and at least one measurable line), worst
+// first, for a "focus here" display.
+func (r CoverageReport) LeastCovered(n int) []FileCoverage {
+	withLines := make([]FileCoverage, 0, len(r.Files))
+	for _, f := range r.Files {
+		if f.TotalLines > 0 {
+			withLines = append(withLines, f)
+		}
+	}
+	sort.SliceStable(withLines, func(i, j int) bool {
+		if withLines[i].Percent() != withLines[j].Percent() {
+			return withLines[i].Percent() < withLines[j].Percent()
+		}
+		return withLines[i].File < withLines[j].File
+	})
+	if n >= 0 && n < len(withLines) {
+		withLines = withLines[:n]
+	}
+	return withLines
+}

--- a/internal/infrastructure/tools/coverage/coverage.go
+++ b/internal/infrastructure/tools/coverage/coverage.go
@@ -1,0 +1,214 @@
+// Package coverage parses a test-coverage report (lcov, Cobertura XML, or JaCoCo XML) into per-file,
+// per-line coverage. The format is auto-detected from the content. Read-only, size-bounded; returns the
+// aggregated measure.CoverageReport plus the raw line map so a caller can compute new-code coverage
+// (changed lines that are covered).
+package coverage
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+)
+
+const maxReportBytes = 256 << 20 // coverage reports can be large; cap defensively
+
+// LineCoverage maps a file path to (line number -> covered). A line present here is an executable line;
+// absent lines are not counted.
+type LineCoverage map[string]map[int]bool
+
+// Parse reads a coverage report file, auto-detects its format, and returns the aggregated report plus the
+// per-line map.
+func Parse(path string) (measure.CoverageReport, LineCoverage, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return measure.CoverageReport{}, nil, fmt.Errorf("stat coverage report: %w", err)
+	}
+	if !fi.Mode().IsRegular() || fi.Size() > maxReportBytes {
+		return measure.CoverageReport{}, nil, fmt.Errorf("%s is not a regular coverage file within %d bytes", path, maxReportBytes)
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- operator-provided report path, regular + size-capped above
+	if err != nil {
+		return measure.CoverageReport{}, nil, fmt.Errorf("read coverage report: %w", err)
+	}
+	return ParseBytes(data)
+}
+
+// ParseBytes parses coverage data whose format is auto-detected: XML with a <coverage> root is Cobertura,
+// XML with a <report> root is JaCoCo, otherwise the data is treated as lcov.
+func ParseBytes(data []byte) (measure.CoverageReport, LineCoverage, error) {
+	trimmed := bytes.TrimSpace(data)
+	var (
+		lc  LineCoverage
+		err error
+	)
+	switch {
+	case bytes.HasPrefix(trimmed, []byte("<")) && bytes.Contains(peek(trimmed), []byte("<report")):
+		lc, err = parseJaCoCo(data)
+	case bytes.HasPrefix(trimmed, []byte("<")) && bytes.Contains(peek(trimmed), []byte("<coverage")):
+		lc, err = parseCobertura(data)
+	default:
+		lc, err = parseLCOV(data)
+	}
+	if err != nil {
+		return measure.CoverageReport{}, nil, err
+	}
+	return measure.NewCoverageReport(lc), lc, nil
+}
+
+// peek returns the first chunk of the data (to sniff the root element past an <?xml?>/doctype prolog).
+func peek(b []byte) []byte {
+	if len(b) > 4096 {
+		return b[:4096]
+	}
+	return b
+}
+
+func mark(lc LineCoverage, file string, line int, covered bool) {
+	if file == "" || line < 1 {
+		return
+	}
+	m := lc[file]
+	if m == nil {
+		m = map[int]bool{}
+		lc[file] = m
+	}
+	// A line covered by any record stays covered (union across duplicate entries / merged reports).
+	if covered {
+		m[line] = true
+	} else if _, ok := m[line]; !ok {
+		m[line] = false
+	}
+}
+
+// parseLCOV parses an lcov .info file: SF:<file> sets the current file, DA:<line>,<hits> records a line.
+func parseLCOV(data []byte) (LineCoverage, error) {
+	lc := LineCoverage{}
+	file := ""
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		switch {
+		case strings.HasPrefix(line, "SF:"):
+			file = strings.TrimSpace(line[3:])
+		case strings.HasPrefix(line, "DA:"):
+			rest := line[3:]
+			comma := strings.IndexByte(rest, ',')
+			if comma < 0 {
+				continue
+			}
+			ln, err1 := strconv.Atoi(strings.TrimSpace(rest[:comma]))
+			hits, err2 := strconv.Atoi(strings.TrimSpace(strings.SplitN(rest[comma+1:], ",", 2)[0]))
+			if err1 != nil || err2 != nil {
+				continue
+			}
+			mark(lc, file, ln, hits > 0)
+		case line == "end_of_record":
+			file = ""
+		}
+	}
+	return lc, nil
+}
+
+// Cobertura XML subset.
+type cobertura struct {
+	Packages struct {
+		Package []struct {
+			Classes struct {
+				Class []struct {
+					Filename string `xml:"filename,attr"`
+					Lines    struct {
+						Line []struct {
+							Number int `xml:"number,attr"`
+							Hits   int `xml:"hits,attr"`
+						} `xml:"line"`
+					} `xml:"lines"`
+				} `xml:"class"`
+			} `xml:"classes"`
+		} `xml:"package"`
+	} `xml:"packages"`
+}
+
+func parseCobertura(data []byte) (LineCoverage, error) {
+	var cov cobertura
+	if err := xml.Unmarshal(data, &cov); err != nil {
+		return nil, fmt.Errorf("parse cobertura: %w", err)
+	}
+	lc := LineCoverage{}
+	for _, p := range cov.Packages.Package {
+		for _, c := range p.Classes.Class {
+			for _, l := range c.Lines.Line {
+				mark(lc, c.Filename, l.Number, l.Hits > 0)
+			}
+		}
+	}
+	return lc, nil
+}
+
+// JaCoCo XML subset. A line is covered when it has covered instructions (ci > 0); ci==0 && mi==0 is a
+// non-executable line and is skipped.
+type jacoco struct {
+	Package []struct {
+		Name       string `xml:"name,attr"`
+		Sourcefile []struct {
+			Name string `xml:"name,attr"`
+			Line []struct {
+				Nr int `xml:"nr,attr"`
+				Mi int `xml:"mi,attr"`
+				Ci int `xml:"ci,attr"`
+			} `xml:"line"`
+		} `xml:"sourcefile"`
+	} `xml:"package"`
+}
+
+func parseJaCoCo(data []byte) (LineCoverage, error) {
+	var rep jacoco
+	if err := xml.Unmarshal(data, &rep); err != nil {
+		return nil, fmt.Errorf("parse jacoco: %w", err)
+	}
+	lc := LineCoverage{}
+	for _, p := range rep.Package {
+		for _, sf := range p.Sourcefile {
+			file := sf.Name
+			if p.Name != "" {
+				file = p.Name + "/" + sf.Name
+			}
+			for _, l := range sf.Line {
+				if l.Ci == 0 && l.Mi == 0 {
+					continue // non-executable line
+				}
+				mark(lc, file, l.Nr, l.Ci > 0)
+			}
+		}
+	}
+	return lc, nil
+}
+
+// NewCodePercent returns the line-coverage percentage over only the changed lines (file -> set), i.e.
+// coverage on new code. changed[file][line] must be true for a changed line. ok=false when no changed
+// line is measurable (so a caller can skip the metric rather than report a misleading 0 or 100).
+func (lc LineCoverage) NewCodePercent(changed map[string]map[int]bool) (pct float64, ok bool) {
+	total, covered := 0, 0
+	for file, lines := range lc {
+		ch := changed[file]
+		if ch == nil {
+			continue
+		}
+		for ln, cov := range lines {
+			if !ch[ln] {
+				continue
+			}
+			total++
+			if cov {
+				covered++
+			}
+		}
+	}
+	if total == 0 {
+		return 0, false
+	}
+	return 100 * float64(covered) / float64(total), true
+}

--- a/internal/infrastructure/tools/coverage/coverage_test.go
+++ b/internal/infrastructure/tools/coverage/coverage_test.go
@@ -1,0 +1,84 @@
+package coverage
+
+import (
+	"math"
+	"testing"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 0.05 }
+
+func TestParseLCOV(t *testing.T) {
+	data := "TN:\nSF:src/a.go\nDA:1,1\nDA:2,0\nDA:3,5\nend_of_record\n"
+	rep, lc, err := ParseBytes([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.TotalLines != 3 || rep.CoveredLines != 2 {
+		t.Errorf("lcov totals: got %d/%d, want 2/3", rep.CoveredLines, rep.TotalLines)
+	}
+	if !approx(rep.Percent(), 66.67) {
+		t.Errorf("percent = %.2f, want ~66.67", rep.Percent())
+	}
+	if !lc["src/a.go"][1] || lc["src/a.go"][2] || !lc["src/a.go"][3] {
+		t.Errorf("lcov line map wrong: %+v", lc["src/a.go"])
+	}
+}
+
+func TestParseCobertura(t *testing.T) {
+	data := `<?xml version="1.0"?>
+<coverage><packages><package><classes>
+<class filename="src/b.py"><lines>
+<line number="1" hits="1"/><line number="2" hits="0"/>
+</lines></class></classes></package></packages></coverage>`
+	rep, _, err := ParseBytes([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.TotalLines != 2 || rep.CoveredLines != 1 {
+		t.Errorf("cobertura totals: got %d/%d, want 1/2", rep.CoveredLines, rep.TotalLines)
+	}
+}
+
+func TestParseJaCoCo(t *testing.T) {
+	data := `<?xml version="1.0"?>
+<report><package name="com/x"><sourcefile name="C.java">
+<line nr="5" mi="0" ci="4"/><line nr="6" mi="2" ci="0"/><line nr="7" mi="0" ci="0"/>
+</sourcefile></package></report>`
+	rep, lc, err := ParseBytes([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.TotalLines != 2 || rep.CoveredLines != 1 { // line 7 (mi=0,ci=0) is non-executable, skipped
+		t.Errorf("jacoco totals: got %d/%d, want 1/2", rep.CoveredLines, rep.TotalLines)
+	}
+	if !lc["com/x/C.java"][5] || lc["com/x/C.java"][6] {
+		t.Errorf("jacoco line map wrong: %+v", lc["com/x/C.java"])
+	}
+	if _, ok := lc["com/x/C.java"][7]; ok {
+		t.Errorf("non-executable line 7 must not be recorded")
+	}
+}
+
+func TestNewCodePercent(t *testing.T) {
+	_, lc, err := ParseBytes([]byte("SF:src/a.go\nDA:1,1\nDA:2,0\nDA:3,5\nend_of_record\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Changed lines 2 (uncovered) + 3 (covered) => 1/2 = 50%. Line 1 is unchanged, excluded.
+	pct, ok := lc.NewCodePercent(map[string]map[int]bool{"src/a.go": {2: true, 3: true}})
+	if !ok || !approx(pct, 50) {
+		t.Errorf("new-code coverage = %.1f ok=%v, want 50", pct, ok)
+	}
+	// No changed line is measurable => ok=false.
+	if _, ok := lc.NewCodePercent(map[string]map[int]bool{"other.go": {9: true}}); ok {
+		t.Errorf("unmeasurable changed set must yield ok=false")
+	}
+}
+
+func TestLeastCovered(t *testing.T) {
+	rep, _, _ := ParseBytes([]byte("SF:hi.go\nDA:1,1\nDA:2,1\nend_of_record\nSF:lo.go\nDA:1,0\nDA:2,0\nend_of_record\n"))
+	lc := rep.LeastCovered(1)
+	if len(lc) != 1 || lc[0].File != "lo.go" {
+		t.Errorf("least-covered should be lo.go, got %+v", lc)
+	}
+}


### PR DESCRIPTION
Implements **Phase 7** of the Code Quality epic (#95, #103): coverage import + PR decoration. Closes the CI loop and finally populates the `coverage` gate metric.

### Coverage import
`internal/infrastructure/tools/coverage` parses **lcov**, **Cobertura XML**, and **JaCoCo XML** (format auto-detected) into per-file, per-line coverage. Read-only, size-bounded. Returns the aggregated `measure.CoverageReport` + the raw line map.

- `measure.CoverageReport` (+ `FileCoverage`, `Percent`, `LeastCovered`).
- `coverage.LineCoverage.NewCodePercent(changed)` computes coverage over **only the changed lines** — Clean-as-You-Code coverage on new code.

### CLI
- `synapse-cli coverage <file> [--fail-below PCT] [--top N]` — overall coverage + least-covered files.
- `synapse-cli gate --coverage <file>` — feeds the `coverage` metric (overall, or **new-code coverage** under `--new-code-only` via the diff), so a gate can require e.g. `coverage >= 80` on new code.
- `synapse-cli gate --format markdown` — a ready-to-post PR-comment summary.

### PR decoration
`docs/guide/cli.md` gains a Clean-as-You-Code gate + coverage + PR-decoration recipe (`gate --format markdown` piped to `gh pr comment`).

### Tested
lcov / Cobertura / JaCoCo parsers, new-code coverage over changed lines, least-covered ranking. E2E-verified: `coverage` command, the gate `coverage` metric whole-codebase (66.7%) and new-code (50% over changed lines), and the markdown output.

`go build ./...`, `go vet ./...`, `CGO_ENABLED=0 go build ./cmd/...`, package tests pass locally.

Part of #103. Epic #95.
