### PR TITLE
feat(codequality): ingest project sources for analysis

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -330,7 +330,8 @@ func main() {
 
 	// Use cases.
 	engService := enguc.NewService(repo, clock, ids, auditLog)
-	projectService := projectuc.NewService(projectRepo, clock, ids, auditLog)
+	projectService := projectuc.NewService(projectRepo, repo, clock, ids, auditLog, !cfg.IsProduction())
+	projectService.SetArchiveStore(file.NewProjectArchiveStore(cfg.ProjectUploadDir, cfg.MaxWorkspaceBytes))
 	// Evidence artifact blob store: MinIO/S3 when configured, else in-memory (dev).
 	var blobStore ports.BlobStore
 	if cfg.BlobEndpoint != "" {
@@ -837,16 +838,19 @@ func main() {
 		os.Exit(1)
 	}
 	router := httpapi.NewRouter(log, auth, engService, scaService, aupService, findingsService, exportService, reportService, evidenceService, reconService, logBroker, transferService, auditService, vexService, usersService, credentialsService)
+	projectService.SetScanner(scaService)
 	router.SetProjects(projectService)
 	router.SetExploitation(exploitationService) // evidence-gated finding verify endpoint
 	// Read-only code-quality dashboard. Server-side analysis is PURE-GO and memory-safe only (pattern
 	// rules + duplication + Go-parser inventory); tree-sitter complexity is intentionally NOT wired here
 	// so the server never runs C parsers over untrusted source (that stays a local-CLI capability).
-	router.SetCodeQuality(codequality.New(
+	codeQualityService := codequality.New(
 		codeanalysis.New(),
 		codequality.WithDuplication(duplication.New(0)),
 		codequality.WithInventory(codeinventory.New()),
-	))
+	)
+	router.SetCodeQuality(codeQualityService)
+	scaService.SetCodeQuality(codeQualityService)
 	if ruleCat, rerr := rulecatalog.Default(); rerr != nil {
 		log.Error("rule catalog init failed", "err", rerr)
 		os.Exit(1)

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -23,7 +23,8 @@ RUN CGO_ENABLED=0 go build -trimpath -o /out/synapse-api ./cmd/synapse-api
 # synapse-cli is bundled too so the image doubles as a cross-platform scanner
 # (`docker run … synapse-cli scan /scan`) – the SCA path runs identically on any host
 # that runs Linux containers (Windows/macOS via Docker Desktop, Linux natively).
-RUN CGO_ENABLED=0 go build -trimpath -o /out/synapse-cli ./cmd/synapse-cli
+RUN CGO_ENABLED=0 go build -trimpath -o /out/synapse-cli ./cmd/synapse-cli \
+    && mkdir -p /out/project-uploads
 
 # Pinned SCA tool binaries, shelled out at runtime.
 FROM anchore/syft:v1.45.1 AS syft
@@ -55,6 +56,7 @@ ENV SYNAPSE_SYFT_BIN=/usr/local/bin/syft \
     SYNAPSE_GRYPE_BIN=/usr/local/bin/grype \
     SYNAPSE_MVN_BIN=/usr/bin/mvn \
     SYNAPSE_GRADLE_BIN=/usr/local/bin/gradle \
+    SYNAPSE_PROJECT_UPLOAD_DIR=/home/synapse/project-uploads \
     JAVA_HOME=/opt/java-home
 EXPOSE 8080
 USER synapse:synapse
@@ -71,8 +73,11 @@ COPY --from=build /out/synapse-api /synapse-api
 COPY --from=build /out/synapse-cli /synapse-cli
 COPY --from=syft /syft /usr/local/bin/syft
 COPY --from=grype /grype /usr/local/bin/grype
+COPY --from=build --chown=nonroot:nonroot /out/project-uploads /project-uploads
 ENV SYNAPSE_SYFT_BIN=/usr/local/bin/syft
 ENV SYNAPSE_GRYPE_BIN=/usr/local/bin/grype
+ENV SYNAPSE_PROJECT_UPLOAD_DIR=/project-uploads
+VOLUME ["/project-uploads"]
 EXPOSE 8080
 USER nonroot:nonroot
 # Default to the API server; override for a one-off scan, e.g.:

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -60,6 +60,10 @@ synapse-cli scan alpine:3.19 --image --offline
 The exit code is 0 when no finding meets the `--fail-on` threshold, and non-zero otherwise.
 Wire it straight into a pipeline step.
 
+### Project analysis parity
+
+`synapse-cli scan <local-path>` runs the same governed security scan path used by a Code Quality Project analysis and creates an ephemeral, scope-checked engagement around the target. The CLI does not attach the Project's combined code-quality report, create a Project, retain async job status, or persist the result; use `synapse-cli gate` for local code-quality gating. Git cloning and archive uploads are managed by the server-side Project flow, so clone or extract the source first for a serverless run.
+
 ## False-positive gate
 
 A scan of a real repository surfaces findings in test files and deliberately-insecure fixtures. Synapse

--- a/internal/adapter/httpapi/agent_handler_test.go
+++ b/internal/adapter/httpapi/agent_handler_test.go
@@ -62,6 +62,9 @@ func (f engRepoH) GetByID(context.Context, shared.ID) (*engagement.Engagement, e
 func (f engRepoH) GetByIDInTenant(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
 	return f.eng, nil
 }
+func (engRepoH) GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
 func (engRepoH) List(context.Context, shared.ID) ([]*engagement.Engagement, error) { return nil, nil }
 
 type findReadH struct{}

--- a/internal/adapter/httpapi/engagement_handler_test.go
+++ b/internal/adapter/httpapi/engagement_handler_test.go
@@ -54,6 +54,14 @@ func (r *engRepoFake) GetByIDInTenant(_ context.Context, tenantID, id shared.ID)
 	}
 	return e, nil
 }
+func (r *engRepoFake) GetByProjectID(_ context.Context, tenantID, projectID shared.ID) (*engdom.Engagement, error) {
+	for _, e := range r.data {
+		if e.ProjectID == projectID && (tenantID.IsZero() || e.TenantID == tenantID) {
+			return e, nil
+		}
+	}
+	return nil, shared.ErrNotFound
+}
 func (r *engRepoFake) List(context.Context, shared.ID) ([]*engdom.Engagement, error) { return nil, nil }
 
 type engIDs struct{}

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -114,7 +114,7 @@ func TestHostileHarness(t *testing.T) {
 		t.Fatalf("seed engagement: %v", err)
 	}
 	projectRepo := memory.NewProjectRepository()
-	projectSvc := projectuc.NewService(projectRepo, fixedClock{}, engIDs{}, &fakeAudit{})
+	projectSvc := projectuc.NewService(projectRepo, engRepo, fixedClock{}, engIDs{}, &fakeAudit{}, true)
 	if _, err := projectSvc.Create(context.Background(), projectuc.CreateInput{
 		TenantID: "tenantA", CreatedBy: "p", Name: "Project A", Key: "project-a",
 		SourceBinding: projectdom.SourceBinding{Kind: projectdom.SourceLocal, Value: "/repo"},
@@ -172,9 +172,12 @@ func TestHostileHarness(t *testing.T) {
 		{"readonly may get own-tenant engagement", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA", http.StatusOK},
 		{"readonly may list projects", "readonly", "tenantA", true, http.MethodGet, "/api/v1/projects", http.StatusOK},
 		{"readonly may get own-tenant project", "readonly", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusOK},
+		{"readonly may read project analysis status", "readonly", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a/analysis-status", http.StatusNotFound},
 		// RBAC deny: readonly holds only view.
 		{"readonly may not create (operate)", "readonly", "tenantA", true, http.MethodPost, "/api/v1/engagements", http.StatusForbidden},
 		{"readonly may not create project (operate)", "readonly", "tenantA", true, http.MethodPost, "/api/v1/projects", http.StatusForbidden},
+		{"readonly may not start project analysis", "readonly", "tenantA", true, http.MethodPost, "/api/v1/projects/project-a/analyses", http.StatusForbidden},
+		{"machine may not start project analysis", "agent", "tenantA", true, http.MethodPost, "/api/v1/projects/project-a/analyses", http.StatusForbidden},
 		{"machine may not list projects", "agent", "tenantA", true, http.MethodGet, "/api/v1/projects", http.StatusForbidden},
 		{"readonly may not author finding (operate)", "readonly", "tenantA", true, http.MethodPost, "/api/v1/engagements/engA/findings", http.StatusForbidden},
 		{"readonly may not triage (triage)", "readonly", "tenantA", true, http.MethodPatch, "/api/v1/engagements/engA/findings/f1", http.StatusForbidden},
@@ -194,6 +197,7 @@ func TestHostileHarness(t *testing.T) {
 		// Same-tenant read still works (isolation does not over-block).
 		{"same-tenant engagement read → 200", "consultant", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA", http.StatusOK},
 		{"cross-tenant project read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusNotFound},
+		{"cross-tenant project analysis → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/projects/project-a/analysis", http.StatusNotFound},
 		{"same-tenant project read → 200", "consultant", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusOK},
 		// Sign-off routes (PermReview) – the crown-jewel separation-of-duties gates. A machine role
 		// can never verify a finding nor decide an agent approval; a consultant lacks review; a

--- a/internal/adapter/httpapi/project_handler.go
+++ b/internal/adapter/httpapi/project_handler.go
@@ -1,8 +1,10 @@
 package httpapi
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -138,7 +140,68 @@ func (rt *Router) latestProjectAnalysis(w http.ResponseWriter, r *http.Request) 
 		writeError(w, rt.log, err)
 		return
 	}
+	data, err = redactProjectAnalysisEngagementIDs(data)
+	if err != nil {
+		writeError(w, rt.log, fmt.Errorf("sanitize project analysis: %w", err))
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(data)
+}
+
+func redactProjectAnalysisEngagementIDs(data []byte) ([]byte, error) {
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, fmt.Errorf("analysis result must be an object")
+	}
+	if err := redactFindingEngagementIDs(result, "findings"); err != nil {
+		return nil, err
+	}
+	if raw, ok := result["code_quality"]; ok && !bytes.Equal(raw, []byte("null")) {
+		var report map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &report); err != nil {
+			return nil, fmt.Errorf("decode code_quality: %w", err)
+		}
+		if report == nil {
+			return nil, fmt.Errorf("code_quality must be an object")
+		}
+		if err := redactFindingEngagementIDs(report, "findings"); err != nil {
+			return nil, fmt.Errorf("sanitize code_quality: %w", err)
+		}
+		encoded, err := json.Marshal(report)
+		if err != nil {
+			return nil, fmt.Errorf("encode code_quality: %w", err)
+		}
+		result["code_quality"] = encoded
+	}
+	return json.Marshal(result)
+}
+
+func redactFindingEngagementIDs(object map[string]json.RawMessage, key string) error {
+	raw, ok := object[key]
+	if !ok || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+	var findings []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &findings); err != nil {
+		return fmt.Errorf("decode %s: %w", key, err)
+	}
+	for _, finding := range findings {
+		if finding == nil {
+			return fmt.Errorf("%s contains a non-object finding", key)
+		}
+		delete(finding, "EngagementID")
+		delete(finding, "engagement_id")
+		delete(finding, "engagementId")
+	}
+	encoded, err := json.Marshal(findings)
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", key, err)
+	}
+	object[key] = encoded
+	return nil
 }

--- a/internal/adapter/httpapi/project_handler.go
+++ b/internal/adapter/httpapi/project_handler.go
@@ -3,17 +3,25 @@ package httpapi
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
 )
 
 type projectService interface {
 	Create(context.Context, projectuc.CreateInput) (*project.Project, error)
+	CreateFromArchive(context.Context, projectuc.CreateInput, string, io.Reader) (*project.Project, error)
 	List(context.Context, shared.ID) ([]*project.Project, error)
 	Get(context.Context, shared.ID, string) (*project.Project, error)
+	StartAnalysis(context.Context, string, shared.ID, string) (ports.ScanJob, error)
+	AnalysisStatus(context.Context, shared.ID, string) (ports.ScanJob, error)
+	LatestAnalysis(context.Context, shared.ID, string) ([]byte, error)
 }
 
 func (rt *Router) SetProjects(s projectService) { rt.projects = s }
@@ -27,16 +35,39 @@ type createProjectRequest struct {
 }
 
 func (rt *Router) createProject(w http.ResponseWriter, r *http.Request) {
-	var req createProjectRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
-		return
+	in := projectuc.CreateInput{TenantID: shared.ID(TenantFrom(r.Context())), CreatedBy: PrincipalFrom(r.Context())}
+	var (
+		p   *project.Project
+		err error
+	)
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+		// Keep the archive cap at 512 MiB while allowing multipart headers and fields.
+		r.Body = http.MaxBytesReader(w, r.Body, (512<<20)+(1<<20))
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid or oversized archive upload"})
+			return
+		}
+		if r.MultipartForm != nil {
+			defer r.MultipartForm.RemoveAll()
+		}
+		f, h, ferr := r.FormFile("archive")
+		if ferr != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "archive file is required"})
+			return
+		}
+		defer f.Close()
+		in.Name, in.Key = r.FormValue("name"), r.FormValue("key")
+		p, err = rt.projects.CreateFromArchive(r.Context(), in, h.Filename, f)
+	} else {
+		var req createProjectRequest
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+			return
+		}
+		in.Name, in.Key, in.SourceBinding = req.Name, req.Key, req.SourceBinding
+		in.DefaultProfileByLang, in.GateID = req.DefaultProfileByLang, req.GateID
+		p, err = rt.projects.Create(r.Context(), in)
 	}
-	p, err := rt.projects.Create(r.Context(), projectuc.CreateInput{
-		TenantID: shared.ID(TenantFrom(r.Context())), CreatedBy: PrincipalFrom(r.Context()),
-		Name: req.Name, Key: req.Key, SourceBinding: req.SourceBinding,
-		DefaultProfileByLang: req.DefaultProfileByLang, GateID: req.GateID,
-	})
 	if err != nil {
 		writeError(w, rt.log, err)
 		return
@@ -60,4 +91,54 @@ func (rt *Router) getProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, p)
+}
+
+type projectAnalysisJobResponse struct {
+	ID          string                 `json:"id"`
+	Target      string                 `json:"target"`
+	Kind        string                 `json:"kind"`
+	Status      ports.ScanStatus       `json:"status"`
+	Stage       string                 `json:"stage"`
+	Progress    int                    `json:"progress"`
+	Error       string                 `json:"error,omitempty"`
+	StartedAt   time.Time              `json:"started_at"`
+	FinishedAt  *time.Time             `json:"finished_at,omitempty"`
+	DebugEvents []ports.ScanDebugEvent `json:"debug_events"`
+}
+
+func projectAnalysisJob(job ports.ScanJob) projectAnalysisJobResponse {
+	return projectAnalysisJobResponse{
+		ID: job.ID, Target: job.Target, Kind: job.Kind, Status: job.Status,
+		Stage: job.Stage, Progress: job.Progress, Error: job.Error,
+		StartedAt: job.StartedAt, FinishedAt: job.FinishedAt, DebugEvents: job.DebugEvents,
+	}
+}
+
+func (rt *Router) startProjectAnalysis(w http.ResponseWriter, r *http.Request) {
+	job, err := rt.projects.StartAnalysis(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())), r.PathValue("key"))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, projectAnalysisJob(job))
+}
+
+func (rt *Router) projectAnalysisStatus(w http.ResponseWriter, r *http.Request) {
+	job, err := rt.projects.AnalysisStatus(r.Context(), shared.ID(TenantFrom(r.Context())), r.PathValue("key"))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, projectAnalysisJob(job))
+}
+
+func (rt *Router) latestProjectAnalysis(w http.ResponseWriter, r *http.Request) {
+	data, err := rt.projects.LatestAnalysis(r.Context(), shared.ID(TenantFrom(r.Context())), r.PathValue("key"))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
 }

--- a/internal/adapter/httpapi/project_handler_test.go
+++ b/internal/adapter/httpapi/project_handler_test.go
@@ -9,10 +9,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
 )
+
+type projectAnalysisServiceStub struct {
+	projectService
+	data []byte
+	err  error
+}
+
+func (s projectAnalysisServiceStub) LatestAnalysis(context.Context, shared.ID, string) ([]byte, error) {
+	return s.data, s.err
+}
 
 func TestProjectAnalysisJobHidesInternalEngagement(t *testing.T) {
 	data, err := json.Marshal(projectAnalysisJob(ports.ScanJob{ID: "job-1", EngagementID: "hidden-engagement"}))
@@ -21,6 +32,54 @@ func TestProjectAnalysisJobHidesInternalEngagement(t *testing.T) {
 	}
 	if strings.Contains(string(data), "engagement") {
 		t.Fatalf("Project analysis response leaked hidden engagement: %s", data)
+	}
+}
+
+func TestLatestProjectAnalysisHidesInternalEngagement(t *testing.T) {
+	const topLevelID = "hidden-top-level-engagement"
+	const codeQualityID = "hidden-code-quality-engagement"
+	data := []byte(`{
+		"future_root":"keep-root",
+		"findings":[{"Title":"top-level finding","EngagementID":"hidden-top-level-engagement","future_finding":"keep-top"}],
+		"code_quality":{"future_report":"keep-report","findings":[{"Title":"quality finding","engagement_id":"hidden-code-quality-engagement","future_finding":"keep-quality"}]}
+	}`)
+	rt := &Router{log: discardLog(), projects: projectAnalysisServiceStub{data: data}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/project/analysis", nil)
+	req.SetPathValue("key", "project")
+	req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "alice", TenantID: "tenant-a"}))
+	rec := httptest.NewRecorder()
+
+	rt.latestProjectAnalysis(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, secret := range []string{topLevelID, codeQualityID, "EngagementID", "engagement_id", "engagementId"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("project analysis leaked %q: %s", secret, body)
+		}
+	}
+	for _, kept := range []string{"keep-root", "keep-top", "keep-report", "keep-quality", "top-level finding", "quality finding"} {
+		if !strings.Contains(body, kept) {
+			t.Fatalf("project analysis dropped %q: %s", kept, body)
+		}
+	}
+}
+
+func TestLatestProjectAnalysisRejectsMalformedCache(t *testing.T) {
+	rt := &Router{log: discardLog(), projects: projectAnalysisServiceStub{data: []byte(`{"findings":"not-an-array","secret":"must-not-leak"}`)}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/project/analysis", nil)
+	req.SetPathValue("key", "project")
+	rec := httptest.NewRecorder()
+
+	rt.latestProjectAnalysis(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "must-not-leak") {
+		t.Fatalf("malformed cache leaked payload: %s", rec.Body.String())
 	}
 }
 

--- a/internal/adapter/httpapi/project_handler_test.go
+++ b/internal/adapter/httpapi/project_handler_test.go
@@ -10,11 +10,22 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
 )
 
+func TestProjectAnalysisJobHidesInternalEngagement(t *testing.T) {
+	data, err := json.Marshal(projectAnalysisJob(ports.ScanJob{ID: "job-1", EngagementID: "hidden-engagement"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "engagement") {
+		t.Fatalf("Project analysis response leaked hidden engagement: %s", data)
+	}
+}
+
 func TestProjectHandlers(t *testing.T) {
-	svc := projectuc.NewService(memory.NewProjectRepository(), fixedClock{t: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}, engIDs{}, &fakeAudit{})
+	svc := projectuc.NewService(memory.NewProjectRepository(), memory.NewEngagementRepository(), fixedClock{t: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}, engIDs{}, &fakeAudit{}, true)
 	rt := &Router{log: discardLog(), projects: svc}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects", strings.NewReader(`{"name":"Synapse","key":"synapse","source_binding":{"Kind":"local","Value":"/repo"}}`))

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -193,6 +193,9 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/projects", rt.authz(userdom.PermOperate, rt.createProject))
 		mux.HandleFunc("GET /api/v1/projects", rt.authz(userdom.PermView, rt.listProjects))
 		mux.HandleFunc("GET /api/v1/projects/{key}", rt.authz(userdom.PermView, rt.getProject))
+		mux.HandleFunc("POST /api/v1/projects/{key}/analyses", rt.authz(userdom.PermOperate, rt.startProjectAnalysis))
+		mux.HandleFunc("GET /api/v1/projects/{key}/analysis-status", rt.authz(userdom.PermView, rt.projectAnalysisStatus))
+		mux.HandleFunc("GET /api/v1/projects/{key}/analysis", rt.authz(userdom.PermView, rt.latestProjectAnalysis))
 	}
 	mux.HandleFunc("POST /api/v1/engagements", rt.authz(userdom.PermOperate, rt.createEngagement))
 	mux.HandleFunc("GET /api/v1/engagements", rt.authz(userdom.PermView, rt.listEngagements))

--- a/internal/domain/engagement/engagement.go
+++ b/internal/domain/engagement/engagement.go
@@ -47,12 +47,13 @@ func (s Status) canTransitionTo(to Status) bool {
 
 // Engagement is the aggregate root for a pentest/security assessment.
 type Engagement struct {
-	ID       shared.ID
-	TenantID shared.ID // multi-tenant-ready; zero value = default tenant in single-tenant mode
-	Name     string
-	Client   string
-	Status   Status
-	Scope    Scope
+	ID        shared.ID
+	TenantID  shared.ID // multi-tenant-ready; zero value = default tenant in single-tenant mode
+	ProjectID shared.ID // non-zero for an internal Project analysis context; hidden from engagement lists
+	Name      string
+	Client    string
+	Status    Status
+	Scope     Scope
 	// RoE holds the minimal rules of engagement (allowed tool classes + blackout
 	// windows) the execution gate enforces alongside scope + the auth window.
 	RoE RoE

--- a/internal/infrastructure/persistence/file/project_archive_store.go
+++ b/internal/infrastructure/persistence/file/project_archive_store.go
@@ -1,0 +1,84 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type ProjectArchiveStore struct {
+	dir      string
+	maxBytes int64
+}
+
+func NewProjectArchiveStore(dir string, maxBytes int64) *ProjectArchiveStore {
+	return &ProjectArchiveStore{dir: dir, maxBytes: maxBytes}
+}
+
+var _ ports.ProjectArchiveStore = (*ProjectArchiveStore)(nil)
+
+func archiveExtension(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	for _, ext := range []string{".tar.gz", ".tgz", ".zip"} {
+		if strings.HasSuffix(name, ext) {
+			return ext
+		}
+	}
+	return ""
+}
+
+func (s *ProjectArchiveStore) Save(ctx context.Context, projectID shared.ID, filename string, src io.Reader) (string, error) {
+	ext := archiveExtension(filename)
+	if projectID.IsZero() || ext == "" {
+		return "", fmt.Errorf("%w: uploaded source must be .zip, .tar.gz, or .tgz", shared.ErrValidation)
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return "", fmt.Errorf("create project upload directory: %w", err)
+	}
+	final := filepath.Join(s.dir, projectID.String()+ext)
+	tmp, err := os.CreateTemp(s.dir, projectID.String()+"-*.upload")
+	if err != nil {
+		return "", fmt.Errorf("create project upload: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	limit := s.maxBytes
+	if limit <= 0 || limit > 512<<20 {
+		limit = 512 << 20
+	}
+	written, copyErr := io.Copy(tmp, io.LimitReader(src, limit+1))
+	closeErr := tmp.Close()
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if copyErr != nil {
+		return "", fmt.Errorf("store project upload: %w", copyErr)
+	}
+	if closeErr != nil {
+		return "", fmt.Errorf("close project upload: %w", closeErr)
+	}
+	if written > limit {
+		return "", fmt.Errorf("%w: uploaded archive exceeds %d bytes", shared.ErrValidation, limit)
+	}
+	_ = os.Remove(final)
+	if err := os.Rename(tmpName, final); err != nil {
+		return "", fmt.Errorf("publish project upload: %w", err)
+	}
+	return filepath.Abs(final)
+}
+
+func (s *ProjectArchiveStore) Delete(_ context.Context, projectID shared.ID) error {
+	for _, ext := range []string{".tar.gz", ".tgz", ".zip"} {
+		if err := os.Remove(filepath.Join(s.dir, projectID.String()+ext)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("delete project upload: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/file/project_archive_store_test.go
+++ b/internal/infrastructure/persistence/file/project_archive_store_test.go
@@ -1,0 +1,38 @@
+package file
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestProjectArchiveStore(t *testing.T) {
+	s := NewProjectArchiveStore(t.TempDir(), 4)
+	path, err := s.Save(context.Background(), "p1", "source.ZIP", bytes.NewBufferString("zip"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(path); err != nil || string(got) != "zip" {
+		t.Fatalf("stored=%q err=%v", got, err)
+	}
+	if err := s.Delete(context.Background(), "p1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("archive still exists: %v", err)
+	}
+}
+
+func TestProjectArchiveStoreRejectsInvalidAndOversized(t *testing.T) {
+	s := NewProjectArchiveStore(t.TempDir(), 3)
+	if _, err := s.Save(context.Background(), "p1", "source.rar", bytes.NewBuffer(nil)); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unsupported=%v", err)
+	}
+	if _, err := s.Save(context.Background(), "p1", "source.tar.gz", bytes.NewBufferString("four")); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("oversized=%v", err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/engagement_repo.go
+++ b/internal/infrastructure/persistence/memory/engagement_repo.go
@@ -52,10 +52,21 @@ func (r *EngagementRepository) GetByIDInTenant(_ context.Context, tenantID, id s
 	if !ok {
 		return nil, shared.ErrNotFound
 	}
-	if !tenantID.IsZero() && e.TenantID != tenantID {
-		return nil, shared.ErrNotFound // cross-tenant access – do not reveal existence
+	if !e.ProjectID.IsZero() || (!tenantID.IsZero() && e.TenantID != tenantID) {
+		return nil, shared.ErrNotFound // cross-tenant/internal access – do not reveal existence
 	}
 	return e, nil
+}
+
+func (r *EngagementRepository) GetByProjectID(_ context.Context, tenantID, projectID shared.ID) (*engagement.Engagement, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, e := range r.data {
+		if e.ProjectID == projectID && (tenantID.IsZero() || e.TenantID == tenantID) {
+			return e, nil
+		}
+	}
+	return nil, shared.ErrNotFound
 }
 
 func (r *EngagementRepository) Update(_ context.Context, e *engagement.Engagement) error {
@@ -83,7 +94,7 @@ func (r *EngagementRepository) List(_ context.Context, tenantID shared.ID) ([]*e
 	defer r.mu.RUnlock()
 	out := make([]*engagement.Engagement, 0, len(r.data))
 	for _, e := range r.data {
-		if tenantID.IsZero() || e.TenantID == tenantID {
+		if e.ProjectID.IsZero() && (tenantID.IsZero() || e.TenantID == tenantID) {
 			out = append(out, e)
 		}
 	}

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -16,7 +16,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-const engagementCols = `id, tenant_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, created_by, updated_by`
+const engagementCols = `id, tenant_id, project_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, created_by, updated_by`
 
 // EngagementRepository persists engagements and their scope to PostgreSQL.
 type EngagementRepository struct{ pool *pgxpool.Pool }
@@ -41,8 +41,8 @@ func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagem
 		return fmt.Errorf("marshal roe: %w", err)
 	}
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
-		e.ID.String(), e.TenantID.String(), e.Name, e.Client, string(e.Status),
+		`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+		e.ID.String(), e.TenantID.String(), e.ProjectID.String(), e.Name, e.Client, string(e.Status),
 		e.AuthorizedFrom, e.AuthorizedTo, e.Audit.CreatedAt, e.Audit.UpdatedAt, e.Timezone, roeJSON, e.LiveReconEnabled,
 		e.Audit.CreatedBy, e.Audit.UpdatedBy); err != nil {
 		return fmt.Errorf("insert engagement: %w", err)
@@ -160,7 +160,7 @@ func (r *EngagementRepository) GetByID(ctx context.Context, id shared.ID) (*enga
 // not revealed).
 func (r *EngagementRepository) GetByIDInTenant(ctx context.Context, tenantID, id shared.ID) (*engagement.Engagement, error) {
 	e, err := scanEngagement(r.pool.QueryRow(ctx,
-		`SELECT `+engagementCols+` FROM engagements WHERE id=$1 AND (tenant_id=$2 OR $2='')`,
+		`SELECT `+engagementCols+` FROM engagements WHERE id=$1 AND project_id IS NULL AND (tenant_id=$2 OR $2='')`,
 		id.String(), tenantID.String()))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, shared.ErrNotFound
@@ -176,6 +176,24 @@ func (r *EngagementRepository) GetByIDInTenant(ctx context.Context, tenantID, id
 	return e, nil
 }
 
+func (r *EngagementRepository) GetByProjectID(ctx context.Context, tenantID, projectID shared.ID) (*engagement.Engagement, error) {
+	e, err := scanEngagement(r.pool.QueryRow(ctx,
+		`SELECT `+engagementCols+` FROM engagements WHERE project_id=$1 AND (tenant_id=$2 OR $2='')`,
+		projectID.String(), tenantID.String()))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, shared.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("select project analysis context: %w", err)
+	}
+	scope, err := r.loadScope(ctx, e.ID)
+	if err != nil {
+		return nil, err
+	}
+	e.Scope = scope
+	return e, nil
+}
+
 // List returns the tenant's engagements, each with its scope loaded (consistent
 // with the in-memory repository; the UI and the scope gate both rely on scope).
 func (r *EngagementRepository) List(ctx context.Context, tenantID shared.ID) ([]*engagement.Engagement, error) {
@@ -184,9 +202,9 @@ func (r *EngagementRepository) List(ctx context.Context, tenantID shared.ID) ([]
 		err  error
 	)
 	if tenantID.IsZero() {
-		rows, err = r.pool.Query(ctx, `SELECT `+engagementCols+` FROM engagements ORDER BY created_at DESC`)
+		rows, err = r.pool.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE project_id IS NULL ORDER BY created_at DESC`)
 	} else {
-		rows, err = r.pool.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE tenant_id=$1 ORDER BY created_at DESC`, tenantID.String())
+		rows, err = r.pool.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE tenant_id=$1 AND project_id IS NULL ORDER BY created_at DESC`, tenantID.String())
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list engagements: %w", err)
@@ -255,10 +273,11 @@ func scanEngagement(row rowScanner) (*engagement.Engagement, error) {
 	var (
 		e              engagement.Engagement
 		idStr, ten, st string
+		projectID      pgtype.Text
 		af, at         pgtype.Timestamptz
 		roeJSON        []byte
 	)
-	if err := row.Scan(&idStr, &ten, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.Audit.CreatedBy, &e.Audit.UpdatedBy); err != nil {
+	if err := row.Scan(&idStr, &ten, &projectID, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.Audit.CreatedBy, &e.Audit.UpdatedBy); err != nil {
 		return nil, err
 	}
 	if len(roeJSON) > 0 {
@@ -268,6 +287,9 @@ func scanEngagement(row rowScanner) (*engagement.Engagement, error) {
 	}
 	e.ID = shared.ID(idStr)
 	e.TenantID = shared.ID(ten)
+	if projectID.Valid {
+		e.ProjectID = shared.ID(projectID.String)
+	}
 	e.Status = engagement.Status(st)
 	if af.Valid {
 		t := af.Time

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -72,6 +72,8 @@ type Config struct {
 	// MaxWorkspaceBytes caps the total size of a prepared SCA workspace: the
 	// acquirer rejects a target whose files exceed it. <=0 keeps the 2 GiB default.
 	MaxWorkspaceBytes int64
+	// ProjectUploadDir retains uploaded Project source archives for repeat analysis.
+	ProjectUploadDir string
 	// Evidence artifact blob store: when BlobEndpoint is set, artifacts go to
 	// MinIO/S3; empty = in-memory (dev). Bucket defaults to synapse-evidence.
 	BlobEndpoint  string
@@ -344,6 +346,7 @@ func Load() Config {
 		IgnoreUnfixed:      getbool("SYNAPSE_IGNORE_UNFIXED", false),
 		Offline:            getbool("SYNAPSE_OFFLINE", false),
 		MaxWorkspaceBytes:  getint64("SYNAPSE_MAX_WORKSPACE_BYTES", 2<<30),
+		ProjectUploadDir:   getenv("SYNAPSE_PROJECT_UPLOAD_DIR", "data/project-uploads"),
 		BlobEndpoint:       getenv("SYNAPSE_BLOB_ENDPOINT", ""),
 		BlobAccessKey:      getenv("SYNAPSE_BLOB_ACCESS_KEY", ""),
 		BlobSecretKey:      getenv("SYNAPSE_BLOB_SECRET_KEY", ""),

--- a/internal/usecase/engagement/service_test.go
+++ b/internal/usecase/engagement/service_test.go
@@ -49,6 +49,14 @@ func (r *memRepo) GetByIDInTenant(_ context.Context, tenantID, id shared.ID) (*d
 	}
 	return e, nil
 }
+func (r *memRepo) GetByProjectID(_ context.Context, tenantID, projectID shared.ID) (*domain.Engagement, error) {
+	for _, e := range r.data {
+		if e.ProjectID == projectID && (tenantID.IsZero() || e.TenantID == tenantID) {
+			return e, nil
+		}
+	}
+	return nil, shared.ErrNotFound
+}
 func (r *memRepo) List(context.Context, shared.ID) ([]*domain.Engagement, error) { return nil, nil }
 
 type fixedClock struct{ t time.Time }

--- a/internal/usecase/execution/guard_test.go
+++ b/internal/usecase/execution/guard_test.go
@@ -27,6 +27,9 @@ func (f *fakeEngRepo) GetByID(context.Context, shared.ID) (*engagement.Engagemen
 func (f *fakeEngRepo) GetByIDInTenant(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
 	return f.eng, f.err
 }
+func (*fakeEngRepo) GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
 func (f *fakeEngRepo) List(context.Context, shared.ID) ([]*engagement.Engagement, error) {
 	return nil, nil
 }

--- a/internal/usecase/orchestrator/load_test.go
+++ b/internal/usecase/orchestrator/load_test.go
@@ -38,6 +38,9 @@ func (r *multiEngRepo) GetByID(_ context.Context, id shared.ID) (*engagement.Eng
 func (r *multiEngRepo) GetByIDInTenant(ctx context.Context, _ shared.ID, id shared.ID) (*engagement.Engagement, error) {
 	return r.GetByID(ctx, id)
 }
+func (*multiEngRepo) GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
 func (r *multiEngRepo) Create(context.Context, *engagement.Engagement) error { return nil }
 func (r *multiEngRepo) Update(context.Context, *engagement.Engagement) error { return nil }
 func (r *multiEngRepo) Delete(context.Context, shared.ID) error              { return nil }

--- a/internal/usecase/orchestrator/orchestrator_test.go
+++ b/internal/usecase/orchestrator/orchestrator_test.go
@@ -71,6 +71,9 @@ func (f *fakeEngRepo) GetByID(context.Context, shared.ID) (*engagement.Engagemen
 func (f *fakeEngRepo) GetByIDInTenant(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
 	return f.eng, nil
 }
+func (*fakeEngRepo) GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
 func (f *fakeEngRepo) List(context.Context, shared.ID) ([]*engagement.Engagement, error) {
 	return nil, nil
 }

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -68,6 +68,9 @@ type EngagementRepository interface {
 	// admin) matches any row; a non-empty tenant matches only its own, so tenant A cannot reach
 	// tenant B's engagement (returns shared.ErrNotFound – existence is not revealed).
 	GetByIDInTenant(ctx context.Context, tenantID, id shared.ID) (*engagement.Engagement, error)
+	// GetByProjectID loads the hidden Project analysis context scoped to tenantID.
+	// It is only for Project use-case internals; normal engagement reads must use GetByIDInTenant.
+	GetByProjectID(ctx context.Context, tenantID, projectID shared.ID) (*engagement.Engagement, error)
 	List(ctx context.Context, tenantID shared.ID) ([]*engagement.Engagement, error)
 	// Update persists changes to an existing engagement aggregate – its row
 	// (name/client/status/authorization window/timezone) and its full scope target

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -4,6 +4,7 @@ package ports
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/advisory"
@@ -42,6 +43,12 @@ type ProjectRepository interface {
 	List(ctx context.Context, tenantID shared.ID) ([]*project.Project, error)
 	GetByKey(ctx context.Context, tenantID shared.ID, key string) (*project.Project, error)
 	DeleteByKey(ctx context.Context, tenantID shared.ID, key string) error
+}
+
+// ProjectArchiveStore retains uploaded source archives so a Project can be re-analyzed.
+type ProjectArchiveStore interface {
+	Save(ctx context.Context, projectID shared.ID, filename string, src io.Reader) (string, error)
+	Delete(ctx context.Context, projectID shared.ID) error
 }
 
 // EngagementRepository persists engagements. Returned aggregates are read-only –

--- a/internal/usecase/projectuc/service.go
+++ b/internal/usecase/projectuc/service.go
@@ -3,23 +3,61 @@ package projectuc
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"path/filepath"
 	"strings"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
 )
 
-type Service struct {
-	repo  ports.ProjectRepository
-	clock ports.Clock
-	ids   ports.IDGenerator
-	audit ports.AuditLogger
+type analysisContextRepository interface {
+	GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error)
 }
 
-func NewService(repo ports.ProjectRepository, clock ports.Clock, ids ports.IDGenerator, audit ports.AuditLogger) *Service {
-	return &Service{repo: repo, clock: clock, ids: ids, audit: audit}
+type Service struct {
+	repo             ports.ProjectRepository
+	engagements      ports.EngagementRepository
+	analysisContexts analysisContextRepository
+	clock            ports.Clock
+	ids              ports.IDGenerator
+	audit            ports.AuditLogger
+	scanner          *scauc.Service
+	archives         ports.ProjectArchiveStore
+	allowLocalSource bool
+}
+
+func NewService(repo ports.ProjectRepository, engagements ports.EngagementRepository, clock ports.Clock, ids ports.IDGenerator, audit ports.AuditLogger, allowLocalSource bool) *Service {
+	contexts, _ := engagements.(analysisContextRepository)
+	return &Service{repo: repo, engagements: engagements, analysisContexts: contexts, clock: clock, ids: ids, audit: audit, allowLocalSource: allowLocalSource}
+}
+
+func (s *Service) SetScanner(scanner *scauc.Service)               { s.scanner = scanner }
+func (s *Service) SetArchiveStore(store ports.ProjectArchiveStore) { s.archives = store }
+
+func (s *Service) CreateFromArchive(ctx context.Context, in CreateInput, filename string, src io.Reader) (*project.Project, error) {
+	if err := requireActor(in.CreatedBy); err != nil {
+		return nil, err
+	}
+	if s.archives == nil {
+		return nil, fmt.Errorf("%w: project archive uploads are not configured", shared.ErrValidation)
+	}
+	id := s.ids.NewID()
+	path, err := s.archives.Save(ctx, id, filename, src)
+	if err != nil {
+		return nil, err
+	}
+	in.SourceBinding = project.SourceBinding{Kind: project.SourceArchive, Value: path}
+	p, err := s.create(ctx, in, id)
+	if err != nil {
+		_ = s.archives.Delete(ctx, id)
+	}
+	return p, err
 }
 
 type CreateInput struct {
@@ -33,17 +71,45 @@ type CreateInput struct {
 }
 
 func (s *Service) Create(ctx context.Context, in CreateInput) (*project.Project, error) {
+	return s.create(ctx, in, s.ids.NewID())
+}
+
+func (s *Service) create(ctx context.Context, in CreateInput, id shared.ID) (*project.Project, error) {
 	if err := requireActor(in.CreatedBy); err != nil {
 		return nil, err
 	}
+	if s.engagements == nil || s.analysisContexts == nil {
+		return nil, fmt.Errorf("%w: project analysis context repository is required", shared.ErrValidation)
+	}
+	if in.SourceBinding.Kind == project.SourceLocal && !s.allowLocalSource {
+		return nil, fmt.Errorf("%w: local project sources are only available in development", shared.ErrValidation)
+	}
+	if in.SourceBinding.Kind == project.SourceLocal || in.SourceBinding.Kind == project.SourceArchive {
+		if abs, err := filepath.Abs(in.SourceBinding.Value); err == nil {
+			in.SourceBinding.Value = abs
+		}
+	}
 	now := s.clock.Now()
-	p, err := project.New(s.ids.NewID(), in.TenantID, in.Name, in.Key, in.SourceBinding, in.DefaultProfileByLang, in.GateID, now)
+	p, err := project.New(id, in.TenantID, in.Name, in.Key, in.SourceBinding, in.DefaultProfileByLang, in.GateID, now)
 	if err != nil {
 		return nil, err
 	}
 	p.Audit.CreatedBy, p.Audit.UpdatedBy = in.CreatedBy, in.CreatedBy
 	if err := s.repo.Create(ctx, p); err != nil {
 		return nil, fmt.Errorf("persist project: %w", err)
+	}
+	analysis, err := engagement.New(s.ids.NewID(), p.TenantID, p.Name+" analysis", "", now)
+	if err == nil {
+		analysis.ProjectID = p.ID
+		analysis.Audit.CreatedBy, analysis.Audit.UpdatedBy = in.CreatedBy, in.CreatedBy
+		err = analysis.SetScope([]engagement.Target{{Kind: engagement.TargetRepo, Value: p.SourceBinding.Value}}, nil, now)
+	}
+	if err == nil {
+		err = s.engagements.Create(ctx, analysis)
+	}
+	if err != nil {
+		_ = s.repo.DeleteByKey(ctx, p.TenantID, p.Key)
+		return nil, fmt.Errorf("persist project analysis context: %w", err)
 	}
 	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: in.CreatedBy, Action: "project.create", Target: p.ID.String(), Metadata: map[string]string{"project": p.Key}, At: now}); err != nil {
 		return nil, fmt.Errorf("audit project.create: %w", err)
@@ -67,6 +133,61 @@ func (s *Service) Get(ctx context.Context, tenantID shared.ID, key string) (*pro
 	return p, nil
 }
 
+func (s *Service) analysisContext(ctx context.Context, tenantID shared.ID, key string) (*project.Project, *engagement.Engagement, error) {
+	p, err := s.Get(ctx, tenantID, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	e, err := s.analysisContexts.GetByProjectID(ctx, tenantID, p.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get project analysis context: %w", err)
+	}
+	return p, e, nil
+}
+
+func (s *Service) StartAnalysis(ctx context.Context, actor string, tenantID shared.ID, key string) (ports.ScanJob, error) {
+	if err := requireActor(actor); err != nil {
+		return ports.ScanJob{}, err
+	}
+	if s.scanner == nil {
+		return ports.ScanJob{}, fmt.Errorf("%w: project analysis is not configured", shared.ErrValidation)
+	}
+	p, e, err := s.analysisContext(ctx, tenantID, key)
+	if err != nil {
+		return ports.ScanJob{}, err
+	}
+	if latest, latestErr := s.scanner.LatestJob(ctx, e.ID); latestErr == nil && latest.Status == ports.ScanRunning {
+		return ports.ScanJob{}, fmt.Errorf("%w: project analysis is already running", shared.ErrConflict)
+	} else if latestErr != nil && !errors.Is(latestErr, shared.ErrNotFound) {
+		return ports.ScanJob{}, latestErr
+	}
+	return s.scanner.StartScanWithOptions(ctx, actor, e.ID, ports.AcquireRequest{
+		Kind: p.SourceBinding.Kind, Value: p.SourceBinding.Value, Ref: p.SourceBinding.Ref,
+	}, scauc.ScanOptions{Mode: scauc.ScanModeFull, CodeQuality: true})
+}
+
+func (s *Service) AnalysisStatus(ctx context.Context, tenantID shared.ID, key string) (ports.ScanJob, error) {
+	if s.scanner == nil {
+		return ports.ScanJob{}, shared.ErrNotFound
+	}
+	_, e, err := s.analysisContext(ctx, tenantID, key)
+	if err != nil {
+		return ports.ScanJob{}, err
+	}
+	return s.scanner.LatestJob(ctx, e.ID)
+}
+
+func (s *Service) LatestAnalysis(ctx context.Context, tenantID shared.ID, key string) ([]byte, error) {
+	if s.scanner == nil {
+		return nil, shared.ErrNotFound
+	}
+	_, e, err := s.analysisContext(ctx, tenantID, key)
+	if err != nil {
+		return nil, err
+	}
+	return s.scanner.LatestResult(ctx, e.ID)
+}
+
 func (s *Service) Delete(ctx context.Context, actor string, tenantID shared.ID, key string) error {
 	if err := requireActor(actor); err != nil {
 		return err
@@ -74,6 +195,15 @@ func (s *Service) Delete(ctx context.Context, actor string, tenantID shared.ID, 
 	p, err := s.repo.GetByKey(ctx, tenantID, strings.TrimSpace(key))
 	if err != nil {
 		return err
+	}
+	if s.engagements != nil {
+		if e, err := s.analysisContexts.GetByProjectID(ctx, tenantID, p.ID); err == nil {
+			if err := s.engagements.Delete(ctx, e.ID); err != nil {
+				return fmt.Errorf("delete project analysis context: %w", err)
+			}
+		} else if !errors.Is(err, shared.ErrNotFound) {
+			return fmt.Errorf("get project analysis context: %w", err)
+		}
 	}
 	if err := s.repo.DeleteByKey(ctx, tenantID, p.Key); err != nil {
 		return fmt.Errorf("delete project: %w", err)

--- a/internal/usecase/projectuc/service.go
+++ b/internal/usecase/projectuc/service.go
@@ -16,14 +16,9 @@ import (
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
 )
 
-type analysisContextRepository interface {
-	GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error)
-}
-
 type Service struct {
 	repo             ports.ProjectRepository
 	engagements      ports.EngagementRepository
-	analysisContexts analysisContextRepository
 	clock            ports.Clock
 	ids              ports.IDGenerator
 	audit            ports.AuditLogger
@@ -33,8 +28,7 @@ type Service struct {
 }
 
 func NewService(repo ports.ProjectRepository, engagements ports.EngagementRepository, clock ports.Clock, ids ports.IDGenerator, audit ports.AuditLogger, allowLocalSource bool) *Service {
-	contexts, _ := engagements.(analysisContextRepository)
-	return &Service{repo: repo, engagements: engagements, analysisContexts: contexts, clock: clock, ids: ids, audit: audit, allowLocalSource: allowLocalSource}
+	return &Service{repo: repo, engagements: engagements, clock: clock, ids: ids, audit: audit, allowLocalSource: allowLocalSource}
 }
 
 func (s *Service) SetScanner(scanner *scauc.Service)               { s.scanner = scanner }
@@ -78,7 +72,7 @@ func (s *Service) create(ctx context.Context, in CreateInput, id shared.ID) (*pr
 	if err := requireActor(in.CreatedBy); err != nil {
 		return nil, err
 	}
-	if s.engagements == nil || s.analysisContexts == nil {
+	if s.engagements == nil {
 		return nil, fmt.Errorf("%w: project analysis context repository is required", shared.ErrValidation)
 	}
 	if in.SourceBinding.Kind == project.SourceLocal && !s.allowLocalSource {
@@ -138,7 +132,7 @@ func (s *Service) analysisContext(ctx context.Context, tenantID shared.ID, key s
 	if err != nil {
 		return nil, nil, err
 	}
-	e, err := s.analysisContexts.GetByProjectID(ctx, tenantID, p.ID)
+	e, err := s.engagements.GetByProjectID(ctx, tenantID, p.ID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get project analysis context: %w", err)
 	}
@@ -197,7 +191,7 @@ func (s *Service) Delete(ctx context.Context, actor string, tenantID shared.ID, 
 		return err
 	}
 	if s.engagements != nil {
-		if e, err := s.analysisContexts.GetByProjectID(ctx, tenantID, p.ID); err == nil {
+		if e, err := s.engagements.GetByProjectID(ctx, tenantID, p.ID); err == nil {
 			if err := s.engagements.Delete(ctx, e.ID); err != nil {
 				return fmt.Errorf("delete project analysis context: %w", err)
 			}

--- a/internal/usecase/projectuc/service_test.go
+++ b/internal/usecase/projectuc/service_test.go
@@ -30,7 +30,7 @@ func (a *captureAudit) Record(_ context.Context, e ports.AuditEntry) error {
 func TestServiceCRUDAndAudit(t *testing.T) {
 	ctx := context.Background()
 	audit := &captureAudit{}
-	svc := NewService(memory.NewProjectRepository(), fixedClock{time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}, fixedIDs{}, audit)
+	svc := NewService(memory.NewProjectRepository(), memory.NewEngagementRepository(), fixedClock{time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}, fixedIDs{}, audit, true)
 	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
 	if err != nil {
 		t.Fatal(err)
@@ -54,8 +54,19 @@ func TestServiceCRUDAndAudit(t *testing.T) {
 }
 
 func TestServiceRequiresActor(t *testing.T) {
-	svc := NewService(memory.NewProjectRepository(), fixedClock{}, fixedIDs{}, &captureAudit{})
+	svc := NewService(memory.NewProjectRepository(), memory.NewEngagementRepository(), fixedClock{}, fixedIDs{}, &captureAudit{}, true)
 	if _, err := svc.Create(context.Background(), CreateInput{Name: "P", Key: "p", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("got %v, want validation", err)
+	}
+}
+
+func TestServiceRejectsLocalSourceOutsideDevelopment(t *testing.T) {
+	svc := NewService(memory.NewProjectRepository(), memory.NewEngagementRepository(), fixedClock{}, fixedIDs{}, &captureAudit{}, false)
+	_, err := svc.Create(context.Background(), CreateInput{
+		TenantID: "tenant-a", CreatedBy: "alice", Name: "Project", Key: "project",
+		SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"},
+	})
+	if !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("got %v, want validation", err)
 	}
 }

--- a/internal/usecase/report/service_test.go
+++ b/internal/usecase/report/service_test.go
@@ -28,6 +28,9 @@ func (f fakeEngRepo) GetByID(context.Context, shared.ID) (*engagement.Engagement
 func (f fakeEngRepo) GetByIDInTenant(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
 	return f.eng, nil
 }
+func (fakeEngRepo) GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
 
 type fakeFindingRepo struct {
 	ports.FindingRepository

--- a/internal/usecase/safety/gate_test.go
+++ b/internal/usecase/safety/gate_test.go
@@ -31,6 +31,9 @@ func (f *fakeEngRepo) GetByID(context.Context, shared.ID) (*engagement.Engagemen
 func (f *fakeEngRepo) GetByIDInTenant(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
 	return f.eng, nil
 }
+func (*fakeEngRepo) GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
 func (f *fakeEngRepo) List(context.Context, shared.ID) ([]*engagement.Engagement, error) {
 	return nil, nil
 }

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/codequality"
 	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -87,6 +88,9 @@ type Service struct {
 	sevEnricher       ports.SeverityEnricher          // optional NVD CVSS backfill for unknown-severity vulns
 	ignoreUnfixed     bool                            // when set, don't promote no-fix vulns to findings (Trivy --ignore-unfixed)
 	guard             *execution.Guard                // shared scope + window + audit gate; built in NewService
+	codeQuality       interface {
+		BuildReport(context.Context, string) (codequality.Report, error)
+	}
 }
 
 // SetSeverityEnricher configures optional severity backfill (NVD CVSS) for vulnerabilities the
@@ -96,6 +100,12 @@ func (s *Service) SetSeverityEnricher(e ports.SeverityEnricher) { s.sevEnricher 
 
 // SetImportedSBOMStore configures the engagement-scoped client SBOM artifact store.
 func (s *Service) SetImportedSBOMStore(store ports.ImportedSBOMStore) { s.importedSBOM = store }
+
+func (s *Service) SetCodeQuality(q interface {
+	BuildReport(context.Context, string) (codequality.Report, error)
+}) {
+	s.codeQuality = q
+}
 
 // SetIgnoreUnfixed controls whether vulnerabilities with no available fix are promoted to
 // findings. true = suppress them (Trivy's --ignore-unfixed); they stay in the vuln inventory.
@@ -466,6 +476,7 @@ type ScanResult struct {
 	Manifest                 ports.ScanManifest       `json:"manifest"`
 	RiskMatches              map[string]int           `json:"risk_matches"` // kev/epss match counts (diagnostic)
 	FindingQuality           FindingQuality           `json:"finding_quality"`
+	CodeQuality              *codequality.Report      `json:"code_quality,omitempty"`
 	// Coverage is the per-ecosystem component tally: components + resolved-version counts per
 	// ecosystem, so a thin / partially-resolved ecosystem is VISIBLE rather than hidden behind the single
 	// global Completeness number ("no silent gap").
@@ -539,6 +550,7 @@ type ScanOptions struct {
 	Mode string `json:"mode"`
 	// DetectionPriority selects comprehensive (default) or precise; see the Detection* consts.
 	DetectionPriority string `json:"detection_priority,omitempty"`
+	CodeQuality       bool   `json:"code_quality,omitempty"`
 }
 
 func normalizeScanOptions(opts ScanOptions) (ScanOptions, error) {
@@ -2088,6 +2100,13 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	result.VulnsBelowThreshold = countBelowThreshold(vulns, s.minSeverity)
 	result.UnfixedSuppressed = countUnfixedSuppressed(vulns, s.minSeverity, s.ignoreUnfixed)
 	result.FindingQuality = computeFindingQuality(result)
+	if opts.CodeQuality && s.codeQuality != nil {
+		report, qerr := s.codeQuality.BuildReport(ctx, ws.Dir)
+		if qerr != nil {
+			return nil, fmt.Errorf("analyze code quality: %w", qerr)
+		}
+		result.CodeQuality = &report
+	}
 	trace.succeed(step, "Findings derived", map[string]int{"vulnerabilities": len(vulns), "licenses": len(lics), "findings": len(result.Findings)})
 	result.DebugEvents = trace.snapshot()
 	if result.SBOM != nil {

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/codequality"
 	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -126,6 +127,13 @@ func (c *countingLic) Scan(context.Context, *sbom.SBOM) ([]ports.LicenseFinding,
 	return []ports.LicenseFinding{{License: "MIT", Category: sbom.LicensePermissive, Verdict: ports.LicenseAllow, Components: []string{"pkg"}}}, nil
 }
 
+type countingCodeQuality struct{ calls int }
+
+func (c *countingCodeQuality) BuildReport(context.Context, string) (codequality.Report, error) {
+	c.calls++
+	return codequality.Report{}, nil
+}
+
 func engagementWithScope(t *testing.T, inScope ...string) *engdom.Engagement {
 	t.Helper()
 	e, err := engdom.New("e1", "", "test", "", time.Unix(0, 0).UTC())
@@ -176,6 +184,29 @@ func TestScanInScopeRunsAndAudits(t *testing.T) {
 	}
 	assertDebugEvent(t, res.DebugEvents, stageVulns, "fake", ports.ScanDebugSucceeded)
 	assertDebugEvent(t, res.DebugEvents, stageLicense, "license-policy", ports.ScanDebugSucceeded)
+}
+
+func TestCodeQualityRequiresExplicitScanOption(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	quality := &countingCodeQuality{}
+	svc := newSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{})
+	svc.SetCodeQuality(quality)
+
+	ordinary, err := svc.Scan(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"})
+	if err != nil {
+		t.Fatalf("ordinary scan: %v", err)
+	}
+	if quality.calls != 0 || ordinary.CodeQuality != nil {
+		t.Fatalf("ordinary scan attached code quality: calls=%d report=%v", quality.calls, ordinary.CodeQuality != nil)
+	}
+
+	project, err := svc.ScanWithOptions(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, CodeQuality: true})
+	if err != nil {
+		t.Fatalf("project scan: %v", err)
+	}
+	if quality.calls != 1 || project.CodeQuality == nil {
+		t.Fatalf("opted-in scan code quality: calls=%d report=%v", quality.calls, project.CodeQuality != nil)
+	}
 }
 
 func TestScanStampsSBOMCreationTime(t *testing.T) {

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -36,6 +36,9 @@ func (f *fakeEngRepo) GetByID(context.Context, shared.ID) (*engdom.Engagement, e
 func (f *fakeEngRepo) GetByIDInTenant(context.Context, shared.ID, shared.ID) (*engdom.Engagement, error) {
 	return f.eng, f.err
 }
+func (*fakeEngRepo) GetByProjectID(context.Context, shared.ID, shared.ID) (*engdom.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
 func (f *fakeEngRepo) List(context.Context, shared.ID) ([]*engdom.Engagement, error) {
 	return nil, nil
 }

--- a/internal/usecase/vex/service_test.go
+++ b/internal/usecase/vex/service_test.go
@@ -22,6 +22,9 @@ func (fakeEngRepo) GetByID(_ context.Context, id shared.ID) (*engagement.Engagem
 func (fakeEngRepo) GetByIDInTenant(_ context.Context, _ shared.ID, id shared.ID) (*engagement.Engagement, error) {
 	return &engagement.Engagement{ID: id, Status: engagement.StatusActive}, nil
 }
+func (fakeEngRepo) GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
 
 type fakeRepo struct {
 	ports.FindingRepository // embedded: unused methods panic if called
@@ -123,6 +126,9 @@ func (missingEngRepo) GetByID(context.Context, shared.ID) (*engagement.Engagemen
 	return nil, shared.ErrNotFound
 }
 func (missingEngRepo) GetByIDInTenant(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
+func (missingEngRepo) GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
 	return nil, shared.ErrNotFound
 }
 

--- a/migrations/0046_project_analysis_context.sql
+++ b/migrations/0046_project_analysis_context.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+ALTER TABLE engagements
+    ADD COLUMN project_id TEXT REFERENCES projects(id) ON DELETE CASCADE;
+CREATE UNIQUE INDEX idx_engagements_project ON engagements(project_id) WHERE project_id IS NOT NULL;
+
+-- Existing projects receive the same hidden, governed scan context new projects get.
+INSERT INTO engagements (id, tenant_id, project_id, name, client, status, created_at, updated_at, created_by, updated_by)
+SELECT 'project-' || p.id, p.tenant_id, p.id, p.name || ' analysis', '', 'draft', p.created_at, p.updated_at, p.created_by, p.updated_by
+FROM projects p
+ON CONFLICT (project_id) WHERE project_id IS NOT NULL DO NOTHING;
+
+INSERT INTO scope_targets (id, engagement_id, in_scope, kind, value)
+SELECT 'project-' || p.id || '-source', 'project-' || p.id, TRUE, 'repo', p.source_binding->>'Value'
+FROM projects p
+WHERE p.source_binding->>'Value' <> ''
+ON CONFLICT (id) DO NOTHING;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_engagements_project;
+ALTER TABLE engagements DROP COLUMN IF EXISTS project_id;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   AgentSession,
   AupStatus,
   CodeQualityView,
+  CodeQualityReport,
   CodeRating,
   Component,
   PendingApproval,
@@ -507,6 +508,38 @@ function mapScanDebugEvent(r: any) {
   }
 }
 
+function mapCodeQualityReport(rep: any): CodeQualityReport {
+  return {
+    inventory: (rep?.inventory?.languages ?? []).map((l: any) => ({
+      language: l.language,
+      files: l.files ?? 0,
+      codeLines: l.code_lines ?? 0,
+      commentLines: l.comment_lines ?? 0,
+      blankLines: l.blank_lines ?? 0,
+      functions: l.functions ?? 0,
+      functionsKnown: !!l.functions_known,
+    })),
+    findings: (rep?.findings ?? []).map(mapFinding),
+    duplication: {
+      blocks: (rep?.duplication?.blocks ?? []).map((b: any) => ({
+        tokens: b.tokens ?? 0,
+        occurrences: (b.occurrences ?? []).map((o: any) => ({ file: o.file, startLine: o.start_line ?? 0, endLine: o.end_line ?? 0 })),
+      })),
+      duplicatedLines: rep?.duplication?.duplicated_lines ?? 0,
+      totalLines: rep?.duplication?.total_lines ?? 0,
+      files: rep?.duplication?.files ?? 0,
+    },
+    rating: {
+      security: (rep?.rating?.security ?? 'A') as CodeRating['security'],
+      reliability: (rep?.rating?.reliability ?? 'A') as CodeRating['reliability'],
+      maintainability: (rep?.rating?.maintainability ?? 'A') as CodeRating['maintainability'],
+      techDebtMinutes: rep?.rating?.tech_debt_minutes ?? 0,
+      debtRatioPct: rep?.rating?.debt_ratio_pct ?? 0,
+      linesOfCode: rep?.rating?.lines_of_code ?? 0,
+    },
+  }
+}
+
 function mapScanResult(r: any): ScanResult {
   return {
     target: r.target ?? '',
@@ -561,6 +594,7 @@ function mapScanResult(r: any): ScanResult {
       pinnedInputs: r.manifest?.pinned_inputs ?? [],
       unpinnedInputs: r.manifest?.unpinned_inputs ?? [],
     },
+    codeQuality: r.code_quality ? mapCodeQualityReport(r.code_quality) : undefined,
     debugEvents: (r.debug_events ?? []).map(mapScanDebugEvent),
   }
 }
@@ -726,8 +760,48 @@ export const api = {
       }),
     ),
 
+  createProjectFromArchive: async (name: string, key: string, archive: File): Promise<Project> => {
+    const form = new FormData()
+    form.append('name', name)
+    form.append('key', key)
+    form.append('archive', archive)
+    const res = await fetch('/api/v1/projects', {
+      method: 'POST',
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+      body: form,
+    })
+    if (res.status === 401 && onUnauthorized) onUnauthorized()
+    if (!res.ok) {
+      let message = `HTTP ${res.status}`
+      try { message = (await res.json())?.error ?? message } catch { /* non-JSON */ }
+      throw new ApiError(res.status, message)
+    }
+    return mapProject(await res.json())
+  },
+
   getProject: async (key: string): Promise<Project> =>
     mapProject(await req(`/projects/${encodeURIComponent(key)}`)),
+
+  startProjectAnalysis: async (key: string): Promise<ScanJob> =>
+    mapScanJob(await req(`/projects/${encodeURIComponent(key)}/analyses`, { method: 'POST' })),
+
+  projectAnalysisStatus: async (key: string): Promise<ScanJob | null> => {
+    try {
+      return mapScanJob(await req(`/projects/${encodeURIComponent(key)}/analysis-status`))
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) return null
+      throw e
+    }
+  },
+
+  latestProjectAnalysis: async (key: string): Promise<ScanResult | null> => {
+    try {
+      return mapScanResult(await req(`/projects/${encodeURIComponent(key)}/analysis`))
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) return null
+      throw e
+    }
+  },
 
   // the engagement's code-quality report (inventory + findings + duplication + A-E ratings). Computed
   // over an in-scope local source directory; an engagement without one returns available=false. 404 (the
@@ -741,39 +815,7 @@ export const api = {
       throw e
     }
     if (!r?.available || !r.report) return { available: false, reason: r?.reason }
-    const rep = r.report
-    return {
-      available: true,
-      report: {
-        inventory: (rep.inventory?.languages ?? []).map((l: any) => ({
-          language: l.language,
-          files: l.files ?? 0,
-          codeLines: l.code_lines ?? 0,
-          commentLines: l.comment_lines ?? 0,
-          blankLines: l.blank_lines ?? 0,
-          functions: l.functions ?? 0,
-          functionsKnown: !!l.functions_known,
-        })),
-        findings: (rep.findings ?? []).map(mapFinding),
-        duplication: {
-          blocks: (rep.duplication?.blocks ?? []).map((b: any) => ({
-            tokens: b.tokens ?? 0,
-            occurrences: (b.occurrences ?? []).map((o: any) => ({ file: o.file, startLine: o.start_line ?? 0, endLine: o.end_line ?? 0 })),
-          })),
-          duplicatedLines: rep.duplication?.duplicated_lines ?? 0,
-          totalLines: rep.duplication?.total_lines ?? 0,
-          files: rep.duplication?.files ?? 0,
-        },
-        rating: {
-          security: (rep.rating?.security ?? 'A') as CodeRating['security'],
-          reliability: (rep.rating?.reliability ?? 'A') as CodeRating['reliability'],
-          maintainability: (rep.rating?.maintainability ?? 'A') as CodeRating['maintainability'],
-          techDebtMinutes: rep.rating?.tech_debt_minutes ?? 0,
-          debtRatioPct: rep.rating?.debt_ratio_pct ?? 0,
-          linesOfCode: rep.rating?.lines_of_code ?? 0,
-        },
-      },
-    }
+    return { available: true, report: mapCodeQualityReport(r.report) }
   },
 
   // the engagement's architecture threat model (DFD). 404 (not ingested) → null.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -294,6 +294,7 @@ export interface ScanResult {
   licenseCoverage: LicenseCoverage
   manifest: ScanManifest
   findingQuality: FindingQuality
+  codeQuality?: CodeQualityReport
   debugEvents: ScanDebugEvent[]
 }
 

--- a/web/src/pages/CodeQualityProject.tsx
+++ b/web/src/pages/CodeQualityProject.tsx
@@ -1,25 +1,85 @@
-import { ArrowLeft, FolderGit2, Gauge, GitBranch } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { AlertTriangle, ArrowLeft, FolderGit2, Gauge, GitBranch, Play, ShieldAlert } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { Link, useLocation, useParams } from 'react-router-dom'
 import { CodeQualityReportView } from '../components/codequality/CodeQualityReportView'
-import { Card, EmptyState, ErrorState, Pill, Spinner } from '../components/ui'
+import { Button, Card, EmptyState, ErrorState, Pill, Spinner } from '../components/ui'
 import { api } from '../lib/api'
-import type { Project } from '../lib/types'
+import type { Project, ScanJob, ScanResult } from '../lib/types'
 
 export function CodeQualityProject() {
   const { key = '' } = useParams()
+  const location = useLocation()
+  const startError = (location.state as { analysisStartError?: string } | null)?.analysisStartError
   const [project, setProject] = useState<Project | null | undefined>(undefined)
+  const [job, setJob] = useState<ScanJob | null>(null)
+  const [analysis, setAnalysis] = useState<ScanResult | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const poll = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  function stopPoll() {
+    if (poll.current) clearInterval(poll.current)
+    poll.current = null
+  }
+
+  async function refreshResult() {
+    try {
+      const result = await api.latestProjectAnalysis(key)
+      if (!result) throw new Error('Analysis completed but its result is unavailable')
+      setAnalysis(result)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load analysis result')
+    }
+  }
+
+  function startPoll() {
+    stopPoll()
+    poll.current = setInterval(async () => {
+      try {
+        const next = await api.projectAnalysisStatus(key)
+        if (!next) throw new Error('Analysis status is unavailable')
+        setJob(next)
+        if (next.status === 'running') return
+        stopPoll()
+        if (next.status === 'succeeded') await refreshResult()
+        else setError(next.error || 'Analysis failed')
+      } catch (e) {
+        stopPoll()
+        setError(e instanceof Error ? e.message : 'Failed to refresh analysis status')
+      }
+    }, 1500)
+  }
 
   useEffect(() => {
-    setProject(undefined)
-    setError(null)
-    api.getProject(key).then(setProject).catch((e) => setError(e instanceof Error ? e.message : 'Failed to load project'))
-  }, [key])
+    let live = true
+    setProject(undefined); setLoadError(null); setError(startError ?? null); setAnalysis(null); setJob(null)
+    Promise.all([api.getProject(key), api.projectAnalysisStatus(key), api.latestProjectAnalysis(key)])
+      .then(([nextProject, nextJob, nextAnalysis]) => {
+        if (!live) return
+        setProject(nextProject); setJob(nextJob); setAnalysis(nextAnalysis)
+        if (nextJob?.status === 'running') startPoll()
+        else if (nextJob?.status === 'failed') setError(nextJob.error || 'Analysis failed')
+      })
+      .catch((e) => { if (live) setLoadError(e instanceof Error ? e.message : 'Failed to load project') })
+    return () => { live = false; stopPoll() }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, startError])
 
-  if (error) return <div className="mx-auto max-w-6xl space-y-3"><ErrorState message={error} /><Link to="/code-quality" className="inline-flex items-center gap-1.5 text-sm text-branddim hover:underline"><ArrowLeft className="size-4" aria-hidden="true" /> All projects</Link></div>
+  async function run() {
+    setError(null)
+    try {
+      const next = await api.startProjectAnalysis(key)
+      setJob(next); startPoll()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to start analysis')
+    }
+  }
+
+  if (loadError && project === undefined) return <div className="mx-auto max-w-6xl space-y-3"><ErrorState message={loadError} /><Link to="/code-quality" className="inline-flex items-center gap-1.5 text-sm text-branddim hover:underline"><ArrowLeft className="size-4" aria-hidden="true" /> All projects</Link></div>
   if (project === undefined) return <Spinner label="Loading project…" />
   if (!project) return null
+  const running = job?.status === 'running'
+  const status = running ? 'Analyzing' : job?.status === 'failed' ? 'Failed' : analysis ? 'Analyzed' : 'Not analyzed'
 
   return (
     <div className="mx-auto max-w-6xl animate-fade-in">
@@ -29,47 +89,29 @@ export function CodeQualityProject() {
       <header className="bg-hero mb-6 rounded-xl border border-border p-6">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0">
-            <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-branddim">
-              <Gauge className="size-4" aria-hidden="true" />
-              Code Quality project
-            </div>
+            <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-branddim"><Gauge className="size-4" aria-hidden="true" />Code Quality project</div>
             <h1 className="truncate text-3xl font-bold tracking-tight">{project.name}</h1>
             <p className="mt-1.5 font-mono text-sm text-mutedfg">{project.key}</p>
           </div>
-          <Pill className="shrink-0 bg-elevated ring-1 ring-inset ring-border"><Gauge className="size-3" aria-hidden="true" /> Not analyzed</Pill>
+          <div className="flex items-center gap-2">
+            <Pill className="shrink-0 bg-elevated ring-1 ring-inset ring-border"><Gauge className="size-3" aria-hidden="true" /> {status}</Pill>
+            <Button variant="brand" loading={running} disabled={running} onClick={run}><Play className="size-4" aria-hidden="true" />{analysis ? 'Run again' : 'Run analysis'}</Button>
+          </div>
         </div>
         <dl className="mt-5 grid grid-cols-1 gap-4 border-t border-border pt-4 text-sm sm:grid-cols-2">
-          <div className="min-w-0">
-            <dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Source</dt>
-            <dd className="mt-1.5 flex min-w-0 items-center gap-2 text-foreground">
-              <FolderGit2 className="size-4 shrink-0 text-mutedfg" aria-hidden="true" />
-              <span className="capitalize">{project.sourceBinding.kind}</span>
-              <span className="truncate font-mono text-xs leading-5" title={project.sourceBinding.value}>{project.sourceBinding.value}</span>
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Quality gate</dt>
-            <dd className="mt-1.5 leading-5 text-foreground">{project.gateId || 'Default'}</dd>
-          </div>
-          {project.sourceBinding.ref && (
-            <div>
-              <dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Branch or tag</dt>
-              <dd className="mt-1.5 flex items-center gap-2 font-mono text-xs leading-5 text-foreground">
-                <GitBranch className="size-4 shrink-0 text-mutedfg" aria-hidden="true" />
-                {project.sourceBinding.ref}
-              </dd>
-            </div>
-          )}
+          <div className="min-w-0"><dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Source</dt><dd className="mt-1.5 flex min-w-0 items-center gap-2 text-foreground"><FolderGit2 className="size-4 shrink-0 text-mutedfg" aria-hidden="true" /><span className="capitalize">{project.sourceBinding.kind}</span><span className="truncate font-mono text-xs leading-5" title={project.sourceBinding.value}>{project.sourceBinding.value}</span></dd></div>
+          <div><dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Quality gate</dt><dd className="mt-1.5 leading-5 text-foreground">{project.gateId || 'Default'}</dd></div>
+          {project.sourceBinding.ref && <div><dt className="text-[10px] font-semibold uppercase tracking-[0.12em] text-subtlefg">Branch or tag</dt><dd className="mt-1.5 flex items-center gap-2 font-mono text-xs leading-5 text-foreground"><GitBranch className="size-4 shrink-0 text-mutedfg" aria-hidden="true" />{project.sourceBinding.ref}</dd></div>}
         </dl>
+        {running && <div className="mt-5"><div className="mb-1.5 flex items-center justify-between text-xs"><span className="capitalize text-foreground">{job.stage || 'starting'}…</span><span className="font-mono tabular-nums text-mutedfg">{job.progress}%</span></div><div className="h-1.5 overflow-hidden rounded-full bg-elevated"><div className="h-full rounded-full bg-brand transition-[width] duration-500" style={{ width: `${Math.max(3, job.progress)}%` }} /></div></div>}
       </header>
-      <CodeQualityReportView
-        report={undefined}
-        empty={
-          <Card title="Analysis">
-            <EmptyState icon={Gauge} title="No analyses yet" hint="This project’s source and quality gate are configured. Source acquisition and analysis execution arrive in the next Code Quality phase." />
-          </Card>
-        }
-      />
+      {error && <div className="mb-6"><ErrorState message={error} /></div>}
+      {analysis && <Card title="Security analysis" className="mb-6"><div className="grid grid-cols-2 gap-3 sm:grid-cols-4"><SecurityMetric label="Findings" value={analysis.findings.length} /><SecurityMetric label="Vulnerabilities" value={analysis.vulnerabilities.length} /><SecurityMetric label="Packages" value={analysis.components.length} /><SecurityMetric label="License issues" value={analysis.licenses.filter((l) => l.verdict !== 'allow').length} /></div>{analysis.completeness.warning && <p className="mt-4 flex items-start gap-2 text-xs text-medium"><AlertTriangle className="mt-0.5 size-4 shrink-0" />{analysis.completeness.warning}</p>}</Card>}
+      <CodeQualityReportView report={analysis?.codeQuality} empty={<Card title="Analysis"><EmptyState icon={running ? Gauge : ShieldAlert} title={running ? 'Analysis in progress' : 'No analyses yet'} hint={running ? 'Source acquisition and the unified quality + security pipeline are running.' : 'Run the project analysis to produce findings and metrics.'} /></Card>} />
     </div>
   )
+}
+
+function SecurityMetric({ label, value }: { label: string; value: number }) {
+  return <div className="rounded-lg border border-border bg-bg px-4 py-3"><div className="font-mono text-2xl font-semibold tabular-nums">{value.toLocaleString()}</div><div className="text-xs text-mutedfg">{label}</div></div>
 }

--- a/web/src/pages/CodeQualityProjects.test.tsx
+++ b/web/src/pages/CodeQualityProjects.test.tsx
@@ -5,14 +5,18 @@ import { api } from '../lib/api'
 import { CodeQualityProject } from './CodeQualityProject'
 import { CodeQualityProjects } from './CodeQualityProjects'
 
-vi.mock('../lib/api', () => ({ api: { listProjects: vi.fn(), createProject: vi.fn(), getProject: vi.fn() } }))
+vi.mock('../lib/api', () => ({ api: { listProjects: vi.fn(), createProject: vi.fn(), createProjectFromArchive: vi.fn(), getProject: vi.fn(), startProjectAnalysis: vi.fn(), projectAnalysisStatus: vi.fn(), latestProjectAnalysis: vi.fn() } }))
 
 const project = { id: 'p1', name: 'Synapse', key: 'synapse', sourceBinding: { kind: 'git' as const, value: 'https://example.com/repo.git', ref: 'main' }, defaultProfileByLang: {}, gateId: '', createdAt: null }
 
 function renderList() { return render(<MemoryRouter><CodeQualityProjects /></MemoryRouter>) }
 
 describe('Code Quality projects', () => {
-  beforeEach(() => { vi.resetAllMocks() })
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.projectAnalysisStatus).mockResolvedValue(null)
+    vi.mocked(api.latestProjectAnalysis).mockResolvedValue(null)
+  })
 
   it('renders loading, empty, and list states', async () => {
     vi.mocked(api.listProjects).mockReturnValue(new Promise(() => {}))
@@ -33,18 +37,19 @@ describe('Code Quality projects', () => {
     expect(await screen.findByText('No code quality projects yet')).toBeInTheDocument()
   })
 
-  it('renders project ratings as not analyzed', async () => {
+  it('renders the latest project analysis status', async () => {
     vi.mocked(api.listProjects).mockResolvedValue([project])
+    vi.mocked(api.projectAnalysisStatus).mockResolvedValue({ id: 'j1', engagementId: '', target: project.sourceBinding.value, kind: 'git', status: 'succeeded', stage: 'done', progress: 100, error: '', startedAt: null, finishedAt: null, debugEvents: [] })
     renderList()
     expect(await screen.findByRole('heading', { name: 'Synapse' })).toBeInTheDocument()
-    expect(screen.getByText('Not analyzed')).toBeInTheDocument()
+    expect(await screen.findByText('Analyzed')).toBeInTheDocument()
     expect(screen.getByText('Open project')).toBeInTheDocument()
-    expect(screen.queryByLabelText('Quality ratings unavailable')).not.toBeInTheDocument()
   })
 
   it('creates and navigates to the shell', async () => {
     vi.mocked(api.listProjects).mockResolvedValue([])
     vi.mocked(api.createProject).mockResolvedValue(project)
+    vi.mocked(api.startProjectAnalysis).mockResolvedValue({ id: 'j1', engagementId: 'e1', target: project.sourceBinding.value, kind: 'git', status: 'running', stage: 'queued', progress: 0, error: '', startedAt: null, finishedAt: null, debugEvents: [] })
     render(
       <MemoryRouter initialEntries={['/code-quality']}>
         <Routes><Route path="/code-quality" element={<CodeQualityProjects />} /><Route path="/code-quality/projects/:key" element={<div>Project shell route</div>} /></Routes>
@@ -58,8 +63,32 @@ describe('Code Quality projects', () => {
     fireEvent.change(screen.getByLabelText('Source'), { target: { value: 'https://example.com/repo.git' } })
     fireEvent.click(screen.getByRole('button', { name: /Create project/i }))
     await waitFor(() => expect(api.createProject).toHaveBeenCalledWith(expect.objectContaining({ key: 'synapse' })))
+    expect(api.startProjectAnalysis).toHaveBeenCalledWith('synapse')
     expect(await screen.findByText('Project shell route')).toBeInTheDocument()
   })
+
+  it('navigates to the created project when auto-start fails', async () => {
+    vi.mocked(api.listProjects).mockResolvedValue([])
+    vi.mocked(api.createProject).mockResolvedValue(project)
+    vi.mocked(api.getProject).mockResolvedValue(project)
+    vi.mocked(api.startProjectAnalysis).mockRejectedValue(new Error('Scanner unavailable'))
+    render(
+      <MemoryRouter initialEntries={['/code-quality']}>
+        <Routes>
+          <Route path="/code-quality" element={<CodeQualityProjects />} />
+          <Route path="/code-quality/projects/:key" element={<CodeQualityProject />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: /New project/i }))
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Synapse' } })
+    fireEvent.change(screen.getByLabelText('Source'), { target: { value: 'https://example.com/repo.git' } })
+    fireEvent.click(screen.getByRole('button', { name: /Create project/i }))
+    expect(await screen.findByRole('heading', { name: 'Synapse' })).toBeInTheDocument()
+    expect(screen.getByText('Scanner unavailable')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Run analysis/i })).toBeInTheDocument()
+  })
+
 
   it('renders an honest project shell empty state', async () => {
     vi.mocked(api.getProject).mockResolvedValue(project)

--- a/web/src/pages/CodeQualityProjects.test.tsx
+++ b/web/src/pages/CodeQualityProjects.test.tsx
@@ -46,6 +46,34 @@ describe('Code Quality projects', () => {
     expect(screen.getByText('Open project')).toBeInTheDocument()
   })
 
+  it('renders not analyzed only for a missing status', async () => {
+    vi.mocked(api.listProjects).mockResolvedValue([project])
+    renderList()
+    expect(await screen.findByText('Not analyzed')).toBeInTheDocument()
+  })
+
+  it('keeps projects visible when a status fetch fails', async () => {
+    vi.mocked(api.listProjects).mockResolvedValue([project])
+    vi.mocked(api.projectAnalysisStatus).mockRejectedValue(new Error('Status unavailable'))
+    renderList()
+    expect(await screen.findByText('Status unavailable')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Synapse' })).toBeInTheDocument()
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+    expect(screen.queryByText('Not analyzed')).not.toBeInTheDocument()
+  })
+
+  it('adds a visible focus style to the archive picker', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { configurable: true, value: vi.fn() })
+    vi.mocked(api.listProjects).mockResolvedValue([])
+    renderList()
+    fireEvent.click(await screen.findByRole('button', { name: /New project/i }))
+    fireEvent.click(screen.getByRole('combobox', { name: 'Source kind' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'Upload archive' }))
+    const picker = screen.getByRole('button', { name: /Drop an archive here or choose a file/i })
+    expect(picker).toHaveClass('focus-visible:outline-none', 'focus-visible:ring-2', 'focus-visible:ring-brand/60', 'focus-visible:ring-offset-2', 'focus-visible:ring-offset-bg')
+  })
+
   it('creates and navigates to the shell', async () => {
     vi.mocked(api.listProjects).mockResolvedValue([])
     vi.mocked(api.createProject).mockResolvedValue(project)

--- a/web/src/pages/CodeQualityProjects.tsx
+++ b/web/src/pages/CodeQualityProjects.tsx
@@ -9,17 +9,27 @@ const allowLocalSource = import.meta.env.DEV
 
 export function CodeQualityProjects() {
   const [projects, setProjects] = useState<Project[] | null>(null)
-  const [statuses, setStatuses] = useState<Record<string, ScanJob | null>>({})
+  const [statuses, setStatuses] = useState<Record<string, ScanJob | null | Error>>({})
   const [error, setError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
 
   function load() {
     setError(null)
+    setProjects(null)
+    setStatuses({})
     api.listProjects()
       .then(async (next) => {
         setProjects(next)
-        const entries = await Promise.all(next.map(async (project) => [project.key, await api.projectAnalysisStatus(project.key).catch(() => null)] as const))
+        const entries = await Promise.all(next.map(async (project) => {
+          try {
+            return [project.key, await api.projectAnalysisStatus(project.key)] as const
+          } catch (error) {
+            return [project.key, error instanceof Error ? error : new Error('Status unavailable')] as const
+          }
+        }))
         setStatuses(Object.fromEntries(entries))
+        const failed = entries.map(([, status]) => status).find((status): status is Error => status instanceof Error)
+        if (failed) setError(failed.message)
       })
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load projects'))
   }
@@ -56,8 +66,8 @@ export function CodeQualityProjects() {
   )
 }
 
-function ProjectCard({ project, job }: { project: Project; job?: ScanJob | null }) {
-  const status = job?.status === 'running' ? 'Analyzing' : job?.status === 'succeeded' ? 'Analyzed' : job?.status === 'failed' ? 'Failed' : 'Not analyzed'
+function ProjectCard({ project, job }: { project: Project; job?: ScanJob | null | Error }) {
+  const status = job instanceof Error ? 'Unknown' : job?.status === 'running' ? 'Analyzing' : job?.status === 'succeeded' ? 'Analyzed' : job?.status === 'failed' ? 'Failed' : 'Not analyzed'
   return (
     <Link to={`/code-quality/projects/${encodeURIComponent(project.key)}`} className="lift card-sheen elev group flex min-h-64 flex-col rounded-xl border border-border bg-card p-5 transition-colors hover:border-brand/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50">
       <div className="flex items-start justify-between gap-3">
@@ -151,7 +161,7 @@ function CreateProjectForm() {
           {kind === 'archive' ? (
             <Field label="Source archive" htmlFor="project-archive" hint=".zip, .tar.gz, or .tgz · max 512 MiB">
               <input ref={archiveInput} id="project-archive" type="file" accept=".zip,.tar.gz,.tgz" className="sr-only" onChange={(e) => { chooseArchive(e.target.files?.[0]); e.target.value = '' }} />
-              <button type="button" onClick={() => archiveInput.current?.click()} onDragEnter={(e) => { e.preventDefault(); setDragging(true) }} onDragOver={(e) => e.preventDefault()} onDragLeave={() => setDragging(false)} onDrop={(e) => { e.preventDefault(); setDragging(false); chooseArchive(e.dataTransfer.files[0]) }} className={`flex min-h-20 w-full items-center justify-center gap-2 rounded-lg border border-dashed px-4 text-sm transition-colors ${dragging ? 'border-brand bg-brand/10 text-foreground' : 'border-border bg-elevated text-mutedfg hover:border-brand/50'}`}>
+              <button type="button" onClick={() => archiveInput.current?.click()} onDragEnter={(e) => { e.preventDefault(); setDragging(true) }} onDragOver={(e) => e.preventDefault()} onDragLeave={() => setDragging(false)} onDrop={(e) => { e.preventDefault(); setDragging(false); chooseArchive(e.dataTransfer.files[0]) }} className={`flex min-h-20 w-full items-center justify-center gap-2 rounded-lg border border-dashed px-4 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${dragging ? 'border-brand bg-brand/10 text-foreground' : 'border-border bg-elevated text-mutedfg hover:border-brand/50'}`}>
                 <Upload className="size-4" aria-hidden="true" />
                 {archive ? `${archive.name} (${(archive.size / 1024 / 1024).toFixed(1)} MiB)` : 'Drop an archive here or choose a file'}
               </button>

--- a/web/src/pages/CodeQualityProjects.tsx
+++ b/web/src/pages/CodeQualityProjects.tsx
@@ -1,18 +1,27 @@
-import { ArrowRight, FolderGit2, Gauge, GitBranch, Plus, X } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { ArrowRight, FolderGit2, Gauge, GitBranch, Plus, Upload, X } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { api } from '../lib/api'
-import type { Project, ProjectSourceKind } from '../lib/types'
+import type { Project, ProjectSourceKind, ScanJob } from '../lib/types'
 import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Select, Spinner } from '../components/ui'
+
+const allowLocalSource = import.meta.env.DEV
 
 export function CodeQualityProjects() {
   const [projects, setProjects] = useState<Project[] | null>(null)
+  const [statuses, setStatuses] = useState<Record<string, ScanJob | null>>({})
   const [error, setError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
 
   function load() {
     setError(null)
-    api.listProjects().then(setProjects).catch((e) => setError(e instanceof Error ? e.message : 'Failed to load projects'))
+    api.listProjects()
+      .then(async (next) => {
+        setProjects(next)
+        const entries = await Promise.all(next.map(async (project) => [project.key, await api.projectAnalysisStatus(project.key).catch(() => null)] as const))
+        setStatuses(Object.fromEntries(entries))
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load projects'))
   }
   useEffect(load, [])
 
@@ -36,18 +45,19 @@ export function CodeQualityProjects() {
       {error && <div className="space-y-3"><ErrorState message={error} /><Button variant="secondary" onClick={load}>Retry</Button></div>}
       {!projects && !error && <Spinner label="Loading projects…" />}
       {projects && projects.length === 0 && !creating && (
-        <EmptyState icon={FolderGit2} title="No code quality projects yet" hint="Create a project to define its source. Project analyses arrive in the next Code Quality phase." action={<Button variant="brand" onClick={() => setCreating(true)}><Plus className="size-4" aria-hidden="true" /> New project</Button>} />
+        <EmptyState icon={FolderGit2} title="No code quality projects yet" hint={`Create a project from Git${allowLocalSource ? ', a server-local path,' : ''} or an uploaded archive. Its first analysis starts automatically.`} action={<Button variant="brand" onClick={() => setCreating(true)}><Plus className="size-4" aria-hidden="true" /> New project</Button>} />
       )}
       {projects && projects.length > 0 && (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-          {projects.map((project) => <ProjectCard key={project.id} project={project} />)}
+          {projects.map((project) => <ProjectCard key={project.id} project={project} job={statuses[project.key]} />)}
         </div>
       )}
     </div>
   )
 }
 
-function ProjectCard({ project }: { project: Project }) {
+function ProjectCard({ project, job }: { project: Project; job?: ScanJob | null }) {
+  const status = job?.status === 'running' ? 'Analyzing' : job?.status === 'succeeded' ? 'Analyzed' : job?.status === 'failed' ? 'Failed' : 'Not analyzed'
   return (
     <Link to={`/code-quality/projects/${encodeURIComponent(project.key)}`} className="lift card-sheen elev group flex min-h-64 flex-col rounded-xl border border-border bg-card p-5 transition-colors hover:border-brand/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50">
       <div className="flex items-start justify-between gap-3">
@@ -56,7 +66,7 @@ function ProjectCard({ project }: { project: Project }) {
           <h2 className="truncate text-lg font-semibold text-foreground">{project.name}</h2>
           <p className="mt-1 truncate font-mono text-xs text-subtlefg">{project.key}</p>
         </div>
-        <Pill className="shrink-0 bg-elevated ring-1 ring-inset ring-border"><Gauge className="size-3" aria-hidden="true" /> Not analyzed</Pill>
+        <Pill className="shrink-0 bg-elevated ring-1 ring-inset ring-border"><Gauge className="size-3" aria-hidden="true" /> {status}</Pill>
       </div>
 
       <dl className="mt-6 flex-1 space-y-4 text-sm">
@@ -93,17 +103,37 @@ function CreateProjectForm() {
   const [kind, setKind] = useState<ProjectSourceKind>('git')
   const [value, setValue] = useState('')
   const [ref, setRef] = useState('')
+  const [archive, setArchive] = useState<File | null>(null)
+  const [dragging, setDragging] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
+  const archiveInput = useRef<HTMLInputElement>(null)
+
+  function chooseArchive(file: File | undefined) {
+    if (!file) return
+    const supported = /\.(zip|tgz|tar\.gz)$/i.test(file.name)
+    if (!supported) { setError('Choose a .zip, .tar.gz, or .tgz archive.'); return }
+    if (file.size > 512 * 1024 * 1024) { setError('Archive must be 512 MiB or smaller.'); return }
+    setArchive(file); setError(null)
+  }
 
   async function submit(event: React.FormEvent) {
     event.preventDefault()
-    if (!name.trim() || !key.trim() || !value.trim()) { setError('Name, key, and source are required.'); return }
+    if (!name.trim() || !key.trim() || (kind === 'archive' ? !archive : !value.trim())) { setError('Name, key, and source are required.'); return }
     setSubmitting(true); setError(null)
     try {
-      const project = await api.createProject({ name: name.trim(), key: key.trim(), sourceBinding: { kind, value: value.trim(), ref: kind === 'git' ? ref.trim() : '' } })
-      navigate(`/code-quality/projects/${encodeURIComponent(project.key)}`)
+      const project = kind === 'archive'
+        ? await api.createProjectFromArchive(name.trim(), key.trim(), archive!)
+        : await api.createProject({ name: name.trim(), key: key.trim(), sourceBinding: { kind, value: value.trim(), ref: kind === 'git' ? ref.trim() : '' } })
+      try {
+        await api.startProjectAnalysis(project.key)
+        navigate(`/code-quality/projects/${encodeURIComponent(project.key)}`)
+      } catch (e) {
+        navigate(`/code-quality/projects/${encodeURIComponent(project.key)}`, {
+          state: { analysisStartError: e instanceof Error ? e.message : 'Failed to start analysis' },
+        })
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create project')
     } finally { setSubmitting(false) }
@@ -117,8 +147,18 @@ function CreateProjectForm() {
           <Field label="Key" hint="Lowercase letters, numbers, and hyphens" htmlFor="project-key"><Input id="project-key" className="font-mono" value={key} onChange={(e) => { setKeyEdited(true); setKey(e.target.value) }} placeholder="synapse-ce" /></Field>
         </div>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-[10rem_1fr]">
-          <Field label="Source kind" htmlFor="project-source-kind"><Select id="project-source-kind" value={kind} onValueChange={(next) => setKind(next as ProjectSourceKind)} ariaLabel="Source kind" className="w-full" options={[{ value: 'git', label: 'Git URL' }, { value: 'local', label: 'Local path' }, { value: 'archive', label: 'Archive path' }]} /></Field>
-          <Field label="Source" htmlFor="project-source"><Input id="project-source" className="font-mono" value={value} onChange={(e) => setValue(e.target.value)} placeholder={kind === 'git' ? 'https://github.com/acme/app.git' : '/path/to/source'} /></Field>
+          <Field label="Source kind" htmlFor="project-source-kind"><Select id="project-source-kind" value={kind} onValueChange={(next) => { setKind(next as ProjectSourceKind); setArchive(null); setError(null) }} ariaLabel="Source kind" className="w-full" options={[{ value: 'git', label: 'Git URL' }, ...(allowLocalSource ? [{ value: 'local', label: 'Local path' }] : []), { value: 'archive', label: 'Upload archive' }]} /></Field>
+          {kind === 'archive' ? (
+            <Field label="Source archive" htmlFor="project-archive" hint=".zip, .tar.gz, or .tgz · max 512 MiB">
+              <input ref={archiveInput} id="project-archive" type="file" accept=".zip,.tar.gz,.tgz" className="sr-only" onChange={(e) => { chooseArchive(e.target.files?.[0]); e.target.value = '' }} />
+              <button type="button" onClick={() => archiveInput.current?.click()} onDragEnter={(e) => { e.preventDefault(); setDragging(true) }} onDragOver={(e) => e.preventDefault()} onDragLeave={() => setDragging(false)} onDrop={(e) => { e.preventDefault(); setDragging(false); chooseArchive(e.dataTransfer.files[0]) }} className={`flex min-h-20 w-full items-center justify-center gap-2 rounded-lg border border-dashed px-4 text-sm transition-colors ${dragging ? 'border-brand bg-brand/10 text-foreground' : 'border-border bg-elevated text-mutedfg hover:border-brand/50'}`}>
+                <Upload className="size-4" aria-hidden="true" />
+                {archive ? `${archive.name} (${(archive.size / 1024 / 1024).toFixed(1)} MiB)` : 'Drop an archive here or choose a file'}
+              </button>
+            </Field>
+          ) : (
+            <Field label="Source" htmlFor="project-source"><Input id="project-source" className="font-mono" value={value} onChange={(e) => setValue(e.target.value)} placeholder={kind === 'git' ? 'https://github.com/acme/app.git' : '/path/to/source'} /></Field>
+          )}
         </div>
         {kind === 'git' && <Field label="Branch or tag" hint="Optional; uses the default branch when empty" htmlFor="project-ref"><Input id="project-ref" className="font-mono" value={ref} onChange={(e) => setRef(e.target.value)} placeholder="main" /></Field>}
         {error && <ErrorState message={error} />}


### PR DESCRIPTION
## Summary
<img width="1571" height="917" alt="image" src="https://github.com/user-attachments/assets/c44c8df8-76e2-4e49-ae47-fce9ec9d348e" />


Closes #176 by making Code Quality projects ingestible and analyzable from the dashboard. Operators can create a project from a Git URL (with an optional ref), a bounded archive upload, or a development-only local path, then start and monitor a unified security and code-quality analysis without exposing the internal engagement used to enforce governance.

The implementation reuses the existing hardened acquisition and async SCA pipeline rather than adding a second scanner. Archive extraction remains bounded and zip-slip-safe through the existing acquirer; the new upload store only accepts `.zip`, `.tar.gz`, and `.tgz` archives and limits retained uploads to the configured workspace cap.

## Changes

### Project source ingest

- Adds multipart project creation for archive uploads, alongside the existing JSON project creation endpoint.
- Supports Git URL sources with an optional branch/tag/ref, uploaded `.zip`/`.tar.gz`/`.tgz` archives, and local paths only outside production.
- Adds a file-backed `ProjectArchiveStore` that validates extensions, caps upload size, writes through a temporary file, publishes atomically, and removes retained archives when a project is deleted.
- Adds `SYNAPSE_PROJECT_UPLOAD_DIR` configuration and a persistent upload volume in the API image.
- Keeps `deploy/docker-compose.full.yml` intentionally out of this PR as requested.

### Governed async analysis

- Creates one hidden project-analysis engagement per project and persists its project association through migration `0046_project_analysis_context.sql`.
- Keeps hidden project-analysis engagements out of ordinary engagement reads and lists while allowing project-scoped lookup internally.
- Adds `POST /api/v1/projects/{key}/analyses`, `GET /api/v1/projects/{key}/analysis-status`, and `GET /api/v1/projects/{key}/analysis`.
- Runs the existing source acquisition, scope/window enforcement, async scan-job runner, findings persistence, scan-result cache, and code-quality report generation.
- Rejects duplicate starts while a project analysis is running and does not leak the hidden engagement ID in the project-analysis API response.

### Dashboard and documentation

- Adds the project source picker, Git ref input, archive drag/drop picker, client-side archive-size/type validation, initial-analysis start, status cards, polling progress, retry/run-again control, security metrics, and code-quality result rendering.
- Documents how `synapse-cli scan` maps to the project-analysis workflow and records the user-visible capability in `CHANGELOG.md`.
- Adds and updates handler, service, archive-store, SCA, RBAC, and frontend tests.

## Verification

- `make build` ✅
- `make test` ✅
- `make vet` ✅
- `corepack pnpm --dir web run typecheck` ✅
- `corepack pnpm --dir web build` ✅
- `git diff --check` ✅
- Exercised the running API with an isolated archive upload: accepted the AUP, uploaded a `.zip`, created the project, started `POST /projects/{key}/analyses`, observed the async job reach `succeeded`, and retrieved the persisted analysis from `GET /projects/{key}/analysis`.
- Probed an unsupported `.rar` upload and received `400 validation error: uploaded source must be .zip, .tar.gz, or .tgz`.
- Probed a nonexistent project analysis status endpoint and received `404 get project: not found`.

## Checklist

- [x] `make build vet test typecheck` passes
- [x] `cd web && pnpm build` passes (dashboard changed)
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets out of logs, deterministic reports, append-only evidence) – see `CONTRIBUTING.md`
- [x] Documentation updated if needed (cli.md)