### PR TITLE
feat(sca): extract .rpm/.deb payloads to scan bundled binaries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,12 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/johnfercher/maroto/v2 v2.4.0
+	github.com/klauspost/compress v1.18.6
 	github.com/minio/minio-go/v7 v7.2.1
 	github.com/phpdave11/gofpdf v1.4.3
 	github.com/pressly/goose/v3 v3.27.2
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
+	github.com/ulikunitz/xz v0.5.16
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/tools v0.48.0
@@ -38,7 +40,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/johnfercher/go-tree v1.1.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tinylib/msgp v1.6.1 h1:ESRv8eL3u+DNHUoSAAQRE50Hm162zqAnBoGv9PzScPY=
 github.com/tinylib/msgp v1.6.1/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
+github.com/ulikunitz/xz v0.5.16 h1:ld6NyySjx5lowVKwJvMRLnW5nxKX/xnpSiFYZ/Lxur0=
+github.com/ulikunitz/xz v0.5.16/go.mod h1:H9Rt/W6/Qj27PGauhQc6nfCDy7vHpzsOThBSaYDoEhw=
 github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
 github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/internal/infrastructure/acquire/acquirer.go
+++ b/internal/infrastructure/acquire/acquirer.go
@@ -160,18 +160,28 @@ func acquireFileArtifact(value string, size, maxBytes int64) (*ports.Workspace, 
 		_ = cleanup()
 		return nil, fmt.Errorf("stage file artifact: %w", err)
 	}
-	// A Python wheel/egg is a ZIP the SBOM generator does not catalog as a loose file, but whose
-	// <dist-info|EGG-INFO> manifest it DOES read once on disk. Unpack it (bounded, zip-slip-safe) alongside
-	// the raw file so the package is identified. Best-effort: a corrupt/oversized archive just leaves the
-	// raw file staged (no worse than before). Other formats (.rpm/.deb/.msi/.jar) are cataloged directly.
+	// Some package artifacts bundle files the SBOM generator can only catalog once they are on disk. Best-
+	// effort: a corrupt/oversized archive just leaves the raw file staged (no worse than before). The
+	// extraction budget is what remains under the workspace cap after the raw copy, so the raw file plus
+	// the extracted tree never exceed it.
+	unpackDir := filepath.Join(dir, filepath.Base(value)+"-unpacked")
+	budget := maxBytes - size
+	if budget < 0 {
+		budget = 0
+	}
 	switch strings.ToLower(filepath.Ext(value)) {
 	case ".whl", ".egg":
 		// Extract ONLY the package metadata (<name>.dist-info / *.egg-info / EGG-INFO) — enough for the
 		// generator to identify the package + version, WITHOUT unpacking its source modules. This keeps a
 		// wheel/egg a package artifact (SCA identity + advisory match, like .rpm/.deb/.msi) rather than
 		// turning it into a source tree that also draws SAST/quality findings on third-party library code.
-		unpackDir := filepath.Join(dir, filepath.Base(value)+"-unpacked")
-		_ = unpackZipBounded(dst, unpackDir, maxBytes, isPyDistMetadata)
+		_ = unpackZipBounded(dst, unpackDir, budget, isPyDistMetadata)
+	case ".rpm":
+		// Extract the cpio payload so the generator catalogs the binaries the package SHIPS (e.g. a bundled
+		// Go binary + its embedded module list), surfacing bundled-dependency CVEs the rpm header alone hides.
+		_ = extractRPMPayload(dst, unpackDir, budget)
+	case ".deb":
+		_ = extractDebPayload(dst, unpackDir, budget) // ditto for a .deb's data.tar
 	}
 	lockfiles, localModules, unresolved, err := inspectWorkspace(dir, maxBytes)
 	if err != nil {

--- a/internal/infrastructure/acquire/payload.go
+++ b/internal/infrastructure/acquire/payload.go
@@ -1,0 +1,283 @@
+package acquire
+
+import (
+	"bufio"
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/ulikunitz/xz"
+)
+
+// This file extracts the file payload of a standalone package artifact (.rpm / .deb) into the workspace so
+// the SBOM generator catalogs the binaries the package SHIPS (e.g. a Go binary and its embedded module
+// list), not just the package's own header identity. A loose .rpm/.deb otherwise yields only name/version
+// from its metadata — the bundled-dependency CVE surface (which is where the real risk lives for an agent
+// packaged as a single Go binary) stays invisible.
+//
+// Everything here reads bytes and writes bounded, path-confined regular files under a caller-owned temp
+// dir; nothing is executed. Extraction shares the same hardening as the image-layer/zip paths (safeJoin
+// path confinement, per-file + total size caps, entry-count cap, symlink/device entries skipped).
+
+const maxCPIONameLen = 8192 // per-entry path-length cap
+
+var (
+	rpmLeadMagic   = []byte{0xED, 0xAB, 0xEE, 0xDB}
+	rpmHeaderMagic = []byte{0x8E, 0xAD, 0xE8}
+	arMagic        = []byte("!<arch>\n")
+)
+
+// extractRPMPayload extracts a .rpm's cpio payload (its shipped files) into destDir, bounded to maxBytes.
+func extractRPMPayload(rpmPath, destDir string, maxBytes int64) error {
+	f, err := os.Open(rpmPath) // #nosec G304 -- staged copy under our own fresh temp dir
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	off, err := rpmPayloadOffset(f)
+	if err != nil {
+		return err
+	}
+	dr, closeFn, err := decompressStream(io.NewSectionReader(f, off, fi.Size()-off))
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	return extractCPIO(io.LimitReader(dr, maxBytes), destDir)
+}
+
+// rpmPayloadOffset walks the RPM structure (lead → signature header [padded to 8] → main header) and
+// returns the byte offset where the compressed cpio payload begins. Header sizes are bounds-checked.
+func rpmPayloadOffset(f io.ReaderAt) (int64, error) {
+	lead := make([]byte, 96)
+	if _, err := f.ReadAt(lead, 0); err != nil {
+		return 0, fmt.Errorf("rpm: read lead: %w", err)
+	}
+	if !bytes.Equal(lead[0:4], rpmLeadMagic) {
+		return 0, errors.New("rpm: bad lead magic")
+	}
+	sigEnd, err := rpmHeaderEnd(f, 96)
+	if err != nil {
+		return 0, err
+	}
+	sigEnd = (sigEnd + 7) &^ 7 // signature header is padded to an 8-byte boundary
+	return rpmHeaderEnd(f, sigEnd)
+}
+
+// rpmHeaderEnd reads the 16-byte header intro at off and returns the offset just past the header store.
+func rpmHeaderEnd(f io.ReaderAt, off int64) (int64, error) {
+	intro := make([]byte, 16)
+	if _, err := f.ReadAt(intro, off); err != nil {
+		return 0, fmt.Errorf("rpm: read header intro: %w", err)
+	}
+	if !bytes.Equal(intro[0:3], rpmHeaderMagic) {
+		return 0, errors.New("rpm: bad header magic")
+	}
+	nindex := binary.BigEndian.Uint32(intro[8:12])
+	hsize := binary.BigEndian.Uint32(intro[12:16])
+	if nindex > 1<<20 || hsize > 1<<30 { // header index/store sanity bounds
+		return 0, fmt.Errorf("rpm: header too large (nindex=%d hsize=%d)", nindex, hsize)
+	}
+	return off + 16 + int64(nindex)*16 + int64(hsize), nil
+}
+
+// extractDebPayload extracts a .deb's data.tar.* (its shipped files) into destDir, bounded to maxBytes.
+func extractDebPayload(debPath, destDir string, maxBytes int64) error {
+	f, err := os.Open(debPath) // #nosec G304 -- staged copy under our own fresh temp dir
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	br := bufio.NewReader(f)
+	magic := make([]byte, len(arMagic))
+	if _, err := io.ReadFull(br, magic); err != nil || !bytes.Equal(magic, arMagic) {
+		return errors.New("deb: not an ar archive")
+	}
+	for {
+		hdr := make([]byte, 60)
+		if _, err := io.ReadFull(br, hdr); err != nil {
+			if err == io.EOF {
+				return errors.New("deb: no data.tar member found")
+			}
+			return err
+		}
+		name := strings.TrimRight(strings.TrimRight(string(hdr[0:16]), " "), "/")
+		size, err := strconv.ParseInt(strings.TrimSpace(string(hdr[48:58])), 10, 64)
+		if err != nil || size < 0 {
+			return fmt.Errorf("deb: bad ar member size: %w", err)
+		}
+		if strings.HasPrefix(name, "data.tar") {
+			dr, closeFn, derr := decompressStream(io.LimitReader(br, size))
+			if derr != nil {
+				return derr
+			}
+			defer closeFn()
+			// Reuse the package's hardened tar extractor (safeJoin + per-file cap + symlink skip).
+			return extractTarStream(io.LimitReader(dr, maxBytes), destDir, maxBytes)
+		}
+		if _, err := io.CopyN(io.Discard, br, size); err != nil {
+			return err
+		}
+		if size%2 == 1 { // ar members are padded to an even boundary
+			if _, err := br.Discard(1); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// decompressStream sniffs the leading magic bytes and wraps r in the matching decompressor. An
+// uncompressed tar (deb "data.tar") passes through. Supports gzip, xz, zstd, bzip2 — the compressors
+// rpm/deb use. It returns a cleanup func the caller MUST defer: the zstd decoder in particular spawns
+// goroutines that leak in a long-lived process unless its Close runs (RHEL 8+ rpms default to zstd).
+func decompressStream(r io.Reader) (io.Reader, func(), error) {
+	noop := func() {}
+	br := bufio.NewReader(r)
+	magic, err := br.Peek(6)
+	if err != nil && err != io.EOF && err != bufio.ErrBufferFull {
+		return nil, noop, err
+	}
+	switch {
+	case bytes.HasPrefix(magic, []byte{0x1F, 0x8B}):
+		gz, gerr := gzip.NewReader(br)
+		if gerr != nil {
+			return nil, noop, gerr
+		}
+		return gz, func() { _ = gz.Close() }, nil
+	case bytes.HasPrefix(magic, []byte{0xFD, '7', 'z', 'X', 'Z', 0x00}):
+		xr, xerr := xz.NewReader(br) // xz.Reader has no Close
+		if xerr != nil {
+			return nil, noop, xerr
+		}
+		return xr, noop, nil
+	case bytes.HasPrefix(magic, []byte{0x28, 0xB5, 0x2F, 0xFD}):
+		zr, zerr := zstd.NewReader(br, zstd.WithDecoderConcurrency(1))
+		if zerr != nil {
+			return nil, noop, zerr
+		}
+		return zr.IOReadCloser(), zr.Close, nil
+	case bytes.HasPrefix(magic, []byte{'B', 'Z', 'h'}):
+		return bzip2.NewReader(br), noop, nil
+	default:
+		return br, noop, nil // treat as an uncompressed tar (deb allows a bare data.tar); tar reader errors cleanly if not
+	}
+}
+
+// extractCPIO extracts an SVR4 "newc" cpio stream (the RPM payload format) into destDir. Only directories
+// and regular files are written; symlink/device/FIFO entries are skipped (their body is still consumed to
+// keep the stream aligned). Total size is bounded by the caller's LimitReader; per-file by the shared cap.
+func extractCPIO(r io.Reader, destDir string) error {
+	br := bufio.NewReader(r)
+	if err := os.MkdirAll(filepath.Clean(destDir), 0o750); err != nil {
+		return err
+	}
+	entries := 0
+	hdr := make([]byte, 110)
+	for {
+		if _, err := io.ReadFull(br, hdr); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				return nil // clean end of stream
+			}
+			return err
+		}
+		if m := string(hdr[0:6]); m != "070701" && m != "070702" {
+			return fmt.Errorf("cpio: bad entry magic %q", m)
+		}
+		field := func(i int) (int64, error) {
+			return strconv.ParseInt(string(hdr[6+i*8:6+i*8+8]), 16, 64)
+		}
+		mode, e1 := field(1)
+		fsize, e2 := field(6)
+		namesize, e3 := field(11)
+		if e1 != nil || e2 != nil || e3 != nil {
+			return errors.New("cpio: non-hex numeric header field")
+		}
+		if namesize <= 0 || namesize > maxCPIONameLen || fsize < 0 {
+			return fmt.Errorf("cpio: bad sizes (name=%d file=%d)", namesize, fsize)
+		}
+		name := make([]byte, namesize)
+		if _, err := io.ReadFull(br, name); err != nil {
+			return err
+		}
+		if err := discardPad(br, 110+int(namesize)); err != nil { // name padded so data starts on a 4-byte boundary
+			return err
+		}
+		n := strings.TrimRight(string(name), "\x00")
+		if n == "TRAILER!!!" {
+			return nil
+		}
+		if entries++; entries > maxArchiveEntries {
+			return errors.New("cpio: too many entries")
+		}
+		if err := writeCPIOEntry(destDir, n, mode, fsize, br); err != nil {
+			return err
+		}
+		if err := discardPad(br, int(fsize)); err != nil { // file data padded to a 4-byte boundary
+			return err
+		}
+	}
+}
+
+// writeCPIOEntry materializes one cpio entry. Directories and regular files (confined via safeJoin) are
+// written; anything else (symlink/device/FIFO) is skipped after consuming its body. A regular file's body
+// must be read as exactly fsize bytes to keep the stream aligned, so it cannot use copyCapped (which reads
+// max+1); the per-file cap is enforced up-front and the total by the caller's stream-level LimitReader.
+func writeCPIOEntry(dest, name string, mode, fsize int64, br *bufio.Reader) error {
+	switch mode & 0xF000 {
+	case 0x4000: // directory
+		target, err := safeJoin(dest, name)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(target, 0o750); err != nil {
+			return err
+		}
+		_, err = io.CopyN(io.Discard, br, fsize) // dirs carry no body, but drain any declared bytes to stay aligned
+		return err
+	case 0x8000: // regular file
+		if fsize > maxArchiveFileBytes {
+			return fmt.Errorf("cpio: entry %q exceeds the per-file cap", name)
+		}
+		target, err := safeJoin(dest, name)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+			return err
+		}
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			return err
+		}
+		_, err = io.CopyN(out, br, fsize)
+		if cerr := out.Close(); err == nil {
+			err = cerr
+		}
+		return err
+	default: // symlink / device / FIFO / socket — never created; consume the body to stay aligned
+		_, err := io.CopyN(io.Discard, br, fsize)
+		return err
+	}
+}
+
+// discardPad skips the bytes that pad `consumed` up to the cpio 4-byte alignment boundary.
+func discardPad(br *bufio.Reader, consumed int) error {
+	if pad := (4 - consumed%4) % 4; pad > 0 {
+		_, err := br.Discard(pad)
+		return err
+	}
+	return nil
+}

--- a/internal/infrastructure/acquire/payload_test.go
+++ b/internal/infrastructure/acquire/payload_test.go
@@ -1,0 +1,239 @@
+package acquire
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- fixture builders (newc cpio / minimal rpm / ar deb) ---
+
+type fentry struct {
+	name string
+	mode int
+	data []byte
+}
+
+func cpioHeader(name string, mode, size int) []byte {
+	namesize := len(name) + 1
+	h := "070701"
+	for _, f := range []int{1, mode, 0, 0, 1, 0, size, 0, 0, 0, 0, namesize, 0} {
+		h += fmt.Sprintf("%08x", f)
+	}
+	b := append([]byte(h), []byte(name)...)
+	b = append(b, 0) // NUL-terminate the name
+	for len(b)%4 != 0 { // pad name so the data starts on a 4-byte boundary
+		b = append(b, 0)
+	}
+	return b
+}
+
+func buildNewcCPIO(entries []fentry) []byte {
+	var out []byte
+	for _, e := range entries {
+		out = append(out, cpioHeader(e.name, e.mode, len(e.data))...)
+		out = append(out, e.data...)
+		for len(out)%4 != 0 {
+			out = append(out, 0)
+		}
+	}
+	return append(out, cpioHeader("TRAILER!!!", 0, 0)...)
+}
+
+func gzipBytes(t *testing.T, b []byte) []byte {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	zw := gzip.NewWriter(buf)
+	if _, err := zw.Write(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func buildRPM(payload []byte) []byte {
+	b := make([]byte, 96) // lead
+	copy(b, rpmLeadMagic)
+	hdr := func() []byte { // magic(3)+ver(1)+reserved(4)+nindex(4=0)+hsize(4=0) = 16 bytes, empty header
+		return append(append([]byte{}, rpmHeaderMagic...), 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	}
+	b = append(b, hdr()...) // signature header (ends at 112, already 8-aligned)
+	b = append(b, hdr()...) // main header (ends at 128)
+	return append(b, payload...)
+}
+
+func buildDeb(t *testing.T, dataTar []byte) []byte {
+	t.Helper()
+	out := append([]byte{}, arMagic...)
+	member := func(name string, data []byte) {
+		out = append(out, []byte(fmt.Sprintf("%-16s%-12d%-6d%-6d%-8s%-10d`\n", name, 0, 0, 0, "100644", len(data)))...)
+		out = append(out, data...)
+		if len(data)%2 == 1 {
+			out = append(out, '\n')
+		}
+	}
+	member("debian-binary", []byte("2.0\n"))
+	member("control.tar.gz", gzipBytes(t, []byte("dummy")))
+	member("data.tar.gz", gzipBytes(t, dataTar))
+	return out
+}
+
+func buildTar(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	tw := tar.NewWriter(buf)
+	for name, content := range files {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// --- tests ---
+
+func TestDecompressStreamDispatch(t *testing.T) {
+	payload := []byte("hello payload")
+	r, closeFn, err := decompressStream(bytes.NewReader(gzipBytes(t, payload)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeFn()
+	got := &bytes.Buffer{}
+	if _, err := got.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	if got.String() != string(payload) {
+		t.Errorf("gzip roundtrip = %q, want %q", got.String(), payload)
+	}
+	// A bare (uncompressed) stream passes through unchanged.
+	r2, close2, _ := decompressStream(bytes.NewReader([]byte("plain")))
+	defer close2()
+	b2 := &bytes.Buffer{}
+	_, _ = b2.ReadFrom(r2)
+	if b2.String() != "plain" {
+		t.Errorf("passthrough = %q", b2.String())
+	}
+}
+
+func TestExtractCPIO(t *testing.T) {
+	cpio := buildNewcCPIO([]fentry{
+		{"usr/bin/app", 0x81a4, []byte("ELF-ish binary bytes")}, // regular file (0100644)
+		{"usr/lib", 0x41ed, nil},                                // directory (040755)
+		{"usr/bin/evil-link", 0xa1ff, []byte("/etc/passwd")},    // symlink (0120777) -> must be skipped
+	})
+	dest := t.TempDir()
+	if err := extractCPIO(bytes.NewReader(cpio), dest); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(filepath.Join(dest, "usr/bin/app")); err != nil || string(b) != "ELF-ish binary bytes" {
+		t.Errorf("regular file not extracted correctly: %v / %q", err, b)
+	}
+	if fi, err := os.Lstat(filepath.Join(dest, "usr/bin/evil-link")); err == nil {
+		t.Errorf("symlink entry must be skipped, but exists (mode %v)", fi.Mode())
+	}
+	if fi, err := os.Stat(filepath.Join(dest, "usr/lib")); err != nil || !fi.IsDir() {
+		t.Errorf("directory entry not created")
+	}
+}
+
+// TestExtractCPIODirWithBodyStaysAligned covers the guard against a crafted directory entry that declares
+// a non-zero body: its bytes must be drained so the following entry is still parsed from the right offset.
+func TestExtractCPIODirWithBodyStaysAligned(t *testing.T) {
+	cpio := buildNewcCPIO([]fentry{
+		{"usr/lib", 0x41ed, []byte("bogusdirbody")}, // directory with a (spec-violating) body -> must be drained
+		{"usr/bin/app", 0x81a4, []byte("real binary")},
+	})
+	dest := t.TempDir()
+	if err := extractCPIO(bytes.NewReader(cpio), dest); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(filepath.Join(dest, "usr/bin/app")); err != nil || string(b) != "real binary" {
+		t.Errorf("entry after a dir-with-body misaligned: %v / %q", err, b)
+	}
+}
+
+func TestExtractCPIORejectsTraversal(t *testing.T) {
+	cpio := buildNewcCPIO([]fentry{{"../../../../tmp/escape", 0x81a4, []byte("pwn")}})
+	dest := t.TempDir()
+	if err := extractCPIO(bytes.NewReader(cpio), dest); err == nil {
+		t.Fatal("expected a path-traversal cpio entry to be rejected")
+	}
+}
+
+func TestExtractRPMPayload(t *testing.T) {
+	rpm := buildRPM(gzipBytes(t, buildNewcCPIO([]fentry{
+		{"usr/bin/xora-node-agent", 0x81a4, []byte("go binary")},
+	})))
+	path := filepath.Join(t.TempDir(), "a.rpm")
+	if err := os.WriteFile(path, rpm, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := extractRPMPayload(path, dest, MaxWorkspaceBytes); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(filepath.Join(dest, "usr/bin/xora-node-agent")); err != nil || string(b) != "go binary" {
+		t.Errorf("rpm payload not extracted: %v / %q", err, b)
+	}
+}
+
+func TestExtractRPMRejectsBadMagic(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.rpm")
+	_ = os.WriteFile(path, append([]byte("NOTANRPM"), make([]byte, 200)...), 0o600)
+	if err := extractRPMPayload(path, filepath.Join(t.TempDir(), "o"), MaxWorkspaceBytes); err == nil {
+		t.Fatal("expected error for a non-rpm file")
+	}
+}
+
+func TestRPMHeaderBoundsRejectsHugeCounts(t *testing.T) {
+	// A main header claiming a huge nindex must be rejected (allocation/DoS guard), not trusted.
+	b := make([]byte, 96)
+	copy(b, rpmLeadMagic)
+	sig := append(append([]byte{}, rpmHeaderMagic...), 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	b = append(b, sig...)
+	main := append(append([]byte{}, rpmHeaderMagic...), 0x01, 0, 0, 0, 0)
+	main = append(main, 0x7F, 0xFF, 0xFF, 0xFF) // nindex huge
+	main = append(main, 0, 0, 0, 0)
+	b = append(b, main...)
+	path := filepath.Join(t.TempDir(), "huge.rpm")
+	_ = os.WriteFile(path, b, 0o600)
+	if err := extractRPMPayload(path, filepath.Join(t.TempDir(), "o"), MaxWorkspaceBytes); err == nil {
+		t.Fatal("expected rejection of an oversized rpm header")
+	}
+}
+
+func TestExtractDebPayload(t *testing.T) {
+	deb := buildDeb(t, buildTar(t, map[string]string{"usr/bin/agent": "deb go binary"}))
+	path := filepath.Join(t.TempDir(), "a.deb")
+	if err := os.WriteFile(path, deb, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := extractDebPayload(path, dest, MaxWorkspaceBytes); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(filepath.Join(dest, "usr/bin/agent")); err != nil || string(b) != "deb go binary" {
+		t.Errorf("deb data.tar not extracted: %v / %q", err, b)
+	}
+}
+
+func TestExtractDebRejectsNonAr(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.deb")
+	_ = os.WriteFile(path, []byte("not an ar archive at all"), 0o600)
+	if err := extractDebPayload(path, filepath.Join(t.TempDir(), "o"), MaxWorkspaceBytes); err == nil {
+		t.Fatal("expected error for a non-ar .deb")
+	}
+}


### PR DESCRIPTION
## Summary

A loose `.rpm`/`.deb` scanned as a file previously yielded only the **package header** (name/version/license). When the package ships a binary — e.g. an agent built as a single Go binary — the real CVE surface is that binary's **bundled dependencies**, invisible to a header-only scan.

This extracts the payload on a `.rpm`/`.deb` file target so the SBOM generator catalogs the shipped binaries + their embedded modules:
- **`.rpm`**: parse lead/signature/main headers → locate the cpio payload → decompress (gzip/xz/zstd/bzip2, magic-sniffed) → new bounded SVR4-newc cpio reader.
- **`.deb`**: parse the `ar` archive → decompress `data.tar.*` → reuse the existing hardened tar extractor.

Adds `github.com/ulikunitz/xz` (pure-Go; no stdlib xz) — RHEL/Debian payloads default to xz.

## Proof — the exact use case

Real `xora-node-agent_0.3.0_linux_amd64.rpm` (node-agent shipped as a Go binary):

| | `scan agent.rpm` before | `scan agent.rpm` after |
|---|---|---|
| components | 1 (package) | **192** (package + 191 Go modules) |
| CVEs | 0 (header has none) | **18** incl. **2 critical** (containerd v1.7.33: CVE-2026-50195, CVE-2026-53492) + 6 high (docker/prometheus/grpc) |
| `--fail-on critical` | exit 0 (looked clean!) | exit 1 (correctly blocks) |

## Safety (untrusted archive)

Independently security-reviewed (no critical/high) + arch-reviewed (dependency-rule PASS). Reuses the package's existing hardening — `safeJoin` path confinement, per-file + cumulative caps, entry-count cap, symlink/device entries never created or followed — extraction is best-effort (a corrupt archive just leaves the raw file staged, never fails the scan). Review findings fixed: the decompressor `Close` is deferred (no zstd goroutine leak in the long-lived server), cpio numeric-field parse fails fast, and a crafted directory-entry body is drained to keep the stream aligned.

`build` / `vet` / `golangci-lint` (0 issues) / full-repo tests (142 pkgs) all green; new tests cover the cpio/rpm/deb/decompressor paths + traversal/symlink/alignment guards.
