### PR TITLE
feat(sca): add uv.lock registry component parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **SCA.** Added first-party OwnSBOM support for exact registry packages in Python `uv.lock` files.
 - **SCA.** Added Conan 1.x node-level `python_requires` components to OwnSBOM output.
 - **SCA.** Added deterministic dependency graph relationships for Conan 1.x `graph_lock` files.
 - **SCA.** Added OwnSBOM support for exact Conan dependencies declared in `conanfile.txt`.

--- a/internal/infrastructure/tools/ownsbom/registry.go
+++ b/internal/infrastructure/tools/ownsbom/registry.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// ownsbomVersion identifies this producer in SBOM provenance. Bump when parser behavior changes.
-	ownsbomVersion = "ownsbom/0.5.0"
+	ownsbomVersion = "ownsbom/0.6.0"
 	// maxManifestBytes caps a single manifest read so a hostile/corrupt repo cannot OOM the scan with an
 	// absurd file. Real manifests are KB–low-MB; exceeding this is malicious or wrong, so it fails loud.
 	maxManifestBytes = 64 << 20
@@ -89,11 +89,11 @@ func New(parsers ...EcosystemParser) (*Registry, error) {
 }
 
 // DefaultRegistry assembles the owned parsers into the detection-independent SBOM producer, covering Go,
-// JS (npm/yarn/pnpm), Python (PyPI/Poetry/Pipfile/Conda), Rust, Java (Maven + Gradle), Ruby, PHP,.NET,
+// JS (npm/yarn/pnpm), Python (PyPI/Poetry/Pipfile/uv/Conda), Rust, Java (Maven + Gradle), Ruby, PHP,.NET,
 // Swift, Dart, Elixir, R (renv), Julia, and Conan. The parsers claim distinct markers, so New does not
 // error here in practice.
 func DefaultRegistry() (*Registry, error) {
-	return New(GoMod{}, NPM{}, Yarn{}, Pnpm{}, PyPI{}, Poetry{}, Pipfile{}, Cargo{}, Maven{}, Gradle{}, BuildGradle{}, Gem{}, Composer{}, NuGet{}, Swift{}, Dart{}, Elixir{}, Conda{}, Renv{}, Julia{}, Conan{})
+	return New(GoMod{}, NPM{}, Yarn{}, Pnpm{}, PyPI{}, Poetry{}, Pipfile{}, UV{}, Cargo{}, Maven{}, Gradle{}, BuildGradle{}, Gem{}, Composer{}, NuGet{}, Swift{}, Dart{}, Elixir{}, Conda{}, Renv{}, Julia{}, Conan{})
 }
 
 // Generate walks the target directory, parses every recognized manifest with its EcosystemParser, and

--- a/internal/infrastructure/tools/ownsbom/uv.go
+++ b/internal/infrastructure/tools/ownsbom/uv.go
@@ -1,0 +1,166 @@
+package ownsbom
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// UV is the owned Python-via-uv parser. It reads registry-backed packages
+// from uv.lock [[package]] blocks and emits normalized PyPI components.
+//
+// Only packages with a non-empty name, concrete resolved version, and
+// canonical registry source are emitted. Local, editable, virtual, Git, and
+// direct-URL package sources are skipped. Dependency edges are intentionally
+// deferred because uv's universal lock can require source, version, and marker
+// disambiguation.
+//
+// The parser targets uv's canonical generated TOML layout, uses only the Go
+// standard library, and performs no network or external-command execution.
+type UV struct{}
+
+// Ecosystem returns the package ecosystem for uv components.
+func (UV) Ecosystem() string {
+	return "pypi"
+}
+
+// Markers returns the expected lockfile basename.
+func (UV) Markers() []string {
+	return []string{"uv.lock"}
+}
+
+type uvPackage struct {
+	name     string
+	version  string
+	registry bool
+}
+
+func uvTOMLAssignment(line string) (key string, value string, ok bool) {
+	i := strings.IndexByte(line, '=')
+	if i <= 0 {
+		return "", "", false
+	}
+
+	key = strings.TrimSpace(line[:i])
+	value = strings.TrimSpace(line[i+1:])
+
+	if key == "" || value == "" {
+		return "", "", false
+	}
+
+	return key, value, true
+}
+
+func uvRegistrySource(value string) bool {
+	value = strings.TrimSpace(value)
+
+	if len(value) < 2 || value[0] != '{' || value[len(value)-1] != '}' {
+		return false
+	}
+
+	inner := strings.TrimSpace(value[1 : len(value)-1])
+
+	key, rawValue, ok := uvTOMLAssignment(inner)
+	if !ok || key != "registry" {
+		return false
+	}
+
+	rawValue = strings.TrimSpace(rawValue)
+	registry := strings.TrimSpace(tomlString(rawValue))
+	if registry == "" {
+		return false
+	}
+
+	// Accept only the canonical single-field form:
+	// source = { registry = "..." }
+	return rawValue == `"`+registry+`"`
+}
+
+// Parse extracts resolved registry packages from a uv.lock file as
+// deterministic PyPI components.
+func (UV) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	scope := sbom.ClassifyScope(in.Path, "")
+	set := newComponentSet()
+
+	var cur uvPackage
+	inPackage := false
+
+	flush := func() {
+		if !inPackage {
+			return
+		}
+
+		name := normalizePyPI(strings.TrimSpace(cur.name))
+		version := strings.TrimSpace(cur.version)
+
+		if cur.registry && name != "" && sbom.IsResolvedVersion(version) {
+			set.add(sbom.Component{
+				Name:     name,
+				Version:  version,
+				PURL:     "pkg:pypi/" + name + "@" + version,
+				Location: in.Path,
+				Scope:    scope,
+			})
+		}
+
+		cur = uvPackage{}
+	}
+
+	sc := bufio.NewScanner(bytes.NewReader(in.Content))
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+
+	for sc.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+
+		line := strings.TrimSpace(sc.Text())
+
+		switch {
+		case line == "[[package]]":
+			flush()
+			inPackage = true
+
+		case strings.HasPrefix(line, "["):
+			flush()
+			inPackage = false
+
+		case inPackage:
+			key, value, ok := uvTOMLAssignment(line)
+			if !ok {
+				continue
+			}
+
+			switch key {
+			case "name":
+				cur.name = tomlString(value)
+			case "version":
+				cur.version = tomlString(value)
+			case "source":
+				cur.registry = uvRegistrySource(value)
+			}
+		}
+	}
+
+	flush()
+
+	if err := sc.Err(); err != nil {
+		return nil, nil, fmt.Errorf("scan uv.lock: %w", err)
+	}
+
+	comps := set.components()
+	sort.Slice(comps, func(i, j int) bool {
+		return comps[i].PURL < comps[j].PURL
+	})
+
+	return comps, nil, nil
+}

--- a/internal/infrastructure/tools/ownsbom/uv_test.go
+++ b/internal/infrastructure/tools/ownsbom/uv_test.go
@@ -1,0 +1,617 @@
+package ownsbom
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+func parseUVTest(t *testing.T, path string, content string) ([]sbom.Component, []sbom.Dependency) {
+	t.Helper()
+
+	comps, deps, err := UV{}.Parse(context.Background(), ParseInput{
+		Path:    path,
+		Content: []byte(content),
+	})
+	if err != nil {
+		t.Fatalf("parse uv.lock: %v", err)
+	}
+
+	return comps, deps
+}
+
+func TestUVMarkersAndEcosystem(t *testing.T) {
+	parser := UV{}
+	if parser.Ecosystem() != "pypi" {
+		t.Errorf("want ecosystem pypi, got %s", parser.Ecosystem())
+	}
+	markers := parser.Markers()
+	if len(markers) != 1 || markers[0] != "uv.lock" {
+		t.Errorf("want exactly one marker uv.lock, got %v", markers)
+	}
+}
+
+func TestUVParseRegistryComponents(t *testing.T) {
+	fixture := `version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "AnyIO"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "typing_extensions"
+version = "4.12.2"
+source = { registry = "https://packages.example.com/simple" }`
+
+	comps, deps := parseUVTest(t, "uv.lock", fixture)
+
+	expectedComps := []sbom.Component{
+		{
+			Name:     "anyio",
+			Version:  "4.4.0",
+			PURL:     "pkg:pypi/anyio@4.4.0",
+			Location: "uv.lock",
+			Scope:    sbom.ScopeProduction,
+		},
+		{
+			Name:     "typing-extensions",
+			Version:  "4.12.2",
+			PURL:     "pkg:pypi/typing-extensions@4.12.2",
+			Location: "uv.lock",
+			Scope:    sbom.ScopeProduction,
+		},
+	}
+
+	if len(comps) != 2 {
+		t.Fatalf("want 2 components, got %d", len(comps))
+	}
+
+	for i, e := range expectedComps {
+		c := comps[i]
+		if c.Name != e.Name || c.Version != e.Version || c.PURL != e.PURL || c.Scope != e.Scope || c.Location != e.Location {
+			t.Errorf("comp %d: want %+v, got %+v", i, e, c)
+		}
+	}
+
+	if deps != nil {
+		t.Errorf("want nil deps, got %+v", deps)
+	}
+}
+
+func TestUVParseFieldOrder(t *testing.T) {
+	fixture := `[[package]]
+source = { registry = "https://pypi.org/simple" }
+version = "4.4.0"
+name = "AnyIO"
+
+[[package]]
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+name = "idna"`
+
+	comps, _ := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 2 {
+		t.Fatalf("want 2 components, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:pypi/anyio@4.4.0" {
+		t.Errorf("first component wrong: %s", comps[0].PURL)
+	}
+	if comps[1].PURL != "pkg:pypi/idna@3.10" {
+		t.Errorf("second component wrong: %s", comps[1].PURL)
+	}
+}
+
+func TestUVParseNameNormalization(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+		wantPURL string
+	}{
+		{
+			name:     "uppercase",
+			input:    "AnyIO",
+			wantName: "anyio",
+			wantPURL: "pkg:pypi/anyio@1.0.0",
+		},
+		{
+			name:     "underscore",
+			input:    "typing_extensions",
+			wantName: "typing-extensions",
+			wantPURL: "pkg:pypi/typing-extensions@1.0.0",
+		},
+		{
+			name:     "dot",
+			input:    "zope.interface",
+			wantName: "zope-interface",
+			wantPURL: "pkg:pypi/zope-interface@1.0.0",
+		},
+		{
+			name:     "separator run",
+			input:    "Some__Pkg.Name",
+			wantName: "some-pkg-name",
+			wantPURL: "pkg:pypi/some-pkg-name@1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := `[[package]]
+name = "` + tt.input + `"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }`
+
+			comps, deps := parseUVTest(t, "uv.lock", fixture)
+
+			if len(comps) != 1 {
+				t.Fatalf("want 1 component, got %d", len(comps))
+			}
+			c := comps[0]
+			if c.Name != tt.wantName {
+				t.Errorf("want name %s, got %s", tt.wantName, c.Name)
+			}
+			if c.Version != "1.0.0" {
+				t.Errorf("want version 1.0.0, got %s", c.Version)
+			}
+			if c.PURL != tt.wantPURL {
+				t.Errorf("want PURL %s, got %s", tt.wantPURL, c.PURL)
+			}
+			if c.Location != "uv.lock" {
+				t.Errorf("want Location uv.lock, got %s", c.Location)
+			}
+			if c.Scope != sbom.ScopeProduction {
+				t.Errorf("want scope %s, got %s", sbom.ScopeProduction, c.Scope)
+			}
+			if deps != nil {
+				t.Errorf("want nil deps, got %v", deps)
+			}
+		})
+	}
+}
+
+func TestUVParseRegistryURLDoesNotChangeIdentity(t *testing.T) {
+	fixture := `[[package]]
+name = "AnyIO"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "anyio"
+version = "4.4.0"
+source = { registry = "https://private.example.com/simple" }`
+
+	comps, _ := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:pypi/anyio@4.4.0" {
+		t.Errorf("want pkg:pypi/anyio@4.4.0, got %s", comps[0].PURL)
+	}
+}
+
+func TestUVParseRegistryPathSource(t *testing.T) {
+	fixture := `[[package]]
+name = "internal-wheel"
+version = "1.2.3"
+source = { registry = "../wheelhouse" }`
+	comps, _ := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:pypi/internal-wheel@1.2.3" {
+		t.Errorf("want pkg:pypi/internal-wheel@1.2.3, got %s", comps[0].PURL)
+	}
+}
+
+func TestUVParseSourcePolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			name: "registry",
+			line: `source = { registry = "https://pypi.org/simple" }`,
+			want: true,
+		},
+		{
+			name: "git",
+			line: `source = { git = "https://github.com/org/repo?rev=abc" }`,
+			want: false,
+		},
+		{
+			name: "direct URL",
+			line: `source = { url = "https://example.com/pkg.whl" }`,
+			want: false,
+		},
+		{
+			name: "path",
+			line: `source = { path = "../pkg.whl" }`,
+			want: false,
+		},
+		{
+			name: "directory",
+			line: `source = { directory = "../pkg" }`,
+			want: false,
+		},
+		{
+			name: "editable",
+			line: `source = { editable = "." }`,
+			want: false,
+		},
+		{
+			name: "virtual",
+			line: `source = { virtual = "." }`,
+			want: false,
+		},
+		{
+			name: "empty registry",
+			line: `source = { registry = "" }`,
+			want: false,
+		},
+		{
+			name: "unknown key",
+			line: `source = { mirror = "https://example.com" }`,
+			want: false,
+		},
+		{
+			name: "substring must not match",
+			line: `source = { not_registry = "https://example.com" }`,
+			want: false,
+		},
+		{
+			name: "non-inline source",
+			line: `source = "https://pypi.org/simple"`,
+			want: false,
+		},
+		{
+			name: "whitespace-only registry",
+			line: `source = { registry = "   " }`,
+			want: false,
+		},
+		{
+			name: "extra inline-table field",
+			line: `source = { registry = "https://pypi.org/simple", git = "unexpected" }`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := `[[package]]
+name = "pkg"
+version = "1.0.0"
+` + tt.line
+			comps, _ := parseUVTest(t, "uv.lock", fixture)
+			if tt.want {
+				if len(comps) != 1 {
+					t.Fatalf("want 1 component, got %d", len(comps))
+				}
+			} else {
+				if len(comps) != 0 {
+					t.Fatalf("want 0 components, got %d", len(comps))
+				}
+			}
+		})
+	}
+}
+
+func TestUVParseSkipsIncompletePackages(t *testing.T) {
+	fixture := `[[package]]
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "missing-version"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "missing-source"
+version = "1.0.0"
+
+[[package]]
+name = "unknown-version"
+version = "unknown"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "floating-version"
+version = "latest"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "valid"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }`
+
+	comps, _ := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 1 {
+		t.Fatalf("want exactly one component, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:pypi/valid@2.0.0" {
+		t.Errorf("want pkg:pypi/valid@2.0.0, got %s", comps[0].PURL)
+	}
+}
+
+func TestUVParseMalformedBlockDoesNotPoisonNext(t *testing.T) {
+	fixture := `[[package]]
+name = "broken"
+version = "1.0.0"
+source = { registry =
+
+[[package]]
+name = "valid"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }`
+	comps, _ := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 1 {
+		t.Fatalf("want exactly one component, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:pypi/valid@2.0.0" {
+		t.Errorf("want pkg:pypi/valid@2.0.0, got %s", comps[0].PURL)
+	}
+}
+
+func TestUVParseNestedTableEndsDirectPackageFields(t *testing.T) {
+	fixture := `[[package]]
+name = "first"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[package.metadata]
+name = "must-not-rebind"
+version = "9.9.9"
+source = { registry = "https://evil.example/simple" }
+
+[[package]]
+name = "second"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }`
+	comps, _ := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 2 {
+		t.Fatalf("want 2 components, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:pypi/first@1.0.0" {
+		t.Errorf("want first@1.0.0, got %s", comps[0].PURL)
+	}
+	if comps[1].PURL != "pkg:pypi/second@2.0.0" {
+		t.Errorf("want second@2.0.0, got %s", comps[1].PURL)
+	}
+}
+
+func TestUVParseDeduplicatesNormalizedPURL(t *testing.T) {
+	fixture := `[[package]]
+name = "Some_Pkg"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "some.pkg"
+version = "1.0.0"
+source = { registry = "https://private.example/simple" }
+
+[[package]]
+name = "some-pkg"
+version = "1.0.0"
+source = { registry = "../wheelhouse" }`
+	comps, _ := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 1 {
+		t.Fatalf("want one component, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:pypi/some-pkg@1.0.0" {
+		t.Errorf("want pkg:pypi/some-pkg@1.0.0, got %s", comps[0].PURL)
+	}
+}
+
+func TestUVParsePreservesMultipleVersions(t *testing.T) {
+	fixture := `[[package]]
+name = "platform-package"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "platform_package"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }`
+	comps, _ := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 2 {
+		t.Fatalf("want 2 components, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:pypi/platform-package@1.0.0" {
+		t.Errorf("want platform-package@1.0.0, got %s", comps[0].PURL)
+	}
+	if comps[1].PURL != "pkg:pypi/platform-package@2.0.0" {
+		t.Errorf("want platform-package@2.0.0, got %s", comps[1].PURL)
+	}
+}
+
+func TestUVParseScopeFromPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantScope string
+	}{
+		{
+			name:      "production",
+			path:      "uv.lock",
+			wantScope: sbom.ScopeProduction,
+		},
+		{
+			name:      "test",
+			path:      "tests/uv.lock",
+			wantScope: sbom.ScopeTest,
+		},
+		{
+			name:      "fixture",
+			path:      "testdata/uv.lock",
+			wantScope: sbom.ScopeFixture,
+		},
+		{
+			name:      "example",
+			path:      "examples/app/uv.lock",
+			wantScope: sbom.ScopeExample,
+		},
+		{
+			name:      "documentation",
+			path:      "docs/sample/uv.lock",
+			wantScope: sbom.ScopeDocumentation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := `[[package]]
+name = "pkg"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }`
+			comps, _ := parseUVTest(t, tt.path, fixture)
+			if len(comps) != 1 {
+				t.Fatalf("want 1 component, got %d", len(comps))
+			}
+			if comps[0].Scope != tt.wantScope {
+				t.Errorf("want scope %s, got %s", tt.wantScope, comps[0].Scope)
+			}
+		})
+	}
+}
+
+func TestUVParseDoesNotInferDependencyEdges(t *testing.T) {
+	fixture := `[[package]]
+name = "anyio"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_version < '3.13'" },
+]`
+	comps, deps := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d", len(comps))
+	}
+	if comps[0].PURL != "pkg:pypi/anyio@4.4.0" {
+		t.Errorf("want anyio, got %s", comps[0].PURL)
+	}
+	if deps != nil {
+		t.Errorf("want nil deps, got %+v", deps)
+	}
+}
+
+func TestUVParseDeterministicOrder(t *testing.T) {
+	fixture := `[[package]]
+name = "zebra"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "AnyIO"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "middle_pkg"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }`
+
+	comps, _ := parseUVTest(t, "uv.lock", fixture)
+	if len(comps) != 3 {
+		t.Fatalf("want 3 components, got %d", len(comps))
+	}
+
+	expectedPURLs := []string{
+		"pkg:pypi/anyio@4.4.0",
+		"pkg:pypi/middle-pkg@2.0.0",
+		"pkg:pypi/zebra@1.0.0",
+	}
+
+	for i, purl := range expectedPURLs {
+		if comps[i].PURL != purl {
+			t.Errorf("comp %d: want %s, got %s", i, purl, comps[i].PURL)
+		}
+	}
+}
+
+func TestUVParseContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := UV{}.Parse(ctx, ParseInput{
+		Path: "uv.lock",
+		Content: []byte(`[[package]]
+name = "anyio"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }`),
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}
+
+func TestUVParseScannerError(t *testing.T) {
+	hugeLine := make([]byte, 5*1024*1024)
+	for i := range hugeLine {
+		hugeLine[i] = 'a'
+	}
+
+	_, _, err := UV{}.Parse(context.Background(), ParseInput{
+		Path:    "uv.lock",
+		Content: hugeLine,
+	})
+
+	if err == nil {
+		t.Fatalf("want error for scanner overflow, got nil")
+	}
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Errorf("want bufio.ErrTooLong, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "scan uv.lock") {
+		t.Errorf("want wrapped scan uv.lock error, got %v", err)
+	}
+}
+
+func TestUVRegistryGenerate(t *testing.T) {
+	dir := t.TempDir()
+	fixture := `[[package]]
+name = "anyio"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }`
+
+	if err := os.WriteFile(filepath.Join(dir, "uv.lock"), []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+
+	doc, err := reg.Generate(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if doc.Source != "ownsbom" || doc.GeneratorVersion != ownsbomVersion {
+		t.Errorf("want source ownsbom and generator %s, got %s and %s", ownsbomVersion, doc.Source, doc.GeneratorVersion)
+	}
+
+	if len(doc.Components) != 1 {
+		t.Fatalf("want 1 component, got %d", len(doc.Components))
+	}
+
+	if doc.Components[0].PURL != "pkg:pypi/anyio@4.4.0" {
+		t.Errorf("want anyio, got %s", doc.Components[0].PURL)
+	}
+
+	if len(doc.Dependencies) != 0 {
+		t.Errorf("want 0 dependencies, got %+v", doc.Dependencies)
+	}
+}


### PR DESCRIPTION
Closes #137

## Summary

Add first-party OwnSBOM support for exact registry-backed packages in Python `uv.lock` files.

The new parser reads canonical `[[package]]` blocks, emits packages with a non-empty name, concrete resolved version, and exact registry source, and normalizes their identities to PyPI PURLs.

## Changes

* Add a dedicated `UV` OwnSBOM parser for `uv.lock`.
* Register `uv.lock` in `DefaultRegistry()`.
* Parse canonical `[[package]]` blocks without invoking the uv CLI.
* Emit only packages whose source is an exact canonical `registry` source.
* Normalize package names using the existing PyPI/PEP 503 normalization.
* Emit components as `pkg:pypi/<normalized-name>@<version>`.
* Preserve multiple resolved versions of the same normalized package name.
* Deduplicate identical normalized name/version PURLs across registry URLs.
* Derive component scope from the lockfile path.
* Skip virtual, editable, directory, path, Git, direct-URL, incomplete, unresolved, and malformed package entries.
* Reject empty, whitespace-only, unknown, and multi-field source tables.
* Treat nested table headers as package-field boundaries.
* Recover from malformed package blocks without affecting later valid packages.
* Sort component output deterministically by PURL.
* Preserve context cancellation and scanner-error handling.
* Add parser-level and `DefaultRegistry()` integration tests.
* Bump the OwnSBOM generator version to `ownsbom/0.6.0`.
* Update the changelog and registry coverage documentation.

## Why components only?

`uv.lock` is a universal lockfile. Dependency entries can require source, version, marker, or resolution disambiguation when multiple locked package identities share the same normalized name.

Resolving dependencies by name alone could connect a package to the wrong locked component. This PR therefore inventories exact registry packages but does not infer dependency graph edges.

Graph support should be handled separately after unambiguous identity-resolution rules are defined.

## Source policy

Included:

```toml
source = { registry = "https://pypi.org/simple" }
```

Private registries and registry index paths are also accepted:

```toml
source = { registry = "https://packages.example.com/simple" }
source = { registry = "../wheelhouse" }
```

Skipped:

```toml
source = { git = "..." }
source = { url = "..." }
source = { path = "..." }
source = { directory = "..." }
source = { editable = "." }
source = { virtual = "." }
source = { registry = "" }
source = { registry = "   " }
```

Unknown or non-canonical source tables are also skipped.

Registry URLs and paths do not alter component identity and are not persisted in emitted components or PURLs.

## Example

Input:

```toml
version = 1

[[package]]
name = "AnyIO"
version = "4.4.0"
source = { registry = "https://pypi.org/simple" }

[[package]]
name = "local-project"
version = "0.1.0"
source = { virtual = "." }
```

Output:

```text
pkg:pypi/anyio@4.4.0
```

The virtual project package is intentionally skipped.

## Parsing behavior

The parser:

* recognizes exact `[[package]]` headers;
* collects package fields independently of their order;
* flushes packages at the next package or table boundary and at EOF;
* ignores dependency arrays and nested package metadata;
* normalizes names using the existing PyPI normalization;
* validates versions using the shared resolved-version policy;
* deduplicates through the existing component set;
* returns no dependency records;
* performs no filesystem, network, or external-command operations.

## Non-goals

* No dependency graph edges.
* No parsing of `pyproject.toml`.
* No uv CLI or network execution.
* No artifact hash extraction.
* No Git, direct-URL, path, directory, editable, or virtual package identities.
* No general-purpose TOML parser.
* No changes to existing Python parsers.
* No new domain types or parser interfaces.
* No third-party dependency.

## Testing

```bash
go test \
  ./internal/infrastructure/tools/ownsbom \
  -run '^TestUV' \
  -count=1 \
  -v

go test \
  ./internal/infrastructure/tools/ownsbom \
  -count=1

go test -race \
  ./internal/infrastructure/tools/ownsbom \
  -count=1

go test ./... -count=1
go build ./...
go vet ./...
CGO_ENABLED=0 go build ./cmd/...
golangci-lint run

cd web
pnpm install --frozen-lockfile
pnpm run typecheck
pnpm build
```

## Test coverage

* parser ecosystem and marker identity;
* basic registry package discovery;
* package-field order independence;
* PyPI/PEP 503 name normalization;
* registry URL-independent identity;
* registry index-path sources;
* Git, URL, path, directory, editable, and virtual source rejection;
* empty and whitespace-only registry rejection;
* unknown and multi-field source-table rejection;
* incomplete and unresolved package blocks;
* malformed package-block recovery;
* nested table boundaries;
* normalized-PURL deduplication;
* multiple versions of one package name;
* path-derived scope classification;
* prevention of inferred dependency edges;
* deterministic PURL ordering;
* context cancellation;
* scanner overflow and wrapped error context;
* `DefaultRegistry()` discovery and provenance.

## Checklist

* [x] Issue linked with `Closes #137`
* [x] Dedicated `uv.lock` parser added
* [x] Parser registered in `DefaultRegistry()`
* [x] Registry packages emitted as PyPI components
* [x] Existing PEP 503 normalization reused
* [x] Existing resolved-version validation reused
* [x] Unsupported source types skipped
* [x] Empty and malformed sources skipped
* [x] Duplicate normalized PURLs removed
* [x] Multiple resolved versions preserved
* [x] Path-derived scope preserved
* [x] No dependency edges inferred
* [x] Output sorted deterministically
* [x] Context cancellation tested
* [x] Scanner failure and wrapping tested
* [x] Registry integration tested
* [x] Generator version bumped to `ownsbom/0.6.0`
* [x] Changelog updated
* [x] No new dependencies introduced