### PR TITLE
Feat/179 a hotspot projection api

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -326,6 +326,79 @@ paths:
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalServerError" }
 
+  /api/v1/projects/{key}/hotspots:
+    parameters:
+      - name: key
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      tags: [projects]
+      summary: List Project Security Hotspot projections
+      operationId: listProjectHotspots
+      description: >
+        Returns catalog-classified Project Security Hotspots without loading a
+        full scan-result blob. This PR is read-only; review transitions are not
+        exposed here.
+      parameters:
+        - name: status
+          in: query
+          schema: { $ref: "#/components/schemas/ProjectHotspotStatus" }
+        - name: rule
+          in: query
+          schema: { type: string, maxLength: 256 }
+        - name: severity
+          in: query
+          schema: { $ref: "#/components/schemas/ProjectHotspotSeverity" }
+        - name: search
+          in: query
+          schema: { type: string, maxLength: 256 }
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 100, default: 25 }
+        - name: before_last_seen_at
+          in: query
+          schema: { type: string, format: date-time }
+        - name: before_id
+          in: query
+          schema: { type: string }
+      responses:
+        "200":
+          description: Project hotspot page
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ProjectHotspotPage" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalServerError" }
+
+  /api/v1/projects/{key}/hotspots/{id}:
+    parameters:
+      - name: key
+        in: path
+        required: true
+        schema: { type: string }
+      - name: id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      tags: [projects]
+      summary: Get one Project Security Hotspot projection
+      operationId: getProjectHotspot
+      responses:
+        "200":
+          description: Project hotspot
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ProjectHotspot" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalServerError" }
+
   /api/v1/rules:
     get:
       tags: [rules]
@@ -804,6 +877,77 @@ components:
           anyOf:
             - $ref: "#/components/schemas/ProjectOverviewUnavailableReason"
             - type: "null"
+
+    ProjectHotspotStatus:
+      type: string
+      enum: [to_review, acknowledged, fixed, safe]
+
+    ProjectHotspotSeverity:
+      type: string
+      enum: [low, medium, high, critical]
+
+    ProjectHotspot:
+      type: object
+      required:
+        - id
+        - rule_key
+        - rule_name
+        - title
+        - description
+        - severity
+        - finding_kind
+        - cwe
+        - location
+        - status
+        - version
+        - first_seen_analysis_id
+        - last_seen_analysis_id
+        - first_seen_at
+        - last_seen_at
+      properties:
+        id: { type: string }
+        rule_key: { type: string }
+        rule_name: { type: string }
+        title: { type: string }
+        description: { type: string }
+        severity: { $ref: "#/components/schemas/ProjectHotspotSeverity" }
+        finding_kind: { type: string }
+        cwe: { type: string }
+        location: { type: string }
+        status: { $ref: "#/components/schemas/ProjectHotspotStatus" }
+        version: { type: integer, minimum: 1 }
+        first_seen_analysis_id: { type: string }
+        last_seen_analysis_id: { type: string }
+        first_seen_at: { type: string, format: date-time }
+        last_seen_at: { type: string, format: date-time }
+
+    ProjectHotspotCursor:
+      type: object
+      required: [before_last_seen_at, before_id]
+      properties:
+        before_last_seen_at: { type: string, format: date-time }
+        before_id: { type: string }
+
+    ProjectHotspotFacets:
+      type: object
+      required: [statuses, rule_keys, severities]
+      properties:
+        statuses: { type: object, additionalProperties: { type: integer, minimum: 0 } }
+        rule_keys: { type: object, additionalProperties: { type: integer, minimum: 0 } }
+        severities: { type: object, additionalProperties: { type: integer, minimum: 0 } }
+
+    ProjectHotspotPage:
+      type: object
+      required: [items, next, facets]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/ProjectHotspot" }
+        next:
+          anyOf:
+            - $ref: "#/components/schemas/ProjectHotspotCursor"
+            - type: "null"
+        facets: { $ref: "#/components/schemas/ProjectHotspotFacets" }
 
     RuleType:
       type: string

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -884,7 +884,7 @@ components:
 
     ProjectHotspotSeverity:
       type: string
-      enum: [low, medium, high, critical]
+      enum: [unknown, info, low, medium, high, critical]
 
     ProjectHotspot:
       type: object

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -344,11 +344,23 @@ func main() {
 	projectService := projectuc.NewService(projectRepo, repo, clock, ids, auditLog, !cfg.IsProduction())
 	projectService.SetArchiveStore(file.NewProjectArchiveStore(cfg.ProjectUploadDir, cfg.MaxWorkspaceBytes))
 	projectService.SetAnalysisStore(projectAnalysisStore)
+	if hotspotStore, ok := projectAnalysisStore.(ports.ProjectHotspotStore); ok {
+		projectService.SetHotspotStore(hotspotStore)
+	} else {
+		log.Error("project hotspot store is not configured")
+		os.Exit(1)
+	}
 	projectService.SetFindingRepository(findingRepo)
 	qualityGateService := qualitygatesuc.NewService(qualityGateStore, auditLog, clock)
 	qualityGateService.SetMutator(qualityGateMutator)
 	projectService.SetQualityGates(qualityGateService)
 	projectService.SetQualityGateMutator(qualityGateMutator)
+	ruleCatalog, catalogErr := rulecatalog.Default()
+	if catalogErr != nil {
+		log.Error("rule catalog init failed", "err", catalogErr)
+		os.Exit(1)
+	}
+	projectService.SetRuleCatalog(ruleCatalog)
 	// Evidence artifact blob store: MinIO/S3 when configured, else in-memory (dev).
 	var blobStore ports.BlobStore
 	if cfg.BlobEndpoint != "" {
@@ -871,10 +883,7 @@ func main() {
 	)
 	router.SetCodeQuality(codeQualityService)
 	scaService.SetCodeQuality(codeQualityService)
-	if ruleCat, rerr := rulecatalog.Default(); rerr != nil {
-		log.Error("rule catalog init failed", "err", rerr)
-		os.Exit(1)
-	} else if rulesSvc, rerr := rules.NewService(ruleCat); rerr != nil {
+	if rulesSvc, rerr := rules.NewService(ruleCatalog); rerr != nil {
 		log.Error("rules service init failed", "err", rerr)
 		os.Exit(1)
 	} else {

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -121,6 +121,7 @@ func TestHostileHarness(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed project: %v", err)
 	}
+	projectSvc.SetHotspotStore(memory.NewProjectAnalysisStore())
 	usersSvc, err := usersuc.NewService(memory.NewUserRepository(), &fakeAudit{}, fixedClock{}, engIDs{})
 	if err != nil {
 		t.Fatalf("users svc: %v", err)
@@ -173,6 +174,8 @@ func TestHostileHarness(t *testing.T) {
 		{"readonly may list projects", "readonly", "tenantA", true, http.MethodGet, "/api/v1/projects", http.StatusOK},
 		{"readonly may get own-tenant project", "readonly", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusOK},
 		{"readonly may read project analysis status", "readonly", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a/analysis-status", http.StatusNotFound},
+		{"readonly may list project hotspots", "readonly", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a/hotspots", http.StatusOK},
+		{"machine may not list project hotspots", "agent", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a/hotspots", http.StatusForbidden},
 		// RBAC deny: readonly holds only view.
 		{"readonly may not create (operate)", "readonly", "tenantA", true, http.MethodPost, "/api/v1/engagements", http.StatusForbidden},
 		{"readonly may not create project (operate)", "readonly", "tenantA", true, http.MethodPost, "/api/v1/projects", http.StatusForbidden},
@@ -198,6 +201,7 @@ func TestHostileHarness(t *testing.T) {
 		{"same-tenant engagement read → 200", "consultant", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA", http.StatusOK},
 		{"cross-tenant project read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusNotFound},
 		{"cross-tenant project analysis → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/projects/project-a/analysis", http.StatusNotFound},
+		{"cross-tenant project hotspots → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/projects/project-a/hotspots", http.StatusNotFound},
 		{"same-tenant project read → 200", "consultant", "tenantA", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusOK},
 		// Sign-off routes (PermReview) – the crown-jewel separation-of-duties gates. A machine role
 		// can never verify a finding nor decide an agent approval; a consultant lacks review; a

--- a/internal/adapter/httpapi/project_handler.go
+++ b/internal/adapter/httpapi/project_handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
@@ -32,6 +33,8 @@ type projectService interface {
 	Overview(context.Context, shared.ID, string) (projectuc.Overview, error)
 	ListAnalyses(context.Context, shared.ID, string, int, time.Time, shared.ID) ([]projectanalysis.Analysis, bool, error)
 	GetAnalysis(context.Context, shared.ID, string, string) (projectanalysis.Analysis, error)
+	ListHotspots(context.Context, shared.ID, string, hotspot.ListFilter) (hotspot.Page, error)
+	GetHotspot(context.Context, shared.ID, string, shared.ID) (hotspot.Hotspot, error)
 }
 
 func (rt *Router) SetProjects(s projectService) { rt.projects = s }

--- a/internal/adapter/httpapi/project_hotspot_handler.go
+++ b/internal/adapter/httpapi/project_hotspot_handler.go
@@ -1,0 +1,152 @@
+package httpapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type projectHotspotResponse struct {
+	ID                  string    `json:"id"`
+	RuleKey             string    `json:"rule_key"`
+	RuleName            string    `json:"rule_name"`
+	Title               string    `json:"title"`
+	Description         string    `json:"description"`
+	Severity            string    `json:"severity"`
+	FindingKind         string    `json:"finding_kind"`
+	CWE                 string    `json:"cwe"`
+	Location            string    `json:"location"`
+	Status              string    `json:"status"`
+	Version             int       `json:"version"`
+	FirstSeenAnalysisID string    `json:"first_seen_analysis_id"`
+	LastSeenAnalysisID  string    `json:"last_seen_analysis_id"`
+	FirstSeenAt         time.Time `json:"first_seen_at"`
+	LastSeenAt          time.Time `json:"last_seen_at"`
+}
+
+type projectHotspotCursorResponse struct {
+	BeforeLastSeenAt time.Time `json:"before_last_seen_at"`
+	BeforeID         string    `json:"before_id"`
+}
+
+type projectHotspotFacetsResponse struct {
+	Statuses   map[string]int `json:"statuses"`
+	RuleKeys   map[string]int `json:"rule_keys"`
+	Severities map[string]int `json:"severities"`
+}
+
+type projectHotspotPageResponse struct {
+	Items  []projectHotspotResponse      `json:"items"`
+	Next   *projectHotspotCursorResponse `json:"next"`
+	Facets projectHotspotFacetsResponse  `json:"facets"`
+}
+
+var projectHotspotQueryParameters = map[string]bool{
+	"status": true, "rule": true, "severity": true, "search": true,
+	"limit": true, "before_last_seen_at": true, "before_id": true,
+}
+
+func (rt *Router) listProjectHotspots(w http.ResponseWriter, r *http.Request) {
+	filter, err := projectHotspotListParams(r)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	page, err := rt.projects.ListHotspots(r.Context(), shared.ID(TenantFrom(r.Context())), r.PathValue("key"), filter)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	out := projectHotspotPageResponse{
+		Items:  make([]projectHotspotResponse, len(page.Items)),
+		Facets: projectHotspotFacetsResponse{Statuses: page.Facets.Statuses, RuleKeys: page.Facets.RuleKeys, Severities: page.Facets.Severities},
+	}
+	for i, item := range page.Items {
+		out.Items[i] = rt.projectHotspotDTO(r.Context(), item)
+	}
+	if page.Next != nil {
+		out.Next = &projectHotspotCursorResponse{BeforeLastSeenAt: page.Next.BeforeLastSeenAt, BeforeID: page.Next.BeforeID.String()}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (rt *Router) getProjectHotspot(w http.ResponseWriter, r *http.Request) {
+	item, err := rt.projects.GetHotspot(r.Context(), shared.ID(TenantFrom(r.Context())), r.PathValue("key"), shared.ID(r.PathValue("id")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, rt.projectHotspotDTO(r.Context(), item))
+}
+
+func (rt *Router) projectHotspotDTO(ctx context.Context, item hotspot.Hotspot) projectHotspotResponse {
+	ruleName := ""
+	if rt.rules != nil {
+		if catalogRule, err := rt.rules.Get(ctx, rule.Key(item.RuleKey)); err == nil {
+			ruleName = catalogRule.Name
+		}
+	}
+	return projectHotspotResponse{
+		ID: item.ID.String(), RuleKey: item.RuleKey, RuleName: ruleName, Title: item.Title, Description: item.Description,
+		Severity: string(item.Severity), FindingKind: string(item.Kind), CWE: item.CWE, Location: item.Location,
+		Status: string(item.Status), Version: item.Version, FirstSeenAnalysisID: item.FirstSeenAnalysisID,
+		LastSeenAnalysisID: item.LastSeenAnalysisID, FirstSeenAt: item.FirstSeenAt, LastSeenAt: item.LastSeenAt,
+	}
+}
+
+func projectHotspotListParams(r *http.Request) (hotspot.ListFilter, error) {
+	for key := range r.URL.Query() {
+		if !projectHotspotQueryParameters[key] {
+			return hotspot.ListFilter{}, fmt.Errorf("%w: unsupported query parameter: %s", shared.ErrValidation, key)
+		}
+	}
+	q := r.URL.Query()
+	filter := hotspot.ListFilter{RuleKey: strings.TrimSpace(q.Get("rule")), Search: strings.TrimSpace(q.Get("search")), Limit: 25}
+	if filter.RuleKey != "" && utf8.RuneCountInString(filter.RuleKey) > 256 {
+		return hotspot.ListFilter{}, fmt.Errorf("%w: rule exceeds maximum length", shared.ErrValidation)
+	}
+	if utf8.RuneCountInString(filter.Search) > 256 {
+		return hotspot.ListFilter{}, fmt.Errorf("%w: search exceeds maximum length", shared.ErrValidation)
+	}
+	if raw := strings.TrimSpace(q.Get("status")); raw != "" {
+		status := hotspot.Status(raw)
+		if !status.Valid() {
+			return hotspot.ListFilter{}, fmt.Errorf("%w: invalid hotspot status", shared.ErrValidation)
+		}
+		filter.Status = &status
+	}
+	if raw := strings.TrimSpace(q.Get("severity")); raw != "" {
+		severity := shared.Severity(raw)
+		if !severity.Valid() || severity == shared.SeverityUnknown {
+			return hotspot.ListFilter{}, fmt.Errorf("%w: invalid hotspot severity", shared.ErrValidation)
+		}
+		filter.Severity = &severity
+	}
+	if raw := strings.TrimSpace(q.Get("limit")); raw != "" {
+		limit, err := strconv.Atoi(raw)
+		if err != nil || limit < 1 || limit > 100 {
+			return hotspot.ListFilter{}, fmt.Errorf("%w: limit must be between 1 and 100", shared.ErrValidation)
+		}
+		filter.Limit = limit
+	}
+	rawTime, rawID := strings.TrimSpace(q.Get("before_last_seen_at")), strings.TrimSpace(q.Get("before_id"))
+	if (rawTime == "") != (rawID == "") {
+		return hotspot.ListFilter{}, fmt.Errorf("%w: before_last_seen_at and before_id must be supplied together", shared.ErrValidation)
+	}
+	if rawTime != "" {
+		before, err := time.Parse(time.RFC3339Nano, rawTime)
+		if err != nil {
+			return hotspot.ListFilter{}, fmt.Errorf("%w: before_last_seen_at must be RFC3339", shared.ErrValidation)
+		}
+		filter.BeforeLastSeenAt, filter.BeforeID = before, shared.ID(rawID)
+	}
+	return filter, nil
+}

--- a/internal/adapter/httpapi/project_hotspot_handler.go
+++ b/internal/adapter/httpapi/project_hotspot_handler.go
@@ -125,7 +125,7 @@ func projectHotspotListParams(r *http.Request) (hotspot.ListFilter, error) {
 	}
 	if raw := strings.TrimSpace(q.Get("severity")); raw != "" {
 		severity := shared.Severity(raw)
-		if !severity.Valid() || severity == shared.SeverityUnknown {
+		if !severity.Valid() {
 			return hotspot.ListFilter{}, fmt.Errorf("%w: invalid hotspot severity", shared.ErrValidation)
 		}
 		filter.Severity = &severity

--- a/internal/adapter/httpapi/project_hotspot_handler_test.go
+++ b/internal/adapter/httpapi/project_hotspot_handler_test.go
@@ -1,0 +1,118 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
+)
+
+type projectHotspotServiceStub struct {
+	projectService
+	page      hotspot.Page
+	item      hotspot.Hotspot
+	listErr   error
+	getErr    error
+	listCalls int
+	getCalls  int
+	tenant    shared.ID
+	key       string
+}
+
+func (s *projectHotspotServiceStub) ListHotspots(_ context.Context, tenantID shared.ID, key string, _ hotspot.ListFilter) (hotspot.Page, error) {
+	s.listCalls++
+	s.tenant, s.key = tenantID, key
+	return s.page, s.listErr
+}
+
+func (s *projectHotspotServiceStub) GetHotspot(_ context.Context, tenantID shared.ID, key string, _ shared.ID) (hotspot.Hotspot, error) {
+	s.getCalls++
+	s.tenant, s.key = tenantID, key
+	return s.item, s.getErr
+}
+
+type hotspotRulesStub struct {
+	rulesService
+	item rule.Rule
+}
+
+func (s hotspotRulesStub) Get(context.Context, rule.Key) (rule.Rule, error) { return s.item, nil }
+func (s hotspotRulesStub) List(context.Context, rules.Filter) ([]rule.Rule, error) {
+	return []rule.Rule{s.item}, nil
+}
+
+func hotspotFixture() hotspot.Hotspot {
+	at := time.Date(2026, 7, 19, 1, 2, 3, 0, time.UTC)
+	return hotspot.Hotspot{
+		ID: "hotspot-1", TenantID: "tenant-a", ProjectID: "project-a", Key: "sast:rule:main.go:7", FindingIdentity: "sast:rule:main.go:7",
+		RuleKey: "rule", Title: "Review this", Description: "Sensitive operation", Severity: shared.SeverityHigh,
+		Kind: finding.KindSAST, CWE: "CWE-798", Location: "main.go:7", Status: hotspot.StatusToReview, Version: 1,
+		FirstSeenAnalysisID: "a1", LastSeenAnalysisID: "a2", FirstSeenAt: at, LastSeenAt: at.Add(time.Hour),
+	}
+}
+
+func TestListProjectHotspotsReturnsScopedProjectionAndFacets(t *testing.T) {
+	stub := &projectHotspotServiceStub{page: hotspot.Page{Items: []hotspot.Hotspot{hotspotFixture()}, Next: &hotspot.Cursor{BeforeLastSeenAt: time.Unix(2, 0), BeforeID: "cursor"}, Facets: hotspot.Facets{Statuses: map[string]int{"to_review": 1}, RuleKeys: map[string]int{"rule": 1}, Severities: map[string]int{"high": 1}}}}
+	rt := &Router{log: discardLog(), projects: stub, rules: hotspotRulesStub{item: rule.Rule{Name: "Sensitive rule"}}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/payments/hotspots?status=to_review&severity=high&limit=10", nil)
+	req.SetPathValue("key", "payments")
+	req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "alice", TenantID: "tenant-a"}))
+	rec := httptest.NewRecorder()
+	rt.listProjectHotspots(rec, req)
+	if rec.Code != http.StatusOK || stub.listCalls != 1 || stub.tenant != "tenant-a" || stub.key != "payments" {
+		t.Fatalf("code=%d calls=%d tenant=%q key=%q body=%s", rec.Code, stub.listCalls, stub.tenant, stub.key, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, secret := range []string{"TenantID", "tenant_id", "ProjectID", "project_id", "EngagementID", "engagement_id", "InternalIssues"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("hotspot response leaked %q: %s", secret, body)
+		}
+	}
+	var decoded struct {
+		Items  []projectHotspotResponse      `json:"items"`
+		Next   *projectHotspotCursorResponse `json:"next"`
+		Facets projectHotspotFacetsResponse  `json:"facets"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Items) != 1 || decoded.Items[0].RuleName != "Sensitive rule" || decoded.Facets.Statuses["to_review"] != 1 || decoded.Next == nil {
+		t.Fatalf("decoded=%+v", decoded)
+	}
+}
+
+func TestProjectHotspotRejectsMalformedQuery(t *testing.T) {
+	for _, query := range []string{"?status=bad", "?severity=unknown", "?limit=0", "?before_id=only", "?unexpected=x"} {
+		rt := &Router{log: discardLog(), projects: &projectHotspotServiceStub{}}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p/hotspots"+query, nil)
+		req.SetPathValue("key", "p")
+		rec := httptest.NewRecorder()
+		rt.listProjectHotspots(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("query=%s code=%d body=%s", query, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestGetProjectHotspotMapsCrossTenantToNotFound(t *testing.T) {
+	stub := &projectHotspotServiceStub{getErr: fmt.Errorf("cross-tenant: %w", shared.ErrNotFound)}
+	rt := &Router{log: discardLog(), projects: stub}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p/hotspots/id", nil)
+	req.SetPathValue("key", "p")
+	req.SetPathValue("id", "id")
+	rec := httptest.NewRecorder()
+	rt.getProjectHotspot(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant code=%d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/adapter/httpapi/project_hotspot_handler_test.go
+++ b/internal/adapter/httpapi/project_hotspot_handler_test.go
@@ -92,7 +92,7 @@ func TestListProjectHotspotsReturnsScopedProjectionAndFacets(t *testing.T) {
 }
 
 func TestProjectHotspotRejectsMalformedQuery(t *testing.T) {
-	for _, query := range []string{"?status=bad", "?severity=unknown", "?limit=0", "?before_id=only", "?unexpected=x"} {
+	for _, query := range []string{"?status=bad", "?severity=bogus", "?limit=0", "?before_id=only", "?unexpected=x"} {
 		rt := &Router{log: discardLog(), projects: &projectHotspotServiceStub{}}
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p/hotspots"+query, nil)
 		req.SetPathValue("key", "p")

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -215,6 +215,8 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/projects", rt.authz(userdom.PermView, rt.listProjects))
 		mux.HandleFunc("GET /api/v1/projects/{key}", rt.authz(userdom.PermView, rt.getProject))
 		mux.HandleFunc("GET /api/v1/projects/{key}/overview", rt.authz(userdom.PermView, rt.projectOverview))
+		mux.HandleFunc("GET /api/v1/projects/{key}/hotspots", rt.authz(userdom.PermView, rt.listProjectHotspots))
+		mux.HandleFunc("GET /api/v1/projects/{key}/hotspots/{id}", rt.authz(userdom.PermView, rt.getProjectHotspot))
 		mux.HandleFunc("PUT /api/v1/projects/{key}/gate", rt.authz(userdom.PermOperate, rt.assignProjectGate))
 		mux.HandleFunc("POST /api/v1/projects/{key}/analyses", rt.authz(userdom.PermOperate, rt.startProjectAnalysis))
 		mux.HandleFunc("GET /api/v1/projects/{key}/analyses", rt.authz(userdom.PermView, rt.listProjectAnalyses))

--- a/internal/domain/hotspot/hotspot.go
+++ b/internal/domain/hotspot/hotspot.go
@@ -1,0 +1,144 @@
+// Package hotspot models Project-scoped Security Hotspot projections.
+package hotspot
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Status is the review state vocabulary reserved for the Security Hotspots product.
+// PR A only persists the initial state; transitions belong to PR B.
+type Status string
+
+const (
+	StatusToReview     Status = "to_review"
+	StatusAcknowledged Status = "acknowledged"
+	StatusFixed        Status = "fixed"
+	StatusSafe         Status = "safe"
+)
+
+func (s Status) Valid() bool {
+	switch s {
+	case StatusToReview, StatusAcknowledged, StatusFixed, StatusSafe:
+		return true
+	default:
+		return false
+	}
+}
+
+// Candidate is the immutable scan-time projection input produced by the classifier.
+// Tenant, Project, analysis timestamps, review state and version are assigned by the
+// persistence boundary so rescans cannot reset review state.
+type Candidate struct {
+	Key             string
+	FindingIdentity string
+	RuleKey         string
+	Title           string
+	Description     string
+	Severity        shared.Severity
+	Kind            finding.Kind
+	CWE             string
+	Location        string
+}
+
+// Hotspot is a tenant- and Project-scoped read model. It deliberately contains no
+// Engagement identity or raw scan payload.
+type Hotspot struct {
+	ID                  shared.ID
+	TenantID            shared.ID
+	ProjectID           shared.ID
+	Key                 string
+	FindingIdentity     string
+	RuleKey             string
+	Title               string
+	Description         string
+	Severity            shared.Severity
+	Kind                finding.Kind
+	CWE                 string
+	Location            string
+	Status              Status
+	Version             int
+	FirstSeenAnalysisID string
+	LastSeenAnalysisID  string
+	FirstSeenAt         time.Time
+	LastSeenAt          time.Time
+	Audit               shared.Audit
+}
+
+// DeterministicID gives a projection a stable opaque identifier across rescans.
+// The tenant and Project are part of the input so equal finding identities in two
+// tenants cannot accidentally address the same resource.
+func DeterministicID(tenantID, projectID shared.ID, key string) shared.ID {
+	sum := sha256.Sum256([]byte(tenantID.String() + "\x00" + projectID.String() + "\x00" + key))
+	return shared.ID(hex.EncodeToString(sum[:16]))
+}
+
+// Validate enforces the fields required for a safe read projection.
+func (h Hotspot) Validate() error {
+	if h.ID.IsZero() || h.TenantID.IsZero() || h.ProjectID.IsZero() {
+		return fmt.Errorf("%w: hotspot identity is required", shared.ErrValidation)
+	}
+	if strings.TrimSpace(h.Key) == "" || strings.TrimSpace(h.FindingIdentity) == "" {
+		return fmt.Errorf("%w: hotspot finding identity is required", shared.ErrValidation)
+	}
+	if strings.TrimSpace(h.RuleKey) == "" {
+		return fmt.Errorf("%w: hotspot rule key is required", shared.ErrValidation)
+	}
+	if strings.TrimSpace(h.Title) == "" || strings.TrimSpace(h.Description) == "" {
+		return fmt.Errorf("%w: hotspot descriptive fields are required", shared.ErrValidation)
+	}
+	if !h.Severity.Valid() || h.Severity == shared.SeverityUnknown {
+		return fmt.Errorf("%w: hotspot severity is invalid", shared.ErrValidation)
+	}
+	if !h.Kind.Valid() {
+		return fmt.Errorf("%w: hotspot finding kind is invalid", shared.ErrValidation)
+	}
+	if !Status(h.Status).Valid() {
+		return fmt.Errorf("%w: hotspot status is invalid", shared.ErrValidation)
+	}
+	if h.Version < 1 {
+		return fmt.Errorf("%w: hotspot version must be positive", shared.ErrValidation)
+	}
+	if strings.TrimSpace(h.FirstSeenAnalysisID) == "" || strings.TrimSpace(h.LastSeenAnalysisID) == "" {
+		return fmt.Errorf("%w: hotspot analysis identity is required", shared.ErrValidation)
+	}
+	if h.FirstSeenAt.IsZero() || h.LastSeenAt.IsZero() || h.LastSeenAt.Before(h.FirstSeenAt) {
+		return fmt.Errorf("%w: hotspot seen timestamps are invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+// ListFilter describes the read API's tenant/project-local filters.
+type ListFilter struct {
+	Status           *Status
+	RuleKey          string
+	Severity         *shared.Severity
+	Search           string
+	Limit            int
+	BeforeLastSeenAt time.Time
+	BeforeID         shared.ID
+}
+
+// Cursor is the deterministic keyset cursor returned by a list operation.
+type Cursor struct {
+	BeforeLastSeenAt time.Time
+	BeforeID         shared.ID
+}
+
+type Facets struct {
+	Statuses   map[string]int
+	RuleKeys   map[string]int
+	Severities map[string]int
+}
+
+type Page struct {
+	Items  []Hotspot
+	Next   *Cursor
+	Facets Facets
+}

--- a/internal/domain/hotspot/hotspot.go
+++ b/internal/domain/hotspot/hotspot.go
@@ -81,7 +81,9 @@ func DeterministicID(tenantID, projectID shared.ID, key string) shared.ID {
 
 // Validate enforces the fields required for a safe read projection.
 func (h Hotspot) Validate() error {
-	if h.ID.IsZero() || h.TenantID.IsZero() || h.ProjectID.IsZero() {
+	// An empty tenant ID is the repository's valid default tenant in
+	// single-tenant mode. Project and hotspot identities are always required.
+	if h.ID.IsZero() || h.ProjectID.IsZero() {
 		return fmt.Errorf("%w: hotspot identity is required", shared.ErrValidation)
 	}
 	if strings.TrimSpace(h.Key) == "" || strings.TrimSpace(h.FindingIdentity) == "" {
@@ -90,14 +92,8 @@ func (h Hotspot) Validate() error {
 	if strings.TrimSpace(h.RuleKey) == "" {
 		return fmt.Errorf("%w: hotspot rule key is required", shared.ErrValidation)
 	}
-	if strings.TrimSpace(h.Title) == "" || strings.TrimSpace(h.Description) == "" {
-		return fmt.Errorf("%w: hotspot descriptive fields are required", shared.ErrValidation)
-	}
-	if !h.Severity.Valid() || h.Severity == shared.SeverityUnknown {
+	if !h.Severity.Valid() {
 		return fmt.Errorf("%w: hotspot severity is invalid", shared.ErrValidation)
-	}
-	if !h.Kind.Valid() {
-		return fmt.Errorf("%w: hotspot finding kind is invalid", shared.ErrValidation)
 	}
 	if !Status(h.Status).Valid() {
 		return fmt.Errorf("%w: hotspot status is invalid", shared.ErrValidation)

--- a/internal/domain/hotspot/hotspot_test.go
+++ b/internal/domain/hotspot/hotspot_test.go
@@ -1,0 +1,39 @@
+package hotspot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestHotspotValidateAndDeterministicID(t *testing.T) {
+	now := time.Date(2026, 7, 19, 1, 2, 3, 0, time.UTC)
+	h := Hotspot{
+		ID: "id", TenantID: "tenant", ProjectID: "project", Key: "sast:rule:file:1", FindingIdentity: "sast:rule:file:1",
+		RuleKey: "rule", Title: "Title", Description: "Description", Severity: shared.SeverityHigh,
+		Kind: finding.KindSAST, Status: StatusToReview, Version: 1, FirstSeenAnalysisID: "a1", LastSeenAnalysisID: "a1",
+		FirstSeenAt: now, LastSeenAt: now,
+	}
+	if err := h.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := DeterministicID("tenant", "project", h.Key), DeterministicID("tenant", "project", h.Key); got != want || got.IsZero() {
+		t.Fatalf("deterministic id=%q want=%q", got, want)
+	}
+	if DeterministicID("other", "project", h.Key) == DeterministicID("tenant", "project", h.Key) {
+		t.Fatal("tenant must be part of deterministic identity")
+	}
+}
+
+func TestStatusValid(t *testing.T) {
+	for _, status := range []Status{StatusToReview, StatusAcknowledged, StatusFixed, StatusSafe} {
+		if !status.Valid() {
+			t.Errorf("%q should be valid", status)
+		}
+	}
+	if Status("unknown").Valid() {
+		t.Fatal("unknown status should be invalid")
+	}
+}

--- a/internal/domain/hotspot/hotspot_test.go
+++ b/internal/domain/hotspot/hotspot_test.go
@@ -27,6 +27,19 @@ func TestHotspotValidateAndDeterministicID(t *testing.T) {
 	}
 }
 
+func TestHotspotValidateAllowsDefaultTenant(t *testing.T) {
+	now := time.Date(2026, 7, 19, 1, 2, 3, 0, time.UTC)
+	h := Hotspot{
+		ID: "id", ProjectID: "project", Key: "sast:rule:file:1", FindingIdentity: "sast:rule:file:1",
+		RuleKey: "rule", Severity: shared.SeverityUnknown,
+		Status: StatusToReview, Version: 1, FirstSeenAnalysisID: "a1", LastSeenAnalysisID: "a1",
+		FirstSeenAt: now, LastSeenAt: now,
+	}
+	if err := h.Validate(); err != nil {
+		t.Fatalf("default tenant should be valid: %v", err)
+	}
+}
+
 func TestStatusValid(t *testing.T) {
 	for _, status := range []Status{StatusToReview, StatusAcknowledged, StatusFixed, StatusSafe} {
 		if !status.Valid() {

--- a/internal/infrastructure/persistence/memory/project_analysis_store.go
+++ b/internal/infrastructure/persistence/memory/project_analysis_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -22,8 +23,9 @@ type storedProjectAnalysis struct {
 }
 
 type ProjectAnalysisStore struct {
-	mu   sync.RWMutex
-	data []storedProjectAnalysis
+	mu       sync.RWMutex
+	data     []storedProjectAnalysis
+	hotspots []hotspot.Hotspot
 }
 
 func NewProjectAnalysisStore() *ProjectAnalysisStore { return &ProjectAnalysisStore{} }
@@ -37,6 +39,25 @@ func (s *ProjectAnalysisStore) Save(ctx context.Context, analysis projectanalysi
 func (s *ProjectAnalysisStore) SaveWithResult(_ context.Context, analysis projectanalysis.Analysis, result []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.saveWithResultLocked(analysis, result)
+}
+
+func (s *ProjectAnalysisStore) SaveWithResultAndHotspots(_ context.Context, analysis projectanalysis.Analysis, result []byte, candidates []hotspot.Candidate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := validateCandidates(analysis, candidates); err != nil {
+		return err
+	}
+	if err := s.saveWithResultLocked(analysis, result); err != nil {
+		return err
+	}
+	for _, candidate := range candidates {
+		s.upsertHotspotLocked(analysis, candidate)
+	}
+	return nil
+}
+
+func (s *ProjectAnalysisStore) saveWithResultLocked(analysis projectanalysis.Analysis, result []byte) error {
 	for _, current := range s.data {
 		if current.analysis.ID == analysis.ID {
 			return nil
@@ -134,6 +155,51 @@ func cloneProjectAnalysis(in projectanalysis.Analysis) projectanalysis.Analysis 
 	}
 	out.Duplication = cloneDuplication(in.Duplication)
 	return out
+}
+
+func validateCandidates(analysis projectanalysis.Analysis, candidates []hotspot.Candidate) error {
+	for _, candidate := range candidates {
+		item := hotspot.Hotspot{
+			ID:       hotspot.DeterministicID(shared.ID(analysis.TenantID), shared.ID(analysis.ProjectID), candidate.Key),
+			TenantID: shared.ID(analysis.TenantID), ProjectID: shared.ID(analysis.ProjectID), Key: candidate.Key,
+			FindingIdentity: candidate.FindingIdentity, RuleKey: candidate.RuleKey, Title: candidate.Title,
+			Description: candidate.Description, Severity: candidate.Severity, Kind: candidate.Kind, CWE: candidate.CWE,
+			Location: candidate.Location, Status: hotspot.StatusToReview, Version: 1,
+			FirstSeenAnalysisID: analysis.ID, LastSeenAnalysisID: analysis.ID,
+			FirstSeenAt: analysis.CreatedAt, LastSeenAt: analysis.CreatedAt,
+			Audit: shared.Audit{CreatedAt: analysis.CreatedAt, UpdatedAt: analysis.CreatedAt},
+		}
+		if err := item.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *ProjectAnalysisStore) upsertHotspotLocked(analysis projectanalysis.Analysis, candidate hotspot.Candidate) {
+	for i := range s.hotspots {
+		current := &s.hotspots[i]
+		if current.TenantID != shared.ID(analysis.TenantID) || current.ProjectID != shared.ID(analysis.ProjectID) || current.Key != candidate.Key {
+			continue
+		}
+		if analysis.CreatedAt.After(current.LastSeenAt) || (analysis.CreatedAt.Equal(current.LastSeenAt) && analysis.ID > current.LastSeenAnalysisID) {
+			current.RuleKey, current.Title, current.Description = candidate.RuleKey, candidate.Title, candidate.Description
+			current.Severity, current.Kind, current.CWE, current.Location = candidate.Severity, candidate.Kind, candidate.CWE, candidate.Location
+			current.LastSeenAnalysisID, current.LastSeenAt = analysis.ID, analysis.CreatedAt
+			current.Audit.UpdatedAt = analysis.CreatedAt
+		}
+		return
+	}
+	s.hotspots = append(s.hotspots, hotspot.Hotspot{
+		ID:       hotspot.DeterministicID(shared.ID(analysis.TenantID), shared.ID(analysis.ProjectID), candidate.Key),
+		TenantID: shared.ID(analysis.TenantID), ProjectID: shared.ID(analysis.ProjectID), Key: candidate.Key,
+		FindingIdentity: candidate.FindingIdentity, RuleKey: candidate.RuleKey, Title: candidate.Title,
+		Description: candidate.Description, Severity: candidate.Severity, Kind: candidate.Kind, CWE: candidate.CWE,
+		Location: candidate.Location, Status: hotspot.StatusToReview, Version: 1,
+		FirstSeenAnalysisID: analysis.ID, LastSeenAnalysisID: analysis.ID,
+		FirstSeenAt: analysis.CreatedAt, LastSeenAt: analysis.CreatedAt,
+		Audit: shared.Audit{CreatedAt: analysis.CreatedAt, UpdatedAt: analysis.CreatedAt},
+	})
 }
 
 func cloneCounts(in projectanalysis.Counts) projectanalysis.Counts {

--- a/internal/infrastructure/persistence/memory/project_analysis_store.go
+++ b/internal/infrastructure/persistence/memory/project_analysis_store.go
@@ -182,6 +182,10 @@ func (s *ProjectAnalysisStore) upsertHotspotLocked(analysis projectanalysis.Anal
 		if current.TenantID != shared.ID(analysis.TenantID) || current.ProjectID != shared.ID(analysis.ProjectID) || current.Key != candidate.Key {
 			continue
 		}
+		if analysis.CreatedAt.Before(current.FirstSeenAt) || (analysis.CreatedAt.Equal(current.FirstSeenAt) && analysis.ID < current.FirstSeenAnalysisID) {
+			current.FirstSeenAnalysisID, current.FirstSeenAt = analysis.ID, analysis.CreatedAt
+			current.Audit.CreatedAt = analysis.CreatedAt
+		}
 		if analysis.CreatedAt.After(current.LastSeenAt) || (analysis.CreatedAt.Equal(current.LastSeenAt) && analysis.ID > current.LastSeenAnalysisID) {
 			current.RuleKey, current.Title, current.Description = candidate.RuleKey, candidate.Title, candidate.Description
 			current.Severity, current.Kind, current.CWE, current.Location = candidate.Severity, candidate.Kind, candidate.CWE, candidate.Location

--- a/internal/infrastructure/persistence/memory/project_hotspot_store.go
+++ b/internal/infrastructure/persistence/memory/project_hotspot_store.go
@@ -1,0 +1,106 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.ProjectHotspotStore = (*ProjectAnalysisStore)(nil)
+var _ ports.ProjectAnalysisProjectionStore = (*ProjectAnalysisStore)(nil)
+
+func (s *ProjectAnalysisStore) ListHotspots(ctx context.Context, tenantID, projectID shared.ID, filter hotspot.ListFilter) (hotspot.Page, error) {
+	if err := ctx.Err(); err != nil {
+		return hotspot.Page{}, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]hotspot.Hotspot, 0)
+	for _, item := range s.hotspots {
+		if item.TenantID != tenantID || item.ProjectID != projectID || !matches(item, filter) {
+			continue
+		}
+		items = append(items, cloneHotspot(item))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].LastSeenAt.Equal(items[j].LastSeenAt) {
+			return items[i].ID > items[j].ID
+		}
+		return items[i].LastSeenAt.After(items[j].LastSeenAt)
+	})
+	page := hotspot.Page{Facets: facets(items)}
+	if !filter.BeforeLastSeenAt.IsZero() {
+		items = afterCursor(items, filter.BeforeLastSeenAt, filter.BeforeID)
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+	page.Items = items
+	if len(items) > limit {
+		page.Items = items[:limit]
+		last := page.Items[len(page.Items)-1]
+		page.Next = &hotspot.Cursor{BeforeLastSeenAt: last.LastSeenAt, BeforeID: last.ID}
+	}
+	return page, nil
+}
+
+func (s *ProjectAnalysisStore) GetHotspot(ctx context.Context, tenantID, projectID, hotspotID shared.ID) (hotspot.Hotspot, error) {
+	if err := ctx.Err(); err != nil {
+		return hotspot.Hotspot{}, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, item := range s.hotspots {
+		if item.TenantID == tenantID && item.ProjectID == projectID && item.ID == hotspotID {
+			return cloneHotspot(item), nil
+		}
+	}
+	return hotspot.Hotspot{}, shared.ErrNotFound
+}
+
+func matches(item hotspot.Hotspot, filter hotspot.ListFilter) bool {
+	if filter.Status != nil && item.Status != *filter.Status {
+		return false
+	}
+	if strings.TrimSpace(filter.RuleKey) != "" && item.RuleKey != strings.TrimSpace(filter.RuleKey) {
+		return false
+	}
+	if filter.Severity != nil && item.Severity != *filter.Severity {
+		return false
+	}
+	query := strings.ToLower(strings.TrimSpace(filter.Search))
+	if query != "" && !strings.Contains(strings.ToLower(strings.Join([]string{item.Key, item.RuleKey, item.Title, item.Description, item.Location}, "\x00")), query) {
+		return false
+	}
+	return true
+}
+
+func afterCursor(items []hotspot.Hotspot, beforeAt time.Time, beforeID shared.ID) []hotspot.Hotspot {
+	for i, item := range items {
+		if item.LastSeenAt.Before(beforeAt) || (item.LastSeenAt.Equal(beforeAt) && item.ID < beforeID) {
+			return items[i:]
+		}
+	}
+	return nil
+}
+
+func facets(items []hotspot.Hotspot) hotspot.Facets {
+	out := hotspot.Facets{Statuses: map[string]int{}, RuleKeys: map[string]int{}, Severities: map[string]int{}}
+	for _, item := range items {
+		out.Statuses[string(item.Status)]++
+		out.RuleKeys[item.RuleKey]++
+		out.Severities[string(item.Severity)]++
+	}
+	return out
+}
+
+func cloneHotspot(in hotspot.Hotspot) hotspot.Hotspot {
+	out := in
+	return out
+}

--- a/internal/infrastructure/persistence/memory/project_hotspot_store_test.go
+++ b/internal/infrastructure/persistence/memory/project_hotspot_store_test.go
@@ -1,0 +1,117 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func projectionCandidate(key string, title string) hotspot.Candidate {
+	return hotspot.Candidate{
+		Key: key, FindingIdentity: key, RuleKey: "rule-" + key, Title: title, Description: "description",
+		Severity: shared.SeverityHigh, Kind: finding.KindSAST,
+	}
+}
+
+func projectionAnalysis(id string, at time.Time) projectanalysis.Analysis {
+	return projectanalysis.Analysis{ID: id, TenantID: "tenant-a", ProjectID: "project-a", CreatedAt: at}
+}
+
+func TestProjectHotspotProjectionRescanPreservesReviewStateAndFirstSeen(t *testing.T) {
+	ctx := context.Background()
+	store := NewProjectAnalysisStore()
+	firstAt := time.Date(2026, 7, 18, 1, 0, 0, 0, time.UTC)
+	secondAt := firstAt.Add(time.Hour)
+	first := projectionCandidate("sast:rule-a:main.go:1", "first")
+	if err := store.SaveWithResultAndHotspots(ctx, projectionAnalysis("a1", firstAt), nil, []hotspot.Candidate{first}); err != nil {
+		t.Fatal(err)
+	}
+	id := hotspot.DeterministicID("tenant-a", "project-a", first.Key)
+	item, err := store.GetHotspot(ctx, "tenant-a", "project-a", id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item.Status, item.Version = hotspot.StatusSafe, 7
+	store.hotspots[0] = item
+	second := projectionCandidate(first.Key, "updated")
+	second.Description = "updated description"
+	if err := store.SaveWithResultAndHotspots(ctx, projectionAnalysis("a2", secondAt), nil, []hotspot.Candidate{second}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.GetHotspot(ctx, "tenant-a", "project-a", id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != hotspot.StatusSafe || got.Version != 7 {
+		t.Fatalf("review state reset: %+v", got)
+	}
+	if got.FirstSeenAnalysisID != "a1" || !got.FirstSeenAt.Equal(firstAt) || got.LastSeenAnalysisID != "a2" || !got.LastSeenAt.Equal(secondAt) || got.Title != "updated" {
+		t.Fatalf("seen metadata/descriptive update: %+v", got)
+	}
+}
+
+func TestProjectHotspotProjectionIsTenantAndProjectScoped(t *testing.T) {
+	ctx := context.Background()
+	store := NewProjectAnalysisStore()
+	analysis := projectionAnalysis("a1", time.Unix(1, 0))
+	if err := store.SaveWithResultAndHotspots(ctx, analysis, nil, []hotspot.Candidate{projectionCandidate("a", "title")}); err != nil {
+		t.Fatal(err)
+	}
+	id := hotspot.DeterministicID("tenant-a", "project-a", "a")
+	if _, err := store.GetHotspot(ctx, "tenant-b", "project-a", id); err != shared.ErrNotFound {
+		t.Fatalf("cross-tenant get=%v, want not found", err)
+	}
+	if _, err := store.GetHotspot(ctx, "tenant-a", "project-b", id); err != shared.ErrNotFound {
+		t.Fatalf("wrong-project get=%v, want not found", err)
+	}
+	page, err := store.ListHotspots(ctx, "tenant-b", "project-a", hotspot.ListFilter{})
+	if err != nil || len(page.Items) != 0 {
+		t.Fatalf("cross-tenant list=%+v err=%v", page, err)
+	}
+}
+
+func TestProjectHotspotProjectionPaginationAndFacets(t *testing.T) {
+	ctx := context.Background()
+	store := NewProjectAnalysisStore()
+	base := time.Date(2026, 7, 18, 1, 0, 0, 0, time.UTC)
+	for i, key := range []string{"a", "b", "c"} {
+		if err := store.SaveWithResultAndHotspots(ctx, projectionAnalysis("a"+key, base.Add(time.Duration(i)*time.Hour)), nil, []hotspot.Candidate{projectionCandidate(key, key)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	page, err := store.ListHotspots(ctx, "tenant-a", "project-a", hotspot.ListFilter{Limit: 2})
+	if err != nil || len(page.Items) != 2 || page.Next == nil || page.Facets.RuleKeys["rule-a"] != 1 {
+		t.Fatalf("first page=%+v err=%v", page, err)
+	}
+	next, err := store.ListHotspots(ctx, "tenant-a", "project-a", hotspot.ListFilter{Limit: 2, BeforeLastSeenAt: page.Next.BeforeLastSeenAt, BeforeID: page.Next.BeforeID})
+	if err != nil || len(next.Items) != 1 || next.Items[0].Key != "a" {
+		t.Fatalf("next page=%+v err=%v", next, err)
+	}
+}
+
+func TestProjectHotspotProjectionRejectsCandidateAtomically(t *testing.T) {
+	ctx := context.Background()
+	store := NewProjectAnalysisStore()
+	valid := projectionCandidate("valid", "valid")
+	invalid := valid
+	invalid.Key = ""
+	if err := store.SaveWithResultAndHotspots(ctx, projectionAnalysis("a1", time.Unix(1, 0)), nil, []hotspot.Candidate{valid, invalid}); err == nil {
+		t.Fatal("invalid candidate should fail")
+	}
+	if _, _, err := store.List(ctx, "tenant-a", "project-a", 10, time.Time{}, ""); err != nil {
+		t.Fatal(err)
+	} else {
+		analyses, _, _ := store.List(ctx, "tenant-a", "project-a", 10, time.Time{}, "")
+		if len(analyses) != 0 {
+			t.Fatalf("analysis committed despite projection validation: %+v", analyses)
+		}
+	}
+	if page, err := store.ListHotspots(ctx, "tenant-a", "project-a", hotspot.ListFilter{}); err != nil || len(page.Items) != 0 {
+		t.Fatalf("hotspot committed despite projection validation: %+v err=%v", page, err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/project_hotspot_store_test.go
+++ b/internal/infrastructure/persistence/memory/project_hotspot_store_test.go
@@ -43,6 +43,11 @@ func TestProjectHotspotProjectionRescanPreservesReviewStateAndFirstSeen(t *testi
 	if err := store.SaveWithResultAndHotspots(ctx, projectionAnalysis("a2", secondAt), nil, []hotspot.Candidate{second}); err != nil {
 		t.Fatal(err)
 	}
+	older := projectionCandidate(first.Key, "older")
+	olderAt := firstAt.Add(-time.Hour)
+	if err := store.SaveWithResultAndHotspots(ctx, projectionAnalysis("a0", olderAt), nil, []hotspot.Candidate{older}); err != nil {
+		t.Fatal(err)
+	}
 	got, err := store.GetHotspot(ctx, "tenant-a", "project-a", id)
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +55,7 @@ func TestProjectHotspotProjectionRescanPreservesReviewStateAndFirstSeen(t *testi
 	if got.Status != hotspot.StatusSafe || got.Version != 7 {
 		t.Fatalf("review state reset: %+v", got)
 	}
-	if got.FirstSeenAnalysisID != "a1" || !got.FirstSeenAt.Equal(firstAt) || got.LastSeenAnalysisID != "a2" || !got.LastSeenAt.Equal(secondAt) || got.Title != "updated" {
+	if got.FirstSeenAnalysisID != "a0" || !got.FirstSeenAt.Equal(olderAt) || got.LastSeenAnalysisID != "a2" || !got.LastSeenAt.Equal(secondAt) || got.Title != "updated" {
 		t.Fatalf("seen metadata/descriptive update: %+v", got)
 	}
 }

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store.go
@@ -53,6 +53,9 @@ func (r *ProjectAnalysisStore) SaveWithResultAndHotspots(ctx context.Context, an
 			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$17,$18)
 			ON CONFLICT (tenant_id, project_id, hotspot_key) DO UPDATE SET
 				finding_identity = EXCLUDED.finding_identity,
+				first_seen_analysis_id = CASE WHEN (EXCLUDED.first_seen_at, EXCLUDED.first_seen_analysis_id) < (project_hotspots.first_seen_at, project_hotspots.first_seen_analysis_id) THEN EXCLUDED.first_seen_analysis_id ELSE project_hotspots.first_seen_analysis_id END,
+				first_seen_at = CASE WHEN (EXCLUDED.first_seen_at, EXCLUDED.first_seen_analysis_id) < (project_hotspots.first_seen_at, project_hotspots.first_seen_analysis_id) THEN EXCLUDED.first_seen_at ELSE project_hotspots.first_seen_at END,
+				created_at = CASE WHEN (EXCLUDED.first_seen_at, EXCLUDED.first_seen_analysis_id) < (project_hotspots.first_seen_at, project_hotspots.first_seen_analysis_id) THEN EXCLUDED.created_at ELSE project_hotspots.created_at END,
 				rule_key = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.rule_key ELSE project_hotspots.rule_key END,
 				title = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.title ELSE project_hotspots.title END,
 				description = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.description ELSE project_hotspots.description END,

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store.go
@@ -1,0 +1,211 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.ProjectAnalysisProjectionStore = (*ProjectAnalysisStore)(nil)
+var _ ports.ProjectHotspotStore = (*ProjectAnalysisStore)(nil)
+
+// SaveWithResultAndHotspots commits the immutable analysis and its projection in
+// one PostgreSQL transaction. A projection write failure rolls the analysis back,
+// so the scan worker cannot publish a successful analysis without its hotspots.
+func (r *ProjectAnalysisStore) SaveWithResultAndHotspots(ctx context.Context, analysis projectanalysis.Analysis, result []byte, candidates []hotspot.Candidate) error {
+	items := make([]hotspot.Hotspot, len(candidates))
+	for i, candidate := range candidates {
+		item, err := projectedHotspot(analysis, candidate)
+		if err != nil {
+			return err
+		}
+		items[i] = item
+	}
+	payload, err := json.Marshal(analysis)
+	if err != nil {
+		return fmt.Errorf("marshal project analysis: %w", err)
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin project analysis transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `INSERT INTO project_analyses (id, tenant_id, project_id, created_at, payload, result)
+		VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (id) DO NOTHING`,
+		analysis.ID, analysis.TenantID, analysis.ProjectID, analysis.CreatedAt, payload, result); err != nil {
+		return fmt.Errorf("insert project analysis: %w", err)
+	}
+	for _, item := range items {
+		if _, err := tx.Exec(ctx, `INSERT INTO project_hotspots
+			(id, tenant_id, project_id, hotspot_key, finding_identity, rule_key, title, description, severity, finding_kind, cwe, location,
+			 status, version, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$17,$18)
+			ON CONFLICT (tenant_id, project_id, hotspot_key) DO UPDATE SET
+				finding_identity = EXCLUDED.finding_identity,
+				rule_key = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.rule_key ELSE project_hotspots.rule_key END,
+				title = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.title ELSE project_hotspots.title END,
+				description = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.description ELSE project_hotspots.description END,
+				severity = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.severity ELSE project_hotspots.severity END,
+				finding_kind = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.finding_kind ELSE project_hotspots.finding_kind END,
+				cwe = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.cwe ELSE project_hotspots.cwe END,
+				location = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.location ELSE project_hotspots.location END,
+				last_seen_analysis_id = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.last_seen_analysis_id ELSE project_hotspots.last_seen_analysis_id END,
+				last_seen_at = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.last_seen_at ELSE project_hotspots.last_seen_at END,
+				updated_at = CASE WHEN (EXCLUDED.last_seen_at, EXCLUDED.last_seen_analysis_id) > (project_hotspots.last_seen_at, project_hotspots.last_seen_analysis_id) THEN EXCLUDED.updated_at ELSE project_hotspots.updated_at END`,
+			item.ID, item.TenantID, item.ProjectID, item.Key, item.FindingIdentity, item.RuleKey, item.Title, item.Description,
+			item.Severity, item.Kind, item.CWE, item.Location, item.Status, item.Version, item.FirstSeenAnalysisID,
+			item.LastSeenAnalysisID, item.FirstSeenAt, item.LastSeenAt); err != nil {
+			return fmt.Errorf("upsert project hotspot: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit project analysis transaction: %w", err)
+	}
+	return nil
+}
+
+func projectedHotspot(analysis projectanalysis.Analysis, candidate hotspot.Candidate) (hotspot.Hotspot, error) {
+	item := hotspot.Hotspot{
+		ID:       hotspot.DeterministicID(shared.ID(analysis.TenantID), shared.ID(analysis.ProjectID), candidate.Key),
+		TenantID: shared.ID(analysis.TenantID), ProjectID: shared.ID(analysis.ProjectID), Key: candidate.Key,
+		FindingIdentity: candidate.FindingIdentity, RuleKey: candidate.RuleKey, Title: candidate.Title,
+		Description: candidate.Description, Severity: candidate.Severity, Kind: candidate.Kind, CWE: candidate.CWE,
+		Location: candidate.Location, Status: hotspot.StatusToReview, Version: 1,
+		FirstSeenAnalysisID: analysis.ID, LastSeenAnalysisID: analysis.ID,
+		FirstSeenAt: analysis.CreatedAt, LastSeenAt: analysis.CreatedAt,
+		Audit: shared.Audit{CreatedAt: analysis.CreatedAt, UpdatedAt: analysis.CreatedAt},
+	}
+	if err := item.Validate(); err != nil {
+		return hotspot.Hotspot{}, err
+	}
+	return item, nil
+}
+
+func (r *ProjectAnalysisStore) ListHotspots(ctx context.Context, tenantID, projectID shared.ID, filter hotspot.ListFilter) (hotspot.Page, error) {
+	where, args := hotspotWhere(tenantID, projectID, filter, true)
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+	args = append(args, limit+1)
+	query := `SELECT id, tenant_id, project_id, hotspot_key, finding_identity, rule_key, title, description, severity, finding_kind, cwe, location,
+		status, version, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at
+		FROM project_hotspots WHERE ` + where + ` ORDER BY last_seen_at DESC, id COLLATE "C" DESC LIMIT $` + fmt.Sprint(len(args))
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return hotspot.Page{}, fmt.Errorf("list project hotspots: %w", err)
+	}
+	defer rows.Close()
+	items := make([]hotspot.Hotspot, 0, limit+1)
+	for rows.Next() {
+		item, err := scanHotspot(rows)
+		if err != nil {
+			return hotspot.Page{}, fmt.Errorf("scan project hotspot: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return hotspot.Page{}, err
+	}
+	page := hotspot.Page{}
+	if len(items) > limit {
+		last := items[limit-1]
+		page.Next = &hotspot.Cursor{BeforeLastSeenAt: last.LastSeenAt, BeforeID: last.ID}
+		items = items[:limit]
+	}
+	page.Items = items
+	facetWhere, facetArgs := hotspotWhere(tenantID, projectID, filter, false)
+	facetRows, err := r.pool.Query(ctx, `SELECT 'status', status, count(*) FROM project_hotspots WHERE `+facetWhere+` GROUP BY status
+		UNION ALL SELECT 'rule', rule_key, count(*) FROM project_hotspots WHERE `+facetWhere+` GROUP BY rule_key
+		UNION ALL SELECT 'severity', severity, count(*) FROM project_hotspots WHERE `+facetWhere+` GROUP BY severity`, facetArgs...)
+	if err != nil {
+		return hotspot.Page{}, fmt.Errorf("facet project hotspots: %w", err)
+	}
+	defer facetRows.Close()
+	page.Facets = hotspot.Facets{Statuses: map[string]int{}, RuleKeys: map[string]int{}, Severities: map[string]int{}}
+	for facetRows.Next() {
+		var kind, value string
+		var count int
+		if err := facetRows.Scan(&kind, &value, &count); err != nil {
+			return hotspot.Page{}, fmt.Errorf("scan project hotspot facet: %w", err)
+		}
+		switch kind {
+		case "status":
+			page.Facets.Statuses[value] = count
+		case "rule":
+			page.Facets.RuleKeys[value] = count
+		case "severity":
+			page.Facets.Severities[value] = count
+		}
+	}
+	return page, facetRows.Err()
+}
+
+func hotspotWhere(tenantID, projectID shared.ID, filter hotspot.ListFilter, cursor bool) (string, []any) {
+	args := []any{tenantID.String(), projectID.String()}
+	parts := []string{"tenant_id = $1", "project_id = $2"}
+	add := func(part string, value any) {
+		args = append(args, value)
+		parts = append(parts, fmt.Sprintf(part, len(args)))
+	}
+	if filter.Status != nil {
+		add("status = $%d", string(*filter.Status))
+	}
+	if strings.TrimSpace(filter.RuleKey) != "" {
+		add("rule_key = $%d", strings.TrimSpace(filter.RuleKey))
+	}
+	if filter.Severity != nil {
+		add("severity = $%d", string(*filter.Severity))
+	}
+	if search := strings.TrimSpace(filter.Search); search != "" {
+		searchArg := len(args) + 1
+		args = append(args, "%"+search+"%", "%"+search+"%", "%"+search+"%", "%"+search+"%", "%"+search+"%")
+		parts = append(parts, fmt.Sprintf("(hotspot_key ILIKE $%d OR rule_key ILIKE $%d OR title ILIKE $%d OR description ILIKE $%d OR location ILIKE $%d)", searchArg, searchArg+1, searchArg+2, searchArg+3, searchArg+4))
+	}
+	if cursor && !filter.BeforeLastSeenAt.IsZero() {
+		args = append(args, filter.BeforeLastSeenAt, filter.BeforeID.String())
+		at, id := len(args)-1, len(args)
+		parts = append(parts, fmt.Sprintf(`(last_seen_at < $%d OR (last_seen_at = $%d AND id COLLATE "C" < $%d))`, at, at, id))
+	}
+	return strings.Join(parts, " AND "), args
+}
+
+func (r *ProjectAnalysisStore) GetHotspot(ctx context.Context, tenantID, projectID, hotspotID shared.ID) (hotspot.Hotspot, error) {
+	row := r.pool.QueryRow(ctx, `SELECT id, tenant_id, project_id, hotspot_key, finding_identity, rule_key, title, description, severity, finding_kind, cwe, location,
+		status, version, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at
+		FROM project_hotspots WHERE tenant_id=$1 AND project_id=$2 AND id=$3`, tenantID.String(), projectID.String(), hotspotID.String())
+	item, err := scanHotspot(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return hotspot.Hotspot{}, shared.ErrNotFound
+	}
+	if err != nil {
+		return hotspot.Hotspot{}, fmt.Errorf("get project hotspot: %w", err)
+	}
+	return item, nil
+}
+
+func scanHotspot(row rowScanner) (hotspot.Hotspot, error) {
+	var item hotspot.Hotspot
+	var tenantID, projectID, status, kind, severity string
+	var createdAt, updatedAt time.Time
+	if err := row.Scan(&item.ID, &tenantID, &projectID, &item.Key, &item.FindingIdentity, &item.RuleKey, &item.Title, &item.Description,
+		&severity, &kind, &item.CWE, &item.Location, &status, &item.Version, &item.FirstSeenAnalysisID, &item.LastSeenAnalysisID,
+		&item.FirstSeenAt, &item.LastSeenAt, &createdAt, &updatedAt); err != nil {
+		return hotspot.Hotspot{}, err
+	}
+	item.TenantID, item.ProjectID = shared.ID(tenantID), shared.ID(projectID)
+	item.Severity, item.Kind, item.Status = shared.Severity(severity), finding.Kind(kind), hotspot.Status(status)
+	item.Audit = shared.Audit{CreatedAt: createdAt, UpdatedAt: updatedAt}
+	return item, nil
+}

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store_test.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store_test.go
@@ -1,0 +1,99 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestProjectHotspotStoreIntegration(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	tenantID := shared.ID("hotspot-test-tenant")
+	projectID := shared.ID("hotspot-test-project")
+	_, _ = pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$1) ON CONFLICT DO NOTHING`, tenantID)
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM tenants WHERE id=$1`, tenantID) })
+	p, err := project.New(projectID, tenantID, "Hotspot Test", "hotspot-test", project.SourceBinding{Kind: project.SourceGit, Value: "https://example.com/repo.git"}, nil, "", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewProjectRepository(pool).Create(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+	store := NewProjectAnalysisStore(pool)
+	firstAt := time.Date(2026, 7, 19, 1, 0, 0, 0, time.UTC)
+	candidate := hotspot.Candidate{Key: "sast:hotspot-rule:main.go:7", FindingIdentity: "sast:hotspot-rule:main.go:7", RuleKey: "hotspot-rule", Title: "first", Description: "description", Severity: shared.SeverityHigh, Kind: finding.KindSAST, Location: "main.go:7"}
+	if err := store.SaveWithResultAndHotspots(ctx, projectanalysis.Analysis{ID: "hotspot-analysis-1", TenantID: tenantID.String(), ProjectID: projectID.String(), CreatedAt: firstAt}, []byte(`{"result":1}`), []hotspot.Candidate{candidate}); err != nil {
+		t.Fatal(err)
+	}
+	id := hotspot.DeterministicID(tenantID, projectID, candidate.Key)
+	if _, err := pool.Exec(ctx, `UPDATE project_hotspots SET status='safe', version=7 WHERE id=$1`, id); err != nil {
+		t.Fatal(err)
+	}
+	candidate.Title = "updated"
+	secondAt := firstAt.Add(time.Hour)
+	if err := store.SaveWithResultAndHotspots(ctx, projectanalysis.Analysis{ID: "hotspot-analysis-2", TenantID: tenantID.String(), ProjectID: projectID.String(), CreatedAt: secondAt}, []byte(`{"result":2}`), []hotspot.Candidate{candidate}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.GetHotspot(ctx, tenantID, projectID, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != hotspot.StatusSafe || got.Version != 7 || got.FirstSeenAnalysisID != "hotspot-analysis-1" || got.LastSeenAnalysisID != "hotspot-analysis-2" || got.Title != "updated" {
+		t.Fatalf("rescan projection=%+v", got)
+	}
+	page, err := store.ListHotspots(ctx, tenantID, projectID, hotspot.ListFilter{Limit: 1, Search: "updated"})
+	if err != nil || len(page.Items) != 1 || page.Facets.Statuses["safe"] != 1 || page.Facets.RuleKeys["hotspot-rule"] != 1 {
+		t.Fatalf("page=%+v err=%v", page, err)
+	}
+	if _, err := store.GetHotspot(ctx, "other-tenant", projectID, id); err != shared.ErrNotFound {
+		t.Fatalf("cross-tenant get=%v, want not found", err)
+	}
+
+	rollbackTenant := shared.ID("hotspot-rollback-tenant")
+	rollbackProject := shared.ID("hotspot-rollback-project")
+	_, _ = pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$1) ON CONFLICT DO NOTHING`, rollbackTenant)
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM tenants WHERE id=$1`, rollbackTenant) })
+	rollbackP, err := project.New(rollbackProject, rollbackTenant, "Rollback", "hotspot-rollback", project.SourceBinding{Kind: project.SourceGit, Value: "https://example.com/repo.git"}, nil, "", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewProjectRepository(pool).Create(ctx, rollbackP); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `ALTER TABLE project_hotspots ADD CONSTRAINT project_hotspots_test_rollback CHECK (tenant_id <> 'hotspot-rollback-tenant')`); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `ALTER TABLE project_hotspots DROP CONSTRAINT IF EXISTS project_hotspots_test_rollback`)
+	})
+	err = store.SaveWithResultAndHotspots(ctx, projectanalysis.Analysis{ID: "rollback-analysis", TenantID: rollbackTenant.String(), ProjectID: rollbackProject.String(), CreatedAt: firstAt}, nil, []hotspot.Candidate{candidate})
+	if err == nil {
+		t.Fatal("forced hotspot insert failure should fail the analysis transaction")
+	}
+	var analyses int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM project_analyses WHERE id='rollback-analysis'`).Scan(&analyses); err != nil {
+		t.Fatal(err)
+	}
+	if analyses != 0 {
+		t.Fatalf("analysis committed despite hotspot failure: count=%d", analyses)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store_test.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store_test.go
@@ -27,8 +27,18 @@ func TestProjectHotspotStoreIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer pool.Close()
+	// Make reruns safe when a previous process was interrupted before t.Cleanup ran.
+	if _, err := pool.Exec(ctx, `ALTER TABLE project_hotspots DROP CONSTRAINT IF EXISTS project_hotspots_test_rollback`); err != nil {
+		t.Fatal(err)
+	}
 	tenantID := shared.ID("hotspot-test-tenant")
 	projectID := shared.ID("hotspot-test-project")
+	if _, err := pool.Exec(ctx, `DELETE FROM projects WHERE tenant_id IN ($1, $2)`, tenantID, "hotspot-rollback-tenant"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM tenants WHERE id IN ($1, $2)`, tenantID, "hotspot-rollback-tenant"); err != nil {
+		t.Fatal(err)
+	}
 	_, _ = pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$1) ON CONFLICT DO NOTHING`, tenantID)
 	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM tenants WHERE id=$1`, tenantID) })
 	p, err := project.New(projectID, tenantID, "Hotspot Test", "hotspot-test", project.SourceBinding{Kind: project.SourceGit, Value: "https://example.com/repo.git"}, nil, "", time.Now().UTC())
@@ -53,11 +63,15 @@ func TestProjectHotspotStoreIntegration(t *testing.T) {
 	if err := store.SaveWithResultAndHotspots(ctx, projectanalysis.Analysis{ID: "hotspot-analysis-2", TenantID: tenantID.String(), ProjectID: projectID.String(), CreatedAt: secondAt}, []byte(`{"result":2}`), []hotspot.Candidate{candidate}); err != nil {
 		t.Fatal(err)
 	}
+	olderAt := firstAt.Add(-time.Hour)
+	if err := store.SaveWithResultAndHotspots(ctx, projectanalysis.Analysis{ID: "hotspot-analysis-0", TenantID: tenantID.String(), ProjectID: projectID.String(), CreatedAt: olderAt}, nil, []hotspot.Candidate{candidate}); err != nil {
+		t.Fatal(err)
+	}
 	got, err := store.GetHotspot(ctx, tenantID, projectID, id)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Status != hotspot.StatusSafe || got.Version != 7 || got.FirstSeenAnalysisID != "hotspot-analysis-1" || got.LastSeenAnalysisID != "hotspot-analysis-2" || got.Title != "updated" {
+	if got.Status != hotspot.StatusSafe || got.Version != 7 || got.FirstSeenAnalysisID != "hotspot-analysis-0" || !got.FirstSeenAt.Equal(olderAt) || got.LastSeenAnalysisID != "hotspot-analysis-2" || got.Title != "updated" {
 		t.Fatalf("rescan projection=%+v", got)
 	}
 	page, err := store.ListHotspots(ctx, tenantID, projectID, hotspot.ListFilter{Limit: 1, Search: "updated"})

--- a/internal/usecase/hotspots/classifier.go
+++ b/internal/usecase/hotspots/classifier.go
@@ -57,7 +57,7 @@ func classifyOne(ctx context.Context, item finding.Finding, catalog ports.RuleCa
 	if err != nil {
 		return hotspot.Candidate{}, false, fmt.Errorf("resolve hotspot rule %q: %w", item.RuleKey, err)
 	}
-	if r.Type != rule.TypeSecurityHotspot || !containsQuality(r.Qualities, rule.QualitySecurity) {
+	if r.Type != rule.TypeSecurityHotspot {
 		return hotspot.Candidate{}, false, nil
 	}
 	location := ""
@@ -75,15 +75,6 @@ func classifyOne(ctx context.Context, item finding.Finding, catalog ports.RuleCa
 		CWE:             item.CWE,
 		Location:        location,
 	}, true, nil
-}
-
-func containsQuality(qualities []rule.Quality, want rule.Quality) bool {
-	for _, quality := range qualities {
-		if quality == want {
-			return true
-		}
-	}
-	return false
 }
 
 func candidateLess(a, b hotspot.Candidate) bool {

--- a/internal/usecase/hotspots/classifier.go
+++ b/internal/usecase/hotspots/classifier.go
@@ -1,0 +1,103 @@
+// Package hotspots contains Project Security Hotspot projection use cases.
+package hotspots
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Classify separates normal publishable findings from catalog-backed hotspot
+// candidates. Unknown rules fail closed as normal findings; catalog failures other
+// than a not-found lookup are returned because an unavailable catalog must not make
+// a Project analysis appear complete with an incomplete projection.
+func Classify(ctx context.Context, findings []finding.Finding, catalog ports.RuleCatalog) ([]finding.Finding, []hotspot.Candidate, error) {
+	issues := make([]finding.Finding, 0, len(findings))
+	byKey := make(map[string]hotspot.Candidate)
+	for _, item := range findings {
+		candidate, ok, err := classifyOne(ctx, item, catalog)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !ok {
+			issues = append(issues, item)
+			continue
+		}
+		if current, exists := byKey[candidate.Key]; !exists || candidateLess(candidate, current) {
+			byKey[candidate.Key] = candidate
+		}
+	}
+
+	candidates := make([]hotspot.Candidate, 0, len(byKey))
+	for _, candidate := range byKey {
+		candidates = append(candidates, candidate)
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Key < candidates[j].Key })
+	return issues, candidates, nil
+}
+
+func classifyOne(ctx context.Context, item finding.Finding, catalog ports.RuleCatalog) (hotspot.Candidate, bool, error) {
+	key := finding.Identity(item)
+	if strings.TrimSpace(item.RuleKey) == "" || key == "" || catalog == nil {
+		return hotspot.Candidate{}, false, nil
+	}
+	r, err := catalog.Get(ctx, rule.Key(strings.TrimSpace(item.RuleKey)))
+	if errors.Is(err, shared.ErrNotFound) {
+		return hotspot.Candidate{}, false, nil
+	}
+	if err != nil {
+		return hotspot.Candidate{}, false, fmt.Errorf("resolve hotspot rule %q: %w", item.RuleKey, err)
+	}
+	if r.Type != rule.TypeSecurityHotspot || !containsQuality(r.Qualities, rule.QualitySecurity) {
+		return hotspot.Candidate{}, false, nil
+	}
+	location := ""
+	if file, line, ok := qualitygate.FileLineOf(item.DedupKey); ok {
+		location = fmt.Sprintf("%s:%d", file, line)
+	}
+	return hotspot.Candidate{
+		Key:             key,
+		FindingIdentity: key,
+		RuleKey:         strings.TrimSpace(item.RuleKey),
+		Title:           item.Title,
+		Description:     item.Description,
+		Severity:        item.Severity,
+		Kind:            item.Kind,
+		CWE:             item.CWE,
+		Location:        location,
+	}, true, nil
+}
+
+func containsQuality(qualities []rule.Quality, want rule.Quality) bool {
+	for _, quality := range qualities {
+		if quality == want {
+			return true
+		}
+	}
+	return false
+}
+
+func candidateLess(a, b hotspot.Candidate) bool {
+	return candidateSortKey(a) < candidateSortKey(b)
+}
+
+func candidateSortKey(candidate hotspot.Candidate) string {
+	return strings.Join([]string{
+		candidate.RuleKey,
+		candidate.Title,
+		candidate.Description,
+		string(candidate.Severity),
+		string(candidate.Kind),
+		candidate.CWE,
+		candidate.Location,
+	}, "\x00")
+}

--- a/internal/usecase/hotspots/classifier_test.go
+++ b/internal/usecase/hotspots/classifier_test.go
@@ -36,7 +36,7 @@ func testFinding(key, ruleKey string, kind finding.Kind) finding.Finding {
 }
 
 func TestClassifyUsesCatalogTypeAndKeepsInputImmutable(t *testing.T) {
-	hotspotRule := testRule("hotspot-rule", rule.TypeSecurityHotspot, rule.QualitySecurity)
+	hotspotRule := testRule("hotspot-rule", rule.TypeSecurityHotspot)
 	bugRule := testRule("bug-rule", rule.TypeBug, rule.QualityReliability)
 	input := []finding.Finding{
 		testFinding("z", "hotspot-rule", finding.KindSAST),
@@ -56,7 +56,7 @@ func TestClassifyUsesCatalogTypeAndKeepsInputImmutable(t *testing.T) {
 	}
 }
 
-func TestClassifyDoesNotUseKindSeverityOrSecurityQualityAlone(t *testing.T) {
+func TestClassifyUsesRuleTypeOnly(t *testing.T) {
 	cases := []struct {
 		name string
 		item finding.Finding
@@ -74,6 +74,15 @@ func TestClassifyDoesNotUseKindSeverityOrSecurityQualityAlone(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("hotspot type without security quality", func(t *testing.T) {
+		item := testFinding("hotspot", "hotspot-rule", finding.KindQuality)
+		r := testRule("hotspot-rule", rule.TypeSecurityHotspot, rule.QualityMaintainability)
+		issues, candidates, err := Classify(context.Background(), []finding.Finding{item}, fakeCatalog{rules: map[rule.Key]rule.Rule{r.Key: r}})
+		if err != nil || len(issues) != 0 || len(candidates) != 1 {
+			t.Fatalf("issues=%+v candidates=%+v err=%v", issues, candidates, err)
+		}
+	})
 }
 
 func TestClassifyDeduplicatesAndSortsCandidates(t *testing.T) {

--- a/internal/usecase/hotspots/classifier_test.go
+++ b/internal/usecase/hotspots/classifier_test.go
@@ -1,0 +1,102 @@
+package hotspots
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type fakeCatalog struct {
+	rules map[rule.Key]rule.Rule
+	err   error
+}
+
+func (f fakeCatalog) List(context.Context) ([]rule.Rule, error) { return nil, nil }
+func (f fakeCatalog) Get(_ context.Context, key rule.Key) (rule.Rule, error) {
+	if f.err != nil {
+		return rule.Rule{}, f.err
+	}
+	r, ok := f.rules[key]
+	if !ok {
+		return rule.Rule{}, shared.ErrNotFound
+	}
+	return r, nil
+}
+
+func testRule(key rule.Key, typ rule.Type, qualities ...rule.Quality) rule.Rule {
+	return rule.Rule{Key: key, Type: typ, Qualities: qualities}
+}
+
+func testFinding(key, ruleKey string, kind finding.Kind) finding.Finding {
+	return finding.Finding{ID: shared.ID(key), DedupKey: key, RuleKey: ruleKey, Kind: kind, Severity: shared.SeverityHigh, Title: "title", Description: "description", CWE: "CWE-1"}
+}
+
+func TestClassifyUsesCatalogTypeAndKeepsInputImmutable(t *testing.T) {
+	hotspotRule := testRule("hotspot-rule", rule.TypeSecurityHotspot, rule.QualitySecurity)
+	bugRule := testRule("bug-rule", rule.TypeBug, rule.QualityReliability)
+	input := []finding.Finding{
+		testFinding("z", "hotspot-rule", finding.KindSAST),
+		testFinding("a", "bug-rule", finding.KindSAST),
+		testFinding("unknown", "missing", finding.KindSecret),
+	}
+	original := append([]finding.Finding(nil), input...)
+	issues, candidates, err := Classify(context.Background(), input, fakeCatalog{rules: map[rule.Key]rule.Rule{hotspotRule.Key: hotspotRule, bugRule.Key: bugRule}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) != 2 || len(candidates) != 1 || candidates[0].Key != "z" {
+		t.Fatalf("issues=%+v candidates=%+v", issues, candidates)
+	}
+	if input[0].Kind != original[0].Kind || input[0].RuleKey != original[0].RuleKey {
+		t.Fatal("classifier mutated input")
+	}
+}
+
+func TestClassifyDoesNotUseKindSeverityOrSecurityQualityAlone(t *testing.T) {
+	cases := []struct {
+		name string
+		item finding.Finding
+		rule rule.Rule
+	}{
+		{"bug type", testFinding("bug", "bug-rule", finding.KindSAST), testRule("bug-rule", rule.TypeBug, rule.QualitySecurity)},
+		{"security quality only", testFinding("quality", "quality-rule", finding.KindQuality), testRule("quality-rule", rule.TypeCodeSmell, rule.QualitySecurity)},
+		{"secret kind", testFinding("secret", "secret-rule", finding.KindSecret), testRule("secret-rule", rule.TypeVulnerability, rule.QualitySecurity)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, candidates, err := Classify(context.Background(), []finding.Finding{tc.item}, fakeCatalog{rules: map[rule.Key]rule.Rule{tc.rule.Key: tc.rule}})
+			if err != nil || len(issues) != 1 || len(candidates) != 0 {
+				t.Fatalf("issues=%+v candidates=%+v err=%v", issues, candidates, err)
+			}
+		})
+	}
+}
+
+func TestClassifyDeduplicatesAndSortsCandidates(t *testing.T) {
+	r := testRule("hotspot", rule.TypeSecurityHotspot, rule.QualitySecurity)
+	items := []finding.Finding{
+		testFinding("b", "hotspot", finding.KindSAST),
+		testFinding("a", "hotspot", finding.KindSAST),
+		testFinding("b", "hotspot", finding.KindSAST),
+	}
+	_, candidates, err := Classify(context.Background(), items, fakeCatalog{rules: map[rule.Key]rule.Rule{r.Key: r}})
+	if err != nil || len(candidates) != 2 || candidates[0].Key != "a" || candidates[1].Key != "b" {
+		t.Fatalf("candidates=%+v err=%v", candidates, err)
+	}
+}
+
+func TestClassifyCatalogErrorsFailClosedOnlyForUnknownRule(t *testing.T) {
+	item := testFinding("id", "rule", finding.KindSAST)
+	_, candidates, err := Classify(context.Background(), []finding.Finding{item}, fakeCatalog{rules: map[rule.Key]rule.Rule{}})
+	if err != nil || len(candidates) != 0 {
+		t.Fatalf("unknown rule candidates=%+v err=%v", candidates, err)
+	}
+	_, _, err = Classify(context.Background(), []finding.Finding{item}, fakeCatalog{err: errors.New("catalog unavailable")})
+	if err == nil {
+		t.Fatal("catalog failure should fail analysis classification")
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -14,6 +14,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/importedsbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
@@ -77,6 +78,21 @@ type ProjectAnalysisStore interface {
 	LatestForProjects(ctx context.Context, tenantID shared.ID, projectIDs []shared.ID) (map[shared.ID]projectanalysis.Analysis, error)
 	List(ctx context.Context, tenantID, projectID shared.ID, limit int, beforeCreatedAt time.Time, beforeID shared.ID) ([]projectanalysis.Analysis, bool, error)
 	Get(ctx context.Context, tenantID, projectID, analysisID shared.ID) (projectanalysis.Analysis, error)
+}
+
+// ProjectAnalysisProjectionStore is the atomic write capability used when a
+// completed Project analysis also contains Security Hotspot candidates. It is
+// optional on the legacy analysis port so focused test doubles can keep their
+// smaller contract; production stores implement it.
+type ProjectAnalysisProjectionStore interface {
+	SaveWithResultAndHotspots(ctx context.Context, analysis projectanalysis.Analysis, result []byte, candidates []hotspot.Candidate) error
+}
+
+// ProjectHotspotStore reads tenant- and Project-scoped hotspot projections.
+// Review mutations are intentionally outside this PR's port.
+type ProjectHotspotStore interface {
+	ListHotspots(ctx context.Context, tenantID, projectID shared.ID, filter hotspot.ListFilter) (hotspot.Page, error)
+	GetHotspot(ctx context.Context, tenantID, projectID, hotspotID shared.ID) (hotspot.Hotspot, error)
 }
 
 // ProjectArchiveStore retains uploaded source archives so a Project can be re-analyzed.

--- a/internal/usecase/projectuc/service.go
+++ b/internal/usecase/projectuc/service.go
@@ -13,11 +13,13 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	hotspotsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/hotspots"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	qualitygatesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/qualitygates"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
@@ -32,6 +34,8 @@ type Service struct {
 	scanner          *scauc.Service
 	archives         ports.ProjectArchiveStore
 	analyses         ports.ProjectAnalysisStore
+	hotspots         ports.ProjectHotspotStore
+	ruleCatalog      ports.RuleCatalog
 	findings         ports.FindingRepository
 	gates            *qualitygatesuc.Service
 	gateMutator      ports.QualityGateMutator
@@ -45,6 +49,8 @@ func NewService(repo ports.ProjectRepository, engagements ports.EngagementReposi
 func (s *Service) SetScanner(scanner *scauc.Service)                      { s.scanner = scanner }
 func (s *Service) SetArchiveStore(store ports.ProjectArchiveStore)        { s.archives = store }
 func (s *Service) SetAnalysisStore(store ports.ProjectAnalysisStore)      { s.analyses = store }
+func (s *Service) SetHotspotStore(store ports.ProjectHotspotStore)        { s.hotspots = store }
+func (s *Service) SetRuleCatalog(catalog ports.RuleCatalog)               { s.ruleCatalog = catalog }
 func (s *Service) SetFindingRepository(repo ports.FindingRepository)      { s.findings = repo }
 func (s *Service) SetQualityGates(gates *qualitygatesuc.Service)          { s.gates = gates }
 func (s *Service) SetQualityGateMutator(mutator ports.QualityGateMutator) { s.gateMutator = mutator }
@@ -367,6 +373,10 @@ func (s *Service) RecordProjectAnalysis(ctx context.Context, engagementID shared
 		}
 	}
 	all = finding.Publishable(all)
+	issues, candidates, err := hotspotsuc.Classify(ctx, all, s.ruleCatalog)
+	if err != nil {
+		return fmt.Errorf("classify project hotspots: %w", err)
+	}
 	loc := 0
 	if result.CodeQuality != nil {
 		loc = result.CodeQuality.Inventory.Totals().CodeLines
@@ -388,7 +398,7 @@ func (s *Service) RecordProjectAnalysis(ctx context.Context, engagementID shared
 	}
 	analysis, err := projectanalysis.Build(projectanalysis.Input{
 		ID: jobID, TenantID: p.TenantID, ProjectID: p.ID, ProjectKey: p.Key, CreatedAt: completedAt,
-		SourceRef: result.SourceRef, SourceCommit: result.SourceCommit, Findings: all, Gate: gate, GateSource: gateSource, GateExempt: result.GateExemptKeys(all), LinesOfCode: loc,
+		SourceRef: result.SourceRef, SourceCommit: result.SourceCommit, Findings: issues, Gate: gate, GateSource: gateSource, GateExempt: result.GateExemptKeys(issues), LinesOfCode: loc,
 		Coverage: result.LineCoverage, Duplication: duplicationOf(result), Previous: baseline,
 	})
 	if err != nil {
@@ -398,10 +408,40 @@ func (s *Service) RecordProjectAnalysis(ctx context.Context, engagementID shared
 	if err != nil {
 		return fmt.Errorf("marshal project analysis result: %w", err)
 	}
-	if err := s.analyses.SaveWithResult(ctx, analysis, data); err != nil {
+	if projectionStore, ok := s.analyses.(ports.ProjectAnalysisProjectionStore); ok {
+		if err := projectionStore.SaveWithResultAndHotspots(ctx, analysis, data, candidates); err != nil {
+			return fmt.Errorf("save project analysis and hotspots: %w", err)
+		}
+	} else if len(candidates) > 0 {
+		return fmt.Errorf("save project analysis and hotspots: projection store is not configured")
+	} else if err := s.analyses.SaveWithResult(ctx, analysis, data); err != nil {
 		return fmt.Errorf("save project analysis: %w", err)
 	}
 	return nil
+}
+
+// ListHotspots returns only projections belonging to the requested tenant and Project.
+func (s *Service) ListHotspots(ctx context.Context, tenantID shared.ID, key string, filter hotspot.ListFilter) (hotspot.Page, error) {
+	if s.hotspots == nil {
+		return hotspot.Page{}, shared.ErrNotFound
+	}
+	p, err := s.Get(ctx, tenantID, key)
+	if err != nil {
+		return hotspot.Page{}, err
+	}
+	return s.hotspots.ListHotspots(ctx, tenantID, p.ID, filter)
+}
+
+// GetHotspot returns one projection only after the Project has been resolved in the caller's tenant.
+func (s *Service) GetHotspot(ctx context.Context, tenantID shared.ID, key string, hotspotID shared.ID) (hotspot.Hotspot, error) {
+	if s.hotspots == nil {
+		return hotspot.Hotspot{}, shared.ErrNotFound
+	}
+	p, err := s.Get(ctx, tenantID, key)
+	if err != nil {
+		return hotspot.Hotspot{}, err
+	}
+	return s.hotspots.GetHotspot(ctx, tenantID, p.ID, hotspotID)
 }
 
 func (s *Service) resolveManagedGate(ctx context.Context, tenantID shared.ID, key string) (qualitygate.Gate, error) {

--- a/internal/usecase/projectuc/service_test.go
+++ b/internal/usecase/projectuc/service_test.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -31,6 +33,17 @@ type captureAudit struct{ entries []ports.AuditEntry }
 func (a *captureAudit) Record(_ context.Context, e ports.AuditEntry) error {
 	a.entries = append(a.entries, e)
 	return nil
+}
+
+type projectRuleCatalog struct{ rules map[rule.Key]rule.Rule }
+
+func (c projectRuleCatalog) List(context.Context) ([]rule.Rule, error) { return nil, nil }
+func (c projectRuleCatalog) Get(_ context.Context, key rule.Key) (rule.Rule, error) {
+	item, ok := c.rules[key]
+	if !ok {
+		return rule.Rule{}, shared.ErrNotFound
+	}
+	return item, nil
 }
 
 func TestServiceCRUDAndAudit(t *testing.T) {
@@ -271,5 +284,55 @@ func TestRecordProjectAnalysisHydratesCurrentTriageOnly(t *testing.T) {
 	}
 	if list[0].Issues.Total != 1 || len(list[0].InternalIssues) != 1 || list[0].InternalIssues[0].Key != "current" {
 		t.Fatalf("stale finding leaked into snapshot: %+v", list[0])
+	}
+}
+
+func TestRecordProjectAnalysisExcludesCatalogHotspotsFromProjectMetrics(t *testing.T) {
+	ctx := context.Background()
+	projects := memory.NewProjectRepository()
+	engagements := memory.NewEngagementRepository()
+	analyses := memory.NewProjectAnalysisStore()
+	svc := NewService(projects, engagements, fixedClock{}, fixedIDs{}, &captureAudit{}, true)
+	svc.SetAnalysisStore(analyses)
+	svc.SetHotspotStore(analyses)
+	svc.SetRuleCatalog(projectRuleCatalog{rules: map[rule.Key]rule.Rule{
+		"hotspot-rule": {Key: "hotspot-rule", Type: rule.TypeSecurityHotspot, Qualities: []rule.Quality{rule.QualitySecurity}},
+	}})
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, err := engagements.GetByProjectID(ctx, p.TenantID, p.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := &scauc.ScanResult{Findings: []finding.Finding{
+		{ID: "hotspot", DedupKey: "sast:hotspot-rule:src/main.go:7", RuleKey: "hotspot-rule", Kind: finding.KindSAST, Severity: shared.SeverityCritical, Title: "Review this", Description: "Review the security-sensitive use", Status: finding.StatusOpen},
+		{ID: "normal", DedupKey: "normal", Kind: finding.KindSCA, Severity: shared.SeverityLow, Title: "Normal", Description: "Normal issue", Status: finding.StatusOpen},
+	}}
+	if err := svc.RecordProjectAnalysis(ctx, e.ID, "job-1", time.Unix(1, 0), result); err != nil {
+		t.Fatal(err)
+	}
+	list, _, err := analyses.List(ctx, p.TenantID, p.ID, 1, time.Time{}, "")
+	if err != nil || len(list) != 1 {
+		t.Fatalf("analysis=%+v err=%v", list, err)
+	}
+	analysis := list[0]
+	if analysis.Issues.Total != 1 || analysis.NewCode.Counts.Total != 1 {
+		t.Fatalf("hotspot counted as issue: %+v", analysis)
+	}
+	if got := analysis.Measures[qualitygate.MetricNewVulnerability]; got != 1 {
+		t.Fatalf("new vulnerability=%v, want 1 normal finding only", got)
+	}
+	if analysis.Rating.Security != "B" {
+		t.Fatalf("security rating=%q, want B from low normal issue only", analysis.Rating.Security)
+	}
+	if got := analysis.Measures[qualitygate.MetricNewCritical]; got != 0 {
+		t.Fatalf("new critical=%v, hotspot leaked into gate measures", got)
+	}
+	id := hotspot.DeterministicID(p.TenantID, p.ID, "sast:hotspot-rule:src/main.go:7")
+	projected, err := analyses.GetHotspot(ctx, p.TenantID, p.ID, id)
+	if err != nil || projected.Status != hotspot.StatusToReview || projected.Location != "src/main.go:7" {
+		t.Fatalf("projection=%+v err=%v", projected, err)
 	}
 }

--- a/migrations/0052_project_hotspots.sql
+++ b/migrations/0052_project_hotspots.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+CREATE TABLE project_hotspots (
+    id                    TEXT PRIMARY KEY,
+    tenant_id             TEXT NOT NULL REFERENCES tenants(id),
+    project_id            TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    hotspot_key           TEXT NOT NULL,
+    finding_identity      TEXT NOT NULL,
+    rule_key              TEXT NOT NULL,
+    title                 TEXT NOT NULL,
+    description           TEXT NOT NULL,
+    severity              TEXT NOT NULL,
+    finding_kind          TEXT NOT NULL,
+    cwe                   TEXT NOT NULL DEFAULT '',
+    location              TEXT NOT NULL DEFAULT '',
+    status                TEXT NOT NULL CHECK (status IN ('to_review', 'acknowledged', 'fixed', 'safe')),
+    version               INTEGER NOT NULL CHECK (version >= 1),
+    first_seen_analysis_id TEXT NOT NULL,
+    last_seen_analysis_id  TEXT NOT NULL,
+    first_seen_at          TIMESTAMPTZ NOT NULL,
+    last_seen_at           TIMESTAMPTZ NOT NULL,
+    last_reviewed_by       TEXT NOT NULL DEFAULT '',
+    last_reviewed_at       TIMESTAMPTZ,
+    created_at             TIMESTAMPTZ NOT NULL,
+    updated_at             TIMESTAMPTZ NOT NULL,
+    UNIQUE (tenant_id, project_id, hotspot_key)
+);
+
+CREATE INDEX idx_project_hotspots_tenant_project_status
+    ON project_hotspots (tenant_id, project_id, status);
+CREATE INDEX idx_project_hotspots_tenant_project_rule
+    ON project_hotspots (tenant_id, project_id, rule_key);
+CREATE INDEX idx_project_hotspots_tenant_project_seen
+    ON project_hotspots (tenant_id, project_id, last_seen_at DESC, id COLLATE "C" DESC);
+
+-- +goose Down
+DROP TABLE project_hotspots;


### PR DESCRIPTION
## Summary

Introduces the read-only Project Security Hotspot foundation for #179.

Findings backed by catalog rules of type `security_hotspot` are now projected into stable, tenant-scoped and Project-scoped hotspot records instead of being treated as confirmed vulnerabilities in Project analysis metrics.

This PR intentionally delivers the projection and read API only. The governed review workflow, Reviewed %, Overview integration, Quality Gate metrics, and Security Hotspots web experience will be completed in the follow-up PR that finishes #179.

## What changed

* Added a dedicated Project Security Hotspot domain model and closed status vocabulary.
* Added deterministic hotspot classification using `Finding.RuleKey → catalog Rule.Type`.
* Added stable hotspot identities across repeated Project analyses.
* Added memory and PostgreSQL persistence implementations.
* Added migration `0052_project_hotspots.sql`.
* Added atomic persistence for the immutable Project analysis and its hotspot projections.
* Added rollback behavior when hotspot projection persistence fails.
* Preserved review state, version, first-seen metadata, and latest descriptive fields across rescans.
* Added deterministic handling for analyses arriving out of chronological order.
* Added read-only Project hotspot endpoints:

  * `GET /api/v1/projects/{key}/hotspots`
  * `GET /api/v1/projects/{key}/hotspots/{id}`
* Added status, rule, severity, and text filters.
* Added deterministic cursor pagination and filtered facets.
* Added tenant isolation, Project isolation, RBAC, response-leakage, persistence, and OpenAPI tests.
* Updated API startup wiring to require the shared rule catalog and hotspot-capable Project analysis store.

## Classification contract

The rule catalog type is the sole authority for hotspot classification:

```text
Finding.RuleKey
→ catalog lookup
→ Rule.Type == security_hotspot
→ Security Hotspot projection
```

Classification does not infer hotspot status from:

* finding kind;
* severity;
* CWE;
* title;
* tags;
* security quality alone.

Findings with missing or unknown rule metadata remain in the normal finding path.

Catalog infrastructure failures fail the Project analysis rather than producing an incomplete hotspot projection.

## Metrics and vulnerability separation

Hotspot candidates are partitioned before the immutable Project snapshot is built.

As a result, Security Hotspots are excluded from:

* Overall issue counts;
* New Code issue counts;
* Security rating calculations;
* `new_vulnerability`;
* severity-based New Code gate metrics;
* existing vulnerability-based Quality Gate calculations.

The immutable raw scan-result blob remains unchanged so the original scanner evidence is retained. Dedicated hotspot presentation and review behavior will be completed in the follow-up PR.

## Persistence and rescan behavior

The Project analysis snapshot and hotspot projections are persisted in one PostgreSQL transaction.

A hotspot projection failure rolls back the analysis write, preventing a successful Project analysis from being published without its hotspot projection.

Across rescans, an existing hotspot preserves:

* its stable ID;
* current review status;
* version;
* first-seen metadata.

Only the latest chronological analysis updates descriptive fields and last-seen metadata. An older analysis arriving later may correct first-seen metadata without overwriting newer hotspot details.

## API and tenancy

Both hotspot routes require `PermView`.

Every request resolves the Project in the authenticated tenant before accessing hotspot data. Persistence queries are additionally scoped by both tenant ID and Project ID.

The API does not expose:

* tenant IDs;
* Project IDs;
* Engagement IDs;
* internal Project analysis identity collections;
* raw scan payloads.

## Intentional follow-up scope

This PR does not implement the complete #179 workflow.

The follow-up PR will add:

* authenticated review transitions:

  * `To review`
  * `Acknowledged`
  * `Fixed`
  * `Safe`
* required review rationale;
* optimistic concurrency;
* attributable append-only review history;
* stricter fail-closed handling for missing classifier configuration;
* Overall and New Code hotspot summaries;
* `security_hotspots_reviewed`;
* Security Review rating;
* Project Overview availability;
* Quality Gate metrics;
* the Project Security Hotspots tab;
* list and review side-panel UI;
* dedicated presentation that avoids ambiguity between raw analysis evidence and hotspot review records.

That follow-up PR will complete the acceptance criteria and close #179.

## Validation

Local validation performed:

* Targeted Go tests — passed
* Rule-producer parity tests — passed
* PostgreSQL integration test against a real database — passed
* Full non-sandbox Go suite — passed
* `go vet ./...` — passed
* OpenAPI YAML parsing — passed
* `git diff --check` — passed

`go test ./...` reaches two existing sandbox integration failures caused by WSL host limitations:

* the sandbox root filesystem cannot be asserted as read-only;
* the sandbox probe cannot fork a process.

These failures are unrelated to the hotspot projection changes. All non-sandbox packages pass.

## Scope

* 20 changed files
* 7 commits
* Backend, persistence, migration, API, OpenAPI, and tests
* No frontend changes
* No review mutations
* No Overview or Quality Gate hotspot metric changes

Refs #179
