### PR TITLE
feat(release): goreleaser pipeline, GHCR image, reusable scan action (#60, #61, #62)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+# Cutting a release is a single push of a semver tag:
+#   git tag v0.1.0 && git push origin v0.1.0
+# goreleaser then builds every binary, publishes a GitHub Release with archives + checksums, and pushes
+# a multi-arch synapse-cli image to GHCR.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # create the GitHub Release and upload assets
+  packages: write # push the container image to GHCR
+
+jobs:
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # goreleaser needs full history + tags to compute the version and changelog.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # QEMU + buildx enable the linux/arm64 image build alongside linux/amd64.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,33 +18,35 @@ jobs:
     name: goreleaser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      # This workflow holds contents:write + packages:write, so third-party actions are pinned to an
+      # immutable commit SHA (with the version tag in a comment). Dependabot bumps the SHA + comment.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           # goreleaser needs full history + tags to compute the version and changelog.
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
 
       # QEMU + buildx enable the linux/arm64 image build alongside linux/amd64.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
           args: release --clean

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ prompt.txt
 
 # Docs site (mkdocs build output)
 /site/
+
+# goreleaser build output
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,9 @@ builds:
     flags: &build_flags
       - -trimpath
     ldflags: &build_ldflags
-      - -s -w -X github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo.version={{ .Version }}
+      # .Tag keeps the leading "v" so the embedded version matches Go's vX.Y.Z convention (the
+      # `go install <module>@<version>` fallback and buildinfo.Module() both report v-prefixed).
+      - -s -w -X github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo.version={{ .Tag }}
     goos: &build_goos
       - linux
       - darwin
@@ -105,6 +107,10 @@ checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 
+# Follow-up hardening (separate PR, needs keyless-signing setup): a cosign `signs:` stanza over
+# checksums.txt plus SLSA provenance and an `sboms:` block, so consumers can verify artifact
+# authenticity rather than only integrity.
+
 # Multi-arch synapse-cli container image on GHCR, built with buildx from the prebuilt binaries (no
 # in-image Go build). The synapse-api image follows the same pattern and can be added when needed; the
 # compose stack already builds an API image from deploy/Dockerfile.
@@ -113,7 +119,7 @@ dockers_v2:
     images:
       - ghcr.io/kkloudtarus/synapse-cli
     tags:
-      - "{{ .Version }}"
+      - "{{ .Tag }}"
       - latest
     platforms:
       - linux/amd64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,155 @@
+# goreleaser configuration for Synapse CE.
+#
+# Cutting a release:
+#   git tag v0.1.0 && git push origin v0.1.0
+# The tag triggers .github/workflows/release.yml, which runs `goreleaser release --clean`:
+# cross-compiled binaries for every target, a checksums file, per-platform archives, a GitHub
+# Release, and a multi-arch synapse-cli container image on GHCR.
+#
+# Every command is pure Go and builds with CGO_ENABLED=0 (the sqlite driver is pure Go), so all five
+# cross-compile from a single Linux runner. `synapse-ast` (the tree-sitter sidecar) is intentionally
+# NOT released here: it needs cgo for full parsing and cannot cross-compile with CGO_ENABLED=0. It can
+# be added later with per-platform cgo toolchains.
+version: 2
+
+project_name: synapse-ce
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: synapse-cli
+    main: ./cmd/synapse-cli
+    binary: synapse-cli
+    env: &build_env
+      - CGO_ENABLED=0
+    flags: &build_flags
+      - -trimpath
+    ldflags: &build_ldflags
+      - -s -w -X github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo.version={{ .Version }}
+    goos: &build_goos
+      - linux
+      - darwin
+      - windows
+    goarch: &build_goarch
+      - amd64
+      - arm64
+    ignore: &build_ignore
+      # Windows/arm64 is not a supported target (keeps the matrix to the five documented builds).
+      - goos: windows
+        goarch: arm64
+
+  - id: synapse-api
+    main: ./cmd/synapse-api
+    binary: synapse-api
+    env: *build_env
+    flags: *build_flags
+    ldflags: *build_ldflags
+    goos: *build_goos
+    goarch: *build_goarch
+    ignore: *build_ignore
+
+  - id: synapse-worker
+    main: ./cmd/synapse-worker
+    binary: synapse-worker
+    env: *build_env
+    flags: *build_flags
+    ldflags: *build_ldflags
+    goos: *build_goos
+    goarch: *build_goarch
+    ignore: *build_ignore
+
+  - id: synapse-callgraph
+    main: ./cmd/synapse-callgraph
+    binary: synapse-callgraph
+    env: *build_env
+    flags: *build_flags
+    ldflags: *build_ldflags
+    goos: *build_goos
+    goarch: *build_goarch
+    ignore: *build_ignore
+
+  - id: synapse-mcp
+    main: ./cmd/synapse-mcp
+    binary: synapse-mcp
+    env: *build_env
+    flags: *build_flags
+    ldflags: *build_ldflags
+    goos: *build_goos
+    goarch: *build_goarch
+    ignore: *build_ignore
+
+archives:
+  # One archive per OS/arch bundling all five binaries (download once, get the whole suite).
+  - id: synapse
+    ids:
+      - synapse-cli
+      - synapse-api
+      - synapse-worker
+      - synapse-callgraph
+      - synapse-mcp
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+# Multi-arch synapse-cli container image on GHCR, built with buildx from the prebuilt binaries (no
+# in-image Go build). The synapse-api image follows the same pattern and can be added when needed; the
+# compose stack already builds an API image from deploy/Dockerfile.
+dockers_v2:
+  - id: synapse-cli
+    images:
+      - ghcr.io/kkloudtarus/synapse-cli
+    tags:
+      - "{{ .Version }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    dockerfile: Dockerfile.cli
+    labels:
+      org.opencontainers.image.title: synapse-cli
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.source: https://github.com/KKloudTarus/synapse-ce
+      org.opencontainers.image.licenses: Apache-2.0
+
+release:
+  github:
+    owner: KKloudTarus
+    name: synapse-ce
+  draft: false
+  prerelease: auto
+
+changelog:
+  # Release-notes changelog generated from git history (separate from the curated CHANGELOG.md).
+  sort: asc
+  use: github
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - Merge pull request
+      - Merge branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **Release engineering.** goreleaser config and a tag-triggered release workflow that publish prebuilt binaries for all five commands (linux, macOS, Windows; amd64 and arm64) with a checksums file, a multi-arch `synapse-cli` container image on GHCR, and a reusable GitHub Action (`uses: KKloudTarus/synapse-ce@v1`) for the CI scan gate.
 - **IaC misconfiguration scanning.** Added a Terraform rule for Amazon RDS DB instances without deletion protection.
 - **SCA.** Added Conan 2.x `config_requires` packages to OwnSBOM component output.
 - **SCA.** Added first-party OwnSBOM support for exact registry packages in Python `uv.lock` files.

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+#
+# Release image for synapse-cli. Built by goreleaser (.goreleaser.yaml `dockers`) from the prebuilt,
+# cross-compiled binary in the build context, so there is NO Go build here. Ships syft (required for any
+# scan) and grype (offline vulnerability DB) so a user can scan with zero host install:
+#
+#   docker run --rm -v "$PWD:/scan:ro" ghcr.io/kkloudtarus/synapse-cli scan /scan --fail-on high
+#
+# This targets the pure-Go SCA/SAST/secret/misconfig path. Sandboxed execution and JVM-from-source
+# resolution need a Linux host with bubblewrap and a JDK/Maven/Gradle, which a plain distroless image
+# does not provide (matching deploy/Dockerfile's `api` target).
+FROM anchore/syft:v1.45.1 AS syft
+FROM anchore/grype:v0.115.0 AS grype
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=syft /syft /usr/local/bin/syft
+COPY --from=grype /grype /usr/local/bin/grype
+# The cross-compiled synapse-cli for this image's platform, supplied by goreleaser at the context root.
+COPY synapse-cli /usr/local/bin/synapse-cli
+ENV SYNAPSE_SYFT_BIN=/usr/local/bin/syft \
+    SYNAPSE_GRYPE_BIN=/usr/local/bin/grype
+USER nonroot:nonroot
+WORKDIR /scan
+ENTRYPOINT ["/usr/local/bin/synapse-cli"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,34 @@ The lasting difference is what sits around the finding:
 - The hardened sandbox and live recon need a Linux host. Without them the API still runs
   (SCA, findings, reports); sandboxed execution fails closed rather than running unsandboxed.
 
+### Install a released build
+
+Grab a prebuilt binary from the [Releases page](https://github.com/KKloudTarus/synapse-ce/releases)
+(linux, macOS and Windows; amd64 and arm64) and verify it against `checksums.txt`. Each archive bundles
+all five commands.
+
+```bash
+# Example: linux/amd64
+curl -fsSL -o synapse.tar.gz \
+  https://github.com/KKloudTarus/synapse-ce/releases/latest/download/synapse-ce_<version>_linux_amd64.tar.gz
+tar -xzf synapse.tar.gz synapse-cli
+./synapse-cli scan ./path/to/project --fail-on high
+```
+
+Or scan with zero install using the container image (bundles `synapse-cli` plus syft and grype):
+
+```bash
+docker run --rm -v "$PWD:/scan:ro" ghcr.io/kkloudtarus/synapse-cli scan /scan --fail-on high
+```
+
+Gate a repository in CI with the reusable action (see [`docs/guide/cli.md`](docs/guide/cli.md#github-action)):
+
+```yaml
+- uses: KKloudTarus/synapse-ce@v1
+  with:
+    fail-on: high
+```
+
 ### Run the full stack with Docker
 
 ```bash

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,12 @@ runs:
             | grep -m1 '"tag_name"' | cut -d '"' -f4)"
         fi
         # Only a strict vX.Y.Z[-suffix] tag is allowed, so a crafted `version` input cannot walk the
-        # download path to an arbitrary artifact.
+        # download path to an arbitrary artifact. The case guard rejects any stray character over the
+        # WHOLE value (empty, newline, slash) that a line-oriented grep would miss; the regex fixes shape.
+        case "${tag}" in
+          ""|*[!A-Za-z0-9.+-]*)
+            echo "::error::invalid release tag '${tag}' (input version='${SYNAPSE_VERSION}')" >&2; exit 1 ;;
+        esac
         if ! printf '%s' "${tag}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.+-][0-9A-Za-z.-]+)?$'; then
           echo "::error::refusing non-semver release tag '${tag}' (input version='${SYNAPSE_VERSION}')" >&2
           exit 1
@@ -89,7 +94,7 @@ runs:
         # Download the archive AND the release checksums, then verify BEFORE extracting/executing.
         curl -fsSL -o "${BIN_DIR}/${asset}" "${base}/${asset}"
         curl -fsSL -o "${BIN_DIR}/checksums.txt" "${base}/checksums.txt"
-        want="$(grep " ${asset}\$" "${BIN_DIR}/checksums.txt" | awk '{print $1}')"
+        want="$(awk -v f="${asset}" '$2 == f {print $1}' "${BIN_DIR}/checksums.txt")"
         if [ -z "${want}" ]; then
           echo "::error::no checksum for ${asset} in checksums.txt" >&2; exit 1
         fi

--- a/action.yml
+++ b/action.yml
@@ -41,9 +41,11 @@ runs:
   steps:
     - name: Install synapse-cli, syft and grype
       shell: bash
+      # No GITHUB_TOKEN is exposed here on purpose: the release lookup hits a PUBLIC endpoint, and
+      # keeping the token out of this step means the `curl | sh` tool installers below cannot exfiltrate
+      # it. Pin `version` to a tag to skip the unauthenticated API call entirely.
       env:
         SYNAPSE_VERSION: ${{ inputs.version }}
-        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
 
@@ -54,15 +56,16 @@ runs:
         BIN_DIR="${RUNNER_TEMP}/synapse-bin"
         mkdir -p "${BIN_DIR}"
 
-        # Resolve the release tag (accept "latest" or an explicit vX.Y.Z).
+        # Resolve the release tag (accept "latest" or an explicit vX.Y.Z). Public repo → no auth needed.
         tag="${SYNAPSE_VERSION}"
         if [ "${tag}" = "latest" ] || [ -z "${tag}" ]; then
-          tag="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-            "https://api.github.com/repos/${REPO}/releases/latest" \
+          tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
             | grep -m1 '"tag_name"' | cut -d '"' -f4)"
         fi
-        if [ -z "${tag}" ]; then
-          echo "::error::could not resolve a synapse-cli release (input version='${SYNAPSE_VERSION}')" >&2
+        # Only a strict vX.Y.Z[-suffix] tag is allowed, so a crafted `version` input cannot walk the
+        # download path to an arbitrary artifact.
+        if ! printf '%s' "${tag}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.+-][0-9A-Za-z.-]+)?$'; then
+          echo "::error::refusing non-semver release tag '${tag}' (input version='${SYNAPSE_VERSION}')" >&2
           exit 1
         fi
         ver="${tag#v}" # goreleaser archive names drop the leading 'v'
@@ -81,20 +84,36 @@ runs:
         esac
         ext="tar.gz"; [ "${os}" = "windows" ] && ext="zip"
         asset="synapse-ce_${ver}_${os}_${arch}.${ext}"
-        url="https://github.com/${REPO}/releases/download/${tag}/${asset}"
+        base="https://github.com/${REPO}/releases/download/${tag}"
 
-        echo "Downloading ${url}"
-        curl -fsSL -o "${BIN_DIR}/${asset}" "${url}"
+        # Download the archive AND the release checksums, then verify BEFORE extracting/executing.
+        curl -fsSL -o "${BIN_DIR}/${asset}" "${base}/${asset}"
+        curl -fsSL -o "${BIN_DIR}/checksums.txt" "${base}/checksums.txt"
+        want="$(grep " ${asset}\$" "${BIN_DIR}/checksums.txt" | awk '{print $1}')"
+        if [ -z "${want}" ]; then
+          echo "::error::no checksum for ${asset} in checksums.txt" >&2; exit 1
+        fi
+        if command -v sha256sum >/dev/null 2>&1; then
+          got="$(sha256sum "${BIN_DIR}/${asset}" | awk '{print $1}')"
+        else
+          got="$(shasum -a 256 "${BIN_DIR}/${asset}" | awk '{print $1}')" # macOS runners
+        fi
+        if [ "${want}" != "${got}" ]; then
+          echo "::error::checksum mismatch for ${asset} (want ${want}, got ${got})" >&2; exit 1
+        fi
+
         if [ "${ext}" = "zip" ]; then
-          unzip -o "${BIN_DIR}/${asset}" -d "${BIN_DIR}" synapse-cli synapse-cli.exe 2>/dev/null || unzip -o "${BIN_DIR}/${asset}" -d "${BIN_DIR}"
+          unzip -o "${BIN_DIR}/${asset}" -d "${BIN_DIR}" >/dev/null
         else
           tar -xzf "${BIN_DIR}/${asset}" -C "${BIN_DIR}" synapse-cli
         fi
         chmod +x "${BIN_DIR}/synapse-cli" 2>/dev/null || true
 
-        # syft (required) + grype (offline DB) via anchore's official, checksum-verifying installers.
-        curl -fsSL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "${BIN_DIR}" "${SYFT_VERSION}"
-        curl -fsSL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b "${BIN_DIR}" "${GRYPE_VERSION}"
+        # syft (required) + grype (offline DB) via anchore's installers, PINNED to the tool version tag
+        # (not the moving main branch) so the installer script itself is fixed. The installers
+        # checksum-verify the tool binaries they fetch.
+        curl -fsSL "https://raw.githubusercontent.com/anchore/syft/${SYFT_VERSION}/install.sh" | sh -s -- -b "${BIN_DIR}" "${SYFT_VERSION}"
+        curl -fsSL "https://raw.githubusercontent.com/anchore/grype/${GRYPE_VERSION}/install.sh" | sh -s -- -b "${BIN_DIR}" "${GRYPE_VERSION}"
 
         echo "${BIN_DIR}" >> "${GITHUB_PATH}"
         echo "SYNAPSE_SYFT_BIN=${BIN_DIR}/syft" >> "${GITHUB_ENV}"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,128 @@
+name: "Synapse SCA scan"
+description: "Run a Synapse SCA + SAST + secret + IaC-misconfig scan and gate CI on findings."
+author: "KKloudTarus"
+branding:
+  icon: "shield"
+  color: "purple"
+
+inputs:
+  path:
+    description: "Path to scan."
+    required: false
+    default: "."
+  fail-on:
+    description: "Minimum severity that fails the build: critical | high | medium | low | info | none."
+    required: false
+    default: "high"
+  sarif:
+    description: "When true, write a SARIF 2.1.0 report and expose its path as the `sarif-file` output."
+    required: false
+    default: "false"
+  offline:
+    description: "When true, run without network egress (offline databases only)."
+    required: false
+    default: "false"
+  version:
+    description: 'synapse-cli release to use, e.g. "v0.1.0", or "latest".'
+    required: false
+    default: "latest"
+  sarif-output:
+    description: "Path for the SARIF report when `sarif` is true."
+    required: false
+    default: "synapse.sarif"
+
+outputs:
+  sarif-file:
+    description: "Path to the generated SARIF report (only when `sarif` is true)."
+    value: ${{ steps.scan.outputs.sarif-file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install synapse-cli, syft and grype
+      shell: bash
+      env:
+        SYNAPSE_VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        # Pinned scanner tool versions (kept in step with the release container image).
+        SYFT_VERSION="v1.45.1"
+        GRYPE_VERSION="v0.115.0"
+        REPO="KKloudTarus/synapse-ce"
+        BIN_DIR="${RUNNER_TEMP}/synapse-bin"
+        mkdir -p "${BIN_DIR}"
+
+        # Resolve the release tag (accept "latest" or an explicit vX.Y.Z).
+        tag="${SYNAPSE_VERSION}"
+        if [ "${tag}" = "latest" ] || [ -z "${tag}" ]; then
+          tag="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://api.github.com/repos/${REPO}/releases/latest" \
+            | grep -m1 '"tag_name"' | cut -d '"' -f4)"
+        fi
+        if [ -z "${tag}" ]; then
+          echo "::error::could not resolve a synapse-cli release (input version='${SYNAPSE_VERSION}')" >&2
+          exit 1
+        fi
+        ver="${tag#v}" # goreleaser archive names drop the leading 'v'
+
+        # Map the runner to goreleaser's OS/arch archive naming.
+        case "${RUNNER_OS}" in
+          Linux) os="linux" ;;
+          macOS) os="darwin" ;;
+          Windows) os="windows" ;;
+          *) echo "::error::unsupported runner OS ${RUNNER_OS}" >&2; exit 1 ;;
+        esac
+        case "${RUNNER_ARCH}" in
+          X64) arch="amd64" ;;
+          ARM64) arch="arm64" ;;
+          *) echo "::error::unsupported runner arch ${RUNNER_ARCH}" >&2; exit 1 ;;
+        esac
+        ext="tar.gz"; [ "${os}" = "windows" ] && ext="zip"
+        asset="synapse-ce_${ver}_${os}_${arch}.${ext}"
+        url="https://github.com/${REPO}/releases/download/${tag}/${asset}"
+
+        echo "Downloading ${url}"
+        curl -fsSL -o "${BIN_DIR}/${asset}" "${url}"
+        if [ "${ext}" = "zip" ]; then
+          unzip -o "${BIN_DIR}/${asset}" -d "${BIN_DIR}" synapse-cli synapse-cli.exe 2>/dev/null || unzip -o "${BIN_DIR}/${asset}" -d "${BIN_DIR}"
+        else
+          tar -xzf "${BIN_DIR}/${asset}" -C "${BIN_DIR}" synapse-cli
+        fi
+        chmod +x "${BIN_DIR}/synapse-cli" 2>/dev/null || true
+
+        # syft (required) + grype (offline DB) via anchore's official, checksum-verifying installers.
+        curl -fsSL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "${BIN_DIR}" "${SYFT_VERSION}"
+        curl -fsSL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b "${BIN_DIR}" "${GRYPE_VERSION}"
+
+        echo "${BIN_DIR}" >> "${GITHUB_PATH}"
+        echo "SYNAPSE_SYFT_BIN=${BIN_DIR}/syft" >> "${GITHUB_ENV}"
+        echo "SYNAPSE_GRYPE_BIN=${BIN_DIR}/grype" >> "${GITHUB_ENV}"
+
+    - name: Run scan
+      id: scan
+      shell: bash
+      env:
+        SYNAPSE_PATH: ${{ inputs.path }}
+        SYNAPSE_FAIL_ON: ${{ inputs.fail-on }}
+        SYNAPSE_SARIF: ${{ inputs.sarif }}
+        SYNAPSE_OFFLINE: ${{ inputs.offline }}
+        SYNAPSE_SARIF_OUT: ${{ inputs.sarif-output }}
+      run: |
+        # Not `-e`: the scan's non-zero exit IS the gate result, propagated deliberately at the end so
+        # the SARIF output is still recorded when the gate fails (an `if: always()` upload keeps working).
+        set -uo pipefail
+        args=(scan "${SYNAPSE_PATH}" --fail-on "${SYNAPSE_FAIL_ON}")
+        if [ "${SYNAPSE_OFFLINE}" = "true" ]; then
+          args+=(--offline)
+        fi
+        rc=0
+        if [ "${SYNAPSE_SARIF}" = "true" ]; then
+          # --sarif writes the SARIF report to stdout; capture it to the requested file.
+          synapse-cli "${args[@]}" --sarif > "${SYNAPSE_SARIF_OUT}" || rc=$?
+          echo "sarif-file=${SYNAPSE_SARIF_OUT}" >> "${GITHUB_OUTPUT}"
+        else
+          synapse-cli "${args[@]}" || rc=$?
+        fi
+        exit "${rc}"

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -41,6 +41,23 @@ synapse-cli scan alpine:3.19 --image --offline
 The exit code is 0 when no finding meets the `--fail-on` threshold, and non-zero otherwise.
 Wire it straight into a pipeline step.
 
+## Container image (Docker)
+
+Every release publishes a multi-arch `synapse-cli` image to GHCR that bundles syft and grype, so you can
+scan with nothing installed but Docker:
+
+```bash
+# scan the current directory (mounted read-only), fail on high-or-critical
+docker run --rm -v "$PWD:/scan:ro" ghcr.io/kkloudtarus/synapse-cli scan /scan --fail-on high
+
+# pin a version instead of latest
+docker run --rm -v "$PWD:/scan:ro" ghcr.io/kkloudtarus/synapse-cli:v0.1.0 scan /scan
+```
+
+The image targets the pure-Go scan path (SBOM, OSV/Grype vulnerabilities, licenses, SAST, secrets, IaC
+misconfig). Sandboxed execution and JVM-from-source resolution need a Linux host with bubblewrap and a
+JDK/Maven/Gradle, so run those on a host install or the batteries-included compose image.
+
 ## Advisory sync (optional owned store)
 
 For detection independence you can maintain an owned advisory store and ingest feeds into it.
@@ -66,9 +83,40 @@ synapse-cli sync-advisories --oval <dir>
 Enable the store at scan time with `SYNAPSE_OWNED_ADVISORY=true`, then it runs alongside the
 live and offline sources.
 
-## GitHub Actions
+## GitHub Action
 
-Gate a build on findings:
+The reusable action installs the released `synapse-cli` (plus syft and grype) and runs the gate, so a
+whole scan step is three lines:
+
+```yaml
+- uses: KKloudTarus/synapse-ce@v1
+  with:
+    fail-on: high        # critical | high | medium | low | info | none (default: high)
+    path: .              # what to scan (default: .)
+    version: latest      # a released tag like v0.1.0, or latest (default)
+```
+
+Emit SARIF and upload it to the Security tab, while still failing the build on high findings:
+
+```yaml
+- id: synapse
+  uses: KKloudTarus/synapse-ce@v1
+  with:
+    fail-on: high
+    sarif: true
+  continue-on-error: true          # let the upload run even when the gate fails
+- name: Upload SARIF
+  if: always()
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: ${{ steps.synapse.outputs.sarif-file }}
+```
+
+Set `offline: true` to run against the bundled offline databases only (no network egress).
+
+### From source
+
+Without the action you can install the tools and build the CLI yourself:
 
 ```yaml
 - name: SCA scan

--- a/internal/platform/buildinfo/buildinfo.go
+++ b/internal/platform/buildinfo/buildinfo.go
@@ -25,8 +25,21 @@ func Module(path string) string {
 	return "unknown"
 }
 
-// App returns the main module's version ("devel" for an untagged build, e.g. go run).
+// version is injected at release-build time via
+//
+//	-ldflags "-X github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo.version=vX.Y.Z"
+//
+// (goreleaser sets it from the git tag). It is empty for `go run`, `go build`, and plain
+// `go install`, which fall back to the compiled build metadata read below.
+var version string
+
+// App returns the main module's version. A release build injects the tag via ldflags (see version);
+// otherwise it reads the compiled build metadata — "devel" for an untagged `go run` / `go build`, or the
+// tag/pseudo-version for `go install <module>@<version>`.
 func App() string {
+	if version != "" {
+		return version
+	}
 	bi, ok := debug.ReadBuildInfo()
 	if !ok || bi.Main.Version == "" || bi.Main.Version == "(devel)" {
 		return "devel"

--- a/internal/platform/buildinfo/buildinfo_test.go
+++ b/internal/platform/buildinfo/buildinfo_test.go
@@ -1,0 +1,28 @@
+package buildinfo
+
+import "testing"
+
+// A release build injects the tag into the package-level version via ldflags; App must prefer it over
+// the compiled build metadata so a released binary reports its real version (recorded for scan
+// reproducibility) rather than "devel".
+func TestAppPrefersInjectedVersion(t *testing.T) {
+	orig := version
+	t.Cleanup(func() { version = orig })
+
+	version = "v1.2.3"
+	if got := App(); got != "v1.2.3" {
+		t.Errorf("App() = %q, want the injected v1.2.3", got)
+	}
+}
+
+// With no injected version (go run / go build / go test), App falls back to build metadata and must
+// never return an empty string.
+func TestAppFallsBackWithoutInjectedVersion(t *testing.T) {
+	orig := version
+	t.Cleanup(func() { version = orig })
+
+	version = ""
+	if got := App(); got == "" {
+		t.Error("App() returned empty; want a non-empty fallback (e.g. \"devel\")")
+	}
+}


### PR DESCRIPTION
## Summary

Release engineering for the #59 epic. This turns `git tag v0.1.0 && git push --tags` into a full release: prebuilt binaries, a container image, and a reusable CI action. Closes #60, #61, #62.

## What is included

**#60 — goreleaser + tagged releases**
- `.goreleaser.yaml` builds all five commands (`synapse-cli`, `synapse-api`, `synapse-worker`, `synapse-callgraph`, `synapse-mcp`) for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64` with `CGO_ENABLED=0` (pure Go, so it cross-compiles from one runner). One archive per OS/arch bundles all five, plus `checksums.txt`.
- `.github/workflows/release.yml` runs `goreleaser release --clean` on `v*` tags.
- `synapse-ast` is intentionally excluded: the tree-sitter sidecar needs cgo and cannot cross-compile with `CGO_ENABLED=0`. It can be added later with per-platform cgo toolchains.

**#61 — GHCR container image**
- `Dockerfile.cli` (distroless, built from the prebuilt binary, bundling pinned syft + grype).
- goreleaser `dockers_v2` publishes a multi-arch (amd64 + arm64) `ghcr.io/kkloudtarus/synapse-cli` image tagged with the version and `latest`.
- The `synapse-api` image follows the same pattern and can be added when needed; the compose stack already builds an API image from `deploy/Dockerfile`.

**#62 — reusable GitHub Action**
- Composite `action.yml` with inputs `path`, `fail-on`, `sarif`, `offline`, `version`. It downloads the released `synapse-cli` (plus syft and grype), runs the gate, and exposes a `sarif-file` output that is set even when the gate fails (so an `if: always()` SARIF upload keeps working).

**Supporting**
- `buildinfo`: an ldflags-settable `version` override so a released binary reports its tag in `scan` `tool_versions` instead of `devel` (falls back to build metadata for `go run` / `go install`). Unit-tested.
- `README.md` + `docs/guide/cli.md`: install-a-release, `docker run`, and Action usage. `dist/` added to `.gitignore`.

## Validation

- `goreleaser check`: config valid, no deprecations (uses `dockers_v2`).
- `goreleaser build --snapshot`: produced all **25** binaries (5 commands × 5 targets); `windows/arm64` correctly excluded.
- Manual `CGO_ENABLED=0` cross-compile of all five targets: OK.
- Version stamp verified at runtime (`scan` reported the injected `v0.9.9-verify`).
- `Dockerfile.cli` builds (linux/amd64) and `docker run … --help` runs.
- `action.yml` / `release.yml` YAML valid; the action's shell steps pass `bash -n`.
- `go build/vet/test ./...` green.

## Notes for the maintainer

- The release workflow is dormant until a `v*` tag is pushed. Nothing here publishes anything on merge.
- The first real release cuts with `git tag v0.1.0 && git push origin v0.1.0`. The action's end-to-end test (per #62) needs that first release to exist before `uses: KKloudTarus/synapse-ce@v1` resolves — pin `@v0.1.0` until a floating `v1` tag is created.
- GHCR push uses the workflow's `GITHUB_TOKEN` with `packages: write`; the package will need to be linked to the repo / made public in org settings after the first push.
