### PR TITLE
fix(sca): resolve composite / independent-build Gradle monorepos

### DIFF
--- a/internal/infrastructure/tools/gradleresolve/resolver.go
+++ b/internal/infrastructure/tools/gradleresolve/resolver.go
@@ -115,6 +115,9 @@ func (r *Resolver) Resolve(ctx context.Context, dir string) ([]sbom.Component, e
 		}
 		out, err := r.run(ctx, root)
 		if err != nil {
+			if isNoRuntimeClasspath(err) {
+				continue // aggregator / non-Java build root (no runtimeClasspath) – expected, not a failure
+			}
 			if firstErr == nil {
 				firstErr = fmt.Errorf("%s: %w", relOrBase(dir, root), err)
 			}
@@ -143,6 +146,14 @@ func relOrBase(dir, root string) string {
 	return filepath.Base(root)
 }
 
+// isNoRuntimeClasspath reports whether a resolve failed only because the build root has no
+// runtimeClasspath configuration — an aggregator / non-Java root (common as the top of a composite
+// build), which is expected and not a real resolution failure worth surfacing.
+func isNoRuntimeClasspath(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "runtimeClasspath' not found") || strings.Contains(s, "not found in configuration container")
+}
+
 func hasBuildFile(dir string) bool {
 	for _, f := range buildFiles {
 		if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
@@ -152,29 +163,75 @@ func hasBuildFile(dir string) bool {
 	return false
 }
 
-// buildRoots finds the Gradle build roots under dir: each directory holding a build script
-// (build.gradle[.kts] / settings.gradle[.kts]), WITHOUT descending into it – a multi-project build's
-// included sub-projects are resolved by running gradle on the build root (the settings.gradle dir), just
-// as `gradle -p <root> dependencies` configures the whole build. dir itself is a root when it has a build
-// file (single-build fast path). Gradle output/VCS/tooling dirs are skipped. Bounded to maxBuildRoots.
+// settingsFiles mark an INDEPENDENT Gradle build (its own root project): a standard multi-project build
+// has one only at the top, while a composite build (`includeBuild`) — and a monorepo of independent
+// service builds — has one in EACH included build.
+var settingsFiles = []string{"settings.gradle", "settings.gradle.kts"}
+
+func hasSettingsFile(dir string) bool {
+	for _, f := range settingsFiles {
+		if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// hasBuildScript reports whether dir has a build.gradle[.kts] (a project build script, ignoring settings).
+func hasBuildScript(dir string) bool {
+	for _, f := range []string{"build.gradle", "build.gradle.kts"} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// buildRoots finds the Gradle build roots under dir. Each directory with a SETTINGS file is an
+// independent build and becomes a root, and the walk keeps descending past it so that composite/included
+// builds (`includeBuild ...`) — e.g. a monorepo whose root settings.gradle pulls each service in as its
+// own build — are all discovered and resolved individually. (Running `gradle -p <root> dependencies` only
+// reports the ROOT project, so an aggregator root with no runtimeClasspath contributes nothing on its own;
+// the included builds are where the real dependency trees live.) When there is NO settings file anywhere,
+// a bare build.gradle at dir is the single build root (the common single-module fast path). Gradle
+// output/VCS/tooling/source dirs are skipped; bounded to maxBuildRoots.
 func buildRoots(dir string) []string {
 	var roots []string
+	var covered []string // settings-root paths: a build.gradle-only dir beneath one is a subproject, not a root
+	underCovered := func(p string) bool {
+		for _, c := range covered {
+			if strings.HasPrefix(p, c+string(os.PathSeparator)) {
+				return true
+			}
+		}
+		return false
+	}
 	_ = filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
 		if err != nil || !d.IsDir() {
 			return nil
 		}
 		if p != dir {
 			switch d.Name() {
-			case "build", "target", ".gradle", "buildSrc", "node_modules", ".git", ".idea":
-				return filepath.SkipDir // Gradle output / build-logic / VCS / tooling – never a build root to run gradle on
+			case "build", "target", ".gradle", "buildSrc", "node_modules", ".git", ".idea", "src":
+				return filepath.SkipDir // Gradle output / build-logic / VCS / tooling / sources – never a build root
 			}
 		}
-		if hasBuildFile(p) {
+		switch {
+		case hasSettingsFile(p):
+			// An independent build (its own root project). Composite builds (`includeBuild`) nest one per
+			// included build, so KEEP descending to find them; its build.gradle-only subdirs are its
+			// subprojects (marked covered below), resolved by gradle on this root.
 			roots = append(roots, p)
-			if len(roots) >= maxBuildRoots {
-				return filepath.SkipAll
+			covered = append(covered, p)
+		case hasBuildScript(p):
+			if underCovered(p) {
+				return filepath.SkipDir // a subproject of an enclosing settings-root build – not a separate root
 			}
-			return filepath.SkipDir // this dir is a build root; its included sub-projects are gradle's job
+			roots = append(roots, p) // a standalone single-module build (no settings file)
+			return filepath.SkipDir  // its own subprojects belong to this build
+		}
+		if len(roots) >= maxBuildRoots {
+			return filepath.SkipAll
 		}
 		return nil
 	})

--- a/internal/infrastructure/tools/gradleresolve/resolver.go
+++ b/internal/infrastructure/tools/gradleresolve/resolver.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -39,9 +40,6 @@ const maxBuildRoots = 200 // bound the sub-project discovery walk (a monorepo of
 // portal / distribution services Gradle reaches to resolve plugins and dependency metadata. Extra
 // private-mirror hosts are added via WithRepoHosts.
 var defaultRepoHosts = []string{"repo1.maven.org", "repo.maven.apache.org", "plugins.gradle.org", "services.gradle.org"}
-
-// buildFiles are the project markers that indicate a Gradle build (Groovy or Kotlin DSL).
-var buildFiles = []string{"build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts"}
 
 // Resolver runs `gradle dependencies` to resolve a Gradle project's full dependency tree. bin is the
 // pinned gradle executable (path/name) – NOT the project's./gradlew.
@@ -115,7 +113,7 @@ func (r *Resolver) Resolve(ctx context.Context, dir string) ([]sbom.Component, e
 		}
 		out, err := r.run(ctx, root)
 		if err != nil {
-			if isNoRuntimeClasspath(err) {
+			if errors.Is(err, errNoRuntimeClasspath) {
 				continue // aggregator / non-Java build root (no runtimeClasspath) – expected, not a failure
 			}
 			if firstErr == nil {
@@ -146,21 +144,16 @@ func relOrBase(dir, root string) string {
 	return filepath.Base(root)
 }
 
-// isNoRuntimeClasspath reports whether a resolve failed only because the build root has no
-// runtimeClasspath configuration — an aggregator / non-Java root (common as the top of a composite
-// build), which is expected and not a real resolution failure worth surfacing.
-func isNoRuntimeClasspath(err error) bool {
-	s := err.Error()
-	return strings.Contains(s, "runtimeClasspath' not found") || strings.Contains(s, "not found in configuration container")
-}
+// errNoRuntimeClasspath signals that a build root has no runtimeClasspath configuration — an aggregator /
+// non-Java root (common as the top of a composite build). Resolve treats it as an expected skip, not a
+// resolution failure. run() returns it after classifying the RAW (un-truncated) gradle stderr.
+var errNoRuntimeClasspath = errors.New("gradle: build root has no runtimeClasspath configuration")
 
-func hasBuildFile(dir string) bool {
-	for _, f := range buildFiles {
-		if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
-			return true
-		}
-	}
-	return false
+// noRuntimeClasspath detects Gradle's "configuration 'runtimeClasspath' not found …" failure in raw
+// stderr. Matched on the un-truncated output (before run() clips it) and on two stable tokens, so a long
+// FAILURE/`* Where:` preamble can't push the marker out of view.
+func noRuntimeClasspath(stderr string) bool {
+	return strings.Contains(stderr, "runtimeClasspath") && strings.Contains(stderr, "not found")
 }
 
 // settingsFiles mark an INDEPENDENT Gradle build (its own root project): a standard multi-project build
@@ -228,7 +221,10 @@ func buildRoots(dir string) []string {
 				return filepath.SkipDir // a subproject of an enclosing settings-root build – not a separate root
 			}
 			roots = append(roots, p) // a standalone single-module build (no settings file)
-			return filepath.SkipDir  // its own subprojects belong to this build
+			if len(roots) >= maxBuildRoots {
+				return filepath.SkipAll
+			}
+			return filepath.SkipDir // its own subprojects belong to this build
 		}
 		if len(roots) >= maxBuildRoots {
 			return filepath.SkipAll
@@ -268,6 +264,9 @@ func (r *Resolver) run(ctx context.Context, dir string) ([]byte, error) {
 			return nil, fmt.Errorf("sandboxed: %w: %s", err, truncate(string(res.Stderr), 300))
 		}
 		if res.ExitCode != 0 {
+			if noRuntimeClasspath(string(res.Stderr)) {
+				return nil, errNoRuntimeClasspath
+			}
 			return nil, fmt.Errorf("exit %d: %s", res.ExitCode, truncate(string(res.Stderr), 300))
 		}
 		return res.Stdout, nil
@@ -286,6 +285,9 @@ func (r *Resolver) run(ctx context.Context, dir string) ([]byte, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if noRuntimeClasspath(stderr.String()) {
+			return nil, errNoRuntimeClasspath
+		}
 		return nil, fmt.Errorf("%w: %s", err, truncate(stderr.String(), 300))
 	}
 	return stdout.Bytes(), nil

--- a/internal/infrastructure/tools/gradleresolve/resolver_test.go
+++ b/internal/infrastructure/tools/gradleresolve/resolver_test.go
@@ -135,6 +135,25 @@ func TestBuildRootsSkipsIncludedAndOutputDirs(t *testing.T) {
 	}
 }
 
+func TestBuildRootsComposite(t *testing.T) {
+	// A composite build (like a service monorepo): the root settings.gradle uses includeBuild for each
+	// service, and each service is its OWN build with its own settings.gradle. Every independent build must
+	// be discovered; a plain subproject (build.gradle only, under a settings root) must NOT be a root.
+	dir := t.TempDir()
+	mkfile(t, dir, "settings.gradle")
+	mkfile(t, dir, "build.gradle")
+	mkfile(t, filepath.Join(dir, "services", "kyc"), "settings.gradle")
+	mkfile(t, filepath.Join(dir, "services", "kyc"), "build.gradle")
+	mkfile(t, filepath.Join(dir, "services", "acct"), "settings.gradle")
+	mkfile(t, filepath.Join(dir, "services", "acct"), "build.gradle")
+	mkfile(t, filepath.Join(dir, "shared", "common"), "settings.gradle")
+	mkfile(t, filepath.Join(dir, "shared", "common"), "build.gradle")
+	mkfile(t, filepath.Join(dir, "shared", "common", "sub"), "build.gradle") // subproject – NOT a root
+	if roots := buildRoots(dir); len(roots) != 4 {
+		t.Fatalf("composite: got %d roots, want 4 (root + kyc + acct + shared/common): %v", len(roots), roots)
+	}
+}
+
 func TestBuildRootsNone(t *testing.T) {
 	if roots := buildRoots(t.TempDir()); len(roots) != 0 {
 		t.Fatalf("no build file: roots = %v, want none", roots)


### PR DESCRIPTION
The Gradle resolver stopped at the FIRST dir with a build script and ran `gradle -p <root> dependencies --configuration runtimeClasspath` there. Two common layouts broke:

- **Aggregator root** (`build.gradle` applying only umbrella/format plugins, no java plugin) has no `runtimeClasspath` → the whole resolve failed with "configuration 'runtimeClasspath' not found" → 0 captured.
- **Composite build** whose root `settings.gradle` uses `includeBuild` per module (a monorepo of INDEPENDENT service builds, each with its own settings.gradle + wrapper) was never descended into — `gradle dependencies` on the aggregator reports only the root project, not the included builds where the real trees live.

`buildRoots` now treats every dir with a **settings file** as an independent build root and keeps descending to find nested included/composite builds; a `build.gradle`-only dir is a standalone root only when NOT under an enclosing settings-root (else it's a subproject the enclosing build covers). An aggregator root with no `runtimeClasspath` is skipped, not surfaced as a failure. Tests cover single / flat-monorepo / standard-multiproject / composite layouts.

**Impact:** a service monorepo that previously resolved **0** transitive deps (only the static build.gradle fallback) now resolves each service's full tree. On a real 4-service Spring-Boot composite repo, **one service alone resolves ~470 transitive coordinates** that were entirely invisible — turning a handful of direct-dep CVEs into the real transitive count (full re-scan number to follow in a comment).