### PR TITLE
feat(codequality): Quality Profiles — named, per-language rule sets (#183)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -111,6 +111,7 @@ import (
 	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/pyreach"
 	qualitygatesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/qualitygates"
+	qualityprofilesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/qualityprofiles"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachability"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachproof"
 	reconuc "github.com/KKloudTarus/synapse-ce/internal/usecase/recon"
@@ -175,6 +176,7 @@ func main() {
 	var scanRunStore ports.ScanRunStore
 	var projectAnalysisStore ports.ProjectAnalysisStore
 	var qualityGateStore ports.QualityGateStore
+	var qualityProfileStore ports.QualityProfileStore
 	var qualityGateMutator ports.QualityGateMutator
 	var reconRunStore ports.ReconRunStore
 	var evidenceStore ports.EvidenceStore
@@ -274,6 +276,7 @@ func main() {
 		scanRunStore = postgres.NewScanRunStore(pool)
 		projectAnalysisStore = postgres.NewProjectAnalysisStore(pool)
 		qualityGateStore = postgres.NewQualityGateStore(pool)
+		qualityProfileStore = postgres.NewQualityProfileStore(pool)
 		reconRunStore = postgres.NewReconRunStore(pool)
 		evidenceStore = postgres.NewEvidenceStore(pool)
 		advisoryStore = postgres.NewAdvisoryRepository(pool)
@@ -311,6 +314,7 @@ func main() {
 		scanRunStore = memory.NewScanRunStore()
 		projectAnalysisStore = memory.NewProjectAnalysisStore()
 		qualityGateStore = memory.NewQualityGateStore()
+		qualityProfileStore = memory.NewQualityProfileStore()
 		reconRunStore = memory.NewReconRunRepository()
 		evidenceStore = memory.NewEvidenceStore()
 		advisoryStore = memory.NewAdvisoryStore()
@@ -367,6 +371,8 @@ func main() {
 		os.Exit(1)
 	}
 	projectService.SetRuleCatalog(ruleCatalog)
+	qualityProfileService := qualityprofilesuc.NewService(qualityProfileStore, ruleCatalog, projectRepo, auditLog, clock)
+	projectService.SetQualityProfiles(qualityProfileService)
 	// Measures API cursor signing: an HMAC-SHA256 key that prevents pagination token tampering.
 	// Production MUST supply at least 32 bytes via SYNAPSE_MEASURE_CURSOR_SECRET; dev gets an
 	// ephemeral random key (cursors won't survive a restart, which is acceptable for dev).
@@ -901,6 +907,7 @@ func main() {
 	scaService.SetProjectAnalysisRecorder(projectService)
 	router.SetProjects(projectService)
 	router.SetQualityGates(qualityGateService)
+	router.SetQualityProfiles(qualityProfileService)
 	router.SetExploitation(exploitationService) // evidence-gated finding verify endpoint
 	// Read-only code-quality dashboard. Server-side analysis is PURE-GO and memory-safe only (pattern
 	// rules + duplication + Go-parser inventory); tree-sitter complexity is intentionally NOT wired here

--- a/internal/adapter/httpapi/quality_profile_handler.go
+++ b/internal/adapter/httpapi/quality_profile_handler.go
@@ -1,0 +1,136 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualityprofile"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// qualityProfileService is the HTTP slice for named, per-language quality profiles: read the built-in
+// and custom profiles, copy a profile, toggle rules + severities on a custom copy, delete a custom
+// profile, and assign a profile to a project language. Mutations are PermOperate; reads are PermView.
+type qualityProfileService interface {
+	List(ctx context.Context, tenantID shared.ID, language string) ([]qualityprofile.Profile, error)
+	Get(ctx context.Context, tenantID shared.ID, key string) (qualityprofile.Profile, error)
+	Copy(ctx context.Context, actor string, tenantID shared.ID, sourceKey, newKey, newName string) (qualityprofile.Profile, error)
+	ActivateRule(ctx context.Context, actor string, tenantID shared.ID, key, ruleKey string, severity shared.Severity) (qualityprofile.Profile, error)
+	DeactivateRule(ctx context.Context, actor string, tenantID shared.ID, key, ruleKey string) (qualityprofile.Profile, error)
+	SetSeverity(ctx context.Context, actor string, tenantID shared.ID, key, ruleKey string, severity shared.Severity) (qualityprofile.Profile, error)
+	Delete(ctx context.Context, actor string, tenantID shared.ID, key string) error
+	Assign(ctx context.Context, actor string, tenantID shared.ID, projectKey, language, profileKey string) error
+}
+
+// SetQualityProfiles wires the quality-profile management endpoints. nil ⇒ routes are not registered.
+func (rt *Router) SetQualityProfiles(s qualityProfileService) { rt.qualityProfiles = s }
+
+func (rt *Router) listQualityProfiles(w http.ResponseWriter, r *http.Request) {
+	profiles, err := rt.qualityProfiles.List(r.Context(), shared.ID(TenantFrom(r.Context())), r.URL.Query().Get("language"))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, profiles)
+}
+
+func (rt *Router) getQualityProfile(w http.ResponseWriter, r *http.Request) {
+	profile, err := rt.qualityProfiles.Get(r.Context(), shared.ID(TenantFrom(r.Context())), r.PathValue("key"))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, profile)
+}
+
+type copyProfileRequest struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+func (rt *Router) copyQualityProfile(w http.ResponseWriter, r *http.Request) {
+	var req copyProfileRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	profile, err := rt.qualityProfiles.Copy(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())), r.PathValue("key"), req.Key, req.Name)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, profile)
+}
+
+type ruleActivationRequest struct {
+	Rule     string `json:"rule"`
+	Severity string `json:"severity"`
+}
+
+func (rt *Router) activateProfileRule(w http.ResponseWriter, r *http.Request) {
+	var req ruleActivationRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	profile, err := rt.qualityProfiles.ActivateRule(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())), r.PathValue("key"), req.Rule, shared.Severity(req.Severity))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, profile)
+}
+
+func (rt *Router) deactivateProfileRule(w http.ResponseWriter, r *http.Request) {
+	var req ruleActivationRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	profile, err := rt.qualityProfiles.DeactivateRule(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())), r.PathValue("key"), req.Rule)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, profile)
+}
+
+func (rt *Router) setProfileRuleSeverity(w http.ResponseWriter, r *http.Request) {
+	var req ruleActivationRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	profile, err := rt.qualityProfiles.SetSeverity(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())), r.PathValue("key"), req.Rule, shared.Severity(req.Severity))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, profile)
+}
+
+func (rt *Router) deleteQualityProfile(w http.ResponseWriter, r *http.Request) {
+	if err := rt.qualityProfiles.Delete(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())), r.PathValue("key")); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type assignProfileRequest struct {
+	Profile string `json:"profile"`
+}
+
+func (rt *Router) assignProjectProfile(w http.ResponseWriter, r *http.Request) {
+	var req assignProfileRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	if err := rt.qualityProfiles.Assign(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())), r.PathValue("key"), r.PathValue("language"), req.Profile); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -35,33 +35,34 @@ import (
 
 // Router wires HTTP routes to use case services.
 type Router struct {
-	log          *slog.Logger
-	auth         *Authenticator
-	eng          *enguc.Service
-	sca          *scauc.Service
-	aup          *aupuc.Service
-	findings     *findingsuc.Service
-	export       *exportuc.Service
-	report       *reportuc.Service
-	evidence     *evidenceuc.Service
-	recon        *reconuc.Service
-	logs         ports.LogStream
-	transfer     *transferuc.Service
-	audit        *audituc.Service
-	vex          *vexuc.Service
-	users        *usersuc.Service
-	credentials  *credentialsuc.Service
-	dastVerifier runtimeVerifierService
-	dastWorkflow dastWorkflowService
-	agent        *agentDeps          // optional; nil ⇒ agent routes are not registered
-	exploitation findingVerifier     // optional; nil ⇒ the verify route is not registered
-	judgments    judgmentService     // optional; nil ⇒ judgment routes are not registered
-	autoVerifier autoVerifierService // optional; nil ⇒ the LLM auto-verify route is not registered
-	threatModels threatModelService  // optional; nil ⇒ threat-model routes are not registered
-	drafts       writeupDraftService // optional; nil ⇒ writeup-draft sign-off routes are not registered
-	projects     projectService      // optional; nil ⇒ project routes are not registered
-	qualityGates qualityGateService  // optional; nil ⇒ quality-gate routes are not registered
-	rules        rulesService        // optional; nil ⇒ rule catalog routes are not registered
+	log             *slog.Logger
+	auth            *Authenticator
+	eng             *enguc.Service
+	sca             *scauc.Service
+	aup             *aupuc.Service
+	findings        *findingsuc.Service
+	export          *exportuc.Service
+	report          *reportuc.Service
+	evidence        *evidenceuc.Service
+	recon           *reconuc.Service
+	logs            ports.LogStream
+	transfer        *transferuc.Service
+	audit           *audituc.Service
+	vex             *vexuc.Service
+	users           *usersuc.Service
+	credentials     *credentialsuc.Service
+	dastVerifier    runtimeVerifierService
+	dastWorkflow    dastWorkflowService
+	agent           *agentDeps            // optional; nil ⇒ agent routes are not registered
+	exploitation    findingVerifier       // optional; nil ⇒ the verify route is not registered
+	judgments       judgmentService       // optional; nil ⇒ judgment routes are not registered
+	autoVerifier    autoVerifierService   // optional; nil ⇒ the LLM auto-verify route is not registered
+	threatModels    threatModelService    // optional; nil ⇒ threat-model routes are not registered
+	drafts          writeupDraftService   // optional; nil ⇒ writeup-draft sign-off routes are not registered
+	projects        projectService        // optional; nil ⇒ project routes are not registered
+	qualityGates    qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
+	qualityProfiles qualityProfileService // optional; nil ⇒ quality-profile routes are not registered
+	rules           rulesService          // optional; nil ⇒ rule catalog routes are not registered
 }
 
 // findingVerifier is the narrow slice of the exploitation use-case the verify endpoint needs:
@@ -209,6 +210,15 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("PUT /api/v1/quality-gates/{key}", rt.authz(userdom.PermOperate, rt.updateQualityGate))
 		mux.HandleFunc("DELETE /api/v1/quality-gates/{key}", rt.authz(userdom.PermOperate, rt.deleteQualityGate))
 	}
+	if rt.qualityProfiles != nil {
+		mux.HandleFunc("GET /api/v1/quality-profiles", rt.authz(userdom.PermView, rt.listQualityProfiles))
+		mux.HandleFunc("GET /api/v1/quality-profiles/{key}", rt.authz(userdom.PermView, rt.getQualityProfile))
+		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/copy", rt.authz(userdom.PermOperate, rt.copyQualityProfile))
+		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/activate", rt.authz(userdom.PermOperate, rt.activateProfileRule))
+		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/deactivate", rt.authz(userdom.PermOperate, rt.deactivateProfileRule))
+		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/severity", rt.authz(userdom.PermOperate, rt.setProfileRuleSeverity))
+		mux.HandleFunc("DELETE /api/v1/quality-profiles/{key}", rt.authz(userdom.PermOperate, rt.deleteQualityProfile))
+	}
 	if rt.projects != nil {
 		mux.HandleFunc("POST /api/v1/projects", rt.authz(userdom.PermOperate, rt.createProject))
 		mux.HandleFunc("GET /api/v1/projects", rt.authz(userdom.PermView, rt.listProjects))
@@ -224,6 +234,9 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/projects/{key}/issues/{id}/transitions", rt.authz(userdom.PermReview, rt.transitionProjectIssue))
 		mux.HandleFunc("GET /api/v1/projects/{key}/issues/{id}/history", rt.authz(userdom.PermView, rt.projectIssueHistory))
 		mux.HandleFunc("PUT /api/v1/projects/{key}/gate", rt.authz(userdom.PermOperate, rt.assignProjectGate))
+		if rt.qualityProfiles != nil {
+			mux.HandleFunc("PUT /api/v1/projects/{key}/profiles/{language}", rt.authz(userdom.PermOperate, rt.assignProjectProfile))
+		}
 		mux.HandleFunc("POST /api/v1/projects/{key}/analyses", rt.authz(userdom.PermOperate, rt.startProjectAnalysis))
 		mux.HandleFunc("GET /api/v1/projects/{key}/analyses", rt.authz(userdom.PermView, rt.listProjectAnalyses))
 		mux.HandleFunc("GET /api/v1/projects/{key}/analyses/{id}", rt.authz(userdom.PermView, rt.getProjectAnalysis))

--- a/internal/domain/qualityprofile/profile.go
+++ b/internal/domain/qualityprofile/profile.go
@@ -1,0 +1,235 @@
+// Package qualityprofile models named, per-language rule sets — the industry-standard "Quality
+// Profile". A built-in default profile per language is generated from the rule catalog (every rule for
+// that language, at its default severity) and is immutable; a user copies a built-in into a custom
+// profile and then activates/deactivates rules and overrides severities. A profile is assigned per
+// language per project (domain/project.DefaultProfileByLang); analyses honor it by translating the
+// assigned profiles into the deterministic qualitygate.Profile overlay applied to findings.
+//
+// It is pure domain: types + operations, no I/O and no LLM. The overlay bridge (ToOverlay) is the single
+// point where a managed profile becomes the serverless .synapse-rules.yaml equivalent.
+package qualityprofile
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// RuleActivation is a rule's state inside a profile: it is active, optionally with a severity that
+// overrides the rule's catalog default. A rule absent from a profile's ActivatedRules is deactivated.
+type RuleActivation struct {
+	// Severity overrides the rule's default severity when non-empty; "" keeps the catalog default.
+	Severity shared.Severity `json:"severity,omitempty"`
+}
+
+// Profile is a named, per-language set of activated rules. BuiltIn profiles are generated from the
+// catalog and immutable (no store row); custom profiles copy a Parent and are persisted per tenant.
+type Profile struct {
+	Key            string                    `json:"key"`
+	Name           string                    `json:"name"`
+	Language       string                    `json:"language"`
+	Parent         string                    `json:"parent,omitempty"` // key the custom profile was copied from ("" for a built-in)
+	ActivatedRules map[string]RuleActivation `json:"activated_rules"`  // keyed by rule.Key; absence = deactivated
+	BuiltIn        bool                      `json:"built_in"`
+}
+
+var keyPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+// LanguageSlug lowercases a language into a key-safe slug (e.g. "JavaScript/TypeScript" → "javascripttypescript").
+func LanguageSlug(language string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(language)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// BuiltInKey is the deterministic key of the built-in default profile for a language.
+func BuiltInKey(language string) string { return "synapse-way-" + LanguageSlug(language) }
+
+// BuiltIn generates the built-in default profile for a language from its catalog rules: every rule is
+// activated at its default severity (no override). Rules whose Language differs are ignored, so callers
+// can pass the whole catalog. Returns a zero Profile with ok=false when no rule targets the language.
+func BuiltIn(language string, rules []rule.Rule) (Profile, bool) {
+	language = strings.TrimSpace(language)
+	if language == "" {
+		return Profile{}, false
+	}
+	activated := map[string]RuleActivation{}
+	for _, r := range rules {
+		if r.Language != language {
+			continue
+		}
+		activated[string(r.Key)] = RuleActivation{} // active at the rule's default severity
+	}
+	if len(activated) == 0 {
+		return Profile{}, false
+	}
+	return Profile{
+		Key:            BuiltInKey(language),
+		Name:           "Synapse way (" + language + ")",
+		Language:       language,
+		ActivatedRules: activated,
+		BuiltIn:        true,
+	}, true
+}
+
+// Copy produces an independent custom profile from p (a built-in or another custom profile), carrying
+// its activated rules and recording p as the parent. The result is validated and never built-in.
+func (p Profile) Copy(key, name string) (Profile, error) {
+	c := Profile{
+		Key:            strings.TrimSpace(key),
+		Name:           strings.TrimSpace(name),
+		Language:       p.Language,
+		Parent:         p.Key,
+		ActivatedRules: cloneActivations(p.ActivatedRules),
+		BuiltIn:        false,
+	}
+	return c.Normalize()
+}
+
+// Clone returns an independent deep copy.
+func (p Profile) Clone() Profile {
+	p.ActivatedRules = cloneActivations(p.ActivatedRules)
+	return p
+}
+
+func cloneActivations(in map[string]RuleActivation) map[string]RuleActivation {
+	out := make(map[string]RuleActivation, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// Active reports whether a rule is enabled in this profile.
+func (p Profile) Active(ruleKey string) bool {
+	_, ok := p.ActivatedRules[ruleKey]
+	return ok
+}
+
+// Activate enables a rule (adding it if absent) with an optional severity override. A built-in profile
+// is immutable, so mutating it is an error. Returns a modified copy; the receiver is never mutated.
+func (p Profile) Activate(ruleKey string, severity shared.Severity) (Profile, error) {
+	if p.BuiltIn {
+		return Profile{}, fmt.Errorf("%w: cannot modify a built-in profile", shared.ErrValidation)
+	}
+	ruleKey = strings.TrimSpace(ruleKey)
+	if ruleKey == "" {
+		return Profile{}, fmt.Errorf("%w: rule key is required", shared.ErrValidation)
+	}
+	if severity != "" && !severity.Valid() {
+		return Profile{}, fmt.Errorf("%w: invalid severity %q", shared.ErrValidation, severity)
+	}
+	out := p.Clone()
+	out.ActivatedRules[ruleKey] = RuleActivation{Severity: severity}
+	return out, nil
+}
+
+// Deactivate disables a rule (removing it from the active set). Built-in profiles are immutable.
+func (p Profile) Deactivate(ruleKey string) (Profile, error) {
+	if p.BuiltIn {
+		return Profile{}, fmt.Errorf("%w: cannot modify a built-in profile", shared.ErrValidation)
+	}
+	ruleKey = strings.TrimSpace(ruleKey)
+	if _, ok := p.ActivatedRules[ruleKey]; !ok {
+		return Profile{}, fmt.Errorf("%w: rule %q is not active in this profile", shared.ErrNotFound, ruleKey)
+	}
+	out := p.Clone()
+	delete(out.ActivatedRules, ruleKey)
+	return out, nil
+}
+
+// SetSeverity overrides (or clears, with "") the severity of an already-active rule. Built-in profiles
+// are immutable.
+func (p Profile) SetSeverity(ruleKey string, severity shared.Severity) (Profile, error) {
+	if p.BuiltIn {
+		return Profile{}, fmt.Errorf("%w: cannot modify a built-in profile", shared.ErrValidation)
+	}
+	ruleKey = strings.TrimSpace(ruleKey)
+	if _, ok := p.ActivatedRules[ruleKey]; !ok {
+		return Profile{}, fmt.Errorf("%w: rule %q is not active in this profile", shared.ErrNotFound, ruleKey)
+	}
+	if severity != "" && !severity.Valid() {
+		return Profile{}, fmt.Errorf("%w: invalid severity %q", shared.ErrValidation, severity)
+	}
+	out := p.Clone()
+	out.ActivatedRules[ruleKey] = RuleActivation{Severity: severity}
+	return out, nil
+}
+
+// Normalize validates and normalizes a custom profile (trimming, key/name/language required, valid
+// severity overrides). It never returns a built-in.
+func (p Profile) Normalize() (Profile, error) {
+	p.Key, p.Name, p.Language = strings.TrimSpace(p.Key), strings.TrimSpace(p.Name), strings.TrimSpace(p.Language)
+	p.BuiltIn = false
+	if p.ActivatedRules == nil {
+		p.ActivatedRules = map[string]RuleActivation{}
+	}
+	if err := p.Validate(); err != nil {
+		return Profile{}, err
+	}
+	return p, nil
+}
+
+// Validate enforces the fields required for a safe profile.
+func (p Profile) Validate() error {
+	if !keyPattern.MatchString(p.Key) {
+		return fmt.Errorf("%w: profile key must be a lowercase hyphenated slug", shared.ErrValidation)
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("%w: profile name is required", shared.ErrValidation)
+	}
+	if strings.TrimSpace(p.Language) == "" {
+		return fmt.Errorf("%w: profile language is required", shared.ErrValidation)
+	}
+	for k, a := range p.ActivatedRules {
+		if strings.TrimSpace(k) == "" {
+			return fmt.Errorf("%w: profile has an empty rule key", shared.ErrValidation)
+		}
+		if a.Severity != "" && !a.Severity.Valid() {
+			return fmt.Errorf("%w: invalid severity %q for rule %q", shared.ErrValidation, a.Severity, k)
+		}
+	}
+	return nil
+}
+
+// SortedRuleKeys returns the activated rule keys in deterministic order (for stable API output).
+func (p Profile) SortedRuleKeys() []string {
+	keys := make([]string, 0, len(p.ActivatedRules))
+	for k := range p.ActivatedRules {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// ToOverlay translates the profile into the deterministic qualitygate.Profile overlay applied to
+// findings, given the full set of the language's catalog rules: a rule not activated is disabled
+// (dropped from results), and an activated rule with a severity override carries that severity. An
+// activated rule at its default severity produces no overlay entry (it passes through unchanged). This
+// is the single bridge that makes a managed profile behave exactly like the .synapse-rules.yaml overlay.
+func (p Profile) ToOverlay(languageRules []rule.Key) qualitygate.Profile {
+	overlay := qualitygate.Profile{Rules: map[string]qualitygate.RuleConfig{}}
+	for _, rk := range languageRules {
+		key := string(rk)
+		act, ok := p.ActivatedRules[key]
+		if !ok {
+			off := false
+			overlay.Rules[key] = qualitygate.RuleConfig{Enabled: &off}
+			continue
+		}
+		if act.Severity != "" {
+			overlay.Rules[key] = qualitygate.RuleConfig{Severity: string(act.Severity)}
+		}
+	}
+	return overlay
+}

--- a/internal/domain/qualityprofile/profile_test.go
+++ b/internal/domain/qualityprofile/profile_test.go
@@ -1,0 +1,133 @@
+package qualityprofile
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func catalog() []rule.Rule {
+	return []rule.Rule{
+		{Key: "go-a", Language: "Go", DefaultSeverity: shared.SeverityHigh},
+		{Key: "go-b", Language: "Go", DefaultSeverity: shared.SeverityMedium},
+		{Key: "py-a", Language: "Python", DefaultSeverity: shared.SeverityLow},
+	}
+}
+
+func TestBuiltInPerLanguage(t *testing.T) {
+	p, ok := BuiltIn("Go", catalog())
+	if !ok {
+		t.Fatal("expected a built-in Go profile")
+	}
+	if p.Key != "synapse-way-go" || p.Language != "Go" || !p.BuiltIn || p.Name != "Synapse way (Go)" {
+		t.Fatalf("built-in profile = %+v", p)
+	}
+	if len(p.ActivatedRules) != 2 || !p.Active("go-a") || !p.Active("go-b") || p.Active("py-a") {
+		t.Fatalf("built-in Go profile must activate exactly the Go rules: %+v", p.ActivatedRules)
+	}
+	// A language with no catalog rules yields ok=false.
+	if _, ok := BuiltIn("Rust", catalog()); ok {
+		t.Error("a language with no rules must not produce a built-in profile")
+	}
+	if _, ok := BuiltIn("", catalog()); ok {
+		t.Error("an empty language must not produce a built-in profile")
+	}
+}
+
+func TestBuiltInIsImmutable(t *testing.T) {
+	p, _ := BuiltIn("Go", catalog())
+	if _, err := p.Activate("go-a", shared.SeverityLow); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("activate on built-in must be rejected, got %v", err)
+	}
+	if _, err := p.Deactivate("go-a"); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("deactivate on built-in must be rejected, got %v", err)
+	}
+	if _, err := p.SetSeverity("go-a", shared.SeverityLow); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("set-severity on built-in must be rejected, got %v", err)
+	}
+}
+
+func TestCopyThenToggle(t *testing.T) {
+	base, _ := BuiltIn("Go", catalog())
+	custom, err := base.Copy("team-go", "Team Go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if custom.BuiltIn || custom.Parent != "synapse-way-go" || custom.Language != "Go" || len(custom.ActivatedRules) != 2 {
+		t.Fatalf("copy = %+v", custom)
+	}
+	// Copy is independent of the parent.
+	custom.ActivatedRules["go-a"] = RuleActivation{Severity: shared.SeverityLow}
+	if base.ActivatedRules["go-a"].Severity != "" {
+		t.Error("mutating a copy must not affect the built-in")
+	}
+
+	custom, _ = base.Copy("team-go", "Team Go")
+	off, err := custom.Deactivate("go-b")
+	if err != nil || off.Active("go-b") {
+		t.Fatalf("deactivate go-b failed: err=%v active=%v", err, off.Active("go-b"))
+	}
+	// Deactivating an already-inactive rule is a not-found error.
+	if _, err := off.Deactivate("go-b"); !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("deactivating an inactive rule should be ErrNotFound, got %v", err)
+	}
+	sev, err := off.SetSeverity("go-a", shared.SeverityCritical)
+	if err != nil || sev.ActivatedRules["go-a"].Severity != shared.SeverityCritical {
+		t.Fatalf("set-severity failed: err=%v got=%+v", err, sev.ActivatedRules["go-a"])
+	}
+	// Set-severity on an inactive rule fails.
+	if _, err := sev.SetSeverity("go-b", shared.SeverityLow); !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("set-severity on inactive rule should be ErrNotFound, got %v", err)
+	}
+	if _, err := sev.Activate("go-x", shared.Severity("bogus")); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("invalid severity must be rejected, got %v", err)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	good, _ := BuiltIn("Go", catalog())
+	custom, _ := good.Copy("team-go", "Team Go")
+	if err := custom.Validate(); err != nil {
+		t.Fatalf("valid custom profile: %v", err)
+	}
+	bad := custom
+	bad.Key = "Bad Key"
+	if err := bad.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("bad key must be rejected, got %v", err)
+	}
+	bad = custom
+	bad.Name = ""
+	if err := bad.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("empty name must be rejected, got %v", err)
+	}
+}
+
+func TestToOverlay(t *testing.T) {
+	base, _ := BuiltIn("Go", catalog())
+	custom, _ := base.Copy("team-go", "Team Go")
+	custom, _ = custom.Deactivate("go-b")                           // go-b disabled
+	custom, _ = custom.SetSeverity("go-a", shared.SeverityCritical) // go-a severity override
+
+	overlay := custom.ToOverlay([]rule.Key{"go-a", "go-b"})
+	// go-b is disabled → Enabled:false; go-a carries the severity override.
+	b, ok := overlay.Rules["go-b"]
+	if !ok || b.Enabled == nil || *b.Enabled {
+		t.Fatalf("go-b must be disabled in the overlay: %+v", b)
+	}
+	a, ok := overlay.Rules["go-a"]
+	if !ok || a.Severity != string(shared.SeverityCritical) {
+		t.Fatalf("go-a must carry the severity override: %+v", a)
+	}
+	// The built-in overlay (all active, no overrides) disables nothing and overrides nothing.
+	baseOverlay := base.ToOverlay([]rule.Key{"go-a", "go-b"})
+	for k, cfg := range baseOverlay.Rules {
+		if cfg.Enabled != nil && !*cfg.Enabled {
+			t.Errorf("built-in overlay must not disable rule %q", k)
+		}
+		if cfg.Severity != "" {
+			t.Errorf("built-in overlay must not override severity for %q", k)
+		}
+	}
+}

--- a/internal/infrastructure/persistence/memory/project_repo.go
+++ b/internal/infrastructure/persistence/memory/project_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
@@ -108,6 +109,24 @@ func (r *ProjectRepository) UpdateGate(_ context.Context, tenantID shared.ID, ke
 		return shared.ErrNotFound
 	}
 	p.GateID = gateID
+	return nil
+}
+
+func (r *ProjectRepository) AssignProfile(_ context.Context, tenantID shared.ID, projectKey, language, profileKey string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, found := r.data[projectStoreKey(tenantID, projectKey)]
+	if !found {
+		return shared.ErrNotFound
+	}
+	if p.DefaultProfileByLang == nil {
+		p.DefaultProfileByLang = map[string]string{}
+	}
+	if strings.TrimSpace(profileKey) == "" {
+		delete(p.DefaultProfileByLang, language)
+		return nil
+	}
+	p.DefaultProfileByLang[language] = profileKey
 	return nil
 }
 

--- a/internal/infrastructure/persistence/memory/quality_profile_store.go
+++ b/internal/infrastructure/persistence/memory/quality_profile_store.go
@@ -1,0 +1,85 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualityprofile"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// QualityProfileStore is a goroutine-safe in-memory custom quality-profile store.
+type QualityProfileStore struct {
+	mu   sync.RWMutex
+	data map[string]qualityprofile.Profile
+}
+
+func NewQualityProfileStore() *QualityProfileStore {
+	return &QualityProfileStore{data: map[string]qualityprofile.Profile{}}
+}
+
+var _ ports.QualityProfileStore = (*QualityProfileStore)(nil)
+
+func qualityProfileStoreKey(tenantID shared.ID, key string) string {
+	return tenantID.String() + "\x00" + strings.TrimSpace(key)
+}
+
+func (s *QualityProfileStore) Create(_ context.Context, tenantID shared.ID, profile qualityprofile.Profile) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := qualityProfileStoreKey(tenantID, profile.Key)
+	if _, found := s.data[key]; found {
+		return shared.ErrConflict
+	}
+	s.data[key] = profile.Clone()
+	return nil
+}
+
+func (s *QualityProfileStore) List(_ context.Context, tenantID shared.ID) ([]qualityprofile.Profile, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]qualityprofile.Profile, 0, len(s.data))
+	prefix := tenantID.String() + "\x00"
+	for key, profile := range s.data {
+		if tenantID.IsZero() || strings.HasPrefix(key, prefix) {
+			out = append(out, profile.Clone())
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out, nil
+}
+
+func (s *QualityProfileStore) Get(_ context.Context, tenantID shared.ID, key string) (qualityprofile.Profile, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	profile, found := s.data[qualityProfileStoreKey(tenantID, key)]
+	if !found {
+		return qualityprofile.Profile{}, shared.ErrNotFound
+	}
+	return profile.Clone(), nil
+}
+
+func (s *QualityProfileStore) Update(_ context.Context, tenantID shared.ID, profile qualityprofile.Profile) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := qualityProfileStoreKey(tenantID, profile.Key)
+	if _, found := s.data[key]; !found {
+		return shared.ErrNotFound
+	}
+	s.data[key] = profile.Clone()
+	return nil
+}
+
+func (s *QualityProfileStore) Delete(_ context.Context, tenantID shared.ID, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	storeKey := qualityProfileStoreKey(tenantID, key)
+	if _, found := s.data[storeKey]; !found {
+		return shared.ErrNotFound
+	}
+	delete(s.data, storeKey)
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/project_repo.go
+++ b/internal/infrastructure/persistence/postgres/project_repo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -118,6 +119,29 @@ func (r *ProjectRepository) UpdateGate(ctx context.Context, tenantID shared.ID, 
 	ct, err := r.pool.Exec(ctx, `UPDATE projects SET gate_id=$3, updated_at=now() WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key, gateID)
 	if err != nil {
 		return fmt.Errorf("update project gate: %w", err)
+	}
+	if ct.RowsAffected() == 0 {
+		return shared.ErrNotFound
+	}
+	return nil
+}
+
+// AssignProfile sets or clears the quality profile for a language in the project's JSONB
+// default_profile_by_lang map, atomically at the column level (no read-modify-write race).
+func (r *ProjectRepository) AssignProfile(ctx context.Context, tenantID shared.ID, projectKey, language, profileKey string) error {
+	var (
+		ct  pgconn.CommandTag
+		err error
+	)
+	if strings.TrimSpace(profileKey) == "" {
+		ct, err = r.pool.Exec(ctx, `UPDATE projects SET default_profile_by_lang = coalesce(default_profile_by_lang, '{}'::jsonb) - $3::text, updated_at=now() WHERE tenant_id=$1 AND key=$2`,
+			tenantID.String(), projectKey, language)
+	} else {
+		ct, err = r.pool.Exec(ctx, `UPDATE projects SET default_profile_by_lang = jsonb_set(coalesce(default_profile_by_lang, '{}'::jsonb), ARRAY[$3::text], to_jsonb($4::text), true), updated_at=now() WHERE tenant_id=$1 AND key=$2`,
+			tenantID.String(), projectKey, language, profileKey)
+	}
+	if err != nil {
+		return fmt.Errorf("assign project profile: %w", err)
 	}
 	if ct.RowsAffected() == 0 {
 		return shared.ErrNotFound

--- a/internal/infrastructure/persistence/postgres/quality_profile_store.go
+++ b/internal/infrastructure/persistence/postgres/quality_profile_store.go
@@ -1,0 +1,113 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualityprofile"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// QualityProfileStore persists tenant-scoped custom quality profiles. Built-in profiles are generated
+// from the rule catalog and never stored here.
+type QualityProfileStore struct{ pool *pgxpool.Pool }
+
+func NewQualityProfileStore(pool *pgxpool.Pool) *QualityProfileStore {
+	return &QualityProfileStore{pool: pool}
+}
+
+var _ ports.QualityProfileStore = (*QualityProfileStore)(nil)
+
+func (s *QualityProfileStore) Create(ctx context.Context, tenantID shared.ID, profile qualityprofile.Profile) error {
+	activated, err := json.Marshal(profile.ActivatedRules)
+	if err != nil {
+		return fmt.Errorf("marshal profile rules: %w", err)
+	}
+	_, err = s.pool.Exec(ctx, `INSERT INTO quality_profiles (tenant_id, key, name, language, parent, activated_rules) VALUES ($1,$2,$3,$4,$5,$6)`,
+		tenantID.String(), profile.Key, profile.Name, profile.Language, profile.Parent, activated)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return shared.ErrConflict
+		}
+		return fmt.Errorf("insert quality profile: %w", err)
+	}
+	return nil
+}
+
+func (s *QualityProfileStore) List(ctx context.Context, tenantID shared.ID) ([]qualityprofile.Profile, error) {
+	rows, err := s.pool.Query(ctx, `SELECT key, name, language, parent, activated_rules FROM quality_profiles WHERE tenant_id=$1 ORDER BY key`, tenantID.String())
+	if err != nil {
+		return nil, fmt.Errorf("list quality profiles: %w", err)
+	}
+	defer rows.Close()
+	out := make([]qualityprofile.Profile, 0)
+	for rows.Next() {
+		profile, err := scanQualityProfile(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, profile)
+	}
+	return out, rows.Err()
+}
+
+func (s *QualityProfileStore) Get(ctx context.Context, tenantID shared.ID, key string) (qualityprofile.Profile, error) {
+	profile, err := scanQualityProfile(s.pool.QueryRow(ctx, `SELECT key, name, language, parent, activated_rules FROM quality_profiles WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return qualityprofile.Profile{}, shared.ErrNotFound
+	}
+	if err != nil {
+		return qualityprofile.Profile{}, fmt.Errorf("select quality profile: %w", err)
+	}
+	return profile, nil
+}
+
+func (s *QualityProfileStore) Update(ctx context.Context, tenantID shared.ID, profile qualityprofile.Profile) error {
+	activated, err := json.Marshal(profile.ActivatedRules)
+	if err != nil {
+		return fmt.Errorf("marshal profile rules: %w", err)
+	}
+	ct, err := s.pool.Exec(ctx, `UPDATE quality_profiles SET name=$3, language=$4, parent=$5, activated_rules=$6, updated_at=now() WHERE tenant_id=$1 AND key=$2`,
+		tenantID.String(), profile.Key, profile.Name, profile.Language, profile.Parent, activated)
+	if err != nil {
+		return fmt.Errorf("update quality profile: %w", err)
+	}
+	if ct.RowsAffected() == 0 {
+		return shared.ErrNotFound
+	}
+	return nil
+}
+
+func (s *QualityProfileStore) Delete(ctx context.Context, tenantID shared.ID, key string) error {
+	ct, err := s.pool.Exec(ctx, `DELETE FROM quality_profiles WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
+	if err != nil {
+		return fmt.Errorf("delete quality profile: %w", err)
+	}
+	if ct.RowsAffected() == 0 {
+		return shared.ErrNotFound
+	}
+	return nil
+}
+
+func scanQualityProfile(row rowScanner) (qualityprofile.Profile, error) {
+	var p qualityprofile.Profile
+	var activated []byte
+	if err := row.Scan(&p.Key, &p.Name, &p.Language, &p.Parent, &activated); err != nil {
+		return qualityprofile.Profile{}, err
+	}
+	p.ActivatedRules = map[string]qualityprofile.RuleActivation{}
+	if len(activated) > 0 {
+		if err := json.Unmarshal(activated, &p.ActivatedRules); err != nil {
+			return qualityprofile.Profile{}, fmt.Errorf("unmarshal profile rules: %w", err)
+		}
+	}
+	return p, nil
+}

--- a/internal/infrastructure/persistence/postgres/quality_profile_store_test.go
+++ b/internal/infrastructure/persistence/postgres/quality_profile_store_test.go
@@ -1,0 +1,78 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualityprofile"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestQualityProfileStoreIntegration(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	tenant := shared.ID("profile-test-tenant")
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$1) ON CONFLICT DO NOTHING`, tenant); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM quality_profiles WHERE tenant_id=$1`, tenant)
+		_, _ = pool.Exec(ctx, `DELETE FROM tenants WHERE id=$1`, tenant)
+	})
+
+	store := NewQualityProfileStore(pool)
+	p := qualityprofile.Profile{
+		Key: "team-go", Name: "Team Go", Language: "Go", Parent: "synapse-way-go",
+		ActivatedRules: map[string]qualityprofile.RuleActivation{
+			"go-a": {Severity: shared.SeverityCritical},
+			"go-b": {},
+		},
+	}
+	if err := store.Create(ctx, tenant, p); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Create(ctx, tenant, p); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate create must conflict, got %v", err)
+	}
+	got, err := store.Get(ctx, tenant, "team-go")
+	if err != nil || got.Language != "Go" || got.Parent != "synapse-way-go" || got.ActivatedRules["go-a"].Severity != shared.SeverityCritical || len(got.ActivatedRules) != 2 {
+		t.Fatalf("get = %+v err=%v", got, err)
+	}
+	// Cross-tenant read is isolated.
+	if _, err := store.Get(ctx, "other-tenant", "team-go"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant get = %v, want not found", err)
+	}
+	// Update: deactivate go-a.
+	delete(got.ActivatedRules, "go-a")
+	if err := store.Update(ctx, tenant, got); err != nil {
+		t.Fatal(err)
+	}
+	reread, _ := store.Get(ctx, tenant, "team-go")
+	if _, ok := reread.ActivatedRules["go-a"]; ok || len(reread.ActivatedRules) != 1 {
+		t.Fatalf("update did not persist: %+v", reread.ActivatedRules)
+	}
+	list, err := store.List(ctx, tenant)
+	if err != nil || len(list) != 1 || list[0].Key != "team-go" {
+		t.Fatalf("list = %+v err=%v", list, err)
+	}
+	if err := store.Delete(ctx, tenant, "team-go"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Get(ctx, tenant, "team-go"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("deleted profile must be gone, got %v", err)
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -22,6 +22,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualityprofile"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -50,6 +51,9 @@ type ProjectRepository interface {
 	UpdateGate(ctx context.Context, tenantID shared.ID, key, gateID string) error
 	CountByGate(ctx context.Context, tenantID shared.ID, gateID string) (int, error)
 	DeleteByKey(ctx context.Context, tenantID shared.ID, key string) error
+	// AssignProfile sets (or clears, with an empty profileKey) the quality profile assigned to a
+	// language for a project (project.DefaultProfileByLang[language]).
+	AssignProfile(ctx context.Context, tenantID shared.ID, projectKey, language, profileKey string) error
 }
 
 // QualityGateStore persists tenant-scoped custom gate definitions.
@@ -60,6 +64,16 @@ type QualityGateStore interface {
 	Update(ctx context.Context, tenantID shared.ID, gate qualitygate.Gate) error
 	Delete(ctx context.Context, tenantID shared.ID, key string) error
 	DeleteIfUnassigned(ctx context.Context, tenantID shared.ID, key string) error
+}
+
+// QualityProfileStore persists tenant-scoped custom quality profiles (named, per-language rule sets).
+// Built-in profiles are generated from the rule catalog and are never stored.
+type QualityProfileStore interface {
+	Create(ctx context.Context, tenantID shared.ID, profile qualityprofile.Profile) error
+	List(ctx context.Context, tenantID shared.ID) ([]qualityprofile.Profile, error)
+	Get(ctx context.Context, tenantID shared.ID, key string) (qualityprofile.Profile, error)
+	Update(ctx context.Context, tenantID shared.ID, profile qualityprofile.Profile) error
+	Delete(ctx context.Context, tenantID shared.ID, key string) error
 }
 
 // QualityGateMutator coordinates managed-gate writes, audit records, and safe custom-gate Project references.

--- a/internal/usecase/projectuc/overview_test.go
+++ b/internal/usecase/projectuc/overview_test.go
@@ -43,6 +43,9 @@ func (r *overviewProjectRepoSpy) GetByID(context.Context, shared.ID, shared.ID) 
 func (r *overviewProjectRepoSpy) UpdateGate(context.Context, shared.ID, string, string) error {
 	panic("unexpected UpdateGate")
 }
+func (r *overviewProjectRepoSpy) AssignProfile(context.Context, shared.ID, string, string, string) error {
+	panic("unexpected AssignProfile")
+}
 func (r *overviewProjectRepoSpy) CountByGate(context.Context, shared.ID, string) (int, error) {
 	panic("unexpected CountByGate")
 }

--- a/internal/usecase/projectuc/service.go
+++ b/internal/usecase/projectuc/service.go
@@ -25,6 +25,7 @@ import (
 	issuesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/issues"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	qualitygatesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/qualitygates"
+	qualityprofilesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/qualityprofiles"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
 )
 
@@ -43,6 +44,7 @@ type Service struct {
 	findings         ports.FindingRepository
 	gates            *qualitygatesuc.Service
 	gateMutator      ports.QualityGateMutator
+	profiles         *qualityprofilesuc.Service
 	allowLocalSource bool
 	cursorSecret     []byte
 }
@@ -57,6 +59,7 @@ func (s *Service) SetAnalysisStore(store ports.ProjectAnalysisStore)      { s.an
 func (s *Service) SetHotspotStore(store ports.ProjectHotspotStore)        { s.hotspots = store }
 func (s *Service) SetIssueStore(store ports.ProjectIssueStore)            { s.issues = store }
 func (s *Service) SetRuleCatalog(catalog ports.RuleCatalog)               { s.ruleCatalog = catalog }
+func (s *Service) SetQualityProfiles(profiles *qualityprofilesuc.Service) { s.profiles = profiles }
 func (s *Service) SetFindingRepository(repo ports.FindingRepository)      { s.findings = repo }
 func (s *Service) SetQualityGates(gates *qualitygatesuc.Service)          { s.gates = gates }
 func (s *Service) SetQualityGateMutator(mutator ports.QualityGateMutator) { s.gateMutator = mutator }
@@ -409,6 +412,16 @@ func (s *Service) RecordProjectAnalysis(ctx context.Context, engagementID shared
 		}
 	}
 	all = finding.Publishable(all)
+	// Honor the project's assigned quality profiles: deactivate rules and apply severity overrides
+	// before classification, so both issues and hotspots reflect the profile (P9, #183). Languages with
+	// no assignment (or assigned to the built-in default) contribute nothing.
+	if s.profiles != nil {
+		overlay, err := s.profiles.OverlayForProject(ctx, p.TenantID, p.DefaultProfileByLang)
+		if err != nil {
+			return fmt.Errorf("resolve project quality profiles: %w", err)
+		}
+		all = overlay.Apply(all)
+	}
 	if s.ruleCatalog == nil {
 		return fmt.Errorf("classify project hotspots: rule catalog is not configured")
 	}

--- a/internal/usecase/qualityprofiles/service.go
+++ b/internal/usecase/qualityprofiles/service.go
@@ -1,0 +1,300 @@
+// Package qualityprofiles manages named, per-language quality profiles: built-in defaults generated
+// from the rule catalog plus tenant-scoped custom copies, and their per-project assignment. It is the
+// application layer over domain/qualityprofile — it never touches HTTP, the DB, or an LLM directly.
+package qualityprofiles
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualityprofile"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Service coordinates quality-profile reads, mutations, and project assignment.
+type Service struct {
+	store    ports.QualityProfileStore
+	catalog  ports.RuleCatalog
+	projects ports.ProjectRepository
+	audit    ports.AuditLogger
+	clock    ports.Clock
+}
+
+// NewService wires the profile service. store persists custom profiles; catalog supplies built-ins and
+// per-language rule sets; projects records the per-language assignment.
+func NewService(store ports.QualityProfileStore, catalog ports.RuleCatalog, projects ports.ProjectRepository, audit ports.AuditLogger, clock ports.Clock) *Service {
+	return &Service{store: store, catalog: catalog, projects: projects, audit: audit, clock: clock}
+}
+
+// catalogByLanguage groups every catalog rule by its language, returning the rules and their sorted
+// rule keys per language.
+func (s *Service) catalogByLanguage(ctx context.Context) (map[string][]rule.Rule, map[string][]rule.Key, error) {
+	rules, err := s.catalog.List(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list rule catalog: %w", err)
+	}
+	byLang := map[string][]rule.Rule{}
+	for _, r := range rules {
+		byLang[r.Language] = append(byLang[r.Language], r)
+	}
+	keys := map[string][]rule.Key{}
+	for lang, rs := range byLang {
+		ks := make([]rule.Key, 0, len(rs))
+		for _, r := range rs {
+			ks = append(ks, r.Key)
+		}
+		sort.Slice(ks, func(i, j int) bool { return ks[i] < ks[j] })
+		keys[lang] = ks
+	}
+	return byLang, keys, nil
+}
+
+// builtIns returns the built-in default profile for every language in the catalog, plus a lookup by key.
+func (s *Service) builtIns(ctx context.Context) ([]qualityprofile.Profile, map[string]qualityprofile.Profile, error) {
+	byLang, _, err := s.catalogByLanguage(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	out := make([]qualityprofile.Profile, 0, len(byLang))
+	byKey := map[string]qualityprofile.Profile{}
+	for lang, rs := range byLang {
+		p, ok := qualityprofile.BuiltIn(lang, rs)
+		if !ok {
+			continue
+		}
+		out = append(out, p)
+		byKey[p.Key] = p
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out, byKey, nil
+}
+
+// List returns the built-in and custom profiles, optionally filtered to a single language.
+func (s *Service) List(ctx context.Context, tenantID shared.ID, language string) ([]qualityprofile.Profile, error) {
+	builtIns, _, err := s.builtIns(ctx)
+	if err != nil {
+		return nil, err
+	}
+	custom, err := s.store.List(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list custom profiles: %w", err)
+	}
+	all := append(builtIns, custom...)
+	language = strings.TrimSpace(language)
+	if language == "" {
+		return all, nil
+	}
+	out := make([]qualityprofile.Profile, 0, len(all))
+	for _, p := range all {
+		if p.Language == language {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// Get resolves a profile by key: a built-in (from the catalog) or a tenant custom profile.
+func (s *Service) Get(ctx context.Context, tenantID shared.ID, key string) (qualityprofile.Profile, error) {
+	key = strings.TrimSpace(key)
+	_, byKey, err := s.builtIns(ctx)
+	if err != nil {
+		return qualityprofile.Profile{}, err
+	}
+	if p, ok := byKey[key]; ok {
+		return p, nil
+	}
+	p, err := s.store.Get(ctx, tenantID, key)
+	if err != nil {
+		return qualityprofile.Profile{}, fmt.Errorf("get profile: %w", err)
+	}
+	return p, nil
+}
+
+func (s *Service) requireActor(actor string) error {
+	if strings.TrimSpace(actor) == "" {
+		return fmt.Errorf("%w: actor is required", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (s *Service) record(ctx context.Context, actor, action, target string, meta map[string]string) error {
+	if s.audit == nil {
+		return nil
+	}
+	return s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target, Metadata: meta, At: s.clock.Now()})
+}
+
+// Copy creates a custom profile from a built-in or another custom profile.
+func (s *Service) Copy(ctx context.Context, actor string, tenantID shared.ID, sourceKey, newKey, newName string) (qualityprofile.Profile, error) {
+	if err := s.requireActor(actor); err != nil {
+		return qualityprofile.Profile{}, err
+	}
+	source, err := s.Get(ctx, tenantID, sourceKey)
+	if err != nil {
+		return qualityprofile.Profile{}, err
+	}
+	copied, err := source.Copy(newKey, newName)
+	if err != nil {
+		return qualityprofile.Profile{}, err
+	}
+	if err := s.builtInConflict(ctx, copied.Key); err != nil {
+		return qualityprofile.Profile{}, err
+	}
+	if err := s.store.Create(ctx, tenantID, copied); err != nil {
+		return qualityprofile.Profile{}, fmt.Errorf("create profile: %w", err)
+	}
+	if err := s.record(ctx, actor, "quality_profile.copy", copied.Key, map[string]string{"profile": copied.Key, "parent": copied.Parent, "language": copied.Language}); err != nil {
+		return qualityprofile.Profile{}, fmt.Errorf("audit quality_profile.copy: %w", err)
+	}
+	return copied, nil
+}
+
+// builtInConflict rejects a custom key that collides with a built-in profile key.
+func (s *Service) builtInConflict(ctx context.Context, key string) error {
+	_, byKey, err := s.builtIns(ctx)
+	if err != nil {
+		return err
+	}
+	if _, ok := byKey[key]; ok {
+		return fmt.Errorf("%w: profile key %q is reserved by a built-in", shared.ErrValidation, key)
+	}
+	return nil
+}
+
+// mutateCustom loads a custom profile, applies fn, persists the result, and audits.
+func (s *Service) mutateCustom(ctx context.Context, actor string, tenantID shared.ID, key, action string, meta map[string]string, fn func(qualityprofile.Profile) (qualityprofile.Profile, error)) (qualityprofile.Profile, error) {
+	if err := s.requireActor(actor); err != nil {
+		return qualityprofile.Profile{}, err
+	}
+	if _, byKey, err := s.builtIns(ctx); err != nil {
+		return qualityprofile.Profile{}, err
+	} else if _, ok := byKey[strings.TrimSpace(key)]; ok {
+		return qualityprofile.Profile{}, fmt.Errorf("%w: built-in profiles cannot be modified", shared.ErrValidation)
+	}
+	current, err := s.store.Get(ctx, tenantID, strings.TrimSpace(key))
+	if err != nil {
+		return qualityprofile.Profile{}, fmt.Errorf("get profile: %w", err)
+	}
+	updated, err := fn(current)
+	if err != nil {
+		return qualityprofile.Profile{}, err
+	}
+	if err := s.store.Update(ctx, tenantID, updated); err != nil {
+		return qualityprofile.Profile{}, fmt.Errorf("update profile: %w", err)
+	}
+	if err := s.record(ctx, actor, action, updated.Key, meta); err != nil {
+		return qualityprofile.Profile{}, fmt.Errorf("audit %s: %w", action, err)
+	}
+	return updated, nil
+}
+
+// ActivateRule enables a rule in a custom profile (with an optional severity override).
+func (s *Service) ActivateRule(ctx context.Context, actor string, tenantID shared.ID, key, ruleKey string, severity shared.Severity) (qualityprofile.Profile, error) {
+	return s.mutateCustom(ctx, actor, tenantID, key, "quality_profile.activate_rule", map[string]string{"profile": key, "rule": ruleKey},
+		func(p qualityprofile.Profile) (qualityprofile.Profile, error) { return p.Activate(ruleKey, severity) })
+}
+
+// DeactivateRule disables a rule in a custom profile.
+func (s *Service) DeactivateRule(ctx context.Context, actor string, tenantID shared.ID, key, ruleKey string) (qualityprofile.Profile, error) {
+	return s.mutateCustom(ctx, actor, tenantID, key, "quality_profile.deactivate_rule", map[string]string{"profile": key, "rule": ruleKey},
+		func(p qualityprofile.Profile) (qualityprofile.Profile, error) { return p.Deactivate(ruleKey) })
+}
+
+// SetSeverity overrides the severity of an active rule in a custom profile.
+func (s *Service) SetSeverity(ctx context.Context, actor string, tenantID shared.ID, key, ruleKey string, severity shared.Severity) (qualityprofile.Profile, error) {
+	return s.mutateCustom(ctx, actor, tenantID, key, "quality_profile.set_severity", map[string]string{"profile": key, "rule": ruleKey, "severity": string(severity)},
+		func(p qualityprofile.Profile) (qualityprofile.Profile, error) {
+			return p.SetSeverity(ruleKey, severity)
+		})
+}
+
+// Delete removes a custom profile. Built-in profiles cannot be deleted.
+func (s *Service) Delete(ctx context.Context, actor string, tenantID shared.ID, key string) error {
+	if err := s.requireActor(actor); err != nil {
+		return err
+	}
+	key = strings.TrimSpace(key)
+	if _, byKey, err := s.builtIns(ctx); err != nil {
+		return err
+	} else if _, ok := byKey[key]; ok {
+		return fmt.Errorf("%w: built-in profiles cannot be deleted", shared.ErrValidation)
+	}
+	if err := s.store.Delete(ctx, tenantID, key); err != nil {
+		return fmt.Errorf("delete profile: %w", err)
+	}
+	return s.record(ctx, actor, "quality_profile.delete", key, map[string]string{"profile": key})
+}
+
+// Assign sets (or clears, with an empty profileKey) the profile assigned to a language for a project.
+// The profile must exist and match the language.
+func (s *Service) Assign(ctx context.Context, actor string, tenantID shared.ID, projectKey, language, profileKey string) error {
+	if err := s.requireActor(actor); err != nil {
+		return err
+	}
+	language = strings.TrimSpace(language)
+	if language == "" {
+		return fmt.Errorf("%w: language is required", shared.ErrValidation)
+	}
+	profileKey = strings.TrimSpace(profileKey)
+	if profileKey != "" {
+		p, err := s.Get(ctx, tenantID, profileKey)
+		if err != nil {
+			return err
+		}
+		if p.Language != language {
+			return fmt.Errorf("%w: profile %q is for language %q, not %q", shared.ErrValidation, profileKey, p.Language, language)
+		}
+	}
+	if err := s.projects.AssignProfile(ctx, tenantID, strings.TrimSpace(projectKey), language, profileKey); err != nil {
+		return fmt.Errorf("assign profile: %w", err)
+	}
+	return s.record(ctx, actor, "quality_profile.assign", projectKey, map[string]string{"project": projectKey, "language": language, "profile": profileKey})
+}
+
+// OverlayForProject builds the combined .synapse-rules.yaml-equivalent overlay a project's assigned
+// profiles impose on findings: each assigned language profile deactivates its non-active rules and
+// applies severity overrides. Languages with no assignment (or an assignment to their built-in default)
+// contribute nothing, so findings pass through unchanged. Rule keys are language-disjoint, so the
+// per-language overlays union cleanly. A missing/mismatched assignment is skipped (best-effort:
+// analysis is never failed by a stale assignment).
+func (s *Service) OverlayForProject(ctx context.Context, tenantID shared.ID, assigned map[string]string) (qualitygate.Profile, error) {
+	overlay := qualitygate.Profile{Rules: map[string]qualitygate.RuleConfig{}}
+	if len(assigned) == 0 {
+		return overlay, nil
+	}
+	_, keysByLang, err := s.catalogByLanguage(ctx)
+	if err != nil {
+		return qualitygate.Profile{}, err
+	}
+	langs := make([]string, 0, len(assigned))
+	for lang := range assigned {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs) // deterministic overlay assembly
+	for _, lang := range langs {
+		profileKey := strings.TrimSpace(assigned[lang])
+		if profileKey == "" || profileKey == qualityprofile.BuiltInKey(lang) {
+			continue // no assignment, or the built-in default (activates everything) → no overlay
+		}
+		p, err := s.Get(ctx, tenantID, profileKey)
+		if err != nil {
+			if errors.Is(err, shared.ErrNotFound) {
+				continue // stale assignment: skip rather than fail the analysis
+			}
+			return qualitygate.Profile{}, err
+		}
+		if p.Language != lang {
+			continue
+		}
+		for k, cfg := range p.ToOverlay(keysByLang[lang]).Rules {
+			overlay.Rules[k] = cfg
+		}
+	}
+	return overlay, nil
+}

--- a/internal/usecase/qualityprofiles/service_test.go
+++ b/internal/usecase/qualityprofiles/service_test.go
@@ -1,0 +1,159 @@
+package qualityprofiles
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeCatalog struct{ rules []rule.Rule }
+
+func (c fakeCatalog) List(context.Context) ([]rule.Rule, error) { return c.rules, nil }
+func (c fakeCatalog) Get(_ context.Context, key rule.Key) (rule.Rule, error) {
+	for _, r := range c.rules {
+		if r.Key == key {
+			return r, nil
+		}
+	}
+	return rule.Rule{}, shared.ErrNotFound
+}
+
+type nopClock struct{}
+
+func (nopClock) Now() time.Time { return time.Unix(0, 0).UTC() }
+
+type nopAudit struct{}
+
+func (nopAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+func newTestService(t *testing.T) (*Service, *memory.ProjectRepository, shared.ID) {
+	t.Helper()
+	cat := fakeCatalog{rules: []rule.Rule{
+		{Key: "go-a", Language: "Go", DefaultSeverity: shared.SeverityHigh},
+		{Key: "go-b", Language: "Go", DefaultSeverity: shared.SeverityMedium},
+		{Key: "py-a", Language: "Python", DefaultSeverity: shared.SeverityLow},
+	}}
+	projects := memory.NewProjectRepository()
+	svc := NewService(memory.NewQualityProfileStore(), cat, projects, nopAudit{}, nopClock{})
+	return svc, projects, shared.ID("tenant")
+}
+
+func TestServiceListBuiltInsPerLanguage(t *testing.T) {
+	svc, _, tenant := newTestService(t)
+	ctx := context.Background()
+
+	all, err := svc.List(ctx, tenant, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 2 { // one built-in per language (Go, Python)
+		t.Fatalf("want 2 built-ins, got %d: %+v", len(all), all)
+	}
+	goOnly, err := svc.List(ctx, tenant, "Go")
+	if err != nil || len(goOnly) != 1 || goOnly[0].Key != "synapse-way-go" || !goOnly[0].BuiltIn {
+		t.Fatalf("Go filter = %+v err=%v", goOnly, err)
+	}
+}
+
+func TestServiceCopyToggleAndBuiltInImmutability(t *testing.T) {
+	svc, _, tenant := newTestService(t)
+	ctx := context.Background()
+
+	// A built-in cannot be mutated or deleted.
+	if _, err := svc.DeactivateRule(ctx, "alice", tenant, "synapse-way-go", "go-a"); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("mutating a built-in must be rejected, got %v", err)
+	}
+	if err := svc.Delete(ctx, "alice", tenant, "synapse-way-go"); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("deleting a built-in must be rejected, got %v", err)
+	}
+	// A custom key colliding with a built-in is rejected.
+	if _, err := svc.Copy(ctx, "alice", tenant, "synapse-way-go", "synapse-way-go", "x"); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("reserved key must be rejected, got %v", err)
+	}
+
+	custom, err := svc.Copy(ctx, "alice", tenant, "synapse-way-go", "team-go", "Team Go")
+	if err != nil || custom.BuiltIn || custom.Parent != "synapse-way-go" || len(custom.ActivatedRules) != 2 {
+		t.Fatalf("copy = %+v err=%v", custom, err)
+	}
+	if _, err := svc.DeactivateRule(ctx, "alice", tenant, "team-go", "go-b"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.SetSeverity(ctx, "alice", tenant, "team-go", "go-a", shared.SeverityCritical); err != nil {
+		t.Fatal(err)
+	}
+	got, err := svc.Get(ctx, tenant, "team-go")
+	if err != nil || got.Active("go-b") || got.ActivatedRules["go-a"].Severity != shared.SeverityCritical {
+		t.Fatalf("persisted custom = %+v err=%v", got, err)
+	}
+	if err := svc.Delete(ctx, "alice", tenant, "team-go"); err != nil {
+		t.Fatalf("delete custom: %v", err)
+	}
+	if _, err := svc.Get(ctx, tenant, "team-go"); !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("deleted profile must be gone, got %v", err)
+	}
+}
+
+func TestServiceAssignAndOverlay(t *testing.T) {
+	svc, projects, tenant := newTestService(t)
+	ctx := context.Background()
+	p, err := project.New("p1", tenant, "Proj", "proj", project.SourceBinding{Kind: project.SourceGit, Value: "https://example.com/r.git"}, nil, "", time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := projects.Create(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+
+	custom, _ := svc.Copy(ctx, "alice", tenant, "synapse-way-go", "team-go", "Team Go")
+	custom, _ = svc.DeactivateRule(ctx, "alice", tenant, custom.Key, "go-b")
+	custom, _ = svc.SetSeverity(ctx, "alice", tenant, custom.Key, "go-a", shared.SeverityLow)
+
+	// Assigning a Python profile to the "Go" language is rejected (language mismatch).
+	if err := svc.Assign(ctx, "alice", tenant, "proj", "Go", "synapse-way-python"); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("language mismatch must be rejected, got %v", err)
+	}
+	if err := svc.Assign(ctx, "alice", tenant, "proj", "Go", "team-go"); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+	saved, _ := projects.GetByKey(ctx, tenant, "proj")
+	if saved.DefaultProfileByLang["Go"] != "team-go" {
+		t.Fatalf("assignment not persisted: %+v", saved.DefaultProfileByLang)
+	}
+
+	overlay, err := svc.OverlayForProject(ctx, tenant, saved.DefaultProfileByLang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg := overlay.Rules["go-b"]; cfg.Enabled == nil || *cfg.Enabled {
+		t.Errorf("go-b must be disabled by the assigned profile: %+v", cfg)
+	}
+	if overlay.Rules["go-a"].Severity != string(shared.SeverityLow) {
+		t.Errorf("go-a must carry the severity override: %+v", overlay.Rules["go-a"])
+	}
+
+	// Assigning the built-in default contributes no overlay (everything active, no overrides).
+	if err := svc.Assign(ctx, "alice", tenant, "proj", "Go", "synapse-way-go"); err != nil {
+		t.Fatal(err)
+	}
+	saved, _ = projects.GetByKey(ctx, tenant, "proj")
+	overlay, _ = svc.OverlayForProject(ctx, tenant, saved.DefaultProfileByLang)
+	if len(overlay.Rules) != 0 {
+		t.Errorf("built-in assignment must yield an empty overlay, got %+v", overlay.Rules)
+	}
+
+	// Clearing the assignment removes it.
+	if err := svc.Assign(ctx, "alice", tenant, "proj", "Go", ""); err != nil {
+		t.Fatal(err)
+	}
+	saved, _ = projects.GetByKey(ctx, tenant, "proj")
+	if _, ok := saved.DefaultProfileByLang["Go"]; ok {
+		t.Errorf("cleared assignment must be gone: %+v", saved.DefaultProfileByLang)
+	}
+}

--- a/migrations/0055_quality_profiles.sql
+++ b/migrations/0055_quality_profiles.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+CREATE TABLE quality_profiles (
+    tenant_id       TEXT NOT NULL REFERENCES tenants(id),
+    key             TEXT NOT NULL,
+    name            TEXT NOT NULL,
+    language        TEXT NOT NULL,
+    parent          TEXT NOT NULL DEFAULT '',
+    activated_rules JSONB NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, key)
+);
+
+CREATE INDEX idx_quality_profiles_tenant_language ON quality_profiles (tenant_id, language);
+
+-- +goose Down
+DROP TABLE quality_profiles;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import { SecurityHotspotsPage } from './pages/SecurityHotspots'
 import { ProjectIssuesPage } from './pages/ProjectIssues'
 import { ProjectMeasuresPage } from './pages/ProjectMeasuresPage'
 import { QualityGates } from './pages/QualityGates'
+import { QualityProfiles } from './pages/QualityProfiles'
 
 export default function App() {
   return (
@@ -39,6 +40,7 @@ function Gate() {
         <Route path="engagements/:id" element={<EngagementDetail />} />
         <Route path="code-quality" element={<CodeQualityProjects />} />
         <Route path="code-quality/gates" element={<QualityGates />} />
+        <Route path="code-quality/profiles" element={<QualityProfiles />} />
         <Route path="code-quality/projects/:key" element={<CodeQualityProject />}>
           <Route index element={<ProjectOverviewPage />} />
           <Route path="hotspots" element={<SecurityHotspotsPage />} />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -48,6 +48,7 @@ import type {
   RuleSeverity,
   RuleDetection,
   QualityGate,
+  QualityProfile,
   Grade,
   Hotspot,
   HotspotStatus,
@@ -132,6 +133,21 @@ export async function projectMeasures(projectKey: string, query: MeasuresQuery, 
 
 
 // ---- mappers: raw API JSON (mixed casing) → clean types ----
+
+function mapQualityProfile(r: any): QualityProfile {
+  const activatedRules: Record<string, { severity: string }> = {}
+  for (const [k, v] of Object.entries(r?.activated_rules ?? {})) {
+    activatedRules[k] = { severity: (v as any)?.severity ?? '' }
+  }
+  return {
+    key: r?.key ?? '',
+    name: r?.name ?? '',
+    language: r?.language ?? '',
+    parent: r?.parent ?? '',
+    activatedRules,
+    builtIn: r?.built_in ?? false,
+  }
+}
 
 function mapQualityGate(r: any): QualityGate {
   return {
@@ -874,6 +890,30 @@ export const api = {
 
   deleteQualityGate: async (key: string): Promise<void> => {
     await req(`/quality-gates/${encodeURIComponent(key)}`, { method: 'DELETE' })
+  },
+
+  // --- Quality profiles ---
+  listQualityProfiles: async (language?: string): Promise<QualityProfile[]> =>
+    ((await req(`/quality-profiles${language ? `?language=${encodeURIComponent(language)}` : ''}`)) ?? []).map(mapQualityProfile),
+
+  copyQualityProfile: async (sourceKey: string, key: string, name: string): Promise<QualityProfile> =>
+    mapQualityProfile(await req(`/quality-profiles/${encodeURIComponent(sourceKey)}/copy`, { method: 'POST', body: JSON.stringify({ key, name }) })),
+
+  activateProfileRule: async (key: string, rule: string, severity = ''): Promise<QualityProfile> =>
+    mapQualityProfile(await req(`/quality-profiles/${encodeURIComponent(key)}/activate`, { method: 'POST', body: JSON.stringify({ rule, severity }) })),
+
+  deactivateProfileRule: async (key: string, rule: string): Promise<QualityProfile> =>
+    mapQualityProfile(await req(`/quality-profiles/${encodeURIComponent(key)}/deactivate`, { method: 'POST', body: JSON.stringify({ rule }) })),
+
+  setProfileRuleSeverity: async (key: string, rule: string, severity: string): Promise<QualityProfile> =>
+    mapQualityProfile(await req(`/quality-profiles/${encodeURIComponent(key)}/severity`, { method: 'POST', body: JSON.stringify({ rule, severity }) })),
+
+  deleteQualityProfile: async (key: string): Promise<void> => {
+    await req(`/quality-profiles/${encodeURIComponent(key)}`, { method: 'DELETE' })
+  },
+
+  assignProjectProfile: async (projectKey: string, language: string, profile: string): Promise<void> => {
+    await req(`/projects/${encodeURIComponent(projectKey)}/profiles/${encodeURIComponent(language)}`, { method: 'PUT', body: JSON.stringify({ profile }) })
   },
 
   // --- Rules ---

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -625,6 +625,15 @@ export interface QualityGate {
   builtIn: boolean
 }
 
+export interface QualityProfile {
+  key: string
+  name: string
+  language: string
+  parent: string
+  activatedRules: Record<string, { severity: string }>
+  builtIn: boolean
+}
+
 export interface LanguageInventory {
   language: string
   files: number

--- a/web/src/pages/CodeQualityProjects.tsx
+++ b/web/src/pages/CodeQualityProjects.tsx
@@ -43,7 +43,7 @@ export function CodeQualityProjects() {
           <h1 className="text-3xl font-bold tracking-tight">Code Quality</h1>
           <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-mutedfg">See what needs attention, enforce quality policy, and track every successful analysis against its previous baseline.</p>
         </div>
-        <div className="flex gap-2"><Link to="/code-quality/gates"><Button variant="secondary">Quality gates</Button></Link><Button variant="brand" onClick={() => setCreating((value) => !value)}>{creating ? <><X className="size-4" aria-hidden="true" /> Cancel</> : <><Plus className="size-4" aria-hidden="true" /> New project</>}</Button></div>
+        <div className="flex gap-2"><Link to="/code-quality/profiles"><Button variant="secondary">Quality profiles</Button></Link><Link to="/code-quality/gates"><Button variant="secondary">Quality gates</Button></Link><Button variant="brand" onClick={() => setCreating((value) => !value)}>{creating ? <><X className="size-4" aria-hidden="true" /> Cancel</> : <><Plus className="size-4" aria-hidden="true" /> New project</>}</Button></div>
       </header>
 
       {creating && <div className="mb-6"><CreateProjectForm /></div>}

--- a/web/src/pages/QualityProfiles.tsx
+++ b/web/src/pages/QualityProfiles.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Copy, Plus, ShieldCheck, Trash2 } from 'lucide-react'
+import { api, ApiError } from '../lib/api'
+import type { QualityProfile, RuleSummary } from '../lib/types'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Select, Spinner } from '../components/ui'
+
+const SEVERITIES = ['critical', 'high', 'medium', 'low'] // matches RuleSeverity
+const RULE_RENDER_CAP = 100
+
+// QualityProfiles is the management page for named, per-language rule sets: browse the built-in default
+// per language, copy it into a custom profile, toggle rules + severities, assign it to a project.
+export function QualityProfiles() {
+  const [profiles, setProfiles] = useState<QualityProfile[] | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [refresh, setRefresh] = useState(0)
+
+  useEffect(() => {
+    let live = true
+    setErr(null)
+    api.listQualityProfiles()
+      .then((list) => { if (live) setProfiles(list) })
+      .catch((e) => { if (live) setErr(e instanceof ApiError ? e.message : 'Failed to load profiles') })
+    return () => { live = false }
+  }, [refresh])
+
+  const byLanguage = useMemo(() => {
+    const map = new Map<string, QualityProfile[]>()
+    for (const p of profiles ?? []) {
+      const list = map.get(p.language) ?? []
+      list.push(p)
+      map.set(p.language, list)
+    }
+    return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  }, [profiles])
+
+  const selected = profiles?.find((p) => p.key === selectedKey) ?? null
+
+  if (err) return <div className="space-y-3"><ErrorState message={err} /><Button variant="secondary" onClick={() => setRefresh((c) => c + 1)}>Retry</Button></div>
+  if (!profiles) return <div className="flex h-40 items-center justify-center"><Spinner label="Loading quality profiles…" /></div>
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Quality Profiles</h1>
+        <p className="mt-1 max-w-2xl text-sm text-mutedfg">Each language has a built-in “Synapse way” profile that activates every catalog rule. Copy it to a custom profile to activate or deactivate rules and override severities, then assign it to a project.</p>
+      </div>
+      <div className="flex flex-col gap-4 lg:flex-row">
+        <nav className="w-full shrink-0 space-y-4 lg:w-72" aria-label="Quality profiles">
+          {byLanguage.length === 0 && <EmptyState icon={ShieldCheck} title="No profiles" hint="No languages are present in the rule catalog." />}
+          {byLanguage.map(([language, list]) => (
+            <div key={language}>
+              <div className="mb-1 text-xs font-semibold uppercase tracking-[0.14em] text-subtlefg">{language}</div>
+              <ul className="space-y-1">
+                {list.map((p) => (
+                  <li key={p.key}>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedKey(p.key)}
+                      aria-pressed={p.key === selectedKey}
+                      className="flex w-full items-center justify-between gap-2 rounded-lg border border-border px-3 py-2 text-left text-sm transition-colors hover:bg-elevated/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 aria-pressed:border-brand/40 aria-pressed:bg-brand/5"
+                    >
+                      <span className="truncate">{p.name}</span>
+                      <Pill className="tabular-nums">{p.builtIn ? 'Built-in' : 'Custom'}</Pill>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </nav>
+        <div className="min-w-0 flex-1">
+          {selected
+            ? <ProfileDetail key={selected.key} profile={selected} onChanged={() => setRefresh((c) => c + 1)} />
+            : <Card title="Select a profile"><EmptyState icon={ShieldCheck} title="No profile selected" hint="Choose a profile on the left to view and edit its rules." /></Card>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ProfileDetail({ profile, onChanged }: { profile: QualityProfile; onChanged: () => void }) {
+  const [rules, setRules] = useState<RuleSummary[] | null>(null)
+  const [rulesErr, setRulesErr] = useState<string | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [copyOpen, setCopyOpen] = useState(false)
+  const [ruleQuery, setRuleQuery] = useState('')
+
+  useEffect(() => {
+    let live = true
+    setRules(null)
+    setRulesErr(null)
+    api.listRules({ languages: [profile.language] })
+      .then((list) => { if (live) setRules(list) })
+      .catch((e) => { if (live) setRulesErr(e instanceof ApiError ? e.message : 'Failed to load rules') })
+    return () => { live = false }
+  }, [profile.language])
+
+  const filtered = useMemo(() => {
+    const q = ruleQuery.trim().toLowerCase()
+    const all = rules ?? []
+    if (!q) return all
+    return all.filter((r) => r.key.toLowerCase().includes(q) || r.name.toLowerCase().includes(q))
+  }, [rules, ruleQuery])
+  const shown = filtered.slice(0, RULE_RENDER_CAP)
+
+  async function run(action: () => Promise<unknown>) {
+    setBusy(true)
+    setErr(null)
+    try { await action(); onChanged() } catch (e) { setErr(e instanceof ApiError ? e.message : 'Action failed') } finally { setBusy(false) }
+  }
+
+  return (
+    <Card
+      title={profile.name}
+      actions={<div className="flex items-center gap-2">
+        <Pill>{profile.builtIn ? 'Built-in' : 'Custom'}</Pill>
+        <Button variant="secondary" disabled={busy} onClick={() => setCopyOpen((v) => !v)}><Copy className="size-4" aria-hidden="true" /> Copy</Button>
+        {!profile.builtIn && <Button variant="secondary" disabled={busy} onClick={() => run(() => api.deleteQualityProfile(profile.key))}><Trash2 className="size-4" aria-hidden="true" /> Delete</Button>}
+      </div>}
+    >
+      <p className="font-mono text-xs text-mutedfg">{profile.key} · {profile.language}{profile.parent ? ` · from ${profile.parent}` : ''}</p>
+      {profile.builtIn && <p className="mt-3 text-xs text-mutedfg">Built-in profiles are immutable. Copy this profile to customize its rules, then assign the copy to a project.</p>}
+      {copyOpen && <CopyForm profile={profile} onDone={() => { setCopyOpen(false); onChanged() }} onError={setErr} />}
+      {err && <div className="mt-3"><ErrorState message={err} /></div>}
+
+      <AssignForm profile={profile} onError={setErr} onDone={onChanged} />
+
+      <div className="mt-5">
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+          <div className="text-sm font-medium">Rules <span className="font-mono tabular-nums text-mutedfg">({Object.keys(profile.activatedRules).length} active)</span></div>
+          <label className="w-full sm:w-64">
+            <span className="sr-only">Filter rules</span>
+            <Input value={ruleQuery} onChange={(e) => setRuleQuery(e.target.value)} placeholder="Filter rules by name or key…" />
+          </label>
+        </div>
+        {rulesErr ? <div className="space-y-3"><ErrorState message={rulesErr} /></div>
+          : !rules ? <div className="flex h-24 items-center justify-center"><Spinner /></div>
+          : rules.length === 0 ? <EmptyState icon={ShieldCheck} title="No rules" hint="The catalog has no rules for this language." />
+          : filtered.length === 0 ? <EmptyState icon={ShieldCheck} title="No matching rules" hint="No rules match the filter." />
+          : (
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="min-w-full text-left text-sm">
+                <thead className="bg-elevated/95 text-[11px] uppercase tracking-[0.14em] text-foreground">
+                  <tr>
+                    <th scope="col" className="px-3 py-2 font-semibold">Active</th>
+                    <th scope="col" className="px-3 py-2 font-semibold">Rule</th>
+                    <th scope="col" className="px-3 py-2 font-semibold">Severity</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/60">
+                  {shown.map((r) => {
+                    const active = profile.activatedRules[r.key] !== undefined
+                    const override = profile.activatedRules[r.key]?.severity ?? ''
+                    return (
+                      <tr key={r.key} className="hover:bg-elevated/30">
+                        <td className="px-3 py-2">
+                          <input
+                            type="checkbox"
+                            checked={active}
+                            disabled={profile.builtIn || busy}
+                            aria-label={`Activate ${r.name}`}
+                            className="size-4 accent-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+                            onChange={(e) => run(() => e.target.checked ? api.activateProfileRule(profile.key, r.key) : api.deactivateProfileRule(profile.key, r.key))}
+                          />
+                        </td>
+                        <td className="px-3 py-2"><div className="font-medium">{r.name}</div><div className="font-mono text-xs text-mutedfg">{r.key}</div></td>
+                        <td className="px-3 py-2">
+                          <Select
+                            value={override || r.defaultSeverity}
+                            ariaLabel={`Severity for ${r.name}`}
+                            disabled={profile.builtIn || !active || busy}
+                            onValueChange={(v) => run(() => api.setProfileRuleSeverity(profile.key, r.key, v === r.defaultSeverity ? '' : v))}
+                            options={SEVERITIES.map((s) => ({ value: s, label: s }))}
+                          />
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        {rules && filtered.length > shown.length && (
+          <p className="mt-2 text-xs text-mutedfg">Showing {shown.length} of <span className="font-mono tabular-nums">{filtered.length}</span> rules. Refine the filter to narrow the list.</p>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+function CopyForm({ profile, onDone, onError }: { profile: QualityProfile; onDone: () => void; onError: (m: string) => void }) {
+  const [key, setKey] = useState('')
+  const [name, setName] = useState('')
+  const [saving, setSaving] = useState(false)
+  return (
+    <form
+      className="mt-4 grid gap-3 rounded-lg border border-border bg-bg p-3 sm:grid-cols-[1fr_1fr_auto] sm:items-end"
+      onSubmit={async (e) => {
+        e.preventDefault()
+        setSaving(true)
+        try { await api.copyQualityProfile(profile.key, key.trim(), name.trim()); onDone() }
+        catch (err) { onError(err instanceof ApiError ? err.message : 'Copy failed') }
+        finally { setSaving(false) }
+      }}
+    >
+      <Field label="New key" hint="lowercase-hyphenated" htmlFor="copy-key"><Input id="copy-key" value={key} onChange={(e) => setKey(e.target.value)} placeholder="team-go" /></Field>
+      <Field label="Name" htmlFor="copy-name"><Input id="copy-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Team Go" /></Field>
+      <Button variant="brand" type="submit" loading={saving}><Plus className="size-4" aria-hidden="true" /> Create copy</Button>
+    </form>
+  )
+}
+
+function AssignForm({ profile, onError, onDone }: { profile: QualityProfile; onError: (m: string) => void; onDone: () => void }) {
+  const [projectKey, setProjectKey] = useState('')
+  const [saving, setSaving] = useState(false)
+  return (
+    <form
+      className="mt-4 grid gap-3 rounded-lg border border-dashed border-border bg-bg p-3 sm:grid-cols-[1fr_auto] sm:items-end"
+      onSubmit={async (e) => {
+        e.preventDefault()
+        if (!projectKey.trim()) return
+        setSaving(true)
+        try { await api.assignProjectProfile(projectKey.trim(), profile.language, profile.key); setProjectKey(''); onDone() }
+        catch (err) { onError(err instanceof ApiError ? err.message : 'Assign failed') }
+        finally { setSaving(false) }
+      }}
+    >
+      <Field label={`Assign to a project (${profile.language})`} htmlFor="assign-project"><Input id="assign-project" value={projectKey} onChange={(e) => setProjectKey(e.target.value)} placeholder="project-key" /></Field>
+      <Button variant="secondary" type="submit" loading={saving}>Assign</Button>
+    </form>
+  )
+}


### PR DESCRIPTION
Closes #183.

Implements **P9 Quality Profiles**: named, per-language rule sets with a built-in default per language, custom copies, per-project assignment, and analyses that honor the assigned profile.

## What changed (vertical slice)
- **domain/qualityprofile** — `Profile{Key,Name,Language,Parent,ActivatedRules,BuiltIn}`. `BuiltIn(language, catalogRules)` generates the immutable **"Synapse way (<lang>)"** default (every catalog rule for the language at its default severity). `Copy`/`Activate`/`Deactivate`/`SetSeverity` are pure receiver-copy mutators; built-ins are immutable. `ToOverlay()` bridges a managed profile to the existing deterministic `qualitygate.Profile` overlay — the single point that makes a profile equivalent to the serverless `.synapse-rules.yaml`.
- **usecase/qualityprofiles** — built-ins from the rule catalog + tenant-scoped custom profiles; List/Get/Copy/ActivateRule/DeactivateRule/SetSeverity/Delete, per-project `Assign` (validates language match, audited), and `OverlayForProject` which resolves a project's per-language assignments into one combined overlay.
- **ports** — `QualityProfileStore`; `ProjectRepository.AssignProfile` (per-language).
- **persistence** — memory + postgres stores; `migrations/0055_quality_profiles.sql` (verified on real PG16). `AssignProfile` mutates the projects JSONB column atomically.
- **projectuc** — `RecordProjectAnalysis` applies the assigned profiles' overlay to findings before hotspot/issue classification, so both honor the profile.
- **HTTP** — `/quality-profiles` list/get/copy/activate/deactivate/severity/delete (PermView read, PermOperate mutate) + `PUT /projects/{key}/profiles/{language}`.
- **web** — Quality Profiles page (per-language list, copy a built-in, rule activation table with severity override + filter/cap, assign to a project) + route + nav.

## Safety
SCA advisory findings are **never** affected — the overlay only keys first-party catalog rules, so a profile can't suppress a dependency vulnerability. Deactivating a rule / overriding severity / assigning is `PermOperate`-gated and audited. LLM-free, deterministic.

## Verification
`go build/vet/test ./...` + `gofmt` clean; postgres store + migration 0055 pass an integration test on real PostgreSQL 16; web `tsc` + `vite build` + 246 vitest tests green on Node 20. Independent go-arch (PASS), security (CLEAN — suppression is by-design + audited), and frontend reviews were run; the frontend rule-table >50-row concern is handled with a filter + render cap.

## Acceptance (#183) — met
Each language has a built-in default profile; a user can copy it, toggle rules + severities, and assign the profile to a project; analyses honor the assigned profile.