### PR TITLE
feat(misconfig): detect RDS instances without deletion protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **IaC misconfiguration scanning.** Added a Terraform rule for Amazon RDS DB instances without deletion protection.
 - **SCA.** Added first-party OwnSBOM support for exact registry packages in Python `uv.lock` files.
 - **SCA.** Added Conan 1.x node-level `python_requires` components to OwnSBOM output.
 - **SCA.** Added deterministic dependency graph relationships for Conan 1.x `graph_lock` files.

--- a/internal/infrastructure/tools/misconfig/terraform.go
+++ b/internal/infrastructure/tools/misconfig/terraform.go
@@ -8,11 +8,13 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-// Terraform (HCL) misconfiguration checks. Rather than a full HCL evaluator, this tracks the enclosing
-// `resource "TYPE" "NAME"` block by brace depth and matches insecure LITERAL attribute values inside it
-// – the common, high-signal cloud misconfigurations (public storage, world-open security groups,
-// disabled encryption, public databases, wildcard IAM, plaintext secrets). Values that come from a
-// variable / interpolation (${...}) are not flagged, keeping false positives low.
+// Terraform (HCL) misconfiguration checks. Rather than a full HCL
+// evaluator, this tracks the enclosing `resource "TYPE" "NAME"` block
+// by brace depth and matches high-confidence insecure literal values or
+// missing secure settings.
+//
+// Dynamic values from variables, locals, data sources, modules, and
+// expressions are not evaluated, keeping false positives low.
 var (
 	tfResourceOpen = regexp.MustCompile(`^\s*resource\s+"([^"]+)"\s+"([^"]*)"\s*\{`)
 	tfPublicACL    = regexp.MustCompile(`(?i)\bacl\s*=\s*"(public-read|public-read-write|authenticated-read)"`)
@@ -113,6 +115,20 @@ func tfBlockRules(rel, resType string, line int, body string) []ports.MisconfigR
 		})
 	}
 	switch resType {
+	case "aws_db_instance":
+		value, present := tfDirectAttribute(
+			body,
+			"deletion_protection",
+		)
+
+		if !present || value == "false" {
+			add(
+				"terraform-rds-deletion-protection-disabled",
+				"RDS deletion protection is not enabled",
+				shared.SeverityLow,
+				"The RDS DB instance does not enable deletion protection, so it can be deleted without first removing an explicit protection control. Set deletion_protection = true to reduce the risk of accidental or unauthorized deletion.",
+			)
+		}
 	case "aws_ecr_repository":
 		if !has("image_tag_mutability") || strings.Contains(body, `image_tag_mutability = "MUTABLE"`) {
 			add("terraform-ecr-mutable-tags", "ECR image tags are mutable", shared.SeverityLow,
@@ -246,4 +262,66 @@ func stripHCLComment(line string) string {
 		}
 	}
 	return line
+}
+
+func tfDirectAttribute(
+	body string,
+	attr string,
+) (string, bool) {
+	body = stripHCLBlockComments(body)
+	depth := 0
+
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+
+		if depth == 1 {
+			key, value, ok := strings.Cut(line, "=")
+			if ok && strings.TrimSpace(key) == attr {
+				return strings.TrimSpace(value), true
+			}
+		}
+
+		depth += strings.Count(line, "{")
+		depth -= strings.Count(line, "}")
+
+		if depth < 0 {
+			depth = 0
+		}
+	}
+
+	return "", false
+}
+
+// stripHCLBlockComments removes /* ... */ block comments from the given string,
+// except when inside a quoted string. It preserves newline characters to maintain
+// line counting and structure.
+func stripHCLBlockComments(body string) string {
+	var out strings.Builder
+	out.Grow(len(body))
+	inQ := false
+	inC := false
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if !inC && c == '"' && (i == 0 || body[i-1] != '\\') {
+			inQ = !inQ
+			out.WriteByte(c)
+			continue
+		}
+		if !inQ && !inC && c == '/' && i+1 < len(body) && body[i+1] == '*' {
+			inC = true
+			i++ // skip '*'
+			continue
+		}
+		if inC {
+			if c == '*' && i+1 < len(body) && body[i+1] == '/' {
+				inC = false
+				i++ // skip '/'
+			} else if c == '\n' {
+				out.WriteByte('\n')
+			}
+			continue
+		}
+		out.WriteByte(c)
+	}
+	return out.String()
 }

--- a/internal/infrastructure/tools/misconfig/terraform_test.go
+++ b/internal/infrastructure/tools/misconfig/terraform_test.go
@@ -6,6 +6,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 func TestTerraformInsecure(t *testing.T) {
@@ -60,6 +63,7 @@ resource "aws_s3_bucket_versioning" "v" {
 		"terraform-ecr-mutable-tags", "terraform-ecr-no-cmk",
 		"terraform-dynamodb-unencrypted", "terraform-dynamodb-no-pitr",
 		"terraform-ebs-unencrypted", "terraform-s3-no-versioning", "terraform-open-egress",
+		"terraform-rds-deletion-protection-disabled",
 	} {
 		if _, ok := got[want]; !ok {
 			t.Errorf("expected Terraform rule %q, got %v", want, keys(got))
@@ -69,7 +73,7 @@ resource "aws_s3_bucket_versioning" "v" {
 
 func TestTerraformSecureNoFindings(t *testing.T) {
 	// A hardened resource set: private ACL, scoped CIDR, encryption on, secret from a variable,
-	// immutable+encrypted ECR, encrypted DynamoDB with PITR.
+	// immutable+encrypted ECR, encrypted DynamoDB with PITR, deletion protection on.
 	tf := `resource "aws_s3_bucket" "b" {
   bucket = "my-bucket"
   acl    = "private"
@@ -100,6 +104,7 @@ resource "aws_db_instance" "db" {
   publicly_accessible = false
   storage_encrypted   = true
   password            = var.db_password
+  deletion_protection = true
 }
 
 resource "aws_ecr_repository" "r" {
@@ -191,3 +196,371 @@ spec:
         - name: web
           image: {{ .Values.image }}
 `
+
+func terraformFindingsByRule(
+	in []ports.MisconfigRawFinding,
+	ruleID string,
+) []ports.MisconfigRawFinding {
+	var out []ports.MisconfigRawFinding
+
+	for _, finding := range in {
+		if finding.RuleID == ruleID {
+			out = append(out, finding)
+		}
+	}
+
+	return out
+}
+
+func TestTerraformRDSDeletionProtectionMissing(t *testing.T) {
+	tf := `resource "aws_db_instance" "primary" {
+  identifier     = "primary"
+  engine         = "postgres"
+  instance_class = "db.t3.micro"
+}`
+	all := scanTerraform(
+		"infra/main.tf",
+		[]byte(tf),
+	)
+
+	got := terraformFindingsByRule(
+		all,
+		"terraform-rds-deletion-protection-disabled",
+	)
+
+	if len(got) != 1 {
+		t.Fatalf("want 1 finding, got %d: %+v", len(got), got)
+	}
+
+	want := ports.MisconfigRawFinding{
+		File:        "infra/main.tf",
+		Line:        1,
+		RuleID:      "terraform-rds-deletion-protection-disabled",
+		Title:       "RDS deletion protection is not enabled",
+		Severity:    shared.SeverityLow,
+		Resource:    "Terraform aws_db_instance",
+		Description: "The RDS DB instance does not enable deletion protection, so it can be deleted without first removing an explicit protection control. Set deletion_protection = true to reduce the risk of accidental or unauthorized deletion.",
+	}
+
+	if got[0] != want {
+		t.Errorf("finding mismatch:\nwant: %+v\n got: %+v", want, got[0])
+	}
+}
+
+func TestTerraformRDSDeletionProtectionFalse(t *testing.T) {
+	tf := `resource "aws_db_instance" "primary" {
+  deletion_protection = false
+}`
+	all := scanTerraform("main.tf", []byte(tf))
+	got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+	if len(got) != 1 {
+		t.Fatalf("want 1 finding, got %d: %+v", len(got), got)
+	}
+	if got[0].Line != 1 {
+		t.Errorf("want line 1, got %d", got[0].Line)
+	}
+	if got[0].Severity != shared.SeverityLow {
+		t.Errorf("want Low severity, got %v", got[0].Severity)
+	}
+}
+
+func TestTerraformRDSDeletionProtectionTrue(t *testing.T) {
+	tf := `resource "aws_db_instance" "primary" {
+  deletion_protection = true
+}`
+	all := scanTerraform("main.tf", []byte(tf))
+	got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+	if len(got) != 0 {
+		t.Fatalf("want 0 findings, got %d: %+v", len(got), got)
+	}
+}
+
+func TestTerraformRDSDeletionProtectionLiteralSyntax(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want int
+	}{
+		{
+			name: "false with spaces",
+			line: `  deletion_protection = false`,
+			want: 1,
+		},
+		{
+			name: "false without spaces",
+			line: `deletion_protection=false`,
+			want: 1,
+		},
+		{
+			name: "false with tab",
+			line: "deletion_protection\t=\tfalse",
+			want: 1,
+		},
+		{
+			name: "true with spaces",
+			line: `  deletion_protection = true`,
+			want: 0,
+		},
+		{
+			name: "true with inline comment",
+			line: `  deletion_protection = true # protected`,
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tf := "resource \"aws_db_instance\" \"primary\" {\n" + tt.line + "\n}"
+			all := scanTerraform("main.tf", []byte(tf))
+			got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+			if len(got) != tt.want {
+				t.Fatalf("want %d findings, got %d: %+v", tt.want, len(got), got)
+			}
+		})
+	}
+}
+
+func TestTerraformRDSDeletionProtectionDynamicValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{
+			name:  "variable",
+			value: `var.enable_deletion_protection`,
+		},
+		{
+			name:  "local",
+			value: `local.enable_deletion_protection`,
+		},
+		{
+			name:  "data source",
+			value: `data.aws_ssm_parameter.deletion_protection.value`,
+		},
+		{
+			name:  "module output",
+			value: `module.database_policy.deletion_protection`,
+		},
+		{
+			name:  "workspace expression",
+			value: `terraform.workspace == "prod"`,
+		},
+		{
+			name:  "conditional expression",
+			value: `var.production ? true : false`,
+		},
+		{
+			name:  "function expression",
+			value: `try(var.enable_deletion_protection, true)`,
+		},
+		{
+			name:  "interpolation string",
+			value: `"${var.enable_deletion_protection}"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tf := "resource \"aws_db_instance\" \"primary\" {\n  deletion_protection = " + tt.value + "\n}"
+			all := scanTerraform("main.tf", []byte(tf))
+			got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+			if len(got) != 0 {
+				t.Fatalf("want 0 findings, got %d: %+v", len(got), got)
+			}
+		})
+	}
+}
+
+func TestTerraformRDSDeletionProtectionCommentsDoNotSuppress(t *testing.T) {
+	tfs := []string{
+		`resource "aws_db_instance" "primary" {
+  # deletion_protection = true
+  engine = "postgres"
+}`,
+		`resource "aws_db_instance" "primary" {
+  // deletion_protection = true
+  engine = "postgres"
+}`,
+		`resource "aws_db_instance" "primary" {
+  engine = "postgres" # deletion_protection = true
+}`,
+		`resource "aws_db_instance" "primary" {
+  /* deletion_protection = true */
+  engine = "postgres"
+}`,
+		`resource "aws_db_instance" "primary" {
+  /*
+  deletion_protection = true
+  */
+  engine = "postgres"
+}`,
+		`resource "aws_db_instance" "primary" {
+  deletion_protection = false /* disabled */
+}`,
+	}
+	for i, tf := range tfs {
+		t.Run("comment_case_"+string(rune('0'+i)), func(t *testing.T) {
+			all := scanTerraform("main.tf", []byte(tf))
+			got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+			if len(got) != 1 {
+				t.Fatalf("want 1 finding, got %d: %+v", len(got), got)
+			}
+		})
+	}
+}
+
+func TestTerraformRDSDeletionProtectionExactAttribute(t *testing.T) {
+	tf := `resource "aws_db_instance" "primary" {
+  deletion_protection_backup = true
+  enable_deletion_protection = true
+  rds_deletion_protection    = true
+}`
+	all := scanTerraform("main.tf", []byte(tf))
+	got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+	if len(got) != 1 {
+		t.Fatalf("want 1 finding, got %d: %+v", len(got), got)
+	}
+}
+
+func TestTerraformRDSDeletionProtectionNestedAttribute(t *testing.T) {
+	tf := `resource "aws_db_instance" "primary" {
+  timeouts {
+    deletion_protection = true
+  }
+}`
+	all := scanTerraform("main.tf", []byte(tf))
+	got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+	if len(got) != 1 {
+		t.Fatalf("want 1 finding, got %d: %+v", len(got), got)
+	}
+}
+
+func TestTerraformRDSDeletionProtectionAfterNestedBlock(t *testing.T) {
+	tf := `resource "aws_db_instance" "primary" {
+  timeouts {
+    create = "60m"
+  }
+
+  deletion_protection = true
+}`
+	all := scanTerraform("main.tf", []byte(tf))
+	got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+	if len(got) != 0 {
+		t.Fatalf("want 0 findings, got %d: %+v", len(got), got)
+	}
+}
+
+func TestTerraformRDSDeletionProtectionDirectFalse(t *testing.T) {
+	tf := `resource "aws_db_instance" "primary" {
+  timeouts {
+    deletion_protection = true
+  }
+
+  deletion_protection = false
+}`
+	all := scanTerraform("main.tf", []byte(tf))
+	got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+	if len(got) != 1 {
+		t.Fatalf("want 1 finding, got %d: %+v", len(got), got)
+	}
+}
+
+func TestTerraformRDSDeletionProtectionResourceScope(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+	}{
+		{
+			name:         "RDS cluster",
+			resourceType: "aws_rds_cluster",
+		},
+		{
+			name:         "DocumentDB cluster",
+			resourceType: "aws_docdb_cluster",
+		},
+		{
+			name:         "Neptune cluster",
+			resourceType: "aws_neptune_cluster",
+		},
+		{
+			name:         "EC2 instance",
+			resourceType: "aws_instance",
+		},
+		{
+			name:         "random resource",
+			resourceType: "random_id",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tf := "resource \"" + tt.resourceType + "\" \"example\" {\n  deletion_protection = false\n}"
+			all := scanTerraform("main.tf", []byte(tf))
+			got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+			if len(got) != 0 {
+				t.Fatalf("want 0 findings, got %d: %+v", len(got), got)
+			}
+		})
+	}
+}
+
+func TestTerraformRDSDeletionProtectionMultipleResources(t *testing.T) {
+	tf := `resource "aws_db_instance" "missing" {
+  engine = "postgres"
+}
+resource "aws_db_instance" "disabled" {
+  deletion_protection = false
+}
+resource "aws_db_instance" "enabled" {
+  deletion_protection = true
+}
+resource "aws_db_instance" "dynamic" {
+  deletion_protection = var.enabled
+}`
+	all := scanTerraform("main.tf", []byte(tf))
+	got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+	if len(got) != 2 {
+		t.Fatalf("want 2 findings, got %d: %+v", len(got), got)
+	}
+	if got[0].Line != 1 {
+		t.Errorf("want start line 1, got %d", got[0].Line)
+	}
+	if got[1].Line != 4 {
+		t.Errorf("want start line 4, got %d", got[1].Line)
+	}
+}
+
+func TestTerraformRDSDeletionProtectionDeterministic(t *testing.T) {
+	tf := `resource "aws_db_instance" "missing" {
+  engine = "postgres"
+}
+resource "aws_db_instance" "disabled" {
+  deletion_protection = false
+}
+resource "aws_db_instance" "enabled" {
+  deletion_protection = true
+}
+resource "aws_ebs_volume" "v" {
+  size = 20
+}`
+	first := scanTerraform("main.tf", []byte(tf))
+	for i := 0; i < 20; i++ {
+		got := scanTerraform("main.tf", []byte(tf))
+		if len(first) != len(got) {
+			t.Fatalf("iteration %d: length mismatch %d != %d", i, len(first), len(got))
+		}
+		for j := range first {
+			if first[j] != got[j] {
+				t.Fatalf("iteration %d: finding %d mismatch: %+v != %+v", i, j, first[j], got[j])
+			}
+		}
+	}
+}
+
+func TestTerraformRDSDeletionProtectionOneFindingPerResource(t *testing.T) {
+	tf := `resource "aws_db_instance" "primary" {
+  deletion_protection = false
+}`
+	all := scanTerraform("main.tf", []byte(tf))
+	got := terraformFindingsByRule(all, "terraform-rds-deletion-protection-disabled")
+	if len(got) != 1 {
+		t.Fatalf("want 1 finding, got %d: %+v", len(got), got)
+	}
+}


### PR DESCRIPTION
Closes #150

## Summary

Add a focused Terraform misconfiguration rule for Amazon RDS DB instances that do not enable deletion protection.

The rule reports an `aws_db_instance` resource when its direct `deletion_protection` attribute is omitted or explicitly set to `false`.

Literal `true` values suppress the finding. Dynamic expressions are left unresolved to avoid speculative false positives.

## Rule

```text
Rule ID:  terraform-rds-deletion-protection-disabled
Title:    RDS deletion protection is not enabled
Severity: Low
Resource: Terraform aws_db_instance
```

## Changes

* Add the `terraform-rds-deletion-protection-disabled` rule.
* Apply the rule only to `aws_db_instance` resources.
* Detect an omitted direct `deletion_protection` attribute.
* Detect the literal value `deletion_protection = false`.
* Suppress the finding for literal `true`.
* Suppress the finding for variables, locals, data references, module outputs, conditional expressions, function calls, and other unresolved values.
* Match the exact direct resource attribute rather than using substring matching.
* Ignore similarly named attributes.
* Ignore attributes inside nested blocks.
* Ignore `#`, `//`, single-line block, and multiline block comments.
* Preserve comment delimiters that occur inside quoted strings.
* Emit exactly one finding per affected resource.
* Report the resource declaration line for both missing and explicit-false cases.
* Update existing insecure and hardened Terraform regression fixtures.
* Add focused positive, negative, metadata, nesting, comment, resource-scope, line-number, and determinism tests.
* Update the IaC misconfiguration changelog.

## Why this matters

Amazon RDS deletion protection adds an explicit safeguard against accidental or unauthorized deletion.

The Terraform AWS provider defaults `deletion_protection` to `false` when the argument is omitted. This rule identifies DB instances whose Terraform configuration does not enable that safeguard.

## Detection behavior

### Finding: attribute omitted

```hcl
resource "aws_db_instance" "primary" {
  engine         = "postgres"
  instance_class = "db.t3.micro"
}
```

### Finding: explicitly disabled

```hcl
resource "aws_db_instance" "primary" {
  deletion_protection = false
}
```

### No finding: explicitly enabled

```hcl
resource "aws_db_instance" "primary" {
  deletion_protection = true
}
```

### No speculative finding: dynamic value

```hcl
resource "aws_db_instance" "primary" {
  deletion_protection = var.enable_deletion_protection
}
```

The scanner does not attempt to evaluate the runtime value of Terraform expressions.

## False-positive controls

The rule:

* applies only to the exact `aws_db_instance` resource type;
* checks only the exact `deletion_protection` attribute;
* considers only direct resource attributes;
* ignores nested-block attributes;
* ignores similarly named attributes;
* removes supported line and block comments before attribute analysis;
* preserves comment-like text inside quoted strings;
* treats non-literal values as unknown;
* emits one block-level finding per affected resource.

Examples that do not suppress a missing-setting finding:

```hcl
# deletion_protection = true
```

```hcl
/*
deletion_protection = true
*/
```

```hcl
deletion_protection_backup = true
```

```hcl
timeouts {
  deletion_protection = true
}
```

## Finding location

Both missing and explicit-false findings use the resource declaration line:

```hcl
resource "aws_db_instance" "primary" {
```

This keeps block-level finding locations consistent.

## Non-goals

* No `aws_rds_cluster` support.
* No Aurora-specific handling.
* No DocumentDB or Neptune support.
* No CloudFormation support.
* No Terraform plan or state analysis.
* No Terraform variable or expression evaluation.
* No `lifecycle.prevent_destroy` analysis.
* No backup-retention or final-snapshot rules.
* No Terraform CLI execution.
* No AWS API calls.
* No changes to finding-domain types or scanner interfaces.
* No new external dependencies.

## Testing

```bash
go test \
  ./internal/infrastructure/tools/misconfig \
  -run 'TestTerraformRDSDeletionProtection' \
  -count=1 \
  -v

go test \
  ./internal/infrastructure/tools/misconfig \
  -run 'TestTerraform' \
  -count=1 \
  -v

go test \
  ./internal/infrastructure/tools/misconfig \
  -count=1

go test -race \
  ./internal/infrastructure/tools/misconfig \
  -count=1

go test ./... -count=1
go build ./...
go vet ./...
CGO_ENABLED=0 go build ./cmd/...
golangci-lint run

cd web
pnpm install --frozen-lockfile
pnpm run typecheck
pnpm build
```

## Test coverage

* missing `deletion_protection`;
* literal `false`;
* literal `true`;
* whitespace and assignment formatting variants;
* variables and locals;
* data references and module outputs;
* conditional and function expressions;
* interpolation expressions;
* hash and slash comments;
* single-line and multiline block comments;
* trailing block comments;
* comment delimiters inside quoted strings;
* similarly named attributes;
* nested attributes;
* direct attributes after nested blocks;
* direct false combined with nested true;
* exact resource-type isolation;
* multiple RDS resources;
* exact resource declaration line numbers;
* exact finding metadata;
* one finding per insecure resource;
* deterministic scanner output;
* existing insecure Terraform fixture;
* existing hardened Terraform fixture.

## Checklist

* [x] Issue linked with `Closes #150`
* [x] Rule applies only to `aws_db_instance`
* [x] Missing setting detected
* [x] Literal `false` detected
* [x] Literal `true` suppressed
* [x] Dynamic expressions suppressed
* [x] Exact direct attribute matching used
* [x] Similar attribute names ignored
* [x] Nested attributes ignored
* [x] Line comments handled
* [x] Single-line block comments handled
* [x] Multiline block comments handled
* [x] Quoted comment delimiters preserved
* [x] Exactly one finding emitted per resource
* [x] Resource declaration line preserved
* [x] Existing Terraform regression fixtures updated
* [x] Changelog updated
* [x] No Terraform CLI or AWS API calls
* [x] No new dependencies introduced
