### PR TITLE
feat(appsec): add Business Service Asset Inventory foundation

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -881,6 +881,84 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/appsec/business-services:
+    get:
+      tags: [appsec]
+      summary: List tenant-scoped AppSec Business Services
+      responses:
+        '200': {description: Business Services}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+    post:
+      tags: [appsec]
+      summary: Create an AppSec Business Service
+      responses:
+        '201': {description: Created}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+  /api/v1/appsec/business-services/{id}/assets:
+    post:
+      tags: [appsec]
+      summary: Link an existing Asset to a Business Service
+      responses:
+        '201': {description: Linked}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+  /api/v1/appsec/assets:
+    get:
+      tags: [appsec]
+      summary: List tenant-scoped AppSec Assets
+      responses:
+        '200': {description: Assets}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+    post:
+      tags: [appsec]
+      summary: Create an AppSec Asset
+      responses:
+        '201': {description: Created}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+  /api/v1/appsec/assets/{id}:
+    get:
+      tags: [appsec]
+      summary: Get a tenant-scoped AppSec Asset
+      responses:
+        '200': {description: Asset}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+  /api/v1/appsec/assets/{id}/versions:
+    post:
+      tags: [appsec]
+      summary: Add an immutable Asset version
+      responses:
+        '201': {description: Created}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+  /api/v1/appsec/assets/{id}/relationships:
+    get:
+      tags: [appsec]
+      summary: List Asset relationship edges
+      responses:
+        '200': {description: Relationships}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+    post:
+      tags: [appsec]
+      summary: Create a typed Asset relationship
+      responses:
+        '201': {description: Created}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
 components:
   securitySchemes:
     bearerAuth:

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -90,6 +90,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/platform/jobs"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/agenttools"
+	assetinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assetinventory"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
 	audituc "github.com/KKloudTarus/synapse-ce/internal/usecase/audit"
@@ -166,6 +167,7 @@ func main() {
 	// Persistence: PostgreSQL when configured, else file + in-memory (dev).
 	var repo ports.EngagementRepository
 	var projectRepo ports.ProjectRepository
+	var assetInventoryRepo ports.AssetInventoryRepository
 	var findingRepo ports.FindingRepository
 	var judgmentStore analysisuc.Store // postgres or memory; satisfies both the narrow Store + ports.JudgmentStore
 	var commentRepo ports.CommentRepository
@@ -267,6 +269,7 @@ func main() {
 		log.Info("acquired single-instance advisory lock")
 		repo = postgres.NewEngagementRepository(pool)
 		projectRepo = postgres.NewProjectRepository(pool)
+		assetInventoryRepo = postgres.NewAssetInventoryRepository(pool)
 		findingRepo = postgres.NewFindingRepository(pool)
 		judgmentStore = postgres.NewJudgmentRepository(pool)
 		commentRepo = postgres.NewCommentRepository(pool)
@@ -305,6 +308,7 @@ func main() {
 	} else {
 		repo = memory.NewEngagementRepository()
 		projectRepo = memory.NewProjectRepository()
+		assetInventoryRepo = memory.NewAssetInventoryRepository()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
 		commentRepo = memory.NewCommentRepository()
@@ -349,6 +353,7 @@ func main() {
 	// Use cases.
 	engService := enguc.NewService(repo, clock, ids, auditLog)
 	projectService := projectuc.NewService(projectRepo, repo, clock, ids, auditLog, !cfg.IsProduction())
+	assetInventoryService := assetinventoryuc.NewService(assetInventoryRepo, clock, ids, auditLog)
 	projectService.SetArchiveStore(file.NewProjectArchiveStore(cfg.ProjectUploadDir, cfg.MaxWorkspaceBytes))
 	projectService.SetAnalysisStore(projectAnalysisStore)
 	if issueStore, ok := projectAnalysisStore.(ports.ProjectIssueStore); ok {
@@ -923,6 +928,7 @@ func main() {
 	}
 	log.Info("immutable project source capture ENABLED", "retention", cfg.ProjectSourceRetention)
 	router.SetProjects(projectService)
+	router.SetAssetInventory(assetInventoryService)
 	router.SetQualityGates(qualityGateService)
 	router.SetQualityProfiles(qualityProfileService)
 	router.SetExploitation(exploitationService) // evidence-gated finding verify endpoint

--- a/internal/adapter/httpapi/asset_inventory_handler.go
+++ b/internal/adapter/httpapi/asset_inventory_handler.go
@@ -1,0 +1,51 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/businessservice"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	assetuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assetinventory"
+)
+
+type assetInventoryService interface {
+	CreateBusinessService(context.Context, assetuc.CreateBusinessServiceInput) (*businessservice.BusinessService, error)
+	ListBusinessServices(context.Context, shared.ID) ([]*businessservice.BusinessService, error)
+	CreateAsset(context.Context, assetuc.CreateAssetInput) (*asset.Asset, error)
+	ListAssets(context.Context, shared.ID) ([]*asset.Asset, error)
+	GetAsset(context.Context, shared.ID, shared.ID) (*asset.Asset, error)
+	AddVersion(context.Context, string, shared.ID, shared.ID, string, string) (asset.Version, error)
+	LinkBusinessServiceAsset(context.Context, string, shared.ID, shared.ID, shared.ID, asset.BusinessServiceRole) (asset.BusinessServiceLink, error)
+	AddRelationship(context.Context, string, shared.ID, shared.ID, shared.ID, asset.RelationshipType) (asset.Relationship, error)
+	ListRelationships(context.Context, shared.ID, shared.ID) ([]asset.Relationship, error)
+}
+
+func (rt *Router) SetAssetInventory(s assetInventoryService) { rt.assetInventory = s }
+
+func decodeAssetInventoryJSON(w http.ResponseWriter, r *http.Request, out any) bool {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(out); err != nil { writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"}); return false }
+	return true
+}
+func (rt *Router) createBusinessService(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name        string `json:"name"`
+		Code        string `json:"code"`
+		Owner       string `json:"owner"`
+		Criticality string `json:"criticality"`
+	}
+	if !decodeAssetInventoryJSON(w, r, &req) { return }
+	s, err := rt.assetInventory.CreateBusinessService(r.Context(), assetuc.CreateBusinessServiceInput{TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Name: req.Name, Code: req.Code, Owner: req.Owner, Criticality: req.Criticality})
+	if err != nil { writeError(w, rt.log, err); return }
+	writeJSON(w, http.StatusCreated, s)
+}
+func (rt *Router) listBusinessServices(w http.ResponseWriter,r *http.Request){out,err:=rt.assetInventory.ListBusinessServices(r.Context(),shared.ID(TenantFrom(r.Context())));if err!=nil{writeError(w,rt.log,err);return};writeJSON(w,http.StatusOK,out)}
+func (rt *Router) createAsset(w http.ResponseWriter,r *http.Request){var req struct{Name string `json:"name"`;Category asset.Category `json:"category"`;Identity asset.Identity `json:"identity"`;Lifecycle asset.Lifecycle `json:"lifecycle"`;Owner string `json:"owner"`;Criticality string `json:"criticality"`;Exposure string `json:"exposure"`;Classification string `json:"classification"`};if !decodeAssetInventoryJSON(w,r,&req){return};a,err:=rt.assetInventory.CreateAsset(r.Context(),assetuc.CreateAssetInput{TenantID:shared.ID(TenantFrom(r.Context())),Actor:PrincipalFrom(r.Context()),Name:req.Name,Category:req.Category,Identity:req.Identity,Lifecycle:req.Lifecycle,Owner:req.Owner,Criticality:req.Criticality,Exposure:req.Exposure,Classification:req.Classification});if err!=nil{writeError(w,rt.log,err);return};writeJSON(w,http.StatusCreated,a)}
+func (rt *Router) listAssets(w http.ResponseWriter,r *http.Request){out,err:=rt.assetInventory.ListAssets(r.Context(),shared.ID(TenantFrom(r.Context())));if err!=nil{writeError(w,rt.log,err);return};writeJSON(w,http.StatusOK,out)}
+func (rt *Router) getAsset(w http.ResponseWriter,r *http.Request){a,err:=rt.assetInventory.GetAsset(r.Context(),shared.ID(TenantFrom(r.Context())),shared.ID(r.PathValue("id")));if err!=nil{writeError(w,rt.log,err);return};writeJSON(w,http.StatusOK,a)}
+func (rt *Router) addAssetVersion(w http.ResponseWriter,r *http.Request){var req struct{Value string `json:"value"`;Source string `json:"source"`};if !decodeAssetInventoryJSON(w,r,&req){return};v,err:=rt.assetInventory.AddVersion(r.Context(),PrincipalFrom(r.Context()),shared.ID(TenantFrom(r.Context())),shared.ID(r.PathValue("id")),req.Value,req.Source);if err!=nil{writeError(w,rt.log,err);return};writeJSON(w,http.StatusCreated,v)}
+func (rt *Router) linkBusinessServiceAsset(w http.ResponseWriter,r *http.Request){var req struct{AssetID shared.ID `json:"asset_id"`;Role asset.BusinessServiceRole `json:"role"`};if !decodeAssetInventoryJSON(w,r,&req){return};out,err:=rt.assetInventory.LinkBusinessServiceAsset(r.Context(),PrincipalFrom(r.Context()),shared.ID(TenantFrom(r.Context())),shared.ID(r.PathValue("id")),req.AssetID,req.Role);if err!=nil{writeError(w,rt.log,err);return};writeJSON(w,http.StatusCreated,out)}
+func (rt *Router) addAssetRelationship(w http.ResponseWriter,r *http.Request){var req struct{ToAssetID shared.ID `json:"to_asset_id"`;Type asset.RelationshipType `json:"type"`};if !decodeAssetInventoryJSON(w,r,&req){return};out,err:=rt.assetInventory.AddRelationship(r.Context(),PrincipalFrom(r.Context()),shared.ID(TenantFrom(r.Context())),shared.ID(r.PathValue("id")),req.ToAssetID,req.Type);if err!=nil{writeError(w,rt.log,err);return};writeJSON(w,http.StatusCreated,out)}
+func (rt *Router) listAssetRelationships(w http.ResponseWriter,r *http.Request){out,err:=rt.assetInventory.ListRelationships(r.Context(),shared.ID(TenantFrom(r.Context())),shared.ID(r.PathValue("id")));if err!=nil{writeError(w,rt.log,err);return};writeJSON(w,http.StatusOK,out)}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -63,6 +63,7 @@ type Router struct {
 	qualityGates    qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
 	qualityProfiles qualityProfileService // optional; nil ⇒ quality-profile routes are not registered
 	rules           rulesService          // optional; nil ⇒ rule catalog routes are not registered
+	assetInventory assetInventoryService // optional; nil ⇒ Asset Inventory routes are not registered
 }
 
 // findingVerifier is the narrow slice of the exploitation use-case the verify endpoint needs:
@@ -192,6 +193,17 @@ func (rt *Router) withEngTenant(h http.HandlerFunc) http.HandlerFunc {
 // without the auth/AUP middleware (which are validated separately).
 func (rt *Router) routes() *http.ServeMux {
 	mux := http.NewServeMux()
+	if rt.assetInventory != nil {
+		mux.HandleFunc("GET /api/v1/appsec/business-services", rt.authz(userdom.PermView, rt.listBusinessServices))
+		mux.HandleFunc("POST /api/v1/appsec/business-services", rt.authz(userdom.PermOperate, rt.createBusinessService))
+		mux.HandleFunc("POST /api/v1/appsec/business-services/{id}/assets", rt.authz(userdom.PermOperate, rt.linkBusinessServiceAsset))
+		mux.HandleFunc("GET /api/v1/appsec/assets", rt.authz(userdom.PermView, rt.listAssets))
+		mux.HandleFunc("POST /api/v1/appsec/assets", rt.authz(userdom.PermOperate, rt.createAsset))
+		mux.HandleFunc("GET /api/v1/appsec/assets/{id}", rt.authz(userdom.PermView, rt.getAsset))
+		mux.HandleFunc("POST /api/v1/appsec/assets/{id}/versions", rt.authz(userdom.PermOperate, rt.addAssetVersion))
+		mux.HandleFunc("GET /api/v1/appsec/assets/{id}/relationships", rt.authz(userdom.PermView, rt.listAssetRelationships))
+		mux.HandleFunc("POST /api/v1/appsec/assets/{id}/relationships", rt.authz(userdom.PermOperate, rt.addAssetRelationship))
+	}
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "service": "synapse-api"})
 	})

--- a/internal/domain/asset/asset.go
+++ b/internal/domain/asset/asset.go
@@ -1,0 +1,250 @@
+// Package asset defines durable, tenant-scoped AppSec inventory records.
+package asset
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Category classifies an AppSec-relevant technical asset.
+type Category string
+
+const (
+	CategoryApplication    Category = "application"
+	CategoryRepository     Category = "repository"
+	CategoryPipeline       Category = "pipeline"
+	CategoryService        Category = "service"
+	CategoryAPI            Category = "api"
+	CategoryEndpoint       Category = "endpoint"
+	CategoryDomain         Category = "domain"
+	CategoryIPRange        Category = "ip_range"
+	CategoryCloudAccount   Category = "cloud_account"
+	CategoryCloudProject   Category = "cloud_project"
+	CategoryCloudResource  Category = "cloud_resource"
+	CategoryCluster        Category = "cluster"
+	CategoryWorkload       Category = "workload"
+	CategoryContainerImage Category = "container_image"
+	CategoryArtifact       Category = "artifact"
+	CategorySBOM           Category = "sbom"
+	CategoryDatabase       Category = "database"
+	CategoryQueue          Category = "queue"
+	CategoryStorage        Category = "storage"
+	CategoryInfrastructure Category = "infrastructure"
+	CategoryIaCModule      Category = "iac_module"
+)
+
+func (c Category) Valid() bool {
+	switch c {
+	case CategoryApplication, CategoryRepository, CategoryPipeline, CategoryService, CategoryAPI, CategoryEndpoint, CategoryDomain, CategoryIPRange, CategoryCloudAccount, CategoryCloudProject, CategoryCloudResource, CategoryCluster, CategoryWorkload, CategoryContainerImage, CategoryArtifact, CategorySBOM, CategoryDatabase, CategoryQueue, CategoryStorage, CategoryInfrastructure, CategoryIaCModule:
+		return true
+	}
+	return false
+}
+
+// Lifecycle records whether an asset remains managed by the organization.
+type Lifecycle string
+
+const (
+	LifecycleActive   Lifecycle = "active"
+	LifecycleRetired  Lifecycle = "retired"
+	LifecyclePlanned  Lifecycle = "planned"
+	LifecycleUnknown  Lifecycle = "unknown"
+)
+
+func (l Lifecycle) Valid() bool {
+	switch l {
+	case LifecycleActive, LifecycleRetired, LifecyclePlanned, LifecycleUnknown:
+		return true
+	}
+	return false
+}
+
+// RelationshipType describes a directed, AppSec-relevant edge between Assets.
+type RelationshipType string
+
+const (
+	RelationshipContains     RelationshipType = "contains"
+	RelationshipPartOf       RelationshipType = "part_of"
+	RelationshipDependsOn    RelationshipType = "depends_on"
+	RelationshipRunsOn       RelationshipType = "runs_on"
+	RelationshipDeployedTo   RelationshipType = "deployed_to"
+	RelationshipExposes      RelationshipType = "exposes"
+	RelationshipBuiltFrom    RelationshipType = "built_from"
+	RelationshipManagedBy    RelationshipType = "managed_by"
+	RelationshipProcessesData RelationshipType = "processes_data"
+)
+
+func (r RelationshipType) Valid() bool {
+	switch r {
+	case RelationshipContains, RelationshipPartOf, RelationshipDependsOn, RelationshipRunsOn, RelationshipDeployedTo, RelationshipExposes, RelationshipBuiltFrom, RelationshipManagedBy, RelationshipProcessesData:
+		return true
+	}
+	return false
+}
+
+// BusinessServiceRole describes why a Business Service references an Asset.
+type BusinessServiceRole string
+
+const (
+	BusinessServiceOwns     BusinessServiceRole = "owns"
+	BusinessServiceUses     BusinessServiceRole = "uses"
+	BusinessServiceSupports BusinessServiceRole = "supports"
+)
+
+func (r BusinessServiceRole) Valid() bool {
+	switch r {
+	case BusinessServiceOwns, BusinessServiceUses, BusinessServiceSupports:
+		return true
+	}
+	return false
+}
+
+var (
+	digestPattern = regexp.MustCompile(`^[a-z0-9]+:[a-fA-F0-9]{32,128}$`)
+	namePattern   = regexp.MustCompile(`^[[:print:]]{1,200}$`)
+)
+
+// Identity is a stable, category-appropriate external identifier. It never holds a credential.
+type Identity struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
+func (i Identity) Validate(category Category) (Identity, error) {
+	i.Kind, i.Value = strings.TrimSpace(strings.ToLower(i.Kind)), strings.TrimSpace(i.Value)
+	if i.Kind == "" || i.Value == "" || len(i.Kind) > 64 || len(i.Value) > 2048 {
+		return Identity{}, fmt.Errorf("%w: asset identity kind and value are required", shared.ErrValidation)
+	}
+	if strings.ContainsAny(i.Value, "\r\n\x00") || strings.Contains(i.Value, "@") && strings.Contains(i.Value, "://") {
+		return Identity{}, fmt.Errorf("%w: invalid asset identity", shared.ErrValidation)
+	}
+	switch category {
+	case CategoryRepository:
+		if i.Kind != "url" {
+			return Identity{}, fmt.Errorf("%w: repository identity must use kind url", shared.ErrValidation)
+		}
+		u, err := url.Parse(i.Value)
+		if err != nil || u.Scheme != "https" || u.Host == "" || u.User != nil {
+			return Identity{}, fmt.Errorf("%w: repository identity must be an https URL without credentials", shared.ErrValidation)
+		}
+	case CategoryEndpoint:
+		if i.Kind != "url" {
+			return Identity{}, fmt.Errorf("%w: endpoint identity must use kind url", shared.ErrValidation)
+		}
+		u, err := url.Parse(i.Value)
+		if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" || u.User != nil {
+			return Identity{}, fmt.Errorf("%w: endpoint identity must be an http(s) URL without credentials", shared.ErrValidation)
+		}
+	case CategoryContainerImage, CategoryArtifact, CategorySBOM:
+		if i.Kind != "digest" || !digestPattern.MatchString(i.Value) {
+			return Identity{}, fmt.Errorf("%w: %s identity must be a digest", shared.ErrValidation, category)
+		}
+	case CategoryDomain:
+		if i.Kind != "domain" || strings.Contains(i.Value, "/") || net.ParseIP(i.Value) != nil || !strings.Contains(i.Value, ".") {
+			return Identity{}, fmt.Errorf("%w: domain identity must be a DNS name", shared.ErrValidation)
+		}
+	case CategoryIPRange:
+		if i.Kind != "cidr" {
+			return Identity{}, fmt.Errorf("%w: ip range identity must use kind cidr", shared.ErrValidation)
+		}
+		if _, _, err := net.ParseCIDR(i.Value); err != nil {
+			return Identity{}, fmt.Errorf("%w: invalid CIDR", shared.ErrValidation)
+		}
+	default:
+		if i.Kind != "external_id" && i.Kind != "package" && i.Kind != "cloud_id" && i.Kind != "name" {
+			return Identity{}, fmt.Errorf("%w: unsupported identity kind %q for %s", shared.ErrValidation, i.Kind, category)
+		}
+	}
+	return i, nil
+}
+
+// Asset is a durable technical inventory record.
+type Asset struct {
+	ID             shared.ID
+	TenantID       shared.ID
+	Name           string
+	Category       Category
+	Identity       Identity
+	Lifecycle      Lifecycle
+	Owner          string
+	Criticality    string
+	Exposure       string
+	Classification string
+	Audit          shared.Audit
+}
+
+func New(id, tenantID shared.ID, name string, category Category, identity Identity, lifecycle Lifecycle, owner, criticality, exposure, classification string, now time.Time) (*Asset, error) {
+	if id.IsZero() {
+		return nil, fmt.Errorf("%w: asset id is required", shared.ErrValidation)
+	}
+	name = strings.TrimSpace(name)
+	if !namePattern.MatchString(name) {
+		return nil, fmt.Errorf("%w: asset name is required and must be at most 200 printable characters", shared.ErrValidation)
+	}
+	if !category.Valid() || !lifecycle.Valid() {
+		return nil, fmt.Errorf("%w: invalid asset category or lifecycle", shared.ErrValidation)
+	}
+	identity, err := identity.Validate(category)
+	if err != nil {
+		return nil, err
+	}
+	for _, value := range []string{owner, criticality, exposure, classification} {
+		if len(strings.TrimSpace(value)) > 200 || strings.ContainsAny(value, "\r\n\x00") {
+			return nil, fmt.Errorf("%w: invalid asset metadata", shared.ErrValidation)
+		}
+	}
+	return &Asset{ID: id, TenantID: tenantID, Name: name, Category: category, Identity: identity, Lifecycle: lifecycle, Owner: strings.TrimSpace(owner), Criticality: strings.TrimSpace(criticality), Exposure: strings.TrimSpace(exposure), Classification: strings.TrimSpace(classification), Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}, nil
+}
+
+// Relationship is a directed edge between two tenant-scoped Assets.
+type Relationship struct {
+	FromAssetID shared.ID
+	ToAssetID   shared.ID
+	Type        RelationshipType
+	Audit       shared.Audit
+}
+
+func NewRelationship(from, to shared.ID, kind RelationshipType, now time.Time) (Relationship, error) {
+	if from.IsZero() || to.IsZero() || from == to || !kind.Valid() {
+		return Relationship{}, fmt.Errorf("%w: invalid asset relationship", shared.ErrValidation)
+	}
+	return Relationship{FromAssetID: from, ToAssetID: to, Type: kind, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}, nil
+}
+
+// BusinessServiceLink associates a durable Asset with a Business Service.
+type BusinessServiceLink struct {
+	BusinessServiceID shared.ID
+	AssetID           shared.ID
+	Role              BusinessServiceRole
+	Audit             shared.Audit
+}
+
+func NewBusinessServiceLink(serviceID, assetID shared.ID, role BusinessServiceRole, now time.Time) (BusinessServiceLink, error) {
+	if serviceID.IsZero() || assetID.IsZero() || !role.Valid() {
+		return BusinessServiceLink{}, fmt.Errorf("%w: invalid business service asset link", shared.ErrValidation)
+	}
+	return BusinessServiceLink{BusinessServiceID: serviceID, AssetID: assetID, Role: role, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}, nil
+}
+
+// Version is an observed or managed version of a durable Asset.
+type Version struct {
+	ID      shared.ID
+	AssetID shared.ID
+	Value   string
+	Source  string
+	Audit   shared.Audit
+}
+
+func NewVersion(id, assetID shared.ID, value, source string, now time.Time) (Version, error) {
+	value, source = strings.TrimSpace(value), strings.TrimSpace(source)
+	if id.IsZero() || assetID.IsZero() || value == "" || len(value) > 512 || len(source) > 100 || strings.ContainsAny(value+source, "\r\n\x00") {
+		return Version{}, fmt.Errorf("%w: invalid asset version", shared.ErrValidation)
+	}
+	return Version{ID: id, AssetID: assetID, Value: value, Source: source, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}, nil
+}

--- a/internal/domain/asset/asset_test.go
+++ b/internal/domain/asset/asset_test.go
@@ -1,0 +1,27 @@
+package asset
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestNewValidatesCategoryIdentity(t *testing.T) {
+	now := time.Now()
+	a, err := New("asset-1", "tenant-a", "Transfer API", CategoryEndpoint, Identity{Kind: "url", Value: "https://api.example.com/transfers"}, LifecycleActive, "payments", "high", "internet", "confidential", now)
+	if err != nil { t.Fatal(err) }
+	if a.Identity.Value != "https://api.example.com/transfers" || a.Audit.CreatedAt != now { t.Fatalf("unexpected asset: %+v", a) }
+	_, err = New("asset-2", "tenant-a", "Bad endpoint", CategoryEndpoint, Identity{Kind: "url", Value: "https://user:secret@example.com"}, LifecycleActive, "", "", "", "", now)
+	if !errors.Is(err, shared.ErrValidation) { t.Fatalf("got %v, want validation error", err) }
+}
+
+func TestRelationshipAndLinkRejectInvalidValues(t *testing.T) {
+	if _, err := NewRelationship("a", "a", RelationshipContains, time.Now()); !errors.Is(err, shared.ErrValidation) { t.Fatalf("got %v", err) }
+	if _, err := NewBusinessServiceLink("", "asset", BusinessServiceOwns, time.Now()); !errors.Is(err, shared.ErrValidation) { t.Fatalf("got %v", err) }
+}
+
+func TestNewVersionRejectsUnsafeMetadata(t *testing.T) {
+	if _, err := NewVersion("version", "asset", "1.0\nsecret", "scanner", time.Now()); !errors.Is(err, shared.ErrValidation) { t.Fatalf("got %v", err) }
+}

--- a/internal/domain/businessservice/business_service.go
+++ b/internal/domain/businessservice/business_service.go
@@ -1,0 +1,41 @@
+// Package businessservice defines the durable AppSec management boundary.
+package businessservice
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var codePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+// BusinessService is a long-lived, tenant-scoped business capability that aggregates AppSec posture.
+type BusinessService struct {
+	ID          shared.ID
+	TenantID    shared.ID
+	Name        string
+	Code        string
+	Owner       string
+	Criticality string
+	Audit       shared.Audit
+}
+
+func New(id, tenantID shared.ID, name, code, owner, criticality string, now time.Time) (*BusinessService, error) {
+	if id.IsZero() {
+		return nil, fmt.Errorf("%w: business service id is required", shared.ErrValidation)
+	}
+	name, code, owner, criticality = strings.TrimSpace(name), strings.TrimSpace(code), strings.TrimSpace(owner), strings.TrimSpace(criticality)
+	if name == "" || len(name) > 200 || strings.ContainsAny(name, "\r\n\x00") {
+		return nil, fmt.Errorf("%w: business service name is required", shared.ErrValidation)
+	}
+	if !codePattern.MatchString(code) {
+		return nil, fmt.Errorf("%w: business service code must be a lowercase hyphenated slug", shared.ErrValidation)
+	}
+	if len(owner) > 200 || len(criticality) > 100 || strings.ContainsAny(owner+criticality, "\r\n\x00") {
+		return nil, fmt.Errorf("%w: invalid business service metadata", shared.ErrValidation)
+	}
+	return &BusinessService{ID: id, TenantID: tenantID, Name: name, Code: code, Owner: owner, Criticality: criticality, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}, nil
+}

--- a/internal/infrastructure/persistence/memory/asset_inventory_repo.go
+++ b/internal/infrastructure/persistence/memory/asset_inventory_repo.go
@@ -1,0 +1,100 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/businessservice"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.AssetInventoryRepository = (*AssetInventoryRepository)(nil)
+
+// AssetInventoryRepository is a goroutine-safe, tenant-scoped development store.
+type AssetInventoryRepository struct {
+	mu           sync.RWMutex
+	services     map[shared.ID]*businessservice.BusinessService
+	serviceByKey map[string]shared.ID
+	assets       map[shared.ID]*asset.Asset
+	versions     map[shared.ID][]asset.Version
+	links        map[shared.ID]map[shared.ID]asset.BusinessServiceLink
+	relations    map[shared.ID][]asset.Relationship
+}
+
+func NewAssetInventoryRepository() *AssetInventoryRepository {
+	return &AssetInventoryRepository{
+		services: map[shared.ID]*businessservice.BusinessService{}, serviceByKey: map[string]shared.ID{}, assets: map[shared.ID]*asset.Asset{},
+		versions: map[shared.ID][]asset.Version{}, links: map[shared.ID]map[shared.ID]asset.BusinessServiceLink{}, relations: map[shared.ID][]asset.Relationship{},
+	}
+}
+
+func inventoryKey(tenantID shared.ID, value string) string { return tenantID.String() + "\x00" + value }
+func cloneService(in *businessservice.BusinessService) *businessservice.BusinessService { cp := *in; return &cp }
+func cloneAsset(in *asset.Asset) *asset.Asset { cp := *in; return &cp }
+
+func (r *AssetInventoryRepository) CreateBusinessService(_ context.Context, service *businessservice.BusinessService) error {
+	if service == nil { return fmt.Errorf("%w: business service is required", shared.ErrValidation) }
+	r.mu.Lock(); defer r.mu.Unlock()
+	key := inventoryKey(service.TenantID, service.Code)
+	if _, ok := r.serviceByKey[key]; ok { return fmt.Errorf("%w: business service code already exists", shared.ErrConflict) }
+	r.services[service.ID] = cloneService(service); r.serviceByKey[key] = service.ID
+	return nil
+}
+func (r *AssetInventoryRepository) ListBusinessServices(_ context.Context, tenantID shared.ID) ([]*businessservice.BusinessService, error) {
+	r.mu.RLock(); defer r.mu.RUnlock(); out := make([]*businessservice.BusinessService, 0)
+	for _, service := range r.services { if service.TenantID == tenantID { out = append(out, cloneService(service)) } }
+	sort.Slice(out, func(i,j int) bool { return out[i].Code < out[j].Code }); return out, nil
+}
+func (r *AssetInventoryRepository) GetBusinessService(_ context.Context, tenantID, id shared.ID) (*businessservice.BusinessService, error) {
+	r.mu.RLock(); defer r.mu.RUnlock(); service, ok := r.services[id]
+	if !ok || service.TenantID != tenantID { return nil, shared.ErrNotFound }; return cloneService(service), nil
+}
+func (r *AssetInventoryRepository) CreateAsset(_ context.Context, a *asset.Asset) error {
+	if a == nil { return fmt.Errorf("%w: asset is required", shared.ErrValidation) }
+	r.mu.Lock(); defer r.mu.Unlock()
+	for _, existing := range r.assets { if existing.TenantID == a.TenantID && existing.Category == a.Category && existing.Identity == a.Identity { return fmt.Errorf("%w: asset identity already exists", shared.ErrConflict) } }
+	r.assets[a.ID] = cloneAsset(a); return nil
+}
+func (r *AssetInventoryRepository) GetAsset(_ context.Context, tenantID, id shared.ID) (*asset.Asset, error) {
+	r.mu.RLock(); defer r.mu.RUnlock(); a, ok := r.assets[id]
+	if !ok || a.TenantID != tenantID { return nil, shared.ErrNotFound }; return cloneAsset(a), nil
+}
+func (r *AssetInventoryRepository) ListAssets(_ context.Context, tenantID shared.ID) ([]*asset.Asset, error) {
+	r.mu.RLock(); defer r.mu.RUnlock(); out := make([]*asset.Asset, 0)
+	for _, a := range r.assets { if a.TenantID == tenantID { out = append(out, cloneAsset(a)) } }
+	sort.Slice(out, func(i,j int) bool { return out[i].Name < out[j].Name }); return out, nil
+}
+func (r *AssetInventoryRepository) CreateVersion(_ context.Context, version asset.Version) error {
+	r.mu.Lock(); defer r.mu.Unlock(); if _, ok := r.assets[version.AssetID]; !ok { return shared.ErrNotFound }
+	for _, existing := range r.versions[version.AssetID] { if existing.Value == version.Value && existing.Source == version.Source { return fmt.Errorf("%w: asset version already exists", shared.ErrConflict) } }
+	r.versions[version.AssetID] = append(r.versions[version.AssetID], version); return nil
+}
+func (r *AssetInventoryRepository) ListVersions(_ context.Context, tenantID, assetID shared.ID) ([]asset.Version, error) {
+	r.mu.RLock(); defer r.mu.RUnlock(); a, ok := r.assets[assetID]; if !ok || a.TenantID != tenantID { return nil, shared.ErrNotFound }
+	out := append([]asset.Version(nil), r.versions[assetID]...); sort.Slice(out, func(i,j int) bool { return out[i].Audit.CreatedAt.After(out[j].Audit.CreatedAt) }); return out, nil
+}
+func (r *AssetInventoryRepository) LinkBusinessServiceAsset(_ context.Context, link asset.BusinessServiceLink) error {
+	r.mu.Lock(); defer r.mu.Unlock(); service, sok := r.services[link.BusinessServiceID]; a, aok := r.assets[link.AssetID]
+	if !sok || !aok || service.TenantID != a.TenantID { return shared.ErrNotFound }
+	if r.links[link.BusinessServiceID] == nil { r.links[link.BusinessServiceID] = map[shared.ID]asset.BusinessServiceLink{} }
+	if _, exists := r.links[link.BusinessServiceID][link.AssetID]; exists { return fmt.Errorf("%w: business service asset link already exists", shared.ErrConflict) }
+	r.links[link.BusinessServiceID][link.AssetID] = link; return nil
+}
+func (r *AssetInventoryRepository) ListBusinessServiceAssets(_ context.Context, tenantID, serviceID shared.ID) ([]asset.BusinessServiceLink, error) {
+	r.mu.RLock(); defer r.mu.RUnlock(); service, ok := r.services[serviceID]; if !ok || service.TenantID != tenantID { return nil, shared.ErrNotFound }
+	out := make([]asset.BusinessServiceLink, 0, len(r.links[serviceID])); for _, link := range r.links[serviceID] { out = append(out, link) }; sort.Slice(out, func(i,j int) bool { return out[i].AssetID < out[j].AssetID }); return out, nil
+}
+func (r *AssetInventoryRepository) CreateRelationship(_ context.Context, tenantID shared.ID, rel asset.Relationship) error {
+	r.mu.Lock(); defer r.mu.Unlock(); from, fok := r.assets[rel.FromAssetID]; to, tok := r.assets[rel.ToAssetID]
+	if !fok || !tok || from.TenantID != tenantID || to.TenantID != tenantID { return shared.ErrNotFound }
+	for _, existing := range r.relations[rel.FromAssetID] { if existing.ToAssetID == rel.ToAssetID && existing.Type == rel.Type { return fmt.Errorf("%w: asset relationship already exists", shared.ErrConflict) } }
+	r.relations[rel.FromAssetID] = append(r.relations[rel.FromAssetID], rel); return nil
+}
+func (r *AssetInventoryRepository) ListRelationships(_ context.Context, tenantID, assetID shared.ID) ([]asset.Relationship, error) {
+	r.mu.RLock(); defer r.mu.RUnlock(); a, ok := r.assets[assetID]; if !ok || a.TenantID != tenantID { return nil, shared.ErrNotFound }
+	out := append([]asset.Relationship(nil), r.relations[assetID]...); for _, rels := range r.relations { for _, rel := range rels { if rel.ToAssetID == assetID { out = append(out, rel) } } }; return out, nil
+}

--- a/internal/infrastructure/persistence/postgres/asset_inventory_repo.go
+++ b/internal/infrastructure/persistence/postgres/asset_inventory_repo.go
@@ -1,0 +1,87 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/businessservice"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const businessServiceCols = `id, tenant_id, name, code, owner, criticality, created_at, updated_at, created_by, updated_by`
+const assetCols = `id, tenant_id, name, category, identity_kind, identity_value, lifecycle, owner, criticality, exposure, classification, created_at, updated_at, created_by, updated_by`
+
+type AssetInventoryRepository struct{ pool *pgxpool.Pool }
+func NewAssetInventoryRepository(pool *pgxpool.Pool) *AssetInventoryRepository { return &AssetInventoryRepository{pool: pool} }
+var _ ports.AssetInventoryRepository = (*AssetInventoryRepository)(nil)
+
+func (r *AssetInventoryRepository) CreateBusinessService(ctx context.Context, s *businessservice.BusinessService) error {
+	_, err := r.pool.Exec(ctx, `INSERT INTO appsec_business_services (`+businessServiceCols+`) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, s.ID.String(), s.TenantID.String(), s.Name, s.Code, s.Owner, s.Criticality, s.Audit.CreatedAt, s.Audit.UpdatedAt, s.Audit.CreatedBy, s.Audit.UpdatedBy)
+	return inventoryWriteError(err, "business service")
+}
+func (r *AssetInventoryRepository) ListBusinessServices(ctx context.Context, tenantID shared.ID) ([]*businessservice.BusinessService, error) {
+	rows, err := r.pool.Query(ctx, `SELECT `+businessServiceCols+` FROM appsec_business_services WHERE tenant_id=$1 ORDER BY code`, tenantID.String()); if err != nil { return nil, fmt.Errorf("list business services: %w", err) }; defer rows.Close()
+	out := make([]*businessservice.BusinessService, 0); for rows.Next() { s, err := scanBusinessService(rows); if err != nil { return nil, err }; out = append(out, s) }; return out, rows.Err()
+}
+func (r *AssetInventoryRepository) GetBusinessService(ctx context.Context, tenantID, id shared.ID) (*businessservice.BusinessService, error) {
+	s, err := scanBusinessService(r.pool.QueryRow(ctx, `SELECT `+businessServiceCols+` FROM appsec_business_services WHERE tenant_id=$1 AND id=$2`, tenantID.String(), id.String())); if errors.Is(err, pgx.ErrNoRows) { return nil, shared.ErrNotFound }; if err != nil { return nil, fmt.Errorf("get business service: %w", err) }; return s, nil
+}
+func (r *AssetInventoryRepository) CreateAsset(ctx context.Context, a *asset.Asset) error {
+	_, err := r.pool.Exec(ctx, `INSERT INTO appsec_assets (`+assetCols+`) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`, a.ID.String(), a.TenantID.String(), a.Name, a.Category, a.Identity.Kind, a.Identity.Value, a.Lifecycle, a.Owner, a.Criticality, a.Exposure, a.Classification, a.Audit.CreatedAt, a.Audit.UpdatedAt, a.Audit.CreatedBy, a.Audit.UpdatedBy)
+	return inventoryWriteError(err, "asset")
+}
+func (r *AssetInventoryRepository) GetAsset(ctx context.Context, tenantID, id shared.ID) (*asset.Asset, error) {
+	a, err := scanAsset(r.pool.QueryRow(ctx, `SELECT `+assetCols+` FROM appsec_assets WHERE tenant_id=$1 AND id=$2`, tenantID.String(), id.String())); if errors.Is(err, pgx.ErrNoRows) { return nil, shared.ErrNotFound }; if err != nil { return nil, fmt.Errorf("get asset: %w", err) }; return a, nil
+}
+func (r *AssetInventoryRepository) ListAssets(ctx context.Context, tenantID shared.ID) ([]*asset.Asset, error) {
+	rows, err := r.pool.Query(ctx, `SELECT `+assetCols+` FROM appsec_assets WHERE tenant_id=$1 ORDER BY name, id`, tenantID.String()); if err != nil { return nil, fmt.Errorf("list assets: %w", err) }; defer rows.Close()
+	out := make([]*asset.Asset, 0); for rows.Next() { a, err := scanAsset(rows); if err != nil { return nil, err }; out = append(out, a) }; return out, rows.Err()
+}
+func (r *AssetInventoryRepository) CreateVersion(ctx context.Context, v asset.Version) error {
+	ct, err := r.pool.Exec(ctx, `INSERT INTO appsec_asset_versions (id,asset_id,value,source,created_at,updated_at,created_by,updated_by) SELECT $1,$2,$3,$4,$5,$6,$7,$8 WHERE EXISTS (SELECT 1 FROM appsec_assets WHERE id=$2)`, v.ID.String(), v.AssetID.String(), v.Value, v.Source, v.Audit.CreatedAt, v.Audit.UpdatedAt, v.Audit.CreatedBy, v.Audit.UpdatedBy)
+	if err != nil { return inventoryWriteError(err, "asset version") }
+	if ct.RowsAffected() == 0 { return shared.ErrNotFound }
+	return nil
+}
+func (r *AssetInventoryRepository) ListVersions(ctx context.Context, tenantID, assetID shared.ID) ([]asset.Version, error) {
+	if _, err := r.GetAsset(ctx, tenantID, assetID); err != nil { return nil, err }
+	rows, err := r.pool.Query(ctx, `SELECT id,asset_id,value,source,created_at,updated_at,created_by,updated_by FROM appsec_asset_versions WHERE asset_id=$1 ORDER BY created_at DESC,id`, assetID.String()); if err != nil { return nil, fmt.Errorf("list asset versions: %w", err) }; defer rows.Close()
+	out := make([]asset.Version, 0); for rows.Next() { var v asset.Version; var id, aid string; if err := rows.Scan(&id,&aid,&v.Value,&v.Source,&v.Audit.CreatedAt,&v.Audit.UpdatedAt,&v.Audit.CreatedBy,&v.Audit.UpdatedBy); err != nil { return nil, err }; v.ID, v.AssetID = shared.ID(id), shared.ID(aid); out = append(out,v) }; return out, rows.Err()
+}
+func (r *AssetInventoryRepository) LinkBusinessServiceAsset(ctx context.Context, link asset.BusinessServiceLink) error {
+	ct, err := r.pool.Exec(ctx, `INSERT INTO appsec_business_service_assets (business_service_id,asset_id,role,created_at,updated_at,created_by,updated_by) SELECT $1,$2,$3,$4,$5,$6,$7 WHERE EXISTS (SELECT 1 FROM appsec_business_services s JOIN appsec_assets a ON a.tenant_id=s.tenant_id WHERE s.id=$1 AND a.id=$2)`, link.BusinessServiceID.String(),link.AssetID.String(),link.Role,link.Audit.CreatedAt,link.Audit.UpdatedAt,link.Audit.CreatedBy,link.Audit.UpdatedBy); if err != nil { return inventoryWriteError(err,"business service asset link") }; if ct.RowsAffected()==0 { return shared.ErrNotFound }; return nil
+}
+func (r *AssetInventoryRepository) ListBusinessServiceAssets(ctx context.Context, tenantID, serviceID shared.ID) ([]asset.BusinessServiceLink, error) {
+	if _, err := r.GetBusinessService(ctx, tenantID, serviceID); err != nil { return nil, err }
+	rows, err := r.pool.Query(ctx, `SELECT business_service_id,asset_id,role,created_at,updated_at,created_by,updated_by FROM appsec_business_service_assets WHERE business_service_id=$1 ORDER BY asset_id`,serviceID.String()); if err != nil { return nil,fmt.Errorf("list business service assets: %w",err)};defer rows.Close();out:=make([]asset.BusinessServiceLink,0);for rows.Next(){var l asset.BusinessServiceLink;var sid,aid string;if err:=rows.Scan(&sid,&aid,&l.Role,&l.Audit.CreatedAt,&l.Audit.UpdatedAt,&l.Audit.CreatedBy,&l.Audit.UpdatedBy);err!=nil{return nil,err};l.BusinessServiceID,l.AssetID=shared.ID(sid),shared.ID(aid);out=append(out,l)};return out,rows.Err()
+}
+func (r *AssetInventoryRepository) CreateRelationship(ctx context.Context, tenantID shared.ID, rel asset.Relationship) error {
+	ct, err := r.pool.Exec(ctx, `INSERT INTO appsec_asset_relationships (from_asset_id,to_asset_id,relationship_type,created_at,updated_at,created_by,updated_by) SELECT $1,$2,$3,$4,$5,$6,$7 WHERE EXISTS (SELECT 1 FROM appsec_assets a JOIN appsec_assets b ON b.tenant_id=a.tenant_id WHERE a.id=$1 AND b.id=$2 AND a.tenant_id=$8)`,rel.FromAssetID.String(),rel.ToAssetID.String(),rel.Type,rel.Audit.CreatedAt,rel.Audit.UpdatedAt,rel.Audit.CreatedBy,rel.Audit.UpdatedBy,tenantID.String());if err!=nil{return inventoryWriteError(err,"asset relationship")};if ct.RowsAffected()==0{return shared.ErrNotFound};return nil
+}
+func (r *AssetInventoryRepository) ListRelationships(ctx context.Context, tenantID, assetID shared.ID) ([]asset.Relationship,error) {
+	if _, err := r.GetAsset(ctx, tenantID, assetID); err != nil { return nil, err }
+	rows, err := r.pool.Query(ctx, `SELECT from_asset_id,to_asset_id,relationship_type,created_at,updated_at,created_by,updated_by FROM appsec_asset_relationships WHERE from_asset_id=$1 OR to_asset_id=$1 ORDER BY created_at,from_asset_id,to_asset_id,relationship_type`, assetID.String())
+	if err != nil { return nil, fmt.Errorf("list asset relationships: %w", err) }
+	defer rows.Close()
+	out := make([]asset.Relationship, 0)
+	for rows.Next() {
+		var rel asset.Relationship
+		var from, to string
+		if err := rows.Scan(&from, &to, &rel.Type, &rel.Audit.CreatedAt, &rel.Audit.UpdatedAt, &rel.Audit.CreatedBy, &rel.Audit.UpdatedBy); err != nil { return nil, err }
+		rel.FromAssetID, rel.ToAssetID = shared.ID(from), shared.ID(to)
+		out = append(out, rel)
+	}
+	return out, rows.Err()
+}
+
+type inventoryRowScanner interface{ Scan(...any) error }
+func scanBusinessService(row inventoryRowScanner)(*businessservice.BusinessService,error){var s businessservice.BusinessService;var id,tenant string;err:=row.Scan(&id,&tenant,&s.Name,&s.Code,&s.Owner,&s.Criticality,&s.Audit.CreatedAt,&s.Audit.UpdatedAt,&s.Audit.CreatedBy,&s.Audit.UpdatedBy);s.ID,s.TenantID=shared.ID(id),shared.ID(tenant);return &s,err}
+func scanAsset(row inventoryRowScanner)(*asset.Asset,error){var a asset.Asset;var id,tenant string;err:=row.Scan(&id,&tenant,&a.Name,&a.Category,&a.Identity.Kind,&a.Identity.Value,&a.Lifecycle,&a.Owner,&a.Criticality,&a.Exposure,&a.Classification,&a.Audit.CreatedAt,&a.Audit.UpdatedAt,&a.Audit.CreatedBy,&a.Audit.UpdatedBy);a.ID,a.TenantID=shared.ID(id),shared.ID(tenant);return &a,err}
+func inventoryWriteError(err error, subject string) error { if err==nil{return nil};var pgErr *pgconn.PgError;if errors.As(err,&pgErr)&&pgErr.Code=="23505"{return fmt.Errorf("%s already exists: %w",subject,shared.ErrConflict)};return fmt.Errorf("persist %s: %w",subject,err) }

--- a/internal/usecase/assetinventory/service.go
+++ b/internal/usecase/assetinventory/service.go
@@ -1,0 +1,195 @@
+// Package assetinventory implements durable AppSec asset and Business Service management.
+package assetinventory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/businessservice"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type Service struct {
+	repo  ports.AssetInventoryRepository
+	clock ports.Clock
+	ids   ports.IDGenerator
+	audit ports.AuditLogger
+}
+
+func NewService(repo ports.AssetInventoryRepository, clock ports.Clock, ids ports.IDGenerator, audit ports.AuditLogger) *Service {
+	return &Service{repo: repo, clock: clock, ids: ids, audit: audit}
+}
+
+type CreateBusinessServiceInput struct {
+	TenantID    shared.ID
+	Actor       string
+	Name        string
+	Code        string
+	Owner       string
+	Criticality string
+}
+
+func (s *Service) CreateBusinessService(ctx context.Context, in CreateBusinessServiceInput) (*businessservice.BusinessService, error) {
+	if err := requireActor(in.Actor); err != nil {
+		return nil, err
+	}
+	now := s.clock.Now()
+	service, err := businessservice.New(s.ids.NewID(), in.TenantID, in.Name, in.Code, in.Owner, in.Criticality, now)
+	if err != nil {
+		return nil, err
+	}
+	service.Audit.CreatedBy, service.Audit.UpdatedBy = in.Actor, in.Actor
+	if err := s.repo.CreateBusinessService(ctx, service); err != nil {
+		return nil, fmt.Errorf("persist business service: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: in.Actor, Action: "appsec.business_service.create", Target: service.ID.String(), Metadata: map[string]string{"code": service.Code}, At: now}); err != nil {
+		return nil, fmt.Errorf("audit business service create: %w", err)
+	}
+	return service, nil
+}
+
+func (s *Service) ListBusinessServices(ctx context.Context, tenantID shared.ID) ([]*businessservice.BusinessService, error) {
+	return s.repo.ListBusinessServices(ctx, tenantID)
+}
+
+type CreateAssetInput struct {
+	TenantID       shared.ID
+	Actor          string
+	Name           string
+	Category       asset.Category
+	Identity       asset.Identity
+	Lifecycle      asset.Lifecycle
+	Owner          string
+	Criticality    string
+	Exposure       string
+	Classification string
+}
+
+func (s *Service) CreateAsset(ctx context.Context, in CreateAssetInput) (*asset.Asset, error) {
+	if err := requireActor(in.Actor); err != nil {
+		return nil, err
+	}
+	now := s.clock.Now()
+	a, err := asset.New(s.ids.NewID(), in.TenantID, in.Name, in.Category, in.Identity, in.Lifecycle, in.Owner, in.Criticality, in.Exposure, in.Classification, now)
+	if err != nil {
+		return nil, err
+	}
+	a.Audit.CreatedBy, a.Audit.UpdatedBy = in.Actor, in.Actor
+	if err := s.repo.CreateAsset(ctx, a); err != nil {
+		return nil, fmt.Errorf("persist asset: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: in.Actor, Action: "appsec.asset.create", Target: a.ID.String(), Metadata: map[string]string{"category": string(a.Category)}, At: now}); err != nil {
+		return nil, fmt.Errorf("audit asset create: %w", err)
+	}
+	return a, nil
+}
+
+func (s *Service) ListAssets(ctx context.Context, tenantID shared.ID) ([]*asset.Asset, error) {
+	return s.repo.ListAssets(ctx, tenantID)
+}
+
+func (s *Service) GetAsset(ctx context.Context, tenantID, assetID shared.ID) (*asset.Asset, error) {
+	return s.repo.GetAsset(ctx, tenantID, assetID)
+}
+
+func (s *Service) AddVersion(ctx context.Context, actor string, tenantID, assetID shared.ID, value, source string) (asset.Version, error) {
+	if err := requireActor(actor); err != nil {
+		return asset.Version{}, err
+	}
+	if _, err := s.repo.GetAsset(ctx, tenantID, assetID); err != nil {
+		return asset.Version{}, err
+	}
+	now := s.clock.Now()
+	version, err := asset.NewVersion(s.ids.NewID(), assetID, value, source, now)
+	if err != nil {
+		return asset.Version{}, err
+	}
+	version.Audit.CreatedBy, version.Audit.UpdatedBy = actor, actor
+	if err := s.repo.CreateVersion(ctx, version); err != nil {
+		return asset.Version{}, fmt.Errorf("persist asset version: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: "appsec.asset.version.create", Target: version.ID.String(), Metadata: map[string]string{"asset_id": assetID.String()}, At: now}); err != nil {
+		return asset.Version{}, fmt.Errorf("audit asset version create: %w", err)
+	}
+	return version, nil
+}
+
+func (s *Service) LinkBusinessServiceAsset(ctx context.Context, actor string, tenantID, serviceID, assetID shared.ID, role asset.BusinessServiceRole) (asset.BusinessServiceLink, error) {
+	if err := requireActor(actor); err != nil {
+		return asset.BusinessServiceLink{}, err
+	}
+	if _, err := s.repo.GetBusinessService(ctx, tenantID, serviceID); err != nil {
+		return asset.BusinessServiceLink{}, err
+	}
+	if _, err := s.repo.GetAsset(ctx, tenantID, assetID); err != nil {
+		return asset.BusinessServiceLink{}, err
+	}
+	now := s.clock.Now()
+	link, err := asset.NewBusinessServiceLink(serviceID, assetID, role, now)
+	if err != nil {
+		return asset.BusinessServiceLink{}, err
+	}
+	link.Audit.CreatedBy, link.Audit.UpdatedBy = actor, actor
+	if err := s.repo.LinkBusinessServiceAsset(ctx, link); err != nil {
+		return asset.BusinessServiceLink{}, fmt.Errorf("link business service asset: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: "appsec.business_service.asset.link", Target: serviceID.String(), Metadata: map[string]string{"asset_id": assetID.String(), "role": string(role)}, At: now}); err != nil {
+		return asset.BusinessServiceLink{}, fmt.Errorf("audit business service asset link: %w", err)
+	}
+	return link, nil
+}
+
+func (s *Service) AddRelationship(ctx context.Context, actor string, tenantID, from, to shared.ID, kind asset.RelationshipType) (asset.Relationship, error) {
+	if err := requireActor(actor); err != nil {
+		return asset.Relationship{}, err
+	}
+	if _, err := s.repo.GetAsset(ctx, tenantID, from); err != nil {
+		return asset.Relationship{}, err
+	}
+	if _, err := s.repo.GetAsset(ctx, tenantID, to); err != nil {
+		return asset.Relationship{}, err
+	}
+	now := s.clock.Now()
+	rel, err := asset.NewRelationship(from, to, kind, now)
+	if err != nil {
+		return asset.Relationship{}, err
+	}
+	for _, existing := range mustListRelationships(ctx, s.repo, tenantID, from) {
+		if existing.FromAssetID == to && existing.ToAssetID == from && ((kind == asset.RelationshipContains && existing.Type == asset.RelationshipContains) || (kind == asset.RelationshipPartOf && existing.Type == asset.RelationshipPartOf)) {
+			return asset.Relationship{}, fmt.Errorf("%w: direct containment cycle", shared.ErrValidation)
+		}
+	}
+	rel.Audit.CreatedBy, rel.Audit.UpdatedBy = actor, actor
+	if err := s.repo.CreateRelationship(ctx, tenantID, rel); err != nil {
+		return asset.Relationship{}, fmt.Errorf("persist asset relationship: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: "appsec.asset.relationship.create", Target: from.String(), Metadata: map[string]string{"to_asset_id": to.String(), "type": string(kind)}, At: now}); err != nil {
+		return asset.Relationship{}, fmt.Errorf("audit asset relationship create: %w", err)
+	}
+	return rel, nil
+}
+
+func (s *Service) ListRelationships(ctx context.Context, tenantID, assetID shared.ID) ([]asset.Relationship, error) {
+	if _, err := s.repo.GetAsset(ctx, tenantID, assetID); err != nil {
+		return nil, err
+	}
+	return s.repo.ListRelationships(ctx, tenantID, assetID)
+}
+
+func mustListRelationships(ctx context.Context, repo ports.AssetInventoryRepository, tenantID, assetID shared.ID) []asset.Relationship {
+	rels, err := repo.ListRelationships(ctx, tenantID, assetID)
+	if err != nil {
+		return nil
+	}
+	return rels
+}
+
+func requireActor(actor string) error {
+	if strings.TrimSpace(actor) == "" {
+		return fmt.Errorf("%w: actor is required", shared.ErrValidation)
+	}
+	return nil
+}

--- a/internal/usecase/ports/asset_inventory.go
+++ b/internal/usecase/ports/asset_inventory.go
@@ -1,0 +1,27 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/businessservice"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// AssetInventoryRepository persists the tenant-scoped AppSec inventory graph.
+type AssetInventoryRepository interface {
+	CreateBusinessService(context.Context, *businessservice.BusinessService) error
+	ListBusinessServices(context.Context, shared.ID) ([]*businessservice.BusinessService, error)
+	GetBusinessService(context.Context, shared.ID, shared.ID) (*businessservice.BusinessService, error)
+
+	CreateAsset(context.Context, *asset.Asset) error
+	GetAsset(context.Context, shared.ID, shared.ID) (*asset.Asset, error)
+	ListAssets(context.Context, shared.ID) ([]*asset.Asset, error)
+	CreateVersion(context.Context, asset.Version) error
+	ListVersions(context.Context, shared.ID, shared.ID) ([]asset.Version, error)
+
+	LinkBusinessServiceAsset(context.Context, asset.BusinessServiceLink) error
+	ListBusinessServiceAssets(context.Context, shared.ID, shared.ID) ([]asset.BusinessServiceLink, error)
+	CreateRelationship(context.Context, shared.ID, asset.Relationship) error
+	ListRelationships(context.Context, shared.ID, shared.ID) ([]asset.Relationship, error)
+}

--- a/migrations/0057_appsec_asset_inventory.sql
+++ b/migrations/0057_appsec_asset_inventory.sql
@@ -1,0 +1,77 @@
+-- +goose Up
+CREATE TABLE appsec_business_services (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    code TEXT NOT NULL,
+    owner TEXT NOT NULL DEFAULT '',
+    criticality TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    updated_by TEXT NOT NULL DEFAULT '',
+    UNIQUE (tenant_id, code)
+);
+
+CREATE TABLE appsec_assets (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    category TEXT NOT NULL,
+    identity_kind TEXT NOT NULL,
+    identity_value TEXT NOT NULL,
+    lifecycle TEXT NOT NULL,
+    owner TEXT NOT NULL DEFAULT '',
+    criticality TEXT NOT NULL DEFAULT '',
+    exposure TEXT NOT NULL DEFAULT '',
+    classification TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    updated_by TEXT NOT NULL DEFAULT '',
+    UNIQUE (tenant_id, category, identity_kind, identity_value)
+);
+CREATE INDEX appsec_assets_tenant_idx ON appsec_assets (tenant_id, name);
+
+CREATE TABLE appsec_asset_versions (
+    id TEXT PRIMARY KEY,
+    asset_id TEXT NOT NULL REFERENCES appsec_assets(id) ON DELETE CASCADE,
+    value TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    updated_by TEXT NOT NULL DEFAULT '',
+    UNIQUE (asset_id, value, source)
+);
+
+CREATE TABLE appsec_business_service_assets (
+    business_service_id TEXT NOT NULL REFERENCES appsec_business_services(id) ON DELETE CASCADE,
+    asset_id TEXT NOT NULL REFERENCES appsec_assets(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    updated_by TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (business_service_id, asset_id)
+);
+
+CREATE TABLE appsec_asset_relationships (
+    from_asset_id TEXT NOT NULL REFERENCES appsec_assets(id) ON DELETE CASCADE,
+    to_asset_id TEXT NOT NULL REFERENCES appsec_assets(id) ON DELETE CASCADE,
+    relationship_type TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    updated_by TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (from_asset_id, to_asset_id, relationship_type),
+    CHECK (from_asset_id <> to_asset_id)
+);
+CREATE INDEX appsec_asset_relationships_to_idx ON appsec_asset_relationships (to_asset_id);
+
+-- +goose Down
+DROP TABLE appsec_asset_relationships;
+DROP TABLE appsec_business_service_assets;
+DROP TABLE appsec_asset_versions;
+DROP TABLE appsec_assets;
+DROP TABLE appsec_business_services;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import { ProjectMeasuresPage } from './pages/ProjectMeasuresPage'
 import { ProjectCodePage } from './pages/ProjectCodePage'
 import { QualityGates } from './pages/QualityGates'
 import { QualityProfiles } from './pages/QualityProfiles'
+import { AppSecInventory } from './pages/AppSecInventory'
 
 export default function App() {
   return (
@@ -39,6 +40,7 @@ function Gate() {
         <Route index element={<Navigate to="/engagements" replace />} />
         <Route path="engagements" element={<Engagements />} />
         <Route path="engagements/:id" element={<EngagementDetail />} />
+        <Route path="appsec" element={<AppSecInventory />} />
         <Route path="code-quality" element={<CodeQualityProjects />} />
         <Route path="code-quality/gates" element={<QualityGates />} />
         <Route path="code-quality/profiles" element={<QualityProfiles />} />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -21,6 +21,21 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       </div>
       <nav className="flex-1 space-y-1 p-3">
         <NavLink
+          to="/appsec"
+          onClick={onNavigate}
+          className={({ isActive }) =>
+            cn(
+              'relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
+              isActive
+                ? 'bg-brand/10 font-semibold text-branddim before:absolute before:left-0 before:top-1/2 before:h-5 before:w-[3px] before:-translate-y-1/2 before:rounded-r-full before:bg-brand before:content-[""]'
+                : 'text-mutedfg hover:bg-elevated hover:text-foreground',
+            )
+          }
+        >
+          <Boxes className="size-[18px]" />
+          Asset Inventory
+        </NavLink>
+        <NavLink
           to="/engagements"
           onClick={onNavigate}
           className={({ isActive }) =>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -69,6 +69,8 @@ import type {
   ProjectCodeFileView,
   ProjectCodeRevision,
   ProjectCodeView,
+  AppSecAsset,
+  AppSecBusinessService,
 } from './types'
 import { mapProjectOverviewResponse, type ProjectOverview } from './projectOverview'
 import { mapProjectMeasureResponse, type MeasuresQuery, type ProjectMeasureResponse } from './projectMeasures'
@@ -1702,4 +1704,9 @@ export const api = {
     const id = encodeURIComponent(engagementId)
     await blobDownload(`/api/v1/engagements/${id}/evidence/${encodeURIComponent(sha)}`, filename || `${sha.slice(0, 12)}.bin`)
   },
+  listAppSecBusinessServices: async (): Promise<AppSecBusinessService[]> =>
+    ((await req('/appsec/business-services')) ?? []).map((s: { ID: string; Name: string; Code: string; Owner: string; Criticality: string }) => ({ id: s.ID, name: s.Name, code: s.Code, owner: s.Owner, criticality: s.Criticality })),
+
+  listAppSecAssets: async (): Promise<AppSecAsset[]> =>
+    ((await req('/appsec/assets')) ?? []).map((a: { ID: string; Name: string; Category: string; Identity: { kind: string; value: string }; Lifecycle: string; Owner: string; Criticality: string; Exposure: string }) => ({ id: a.ID, name: a.Name, category: a.Category, identity: a.Identity, lifecycle: a.Lifecycle, owner: a.Owner, criticality: a.Criticality, exposure: a.Exposure })),
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1104,3 +1104,23 @@ export interface ProjectCodeDiffResponse {
   capabilities: ProjectCodeDiffCapabilities
   diff: ProjectCodeDiffView
 }
+
+
+export interface AppSecBusinessService {
+  id: string
+  name: string
+  code: string
+  owner: string
+  criticality: string
+}
+
+export interface AppSecAsset {
+  id: string
+  name: string
+  category: string
+  identity: { kind: string; value: string }
+  lifecycle: string
+  owner: string
+  criticality: string
+  exposure: string
+}

--- a/web/src/pages/AppSecInventory.tsx
+++ b/web/src/pages/AppSecInventory.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { Boxes, Building2, RefreshCw, ShieldCheck } from 'lucide-react'
+import { Card, EmptyState, ErrorState, Spinner } from '../components/ui'
+import { api } from '../lib/api'
+import type { AppSecAsset, AppSecBusinessService } from '../lib/types'
+
+export function AppSecInventory() {
+  const [services, setServices] = useState<AppSecBusinessService[] | null>(null)
+  const [assets, setAssets] = useState<AppSecAsset[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const load = () => {
+    setError(null)
+    Promise.all([api.listAppSecBusinessServices(), api.listAppSecAssets()])
+      .then(([nextServices, nextAssets]) => { setServices(nextServices); setAssets(nextAssets) })
+      .catch((reason: unknown) => setError(reason instanceof Error ? reason.message : 'Failed to load Asset Inventory'))
+  }
+  useEffect(load, [])
+  if (error) return <main className="p-6"><ErrorState message={error} onRetry={load} /></main>
+  if (!services || !assets) return <main className="flex min-h-64 items-center justify-center"><Spinner /> <span className="ml-2 text-mutedfg">Loading Asset Inventory…</span></main>
+  return <main className="mx-auto w-full max-w-7xl p-5 md:p-8">
+    <header className="mb-7 flex flex-wrap items-start justify-between gap-4">
+      <div><div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-branddim"><ShieldCheck className="size-4" /> AppSec foundation</div><h1 className="text-3xl font-bold tracking-tight">Asset Inventory</h1><p className="mt-1.5 max-w-2xl text-sm text-mutedfg">Business Services own long-lived security posture. Assets are reusable technical records for future Assessments and scheduled scans.</p></div>
+      <button onClick={load} className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium hover:bg-raised"><RefreshCw className="size-4" /> Refresh</button>
+    </header>
+    <section className="grid gap-4 md:grid-cols-2">
+      <Card className="p-5"><div className="mb-4 flex items-center gap-2"><Building2 className="size-5 text-brand" /><h2 className="font-semibold">Business Services</h2><span className="ml-auto rounded-full bg-brand/10 px-2 py-0.5 text-xs text-branddim">{services.length}</span></div>{services.length === 0 ? <EmptyState title="No Business Services yet" hint="Create the first service to establish its AppSec management boundary." /> : <div className="space-y-3">{services.map((service) => <div key={service.id} className="rounded-lg border border-border bg-elevated p-3"><div className="font-medium">{service.name}</div><div className="mt-1 flex gap-2 text-xs text-mutedfg"><span>{service.code}</span>{service.owner && <span>· {service.owner}</span>}{service.criticality && <span>· {service.criticality}</span>}</div></div>)}</div>}</Card>
+      <Card className="p-5"><div className="mb-4 flex items-center gap-2"><Boxes className="size-5 text-brand" /><h2 className="font-semibold">Technical Assets</h2><span className="ml-auto rounded-full bg-brand/10 px-2 py-0.5 text-xs text-branddim">{assets.length}</span></div>{assets.length === 0 ? <EmptyState title="No Assets yet" hint="Register web, mobile, cloud, API, repository, image, or SBOM assets." /> : <div className="space-y-3">{assets.map((asset) => <div key={asset.id} className="rounded-lg border border-border bg-elevated p-3"><div className="flex items-center justify-between gap-3"><div className="font-medium">{asset.name}</div><span className="rounded bg-surface px-2 py-0.5 font-mono text-xs text-branddim">{asset.category}</span></div><div className="mt-1 truncate font-mono text-xs text-mutedfg">{asset.identity.value}</div><div className="mt-2 text-xs text-mutedfg">{asset.lifecycle}{asset.owner ? ` · ${asset.owner}` : ''}{asset.exposure ? ` · ${asset.exposure}` : ''}</div></div>)}</div>}</Card>
+    </section>
+  </main>
+}


### PR DESCRIPTION
## Summary

Implements the first #361 Asset Inventory slice for long-lived Business Service–centered AppSec management.

- Adds tenant-scoped Business Services, Assets, versions, typed relationships, and Business Service/Asset links.
- Validates category-specific identities and rejects credential-bearing repository/endpoint URLs.
- Adds in-memory and PostgreSQL adapters plus migration `0057_appsec_asset_inventory.sql`.
- Wires authenticated `/api/v1/appsec/*` create/read/link/version/relationship endpoints.
- Adds the visible **Asset Inventory** dashboard workspace at `/appsec`.

## Verification

- `go test ./...`
- `cd web && pnpm build`
- Local authenticated API smoke: created Digital Banking, created Transfer API, linked it with role `owns`.
- Browser verification of the Asset Inventory workspace.

Part of #361. Keep #361 open until the full CRUD/detail lifecycle and its remaining acceptance criteria are complete.