### PR TITLE
fix(misconfig): apply the compose/actions review fixes missed by #131's merge

### DIFF
--- a/internal/infrastructure/tools/misconfig/compose.go
+++ b/internal/infrastructure/tools/misconfig/compose.go
@@ -34,14 +34,17 @@ func looksCompose(data []byte) bool {
 }
 
 var (
-	reComposePrivileged = regexp.MustCompile(`(?i)^\s*privileged\s*:\s*(?:"true"|'true'|true)\s*$`)
-	reComposeNetHost    = regexp.MustCompile(`(?i)^\s*network_mode\s*:\s*["']?host["']?\s*$`)
-	reComposePIDHost    = regexp.MustCompile(`(?i)^\s*pid\s*:\s*["']?host["']?\s*$`)
-	reComposeIPCHost    = regexp.MustCompile(`(?i)^\s*ipc\s*:\s*["']?host["']?\s*$`)
-	reComposeImage      = regexp.MustCompile(`(?i)^\s*image\s*:\s*(.+?)\s*$`)
-	reComposeCapAdd     = regexp.MustCompile(`(?i)^\s*cap_add\s*:\s*(.*)$`)
-	reComposeEnvKey     = regexp.MustCompile(`(?i)^\s*-?\s*["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*[:=]\s*(.+?)\s*$`)
-	reListItem          = regexp.MustCompile(`^\s*-\s*(.+?)\s*$`)
+	reComposePrivileged  = regexp.MustCompile(`(?i)^\s*privileged\s*:\s*(?:"true"|'true'|true)\s*$`)
+	reComposeNetHost     = regexp.MustCompile(`(?i)^\s*network_mode\s*:\s*["']?host["']?\s*$`)
+	reComposePIDHost     = regexp.MustCompile(`(?i)^\s*pid\s*:\s*["']?host["']?\s*$`)
+	reComposeIPCHost     = regexp.MustCompile(`(?i)^\s*ipc\s*:\s*["']?host["']?\s*$`)
+	reComposeUsernsHost  = regexp.MustCompile(`(?i)^\s*userns_mode\s*:\s*["']?host["']?\s*$`)
+	reComposeUnconfined  = regexp.MustCompile(`(?i)(seccomp|apparmor)[:=]unconfined|\blabel[:=]disable\b`)
+	reComposeImage       = regexp.MustCompile(`(?i)^\s*image\s*:\s*(.+?)\s*$`)
+	reComposeCapAdd      = regexp.MustCompile(`(?i)^\s*cap_add\s*:\s*(.*)$`)
+	reComposeEnvKey      = regexp.MustCompile(`(?i)^\s*-?\s*["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*[:=]\s*(.+?)\s*$`)
+	reComposeServiceHead = regexp.MustCompile(`^([A-Za-z0-9._-]+)\s*:\s*(?:&\S+)?\s*$`)
+	reListItem           = regexp.MustCompile(`^\s*-\s*(.+?)\s*$`)
 )
 
 // indentOf returns the number of leading spaces (tabs count as one) of a line.
@@ -59,12 +62,13 @@ func indentOf(line string) int {
 
 // scanCompose runs the owned Docker Compose checks. It is line-based (so every finding carries an exact
 // line), tracking the current service name for the Resource label and the enclosing `cap_add:` /
-// `environment:` block by indentation.
+// `environment:` block by indentation. Environment entries are handled before the single-line rules so an
+// env var whose key happens to look like a directive (e.g. `PRIVILEGED: true`) is not misclassified.
 func scanCompose(rel string, data []byte) []ports.MisconfigRawFinding {
 	var out []ports.MisconfigRawFinding
 	lines := strings.Split(string(data), "\n")
 
-	service := ""     // current top-level service name (2-space indent under services:)
+	service := ""
 	serviceIndent := -1
 	inServices := false
 	capIndent := -1 // indent of the `cap_add:` key; >-1 means following list items are capabilities
@@ -93,104 +97,103 @@ func scanCompose(rel string, data []byte) []ports.MisconfigRawFinding {
 			envIndent = -1
 		}
 
-		if strings.HasPrefix(trimmed, "services:") && ind == 0 {
+		if trimmed == "services:" && ind == 0 {
 			inServices = true
 			continue
 		}
 		// A new top-level section (networks:, volumes:, ...) ends the services block.
-		if ind == 0 && !strings.HasPrefix(trimmed, "services:") {
+		if ind == 0 && trimmed != "services:" {
 			inServices = false
 		}
-		// A service header: `  name:` directly under services:.
-		if inServices && strings.HasSuffix(trimmed, ":") && !strings.Contains(trimmed, " ") {
+		// A service header: `  name:` (optionally with a YAML anchor) directly under services:.
+		if inServices && reComposeServiceHead.MatchString(trimmed) {
 			if serviceIndent == -1 {
 				serviceIndent = ind
 			}
 			if ind == serviceIndent {
-				service = strings.TrimSuffix(trimmed, ":")
+				service = reComposeServiceHead.FindStringSubmatch(trimmed)[1]
 				capIndent, envIndent = -1, -1
 				continue
 			}
 		}
 
-		switch {
-		case reComposePrivileged.MatchString(line):
-			out = append(out, ports.MisconfigRawFinding{
-				File: rel, Line: ln, RuleID: "compose-privileged", Title: "Privileged container",
-				Severity: shared.SeverityHigh, Resource: res(),
-				Description: "A Compose service runs with privileged: true, which disables almost all container isolation (full device access, capabilities, and host kernel interfaces). Remove privileged and grant only the specific capabilities/devices the workload needs.",
-			})
-		case reComposeNetHost.MatchString(line):
-			out = append(out, ports.MisconfigRawFinding{
-				File: rel, Line: ln, RuleID: "compose-host-network", Title: "Host network mode",
-				Severity: shared.SeverityMedium, Resource: res(),
-				Description: "network_mode: host shares the host network namespace, so the container can bind host ports and reach loopback-only services, bypassing network isolation. Use a bridge/user-defined network and publish only the needed ports.",
-			})
-		case reComposePIDHost.MatchString(line):
-			out = append(out, ports.MisconfigRawFinding{
-				File: rel, Line: ln, RuleID: "compose-host-pid", Title: "Host PID namespace",
-				Severity: shared.SeverityMedium, Resource: res(),
-				Description: "pid: host shares the host process namespace, letting the container see and signal host processes. Remove it unless a debugging/monitoring workload genuinely requires host process visibility.",
-			})
-		case reComposeIPCHost.MatchString(line):
-			out = append(out, ports.MisconfigRawFinding{
-				File: rel, Line: ln, RuleID: "compose-host-ipc", Title: "Host IPC namespace",
-				Severity: shared.SeverityLow, Resource: res(),
-				Description: "ipc: host shares the host IPC namespace (shared memory, semaphores), weakening isolation between the container and the host. Remove it unless explicitly required.",
-			})
-		case strings.Contains(line, "/var/run/docker.sock"), strings.Contains(line, "/run/docker.sock"):
-			out = append(out, ports.MisconfigRawFinding{
-				File: rel, Line: ln, RuleID: "compose-docker-socket-mount", Title: "Docker socket mounted into a container",
-				Severity: shared.SeverityHigh, Resource: res(),
-				Description: "Mounting the Docker socket grants the container full control of the Docker daemon, which is equivalent to root on the host (it can start privileged containers or mount host paths). Avoid it; if unavoidable, use a locked-down socket proxy with a minimal allowlist.",
-			})
-		case reComposeCapAdd.MatchString(line):
-			// Inline form `cap_add: [SYS_ADMIN]` or the start of a list block.
-			m := reComposeCapAdd.FindStringSubmatch(line)
+		// Environment entries first: an env KEY must not be matched by the directive regexes below.
+		if envIndent >= 0 {
+			if f, ok := composeSecretEnv(line, rel, ln, res()); ok {
+				out = append(out, f)
+			}
+			continue
+		}
+		// Capability list items under a cap_add: block.
+		if capIndent >= 0 && reListItem.MatchString(line) {
+			cap := reListItem.FindStringSubmatch(line)[1]
+			if f, ok := dangerousCapFinding(strings.Trim(strings.TrimSpace(cap), `"'`), rel, ln, res()); ok {
+				out = append(out, f)
+			}
+			continue
+		}
+		// Block openers.
+		if trimmed == "environment:" {
+			envIndent = ind
+			continue
+		}
+		if m := reComposeCapAdd.FindStringSubmatch(line); m != nil {
 			capIndent = ind
-			if inline := strings.Trim(strings.TrimSpace(m[1]), "[]"); inline != "" {
+			if inline := strings.Trim(strings.TrimSpace(m[1]), "[]"); inline != "" { // inline `cap_add: [SYS_ADMIN]`
 				for _, c := range strings.Split(inline, ",") {
-					if f, ok := dangerousCapFinding(strings.TrimSpace(c), rel, ln, res()); ok {
+					if f, ok := dangerousCapFinding(strings.Trim(strings.TrimSpace(c), `"'`), rel, ln, res()); ok {
 						out = append(out, f)
 					}
 				}
 			}
-		case capIndent >= 0 && reListItem.MatchString(line):
-			cap := reListItem.FindStringSubmatch(line)[1]
-			if f, ok := dangerousCapFinding(strings.Trim(cap, `"'`), rel, ln, res()); ok {
-				out = append(out, f)
-			}
+			continue
+		}
+
+		switch {
+		case reComposePrivileged.MatchString(line):
+			out = append(out, mkCompose(rel, ln, "compose-privileged", "Privileged container", shared.SeverityHigh, res(),
+				"A Compose service runs with privileged: true, which disables almost all container isolation (full device access, capabilities, and host kernel interfaces). Remove privileged and grant only the specific capabilities/devices the workload needs."))
+		case reComposeNetHost.MatchString(line):
+			out = append(out, mkCompose(rel, ln, "compose-host-network", "Host network mode", shared.SeverityMedium, res(),
+				"network_mode: host shares the host network namespace, so the container can bind host ports and reach loopback-only services, bypassing network isolation. Use a bridge/user-defined network and publish only the needed ports."))
+		case reComposePIDHost.MatchString(line):
+			out = append(out, mkCompose(rel, ln, "compose-host-pid", "Host PID namespace", shared.SeverityMedium, res(),
+				"pid: host shares the host process namespace, letting the container see and signal host processes. Remove it unless a debugging/monitoring workload genuinely requires host process visibility."))
+		case reComposeIPCHost.MatchString(line):
+			out = append(out, mkCompose(rel, ln, "compose-host-ipc", "Host IPC namespace", shared.SeverityLow, res(),
+				"ipc: host shares the host IPC namespace (shared memory, semaphores), weakening isolation between the container and the host. Remove it unless explicitly required."))
+		case reComposeUsernsHost.MatchString(line):
+			out = append(out, mkCompose(rel, ln, "compose-userns-host", "User namespace isolation disabled", shared.SeverityMedium, res(),
+				"userns_mode: host disables user-namespace remapping, so the container's root maps to host root. Remove it and rely on userns remapping (or run as a non-root user)."))
+		case reComposeUnconfined.MatchString(line):
+			out = append(out, mkCompose(rel, ln, "compose-unconfined-security-opt", "Container security profile disabled", shared.SeverityHigh, res(),
+				"A security_opt disables a kernel confinement profile (seccomp/AppArmor unconfined, or SELinux label:disable), removing a major layer of syscall/host isolation. Keep the default profiles or supply a tailored one; do not disable them."))
+		case strings.Contains(line, "/var/run/docker.sock"), strings.Contains(line, "/run/docker.sock"):
+			out = append(out, mkCompose(rel, ln, "compose-docker-socket-mount", "Docker socket mounted into a container", shared.SeverityHigh, res(),
+				"Mounting the Docker socket grants the container full control of the Docker daemon, which is equivalent to root on the host (it can start privileged containers or mount host paths). Avoid it; if unavoidable, use a locked-down socket proxy with a minimal allowlist."))
 		case reComposeImage.MatchString(line):
 			img := strings.Trim(reComposeImage.FindStringSubmatch(line)[1], `"'`)
 			if img != "" && !strings.Contains(img, "$") && !strings.Contains(img, "@sha256:") {
 				if tag := imageTag(img); tag == "" || tag == "latest" {
-					out = append(out, ports.MisconfigRawFinding{
-						File: rel, Line: ln, RuleID: "compose-image-unpinned", Title: "Image is not version-pinned",
-						Severity: shared.SeverityLow, Resource: res(),
-						Description: "The service image uses no tag or :latest, so a redeploy can silently pull a changed or vulnerable image. Pin an explicit version tag, ideally with an @sha256 digest.",
-					})
+					out = append(out, mkCompose(rel, ln, "compose-image-unpinned", "Image is not version-pinned", shared.SeverityLow, res(),
+						"The service image uses no tag or :latest, so a redeploy can silently pull a changed or vulnerable image. Pin an explicit version tag, ideally with an @sha256 digest."))
 				}
-			}
-		case strings.HasSuffix(trimmed, "environment:"):
-			envIndent = ind
-		case envIndent >= 0:
-			if f, ok := composeSecretEnv(line, rel, ln, res()); ok {
-				out = append(out, f)
 			}
 		}
 	}
 	return out
 }
 
+func mkCompose(rel string, line int, id, title string, sev shared.Severity, resource, desc string) ports.MisconfigRawFinding {
+	return ports.MisconfigRawFinding{File: rel, Line: line, RuleID: id, Title: title, Severity: sev, Resource: resource, Description: desc}
+}
+
 func dangerousCapFinding(cap, rel string, line int, resource string) (ports.MisconfigRawFinding, bool) {
 	if cap == "" || !dangerousCaps[strings.ToUpper(cap)] {
 		return ports.MisconfigRawFinding{}, false
 	}
-	return ports.MisconfigRawFinding{
-		File: rel, Line: line, RuleID: "compose-dangerous-capability", Title: "Dangerous Linux capability added",
-		Severity: shared.SeverityHigh, Resource: resource,
-		Description: "cap_add grants " + clip(strings.ToUpper(cap)) + ", a capability broad enough to escape or compromise the host (e.g. SYS_ADMIN, NET_ADMIN, or ALL). Drop it and add only narrowly-scoped capabilities the workload actually needs.",
-	}, true
+	return mkCompose(rel, line, "compose-dangerous-capability", "Dangerous Linux capability added", shared.SeverityHigh, resource,
+		"cap_add grants "+clip(strings.ToUpper(cap))+", a capability broad enough to escape or compromise the host (e.g. SYS_ADMIN, NET_ADMIN, or ALL). Drop it and add only narrowly-scoped capabilities the workload actually needs."), true
 }
 
 // composeSecretEnv flags a literal secret assigned in an environment: entry (list `- KEY=v` or map
@@ -207,9 +210,6 @@ func composeSecretEnv(line, rel string, ln int, resource string) (ports.Misconfi
 	if val == "" || strings.Contains(val, "$") {
 		return ports.MisconfigRawFinding{}, false
 	}
-	return ports.MisconfigRawFinding{
-		File: rel, Line: ln, RuleID: "compose-secret-in-env", Title: "Secret hardcoded in environment",
-		Severity: shared.SeverityMedium, Resource: resource,
-		Description: "A secret-looking environment key (" + clip(key) + ") is assigned a literal value in the Compose file, so the credential lives in source control. Inject it at runtime via an env_file kept out of VCS, a secrets manager, or Docker/Compose secrets.",
-	}, true
+	return mkCompose(rel, ln, "compose-secret-in-env", "Secret hardcoded in environment", shared.SeverityMedium, resource,
+		"A secret-looking environment key ("+clip(key)+") is assigned a literal value in the Compose file, so the credential lives in source control. Inject it at runtime via an env_file kept out of VCS, a secrets manager, or Docker/Compose secrets."), true
 }

--- a/internal/infrastructure/tools/misconfig/compose_actions_test.go
+++ b/internal/infrastructure/tools/misconfig/compose_actions_test.go
@@ -96,6 +96,89 @@ jobs:
 	}
 }
 
+func TestGitHubActionsEnvRoutingNotFlagged(t *testing.T) {
+	// The recommended mitigation: pass untrusted input through env: (even AFTER run:) and reference it as
+	// a shell variable. This must NOT be flagged as injection (regression guard for the run-block tracker).
+	wf := `jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "$TITLE"
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+`
+	got := ruleIDs(scan(t, map[string]string{".github/workflows/ci.yml": wf}))
+	if _, ok := got["gha-script-injection"]; ok {
+		t.Errorf("env-routed untrusted input (the mitigation) must not be flagged; got %v", keys(got))
+	}
+}
+
+func TestGitHubActionsNoFalsePositiveInsideRunScript(t *testing.T) {
+	// YAML-looking text echoed inside a run: script must not trigger the trigger/permissions/uses rules.
+	wf := `jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "permissions: write-all"
+          echo "uses: foo/bar@v1"
+`
+	got := ruleIDs(scan(t, map[string]string{".github/workflows/ci.yml": wf}))
+	for _, r := range []string{"gha-permissions-write-all", "gha-unpinned-action"} {
+		if _, ok := got[r]; ok {
+			t.Errorf("%s must not fire on run-script content; got %v", r, keys(got))
+		}
+	}
+}
+
+func TestGitHubActionsCommentedTriggerNotFlagged(t *testing.T) {
+	wf := `on: [push]  # not pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+`
+	got := ruleIDs(scan(t, map[string]string{".github/workflows/ci.yaml": wf}))
+	if _, ok := got["gha-pull-request-target"]; ok {
+		t.Errorf("a commented mention of pull_request_target must not be flagged; got %v", keys(got))
+	}
+}
+
+func TestComposeQuotedInlineCapAndSecurityOpt(t *testing.T) {
+	compose := `services:
+  app:
+    image: alpine:3.20
+    cap_add: ["SYS_ADMIN"]
+    userns_mode: host
+    security_opt:
+      - seccomp:unconfined
+`
+	got := ruleIDs(scan(t, map[string]string{"docker-compose.yml": compose}))
+	for _, want := range []string{"compose-dangerous-capability", "compose-userns-host", "compose-unconfined-security-opt"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("compose: expected %s; got %v", want, keys(got))
+		}
+	}
+}
+
+func TestComposeEnvKeyNotMisclassified(t *testing.T) {
+	// An env var whose key happens to look like a directive must be treated as an env var, not the directive.
+	compose := `services:
+  app:
+    image: alpine:3.20
+    environment:
+      PRIVILEGED: "true"
+      NETWORK_MODE: host
+`
+	got := ruleIDs(scan(t, map[string]string{"compose.yaml": compose}))
+	for _, bad := range []string{"compose-privileged", "compose-host-network"} {
+		if _, ok := got[bad]; ok {
+			t.Errorf("%s must not fire on an environment variable key; got %v", bad, keys(got))
+		}
+	}
+}
+
 func TestGitHubActionsRulesGatedToWorkflowPath(t *testing.T) {
 	// The same `uses:`/`run:` content OUTSIDE .github/workflows/ must not trigger the workflow rules
 	// (path gating), and must not be misread as a Compose file either.

--- a/internal/infrastructure/tools/misconfig/githubactions.go
+++ b/internal/infrastructure/tools/misconfig/githubactions.go
@@ -20,25 +20,64 @@ func isGitHubActionsPath(rel string) bool {
 }
 
 var (
-	reGHUses       = regexp.MustCompile(`(?i)^\s*(?:-\s*)?uses\s*:\s*["']?([^"'@\s]+)@([^"'\s#]+)["']?`)
-	reGHSHA        = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	reGHUses = regexp.MustCompile(`(?i)^\s*(?:-\s*)?uses\s*:\s*["']?([^"'@\s]+)@([^"'\s#]+)["']?`)
+	reGHSHA  = regexp.MustCompile(`(?i)^[0-9a-f]{40}$`)
 	// pull_request_target as a trigger in any form: a block key (`pull_request_target:`), an inline
 	// `on: pull_request_target` / `on: [push, pull_request_target]` scalar/list, or a `- pull_request_target`
 	// list item. `\b` keeps it from matching the safe `pull_request` trigger.
 	reGHPRTarget = regexp.MustCompile(`(?i)^\s*(pull_request_target\s*:|on\s*:.*\bpull_request_target\b|-\s*["']?pull_request_target["']?\s*$)`)
-	reGHWriteAll   = regexp.MustCompile(`(?i)^\s*permissions\s*:\s*write-all\s*$`)
-	reGHRunKey     = regexp.MustCompile(`(?i)^\s*(?:-\s*)?run\s*:`)
-	reGHInjectable = regexp.MustCompile(`(?i)\$\{\{\s*[^}]*(github\.event\.[a-z0-9_.*\[\]]*\.(title|body|message|name|email|ref|label)|github\.head_ref|github\.event\.pull_request\.head\.ref)[^}]*\}\}`)
+	reGHWriteAll = regexp.MustCompile(`(?i)^\s*permissions\s*:\s*write-all\s*$`)
+	// A `run:` (shell) or `script:` (actions/github-script) key opens an injection-tracked block.
+	reGHRunKey = regexp.MustCompile(`(?i)^\s*(?:-\s*)?(?:run|script)\s*:`)
+	// An attacker-controllable expression: an untrusted github.event.* field (ending in a risky suffix)
+	// or github.head_ref / the PR head ref, interpolated via ${{ ... }}.
+	reGHInjectable = regexp.MustCompile(`(?i)\$\{\{\s*[^}]*(github\.event\.[a-z0-9_.*\[\]]*\.[a-z0-9_]*(title|body|message|name|email|ref|label|branch)|github\.head_ref|github\.event\.pull_request\.head\.ref)[^}]*\}\}`)
 )
 
+// keyColumn returns the column (0-based) at which a mapping key begins on a line, skipping leading
+// whitespace and an optional `- ` list-item dash. For `      - run: |` it returns the column of `run`,
+// so a sibling key (`env:`, `with:`) at that same column ends the run block rather than being read as
+// part of the run script (which its deeper-indented lines are).
+func keyColumn(line string) int {
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	if i < len(line) && line[i] == '-' {
+		i++
+		for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+			i++
+		}
+	}
+	return i
+}
+
+// stripYAMLComment removes a trailing `#` comment (a hash at line start or after whitespace, outside
+// quotes) so a comment mentioning a trigger/action does not false-positive.
+func stripYAMLComment(s string) string {
+	inS, inD := false, false
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == '\'' && !inD:
+			inS = !inS
+		case c == '"' && !inS:
+			inD = !inD
+		case c == '#' && !inS && !inD && (i == 0 || s[i-1] == ' ' || s[i-1] == '\t'):
+			return s[:i]
+		}
+	}
+	return s
+}
+
 // scanGitHubActions runs the owned GitHub Actions workflow checks. Line-based so every finding carries an
-// exact line; it tracks the enclosing `run:` block (by indentation) so shell-injection sinks are only
-// flagged inside run scripts.
+// exact line; it tracks the enclosing `run:`/`script:` block by the key's own column so shell-injection
+// sinks are only flagged inside the script (and trigger/permissions/uses checks are not confused by
+// script content that echoes YAML).
 func scanGitHubActions(rel string, data []byte) []ports.MisconfigRawFinding {
 	var out []ports.MisconfigRawFinding
 	lines := strings.Split(string(data), "\n")
 
-	runIndent := -1 // indent of the enclosing `run:` key; >-1 means we are inside its script
+	runCol := -1 // key column of the enclosing run:/script: block; >-1 means we are inside its script
 
 	for i, raw := range lines {
 		line := strings.TrimRight(raw, "\r")
@@ -49,38 +88,39 @@ func scanGitHubActions(rel string, data []byte) []ports.MisconfigRawFinding {
 		}
 		ind := indentOf(line)
 
-		// A run: script block ends when indentation returns to or above the run: key.
+		// A run:/script: block ends when indentation returns to or above the block key's column.
 		inRun := false
-		if runIndent >= 0 {
-			if ind > runIndent {
+		if runCol >= 0 {
+			if ind > runCol {
 				inRun = true
 			} else {
-				runIndent = -1
+				runCol = -1
 			}
 		}
+		code := stripYAMLComment(line) // comment-free view for trigger/permissions/uses matching
 
 		switch {
-		case reGHPRTarget.MatchString(line):
+		case !inRun && reGHPRTarget.MatchString(code):
 			out = append(out, ports.MisconfigRawFinding{
 				File: rel, Line: ln, RuleID: "gha-pull-request-target", Title: "Workflow triggers on pull_request_target",
 				Severity: shared.SeverityHigh, Resource: "workflow trigger",
 				Description: "pull_request_target runs with the base repository's secrets and a read/write token while able to check out untrusted PR code. If it checks out and builds/executes the PR head, a fork can exfiltrate secrets or tamper with the repo. Prefer pull_request; if pull_request_target is required, never check out or execute untrusted head code and keep permissions minimal.",
 			})
-		case reGHWriteAll.MatchString(line):
+		case !inRun && reGHWriteAll.MatchString(code):
 			out = append(out, ports.MisconfigRawFinding{
 				File: rel, Line: ln, RuleID: "gha-permissions-write-all", Title: "Workflow grants write-all permissions",
 				Severity: shared.SeverityMedium, Resource: "workflow permissions",
 				Description: "permissions: write-all grants the GITHUB_TOKEN write access to every scope, far beyond what most jobs need. Set least-privilege permissions (default read-only at the top level, granting specific write scopes only to the jobs that need them).",
 			})
-		case reGHRunKey.MatchString(line):
-			runIndent = ind
-			if reGHInjectable.MatchString(line) { // single-line `run:` with an inline injectable expression
+		case !inRun && reGHRunKey.MatchString(line):
+			runCol = keyColumn(line)
+			if reGHInjectable.MatchString(line) { // single-line run:/script: with an inline injectable expression
 				out = append(out, ghInjectionFinding(rel, ln))
 			}
 		case inRun && reGHInjectable.MatchString(line):
 			out = append(out, ghInjectionFinding(rel, ln))
-		case reGHUses.MatchString(line):
-			m := reGHUses.FindStringSubmatch(line)
+		case !inRun && reGHUses.MatchString(code):
+			m := reGHUses.FindStringSubmatch(code)
 			action, ref := m[1], m[2]
 			if strings.HasPrefix(action, "./") || strings.HasPrefix(strings.ToLower(ref), "sha256:") {
 				continue // local composite action, or a docker digest ref (already immutable)
@@ -101,6 +141,6 @@ func ghInjectionFinding(rel string, ln int) ports.MisconfigRawFinding {
 	return ports.MisconfigRawFinding{
 		File: rel, Line: ln, RuleID: "gha-script-injection", Title: "Untrusted input interpolated into a run script",
 		Severity: shared.SeverityHigh, Resource: "run step",
-		Description: "A run: script interpolates an attacker-controllable ${{ github.event.* }} / ${{ github.head_ref }} value directly into the shell, allowing script injection (the value is substituted before the shell runs). Pass it through an env: variable and reference it as \"$VAR\" (quoted) instead of interpolating it into the command.",
+		Description: "A run:/script: step interpolates an attacker-controllable ${{ github.event.* }} / ${{ github.head_ref }} value directly into the script, allowing injection (the value is substituted before the script runs). Pass it through an env: variable and reference it as \"$VAR\" (quoted) instead of interpolating it into the command.",
 	}
 }


### PR DESCRIPTION
Follow-up to #126/#131. The review-fix commit for the compose + GitHub Actions scanners was not pushed before #131 was squash-merged, so main shipped the initial version. This re-applies those fixes:

- **gha (HIGH FP):** track the `run:`/`script:` block by the key's own column (not the list-dash indent) so a sibling `env:` after `run:` (the recommended mitigation) isn't false-flagged as injection.
- **gha:** gate trigger/permissions/uses checks with `!inRun`; strip trailing `#` comments (quote-aware) before trigger matching; cover `actions/github-script` `script:` sinks; broaden injectable-field suffixes; case-insensitive SHA.
- **compose:** strip quotes on inline `cap_add: ["SYS_ADMIN"]`; evaluate `environment:` entries before directive regexes (so an env key like `PRIVILEGED: true` isn't misclassified); add `security_opt` unconfined + `userns_mode: host`; regex service-header (anchor-tolerant); exact `environment:` header.
- gofmt-clean; tests extended for every fixed case.

Full suite + vet green. Verified on the real Java monorepo: the true misconfigs still surface and the env-routing/comment/env-key cases correctly do not fire.