### PR TITLE
feat(sca): scan standalone .rpm/.deb/.msi package files

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -61,6 +61,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/licensemeta"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifest"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifestresolve"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/msi"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavencoord"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
@@ -559,6 +560,7 @@ func main() {
 	scaService.SetImportedSBOMStore(importedSBOMStore)
 	scaService.SetGateDecoder(qualityprofile.LoadGateBytes)
 	scaService.SetSBOMEnricher(manifest.New())
+	scaService.SetArtifactCataloger(msi.New()) // recover Windows Installer (.msi) product identity into the SBOM
 	scaService.SetMavenCoordResolver(mavencoord.New())   // recover real Maven coords from JAR pom.properties (offline) before license lookup
 	scaService.SetJarChecksumResolver(jarchecksum.New()) // capture JAR artifact SHA-1 from the workspace (Syft omits it from CycloneDX)
 	// SHA-1 coordinate recovery for shaded/metadata-less JARs: offline trivy-java-db-format

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -56,6 +56,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/licensemeta"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifest"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/manifestresolve"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/msi"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavencoord"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/mavenresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
@@ -1150,6 +1151,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	)
 	sca.SetGateDecoder(qualityprofile.LoadGateBytes)
 	sca.SetSBOMEnricher(manifest.New())
+	sca.SetArtifactCataloger(msi.New()) // recover Windows Installer (.msi) product identity into the SBOM
 	sca.SetMavenCoordResolver(mavencoord.New())   // recover real Maven coords from JAR pom.properties (offline) before license lookup
 	sca.SetJarChecksumResolver(jarchecksum.New()) // capture JAR artifact SHA-1 from the workspace (Syft omits it from CycloneDX)
 	// SHA-1 coordinate recovery for shaded/metadata-less JARs: offline trivy-java-db index

--- a/internal/infrastructure/acquire/acquirer.go
+++ b/internal/infrastructure/acquire/acquirer.go
@@ -122,6 +122,13 @@ func acquireLocal(value string, maxBytes int64) (*ports.Workspace, error) {
 	if fi.Mode()&fs.ModeSymlink != 0 {
 		return nil, fmt.Errorf("%w: target path is a symlink", shared.ErrValidation)
 	}
+	// A single-file target (e.g. a .rpm / .deb / .msi / .jar package artifact) is staged into a fresh
+	// workspace directory so the catalogers — which walk a directory — can process it. This lets Syft's
+	// rpm-archive / deb-archive / java-archive catalogers (and the owned MSI cataloger) identify a loose
+	// package for a supply-chain / pre-install scan, not only packages already installed in an image.
+	if fi.Mode().IsRegular() {
+		return acquireFileArtifact(value, fi.Size(), maxBytes)
+	}
 	lockfiles, localModules, unresolved, err := inspectWorkspace(value, maxBytes)
 	if err != nil {
 		return nil, err
@@ -129,6 +136,59 @@ func acquireLocal(value string, maxBytes int64) (*ports.Workspace, error) {
 	// Scanned in place (no container isolation until P3); per-file symlink/special
 	// guards live in the detector, which re-walks this dir.
 	return &ports.Workspace{Dir: value, Lockfiles: lockfiles, LocalModules: localModules, UnresolvedEcosystems: unresolved}, nil
+}
+
+// acquireFileArtifact stages a single regular file into a temp workspace dir (bounded copy), so a loose
+// package artifact can be cataloged. The workspace carries a Cleanup that removes the temp dir.
+func acquireFileArtifact(value string, size, maxBytes int64) (*ports.Workspace, error) {
+	if maxBytes <= 0 {
+		maxBytes = MaxWorkspaceBytes
+	}
+	if size > maxBytes {
+		return nil, fmt.Errorf("%w: file %q (%d bytes) exceeds the workspace cap (%d bytes)", shared.ErrValidation, filepath.Base(value), size, maxBytes)
+	}
+	dir, err := os.MkdirTemp("", "synapse-ws-*")
+	if err != nil {
+		return nil, fmt.Errorf("stage file artifact: %w", err)
+	}
+	cleanup := func() error { return os.RemoveAll(dir) }
+	// Keep the original basename so extension-based catalogers (rpm/deb/msi/jar) recognize the artifact.
+	dst := filepath.Join(dir, filepath.Base(value))
+	if err := copyFileBounded(value, dst, maxBytes); err != nil {
+		_ = cleanup()
+		return nil, fmt.Errorf("stage file artifact: %w", err)
+	}
+	lockfiles, localModules, unresolved, err := inspectWorkspace(dir, maxBytes)
+	if err != nil {
+		_ = cleanup()
+		return nil, err
+	}
+	return &ports.Workspace{Dir: dir, Lockfiles: lockfiles, LocalModules: localModules, UnresolvedEcosystems: unresolved, Cleanup: cleanup}, nil
+}
+
+// copyFileBounded copies src to dst, failing if src exceeds maxBytes (defense against a size that changed
+// between stat and copy). dst is created 0600 under the caller's fresh temp dir.
+func copyFileBounded(src, dst string, maxBytes int64) error {
+	in, err := os.Open(src) // #nosec G304 -- caller-supplied scan target, opened read-only
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	n, err := io.Copy(out, io.LimitReader(in, maxBytes+1))
+	if cerr := out.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		return err
+	}
+	if n > maxBytes {
+		return fmt.Errorf("%w: file exceeds the workspace cap (%d bytes)", shared.ErrValidation, maxBytes)
+	}
+	return nil
 }
 
 func (a *Acquirer) acquireGit(ctx context.Context, url, ref string) (*ports.Workspace, error) {

--- a/internal/infrastructure/tools/grype/scanner.go
+++ b/internal/infrastructure/tools/grype/scanner.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -190,32 +191,33 @@ type cdxProperty struct {
 // when available (faithful, lossless), else a minimal reconstruction from the
 // parsed components (PURL-matched) as a fallback.
 func writeCycloneDX(doc *sbom.SBOM) (path string, cleanup func(), err error) {
+	// The OS distro lets Grype scope OS-package (rpm/deb/apk) matching to the right advisory namespace
+	// (redhat:8, …). Grype reads it from an operating-system COMPONENT (not metadata.component). We source
+	// it from an OS-package PURL's `distro=` qualifier (installed-OS scans) OR infer it from a standalone
+	// rpm's release suffix (a loose .rpm has no OS context, but `.el8`→redhat 8, `.fc39`→fedora 39, …).
+	id, ver := distroFromComponents(doc.Components)
 	data := doc.Raw
 	if len(data) == 0 {
 		bom := cdxBOM{BomFormat: "CycloneDX", SpecVersion: "1.5", Version: 1}
-		// The OS distro (from an OS-package PURL's `distro=` qualifier) MUST be carried into the SBOM as
-		// a metadata.component of type operating-system. Grype scopes OS-package matching to that distro's
-		// advisory namespace (e.g. redhat:9); without it, an el9 package is matched against EVERY RHEL
-		// stream's advisories (el6/el7/el8/el10) - a large false-positive inflation. The generator's own
-		// CycloneDX (doc.Raw path) already carries this; the reconstruction must reproduce it.
-		if id, ver := distroFromComponents(doc.Components); id != "" {
-			bom.Metadata = &cdxMetadata{Component: &cdxComponent{
-				Type: "operating-system", Name: id, Version: ver,
-				Properties: []cdxProperty{
-					{Name: "syft:distro:id", Value: id},
-					{Name: "syft:distro:versionID", Value: ver},
-				},
-			}}
-		}
 		for _, c := range doc.Components {
 			if c.PURL == "" {
 				continue // grype matches by PURL/CPE; un-purled entries cannot match
 			}
 			bom.Components = append(bom.Components, cdxComponent{Type: "library", Name: c.Name, Version: c.Version, PURL: c.PURL})
 		}
+		if id != "" {
+			bom.Components = append(bom.Components, osComponent(id, ver))
+		}
 		data, err = json.Marshal(bom)
 		if err != nil {
 			return "", func() {}, err
+		}
+	} else if id != "" {
+		// The generator's raw SBOM may lack an operating-system component (e.g. a standalone .rpm artifact
+		// has no installed-OS context). Inject the inferred distro so Grype can scope; a no-op if the raw
+		// already carries one (an image scan) or cannot be parsed.
+		if injected, ok := injectOSComponent(data, id, ver); ok {
+			data = injected
 		}
 	}
 	// A dedicated dir (not a bare /tmp file) so the sandbox can bind ONLY the SBOM
@@ -233,10 +235,11 @@ func writeCycloneDX(doc *sbom.SBOM) (path string, cleanup func(), err error) {
 	return path, cleanup, nil
 }
 
-// distroFromComponents extracts the OS distro (id, versionID) from the `distro=<id>-<versionID>` qualifier
-// the OS-package catalogers attach to rpm/deb/apk PURLs (e.g. "pkg:rpm/rhel/openssl@...?distro=rhel-9.8").
-// It returns the first one found, or ("","") when no component carries a distro. Grype needs the distro on
-// the SBOM's metadata.component to scope OS-package matching to the correct advisory namespace.
+// distroFromComponents determines the OS distro (id, versionID) for Grype scoping. It first uses the
+// `distro=<id>-<versionID>` qualifier the OS-package catalogers attach to rpm/deb/apk PURLs from an
+// INSTALLED OS (e.g. "…?distro=rhel-9.8"); failing that, it infers the distro from a standalone rpm's
+// release suffix (a loose .rpm carries no OS context, but its release encodes the target: `.el8`→rhel 8).
+// Returns ("","") when nothing indicates a distro.
 func distroFromComponents(comps []sbom.Component) (id, versionID string) {
 	for _, c := range comps {
 		tag := purlDistroTag(c.PURL)
@@ -248,7 +251,89 @@ func distroFromComponents(comps []sbom.Component) (id, versionID string) {
 		}
 		return tag, "" // id with no version still lets grype resolve the family
 	}
+	for _, c := range comps {
+		if !strings.HasPrefix(c.PURL, "pkg:rpm/") {
+			continue
+		}
+		if did, dver := distroFromRPMRelease(c.Version); did != "" {
+			return did, dver
+		}
+	}
 	return "", ""
+}
+
+// rpmReleaseDistroRE matches the distribution tag in an rpm release, e.g. the ".el8" in
+// "7.61.1-33.el8" / "7.61.1-33.el8_9". Only the mainstream, grype-supported families are mapped.
+var rpmReleaseDistroRE = regexp.MustCompile(`\.(el|fc|amzn)(\d+)`)
+
+// distroFromRPMRelease infers (grype distro id, versionID) from an rpm release suffix. el→rhel (grype maps
+// it to the redhat namespace), fc→fedora, amzn→amzn. Returns ("","") for an unrecognized/absent tag.
+func distroFromRPMRelease(version string) (id, versionID string) {
+	m := rpmReleaseDistroRE.FindStringSubmatch(version)
+	if m == nil {
+		return "", ""
+	}
+	switch m[1] {
+	case "el":
+		return "rhel", m[2]
+	case "fc":
+		return "fedora", m[2]
+	case "amzn":
+		return "amzn", m[2]
+	}
+	return "", ""
+}
+
+// osComponent builds a CycloneDX operating-system component carrying the syft:distro properties Grype reads
+// to scope OS-package matching. Grype keys on an operating-system COMPONENT in components[] (not
+// metadata.component), so this is appended to the components list.
+func osComponent(id, ver string) cdxComponent {
+	return cdxComponent{
+		Type: "operating-system", Name: id, Version: ver,
+		Properties: []cdxProperty{
+			{Name: "syft:distro:id", Value: id},
+			{Name: "syft:distro:versionID", Value: ver},
+		},
+	}
+}
+
+// injectOSComponent appends an operating-system component (with syft:distro properties) to a raw CycloneDX
+// document that has none, so Grype can scope OS-package matching for it. Returns (raw, false) unchanged when
+// the document already has an operating-system component or cannot be parsed (fail-safe: never corrupt it).
+func injectOSComponent(raw []byte, id, ver string) ([]byte, bool) {
+	var doc map[string]json.RawMessage
+	if json.Unmarshal(raw, &doc) != nil {
+		return raw, false
+	}
+	var comps []json.RawMessage
+	if c, ok := doc["components"]; ok {
+		if json.Unmarshal(c, &comps) != nil {
+			return raw, false
+		}
+	}
+	for _, c := range comps {
+		var probe struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(c, &probe) == nil && probe.Type == "operating-system" {
+			return raw, false // already scoped
+		}
+	}
+	osc, err := json.Marshal(osComponent(id, ver))
+	if err != nil {
+		return raw, false
+	}
+	comps = append(comps, osc)
+	cb, err := json.Marshal(comps)
+	if err != nil {
+		return raw, false
+	}
+	doc["components"] = cb
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return raw, false
+	}
+	return out, true
 }
 
 // purlDistroTag returns a PURL's `distro` qualifier value, or "" when absent/unparseable.

--- a/internal/infrastructure/tools/grype/scanner_test.go
+++ b/internal/infrastructure/tools/grype/scanner_test.go
@@ -125,19 +125,74 @@ func TestWriteCycloneDXCarriesDistro(t *testing.T) {
 	if err := json.Unmarshal(data, &bom); err != nil {
 		t.Fatal(err)
 	}
-	if bom.Metadata == nil || bom.Metadata.Component == nil {
-		t.Fatalf("SBOM has no metadata.component distro; grype cannot scope OS matching")
+	// Grype scopes OS-package matching from an operating-system COMPONENT in components[] (NOT
+	// metadata.component), so the distro must be injected there.
+	var osc *cdxComponent
+	for i := range bom.Components {
+		if bom.Components[i].Type == "operating-system" {
+			osc = &bom.Components[i]
+			break
+		}
 	}
-	mc := bom.Metadata.Component
-	if mc.Type != "operating-system" || mc.Name != "rhel" || mc.Version != "9.8" {
-		t.Errorf("distro component = {%q %q %q}, want {operating-system rhel 9.8}", mc.Type, mc.Name, mc.Version)
+	if osc == nil {
+		t.Fatalf("SBOM has no operating-system component; grype cannot scope OS matching")
+	}
+	if osc.Name != "rhel" || osc.Version != "9.8" {
+		t.Errorf("distro component = {%q %q}, want {rhel 9.8}", osc.Name, osc.Version)
 	}
 	props := map[string]string{}
-	for _, p := range mc.Properties {
+	for _, p := range osc.Properties {
 		props[p.Name] = p.Value
 	}
 	if props["syft:distro:id"] != "rhel" || props["syft:distro:versionID"] != "9.8" {
 		t.Errorf("syft:distro props = %v, want id=rhel versionID=9.8", props)
+	}
+}
+
+// TestDistroFromRPMRelease covers inferring the distro from a standalone rpm's release suffix (a loose
+// .rpm carries no distro= qualifier, but its release encodes the target distro), plus injecting it into a
+// raw SBOM that has no operating-system component.
+func TestDistroFromRPMRelease(t *testing.T) {
+	cases := map[string][2]string{
+		"7.61.1-33.el8":  {"rhel", "8"},
+		"0:1.2-3.el9_8":  {"rhel", "9"},
+		"2.0-1.fc39":     {"fedora", "39"},
+		"1.0-2.amzn2":    {"amzn", "2"},
+		"1.0-1":          {"", ""},       // no dist tag
+		"1.0-1.suse":     {"", ""},       // unmapped
+	}
+	for ver, want := range cases {
+		id, v := distroFromRPMRelease(ver)
+		if id != want[0] || v != want[1] {
+			t.Errorf("distroFromRPMRelease(%q) = (%q,%q), want (%q,%q)", ver, id, v, want[0], want[1])
+		}
+	}
+
+	// A standalone rpm (no distro= qualifier) gets its distro inferred + injected as an OS component.
+	doc := &sbom.SBOM{Components: []sbom.Component{
+		{Name: "curl", Version: "0:7.61.1-33.el8", PURL: "pkg:rpm/curl@7.61.1-33.el8?arch=x86_64&epoch=0"},
+	}}
+	if id, ver := distroFromComponents(doc.Components); id != "rhel" || ver != "8" {
+		t.Fatalf("distroFromComponents inference = (%q,%q), want (rhel,8)", id, ver)
+	}
+	path, cleanup, err := writeCycloneDX(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	data, _ := os.ReadFile(path)
+	var bom cdxBOM
+	if err := json.Unmarshal(data, &bom); err != nil {
+		t.Fatal(err)
+	}
+	hasOS := false
+	for _, c := range bom.Components {
+		if c.Type == "operating-system" && c.Name == "rhel" && c.Version == "8" {
+			hasOS = true
+		}
+	}
+	if !hasOS {
+		t.Errorf("standalone rpm SBOM missing inferred operating-system component (rhel 8): %+v", bom.Components)
 	}
 }
 

--- a/internal/infrastructure/tools/msi/cataloger.go
+++ b/internal/infrastructure/tools/msi/cataloger.go
@@ -1,0 +1,146 @@
+package msi
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Bounds for a directory walk (a scanned tree could be arbitrarily large / hostile).
+const (
+	maxMSIFiles   = 256
+	maxMSIFileLen = 512 << 20 // skip anything larger than 512 MiB (a real installer's tables are tiny)
+)
+
+// Cataloger discovers Windows Installer (.msi) artifacts under a workspace directory and recovers each
+// installer's product identity from its Property table, emitting one SBOM component per .msi. It never
+// executes an installer — it only reads compound-file bytes. Best-effort: an unreadable/corrupt .msi is
+// skipped, never fatal to the scan.
+type Cataloger struct{}
+
+var _ ports.ArtifactCataloger = (*Cataloger)(nil)
+
+// New returns a Cataloger.
+func New() *Cataloger { return &Cataloger{} }
+
+// CatalogArtifacts walks dir for *.msi files and returns a component for each one whose Property table
+// yields a product name. Directory-walk and per-file errors are swallowed (best-effort inventory); a
+// canceled context stops the walk.
+func (c *Cataloger) CatalogArtifacts(ctx context.Context, dir string) ([]sbom.Component, error) {
+	if dir == "" {
+		return nil, nil
+	}
+	var out []sbom.Component
+	seen := 0
+	// Capture the walk error: a canceled/timed-out scan must propagate (never report a partial catalog as
+	// success). Per-entry read errors are swallowed inside the callback, so the only non-nil return here is
+	// the context error.
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable entry: skip, keep walking
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		// Only regular files: skip dirs, and — critically — symlinks/devices/FIFOs. A planted
+		// `x.msi -> /dev/zero` would otherwise be read forever (OOM), and a FIFO would hang the scan.
+		// WalkDir does not follow symlinks, and d.Type() reports the link itself (from Lstat).
+		if !d.Type().IsRegular() || !strings.EqualFold(filepath.Ext(path), ".msi") {
+			return nil
+		}
+		if seen >= maxMSIFiles {
+			return filepath.SkipAll
+		}
+		seen++
+		if comp, ok := catalogFile(path, dir); ok {
+			out = append(out, comp)
+		}
+		return nil
+	})
+	return out, walkErr
+}
+
+// catalogFile parses one .msi and builds a component. ok is false when the file is too large, unreadable,
+// not a valid MSI, or carries no product name.
+func catalogFile(path, root string) (sbom.Component, bool) {
+	fi, err := os.Stat(path)
+	if err != nil || fi.Size() > maxMSIFileLen {
+		return sbom.Component{}, false
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path comes from a bounded WalkDir over the scan workspace
+	if err != nil {
+		return sbom.Component{}, false
+	}
+	info, err := Parse(data)
+	if err != nil {
+		return sbom.Component{}, false
+	}
+	name := info.ProductName
+	if name == "" {
+		return sbom.Component{}, false // no identity recovered — nothing useful to report
+	}
+	loc := path
+	if rel, rerr := filepath.Rel(root, path); rerr == nil {
+		loc = rel
+	}
+	comp := sbom.Component{
+		Name:     name,
+		Version:  info.ProductVersion,
+		PURL:     msiPURL(info),
+		Scope:    sbom.ScopeProduction,
+		Location: loc,
+	}
+	if info.Manufacturer != "" {
+		comp.Supplier = info.Manufacturer
+		comp.SupplierSource = sbom.SupplierDeclared // the MSI Property table is the product's own manifest
+	}
+	return comp, true
+}
+
+// msiPURL builds a best-effort package URL. There is no registered purl type for a Windows Installer product,
+// so we use the "generic" type namespaced by the (slugged) manufacturer — enough to identify + dedup the
+// artifact in the SBOM. (Generic PURLs are not advisory-matchable; an MSI is cataloged for inventory, not
+// CVE lookup, which has no reliable identifier for arbitrary installed products.)
+func msiPURL(info Info) string {
+	name := slug(info.ProductName)
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("pkg:generic/")
+	if ns := slug(info.Manufacturer); ns != "" {
+		b.WriteString(ns)
+		b.WriteString("/")
+	}
+	b.WriteString(name)
+	if v := strings.TrimSpace(info.ProductVersion); v != "" {
+		b.WriteString("@")
+		b.WriteString(v)
+	}
+	return b.String()
+}
+
+// slug lowercases and reduces a display string to a PURL-safe token (alphanumerics and '.', '-', '_';
+// runs of other characters collapse to a single '-').
+func slug(s string) string {
+	var b strings.Builder
+	dash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_':
+			b.WriteRune(r)
+			dash = false
+		default:
+			if !dash && b.Len() > 0 {
+				b.WriteRune('-')
+				dash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-._")
+}

--- a/internal/infrastructure/tools/msi/cataloger_test.go
+++ b/internal/infrastructure/tools/msi/cataloger_test.go
@@ -1,0 +1,72 @@
+package msi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCatalogArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	data := buildTestMSI(t, []kv{
+		{"ProductName", "GitHub CLI"},
+		{"ProductVersion", "2.62.0"},
+		{"Manufacturer", "GitHub, Inc."},
+	})
+	if err := os.WriteFile(filepath.Join(dir, "gh.msi"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A non-MSI file with a .msi extension must be skipped (best-effort, no crash).
+	if err := os.WriteFile(filepath.Join(dir, "bogus.msi"), []byte("not a compound file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A non-.msi file is ignored.
+	if err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	comps, err := New().CatalogArtifacts(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comps) != 1 {
+		t.Fatalf("want 1 component (bogus.msi skipped), got %d: %+v", len(comps), comps)
+	}
+	c := comps[0]
+	if c.Name != "GitHub CLI" || c.Version != "2.62.0" {
+		t.Errorf("component identity = %q@%q", c.Name, c.Version)
+	}
+	if c.Supplier != "GitHub, Inc." || c.SupplierSource == "" {
+		t.Errorf("supplier = %q (%q)", c.Supplier, c.SupplierSource)
+	}
+	if c.PURL != "pkg:generic/github-inc/github-cli@2.62.0" {
+		t.Errorf("purl = %q", c.PURL)
+	}
+	if c.Location != "gh.msi" {
+		t.Errorf("location = %q, want gh.msi", c.Location)
+	}
+}
+
+func TestCatalogArtifactsEmptyDir(t *testing.T) {
+	comps, err := New().CatalogArtifacts(context.Background(), t.TempDir())
+	if err != nil || comps != nil {
+		t.Fatalf("empty dir: want nil,nil; got %+v,%v", comps, err)
+	}
+}
+
+func TestSlug(t *testing.T) {
+	cases := map[string]string{
+		"GitHub, Inc.":  "github-inc",
+		"Acme Corp":     "acme-corp",
+		"7-Zip":         "7-zip",
+		"  Spaces  ":    "spaces",
+		"a/b\\c:d":      "a-b-c-d",
+		"node.js":       "node.js",
+	}
+	for in, want := range cases {
+		if got := slug(in); got != want {
+			t.Errorf("slug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/infrastructure/tools/msi/cfbf.go
+++ b/internal/infrastructure/tools/msi/cfbf.go
@@ -1,0 +1,282 @@
+// Package msi parses a Windows Installer (.msi) file — a pure-Go, dependency-free reader for the OLE2
+// Compound File Binary Format (MS-CFB) container plus the MSI table layout on top of it — to recover the
+// installed product's identity (name, version, manufacturer, product code) for cataloging. It resolves no
+// external resources and never executes the installer; it only reads bytes, with hard bounds throughout so
+// a crafted/corrupt file degrades to an error rather than exhausting memory or looping.
+package msi
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// Bounds (defense-in-depth against a hostile/corrupt compound file).
+const (
+	maxSectors    = 1 << 22 // 4M sectors (≥16 GiB at 4 KiB) — a sane ceiling for a scanned artifact
+	maxDirEntries = 1 << 20 // directory-entry cap
+	maxStreamSize = 64 << 20 // per-stream read cap (a real MSI table stream is far smaller)
+)
+
+const (
+	dirEntryLen  = 128
+	freeSect     = 0xFFFFFFFF
+	endOfChain   = 0xFFFFFFFE
+	fatSect      = 0xFFFFFFFD
+	objStream    = 2
+	objRootStore = 5
+)
+
+var cfbfSignature = []byte{0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1}
+
+// dirEntry is one compound-file directory entry (a storage, stream, or the root).
+type dirEntry struct {
+	name       string // decoded UTF-16 name (MSI-mangled for MSI tables; decoded separately)
+	objType    byte
+	startSect  uint32
+	size       uint64
+}
+
+// cfbf is a parsed compound file with random access to its streams by directory index.
+type cfbf struct {
+	data       []byte
+	sectorSize int
+	miniShift  uint
+	miniSize   int
+	miniCutoff uint32
+	fat        []uint32
+	miniFAT    []uint32
+	dir        []dirEntry
+	miniStream []byte // the root entry's stream (container of mini-sectors)
+}
+
+// openCFBF parses the compound-file structure (header, FAT/DIFAT, directory, mini FAT + mini stream).
+func openCFBF(data []byte) (*cfbf, error) {
+	if len(data) < 512 || !hasPrefix(data, cfbfSignature) {
+		return nil, errors.New("not an OLE2 compound file (bad signature)")
+	}
+	major := binary.LittleEndian.Uint16(data[26:28])
+	if binary.LittleEndian.Uint16(data[28:30]) != 0xFFFE {
+		return nil, errors.New("cfbf: unexpected byte order")
+	}
+	sectorShift := binary.LittleEndian.Uint16(data[30:32])
+	sectorSize := 1 << sectorShift
+	if (major == 3 && sectorSize != 512) || (major == 4 && sectorSize != 4096) || (sectorSize != 512 && sectorSize != 4096) {
+		return nil, fmt.Errorf("cfbf: bad sector size %d for major %d", sectorSize, major)
+	}
+	c := &cfbf{
+		data:       data,
+		sectorSize: sectorSize,
+		miniShift:  uint(binary.LittleEndian.Uint16(data[32:34])),
+		miniCutoff: binary.LittleEndian.Uint32(data[56:60]),
+	}
+	c.miniSize = 1 << c.miniShift
+	if c.miniSize != 64 { // MS-CFB fixes the mini-sector shift at 6 (64-byte mini sectors)
+		return nil, fmt.Errorf("cfbf: unexpected mini sector size %d", c.miniSize)
+	}
+
+	numFATSect := binary.LittleEndian.Uint32(data[44:48])
+	firstDirSect := binary.LittleEndian.Uint32(data[48:52])
+	firstMiniFATSect := binary.LittleEndian.Uint32(data[60:64])
+	numMiniFATSect := binary.LittleEndian.Uint32(data[64:68])
+	firstDIFATSect := binary.LittleEndian.Uint32(data[68:72])
+	numDIFATSect := binary.LittleEndian.Uint32(data[72:76])
+	// Header-declared sector counts are attacker-controlled; cap them before they drive any allocation or
+	// loop bound (a crafted count could otherwise force a multi-GiB make / billions of iterations).
+	if numFATSect > maxSectors || numDIFATSect > maxSectors || numMiniFATSect > maxSectors {
+		return nil, fmt.Errorf("cfbf: sector count exceeds cap (fat=%d difat=%d minifat=%d)", numFATSect, numDIFATSect, numMiniFATSect)
+	}
+
+	// DIFAT: 109 entries in the header, then chained DIFAT sectors (last u32 of each is the next).
+	difat := make([]uint32, 0, 109)
+	for i := 0; i < 109; i++ {
+		difat = append(difat, binary.LittleEndian.Uint32(data[76+i*4:80+i*4]))
+	}
+	sect := firstDIFATSect
+	for n, seen := uint32(0), 0; n < numDIFATSect && sect != endOfChain && sect != freeSect; n++ {
+		if seen++; seen > maxSectors {
+			return nil, errors.New("cfbf: DIFAT chain too long / cyclic")
+		}
+		buf, err := c.readSector(sect)
+		if err != nil {
+			return nil, err
+		}
+		perSect := sectorSize/4 - 1
+		for i := 0; i < perSect; i++ {
+			difat = append(difat, binary.LittleEndian.Uint32(buf[i*4:i*4+4]))
+		}
+		if len(difat) > maxSectors { // total FAT-sector pointers cannot exceed the sector cap
+			return nil, errors.New("cfbf: DIFAT too large")
+		}
+		sect = binary.LittleEndian.Uint32(buf[perSect*4:])
+	}
+
+	// FAT: concatenate the FAT sectors listed in the DIFAT. No capacity hint from the (untrusted) header —
+	// growth is bounded by readSector failing past EOF and by the DIFAT cap above.
+	c.fat = make([]uint32, 0)
+	for i, fs := 0, 0; i < len(difat) && fs < int(numFATSect); i++ {
+		if difat[i] == freeSect {
+			continue
+		}
+		buf, err := c.readSector(difat[i])
+		if err != nil {
+			return nil, err
+		}
+		for j := 0; j < sectorSize/4; j++ {
+			c.fat = append(c.fat, binary.LittleEndian.Uint32(buf[j*4:j*4+4]))
+		}
+		fs++
+	}
+
+	// Directory entries (chained via FAT from the first directory sector).
+	dirBytes, err := c.readChain(firstDirSect, 0)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.parseDir(dirBytes); err != nil {
+		return nil, err
+	}
+
+	// Mini FAT + mini stream (the root entry's stream is the mini-sector container).
+	if numMiniFATSect > 0 && firstMiniFATSect != endOfChain {
+		mfBytes, err := c.readChain(firstMiniFATSect, 0)
+		if err != nil {
+			return nil, err
+		}
+		c.miniFAT = make([]uint32, len(mfBytes)/4)
+		for i := range c.miniFAT {
+			c.miniFAT[i] = binary.LittleEndian.Uint32(mfBytes[i*4 : i*4+4])
+		}
+	}
+	if len(c.dir) > 0 && c.dir[0].objType == objRootStore && c.dir[0].size > 0 {
+		ms, err := c.readChain(c.dir[0].startSect, c.dir[0].size)
+		if err != nil {
+			return nil, err
+		}
+		c.miniStream = ms
+	}
+	return c, nil
+}
+
+func (c *cfbf) readSector(n uint32) ([]byte, error) {
+	if n > maxSectors {
+		return nil, fmt.Errorf("cfbf: sector %d exceeds cap", n)
+	}
+	off := (int(n) + 1) * c.sectorSize // header (or its padded first-sector region) precedes sector 0
+	if off < 0 || off+c.sectorSize > len(c.data) {
+		return nil, fmt.Errorf("cfbf: sector %d out of range", n)
+	}
+	return c.data[off : off+c.sectorSize], nil
+}
+
+// readChain reads a FAT sector chain starting at start. If limit>0 the result is truncated to limit bytes.
+func (c *cfbf) readChain(start uint32, limit uint64) ([]byte, error) {
+	var out []byte
+	seen := 0
+	for s := start; s != endOfChain && s != freeSect; {
+		if seen++; seen > maxSectors {
+			return nil, errors.New("cfbf: FAT chain too long / cyclic")
+		}
+		buf, err := c.readSector(s)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, buf...)
+		if uint64(len(out)) > maxStreamSize {
+			return nil, errors.New("cfbf: stream exceeds cap")
+		}
+		if int(s) >= len(c.fat) {
+			return nil, fmt.Errorf("cfbf: FAT index %d out of range", s)
+		}
+		s = c.fat[s]
+	}
+	if limit > 0 && uint64(len(out)) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// readMiniChain reads a mini-FAT chain from the mini stream (for streams below the cutoff).
+func (c *cfbf) readMiniChain(start uint32, size uint64) ([]byte, error) {
+	var out []byte
+	seen := 0
+	for s := start; s != endOfChain && s != freeSect; {
+		if seen++; seen > maxSectors {
+			return nil, errors.New("cfbf: mini chain too long / cyclic")
+		}
+		off := int(s) * c.miniSize
+		if off < 0 || off+c.miniSize > len(c.miniStream) {
+			return nil, fmt.Errorf("cfbf: mini sector %d out of range", s)
+		}
+		out = append(out, c.miniStream[off:off+c.miniSize]...)
+		if uint64(len(out)) > maxStreamSize {
+			return nil, errors.New("cfbf: mini stream exceeds cap")
+		}
+		if int(s) >= len(c.miniFAT) {
+			return nil, fmt.Errorf("cfbf: mini FAT index %d out of range", s)
+		}
+		s = c.miniFAT[s]
+	}
+	if size > 0 && uint64(len(out)) > size {
+		out = out[:size]
+	}
+	return out, nil
+}
+
+func (c *cfbf) parseDir(b []byte) error {
+	n := len(b) / dirEntryLen
+	if n > maxDirEntries {
+		return errors.New("cfbf: too many directory entries")
+	}
+	for i := 0; i < n; i++ {
+		e := b[i*dirEntryLen : (i+1)*dirEntryLen]
+		nameLen := int(binary.LittleEndian.Uint16(e[64:66]))
+		objType := e[66]
+		if objType == 0 { // unallocated
+			continue
+		}
+		name := ""
+		if nameLen >= 2 && nameLen <= 64 {
+			name = utf16LEString(e[0 : nameLen-2]) // strip the trailing UTF-16 null
+		}
+		c.dir = append(c.dir, dirEntry{
+			name:      name,
+			objType:   objType,
+			startSect: binary.LittleEndian.Uint32(e[116:120]),
+			size:      binary.LittleEndian.Uint64(e[120:128]),
+		})
+	}
+	return nil
+}
+
+// stream returns the bytes of the stream directory entry (regular FAT chain if size >= cutoff, else mini).
+func (c *cfbf) stream(e dirEntry) ([]byte, error) {
+	if e.objType != objStream {
+		return nil, fmt.Errorf("cfbf: %q is not a stream", e.name)
+	}
+	if e.size >= uint64(c.miniCutoff) {
+		return c.readChain(e.startSect, e.size)
+	}
+	return c.readMiniChain(e.startSect, e.size)
+}
+
+func hasPrefix(b, prefix []byte) bool {
+	if len(b) < len(prefix) {
+		return false
+	}
+	for i := range prefix {
+		if b[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// utf16LEString decodes little-endian UTF-16 bytes to a Go string (BMP + surrogate pairs).
+func utf16LEString(b []byte) string {
+	u := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		u = append(u, binary.LittleEndian.Uint16(b[i:i+2]))
+	}
+	return string(utf16Decode(u))
+}

--- a/internal/infrastructure/tools/msi/msi.go
+++ b/internal/infrastructure/tools/msi/msi.go
@@ -1,0 +1,176 @@
+package msi
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unicode/utf16"
+)
+
+// Info is the identity recovered from an MSI's Property table (the authoritative source). Fields are empty
+// when the installer does not set the corresponding property.
+type Info struct {
+	ProductName    string
+	ProductVersion string
+	Manufacturer   string
+	ProductCode    string // {GUID}
+	UpgradeCode    string // {GUID}
+}
+
+// mangleAlphabet is the 64-symbol set MSI uses to encode table/stream names into the compound-file
+// directory (each directory name is otherwise limited to a small set of chars).
+const mangleAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._"
+
+// maxStrings caps the interned string-table size (a 3-byte string ref addresses at most 16M strings; this
+// ceiling is well above any real MSI yet bounds a zero-length-entry amplification attack).
+const maxStrings = 4_000_000
+
+// Parse reads an MSI (.msi) file and returns the product Info from its Property table. It never resolves or
+// executes anything — it only decodes the compound-file bytes. A non-MSI / corrupt input returns an error.
+func Parse(data []byte) (Info, error) {
+	c, err := openCFBF(data)
+	if err != nil {
+		return Info{}, fmt.Errorf("msi: open compound file: %w", err)
+	}
+
+	// Resolve the MSI table streams by their DECODED (demangled) names.
+	var strData, strPool, prop []byte
+	for i := range c.dir {
+		e := c.dir[i]
+		if e.objType != objStream {
+			continue
+		}
+		switch decodeStreamName(e.name) {
+		case "_StringData":
+			if strData, err = c.stream(e); err != nil {
+				return Info{}, fmt.Errorf("read _StringData: %w", err)
+			}
+		case "_StringPool":
+			if strPool, err = c.stream(e); err != nil {
+				return Info{}, fmt.Errorf("read _StringPool: %w", err)
+			}
+		case "Property":
+			if prop, err = c.stream(e); err != nil {
+				return Info{}, fmt.Errorf("read Property: %w", err)
+			}
+		}
+	}
+	if strPool == nil || strData == nil {
+		return Info{}, fmt.Errorf("msi: string table not found (not a valid MSI database)")
+	}
+	if prop == nil {
+		return Info{}, fmt.Errorf("msi: Property table not found")
+	}
+
+	strings, err := loadStringTable(strPool, strData)
+	if err != nil {
+		return Info{}, err
+	}
+	props := parsePropertyTable(prop, strings)
+
+	return Info{
+		ProductName:    props["ProductName"],
+		ProductVersion: props["ProductVersion"],
+		Manufacturer:   props["Manufacturer"],
+		ProductCode:    props["ProductCode"],
+		UpgradeCode:    props["UpgradeCode"],
+	}, nil
+}
+
+// decodeStreamName demangles an MSI compound-file stream/table name (MS-CFB names are limited, so MSI packs
+// table names using mangleAlphabet). Characters outside the coded range (e.g. the \x05SummaryInformation
+// prefix, or already-literal names) pass through unchanged.
+func decodeStreamName(in string) string {
+	var out []rune
+	for _, ch := range in {
+		switch {
+		case ch == 0x4840: // "this is a table" sentinel prefix — carries no character
+			continue
+		case ch >= 0x3800 && ch < 0x4800: // two packed symbols
+			ch -= 0x3800
+			out = append(out, rune(mangleAlphabet[ch&0x3f]))
+			out = append(out, rune(mangleAlphabet[(ch>>6)&0x3f]))
+		case ch >= 0x4800 && ch < 0x4840: // one packed symbol
+			out = append(out, rune(mangleAlphabet[(ch-0x4800)&0x3f]))
+		default:
+			out = append(out, ch)
+		}
+	}
+	return string(out)
+}
+
+// loadStringTable rebuilds the interned string table from _StringPool (per-string length+refcount entries)
+// and _StringData (the concatenated string bytes). String index 0 is the empty string; index i (1-based)
+// is the i-th string. A zero-size entry with a non-zero refcount is a >64 KiB "long string" spanning two
+// pool entries. All slices are bounds-checked (a corrupt pool/data yields an error, never a panic).
+func loadStringTable(pool, data []byte) ([]string, error) {
+	strs := []string{""} // index 0 = empty
+	offset := 0
+	// The first 4-byte pool entry is a header (codepage); real strings start at the second entry.
+	for pos := 4; pos+4 <= len(pool); pos += 4 {
+		if len(strs) > maxStrings { // cap the interned-string count (defends against a zero-length-entry flood)
+			return nil, fmt.Errorf("msi: string table exceeds %d entries", maxStrings)
+		}
+		size := int(binary.LittleEndian.Uint16(pool[pos : pos+2]))
+		refcount := binary.LittleEndian.Uint16(pool[pos+2 : pos+4])
+		length := size
+		if size == 0 && refcount != 0 {
+			// long string: total length = (refcount << 16) | (next entry's size field)
+			pos += 4
+			if pos+4 > len(pool) {
+				break
+			}
+			low := int(binary.LittleEndian.Uint16(pool[pos : pos+2]))
+			length = int(refcount)<<16 | low
+		}
+		if length < 0 || offset+length > len(data) {
+			return nil, fmt.Errorf("msi: string table overruns _StringData (offset %d + %d > %d)", offset, length, len(data))
+		}
+		strs = append(strs, string(data[offset:offset+length]))
+		offset += length
+	}
+	return strs, nil
+}
+
+// parsePropertyTable decodes the MSI Property table stream into a name→value map. The table has two string
+// columns (Property, Value); MSI stores rows COLUMN-major, each cell a 2-byte (or 3-byte, when the pool has
+// >0xFFFF strings) index into the string table. Out-of-range indices are skipped defensively.
+func parsePropertyTable(stream []byte, strs []string) map[string]string {
+	refSize := 2
+	if len(strs) > 0xFFFF {
+		refSize = 3
+	}
+	rowBytes := 2 * refSize
+	if rowBytes == 0 || len(stream) < rowBytes {
+		return map[string]string{}
+	}
+	rows := len(stream) / rowBytes
+	ref := func(base, row int) int {
+		off := base + row*refSize
+		if off+refSize > len(stream) {
+			return 0
+		}
+		if refSize == 3 {
+			return int(stream[off]) | int(stream[off+1])<<8 | int(stream[off+2])<<16
+		}
+		return int(binary.LittleEndian.Uint16(stream[off : off+2]))
+	}
+	get := func(i int) string {
+		if i >= 0 && i < len(strs) {
+			return strs[i]
+		}
+		return ""
+	}
+	out := make(map[string]string, rows)
+	valBase := rows * refSize // column-major: all Property refs, then all Value refs
+	for r := 0; r < rows; r++ {
+		name := get(ref(0, r))
+		if name == "" {
+			continue
+		}
+		out[name] = get(ref(valBase, r))
+	}
+	return out
+}
+
+// utf16Decode converts a UTF-16 code-unit sequence (BMP + surrogate pairs) to runes.
+func utf16Decode(u []uint16) []rune { return utf16.Decode(u) }

--- a/internal/infrastructure/tools/msi/msi_test.go
+++ b/internal/infrastructure/tools/msi/msi_test.go
@@ -1,0 +1,277 @@
+package msi
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestDecodeStreamName(t *testing.T) {
+	// Plain ASCII / literal names pass through unchanged (chars below the coded range).
+	if got := decodeStreamName("cab1.cab"); got != "cab1.cab" {
+		t.Errorf("literal name = %q, want cab1.cab", got)
+	}
+	// The \x05SummaryInformation stream: a \x05 prefix (literal, below the coded range) + literal name.
+	if got := decodeStreamName("\x05SummaryInformation"); got != "\x05SummaryInformation" {
+		t.Errorf("summary name = %q", got)
+	}
+	// A real MSI-mangled table name from a WiX installer: U+4840 (table sentinel) + coded pairs → "Property".
+	mangled := string([]rune{0x4840, 0x4559, 0x44F2, 0x4568, 0x4737})
+	if got := decodeStreamName(mangled); got != "Property" {
+		t.Errorf("mangled Property = %q, want Property", got)
+	}
+	// "_Validation": U+4840 sentinel + U+3FFF ("_V") + ...
+	val := string([]rune{0x4840, 0x3FFF, 0x43E4, 0x41EC, 0x45E4, 0x44AC, 0x4831})
+	if got := decodeStreamName(val); got != "_Validation" {
+		t.Errorf("mangled _Validation = %q, want _Validation", got)
+	}
+}
+
+func TestLoadStringTable(t *testing.T) {
+	// Two strings "GitHub CLI" (10) and "2.62.0" (6): pool = header + two length/refcount entries.
+	data := []byte("GitHub CLI2.62.0")
+	pool := make([]byte, 4) // header entry (codepage) — skipped
+	pool = appendPoolEntry(pool, 10, 1)
+	pool = appendPoolEntry(pool, 6, 1)
+	strs, err := loadStringTable(pool, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Index 0 = empty, 1 = first string, 2 = second.
+	if len(strs) != 3 || strs[0] != "" || strs[1] != "GitHub CLI" || strs[2] != "2.62.0" {
+		t.Fatalf("strings = %#v", strs)
+	}
+}
+
+func TestLoadStringTableOverrunIsError(t *testing.T) {
+	pool := append(make([]byte, 4), appendPoolEntry(nil, 99, 1)...) // claims 99 bytes
+	if _, err := loadStringTable(pool, []byte("short")); err == nil {
+		t.Fatal("expected error when a string overruns _StringData")
+	}
+}
+
+func TestParsePropertyTable(t *testing.T) {
+	// strings: 1=ProductName 2=GitHub CLI 3=ProductVersion 4=2.62.0
+	strs := []string{"", "ProductName", "GitHub CLI", "ProductVersion", "2.62.0"}
+	// Column-major, 2-byte refs, 2 rows: [nameRefs...][valueRefs...]
+	stream := make([]byte, 0, 8)
+	stream = appendU16(stream, 1) // row0 name -> ProductName
+	stream = appendU16(stream, 3) // row1 name -> ProductVersion
+	stream = appendU16(stream, 2) // row0 value -> GitHub CLI
+	stream = appendU16(stream, 4) // row1 value -> 2.62.0
+	props := parsePropertyTable(stream, strs)
+	if props["ProductName"] != "GitHub CLI" || props["ProductVersion"] != "2.62.0" {
+		t.Fatalf("props = %#v", props)
+	}
+}
+
+// TestParseSyntheticMSI builds a minimal-but-valid compound file (plain-ASCII stream names, which the
+// demangler passes through unchanged) carrying the three MSI tables Parse needs, then round-trips it — this
+// exercises the CFBF reader (header/FAT/directory/streams) end to end without shipping a real installer.
+func TestParseSyntheticMSI(t *testing.T) {
+	want := Info{ProductName: "Widget", ProductVersion: "3.1.4", Manufacturer: "Acme Corp"}
+	data := buildTestMSI(t, []kv{
+		{"ProductName", want.ProductName},
+		{"ProductVersion", want.ProductVersion},
+		{"Manufacturer", want.Manufacturer},
+	})
+	got, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Parse = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseRejectsNonMSI(t *testing.T) {
+	if _, err := Parse([]byte("this is not a compound file")); err == nil {
+		t.Fatal("expected error for non-CFBF input")
+	}
+}
+
+// TestOpenCFBFRejectsHostileHeader covers the header-count / mini-sector-size guards that stop a tiny
+// crafted file from forcing a multi-GiB allocation or an unbounded DIFAT loop (security-audit findings).
+func TestOpenCFBFRejectsHostileHeader(t *testing.T) {
+	base := func() []byte {
+		b := make([]byte, 512)
+		copy(b[0:8], cfbfSignature)
+		binary.LittleEndian.PutUint16(b[26:28], 3)      // major
+		binary.LittleEndian.PutUint16(b[28:30], 0xFFFE) // byte order
+		binary.LittleEndian.PutUint16(b[30:32], 9)      // sector shift -> 512
+		binary.LittleEndian.PutUint16(b[32:34], 6)      // mini sector shift -> 64
+		return b
+	}
+	cases := map[string]func([]byte){
+		"huge numFATSect":   func(b []byte) { binary.LittleEndian.PutUint32(b[44:48], 0x00200000) },
+		"huge numDIFATSect": func(b []byte) { binary.LittleEndian.PutUint32(b[72:76], 0xFFFFFFFF) },
+		"bad miniShift":     func(b []byte) { binary.LittleEndian.PutUint16(b[32:34], 63) },
+	}
+	for name, mut := range cases {
+		t.Run(name, func(t *testing.T) {
+			b := base()
+			mut(b)
+			if _, err := openCFBF(b); err == nil {
+				t.Fatal("expected error for hostile header")
+			}
+		})
+	}
+}
+
+// --- test helpers (byte encoders + a tiny CFBF/MSI writer) ---
+
+type kv struct{ k, v string }
+
+func appendU16(b []byte, v uint16) []byte { return binary.LittleEndian.AppendUint16(b, v) }
+
+func appendPoolEntry(b []byte, size, refcount uint16) []byte {
+	b = appendU16(b, size)
+	return appendU16(b, refcount)
+}
+
+// buildTestMSI writes a 512-byte-sector compound file with mini-stream cutoff 0 (so every stream uses the
+// regular FAT chain — no mini FAT needed) containing _StringData, _StringPool and Property.
+func buildTestMSI(t *testing.T, props []kv) []byte {
+	t.Helper()
+
+	// Intern strings (index 0 = empty).
+	index := map[string]int{"": 0}
+	var order []string
+	intern := func(s string) int {
+		if i, ok := index[s]; ok {
+			return i
+		}
+		i := len(order) + 1
+		index[s] = i
+		order = append(order, s)
+		return i
+	}
+	type row struct{ nameRef, valRef int }
+	var rows []row
+	for _, p := range props {
+		rows = append(rows, row{intern(p.k), intern(p.v)})
+	}
+
+	var strData []byte
+	strPool := make([]byte, 4) // header entry (codepage) — skipped by the reader
+	for _, s := range order {
+		strData = append(strData, s...)
+		strPool = appendPoolEntry(strPool, uint16(len(s)), 1)
+	}
+
+	propStream := make([]byte, 0, len(rows)*4)
+	for _, r := range rows {
+		propStream = appendU16(propStream, uint16(r.nameRef))
+	}
+	for _, r := range rows {
+		propStream = appendU16(propStream, uint16(r.valRef))
+	}
+
+	streams := []struct {
+		name string
+		data []byte
+	}{
+		{"_StringData", strData},
+		{"_StringPool", strPool},
+		{"Property", propStream},
+	}
+
+	const sectorSize = 512
+	nSect := func(n int) int {
+		if n == 0 {
+			return 0
+		}
+		return (n + sectorSize - 1) / sectorSize
+	}
+
+	// Sector layout: 0=FAT, 1=directory, 2.. = stream data.
+	fat := make([]uint32, sectorSize/4) // one FAT sector = 128 entries
+	for i := range fat {
+		fat[i] = freeSect
+	}
+	fat[0] = fatSect
+	fat[1] = endOfChain // directory is one sector
+
+	type placed struct{ start uint32 }
+	placedAt := make([]placed, len(streams))
+	next := uint32(2)
+	for i, s := range streams {
+		ns := nSect(len(s.data))
+		if ns == 0 {
+			placedAt[i] = placed{endOfChain}
+			continue
+		}
+		placedAt[i] = placed{next}
+		for j := 0; j < ns; j++ {
+			if j == ns-1 {
+				fat[next] = endOfChain
+			} else {
+				fat[next] = next + 1
+			}
+			next++
+		}
+	}
+	totalSectors := int(next)
+
+	// Assemble the file: header (512) + each sector (512).
+	buf := make([]byte, sectorSize*(1+totalSectors))
+
+	// Header.
+	copy(buf[0:8], cfbfSignature)
+	binary.LittleEndian.PutUint16(buf[26:28], 3)      // major version (512-byte sectors)
+	binary.LittleEndian.PutUint16(buf[28:30], 0xFFFE) // byte order
+	binary.LittleEndian.PutUint16(buf[30:32], 9)      // sector shift -> 512
+	binary.LittleEndian.PutUint16(buf[32:34], 6)      // mini sector shift -> 64
+	binary.LittleEndian.PutUint32(buf[44:48], 1)      // number of FAT sectors
+	binary.LittleEndian.PutUint32(buf[48:52], 1)      // first directory sector
+	binary.LittleEndian.PutUint32(buf[56:60], 0)      // mini stream cutoff (0 -> all streams use the FAT)
+	binary.LittleEndian.PutUint32(buf[60:64], endOfChain)
+	binary.LittleEndian.PutUint32(buf[64:68], 0)          // number of mini FAT sectors
+	binary.LittleEndian.PutUint32(buf[68:72], endOfChain) // first DIFAT sector
+	binary.LittleEndian.PutUint32(buf[72:76], 0)          // number of DIFAT sectors
+	binary.LittleEndian.PutUint32(buf[76:80], 0)          // DIFAT[0] -> FAT is at sector 0
+	for i := 1; i < 109; i++ {
+		binary.LittleEndian.PutUint32(buf[76+i*4:80+i*4], freeSect)
+	}
+
+	sectorOff := func(n int) int { return sectorSize * (n + 1) } // header precedes sector 0
+
+	// Sector 0: FAT.
+	for i, v := range fat {
+		binary.LittleEndian.PutUint32(buf[sectorOff(0)+i*4:], v)
+	}
+
+	// Sector 1: directory (root + one entry per stream).
+	writeDirEntry(buf[sectorOff(1):], 0, "Root Entry", objRootStore, endOfChain, 0)
+	for i, s := range streams {
+		writeDirEntry(buf[sectorOff(1)+(i+1)*dirEntryLen:], 0, s.name, objStream, placedAt[i].start, uint64(len(s.data)))
+	}
+
+	// Stream data sectors.
+	for i, s := range streams {
+		if placedAt[i].start == endOfChain {
+			continue
+		}
+		copy(buf[sectorOff(int(placedAt[i].start)):], s.data)
+	}
+	return buf
+}
+
+func writeDirEntry(dst []byte, _ int, name string, objType byte, start uint32, size uint64) {
+	// UTF-16LE name + trailing null; name length in bytes at [64:66].
+	u := utf16Encode(name)
+	for i, c := range u {
+		binary.LittleEndian.PutUint16(dst[i*2:], c)
+	}
+	binary.LittleEndian.PutUint16(dst[64:66], uint16((len(u)+1)*2))
+	dst[66] = objType
+	binary.LittleEndian.PutUint32(dst[116:120], start)
+	binary.LittleEndian.PutUint64(dst[120:128], size)
+}
+
+func utf16Encode(s string) []uint16 {
+	var u []uint16
+	for _, r := range s {
+		u = append(u, uint16(r))
+	}
+	return u
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -914,6 +914,14 @@ type SBOMEnricher interface {
 	Enrich(ctx context.Context, dir string, doc *sbom.SBOM) SBOMEnrichment
 }
 
+// ArtifactCataloger catalogs standalone package/installer artifacts under a scanned directory that the SBOM
+// generator does not parse (e.g. a Windows Installer .msi, whose product identity lives in an OLE2 compound
+// file). It reads the artifact's own manifest — never executes it — and returns one component per artifact.
+// It runs on the workspace Dir (a file-target or source tree), not a materialized image rootfs.
+type ArtifactCataloger interface {
+	CatalogArtifacts(ctx context.Context, dir string) ([]sbom.Component, error)
+}
+
 // DetectionSource is one vulnerability detector (OSV, Grype, …). The SCA service
 // runs EVERY source against the same Syft SBOM and correlates the results, so
 // sources augment – not replace – each other. A source returns raw

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -71,6 +71,7 @@ type Service struct {
 	fpTriager          ports.FPTriager                 // optional LLM false-positive critique of production-scope source findings
 	osPkgCataloger     ports.OSPackageCataloger        // optional owned OS-package cataloging (dpkg/apk) from an image rootfs
 	instCataloger      ports.InstalledPackageCataloger // optional owned installed-package cataloging (Go binaries, Python dist-info) from an image rootfs
+	artifactCataloger  ports.ArtifactCataloger         // optional owned standalone-artifact cataloging (.msi product identity) from the workspace dir
 	suppression        ports.SuppressionLoader         // optional repo-committed .synapseignore accepted-risk policy
 	vexLoader          ports.VEXLoader                 // optional in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
 	complianceOn       bool                            // when set, attach the AppSec-baseline compliance report to a scan
@@ -180,6 +181,11 @@ func (s *Service) SetOSPackageCataloger(c ports.OSPackageCataloger) { s.osPkgCat
 func (s *Service) SetInstalledPackageCataloger(c ports.InstalledPackageCataloger) {
 	s.instCataloger = c
 }
+
+// SetArtifactCataloger configures optional owned cataloging of standalone package/installer artifacts (a
+// Windows Installer .msi) discovered under the workspace directory. nil ⇒ off. It runs on any target
+// (file-target or source tree), independent of image-rootfs materialization.
+func (s *Service) SetArtifactCataloger(c ports.ArtifactCataloger) { s.artifactCataloger = c }
 
 // SetSBOMCache configures the optional generated-SBOM cache. nil ⇒ always regenerate. Best-effort: a cache
 // miss or error never affects correctness, only whether the cataloging step is skipped.
@@ -1752,6 +1758,19 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		step = trace.start(stageSBOM, "sbom-enrichment", "manifest-enricher", "Enrich SBOM from manifests", map[string]int{"components": before})
 		s.sbomEnricher.Enrich(ctx, ws.Dir, doc)
 		trace.succeed(step, "SBOM enrichment completed", map[string]int{"components_before": before, "components": countComponents(doc)})
+	}
+	// Owned standalone-artifact cataloging (.msi product identity) over the workspace dir: the SBOM generator
+	// has no cataloger for a Windows Installer, so recover each installer's product from its OLE2 Property
+	// table and add it to the SBOM. Best-effort; deduped by name@version. Runs on any target (file or tree),
+	// independent of image-rootfs materialization.
+	if s.artifactCataloger != nil && ws.Dir != "" {
+		before := countComponents(doc)
+		step = trace.start(stageSBOM, "artifact-catalog", "artifact-cataloger", "Catalog standalone artifacts (.msi)", map[string]int{"components": before})
+		if artComps, aerr := s.artifactCataloger.CatalogArtifacts(ctx, ws.Dir); aerr != nil {
+			trace.fail(step, aerr)
+		} else {
+			trace.succeed(step, "Artifact cataloging completed", map[string]int{"artifacts_added": mergeComponents(doc, artComps)})
+		}
 	}
 	// Owned OS-package cataloging (dpkg/apk) from a materialized image rootfs: detection-independent OS
 	// packages, added BEFORE detection so they get advisory-matched. Best-effort, and deduped by name@version


### PR DESCRIPTION
## Summary

Adds first-class scanning of **standalone package/installer files** passed directly as a scan target (`synapse-cli scan foo.rpm|foo.msi|foo.deb|foo.jar`), not just source trees and container images.

## What changed

- **acquire** — a single regular-file target is staged into a temp workspace (bounded copy, basename preserved) so Syft's rpm/deb/jar archive catalogers run over it.
- **grype (`.rpm`)** — a loose `.rpm` carries no `distro=` PURL qualifier, so the target distro is inferred from the RPM release suffix (`.el8`→rhel:8, `.fc39`→fedora:39, `.amzn2`→amzn:2) and injected as an **operating-system component** in `components[]` (grype scopes OS-package advisory matching from that component, *not* `metadata.component`). Verified E2E: `scan curl-7.61.1-33.el8.rpm` → **33 findings**, matching grype's `--distro redhat:8` ground truth.
- **msi (new)** — a dependency-free, pure-Go reader for the **OLE2/CFBF compound file** + **MSI table layout** (stream-name demangling, `_StringPool`/`_StringData` interning, `Property` table) recovers the installer's product identity (ProductName / ProductVersion / Manufacturer / ProductCode / UpgradeCode) and emits one SBOM component per `.msi` via the new `ports.ArtifactCataloger`. Verified E2E on a real WiX installer: `scan gh_2.62.0_windows_amd64.msi` → `GitHub CLI` `2.62.0`, supplier `GitHub, Inc.`.

There is no reliable CVE identifier for arbitrary installed Windows products, so an `.msi` is cataloged for **SBOM inventory** (generic PURL), not advisory-matched — the honest scope.

## Safety (untrusted binary input)

The scanned file is fully attacker-controlled, so all binary parsing is bounded (per a security-audit pass):
- header sector-counts (`numFATSect`/`numDIFATSect`/`numMiniFATSect`) and the mini-sector size are validated before driving any allocation or loop;
- the DIFAT chain has a cycle/iteration guard and a total-size cap;
- no untrusted capacity hint drives a `make`;
- the interned string table is capped;
- the cataloger walk skips non-regular files — a planted `x.msi -> /dev/zero` symlink or a FIFO can neither OOM nor hang the scan (verified).

## Test

`go build`, `go vet`, `golangci-lint` (0 issues), and unit tests all green — including a synthetic-CFBF round-trip, the demangler/string-pool/property-table units, hostile-header rejection, and the symlink-skip guard. Independently reviewed by the security-auditor and go-arch-reviewer agents (all findings addressed).
