### PR TITLE
feat(web): add inline judgment review workflow

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -442,6 +442,7 @@ function mapEvidenceItem(r: any): EvidenceItem {
   return {
     id: r.ID ?? '',
     kind: r.Kind ?? '',
+    contentBase64: r.Content ?? '',
     hash: r.Hash ?? '',
     previousHash: r.PreviousHash ?? '',
     storageRef: r.StorageRef ?? '',
@@ -589,10 +590,12 @@ function mapJudgment(r: any): Judgment {
     id: r.ID ?? '',
     engagementId: r.EngagementID ?? '',
     capability: r.Capability ?? '',
+    subjectKind: r.SubjectKind ?? '',
     subjectId: r.SubjectID ?? '',
     state: (r.State ?? 'proposed') as Judgment['state'],
     evidenceScore: r.EvidenceScore ?? 0,
     proposedBy: r.ProposedBy ?? '',
+    version: r.Version ?? 0,
     claim: r.Claim ?? {},
   }
 }
@@ -669,6 +672,28 @@ export const api = {
       throw e
     }
   },
+
+  verifyJudgment: async (
+    engagementId: string,
+    judgmentId: string,
+    score: number,
+    rationale: string,
+    version: number,
+  ): Promise<Judgment> =>
+    mapJudgment(
+      await req(
+        `/engagements/${encodeURIComponent(engagementId)}/judgments/${encodeURIComponent(judgmentId)}/verify`,
+        { method: 'POST', body: JSON.stringify({ score, rationale, version }) },
+      ),
+    ),
+
+  acceptJudgment: async (engagementId: string, judgmentId: string, version: number): Promise<Judgment> =>
+    mapJudgment(
+      await req(
+        `/engagements/${encodeURIComponent(engagementId)}/judgments/${encodeURIComponent(judgmentId)}/accept`,
+        { method: 'POST', body: JSON.stringify({ version }) },
+      ),
+    ),
 
   acceptAup: (version: string): Promise<unknown> =>
     req('/aup/accept', { method: 'POST', body: JSON.stringify({ version }) }),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -124,10 +124,12 @@ export interface Judgment {
   id: string
   engagementId: string
   capability: string // 'risk_narrative' | 'critique' | 'reachability' | 'threat' | …
+  subjectKind: string
   subjectId: string
   state: JudgmentState
   evidenceScore: number // 0..100
   proposedBy: string
+  version: number
   claim: RiskNarrativeClaim | CritiqueClaim | ReachabilityClaim | Record<string, unknown>
 }
 
@@ -321,6 +323,7 @@ export interface AupStatus {
 export interface EvidenceItem {
   id: string
   kind: string
+  contentBase64: string // sealed payload; Go encodes []byte as base64 in JSON
   hash: string
   previousHash: string
   storageRef: string // blob sha256 for an artifact; '' for a sealed summary

--- a/web/src/pages/EngagementDetail.tsx
+++ b/web/src/pages/EngagementDetail.tsx
@@ -76,6 +76,7 @@ import type {
   FindingComment,
   ImportedSBOMMetadata,
   Judgment,
+  CurrentUser,
   RiskNarrativeClaim,
   CritiqueClaim,
   ReachabilityClaim,
@@ -96,7 +97,7 @@ import { StatusPill } from './Engagements'
 // Lazy-loaded so React Flow stays out of the initial bundle (only the Graph tab needs it).
 const DependencyGraphTab = lazy(() => import('./DependencyGraph').then((m) => ({ default: m.DependencyGraphTab })))
 
-type Tab = 'overview' | 'findings' | 'components' | 'vulns' | 'licenses' | 'graph' | 'quality' | 'threats' | 'recon' | 'agent' | 'evidence' | 'settings'
+type Tab = 'overview' | 'findings' | 'components' | 'vulns' | 'licenses' | 'graph' | 'quality' | 'threats' | 'recon' | 'agent' | 'reviews' | 'evidence' | 'settings'
 
 export function EngagementDetail() {
   const { id = '' } = useParams()
@@ -267,6 +268,7 @@ export function EngagementDetail() {
         {tab === 'quality' && <CodeQualityTab engagementId={id} />}
         {tab === 'recon' && <ReconTab eng={eng} onGoTab={setTab} />}
         {tab === 'agent' && <AgentTab engagementId={id} />}
+        {tab === 'reviews' && <JudgmentReviewTab key={id} engagementId={id} />}
         {tab === 'evidence' && <EvidenceTab key={id} engagementId={id} />}
         {tab === 'settings' && <SettingsTab eng={eng} onUpdated={setEng} />}
       </div>
@@ -1136,6 +1138,7 @@ const TABS: { id: Tab; label: string; icon: typeof LayoutDashboard; countKey?: k
   { id: 'quality', label: 'Code Quality', icon: Gauge },
   { id: 'recon', label: 'Recon', icon: Radar },
   { id: 'agent', label: 'Agent', icon: Bot },
+  { id: 'reviews', label: 'Awaiting review', icon: ShieldQuestion },
   { id: 'evidence', label: 'Evidence', icon: ShieldCheck },
   { id: 'settings', label: 'Settings', icon: SlidersHorizontal },
 ]
@@ -2087,6 +2090,304 @@ function ExplainJudgments({ engagementId, findingId }: { engagementId: string; f
           </li>
         ))}
       </ul>
+    </div>
+  )
+}
+
+const GATED_JUDGMENT_CAPABILITIES = new Set(['reachability', 'sast', 'critique', 'threat', 'vex_justification'])
+
+function JudgmentClaim({ judgment }: { judgment: Judgment }) {
+  if (judgment.capability === 'reachability') return <Reachability j={judgment} />
+  if (judgment.capability === 'critique') return <Critique j={judgment} />
+  if (judgment.capability === 'risk_narrative') return <RiskNarrative j={judgment} />
+
+  return (
+    <dl className="grid grid-cols-1 gap-2 text-xs sm:grid-cols-2">
+      {Object.entries(judgment.claim).map(([key, value]) => (
+        <div key={key} className="rounded-md border border-border bg-elevated px-2.5 py-2">
+          <dt className="text-[11px] uppercase tracking-wide text-subtlefg">{key.replaceAll('_', ' ')}</dt>
+          <dd className="mt-0.5 break-words font-mono text-foreground">
+            {Array.isArray(value) ? value.join(', ') : String(value ?? '–')}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+function sealedJudgmentId(item: EvidenceItem): string {
+  if (item.kind !== 'judgment_proposed' || !item.contentBase64) return ''
+  try {
+    const bytes = Uint8Array.from(atob(item.contentBase64), (c) => c.charCodeAt(0))
+    const payload = JSON.parse(new TextDecoder().decode(bytes)) as unknown
+    if (payload && typeof payload === 'object' && 'judgment_id' in payload) {
+      const id = (payload as { judgment_id?: unknown }).judgment_id
+      return typeof id === 'string' ? id : ''
+    }
+  } catch {
+    // A malformed ledger item must not hide the rest of the review queue.
+  }
+  return ''
+}
+
+function JudgmentReviewTab({ engagementId }: { engagementId: string }) {
+  const [judgments, setJudgments] = useState<Judgment[] | null>(null)
+  const [ledger, setLedger] = useState<EvidenceLedger | null>(null)
+  const [me, setMe] = useState<CurrentUser | null | undefined>(undefined)
+  const [selected, setSelected] = useState<Judgment | null>(null)
+  const [err, setErr] = useState('')
+  const [notice, setNotice] = useState('')
+  const reviewHeadingRef = useRef<HTMLHeadingElement>(null)
+  const pendingReviewFocus = useRef<string | null>(null)
+
+  function focusReviewTrigger(id?: string) {
+    pendingReviewFocus.current = id ?? ''
+  }
+
+  useEffect(() => {
+    const id = pendingReviewFocus.current
+    if (id === null) return
+    pendingReviewFocus.current = null
+    const triggers = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-review-trigger]'))
+    const trigger = triggers.find((button) => button.dataset.reviewTrigger === id) ?? triggers[0]
+    ;(trigger ?? reviewHeadingRef.current)?.focus({ preventScroll: true })
+  }, [judgments, selected])
+
+  const load = useCallback(async () => {
+    setErr('')
+    try {
+      const [nextJudgments, nextLedger, currentUser] = await Promise.all([
+        api.judgments(engagementId),
+        api.evidenceLedger(engagementId),
+        api.me().catch(() => null),
+      ])
+      setJudgments(nextJudgments.filter((j) => j.state === 'proposed'))
+      setLedger(nextLedger)
+      setMe(currentUser)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to load judgments')
+    }
+  }, [engagementId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  async function settled(updated: Judgment) {
+    setJudgments((current) => current?.filter((j) => j.id !== updated.id) ?? current)
+    setSelected(null)
+    setNotice('')
+    focusReviewTrigger()
+    const nextLedger = await api.evidenceLedger(engagementId).catch(() => null)
+    if (nextLedger) setLedger(nextLedger)
+  }
+
+  async function conflict() {
+    const id = selected?.id
+    setSelected(null)
+    setNotice('This judgment changed; the review list was reloaded.')
+    await load()
+    focusReviewTrigger(id)
+  }
+
+  if (judgments === null && !err) return <Spinner label="Loading judgments…" />
+  if (err)
+    return (
+      <div className="space-y-3">
+        <ErrorState message={err} />
+        <Button variant="secondary" onClick={load}>Retry</Button>
+      </div>
+    )
+  if (!judgments?.length) {
+    return (
+      <div className="space-y-3">
+        <EmptyState icon={ShieldCheck} title="No judgments awaiting review" hint="All proposed judgments have been settled." />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 ref={reviewHeadingRef} tabIndex={-1} className="text-lg font-semibold text-foreground">Judgments awaiting review</h2>
+        <p className="mt-1 text-sm text-mutedfg">
+          Verify evidence-gated claims or accept descriptive claims. The server records every decision in the evidence chain.
+        </p>
+      </div>
+      {notice && <p role="status" className="text-sm text-accent">{notice}</p>}
+      {!ledger?.intact && (
+        <p role="alert" className="flex items-center gap-2 text-sm text-critical">
+          <AlertTriangle className="size-4" /> Evidence chain integrity check failed.
+        </p>
+      )}
+      <ul role="list" className="space-y-3">
+        {judgments.map((judgment) => {
+          const gated = GATED_JUDGMENT_CAPABILITIES.has(judgment.capability)
+          const evidence = ledger?.items.find((item) => sealedJudgmentId(item) === judgment.id)
+          const blockedReason =
+            me === undefined
+              ? 'Loading reviewer identity…'
+              : me === null
+                ? 'Reviewer identity is unavailable.'
+                : me.id === judgment.proposedBy
+                  ? 'The proposer cannot review their own judgment.'
+                  : me.role !== 'admin' && me.role !== 'reviewer'
+                    ? 'Reviewer permission is required.'
+                    : ''
+          return (
+            <li
+              key={judgment.id}
+              onClick={(event) => {
+                if (blockedReason || (event.target as HTMLElement).closest('button, input, textarea, label, select, a')) return
+                setSelected(judgment)
+              }}
+              onKeyDown={(event) => {
+                if (blockedReason || event.target !== event.currentTarget || (event.key !== 'Enter' && event.key !== ' ')) return
+                event.preventDefault()
+                setSelected(judgment)
+              }}
+              tabIndex={blockedReason ? undefined : 0}
+            >
+              <Card bodyClass="p-4" className={cn(!blockedReason && 'cursor-pointer hover:border-borderstrong')}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium capitalize text-foreground">{judgment.capability.replaceAll('_', ' ')}</span>
+                      <JudgmentStateBadge state={judgment.state} />
+                      <Pill>{gated ? 'evidence-gated' : 'human acceptance'}</Pill>
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-mutedfg">
+                      <span>{judgment.subjectKind || 'subject'}: <span className="break-all font-mono text-foreground">{judgment.subjectId}</span></span>
+                      <span>proposed by <span className="font-mono text-foreground">{judgment.proposedBy}</span></span>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <Button
+                      variant="secondary"
+                      data-review-trigger={judgment.id}
+                      aria-expanded={selected?.id === judgment.id}
+                      aria-controls={`judgment-review-${judgment.id}`}
+                      disabled={Boolean(blockedReason)}
+                      title={blockedReason || undefined}
+                      onClick={() => setSelected(judgment)}
+                      className="px-3 py-1.5"
+                    >
+                      {gated ? <ShieldCheck className="size-4" /> : <CheckCircle2 className="size-4" />}
+                      {gated ? 'Verify' : 'Accept'}
+                    </Button>
+                    {blockedReason && <p className="mt-1 max-w-64 text-xs text-subtlefg">{blockedReason}</p>}
+                  </div>
+                </div>
+                <div className="mt-4 rounded-lg border border-border bg-bg p-3">
+                  <JudgmentClaim judgment={judgment} />
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-mutedfg">
+                  {evidence ? (
+                    <>
+                      <span className="flex items-center gap-1.5 text-accent"><ShieldCheck className="size-3.5" /> Sealed proposal</span>
+                      <span className="font-mono" title={evidence.hash}>sha256 {evidence.hash.slice(0, 12)}</span>
+                      <span>by {evidence.createdBy}</span>
+                      <span>{evidence.createdAt ? new Date(evidence.createdAt).toLocaleString() : '–'}</span>
+                    </>
+                  ) : (
+                    <span className="flex items-center gap-1.5 text-medium"><ShieldQuestion className="size-3.5" /> Sealed proposal evidence unavailable</span>
+                  )}
+                </div>
+                {selected?.id === judgment.id && (
+                  <JudgmentReviewForm
+                    engagementId={engagementId}
+                    judgment={judgment}
+                    onCancel={() => {
+                      setSelected(null)
+                      focusReviewTrigger(judgment.id)
+                    }}
+                    onSettled={settled}
+                    onConflict={conflict}
+                  />
+                )}
+              </Card>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+function JudgmentReviewForm({
+  engagementId,
+  judgment,
+  onCancel,
+  onSettled,
+  onConflict,
+}: {
+  engagementId: string
+  judgment: Judgment
+  onCancel: () => void
+  onSettled: (judgment: Judgment) => void
+  onConflict: () => void
+}) {
+  const gated = GATED_JUDGMENT_CAPABILITIES.has(judgment.capability)
+  const [score, setScore] = useState(90)
+  const [rationale, setRationale] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+
+  async function submit() {
+    setBusy(true)
+    setErr('')
+    try {
+      const updated = gated
+        ? await api.verifyJudgment(engagementId, judgment.id, score, rationale.trim(), judgment.version)
+        : await api.acceptJudgment(engagementId, judgment.id, judgment.version)
+      onSettled(updated)
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) onConflict()
+      else setErr(e instanceof ApiError ? e.message : `${gated ? 'Verify' : 'Accept'} failed`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div id={`judgment-review-${judgment.id}`} className="mt-4 border-t border-border pt-4">
+      {gated ? (
+        <div className="space-y-3">
+          <p className="text-xs text-mutedfg">
+            Record an adversarial verdict. Scores ≥ {EVIDENCE_BAR} confirm this claim; lower scores refute it. Either outcome is sealed.
+          </p>
+          <Field label="Evidence score" hint="0–100">
+            <Input
+              type="number"
+              min={0}
+              max={100}
+              value={score}
+              onChange={(e) => setScore(Math.max(0, Math.min(100, Number(e.target.value))))}
+            />
+          </Field>
+          <Field label="Rationale">
+            <textarea
+              value={rationale}
+              onChange={(e) => setRationale(e.target.value)}
+              rows={4}
+              placeholder="How the claim was reproduced or refuted"
+              className="w-full rounded-lg border border-border bg-elevated px-3 py-2 text-sm text-foreground placeholder:text-subtlefg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand/40"
+            />
+          </Field>
+        </div>
+      ) : (
+        <p className="text-sm text-mutedfg">
+          Accept this descriptive claim as reviewed. The acceptance is sealed into the evidence chain.
+        </p>
+      )}
+
+      {err && <p role="alert" className="mt-3 text-sm text-critical">{err}</p>}
+      <div className="mt-4 flex justify-end gap-2">
+        <Button variant="ghost" disabled={busy} onClick={onCancel}>Cancel</Button>
+        <Button loading={busy} disabled={gated && !rationale.trim()} onClick={submit}>
+          {gated ? 'Seal verdict' : 'Accept judgment'}
+        </Button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

<img width="1491" height="757" alt="Screenshot 2026-07-13 014650" src="https://github.com/user-attachments/assets/30ee672b-4ae1-4e09-9ab4-d213acda7b84" />

Implements the reviewer workflow requested in [#159](https://github.com/KKloudTarus/synapse-ce/issues/159): reviewers can resolve proposed AI judgments from the engagement dashboard without leaving the relevant claim and evidence context.

Closes #159

## Changes

### API client

- Add `api.verifyJudgment(engagementId, judgmentId, score, rationale, version)`.
  - Sends `POST /api/v1/engagements/{id}/judgments/{jid}/verify`.
  - Supports the server’s evidence score, rationale, and optimistic-concurrency version contract.
- Add `api.acceptJudgment(engagementId, judgmentId, version)`.
  - Sends `POST /api/v1/engagements/{id}/judgments/{jid}/accept`.
  - Supports accepting ungated descriptive claims.

### Reviewer queue

- Add an **Awaiting review** tab to the engagement detail view.
- Load proposed judgments, the current reviewer identity, and the evidence ledger together.
- Display each judgment’s:
  - capability and proposal state;
  - gated versus human-acceptance requirement;
  - subject kind and subject identifier;
  - proposer identity;
  - typed claim fields;
  - sealed proposal evidence hash, creator, and timestamp;
  - evidence-unavailable warning where no matching sealed proposal exists.

### Review actions

- Render the review form inline within the selected judgment card.
- Gated capabilities (`reachability`, `sast`, `critique`, `threat`, `vex_justification`) require:
  - a bounded 0–100 evidence score;
  - a non-empty rationale;
  - a sealed verify action.
- Ungated capabilities (`risk_narrative`, `correlation`) provide explicit human acceptance.
- Remove settled judgments from the pending queue and refresh the evidence ledger.
- Handle stale versions by reloading the queue after a `409 Conflict`.

### Authorization and accessibility

- Disable actions while the reviewer identity is loading or unavailable.
- Prevent self-review when the current reviewer matches `proposedBy`.
- Disable actions for users without `admin` or `reviewer` capability.
- Make reviewable cards expandable with mouse, Enter, or Space.
- Expose inline form state with `aria-expanded` and `aria-controls`.
- Restore focus to the relevant action after cancel/conflict, or to the next available review action after settlement.
- Use `preventScroll` for focus changes so accepting a lower card does not jump the review list to the top.
- Add explicit long-token wrapping for subject IDs on narrow viewports.

## Validation

- `npm --prefix web run typecheck`
- `npm --prefix web run build`
- Local Docker stack rebuilt successfully with:

  ```bash
  docker compose --env-file deploy/.env -f deploy/docker-compose.full.yml up -d --build
  ```

- Chrome DevTools local UI validation covered:
  - inline review expansion through card click and action button;
  - keyboard expansion through Enter and Space;
  - `aria-expanded` / `aria-controls`;
  - ungated accept API request returning `200`;
  - settled card removal;
  - no success-message residue after settlement;
  - preserved review-list scroll position;
  - no horizontal page overflow at a 390px viewport.

## Checklist

- [ ] `make build vet test typecheck` passes
- [x] `cd web && pnpm build` passes (if the dashboard changed)
- [ ] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets
      out of logs, deterministic reports, append-only evidence) – see CONTRIBUTING.md
- [ ] Documentation updated if needed
