### PR TITLE
feat(sca): scan standalone Python wheel/egg (.whl/.egg) files

### DIFF
--- a/internal/infrastructure/acquire/acquirer.go
+++ b/internal/infrastructure/acquire/acquirer.go
@@ -6,8 +6,10 @@
 package acquire
 
 import (
+	"archive/zip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -158,6 +160,19 @@ func acquireFileArtifact(value string, size, maxBytes int64) (*ports.Workspace, 
 		_ = cleanup()
 		return nil, fmt.Errorf("stage file artifact: %w", err)
 	}
+	// A Python wheel/egg is a ZIP the SBOM generator does not catalog as a loose file, but whose
+	// <dist-info|EGG-INFO> manifest it DOES read once on disk. Unpack it (bounded, zip-slip-safe) alongside
+	// the raw file so the package is identified. Best-effort: a corrupt/oversized archive just leaves the
+	// raw file staged (no worse than before). Other formats (.rpm/.deb/.msi/.jar) are cataloged directly.
+	switch strings.ToLower(filepath.Ext(value)) {
+	case ".whl", ".egg":
+		// Extract ONLY the package metadata (<name>.dist-info / *.egg-info / EGG-INFO) — enough for the
+		// generator to identify the package + version, WITHOUT unpacking its source modules. This keeps a
+		// wheel/egg a package artifact (SCA identity + advisory match, like .rpm/.deb/.msi) rather than
+		// turning it into a source tree that also draws SAST/quality findings on third-party library code.
+		unpackDir := filepath.Join(dir, filepath.Base(value)+"-unpacked")
+		_ = unpackZipBounded(dst, unpackDir, maxBytes, isPyDistMetadata)
+	}
 	lockfiles, localModules, unresolved, err := inspectWorkspace(dir, maxBytes)
 	if err != nil {
 		_ = cleanup()
@@ -189,6 +204,99 @@ func copyFileBounded(src, dst string, maxBytes int64) error {
 		return fmt.Errorf("%w: file exceeds the workspace cap (%d bytes)", shared.ErrValidation, maxBytes)
 	}
 	return nil
+}
+
+// unpackZipBounded extracts a ZIP (a Python wheel/egg) into destDir with hard bounds: every entry is
+// confined to destDir (zip-slip / path-traversal rejected), the cumulative uncompressed size is capped and
+// the entry count is capped (decompression bomb), and symlink/device entries are skipped (never created or
+// followed). It only ever writes regular files under a caller-owned fresh temp dir. Any malformed entry
+// aborts extraction with an error; callers treat it as best-effort.
+func unpackZipBounded(zipPath, destDir string, maxTotalBytes int64, keep func(name string) bool) error {
+	const maxEntries = 20000
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = zr.Close() }()
+	if len(zr.File) > maxEntries {
+		return errors.New("zip: too many entries")
+	}
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
+		return err
+	}
+	clean := filepath.Clean(destDir)
+	var written int64
+	for _, f := range zr.File {
+		if keep != nil && !keep(f.Name) {
+			continue // caller only wants a subset (e.g. a wheel's metadata, not its source); a kept
+			// file's parent dirs are created on write, so filtered-out directory entries need no MkdirAll
+		}
+		target := filepath.Join(clean, f.Name) // #nosec G305 -- Join cleans the path; the very next line rejects any target that escapes the (cleaned) destination root
+		if target != clean && !strings.HasPrefix(target, clean+string(os.PathSeparator)) {
+			return fmt.Errorf("zip: entry %q escapes destination", f.Name)
+		}
+		info := f.FileInfo()
+		if info.IsDir() {
+			if err := os.MkdirAll(target, 0o750); err != nil {
+				return err
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() { // skip symlinks/devices encoded in the archive
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+			return err
+		}
+		n, err := extractZipEntry(f, target, maxTotalBytes-written)
+		if err != nil {
+			return err
+		}
+		if written += n; written > maxTotalBytes {
+			return errors.New("zip: uncompressed size exceeds cap")
+		}
+	}
+	return nil
+}
+
+// isPyDistMetadata reports whether a zip entry path is Python package metadata — a wheel's
+// "<name>-<ver>.dist-info/…" or an egg's "*.egg-info/…" / "EGG-INFO/…" — which the SBOM generator reads to
+// identify the package. Source modules (.py, etc.) are excluded so a wheel stays a package artifact.
+func isPyDistMetadata(name string) bool {
+	for _, seg := range strings.Split(name, "/") {
+		if seg == "EGG-INFO" || strings.HasSuffix(seg, ".dist-info") || strings.HasSuffix(seg, ".egg-info") {
+			return true
+		}
+	}
+	return false
+}
+
+// extractZipEntry writes one zip entry to target, copying at most remaining+1 bytes so the caller's
+// cumulative cap is enforced (defends against a compression bomb). Returns the bytes written.
+func extractZipEntry(f *zip.File, target string, remaining int64) (int64, error) {
+	if remaining <= 0 {
+		return 0, errors.New("zip: uncompressed size exceeds cap")
+	}
+	rc, err := f.Open()
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = rc.Close() }()
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return 0, err
+	}
+	n, err := io.Copy(out, io.LimitReader(rc, remaining+1))
+	if cerr := out.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		return n, err
+	}
+	if n > remaining {
+		return n, errors.New("zip: uncompressed size exceeds cap")
+	}
+	return n, nil
 }
 
 func (a *Acquirer) acquireGit(ctx context.Context, url, ref string) (*ports.Workspace, error) {

--- a/internal/infrastructure/acquire/filetarget_test.go
+++ b/internal/infrastructure/acquire/filetarget_test.go
@@ -1,0 +1,128 @@
+package acquire
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsPyDistMetadata(t *testing.T) {
+	yes := []string{
+		"Jinja2-2.10.dist-info/METADATA",
+		"Jinja2-2.10.dist-info/RECORD",
+		"rack.egg-info/PKG-INFO",
+		"EGG-INFO/PKG-INFO",
+	}
+	no := []string{
+		"jinja2/__init__.py",
+		"jinja2/compiler.py",
+		"README.md",
+		"jinja2/tests.py",
+	}
+	for _, p := range yes {
+		if !isPyDistMetadata(p) {
+			t.Errorf("isPyDistMetadata(%q) = false, want true", p)
+		}
+	}
+	for _, p := range no {
+		if isPyDistMetadata(p) {
+			t.Errorf("isPyDistMetadata(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestUnpackZipBoundedMetadataFilter(t *testing.T) {
+	zipPath := writeZip(t, []zipEntry{
+		{name: "Jinja2-2.10.dist-info/METADATA", content: "Metadata-Version: 2.1\nName: Jinja2\nVersion: 2.10\n"},
+		{name: "jinja2/__init__.py", content: "import os\n"}, // source module: must NOT be extracted
+	})
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := unpackZipBounded(zipPath, dest, MaxWorkspaceBytes, isPyDistMetadata); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "Jinja2-2.10.dist-info", "METADATA")); err != nil {
+		t.Errorf("METADATA should be extracted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "jinja2", "__init__.py")); !os.IsNotExist(err) {
+		t.Errorf("source module must NOT be extracted (metadata-only), got err=%v", err)
+	}
+}
+
+func TestUnpackZipBoundedRejectsZipSlip(t *testing.T) {
+	zipPath := writeZip(t, []zipEntry{
+		{name: "../../../../tmp/escape.dist-info/METADATA", content: "pwned"},
+	})
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := unpackZipBounded(zipPath, dest, MaxWorkspaceBytes, nil); err == nil {
+		t.Fatal("expected zip-slip entry to be rejected")
+	}
+}
+
+func TestUnpackZipBoundedSkipsSymlink(t *testing.T) {
+	zipPath := writeZip(t, []zipEntry{
+		{name: "a.dist-info/link", content: "/etc/passwd", symlink: true},
+		{name: "a.dist-info/METADATA", content: "Name: a\nVersion: 1\n"},
+	})
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := unpackZipBounded(zipPath, dest, MaxWorkspaceBytes, nil); err != nil {
+		t.Fatal(err)
+	}
+	if fi, err := os.Lstat(filepath.Join(dest, "a.dist-info", "link")); err == nil {
+		t.Errorf("symlink entry must be skipped, but was created (mode %v)", fi.Mode())
+	}
+	if _, err := os.Stat(filepath.Join(dest, "a.dist-info", "METADATA")); err != nil {
+		t.Errorf("regular entry alongside the symlink should still extract: %v", err)
+	}
+}
+
+func TestUnpackZipBoundedBombCap(t *testing.T) {
+	zipPath := writeZip(t, []zipEntry{
+		{name: "a.dist-info/METADATA", content: string(make([]byte, 4096))},
+	})
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := unpackZipBounded(zipPath, dest, 100, nil); err == nil { // cap below entry size
+		t.Fatal("expected an error when uncompressed size exceeds the cap")
+	}
+}
+
+// TestAcquireFileArtifactWheel round-trips a wheel through the file-target path and asserts the workspace
+// carries the extracted dist-info metadata (so the generator can identify the package) but not its source.
+func TestAcquireFileArtifactWheel(t *testing.T) {
+	zp := writeZip(t, []zipEntry{
+		{name: "Jinja2-2.10.dist-info/METADATA", content: "Metadata-Version: 2.1\nName: Jinja2\nVersion: 2.10\n"},
+		{name: "jinja2/__init__.py", content: "x = 1\n"},
+	})
+	whl := filepath.Join(filepath.Dir(zp), "Jinja2-2.10-py3-none-any.whl")
+	if err := os.Rename(zp, whl); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(whl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ws, err := acquireFileArtifact(whl, fi.Size(), MaxWorkspaceBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if ws.Cleanup != nil {
+			_ = ws.Cleanup()
+		}
+	}()
+	found := false
+	_ = filepath.Walk(ws.Dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info == nil {
+			return nil
+		}
+		if info.Name() == "METADATA" {
+			found = true
+		}
+		if info.Name() == "__init__.py" {
+			t.Errorf("wheel source module leaked into workspace: %s", p)
+		}
+		return nil
+	})
+	if !found {
+		t.Error("wheel dist-info METADATA not present in workspace")
+	}
+}


### PR DESCRIPTION
## Summary

Extends standalone package-artifact scanning to **Python wheels/eggs** (`.whl`/`.egg`) — files that grype, Trivy, and Syft all return **0** for when scanned as a loose file.

A wheel/egg is a ZIP whose `<name>.dist-info` / `*.egg-info` metadata the SBOM generator reads once on disk. On a `.whl`/`.egg` target we extract **only that metadata** into the workspace, so the package is identified and advisory-matched — without unpacking its source modules (which would turn a package artifact into a source tree and draw SAST/quality findings on third-party library code).

## Proof

`Jinja2-2.10.whl`: grype standalone = **0**; Synapse = **jinja2@2.10 + 6 real CVEs** (CVE-2019-10906, CVE-2020-28493, CVE-2024-22195, CVE-2024-34064, CVE-2024-56326, CVE-2025-27516) — SCA only, no SAST-on-library-source noise (consistent with `.rpm`/`.deb`/`.msi`/`.jar`).

## Verification matrix (this + prior artifact work), Synapse vs grype, same files

| Artifact | grype | Synapse |
|---|---|---|
| `.rpm` curl-el8 | 0 | 33 |
| `.deb` libssl (`+deb10`) | 0 | 27 |
| `.deb` zlib (base, no marker) | 0 | 0 (cataloged, no false CVE) |
| `.msi` gh-cli | 0 | identity (only Synapse) |
| `.jar` log4j | 7 | 7 (parity) |
| `.whl` jinja2 (**this PR**) | 0 | 6 |

## Safety (untrusted ZIP)

Independently security-reviewed (clean on all critical concerns): every entry confined to the destination (zip-slip rejected), cumulative uncompressed-size + entry-count caps (decompression bomb), symlink/device entries skipped (never created or followed), fresh caller-owned temp dir, no shell/exec. New tests cover zip-slip, symlink-skip, bomb-cap, the metadata-only filter, and the full wheel round-trip.

`build` / `vet` / `golangci-lint` (0 issues) / tests all green.
