### PR TITLE
fix(sca): read accepted-risk policy from the CI repo for image scans

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1328,7 +1328,16 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		return fmt.Errorf("register ephemeral engagement: %w", err)
 	}
 
-	res, err := sca.ScanWithOptions(ctx, "synapse-cli", eng.ID, ports.AcquireRequest{Kind: acqKind, Value: target}, scauc.ScanOptions{Mode: mode, DetectionPriority: priority})
+	// For an image scan the workspace is the materialized image, which does not carry the CI repo's
+	// accepted-risk policy (.synapseignore / OpenVEX). Read that policy from the invocation CWD (the
+	// checked-out repo) instead. Source scans leave PolicyDir empty (policy travels with the scanned tree).
+	policyDir := ""
+	if image {
+		if cwd, werr := os.Getwd(); werr == nil {
+			policyDir = cwd
+		}
+	}
+	res, err := sca.ScanWithOptions(ctx, "synapse-cli", eng.ID, ports.AcquireRequest{Kind: acqKind, Value: target}, scauc.ScanOptions{Mode: mode, DetectionPriority: priority, PolicyDir: policyDir})
 	if err != nil {
 		return fmt.Errorf("scan: %w", err)
 	}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -598,6 +598,11 @@ const (
 
 type ScanOptions struct {
 	Mode string `json:"mode"`
+	// PolicyDir overrides where the repo-committed accepted-risk policy (.synapseignore / OpenVEX) is read
+	// from. Empty ⇒ the scanned workspace (ws.Dir), correct for a source/repo scan where the policy travels
+	// with the code. For an IMAGE scan the workspace is the materialized image, which does NOT carry the
+	// operator's CI-repo governance, so the CLI sets this to the invocation CWD (the checked-out repo).
+	PolicyDir string `json:"policy_dir,omitempty"`
 	// DetectionPriority selects comprehensive (default) or precise; see the Detection* consts.
 	DetectionPriority string                  `json:"detection_priority,omitempty"`
 	CodeQuality       bool                    `json:"code_quality,omitempty"`
@@ -2194,8 +2199,14 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	// accepted-risk (SuppressedFindings) so a CI --fail-on gate can exempt them, but does NOT remove them:
 	// they stay reported, persisted, and evidence-sealed, so an acceptance can never hide a finding from a
 	// deliverable or the tamper-evident record. Expired/malformed rules are surfaced, not applied. Best-effort.
+	// The accepted-risk policy is CI-repo governance: read it from opts.PolicyDir when set (the invocation
+	// CWD for an image scan), else from the scanned workspace (a source/repo scan carries its own policy).
+	policyDir := ws.Dir
+	if opts.PolicyDir != "" {
+		policyDir = opts.PolicyDir
+	}
 	if s.suppression != nil {
-		if set, serr := s.suppression.Load(ctx, ws.Dir); serr == nil {
+		if set, serr := s.suppression.Load(ctx, policyDir); serr == nil {
 			applySuppressions(result, set, now)
 		}
 	}
@@ -2203,7 +2214,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	// accepted-risk on the SAME surface (gate-exempt, still reported + sealed). A malformed doc is surfaced,
 	// not silently ignored, and fail-safe (nothing suppressed).
 	if s.vexLoader != nil {
-		if doc, verr := s.vexLoader.Load(ctx, ws.Dir); verr != nil {
+		if doc, verr := s.vexLoader.Load(ctx, policyDir); verr != nil {
 			result.SourceWarnings = append(result.SourceWarnings, "in-repo VEX (.synapse.vex.json) was not applied (unreadable or not a valid OpenVEX document)")
 		} else {
 			applyVEX(result, doc)


### PR DESCRIPTION
## Summary

The repo-committed accepted-risk policy (`.synapseignore` / OpenVEX `.synapse.vex.json`) was loaded from the scanned workspace `ws.Dir`. That's correct for a **source** scan (the policy travels with the code), but for an **image** scan `ws.Dir` is the materialized image — which does not carry the operator's CI-repo governance. So a repo's `.synapseignore` was **silently never applied to image scans**, and a CI image gate had no way to accept a documented, unfixable-upstream CVE.

Fix: add `ScanOptions.PolicyDir`; the CLI sets it to the invocation **CWD** (the checked-out CI repo) for image scans, leaving source scans unchanged (empty ⇒ `ws.Dir`). Accepted-risk findings are still reported + evidence-sealed with expiry/justification — only their `--fail-on` exemption now works for image gates.

## Test Plan

- `go build ./... && go vet ./... && go test ./internal/usecase/sca/...` — green.
- Manual E2E: `synapse-cli scan <image.tar> --image` from a CWD containing a `.synapseignore` now reports `accepted-risk via .synapseignore: N (still reported + evidence-sealed; exempt from --fail-on)` and the listed CVE no longer trips `--fail-on` — verified on a real image with a pillow CVE. Without the flag (source scan) behavior is unchanged.
