### PR TITLE
feat(quality): auto-discover the synapse-ast sidecar next to the binary (zero setup)

### DIFF
--- a/internal/infrastructure/tools/ast/discovery_test.go
+++ b/internal/infrastructure/tools/ast/discovery_test.go
@@ -1,0 +1,40 @@
+package ast
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveSidecarInPrefersBundled(t *testing.T) {
+	dir := t.TempDir()
+	bundled := filepath.Join(dir, sidecarName())
+	if err := os.WriteFile(bundled, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveSidecarIn(dir); got != bundled {
+		t.Errorf("want bundled sidecar %q, got %q", bundled, got)
+	}
+}
+
+func TestResolveSidecarInFallsBackToPath(t *testing.T) {
+	// An empty dir (no bundled sidecar) falls back to the bare name for a PATH lookup at exec time.
+	if got := resolveSidecarIn(t.TempDir()); got != sidecarName() {
+		t.Errorf("want fallback %q, got %q", sidecarName(), got)
+	}
+	// A directory entry named like the sidecar must NOT be picked (it is not a regular file).
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, sidecarName()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveSidecarIn(dir); got != sidecarName() {
+		t.Errorf("a directory named like the sidecar must be ignored; got %q", got)
+	}
+}
+
+func TestNewEmptyBinResolves(t *testing.T) {
+	// New("") must never leave bin empty (it resolves to a bundled path or the bare name).
+	if p := New(""); p.bin == "" {
+		t.Errorf("New(\"\") left bin empty")
+	}
+}

--- a/internal/infrastructure/tools/ast/discovery_test.go
+++ b/internal/infrastructure/tools/ast/discovery_test.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -29,6 +30,16 @@ func TestResolveSidecarInFallsBackToPath(t *testing.T) {
 	}
 	if got := resolveSidecarIn(dir); got != sidecarName() {
 		t.Errorf("a directory named like the sidecar must be ignored; got %q", got)
+	}
+	// A NON-executable regular file must not shadow a working PATH copy (fall through to the bare name).
+	if runtime.GOOS != "windows" {
+		nx := t.TempDir()
+		if err := os.WriteFile(filepath.Join(nx, sidecarName()), []byte("stub"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := resolveSidecarIn(nx); got != sidecarName() {
+			t.Errorf("a non-executable stub must not be selected; got %q", got)
+		}
 	}
 }
 

--- a/internal/infrastructure/tools/ast/provider.go
+++ b/internal/infrastructure/tools/ast/provider.go
@@ -11,7 +11,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"unicode/utf8"
 
@@ -30,12 +33,48 @@ type Provider struct {
 	runner ports.ToolRunner
 }
 
-// New returns a provider using the given synapse-ast binary (defaults to "synapse-ast" in PATH).
+// New returns a provider using the given synapse-ast binary. An empty bin triggers zero-setup discovery
+// (resolveSidecar): the sidecar shipped ALONGSIDE the running executable is used automatically, so a
+// distribution that bundles synapse-cli + synapse-ast "just works" with no SYNAPSE_AST_BIN and no PATH
+// entry; otherwise it falls back to "synapse-ast" resolved on PATH by exec.
 func New(bin string) *Provider {
 	if strings.TrimSpace(bin) == "" {
-		bin = "synapse-ast"
+		bin = resolveSidecar()
 	}
 	return &Provider{bin: bin}
+}
+
+// sidecarName is the sidecar executable's basename for the current OS.
+func sidecarName() string {
+	if runtime.GOOS == "windows" {
+		return "synapse-ast.exe"
+	}
+	return "synapse-ast"
+}
+
+// resolveSidecar finds the synapse-ast sidecar with zero configuration. It prefers a copy sitting next to
+// the running executable (the common "bundled distribution" layout), then the plain name for a PATH
+// lookup at exec time. Returning the bare name (not "") keeps the existing behavior when nothing is
+// bundled: a missing binary later degrades to available=false, never an error.
+func resolveSidecar() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return sidecarName()
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return resolveSidecarIn(filepath.Dir(exe))
+}
+
+// resolveSidecarIn returns the bundled sidecar path if it exists in exeDir, else the bare name (PATH
+// lookup at exec time). Split out from resolveSidecar so the discovery logic is unit-testable.
+func resolveSidecarIn(exeDir string) string {
+	cand := filepath.Join(exeDir, sidecarName())
+	if fi, err := os.Stat(cand); err == nil && fi.Mode().IsRegular() {
+		return cand
+	}
+	return sidecarName()
 }
 
 // WithRunner confines the sidecar via a ToolRunner (the SandboxRunner) – recommended in production, since

--- a/internal/infrastructure/tools/ast/provider.go
+++ b/internal/infrastructure/tools/ast/provider.go
@@ -67,12 +67,16 @@ func resolveSidecar() string {
 	return resolveSidecarIn(filepath.Dir(exe))
 }
 
-// resolveSidecarIn returns the bundled sidecar path if it exists in exeDir, else the bare name (PATH
-// lookup at exec time). Split out from resolveSidecar so the discovery logic is unit-testable.
+// resolveSidecarIn returns the bundled sidecar path if a runnable copy exists in exeDir, else the bare
+// name (PATH lookup at exec time). Split out from resolveSidecar so the discovery logic is unit-testable.
+// It requires a regular, executable file: a non-executable stub (0-byte / partial download / wrong perms)
+// next to the launcher must NOT shadow a working copy on PATH — falling through lets PATH still resolve.
 func resolveSidecarIn(exeDir string) string {
 	cand := filepath.Join(exeDir, sidecarName())
 	if fi, err := os.Stat(cand); err == nil && fi.Mode().IsRegular() {
-		return cand
+		if runtime.GOOS == "windows" || fi.Mode().Perm()&0o111 != 0 { // exec bit is meaningless on Windows
+			return cand
+		}
 	}
 	return sidecarName()
 }


### PR DESCRIPTION
Removes a setup step for the code-quality features. `ast.New("")` now discovers the `synapse-ast` sidecar shipped **next to the running executable** (`os.Executable` dir) before falling back to a PATH lookup, so `synapse-cli quality/metrics <path>` works with **no `SYNAPSE_AST_BIN` and no PATH entry** when the binaries ship together.

Best-effort + FP-free: missing sidecar still degrades to `available=false` (never an error); only a regular file is accepted (a dir named like the sidecar is ignored); a symlinked launcher is resolved. `resolveSidecarIn` is unit-tested (bundled-preferred, fallback, dir-ignored) + `New("")` never leaves bin empty.

Verified E2E: `metrics` computes Java complexity with neither `SYNAPSE_AST_BIN` set nor `synapse-ast` on PATH, using the bundled copy. build + vet + `CGO_ENABLED=0 build ./cmd/...` green.