### PR TITLE
feat(codequality): persist engagement scan reports

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -887,7 +887,6 @@ func main() {
 		codequality.WithDuplication(duplication.New(0)),
 		codequality.WithInventory(codeinventory.New()),
 	)
-	router.SetCodeQuality(codeQualityService)
 	scaService.SetCodeQuality(codeQualityService)
 	if rulesSvc, rerr := rules.NewService(ruleCatalog); rerr != nil {
 		log.Error("rules service init failed", "err", rerr)

--- a/internal/adapter/httpapi/codequality_handler.go
+++ b/internal/adapter/httpapi/codequality_handler.go
@@ -1,24 +1,14 @@
 package httpapi
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/codequality"
 )
-
-// codeQualityService is the narrow slice of the code-quality use-case the HTTP layer needs: build the
-// dashboard report (inventory + findings + duplication + ratings) for a local source tree.
-// *codequality.Service satisfies it. Optional: nil => the code-quality route is not registered.
-type codeQualityService interface {
-	BuildReport(ctx context.Context, root string) (codequality.Report, error)
-}
-
-// SetCodeQuality wires the read-only code-quality dashboard endpoint.
-func (rt *Router) SetCodeQuality(s codeQualityService) { rt.codeQuality = s }
 
 // codeQualityReportView wraps the latest stored code-quality report with an availability flag.
 type codeQualityReportView struct {
@@ -54,7 +44,7 @@ func (rt *Router) codeQualityReport(w http.ResponseWriter, r *http.Request) {
 		CodeQuality *codequality.Report `json:"code_quality"`
 	}
 	if err := json.Unmarshal(data, &cached); err != nil {
-		writeError(w, rt.log, err)
+		writeError(w, rt.log, fmt.Errorf("decode cached scan result: %w", err))
 		return
 	}
 	if cached.CodeQuality == nil {

--- a/internal/adapter/httpapi/codequality_handler.go
+++ b/internal/adapter/httpapi/codequality_handler.go
@@ -2,10 +2,10 @@ package httpapi
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
-	"os"
 
-	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/codequality"
 )
@@ -20,58 +20,46 @@ type codeQualityService interface {
 // SetCodeQuality wires the read-only code-quality dashboard endpoint.
 func (rt *Router) SetCodeQuality(s codeQualityService) { rt.codeQuality = s }
 
-// codeQualityReportView wraps the report with an availability flag: code quality is computed over a LOCAL
-// source directory, so an engagement whose scope has no on-disk directory (e.g. an image-only or remote
-// target) returns Available=false with a reason rather than an error.
+// codeQualityReportView wraps the latest stored code-quality report with an availability flag.
 type codeQualityReportView struct {
 	Available bool                `json:"available"`
 	Reason    string              `json:"reason,omitempty"`
 	Report    *codequality.Report `json:"report,omitempty"`
 }
 
-// codeQualityReport returns the code-quality report for the engagement's in-scope local source directory.
-// Auth (PermView) + tenant scoping are applied by the route wrapper. The analyzed path is taken ONLY from
-// the engagement's authorized in-scope targets (never a client-supplied path), and must exist on disk.
+const codeQualityUnavailable = "Run an Engagement scan with Code quality enabled to generate a stored report"
+
+// codeQualityReport returns the code-quality report stored by the latest explicit Engagement scan. Auth
+// (PermView) + tenant scoping are applied by the route wrapper. Reading this endpoint never analyzes source.
 func (rt *Router) codeQualityReport(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		writeJSON(w, http.StatusBadRequest, errorBody{Error: "engagement id is required"})
 		return
 	}
-	e, err := rt.eng.Get(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(id))
+	if _, err := rt.eng.Get(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(id)); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	data, err := rt.sca.LatestResult(r.Context(), shared.ID(id))
+	if errors.Is(err, shared.ErrNotFound) {
+		writeJSON(w, http.StatusOK, codeQualityReportView{Reason: codeQualityUnavailable})
+		return
+	}
 	if err != nil {
 		writeError(w, rt.log, err)
 		return
 	}
-	root := localSourceDir(e.Scope)
-	if root == "" {
-		writeJSON(w, http.StatusOK, codeQualityReportView{
-			Available: false,
-			Reason:    "Code Quality requires an in-scope local source directory; this engagement has none",
-		})
-		return
+	var cached struct {
+		CodeQuality *codequality.Report `json:"code_quality"`
 	}
-	rep, err := rt.codeQuality.BuildReport(r.Context(), root)
-	if err != nil {
+	if err := json.Unmarshal(data, &cached); err != nil {
 		writeError(w, rt.log, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, codeQualityReportView{Available: true, Report: &rep})
-}
-
-// localSourceDir returns the first in-scope repo target whose value is an existing local directory and is
-// not excluded by the engagement's out-of-scope rules, or "" when none is. Only authorized scope targets
-// are considered, so a caller can never point the analyzer at an arbitrary server path; the AllowsTarget
-// check honors the "out-of-scope always wins" invariant at the repo level. (Pruning out-of-scope SUBPATHS
-// inside an allowed repo is a follow-up; the analyzer walk currently covers the whole allowed directory.)
-func localSourceDir(scope engagement.Scope) string {
-	for _, t := range scope.InScope {
-		if t.Kind != engagement.TargetRepo || !scope.AllowsTarget(t) {
-			continue
-		}
-		if fi, err := os.Stat(t.Value); err == nil && fi.IsDir() {
-			return t.Value
-		}
+	if cached.CodeQuality == nil {
+		writeJSON(w, http.StatusOK, codeQualityReportView{Reason: codeQualityUnavailable})
+		return
 	}
-	return ""
+	writeJSON(w, http.StatusOK, codeQualityReportView{Available: true, Report: cached.CodeQuality})
 }

--- a/internal/adapter/httpapi/codequality_handler_test.go
+++ b/internal/adapter/httpapi/codequality_handler_test.go
@@ -15,13 +15,6 @@ import (
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
 )
 
-type codeQualityFake struct{ calls int }
-
-func (s *codeQualityFake) BuildReport(context.Context, string) (codequality.Report, error) {
-	s.calls++
-	return codequality.Report{}, nil
-}
-
 type scanResultsFake struct {
 	data []byte
 	err  error
@@ -32,11 +25,10 @@ func (s scanResultsFake) LatestResult(context.Context, shared.ID) ([]byte, error
 	return s.data, s.err
 }
 
-func newCodeQualityRouter(t *testing.T, results ports.ScanResultStore, analyzer *codeQualityFake) *Router {
+func newCodeQualityRouter(t *testing.T, results ports.ScanResultStore) *Router {
 	t.Helper()
 	rt, _, _ := newEngRouter(t)
 	rt.sca = scauc.NewService(nil, nil, nil, results, nil, nil, nil, nil, ports.Provenance{}, fixedClock{}, &fakeAudit{}, shared.SeverityInfo, 0, nil, nil, nil, nil, nil, nil, nil)
-	rt.SetCodeQuality(analyzer)
 	return rt
 }
 
@@ -56,8 +48,7 @@ func TestCodeQualityReportReturnsStoredScanResult(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	analyzer := &codeQualityFake{}
-	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{data: data}, analyzer))
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{data: data}))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
@@ -68,14 +59,10 @@ func TestCodeQualityReportReturnsStoredScanResult(t *testing.T) {
 	if !got.Available || got.Report == nil || len(got.Report.Findings) != 1 || got.Report.Findings[0].Title != "Stored finding" {
 		t.Fatalf("response = %+v", got)
 	}
-	if analyzer.calls != 0 {
-		t.Fatalf("BuildReport calls = %d, want 0", analyzer.calls)
-	}
 }
 
 func TestCodeQualityReportWithoutStoredReportIsUnavailable(t *testing.T) {
-	analyzer := &codeQualityFake{}
-	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{data: []byte(`{}`)}, analyzer))
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{data: []byte(`{}`)}))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
@@ -85,15 +72,11 @@ func TestCodeQualityReportWithoutStoredReportIsUnavailable(t *testing.T) {
 	}
 	if got.Available || got.Reason != codeQualityUnavailable {
 		t.Fatalf("response = %+v", got)
-	}
-	if analyzer.calls != 0 {
-		t.Fatalf("BuildReport calls = %d, want 0", analyzer.calls)
 	}
 }
 
 func TestCodeQualityReportWithoutScanIsUnavailable(t *testing.T) {
-	analyzer := &codeQualityFake{}
-	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{err: shared.ErrNotFound}, analyzer))
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{err: shared.ErrNotFound}))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
@@ -104,20 +87,17 @@ func TestCodeQualityReportWithoutScanIsUnavailable(t *testing.T) {
 	if got.Available || got.Reason != codeQualityUnavailable {
 		t.Fatalf("response = %+v", got)
 	}
-	if analyzer.calls != 0 {
-		t.Fatalf("BuildReport calls = %d, want 0", analyzer.calls)
-	}
 }
 
 func TestCodeQualityReportRejectsInvalidStoredResult(t *testing.T) {
-	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{data: []byte("not json")}, &codeQualityFake{}))
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{data: []byte("not json")}))
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
 }
 
 func TestCodeQualityReportSurfacesResultStoreError(t *testing.T) {
-	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{err: errors.New("store unavailable")}, &codeQualityFake{}))
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{err: errors.New("store unavailable")}))
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}

--- a/internal/adapter/httpapi/codequality_handler_test.go
+++ b/internal/adapter/httpapi/codequality_handler_test.go
@@ -1,48 +1,124 @@
 package httpapi
 
 import (
-	"os"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/codequality"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
 )
 
-func scopeOf(in []engagement.Target, out ...engagement.Target) engagement.Scope {
-	return engagement.Scope{InScope: in, OutOfScope: out}
+type codeQualityFake struct{ calls int }
+
+func (s *codeQualityFake) BuildReport(context.Context, string) (codequality.Report, error) {
+	s.calls++
+	return codequality.Report{}, nil
 }
 
-func TestLocalSourceDir(t *testing.T) {
-	dir := t.TempDir()
-	// A repo target whose value is an existing directory is returned.
-	got := localSourceDir(scopeOf([]engagement.Target{
-		{Kind: engagement.TargetDomain, Value: "app.example.com"},
-		{Kind: engagement.TargetRepo, Value: dir},
-	}))
-	if got != dir {
-		t.Errorf("want %q, got %q", dir, got)
+type scanResultsFake struct {
+	data []byte
+	err  error
+}
+
+func (s scanResultsFake) SaveResult(context.Context, shared.ID, []byte) error { return nil }
+func (s scanResultsFake) LatestResult(context.Context, shared.ID) ([]byte, error) {
+	return s.data, s.err
+}
+
+func newCodeQualityRouter(t *testing.T, results ports.ScanResultStore, analyzer *codeQualityFake) *Router {
+	t.Helper()
+	rt, _, _ := newEngRouter(t)
+	rt.sca = scauc.NewService(nil, nil, nil, results, nil, nil, nil, nil, ports.Provenance{}, fixedClock{}, &fakeAudit{}, shared.SeverityInfo, 0, nil, nil, nil, nil, nil, nil, nil)
+	rt.SetCodeQuality(analyzer)
+	return rt
+}
+
+func codeQualityCall(rt *Router) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/engagements/eng-1/code-quality", nil)
+	req.SetPathValue("id", "eng-1")
+	rec := httptest.NewRecorder()
+	rt.codeQualityReport(rec, req)
+	return rec
+}
+
+func TestCodeQualityReportReturnsStoredScanResult(t *testing.T) {
+	stored := codequality.Report{Findings: []finding.Finding{{Title: "Stored finding"}}}
+	data, err := json.Marshal(struct {
+		CodeQuality *codequality.Report `json:"code_quality"`
+	}{CodeQuality: &stored})
+	if err != nil {
+		t.Fatal(err)
 	}
-	// A repo target pointing at a non-existent path is ignored (no arbitrary path leaks).
-	if s := localSourceDir(scopeOf([]engagement.Target{{Kind: engagement.TargetRepo, Value: "/no/such/dir/xyz"}})); s != "" {
-		t.Errorf("non-existent path must yield \"\", got %q", s)
+	analyzer := &codeQualityFake{}
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{data: data}, analyzer))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
-	// A repo target pointing at a FILE (not a dir) is ignored.
-	f := dir + "/afile"
-	os.WriteFile(f, []byte("x"), 0o644)
-	if s := localSourceDir(scopeOf([]engagement.Target{{Kind: engagement.TargetRepo, Value: f}})); s != "" {
-		t.Errorf("file target must yield \"\", got %q", s)
+	var got codeQualityReportView
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
 	}
-	// Non-repo kinds (image/url) never match.
-	if s := localSourceDir(scopeOf([]engagement.Target{{Kind: engagement.TargetImage, Value: dir}})); s != "" {
-		t.Errorf("non-repo kind must yield \"\", got %q", s)
+	if !got.Available || got.Report == nil || len(got.Report.Findings) != 1 || got.Report.Findings[0].Title != "Stored finding" {
+		t.Fatalf("response = %+v", got)
 	}
-	// A repo that is also out-of-scope must be rejected (out-of-scope always wins).
-	if s := localSourceDir(scopeOf(
-		[]engagement.Target{{Kind: engagement.TargetRepo, Value: dir}},
-		engagement.Target{Kind: engagement.TargetRepo, Value: dir},
-	)); s != "" {
-		t.Errorf("out-of-scope repo must yield \"\", got %q", s)
+	if analyzer.calls != 0 {
+		t.Fatalf("BuildReport calls = %d, want 0", analyzer.calls)
 	}
-	if s := localSourceDir(scopeOf(nil)); s != "" {
-		t.Errorf("empty targets must yield \"\", got %q", s)
+}
+
+func TestCodeQualityReportWithoutStoredReportIsUnavailable(t *testing.T) {
+	analyzer := &codeQualityFake{}
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{data: []byte(`{}`)}, analyzer))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got codeQualityReportView
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Available || got.Reason != codeQualityUnavailable {
+		t.Fatalf("response = %+v", got)
+	}
+	if analyzer.calls != 0 {
+		t.Fatalf("BuildReport calls = %d, want 0", analyzer.calls)
+	}
+}
+
+func TestCodeQualityReportWithoutScanIsUnavailable(t *testing.T) {
+	analyzer := &codeQualityFake{}
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{err: shared.ErrNotFound}, analyzer))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got codeQualityReportView
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Available || got.Reason != codeQualityUnavailable {
+		t.Fatalf("response = %+v", got)
+	}
+	if analyzer.calls != 0 {
+		t.Fatalf("BuildReport calls = %d, want 0", analyzer.calls)
+	}
+}
+
+func TestCodeQualityReportRejectsInvalidStoredResult(t *testing.T) {
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{data: []byte("not json")}, &codeQualityFake{}))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCodeQualityReportSurfacesResultStoreError(t *testing.T) {
+	rec := codeQualityCall(newCodeQualityRouter(t, scanResultsFake{err: errors.New("store unavailable")}, &codeQualityFake{}))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
 }

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -59,7 +59,6 @@ type Router struct {
 	autoVerifier autoVerifierService // optional; nil ⇒ the LLM auto-verify route is not registered
 	threatModels threatModelService  // optional; nil ⇒ threat-model routes are not registered
 	drafts       writeupDraftService // optional; nil ⇒ writeup-draft sign-off routes are not registered
-	codeQuality  codeQualityService  // optional; nil ⇒ the code-quality route is not registered
 	projects     projectService      // optional; nil ⇒ project routes are not registered
 	qualityGates qualityGateService  // optional; nil ⇒ quality-gate routes are not registered
 	rules        rulesService        // optional; nil ⇒ rule catalog routes are not registered
@@ -274,7 +273,7 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("PUT /api/v1/engagements/{id}/threat-model", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.putThreatModel)))
 		mux.HandleFunc("GET /api/v1/engagements/{id}/threat-model", rt.authz(userdom.PermView, rt.withEngTenant(rt.getThreatModel)))
 	}
-	if rt.codeQuality != nil { // read-only code-quality dashboard (PermView)
+	if rt.sca != nil { // persisted Code Quality reports are stored by the SCA service
 		mux.HandleFunc("GET /api/v1/engagements/{id}/code-quality", rt.authz(userdom.PermView, rt.withEngTenant(rt.codeQualityReport)))
 	}
 	if rt.drafts != nil { // AI-proposed write-up drafts – read (PermView) + human sign-off edit/accept/reject (PermReview, SoD)

--- a/internal/adapter/httpapi/sca_handler.go
+++ b/internal/adapter/httpapi/sca_handler.go
@@ -15,9 +15,10 @@ import (
 type scaScanRequest struct {
 	EngagementID string `json:"engagement_id"`
 	Target       string `json:"target"`
-	Kind         string `json:"kind"` // local (default) | git | archive | image
-	Ref          string `json:"ref"`  // optional git branch/tag
-	Mode         string `json:"mode"` // full (default) | vulnerabilities | licenses
+	Kind         string `json:"kind"`         // local (default) | git | archive | image
+	Ref          string `json:"ref"`          // optional git branch/tag
+	Mode         string `json:"mode"`         // full (default) | vulnerabilities | licenses
+	CodeQuality  bool   `json:"code_quality"` // include first-party code-quality findings
 }
 
 // validateScanTarget rejects a malformed target synchronously. Returns
@@ -104,7 +105,7 @@ func (rt *Router) runSCAScan(w http.ResponseWriter, r *http.Request) {
 		PrincipalFrom(r.Context()),
 		shared.ID(req.EngagementID),
 		ports.AcquireRequest{Kind: req.Kind, Value: req.Target, Ref: req.Ref},
-		scauc.ScanOptions{Mode: req.Mode},
+		scauc.ScanOptions{Mode: req.Mode, CodeQuality: req.CodeQuality},
 	)
 	if err != nil {
 		writeError(w, rt.log, err)

--- a/internal/domain/qualitygate/profile.go
+++ b/internal/domain/qualitygate/profile.go
@@ -46,35 +46,49 @@ func (p Profile) Apply(findings []finding.Finding) []finding.Finding {
 	return out
 }
 
-// knownKinds are the dedup-key prefixes whose rule id is the SECOND field (<kind>:<rule>:<file>:<line>).
+// knownKinds are the first-party dedup-key prefixes whose rule id follows the kind.
 var knownKinds = map[string]bool{"sast": true, "secret": true, "misconfig": true, "quality": true, "reliability": true}
 
-// RuleIDOf extracts the rule/advisory identifier a profile keys on from a finding's dedup key: the second
-// field for first-party kinds (<kind>:<rule>:...), else the first field (an SCA advisory id).
+// firstPartyParts returns the rule and path fields for legacy <kind>:<rule>:<file>:<line> keys and
+// Code Quality's collision-safe cq:<kind>:<rule>:<file>:<line> keys.
+func firstPartyParts(dedupKey string) (parts []string, offset int, ok bool) {
+	parts = strings.Split(dedupKey, ":")
+	if len(parts) >= 5 && parts[0] == "cq" && knownKinds[parts[1]] {
+		return parts, 2, true
+	}
+	if len(parts) >= 4 && knownKinds[parts[0]] {
+		return parts, 1, true
+	}
+	return nil, 0, false
+}
+
+// RuleIDOf extracts the rule/advisory identifier a profile keys on from a first-party dedup key, or the
+// first field of an SCA advisory key.
 func RuleIDOf(dedupKey string) string {
-	parts := strings.Split(dedupKey, ":")
+	parts, offset, ok := firstPartyParts(dedupKey)
+	if ok {
+		return parts[offset]
+	}
+	parts = strings.Split(dedupKey, ":")
 	if len(parts) == 0 {
 		return ""
-	}
-	if len(parts) >= 2 && knownKinds[parts[0]] {
-		return parts[1]
 	}
 	return parts[0]
 }
 
-// FileLineOf extracts the source file and 1-based line from a first-party dedup key
-// (<kind>:<rule>:<file>:<line>). ok=false for a key that is not line-anchored (e.g. an SCA advisory key),
-// so a caller can decide how to treat non-line-anchored findings under new-code gating.
+// FileLineOf extracts the source file and 1-based line from a first-party dedup key. ok=false for a key
+// that is not line-anchored (e.g. an SCA advisory key), so a caller can decide how to treat it under
+// new-code gating.
 func FileLineOf(dedupKey string) (file string, line int, ok bool) {
-	parts := strings.Split(dedupKey, ":")
-	if len(parts) < 4 || !knownKinds[parts[0]] {
+	parts, offset, ok := firstPartyParts(dedupKey)
+	if !ok {
 		return "", 0, false
 	}
 	n, err := strconv.Atoi(parts[len(parts)-1])
 	if err != nil || n < 1 {
 		return "", 0, false
 	}
-	file = strings.Join(parts[2:len(parts)-1], ":") // rejoin a Windows-y path that contained colons
+	file = strings.Join(parts[offset+1:len(parts)-1], ":") // rejoin a Windows-y path that contained colons
 	if file == "" {
 		return "", 0, false
 	}

--- a/internal/domain/qualitygate/profile_test.go
+++ b/internal/domain/qualitygate/profile_test.go
@@ -11,9 +11,10 @@ func boolp(b bool) *bool { return &b }
 
 func TestRuleIDOf(t *testing.T) {
 	cases := map[string]string{
-		"quality:quality-todo-comment:a.go:3": "quality-todo-comment",
-		"sast:weak-hash-md5:x/y.go:12":        "weak-hash-md5",
-		"CVE-2024-1234:pkg:1.0.0":             "CVE-2024-1234", // SCA: no kind prefix -> first field
+		"quality:quality-todo-comment:a.go:3":    "quality-todo-comment",
+		"cq:quality:quality-todo-comment:a.go:3": "quality-todo-comment",
+		"sast:weak-hash-md5:x/y.go:12":           "weak-hash-md5",
+		"CVE-2024-1234:pkg:1.0.0":                "CVE-2024-1234", // SCA: no kind prefix -> first field
 	}
 	for dedup, want := range cases {
 		if got := RuleIDOf(dedup); got != want {
@@ -23,9 +24,14 @@ func TestRuleIDOf(t *testing.T) {
 }
 
 func TestFileLineOf(t *testing.T) {
-	f, l, ok := FileLineOf("quality:quality-todo-comment:pkg/a.go:42")
-	if !ok || f != "pkg/a.go" || l != 42 {
-		t.Errorf("got (%q,%d,%v), want (pkg/a.go,42,true)", f, l, ok)
+	for _, key := range []string{
+		"quality:quality-todo-comment:pkg/a.go:42",
+		"cq:quality:quality-todo-comment:pkg/a.go:42",
+	} {
+		f, l, ok := FileLineOf(key)
+		if !ok || f != "pkg/a.go" || l != 42 {
+			t.Errorf("FileLineOf(%q) = (%q,%d,%v), want (pkg/a.go,42,true)", key, f, l, ok)
+		}
 	}
 	if _, _, ok := FileLineOf("CVE-2024-1: pkg:1.0"); ok {
 		t.Error("an SCA (non-line-anchored) key must return ok=false")

--- a/internal/usecase/codequality/service.go
+++ b/internal/usecase/codequality/service.go
@@ -188,13 +188,12 @@ func (s *Service) analyze(ctx context.Context, root string) ([]finding.Finding, 
 	return out, dupReport, nil
 }
 
-// newFinding maps a raw code-quality signal to a first-party finding. The DedupKey (<kind>:<rule>:<file>:
-// <line>) is the same shape the SARIF exporter's firstPartyLoc parses, so the finding gets a file:line
-// physical location automatically. The finding is TRANSIENT (read-only CLI/SARIF producer): EngagementID
-// and Audit are intentionally unset; a future scan/store wiring must populate them (as the SCA first-party
-// builders do) before persisting.
+// newFinding maps a raw code-quality signal to a first-party finding. The DedupKey
+// (cq:<kind>:<rule>:<file>:<line>) keeps this producer separate from pattern-SAST while preserving the
+// SARIF exporter physical location. The finding is TRANSIENT (read-only CLI/SARIF producer): EngagementID
+// and Audit are intentionally unset; SCA scan wiring populates them before persistence.
 func newFinding(kind, ruleID, cwe string, sev shared.Severity, title, desc, file string, line int) finding.Finding {
-	dedup := kind + ":" + ruleID + ":" + file + ":" + strconv.Itoa(line)
+	dedup := "cq:" + kind + ":" + ruleID + ":" + file + ":" + strconv.Itoa(line)
 	k := finding.KindQuality
 	switch kind {
 	case "reliability":

--- a/internal/usecase/codequality/service_test.go
+++ b/internal/usecase/codequality/service_test.go
@@ -62,7 +62,7 @@ func TestServiceMapsAndBridges(t *testing.T) {
 		t.Fatalf("analyze: %v", err)
 	}
 	todo := byRule(fs, "quality-todo-comment")
-	if todo == nil || todo.Kind != finding.KindQuality || todo.DedupKey != "quality:quality-todo-comment:a.go:3" {
+	if todo == nil || todo.Kind != finding.KindQuality || todo.DedupKey != "cq:quality:quality-todo-comment:a.go:3" {
 		t.Errorf("todo mapping wrong: %+v", todo)
 	}
 	if todo.Class != finding.ClassFirstParty || todo.Status != finding.StatusOpen {
@@ -112,6 +112,18 @@ func (f fakeBugs) Bugs(context.Context, string) ([]ports.BugFinding, bool, error
 	return f.bugs, f.available, nil
 }
 
+func TestCodeQualitySASTKeysAreNamespaced(t *testing.T) {
+	fs, err := New(fakeAnalyzer{raws: []ports.CodeAnalysisRawFinding{{
+		Kind: "sast", RuleID: "weak-hash-md5", File: "cmd/app/main.go", Line: 42,
+	}}}).Analyze(context.Background(), "root")
+	if err != nil || len(fs) != 1 {
+		t.Fatalf("findings = %+v, err = %v", fs, err)
+	}
+	if got, want := fs[0].DedupKey, "cq:sast:weak-hash-md5:cmd/app/main.go:42"; got != want {
+		t.Fatalf("DedupKey = %q, want %q", got, want)
+	}
+}
+
 func TestBugsBridgeEmitsReliability(t *testing.T) {
 	bugs := fakeBugs{available: true, bugs: []ports.BugFinding{
 		{Rule: "reliability-unreachable-code", Message: "unreachable", File: "a.go", Line: 7},
@@ -123,7 +135,7 @@ func TestBugsBridgeEmitsReliability(t *testing.T) {
 		t.Fatalf("analyze: %v", err)
 	}
 	unr := byRule(fs, "reliability-unreachable-code")
-	if unr == nil || unr.Kind != finding.KindReliability || unr.DedupKey != "reliability:reliability-unreachable-code:a.go:7" {
+	if unr == nil || unr.Kind != finding.KindReliability || unr.DedupKey != "cq:reliability:reliability-unreachable-code:a.go:7" {
 		t.Errorf("unreachable bug mapping wrong: %+v", unr)
 	}
 	cc := byRule(fs, "reliability-constant-condition")

--- a/internal/usecase/export/sarif.go
+++ b/internal/usecase/export/sarif.go
@@ -200,14 +200,13 @@ func buildSARIF(findings []finding.Finding, version string, opts SARIFOptions) *
 }
 
 // firstPartyLoc parses a first-party finding dedup key of the form
-// "<kind>:<ruleID>:<file>:<line>" (kind in sast|secret|misconfig, as written by the SCA
-// finding builders) into the engine rule id and its physical file:line. The rule id and the
-// trailing line never contain ':', so a file path that does is recovered as the middle join.
-// Returns ok=false for any other key (SCA "vuln:...", "license:...") or a malformed one.
+// "<kind>:<ruleID>:<file>:<line>" or "cq:<kind>:<ruleID>:<file>:<line>" into the engine rule id
+// and its physical file:line. The rule id and trailing line never contain ':', so a file path that does
+// is recovered as the middle join. Returns ok=false for SCA "vuln:...", "license:...", or malformed keys.
 func firstPartyLoc(key string) (ruleID, file string, line int, ok bool) {
 	var rest string
 	matched := false
-	for _, kind := range []string{"sast:", "secret:", "misconfig:", "quality:", "reliability:"} {
+	for _, kind := range []string{"cq:sast:", "cq:quality:", "cq:reliability:", "sast:", "secret:", "misconfig:"} {
 		if r, has := strings.CutPrefix(key, kind); has {
 			rest, matched = r, true
 			break

--- a/internal/usecase/export/sarif_test.go
+++ b/internal/usecase/export/sarif_test.go
@@ -140,6 +140,8 @@ func TestFirstPartyLocParsing(t *testing.T) {
 		{"sast", "sast:weak-crypto-md5:app/main.go:42", true, "weak-crypto-md5", "app/main.go", 42},
 		{"secret", "secret:aws-key:a/b/c.env:3", true, "aws-key", "a/b/c.env", 3},
 		{"misconfig", "misconfig:dockerfile-run-sudo:Dockerfile:5", true, "dockerfile-run-sudo", "Dockerfile", 5},
+		{"code-quality", "cq:quality:quality-todo:app/main.go:6", true, "quality-todo", "app/main.go", 6},
+		{"code-quality-sast", "cq:sast:weak-crypto-md5:app/main.go:42", true, "weak-crypto-md5", "app/main.go", 42},
 		{"path-with-colon", "sast:rule:weird:path.go:7", true, "rule", "weird:path.go", 7},
 		{"sca-vuln", "vuln:CVE-2020-7471:django:2.2.0", false, "", "", 0},
 		{"license", "license:GPL-3.0-only", false, "", "", 0},

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -427,10 +427,10 @@ func buildCodeQualityFindings(engagementID shared.ID, items []finding.Finding, n
 
 func codeQualityFile(dedupKey string) string {
 	parts := strings.Split(dedupKey, ":")
-	if len(parts) < 4 {
+	if len(parts) < 5 || parts[0] != "cq" {
 		return ""
 	}
-	return strings.Join(parts[2:len(parts)-1], ":")
+	return strings.Join(parts[3:len(parts)-1], ":")
 }
 
 // findingID is a stable id derived from the engagement + dedup key, so the same

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -407,6 +407,32 @@ func sastPriority(sev shared.Severity) int {
 	}
 }
 
+// buildCodeQualityFindings stamps the transient code-quality producer output with
+// the engagement identity and audit fields required by the finding store.
+func buildCodeQualityFindings(engagementID shared.ID, items []finding.Finding, now time.Time) []finding.Finding {
+	out := make([]finding.Finding, 0, len(items))
+	for _, item := range items {
+		scope := sbom.ClassifyScope(codeQualityFile(item.DedupKey), "")
+		item.ID = findingID(engagementID, item.DedupKey)
+		item.EngagementID = engagementID
+		item.Scope = scope
+		item.Reachability = vulnerability.Reachability(scope, true)
+		item.Impact = vulnerability.Impact(item.Severity, scope)
+		item.Priority = sastPriority(item.Severity)
+		item.Audit = shared.Audit{CreatedAt: now, UpdatedAt: now}
+		out = append(out, item)
+	}
+	return out
+}
+
+func codeQualityFile(dedupKey string) string {
+	parts := strings.Split(dedupKey, ":")
+	if len(parts) < 4 {
+		return ""
+	}
+	return strings.Join(parts[2:len(parts)-1], ":")
+}
+
 // findingID is a stable id derived from the engagement + dedup key, so the same
 // issue always maps to the same finding across re-scans.
 func findingID(engagementID shared.ID, dedupKey string) shared.ID {

--- a/internal/usecase/sca/findings_test.go
+++ b/internal/usecase/sca/findings_test.go
@@ -228,6 +228,20 @@ func TestBuildFindingsSAST(t *testing.T) {
 	}
 }
 
+func TestCodeQualityFindingsUseDistinctSASTNamespace(t *testing.T) {
+	now := time.Unix(0, 0).UTC()
+	pattern := buildFindings("eng1", &ScanResult{}, now, shared.SeverityInfo, false, []ports.SASTRawFinding{{
+		File: "cmd/app/main.go", Line: 42, RuleID: "weak-hash-md5", Severity: shared.SeverityHigh,
+	}})[0]
+	quality := buildCodeQualityFindings("eng1", []finding.Finding{{
+		Kind: finding.KindSAST, RuleKey: "weak-hash-md5", Severity: shared.SeverityHigh,
+		DedupKey: "cq:sast:weak-hash-md5:cmd/app/main.go:42",
+	}}, now)[0]
+	if pattern.DedupKey == quality.DedupKey || pattern.ID == quality.ID {
+		t.Fatalf("pattern and code-quality SAST findings collided: pattern=%+v quality=%+v", pattern, quality)
+	}
+}
+
 func TestBuildSecretFindings(t *testing.T) {
 	raws := []ports.SecretRawFinding{
 		{File: "main.go", Line: 10, RuleID: "aws-key", Severity: shared.SeverityHigh, Title: "Hardcoded key"},

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -2176,6 +2176,14 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		}
 		result.Findings = append(result.Findings, buildMisconfigFindings(engagementID, misRaws, now, s.minSeverity)...)
 	}
+	if opts.CodeQuality && s.codeQuality != nil {
+		report, qerr := s.codeQuality.BuildReport(ctx, ws.Dir)
+		if qerr != nil {
+			return nil, fmt.Errorf("analyze code quality: %w", qerr)
+		}
+		result.CodeQuality = &report
+		result.Findings = append(result.Findings, buildCodeQualityFindings(engagementID, report.Findings, now)...)
+	}
 	// Apply the repo-committed .synapseignore accepted-risk policy. It ANNOTATES matched findings as
 	// accepted-risk (SuppressedFindings) so a CI --fail-on gate can exempt them, but does NOT remove them:
 	// they stay reported, persisted, and evidence-sealed, so an acceptance can never hide a finding from a
@@ -2210,13 +2218,6 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	result.VulnsBelowThreshold = countBelowThreshold(vulns, s.minSeverity)
 	result.UnfixedSuppressed = countUnfixedSuppressed(vulns, s.minSeverity, s.ignoreUnfixed)
 	result.FindingQuality = computeFindingQuality(result)
-	if opts.CodeQuality && s.codeQuality != nil {
-		report, qerr := s.codeQuality.BuildReport(ctx, ws.Dir)
-		if qerr != nil {
-			return nil, fmt.Errorf("analyze code quality: %w", qerr)
-		}
-		result.CodeQuality = &report
-	}
 	trace.succeed(step, "Findings derived", map[string]int{"vulnerabilities": len(vulns), "licenses": len(lics), "findings": len(result.Findings)})
 	result.DebugEvents = trace.snapshot()
 	if result.SBOM != nil {

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -137,11 +137,15 @@ func (c *countingLic) Scan(context.Context, *sbom.SBOM) ([]ports.LicenseFinding,
 	return []ports.LicenseFinding{{License: "MIT", Category: sbom.LicensePermissive, Verdict: ports.LicenseAllow, Components: []string{"pkg"}}}, nil
 }
 
-type countingCodeQuality struct{ calls int }
+type countingCodeQuality struct {
+	calls  int
+	report codequality.Report
+	err    error
+}
 
 func (c *countingCodeQuality) BuildReport(context.Context, string) (codequality.Report, error) {
 	c.calls++
-	return codequality.Report{}, nil
+	return c.report, c.err
 }
 
 func engagementWithScope(t *testing.T, inScope ...string) *engdom.Engagement {
@@ -216,6 +220,90 @@ func TestCodeQualityRequiresExplicitScanOption(t *testing.T) {
 	}
 	if quality.calls != 1 || project.CodeQuality == nil {
 		t.Fatalf("opted-in scan code quality: calls=%d report=%v", quality.calls, project.CodeQuality != nil)
+	}
+}
+
+func TestCodeQualityFindingsPersistWithScan(t *testing.T) {
+	ctx := context.Background()
+	now := time.Unix(100, 0).UTC()
+	findings := memory.NewFindingRepository()
+	runs := memory.NewScanRunStore()
+	results := memory.NewScanResultStore()
+	evidenceStore := &fakeEvidence{}
+	evidenceService, err := evidenceuc.NewService(evidenceStore, nil, &fakeAudit{}, fakeClock{t: now}, fakeIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	quality := &countingCodeQuality{report: codequality.Report{Findings: []finding.Finding{{
+		Title: "High complexity (internal/handler.go:42)", Description: "Split this function.", Severity: shared.SeverityMedium,
+		CWE: "CWE-1120", Sources: []string{"synapse-codeanalysis"}, Class: finding.ClassFirstParty,
+		Status: finding.StatusOpen, Kind: finding.KindQuality, RuleKey: "quality-high-complexity", DedupKey: "quality:quality-high-complexity:internal/handler.go:42",
+	}}}}
+	svc := NewService(
+		&fakeEngRepo{eng: engagementWithScope(t, "myrepo")}, findings, nil, results, nil, runs, evidenceService, fakeIDs{},
+		ports.Provenance{}, fakeClock{t: now}, &fakeAudit{}, shared.SeverityHigh, 0,
+		&fakeAcquirer{dir: "/tmp/ws"}, &fakeDetector{}, fakeSBOM{}, []ports.DetectionSource{fakeVuln{}}, nil, fakeLic{}, nil,
+	)
+	svc.SetCodeQuality(quality)
+
+	for i := 0; i < 2; i++ {
+		result, err := svc.ScanWithOptions(ctx, "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, CodeQuality: true})
+		if err != nil {
+			t.Fatalf("scan %d: %v", i, err)
+		}
+		if result.CodeQuality == nil || len(result.Findings) != 1 || result.FindingQuality.RawFindings != 1 || result.ReproDigest == "" {
+			t.Fatalf("result did not include code-quality finding: %+v", result)
+		}
+	}
+
+	stored, err := findings.ListByEngagement(ctx, "e1")
+	if err != nil || len(stored) != 1 {
+		t.Fatalf("persisted findings = %+v, err=%v", stored, err)
+	}
+	f := stored[0]
+	if f.ID != findingID("e1", f.DedupKey) || f.EngagementID != "e1" || f.Kind != finding.KindQuality || f.RuleKey != "quality-high-complexity" || f.Class != finding.ClassFirstParty || f.Scope != sbom.ScopeProduction || !f.Audit.CreatedAt.Equal(now) {
+		t.Fatalf("persisted code-quality finding = %+v", f)
+	}
+	history, err := runs.List(ctx, "e1")
+	if err != nil || len(history) != 2 || len(history[0].FindingKeys) != 1 || history[0].FindingKeys[0] != f.DedupKey {
+		t.Fatalf("scan history = %+v, err=%v", history, err)
+	}
+	if len(evidenceStore.items) != 2 || !strings.Contains(string(evidenceStore.items[0].Content), f.DedupKey) {
+		t.Fatalf("evidence did not seal code-quality finding: %+v", evidenceStore.items)
+	}
+	data, err := results.LatestResult(ctx, "e1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cached ScanResult
+	if err := json.Unmarshal(data, &cached); err != nil || len(cached.Findings) != 1 || cached.Findings[0].DedupKey != f.DedupKey {
+		t.Fatalf("cached result = %+v, err=%v", cached, err)
+	}
+}
+
+func TestCodeQualityFailurePersistsNoFindings(t *testing.T) {
+	ctx := context.Background()
+	findings := memory.NewFindingRepository()
+	runs := memory.NewScanRunStore()
+	results := memory.NewScanResultStore()
+	svc := NewService(
+		&fakeEngRepo{eng: engagementWithScope(t, "myrepo")}, findings, nil, results, nil, runs, nil, fakeIDs{},
+		ports.Provenance{}, fakeClock{t: time.Unix(100, 0).UTC()}, &fakeAudit{}, shared.SeverityHigh, 0,
+		&fakeAcquirer{dir: "/tmp/ws"}, &fakeDetector{}, fakeSBOM{}, []ports.DetectionSource{fakeVuln{}}, nil, fakeLic{}, nil,
+	)
+	svc.SetCodeQuality(&countingCodeQuality{err: errors.New("analyzer unavailable")})
+
+	if _, err := svc.ScanWithOptions(ctx, "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, CodeQuality: true}); err == nil || !strings.Contains(err.Error(), "analyze code quality") {
+		t.Fatalf("err=%v, want code-quality failure", err)
+	}
+	if got, _ := findings.ListByEngagement(ctx, "e1"); len(got) != 0 {
+		t.Fatalf("partial findings persisted: %+v", got)
+	}
+	if got, _ := runs.List(ctx, "e1"); len(got) != 0 {
+		t.Fatalf("scan history persisted after failure: %+v", got)
+	}
+	if _, err := results.LatestResult(ctx, "e1"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cached result error = %v, want not found", err)
 	}
 }
 

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -237,7 +237,7 @@ func TestCodeQualityFindingsPersistWithScan(t *testing.T) {
 	quality := &countingCodeQuality{report: codequality.Report{Findings: []finding.Finding{{
 		Title: "High complexity (internal/handler.go:42)", Description: "Split this function.", Severity: shared.SeverityMedium,
 		CWE: "CWE-1120", Sources: []string{"synapse-codeanalysis"}, Class: finding.ClassFirstParty,
-		Status: finding.StatusOpen, Kind: finding.KindQuality, RuleKey: "quality-high-complexity", DedupKey: "quality:quality-high-complexity:internal/handler.go:42",
+		Status: finding.StatusOpen, Kind: finding.KindQuality, RuleKey: "quality-high-complexity", DedupKey: "cq:quality:quality-high-complexity:internal/handler.go:42",
 	}}}}
 	svc := NewService(
 		&fakeEngRepo{eng: engagementWithScope(t, "myrepo")}, findings, nil, results, nil, runs, evidenceService, fakeIDs{},

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1369,10 +1369,10 @@ export const api = {
     })
   },
 
-  startScan: async (engagementId: string, target: string, kind: string, ref = '', mode = 'full'): Promise<ScanJob> => {
+  startScan: async (engagementId: string, target: string, kind: string, ref = '', mode = 'full', codeQuality = false): Promise<ScanJob> => {
     const r = await req('/sca/scans', {
       method: 'POST',
-      body: JSON.stringify({ engagement_id: engagementId, target, kind, ref, mode }),
+      body: JSON.stringify({ engagement_id: engagementId, target, kind, ref, mode, code_quality: codeQuality }),
     })
     return mapScanJob(r)
   },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1070,9 +1070,8 @@ export const api = {
     }
   },
 
-  // the engagement's code-quality report (inventory + findings + duplication + A-E ratings). Computed
-  // over an in-scope local source directory; an engagement without one returns available=false. 404 (the
-  // route is not registered when code quality is disabled) → also available=false.
+  // The latest stored code-quality report (inventory + findings + duplication + A-E ratings). A missing
+  // opted-in scan returns available=false; 404 remains unavailable for an absent engagement or older server.
   codeQuality: async (engagementId: string): Promise<CodeQualityView> => {
     let r: any
     try {

--- a/web/src/pages/CodeQualityTab.test.tsx
+++ b/web/src/pages/CodeQualityTab.test.tsx
@@ -19,7 +19,7 @@ describe('CodeQualityTab', () => {
   it('renders loading and backend errors', async () => {
     vi.mocked(api.codeQuality).mockReturnValue(new Promise(() => {}))
     const view = render(<CodeQualityTab engagementId="e1" />)
-    expect(screen.getByText('Analyzing code quality…')).toBeInTheDocument()
+    expect(screen.getByText('Loading latest code quality result…')).toBeInTheDocument()
     view.unmount()
 
     vi.mocked(api.codeQuality).mockRejectedValue(new Error('Analysis failed'))

--- a/web/src/pages/CodeQualityTab.tsx
+++ b/web/src/pages/CodeQualityTab.tsx
@@ -30,7 +30,7 @@ export function CodeQualityTab({ engagementId }: { engagementId: string }) {
           <EmptyState
             icon={Gauge}
             title="Code Quality unavailable"
-            hint={view.reason || 'Code Quality requires an in-scope local source directory; this engagement has none.'}
+            hint={view.reason || 'Run an Engagement scan with Code quality enabled to generate a stored report.'}
           />
         </Card>
       }

--- a/web/src/pages/CodeQualityTab.tsx
+++ b/web/src/pages/CodeQualityTab.tsx
@@ -5,7 +5,7 @@ import type { CodeQualityView } from '../lib/types'
 import { Card, EmptyState, ErrorState, Spinner } from '../components/ui'
 import { CodeQualityReportView } from '../components/codequality/CodeQualityReportView'
 
-// CodeQualityTab loads the engagement-scoped report; rendering is shared with Project shells.
+// CodeQualityTab loads the latest stored engagement-scoped report; rendering is shared with Project shells.
 export function CodeQualityTab({ engagementId }: { engagementId: string }) {
   const [view, setView] = useState<CodeQualityView | undefined>(undefined)
   const [err, setErr] = useState<string | null>(null)
@@ -20,7 +20,7 @@ export function CodeQualityTab({ engagementId }: { engagementId: string }) {
   }, [engagementId])
 
   if (err) return <ErrorState message={err} />
-  if (view === undefined) return <Spinner label="Analyzing code quality…" />
+  if (view === undefined) return <Spinner label="Loading latest code quality result…" />
 
   return (
     <CodeQualityReportView

--- a/web/src/pages/EngagementDetail.tsx
+++ b/web/src/pages/EngagementDetail.tsx
@@ -475,8 +475,6 @@ function ExportButtons({ engagementId, scan, onChanged }: { engagementId: string
 
 // Mirrors the report builder's canonical sections (internal/usecase/report); keys +
 // order must match so the customer deliverable renders predictably.
-// Mirrors the report builder's canonical sections (internal/usecase/report); keys +
-// order must match so the customer deliverable renders predictably.
 const REPORT_SECTIONS: { key: string; label: string }[] = [
   { key: 'engagement', label: 'Engagement summary' },
   { key: 'scope', label: 'Scope statement' },
@@ -967,7 +965,12 @@ function ScanPanel({
         <SegmentedScanMode value={mode} onChange={setMode} />
         {!usingImportedSBOM && (
           <label className="flex h-10 shrink-0 cursor-pointer items-center gap-2 rounded-lg border border-border bg-elevated px-3 text-sm text-mutedfg hover:text-foreground">
-            <input type="checkbox" checked={codeQuality} onChange={(e) => setCodeQuality(e.target.checked)} className="size-4 accent-brand" />
+            <input
+              type="checkbox"
+              checked={codeQuality}
+              onChange={(e) => setCodeQuality(e.target.checked)}
+              className="size-4 accent-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+            />
             Code quality
           </label>
         )}

--- a/web/src/pages/EngagementDetail.tsx
+++ b/web/src/pages/EngagementDetail.tsx
@@ -814,6 +814,7 @@ function ScanPanel({
   const [kind, setKind] = useState(detectKind(target0))
   const [kindManual, setKindManual] = useState(false)
   const [mode, setMode] = useState<ScanMode>('full')
+  const [codeQuality, setCodeQuality] = useState(false)
   const [branch, setBranch] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [summary, setSummary] = useState<ScanResult | null>(null)
@@ -894,7 +895,7 @@ function ScanPanel({
     setSummary(null)
     try {
       const ref = kind === 'git' ? branch.trim() : ''
-      setJob(await api.startScan(eng.id, usingImportedSBOM ? '' : target.trim(), usingImportedSBOM ? 'imported-sbom' : kind, ref, mode))
+      setJob(await api.startScan(eng.id, usingImportedSBOM ? '' : target.trim(), usingImportedSBOM ? 'imported-sbom' : kind, ref, mode, codeQuality))
       startPoll()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to start scan')
@@ -964,6 +965,12 @@ function ScanPanel({
           />
         )}
         <SegmentedScanMode value={mode} onChange={setMode} />
+        {!usingImportedSBOM && (
+          <label className="flex h-10 shrink-0 cursor-pointer items-center gap-2 rounded-lg border border-border bg-elevated px-3 text-sm text-mutedfg hover:text-foreground">
+            <input type="checkbox" checked={codeQuality} onChange={(e) => setCodeQuality(e.target.checked)} className="size-4 accent-brand" />
+            Code quality
+          </label>
+        )}
         {usingImportedSBOM ? (
           <div className="flex h-10 min-w-0 items-center rounded-lg border border-border bg-elevated px-3 font-mono text-sm text-mutedfg lg:flex-1">
             <span className="truncate">{importedSBOM?.targetRef || importedSBOM?.filename || 'SBOM.json'}</span>

--- a/web/src/pages/RuleDetail.test.tsx
+++ b/web/src/pages/RuleDetail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import RuleDetail from './RuleDetail'
@@ -171,20 +171,18 @@ describe('RuleDetail Page', () => {
     // Second request resolves immediately
     vi.mocked(api.getRule).mockResolvedValueOnce(otherRule)
 
-    // Navigate in the same instance
-    await waitFor(() => {
-      router.navigate('/rules/py:xss')
+    // Navigate in the same instance exactly once.
+    await act(async () => {
+      await router.navigate('/rules/py:xss')
     })
 
-    // Second request resolves and displays
-    expect(
-      await screen.findByRole('heading', {
-        name: 'XSS Vulnerability',
-      }),
-    ).toBeInTheDocument()
+    // Second request resolves and displays.
+    expect(await screen.findByRole('heading', { name: 'XSS Vulnerability' })).toBeInTheDocument()
 
-    // Now resolve the stale first response
-    resolveFirst(mockRule)
+    // Now resolve the stale first response.
+    await act(async () => {
+      resolveFirst(mockRule)
+    })
 
     await waitFor(() => {
       expect(

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -2,6 +2,19 @@ import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { afterEach } from 'vitest'
 
+// React Router passes jsdom's AbortSignal to Node's native Request during navigation.
+// Node rejects that cross-realm signal, though jsdom never performs the request.
+const NativeRequest = globalThis.Request
+if (NativeRequest) {
+  globalThis.Request = new Proxy(NativeRequest, {
+    construct(target, [input, init]) {
+      if (!init?.signal) return new target(input, init)
+      const { signal: _, ...withoutSignal } = init
+      return new target(input, withoutSignal)
+    },
+  }) as typeof Request
+}
+
 afterEach(() => {
   cleanup()
 })


### PR DESCRIPTION
## Summary

Persist Code Quality analysis as part of an explicit Engagement scan and make
the dashboard read the latest stored report. Refreshing the Code Quality tab no
longer re-analyzes the source tree.

Closes #289

## Changes

- Added the explicit `code_quality` scan option from the Engagement UI through
  the scan API into the SCA pipeline.
- Persisted Code Quality findings through the existing Engagement finding
  lifecycle, including stable IDs, deduplication, audit metadata, triage
  preservation, scan history, evidence, reproducibility digest, and finding
  quality metrics.
- Stored the Code Quality report in the latest scan-result cache.
- Changed `GET /engagements/{id}/code-quality` to return only the report from
  the latest persisted scan result.
  - It never calls `BuildReport` or re-analyzes source.
  - Engagements without an opted-in Code Quality scan receive clear guidance
    to run one.
  - Stored reports remain readable even if the original local workspace is no
    longer available.
- Updated Code Quality loading copy to describe loading the latest stored
  result.
- Added handler tests for stored, absent, corrupt, and unavailable cached
  results.

## Verification

- `go test ./internal/adapter/httpapi ./internal/usecase/sca`
- `go test ./...`
- `go vet ./...`
- `pnpm --dir web run typecheck`
- `git diff --check`

## Checklist

- [x] `make build vet test typecheck` passes
- [x] `cd web && pnpm build` passes (if the dashboard changed)
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets out of logs, deterministic reports, append-only evidence) – see CONTRIBUTING.md
- [ ] Documentation updated if needed