### PR TITLE
Feat/180 c measures explorer

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { ProjectAnalysisPage } from './pages/ProjectAnalysisPage'
 import { ProjectOverviewPage } from './pages/ProjectOverviewPage'
 import { SecurityHotspotsPage } from './pages/SecurityHotspots'
 import { ProjectIssuesPage } from './pages/ProjectIssues'
+import { ProjectMeasuresPage } from './pages/ProjectMeasuresPage'
 import { QualityGates } from './pages/QualityGates'
 
 export default function App() {
@@ -42,6 +43,7 @@ function Gate() {
           <Route index element={<ProjectOverviewPage />} />
           <Route path="hotspots" element={<SecurityHotspotsPage />} />
           <Route path="issues" element={<ProjectIssuesPage />} />
+          <Route path="measures" element={<ProjectMeasuresPage />} />
           <Route path="analysis" element={<ProjectAnalysisPage />} />
           <Route path="activity" element={<ProjectActivityPage />} />
         </Route>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -94,7 +94,10 @@ async function req(path: string, init?: RequestInit): Promise<any> {
         ...(init?.headers ?? {}),
       },
     })
-  } catch {
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error
+    }
     throw new ApiError(0, 'Cannot reach the API. Is the server running on :8080?')
   }
   if (res.status === 401 && onUnauthorized) onUnauthorized()

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -61,6 +61,7 @@ import type {
   IssueReviewEvent,
 } from './types'
 import { mapProjectOverviewResponse, type ProjectOverview } from './projectOverview'
+import { mapProjectMeasureResponse, type MeasuresQuery, type ProjectMeasureResponse } from './projectMeasures'
 
 export class ApiError extends Error {
   constructor(
@@ -110,6 +111,24 @@ async function req(path: string, init?: RequestInit): Promise<any> {
   if (res.status === 204) return null
   return res.json()
 }
+
+export async function projectMeasures(projectKey: string, query: MeasuresQuery, signal?: AbortSignal): Promise<ProjectMeasureResponse> {
+  const q = new URLSearchParams()
+  if (query.path) q.set('path', query.path)
+  if (query.limit) q.set('limit', query.limit.toString())
+  if (query.cursor) q.set('cursor', query.cursor) // Never decode or mutate cursor
+  if (query.domain) {
+    for (const d of query.domain) {
+      if (d) q.append('domain', d)
+    }
+  }
+  const qs = q.toString()
+  // Add signal parameter to the req function if it supports it, or use fetch directly if needed.
+  // wait, the `req` function has an `init?: RequestInit` argument, so we can pass { signal }.
+  const raw = await req(`/projects/${encodeURIComponent(projectKey)}/measures${qs ? `?${qs}` : ''}`, { signal })
+  return mapProjectMeasureResponse(raw)
+}
+
 
 // ---- mappers: raw API JSON (mixed casing) → clean types ----
 
@@ -839,6 +858,7 @@ function mapIssueReviewEvent(r: any): IssueReviewEvent {
 }
 
 export const api = {
+  projectMeasures,
   aup: (): Promise<AupStatus> => req('/aup'),
 
   // --- Quality gates ---

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -126,8 +126,6 @@ export async function projectMeasures(projectKey: string, query: MeasuresQuery, 
     }
   }
   const qs = q.toString()
-  // Add signal parameter to the req function if it supports it, or use fetch directly if needed.
-  // wait, the `req` function has an `init?: RequestInit` argument, so we can pass { signal }.
   const raw = await req(`/projects/${encodeURIComponent(projectKey)}/measures${qs ? `?${qs}` : ''}`, { signal })
   return mapProjectMeasureResponse(raw)
 }

--- a/web/src/lib/projectMeasures.test.ts
+++ b/web/src/lib/projectMeasures.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { mapProjectMeasureResponse } from './projectMeasures'
+
+describe('projectMeasures mapper', () => {
+  it('maps available zero values to zero', () => {
+    const raw = {
+      state: 'analyzed',
+      node: {
+        size: {
+          files: { availability: 'available', value: 0 },
+        },
+      },
+    }
+    const res = mapProjectMeasureResponse(raw)
+    expect(res.node?.size?.files.availability).toBe('available')
+    expect(res.node?.size?.files.value).toBe(0)
+  })
+
+  it('maps unavailable values to null, not 0', () => {
+    const raw = {
+      state: 'analyzed',
+      node: {
+        size: {
+          files: { availability: 'unavailable' },
+        },
+      },
+    }
+    const res = mapProjectMeasureResponse(raw)
+    expect(res.node?.size?.files.availability).toBe('unavailable')
+    expect(res.node?.size?.files.value).toBeNull()
+  })
+
+  it('keeps not_applicable distinct and value null', () => {
+    const raw = {
+      state: 'analyzed',
+      node: {
+        coverage: {
+          new_code_coverage: { availability: 'not_applicable' },
+        },
+      },
+    }
+    const res = mapProjectMeasureResponse(raw)
+    expect(res.node?.coverage?.newCodeCoverage.availability).toBe('not_applicable')
+    expect(res.node?.coverage?.newCodeCoverage.value).toBeNull()
+  })
+
+  it('preserves unavailable_reason', () => {
+    const raw = {
+      node: {
+        issues: {
+          by_type: {
+            bug: { availability: 'unavailable', unavailable_reason: 'no_attribution' },
+          },
+        },
+      },
+    }
+    const res = mapProjectMeasureResponse(raw)
+    expect(res.node?.issues?.byType['bug']?.reason).toBe('no_attribution')
+  })
+
+  it('treats omitted domains as null', () => {
+    const raw = {
+      node: {
+        kind: 'project',
+        // missing size, complexity, coverage, etc.
+      },
+    }
+    const res = mapProjectMeasureResponse(raw)
+    expect(res.node?.size).toBeNull()
+    expect(res.node?.complexity).toBeNull()
+    expect(res.node?.coverage).toBeNull()
+  })
+
+  it('defaults omitted child items to an empty array', () => {
+    const raw = {
+      children: {
+        // missing items
+        next_cursor: 'abc',
+      },
+    }
+    const res = mapProjectMeasureResponse(raw)
+    expect(res.children.items).toEqual([])
+    expect(res.children.nextCursor).toBe('abc')
+  })
+
+  it('preserves next_cursor exactly', () => {
+    const raw = {
+      children: {
+        next_cursor: 'opaque_cursor_123==',
+      },
+    }
+    const res = mapProjectMeasureResponse(raw)
+    expect(res.children.nextCursor).toBe('opaque_cursor_123==')
+  })
+})

--- a/web/src/lib/projectMeasures.test.ts
+++ b/web/src/lib/projectMeasures.test.ts
@@ -92,4 +92,23 @@ describe('projectMeasures mapper', () => {
     const res = mapProjectMeasureResponse(raw)
     expect(res.children.nextCursor).toBe('opaque_cursor_123==')
   })
+
+  it('available + null must not become zero', () => {
+    const raw = {
+      state: 'analyzed',
+      node: {
+        size: {
+          files: { availability: 'available', value: null },
+        },
+        ratings: {
+          security: { availability: 'available', grade: null },
+        }
+      },
+    }
+    const res = mapProjectMeasureResponse(raw)
+    expect(res.node?.size?.files.availability).toBe('available')
+    expect(res.node?.size?.files.value).toBeNull()
+    expect(res.node?.ratings?.security.availability).toBe('available')
+    expect(res.node?.ratings?.security.grade).toBeNull()
+  })
 })

--- a/web/src/lib/projectMeasures.ts
+++ b/web/src/lib/projectMeasures.ts
@@ -1,0 +1,255 @@
+export type MeasureAvailability = 'available' | 'unavailable' | 'not_applicable'
+
+export interface MeasureCountMetric {
+  availability: MeasureAvailability
+  value: number | null
+  reason: string | null
+}
+
+export interface MeasureDecimalMetric {
+  availability: MeasureAvailability
+  value: number | null
+  reason: string | null
+}
+
+export interface MeasureGradeMetric {
+  availability: MeasureAvailability
+  grade: string | null
+  reason: string | null
+}
+
+export interface SizeMeasures {
+  files: MeasureCountMetric
+  ncloc: MeasureCountMetric
+  commentLines: MeasureCountMetric
+  blankLines: MeasureCountMetric
+  functions: MeasureCountMetric
+  commentDensity: MeasureDecimalMetric
+}
+
+export interface ComplexityMeasures {
+  cyclomatic: MeasureCountMetric
+  cognitive: MeasureCountMetric
+}
+
+export interface CoverageMeasures {
+  coveredLines: MeasureCountMetric
+  coverableLines: MeasureCountMetric
+  coverage: MeasureDecimalMetric
+  newCodeCoverage: MeasureDecimalMetric
+}
+
+export interface DuplicationMeasures {
+  duplicatedLines: MeasureCountMetric
+  duplicationBlocks: MeasureCountMetric
+  duplicationDensity: MeasureDecimalMetric
+}
+
+export interface IssueMeasures {
+  byType: Record<string, MeasureCountMetric>
+  bySeverity: Record<string, MeasureCountMetric>
+}
+
+export interface DebtMeasures {
+  remediationEffortMinutes: MeasureCountMetric
+}
+
+export interface RatingsMeasures {
+  security: MeasureGradeMetric
+  reliability: MeasureGradeMetric
+  maintainability: MeasureGradeMetric
+}
+
+export interface ProjectNodeInfo {
+  key: string
+  name: string
+}
+
+export interface AnalysisMetadata {
+  id: string
+  createdAt: string
+  sourceRef: string
+  sourceCommit: string
+}
+
+export interface MeasureNode {
+  path: string
+  name: string
+  kind: 'project' | 'directory' | 'file'
+  language: string
+  size: SizeMeasures | null
+  complexity: ComplexityMeasures | null
+  coverage: CoverageMeasures | null
+  duplication: DuplicationMeasures | null
+  issues: IssueMeasures | null
+  debt: DebtMeasures | null
+  ratings: RatingsMeasures | null
+}
+
+export interface ChildCollection {
+  items: MeasureNode[]
+  nextCursor: string | null
+}
+
+export interface ProjectMeasureResponse {
+  state: 'analyzed' | 'not_analyzed'
+  project: ProjectNodeInfo
+  analysis: AnalysisMetadata | null
+  path: string
+  includedDomains: string[]
+  node: MeasureNode | null
+  children: ChildCollection
+}
+
+export interface MeasuresQuery {
+  path?: string
+  domain?: string[]
+  limit?: number
+  cursor?: string
+}
+
+function mapCountMetric(raw: any): MeasureCountMetric {
+  if (!raw) return { availability: 'unavailable', value: null, reason: null }
+  return {
+    availability: raw.availability ?? 'unavailable',
+    value: raw.availability === 'available' ? (raw.value ?? 0) : null,
+    reason: raw.unavailable_reason ?? null,
+  }
+}
+
+function mapDecimalMetric(raw: any): MeasureDecimalMetric {
+  if (!raw) return { availability: 'unavailable', value: null, reason: null }
+  return {
+    availability: raw.availability ?? 'unavailable',
+    value: raw.availability === 'available' ? (raw.value ?? 0) : null,
+    reason: raw.unavailable_reason ?? null,
+  }
+}
+
+function mapGradeMetric(raw: any): MeasureGradeMetric {
+  if (!raw) return { availability: 'unavailable', grade: null, reason: null }
+  return {
+    availability: raw.availability ?? 'unavailable',
+    grade: raw.availability === 'available' ? (raw.grade ?? null) : null,
+    reason: raw.unavailable_reason ?? null,
+  }
+}
+
+function mapSizeMeasures(raw: any): SizeMeasures | null {
+  if (!raw) return null
+  return {
+    files: mapCountMetric(raw.files),
+    ncloc: mapCountMetric(raw.ncloc),
+    commentLines: mapCountMetric(raw.comment_lines),
+    blankLines: mapCountMetric(raw.blank_lines),
+    functions: mapCountMetric(raw.functions),
+    commentDensity: mapDecimalMetric(raw.comment_density),
+  }
+}
+
+function mapComplexityMeasures(raw: any): ComplexityMeasures | null {
+  if (!raw) return null
+  return {
+    cyclomatic: mapCountMetric(raw.cyclomatic),
+    cognitive: mapCountMetric(raw.cognitive),
+  }
+}
+
+function mapCoverageMeasures(raw: any): CoverageMeasures | null {
+  if (!raw) return null
+  return {
+    coveredLines: mapCountMetric(raw.covered_lines),
+    coverableLines: mapCountMetric(raw.coverable_lines),
+    coverage: mapDecimalMetric(raw.coverage),
+    newCodeCoverage: mapDecimalMetric(raw.new_code_coverage),
+  }
+}
+
+function mapDuplicationMeasures(raw: any): DuplicationMeasures | null {
+  if (!raw) return null
+  return {
+    duplicatedLines: mapCountMetric(raw.duplicated_lines),
+    duplicationBlocks: mapCountMetric(raw.duplication_blocks),
+    duplicationDensity: mapDecimalMetric(raw.duplication_density),
+  }
+}
+
+function mapIssueMeasures(raw: any): IssueMeasures | null {
+  if (!raw) return null
+  
+  const byType: Record<string, MeasureCountMetric> = {}
+  if (raw.by_type) {
+    for (const [k, v] of Object.entries(raw.by_type)) {
+      byType[k] = mapCountMetric(v)
+    }
+  }
+
+  const bySeverity: Record<string, MeasureCountMetric> = {}
+  if (raw.by_severity) {
+    for (const [k, v] of Object.entries(raw.by_severity)) {
+      bySeverity[k] = mapCountMetric(v)
+    }
+  }
+
+  return { byType, bySeverity }
+}
+
+function mapDebtMeasures(raw: any): DebtMeasures | null {
+  if (!raw) return null
+  return {
+    remediationEffortMinutes: mapCountMetric(raw.remediation_effort_minutes),
+  }
+}
+
+function mapRatingsMeasures(raw: any): RatingsMeasures | null {
+  if (!raw) return null
+  return {
+    security: mapGradeMetric(raw.security),
+    reliability: mapGradeMetric(raw.reliability),
+    maintainability: mapGradeMetric(raw.maintainability),
+  }
+}
+
+export function mapMeasureNode(raw: any): MeasureNode | null {
+  if (!raw) return null
+  return {
+    path: raw.path ?? '',
+    name: raw.name ?? '',
+    kind: raw.kind ?? 'file',
+    language: raw.language ?? '',
+    size: mapSizeMeasures(raw.size),
+    complexity: mapComplexityMeasures(raw.complexity),
+    coverage: mapCoverageMeasures(raw.coverage),
+    duplication: mapDuplicationMeasures(raw.duplication),
+    issues: mapIssueMeasures(raw.issues),
+    debt: mapDebtMeasures(raw.debt),
+    ratings: mapRatingsMeasures(raw.ratings),
+  }
+}
+
+export function mapProjectMeasureResponse(raw: any): ProjectMeasureResponse {
+  const childrenItems = Array.isArray(raw?.children?.items) 
+    ? raw.children.items.map(mapMeasureNode).filter(Boolean) as MeasureNode[]
+    : []
+
+  return {
+    state: raw?.state ?? 'not_analyzed',
+    project: {
+      key: raw?.project?.key ?? '',
+      name: raw?.project?.name ?? '',
+    },
+    analysis: raw?.analysis ? {
+      id: raw.analysis.id ?? '',
+      createdAt: raw.analysis.created_at ?? '',
+      sourceRef: raw.analysis.source_ref ?? '',
+      sourceCommit: raw.analysis.source_commit ?? '',
+    } : null,
+    path: raw?.path ?? '',
+    includedDomains: Array.isArray(raw?.included_domains) ? raw.included_domains : [],
+    node: mapMeasureNode(raw?.node),
+    children: {
+      items: childrenItems,
+      nextCursor: raw?.children?.next_cursor ?? null,
+    }
+  }
+}

--- a/web/src/lib/projectMeasures.ts
+++ b/web/src/lib/projectMeasures.ts
@@ -112,7 +112,7 @@ function mapCountMetric(raw: any): MeasureCountMetric {
   if (!raw) return { availability: 'unavailable', value: null, reason: null }
   return {
     availability: raw.availability ?? 'unavailable',
-    value: raw.availability === 'available' ? (raw.value ?? 0) : null,
+    value: raw.availability === 'available' && typeof raw.value === 'number' ? raw.value : null,
     reason: raw.unavailable_reason ?? null,
   }
 }
@@ -121,7 +121,7 @@ function mapDecimalMetric(raw: any): MeasureDecimalMetric {
   if (!raw) return { availability: 'unavailable', value: null, reason: null }
   return {
     availability: raw.availability ?? 'unavailable',
-    value: raw.availability === 'available' ? (raw.value ?? 0) : null,
+    value: raw.availability === 'available' && typeof raw.value === 'number' ? raw.value : null,
     reason: raw.unavailable_reason ?? null,
   }
 }
@@ -130,7 +130,7 @@ function mapGradeMetric(raw: any): MeasureGradeMetric {
   if (!raw) return { availability: 'unavailable', grade: null, reason: null }
   return {
     availability: raw.availability ?? 'unavailable',
-    grade: raw.availability === 'available' ? (raw.grade ?? null) : null,
+    grade: raw.availability === 'available' && typeof raw.grade === 'string' ? raw.grade : null,
     reason: raw.unavailable_reason ?? null,
   }
 }

--- a/web/src/pages/CodeQualityProject.tsx
+++ b/web/src/pages/CodeQualityProject.tsx
@@ -276,6 +276,7 @@ export function CodeQualityProject() {
         <ProjectNavLink to={`/code-quality/projects/${encodeURIComponent(key)}`} end>Overview</ProjectNavLink>
         <ProjectNavLink to={`/code-quality/projects/${encodeURIComponent(key)}/hotspots`}>Security Hotspots</ProjectNavLink>
         <ProjectNavLink to={`/code-quality/projects/${encodeURIComponent(key)}/issues`}>Issues</ProjectNavLink>
+        <ProjectNavLink to={`/code-quality/projects/${encodeURIComponent(key)}/measures`}>Measures</ProjectNavLink>
         <ProjectNavLink to={`/code-quality/projects/${encodeURIComponent(key)}/analysis`}>Analysis details</ProjectNavLink>
         <ProjectNavLink to={`/code-quality/projects/${encodeURIComponent(key)}/activity`}>Activity</ProjectNavLink>
       </nav>

--- a/web/src/pages/ProjectMeasuresPage.test.tsx
+++ b/web/src/pages/ProjectMeasuresPage.test.tsx
@@ -202,9 +202,77 @@ describe('Project Measures route and logic', () => {
     })
   })
 
-  it('stale responses cannot replace newer path results', async () => {
-    let resolveFirst!: (val: any) => void
-    const firstPromise = new Promise(res => { resolveFirst = res })
+  it('renders correct severity keys for issues', async () => {
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
+      node: {
+        path: '', name: 'Synapse', kind: 'project', language: '', size: null, complexity: null, coverage: null, duplication: null, debt: null, ratings: null,
+        issues: {
+          byType: {},
+          bySeverity: {
+            critical: { availability: 'available', value: 5, reason: null },
+            high: { availability: 'available', value: 4, reason: null },
+            medium: { availability: 'available', value: 3, reason: null },
+            low: { availability: 'available', value: 2, reason: null },
+            info: { availability: 'available', value: 1, reason: null },
+          }
+        }
+      },
+      children: { items: [], nextCursor: null }
+    }))
+    
+    renderRoute('/code-quality/projects/synapse/measures?domain=issues')
+    
+    expect(await screen.findByText('Current Node Metrics')).toBeInTheDocument()
+    
+    expect(screen.getByText('Critical')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+    
+    expect(screen.getByText('High')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+    
+    expect(screen.getByText('Medium')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+    
+    expect(screen.getByText('Low')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    
+    expect(screen.getByText('Info')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('normal load more appends children and deduplicates', async () => {
+    vi.mocked(api.projectMeasures).mockResolvedValueOnce(buildResponse({
+      children: {
+        items: [{ path: '1', name: '1', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any],
+        nextCursor: 'next-page'
+      }
+    }))
+    
+    renderRoute('/code-quality/projects/synapse/measures')
+    expect(await screen.findByText('1')).toBeInTheDocument()
+    
+    vi.mocked(api.projectMeasures).mockResolvedValueOnce(buildResponse({
+      children: {
+        // returning 1 again to test deduplication, and a new item 2
+        items: [
+          { path: '1', name: '1', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any,
+          { path: '2', name: '2', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any
+        ],
+        nextCursor: null
+      }
+    }))
+    
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+    
+    expect(await screen.findByText('2')).toBeInTheDocument()
+    // It should render 1 only once. We can query getAllByText('1') but the breadcrumb and metric might interfere if they are named 1. 
+    // The link for '1' is rendered.
+    expect(screen.getAllByRole('button', { name: '1' }).length).toBe(1)
+  })
+
+  it('stale aborted responses do not replace newer path results or show error', async () => {
+    let rejectFirst!: (err: any) => void
+    const firstPromise = new Promise((_, rej) => { rejectFirst = rej })
     
     let resolveSecond!: (val: any) => void
     const secondPromise = new Promise(res => { resolveSecond = res })
@@ -238,20 +306,18 @@ describe('Project Measures route and logic', () => {
     expect(await screen.findByText('B1')).toBeInTheDocument()
     expect(screen.queryByText('A1')).not.toBeInTheDocument()
 
-    // 5. Now resolve the stale load more for A
+    // 5. Now resolve the stale load more for A by throwing AbortError
     act(() => {
-      resolveFirst(buildResponse({
-        path: 'A',
-        children: { items: [{ path: 'A/2', name: 'A2', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any], nextCursor: null }
-      }))
+      rejectFirst(new DOMException('Aborted', 'AbortError'))
     })
 
     // Wait a bit to ensure no state updates happen
     await new Promise(r => setTimeout(r, 50))
     
-    // Assert only B1 remains, A2 was ignored
+    // Assert only B1 remains, no error state is shown
     expect(screen.getByText('B1')).toBeInTheDocument()
-    expect(screen.queryByText('A2')).not.toBeInTheDocument()
+    expect(screen.queryByText('Failed to load more')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cannot reach the API')).not.toBeInTheDocument()
   })
 
   it('renders VirtualTable for >50 rows', async () => {

--- a/web/src/pages/ProjectMeasuresPage.test.tsx
+++ b/web/src/pages/ProjectMeasuresPage.test.tsx
@@ -1,0 +1,210 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../lib/api'
+import { CodeQualityProject } from './CodeQualityProject'
+import { ProjectMeasuresPage } from './ProjectMeasuresPage'
+import type { ProjectMeasureResponse } from '../lib/projectMeasures'
+
+vi.mock('../lib/api', () => ({
+  api: {
+    getProject: vi.fn(),
+    projectAnalysisStatus: vi.fn(),
+    projectMeasures: vi.fn(),
+    listQualityGates: vi.fn(),
+  },
+}))
+
+const project = {
+  id: 'project-synapse',
+  name: 'Synapse',
+  key: 'synapse',
+  sourceBinding: { kind: 'git', value: 'https://example.com', ref: 'main' },
+  defaultProfileByLang: {},
+  gateId: '',
+  createdAt: null,
+  latestAnalysis: null,
+  latestJob: null,
+}
+
+function buildResponse(overrides: Partial<ProjectMeasureResponse> = {}): ProjectMeasureResponse {
+  return {
+    state: 'analyzed',
+    project: { key: 'synapse', name: 'Synapse' },
+    analysis: { id: 'a1', createdAt: '', sourceRef: '', sourceCommit: '' },
+    path: '',
+    includedDomains: ['size'],
+    node: {
+      path: '', name: 'Synapse', kind: 'project', language: '',
+      size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null,
+    },
+    children: { items: [], nextCursor: null },
+    ...overrides,
+  }
+}
+
+describe('Project Measures route and logic', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.getProject).mockResolvedValue(project as any)
+    vi.mocked(api.projectAnalysisStatus).mockResolvedValue(null)
+    vi.mocked(api.listQualityGates).mockResolvedValue([])
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse())
+  })
+
+  function renderRoute(initialPath: string) {
+    const router = createMemoryRouter([
+      {
+        path: '/code-quality/projects/:key',
+        element: <CodeQualityProject />,
+        children: [
+          { path: 'measures', element: <ProjectMeasuresPage /> },
+        ],
+      },
+    ], { initialEntries: [initialPath] })
+    render(<RouterProvider router={router} />)
+    return router
+  }
+
+  it('renders project root and not-analyzed state', async () => {
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({ state: 'not_analyzed' }))
+    renderRoute('/code-quality/projects/synapse/measures')
+    expect(await screen.findByText('No completed analysis yet')).toBeInTheDocument()
+  })
+
+  it('directory click changes URL path', async () => {
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
+      children: {
+        items: [{ path: 'src', name: 'src', kind: 'directory', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null }],
+        nextCursor: null
+      }
+    }))
+    const router = renderRoute('/code-quality/projects/synapse/measures?domain=size')
+    await waitFor(() => expect(screen.getAllByText('src').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getByRole('button', { name: 'src' }))
+    
+    await waitFor(() => {
+      const search = new URLSearchParams(router.state.location.search)
+      expect(search.get('path')).toBe('src')
+      expect(search.get('domain')).toBe('size')
+    })
+  })
+
+  it('breadcrumbs navigate to parent paths and browser back restores path', async () => {
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
+      path: 'src/internal',
+    }))
+    const router = renderRoute('/code-quality/projects/synapse/measures?path=src%2Finternal&domain=size')
+    
+    // Wait for 'internal' to load
+    expect(await screen.findByText('internal')).toBeInTheDocument()
+    
+    // Navigate to root (Synapse button in breadcrumb)
+    fireEvent.click(screen.getByRole('button', { name: 'Synapse' }))
+    await waitFor(() => {
+      const search = new URLSearchParams(router.state.location.search)
+      expect(search.get('path')).toBeNull()
+      expect(search.get('domain')).toBe('size')
+    })
+    
+    // Simulate back
+    await act(async () => {
+      // Use fireEvent on the window popstate or simply rely on the memory router's structure?
+      // Since router is created locally and memory router handles back navigation:
+      router.navigate(-1)
+    })
+    await waitFor(() => {
+      const search = new URLSearchParams(router.state.location.search)
+      expect(search.get('path')).toBe('src/internal')
+      expect(search.get('domain')).toBe('size')
+    })
+  })
+
+  it('file rows are not treated as directories and directory ordering precedes file', async () => {
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
+      children: {
+        items: [
+          { path: 'a.ts', name: 'a.ts', kind: 'file', language: 'ts', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null },
+          { path: 'dir', name: 'dir', kind: 'directory', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null }
+        ],
+        nextCursor: null
+      }
+    }))
+    renderRoute('/code-quality/projects/synapse/measures')
+    
+    expect(await screen.findByText('dir')).toBeInTheDocument()
+    expect(screen.getByText('a.ts')).toBeInTheDocument()
+    
+    // dir is clickable, a.ts is not (we can check tag name or just the fact that fireEvent won't fail if it's a button, but let's just use getByText)
+    expect(screen.getByText('dir').tagName.toLowerCase()).toBe('button')
+    expect(screen.getByText('a.ts').tagName.toLowerCase()).toBe('span')
+  })
+
+  it('handles metric value rendering (zero, unavailable, not_applicable)', async () => {
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
+      children: {
+        items: [
+          { 
+            path: 'a', name: 'a', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null 
+          }
+        ],
+        nextCursor: null
+      }
+    }))
+    // Overriding the child's size after mocking
+    const items = [
+      {
+        path: 'a', name: 'a', kind: 'file', language: '',
+        size: { 
+          files: { availability: 'available', value: 0, reason: null },
+          ncloc: { availability: 'not_applicable', value: null, reason: 'test-reason' },
+          commentLines: { availability: 'not_applicable', value: null, reason: null },
+          blankLines: { availability: 'available', value: null, reason: null }, // shouldn't happen, but testing fallback
+          functions: { availability: 'available', value: 42, reason: null },
+          commentDensity: { availability: 'available', value: 0.5, reason: null }
+        },
+        complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null
+      }
+    ] as any
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
+      children: { items, nextCursor: null }
+    }))
+    
+    renderRoute('/code-quality/projects/synapse/measures')
+    
+    expect(await screen.findByText('a')).toBeInTheDocument()
+    expect(screen.getByText('0')).toBeInTheDocument() // available 0
+    expect(screen.getByText('N/A')).toBeInTheDocument() // not applicable
+    expect(screen.getByText('42')).toBeInTheDocument() // available > 0
+  })
+
+  it('load more appends children and path changes reset pagination', async () => {
+    vi.mocked(api.projectMeasures).mockResolvedValueOnce(buildResponse({
+      children: {
+        items: [{ path: '1', name: '1', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any],
+        nextCursor: 'next-page'
+      }
+    }))
+    
+    renderRoute('/code-quality/projects/synapse/measures')
+    expect(await screen.findByText('1')).toBeInTheDocument()
+    
+    vi.mocked(api.projectMeasures).mockResolvedValueOnce(buildResponse({
+      children: {
+        items: [{ path: '2', name: '2', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any],
+        nextCursor: null
+      }
+    }))
+    
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+    
+    expect(await screen.findByText('2')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument() // appended, not replaced
+  })
+
+  it('stale responses cannot replace newer path results', async () => {
+    // using abort controller pattern: if user navigates away, the request is aborted.
+    // React handles this since we check live in useEffect, but we can verify the mock isn't applying wrong data.
+    // Real validation is best in E2E, but we know useEffect has let live = true.
+  })
+})

--- a/web/src/pages/ProjectMeasuresPage.test.tsx
+++ b/web/src/pages/ProjectMeasuresPage.test.tsx
@@ -15,6 +15,14 @@ vi.mock('../lib/api', () => ({
   },
 }))
 
+vi.mock('../components/VirtualTable', () => ({
+  VirtualTable: ({ items }: any) => (
+    <div data-testid="virtual-table">
+      {items.map((x: any) => <div key={x.path}>{x.name}</div>)}
+    </div>
+  )
+}))
+
 const project = {
   id: 'project-synapse',
   name: 'Synapse',
@@ -59,12 +67,34 @@ describe('Project Measures route and logic', () => {
         element: <CodeQualityProject />,
         children: [
           { path: 'measures', element: <ProjectMeasuresPage /> },
+          { path: '', element: <div>Overview</div> },
+          { path: 'issues', element: <div>Issues</div> },
+          { path: 'hotspots', element: <div>Hotspots</div> },
+          { path: 'analysis', element: <div>Analysis</div> },
+          { path: 'activity', element: <div>Activity</div> },
         ],
       },
     ], { initialEntries: [initialPath] })
     render(<RouterProvider router={router} />)
     return router
   }
+
+  it('routing regression test ensures tabs exist and route correctly', async () => {
+    const router = renderRoute('/code-quality/projects/synapse/measures')
+    
+    // Wait for the page to render (Current Node Metrics is in data.node detail panel)
+    expect(await screen.findByText('Current Node Metrics')).toBeInTheDocument()
+    
+    // Tab verification
+    const tabs = ['Overview', 'Issues', 'Security Hotspots', 'Measures', 'Analysis details', 'Activity']
+    for (const tab of tabs) {
+      expect(screen.getByRole('link', { name: tab })).toBeInTheDocument()
+    }
+    
+    // Navigate away
+    fireEvent.click(screen.getByRole('link', { name: 'Issues' }))
+    await waitFor(() => expect(router.state.location.pathname).toBe('/code-quality/projects/synapse/issues'))
+  })
 
   it('renders project root and not-analyzed state', async () => {
     vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({ state: 'not_analyzed' }))
@@ -96,10 +126,8 @@ describe('Project Measures route and logic', () => {
     }))
     const router = renderRoute('/code-quality/projects/synapse/measures?path=src%2Finternal&domain=size')
     
-    // Wait for 'internal' to load
     expect(await screen.findByText('internal')).toBeInTheDocument()
     
-    // Navigate to root (Synapse button in breadcrumb)
     fireEvent.click(screen.getByRole('button', { name: 'Synapse' }))
     await waitFor(() => {
       const search = new URLSearchParams(router.state.location.search)
@@ -107,10 +135,7 @@ describe('Project Measures route and logic', () => {
       expect(search.get('domain')).toBe('size')
     })
     
-    // Simulate back
     await act(async () => {
-      // Use fireEvent on the window popstate or simply rely on the memory router's structure?
-      // Since router is created locally and memory router handles back navigation:
       router.navigate(-1)
     })
     await waitFor(() => {
@@ -120,7 +145,38 @@ describe('Project Measures route and logic', () => {
     })
   })
 
-  it('file rows are not treated as directories and directory ordering precedes file', async () => {
+  it('file drill down, node details rendering, and ordering', async () => {
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
+      node: {
+        path: 'a.ts', name: 'a.ts', kind: 'file', language: 'ts',
+        size: { 
+          files: { availability: 'available', value: 1, reason: null },
+          ncloc: { availability: 'not_applicable', value: null, reason: null },
+          commentLines: { availability: 'not_applicable', value: null, reason: null },
+          blankLines: { availability: 'available', value: null, reason: null },
+          functions: { availability: 'available', value: 42, reason: null },
+          commentDensity: { availability: 'available', value: 0.5, reason: null }
+        },
+        complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null
+      },
+      children: {
+        items: [],
+        nextCursor: null
+      }
+    }))
+    const router = renderRoute('/code-quality/projects/synapse/measures?path=a.ts&domain=size')
+    
+    // Node metrics panel should render "Current Node Metrics"
+    expect(await screen.findByText('Current Node Metrics')).toBeInTheDocument()
+    
+    // Ensure "Empty directory" is NOT shown for files
+    expect(screen.queryByText('Empty directory')).not.toBeInTheDocument()
+    
+    // Verify file metric details are rendered
+    expect(screen.getByText('Lines of Code')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument() // Functions value
+    
+    // Now simulate clicking a file from a list
     vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
       children: {
         items: [
@@ -130,81 +186,90 @@ describe('Project Measures route and logic', () => {
         nextCursor: null
       }
     }))
-    renderRoute('/code-quality/projects/synapse/measures')
+    router.navigate('/code-quality/projects/synapse/measures?domain=size')
     
     expect(await screen.findByText('dir')).toBeInTheDocument()
     expect(screen.getByText('a.ts')).toBeInTheDocument()
     
-    // dir is clickable, a.ts is not (we can check tag name or just the fact that fireEvent won't fail if it's a button, but let's just use getByText)
-    expect(screen.getByText('dir').tagName.toLowerCase()).toBe('button')
-    expect(screen.getByText('a.ts').tagName.toLowerCase()).toBe('span')
-  })
-
-  it('handles metric value rendering (zero, unavailable, not_applicable)', async () => {
-    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
-      children: {
-        items: [
-          { 
-            path: 'a', name: 'a', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null 
-          }
-        ],
-        nextCursor: null
-      }
-    }))
-    // Overriding the child's size after mocking
-    const items = [
-      {
-        path: 'a', name: 'a', kind: 'file', language: '',
-        size: { 
-          files: { availability: 'available', value: 0, reason: null },
-          ncloc: { availability: 'not_applicable', value: null, reason: 'test-reason' },
-          commentLines: { availability: 'not_applicable', value: null, reason: null },
-          blankLines: { availability: 'available', value: null, reason: null }, // shouldn't happen, but testing fallback
-          functions: { availability: 'available', value: 42, reason: null },
-          commentDensity: { availability: 'available', value: 0.5, reason: null }
-        },
-        complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null
-      }
-    ] as any
-    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
-      children: { items, nextCursor: null }
-    }))
+    // Both dir and file should be clickable buttons!
+    expect(screen.getByRole('button', { name: 'dir' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'a.ts' })).toBeInTheDocument()
     
-    renderRoute('/code-quality/projects/synapse/measures')
-    
-    expect(await screen.findByText('a')).toBeInTheDocument()
-    expect(screen.getByText('0')).toBeInTheDocument() // available 0
-    expect(screen.getByText('N/A')).toBeInTheDocument() // not applicable
-    expect(screen.getByText('42')).toBeInTheDocument() // available > 0
-  })
-
-  it('load more appends children and path changes reset pagination', async () => {
-    vi.mocked(api.projectMeasures).mockResolvedValueOnce(buildResponse({
-      children: {
-        items: [{ path: '1', name: '1', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any],
-        nextCursor: 'next-page'
-      }
-    }))
-    
-    renderRoute('/code-quality/projects/synapse/measures')
-    expect(await screen.findByText('1')).toBeInTheDocument()
-    
-    vi.mocked(api.projectMeasures).mockResolvedValueOnce(buildResponse({
-      children: {
-        items: [{ path: '2', name: '2', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any],
-        nextCursor: null
-      }
-    }))
-    
-    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
-    
-    expect(await screen.findByText('2')).toBeInTheDocument()
-    expect(screen.getByText('1')).toBeInTheDocument() // appended, not replaced
+    fireEvent.click(screen.getByRole('button', { name: 'a.ts' }))
+    await waitFor(() => {
+      const search = new URLSearchParams(router.state.location.search)
+      expect(search.get('path')).toBe('a.ts')
+    })
   })
 
   it('stale responses cannot replace newer path results', async () => {
-    // using abort controller pattern: if user navigates away, the request is aborted.
-    // React handles this since we check live in useEffect, but we can verify the mock isn't applying wrong data.
-    // Real validation is best in E2E, but we know useEffect has let live = true.
+    let resolveFirst!: (val: any) => void
+    const firstPromise = new Promise(res => { resolveFirst = res })
+    
+    let resolveSecond!: (val: any) => void
+    const secondPromise = new Promise(res => { resolveSecond = res })
+
+    // 1. Initial load for path "A"
+    vi.mocked(api.projectMeasures).mockResolvedValueOnce(buildResponse({
+      path: 'A',
+      children: { items: [{ path: 'A/1', name: 'A1', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any], nextCursor: 'next-A' }
+    }))
+    
+    const router = renderRoute('/code-quality/projects/synapse/measures?path=A&domain=size')
+    expect(await screen.findByText('A1')).toBeInTheDocument()
+
+    // 2. Click load more for A (this returns firstPromise which we hold)
+    vi.mocked(api.projectMeasures).mockReturnValueOnce(firstPromise as any)
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+    
+    // 3. While load more is pending, navigate to path "B"
+    vi.mocked(api.projectMeasures).mockReturnValueOnce(secondPromise as any)
+    act(() => {
+      router.navigate('/code-quality/projects/synapse/measures?path=B&domain=size')
+    })
+    
+    // 4. Resolve B
+    act(() => {
+      resolveSecond(buildResponse({
+        path: 'B',
+        children: { items: [{ path: 'B/1', name: 'B1', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any], nextCursor: null }
+      }))
+    })
+    expect(await screen.findByText('B1')).toBeInTheDocument()
+    expect(screen.queryByText('A1')).not.toBeInTheDocument()
+
+    // 5. Now resolve the stale load more for A
+    act(() => {
+      resolveFirst(buildResponse({
+        path: 'A',
+        children: { items: [{ path: 'A/2', name: 'A2', kind: 'file', language: '', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null } as any], nextCursor: null }
+      }))
+    })
+
+    // Wait a bit to ensure no state updates happen
+    await new Promise(r => setTimeout(r, 50))
+    
+    // Assert only B1 remains, A2 was ignored
+    expect(screen.getByText('B1')).toBeInTheDocument()
+    expect(screen.queryByText('A2')).not.toBeInTheDocument()
+  })
+
+  it('renders VirtualTable for >50 rows', async () => {
+    const items = Array.from({ length: 60 }).map((_, i) => ({
+      path: `f${i}.ts`, name: `f${i}.ts`, kind: 'file', language: 'ts', size: null, complexity: null, coverage: null, duplication: null, issues: null, debt: null, ratings: null
+    }))
+    
+    vi.mocked(api.projectMeasures).mockResolvedValue(buildResponse({
+      children: { items: items as any, nextCursor: null }
+    }))
+    
+    renderRoute('/code-quality/projects/synapse/measures?domain=size')
+    
+    expect(await screen.findByTestId('virtual-table')).toBeInTheDocument()
+    expect(screen.getByText('f0.ts')).toBeInTheDocument()
+    expect(screen.getByText('f59.ts')).toBeInTheDocument()
+    
+    // Native table uses table
+    expect(screen.queryByRole('columnheader')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/ProjectMeasuresPage.tsx
+++ b/web/src/pages/ProjectMeasuresPage.tsx
@@ -107,8 +107,11 @@ export function ProjectMeasuresPage() {
           }
         }
       })
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load more')
+    } catch (error) {
+      if (generation !== requestGenerationRef.current) return
+      if (error instanceof DOMException && error.name === 'AbortError') return
+      
+      setError(error instanceof Error ? error.message : 'Failed to load more')
     } finally {
       setLoadingMore(false)
     }
@@ -308,10 +311,10 @@ function CurrentNodeMeasures({ node, domain }: { node: MeasureNode, domain: stri
       { label: 'Vulnerabilities', m: node.issues?.byType['vulnerability'] },
       { label: 'Code Smells', m: node.issues?.byType['code_smell'] },
       { label: 'Security Hotspots', m: node.issues?.byType['security_hotspot'] },
-      { label: 'Blocker', m: node.issues?.bySeverity['blocker'] },
       { label: 'Critical', m: node.issues?.bySeverity['critical'] },
-      { label: 'Major', m: node.issues?.bySeverity['major'] },
-      { label: 'Minor', m: node.issues?.bySeverity['minor'] },
+      { label: 'High', m: node.issues?.bySeverity['high'] },
+      { label: 'Medium', m: node.issues?.bySeverity['medium'] },
+      { label: 'Low', m: node.issues?.bySeverity['low'] },
       { label: 'Info', m: node.issues?.bySeverity['info'] }
     )
   } else if (domain === 'debt') {

--- a/web/src/pages/ProjectMeasuresPage.tsx
+++ b/web/src/pages/ProjectMeasuresPage.tsx
@@ -157,18 +157,20 @@ export function ProjectMeasuresPage() {
       <div className="flex flex-wrap items-center justify-between gap-4">
         {/* Breadcrumbs */}
         <nav className="flex items-center text-sm font-medium text-mutedfg" aria-label="Breadcrumb">
-          <button 
+          <button
             onClick={() => setPath('')}
-            className="hover:text-foreground transition-colors"
+            aria-current={breadcrumbs.length === 0 ? 'page' : undefined}
+            className="rounded-sm hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
           >
             {data.project.name}
           </button>
           {breadcrumbs.map((b, i) => (
             <div key={b.path} className="flex items-center">
               <ChevronRight className="size-4 mx-1" aria-hidden="true" />
-              <button 
+              <button
                 onClick={() => setPath(b.path)}
-                className={cn("hover:text-foreground transition-colors", i === breadcrumbs.length - 1 && "text-foreground")}
+                aria-current={i === breadcrumbs.length - 1 ? 'page' : undefined}
+                className={cn("rounded-sm hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60", i === breadcrumbs.length - 1 && "text-foreground")}
               >
                 {b.label}
               </button>
@@ -182,8 +184,9 @@ export function ProjectMeasuresPage() {
             <button
               key={d.key}
               onClick={() => setDomain(d.key)}
+              aria-pressed={domain === d.key}
               className={cn(
-                "px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
+                "px-3 py-1.5 text-xs font-medium rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60",
                 domain === d.key ? "bg-bg text-foreground shadow-sm ring-1 ring-border" : "text-mutedfg hover:text-foreground hover:bg-elevated/50"
               )}
             >
@@ -200,7 +203,7 @@ export function ProjectMeasuresPage() {
       )}
 
       {data.node?.kind !== 'file' && (
-        <div className="bg-bg border border-border rounded-xl overflow-hidden">
+        <div className="bg-card border border-border rounded-xl overflow-hidden">
           {sortedItems.length === 0 ? (
             <EmptyState
               icon={Folder}
@@ -219,16 +222,16 @@ export function ProjectMeasuresPage() {
             <table className="min-w-full text-left text-sm whitespace-nowrap">
               <thead className="bg-elevated/95 text-[11px] uppercase tracking-[0.14em] text-foreground border-b border-borderstrong sticky top-0">
                 <tr>
-                  {columns(setPath).map((c, i) => (
-                    <th key={i} className={cn("px-4 py-3 font-semibold", c.className)}>{c.header}</th>
+                  {columns(setPath).map((c) => (
+                    <th key={c.header} scope="col" className={cn("px-4 py-3 font-semibold", c.className)}>{c.header}</th>
                   ))}
                 </tr>
               </thead>
               <tbody className="divide-y divide-border/60">
                 {sortedItems.map(item => (
                   <tr key={item.path} className="hover:bg-elevated/40 transition-colors">
-                    {columns(setPath).map((c, i) => (
-                      <td key={i} className={cn("px-4 py-3 min-w-0 truncate", c.className)}>
+                    {columns(setPath).map((c) => (
+                      <td key={c.header} className={cn("px-4 py-3 min-w-0 truncate", c.className)}>
                         {c.cell(item)}
                       </td>
                     ))}
@@ -271,8 +274,10 @@ function MetricValue({ m }: { m: MeasureCountMetric | MeasureDecimalMetric | Mea
   }
   
   if (m.value === null) return <span className="text-mutedfg">-</span>
-  
-  return <span className="tabular-nums font-mono">{m.value}</span>
+
+  // Round decimals (e.g. coverage/density percentages) and group large counts, matching the
+  // sibling tabs; small integers render unchanged.
+  return <span className="tabular-nums font-mono">{m.value.toLocaleString(undefined, { maximumFractionDigits: 2 })}</span>
 }
 
 function CurrentNodeMeasures({ node, domain }: { node: MeasureNode, domain: string }) {
@@ -330,11 +335,11 @@ function CurrentNodeMeasures({ node, domain }: { node: MeasureNode, domain: stri
   }
 
   return (
-    <div className="bg-bg border border-border rounded-xl p-4">
+    <div className="bg-card border border-border rounded-xl p-4">
       <h3 className="text-sm font-semibold mb-3">Current Node Metrics</h3>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-        {metrics.map((item, i) => (
-          <div key={i} className="flex flex-col gap-1">
+        {metrics.map((item) => (
+          <div key={item.label} className="flex flex-col gap-1">
             <span className="text-xs font-medium text-mutedfg">{item.label}</span>
             <div className="text-sm"><MetricValue m={item.m} /></div>
           </div>
@@ -353,11 +358,11 @@ function getDomainColumns(domain: string): (setPath: (p: string) => void) => Col
         const navigable = item.kind === 'directory' || item.kind === 'file'
         return (
           <div className="flex items-center gap-2">
-            {item.kind === 'directory' ? <Folder className="size-4 text-branddim shrink-0" /> : <File className="size-4 text-mutedfg shrink-0" />}
+            {item.kind === 'directory' ? <Folder className="size-4 text-branddim shrink-0" aria-hidden="true" /> : <File className="size-4 text-mutedfg shrink-0" aria-hidden="true" />}
             {navigable ? (
-              <button 
+              <button
                 onClick={() => setPath(item.path)}
-                className="font-medium hover:underline hover:text-brand text-left truncate"
+                className="rounded-sm font-medium hover:underline hover:text-brand text-left truncate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
                 title={item.name}
               >
                 {item.name}

--- a/web/src/pages/ProjectMeasuresPage.tsx
+++ b/web/src/pages/ProjectMeasuresPage.tsx
@@ -1,0 +1,342 @@
+import { useEffect, useRef, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { Folder, File, ChevronRight, AlertCircle } from 'lucide-react'
+import { api } from '../lib/api'
+import { Button, EmptyState, ErrorState, Spinner, Pill, cn } from '../components/ui'
+import { VirtualTable, type Column } from '../components/VirtualTable'
+import { useProjectRouteContext, ProjectRouteEmpty } from './CodeQualityProject'
+import type { 
+  ProjectMeasureResponse, 
+  MeasureNode, 
+  MeasureCountMetric, 
+  MeasureDecimalMetric, 
+  MeasureGradeMetric 
+} from '../lib/projectMeasures'
+
+const DOMAINS = [
+  { key: 'size', label: 'Size' },
+  { key: 'complexity', label: 'Complexity' },
+  { key: 'coverage', label: 'Coverage' },
+  { key: 'duplication', label: 'Duplications' },
+  { key: 'issues', label: 'Issues' },
+  { key: 'debt', label: 'Technical Debt' },
+  { key: 'ratings', label: 'Ratings' },
+]
+
+export function ProjectMeasuresPage() {
+  const { projectKey, job } = useProjectRouteContext()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const path = searchParams.get('path') ?? ''
+  const domain = searchParams.get('domain') ?? 'size'
+
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [data, setData] = useState<ProjectMeasureResponse | null>(null)
+  
+  const abortController = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    let live = true
+    setLoading(true)
+    setError(null)
+    setData(null)
+
+    if (abortController.current) {
+      abortController.current.abort()
+    }
+    const ac = new AbortController()
+    abortController.current = ac
+
+    api.projectMeasures(projectKey, { path, domain: [domain], limit: 100 }, ac.signal)
+      .then((res) => {
+        if (!live) return
+        setData(res)
+      })
+      .catch((err) => {
+        if (!live || err.name === 'AbortError') return
+        setError(err instanceof Error ? err.message : 'Failed to load measures')
+      })
+      .finally(() => {
+        if (live) setLoading(false)
+      })
+
+    return () => {
+      live = false
+      ac.abort()
+    }
+  }, [projectKey, path, domain])
+
+  async function loadMore() {
+    if (!data?.children.nextCursor || loadingMore) return
+    setLoadingMore(true)
+    setError(null)
+
+    try {
+      const res = await api.projectMeasures(projectKey, {
+        path,
+        domain: [domain],
+        limit: 100,
+        cursor: data.children.nextCursor
+      })
+      setData((prev) => {
+        if (!prev) return res
+        // Prevent duplicated rows by using a simple Set of paths (though backend handles cursor correctly)
+        const existing = new Set(prev.children.items.map(x => x.path))
+        const newItems = res.children.items.filter(x => !existing.has(x.path))
+        return {
+          ...prev,
+          children: {
+            items: [...prev.children.items, ...newItems],
+            nextCursor: res.children.nextCursor,
+          }
+        }
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load more')
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  function setPath(newPath: string) {
+    const sp = new URLSearchParams(searchParams)
+    if (newPath) sp.set('path', newPath)
+    else sp.delete('path')
+    setSearchParams(sp)
+  }
+
+  function setDomain(newDomain: string) {
+    const sp = new URLSearchParams(searchParams)
+    sp.set('domain', newDomain)
+    setSearchParams(sp)
+  }
+
+  if (loading) return <Spinner label="Loading measures…" />
+  if (error && !data) return <ErrorState message={error} />
+  if (!data || data.state === 'not_analyzed') return <ProjectRouteEmpty running={job?.status === 'running'} />
+
+  // Breadcrumbs processing
+  const parts = path ? path.split('/') : []
+  const breadcrumbs = []
+  let currentPath = ''
+  for (let i = 0; i < parts.length; i++) {
+    currentPath += (i === 0 ? '' : '/') + parts[i]
+    breadcrumbs.push({ label: parts[i], path: currentPath })
+  }
+
+  // Sort children: directories first
+  const sortedItems = [...data.children.items].sort((a, b) => {
+    if (a.kind === 'directory' && b.kind !== 'directory') return -1
+    if (a.kind !== 'directory' && b.kind === 'directory') return 1
+    return a.name.localeCompare(b.name)
+  })
+
+  const columns = getDomainColumns(domain)
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        {/* Breadcrumbs */}
+        <nav className="flex items-center text-sm font-medium text-mutedfg" aria-label="Breadcrumb">
+          <button 
+            onClick={() => setPath('')}
+            className="hover:text-foreground transition-colors"
+          >
+            {data.project.name}
+          </button>
+          {breadcrumbs.map((b, i) => (
+            <div key={b.path} className="flex items-center">
+              <ChevronRight className="size-4 mx-1" aria-hidden="true" />
+              <button 
+                onClick={() => setPath(b.path)}
+                className={cn("hover:text-foreground transition-colors", i === breadcrumbs.length - 1 && "text-foreground")}
+              >
+                {b.label}
+              </button>
+            </div>
+          ))}
+        </nav>
+
+        {/* Domain Selector */}
+        <div className="flex gap-1 bg-elevated p-1 rounded-lg border border-border">
+          {DOMAINS.map(d => (
+            <button
+              key={d.key}
+              onClick={() => setDomain(d.key)}
+              className={cn(
+                "px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
+                domain === d.key ? "bg-bg text-foreground shadow-sm ring-1 ring-border" : "text-mutedfg hover:text-foreground hover:bg-elevated/50"
+              )}
+            >
+              {d.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && <ErrorState message={error} />}
+
+      <div className="bg-bg border border-border rounded-xl overflow-hidden">
+        {sortedItems.length === 0 ? (
+          <EmptyState
+            icon={Folder}
+            title="Empty directory"
+            hint="This directory has no measurable children."
+          />
+        ) : sortedItems.length > 50 ? (
+          <VirtualTable
+            columns={columns(setPath)}
+            items={sortedItems}
+            rowKey={(item) => item.path}
+            totalItems={undefined}
+          />
+        ) : (
+          <div className="overflow-x-auto min-w-full">
+            <table className="min-w-full text-left text-sm whitespace-nowrap">
+              <thead className="bg-elevated/95 text-[11px] uppercase tracking-[0.14em] text-foreground border-b border-borderstrong sticky top-0">
+                <tr>
+                  {columns(setPath).map((c, i) => (
+                    <th key={i} className={cn("px-4 py-3 font-semibold", c.className)}>{c.header}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {sortedItems.map(item => (
+                  <tr key={item.path} className="hover:bg-elevated/40 transition-colors">
+                    {columns(setPath).map((c, i) => (
+                      <td key={i} className={cn("px-4 py-3 min-w-0 truncate", c.className)}>
+                        {c.cell(item)}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {data.children.nextCursor && (
+        <div className="flex justify-center pt-4">
+          <Button variant="secondary" onClick={loadMore} loading={loadingMore}>
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MetricValue({ m }: { m: MeasureCountMetric | MeasureDecimalMetric | MeasureGradeMetric | undefined }) {
+  if (!m) return <span className="text-mutedfg" title="Omitted">-</span>
+  if (m.availability === 'not_applicable') {
+    return <span className="text-subtlefg" title="Not applicable">N/A</span>
+  }
+  if (m.availability === 'unavailable') {
+    return (
+      <span className="text-mutedfg flex items-center gap-1" title={m.reason ?? 'Unavailable'}>
+        -
+        {m.reason && <AlertCircle className="size-3 text-branddim" aria-hidden="true" />}
+      </span>
+    )
+  }
+  
+  if ('grade' in m) {
+    return <span className="font-medium font-mono">{m.grade}</span>
+  }
+  
+  if (m.value === null) return <span className="text-mutedfg">-</span>
+  
+  return <span className="tabular-nums font-mono">{m.value}</span>
+}
+
+function getDomainColumns(domain: string): (setPath: (p: string) => void) => Column<MeasureNode>[] {
+  const baseColumns: (setPath: (p: string) => void) => Column<MeasureNode>[] = (setPath) => [
+    {
+      header: 'Name',
+      className: 'w-[40%]',
+      cell: (item) => (
+        <div className="flex items-center gap-2">
+          {item.kind === 'directory' ? <Folder className="size-4 text-branddim shrink-0" /> : <File className="size-4 text-mutedfg shrink-0" />}
+          {item.kind === 'directory' ? (
+            <button 
+              onClick={() => setPath(item.path)}
+              className="font-medium hover:underline hover:text-brand text-left truncate"
+              title={item.name}
+            >
+              {item.name}
+            </button>
+          ) : (
+            <span className="font-medium truncate" title={item.name}>{item.name}</span>
+          )}
+        </div>
+      )
+    },
+    {
+      header: 'Kind',
+      className: 'w-[15%]',
+      cell: (item) => <span className="capitalize">{item.kind}</span>
+    },
+    {
+      header: 'Language',
+      className: 'w-[15%]',
+      cell: (item) => item.language ? <Pill>{item.language}</Pill> : null
+    },
+  ]
+
+  return (setPath) => {
+    const base = baseColumns(setPath)
+    switch (domain) {
+      case 'size':
+        return [
+          ...base,
+          { header: 'Files', cell: (i) => <MetricValue m={i.size?.files} /> },
+          { header: 'Code Lines', cell: (i) => <MetricValue m={i.size?.ncloc} /> },
+          { header: 'Functions', cell: (i) => <MetricValue m={i.size?.functions} /> },
+        ]
+      case 'complexity':
+        return [
+          ...base,
+          { header: 'Cyclomatic', cell: (i) => <MetricValue m={i.complexity?.cyclomatic} /> },
+          { header: 'Cognitive', cell: (i) => <MetricValue m={i.complexity?.cognitive} /> },
+        ]
+      case 'coverage':
+        return [
+          ...base,
+          { header: 'Coverage %', cell: (i) => <MetricValue m={i.coverage?.coverage} /> },
+          { header: 'New Code %', cell: (i) => <MetricValue m={i.coverage?.newCodeCoverage} /> },
+          { header: 'Covered Lines', cell: (i) => <MetricValue m={i.coverage?.coveredLines} /> },
+        ]
+      case 'duplication':
+        return [
+          ...base,
+          { header: 'Duplication %', cell: (i) => <MetricValue m={i.duplication?.duplicationDensity} /> },
+          { header: 'Duplicated Lines', cell: (i) => <MetricValue m={i.duplication?.duplicatedLines} /> },
+          { header: 'Blocks', cell: (i) => <MetricValue m={i.duplication?.duplicationBlocks} /> },
+        ]
+      case 'issues':
+        return [
+          ...base,
+          { header: 'Bugs', cell: (i) => <MetricValue m={i.issues?.byType['bug']} /> },
+          { header: 'Vulnerabilities', cell: (i) => <MetricValue m={i.issues?.byType['vulnerability']} /> },
+          { header: 'Code Smells', cell: (i) => <MetricValue m={i.issues?.byType['code_smell']} /> },
+          { header: 'Hotspots', cell: (i) => <MetricValue m={i.issues?.byType['security_hotspot']} /> },
+        ]
+      case 'debt':
+        return [
+          ...base,
+          { header: 'Remediation Effort', cell: (i) => <MetricValue m={i.debt?.remediationEffortMinutes} /> },
+        ]
+      case 'ratings':
+        return [
+          ...base,
+          { header: 'Security', cell: (i) => <MetricValue m={i.ratings?.security} /> },
+          { header: 'Reliability', cell: (i) => <MetricValue m={i.ratings?.reliability} /> },
+          { header: 'Maintainability', cell: (i) => <MetricValue m={i.ratings?.maintainability} /> },
+        ]
+      default:
+        return base
+    }
+  }
+}

--- a/web/src/pages/ProjectMeasuresPage.tsx
+++ b/web/src/pages/ProjectMeasuresPage.tsx
@@ -35,12 +35,15 @@ export function ProjectMeasuresPage() {
   const [data, setData] = useState<ProjectMeasureResponse | null>(null)
   
   const abortController = useRef<AbortController | null>(null)
+  const requestGenerationRef = useRef(0)
 
   useEffect(() => {
     let live = true
     setLoading(true)
     setError(null)
     setData(null)
+    
+    requestGenerationRef.current += 1
 
     if (abortController.current) {
       abortController.current.abort()
@@ -72,13 +75,25 @@ export function ProjectMeasuresPage() {
     setLoadingMore(true)
     setError(null)
 
+    const generation = requestGenerationRef.current
+    const requestedPath = path
+    const requestedDomain = domain
+
     try {
       const res = await api.projectMeasures(projectKey, {
         path,
         domain: [domain],
         limit: 100,
         cursor: data.children.nextCursor
-      })
+      }, abortController.current?.signal)
+      
+      if (
+        generation !== requestGenerationRef.current ||
+        requestedPath !== path ||
+        requestedDomain !== domain
+      ) {
+        return
+      }
       setData((prev) => {
         if (!prev) return res
         // Prevent duplicated rows by using a simple Set of paths (though backend handles cursor correctly)
@@ -176,14 +191,19 @@ export function ProjectMeasuresPage() {
       </div>
 
       {error && <ErrorState message={error} />}
+      
+      {data.node && (
+        <CurrentNodeMeasures node={data.node} domain={domain} />
+      )}
 
-      <div className="bg-bg border border-border rounded-xl overflow-hidden">
-        {sortedItems.length === 0 ? (
-          <EmptyState
-            icon={Folder}
-            title="Empty directory"
-            hint="This directory has no measurable children."
-          />
+      {data.node?.kind !== 'file' && (
+        <div className="bg-bg border border-border rounded-xl overflow-hidden">
+          {sortedItems.length === 0 ? (
+            <EmptyState
+              icon={Folder}
+              title="Empty directory"
+              hint="This directory has no measurable children."
+            />
         ) : sortedItems.length > 50 ? (
           <VirtualTable
             columns={columns(setPath)}
@@ -216,8 +236,9 @@ export function ProjectMeasuresPage() {
           </div>
         )}
       </div>
+      )}
 
-      {data.children.nextCursor && (
+      {data.node?.kind !== 'file' && data.children.nextCursor && (
         <div className="flex justify-center pt-4">
           <Button variant="secondary" onClick={loadMore} loading={loadingMore}>
             Load more
@@ -251,27 +272,99 @@ function MetricValue({ m }: { m: MeasureCountMetric | MeasureDecimalMetric | Mea
   return <span className="tabular-nums font-mono">{m.value}</span>
 }
 
+function CurrentNodeMeasures({ node, domain }: { node: MeasureNode, domain: string }) {
+  const metrics: { label: string, m: MeasureCountMetric | MeasureDecimalMetric | MeasureGradeMetric | undefined }[] = []
+  
+  if (domain === 'size') {
+    metrics.push(
+      { label: 'Files', m: node.size?.files },
+      { label: 'Lines of Code', m: node.size?.ncloc },
+      { label: 'Functions', m: node.size?.functions },
+      { label: 'Comment Lines', m: node.size?.commentLines },
+      { label: 'Blank Lines', m: node.size?.blankLines },
+      { label: 'Comment Density', m: node.size?.commentDensity }
+    )
+  } else if (domain === 'complexity') {
+    metrics.push(
+      { label: 'Cyclomatic', m: node.complexity?.cyclomatic },
+      { label: 'Cognitive', m: node.complexity?.cognitive }
+    )
+  } else if (domain === 'coverage') {
+    metrics.push(
+      { label: 'Coverage', m: node.coverage?.coverage },
+      { label: 'New Code Coverage', m: node.coverage?.newCodeCoverage },
+      { label: 'Covered Lines', m: node.coverage?.coveredLines },
+      { label: 'Coverable Lines', m: node.coverage?.coverableLines }
+    )
+  } else if (domain === 'duplication') {
+    metrics.push(
+      { label: 'Duplication Density', m: node.duplication?.duplicationDensity },
+      { label: 'Duplicated Lines', m: node.duplication?.duplicatedLines },
+      { label: 'Duplication Blocks', m: node.duplication?.duplicationBlocks }
+    )
+  } else if (domain === 'issues') {
+    metrics.push(
+      { label: 'Bugs', m: node.issues?.byType['bug'] },
+      { label: 'Vulnerabilities', m: node.issues?.byType['vulnerability'] },
+      { label: 'Code Smells', m: node.issues?.byType['code_smell'] },
+      { label: 'Security Hotspots', m: node.issues?.byType['security_hotspot'] },
+      { label: 'Blocker', m: node.issues?.bySeverity['blocker'] },
+      { label: 'Critical', m: node.issues?.bySeverity['critical'] },
+      { label: 'Major', m: node.issues?.bySeverity['major'] },
+      { label: 'Minor', m: node.issues?.bySeverity['minor'] },
+      { label: 'Info', m: node.issues?.bySeverity['info'] }
+    )
+  } else if (domain === 'debt') {
+    metrics.push(
+      { label: 'Remediation Effort (mins)', m: node.debt?.remediationEffortMinutes }
+    )
+  } else if (domain === 'ratings') {
+    metrics.push(
+      { label: 'Security', m: node.ratings?.security },
+      { label: 'Reliability', m: node.ratings?.reliability },
+      { label: 'Maintainability', m: node.ratings?.maintainability }
+    )
+  }
+
+  return (
+    <div className="bg-bg border border-border rounded-xl p-4">
+      <h3 className="text-sm font-semibold mb-3">Current Node Metrics</h3>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+        {metrics.map((item, i) => (
+          <div key={i} className="flex flex-col gap-1">
+            <span className="text-xs font-medium text-mutedfg">{item.label}</span>
+            <div className="text-sm"><MetricValue m={item.m} /></div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function getDomainColumns(domain: string): (setPath: (p: string) => void) => Column<MeasureNode>[] {
   const baseColumns: (setPath: (p: string) => void) => Column<MeasureNode>[] = (setPath) => [
     {
       header: 'Name',
       className: 'w-[40%]',
-      cell: (item) => (
-        <div className="flex items-center gap-2">
-          {item.kind === 'directory' ? <Folder className="size-4 text-branddim shrink-0" /> : <File className="size-4 text-mutedfg shrink-0" />}
-          {item.kind === 'directory' ? (
-            <button 
-              onClick={() => setPath(item.path)}
-              className="font-medium hover:underline hover:text-brand text-left truncate"
-              title={item.name}
-            >
-              {item.name}
-            </button>
-          ) : (
-            <span className="font-medium truncate" title={item.name}>{item.name}</span>
-          )}
-        </div>
-      )
+      cell: (item) => {
+        const navigable = item.kind === 'directory' || item.kind === 'file'
+        return (
+          <div className="flex items-center gap-2">
+            {item.kind === 'directory' ? <Folder className="size-4 text-branddim shrink-0" /> : <File className="size-4 text-mutedfg shrink-0" />}
+            {navigable ? (
+              <button 
+                onClick={() => setPath(item.path)}
+                className="font-medium hover:underline hover:text-brand text-left truncate"
+                title={item.name}
+              >
+                {item.name}
+              </button>
+            ) : (
+              <span className="font-medium truncate" title={item.name}>{item.name}</span>
+            )}
+          </div>
+        )
+      }
     },
     {
       header: 'Kind',


### PR DESCRIPTION
## Summary

This PR completes Phase C of #180 by adding the Project Measures Explorer frontend.

It exposes the immutable Measures API through a new Code Quality project tab and allows users to browse computed metrics from project to directory to file.

## What changed

* Added the nested route:

  ```text
  /code-quality/projects/:key/measures
  ```

* Added the **Measures** tab without removing or replacing the existing Overview, Issues, Security Hotspots, Analysis, or Activity routes.

* Added typed frontend contracts and mapping for the Project Measures API.

* Added metric-domain views for:

  * Size
  * Complexity
  * Coverage
  * Duplications
  * Issues
  * Technical debt
  * Ratings

* Added URL-backed path navigation and breadcrumbs.

* Added project, directory, and file drill-down.

* Added a current-node details panel exposing all measures returned for the selected domain.

* Added direct-child cursor pagination with append and path-based deduplication.

* Added `VirtualTable` rendering when more than 50 rows are displayed.

* Added loading, error, not-analyzed, empty-directory, and file-detail states.

## Data handling

The UI preserves the backend measure semantics:

* Measured zero remains `0`.
* `unavailable` is not displayed as zero.
* `not_applicable` remains distinct from unavailable.
* Ratings and New Code coverage remain project-root-only.
* Pagination cursors remain opaque and are never decoded or modified.
* The frontend does not recompute coverage, duplication, ratings, issue counts, or technical debt.

The API mapper also fails closed: malformed `available` metrics with missing values are not converted into artificial zero values.

## Request safety

Primary and paginated requests are protected against stale responses.

Changing the selected path or metric domain:

* cancels the previous request;
* resets pagination state;
* prevents old pages from being appended to the new path;
* silently ignores expected `AbortError` failures instead of showing a false network error.

## Tests

Added frontend coverage for:

* API response mapping;
* available-zero, unavailable, and not-applicable states;
* malformed available values;
* project, directory, and file navigation;
* breadcrumb navigation;
* current-node measures;
* issue type and severity mapping;
* normal pagination append;
* duplicate-path removal;
* stale pagination cancellation;
* AbortError handling;
* pagination reset when changing paths;
* file rows not behaving as expandable directories;
* `VirtualTable` usage above 50 rows;
* preservation of all existing project navigation tabs.

## Validation

The frontend test suite passes successfully:

```text
pnpm test
```

The implementation was also reviewed against `upstream/main` to confirm that existing Overview, Issues, Security Hotspots, Analysis, and Activity routes remain intact.

Closes #180
