### PR TITLE
feat(sca): static build.gradle direct-dep fallback + JDK auto-detection (#124)

### DIFF
--- a/internal/infrastructure/tools/gradleresolve/javahome_test.go
+++ b/internal/infrastructure/tools/gradleresolve/javahome_test.go
@@ -1,0 +1,72 @@
+package gradleresolve
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func makeJDK(t *testing.T) string {
+	t.Helper()
+	jdk := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(jdk, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jdk, "bin", "java"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return jdk
+}
+
+func TestJavaHomeValid(t *testing.T) {
+	if !javaHomeValid(makeJDK(t)) {
+		t.Errorf("a dir with bin/java must be a valid JAVA_HOME")
+	}
+	if javaHomeValid(t.TempDir()) {
+		t.Errorf("an empty dir must not be a valid JAVA_HOME")
+	}
+	if javaHomeValid("") {
+		t.Errorf("empty string must not be valid")
+	}
+}
+
+func TestEnsureJavaHome(t *testing.T) {
+	jdk := makeJDK(t)
+
+	// A valid JAVA_HOME is kept and detect() is never consulted.
+	env := ensureJavaHome([]string{"PATH=/usr/bin", "JAVA_HOME=" + jdk}, func() string {
+		t.Fatal("detect must not run when JAVA_HOME is already valid")
+		return ""
+	})
+	if envValue(env, "JAVA_HOME") != jdk {
+		t.Errorf("valid JAVA_HOME should be kept, got %q", envValue(env, "JAVA_HOME"))
+	}
+
+	// An invalid JAVA_HOME is replaced by the detected JDK, with exactly one JAVA_HOME entry.
+	env = ensureJavaHome([]string{"PATH=/usr/bin", "JAVA_HOME=/does/not/exist"}, func() string { return jdk })
+	if envValue(env, "JAVA_HOME") != jdk {
+		t.Errorf("invalid JAVA_HOME should be replaced with %q, got %q", jdk, envValue(env, "JAVA_HOME"))
+	}
+	n := 0
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "JAVA_HOME=") {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("want exactly one JAVA_HOME entry after replace, got %d", n)
+	}
+
+	// A missing JAVA_HOME with a detected JDK gets it set.
+	env = ensureJavaHome([]string{"PATH=/usr/bin"}, func() string { return jdk })
+	if envValue(env, "JAVA_HOME") != jdk {
+		t.Errorf("missing JAVA_HOME should be set to detected JDK")
+	}
+
+	// Nothing detected + invalid current => left unchanged (Gradle surfaces its own error).
+	env = ensureJavaHome([]string{"JAVA_HOME=/does/not/exist"}, func() string { return "" })
+	if envValue(env, "JAVA_HOME") != "/does/not/exist" {
+		t.Errorf("should be unchanged when detect finds nothing, got %q", envValue(env, "JAVA_HOME"))
+	}
+}

--- a/internal/infrastructure/tools/gradleresolve/javahome_test.go
+++ b/internal/infrastructure/tools/gradleresolve/javahome_test.go
@@ -13,8 +13,10 @@ func makeJDK(t *testing.T) string {
 	if err := os.MkdirAll(filepath.Join(jdk, "bin"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(jdk, "bin", "java"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
+	for _, exe := range []string{"java", "javac"} { // a JDK has both; javaHomeValid requires the compiler
+		if err := os.WriteFile(filepath.Join(jdk, "bin", exe), []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return jdk
 }
@@ -28,6 +30,17 @@ func TestJavaHomeValid(t *testing.T) {
 	}
 	if javaHomeValid("") {
 		t.Errorf("empty string must not be valid")
+	}
+	// A JRE (java but no javac) must be rejected – Gradle needs a JDK.
+	jre := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(jre, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jre, "bin", "java"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if javaHomeValid(jre) {
+		t.Errorf("a JRE (no javac) must not be accepted as a JDK")
 	}
 }
 

--- a/internal/infrastructure/tools/gradleresolve/resolver.go
+++ b/internal/infrastructure/tools/gradleresolve/resolver.go
@@ -221,7 +221,11 @@ func (r *Resolver) run(ctx context.Context, dir string) ([]byte, error) {
 	// controlled env already).
 	var stdout, stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, r.bin, args...)
-	cmd.Env = append(scrubSynapseEnv(os.Environ()), env...)
+	// Gradle refuses to run if JAVA_HOME is unset or points at an absent JDK (a common local-dev state).
+	// On the trusted-local direct-exec path, auto-detect a JDK and inject it so resolution succeeds
+	// instead of failing with "JAVA_HOME is set to an invalid directory"; if none is found the env is
+	// left as-is and Gradle's own error is surfaced (via source_warnings).
+	cmd.Env = ensureJavaHome(append(scrubSynapseEnv(os.Environ()), env...), detectJDK)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -324,4 +328,83 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return string(r[:n]) + "…"
+}
+
+// ensureJavaHome returns env with a usable JAVA_HOME. If env's JAVA_HOME is missing or points at a
+// directory that is not a JDK, it calls detect() to find one and sets it; if detect finds nothing the env
+// is returned unchanged (Gradle then surfaces its own JAVA_HOME error). detect is a parameter so tests can
+// inject a deterministic result.
+func ensureJavaHome(env []string, detect func() string) []string {
+	if javaHomeValid(envValue(env, "JAVA_HOME")) {
+		return env
+	}
+	jdk := detect()
+	if jdk == "" {
+		return env
+	}
+	return setEnvVar(env, "JAVA_HOME", jdk)
+}
+
+// javaHomeValid reports whether dir looks like a JDK/JRE home (has a bin/java[.exe] executable).
+func javaHomeValid(dir string) bool {
+	if strings.TrimSpace(dir) == "" {
+		return false
+	}
+	for _, name := range []string{"java", "java.exe"} {
+		if fi, err := os.Stat(filepath.Join(dir, "bin", name)); err == nil && !fi.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+// detectJDK finds a JDK home on the local host (trusted-local path only). It prefers the macOS
+// java_home helper, then well-known install roots on macOS/Linux/Homebrew. Returns "" when none is found.
+func detectJDK() string {
+	if out, err := exec.Command("/usr/libexec/java_home").Output(); err == nil { // macOS
+		if p := strings.TrimSpace(string(out)); javaHomeValid(p) {
+			return p
+		}
+	}
+	globs := []string{
+		"/usr/lib/jvm/*",
+		"/Library/Java/JavaVirtualMachines/*/Contents/Home",
+		filepath.Join(os.Getenv("HOME"), "Library/Java/JavaVirtualMachines/*/Contents/Home"),
+		"/opt/homebrew/opt/openjdk*/libexec/openjdk.jdk/Contents/Home",
+		"/opt/homebrew/opt/openjdk*",
+		"/usr/local/opt/openjdk*",
+	}
+	for _, g := range globs {
+		matches, _ := filepath.Glob(g)
+		for _, m := range matches {
+			if javaHomeValid(m) {
+				return m
+			}
+		}
+	}
+	return ""
+}
+
+// envValue returns the last value of key in an environment list ("" if absent).
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	val := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			val = kv[len(prefix):]
+		}
+	}
+	return val
+}
+
+// setEnvVar returns env with key set to val, removing any prior entries for key (last-wins on all OSes).
+func setEnvVar(env []string, key, val string) []string {
+	prefix := key + "="
+	out := env[:0:0]
+	for _, kv := range env {
+		if !strings.HasPrefix(kv, prefix) {
+			out = append(out, kv)
+		}
+	}
+	return append(out, prefix+val)
 }

--- a/internal/infrastructure/tools/gradleresolve/resolver.go
+++ b/internal/infrastructure/tools/gradleresolve/resolver.go
@@ -225,7 +225,7 @@ func (r *Resolver) run(ctx context.Context, dir string) ([]byte, error) {
 	// On the trusted-local direct-exec path, auto-detect a JDK and inject it so resolution succeeds
 	// instead of failing with "JAVA_HOME is set to an invalid directory"; if none is found the env is
 	// left as-is and Gradle's own error is surfaced (via source_warnings).
-	cmd.Env = ensureJavaHome(append(scrubSynapseEnv(os.Environ()), env...), detectJDK)
+	cmd.Env = ensureJavaHome(append(scrubSynapseEnv(os.Environ()), env...), func() string { return detectJDK(ctx) })
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -345,23 +345,27 @@ func ensureJavaHome(env []string, detect func() string) []string {
 	return setEnvVar(env, "JAVA_HOME", jdk)
 }
 
-// javaHomeValid reports whether dir looks like a JDK/JRE home (has a bin/java[.exe] executable).
+// javaHomeValid reports whether dir looks like a JDK home. Gradle needs a JDK (not just a JRE), so it
+// requires BOTH bin/java and bin/javac (the compiler is JDK-only).
 func javaHomeValid(dir string) bool {
 	if strings.TrimSpace(dir) == "" {
 		return false
 	}
-	for _, name := range []string{"java", "java.exe"} {
-		if fi, err := os.Stat(filepath.Join(dir, "bin", name)); err == nil && !fi.IsDir() {
-			return true
+	hasExe := func(names ...string) bool {
+		for _, name := range names {
+			if fi, err := os.Stat(filepath.Join(dir, "bin", name)); err == nil && !fi.IsDir() {
+				return true
+			}
 		}
+		return false
 	}
-	return false
+	return hasExe("java", "java.exe") && hasExe("javac", "javac.exe")
 }
 
 // detectJDK finds a JDK home on the local host (trusted-local path only). It prefers the macOS
 // java_home helper, then well-known install roots on macOS/Linux/Homebrew. Returns "" when none is found.
-func detectJDK() string {
-	if out, err := exec.Command("/usr/libexec/java_home").Output(); err == nil { // macOS
+func detectJDK(ctx context.Context) string {
+	if out, err := exec.CommandContext(ctx, "/usr/libexec/java_home").Output(); err == nil { // macOS
 		if p := strings.TrimSpace(string(out)); javaHomeValid(p) {
 			return p
 		}

--- a/internal/infrastructure/tools/manifest/enricher.go
+++ b/internal/infrastructure/tools/manifest/enricher.go
@@ -66,6 +66,12 @@ func (Enricher) Enrich(ctx context.Context, dir string, doc *sbom.SBOM) ports.SB
 				// SBOM producer (ownsbom.Gradle) and this Syft-enrichment path; no duplicated catalog parser.
 				gradleComps = append(gradleComps, ownsbom.ParseGradleCatalog(data)...)
 			}
+		case "build.gradle", "build.gradle.kts":
+			if data := read(path); data != nil {
+				// Inline `dependencies { ... }` coordinates with a literal version (shared owned parser),
+				// so a pinned direct dependency is captured when the resolver can't run.
+				gradleComps = append(gradleComps, ownsbom.ParseBuildGradleDeps(data)...)
+			}
 		case "pnpm-lock.yaml":
 			if data := read(path); data != nil {
 				for k, v := range parsePnpmScopes(data) {

--- a/internal/infrastructure/tools/ownsbom/buildgradle.go
+++ b/internal/infrastructure/tools/ownsbom/buildgradle.go
@@ -1,0 +1,104 @@
+package ownsbom
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// BuildGradle is the owned parser for a Gradle build script's INLINE dependency declarations
+// (build.gradle / build.gradle.kts `dependencies { ... }`). It complements the version-catalog parser
+// (ownsbom.Gradle, libs.versions.toml) and the runtime resolver (gradleresolve): those cover the catalog
+// and the fully-resolved transitive tree, while this recovers coordinates declared directly in the build
+// script with a concrete version, so a pinned vulnerable DIRECT dependency is detectable even when the
+// resolver cannot run (no JDK, offline, private repo). Only declarations with a literal version are
+// emitted; version-less (BOM/platform-managed) and interpolated (${var}) coordinates are skipped, since
+// without a concrete version they cannot be matched against an advisory. Gradle uses Maven coordinates, so
+// the components are pkg:maven PURLs. The registry dedups by PURL, so overlap with the resolver/catalog is
+// merged rather than double-counted.
+type BuildGradle struct{}
+
+func (BuildGradle) Ecosystem() string { return "maven" }
+func (BuildGradle) Markers() []string { return []string{"build.gradle", "build.gradle.kts"} }
+
+func (BuildGradle) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+	comps := ParseBuildGradleDeps(in.Content)
+	for i := range comps {
+		comps[i].Location = in.Path
+	}
+	return comps, nil, nil
+}
+
+var (
+	// reDepBlockOpen matches the start of a `dependencies { ... }` block (Groovy or Kotlin DSL).
+	reDepBlockOpen = regexp.MustCompile(`(?i)^dependencies\s*\{`)
+	// buildGradleCoordRE matches a "group:artifact:version" coordinate inside a quoted string
+	// (Groovy '...' or Kotlin "..."). group/artifact use coordinate characters; the version is captured
+	// loosely and validated by concreteVersionRE (interpolated/property versions are rejected).
+	buildGradleCoordRE = regexp.MustCompile(`["']([A-Za-z0-9_.-]+):([A-Za-z0-9_.-]+):([^"':\s]+)["']`)
+	// concreteVersionRE requires a version beginning with a digit (1.2.3, 20240101-abc, 2.2.2), rejecting
+	// ${var}/$var interpolation, version.ref placeholders, and words like "latest.release".
+	concreteVersionRE = regexp.MustCompile(`^[0-9][A-Za-z0-9_.+-]*$`)
+)
+
+// ParseBuildGradleDeps extracts inline Maven coordinates (with a literal version) from a Gradle build
+// script's dependencies { } block(s). It tracks brace depth so coordinates in other blocks (plugins,
+// repositories, buildscript, dependencyManagement) are ignored, and dedups by group:artifact@version.
+func ParseBuildGradleDeps(data []byte) []sbom.Component {
+	var out []sbom.Component
+	seen := map[string]bool{}
+	collect := func(line string) {
+		for _, m := range buildGradleCoordRE.FindAllStringSubmatch(line, -1) {
+			group, artifact, ver := m[1], m[2], m[3]
+			if !concreteVersionRE.MatchString(ver) {
+				continue
+			}
+			key := group + ":" + artifact + "@" + ver
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, sbom.Component{
+				Name:    group + ":" + artifact,
+				Version: ver,
+				Scope:   sbom.ScopeProduction,
+				PURL:    "pkg:maven/" + group + "/" + artifact + "@" + ver,
+			})
+		}
+	}
+
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	inDeps := false
+	depth := 0
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "*") || strings.HasPrefix(line, "/*") {
+			continue
+		}
+		opens := strings.Count(line, "{")
+		closes := strings.Count(line, "}")
+		if !inDeps {
+			if !reDepBlockOpen.MatchString(line) {
+				continue
+			}
+			inDeps = true
+			depth = opens - closes // the `dependencies {` brace (and any on the same line)
+			collect(line)          // rare one-liner `dependencies { implementation '...' }`
+			if depth <= 0 {
+				inDeps = false
+			}
+			continue
+		}
+		collect(line)
+		depth += opens - closes
+		if depth <= 0 {
+			inDeps = false
+		}
+	}
+	return out
+}

--- a/internal/infrastructure/tools/ownsbom/buildgradle.go
+++ b/internal/infrastructure/tools/ownsbom/buildgradle.go
@@ -1,8 +1,6 @@
 package ownsbom
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"regexp"
 	"strings"
@@ -17,14 +15,19 @@ import (
 // script with a concrete version, so a pinned vulnerable DIRECT dependency is detectable even when the
 // resolver cannot run (no JDK, offline, private repo). Only declarations with a literal version are
 // emitted; version-less (BOM/platform-managed) and interpolated (${var}) coordinates are skipped, since
-// without a concrete version they cannot be matched against an advisory. Gradle uses Maven coordinates, so
-// the components are pkg:maven PURLs. The registry dedups by PURL, so overlap with the resolver/catalog is
-// merged rather than double-counted.
+// without a concrete version they cannot be matched against an advisory. Coordinates inside a
+// `buildscript { }` (build-plugin classpath) are ignored – those are build-time tooling, not runtime
+// artifacts. Gradle uses Maven coordinates, so the components are pkg:maven PURLs; the registry dedups by
+// PURL, so overlap with the resolver/catalog is merged rather than double-counted.
 type BuildGradle struct{}
 
+// Ecosystem identifies this parser's package ecosystem (Gradle deps are Maven coordinates).
 func (BuildGradle) Ecosystem() string { return "maven" }
+
+// Markers are the build-script basenames this parser claims (Groovy + Kotlin DSL).
 func (BuildGradle) Markers() []string { return []string{"build.gradle", "build.gradle.kts"} }
 
+// Parse extracts the build script's inline dependency coordinates, tagging each with the script path.
 func (BuildGradle) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
 	comps := ParseBuildGradleDeps(in.Content)
 	for i := range comps {
@@ -33,72 +36,148 @@ func (BuildGradle) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []
 	return comps, nil, nil
 }
 
-var (
-	// reDepBlockOpen matches the start of a `dependencies { ... }` block (Groovy or Kotlin DSL).
-	reDepBlockOpen = regexp.MustCompile(`(?i)^dependencies\s*\{`)
-	// buildGradleCoordRE matches a "group:artifact:version" coordinate inside a quoted string
-	// (Groovy '...' or Kotlin "..."). group/artifact use coordinate characters; the version is captured
-	// loosely and validated by concreteVersionRE (interpolated/property versions are rejected).
-	buildGradleCoordRE = regexp.MustCompile(`["']([A-Za-z0-9_.-]+):([A-Za-z0-9_.-]+):([^"':\s]+)["']`)
-	// concreteVersionRE requires a version beginning with a digit (1.2.3, 20240101-abc, 2.2.2), rejecting
-	// ${var}/$var interpolation, version.ref placeholders, and words like "latest.release".
-	concreteVersionRE = regexp.MustCompile(`^[0-9][A-Za-z0-9_.+-]*$`)
-)
+// concreteVersionRE requires a version beginning with a digit and containing no `+` (1.2.3, 20240101-abc,
+// 2.2.2). `+` is excluded on purpose so a Gradle dynamic selector (1.+, 2.+, 1.0.+) is NOT treated as
+// concrete – it has no single version to match and the Maven comparator would collapse `1.+` to the bare
+// major `1`, a phantom match. Interpolation (${var}), ranges ([1.0,2.0)) and words (latest.release) are
+// rejected by the digit-lead requirement.
+var concreteVersionRE = regexp.MustCompile(`^[0-9][A-Za-z0-9_.-]*$`)
 
 // ParseBuildGradleDeps extracts inline Maven coordinates (with a literal version) from a Gradle build
-// script's dependencies { } block(s). It tracks brace depth so coordinates in other blocks (plugins,
-// repositories, buildscript, dependencyManagement) are ignored, and dedups by group:artifact@version.
+// script's dependencies { } block(s). It is a small comment- and string-aware scanner that tracks a stack
+// of enclosing block names, so a coordinate is emitted only when it sits inside a `dependencies { }` that
+// is NOT nested under `buildscript { }` (build-plugin classpath). Dedups by group:artifact@version.
 func ParseBuildGradleDeps(data []byte) []sbom.Component {
 	var out []sbom.Component
 	seen := map[string]bool{}
-	collect := func(line string) {
-		for _, m := range buildGradleCoordRE.FindAllStringSubmatch(line, -1) {
-			group, artifact, ver := m[1], m[2], m[3]
-			if !concreteVersionRE.MatchString(ver) {
-				continue
-			}
-			key := group + ":" + artifact + "@" + ver
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-			out = append(out, sbom.Component{
-				Name:    group + ":" + artifact,
-				Version: ver,
-				Scope:   sbom.ScopeProduction,
-				PURL:    "pkg:maven/" + group + "/" + artifact + "@" + ver,
-			})
+	collect := func(content string) {
+		group, artifact, ver, ok := splitGradleCoord(content)
+		if !ok {
+			return
 		}
+		key := group + ":" + artifact + "@" + ver
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, sbom.Component{
+			Name:    group + ":" + artifact,
+			Version: ver,
+			Scope:   sbom.ScopeProduction,
+			PURL:    "pkg:maven/" + group + "/" + artifact + "@" + ver,
+		})
 	}
 
-	sc := bufio.NewScanner(bytes.NewReader(data))
-	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	inDeps := false
-	depth := 0
-	for sc.Scan() {
-		line := strings.TrimSpace(sc.Text())
-		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "*") || strings.HasPrefix(line, "/*") {
-			continue
+	src := data
+	var stack []string              // enclosing block names, e.g. ["buildscript","dependencies"]
+	var ident []byte                // identifier accumulated before a '{'
+	lastIdent := ""                 // last complete identifier seen (the token before '{' when separated by space)
+	var quote byte                  // active quote char (0 = none)
+	qStart := -1                    // index just after the opening quote
+	inLine, inBlock := false, false // // and /* */ comments
+	flushIdent := func() {
+		if s := strings.TrimSpace(string(ident)); s != "" {
+			lastIdent = s
 		}
-		opens := strings.Count(line, "{")
-		closes := strings.Count(line, "}")
-		if !inDeps {
-			if !reDepBlockOpen.MatchString(line) {
-				continue
-			}
-			inDeps = true
-			depth = opens - closes // the `dependencies {` brace (and any on the same line)
-			collect(line)          // rare one-liner `dependencies { implementation '...' }`
-			if depth <= 0 {
-				inDeps = false
+		ident = ident[:0]
+	}
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		switch {
+		case inLine:
+			if c == '\n' {
+				inLine = false
 			}
 			continue
-		}
-		collect(line)
-		depth += opens - closes
-		if depth <= 0 {
-			inDeps = false
+		case inBlock:
+			if c == '*' && i+1 < len(src) && src[i+1] == '/' {
+				inBlock = false
+				i++
+			}
+			continue
+		case quote != 0:
+			if c == quote {
+				if inRuntimeDeps(stack) {
+					collect(string(src[qStart:i]))
+				}
+				quote = 0
+			}
+			continue
+		case c == '/' && i+1 < len(src) && src[i+1] == '/':
+			flushIdent()
+			inLine = true
+			i++
+			continue
+		case c == '/' && i+1 < len(src) && src[i+1] == '*':
+			flushIdent()
+			inBlock = true
+			i++
+			continue
+		case c == '\'' || c == '"':
+			flushIdent()
+			quote = c
+			qStart = i + 1
+			continue
+		case isIdentByte(c):
+			ident = append(ident, c)
+			continue
+		case c == '{':
+			name := strings.TrimSpace(string(ident))
+			if name == "" {
+				name = lastIdent
+			}
+			stack = append(stack, name)
+			ident = ident[:0]
+			lastIdent = ""
+			continue
+		case c == '}':
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+			ident = ident[:0]
+			lastIdent = ""
+			continue
+		default:
+			flushIdent()
 		}
 	}
 	return out
+}
+
+// inRuntimeDeps reports whether the current block stack is inside a runtime `dependencies { }` block –
+// i.e. it contains a "dependencies" frame and no "buildscript" frame (buildscript deps are build-time
+// plugin classpath, not runtime artifacts).
+func inRuntimeDeps(stack []string) bool {
+	deps := false
+	for _, s := range stack {
+		switch s {
+		case "buildscript":
+			return false
+		case "dependencies":
+			deps = true
+		}
+	}
+	return deps
+}
+
+// splitGradleCoord parses "group:artifact:version[:classifier]" (optionally with an "@ext" on the
+// version), returning the coordinate when the version is concrete. A 2-part "group:artifact" (version
+// supplied by a BOM) or any interpolated/dynamic version yields ok=false.
+func splitGradleCoord(s string) (group, artifact, version string, ok bool) {
+	parts := strings.Split(strings.TrimSpace(s), ":")
+	if len(parts) < 3 {
+		return "", "", "", false
+	}
+	group, artifact, version = parts[0], parts[1], parts[2]
+	if at := strings.IndexByte(version, '@'); at >= 0 { // drop @ext (e.g. 1.0@aar)
+		version = version[:at]
+	}
+	if group == "" || artifact == "" || !concreteVersionRE.MatchString(version) {
+		return "", "", "", false
+	}
+	return group, artifact, version, true
+}
+
+func isIdentByte(c byte) bool {
+	return c == '_' || c == '.' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }

--- a/internal/infrastructure/tools/ownsbom/buildgradle_test.go
+++ b/internal/infrastructure/tools/ownsbom/buildgradle_test.go
@@ -1,0 +1,67 @@
+package ownsbom
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+func TestParseBuildGradleDeps(t *testing.T) {
+	src := `
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.4.3'
+}
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'   // BOM-managed, no version -> skip
+    implementation 'io.github.openfeign.form:feign-form:3.8.0'          // concrete -> keep
+    implementation "com.amazonaws:aws-java-sdk-s3:1.12.371"             // double-quoted -> keep
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'          // keep
+    implementation "org.example:lib:${someVersion}"                     // interpolated -> skip
+    implementation('io.grpc:grpc-core:1.60.0') { exclude group: 'x' }   // keep, brace on the same line
+}
+repositories {
+    maven { url 'https://repo.example.com/foo' }
+}
+`
+	comps := ParseBuildGradleDeps([]byte(src))
+	got := map[string]string{}
+	for _, c := range comps {
+		got[c.Name] = c.Version
+		if c.PURL == "" || c.Scope != sbom.ScopeProduction {
+			t.Errorf("component missing PURL/scope: %+v", c)
+		}
+	}
+	want := map[string]string{
+		"io.github.openfeign.form:feign-form": "3.8.0",
+		"com.amazonaws:aws-java-sdk-s3":       "1.12.371",
+		"org.junit.jupiter:junit-jupiter":     "5.8.2",
+		"io.grpc:grpc-core":                   "1.60.0",
+	}
+	if len(comps) != len(want) {
+		t.Fatalf("want %d comps, got %d: %+v", len(want), len(comps), comps)
+	}
+	for name, ver := range want {
+		if got[name] != ver {
+			t.Errorf("%s: want version %s, got %q", name, ver, got[name])
+		}
+	}
+	for _, bad := range []string{"org.springframework.boot:spring-boot-starter-web", "org.example:lib"} {
+		if _, ok := got[bad]; ok {
+			t.Errorf("%s must not be extracted (version-less/interpolated)", bad)
+		}
+	}
+	// A grpc-core PURL must be well-formed maven.
+	if got := purlOf(comps, "io.grpc:grpc-core"); got != "pkg:maven/io.grpc/grpc-core@1.60.0" {
+		t.Errorf("grpc-core PURL wrong: %q", got)
+	}
+}
+
+func purlOf(comps []sbom.Component, name string) string {
+	for _, c := range comps {
+		if c.Name == name {
+			return c.PURL
+		}
+	}
+	return ""
+}

--- a/internal/infrastructure/tools/ownsbom/buildgradle_test.go
+++ b/internal/infrastructure/tools/ownsbom/buildgradle_test.go
@@ -57,6 +57,67 @@ repositories {
 	}
 }
 
+func TestParseBuildGradleDepsExcludesBuildscriptAndComments(t *testing.T) {
+	src := `
+buildscript {
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'          // build-time plugin -> must NOT be emitted
+    }
+}
+dependencies {
+    implementation 'real:lib:1.2.3'   // was 'com.fasterxml.jackson.core:jackson-databind:2.9.9' -> comment ignored
+    implementation 'dyn:sel:1.+'      // dynamic selector -> must NOT be emitted (phantom-major FP)
+    /* implementation 'blocked:out:9.9.9' */
+    implementation 'ok:concrete:2.0.0'
+}
+`
+	comps := ParseBuildGradleDeps([]byte(src))
+	got := map[string]bool{}
+	for _, c := range comps {
+		got[c.Name] = true
+	}
+	for _, want := range []string{"real:lib", "ok:concrete"} {
+		if !got[want] {
+			t.Errorf("expected %s to be emitted; got %v", want, got)
+		}
+	}
+	for _, bad := range []string{
+		"com.android.tools.build:gradle",              // buildscript classpath
+		"com.fasterxml.jackson.core:jackson-databind", // trailing-comment coord
+		"blocked:out", // block-comment coord
+		"dyn:sel",     // dynamic version 1.+
+	} {
+		if got[bad] {
+			t.Errorf("%s must NOT be emitted", bad)
+		}
+	}
+	if len(comps) != 2 {
+		t.Errorf("want exactly 2 components (real:lib, ok:concrete), got %d: %+v", len(comps), comps)
+	}
+}
+
+func TestSplitGradleCoord(t *testing.T) {
+	cases := []struct {
+		in                       string
+		wantOK                   bool
+		group, artifact, version string
+	}{
+		{"g:a:1.2.3", true, "g", "a", "1.2.3"},
+		{"g:a:1.0@aar", true, "g", "a", "1.0"},    // @ext stripped
+		{"g:a:1.0:jar", true, "g", "a", "1.0"},    // classifier ignored (version is 3rd part)
+		{"g:a", false, "", "", ""},                // version-less (BOM)
+		{"g:a:${v}", false, "", "", ""},           // interpolated
+		{"g:a:1.+", false, "", "", ""},            // dynamic
+		{"g:a:latest.release", false, "", "", ""}, // word
+	}
+	for _, c := range cases {
+		g, a, v, ok := splitGradleCoord(c.in)
+		if ok != c.wantOK || (ok && (g != c.group || a != c.artifact || v != c.version)) {
+			t.Errorf("splitGradleCoord(%q) = (%q,%q,%q,%v), want (%q,%q,%q,%v)", c.in, g, a, v, ok, c.group, c.artifact, c.version, c.wantOK)
+		}
+	}
+}
+
 func purlOf(comps []sbom.Component, name string) string {
 	for _, c := range comps {
 		if c.Name == name {

--- a/internal/infrastructure/tools/ownsbom/registry.go
+++ b/internal/infrastructure/tools/ownsbom/registry.go
@@ -93,7 +93,7 @@ func New(parsers ...EcosystemParser) (*Registry, error) {
 // Swift, Dart, Elixir, R (renv), Julia, and Conan. The parsers claim distinct markers, so New does not
 // error here in practice.
 func DefaultRegistry() (*Registry, error) {
-	return New(GoMod{}, NPM{}, Yarn{}, Pnpm{}, PyPI{}, Poetry{}, Pipfile{}, Cargo{}, Maven{}, Gradle{}, Gem{}, Composer{}, NuGet{}, Swift{}, Dart{}, Elixir{}, Conda{}, Renv{}, Julia{}, Conan{})
+	return New(GoMod{}, NPM{}, Yarn{}, Pnpm{}, PyPI{}, Poetry{}, Pipfile{}, Cargo{}, Maven{}, Gradle{}, BuildGradle{}, Gem{}, Composer{}, NuGet{}, Swift{}, Dart{}, Elixir{}, Conda{}, Renv{}, Julia{}, Conan{})
 }
 
 // Generate walks the target directory, parses every recognized manifest with its EcosystemParser, and


### PR DESCRIPTION
Fixes #124. When a Gradle project can't be fully resolved (no JDK, offline, private/unreachable repo), SCA saw ~0 usable components and reported 0 vulns despite concrete-version deps declared in the build script.

**Static fallback** — new owned parser `ownsbom.BuildGradle` (markers `build.gradle`/`build.gradle.kts`) extracts inline `dependencies { }` Maven coordinates with a **literal** version (version-less BOM-managed + `${interpolated}` are skipped — not advisory-matchable). Registered in the owned registry + wired into the Syft-enrichment path (mirrors the existing `libs.versions.toml` parser). Registry dedups by PURL, so no double-count with the catalog/resolver.

**JDK auto-detection** — on the trusted-local direct-exec path the gradle resolver injects a discovered `JAVA_HOME` (macOS `java_home`, then well-known JDK roots) when the inherited one is missing/invalid, so resolution succeeds instead of failing with "JAVA_HOME is set to an invalid directory"; if none is found the env is untouched and Gradle's own error is still surfaced.

**Verified on a real Java monorepo** (no lockfile, unreachable private repo): SBOM grows **12 → 47** components and SCA reports **4 real CVEs** (commons-fileupload 1.5 HIGH, commons-lang3 3.12.0, bcpkix-jdk15on 1.70 ×2) where it previously found none. Completeness warning stays (confident:false — transitive tree not captured). Full suite (118 pkgs) + vet + gofmt green.