### PR TITLE
feat(sca): resolve lockfile-less composer.json / Gemfile / pyproject.toml

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -56,6 +56,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/licensefile"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/licensemeta"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifest"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifestresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavencoord"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
@@ -558,6 +559,20 @@ func main() {
 		} else {
 			scaService.SetNPMResolver(npmresolve.New(cfg.NPMBin).WithRunner(scaSandbox).WithRegistryHosts(cfg.NPMRegistryHosts))
 			log.Info("npm resolution ENABLED (npm install --package-lock-only, sandbox-confined; best-effort)", "extra_registry_hosts", len(cfg.NPMRegistryHosts))
+		}
+	}
+	// Lockfile-less manifest resolvers (composer.json / Gemfile / pyproject.toml): each runs its ecosystem
+	// tool over an untrusted manifest and reaches the registry, so the SERVER enables them ONLY with the SCA
+	// sandbox and FAILS CLOSED otherwise. Lock-only + no-scripts + a throwaway copy mean no project code runs.
+	if cfg.ManifestResolveEnabled {
+		if scaSandbox == nil {
+			log.Warn("SYNAPSE_MANIFEST_RESOLVE_ENABLED ignored: it requires the SCA sandbox (composer/bundle/poetry would otherwise reach the network over an untrusted manifest on the host). Enable the sandbox to use it.")
+		} else {
+			binOf := map[string]string{"composer": cfg.ComposerBin, "gem": cfg.BundleBin, "poetry": cfg.PoetryBin}
+			for _, eco := range []string{"composer", "gem", "poetry"} {
+				scaService.AddManifestResolver(manifestresolve.New(eco, binOf[eco]).WithRunner(scaSandbox).WithRegistryHosts(cfg.ManifestRegistryHosts))
+			}
+			log.Info("lockfile-less manifest resolution ENABLED (composer/gem/poetry, sandbox-confined; best-effort)", "extra_registry_hosts", len(cfg.ManifestRegistryHosts))
 		}
 	}
 	if cfg.JVMReachabilityEnabled {

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1041,7 +1041,8 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		for _, eco := range []string{"composer", "gem", "poetry"} {
 			sca.AddManifestResolver(manifestresolve.New(eco, binOf[eco]).WithRegistryHosts(cfg.ManifestRegistryHosts))
 		}
-		fmt.Fprintln(os.Stderr, "synapse-cli: manifest resolvers ON – run composer/bundle/poetry in lock-only, no-scripts mode over a COPY of a lockfile-less composer.json/Gemfile/pyproject.toml (no project scripts run; set SYNAPSE_MANIFEST_RESOLVE_ENABLED=false to disable)")
+		fmt.Fprintln(os.Stderr, "synapse-cli: manifest resolvers ON – composer/poetry resolve a lockfile-less composer.json/pyproject.toml over a COPY in lock-only, no-scripts mode (inert manifests; no project code runs)")
+		fmt.Fprintln(os.Stderr, "synapse-cli: manifest resolvers ON – `bundle lock` EVALUATES a lockfile-less Gemfile as Ruby, so it runs the project's manifest code UNSANDBOXED (trusted-local assumption, like the Gradle resolver); set SYNAPSE_MANIFEST_RESOLVE_ENABLED=false to disable")
 	}
 	// Coarse JVM class-reachability – default-on for the CLI (read-only bytecode parsing, no exec);
 	// tags each JVM component reachable/unreferenced from the app's compiled closure. Opt out with

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/licensefile"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/licensemeta"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifest"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifestresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavencoord"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
@@ -1028,6 +1029,19 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	if npmOn {
 		sca.SetNPMResolver(npmresolve.New(cfg.NPMBin).WithRegistryHosts(cfg.NPMRegistryHosts))
 		fmt.Fprintln(os.Stderr, "synapse-cli: npm resolver ON – runs `npm install --package-lock-only --ignore-scripts` over a COPY of a lockfile-less package.json to pin versions (no project scripts run; set SYNAPSE_NPM_RESOLVE_ENABLED=false to disable)")
+	}
+	// Lockfile-less manifest resolvers (composer.json / Gemfile / pyproject.toml) – default-on for the CLI
+	// (trusted local). Each runs its ecosystem tool in lock-only, no-scripts mode over a COPY. Best-effort.
+	manifestOn := cfg.ManifestResolveEnabled
+	if _, set := os.LookupEnv("SYNAPSE_MANIFEST_RESOLVE_ENABLED"); !set {
+		manifestOn = true
+	}
+	if manifestOn {
+		binOf := map[string]string{"composer": cfg.ComposerBin, "gem": cfg.BundleBin, "poetry": cfg.PoetryBin}
+		for _, eco := range []string{"composer", "gem", "poetry"} {
+			sca.AddManifestResolver(manifestresolve.New(eco, binOf[eco]).WithRegistryHosts(cfg.ManifestRegistryHosts))
+		}
+		fmt.Fprintln(os.Stderr, "synapse-cli: manifest resolvers ON – run composer/bundle/poetry in lock-only, no-scripts mode over a COPY of a lockfile-less composer.json/Gemfile/pyproject.toml (no project scripts run; set SYNAPSE_MANIFEST_RESOLVE_ENABLED=false to disable)")
 	}
 	// Coarse JVM class-reachability – default-on for the CLI (read-only bytecode parsing, no exec);
 	// tags each JVM component reachable/unreferenced from the app's compiled closure. Opt out with

--- a/internal/infrastructure/tools/manifestresolve/resolver.go
+++ b/internal/infrastructure/tools/manifestresolve/resolver.go
@@ -8,11 +8,18 @@
 //	gem       Gemfile        -> bundle lock                                              -> Gemfile.lock
 //	poetry    pyproject.toml -> poetry lock                                              -> poetry.lock
 //
-// SECURITY mirrors npmresolve: each tool runs with lifecycle scripts/plugins DISABLED so no project code
-// executes; it runs against a temp copy so the user's project is never mutated; it invokes a PINNED tool
-// (never a project-vendored one) with SYNAPSE_*/credential env scrubbed; in production it MUST run through
-// a ToolRunner (the sandbox) with egress restricted to the ecosystem registry, and the API composition
-// root refuses to enable it without a sandbox (fail-closed). Direct-exec is the trusted-local CLI path.
+// SECURITY: it always runs against a temp COPY (the user's project is never mutated), invokes a PINNED
+// tool (never a project-vendored one) with SYNAPSE_*/credential env scrubbed, and in production MUST run
+// through a ToolRunner (the sandbox) with egress restricted to the ecosystem registry — the API root
+// refuses to enable it without a sandbox (fail-closed). The "no project code runs" guarantee is
+// ECOSYSTEM-SPECIFIC, not blanket:
+//   - composer (--no-scripts --no-plugins) and poetry (lock) operate on INERT data (composer.json is
+//     JSON, pyproject.toml is TOML) and do not execute the project manifest. (poetry may build a
+//     dependency's sdist to read metadata — that is dependency code, not the project's.)
+//   - gem: `bundle lock` EVALUATES the Gemfile, which IS a Ruby program, so it executes PROJECT code —
+//     the same risk class as the Gradle resolver. On the trusted-local CLI direct-exec path this runs
+//     UNSANDBOXED (with an honest banner); the API path confines it in the sandbox.
+//
 // Best-effort + OPT-IN: no manifest / a committed lockfile / a missing tool / any error is a no-op and
 // never fails the scan.
 package manifestresolve
@@ -165,7 +172,16 @@ func (r *Resolver) allowedHosts() []string {
 }
 
 func (r *Resolver) run(ctx context.Context, work string) error {
-	env := []string{"HOME=" + work} // keep the tool's home/cache inside the throwaway dir
+	// Pin every tool's home/cache/config inside the throwaway dir so nothing reads host credentials
+	// (~/.composer/auth.json, ~/.gem/credentials, poetry keyring) or writes to the host cache.
+	env := []string{
+		"HOME=" + work,
+		"COMPOSER_HOME=" + filepath.Join(work, ".composer"),
+		"BUNDLE_USER_HOME=" + filepath.Join(work, ".bundle"),
+		"POETRY_CACHE_DIR=" + filepath.Join(work, ".poetry-cache"),
+		"XDG_CACHE_HOME=" + filepath.Join(work, ".cache"),
+		"XDG_CONFIG_HOME=" + filepath.Join(work, ".config"),
+	}
 	if r.runner != nil {
 		res, err := r.runner.Run(ctx, ports.ToolSpec{
 			Name:         r.bin,
@@ -203,10 +219,12 @@ func scrubSensitiveEnv(env []string) []string {
 		if i := strings.IndexByte(kv, '='); i >= 0 {
 			name = kv[:i]
 		}
-		if strings.HasPrefix(name, "SYNAPSE_") {
+		u := strings.ToUpper(name)
+		// SYNAPSE_*, bundler per-host creds (BUNDLE_<HOST>=user:pass), and composer inline creds
+		// (COMPOSER_AUTH) are stripped by prefix/name; the rest by credential fragment.
+		if strings.HasPrefix(u, "SYNAPSE_") || strings.HasPrefix(u, "BUNDLE_") || u == "COMPOSER_AUTH" {
 			continue
 		}
-		u := strings.ToUpper(name)
 		sensitive := false
 		for _, frag := range []string{"TOKEN", "SECRET", "PASSWORD", "PASSWD", "APIKEY", "API_KEY", "ACCESS_KEY", "PRIVATE_KEY", "CREDENTIAL"} {
 			if strings.Contains(u, frag) {

--- a/internal/infrastructure/tools/manifestresolve/resolver.go
+++ b/internal/infrastructure/tools/manifestresolve/resolver.go
@@ -1,0 +1,231 @@
+// Package manifestresolve resolves the dependency tree of a lockfile-less package manifest by shelling
+// out (argv only, no shell) to the ecosystem's own tool in a LOCK-ONLY, NO-SCRIPTS mode over a THROWAWAY
+// COPY of the manifest, then reusing the owned lockfile parser to emit pinned components. It generalizes
+// the npm resolver to the long tail of lockfile-only ecosystems whose human-authored manifest declares
+// only version RANGES (so the SBOM otherwise has no resolvable version to advisory-match):
+//
+//	composer  composer.json  -> composer update --no-install --no-scripts --no-plugins  -> composer.lock
+//	gem       Gemfile        -> bundle lock                                              -> Gemfile.lock
+//	poetry    pyproject.toml -> poetry lock                                              -> poetry.lock
+//
+// SECURITY mirrors npmresolve: each tool runs with lifecycle scripts/plugins DISABLED so no project code
+// executes; it runs against a temp copy so the user's project is never mutated; it invokes a PINNED tool
+// (never a project-vendored one) with SYNAPSE_*/credential env scrubbed; in production it MUST run through
+// a ToolRunner (the sandbox) with egress restricted to the ecosystem registry, and the API composition
+// root refuses to enable it without a sandbox (fail-closed). Direct-exec is the trusted-local CLI path.
+// Best-effort + OPT-IN: no manifest / a committed lockfile / a missing tool / any error is a no-op and
+// never fails the scan.
+package manifestresolve
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ownsbom"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// spec describes how to resolve one ecosystem's lockfile-less manifest.
+type spec struct {
+	ecosystem    string   // short label for tracing/warnings ("composer", "gem", "poetry")
+	defaultBin   string   // the resolving tool ("composer", "bundle", "poetry")
+	manifest     string   // the human-authored manifest that triggers resolution
+	lockfiles    []string // committed lockfiles that make resolution redundant (short-circuit no-op)
+	produced     string   // the lockfile the resolve writes into the temp dir
+	args         []string // lock-only, no-scripts resolve argv
+	registryHost string   // default egress allow-host for the sandbox
+	// parse turns the produced lockfile bytes into components (the owned parser).
+	parse func(ctx context.Context, in ownsbom.ParseInput) ([]sbom.Component, []sbom.Dependency, error)
+}
+
+// specs is the built-in ecosystem table. Each reuses the OWNED lockfile parser (one implementation).
+var specs = map[string]spec{
+	"composer": {
+		ecosystem: "composer", defaultBin: "composer", manifest: "composer.json",
+		lockfiles: []string{"composer.lock"}, produced: "composer.lock",
+		args:         []string{"update", "--no-install", "--no-scripts", "--no-plugins", "--no-audit", "--no-interaction"},
+		registryHost: "repo.packagist.org",
+		parse: func(ctx context.Context, in ownsbom.ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+			return ownsbom.Composer{}.Parse(ctx, in)
+		},
+	},
+	"gem": {
+		ecosystem: "gem", defaultBin: "bundle", manifest: "Gemfile",
+		lockfiles: []string{"Gemfile.lock"}, produced: "Gemfile.lock",
+		args:         []string{"lock"},
+		registryHost: "rubygems.org",
+		parse: func(ctx context.Context, in ownsbom.ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+			return ownsbom.Gem{}.Parse(ctx, in)
+		},
+	},
+	"poetry": {
+		ecosystem: "poetry", defaultBin: "poetry", manifest: "pyproject.toml",
+		lockfiles: []string{"poetry.lock"}, produced: "poetry.lock",
+		args:         []string{"lock", "--no-interaction"},
+		registryHost: "pypi.org",
+		parse: func(ctx context.Context, in ownsbom.ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
+			return ownsbom.Poetry{}.Parse(ctx, in)
+		},
+	},
+}
+
+// Resolver resolves one ecosystem (chosen at construction) via manifestresolve.New(ecosystem, bin).
+type Resolver struct {
+	spec     spec
+	bin      string
+	runner   ports.ToolRunner
+	regHosts []string
+}
+
+// New returns a resolver for the given ecosystem ("composer"/"gem"/"poetry"). bin overrides the default
+// tool binary ("" = the ecosystem default). An unknown ecosystem yields a resolver whose Resolve is a
+// no-op, so a caller need not special-case it.
+func New(ecosystem, bin string) *Resolver {
+	s := specs[ecosystem]
+	if strings.TrimSpace(bin) == "" {
+		bin = s.defaultBin
+	}
+	return &Resolver{spec: s, bin: bin}
+}
+
+// Ecosystem identifies the resolver (for tracing/source warnings).
+func (r *Resolver) Ecosystem() string { return r.spec.ecosystem }
+
+// WithRunner confines the tool in a ToolRunner (the sandbox): the throwaway workdir is the one writable
+// bind and egress is restricted to the ecosystem registry. nil keeps the direct exec (trusted-local CLI).
+func (r *Resolver) WithRunner(runner ports.ToolRunner) *Resolver { r.runner = runner; return r }
+
+// WithRegistryHosts adds extra registry hosts to the sandbox egress allow-list (private mirror).
+func (r *Resolver) WithRegistryHosts(hosts []string) *Resolver {
+	for _, h := range hosts {
+		if h = strings.TrimSpace(h); h != "" {
+			r.regHosts = append(r.regHosts, h)
+		}
+	}
+	return r
+}
+
+var _ ports.ManifestResolver = (*Resolver)(nil)
+
+// Resolve returns the resolved component tree for the ecosystem's lockfile-less manifest under dir. It is
+// a no-op (nil, nil) when the ecosystem is unknown, there is no manifest, or a committed lockfile is
+// present. A missing tool or any resolution error returns (nil, err) — surfaced as a source warning,
+// never failing the scan; components are returned only on success. Only the top-level dir is inspected.
+func (r *Resolver) Resolve(ctx context.Context, dir string) ([]sbom.Component, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if r.spec.manifest == "" { // unknown ecosystem
+		return nil, nil
+	}
+	manifest := filepath.Join(dir, r.spec.manifest)
+	if fi, err := os.Stat(manifest); err != nil || !fi.Mode().IsRegular() {
+		return nil, nil
+	}
+	for _, ln := range r.spec.lockfiles {
+		if fi, err := os.Stat(filepath.Join(dir, ln)); err == nil && fi.Mode().IsRegular() {
+			return nil, nil // a committed lockfile is parsed directly; resolution would be redundant
+		}
+	}
+
+	work, err := os.MkdirTemp("", "synapse-manifestresolve-")
+	if err != nil {
+		return nil, fmt.Errorf("%s resolve: temp dir: %w", r.spec.ecosystem, err)
+	}
+	defer func() { _ = os.RemoveAll(work) }()
+	data, err := os.ReadFile(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("%s resolve: read %s: %w", r.spec.ecosystem, r.spec.manifest, err)
+	}
+	if err := os.WriteFile(filepath.Join(work, r.spec.manifest), data, 0o600); err != nil {
+		return nil, fmt.Errorf("%s resolve: stage %s: %w", r.spec.ecosystem, r.spec.manifest, err)
+	}
+	if err := r.run(ctx, work); err != nil {
+		return nil, err
+	}
+	lock, err := os.ReadFile(filepath.Join(work, r.spec.produced))
+	if err != nil {
+		return nil, fmt.Errorf("%s resolve: no %s produced: %w", r.spec.ecosystem, r.spec.produced, err)
+	}
+	comps, _, err := r.spec.parse(ctx, ownsbom.ParseInput{Dir: dir, Path: manifest, Content: lock})
+	if err != nil {
+		return nil, fmt.Errorf("%s resolve: parse generated lock: %w", r.spec.ecosystem, err)
+	}
+	return comps, nil
+}
+
+func (r *Resolver) allowedHosts() []string {
+	return append([]string{r.spec.registryHost}, r.regHosts...)
+}
+
+func (r *Resolver) run(ctx context.Context, work string) error {
+	env := []string{"HOME=" + work} // keep the tool's home/cache inside the throwaway dir
+	if r.runner != nil {
+		res, err := r.runner.Run(ctx, ports.ToolSpec{
+			Name:         r.bin,
+			Args:         r.spec.args,
+			Workdir:      work,
+			Env:          env,
+			EgressPolicy: &ports.EgressPolicy{AllowDomains: r.allowedHosts()},
+		})
+		if err != nil {
+			return fmt.Errorf("%s resolve (sandboxed): %w: %s", r.spec.ecosystem, err, truncate(string(res.Stderr), 300))
+		}
+		if res.ExitCode != 0 {
+			return fmt.Errorf("%s resolve: exit %d: %s", r.spec.ecosystem, res.ExitCode, truncate(string(res.Stderr), 300))
+		}
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, r.bin, r.spec.args...)
+	cmd.Dir = work
+	cmd.Env = append(scrubSensitiveEnv(os.Environ()), env...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s resolve: %w: %s", r.spec.ecosystem, err, truncate(stderr.String(), 300))
+	}
+	return nil
+}
+
+// scrubSensitiveEnv drops SYNAPSE_* and common credential env vars so a resolution subprocess can't read
+// Synapse or host secrets. Mirrors npmresolve.scrubSensitiveEnv.
+func scrubSensitiveEnv(env []string) []string {
+	out := env[:0:0]
+	for _, kv := range env {
+		name := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			name = kv[:i]
+		}
+		if strings.HasPrefix(name, "SYNAPSE_") {
+			continue
+		}
+		u := strings.ToUpper(name)
+		sensitive := false
+		for _, frag := range []string{"TOKEN", "SECRET", "PASSWORD", "PASSWD", "APIKEY", "API_KEY", "ACCESS_KEY", "PRIVATE_KEY", "CREDENTIAL"} {
+			if strings.Contains(u, frag) {
+				sensitive = true
+				break
+			}
+		}
+		if !sensitive {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+func truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}

--- a/internal/infrastructure/tools/manifestresolve/resolver_test.go
+++ b/internal/infrastructure/tools/manifestresolve/resolver_test.go
@@ -49,17 +49,24 @@ func TestEcosystemLabelAndSpecs(t *testing.T) {
 			t.Errorf("Ecosystem() = %q, want %q", got, want)
 		}
 	}
-	// Every spec must run in a no-scripts / lock-only mode (safety-critical, per ecosystem).
+	// Per-ecosystem invocation safety. composer runs on inert JSON with scripts+plugins DISABLED; poetry
+	// runs on inert TOML in lock (resolve-only) mode. gem is DIFFERENT: `bundle lock` evaluates the Gemfile
+	// (Ruby), so it is NOT script-isolated — its safety is the trusted-local/sandbox posture, not a flag.
 	for eco, s := range specs {
 		joined := strings.Join(s.args, " ")
 		switch eco {
 		case "composer":
-			if !strings.Contains(joined, "--no-scripts") || !strings.Contains(joined, "--no-install") {
-				t.Errorf("composer args must be no-scripts + no-install: %q", joined)
+			if !strings.Contains(joined, "--no-scripts") || !strings.Contains(joined, "--no-plugins") || !strings.Contains(joined, "--no-install") {
+				t.Errorf("composer args must be no-scripts + no-plugins + no-install: %q", joined)
 			}
-		case "gem", "poetry":
+		case "poetry":
 			if !strings.Contains(joined, "lock") || strings.Contains(joined, "install") {
-				t.Errorf("%s args must be lock-only (no install): %q", eco, joined)
+				t.Errorf("poetry args must be lock-only (no install): %q", joined)
+			}
+		case "gem":
+			// Resolve-only (no install), but note: this does NOT make it code-isolated (Gemfile is Ruby).
+			if !strings.Contains(joined, "lock") || strings.Contains(joined, "install") {
+				t.Errorf("gem args must be `lock` (no install): %q", joined)
 			}
 		}
 	}

--- a/internal/infrastructure/tools/manifestresolve/resolver_test.go
+++ b/internal/infrastructure/tools/manifestresolve/resolver_test.go
@@ -1,0 +1,80 @@
+package manifestresolve
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNoOpWithoutManifest(t *testing.T) {
+	for _, eco := range []string{"composer", "gem", "poetry"} {
+		comps, err := New(eco, "").Resolve(context.Background(), t.TempDir())
+		if err != nil || comps != nil {
+			t.Errorf("%s: no manifest must be a no-op; got %d comps err=%v", eco, len(comps), err)
+		}
+	}
+}
+
+func TestNoOpWhenLockfilePresent(t *testing.T) {
+	cases := map[string][2]string{ // ecosystem -> {manifest, committed lockfile}
+		"composer": {"composer.json", "composer.lock"},
+		"gem":      {"Gemfile", "Gemfile.lock"},
+		"poetry":   {"pyproject.toml", "poetry.lock"},
+	}
+	for eco, f := range cases {
+		dir := t.TempDir()
+		must(t, filepath.Join(dir, f[0]), "{}")
+		must(t, filepath.Join(dir, f[1]), "{}")
+		// Bad bin proves the tool is never invoked when a lockfile already exists.
+		comps, err := New(eco, "/nonexistent/tool").Resolve(context.Background(), dir)
+		if err != nil || comps != nil {
+			t.Errorf("%s: committed lockfile must short-circuit; got %d comps err=%v", eco, len(comps), err)
+		}
+	}
+}
+
+func TestUnknownEcosystemIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	must(t, filepath.Join(dir, "whatever"), "x")
+	if comps, err := New("golang", "go").Resolve(context.Background(), dir); err != nil || comps != nil {
+		t.Errorf("unknown ecosystem must be a no-op; got %d comps err=%v", len(comps), err)
+	}
+}
+
+func TestEcosystemLabelAndSpecs(t *testing.T) {
+	for eco, want := range map[string]string{"composer": "composer", "gem": "gem", "poetry": "poetry"} {
+		if got := New(eco, "").Ecosystem(); got != want {
+			t.Errorf("Ecosystem() = %q, want %q", got, want)
+		}
+	}
+	// Every spec must run in a no-scripts / lock-only mode (safety-critical, per ecosystem).
+	for eco, s := range specs {
+		joined := strings.Join(s.args, " ")
+		switch eco {
+		case "composer":
+			if !strings.Contains(joined, "--no-scripts") || !strings.Contains(joined, "--no-install") {
+				t.Errorf("composer args must be no-scripts + no-install: %q", joined)
+			}
+		case "gem", "poetry":
+			if !strings.Contains(joined, "lock") || strings.Contains(joined, "install") {
+				t.Errorf("%s args must be lock-only (no install): %q", eco, joined)
+			}
+		}
+	}
+}
+
+func TestScrubSensitiveEnv(t *testing.T) {
+	out := scrubSensitiveEnv([]string{"PATH=/x", "HOME=/h", "NPM_TOKEN=s", "AWS_SECRET_ACCESS_KEY=s", "SYNAPSE_DB_DSN=s", "GITHUB_TOKEN=s"})
+	if len(out) != 2 {
+		t.Errorf("only PATH+HOME must survive, got %v", out)
+	}
+}
+
+func must(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -249,6 +249,15 @@ type Config struct {
 	NPMResolveEnabled bool
 	NPMBin            string
 	NPMRegistryHosts  []string
+	// ManifestResolveEnabled turns on lockfile-less manifest resolution for composer.json / Gemfile /
+	// pyproject.toml via each ecosystem's own lock tool (no scripts). Reaches the registry, so production
+	// MUST run it sandbox-confined. Bins default to composer/bundle/poetry; ManifestRegistryHosts extends
+	// the egress allow-list (private mirror).
+	ManifestResolveEnabled bool
+	ComposerBin            string
+	BundleBin              string
+	PoetryBin              string
+	ManifestRegistryHosts  []string
 	// JVMReachabilityEnabled turns on coarse JVM class-reachability tagging: after resolving the
 	// dependency tree, tag each component with whether the app's own compiled classes (transitively)
 	// reference its classes, so a finding on an unreferenced dependency can be deprioritized. Read-only
@@ -377,6 +386,11 @@ func Load() Config {
 		NPMResolveEnabled:      getbool("SYNAPSE_NPM_RESOLVE_ENABLED", false),
 		NPMBin:                 getenv("SYNAPSE_NPM_BIN", "npm"),
 		NPMRegistryHosts:       splitList(getenv("SYNAPSE_NPM_REGISTRY_HOSTS", "")),
+		ManifestResolveEnabled: getbool("SYNAPSE_MANIFEST_RESOLVE_ENABLED", false),
+		ComposerBin:            getenv("SYNAPSE_COMPOSER_BIN", "composer"),
+		BundleBin:              getenv("SYNAPSE_BUNDLE_BIN", "bundle"),
+		PoetryBin:              getenv("SYNAPSE_POETRY_BIN", "poetry"),
+		ManifestRegistryHosts:  splitList(getenv("SYNAPSE_MANIFEST_REGISTRY_HOSTS", "")),
 		JVMReachabilityEnabled: getbool("SYNAPSE_JVM_REACHABILITY_ENABLED", true),
 		JarHashOnlineEnabled:   getbool("SYNAPSE_JARHASH_ONLINE_ENABLED", false),
 		JarHashBaseURL:         getenv("SYNAPSE_JARHASH_BASE_URL", ""),

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -727,6 +727,16 @@ type NPMResolver interface {
 	Resolve(ctx context.Context, dir string) ([]sbom.Component, error)
 }
 
+// ManifestResolver resolves a lockfile-less package manifest (composer.json / Gemfile / pyproject.toml,
+// ...) to a pinned component tree by running the ecosystem's own lock tool in a no-scripts, lock-only
+// mode over a throwaway copy. Ecosystem() labels it for tracing. Several may be registered; each is a
+// no-op when its manifest is absent or a committed lockfile is present. Best-effort + OPT-IN; a
+// production implementation MUST run sandbox-confined (untrusted manifest, reaches the registry).
+type ManifestResolver interface {
+	Ecosystem() string
+	Resolve(ctx context.Context, dir string) ([]sbom.Component, error)
+}
+
 // SBOMEnrichment is what an SBOMEnricher contributed, for honest provenance.
 type SBOMEnrichment struct {
 	ComponentsAdded   int      // components the generator missed (Maven/Gradle direct deps)

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -80,6 +80,7 @@ type Service struct {
 	mavenResolver     ports.MavenResolver             // optional Maven transitive-tree resolver (`mvn dependency:list`)
 	gradleResolver    ports.GradleResolver            // optional Gradle transitive-tree resolver (`gradle dependencies`)
 	npmResolver       ports.NPMResolver               // optional npm resolver (`npm install --package-lock-only`) for a lockfile-less package.json
+	manifestResolvers []ports.ManifestResolver        // optional lockfile-less resolvers for composer.json / Gemfile / pyproject.toml / ...
 	jvmReach          ports.JVMReachabilityAnalyzer   // optional coarse JVM class-reachability tagger
 	sevEnricher       ports.SeverityEnricher          // optional NVD CVSS backfill for unknown-severity vulns
 	ignoreUnfixed     bool                            // when set, don't promote no-fix vulns to findings (Trivy --ignore-unfixed)
@@ -255,6 +256,14 @@ func (s *Service) SetGradleResolver(r ports.GradleResolver) { s.gradleResolver =
 // a package.json that has no committed lockfile into a pinned pkg:npm tree. nil ⇒ disabled.
 func (s *Service) SetNPMResolver(r ports.NPMResolver) { s.npmResolver = r }
 
+// AddManifestResolver registers a lockfile-less manifest resolver (composer/gem/poetry/...). Several may
+// be added; each runs best-effort and no-ops when its manifest is absent or already locked.
+func (s *Service) AddManifestResolver(r ports.ManifestResolver) {
+	if r != nil {
+		s.manifestResolvers = append(s.manifestResolvers, r)
+	}
+}
+
 // mergeResolvedJVM folds a resolver's transitive pkg:maven tree into doc and dedups by identity. Shared by
 // the Maven + Gradle resolvers (both emit Maven coordinates). No-op on an empty resolved set – with nothing
 // authoritative to substitute, syft's view (including any target/ jars, then the only version source) is
@@ -302,6 +311,37 @@ func mergeResolvedNPM(doc *sbom.SBOM, resolved []sbom.Component) {
 			continue // resolver owns the versioned npm tree; drop the redundant unversioned placeholders
 		}
 		kept = append(kept, c)
+	}
+	doc.Components = sbom.DedupeComponents(append(kept, resolved...))
+}
+
+// mergeResolvedManifest folds a lockfile-less manifest resolver's pinned tree into doc. It drops the
+// generator's UNVERSIONED components of the SAME ecosystem(s) as the resolved set (e.g. the range-declared
+// placeholders a composer.json/Gemfile/pyproject.toml yields), keeps concretely-versioned ones, then adds
+// the resolved tree and dedups by PURL. The ecosystem is derived from the resolved components' PURL type
+// (pkg:composer/, pkg:gem/, pkg:pypi/, ...), so it is generic across resolvers. No-op on an empty set.
+func mergeResolvedManifest(doc *sbom.SBOM, resolved []sbom.Component) {
+	if len(resolved) == 0 {
+		return
+	}
+	prefixes := map[string]bool{}
+	for _, c := range resolved {
+		if i := strings.IndexByte(c.PURL, '/'); i > 0 {
+			prefixes[c.PURL[:i+1]] = true // e.g. "pkg:composer/"
+		}
+	}
+	kept := make([]sbom.Component, 0, len(doc.Components))
+	for _, c := range doc.Components {
+		drop := false
+		for p := range prefixes {
+			if strings.HasPrefix(c.PURL, p) && !sbom.IsResolvedVersion(c.Version) {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			kept = append(kept, c)
+		}
 	}
 	doc.Components = sbom.DedupeComponents(append(kept, resolved...))
 }
@@ -1630,6 +1670,32 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 			trace.succeed(step, "npm resolution skipped (no lockless package.json)", map[string]int{"components": countComponents(doc)})
 		}
 	}
+	// Lockfile-less manifest resolvers (composer.json / Gemfile / pyproject.toml): each runs the
+	// ecosystem's own lock tool over a throwaway copy (no scripts) to pin versions; best-effort + opt-in,
+	// sandbox-gated in production. Merge like npm: drop the generator's unversioned placeholders of that
+	// ecosystem, keep versioned, dedup.
+	var manifestResolveErrs []string
+	for _, mr := range s.manifestResolvers {
+		if ctx.Err() != nil {
+			break
+		}
+		eco := mr.Ecosystem()
+		step = trace.start(stageSBOM, "manifest-resolve", eco+"-resolver", "Resolve "+eco+" dependency tree", map[string]int{"components": countComponents(doc)})
+		resolvedComps, mrr := mr.Resolve(ctx, ws.Dir)
+		before := countComponents(doc)
+		if len(resolvedComps) > 0 {
+			mergeResolvedManifest(doc, resolvedComps)
+		}
+		switch {
+		case mrr != nil:
+			manifestResolveErrs = append(manifestResolveErrs, fmt.Sprintf("%s: %v", eco, mrr))
+			trace.fail(step, mrr)
+		case len(resolvedComps) > 0:
+			trace.succeed(step, eco+" dependency tree resolved", map[string]int{"components_before": before, "components": countComponents(doc), "resolved": len(resolvedComps)})
+		default:
+			trace.succeed(step, eco+" resolution skipped (no lockless manifest)", map[string]int{"components": countComponents(doc)})
+		}
+	}
 	// Coarse JVM class-reachability, best-effort + opt-in: tag each JVM component with whether the
 	// app's own compiled code (transitively) references its classes, so a finding on a dependency the
 	// project never wires in can be DEPRIORITIZED. Runs post-resolve over the resolved tree + the built
@@ -1812,6 +1878,10 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	if npmResolveErr != nil {
 		sourceWarnings = append(sourceWarnings, fmt.Sprintf(
 			"npm dependency resolution failed – package.json tree NOT captured (result INCOMPLETE): %v", npmResolveErr))
+	}
+	for _, e := range manifestResolveErrs {
+		sourceWarnings = append(sourceWarnings, fmt.Sprintf(
+			"manifest dependency resolution failed – tree NOT captured (result INCOMPLETE): %s", e))
 	}
 	// An image target whose rootfs could not be assembled means OS packages were NOT owned-cataloged; surface
 	// it (never silent) so an absent OS-package set reads as "not analyzed", not "no OS packages".


### PR DESCRIPTION
Completes the zero-setup SCA roadmap: generalizes the npm resolver to the long tail of lockfile-only ecosystems whose human manifest declares only version ranges (so the SBOM had no resolvable version to advisory-match).

New generic `manifestresolve` adapter (`ports.ManifestResolver`) + a spec table:

| ecosystem | manifest | resolve (lock-only, no scripts) | owned parser |
|---|---|---|---|
| composer | composer.json | `composer update --no-install --no-scripts --no-plugins` | Composer (composer.lock) |
| gem | Gemfile | `bundle lock` | Gem (Gemfile.lock) |
| poetry | pyproject.toml | `poetry lock` | Poetry (poetry.lock) |

Each runs the ecosystem tool over a **throwaway copy** of the manifest, then reuses the owned lockfile parser to emit pinned components.

**Safety** (mirrors the npm resolver): no project scripts run, the source is never mutated, a pinned tool, `SYNAPSE_*`/credential env scrubbed; CLI default-on/direct-exec (trusted-local, transparency note), API **sandbox-gated + fail-closed** (egress → the ecosystem registry). Best-effort + opt-in (`SYNAPSE_MANIFEST_RESOLVE_ENABLED`): no manifest / committed lockfile / missing tool / any error is a no-op, scan never fails.

SCA service holds a slice of resolvers (`AddManifestResolver`) and folds each via a generic `mergeResolvedManifest` that drops the generator's unversioned placeholders of the resolved ecosystem(s) (derived from the PURL type) and dedups by PURL. Unit tests cover no-op paths, the no-scripts/lock-only args per ecosystem, and credential-env scrubbing. Full suite (120 pkgs) + vet + `CGO_ENABLED=0 build ./cmd/...` green.
