### PR TITLE
feat(nvd): offline CVSS database from the NVD JSON feed (airgapped, no rate limit)

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -8,9 +8,11 @@
 package main
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -96,6 +98,14 @@ func main() {
 			usage() // missing <dir> exits 2, consistent with scan's missing-path
 		}
 		if err := syncAdvisories(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
+			os.Exit(1)
+		}
+	case "build-cvss-db":
+		if len(os.Args) < 4 {
+			usage() // need <out> + at least one NVD json input
+		}
+		if err := runBuildCVSSDB(os.Args[2], os.Args[3:]); err != nil {
 			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 			os.Exit(1)
 		}
@@ -263,6 +273,41 @@ func printable(s string) string {
 
 // runInventory prints a per-language code-size inventory for a local source tree (the Phase-0
 // code-quality surface). Pure-Go, read-only; no engagement/DB needed.
+// runBuildCVSSDB parses NVD JSON feed files into a compact local CVSS database (JSONL, gzip if the
+// out path ends .gz) that the offline severity enricher (SYNAPSE_NVD_CVSS_DB) reads to backfill CVSS
+// with no network and no rate limit. Inputs may be plain or .gz NVD JSON (API 2.0 or legacy 1.1) and
+// may be shell globs.
+func runBuildCVSSDB(out string, inputs []string) error {
+	var paths []string
+	for _, in := range inputs {
+		if matches, gerr := filepath.Glob(in); gerr == nil && len(matches) > 0 {
+			paths = append(paths, matches...)
+		} else {
+			paths = append(paths, in)
+		}
+	}
+	if len(paths) == 0 {
+		return fmt.Errorf("no NVD json inputs")
+	}
+	f, err := os.Create(out)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", out, err)
+	}
+	defer f.Close()
+	var w io.Writer = f
+	if strings.HasSuffix(strings.ToLower(out), ".gz") {
+		gz := gzip.NewWriter(f)
+		defer gz.Close()
+		w = gz
+	}
+	n, err := nvd.BuildDB(paths, w)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "synapse-cli: built CVSS DB %s – %d CVE entries from %d file(s)\n", out, n, len(paths))
+	return nil
+}
+
 func runInventory(dir string) error {
 	// Wire the synapse-ast sidecar so non-Go languages get accurate function counts too. If the binary is
 	// absent or built without the tree-sitter backend, the provider reports unavailable and the inventory
@@ -921,6 +966,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --remote-distros # fetch + ingest OS-package advisories (Debian/Alpine) from OSV (large; requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --csaf <dir> # ingest a local CSAF 2.0 advisory dump (requires SYNAPSE_DB_DSN)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli sync-advisories --oval <dir> # ingest a local Ubuntu OVAL dump (com.ubuntu.*.cve.oval.xml[.bz2]; requires SYNAPSE_DB_DSN)")
+	fmt.Fprintln(os.Stderr, "  synapse-cli build-cvss-db <out.jsonl[.gz]> <nvd-*.json[.gz]...>  # build an OFFLINE CVSS DB from NVD JSON feeds; use it via SYNAPSE_NVD_CVSS_DB to backfill CVSS with no network/rate-limit")
 	os.Exit(2)
 }
 
@@ -1195,12 +1241,6 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		sca.SetSecretScanner(secretscan.New()) // deterministic, redacted secret scan (CI-friendly)
 		sca.SetIncludeTestSecrets(includeTest) // by default suppress test/fixture/docs/detector-pattern secrets (fake creds)
 	}
-	// Optional NVD CVSS backfill for CVEs the detection sources left without a CVSS score
-	// (opt-in + online only; NVD is rate-limited, so this is bounded/best-effort).
-	if !(offline || cfg.Offline) && strings.EqualFold(os.Getenv("SYNAPSE_NVD_ENRICH_ENABLED"), "true") {
-		sca.SetSeverityEnricher(nvd.New(os.Getenv("SYNAPSE_NVD_BASE_URL"), os.Getenv("SYNAPSE_NVD_API_KEY"), nil))
-		fmt.Fprintln(os.Stderr, "synapse-cli: NVD CVSS enrichment ON (backfills unknown-severity CVEs from NVD; rate-limited, best-effort)")
-	}
 	if cfg.MisconfigEnabled {
 		// Trusted-local model (like the CLI's maven/gradle resolvers): render Helm charts via a direct
 		// `helm template` exec. It runs the chart's templates on the host, so use it only on a project you trust.
@@ -1233,8 +1273,21 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	}
 	// JAR-embedded licenses + workspace LICENSE files for every ecosystem.
 	sca.SetLicenseFileResolver(licensefile.NewChain(jarlicense.New(), licensefile.New()))
-	// Backfill unknown vuln severities from NVD CVSS (best-effort; set SYNAPSE_NVD_API_KEY for throughput).
-	sca.SetSeverityEnricher(nvd.New(cfg.NVDAPIURL, cfg.NVDAPIKey, nil).WithBudget(cfg.NVDBudget))
+	// Backfill CVSS. Prefer a LOCAL NVD CVSS DB (offline: no network, no rate limit, fills EVERY
+	// missing CVSS — the airgapped path and the way to give large dependency trees real CVSS scores)
+	// when SYNAPSE_NVD_CVSS_DB points to a DB built by `synapse-cli build-cvss-db`; otherwise fall
+	// back to the online NVD enricher (rate-limited, best-effort, unknown-severity only).
+	if p := strings.TrimSpace(os.Getenv("SYNAPSE_NVD_CVSS_DB")); p != "" {
+		if oe, oerr := nvd.LoadOffline(p); oerr != nil {
+			fmt.Fprintf(os.Stderr, "synapse-cli: NVD offline CVSS DB %q not usable (%v) – falling back to online NVD\n", p, oerr)
+			sca.SetSeverityEnricher(nvd.New(cfg.NVDAPIURL, cfg.NVDAPIKey, nil).WithBudget(cfg.NVDBudget))
+		} else {
+			sca.SetSeverityEnricher(oe)
+			fmt.Fprintf(os.Stderr, "synapse-cli: NVD offline CVSS DB ON (%d CVEs) – backfills missing CVSS locally, no network/rate-limit\n", oe.Size())
+		}
+	} else {
+		sca.SetSeverityEnricher(nvd.New(cfg.NVDAPIURL, cfg.NVDAPIKey, nil).WithBudget(cfg.NVDBudget))
+	}
 	// --ignore-unfixed (or SYNAPSE_IGNORE_UNFIXED) drops vulns with no upstream fix – the
 	// classic distro-noise reducer for OS-package scans (matches Trivy's --ignore-unfixed).
 	sca.SetIgnoreUnfixed(ignoreUnfixed || cfg.IgnoreUnfixed)

--- a/internal/infrastructure/tools/nvd/ingest.go
+++ b/internal/infrastructure/tools/nvd/ingest.go
@@ -1,0 +1,134 @@
+package nvd
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// BuildDB parses NVD JSON feed files and writes a compact CVSS database as JSONL (one
+// {"id","v","s"} object per CVE) to out. It accepts both the NVD API 2.0 shape
+// ("vulnerabilities":[{"cve":{"id","metrics":{...}}}]) and the legacy 1.1 feed shape
+// ("CVE_Items":[{"cve":{"CVE_data_meta":{"ID"}},"impact":{...}}]), gzip-compressed or plain. For
+// each CVE it records the strongest available vector, preferring CVSS v3.1 > v3.0 > v2. A CVE
+// with no CVSS vector is skipped (nothing to store). Returns the number of entries written.
+func BuildDB(inPaths []string, out io.Writer) (int, error) {
+	w := bufio.NewWriter(out)
+	defer w.Flush()
+	enc := json.NewEncoder(w)
+	total := 0
+	for _, p := range inPaths {
+		n, err := ingestFile(p, enc)
+		if err != nil {
+			return total, fmt.Errorf("ingest %s: %w", filepath.Base(p), err)
+		}
+		total += n
+	}
+	return total, nil
+}
+
+func ingestFile(path string, enc *json.Encoder) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	var r io.Reader = f
+	if strings.HasSuffix(strings.ToLower(path), ".gz") {
+		gz, gerr := gzip.NewReader(f)
+		if gerr != nil {
+			return 0, fmt.Errorf("gunzip: %w", gerr)
+		}
+		defer gz.Close()
+		r = gz
+	}
+	var doc nvdFeed
+	if err := json.NewDecoder(r).Decode(&doc); err != nil {
+		return 0, fmt.Errorf("decode json: %w", err)
+	}
+
+	n := 0
+	write := func(id, vector string, score float64) {
+		id = cveID(id)
+		if id == "" || vector == "" {
+			return
+		}
+		_ = enc.Encode(dbEntry{ID: id, Vector: vector, Score: score})
+		n++
+	}
+	// NVD API 2.0
+	for _, item := range doc.Vulnerabilities {
+		if v, s, ok := bestAPI2(item.CVE.Metrics); ok {
+			write(item.CVE.ID, v, s)
+		}
+	}
+	// Legacy 1.1 feed
+	for _, item := range doc.CVEItems {
+		if v := item.Impact.BaseMetricV3.CVSSV3.Vector; v != "" {
+			write(item.CVE.Meta.ID, v, item.Impact.BaseMetricV3.CVSSV3.Base)
+		} else if v := item.Impact.BaseMetricV2.CVSSV2.Vector; v != "" {
+			write(item.CVE.Meta.ID, v, item.Impact.BaseMetricV2.CVSSV2.Base)
+		}
+	}
+	return n, nil
+}
+
+// bestAPI2 picks the strongest CVSS metric from an API-2.0 metrics block (v3.1 > v3.0 > v2).
+func bestAPI2(m nvdMetrics) (string, float64, bool) {
+	for _, group := range [][]nvdMetric{m.V31, m.V30, m.V2} {
+		if len(group) > 0 && group[0].CVSSData.Vector != "" {
+			return group[0].CVSSData.Vector, group[0].CVSSData.Base, true
+		}
+	}
+	return "", 0, false
+}
+
+// --- NVD JSON shapes (only the CVSS-relevant subset) ---
+
+type nvdFeed struct {
+	Vulnerabilities []struct {
+		CVE struct {
+			ID      string     `json:"id"`
+			Metrics nvdMetrics `json:"metrics"`
+		} `json:"cve"`
+	} `json:"vulnerabilities"`
+	CVEItems []struct {
+		CVE struct {
+			Meta struct {
+				ID string `json:"ID"`
+			} `json:"CVE_data_meta"`
+		} `json:"cve"`
+		Impact struct {
+			BaseMetricV3 struct {
+				CVSSV3 struct {
+					Vector string  `json:"vectorString"`
+					Base   float64 `json:"baseScore"`
+				} `json:"cvssV3"`
+			} `json:"baseMetricV3"`
+			BaseMetricV2 struct {
+				CVSSV2 struct {
+					Vector string  `json:"vectorString"`
+					Base   float64 `json:"baseScore"`
+				} `json:"cvssV2"`
+			} `json:"baseMetricV2"`
+		} `json:"impact"`
+	} `json:"CVE_Items"`
+}
+
+type nvdMetrics struct {
+	V31 []nvdMetric `json:"cvssMetricV31"`
+	V30 []nvdMetric `json:"cvssMetricV30"`
+	V2  []nvdMetric `json:"cvssMetricV2"`
+}
+
+type nvdMetric struct {
+	CVSSData struct {
+		Vector string  `json:"vectorString"`
+		Base   float64 `json:"baseScore"`
+	} `json:"cvssData"`
+}

--- a/internal/infrastructure/tools/nvd/offline.go
+++ b/internal/infrastructure/tools/nvd/offline.go
@@ -1,0 +1,113 @@
+package nvd
+
+import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// OfflineEnricher backfills CVSS from a LOCAL NVD-derived database (built by BuildDB from the NVD
+// JSON feed). Unlike the online Enricher it needs no network and is not rate-limited, so it can fill
+// a real CVSS score for EVERY matching CVE — the airgapped path, and the way to give a large
+// dependency tree (whose OSV/GHSA advisories often carry only a severity label, no CVSS vector) the
+// CVSS numbers a commercial SCA report shows. It fills a MISSING CVSS vector/score and an UNKNOWN
+// severity; it never overrides a severity a detection source already set.
+type OfflineEnricher struct {
+	db map[string]cvss // CVE id (upper) -> CVSS
+}
+
+var _ ports.SeverityEnricher = (*OfflineEnricher)(nil)
+
+// dbEntry is one line of the CVSS DB (compact JSONL): id + CVSS vector + base score.
+type dbEntry struct {
+	ID     string  `json:"id"`
+	Vector string  `json:"v"`
+	Score  float64 `json:"s"`
+}
+
+// LoadOffline reads a CVSS DB (JSONL, optionally gzip-compressed) produced by BuildDB. Malformed
+// lines are skipped so a partially-corrupt DB still loads what it can (best-effort, never panics).
+func LoadOffline(path string) (*OfflineEnricher, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open cvss db: %w", err)
+	}
+	defer f.Close()
+
+	var r io.Reader = f
+	if strings.HasSuffix(strings.ToLower(path), ".gz") {
+		gz, gerr := gzip.NewReader(f)
+		if gerr != nil {
+			return nil, fmt.Errorf("gunzip cvss db: %w", gerr)
+		}
+		defer gz.Close()
+		r = gz
+	}
+
+	db := make(map[string]cvss, 1<<16)
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 1<<20), 8<<20) // long lines OK
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e dbEntry
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
+		id := cveID(e.ID)
+		if id == "" || strings.TrimSpace(e.Vector) == "" {
+			continue
+		}
+		db[id] = cvss{score: e.Score, vector: e.Vector}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("read cvss db: %w", err)
+	}
+	return &OfflineEnricher{db: db}, nil
+}
+
+// Size reports how many CVEs are loaded (diagnostic).
+func (o *OfflineEnricher) Size() int { return len(o.db) }
+
+// Enrich fills a missing CVSS vector/score (and an unknown severity) from the local DB. It is a
+// pure in-memory lookup, so it fills EVERY matching CVE regardless of scan size and ignores ctx
+// timeouts. A detection source's non-unknown severity is preserved.
+func (o *OfflineEnricher) Enrich(_ context.Context, vulns []vulnerability.Vulnerability) ports.SeverityResult {
+	res := ports.SeverityResult{Vulns: vulns, Source: "nvd-offline"}
+	if len(o.db) == 0 {
+		return res
+	}
+	for i := range vulns {
+		needVector := strings.TrimSpace(vulns[i].CVSSVector) == ""
+		needSeverity := vulns[i].Severity == shared.SeverityUnknown
+		if !needVector && !needSeverity {
+			continue
+		}
+		c, ok := o.db[cveID(vulns[i].ID)]
+		if !ok {
+			continue
+		}
+		if needVector {
+			vulns[i].CVSSVector = c.vector
+			if vulns[i].CVSSScore == 0 {
+				vulns[i].CVSSScore = c.score
+			}
+		}
+		if needSeverity {
+			vulns[i].Severity = shared.SeverityFromScore(c.score)
+		}
+		res.Matches++
+	}
+	return res
+}

--- a/internal/infrastructure/tools/nvd/offline_test.go
+++ b/internal/infrastructure/tools/nvd/offline_test.go
@@ -1,0 +1,96 @@
+package nvd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+)
+
+// api2 is a minimal NVD API-2.0 feed with a v3.1 metric and a v2-only CVE.
+const api2 = `{"vulnerabilities":[
+ {"cve":{"id":"CVE-2021-44228","metrics":{"cvssMetricV31":[{"cvssData":{"vectorString":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H","baseScore":10.0}}],"cvssMetricV2":[{"cvssData":{"vectorString":"AV:N/AC:M/Au:N/C:C/I:C/A:C","baseScore":9.3}}]}}},
+ {"cve":{"id":"CVE-2015-0001","metrics":{"cvssMetricV2":[{"cvssData":{"vectorString":"AV:L/AC:L/Au:N/C:N/I:N/A:C","baseScore":4.9}}]}}},
+ {"cve":{"id":"CVE-9999-0000","metrics":{}}}
+]}`
+
+// legacy11 is a minimal legacy NVD 1.1 feed.
+const legacy11 = `{"CVE_Items":[
+ {"cve":{"CVE_data_meta":{"ID":"CVE-2018-1000"}},"impact":{"baseMetricV3":{"cvssV3":{"vectorString":"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N","baseScore":7.5}}}}
+]}`
+
+func TestBuildDBBothFormats(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "api2.json")
+	f2 := filepath.Join(dir, "legacy.json")
+	os.WriteFile(f1, []byte(api2), 0o600)
+	os.WriteFile(f2, []byte(legacy11), 0o600)
+
+	var buf bytes.Buffer
+	n, err := BuildDB([]string{f1, f2}, &buf)
+	if err != nil {
+		t.Fatalf("BuildDB: %v", err)
+	}
+	// 2 from api2 (the empty-metrics CVE is skipped) + 1 from legacy = 3
+	if n != 3 {
+		t.Fatalf("want 3 entries, got %d\n%s", n, buf.String())
+	}
+	out := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte(`"id":"CVE-2021-44228"`)) || !bytes.Contains(buf.Bytes(), []byte(`CVSS:3.1/`)) {
+		t.Errorf("expected v3.1 vector preferred for log4shell, got: %s", out)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte(`"id":"CVE-2018-1000"`)) {
+		t.Errorf("expected legacy 1.1 CVE ingested, got: %s", out)
+	}
+}
+
+func TestOfflineEnrich(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.json")
+	os.WriteFile(src, []byte(api2+"\n"), 0o600)
+	dbPath := filepath.Join(dir, "cvss.jsonl")
+	out, _ := os.Create(dbPath)
+	if _, err := BuildDB([]string{src}, out); err != nil {
+		t.Fatal(err)
+	}
+	out.Close()
+
+	oe, err := LoadOffline(dbPath)
+	if err != nil {
+		t.Fatalf("LoadOffline: %v", err)
+	}
+	if oe.Size() != 2 {
+		t.Fatalf("want 2 CVEs loaded, got %d", oe.Size())
+	}
+
+	vulns := []vulnerability.Vulnerability{
+		{ID: "CVE-2021-44228", Severity: shared.SeverityHigh},                                 // known sev, no CVSS → fill vector, keep sev
+		{ID: "CVE-2015-0001", Severity: shared.SeverityUnknown},                               // unknown sev → fill sev from score
+		{ID: "CVE-2000-9999", Severity: shared.SeverityUnknown},                               // not in DB → untouched
+		{ID: "CVE-2021-44228", Severity: shared.SeverityLow, CVSSVector: "CVSS:3.1/EXISTING"}, // already has CVSS → untouched
+	}
+	res := oe.Enrich(context.Background(), vulns)
+
+	if vulns[0].CVSSVector == "" || vulns[0].Severity != shared.SeverityHigh {
+		t.Errorf("v0: want CVSS filled + severity preserved, got vec=%q sev=%q", vulns[0].CVSSVector, vulns[0].Severity)
+	}
+	if vulns[1].Severity == shared.SeverityUnknown {
+		t.Errorf("v1: unknown severity should be backfilled from CVSS score")
+	}
+	if vulns[2].CVSSVector != "" || vulns[2].Severity != shared.SeverityUnknown {
+		t.Errorf("v2: absent CVE must be untouched, got vec=%q sev=%q", vulns[2].CVSSVector, vulns[2].Severity)
+	}
+	if vulns[3].CVSSVector != "CVSS:3.1/EXISTING" || vulns[3].Severity != shared.SeverityLow {
+		t.Errorf("v3: existing CVSS/severity must be preserved, got vec=%q sev=%q", vulns[3].CVSSVector, vulns[3].Severity)
+	}
+	if res.Matches < 2 {
+		t.Errorf("want >=2 matches, got %d", res.Matches)
+	}
+	if res.Source != "nvd-offline" {
+		t.Errorf("want source nvd-offline, got %q", res.Source)
+	}
+}


### PR DESCRIPTION
## Why
Closes the last CVSS-parity gap vs a commercial SCA report. synapse's CVSS coverage is ~96% on OS/Go images, but drops to ~1% on massive Java/JS dependency trees (e.g. the doris image: 34,667 CVEs, only ~500 with a CVSS vector) — because OSV/GHSA advisories for those ecosystems carry only a severity **label**, no CVSS **vector**. The online NVD enricher can't fix this: it's rate-limited (5 req/30s anon) and only targets unknown-severity CVEs.

## What
An **offline** NVD CVSS path — no network, no rate limit, air-gapped-friendly:

- **`synapse-cli build-cvss-db <out.jsonl[.gz]> <nvd-*.json[.gz]...>`** — parse NVD JSON feeds (API 2.0 *and* legacy 1.1; gzip or plain) into a compact CVSS DB, preferring CVSS v3.1 > v3.0 > v2. Build it once from an NVD dump and ship it with the scanner.
- **`OfflineEnricher`** (`ports.SeverityEnricher`) — loads the DB and backfills a **missing** CVSS vector/score (and an **unknown** severity) for every matching CVE via an in-memory lookup. Never overrides a severity a detection source already set.
- The CLI **prefers** the offline DB when `SYNAPSE_NVD_CVSS_DB` is set (works even with `--offline`); falls back to the online NVD enricher otherwise.

## Proof
- Unit tests: both feed formats, v3.1/v2 preference, fill-vs-preserve rules.
- Live NVD: built a DB for 12 real CVEs a doris scan reported **without** CVSS (`CVE-2007-4559`, `CVE-2013-4312`, …) — all resolved to their real vectors/scores (v3.1 where present, v2 fallback). `synapse-cli scan … ` with `SYNAPSE_NVD_CVSS_DB` set (plain + gzip) wires it and logs `NVD offline CVSS DB ON (N CVEs)`.

Build + vet + tests green.
