### PR TITLE
Feat/finding rule key

### DIFF
--- a/internal/domain/finding/finding.go
+++ b/internal/domain/finding/finding.go
@@ -2,7 +2,9 @@
 package finding
 
 import (
+	"errors"
 	"strings"
+	"unicode"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/verdict"
@@ -17,6 +19,12 @@ const (
 	StatusConfirmed  Status = "confirmed"
 	StatusFalsePos   Status = "false_positive"
 	StatusRemediated Status = "remediated"
+)
+
+var (
+	ErrRuleKeyRequired  = errors.New("rule key is required")
+	ErrRuleKeyForbidden = errors.New("rule key is not allowed")
+	ErrRuleKeyInvalid   = errors.New("rule key is invalid")
 )
 
 // Finding classes: third-party findings are actionable; first-party
@@ -61,6 +69,15 @@ func (k Kind) Valid() bool {
 	return false
 }
 
+// IsRuleBased reports whether k is a kind that requires a catalog rule key.
+func (k Kind) IsRuleBased() bool {
+	switch k {
+	case KindSAST, KindSecret, KindMisconfig, KindQuality, KindReliability:
+		return true
+	}
+	return false
+}
+
 // Valid reports whether s is a known triage status.
 func (s Status) Valid() bool {
 	switch s {
@@ -85,6 +102,9 @@ type Finding struct {
 	// manual); it drives promotion gating. Empty is treated as KindSCA for
 	// backward compatibility with legacy rows.
 	Kind Kind
+
+	// RuleKey is the stable catalog rule identifier emitted by the producer.
+	RuleKey string
 
 	// Workflow: the human assignee, and an optimistic-concurrency version that
 	// Kanban/status/assignee edits check to prevent lost updates.
@@ -190,4 +210,27 @@ func Publishable(in []Finding) []Finding {
 		}
 	}
 	return out
+}
+
+// ValidateRuleKey enforces the structural invariant for rule keys: rule-based
+// findings must have a valid key, non-rule findings must have an empty key.
+func (f Finding) ValidateRuleKey() error {
+	if !f.Kind.IsRuleBased() {
+		if f.RuleKey != "" {
+			return ErrRuleKeyForbidden
+		}
+		return nil
+	}
+
+	if f.RuleKey == "" {
+		return ErrRuleKeyRequired
+	}
+
+	for _, r := range f.RuleKey {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return ErrRuleKeyInvalid
+		}
+	}
+
+	return nil
 }

--- a/internal/domain/finding/finding_test.go
+++ b/internal/domain/finding/finding_test.go
@@ -106,3 +106,55 @@ func TestMeetsEvidenceBar(t *testing.T) {
 		}
 	}
 }
+
+func TestIsRuleBased(t *testing.T) {
+	for _, k := range []Kind{KindSAST, KindSecret, KindMisconfig, KindQuality, KindReliability} {
+		if !k.IsRuleBased() {
+			t.Errorf("Kind %q should be rule-based", k)
+		}
+	}
+	for _, k := range []Kind{"", KindSCA, KindRecon, KindExploitation, KindManual, KindDAST, KindThreat, KindHypothesis, "unknown"} {
+		if k.IsRuleBased() {
+			t.Errorf("Kind %q should not be rule-based", k)
+		}
+	}
+}
+
+func TestValidateRuleKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		kind    Kind
+		ruleKey string
+		wantErr error
+	}{
+		{"valid sast", KindSAST, "go:sql-injection", nil},
+		{"valid secret", KindSecret, "aws-key", nil},
+		{"valid misconfig", KindMisconfig, "tf.s3.public", nil},
+		{"valid quality", KindQuality, "quality-duplicated-block", nil},
+		{"valid reliability", KindReliability, "reliability-empty-catch", nil},
+		{"empty rule-based", KindSAST, "", ErrRuleKeyRequired},
+		{"empty non-rule", KindSCA, "", nil},
+		{"empty kind (treated as sca)", "", "", nil},
+		{"non-empty sca", KindSCA, "some-key", ErrRuleKeyForbidden},
+		{"non-empty unknown", "unknown", "key", ErrRuleKeyForbidden},
+		{"leading space", KindSAST, " key", ErrRuleKeyInvalid},
+		{"trailing space", KindSAST, "key ", ErrRuleKeyInvalid},
+		{"tab", KindSAST, "my\tkey", ErrRuleKeyInvalid},
+		{"newline", KindSAST, "my\nkey", ErrRuleKeyInvalid},
+		{"unicode space", KindSAST, "my\u2000key", ErrRuleKeyInvalid},
+		{"control", KindSAST, "my\x00key", ErrRuleKeyInvalid},
+		{"hyphen", KindSAST, "my-key", nil},
+		{"underscore", KindSAST, "my_key", nil},
+		{"slash", KindSAST, "my/key", nil},
+		{"dot", KindSAST, "my.key", nil},
+		{"colon future", KindSAST, "go:sql-injection", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := Finding{Kind: c.kind, RuleKey: c.ruleKey}
+			if err := f.ValidateRuleKey(); err != c.wantErr {
+				t.Errorf("Kind %q RuleKey %q: got %v, want %v", c.kind, c.ruleKey, err, c.wantErr)
+			}
+		})
+	}
+}

--- a/internal/domain/finding/sast.go
+++ b/internal/domain/finding/sast.go
@@ -60,6 +60,7 @@ func NewSAST(id, engagementID shared.ID, in SASTInput, now time.Time) (Finding, 
 		Priority:     priorityForSeverity(sev),
 		Status:       StatusOpen,
 		Kind:         KindSAST,
+		RuleKey:      rule,
 		DedupKey:     "sast:ai:" + anchor,
 		// ProposedBy LEFT EMPTY (the judgment-layer gate already ran) – see the doc above.
 		Version: 1,

--- a/internal/domain/finding/sast_test.go
+++ b/internal/domain/finding/sast_test.go
@@ -31,6 +31,9 @@ func TestNewSAST(t *testing.T) {
 	if f.ProposedBy != "" {
 		t.Errorf("ProposedBy must be empty (the gate ran at the judgment layer) – else the projection is re-gated stuck-at-0, got %q", f.ProposedBy)
 	}
+	if f.RuleKey != "taint-sqli" {
+		t.Errorf("RuleKey must match the supplied rule, got %q", f.RuleKey)
+	}
 	// The title is templated from the structured fields (no LLM prose).
 	if want := "Taint: taint-sqli (CWE-89) at app/dao.Find"; f.Title != want {
 		t.Errorf("title must be templated, want %q got %q", want, f.Title)

--- a/internal/infrastructure/persistence/memory/finding_repo.go
+++ b/internal/infrastructure/persistence/memory/finding_repo.go
@@ -28,6 +28,9 @@ var _ ports.FindingRepository = (*FindingRepository)(nil)
 // Upsert inserts or updates findings, deduped by (engagement, dedup key). On
 // update it preserves the existing triage status + created timestamp.
 func (r *FindingRepository) Upsert(_ context.Context, findings []finding.Finding) error {
+	if err := validateFindingBatch(findings); err != nil {
+		return err
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, f := range findings {
@@ -145,4 +148,15 @@ func (r *FindingRepository) ListPublishableByEngagement(ctx context.Context, eng
 		return nil, err
 	}
 	return finding.Publishable(all), nil
+}
+
+// validateFindingBatch asserts domain invariants (like RuleKey constraints) for a
+// batch before writing to the database. An atomic failure prevents partial writes.
+func validateFindingBatch(findings []finding.Finding) error {
+	for _, f := range findings {
+		if err := f.ValidateRuleKey(); err != nil {
+			return fmt.Errorf("finding %s (kind %s): %w", f.DedupKey, f.Kind, err)
+		}
+	}
+	return nil
 }

--- a/internal/infrastructure/persistence/memory/finding_repo_test.go
+++ b/internal/infrastructure/persistence/memory/finding_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -50,55 +51,72 @@ func TestFindingRepositoryUpsertDedup(t *testing.T) {
 func TestFindingRepositoryRuleKey(t *testing.T) {
 	r := NewFindingRepository()
 	ctx := context.Background()
+	now := time.Now().UTC()
 
-	// 1. Initial insert with RuleKey
-	f1 := finding.Finding{
-		ID: "f1", EngagementID: "e1", Title: "SAST issue", Kind: finding.KindSAST,
-		RuleKey: "go:sql-injection", DedupKey: "sast:go:sql-injection:main.go:1",
+	// 1. Validation rejection of batch with one invalid
+	valid := finding.Finding{ID: "f1", EngagementID: "e1", Kind: finding.KindSAST, RuleKey: "good", DedupKey: "sast:good:1"}
+	invalid := finding.Finding{ID: "f2", EngagementID: "e1", Kind: finding.KindSAST, RuleKey: "bad ", DedupKey: "sast:bad:2"} // space
+	err := r.Upsert(ctx, []finding.Finding{valid, invalid})
+	if err == nil || !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("expected validation error for invalid batch, got %v", err)
 	}
-	if err := r.Upsert(ctx, []finding.Finding{f1}); err != nil {
+	l, _ := r.ListByEngagement(ctx, "e1")
+	if len(l) != 0 {
+		t.Errorf("repository should be empty after failed batch, got %d", len(l))
+	}
+
+	// 2. Non-rule finding with RuleKey rejected
+	nonRule := finding.Finding{ID: "f3", EngagementID: "e1", Kind: finding.KindSCA, RuleKey: "should-be-empty", DedupKey: "sca:1"}
+	if err := r.Upsert(ctx, []finding.Finding{nonRule}); err == nil {
+		t.Error("non-rule finding with RuleKey should be rejected")
+	}
+
+	// 3. Conflict healing: legacy blank RuleKey gets updated by new upsert
+	// Simulate legacy blank by directly injecting it with some triage fields
+	r.data["e1"] = map[string]finding.Finding{}
+	r.data["e1"]["sast:legacy:main.go:2"] = finding.Finding{
+		ID: "f4", EngagementID: "e1", Kind: finding.KindSAST, DedupKey: "sast:legacy:main.go:2",
+		RuleKey: "", // legacy blank
+		Status:  finding.StatusConfirmed, Assignee: "alice", EvidenceScore: 100, Audit: shared.Audit{CreatedAt: now},
+	}
+
+	// Scanner re-runs and upserts with the correct key
+	f4Scan := finding.Finding{
+		ID: "f4", EngagementID: "e1", Kind: finding.KindSAST, DedupKey: "sast:legacy:main.go:2",
+		RuleKey: "legacy-rule",
+	}
+	if err := r.Upsert(ctx, []finding.Finding{f4Scan}); err != nil {
 		t.Fatal(err)
 	}
 
 	list, _ := r.ListByEngagement(ctx, "e1")
-	if len(list) != 1 || list[0].RuleKey != "go:sql-injection" {
-		t.Fatalf("want RuleKey 'go:sql-injection', got %+v", list)
-	}
-
-	// 2. Conflict healing: legacy blank RuleKey gets updated by new upsert
-	// Simulate legacy blank by directly injecting it
-	r.data["e1"]["sast:legacy:main.go:2"] = finding.Finding{
-		ID: "f2", EngagementID: "e1", Kind: finding.KindSAST, DedupKey: "sast:legacy:main.go:2",
-		RuleKey: "", // legacy blank
-	}
-
-	// Scanner re-runs and upserts with the correct key
-	f2 := finding.Finding{
-		ID: "f2", EngagementID: "e1", Kind: finding.KindSAST, DedupKey: "sast:legacy:main.go:2",
-		RuleKey: "legacy-rule",
-	}
-	if err := r.Upsert(ctx, []finding.Finding{f2}); err != nil {
-		t.Fatal(err)
-	}
-
-	list, _ = r.ListByEngagement(ctx, "e1")
 	var healed *finding.Finding
 	for i := range list {
-		if list[i].ID == "f2" {
+		if list[i].ID == "f4" {
 			healed = &list[i]
 		}
 	}
-	if healed == nil || healed.RuleKey != "legacy-rule" {
+	if healed == nil {
+		t.Fatal("expected healed finding")
+	}
+	if healed.RuleKey != "legacy-rule" {
 		t.Errorf("RuleKey should heal on conflict, got %q", healed.RuleKey)
 	}
-
-	// 3. Validation rejection
-	bad := finding.Finding{
-		ID: "f3", EngagementID: "e1", Kind: finding.KindSecret, DedupKey: "secret:bad",
-		RuleKey: " bad ", // invalid spaces
+	if healed.Status != finding.StatusConfirmed || healed.Assignee != "alice" || healed.EvidenceScore != 100 || !healed.Audit.CreatedAt.Equal(now) {
+		t.Errorf("triage fields should be preserved, got %+v", healed)
 	}
-	err := r.Upsert(ctx, []finding.Finding{bad})
-	if err == nil || !strings.Contains(err.Error(), "rule key is invalid") {
-		t.Errorf("expected validation error, got %v", err)
+
+	// 4. Update methods do not lose RuleKey
+	fUpd, err := r.UpdateStatus(ctx, "e1", "f4", finding.StatusFalsePos, healed.Version)
+	if err != nil || fUpd.RuleKey != "legacy-rule" {
+		t.Errorf("UpdateStatus must preserve RuleKey, got %q (err: %v)", fUpd.RuleKey, err)
+	}
+	fUpd, err = r.SetAssignee(ctx, "e1", "f4", "charlie", fUpd.Version)
+	if err != nil || fUpd.RuleKey != "legacy-rule" {
+		t.Errorf("SetAssignee must preserve RuleKey, got %q (err: %v)", fUpd.RuleKey, err)
+	}
+	fUpd, err = r.SetEvidenceScore(ctx, "e1", "f4", 50, fUpd.Version)
+	if err != nil || fUpd.RuleKey != "legacy-rule" {
+		t.Errorf("SetEvidenceScore must preserve RuleKey, got %q (err: %v)", fUpd.RuleKey, err)
 	}
 }

--- a/internal/infrastructure/persistence/memory/finding_repo_test.go
+++ b/internal/infrastructure/persistence/memory/finding_repo_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -43,5 +44,61 @@ func TestFindingRepositoryUpsertDedup(t *testing.T) {
 	// other engagements isolated
 	if l, _ := r.ListByEngagement(ctx, "other"); len(l) != 0 {
 		t.Errorf("other engagement should have no findings, got %d", len(l))
+	}
+}
+
+func TestFindingRepositoryRuleKey(t *testing.T) {
+	r := NewFindingRepository()
+	ctx := context.Background()
+
+	// 1. Initial insert with RuleKey
+	f1 := finding.Finding{
+		ID: "f1", EngagementID: "e1", Title: "SAST issue", Kind: finding.KindSAST,
+		RuleKey: "go:sql-injection", DedupKey: "sast:go:sql-injection:main.go:1",
+	}
+	if err := r.Upsert(ctx, []finding.Finding{f1}); err != nil {
+		t.Fatal(err)
+	}
+
+	list, _ := r.ListByEngagement(ctx, "e1")
+	if len(list) != 1 || list[0].RuleKey != "go:sql-injection" {
+		t.Fatalf("want RuleKey 'go:sql-injection', got %+v", list)
+	}
+
+	// 2. Conflict healing: legacy blank RuleKey gets updated by new upsert
+	// Simulate legacy blank by directly injecting it
+	r.data["e1"]["sast:legacy:main.go:2"] = finding.Finding{
+		ID: "f2", EngagementID: "e1", Kind: finding.KindSAST, DedupKey: "sast:legacy:main.go:2",
+		RuleKey: "", // legacy blank
+	}
+
+	// Scanner re-runs and upserts with the correct key
+	f2 := finding.Finding{
+		ID: "f2", EngagementID: "e1", Kind: finding.KindSAST, DedupKey: "sast:legacy:main.go:2",
+		RuleKey: "legacy-rule",
+	}
+	if err := r.Upsert(ctx, []finding.Finding{f2}); err != nil {
+		t.Fatal(err)
+	}
+
+	list, _ = r.ListByEngagement(ctx, "e1")
+	var healed *finding.Finding
+	for i := range list {
+		if list[i].ID == "f2" {
+			healed = &list[i]
+		}
+	}
+	if healed == nil || healed.RuleKey != "legacy-rule" {
+		t.Errorf("RuleKey should heal on conflict, got %q", healed.RuleKey)
+	}
+
+	// 3. Validation rejection
+	bad := finding.Finding{
+		ID: "f3", EngagementID: "e1", Kind: finding.KindSecret, DedupKey: "secret:bad",
+		RuleKey: " bad ", // invalid spaces
+	}
+	err := r.Upsert(ctx, []finding.Finding{bad})
+	if err == nil || !strings.Contains(err.Error(), "rule key is invalid") {
+		t.Errorf("expected validation error, got %v", err)
 	}
 }

--- a/internal/infrastructure/persistence/postgres/finding_repo.go
+++ b/internal/infrastructure/persistence/postgres/finding_repo.go
@@ -17,7 +17,7 @@ import (
 // findingCols is the SELECT/RETURNING projection scanned by scanFinding.
 const findingCols = `id, engagement_id, title, description, severity, cvss_vector, cwe, status, evidence_score, ` +
 	`COALESCE(dedup_key, ''), kev, risk_score, created_at, updated_at, sources, confidence, class, scope, ` +
-	`reachability, impact, priority, kind, assignee, version, proposed_by, class_reachability`
+	`reachability, impact, priority, kind, assignee, version, proposed_by, class_reachability, rule_key`
 
 // FindingRepository persists findings to PostgreSQL, deduped per engagement.
 type FindingRepository struct{ pool *pgxpool.Pool }
@@ -34,6 +34,9 @@ var _ ports.FindingRepository = (*FindingRepository)(nil)
 // and created_at – and bumps version (a re-scan IS a concurrent change) – so human
 // triage state is never clobbered.
 func (r *FindingRepository) Upsert(ctx context.Context, findings []finding.Finding) error {
+	if err := validateFindingBatch(findings); err != nil {
+		return err
+	}
 	if len(findings) == 0 {
 		return nil
 	}
@@ -48,20 +51,20 @@ func (r *FindingRepository) Upsert(ctx context.Context, findings []finding.Findi
 		// tenant-scoped engagement gate; deriving this row's tenant_id from the engagement
 		// is a remaining row-level follow-up and does not affect read isolation today.
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO findings (id, tenant_id, engagement_id, title, description, severity, cvss_vector, cwe, status, evidence_score, dedup_key, kev, risk_score, created_at, updated_at, sources, confidence, class, scope, reachability, impact, priority, kind, assignee, version, proposed_by, class_reachability)
-			 VALUES ($1, '', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
+			`INSERT INTO findings (id, tenant_id, engagement_id, title, description, severity, cvss_vector, cwe, status, evidence_score, dedup_key, kev, risk_score, created_at, updated_at, sources, confidence, class, scope, reachability, impact, priority, kind, assignee, version, proposed_by, class_reachability, rule_key)
+			 VALUES ($1, '', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
 			 ON CONFLICT (engagement_id, dedup_key) WHERE dedup_key IS NOT NULL
 			 DO UPDATE SET title = EXCLUDED.title, description = EXCLUDED.description,
 			               severity = EXCLUDED.severity, cvss_vector = EXCLUDED.cvss_vector, kev = EXCLUDED.kev, risk_score = EXCLUDED.risk_score,
 			               sources = EXCLUDED.sources, confidence = EXCLUDED.confidence, class = EXCLUDED.class,
 			               scope = EXCLUDED.scope, reachability = EXCLUDED.reachability, impact = EXCLUDED.impact, priority = EXCLUDED.priority,
 			               kind = EXCLUDED.kind, class_reachability = EXCLUDED.class_reachability,
-			               updated_at = EXCLUDED.updated_at`,
+			               rule_key = EXCLUDED.rule_key, updated_at = EXCLUDED.updated_at`,
 			f.ID.String(), f.EngagementID.String(), f.Title, f.Description, string(f.Severity),
 			f.CVSSVector, f.CWE, string(f.Status), f.EvidenceScore, f.DedupKey,
 			f.KEV, f.RiskScore, f.Audit.CreatedAt, f.Audit.UpdatedAt, strings.Join(f.Sources, ","), f.Confidence, classOrDefault(f.Class),
 			scopeOrDefault(f.Scope), reachOrDefault(f.Reachability), f.Impact, priorityOrDefault(f.Priority), kindOrDefault(string(f.Kind)),
-			f.Assignee, versionOrDefault(f.Version), f.ProposedBy, f.ClassReachability); err != nil {
+			f.Assignee, versionOrDefault(f.Version), f.ProposedBy, f.ClassReachability, f.RuleKey); err != nil {
 			return fmt.Errorf("upsert finding: %w", err)
 		}
 	}
@@ -186,7 +189,7 @@ func scanFinding(row rowScanner) (finding.Finding, error) {
 	if err := row.Scan(&id, &eid, &f.Title, &f.Description, &sev, &f.CVSSVector, &f.CWE,
 		&status, &f.EvidenceScore, &dedup, &f.KEV, &f.RiskScore, &f.Audit.CreatedAt, &f.Audit.UpdatedAt,
 		&sources, &f.Confidence, &f.Class, &f.Scope, &f.Reachability, &f.Impact, &f.Priority, &kind,
-		&f.Assignee, &f.Version, &f.ProposedBy, &f.ClassReachability); err != nil {
+		&f.Assignee, &f.Version, &f.ProposedBy, &f.ClassReachability, &f.RuleKey); err != nil {
 		return finding.Finding{}, err
 	}
 	f.ID = shared.ID(id)
@@ -249,4 +252,15 @@ func splitSources(s string) []string {
 		return nil
 	}
 	return strings.Split(s, ",")
+}
+
+// validateFindingBatch asserts domain invariants (like RuleKey constraints) for a
+// batch before writing to the database. An atomic failure prevents partial writes.
+func validateFindingBatch(findings []finding.Finding) error {
+	for _, f := range findings {
+		if err := f.ValidateRuleKey(); err != nil {
+			return fmt.Errorf("finding %s (kind %s): %w", f.DedupKey, f.Kind, err)
+		}
+	}
+	return nil
 }

--- a/internal/infrastructure/persistence/postgres/finding_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/finding_repo_test.go
@@ -103,7 +103,7 @@ func TestFindingRepository(t *testing.T) {
 	}
 
 	// RuleKey enhancements:
-	// 4. Mixed valid/invalid batch không tạo partial rows.
+	// Mixed valid/invalid batch prevents partial inserts.
 	fidValid := shared.ID("fid-" + randHex(t))
 	fidInvalid := shared.ID("fid-" + randHex(t))
 	validF := finding.Finding{ID: fidValid, EngagementID: eid, Kind: finding.KindSAST, DedupKey: "sast:valid", RuleKey: "valid"}
@@ -113,13 +113,15 @@ func TestFindingRepository(t *testing.T) {
 	}
 	// Verify neither were inserted
 	var count int
-	pool.QueryRow(ctx, "SELECT count(*) FROM findings WHERE id IN ($1, $2)", fidValid, fidInvalid).Scan(&count)
+	if err := pool.QueryRow(ctx, "SELECT count(*) FROM findings WHERE id IN ($1, $2)", fidValid, fidInvalid).Scan(&count); err != nil {
+		t.Fatalf("count partial rows: %v", err)
+	}
 	if count != 0 {
 		t.Errorf("expected 0 partial rows, got %d", count)
 	}
 
-	// 5. Non-rule finding với empty RuleKey persist bình thường.
-	// 6. Non-rule finding với non-empty RuleKey bị từ chối.
+	// Non-rule findings with empty RuleKey persist normally.
+	// Non-rule findings with non-empty RuleKey are rejected.
 	nonRuleValid := finding.Finding{ID: shared.ID("fid-" + randHex(t)), EngagementID: eid, Kind: finding.KindSCA, DedupKey: "sca:1", RuleKey: ""}
 	nonRuleInvalid := finding.Finding{ID: shared.ID("fid-" + randHex(t)), EngagementID: eid, Kind: finding.KindManual, DedupKey: "manual:1", RuleKey: "bad"}
 	if err := repo.Upsert(ctx, []finding.Finding{nonRuleValid}); err != nil {
@@ -129,10 +131,8 @@ func TestFindingRepository(t *testing.T) {
 		t.Error("non-rule finding with non-empty RuleKey should be rejected")
 	}
 
-	// 7. Legacy rule-based row với blank RuleKey vẫn đọc được.
-	// 2. Existing blank RuleKey được scan mới chữa.
-	// 3. Triage fields vẫn được giữ.
-	// 1. Conflict upsert cập nhật RuleKey.
+	// Conflict healing: legacy rule-based rows with a blank RuleKey can still be read.
+	// A new scan with a valid RuleKey heals the missing key while preserving existing triage fields.
 	fidLegacy := shared.ID("fid-" + randHex(t))
 	_, err = pool.Exec(ctx,
 		`INSERT INTO findings (id, tenant_id, engagement_id, title, description, severity, cvss_vector, cwe, status, evidence_score, dedup_key, kev, risk_score, created_at, updated_at, sources, confidence, class, scope, reachability, impact, priority, kind, assignee, version, proposed_by, class_reachability, rule_key)
@@ -174,9 +174,7 @@ func TestFindingRepository(t *testing.T) {
 		t.Errorf("triage fields should be preserved: status=%v, assignee=%v, evidence=%v", healed.Status, healed.Assignee, healed.EvidenceScore)
 	}
 
-	// 8. UpdateStatus trả và giữ RuleKey.
-	// 9. SetAssignee trả và giữ RuleKey.
-	// 10. SetEvidenceScore trả và giữ RuleKey.
+	// Triage methods correctly return and preserve the finding's RuleKey.
 	fUpd, err := repo.UpdateStatus(ctx, eid, fidLegacy, finding.StatusFalsePos, healed.Version)
 	if err != nil || fUpd.RuleKey != "healed-rule" {
 		t.Errorf("UpdateStatus must preserve RuleKey, got %q (err: %v)", fUpd.RuleKey, err)

--- a/internal/infrastructure/persistence/postgres/finding_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/finding_repo_test.go
@@ -102,32 +102,91 @@ func TestFindingRepository(t *testing.T) {
 		t.Errorf("kev/risk_score round-trip failed: KEV=%v risk=%v", ranked[0].KEV, ranked[0].RiskScore)
 	}
 
-	// RuleKey round-trip and validation
-	fRule := finding.Finding{
-		ID: shared.ID("fid-" + randHex(t)), EngagementID: eid, Title: "RuleKey test", Kind: finding.KindSAST,
-		Severity: shared.SeverityMedium, Status: finding.StatusOpen, DedupKey: "sast:my-rule:a.go:1",
-		RuleKey: "my-rule", Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	// RuleKey enhancements:
+	// 4. Mixed valid/invalid batch không tạo partial rows.
+	fidValid := shared.ID("fid-" + randHex(t))
+	fidInvalid := shared.ID("fid-" + randHex(t))
+	validF := finding.Finding{ID: fidValid, EngagementID: eid, Kind: finding.KindSAST, DedupKey: "sast:valid", RuleKey: "valid"}
+	invalidF := finding.Finding{ID: fidInvalid, EngagementID: eid, Kind: finding.KindSAST, DedupKey: "sast:invalid", RuleKey: ""}
+	if err := repo.Upsert(ctx, []finding.Finding{validF, invalidF}); err == nil {
+		t.Error("expected Upsert to fail atomic validation due to empty RuleKey, but succeeded")
 	}
-	if err := repo.Upsert(ctx, []finding.Finding{fRule}); err != nil {
-		t.Fatalf("upsert rulekey finding: %v", err)
-	}
-	ranked, _ = repo.ListByEngagement(ctx, eid)
-	var foundRule *finding.Finding
-	for i := range ranked {
-		if ranked[i].ID == fRule.ID {
-			foundRule = &ranked[i]
-		}
-	}
-	if foundRule == nil || foundRule.RuleKey != "my-rule" {
-		t.Errorf("RuleKey round-trip failed: want my-rule, got %q", foundRule.RuleKey)
+	// Verify neither were inserted
+	var count int
+	pool.QueryRow(ctx, "SELECT count(*) FROM findings WHERE id IN ($1, $2)", fidValid, fidInvalid).Scan(&count)
+	if count != 0 {
+		t.Errorf("expected 0 partial rows, got %d", count)
 	}
 
-	// Validation rejection on invalid batch
-	badRule := finding.Finding{
-		ID: shared.ID("fid-" + randHex(t)), EngagementID: eid, Kind: finding.KindSAST,
-		DedupKey: "sast:bad", RuleKey: "",
+	// 5. Non-rule finding với empty RuleKey persist bình thường.
+	// 6. Non-rule finding với non-empty RuleKey bị từ chối.
+	nonRuleValid := finding.Finding{ID: shared.ID("fid-" + randHex(t)), EngagementID: eid, Kind: finding.KindSCA, DedupKey: "sca:1", RuleKey: ""}
+	nonRuleInvalid := finding.Finding{ID: shared.ID("fid-" + randHex(t)), EngagementID: eid, Kind: finding.KindManual, DedupKey: "manual:1", RuleKey: "bad"}
+	if err := repo.Upsert(ctx, []finding.Finding{nonRuleValid}); err != nil {
+		t.Errorf("non-rule finding with empty RuleKey should persist, got %v", err)
 	}
-	if err := repo.Upsert(ctx, []finding.Finding{badRule}); err == nil {
-		t.Error("expected Upsert to fail atomic validation due to empty RuleKey, but succeeded")
+	if err := repo.Upsert(ctx, []finding.Finding{nonRuleInvalid}); err == nil {
+		t.Error("non-rule finding with non-empty RuleKey should be rejected")
+	}
+
+	// 7. Legacy rule-based row với blank RuleKey vẫn đọc được.
+	// 2. Existing blank RuleKey được scan mới chữa.
+	// 3. Triage fields vẫn được giữ.
+	// 1. Conflict upsert cập nhật RuleKey.
+	fidLegacy := shared.ID("fid-" + randHex(t))
+	_, err = pool.Exec(ctx,
+		`INSERT INTO findings (id, tenant_id, engagement_id, title, description, severity, cvss_vector, cwe, status, evidence_score, dedup_key, kev, risk_score, created_at, updated_at, sources, confidence, class, scope, reachability, impact, priority, kind, assignee, version, proposed_by, class_reachability, rule_key)
+		 VALUES ($1, '', $2, 'legacy', '', 'medium', '', '', 'confirmed', 50, 'sast:legacy', false, 0, $3, $3, '', '', '', '', '', '', 3, 'sast', 'alice', 1, '', '', '')`,
+		fidLegacy, eid, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	// Read legacy row
+	legacyList, _ := repo.ListByEngagement(ctx, eid)
+	var readLegacy *finding.Finding
+	for i := range legacyList {
+		if legacyList[i].ID == fidLegacy {
+			readLegacy = &legacyList[i]
+		}
+	}
+	if readLegacy == nil || readLegacy.RuleKey != "" {
+		t.Errorf("expected to read legacy row with empty RuleKey, got %+v", readLegacy)
+	}
+
+	// Scan heals it
+	healedF := finding.Finding{ID: fidLegacy, EngagementID: eid, Kind: finding.KindSAST, DedupKey: "sast:legacy", RuleKey: "healed-rule"}
+	if err := repo.Upsert(ctx, []finding.Finding{healedF}); err != nil {
+		t.Fatalf("upsert to heal legacy row: %v", err)
+	}
+
+	list2, _ := repo.ListByEngagement(ctx, eid)
+	var healed *finding.Finding
+	for i := range list2 {
+		if list2[i].ID == fidLegacy {
+			healed = &list2[i]
+		}
+	}
+	if healed == nil || healed.RuleKey != "healed-rule" {
+		t.Errorf("conflict upsert should update RuleKey, got %q", healed.RuleKey)
+	}
+	if healed.Status != finding.StatusConfirmed || healed.Assignee != "alice" || healed.EvidenceScore != 50 {
+		t.Errorf("triage fields should be preserved: status=%v, assignee=%v, evidence=%v", healed.Status, healed.Assignee, healed.EvidenceScore)
+	}
+
+	// 8. UpdateStatus trả và giữ RuleKey.
+	// 9. SetAssignee trả và giữ RuleKey.
+	// 10. SetEvidenceScore trả và giữ RuleKey.
+	fUpd, err := repo.UpdateStatus(ctx, eid, fidLegacy, finding.StatusFalsePos, healed.Version)
+	if err != nil || fUpd.RuleKey != "healed-rule" {
+		t.Errorf("UpdateStatus must preserve RuleKey, got %q (err: %v)", fUpd.RuleKey, err)
+	}
+	fUpd, err = repo.SetAssignee(ctx, eid, fidLegacy, "charlie", fUpd.Version)
+	if err != nil || fUpd.RuleKey != "healed-rule" {
+		t.Errorf("SetAssignee must preserve RuleKey, got %q (err: %v)", fUpd.RuleKey, err)
+	}
+	fUpd, err = repo.SetEvidenceScore(ctx, eid, fidLegacy, 90, fUpd.Version)
+	if err != nil || fUpd.RuleKey != "healed-rule" {
+		t.Errorf("SetEvidenceScore must preserve RuleKey, got %q (err: %v)", fUpd.RuleKey, err)
 	}
 }

--- a/internal/infrastructure/persistence/postgres/finding_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/finding_repo_test.go
@@ -101,4 +101,33 @@ func TestFindingRepository(t *testing.T) {
 	if !ranked[0].KEV || ranked[0].RiskScore != 8.0 {
 		t.Errorf("kev/risk_score round-trip failed: KEV=%v risk=%v", ranked[0].KEV, ranked[0].RiskScore)
 	}
+
+	// RuleKey round-trip and validation
+	fRule := finding.Finding{
+		ID: shared.ID("fid-" + randHex(t)), EngagementID: eid, Title: "RuleKey test", Kind: finding.KindSAST,
+		Severity: shared.SeverityMedium, Status: finding.StatusOpen, DedupKey: "sast:my-rule:a.go:1",
+		RuleKey: "my-rule", Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+	if err := repo.Upsert(ctx, []finding.Finding{fRule}); err != nil {
+		t.Fatalf("upsert rulekey finding: %v", err)
+	}
+	ranked, _ = repo.ListByEngagement(ctx, eid)
+	var foundRule *finding.Finding
+	for i := range ranked {
+		if ranked[i].ID == fRule.ID {
+			foundRule = &ranked[i]
+		}
+	}
+	if foundRule == nil || foundRule.RuleKey != "my-rule" {
+		t.Errorf("RuleKey round-trip failed: want my-rule, got %q", foundRule.RuleKey)
+	}
+
+	// Validation rejection on invalid batch
+	badRule := finding.Finding{
+		ID: shared.ID("fid-" + randHex(t)), EngagementID: eid, Kind: finding.KindSAST,
+		DedupKey: "sast:bad", RuleKey: "",
+	}
+	if err := repo.Upsert(ctx, []finding.Finding{badRule}); err == nil {
+		t.Error("expected Upsert to fail atomic validation due to empty RuleKey, but succeeded")
+	}
 }

--- a/internal/infrastructure/persistence/postgres/migration_0044_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0044_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pressly/goose/v3"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
@@ -68,15 +69,22 @@ func TestMigration0044(t *testing.T) {
 		dedupKey string
 		wantRule string
 	}{
-		{uuid.New().String(), "sast", "sast:go:sql-injection:main.go:42", "go:sql-injection"},
-		{uuid.New().String(), "sast", "sast:go:sql-injection:C:\\project\\main.go:42", "go:sql-injection"},
-		{uuid.New().String(), "secret", "secret:aws-key:file.txt:1", "aws-key"},
-		{uuid.New().String(), "misconfig", "misconfig:tf.s3.public:main.tf:10", "tf.s3.public"},
-		{uuid.New().String(), "quality", "quality:quality-duplicated-block:src/foo.js:12", "quality-duplicated-block"},
-		{uuid.New().String(), "reliability", "reliability:reliability-empty-catch:test.java:5", "reliability-empty-catch"},
-		{uuid.New().String(), "sast", "sast:my:weird:rule:name:path/file.go:1", "my:weird:rule:name"},
-		{uuid.New().String(), "sca", "vuln:CVE-1:pkg:1", ""},
-		{uuid.New().String(), "sast", "sast:bad-format", ""}, // Does not match regex
+		{uuid.New().String(), "sast", "sast:sql-injection:src/a.go:10", "sql-injection"},
+		{uuid.New().String(), "secret", "secret:google-api-key:src/a.go:11", "google-api-key"},
+		{uuid.New().String(), "misconfig", "misconfig:terraform-open-egress:main.tf:12", "terraform-open-egress"},
+		{uuid.New().String(), "quality", "quality:quality-high-complexity:src/a.go:13", "quality-high-complexity"},
+		{uuid.New().String(), "reliability", "reliability:reliability-empty-catch:src/A.java:14", "reliability-empty-catch"},
+		{uuid.New().String(), "sast", "sast:sql-injection:C:\\src\\main.go:42", "sql-injection"},
+		{uuid.New().String(), "sast", "secret:google-api-key:file.go:1", ""}, // Prefix mismatch
+		{uuid.New().String(), "sast", "sast::file.go:1", ""},                 // Empty rule
+		{uuid.New().String(), "sast", "sast:rule::1", ""},                    // Empty path
+		{uuid.New().String(), "sast", "sast:rule:file.go:not-a-number", ""},  // Non-numeric line
+		{uuid.New().String(), "sast", "sast:go:sql-injection:file.go:1", ""}, // Colons in rule
+		{uuid.New().String(), "sca", "sca:some-rule:file.go:1", ""},          // Unsupported kind
+		{uuid.New().String(), "manual", "manual:some-rule:file.go:1", ""},
+		{uuid.New().String(), "dast", "dast:some-rule:file.go:1", ""},
+		{uuid.New().String(), "", "sast:sql-injection:src/a.go:10", ""}, // Empty kind
+		{uuid.New().String(), "sast", "arbitrary malformed string", ""},
 	}
 
 	now := time.Now().UTC()
@@ -113,13 +121,32 @@ func TestMigration0044(t *testing.T) {
 	}
 
 	// Assert rule_key is gone
-	err = pool.QueryRow(ctx, "SELECT rule_key FROM findings WHERE id=$1", fixtures[0].id).Scan(nil)
+	var scanVal string
+	err = pool.QueryRow(ctx, "SELECT rule_key FROM findings WHERE id=$1", fixtures[0].id).Scan(&scanVal)
 	if err == nil {
 		t.Error("rule_key column still exists after Down")
+	} else if pgErr, ok := err.(*pgconn.PgError); ok {
+		if pgErr.Code != "42703" { // undefined_column
+			t.Errorf("expected undefined_column error, got: %v", pgErr.Code)
+		}
+	} else {
+		t.Errorf("expected pgx error, got: %T %v", err, err)
 	}
 
 	// 6. Apply Up again
 	if err := goose.UpTo(db, ".", 44); err != nil {
 		t.Fatalf("goose up to 44 (second time): %v", err)
+	}
+
+	// Assert column exists and backfill is correct again
+	for _, f := range fixtures {
+		var gotRule string
+		if err := pool.QueryRow(ctx, "SELECT rule_key FROM findings WHERE id=$1", f.id).Scan(&gotRule); err != nil {
+			t.Errorf("fixture %s not found on second up: %v", f.id, err)
+			continue
+		}
+		if gotRule != f.wantRule {
+			t.Errorf("fixture %s (dedup: %s): got rule_key %q, want %q on second up", f.id, f.dedupKey, gotRule, f.wantRule)
+		}
 	}
 }

--- a/internal/infrastructure/persistence/postgres/migration_0044_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0044_test.go
@@ -1,0 +1,125 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+func TestMigration0044(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+
+	// 1. Connect to DB and migrate DOWN to 43 to test 44 Up
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("initial migrate up: %v", err)
+	}
+
+	db, err := goose.OpenDBWithDriver("pgx", dsn)
+	if err != nil {
+		t.Fatalf("goose open db: %v", err)
+	}
+	defer db.Close()
+
+	goose.SetBaseFS(migrations.FS)
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatalf("goose set dialect: %v", err)
+	}
+
+	if err := goose.DownTo(db, ".", 43); err != nil {
+		t.Fatalf("goose down to 43: %v", err)
+	}
+
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	eidString := uuid.New().String()
+	eid := shared.ID(eidString)
+	e, err := engagement.New(eid, "", "test", "", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("new engagement: %v", err)
+	}
+	if err := NewEngagementRepository(pool).Create(ctx, e); err != nil {
+		t.Fatalf("insert engagement: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM findings WHERE engagement_id=$1", eidString)
+		_, _ = pool.Exec(ctx, "DELETE FROM engagements WHERE id=$1", eidString)
+	})
+
+	// 2. Insert the fixture matrix (legacy rows without rule_key column since we are at v43)
+	fixtures := []struct {
+		id       string
+		kind     string
+		dedupKey string
+		wantRule string
+	}{
+		{uuid.New().String(), "sast", "sast:go:sql-injection:main.go:42", "go:sql-injection"},
+		{uuid.New().String(), "sast", "sast:go:sql-injection:C:\\project\\main.go:42", "go:sql-injection"},
+		{uuid.New().String(), "secret", "secret:aws-key:file.txt:1", "aws-key"},
+		{uuid.New().String(), "misconfig", "misconfig:tf.s3.public:main.tf:10", "tf.s3.public"},
+		{uuid.New().String(), "quality", "quality:quality-duplicated-block:src/foo.js:12", "quality-duplicated-block"},
+		{uuid.New().String(), "reliability", "reliability:reliability-empty-catch:test.java:5", "reliability-empty-catch"},
+		{uuid.New().String(), "sast", "sast:my:weird:rule:name:path/file.go:1", "my:weird:rule:name"},
+		{uuid.New().String(), "sca", "vuln:CVE-1:pkg:1", ""},
+		{uuid.New().String(), "sast", "sast:bad-format", ""}, // Does not match regex
+	}
+
+	now := time.Now().UTC()
+	for _, f := range fixtures {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO findings (id, tenant_id, engagement_id, title, description, severity, cvss_vector, cwe, status, evidence_score, dedup_key, kev, risk_score, created_at, updated_at, sources, confidence, class, scope, reachability, impact, priority, kind, assignee, version, proposed_by, class_reachability)
+			 VALUES ($1, '', $2, 'test', 'desc', 'medium', '', '', 'open', 0, $3, false, 0.0, $4, $4, '', '', 'third_party', 'unknown', 'unknown', '', 3, $5, '', 1, '', '')`,
+			f.id, eidString, f.dedupKey, now, f.kind)
+		if err != nil {
+			t.Fatalf("insert fixture %s: %v", f.id, err)
+		}
+	}
+
+	// 3. Apply 0044 Up
+	if err := goose.UpTo(db, ".", 44); err != nil {
+		t.Fatalf("goose up to 44: %v", err)
+	}
+
+	// 4. Assert row states
+	for _, f := range fixtures {
+		var gotRule string
+		if err := pool.QueryRow(ctx, "SELECT rule_key FROM findings WHERE id=$1", f.id).Scan(&gotRule); err != nil {
+			t.Errorf("fixture %s not found: %v", f.id, err)
+			continue
+		}
+		if gotRule != f.wantRule {
+			t.Errorf("fixture %s (dedup: %s): got rule_key %q, want %q", f.id, f.dedupKey, gotRule, f.wantRule)
+		}
+	}
+
+	// 5. Apply Down
+	if err := goose.DownTo(db, ".", 43); err != nil {
+		t.Fatalf("goose down to 43: %v", err)
+	}
+
+	// Assert rule_key is gone
+	err = pool.QueryRow(ctx, "SELECT rule_key FROM findings WHERE id=$1", fixtures[0].id).Scan(nil)
+	if err == nil {
+		t.Error("rule_key column still exists after Down")
+	}
+
+	// 6. Apply Up again
+	if err := goose.UpTo(db, ".", 44); err != nil {
+		t.Fatalf("goose up to 44 (second time): %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/migration_0044_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0044_test.go
@@ -83,7 +83,7 @@ func TestMigration0044(t *testing.T) {
 		{uuid.New().String(), "sca", "sca:some-rule:file.go:1", ""},          // Unsupported kind
 		{uuid.New().String(), "manual", "manual:some-rule:file.go:1", ""},
 		{uuid.New().String(), "dast", "dast:some-rule:file.go:1", ""},
-		{uuid.New().String(), "", "sast:sql-injection:src/a.go:10", ""}, // Empty kind
+		{uuid.New().String(), "", "sast:sql-injection:src/a.go:11", ""}, // Empty kind
 		{uuid.New().String(), "sast", "arbitrary malformed string", ""},
 	}
 

--- a/internal/usecase/codequality/catalog_parity_test.go
+++ b/internal/usecase/codequality/catalog_parity_test.go
@@ -2,7 +2,6 @@ package codequality
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -62,11 +61,11 @@ func TestCatalogParity(t *testing.T) {
 	}
 
 	for _, f := range fs {
-		parts := strings.SplitN(f.DedupKey, ":", 3)
-		if len(parts) < 2 {
+		ruleID := f.RuleKey
+		if ruleID == "" {
+			t.Errorf("Finding missing RuleKey: %s", f.DedupKey)
 			continue
 		}
-		ruleID := parts[1]
 		catRule, ok := catalogMap[ruleID]
 		if !ok {
 			t.Errorf("Rule %s missing from catalog", ruleID)

--- a/internal/usecase/codequality/service.go
+++ b/internal/usecase/codequality/service.go
@@ -184,6 +184,7 @@ func newFinding(kind, ruleID, cwe string, sev shared.Severity, title, desc, file
 		Class:       finding.ClassFirstParty,
 		Status:      finding.StatusOpen,
 		Kind:        k,
+		RuleKey:     ruleID,
 		DedupKey:    dedup,
 	}
 }

--- a/internal/usecase/codequality/service_test.go
+++ b/internal/usecase/codequality/service_test.go
@@ -34,16 +34,13 @@ func (f fakeMetrics) Complexity(context.Context, string) (measure.ComplexityRepo
 	return f.rep, f.available, nil
 }
 
-func byRule(fs []finding.Finding) map[string]finding.Finding {
-	m := map[string]finding.Finding{}
-	for _, f := range fs {
-		// dedup key is <kind>:<rule>:<file>:<line>; index by rule id (2nd field)
-		parts := strings.SplitN(f.DedupKey, ":", 3)
-		if len(parts) >= 2 {
-			m[parts[1]] = f
+func byRule(findings []finding.Finding, ruleKey string) *finding.Finding {
+	for i := range findings {
+		if findings[i].RuleKey == ruleKey {
+			return &findings[i]
 		}
 	}
-	return m
+	return nil
 }
 
 func TestServiceMapsAndBridges(t *testing.T) {
@@ -64,31 +61,39 @@ func TestServiceMapsAndBridges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("analyze: %v", err)
 	}
-	m := byRule(fs)
-
-	todo, ok := m["quality-todo-comment"]
-	if !ok || todo.Kind != finding.KindQuality || todo.DedupKey != "quality:quality-todo-comment:a.go:3" {
+	todo := byRule(fs, "quality-todo-comment")
+	if todo == nil || todo.Kind != finding.KindQuality || todo.DedupKey != "quality:quality-todo-comment:a.go:3" {
 		t.Errorf("todo mapping wrong: %+v", todo)
 	}
 	if todo.Class != finding.ClassFirstParty || todo.Status != finding.StatusOpen {
 		t.Errorf("todo class/status wrong: %+v", todo)
 	}
-	for _, f := range fs {
-		if f.RuleKey == "" {
-			t.Errorf("finding %q missing RuleKey", f.DedupKey)
-		}
+	if todo.RuleKey != "quality-todo-comment" {
+		t.Errorf("todo RuleKey = %q", todo.RuleKey)
 	}
-	ec, ok := m["reliability-empty-catch"]
-	if !ok || ec.Kind != finding.KindReliability {
+
+	ec := byRule(fs, "reliability-empty-catch")
+	if ec == nil || ec.Kind != finding.KindReliability {
 		t.Errorf("empty-catch kind wrong: %+v", ec)
 	}
-	dupF, ok := m["quality-duplicated-block"]
-	if !ok || dupF.Kind != finding.KindQuality || !strings.Contains(dupF.Title, "x.go") {
+	if ec.RuleKey != "reliability-empty-catch" {
+		t.Errorf("empty-catch RuleKey = %q", ec.RuleKey)
+	}
+
+	dupF := byRule(fs, "quality-duplicated-block")
+	if dupF == nil || dupF.Kind != finding.KindQuality || !strings.Contains(dupF.Title, "x.go") {
 		t.Errorf("duplication bridge wrong: %+v", dupF)
 	}
-	hc, ok := m["quality-high-complexity"]
-	if !ok || !strings.Contains(hc.Title, "25") {
+	if dupF.RuleKey != "quality-duplicated-block" {
+		t.Errorf("duplication RuleKey = %q", dupF.RuleKey)
+	}
+
+	hc := byRule(fs, "quality-high-complexity")
+	if hc == nil || !strings.Contains(hc.Title, "25") {
 		t.Errorf("complexity bridge should flag the cyclomatic-25 function: %+v", hc)
+	}
+	if hc.RuleKey != "quality-high-complexity" {
+		t.Errorf("complexity RuleKey = %q", hc.RuleKey)
 	}
 	// The cyclomatic-2 function must NOT be flagged.
 	for _, f := range fs {
@@ -117,12 +122,12 @@ func TestBugsBridgeEmitsReliability(t *testing.T) {
 	if err != nil {
 		t.Fatalf("analyze: %v", err)
 	}
-	m := byRule(fs)
-	unr, ok := m["reliability-unreachable-code"]
-	if !ok || unr.Kind != finding.KindReliability || unr.DedupKey != "reliability:reliability-unreachable-code:a.go:7" {
+	unr := byRule(fs, "reliability-unreachable-code")
+	if unr == nil || unr.Kind != finding.KindReliability || unr.DedupKey != "reliability:reliability-unreachable-code:a.go:7" {
 		t.Errorf("unreachable bug mapping wrong: %+v", unr)
 	}
-	if cc, ok := m["reliability-constant-condition"]; !ok || cc.Kind != finding.KindReliability {
+	cc := byRule(fs, "reliability-constant-condition")
+	if cc == nil || cc.Kind != finding.KindReliability {
 		t.Errorf("constant-condition bug missing/wrong: %+v", cc)
 	}
 	// unavailable detector emits nothing.
@@ -170,11 +175,10 @@ func TestTestScopedInfoSmellsSuppressed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("analyze: %v", err)
 	}
-	m := byRule(fs)
 	if len(fs) != 2 {
 		t.Fatalf("default should drop the test-scoped info smell, want 2, got %d: %+v", len(fs), fs)
 	}
-	if _, ok := m["reliability-empty-catch"]; !ok {
+	if byRule(fs, "reliability-empty-catch") == nil {
 		t.Errorf("a medium finding in test code must be kept")
 	}
 	// The prod commented-out-code must survive; the test one must not.

--- a/internal/usecase/codequality/service_test.go
+++ b/internal/usecase/codequality/service_test.go
@@ -73,6 +73,11 @@ func TestServiceMapsAndBridges(t *testing.T) {
 	if todo.Class != finding.ClassFirstParty || todo.Status != finding.StatusOpen {
 		t.Errorf("todo class/status wrong: %+v", todo)
 	}
+	for _, f := range fs {
+		if f.RuleKey == "" {
+			t.Errorf("finding %q missing RuleKey", f.DedupKey)
+		}
+	}
 	ec, ok := m["reliability-empty-catch"]
 	if !ok || ec.Kind != finding.KindReliability {
 		t.Errorf("empty-catch kind wrong: %+v", ec)

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -211,6 +211,7 @@ func buildFindings(engagementID shared.ID, res *ScanResult, now time.Time, minSe
 			Priority:     sastPriority(sr.Severity),
 			Status:       finding.StatusOpen,
 			Kind:         finding.KindSAST,
+			RuleKey:      sr.RuleID,
 			DedupKey:     dedup,
 			Audit:        shared.Audit{CreatedAt: now, UpdatedAt: now},
 		})
@@ -246,6 +247,7 @@ func buildSecretFindings(engagementID shared.ID, raws []ports.SecretRawFinding, 
 			Priority: sastPriority(sr.Severity),
 			Status:   finding.StatusOpen,
 			Kind:     finding.KindSecret,
+			RuleKey:  sr.RuleID,
 			DedupKey: dedup,
 			Audit:    shared.Audit{CreatedAt: now, UpdatedAt: now},
 		})
@@ -286,6 +288,7 @@ func buildMisconfigFindings(engagementID shared.ID, raws []ports.MisconfigRawFin
 			Priority: sastPriority(mr.Severity),
 			Status:   finding.StatusOpen,
 			Kind:     finding.KindMisconfig,
+			RuleKey:  mr.RuleID,
 			DedupKey: dedup,
 			Audit:    shared.Audit{CreatedAt: now, UpdatedAt: now},
 		})

--- a/internal/usecase/sca/findings_test.go
+++ b/internal/usecase/sca/findings_test.go
@@ -173,11 +173,12 @@ func TestBuildFindingsSAST(t *testing.T) {
 	raws := []ports.SASTRawFinding{
 		{File: "cmd/app/main.go", Line: 42, RuleID: "weak-hash-md5", CWE: "CWE-327", Severity: shared.SeverityMedium, Title: "Weak hash: MD5", Description: "use SHA-256", OWASP2025: "A04:2025 Cryptographic Failures", EntryPoint: "POST /login", Source: "password/crypto lifecycle", SourceEvidence: "line-local crypto/password lifecycle cue", Sink: "password hashing sink", SinkEvidence: "line 42: password hashing sink", ControlEvidence: "line 40: route POST /login", RouteMiddleware: "line 40: route-level authenticated middleware cue", AuthEvidence: "line 40: route-level authenticated middleware cue", Exposure: "authenticated application route", TrustBoundary: "internet/client-controlled input crosses into server-side password hashing sink", Impact: "possible weak cryptographic protection", Route: "POST /login", AuthScope: "authenticated", DataFlow: "password/crypto lifecycle -> password hashing sink via POST /login", DataFlowEvidence: "not-applicable: finding is about source/lifecycle material rather than request source-to-sink flow", DataFlowConfidence: "not-applicable", Preconditions: "no extra preconditions visible beyond the candidate source/sink path", CounterEvidence: "none observed in bounded local context", ValidationRubric: "source=present; control=present; sink=present; dataflow=not-applicable; counterevidence=none_observed", ValidationMethod: "static-code-understanding", ValidationDisposition: "reportable-static-candidate", Exploitability: "candidate", AttackPath: "attacker reaches login hashing path", Confidence: "high", SeverityRationale: "Pattern severity is medium for CWE-327."},
 		{File: "internal/auth/login.go", Line: 7, RuleID: "hardcoded-aws-access-key", CWE: "CWE-798", Severity: shared.SeverityCritical, Title: "Hardcoded AWS access key id", Description: "rotate"},
-		{File: "x.go", Line: 1, RuleID: "weak-hash-sha1", CWE: "CWE-327", Severity: shared.SeverityLow, Title: "low", Description: "x"}, // below threshold
+		{File: "x.go", Line: 1, RuleID: "weak-hash-sha1", CWE: "CWE-327", Severity: shared.SeverityLow, Title: "low", Description: "x"},         // below threshold
+		{File: "y.go", Line: 2, RuleID: "go:example-rule", CWE: "CWE-89", Severity: shared.SeverityHigh, Title: "colon test", Description: "y"}, // colon-containing rule
 	}
 	got := buildFindings("eng1", res, now, shared.SeverityMedium, false, raws)
-	if len(got) != 2 { // Medium + Critical kept; Low filtered by the threshold
-		t.Fatalf("want 2 SAST findings (Low filtered), got %d: %+v", len(got), got)
+	if len(got) != 3 { // Medium + Critical + High kept; Low filtered by the threshold
+		t.Fatalf("want 3 SAST findings (Low filtered), got %d: %+v", len(got), got)
 	}
 	var md5 *finding.Finding
 	for i := range got {
@@ -193,6 +194,20 @@ func TestBuildFindingsSAST(t *testing.T) {
 	}
 	if md5.RuleKey != "weak-hash-md5" {
 		t.Fatalf("SAST finding RuleKey = %q, want 'weak-hash-md5'", md5.RuleKey)
+	}
+
+	// verify the colon-containing finding
+	var colon *finding.Finding
+	for i := range got {
+		if got[i].RuleKey == "go:example-rule" {
+			colon = &got[i]
+		}
+	}
+	if colon == nil {
+		t.Fatalf("missing colon-containing finding")
+	}
+	if colon.DedupKey != "sast:go:example-rule:y.go:2" {
+		t.Fatalf("colon-containing DedupKey wrong: %q", colon.DedupKey)
 	}
 	for _, want := range []string{"AppSec validation envelope", "OWASP/CWE mapping: A04:2025 Cryptographic Failures / CWE-327", "Source: password/crypto lifecycle", "Source evidence:", "Sink/control: password hashing sink", "Sink evidence:", "Control evidence:", "Route middleware:", "Auth evidence:", "Exposure: authenticated application route", "Trust boundary:", "Impact hypothesis:", "Route reachability: POST /login", "Validation receipt: static-code-understanding / reportable-static-candidate", "Preconditions/proof gaps:", "Counterevidence:", "Validation rubric:", "Dataflow:", "Dataflow evidence:", "Dataflow confidence:", "Exploitability validation:", "Attack-path calibration:", "Severity rationale:"} {
 		if !strings.Contains(md5.Description, want) {

--- a/internal/usecase/sca/findings_test.go
+++ b/internal/usecase/sca/findings_test.go
@@ -191,6 +191,9 @@ func TestBuildFindingsSAST(t *testing.T) {
 	if md5.Kind != finding.KindSAST || md5.Class != finding.ClassFirstParty || md5.CWE != "CWE-327" || md5.ProposedBy != "" {
 		t.Fatalf("SAST finding fields wrong: %+v", md5)
 	}
+	if md5.RuleKey != "weak-hash-md5" {
+		t.Fatalf("SAST finding RuleKey = %q, want 'weak-hash-md5'", md5.RuleKey)
+	}
 	for _, want := range []string{"AppSec validation envelope", "OWASP/CWE mapping: A04:2025 Cryptographic Failures / CWE-327", "Source: password/crypto lifecycle", "Source evidence:", "Sink/control: password hashing sink", "Sink evidence:", "Control evidence:", "Route middleware:", "Auth evidence:", "Exposure: authenticated application route", "Trust boundary:", "Impact hypothesis:", "Route reachability: POST /login", "Validation receipt: static-code-understanding / reportable-static-candidate", "Preconditions/proof gaps:", "Counterevidence:", "Validation rubric:", "Dataflow:", "Dataflow evidence:", "Dataflow confidence:", "Exploitability validation:", "Attack-path calibration:", "Severity rationale:"} {
 		if !strings.Contains(md5.Description, want) {
 			t.Fatalf("SAST proof summary missing %q from description:\n%s", want, md5.Description)
@@ -207,5 +210,26 @@ func TestBuildFindingsSAST(t *testing.T) {
 	again := buildFindings("eng1", res, now.Add(time.Hour), shared.SeverityMedium, false, raws)
 	if md5.ID != findingID("eng1", md5.DedupKey) || again[0].ID != got[0].ID {
 		t.Error("SAST finding id not deterministic")
+	}
+}
+
+func TestBuildSecretFindings(t *testing.T) {
+	raws := []ports.SecretRawFinding{
+		{File: "main.go", Line: 10, RuleID: "aws-key", Severity: shared.SeverityHigh, Title: "Hardcoded key"},
+	}
+	now := time.Now().UTC()
+	got := buildSecretFindings("eng1", raws, now, shared.SeverityMedium)
+	if len(got) != 1 {
+		t.Fatalf("want 1 secret finding, got %d", len(got))
+	}
+	f := got[0]
+	if f.Kind != finding.KindSecret {
+		t.Errorf("Kind = %q, want %q", f.Kind, finding.KindSecret)
+	}
+	if f.RuleKey != "aws-key" {
+		t.Errorf("RuleKey = %q, want 'aws-key'", f.RuleKey)
+	}
+	if f.DedupKey != "secret:aws-key:main.go:10" {
+		t.Errorf("DedupKey = %q, want 'secret:aws-key:main.go:10'", f.DedupKey)
 	}
 }

--- a/internal/usecase/sca/misconfig_findings_test.go
+++ b/internal/usecase/sca/misconfig_findings_test.go
@@ -22,12 +22,12 @@ func TestBuildMisconfigFindings(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("want 2 findings (low dropped by threshold), got %d", len(got))
 	}
-	for _, f := range got {
+	for i, f := range got {
 		if f.Kind != finding.KindMisconfig {
 			t.Errorf("finding %q must be Kind=misconfig, got %q", f.Title, f.Kind)
 		}
-		if f.RuleKey == "" {
-			t.Errorf("finding %q must have RuleKey populated", f.Title)
+		if f.RuleKey != raws[i].RuleID {
+			t.Errorf("finding %q must have RuleKey = %q, got %q", f.Title, raws[i].RuleID, f.RuleKey)
 		}
 		if f.Class != finding.ClassFirstParty {
 			t.Errorf("misconfig must be first-party, got %q", f.Class)

--- a/internal/usecase/sca/misconfig_findings_test.go
+++ b/internal/usecase/sca/misconfig_findings_test.go
@@ -26,6 +26,9 @@ func TestBuildMisconfigFindings(t *testing.T) {
 		if f.Kind != finding.KindMisconfig {
 			t.Errorf("finding %q must be Kind=misconfig, got %q", f.Title, f.Kind)
 		}
+		if f.RuleKey == "" {
+			t.Errorf("finding %q must have RuleKey populated", f.Title)
+		}
 		if f.Class != finding.ClassFirstParty {
 			t.Errorf("misconfig must be first-party, got %q", f.Class)
 		}

--- a/migrations/0044_finding_rule_key.sql
+++ b/migrations/0044_finding_rule_key.sql
@@ -2,11 +2,12 @@
 -- +goose StatementBegin
 ALTER TABLE findings ADD COLUMN rule_key TEXT NOT NULL DEFAULT '';
 
--- Safe regex-based backfill extracting the rule_id from the colon-delimited dedup_key.
--- Format: <kind>:<rule-id>:<file>:<line>
--- The rule-id is the capture group (.+).
--- The file path (?:(?:[a-zA-Z]:[/\\])?[^:]+) safely handles optional Windows drive letters
--- without capturing, ensuring colons inside the rule_id are safely matched.
+-- Conservatively backfill only the pre-RuleKey legacy format:
+-- <kind>:<colon-free-rule-id>:<path>:<numeric-line>.
+--
+-- The prefix must match the stored kind. Paths may use an optional
+-- Windows drive prefix, but ambiguous colon-containing rule IDs are
+-- deliberately left empty.
 UPDATE findings
 SET rule_key = split_part(dedup_key, ':', 2)
 WHERE rule_key = ''
@@ -20,7 +21,9 @@ WHERE rule_key = ''
   AND dedup_key ~ (
       '^'
       || kind::text
-      || ':[^:[:space:][:cntrl:]]+:.+:[0-9]+$'
+      || ':[^:[:space:][:cntrl:]]+:'
+      || '([A-Za-z]:[/\\])?'
+      || '[^:]+:[0-9]+$'
   );
 -- +goose StatementEnd
 

--- a/migrations/0044_finding_rule_key.sql
+++ b/migrations/0044_finding_rule_key.sql
@@ -8,12 +8,20 @@ ALTER TABLE findings ADD COLUMN rule_key TEXT NOT NULL DEFAULT '';
 -- The file path (?:(?:[a-zA-Z]:[/\\])?[^:]+) safely handles optional Windows drive letters
 -- without capturing, ensuring colons inside the rule_id are safely matched.
 UPDATE findings
-SET rule_key = COALESCE(
-    substring(dedup_key from '^(?:sast|secret|misconfig|quality|reliability):(.+?):(?:(?:[a-zA-Z]:[/\\])?[^:]+):\d+$'),
-    ''
-)
-WHERE kind IN ('sast', 'secret', 'misconfig', 'quality', 'reliability')
-  AND rule_key = '';
+SET rule_key = split_part(dedup_key, ':', 2)
+WHERE rule_key = ''
+  AND kind::text IN (
+      'sast',
+      'secret',
+      'misconfig',
+      'quality',
+      'reliability'
+  )
+  AND dedup_key ~ (
+      '^'
+      || kind::text
+      || ':[^:[:space:][:cntrl:]]+:.+:[0-9]+$'
+  );
 -- +goose StatementEnd
 
 -- +goose Down

--- a/migrations/0044_finding_rule_key.sql
+++ b/migrations/0044_finding_rule_key.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE findings ADD COLUMN rule_key TEXT NOT NULL DEFAULT '';
+
+-- Safe regex-based backfill extracting the rule_id from the colon-delimited dedup_key.
+-- Format: <kind>:<rule-id>:<file>:<line>
+-- The rule-id is the capture group (.+).
+-- The file path (?:(?:[a-zA-Z]:[/\\])?[^:]+) safely handles optional Windows drive letters
+-- without capturing, ensuring colons inside the rule_id are safely matched.
+UPDATE findings
+SET rule_key = COALESCE(
+    substring(dedup_key from '^(?:sast|secret|misconfig|quality|reliability):(.+?):(?:(?:[a-zA-Z]:[/\\])?[^:]+):\d+$'),
+    ''
+)
+WHERE kind IN ('sast', 'secret', 'misconfig', 'quality', 'reliability')
+  AND rule_key = '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE findings DROP COLUMN rule_key;
+-- +goose StatementEnd


### PR DESCRIPTION
## Summary

Persists stable rule catalog keys on rule-based findings and safely backfills eligible legacy PostgreSQL records.

This change connects the built-in rule catalog to the finding domain and persistence paths while preserving existing rule identifiers, deduplication behavior, and human-managed triage state.

## Changes

* add `RuleKey` to the finding domain
* add explicit classification for rule-based finding kinds
* validate the relationship between `Finding.Kind` and `Finding.RuleKey`
* propagate raw producer rule IDs into:

  * SAST findings
  * secret findings
  * misconfiguration findings
  * code-quality findings
  * reliability findings
* keep non-rule-based findings without a RuleKey
* persist RuleKey through the in-memory finding repository
* persist RuleKey through PostgreSQL insert, update, projection, and scan paths
* validate complete upsert batches before any repository mutation
* update conflict handling so rescans can populate legacy findings with an empty RuleKey
* preserve existing human-managed fields during rescans, including status, assignee, creation time, and evidence score
* add migration `0044_finding_rule_key.sql`
* add `rule_key TEXT NOT NULL DEFAULT ''` to the `findings` table
* conservatively backfill legacy RuleKeys only when the existing dedup key has an unambiguous supported format
* leave malformed, ambiguous, prefix-mismatched, and non-rule-based legacy rows unchanged
* support legacy Windows paths during migration backfill
* add migration Up/Down/Up coverage
* add domain, producer propagation, repository, atomicity, healing, and regression tests

## RuleKey contract

The following finding kinds require a RuleKey:

* `sast`
* `secret`
* `misconfig`
* `quality`
* `reliability`

The following finding kinds must keep RuleKey empty:

* `sca`
* `recon`
* `exploitation`
* `manual`
* `dast`
* `threat`
* `hypothesis`

RuleKeys are preserved exactly as emitted by their producer. They are not derived from titles, CWE metadata, catalog names, or runtime parsing of `DedupKey`.

## Migration behavior

The migration only backfills legacy rows matching the unambiguous format:

```text
<kind>:<colon-free-rule-id>:<path>:<numeric-line>
```

The dedup-key prefix must match the stored finding kind.

The migration intentionally does not infer RuleKeys from ambiguous legacy values containing colon-separated rule identifiers. New findings with colon-containing RuleKeys remain fully supported because their RuleKey is written directly by the producer.

## Compatibility

* existing rule IDs remain unchanged
* existing finding dedup keys remain unchanged
* SARIF rule IDs remain unchanged
* suppression and failure-threshold behavior remain unchanged
* existing triage fields remain preserved during rescans
* legacy rows with an empty RuleKey remain readable
* non-rule-based findings continue to use an empty RuleKey

## Validation

* domain RuleKey validation tests
* producer-to-finding RuleKey propagation tests
* in-memory repository round-trip and atomicity tests
* PostgreSQL repository round-trip and atomicity tests
* legacy blank-key healing tests
* migration safe/unsafe fixture matrix
* PostgreSQL migration Up/Down/Up test
* focused race-detector suite
* `go vet ./...`
* full repository test suite

Part of #182.

This PR implements the RuleKey persistence and legacy-backfill portion of the issue.

This PR does not add the Rules API or Rules Explorer and does not close #182.
