### PR TITLE
fix(web): render agent chat markdown, collapse tool JSON, add follow-up run

### DIFF
--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -1,0 +1,176 @@
+import { type ReactNode } from 'react'
+import { cn } from './ui'
+
+// Markdown is a SMALL, dependency-free, XSS-safe renderer for agent / LLM prose. It emits React elements
+// ONLY — never dangerouslySetInnerHTML — so untrusted model output can never inject HTML into the page (a
+// non-negotiable for a security tool). It covers the constructs the model actually emits (headings,
+// bold/italic, inline + fenced code, bullet/numbered lists, paragraphs) and degrades any unrecognized
+// syntax to plain text; it never throws. Links are rendered as plain styled text (their URL inline), NOT
+// as clickable anchors — we do not navigate from untrusted model output.
+export function Markdown({ children, className }: { children: string; className?: string }) {
+  const blocks = parseBlocks((children ?? '').replace(/\r\n/g, '\n'))
+  // No base font-size here — the caller controls it (cn is a naive join, not tailwind-merge, so a base
+  // size would collide with a caller's text-xs). Only leading/spacing/color are fixed.
+  return <div className={cn('space-y-1.5 leading-relaxed text-foreground', className)}>{blocks}</div>
+}
+
+// listItemRE matches a bullet (-, *, +) or ordered (1.) list marker at the start of a (possibly indented) line.
+const listItemRE = /^\s*([-*+]|\d+[.)])\s+/
+const headingRE = /^(#{1,6})\s+(.*)$/
+
+function parseBlocks(src: string): ReactNode[] {
+  const lines = src.split('\n')
+  const out: ReactNode[] = []
+  let i = 0
+  let key = 0
+  while (i < lines.length) {
+    const line = lines[i]
+
+    // Fenced code block: ``` … ```
+    if (line.trimStart().startsWith('```')) {
+      const code: string[] = []
+      i++
+      while (i < lines.length && !lines[i].trimStart().startsWith('```')) {
+        code.push(lines[i])
+        i++
+      }
+      i++ // consume the closing fence (if any)
+      out.push(
+        <pre key={key++} className="overflow-x-auto rounded-md border border-border bg-elevated p-2 font-mono text-xs text-foreground">
+          <code>{code.join('\n')}</code>
+        </pre>,
+      )
+      continue
+    }
+
+    // Heading: #, ##, … → weighted text (kept compact for a chat bubble).
+    const h = headingRE.exec(line)
+    if (h) {
+      out.push(
+        <div key={key++} className={cn('font-semibold text-foreground', h[1].length <= 2 ? 'mt-2 text-sm' : 'mt-1 text-xs uppercase tracking-wide text-mutedfg')}>
+          {renderInline(h[2])}
+        </div>,
+      )
+      i++
+      continue
+    }
+
+    // List: consecutive bullet or ordered items.
+    if (listItemRE.test(line)) {
+      const ordered = /^\s*\d+[.)]\s+/.test(line)
+      const items: ReactNode[] = []
+      while (i < lines.length && listItemRE.test(lines[i])) {
+        const text = lines[i].replace(listItemRE, '')
+        items.push(
+          <li key={items.length} className="ml-4 list-outside">
+            {renderInline(text)}
+          </li>,
+        )
+        i++
+      }
+      out.push(
+        ordered ? (
+          <ol key={key++} className="list-decimal space-y-0.5">
+            {items}
+          </ol>
+        ) : (
+          <ul key={key++} className="list-disc space-y-0.5">
+            {items}
+          </ul>
+        ),
+      )
+      continue
+    }
+
+    // Blank line → paragraph break.
+    if (line.trim() === '') {
+      i++
+      continue
+    }
+
+    // Paragraph: gather consecutive lines until a blank / block boundary.
+    const para: string[] = []
+    while (
+      i < lines.length &&
+      lines[i].trim() !== '' &&
+      !listItemRE.test(lines[i]) &&
+      !headingRE.test(lines[i]) &&
+      !lines[i].trimStart().startsWith('```')
+    ) {
+      para.push(lines[i])
+      i++
+    }
+    out.push(
+      <p key={key++} className="break-words">
+        {renderInline(para.join('\n'))}
+      </p>,
+    )
+  }
+  return out
+}
+
+// renderInline handles inline spans: `code`, **bold**, *italic* / _italic_. It recurses into bold/italic on
+// strictly-smaller substrings (always terminates) and treats a newline inside a paragraph as a soft break.
+function renderInline(text: string): ReactNode[] {
+  const out: ReactNode[] = []
+  let buf = ''
+  let i = 0
+  let key = 0
+  const flush = () => {
+    if (buf) {
+      // Preserve intra-paragraph line breaks.
+      const parts = buf.split('\n')
+      parts.forEach((p, idx) => {
+        if (idx > 0) out.push(<br key={`br${key++}`} />)
+        if (p) out.push(p)
+      })
+      buf = ''
+    }
+  }
+  while (i < text.length) {
+    const rest = text.slice(i)
+    // inline code `…`
+    if (text[i] === '`') {
+      const end = text.indexOf('`', i + 1)
+      if (end > i) {
+        flush()
+        out.push(
+          <code key={key++} className="rounded bg-elevated px-1 py-0.5 font-mono text-[0.85em] text-branddim">
+            {text.slice(i + 1, end)}
+          </code>,
+        )
+        i = end + 1
+        continue
+      }
+    }
+    // bold **…**
+    if (rest.startsWith('**')) {
+      const end = text.indexOf('**', i + 2)
+      if (end > i) {
+        flush()
+        out.push(
+          <strong key={key++} className="font-semibold text-foreground">
+            {renderInline(text.slice(i + 2, end))}
+          </strong>,
+        )
+        i = end + 2
+        continue
+      }
+    }
+    // italic *…* or _…_ (single delimiter, non-empty)
+    if (text[i] === '*' || text[i] === '_') {
+      const ch = text[i]
+      const end = text.indexOf(ch, i + 1)
+      if (end > i + 1) {
+        flush()
+        out.push(<em key={key++}>{renderInline(text.slice(i + 1, end))}</em>)
+        i = end + 1
+        continue
+      }
+    }
+    buf += text[i]
+    i++
+  }
+  flush()
+  return out
+}

--- a/web/src/pages/AgentTab.tsx
+++ b/web/src/pages/AgentTab.tsx
@@ -1,6 +1,7 @@
 import { Bot, CheckCircle2, Eye, ListChecks, ListTree, Loader2, Network, Play, ShieldAlert, X, Zap, type LucideIcon } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button, Card, cn, EmptyState, ErrorState, Spinner } from '../components/ui'
+import { Markdown } from '../components/Markdown'
 import { api, streamAgentSession } from '../lib/api'
 import type { AgentDecision, AgentMessage, AgentPlan, AgentReadiness, AgentSession, PendingApproval } from '../lib/types'
 
@@ -63,19 +64,31 @@ export function AgentTab({ engagementId }: { engagementId: string }) {
     return () => clearInterval(t)
   }, [refresh])
 
+  // startWithGoal starts a NEW goal-scoped session (the agent runs one goal per session — a typed
+  // state machine, not a free-form chat) and selects it. Shared by the top form and the per-session
+  // "follow-up run" affordance, so finishing one run never dead-ends the operator.
+  const startWithGoal = useCallback(
+    async (g: string) => {
+      const goalStr = g.trim()
+      if (!goalStr) return
+      setStarting(true)
+      setError(null)
+      try {
+        const sess = await api.startAgentSession(engagementId, goalStr)
+        setGoal('')
+        setActiveId(sess.id)
+        await refresh()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to start the agent')
+      } finally {
+        setStarting(false)
+      }
+    },
+    [engagementId, refresh],
+  )
+
   async function startAgent() {
-    if (!goal.trim()) return
-    setStarting(true)
-    try {
-      const sess = await api.startAgentSession(engagementId, goal.trim())
-      setGoal('')
-      setActiveId(sess.id)
-      await refresh()
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to start the agent')
-    } finally {
-      setStarting(false)
-    }
+    await startWithGoal(goal)
   }
 
   async function decide(actionId: string, approve: boolean) {
@@ -156,7 +169,14 @@ export function AgentTab({ engagementId }: { engagementId: string }) {
           </Card>
           <div className="lg:col-span-2">
             {activeId ? (
-              <SessionTranscript key={activeId} engagementId={engagementId} sessionId={activeId} onChanged={refresh} />
+              <SessionTranscript
+                key={activeId}
+                engagementId={engagementId}
+                sessionId={activeId}
+                onChanged={refresh}
+                onFollowUp={startWithGoal}
+                followUpBusy={starting}
+              />
             ) : (
               <Card title="Transcript">
                 <p className="text-sm text-mutedfg">Select a session to view its transcript.</p>
@@ -275,13 +295,18 @@ function SessionTranscript({
   engagementId,
   sessionId,
   onChanged,
+  onFollowUp,
+  followUpBusy,
 }: {
   engagementId: string
   sessionId: string
   onChanged: () => void
+  onFollowUp: (goal: string) => void
+  followUpBusy: boolean
 }) {
   const [messages, setMessages] = useState<AgentMessage[]>([])
   const [status, setStatus] = useState<string>('running')
+  const [followUp, setFollowUp] = useState('')
   const boxRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -363,6 +388,40 @@ function SessionTranscript({
       </div>
       <PlanGraph engagementId={engagementId} sessionId={sessionId} status={status} />
       <DecisionLog engagementId={engagementId} sessionId={sessionId} status={status} />
+      {terminal(status) && (
+        <div className="mt-3 border-t border-border pt-3">
+          <p className="mb-1.5 text-xs text-mutedfg">
+            This run is {status}. The agent runs one goal per session — start a follow-up run to continue this
+            line of work (it opens a fresh session).
+          </p>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <input
+              value={followUp}
+              onChange={(e) => setFollowUp(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing && followUp.trim() && !followUpBusy) {
+                  onFollowUp(followUp)
+                  setFollowUp('')
+                }
+              }}
+              placeholder="Follow-up goal, e.g. “now triage the SQLi candidates one by one”"
+              aria-label="Follow-up goal"
+              className="flex-1 rounded-lg border border-border bg-elevated px-3 py-2 text-sm text-foreground placeholder:text-mutedfg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand/40"
+            />
+            <Button
+              loading={followUpBusy}
+              disabled={!followUp.trim()}
+              onClick={() => {
+                onFollowUp(followUp)
+                setFollowUp('')
+              }}
+              className="px-3 py-2"
+            >
+              <Play className="size-4" /> Follow up
+            </Button>
+          </div>
+        </div>
+      )}
     </Card>
   )
 }
@@ -517,7 +576,64 @@ function MessageRow({ m }: { m: AgentMessage }) {
           → {m.toolCalls.map((c) => c.name).join(', ')}
         </div>
       )}
-      {m.content && <div className="whitespace-pre-wrap break-words font-mono text-xs text-foreground">{m.content}</div>}
+      {m.content &&
+        (m.role === 'tool' ? (
+          // Tool output is untrusted + often verbose JSON; collapse it behind a one-line summary rather
+          // than dumping a raw blob at the operator.
+          <ToolResult content={m.content} />
+        ) : m.role === 'assistant' ? (
+          // The model writes markdown prose; render it (never as raw HTML) instead of leaking the syntax.
+          <Markdown className="text-xs">{m.content}</Markdown>
+        ) : (
+          <div className="whitespace-pre-wrap break-words text-xs text-foreground">{m.content}</div>
+        ))}
     </div>
   )
+}
+
+// ToolResult presents an (untrusted) tool message: a one-line human summary, expandable to pretty-printed
+// JSON. It never executes or trusts the content — just formats it.
+function ToolResult({ content }: { content: string }) {
+  const parsed = safeParse(content)
+  const pretty = parsed !== undefined ? JSON.stringify(parsed, null, 2) : null
+  return (
+    <details className="text-xs">
+      <summary className="cursor-pointer select-none rounded text-mutedfg marker:text-mutedfg hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40">
+        {toolSummary(parsed, content)}
+      </summary>
+      <pre className="mt-1 max-h-64 overflow-auto rounded-md border border-border bg-bg p-2 font-mono text-[11px] leading-relaxed text-mutedfg">
+        {pretty ?? content}
+      </pre>
+    </details>
+  )
+}
+
+function safeParse(s: string): unknown {
+  try {
+    return JSON.parse(s)
+  } catch {
+    return undefined
+  }
+}
+
+// toolSummary builds a one-line, human-readable headline for a tool result so the operator sees WHAT it
+// returned without expanding: an array's length, a notable headline field, or a field count.
+function toolSummary(parsed: unknown, raw: string): string {
+  const suffix = ' — click to expand'
+  if (Array.isArray(parsed)) return `${parsed.length} item${parsed.length === 1 ? '' : 's'}${suffix}`
+  if (parsed && typeof parsed === 'object') {
+    const o = parsed as Record<string, unknown>
+    for (const k of ['note', 'summary', 'state', 'status', 'verdict', 'message']) {
+      const v = o[k]
+      if (typeof v === 'string' && v.trim()) return clipText(v.trim(), 120) + suffix
+    }
+    const n = Object.keys(o).length
+    return `result (${n} field${n === 1 ? '' : 's'})${suffix}`
+  }
+  const t = raw.trim()
+  return (t ? clipText(t, 120) : 'result') + suffix
+}
+
+function clipText(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n) + '…'
 }


### PR DESCRIPTION
## Fix Agent chat UX: render markdown, collapse tool JSON, add follow-up run

Three defects the operator hit in the Agent panel:
1. the model's **markdown answer leaked as raw text** (`**bold**`, `##`, `- bullets` shown literally in a monospace block);
2. **tool results were dumped as a raw JSON blob** with no end-user framing;
3. a **finished run dead-ended** — no way to continue.

### Fixes
- **`components/Markdown.tsx`** — a small, dependency-free, **XSS-safe** renderer (React elements only, *never* `dangerouslySetInnerHTML`, so untrusted model output can't inject HTML). Headings, bold/italic, inline + fenced code, bullet/ordered lists, paragraphs; degrades unknown syntax to plain text, never throws; links render as plain text (we don't navigate from model output).
- **`MessageRow`** — assistant content → `<Markdown>`; tool result → a collapsible `<details>/<summary>` (`ToolResult`) with a one-line human summary (array length / a headline field / field count), expandable to pretty-printed JSON.
- **`SessionTranscript`** — when a run is terminal, a **"follow-up run"** input (aria-label + design-system focus ring). The agent is goal-per-session by design (a typed Go state machine, not free-form chat), so this opens a fresh session rather than faking multi-turn — the operator is never dead-ended.

### Quality
No new deps. `pnpm typecheck` + `pnpm build` clean. **frontend-reviewer: PASS** — design-system tokens only (no raw hex), dark-mode contrast ≥ 4.5:1, a11y wiring intact, no `dangerouslySetInnerHTML`; its two LOW nits (a `text-sm`/`text-xs` `cn` conflict; a missing focus ring on the new `<summary>`) are fixed here.

### Validated with real AI
Ran a live agent session (`cx/gpt-5.4`): the transcript's assistant message was markdown (`## Summary` + `- …`) and the tool result was JSON (`{"findings":[],…}`) — exactly the two shapes now rendered correctly (heading + bullets; collapsed summary + expandable JSON), with the follow-up input appearing on the succeeded (terminal) run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
