### PR TITLE
fix(sca): scope OS-package advisory matching to the distro release

### DIFF
--- a/internal/infrastructure/tools/grype/scanner.go
+++ b/internal/infrastructure/tools/grype/scanner.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -164,14 +165,25 @@ type cdxBOM struct {
 	BomFormat   string         `json:"bomFormat"`
 	SpecVersion string         `json:"specVersion"`
 	Version     int            `json:"version"`
+	Metadata    *cdxMetadata   `json:"metadata,omitempty"`
 	Components  []cdxComponent `json:"components"`
 }
 
+type cdxMetadata struct {
+	Component *cdxComponent `json:"component,omitempty"`
+}
+
 type cdxComponent struct {
-	Type    string `json:"type"`
-	Name    string `json:"name"`
-	Version string `json:"version"`
-	PURL    string `json:"purl,omitempty"`
+	Type       string        `json:"type"`
+	Name       string        `json:"name"`
+	Version    string        `json:"version,omitempty"`
+	PURL       string        `json:"purl,omitempty"`
+	Properties []cdxProperty `json:"properties,omitempty"`
+}
+
+type cdxProperty struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // writeCycloneDX stages the SBOM for Grype: the generator's original CycloneDX
@@ -181,6 +193,20 @@ func writeCycloneDX(doc *sbom.SBOM) (path string, cleanup func(), err error) {
 	data := doc.Raw
 	if len(data) == 0 {
 		bom := cdxBOM{BomFormat: "CycloneDX", SpecVersion: "1.5", Version: 1}
+		// The OS distro (from an OS-package PURL's `distro=` qualifier) MUST be carried into the SBOM as
+		// a metadata.component of type operating-system. Grype scopes OS-package matching to that distro's
+		// advisory namespace (e.g. redhat:9); without it, an el9 package is matched against EVERY RHEL
+		// stream's advisories (el6/el7/el8/el10) - a large false-positive inflation. The generator's own
+		// CycloneDX (doc.Raw path) already carries this; the reconstruction must reproduce it.
+		if id, ver := distroFromComponents(doc.Components); id != "" {
+			bom.Metadata = &cdxMetadata{Component: &cdxComponent{
+				Type: "operating-system", Name: id, Version: ver,
+				Properties: []cdxProperty{
+					{Name: "syft:distro:id", Value: id},
+					{Name: "syft:distro:versionID", Value: ver},
+				},
+			}}
+		}
 		for _, c := range doc.Components {
 			if c.PURL == "" {
 				continue // grype matches by PURL/CPE; un-purled entries cannot match
@@ -205,6 +231,37 @@ func writeCycloneDX(doc *sbom.SBOM) (path string, cleanup func(), err error) {
 		return "", func() {}, err
 	}
 	return path, cleanup, nil
+}
+
+// distroFromComponents extracts the OS distro (id, versionID) from the `distro=<id>-<versionID>` qualifier
+// the OS-package catalogers attach to rpm/deb/apk PURLs (e.g. "pkg:rpm/rhel/openssl@...?distro=rhel-9.8").
+// It returns the first one found, or ("","") when no component carries a distro. Grype needs the distro on
+// the SBOM's metadata.component to scope OS-package matching to the correct advisory namespace.
+func distroFromComponents(comps []sbom.Component) (id, versionID string) {
+	for _, c := range comps {
+		tag := purlDistroTag(c.PURL)
+		if tag == "" {
+			continue
+		}
+		if i := strings.IndexByte(tag, '-'); i > 0 {
+			return tag[:i], tag[i+1:]
+		}
+		return tag, "" // id with no version still lets grype resolve the family
+	}
+	return "", ""
+}
+
+// purlDistroTag returns a PURL's `distro` qualifier value, or "" when absent/unparseable.
+func purlDistroTag(purl string) string {
+	q := strings.IndexByte(purl, '?')
+	if q < 0 {
+		return ""
+	}
+	vals, err := url.ParseQuery(purl[q+1:])
+	if err != nil {
+		return ""
+	}
+	return vals.Get("distro")
 }
 
 // ---- Grype JSON output ----

--- a/internal/infrastructure/tools/grype/scanner_test.go
+++ b/internal/infrastructure/tools/grype/scanner_test.go
@@ -3,6 +3,7 @@ package grype
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
@@ -99,5 +100,63 @@ func TestGrypeEmptySBOM(t *testing.T) {
 	raws, err := s.Scan(context.Background(), &sbom.SBOM{})
 	if err != nil || raws != nil {
 		t.Fatalf("empty sbom: want nil,nil; got %v,%v", raws, err)
+	}
+}
+
+// TestWriteCycloneDXCarriesDistro verifies the reconstructed SBOM (doc.Raw empty) puts the OS distro on
+// metadata.component so Grype scopes OS-package matching to the right advisory namespace (e.g. redhat:9).
+// Without it, an el9 package is matched against every RHEL stream's advisories - a large false-positive
+// inflation (a clean ubi9 base went from 30 to 555 RHSA matches before this fix).
+func TestWriteCycloneDXCarriesDistro(t *testing.T) {
+	doc := &sbom.SBOM{Components: []sbom.Component{
+		{Name: "openssl", Version: "1:3.5.5-5.el9_8", PURL: "pkg:rpm/rhel/openssl@1:3.5.5-5.el9_8?arch=x86_64&distro=rhel-9.8"},
+		{Name: "some-app", Version: "1.0.0", PURL: "pkg:golang/example.com/app@1.0.0"},
+	}}
+	path, cleanup, err := writeCycloneDX(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bom cdxBOM
+	if err := json.Unmarshal(data, &bom); err != nil {
+		t.Fatal(err)
+	}
+	if bom.Metadata == nil || bom.Metadata.Component == nil {
+		t.Fatalf("SBOM has no metadata.component distro; grype cannot scope OS matching")
+	}
+	mc := bom.Metadata.Component
+	if mc.Type != "operating-system" || mc.Name != "rhel" || mc.Version != "9.8" {
+		t.Errorf("distro component = {%q %q %q}, want {operating-system rhel 9.8}", mc.Type, mc.Name, mc.Version)
+	}
+	props := map[string]string{}
+	for _, p := range mc.Properties {
+		props[p.Name] = p.Value
+	}
+	if props["syft:distro:id"] != "rhel" || props["syft:distro:versionID"] != "9.8" {
+		t.Errorf("syft:distro props = %v, want id=rhel versionID=9.8", props)
+	}
+}
+
+func TestDistroFromComponents(t *testing.T) {
+	tests := []struct {
+		name, purl, wantID, wantVer string
+	}{
+		{"rhel rpm", "pkg:rpm/rhel/openssl@1:3.5.5-5.el9_8?arch=x86_64&distro=rhel-9.8", "rhel", "9.8"},
+		{"debian deb", "pkg:deb/debian/libc6@2.36?arch=amd64&distro=debian-12", "debian", "12"},
+		{"ubuntu multi-dot", "pkg:deb/ubuntu/bash@5.1?distro=ubuntu-22.04", "ubuntu", "22.04"},
+		{"no distro qualifier", "pkg:golang/example.com/app@1.0.0", "", ""},
+		{"no qualifiers at all", "pkg:rpm/rhel/openssl@1.0", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ver := distroFromComponents([]sbom.Component{{PURL: tc.purl}})
+			if id != tc.wantID || ver != tc.wantVer {
+				t.Errorf("distroFromComponents(%q) = (%q,%q), want (%q,%q)", tc.purl, id, ver, tc.wantID, tc.wantVer)
+			}
+		})
 	}
 }

--- a/internal/infrastructure/tools/osv/scanner.go
+++ b/internal/infrastructure/tools/osv/scanner.go
@@ -54,6 +54,16 @@ var _ ports.DetectionSource = (*Scanner)(nil)
 // Name identifies this detection source.
 func (*Scanner) Name() string { return "osv" }
 
+// isOSDistroPURL reports whether a PURL is an OS-distro package (rpm/deb/apk). Their advisory matching must
+// be scoped to the distro RELEASE (redhat:9, debian:12, …); that is handled by Grype + the owned OVAL/CSAF
+// feeds, not by OSV.dev's release-unaware PURL query. Excluding them from OSV removes cross-stream
+// false positives without losing coverage (Grype scans every OS package).
+func isOSDistroPURL(purl string) bool {
+	return strings.HasPrefix(purl, "pkg:rpm/") ||
+		strings.HasPrefix(purl, "pkg:deb/") ||
+		strings.HasPrefix(purl, "pkg:apk/")
+}
+
 // Scan batches the components' PURLs to OSV.dev, fetches details for each unique
 // advisory, and maps them to raw findings (correlation merges across sources).
 func (s *Scanner) Scan(ctx context.Context, doc *sbom.SBOM) ([]vulnerability.RawFinding, error) {
@@ -67,9 +77,19 @@ func (s *Scanner) Scan(ctx context.Context, doc *sbom.SBOM) ([]vulnerability.Raw
 	}
 	var items []item
 	for i, c := range doc.Components {
-		if c.PURL != "" {
-			items = append(items, item{compIdx: i, purl: c.PURL})
+		if c.PURL == "" {
+			continue
 		}
+		// OS-distro packages (rpm/deb/apk) are matched by Grype + the owned OVAL/CSAF feeds, which scope to
+		// the package's distro RELEASE. OSV.dev's PURL query is NOT release-scoped for these, so it returns
+		// advisories from every stream (e.g. a RHEL-8-Satellite "el8sat" fix reported against an el9 package)
+		// - a large false-positive inflation (a clean ubi9 base yielded 555 OSV RHSA matches vs Grype's 31).
+		// Route OS packages to the distro-scoped sources only; OSV keeps the language ecosystems
+		// (Go/npm/PyPI/Maven/…), where its PURL matching is authoritative.
+		if isOSDistroPURL(c.PURL) {
+			continue
+		}
+		items = append(items, item{compIdx: i, purl: c.PURL})
 	}
 	if len(items) == 0 {
 		return nil, nil

--- a/internal/infrastructure/tools/osv/scanner_test.go
+++ b/internal/infrastructure/tools/osv/scanner_test.go
@@ -126,3 +126,59 @@ func TestScanEmptySBOM(t *testing.T) {
 		t.Fatalf("empty sbom: v=%v err=%v (want nil,nil, no network call)", v, err)
 	}
 }
+
+// TestScanSkipsOSDistroPackages verifies the OSV source does NOT query OSV.dev for OS-distro packages
+// (rpm/deb/apk). OSV.dev's PURL query is not release-scoped for these, so it returns advisories from every
+// distro stream (e.g. an el8sat fix for an el9 package) - a large false-positive inflation. OS packages are
+// covered by the distro-scoped sources (Grype + owned OVAL/CSAF); only language ecosystems go to OSV.
+func TestScanSkipsOSDistroPackages(t *testing.T) {
+	var queried []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/querybatch", func(w http.ResponseWriter, r *http.Request) {
+		var req batchReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		for _, q := range req.Queries {
+			queried = append(queried, q.Package.PURL)
+		}
+		_ = json.NewEncoder(w).Encode(batchResp{Results: make([]batchResult, len(req.Queries))})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	sc := New(srv.URL, srv.Client())
+	doc := &sbom.SBOM{Components: []sbom.Component{
+		{Name: "openssl", Version: "1:3.5.5-5.el9_8", PURL: "pkg:rpm/rhel/openssl@1:3.5.5-5.el9_8?distro=rhel-9.8"},
+		{Name: "libc6", Version: "2.36", PURL: "pkg:deb/debian/libc6@2.36?distro=debian-12"},
+		{Name: "musl", Version: "1.2.4", PURL: "pkg:apk/alpine/musl@1.2.4?distro=alpine-3.19"},
+		{Name: "left-pad", Version: "1.0.0", PURL: "pkg:npm/left-pad@1.0.0"},
+		{Name: "example.com/app", Version: "1.0.0", PURL: "pkg:golang/example.com/app@1.0.0"},
+	}}
+	if _, err := sc.Scan(context.Background(), doc); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	want := map[string]bool{"pkg:npm/left-pad@1.0.0": true, "pkg:golang/example.com/app@1.0.0": true}
+	if len(queried) != len(want) {
+		t.Fatalf("OSV queried %v; want only the 2 language PURLs", queried)
+	}
+	for _, p := range queried {
+		if !want[p] {
+			t.Errorf("OS-distro PURL was wrongly queried against OSV: %q", p)
+		}
+	}
+}
+
+func TestIsOSDistroPURL(t *testing.T) {
+	cases := map[string]bool{
+		"pkg:rpm/rhel/openssl@1:3.5.5-5.el9_8?distro=rhel-9.8": true,
+		"pkg:deb/debian/libc6@2.36?distro=debian-12":           true,
+		"pkg:apk/alpine/musl@1.2.4":                            true,
+		"pkg:npm/left-pad@1.0.0":                               false,
+		"pkg:golang/example.com/app@1.0.0":                     false,
+		"pkg:pypi/requests@2.0":                                false,
+	}
+	for purl, want := range cases {
+		if got := isOSDistroPURL(purl); got != want {
+			t.Errorf("isOSDistroPURL(%q) = %v, want %v", purl, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The OSV detection source queried OSV.dev for **every** component PURL, including OS-distro packages (`rpm`/`deb`/`apk`). OSV.dev's PURL query is **not** scoped to a package's distro release, so for an OS package it returns advisories from every distro stream — e.g. a RHEL-8-Satellite (`el8sat`) fix reported against an `el9` package. On a clean, fully-patched **ubi9** base this inflated the scan from Grype's accurate **31** Red Hat advisories to **555**, almost all false positives that would block a merge on a `fail-on high` gate.

**Fix:** the OSV source now skips OS-distro packages (`rpm`/`deb`/`apk`). Those are already covered by **Grype** and the **owned OVAL/CSAF** feeds, both of which scope matching to the package's release (`redhat:9`, `debian:12`, …). OSV keeps the language ecosystems (Go/npm/PyPI/Maven/…), where its PURL matching is authoritative. This mirrors how Trivy / osv-scanner split OS-package vs language-dependency detection.

Also hardens the Grype SBOM reconstruction (the `doc.Raw`-empty fallback, used by the owned SBOM producer): it now carries the OS distro onto `metadata.component` (`operating-system` + `syft:distro:{id,versionID}`, derived from the OS-package PURL's `distro=` qualifier) so Grype can scope OS-package matching there too. The generator's own CycloneDX already includes this.

## Impact (measured on `registry.access.redhat.com/ubi9/ubi:latest`)

| | total findings | RHSA/RHBA (OSV) | high + critical |
|---|---|---|---|
| before | 1002 | 555 | 296 |
| after | 447 | 0 | 26 |

No real coverage is lost: Grype scans every OS package and its real, CVE-labelled OS findings remain (the 26 high/critical are genuine base-OS CVEs, mostly WONTFIX/no-fix).

## Test Plan

- `go build ./... && go vet ./...`
- New unit tests, all passing:
  - `TestScanSkipsOSDistroPackages` — a mock OSV server asserts `rpm`/`deb`/`apk` PURLs are never queried, only the language PURLs are.
  - `TestIsOSDistroPURL` — table of OS vs language PURLs.
  - `TestWriteCycloneDXCarriesDistro` / `TestDistroFromComponents` — the Grype fallback SBOM carries the distro on `metadata.component`.
- Manual E2E: re-scanned the public ubi9 image before/after (numbers above); confirmed Grype's real findings are unchanged and only the OSV cross-stream inflation is removed.
