### PR TITLE
feat(codequality): add project aggregate and product area

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -107,6 +107,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/llmverifier"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/pyreach"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachability"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachproof"
@@ -158,6 +159,7 @@ func main() {
 
 	// Persistence: PostgreSQL when configured, else file + in-memory (dev).
 	var repo ports.EngagementRepository
+	var projectRepo ports.ProjectRepository
 	var findingRepo ports.FindingRepository
 	var judgmentStore analysisuc.Store // postgres or memory; satisfies both the narrow Store + ports.JudgmentStore
 	var commentRepo ports.CommentRepository
@@ -254,6 +256,7 @@ func main() {
 		defer lockConn.Release()
 		log.Info("acquired single-instance advisory lock")
 		repo = postgres.NewEngagementRepository(pool)
+		projectRepo = postgres.NewProjectRepository(pool)
 		findingRepo = postgres.NewFindingRepository(pool)
 		judgmentStore = postgres.NewJudgmentRepository(pool)
 		commentRepo = postgres.NewCommentRepository(pool)
@@ -287,6 +290,7 @@ func main() {
 		log.Info("persistence: postgres")
 	} else {
 		repo = memory.NewEngagementRepository()
+		projectRepo = memory.NewProjectRepository()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
 		commentRepo = memory.NewCommentRepository()
@@ -326,6 +330,7 @@ func main() {
 
 	// Use cases.
 	engService := enguc.NewService(repo, clock, ids, auditLog)
+	projectService := projectuc.NewService(projectRepo, clock, ids, auditLog)
 	// Evidence artifact blob store: MinIO/S3 when configured, else in-memory (dev).
 	var blobStore ports.BlobStore
 	if cfg.BlobEndpoint != "" {
@@ -832,6 +837,7 @@ func main() {
 		os.Exit(1)
 	}
 	router := httpapi.NewRouter(log, auth, engService, scaService, aupService, findingsService, exportService, reportService, evidenceService, reconService, logBroker, transferService, auditService, vexService, usersService, credentialsService)
+	router.SetProjects(projectService)
 	router.SetExploitation(exploitationService) // evidence-gated finding verify endpoint
 	// Read-only code-quality dashboard. Server-side analysis is PURE-GO and memory-safe only (pattern
 	// rules + duplication + Go-parser inventory); tree-sitter complexity is intentionally NOT wired here

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -23,6 +23,14 @@ interfaces in `internal/usecase/ports`. The domain stays pure, with no framework
 tool types in it. `cmd/*` is the composition root: it wires concrete implementations into the
 interfaces in `main`, and holds no business logic.
 
+## Projects and engagements
+
+A **Project** is a long-lived code-quality identity: it binds source and configuration and will
+own its analysis history. An **Engagement** is a time-bounded security assessment whose scope,
+authorization window, and lifecycle gate all execution. They are independent aggregates; neither
+owns the other. Both may invoke the same analysis pipeline, while future project analyses reference
+their Project instead of duplicating or forking that engine.
+
 ## Binaries
 
 | Binary | Role |

--- a/internal/adapter/httpapi/codequality_handler.go
+++ b/internal/adapter/httpapi/codequality_handler.go
@@ -47,7 +47,7 @@ func (rt *Router) codeQualityReport(w http.ResponseWriter, r *http.Request) {
 	if root == "" {
 		writeJSON(w, http.StatusOK, codeQualityReportView{
 			Available: false,
-			Reason:    "code quality requires an in-scope local source directory; this engagement has none",
+			Reason:    "Code Quality requires an in-scope local source directory; this engagement has none",
 		})
 		return
 	}

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	projectdom "github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/threatmodel"
@@ -18,6 +19,7 @@ import (
 	dastverifieruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastverifier"
 	dastworkflowuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastworkflow"
 	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
 	usersuc "github.com/KKloudTarus/synapse-ce/internal/usecase/users"
 )
@@ -111,14 +113,23 @@ func TestHostileHarness(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed engagement: %v", err)
 	}
+	projectRepo := memory.NewProjectRepository()
+	projectSvc := projectuc.NewService(projectRepo, fixedClock{}, engIDs{}, &fakeAudit{})
+	if _, err := projectSvc.Create(context.Background(), projectuc.CreateInput{
+		TenantID: "tenantA", CreatedBy: "p", Name: "Project A", Key: "project-a",
+		SourceBinding: projectdom.SourceBinding{Kind: projectdom.SourceLocal, Value: "/repo"},
+	}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
 	usersSvc, err := usersuc.NewService(memory.NewUserRepository(), &fakeAudit{}, fixedClock{}, engIDs{})
 	if err != nil {
 		t.Fatalf("users svc: %v", err)
 	}
 	rt := &Router{
-		log:   discardLog(),
-		eng:   enguc.NewService(engRepo, fixedClock{}, engIDs{}, &fakeAudit{}),
-		users: usersSvc,
+		log:      discardLog(),
+		eng:      enguc.NewService(engRepo, fixedClock{}, engIDs{}, &fakeAudit{}),
+		projects: projectSvc,
+		users:    usersSvc,
 	}
 	// Register the two CONDITIONAL sign-off routes so the harness guards their gates too: the
 	// PermReview /verify route (needs a non-nil exploitation verifier) and the agent routes incl.
@@ -159,8 +170,12 @@ func TestHostileHarness(t *testing.T) {
 		// RBAC allow (view): every human role reads.
 		{"readonly may list", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements", http.StatusOK},
 		{"readonly may get own-tenant engagement", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA", http.StatusOK},
+		{"readonly may list projects", "readonly", "tenantA", true, http.MethodGet, "/api/v1/projects", http.StatusOK},
+		{"readonly may get own-tenant project", "readonly", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusOK},
 		// RBAC deny: readonly holds only view.
 		{"readonly may not create (operate)", "readonly", "tenantA", true, http.MethodPost, "/api/v1/engagements", http.StatusForbidden},
+		{"readonly may not create project (operate)", "readonly", "tenantA", true, http.MethodPost, "/api/v1/projects", http.StatusForbidden},
+		{"machine may not list projects", "agent", "tenantA", true, http.MethodGet, "/api/v1/projects", http.StatusForbidden},
 		{"readonly may not author finding (operate)", "readonly", "tenantA", true, http.MethodPost, "/api/v1/engagements/engA/findings", http.StatusForbidden},
 		{"readonly may not triage (triage)", "readonly", "tenantA", true, http.MethodPatch, "/api/v1/engagements/engA/findings/f1", http.StatusForbidden},
 		{"readonly may not run scan (operate)", "readonly", "tenantA", true, http.MethodPost, "/api/v1/sca/scans", http.StatusForbidden},
@@ -178,6 +193,8 @@ func TestHostileHarness(t *testing.T) {
 		{"cross-tenant child resource → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/findings", http.StatusNotFound},
 		// Same-tenant read still works (isolation does not over-block).
 		{"same-tenant engagement read → 200", "consultant", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA", http.StatusOK},
+		{"cross-tenant project read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusNotFound},
+		{"same-tenant project read → 200", "consultant", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusOK},
 		// Sign-off routes (PermReview) – the crown-jewel separation-of-duties gates. A machine role
 		// can never verify a finding nor decide an agent approval; a consultant lacks review; a
 		// reviewer in another tenant is tenant-blocked (404) before the sign-off runs.

--- a/internal/adapter/httpapi/project_handler.go
+++ b/internal/adapter/httpapi/project_handler.go
@@ -1,0 +1,63 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
+)
+
+type projectService interface {
+	Create(context.Context, projectuc.CreateInput) (*project.Project, error)
+	List(context.Context, shared.ID) ([]*project.Project, error)
+	Get(context.Context, shared.ID, string) (*project.Project, error)
+}
+
+func (rt *Router) SetProjects(s projectService) { rt.projects = s }
+
+type createProjectRequest struct {
+	Name                 string                `json:"name"`
+	Key                  string                `json:"key"`
+	SourceBinding        project.SourceBinding `json:"source_binding"`
+	DefaultProfileByLang map[string]string     `json:"default_profile_by_lang"`
+	GateID               string                `json:"gate_id"`
+}
+
+func (rt *Router) createProject(w http.ResponseWriter, r *http.Request) {
+	var req createProjectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	p, err := rt.projects.Create(r.Context(), projectuc.CreateInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), CreatedBy: PrincipalFrom(r.Context()),
+		Name: req.Name, Key: req.Key, SourceBinding: req.SourceBinding,
+		DefaultProfileByLang: req.DefaultProfileByLang, GateID: req.GateID,
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, p)
+}
+
+func (rt *Router) listProjects(w http.ResponseWriter, r *http.Request) {
+	list, err := rt.projects.List(r.Context(), shared.ID(TenantFrom(r.Context())))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, list)
+}
+
+func (rt *Router) getProject(w http.ResponseWriter, r *http.Request) {
+	p, err := rt.projects.Get(r.Context(), shared.ID(TenantFrom(r.Context())), r.PathValue("key"))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, p)
+}

--- a/internal/adapter/httpapi/project_handler_test.go
+++ b/internal/adapter/httpapi/project_handler_test.go
@@ -1,0 +1,49 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
+)
+
+func TestProjectHandlers(t *testing.T) {
+	svc := projectuc.NewService(memory.NewProjectRepository(), fixedClock{t: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}, engIDs{}, &fakeAudit{})
+	rt := &Router{log: discardLog(), projects: svc}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects", strings.NewReader(`{"name":"Synapse","key":"synapse","source_binding":{"Kind":"local","Value":"/repo"}}`))
+	req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "alice", TenantID: "tenant-a"}))
+	rec := httptest.NewRecorder()
+	rt.createProject(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: code=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/projects/synapse", nil)
+	req.SetPathValue("key", "synapse")
+	req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "alice", TenantID: "tenant-a"}))
+	rec = httptest.NewRecorder()
+	rt.getProject(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get: code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil || body["Key"] != "synapse" {
+		t.Fatalf("body=%v err=%v", body, err)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/projects/synapse", nil)
+	req.SetPathValue("key", "synapse")
+	req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "bob", TenantID: "tenant-b"}))
+	rec = httptest.NewRecorder()
+	rt.getProject(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant: got %d, want 404", rec.Code)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -59,6 +59,7 @@ type Router struct {
 	threatModels threatModelService  // optional; nil ⇒ threat-model routes are not registered
 	drafts       writeupDraftService // optional; nil ⇒ writeup-draft sign-off routes are not registered
 	codeQuality  codeQualityService  // optional; nil ⇒ the code-quality route is not registered
+	projects     projectService      // optional; nil ⇒ project routes are not registered
 	rules        rulesService        // optional; nil ⇒ rule catalog routes are not registered
 }
 
@@ -188,6 +189,11 @@ func (rt *Router) routes() *http.ServeMux {
 	// caller then hits the tenant 404. Machine (mcp/agent) roles are granted nothing here.
 	mux.HandleFunc("GET /api/v1/aup", rt.getAUP)
 	mux.HandleFunc("POST /api/v1/aup/accept", rt.acceptAUP)
+	if rt.projects != nil {
+		mux.HandleFunc("POST /api/v1/projects", rt.authz(userdom.PermOperate, rt.createProject))
+		mux.HandleFunc("GET /api/v1/projects", rt.authz(userdom.PermView, rt.listProjects))
+		mux.HandleFunc("GET /api/v1/projects/{key}", rt.authz(userdom.PermView, rt.getProject))
+	}
 	mux.HandleFunc("POST /api/v1/engagements", rt.authz(userdom.PermOperate, rt.createEngagement))
 	mux.HandleFunc("GET /api/v1/engagements", rt.authz(userdom.PermView, rt.listEngagements))
 	mux.HandleFunc("GET /api/v1/engagements/{id}", rt.authz(userdom.PermView, rt.getEngagement))

--- a/internal/domain/project/project.go
+++ b/internal/domain/project/project.go
@@ -1,0 +1,87 @@
+// Package project is the aggregate root for a long-lived code-quality project.
+package project
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	SourceLocal   = "local"
+	SourceGit     = "git"
+	SourceArchive = "archive"
+)
+
+var (
+	keyPattern    = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	gitRefPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
+)
+
+// SourceBinding identifies source that a later analysis run can acquire.
+type SourceBinding struct {
+	Kind  string
+	Value string
+	Ref   string
+}
+
+// Project is a long-lived code-quality identity, independent of an Engagement.
+type Project struct {
+	ID                   shared.ID
+	TenantID             shared.ID
+	Name                 string
+	Key                  string
+	SourceBinding        SourceBinding
+	DefaultProfileByLang map[string]string
+	GateID               string
+	Audit                shared.Audit
+}
+
+// New creates a validated Project.
+func New(id, tenantID shared.ID, name, key string, source SourceBinding, profiles map[string]string, gateID string, now time.Time) (*Project, error) {
+	if id.IsZero() {
+		return nil, fmt.Errorf("%w: project id is required", shared.ErrValidation)
+	}
+	name, key = strings.TrimSpace(name), strings.TrimSpace(key)
+	if name == "" {
+		return nil, fmt.Errorf("%w: project name is required", shared.ErrValidation)
+	}
+	if !keyPattern.MatchString(key) {
+		return nil, fmt.Errorf("%w: project key must be a lowercase hyphenated slug", shared.ErrValidation)
+	}
+	source.Kind, source.Value, source.Ref = strings.TrimSpace(source.Kind), strings.TrimSpace(source.Value), strings.TrimSpace(source.Ref)
+	if source.Value == "" {
+		return nil, fmt.Errorf("%w: project source value is required", shared.ErrValidation)
+	}
+	switch source.Kind {
+	case SourceLocal, SourceArchive:
+		if source.Ref != "" {
+			return nil, fmt.Errorf("%w: source ref is only valid for git", shared.ErrValidation)
+		}
+	case SourceGit:
+		if !strings.HasPrefix(strings.ToLower(source.Value), "https://") {
+			return nil, fmt.Errorf("%w: git source must be https://", shared.ErrValidation)
+		}
+		if len(source.Ref) > 255 || (source.Ref != "" && !gitRefPattern.MatchString(source.Ref)) {
+			return nil, fmt.Errorf("%w: invalid git source ref", shared.ErrValidation)
+		}
+	default:
+		return nil, fmt.Errorf("%w: unknown project source kind %q", shared.ErrValidation, source.Kind)
+	}
+	profileCopy := make(map[string]string, len(profiles))
+	for lang, profile := range profiles {
+		lang, profile = strings.TrimSpace(lang), strings.TrimSpace(profile)
+		if lang == "" || profile == "" {
+			return nil, fmt.Errorf("%w: profile language and key are required", shared.ErrValidation)
+		}
+		profileCopy[lang] = profile
+	}
+	return &Project{
+		ID: id, TenantID: tenantID, Name: name, Key: key, SourceBinding: source,
+		DefaultProfileByLang: profileCopy, GateID: strings.TrimSpace(gateID),
+		Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}, nil
+}

--- a/internal/domain/project/project.go
+++ b/internal/domain/project/project.go
@@ -3,6 +3,8 @@ package project
 
 import (
 	"fmt"
+	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -61,9 +63,14 @@ func New(id, tenantID shared.ID, name, key string, source SourceBinding, profile
 		if source.Ref != "" {
 			return nil, fmt.Errorf("%w: source ref is only valid for git", shared.ErrValidation)
 		}
+		source.Value = filepath.Clean(source.Value)
 	case SourceGit:
-		if !strings.HasPrefix(strings.ToLower(source.Value), "https://") {
-			return nil, fmt.Errorf("%w: git source must be https://", shared.ErrValidation)
+		u, err := url.Parse(source.Value)
+		if err != nil || u.Scheme != "https" || u.Host == "" {
+			return nil, fmt.Errorf("%w: git source must be an https URL with a host", shared.ErrValidation)
+		}
+		if u.User != nil {
+			return nil, fmt.Errorf("%w: git source must not contain embedded credentials", shared.ErrValidation)
 		}
 		if len(source.Ref) > 255 || (source.Ref != "" && !gitRefPattern.MatchString(source.Ref)) {
 			return nil, fmt.Errorf("%w: invalid git source ref", shared.ErrValidation)

--- a/internal/domain/project/project_test.go
+++ b/internal/domain/project/project_test.go
@@ -1,0 +1,52 @@
+package project
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestNew(t *testing.T) {
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	profiles := map[string]string{"go": "default"}
+	p, err := New("p1", "tenant-a", " Synapse ", "synapse-ce", SourceBinding{Kind: SourceGit, Value: "https://example.com/repo.git", Ref: "main"}, profiles, " gate-1 ", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profiles["go"] = "changed"
+	if p.Name != "Synapse" || p.GateID != "gate-1" || p.DefaultProfileByLang["go"] != "default" || p.Audit.CreatedAt != now {
+		t.Fatalf("unexpected project: %+v", p)
+	}
+}
+
+func TestNewRejectsInvalidInput(t *testing.T) {
+	now := time.Now()
+	valid := SourceBinding{Kind: SourceLocal, Value: "/repo"}
+	cases := []struct {
+		name, key string
+		id        shared.ID
+		source    SourceBinding
+	}{
+		{"missing id", "ok", "", valid},
+		{"missing name", "ok", "p1", valid},
+		{"bad key", "Not A Slug", "p1", valid},
+		{"missing source", "ok", "p1", SourceBinding{Kind: SourceLocal}},
+		{"bad kind", "ok", "p1", SourceBinding{Kind: "image", Value: "x"}},
+		{"insecure git", "ok", "p1", SourceBinding{Kind: SourceGit, Value: "http://example.com/repo.git"}},
+		{"bad git ref", "ok", "p1", SourceBinding{Kind: SourceGit, Value: "https://example.com/repo.git", Ref: "--depth=2"}},
+		{"ref on local", "ok", "p1", SourceBinding{Kind: SourceLocal, Value: "/repo", Ref: "main"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name := "Project"
+			if tc.name == "missing name" {
+				name = ""
+			}
+			if _, err := New(tc.id, "", name, tc.key, tc.source, nil, "", now); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("got %v, want validation error", err)
+			}
+		})
+	}
+}

--- a/internal/domain/project/project_test.go
+++ b/internal/domain/project/project_test.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -21,6 +22,17 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewCleansFilesystemSource(t *testing.T) {
+	want := filepath.Join(string(filepath.Separator), "repo")
+	p, err := New("p1", "tenant-a", "Project", "project", SourceBinding{Kind: SourceLocal, Value: filepath.Join(want, "..", "repo")}, nil, "", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.SourceBinding.Value != want {
+		t.Fatalf("source = %q, want %q", p.SourceBinding.Value, want)
+	}
+}
+
 func TestNewRejectsInvalidInput(t *testing.T) {
 	now := time.Now()
 	valid := SourceBinding{Kind: SourceLocal, Value: "/repo"}
@@ -35,6 +47,8 @@ func TestNewRejectsInvalidInput(t *testing.T) {
 		{"missing source", "ok", "p1", SourceBinding{Kind: SourceLocal}},
 		{"bad kind", "ok", "p1", SourceBinding{Kind: "image", Value: "x"}},
 		{"insecure git", "ok", "p1", SourceBinding{Kind: SourceGit, Value: "http://example.com/repo.git"}},
+		{"git without host", "ok", "p1", SourceBinding{Kind: SourceGit, Value: "https://"}},
+		{"git with credentials", "ok", "p1", SourceBinding{Kind: SourceGit, Value: "https://user:token@example.com/repo.git"}},
 		{"bad git ref", "ok", "p1", SourceBinding{Kind: SourceGit, Value: "https://example.com/repo.git", Ref: "--depth=2"}},
 		{"ref on local", "ok", "p1", SourceBinding{Kind: SourceLocal, Value: "/repo", Ref: "main"}},
 	}

--- a/internal/infrastructure/persistence/memory/project_repo.go
+++ b/internal/infrastructure/persistence/memory/project_repo.go
@@ -1,0 +1,102 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ProjectRepository is a goroutine-safe in-memory project store.
+type ProjectRepository struct {
+	mu   sync.RWMutex
+	data map[string]*project.Project
+}
+
+func NewProjectRepository() *ProjectRepository {
+	return &ProjectRepository{data: make(map[string]*project.Project)}
+}
+
+var _ ports.ProjectRepository = (*ProjectRepository)(nil)
+
+func projectStoreKey(tenantID shared.ID, key string) string { return tenantID.String() + "\x00" + key }
+
+func cloneProject(p *project.Project) *project.Project {
+	cp := *p
+	cp.DefaultProfileByLang = make(map[string]string, len(p.DefaultProfileByLang))
+	for k, v := range p.DefaultProfileByLang {
+		cp.DefaultProfileByLang[k] = v
+	}
+	return &cp
+}
+
+func (r *ProjectRepository) Create(_ context.Context, p *project.Project) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := projectStoreKey(p.TenantID, p.Key)
+	if _, ok := r.data[key]; ok {
+		return fmt.Errorf("project key %q already exists: %w", p.Key, shared.ErrConflict)
+	}
+	r.data[key] = cloneProject(p)
+	return nil
+}
+
+func (r *ProjectRepository) List(_ context.Context, tenantID shared.ID) ([]*project.Project, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*project.Project, 0, len(r.data))
+	for _, p := range r.data {
+		if tenantID.IsZero() || p.TenantID == tenantID {
+			out = append(out, cloneProject(p))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Audit.CreatedAt.Equal(out[j].Audit.CreatedAt) {
+			return out[i].Key < out[j].Key
+		}
+		return out[i].Audit.CreatedAt.After(out[j].Audit.CreatedAt)
+	})
+	return out, nil
+}
+
+func (r *ProjectRepository) GetByKey(_ context.Context, tenantID shared.ID, key string) (*project.Project, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if tenantID.IsZero() {
+		for _, p := range r.data {
+			if p.Key == key {
+				return cloneProject(p), nil
+			}
+		}
+		return nil, shared.ErrNotFound
+	}
+	p, ok := r.data[projectStoreKey(tenantID, key)]
+	if !ok {
+		return nil, shared.ErrNotFound
+	}
+	return cloneProject(p), nil
+}
+
+func (r *ProjectRepository) DeleteByKey(_ context.Context, tenantID shared.ID, key string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if tenantID.IsZero() {
+		for storeKey, p := range r.data {
+			if p.Key == key {
+				delete(r.data, storeKey)
+				return nil
+			}
+		}
+		return shared.ErrNotFound
+	}
+	storeKey := projectStoreKey(tenantID, key)
+	if _, ok := r.data[storeKey]; !ok {
+		return shared.ErrNotFound
+	}
+	delete(r.data, storeKey)
+	return nil
+}

--- a/internal/infrastructure/persistence/memory/project_repo.go
+++ b/internal/infrastructure/persistence/memory/project_repo.go
@@ -63,16 +63,24 @@ func (r *ProjectRepository) List(_ context.Context, tenantID shared.ID) ([]*proj
 	return out, nil
 }
 
+func olderProject(a, b *project.Project) bool {
+	return a.Audit.CreatedAt.Before(b.Audit.CreatedAt) || (a.Audit.CreatedAt.Equal(b.Audit.CreatedAt) && a.ID < b.ID)
+}
+
 func (r *ProjectRepository) GetByKey(_ context.Context, tenantID shared.ID, key string) (*project.Project, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if tenantID.IsZero() {
+		var found *project.Project
 		for _, p := range r.data {
-			if p.Key == key {
-				return cloneProject(p), nil
+			if p.Key == key && (found == nil || olderProject(p, found)) {
+				found = p
 			}
 		}
-		return nil, shared.ErrNotFound
+		if found == nil {
+			return nil, shared.ErrNotFound
+		}
+		return cloneProject(found), nil
 	}
 	p, ok := r.data[projectStoreKey(tenantID, key)]
 	if !ok {
@@ -85,13 +93,18 @@ func (r *ProjectRepository) DeleteByKey(_ context.Context, tenantID shared.ID, k
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if tenantID.IsZero() {
+		var foundKey string
+		var found *project.Project
 		for storeKey, p := range r.data {
-			if p.Key == key {
-				delete(r.data, storeKey)
-				return nil
+			if p.Key == key && (found == nil || olderProject(p, found)) {
+				foundKey, found = storeKey, p
 			}
 		}
-		return shared.ErrNotFound
+		if found == nil {
+			return shared.ErrNotFound
+		}
+		delete(r.data, foundKey)
+		return nil
 	}
 	storeKey := projectStoreKey(tenantID, key)
 	if _, ok := r.data[storeKey]; !ok {

--- a/internal/infrastructure/persistence/memory/project_repo_test.go
+++ b/internal/infrastructure/persistence/memory/project_repo_test.go
@@ -1,0 +1,50 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestProjectRepository(t *testing.T) {
+	ctx := context.Background()
+	r := NewProjectRepository()
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	p, err := project.New("p1", "tenant-a", "Project", "project", project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}, map[string]string{"go": "default"}, "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Create(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Create(ctx, p); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate = %v, want conflict", err)
+	}
+	p.Name = "mutated"
+	got, err := r.GetByKey(ctx, "tenant-a", "project")
+	if err != nil || got.Name != "Project" {
+		t.Fatalf("copy-on-write failed: got=%+v err=%v", got, err)
+	}
+	got.DefaultProfileByLang["go"] = "mutated"
+	got, _ = r.GetByKey(ctx, "tenant-a", "project")
+	if got.DefaultProfileByLang["go"] != "default" {
+		t.Fatal("copy-on-read failed")
+	}
+	if _, err := r.GetByKey(ctx, "tenant-b", "project"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant read = %v, want not found", err)
+	}
+	list, err := r.List(ctx, "tenant-a")
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list=%+v err=%v", list, err)
+	}
+	if err := r.DeleteByKey(ctx, "tenant-a", "project"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.GetByKey(ctx, "tenant-a", "project"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("after delete = %v, want not found", err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/project_repo_test.go
+++ b/internal/infrastructure/persistence/memory/project_repo_test.go
@@ -10,6 +10,40 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
+func TestProjectRepositoryZeroTenantSelectionIsDeterministic(t *testing.T) {
+	ctx := context.Background()
+	r := NewProjectRepository()
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	for _, p := range []*project.Project{
+		mustProject(t, "p2", "tenant-b", now),
+		mustProject(t, "p1", "tenant-a", now),
+	} {
+		if err := r.Create(ctx, p); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := r.GetByKey(ctx, "", "project")
+	if err != nil || got.ID != "p1" {
+		t.Fatalf("zero-tenant get = %+v, %v; want p1", got, err)
+	}
+	if err := r.DeleteByKey(ctx, "", "project"); err != nil {
+		t.Fatal(err)
+	}
+	got, err = r.GetByKey(ctx, "", "project")
+	if err != nil || got.ID != "p2" {
+		t.Fatalf("zero-tenant get after delete = %+v, %v; want p2", got, err)
+	}
+}
+
+func mustProject(t *testing.T, id, tenant string, now time.Time) *project.Project {
+	t.Helper()
+	p, err := project.New(shared.ID(id), shared.ID(tenant), "Project", "project", project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}, nil, "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
 func TestProjectRepository(t *testing.T) {
 	ctx := context.Background()
 	r := NewProjectRepository()

--- a/internal/infrastructure/persistence/postgres/project_repo.go
+++ b/internal/infrastructure/persistence/postgres/project_repo.go
@@ -75,7 +75,7 @@ func (r *ProjectRepository) List(ctx context.Context, tenantID shared.ID) ([]*pr
 func (r *ProjectRepository) GetByKey(ctx context.Context, tenantID shared.ID, key string) (*project.Project, error) {
 	var row pgx.Row
 	if tenantID.IsZero() {
-		row = r.pool.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE key=$1 ORDER BY created_at LIMIT 1`, key)
+		row = r.pool.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE key=$1 ORDER BY created_at, id LIMIT 1`, key)
 	} else {
 		row = r.pool.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
 	}
@@ -95,7 +95,7 @@ func (r *ProjectRepository) DeleteByKey(ctx context.Context, tenantID shared.ID,
 		err error
 	)
 	if tenantID.IsZero() {
-		ct, err = r.pool.Exec(ctx, `DELETE FROM projects WHERE id=(SELECT id FROM projects WHERE key=$1 ORDER BY created_at LIMIT 1)`, key)
+		ct, err = r.pool.Exec(ctx, `DELETE FROM projects WHERE id=(SELECT id FROM projects WHERE key=$1 ORDER BY created_at, id LIMIT 1)`, key)
 	} else {
 		ct, err = r.pool.Exec(ctx, `DELETE FROM projects WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
 	}

--- a/internal/infrastructure/persistence/postgres/project_repo.go
+++ b/internal/infrastructure/persistence/postgres/project_repo.go
@@ -1,0 +1,129 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const projectCols = `id, tenant_id, name, key, source_binding, default_profile_by_lang, gate_id, created_at, updated_at, created_by, updated_by`
+
+type ProjectRepository struct{ pool *pgxpool.Pool }
+
+func NewProjectRepository(pool *pgxpool.Pool) *ProjectRepository {
+	return &ProjectRepository{pool: pool}
+}
+
+var _ ports.ProjectRepository = (*ProjectRepository)(nil)
+
+func (r *ProjectRepository) Create(ctx context.Context, p *project.Project) error {
+	source, err := json.Marshal(p.SourceBinding)
+	if err != nil {
+		return fmt.Errorf("marshal project source: %w", err)
+	}
+	profiles, err := json.Marshal(p.DefaultProfileByLang)
+	if err != nil {
+		return fmt.Errorf("marshal project profiles: %w", err)
+	}
+	_, err = r.pool.Exec(ctx, `INSERT INTO projects (`+projectCols+`) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		p.ID.String(), p.TenantID.String(), p.Name, p.Key, source, profiles, p.GateID,
+		p.Audit.CreatedAt, p.Audit.UpdatedAt, p.Audit.CreatedBy, p.Audit.UpdatedBy)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return fmt.Errorf("project key %q already exists: %w", p.Key, shared.ErrConflict)
+		}
+		return fmt.Errorf("insert project: %w", err)
+	}
+	return nil
+}
+
+func (r *ProjectRepository) List(ctx context.Context, tenantID shared.ID) ([]*project.Project, error) {
+	var (
+		rows pgx.Rows
+		err  error
+	)
+	if tenantID.IsZero() {
+		rows, err = r.pool.Query(ctx, `SELECT `+projectCols+` FROM projects ORDER BY created_at DESC, key`)
+	} else {
+		rows, err = r.pool.Query(ctx, `SELECT `+projectCols+` FROM projects WHERE tenant_id=$1 ORDER BY created_at DESC, key`, tenantID.String())
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+	defer rows.Close()
+	out := make([]*project.Project, 0)
+	for rows.Next() {
+		p, err := scanProject(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan project: %w", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (r *ProjectRepository) GetByKey(ctx context.Context, tenantID shared.ID, key string) (*project.Project, error) {
+	var row pgx.Row
+	if tenantID.IsZero() {
+		row = r.pool.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE key=$1 ORDER BY created_at LIMIT 1`, key)
+	} else {
+		row = r.pool.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
+	}
+	p, err := scanProject(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, shared.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("select project: %w", err)
+	}
+	return p, nil
+}
+
+func (r *ProjectRepository) DeleteByKey(ctx context.Context, tenantID shared.ID, key string) error {
+	var (
+		ct  pgconn.CommandTag
+		err error
+	)
+	if tenantID.IsZero() {
+		ct, err = r.pool.Exec(ctx, `DELETE FROM projects WHERE id=(SELECT id FROM projects WHERE key=$1 ORDER BY created_at LIMIT 1)`, key)
+	} else {
+		ct, err = r.pool.Exec(ctx, `DELETE FROM projects WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
+	}
+	if err != nil {
+		return fmt.Errorf("delete project: %w", err)
+	}
+	if ct.RowsAffected() == 0 {
+		return shared.ErrNotFound
+	}
+	return nil
+}
+
+func scanProject(row rowScanner) (*project.Project, error) {
+	var (
+		p                    project.Project
+		id, tenant           string
+		sourceJSON, profiles []byte
+	)
+	if err := row.Scan(&id, &tenant, &p.Name, &p.Key, &sourceJSON, &profiles, &p.GateID,
+		&p.Audit.CreatedAt, &p.Audit.UpdatedAt, &p.Audit.CreatedBy, &p.Audit.UpdatedBy); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(sourceJSON, &p.SourceBinding); err != nil {
+		return nil, fmt.Errorf("unmarshal project source: %w", err)
+	}
+	if err := json.Unmarshal(profiles, &p.DefaultProfileByLang); err != nil {
+		return nil, fmt.Errorf("unmarshal project profiles: %w", err)
+	}
+	p.ID, p.TenantID = shared.ID(id), shared.ID(tenant)
+	return &p, nil
+}

--- a/internal/infrastructure/persistence/postgres/project_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/project_repo_test.go
@@ -1,0 +1,57 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestProjectRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	tenant := "project-test-tenant"
+	_, _ = pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$1) ON CONFLICT DO NOTHING`, tenant)
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM tenants WHERE id=$1`, tenant) })
+
+	r := NewProjectRepository(pool)
+	p, err := project.New("project-test-id", shared.ID(tenant), "Project", "project-test", project.SourceBinding{Kind: project.SourceGit, Value: "https://example.com/repo.git", Ref: "main"}, map[string]string{"go": "default"}, "gate", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Create(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Create(ctx, p); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate=%v, want conflict", err)
+	}
+	got, err := r.GetByKey(ctx, shared.ID(tenant), p.Key)
+	if err != nil || got.SourceBinding.Ref != "main" || got.DefaultProfileByLang["go"] != "default" {
+		t.Fatalf("round trip: got=%+v err=%v", got, err)
+	}
+	if _, err := r.GetByKey(ctx, "another-tenant", p.Key); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant=%v, want not found", err)
+	}
+	list, err := r.List(ctx, shared.ID(tenant))
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list=%+v err=%v", list, err)
+	}
+	if err := r.DeleteByKey(ctx, shared.ID(tenant), p.Key); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -16,6 +16,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/importedsbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -37,6 +38,13 @@ type IDGenerator interface {
 
 // EngagementRepository persists engagements. Returned aggregates are read-only –
 // callers must not mutate them (implementations may return shared instances).
+type ProjectRepository interface {
+	Create(ctx context.Context, p *project.Project) error
+	List(ctx context.Context, tenantID shared.ID) ([]*project.Project, error)
+	GetByKey(ctx context.Context, tenantID shared.ID, key string) (*project.Project, error)
+	DeleteByKey(ctx context.Context, tenantID shared.ID, key string) error
+}
+
 type EngagementRepository interface {
 	Create(ctx context.Context, e *engagement.Engagement) error
 	// GetByID loads an engagement by id WITHOUT a tenant predicate. It is reserved for INTERNAL

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -36,8 +36,7 @@ type IDGenerator interface {
 	NewID() shared.ID
 }
 
-// EngagementRepository persists engagements. Returned aggregates are read-only –
-// callers must not mutate them (implementations may return shared instances).
+// ProjectRepository persists tenant-scoped Project aggregates.
 type ProjectRepository interface {
 	Create(ctx context.Context, p *project.Project) error
 	List(ctx context.Context, tenantID shared.ID) ([]*project.Project, error)
@@ -45,6 +44,8 @@ type ProjectRepository interface {
 	DeleteByKey(ctx context.Context, tenantID shared.ID, key string) error
 }
 
+// EngagementRepository persists engagements. Returned aggregates are read-only –
+// callers must not mutate them (implementations may return shared instances).
 type EngagementRepository interface {
 	Create(ctx context.Context, e *engagement.Engagement) error
 	// GetByID loads an engagement by id WITHOUT a tenant predicate. It is reserved for INTERNAL

--- a/internal/usecase/projectuc/service.go
+++ b/internal/usecase/projectuc/service.go
@@ -1,0 +1,84 @@
+// Package projectuc implements project application logic.
+package projectuc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type Service struct {
+	repo  ports.ProjectRepository
+	clock ports.Clock
+	ids   ports.IDGenerator
+	audit ports.AuditLogger
+}
+
+func NewService(repo ports.ProjectRepository, clock ports.Clock, ids ports.IDGenerator, audit ports.AuditLogger) *Service {
+	return &Service{repo: repo, clock: clock, ids: ids, audit: audit}
+}
+
+type CreateInput struct {
+	TenantID             shared.ID
+	CreatedBy            string
+	Name                 string
+	Key                  string
+	SourceBinding        project.SourceBinding
+	DefaultProfileByLang map[string]string
+	GateID               string
+}
+
+func (s *Service) Create(ctx context.Context, in CreateInput) (*project.Project, error) {
+	if err := requireActor(in.CreatedBy); err != nil {
+		return nil, err
+	}
+	now := s.clock.Now()
+	p, err := project.New(s.ids.NewID(), in.TenantID, in.Name, in.Key, in.SourceBinding, in.DefaultProfileByLang, in.GateID, now)
+	if err != nil {
+		return nil, err
+	}
+	p.Audit.CreatedBy, p.Audit.UpdatedBy = in.CreatedBy, in.CreatedBy
+	if err := s.repo.Create(ctx, p); err != nil {
+		return nil, fmt.Errorf("persist project: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: in.CreatedBy, Action: "project.create", Target: p.ID.String(), Metadata: map[string]string{"project": p.Key}, At: now}); err != nil {
+		return nil, fmt.Errorf("audit project.create: %w", err)
+	}
+	return p, nil
+}
+
+func (s *Service) List(ctx context.Context, tenantID shared.ID) ([]*project.Project, error) {
+	return s.repo.List(ctx, tenantID)
+}
+
+func (s *Service) Get(ctx context.Context, tenantID shared.ID, key string) (*project.Project, error) {
+	return s.repo.GetByKey(ctx, tenantID, strings.TrimSpace(key))
+}
+
+func (s *Service) Delete(ctx context.Context, actor string, tenantID shared.ID, key string) error {
+	if err := requireActor(actor); err != nil {
+		return err
+	}
+	p, err := s.repo.GetByKey(ctx, tenantID, strings.TrimSpace(key))
+	if err != nil {
+		return err
+	}
+	if err := s.repo.DeleteByKey(ctx, tenantID, p.Key); err != nil {
+		return fmt.Errorf("delete project: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: "project.delete", Target: p.ID.String(), Metadata: map[string]string{"project": p.Key}, At: s.clock.Now()}); err != nil {
+		return fmt.Errorf("audit project.delete: %w", err)
+	}
+	return nil
+}
+
+func requireActor(actor string) error {
+	if strings.TrimSpace(actor) == "" {
+		return fmt.Errorf("%w: actor is required", shared.ErrValidation)
+	}
+	return nil
+}

--- a/internal/usecase/projectuc/service.go
+++ b/internal/usecase/projectuc/service.go
@@ -52,11 +52,19 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*project.Project,
 }
 
 func (s *Service) List(ctx context.Context, tenantID shared.ID) ([]*project.Project, error) {
-	return s.repo.List(ctx, tenantID)
+	list, err := s.repo.List(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+	return list, nil
 }
 
 func (s *Service) Get(ctx context.Context, tenantID shared.ID, key string) (*project.Project, error) {
-	return s.repo.GetByKey(ctx, tenantID, strings.TrimSpace(key))
+	p, err := s.repo.GetByKey(ctx, tenantID, strings.TrimSpace(key))
+	if err != nil {
+		return nil, fmt.Errorf("get project: %w", err)
+	}
+	return p, nil
 }
 
 func (s *Service) Delete(ctx context.Context, actor string, tenantID shared.ID, key string) error {

--- a/internal/usecase/projectuc/service_test.go
+++ b/internal/usecase/projectuc/service_test.go
@@ -1,0 +1,61 @@
+package projectuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fixedClock struct{ now time.Time }
+
+func (c fixedClock) Now() time.Time { return c.now }
+
+type fixedIDs struct{}
+
+func (fixedIDs) NewID() shared.ID { return "p1" }
+
+type captureAudit struct{ entries []ports.AuditEntry }
+
+func (a *captureAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.entries = append(a.entries, e)
+	return nil
+}
+
+func TestServiceCRUDAndAudit(t *testing.T) {
+	ctx := context.Background()
+	audit := &captureAudit{}
+	svc := NewService(memory.NewProjectRepository(), fixedClock{time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}, fixedIDs{}, audit)
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Audit.CreatedBy != "alice" || len(audit.entries) != 1 || audit.entries[0].Action != "project.create" {
+		t.Fatalf("create audit/owner: p=%+v audit=%+v", p, audit.entries)
+	}
+	if _, err := svc.Get(ctx, "tenant-b", "project"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant=%v, want not found", err)
+	}
+	list, err := svc.List(ctx, "tenant-a")
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list=%+v err=%v", list, err)
+	}
+	if err := svc.Delete(ctx, "alice", "tenant-a", "project"); err != nil {
+		t.Fatal(err)
+	}
+	if len(audit.entries) != 2 || audit.entries[1].Action != "project.delete" {
+		t.Fatalf("delete audit=%+v", audit.entries)
+	}
+}
+
+func TestServiceRequiresActor(t *testing.T) {
+	svc := NewService(memory.NewProjectRepository(), fixedClock{}, fixedIDs{}, &captureAudit{})
+	if _, err := svc.Create(context.Background(), CreateInput{Name: "P", Key: "p", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("got %v, want validation", err)
+	}
+}

--- a/migrations/0045_projects.sql
+++ b/migrations/0045_projects.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+CREATE TABLE projects (
+    id                      TEXT PRIMARY KEY,
+    tenant_id               TEXT NOT NULL REFERENCES tenants(id),
+    name                    TEXT NOT NULL,
+    key                     TEXT NOT NULL,
+    source_binding          JSONB NOT NULL,
+    default_profile_by_lang JSONB NOT NULL DEFAULT '{}',
+    gate_id                 TEXT NOT NULL DEFAULT '',
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by              TEXT NOT NULL DEFAULT '',
+    updated_by              TEXT NOT NULL DEFAULT '',
+    UNIQUE (tenant_id, key)
+);
+CREATE INDEX idx_projects_tenant_created ON projects(tenant_id, created_at DESC);
+
+-- +goose Down
+DROP TABLE projects;

--- a/web/src/App.rules.test.tsx
+++ b/web/src/App.rules.test.tsx
@@ -10,6 +10,8 @@ vi.mock('./lib/api', () => ({
     listRules: vi.fn(),
     getRule: vi.fn(),
     listEngagements: vi.fn(),
+    listProjects: vi.fn(),
+    getProject: vi.fn(),
     getAuditLogs: vi.fn(),
     getTeam: vi.fn(),
   },
@@ -29,6 +31,7 @@ describe('App Routing - Rules', () => {
   beforeEach(() => {
     vi.mocked(api.listRules).mockResolvedValue([])
     vi.mocked(api.listEngagements).mockResolvedValue([])
+    vi.mocked(api.listProjects).mockResolvedValue([])
     vi.mocked(api.getRule).mockResolvedValue({
       key: 'go:sql',
       name: 'SQL Injection',
@@ -95,6 +98,16 @@ describe('App Routing - Rules', () => {
 
     const rulesLink = screen.getByRole('link', { name: /Rules/i })
     expect(rulesLink.className).toMatch(/bg-brand\/10|text-branddim/)
+  })
+
+  it('keeps Code Quality active on project shells', () => {
+    render(
+      <MemoryRouter initialEntries={['/code-quality/projects/synapse']}>
+        <Sidebar />
+      </MemoryRouter>
+    )
+    const link = screen.getByRole('link', { name: /Code Quality/i })
+    expect(link.className).toMatch(/bg-brand\/10|text-branddim/)
   })
 
   it('opens mobile navigation and navigates to Rules', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,8 @@ import { Engagements } from './pages/Engagements'
 import { Team } from './pages/Team'
 import Rules from './pages/Rules'
 import RuleDetail from './pages/RuleDetail'
+import { CodeQualityProject } from './pages/CodeQualityProject'
+import { CodeQualityProjects } from './pages/CodeQualityProjects'
 
 export default function App() {
   return (
@@ -28,6 +30,8 @@ function Gate() {
         <Route index element={<Navigate to="/engagements" replace />} />
         <Route path="engagements" element={<Engagements />} />
         <Route path="engagements/:id" element={<EngagementDetail />} />
+        <Route path="code-quality" element={<CodeQualityProjects />} />
+        <Route path="code-quality/projects/:key" element={<CodeQualityProject />} />
         <Route path="rules" element={<Rules />} />
         <Route path="rules/:key" element={<RuleDetail />} />
         <Route path="audit" element={<Audit />} />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Boxes, FileText, Radar, ScrollText, Settings, Target, Users, X, Library, type LucideIcon } from 'lucide-react'
+import { Boxes, FileText, Gauge, Radar, ScrollText, Settings, Target, Users, X, Library, type LucideIcon } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
 import { cn } from './ui'
@@ -66,6 +66,22 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
         >
           <Library className="size-[18px]" />
           Rules
+        </NavLink>
+
+        <NavLink
+          to="/code-quality"
+          onClick={onNavigate}
+          className={() =>
+            cn(
+              'relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
+              location.pathname.startsWith('/code-quality')
+                ? 'bg-brand/10 font-semibold text-branddim before:absolute before:left-0 before:top-1/2 before:h-5 before:w-[3px] before:-translate-y-1/2 before:rounded-r-full before:bg-brand before:content-[""]'
+                : 'text-mutedfg hover:bg-elevated hover:text-foreground',
+            )
+          }
+        >
+          <Gauge className="size-[18px]" />
+          Code Quality
         </NavLink>
 
         <NavLink

--- a/web/src/components/codequality/CodeQualityReportView.test.tsx
+++ b/web/src/components/codequality/CodeQualityReportView.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CodeQualityReport, Finding } from '../../lib/types'
+import { CodeQualityReportView } from './CodeQualityReportView'
+
+const finding: Finding = {
+  id: 'f1', engagementId: 'e1', title: 'Nested control flow (web/src/App.tsx:42)', description: '', severity: 'medium', cvssVector: '', cwe: '', status: 'open', dedupKey: 'quality:nested', kev: false, riskScore: 0, class: '', scope: '', reachability: '', impact: '', priority: 3, assignee: '', version: 1, kind: 'quality', evidenceScore: 0, proposedBy: '', complianceControls: [],
+}
+
+const report: CodeQualityReport = {
+  inventory: [
+    { language: 'TypeScript', files: 20, codeLines: 1500, commentLines: 80, blankLines: 120, functions: 90, functionsKnown: true },
+    { language: 'Go', files: 40, codeLines: 3200, commentLines: 150, blankLines: 200, functions: 0, functionsKnown: false },
+  ],
+  findings: [finding],
+  duplication: {
+    totalLines: 4700,
+    duplicatedLines: 235,
+    files: 2,
+    blocks: [{ tokens: 85, occurrences: [{ file: 'internal/a.go', startLine: 10, endLine: 20 }, { file: 'internal/b.go', startLine: 30, endLine: 40 }] }],
+  },
+  rating: { security: 'A', reliability: 'C', maintainability: 'D', techDebtMinutes: 135, debtRatioPct: 2.8, linesOfCode: 4700 },
+}
+
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect
+
+beforeEach(() => {
+  Element.prototype.getBoundingClientRect = vi.fn(() => ({ width: 800, height: 600, top: 0, left: 0, bottom: 600, right: 800, x: 0, y: 0, toJSON: () => {} }))
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 600 })
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 600 })
+})
+
+afterEach(() => { Element.prototype.getBoundingClientRect = originalGetBoundingClientRect })
+
+describe('CodeQualityReportView', () => {
+  it('renders ratings, measures, and languages', () => {
+    render(<CodeQualityReportView report={report} empty={<div>Unavailable</div>} />)
+
+    expect(screen.getByLabelText('Security rating A')).toBeInTheDocument()
+    expect(screen.getByLabelText('Reliability rating C')).toBeInTheDocument()
+    expect(screen.getByLabelText('Maintainability rating D')).toBeInTheDocument()
+    expect(screen.getByText('Worst security issue severity')).toBeInTheDocument()
+    expect(screen.getByText('Worst reliability issue severity')).toBeInTheDocument()
+    expect(screen.getByText('2.80% technical-debt ratio')).toBeInTheDocument()
+    expect(screen.getByText('2h 15m')).toBeInTheDocument()
+    expect(screen.getByText('4,700')).toBeInTheDocument()
+    expect(screen.getByText('5.0%')).toBeInTheDocument()
+
+    const languageTable = screen.getAllByRole('table')[0]
+    const cells = within(languageTable).getAllByRole('cell')
+    expect(cells[0]).toHaveTextContent('Go')
+    expect(within(languageTable).getByText('n/a')).toBeInTheDocument()
+    expect(within(languageTable).getByText('TypeScript')).toBeInTheDocument()
+  })
+
+  it('renders duplicate locations and quality findings', () => {
+    render(<CodeQualityReportView report={report} empty={<div>Unavailable</div>} />)
+
+    expect(screen.getByText('85 tokens · 2 locations')).toBeInTheDocument()
+    expect(screen.getByText('internal/a.go')).toBeInTheDocument()
+    expect(screen.getByText('lines 10–20')).toBeInTheDocument()
+    expect(screen.getByText('Nested control flow (web/src/App.tsx:42)')).toBeInTheDocument()
+  })
+
+  it('renders factual empty sections for a completed report', () => {
+    render(<CodeQualityReportView report={{ ...report, inventory: [], findings: [], duplication: { blocks: [], duplicatedLines: 0, totalLines: 0, files: 0 } }} empty={<div>Unavailable</div>} />)
+
+    expect(screen.getByText('No source files detected in this analysis.')).toBeInTheDocument()
+    expect(screen.getByText('No duplicated code blocks were detected.')).toBeInTheDocument()
+    expect(screen.getByText('No code-quality issues were detected in this analysis.')).toBeInTheDocument()
+    expect(screen.queryByText('Unavailable')).not.toBeInTheDocument()
+  })
+
+  it('renders the caller unavailable state when no report exists', () => {
+    render(<CodeQualityReportView report={undefined} empty={<div>Unavailable</div>} />)
+    expect(screen.getByText('Unavailable')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/codequality/CodeQualityReportView.test.tsx
+++ b/web/src/components/codequality/CodeQualityReportView.test.tsx
@@ -53,6 +53,12 @@ describe('CodeQualityReportView', () => {
     expect(within(languageTable).getByText('TypeScript')).toBeInTheDocument()
   })
 
+  it('discloses when duplicated blocks are limited', () => {
+    const blocks = Array.from({ length: 21 }, (_, index) => ({ tokens: index + 1, occurrences: [{ file: `file-${index}.go`, startLine: 1, endLine: 2 }] }))
+    render(<CodeQualityReportView report={{ ...report, duplication: { ...report.duplication, blocks } }} empty={<div>Unavailable</div>} />)
+    expect(screen.getByText('Showing 20 of 21')).toBeInTheDocument()
+  })
+
   it('renders duplicate locations and quality findings', () => {
     render(<CodeQualityReportView report={report} empty={<div>Unavailable</div>} />)
 

--- a/web/src/components/codequality/CodeQualityReportView.tsx
+++ b/web/src/components/codequality/CodeQualityReportView.tsx
@@ -1,0 +1,176 @@
+import { useMemo, type ReactNode } from 'react'
+import { Braces, Copy, FileCode2, Gauge, ShieldCheck, Wrench } from 'lucide-react'
+import type { CodeQualityReport, Finding, Grade, LanguageInventory } from '../../lib/types'
+import { Card, Pill, SevBadge, cn } from '../ui'
+import { VirtualTable, type Column } from '../VirtualTable'
+
+function gradeTone(grade: Grade): string {
+  switch (grade) {
+    case 'A':
+    case 'B':
+      return 'border-low/25 bg-low/10 text-low'
+    case 'C':
+      return 'border-medium/25 bg-medium/10 text-medium'
+    default:
+      return 'border-critical/25 bg-critical/10 text-critical'
+  }
+}
+
+function GradeCard({ label, grade, detail, icon: Icon }: { label: string; grade: Grade; detail: string; icon: typeof Gauge }) {
+  return (
+    <div className="flex min-h-28 items-center gap-4 rounded-lg border border-border bg-bg px-4 py-4">
+      <span
+        className={cn('inline-flex size-14 shrink-0 items-center justify-center rounded-lg border font-mono text-3xl font-semibold tabular-nums', gradeTone(grade))}
+        aria-label={`${label} rating ${grade}`}
+      >
+        {grade}
+      </span>
+      <div className="min-w-0">
+        <div className="mb-1 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-mutedfg">
+          <Icon className="size-4" aria-hidden="true" />
+          {label}
+        </div>
+        <p className="text-sm text-foreground">Grade {grade}</p>
+        <p className="mt-0.5 text-xs text-subtlefg">{detail}</p>
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value, hint, icon: Icon }: { label: string; value: string; hint: string; icon: typeof Gauge }) {
+  return (
+    <div className="bg-card px-5 py-4">
+      <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-mutedfg">
+        <Icon className="size-3.5" aria-hidden="true" />
+        {label}
+      </div>
+      <div className="mt-1 font-mono text-2xl font-semibold tabular-nums text-foreground">{value}</div>
+      <div className="mt-0.5 text-xs text-subtlefg">{hint}</div>
+    </div>
+  )
+}
+
+const findingCols: Column<Finding>[] = [
+  { header: 'Severity', className: 'w-24 shrink-0', cell: (finding) => <SevBadge sev={finding.severity} /> },
+  { header: 'Kind', className: 'w-28 shrink-0', cell: (finding) => <Pill>{finding.kind}</Pill> },
+  { header: 'Issue', className: 'min-w-64 flex-1', cell: (finding) => <span className="text-sm text-foreground">{finding.title}</span> },
+]
+
+const languageCols: Column<LanguageInventory>[] = [
+  { header: 'Language', className: 'min-w-40 flex-1', cell: (language) => <span className="font-medium text-foreground">{language.language}</span> },
+  { header: 'Files', className: 'w-20 shrink-0 text-right', cell: (language) => <span className="font-mono tabular-nums text-mutedfg">{language.files.toLocaleString()}</span> },
+  { header: 'Code', className: 'w-24 shrink-0 text-right', cell: (language) => <span className="font-mono tabular-nums text-foreground">{language.codeLines.toLocaleString()}</span> },
+  { header: 'Comments', className: 'w-24 shrink-0 text-right', cell: (language) => <span className="font-mono tabular-nums text-mutedfg">{language.commentLines.toLocaleString()}</span> },
+  { header: 'Functions', className: 'w-24 shrink-0 text-right', cell: (language) => <span className="font-mono tabular-nums text-mutedfg">{language.functionsKnown ? language.functions.toLocaleString() : 'n/a'}</span> },
+]
+
+export function CodeQualityReportView({ report, empty }: { report?: CodeQualityReport; empty: ReactNode }) {
+  const findings = report?.findings ?? []
+  const kindCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const finding of findings) counts[finding.kind] = (counts[finding.kind] ?? 0) + 1
+    return counts
+  }, [findings])
+
+  if (!report) return <>{empty}</>
+
+  const total = report.inventory.reduce(
+    (acc, language) => ({ files: acc.files + language.files, code: acc.code + language.codeLines }),
+    { files: 0, code: 0 },
+  )
+  const dupDensity = report.duplication.totalLines > 0 ? (100 * report.duplication.duplicatedLines) / report.duplication.totalLines : 0
+  const debtH = Math.floor(report.rating.techDebtMinutes / 60)
+  const debtM = report.rating.techDebtMinutes % 60
+  const languages = [...report.inventory].sort((a, b) => b.codeLines - a.codeLines)
+  const duplicateBlocks = [...report.duplication.blocks].sort((a, b) => b.tokens - a.tokens).slice(0, 20)
+
+  return (
+    <div className="space-y-6">
+      <Card title="Quality ratings">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <GradeCard label="Security" grade={report.rating.security} detail="Worst security issue severity" icon={ShieldCheck} />
+          <GradeCard label="Reliability" grade={report.rating.reliability} detail="Worst reliability issue severity" icon={Gauge} />
+          <GradeCard label="Maintainability" grade={report.rating.maintainability} detail={`${report.rating.debtRatioPct.toFixed(2)}% technical-debt ratio`} icon={Wrench} />
+        </div>
+      </Card>
+
+      <Card
+        title="Measures"
+        actions={
+          <span className="text-xs text-subtlefg" title="Technical debt is estimated from maintainability issue severity: info 5m, low 10m, medium 20m, high 60m, critical 120m. The ratio compares that debt with 30 minutes per line of code.">
+            Estimated remediation effort
+          </span>
+        }
+        bodyClass="p-0"
+      >
+        <div className="grid grid-cols-1 gap-px bg-border sm:grid-cols-2 lg:grid-cols-4">
+          <Metric label="Technical debt" value={`${debtH}h ${debtM}m`} hint={`${report.rating.debtRatioPct.toFixed(2)}% of estimated development cost`} icon={Wrench} />
+          <Metric label="Code lines" value={total.code.toLocaleString()} hint={`${total.files.toLocaleString()} source files`} icon={FileCode2} />
+          <Metric label="Duplication" value={`${dupDensity.toFixed(1)}%`} hint={`${report.duplication.blocks.length.toLocaleString()} duplicate blocks`} icon={Copy} />
+          <Metric label="Issues" value={findings.length.toLocaleString()} hint={`${kindCounts.quality ?? 0} quality · ${kindCounts.reliability ?? 0} reliability`} icon={Gauge} />
+        </div>
+      </Card>
+
+      <Card title="Languages" actions={<Pill>{languages.length.toLocaleString()} detected</Pill>} bodyClass="p-0">
+        {languages.length === 0 ? (
+          <p className="px-6 py-5 text-sm text-mutedfg">No source files detected in this analysis.</p>
+        ) : (
+          <VirtualTable
+            columns={languageCols}
+            items={languages}
+            rowKey={(language) => language.language}
+            rowHeight={44}
+            maxHeightClass="max-h-96"
+            tableMinWidthClass="min-w-[640px]"
+          />
+        )}
+      </Card>
+
+      <Card
+        title="Duplicated blocks"
+        actions={<Pill>{dupDensity.toFixed(1)}% density</Pill>}
+        bodyClass={duplicateBlocks.length === 0 ? undefined : 'p-0'}
+      >
+        {duplicateBlocks.length === 0 ? (
+          <p className="text-sm text-mutedfg">No duplicated code blocks were detected.</p>
+        ) : (
+          <ol className="max-h-[32rem] divide-y divide-border overflow-y-auto overscroll-contain">
+            {duplicateBlocks.map((block, index) => (
+              <li key={index} className="px-5 py-4">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+                  <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+                    <Copy className="size-3.5 text-mutedfg" aria-hidden="true" />
+                    Duplicate group {index + 1}
+                  </span>
+                  <span className="font-mono text-xs tabular-nums text-mutedfg">{block.tokens.toLocaleString()} tokens · {block.occurrences.length.toLocaleString()} locations</span>
+                </div>
+                <div className="mt-2 space-y-1 rounded-md border border-border bg-elevated px-3 py-2 font-mono text-xs text-mutedfg">
+                  {block.occurrences.map((occurrence, occurrenceIndex) => (
+                    <div key={occurrenceIndex} className="flex min-w-0 items-center gap-2">
+                      <Braces className="size-3 shrink-0 text-subtlefg" aria-hidden="true" />
+                      <span className="truncate text-foreground">{occurrence.file}</span>
+                      <span className="ml-auto shrink-0 tabular-nums">lines {occurrence.startLine}–{occurrence.endLine}</span>
+                    </div>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </Card>
+
+      <Card title="Maintainability & reliability issues" actions={<Pill>{findings.length.toLocaleString()} issues</Pill>} bodyClass={findings.length === 0 ? undefined : 'p-0'}>
+        {findings.length === 0 ? (
+          <p className="text-sm text-mutedfg">No code-quality issues were detected in this analysis.</p>
+        ) : (
+          <VirtualTable
+            columns={findingCols}
+            items={findings}
+            rowKey={(finding, index) => finding.id || `${finding.dedupKey}-${index}`}
+            tableMinWidthClass="min-w-[640px]"
+          />
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/web/src/components/codequality/CodeQualityReportView.tsx
+++ b/web/src/components/codequality/CodeQualityReportView.tsx
@@ -128,7 +128,7 @@ export function CodeQualityReportView({ report, empty }: { report?: CodeQualityR
 
       <Card
         title="Duplicated blocks"
-        actions={<Pill>{dupDensity.toFixed(1)}% density</Pill>}
+        actions={<div className="flex items-center gap-2"><Pill>{dupDensity.toFixed(1)}% density</Pill>{report.duplication.blocks.length > duplicateBlocks.length && <span className="text-xs text-subtlefg">Showing {duplicateBlocks.length.toLocaleString()} of {report.duplication.blocks.length.toLocaleString()}</span>}</div>}
         bodyClass={duplicateBlocks.length === 0 ? undefined : 'p-0'}
       >
         {duplicateBlocks.length === 0 ? (

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -167,6 +167,7 @@ export function Field({
 export type SelectOption = { value: string; label: ReactNode }
 
 export function Select({
+  id,
   value,
   onValueChange,
   options,
@@ -175,6 +176,7 @@ export function Select({
   size = 'md',
   className,
 }: {
+  id?: string
   value: string
   onValueChange: (value: string) => void
   options: SelectOption[]
@@ -186,6 +188,7 @@ export function Select({
   return (
     <RSelect.Root value={value} onValueChange={onValueChange} disabled={disabled}>
       <RSelect.Trigger
+        id={id}
         aria-label={ariaLabel}
         className={cn(
           'input-inset group inline-flex items-center justify-between gap-2 rounded-lg border border-border bg-elevated text-foreground transition-colors',

--- a/web/src/lib/api.projects.test.ts
+++ b/web/src/lib/api.projects.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from './api'
+
+describe('Projects API', () => {
+  let fetchSpy: any
+
+  beforeEach(() => { fetchSpy = vi.spyOn(globalThis, 'fetch') })
+
+  it('maps project fields', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 200, json: async () => [{ ID: 'p1', Name: 'Synapse', Key: 'synapse', SourceBinding: { Kind: 'git', Value: 'https://example.com/repo.git', Ref: 'main' }, DefaultProfileByLang: { go: 'default' }, GateID: 'gate', Audit: { CreatedAt: '2026-07-15T00:00:00Z' } }] } as Response)
+    const projects = await api.listProjects()
+    expect(projects[0]).toMatchObject({ id: 'p1', key: 'synapse', gateId: 'gate', sourceBinding: { kind: 'git', ref: 'main' } })
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/projects', expect.any(Object))
+  })
+
+  it('creates with the backend source contract', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 201, json: async () => ({ ID: 'p1', Key: 'synapse', SourceBinding: { Kind: 'local', Value: '/repo' } }) } as Response)
+    await api.createProject({ name: 'Synapse', key: 'synapse', sourceBinding: { kind: 'local', value: '/repo', ref: '' } })
+    const init = fetchSpy.mock.calls[0][1] as RequestInit
+    expect(fetchSpy.mock.calls[0][0]).toBe('/api/v1/projects')
+    expect(JSON.parse(String(init.body))).toEqual({ name: 'Synapse', key: 'synapse', source_binding: { Kind: 'local', Value: '/repo', Ref: '' } })
+  })
+
+  it('encodes project keys', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ Key: 'a b' }) } as Response)
+    await api.getProject('a b')
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/projects/a%20b', expect.any(Object))
+  })
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -10,7 +10,9 @@ import type {
   Component,
   PendingApproval,
   CreateEngagementInput,
+  CreateProjectInput,
   Engagement,
+  Project,
   EvidenceItem,
   EvidenceLedger,
   Finding,
@@ -91,6 +93,22 @@ async function req(path: string, init?: RequestInit): Promise<any> {
 }
 
 // ---- mappers: raw API JSON (mixed casing) → clean types ----
+
+function mapProject(r: any): Project {
+  return {
+    id: r.ID ?? '',
+    name: r.Name ?? '',
+    key: r.Key ?? '',
+    sourceBinding: {
+      kind: r.SourceBinding?.Kind ?? 'local',
+      value: r.SourceBinding?.Value ?? '',
+      ref: r.SourceBinding?.Ref ?? '',
+    },
+    defaultProfileByLang: r.DefaultProfileByLang ?? {},
+    gateId: r.GateID ?? '',
+    createdAt: r.Audit?.CreatedAt ?? null,
+  }
+}
 
 function mapEngagement(r: any): Engagement {
   const targets = (xs: any[]): { kind: string; value: string }[] =>
@@ -688,6 +706,28 @@ export const api = {
   getRule: async (key: string): Promise<RuleDetail> => {
     return mapRuleDetail(await req(`/rules/${encodeURIComponent(key)}`))
   },
+
+  listProjects: async (): Promise<Project[]> =>
+    ((await req('/projects')) ?? []).map(mapProject),
+
+  createProject: async (input: CreateProjectInput): Promise<Project> =>
+    mapProject(
+      await req('/projects', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: input.name,
+          key: input.key,
+          source_binding: {
+            Kind: input.sourceBinding.kind,
+            Value: input.sourceBinding.value,
+            Ref: input.sourceBinding.ref,
+          },
+        }),
+      }),
+    ),
+
+  getProject: async (key: string): Promise<Project> =>
+    mapProject(await req(`/projects/${encodeURIComponent(key)}`)),
 
   // the engagement's code-quality report (inventory + findings + duplication + A-E ratings). Computed
   // over an in-scope local source directory; an engagement without one returns available=false. 404 (the

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -584,6 +584,30 @@ export interface ThreatModel {
 
 // ---- Code quality (Phase 6 dashboard) ----
 
+export type ProjectSourceKind = 'local' | 'git' | 'archive'
+
+export interface ProjectSourceBinding {
+  kind: ProjectSourceKind
+  value: string
+  ref: string
+}
+
+export interface Project {
+  id: string
+  name: string
+  key: string
+  sourceBinding: ProjectSourceBinding
+  defaultProfileByLang: Record<string, string>
+  gateId: string
+  createdAt: string | null
+}
+
+export interface CreateProjectInput {
+  name: string
+  key: string
+  sourceBinding: ProjectSourceBinding
+}
+
 export interface LanguageInventory {
   language: string
   files: number

--- a/web/src/pages/CodeQualityProject.tsx
+++ b/web/src/pages/CodeQualityProject.tsx
@@ -1,0 +1,75 @@
+import { ArrowLeft, FolderGit2, Gauge, GitBranch } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { CodeQualityReportView } from '../components/codequality/CodeQualityReportView'
+import { Card, EmptyState, ErrorState, Pill, Spinner } from '../components/ui'
+import { api } from '../lib/api'
+import type { Project } from '../lib/types'
+
+export function CodeQualityProject() {
+  const { key = '' } = useParams()
+  const [project, setProject] = useState<Project | null | undefined>(undefined)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setProject(undefined)
+    setError(null)
+    api.getProject(key).then(setProject).catch((e) => setError(e instanceof Error ? e.message : 'Failed to load project'))
+  }, [key])
+
+  if (error) return <div className="mx-auto max-w-6xl space-y-3"><ErrorState message={error} /><Link to="/code-quality" className="inline-flex items-center gap-1.5 text-sm text-branddim hover:underline"><ArrowLeft className="size-4" aria-hidden="true" /> All projects</Link></div>
+  if (project === undefined) return <Spinner label="Loading project…" />
+  if (!project) return null
+
+  return (
+    <div className="mx-auto max-w-6xl animate-fade-in">
+      <Link to="/code-quality" className="mb-4 inline-flex items-center gap-1.5 text-sm text-mutedfg transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50">
+        <ArrowLeft className="size-4" aria-hidden="true" /> All projects
+      </Link>
+      <header className="bg-hero mb-6 rounded-xl border border-border p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-branddim">
+              <Gauge className="size-4" aria-hidden="true" />
+              Code Quality project
+            </div>
+            <h1 className="truncate text-3xl font-bold tracking-tight">{project.name}</h1>
+            <p className="mt-1.5 font-mono text-sm text-mutedfg">{project.key}</p>
+          </div>
+          <Pill className="shrink-0 bg-elevated ring-1 ring-inset ring-border"><Gauge className="size-3" aria-hidden="true" /> Not analyzed</Pill>
+        </div>
+        <dl className="mt-5 grid grid-cols-1 gap-4 border-t border-border pt-4 text-sm sm:grid-cols-2">
+          <div className="min-w-0">
+            <dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Source</dt>
+            <dd className="mt-1.5 flex min-w-0 items-center gap-2 text-foreground">
+              <FolderGit2 className="size-4 shrink-0 text-mutedfg" aria-hidden="true" />
+              <span className="capitalize">{project.sourceBinding.kind}</span>
+              <span className="truncate font-mono text-xs leading-5" title={project.sourceBinding.value}>{project.sourceBinding.value}</span>
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Quality gate</dt>
+            <dd className="mt-1.5 leading-5 text-foreground">{project.gateId || 'Default'}</dd>
+          </div>
+          {project.sourceBinding.ref && (
+            <div>
+              <dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Branch or tag</dt>
+              <dd className="mt-1.5 flex items-center gap-2 font-mono text-xs leading-5 text-foreground">
+                <GitBranch className="size-4 shrink-0 text-mutedfg" aria-hidden="true" />
+                {project.sourceBinding.ref}
+              </dd>
+            </div>
+          )}
+        </dl>
+      </header>
+      <CodeQualityReportView
+        report={undefined}
+        empty={
+          <Card title="Analysis">
+            <EmptyState icon={Gauge} title="No analyses yet" hint="This project’s source and quality gate are configured. Source acquisition and analysis execution arrive in the next Code Quality phase." />
+          </Card>
+        }
+      />
+    </div>
+  )
+}

--- a/web/src/pages/CodeQualityProjects.test.tsx
+++ b/web/src/pages/CodeQualityProjects.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { api } from '../lib/api'
+import { CodeQualityProject } from './CodeQualityProject'
+import { CodeQualityProjects } from './CodeQualityProjects'
+
+vi.mock('../lib/api', () => ({ api: { listProjects: vi.fn(), createProject: vi.fn(), getProject: vi.fn() } }))
+
+const project = { id: 'p1', name: 'Synapse', key: 'synapse', sourceBinding: { kind: 'git' as const, value: 'https://example.com/repo.git', ref: 'main' }, defaultProfileByLang: {}, gateId: '', createdAt: null }
+
+function renderList() { return render(<MemoryRouter><CodeQualityProjects /></MemoryRouter>) }
+
+describe('Code Quality projects', () => {
+  beforeEach(() => { vi.resetAllMocks() })
+
+  it('renders loading, empty, and list states', async () => {
+    vi.mocked(api.listProjects).mockReturnValue(new Promise(() => {}))
+    const view = renderList()
+    expect(screen.getByText('Loading projects…')).toBeInTheDocument()
+    view.unmount()
+
+    vi.mocked(api.listProjects).mockResolvedValue([])
+    renderList()
+    expect(await screen.findByText('No code quality projects yet')).toBeInTheDocument()
+  })
+
+  it('retries a failed project list', async () => {
+    vi.mocked(api.listProjects).mockRejectedValueOnce(new Error('Network error')).mockResolvedValue([])
+    renderList()
+    expect(await screen.findByText('Network error')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByText('No code quality projects yet')).toBeInTheDocument()
+  })
+
+  it('renders project ratings as not analyzed', async () => {
+    vi.mocked(api.listProjects).mockResolvedValue([project])
+    renderList()
+    expect(await screen.findByRole('heading', { name: 'Synapse' })).toBeInTheDocument()
+    expect(screen.getByText('Not analyzed')).toBeInTheDocument()
+    expect(screen.getByText('Open project')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Quality ratings unavailable')).not.toBeInTheDocument()
+  })
+
+  it('creates and navigates to the shell', async () => {
+    vi.mocked(api.listProjects).mockResolvedValue([])
+    vi.mocked(api.createProject).mockResolvedValue(project)
+    render(
+      <MemoryRouter initialEntries={['/code-quality']}>
+        <Routes><Route path="/code-quality" element={<CodeQualityProjects />} /><Route path="/code-quality/projects/:key" element={<div>Project shell route</div>} /></Routes>
+      </MemoryRouter>,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: /New project/i }))
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Synapse' } })
+    fireEvent.change(screen.getByLabelText('Source'), { target: { value: 'https://example.com/repo.git' } })
+    fireEvent.click(screen.getByRole('button', { name: /Create project/i }))
+    await waitFor(() => expect(api.createProject).toHaveBeenCalledWith(expect.objectContaining({ key: 'synapse' })))
+    expect(await screen.findByText('Project shell route')).toBeInTheDocument()
+  })
+
+  it('renders an honest project shell empty state', async () => {
+    vi.mocked(api.getProject).mockResolvedValue(project)
+    render(<MemoryRouter initialEntries={['/code-quality/projects/synapse']}><Routes><Route path="/code-quality/projects/:key" element={<CodeQualityProject />} /></Routes></MemoryRouter>)
+    expect(await screen.findByRole('heading', { name: 'Synapse' })).toBeInTheDocument()
+    expect(screen.getByText('No analyses yet')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/CodeQualityProjects.test.tsx
+++ b/web/src/pages/CodeQualityProjects.test.tsx
@@ -51,6 +51,9 @@ describe('Code Quality projects', () => {
       </MemoryRouter>,
     )
     fireEvent.click(await screen.findByRole('button', { name: /New project/i }))
+    const sourceKind = screen.getByRole('combobox', { name: 'Source kind' })
+    expect(sourceKind).toHaveAttribute('id', 'project-source-kind')
+    expect(document.querySelector('label[for="project-source-kind"]')).toHaveTextContent('Source kind')
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Synapse' } })
     fireEvent.change(screen.getByLabelText('Source'), { target: { value: 'https://example.com/repo.git' } })
     fireEvent.click(screen.getByRole('button', { name: /Create project/i }))

--- a/web/src/pages/CodeQualityProjects.tsx
+++ b/web/src/pages/CodeQualityProjects.tsx
@@ -117,7 +117,7 @@ function CreateProjectForm() {
           <Field label="Key" hint="Lowercase letters, numbers, and hyphens" htmlFor="project-key"><Input id="project-key" className="font-mono" value={key} onChange={(e) => { setKeyEdited(true); setKey(e.target.value) }} placeholder="synapse-ce" /></Field>
         </div>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-[10rem_1fr]">
-          <Field label="Source kind"><Select value={kind} onValueChange={(next) => setKind(next as ProjectSourceKind)} ariaLabel="Source kind" className="w-full" options={[{ value: 'git', label: 'Git URL' }, { value: 'local', label: 'Local path' }, { value: 'archive', label: 'Archive path' }]} /></Field>
+          <Field label="Source kind" htmlFor="project-source-kind"><Select id="project-source-kind" value={kind} onValueChange={(next) => setKind(next as ProjectSourceKind)} ariaLabel="Source kind" className="w-full" options={[{ value: 'git', label: 'Git URL' }, { value: 'local', label: 'Local path' }, { value: 'archive', label: 'Archive path' }]} /></Field>
           <Field label="Source" htmlFor="project-source"><Input id="project-source" className="font-mono" value={value} onChange={(e) => setValue(e.target.value)} placeholder={kind === 'git' ? 'https://github.com/acme/app.git' : '/path/to/source'} /></Field>
         </div>
         {kind === 'git' && <Field label="Branch or tag" hint="Optional; uses the default branch when empty" htmlFor="project-ref"><Input id="project-ref" className="font-mono" value={ref} onChange={(e) => setRef(e.target.value)} placeholder="main" /></Field>}

--- a/web/src/pages/CodeQualityProjects.tsx
+++ b/web/src/pages/CodeQualityProjects.tsx
@@ -1,0 +1,129 @@
+import { ArrowRight, FolderGit2, Gauge, GitBranch, Plus, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { api } from '../lib/api'
+import type { Project, ProjectSourceKind } from '../lib/types'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Select, Spinner } from '../components/ui'
+
+export function CodeQualityProjects() {
+  const [projects, setProjects] = useState<Project[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+
+  function load() {
+    setError(null)
+    api.listProjects().then(setProjects).catch((e) => setError(e instanceof Error ? e.message : 'Failed to load projects'))
+  }
+  useEffect(load, [])
+
+  return (
+    <div className="mx-auto max-w-6xl animate-fade-in">
+      <header className="bg-hero mb-6 flex flex-wrap items-center justify-between gap-4 rounded-xl border border-border p-6">
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-branddim">
+            <Gauge className="size-4" aria-hidden="true" />
+            Projects
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight">Code Quality</h1>
+          <p className="mt-1.5 max-w-xl text-sm leading-relaxed text-mutedfg">Long-lived projects keep code health separate from time-bounded pentest engagements.</p>
+        </div>
+        <Button variant="brand" onClick={() => setCreating((value) => !value)}>
+          {creating ? <><X className="size-4" aria-hidden="true" /> Cancel</> : <><Plus className="size-4" aria-hidden="true" /> New project</>}
+        </Button>
+      </header>
+
+      {creating && <div className="mb-6"><CreateProjectForm /></div>}
+      {error && <div className="space-y-3"><ErrorState message={error} /><Button variant="secondary" onClick={load}>Retry</Button></div>}
+      {!projects && !error && <Spinner label="Loading projects…" />}
+      {projects && projects.length === 0 && !creating && (
+        <EmptyState icon={FolderGit2} title="No code quality projects yet" hint="Create a project to define its source. Project analyses arrive in the next Code Quality phase." action={<Button variant="brand" onClick={() => setCreating(true)}><Plus className="size-4" aria-hidden="true" /> New project</Button>} />
+      )}
+      {projects && projects.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {projects.map((project) => <ProjectCard key={project.id} project={project} />)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProjectCard({ project }: { project: Project }) {
+  return (
+    <Link to={`/code-quality/projects/${encodeURIComponent(project.key)}`} className="lift card-sheen elev group flex min-h-64 flex-col rounded-xl border border-border bg-card p-5 transition-colors hover:border-brand/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-subtlefg">Project</p>
+          <h2 className="truncate text-lg font-semibold text-foreground">{project.name}</h2>
+          <p className="mt-1 truncate font-mono text-xs text-subtlefg">{project.key}</p>
+        </div>
+        <Pill className="shrink-0 bg-elevated ring-1 ring-inset ring-border"><Gauge className="size-3" aria-hidden="true" /> Not analyzed</Pill>
+      </div>
+
+      <dl className="mt-6 flex-1 space-y-4 text-sm">
+        <div>
+          <dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Source</dt>
+          <dd className="mt-1 flex min-w-0 items-center gap-2 text-mutedfg">
+            <FolderGit2 className="size-4 shrink-0" aria-hidden="true" />
+            <span className="capitalize">{project.sourceBinding.kind}</span>
+            <span className="truncate font-mono text-xs text-foreground" title={project.sourceBinding.value}>{project.sourceBinding.value}</span>
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Quality gate</dt>
+          <dd className="mt-1 text-foreground">{project.gateId || 'Default'}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-6 flex items-center justify-between gap-4 border-t border-border pt-4">
+        <p className="text-xs leading-relaxed text-mutedfg">Open project</p>
+        <ArrowRight className="size-4 shrink-0 text-subtlefg transition-transform group-hover:translate-x-0.5 group-hover:text-branddim" aria-hidden="true" />
+      </div>
+    </Link>
+  )
+}
+
+function slugify(value: string): string {
+  return value.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
+function CreateProjectForm() {
+  const [name, setName] = useState('')
+  const [key, setKey] = useState('')
+  const [keyEdited, setKeyEdited] = useState(false)
+  const [kind, setKind] = useState<ProjectSourceKind>('git')
+  const [value, setValue] = useState('')
+  const [ref, setRef] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault()
+    if (!name.trim() || !key.trim() || !value.trim()) { setError('Name, key, and source are required.'); return }
+    setSubmitting(true); setError(null)
+    try {
+      const project = await api.createProject({ name: name.trim(), key: key.trim(), sourceBinding: { kind, value: value.trim(), ref: kind === 'git' ? ref.trim() : '' } })
+      navigate(`/code-quality/projects/${encodeURIComponent(project.key)}`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create project')
+    } finally { setSubmitting(false) }
+  }
+
+  return (
+    <Card title={<span className="inline-flex items-center gap-2"><FolderGit2 className="size-4 text-mutedfg" aria-hidden="true" /> New project</span>} className="animate-fade-in">
+      <form onSubmit={submit} className="space-y-5">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Field label="Name" htmlFor="project-name"><Input id="project-name" value={name} onChange={(e) => { setName(e.target.value); if (!keyEdited) setKey(slugify(e.target.value)) }} placeholder="Synapse CE" autoFocus /></Field>
+          <Field label="Key" hint="Lowercase letters, numbers, and hyphens" htmlFor="project-key"><Input id="project-key" className="font-mono" value={key} onChange={(e) => { setKeyEdited(true); setKey(e.target.value) }} placeholder="synapse-ce" /></Field>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-[10rem_1fr]">
+          <Field label="Source kind"><Select value={kind} onValueChange={(next) => setKind(next as ProjectSourceKind)} ariaLabel="Source kind" className="w-full" options={[{ value: 'git', label: 'Git URL' }, { value: 'local', label: 'Local path' }, { value: 'archive', label: 'Archive path' }]} /></Field>
+          <Field label="Source" htmlFor="project-source"><Input id="project-source" className="font-mono" value={value} onChange={(e) => setValue(e.target.value)} placeholder={kind === 'git' ? 'https://github.com/acme/app.git' : '/path/to/source'} /></Field>
+        </div>
+        {kind === 'git' && <Field label="Branch or tag" hint="Optional; uses the default branch when empty" htmlFor="project-ref"><Input id="project-ref" className="font-mono" value={ref} onChange={(e) => setRef(e.target.value)} placeholder="main" /></Field>}
+        {error && <ErrorState message={error} />}
+        <div className="flex justify-end"><Button variant="brand" type="submit" loading={submitting}><GitBranch className="size-4" aria-hidden="true" /> Create project</Button></div>
+      </form>
+    </Card>
+  )
+}

--- a/web/src/pages/CodeQualityTab.test.tsx
+++ b/web/src/pages/CodeQualityTab.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../lib/api'
+import type { CodeQualityReport } from '../lib/types'
+import { CodeQualityTab } from './CodeQualityTab'
+
+vi.mock('../lib/api', () => ({ api: { codeQuality: vi.fn() } }))
+
+const report: CodeQualityReport = {
+  inventory: [],
+  findings: [],
+  duplication: { blocks: [], duplicatedLines: 0, totalLines: 0, files: 0 },
+  rating: { security: 'A', reliability: 'B', maintainability: 'C', techDebtMinutes: 0, debtRatioPct: 0, linesOfCode: 0 },
+}
+
+describe('CodeQualityTab', () => {
+  beforeEach(() => { vi.resetAllMocks() })
+
+  it('renders loading and backend errors', async () => {
+    vi.mocked(api.codeQuality).mockReturnValue(new Promise(() => {}))
+    const view = render(<CodeQualityTab engagementId="e1" />)
+    expect(screen.getByText('Analyzing code quality…')).toBeInTheDocument()
+    view.unmount()
+
+    vi.mocked(api.codeQuality).mockRejectedValue(new Error('Analysis failed'))
+    render(<CodeQualityTab engagementId="e1" />)
+    expect(await screen.findByText('Analysis failed')).toBeInTheDocument()
+  })
+
+  it('explains why Code Quality is unavailable', async () => {
+    vi.mocked(api.codeQuality).mockResolvedValue({ available: false, reason: 'No local source directory.' })
+    render(<CodeQualityTab engagementId="e1" />)
+    expect(await screen.findByText('Code Quality unavailable')).toBeInTheDocument()
+    expect(screen.getByText('No local source directory.')).toBeInTheDocument()
+  })
+
+  it('renders the shared report presentation', async () => {
+    vi.mocked(api.codeQuality).mockResolvedValue({ available: true, report })
+    render(<CodeQualityTab engagementId="e1" />)
+    expect(await screen.findByRole('heading', { name: 'Quality ratings' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Security rating A')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/CodeQualityTab.tsx
+++ b/web/src/pages/CodeQualityTab.tsx
@@ -1,63 +1,13 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Copy, Gauge, ShieldCheck, Wrench } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Gauge } from 'lucide-react'
 import { api } from '../lib/api'
-import type { CodeQualityView, Finding, Grade, LanguageInventory } from '../lib/types'
-import { Card, EmptyState, ErrorState, Pill, SevBadge, Spinner, cn } from '../components/ui'
-import { VirtualTable, type Column } from '../components/VirtualTable'
+import type { CodeQualityView } from '../lib/types'
+import { Card, EmptyState, ErrorState, Spinner } from '../components/ui'
+import { CodeQualityReportView } from '../components/codequality/CodeQualityReportView'
 
-// gradeTone maps an A-E grade to a severity-token color (A/B good, C caution, D/E bad).
-function gradeTone(g: Grade): string {
-  switch (g) {
-    case 'A':
-    case 'B':
-      return 'text-low ring-low/30 bg-low/10'
-    case 'C':
-      return 'text-medium ring-medium/30 bg-medium/10'
-    default: // D, E
-      return 'text-critical ring-critical/30 bg-critical/10'
-  }
-}
-
-function GradeBadge({ label, grade, icon: Icon }: { label: string; grade: Grade; icon: typeof Gauge }) {
-  return (
-    <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-3">
-      <span className={cn('inline-flex size-9 items-center justify-center rounded-md text-lg font-semibold ring-1 tabular-nums', gradeTone(grade))} aria-hidden>
-        {grade}
-      </span>
-      <div className="min-w-0">
-        <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-          <Icon className="size-3.5 text-mutedfg" />
-          {label}
-        </div>
-        <div className="text-xs text-mutedfg">
-          rating <span className="font-medium">{grade}</span>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
-  return (
-    <div className="rounded-lg border border-border bg-card p-3">
-      <div className="text-xs text-mutedfg">{label}</div>
-      <div className="font-mono text-lg tabular-nums text-foreground">{value}</div>
-      {hint && <div className="text-xs text-mutedfg">{hint}</div>}
-    </div>
-  )
-}
-
-const findingCols: Column<Finding>[] = [
-  { header: 'Severity', className: 'w-24', cell: (f) => <SevBadge sev={f.severity} /> },
-  { header: 'Kind', className: 'w-28', cell: (f) => <Pill>{f.kind}</Pill> },
-  { header: 'Issue', className: 'flex-1', cell: (f) => <span className="text-sm text-foreground">{f.title}</span> },
-]
-
-// CodeQualityTab renders the engagement's code-quality dashboard: A-E health ratings + technical debt,
-// the per-language size inventory, the duplication summary, and the maintainability/reliability findings.
-// Read-only; computed server-side over the in-scope local source directory (pure-Go, memory-safe).
+// CodeQualityTab loads the engagement-scoped report; rendering is shared with Project shells.
 export function CodeQualityTab({ engagementId }: { engagementId: string }) {
-  const [view, setView] = useState<CodeQualityView | undefined>(undefined) // undefined = loading
+  const [view, setView] = useState<CodeQualityView | undefined>(undefined)
   const [err, setErr] = useState<string | null>(null)
 
   useEffect(() => {
@@ -69,120 +19,21 @@ export function CodeQualityTab({ engagementId }: { engagementId: string }) {
       .catch((e) => setErr(e instanceof Error ? e.message : 'Failed to load code quality'))
   }, [engagementId])
 
-  const findings = view?.report?.findings ?? []
-  const kindCounts = useMemo(() => {
-    const c: Record<string, number> = {}
-    for (const f of findings) c[f.kind] = (c[f.kind] ?? 0) + 1
-    return c
-  }, [findings])
-
   if (err) return <ErrorState message={err} />
   if (view === undefined) return <Spinner label="Analyzing code quality…" />
-  if (!view.available || !view.report) {
-    return (
-      <EmptyState
-        icon={Gauge}
-        title="Code quality unavailable"
-        hint={view.reason || 'Code quality is computed over an in-scope local source directory; this engagement has none.'}
-      />
-    )
-  }
-
-  const r = view.report
-  const total = r.inventory.reduce(
-    (acc, l) => ({ files: acc.files + l.files, code: acc.code + l.codeLines }),
-    { files: 0, code: 0 },
-  )
-  const dupDensity = r.duplication.totalLines > 0 ? (100 * r.duplication.duplicatedLines) / r.duplication.totalLines : 0
-  const debtH = Math.floor(r.rating.techDebtMinutes / 60)
-  const debtM = r.rating.techDebtMinutes % 60
-  const langs = [...r.inventory].sort((a, b) => b.codeLines - a.codeLines)
 
   return (
-    <div className="space-y-5">
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <GradeBadge label="Security" grade={r.rating.security} icon={ShieldCheck} />
-        <GradeBadge label="Reliability" grade={r.rating.reliability} icon={Gauge} />
-        <GradeBadge label="Maintainability" grade={r.rating.maintainability} icon={Wrench} />
-      </div>
-
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Stat label="Technical debt" value={`${debtH}h ${debtM}m`} hint={`ratio ${r.rating.debtRatioPct.toFixed(1)}%`} />
-        <Stat label="Code lines" value={total.code.toLocaleString()} hint={`${total.files} files`} />
-        <Stat label="Duplication" value={`${dupDensity.toFixed(1)}%`} hint={`${r.duplication.blocks.length} blocks`} />
-        <Stat label="Issues" value={String(findings.length)} hint={`${kindCounts['quality'] ?? 0} quality · ${kindCounts['reliability'] ?? 0} reliability`} />
-      </div>
-
-      <Card title="Languages">
-        {langs.length === 0 ? (
-          <p className="text-sm text-mutedfg">No source files detected.</p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr className="text-left text-xs text-mutedfg">
-                  <th className="py-1 pr-4 font-medium">Language</th>
-                  <th className="py-1 pr-4 text-right font-medium">Files</th>
-                  <th className="py-1 pr-4 text-right font-medium">Code</th>
-                  <th className="py-1 pr-4 text-right font-medium">Comments</th>
-                  <th className="py-1 text-right font-medium">Functions</th>
-                </tr>
-              </thead>
-              <tbody className="font-mono tabular-nums">
-                {langs.map((l: LanguageInventory) => (
-                  <tr key={l.language} className="border-t border-border">
-                    <td className="py-1 pr-4 font-sans text-foreground">{l.language}</td>
-                    <td className="py-1 pr-4 text-right text-mutedfg">{l.files}</td>
-                    <td className="py-1 pr-4 text-right text-foreground">{l.codeLines.toLocaleString()}</td>
-                    <td className="py-1 pr-4 text-right text-mutedfg">{l.commentLines.toLocaleString()}</td>
-                    <td className="py-1 text-right text-mutedfg">{l.functionsKnown ? l.functions : 'n/a'}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </Card>
-
-      {r.duplication.blocks.length > 0 && (
-        <Card title="Duplicated blocks">
-          <p className="mb-2 text-xs text-mutedfg">
-            {dupDensity.toFixed(1)}% of {r.duplication.totalLines.toLocaleString()} code lines
-          </p>
-          <ul className="space-y-2">
-            {[...r.duplication.blocks]
-              .sort((a, b) => b.tokens - a.tokens)
-              .slice(0, 20)
-              .map((b, i) => (
-                <li key={i} className="rounded-md border border-border bg-muted/30 p-2 text-sm">
-                  <div className="flex items-center gap-1.5 text-mutedfg">
-                    <Copy className="size-3.5" />
-                    <span className="font-mono tabular-nums text-foreground">{b.tokens}</span> tokens, {b.occurrences.length} places
-                  </div>
-                  <div className="mt-1 space-y-0.5 font-mono text-xs text-mutedfg">
-                    {b.occurrences.map((o, j) => (
-                      <div key={j}>
-                        {o.file}:{o.startLine}-{o.endLine}
-                      </div>
-                    ))}
-                  </div>
-                </li>
-              ))}
-          </ul>
-        </Card>
-      )}
-
-      <Card title="Maintainability & reliability issues">
-        {findings.length === 0 ? (
-          <p className="text-sm text-mutedfg">No code-quality issues found.</p>
-        ) : (
-          <VirtualTable
-            columns={findingCols}
-            items={findings}
-            rowKey={(f, i) => f.id || `${f.dedupKey}-${i}`}
+    <CodeQualityReportView
+      report={view.report}
+      empty={
+        <Card title="Analysis">
+          <EmptyState
+            icon={Gauge}
+            title="Code Quality unavailable"
+            hint={view.reason || 'Code Quality requires an in-scope local source directory; this engagement has none.'}
           />
-        )}
-      </Card>
-    </div>
+        </Card>
+      }
+    />
   )
 }


### PR DESCRIPTION
## Summary

<img width="1187" height="845" alt="image" src="https://github.com/user-attachments/assets/a2e30c94-8169-4873-b015-2bc3393e1ee4" />
<img width="1176" height="850" alt="image" src="https://github.com/user-attachments/assets/d3bb894c-de11-4309-88c3-929687524e53" />

Closes #175.

Introduce a first-class, long-lived `Project` aggregate and a top-level Code Quality product area, separate from time-bounded pentest engagements.

This change establishes the P1 foundation for project-based code quality:

- users can create, list, and open tenant-scoped Code Quality projects;
- each project stores its source binding, default language profiles, and quality-gate reference;
- project mutations are audited and project routes are protected by the existing authentication/RBAC chokepoint;
- the existing engagement Code Quality tab remains functional;
- engagement and project surfaces share one reusable Code Quality report renderer instead of forking the analysis presentation.

This PR intentionally stops at the project shell boundary defined by #175:

- source acquisition and project analysis execution remain in #176;
- persisted analysis snapshots and activity/history remain in #177;
- real project ratings, overview cards, and gate verdicts remain in #178.

Until those phases land, project cards and project detail pages explicitly show `Not analyzed` / `No analyses yet` rather than fabricating ratings or triggering analysis on page load.

## Changes

### Project domain

- Add the pure `domain/project` aggregate with:
  - project ID and tenant ownership;
  - human-readable name and lowercase slug key;
  - `local`, `git`, and `archive` source bindings;
  - optional Git branch/tag;
  - default quality-profile mapping by language;
  - quality-gate reference;
  - creation/update audit metadata.
- Validate:
  - required IDs, names, keys, and source values;
  - lowercase hyphenated project keys;
  - supported source kinds;
  - Git-only refs;
  - HTTPS Git sources;
  - conservative Git ref syntax and length;
  - non-empty profile language/profile values.
- Defensively copy profile maps to prevent callers from mutating aggregate state after construction.

### Persistence

- Add the tenant-aware `ProjectRepository` port with:
  - create;
  - list by tenant;
  - get by tenant and key;
  - delete by tenant and key.
- Add an in-memory implementation with:
  - tenant-local key uniqueness;
  - deterministic newest-first listing;
  - copy-on-read and copy-on-write behavior;
  - cross-tenant not-found semantics.
- Add a PostgreSQL implementation using `pgx` with:
  - tenant-scoped reads and deletes;
  - JSONB source bindings and language-profile mappings;
  - PostgreSQL unique-violation mapping to `shared.ErrConflict`;
  - deterministic project ordering.
- Add migration `0045_projects.sql` with:
  - tenant foreign key;
  - unique `(tenant_id, key)` constraint;
  - JSONB source/profile columns;
  - quality-gate reference;
  - timestamps and actor metadata;
  - tenant/creation-time index.
- Do not add an analysis table or quality-gate foreign key before those owning aggregates exist.

### Use cases and audit

- Add `projectuc.Service` with create, list, get, and delete operations.
- Require an attributable actor for project mutations.
- Stamp creator/updater metadata during creation.
- Record append-only audit events:
  - `project.create`;
  - `project.delete`.
- Preserve cross-tenant invisibility by returning not-found rather than disclosing project existence.

### HTTP API and RBAC

Add the P1 routes requested by #175:

- `GET /api/v1/projects`
  - requires `PermView`;
  - returns projects visible to the current tenant.
- `POST /api/v1/projects`
  - requires `PermOperate`;
  - derives tenant and actor from the authenticated request context.
- `GET /api/v1/projects/{key}`
  - requires `PermView`;
  - returns cross-tenant requests as not-found.

Wire the service into both in-memory and PostgreSQL composition roots.

A DELETE HTTP route is intentionally not added because #175 only specifies list/create/get routes. The audited delete use case and repository operation are present as part of the aggregate foundation.

### Top-level Code Quality area

- Add a top-level Code Quality sidebar destination.
- Keep the navigation item active across:
  - `/code-quality`;
  - `/code-quality/projects/:key`.
- Add a Projects home with:
  - loading state;
  - retryable error state;
  - empty state;
  - responsive project cards;
  - inline project creation form;
  - editable generated project key;
  - source-kind selection;
  - source path/URL;
  - optional Git branch/tag.
- Navigate directly to the project shell after successful creation.
- Add a project shell showing:
  - project identity;
  - source kind and binding;
  - optional branch/tag;
  - selected/default quality gate;
  - explicit `Not analyzed` status;
  - honest `No analyses yet` explanation.

No project-analysis CTA is added because source acquisition and analysis execution belong to #176.

### Shared Code Quality report UI

- Extract the engagement report presentation from `CodeQualityTab.tsx` into the reusable `CodeQualityReportView`.
- Keep `CodeQualityTab` responsible only for:
  - engagement report loading;
  - loading/error states;
  - unavailable-source explanation.
- Reuse the shared renderer for future project analysis results.
- Align the report presentation with existing Recon and Engagement UI patterns:
  - responsive A–E rating cards;
  - dimension-specific rating explanations;
  - measures in a consistently divided responsive grid;
  - technical-debt estimate and debt-ratio context;
  - virtualized language inventory;
  - scroll-bounded duplicate-block groups;
  - virtualized maintainability/reliability findings;
  - consistent cards, typography, spacing, status pills, focus states, and design tokens.
- Preserve factual empty states for:
  - unavailable analysis;
  - no detected source files;
  - no duplicated blocks;
  - no code-quality findings.

### Project and Engagement boundary

Document the aggregate relationship:

- `Project` is the long-lived identity and configuration owner for Code Quality.
- `Engagement` is a time-bounded authorized security assessment.
- Neither aggregate owns the other.
- Both surfaces reuse the same governed analysis/report engine.
- Future project analyses reference their owning project rather than duplicating the engine.

### Tests

Add or extend coverage for:

- Project constructor validation and defensive copying.
- Memory repository uniqueness, ordering, tenant isolation, deletion, and copy semantics.
- Opt-in PostgreSQL create/get/list/delete, JSONB round-trip, duplicate-key handling, and tenant isolation.
- Project use-case audit attribution and cross-tenant behavior.
- Project HTTP create/get and cross-tenant not-found handling.
- Real-router RBAC behavior for:
  - readonly project listing/get;
  - denied readonly create;
  - denied machine-role access;
  - same-tenant access;
  - cross-tenant access.
- Frontend Project API mapping and request serialization.
- Project loading, retry, empty, list, creation, navigation, and shell states.
- Shared report ratings, measures, language ordering, duplicate locations, findings, and completed-analysis empty sections.
- Engagement Code Quality loading, backend errors, unavailable-source explanations, and shared-renderer output.
- Sidebar active state on nested project routes.

### Scope boundaries

This PR does not implement:

- Git/archive acquisition for project analyses;
- project analysis jobs or progress reporting;
- persisted project analysis snapshots;
- activity/history or new-code comparison;
- real project overview ratings;
- managed quality profiles or quality gates.

Those remain assigned to #176–#178 and subsequent issues.

## Checklist

- [x] `make build vet test typecheck` passes
- [x] `cd web && pnpm build` passes (if the dashboard changed)
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets
      out of logs, deterministic reports, append-only evidence) – see CONTRIBUTING.md
- [x] Documentation updated if needed

### Verification notes

- `go test ./...` — passed.
- `go vet ./...` — passed.
- Frontend TypeScript typecheck — passed.
- Full frontend suite — 104 tests passed.
- Vite production build — passed.
- `git diff --cached --check` — passed.
