### PR TITLE
feat(report): surface accepted risk-narrative + correlation judgments (#160)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -892,6 +892,7 @@ func main() {
 			}
 		}
 		exportService.SetJudgments(judgmentStore) // OpenVEX justification-by-tier from confirmed not_reachable judgments
+		reportService.SetJudgments(judgmentStore) // ACCEPTED risk-narrative + correlation → closed report tokens (LLM-free)
 		log.Info("AI judgment lifecycle ENABLED (verify/accept/list)")
 	}
 	// AI-proposed, human-gated finding write-up drafts. The service is shared by the agent's

--- a/internal/infrastructure/report/maroto.go
+++ b/internal/infrastructure/report/maroto.go
@@ -97,6 +97,18 @@ func (Renderer) Render(_ context.Context, eng *engagement.Engagement, findings [
 		}
 	}
 
+	// Accepted AI judgments – closed tokens only (risk rationale drivers/priority, cross-check source
+	// names). No model prose ever reaches the PDF (the report path is LLM-free).
+	if len(insight.RiskRationales) > 0 || len(insight.CorrelationNotes) > 0 {
+		section(m, "AI analysis (accepted)")
+		for _, rr := range insight.RiskRationales {
+			m.AddRow(5, text.NewCol(12, fmt.Sprintf("AI risk rationale — %s: priority %d, drivers %s", rr.Subject, rr.Priority, strings.Join(rr.Drivers, ", ")), props.Text{Size: 8, Color: gray()}))
+		}
+		for _, cn := range insight.CorrelationNotes {
+			m.AddRow(5, text.NewCol(12, fmt.Sprintf("Cross-check — %s: reported by [%s]; not reported by [%s]", cn.Subject, strings.Join(cn.Reporters, ", "), strings.Join(cn.Missing, ", ")), props.Text{Size: 8, Color: gray()}))
+		}
+	}
+
 	// Executive summary – posture in one line + third-party headline numbers.
 	section(m, "Executive summary")
 	m.AddRow(10, text.NewCol(12, executivePosture(crit, high, len(thirdParty), insight), props.Text{Size: 10}))

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -397,6 +397,28 @@ type ReportInsight struct {
 	Development    int
 	ExampleTest    int
 	PriorityCounts map[int]int
+	// RiskRationales + CorrelationNotes are LLM-free projections of ACCEPTED (human-confirmed) AI
+	// judgments — closed tokens only (drivers/priority, reporter/missing source names), never model
+	// prose — so the report can surface AI risk rationale and cross-check disagreements while the report
+	// path stays LLM-free. Empty unless judgments were accepted.
+	RiskRationales   []RiskRationale
+	CorrelationNotes []CorrelationNote
+}
+
+// RiskRationale is a rendered projection of an ACCEPTED risk-narrative judgment: the closed driver tokens
+// plus the 1..5 priority. Templated tokens only — never model prose.
+type RiskRationale struct {
+	Subject  string   `json:"subject"` // "<kind>:<id>" the narrative is about
+	Drivers  []string `json:"drivers"`
+	Priority int      `json:"priority"`
+}
+
+// CorrelationNote is a rendered projection of an ACCEPTED cross-check correlation judgment: which
+// detection sources reported a vuln and which did NOT — a data-quality note that never auto-resolves it.
+type CorrelationNote struct {
+	Subject   string   `json:"subject"`
+	Reporters []string `json:"reporters"`
+	Missing   []string `json:"missing"`
 }
 
 // ReportRenderer renders a deterministic PDF report from stored engagement data

--- a/internal/usecase/report/judgments.go
+++ b/internal/usecase/report/judgments.go
@@ -1,0 +1,75 @@
+package report
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// judgmentReader is the narrow read slice the report needs to surface ACCEPTED risk-narrative and
+// correlation judgments. Only these two ungated capabilities are read, and only their closed-token
+// fields are rendered — the report path stays LLM-free (no model prose ever reaches a deliverable).
+type judgmentReader interface {
+	ListByEngagement(ctx context.Context, engagementID shared.ID) ([]judgment.Judgment, error)
+}
+
+// SetJudgments wires the optional reader that projects accepted risk-narrative + correlation judgments
+// into the report insight. nil leaves those sections empty.
+func (s *Service) SetJudgments(r judgmentReader) { s.judgments = r }
+
+// projectAcceptedJudgments reads the engagement's judgments and fills insight.RiskRationales /
+// CorrelationNotes from the PUBLISHABLE (human-accepted) risk-narrative + correlation ones, as closed
+// tokens. Deterministic order (byte-reproducible report). Best-effort: a read error leaves them empty.
+func projectAcceptedJudgments(ctx context.Context, r judgmentReader, engagementID shared.ID, insight *ports.ReportInsight) {
+	js, err := r.ListByEngagement(ctx, engagementID)
+	if err != nil {
+		return
+	}
+	for _, j := range js {
+		if !j.Publishable() { // ungated ⇒ publishable == human-accepted (confirmed)
+			continue
+		}
+		subject := string(j.SubjectKind) + ":" + string(j.SubjectID)
+		switch j.Capability {
+		case judgment.CapRiskNarrative:
+			if c, ok := j.Claim.(judgment.RiskNarrativeClaim); ok {
+				insight.RiskRationales = append(insight.RiskRationales, ports.RiskRationale{
+					Subject: subject, Drivers: append([]string(nil), c.Drivers...), Priority: c.Priority,
+				})
+			}
+		case judgment.CapCorrelation:
+			if c, ok := j.Claim.(judgment.CorrelationClaim); ok {
+				insight.CorrelationNotes = append(insight.CorrelationNotes, ports.CorrelationNote{
+					Subject: subject, Reporters: append([]string(nil), c.Reporters...), Missing: append([]string(nil), c.Missing...),
+				})
+			}
+		}
+	}
+	// TOTAL comparators (tie-break down to every field) so the order is byte-reproducible even when a
+	// subject carries multiple accepted judgments — reports are SHA-256-sealed + hash-chained, so an
+	// unstable permutation of equal-subject rows would change the sealed bytes across regenerations.
+	sort.Slice(insight.RiskRationales, func(a, b int) bool {
+		x, y := insight.RiskRationales[a], insight.RiskRationales[b]
+		if x.Subject != y.Subject {
+			return x.Subject < y.Subject
+		}
+		if x.Priority != y.Priority {
+			return x.Priority < y.Priority
+		}
+		return strings.Join(x.Drivers, ",") < strings.Join(y.Drivers, ",")
+	})
+	sort.Slice(insight.CorrelationNotes, func(a, b int) bool {
+		x, y := insight.CorrelationNotes[a], insight.CorrelationNotes[b]
+		if x.Subject != y.Subject {
+			return x.Subject < y.Subject
+		}
+		if r := strings.Join(x.Reporters, ",") + "|" + strings.Join(x.Missing, ","); r != strings.Join(y.Reporters, ",")+"|"+strings.Join(y.Missing, ",") {
+			return r < strings.Join(y.Reporters, ",")+"|"+strings.Join(y.Missing, ",")
+		}
+		return false
+	})
+}

--- a/internal/usecase/report/judgments_test.go
+++ b/internal/usecase/report/judgments_test.go
@@ -1,0 +1,154 @@
+package report
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// fakeJudgments is a stand-in judgmentReader returning a fixed list.
+type fakeJudgments struct {
+	list []judgment.Judgment
+	err  error
+}
+
+func (f fakeJudgments) ListByEngagement(context.Context, shared.ID) ([]judgment.Judgment, error) {
+	return f.list, f.err
+}
+
+func acceptedNarrative(subjectID shared.ID, drivers []string, priority int) judgment.Judgment {
+	return judgment.Judgment{
+		Capability: judgment.CapRiskNarrative, State: judgment.StateConfirmed,
+		SubjectKind: judgment.SubjectFinding, SubjectID: subjectID,
+		Claim: judgment.RiskNarrativeClaim{Drivers: drivers, Priority: priority},
+	}
+}
+
+func acceptedCorrelation(subjectID shared.ID, reporters, missing []string) judgment.Judgment {
+	return judgment.Judgment{
+		Capability: judgment.CapCorrelation, State: judgment.StateConfirmed,
+		SubjectKind: judgment.SubjectComponent, SubjectID: subjectID,
+		Claim: judgment.CorrelationClaim{Reporters: reporters, Missing: missing},
+	}
+}
+
+// TestReportProjectsAcceptedJudgments proves ACCEPTED risk-narrative + correlation judgments surface in
+// the scan section as closed tokens (drivers/priority, reporter/missing lists) — no model prose.
+func TestReportProjectsAcceptedJudgments(t *testing.T) {
+	svc, cap := newService(ports.ReportInsight{HasScan: true, ScanTarget: "/srv/app", Actionable: 1}, sampleFindings())
+	svc.SetJudgments(fakeJudgments{list: []judgment.Judgment{
+		acceptedNarrative("manual:1", []string{"kev", "epss-high"}, 4),
+		acceptedCorrelation("pkg:npm/left-pad@1.0.0", []string{"osv", "grype"}, []string{"owned"}),
+	}})
+
+	if _, _, _, err := svc.Render(context.Background(), "", "e1", Options{Format: FormatHTML}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	sec := findSection(cap.last, "Scan & SBOM Insight")
+	if sec == nil {
+		t.Fatal("scan section missing")
+	}
+	joined := strings.Join(sec.Paragraphs, "\n")
+	wantRisk := "AI risk rationale — finding:manual:1: priority 4, drivers kev, epss-high."
+	wantCorr := "Cross-check — component:pkg:npm/left-pad@1.0.0: reported by [osv, grype]; not reported by [owned]."
+	if !strings.Contains(joined, wantRisk) {
+		t.Errorf("risk rationale token missing.\n got: %q\nwant substr: %q", joined, wantRisk)
+	}
+	if !strings.Contains(joined, wantCorr) {
+		t.Errorf("correlation token missing.\n got: %q\nwant substr: %q", joined, wantCorr)
+	}
+}
+
+// TestReportJudgmentSectionAppearsWithoutScan proves the projection alone (no SBOM scan) still emits the
+// section, so accepted AI judgments are never silently dropped from a non-scan engagement.
+func TestReportJudgmentSectionAppearsWithoutScan(t *testing.T) {
+	svc, cap := newService(ports.ReportInsight{}, sampleFindings()) // HasScan == false
+	svc.SetJudgments(fakeJudgments{list: []judgment.Judgment{
+		acceptedNarrative("manual:1", []string{"kev"}, 3),
+	}})
+	if _, _, _, err := svc.Render(context.Background(), "", "e1", Options{Format: FormatHTML}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if findSection(cap.last, "Scan & SBOM Insight") == nil {
+		t.Fatal("scan section should appear when only accepted judgments are present")
+	}
+}
+
+// TestReportSkipsUnacceptedAndSortsDeterministically proves (a) proposed / refuted judgments are excluded
+// (only human-accepted ones publish) and (b) output order is byte-reproducible (sorted by subject).
+func TestReportSkipsUnacceptedAndSortsDeterministically(t *testing.T) {
+	proposed := acceptedNarrative("manual:9", []string{"kev"}, 5)
+	proposed.State = judgment.StateProposed // NOT publishable
+	refuted := acceptedNarrative("manual:8", []string{"kev"}, 5)
+	refuted.State = judgment.StateRefuted // NOT publishable
+
+	var insight ports.ReportInsight
+	insight.HasScan = false
+	r := fakeJudgments{list: []judgment.Judgment{
+		acceptedNarrative("manual:3", []string{"epss-high"}, 2),
+		proposed,
+		acceptedNarrative("manual:1", []string{"kev"}, 4),
+		refuted,
+	}}
+	projectAcceptedJudgments(context.Background(), r, "e1", &insight)
+
+	if len(insight.RiskRationales) != 2 {
+		t.Fatalf("want 2 accepted rationales (proposed+refuted excluded), got %d", len(insight.RiskRationales))
+	}
+	if insight.RiskRationales[0].Subject != "finding:manual:1" || insight.RiskRationales[1].Subject != "finding:manual:3" {
+		t.Errorf("rationales not sorted by subject: %+v", insight.RiskRationales)
+	}
+}
+
+// TestReportProjectionIsByteReproducible proves the projection is TOTALLY ordered: multiple accepted
+// judgments on the SAME subject (same priority, different drivers) sort deterministically regardless of
+// the store's return order — reports are hash-sealed, so an unstable permutation would change the bytes.
+func TestReportProjectionIsByteReproducible(t *testing.T) {
+	// Same subject + same priority, differing only in Drivers — the tie-break case that an unstable,
+	// non-total sort would permute.
+	a := acceptedNarrative("manual:1", []string{"kev"}, 3)
+	b := acceptedNarrative("manual:1", []string{"epss-high"}, 3)
+	c := acceptedNarrative("manual:1", []string{"reachable"}, 3)
+
+	order1 := []judgment.Judgment{a, b, c}
+	order2 := []judgment.Judgment{c, a, b} // same set, different store order
+
+	var i1, i2 ports.ReportInsight
+	projectAcceptedJudgments(context.Background(), fakeJudgments{list: order1}, "e1", &i1)
+	projectAcceptedJudgments(context.Background(), fakeJudgments{list: order2}, "e1", &i2)
+
+	if len(i1.RiskRationales) != 3 {
+		t.Fatalf("want 3 rationales, got %d", len(i1.RiskRationales))
+	}
+	for k := range i1.RiskRationales {
+		if strings.Join(i1.RiskRationales[k].Drivers, ",") != strings.Join(i2.RiskRationales[k].Drivers, ",") {
+			t.Fatalf("projection order differs by input order at %d: %v vs %v", k, i1.RiskRationales, i2.RiskRationales)
+		}
+	}
+	// Concretely: sorted by joined drivers → epss-high, kev, reachable.
+	got := []string{
+		strings.Join(i1.RiskRationales[0].Drivers, ","),
+		strings.Join(i1.RiskRationales[1].Drivers, ","),
+		strings.Join(i1.RiskRationales[2].Drivers, ","),
+	}
+	want := []string{"epss-high", "kev", "reachable"}
+	for k := range want {
+		if got[k] != want[k] {
+			t.Errorf("tie-break order[%d] = %q, want %q", k, got[k], want[k])
+		}
+	}
+}
+
+// TestReportJudgmentReadErrorIsBestEffort proves a judgment-store read error leaves the report sections
+// empty rather than failing the whole render (deliverables must not depend on the optional AI layer).
+func TestReportJudgmentReadErrorIsBestEffort(t *testing.T) {
+	var insight ports.ReportInsight
+	projectAcceptedJudgments(context.Background(), fakeJudgments{err: shared.ErrNotFound}, "e1", &insight)
+	if len(insight.RiskRationales) != 0 || len(insight.CorrelationNotes) != 0 {
+		t.Fatalf("read error should leave sections empty, got %+v / %+v", insight.RiskRationales, insight.CorrelationNotes)
+	}
+}

--- a/internal/usecase/report/livedemo_ai_test.go
+++ b/internal/usecase/report/livedemo_ai_test.go
@@ -1,0 +1,183 @@
+package report
+
+// Live-AI demonstration for #160: a REAL model (9router / OpenAI-compatible) produces the risk-narrative
+// drivers + priority; those closed tokens pass the domain's closed-vocabulary gate; the report SERVICE
+// projects an ACCEPTED judgment to plain tokens; and the REAL HTML + PDF renderers emit them — while the
+// report path stays LLM-free (the model never touches the renderer; only typed tokens cross the boundary).
+//
+// Gated behind SYNAPSE_LIVE_AI=1 so the normal suite stays hermetic. Run:
+//   SYNAPSE_LIVE_AI=1 SYNAPSE_LLM_BASE_URL=http://localhost:20128/v1 SYNAPSE_LLM_MODEL=cx/gpt-5.4 \
+//     go test ./internal/usecase/report/ -run TestLiveAIRiskNarrativeToReport -v
+
+import (
+	"context"
+	"encoding/json"
+	htmlpkg "html"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/llm/openai"
+	inforeport "github.com/KKloudTarus/synapse-ce/internal/infrastructure/report"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// extractJSONObject pulls the first balanced {...} out of a possibly-chatty completion (9router does not
+// honor response_format, so the model may wrap JSON in prose or a code fence). Mirrors the tolerant parse
+// used by the fptriage/llmverifier coordinators.
+func extractJSONObject(s string) string {
+	start := strings.IndexByte(s, '{')
+	if start < 0 {
+		return ""
+	}
+	depth, inStr, esc := 0, false, false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case esc:
+			esc = false
+		case c == '\\' && inStr:
+			esc = true
+		case c == '"':
+			inStr = !inStr
+		case inStr:
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1]
+			}
+		}
+	}
+	return ""
+}
+
+func TestLiveAIRiskNarrativeToReport(t *testing.T) {
+	if os.Getenv("SYNAPSE_LIVE_AI") != "1" {
+		t.Skip("set SYNAPSE_LIVE_AI=1 to run the live 9router demonstration")
+	}
+	base := os.Getenv("SYNAPSE_LLM_BASE_URL")
+	if base == "" {
+		base = "http://localhost:20128/v1"
+	}
+	model := os.Getenv("SYNAPSE_LLM_MODEL")
+	if model == "" {
+		model = "cx/gpt-5.4"
+	}
+	llm, err := openai.New(base, os.Getenv("SYNAPSE_LLM_API_KEY"), model, 90*time.Second)
+	if err != nil {
+		t.Fatalf("openai client: %v", err)
+	}
+
+	// A concrete, high-signal finding. The model must map these facts to CLOSED driver tokens (no prose).
+	const sys = `You are a security triage assistant for a pentest platform. You explain WHY a finding's risk ` +
+		`priority is what it is, using only structured driver tokens — never prose. A driver token is a ` +
+		`lowercase identifier, optionally with a numeric comparison, matching this grammar: ` +
+		`^[a-z][a-z0-9_]*((<=|>=|==|!=|<|>)[0-9]+(\.[0-9]+)?)?$ . ` +
+		`Examples: kev, reachable, internet_facing, epss>0.9, cvss>=9. ` +
+		`Reply with ONLY a JSON object: {"drivers":[...tokens...],"priority":<1..5>}. No commentary.`
+	const usr = `Finding: CVE-2021-44228 (Log4Shell) in org.apache.logging.log4j:log4j-core 2.14.1. ` +
+		`Facts: listed in the CISA KEV catalog; EPSS = 0.97; CVSS base = 10.0 (critical); the vulnerable ` +
+		`JndiLookup path is reachable from an internet-facing HTTP request handler. ` +
+		`Give the driver tokens and the 1..5 priority.`
+
+	resp, err := llm.Chat(context.Background(), ports.ChatRequest{
+		Model:       model,
+		Temperature: 0,
+		MaxTokens:   400,
+		Messages: []agent.Message{
+			{Role: agent.RoleSystem, Content: sys},
+			{Role: agent.RoleUser, Content: usr},
+		},
+	})
+	if err != nil {
+		t.Fatalf("live chat: %v", err)
+	}
+	raw := extractJSONObject(resp.Content)
+	t.Logf("model=%s\nraw content: %s\nextracted JSON: %s", model, resp.Content, raw)
+	if raw == "" {
+		t.Fatalf("model returned no JSON object: %q", resp.Content)
+	}
+	var out struct {
+		Drivers  []string `json:"drivers"`
+		Priority int      `json:"priority"`
+	}
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("parse model JSON %q: %v", raw, err)
+	}
+	// clamp priority into the domain's 1..5 range (defensive; the domain also rejects out-of-range).
+	if out.Priority < 1 {
+		out.Priority = 1
+	}
+	if out.Priority > 5 {
+		out.Priority = 5
+	}
+
+	// The closed-vocabulary gate is the anti-hallucination boundary: real model tokens must pass it, or the
+	// judgment is rejected before it can ever reach a deliverable. This asserts the model stayed in-grammar.
+	claim := judgment.RiskNarrativeClaim{Drivers: out.Drivers, Priority: out.Priority}
+	if verr := claim.Validate(); verr != nil {
+		t.Fatalf("model produced out-of-vocabulary drivers %v (priority %d): %v", out.Drivers, out.Priority, verr)
+	}
+	t.Logf("AI-derived, gate-valid claim: drivers=%v priority=%d", out.Drivers, out.Priority)
+
+	// Feed an ACCEPTED judgment built from the REAL model output through the REAL report service +
+	// REAL renderers. The renderer only ever sees plain tokens; no model call happens in this path.
+	accepted := judgment.Judgment{
+		Capability: judgment.CapRiskNarrative, State: judgment.StateConfirmed,
+		SubjectKind: judgment.SubjectFinding, SubjectID: "manual:1", Claim: claim,
+	}
+	corr := acceptedCorrelation("pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+		[]string{"osv", "grype"}, []string{"owned"})
+
+	eng := &engagement.Engagement{Name: "log4shell-live", Client: "Acme"}
+	svc := NewService(
+		fakeEngRepo{eng: eng},
+		fakeFindingRepo{list: sampleFindings()},
+		fakeRetestRepo{},
+		nil,
+		inforeport.NewRenderer(), // real maroto PDF renderer
+		fakeInsight{ins: ports.ReportInsight{HasScan: true, ScanTarget: "/srv/app", Actionable: 1}},
+		fakeClock{},
+		"v-live",
+	)
+	htmlR := inforeport.NewHTMLRenderer() // real HTML renderer
+	svc.RegisterFormat(FormatHTML, htmlR)
+	svc.SetJudgments(fakeJudgments{list: []judgment.Judgment{accepted, corr}})
+
+	// HTML: assert the AI-derived tokens land in the deliverable text.
+	htmlBytes, _, _, err := svc.Render(context.Background(), "", "e1", Options{Format: FormatHTML})
+	if err != nil {
+		t.Fatalf("render html: %v", err)
+	}
+	html := string(htmlBytes)
+	for _, d := range out.Drivers {
+		// html/template auto-escapes, so a token like "epss>0.97" appears as "epss&gt;0.97".
+		if !strings.Contains(html, htmlpkg.EscapeString(d)) {
+			t.Errorf("rendered HTML is missing AI driver token %q", d)
+		}
+	}
+	if !strings.Contains(html, "AI risk rationale") {
+		t.Error("rendered HTML is missing the AI risk-rationale line")
+	}
+	if !strings.Contains(html, "Cross-check") {
+		t.Error("rendered HTML is missing the cross-check line")
+	}
+
+	// PDF: prove the same insight renders to a real PDF (maroto) without error (Generate → load →
+	// projectAcceptedJudgments → maroto, which draws the "AI analysis (accepted)" token block).
+	pdfBytes, _, err := svc.Generate(context.Background(), "", "e1")
+	if err != nil {
+		t.Fatalf("render pdf: %v", err)
+	}
+	if len(pdfBytes) < 500 || !strings.HasPrefix(string(pdfBytes), "%PDF") {
+		t.Fatalf("pdf render looks wrong: %d bytes, prefix %q", len(pdfBytes), string(pdfBytes[:min(8, len(pdfBytes))]))
+	}
+	t.Logf("PASS: real model → gate-valid tokens → HTML (%d bytes) + PDF (%d bytes), LLM-free render path",
+		len(html), len(pdfBytes))
+}

--- a/internal/usecase/report/service.go
+++ b/internal/usecase/report/service.go
@@ -172,6 +172,7 @@ type Service struct {
 	evidence     ports.ReportEvidenceProvider // optional; nil disables the image-exhibits section
 	renderer     ports.ReportRenderer
 	insight      ports.ReportInsightProvider
+	judgments    judgmentReader // optional; ACCEPTED risk-narrative + correlation judgments → insight tokens
 	clock        ports.Clock
 	version      string
 	docRenderers map[string]ports.DocRenderer
@@ -231,6 +232,12 @@ func (s *Service) load(ctx context.Context, tenantID, engagementID shared.ID) (l
 		if insight.EvidenceCount > 0 && !insight.EvidenceIntact {
 			return loaded{}, fmt.Errorf("%w: evidence chain verification failed – report blocked", shared.ErrValidation)
 		}
+	}
+	// Project ACCEPTED (human-confirmed) risk-narrative + correlation judgments into the insight as
+	// closed tokens (LLM-free — the report path never sees model prose). Best-effort: a judgment-store
+	// error leaves the report unchanged rather than blocking it.
+	if s.judgments != nil {
+		projectAcceptedJudgments(ctx, s.judgments, engagementID, &insight)
 	}
 	// Pin the report timestamp to the SCAN time (not generation time) so output is a
 	// pure function of stored data – byte-identical + SHA-256-stable across repeated
@@ -799,21 +806,30 @@ func complianceLabel(cwe string) string {
 }
 
 func scanSection(insight ports.ReportInsight) (ports.ReportSection, bool) {
-	if !insight.HasScan {
+	if !insight.HasScan && len(insight.RiskRationales) == 0 && len(insight.CorrelationNotes) == 0 {
 		return ports.ReportSection{}, false
 	}
 	sec := ports.ReportSection{Heading: "Scan & SBOM Insight"}
-	if insight.CompletenessNote != "" {
-		sec.Paragraphs = append(sec.Paragraphs, insight.CompletenessNote)
+	if insight.HasScan {
+		if insight.CompletenessNote != "" {
+			sec.Paragraphs = append(sec.Paragraphs, insight.CompletenessNote)
+		}
+		sec.Paragraphs = append(sec.Paragraphs, fmt.Sprintf("Reproducibility score: %d/100.", insight.ReproScore))
+		if insight.VulnDBSnapshot != "" {
+			sec.Paragraphs = append(sec.Paragraphs, "Vulnerability DB snapshot: "+insight.VulnDBSnapshot)
+		}
+		if insight.GrypeDBVersion != "" {
+			sec.Paragraphs = append(sec.Paragraphs, "Grype DB version: "+insight.GrypeDBVersion)
+		}
+		sec.Paragraphs = append(sec.Paragraphs, fmt.Sprintf("License detection: %d known, %d unknown (%.0f%%).", insight.LicenseDetected, insight.LicenseUnknown, insight.LicensePct))
 	}
-	sec.Paragraphs = append(sec.Paragraphs, fmt.Sprintf("Reproducibility score: %d/100.", insight.ReproScore))
-	if insight.VulnDBSnapshot != "" {
-		sec.Paragraphs = append(sec.Paragraphs, "Vulnerability DB snapshot: "+insight.VulnDBSnapshot)
+	// Accepted AI judgments, rendered as closed tokens (no model prose): risk rationale + cross-check.
+	for _, rr := range insight.RiskRationales {
+		sec.Paragraphs = append(sec.Paragraphs, fmt.Sprintf("AI risk rationale — %s: priority %d, drivers %s.", rr.Subject, rr.Priority, strings.Join(rr.Drivers, ", ")))
 	}
-	if insight.GrypeDBVersion != "" {
-		sec.Paragraphs = append(sec.Paragraphs, "Grype DB version: "+insight.GrypeDBVersion)
+	for _, cn := range insight.CorrelationNotes {
+		sec.Paragraphs = append(sec.Paragraphs, fmt.Sprintf("Cross-check — %s: reported by [%s]; not reported by [%s].", cn.Subject, strings.Join(cn.Reporters, ", "), strings.Join(cn.Missing, ", ")))
 	}
-	sec.Paragraphs = append(sec.Paragraphs, fmt.Sprintf("License detection: %d known, %d unknown (%.0f%%).", insight.LicenseDetected, insight.LicenseUnknown, insight.LicensePct))
 	return sec, true
 }
 


### PR DESCRIPTION
## #160 — surface accepted risk-narrative + correlation judgments in the report

`risk_narrative` and `correlation` judgments were built end-to-end (agent proposes → human accepts) but **dead-ended**: nothing on the server projected them into a deliverable. This wires them into the report as **closed tokens**, keeping the report path LLM-free.

### What changed
- **`ports.ReportInsight`** gains `RiskRationales` + `CorrelationNotes` — closed-token DTOs (drivers/priority, reporter/missing source names), never model prose.
- **`report.Service.SetJudgments` + `projectAcceptedJudgments`** read **only `Publishable()`** (human-accepted) risk-narrative + correlation judgments and project them to the insight with a **total, byte-reproducible sort** (reports are SHA-256-sealed + hash-chained, so equal-subject rows must never permute). Best-effort: a store read error leaves the sections empty rather than failing the render.
- **Renderers**: text (`Scan & SBOM Insight`) and maroto PDF (`AI analysis (accepted)`) emit the same `AI risk rationale — …` / `Cross-check — …` token lines.
- **`cmd/synapse-api`** wires `reportService.SetJudgments(judgmentStore)` under `cfg.JudgmentsEnabled`, mirroring `exportService.SetJudgments`.

### Golden rule 5 (no LLM in the report path) preserved
The renderer only ever sees plain tokens. `domain/judgment` is a prose-free typed domain, so the report **service** may read it and project to DTOs. `TestReportPathHasNoLLM` + the transitive scan stay green.

### Tests
- Projection: accepted-only, sorted, **byte-reproducible tie-break**, no-scan-still-renders, read-error-best-effort.
- **Live AI** (gated `SYNAPSE_LIVE_AI=1`): a real 9router model (`cx/gpt-5.4`) produced `["kev","epss>0.9","cvss>=9","reachable","internet_facing"]` priority 5 → tokens cleared the closed-vocab gate → landed in **real HTML (5789 B) + PDF (22020 B)**, LLM-free render path.

### Review
- **security-auditor**: CLEAN (no golden-rule violations; only-`Publishable()` gating verified; renderers escape; no secrets).
- **go-arch-reviewer**: dependency rule PASS; found + **fixed** a non-deterministic sort (now total order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
