### PR TITLE
feat(sca): add Conan 2.x config_requires components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **SCA.** Added Conan 2.x `config_requires` packages to OwnSBOM component output.
 - **SCA.** Added first-party OwnSBOM support for exact registry packages in Python `uv.lock` files.
 - **SCA.** Added Conan 1.x node-level `python_requires` components to OwnSBOM output.
 - **SCA.** Added deterministic dependency graph relationships for Conan 1.x `graph_lock` files.

--- a/internal/infrastructure/tools/ownsbom/conan.go
+++ b/internal/infrastructure/tools/ownsbom/conan.go
@@ -17,15 +17,17 @@ import (
 // components.
 //
 // Two lockfile shapes are supported: Conan 2.x lists reference strings under
-// requires, build_requires, and python_requires. Conan 1.x stores package
-// references and graph relationships in graph_lock nodes. References use the
-// form name/version[@user/channel][#recipe_revision].
+// requires, build_requires, python_requires, and config_requires. Conan 1.x
+// stores package references and graph relationships in graph_lock nodes.
+// References use the form
+// name/version[@user/channel][#recipe_revision[%revision_timestamp]].
 //
-// Conan 1.x requires and build_requires node IDs emit deterministic dependency
-// relationships. Node-level python_requires references are emitted as development- or
-// background-scoped components only because Conan stores a transitive
-// reference closure rather than direct graph node IDs. The parser uses only
-// the Go standard library.
+// Conan 2.x build, Python, and configuration requirements are emitted as
+// development- or background-scoped components. Conan 1.x requires and
+// build_requires node IDs emit deterministic dependency relationships.
+// Node-level python_requires references are emitted as components only because
+// Conan stores a transitive reference closure rather than direct graph node
+// IDs. The parser uses only the Go standard library.
 type Conan struct{}
 
 // Ecosystem identifies this parser's package ecosystem.
@@ -46,6 +48,7 @@ type conanLock struct {
 	Requires       []string `json:"requires"`
 	BuildRequires  []string `json:"build_requires"`
 	PythonRequires []string `json:"python_requires"`
+	ConfigRequires []string `json:"config_requires"`
 	GraphLock      struct {
 		Nodes map[string]conanLockNode `json:"nodes"`
 	} `json:"graph_lock"`
@@ -53,10 +56,12 @@ type conanLock struct {
 
 // Parse extracts resolved Conan components and, for Conan 1.x graph_lock
 // files, dependency relationships from requires and build_requires.
-// Node-level python_requires references are included as components but are
-// not inferred as direct dependency edges.
+// Top-level Conan 2.x config_requires and Conan 1.x node-level
+// python_requires are included as components but do not create dependency
+// edges.
 // Results are sorted deterministically because Conan 1.x nodes are stored in a
-// JSON object and therefore decoded into a Go map with unspecified iteration order.
+// JSON object and therefore decoded into a Go map with unspecified iteration
+// order.
 func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
@@ -82,8 +87,8 @@ func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 		return name, version, purl, true
 	}
 
-	// Scope build/python requires as development (build-time tooling), matching the conanfile.txt mapping
-	// of [tool_requires]; the path scope may already be a background one, which wins.
+	// Scope build, Python, and configuration requirements as development-time
+	// inputs. A path-derived background scope takes precedence.
 	prod := sbom.ClassifyScope(in.Path, "")
 	dev := prod
 	if !sbom.IsBackgroundScope(prod) {
@@ -110,6 +115,9 @@ func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 		add(ref, dev)
 	}
 	for _, ref := range lock.PythonRequires {
+		add(ref, dev)
+	}
+	for _, ref := range lock.ConfigRequires {
 		add(ref, dev)
 	}
 
@@ -204,8 +212,9 @@ func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 	return comps, deps, nil
 }
 
-// parseConanRef splits a Conan reference name/version[@user/channel][#recipe_revision] into its name and
-// version. The version is the segment after the first "/", cut at the first "@" (user/channel) or "#"
+// parseConanRef splits a Conan reference
+// name/version[@user/channel][#recipe_revision[%revision_timestamp]]
+// into its name and version. The version is the segment after the first "/", cut at the first "@" (user/channel) or "#"
 // (recipe revision). Returns empty strings when the ref has no version segment.
 func parseConanRef(ref string) (string, string) {
 	ref = strings.TrimSpace(ref)

--- a/internal/infrastructure/tools/ownsbom/conan_test.go
+++ b/internal/infrastructure/tools/ownsbom/conan_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 )
 
-// Conan 2.x: reference strings under requires / build_requires / python_requires.
+// Conan 2.x: reference strings under requires, build_requires,
+// python_requires, and config_requires.
 const conanLockV2Fixture = `{
   "version": "0.5",
   "requires": [
@@ -24,6 +25,9 @@ const conanLockV2Fixture = `{
   ],
   "python_requires": [
     "config/2.0@company/stable"
+  ],
+  "config_requires": [
+    "company-config/3.2#abc123%1724319985.398"
   ]
 }`
 
@@ -59,8 +63,8 @@ func TestConanParseV2(t *testing.T) {
 	for _, c := range comps {
 		byName[c.Name] = c
 	}
-	if len(comps) != 4 {
-		t.Fatalf("want 4 components (zlib, openssl, cmake, config), got %d (%+v)", len(comps), comps)
+	if len(comps) != 5 {
+		t.Fatalf("want 5 components (zlib, openssl, cmake, config, company-config), got %d (%+v)", len(comps), comps)
 	}
 	if c := byName["zlib"]; c.PURL != "pkg:conan/zlib@1.2.13" {
 		t.Errorf("zlib PURL wrong (revision must be stripped): %+v", c)
@@ -73,6 +77,9 @@ func TestConanParseV2(t *testing.T) {
 	}
 	if c := byName["config"]; c.Scope != sbom.ScopeDevelopment {
 		t.Errorf("config scope wrong: %+v", c)
+	}
+	if c := byName["company-config"]; c.Name != "company-config" || c.Version != "3.2" || c.PURL != "pkg:conan/company-config@3.2" || c.Scope != sbom.ScopeDevelopment || c.Location != "conan.lock" {
+		t.Errorf("company-config component wrong: %+v", c)
 	}
 }
 
@@ -707,5 +714,384 @@ func TestConanRegistryGenerateIncludesPythonRequires(t *testing.T) {
 	}
 	if len(doc.Dependencies) != 0 {
 		t.Errorf("want 0 dependencies, got %+v", doc.Dependencies)
+	}
+}
+
+func TestConanParseV2ConfigRequiresOnly(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+  "version": "0.5",
+  "requires": [],
+  "build_requires": [],
+  "python_requires": [],
+  "config_requires": [
+    "company-config/3.2"
+  ]
+}`))
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d: %+v", len(comps), comps)
+	}
+	c := comps[0]
+	if c.Name != "company-config" || c.Version != "3.2" || c.PURL != "pkg:conan/company-config@3.2" || c.Scope != sbom.ScopeDevelopment || c.Location != "conan.lock" {
+		t.Errorf("wrong component: %+v", c)
+	}
+	if deps != nil {
+		t.Errorf("want nil deps, got %v", deps)
+	}
+}
+
+func TestConanParseV2ConfigRequiresNormalization(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      string
+		wantPURL string
+	}{
+		{
+			name:     "plain",
+			ref:      "config/1.0",
+			wantPURL: "pkg:conan/config@1.0",
+		},
+		{
+			name:     "user channel",
+			ref:      "config/1.0@company/stable",
+			wantPURL: "pkg:conan/config@1.0",
+		},
+		{
+			name:     "recipe revision",
+			ref:      "config/1.0#abc123",
+			wantPURL: "pkg:conan/config@1.0",
+		},
+		{
+			name:     "revision timestamp",
+			ref:      "config/1.0#abc123%1724319985.398",
+			wantPURL: "pkg:conan/config@1.0",
+		},
+		{
+			name:     "user channel revision timestamp",
+			ref:      "config/1.0@company/stable#abc123%1724319985.398",
+			wantPURL: "pkg:conan/config@1.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comps, deps := parseConanTest(t, "conan.lock", []byte(fmt.Sprintf(`{"version": "0.5", "config_requires": ["%s"]}`, tt.ref)))
+			if len(comps) != 1 {
+				t.Fatalf("want 1 component, got %d: %+v", len(comps), comps)
+			}
+			c := comps[0]
+			if c.Name != "config" || c.Version != "1.0" || c.PURL != tt.wantPURL || c.Scope != sbom.ScopeDevelopment || c.Location != "conan.lock" {
+				t.Errorf("wrong component: %+v", c)
+			}
+			if deps != nil {
+				t.Errorf("want nil deps, got %v", deps)
+			}
+		})
+	}
+}
+
+func TestConanParseV2ConfigRequiresScopePrecedence(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+  "version": "0.5",
+  "config_requires": [
+    "shared-config/1.0@company/stable#abc123"
+  ],
+  "requires": [
+    "shared-config/1.0"
+  ]
+}`))
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d: %+v", len(comps), comps)
+	}
+	c := comps[0]
+	if c.Name != "shared-config" || c.Version != "1.0" || c.PURL != "pkg:conan/shared-config@1.0" || c.Scope != sbom.ScopeProduction {
+		t.Errorf("wrong component: %+v", c)
+	}
+	if deps != nil {
+		t.Errorf("want nil deps, got %v", deps)
+	}
+}
+
+func TestConanParseV2ConfigRequiresBackgroundScope(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantScope string
+	}{
+		{
+			name:      "test",
+			path:      "tests/conan.lock",
+			wantScope: sbom.ScopeTest,
+		},
+		{
+			name:      "fixture",
+			path:      "testdata/conan.lock",
+			wantScope: sbom.ScopeFixture,
+		},
+		{
+			name:      "example",
+			path:      "examples/app/conan.lock",
+			wantScope: sbom.ScopeExample,
+		},
+		{
+			name:      "documentation",
+			path:      "docs/sample/conan.lock",
+			wantScope: sbom.ScopeDocumentation,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comps, deps := parseConanTest(t, tt.path, []byte(`{
+  "version": "0.5",
+  "requires": [
+    "app/1.0"
+  ],
+  "config_requires": [
+    "company-config/3.2"
+  ]
+}`))
+			if len(comps) != 2 {
+				t.Fatalf("want 2 components, got %d: %+v", len(comps), comps)
+			}
+			var app, cfg sbom.Component
+			for _, c := range comps {
+				if c.Name == "app" {
+					app = c
+				} else if c.Name == "company-config" {
+					cfg = c
+				}
+			}
+			if app.Scope != tt.wantScope {
+				t.Errorf("want app scope %q, got %q", tt.wantScope, app.Scope)
+			}
+			if cfg.Scope != tt.wantScope {
+				t.Errorf("want cfg scope %q, got %q", tt.wantScope, cfg.Scope)
+			}
+			if deps != nil {
+				t.Errorf("want nil deps, got %v", deps)
+			}
+		})
+	}
+}
+
+func TestConanParseV2ConfigRequiresDeduplicatesPURL(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+  "version": "0.5",
+  "config_requires": [
+    "config/1.0",
+    "config/1.0@company/stable",
+    "config/1.0#abc123",
+    "config/1.0#abc123%1724319985.398"
+  ]
+}`))
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d: %+v", len(comps), comps)
+	}
+	c := comps[0]
+	if c.Name != "config" || c.Version != "1.0" || c.PURL != "pkg:conan/config@1.0" || c.Scope != sbom.ScopeDevelopment {
+		t.Errorf("wrong component: %+v", c)
+	}
+	if deps != nil {
+		t.Errorf("want nil deps, got %v", deps)
+	}
+}
+
+func TestConanParseV2ConfigRequiresCrossKindDedup(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+  "version": "0.5",
+  "build_requires": [
+    "config/1.0"
+  ],
+  "python_requires": [
+    "config/1.0@company/stable"
+  ],
+  "config_requires": [
+    "config/1.0#abc123"
+  ]
+}`))
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d: %+v", len(comps), comps)
+	}
+	c := comps[0]
+	if c.Name != "config" || c.Version != "1.0" || c.PURL != "pkg:conan/config@1.0" || c.Scope != sbom.ScopeDevelopment {
+		t.Errorf("wrong component: %+v", c)
+	}
+	if deps != nil {
+		t.Errorf("want nil deps, got %v", deps)
+	}
+}
+
+func TestConanParseV2ConfigRequiresPreservesVersions(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+  "version": "0.5",
+  "config_requires": [
+    "config/2.0",
+    "config/1.0"
+  ]
+}`))
+	if len(comps) != 2 {
+		t.Fatalf("want 2 components, got %d: %+v", len(comps), comps)
+	}
+	if comps[0].PURL != "pkg:conan/config@1.0" || comps[1].PURL != "pkg:conan/config@2.0" {
+		t.Errorf("wrong components or not sorted: %+v", comps)
+	}
+	if comps[0].Scope != sbom.ScopeDevelopment || comps[1].Scope != sbom.ScopeDevelopment {
+		t.Errorf("wrong scopes: %+v", comps)
+	}
+	if deps != nil {
+		t.Errorf("want nil deps, got %v", deps)
+	}
+}
+
+func TestConanParseV2ConfigRequiresSkipsMalformed(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+  "version": "0.5",
+  "config_requires": [
+    "",
+    "   ",
+    "invalid-reference",
+    "/1.0",
+    "config/",
+    "valid-config/2.0#abc123%1724319985.398"
+  ]
+}`))
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component, got %d: %+v", len(comps), comps)
+	}
+	if comps[0].PURL != "pkg:conan/valid-config@2.0" || comps[0].Scope != sbom.ScopeDevelopment {
+		t.Errorf("wrong component: %+v", comps[0])
+	}
+	if deps != nil {
+		t.Errorf("want nil deps, got %v", deps)
+	}
+}
+
+func TestConanParseV2ConfigRequiresDoNotInferEdges(t *testing.T) {
+	comps, deps := parseConanTest(t, "conan.lock", []byte(`{
+  "version": "0.5",
+  "requires": [
+    "app/1.0",
+    "lib/2.0"
+  ],
+  "config_requires": [
+    "company-config/3.2"
+  ]
+}`))
+	if len(comps) != 3 {
+		t.Fatalf("want 3 components, got %d: %+v", len(comps), comps)
+	}
+	if deps != nil {
+		t.Errorf("want nil deps, got %v", deps)
+	}
+}
+
+func TestConanParseV2ConfigRequiresDeterministic(t *testing.T) {
+	fixture := []byte(`{
+  "version": "0.5",
+  "config_requires": [
+    "z-config/1.0",
+    "a-config/2.0",
+    "middle-config/3.0"
+  ],
+  "requires": [
+    "app/1.0"
+  ]
+}`)
+	firstComps, firstDeps := parseConanTest(t, "conan.lock", fixture)
+	if len(firstComps) != 4 {
+		t.Fatalf("want 4 components, got %d: %+v", len(firstComps), firstComps)
+	}
+	expectedOrder := []string{
+		"pkg:conan/a-config@2.0",
+		"pkg:conan/app@1.0",
+		"pkg:conan/middle-config@3.0",
+		"pkg:conan/z-config@1.0",
+	}
+	for i, purl := range expectedOrder {
+		if firstComps[i].PURL != purl {
+			t.Errorf("item %d want %s, got %s", i, purl, firstComps[i].PURL)
+		}
+	}
+	for i := 0; i < 20; i++ {
+		comps, deps := parseConanTest(t, "conan.lock", fixture)
+		if !reflect.DeepEqual(firstComps, comps) {
+			t.Errorf("components differ on run %d", i)
+		}
+		if !reflect.DeepEqual(firstDeps, deps) {
+			t.Errorf("dependencies differ on run %d", i)
+		}
+	}
+}
+
+func TestConanRegistryGenerateIncludesConfigRequires(t *testing.T) {
+	dir := t.TempDir()
+
+	fixture := []byte(`{
+	  "version": "0.5",
+	  "requires": [
+	    "app/1.0"
+	  ],
+	  "config_requires": [
+	    "company-config/3.2#abc123%1724319985.398"
+	  ]
+	}`)
+
+	if err := os.WriteFile(
+		filepath.Join(dir, "conan.lock"),
+		fixture,
+		0o644,
+	); err != nil {
+		t.Fatalf("write conan.lock: %v", err)
+	}
+
+	reg, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+
+	doc, err := reg.Generate(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if doc.Source != "ownsbom" ||
+		doc.GeneratorVersion != ownsbomVersion {
+		t.Errorf(
+			"want source ownsbom and generator %s, got %s and %s",
+			ownsbomVersion,
+			doc.Source,
+			doc.GeneratorVersion,
+		)
+	}
+
+	if len(doc.Components) != 2 {
+		t.Fatalf(
+			"want 2 components, got %d: %+v",
+			len(doc.Components),
+			doc.Components,
+		)
+	}
+
+	byName := make(map[string]sbom.Component, len(doc.Components))
+	for _, component := range doc.Components {
+		byName[component.Name] = component
+	}
+
+	if component := byName["app"]; component.PURL != "pkg:conan/app@1.0" ||
+		component.Scope != sbom.ScopeProduction {
+		t.Errorf("app component wrong: %+v", component)
+	}
+
+	if component := byName["company-config"]; component.PURL != "pkg:conan/company-config@3.2" ||
+		component.Scope != sbom.ScopeDevelopment {
+		t.Errorf(
+			"company-config component wrong: %+v",
+			component,
+		)
+	}
+
+	if len(doc.Dependencies) != 0 {
+		t.Errorf(
+			"want no dependencies, got %+v",
+			doc.Dependencies,
+		)
 	}
 }

--- a/internal/infrastructure/tools/ownsbom/registry.go
+++ b/internal/infrastructure/tools/ownsbom/registry.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// ownsbomVersion identifies this producer in SBOM provenance. Bump when parser behavior changes.
-	ownsbomVersion = "ownsbom/0.6.0"
+	ownsbomVersion = "ownsbom/0.7.0"
 	// maxManifestBytes caps a single manifest read so a hostile/corrupt repo cannot OOM the scan with an
 	// absurd file. Real manifests are KB–low-MB; exceeding this is malicious or wrong, so it fails loud.
 	maxManifestBytes = 64 << 20


### PR DESCRIPTION
Closes #142

## Summary

Add OwnSBOM component discovery for Conan 2.x top-level `config_requires`.

Conan configuration packages are resolved inputs used to pin and verify the configuration applied by Conan. OwnSBOM now inventories those exact package references as normalized Conan components while intentionally avoiding inferred dependency edges.

## Changes

* Extend the Conan 2.x lockfile model with `config_requires`.
* Normalize configuration-package references using the existing Conan reference parser.
* Strip user/channel, recipe-revision, and revision-timestamp suffixes from component identity.
* Emit components as `pkg:conan/<name>@<version>`.
* Scope configuration-only packages as development dependencies on normal project paths.
* Preserve path-derived background scopes for test, fixture, example, and documentation lockfiles.
* Process regular `requires` before `config_requires` so duplicate packages retain production scope.
* Deduplicate normalized PURLs across Conan 2.x requirement categories.
* Preserve multiple resolved versions of the same package name.
* Skip malformed or incomplete references without failing an otherwise valid lockfile.
* Preserve existing Conan 1.x graph relationships.
* Preserve existing Conan 1.x node-level `python_requires` component behavior.
* Preserve existing Conan 2.x `requires`, `build_requires`, and `python_requires` behavior.
* Preserve existing `conanfile.txt` parsing and lockfile precedence.
* Keep component output deterministic.
* Add focused parser and `DefaultRegistry()` integration tests.
* Bump the OwnSBOM generator version to `ownsbom/0.7.0`.
* Update the changelog and Conan parser documentation.

## Why include configuration packages?

Conan configuration packages are resolved package inputs that constrain the configuration used by install, build, create, and graph operations.

They are not runtime application libraries, but they affect build reproducibility and configuration behavior. This PR therefore inventories them as development-scoped components.

## Why no dependency edges?

Conan 2.x stores `config_requires` as a top-level collection of resolved package references. The parsed lockfile shape does not provide a direct source-node relationship for those references.

Inferring edges from every runtime or build dependency would create relationships that are not represented in the lockfile. This PR therefore emits configuration packages as components only.

## Scope behavior

For a normal project lockfile:

```text
pkg:conan/app@1.0            production
pkg:conan/company-config@3.2 development
```

For a lockfile under a background path such as `tests/`:

```text
pkg:conan/app@1.0            test
pkg:conan/company-config@3.2 test
```

When the same normalized PURL appears under both `requires` and `config_requires`, the regular requirement is processed first and retains production scope.

## Example

Input:

```json
{
  "version": "0.5",
  "requires": [
    "zlib/1.3.1"
  ],
  "config_requires": [
    "company-config/3.2@company/stable#abc123%1724319985.398"
  ]
}
```

Output:

```text
pkg:conan/company-config@3.2
pkg:conan/zlib@1.3.1
```

No dependency edge is inferred from `config_requires`.

## Non-goals

* No dependency graph edges from `config_requires`.
* No Conan 1.x graph changes.
* No parsing of `conanfile.py`.
* No new `conanfile.txt` section.
* No Conan CLI or network execution.
* No configuration installation or validation.
* No representation of configuration installation order.
* No PURL qualifiers or remote metadata.
* No domain-model or parser-interface changes.
* No new external dependency.

## Testing

```bash
go test \
  ./internal/infrastructure/tools/ownsbom \
  -run 'TestConan' \
  -count=1 \
  -v

go test \
  ./internal/infrastructure/tools/ownsbom \
  -count=1

go test -race \
  ./internal/infrastructure/tools/ownsbom \
  -count=1

go test ./... -count=1
go build ./...
go vet ./...
CGO_ENABLED=0 go build ./cmd/...
golangci-lint run

cd web
pnpm install --frozen-lockfile
pnpm run typecheck
pnpm build
```

## Test coverage

* basic Conan 2.x configuration component discovery;
* configuration-only lockfiles;
* plain reference normalization;
* user/channel normalization;
* recipe-revision normalization;
* revision-timestamp normalization;
* production scope precedence independent of JSON field order;
* background path scope preservation;
* normalized-PURL deduplication;
* cross-category deduplication;
* preservation of multiple resolved versions;
* malformed-reference recovery;
* prevention of inferred dependency edges;
* deterministic component ordering;
* Conan 1.x graph regression behavior;
* Conan 1.x Python-requirement regression behavior;
* Conan 2.x existing category regression behavior;
* `conanfile.txt` parsing and lockfile precedence;
* registry propagation and generator provenance;
* context cancellation and malformed JSON handling.

## Checklist

* [x] Dedicated issue linked with `Closes #142`
* [x] `config_requires` modeled
* [x] Existing Conan reference normalization reused
* [x] Configuration packages emitted as Conan components
* [x] Development scope assigned on normal paths
* [x] Background scope preserved
* [x] Production duplicate scope preserved
* [x] Duplicate normalized PURLs removed
* [x] Multiple resolved versions preserved
* [x] Malformed references handled fail-soft
* [x] No dependency edges inferred
* [x] Conan 1.x behavior preserved
* [x] Existing Conan 2.x behavior preserved
* [x] `conanfile.txt` behavior preserved
* [x] Deterministic output tested
* [x] Registry integration tested
* [x] Generator version bumped to `ownsbom/0.7.0`
* [x] Changelog updated
* [x] No new dependencies introduced
