### PR TITLE
feat(codequality): add rule domain and catalog registry

### DIFF
--- a/docs/guide/code-quality-rules.md
+++ b/docs/guide/code-quality-rules.md
@@ -88,9 +88,9 @@ Rules are catalogued as first-class entities (see [#182](https://github.com/KKlo
 
 ```
 Rule {
-  Key            // stable, e.g. "go:unhandled-error"  (namespace by language)
+  Key            // stable, opaque. Namespace by analyzer domain. Existing IDs never renamed.
   Name           // short human title
-  Language       // "Go", "Python", …
+  Language       // explicit user-facing language ("Go", "Python", etc.). Never parsed from Key.
   Type           // bug | vulnerability | code_smell | security_hotspot
   Qualities[]    // security | reliability | maintainability
   DefaultSeverity// critical | high | medium | low | info
@@ -98,7 +98,9 @@ Rule {
   CWE[] / OWASP[]// when security-relevant
   Description    // what it flags (our own words)
   Rationale      // why it matters (cite the concept origin + a source link)
-  Remediation    // how to fix, with our own compliant + non-compliant example
+  Remediation    // how to fix
+  CompliantExample    // compliant code example
+  NoncompliantExample // non-compliant code example
   RemediationEffort // minutes, for the tech-debt measure
   Detection      // ast | pattern | metric
 }

--- a/internal/domain/rule/rule.go
+++ b/internal/domain/rule/rule.go
@@ -1,0 +1,253 @@
+package rule
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type Key string
+
+type Type string
+
+const (
+	TypeBug             Type = "bug"
+	TypeVulnerability   Type = "vulnerability"
+	TypeCodeSmell       Type = "code_smell"
+	TypeSecurityHotspot Type = "security_hotspot"
+)
+
+func (t Type) Valid() bool {
+	switch t {
+	case TypeBug, TypeVulnerability, TypeCodeSmell, TypeSecurityHotspot:
+		return true
+	default:
+		return false
+	}
+}
+
+type Quality string
+
+const (
+	QualitySecurity        Quality = "security"
+	QualityReliability     Quality = "reliability"
+	QualityMaintainability Quality = "maintainability"
+)
+
+func (q Quality) Valid() bool {
+	switch q {
+	case QualitySecurity, QualityReliability, QualityMaintainability:
+		return true
+	default:
+		return false
+	}
+}
+
+type Detection string
+
+const (
+	DetectionAST     Detection = "ast"
+	DetectionPattern Detection = "pattern"
+	DetectionMetric  Detection = "metric"
+)
+
+func (d Detection) Valid() bool {
+	switch d {
+	case DetectionAST, DetectionPattern, DetectionMetric:
+		return true
+	default:
+		return false
+	}
+}
+
+type Rule struct {
+	Key                 Key
+	Name                string
+	Language            string
+	Type                Type
+	Qualities           []Quality
+	DefaultSeverity     shared.Severity
+	Tags                []string
+	CWE                 []string
+	OWASP               []string
+	Description         string
+	Rationale           string
+	Remediation         string
+	CompliantExample    string
+	NoncompliantExample string
+	RemediationEffort   int
+	Detection           Detection
+}
+
+func validateMetadataValue(
+	kind string,
+	value string,
+	seen map[string]struct{},
+) error {
+	trimmed := strings.TrimSpace(value)
+
+	if trimmed == "" {
+		return fmt.Errorf("%s value is empty or whitespace-only", kind)
+	}
+
+	if trimmed != value {
+		return fmt.Errorf("%s value has surrounding whitespace", kind)
+	}
+
+	key := strings.ToLower(trimmed)
+	if _, exists := seen[key]; exists {
+		return fmt.Errorf("duplicate %s value %q", kind, value)
+	}
+
+	seen[key] = struct{}{}
+	return nil
+}
+
+func (r Rule) Validate() error {
+	kStr := string(r.Key)
+	if strings.TrimSpace(kStr) == "" ||
+		strings.ContainsAny(kStr, "/?#") ||
+		strings.IndexFunc(kStr, unicode.IsSpace) >= 0 ||
+		strings.IndexFunc(kStr, unicode.IsControl) >= 0 {
+		return errors.New(
+			"key is empty or contains whitespace, control characters, or route delimiters",
+		)
+	}
+
+	if strings.TrimSpace(r.Name) == "" {
+		return errors.New("name is empty or whitespace-only")
+	}
+
+	if strings.TrimSpace(r.Language) == "" {
+		return errors.New("language is empty or whitespace-only")
+	}
+
+	if !r.Type.Valid() {
+		return errors.New("invalid type")
+	}
+
+	if len(r.Qualities) == 0 {
+		return errors.New("qualities must contain at least one value")
+	}
+
+	seenQualities := make(map[Quality]bool)
+	hasSecurity := false
+	hasReliability := false
+	hasMaintainability := false
+
+	for _, q := range r.Qualities {
+		if !q.Valid() {
+			return errors.New("invalid quality")
+		}
+		if seenQualities[q] {
+			return errors.New("duplicate quality")
+		}
+		seenQualities[q] = true
+		switch q {
+		case QualitySecurity:
+			hasSecurity = true
+		case QualityReliability:
+			hasReliability = true
+		case QualityMaintainability:
+			hasMaintainability = true
+		}
+	}
+
+	switch r.Type {
+	case TypeBug:
+		if !hasReliability {
+			return errors.New("bug type requires reliability quality")
+		}
+	case TypeVulnerability, TypeSecurityHotspot:
+		if !hasSecurity {
+			return fmt.Errorf("%s type requires security quality", r.Type)
+		}
+	case TypeCodeSmell:
+		if !hasMaintainability {
+			return errors.New("code_smell type requires maintainability quality")
+		}
+	}
+
+	if !r.DefaultSeverity.Valid() || r.DefaultSeverity == shared.SeverityUnknown {
+		return errors.New("invalid or unknown default severity")
+	}
+
+	seenTags := make(map[string]struct{})
+	for _, t := range r.Tags {
+		if err := validateMetadataValue("tag", t, seenTags); err != nil {
+			return err
+		}
+	}
+
+	seenCWE := make(map[string]struct{})
+	for _, c := range r.CWE {
+		if err := validateMetadataValue("cwe", c, seenCWE); err != nil {
+			return err
+		}
+	}
+
+	seenOWASP := make(map[string]struct{})
+	for _, o := range r.OWASP {
+		if err := validateMetadataValue("owasp", o, seenOWASP); err != nil {
+			return err
+		}
+	}
+
+	if strings.TrimSpace(r.Description) == "" {
+		return errors.New("description is empty or whitespace-only")
+	}
+
+	if strings.TrimSpace(r.Rationale) == "" {
+		return errors.New("rationale is empty or whitespace-only")
+	}
+
+	if strings.TrimSpace(r.Remediation) == "" {
+		return errors.New("remediation is empty or whitespace-only")
+	}
+
+	if strings.TrimSpace(r.CompliantExample) == "" {
+		return errors.New("compliant example is empty or whitespace-only")
+	}
+
+	if strings.TrimSpace(r.NoncompliantExample) == "" {
+		return errors.New("non-compliant example is empty or whitespace-only")
+	}
+
+	if strings.TrimSpace(r.CompliantExample) == strings.TrimSpace(r.NoncompliantExample) {
+		return errors.New("compliant and non-compliant examples are identical after trimming")
+	}
+
+	if r.RemediationEffort <= 0 {
+		return errors.New("remediation effort must be greater than zero")
+	}
+
+	if !r.Detection.Valid() {
+		return errors.New("invalid detection")
+	}
+
+	return nil
+}
+
+func (r Rule) Clone() Rule {
+	res := r
+	if r.Qualities != nil {
+		res.Qualities = make([]Quality, len(r.Qualities))
+		copy(res.Qualities, r.Qualities)
+	}
+	if r.Tags != nil {
+		res.Tags = make([]string, len(r.Tags))
+		copy(res.Tags, r.Tags)
+	}
+	if r.CWE != nil {
+		res.CWE = make([]string, len(r.CWE))
+		copy(res.CWE, r.CWE)
+	}
+	if r.OWASP != nil {
+		res.OWASP = make([]string, len(r.OWASP))
+		copy(res.OWASP, r.OWASP)
+	}
+	return res
+}

--- a/internal/domain/rule/rule_test.go
+++ b/internal/domain/rule/rule_test.go
@@ -1,0 +1,224 @@
+package rule_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestTypeValid(t *testing.T) {
+	tests := []struct {
+		typ  rule.Type
+		want bool
+	}{
+		{rule.TypeBug, true},
+		{rule.TypeVulnerability, true},
+		{rule.TypeCodeSmell, true},
+		{rule.TypeSecurityHotspot, true},
+		{"", false},
+		{"unknown", false},
+	}
+	for _, tt := range tests {
+		if got := tt.typ.Valid(); got != tt.want {
+			t.Errorf("Type(%q).Valid() = %v, want %v", tt.typ, got, tt.want)
+		}
+	}
+}
+
+func TestQualityValid(t *testing.T) {
+	tests := []struct {
+		qual rule.Quality
+		want bool
+	}{
+		{rule.QualitySecurity, true},
+		{rule.QualityReliability, true},
+		{rule.QualityMaintainability, true},
+		{"", false},
+		{"unknown", false},
+	}
+	for _, tt := range tests {
+		if got := tt.qual.Valid(); got != tt.want {
+			t.Errorf("Quality(%q).Valid() = %v, want %v", tt.qual, got, tt.want)
+		}
+	}
+}
+
+func TestDetectionValid(t *testing.T) {
+	tests := []struct {
+		det  rule.Detection
+		want bool
+	}{
+		{rule.DetectionAST, true},
+		{rule.DetectionPattern, true},
+		{rule.DetectionMetric, true},
+		{"", false},
+		{"unknown", false},
+	}
+	for _, tt := range tests {
+		if got := tt.det.Valid(); got != tt.want {
+			t.Errorf("Detection(%q).Valid() = %v, want %v", tt.det, got, tt.want)
+		}
+	}
+}
+
+func validRule() rule.Rule {
+	return rule.Rule{
+		Key:                 "valid-key",
+		Name:                "Valid Rule",
+		Language:            "General",
+		Type:                rule.TypeVulnerability,
+		Qualities:           []rule.Quality{rule.QualitySecurity},
+		DefaultSeverity:     shared.SeverityHigh,
+		Tags:                []string{"tag1", "tag2"},
+		CWE:                 []string{"CWE-79"},
+		OWASP:               []string{"A1"},
+		Description:         "desc",
+		Rationale:           "rat",
+		Remediation:         "rem",
+		CompliantExample:    "comp",
+		NoncompliantExample: "noncomp",
+		RemediationEffort:   5,
+		Detection:           rule.DetectionPattern,
+	}
+}
+
+func TestRuleValidateComplete(t *testing.T) {
+	r := validRule()
+	if err := r.Validate(); err != nil {
+		t.Errorf("expected valid rule to have no error, got %v", err)
+	}
+}
+
+func TestRuleValidateRequiredFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		modifier func(*rule.Rule)
+	}{
+		{"empty key", func(r *rule.Rule) { r.Key = "" }},
+		{"whitespace key", func(r *rule.Rule) { r.Key = "  " }},
+		{"empty name", func(r *rule.Rule) { r.Name = "  " }},
+		{"empty language", func(r *rule.Rule) { r.Language = "  " }},
+		{"empty type", func(r *rule.Rule) { r.Type = "" }},
+		{"no qualities", func(r *rule.Rule) { r.Qualities = nil }},
+		{"unknown severity", func(r *rule.Rule) { r.DefaultSeverity = "unknown" }},
+		{"empty description", func(r *rule.Rule) { r.Description = "  " }},
+		{"empty rationale", func(r *rule.Rule) { r.Rationale = "  " }},
+		{"empty remediation", func(r *rule.Rule) { r.Remediation = "  " }},
+		{"empty compliant example", func(r *rule.Rule) { r.CompliantExample = "  " }},
+		{"empty non-compliant example", func(r *rule.Rule) { r.NoncompliantExample = "  " }},
+		{"zero remediation effort", func(r *rule.Rule) { r.RemediationEffort = 0 }},
+		{"negative remediation effort", func(r *rule.Rule) { r.RemediationEffort = -5 }},
+		{"empty detection", func(r *rule.Rule) { r.Detection = "" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := validRule()
+			tt.modifier(&r)
+			if err := r.Validate(); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestRuleValidateKeyCompatibility(t *testing.T) {
+	tests := []struct {
+		key   string
+		valid bool
+	}{
+		{"weak-hash-md5", true},
+		{"aws-access-key-id", true},
+		{"terraform-rds-deletion-protection-disabled", true},
+		{"quality-high-complexity", true},
+		{"go:unhandled-error", true},
+		{"", false},
+		{" rule", false},
+		{"rule ", false},
+		{"rule key", false},
+		{"go:unhandled error", false},
+		{"rule\tkey", false},
+		{"rule\nkey", false},
+		{"rule/name", false},
+		{"rule?x", false},
+		{"rule#fragment", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			r := validRule()
+			r.Key = rule.Key(tt.key)
+			err := r.Validate()
+			if tt.valid && err != nil {
+				t.Errorf("expected valid key %q, got err: %v", tt.key, err)
+			} else if !tt.valid && err == nil {
+				t.Errorf("expected error for key %q", tt.key)
+			}
+		})
+	}
+}
+
+func TestRuleValidateTypeQualityConsistency(t *testing.T) {
+	tests := []struct {
+		name      string
+		typ       rule.Type
+		qualities []rule.Quality
+		valid     bool
+	}{
+		{"bug without reliability", rule.TypeBug, []rule.Quality{rule.QualitySecurity}, false},
+		{"vulnerability without security", rule.TypeVulnerability, []rule.Quality{rule.QualityReliability}, false},
+		{"security hotspot without security", rule.TypeSecurityHotspot, []rule.Quality{rule.QualityMaintainability}, false},
+		{"code smell without maintainability", rule.TypeCodeSmell, []rule.Quality{rule.QualityReliability}, false},
+		{"vulnerability with security + reliability", rule.TypeVulnerability, []rule.Quality{rule.QualitySecurity, rule.QualityReliability}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := validRule()
+			r.Type = tt.typ
+			r.Qualities = tt.qualities
+			err := r.Validate()
+			if tt.valid && err != nil {
+				t.Errorf("expected valid, got err: %v", err)
+			} else if !tt.valid && err == nil {
+				t.Errorf("expected error")
+			}
+		})
+	}
+}
+
+func TestRuleValidateDuplicateMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		modifier func(*rule.Rule)
+	}{
+		{"duplicate quality", func(r *rule.Rule) { r.Qualities = []rule.Quality{rule.QualitySecurity, rule.QualitySecurity} }},
+		{"duplicate tag", func(r *rule.Rule) { r.Tags = []string{"tag1", "tag1"} }},
+		{"duplicate tag differing only by case", func(r *rule.Rule) { r.Tags = []string{"tag1", "TAG1"} }},
+		{"tag with surrounding whitespace", func(r *rule.Rule) { r.Tags = []string{" tag1 "} }},
+		{"empty tag", func(r *rule.Rule) { r.Tags = []string{"  "} }},
+		{"duplicate CWE", func(r *rule.Rule) { r.CWE = []string{"CWE-1", "CWE-1"} }},
+		{"CWE with surrounding whitespace", func(r *rule.Rule) { r.CWE = []string{" CWE-1 "} }},
+		{"empty CWE", func(r *rule.Rule) { r.CWE = []string{"  "} }},
+		{"duplicate OWASP", func(r *rule.Rule) { r.OWASP = []string{"A1", "A1"} }},
+		{"OWASP with surrounding whitespace", func(r *rule.Rule) { r.OWASP = []string{" A1 "} }},
+		{"empty OWASP", func(r *rule.Rule) { r.OWASP = []string{"  "} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := validRule()
+			tt.modifier(&r)
+			if err := r.Validate(); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestRuleValidateExamplesDiffer(t *testing.T) {
+	r := validRule()
+	r.CompliantExample = "  same  "
+	r.NoncompliantExample = "same"
+	if err := r.Validate(); err == nil || !strings.Contains(err.Error(), "identical") {
+		t.Errorf("expected error about identical examples, got %v", err)
+	}
+}

--- a/internal/infrastructure/rulecatalog/catalog.go
+++ b/internal/infrastructure/rulecatalog/catalog.go
@@ -1,0 +1,69 @@
+package rulecatalog
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type Catalog struct {
+	byKey map[rule.Key]rule.Rule
+	keys  []rule.Key
+}
+
+func New(entries []rule.Rule) (*Catalog, error) {
+	byKey := make(map[rule.Key]rule.Rule, len(entries))
+	var keys []rule.Key
+
+	for _, e := range entries {
+		if err := e.Validate(); err != nil {
+			return nil, fmt.Errorf("validate rule %q: %w", e.Key, err)
+		}
+		if _, exists := byKey[e.Key]; exists {
+			return nil, fmt.Errorf("duplicate rule key %q", e.Key)
+		}
+		c := e.Clone()
+		byKey[c.Key] = c
+		keys = append(keys, c.Key)
+	}
+
+	sort.SliceStable(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+
+	return &Catalog{
+		byKey: byKey,
+		keys:  keys,
+	}, nil
+}
+
+func (c *Catalog) List(ctx context.Context) ([]rule.Rule, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	if len(c.keys) == 0 {
+		return []rule.Rule{}, nil
+	}
+
+	res := make([]rule.Rule, 0, len(c.keys))
+	for _, k := range c.keys {
+		res = append(res, c.byKey[k].Clone())
+	}
+	return res, nil
+}
+
+func (c *Catalog) Get(ctx context.Context, key rule.Key) (rule.Rule, error) {
+	if ctx.Err() != nil {
+		return rule.Rule{}, ctx.Err()
+	}
+
+	r, ok := c.byKey[key]
+	if !ok {
+		return rule.Rule{}, shared.ErrNotFound
+	}
+	return r.Clone(), nil
+}

--- a/internal/infrastructure/rulecatalog/catalog_test.go
+++ b/internal/infrastructure/rulecatalog/catalog_test.go
@@ -1,0 +1,199 @@
+package rulecatalog_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/rulecatalog"
+)
+
+func validRule(key string) rule.Rule {
+	return rule.Rule{
+		Key:                 rule.Key(key),
+		Name:                "Valid Rule",
+		Language:            "General",
+		Type:                rule.TypeVulnerability,
+		Qualities:           []rule.Quality{rule.QualitySecurity},
+		DefaultSeverity:     shared.SeverityHigh,
+		Tags:                []string{"tag1"},
+		CWE:                 []string{"CWE-79"},
+		OWASP:               []string{"A1"},
+		Description:         "desc",
+		Rationale:           "rat",
+		Remediation:         "rem",
+		CompliantExample:    "comp",
+		NoncompliantExample: "noncomp",
+		RemediationEffort:   5,
+		Detection:           rule.DetectionPattern,
+	}
+}
+
+func TestCatalogRejectsDuplicateKey(t *testing.T) {
+	entries := []rule.Rule{
+		validRule("rule-1"),
+		validRule("rule-1"),
+	}
+
+	_, err := rulecatalog.New(entries)
+	if err == nil {
+		t.Fatal("expected error for duplicate key")
+	}
+}
+
+func TestCatalogRejectsInvalidRule(t *testing.T) {
+	entry := validRule("rule-1")
+	entry.Name = ""
+
+	_, err := rulecatalog.New([]rule.Rule{entry})
+	if err == nil {
+		t.Fatal("expected invalid rule to be rejected")
+	}
+}
+
+func TestCatalogListEmpty(t *testing.T) {
+	cat, err := rulecatalog.New(nil)
+	if err != nil {
+		t.Fatalf("New empty catalog: %v", err)
+	}
+
+	got, err := cat.List(context.Background())
+	if err != nil {
+		t.Fatalf("List empty catalog: %v", err)
+	}
+
+	if got == nil {
+		t.Fatal("expected non-nil empty slice")
+	}
+
+	if len(got) != 0 {
+		t.Fatalf("expected zero rules, got %d", len(got))
+	}
+}
+
+func TestCatalogListSortedByKey(t *testing.T) {
+	entries := []rule.Rule{
+		validRule("rule-z"),
+		validRule("rule-b"),
+		validRule("rule-m"),
+		validRule("rule-a"),
+	}
+
+	cat, err := rulecatalog.New(entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	res, err := cat.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if len(res) != 4 {
+		t.Fatalf("expected 4, got %d", len(res))
+	}
+
+	if res[0].Key != "rule-a" || res[1].Key != "rule-b" || res[2].Key != "rule-m" || res[3].Key != "rule-z" {
+		t.Errorf("expected sorted keys, got %v", res)
+	}
+}
+
+func TestCatalogCopiesInput(t *testing.T) {
+	r := validRule("rule-1")
+	entries := []rule.Rule{r}
+
+	cat, err := rulecatalog.New(entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries[0].Key = "rule-2"
+	entries[0].Qualities[0] = rule.QualityReliability
+	entries[0].Tags[0] = "mutated-tag"
+	entries[0].CWE[0] = "CWE-999"
+	entries[0].OWASP[0] = "A99"
+
+	res, err := cat.Get(context.Background(), "rule-1")
+	if err != nil {
+		t.Fatalf("Get rule-1: %v", err)
+	}
+
+	if res.Tags[0] == "mutated-tag" || res.Qualities[0] == rule.QualityReliability || res.CWE[0] == "CWE-999" || res.OWASP[0] == "A99" {
+		t.Error("catalog mutated when input was mutated")
+	}
+}
+
+func TestCatalogReturnsCopies(t *testing.T) {
+	entries := []rule.Rule{validRule("rule-1")}
+	cat, err := rulecatalog.New(entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	res, err := cat.Get(context.Background(), "rule-1")
+	if err != nil {
+		t.Fatalf("Get rule-1: %v", err)
+	}
+	res.Qualities[0] = rule.QualityReliability
+	res.Tags[0] = "mutated-tag"
+	res.CWE[0] = "CWE-999"
+	res.OWASP[0] = "A99"
+
+	res2, err := cat.Get(context.Background(), "rule-1")
+	if err != nil {
+		t.Fatalf("Get rule-1: %v", err)
+	}
+	if res2.Tags[0] == "mutated-tag" || res2.Qualities[0] == rule.QualityReliability || res2.CWE[0] == "CWE-999" || res2.OWASP[0] == "A99" {
+		t.Error("catalog mutated when returned value was mutated")
+	}
+
+	listRes, err := cat.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	listRes[0].Qualities[0] = rule.QualityReliability
+	listRes[0].Tags[0] = "mutated-again"
+	listRes[0].CWE[0] = "CWE-999"
+	listRes[0].OWASP[0] = "A99"
+
+	listRes2, err := cat.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if listRes2[0].Tags[0] == "mutated-again" || listRes2[0].Qualities[0] == rule.QualityReliability || listRes2[0].CWE[0] == "CWE-999" || listRes2[0].OWASP[0] == "A99" {
+		t.Error("catalog mutated when returned list was mutated")
+	}
+}
+
+func TestCatalogContextCancellation(t *testing.T) {
+	cat, err := rulecatalog.New([]rule.Rule{validRule("rule-1")})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = cat.List(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("List expected context.Canceled, got %v", err)
+	}
+
+	_, err = cat.Get(ctx, "rule-1")
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Get expected context.Canceled, got %v", err)
+	}
+}
+
+func TestCatalogGetMissing(t *testing.T) {
+	cat, err := rulecatalog.New([]rule.Rule{validRule("rule-1")})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = cat.Get(context.Background(), "missing")
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -16,6 +16,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/importedsbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/threatmodel"
@@ -1134,4 +1135,11 @@ type LicenseFileResolver interface {
 // LicenseScanner classifies component licenses and evaluates them against policy.
 type LicenseScanner interface {
 	Scan(ctx context.Context, doc *sbom.SBOM) ([]LicenseFinding, error)
+}
+
+// RuleCatalog is the first-party immutable reference data repository for rules.
+// It is read-only.
+type RuleCatalog interface {
+	List(ctx context.Context) ([]rule.Rule, error)
+	Get(ctx context.Context, key rule.Key) (rule.Rule, error)
 }


### PR DESCRIPTION
Part of #182

## Summary

Introduce the foundational domain model and immutable registry for Synapse's first-class rule catalog.

This PR defines the canonical rule metadata contract that the remaining #182 work will use for existing-rule backfill, persisted finding rule keys, catalog APIs, and the Rules Explorer.

It intentionally does not close #182. Subsequent PRs will populate the complete first-party catalog, propagate `RuleKey` through findings, expose the read-only API, and add the web interface.

## Changes

### Rule domain

* Add the canonical `rule.Rule` domain model with:

  * stable opaque key;
  * explicit name and language;
  * issue type;
  * impacted software qualities;
  * default severity;
  * tags;
  * CWE and OWASP mappings;
  * description and rationale;
  * remediation guidance;
  * compliant and non-compliant examples;
  * remediation effort;
  * detection mode.

* Add typed enums for:

  * `bug`;
  * `vulnerability`;
  * `code_smell`;
  * `security_hotspot`;
  * `security`;
  * `reliability`;
  * `maintainability`;
  * `ast`;
  * `pattern`;
  * `metric`.

### Validation

* Preserve existing flat and prefixed rule IDs without renaming them.
* Support future analyzer-namespaced keys such as `go:unhandled-error`.
* Treat rule keys as opaque values rather than parsing metadata from them.
* Reject empty keys, whitespace, control characters, and URL route delimiters.
* Require all mandatory rule metadata.
* Reject unknown types, qualities, detection modes, and default severities.
* Reject `unknown` as a catalog default severity.
* Require at least one impacted quality.
* Enforce the minimum type-to-quality relationship:

  * bugs affect reliability;
  * vulnerabilities affect security;
  * security hotspots affect security;
  * code smells affect maintainability.
* Allow rules to affect additional qualities.
* Reject duplicate qualities.
* Reject empty, whitespace-padded, or case-insensitive duplicate tags, CWE mappings, and OWASP mappings.
* Require distinct compliant and non-compliant examples.
* Require a positive remediation-effort estimate.

### Immutable catalog

* Add a read-only in-memory rule catalog.
* Validate every rule during catalog construction.
* Reject duplicate rule keys.
* Deep-copy caller-owned rule metadata on input.
* Deep-copy rule metadata returned from `Get` and `List`.
* Sort catalog entries deterministically by rule key.
* Return a non-nil empty slice for an empty catalog.
* Preserve context cancellation.
* Return the shared not-found sentinel for unknown keys.
* Include the affected rule key in catalog-construction errors.

### Use-case port

* Add a narrow read-only `RuleCatalog` port with:

  * `List`;
  * `Get`.

* Do not add create, update, delete, enable, disable, or profile-assignment operations.

### Contributor documentation

* Synchronize the code-quality rule authoring guide with the canonical schema.
* Document explicit compliant and non-compliant examples.
* Retain impacted qualities and detection mode as separate metadata.
* Clarify that remediation effort is measured in minutes.
* Generalize namespacing from source languages to analyzer domains.
* Clarify that existing IDs remain stable.
* Clarify that language is explicit and is never derived from the rule key.

## Design decisions

### Existing IDs remain stable

Existing IDs may already be referenced by deduplication, SARIF output, profiles, quality gates, and suppressions. This PR therefore accepts existing identifiers unchanged.

New rules may use analyzer-domain namespaces, but the catalog never assumes that a key's syntax identifies its language or rule type.

### Type and quality are separate axes

`Type` describes what kind of issue a rule reports.

`Qualities` describe which Code Quality ratings the rule affects. A rule may affect more than one quality.

### Immutable reference data

The first-party catalog is read-only reference data. The registry owns copies of its entries and does not expose mutable internal slices.

This establishes deterministic behavior and prevents consumers from changing global rule metadata at runtime.

## Non-goals

This PR does not:

* populate the complete existing-rule catalog;
* rename existing rule IDs;
* add new detection rules;
* add `RuleKey` to persisted findings;
* modify finding deduplication;
* add a database migration;
* expose Rules API endpoints;
* add the Rules Explorer;
* implement Quality Profiles;
* implement Quality Gates;
* implement rule CRUD;
* add aliases;
* close #182.

## Testing

```bash
go test \
  ./internal/domain/rule \
  -count=1 \
  -v

go test \
  ./internal/infrastructure/rulecatalog \
  -count=1 \
  -v

go test -race \
  ./internal/infrastructure/rulecatalog \
  -count=1

go vet \
  ./internal/domain/rule \
  ./internal/infrastructure/rulecatalog
```

## Test coverage

* valid type, quality, and detection enums;
* unknown and empty enum values;
* complete valid rule metadata;
* required-field validation;
* existing flat rule-key compatibility;
* future namespaced rule-key compatibility;
* whitespace, control-character, and route-delimiter rejection;
* type-to-quality consistency;
* multiple impacted qualities;
* duplicate qualities;
* duplicate tags, CWE mappings, and OWASP mappings;
* case-insensitive duplicate metadata;
* surrounding-whitespace rejection;
* distinct compliant/non-compliant examples;
* duplicate catalog keys;
* invalid catalog entries;
* empty catalog behavior;
* deterministic key ordering;
* input deep-copy behavior;
* `Get` output deep-copy behavior;
* `List` output deep-copy behavior;
* context cancellation;
* missing-key behavior;
* race safety for concurrent read-only catalog access.

## Checklist

* [x] Canonical rule schema implemented
* [x] Existing rule-key compatibility preserved
* [x] Future namespaced keys supported
* [x] Type and quality modeled separately
* [x] Validation invariants added
* [x] Immutable catalog added
* [x] Deterministic ordering added
* [x] Deep-copy behavior tested
* [x] Read-only use-case port added
* [x] Contributor guide synchronized
* [x] No detector behavior changed
* [x] No persistence change
* [x] No new external dependencies
* [x] Focused tests pass
* [x] Focused race test passes
