### PR TITLE
fix(sca): don't gate on advisories for unknown-version components

### DIFF
--- a/internal/usecase/sca/findings_test.go
+++ b/internal/usecase/sca/findings_test.go
@@ -262,3 +262,35 @@ func TestBuildSecretFindings(t *testing.T) {
 		t.Errorf("DedupKey = %q, want 'secret:aws-key:main.go:10'", f.DedupKey)
 	}
 }
+
+// TestClassifyVulns_UnversionedClearsFix verifies that a vulnerability matched to a component with no
+// resolvable installed version (e.g. a vendored dep whose package.json has the version stripped, like
+// Next.js dist/compiled/*) is marked Unversioned and has its FixedVersion cleared — so --ignore-unfixed
+// keeps it out of the actionable gate instead of matching every historical CVE for the bare name. A
+// component WITH a resolvable version keeps its fix and gates normally.
+func TestClassifyVulns_UnversionedClearsFix(t *testing.T) {
+	doc := &sbom.SBOM{}
+	vulns := []vulnerability.Vulnerability{
+		{ID: "CVE-2015-8860", Component: "tar", Version: "", FixedVersion: "2.0.0", FixState: "fixed", Severity: shared.SeverityHigh},
+		{ID: "CVE-2026-64642", Component: "next", Version: "16.2.10", FixedVersion: "16.2.11", FixState: "fixed", Severity: shared.SeverityHigh},
+	}
+	classifyVulns(doc, vulns)
+
+	// Unversioned dep: fix cleared, so ignore-unfixed drops it from the gate.
+	if !vulns[0].Unversioned {
+		t.Errorf("tar (empty version) should be Unversioned")
+	}
+	if vulns[0].FixedVersion != "" {
+		t.Errorf("tar FixedVersion should be cleared (unconfirmable), got %q", vulns[0].FixedVersion)
+	}
+	if vulns[0].FixState == "fixed" {
+		t.Errorf("tar FixState should not remain %q for an unversioned match", vulns[0].FixState)
+	}
+	// Resolved-version dep: keeps its real fix and gates.
+	if vulns[1].Unversioned {
+		t.Errorf("next@16.2.10 should NOT be Unversioned")
+	}
+	if vulns[1].FixedVersion != "16.2.11" {
+		t.Errorf("next FixedVersion should be preserved, got %q", vulns[1].FixedVersion)
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -2455,6 +2455,18 @@ func classifyVulns(doc *sbom.SBOM, vulns []vulnerability.Vulnerability) {
 	for i := range vulns {
 		v := &vulns[i]
 		v.Unversioned = !sbom.IsResolvedVersion(v.Version)
+		if v.Unversioned {
+			// No resolvable installed version → the advisory cannot be confirmed to apply (the
+			// source matched by NAME only, e.g. a vendored dep whose package.json has the version
+			// stripped, like Next.js dist/compiled/*). A "fixed in X" is not actionable without a
+			// known current version, so drop it: the finding stays as a historical/informational
+			// advisory (ClassFirstPartyHistoric) but is treated as no-fix, so --ignore-unfixed keeps
+			// it out of the actionable gate instead of matching every historical CVE for the name.
+			v.FixedVersion = ""
+			if v.FixState == "fixed" {
+				v.FixState = "unknown"
+			}
+		}
 		if firstParty[v.Component] {
 			v.FirstParty = true
 		}


### PR DESCRIPTION
## Summary
A component matched by NAME only (no resolvable installed version) can't be confirmed vulnerable — there's no version to compare to the affected range. Vendored deps that ship a version-stripped package.json (Next.js `dist/compiled/*`: tar/ws/jsonwebtoken/semver/…) match **every historical CVE** for the bare name → dozens of false 'fixable high+' findings that block the gate (a portal image showed **35**).

`classifyVulns` already marks these `Unversioned` (ClassFirstPartyHistoric — 'historical, not actionable'), but they kept a `FixedVersion`, so `--ignore-unfixed` didn't drop them and the gate still counted them. Clear `FixedVersion` (+ demote FixState) for unversioned vulns → they stay recorded as informational but are treated as no-fix, kept out of the actionable gate. Resolved-version components are unaffected (real CVEs still gate).

## Test Plan
- `go build ./... && go vet ./... && go test ./internal/usecase/sca/...` green.
- New unit test `TestClassifyVulns_UnversionedClearsFix`: an empty-version `tar` finding with a fixed version is marked Unversioned + FixedVersion cleared; a resolved `next@16.2.10` keeps its fix.