### PR TITLE
feat(misconfig): scan docker-compose and GitHub Actions workflows (#126)

### DIFF
--- a/internal/infrastructure/tools/misconfig/compose.go
+++ b/internal/infrastructure/tools/misconfig/compose.go
@@ -1,0 +1,215 @@
+package misconfig
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// isComposeName recognises the conventional Docker Compose file names.
+func isComposeName(name string) bool {
+	n := strings.ToLower(name)
+	switch n {
+	case "docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml":
+		return true
+	}
+	// docker-compose.<env>.yml / compose.override.yaml, etc.
+	return (strings.HasPrefix(n, "docker-compose.") || strings.HasPrefix(n, "compose.")) &&
+		(strings.HasSuffix(n, ".yml") || strings.HasSuffix(n, ".yaml"))
+}
+
+var reComposeServices = regexp.MustCompile(`(?m)^services:\s*$`)
+
+// looksCompose sniffs a non-conventionally-named YAML file that is a Compose file: a top-level
+// `services:` mapping plus at least one service-shaped key. It intentionally does not fire on a
+// Kubernetes manifest (which the caller has already ruled out) since those never have top-level services.
+func looksCompose(data []byte) bool {
+	s := string(data)
+	if !reComposeServices.MatchString(s) {
+		return false
+	}
+	return strings.Contains(s, "image:") || strings.Contains(s, "build:") || strings.Contains(s, "container_name:")
+}
+
+var (
+	reComposePrivileged = regexp.MustCompile(`(?i)^\s*privileged\s*:\s*(?:"true"|'true'|true)\s*$`)
+	reComposeNetHost    = regexp.MustCompile(`(?i)^\s*network_mode\s*:\s*["']?host["']?\s*$`)
+	reComposePIDHost    = regexp.MustCompile(`(?i)^\s*pid\s*:\s*["']?host["']?\s*$`)
+	reComposeIPCHost    = regexp.MustCompile(`(?i)^\s*ipc\s*:\s*["']?host["']?\s*$`)
+	reComposeImage      = regexp.MustCompile(`(?i)^\s*image\s*:\s*(.+?)\s*$`)
+	reComposeCapAdd     = regexp.MustCompile(`(?i)^\s*cap_add\s*:\s*(.*)$`)
+	reComposeEnvKey     = regexp.MustCompile(`(?i)^\s*-?\s*["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*[:=]\s*(.+?)\s*$`)
+	reListItem          = regexp.MustCompile(`^\s*-\s*(.+?)\s*$`)
+)
+
+// indentOf returns the number of leading spaces (tabs count as one) of a line.
+func indentOf(line string) int {
+	n := 0
+	for _, r := range line {
+		if r == ' ' || r == '\t' {
+			n++
+			continue
+		}
+		break
+	}
+	return n
+}
+
+// scanCompose runs the owned Docker Compose checks. It is line-based (so every finding carries an exact
+// line), tracking the current service name for the Resource label and the enclosing `cap_add:` /
+// `environment:` block by indentation.
+func scanCompose(rel string, data []byte) []ports.MisconfigRawFinding {
+	var out []ports.MisconfigRawFinding
+	lines := strings.Split(string(data), "\n")
+
+	service := ""     // current top-level service name (2-space indent under services:)
+	serviceIndent := -1
+	inServices := false
+	capIndent := -1 // indent of the `cap_add:` key; >-1 means following list items are capabilities
+	envIndent := -1 // indent of the `environment:` key
+	res := func() string {
+		if service == "" {
+			return "compose service"
+		}
+		return "compose service " + service
+	}
+
+	for i, raw := range lines {
+		line := strings.TrimRight(raw, "\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		ln := i + 1
+		ind := indentOf(line)
+
+		// Leaving a tracked block once indentation returns to or above the block key's level.
+		if capIndent >= 0 && ind <= capIndent {
+			capIndent = -1
+		}
+		if envIndent >= 0 && ind <= envIndent {
+			envIndent = -1
+		}
+
+		if strings.HasPrefix(trimmed, "services:") && ind == 0 {
+			inServices = true
+			continue
+		}
+		// A new top-level section (networks:, volumes:, ...) ends the services block.
+		if ind == 0 && !strings.HasPrefix(trimmed, "services:") {
+			inServices = false
+		}
+		// A service header: `  name:` directly under services:.
+		if inServices && strings.HasSuffix(trimmed, ":") && !strings.Contains(trimmed, " ") {
+			if serviceIndent == -1 {
+				serviceIndent = ind
+			}
+			if ind == serviceIndent {
+				service = strings.TrimSuffix(trimmed, ":")
+				capIndent, envIndent = -1, -1
+				continue
+			}
+		}
+
+		switch {
+		case reComposePrivileged.MatchString(line):
+			out = append(out, ports.MisconfigRawFinding{
+				File: rel, Line: ln, RuleID: "compose-privileged", Title: "Privileged container",
+				Severity: shared.SeverityHigh, Resource: res(),
+				Description: "A Compose service runs with privileged: true, which disables almost all container isolation (full device access, capabilities, and host kernel interfaces). Remove privileged and grant only the specific capabilities/devices the workload needs.",
+			})
+		case reComposeNetHost.MatchString(line):
+			out = append(out, ports.MisconfigRawFinding{
+				File: rel, Line: ln, RuleID: "compose-host-network", Title: "Host network mode",
+				Severity: shared.SeverityMedium, Resource: res(),
+				Description: "network_mode: host shares the host network namespace, so the container can bind host ports and reach loopback-only services, bypassing network isolation. Use a bridge/user-defined network and publish only the needed ports.",
+			})
+		case reComposePIDHost.MatchString(line):
+			out = append(out, ports.MisconfigRawFinding{
+				File: rel, Line: ln, RuleID: "compose-host-pid", Title: "Host PID namespace",
+				Severity: shared.SeverityMedium, Resource: res(),
+				Description: "pid: host shares the host process namespace, letting the container see and signal host processes. Remove it unless a debugging/monitoring workload genuinely requires host process visibility.",
+			})
+		case reComposeIPCHost.MatchString(line):
+			out = append(out, ports.MisconfigRawFinding{
+				File: rel, Line: ln, RuleID: "compose-host-ipc", Title: "Host IPC namespace",
+				Severity: shared.SeverityLow, Resource: res(),
+				Description: "ipc: host shares the host IPC namespace (shared memory, semaphores), weakening isolation between the container and the host. Remove it unless explicitly required.",
+			})
+		case strings.Contains(line, "/var/run/docker.sock"), strings.Contains(line, "/run/docker.sock"):
+			out = append(out, ports.MisconfigRawFinding{
+				File: rel, Line: ln, RuleID: "compose-docker-socket-mount", Title: "Docker socket mounted into a container",
+				Severity: shared.SeverityHigh, Resource: res(),
+				Description: "Mounting the Docker socket grants the container full control of the Docker daemon, which is equivalent to root on the host (it can start privileged containers or mount host paths). Avoid it; if unavoidable, use a locked-down socket proxy with a minimal allowlist.",
+			})
+		case reComposeCapAdd.MatchString(line):
+			// Inline form `cap_add: [SYS_ADMIN]` or the start of a list block.
+			m := reComposeCapAdd.FindStringSubmatch(line)
+			capIndent = ind
+			if inline := strings.Trim(strings.TrimSpace(m[1]), "[]"); inline != "" {
+				for _, c := range strings.Split(inline, ",") {
+					if f, ok := dangerousCapFinding(strings.TrimSpace(c), rel, ln, res()); ok {
+						out = append(out, f)
+					}
+				}
+			}
+		case capIndent >= 0 && reListItem.MatchString(line):
+			cap := reListItem.FindStringSubmatch(line)[1]
+			if f, ok := dangerousCapFinding(strings.Trim(cap, `"'`), rel, ln, res()); ok {
+				out = append(out, f)
+			}
+		case reComposeImage.MatchString(line):
+			img := strings.Trim(reComposeImage.FindStringSubmatch(line)[1], `"'`)
+			if img != "" && !strings.Contains(img, "$") && !strings.Contains(img, "@sha256:") {
+				if tag := imageTag(img); tag == "" || tag == "latest" {
+					out = append(out, ports.MisconfigRawFinding{
+						File: rel, Line: ln, RuleID: "compose-image-unpinned", Title: "Image is not version-pinned",
+						Severity: shared.SeverityLow, Resource: res(),
+						Description: "The service image uses no tag or :latest, so a redeploy can silently pull a changed or vulnerable image. Pin an explicit version tag, ideally with an @sha256 digest.",
+					})
+				}
+			}
+		case strings.HasSuffix(trimmed, "environment:"):
+			envIndent = ind
+		case envIndent >= 0:
+			if f, ok := composeSecretEnv(line, rel, ln, res()); ok {
+				out = append(out, f)
+			}
+		}
+	}
+	return out
+}
+
+func dangerousCapFinding(cap, rel string, line int, resource string) (ports.MisconfigRawFinding, bool) {
+	if cap == "" || !dangerousCaps[strings.ToUpper(cap)] {
+		return ports.MisconfigRawFinding{}, false
+	}
+	return ports.MisconfigRawFinding{
+		File: rel, Line: line, RuleID: "compose-dangerous-capability", Title: "Dangerous Linux capability added",
+		Severity: shared.SeverityHigh, Resource: resource,
+		Description: "cap_add grants " + clip(strings.ToUpper(cap)) + ", a capability broad enough to escape or compromise the host (e.g. SYS_ADMIN, NET_ADMIN, or ALL). Drop it and add only narrowly-scoped capabilities the workload actually needs.",
+	}, true
+}
+
+// composeSecretEnv flags a literal secret assigned in an environment: entry (list `- KEY=v` or map
+// `KEY: v` form). A value that interpolates a variable ($X / ${X}) or is empty is not a baked secret.
+func composeSecretEnv(line, rel string, ln int, resource string) (ports.MisconfigRawFinding, bool) {
+	m := reComposeEnvKey.FindStringSubmatch(line)
+	if m == nil {
+		return ports.MisconfigRawFinding{}, false
+	}
+	key, val := m[1], strings.Trim(strings.TrimSpace(m[2]), `"'`)
+	if !secretKeyRe.MatchString(key) {
+		return ports.MisconfigRawFinding{}, false
+	}
+	if val == "" || strings.Contains(val, "$") {
+		return ports.MisconfigRawFinding{}, false
+	}
+	return ports.MisconfigRawFinding{
+		File: rel, Line: ln, RuleID: "compose-secret-in-env", Title: "Secret hardcoded in environment",
+		Severity: shared.SeverityMedium, Resource: resource,
+		Description: "A secret-looking environment key (" + clip(key) + ") is assigned a literal value in the Compose file, so the credential lives in source control. Inject it at runtime via an env_file kept out of VCS, a secrets manager, or Docker/Compose secrets.",
+	}, true
+}

--- a/internal/infrastructure/tools/misconfig/compose_actions_test.go
+++ b/internal/infrastructure/tools/misconfig/compose_actions_test.go
@@ -1,0 +1,112 @@
+package misconfig
+
+import "testing"
+
+func TestComposeInsecure(t *testing.T) {
+	compose := `services:
+  web:
+    image: nginx:latest
+    privileged: true
+    network_mode: host
+    pid: host
+    ipc: host
+    cap_add:
+      - SYS_ADMIN
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - DB_PASSWORD=supersecret123
+`
+	got := ruleIDs(scan(t, map[string]string{"docker-compose.yml": compose}))
+	for _, want := range []string{
+		"compose-privileged", "compose-host-network", "compose-host-pid", "compose-host-ipc",
+		"compose-dangerous-capability", "compose-docker-socket-mount", "compose-image-unpinned",
+		"compose-secret-in-env",
+	} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("compose: expected %s; got %v", want, keys(got))
+		}
+	}
+	// The docker-socket finding must name the right line (the volume line, not the service header).
+	if f := got["compose-docker-socket-mount"]; f.Line == 0 {
+		t.Errorf("docker-socket finding has no line")
+	}
+}
+
+func TestComposeClean(t *testing.T) {
+	// A hardened service: pinned image, no privileged/host modes, interpolated (not literal) secret.
+	compose := `services:
+  web:
+    image: nginx:1.27.3@sha256:abc
+    read_only: true
+    environment:
+      - DB_PASSWORD=${DB_PASSWORD}
+      - LOG_LEVEL=info
+`
+	got := ruleIDs(scan(t, map[string]string{"compose.yaml": compose}))
+	for bad := range got {
+		t.Errorf("clean compose should not be flagged, got %s", bad)
+	}
+}
+
+func TestGitHubActionsInsecure(t *testing.T) {
+	wf := `name: ci
+on: pull_request_target
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: greet
+        run: echo "hello ${{ github.event.issue.title }}"
+      - name: multi
+        run: |
+          echo "${{ github.head_ref }}"
+`
+	got := ruleIDs(scan(t, map[string]string{".github/workflows/ci.yml": wf}))
+	for _, want := range []string{
+		"gha-pull-request-target", "gha-permissions-write-all", "gha-unpinned-action", "gha-script-injection",
+	} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("gha: expected %s; got %v", want, keys(got))
+		}
+	}
+}
+
+func TestGitHubActionsClean(t *testing.T) {
+	// SHA-pinned action, safe trigger, untrusted input passed via env (not interpolated into the shell).
+	wf := `name: ci
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: greet
+        env:
+          TITLE: ${{ github.event.issue.title }}
+        run: echo "hello $TITLE"
+`
+	got := ruleIDs(scan(t, map[string]string{".github/workflows/ci.yaml": wf}))
+	for bad := range got {
+		t.Errorf("clean workflow should not be flagged, got %s", bad)
+	}
+}
+
+func TestGitHubActionsRulesGatedToWorkflowPath(t *testing.T) {
+	// The same `uses:`/`run:` content OUTSIDE .github/workflows/ must not trigger the workflow rules
+	// (path gating), and must not be misread as a Compose file either.
+	yaml := `steps:
+  - uses: actions/checkout@v4
+    run: echo "${{ github.event.issue.title }}"
+`
+	got := ruleIDs(scan(t, map[string]string{"docs/example.yaml": yaml}))
+	for _, r := range []string{"gha-unpinned-action", "gha-script-injection"} {
+		if _, ok := got[r]; ok {
+			t.Errorf("%s must not fire outside .github/workflows/; got %v", r, keys(got))
+		}
+	}
+}

--- a/internal/infrastructure/tools/misconfig/githubactions.go
+++ b/internal/infrastructure/tools/misconfig/githubactions.go
@@ -1,0 +1,106 @@
+package misconfig
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// isGitHubActionsPath reports whether a workspace-relative path is a GitHub Actions workflow
+// (.github/workflows/*.yml|*.yaml). Detection is by path, since the filename alone is not distinctive.
+func isGitHubActionsPath(rel string) bool {
+	p := strings.ToLower(filepath.ToSlash(rel))
+	if !strings.Contains(p, ".github/workflows/") {
+		return false
+	}
+	return strings.HasSuffix(p, ".yml") || strings.HasSuffix(p, ".yaml")
+}
+
+var (
+	reGHUses       = regexp.MustCompile(`(?i)^\s*(?:-\s*)?uses\s*:\s*["']?([^"'@\s]+)@([^"'\s#]+)["']?`)
+	reGHSHA        = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	// pull_request_target as a trigger in any form: a block key (`pull_request_target:`), an inline
+	// `on: pull_request_target` / `on: [push, pull_request_target]` scalar/list, or a `- pull_request_target`
+	// list item. `\b` keeps it from matching the safe `pull_request` trigger.
+	reGHPRTarget = regexp.MustCompile(`(?i)^\s*(pull_request_target\s*:|on\s*:.*\bpull_request_target\b|-\s*["']?pull_request_target["']?\s*$)`)
+	reGHWriteAll   = regexp.MustCompile(`(?i)^\s*permissions\s*:\s*write-all\s*$`)
+	reGHRunKey     = regexp.MustCompile(`(?i)^\s*(?:-\s*)?run\s*:`)
+	reGHInjectable = regexp.MustCompile(`(?i)\$\{\{\s*[^}]*(github\.event\.[a-z0-9_.*\[\]]*\.(title|body|message|name|email|ref|label)|github\.head_ref|github\.event\.pull_request\.head\.ref)[^}]*\}\}`)
+)
+
+// scanGitHubActions runs the owned GitHub Actions workflow checks. Line-based so every finding carries an
+// exact line; it tracks the enclosing `run:` block (by indentation) so shell-injection sinks are only
+// flagged inside run scripts.
+func scanGitHubActions(rel string, data []byte) []ports.MisconfigRawFinding {
+	var out []ports.MisconfigRawFinding
+	lines := strings.Split(string(data), "\n")
+
+	runIndent := -1 // indent of the enclosing `run:` key; >-1 means we are inside its script
+
+	for i, raw := range lines {
+		line := strings.TrimRight(raw, "\r")
+		trimmed := strings.TrimSpace(line)
+		ln := i + 1
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		ind := indentOf(line)
+
+		// A run: script block ends when indentation returns to or above the run: key.
+		inRun := false
+		if runIndent >= 0 {
+			if ind > runIndent {
+				inRun = true
+			} else {
+				runIndent = -1
+			}
+		}
+
+		switch {
+		case reGHPRTarget.MatchString(line):
+			out = append(out, ports.MisconfigRawFinding{
+				File: rel, Line: ln, RuleID: "gha-pull-request-target", Title: "Workflow triggers on pull_request_target",
+				Severity: shared.SeverityHigh, Resource: "workflow trigger",
+				Description: "pull_request_target runs with the base repository's secrets and a read/write token while able to check out untrusted PR code. If it checks out and builds/executes the PR head, a fork can exfiltrate secrets or tamper with the repo. Prefer pull_request; if pull_request_target is required, never check out or execute untrusted head code and keep permissions minimal.",
+			})
+		case reGHWriteAll.MatchString(line):
+			out = append(out, ports.MisconfigRawFinding{
+				File: rel, Line: ln, RuleID: "gha-permissions-write-all", Title: "Workflow grants write-all permissions",
+				Severity: shared.SeverityMedium, Resource: "workflow permissions",
+				Description: "permissions: write-all grants the GITHUB_TOKEN write access to every scope, far beyond what most jobs need. Set least-privilege permissions (default read-only at the top level, granting specific write scopes only to the jobs that need them).",
+			})
+		case reGHRunKey.MatchString(line):
+			runIndent = ind
+			if reGHInjectable.MatchString(line) { // single-line `run:` with an inline injectable expression
+				out = append(out, ghInjectionFinding(rel, ln))
+			}
+		case inRun && reGHInjectable.MatchString(line):
+			out = append(out, ghInjectionFinding(rel, ln))
+		case reGHUses.MatchString(line):
+			m := reGHUses.FindStringSubmatch(line)
+			action, ref := m[1], m[2]
+			if strings.HasPrefix(action, "./") || strings.HasPrefix(strings.ToLower(ref), "sha256:") {
+				continue // local composite action, or a docker digest ref (already immutable)
+			}
+			if !reGHSHA.MatchString(ref) {
+				out = append(out, ports.MisconfigRawFinding{
+					File: rel, Line: ln, RuleID: "gha-unpinned-action", Title: "Third-party action not pinned to a commit SHA",
+					Severity: shared.SeverityMedium, Resource: "uses " + clip(action+"@"+ref),
+					Description: "The action is referenced by a mutable tag or branch (" + clip(ref) + ") instead of a full 40-character commit SHA. A compromised or force-pushed tag would run attacker-controlled code with this workflow's token and secrets. Pin to a commit SHA (optionally with a version comment).",
+				})
+			}
+		}
+	}
+	return out
+}
+
+func ghInjectionFinding(rel string, ln int) ports.MisconfigRawFinding {
+	return ports.MisconfigRawFinding{
+		File: rel, Line: ln, RuleID: "gha-script-injection", Title: "Untrusted input interpolated into a run script",
+		Severity: shared.SeverityHigh, Resource: "run step",
+		Description: "A run: script interpolates an attacker-controllable ${{ github.event.* }} / ${{ github.head_ref }} value directly into the shell, allowing script injection (the value is substituted before the shell runs). Pass it through an env: variable and reference it as \"$VAR\" (quoted) instead of interpolating it into the command.",
+	}
+}

--- a/internal/infrastructure/tools/misconfig/scanner.go
+++ b/internal/infrastructure/tools/misconfig/scanner.go
@@ -70,6 +70,8 @@ const (
 	cfgKubernetes
 	cfgTerraform
 	cfgCloudFormation
+	cfgCompose
+	cfgGithubActions
 )
 
 // ScanConfigs walks root, classifies each regular file, and returns located misconfig findings.
@@ -127,10 +129,16 @@ func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.Misconf
 		if e != nil || isBinary(data) {
 			return nil
 		}
+		rel := strings.TrimPrefix(strings.TrimPrefix(path, root), string(os.PathSeparator))
 		if kind == cfgNone {
-			// Decide by content: a Kubernetes manifest declares apiVersion + kind; a CloudFormation
-			// template declares AWSTemplateFormatVersion or a Resources map of AWS:: types.
+			// Decide by path/content: a GitHub Actions workflow lives under .github/workflows/; a Compose
+			// file declares a top-level services: map; a Kubernetes manifest declares apiVersion + kind; a
+			// CloudFormation template declares AWSTemplateFormatVersion or a Resources map of AWS:: types.
 			switch {
+			case isGitHubActionsPath(rel):
+				kind = cfgGithubActions
+			case looksCompose(data):
+				kind = cfgCompose
 			case looksKubernetes(data):
 				kind = cfgKubernetes
 			case looksCloudFormation(data):
@@ -139,7 +147,6 @@ func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.Misconf
 				return nil
 			}
 		}
-		rel := strings.TrimPrefix(strings.TrimPrefix(path, root), string(os.PathSeparator))
 		switch kind {
 		case cfgDockerfile:
 			out = append(out, scanDockerfile(rel, data)...)
@@ -149,6 +156,10 @@ func (s *Scanner) ScanConfigs(ctx context.Context, root string) ([]ports.Misconf
 			out = append(out, scanTerraform(rel, data)...)
 		case cfgCloudFormation:
 			out = append(out, scanCloudFormation(rel, data)...)
+		case cfgCompose:
+			out = append(out, scanCompose(rel, data)...)
+		case cfgGithubActions:
+			out = append(out, scanGitHubActions(rel, data)...)
 		}
 		return nil
 	})
@@ -167,6 +178,9 @@ func classifyName(name string) configKind {
 	}
 	if strings.HasSuffix(strings.ToLower(name), ".tf") {
 		return cfgTerraform
+	}
+	if isComposeName(name) {
+		return cfgCompose
 	}
 	return cfgNone
 }


### PR DESCRIPTION
Fixes #126. Adds two line-based scanners to the misconfig package (which previously covered only Dockerfile/K8s/Helm/Terraform/CloudFormation):

**compose.go** – docker-compose/compose files (conventional name or top-level `services:` sniff): privileged, host network/pid/ipc, mounted Docker socket, dangerous `cap_add`, unpinned image (`:latest`/no tag), literal secrets in `environment` (interpolated `${VARS}` are not flagged).

**githubactions.go** – workflows under `.github/workflows/*.yml|yaml` (path-gated): `pull_request_target`, `permissions: write-all`, third-party actions not pinned to a 40-char commit SHA, and `${{ github.event.* }}`/`${{ github.head_ref }}` interpolated into a `run:` script (indentation-tracked).

Findings carry exact file:line. Table tests cover TP + FP (hardened compose, SHA-pinned + env-var-passed workflow) and the path gate. Full misconfig suite + vet green.