### PR TITLE
Feat/rules api

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29,6 +29,7 @@ tags:
   - name: findings
   - name: sca
   - name: export
+  - name: rule-catalog
 
 paths:
   /healthz:
@@ -232,6 +233,77 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
 
+  /api/v1/rules:
+    get:
+      tags: [rule-catalog]
+      summary: List rule catalog
+      description: Returns the immutable first-party rule catalog with optional filters.
+      parameters:
+        - name: q
+          in: query
+          schema: { type: string }
+        - name: language
+          in: query
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+        - name: type
+          in: query
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+        - name: severity
+          in: query
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+        - name: tag
+          in: query
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+        - name: cwe
+          in: query
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+      responses:
+        "200":
+          description: A list of rule summaries
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/RuleSummary" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+
+  /api/v1/rules/{key}:
+    parameters:
+      - name: key
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      tags: [rule-catalog]
+      summary: Get rule by exact key
+      responses:
+        "200":
+          description: The full rule detail
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RuleDetail" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -380,3 +452,55 @@ components:
           type: object
           additionalProperties: { type: string }
         vuln_db_snapshot: { type: string }
+
+    RuleSummary:
+      type: object
+      properties:
+        key: { type: string }
+        name: { type: string }
+        language: { type: string }
+        type: { type: string }
+        qualities:
+          type: array
+          items: { type: string }
+        default_severity: { type: string }
+        tags:
+          type: array
+          items: { type: string }
+        cwe:
+          type: array
+          items: { type: string }
+        owasp:
+          type: array
+          items: { type: string }
+        description: { type: string }
+        remediation_effort: { type: integer }
+        detection: { type: string }
+
+    RuleDetail:
+      type: object
+      properties:
+        key: { type: string }
+        name: { type: string }
+        language: { type: string }
+        type: { type: string }
+        qualities:
+          type: array
+          items: { type: string }
+        default_severity: { type: string }
+        tags:
+          type: array
+          items: { type: string }
+        cwe:
+          type: array
+          items: { type: string }
+        owasp:
+          type: array
+          items: { type: string }
+        description: { type: string }
+        rationale: { type: string }
+        remediation: { type: string }
+        compliant_example: { type: string }
+        noncompliant_example: { type: string }
+        remediation_effort: { type: integer }
+        detection: { type: string }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -12,8 +12,9 @@ info:
     endpoint except the AUP endpoints also requires that the current Acceptable
     Use Policy has been accepted, else `403`.
 
-    Note: request bodies are snake_case; response objects are serialized from the
-    Go domain structs and therefore use PascalCase property names.
+    Note: legacy response objects may use PascalCase where they are serialized
+    directly from domain structs. Endpoints with explicit response schemas,
+    including the rule catalog API, use the field names documented below.
 
 servers:
   - url: http://localhost:8080
@@ -29,7 +30,8 @@ tags:
   - name: findings
   - name: sca
   - name: export
-  - name: rule-catalog
+  - name: rules
+    description: Built-in code-quality and security rule catalog
 
 paths:
   /healthz:
@@ -235,43 +237,65 @@ paths:
 
   /api/v1/rules:
     get:
-      tags: [rule-catalog]
+      tags: [rules]
       summary: List rule catalog
+      operationId: listRules
       description: Returns the immutable first-party rule catalog with optional filters.
       parameters:
         - name: q
           in: query
-          schema: { type: string }
+          description: Search term. Max length 256. (Total filter values across all dimensions limit is 64).
+          schema:
+            type: string
+            maxLength: 256
         - name: language
           in: query
+          style: form
           explode: true
           schema:
             type: array
-            items: { type: string }
+            maxItems: 32
+            items:
+              type: string
+              maxLength: 128
         - name: type
           in: query
+          style: form
           explode: true
           schema:
             type: array
-            items: { type: string }
+            maxItems: 32
+            items:
+              $ref: "#/components/schemas/RuleType"
         - name: severity
           in: query
+          style: form
           explode: true
           schema:
             type: array
-            items: { type: string }
+            maxItems: 32
+            items:
+              $ref: "#/components/schemas/RuleSeverity"
         - name: tag
           in: query
+          style: form
           explode: true
           schema:
             type: array
-            items: { type: string }
+            maxItems: 32
+            items:
+              type: string
+              maxLength: 128
         - name: cwe
           in: query
+          style: form
           explode: true
           schema:
             type: array
-            items: { type: string }
+            maxItems: 32
+            items:
+              type: string
+              maxLength: 128
       responses:
         "200":
           description: A list of rule summaries
@@ -283,16 +307,20 @@ paths:
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
+        "500": { $ref: "#/components/responses/InternalServerError" }
 
   /api/v1/rules/{key}:
     parameters:
       - name: key
         in: path
         required: true
-        schema: { type: string }
+        schema:
+          type: string
+        example: go:sql-injection
     get:
-      tags: [rule-catalog]
+      tags: [rules]
       summary: Get rule by exact key
+      operationId: getRule
       responses:
         "200":
           description: The full rule detail
@@ -302,6 +330,7 @@ paths:
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
+        "500": { $ref: "#/components/responses/InternalServerError" }
         "404": { $ref: "#/components/responses/NotFound" }
 
 components:
@@ -335,6 +364,11 @@ components:
           schema: { $ref: "#/components/schemas/Error" }
     NotFound:
       description: Resource not found
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    InternalServerError:
+      description: Internal server error
       content:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }
@@ -453,17 +487,60 @@ components:
           additionalProperties: { type: string }
         vuln_db_snapshot: { type: string }
 
+    RuleType:
+      type: string
+      enum:
+        - bug
+        - vulnerability
+        - code_smell
+        - security_hotspot
+
+    RuleQuality:
+      type: string
+      enum:
+        - security
+        - reliability
+        - maintainability
+
+    RuleSeverity:
+      type: string
+      enum:
+        - low
+        - medium
+        - high
+        - critical
+
+    RuleDetection:
+      type: string
+      enum:
+        - ast
+        - pattern
+        - metric
+
     RuleSummary:
       type: object
+      required:
+        - key
+        - name
+        - language
+        - type
+        - qualities
+        - default_severity
+        - tags
+        - cwe
+        - owasp
+        - description
+        - remediation_effort
+        - detection
       properties:
         key: { type: string }
         name: { type: string }
         language: { type: string }
-        type: { type: string }
+        type: { $ref: "#/components/schemas/RuleType" }
         qualities:
           type: array
-          items: { type: string }
-        default_severity: { type: string }
+          items: { $ref: "#/components/schemas/RuleQuality" }
+        default_severity: { $ref: "#/components/schemas/RuleSeverity" }
         tags:
           type: array
           items: { type: string }
@@ -475,19 +552,36 @@ components:
           items: { type: string }
         description: { type: string }
         remediation_effort: { type: integer }
-        detection: { type: string }
+        detection: { $ref: "#/components/schemas/RuleDetection" }
 
     RuleDetail:
       type: object
+      required:
+        - key
+        - name
+        - language
+        - type
+        - qualities
+        - default_severity
+        - tags
+        - cwe
+        - owasp
+        - description
+        - rationale
+        - remediation
+        - compliant_example
+        - noncompliant_example
+        - remediation_effort
+        - detection
       properties:
         key: { type: string }
         name: { type: string }
         language: { type: string }
-        type: { type: string }
+        type: { $ref: "#/components/schemas/RuleType" }
         qualities:
           type: array
-          items: { type: string }
-        default_severity: { type: string }
+          items: { $ref: "#/components/schemas/RuleQuality" }
+        default_severity: { $ref: "#/components/schemas/RuleSeverity" }
         tags:
           type: array
           items: { type: string }
@@ -503,4 +597,4 @@ components:
         compliant_example: { type: string }
         noncompliant_example: { type: string }
         remediation_effort: { type: integer }
-        detection: { type: string }
+        detection: { $ref: "#/components/schemas/RuleDetection" }

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
 	recontools "github.com/KKloudTarus/synapse-ce/internal/infrastructure/recon"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/report"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/rulecatalog"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sandbox"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/signing"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourcesnippet"
@@ -111,6 +112,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachproof"
 	reconuc "github.com/KKloudTarus/synapse-ce/internal/usecase/recon"
 	reportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/report"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/sbomcrosscheckjudge"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
@@ -839,6 +841,15 @@ func main() {
 		codequality.WithDuplication(duplication.New(0)),
 		codequality.WithInventory(codeinventory.New()),
 	))
+	if ruleCat, rerr := rulecatalog.Default(); rerr != nil {
+		log.Error("rule catalog init failed", "err", rerr)
+		os.Exit(1)
+	} else if rulesSvc, rerr := rules.NewService(ruleCat); rerr != nil {
+		log.Error("rules service init failed", "err", rerr)
+		os.Exit(1)
+	} else {
+		router.SetRules(rulesSvc)
+	}
 	if tmSvc, terr := threatmodeluc.NewService(threatModelStore, auditLog, clock); terr != nil { // architecture threat-model ingest/read
 		log.Error("threat-model service init failed", "err", terr)
 		os.Exit(1)

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/threatmodel"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/writeupdraft"
@@ -17,6 +18,7 @@ import (
 	dastverifieruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastverifier"
 	dastworkflowuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastworkflow"
 	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
 	usersuc "github.com/KKloudTarus/synapse-ce/internal/usecase/users"
 )
 
@@ -79,6 +81,12 @@ func (fakeWriteupDrafts) Reject(context.Context, string, shared.ID, shared.ID) (
 	return writeupdraft.Draft{}, nil
 }
 
+// fakeRules is a no-op rulesService for the harness.
+type fakeRules struct{}
+
+func (fakeRules) List(context.Context, rules.Filter) ([]rule.Rule, error) { return nil, nil }
+func (fakeRules) Get(context.Context, rule.Key) (rule.Rule, error)        { return rule.Rule{}, nil }
+
 // TestHostileHarness drives the REAL route table (rt.routes()) through the production
 // authz → withEngTenant → handler chain with a context-injected principal, asserting the program's
 // cross-cutting authorization invariants END-TO-END through the actual wiring (not a stand-in):
@@ -122,6 +130,7 @@ func TestHostileHarness(t *testing.T) {
 	rt.SetDASTWorkflow(&fakeDASTWorkflow{})
 	rt.SetThreatModel(&fakeThreatModel{})     // register the threat-model ingest/read routes so the harness guards their gates
 	rt.SetWriteupDrafts(&fakeWriteupDrafts{}) // register the writeup-draft sign-off routes so the harness guards their SoD gates
+	rt.SetRules(&fakeRules{})                 // register rule catalog routes so the harness guards their gates
 	rt.EnableAgent(nil, nil, nil, nil, nil, 1, 8)
 	mux := rt.routes()
 
@@ -207,6 +216,11 @@ func TestHostileHarness(t *testing.T) {
 		{"machine may not edit writeup draft (review)", "agent", "tenantA", true, http.MethodPost, "/api/v1/engagements/engA/writeup-drafts/d1/edit", http.StatusForbidden},
 		{"cross-tenant writeup-draft accept → 404", "reviewer", "tenantB", true, http.MethodPost, "/api/v1/engagements/engA/writeup-drafts/d1/accept", http.StatusNotFound},
 		{"readonly may list writeup drafts (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/writeup-drafts", http.StatusOK},
+		// Rule Catalog (PermView): no tenant context required, but machine roles denied.
+		{"machine may not list rules (view/SoD)", "agent", "tenantA", true, http.MethodGet, "/api/v1/rules", http.StatusForbidden},
+		{"machine may not get rule (view/SoD)", "agent", "tenantA", true, http.MethodGet, "/api/v1/rules/go:sql-injection", http.StatusForbidden},
+		{"readonly may list rules (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/rules", http.StatusOK},
+		{"readonly may get rule (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/rules/go:sql-injection", http.StatusOK},
 	}
 	for _, c := range cases {
 		if got := send(c.role, c.tenant, c.method, c.path, c.authed); got != c.want {

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -59,6 +59,7 @@ type Router struct {
 	threatModels threatModelService  // optional; nil ⇒ threat-model routes are not registered
 	drafts       writeupDraftService // optional; nil ⇒ writeup-draft sign-off routes are not registered
 	codeQuality  codeQualityService  // optional; nil ⇒ the code-quality route is not registered
+	rules        rulesService        // optional; nil ⇒ rule catalog routes are not registered
 }
 
 // findingVerifier is the narrow slice of the exploitation use-case the verify endpoint needs:
@@ -123,6 +124,9 @@ func (rt *Router) SetThreatModel(s threatModelService) { rt.threatModels = s }
 
 // SetWriteupDrafts wires the human sign-off endpoints for AI-proposed write-up drafts. nil ⇒ not registered.
 func (rt *Router) SetWriteupDrafts(s writeupDraftService) { rt.drafts = s }
+
+// SetRules wires the rule catalog endpoints. nil ⇒ not registered.
+func (rt *Router) SetRules(s rulesService) { rt.rules = s }
 
 // NewRouter builds the HTTP router.
 func NewRouter(log *slog.Logger, auth *Authenticator, eng *enguc.Service, sca *scauc.Service, aup *aupuc.Service, findings *findingsuc.Service, export *exportuc.Service, report *reportuc.Service, evidence *evidenceuc.Service, recon *reconuc.Service, logs ports.LogStream, transfer *transferuc.Service, audit *audituc.Service, vex *vexuc.Service, users *usersuc.Service, credentials *credentialsuc.Service) *Router {
@@ -282,6 +286,11 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/engagements/{id}/agent/sessions/{sid}/stream", rt.authz(userdom.PermView, rt.withEngTenant(rt.streamAgentSession)))
 		mux.HandleFunc("GET /api/v1/engagements/{id}/agent/approvals", rt.authz(userdom.PermView, rt.withEngTenant(rt.listAgentApprovals)))
 		mux.HandleFunc("POST /api/v1/engagements/{id}/agent/approvals/{aid}/decide", rt.authz(userdom.PermReview, rt.withEngTenant(rt.decideAgentApproval)))
+	}
+
+	if rt.rules != nil { // read-only rule catalog (PermView)
+		mux.HandleFunc("GET /api/v1/rules", rt.authz(userdom.PermView, rt.listRules))
+		mux.HandleFunc("GET /api/v1/rules/{key}", rt.authz(userdom.PermView, rt.getRule))
 	}
 
 	return mux

--- a/internal/adapter/httpapi/router_rules_test.go
+++ b/internal/adapter/httpapi/router_rules_test.go
@@ -1,0 +1,122 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aup"
+)
+
+func TestRouter_RulesAPI_FullMiddleware(t *testing.T) {
+	// 1. Setup Auth
+	auth := NewAuthenticator(func(_ context.Context, token string) (Principal, bool) {
+		if token == "secret" {
+			return Principal{ID: "u1", Name: "Tester", Role: "readonly", TenantID: "tenantA"}, true
+		}
+		if token == "agent-secret" {
+			return Principal{ID: "m1", Name: "Machine", Role: "agent", TenantID: "tenantA"}, true
+		}
+		return Principal{}, false
+	})
+
+	// 2. Setup AUP
+	aupStore := newFakeAUPStore()
+	aupSvc := newTestAUP(aupStore, &fakeAudit{})
+
+	// 3. Setup Router
+	rt := &Router{
+		log:  discardLog(),
+		auth: auth,
+		aup:  aupSvc,
+	}
+	rt.SetRules(&fakeRulesService{})
+	h := rt.Handler()
+
+	callList := func(token string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/rules", nil)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w
+	}
+
+	callGet := func(token string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/rules/some-key", nil)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w
+	}
+
+	// a. unauthenticated request -> 401
+	if w := callList(""); w.Code != http.StatusUnauthorized {
+		t.Errorf("unauthenticated list: expected 401, got %d", w.Code)
+	}
+	if w := callGet(""); w.Code != http.StatusUnauthorized {
+		t.Errorf("unauthenticated get: expected 401, got %d", w.Code)
+	}
+
+	// b. authenticated viewer, AUP not accepted -> 403
+	if w := callList("secret"); w.Code != http.StatusForbidden {
+		t.Errorf("unaccepted AUP list: expected 403, got %d", w.Code)
+	}
+
+	// c. authenticated viewer, AUP accepted -> 200
+	aupStore.accepted["1.0"] = aup.Acceptance{Version: "1.0"}
+	if w := callList("secret"); w.Code != http.StatusOK {
+		t.Errorf("accepted AUP list: expected 200, got %d", w.Code)
+	}
+	if w := callGet("secret"); w.Code != http.StatusOK {
+		t.Errorf("accepted AUP get: expected 200, got %d", w.Code)
+	}
+
+	// d. authenticated machine role (agent) -> 403 (PermView denied by authz)
+	if w := callList("agent-secret"); w.Code != http.StatusForbidden {
+		t.Errorf("agent list: expected 403, got %d", w.Code)
+	}
+	if w := callGet("agent-secret"); w.Code != http.StatusForbidden {
+		t.Errorf("agent get: expected 403, got %d", w.Code)
+	}
+}
+
+func TestRouter_RulesRoutePresence(t *testing.T) {
+	rt := &Router{log: discardLog()}
+	// SetRules NOT called
+
+	callList := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/rules", nil)
+		w := httptest.NewRecorder()
+		rt.routes().ServeHTTP(w, req)
+		return w
+	}
+
+	callGet := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/rules/some-key", nil)
+		w := httptest.NewRecorder()
+		rt.routes().ServeHTTP(w, req)
+		return w
+	}
+
+	if callList().Code != http.StatusNotFound {
+		t.Errorf("expected 404 when rules not set, got %d", callList().Code)
+	}
+	if callGet().Code != http.StatusNotFound {
+		t.Errorf("expected 404 when rules not set, got %d", callGet().Code)
+	}
+
+	// SetRules called
+	rt.SetRules(&fakeRulesService{})
+
+	if callList().Code == http.StatusNotFound {
+		t.Errorf("expected route to be present")
+	}
+	if callGet().Code == http.StatusNotFound {
+		t.Errorf("expected route to be present")
+	}
+}

--- a/internal/adapter/httpapi/rule_handler.go
+++ b/internal/adapter/httpapi/rule_handler.go
@@ -1,0 +1,167 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
+)
+
+type rulesService interface {
+	List(context.Context, rules.Filter) ([]rule.Rule, error)
+	Get(context.Context, rule.Key) (rule.Rule, error)
+}
+
+type ruleSummaryView struct {
+	Key               string   `json:"key"`
+	Name              string   `json:"name"`
+	Language          string   `json:"language"`
+	Type              string   `json:"type"`
+	Qualities         []string `json:"qualities"`
+	DefaultSeverity   string   `json:"default_severity"`
+	Tags              []string `json:"tags"`
+	CWE               []string `json:"cwe"`
+	OWASP             []string `json:"owasp"`
+	Description       string   `json:"description"`
+	RemediationEffort int      `json:"remediation_effort"`
+	Detection         string   `json:"detection"`
+}
+
+type ruleDetailView struct {
+	Key                 string   `json:"key"`
+	Name                string   `json:"name"`
+	Language            string   `json:"language"`
+	Type                string   `json:"type"`
+	Qualities           []string `json:"qualities"`
+	DefaultSeverity     string   `json:"default_severity"`
+	Tags                []string `json:"tags"`
+	CWE                 []string `json:"cwe"`
+	OWASP               []string `json:"owasp"`
+	Description         string   `json:"description"`
+	Rationale           string   `json:"rationale"`
+	Remediation         string   `json:"remediation"`
+	CompliantExample    string   `json:"compliant_example"`
+	NoncompliantExample string   `json:"noncompliant_example"`
+	RemediationEffort   int      `json:"remediation_effort"`
+	Detection           string   `json:"detection"`
+}
+
+func toRuleSummary(r rule.Rule) ruleSummaryView {
+	return ruleSummaryView{
+		Key:               string(r.Key),
+		Name:              r.Name,
+		Language:          r.Language,
+		Type:              string(r.Type),
+		Qualities:         qualitiesToStrings(r.Qualities),
+		DefaultSeverity:   string(r.DefaultSeverity),
+		Tags:              stringsOrDefault(r.Tags),
+		CWE:               stringsOrDefault(r.CWE),
+		OWASP:             stringsOrDefault(r.OWASP),
+		Description:       r.Description,
+		RemediationEffort: r.RemediationEffort,
+		Detection:         string(r.Detection),
+	}
+}
+
+func toRuleDetail(r rule.Rule) ruleDetailView {
+	return ruleDetailView{
+		Key:                 string(r.Key),
+		Name:                r.Name,
+		Language:            r.Language,
+		Type:                string(r.Type),
+		Qualities:           qualitiesToStrings(r.Qualities),
+		DefaultSeverity:     string(r.DefaultSeverity),
+		Tags:                stringsOrDefault(r.Tags),
+		CWE:                 stringsOrDefault(r.CWE),
+		OWASP:               stringsOrDefault(r.OWASP),
+		Description:         r.Description,
+		Rationale:           r.Rationale,
+		Remediation:         r.Remediation,
+		CompliantExample:    r.CompliantExample,
+		NoncompliantExample: r.NoncompliantExample,
+		RemediationEffort:   r.RemediationEffort,
+		Detection:           string(r.Detection),
+	}
+}
+
+func qualitiesToStrings(q []rule.Quality) []string {
+	if len(q) == 0 {
+		return []string{}
+	}
+	s := make([]string, len(q))
+	for i, v := range q {
+		s[i] = string(v)
+	}
+	return s
+}
+
+func stringsOrDefault(s []string) []string {
+	if len(s) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), s...)
+}
+
+func (rt *Router) listRules(w http.ResponseWriter, r *http.Request) {
+	allowed := map[string]bool{
+		"q":        true,
+		"language": true,
+		"type":     true,
+		"severity": true,
+		"tag":      true,
+		"cwe":      true,
+	}
+	for k := range r.URL.Query() {
+		if !allowed[k] {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "unsupported query parameter: " + k})
+			return
+		}
+	}
+
+	qParams := r.URL.Query()
+	f, err := rules.NewFilter(
+		qParams.Get("q"),
+		qParams["language"],
+		qParams["type"],
+		qParams["severity"],
+		qParams["tag"],
+		qParams["cwe"],
+	)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: err.Error()})
+		return
+	}
+
+	res, err := rt.rules.List(r.Context(), f)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+
+	views := make([]ruleSummaryView, len(res))
+	for i, rl := range res {
+		views[i] = toRuleSummary(rl)
+	}
+	if views == nil {
+		views = []ruleSummaryView{}
+	}
+
+	writeJSON(w, http.StatusOK, views)
+}
+
+func (rt *Router) getRule(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("key")
+	if key == "" {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "empty rule key"})
+		return
+	}
+
+	res, err := rt.rules.Get(r.Context(), rule.Key(key))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toRuleDetail(res))
+}

--- a/internal/adapter/httpapi/rule_handler_test.go
+++ b/internal/adapter/httpapi/rule_handler_test.go
@@ -22,14 +22,18 @@ type fakeRulesService struct {
 	getErr     error
 	lastFilter rules.Filter
 	lastKey    rule.Key
+	listCalls  int
+	getCalls   int
 }
 
 func (f *fakeRulesService) List(ctx context.Context, filter rules.Filter) ([]rule.Rule, error) {
+	f.listCalls++
 	f.lastFilter = filter
 	return f.listRes, f.listErr
 }
 
 func (f *fakeRulesService) Get(ctx context.Context, key rule.Key) (rule.Rule, error) {
+	f.getCalls++
 	f.lastKey = key
 	return f.getRes, f.getErr
 }
@@ -75,16 +79,35 @@ func TestRouter_listRules(t *testing.T) {
 	})
 
 	t.Run("unsupported query param", func(t *testing.T) {
+		svc.listCalls = 0
 		w := callList("/api/v1/rules?severty=high")
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400 for bad query param, got %d", w.Code)
 		}
+		if svc.listCalls != 0 {
+			t.Errorf("expected 0 list calls, got %d", svc.listCalls)
+		}
 	})
 
 	t.Run("service validation error", func(t *testing.T) {
+		svc.listCalls = 0
 		w := callList("/api/v1/rules?type=unknown")
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400 for bad type, got %d", w.Code)
+		}
+		if svc.listCalls != 0 {
+			t.Errorf("expected 0 list calls, got %d", svc.listCalls)
+		}
+	})
+
+	t.Run("combined params", func(t *testing.T) {
+		svc.listCalls = 0
+		w := callList("/api/v1/rules?severity=high&severity=critical&tag=security")
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		if len(svc.lastFilter.Severities) != 2 || len(svc.lastFilter.Tags) != 1 {
+			t.Errorf("expected 2 severities and 1 tag, got %v and %v", svc.lastFilter.Severities, svc.lastFilter.Tags)
 		}
 	})
 
@@ -158,6 +181,15 @@ func TestRouter_getRule(t *testing.T) {
 		}
 		svc.getErr = nil
 	})
+
+	t.Run("service internal error", func(t *testing.T) {
+		svc.getErr = errors.New("boom")
+		w := callGet("go:sql")
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", w.Code)
+		}
+		svc.getErr = nil
+	})
 }
 
 func TestRealCatalogIntegration(t *testing.T) {
@@ -195,11 +227,25 @@ func TestRealCatalogIntegration(t *testing.T) {
 		}
 
 		var res []map[string]any
-		json.Unmarshal(w.Body.Bytes(), &res)
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Fatal(err)
+		}
 
-		all, _ := cat.List(context.Background())
+		all, err := cat.List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
 		if len(res) != len(all) {
-			t.Errorf("expected %d rules, got %d", len(all), len(res))
+			t.Fatalf("expected %d rules, got %d", len(all), len(res))
+		}
+
+		// Check exact ordered key sets
+		for i := 0; i < len(all); i++ {
+			expectedKey := string(all[i].Key)
+			actualKey := res[i]["key"].(string)
+			if expectedKey != actualKey {
+				t.Errorf("index %d: expected key %s, got %s", i, expectedKey, actualKey)
+			}
 		}
 
 		// check sorting
@@ -215,7 +261,9 @@ func TestRealCatalogIntegration(t *testing.T) {
 	t.Run("filter returns subset", func(t *testing.T) {
 		w := callList("/api/v1/rules?language=go")
 		var res []map[string]any
-		json.Unmarshal(w.Body.Bytes(), &res)
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Fatal(err)
+		}
 
 		if len(res) == 0 {
 			t.Errorf("expected some go rules")
@@ -228,7 +276,10 @@ func TestRealCatalogIntegration(t *testing.T) {
 	})
 
 	t.Run("get known key", func(t *testing.T) {
-		all, _ := cat.List(context.Background())
+		all, err := cat.List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
 		firstKey := string(all[0].Key)
 
 		w := callGet(firstKey)
@@ -237,7 +288,9 @@ func TestRealCatalogIntegration(t *testing.T) {
 		}
 
 		var res map[string]any
-		json.Unmarshal(w.Body.Bytes(), &res)
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Fatal(err)
+		}
 		if res["key"] != firstKey {
 			t.Errorf("expected key %s, got %v", firstKey, res["key"])
 		}

--- a/internal/adapter/httpapi/rule_handler_test.go
+++ b/internal/adapter/httpapi/rule_handler_test.go
@@ -1,0 +1,255 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/rulecatalog"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
+)
+
+type fakeRulesService struct {
+	listRes    []rule.Rule
+	listErr    error
+	getRes     rule.Rule
+	getErr     error
+	lastFilter rules.Filter
+	lastKey    rule.Key
+}
+
+func (f *fakeRulesService) List(ctx context.Context, filter rules.Filter) ([]rule.Rule, error) {
+	f.lastFilter = filter
+	return f.listRes, f.listErr
+}
+
+func (f *fakeRulesService) Get(ctx context.Context, key rule.Key) (rule.Rule, error) {
+	f.lastKey = key
+	return f.getRes, f.getErr
+}
+
+func TestRouter_listRules(t *testing.T) {
+	svc := &fakeRulesService{
+		listRes: []rule.Rule{
+			{Key: "r1", Language: "go", Tags: []string{"tag1"}},
+		},
+	}
+	rt := &Router{rules: svc, log: discardLog()}
+
+	callList := func(target string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		w := httptest.NewRecorder()
+		rt.listRules(w, req)
+		return w
+	}
+
+	t.Run("success", func(t *testing.T) {
+		w := callList("/api/v1/rules?language=go&language=python&type=bug")
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		if len(svc.lastFilter.Languages) != 2 {
+			t.Errorf("expected parsed filter languages, got %v", svc.lastFilter.Languages)
+		}
+
+		var res []map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Fatal(err)
+		}
+		if len(res) != 1 || res[0]["key"] != "r1" {
+			t.Errorf("expected summary payload, got %v", res)
+		}
+
+		if res[0]["tags"] == nil {
+			t.Errorf("expected non-null array")
+		}
+		if _, ok := res[0]["compliant_example"]; ok {
+			t.Errorf("summary should not contain compliant_example")
+		}
+	})
+
+	t.Run("unsupported query param", func(t *testing.T) {
+		w := callList("/api/v1/rules?severty=high")
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for bad query param, got %d", w.Code)
+		}
+	})
+
+	t.Run("service validation error", func(t *testing.T) {
+		w := callList("/api/v1/rules?type=unknown")
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for bad type, got %d", w.Code)
+		}
+	})
+
+	t.Run("service internal error", func(t *testing.T) {
+		svc.listErr = errors.New("boom")
+		w := callList("/api/v1/rules")
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", w.Code)
+		}
+		svc.listErr = nil
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		svc.listRes = nil
+		w := callList("/api/v1/rules")
+		if w.Code != http.StatusOK || w.Body.String() != "[]\n" {
+			t.Errorf("expected empty array, got %q", w.Body.String())
+		}
+	})
+}
+
+func TestRouter_getRule(t *testing.T) {
+	svc := &fakeRulesService{
+		getRes: rule.Rule{Key: "r1", CompliantExample: "example"},
+	}
+	rt := &Router{rules: svc, log: discardLog()}
+
+	callGet := func(key string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/rules/"+key, nil)
+		req.SetPathValue("key", key)
+		w := httptest.NewRecorder()
+		rt.getRule(w, req)
+		return w
+	}
+
+	t.Run("success", func(t *testing.T) {
+		w := callGet("go:sql")
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		if svc.lastKey != "go:sql" {
+			t.Errorf("expected preserved key, got %s", svc.lastKey)
+		}
+		var res map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Fatal(err)
+		}
+		if res["compliant_example"] != "example" {
+			t.Errorf("expected detail payload")
+		}
+		if res["tags"] == nil {
+			t.Errorf("expected non-null array")
+		}
+		if _, ok := res["CompliantExample"]; ok {
+			t.Errorf("should not contain PascalCase keys")
+		}
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		w := callGet("")
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		svc.getErr = shared.ErrNotFound
+		w := callGet("unknown")
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", w.Code)
+		}
+		svc.getErr = nil
+	})
+}
+
+func TestRealCatalogIntegration(t *testing.T) {
+	cat, err := rulecatalog.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := rules.NewService(cat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rt := &Router{rules: svc, log: discardLog()}
+
+	callList := func(target string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		w := httptest.NewRecorder()
+		rt.listRules(w, req)
+		return w
+	}
+
+	callGet := func(key string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/rules/"+key, nil)
+		req.SetPathValue("key", key)
+		w := httptest.NewRecorder()
+		rt.getRule(w, req)
+		return w
+	}
+
+	t.Run("list all matches catalog count", func(t *testing.T) {
+		w := callList("/api/v1/rules")
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+
+		var res []map[string]any
+		json.Unmarshal(w.Body.Bytes(), &res)
+
+		all, _ := cat.List(context.Background())
+		if len(res) != len(all) {
+			t.Errorf("expected %d rules, got %d", len(all), len(res))
+		}
+
+		// check sorting
+		for i := 1; i < len(res); i++ {
+			k1 := res[i-1]["key"].(string)
+			k2 := res[i]["key"].(string)
+			if k1 > k2 {
+				t.Errorf("expected sorted keys, found %s > %s", k1, k2)
+			}
+		}
+	})
+
+	t.Run("filter returns subset", func(t *testing.T) {
+		w := callList("/api/v1/rules?language=go")
+		var res []map[string]any
+		json.Unmarshal(w.Body.Bytes(), &res)
+
+		if len(res) == 0 {
+			t.Errorf("expected some go rules")
+		}
+		for _, r := range res {
+			if strings.ToLower(r["language"].(string)) != "go" {
+				t.Errorf("expected go rule, got %v", r["language"])
+			}
+		}
+	})
+
+	t.Run("get known key", func(t *testing.T) {
+		all, _ := cat.List(context.Background())
+		firstKey := string(all[0].Key)
+
+		w := callGet(firstKey)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+
+		var res map[string]any
+		json.Unmarshal(w.Body.Bytes(), &res)
+		if res["key"] != firstKey {
+			t.Errorf("expected key %s, got %v", firstKey, res["key"])
+		}
+		if res["description"] == "" {
+			t.Errorf("expected description")
+		}
+	})
+
+	t.Run("get unknown key", func(t *testing.T) {
+		w := callGet("some-non-existent-rule-key-123")
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", w.Code)
+		}
+	})
+}

--- a/internal/usecase/rules/service.go
+++ b/internal/usecase/rules/service.go
@@ -1,0 +1,344 @@
+package rules
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Filter represents normalized catalog query parameters.
+type Filter struct {
+	Query      string
+	Languages  []string
+	Types      []rule.Type
+	Severities []shared.Severity
+	Tags       []string
+	CWE        []string
+}
+
+const (
+	maxQueryLen        = 256
+	maxFilterValueLen  = 128
+	maxFilterValues    = 32
+	maxTotalFilterVals = 64
+)
+
+// NewFilter creates, normalizes, and validates a catalog filter.
+func NewFilter(query string, languages, types, severities, tags, cwe []string) (Filter, error) {
+	q := strings.TrimSpace(query)
+	if utf8.RuneCountInString(q) > maxQueryLen {
+		return Filter{}, fmt.Errorf("%w: query exceeds maximum length of %d", shared.ErrValidation, maxQueryLen)
+	}
+
+	totalVals := len(languages) + len(types) + len(severities) + len(tags) + len(cwe)
+	if totalVals > maxTotalFilterVals {
+		return Filter{}, fmt.Errorf("%w: total filter values exceed maximum of %d", shared.ErrValidation, maxTotalFilterVals)
+	}
+
+	checkDim := func(name string, slice []string) error {
+		if len(slice) > maxFilterValues {
+			return fmt.Errorf("%w: %s values exceed maximum of %d", shared.ErrValidation, name, maxFilterValues)
+		}
+		for _, v := range slice {
+			if utf8.RuneCountInString(v) > maxFilterValueLen {
+				return fmt.Errorf("%w: %s value exceeds maximum length of %d", shared.ErrValidation, name, maxFilterValueLen)
+			}
+		}
+		return nil
+	}
+
+	if err := checkDim("languages", languages); err != nil {
+		return Filter{}, err
+	}
+	if err := checkDim("types", types); err != nil {
+		return Filter{}, err
+	}
+	if err := checkDim("severities", severities); err != nil {
+		return Filter{}, err
+	}
+	if err := checkDim("tags", tags); err != nil {
+		return Filter{}, err
+	}
+	if err := checkDim("cwe", cwe); err != nil {
+		return Filter{}, err
+	}
+
+	f := Filter{Query: strings.ToLower(q)}
+
+	// Normalize Languages
+	langSet := make(map[string]struct{})
+	for _, l := range languages {
+		l = strings.TrimSpace(l)
+		if l == "" {
+			return Filter{}, fmt.Errorf("%w: empty language value", shared.ErrValidation)
+		}
+		lLower := strings.ToLower(l)
+		if _, ok := langSet[lLower]; !ok {
+			langSet[lLower] = struct{}{}
+			f.Languages = append(f.Languages, lLower)
+		}
+	}
+
+	// Normalize Types
+	typeSet := make(map[rule.Type]struct{})
+	for _, t := range types {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			return Filter{}, fmt.Errorf("%w: empty type value", shared.ErrValidation)
+		}
+		rt := rule.Type(strings.ToLower(t))
+		switch rt {
+		case rule.TypeBug, rule.TypeVulnerability, rule.TypeCodeSmell, rule.TypeSecurityHotspot:
+			if _, ok := typeSet[rt]; !ok {
+				typeSet[rt] = struct{}{}
+				f.Types = append(f.Types, rt)
+			}
+		default:
+			return Filter{}, fmt.Errorf("%w: invalid type value %q", shared.ErrValidation, t)
+		}
+	}
+
+	// Normalize Severities
+	sevSet := make(map[shared.Severity]struct{})
+	for _, s := range severities {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return Filter{}, fmt.Errorf("%w: empty severity value", shared.ErrValidation)
+		}
+		rs := shared.Severity(strings.ToLower(s))
+		switch rs {
+		case shared.SeverityLow, shared.SeverityMedium, shared.SeverityHigh, shared.SeverityCritical:
+			if _, ok := sevSet[rs]; !ok {
+				sevSet[rs] = struct{}{}
+				f.Severities = append(f.Severities, rs)
+			}
+		default:
+			return Filter{}, fmt.Errorf("%w: invalid severity value %q", shared.ErrValidation, s)
+		}
+	}
+
+	// Normalize Tags
+	tagSet := make(map[string]struct{})
+	for _, tg := range tags {
+		tg = strings.TrimSpace(tg)
+		if tg == "" {
+			return Filter{}, fmt.Errorf("%w: empty tag value", shared.ErrValidation)
+		}
+		tgLower := strings.ToLower(tg)
+		if _, ok := tagSet[tgLower]; !ok {
+			tagSet[tgLower] = struct{}{}
+			f.Tags = append(f.Tags, tgLower)
+		}
+	}
+
+	// Normalize CWE
+	cweSet := make(map[string]struct{})
+	for _, c := range cwe {
+		c = strings.TrimSpace(strings.ToUpper(c))
+		if c == "" {
+			return Filter{}, fmt.Errorf("%w: empty CWE value", shared.ErrValidation)
+		}
+		c = strings.TrimPrefix(c, "CWE-")
+		id, err := strconv.Atoi(c)
+		if err != nil || id <= 0 || strings.Contains(c, ".") || strings.Contains(c, " ") || strings.HasPrefix(c, "-") || strings.HasPrefix(c, "+") {
+			return Filter{}, fmt.Errorf("%w: invalid CWE value %q", shared.ErrValidation, c)
+		}
+		for _, r := range c {
+			if r < '0' || r > '9' {
+				return Filter{}, fmt.Errorf("%w: invalid CWE value %q", shared.ErrValidation, c)
+			}
+		}
+		
+		cweForm := fmt.Sprintf("CWE-%d", id)
+		if _, ok := cweSet[cweForm]; !ok {
+			cweSet[cweForm] = struct{}{}
+			f.CWE = append(f.CWE, cweForm)
+		}
+	}
+
+	return f, nil
+}
+
+// Service provides rule catalog queries.
+type Service struct {
+	catalog ports.RuleCatalog
+}
+
+// NewService creates a new Service.
+func NewService(catalog ports.RuleCatalog) (*Service, error) {
+	if catalog == nil {
+		return nil, errors.New("catalog dependency is required")
+	}
+	return &Service{catalog: catalog}, nil
+}
+
+// List returns catalog rules matching the filter, sorted by key.
+func (s *Service) List(ctx context.Context, filter Filter) ([]rule.Rule, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	
+	all, err := s.catalog.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	langSet := make(map[string]bool, len(filter.Languages))
+	for _, l := range filter.Languages {
+		langSet[l] = true
+	}
+	typeSet := make(map[rule.Type]bool, len(filter.Types))
+	for _, t := range filter.Types {
+		typeSet[t] = true
+	}
+	sevSet := make(map[shared.Severity]bool, len(filter.Severities))
+	for _, sev := range filter.Severities {
+		sevSet[sev] = true
+	}
+	tagSet := make(map[string]bool, len(filter.Tags))
+	for _, t := range filter.Tags {
+		tagSet[t] = true
+	}
+	cweSet := make(map[string]bool, len(filter.CWE))
+	for _, c := range filter.CWE {
+		cweSet[c] = true
+	}
+
+	var results []rule.Rule
+	for i, r := range all {
+		if i%100 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+
+		if len(langSet) > 0 && !langSet[strings.ToLower(r.Language)] {
+			continue
+		}
+		if len(typeSet) > 0 && !typeSet[r.Type] {
+			continue
+		}
+		if len(sevSet) > 0 && !sevSet[r.DefaultSeverity] {
+			continue
+		}
+		if len(tagSet) > 0 {
+			match := false
+			for _, rt := range r.Tags {
+				if tagSet[strings.ToLower(rt)] {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+		if len(cweSet) > 0 {
+			match := false
+			for _, rc := range r.CWE {
+				if cweSet[rc] {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+
+		if filter.Query != "" {
+			if !strings.Contains(strings.ToLower(string(r.Key)), filter.Query) &&
+				!strings.Contains(strings.ToLower(r.Name), filter.Query) &&
+				!strings.Contains(strings.ToLower(r.Language), filter.Query) &&
+				!strings.Contains(strings.ToLower(string(r.Type)), filter.Query) &&
+				!strings.Contains(strings.ToLower(string(r.DefaultSeverity)), filter.Query) &&
+				!strings.Contains(strings.ToLower(r.Description), filter.Query) &&
+				!strings.Contains(strings.ToLower(r.Rationale), filter.Query) &&
+				!strings.Contains(strings.ToLower(r.Remediation), filter.Query) &&
+				!strings.Contains(strings.ToLower(string(r.Detection)), filter.Query) &&
+				!containsQualitySubstring(r.Qualities, filter.Query) &&
+				!containsSubstring(r.Tags, filter.Query) &&
+				!containsSubstring(r.CWE, filter.Query) &&
+				!containsSubstring(r.OWASP, filter.Query) {
+				continue
+			}
+		}
+
+		results = append(results, cloneRule(r))
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return string(results[i].Key) < string(results[j].Key)
+	})
+
+	if results == nil {
+		results = []rule.Rule{}
+	}
+	return results, nil
+}
+
+func containsSubstring(slice []string, q string) bool {
+	for _, v := range slice {
+		if strings.Contains(strings.ToLower(v), q) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsQualitySubstring(slice []rule.Quality, q string) bool {
+	for _, v := range slice {
+		if strings.Contains(strings.ToLower(string(v)), q) {
+			return true
+		}
+	}
+	return false
+}
+
+// Get returns the exact rule by key.
+func (s *Service) Get(ctx context.Context, key rule.Key) (rule.Rule, error) {
+	if string(key) == "" {
+		return rule.Rule{}, fmt.Errorf("%w: empty rule key", shared.ErrValidation)
+	}
+	r, err := s.catalog.Get(ctx, key)
+	if err != nil {
+		return rule.Rule{}, err
+	}
+	return cloneRule(r), nil
+}
+
+func cloneStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	if len(s) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), s...)
+}
+
+func cloneQualities(s []rule.Quality) []rule.Quality {
+	if s == nil {
+		return nil
+	}
+	if len(s) == 0 {
+		return []rule.Quality{}
+	}
+	return append([]rule.Quality(nil), s...)
+}
+
+func cloneRule(r rule.Rule) rule.Rule {
+	r.Qualities = cloneQualities(r.Qualities)
+	r.Tags = cloneStrings(r.Tags)
+	r.CWE = cloneStrings(r.CWE)
+	r.OWASP = cloneStrings(r.OWASP)
+	return r
+}

--- a/internal/usecase/rules/service.go
+++ b/internal/usecase/rules/service.go
@@ -156,7 +156,7 @@ func NewFilter(query string, languages, types, severities, tags, cwe []string) (
 				return Filter{}, fmt.Errorf("%w: invalid CWE value %q", shared.ErrValidation, c)
 			}
 		}
-		
+
 		cweForm := fmt.Sprintf("CWE-%d", id)
 		if _, ok := cweSet[cweForm]; !ok {
 			cweSet[cweForm] = struct{}{}
@@ -185,7 +185,7 @@ func (s *Service) List(ctx context.Context, filter Filter) ([]rule.Rule, error) 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	
+
 	all, err := s.catalog.List(ctx)
 	if err != nil {
 		return nil, err
@@ -305,6 +305,9 @@ func containsQualitySubstring(slice []rule.Quality, q string) bool {
 
 // Get returns the exact rule by key.
 func (s *Service) Get(ctx context.Context, key rule.Key) (rule.Rule, error) {
+	if err := ctx.Err(); err != nil {
+		return rule.Rule{}, err
+	}
 	if string(key) == "" {
 		return rule.Rule{}, fmt.Errorf("%w: empty rule key", shared.ErrValidation)
 	}

--- a/internal/usecase/rules/service_test.go
+++ b/internal/usecase/rules/service_test.go
@@ -1,0 +1,334 @@
+package rules_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
+)
+
+type fakeCatalog struct {
+	rules []rule.Rule
+	err   error
+}
+
+func (f *fakeCatalog) List(ctx context.Context) ([]rule.Rule, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rules, nil
+}
+
+func (f *fakeCatalog) Get(ctx context.Context, key rule.Key) (rule.Rule, error) {
+	if f.err != nil {
+		return rule.Rule{}, f.err
+	}
+	for _, r := range f.rules {
+		if r.Key == key {
+			return r, nil
+		}
+	}
+	return rule.Rule{}, shared.ErrNotFound
+}
+
+func TestNewFilter(t *testing.T) {
+	cases := []struct {
+		name       string
+		query      string
+		languages  []string
+		types      []string
+		severities []string
+		tags       []string
+		cwe        []string
+		wantErr    bool
+		check      func(t *testing.T, f rules.Filter)
+	}{
+		{
+			name: "empty everything",
+			check: func(t *testing.T, f rules.Filter) {
+				if f.Query != "" || len(f.Languages) > 0 || len(f.Types) > 0 || len(f.Severities) > 0 || len(f.Tags) > 0 || len(f.CWE) > 0 {
+					t.Errorf("expected empty filter, got %+v", f)
+				}
+			},
+		},
+		{
+			name:  "whitespace query",
+			query: "   \t\n",
+			check: func(t *testing.T, f rules.Filter) {
+				if f.Query != "" {
+					t.Errorf("expected empty query, got %q", f.Query)
+				}
+			},
+		},
+		{
+			name:      "language deduplication and lowercase internal preservation",
+			languages: []string{"go", "GO", " Go "},
+			check: func(t *testing.T, f rules.Filter) {
+				if len(f.Languages) != 1 || strings.ToLower(f.Languages[0]) != "go" {
+					t.Errorf("expected deduplicated 'go', got %v", f.Languages)
+				}
+			},
+		},
+		{
+			name:  "valid types case-insensitive",
+			types: []string{"BUG", "vulnerability ", "CoDe_SmeLL", "security_hotspot"},
+			check: func(t *testing.T, f rules.Filter) {
+				if len(f.Types) != 4 {
+					t.Errorf("expected 4 types, got %v", f.Types)
+				}
+			},
+		},
+		{
+			name:    "invalid type",
+			types:   []string{"unknown"},
+			wantErr: true,
+		},
+		{
+			name:       "valid severities case-insensitive",
+			severities: []string{"LOW", "medium ", "High", "Critical"},
+			check: func(t *testing.T, f rules.Filter) {
+				if len(f.Severities) != 4 {
+					t.Errorf("expected 4 severities, got %v", f.Severities)
+				}
+			},
+		},
+		{
+			name:       "invalid severity",
+			severities: []string{"warning"},
+			wantErr:    true,
+		},
+		{
+			name: "cwe parsing and deduplication",
+			cwe:  []string{"CWE-89", "cwe-89", "89", " 89 "},
+			check: func(t *testing.T, f rules.Filter) {
+				if len(f.CWE) != 1 || f.CWE[0] != "CWE-89" {
+					t.Errorf("expected [CWE-89], got %v", f.CWE)
+				}
+			},
+		},
+		{name: "cwe missing number", cwe: []string{"CWE-"}, wantErr: true},
+		{name: "cwe negative", cwe: []string{"-89"}, wantErr: true},
+		{name: "cwe zero", cwe: []string{"0"}, wantErr: true},
+		{name: "cwe decimal", cwe: []string{"89.0"}, wantErr: true},
+		{name: "cwe letter", cwe: []string{"CWE-abc"}, wantErr: true},
+		{
+			name:  "boundary 256 query",
+			query: strings.Repeat("a", 256),
+		},
+		{
+			name:    "boundary 257 query",
+			query:   strings.Repeat("a", 257),
+			wantErr: true,
+		},
+		{
+			name: "64 values exact",
+			tags: make([]string, 32),
+			cwe:  make([]string, 32),
+			check: func(t *testing.T, f rules.Filter) {
+			},
+		},
+	}
+
+	// 64 values exact logic setup
+	for i := 0; i < 32; i++ {
+		cases[15].tags[i] = "tag"
+		cases[15].cwe[i] = "89"
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := rules.NewFilter(tc.query, tc.languages, tc.types, tc.severities, tc.tags, tc.cwe)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr %v, got %v", tc.wantErr, err)
+			}
+			if !tc.wantErr && tc.check != nil {
+				tc.check(t, f)
+			}
+		})
+	}
+}
+
+func TestNewFilter_Bounds(t *testing.T) {
+	tags32 := make([]string, 32)
+	for i := range tags32 {
+		tags32[i] = "tag"
+	}
+	cwe32 := make([]string, 32)
+	for i := range cwe32 {
+		cwe32[i] = "89"
+	}
+	_, err := rules.NewFilter("", nil, nil, nil, tags32, cwe32)
+	if err != nil {
+		t.Errorf("64 total values should be allowed, got %v", err)
+	}
+}
+
+// wait, the rule says max values per dimension is 32! Let's test that directly:
+func TestNewFilter_DimensionBound(t *testing.T) {
+	tags32 := make([]string, 32)
+	for i := range tags32 {
+		tags32[i] = "tag"
+	}
+	if _, err := rules.NewFilter("", nil, nil, nil, tags32, nil); err != nil {
+		t.Errorf("32 tags should be permitted, got %v", err)
+	}
+
+	tags33 := make([]string, 33)
+	for i := range tags33 {
+		tags33[i] = "tag"
+	}
+	if _, err := rules.NewFilter("", nil, nil, nil, tags33, nil); err == nil {
+		t.Error("33 tags should be rejected")
+	}
+
+	// Total filter values limit is 64.
+	// 32 tags and 32 CWEs
+	cwes32 := make([]string, 32)
+	for i := range cwes32 {
+		cwes32[i] = "1"
+	}
+	if _, err := rules.NewFilter("", nil, nil, nil, tags32, cwes32); err != nil {
+		t.Errorf("64 total values should be permitted, got %v", err)
+	}
+
+	// 32 tags, 32 cwe, 1 language
+	if _, err := rules.NewFilter("", []string{"go"}, nil, nil, tags32, cwes32); err == nil {
+		t.Error("65 total values should be rejected")
+	}
+}
+
+func TestService_List(t *testing.T) {
+	ctx := context.Background()
+
+	cat := &fakeCatalog{
+		rules: []rule.Rule{
+			{Key: "z-rule", Language: "python", Type: rule.TypeBug, DefaultSeverity: shared.SeverityLow, Tags: []string{"tag2"}, CWE: []string{"CWE-1"}},
+			{Key: "a-rule", Language: "go", Type: rule.TypeVulnerability, DefaultSeverity: shared.SeverityHigh, Tags: []string{"tag1"}, CWE: []string{"CWE-89"}, Description: "has SQL"},
+			{Key: "m-rule", Language: "go", Type: rule.TypeCodeSmell, DefaultSeverity: shared.SeverityMedium, Tags: []string{"tag1", "tag2"}, CWE: []string{"CWE-79"}},
+		},
+	}
+
+	svc, err := rules.NewService(cat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Unsorted input returns sorted output by key
+	f, _ := rules.NewFilter("", nil, nil, nil, nil, nil)
+	out, err := svc.List(ctx, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 3 || string(out[0].Key) != "a-rule" || string(out[1].Key) != "m-rule" || string(out[2].Key) != "z-rule" {
+		t.Errorf("expected ascending key sort, got %+v", out)
+	}
+
+	// 2. Filter OR semantics in dimension, AND semantics across
+	f, _ = rules.NewFilter("", []string{"go"}, []string{"vulnerability", "code_smell"}, nil, []string{"tag1"}, nil)
+	out, _ = svc.List(ctx, f)
+	if len(out) != 2 || string(out[0].Key) != "a-rule" || string(out[1].Key) != "m-rule" {
+		t.Errorf("expected a-rule and m-rule, got %+v", out)
+	}
+
+	// 3. CWE matching
+	f, _ = rules.NewFilter("", nil, nil, nil, nil, []string{"89"})
+	out, _ = svc.List(ctx, f)
+	if len(out) != 1 || string(out[0].Key) != "a-rule" {
+		t.Errorf("expected a-rule, got %+v", out)
+	}
+
+	// 4. Query text matching case-insensitive
+	f, _ = rules.NewFilter("SQl", nil, nil, nil, nil, nil)
+	out, _ = svc.List(ctx, f)
+	if len(out) != 1 || string(out[0].Key) != "a-rule" {
+		t.Errorf("expected a-rule, got %+v", out)
+	}
+
+	// 5. No match returns non-nil empty slice
+	f, _ = rules.NewFilter("nomatch", nil, nil, nil, nil, nil)
+	out, _ = svc.List(ctx, f)
+	if out == nil || len(out) != 0 {
+		t.Errorf("expected non-nil empty slice, got %v", out)
+	}
+
+	// 6. Source rules are cloned (slices)
+	cat.rules[0].Tags[0] = "mutated" // change the original, should not affect previously returned
+	// wait, we returned clones. Let's mutate the clone and see if source is affected
+	f, _ = rules.NewFilter("", nil, nil, nil, nil, nil)
+	out, _ = svc.List(ctx, f)
+	out[0].Tags[0] = "mutated-clone"
+	if cat.rules[1].Tags[0] == "mutated-clone" { // index 1 in source is index 0 in sorted
+		t.Errorf("source catalog was mutated!")
+	}
+}
+
+func TestService_Get(t *testing.T) {
+	ctx := context.Background()
+
+	cat := &fakeCatalog{
+		rules: []rule.Rule{
+			{Key: "go:sql-injection"},
+			{Key: "a-rule", Tags: []string{"tag1"}},
+		},
+	}
+
+	svc, err := rules.NewService(cat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Exact match including colon
+	r, err := svc.Get(ctx, rule.Key("go:sql-injection"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Key != "go:sql-injection" {
+		t.Errorf("expected go:sql-injection, got %q", r.Key)
+	}
+
+	// Case-sensitive miss
+	_, err = svc.Get(ctx, rule.Key("GO:SQL-INJECTION"))
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+
+	// Empty key
+	_, err = svc.Get(ctx, rule.Key(""))
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("expected ErrValidation, got %v", err)
+	}
+
+	// Slice cloning
+	r2, _ := svc.Get(ctx, rule.Key("a-rule"))
+	r2.Tags[0] = "mutated"
+	if cat.rules[1].Tags[0] == "mutated" {
+		t.Errorf("source catalog was mutated!")
+	}
+}
+
+func TestNewService_NilDependency(t *testing.T) {
+	_, err := rules.NewService(nil)
+	if err == nil {
+		t.Error("expected error for nil catalog")
+	}
+}
+
+func TestService_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	svc, _ := rules.NewService(&fakeCatalog{})
+	_, err := svc.List(ctx, rules.Filter{})
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context canceled, got %v", err)
+	}
+
+	_, err = svc.Get(ctx, rule.Key("a"))
+	// fake catalog currently just returns on Get if f.err!=nil, else loops.
+	// We need to implement context propagation in the service or fake.
+	// Wait, catalog handles context.
+}

--- a/internal/usecase/rules/service_test.go
+++ b/internal/usecase/rules/service_test.go
@@ -12,11 +12,14 @@ import (
 )
 
 type fakeCatalog struct {
-	rules []rule.Rule
-	err   error
+	rules     []rule.Rule
+	err       error
+	getCalls  int
+	listCalls int
 }
 
 func (f *fakeCatalog) List(ctx context.Context) ([]rule.Rule, error) {
+	f.listCalls++
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -24,6 +27,7 @@ func (f *fakeCatalog) List(ctx context.Context) ([]rule.Rule, error) {
 }
 
 func (f *fakeCatalog) Get(ctx context.Context, key rule.Key) (rule.Rule, error) {
+	f.getCalls++
 	if f.err != nil {
 		return rule.Rule{}, f.err
 	}
@@ -167,7 +171,7 @@ func TestNewFilter_Bounds(t *testing.T) {
 	}
 }
 
-// wait, the rule says max values per dimension is 32! Let's test that directly:
+// Test dimension bounds (max 32):
 func TestNewFilter_DimensionBound(t *testing.T) {
 	tags32 := make([]string, 32)
 	for i := range tags32 {
@@ -257,7 +261,7 @@ func TestService_List(t *testing.T) {
 
 	// 6. Source rules are cloned (slices)
 	cat.rules[0].Tags[0] = "mutated" // change the original, should not affect previously returned
-	// wait, we returned clones. Let's mutate the clone and see if source is affected
+	// Verify we returned clones. Let's mutate the clone and see if source is affected
 	f, _ = rules.NewFilter("", nil, nil, nil, nil, nil)
 	out, _ = svc.List(ctx, f)
 	out[0].Tags[0] = "mutated-clone"
@@ -317,18 +321,137 @@ func TestNewService_NilDependency(t *testing.T) {
 	}
 }
 
-func TestService_ContextCancel(t *testing.T) {
+func TestServiceListCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	svc, _ := rules.NewService(&fakeCatalog{})
+	cat := &fakeCatalog{}
+	svc, _ := rules.NewService(cat)
 	_, err := svc.List(ctx, rules.Filter{})
 	if err == nil || !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context canceled, got %v", err)
 	}
 
-	_, err = svc.Get(ctx, rule.Key("a"))
-	// fake catalog currently just returns on Get if f.err!=nil, else loops.
-	// We need to implement context propagation in the service or fake.
-	// Wait, catalog handles context.
+	if cat.listCalls != 0 {
+		t.Fatalf("catalog.List called %d times", cat.listCalls)
+	}
+}
+
+func TestServiceGetCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cat := &fakeCatalog{}
+	svc, err := rules.NewService(cat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = svc.Get(ctx, rule.Key("a-rule"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	if cat.getCalls != 0 {
+		t.Fatalf("catalog.Get called %d times", cat.getCalls)
+	}
+}
+
+func TestNewFilter_Advanced(t *testing.T) {
+	cases := []struct {
+		name       string
+		languages  []string
+		types      []string
+		severities []string
+		tags       []string
+		cwe        []string
+		wantErr    bool
+	}{
+		{name: "empty language value", languages: []string{""}, wantErr: true},
+		{name: "empty type value", types: []string{""}, wantErr: true},
+		{name: "empty severity value", severities: []string{""}, wantErr: true},
+		{name: "empty tag value", tags: []string{""}, wantErr: true},
+		{name: "boundary 128 language", languages: []string{strings.Repeat("a", 128)}, wantErr: false},
+		{name: "boundary 129 language", languages: []string{strings.Repeat("a", 129)}, wantErr: true},
+		{name: "CWE--89", cwe: []string{"CWE--89"}, wantErr: true},
+		{name: "CWE-+89", cwe: []string{"CWE-+89"}, wantErr: true},
+		{name: "  CWE-89", cwe: []string{"  CWE-89"}, wantErr: false}, // gets trimmed
+		{name: "CWE-00089", cwe: []string{"CWE-00089"}, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := rules.NewFilter("", tc.languages, tc.types, tc.severities, tc.tags, tc.cwe)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestService_List_Advanced(t *testing.T) {
+	ctx := context.Background()
+	cat := &fakeCatalog{
+		rules: []rule.Rule{
+			{
+				Key: "a", Name: "name_match", Language: "go", Type: rule.TypeBug, DefaultSeverity: shared.SeverityLow,
+				Description: "desc", Rationale: "rat", Remediation: "rem", Detection: rule.DetectionAST,
+				Tags: []string{"tag1"}, CWE: []string{"CWE-1"}, OWASP: []string{"A1"}, Qualities: []rule.Quality{rule.QualitySecurity},
+			},
+			{Key: "b", CompliantExample: "match_but_ignored", NoncompliantExample: "match_but_ignored"},
+		},
+	}
+	svc, _ := rules.NewService(cat)
+
+	// Test search matches and non-matches
+	f, _ := rules.NewFilter("name_match", nil, nil, nil, nil, nil)
+	out, _ := svc.List(ctx, f)
+	if len(out) != 1 {
+		t.Errorf("expected match")
+	}
+
+	f, _ = rules.NewFilter("match_but_ignored", nil, nil, nil, nil, nil)
+	out, _ = svc.List(ctx, f)
+	if len(out) != 0 {
+		t.Errorf("should not match examples")
+	}
+
+	// Test empty catalog
+	catEmpty := &fakeCatalog{rules: []rule.Rule{}}
+	svcEmpty, _ := rules.NewService(catEmpty)
+	out, _ = svcEmpty.List(ctx, rules.Filter{})
+	if out == nil {
+		t.Errorf("expected non-nil empty slice")
+	}
+
+	// Test error propagation
+	catErr := &fakeCatalog{err: errors.New("boom")}
+	svcErr, _ := rules.NewService(catErr)
+	_, err := svcErr.List(ctx, rules.Filter{})
+	if err == nil || err.Error() != "boom" {
+		t.Errorf("expected error propagation")
+	}
+}
+
+func TestService_Get_Advanced(t *testing.T) {
+	ctx := context.Background()
+	cat := &fakeCatalog{
+		rules: []rule.Rule{
+			{Key: " go:rule "}, // whitespace
+		},
+	}
+	svc, _ := rules.NewService(cat)
+
+	// Exact case lookup with whitespace
+	r, err := svc.Get(ctx, rule.Key(" go:rule "))
+	if err != nil || r.Key != " go:rule " {
+		t.Errorf("expected match")
+	}
+
+	// Error propagation
+	catErr := &fakeCatalog{err: errors.New("boom")}
+	svcErr, _ := rules.NewService(catErr)
+	_, err = svcErr.Get(ctx, rule.Key("k"))
+	if err == nil || err.Error() != "boom" {
+		t.Errorf("expected error propagation")
+	}
 }


### PR DESCRIPTION
## Summary

Exposes the immutable first-party rule catalog through authenticated, read-only API endpoints.

This provides the backend contract required by the Rules Explorer while keeping the catalog independent from findings, engagements, tenants, and persistence.

## Changes

* add a rule-catalog query service backed by `ports.RuleCatalog`
* add deterministic, case-insensitive free-text search across rule metadata
* add repeatable filters for:

  * language
  * rule type
  * default severity
  * tag
  * CWE
* apply OR semantics within the same filter dimension
* apply AND semantics across different filter dimensions
* normalize and deduplicate filter values
* validate unsupported parameters, enum values, CWE identifiers, input lengths, and filter counts
* add `GET /api/v1/rules`
* add `GET /api/v1/rules/{key}`
* support exact lookup of opaque rule keys, including keys containing `:`
* return deterministic list results ordered by rule key
* add explicit snake_case summary and detail DTOs
* guarantee non-null arrays in API responses
* keep detailed rationale, remediation, and examples exclusive to the detail endpoint
* protect both endpoints with the existing authentication, AUP, and `PermView` authorization chain
* preserve existing machine-role restrictions
* avoid tenant or engagement scoping for global catalog metadata
* construct the default immutable catalog once during API startup
* document both endpoints, filters, limits, enums, response schemas, and error responses in OpenAPI
* add use-case, handler, middleware, route-registration, and real-catalog integration tests

## API behavior

### List rules

```http
GET /api/v1/rules
```

Supported query parameters:

* `q`
* `language`
* `type`
* `severity`
* `tag`
* `cwe`

Repeated values use OR semantics within the same dimension:

```text
language=go&language=python
```

Different dimensions are combined using AND semantics:

```text
language=go&type=vulnerability&severity=high
```

Results are always ordered by rule key. Requests with no matching rules return:

```json
[]
```

### Get rule detail

```http
GET /api/v1/rules/{key}
```

Detail lookup is exact and case-sensitive. Rule keys are treated as opaque identifiers and are not normalized, split, or rewritten.

## Security and architecture

* both endpoints require authentication
* the existing Acceptable Use Policy gate remains enforced
* both endpoints require `PermView`
* machine roles remain denied
* no engagement or tenant context is required
* no database or finding repository is accessed
* the use case depends only on `ports.RuleCatalog`
* the rule domain is not serialized directly
* the catalog is initialized once at the composition root
* no write endpoints are introduced

## Validation

* filter normalization and boundary tests
* OR/AND filter-semantics tests
* deterministic ordering tests
* context-cancellation tests
* catalog error-propagation tests
* result-cloning and immutability tests
* HTTP validation and error-mapping tests
* middleware authentication, AUP, and authorization tests
* conditional route-registration tests
* real default-catalog integration tests
* OpenAPI validation
* focused race-detector suite
* `go vet ./...`
* full repository test suite

Part of #182.

This PR implements the Rules API portion of the issue.

This PR does not add the Rules Explorer and does not close #182.
