### PR TITLE
refactor: replace brittle inventory counts

### DIFF
--- a/internal/adapter/mcpserver/server_test.go
+++ b/internal/adapter/mcpserver/server_test.go
@@ -107,16 +107,36 @@ func TestMCPToolsList(t *testing.T) {
 	_, out := rpc(t, h, "secret-token", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
 	res, _ := out["result"].(map[string]any)
 	tools, _ := res["tools"].([]any)
-	if len(tools) != 9 { // + SAST/detail/evidence-sufficiency/runtime-verification read-only advisory tools
-		t.Fatalf("expected 9 catalog tools, got %d", len(tools))
+	expected := map[string]bool{
+		agenttools.ToolListFindings:            true,
+		agenttools.ToolGetFindingDetail:        true,
+		agenttools.ToolListSASTValidation:      true,
+		agenttools.ToolPlanRuntimeVerification: true,
+		agenttools.ToolListEvidence:            true,
+		agenttools.ToolVerifyCustody:           true,
+		agenttools.ToolListReconTools:          true,
+		agenttools.ToolStartRecon:              true,
+		agenttools.ToolEvidenceSufficiency:     true,
 	}
-	names := map[string]bool{}
+	actual := make(map[string]bool, len(tools))
 	for _, tt := range tools {
 		m := tt.(map[string]any)
-		names[m["name"].(string)] = true
+		name := m["name"].(string)
+		if actual[name] {
+			t.Errorf("duplicate tool name: %s", name)
+			continue
+		}
+		actual[name] = true
 	}
-	if !names[agenttools.ToolListFindings] || !names[agenttools.ToolGetFindingDetail] || !names[agenttools.ToolListSASTValidation] || !names[agenttools.ToolPlanRuntimeVerification] || !names[agenttools.ToolStartRecon] {
-		t.Errorf("missing expected tools: %v", names)
+	for name := range expected {
+		if !actual[name] {
+			t.Errorf("missing expected tool: %s", name)
+		}
+	}
+	for name := range actual {
+		if !expected[name] {
+			t.Errorf("unexpected tool: %s", name)
+		}
 	}
 }
 

--- a/internal/infrastructure/rulecatalog/default_test.go
+++ b/internal/infrastructure/rulecatalog/default_test.go
@@ -64,11 +64,6 @@ func TestDefault_GoldenInventory(t *testing.T) {
 		prev = line
 		expectedKeys[line] = true
 	}
-
-	if len(expectedKeys) != 212 {
-		t.Errorf("Golden file must have exactly 212 rules, found %d", len(expectedKeys))
-	}
-
 	actualRules, err := cat.List(context.Background())
 	if err != nil {
 		t.Fatalf("List() failed: %v", err)

--- a/internal/infrastructure/tools/secretscan/catalog_parity_test.go
+++ b/internal/infrastructure/tools/secretscan/catalog_parity_test.go
@@ -24,16 +24,29 @@ func TestCatalogParity(t *testing.T) {
 		catalogMap[string(r.Key)] = r
 	}
 
-	builtin := defaultRules()
-
-	if len(builtin) != 8 {
-		t.Fatalf("Secret scanner must have exactly 8 rules, found %d", len(builtin))
+	expectedCWE := map[string]string{
+		"aws-access-key-id": "CWE-798",
+		"github-token":      "CWE-798",
+		"gitlab-pat":        "CWE-798",
+		"slack-token":       "CWE-798",
+		"google-api-key":    "CWE-798",
+		"private-key":       "CWE-321",
+		"jwt":               "CWE-798",
+		"generic-secret":    "CWE-798",
 	}
-
-	seenInBuiltin := make(map[string]bool)
+	builtin := defaultRules()
+	seenInBuiltin := make(map[string]bool, len(builtin))
 
 	for _, tc := range builtin {
+		if seenInBuiltin[tc.id] {
+			t.Errorf("Duplicate secret scanner rule: %s", tc.id)
+			continue
+		}
 		seenInBuiltin[tc.id] = true
+		if _, ok := expectedCWE[tc.id]; !ok {
+			t.Errorf("Unexpected secret scanner rule: %s", tc.id)
+			continue
+		}
 		catRule, ok := catalogMap[tc.id]
 		if !ok {
 			t.Errorf("Rule %s missing from catalog", tc.id)
@@ -62,17 +75,6 @@ func TestCatalogParity(t *testing.T) {
 		}
 
 		// CWE parity
-		expectedCWE := map[string]string{
-			"aws-access-key-id": "CWE-798",
-			"github-token":      "CWE-798",
-			"gitlab-pat":        "CWE-798",
-			"slack-token":       "CWE-798",
-			"google-api-key":    "CWE-798",
-			"private-key":       "CWE-321",
-			"jwt":               "CWE-798",
-			"generic-secret":    "CWE-798",
-		}
-
 		expected := expectedCWE[tc.id]
 		if expected == "" {
 			t.Errorf("Rule %s has no mapped expected CWE", tc.id)
@@ -88,6 +90,12 @@ func TestCatalogParity(t *testing.T) {
 		}
 		if !foundCWE {
 			t.Errorf("Rule %s CWE mismatch: expected %s, got %v", tc.id, expected, catRule.CWE)
+		}
+	}
+
+	for id := range expectedCWE {
+		if !seenInBuiltin[id] {
+			t.Errorf("Expected secret scanner rule missing: %s", id)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Replace brittle hardcoded inventory counts with exact identifier registries in the rule catalog, secret scanner, and MCP tool-list tests.

This removes merge-prone numeric sentinels while strengthening the contracts: tests now detect missing, unexpected, and duplicate identifiers where applicable.

Closes #223.

## Changes

- Removed the redundant rule-catalog golden-file count assertion.
  - Retained existing golden-file structure validation, bidirectional key comparison, and ordering checks.
- Made the secret scanner’s expected key-to-CWE map its single inventory registry.
  - Detects duplicate builtin rule IDs.
  - Detects unexpected builtin rule IDs.
  - Detects expected rules missing from `defaultRules()`.
  - Preserves existing catalog metadata and CWE assertions.
- Replaced the MCP tool count and partial name check with an exact expected base-tool registry.
  - Detects duplicate, missing, and unexpected MCP tool names from the `tools/list` RPC response.
- Kept the change limited to the three affected test files; no production behavior, dependencies, or golden inventory data changed.

## Checklist

- [ ] `make build vet test typecheck` passes
  `make build vet test` passes; `typecheck` has not been run separately.
- [x] `cd web && pnpm build` passes (if the dashboard changed)
  N/A — dashboard was not changed.
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets out of logs, deterministic reports, append-only evidence) – see CONTRIBUTING.md
- [x] Documentation updated if needed
  N/A — test-only refactor with no user-facing or operational documentation impact.