### PR TITLE
[codex] feat: add XML well-formedness rules

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -515,6 +515,7 @@ components:
       enum:
         - ast
         - pattern
+        - parse
         - metric
 
     RuleSummary:

--- a/docs/guide/code-quality-rules.md
+++ b/docs/guide/code-quality-rules.md
@@ -22,7 +22,7 @@ copy. Specifically:
   [OWASP](https://owasp.org/), [SEI CERT](https://wiki.sei.cmu.edu/confluence/display/seccode) secure-coding
   standards, and [ISO/IEC 25010](https://www.iso.org/standard/78176.html) software-quality attributes.
 - **Do** write our own rule title, description, rationale, remediation, and code examples, and our own
-  detection (AST query, token/line pattern, or metric threshold).
+  detection (AST query, structured parser check, token/line pattern, or metric threshold).
 - **Do not** copy any third-party rule's text, description, examples, or detection code, and **do not**
   attribute our rules to a specific commercial product. Cite the *concept's* origin (a CWE id, a
   style-guide section, a linter category) — not another tool's rule prose.
@@ -102,15 +102,15 @@ Rule {
   CompliantExample    // compliant code example
   NoncompliantExample // non-compliant code example
   RemediationEffort // minutes, for the tech-debt measure
-  Detection      // ast | pattern | metric
+  Detection      // ast | parse | pattern | metric
 }
 ```
 
 ## Detection & the parser
 
 Detection is one of: an **AST query** (via the sandboxed `synapse-ast` sidecar, tree-sitter), a
-**token/line pattern**, or a **metric threshold** (complexity, size, duplication). Prefer AST rules
-where a grammar exists.
+**structured parser check**, a **token/line pattern**, or a **metric threshold** (complexity, size,
+duplication). Prefer AST rules where a grammar exists.
 
 The sidecar currently parses **Python, JavaScript, Java** for function-level metrics (via go-enry for
 line counts of many more). Languages that need a new tree-sitter grammar (or a structured-config

--- a/internal/domain/rule/rule.go
+++ b/internal/domain/rule/rule.go
@@ -51,12 +51,13 @@ type Detection string
 const (
 	DetectionAST     Detection = "ast"
 	DetectionPattern Detection = "pattern"
+	DetectionParse   Detection = "parse"
 	DetectionMetric  Detection = "metric"
 )
 
 func (d Detection) Valid() bool {
 	switch d {
-	case DetectionAST, DetectionPattern, DetectionMetric:
+	case DetectionAST, DetectionPattern, DetectionParse, DetectionMetric:
 		return true
 	default:
 		return false

--- a/internal/domain/rule/rule_test.go
+++ b/internal/domain/rule/rule_test.go
@@ -52,6 +52,7 @@ func TestDetectionValid(t *testing.T) {
 	}{
 		{rule.DetectionAST, true},
 		{rule.DetectionPattern, true},
+		{rule.DetectionParse, true},
 		{rule.DetectionMetric, true},
 		{"", false},
 		{"unknown", false},

--- a/internal/infrastructure/rulecatalog/default.go
+++ b/internal/infrastructure/rulecatalog/default.go
@@ -14,6 +14,7 @@ func Default() (*Catalog, error) {
 	all = append(all, misconfigRules()...)
 	all = append(all, qualityRules()...)
 	all = append(all, reliabilityRules()...)
+	all = append(all, xmlRules()...)
 
 	return New(all)
 }

--- a/internal/infrastructure/rulecatalog/default_test.go
+++ b/internal/infrastructure/rulecatalog/default_test.go
@@ -64,8 +64,8 @@ func TestDefault_GoldenInventory(t *testing.T) {
 		expectedKeys[line] = true
 	}
 
-	if len(expectedKeys) != 143 {
-		t.Errorf("Golden file must have exactly 143 rules, found %d", len(expectedKeys))
+	if len(expectedKeys) != 145 {
+		t.Errorf("Golden file must have exactly 145 rules, found %d", len(expectedKeys))
 	}
 
 	actualRules, err := cat.List(context.Background())

--- a/internal/infrastructure/rulecatalog/default_test.go
+++ b/internal/infrastructure/rulecatalog/default_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/rulecatalog"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDefault_Validation(t *testing.T) {
@@ -153,6 +154,48 @@ func TestDefault_NoDuplicates(t *testing.T) {
 
 	if len(seen) != len(list) {
 		t.Fatalf("Length mismatch: %d unique keys vs %d listed rules", len(seen), len(list))
+	}
+}
+
+func TestDefault_DetectionValuesDocumentedInOpenAPI(t *testing.T) {
+	cat, err := rulecatalog.Default()
+	if err != nil {
+		t.Fatalf("Default() failed: %v", err)
+	}
+	rules, err := cat.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "api", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read OpenAPI spec: %v", err)
+	}
+
+	var spec struct {
+		Components struct {
+			Schemas map[string]struct {
+				Enum []rule.Detection `yaml:"enum"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse OpenAPI spec: %v", err)
+	}
+
+	enum := spec.Components.Schemas["RuleDetection"].Enum
+	if len(enum) == 0 {
+		t.Fatal("OpenAPI RuleDetection enum is missing or empty")
+	}
+	allowed := make(map[rule.Detection]bool, len(enum))
+	for _, detection := range enum {
+		allowed[detection] = true
+	}
+
+	for _, r := range rules {
+		if !allowed[r.Detection] {
+			t.Errorf("rule %s uses detection %q missing from OpenAPI RuleDetection enum", r.Key, r.Detection)
+		}
 	}
 }
 

--- a/internal/infrastructure/rulecatalog/metadata_test.go
+++ b/internal/infrastructure/rulecatalog/metadata_test.go
@@ -197,6 +197,7 @@ func TestMetadata_ApprovedLanguage(t *testing.T) {
 		"CloudFormation":        true,
 		"GitHub Actions":        true,
 		"Secrets":               true,
+		"XML":                   true,
 	}
 
 	for _, r := range rules {

--- a/internal/infrastructure/rulecatalog/testdata/rule_keys.txt
+++ b/internal/infrastructure/rulecatalog/testdata/rule_keys.txt
@@ -139,5 +139,7 @@ weak-hash-md5
 weak-hash-sha1
 weak-rsa-key-size
 world-writable-permissions
+xml:duplicate-attribute
+xml:not-well-formed
 xpath-injection
 xxe-insecure-xml-parsing

--- a/internal/infrastructure/rulecatalog/xml.go
+++ b/internal/infrastructure/rulecatalog/xml.go
@@ -1,0 +1,47 @@
+package rulecatalog
+
+import (
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func xmlRules() []rule.Rule {
+	return []rule.Rule{
+		{
+			Key:                 "xml:not-well-formed",
+			Name:                "XML document is not well formed",
+			Language:            "XML",
+			Type:                rule.TypeBug,
+			Qualities:           []rule.Quality{rule.QualityReliability},
+			DefaultSeverity:     shared.SeverityMedium,
+			Tags:                []string{"xml", "well-formedness"},
+			CWE:                 []string{},
+			OWASP:               []string{},
+			Description:         "Detects XML files that cannot be parsed as a single well-formed document.",
+			Rationale:           "XML processors are required to reject documents that violate well-formedness constraints, so malformed configuration can fail at load time or be ignored by downstream tooling.\n\nSource: https://www.w3.org/TR/xml/",
+			Remediation:         "Fix the XML structure so tags are properly nested, each document has one root element, and markup syntax is valid.",
+			CompliantExample:    "<service><name>api</name></service>",
+			NoncompliantExample: "<service><name>api</service>",
+			RemediationEffort:   5,
+			Detection:           rule.DetectionParse,
+		},
+		{
+			Key:                 "xml:duplicate-attribute",
+			Name:                "Duplicate XML attribute",
+			Language:            "XML",
+			Type:                rule.TypeBug,
+			Qualities:           []rule.Quality{rule.QualityReliability},
+			DefaultSeverity:     shared.SeverityLow,
+			Tags:                []string{"xml", "well-formedness", "attributes"},
+			CWE:                 []string{},
+			OWASP:               []string{},
+			Description:         "Detects an XML start tag that repeats the same attribute name.",
+			Rationale:           "XML well-formedness requires each attribute name to appear at most once on a single start tag; duplicates make the element invalid and can create ambiguous configuration values.\n\nSource: https://www.w3.org/TR/xml/",
+			Remediation:         "Keep a single value for the attribute and remove the duplicate, or split distinct meanings into differently named attributes.",
+			CompliantExample:    "<service name=\"api\" role=\"worker\" />",
+			NoncompliantExample: "<service name=\"api\" name=\"worker\" />",
+			RemediationEffort:   5,
+			Detection:           rule.DetectionParse,
+		},
+	}
+}

--- a/internal/infrastructure/tools/codeanalysis/analyzer.go
+++ b/internal/infrastructure/tools/codeanalysis/analyzer.go
@@ -76,20 +76,26 @@ func (a *Analyzer) Analyze(ctx context.Context, root string) ([]ports.CodeAnalys
 		if enry.IsVendor(path) || enry.IsDotFile(path) || enry.IsGenerated(path, content) || enry.IsBinary(content) {
 			return nil
 		}
+		ext := strings.ToLower(filepath.Ext(path))
 		lang := enry.GetLanguage(filepath.Base(path), content)
-		if lang == "" {
+		isXML := isXMLSource(ext, lang)
+		if lang == "" && !isXML {
 			return nil
 		}
-		switch enry.GetLanguageType(lang) {
-		case enry.Programming, enry.Markup:
-		default:
-			return nil
+		if !isXML {
+			switch enry.GetLanguageType(lang) {
+			case enry.Programming, enry.Markup:
+			default:
+				return nil
+			}
 		}
 		rel, relErr := filepath.Rel(root, path)
 		if relErr != nil {
 			rel = path
 		}
-		ext := strings.ToLower(filepath.Ext(path))
+		if isXML {
+			out = append(out, scanXMLFile(rel, content)...)
+		}
 		out = append(out, a.scanFile(rel, ext, content)...)
 		return nil
 	})

--- a/internal/infrastructure/tools/codeanalysis/catalog_parity_test.go
+++ b/internal/infrastructure/tools/codeanalysis/catalog_parity_test.go
@@ -92,6 +92,57 @@ func TestCatalogParity(t *testing.T) {
 		}
 	}
 
+	seenXML := map[string]bool{}
+	for _, tc := range builtinXMLRules() {
+		seenXML[tc.id] = true
+		catRule, ok := catalogMap[tc.id]
+		if !ok {
+			t.Errorf("Rule %s missing from catalog", tc.id)
+			continue
+		}
+
+		if catRule.Name != tc.title {
+			t.Errorf("Rule %s Title mismatch: catalog=%q engine=%q", tc.id, catRule.Name, tc.title)
+		}
+		if catRule.DefaultSeverity != tc.severity {
+			t.Errorf("Rule %s Severity mismatch: catalog=%v engine=%v", tc.id, catRule.DefaultSeverity, tc.severity)
+		}
+		if catRule.Language != "XML" {
+			t.Errorf("Rule %s Language mismatch: expected XML", tc.id)
+		}
+		if catRule.Type != domainrule.TypeBug {
+			t.Errorf("Rule %s Type mismatch: expected Bug", tc.id)
+		}
+		if len(catRule.Qualities) != 1 || catRule.Qualities[0] != domainrule.QualityReliability {
+			t.Errorf("Rule %s Quality mismatch: expected Reliability", tc.id)
+		}
+		if catRule.Detection != domainrule.DetectionParse {
+			t.Errorf("Rule %s Detection mode mismatch: expected Parse", tc.id)
+		}
+
+		matched := false
+		for _, f := range scanXMLFile("fixture.xml", []byte(catRule.NoncompliantExample)) {
+			if f.RuleID == tc.id {
+				matched = true
+				if f.Title != tc.title {
+					t.Errorf("Rule %s Title mismatch in finding: got %q", tc.id, f.Title)
+				}
+				if f.Severity != tc.severity {
+					t.Errorf("Rule %s Severity mismatch in finding: got %v", tc.id, f.Severity)
+				}
+			}
+		}
+		if !matched {
+			t.Errorf("Rule %s noncompliant example does not trigger detector", tc.id)
+		}
+
+		for _, f := range scanXMLFile("fixture.xml", []byte(catRule.CompliantExample)) {
+			if f.RuleID == tc.id {
+				t.Errorf("Rule %s compliant example unexpectedly triggered detector", tc.id)
+			}
+		}
+	}
+
 	for _, r := range rules {
 		if r.Key == "quality-todo-comment" || r.Key == "quality-commented-out-code" || r.Key == "reliability-empty-catch" || r.Key == "reliability-self-assignment" || r.Key == "reliability-self-comparison" {
 			found := false
@@ -104,6 +155,9 @@ func TestCatalogParity(t *testing.T) {
 			if !found {
 				t.Errorf("Rule %s in catalog but missing from builtinRules", r.Key)
 			}
+		}
+		if r.Language == "XML" && !seenXML[string(r.Key)] {
+			t.Errorf("Rule %s in XML catalog but missing from builtinXMLRules", r.Key)
 		}
 	}
 }

--- a/internal/infrastructure/tools/codeanalysis/xml.go
+++ b/internal/infrastructure/tools/codeanalysis/xml.go
@@ -1,0 +1,291 @@
+package codeanalysis
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	xmlNotWellFormedRuleID      = "xml:not-well-formed"
+	xmlDuplicateAttributeRuleID = "xml:duplicate-attribute"
+)
+
+type xmlRule struct {
+	id       string
+	title    string
+	severity shared.Severity
+}
+
+func builtinXMLRules() []xmlRule {
+	return []xmlRule{
+		{
+			id:       xmlNotWellFormedRuleID,
+			title:    "XML document is not well formed",
+			severity: shared.SeverityMedium,
+		},
+		{
+			id:       xmlDuplicateAttributeRuleID,
+			title:    "Duplicate XML attribute",
+			severity: shared.SeverityLow,
+		},
+	}
+}
+
+func isXMLSource(ext, lang string) bool {
+	if lang == "XML" {
+		return true
+	}
+	switch ext {
+	case ".xml", ".xsd", ".xsl", ".xslt", ".wsdl":
+		return true
+	default:
+		return false
+	}
+}
+
+func scanXMLFile(rel string, content []byte) []ports.CodeAnalysisRawFinding {
+	out := scanXMLDuplicateAttributes(rel, content)
+	if f, ok := scanXMLWellFormed(rel, content); ok {
+		out = append(out, f)
+	}
+	return out
+}
+
+func xmlRawFinding(id, title string, severity shared.Severity, rel string, line int, desc string) ports.CodeAnalysisRawFinding {
+	if line <= 0 {
+		line = 1
+	}
+	return ports.CodeAnalysisRawFinding{
+		Kind:        kindReliability,
+		RuleID:      id,
+		CWE:         "",
+		Severity:    severity,
+		Title:       title,
+		Description: desc,
+		File:        rel,
+		Line:        line,
+	}
+}
+
+func scanXMLWellFormed(rel string, content []byte) (ports.CodeAnalysisRawFinding, bool) {
+	dec := xml.NewDecoder(bytes.NewReader(content))
+	rootCount := 0
+	depth := 0
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			if rootCount == 0 && len(bytes.TrimSpace(content)) > 0 {
+				return xmlRawFinding(
+					xmlNotWellFormedRuleID,
+					"XML document is not well formed",
+					shared.SeverityMedium,
+					rel,
+					1,
+					"XML parsing reached the end of the file without a document element.",
+				), true
+			}
+			return ports.CodeAnalysisRawFinding{}, false
+		}
+		if err != nil {
+			line, _ := dec.InputPos()
+			var syntaxErr *xml.SyntaxError
+			if errors.As(err, &syntaxErr) && syntaxErr.Line > 0 {
+				line = syntaxErr.Line
+			}
+			msg := strings.TrimSpace(err.Error())
+			return xmlRawFinding(
+				xmlNotWellFormedRuleID,
+				"XML document is not well formed",
+				shared.SeverityMedium,
+				rel,
+				line,
+				"XML parsing failed before the full document could be read: "+msg+".",
+			), true
+		}
+		switch tok.(type) {
+		case xml.StartElement:
+			if depth == 0 {
+				rootCount++
+				if rootCount > 1 {
+					line, _ := dec.InputPos()
+					return xmlRawFinding(
+						xmlNotWellFormedRuleID,
+						"XML document is not well formed",
+						shared.SeverityMedium,
+						rel,
+						line,
+						"XML parsing found more than one top-level document element.",
+					), true
+				}
+			}
+			depth++
+		case xml.EndElement:
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+}
+
+func scanXMLDuplicateAttributes(rel string, content []byte) []ports.CodeAnalysisRawFinding {
+	var out []ports.CodeAnalysisRawFinding
+	line := 1
+	for i := 0; i < len(content); {
+		if content[i] == '\n' {
+			line++
+			i++
+			continue
+		}
+		if content[i] != '<' {
+			i++
+			continue
+		}
+		switch {
+		case hasPrefix(content, i, "<!--"):
+			i = skipUntil(content, i+4, []byte("-->"), &line)
+			continue
+		case hasPrefix(content, i, "<![CDATA["):
+			i = skipUntil(content, i+9, []byte("]]>"), &line)
+			continue
+		case i+1 < len(content) && content[i+1] == '?':
+			i = skipUntil(content, i+2, []byte("?>"), &line)
+			continue
+		case i+1 < len(content) && content[i+1] == '!':
+			i = skipUntil(content, i+2, []byte(">"), &line)
+			continue
+		case i+1 < len(content) && content[i+1] == '/':
+			i++
+			continue
+		case i+1 >= len(content) || !isXMLNameStartByte(content[i+1]):
+			i++
+			continue
+		}
+
+		i += 2 // skip '<' and first name byte
+		for i < len(content) && isXMLNameByte(content[i]) {
+			if content[i] == '\n' {
+				line++
+			}
+			i++
+		}
+
+		seen := map[string]int{}
+		for i < len(content) {
+			i = skipXMLSpace(content, i, &line)
+			if i >= len(content) {
+				return out
+			}
+			if content[i] == '>' {
+				i++
+				break
+			}
+			if content[i] == '/' && i+1 < len(content) && content[i+1] == '>' {
+				i += 2
+				break
+			}
+
+			attrLine := line
+			nameStart := i
+			for i < len(content) && isXMLNameByte(content[i]) {
+				i++
+			}
+			if nameStart == i {
+				if content[i] == '\n' {
+					line++
+				}
+				i++
+				continue
+			}
+			name := string(content[nameStart:i])
+			if _, ok := seen[name]; ok {
+				desc := fmt.Sprintf("Element start tag repeats attribute %q, which violates XML well-formedness and can make configuration interpretation ambiguous.", name)
+				out = append(out, xmlRawFinding(
+					xmlDuplicateAttributeRuleID,
+					"Duplicate XML attribute",
+					shared.SeverityLow,
+					rel,
+					attrLine,
+					desc,
+				))
+			} else {
+				seen[name] = attrLine
+			}
+
+			i = skipXMLSpace(content, i, &line)
+			if i < len(content) && content[i] == '=' {
+				i++
+				i = skipXMLSpace(content, i, &line)
+				i = skipXMLAttributeValue(content, i, &line)
+			}
+		}
+	}
+	return out
+}
+
+func hasPrefix(content []byte, i int, prefix string) bool {
+	return i+len(prefix) <= len(content) && string(content[i:i+len(prefix)]) == prefix
+}
+
+func skipUntil(content []byte, i int, marker []byte, line *int) int {
+	for i < len(content) {
+		if len(marker) > 0 && i+len(marker) <= len(content) && bytes.Equal(content[i:i+len(marker)], marker) {
+			return i + len(marker)
+		}
+		if content[i] == '\n' {
+			*line = *line + 1
+		}
+		i++
+	}
+	return i
+}
+
+func skipXMLSpace(content []byte, i int, line *int) int {
+	for i < len(content) {
+		switch content[i] {
+		case ' ', '\t', '\r':
+			i++
+		case '\n':
+			*line = *line + 1
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func skipXMLAttributeValue(content []byte, i int, line *int) int {
+	if i >= len(content) {
+		return i
+	}
+	quote := content[i]
+	if quote != '"' && quote != '\'' {
+		return i
+	}
+	i++
+	for i < len(content) {
+		if content[i] == '\n' {
+			*line = *line + 1
+		}
+		if content[i] == quote {
+			return i + 1
+		}
+		i++
+	}
+	return i
+}
+
+func isXMLNameStartByte(b byte) bool {
+	return b == ':' || b == '_' || b >= 0x80 || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}
+
+func isXMLNameByte(b byte) bool {
+	return isXMLNameStartByte(b) || b == '-' || b == '.' || (b >= '0' && b <= '9')
+}

--- a/internal/infrastructure/tools/codeanalysis/xml_test.go
+++ b/internal/infrastructure/tools/codeanalysis/xml_test.go
@@ -1,0 +1,53 @@
+package codeanalysis
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestXMLBugRules(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"compliant.xml":           "<service><name>api</name></service>",
+		"duplicate-attribute.xml": "<service name=\"api\" name=\"worker\" />",
+		"not-well-formed.xml":     "<service><name>api</service>",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	findings, err := New().Analyze(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	byRuleFile := map[string]bool{}
+	for _, f := range findings {
+		byRuleFile[f.RuleID+":"+f.File] = true
+	}
+
+	if !byRuleFile[xmlDuplicateAttributeRuleID+":duplicate-attribute.xml"] {
+		t.Fatalf("expected %s on duplicate-attribute.xml, got %+v", xmlDuplicateAttributeRuleID, findings)
+	}
+	if !byRuleFile[xmlNotWellFormedRuleID+":not-well-formed.xml"] {
+		t.Fatalf("expected %s on not-well-formed.xml, got %+v", xmlNotWellFormedRuleID, findings)
+	}
+	if byRuleFile[xmlDuplicateAttributeRuleID+":compliant.xml"] || byRuleFile[xmlNotWellFormedRuleID+":compliant.xml"] {
+		t.Fatalf("compliant.xml unexpectedly produced XML bug findings: %+v", findings)
+	}
+}
+
+func TestXMLDuplicateAttributeIgnoresNonMarkupSections(t *testing.T) {
+	content := []byte(`<?xml version="1.0"?>
+<!-- <service name="api" name="worker" /> -->
+<service name="api"><![CDATA[<node id="a" id="b" />]]></service>`)
+
+	findings := scanXMLDuplicateAttributes("service.xml", content)
+	if len(findings) != 0 {
+		t.Fatalf("expected no duplicate-attribute findings in comments/CDATA, got %+v", findings)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a small XML bugs/well-formedness slice for #210: parser-backed findings for malformed XML and duplicate attributes.

## Changes

- Add XML file-level codeanalysis rules for `xml:not-well-formed` and `xml:duplicate-attribute`.
- Catalogue the XML rules with metadata, examples, and a `parse` detection mode.
- Add focused XML analyzer tests plus catalog parity/golden inventory coverage.
- Update the code-quality rule authoring guide to include structured parser checks.

Refs #210.

## Validation

- `go test ./internal/domain/rule ./internal/infrastructure/rulecatalog ./internal/infrastructure/tools/codeanalysis ./internal/usecase/codequality`
- `make build`
- `make test`
- `make vet`
- `make typecheck`
- `CGO_ENABLED=0 go build ./cmd/...`

## Checklist

- [x] `make build vet test typecheck` passes
- [x] `cd web && pnpm build` passes (if the dashboard changed) - not run; no dashboard/web changes
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets out of logs, deterministic reports, append-only evidence) - read-only parser/catalog change only
- [x] Documentation updated if needed

AI assistance: This PR was prepared with OpenAI Codex.
