### PR TITLE
feat(sca): add Conan 1.x python_requires components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **SCA.** Added Conan 1.x node-level `python_requires` components to OwnSBOM output.
 - **SCA.** Added deterministic dependency graph relationships for Conan 1.x `graph_lock` files.
 - **SCA.** Added OwnSBOM support for exact Conan dependencies declared in `conanfile.txt`.
 - **SCA (software composition analysis).** First-party SBOM generation across many

--- a/internal/infrastructure/tools/ownsbom/conan.go
+++ b/internal/infrastructure/tools/ownsbom/conan.go
@@ -16,14 +16,16 @@ import (
 // dependency set produced by the Conan package manager, into Conan
 // components.
 //
-// Two lockfile shapes are supported: the Conan 2.x form lists reference
-// strings under requires, build_requires, and python_requires. The Conan 1.x
-// form stores references in graph_lock nodes. References use the form
-// name/version[@user/channel][#recipe_revision].
+// Two lockfile shapes are supported: Conan 2.x lists reference strings under
+// requires, build_requires, and python_requires. Conan 1.x stores package
+// references and graph relationships in graph_lock nodes. References use the
+// form name/version[@user/channel][#recipe_revision].
 //
-// Conan 1.x graph nodes additionally emit deterministic dependency
-// relationships from requires and build_requires. The parser uses only the
-// Go standard library.
+// Conan 1.x requires and build_requires node IDs emit deterministic dependency
+// relationships. Node-level python_requires references are emitted as development- or
+// background-scoped components only because Conan stores a transitive
+// reference closure rather than direct graph node IDs. The parser uses only
+// the Go standard library.
 type Conan struct{}
 
 // Ecosystem identifies this parser's package ecosystem.
@@ -33,9 +35,10 @@ func (Conan) Ecosystem() string { return "conan" }
 func (Conan) Markers() []string { return []string{"conan.lock", "conanfile.txt"} }
 
 type conanLockNode struct {
-	Ref           string   `json:"ref"`
-	Requires      []string `json:"requires"`
-	BuildRequires []string `json:"build_requires"`
+	Ref            string   `json:"ref"`
+	Requires       []string `json:"requires"`
+	BuildRequires  []string `json:"build_requires"`
+	PythonRequires []string `json:"python_requires"`
 }
 
 // conanLock covers both lockfile shapes: the 2.x top-level reference lists and the 1.x graph_lock nodes.
@@ -49,9 +52,11 @@ type conanLock struct {
 }
 
 // Parse extracts resolved Conan components and, for Conan 1.x graph_lock
-// files, dependency graph edges. Results are sorted deterministically because
-// Conan 1.x nodes are stored in a JSON object and therefore decoded into a Go
-// map with unspecified iteration order.
+// files, dependency relationships from requires and build_requires.
+// Node-level python_requires references are included as components but are
+// not inferred as direct dependency edges.
+// Results are sorted deterministically because Conan 1.x nodes are stored in a
+// JSON object and therefore decoded into a Go map with unspecified iteration order.
 func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
@@ -134,6 +139,17 @@ func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 			Location: in.Path,
 			Scope:    prod,
 		})
+	}
+
+	// Add node-level python_requires after all regular graph components so a
+	// package present in both forms retains its path-derived graph scope.
+	for _, id := range nodeIDs {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		for _, ref := range lock.GraphLock.Nodes[id].PythonRequires {
+			add(ref, dev)
+		}
 	}
 
 	// Pass 2: Aggregate valid dependency edges according to PURL identity, ignoring self-edges.

--- a/internal/infrastructure/tools/ownsbom/conan_test.go
+++ b/internal/infrastructure/tools/ownsbom/conan_test.go
@@ -3,6 +3,7 @@ package ownsbom
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -21,7 +22,9 @@ const conanLockV2Fixture = `{
   "build_requires": [
     "cmake/3.27.0"
   ],
-  "python_requires": []
+  "python_requires": [
+    "config/2.0@company/stable"
+  ]
 }`
 
 // Conan 1.x: a graph_lock whose node ref fields carry the same reference strings.
@@ -35,6 +38,15 @@ const conanLockV1Fixture = `{
   }
 }`
 
+func parseConanTest(t *testing.T, path string, content []byte) ([]sbom.Component, []sbom.Dependency) {
+	t.Helper()
+	comps, deps, err := Conan{}.Parse(context.Background(), ParseInput{Path: path, Content: content})
+	if err != nil {
+		t.Fatalf("parse Conan fixture: %v", err)
+	}
+	return comps, deps
+}
+
 func TestConanParseV2(t *testing.T) {
 	comps, deps, err := Conan{}.Parse(context.Background(), ParseInput{Path: "conan.lock", Content: []byte(conanLockV2Fixture)})
 	if err != nil {
@@ -47,14 +59,20 @@ func TestConanParseV2(t *testing.T) {
 	for _, c := range comps {
 		byName[c.Name] = c
 	}
-	if len(comps) != 3 {
-		t.Fatalf("want 3 components (zlib, openssl, cmake), got %d (%+v)", len(comps), comps)
+	if len(comps) != 4 {
+		t.Fatalf("want 4 components (zlib, openssl, cmake, config), got %d (%+v)", len(comps), comps)
 	}
 	if c := byName["zlib"]; c.PURL != "pkg:conan/zlib@1.2.13" {
 		t.Errorf("zlib PURL wrong (revision must be stripped): %+v", c)
 	}
+	if c := byName["zlib"]; c.Scope != sbom.ScopeProduction {
+		t.Errorf("zlib scope wrong: %+v", c)
+	}
 	if c := byName["openssl"]; c.Version != "3.1.0" {
 		t.Errorf("openssl version wrong (user/channel + revision must be stripped): %+v", c)
+	}
+	if c := byName["config"]; c.Scope != sbom.ScopeDevelopment {
+		t.Errorf("config scope wrong: %+v", c)
 	}
 }
 
@@ -240,7 +258,7 @@ func TestConanParseV1GraphEdgeCases(t *testing.T) {
 			},
 		},
 		{
-			name: "python requires ignored",
+			name: "python requires emitted as components only",
 			fixture: `{
 			  "version": "0.4",
 			  "graph_lock": {
@@ -250,7 +268,7 @@ func TestConanParseV1GraphEdgeCases(t *testing.T) {
 			    }
 			  }
 			}`,
-			wantComps: []string{"pkg:conan/app@1.0", "pkg:conan/lib@3.0"},
+			wantComps: []string{"pkg:conan/app@1.0", "pkg:conan/lib@3.0", "pkg:conan/pyreq@2.0"},
 			wantDeps: []sbom.Dependency{
 				{Ref: "pkg:conan/app@1.0", DependsOn: []string{"pkg:conan/lib@3.0"}},
 			},
@@ -390,21 +408,304 @@ func TestConanRegistryGenerateIncludesGraphEdges(t *testing.T) {
 }
 
 func TestConanParseV1GraphDeterministic(t *testing.T) {
-	firstComps, firstDeps, err := Conan{}.Parse(context.Background(), ParseInput{Path: "conan.lock", Content: []byte(conanLockV1GraphFixture)})
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	firstComps, firstDeps := parseConanTest(t, "conan.lock", []byte(conanLockV1GraphFixture))
 
 	for i := 0; i < 20; i++ {
-		comps, deps, err := Conan{}.Parse(context.Background(), ParseInput{Path: "conan.lock", Content: []byte(conanLockV1GraphFixture)})
-		if err != nil {
-			t.Fatalf("parse: %v", err)
-		}
+		comps, deps := parseConanTest(t, "conan.lock", []byte(conanLockV1GraphFixture))
 		if !reflect.DeepEqual(firstComps, comps) {
 			t.Fatalf("components not deterministic at iter %d", i)
 		}
 		if !reflect.DeepEqual(firstDeps, deps) {
 			t.Fatalf("dependencies not deterministic at iter %d", i)
 		}
+	}
+}
+
+func TestConanParseV1PythonRequiresComponents(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+		  "version": "0.4",
+		  "graph_lock": {
+		    "nodes": {
+		      "0": {
+		        "ref": "app/1.0",
+		        "requires": ["1"],
+		        "python_requires": ["build-config/2.0@company/stable"]
+		      },
+		      "1": { "ref": "lib/3.0" }
+		    }
+		  }
+		}`))
+
+	expectedComps := []sbom.Component{
+		{Name: "app", Version: "1.0", PURL: "pkg:conan/app@1.0", Scope: sbom.ScopeProduction, Location: "conan.lock"},
+		{Name: "build-config", Version: "2.0", PURL: "pkg:conan/build-config@2.0", Scope: sbom.ScopeDevelopment, Location: "conan.lock"},
+		{Name: "lib", Version: "3.0", PURL: "pkg:conan/lib@3.0", Scope: sbom.ScopeProduction, Location: "conan.lock"},
+	}
+
+	if len(comps) != len(expectedComps) {
+		t.Fatalf("want %d components, got %d", len(expectedComps), len(comps))
+	}
+
+	for i, c := range comps {
+		e := expectedComps[i]
+		if c.Name != e.Name || c.Version != e.Version || c.PURL != e.PURL || c.Scope != e.Scope || c.Location != e.Location {
+			t.Errorf("comp %d: want %+v, got %+v", i, e, c)
+		}
+	}
+
+	if len(deps) != 1 || deps[0].Ref != "pkg:conan/app@1.0" || len(deps[0].DependsOn) != 1 || deps[0].DependsOn[0] != "pkg:conan/lib@3.0" {
+		t.Errorf("deps wrong, got: %+v", deps)
+	}
+}
+
+func TestConanParseV1PythonRequiresNormalization(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      string
+		wantPURL string
+	}{
+		{"plain", "config/1.0", "pkg:conan/config@1.0"},
+		{"user channel", "config/1.0@company/stable", "pkg:conan/config@1.0"},
+		{"recipe revision", "config/1.0#rev123", "pkg:conan/config@1.0"},
+		{"user channel and revision", "config/1.0@company/stable#rev123", "pkg:conan/config@1.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := fmt.Sprintf(`{"version":"0.4","graph_lock":{"nodes":{"0":{"python_requires":["%s"]}}}}`, tt.ref)
+			comps, _ := parseConanTest(t, "conan.lock", []byte(fixture))
+			if len(comps) != 1 {
+				t.Fatalf("want 1 component, got %d", len(comps))
+			}
+			if comps[0].PURL != tt.wantPURL {
+				t.Errorf("want PURL %s, got %s", tt.wantPURL, comps[0].PURL)
+			}
+			if comps[0].Name != "config" || comps[0].Version != "1.0" {
+				t.Errorf("name/version wrong: %s/%s", comps[0].Name, comps[0].Version)
+			}
+			if comps[0].Scope != sbom.ScopeDevelopment {
+				t.Errorf("scope wrong, got %s", comps[0].Scope)
+			}
+		})
+	}
+}
+
+func TestConanParseV1PythonRequiresDuplicate(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+		  "version": "0.4",
+		  "graph_lock": {
+		    "nodes": {
+		      "0": {
+		        "ref": "app/1.0",
+		        "python_requires": ["config/1.0", "config/1.0@company/stable", "config/1.0#rev123"]
+		      },
+		      "1": {
+		        "ref": "lib/2.0",
+		        "python_requires": ["config/1.0"]
+		      }
+		    }
+		  }
+		}`))
+	if len(comps) != 3 {
+		t.Fatalf("want 3 components (app, config, lib), got %d", len(comps))
+	}
+	if comps[1].PURL != "pkg:conan/config@1.0" {
+		t.Errorf("config component missing or wrong order: %+v", comps[1])
+	}
+	if len(deps) != 0 {
+		t.Errorf("expected 0 dependencies from python_requires, got %d", len(deps))
+	}
+}
+
+func TestConanParseV1PythonRequiresMalformed(t *testing.T) {
+	comps, _ := parseConanTest(t, "conan.lock", []byte(`{
+		  "version": "0.4",
+		  "graph_lock": {
+		    "nodes": {
+		      "0": {
+		        "python_requires": ["invalid-reference", "config/", " /1.0", "valid/2.0"]
+		      }
+		    }
+		  }
+		}`))
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:conan/valid@2.0" {
+		t.Errorf("want valid/2.0, got %s", comps[0].PURL)
+	}
+}
+
+func TestConanParseV1PythonRequiresRefLessRoot(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+		  "version": "0.4",
+		  "graph_lock": {
+		    "nodes": {
+		      "0": {
+		        "path": "/project/conanfile.py",
+		        "python_requires": ["build-config/2.0"]
+		      },
+		      "1": { "ref": "lib/3.0" }
+		    }
+		  }
+		}`))
+
+	if len(comps) != 2 || comps[0].PURL != "pkg:conan/build-config@2.0" || comps[1].PURL != "pkg:conan/lib@3.0" {
+		t.Errorf("components wrong: %+v", comps)
+	}
+	if len(deps) != 0 {
+		t.Errorf("deps should be empty")
+	}
+}
+
+func TestConanParseV1PythonRequiresScopePrecedence(t *testing.T) {
+	comps, _ := parseConanTest(t, "conan.lock", []byte(`{
+		  "version": "0.4",
+		  "graph_lock": {
+		    "nodes": {
+		      "1": {
+		        "ref": "app/1.0",
+		        "python_requires": ["config/1.0"]
+		      },
+		      "9": {
+		        "ref": "config/1.0"
+		      }
+		    }
+		  }
+		}`))
+	if len(comps) != 2 {
+		t.Fatalf("want 2 comps")
+	}
+	var configComp sbom.Component
+	for _, c := range comps {
+		if c.Name == "config" {
+			configComp = c
+		}
+	}
+	if configComp.Scope != sbom.ScopeProduction {
+		t.Errorf("want config to retain production scope, got %s", configComp.Scope)
+	}
+}
+
+func TestConanParseV1PythonRequiresBackgroundPath(t *testing.T) {
+	comps, _ := parseConanTest(t, "tests/integration/conan.lock", []byte(`{
+		  "version": "0.4",
+		  "graph_lock": {
+		    "nodes": {
+		      "0": { "ref": "app/1.0", "python_requires": ["config/1.0"] }
+		    }
+		  }
+		}`))
+
+	if len(comps) != 2 {
+		t.Fatalf("want 2 components, got %d: %+v", len(comps), comps)
+	}
+
+	want := map[string]bool{
+		"pkg:conan/app@1.0":    true,
+		"pkg:conan/config@1.0": true,
+	}
+
+	for _, c := range comps {
+		if !want[c.PURL] {
+			t.Errorf("unexpected component: %+v", c)
+		}
+		if c.Scope != sbom.ScopeTest {
+			t.Errorf("component %s: want scope %s, got %s", c.PURL, sbom.ScopeTest, c.Scope)
+		}
+	}
+}
+
+func TestConanParseV1PythonRequiresMixedEdgeKinds(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+		  "version": "0.4",
+		  "graph_lock": {
+		    "nodes": {
+		      "0": {
+		        "ref": "app/1.0",
+		        "requires": ["1"],
+		        "build_requires": ["2"],
+		        "python_requires": ["config/3.0"]
+		      },
+		      "1": { "ref": "runtime/1.0" },
+		      "2": { "ref": "cmake/2.0" }
+		    }
+		  }
+		}`))
+	if len(comps) != 4 {
+		t.Fatalf("want 4 components")
+	}
+	if len(deps) != 1 || len(deps[0].DependsOn) != 2 {
+		t.Fatalf("want 1 dep with 2 edges, got %+v", deps)
+	}
+	if deps[0].DependsOn[0] != "pkg:conan/cmake@2.0" || deps[0].DependsOn[1] != "pkg:conan/runtime@1.0" {
+		t.Errorf("DependsOn wrong: %v", deps[0].DependsOn)
+	}
+}
+
+func TestConanParseV1PythonRequiresDoNotInferEdges(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+		  "version": "0.4",
+		  "graph_lock": {
+		    "nodes": {
+		      "0": {
+		        "ref": "app/1.0",
+		        "python_requires": ["direct-config/1.0", "transitive-base/2.0"]
+		      }
+		    }
+		  }
+		}`))
+	if len(comps) != 3 {
+		t.Fatalf("want 3 components")
+	}
+	if len(deps) != 0 {
+		t.Errorf("dependencies should be nil, got: %+v", deps)
+	}
+}
+
+func TestConanParseV1PythonRequiresDeterministic(t *testing.T) {
+	fixture := []byte(`{
+	  "version": "0.4",
+	  "graph_lock": {
+	    "nodes": {
+	      "1": { "ref": "lib-b/1.0", "python_requires": ["config/1.0@user/chan#rev"] },
+	      "0": { "ref": "app/1.0", "requires": ["1"], "python_requires": ["config/1.0"] }
+	    }
+	  }
+	}`)
+	firstComps, firstDeps := parseConanTest(t, "conan.lock", fixture)
+	for i := 0; i < 20; i++ {
+		comps, deps := parseConanTest(t, "conan.lock", fixture)
+		if !reflect.DeepEqual(firstComps, comps) {
+			t.Fatalf("components not deterministic at iter %d", i)
+		}
+		if !reflect.DeepEqual(firstDeps, deps) {
+			t.Fatalf("dependencies not deterministic at iter %d", i)
+		}
+	}
+}
+
+func TestConanRegistryGenerateIncludesPythonRequires(t *testing.T) {
+	dir := t.TempDir()
+	fixture := []byte(`{"version": "0.4", "graph_lock": {"nodes": {"0": {"python_requires": ["config/1.0"]}}}}`)
+	if err := os.WriteFile(filepath.Join(dir, "conan.lock"), fixture, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	doc, err := reg.Generate(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if doc.Source != "ownsbom" || doc.GeneratorVersion != ownsbomVersion {
+		t.Errorf("want source ownsbom and generator %s, got %s and %s", ownsbomVersion, doc.Source, doc.GeneratorVersion)
+	}
+	if len(doc.Components) != 1 || doc.Components[0].Name != "config" {
+		t.Errorf("want 1 config component, got %+v", doc.Components)
+	}
+	if len(doc.Dependencies) != 0 {
+		t.Errorf("want 0 dependencies, got %+v", doc.Dependencies)
 	}
 }

--- a/internal/infrastructure/tools/ownsbom/registry.go
+++ b/internal/infrastructure/tools/ownsbom/registry.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// ownsbomVersion identifies this producer in SBOM provenance. Bump when parser behavior changes.
-	ownsbomVersion = "ownsbom/0.4.0"
+	ownsbomVersion = "ownsbom/0.5.0"
 	// maxManifestBytes caps a single manifest read so a hostile/corrupt repo cannot OOM the scan with an
 	// absurd file. Real manifests are KB–low-MB; exceeding this is malicious or wrong, so it fails loud.
 	maxManifestBytes = 64 << 20


### PR DESCRIPTION
## Summary

Add OwnSBOM component discovery for Conan 1.x node-level `python_requires`.

Conan 1.x stores these entries as resolved package references rather than graph node IDs. OwnSBOM now inventories them as normalized Conan components while intentionally avoiding inferred dependency edges because the lockfile may contain a transitive Python-requirement closure rather than direct dependency topology.

## Changes

* Extend Conan 1.x `graph_lock` nodes with `python_requires`.
* Normalize node-level Python requirement references using the existing Conan reference parser.
* Strip user/channel and recipe-revision suffixes from component identities.
* Emit normalized `pkg:conan/<name>@<version>` components.
* Assign development scope to Python-requirement-only components on normal project paths.
* Preserve existing background scopes for lockfiles under test, fixture, example, or documentation paths.
* Process regular graph components before Python requirements so packages present in both forms retain their graph-derived scope.
* Deduplicate references that normalize to the same PURL.
* Skip malformed or incomplete references without failing the entire lockfile.
* Preserve existing `requires` and `build_requires` dependency relationships.
* Do not infer direct dependency edges from node-level `python_requires`.
* Preserve Conan 2.x and `conanfile.txt` behavior.
* Add focused normalization, deduplication, malformed-input, scope-precedence, background-scope, ref-less-root, mixed-edge, no-inferred-edge, determinism, registry, and regression tests.
* Bump the OwnSBOM generator version to `ownsbom/0.5.0`.
* Update the changelog and Conan parser documentation.

## Why no dependency edges?

Conan 1.x serializes `requires` and `build_requires` as graph node IDs, allowing OwnSBOM to resolve direct dependency relationships.

Node-level `python_requires`, however, are stored as package references and may include transitive Python requirements. Treating every listed reference as a direct edge would flatten the dependency topology and could produce incorrect dependency paths.

This change therefore inventories these packages as components only.

## Scope behavior

For a regular project lockfile:

```text
pkg:conan/app@1.0          production
pkg:conan/build-config@2.0 development
```

For a lockfile under a background path such as `tests/`:

```text
pkg:conan/app@1.0          test
pkg:conan/build-config@2.0 test
```

When the same PURL appears as both a regular graph node and a Python requirement, the regular graph component is processed first and retains its path-derived scope.

## Example

Given:

```json
{
  "version": "0.4",
  "graph_lock": {
    "nodes": {
      "0": {
        "ref": "app/1.0",
        "requires": ["1"],
        "python_requires": [
          "build-config/2.0@company/stable"
        ]
      },
      "1": {
        "ref": "lib/3.0"
      }
    }
  }
}
```

OwnSBOM emits:

```text
Components:
- pkg:conan/app@1.0
- pkg:conan/build-config@2.0
- pkg:conan/lib@3.0

Dependency relationships:
- pkg:conan/app@1.0
  → pkg:conan/lib@3.0
```

No dependency edge is inferred from `app` to `build-config`.

## Non-goals

* No dependency-edge inference from `python_requires`.
* No parsing of `conanfile.py`.
* No Conan CLI or network execution.
* No synthetic project-root component.
* No changes to existing Conan graph topology.
* No changes to the SBOM domain model or parser interfaces.
* No external dependencies.

## Testing

The following checks were executed locally:

```bash
go test ./internal/infrastructure/tools/ownsbom \
  -run 'TestConan' \
  -count=1 \
  -v

go test -race \
  ./internal/infrastructure/tools/ownsbom \
  -count=1

go build ./...
go vet ./...
CGO_ENABLED=0 go build ./cmd/...

cd web
pnpm run typecheck
pnpm build
```

The test suite covers:

* Conan 1.x node-level `python_requires` component discovery;
* user/channel and recipe-revision normalization;
* normalized-PURL deduplication;
* malformed references;
* reference-less consumer roots;
* regular graph scope precedence over Python-requirement scope;
* background-path scope preservation;
* mixed `requires`, `build_requires`, and `python_requires`;
* prevention of inferred Python-requirement edges;
* deterministic component and dependency output;
* registry propagation and generator provenance;
* Conan 1.x graph regression behavior;
* Conan 2.x regression behavior;
* existing `conanfile.txt` parsing and lockfile precedence;
* context cancellation and malformed lockfile handling.

## Local environment note

The focused OwnSBOM suite, race test, backend build, vet, CGO-disabled build, and frontend typecheck/build completed successfully.

A complete local `go test ./...` run was not reported as passing because the Linux sandbox package encountered a WSL-specific environment limitation unrelated to this OwnSBOM change. The Pull Request workflow will provide the authoritative full-suite result.

## Checklist

* [x] Conan 1.x node-level `python_requires` parsed
* [x] Components normalized to Conan PURLs
* [x] User/channel and recipe revisions stripped
* [x] Python-requirement-only scope classified correctly
* [x] Regular graph component scope takes precedence
* [x] Background path scope preserved
* [x] Duplicate normalized identities removed
* [x] Malformed references handled fail-soft
* [x] No direct edges inferred from `python_requires`
* [x] Existing graph relationships preserved
* [x] Conan 2.x behavior preserved
* [x] `conanfile.txt` behavior preserved
* [x] Determinism tested
* [x] Registry integration tested
* [x] Generator version bumped to `ownsbom/0.5.0`
* [x] Changelog updated
* [x] No new dependencies introduced