### PR TITLE
feat(codequality): add Rules Explorer

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-select": "^2.3.3",
@@ -22,11 +24,16 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.2",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.3",
+    "jsdom": "^24.0.0",
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.3",
-    "vite": "^8.1.3"
+    "vite": "^8.1.3",
+    "vitest": "^3.0.0"
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -38,7 +38,16 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.2
-        version: 4.3.2(vite@8.1.3(jiti@2.7.0))
+        version: 4.3.2(vite@8.1.3(esbuild@0.28.1)(jiti@2.7.0))
+      '@testing-library/jest-dom':
+        specifier: ^6.4.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.5.0
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.17
@@ -47,7 +56,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.3(jiti@2.7.0))
+        version: 6.0.3(vite@8.1.3(esbuild@0.28.1)(jiti@2.7.0))
+      jsdom:
+        specifier: ^24.0.0
+        version: 24.1.3
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -56,9 +68,58 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.3
-        version: 8.1.3(jiti@2.7.0)
+        version: 8.1.3(esbuild@0.28.1)(jiti@2.7.0)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(jiti@2.7.0)(jsdom@24.1.3)(lightningcss@1.32.0)
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -68,6 +129,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -400,36 +617,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.4':
     resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.4':
     resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.4':
     resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.4':
     resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.4':
     resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
@@ -456,6 +679,144 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
 
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
@@ -495,24 +856,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
     resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.2':
     resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
@@ -556,8 +921,43 @@ packages:
   '@tanstack/virtual-core@3.17.3':
     resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
@@ -576,6 +976,12 @@ packages:
 
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -597,6 +1003,35 @@ packages:
         optional: true
       babel-plugin-react-compiler:
         optional: true
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@xyflow/react@12.11.2':
     resolution: {integrity: sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==}
@@ -623,13 +1058,55 @@ packages:
     resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
     engines: {node: '>=0.8'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   cfb@1.2.2:
     resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
     engines: {node: '>=0.8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   classcat@5.0.5:
     resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
@@ -638,6 +1115,10 @@ packages:
     resolution: {integrity: sha512-iz3zJLhlrg37/gYRWgEPkaFTtzmnEv1h+r7NgZum2lFElYQPi0/5bnmuDfODHxfp0INEfnRqyfyeIJDbb7ahRw==}
     engines: {node: '>=0.8'}
     hasBin: true
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@2.14.1:
     resolution: {integrity: sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==}
@@ -653,6 +1134,13 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -695,6 +1183,34 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -702,13 +1218,58 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   exit-on-epipe@1.0.1:
     resolution: {integrity: sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==}
     engines: {node: '>=0.8'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -725,6 +1286,10 @@ packages:
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   frac@1.1.2:
     resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
     engines: {node: '>=0.8'}
@@ -734,16 +1299,81 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@24.1.3:
+    resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -780,24 +1410,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -815,18 +1449,60 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lucide-react@1.23.0:
     resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -839,15 +1515,32 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   printj@1.1.2:
     resolution: {integrity: sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==}
     engines: {node: '>=0.8'}
     hasBin: true
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -900,16 +1593,44 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
   rolldown@1.1.4:
     resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -919,6 +1640,22 @@ packages:
     resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
     engines: {node: '>=0.8'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.3.2:
     resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
 
@@ -926,9 +1663,35 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -937,6 +1700,13 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -962,6 +1732,51 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -1006,6 +1821,60 @@ packages:
       yaml:
         optional: true
 
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wmf@1.0.2:
     resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
     engines: {node: '>=0.8'}
@@ -1014,10 +1883,29 @@ packages:
     resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
     engines: {node: '>=0.8'}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xlsx-js-style@1.2.0:
     resolution: {integrity: sha512-DDT4FXFSWfT4DXMSok/m3TvmP1gvO3dn0Eu/c+eXHW5Kzmp7IczNkxg/iEPnImbG9X0Vb8QhROda5eatSR/97Q==}
     engines: {node: '>=0.8'}
     hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -1036,6 +1924,46 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/runtime@7.29.7': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -1050,6 +1978,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -1369,6 +2375,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
   '@tailwindcss/node@4.3.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -1430,12 +2511,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
 
-  '@tailwindcss/vite@4.3.2(vite@8.1.3(jiti@2.7.0))':
+  '@tailwindcss/vite@4.3.2(vite@8.1.3(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
-      vite: 8.1.3(jiti@2.7.0)
+      vite: 8.1.3(esbuild@0.28.1)(jiti@2.7.0)
 
   '@tanstack/react-virtual@3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -1445,10 +2526,51 @@ snapshots:
 
   '@tanstack/virtual-core@3.17.3': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-color@3.1.3': {}
 
@@ -1471,6 +2593,10 @@ snapshots:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
 
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -1479,10 +2605,52 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.3(jiti@2.7.0))':
+  '@vitejs/plugin-react@6.0.3(vite@8.1.3(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.3(jiti@2.7.0)
+      vite: 8.1.3(esbuild@0.28.1)(jiti@2.7.0)
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@xyflow/react@12.11.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -1516,14 +2684,47 @@ snapshots:
 
   adler-32@1.3.1: {}
 
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   cfb@1.2.2:
     dependencies:
       adler-32: 1.3.1
       crc-32: 1.2.2
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   classcat@5.0.5: {}
 
@@ -1532,6 +2733,10 @@ snapshots:
       commander: 2.14.1
       exit-on-epipe: 1.0.1
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@2.14.1: {}
 
   commander@2.17.1: {}
@@ -1539,6 +2744,13 @@ snapshots:
   cookie@1.1.1: {}
 
   crc-32@1.2.2: {}
+
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -1578,16 +2790,97 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
+
+  delayed-stream@1.0.0: {}
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  entities@6.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   exit-on-epipe@1.0.1: {}
+
+  expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -1597,16 +2890,114 @@ snapshots:
 
   fflate@0.8.3: {}
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   frac@1.1.2: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  indent-string@4.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
   jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsdom@24.1.3:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.6
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1657,15 +3048,43 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
   lucide-react@1.23.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  min-indent@1.0.1: {}
+
+  ms@2.1.3: {}
+
   nanoid@3.3.15: {}
+
+  nwsapi@2.2.24: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -1677,12 +3096,28 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   printj@1.1.2: {}
+
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
+  punycode@2.3.1: {}
+
+  querystringify@2.2.0: {}
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -1727,6 +3162,13 @@ snapshots:
 
   react@19.2.7: {}
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  requires-port@1.0.0: {}
+
   rolldown@1.1.4:
     dependencies:
       '@oxc-project/types': 0.138.0
@@ -1748,9 +3190,52 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   set-cookie-parser@2.7.2: {}
+
+  siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -1758,18 +3243,60 @@ snapshots:
     dependencies:
       frac: 1.1.2
 
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.3.2: {}
 
   tapable@2.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
   tslib@2.8.1: {}
 
   typescript@6.0.3: {}
+
+  universalify@0.2.0: {}
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -1790,7 +3317,41 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  vite@8.1.3(jiti@2.7.0):
+  vite-node@3.2.4(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+
+  vite@8.1.3(esbuild@0.28.1)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -1798,12 +3359,78 @@ snapshots:
       rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
+
+  vitest@3.2.7(jiti@2.7.0)(jsdom@24.1.3)(lightningcss@1.32.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wmf@1.0.2: {}
 
   word@0.3.0: {}
+
+  ws@8.21.0: {}
 
   xlsx-js-style@1.2.0:
     dependencies:
@@ -1817,6 +3444,10 @@ snapshots:
       ssf: 0.11.2
       wmf: 1.0.2
       word: 0.3.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   zustand@4.5.7(@types/react@19.2.17)(react@19.2.7):
     dependencies:

--- a/web/src/App.rules.test.tsx
+++ b/web/src/App.rules.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import App from './App'
+import { api } from './lib/api'
+import { Sidebar } from './components/Sidebar'
+
+vi.mock('./lib/api', () => ({
+  api: {
+    listRules: vi.fn(),
+    getRule: vi.fn(),
+    listEngagements: vi.fn(),
+    getAuditLogs: vi.fn(),
+    getTeam: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    constructor(public status: number, message: string) {
+      super(message)
+    }
+  },
+}))
+
+vi.mock('./auth/AuthContext', () => ({
+  AuthProvider: ({ children }: any) => children,
+  useAuth: () => ({ phase: 'ready', logout: vi.fn() }),
+}))
+
+describe('App Routing - Rules', () => {
+  beforeEach(() => {
+    vi.mocked(api.listRules).mockResolvedValue([])
+    vi.mocked(api.listEngagements).mockResolvedValue([])
+    vi.mocked(api.getRule).mockResolvedValue({
+      key: 'go:sql',
+      name: 'SQL Injection',
+      language: 'go',
+      type: 'vulnerability',
+      qualities: [],
+      defaultSeverity: 'high',
+      tags: [],
+      cwe: [],
+      owasp: [],
+      description: 'Desc',
+      rationale: '',
+      remediation: '',
+      compliantExample: '',
+      noncompliantExample: '',
+      remediationEffort: 10,
+      detection: 'ast',
+    })
+  })
+
+  it('renders Rules page on /rules route', async () => {
+    render(
+      <MemoryRouter initialEntries={['/rules']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Rules' })).toBeInTheDocument()
+    })
+  })
+
+  it('renders RuleDetail page on /rules/:key route and decodes colon exactly once', async () => {
+    render(
+      <MemoryRouter initialEntries={['/rules/go%3Asql']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'SQL Injection' })).toBeInTheDocument()
+    })
+
+    expect(api.getRule).toHaveBeenCalledWith('go:sql')
+  })
+
+  it('maintains active state on Rules list', async () => {
+    render(
+      <MemoryRouter initialEntries={['/rules']}>
+        <Sidebar />
+      </MemoryRouter>
+    )
+
+    const rulesLink = screen.getByRole('link', { name: /Rules/i })
+    expect(rulesLink.className).toMatch(/bg-brand\/10|text-branddim/)
+  })
+
+  it('maintains active state on Rules detail', async () => {
+    render(
+      <MemoryRouter initialEntries={['/rules/go:sql']}>
+        <Sidebar />
+      </MemoryRouter>
+    )
+
+    const rulesLink = screen.getByRole('link', { name: /Rules/i })
+    expect(rulesLink.className).toMatch(/bg-brand\/10|text-branddim/)
+  })
+
+  it('opens mobile navigation and navigates to Rules', async () => {
+    render(
+      <MemoryRouter initialEntries={['/engagements']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    // Wait for Engagements page to render
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Engagements' })).toBeInTheDocument()
+    })
+
+    // Open menu button MUST exist — mandatory assertion
+    const menuButton = screen.getByRole('button', { name: /open menu/i })
+    expect(menuButton).toBeDefined()
+    fireEvent.click(menuButton)
+
+    // The mobile sidebar must now be open — find the dialog
+    const dialog = screen.getByRole('dialog', { name: /navigation/i })
+    expect(dialog).toBeInTheDocument()
+
+    // Find the Rules link inside the dialog and click it
+    const allRulesLinks = screen.getAllByRole('link', { name: /^Rules$/i })
+    const mobileRulesLink = allRulesLinks.at(-1)!
+    expect(mobileRulesLink).toBeDefined()
+    fireEvent.click(mobileRulesLink)
+
+    // Route must change to /rules
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Rules' })).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: /navigation/i }),
+      ).not.toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,8 @@ import { Connect } from './pages/Connect'
 import { EngagementDetail } from './pages/EngagementDetail'
 import { Engagements } from './pages/Engagements'
 import { Team } from './pages/Team'
+import Rules from './pages/Rules'
+import RuleDetail from './pages/RuleDetail'
 
 export default function App() {
   return (
@@ -26,6 +28,8 @@ function Gate() {
         <Route index element={<Navigate to="/engagements" replace />} />
         <Route path="engagements" element={<Engagements />} />
         <Route path="engagements/:id" element={<EngagementDetail />} />
+        <Route path="rules" element={<Rules />} />
+        <Route path="rules/:key" element={<RuleDetail />} />
         <Route path="audit" element={<Audit />} />
         <Route path="team" element={<Team />} />
         <Route path="*" element={<Navigate to="/engagements" replace />} />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
-import { Boxes, FileText, Radar, ScrollText, Settings, Target, Users, X, type LucideIcon } from 'lucide-react'
+import { Boxes, FileText, Radar, ScrollText, Settings, Target, Users, X, Library, type LucideIcon } from 'lucide-react'
 import { useEffect, useRef } from 'react'
-import { NavLink } from 'react-router-dom'
+import { NavLink, useLocation } from 'react-router-dom'
 import { cn } from './ui'
 import logo from '../assets/logo.png'
 
@@ -12,6 +12,7 @@ const SOON: { icon: LucideIcon; label: string }[] = [
 ]
 
 function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
+  const location = useLocation()
   return (
     <>
       <div className="flex h-14 items-center gap-2 border-b border-border px-5">
@@ -49,6 +50,22 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
         >
           <ScrollText className="size-[18px]" />
           Audit log
+        </NavLink>
+
+        <NavLink
+          to="/rules"
+          onClick={onNavigate}
+          className={({ isActive }) =>
+            cn(
+              'relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
+              isActive || location.pathname.startsWith('/rules')
+                ? 'bg-brand/10 font-semibold text-branddim before:absolute before:left-0 before:top-1/2 before:h-5 before:w-[3px] before:-translate-y-1/2 before:rounded-r-full before:bg-brand before:content-[""]'
+                : 'text-mutedfg hover:bg-elevated hover:text-foreground',
+            )
+          }
+        >
+          <Library className="size-[18px]" />
+          Rules
         </NavLink>
 
         <NavLink

--- a/web/src/components/rules/FacetFilter.test.tsx
+++ b/web/src/components/rules/FacetFilter.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { FacetFilter } from './FacetFilter'
+
+describe('FacetFilter', () => {
+  it('renders trigger with label', () => {
+    render(<FacetFilter label="Type" values={['bug']} selected={[]} onChange={() => {}} />)
+    expect(screen.getByRole('button', { name: /Type/i })).toBeInTheDocument()
+  })
+
+  it('shows selected count', () => {
+    render(<FacetFilter label="Type" values={['bug', 'vulnerability']} selected={['bug', 'vulnerability']} onChange={() => {}} />)
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('opens panel on click', () => {
+    render(<FacetFilter label="Type" values={['bug']} selected={[]} onChange={() => {}} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Type/i }))
+    expect(screen.getByRole('dialog', { name: /Filter by Type/i })).toBeInTheDocument()
+  })
+
+  it('calls onChange when selecting an option', () => {
+    const onChange = vi.fn()
+    render(<FacetFilter label="Type" values={['bug', 'vulnerability']} selected={[]} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /Type/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'bug' }))
+    expect(onChange).toHaveBeenCalledWith(['bug'])
+  })
+
+  it('calls onChange when deselecting an option', () => {
+    const onChange = vi.fn()
+    render(<FacetFilter label="Type" values={['bug', 'vulnerability']} selected={['bug']} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /Type/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'bug' }))
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it('clears all selections', () => {
+    const onChange = vi.fn()
+    render(<FacetFilter label="Type" values={['bug', 'vulnerability']} selected={['bug', 'vulnerability']} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /Type/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Clear/i }))
+    expect(onChange).toHaveBeenCalledWith([])
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes on Escape and returns focus', () => {
+    render(<FacetFilter label="Type" values={['bug']} selected={[]} onChange={() => {}} />)
+    const trigger = screen.getByRole('button', { name: /Type/i })
+    fireEvent.click(trigger)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('closes on outside click', () => {
+    render(
+      <div>
+        <FacetFilter label="Type" values={['bug']} selected={[]} onChange={() => {}} />
+        <div data-testid="outside">Outside</div>
+      </div>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Type/i }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('formats values correctly', () => {
+    render(
+      <FacetFilter
+        label="Type"
+        values={['code_smell']}
+        selected={[]}
+        onChange={() => {}}
+        formatValue={(v) => v === 'code_smell' ? 'Code smell' : v}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Type/i }))
+    expect(screen.getByRole('checkbox', { name: 'Code smell' })).toBeInTheDocument()
+  })
+})

--- a/web/src/components/rules/FacetFilter.tsx
+++ b/web/src/components/rules/FacetFilter.tsx
@@ -1,0 +1,142 @@
+import { Check, ChevronDown, X } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '../ui'
+
+interface FacetFilterProps<T extends string> {
+  label: string
+  values: T[]
+  selected: T[]
+  formatValue?: (value: T) => string
+  onChange: (next: T[]) => void
+}
+
+export function FacetFilter<T extends string>({
+  label,
+  values,
+  selected,
+  formatValue = (v) => v,
+  onChange,
+}: FacetFilterProps<T>) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onClick = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const toggleValue = (val: T) => {
+    if (selected.includes(val)) {
+      onChange(selected.filter((v) => v !== val))
+    } else {
+      onChange([...selected, val])
+    }
+  }
+
+  const clear = () => {
+    onChange([])
+    setOpen(false)
+    triggerRef.current?.focus()
+  }
+
+  return (
+    <div className="relative inline-block text-left" ref={containerRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface',
+          open
+            ? 'border-brand/40 bg-elevated text-foreground'
+            : 'border-border border-dashed bg-transparent text-foreground hover:bg-elevated hover:text-foreground',
+          selected.length > 0 && 'border-solid border-brand/40 bg-brand/5 text-branddim hover:bg-brand/10',
+        )}
+      >
+        {label}
+        {selected.length > 0 && (
+          <>
+            <span className="mx-1 h-4 w-[1px] bg-border" />
+            <span className="flex size-5 items-center justify-center rounded-sm bg-brand/20 text-[11px] text-branddim">
+              {selected.length}
+            </span>
+          </>
+        )}
+        <ChevronDown className="ml-1 size-3.5 opacity-50" />
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label={`Filter by ${label}`}
+          className="absolute left-0 top-full z-50 mt-1.5 w-64 rounded-xl border border-border bg-elevated p-2 shadow-xl outline-none motion-reduce:transition-none"
+        >
+          {values.length === 0 ? (
+            <div className="p-4 text-center text-sm text-mutedfg">No options available</div>
+          ) : (
+            <div className="max-h-60 overflow-y-auto outline-none">
+              <ul className="space-y-1">
+                {values.map((v) => {
+                  const isSelected = selected.includes(v)
+                  return (
+                    <li key={v}>
+                      <label className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 text-sm transition-colors hover:bg-surface focus-within:ring-2 focus-within:ring-brand">
+                        <div
+                          className={cn(
+                            'flex size-4 shrink-0 items-center justify-center rounded-[4px] border transition-colors',
+                            isSelected ? 'border-brand bg-brand text-brandfg' : 'border-border bg-transparent',
+                          )}
+                        >
+                          {isSelected && <Check className="size-3" />}
+                        </div>
+                        <input
+                          type="checkbox"
+                          className="sr-only"
+                          checked={isSelected}
+                          onChange={() => toggleValue(v)}
+                          name={v}
+                          aria-label={formatValue(v)}
+                        />
+                        <span className="flex-1 truncate">{formatValue(v)}</span>
+                      </label>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          )}
+
+          {selected.length > 0 && (
+            <div className="mt-2 border-t border-border pt-2">
+              <button
+                type="button"
+                onClick={clear}
+                className="flex w-full items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium text-mutedfg transition-colors hover:bg-surface hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+              >
+                <X className="size-3.5" />
+                Clear
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/rules/RuleExamples.tsx
+++ b/web/src/components/rules/RuleExamples.tsx
@@ -1,0 +1,42 @@
+import { CheckCircle2, XCircle } from 'lucide-react'
+
+interface RuleExamplesProps {
+  compliant: string
+  noncompliant: string
+}
+
+export function RuleExamples({ compliant, noncompliant }: RuleExamplesProps) {
+  if (!compliant && !noncompliant) return null
+
+  return (
+    <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
+      {noncompliant && (
+        <div className="flex flex-col overflow-hidden rounded-xl border border-danger/30 bg-surface">
+          <div className="flex items-center gap-2 border-b border-danger/20 bg-danger/10 px-4 py-2 font-medium text-danger">
+            <XCircle className="size-4" />
+            <span>Noncompliant</span>
+          </div>
+          <div className="flex-1 overflow-x-auto p-4">
+            <pre className="text-sm">
+              <code>{noncompliant}</code>
+            </pre>
+          </div>
+        </div>
+      )}
+
+      {compliant && (
+        <div className="flex flex-col overflow-hidden rounded-xl border border-success/30 bg-surface">
+          <div className="flex items-center gap-2 border-b border-success/20 bg-success/10 px-4 py-2 font-medium text-success">
+            <CheckCircle2 className="size-4" />
+            <span>Compliant</span>
+          </div>
+          <div className="flex-1 overflow-x-auto p-4">
+            <pre className="text-sm">
+              <code>{compliant}</code>
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/rules/RuleMetadata.tsx
+++ b/web/src/components/rules/RuleMetadata.tsx
@@ -1,0 +1,85 @@
+import {
+  formatRuleType,
+  formatRuleQuality,
+  formatRuleSeverity,
+  formatRuleDetection,
+  formatRemediationEffort,
+} from '../../lib/ruleFormat'
+import { sevSoft } from '../../lib/severity'
+import type { RuleDetail, RuleSummary } from '../../lib/types'
+import { cn, Pill } from '../ui'
+
+interface RuleMetadataProps {
+  rule: RuleSummary | RuleDetail
+  variant?: 'compact' | 'detail'
+}
+
+export function RuleMetadata({ rule, variant = 'detail' }: RuleMetadataProps) {
+  const isDetail = variant === 'detail'
+
+  return (
+    <div className={cn('flex flex-wrap items-center gap-2', isDetail && 'text-sm')}>
+      <span
+        className={cn(
+          'inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ring-1 ring-inset',
+          sevSoft[rule.defaultSeverity] || sevSoft.unknown,
+        )}
+      >
+        {formatRuleSeverity(rule.defaultSeverity)}
+      </span>
+
+      <span className="text-mutedfg flex items-center gap-2">
+        <span className="font-mono text-xs">{rule.language}</span>
+        <span className="text-border px-1">•</span>
+        <span>{formatRuleType(rule.type)}</span>
+
+        {isDetail && rule.detection && (
+          <>
+            <span className="text-border px-1">•</span>
+            <span>{formatRuleDetection(rule.detection)}</span>
+          </>
+        )}
+
+        {isDetail && rule.remediationEffort > 0 && (
+          <>
+            <span className="text-border px-1">•</span>
+            <span>{formatRemediationEffort(rule.remediationEffort)}</span>
+          </>
+        )}
+      </span>
+
+      {rule.qualities?.length > 0 && (
+        <>
+          <span className="text-border px-1">•</span>
+          <div className="flex gap-1.5">
+            {rule.qualities.map((q) => (
+              <Pill key={q} className="bg-elevated">
+                {formatRuleQuality(q)}
+              </Pill>
+            ))}
+          </div>
+        </>
+      )}
+
+      {isDetail && (
+        <div className="mt-2 flex w-full flex-wrap gap-1.5">
+          {rule.cwe?.map((c) => (
+            <Pill key={c} className="bg-surface border-border">
+              {c}
+            </Pill>
+          ))}
+          {rule.owasp?.map((o) => (
+            <Pill key={o} className="bg-surface border-border">
+              {o}
+            </Pill>
+          ))}
+          {rule.tags?.map((t) => (
+            <Pill key={t} className="bg-surface border-border">
+              {t}
+            </Pill>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/rules/VirtualRuleCards.test.tsx
+++ b/web/src/components/rules/VirtualRuleCards.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { VirtualRuleCards } from './VirtualRuleCards'
+import type { RuleSummary } from '../../lib/types'
+
+describe('VirtualRuleCards', () => {
+  const mockRules: RuleSummary[] = Array.from({ length: 150 }).map((_, i) => ({
+    key: `rule-${i}`,
+    name: `Virtual Rule ${i}`,
+    language: 'go',
+    type: 'vulnerability',
+    qualities: ['security'],
+    defaultSeverity: 'high',
+    tags: ['owasp'],
+    cwe: ['CWE-89'],
+    owasp: ['A03:2021'],
+    description: `Description for rule ${i}`,
+    remediationEffort: 30,
+    detection: 'pattern',
+  }))
+
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect
+
+  beforeEach(() => {
+    window.ResizeObserver = class ResizeObserver {
+      constructor(private cb: ResizeObserverCallback) {}
+      observe(target: Element) {
+        this.cb([{ target, contentRect: target.getBoundingClientRect() } as ResizeObserverEntry], this)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+
+    // Mock bounding client rect to give the container a height of 800px
+    Element.prototype.getBoundingClientRect = vi.fn(() => ({
+      width: 400,
+      height: 800,
+      top: 0,
+      left: 0,
+      bottom: 800,
+      right: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }))
+    
+    // Mock element height properties
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 800 })
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 800 })
+  })
+
+  afterEach(() => {
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    delete (window as any).ResizeObserver
+  })
+
+  it('renders a windowed subset for 100+ rules', () => {
+    render(
+      <MemoryRouter>
+        <VirtualRuleCards rules={mockRules} detailFrom="?q=test" />
+      </MemoryRouter>
+    )
+
+    const renderedCards = screen.getAllByRole('heading', { name: /Virtual Rule/ })
+    // With 800px height and 220px estimated item height + overscan, it should be well under 150
+    expect(renderedCards.length).toBeGreaterThan(0)
+    expect(renderedCards.length).toBeLessThan(150)
+  })
+
+  it('does not render all cards simultaneously', () => {
+    render(
+      <MemoryRouter>
+        <VirtualRuleCards rules={mockRules} detailFrom="?q=test" />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByText('Virtual Rule 149')).not.toBeInTheDocument()
+  })
+
+  it('the first visible cards contain correct data', () => {
+    render(
+      <MemoryRouter>
+        <VirtualRuleCards rules={mockRules} detailFrom="?q=test" />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Virtual Rule 0')).toBeInTheDocument()
+    expect(screen.getByText('rule-0')).toBeInTheDocument()
+    expect(screen.getByText('Description for rule 0')).toBeInTheDocument()
+  })
+
+  it('scrolling changes the rendered window', async () => {
+    render(
+      <MemoryRouter>
+        <VirtualRuleCards rules={mockRules} detailFrom="?q=test" />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Virtual Rule 0')).toBeInTheDocument()
+
+    // Simulate scrolling down
+    const container = screen.getByLabelText('Rule results')
+    container.scrollTop = 20000
+    fireEvent.scroll(container)
+
+    // Give the virtualizer a moment to update
+    await waitFor(() => {
+      // At scrollTop 20000, indices around 45-60 are in view.
+      expect(screen.queryByText('Virtual Rule 50')).toBeInTheDocument()
+    })
+  })
+
+  it('detail links preserve encoded keys and from state', async () => {
+    const LocationSpy = () => {
+      const location = useLocation()
+      return <div data-testid="location-state">{JSON.stringify(location.state)}</div>
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<VirtualRuleCards rules={mockRules} detailFrom="?q=test" />} />
+          <Route path="/rules/:key" element={<LocationSpy />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    const firstLink = screen.getByRole('link', { name: /Virtual Rule 0/ })
+    expect(firstLink).toHaveAttribute('href', '/rules/rule-0')
+    
+    fireEvent.click(firstLink)
+    
+    await waitFor(() => {
+      expect(screen.getByTestId('location-state')).toHaveTextContent('{"from":"?q=test"}')
+    })
+  })
+
+  it('total virtual height represents the complete collection', () => {
+    render(
+      <MemoryRouter>
+        <VirtualRuleCards rules={mockRules} detailFrom="?q=test" />
+      </MemoryRouter>
+    )
+
+    // Find the relative wrapper div that applies the total height
+    // It is the child of the container with aria-rowcount
+    const container = screen.getByLabelText('Rule results')
+    const wrapper = container.firstChild as HTMLElement
+    
+    // Total height should be roughly 150 * 220 = 33000px
+    const styleHeight = wrapper.style.height
+    const heightValue = parseInt(styleHeight, 10)
+    expect(heightValue).toBeGreaterThan(30000)
+  })
+
+  it('empty input does not crash', () => {
+    render(
+      <MemoryRouter>
+        <VirtualRuleCards rules={[]} detailFrom="?q=test" />
+      </MemoryRouter>
+    )
+
+    const container = screen.getByLabelText('Rule results')
+    expect(container).toHaveAttribute('aria-rowcount', '0')
+  })
+})

--- a/web/src/components/rules/VirtualRuleCards.tsx
+++ b/web/src/components/rules/VirtualRuleCards.tsx
@@ -1,0 +1,73 @@
+import { useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { Card } from '../ui'
+import { RuleMetadata } from './RuleMetadata'
+import { ChevronRight } from 'lucide-react'
+import type { RuleSummary } from '../../lib/types'
+
+interface VirtualRuleCardsProps {
+  rules: RuleSummary[]
+  detailFrom: string
+}
+
+export function VirtualRuleCards({ rules, detailFrom }: VirtualRuleCardsProps) {
+  const parentRef = useRef<HTMLDivElement>(null)
+
+  const virtualizer = useVirtualizer({
+    count: rules.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 220,
+    overscan: 8,
+  })
+
+  return (
+    <div
+      ref={parentRef}
+      className="max-h-[70vh] overflow-auto md:hidden"
+      aria-label="Rule results"
+      aria-rowcount={rules.length}
+    >
+      <div
+        className="relative w-full"
+        style={{ height: `${virtualizer.getTotalSize()}px` }}
+      >
+        {virtualizer.getVirtualItems().map((virtualItem) => {
+          const rule = rules[virtualItem.index]
+
+          return (
+            <div
+              key={rule.key}
+              data-index={virtualItem.index}
+              ref={virtualizer.measureElement}
+              className="absolute left-0 top-0 w-full pb-3"
+              style={{
+                transform: `translateY(${virtualItem.start}px)`,
+              }}
+            >
+              <Link
+                to={`/rules/${encodeURIComponent(rule.key)}`}
+                state={{ from: detailFrom }}
+                className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface rounded-xl"
+              >
+                <Card className="flex items-center gap-4 p-5 transition-colors hover:border-brand/40 elev card-sheen">
+                  <div className="flex-1 min-w-0">
+                    <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                      <h3 className="font-semibold text-foreground group-hover:text-brand">
+                        {rule.name}
+                      </h3>
+                      <span className="shrink-0 rounded bg-elevated px-1.5 py-0.5 font-mono text-[11px] text-mutedfg">{rule.key}</span>
+                    </div>
+                    <p className="text-xs text-mutedfg line-clamp-2 mb-3">{rule.description}</p>
+                    <RuleMetadata rule={rule} variant="compact" />
+                  </div>
+                  <ChevronRight className="size-5 shrink-0 text-mutedfg opacity-0 transition-all group-hover:-translate-x-1 group-hover:opacity-100" />
+                </Card>
+              </Link>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -228,9 +228,9 @@ export function Select({
 
 // ---- States ----
 
-export function Spinner({ label }: { label?: string }) {
+export function Spinner({ label, className }: { label?: string; className?: string }) {
   return (
-    <div className="flex items-center justify-center gap-2 py-10 text-sm text-mutedfg">
+    <div className={cn("flex items-center justify-center gap-2 py-10 text-sm text-mutedfg", className)}>
       <Loader2 className="size-4 animate-spin" />
       {label ?? 'Loading…'}
     </div>

--- a/web/src/lib/api.rules.test.ts
+++ b/web/src/lib/api.rules.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api, ApiError } from './api'
+
+describe('Rules API', () => {
+  let fetchSpy: any
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  describe('listRules', () => {
+    it('calls /rules with no filters', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as unknown as Response)
+
+      await api.listRules()
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/rules', expect.any(Object))
+    })
+
+    it('encodes query URL parameters', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as unknown as Response)
+
+      await api.listRules({ query: 'sql injection &' })
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/rules?q=sql+injection+%26', expect.any(Object))
+    })
+
+    it('repeats language values', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as unknown as Response)
+
+      await api.listRules({ languages: ['go', 'python'] })
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/rules?language=go&language=python', expect.any(Object))
+    })
+
+    it('repeats type values', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as unknown as Response)
+
+      await api.listRules({ types: ['bug', 'vulnerability'] })
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/rules?type=bug&type=vulnerability', expect.any(Object))
+    })
+
+    it('repeats severity values', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as unknown as Response)
+
+      await api.listRules({ severities: ['high', 'critical'] })
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/rules?severity=high&severity=critical', expect.any(Object))
+    })
+
+    it('repeats tag values', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as unknown as Response)
+
+      await api.listRules({ tags: ['security', 'owasp'] })
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/rules?tag=security&tag=owasp', expect.any(Object))
+    })
+
+    it('repeats CWE values', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as unknown as Response)
+
+      await api.listRules({ cwe: ['CWE-79', 'CWE-89'] })
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/rules?cwe=CWE-79&cwe=CWE-89', expect.any(Object))
+    })
+
+    it('combines filter dimensions and omits empty values', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as unknown as Response)
+
+      await api.listRules({
+        query: '   x ',
+        languages: ['go'],
+        types: [],
+      })
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/rules?q=x&language=go', expect.any(Object))
+    })
+
+    it('maps array normalization and snake_case', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [
+          {
+            key: 'go:sec',
+            default_severity: 'high',
+            remediation_effort: 30,
+            tags: null,
+          },
+        ],
+      } as unknown as Response)
+
+      const res = await api.listRules()
+      expect(res).toHaveLength(1)
+      expect(res[0].key).toBe('go:sec')
+      expect(res[0].defaultSeverity).toBe('high')
+      expect(res[0].remediationEffort).toBe(30)
+      expect(res[0].tags).toEqual([]) // nil normalized to []
+    })
+    
+    it('propagates backend errors', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'internal failure' }),
+      } as unknown as Response)
+      
+      await expect(api.listRules()).rejects.toThrow('internal failure')
+    })
+  })
+
+  describe('getRule', () => {
+    it('encodes colon keys exactly once', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ key: 'go:sql-injection' }),
+      } as unknown as Response)
+
+      await api.getRule('go:sql-injection')
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/rules/go%3Asql-injection', expect.any(Object))
+    })
+
+    it('maps detail and snake_case', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          key: 'foo',
+          compliant_example: 'good()',
+          noncompliant_example: 'bad()',
+        }),
+      } as unknown as Response)
+
+      const res = await api.getRule('foo')
+      expect(res.key).toBe('foo')
+      expect(res.compliantExample).toBe('good()')
+      expect(res.noncompliantExample).toBe('bad()')
+    })
+    
+    it('propagates 401 without suppressing', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: 'unauthorized' }),
+      } as unknown as Response)
+      
+      await expect(api.getRule('foo')).rejects.toThrow(ApiError)
+    })
+  })
+
+  describe('detection mapper', () => {
+    async function mapDetection(detection: string): Promise<string> {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [{ key: 'test', detection }],
+      } as unknown as Response)
+      const res = await api.listRules()
+      return res[0].detection
+    }
+
+    it('accepts ast', async () => {
+      expect(await mapDetection('ast')).toBe('ast')
+    })
+
+    it('accepts pattern', async () => {
+      expect(await mapDetection('pattern')).toBe('pattern')
+    })
+
+    it('accepts metric', async () => {
+      expect(await mapDetection('metric')).toBe('metric')
+    })
+
+    it('rejects regex to fallback', async () => {
+      expect(await mapDetection('regex')).toBe('pattern')
+    })
+
+    it('rejects secret to fallback', async () => {
+      expect(await mapDetection('secret')).toBe('pattern')
+    })
+
+    it('rejects analyzer to fallback', async () => {
+      expect(await mapDetection('analyzer')).toBe('pattern')
+    })
+
+    it('rejects empty string to fallback', async () => {
+      expect(await mapDetection('')).toBe('pattern')
+    })
+  })
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -32,6 +32,13 @@ import type {
   Vulnerability,
   Writeup,
   ThreatModel,
+  RuleSummary,
+  RuleDetail,
+  RuleListFilters,
+  RuleType,
+  RuleQuality,
+  RuleSeverity,
+  RuleDetection,
 } from './types'
 
 export class ApiError extends Error {
@@ -600,8 +607,87 @@ function mapJudgment(r: any): Judgment {
   }
 }
 
+// --- Rules ---
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((v) => asString(v)) : []
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === 'number' ? value : fallback
+}
+
+function asRuleType(value: unknown): RuleType {
+  const s = asString(value)
+  return ['bug', 'vulnerability', 'code_smell', 'security_hotspot'].includes(s) ? (s as RuleType) : 'code_smell'
+}
+
+function asRuleQualityArray(value: unknown): RuleQuality[] {
+  const arr = asStringArray(value)
+  return arr.filter((s) => ['security', 'reliability', 'maintainability'].includes(s)) as RuleQuality[]
+}
+
+function asRuleSeverity(value: unknown): RuleSeverity {
+  const s = asString(value)
+  return ['low', 'medium', 'high', 'critical'].includes(s) ? (s as RuleSeverity) : 'medium'
+}
+
+function asRuleDetection(value: unknown): RuleDetection {
+  const s = asString(value)
+  return s === 'ast' || s === 'pattern' || s === 'metric' ? s : 'pattern'
+}
+
+function mapRuleSummary(raw: any): RuleSummary {
+  return {
+    key: asString(raw?.key),
+    name: asString(raw?.name),
+    language: asString(raw?.language),
+    type: asRuleType(raw?.type),
+    qualities: asRuleQualityArray(raw?.qualities),
+    defaultSeverity: asRuleSeverity(raw?.default_severity),
+    tags: asStringArray(raw?.tags),
+    cwe: asStringArray(raw?.cwe),
+    owasp: asStringArray(raw?.owasp),
+    description: asString(raw?.description),
+    remediationEffort: asNumber(raw?.remediation_effort),
+    detection: asRuleDetection(raw?.detection),
+  }
+}
+
+function mapRuleDetail(raw: any): RuleDetail {
+  return {
+    ...mapRuleSummary(raw),
+    rationale: asString(raw?.rationale),
+    remediation: asString(raw?.remediation),
+    compliantExample: asString(raw?.compliant_example),
+    noncompliantExample: asString(raw?.noncompliant_example),
+  }
+}
+
 export const api = {
   aup: (): Promise<AupStatus> => req('/aup'),
+
+  // --- Rules ---
+  listRules: async (filters: Partial<RuleListFilters> = {}): Promise<RuleSummary[]> => {
+    const q = new URLSearchParams()
+    if (filters.query?.trim()) q.set('q', filters.query.trim())
+    for (const value of filters.languages ?? []) q.append('language', value)
+    for (const value of filters.types ?? []) q.append('type', value)
+    for (const value of filters.severities ?? []) q.append('severity', value)
+    for (const value of filters.tags ?? []) q.append('tag', value)
+    for (const value of filters.cwe ?? []) q.append('cwe', value)
+    const qs = q.toString()
+    const res = await req(`/rules${qs ? `?${qs}` : ''}`)
+    return Array.isArray(res) ? res.map(mapRuleSummary) : []
+  },
+
+  getRule: async (key: string): Promise<RuleDetail> => {
+    return mapRuleDetail(await req(`/rules/${encodeURIComponent(key)}`))
+  },
 
   // the engagement's code-quality report (inventory + findings + duplication + A-E ratings). Computed
   // over an in-scope local source directory; an engagement without one returns available=false. 404 (the

--- a/web/src/lib/ruleFilters.test.ts
+++ b/web/src/lib/ruleFilters.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import { parseRuleFilters, serializeRuleFilters, hasActiveRuleFilters } from './ruleFilters'
+
+describe('parseRuleFilters', () => {
+  it('handles empty URL', () => {
+    const params = new URLSearchParams()
+    const filters = parseRuleFilters(params)
+    expect(filters.query).toBe('')
+    expect(filters.languages).toEqual([])
+  })
+
+  it('parses query only', () => {
+    const params = new URLSearchParams('q=test')
+    const filters = parseRuleFilters(params)
+    expect(filters.query).toBe('test')
+  })
+
+  it('parses repeated filters', () => {
+    const params = new URLSearchParams('language=go&language=python&type=bug&type=vulnerability')
+    const filters = parseRuleFilters(params)
+    expect(filters.languages).toEqual(['go', 'python'])
+    expect(filters.types).toEqual(['bug', 'vulnerability'])
+  })
+
+  it('removes duplicate values case-insensitively with first casing wins', () => {
+    const params = new URLSearchParams('language=Go&language=go&language=GO')
+    const filters = parseRuleFilters(params)
+    expect(filters.languages).toEqual(['Go'])
+  })
+
+  it('ignores invalid type and severity', () => {
+    const params = new URLSearchParams('type=invalid&severity=super_high&severity=high')
+    const filters = parseRuleFilters(params)
+    expect(filters.types).toEqual([])
+    expect(filters.severities).toEqual(['high'])
+  })
+
+  it('canonicalizes type and severity', () => {
+    const params = new URLSearchParams()
+    params.append('type', 'VULNERABILITY')
+    params.append('type', 'BuG')
+    params.append('severity', 'HIGH')
+
+    const filters = parseRuleFilters(params)
+    expect(filters.types).toEqual(['vulnerability', 'bug'])
+    expect(filters.severities).toEqual(['high'])
+  })
+
+  it('canonicalizes CWE forms', () => {
+    const params = new URLSearchParams()
+    params.append('cwe', '89')
+    params.append('cwe', 'cwe-79')
+    params.append('cwe', 'CWE-20')
+    params.append('cwe', 'invalid')
+
+    const filters = parseRuleFilters(params)
+    expect(filters.cwe).toEqual(['CWE-89', 'CWE-79', 'CWE-20'])
+  })
+
+  it('removes empty values', () => {
+    const params = new URLSearchParams('language=  &language=&type=bug')
+    const filters = parseRuleFilters(params)
+    expect(filters.languages).toEqual([])
+    expect(filters.types).toEqual(['bug'])
+  })
+
+  it('enforces 256 char limit on query', () => {
+    const long = 'a'.repeat(300)
+    const params = new URLSearchParams(`q=${long}`)
+    const filters = parseRuleFilters(params)
+    expect(filters.query.length).toBe(256)
+  })
+
+  it('enforces 128 char limit on filter values', () => {
+    const long = 'b'.repeat(150)
+    const params = new URLSearchParams(`language=${long}`)
+    const filters = parseRuleFilters(params)
+    expect(filters.languages[0].length).toBe(128)
+  })
+
+  it('enforces 32 items per dimension boundary', () => {
+    const params = new URLSearchParams()
+    for (let i = 0; i < 40; i++) params.append('tag', `tag${i}`)
+    const filters = parseRuleFilters(params)
+    expect(filters.tags.length).toBe(32)
+  })
+
+  it('enforces 64 total facets boundary', () => {
+    const params = new URLSearchParams()
+    for (let i = 0; i < 40; i++) params.append('tag', `tag${i}`)
+    for (let i = 0; i < 40; i++) params.append('cwe', `CWE-${i}`)
+    const filters = parseRuleFilters(params)
+    expect(filters.tags.length + filters.cwe.length).toBe(64)
+  })
+})
+
+describe('serializeRuleFilters', () => {
+  it('serializes deterministically', () => {
+    const filters: any = {
+      query: 'inj',
+      languages: ['python', 'Go'],
+      types: [],
+      severities: ['high'],
+      tags: [],
+      cwe: [],
+    }
+    const params = serializeRuleFilters(filters)
+    expect(params.toString()).toBe('q=inj&language=Go&language=python&severity=high')
+  })
+
+  it('serializes canonical forms', () => {
+    const filters: any = {
+      query: '',
+      languages: [],
+      types: ['VULNERABILITY', 'invalid'],
+      severities: ['HIGH'],
+      tags: [],
+      cwe: ['89', 'cwe-79'],
+    }
+    const params = serializeRuleFilters(filters)
+    expect(params.getAll('type')).toEqual(['vulnerability'])
+    expect(params.getAll('severity')).toEqual(['high'])
+    expect(params.getAll('cwe')).toEqual(['CWE-79', 'CWE-89']) // sorted
+  })
+
+  it('deduplicates and sorts values', () => {
+    const filters = {
+      query: '',
+      languages: ['b', 'A', 'a', 'C'],
+      types: [],
+      severities: [],
+      tags: [],
+      cwe: [],
+    }
+    const params = serializeRuleFilters(filters as any)
+    expect(params.toString()).toBe('language=A&language=b&language=C')
+  })
+
+  it('parse -> serialize -> parse stability', () => {
+    const initial = new URLSearchParams('severity=high&language=python&language=go&q=test&tag=Security')
+    const parsed = parseRuleFilters(initial)
+    const serialized = serializeRuleFilters(parsed)
+    const reparsed = parseRuleFilters(serialized)
+    parsed.languages.sort()
+    reparsed.languages.sort()
+    expect(reparsed).toEqual(parsed)
+  })
+})
+
+describe('hasActiveRuleFilters', () => {
+  it('returns false for empty filters', () => {
+    expect(hasActiveRuleFilters({ query: '', languages: [], types: [], severities: [], tags: [], cwe: [] } as any)).toBe(false)
+  })
+
+  it('returns true if any filter is active', () => {
+    expect(hasActiveRuleFilters({ query: 'a' } as any)).toBe(true)
+    expect(hasActiveRuleFilters({ languages: ['go'] } as any)).toBe(true)
+  })
+})

--- a/web/src/lib/ruleFilters.ts
+++ b/web/src/lib/ruleFilters.ts
@@ -1,0 +1,133 @@
+import type { RuleListFilters, RuleType, RuleSeverity } from './types'
+
+const KNOWN_TYPES = new Set<RuleType>(['bug', 'vulnerability', 'code_smell', 'security_hotspot'])
+const KNOWN_SEVERITIES = new Set<RuleSeverity>(['low', 'medium', 'high', 'critical'])
+
+const MAX_QUERY_LEN = 256
+const MAX_FILTER_LEN = 128
+const MAX_PER_DIMENSION = 32
+const MAX_TOTAL_FACETS = 64
+
+function safeTrimLimit(v: string, limit: number): string {
+  const t = v.trim()
+  return Array.from(t).slice(0, limit).join('')
+}
+
+export function parseRuleFilters(params: URLSearchParams): RuleListFilters {
+  const filters: RuleListFilters = {
+    query: '',
+    languages: [],
+    types: [],
+    severities: [],
+    tags: [],
+    cwe: [],
+  }
+
+  let facetCount = 0
+
+  const q = params.get('q')
+  if (q && q.trim()) {
+    filters.query = safeTrimLimit(q, MAX_QUERY_LEN)
+  }
+
+  const parseDimension = <T extends string>(
+    key: string,
+    target: T[],
+    canonicalize: (val: string) => string | null = (v) => v,
+  ) => {
+    const values = params.getAll(key)
+    const seen = new Set<string>()
+
+    for (const val of values) {
+      if (facetCount >= MAX_TOTAL_FACETS) break
+      if (target.length >= MAX_PER_DIMENSION) break
+
+      const trimmed = safeTrimLimit(val, MAX_FILTER_LEN)
+      if (!trimmed) continue
+
+      const canonical = canonicalize(trimmed)
+      if (!canonical) continue
+
+      const lower = canonical.toLowerCase()
+      if (seen.has(lower)) continue
+
+      seen.add(lower)
+      target.push(canonical as T)
+      facetCount++
+    }
+  }
+
+  parseDimension('language', filters.languages)
+  parseDimension('type', filters.types, (v) => {
+    const lower = v.toLowerCase()
+    return KNOWN_TYPES.has(lower as RuleType) ? lower : null
+  })
+  parseDimension('severity', filters.severities, (v) => {
+    const lower = v.toLowerCase()
+    return KNOWN_SEVERITIES.has(lower as RuleSeverity) ? lower : null
+  })
+  parseDimension('tag', filters.tags)
+  parseDimension('cwe', filters.cwe, (v) => {
+    // 89, cwe-89, CWE-89 -> CWE-89
+    const match = v.match(/^(?:cwe-)?(\d+)$/i)
+    if (!match) return null
+    return `CWE-${match[1]}`
+  })
+
+  return filters
+}
+
+export function serializeRuleFilters(filters: RuleListFilters): URLSearchParams {
+  const p = new URLSearchParams()
+  if (filters.query?.trim()) {
+    p.set('q', filters.query.trim())
+  }
+
+  const appendUnique = (key: string, values: string[], canonicalize: (val: string) => string | null = (v) => v) => {
+    if (!values) return
+    const seen = new Set<string>()
+    const sorted = [...values]
+      .map(v => v.trim())
+      .map(v => canonicalize(v))
+      .filter((v): v is string => Boolean(v))
+      .filter((v) => {
+        const lower = v.toLowerCase()
+        if (seen.has(lower)) return false
+        seen.add(lower)
+        return true
+      })
+      .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+
+    for (const val of sorted) {
+      p.append(key, val)
+    }
+  }
+
+  appendUnique('language', filters.languages)
+  appendUnique('type', filters.types, (v) => {
+    const lower = v.toLowerCase()
+    return KNOWN_TYPES.has(lower as RuleType) ? lower : null
+  })
+  appendUnique('severity', filters.severities, (v) => {
+    const lower = v.toLowerCase()
+    return KNOWN_SEVERITIES.has(lower as RuleSeverity) ? lower : null
+  })
+  appendUnique('tag', filters.tags)
+  appendUnique('cwe', filters.cwe, (v) => {
+    const match = v.match(/^(?:cwe-)?(\d+)$/i)
+    if (!match) return null
+    return `CWE-${match[1]}`
+  })
+
+  return p
+}
+
+export function hasActiveRuleFilters(filters: RuleListFilters): boolean {
+  if (filters.query?.trim()) return true
+  if (filters.languages?.length) return true
+  if (filters.types?.length) return true
+  if (filters.severities?.length) return true
+  if (filters.tags?.length) return true
+  if (filters.cwe?.length) return true
+  return false
+}

--- a/web/src/lib/ruleFormat.test.ts
+++ b/web/src/lib/ruleFormat.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatRuleType,
+  formatRuleSeverity,
+  formatRuleQuality,
+  formatRuleDetection,
+  formatRemediationEffort,
+  deriveRuleFacets
+} from './ruleFormat'
+import type { RuleSummary } from './types'
+
+describe('Formatters', () => {
+  it('formats rule type', () => {
+    expect(formatRuleType('code_smell')).toBe('Code smell')
+    expect(formatRuleType('security_hotspot')).toBe('Security hotspot')
+    expect(formatRuleType('vulnerability')).toBe('Vulnerability')
+    expect(formatRuleType('bug')).toBe('Bug')
+    expect(formatRuleType('unknown' as any)).toBe('unknown')
+  })
+
+  it('formats rule severity', () => {
+    expect(formatRuleSeverity('critical')).toBe('Critical')
+    expect(formatRuleSeverity('high')).toBe('High')
+    expect(formatRuleSeverity('medium')).toBe('Medium')
+    expect(formatRuleSeverity('low')).toBe('Low')
+  })
+
+  it('formats rule quality', () => {
+    expect(formatRuleQuality('security')).toBe('Security')
+    expect(formatRuleQuality('reliability')).toBe('Reliability')
+    expect(formatRuleQuality('maintainability')).toBe('Maintainability')
+  })
+
+  it('formats rule detection', () => {
+    expect(formatRuleDetection('ast')).toBe('AST')
+    expect(formatRuleDetection('pattern')).toBe('Pattern')
+    expect(formatRuleDetection('metric')).toBe('Metric')
+  })
+
+  it('formats remediation effort', () => {
+    expect(formatRemediationEffort(0)).toBe('Not estimated')
+    expect(formatRemediationEffort(1)).toBe('1 min')
+    expect(formatRemediationEffort(30)).toBe('30 min')
+    expect(formatRemediationEffort(60)).toBe('1h')
+    expect(formatRemediationEffort(90)).toBe('1h 30m')
+    expect(formatRemediationEffort(120)).toBe('2h')
+  })
+})
+
+describe('deriveRuleFacets', () => {
+  it('derives facets properly from rules', () => {
+    const rules: RuleSummary[] = [
+      {
+        key: '1', name: '', description: '',
+        language: 'go', type: 'bug', defaultSeverity: 'high', tags: ['b', 'a'], cwe: ['CWE-79', 'CWE-89'],
+        qualities: [], owasp: [], remediationEffort: 0, detection: 'ast'
+      },
+      {
+        key: '2', name: '', description: '',
+        language: 'python', type: 'vulnerability', defaultSeverity: 'critical', tags: ['a'], cwe: ['CWE-22'],
+        qualities: [], owasp: [], remediationEffort: 0, detection: 'pattern'
+      },
+      {
+        key: '3', name: '', description: '',
+        language: 'Go', type: 'bug', defaultSeverity: 'high', tags: ['c'], cwe: ['CWE-89'],
+        qualities: [], owasp: [], remediationEffort: 0, detection: 'pattern'
+      }
+    ]
+
+    const facets = deriveRuleFacets(rules)
+
+    expect(facets.languages).toEqual(['go', 'python'])
+    expect(facets.types).toEqual(['vulnerability', 'bug'])
+    expect(facets.severities).toEqual(['critical', 'high'])
+    expect(facets.tags).toEqual(['a', 'b', 'c'])
+    expect(facets.cwe).toEqual(['CWE-22', 'CWE-79', 'CWE-89'])
+  })
+
+  it('does not mutate input array', () => {
+    const rules: RuleSummary[] = []
+    deriveRuleFacets(rules)
+    expect(rules).toEqual([])
+  })
+
+  it('handles empty values', () => {
+    const rules: Partial<RuleSummary>[] = [
+      { language: ' ', type: undefined, defaultSeverity: undefined, tags: [' ', 'valid'] }
+    ]
+    const facets = deriveRuleFacets(rules as any)
+    expect(facets.languages).toEqual([])
+    expect(facets.tags).toEqual(['valid'])
+  })
+})

--- a/web/src/lib/ruleFormat.ts
+++ b/web/src/lib/ruleFormat.ts
@@ -1,0 +1,122 @@
+import type { RuleSummary, RuleFacets, RuleType, RuleQuality, RuleSeverity, RuleDetection } from './types'
+
+export function formatRuleType(value: RuleType): string {
+  switch (value) {
+    case 'code_smell': return 'Code smell'
+    case 'security_hotspot': return 'Security hotspot'
+    case 'vulnerability': return 'Vulnerability'
+    case 'bug': return 'Bug'
+    default: return value || 'Unknown'
+  }
+}
+
+export function formatRuleQuality(value: RuleQuality): string {
+  switch (value) {
+    case 'security': return 'Security'
+    case 'reliability': return 'Reliability'
+    case 'maintainability': return 'Maintainability'
+    default: return value || 'Unknown'
+  }
+}
+
+export function formatRuleSeverity(value: RuleSeverity): string {
+  if (!value) return 'Unknown'
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+export function formatRuleDetection(value: RuleDetection): string {
+  switch (value) {
+    case 'ast': return 'AST'
+    case 'pattern': return 'Pattern'
+    case 'metric': return 'Metric'
+    default: return value || 'Unknown'
+  }
+}
+
+export function formatRemediationEffort(minutes: number): string {
+  if (!minutes || minutes <= 0) return 'Not estimated'
+  if (minutes < 60) return `${minutes} min`
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  if (m === 0) return `${h}h`
+  return `${h}h ${m}m`
+}
+
+const TYPE_ORDER: Record<RuleType, number> = {
+  vulnerability: 1,
+  security_hotspot: 2,
+  bug: 3,
+  code_smell: 4,
+}
+
+const SEVERITY_ORDER: Record<RuleSeverity, number> = {
+  critical: 1,
+  high: 2,
+  medium: 3,
+  low: 4,
+}
+
+function parseCweNumber(cwe: string): number {
+  const match = /^CWE-(\d+)$/i.exec(cwe)
+  return match ? parseInt(match[1], 10) : Infinity
+}
+
+export function deriveRuleFacets(rules: RuleSummary[]): RuleFacets {
+  const facets: RuleFacets = {
+    languages: [],
+    types: [],
+    severities: [],
+    tags: [],
+    cwe: [],
+  }
+
+  const lMap = new Map<string, string>()
+  const tSet = new Set<RuleType>()
+  const sSet = new Set<RuleSeverity>()
+  const tgMap = new Map<string, string>()
+  const cSet = new Set<string>()
+
+  for (const r of rules) {
+    if (r.language?.trim()) {
+      const v = r.language.trim()
+      if (!lMap.has(v.toLowerCase())) lMap.set(v.toLowerCase(), v)
+    }
+    if (r.type) tSet.add(r.type)
+    if (r.defaultSeverity) sSet.add(r.defaultSeverity)
+    for (const tag of r.tags ?? []) {
+      if (tag?.trim()) {
+        const v = tag.trim()
+        if (!tgMap.has(v.toLowerCase())) tgMap.set(v.toLowerCase(), v)
+      }
+    }
+    for (const c of r.cwe ?? []) {
+      if (c?.trim()) cSet.add(c.trim())
+    }
+  }
+
+  facets.languages = Array.from(lMap.values()).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+  facets.tags = Array.from(tgMap.values()).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+
+  facets.types = Array.from(tSet).sort((a, b) => {
+    const o1 = TYPE_ORDER[a] ?? 999
+    const o2 = TYPE_ORDER[b] ?? 999
+    if (o1 !== o2) return o1 - o2
+    return a.localeCompare(b)
+  })
+
+  facets.severities = Array.from(sSet).sort((a, b) => {
+    const o1 = SEVERITY_ORDER[a] ?? 999
+    const o2 = SEVERITY_ORDER[b] ?? 999
+    if (o1 !== o2) return o1 - o2
+    return a.localeCompare(b)
+  })
+
+  facets.cwe = Array.from(cSet).sort((a, b) => {
+    const n1 = parseCweNumber(a)
+    const n2 = parseCweNumber(b)
+    if (n1 !== n2) return n1 - n2
+    return a.localeCompare(b, undefined, { sensitivity: 'base' })
+  })
+
+  return facets
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -635,3 +635,66 @@ export interface CodeQualityView {
   reason?: string
   report?: CodeQualityReport
 }
+
+// --- Rules API ---
+
+export type RuleType =
+  | 'bug'
+  | 'vulnerability'
+  | 'code_smell'
+  | 'security_hotspot'
+
+export type RuleQuality =
+  | 'security'
+  | 'reliability'
+  | 'maintainability'
+
+export type RuleSeverity =
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'critical'
+
+export type RuleDetection =
+  | 'ast'
+  | 'pattern'
+  | 'metric'
+
+export interface RuleSummary {
+  key: string
+  name: string
+  language: string
+  type: RuleType
+  qualities: RuleQuality[]
+  defaultSeverity: RuleSeverity
+  tags: string[]
+  cwe: string[]
+  owasp: string[]
+  description: string
+  remediationEffort: number
+  detection: RuleDetection
+}
+
+export interface RuleDetail extends RuleSummary {
+  rationale: string
+  remediation: string
+  compliantExample: string
+  noncompliantExample: string
+}
+
+export interface RuleListFilters {
+  query: string
+  languages: string[]
+  types: RuleType[]
+  severities: RuleSeverity[]
+  tags: string[]
+  cwe: string[]
+}
+
+export interface RuleFacets {
+  languages: string[]
+  types: RuleType[]
+  severities: RuleSeverity[]
+  tags: string[]
+  cwe: string[]
+}

--- a/web/src/pages/RuleDetail.test.tsx
+++ b/web/src/pages/RuleDetail.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import RuleDetail from './RuleDetail'
+import { api, ApiError } from '../lib/api'
+import type { RuleDetail as RuleDetailType } from '../lib/types'
+
+vi.mock('../lib/api', () => ({
+  api: {
+    getRule: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    constructor(public status: number, message: string) {
+      super(message)
+    }
+  },
+}))
+
+function renderRuleDetail(initialEntry = '/rules/go:sql-injection', state?: any) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: initialEntry, state }]}>
+      <Routes>
+        <Route path="/rules/:key" element={<RuleDetail />} />
+        <Route path="/rules" element={<div data-testid="rules-list">Rules List Fallback</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('RuleDetail Page', () => {
+  const mockRule: RuleDetailType = {
+    key: 'go:sql-injection',
+    name: 'SQL Injection',
+    language: 'go',
+    type: 'vulnerability',
+    qualities: ['security'],
+    defaultSeverity: 'high',
+    tags: ['owasp'],
+    cwe: ['CWE-89'],
+    owasp: ['A03:2021'],
+    description: 'A simple description with <script>alert(1)</script>',
+    rationale: 'Why it matters',
+    remediation: 'How to fix it',
+    compliantExample: 'good code',
+    noncompliantExample: 'bad code',
+    remediationEffort: 30,
+    detection: 'ast',
+  }
+
+  const otherRule: RuleDetailType = {
+    ...mockRule,
+    key: 'py:xss',
+    name: 'XSS Vulnerability',
+    language: 'python',
+    description: 'Cross-site scripting',
+  }
+
+  beforeEach(() => {
+    vi.mocked(api.getRule).mockReset()
+  })
+
+  it('renders loading state initially', async () => {
+    vi.mocked(api.getRule).mockReturnValue(new Promise(() => {}))
+    renderRuleDetail()
+    expect(screen.getByRole('link', { name: /Back to rules/i })).toBeInTheDocument()
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+
+  it('renders rule details correctly', async () => {
+    vi.mocked(api.getRule).mockResolvedValue(mockRule)
+    renderRuleDetail()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'SQL Injection' })).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('go:sql-injection')).toBeInTheDocument()
+    expect(screen.getByText(/A simple description with <script>alert\(1\)<\/script>/)).toBeInTheDocument()
+    expect(screen.getByText('Why it matters')).toBeInTheDocument()
+    expect(screen.getByText('How to fix it')).toBeInTheDocument()
+    expect(screen.getByText('good code')).toBeInTheDocument()
+    expect(screen.getByText('bad code')).toBeInTheDocument()
+  })
+
+  it('renders dedicated 404 state', async () => {
+    vi.mocked(api.getRule).mockRejectedValue(new ApiError(404, 'Rule not found'))
+    renderRuleDetail()
+
+    await waitFor(() => {
+      expect(screen.getByText('Rule not found')).toBeInTheDocument()
+      expect(screen.getByText('The requested rule key does not exist in the catalog.')).toBeInTheDocument()
+    })
+  })
+
+  it('renders generic error state', async () => {
+    vi.mocked(api.getRule).mockRejectedValue(new ApiError(500, 'Server error'))
+    renderRuleDetail()
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load rule details')).toBeInTheDocument()
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+  })
+
+  it('retries on generic error', async () => {
+    vi.mocked(api.getRule).mockRejectedValueOnce(new ApiError(500, 'Server error'))
+    renderRuleDetail()
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+
+    vi.mocked(api.getRule).mockResolvedValue(mockRule)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('SQL Injection')).toBeInTheDocument()
+    })
+  })
+
+  it('navigates back to list with preserved query params', async () => {
+    vi.mocked(api.getRule).mockResolvedValue(mockRule)
+    renderRuleDetail('/rules/go:sql-injection', { from: '?q=sql' })
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'SQL Injection' })).toBeInTheDocument()
+    })
+
+    const backLink = screen.getByRole('link', { name: /Back to rules/i })
+    expect(backLink.getAttribute('href')).toBe('/rules?q=sql')
+  })
+
+  it('navigates back to list via direct visit fallback', async () => {
+    vi.mocked(api.getRule).mockResolvedValue(mockRule)
+    renderRuleDetail('/rules/go:sql-injection')
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'SQL Injection' })).toBeInTheDocument()
+    })
+
+    const backLink = screen.getByRole('link', { name: /Back to rules/i })
+    expect(backLink.getAttribute('href')).toBe('/rules')
+  })
+
+  it('does not overwrite new rule with stale response when key changes', async () => {
+    // First key loads slowly
+    let resolveFirst!: (val: RuleDetailType) => void
+    vi.mocked(api.getRule).mockImplementationOnce(
+      () => new Promise<RuleDetailType>((resolve) => { resolveFirst = resolve }),
+    )
+
+    const { createMemoryRouter, RouterProvider } = await import('react-router-dom')
+
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/rules/:key',
+          element: <RuleDetail />,
+        },
+      ],
+      {
+        initialEntries: ['/rules/go:sql-injection'],
+      },
+    )
+
+    render(<RouterProvider router={router} />)
+
+    // Loading state for first key
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+
+    // Second request resolves immediately
+    vi.mocked(api.getRule).mockResolvedValueOnce(otherRule)
+
+    // Navigate in the same instance
+    await waitFor(() => {
+      router.navigate('/rules/py:xss')
+    })
+
+    // Second request resolves and displays
+    expect(
+      await screen.findByRole('heading', {
+        name: 'XSS Vulnerability',
+      }),
+    ).toBeInTheDocument()
+
+    // Now resolve the stale first response
+    resolveFirst(mockRule)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', {
+          name: 'XSS Vulnerability',
+        }),
+      ).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole('heading', {
+        name: 'SQL Injection',
+      }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/RuleDetail.tsx
+++ b/web/src/pages/RuleDetail.tsx
@@ -1,0 +1,182 @@
+import { ArrowLeft, AlertCircle, RefreshCw, SearchX } from 'lucide-react'
+import { useEffect, useState, useCallback } from 'react'
+import { Link, useParams, useLocation } from 'react-router-dom'
+import { api, ApiError } from '../lib/api'
+import type { RuleDetail } from '../lib/types'
+import { EmptyState, Spinner } from '../components/ui'
+import { RuleMetadata } from '../components/rules/RuleMetadata'
+import { RuleExamples } from '../components/rules/RuleExamples'
+
+export default function RuleDetailPage() {
+  const { key } = useParams<{ key: string }>()
+  const location = useLocation()
+  const from = location.state?.from || ''
+
+  const [rule, setRule] = useState<RuleDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<{ status: number, message: string } | null>(null)
+
+  const loadRule = useCallback(() => {
+    if (!key) return
+    let active = true
+    setLoading(true)
+    setError(null)
+
+    api.getRule(key)
+      .then((res) => {
+        if (!active) return
+        setRule(res)
+      })
+      .catch((err) => {
+        if (!active) return
+        if (err instanceof ApiError) {
+          setError({ status: err.status, message: err.message })
+        } else {
+          setError({ status: 500, message: 'An error occurred' })
+        }
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [key])
+
+  useEffect(() => {
+    const cleanup = loadRule()
+    return cleanup
+  }, [loadRule])
+
+  if (error) {
+    if (error.status === 404) {
+      return (
+        <div className="mx-auto max-w-4xl animate-fade-in">
+          <Link
+            to={`/rules${from}`}
+            className="mb-6 inline-flex items-center gap-2 self-start text-sm font-medium text-mutedfg transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" />
+            Back to rules
+          </Link>
+          <EmptyState
+            icon={SearchX}
+            title="Rule not found"
+            hint="The requested rule key does not exist in the catalog."
+            action={
+              <div className="mt-4 flex items-center justify-center gap-3">
+                <Link
+                  to={`/rules${from}`}
+                  className="rounded-lg border border-border bg-transparent px-4 py-2 text-sm font-medium text-foreground hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                >
+                  Back to rules
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => loadRule()}
+                  className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-brandfg hover:bg-brand/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface inline-flex items-center gap-2"
+                >
+                  <RefreshCw className="size-4" />
+                  Retry
+                </button>
+              </div>
+            }
+          />
+        </div>
+      )
+    }
+
+    return (
+      <div className="mx-auto max-w-4xl animate-fade-in">
+        <Link
+          to={`/rules${from}`}
+          className="mb-6 inline-flex items-center gap-2 self-start text-sm font-medium text-mutedfg transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+          Back to rules
+        </Link>
+        <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-6 text-center text-red-600 dark:text-red-400">
+          <AlertCircle className="mx-auto mb-3 size-6" />
+          <h2 className="text-lg font-semibold">Failed to load rule details</h2>
+          <p className="mt-2 text-sm">{error.message}</p>
+          <button
+            onClick={() => loadRule()}
+            className="mt-6 inline-flex items-center gap-2 rounded-lg bg-red-500/10 px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-500/20 dark:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+          >
+            <RefreshCw className="size-4" />
+            Retry
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (loading || !rule) {
+    return (
+      <div className="mx-auto max-w-4xl animate-fade-in">
+        <Link
+          to={`/rules${from}`}
+          className="mb-6 inline-flex items-center gap-2 self-start text-sm font-medium text-mutedfg transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+          Back to rules
+        </Link>
+        <div className="flex h-40 items-center justify-center">
+          <Spinner className="size-6 text-brand" />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl animate-fade-in pb-12">
+      <Link
+        to={`/rules${from}`}
+        className="mb-6 inline-flex items-center gap-2 self-start text-sm font-medium text-mutedfg transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface rounded-sm"
+      >
+        <ArrowLeft className="size-4" />
+        Back to rules
+      </Link>
+
+      <header className="mb-8">
+        <div className="mb-2 flex items-center gap-3">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">{rule.name}</h1>
+          <span className="rounded-md bg-elevated px-2 py-1 font-mono text-xs font-medium text-mutedfg border border-border">
+            {rule.key}
+          </span>
+        </div>
+        <RuleMetadata rule={rule} variant="detail" />
+      </header>
+
+      <div className="space-y-8">
+        <section>
+          <h2 className="mb-3 text-lg font-semibold text-foreground">Description</h2>
+          <div className="prose prose-sm prose-zinc dark:prose-invert max-w-none text-mutedfg">
+            {rule.description}
+          </div>
+        </section>
+
+        {rule.rationale && (
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-foreground">Rationale</h2>
+            <div className="prose prose-sm prose-zinc dark:prose-invert max-w-none text-mutedfg">
+              {rule.rationale}
+            </div>
+          </section>
+        )}
+
+        {rule.remediation && (
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-foreground">Remediation</h2>
+            <div className="prose prose-sm prose-zinc dark:prose-invert max-w-none text-mutedfg">
+              {rule.remediation}
+            </div>
+          </section>
+        )}
+
+        <RuleExamples compliant={rule.compliantExample} noncompliant={rule.noncompliantExample} />
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/Rules.test.tsx
+++ b/web/src/pages/Rules.test.tsx
@@ -1,0 +1,314 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import Rules from './Rules'
+import { api, ApiError } from '../lib/api'
+import type { RuleSummary } from '../lib/types'
+
+vi.mock('../lib/api', () => ({
+  api: {
+    listRules: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    constructor(public status: number, message: string) {
+      super(message)
+    }
+  },
+}))
+
+function renderRules(initialUrl = '/rules') {
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <Rules />
+    </MemoryRouter>
+  )
+}
+
+describe('Rules Page', () => {
+  const mockRules: RuleSummary[] = [
+    {
+      key: 'go:sql',
+      name: 'SQL Injection',
+      language: 'go',
+      type: 'vulnerability',
+      qualities: ['security'],
+      defaultSeverity: 'high',
+      tags: ['owasp'],
+      cwe: ['CWE-89'],
+      owasp: ['A03:2021'],
+      description: 'SQL injection vulnerability',
+      remediationEffort: 30,
+      detection: 'ast',
+    },
+  ]
+
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect
+
+  beforeEach(() => {
+    vi.mocked(api.listRules).mockReset()
+
+    window.ResizeObserver = class ResizeObserver {
+      constructor(private cb: ResizeObserverCallback) {}
+      observe(target: Element) {
+        this.cb([{ target, contentRect: target.getBoundingClientRect() } as ResizeObserverEntry], this)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    Element.prototype.getBoundingClientRect = vi.fn(() => ({
+      width: 1000,
+      height: 800,
+      top: 0,
+      left: 0,
+      bottom: 800,
+      right: 1000,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }))
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 800 })
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 800 })
+  })
+
+  afterEach(() => {
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    delete (window as any).ResizeObserver
+  })
+
+  it('makes exactly one initial API request when no filters', async () => {
+    vi.mocked(api.listRules).mockResolvedValue(mockRules)
+    renderRules()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('SQL Injection').length).toBeGreaterThan(0)
+    })
+
+    expect(api.listRules).toHaveBeenCalledTimes(1)
+    expect(api.listRules).toHaveBeenCalledWith()
+  })
+
+  it('makes exactly two API requests for initially filtered URL', async () => {
+    vi.mocked(api.listRules)
+      .mockResolvedValueOnce(mockRules)  // catalog
+      .mockResolvedValue(mockRules)      // filtered
+
+    renderRules('/rules?q=sql')
+
+    await waitFor(() => {
+      expect(screen.getAllByText('SQL Injection').length).toBeGreaterThan(0)
+    })
+
+    // Wait for all effects to settle
+    await waitFor(() => {
+      expect(api.listRules).toHaveBeenCalledTimes(2)
+    })
+
+    // Verify: call 0 = catalog (no args), call 1 = filtered (with filters)
+    expect(vi.mocked(api.listRules).mock.calls[0]).toEqual([])
+    expect(vi.mocked(api.listRules).mock.calls[1][0]).toEqual(
+      expect.objectContaining({ query: 'sql' }),
+    )
+
+    // Confirm it stays at 2, not 3
+    await new Promise((r) => setTimeout(r, 100))
+    expect(api.listRules).toHaveBeenCalledTimes(2)
+  })
+
+  it('reuses catalogRules when filters are cleared', async () => {
+    vi.mocked(api.listRules).mockResolvedValue(mockRules)
+    renderRules('/rules?q=sql')
+
+    await waitFor(() => {
+      expect(api.listRules).toHaveBeenCalledTimes(2)
+    })
+
+    // Clear filters
+    const clearBtn = screen.getByRole('button', { name: 'Clear search' })
+    fireEvent.click(clearBtn)
+
+    await waitFor(() => {
+      expect(api.listRules).toHaveBeenCalledTimes(2)
+      expect(screen.getByText('1 rules')).toBeInTheDocument()
+    })
+  })
+
+  it('renders loading state initially', async () => {
+    vi.mocked(api.listRules).mockReturnValue(new Promise(() => {}))
+    renderRules()
+    expect(screen.getByRole('heading', { name: 'Rules' })).toBeInTheDocument()
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+
+  it('renders initial error and retry', async () => {
+    vi.mocked(api.listRules).mockRejectedValueOnce(new ApiError(500, 'Network error'))
+    vi.mocked(api.listRules).mockResolvedValue(mockRules)
+    renderRules()
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load catalog')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => {
+      expect(screen.getAllByText('SQL Injection').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('renders filtered error with visible Retry that works', async () => {
+    vi.mocked(api.listRules).mockResolvedValueOnce(mockRules) // catalog
+    renderRules()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('SQL Injection').length).toBeGreaterThan(0)
+    })
+
+    // Trigger filter — filtered request fails
+    vi.mocked(api.listRules).mockRejectedValueOnce(new ApiError(500, 'Filter error'))
+    const searchInput = screen.getByRole('textbox', { name: 'Search rules' })
+    fireEvent.change(searchInput, { target: { value: 'test' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load filtered results')).toBeInTheDocument()
+    })
+
+    // Previous results are still visible
+    expect(screen.getAllByText('SQL Injection').length).toBeGreaterThan(0)
+
+    // Retry button is visible and clickable
+    const retryBtn = screen.getByRole('button', { name: 'Retry' })
+    expect(retryBtn).toBeVisible()
+
+    const callsBefore = vi.mocked(api.listRules).mock.calls.length
+    vi.mocked(api.listRules).mockResolvedValueOnce([]) // success on retry
+
+    fireEvent.click(retryBtn)
+
+    await waitFor(() => {
+      // One more filtered call was made
+      expect(vi.mocked(api.listRules).mock.calls.length).toBe(callsBefore + 1)
+      // Error disappears
+      expect(screen.queryByText('Failed to load filtered results')).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders full empty catalog state', async () => {
+    vi.mocked(api.listRules).mockResolvedValue([])
+    renderRules()
+
+    await waitFor(() => {
+      expect(screen.getByText('No rules are available.')).toBeInTheDocument()
+    })
+  })
+
+  it('renders no-match state', async () => {
+    vi.mocked(api.listRules)
+      .mockResolvedValueOnce(mockRules) // catalog
+      .mockResolvedValue([])            // filtered
+
+    renderRules('/rules?q=nomatch')
+
+    await waitFor(() => {
+      expect(screen.getByText('No rules match these filters.')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Clear all filters' })).toBeInTheDocument()
+    })
+  })
+
+  it('debounces search input and applies to URL', async () => {
+    vi.mocked(api.listRules).mockResolvedValue(mockRules)
+    renderRules()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('SQL Injection').length).toBeGreaterThan(0)
+    })
+
+    const searchInput = screen.getByRole('textbox', { name: 'Search rules' })
+    fireEvent.change(searchInput, { target: { value: 'test' } })
+
+    expect(api.listRules).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => {
+      expect(api.listRules).toHaveBeenCalledTimes(2)
+      expect(vi.mocked(api.listRules).mock.calls[1][0]).toEqual(expect.objectContaining({ query: 'test' }))
+    }, { timeout: 500 })
+  })
+
+  it('clears search with Escape', async () => {
+    vi.mocked(api.listRules).mockResolvedValue(mockRules)
+    renderRules('/rules?q=test')
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Search rules' })).toHaveValue('test')
+    })
+
+    const searchInput = screen.getByRole('textbox', { name: 'Search rules' })
+    fireEvent.keyDown(searchInput, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(searchInput).toHaveValue('')
+    })
+  })
+
+  it('renders active filter chips and clears them', async () => {
+    vi.mocked(api.listRules).mockResolvedValue(mockRules)
+    renderRules('/rules?type=vulnerability')
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Vulnerability/i).length).toBeGreaterThan(0)
+    })
+
+    const removeBtn = screen.getByRole('button', { name: 'Remove Vulnerability filter' })
+    fireEvent.click(removeBtn)
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Remove Vulnerability filter')).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders Clear all button', async () => {
+    vi.mocked(api.listRules).mockResolvedValue(mockRules)
+    renderRules('/rules?type=vulnerability')
+
+    await waitFor(() => {
+      const clearAllBtn = screen.getByRole('button', { name: 'Clear all' })
+      expect(clearAllBtn).toBeInTheDocument()
+    })
+  })
+
+  it('virtualizes large rule catalogs for desktop and mobile', async () => {
+    // Generate a fixture with 1000 rules to trigger virtualization constraints
+    const largeCatalog: RuleSummary[] = Array.from({ length: 1000 }).map((_, i) => ({
+      ...mockRules[0],
+      key: `rule-${i}`,
+      name: `Virtual Rule ${i}`,
+    }))
+
+    vi.mocked(api.listRules).mockResolvedValue(largeCatalog)
+    renderRules()
+
+    await waitFor(() => {
+      // Must have the table semantics for Desktop
+      const table = screen.getByRole('table')
+      expect(table).toBeInTheDocument()
+      expect(table).toHaveAttribute('aria-rowcount', '1001')
+
+      // Must have the list semantics for Mobile cards
+      const mobileList = screen.getByLabelText('Rule results')
+      expect(mobileList).toBeInTheDocument()
+      expect(mobileList).toHaveAttribute('aria-rowcount', '1000')
+    })
+
+    // Desktop: DOM should not have one row for every item
+    const rows = screen.getAllByRole('row')
+    expect(rows.length).toBeLessThan(100)
+
+    // Mobile: DOM should not have one card for every item
+    const cards = screen.getAllByRole('heading', { name: /Virtual Rule/ })
+    expect(cards.length).toBeLessThan(100)
+
+    // The first visible items should retain links and metadata
+    const firstRuleName = screen.getAllByText('Virtual Rule 0')[0]
+    expect(firstRuleName).toBeInTheDocument()
+    expect(firstRuleName.closest('a')).toHaveAttribute('href', '/rules/rule-0')
+  })
+})

--- a/web/src/pages/Rules.tsx
+++ b/web/src/pages/Rules.tsx
@@ -1,0 +1,425 @@
+import { Search, ChevronRight, X, AlertCircle, RefreshCw } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { api, ApiError } from '../lib/api'
+import { hasActiveRuleFilters, parseRuleFilters, serializeRuleFilters } from '../lib/ruleFilters'
+import { deriveRuleFacets, formatRuleSeverity, formatRuleType } from '../lib/ruleFormat'
+import type { RuleFacets, RuleSummary, RuleType, RuleSeverity } from '../lib/types'
+import { Card, EmptyState, Spinner, cn } from '../components/ui'
+import { FacetFilter } from '../components/rules/FacetFilter'
+import { VirtualTable } from '../components/VirtualTable'
+import { VirtualRuleCards } from '../components/rules/VirtualRuleCards'
+
+type FilterKey = 'languages' | 'types' | 'severities' | 'tags' | 'cwe'
+
+function formatFilterChip(key: FilterKey, val: string): string {
+  if (key === 'types') return formatRuleType(val as RuleType)
+  if (key === 'severities') return formatRuleSeverity(val as RuleSeverity)
+  return val
+}
+
+export default function Rules() {
+  const [params, setParams] = useSearchParams()
+  const filters = useMemo(() => parseRuleFilters(params), [params])
+  const activeFilters = hasActiveRuleFilters(filters)
+
+  const [catalogRules, setCatalogRules] = useState<RuleSummary[]>([])
+  const [catalogLoading, setCatalogLoading] = useState(true)
+  const [catalogError, setCatalogError] = useState<string | null>(null)
+  const [facets, setFacets] = useState<RuleFacets>({ languages: [], types: [], severities: [], tags: [], cwe: [] })
+
+  const [resultRules, setResultRules] = useState<RuleSummary[]>([])
+  const [resultLoading, setResultLoading] = useState(false)
+  const [resultError, setResultError] = useState<string | null>(null)
+
+  const [filteredRetryVersion, setFilteredRetryVersion] = useState(0)
+  const reqSeq = useRef(0)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const [query, setQuery] = useState(filters.query)
+
+  useEffect(() => {
+    setQuery(filters.query)
+  }, [filters.query])
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (query !== filters.query) {
+        const nextFilters = { ...filters, query }
+        setParams(serializeRuleFilters(nextFilters), { replace: true })
+      }
+    }, 250)
+    return () => clearTimeout(timeout)
+  }, [query, filters, setParams])
+
+  const loadCatalog = useCallback(() => {
+    let active = true
+    setCatalogLoading(true)
+    setCatalogError(null)
+
+    api.listRules()
+      .then((res) => {
+        if (!active) return
+        setCatalogRules(res)
+        setFacets(deriveRuleFacets(res))
+      })
+      .catch((err) => {
+        if (!active) return
+        setCatalogError(err instanceof ApiError ? err.message : 'An error occurred')
+      })
+      .finally(() => {
+        if (active) setCatalogLoading(false)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  useEffect(() => {
+    const cleanup = loadCatalog()
+    return cleanup
+  }, [loadCatalog])
+
+  // Sync catalogRules → resultRules when no filters are active.
+  useEffect(() => {
+    if (!activeFilters) {
+      setResultRules(catalogRules)
+      setResultError(null)
+      setResultLoading(false)
+    }
+  }, [activeFilters, catalogRules])
+
+  // Filtered request — does NOT depend on catalogRules.
+  const canonicalFilterKey = params.toString()
+  useEffect(() => {
+    if (!activeFilters) return
+
+    let active = true
+    const seq = ++reqSeq.current
+    setResultError(null)
+    setResultLoading(true)
+
+    api.listRules(filters)
+      .then((res) => {
+        if (!active || seq !== reqSeq.current) return
+        setResultRules(res)
+      })
+      .catch((err) => {
+        if (!active || seq !== reqSeq.current) return
+        setResultError(err instanceof ApiError ? err.message : 'An error occurred')
+      })
+      .finally(() => {
+        if (active && seq === reqSeq.current) setResultLoading(false)
+      })
+
+    return () => {
+      active = false
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeFilters, canonicalFilterKey, filteredRetryVersion])
+
+  const handleFilterChange = (key: FilterKey, value: string[]) => {
+    const nextFilters = { ...filters, [key]: value }
+    setParams(serializeRuleFilters(nextFilters))
+  }
+
+  const removeChip = (key: FilterKey, val: string) => {
+    const nextFilters = { ...filters, [key]: filters[key].filter(v => v !== val) }
+    setParams(serializeRuleFilters(nextFilters))
+  }
+
+  const clearQuery = () => {
+    setQuery('')
+    const nextFilters = { ...filters, query: '' }
+    setParams(serializeRuleFilters(nextFilters))
+    searchInputRef.current?.focus()
+  }
+
+  const clearAllFilters = () => {
+    setQuery('')
+    setParams(new URLSearchParams())
+  }
+
+  const handleSearchKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      clearQuery()
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl animate-fade-in pb-12">
+      <header className="bg-hero mb-6 flex flex-col gap-4 rounded-xl border border-border p-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">Rules</h1>
+          <p className="mt-1.5 max-w-xl text-sm text-mutedfg">
+            Browse first-party security and code-quality rules, their rationale, and remediation guidance.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center justify-end md:self-end">
+          {!catalogLoading && !catalogError && (
+            <p className="text-sm font-medium text-mutedfg" aria-live="polite">
+              {activeFilters ? `${resultRules.length} of ${catalogRules.length} rules` : `${catalogRules.length} rules`}
+            </p>
+          )}
+        </div>
+      </header>
+
+      {catalogError ? (
+        <div className="mb-6 rounded-lg border border-red-500/20 bg-red-500/5 p-4 text-sm text-red-600 dark:text-red-400">
+          <div className="flex items-center gap-2 font-medium">
+            <AlertCircle className="size-4" />
+            Failed to load catalog
+          </div>
+          <p className="mt-1 ml-6">{catalogError}</p>
+          <button
+            onClick={() => loadCatalog()}
+            className="mt-3 ml-6 inline-flex items-center gap-1.5 text-xs font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface rounded-sm"
+          >
+            <RefreshCw className="size-3" />
+            Retry
+          </button>
+        </div>
+      ) : catalogLoading ? (
+        <Spinner className="mt-12 size-6 text-brand" />
+      ) : (
+        <>
+          <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center">
+            <div className="relative max-w-md flex-1">
+              <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-mutedfg" />
+              <input
+                ref={searchInputRef}
+                aria-label="Search rules"
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={handleSearchKey}
+                placeholder="Search rules..."
+                className="w-full rounded-lg border border-border bg-card py-2 pl-9 pr-8 text-sm text-foreground transition-colors placeholder:text-mutedfg focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand shadow-sm"
+                maxLength={256}
+              />
+              {query && (
+                <button
+                  type="button"
+                  onClick={clearQuery}
+                  aria-label="Clear search"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-mutedfg transition-colors hover:bg-surface hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                >
+                  <X className="size-3.5" />
+                </button>
+              )}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <FacetFilter
+                label="Language"
+                values={facets.languages}
+                selected={filters.languages}
+                onChange={(v) => handleFilterChange('languages', v)}
+              />
+              <FacetFilter
+                label="Type"
+                values={facets.types}
+                selected={filters.types}
+                formatValue={formatRuleType}
+                onChange={(v) => handleFilterChange('types', v)}
+              />
+              <FacetFilter
+                label="Severity"
+                values={facets.severities}
+                selected={filters.severities}
+                formatValue={formatRuleSeverity}
+                onChange={(v) => handleFilterChange('severities', v)}
+              />
+              <FacetFilter
+                label="Tag"
+                values={facets.tags}
+                selected={filters.tags}
+                onChange={(v) => handleFilterChange('tags', v)}
+              />
+              <FacetFilter
+                label="CWE"
+                values={facets.cwe}
+                selected={filters.cwe}
+                onChange={(v) => handleFilterChange('cwe', v)}
+              />
+              {activeFilters && (
+                <button
+                  type="button"
+                  onClick={clearAllFilters}
+                  className="ml-2 text-sm font-medium text-branddim transition-colors hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface rounded-sm"
+                >
+                  Clear all
+                </button>
+              )}
+            </div>
+          </div>
+
+          {activeFilters && (
+            <div className="mb-6 flex flex-wrap gap-2">
+              {(['languages', 'types', 'severities', 'tags', 'cwe'] as const).map(key => 
+                filters[key].map(val => (
+                  <div key={`${key}-${val}`} className="flex items-center gap-1 rounded-md bg-brand/10 pl-2.5 pr-1 py-1 text-xs font-medium text-branddim">
+                    {formatFilterChip(key, val)}
+                    <button
+                      type="button"
+                      aria-label={`Remove ${formatFilterChip(key, val)} filter`}
+                      onClick={() => removeChip(key, val)}
+                      className="rounded-full p-0.5 transition-colors hover:bg-brand/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+
+          <div className="space-y-4" aria-busy={resultLoading}>
+            {resultError && (
+              <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-4 text-sm text-red-600 dark:text-red-400">
+                <div className="flex items-center gap-2 font-medium">
+                  <AlertCircle className="size-4" />
+                  Failed to load filtered results
+                </div>
+                <p className="mt-1 ml-6">{resultError}</p>
+                <button
+                  type="button"
+                  onClick={() => setFilteredRetryVersion((v) => v + 1)}
+                  className="mt-3 ml-6 inline-flex items-center gap-1.5 text-xs font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface rounded-sm"
+                >
+                  <RefreshCw className="size-3" />
+                  Retry
+                </button>
+              </div>
+            )}
+
+            {!activeFilters && catalogRules.length === 0 ? (
+              <EmptyState
+                icon={Search}
+                title="No rules are available."
+                hint="The catalog is currently empty."
+              />
+            ) : activeFilters && resultRules.length === 0 && !resultLoading && !resultError ? (
+              <EmptyState
+                icon={Search}
+                title="No rules match these filters."
+                hint="Try adjusting or removing some filters to find what you're looking for."
+                action={
+                  <button
+                    type="button"
+                    onClick={clearAllFilters}
+                    className="mt-4 rounded-lg bg-brand px-4 py-2 text-sm font-medium text-brandfg hover:bg-brand/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                  >
+                    Clear all filters
+                  </button>
+                }
+              />
+            ) : (
+              <div className={cn("transition-opacity duration-200", resultLoading && "opacity-50 pointer-events-none")}>
+                {/* Desktop Table */}
+                <div className="hidden md:block">
+                  <Card bodyClass="p-0">
+                    <VirtualTable
+                      columns={[
+                        {
+                          header: 'Rule',
+                          className: 'min-w-[22rem] flex-1',
+                          cell: (rule) => (
+                            <div className="flex flex-col gap-1 py-3">
+                              <Link 
+                                to={`/rules/${encodeURIComponent(rule.key)}`}
+                                state={{ from: params.toString() ? `?${params.toString()}` : '' }}
+                                className="font-semibold text-foreground hover:text-brand focus-visible:outline-none focus-visible:underline"
+                              >
+                                {rule.name}
+                              </Link>
+                              <div className="flex items-center gap-2">
+                                <span className="rounded bg-elevated px-1.5 py-0.5 font-mono text-[11px] text-mutedfg border border-border/50">{rule.key}</span>
+                              </div>
+                              <p className="text-xs text-mutedfg line-clamp-2 mt-0.5" title={rule.description}>{rule.description}</p>
+                            </div>
+                          ),
+                        },
+                        {
+                          header: 'Language',
+                          className: 'w-28 shrink-0',
+                          cell: (rule) => <span className="capitalize text-mutedfg">{rule.language}</span>,
+                        },
+                        {
+                          header: 'Type',
+                          className: 'w-36 shrink-0',
+                          cell: (rule) => <span className="text-mutedfg">{formatRuleType(rule.type)}</span>,
+                        },
+                        {
+                          header: 'Qualities',
+                          className: 'w-44 shrink-0',
+                          cell: (rule) => (
+                            <div className="flex flex-col gap-1 text-mutedfg">
+                              {rule.qualities.length > 0 ? rule.qualities.map(q => <span key={q} className="capitalize">{q}</span>) : '-'}
+                            </div>
+                          ),
+                        },
+                        {
+                          header: 'Severity',
+                          className: 'w-28 shrink-0',
+                          cell: (rule) => <span className="text-mutedfg">{formatRuleSeverity(rule.defaultSeverity)}</span>,
+                        },
+                        {
+                          header: 'Tags',
+                          className: 'w-56 shrink-0',
+                          cell: (rule) => {
+                            const maxTags = 3
+                            const visibleTags = rule.tags.slice(0, maxTags)
+                            const extraTags = rule.tags.length - maxTags
+                            return (
+                              <div className="flex flex-wrap gap-1 text-mutedfg">
+                                {visibleTags.map(t => (
+                                  <span key={t} className="rounded bg-surface px-1.5 py-0.5 text-[11px] border border-border/50">{t}</span>
+                                ))}
+                                {extraTags > 0 && (
+                                  <span className="rounded bg-surface px-1.5 py-0.5 text-[11px] border border-border/50">+{extraTags}</span>
+                                )}
+                              </div>
+                            )
+                          },
+                        },
+                        {
+                          header: '',
+                          className: 'w-10 shrink-0 text-right',
+                          cell: (rule) => (
+                            <Link 
+                              to={`/rules/${encodeURIComponent(rule.key)}`}
+                              state={{ from: params.toString() ? `?${params.toString()}` : '' }}
+                              aria-label={`View ${rule.name} details`}
+                              className="inline-flex size-8 items-center justify-center rounded-lg text-mutedfg hover:bg-elevated hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                            >
+                              <ChevronRight className="size-4" />
+                            </Link>
+                          ),
+                        },
+                      ]}
+                      items={resultRules}
+                      rowKey={(rule) => rule.key}
+                      rowHeight={96}
+                      maxHeightClass="max-h-[70vh]"
+                      tableMinWidthClass="min-w-[72rem]"
+                      totalItems={resultRules.length}
+                    />
+                  </Card>
+                </div>
+
+                {/* Mobile Cards */}
+                <VirtualRuleCards 
+                  rules={resultRules} 
+                  detailFrom={params.toString() ? `?${params.toString()}` : ''} 
+                />
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,14 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    restoreMocks: true,
+    clearMocks: true,
+  },
+})


### PR DESCRIPTION
## Summary

Adds the Rules Explorer web experience for browsing and understanding Synapse's built-in first-party rule catalog.

The explorer consumes the authenticated Rules API and provides URL-backed search, multi-value filtering, stable detail routes, remediation guidance, and compliant and noncompliant examples.

## Changes

* add typed frontend models for rule summaries, rule details, filters, and facets
* add Rules API client methods with:

  * repeated query parameters
  * snake_case-to-camelCase response mapping
  * safe rule-key encoding
  * normalized array fields
* add deterministic parsing and serialization of rule filters in the URL
* normalize rule types, severities, and CWE identifiers from manually edited URLs
* add the `/rules` catalog route
* add the `/rules/:key` detail route
* add Rules to desktop and mobile navigation
* preserve the active navigation state on both list and detail routes
* add debounced free-text search
* add multi-value facets for:

  * language
  * rule type
  * default severity
  * tag
  * CWE
* preserve filter state across refreshes, browser navigation, and rule-detail navigation
* add removable active-filter chips and Clear all actions
* derive facet options and total counts from the complete catalog
* request server-filtered results only when filters are active
* prevent stale API responses from overwriting newer list or detail results
* add retryable initial and filtered-result error states
* add dedicated empty-catalog, no-match, and rule-not-found states
* add a semantic desktop results table
* add responsive mobile result cards
* show rule name, key, description, language, type, qualities, severity, and tags in list results
* add complete rule-detail sections for:

  * description
  * rationale
  * remediation
  * compliant example
  * noncompliant example
  * detection metadata
  * remediation effort
  * CWE, OWASP, and tags
* render rule content and examples safely as text
* add keyboard-accessible facet controls with checkbox semantics, Escape handling, outside-click handling, and focus restoration
* add accessible labels, live result counts, busy states, and clear actions
* add Vitest and React Testing Library infrastructure
* add coverage for:

  * API request construction and response mapping
  * URL parsing, normalization, bounds, and deterministic serialization
  * facet derivation and formatting
  * facet keyboard and focus behavior
  * list loading, filtering, retry, empty, and stale-response behavior
  * rule-detail loading, retry, not-found, safe rendering, and stale-response behavior
  * list and detail routing
  * encoded rule keys
  * Sidebar active states
  * mobile navigation and drawer closing

## User experience

Users can open the global Rules section, search across rule metadata, combine multiple facets, share or refresh the resulting URL, inspect a rule's complete documentation, and return to the same filtered catalog state.

Rule keys are treated as opaque identifiers and safely support punctuation such as `:`.

## Request behavior

* the initial unfiltered page performs one catalog request
* the full catalog is reused when no filters are active
* active filters produce one server-filtered request per canonical URL state
* search requests are debounced
* previous results remain visible while filtered results load
* stale list and detail responses cannot overwrite newer state
* filtered and detail failures can be retried

## Security and architecture

* the explorer is read-only
* existing authentication and Acceptable Use Policy behavior remain unchanged
* no tenant or engagement context is required
* all API access remains centralized in the existing frontend API client
* rule keys are encoded before being placed in request paths
* API text is rendered as text rather than HTML
* no `dangerouslySetInnerHTML`, `innerHTML`, or runtime code evaluation is used
* no rule data or authentication token is persisted locally
* no backend, database, migration, or rule-metadata changes are included

## Validation

* TypeScript typecheck
* API-client tests
* URL and filter-state tests
* facet interaction and accessibility tests
* Rules list-page tests
* rule-detail tests
* routing and Sidebar tests
* existing Node web regression test
* production Vite build
* production dependency audit
* repository Go tests and vet
* whitespace and diff validation

Completes the remaining Rules Explorer acceptance criteria for #182.
