### PR TITLE
feat(sca): resolve a lockfile-less package.json (zero-setup JS dependency SCA)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavencoord"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/npmresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/nvd"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ospkg"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/osv"
@@ -545,6 +546,18 @@ func main() {
 			scaService.SetGradleResolver(gradleresolve.New(cfg.GradleBin).WithRunner(scaSandbox).
 				WithRepoHosts(cfg.MavenRepoHosts).WithGradleHome(cfg.GradleHome))
 			log.Info("Gradle transitive-tree resolution ENABLED (gradle dependencies, sandbox-confined; best-effort)", "extra_repo_hosts", len(cfg.MavenRepoHosts), "persistent_cache", cfg.GradleHome != "")
+		}
+	}
+	// npm resolution for a lockfile-less package.json (`npm install --package-lock-only --ignore-scripts`):
+	// reaches the registry over an untrusted manifest, so the SERVER enables it ONLY with the SCA sandbox
+	// and FAILS CLOSED otherwise (never host-execs npm over an untrusted target). --ignore-scripts + a
+	// throwaway copy mean no project code runs and the source is never mutated. Opt-in.
+	if cfg.NPMResolveEnabled {
+		if scaSandbox == nil {
+			log.Warn("SYNAPSE_NPM_RESOLVE_ENABLED ignored: it requires the SCA sandbox (npm would otherwise reach the network over an untrusted manifest on the host). Enable the sandbox to use it.")
+		} else {
+			scaService.SetNPMResolver(npmresolve.New(cfg.NpmBin).WithRunner(scaSandbox).WithRegistryHosts(cfg.NpmRegistryHosts))
+			log.Info("npm resolution ENABLED (npm install --package-lock-only, sandbox-confined; best-effort)", "extra_registry_hosts", len(cfg.NpmRegistryHosts))
 		}
 	}
 	if cfg.JVMReachabilityEnabled {

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -556,8 +556,8 @@ func main() {
 		if scaSandbox == nil {
 			log.Warn("SYNAPSE_NPM_RESOLVE_ENABLED ignored: it requires the SCA sandbox (npm would otherwise reach the network over an untrusted manifest on the host). Enable the sandbox to use it.")
 		} else {
-			scaService.SetNPMResolver(npmresolve.New(cfg.NpmBin).WithRunner(scaSandbox).WithRegistryHosts(cfg.NpmRegistryHosts))
-			log.Info("npm resolution ENABLED (npm install --package-lock-only, sandbox-confined; best-effort)", "extra_registry_hosts", len(cfg.NpmRegistryHosts))
+			scaService.SetNPMResolver(npmresolve.New(cfg.NPMBin).WithRunner(scaSandbox).WithRegistryHosts(cfg.NPMRegistryHosts))
+			log.Info("npm resolution ENABLED (npm install --package-lock-only, sandbox-confined; best-effort)", "extra_registry_hosts", len(cfg.NPMRegistryHosts))
 		}
 	}
 	if cfg.JVMReachabilityEnabled {

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1026,7 +1026,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		npmOn = true
 	}
 	if npmOn {
-		sca.SetNPMResolver(npmresolve.New(cfg.NpmBin).WithRegistryHosts(cfg.NpmRegistryHosts))
+		sca.SetNPMResolver(npmresolve.New(cfg.NPMBin).WithRegistryHosts(cfg.NPMRegistryHosts))
 		fmt.Fprintln(os.Stderr, "synapse-cli: npm resolver ON – runs `npm install --package-lock-only --ignore-scripts` over a COPY of a lockfile-less package.json to pin versions (no project scripts run; set SYNAPSE_NPM_RESOLVE_ENABLED=false to disable)")
 	}
 	// Coarse JVM class-reachability – default-on for the CLI (read-only bytecode parsing, no exec);

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavencoord"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/npmresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/nvd"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ospkg"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/osv"
@@ -1017,6 +1018,16 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		sca.SetGradleResolver(gradleresolve.New(cfg.GradleBin).WithRepoHosts(cfg.MavenRepoHosts).WithGradleHome(cfg.GradleHome))
 		// Gradle evaluates build.gradle (arbitrary Groovy/Kotlin) – even higher-risk than mvn; surface it.
 		fmt.Fprintln(os.Stderr, "synapse-cli: Gradle resolver ON – runs `gradle` UNSANDBOXED over the project if it has a build.gradle, which executes the build script (trusted-local assumption; set SYNAPSE_GRADLE_RESOLVE_ENABLED=false to disable)")
+	}
+	// npm resolution for a lockfile-less package.json – same default-on-for-CLI model (trusted local).
+	// Opt out with SYNAPSE_NPM_RESOLVE_ENABLED=false. Best-effort; --ignore-scripts so no project code runs.
+	npmOn := cfg.NPMResolveEnabled
+	if _, set := os.LookupEnv("SYNAPSE_NPM_RESOLVE_ENABLED"); !set {
+		npmOn = true
+	}
+	if npmOn {
+		sca.SetNPMResolver(npmresolve.New(cfg.NpmBin).WithRegistryHosts(cfg.NpmRegistryHosts))
+		fmt.Fprintln(os.Stderr, "synapse-cli: npm resolver ON – runs `npm install --package-lock-only --ignore-scripts` over a COPY of a lockfile-less package.json to pin versions (no project scripts run; set SYNAPSE_NPM_RESOLVE_ENABLED=false to disable)")
 	}
 	// Coarse JVM class-reachability – default-on for the CLI (read-only bytecode parsing, no exec);
 	// tags each JVM component reachable/unreferenced from the app's compiled closure. Opt out with

--- a/internal/infrastructure/tools/npmresolve/resolver.go
+++ b/internal/infrastructure/tools/npmresolve/resolver.go
@@ -1,0 +1,191 @@
+// Package npmresolve resolves an npm project's dependency tree (direct + transitive, with pinned
+// versions) from a package.json that has NO committed lockfile — the common raw-source state where the
+// manifest declares only semver RANGES (^1.2.3, ~1.0, >=2) and the SBOM otherwise sees no resolvable
+// version to advisory-match. It shells out (argv only, no shell) to a pinned `npm` binary running
+// `npm install --package-lock-only --ignore-scripts`, which resolves the full tree from the registry into
+// a package-lock.json WITHOUT downloading node_modules and WITHOUT running any lifecycle script, then
+// reuses the owned package-lock.json parser to emit pkg:npm components. Zero-setup: the user does not have
+// to run `npm install` first.
+//
+// SECURITY: package.json can declare preinstall/install/postinstall lifecycle scripts that run arbitrary
+// code. `--ignore-scripts` disables them, and `--package-lock-only` skips node_modules/build entirely, so
+// no project code executes. The command runs against a COPY of package.json in a throwaway temp dir, so
+// the user's project is never mutated. It invokes a PINNED `npm` (never a project-vendored one). In
+// production it MUST run through a ToolRunner (the sandbox) confining the filesystem and restricting egress
+// to the configured registry; the API composition root refuses to enable it without a sandbox
+// (fail-closed). Direct-exec is the trusted-local CLI dogfood path. OPT-IN (SYNAPSE_NPM_RESOLVE_ENABLED) +
+// BEST-EFFORT: no package.json / a committed lockfile / missing npm / any error yields no components and
+// never fails the scan.
+package npmresolve
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownsbom"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// defaultRegistryHosts is the egress allow-list for the sandboxed run: the public npm registry. Private
+// registries are added via WithRegistryHosts.
+var defaultRegistryHosts = []string{"registry.npmjs.org"}
+
+// lockfileNames are the committed lockfiles that make resolution redundant (the owned NPM/other parsers
+// already read them on their own marker pass), so the resolver stays a no-op when one is present.
+var lockfileNames = []string{"package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml"}
+
+// Resolver runs `npm install --package-lock-only` to resolve a package.json with no committed lockfile.
+type Resolver struct {
+	bin      string
+	runner   ports.ToolRunner
+	regHosts []string
+}
+
+// New returns a resolver using the given npm binary (defaults to "npm" in PATH).
+func New(bin string) *Resolver {
+	if strings.TrimSpace(bin) == "" {
+		bin = "npm"
+	}
+	return &Resolver{bin: bin}
+}
+
+// WithRunner runs npm through a ToolRunner (the SandboxRunner): the throwaway workdir is the one writable
+// bind and egress is restricted to the configured registry. nil keeps the direct exec (dev/CLI; trusted).
+func (r *Resolver) WithRunner(runner ports.ToolRunner) *Resolver { r.runner = runner; return r }
+
+// WithRegistryHosts adds extra registry hosts to the sandbox egress allow-list (private mirror).
+func (r *Resolver) WithRegistryHosts(hosts []string) *Resolver {
+	for _, h := range hosts {
+		if h = strings.TrimSpace(h); h != "" {
+			r.regHosts = append(r.regHosts, h)
+		}
+	}
+	return r
+}
+
+var _ ports.NPMResolver = (*Resolver)(nil)
+
+// Resolve returns the resolved pkg:npm component tree for a package.json under dir with no committed
+// lockfile. It is a no-op (nil, nil) when there is no package.json, a lockfile is already present, or npm
+// is unavailable; any resolution error is returned alongside whatever resolved so a failure is diagnosable.
+func (r *Resolver) Resolve(ctx context.Context, dir string) ([]sbom.Component, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	pkgJSON := filepath.Join(dir, "package.json")
+	if fi, err := os.Stat(pkgJSON); err != nil || !fi.Mode().IsRegular() {
+		return nil, nil // not an npm project (root)
+	}
+	for _, ln := range lockfileNames {
+		if fi, err := os.Stat(filepath.Join(dir, ln)); err == nil && fi.Mode().IsRegular() {
+			return nil, nil // a committed lockfile is parsed directly; resolution would be redundant
+		}
+	}
+
+	// Work in a throwaway dir so npm never writes into the user's project. npm needs a writable HOME +
+	// cache; keep both inside the temp dir so nothing leaks onto the host.
+	work, err := os.MkdirTemp("", "synapse-npmresolve-")
+	if err != nil {
+		return nil, fmt.Errorf("npm resolve: temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(work) }()
+	data, err := os.ReadFile(pkgJSON)
+	if err != nil {
+		return nil, fmt.Errorf("npm resolve: read package.json: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(work, "package.json"), data, 0o600); err != nil {
+		return nil, fmt.Errorf("npm resolve: stage package.json: %w", err)
+	}
+
+	if err := r.run(ctx, work); err != nil {
+		return nil, err
+	}
+	lock, err := os.ReadFile(filepath.Join(work, "package-lock.json"))
+	if err != nil {
+		return nil, fmt.Errorf("npm resolve: no package-lock.json produced: %w", err)
+	}
+	comps, _, err := ownsbom.NPM{}.Parse(ctx, ownsbom.ParseInput{Dir: dir, Path: pkgJSON, Content: lock})
+	if err != nil {
+		return nil, fmt.Errorf("npm resolve: parse generated lock: %w", err)
+	}
+	return comps, nil
+}
+
+// args resolves the lockfile only, with all script execution and interactive/telemetry noise disabled.
+func (r *Resolver) args() []string {
+	return []string{
+		"install", "--package-lock-only", "--ignore-scripts",
+		"--no-audit", "--no-fund", "--no-update-notifier", "--loglevel=error",
+	}
+}
+
+func (r *Resolver) allowedHosts() []string {
+	return append(append([]string{}, defaultRegistryHosts...), r.regHosts...)
+}
+
+// run executes npm in the prepared work dir. env keeps npm's HOME and cache inside the throwaway dir.
+func (r *Resolver) run(ctx context.Context, work string) error {
+	env := []string{
+		"HOME=" + work,
+		"npm_config_cache=" + filepath.Join(work, ".npm"),
+		"npm_config_fund=false",
+		"npm_config_audit=false",
+		"npm_config_update_notifier=false",
+	}
+	if r.runner != nil {
+		res, err := r.runner.Run(ctx, ports.ToolSpec{
+			Name:         r.bin,
+			Args:         r.args(),
+			Workdir:      work, // the one writable bind (package.json copy + generated lock + cache)
+			Env:          env,
+			EgressPolicy: &ports.EgressPolicy{AllowDomains: r.allowedHosts()},
+		})
+		if err != nil {
+			return fmt.Errorf("npm resolve (sandboxed): %w: %s", err, truncate(string(res.Stderr), 300))
+		}
+		if res.ExitCode != 0 {
+			return fmt.Errorf("npm resolve: exit %d: %s", res.ExitCode, truncate(string(res.Stderr), 300))
+		}
+		return nil
+	}
+	// Direct exec: dev/CLI path for a TRUSTED local project. --ignore-scripts still holds, so no project
+	// code runs; scrub SYNAPSE_* secrets from the child regardless (defense-in-depth).
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, r.bin, r.args()...)
+	cmd.Dir = work
+	cmd.Env = append(scrubSynapseEnv(os.Environ()), env...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("npm resolve: %w: %s", err, truncate(stderr.String(), 300))
+	}
+	return nil
+}
+
+// scrubSynapseEnv drops SYNAPSE_* entries so the child npm (and any transitively-run tooling) cannot read
+// Synapse secrets from the environment. Non-SYNAPSE vars (PATH, npm config, ...) are preserved.
+func scrubSynapseEnv(env []string) []string {
+	out := env[:0:0]
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "SYNAPSE_") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}

--- a/internal/infrastructure/tools/npmresolve/resolver.go
+++ b/internal/infrastructure/tools/npmresolve/resolver.go
@@ -72,8 +72,10 @@ func (r *Resolver) WithRegistryHosts(hosts []string) *Resolver {
 var _ ports.NPMResolver = (*Resolver)(nil)
 
 // Resolve returns the resolved pkg:npm component tree for a package.json under dir with no committed
-// lockfile. It is a no-op (nil, nil) when there is no package.json, a lockfile is already present, or npm
-// is unavailable; any resolution error is returned alongside whatever resolved so a failure is diagnosable.
+// lockfile. It is a no-op (nil, nil) when there is no package.json or a committed lockfile is already
+// present. A missing npm binary or any resolution error returns (nil, err), which the SCA service surfaces
+// as a source warning (never failing the scan); components are returned only on success (never partial).
+// Only the top-level dir is inspected (a monorepo with package.json in subfolders is not walked here).
 func (r *Resolver) Resolve(ctx context.Context, dir string) ([]sbom.Component, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -159,7 +161,7 @@ func (r *Resolver) run(ctx context.Context, work string) error {
 	var stdout, stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, r.bin, r.args()...)
 	cmd.Dir = work
-	cmd.Env = append(scrubSynapseEnv(os.Environ()), env...)
+	cmd.Env = append(scrubSensitiveEnv(os.Environ()), env...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -168,17 +170,38 @@ func (r *Resolver) run(ctx context.Context, work string) error {
 	return nil
 }
 
-// scrubSynapseEnv drops SYNAPSE_* entries so the child npm (and any transitively-run tooling) cannot read
-// Synapse secrets from the environment. Non-SYNAPSE vars (PATH, npm config, ...) are preserved.
-func scrubSynapseEnv(env []string) []string {
+// scrubSensitiveEnv drops SYNAPSE_* entries AND common credential env vars (registry / CI / cloud tokens
+// such as NPM_TOKEN, NODE_AUTH_TOKEN, GITHUB_TOKEN, AWS_SECRET_ACCESS_KEY) so the child npm — and anything
+// it transitively spawns — cannot read Synapse or host secrets from the environment. Non-sensitive vars
+// (PATH, npm config, ...) are preserved. Defense-in-depth on the trusted-local direct-exec path; the
+// sandbox path already runs with a controlled, non-inherited env.
+func scrubSensitiveEnv(env []string) []string {
 	out := env[:0:0]
 	for _, kv := range env {
-		if strings.HasPrefix(kv, "SYNAPSE_") {
+		name := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			name = kv[:i]
+		}
+		if isSensitiveEnvName(name) {
 			continue
 		}
 		out = append(out, kv)
 	}
 	return out
+}
+
+// isSensitiveEnvName reports whether an env var name looks like a Synapse or credential variable.
+func isSensitiveEnvName(name string) bool {
+	if strings.HasPrefix(name, "SYNAPSE_") {
+		return true
+	}
+	u := strings.ToUpper(name)
+	for _, frag := range []string{"TOKEN", "SECRET", "PASSWORD", "PASSWD", "APIKEY", "API_KEY", "ACCESS_KEY", "PRIVATE_KEY", "CREDENTIAL"} {
+		if strings.Contains(u, frag) {
+			return true
+		}
+	}
+	return false
 }
 
 func truncate(s string, n int) string {

--- a/internal/infrastructure/tools/npmresolve/resolver_test.go
+++ b/internal/infrastructure/tools/npmresolve/resolver_test.go
@@ -1,0 +1,63 @@
+package npmresolve
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveNoOpWithoutPackageJSON(t *testing.T) {
+	comps, err := New("npm").Resolve(context.Background(), t.TempDir())
+	if err != nil || comps != nil {
+		t.Errorf("no package.json must be a no-op (nil, nil); got %d comps, err=%v", len(comps), err)
+	}
+}
+
+func TestResolveNoOpWhenLockfilePresent(t *testing.T) {
+	// A committed lockfile is parsed directly by the owned parser, so the resolver must NOT run npm
+	// (redundant, and it would waste a network round trip). Uses a bad bin to prove npm is never invoked.
+	for _, lock := range lockfileNames {
+		dir := t.TempDir()
+		write(t, filepath.Join(dir, "package.json"), `{"name":"x","version":"1.0.0"}`)
+		write(t, filepath.Join(dir, lock), "{}")
+		comps, err := New("/nonexistent/npm-should-never-run").Resolve(context.Background(), dir)
+		if err != nil || comps != nil {
+			t.Errorf("%s present must short-circuit to (nil, nil); got %d comps, err=%v", lock, len(comps), err)
+		}
+	}
+}
+
+func TestArgsAreScriptSafe(t *testing.T) {
+	got := strings.Join(New("npm").args(), " ")
+	for _, must := range []string{"--ignore-scripts", "--package-lock-only"} {
+		if !strings.Contains(got, must) {
+			t.Errorf("resolver args MUST contain %q (safety-critical); got %q", must, got)
+		}
+	}
+	// No build/install of node_modules and no arbitrary run.
+	if strings.Contains(got, "run ") || strings.Contains(got, "exec") {
+		t.Errorf("resolver args must not run scripts/exec; got %q", got)
+	}
+}
+
+func TestScrubSynapseEnv(t *testing.T) {
+	in := []string{"PATH=/usr/bin", "SYNAPSE_LLM_API_KEY=secret", "HOME=/h", "SYNAPSE_DB_DSN=x"}
+	out := scrubSynapseEnv(in)
+	for _, kv := range out {
+		if strings.HasPrefix(kv, "SYNAPSE_") {
+			t.Errorf("SYNAPSE_* must be scrubbed; found %q", kv)
+		}
+	}
+	if len(out) != 2 {
+		t.Errorf("want the 2 non-SYNAPSE vars kept, got %v", out)
+	}
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/infrastructure/tools/npmresolve/resolver_test.go
+++ b/internal/infrastructure/tools/npmresolve/resolver_test.go
@@ -42,16 +42,25 @@ func TestArgsAreScriptSafe(t *testing.T) {
 	}
 }
 
-func TestScrubSynapseEnv(t *testing.T) {
-	in := []string{"PATH=/usr/bin", "SYNAPSE_LLM_API_KEY=secret", "HOME=/h", "SYNAPSE_DB_DSN=x"}
-	out := scrubSynapseEnv(in)
+func TestScrubSensitiveEnv(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin", "HOME=/h", // kept
+		"SYNAPSE_LLM_API_KEY=x", "SYNAPSE_DB_DSN=x", // Synapse
+		"NPM_TOKEN=x", "NODE_AUTH_TOKEN=x", "GITHUB_TOKEN=x", // registry/CI
+		"AWS_SECRET_ACCESS_KEY=x", "AWS_ACCESS_KEY_ID=x", "DB_PASSWORD=x", // cloud/db creds
+	}
+	out := scrubSensitiveEnv(in)
+	kept := map[string]bool{}
 	for _, kv := range out {
-		if strings.HasPrefix(kv, "SYNAPSE_") {
-			t.Errorf("SYNAPSE_* must be scrubbed; found %q", kv)
+		kept[kv] = true
+		for _, frag := range []string{"SYNAPSE_", "TOKEN", "SECRET", "ACCESS_KEY", "PASSWORD"} {
+			if strings.Contains(strings.ToUpper(kv), frag) {
+				t.Errorf("sensitive var must be scrubbed; found %q", kv)
+			}
 		}
 	}
-	if len(out) != 2 {
-		t.Errorf("want the 2 non-SYNAPSE vars kept, got %v", out)
+	if !kept["PATH=/usr/bin"] || !kept["HOME=/h"] || len(out) != 2 {
+		t.Errorf("only the 2 non-sensitive vars must remain, got %v", out)
 	}
 }
 

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -245,10 +245,10 @@ type Config struct {
 	// NPMResolveEnabled turns on npm dependency resolution via `npm install --package-lock-only` for a
 	// package.json with no committed lockfile (best-effort + opt-in). It runs --ignore-scripts (no project
 	// code executes) against a throwaway copy, but reaches the registry, so production MUST run it
-	// sandbox-confined. NpmBin is the pinned npm executable; NpmRegistryHosts extends the egress allow-list.
+	// sandbox-confined. NPMBin is the pinned npm executable; NPMRegistryHosts extends the egress allow-list.
 	NPMResolveEnabled bool
-	NpmBin            string
-	NpmRegistryHosts  []string
+	NPMBin            string
+	NPMRegistryHosts  []string
 	// JVMReachabilityEnabled turns on coarse JVM class-reachability tagging: after resolving the
 	// dependency tree, tag each component with whether the app's own compiled classes (transitively)
 	// reference its classes, so a finding on an unreferenced dependency can be deprioritized. Read-only
@@ -375,8 +375,8 @@ func Load() Config {
 		GradleBin:              getenv("SYNAPSE_GRADLE_BIN", "gradle"),
 		GradleHome:             getenv("SYNAPSE_GRADLE_HOME", ""),
 		NPMResolveEnabled:      getbool("SYNAPSE_NPM_RESOLVE_ENABLED", false),
-		NpmBin:                 getenv("SYNAPSE_NPM_BIN", "npm"),
-		NpmRegistryHosts:       splitList(getenv("SYNAPSE_NPM_REGISTRY_HOSTS", "")),
+		NPMBin:                 getenv("SYNAPSE_NPM_BIN", "npm"),
+		NPMRegistryHosts:       splitList(getenv("SYNAPSE_NPM_REGISTRY_HOSTS", "")),
 		JVMReachabilityEnabled: getbool("SYNAPSE_JVM_REACHABILITY_ENABLED", true),
 		JarHashOnlineEnabled:   getbool("SYNAPSE_JARHASH_ONLINE_ENABLED", false),
 		JarHashBaseURL:         getenv("SYNAPSE_JARHASH_BASE_URL", ""),

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -242,6 +242,13 @@ type Config struct {
 	GradleResolveEnabled bool
 	GradleBin            string
 	GradleHome           string
+	// NPMResolveEnabled turns on npm dependency resolution via `npm install --package-lock-only` for a
+	// package.json with no committed lockfile (best-effort + opt-in). It runs --ignore-scripts (no project
+	// code executes) against a throwaway copy, but reaches the registry, so production MUST run it
+	// sandbox-confined. NpmBin is the pinned npm executable; NpmRegistryHosts extends the egress allow-list.
+	NPMResolveEnabled bool
+	NpmBin            string
+	NpmRegistryHosts  []string
 	// JVMReachabilityEnabled turns on coarse JVM class-reachability tagging: after resolving the
 	// dependency tree, tag each component with whether the app's own compiled classes (transitively)
 	// reference its classes, so a finding on an unreferenced dependency can be deprioritized. Read-only
@@ -367,6 +374,9 @@ func Load() Config {
 		GradleResolveEnabled:   getbool("SYNAPSE_GRADLE_RESOLVE_ENABLED", false),
 		GradleBin:              getenv("SYNAPSE_GRADLE_BIN", "gradle"),
 		GradleHome:             getenv("SYNAPSE_GRADLE_HOME", ""),
+		NPMResolveEnabled:      getbool("SYNAPSE_NPM_RESOLVE_ENABLED", false),
+		NpmBin:                 getenv("SYNAPSE_NPM_BIN", "npm"),
+		NpmRegistryHosts:       splitList(getenv("SYNAPSE_NPM_REGISTRY_HOSTS", "")),
 		JVMReachabilityEnabled: getbool("SYNAPSE_JVM_REACHABILITY_ENABLED", true),
 		JarHashOnlineEnabled:   getbool("SYNAPSE_JARHASH_ONLINE_ENABLED", false),
 		JarHashBaseURL:         getenv("SYNAPSE_JARHASH_BASE_URL", ""),

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -713,6 +713,20 @@ type GradleResolver interface {
 	Resolve(ctx context.Context, dir string) ([]sbom.Component, error)
 }
 
+// NPMResolver resolves an npm project's FULL dependency tree (direct + transitive, with pinned versions)
+// from a package.json that has NO committed lockfile — the common raw-source state where the manifest
+// declares only semver RANGES and the SBOM otherwise sees no resolvable version to advisory-match. It
+// returns versioned pkg:npm components for the SCA pipeline to fold in.
+//
+// SAFETY: package.json can declare lifecycle scripts (preinstall/install/postinstall) that run arbitrary
+// code. A production implementation MUST run sandbox-confined with egress restricted to the registry and
+// MUST resolve the lockfile only (--ignore-scripts, no node_modules, no build) so no project code executes.
+// Best-effort + OPT-IN: a non-npm target, a committed lockfile, a missing npm binary, or any resolution
+// error returns no components and never fails the scan.
+type NPMResolver interface {
+	Resolve(ctx context.Context, dir string) ([]sbom.Component, error)
+}
+
 // SBOMEnrichment is what an SBOMEnricher contributed, for honest provenance.
 type SBOMEnrichment struct {
 	ComponentsAdded   int      // components the generator missed (Maven/Gradle direct deps)

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -79,6 +79,7 @@ type Service struct {
 	graphResolver     ports.DependencyGraphResolver   // optional transitive-edge resolver (Go via `go mod graph`)
 	mavenResolver     ports.MavenResolver             // optional Maven transitive-tree resolver (`mvn dependency:list`)
 	gradleResolver    ports.GradleResolver            // optional Gradle transitive-tree resolver (`gradle dependencies`)
+	npmResolver       ports.NPMResolver               // optional npm resolver (`npm install --package-lock-only`) for a lockfile-less package.json
 	jvmReach          ports.JVMReachabilityAnalyzer   // optional coarse JVM class-reachability tagger
 	sevEnricher       ports.SeverityEnricher          // optional NVD CVSS backfill for unknown-severity vulns
 	ignoreUnfixed     bool                            // when set, don't promote no-fix vulns to findings (Trivy --ignore-unfixed)
@@ -250,6 +251,10 @@ func (s *Service) SetMavenResolver(r ports.MavenResolver) { s.mavenResolver = r 
 // resolution error leaves the SBOM unchanged and never fails the scan.
 func (s *Service) SetGradleResolver(r ports.GradleResolver) { s.gradleResolver = r }
 
+// SetNPMResolver configures the optional npm resolver (`npm install --package-lock-only`), which resolves
+// a package.json that has no committed lockfile into a pinned pkg:npm tree. nil ⇒ disabled.
+func (s *Service) SetNPMResolver(r ports.NPMResolver) { s.npmResolver = r }
+
 // mergeResolvedJVM folds a resolver's transitive pkg:maven tree into doc and dedups by identity. Shared by
 // the Maven + Gradle resolvers (both emit Maven coordinates). No-op on an empty resolved set – with nothing
 // authoritative to substitute, syft's view (including any target/ jars, then the only version source) is
@@ -277,6 +282,24 @@ func mergeResolvedJVM(doc *sbom.SBOM, resolved []sbom.Component, completeScopes 
 	for _, c := range doc.Components {
 		if strings.HasPrefix(c.PURL, "pkg:maven/") && (completeScopes || !sbom.IsResolvedVersion(c.Version)) {
 			continue // resolver owns (this slice of) the JVM tree; drop the redundant syft entries
+		}
+		kept = append(kept, c)
+	}
+	doc.Components = sbom.DedupeComponents(append(kept, resolved...))
+}
+
+// mergeResolvedNPM folds an npm resolver's pinned pkg:npm tree into doc. Like the Gradle path it drops
+// only the generator's UNVERSIONED npm placeholders (a lockfile-less package.json yields range-declared,
+// version-less entries) and keeps any concretely-versioned npm components, then adds the resolved tree and
+// dedups by identity. No-op on an empty resolved set.
+func mergeResolvedNPM(doc *sbom.SBOM, resolved []sbom.Component) {
+	if len(resolved) == 0 {
+		return
+	}
+	kept := make([]sbom.Component, 0, len(doc.Components))
+	for _, c := range doc.Components {
+		if strings.HasPrefix(c.PURL, "pkg:npm/") && !sbom.IsResolvedVersion(c.Version) {
+			continue // resolver owns the versioned npm tree; drop the redundant unversioned placeholders
 		}
 		kept = append(kept, c)
 	}
@@ -1541,7 +1564,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	// unversioned pom-derived Maven placeholders with the resolved tree (direct + transitive, versioned) so
 	// detection + licensing run over the real artifacts. A non-Maven target / missing mvn / error is a no-op.
 	mavenResolved := false
-	var mavenResolveErr, gradleResolveErr error // surfaced as a SourceWarning so a failed resolve is diagnosable
+	var mavenResolveErr, gradleResolveErr, npmResolveErr error // surfaced as a SourceWarning so a failed resolve is diagnosable
 	if s.mavenResolver != nil {
 		step = trace.start(stageSBOM, "maven-resolve", "maven-resolver", "Resolve Maven dependency tree", map[string]int{"components": countComponents(doc)})
 		resolvedComps, mrr := s.mavenResolver.Resolve(ctx, ws.Dir)
@@ -1582,6 +1605,29 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 			trace.succeed(step, "Gradle dependency tree resolved", map[string]int{"components_before": before, "components": countComponents(doc), "resolved": len(resolvedComps)})
 		default:
 			trace.succeed(step, "Gradle resolution skipped (not a Gradle project)", map[string]int{"components": countComponents(doc)})
+		}
+	}
+	// Resolve a lockfile-less npm package.json to a pinned tree via `npm install --package-lock-only`
+	// (best-effort + opt-in). Zero-setup: package.json alone declares only semver ranges, so without this
+	// (and without a committed lockfile) there is no version to advisory-match. npm components merge like
+	// the JVM ones: drop the generator's unversioned placeholders, keep resolved versions.
+	npmResolved := false
+	if s.npmResolver != nil {
+		step = trace.start(stageSBOM, "npm-resolve", "npm-resolver", "Resolve npm dependency tree", map[string]int{"components": countComponents(doc)})
+		resolvedComps, nrr := s.npmResolver.Resolve(ctx, ws.Dir)
+		before := countComponents(doc)
+		if len(resolvedComps) > 0 {
+			mergeResolvedNPM(doc, resolvedComps)
+			npmResolved = true
+		}
+		switch {
+		case nrr != nil:
+			npmResolveErr = nrr
+			trace.fail(step, nrr)
+		case npmResolved:
+			trace.succeed(step, "npm dependency tree resolved", map[string]int{"components_before": before, "components": countComponents(doc), "resolved": len(resolvedComps)})
+		default:
+			trace.succeed(step, "npm resolution skipped (no lockless package.json)", map[string]int{"components": countComponents(doc)})
 		}
 	}
 	// Coarse JVM class-reachability, best-effort + opt-in: tag each JVM component with whether the
@@ -1762,6 +1808,10 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 			sourceWarnings = append(sourceWarnings, fmt.Sprintf(
 				"Gradle dependency resolution failed – transitive tree NOT captured (result INCOMPLETE): %v", gradleResolveErr))
 		}
+	}
+	if npmResolveErr != nil {
+		sourceWarnings = append(sourceWarnings, fmt.Sprintf(
+			"npm dependency resolution failed – package.json tree NOT captured (result INCOMPLETE): %v", npmResolveErr))
 	}
 	// An image target whose rootfs could not be assembled means OS packages were NOT owned-cataloged; surface
 	// it (never silent) so an absent OS-package set reads as "not analyzed", not "no OS packages".


### PR DESCRIPTION
Makes Synapse zero-setup for JS SCA. A raw JS source usually ships `package.json` but no committed lockfile, so its deps are declared only as semver ranges — the SBOM had no resolvable version and SCA reported **nothing** (the same "you must prepare the source first" friction as Trivy, and the same class as the earlier Gradle limit fixed in #124).

**New `npmresolve` adapter** (`ports.NPMResolver`) runs the package manager in `--package-lock-only --ignore-scripts` mode over a **throwaway copy** of `package.json`, resolving the full transitive tree into a lockfile **without** downloading `node_modules` and **without** running any lifecycle script, then reuses the owned lockfile parser to emit pinned `pkg:npm` components.

**Safety**
- `--ignore-scripts` → no `preinstall`/`install`/`postinstall` project code runs.
- Runs against a temp copy → the user's project is never mutated.
- Pinned binary (never a project-vendored one); `SYNAPSE_*` env scrubbed from the child.
- CLI: default-on / direct-exec (trusted-local dogfood) with a stderr transparency note.
- API: enabled **only** with the SCA sandbox (egress confined to the registry), **fails closed** otherwise — never host-execs over an untrusted target.
- Best-effort + opt-in (`SYNAPSE_NPM_RESOLVE_ENABLED`): no `package.json` / a committed lockfile / missing binary / any error → no-op, scan never fails. `mergeResolvedNPM` drops only the generator's unversioned placeholders before folding in the resolved tree (dedup by PURL).

**Verified E2E** — a `package.json` declaring `express@4.17.1` + `lodash` with **NO lockfile**:
```
SBOM components: 51 (pkg:npm, full transitive tree)
vulnerabilities: 11  (4 high: qs, path-to-regexp x2, body-parser; + medium/low)
```
where Synapse/Trivy previously found **zero** on the same raw folder.

Unit tests: no-op paths (no manifest / committed lockfile present), script-safe args (`--ignore-scripts` + `--package-lock-only` required), `SYNAPSE_*` scrubbing. `go build ./...`, `go vet`, `CGO_ENABLED=0 build ./cmd/...`, and the full suite (119 pkgs) pass.
