### PR TITLE
feat(codequality): add new_coverage + new_duplication gate metrics (#184)

### DIFF
--- a/internal/domain/qualitygate/gate_test.go
+++ b/internal/domain/qualitygate/gate_test.go
@@ -47,3 +47,30 @@ func TestDefaultGate(t *testing.T) {
 		t.Error("a new critical must fail the default gate")
 	}
 }
+
+func TestValidMetricAcceptsNewCodeCoverageAndDuplication(t *testing.T) {
+	for _, m := range []string{MetricNewCoverage, MetricNewDuplication, MetricSecurityHotspotsReviewed} {
+		if !ValidMetric(m) {
+			t.Errorf("metric %q must be a valid gate condition metric", m)
+		}
+	}
+	if ValidMetric("not_a_metric") {
+		t.Error("an unknown metric must be rejected")
+	}
+	// A custom gate using the new-code metrics validates, and — since neither is measured yet — a
+	// `new_coverage >= 80` condition reads 0 and fails closed while `new_duplication <= 3` passes at 0.
+	g := Gate{Key: "clean-as-you-code", Name: "Clean as You Code", Conditions: []Condition{
+		{Metric: MetricNewCoverage, Op: OpGE, Threshold: 80},
+		{Metric: MetricNewDuplication, Op: OpLE, Threshold: 3},
+	}}
+	if _, err := g.Normalize(); err != nil {
+		t.Fatalf("custom gate with new-code metrics must validate: %v", err)
+	}
+	res := Evaluate(g, Snapshot{})
+	if res.Passed {
+		t.Error("an unmeasured new_coverage>=80 must fail closed on an empty snapshot")
+	}
+	if len(res.Failures()) != 1 || res.Failures()[0].Condition.Metric != MetricNewCoverage {
+		t.Errorf("only new_coverage should fail closed at 0; failures=%+v", res.Failures())
+	}
+}

--- a/internal/domain/qualitygate/metrics.go
+++ b/internal/domain/qualitygate/metrics.go
@@ -4,32 +4,38 @@ package qualitygate
 // (Clean as You Code); the others are whole-codebase. Ratings are numeric: A=1, B=2, C=3, D=4, E=5, so
 // `security_rating <= 1` means "must be A".
 const (
-	MetricNewCritical      = "new_critical"      // new findings with critical severity
-	MetricNewHigh          = "new_high"          // new findings with high severity
-	MetricNewMedium        = "new_medium"        // new findings with medium severity
-	MetricNewSecret        = "new_secret"        // new secret findings
-	MetricNewVulnerability = "new_vulnerability" // new security findings (sca/sast/secret/misconfig/exploitation/dast)
-	MetricNewIssues        = "new_issues"        // all new findings
-	MetricTotalCritical    = "total_critical"    // whole-codebase critical findings
-	MetricDuplicationPct   = "duplication_density"
-	MetricCoveragePct      = "coverage"
+	MetricNewCritical                 = "new_critical"      // new findings with critical severity
+	MetricNewHigh                     = "new_high"          // new findings with high severity
+	MetricNewMedium                   = "new_medium"        // new findings with medium severity
+	MetricNewSecret                   = "new_secret"        // new secret findings
+	MetricNewVulnerability            = "new_vulnerability" // new security findings (sca/sast/secret/misconfig/exploitation/dast)
+	MetricNewIssues                   = "new_issues"        // all new findings
+	MetricTotalCritical               = "total_critical"    // whole-codebase critical findings
+	MetricDuplicationPct              = "duplication_density"
+	MetricCoveragePct                 = "coverage"
 	MetricSecurityRating              = "security_rating"
 	MetricReliability                 = "reliability_rating"
 	MetricMaintainability             = "maintainability_rating"
 	MetricSecurityHotspotsReviewed    = "security_hotspots_reviewed"
 	MetricNewSecurityHotspotsReviewed = "new_security_hotspots_reviewed"
+	MetricNewCoverage                 = "new_coverage"    // line coverage on new/changed code
+	MetricNewDuplication              = "new_duplication" // duplication density on new/changed code
 )
 
 // knownMetrics is the set a gate condition may reference, so a typo'd metric name is rejected at load
 // time (a metric absent from the snapshot reads as 0, which could otherwise silently pass a gate).
-// NOTE: `coverage` is accepted but not yet measured (lands with the coverage-import phase); a coverage
-// condition therefore reads 0 and fails closed until then.
+// NOTE: `coverage`, `new_coverage`, and `new_duplication` are accepted as valid condition metrics but are
+// not yet measured (coverage lands with the coverage-import phase; the new-code variants need retained
+// changed-line data). Until then each reads 0 from the snapshot: a `>=` coverage condition fails closed,
+// and a `<=` new_duplication condition passes at 0. They are offered so a custom gate can encode the
+// Clean-as-You-Code policy now and start enforcing the moment the measurement lands.
 var knownMetrics = map[string]bool{
 	MetricNewCritical: true, MetricNewHigh: true, MetricNewMedium: true, MetricNewSecret: true,
 	MetricNewVulnerability: true, MetricNewIssues: true, MetricTotalCritical: true,
 	MetricDuplicationPct: true, MetricCoveragePct: true,
 	MetricSecurityRating: true, MetricReliability: true, MetricMaintainability: true,
 	MetricSecurityHotspotsReviewed: true, MetricNewSecurityHotspotsReviewed: true,
+	MetricNewCoverage: true, MetricNewDuplication: true,
 }
 
 // ValidMetric reports whether name is a recognized gate metric.

--- a/web/src/components/codequality/qualityPresentation.tsx
+++ b/web/src/components/codequality/qualityPresentation.tsx
@@ -7,6 +7,7 @@ export const metricLabels: Record<string, string> = {
   new_vulnerability: 'New vulnerabilities', new_issues: 'New issues', total_critical: 'Total critical issues', coverage: 'Line coverage',
   duplication_density: 'Duplication density', security_rating: 'Security rating', reliability_rating: 'Reliability rating', maintainability_rating: 'Maintainability rating',
   security_hotspots_reviewed: 'Security Hotspots Reviewed', new_security_hotspots_reviewed: 'New Security Hotspots Reviewed',
+  new_coverage: 'New Code coverage', new_duplication: 'New Code duplication',
 }
 
 export function metricLabel(metric: string) { return metricLabels[metric] ?? metric.replaceAll('_', ' ') }

--- a/web/src/pages/QualityGates.tsx
+++ b/web/src/pages/QualityGates.tsx
@@ -5,7 +5,7 @@ import type { QualityGate, QualityGateCondition } from '../lib/types'
 import { metricLabel } from '../components/codequality/qualityPresentation'
 import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Select, Spinner } from '../components/ui'
 
-const metrics = ['new_critical', 'new_high', 'new_medium', 'new_secret', 'new_vulnerability', 'new_issues', 'total_critical', 'coverage', 'duplication_density', 'security_rating', 'reliability_rating', 'maintainability_rating', 'security_hotspots_reviewed', 'new_security_hotspots_reviewed']
+const metrics = ['new_critical', 'new_high', 'new_medium', 'new_secret', 'new_vulnerability', 'new_issues', 'total_critical', 'coverage', 'new_coverage', 'duplication_density', 'new_duplication', 'security_rating', 'reliability_rating', 'maintainability_rating', 'security_hotspots_reviewed', 'new_security_hotspots_reviewed']
 const operators: QualityGateCondition['op'][] = ['<=', '>=', '==', '<', '>']
 const blankCondition = (): QualityGateCondition => ({ metric: 'new_high', op: '<=', threshold: 0 })
 


### PR DESCRIPTION
Closes #184.

Completes the final open item of the **Quality Gates (P10)** epic. The named/managed gate domain (`Gate{Key,Name,Conditions,BuiltIn}`), the built-in **"Synapse way"** gate, full CRUD + per-project assignment, per-analysis evaluation, overview surfacing, CLI Pass/Fail, and the web Quality Gates page (list + condition editor + assignment) all already shipped under P10 — verified against the acceptance criteria below. The one unchecked task was the missing Clean-as-You-Code metric names.

## What changed
- `domain/qualitygate/metrics.go`: add `new_coverage` and `new_duplication` as valid gate condition metrics (`security_hotspots_reviewed` already existed). Both are **accepted but not yet measured** (they need retained changed-line data) — so, exactly like the existing `coverage` metric, they read 0 from the snapshot: a `new_coverage >= X` condition **fails closed** and a `new_duplication <= Y` passes at 0. Documented in-code, and deliberately **not** added to the shipped built-in gate (doing so would fail-close every project until the measurement lands).
- Web: both metrics are now selectable in the gate condition editor, with friendly labels.
- Test: `ValidMetric` accepts the new metrics; a custom Clean-as-You-Code gate validates and its unmeasured `new_coverage` fails closed on an empty snapshot.

## Verification
`go build/vet/test ./...` clean, `gofmt` clean; web `tsc` + all 246 tests pass on Node 20.

## Acceptance (#184) — met
A built-in "Synapse way" gate exists; a user can create a custom gate, edit conditions, assign it to a project, and see Pass/Fail (with failing conditions) on the overview and in the CLI.