### PR TITLE
docs(codequality): rule-pack methodology + enforce built-in-profile acceptance (#185)

### DIFF
--- a/docs/guide/code-quality-rules.md
+++ b/docs/guide/code-quality-rules.md
@@ -5,8 +5,9 @@
 This guide is for contributors adding or reviewing **code-quality rules**. Synapse's code-quality
 engine (see the [Features](features.md) guide) turns parsed source into `Kind=quality` /
 `Kind=reliability` findings and the A–E ratings. Each language ships a built-in **"Synapse way"**
-quality profile — a curated set of rules. This page defines how those rules are modelled, how they are
-authored, and the authoritative sources each language draws on.
+quality profile — **generated automatically from the catalog rules for that language** (every rule whose
+`Language` matches, at its default severity). This page defines how those rules are modelled, how they
+are authored, and the authoritative sources each language draws on.
 
 Tracking epic: [Code Quality as a product](https://github.com/KKloudTarus/synapse-ce/issues/174) ·
 language rule-pack tracker: [#185](https://github.com/KKloudTarus/synapse-ce/issues/185).
@@ -124,9 +125,35 @@ analyzer) before AST rules are possible are noted in the matrix below.
    rationale, and a compliant + non-compliant example.
 3. Implement detection (AST query preferred) and add a **golden test** per rule: a fixture that must
    flag and one that must not.
-4. Add the rule to the language's built-in "Synapse way" profile ([#183](https://github.com/KKloudTarus/synapse-ce/issues/183)).
-5. Keep the rule catalogue browsable ([#182](https://github.com/KKloudTarus/synapse-ce/issues/182)) and
-   gate-eligible ([#184](https://github.com/KKloudTarus/synapse-ce/issues/184)).
+4. Catalogue the rule ([#182](https://github.com/KKloudTarus/synapse-ce/issues/182)) with its
+   `Language` set. That is all that is required to ship it: the built-in **"Synapse way (<language>)"**
+   profile is generated from the catalog, so a correctly-`Language`-tagged rule is automatically active
+   in that language's default profile ([#183](https://github.com/KKloudTarus/synapse-ce/issues/183)),
+   browsable in the Rules explorer, and gate-eligible ([#184](https://github.com/KKloudTarus/synapse-ce/issues/184)).
+
+## Built-in profiles, custom profiles & the gate
+
+How a rule flows from the catalogue to an enforced gate result (the shipped
+[#182](https://github.com/KKloudTarus/synapse-ce/issues/182)/[#183](https://github.com/KKloudTarus/synapse-ce/issues/183)/[#184](https://github.com/KKloudTarus/synapse-ce/issues/184)
+plumbing):
+
+- **Built-in profile (generated, immutable).** For each language, `qualityprofile.BuiltIn` activates
+  every catalog rule for that `Language` at its default severity, under the key `synapse-way-<slug>`. It
+  is never stored and never edited — it always reflects the current catalogue.
+- **Custom profile (copy, editable).** A user copies a built-in into a tenant-scoped custom profile,
+  then **deactivates** rules or **overrides** severities. Deactivating/overriding is `PermOperate`-gated
+  and audited; it never touches SCA advisory findings (a profile can only affect first-party catalog
+  rules, so it can't suppress a dependency vulnerability).
+- **Assignment.** A profile is assigned per language per project. At analysis time the assigned profiles
+  are resolved into one overlay that drops deactivated rules and applies severity overrides before the
+  findings are classified, rated, and gated — so **analyses honor the assigned profile**.
+- **Gate.** Metrics feed the Quality Gate ([#184](https://github.com/KKloudTarus/synapse-ce/issues/184)):
+  the whole-codebase and Clean-as-You-Code (`new_*`) counts, ratings, hotspots-reviewed, and the
+  coverage/duplication metrics (`coverage`, `new_coverage`, `duplication_density`, `new_duplication`).
+
+The acceptance invariant — *every shipped language has a non-empty built-in profile* — is enforced by a
+test over the real catalogue (`internal/infrastructure/rulecatalog` → `qualityprofile.BuiltIn` per
+language), so adding the first rule for a new language automatically gives it a "Synapse way" profile.
 
 ## Language source matrix
 

--- a/internal/infrastructure/rulecatalog/builtin_profile_test.go
+++ b/internal/infrastructure/rulecatalog/builtin_profile_test.go
@@ -1,0 +1,59 @@
+package rulecatalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/qualityprofile"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/rulecatalog"
+)
+
+// TestEveryShippedLanguageHasBuiltInProfile enforces the #185 acceptance criterion at the code level:
+// every language present in the shipped rule catalog produces a non-empty built-in "Synapse way"
+// profile (P9, #183), so the built-in profile is browsable in the Rules explorer (#182), assignable via
+// Quality Profiles (#183), and gate-eligible (#184). Adding a rule for a new language automatically
+// gives that language a built-in profile — this test guards that invariant against regressions.
+func TestEveryShippedLanguageHasBuiltInProfile(t *testing.T) {
+	cat, err := rulecatalog.Default()
+	if err != nil {
+		t.Fatalf("Default(): %v", err)
+	}
+	rules, err := cat.List(context.Background())
+	if err != nil {
+		t.Fatalf("List(): %v", err)
+	}
+	if len(rules) == 0 {
+		t.Fatal("the shipped rule catalog is empty")
+	}
+
+	byLang := map[string][]rule.Rule{}
+	for _, r := range rules {
+		byLang[r.Language] = append(byLang[r.Language], r)
+	}
+
+	for lang, langRules := range byLang {
+		profile, ok := qualityprofile.BuiltIn(lang, rules)
+		if !ok {
+			t.Errorf("language %q ships %d rule(s) but has no built-in profile", lang, len(langRules))
+			continue
+		}
+		if profile.Key != qualityprofile.BuiltInKey(lang) || !profile.BuiltIn || profile.Language != lang {
+			t.Errorf("language %q built-in profile is malformed: %+v", lang, profile)
+		}
+		// Every catalog rule for the language is activated in the built-in default (the "Synapse way").
+		if len(profile.ActivatedRules) != len(langRules) {
+			t.Errorf("language %q: built-in activates %d rules, catalog has %d", lang, len(profile.ActivatedRules), len(langRules))
+		}
+		if err := profile.Validate(); err != nil {
+			t.Errorf("language %q built-in profile invalid: %v", lang, err)
+		}
+	}
+
+	// The core shipped packs (per docs/guide/code-quality-rules.md) must each have a built-in profile.
+	for _, lang := range []string{"Go", "Python", "Java", "JavaScript/TypeScript", "Secrets"} {
+		if _, ok := qualityprofile.BuiltIn(lang, rules); !ok {
+			t.Errorf("expected a shipped built-in profile for %q", lang)
+		}
+	}
+}


### PR DESCRIPTION
Closes #185.

**#185 is the L0 tracker + clean-room authoring methodology** for the 26 per-language rule packs. This PR completes its own deliverable — the methodology + the acceptance plumbing — and encodes the acceptance as an enforced test. (The 26 per-language packs are their own tracked issues #186–#214; several are already shipped/closed — JS-TS #188, Java #196, Python #187 — and per-pack authoring continues there.)

## What this delivers
The canonical guide `docs/guide/code-quality-rules.md` was committed earlier; the dependencies it tracked are now all shipped this cycle — rule schema (#182), **Quality Profiles (#183)**, **Quality Gates (#184)**. This PR:

- **Brings the guide current with the shipped mechanism.** The built-in **"Synapse way"** profile is now *generated* from the catalog (every rule whose `Language` matches, at its default severity), not hand-curated — so authoring a rule is simply cataloguing it with the right `Language`. Rewrote the authoring workflow, and added a **"Built-in profiles, custom profiles & the gate"** section documenting the end-to-end flow now that #183/#184 are live: generated built-in → copy → deactivate/override (audited, first-party only, **never suppresses SCA**) → per-language project assignment → overlay applied at analysis time → gate metrics.
- **Enforces the acceptance as a test.** `internal/infrastructure/rulecatalog/builtin_profile_test.go` asserts — over the **real shipped catalog** — that every language present yields a non-empty built-in profile via `qualityprofile.BuiltIn`, that it activates exactly that language's catalog rules, and that the core packs (Go/Python/Java/JS-TS/Secrets) each have one.

## Acceptance (#185) — met
Each shipped language has a built-in "Synapse way" profile of clean-room rules, browsable in the Rules explorer (#182), assignable via Quality Profiles (#183), and enforced by the gate (#184) — all documented in the authoring guide, and now guarded by a regression test.

## Verification
`go build/vet/test ./...` + `gofmt` clean.