### PR TITLE
feat(codequality): suppress info-severity smells in test code by default (#125)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -370,6 +370,9 @@ func runQuality(args []string) error {
 			byKind[f.Kind]++
 		}
 		fmt.Printf("  findings: %d (quality: %d, reliability: %d)\n", len(findings), byKind[finding.KindQuality], byKind[finding.KindReliability])
+		if !includeTestSmells {
+			fmt.Println("  note: info-severity smells in test code are hidden (--include-test-smells to show)")
+		}
 		for _, f := range findings {
 			fmt.Printf("    [%-8s %-11s] %s\n", f.Severity, f.Kind, f.Title)
 		}

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -313,6 +313,7 @@ func runQuality(args []string) error {
 	}
 	failOn := ""
 	sarifOut := false
+	includeTestSmells := false
 	complexityMin := codequality.DefaultComplexityThreshold
 	for i := 1; i < len(args); i++ {
 		switch {
@@ -328,6 +329,8 @@ func runQuality(args []string) error {
 			i++
 		case args[i] == "--sarif":
 			sarifOut = true
+		case args[i] == "--include-test-smells":
+			includeTestSmells = true
 		default:
 			return fmt.Errorf("unknown or incomplete option %q", args[i])
 		}
@@ -345,6 +348,7 @@ func runQuality(args []string) error {
 		codequality.WithDuplication(duplication.New(0)),
 		codequality.WithComplexity(ast.New(os.Getenv("SYNAPSE_AST_BIN")), complexityMin),
 		codequality.WithBugs(ast.New(os.Getenv("SYNAPSE_AST_BIN"))),
+		codequality.WithTestScopedSmells(includeTestSmells),
 	)
 	findings, err := svc.Analyze(context.Background(), dir)
 	if err != nil {
@@ -776,7 +780,8 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  synapse-cli inventory <path>             # per-language code-size inventory (files, code/comment/blank lines, functions) – no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli metrics <path> [--fail-on-complexity N] [--top N]  # per-function cyclomatic+cognitive complexity (needs the synapse-ast sidecar)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli duplication <path> [--min-tokens N] [--fail-on-duplication PCT] [--top N]  # copy-paste detection (blocks, lines, density) – no DB")
-	fmt.Fprintln(os.Stderr, "  synapse-cli quality <path> [--fail-on SEV] [--min-complexity N] [--sarif]  # maintainability + reliability findings (+ duplication, + complexity via synapse-ast) – no DB")
+	fmt.Fprintln(os.Stderr, "  synapse-cli quality <path> [--fail-on SEV] [--min-complexity N] [--include-test-smells] [--sarif]  # maintainability + reliability findings (+ duplication, + complexity via synapse-ast) – no DB")
+	fmt.Fprintln(os.Stderr, "      --include-test-smells  also report info-severity smells in test code (suppressed by default)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli rating <path> [--json] [--fail-below GRADE]  # A-E health grades (security/reliability/maintainability) + technical debt – no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli gate <path> [--new-code-only] [--base REF] [--gate FILE] [--rules FILE] [--coverage FILE] [--format text|markdown]  # Clean-as-You-Code quality gate")
 	fmt.Fprintln(os.Stderr, "  synapse-cli coverage <lcov|cobertura|jacoco file> [--fail-below PCT] [--top N]  # parse a coverage report (auto-detected)")

--- a/internal/usecase/codequality/service.go
+++ b/internal/usecase/codequality/service.go
@@ -10,8 +10,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
@@ -27,12 +29,13 @@ const DefaultComplexityThreshold = 15
 // Service produces code-quality findings. analyzer is required; dup, metrics and inventory are optional
 // enrichers.
 type Service struct {
-	analyzer      ports.CodeAnalyzer
-	dup           ports.DuplicationScanner
-	metrics       ports.CodeMetricsProvider
-	inventory     ports.CodeInventoryScanner
-	bugs          ports.BugDetector
-	complexityMin int
+	analyzer          ports.CodeAnalyzer
+	dup               ports.DuplicationScanner
+	metrics           ports.CodeMetricsProvider
+	inventory         ports.CodeInventoryScanner
+	bugs              ports.BugDetector
+	complexityMin     int
+	includeTestSmells bool
 }
 
 // Option configures a Service.
@@ -54,6 +57,15 @@ func WithBugs(b ports.BugDetector) Option { return func(s *Service) { s.bugs = b
 var bugCWE = map[string]string{
 	"reliability-unreachable-code":   "CWE-561", // dead code
 	"reliability-constant-condition": "CWE-570", // expression is always false/true
+}
+
+// WithTestScopedSmells controls whether info-severity code smells located in test code (src/test,
+// *_test.*, *.spec.*, __tests__, testdata, ...) are emitted. They are SUPPRESSED by default: a rule like
+// commented-out-code fires heavily in tests and otherwise drowns the higher-value findings (complexity,
+// duplication, reliability). Pass true to restore full verbosity. Only Info-severity smells are affected;
+// medium/high findings (and every non-test finding) are always kept.
+func WithTestScopedSmells(include bool) Option {
+	return func(s *Service) { s.includeTestSmells = include }
 }
 
 // WithComplexity adds high-complexity maintainability findings (functions over threshold), using the AST
@@ -94,6 +106,9 @@ func (s *Service) analyze(ctx context.Context, root string) ([]finding.Finding, 
 		return nil, measure.DuplicationReport{}, fmt.Errorf("code analysis: %w", err)
 	}
 	for _, r := range raws {
+		if !s.includeTestSmells && r.Severity == shared.SeverityInfo && isTestPath(r.File) {
+			continue // low-value info smell in test code – suppressed by default (see WithTestScopedSmells)
+		}
 		out = append(out, newFinding(r.Kind, r.RuleID, r.CWE, r.Severity, r.Title, r.Description, r.File, r.Line))
 	}
 
@@ -172,6 +187,36 @@ func newFinding(kind, ruleID, cwe string, sev shared.Severity, title, desc, file
 func deterministicID(dedupKey string) shared.ID {
 	sum := sha256.Sum256([]byte("codequality|" + dedupKey))
 	return shared.ID(hex.EncodeToString(sum[:16]))
+}
+
+// isTestPath reports whether a source path is test/spec/fixture code, where info-severity smells
+// (commented-out code, TODOs) are low-value noise. Matches common directory and filename conventions
+// across ecosystems (Go _test.go, JS/TS .test./.spec., Python test_*, Java src/test + *Test.java, ...).
+func isTestPath(p string) bool {
+	q := strings.ToLower(filepath.ToSlash(p))
+	for _, seg := range []string{
+		"/test/", "/tests/", "/testing/", "/__tests__/", "/__mocks__/", "/testdata/", "/spec/", "/specs/", "/fixtures/",
+	} {
+		if strings.Contains(q, seg) {
+			return true
+		}
+	}
+	if strings.HasPrefix(q, "test/") || strings.HasPrefix(q, "tests/") || strings.HasPrefix(q, "spec/") || strings.HasPrefix(q, "testdata/") {
+		return true
+	}
+	base := q
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	if strings.HasPrefix(base, "test_") { // python test_foo.py
+		return true
+	}
+	for _, m := range []string{"_test.", ".test.", "_spec.", ".spec.", "test.java", "tests.java"} {
+		if strings.Contains(base, m) {
+			return true
+		}
+	}
+	return false
 }
 
 // Report is the full code-quality dashboard payload for a source tree: the per-language inventory, the

--- a/internal/usecase/codequality/service.go
+++ b/internal/usecase/codequality/service.go
@@ -64,6 +64,10 @@ var bugCWE = map[string]string{
 // commented-out-code fires heavily in tests and otherwise drowns the higher-value findings (complexity,
 // duplication, reliability). Pass true to restore full verbosity. Only Info-severity smells are affected;
 // medium/high findings (and every non-test finding) are always kept.
+//
+// Because the filter lives in the single analyze() chokepoint, it also applies to BuildReport and thus to
+// rating.Compute: test-scoped Info smells (5 debt-minutes each) are excluded from the technical-debt total
+// and the maintainability grade by default, which is intentional (test TODOs are not production debt).
 func WithTestScopedSmells(include bool) Option {
 	return func(s *Service) { s.includeTestSmells = include }
 }
@@ -193,15 +197,16 @@ func deterministicID(dedupKey string) shared.ID {
 // (commented-out code, TODOs) are low-value noise. Matches common directory and filename conventions
 // across ecosystems (Go _test.go, JS/TS .test./.spec., Python test_*, Java src/test + *Test.java, ...).
 func isTestPath(p string) bool {
-	q := strings.ToLower(filepath.ToSlash(p))
-	for _, seg := range []string{
-		"/test/", "/tests/", "/testing/", "/__tests__/", "/__mocks__/", "/testdata/", "/spec/", "/specs/", "/fixtures/",
-	} {
+	slash := filepath.ToSlash(p)
+	q := strings.ToLower(slash)
+	// Directory conventions. Deliberately NOT /testing/ or /spec(s)/ – those are common production
+	// package/dir names (test helpers that ship in the binary, OpenAPI/language specs).
+	for _, seg := range []string{"/test/", "/tests/", "/__tests__/", "/__mocks__/", "/testdata/", "/fixtures/"} {
 		if strings.Contains(q, seg) {
 			return true
 		}
 	}
-	if strings.HasPrefix(q, "test/") || strings.HasPrefix(q, "tests/") || strings.HasPrefix(q, "spec/") || strings.HasPrefix(q, "testdata/") {
+	if strings.HasPrefix(q, "test/") || strings.HasPrefix(q, "tests/") || strings.HasPrefix(q, "testdata/") {
 		return true
 	}
 	base := q
@@ -211,8 +216,17 @@ func isTestPath(p string) bool {
 	if strings.HasPrefix(base, "test_") { // python test_foo.py
 		return true
 	}
-	for _, m := range []string{"_test.", ".test.", "_spec.", ".spec.", "test.java", "tests.java"} {
+	// Dot/underscore-bounded filename conventions (JS/TS .test./.spec., Python _test./_spec.).
+	for _, m := range []string{"_test.", ".test.", "_spec.", ".spec."} {
 		if strings.Contains(base, m) {
+			return true
+		}
+	}
+	// CamelCase suffix conventions (JUnit/Kotlin/C#/Scala). Matched case-sensitively on the ORIGINAL
+	// basename so a capital T distinguishes FooTest.java from production files like Latest.java/Contest.java.
+	obase := filepath.Base(slash)
+	for _, suf := range []string{"Test.java", "Tests.java", "Test.kt", "Tests.kt", "Test.cs", "Tests.cs", "Spec.scala"} {
+		if strings.HasSuffix(obase, suf) {
 			return true
 		}
 	}

--- a/internal/usecase/codequality/service_test.go
+++ b/internal/usecase/codequality/service_test.go
@@ -153,3 +153,45 @@ func TestAnalyzerOnly(t *testing.T) {
 		t.Fatalf("want 1 finding, got %d err=%v", len(fs), err)
 	}
 }
+
+func TestTestScopedInfoSmellsSuppressed(t *testing.T) {
+	raws := []ports.CodeAnalysisRawFinding{
+		{Kind: "quality", RuleID: "quality-commented-out-code", Severity: shared.SeverityInfo, Title: "commented", File: "src/test/java/FooTest.java", Line: 3},
+		{Kind: "quality", RuleID: "quality-commented-out-code", Severity: shared.SeverityInfo, Title: "commented", File: "src/main/java/Foo.java", Line: 9},
+		{Kind: "reliability", RuleID: "reliability-empty-catch", Severity: shared.SeverityMedium, Title: "empty catch", File: "src/test/java/FooTest.java", Line: 5},
+	}
+	// Default: info smell in test code is dropped; the prod info smell and the test-scoped MEDIUM stay.
+	fs, err := New(fakeAnalyzer{raws: raws}).Analyze(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	m := byRule(fs)
+	if len(fs) != 2 {
+		t.Fatalf("default should drop the test-scoped info smell, want 2, got %d: %+v", len(fs), fs)
+	}
+	if _, ok := m["reliability-empty-catch"]; !ok {
+		t.Errorf("a medium finding in test code must be kept")
+	}
+	// The prod commented-out-code must survive; the test one must not.
+	var prod, test int
+	for _, f := range fs {
+		if strings.Contains(f.DedupKey, "src/main/") {
+			prod++
+		}
+		if strings.Contains(f.DedupKey, "FooTest.java") && f.Kind == finding.KindQuality {
+			test++
+		}
+	}
+	if prod != 1 || test != 0 {
+		t.Errorf("want prod-info kept (1) and test-info dropped (0); got prod=%d test=%d", prod, test)
+	}
+
+	// Opt-in restores full verbosity.
+	all, err := New(fakeAnalyzer{raws: raws}, WithTestScopedSmells(true)).Analyze(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("WithTestScopedSmells(true) should keep all 3, got %d", len(all))
+	}
+}

--- a/internal/usecase/codequality/service_test.go
+++ b/internal/usecase/codequality/service_test.go
@@ -195,3 +195,30 @@ func TestTestScopedInfoSmellsSuppressed(t *testing.T) {
 		t.Errorf("WithTestScopedSmells(true) should keep all 3, got %d", len(all))
 	}
 }
+
+func TestIsTestPath(t *testing.T) {
+	tests := map[string]bool{
+		"src/test/java/com/x/FooTest.java":  true,
+		"services/kyc/src/test/java/A.java": true,
+		"pkg/foo_test.go":                   true,
+		"app/user.test.ts":                  true,
+		"app/user.spec.ts":                  true,
+		"tests/test_login.py":               true,
+		"foo/testdata/sample.json":          true,
+		"a/__tests__/b.js":                  true,
+		"Bar.kt":                            false,
+		"BarTest.kt":                        true,
+		// Production files that must NOT be misclassified (the substring-match FP class).
+		"src/main/java/com/x/Latest.java":   false,
+		"src/main/java/com/x/Contest.java":  false,
+		"src/main/java/com/x/Greatest.java": false,
+		"pkg/testing/helper.go":             false, // production test-helper package
+		"api/spec/handler.go":               false, // production spec dir
+		"src/main/java/com/x/Foo.java":      false,
+	}
+	for path, want := range tests {
+		if got := isTestPath(path); got != want {
+			t.Errorf("isTestPath(%q) = %v, want %v", path, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #125. A rule like `commented-out-code` fires heavily in test files and drowns the higher-value findings. codequality now drops **Info-severity** smells located in test/spec/fixture code by default (`isTestPath`: `src/test`, `*_test.*`, `*.spec.*`, `__tests__`, `testdata`, `test_*`, `*Test.java`, ...). Medium/high findings and all non-test findings are always kept; the duplication/complexity/reliability bridges are untouched.

`synapse-cli quality --include-test-smells` (Option `WithTestScopedSmells`) restores full verbosity.

**Impact on a real Java monorepo:** `commented-out-code` drops from **505 → 7** (the rest were all in tests); the report is then led by actionable duplication/complexity rather than info noise, and the reliability findings are preserved. Unit test covers suppress-by-default, keep-prod-info, keep-test-medium, and the opt-in. Full suite (118 pkgs) + vet + gofmt green.