### PR TITLE
test(quality): add the Phase 8 bug-bridge + adapter-unavailable unit tests

### DIFF
--- a/internal/infrastructure/tools/ast/provider_test.go
+++ b/internal/infrastructure/tools/ast/provider_test.go
@@ -28,6 +28,17 @@ func TestProviderEmptyRoot(t *testing.T) {
 	}
 }
 
+func TestBugsUnavailableWhenBinaryMissing(t *testing.T) {
+	p := New("/nonexistent/synapse-ast-does-not-exist")
+	bugs, available, err := p.Bugs(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("missing binary must not error, got %v", err)
+	}
+	if available || len(bugs) != 0 {
+		t.Errorf("missing binary must report unavailable + no bugs, got available=%v bugs=%d", available, len(bugs))
+	}
+}
+
 func TestComplexityUnavailableWhenBinaryMissing(t *testing.T) {
 	p := New("/nonexistent/synapse-ast-does-not-exist")
 	report, available, err := p.Complexity(context.Background(), t.TempDir())

--- a/internal/usecase/codequality/service_test.go
+++ b/internal/usecase/codequality/service_test.go
@@ -93,6 +93,41 @@ func TestServiceMapsAndBridges(t *testing.T) {
 	}
 }
 
+type fakeBugs struct {
+	bugs      []ports.BugFinding
+	available bool
+}
+
+func (f fakeBugs) Bugs(context.Context, string) ([]ports.BugFinding, bool, error) {
+	return f.bugs, f.available, nil
+}
+
+func TestBugsBridgeEmitsReliability(t *testing.T) {
+	bugs := fakeBugs{available: true, bugs: []ports.BugFinding{
+		{Rule: "reliability-unreachable-code", Message: "unreachable", File: "a.go", Line: 7},
+		{Rule: "reliability-constant-condition", Message: "always true", File: "b.py", Line: 3},
+	}}
+	svc := New(fakeAnalyzer{}, WithBugs(bugs))
+	fs, err := svc.Analyze(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	m := byRule(fs)
+	unr, ok := m["reliability-unreachable-code"]
+	if !ok || unr.Kind != finding.KindReliability || unr.DedupKey != "reliability:reliability-unreachable-code:a.go:7" {
+		t.Errorf("unreachable bug mapping wrong: %+v", unr)
+	}
+	if cc, ok := m["reliability-constant-condition"]; !ok || cc.Kind != finding.KindReliability {
+		t.Errorf("constant-condition bug missing/wrong: %+v", cc)
+	}
+	// unavailable detector emits nothing.
+	svc2 := New(fakeAnalyzer{}, WithBugs(fakeBugs{available: false, bugs: bugs.bugs}))
+	fs2, _ := svc2.Analyze(context.Background(), "root")
+	if len(fs2) != 0 {
+		t.Errorf("unavailable bug detector must emit nothing, got %+v", fs2)
+	}
+}
+
 func TestComplexityUnavailableSkipsBridge(t *testing.T) {
 	svc := New(fakeAnalyzer{}, WithComplexity(fakeMetrics{available: false, rep: measure.ComplexityReport{
 		Functions: []measure.FunctionComplexity{{Name: "x", Cyclomatic: 99}},


### PR DESCRIPTION
Two unit tests written for Phase 8 (#120) that missed the commit's file list: the `codequality.WithBugs` -> Kind=reliability bridge, and the `ast` adapter's `Bugs` unavailable-path (missing binary -> available=false, no error). The feature and the astwalk cgo detection tests were already merged. Tests pass locally.