### PR TITLE
docs(cli): correct the inventory function-count note (#127)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -175,7 +175,8 @@ func runInventory(dir string) error {
 		printInvRow(li)
 	}
 	printInvRow(inv.Totals())
-	fmt.Println("  functions: accurate for Go; other languages land with the multi-language AST phase")
+	fmt.Println("  functions: Go counted in-process; Java/JavaScript/Python via the synapse-ast sidecar")
+	fmt.Println("             (set SYNAPSE_AST_BIN, or have `synapse-ast` on PATH); other languages show n/a")
 	return nil
 }
 


### PR DESCRIPTION
Fixes #127. `runInventory` wires the `synapse-ast` sidecar via `WithASTProvider`, so Java/JavaScript/Python function counts are populated when the sidecar is present; the old note said counts were Go-only. Reworded to reflect actual behavior (Go in-process; Java/JS/Python via the sidecar when `SYNAPSE_AST_BIN`/PATH is set; other languages n/a). No logic change.