### PR TITLE
feat(scan): run AI false-positive triage in the scan pipeline — CLI + API (#158)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/report"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sandbox"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/signing"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourcesnippet"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/timestamp"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/toolrunner"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/bincat"
@@ -98,6 +100,7 @@ import (
 	exploitationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
 	exportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/export"
 	findingsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findings"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fptriage"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachability"
@@ -606,6 +609,30 @@ func main() {
 		}
 		scaService.SetMisconfigScanner(mc) // deterministic IaC/config misconfig scan in the scan pipeline
 		log.Info("misconfig scanning ENABLED (Dockerfile + Kubernetes + Terraform); " + helmMode)
+	}
+	// AI false-positive triage in the scan pipeline (opt-in, best-effort, PROPOSE-ONLY). Independent of
+	// the agent: it critiques production-scope source findings and marks suspected FPs retain-and-mark
+	// (held back from the gate via ScanResult.SuspectedFPKeys, still reported + sealed). A distinct
+	// SYNAPSE_VERIFIER_MODEL enables two-model consensus.
+	if cfg.FPTriageEnabled && strings.TrimSpace(cfg.FPTriageModel) != "" {
+		if tllm, terr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.FPTriageModel, cfg.LLMTimeout); terr != nil {
+			log.Warn("AI false-positive triage DISABLED (LLM unavailable)", "err", terr)
+		} else {
+			coord := fptriage.New(tllm, cfg.FPTriageModel)
+			mode := "single-model"
+			if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
+				if vllm, verr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.VerifierModel, cfg.LLMTimeout); verr == nil {
+					coord.WithVerifier(vllm, cfg.VerifierModel)
+					mode = "verified by " + cfg.VerifierModel
+				} else {
+					log.Warn("AI FP-triage verifier unavailable, single-model", "err", verr)
+				}
+			}
+			scaService.SetFPTriage(fptriage.NewTriager(coord, func(root string) ports.SourceSnippetReader {
+				return sourcesnippet.Reader{Root: root}
+			}))
+			log.Info("AI false-positive triage ENABLED ("+mode+"); suspected FPs held back from the gate, still reported", "model", cfg.FPTriageModel)
+		}
 	}
 	if cfg.SuppressionEnabled {
 		scaService.SetSuppressionLoader(ignorefile.New()) // repo-committed .synapseignore accepted-risk policy

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -30,6 +29,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/llm/openai"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourcesnippet"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/ast"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/bincat"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/codeanalysis"
@@ -1105,6 +1105,28 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	// classic distro-noise reducer for OS-package scans (matches Trivy's --ignore-unfixed).
 	sca.SetIgnoreUnfixed(ignoreUnfixed || cfg.IgnoreUnfixed)
 
+	// AI false-positive triage (opt-in). Inject an LLM critic the scan pipeline runs over the remaining
+	// production-scope first-party source findings; a "refuted" verdict marks the finding suspected-FP
+	// (retain-and-mark, held back from the gate below), never a deletion. Propose-only + best-effort. A
+	// distinct SYNAPSE_VERIFIER_MODEL enables two-model consensus. Skipped for image targets (no source).
+	if cfg.FPTriageEnabled && strings.TrimSpace(cfg.FPTriageModel) != "" && !image {
+		if llm, lerr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.FPTriageModel, cfg.LLMTimeout); lerr != nil {
+			fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage disabled: %v\n", lerr)
+		} else {
+			coord := fptriage.New(llm, cfg.FPTriageModel)
+			if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
+				if vllm, verr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.VerifierModel, cfg.LLMTimeout); verr == nil {
+					coord.WithVerifier(vllm, cfg.VerifierModel)
+				} else {
+					fmt.Fprintf(os.Stderr, "synapse-cli: verifier model %q unavailable, falling back to single-model triage: %v\n", cfg.VerifierModel, verr)
+				}
+			}
+			sca.SetFPTriage(fptriage.NewTriager(coord, func(root string) ports.SourceSnippetReader {
+				return sourcesnippet.Reader{Root: root}
+			}))
+		}
+	}
+
 	// Ephemeral engagement covering the target so the real (gated) Scan path runs.
 	eng, err := engagement.New(ids.NewID(), "", "synapse-cli dogfood", "", clock.Now())
 	if err != nil {
@@ -1124,49 +1146,15 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		return fmt.Errorf("scan: %w", err)
 	}
 
-	// AI false-positive gate (opt-in, best-effort). After the deterministic scope pass, ask the
-	// configured LLM to adjudicate the remaining PRODUCTION-scope first-party source findings. The model
-	// is a proposer only: a "refuted" verdict at/above the confidence bar marks the finding suspected-FP
-	// (retain-and-mark — still reported + sealed, only held back from the gate), never a deletion. Skipped
-	// for image targets (no local source tree) and when no LLM model is configured; any error is non-fatal.
-	fpSuspect := map[string]bool{}
-	if cfg.FPTriageEnabled && strings.TrimSpace(cfg.FPTriageModel) != "" && !image {
-		if llm, lerr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.FPTriageModel, cfg.LLMTimeout); lerr != nil {
-			fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage disabled: %v\n", lerr)
-		} else if cands := fpTriageCandidates(res.Findings); len(cands) > 0 {
-			coord := fptriage.New(llm, cfg.FPTriageModel)
-			// Distinct-verifier consensus: when SYNAPSE_VERIFIER_MODEL names a DIFFERENT model, a
-			// refutation must be independently confirmed by it before it exempts the gate (two-model
-			// agreement — the CLI analogue of the judgment gate's distinct verifier).
-			if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
-				if vllm, verr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.VerifierModel, cfg.LLMTimeout); verr == nil {
-					coord.WithVerifier(vllm, cfg.VerifierModel)
-				} else {
-					fmt.Fprintf(os.Stderr, "synapse-cli: verifier model %q unavailable, falling back to single-model triage: %v\n", cfg.VerifierModel, verr)
-				}
-			}
-			tctx, cancel := context.WithTimeout(ctx, 20*time.Minute)
-			crits := coord.Assess(tctx, cands, fileSnippetReader{root: target})
-			cancel()
-			res.AITriage, fpSuspect = summarizeCritiques(crits, coord.MinConfidence())
-			nErr, sample := 0, ""
-			for _, c := range crits {
-				if c.Err != nil {
-					nErr++
-					if sample == "" {
-						sample = c.Err.Error()
-					}
-				}
-			}
-			mode := "single-model"
-			if coord.VerifierModel() != "" {
-				mode = "verified by " + coord.VerifierModel()
-			}
-			fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage (%s, %s): assessed %d, critiqued %d, unassessed %d, %d suspected false positive(s) held back from the gate\n", cfg.FPTriageModel, mode, len(cands), len(res.AITriage), nErr, len(fpSuspect))
-			if nErr > 0 {
-				fmt.Fprintf(os.Stderr, "synapse-cli: %d finding(s) could not be assessed (left to gate normally); first: %s\n", nErr, sample)
-			}
+	// The scan pipeline ran the AI false-positive triage (if injected above); report the outcome. A
+	// suspected-FP is held back from the --fail-on gate (retain-and-mark), still reported in ai_triage.
+	fpSuspect := res.SuspectedFPKeys()
+	if len(res.AITriage) > 0 {
+		mode := "single-model"
+		if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
+			mode = "verified by " + cfg.VerifierModel
 		}
+		fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage (%s, %s): critiqued %d finding(s), %d suspected false positive(s) held back from the gate\n", cfg.FPTriageModel, mode, len(res.AITriage), len(fpSuspect))
 	}
 
 	switch {
@@ -1260,91 +1248,6 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		return fmt.Errorf("%d finding(s) at or above %s", over, failOn)
 	}
 	return nil
-}
-
-// fpTriageCandidates selects the findings worth an LLM critique: production-scope, first-party source
-// analysis (SAST/secret/misconfig). Background-scope findings are already gate-exempt deterministically,
-// and SCA/advisory findings are DB-backed facts, so neither is critiqued.
-func fpTriageCandidates(fs []finding.Finding) []finding.Finding {
-	out := make([]finding.Finding, 0, len(fs))
-	for _, f := range fs {
-		if sbom.IsBackgroundScope(f.Scope) {
-			continue
-		}
-		switch f.Kind {
-		case finding.KindSAST, finding.KindSecret, finding.KindMisconfig:
-			out = append(out, f)
-		}
-	}
-	return out
-}
-
-// summarizeCritiques turns the coordinator's per-finding critiques into the ScanResult DTO slice and a
-// set of DedupKeys the gate should exempt (suspected false positives). A best-effort failure (Err set)
-// is skipped, so an unassessed finding is left to gate normally.
-func summarizeCritiques(crits []fptriage.Critique, minConf int) ([]scauc.AICritique, map[string]bool) {
-	suspect := map[string]bool{}
-	out := make([]scauc.AICritique, 0, len(crits))
-	for _, c := range crits {
-		if c.Err != nil {
-			continue
-		}
-		fp := c.SuspectedFP(minConf)
-		out = append(out, scauc.AICritique{
-			FindingID:   c.FindingID,
-			DedupKey:    c.DedupKey,
-			Verdict:     string(c.Claim.Verdict),
-			Driver:      c.Claim.Driver,
-			Confidence:  c.Claim.Confidence,
-			SuspectedFP: fp,
-			Verified:    fp && c.VerifyAttempted, // a suspected-FP that a DISTINCT verifier confirmed
-		})
-		if fp {
-			suspect[c.DedupKey] = true
-		}
-	}
-	return out, suspect
-}
-
-// fileSnippetReader reads a bounded source excerpt from the scanned (trusted-local) workspace so the
-// critique model sees the actual code, not just the finding metadata.
-type fileSnippetReader struct{ root string }
-
-func (r fileSnippetReader) Snippet(file string, line, radius int) (string, error) {
-	p := filepath.Join(r.root, filepath.FromSlash(file))
-	// Defense-in-depth: keep the read inside the scanned root (the path is our own finding's). Resolve
-	// symlinks on both sides so a link inside the root can't point outside, and match the boundary
-	// precisely so a legitimate name like "..gitkeep" is not rejected.
-	root, err := filepath.EvalSymlinks(r.root)
-	if err != nil {
-		root = r.root
-	}
-	rp, err := filepath.EvalSymlinks(p)
-	if err != nil {
-		return "", err // missing/broken file → the coordinator critiques on metadata only
-	}
-	rel, err := filepath.Rel(root, rp)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return "", fmt.Errorf("snippet path escapes scan root")
-	}
-	data, err := os.ReadFile(rp)
-	if err != nil {
-		return "", err
-	}
-	lines := strings.Split(string(data), "\n")
-	lo := line - radius
-	if lo < 1 {
-		lo = 1
-	}
-	hi := line + radius
-	if hi > len(lines) {
-		hi = len(lines)
-	}
-	var b strings.Builder
-	for i := lo; i <= hi; i++ {
-		fmt.Fprintf(&b, "%d: %s\n", i, lines[i-1])
-	}
-	return b.String(), nil
 }
 
 func printReport(target string, res *scauc.ScanResult) {

--- a/internal/infrastructure/sourcesnippet/reader.go
+++ b/internal/infrastructure/sourcesnippet/reader.go
@@ -1,0 +1,55 @@
+// Package sourcesnippet reads a bounded source excerpt from a scanned workspace for the AI false-positive
+// triage. It is the concrete ports.SourceSnippetReader; the fs read lives here (infrastructure), never in
+// the usecase layer.
+package sourcesnippet
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Reader reads snippets from files under Root (the Synapse-controlled scanned tree).
+type Reader struct{ Root string }
+
+var _ ports.SourceSnippetReader = Reader{}
+
+// Snippet returns the [line-radius, line+radius] window of the file (1-based), each line prefixed with its
+// number. Symlinks are resolved and the read is contained inside Root (defense-in-depth: the path is our
+// own finding's, but a link inside the tree must not point outside).
+func (r Reader) Snippet(file string, line, radius int) (string, error) {
+	p := filepath.Join(r.Root, filepath.FromSlash(file))
+	root, err := filepath.EvalSymlinks(r.Root)
+	if err != nil {
+		root = r.Root
+	}
+	rp, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return "", err // missing/broken file → the coordinator critiques on metadata only
+	}
+	rel, err := filepath.Rel(root, rp)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("snippet path escapes scan root")
+	}
+	data, err := os.ReadFile(rp)
+	if err != nil {
+		return "", err
+	}
+	lines := strings.Split(string(data), "\n")
+	lo := line - radius
+	if lo < 1 {
+		lo = 1
+	}
+	hi := line + radius
+	if hi > len(lines) {
+		hi = len(lines)
+	}
+	var b strings.Builder
+	for i := lo; i <= hi; i++ {
+		fmt.Fprintf(&b, "%d: %s\n", i, lines[i-1])
+	}
+	return b.String(), nil
+}

--- a/internal/infrastructure/sourcesnippet/reader.go
+++ b/internal/infrastructure/sourcesnippet/reader.go
@@ -4,13 +4,19 @@
 package sourcesnippet
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+// maxSnippetFileBytes bounds how much of a source file is read for a snippet. A source file a scanner
+// already parsed is small, so this is defense-in-depth against a pathological/huge file, not a real limit.
+const maxSnippetFileBytes = 8 << 20 // 8 MiB
 
 // Reader reads snippets from files under Root (the Synapse-controlled scanned tree).
 type Reader struct{ Root string }
@@ -19,8 +25,12 @@ var _ ports.SourceSnippetReader = Reader{}
 
 // Snippet returns the [line-radius, line+radius] window of the file (1-based), each line prefixed with its
 // number. Symlinks are resolved and the read is contained inside Root (defense-in-depth: the path is our
-// own finding's, but a link inside the tree must not point outside).
-func (r Reader) Snippet(file string, line, radius int) (string, error) {
+// own finding's, but a link inside the tree must not point outside), the read is size-capped, and ctx is
+// honored.
+func (r Reader) Snippet(ctx context.Context, file string, line, radius int) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	p := filepath.Join(r.Root, filepath.FromSlash(file))
 	root, err := filepath.EvalSymlinks(r.Root)
 	if err != nil {
@@ -34,7 +44,12 @@ func (r Reader) Snippet(file string, line, radius int) (string, error) {
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return "", fmt.Errorf("snippet path escapes scan root")
 	}
-	data, err := os.ReadFile(rp)
+	f, err := os.Open(rp)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxSnippetFileBytes))
 	if err != nil {
 		return "", err
 	}

--- a/internal/usecase/fptriage/coordinator.go
+++ b/internal/usecase/fptriage/coordinator.go
@@ -132,6 +132,17 @@ func (c *Coordinator) Assess(ctx context.Context, candidates []finding.Finding, 
 		go func(i int) {
 			defer wg.Done()
 			defer func() { <-sem }()
+			// Make the best-effort guarantee unconditional: a panic in one critique becomes that
+			// finding's Err (it then gates normally), never taking down the scan pipeline.
+			defer func() {
+				if r := recover(); r != nil {
+					out[i] = Critique{
+						FindingID: string(candidates[i].ID),
+						DedupKey:  candidates[i].DedupKey,
+						Err:       fmt.Errorf("critique panicked: %v", r),
+					}
+				}
+			}()
 			out[i] = c.assessOne(ctx, candidates[i], src)
 		}(i)
 	}
@@ -148,7 +159,7 @@ func (c *Coordinator) assessOne(ctx context.Context, f finding.Finding, src Sour
 	snippet := ""
 	if src != nil {
 		if file, line, ok := locationOf(f); ok {
-			if s, err := src.Snippet(file, line, c.radius); err == nil {
+			if s, err := src.Snippet(ctx, file, line, c.radius); err == nil {
 				snippet = s
 			}
 		}

--- a/internal/usecase/fptriage/coordinator.go
+++ b/internal/usecase/fptriage/coordinator.go
@@ -26,13 +26,10 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-// SourceReader returns a small source excerpt around file:line (1-based), radius lines each side. The
-// workspace it reads from is Synapse-controlled (a trusted-local dir or a sandbox-acquired tree), so
-// this is a bounded read, not a path handed to a tool. An error (missing file, binary) is non-fatal:
-// the coordinator critiques on the finding metadata alone.
-type SourceReader interface {
-	Snippet(file string, line, radius int) (string, error)
-}
+// SourceReader is the source-excerpt reader the coordinator uses for context (an alias for the shared
+// port, so the concrete fs reader lives in infrastructure, not here). An error is non-fatal: the
+// coordinator critiques on finding metadata alone.
+type SourceReader = ports.SourceSnippetReader
 
 // Critique is the model's per-finding verdict. Err is set when the (proposer) model could not be
 // consulted (timeout, transport, or an unparseable/invalid reply); such a critique is treated as

--- a/internal/usecase/fptriage/triager.go
+++ b/internal/usecase/fptriage/triager.go
@@ -1,0 +1,61 @@
+package fptriage
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Triager adapts a Coordinator to the ports.FPTriager the scan pipeline injects, so the SAME triage runs
+// for both the CLI (synchronous) and the durable API scan job. It owns the mapping from a Coordinator
+// Critique to the advisory ports.AICritique DTO (dropping best-effort failures, which then gate normally)
+// and builds a per-workspace source reader through the injected factory (the fs read stays in
+// infrastructure, never here).
+type Triager struct {
+	coord     *Coordinator
+	readerFor func(root string) ports.SourceSnippetReader
+	minConf   int
+}
+
+var _ ports.FPTriager = (*Triager)(nil)
+
+// NewTriager wraps a Coordinator. readerFor returns the source reader rooted at a scan's workspace dir
+// (nil-safe: a nil factory means the coordinator critiques on metadata only).
+func NewTriager(coord *Coordinator, readerFor func(root string) ports.SourceSnippetReader) *Triager {
+	mc := 0
+	if coord != nil {
+		mc = coord.MinConfidence()
+	}
+	return &Triager{coord: coord, readerFor: readerFor, minConf: mc}
+}
+
+// Triage critiques each candidate and returns the advisory verdicts. A best-effort failure (Err set) is
+// dropped so that finding gates normally. Never mutates a finding.
+func (t *Triager) Triage(ctx context.Context, candidates []finding.Finding, workspaceDir string) []ports.AICritique {
+	if t == nil || t.coord == nil || len(candidates) == 0 {
+		return nil
+	}
+	var reader ports.SourceSnippetReader
+	if t.readerFor != nil {
+		reader = t.readerFor(workspaceDir)
+	}
+	crits := t.coord.Assess(ctx, candidates, reader)
+	out := make([]ports.AICritique, 0, len(crits))
+	for _, c := range crits {
+		if c.Err != nil {
+			continue
+		}
+		fp := c.SuspectedFP(t.minConf)
+		out = append(out, ports.AICritique{
+			FindingID:   c.FindingID,
+			DedupKey:    c.DedupKey,
+			Verdict:     string(c.Claim.Verdict),
+			Driver:      c.Claim.Driver,
+			Confidence:  c.Claim.Confidence,
+			SuspectedFP: fp,
+			Verified:    fp && c.VerifyAttempted, // a suspected-FP a DISTINCT verifier confirmed
+		})
+	}
+	return out
+}

--- a/internal/usecase/fptriage/triager_test.go
+++ b/internal/usecase/fptriage/triager_test.go
@@ -1,0 +1,50 @@
+package fptriage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestTriagerMapsToPortsDTO(t *testing.T) {
+	llm := fakeLLM{byTitleSubstr: map[string]string{
+		"fp.go":   `{"verdict":"refuted","driver":"test_or_example_code","confidence":90}`,
+		"real.go": `{"verdict":"sound","driver":"attacker_controlled","confidence":80}`,
+	}}
+	tr := NewTriager(New(llm, "m"), nil) // nil reader → metadata-only critique
+	var _ ports.FPTriager = tr           // implements the port
+	cands := []finding.Finding{
+		mkFinding("1", "X (a/fp.go:1)"),
+		mkFinding("2", "Y (a/real.go:2)"),
+	}
+	out := tr.Triage(context.Background(), cands, "/root")
+	if len(out) != 2 {
+		t.Fatalf("want 2 critiques, got %d", len(out))
+	}
+	byKey := map[string]ports.AICritique{}
+	for _, c := range out {
+		byKey[c.DedupKey] = c
+	}
+	if c := byKey["dk-1"]; !c.SuspectedFP || c.Verdict != "refuted" || c.Driver != "test_or_example_code" {
+		t.Errorf("fp finding mapping wrong: %+v", c)
+	}
+	if c := byKey["dk-2"]; c.SuspectedFP || c.Verdict != "sound" {
+		t.Errorf("sound finding must not be suspected-FP: %+v", c)
+	}
+	// Verified is false in single-model mode.
+	if byKey["dk-1"].Verified {
+		t.Error("single-model refutation must not be marked verified")
+	}
+}
+
+func TestTriagerNilSafe(t *testing.T) {
+	var tr *Triager
+	if got := tr.Triage(context.Background(), []finding.Finding{mkFinding("1", "X (a.go:1)")}, "/r"); got != nil {
+		t.Errorf("nil triager must return nil, got %v", got)
+	}
+	if got := NewTriager(nil, nil).Triage(context.Background(), nil, "/r"); got != nil {
+		t.Errorf("nil coordinator / no candidates must return nil, got %v", got)
+	}
+}

--- a/internal/usecase/ports/fptriage.go
+++ b/internal/usecase/ports/fptriage.go
@@ -1,0 +1,40 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+)
+
+// SourceSnippetReader returns a small source excerpt around file:line (1-based, radius lines each side)
+// from a workspace. The concrete implementation reads the Synapse-controlled scanned tree (a bounded,
+// read-only helper), so this is not a path handed to a tool. An error (missing/binary file) is
+// non-fatal — the caller critiques on finding metadata alone.
+type SourceSnippetReader interface {
+	Snippet(file string, line, radius int) (string, error)
+}
+
+// AICritique is one finding's LLM false-positive verdict (propose-only, advisory). Verdict and Driver use
+// the closed judgment.CritiqueClaim vocabulary (no free prose). SuspectedFP is set when a "refuted"
+// verdict clears the confidence bar — and, when a distinct verifier is configured, it independently
+// confirmed. It is retain-and-mark: a suspected-FP finding stays reported and sealed and is only held
+// back from the CI gate, never deleted.
+type AICritique struct {
+	FindingID   string `json:"finding_id"`
+	DedupKey    string `json:"dedup_key"`
+	Verdict     string `json:"verdict"`
+	Driver      string `json:"driver"`
+	Confidence  int    `json:"confidence"`
+	SuspectedFP bool   `json:"suspected_fp"`
+	// Verified is true when a DISTINCT verifier model independently confirmed the refutation (two-model
+	// consensus). Omitted when no verifier was configured (single-model triage).
+	Verified bool `json:"verified,omitempty"`
+}
+
+// FPTriager runs an LLM false-positive critique over candidate findings from a workspace and returns a
+// per-candidate advisory verdict. It is best-effort and PROPOSE-ONLY: it never mutates or deletes a
+// finding; the caller applies a suspected-FP as retain-and-mark (held back from the --fail-on gate,
+// still reported and evidence-sealed). Injected optionally into the scan pipeline; nil = no triage.
+type FPTriager interface {
+	Triage(ctx context.Context, candidates []finding.Finding, workspaceDir string) []AICritique
+}

--- a/internal/usecase/ports/fptriage.go
+++ b/internal/usecase/ports/fptriage.go
@@ -11,7 +11,7 @@ import (
 // read-only helper), so this is not a path handed to a tool. An error (missing/binary file) is
 // non-fatal — the caller critiques on finding metadata alone.
 type SourceSnippetReader interface {
-	Snippet(file string, line, radius int) (string, error)
+	Snippet(ctx context.Context, file string, line, radius int) (string, error)
 }
 
 // AICritique is one finding's LLM false-positive verdict (propose-only, advisory). Verdict and Driver use

--- a/internal/usecase/sca/fptriage_test.go
+++ b/internal/usecase/sca/fptriage_test.go
@@ -1,0 +1,41 @@
+package sca
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestFPTriageCandidates(t *testing.T) {
+	fs := []finding.Finding{
+		{DedupKey: "sast-prod", Kind: finding.KindSAST, Scope: sbom.ScopeProduction},
+		{DedupKey: "secret-prod", Kind: finding.KindSecret, Scope: sbom.ScopeProduction},
+		{DedupKey: "misconfig-prod", Kind: finding.KindMisconfig, Scope: sbom.ScopeProduction},
+		{DedupKey: "sast-test", Kind: finding.KindSAST, Scope: sbom.ScopeTest},       // background → skip
+		{DedupKey: "sca-prod", Kind: finding.KindSCA, Scope: sbom.ScopeProduction},   // SCA → skip (DB-backed fact)
+		{DedupKey: "sast-fixture", Kind: finding.KindSAST, Scope: sbom.ScopeFixture}, // background → skip
+	}
+	got := fpTriageCandidates(fs)
+	if len(got) != 3 {
+		t.Fatalf("want 3 production source candidates, got %d: %+v", len(got), got)
+	}
+	for _, c := range got {
+		if sbom.IsBackgroundScope(c.Scope) || c.Kind == finding.KindSCA {
+			t.Errorf("unexpected candidate: %+v", c)
+		}
+	}
+}
+
+func TestSuspectedFPKeys(t *testing.T) {
+	res := &ScanResult{AITriage: []ports.AICritique{
+		{DedupKey: "a", SuspectedFP: true},
+		{DedupKey: "b", SuspectedFP: false},
+		{DedupKey: "c", SuspectedFP: true},
+	}}
+	keys := res.SuspectedFPKeys()
+	if len(keys) != 2 || !keys["a"] || !keys["c"] || keys["b"] {
+		t.Errorf("SuspectedFPKeys = %v, want {a,c}", keys)
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -63,6 +63,7 @@ type Service struct {
 	sastAnalyzer      ports.SASTAnalyzer              // optional deterministic pattern-SAST over the live workspace
 	secretScanner     ports.SecretScanner             // optional deterministic secret scan over the live workspace
 	misconfig         ports.MisconfigScanner          // optional deterministic IaC/config misconfig scan over the live workspace
+	fpTriager         ports.FPTriager                 // optional LLM false-positive critique of production-scope source findings
 	osPkgCataloger    ports.OSPackageCataloger        // optional owned OS-package cataloging (dpkg/apk) from an image rootfs
 	instCataloger     ports.InstalledPackageCataloger // optional owned installed-package cataloging (Go binaries, Python dist-info) from an image rootfs
 	suppression       ports.SuppressionLoader         // optional repo-committed .synapseignore accepted-risk policy
@@ -129,6 +130,12 @@ func (s *Service) SetSASTAnalyzer(a ports.SASTAnalyzer) { s.sastAnalyzer = a }
 
 // SetSecretScanner configures the optional deterministic secret scanner. nil ⇒ no secret scanning.
 func (s *Service) SetSecretScanner(sc ports.SecretScanner) { s.secretScanner = sc }
+
+// SetFPTriage injects the optional LLM false-positive triager. When set, the pipeline critiques the
+// production-scope first-party source findings after they are built and records the advisory verdicts on
+// ScanResult.AITriage; a suspected-FP is retain-and-mark (gate-exempt via SuspectedFPKeys, still
+// reported + sealed). Best-effort; nil = no triage.
+func (s *Service) SetFPTriage(t ports.FPTriager) { s.fpTriager = t }
 
 // SetOSPackageCataloger configures optional owned OS-package cataloging (dpkg/apk) from a materialized image
 // rootfs (Workspace.RootFS). nil ⇒ no owned OS cataloging. It only runs when a rootfs was materialized.
@@ -469,23 +476,39 @@ type ScanResult struct {
 	// AITriage holds an optional LLM false-positive critique of first-party source findings (opt-in,
 	// best-effort). Each entry is the model's PROPOSED verdict; a suspected-FP entry is retain-and-mark
 	// (the finding stays reported here and sealed, it is only held back from the CI gate), never a
-	// deletion. Empty unless the FP-triage gate ran.
-	AITriage []AICritique `json:"ai_triage,omitempty"`
+	// deletion. Populated by the injected ports.FPTriager for BOTH the CLI and the durable API scan job;
+	// empty unless the FP-triage gate ran.
+	AITriage []ports.AICritique `json:"ai_triage,omitempty"`
 }
 
-// AICritique is one finding's LLM false-positive verdict (propose-only, advisory). Verdict and Driver
-// use the closed judgment.CritiqueClaim vocabulary (no free prose); SuspectedFP is set when the verdict
-// is "refuted" at or above the coordinator's confidence bar.
-type AICritique struct {
-	FindingID   string `json:"finding_id"`
-	DedupKey    string `json:"dedup_key"`
-	Verdict     string `json:"verdict"`
-	Driver      string `json:"driver"`
-	Confidence  int    `json:"confidence"`
-	SuspectedFP bool   `json:"suspected_fp"`
-	// Verified is true when a DISTINCT verifier model independently confirmed the refutation (two-model
-	// consensus). Omitted when no verifier was configured (single-model triage).
-	Verified bool `json:"verified,omitempty"`
+// SuspectedFPKeys returns the set of finding DedupKeys the AI triage marked as suspected false positives
+// (retain-and-mark). A --fail-on gate exempts these (still reported + sealed), the same way it exempts
+// accepted-risk and needs-verify findings.
+func (r *ScanResult) SuspectedFPKeys() map[string]bool {
+	out := map[string]bool{}
+	for _, c := range r.AITriage {
+		if c.SuspectedFP {
+			out[c.DedupKey] = true
+		}
+	}
+	return out
+}
+
+// fpTriageCandidates selects the findings worth an LLM critique: production-scope, first-party source
+// analysis (SAST/secret/misconfig). Background-scope findings are already gate-exempt deterministically,
+// and SCA/advisory findings are DB-backed facts, so neither is critiqued.
+func fpTriageCandidates(fs []finding.Finding) []finding.Finding {
+	out := make([]finding.Finding, 0, len(fs))
+	for _, f := range fs {
+		if sbom.IsBackgroundScope(f.Scope) {
+			continue
+		}
+		switch f.Kind {
+		case finding.KindSAST, finding.KindSecret, finding.KindMisconfig:
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 const (
@@ -2035,6 +2058,17 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 			result.SourceWarnings = append(result.SourceWarnings, "in-repo VEX (.synapse.vex.json) was not applied (unreadable or not a valid OpenVEX document)")
 		} else {
 			applyVEX(result, doc)
+		}
+	}
+	// AI false-positive triage (opt-in, best-effort, PROPOSE-ONLY). After the deterministic pass, the
+	// injected triager critiques the remaining production-scope first-party source findings and records
+	// advisory verdicts on AITriage; a suspected-FP is retain-and-mark (held back from the gate via
+	// SuspectedFPKeys, still reported + sealed). Runs for BOTH the CLI and the durable API scan job.
+	if s.fpTriager != nil {
+		if cands := fpTriageCandidates(result.Findings); len(cands) > 0 {
+			tstep := trace.start(stageFindings, "ai-fp-triage", "fp-triager", "AI false-positive triage", map[string]int{"candidates": len(cands)})
+			result.AITriage = s.fpTriager.Triage(ctx, cands, ws.Dir)
+			trace.succeed(tstep, "AI false-positive triage", map[string]int{"candidates": len(cands), "critiqued": len(result.AITriage), "suspected_fp": len(result.SuspectedFPKeys())})
 		}
 	}
 	result.MinSeverity = s.minSeverity


### PR DESCRIPTION
Closes #158.

## Summary
The AI false-positive triage (#154/#156) ran only in `synapse-cli`. This moves it into the scan pipeline as an injected step, so the **durable API scan job** gets it too — both paths now populate `ScanResult.AITriage`.

## Design
- New `ports.FPTriager` + `ports.AICritique` + `ports.SourceSnippetReader`.
- `sca.Service.SetFPTriage(...)`: `runPipeline` critiques the production-scope first-party source findings after the deterministic pass and records advisory verdicts on `ScanResult.AITriage`. New `ScanResult.SuspectedFPKeys()` exposes the retain-and-mark set the gate exempts (mirrors `SuppressedKeys`/`NeedsVerifyKeys`).
- `fptriage.Triager` adapts a `Coordinator` to the port (maps `Critique`→`ports.AICritique`; drops best-effort failures so they gate normally). The fs source reader moves to `internal/infrastructure/sourcesnippet` (fs stays in infra, not usecase).
- **CLI**: injects the triager (proposer + optional distinct verifier) and reads `res.SuspectedFPKeys()` at the gate — removed the duplicated inline block + helpers.
- **API** (`cmd/synapse-api`): wires the same triager when `SYNAPSE_FP_TRIAGE_ENABLED`, independent of the agent.

## Invariants preserved
Propose-only + best-effort: a suspected-FP is **retain-and-mark** (still reported and evidence-sealed, only held back from `--fail-on`), never deleted. The distinct-verifier consensus (#156) carries over.

## Tested with real AI
Live via the shared pipeline against an OpenAI-compatible gateway (proposer `cx/gpt-5.4-mini` + verifier `cx/gpt-5.4`): 6 findings critiqued, 5 confirmed by the distinct verifier and held back, **1 the verifier declined stayed gating** (consensus working). Unit tests: `Triager` DTO mapping + nil-safety, `fpTriageCandidates` selection, `SuspectedFPKeys`. `go test ./...` green.

The API and CLI share the exact `runPipeline` step, so the live CLI run exercises the same code the async API job runs.