### PR TITLE
fix(sast): scope language-specific rules + stop generic-sql-execute matching non-SQL .execute() (#122, #123)

### DIFF
--- a/internal/infrastructure/tools/sast/analyzer.go
+++ b/internal/infrastructure/tools/sast/analyzer.go
@@ -264,10 +264,14 @@ func sourceFromContextBlock(lower string, line int) (source, evidence string) {
 }
 
 func (a *Analyzer) findingFromRule(rel string, line int, ruleID string, lines []string, project projectContext) (ports.SASTRawFinding, bool) {
+	ext := strings.ToLower(filepath.Ext(rel))
 	for ri := range a.rules {
 		r := &a.rules[ri]
 		if r.id != ruleID {
 			continue
+		}
+		if !r.appliesTo(ext) {
+			return ports.SASTRawFinding{}, false // honor the language gate on the contextual path too
 		}
 		h := ports.SASTRawFinding{
 			File: rel, Line: line, RuleID: r.id, CWE: r.cwe,

--- a/internal/infrastructure/tools/sast/analyzer_test.go
+++ b/internal/infrastructure/tools/sast/analyzer_test.go
@@ -187,7 +187,10 @@ func TestRuleCorpus(t *testing.T) {
 			tp: []string{
 				`cursor.execute("SELECT * FROM users WHERE id=" + request.args["id"])`,
 				`mysqli_query($db, "SELECT * FROM users WHERE id=".$_GET["id"])`,
-				`stmt.executeQuery("SELECT * FROM users WHERE id=" + id)`, // JDBC bare-execute TP survives the fix
+				`stmt.executeQuery("SELECT * FROM users WHERE id=" + id)`,          // JDBC bare-execute TP survives the fix
+				`mysqli_query($db, "SELECT * FROM users WHERE n='" . $name . "'")`, // PHP indirect concat via `.$`
+				`cursor.execute("SELECT * FROM users WHERE n='{}'".format(name))`,  // Python str.format
+				`cursor.execute(f"SELECT * FROM users WHERE id={uid}")`,            // Python f-string
 			},
 			fp: []string{
 				`cursor.execute("SELECT * FROM users WHERE id=?", [id])`,
@@ -195,6 +198,7 @@ func TestRuleCorpus(t *testing.T) {
 				`taskExecutor.execute(decorator.decorate(command))`,
 				`worker.execute(new KycContext(lookup(id)))`,
 				`pool.execute(() -> counter.add(delta + 1))`,
+				`cursor.execute("SELECT * FROM t WHERE x LIKE '%admin%'")`, // constant LIKE, not injection (guards the dropped `%`)
 			},
 		},
 		{
@@ -427,6 +431,9 @@ func TestLanguageGatedRulesRespectExtensions(t *testing.T) {
 		{"unsafe-deserialization-node-serialize", `const o = unserialize(req.body.data)`, "d.js", "d.go"},
 		// exercises the contextual (multi-line block) path in findingFromRule, not just scanLines
 		{"possible-idor-prisma-id-only", `await prisma.pet.update({ where: { id: petId }, data: body })`, "svc.ts", "svc.go"},
+		// .mts/.cts (TS ESM/CJS) and single-file components must still be scanned by the JS/TS rules
+		{"prisma-raw-sql-unsafe", `await prisma.$queryRawUnsafe(sql)`, "handlers.mts", "handlers.go"},
+		{"dom-xss-inner-html", `el.innerHTML = location.hash`, "App.vue", "app.py"},
 	}
 	for _, c := range cases {
 		fires := t.TempDir()

--- a/internal/infrastructure/tools/sast/analyzer_test.go
+++ b/internal/infrastructure/tools/sast/analyzer_test.go
@@ -425,6 +425,8 @@ func TestLanguageGatedRulesRespectExtensions(t *testing.T) {
 		{"prisma-raw-sql-unsafe", `await prisma.$queryRawUnsafe(sql)`, "db.ts", "db.go"},
 		{"react-dangerous-html", `<div dangerouslySetInnerHTML={{ __html: note }} />`, "View.tsx", "view.py"},
 		{"unsafe-deserialization-node-serialize", `const o = unserialize(req.body.data)`, "d.js", "d.go"},
+		// exercises the contextual (multi-line block) path in findingFromRule, not just scanLines
+		{"possible-idor-prisma-id-only", `await prisma.pet.update({ where: { id: petId }, data: body })`, "svc.ts", "svc.go"},
 	}
 	for _, c := range cases {
 		fires := t.TempDir()

--- a/internal/infrastructure/tools/sast/analyzer_test.go
+++ b/internal/infrastructure/tools/sast/analyzer_test.go
@@ -175,6 +175,7 @@ func TestRuleCorpus(t *testing.T) {
 			rule: "prisma-raw-sql-unsafe",
 			tp:   []string{`await prisma.$queryRawUnsafe(`},
 			fp:   []string{`await prisma.$queryRaw` + "`SELECT * FROM users WHERE id = ${id}`"},
+			file: "case.ts",
 		},
 		{
 			rule: "template-sql-interpolation",
@@ -183,13 +184,24 @@ func TestRuleCorpus(t *testing.T) {
 		},
 		{
 			rule: "generic-sql-dynamic-execute",
-			tp:   []string{`cursor.execute("SELECT * FROM users WHERE id=" + request.args["id"])`, `mysqli_query($db, "SELECT * FROM users WHERE id=".$_GET["id"])`},
-			fp:   []string{`cursor.execute("SELECT * FROM users WHERE id=?", [id])`},
+			tp: []string{
+				`cursor.execute("SELECT * FROM users WHERE id=" + request.args["id"])`,
+				`mysqli_query($db, "SELECT * FROM users WHERE id=".$_GET["id"])`,
+				`stmt.executeQuery("SELECT * FROM users WHERE id=" + id)`, // JDBC bare-execute TP survives the fix
+			},
+			fp: []string{
+				`cursor.execute("SELECT * FROM users WHERE id=?", [id])`,
+				// java.util.concurrent Executor / worker dispatch – NOT SQL. Used to match on the bare `.`.
+				`taskExecutor.execute(decorator.decorate(command))`,
+				`worker.execute(new KycContext(lookup(id)))`,
+				`pool.execute(() -> counter.add(delta + 1))`,
+			},
 		},
 		{
 			rule: "child-process-exec-template",
 			tp:   []string{"exec(`file \"${savedPath}\"`)"},
 			fp:   []string{`execFile("file", [savedPath])`},
+			file: "case.js",
 		},
 		{
 			rule: "generic-command-injection-sink",
@@ -200,6 +212,7 @@ func TestRuleCorpus(t *testing.T) {
 			rule: "unsafe-deserialization-node-serialize",
 			tp:   []string{`const obj = unserialize(req.body.data)`},
 			fp:   []string{`// unserialize user data would be unsafe`},
+			file: "case.js",
 		},
 		{
 			rule: "unsafe-deserialization-generic",
@@ -220,6 +233,7 @@ func TestRuleCorpus(t *testing.T) {
 			rule: "react-dangerous-html",
 			tp:   []string{`<div dangerouslySetInnerHTML={{ __html: note }} />`},
 			fp:   []string{`// dangerouslySetInnerHTML would be unsafe for comments`},
+			file: "case.tsx",
 		},
 		{
 			rule: "server-template-injection",
@@ -255,6 +269,7 @@ func TestRuleCorpus(t *testing.T) {
 			rule: "possible-idor-prisma-id-only",
 			tp:   []string{`await prisma.pet.update({ where: { id: petId }, data: body })`},
 			fp:   []string{`await prisma.pet.update({ where: { id_ownerId: { id: petId, ownerId } }, data })`},
+			file: "case.ts",
 		},
 		{
 			rule: "mass-assignment-request-body",
@@ -275,6 +290,7 @@ func TestRuleCorpus(t *testing.T) {
 			rule: "dom-xss-inner-html",
 			tp:   []string{"el.innerHTML = `<h1>${req.query.name}</h1>`", `container.innerHTML = location.hash`, `document.write(location.search)`, `list.innerHTML += req.body.html`},
 			fp:   []string{`el.innerHTML = ""`, `el.innerHTML = sanitize(userInput)`, "el.innerHTML = `<b>${count}</b>`"},
+			file: "case.js",
 		},
 		{
 			rule: "nosql-injection-request",
@@ -391,6 +407,35 @@ func TestRuleCorpus(t *testing.T) {
 			if n := len(findingsByRule(t, root)[c.rule]); n > 0 {
 				t.Errorf("%s: false-positive %q was wrongly flagged (%d hits)", c.rule, fp, n)
 			}
+		}
+	}
+}
+
+// TestLanguageGatedRulesRespectExtensions locks the fix for the language-scoping bug: a rule whose
+// idiom belongs to one ecosystem (Python SQLAlchemy, Prisma, React/DOM, node-serialize) must fire on
+// its own file type and stay silent on a foreign one, so it can never mislabel e.g. a .java file.
+func TestLanguageGatedRulesRespectExtensions(t *testing.T) {
+	cases := []struct {
+		rule    string
+		snippet string
+		firesIn string // extension where the rule should fire
+		quietIn string // foreign extension where the rule must stay silent
+	}{
+		{"sqlalchemy-raw-sql-dynamic", `db.session.execute(f"SELECT * FROM users WHERE n = '{q}'")`, "svc.py", "Svc.java"},
+		{"prisma-raw-sql-unsafe", `await prisma.$queryRawUnsafe(sql)`, "db.ts", "db.go"},
+		{"react-dangerous-html", `<div dangerouslySetInnerHTML={{ __html: note }} />`, "View.tsx", "view.py"},
+		{"unsafe-deserialization-node-serialize", `const o = unserialize(req.body.data)`, "d.js", "d.go"},
+	}
+	for _, c := range cases {
+		fires := t.TempDir()
+		writeFile(t, fires, c.firesIn, c.snippet+"\n")
+		if len(findingsByRule(t, fires)[c.rule]) == 0 {
+			t.Errorf("%s: expected a finding in %s", c.rule, c.firesIn)
+		}
+		quiet := t.TempDir()
+		writeFile(t, quiet, c.quietIn, c.snippet+"\n")
+		if n := len(findingsByRule(t, quiet)[c.rule]); n > 0 {
+			t.Errorf("%s: must not fire in foreign file %s (%d hits)", c.rule, c.quietIn, n)
 		}
 	}
 }

--- a/internal/infrastructure/tools/sast/patterns.go
+++ b/internal/infrastructure/tools/sast/patterns.go
@@ -38,8 +38,12 @@ var cSourceExts = map[string]bool{
 // Python- or JS/TS-specific pattern (SQLAlchemy, Prisma, React/DOM, node-serialize, ...) can never
 // false-positive on a same-named construct in another language (e.g. the "Python SQLAlchemy" rule
 // firing on a .java file, or a Prisma rule on Go). nil exts stays language-agnostic.
-var pyExts = map[string]bool{".py": true, ".pyi": true, ".pyw": true}
-var jsExts = map[string]bool{".js": true, ".jsx": true, ".mjs": true, ".cjs": true, ".ts": true, ".tsx": true}
+var pyExts = map[string]bool{".py": true, ".pyi": true, ".pyw": true, ".pyx": true}
+var jsExts = map[string]bool{
+	".js": true, ".jsx": true, ".mjs": true, ".cjs": true,
+	".ts": true, ".tsx": true, ".mts": true, ".cts": true, // .mts/.cts are first-class TS ESM/CJS extensions
+	".vue": true, ".svelte": true, ".astro": true, // single-file components embed JS/TS
+}
 
 // placeholderSecret drops obvious non-secrets (env refs, templating, placeholders) so the
 // hardcoded-credential rule stays high-signal – deterministic findings are publishable directly
@@ -175,12 +179,14 @@ func builtinRules() []rule {
 		{
 			id: "generic-sql-dynamic-execute", cwe: "CWE-89", severity: shared.SeverityHigh, title: "SQL execution uses dynamic string construction",
 			desc: "A SQL execution sink appears to receive a string built from request/user-controlled data. Use parameterized queries or ORM query builders.",
-			// The evidence must be a request/interpolation marker OR a string literal that is then
-			// concatenated (`"..." +`). A bare `.` used to count as evidence, which flagged any
+			// The evidence must be a request/interpolation marker, an f-string, OR a string literal that is
+			// then combined dynamically: `"..." +` (concat), `"..." . $var` (PHP concat), or
+			// `"...".format(` (Python). A bare `.` used to count as evidence, which flagged any
 			// `x.execute(y.z(...))` – notably java.util.concurrent Executor.execute(Runnable) – as SQL
-			// injection; requiring a quoted literal before the `+` keeps the JDBC/DBAPI true positives
-			// (stmt.executeQuery("SELECT ..." + q)) while dropping the executor/worker false positives.
-			re:     regexp.MustCompile(`(?i)(cursor\.execute|execute(Query|Update)?|mysqli_query|pg_query|sequelize\.query|ActiveRecord::Base\.connection\.execute)\s*\([^;\n]*(request\.|req\.|params\[|\$_(GET|POST|REQUEST)|\$\{|#\{|["'` + "`" + `][^;\n]*\+)`),
+			// injection; anchoring the concat markers to a preceding quote keeps the JDBC/DBAPI/PHP/Python
+			// true positives while dropping the executor/worker false positives. (Bare `%` is deliberately
+			// excluded: it false-positives on constant `LIKE '%x%'` queries.)
+			re:     regexp.MustCompile(`(?i)(cursor\.execute|execute(Query|Update)?|mysqli_query|pg_query|sequelize\.query|ActiveRecord::Base\.connection\.execute)\s*\([^;\n]*(request\.|req\.|params\[|\$_(GET|POST|REQUEST)|\$\{|#\{|\bf["'` + "`" + `]|["'` + "`" + `][^;\n]*(\+|\.\s*\$|\.format\s*\())`),
 			skipFn: commentOnlyLine,
 		},
 		{

--- a/internal/infrastructure/tools/sast/patterns.go
+++ b/internal/infrastructure/tools/sast/patterns.go
@@ -34,6 +34,13 @@ var cSourceExts = map[string]bool{
 	".hxx": true, ".m": true, ".mm": true,
 }
 
+// pyExts / jsExts gate rules whose sink or idiom belongs to a single language ecosystem, so a
+// Python- or JS/TS-specific pattern (SQLAlchemy, Prisma, React/DOM, node-serialize, ...) can never
+// false-positive on a same-named construct in another language (e.g. the "Python SQLAlchemy" rule
+// firing on a .java file, or a Prisma rule on Go). nil exts stays language-agnostic.
+var pyExts = map[string]bool{".py": true, ".pyi": true, ".pyw": true}
+var jsExts = map[string]bool{".js": true, ".jsx": true, ".mjs": true, ".cjs": true, ".ts": true, ".tsx": true}
+
 // placeholderSecret drops obvious non-secrets (env refs, templating, placeholders) so the
 // hardcoded-credential rule stays high-signal – deterministic findings are publishable directly
 // (no AI gate), so precision matters more than recall here.
@@ -157,6 +164,7 @@ func builtinRules() []rule {
 			desc:   "Prisma $queryRawUnsafe executes string-built SQL. If request-controlled values reach the query string this is SQL injection; use parameterized $queryRaw or Prisma query builders.",
 			re:     regexp.MustCompile(`(?i)\$queryRawUnsafe\s*(<[^>]+>)?\s*[\(\x60]`),
 			skipFn: commentOnlyLine,
+			exts:   jsExts,
 		},
 		{
 			id: "template-sql-interpolation", cwe: "CWE-89", severity: shared.SeverityCritical, title: "SQL string interpolates dynamic data",
@@ -166,8 +174,13 @@ func builtinRules() []rule {
 		},
 		{
 			id: "generic-sql-dynamic-execute", cwe: "CWE-89", severity: shared.SeverityHigh, title: "SQL execution uses dynamic string construction",
-			desc:   "A SQL execution sink appears to receive a string built from request/user-controlled data. Use parameterized queries or ORM query builders.",
-			re:     regexp.MustCompile(`(?i)(cursor\.execute|execute(Query|Update)?|mysqli_query|pg_query|sequelize\.query|ActiveRecord::Base\.connection\.execute)\s*\([^;\n]*(\+|%|\.|\$\{|#\{|params\[|request\.|req\.|\$_(GET|POST|REQUEST))`),
+			desc: "A SQL execution sink appears to receive a string built from request/user-controlled data. Use parameterized queries or ORM query builders.",
+			// The evidence must be a request/interpolation marker OR a string literal that is then
+			// concatenated (`"..." +`). A bare `.` used to count as evidence, which flagged any
+			// `x.execute(y.z(...))` – notably java.util.concurrent Executor.execute(Runnable) – as SQL
+			// injection; requiring a quoted literal before the `+` keeps the JDBC/DBAPI true positives
+			// (stmt.executeQuery("SELECT ..." + q)) while dropping the executor/worker false positives.
+			re:     regexp.MustCompile(`(?i)(cursor\.execute|execute(Query|Update)?|mysqli_query|pg_query|sequelize\.query|ActiveRecord::Base\.connection\.execute)\s*\([^;\n]*(request\.|req\.|params\[|\$_(GET|POST|REQUEST)|\$\{|#\{|["'` + "`" + `][^;\n]*\+)`),
 			skipFn: commentOnlyLine,
 		},
 		{
@@ -181,12 +194,14 @@ func builtinRules() []rule {
 			desc:   "SQLAlchemy/session execution appears to receive dynamically formatted SQL. Use bound parameters instead of f-strings, concatenation, or request-derived interpolation.",
 			re:     regexp.MustCompile(`(?i)(session\.execute|connection\.execute|db\.session\.execute|text)\s*\([^;\n]*(f["']|%|\+|request\.|params\[)`),
 			skipFn: commentOnlyLine,
+			exts:   pyExts,
 		},
 		{
 			id: "child-process-exec-template", cwe: "CWE-78", severity: shared.SeverityCritical, title: "Shell command uses template interpolation",
 			desc:   "child_process.exec runs through a shell. Interpolating paths, filenames, request fields, or other variables can enable command injection; use execFile/spawn with argv and strict validation.",
 			re:     regexp.MustCompile("(?i)\\bexec\\s*\\(\\s*`[^`]*\\$\\{[^}]+}[^`]*`"),
 			skipFn: commentOnlyLine,
+			exts:   jsExts,
 		},
 		{
 			id: "generic-command-injection-sink", cwe: "CWE-78", severity: shared.SeverityHigh, title: "Command execution sink receives dynamic input",
@@ -205,6 +220,7 @@ func builtinRules() []rule {
 			desc:   "node-serialize unserialize() can execute attacker-controlled JavaScript payloads. Never deserialize untrusted request data with this package.",
 			re:     regexp.MustCompile(`(?i)\bunserialize\s*\(`),
 			skipFn: commentOnlyLine,
+			exts:   jsExts,
 		},
 		{
 			id: "unsafe-deserialization-generic", cwe: "CWE-502", severity: shared.SeverityHigh, title: "Unsafe deserialization of potentially untrusted data",
@@ -235,6 +251,7 @@ func builtinRules() []rule {
 			desc:   "dangerouslySetInnerHTML bypasses React escaping. Ensure the value is sanitized server-side and client-side before rendering untrusted content.",
 			re:     regexp.MustCompile(`\bdangerouslySetInnerHTML\b`),
 			skipFn: commentOnlyLine,
+			exts:   jsExts,
 		},
 		{
 			id: "reflected-response-write", cwe: "CWE-79", severity: shared.SeverityHigh, title: "Response writes potentially unescaped request data",
@@ -283,6 +300,7 @@ func builtinRules() []rule {
 			desc:   "A Prisma find/update/delete operation appears to select an object by id only. For user-owned resources, include an owner/tenant/role predicate or perform an explicit authorization check.",
 			re:     regexp.MustCompile(`(?i)prisma\.\w+\.(findUnique|update|delete)\s*\(\s*\{\s*where\s*:\s*\{\s*id\s*[:}]`),
 			skipFn: commentOnlyLine,
+			exts:   jsExts,
 		},
 		{
 			id: "mass-assignment-request-body", cwe: "CWE-915", severity: shared.SeverityMedium, title: "Mass assignment from request body",
@@ -309,6 +327,7 @@ func builtinRules() []rule {
 			// when it carries a taint source. \+?= also catches the innerHTML += append form.
 			re:     regexp.MustCompile(`(?i)(\.(inner|outer)HTML\s*\+?=\s*[^;\n]*(req\.|request\.|params\[|location\.(hash|search|href|pathname)|document\.(URL|referrer|cookie)|window\.name|\$\{[^}]*(req\.|location\.|document\.|params\[))|document\.write\s*\(\s*[^)\n]*(location\.|document\.(URL|referrer)|req\.|params\[|\$\{[^}]*(req\.|location\.|document\.)))`),
 			skipFn: commentOnlyLine,
+			exts:   jsExts,
 		},
 		{
 			id: "nosql-injection-request", cwe: "CWE-943", severity: shared.SeverityHigh, title: "NoSQL query built from request data",


### PR DESCRIPTION
Fixes #122 and #123 — two SAST false-positive classes, verified on a real Java monorepo.

## #122 — language-specific rules fired on foreign files

The `rule` struct already had an `exts` language gate (`appliesTo`), but seven single-ecosystem rules left it nil and so ran on every file. The clearest symptom: the `sqlalchemy-raw-sql-dynamic` rule, titled *"Python SQLAlchemy…"*, fired on `.java` files.

Gated:
- `sqlalchemy-raw-sql-dynamic` → Python (`.py`, `.pyi`, `.pyw`)
- `prisma-raw-sql-unsafe`, `possible-idor-prisma-id-only`, `child-process-exec-template`, `unsafe-deserialization-node-serialize`, `react-dangerous-html`, `dom-xss-inner-html` → JS/TS family (`.js .jsx .mjs .cjs .ts .tsx`)

Language-agnostic rules (generic credential, private key, `generic-sql-dynamic-execute`, …) stay `exts: nil`.

## #123 — `generic-sql-dynamic-execute` matched non-SQL `.execute()`

The taint-evidence group contained a bare literal `.`, so any `x.execute(y.z(...))` matched — most notably `java.util.concurrent` `Executor.execute(Runnable)` and worker dispatch — and was reported as CWE-89 (High). The evidence now requires a request/interpolation marker (`req.`/`request.`/`params[`/`$_GET`/`${`/`#{`) **or** a quoted string literal followed by concatenation (`"..." +`). The bare `execute(` sink stays (JDBC), so `stmt.executeQuery("SELECT … " + q)` still fires.

## Verification (real Java monorepo, not in this repo)

Before: 8 SAST findings including 5 false positives (2× SQLAlchemy-on-Java, 3× `Executor.execute`).
After: those exact 5 disappear; the mass-assignment + hardcoded-credential findings and both secret findings remain. Zero new findings.

Tests: extended the rule corpus (executor negatives + a JDBC positive), set `file:` on the now-gated corpus entries, and added `TestLanguageGatedRulesRespectExtensions` (each gated rule fires in its own language, silent in a foreign one). `go build ./...`, `go vet`, and the full suite pass.
