### PR TITLE
fix(code-quality): retain immutable source snapshots

### DIFF
--- a/deploy/docker-compose.full.yml
+++ b/deploy/docker-compose.full.yml
@@ -63,20 +63,32 @@ services:
       mc mb --ignore-existing local/${BLOB_BUCKET:-synapse-evidence} &&
       echo 'bucket ready'"
 
+  # A named volume is mounted after image build, so Docker creates it root-owned;
+  # initialize it before the non-root API starts.
+  project-source-artifacts-init:
+    image: alpine:3.22
+    user: "0:0"
+    command: ["sh", "-c", "chown -R 10001:999 /project-source-artifacts"]
+    volumes:
+      - project-source-artifacts:/project-source-artifacts
+
   synapse-api:
-    build:
-      context: ..
-      dockerfile: deploy/Dockerfile
-      target: full            # batteries-included: JDK + Maven + Gradle + git + syft + grype
     depends_on:
+      project-source-artifacts-init:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       minio-init:
         condition: service_completed_successfully
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+      target: full            # batteries-included: JDK + Maven + Gradle + git + syft + grype
     ports:
       - "8080:8080"
     volumes:
       - scancache:/home/synapse   # persist the Maven/Gradle caches across CLI scans
+      - project-source-artifacts:/home/synapse/project-source-artifacts
       # - ../:/scan:ro            # uncomment to `synapse-cli scan /scan` this repo
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS localhost:8080/healthz || exit 1"]
@@ -170,3 +182,4 @@ volumes:
   pgdata:
   miniodata:
   scancache:
+  project-source-artifacts:

--- a/internal/usecase/projectuc/code_viewer.go
+++ b/internal/usecase/projectuc/code_viewer.go
@@ -242,18 +242,6 @@ func (s *Service) ReadCodeDiff(ctx context.Context, tenantID shared.ID, key, ana
 		if change.NewPath != "" && manifestOmittedByLimit(analysis.SourceManifest, change.NewPath) {
 			return CodeDiffView{}, analysis.Capabilities, projectanalysis.ErrSourceLimit
 		}
-		if change.OldPath != "" && s.sourceArtifacts != nil {
-			_, out.BaseFile, err = s.sourceArtifacts.LoadBase(ctx, tenantID, shared.ID(analysis.ProjectID), analysis.ID, change.OldPath)
-			if err != nil {
-				return CodeDiffView{}, analysis.Capabilities, err
-			}
-		}
-		if change.NewPath != "" && s.sourceArtifacts != nil {
-			_, out.SourceFile, err = s.sourceArtifacts.Load(ctx, tenantID, shared.ID(analysis.ProjectID), analysis.ID, change.NewPath)
-			if err != nil {
-				return CodeDiffView{}, analysis.Capabilities, err
-			}
-		}
 		return out, analysis.Capabilities, nil
 	}
 	return CodeDiffView{}, analysis.Capabilities, shared.ErrNotFound

--- a/internal/usecase/projectuc/code_viewer_test.go
+++ b/internal/usecase/projectuc/code_viewer_test.go
@@ -186,7 +186,7 @@ func TestCodeFindingsConvertsMultilineColumnsToUTF16(t *testing.T) {
 }
 
 func TestReadCodeDiffServesPersistedUnifiedAndSplitData(t *testing.T) {
-	artifacts := &codeArtifactStub{data: []byte("new\n"), baseData: []byte("old\n")}
+	artifacts := &codeArtifactStub{err: projectanalysis.ErrSourceIntegrity, baseErr: projectanalysis.ErrSourceIntegrity}
 	svc, analyses, p := newCodeService(t, artifacts)
 	saveCodeAnalysis(t, analyses, p, projectanalysis.Analysis{
 		Capabilities: projectanalysis.SourceCapabilities{
@@ -202,8 +202,8 @@ func TestReadCodeDiffServesPersistedUnifiedAndSplitData(t *testing.T) {
 			t.Fatalf("view=%s diff=%+v err=%v", view, diff, err)
 		}
 	}
-	if !artifacts.loaded || !artifacts.baseLoaded {
-		t.Fatalf("immutable artifacts not loaded: %+v", artifacts)
+	if artifacts.loaded || artifacts.baseLoaded {
+		t.Fatalf("diff read should not load source artifacts: %+v", artifacts)
 	}
 }
 

--- a/web/src/components/codequality/ProjectCodeWorkspace.test.tsx
+++ b/web/src/components/codequality/ProjectCodeWorkspace.test.tsx
@@ -83,12 +83,12 @@ describe('ProjectCodeWorkspace', () => {
     expect(navigate).toHaveBeenCalledWith(1001)
   })
 
-  it('renders aligned split rows and newline markers', () => {
+  it('renders persisted diff rows when source loading fails', () => {
     const diff = {
       capabilities: { source: { available: true, reason: null }, comparison: { available: true, reason: null }, unifiedDiff: { available: true, reason: null }, splitDiff: { available: true, reason: null }, highlighting: { available: false, reason: 'unsupported' } },
       diff: { analysisId: 'a1', base: index.head, head: index.head, path: 'src/main.ts', view: 'split' as const, contextTruncated: true, change: { oldPath: 'src/main.ts', newPath: 'src/main.ts', status: 'modified' as const, binary: false, modeOld: '100644', modeNew: '100644', hunks: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, rows: [{ kind: 'removed' as const, oldLine: 1, newLine: null, text: 'old', noFinalNewline: false }, { kind: 'added' as const, oldLine: null, newLine: 1, text: 'new', noFinalNewline: true }] }] } },
     }
-    render(<ProjectCodeWorkspace index={index} source={source} diff={diff} selectedPath="src/main.ts" selectedFindingId={null} view="split" onSelectFile={vi.fn()} onSelectFinding={vi.fn()} onView={vi.fn()} onRetrySource={vi.fn()} sourceError={null} diffError={null} />)
+    render(<ProjectCodeWorkspace index={index} source={null} diff={diff} selectedPath="src/main.ts" selectedFindingId={null} view="split" onSelectFile={vi.fn()} onSelectFinding={vi.fn()} onView={vi.fn()} onRetrySource={vi.fn()} sourceError="source artifact integrity check failed" diffError={null} />)
 
     expect(screen.getByRole('table', { name: 'Split code diff' })).toBeInTheDocument()
     expect(screen.getByText('old')).toBeInTheDocument()
@@ -108,6 +108,7 @@ describe('ProjectCodeWorkspace', () => {
     const { container } = render(<ProjectCodeWorkspace index={index} source={source} diff={diff} selectedPath="src/main.ts" selectedFindingId={null} view="unified" onSelectFile={vi.fn()} onSelectFinding={vi.fn()} onView={vi.fn()} onRetrySource={vi.fn()} sourceError={null} diffError={null} />)
 
     expect(screen.getByRole('table', { name: 'Unified code diff' })).toHaveAttribute('aria-rowcount', '502')
+    expect(screen.getByText('line-1')).toBeInTheDocument()
     expect(screen.getAllByRole('row').length).toBeLessThan(100)
     expect(screen.getByRole('status')).toHaveTextContent('src/main.ts, unified view')
     expect(container.firstElementChild).not.toHaveAttribute('aria-live')

--- a/web/src/components/codequality/ProjectCodeWorkspace.tsx
+++ b/web/src/components/codequality/ProjectCodeWorkspace.tsx
@@ -65,10 +65,11 @@ export function ProjectCodeWorkspace({
   const findings = useMemo(() => [...(source?.findings ?? [])].sort((a, b) => a.location.startLine - b.location.startLine || a.id.localeCompare(b.id)), [source])
   const selectedFinding = findings.find((finding) => finding.id === selectedFindingId) ?? null
   const selectedFile = index.files.find((file) => file.path === selectedPath) ?? null
+  const contentError = view === 'source' ? sourceError : diffError
   const workspaceStatus = !selectedFile
     ? 'No source file selected'
-    : sourceError || diffError
-      ? `${selectedFile.path}: ${sourceError ?? diffError}`
+    : contentError
+      ? `${selectedFile.path}: ${contentError}`
       : view === 'source' && !source || view !== 'source' && !diff
         ? `Loading ${view} view for ${selectedFile.path}`
         : `${selectedFile.path}, ${view} view${selectedFinding ? `, finding ${findings.indexOf(selectedFinding) + 1} of ${findings.length}` : ''}`
@@ -148,17 +149,14 @@ export function ProjectCodeWorkspace({
         <section className="flex min-w-0 flex-1 flex-col">
           <WorkspaceHeader file={selectedFile} index={index} view={view} diff={diff} onView={onView} />
           {!selectedFile ? <EmptyState icon={FileCode2} title="Select a source file" hint="Choose a captured file to inspect the immutable analysis snapshot." />
-            : !selectedFile.sourceAvailable ? <Unavailable file={selectedFile} />
-              : sourceError ? <PaneError message={sourceError} onRetry={onRetrySource} />
-                : !source ? <CodeSkeleton />
-                  : <>
-                    {view === 'source'
-                      ? <SourcePane source={source} selectedFinding={selectedFinding} onSelectFinding={onSelectFinding} onNavigateLine={onNavigateLine} />
-                      : diffError ? <PaneError message={diffError} onRetry={onRetrySource} />
-                        : diff ? <DiffPane diff={diff} split={view === 'split'} />
-                          : <CodeSkeleton />}
-                    <FindingPanel findings={findings} selected={selectedFinding} onSelect={onSelectFinding} />
-                  </>}
+            : view === 'source'
+              ? !selectedFile.sourceAvailable ? <Unavailable file={selectedFile} />
+                : sourceError ? <PaneError message={sourceError} onRetry={onRetrySource} />
+                  : !source ? <CodeSkeleton />
+                    : <><SourcePane source={source} selectedFinding={selectedFinding} onSelectFinding={onSelectFinding} onNavigateLine={onNavigateLine} /><FindingPanel findings={findings} selected={selectedFinding} onSelect={onSelectFinding} /></>
+              : diffError ? <PaneError message={diffError} onRetry={onRetrySource} />
+                : diff ? <><DiffPane diff={diff} split={view === 'split'} /><FindingPanel findings={findings} selected={selectedFinding} onSelect={onSelectFinding} /></>
+                  : <CodeSkeleton />}
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Close #345 

Fix Code Quality source/diff snapshots becoming unavailable after analysis:

- decouple persisted Unified/Split diff rendering from source-artifact reads;
- retain strict validation for Source view reads;
- provision a dedicated, initialized source-artifact volume in the full Compose stack so the non-root API process can persist immutable snapshots.

## Root cause

`scancache` was mounted at `/home/synapse`, masking the image-created
`/home/synapse/project-source-artifacts` directory. The mounted volume was
root-owned while the API runs as UID `10001`, so source capture failed and the
analysis persisted unavailable source metadata.

A fresh analysis now returns `200` from `/code/file` and renders captured
source in the Code Quality workspace. Snapshots from analyses created before
the fix remain unavailable because they were never captured.

## Tests

- `go test ./internal/usecase/projectuc ./internal/adapter/httpapi ./internal/infrastructure/sourceartifact`
- `cd web && pnpm exec vitest run src/components/codequality/ProjectCodeWorkspace.test.tsx src/lib/api.projects.test.ts`
- `cd web && pnpm typecheck`
- `cd web && pnpm build`
- `docker compose -f deploy/docker-compose.full.yml config --quiet`
- `git diff --check`