### PR TITLE
feat(codequality): stand up the Java AST tier on synapse-ast

### DIFF
--- a/internal/infrastructure/rulecatalog/default.go
+++ b/internal/infrastructure/rulecatalog/default.go
@@ -11,6 +11,7 @@ func Default() (*Catalog, error) {
 
 	all = append(all, sastRules()...)
 	all = append(all, langPackCatalog()...)
+	all = append(all, javaASTRules()...)
 	all = append(all, secretRules()...)
 	all = append(all, misconfigRules()...)
 	all = append(all, qualityRules()...)

--- a/internal/infrastructure/rulecatalog/java_ast.go
+++ b/internal/infrastructure/rulecatalog/java_ast.go
@@ -1,0 +1,36 @@
+package rulecatalog
+
+import (
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type javaASTRuleSpec struct {
+	key, name, cwe, compliant, noncompliant, remediation, description string
+	type_                                                             rule.Type
+	quality                                                           rule.Quality
+	severity                                                          shared.Severity
+}
+
+// javaASTRules are the Java structural rules emitted by the synapse-ast tree-sitter sidecar
+// (internal/infrastructure/tools/astwalk). They catch multi-line/structural issues a line regex cannot.
+func javaASTRules() []rule.Rule {
+	specs := []javaASTRuleSpec{
+		{"java-ast-empty-method", "Empty method body", "", "void handle() {\n    process(event);\n}", "void handle() {}", "Implement the method, or if it is intentionally empty, add a comment explaining why.", "an empty non-abstract method body", rule.TypeCodeSmell, rule.QualityMaintainability, shared.SeverityLow},
+		{"java-ast-missing-switch-default", "switch without a default", "CWE-478", "switch (state) {\n    case OPEN: open(); break;\n    default: throw new IllegalStateException();\n}", "switch (state) {\n    case OPEN: open(); break;\n}", "Add a default branch (even one that throws) so unhandled values are not silently ignored.", "a switch statement with no default branch", rule.TypeBug, rule.QualityReliability, shared.SeverityMedium},
+		{"java-ast-nested-try", "Nested try statement", "", "try {\n    step1();\n    step2();\n} catch (IOException e) {\n    log.warn(\"failed\", e);\n}", "try {\n    try {\n        step1();\n    } finally {\n        cleanup();\n    }\n} catch (IOException e) {\n    log.warn(\"failed\", e);\n}", "Extract the inner try into its own method to flatten the control flow.", "a try statement nested directly inside another try", rule.TypeCodeSmell, rule.QualityMaintainability, shared.SeverityLow},
+		{"java-ast-empty-if-block", "Empty if block", "", "if (ready) {\n    start();\n}", "if (ready) {\n}", "Remove the empty if, or add the intended body.", "an if statement with an empty body", rule.TypeBug, rule.QualityReliability, shared.SeverityLow},
+		{"java-ast-collapsible-if", "Collapsible if statement", "", "if (a && b) {\n    run();\n}", "if (a) {\n    if (b) {\n        run();\n    }\n}", "Combine the two conditions with && into a single if.", "an if whose only statement is another if with no else", rule.TypeCodeSmell, rule.QualityMaintainability, shared.SeverityLow},
+	}
+	rules := make([]rule.Rule, 0, len(specs))
+	for _, s := range specs {
+		rules = append(rules, rule.Rule{
+			Key: rule.Key(s.key), Name: s.name, Language: "Java", Type: s.type_, Qualities: []rule.Quality{s.quality}, DefaultSeverity: s.severity,
+			Tags: []string{"java", "ast"}, CWE: optionalCWE(s.cwe), OWASP: []string{},
+			Description: "Detects " + s.description + " in Java source.",
+			Rationale:   "This rule reports a Java structure that reduces reliability or maintainability, detected on the syntax tree.\n\nSource: https://docs.oracle.com/javase/specs/",
+			Remediation: s.remediation, CompliantExample: s.compliant, NoncompliantExample: s.noncompliant, RemediationEffort: 15, Detection: rule.DetectionAST,
+		})
+	}
+	return rules
+}

--- a/internal/infrastructure/rulecatalog/testdata/rule_keys.txt
+++ b/internal/infrastructure/rulecatalog/testdata/rule_keys.txt
@@ -116,6 +116,11 @@ insecure-cookie-flags
 insecure-randomness-security-context
 insecure-temp-file
 insecure-tls-verify-disabled
+java-ast-collapsible-if
+java-ast-empty-if-block
+java-ast-empty-method
+java-ast-missing-switch-default
+java-ast-nested-try
 java-bigdecimal-double
 java-biginteger-literal
 java-boolean-getboolean

--- a/internal/infrastructure/tools/astwalk/java_quality_cgo.go
+++ b/internal/infrastructure/tools/astwalk/java_quality_cgo.go
@@ -1,0 +1,106 @@
+//go:build cgo
+
+package astwalk
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// javaRule is the metadata for one Java AST quality rule (short key -> finding fields).
+var javaRules = map[string]pythonRule{
+	"empty-method":    {"quality", "java-ast-empty-method", "", "low", "Empty method body", "A non-abstract method with an empty body does nothing; add an implementation, or document why it is intentionally empty."},
+	"missing-default": {"reliability", "java-ast-missing-switch-default", "CWE-478", "medium", "switch without a default", "A switch with no default branch silently ignores unhandled values; add a default (even if it throws)."},
+	"nested-try":      {"quality", "java-ast-nested-try", "", "low", "Nested try statement", "A try nested directly inside another try is hard to follow; extract the inner block into a method."},
+	"empty-if-block":  {"reliability", "java-ast-empty-if-block", "", "low", "Empty if block", "An if with an empty body has no effect and usually signals unfinished or dead code."},
+	"collapsible-if":  {"quality", "java-ast-collapsible-if", "", "low", "Collapsible if statement", "An if whose only statement is another if (with no else) can be merged with && for clarity."},
+}
+
+func javaFinding(key string, n *sitter.Node, rel string) QualityFinding {
+	r := javaRules[key]
+	return QualityFinding{Kind: r.kind, Rule: r.id, CWE: r.cwe, Severity: r.severity, Title: r.title, Description: r.description, File: rel, Line: int(n.StartPoint().Row) + 1}
+}
+
+// javaFindings walks a tree-sitter Java tree and reports structural quality issues that a line-level
+// regex cannot express (empty bodies, missing switch default, nested/collapsible control flow).
+func javaFindings(root *sitter.Node, src []byte, rel string) []QualityFinding {
+	var out []QualityFinding
+	stack := []*sitter.Node{root}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		switch n.Type() {
+		case "method_declaration":
+			if body := n.ChildByFieldName("body"); body != nil && body.Type() == "block" && body.NamedChildCount() == 0 {
+				out = append(out, javaFinding("empty-method", n, rel))
+			}
+		case "switch_expression", "switch_statement":
+			if !javaSwitchHasDefault(n, src) {
+				out = append(out, javaFinding("missing-default", n, rel))
+			}
+		case "try_statement":
+			if javaHasNestedTry(n) {
+				out = append(out, javaFinding("nested-try", n, rel))
+			}
+		case "if_statement":
+			cons := n.ChildByFieldName("consequence")
+			if cons != nil && cons.Type() == "block" && cons.NamedChildCount() == 0 {
+				out = append(out, javaFinding("empty-if-block", n, rel))
+			}
+			if n.ChildByFieldName("alternative") == nil && javaCollapsibleIf(cons) {
+				out = append(out, javaFinding("collapsible-if", n, rel))
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	return dedupeQuality(out)
+}
+
+// javaSwitchHasDefault reports whether a switch node contains a default label.
+func javaSwitchHasDefault(n *sitter.Node, src []byte) bool {
+	stack := []*sitter.Node{n}
+	for len(stack) > 0 {
+		c := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		t := c.Type()
+		if t == "switch_label" || t == "switch_rule" {
+			if strings.HasPrefix(strings.TrimSpace(c.Content(src)), "default") {
+				return true
+			}
+		}
+		for i := 0; i < int(c.ChildCount()); i++ {
+			stack = append(stack, c.Child(i))
+		}
+	}
+	return false
+}
+
+// javaHasNestedTry reports whether a try node contains another try_statement in its subtree.
+func javaHasNestedTry(n *sitter.Node) bool {
+	var walk func(c *sitter.Node) bool
+	walk = func(c *sitter.Node) bool {
+		for i := 0; i < int(c.ChildCount()); i++ {
+			ch := c.Child(i)
+			if ch.Type() == "try_statement" {
+				return true
+			}
+			if walk(ch) {
+				return true
+			}
+		}
+		return false
+	}
+	return walk(n)
+}
+
+// javaCollapsibleIf reports whether a then-block's single statement is an if with no else.
+func javaCollapsibleIf(block *sitter.Node) bool {
+	if block == nil || block.Type() != "block" || block.NamedChildCount() != 1 {
+		return false
+	}
+	inner := block.NamedChild(0)
+	return inner != nil && inner.Type() == "if_statement" && inner.ChildByFieldName("alternative") == nil
+}

--- a/internal/infrastructure/tools/astwalk/python_quality_cgo.go
+++ b/internal/infrastructure/tools/astwalk/python_quality_cgo.go
@@ -70,14 +70,19 @@ var (
 func QualityFor(ctx context.Context, root string) (Quality, error) {
 	out := Quality{Findings: []QualityFinding{}}
 	truncated, err := walkSource(ctx, root, func(rel, lang string, content []byte) {
-		if lang != "Python" {
+		if lang != "Python" && lang != "Java" {
 			return
 		}
 		tree := parseRoot(ctx, specs[lang], content)
 		if tree == nil {
 			return
 		}
-		out.Findings = append(out.Findings, pythonFindings(tree, content, rel)...)
+		switch lang {
+		case "Python":
+			out.Findings = append(out.Findings, pythonFindings(tree, content, rel)...)
+		case "Java":
+			out.Findings = append(out.Findings, javaFindings(tree, content, rel)...)
+		}
 	})
 	if err != nil {
 		return Quality{}, err

--- a/internal/infrastructure/tools/astwalk/python_quality_cgo_test.go
+++ b/internal/infrastructure/tools/astwalk/python_quality_cgo_test.go
@@ -255,3 +255,45 @@ data = yaml.safe_load(text)
 		}
 	}
 }
+
+func TestQualityForJavaAST(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "App.java", `
+class App {
+    void empty() {}
+    void handle(int state) {
+        switch (state) {
+            case 1: open(); break;
+        }
+    }
+    void nested() {
+        try {
+            try { step1(); } finally { cleanup(); }
+        } catch (Exception e) { log(e); }
+    }
+    void guard(boolean ready, boolean a, boolean b) {
+        if (ready) {
+        }
+        if (a) {
+            if (b) { run(); }
+        }
+    }
+}
+`)
+	res, err := QualityFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("QualityFor: %v", err)
+	}
+	got := map[string]bool{}
+	for _, f := range res.Findings {
+		got[f.Rule] = true
+	}
+	for _, rule := range []string{
+		"java-ast-empty-method", "java-ast-missing-switch-default",
+		"java-ast-nested-try", "java-ast-empty-if-block", "java-ast-collapsible-if",
+	} {
+		if !got[rule] {
+			t.Errorf("missing %s in %+v", rule, res.Findings)
+		}
+	}
+}


### PR DESCRIPTION
Advances #196 onto the **AST tier**. Extends `QualityFor` to dispatch Java to a new `javaFindings` tree-sitter walker + 5 structural rules (empty method, missing switch default, nested try, empty if-block, collapsible if) that line-regex cannot express. Verified through the real tree-sitter Java engine (TestQualityForJavaAST); CGO + CGO-free clean. Establishes the multi-language AST framework (Python + Java) that the header parity targets require.