### PR TITLE
feat(agent): durable-worker agent toolset parity with the API (#161)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1031,15 +1031,25 @@ func main() {
 			log.Error("agent catalog init failed", "err", cerr)
 			os.Exit(1)
 		}
-		agentCatalog.EnablePlanning()                            // advertise + dispatch propose_plan (paired with SetPlanStore below)
-		agentCatalog.EnableFindingProposals(exploitationService) // agent can record unproven findings (score 0)
-		agentCatalog.EnableHypotheses(exploitationService)       // agent can propose attack-chain hypotheses (score 0; gated until human-verified)
-		agentCatalog.EnableReachability(scanResultStore)         // agent can read dep-graph reachability facts (T0/T1)
-		if judgmentSvc != nil {                                  // agent can PROPOSE reachability judgments (score 0); verify stays human-only (PermReview)
-			agentCatalog.EnableJudgments(judgmentSvc)
+		// Enable the agent's tools through the SHARED toolset helper so the inline (here) and durable
+		// (synapse-worker) catalogs advertise an IDENTICAL tool set — the durable/inline parity guarantee
+		// (#161). Planning + findings + hypotheses + reachability are always on; judgments + writeup drafts
+		// mirror their feature flags (assigned only when the concrete service is non-nil, to avoid a
+		// non-nil interface wrapping a typed-nil pointer).
+		toolset := agenttools.AgentToolset{
+			Findings:     exploitationService, // record unproven findings (score 0)
+			Hypotheses:   exploitationService, // propose attack-chain hypotheses (score 0; gated until human-verified)
+			Reachability: scanResultStore,     // read dep-graph reachability facts (T0/T1)
 		}
-		if writeupDraftSvc != nil { // agent can PROPOSE finding write-up drafts (prose); edit/accept stays human-only
-			agentCatalog.EnableWriteupDrafts(writeupDraftSvc)
+		if judgmentSvc != nil { // PROPOSE reachability/critique/… judgments (score 0); verify stays human-only (PermReview)
+			toolset.Judgments = judgmentSvc
+		}
+		if writeupDraftSvc != nil { // PROPOSE finding write-up drafts (prose); edit/accept stays human-only
+			toolset.WriteupDrafts = writeupDraftSvc
+		}
+		if terr := agentCatalog.EnableAgentToolset(toolset); terr != nil {
+			log.Error("agent toolset wiring failed", "err", terr)
+			os.Exit(1)
 		}
 		// The executor drives recon through the SAME dispatcher-backed recon service (in-process
 		// pool), so the inline agent never starves a queue claim. A durable agent-on-worker would

--- a/cmd/synapse-worker/main.go
+++ b/cmd/synapse-worker/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/platform/jobs"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/agenttools"
+	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
 	egresspolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/egress"
 	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
@@ -45,6 +46,7 @@ import (
 	reconuc "github.com/KKloudTarus/synapse-ce/internal/usecase/recon"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/worker"
+	writeupdraftuc "github.com/KKloudTarus/synapse-ce/internal/usecase/writeupdraftuc"
 )
 
 func main() {
@@ -206,6 +208,11 @@ func main() {
 	// blocking recon poll never starves THIS worker's recon-claim loop (the self-deadlock the
 	// design flags). The agent session lock is the connection-holding advisory RunLock (it must
 	// not expire mid-LLM-loop); recon uses the row-lease lock above.
+	if cfg.AgentEnabled && cfg.LLMModel == "" {
+		// The API hard-errors in this case; the worker degrades to no-agent (fail-safe) but must say so,
+		// or a misconfigured worker silently runs without the durable agent handler (operator visibility).
+		log.Warn("SYNAPSE_AGENT_ENABLED is set but SYNAPSE_LLM_MODEL is empty: the durable agent handler is DISABLED on this worker (set SYNAPSE_LLM_MODEL to match the API)")
+	}
 	if cfg.AgentEnabled && cfg.LLMModel != "" {
 		agentSessionStore := postgres.NewAgentSessionStore(pool)
 		approvalStore := postgres.NewApprovalStore(pool)
@@ -249,11 +256,40 @@ func main() {
 			log.Error("agent catalog init failed", "err", cerr)
 			os.Exit(1)
 		}
-		agentCatalog.EnablePlanning() // advertise + dispatch propose_plan (paired with SetPlanStore below)
-		if exploitSvc, eerr := exploitationuc.NewService(findingRepo, evidenceService, auditLog, clock, ids); eerr == nil {
-			agentCatalog.EnableFindingProposals(exploitSvc) // durable agent can record unproven findings (score 0)
-		} else {
+		// Build the SAME toolset dependencies the inline API agent wires so a DURABLE run advertises an
+		// IDENTICAL tool set (#161 parity). Before this, the worker enabled only planning + finding
+		// proposals, so an agent driven durably saw a strictly smaller toolset than the same session run
+		// inline. Findings/hypotheses (exploitation) + reachability (scan-result store) are always on;
+		// judgments + writeup drafts mirror their feature flags — matching the API exactly. All are
+		// PROPOSE-only here: a distinct human confirms/verifies out of band via the API (PermReview).
+		exploitSvc, eerr := exploitationuc.NewService(findingRepo, evidenceService, auditLog, clock, ids)
+		if eerr != nil {
 			log.Error("exploitation service init failed", "err", eerr)
+			os.Exit(1)
+		}
+		toolset := agenttools.AgentToolset{
+			Findings:     exploitSvc,
+			Hypotheses:   exploitSvc,
+			Reachability: postgres.NewScanResultStore(pool),
+		}
+		if cfg.JudgmentsEnabled {
+			judgmentSvc, jerr := analysisuc.NewService(postgres.NewJudgmentRepository(pool), evidenceService, auditLog, clock, ids)
+			if jerr != nil {
+				log.Error("analysis (judgment) service init failed", "err", jerr)
+				os.Exit(1)
+			}
+			toolset.Judgments = judgmentSvc
+		}
+		if cfg.WriteupDraftsEnabled {
+			writeupSvc, werr := writeupdraftuc.NewService(postgres.NewWriteupDraftRepository(pool), auditLog, clock, ids)
+			if werr != nil {
+				log.Error("writeup-draft service init failed", "err", werr)
+				os.Exit(1)
+			}
+			toolset.WriteupDrafts = writeupSvc
+		}
+		if terr := agentCatalog.EnableAgentToolset(toolset); terr != nil {
+			log.Error("agent toolset wiring failed (durable/inline parity)", "err", terr)
 			os.Exit(1)
 		}
 		agentExec, xerr := orchestrator.NewReconExecutor(agentReconSvc, evidenceService, clock, 500*time.Millisecond, cfg.ReconTimeout+time.Minute)

--- a/internal/usecase/agenttools/livedemo_ai_test.go
+++ b/internal/usecase/agenttools/livedemo_ai_test.go
@@ -1,0 +1,112 @@
+package agenttools
+
+// Live-AI demonstration for #161 (durable/inline agent toolset parity): the synapse-worker durable agent
+// now advertises the SAME full tool catalog as the inline synapse-api agent — both wire it through the one
+// shared helper EnableAgentToolset. This drives a REAL 9router model against that full catalog and proves
+// a tool the worker PREVIOUSLY LACKED (propose_critique, a judgment tool) is both offered to AND used by
+// the model, then dispatches the model's own call end-to-end (recording a PROPOSED judgment at score 0 —
+// never a confirmation; the agent stays propose-only).
+//
+// Gated behind SYNAPSE_LIVE_AI=1 so the normal suite stays hermetic. Run:
+//   SYNAPSE_LIVE_AI=1 SYNAPSE_LLM_BASE_URL=http://localhost:20128/v1 SYNAPSE_LLM_MODEL=cx/gpt-5.4 \
+//     go test ./internal/usecase/agenttools/ -run TestLiveAIWorkerToolsetParity -v
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/llm/openai"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// newOnWorker is the set of tools the durable worker did NOT advertise before #161 (it enabled only
+// planning + finding proposals). The parity fix means a real model driven durably can now reach these.
+var newOnWorker = map[string]bool{
+	ToolProposeAttackChain:      true,
+	ToolReachabilityContext:     true,
+	ToolProposeReachability:     true,
+	ToolProposeSASTValidation:   true,
+	ToolProposeCritique:         true,
+	ToolProposeRiskNarrative:    true,
+	ToolProposeThreat:           true,
+	ToolProposeVexJustification: true,
+	ToolProposeWriteupDraft:     true,
+}
+
+func TestLiveAIWorkerToolsetParity(t *testing.T) {
+	if os.Getenv("SYNAPSE_LIVE_AI") != "1" {
+		t.Skip("set SYNAPSE_LIVE_AI=1 to run the live 9router demonstration")
+	}
+	base := os.Getenv("SYNAPSE_LLM_BASE_URL")
+	if base == "" {
+		base = "http://localhost:20128/v1"
+	}
+	model := os.Getenv("SYNAPSE_LLM_MODEL")
+	if model == "" {
+		model = "cx/gpt-5.4"
+	}
+	llm, err := openai.New(base, os.Getenv("SYNAPSE_LLM_API_KEY"), model, 90*time.Second)
+	if err != nil {
+		t.Fatalf("openai client: %v", err)
+	}
+
+	// Build the durable worker's catalog EXACTLY as cmd/synapse-worker now does: through the shared helper.
+	c, _ := newCatalog(t, nil, nil)
+	if terr := c.EnableAgentToolset(fullToolset()); terr != nil {
+		t.Fatalf("EnableAgentToolset: %v", terr)
+	}
+	if !toolNames(c)[ToolProposeCritique] {
+		t.Fatal("catalog is missing propose_critique — the parity tool under test")
+	}
+
+	resp, err := llm.Chat(context.Background(), ports.ChatRequest{
+		Model: model,
+		Tools: c.Tools(), // the FULL catalog, identical to the inline API agent's
+		Messages: []agent.Message{
+			{Role: agent.RoleSystem, Content: "You are an AppSec agent reviewing findings for the current engagement. When you judge a finding is likely a false positive, RECORD your adversarial critique using the available tool. Use a structured driver token (e.g. not_reachable), never prose."},
+			{Role: agent.RoleUser, Content: "Finding manual:1 is a reported SQL injection, but the vulnerable sink sits on a code path that is never reachable from any request handler. Record your critique."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("live chat: %v", err)
+	}
+	t.Logf("finish=%s tool_calls=%d content=%q", resp.FinishReason, len(resp.ToolCalls), resp.Content)
+	if len(resp.ToolCalls) == 0 {
+		t.Fatalf("model proposed no tool call against the full catalog; content=%q", resp.Content)
+	}
+
+	// The model must have reached for a tool the durable worker GAINED in #161 (not one it already had).
+	var picked *agent.ToolCall
+	for i := range resp.ToolCalls {
+		if newOnWorker[resp.ToolCalls[i].Name] {
+			picked = &resp.ToolCalls[i]
+			break
+		}
+	}
+	if picked == nil {
+		t.Fatalf("model used no parity-gained tool; proposed %v (worker previously advertised only planning + finding proposals)", toolCallNames(resp.ToolCalls))
+	}
+	t.Logf("model proposed parity-gained tool %q args=%s", picked.Name, string(picked.Arguments))
+
+	// Dispatch the model's own call through the durable catalog — proving the parity tool is not merely
+	// advertised but usable end-to-end. A judgment propose tool records a PROPOSED judgment at score 0.
+	res, err := c.Dispatch(context.Background(), session(), *picked)
+	if err != nil {
+		t.Fatalf("dispatch %q: %v", picked.Name, err)
+	}
+	if res.Data == nil && res.Proposal == nil && res.Plan == nil {
+		t.Fatalf("dispatch of %q returned an empty result", picked.Name)
+	}
+	t.Logf("PASS: durable/inline toolset parity — a real model used the worker's parity-gained tool %q and it dispatched: data=%s", picked.Name, string(res.Data))
+}
+
+func toolCallNames(cs []agent.ToolCall) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.Name)
+	}
+	return out
+}

--- a/internal/usecase/agenttools/wiring.go
+++ b/internal/usecase/agenttools/wiring.go
@@ -1,0 +1,54 @@
+package agenttools
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// AgentToolset bundles the dependencies that switch on the agent's engagement-scoped tools beyond the
+// always-available read tools. Both composition roots — the inline agent in synapse-api and the durable
+// agent in synapse-worker — enable their orchestrator catalog through THIS one struct, so a given agent
+// run advertises an IDENTICAL tool set no matter WHERE it executes. Before this, the worker enabled only
+// planning + finding proposals while the API enabled the full set, so the same session saw a smaller
+// toolset when driven durably — a correctness bug (issue #161).
+//
+// Findings, Hypotheses and Reachability are REQUIRED: a durable run must never silently advertise fewer
+// PROPOSAL tools than the inline run. Judgments and WriteupDrafts are OPTIONAL and mirror their feature
+// flags — a nil field leaves that tool off in BOTH binaries (they are gated by SYNAPSE_JUDGMENTS_ENABLED /
+// SYNAPSE_WRITEUP_DRAFTS_ENABLED). To keep a tool off, the composition root leaves the field nil; it must
+// NOT assign a typed-nil service pointer (a non-nil interface wrapping a nil pointer), because that would
+// wire a tool backed by nothing. Each field is a propose/read-only slice — the agent can never confirm.
+type AgentToolset struct {
+	Findings      findingProposer      // required: propose_finding
+	Hypotheses    hypothesisProposer   // required: propose_attack_chain
+	Reachability  scanResultReader     // required: reachability_context (read-only)
+	Judgments     judgmentProposer     // optional (nil ⇒ off): propose_reachability/sast_validation/critique/risk_narrative/threat/vex_justification
+	WriteupDrafts writeupdraftProposer // optional (nil ⇒ off): propose_writeup_draft
+}
+
+// EnableAgentToolset turns on planning + the proposal/read tools from a single dependency set, so the
+// inline (API) and durable (worker) catalogs are wired identically — the durable/inline parity guarantee
+// (issue #161). It FAILS CLOSED: a missing REQUIRED dependency returns an error rather than advertising a
+// partial toolset (a durable agent with fewer tools than the inline one is a correctness bug, not a valid
+// degraded mode). Planning is always on — both composition roots pair it with an orchestrator PlanStore.
+//
+// It calls the same narrow Enable* setters a composition root would, so the propose-only, never-confirm
+// invariant is unchanged: the agent still only proposes (score 0); a distinct human/verifier confirms out
+// of band. Optional deps are wired only when non-nil, matching each feature flag.
+func (c *Catalog) EnableAgentToolset(t AgentToolset) error {
+	if t.Findings == nil || t.Hypotheses == nil || t.Reachability == nil {
+		return fmt.Errorf("%w: agent toolset requires findings, hypotheses and reachability dependencies (refusing to advertise a partial toolset)", shared.ErrValidation)
+	}
+	c.EnablePlanning()
+	c.EnableFindingProposals(t.Findings)
+	c.EnableHypotheses(t.Hypotheses)
+	c.EnableReachability(t.Reachability)
+	if t.Judgments != nil {
+		c.EnableJudgments(t.Judgments)
+	}
+	if t.WriteupDrafts != nil {
+		c.EnableWriteupDrafts(t.WriteupDrafts)
+	}
+	return nil
+}

--- a/internal/usecase/agenttools/wiring_test.go
+++ b/internal/usecase/agenttools/wiring_test.go
@@ -1,0 +1,132 @@
+package agenttools
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// toolNames collects the set of advertised tool names.
+func toolNames(c *Catalog) map[string]bool {
+	m := make(map[string]bool)
+	for _, t := range c.Tools() {
+		m[t.Name] = true
+	}
+	return m
+}
+
+func fullToolset() AgentToolset {
+	return AgentToolset{
+		Findings:      &fakeProposer{},
+		Hypotheses:    &fakeHypProposer{},
+		Reachability:  &fakeScanResults{},
+		Judgments:     &fakeJudgmentProposer{},
+		WriteupDrafts: &fakeWriteupdraftProposer{},
+	}
+}
+
+// toolsetControlled is the EXACT set of tools EnableAgentToolset switches on beyond the always-present
+// read tools. It is the parity contract: both composition roots (synapse-api inline + synapse-worker
+// durable) enable their catalog through EnableAgentToolset, so both advertise these — and only these —
+// extra tools. A new Enable* added to the helper without updating this list fails the "no extras" check.
+var toolsetControlled = []string{
+	ToolProposePlan,
+	ToolProposeFinding,
+	ToolProposeAttackChain,
+	ToolReachabilityContext,
+	ToolProposeReachability,
+	ToolProposeSASTValidation,
+	ToolProposeCritique,
+	ToolProposeRiskNarrative,
+	ToolProposeThreat,
+	ToolProposeVexJustification,
+	ToolProposeWriteupDraft,
+}
+
+// TestEnableAgentToolsetEnablesFullSet locks the durable/inline parity guarantee: a FULL dependency set
+// advertises exactly the always-on read tools PLUS the controlled set — no more, no less. Because both
+// binaries call this one helper, this assertion pins that they advertise an identical tool set.
+func TestEnableAgentToolsetEnablesFullSet(t *testing.T) {
+	bare, _ := newCatalog(t, nil, nil)
+	base := toolNames(bare)
+
+	c, _ := newCatalog(t, nil, nil)
+	if err := c.EnableAgentToolset(fullToolset()); err != nil {
+		t.Fatalf("EnableAgentToolset(full): %v", err)
+	}
+	full := toolNames(c)
+
+	controlled := make(map[string]bool, len(toolsetControlled))
+	for _, name := range toolsetControlled {
+		controlled[name] = true
+		if base[name] {
+			t.Errorf("base catalog unexpectedly already advertises %q", name)
+		}
+		if !full[name] {
+			t.Errorf("full toolset is missing controlled tool %q", name)
+		}
+	}
+	// No tool beyond the base read tools + the controlled set may appear — a new Enable* wired into the
+	// helper must be reflected here (and thus in BOTH binaries), never silently on one side only.
+	for name := range full {
+		if !base[name] && !controlled[name] {
+			t.Errorf("EnableAgentToolset added an unexpected tool %q (update toolsetControlled + both cmds)", name)
+		}
+	}
+}
+
+// TestEnableAgentToolsetOptionalOff proves the optional deps (judgments, writeup drafts) gate their tools:
+// nil ⇒ off, so a binary with the feature flag off advertises the same reduced set as any other.
+func TestEnableAgentToolsetOptionalOff(t *testing.T) {
+	c, _ := newCatalog(t, nil, nil)
+	if err := c.EnableAgentToolset(AgentToolset{
+		Findings:     &fakeProposer{},
+		Hypotheses:   &fakeHypProposer{},
+		Reachability: &fakeScanResults{},
+	}); err != nil {
+		t.Fatalf("EnableAgentToolset(required-only): %v", err)
+	}
+	names := toolNames(c)
+
+	for _, n := range []string{ToolProposePlan, ToolProposeFinding, ToolProposeAttackChain, ToolReachabilityContext} {
+		if !names[n] {
+			t.Errorf("required tool %q missing", n)
+		}
+	}
+	for _, n := range []string{
+		ToolProposeReachability, ToolProposeSASTValidation, ToolProposeCritique,
+		ToolProposeRiskNarrative, ToolProposeThreat, ToolProposeVexJustification, ToolProposeWriteupDraft,
+	} {
+		if names[n] {
+			t.Errorf("optional tool %q must be OFF when its dependency is nil", n)
+		}
+	}
+}
+
+// TestEnableAgentToolsetFailsClosed proves a missing REQUIRED dependency returns ErrValidation and enables
+// NOTHING — the durable worker fails closed rather than advertising a partial toolset (the #161 defect).
+func TestEnableAgentToolsetFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		ts   AgentToolset
+	}{
+		{"no findings", AgentToolset{Hypotheses: &fakeHypProposer{}, Reachability: &fakeScanResults{}}},
+		{"no hypotheses", AgentToolset{Findings: &fakeProposer{}, Reachability: &fakeScanResults{}}},
+		{"no reachability", AgentToolset{Findings: &fakeProposer{}, Hypotheses: &fakeHypProposer{}}},
+		{"empty", AgentToolset{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newCatalog(t, nil, nil)
+			before := len(toolNames(c))
+			err := c.EnableAgentToolset(tc.ts)
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want ErrValidation, got %v", err)
+			}
+			if after := len(toolNames(c)); after != before {
+				t.Errorf("fail-closed violated: advertised tool count changed %d → %d after a rejected wiring", before, after)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## #161 — durable-worker agent toolset parity with the API

The **inline API agent** enabled the full tool set (planning, finding/hypothesis proposals, reachability reads, judgment proposals, writeup drafts) while the **durable synapse-worker agent** enabled only planning + finding proposals. The *same* agent session therefore advertised a **strictly smaller** tool set when driven durably than when run inline — a correctness bug (a plan/critique the model would form inline was simply unavailable on the worker).

### What changed
- **`agenttools.AgentToolset` + `(*Catalog).EnableAgentToolset`** — one shared dependency set that turns on planning + the proposal/read tools **identically** for both binaries. Findings/hypotheses/reachability are **required**; it **fails closed** (`ErrValidation`, nothing enabled) rather than advertise a partial toolset. Judgments + writeup drafts are optional and mirror their feature flags (`nil ⇒ off` in both).
- **`cmd/synapse-api`** — same tools as before, now routed through `EnableAgentToolset`.
- **`cmd/synapse-worker`** — builds the same deps (exploitation, scan-result store, and — under `SYNAPSE_JUDGMENTS_ENABLED` / `SYNAPSE_WRITEUP_DRAFTS_ENABLED` — analysis + writeup-draft services) and reaches parity. **All propose-only**: a distinct human confirms/verifies out of band via the API (PermReview). The agent never confirms.

### Safety (golden rule 4)
The worker's newly-advertised tools are propose-only and non-executing. The worker wires only the narrow `Propose` slices (no verify/accept path reaches the agent). `EnableAgentToolset` only calls the existing narrow `Enable*` setters — no new capability, no score-setter, no confirm path. `TestCatalogCannotReachAScoreSetter` stays green.

### Tests
- **Parity lock**: full deps ⇒ exactly the always-on read tools + the controlled set, no more/less (a new `Enable*` must be reflected in the test and thus in **both** binaries).
- **Optional-off** + **fail-closed** (table-driven).
- **Live AI** (gated `SYNAPSE_LIVE_AI=1`): a real 9router model (`cx/gpt-5.4`), given the worker's now-full catalog, proposed `propose_critique` (a tool the worker previously **lacked**) → the catalog dispatched it to a **PROPOSED judgment at score 0** (`publishable=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
