### PR TITLE
feat(codequality): stand up the JavaScript AST tier on synapse-ast

### DIFF
--- a/internal/infrastructure/rulecatalog/default.go
+++ b/internal/infrastructure/rulecatalog/default.go
@@ -12,6 +12,7 @@ func Default() (*Catalog, error) {
 	all = append(all, sastRules()...)
 	all = append(all, langPackCatalog()...)
 	all = append(all, javaASTRules()...)
+	all = append(all, jsASTRules()...)
 	all = append(all, secretRules()...)
 	all = append(all, misconfigRules()...)
 	all = append(all, qualityRules()...)

--- a/internal/infrastructure/rulecatalog/js_ast.go
+++ b/internal/infrastructure/rulecatalog/js_ast.go
@@ -1,0 +1,29 @@
+package rulecatalog
+
+import (
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// jsASTRules are the JavaScript structural rules emitted by the synapse-ast tree-sitter sidecar
+// (internal/infrastructure/tools/astwalk). They catch structural issues a line regex cannot.
+func jsASTRules() []rule.Rule {
+	specs := []javaASTRuleSpec{
+		{"js-ast-empty-function", "Empty function body", "", "function handle(e) {\n    process(e);\n}", "function handle(e) {}", "Implement the function, or document why it is intentionally empty.", "an empty named function body", rule.TypeCodeSmell, rule.QualityMaintainability, shared.SeverityLow},
+		{"js-ast-missing-switch-default", "switch without a default", "CWE-478", "switch (state) {\n    case 1: open(); break;\n    default: fail();\n}", "switch (state) {\n    case 1: open(); break;\n}", "Add a default case so unhandled values are not silently ignored.", "a switch statement with no default case", rule.TypeBug, rule.QualityReliability, shared.SeverityMedium},
+		{"js-ast-too-many-params", "Function has too many parameters", "", "function configure(options) {\n    apply(options);\n}", "function configure(host, port, timeout, tls, user, pass, retries, backoff) {\n    connect(host, port);\n}", "Pass an options object instead of a long parameter list.", "a function declared with more than seven parameters", rule.TypeCodeSmell, rule.QualityMaintainability, shared.SeverityLow},
+		{"js-ast-long-function", "Overly long function", "", "function build() {\n    return assemble(parts);\n}", "function build() {\n    // more than fifty sequential statements\n    return result;\n}", "Split the function into smaller, focused functions.", "a function with an excessive number of statements", rule.TypeCodeSmell, rule.QualityMaintainability, shared.SeverityLow},
+		{"js-ast-large-class", "Class has too many methods", "", "class Small {\n    a() {}\n    b() {}\n}", "class God {\n    // more than twenty methods\n    a() {}\n    b() {}\n}", "Split the class along its distinct responsibilities.", "a class declaring an excessive number of methods", rule.TypeCodeSmell, rule.QualityMaintainability, shared.SeverityLow},
+	}
+	rules := make([]rule.Rule, 0, len(specs))
+	for _, s := range specs {
+		rules = append(rules, rule.Rule{
+			Key: rule.Key(s.key), Name: s.name, Language: "JavaScript/TypeScript", Type: s.type_, Qualities: []rule.Quality{s.quality}, DefaultSeverity: s.severity,
+			Tags: []string{"javascript", "ast"}, CWE: optionalCWE(s.cwe), OWASP: []string{},
+			Description: "Detects " + s.description + " in JavaScript/TypeScript source.",
+			Rationale:   "This rule reports a JavaScript structure that reduces reliability or maintainability, detected on the syntax tree.\n\nSource: https://developer.mozilla.org/en-US/docs/Web/JavaScript",
+			Remediation: s.remediation, CompliantExample: s.compliant, NoncompliantExample: s.noncompliant, RemediationEffort: 15, Detection: rule.DetectionAST,
+		})
+	}
+	return rules
+}

--- a/internal/infrastructure/rulecatalog/testdata/rule_keys.txt
+++ b/internal/infrastructure/rulecatalog/testdata/rule_keys.txt
@@ -193,6 +193,11 @@ java-throw-raw-runtime
 java-toarray-noarg
 jfrog-token
 js-array-sort-no-compare
+js-ast-empty-function
+js-ast-large-class
+js-ast-long-function
+js-ast-missing-switch-default
+js-ast-too-many-params
 js-document-cookie-write
 js-dom-xss-outerhtml
 js-dot-notation

--- a/internal/infrastructure/tools/astwalk/js_quality_cgo.go
+++ b/internal/infrastructure/tools/astwalk/js_quality_cgo.go
@@ -1,0 +1,76 @@
+//go:build cgo
+
+package astwalk
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// jsRules is the metadata for the JavaScript AST quality rules (short key -> finding fields).
+var jsRules = map[string]pythonRule{
+	"empty-function":  {"quality", "js-ast-empty-function", "", "low", "Empty function body", "A named function with an empty body does nothing; implement it or document why it is intentionally empty."},
+	"missing-default": {"reliability", "js-ast-missing-switch-default", "CWE-478", "medium", "switch without a default", "A switch with no default branch silently ignores unhandled values; add a default case."},
+	"too-many-params": {"quality", "js-ast-too-many-params", "", "low", "Function has too many parameters", "A long parameter list is hard to call correctly; pass an options object instead."},
+	"long-function":   {"quality", "js-ast-long-function", "", "low", "Overly long function", "A function with a very large number of statements is hard to understand and test; split it up."},
+	"large-class":     {"quality", "js-ast-large-class", "", "low", "Class has too many methods", "A class with a very large number of methods likely has too many responsibilities; consider splitting it."},
+}
+
+func jsFinding(key string, n *sitter.Node, rel string) QualityFinding {
+	r := jsRules[key]
+	return QualityFinding{Kind: r.kind, Rule: r.id, CWE: r.cwe, Severity: r.severity, Title: r.title, Description: r.description, File: rel, Line: int(n.StartPoint().Row) + 1}
+}
+
+// jsFindings walks a tree-sitter JavaScript tree for structural quality issues (empty bodies, missing
+// switch default, oversized functions/classes) that a line regex cannot express.
+func jsFindings(root *sitter.Node, src []byte, rel string) []QualityFinding {
+	var out []QualityFinding
+	stack := []*sitter.Node{root}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		switch n.Type() {
+		case "function_declaration", "method_definition", "generator_function_declaration", "function_expression":
+			if body := n.ChildByFieldName("body"); body != nil && body.Type() == "statement_block" {
+				if body.NamedChildCount() == 0 {
+					out = append(out, jsFinding("empty-function", n, rel))
+				}
+				if int(body.NamedChildCount()) > 50 {
+					out = append(out, jsFinding("long-function", n, rel))
+				}
+			}
+			if p := n.ChildByFieldName("parameters"); p != nil && int(p.NamedChildCount()) > 7 {
+				out = append(out, jsFinding("too-many-params", n, rel))
+			}
+		case "switch_statement":
+			if body := n.ChildByFieldName("body"); body != nil && !jsSwitchHasDefault(body) {
+				out = append(out, jsFinding("missing-default", n, rel))
+			}
+		case "class_declaration", "class":
+			if body := n.ChildByFieldName("body"); body != nil {
+				methods := 0
+				for i := 0; i < int(body.NamedChildCount()); i++ {
+					if body.NamedChild(i).Type() == "method_definition" {
+						methods++
+					}
+				}
+				if methods > 20 {
+					out = append(out, jsFinding("large-class", n, rel))
+				}
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	return dedupeQuality(out)
+}
+
+// jsSwitchHasDefault reports whether a switch_body contains a default case.
+func jsSwitchHasDefault(body *sitter.Node) bool {
+	for i := 0; i < int(body.NamedChildCount()); i++ {
+		if body.NamedChild(i).Type() == "switch_default" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/tools/astwalk/python_quality_cgo.go
+++ b/internal/infrastructure/tools/astwalk/python_quality_cgo.go
@@ -125,7 +125,7 @@ var (
 func QualityFor(ctx context.Context, root string) (Quality, error) {
 	out := Quality{Findings: []QualityFinding{}}
 	truncated, err := walkSource(ctx, root, func(rel, lang string, content []byte) {
-		if lang != "Python" && lang != "Java" {
+		if lang != "Python" && lang != "Java" && lang != "JavaScript" {
 			return
 		}
 		tree := parseRoot(ctx, specs[lang], content)
@@ -137,6 +137,8 @@ func QualityFor(ctx context.Context, root string) (Quality, error) {
 			out.Findings = append(out.Findings, pythonFindings(tree, content, rel)...)
 		case "Java":
 			out.Findings = append(out.Findings, javaFindings(tree, content, rel)...)
+		case "JavaScript":
+			out.Findings = append(out.Findings, jsFindings(tree, content, rel)...)
 		}
 	})
 	if err != nil {

--- a/internal/infrastructure/tools/astwalk/python_quality_cgo_test.go
+++ b/internal/infrastructure/tools/astwalk/python_quality_cgo_test.go
@@ -425,3 +425,32 @@ func TestQualityForPythonASTStructure(t *testing.T) {
 		}
 	}
 }
+
+func TestQualityForJavaScriptAST(t *testing.T) {
+	root := t.TempDir()
+	var big strings.Builder
+	big.WriteString("class Big {\n")
+	for i := 0; i < 25; i++ {
+		big.WriteString("  m")
+		big.WriteByte(byte('a' + i%26))
+		big.WriteString("() { return 1; }\n")
+	}
+	big.WriteString("}\n")
+	writeFile(t, root, "a.js", "function empty() {}\n"+
+		"function many(a, b, c, d, e, f, g, h) { return a; }\n"+
+		"function pick(s) {\n  switch (s) {\n    case 1: return 1;\n  }\n}\n"+
+		big.String())
+	res, err := QualityFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("QualityFor: %v", err)
+	}
+	got := map[string]bool{}
+	for _, f := range res.Findings {
+		got[f.Rule] = true
+	}
+	for _, rule := range []string{"js-ast-empty-function", "js-ast-too-many-params", "js-ast-missing-switch-default", "js-ast-large-class"} {
+		if !got[rule] {
+			t.Errorf("missing %s in %+v", rule, res.Findings)
+		}
+	}
+}


### PR DESCRIPTION
Advances #188 onto the AST tier, completing the Python+Java+JS trio. New `jsFindings` tree-sitter walker + 5 structural rules (empty function, missing switch default, too many params, long function, large class). Verified through the real tree-sitter JS engine.