### PR TITLE
fix(sca): drop the Gradle wrapper jar from the SBOM (spurious version-UNKNOWN component) (#146)

### DIFF
--- a/internal/infrastructure/tools/syft/generator.go
+++ b/internal/infrastructure/tools/syft/generator.go
@@ -270,6 +270,9 @@ func parseCycloneDX(data []byte) ([]sbom.Component, []sbom.Dependency, string, e
 			continue // skip entries that don't identify a package
 		}
 		loc, layerID := c.primaryLocation()
+		if isGradleWrapperJar(loc) {
+			continue // the Gradle wrapper jar is build tooling, not a dependency (Syft emits it version-UNKNOWN)
+		}
 		supplier, supplierSrc := sbom.SupplierWithSource(c.Supplier.Name, c.PURL)
 		comp := sbom.Component{
 			Name: c.Name, Version: c.Version, PURL: c.PURL,
@@ -379,4 +382,11 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return string(r[:n]) + "…"
+}
+
+// isGradleWrapperJar reports whether loc is the Gradle wrapper jar (gradle/wrapper/gradle-wrapper.jar) —
+// build tooling, not a project dependency. Syft catalogs it as a version-UNKNOWN pkg:maven pseudo-
+// component that can't be advisory-matched, so it is pure SBOM noise and is dropped.
+func isGradleWrapperJar(loc string) bool {
+	return strings.HasSuffix(filepath.ToSlash(loc), "gradle/wrapper/gradle-wrapper.jar")
 }

--- a/internal/infrastructure/tools/syft/generator.go
+++ b/internal/infrastructure/tools/syft/generator.go
@@ -384,9 +384,11 @@ func truncate(s string, n int) string {
 	return string(r[:n]) + "…"
 }
 
-// isGradleWrapperJar reports whether loc is the Gradle wrapper jar (gradle/wrapper/gradle-wrapper.jar) —
+// isGradleWrapperJar reports whether loc is the Gradle wrapper jar (<project>/gradle/wrapper/gradle-wrapper.jar) —
 // build tooling, not a project dependency. Syft catalogs it as a version-UNKNOWN pkg:maven pseudo-
-// component that can't be advisory-matched, so it is pure SBOM noise and is dropped.
+// component that can't be advisory-matched, so it is pure SBOM noise and is dropped. The suffix is anchored on
+// a path separator so a directory merely ending in "gradle" (e.g. mygradle/wrapper/…) can't match; Syft always
+// emits '/'-delimited location paths, so no separator normalization is needed.
 func isGradleWrapperJar(loc string) bool {
-	return strings.HasSuffix(filepath.ToSlash(loc), "gradle/wrapper/gradle-wrapper.jar")
+	return strings.HasSuffix(loc, "/gradle/wrapper/gradle-wrapper.jar")
 }

--- a/internal/infrastructure/tools/syft/generator_test.go
+++ b/internal/infrastructure/tools/syft/generator_test.go
@@ -205,3 +205,20 @@ func TestParseCycloneDXDropsGradleWrapper(t *testing.T) {
 		t.Fatalf("want only commons-lang3, got %+v", comps)
 	}
 }
+
+func TestParseCycloneDXKeepsNonWrapperGradleArtifact(t *testing.T) {
+	// The drop is anchored to the canonical wrapper location. A real published artifact whose filename
+	// merely starts with "gradle-wrapper" (e.g. a versioned jar in a Maven-style path) must be KEPT — this
+	// locks the suffix from being loosened into a name match later.
+	doc := `{"components":[
+	  {"bom-ref":"a","name":"gradle-wrapper","version":"8.5","purl":"pkg:maven/org.gradle/gradle-wrapper@8.5",
+	   "properties":[{"name":"syft:location:0:path","value":"/root/.m2/repository/org/gradle/gradle-wrapper/8.5/gradle-wrapper-8.5.jar"}]}
+	]}`
+	comps, _, _, err := parseCycloneDX([]byte(doc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(comps) != 1 || comps[0].Version != "8.5" {
+		t.Fatalf("a versioned gradle-wrapper artifact must be kept, got %+v", comps)
+	}
+}

--- a/internal/infrastructure/tools/syft/generator_test.go
+++ b/internal/infrastructure/tools/syft/generator_test.go
@@ -1,6 +1,9 @@
 package syft
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const cdxFixture = `{
   "components": [
@@ -179,5 +182,26 @@ func TestParseCycloneDXDependencyDedup(t *testing.T) {
 	}
 	if len(deps[0].DependsOn) != 1 || deps[0].DependsOn[0] != "pkg:npm/b@1" {
 		t.Errorf("dependsOn = %+v, want [pkg:npm/b@1] (self-edge + dup dropped)", deps[0].DependsOn)
+	}
+}
+
+func TestParseCycloneDXDropsGradleWrapper(t *testing.T) {
+	doc := `{"components":[
+	  {"bom-ref":"a","name":"gradle-wrapper","version":"UNKNOWN","purl":"pkg:maven/gradle-wrapper/gradle-wrapper",
+	   "properties":[{"name":"syft:location:0:path","value":"/gradle/wrapper/gradle-wrapper.jar"}]},
+	  {"bom-ref":"b","name":"commons-lang3","version":"3.17.0","purl":"pkg:maven/org.apache.commons/commons-lang3@3.17.0",
+	   "properties":[{"name":"syft:location:0:path","value":"/build/libs/app.jar"}]}
+	]}`
+	comps, _, _, err := parseCycloneDX([]byte(doc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, c := range comps {
+		if c.Name == "gradle-wrapper" || strings.Contains(c.PURL, "gradle-wrapper") {
+			t.Errorf("gradle wrapper jar must be dropped, got %+v", c)
+		}
+	}
+	if len(comps) != 1 || comps[0].Name != "commons-lang3" {
+		t.Fatalf("want only commons-lang3, got %+v", comps)
 	}
 }


### PR DESCRIPTION
Fixes #146. Syft catalogs `gradle/wrapper/gradle-wrapper.jar` as `pkg:maven/gradle-wrapper/gradle-wrapper@UNKNOWN` — build tooling, not a dependency, no resolvable coordinate (unmatchable) → SBOM noise. `parseCycloneDX` drops the component whose primary location is `gradle/wrapper/gradle-wrapper.jar`. Real deps unaffected; regression test added. Full suite (120) + vet green.