### PR TITLE
feat(quality): deeper bug detection (Code Quality Phase 8)

### DIFF
--- a/cmd/synapse-ast/main.go
+++ b/cmd/synapse-ast/main.go
@@ -20,8 +20,8 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 3 || (os.Args[1] != "functions" && os.Args[1] != "metrics") {
-		fmt.Fprintln(os.Stderr, "usage: synapse-ast functions|metrics <dir>")
+	if len(os.Args) != 3 || (os.Args[1] != "functions" && os.Args[1] != "metrics" && os.Args[1] != "bugs") {
+		fmt.Fprintln(os.Stderr, "usage: synapse-ast functions|metrics|bugs <dir>")
 		os.Exit(2)
 	}
 	var (
@@ -33,6 +33,8 @@ func main() {
 		out, err = astwalk.FunctionsFor(context.Background(), os.Args[2])
 	case "metrics":
 		out, err = astwalk.MetricsFor(context.Background(), os.Args[2])
+	case "bugs":
+		out, err = astwalk.BugsFor(context.Background(), os.Args[2])
 	}
 	if errors.Is(err, astwalk.ErrUnavailable) {
 		fmt.Fprintln(os.Stderr, "synapse-ast:", err)

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -343,6 +343,7 @@ func runQuality(args []string) error {
 		codeanalysis.New(),
 		codequality.WithDuplication(duplication.New(0)),
 		codequality.WithComplexity(ast.New(os.Getenv("SYNAPSE_AST_BIN")), complexityMin),
+		codequality.WithBugs(ast.New(os.Getenv("SYNAPSE_AST_BIN"))),
 	)
 	findings, err := svc.Analyze(context.Background(), dir)
 	if err != nil {
@@ -417,6 +418,7 @@ func runRating(args []string) error {
 		codeanalysis.New(),
 		codequality.WithDuplication(duplication.New(0)),
 		codequality.WithComplexity(ast.New(os.Getenv("SYNAPSE_AST_BIN")), codequality.DefaultComplexityThreshold),
+		codequality.WithBugs(ast.New(os.Getenv("SYNAPSE_AST_BIN"))),
 	)
 	findings, err := svc.Analyze(ctx, dir)
 	if err != nil {
@@ -516,6 +518,7 @@ func runGate(args []string) error {
 		codeanalysis.New(),
 		codequality.WithDuplication(duplication.New(0)),
 		codequality.WithComplexity(ast.New(os.Getenv("SYNAPSE_AST_BIN")), codequality.DefaultComplexityThreshold),
+		codequality.WithBugs(ast.New(os.Getenv("SYNAPSE_AST_BIN"))),
 	)
 	findings, err := svc.Analyze(ctx, dir)
 	if err != nil {

--- a/internal/infrastructure/tools/ast/provider.go
+++ b/internal/infrastructure/tools/ast/provider.go
@@ -46,6 +46,7 @@ func (p *Provider) WithRunner(r ports.ToolRunner) *Provider { p.runner = r; retu
 var (
 	_ ports.ASTProvider         = (*Provider)(nil)
 	_ ports.CodeMetricsProvider = (*Provider)(nil)
+	_ ports.BugDetector         = (*Provider)(nil)
 )
 
 // FunctionCounts runs `synapse-ast functions <root>` and returns per-language function counts. A sidecar
@@ -93,6 +94,37 @@ func (p *Provider) Complexity(ctx context.Context, root string) (measure.Complex
 		return measure.ComplexityReport{}, false, fmt.Errorf("parse synapse-ast metrics: %w", err)
 	}
 	return measure.ComplexityReport{Functions: wire.Functions, Truncated: wire.Truncated}, true, nil
+}
+
+// Bugs runs `synapse-ast bugs <root>` and returns the deterministic reliability defects. A sidecar built
+// without the tree-sitter backend (or an absent binary) maps to available=false so the caller degrades.
+func (p *Provider) Bugs(ctx context.Context, root string) ([]ports.BugFinding, bool, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, false, nil
+	}
+	out, exit, err := p.run(ctx, "bugs", root)
+	if exit == exitUnavailable {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	var wire struct {
+		Bugs []struct {
+			File    string `json:"file"`
+			Line    int    `json:"line"`
+			Rule    string `json:"rule"`
+			Message string `json:"message"`
+		} `json:"bugs"`
+	}
+	if err := json.Unmarshal(out, &wire); err != nil {
+		return nil, false, fmt.Errorf("parse synapse-ast bugs: %w", err)
+	}
+	findings := make([]ports.BugFinding, 0, len(wire.Bugs))
+	for _, b := range wire.Bugs {
+		findings = append(findings, ports.BugFinding{Rule: b.Rule, Message: b.Message, File: b.File, Line: b.Line})
+	}
+	return findings, true, nil
 }
 
 // run executes the sidecar (sandboxed when a runner is set, else direct os/exec) and returns stdout, the

--- a/internal/infrastructure/tools/astwalk/astwalk.go
+++ b/internal/infrastructure/tools/astwalk/astwalk.go
@@ -44,6 +44,21 @@ type Metrics struct {
 	Truncated bool             `json:"truncated,omitempty"`
 }
 
+// Bug is one deterministic reliability defect found by the AST dataflow checks (deeper than the
+// line-pattern rules): a rule id, the file:line it occurs at, and a human message.
+type Bug struct {
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+	Rule    string `json:"rule"`
+	Message string `json:"message"`
+}
+
+// Bugs is the `bugs` wire output.
+type Bugs struct {
+	Bugs      []Bug `json:"bugs"`
+	Truncated bool  `json:"truncated,omitempty"`
+}
+
 const (
 	maxFileBytes = 4 << 20
 	maxFiles     = 200_000

--- a/internal/infrastructure/tools/astwalk/bugs_cgo.go
+++ b/internal/infrastructure/tools/astwalk/bugs_cgo.go
@@ -4,8 +4,8 @@
 // use the tree-sitter AST and intra-block statement order, so they catch defects a regex cannot:
 //   - reliability-unreachable-code: a statement following an unconditional terminator (return/throw/
 //     raise/break/continue) in the same block can never execute.
-//   - reliability-constant-condition: an if/while/do whose condition is a boolean literal is always
-//     taken or never taken (a logic bug or leftover debug flag).
+//   - reliability-constant-condition: an `if` whose condition is a boolean literal is always taken or
+//     never taken (a logic bug or leftover debug flag). Loops are excluded on purpose (see bugSpecs).
 //
 // Deterministic (no LLM); emitted as ungated Kind=reliability findings, like the pattern rules.
 package astwalk
@@ -97,12 +97,17 @@ func detectBugs(root *sitter.Node, content []byte, sp bugSpec, rel string) []Bug
 	return bugs
 }
 
-// unreachable flags the first statement that follows an unconditional terminator in a block.
+// notDeadAfterTerminator are named block children that, appearing after a terminator, are NOT genuinely
+// unreachable: comments; a hoisted JS function declaration (still defined and callable); and an empty
+// statement (a bare ";").
+var notDeadAfterTerminator = set("comment", "function_declaration", "empty_statement")
+
+// unreachable flags the first genuinely-dead statement that follows an unconditional terminator in a block.
 func unreachable(block *sitter.Node, sp bugSpec, rel string) (Bug, bool) {
 	terminated := false
 	for i := 0; i < int(block.NamedChildCount()); i++ {
 		c := block.NamedChild(i)
-		if c.Type() == "comment" {
+		if notDeadAfterTerminator[c.Type()] {
 			continue
 		}
 		if terminated {
@@ -120,7 +125,7 @@ func unreachable(block *sitter.Node, sp bugSpec, rel string) (Bug, bool) {
 	return Bug{}, false
 }
 
-// constantCondition flags an if/while/do whose condition is a boolean literal.
+// constantCondition flags an `if` whose condition is a boolean literal (loops are excluded by bugSpecs).
 func constantCondition(node *sitter.Node, content []byte, rel string) (Bug, bool) {
 	cond := node.ChildByFieldName("condition")
 	if cond == nil {

--- a/internal/infrastructure/tools/astwalk/bugs_cgo.go
+++ b/internal/infrastructure/tools/astwalk/bugs_cgo.go
@@ -1,0 +1,139 @@
+//go:build cgo
+
+// Package astwalk (cgo build): the deeper-bug-detection pass. Unlike the line-pattern rules, these checks
+// use the tree-sitter AST and intra-block statement order, so they catch defects a regex cannot:
+//   - reliability-unreachable-code: a statement following an unconditional terminator (return/throw/
+//     raise/break/continue) in the same block can never execute.
+//   - reliability-constant-condition: an if/while/do whose condition is a boolean literal is always
+//     taken or never taken (a logic bug or leftover debug flag).
+//
+// Deterministic (no LLM); emitted as ungated Kind=reliability findings, like the pattern rules.
+package astwalk
+
+import (
+	"context"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+type bugSpec struct {
+	blocks      map[string]bool // statement-block node types (children are statements)
+	terminators map[string]bool // nodes that unconditionally end control flow
+	condHolders map[string]bool // nodes carrying a "condition" field to constant-check
+}
+
+// condHolders is if_statement ONLY on purpose: `while (true)` / `do {} while (true)` are the idiomatic
+// infinite loop, so flagging a constant loop condition would be a false positive. A constant `if`
+// condition, by contrast, is a real logic bug or a leftover debug flag.
+var bugSpecs = map[string]bugSpec{
+	"Python": {
+		blocks:      set("block"),
+		terminators: set("return_statement", "raise_statement", "break_statement", "continue_statement"),
+		condHolders: set("if_statement"),
+	},
+	"JavaScript": {
+		blocks:      set("statement_block"),
+		terminators: set("return_statement", "throw_statement", "break_statement", "continue_statement"),
+		condHolders: set("if_statement"),
+	},
+	"Java": {
+		blocks:      set("block"),
+		terminators: set("return_statement", "throw_statement", "break_statement", "continue_statement"),
+		condHolders: set("if_statement"),
+	},
+}
+
+var boolLiterals = set("true", "false", "True", "False")
+
+// BugsFor parses every supported-language file under root and returns the deterministic reliability bugs.
+func BugsFor(ctx context.Context, root string) (Bugs, error) {
+	var out Bugs
+	out.Bugs = []Bug{}
+	truncated, err := walkSource(ctx, root, func(rel, lang string, content []byte) {
+		sp, ok := bugSpecs[lang]
+		if !ok {
+			return
+		}
+		root := parseRoot(ctx, sp2spec(lang), content)
+		if root == nil {
+			return
+		}
+		out.Bugs = append(out.Bugs, detectBugs(root, content, sp, rel)...)
+	})
+	if err != nil {
+		return Bugs{}, err
+	}
+	out.Truncated = truncated
+	return out, nil
+}
+
+// sp2spec returns the parse spec (grammar) for a language so BugsFor can parse; the metric `spec` already
+// holds the *sitter.Language, reused here.
+func sp2spec(lang string) spec { return specs[lang] }
+
+// detectBugs walks the tree (iterative DFS) applying the block-level and condition-level checks.
+func detectBugs(root *sitter.Node, content []byte, sp bugSpec, rel string) []Bug {
+	var bugs []Bug
+	stack := []*sitter.Node{root}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		t := n.Type()
+		if sp.blocks[t] {
+			if b, ok := unreachable(n, sp, rel); ok {
+				bugs = append(bugs, b)
+			}
+		}
+		if sp.condHolders[t] {
+			if b, ok := constantCondition(n, content, rel); ok {
+				bugs = append(bugs, b)
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	return bugs
+}
+
+// unreachable flags the first statement that follows an unconditional terminator in a block.
+func unreachable(block *sitter.Node, sp bugSpec, rel string) (Bug, bool) {
+	terminated := false
+	for i := 0; i < int(block.NamedChildCount()); i++ {
+		c := block.NamedChild(i)
+		if c.Type() == "comment" {
+			continue
+		}
+		if terminated {
+			return Bug{
+				File:    rel,
+				Line:    int(c.StartPoint().Row) + 1,
+				Rule:    "reliability-unreachable-code",
+				Message: "statement is unreachable: it follows an unconditional return/throw/break/continue in the same block",
+			}, true
+		}
+		if sp.terminators[c.Type()] {
+			terminated = true
+		}
+	}
+	return Bug{}, false
+}
+
+// constantCondition flags an if/while/do whose condition is a boolean literal.
+func constantCondition(node *sitter.Node, content []byte, rel string) (Bug, bool) {
+	cond := node.ChildByFieldName("condition")
+	if cond == nil {
+		return Bug{}, false
+	}
+	txt := strings.TrimSpace(strings.Trim(strings.TrimSpace(cond.Content(content)), "()"))
+	if !boolLiterals[txt] {
+		return Bug{}, false
+	}
+	return Bug{
+		File:    rel,
+		Line:    int(node.StartPoint().Row) + 1,
+		Rule:    "reliability-constant-condition",
+		Message: "condition is the constant " + txt + ", so the branch is always (or never) taken",
+	}, true
+}

--- a/internal/infrastructure/tools/astwalk/bugs_cgo_test.go
+++ b/internal/infrastructure/tools/astwalk/bugs_cgo_test.go
@@ -56,11 +56,14 @@ func TestBugsForNoFalsePositive(t *testing.T) {
 	root := t.TempDir()
 	// Clean code: a normal if, a normal return, a real infinite loop. No bugs.
 	writeFile(t, root, "c.js", "function ok(x){\n  if (x > 0) { return 1; }\n  while (true) { if (stop()) return 2; }\n  return 0;\n}\n")
+	// A hoisted function declaration after a return is still callable (NOT dead); a trailing empty
+	// statement after a return is not a dead statement either.
+	writeFile(t, root, "d.js", "function h(x){\n  return x;\n  function helper(){ return 1; }\n}\nfunction i(){\n  return 0;\n  ;\n}\n")
 	res, err := BugsFor(context.Background(), root)
 	if err != nil {
 		t.Fatalf("BugsFor: %v", err)
 	}
 	if len(res.Bugs) != 0 {
-		t.Errorf("clean code must yield no bugs, got %+v", res.Bugs)
+		t.Errorf("clean code (incl. hoisted func + empty stmt after return) must yield no bugs, got %+v", res.Bugs)
 	}
 }

--- a/internal/infrastructure/tools/astwalk/bugs_cgo_test.go
+++ b/internal/infrastructure/tools/astwalk/bugs_cgo_test.go
@@ -1,0 +1,66 @@
+//go:build cgo
+
+package astwalk
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBugsForCGO(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "a.py", "def f(x):\n"+
+		"    if x:\n"+
+		"        return 1\n"+
+		"        print(\"dead\")\n"+ // unreachable (after return)
+		"    if True:\n"+ // constant condition
+		"        return 2\n"+
+		"    while True:\n"+ // idiomatic infinite loop: must NOT be flagged
+		"        break\n"+
+		"    return 3\n")
+	writeFile(t, root, "b.js", "function g(x){\n"+
+		"  if (x) { throw new Error('e'); doMore(); }\n"+ // unreachable (after throw)
+		"  if (false) { neverRuns(); }\n"+ // constant condition
+		"  while (true) { if (done()) break; }\n"+ // idiomatic: NOT flagged
+		"  return 0;\n"+
+		"}\n")
+
+	res, err := BugsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("BugsFor: %v", err)
+	}
+	type key struct {
+		file, rule string
+	}
+	got := map[key]bool{}
+	for _, b := range res.Bugs {
+		got[key{b.File, b.Rule}] = true
+	}
+	for _, want := range []key{
+		{"a.py", "reliability-unreachable-code"},
+		{"a.py", "reliability-constant-condition"},
+		{"b.js", "reliability-unreachable-code"},
+		{"b.js", "reliability-constant-condition"},
+	} {
+		if !got[want] {
+			t.Errorf("missing bug %+v (all: %+v)", want, res.Bugs)
+		}
+	}
+	// while(true)/while True must NOT produce a constant-condition bug (idiomatic infinite loop).
+	if len(res.Bugs) != 4 {
+		t.Errorf("want exactly 4 bugs (no while-true false positive), got %d: %+v", len(res.Bugs), res.Bugs)
+	}
+}
+
+func TestBugsForNoFalsePositive(t *testing.T) {
+	root := t.TempDir()
+	// Clean code: a normal if, a normal return, a real infinite loop. No bugs.
+	writeFile(t, root, "c.js", "function ok(x){\n  if (x > 0) { return 1; }\n  while (true) { if (stop()) return 2; }\n  return 0;\n}\n")
+	res, err := BugsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("BugsFor: %v", err)
+	}
+	if len(res.Bugs) != 0 {
+		t.Errorf("clean code must yield no bugs, got %+v", res.Bugs)
+	}
+}

--- a/internal/infrastructure/tools/astwalk/parse_nocgo.go
+++ b/internal/infrastructure/tools/astwalk/parse_nocgo.go
@@ -14,3 +14,7 @@ func FunctionsFor(ctx context.Context, root string) (Result, error) {
 func MetricsFor(ctx context.Context, root string) (Metrics, error) {
 	return Metrics{}, ErrUnavailable
 }
+
+func BugsFor(ctx context.Context, root string) (Bugs, error) {
+	return Bugs{}, ErrUnavailable
+}

--- a/internal/usecase/codequality/service.go
+++ b/internal/usecase/codequality/service.go
@@ -31,6 +31,7 @@ type Service struct {
 	dup           ports.DuplicationScanner
 	metrics       ports.CodeMetricsProvider
 	inventory     ports.CodeInventoryScanner
+	bugs          ports.BugDetector
 	complexityMin int
 }
 
@@ -43,6 +44,16 @@ func WithDuplication(d ports.DuplicationScanner) Option { return func(s *Service
 // WithInventory wires the code-size inventory, enabling Report() to compute ratings + a health summary.
 func WithInventory(inv ports.CodeInventoryScanner) Option {
 	return func(s *Service) { s.inventory = inv }
+}
+
+// WithBugs wires the deeper AST bug detector (unreachable code, constant conditions), emitting its
+// findings as Kind=reliability. Requires the synapse-ast sidecar; degrades to nothing without it.
+func WithBugs(b ports.BugDetector) Option { return func(s *Service) { s.bugs = b } }
+
+// bugCWE maps a deeper-bug rule id to its CWE for the finding.
+var bugCWE = map[string]string{
+	"reliability-unreachable-code":   "CWE-561", // dead code
+	"reliability-constant-condition": "CWE-570", // expression is always false/true
 }
 
 // WithComplexity adds high-complexity maintainability findings (functions over threshold), using the AST
@@ -113,6 +124,18 @@ func (s *Service) analyze(ctx context.Context, root string) ([]finding.Finding, 
 				title := fmt.Sprintf("High cyclomatic complexity: %d (%s)", f.Cyclomatic, f.Name)
 				desc := fmt.Sprintf("Function %q has cyclomatic complexity %d (cognitive %d), above %d. Break it into smaller units to improve testability and readability.", f.Name, f.Cyclomatic, f.Cognitive, s.complexityMin)
 				out = append(out, newFinding("quality", "quality-high-complexity", "CWE-1120", shared.SeverityMedium, title, desc, f.File, f.Line))
+			}
+		}
+	}
+
+	if s.bugs != nil {
+		bugs, available, berr := s.bugs.Bugs(ctx, root)
+		if berr != nil {
+			return nil, measure.DuplicationReport{}, fmt.Errorf("bug detection: %w", berr)
+		}
+		if available {
+			for _, b := range bugs {
+				out = append(out, newFinding("reliability", b.Rule, bugCWE[b.Rule], shared.SeverityMedium, b.Message, b.Message, b.File, b.Line))
 			}
 		}
 	}

--- a/internal/usecase/ports/bugdetector.go
+++ b/internal/usecase/ports/bugdetector.go
@@ -1,0 +1,19 @@
+package ports
+
+import "context"
+
+// BugFinding is one deterministic reliability defect from the deeper (AST dataflow) bug detection: a rule
+// id, a human message, and the source file:line. Kind is always reliability.
+type BugFinding struct {
+	Rule    string
+	Message string
+	File    string
+	Line    int
+}
+
+// BugDetector runs the deeper, AST-based reliability checks (unreachable code, constant conditions, ...)
+// over a source tree via the sandboxed synapse-ast sidecar. available=false when no AST backend is
+// built/wired (a CGO-free build), so a caller degrades rather than failing.
+type BugDetector interface {
+	Bugs(ctx context.Context, root string) (findings []BugFinding, available bool, err error)
+}


### PR DESCRIPTION
Implements **Phase 8** of the Code Quality epic (#95, #105): deeper bug detection — AST dataflow reliability checks that catch defects the line-pattern rules cannot.

Computed in the sandboxed `synapse-ast` sidecar (tree-sitter), so no C parser runs in the server. Deterministic, so emitted as **ungated `Kind=reliability`** findings (this is the "deeper" tier on top of the Phase-3 pattern rules).

### Checks (Python / JavaScript / Java)
- **`reliability-unreachable-code`** (CWE-561): a statement after an unconditional `return`/`throw`/`raise`/`break`/`continue` in the same block. Needs intra-block statement order, not a regex.
- **`reliability-constant-condition`** (CWE-570): an `if` whose condition is a boolean literal. **`while (true)` / `do..while (true)` are deliberately NOT flagged** (idiomatic infinite loop) — no false positive on them, matching what a mature analyzer does.

### Pieces
- `astwalk` (cgo) `bugs` pass + `cmd/synapse-ast bugs <dir>`; CGO-free stub keeps `CGO_ENABLED=0 go build ./cmd/...` green.
- `ports.BugDetector` + the `ast` adapter's `Bugs` (absent/CGO-free sidecar -> `available=false`, no error).
- `codequality.WithBugs` bridges bugs into the finding pipeline as `Kind=reliability`; wired into `synapse-cli quality`/`gate`/`rating`. **Not** wired server-side (pure-Go only there).

### Tested
astwalk cgo fixtures (unreachable + constant-condition across py/js/java + a no-false-positive case including `while(true)`), the bug bridge via a fake detector, adapter unavailable-path, and E2E via `synapse-cli quality` (2 reliability findings with the sidecar; graceful 0 without it).

`go build ./...`, `go vet ./...`, `CGO_ENABLED=0 go build ./cmd/...`, package tests pass locally.

### Note
This is the deterministic dataflow tier (the DBD-class checks). A lower-confidence LLM-assisted tier would instead be judgment-gated; deterministic checks are ungated like the other first-party findings. Framework is ready for more checks (guaranteed null-deref, resource leak) as follow-ups.

Part of #105. Epic #95.
