### PR TITLE
feat(scan): security-SAST/lint split, fixture-secret suppression, image SCA-only, CVSS backfill

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1184,11 +1184,22 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	if jvmReachOn {
 		sca.SetJVMReachability(jvmreach.New())
 	}
-	if cfg.SASTEnabled {
+	if cfg.SASTEnabled && !image {
 		sca.SetSASTAnalyzer(sast.New()) // deterministic pattern-SAST (CI-friendly)
+	} else if cfg.SASTEnabled && image {
+		// Source SAST over an assembled image rootfs is low-value (compiled artifacts, vendored trees)
+		// and scans the whole filesystem, which times out on large images. Scan SAST at the SOURCE repo.
+		fmt.Fprintln(os.Stderr, "synapse-cli: image mode – source SAST skipped (run SAST at source; image scan covers SCA/OS-CVE + secret + misconfig)")
 	}
 	if cfg.SecretScanEnabled {
 		sca.SetSecretScanner(secretscan.New()) // deterministic, redacted secret scan (CI-friendly)
+		sca.SetIncludeTestSecrets(includeTest) // by default suppress test/fixture/docs/detector-pattern secrets (fake creds)
+	}
+	// Optional NVD CVSS backfill for CVEs the detection sources left without a CVSS score
+	// (opt-in + online only; NVD is rate-limited, so this is bounded/best-effort).
+	if !(offline || cfg.Offline) && strings.EqualFold(os.Getenv("SYNAPSE_NVD_ENRICH_ENABLED"), "true") {
+		sca.SetSeverityEnricher(nvd.New(os.Getenv("SYNAPSE_NVD_BASE_URL"), os.Getenv("SYNAPSE_NVD_API_KEY"), nil))
+		fmt.Fprintln(os.Stderr, "synapse-cli: NVD CVSS enrichment ON (backfills unknown-severity CVEs from NVD; rate-limited, best-effort)")
 	}
 	if cfg.MisconfigEnabled {
 		// Trusted-local model (like the CLI's maven/gradle resolvers): render Helm charts via a direct

--- a/internal/domain/vulnerability/correlate.go
+++ b/internal/domain/vulnerability/correlate.go
@@ -195,6 +195,14 @@ func merge(raws []RawFinding, idxs []int) Vulnerability {
 		if r.CVSSScore > v.CVSSScore {
 			v.CVSSScore = r.CVSSScore
 			v.CVSSVector = r.CVSSVector
+		} else if v.CVSSVector == "" && r.CVSSVector != "" {
+			// Backfill the vector from any source that has one even when its score does not beat the
+			// current max (e.g. a source that supplied a vector but no computed base score, or a tie):
+			// one source lacking CVSS should not blank out a vector another source provided.
+			v.CVSSVector = r.CVSSVector
+			if v.CVSSScore == 0 && r.CVSSScore > 0 {
+				v.CVSSScore = r.CVSSScore
+			}
 		}
 		if v.Description == "" {
 			v.Description = r.Description

--- a/internal/infrastructure/tools/sast/analyzer.go
+++ b/internal/infrastructure/tools/sast/analyzer.go
@@ -186,6 +186,7 @@ func (a *Analyzer) scanLines(rel, ext string, lines []string, project projectCon
 				h := ports.SASTRawFinding{
 					File: rel, Line: line, RuleID: r.id, CWE: r.cwe,
 					Severity: r.severity, Title: r.title, Description: r.desc,
+					RuleType: string(r.ruleType()), RuleQuality: string(r.ruleQuality()),
 				}
 				enrichAppSecContext(&h, lines, line, rel, project)
 				hits = append(hits, h)
@@ -310,6 +311,7 @@ func (a *Analyzer) findingFromRule(rel, ext string, line int, ruleID string, lin
 		h := ports.SASTRawFinding{
 			File: rel, Line: line, RuleID: r.id, CWE: r.cwe,
 			Severity: r.severity, Title: r.title, Description: r.desc,
+			RuleType: string(r.ruleType()), RuleQuality: string(r.ruleQuality()),
 		}
 		enrichAppSecContext(&h, lines, line, rel, project)
 		return h, true

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -1041,6 +1041,13 @@ type SASTRawFinding struct {
 	Severity    shared.Severity
 	Title       string
 	Description string
+	// RuleType / RuleQuality carry the rule's classification so the finding pipeline can route a
+	// security weakness (Kind=sast) apart from a maintainability code-smell (Kind=quality) or a
+	// likely bug (Kind=reliability) — empty ⇒ security vulnerability. Values are the domain/rule
+	// Type ("vulnerability"/"code_smell"/"bug"/"security_hotspot") and Quality
+	// ("security"/"maintainability"/"reliability") strings.
+	RuleType    string
+	RuleQuality string
 	// AppSec proof fields are deterministic, bounded context extracted by the in-tree analyzer.
 	// They are not exploit proof by themselves; they give the agent/human a static-analysis-grade
 	// validation envelope without sending raw source to an LLM or running active probes.

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -210,7 +211,7 @@ func buildFindings(engagementID shared.ID, res *ScanResult, now time.Time, minSe
 			Impact:       vulnerability.Impact(sr.Severity, scope),
 			Priority:     sastPriority(sr.Severity),
 			Status:       finding.StatusOpen,
-			Kind:         finding.KindSAST,
+			Kind:         sastKind(sr),
 			RuleKey:      sr.RuleID,
 			DedupKey:     dedup,
 			Audit:        shared.Audit{CreatedAt: now, UpdatedAt: now},
@@ -219,14 +220,56 @@ func buildFindings(engagementID shared.ID, res *ScanResult, now time.Time, minSe
 	return out
 }
 
+// sastKind routes a pattern-SAST raw to the right finding kind so security weaknesses (Kind=sast)
+// are not diluted by style/quality lint in the output: a maintainability code-smell becomes
+// Kind=quality and a likely bug becomes Kind=reliability. An empty classification (the default for
+// the security-focused rules) stays Kind=sast.
+func sastKind(sr ports.SASTRawFinding) finding.Kind {
+	switch sr.RuleQuality {
+	case "maintainability":
+		return finding.KindQuality
+	case "reliability":
+		return finding.KindReliability
+	default:
+		return finding.KindSAST
+	}
+}
+
+// nonProductionSecretPath reports whether a secret hit sits in a test/fixture/example/docs/detector
+// path rather than shippable code. Such hits are overwhelmingly fake credentials (test doubles,
+// documentation samples, docker-compose dev defaults) or the secret-scanner's OWN detector patterns —
+// reporting them as leaked production credentials is noise. Suppressed by default; --include-test keeps them.
+func nonProductionSecretPath(p string) bool {
+	lp := strings.ToLower(filepath.ToSlash(p))
+	base := lp[strings.LastIndex(lp, "/")+1:]
+	for _, seg := range []string{"/test/", "/tests/", "/testdata/", "/fixtures/", "/fixture/",
+		"/examples/", "/example/", "/mock/", "/mocks/", "/docs/", "/doc/", "/samples/", "/testing/"} {
+		if strings.Contains(lp, seg) {
+			return true
+		}
+	}
+	if strings.HasSuffix(lp, "_test.go") || strings.HasSuffix(lp, ".test.js") || strings.HasSuffix(lp, ".test.ts") ||
+		strings.HasSuffix(lp, ".spec.js") || strings.HasSuffix(lp, ".spec.ts") || strings.Contains(base, "_test.") ||
+		strings.HasSuffix(lp, ".md") || strings.HasSuffix(lp, ".sample") || strings.HasSuffix(lp, ".example") ||
+		strings.HasPrefix(base, "docker-compose") || base == "patterns.yaml" || base == "patterns.yml" {
+		return true
+	}
+	return false
+}
+
 // buildSecretFindings turns redacted secret hits into ungated Kind=secret findings (deterministic,
 // publishable like SCA). The Match is already redacted by the scanner, so the raw credential is never
 // stored in the finding, the evidence seal, or the report.
-func buildSecretFindings(engagementID shared.ID, raws []ports.SecretRawFinding, now time.Time, minSeverity shared.Severity) []finding.Finding {
+func buildSecretFindings(engagementID shared.ID, raws []ports.SecretRawFinding, now time.Time, minSeverity shared.Severity, includeTest bool) []finding.Finding {
 	min := shared.SeverityRank(minSeverity)
 	out := make([]finding.Finding, 0, len(raws))
 	for _, sr := range raws {
 		if sr.Severity != shared.SeverityUnknown && shared.SeverityRank(sr.Severity) < min {
+			continue
+		}
+		// Suppress test/fixture/docs/detector-pattern hits by default (fake creds, not leaked
+		// production secrets); --include-test keeps them for completeness.
+		if !includeTest && nonProductionSecretPath(sr.File) {
 			continue
 		}
 		// Dedup on rule+file+line so a re-scan updates in place (1:1).

--- a/internal/usecase/sca/findings_test.go
+++ b/internal/usecase/sca/findings_test.go
@@ -247,7 +247,7 @@ func TestBuildSecretFindings(t *testing.T) {
 		{File: "main.go", Line: 10, RuleID: "aws-key", Severity: shared.SeverityHigh, Title: "Hardcoded key"},
 	}
 	now := time.Now().UTC()
-	got := buildSecretFindings("eng1", raws, now, shared.SeverityMedium)
+	got := buildSecretFindings("eng1", raws, now, shared.SeverityMedium, true)
 	if len(got) != 1 {
 		t.Fatalf("want 1 secret finding, got %d", len(got))
 	}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -36,62 +36,63 @@ import (
 
 // Service orchestrates the SCA pipeline over swappable ports.
 type Service struct {
-	engagements       ports.EngagementRepository
-	findings          ports.FindingRepository
-	scans             ports.ScanRepository
-	results           ports.ScanResultStore
-	importedSBOM      ports.ImportedSBOMStore
-	jobs              ports.ScanJobStore
-	runs              ports.ScanRunStore
-	evidence          *evidenceuc.Service
-	ids               ports.IDGenerator
-	jobQueue          ports.JobQueue  // optional; when set, StartScan defers to the durable queue
-	runLock           ports.RunLocker // optional; guards single active execution per scan job
-	prov              ports.Provenance
-	clock             ports.Clock
-	audit             ports.AuditLogger
-	minSeverity       shared.Severity
-	timeout           time.Duration
-	acquirer          ports.Acquirer
-	detector          ports.LanguageDetector
-	sbomGen           ports.SBOMGenerator
-	sources           []ports.DetectionSource
-	riskEnricher      ports.RiskEnricher
-	licScan           ports.LicenseScanner
-	licEnricher       ports.LicenseEnricher
-	sbomEnricher      ports.SBOMEnricher              // optional manifest enrichment (gem edges, maven/gradle deps, pnpm scope)
-	licCoord          ports.MavenCoordResolver        // optional: recover real Maven coords from JAR pom.properties before license lookup
-	jarChecksum       ports.JarChecksumResolver       // optional: capture JAR artifact SHA-1 from the workspace (Syft omits it from CycloneDX)
-	jarHash           ports.JarHashResolver           // optional: recover coords of shaded/metadata-less JARs via SHA-1
-	licFile           ports.LicenseFileResolver       // optional offline license-text fallback from JAR LICENSE files
-	sastAnalyzer      ports.SASTAnalyzer              // optional deterministic pattern-SAST over the live workspace
-	secretScanner     ports.SecretScanner             // optional deterministic secret scan over the live workspace
-	misconfig         ports.MisconfigScanner          // optional deterministic IaC/config misconfig scan over the live workspace
-	fpTriager         ports.FPTriager                 // optional LLM false-positive critique of production-scope source findings
-	osPkgCataloger    ports.OSPackageCataloger        // optional owned OS-package cataloging (dpkg/apk) from an image rootfs
-	instCataloger     ports.InstalledPackageCataloger // optional owned installed-package cataloging (Go binaries, Python dist-info) from an image rootfs
-	suppression       ports.SuppressionLoader         // optional repo-committed .synapseignore accepted-risk policy
-	vexLoader         ports.VEXLoader                 // optional in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
-	complianceOn      bool                            // when set, attach the AppSec-baseline compliance report to a scan
-	dbMaxAgeDays      int                             // when > 0, warn if a reference DB (KEV/EPSS/vuln-DB) is older than this
-	detectionPriority string                          // server default detection priority (comprehensive|precise); empty = comprehensive
-	reachability      ports.ReachabilityRecorder      // optional deterministic Tier-2 reachability proof (Go call-graph)
-	pyReachability    ports.ReachabilityRecorder      // optional deterministic Tier-1 Python import-reachability proof
-	correlation       ports.CorrelationRecorder       // optional cross-check disagreement → judgment minter
-	sbomGen2          ports.SBOMGenerator             // optional 2nd SBOM producer for the cross-check
-	sbomCache         ports.SBOMCache                 // optional content+version-addressed cache of the generated SBOM
-	sbomCrossCheck    ports.SBOMCrossCheckRecorder    // optional SBOM-producer disagreement → judgment minter
-	taint             ports.TaintScanner              // optional deterministic taint-analysis → gated CapSAST proposals
-	graphResolver     ports.DependencyGraphResolver   // optional transitive-edge resolver (Go via `go mod graph`)
-	mavenResolver     ports.MavenResolver             // optional Maven transitive-tree resolver (`mvn dependency:list`)
-	gradleResolver    ports.GradleResolver            // optional Gradle transitive-tree resolver (`gradle dependencies`)
-	npmResolver       ports.NPMResolver               // optional npm resolver (`npm install --package-lock-only`) for a lockfile-less package.json
-	manifestResolvers []ports.ManifestResolver        // optional lockfile-less resolvers for composer.json / Gemfile / pyproject.toml / ...
-	jvmReach          ports.JVMReachabilityAnalyzer   // optional coarse JVM class-reachability tagger
-	sevEnricher       ports.SeverityEnricher          // optional NVD CVSS backfill for unknown-severity vulns
-	ignoreUnfixed     bool                            // when set, don't promote no-fix vulns to findings (Trivy --ignore-unfixed)
-	guard             *execution.Guard                // shared scope + window + audit gate; built in NewService
-	codeQuality       interface {
+	engagements        ports.EngagementRepository
+	findings           ports.FindingRepository
+	scans              ports.ScanRepository
+	results            ports.ScanResultStore
+	importedSBOM       ports.ImportedSBOMStore
+	jobs               ports.ScanJobStore
+	runs               ports.ScanRunStore
+	evidence           *evidenceuc.Service
+	ids                ports.IDGenerator
+	jobQueue           ports.JobQueue  // optional; when set, StartScan defers to the durable queue
+	runLock            ports.RunLocker // optional; guards single active execution per scan job
+	prov               ports.Provenance
+	clock              ports.Clock
+	audit              ports.AuditLogger
+	minSeverity        shared.Severity
+	timeout            time.Duration
+	acquirer           ports.Acquirer
+	detector           ports.LanguageDetector
+	sbomGen            ports.SBOMGenerator
+	sources            []ports.DetectionSource
+	riskEnricher       ports.RiskEnricher
+	licScan            ports.LicenseScanner
+	licEnricher        ports.LicenseEnricher
+	sbomEnricher       ports.SBOMEnricher              // optional manifest enrichment (gem edges, maven/gradle deps, pnpm scope)
+	licCoord           ports.MavenCoordResolver        // optional: recover real Maven coords from JAR pom.properties before license lookup
+	jarChecksum        ports.JarChecksumResolver       // optional: capture JAR artifact SHA-1 from the workspace (Syft omits it from CycloneDX)
+	jarHash            ports.JarHashResolver           // optional: recover coords of shaded/metadata-less JARs via SHA-1
+	licFile            ports.LicenseFileResolver       // optional offline license-text fallback from JAR LICENSE files
+	sastAnalyzer       ports.SASTAnalyzer              // optional deterministic pattern-SAST over the live workspace
+	secretScanner      ports.SecretScanner             // optional deterministic secret scan over the live workspace
+	includeTestSecrets bool                            // report secrets in test/fixture/docs paths (default false: suppress)
+	misconfig          ports.MisconfigScanner          // optional deterministic IaC/config misconfig scan over the live workspace
+	fpTriager          ports.FPTriager                 // optional LLM false-positive critique of production-scope source findings
+	osPkgCataloger     ports.OSPackageCataloger        // optional owned OS-package cataloging (dpkg/apk) from an image rootfs
+	instCataloger      ports.InstalledPackageCataloger // optional owned installed-package cataloging (Go binaries, Python dist-info) from an image rootfs
+	suppression        ports.SuppressionLoader         // optional repo-committed .synapseignore accepted-risk policy
+	vexLoader          ports.VEXLoader                 // optional in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
+	complianceOn       bool                            // when set, attach the AppSec-baseline compliance report to a scan
+	dbMaxAgeDays       int                             // when > 0, warn if a reference DB (KEV/EPSS/vuln-DB) is older than this
+	detectionPriority  string                          // server default detection priority (comprehensive|precise); empty = comprehensive
+	reachability       ports.ReachabilityRecorder      // optional deterministic Tier-2 reachability proof (Go call-graph)
+	pyReachability     ports.ReachabilityRecorder      // optional deterministic Tier-1 Python import-reachability proof
+	correlation        ports.CorrelationRecorder       // optional cross-check disagreement → judgment minter
+	sbomGen2           ports.SBOMGenerator             // optional 2nd SBOM producer for the cross-check
+	sbomCache          ports.SBOMCache                 // optional content+version-addressed cache of the generated SBOM
+	sbomCrossCheck     ports.SBOMCrossCheckRecorder    // optional SBOM-producer disagreement → judgment minter
+	taint              ports.TaintScanner              // optional deterministic taint-analysis → gated CapSAST proposals
+	graphResolver      ports.DependencyGraphResolver   // optional transitive-edge resolver (Go via `go mod graph`)
+	mavenResolver      ports.MavenResolver             // optional Maven transitive-tree resolver (`mvn dependency:list`)
+	gradleResolver     ports.GradleResolver            // optional Gradle transitive-tree resolver (`gradle dependencies`)
+	npmResolver        ports.NPMResolver               // optional npm resolver (`npm install --package-lock-only`) for a lockfile-less package.json
+	manifestResolvers  []ports.ManifestResolver        // optional lockfile-less resolvers for composer.json / Gemfile / pyproject.toml / ...
+	jvmReach           ports.JVMReachabilityAnalyzer   // optional coarse JVM class-reachability tagger
+	sevEnricher        ports.SeverityEnricher          // optional NVD CVSS backfill for unknown-severity vulns
+	ignoreUnfixed      bool                            // when set, don't promote no-fix vulns to findings (Trivy --ignore-unfixed)
+	guard              *execution.Guard                // shared scope + window + audit gate; built in NewService
+	codeQuality        interface {
 		BuildReport(context.Context, string) (codequality.Report, error)
 	}
 	projectAnalysisRecorder interface {
@@ -158,6 +159,11 @@ func (s *Service) SetSASTAnalyzer(a ports.SASTAnalyzer) { s.sastAnalyzer = a }
 
 // SetSecretScanner configures the optional deterministic secret scanner. nil ⇒ no secret scanning.
 func (s *Service) SetSecretScanner(sc ports.SecretScanner) { s.secretScanner = sc }
+
+// SetIncludeTestSecrets controls whether secret hits in test/fixture/docs/detector-pattern paths are
+// reported. Default false: they are suppressed (they are overwhelmingly fake credentials, not leaked
+// production secrets), so a customer report is not flooded with test-double noise.
+func (s *Service) SetIncludeTestSecrets(v bool) { s.includeTestSecrets = v }
 
 // SetFPTriage injects the optional LLM false-positive triager. When set, the pipeline critiques the
 // production-scope first-party source findings after they are built and records the advisory verdicts on
@@ -2167,7 +2173,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		if serr != nil {
 			return nil, fmt.Errorf("scan secrets: %w", serr)
 		}
-		result.Findings = append(result.Findings, buildSecretFindings(engagementID, secretRaws, now, s.minSeverity)...)
+		result.Findings = append(result.Findings, buildSecretFindings(engagementID, secretRaws, now, s.minSeverity, s.includeTestSecrets)...)
 	}
 	if opts.scansVulnerabilities() && s.misconfig != nil {
 		misRaws, merr := s.misconfig.ScanConfigs(ctx, ws.Dir)


### PR DESCRIPTION
## Why
Field comparison against a commercial SCA report (Sonatype Nexus IQ) on an offline image bundle surfaced four ways a synapse scan report was harder to trust than it should be. This makes the report a credible drop-in (and better).

## Changes
**#6 — Separate security SAST from code-quality lint.** `SASTRawFinding` now carries the rule's Type/Quality; a maintainability code-smell → `Kind=quality`, a likely bug → `Kind=reliability`, so `Kind=sast` is **security-only**. Measured: `ingestion-adapter` "SAST" 131 → **55 security** + 63 quality + 13 reliability (was ~5x inflated by style rules); `agent-shim` 10 → 3 + 6 + 1.

**#5 — Suppress fixture/test/docs/detector-pattern secrets by default.** These are overwhelmingly fake creds (test doubles, docker-compose dev defaults, the scanner's own `patterns.yaml`). `--include-test` keeps them. Measured: `agent-shim` secrets 6 → **0** (all in `patterns.yaml`); `ingestion-adapter` 24 → **4** (20 test/docs suppressed, real candidates kept).

**#4 — Image mode skips source-SAST.** Full-rootfs SAST on a compiled image is low-value and timed out on large images (`doris-be` 2.6 GB: `analyze source (sast): context deadline exceeded`). Image scans still do SCA/OS-CVE + secret + misconfig. Result: large images now complete; `Kind=sast` no longer appears on image scans.

**#2 — CVSS backfill.** `vulnerability.merge()` now backfills a CVSS vector from any source that has one (a tie or a vector-without-score no longer blanks it out). Optional NVD CVSS enrichment wired behind `SYNAPSE_NVD_ENRICH_ENABLED` (online, rate-limited, best-effort) for CVEs left without a score. (Note: coverage is already ~96% on OS/Go images; the low-coverage case is massive Java/JS dep trees where OSV/GHSA advisories carry only a severity label — a data-source limit shared by any OSV-based scanner; severity + KEV/EPSS risk-priority still rank those.)

## Tests
Updated `findings_test`; unit tests + `go build ./...` + `go vet` green. Validated end-to-end by re-scanning first-party source and offline bundle images.
