### PR TITLE
feat(appsec): manage Business Service assessments

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -950,7 +950,7 @@ paths:
         '404': {$ref: '#/components/responses/NotFound'}
     post:
       tags: [appsec]
-      summary: Atomically create an assessment and required engagement children
+      summary: Atomically create an assessment and required scoped assets
       operationId: createAppSecAssessment
       parameters: [{name: sid, in: path, required: true, schema: {type: string}}]
       requestBody: {required: true, content: {application/json: {schema: {$ref: '#/components/schemas/CreateAppSecAssessmentRequest'}}}}
@@ -971,6 +971,19 @@ paths:
       - {name: id, in: path, required: true, schema: {type: string}}
       responses:
         '200': {description: Assessment, content: {application/json: {schema: {$ref: '#/components/schemas/AppSecAssessment'}}}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+  /api/v1/appsec/business-services/{sid}/assessments/{id}/assets:
+    get:
+      tags: [appsec]
+      summary: List scoped assets belonging to an assessment
+      operationId: listAppSecAssessmentAssets
+      parameters:
+      - {name: sid, in: path, required: true, schema: {type: string}}
+      - {name: id, in: path, required: true, schema: {type: string}}
+      responses:
+        '200': {description: Assessment assets, content: {application/json: {schema: {type: array, items: {$ref: '#/components/schemas/AppSecAssessmentAsset'}}}}}
         '401': {$ref: '#/components/responses/Unauthorized'}
         '403': {$ref: '#/components/responses/Forbidden'}
         '404': {$ref: '#/components/responses/NotFound'}
@@ -1084,24 +1097,33 @@ components:
         objective: {type: string, maxLength: 4000}
         status: {type: string, enum: [draft, active, closed]}
         policy: {$ref: '#/components/schemas/AppSecAssessmentPolicy'}
-    CreateAppSecEngagementRequest:
+    AppSecAssessmentAsset:
+      type: object
+      required: [id, assessment_id, name, client, status]
+      properties:
+        id: {type: string}
+        assessment_id: {type: string}
+        name: {type: string, maxLength: 256}
+        client: {type: string, maxLength: 256}
+        status: {type: string, enum: [draft, active, completed, archived]}
+    CreateAppSecAssessmentRequest:
+      type: object
+      required: [name, assets]
+      properties:
+        name: {type: string, maxLength: 256}
+        objective: {type: string, maxLength: 4000}
+        policy: {$ref: '#/components/schemas/AppSecAssessmentPolicy'}
+        assets:
+          type: array
+          minItems: 1
+          maxItems: 128
+          items: {$ref: '#/components/schemas/AppSecAssessmentAssetInput'}
+    AppSecAssessmentAssetInput:
       type: object
       required: [name]
       properties:
         name: {type: string, maxLength: 256}
         client: {type: string, maxLength: 256}
-    CreateAppSecAssessmentRequest:
-      type: object
-      required: [name, engagements]
-      properties:
-        name: {type: string, maxLength: 256}
-        objective: {type: string, maxLength: 4000}
-        policy: {$ref: '#/components/schemas/AppSecAssessmentPolicy'}
-        engagements:
-          type: array
-          minItems: 1
-          maxItems: 128
-          items: {$ref: '#/components/schemas/CreateAppSecEngagementRequest'}
 
     ProjectCodeCapability:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -881,6 +881,100 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/appsec/business-services:
+    get:
+      tags: [appsec]
+      summary: List tenant-scoped business services
+      operationId: listAppSecBusinessServices
+      responses:
+        '200':
+          description: Business services
+          content: {application/json: {schema: {type: array, items: {$ref: '#/components/schemas/AppSecBusinessService'}}}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+    post:
+      tags: [appsec]
+      summary: Create a business service
+      operationId: createAppSecBusinessService
+      requestBody: {required: true, content: {application/json: {schema: {$ref: '#/components/schemas/CreateAppSecBusinessServiceRequest'}}}}
+      responses:
+        '201': {description: Business service created, content: {application/json: {schema: {$ref: '#/components/schemas/AppSecBusinessService'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+  /api/v1/appsec/business-services/{id}:
+    get:
+      tags: [appsec]
+      summary: Get a business service
+      operationId: getAppSecBusinessService
+      parameters: [{name: id, in: path, required: true, schema: {type: string}}]
+      responses:
+        '200': {description: Business service, content: {application/json: {schema: {$ref: '#/components/schemas/AppSecBusinessService'}}}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+    put:
+      tags: [appsec]
+      summary: Fully replace a business service
+      operationId: updateAppSecBusinessService
+      parameters: [{name: id, in: path, required: true, schema: {type: string}}]
+      requestBody: {required: true, content: {application/json: {schema: {$ref: '#/components/schemas/UpdateAppSecBusinessServiceRequest'}}}}
+      responses:
+        '200': {description: Business service updated, content: {application/json: {schema: {$ref: '#/components/schemas/AppSecBusinessService'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Business service name conflict}
+    delete:
+      tags: [appsec]
+      summary: Delete an empty business service
+      operationId: deleteAppSecBusinessService
+      parameters: [{name: id, in: path, required: true, schema: {type: string}}]
+      responses:
+        '204': {description: Business service deleted}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Business Service has Assessments}
+  /api/v1/appsec/business-services/{sid}/assessments:
+    get:
+      tags: [appsec]
+      summary: List assessments for a business service
+      operationId: listAppSecAssessments
+      parameters: [{name: sid, in: path, required: true, schema: {type: string}}]
+      responses:
+        '200': {description: Assessments, content: {application/json: {schema: {type: array, items: {$ref: '#/components/schemas/AppSecAssessment'}}}}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+    post:
+      tags: [appsec]
+      summary: Atomically create an assessment and required engagement children
+      operationId: createAppSecAssessment
+      parameters: [{name: sid, in: path, required: true, schema: {type: string}}]
+      requestBody: {required: true, content: {application/json: {schema: {$ref: '#/components/schemas/CreateAppSecAssessmentRequest'}}}}
+      responses:
+        '201': {description: Assessment created, content: {application/json: {schema: {$ref: '#/components/schemas/AppSecAssessment'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Assessment name conflict}
+  /api/v1/appsec/business-services/{sid}/assessments/{id}:
+    get:
+      tags: [appsec]
+      summary: Get an assessment beneath its business service
+      operationId: getAppSecAssessment
+      parameters:
+      - {name: sid, in: path, required: true, schema: {type: string}}
+      - {name: id, in: path, required: true, schema: {type: string}}
+      responses:
+        '200': {description: Assessment, content: {application/json: {schema: {$ref: '#/components/schemas/AppSecAssessment'}}}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
 components:
   securitySchemes:
     bearerAuth:
@@ -949,6 +1043,65 @@ components:
       type: object
       properties:
         error: {type: string}
+    AppSecBusinessService:
+      type: object
+      required: [id, name, criticality, lifecycle]
+      properties:
+        id: {type: string}
+        name: {type: string, maxLength: 256}
+        description: {type: string, maxLength: 4000}
+        criticality: {type: string, enum: [low, medium, high, critical]}
+        lifecycle: {type: string, enum: [planned, active, retired]}
+    CreateAppSecBusinessServiceRequest:
+      type: object
+      required: [name]
+      properties:
+        name: {type: string, maxLength: 256}
+        description: {type: string, maxLength: 4000}
+        criticality: {type: string, enum: [low, medium, high, critical], default: medium}
+        lifecycle: {type: string, enum: [planned, active, retired], default: planned}
+    UpdateAppSecBusinessServiceRequest:
+      type: object
+      required: [name, criticality, lifecycle]
+      properties:
+        name: {type: string, maxLength: 256}
+        description: {type: string, maxLength: 4000}
+        criticality: {type: string, enum: [low, medium, high, critical]}
+        lifecycle: {type: string, enum: [planned, active, retired]}
+    AppSecAssessmentPolicy:
+      type: object
+      properties:
+        cadence: {type: string, maxLength: 128}
+        release: {type: string, maxLength: 256}
+        environment: {type: string, maxLength: 128}
+    AppSecAssessment:
+      type: object
+      required: [id, business_service_id, name, objective, status, policy]
+      properties:
+        id: {type: string}
+        business_service_id: {type: string}
+        name: {type: string, maxLength: 256}
+        objective: {type: string, maxLength: 4000}
+        status: {type: string, enum: [draft, active, closed]}
+        policy: {$ref: '#/components/schemas/AppSecAssessmentPolicy'}
+    CreateAppSecEngagementRequest:
+      type: object
+      required: [name]
+      properties:
+        name: {type: string, maxLength: 256}
+        client: {type: string, maxLength: 256}
+    CreateAppSecAssessmentRequest:
+      type: object
+      required: [name, engagements]
+      properties:
+        name: {type: string, maxLength: 256}
+        objective: {type: string, maxLength: 4000}
+        policy: {$ref: '#/components/schemas/AppSecAssessmentPolicy'}
+        engagements:
+          type: array
+          minItems: 1
+          maxItems: 128
+          items: {$ref: '#/components/schemas/CreateAppSecEngagementRequest'}
 
     ProjectCodeCapability:
       type: object

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -250,3 +250,39 @@ func TestOpenAPI_StrictValidation(t *testing.T) {
 		})
 	})
 }
+
+func TestOpenAPI_AppSecManagementContract(t *testing.T) {
+	b, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var spec map[string]any
+	if err := yaml.Unmarshal(b, &spec); err != nil {
+		t.Fatal(err)
+	}
+	paths, ok := spec["paths"].(map[string]any)
+	if !ok {
+		t.Fatal("paths is not a mapping")
+	}
+	required := map[string][]string{
+		"/api/v1/appsec/business-services": {"get", "post"},
+		"/api/v1/appsec/business-services/{id}": {"get", "put", "delete"},
+		"/api/v1/appsec/business-services/{sid}/assessments": {"get", "post"},
+		"/api/v1/appsec/business-services/{sid}/assessments/{id}": {"get"},
+	}
+	for path, methods := range required {
+		item, ok := paths[path].(map[string]any)
+		if !ok {
+			t.Errorf("missing path %s", path)
+			continue
+		}
+		for _, method := range methods {
+			if _, ok := item[method]; !ok {
+				t.Errorf("missing %s %s", method, path)
+			}
+		}
+	}
+	if _, exists := paths["/api/v1/appsec/assets"]; exists {
+		t.Error("public asset inventory path must be absent")
+	}
+}

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -237,7 +237,11 @@ func main() {
 		// until multi-replica horizontal scaling lands (P5).
 		startup, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
-		if err := postgres.Migrate(startup, cfg.DBDSN); err != nil {
+		migrateDSN := cfg.DBMigrateDSN
+		if migrateDSN == "" {
+			migrateDSN = cfg.DBDSN
+		}
+		if err := postgres.Migrate(startup, migrateDSN); err != nil {
 			log.Error("db migrate failed", "err", err)
 			os.Exit(1)
 		}

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -249,6 +249,12 @@ func main() {
 			log.Error("db connect failed", "err", err)
 			os.Exit(1)
 		}
+		if cfg.IsProduction() {
+			if err := postgres.RequireNonSuperuser(startup, pool); err != nil {
+				log.Error("unsafe postgres application role", "err", err)
+				os.Exit(1)
+			}
+		}
 		defer pool.Close()
 		// Single-instance guard: until horizontal scaling the repos
 		// ignore tenant_id and there is no leader election, so two writers would race. A

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -92,6 +92,8 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/agenttools"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
+	assessmentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentuc"
+	assetuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
 	audituc "github.com/KKloudTarus/synapse-ce/internal/usecase/audit"
 	aupuc "github.com/KKloudTarus/synapse-ce/internal/usecase/aup"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/codequality"
@@ -197,6 +199,8 @@ func main() {
 	var approvalStore ports.ApprovalStore         // durable HITL approval queue
 	var planStore ports.PlanStore                 // agent execution-plan DAG
 	var decisionStore ports.DecisionStore         // structured decision log
+	var assetInventoryRepo ports.AssetInventoryRepository
+	var assessmentRepo ports.AssessmentRepository
 
 	// Credential vault cipher: a configured master key gives durable
 	// encryption; an empty key yields an ephemeral one (dev only – stored secrets won't
@@ -311,9 +315,12 @@ func main() {
 		approvalStore = postgres.NewApprovalStore(pool)
 		planStore = postgres.NewAgentPlanStore(pool)
 		decisionStore = postgres.NewAgentDecisionStore(pool)
+		assetInventoryRepo = postgres.NewAssetInventoryRepository(pool)
+		assessmentRepo = postgres.NewAssessmentRepository(pool)
 		log.Info("persistence: postgres")
 	} else {
-		repo = memory.NewEngagementRepository()
+		memoryEngagementRepo := memory.NewEngagementRepository()
+		repo = memoryEngagementRepo
 		projectRepo = memory.NewProjectRepository()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
@@ -343,6 +350,9 @@ func main() {
 		approvalStore = memory.NewApprovalStore()
 		planStore = memory.NewPlanStore()
 		decisionStore = memory.NewDecisionStore()
+		memoryAssetRepo := memory.NewAssetInventoryRepository()
+		assetInventoryRepo = memoryAssetRepo
+		assessmentRepo = memory.NewAssessmentRepository(memoryAssetRepo, memoryEngagementRepo)
 		log.Info("persistence: in-memory + file (set SYNAPSE_DB_DSN for postgres)")
 	}
 
@@ -916,6 +926,16 @@ func main() {
 		log.Error("safety gate init failed", "err", err)
 		os.Exit(1)
 	}
+	assetInventoryService, err := assetuc.New(assetInventoryRepo, clock, ids)
+	if err != nil {
+		log.Error("asset inventory service init failed", "err", err)
+		os.Exit(1)
+	}
+	assessmentService, err := assessmentuc.New(assessmentRepo, assetInventoryRepo, clock, ids)
+	if err != nil {
+		log.Error("assessment service init failed", "err", err)
+		os.Exit(1)
+	}
 	router := httpapi.NewRouter(log, auth, engService, scaService, aupService, findingsService, exportService, reportService, evidenceService, reconService, logBroker, transferService, auditService, vexService, usersService, credentialsService)
 	projectService.SetScanner(scaService)
 	scaService.SetProjectAnalysisRecorder(projectService)
@@ -936,6 +956,8 @@ func main() {
 	router.SetQualityGates(qualityGateService)
 	router.SetQualityProfiles(qualityProfileService)
 	router.SetExploitation(exploitationService) // evidence-gated finding verify endpoint
+	router.SetBusinessServices(assetInventoryService)
+	router.SetAssessments(assessmentService)
 	// Read-only code-quality dashboard. Server-side analysis is PURE-GO and memory-safe only (pattern
 	// rules + duplication + Go-parser inventory); tree-sitter complexity is intentionally NOT wired here
 	// so the server never runs C parsers over untrusted source (that stays a local-CLI capability).

--- a/cmd/synapse-worker/main.go
+++ b/cmd/synapse-worker/main.go
@@ -315,7 +315,7 @@ func main() {
 			os.Exit(1)
 		}
 		approvalSvc.SetResumeEnqueuer(func(ctx context.Context, sid, aid shared.ID) error {
-			p, err := orchestrator.ResumeJob(sid, aid)
+			p, err := orchestrator.ResumeJob(ctx, sid, aid)
 			if err != nil {
 				return err
 			}

--- a/internal/adapter/httpapi/agent_handler.go
+++ b/internal/adapter/httpapi/agent_handler.go
@@ -162,7 +162,7 @@ func (rt *Router) startAgentSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, rt.log, err)
 		return
 	}
-	payload, err := orchestrator.DriveJob(sess.ID)
+	payload, err := orchestrator.DriveJob(r.Context(), sess.ID)
 	if err != nil {
 		release()
 		writeError(w, rt.log, err)
@@ -292,7 +292,7 @@ func (rt *Router) decideAgentApproval(w http.ResponseWriter, r *http.Request) {
 	}
 	// Resume either way: an approval executes the action; a denial is fed back and the loop
 	// continues so the agent can adapt.
-	payload, err := orchestrator.ResumeJob(prop.SessionID, actionID)
+	payload, err := orchestrator.ResumeJob(r.Context(), prop.SessionID, actionID)
 	if err != nil {
 		release()
 		writeError(w, rt.log, err)

--- a/internal/adapter/httpapi/agent_handler_test.go
+++ b/internal/adapter/httpapi/agent_handler_test.go
@@ -183,7 +183,8 @@ func TestReserveAgentSlot_DurableAlwaysReserves(t *testing.T) {
 }
 
 func withPrincipal(req *http.Request, id, role string) *http.Request {
-	return req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: id, Name: id, Role: role}))
+	ctx := context.WithValue(req.Context(), principalKey, Principal{ID: id, Name: id, Role: role})
+	return req.WithContext(shared.WithTenant(ctx, ""))
 }
 
 func TestStartAgentSessionReturnsSession(t *testing.T) {

--- a/internal/adapter/httpapi/assessment_handler.go
+++ b/internal/adapter/httpapi/assessment_handler.go
@@ -1,0 +1,71 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	assessmentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentuc"
+)
+
+type createAssessmentRequest struct {
+	Name        string            `json:"name"`
+	Objective   string            `json:"objective"`
+	Policy      assessment.Policy `json:"policy"`
+	Engagements []struct {
+		Name   string `json:"name"`
+		Client string `json:"client"`
+	} `json:"engagements"`
+}
+
+type assessmentResponse struct {
+	ID                string            `json:"id"`
+	BusinessServiceID string            `json:"business_service_id"`
+	Name              string            `json:"name"`
+	Objective         string            `json:"objective"`
+	Status            assessment.Status `json:"status"`
+	Policy            assessment.Policy `json:"policy"`
+}
+
+func assessmentDTO(a assessment.Assessment) assessmentResponse {
+	return assessmentResponse{ID: a.ID.String(), BusinessServiceID: a.BusinessServiceID.String(), Name: a.Name, Objective: a.Objective, Status: a.Status, Policy: a.Policy}
+}
+
+func (rt *Router) createAssessment(w http.ResponseWriter, r *http.Request) {
+	var req createAssessmentRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	children := make([]assessmentuc.EngagementInput, len(req.Engagements))
+	for i, e := range req.Engagements {
+		children[i] = assessmentuc.EngagementInput{Name: e.Name, Client: e.Client}
+	}
+	a, err := rt.assessments.Create(r.Context(), assessmentuc.CreateInput{TenantID: shared.ID(TenantFrom(r.Context())), BusinessServiceID: shared.ID(r.PathValue("sid")), Actor: PrincipalFrom(r.Context()), Name: req.Name, Objective: req.Objective, Policy: req.Policy, Engagements: children})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, assessmentDTO(a))
+}
+func (rt *Router) listAssessments(w http.ResponseWriter, r *http.Request) {
+	items, err := rt.assessments.List(r.Context(), shared.ID(r.PathValue("sid")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	out := make([]assessmentResponse, len(items))
+	for i, item := range items {
+		out[i] = assessmentDTO(item)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+func (rt *Router) getAssessment(w http.ResponseWriter, r *http.Request) {
+	a, err := rt.assessments.Get(r.Context(), shared.ID(r.PathValue("sid")), shared.ID(r.PathValue("id")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, assessmentDTO(a))
+}

--- a/internal/adapter/httpapi/assessment_handler.go
+++ b/internal/adapter/httpapi/assessment_handler.go
@@ -10,13 +10,13 @@ import (
 )
 
 type createAssessmentRequest struct {
-	Name        string            `json:"name"`
-	Objective   string            `json:"objective"`
-	Policy      assessment.Policy `json:"policy"`
-	Engagements []struct {
+	Name      string            `json:"name"`
+	Objective string            `json:"objective"`
+	Policy    assessment.Policy `json:"policy"`
+	Assets    []struct {
 		Name   string `json:"name"`
 		Client string `json:"client"`
-	} `json:"engagements"`
+	} `json:"assets"`
 }
 
 type assessmentResponse struct {
@@ -26,6 +26,14 @@ type assessmentResponse struct {
 	Objective         string            `json:"objective"`
 	Status            assessment.Status `json:"status"`
 	Policy            assessment.Policy `json:"policy"`
+}
+
+type assessmentAssetResponse struct {
+	ID           string `json:"id"`
+	AssessmentID string `json:"assessment_id"`
+	Name         string `json:"name"`
+	Client       string `json:"client"`
+	Status       string `json:"status"`
 }
 
 func assessmentDTO(a assessment.Assessment) assessmentResponse {
@@ -38,11 +46,11 @@ func (rt *Router) createAssessment(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
 		return
 	}
-	children := make([]assessmentuc.EngagementInput, len(req.Engagements))
-	for i, e := range req.Engagements {
-		children[i] = assessmentuc.EngagementInput{Name: e.Name, Client: e.Client}
+	children := make([]assessmentuc.AssetInput, len(req.Assets))
+	for i, asset := range req.Assets {
+		children[i] = assessmentuc.AssetInput{Name: asset.Name, Client: asset.Client}
 	}
-	a, err := rt.assessments.Create(r.Context(), assessmentuc.CreateInput{TenantID: shared.ID(TenantFrom(r.Context())), BusinessServiceID: shared.ID(r.PathValue("sid")), Actor: PrincipalFrom(r.Context()), Name: req.Name, Objective: req.Objective, Policy: req.Policy, Engagements: children})
+	a, err := rt.assessments.Create(r.Context(), assessmentuc.CreateInput{TenantID: shared.ID(TenantFrom(r.Context())), BusinessServiceID: shared.ID(r.PathValue("sid")), Actor: PrincipalFrom(r.Context()), Name: req.Name, Objective: req.Objective, Policy: req.Policy, Assets: children})
 	if err != nil {
 		writeError(w, rt.log, err)
 		return
@@ -68,4 +76,24 @@ func (rt *Router) getAssessment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, assessmentDTO(a))
+}
+
+func (rt *Router) listAssessmentAssets(w http.ResponseWriter, r *http.Request) {
+	serviceID, assessmentID := shared.ID(r.PathValue("sid")), shared.ID(r.PathValue("id"))
+	if _, err := rt.assessments.Get(r.Context(), serviceID, assessmentID); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	items, err := rt.eng.List(r.Context(), shared.ID(TenantFrom(r.Context())))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	out := make([]assessmentAssetResponse, 0)
+	for _, item := range items {
+		if item.AssessmentID == assessmentID {
+			out = append(out, assessmentAssetResponse{ID: item.ID.String(), AssessmentID: assessmentID.String(), Name: item.Name, Client: item.Client, Status: string(item.Status)})
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
 }

--- a/internal/adapter/httpapi/assessment_handler_test.go
+++ b/internal/adapter/httpapi/assessment_handler_test.go
@@ -1,0 +1,36 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	assessmentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentuc"
+)
+
+func TestAssessmentRoutesRequireNestedTenantContext(t *testing.T) {
+	services := memory.NewAssetInventoryRepository()
+	engagements := memory.NewEngagementRepository()
+	svc, err := assessmentuc.New(memory.NewAssessmentRepository(services, engagements), services, idgen.SystemClock{}, idgen.RandomID{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := services.CreateBusinessService(shared.WithTenant(context.Background(), "tenant-a"), asset.BusinessService{ID: "service-a", TenantID: "tenant-a", Name: "Service", Criticality: asset.CriticalityMedium, Lifecycle: asset.LifecyclePlanned}); err != nil {
+		t.Fatal(err)
+	}
+	rt := &Router{log: discardLog()}
+	rt.SetAssessments(svc)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/appsec/business-services/service-a/assessments", strings.NewReader(`{"name":"Release","engagements":[{"name":"Transfer"}]}`))
+	req = req.WithContext(shared.WithTenant(context.WithValue(req.Context(), principalKey, Principal{ID: "admin", Role: "admin", TenantID: "tenant-a"}), "tenant-a"))
+	rec := httptest.NewRecorder()
+	rt.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/adapter/httpapi/assessment_handler_test.go
+++ b/internal/adapter/httpapi/assessment_handler_test.go
@@ -26,7 +26,7 @@ func TestAssessmentRoutesRequireNestedTenantContext(t *testing.T) {
 	}
 	rt := &Router{log: discardLog()}
 	rt.SetAssessments(svc)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/appsec/business-services/service-a/assessments", strings.NewReader(`{"name":"Release","engagements":[{"name":"Transfer"}]}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/appsec/business-services/service-a/assessments", strings.NewReader(`{"name":"Release","assets":[{"name":"Transfer"}]}`))
 	req = req.WithContext(shared.WithTenant(context.WithValue(req.Context(), principalKey, Principal{ID: "admin", Role: "admin", TenantID: "tenant-a"}), "tenant-a"))
 	rec := httptest.NewRecorder()
 	rt.routes().ServeHTTP(rec, req)

--- a/internal/adapter/httpapi/auth.go
+++ b/internal/adapter/httpapi/auth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
 // PrincipalOperator is the fallback principal id (the bootstrap admin also uses it,
@@ -82,7 +84,7 @@ func (a *Authenticator) Middleware(publicPaths map[string]bool, next http.Handle
 			unauthorized(w)
 			return
 		}
-		ctx := context.WithValue(r.Context(), principalKey, principal)
+		ctx := shared.WithTenant(context.WithValue(r.Context(), principalKey, principal), shared.ID(principal.TenantID))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/adapter/httpapi/auth_test.go
+++ b/internal/adapter/httpapi/auth_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
 // TestTenantPropagatesThroughContext covers the tenant foundation: the tenant the resolver
@@ -15,9 +17,12 @@ func TestTenantPropagatesThroughContext(t *testing.T) {
 		return Principal{ID: "u1", Name: "T", Role: "member", TenantID: "acme"}, true
 	})
 	var gotTenant, gotActor string
+	var gotPersistenceTenant shared.ID
+	var tenantBound bool
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		gotTenant = TenantFrom(r.Context())
 		gotActor = PrincipalFrom(r.Context())
+		gotPersistenceTenant, tenantBound = shared.TenantFrom(r.Context())
 	})
 	h := auth.Middleware(map[string]bool{}, next)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/engagements", nil)
@@ -28,6 +33,9 @@ func TestTenantPropagatesThroughContext(t *testing.T) {
 	}
 	if gotActor != "u1" {
 		t.Errorf("PrincipalFrom = %q, want u1", gotActor)
+	}
+	if !tenantBound || gotPersistenceTenant != "acme" {
+		t.Errorf("shared.TenantFrom = %q, bound=%v; want acme,true", gotPersistenceTenant, tenantBound)
 	}
 }
 

--- a/internal/adapter/httpapi/business_service_handler.go
+++ b/internal/adapter/httpapi/business_service_handler.go
@@ -1,0 +1,94 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	assetuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
+)
+
+type createBusinessServiceRequest struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Criticality asset.Criticality `json:"criticality"`
+	Lifecycle   asset.Lifecycle   `json:"lifecycle"`
+}
+
+type updateBusinessServiceRequest struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Criticality asset.Criticality `json:"criticality"`
+	Lifecycle   asset.Lifecycle   `json:"lifecycle"`
+}
+
+type businessServiceResponse struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Criticality asset.Criticality `json:"criticality"`
+	Lifecycle   asset.Lifecycle   `json:"lifecycle"`
+}
+
+func businessServiceDTO(s asset.BusinessService) businessServiceResponse {
+	return businessServiceResponse{ID: s.ID.String(), Name: s.Name, Description: s.Description, Criticality: s.Criticality, Lifecycle: s.Lifecycle}
+}
+
+func (rt *Router) createBusinessService(w http.ResponseWriter, r *http.Request) {
+	var req createBusinessServiceRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	s, err := rt.businessServices.CreateBusinessService(r.Context(), assetuc.CreateBusinessServiceInput{TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Name: req.Name, Description: req.Description, Criticality: req.Criticality, Lifecycle: req.Lifecycle})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, businessServiceDTO(s))
+}
+
+func (rt *Router) listBusinessServices(w http.ResponseWriter, r *http.Request) {
+	services, err := rt.businessServices.ListBusinessServices(r.Context())
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	out := make([]businessServiceResponse, len(services))
+	for i, s := range services {
+		out[i] = businessServiceDTO(s)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (rt *Router) getBusinessService(w http.ResponseWriter, r *http.Request) {
+	s, err := rt.businessServices.GetBusinessService(r.Context(), shared.ID(r.PathValue("id")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, businessServiceDTO(s))
+}
+
+func (rt *Router) updateBusinessService(w http.ResponseWriter, r *http.Request) {
+	var req updateBusinessServiceRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	s, err := rt.businessServices.UpdateBusinessService(r.Context(), shared.ID(r.PathValue("id")), assetuc.UpdateBusinessServiceInput{Actor: PrincipalFrom(r.Context()), Name: req.Name, Description: req.Description, Criticality: req.Criticality, Lifecycle: req.Lifecycle})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, businessServiceDTO(s))
+}
+
+func (rt *Router) deleteBusinessService(w http.ResponseWriter, r *http.Request) {
+	if err := rt.businessServices.DeleteBusinessService(r.Context(), shared.ID(r.PathValue("id"))); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/adapter/httpapi/business_service_handler_test.go
+++ b/internal/adapter/httpapi/business_service_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
 	assessmentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentuc"
 	assetuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
 )
 
 func TestBusinessServiceManagementRoutes(t *testing.T) {
@@ -29,6 +30,7 @@ func TestBusinessServiceManagementRoutes(t *testing.T) {
 	rt := &Router{log: discardLog()}
 	rt.SetBusinessServices(assets)
 	rt.SetAssessments(assessments)
+	rt.eng = enguc.NewService(engagements, idgen.SystemClock{}, idgen.RandomID{}, nil)
 	do := func(tenant, role, method, target, body string) *httptest.ResponseRecorder {
 		req := httptest.NewRequest(method, target, bytes.NewBufferString(body))
 		req = req.WithContext(shared.WithTenant(context.WithValue(req.Context(), principalKey, Principal{ID: "operator", Role: role, TenantID: tenant}), shared.ID(tenant)))
@@ -56,13 +58,13 @@ func TestBusinessServiceManagementRoutes(t *testing.T) {
 	if got := do("tenant-b", "consultant", http.MethodGet, "/api/v1/appsec/business-services/"+service.ID, "").Code; got != http.StatusNotFound {
 		t.Fatalf("cross tenant get=%d", got)
 	}
-	if got := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services/missing/assessments", `{"name":"A","engagements":[{"name":"E"}]}`).Code; got != http.StatusNotFound {
+	if got := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services/missing/assessments", `{"name":"A","assets":[{"name":"E"}]}`).Code; got != http.StatusNotFound {
 		t.Fatalf("missing parent create=%d", got)
 	}
-	if got := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services/"+service.ID+"/assessments", `{"name":"A","engagements":[]}`).Code; got != http.StatusBadRequest {
+	if got := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services/"+service.ID+"/assessments", `{"name":"A","assets":[]}`).Code; got != http.StatusBadRequest {
 		t.Fatalf("zero children=%d", got)
 	}
-	assessment := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services/"+service.ID+"/assessments", `{"name":"A","engagements":[{"name":"E","client":"Client"}]}`)
+	assessment := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services/"+service.ID+"/assessments", `{"name":"A","assets":[{"name":"E","client":"Client"}]}`)
 	if assessment.Code != http.StatusCreated {
 		t.Fatalf("assessment=%d %s", assessment.Code, assessment.Body.String())
 	}
@@ -71,6 +73,10 @@ func TestBusinessServiceManagementRoutes(t *testing.T) {
 	}
 	if err := json.Unmarshal(assessment.Body.Bytes(), &createdAssessment); err != nil {
 		t.Fatal(err)
+	}
+	assetsForAssessment := do("tenant-a", "readonly", http.MethodGet, "/api/v1/appsec/business-services/"+service.ID+"/assessments/"+createdAssessment.ID+"/assets", "")
+	if assetsForAssessment.Code != http.StatusOK || !bytes.Contains(assetsForAssessment.Body.Bytes(), []byte(`"name":"E"`)) {
+		t.Fatalf("assessment assets=%d %s", assetsForAssessment.Code, assetsForAssessment.Body.String())
 	}
 	other := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services", `{"name":"Other","criticality":"medium","lifecycle":"planned"}`)
 	var otherService struct {

--- a/internal/adapter/httpapi/business_service_handler_test.go
+++ b/internal/adapter/httpapi/business_service_handler_test.go
@@ -1,0 +1,92 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	assessmentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentuc"
+	assetuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
+)
+
+func TestBusinessServiceManagementRoutes(t *testing.T) {
+	services := memory.NewAssetInventoryRepository()
+	engagements := memory.NewEngagementRepository()
+	assets, err := assetuc.New(services, idgen.SystemClock{}, idgen.RandomID{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessments, err := assessmentuc.New(memory.NewAssessmentRepository(services, engagements), services, idgen.SystemClock{}, idgen.RandomID{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := &Router{log: discardLog()}
+	rt.SetBusinessServices(assets)
+	rt.SetAssessments(assessments)
+	do := func(tenant, role, method, target, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, target, bytes.NewBufferString(body))
+		req = req.WithContext(shared.WithTenant(context.WithValue(req.Context(), principalKey, Principal{ID: "operator", Role: role, TenantID: tenant}), shared.ID(tenant)))
+		rec := httptest.NewRecorder()
+		rt.routes().ServeHTTP(rec, req)
+		return rec
+	}
+	created := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services", `{"name":"Payments","description":"Old","criticality":"medium","lifecycle":"planned"}`)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create=%d %s", created.Code, created.Body.String())
+	}
+	var service struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(created.Body.Bytes(), &service); err != nil || service.ID == "" {
+		t.Fatalf("service=%s err=%v", created.Body.String(), err)
+	}
+	updated := do("tenant-a", "consultant", http.MethodPut, "/api/v1/appsec/business-services/"+service.ID, `{"name":"Payments v2","description":"Updated","criticality":"high","lifecycle":"active"}`)
+	if updated.Code != http.StatusOK || !bytes.Contains(updated.Body.Bytes(), []byte(`"name":"Payments v2"`)) {
+		t.Fatalf("update=%d %s", updated.Code, updated.Body.String())
+	}
+	if got := do("tenant-a", "readonly", http.MethodPut, "/api/v1/appsec/business-services/"+service.ID, `{}`).Code; got != http.StatusForbidden {
+		t.Fatalf("readonly put=%d", got)
+	}
+	if got := do("tenant-b", "consultant", http.MethodGet, "/api/v1/appsec/business-services/"+service.ID, "").Code; got != http.StatusNotFound {
+		t.Fatalf("cross tenant get=%d", got)
+	}
+	if got := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services/missing/assessments", `{"name":"A","engagements":[{"name":"E"}]}`).Code; got != http.StatusNotFound {
+		t.Fatalf("missing parent create=%d", got)
+	}
+	if got := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services/"+service.ID+"/assessments", `{"name":"A","engagements":[]}`).Code; got != http.StatusBadRequest {
+		t.Fatalf("zero children=%d", got)
+	}
+	assessment := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services/"+service.ID+"/assessments", `{"name":"A","engagements":[{"name":"E","client":"Client"}]}`)
+	if assessment.Code != http.StatusCreated {
+		t.Fatalf("assessment=%d %s", assessment.Code, assessment.Body.String())
+	}
+	var createdAssessment struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(assessment.Body.Bytes(), &createdAssessment); err != nil {
+		t.Fatal(err)
+	}
+	other := do("tenant-a", "consultant", http.MethodPost, "/api/v1/appsec/business-services", `{"name":"Other","criticality":"medium","lifecycle":"planned"}`)
+	var otherService struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(other.Body.Bytes(), &otherService)
+	if got := do("tenant-a", "readonly", http.MethodGet, "/api/v1/appsec/business-services/"+otherService.ID+"/assessments/"+createdAssessment.ID, "").Code; got != http.StatusNotFound {
+		t.Fatalf("wrong parent get=%d", got)
+	}
+	if got := do("tenant-a", "consultant", http.MethodDelete, "/api/v1/appsec/business-services/"+service.ID, "").Code; got != http.StatusConflict {
+		t.Fatalf("delete populated=%d", got)
+	}
+	if got := do("tenant-a", "consultant", http.MethodDelete, "/api/v1/appsec/business-services/"+otherService.ID, "").Code; got != http.StatusNoContent {
+		t.Fatalf("delete empty=%d", got)
+	}
+	if got := do("tenant-a", "readonly", http.MethodGet, "/api/v1/appsec/assets", "").Code; got != http.StatusNotFound {
+		t.Fatalf("assets route=%d", got)
+	}
+}

--- a/internal/adapter/httpapi/project_issue_handler_test.go
+++ b/internal/adapter/httpapi/project_issue_handler_test.go
@@ -1,10 +1,14 @@
 package httpapi
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/issue"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
@@ -45,5 +49,33 @@ func TestProjectIssueListParams(t *testing.T) {
 				t.Fatalf("want ErrValidation, got %v", err)
 			}
 		})
+	}
+}
+
+type projectIssueServiceStub struct {
+	projectService
+	getErr error
+	tenant shared.ID
+}
+
+func (s *projectIssueServiceStub) GetIssue(_ context.Context, tenantID shared.ID, _ string, _ shared.ID) (issue.Issue, error) {
+	s.tenant = tenantID
+	return issue.Issue{}, s.getErr
+}
+
+func TestGetProjectIssueMapsCrossTenantToNotFound(t *testing.T) {
+	stub := &projectIssueServiceStub{getErr: fmt.Errorf("cross-tenant: %w", shared.ErrNotFound)}
+	rt := &Router{log: discardLog(), projects: stub}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p/issues/id", nil)
+	req.SetPathValue("key", "p")
+	req.SetPathValue("id", "id")
+	req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "bob", TenantID: "tenant-b"}))
+	rec := httptest.NewRecorder()
+	rt.getProjectIssue(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if stub.tenant != "tenant-b" {
+		t.Fatalf("tenant=%q, want tenant-b", stub.tenant)
 	}
 }

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -8,12 +8,15 @@ import (
 	"path"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/writeupdraft"
+	assessmentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentuc"
+	assetuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
 	audituc "github.com/KKloudTarus/synapse-ce/internal/usecase/audit"
 	aupuc "github.com/KKloudTarus/synapse-ce/internal/usecase/aup"
 	credentialsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/credentials"
@@ -35,34 +38,36 @@ import (
 
 // Router wires HTTP routes to use case services.
 type Router struct {
-	log             *slog.Logger
-	auth            *Authenticator
-	eng             *enguc.Service
-	sca             *scauc.Service
-	aup             *aupuc.Service
-	findings        *findingsuc.Service
-	export          *exportuc.Service
-	report          *reportuc.Service
-	evidence        *evidenceuc.Service
-	recon           *reconuc.Service
-	logs            ports.LogStream
-	transfer        *transferuc.Service
-	audit           *audituc.Service
-	vex             *vexuc.Service
-	users           *usersuc.Service
-	credentials     *credentialsuc.Service
-	dastVerifier    runtimeVerifierService
-	dastWorkflow    dastWorkflowService
-	agent           *agentDeps            // optional; nil ⇒ agent routes are not registered
-	exploitation    findingVerifier       // optional; nil ⇒ the verify route is not registered
-	judgments       judgmentService       // optional; nil ⇒ judgment routes are not registered
-	autoVerifier    autoVerifierService   // optional; nil ⇒ the LLM auto-verify route is not registered
-	threatModels    threatModelService    // optional; nil ⇒ threat-model routes are not registered
-	drafts          writeupDraftService   // optional; nil ⇒ writeup-draft sign-off routes are not registered
-	projects        projectService        // optional; nil ⇒ project routes are not registered
-	qualityGates    qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
-	qualityProfiles qualityProfileService // optional; nil ⇒ quality-profile routes are not registered
-	rules           rulesService          // optional; nil ⇒ rule catalog routes are not registered
+	log              *slog.Logger
+	auth             *Authenticator
+	eng              *enguc.Service
+	sca              *scauc.Service
+	aup              *aupuc.Service
+	findings         *findingsuc.Service
+	export           *exportuc.Service
+	report           *reportuc.Service
+	evidence         *evidenceuc.Service
+	recon            *reconuc.Service
+	logs             ports.LogStream
+	transfer         *transferuc.Service
+	audit            *audituc.Service
+	vex              *vexuc.Service
+	users            *usersuc.Service
+	credentials      *credentialsuc.Service
+	dastVerifier     runtimeVerifierService
+	dastWorkflow     dastWorkflowService
+	agent            *agentDeps             // optional; nil ⇒ agent routes are not registered
+	exploitation     findingVerifier        // optional; nil ⇒ the verify route is not registered
+	judgments        judgmentService        // optional; nil ⇒ judgment routes are not registered
+	autoVerifier     autoVerifierService    // optional; nil ⇒ the LLM auto-verify route is not registered
+	threatModels     threatModelService     // optional; nil ⇒ threat-model routes are not registered
+	drafts           writeupDraftService    // optional; nil ⇒ writeup-draft sign-off routes are not registered
+	projects         projectService         // optional; nil ⇒ project routes are not registered
+	qualityGates     qualityGateService     // optional; nil ⇒ quality-gate routes are not registered
+	qualityProfiles  qualityProfileService  // optional; nil ⇒ quality-profile routes are not registered
+	rules            rulesService           // optional; nil ⇒ rule catalog routes are not registered
+	businessServices businessServiceService // optional; nil ⇒ Business Service routes are not registered
+	assessments      *assessmentuc.Service  // optional; nil ⇒ assessment routes are not registered
 }
 
 // findingVerifier is the narrow slice of the exploitation use-case the verify endpoint needs:
@@ -74,6 +79,21 @@ type findingVerifier interface {
 
 // SetExploitation wires the evidence-gated finding-verify endpoint.
 func (rt *Router) SetExploitation(v findingVerifier) { rt.exploitation = v }
+
+// businessServiceService is the complete public Business Service management slice.
+type businessServiceService interface {
+	CreateBusinessService(context.Context, assetuc.CreateBusinessServiceInput) (asset.BusinessService, error)
+	UpdateBusinessService(context.Context, shared.ID, assetuc.UpdateBusinessServiceInput) (asset.BusinessService, error)
+	GetBusinessService(context.Context, shared.ID) (asset.BusinessService, error)
+	ListBusinessServices(context.Context) ([]asset.BusinessService, error)
+	DeleteBusinessService(context.Context, shared.ID) error
+}
+
+// SetBusinessServices wires tenant-scoped AppSec Business Service management routes.
+func (rt *Router) SetBusinessServices(s businessServiceService) { rt.businessServices = s }
+
+// SetAssessments wires nested Assessment routes.
+func (rt *Router) SetAssessments(s *assessmentuc.Service) { rt.assessments = s }
 
 // judgmentService is the narrow slice of the analysis use-case the HTTP layer needs: list
 // the engagement's AI judgments (read) and apply a distinct-verifier verdict / human acceptance.
@@ -218,6 +238,18 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/deactivate", rt.authz(userdom.PermOperate, rt.deactivateProfileRule))
 		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/severity", rt.authz(userdom.PermOperate, rt.setProfileRuleSeverity))
 		mux.HandleFunc("DELETE /api/v1/quality-profiles/{key}", rt.authz(userdom.PermOperate, rt.deleteQualityProfile))
+	}
+	if rt.businessServices != nil {
+		mux.HandleFunc("POST /api/v1/appsec/business-services", rt.authz(userdom.PermOperate, rt.createBusinessService))
+		mux.HandleFunc("GET /api/v1/appsec/business-services", rt.authz(userdom.PermView, rt.listBusinessServices))
+		mux.HandleFunc("GET /api/v1/appsec/business-services/{id}", rt.authz(userdom.PermView, rt.getBusinessService))
+		mux.HandleFunc("PUT /api/v1/appsec/business-services/{id}", rt.authz(userdom.PermOperate, rt.updateBusinessService))
+		mux.HandleFunc("DELETE /api/v1/appsec/business-services/{id}", rt.authz(userdom.PermOperate, rt.deleteBusinessService))
+	}
+	if rt.assessments != nil {
+		mux.HandleFunc("POST /api/v1/appsec/business-services/{sid}/assessments", rt.authz(userdom.PermOperate, rt.createAssessment))
+		mux.HandleFunc("GET /api/v1/appsec/business-services/{sid}/assessments", rt.authz(userdom.PermView, rt.listAssessments))
+		mux.HandleFunc("GET /api/v1/appsec/business-services/{sid}/assessments/{id}", rt.authz(userdom.PermView, rt.getAssessment))
 	}
 	if rt.projects != nil {
 		mux.HandleFunc("POST /api/v1/projects", rt.authz(userdom.PermOperate, rt.createProject))

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -250,6 +250,7 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/appsec/business-services/{sid}/assessments", rt.authz(userdom.PermOperate, rt.createAssessment))
 		mux.HandleFunc("GET /api/v1/appsec/business-services/{sid}/assessments", rt.authz(userdom.PermView, rt.listAssessments))
 		mux.HandleFunc("GET /api/v1/appsec/business-services/{sid}/assessments/{id}", rt.authz(userdom.PermView, rt.getAssessment))
+		mux.HandleFunc("GET /api/v1/appsec/business-services/{sid}/assessments/{id}/assets", rt.authz(userdom.PermView, rt.listAssessmentAssets))
 	}
 	if rt.projects != nil {
 		mux.HandleFunc("POST /api/v1/projects", rt.authz(userdom.PermOperate, rt.createProject))

--- a/internal/domain/agent/agent.go
+++ b/internal/domain/agent/agent.go
@@ -77,6 +77,7 @@ const (
 // and replayable for audit. ProviderBase + Model + PromptHash pin WHAT reasoned about it.
 type Session struct {
 	ID             shared.ID
+	TenantID       shared.ID // immutable owner; carried by durable jobs before repository access
 	EngagementID   shared.ID
 	InitiatedBy    string // the human actor who started it (attribution; never an agent id)
 	Goal           string

--- a/internal/domain/assessment/assessment.go
+++ b/internal/domain/assessment/assessment.go
@@ -1,0 +1,53 @@
+// Package assessment models a durable AppSec assessment beneath one business service.
+package assessment
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type Status string
+
+const (
+	StatusDraft  Status = "draft"
+	StatusActive Status = "active"
+	StatusClosed Status = "closed"
+)
+
+func (s Status) Valid() bool { return s == StatusDraft || s == StatusActive || s == StatusClosed }
+
+type Policy struct {
+	Cadence     string `json:"cadence"`
+	Release     string `json:"release"`
+	Environment string `json:"environment"`
+}
+
+func (p Policy) Validate() error {
+	if utf8.RuneCountInString(p.Cadence) > 128 || utf8.RuneCountInString(p.Release) > 256 || utf8.RuneCountInString(p.Environment) > 128 {
+		return fmt.Errorf("%w: assessment policy exceeds limits", shared.ErrValidation)
+	}
+	return nil
+}
+
+type Assessment struct {
+	ID, TenantID, BusinessServiceID shared.ID
+	Name, Objective                 string
+	Status                          Status
+	Policy                          Policy
+	Audit                           shared.Audit
+}
+
+func New(id, tenant, service shared.ID, name, objective string, policy Policy, now time.Time) (Assessment, error) {
+	a := Assessment{ID: id, TenantID: tenant, BusinessServiceID: service, Name: strings.TrimSpace(name), Objective: strings.TrimSpace(objective), Status: StatusDraft, Policy: policy, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}
+	return a, a.Validate()
+}
+func (a Assessment) Validate() error {
+	if a.ID.IsZero() || a.BusinessServiceID.IsZero() || strings.TrimSpace(a.Name) == "" || utf8.RuneCountInString(a.Name) > 256 || utf8.RuneCountInString(a.Objective) > 4000 || !a.Status.Valid() {
+		return fmt.Errorf("%w: invalid assessment", shared.ErrValidation)
+	}
+	return a.Policy.Validate()
+}

--- a/internal/domain/assessment/assessment_test.go
+++ b/internal/domain/assessment/assessment_test.go
@@ -1,0 +1,24 @@
+package assessment
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAssessmentRequiresBusinessServiceAndBoundedPolicy(t *testing.T) {
+	now := time.Now().UTC()
+	a, err := New("assessment-1", "tenant-a", "service-1", "Payments release", "Validate the release", Policy{Cadence: "P30D", Release: "2026.08", Environment: "production"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Status != StatusDraft {
+		t.Fatalf("status=%s", a.Status)
+	}
+	_, err = New("assessment-2", "tenant-a", "", "missing parent", "", Policy{}, now)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing service error=%v", err)
+	}
+}

--- a/internal/domain/asset/asset.go
+++ b/internal/domain/asset/asset.go
@@ -1,0 +1,290 @@
+// Package asset models the bounded, tenant-owned AppSec inventory. It is not a
+// general CMDB: identities are security-relevant and intentionally constrained.
+package asset
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type Category string
+
+const (
+	CategoryApplication    Category = "application"
+	CategoryRepository     Category = "repository"
+	CategoryService        Category = "service"
+	CategoryAPI            Category = "api"
+	CategoryEndpoint       Category = "endpoint"
+	CategoryDomain         Category = "domain"
+	CategoryCloudResource  Category = "cloud_resource"
+	CategoryContainerImage Category = "container_image"
+	CategoryArtifact       Category = "artifact"
+	CategorySBOM           Category = "sbom"
+	CategoryInfrastructure Category = "infrastructure"
+	CategoryIaCModule      Category = "iac_module"
+)
+
+func (c Category) Valid() bool {
+	switch c {
+	case CategoryApplication, CategoryRepository, CategoryService, CategoryAPI, CategoryEndpoint,
+		CategoryDomain, CategoryCloudResource, CategoryContainerImage, CategoryArtifact, CategorySBOM,
+		CategoryInfrastructure, CategoryIaCModule:
+		return true
+	default:
+		return false
+	}
+}
+
+type Lifecycle string
+
+const (
+	LifecyclePlanned Lifecycle = "planned"
+	LifecycleActive  Lifecycle = "active"
+	LifecycleRetired Lifecycle = "retired"
+)
+
+func (l Lifecycle) Valid() bool {
+	return l == LifecyclePlanned || l == LifecycleActive || l == LifecycleRetired
+}
+
+type Criticality string
+
+const (
+	CriticalityLow      Criticality = "low"
+	CriticalityMedium   Criticality = "medium"
+	CriticalityHigh     Criticality = "high"
+	CriticalityCritical Criticality = "critical"
+)
+
+func (c Criticality) Valid() bool {
+	return c == CriticalityLow || c == CriticalityMedium || c == CriticalityHigh || c == CriticalityCritical
+}
+
+type Exposure string
+
+const (
+	ExposureInternal Exposure = "internal"
+	ExposurePartner  Exposure = "partner"
+	ExposurePublic   Exposure = "public"
+)
+
+func (e Exposure) Valid() bool {
+	return e == ExposureInternal || e == ExposurePartner || e == ExposurePublic
+}
+
+// Identity is the stable, unique security identifier for an asset within a tenant.
+// It must never contain a credential, access token, or other secret.
+type Identity struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
+// AssetIdentity is the explicit inventory name for Identity.
+type AssetIdentity = Identity
+
+func (i Identity) Validate(category Category) error {
+	kind, value := strings.TrimSpace(i.Kind), strings.TrimSpace(i.Value)
+	if kind == "" || value == "" || utf8.RuneCountInString(kind) > 64 || utf8.RuneCountInString(value) > 2048 {
+		return fmt.Errorf("%w: asset identity is required and bounded", shared.ErrValidation)
+	}
+	if strings.ContainsAny(value, "\r\n\x00") || hasCredential(value) {
+		return fmt.Errorf("%w: asset identity must not contain credentials or controls", shared.ErrValidation)
+	}
+	switch category {
+	case CategoryRepository:
+		return validateRepositoryIdentity(value)
+	case CategoryEndpoint, CategoryAPI:
+		return validateURLIdentity(value)
+	case CategoryDomain:
+		if strings.Contains(value, "/") || strings.Contains(value, ":") || !strings.Contains(value, ".") {
+			return fmt.Errorf("%w: domain identity is invalid", shared.ErrValidation)
+		}
+	case CategoryContainerImage:
+		if !strings.Contains(value, "@sha256:") || len(value) < len("x@sha256:")+64 {
+			return fmt.Errorf("%w: container image identity requires an immutable sha256 digest", shared.ErrValidation)
+		}
+	case CategorySBOM:
+		if !strings.HasPrefix(value, "sha256:") || len(value) != len("sha256:")+64 {
+			return fmt.Errorf("%w: SBOM identity requires a sha256 digest", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func hasCredential(value string) bool {
+	lower := strings.ToLower(value)
+	return strings.Contains(lower, "password=") || strings.Contains(lower, "token=") || strings.Contains(lower, "apikey=")
+}
+
+func validateRepositoryIdentity(value string) error {
+	if strings.HasPrefix(value, "git@") {
+		return nil
+	}
+	return validateURLIdentity(value)
+}
+
+func validateURLIdentity(value string) error {
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.User != nil || (u.Scheme != "https" && u.Scheme != "http" && u.Scheme != "ssh") {
+		return fmt.Errorf("%w: URL identity is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+type Asset struct {
+	ID             shared.ID
+	TenantID       shared.ID
+	Name           string
+	Category       Category
+	Identity       Identity
+	Lifecycle      Lifecycle
+	Criticality    Criticality
+	Exposure       Exposure
+	Classification string
+	Version        int
+	Audit          shared.Audit
+}
+
+func New(id, tenantID shared.ID, name string, category Category, identity Identity, now time.Time) (Asset, error) {
+	a := Asset{ID: id, TenantID: tenantID, Name: strings.TrimSpace(name), Category: category, Identity: identity, Lifecycle: LifecyclePlanned, Criticality: CriticalityMedium, Exposure: ExposureInternal, Version: 1, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}
+	return a, a.Validate()
+}
+
+func (a Asset) Validate() error {
+	if a.ID.IsZero() || strings.TrimSpace(a.Name) == "" || utf8.RuneCountInString(a.Name) > 256 || !a.Category.Valid() || !a.Lifecycle.Valid() || !a.Criticality.Valid() || !a.Exposure.Valid() || a.Version < 1 {
+		return fmt.Errorf("%w: invalid asset", shared.ErrValidation)
+	}
+	if utf8.RuneCountInString(a.Classification) > 128 {
+		return fmt.Errorf("%w: asset classification exceeds limit", shared.ErrValidation)
+	}
+	return a.Identity.Validate(a.Category)
+}
+
+// Version is an immutable audit record made whenever an asset's mutable posture
+// changes. Snapshot is application-owned JSON; repositories cap its size.
+type Version struct {
+	ID        shared.ID
+	TenantID  shared.ID
+	AssetID   shared.ID
+	Number    int
+	Snapshot  []byte
+	CreatedAt time.Time
+	CreatedBy string
+}
+
+func (v Version) Validate() error {
+	if v.ID.IsZero() || v.AssetID.IsZero() || v.Number < 1 || len(v.Snapshot) == 0 || len(v.Snapshot) > 64<<10 || !json.Valid(v.Snapshot) || v.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: invalid asset version", shared.ErrValidation)
+	}
+	return nil
+}
+
+// AssetVersion is the explicit inventory name for Version.
+type AssetVersion = Version
+
+type RelationshipType string
+
+const (
+	RelationshipContains      RelationshipType = "contains"
+	RelationshipPartOf        RelationshipType = "part_of"
+	RelationshipDependsOn     RelationshipType = "depends_on"
+	RelationshipRunsOn        RelationshipType = "runs_on"
+	RelationshipDeployedTo    RelationshipType = "deployed_to"
+	RelationshipExposes       RelationshipType = "exposes"
+	RelationshipBuiltFrom     RelationshipType = "built_from"
+	RelationshipManagedBy     RelationshipType = "managed_by"
+	RelationshipProcessesData RelationshipType = "processes_data"
+)
+
+func (r RelationshipType) Valid() bool {
+	switch r {
+	case RelationshipContains, RelationshipPartOf, RelationshipDependsOn, RelationshipRunsOn, RelationshipDeployedTo, RelationshipExposes, RelationshipBuiltFrom, RelationshipManagedBy, RelationshipProcessesData:
+		return true
+	default:
+		return false
+	}
+}
+
+type Relationship struct {
+	ID          shared.ID
+	TenantID    shared.ID
+	FromAssetID shared.ID
+	ToAssetID   shared.ID
+	Type        RelationshipType
+	CreatedAt   time.Time
+	CreatedBy   string
+}
+
+func (r Relationship) Validate() error {
+	if r.ID.IsZero() || r.FromAssetID.IsZero() || r.ToAssetID.IsZero() || r.FromAssetID == r.ToAssetID || !r.Type.Valid() || r.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: invalid asset relationship", shared.ErrValidation)
+	}
+	return nil
+}
+
+type BusinessService struct {
+	ID          shared.ID
+	TenantID    shared.ID
+	Name        string
+	Description string
+	Criticality Criticality
+	Lifecycle   Lifecycle
+	Audit       shared.Audit
+}
+
+func (b BusinessService) Validate() error {
+	if b.ID.IsZero() || strings.TrimSpace(b.Name) == "" || utf8.RuneCountInString(b.Name) > 256 || utf8.RuneCountInString(b.Description) > 4000 || !b.Criticality.Valid() || !b.Lifecycle.Valid() {
+		return fmt.Errorf("%w: invalid business service", shared.ErrValidation)
+	}
+	return nil
+}
+
+type AssetLinkRole string
+
+const (
+	AssetLinkOwns     AssetLinkRole = "owns"
+	AssetLinkUses     AssetLinkRole = "uses"
+	AssetLinkSupports AssetLinkRole = "supports"
+)
+
+func (r AssetLinkRole) Valid() bool {
+	return r == AssetLinkOwns || r == AssetLinkUses || r == AssetLinkSupports
+}
+
+type BusinessServiceAssetLink struct {
+	BusinessServiceID shared.ID
+	AssetID           shared.ID
+	Role              AssetLinkRole
+	CreatedAt         time.Time
+	CreatedBy         string
+}
+
+func (l BusinessServiceAssetLink) Validate() error {
+	if l.BusinessServiceID.IsZero() || l.AssetID.IsZero() || !l.Role.Valid() || l.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: invalid business-service asset link", shared.ErrValidation)
+	}
+	return nil
+}
+
+type OwnershipAssignment struct {
+	ID        shared.ID
+	TenantID  shared.ID
+	AssetID   shared.ID
+	Principal string
+	Role      string
+	CreatedAt time.Time
+	CreatedBy string
+}
+
+func (o OwnershipAssignment) Validate() error {
+	if o.ID.IsZero() || o.AssetID.IsZero() || strings.TrimSpace(o.Principal) == "" || utf8.RuneCountInString(o.Principal) > 256 || strings.TrimSpace(o.Role) == "" || utf8.RuneCountInString(o.Role) > 64 || o.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: invalid asset ownership assignment", shared.ErrValidation)
+	}
+	return nil
+}

--- a/internal/domain/asset/asset_test.go
+++ b/internal/domain/asset/asset_test.go
@@ -1,0 +1,53 @@
+package asset
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestIdentityValidationRejectsSecretsAndInvalidCategoryForms(t *testing.T) {
+	cases := []struct {
+		name     string
+		category Category
+		identity Identity
+		valid    bool
+	}{
+		{"repository URL", CategoryRepository, Identity{Kind: "url", Value: "https://github.com/acme/payments.git"}, true},
+		{"repository credential", CategoryRepository, Identity{Kind: "url", Value: "https://alice:secret@github.com/acme/payments.git"}, false},
+		{"endpoint URL", CategoryEndpoint, Identity{Kind: "url", Value: "https://api.example.com/v1"}, true},
+		{"endpoint non URL", CategoryEndpoint, Identity{Kind: "url", Value: "api.example.com"}, false},
+		{"image digest", CategoryContainerImage, Identity{Kind: "digest", Value: "registry.example/payments@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, true},
+		{"image tag", CategoryContainerImage, Identity{Kind: "digest", Value: "registry.example/payments:latest"}, false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.identity.Validate(tt.category)
+			if (err == nil) != tt.valid {
+				t.Fatalf("err=%v valid=%v", err, tt.valid)
+			}
+		})
+	}
+	if _, err := New("queue-a", "tenant-a", "Queue", Category("queue"), Identity{Kind: "name", Value: "queue-a"}, time.Now().UTC()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("deferred category error=%v", err)
+	}
+}
+
+func TestAssetAndLinksValidateBoundedTenantSafeIdentity(t *testing.T) {
+	now := time.Now().UTC()
+	a, err := New("asset-1", "tenant-a", "Payments API", CategoryAPI, Identity{Kind: "url", Value: "https://api.example.com"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Version != 1 || a.Lifecycle != LifecyclePlanned {
+		t.Fatalf("asset=%+v", a)
+	}
+	if err := (Relationship{ID: "r1", TenantID: "tenant-a", FromAssetID: a.ID, ToAssetID: a.ID, Type: RelationshipDependsOn, CreatedAt: now}).Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("self relation error=%v", err)
+	}
+	if err := (BusinessServiceAssetLink{BusinessServiceID: "service-1", AssetID: a.ID, Role: AssetLinkOwns, CreatedAt: now}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/domain/recon/recon.go
+++ b/internal/domain/recon/recon.go
@@ -38,6 +38,7 @@ func (s Status) Terminal() bool { return s == StatusSucceeded || s == StatusFail
 // track progress, survive reloads, and link to the sealed evidence.
 type Run struct {
 	ID           shared.ID  `json:"id"`
+	TenantID     shared.ID  `json:"-"`
 	EngagementID shared.ID  `json:"engagementId"`
 	Tool         string     `json:"tool"`   // recon tool name, e.g. "subfinder"
 	Target       string     `json:"target"` // the in-scope target value the run was launched against

--- a/internal/domain/shared/tenant_context.go
+++ b/internal/domain/shared/tenant_context.go
@@ -1,0 +1,19 @@
+package shared
+
+import "context"
+
+type tenantContextKey struct{}
+
+// WithTenant binds the authenticated or durable-job tenant to a context. The
+// empty value is the existing default tenant; a missing value is distinguishable
+// through TenantFrom and must not be treated as a wildcard.
+func WithTenant(ctx context.Context, tenantID ID) context.Context {
+	return context.WithValue(ctx, tenantContextKey{}, tenantID)
+}
+
+// TenantFrom returns the context tenant and whether a caller explicitly bound
+// one. A missing context is unsafe for RLS-backed persistence.
+func TenantFrom(ctx context.Context) (ID, bool) {
+	tenantID, ok := ctx.Value(tenantContextKey{}).(ID)
+	return tenantID, ok
+}

--- a/internal/infrastructure/persistence/memory/agent_session_store.go
+++ b/internal/infrastructure/persistence/memory/agent_session_store.go
@@ -58,6 +58,21 @@ func (s *AgentSessionStore) ListByEngagement(_ context.Context, engagementID sha
 	return out, nil
 }
 
+func (s *AgentSessionStore) TenantIDs(_ context.Context) ([]shared.ID, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seen := map[shared.ID]struct{}{}
+	for _, sess := range s.sessions {
+		seen[sess.TenantID] = struct{}{}
+	}
+	out := make([]shared.ID, 0, len(seen))
+	for tenantID := range seen {
+		out = append(out, tenantID)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
 func (s *AgentSessionStore) ListResumable(_ context.Context, staleFor time.Duration, now time.Time, limit int) ([]agent.Session, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/infrastructure/persistence/memory/approval_store.go
+++ b/internal/infrastructure/persistence/memory/approval_store.go
@@ -51,6 +51,10 @@ func (s *ApprovalStore) Pending(_ context.Context, engagementID shared.ID) ([]ag
 	return out, nil
 }
 
+func (s *ApprovalStore) TenantIDs(_ context.Context) ([]shared.ID, error) {
+	return []shared.ID{""}, nil
+}
+
 func (s *ApprovalStore) EngagementsWithPending(_ context.Context) ([]shared.ID, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/infrastructure/persistence/memory/assessment.go
+++ b/internal/infrastructure/persistence/memory/assessment.go
@@ -1,0 +1,110 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentRepository struct {
+	mu          sync.RWMutex
+	items       map[shared.ID]assessment.Assessment
+	services    *AssetInventoryRepository
+	engagements *EngagementRepository
+}
+
+func NewAssessmentRepository(services *AssetInventoryRepository, engagements *EngagementRepository) *AssessmentRepository {
+	r := &AssessmentRepository{items: map[shared.ID]assessment.Assessment{}, services: services, engagements: engagements}
+	if services != nil {
+		services.assessments = r
+	}
+	return r
+}
+
+var _ ports.AssessmentRepository = (*AssessmentRepository)(nil)
+
+func (r *AssessmentRepository) Create(ctx context.Context, a assessment.Assessment, children []*engagement.Engagement) error {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok || tenantID != a.TenantID || r.services == nil || r.engagements == nil {
+		return fmt.Errorf("%w: assessment tenant context", shared.ErrValidation)
+	}
+	if err := a.Validate(); err != nil || len(children) == 0 {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("%w: assessment requires an engagement", shared.ErrValidation)
+	}
+
+	r.services.mu.Lock()
+	defer r.services.mu.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.engagements.mu.Lock()
+	defer r.engagements.mu.Unlock()
+
+	service, ok := r.services.services[a.BusinessServiceID]
+	if !ok || service.TenantID != tenantID {
+		return fmt.Errorf("business service %s: %w", a.BusinessServiceID, shared.ErrNotFound)
+	}
+	if _, ok := r.items[a.ID]; ok {
+		return fmt.Errorf("assessment: %w", shared.ErrConflict)
+	}
+	for _, existing := range r.items {
+		if existing.TenantID == tenantID && existing.BusinessServiceID == a.BusinessServiceID && existing.Name == a.Name {
+			return fmt.Errorf("assessment name: %w", shared.ErrConflict)
+		}
+	}
+	seen := make(map[shared.ID]struct{}, len(children))
+	for _, child := range children {
+		if child == nil || child.ID.IsZero() || child.TenantID != tenantID || child.AssessmentID != a.ID {
+			return fmt.Errorf("%w: invalid assessment engagement", shared.ErrValidation)
+		}
+		if _, duplicate := seen[child.ID]; duplicate {
+			return fmt.Errorf("assessment engagement: %w", shared.ErrConflict)
+		}
+		if _, exists := r.engagements.data[child.ID]; exists {
+			return fmt.Errorf("assessment engagement: %w", shared.ErrConflict)
+		}
+		seen[child.ID] = struct{}{}
+	}
+	r.items[a.ID] = a
+	for _, child := range children {
+		r.engagements.data[child.ID] = child
+	}
+	return nil
+}
+
+func (r *AssessmentRepository) Get(ctx context.Context, id shared.ID) (assessment.Assessment, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return assessment.Assessment{}, fmt.Errorf("%w: assessment tenant context", shared.ErrValidation)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.items[id]
+	if !ok || a.TenantID != tenantID {
+		return assessment.Assessment{}, fmt.Errorf("assessment: %w", shared.ErrNotFound)
+	}
+	return a, nil
+}
+
+func (r *AssessmentRepository) ListByBusinessService(ctx context.Context, id shared.ID) ([]assessment.Assessment, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: assessment tenant context", shared.ErrValidation)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := []assessment.Assessment{}
+	for _, a := range r.items {
+		if a.TenantID == tenantID && a.BusinessServiceID == id {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}

--- a/internal/infrastructure/persistence/memory/assessment_test.go
+++ b/internal/infrastructure/persistence/memory/assessment_test.go
@@ -1,0 +1,62 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAssessmentCreateIsAtomicAndUnique(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant")
+	now := time.Now().UTC()
+	services := NewAssetInventoryRepository()
+	engagements := NewEngagementRepository()
+	repo := NewAssessmentRepository(services, engagements)
+	if err := services.CreateBusinessService(ctx, asset.BusinessService{ID: "service", TenantID: "tenant", Name: "Service", Criticality: asset.CriticalityMedium, Lifecycle: asset.LifecyclePlanned}); err != nil {
+		t.Fatal(err)
+	}
+	a, err := assessment.New("assessment", "tenant", "service", "Name", "", assessment.Policy{}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	good, err := engagement.New("good", "tenant", "Good", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	good.AssessmentID = a.ID
+	bad, err := engagement.New("bad", "other", "Bad", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad.AssessmentID = a.ID
+	if err := repo.Create(ctx, a, []*engagement.Engagement{good, bad}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("invalid create=%v", err)
+	}
+	if _, err := repo.Get(ctx, a.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("assessment persisted=%v", err)
+	}
+	if _, err := engagements.GetByID(ctx, good.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("child persisted=%v", err)
+	}
+	if err := repo.Create(ctx, a, []*engagement.Engagement{good}); err != nil {
+		t.Fatal(err)
+	}
+	duplicate, err := assessment.New("assessment-2", "tenant", "service", "Name", "", assessment.Policy{}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := engagement.New("child-2", "tenant", "Child", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child.AssessmentID = duplicate.ID
+	if err := repo.Create(ctx, duplicate, []*engagement.Engagement{child}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate name=%v", err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/asset_inventory.go
+++ b/internal/infrastructure/persistence/memory/asset_inventory.go
@@ -1,0 +1,355 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssetInventoryRepository struct {
+	mu            sync.RWMutex
+	assets        map[shared.ID]asset.Asset
+	versions      map[shared.ID][]asset.Version
+	services      map[shared.ID]asset.BusinessService
+	links         map[shared.ID][]asset.BusinessServiceAssetLink
+	relationships map[shared.ID][]asset.Relationship
+	owners        map[shared.ID][]asset.OwnershipAssignment
+	assessments   *AssessmentRepository
+}
+
+func NewAssetInventoryRepository() *AssetInventoryRepository {
+	return &AssetInventoryRepository{assets: map[shared.ID]asset.Asset{}, versions: map[shared.ID][]asset.Version{}, services: map[shared.ID]asset.BusinessService{}, links: map[shared.ID][]asset.BusinessServiceAssetLink{}, relationships: map[shared.ID][]asset.Relationship{}, owners: map[shared.ID][]asset.OwnershipAssignment{}}
+}
+
+var _ ports.AssetInventoryRepository = (*AssetInventoryRepository)(nil)
+
+func assetTenant(ctx context.Context) (shared.ID, error) {
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return "", fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
+	return tenant, nil
+}
+
+func (r *AssetInventoryRepository) CreateAsset(ctx context.Context, a asset.Asset) error {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if a.TenantID != tenant || a.Validate() != nil {
+		return fmt.Errorf("%w: invalid tenant-scoped asset", shared.ErrValidation)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, existing := range r.assets {
+		if existing.TenantID == tenant && existing.Category == a.Category && existing.Identity == a.Identity {
+			return fmt.Errorf("asset identity: %w", shared.ErrConflict)
+		}
+	}
+	r.assets[a.ID] = a
+	return nil
+}
+
+func (r *AssetInventoryRepository) GetAsset(ctx context.Context, id shared.ID) (asset.Asset, error) {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return asset.Asset{}, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.assets[id]
+	if !ok || a.TenantID != tenant {
+		return asset.Asset{}, fmt.Errorf("asset %s: %w", id, shared.ErrNotFound)
+	}
+	return a, nil
+}
+
+func (r *AssetInventoryRepository) ListAssets(ctx context.Context) ([]asset.Asset, error) {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := []asset.Asset{}
+	for _, a := range r.assets {
+		if a.TenantID == tenant {
+			out = append(out, a)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (r *AssetInventoryRepository) UpdateAsset(ctx context.Context, a asset.Asset, version asset.Version) error {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if a.TenantID != tenant || a.Validate() != nil || version.TenantID != tenant || version.AssetID != a.ID || version.Number != a.Version || version.Validate() != nil {
+		return fmt.Errorf("%w: invalid asset update", shared.ErrValidation)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	old, ok := r.assets[a.ID]
+	if !ok || old.TenantID != tenant {
+		return fmt.Errorf("asset %s: %w", a.ID, shared.ErrNotFound)
+	}
+	if a.Version != old.Version+1 {
+		return fmt.Errorf("asset %s: %w", a.ID, shared.ErrConflict)
+	}
+	r.assets[a.ID] = a
+	r.versions[a.ID] = append(r.versions[a.ID], version)
+	return nil
+}
+
+func (r *AssetInventoryRepository) ListAssetVersions(ctx context.Context, id shared.ID) ([]asset.Version, error) {
+	if _, err := r.GetAsset(ctx, id); err != nil {
+		return nil, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]asset.Version(nil), r.versions[id]...), nil
+}
+
+func (r *AssetInventoryRepository) CreateBusinessService(ctx context.Context, service asset.BusinessService) error {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if service.TenantID != tenant || service.Validate() != nil {
+		return fmt.Errorf("%w: invalid business service", shared.ErrValidation)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, existing := range r.services {
+		if existing.TenantID == tenant && existing.Name == service.Name {
+			return fmt.Errorf("business service name: %w", shared.ErrConflict)
+		}
+	}
+	r.services[service.ID] = service
+	return nil
+}
+func (r *AssetInventoryRepository) GetBusinessService(ctx context.Context, id shared.ID) (asset.BusinessService, error) {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return asset.BusinessService{}, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	service, ok := r.services[id]
+	if !ok || service.TenantID != tenant {
+		return asset.BusinessService{}, fmt.Errorf("business service %s: %w", id, shared.ErrNotFound)
+	}
+	return service, nil
+}
+func (r *AssetInventoryRepository) ListBusinessServices(ctx context.Context) ([]asset.BusinessService, error) {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := []asset.BusinessService{}
+	for _, service := range r.services {
+		if service.TenantID == tenant {
+			out = append(out, service)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (r *AssetInventoryRepository) UpdateBusinessService(ctx context.Context, service asset.BusinessService) error {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if service.TenantID != tenant || service.Validate() != nil {
+		return fmt.Errorf("%w: invalid business service", shared.ErrValidation)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if current, ok := r.services[service.ID]; !ok || current.TenantID != tenant {
+		return fmt.Errorf("business service %s: %w", service.ID, shared.ErrNotFound)
+	}
+	for id, existing := range r.services {
+		if id != service.ID && existing.TenantID == tenant && existing.Name == service.Name {
+			return fmt.Errorf("business service name: %w", shared.ErrConflict)
+		}
+	}
+	r.services[service.ID] = service
+	return nil
+}
+func (r *AssetInventoryRepository) LinkBusinessServiceAsset(ctx context.Context, link asset.BusinessServiceAssetLink) error {
+	if link.Validate() != nil {
+		return fmt.Errorf("%w: invalid asset link", shared.ErrValidation)
+	}
+	if _, err := r.GetBusinessService(ctx, link.BusinessServiceID); err != nil {
+		return err
+	}
+	if _, err := r.GetAsset(ctx, link.AssetID); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, existing := range r.links[link.BusinessServiceID] {
+		if existing.AssetID == link.AssetID {
+			return fmt.Errorf("asset link: %w", shared.ErrConflict)
+		}
+	}
+	r.links[link.BusinessServiceID] = append(r.links[link.BusinessServiceID], link)
+	return nil
+}
+func (r *AssetInventoryRepository) ListBusinessServiceAssets(ctx context.Context, serviceID shared.ID) ([]asset.BusinessServiceAssetLink, error) {
+	if _, err := r.GetBusinessService(ctx, serviceID); err != nil {
+		return nil, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]asset.BusinessServiceAssetLink(nil), r.links[serviceID]...), nil
+}
+func (r *AssetInventoryRepository) CreateRelationship(ctx context.Context, rel asset.Relationship) error {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if rel.TenantID != tenant || rel.Validate() != nil {
+		return fmt.Errorf("%w: invalid asset relationship", shared.ErrValidation)
+	}
+	if _, err := r.GetAsset(ctx, rel.FromAssetID); err != nil {
+		return err
+	}
+	if _, err := r.GetAsset(ctx, rel.ToAssetID); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, existing := range r.relationships[rel.FromAssetID] {
+		if existing.ToAssetID == rel.ToAssetID && existing.Type == rel.Type {
+			return fmt.Errorf("asset relationship: %w", shared.ErrConflict)
+		}
+	}
+	if rel.Type == asset.RelationshipContains || rel.Type == asset.RelationshipPartOf {
+		if r.reachesLocked(rel.ToAssetID, rel.FromAssetID, map[shared.ID]bool{}) {
+			return fmt.Errorf("asset relationship cycle: %w", shared.ErrValidation)
+		}
+	}
+	r.relationships[rel.FromAssetID] = append(r.relationships[rel.FromAssetID], rel)
+	return nil
+}
+func (r *AssetInventoryRepository) reachesLocked(from, to shared.ID, seen map[shared.ID]bool) bool {
+	if from == to {
+		return true
+	}
+	if seen[from] {
+		return false
+	}
+	seen[from] = true
+	for _, rel := range r.relationships[from] {
+		if rel.Type == asset.RelationshipContains || rel.Type == asset.RelationshipPartOf {
+			if r.reachesLocked(rel.ToAssetID, to, seen) {
+				return true
+			}
+		}
+	}
+	return false
+}
+func (r *AssetInventoryRepository) ListRelationships(ctx context.Context, id shared.ID) ([]asset.Relationship, error) {
+	if _, err := r.GetAsset(ctx, id); err != nil {
+		return nil, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]asset.Relationship(nil), r.relationships[id]...), nil
+}
+func (r *AssetInventoryRepository) AssignOwner(ctx context.Context, owner asset.OwnershipAssignment) error {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if owner.TenantID != tenant || owner.Validate() != nil {
+		return fmt.Errorf("%w: invalid ownership", shared.ErrValidation)
+	}
+	if _, err := r.GetAsset(ctx, owner.AssetID); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, existing := range r.owners[owner.AssetID] {
+		if existing.Principal == owner.Principal && existing.Role == owner.Role {
+			return fmt.Errorf("ownership: %w", shared.ErrConflict)
+		}
+	}
+	r.owners[owner.AssetID] = append(r.owners[owner.AssetID], owner)
+	return nil
+}
+func (r *AssetInventoryRepository) ListOwners(ctx context.Context, id shared.ID) ([]asset.OwnershipAssignment, error) {
+	if _, err := r.GetAsset(ctx, id); err != nil {
+		return nil, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]asset.OwnershipAssignment(nil), r.owners[id]...), nil
+}
+
+func (r *AssetInventoryRepository) DeleteAsset(ctx context.Context, id shared.ID) error {
+	if _, err := r.GetAsset(ctx, id); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.assets, id)
+	delete(r.versions, id)
+	delete(r.relationships, id)
+	delete(r.owners, id)
+	for from, relationships := range r.relationships {
+		kept := relationships[:0]
+		for _, relationship := range relationships {
+			if relationship.ToAssetID != id {
+				kept = append(kept, relationship)
+			}
+		}
+		r.relationships[from] = kept
+	}
+	for serviceID, links := range r.links {
+		kept := links[:0]
+		for _, link := range links {
+			if link.AssetID != id {
+				kept = append(kept, link)
+			}
+		}
+		r.links[serviceID] = kept
+	}
+	return nil
+}
+
+func (r *AssetInventoryRepository) DeleteBusinessService(ctx context.Context, id shared.ID) error {
+	tenant, err := assetTenant(ctx)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	service, ok := r.services[id]
+	if !ok || service.TenantID != tenant {
+		return fmt.Errorf("business service %s: %w", id, shared.ErrNotFound)
+	}
+	if r.assessments != nil {
+		r.assessments.mu.RLock()
+		defer r.assessments.mu.RUnlock()
+		for _, item := range r.assessments.items {
+			if item.TenantID == tenant && item.BusinessServiceID == id {
+				return fmt.Errorf("business service assessments: %w", shared.ErrConflict)
+			}
+		}
+	}
+	delete(r.services, id)
+	delete(r.links, id)
+	return nil
+}

--- a/internal/infrastructure/persistence/memory/asset_inventory_test.go
+++ b/internal/infrastructure/persistence/memory/asset_inventory_test.go
@@ -1,0 +1,87 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAssetInventoryTenantIsolationAndSharedLinks(t *testing.T) {
+	repo := NewAssetInventoryRepository()
+	now := time.Now().UTC()
+	ctxA := shared.WithTenant(context.Background(), "tenant-a")
+	ctxB := shared.WithTenant(context.Background(), "tenant-b")
+	a, err := asset.New("asset-a", "tenant-a", "Payments API", asset.CategoryAPI, asset.Identity{Kind: "url", Value: "https://payments.example.test"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.CreateAsset(ctxA, a); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.GetAsset(ctxB, a.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant asset error=%v", err)
+	}
+	for _, id := range []shared.ID{"service-a", "service-a-2"} {
+		service := asset.BusinessService{ID: id, TenantID: "tenant-a", Name: id.String(), Criticality: asset.CriticalityHigh, Lifecycle: asset.LifecycleActive, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}
+		if err := repo.CreateBusinessService(ctxA, service); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.LinkBusinessServiceAsset(ctxA, asset.BusinessServiceAssetLink{BusinessServiceID: id, AssetID: a.ID, Role: asset.AssetLinkUses, CreatedAt: now}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	links, err := repo.ListBusinessServiceAssets(ctxA, "service-a")
+	if err != nil || len(links) != 1 || links[0].AssetID != a.ID {
+		t.Fatalf("links=%+v err=%v", links, err)
+	}
+}
+
+func TestAssetInventoryRejectsContainmentCycle(t *testing.T) {
+	repo := NewAssetInventoryRepository()
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	now := time.Now().UTC()
+	for _, id := range []shared.ID{"a", "b"} {
+		a, _ := asset.New(id, "tenant-a", id.String(), asset.CategoryService, asset.Identity{Kind: "name", Value: id.String()}, now)
+		if err := repo.CreateAsset(ctx, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := repo.CreateRelationship(ctx, asset.Relationship{ID: "ab", TenantID: "tenant-a", FromAssetID: "a", ToAssetID: "b", Type: asset.RelationshipContains, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.CreateRelationship(ctx, asset.Relationship{ID: "ba", TenantID: "tenant-a", FromAssetID: "b", ToAssetID: "a", Type: asset.RelationshipContains, CreatedAt: now}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cycle error=%v", err)
+	}
+}
+
+func TestDeleteAssetRemovesIncomingRelationships(t *testing.T) {
+	repo := NewAssetInventoryRepository()
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	now := time.Now().UTC()
+	for _, id := range []shared.ID{"a", "b"} {
+		item, err := asset.New(id, "tenant-a", id.String(), asset.CategoryService, asset.Identity{Kind: "name", Value: id.String()}, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.CreateAsset(ctx, item); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := repo.CreateRelationship(ctx, asset.Relationship{ID: "ab", TenantID: "tenant-a", FromAssetID: "a", ToAssetID: "b", Type: asset.RelationshipDependsOn, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.DeleteAsset(ctx, "b"); err != nil {
+		t.Fatal(err)
+	}
+	relationships, err := repo.ListRelationships(ctx, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(relationships) != 0 {
+		t.Fatalf("relationships=%+v, want none", relationships)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/agent_decision_store.go
+++ b/internal/infrastructure/persistence/postgres/agent_decision_store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -14,17 +15,10 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-// AgentDecisionStore is the durable ports.DecisionStore on PostgreSQL (migration 0032).
-// seq is a monotonic per-session counter (MAX+1). Idempotency is enforced by
-// partial unique indexes – one row per (session_id, action_id) for steps and one stop per
-// session – so a redelivered drive that re-records a decision is a no-op (ON CONFLICT DO
-// NOTHING), never a forked log. Decisions are written by a single driver under the session run
-// lock, so the MAX+1 read/insert pair is race-free.
-type AgentDecisionStore struct {
-	pool *pgxpool.Pool
-}
+// AgentDecisionStore persists the structured agent decision log in tenant-bound
+// transactions. A durable redelivery cannot write or read another tenant's log.
+type AgentDecisionStore struct{ pool *pgxpool.Pool }
 
-// NewAgentDecisionStore returns a Postgres-backed decision store.
 func NewAgentDecisionStore(pool *pgxpool.Pool) *AgentDecisionStore {
 	return &AgentDecisionStore{pool: pool}
 }
@@ -40,69 +34,63 @@ func (s *AgentDecisionStore) AppendDecision(ctx context.Context, d agent.AgentDe
 	if err != nil {
 		return fmt.Errorf("marshal decision refs: %w", err)
 	}
-	// seq is allocated as MAX+1 then inserted. Under a parallel batch, several drivers in
-	// the same session can read the same MAX+1 and collide on the (session_id, seq) PK – that is
-	// NOT an idempotent re-record and must RETRY with a fresh seq (else the projection silently
-	// drops a row). A collision on the partial unique indexes (same action for a step, or a
-	// second stop) IS a genuine idempotent re-record → success, no retry. We distinguish by the
-	// violated constraint name so a seq collision never masquerades as a dedup.
-	for attempt := 0; attempt < 16; attempt++ {
-		var seq int
-		if err := s.pool.QueryRow(ctx,
-			`SELECT COALESCE(MAX(seq), -1) + 1 FROM agent_decisions WHERE session_id=$1`, d.SessionID.String()).Scan(&seq); err != nil {
-			return fmt.Errorf("next decision seq: %w", err)
-		}
-		_, err = s.pool.Exec(ctx,
-			`INSERT INTO agent_decisions
-			   (session_id, seq, engagement_id, kind, outcome, action_id, tool, action, target, risk, decided_by, stop_reason, reason, refs, created_by, created_at)
-			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
-			d.SessionID.String(), seq, d.EngagementID.String(), string(d.Kind), string(d.Outcome), d.ActionID.String(),
-			d.Tool, d.Action, d.Target, string(d.Risk), d.DecidedBy, string(d.StopReason), reason, refs, d.CreatedBy, d.CreatedAt)
-		if err == nil {
-			return nil
-		}
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			switch pgErr.ConstraintName {
-			case "idx_agent_decisions_step_action", "idx_agent_decisions_one_stop":
-				return nil // genuine idempotent re-record (same action / second stop) – no-op
-			default: // (session_id, seq) PK collision under concurrency – retry with a fresh seq
-				continue
-			}
-		}
-		return fmt.Errorf("append agent decision: %w", err)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("append agent decision: %w", shared.ErrValidation)
 	}
-	return fmt.Errorf("append agent decision: %w: seq contention exceeded retries", shared.ErrConflict)
+	return WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		for range 16 {
+			var seq int
+			if err := tx.QueryRow(ctx, `SELECT COALESCE(MAX(seq), -1) + 1 FROM agent_decisions WHERE session_id=$1`, d.SessionID.String()).Scan(&seq); err != nil {
+				return fmt.Errorf("next decision seq: %w", err)
+			}
+			_, err = tx.Exec(ctx, `INSERT INTO agent_decisions (tenant_id, session_id, seq, engagement_id, kind, outcome, action_id, tool, action, target, risk, decided_by, stop_reason, reason, refs, created_by, created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`, tenantID.String(), d.SessionID.String(), seq, d.EngagementID.String(), string(d.Kind), string(d.Outcome), d.ActionID.String(), d.Tool, d.Action, d.Target, string(d.Risk), d.DecidedBy, string(d.StopReason), reason, refs, d.CreatedBy, d.CreatedAt)
+			if err == nil {
+				return nil
+			}
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				switch pgErr.ConstraintName {
+				case "idx_agent_decisions_step_action", "idx_agent_decisions_one_stop":
+					return nil
+				default:
+					continue
+				}
+			}
+			return fmt.Errorf("append agent decision: %w", err)
+		}
+		return fmt.Errorf("append agent decision: %w: seq contention exceeded retries", shared.ErrConflict)
+	})
 }
 
 func (s *AgentDecisionStore) ListBySession(ctx context.Context, sessionID shared.ID) ([]agent.AgentDecision, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT session_id, seq, engagement_id, kind, outcome, action_id, tool, action, target, risk, decided_by, stop_reason, reason, refs, created_by, created_at
-		 FROM agent_decisions WHERE session_id=$1 ORDER BY seq`, sessionID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list agent decisions: %w", err)
-	}
-	defer rows.Close()
 	var out []agent.AgentDecision
-	for rows.Next() {
-		var (
-			d                         agent.AgentDecision
-			kind, outcome, stopReason string
-			reason, refs              []byte
-		)
-		if err := rows.Scan(&d.SessionID, &d.Seq, &d.EngagementID, &kind, &outcome, &d.ActionID, &d.Tool, &d.Action, &d.Target, &d.Risk, &d.DecidedBy, &stopReason, &reason, &refs, &d.CreatedBy, &d.CreatedAt); err != nil {
-			return nil, fmt.Errorf("scan agent decision: %w", err)
+	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT session_id, seq, engagement_id, kind, outcome, action_id, tool, action, target, risk, decided_by, stop_reason, reason, refs, created_by, created_at FROM agent_decisions WHERE session_id=$1 ORDER BY seq`, sessionID.String())
+		if err != nil {
+			return fmt.Errorf("list agent decisions: %w", err)
 		}
-		d.Kind = agent.DecisionKind(kind)
-		d.Outcome = agent.StepOutcome(outcome)
-		d.StopReason = agent.StopReason(stopReason)
-		if len(reason) > 0 {
-			_ = json.Unmarshal(reason, &d.Reason)
+		defer rows.Close()
+		for rows.Next() {
+			var d agent.AgentDecision
+			var kind, outcome, stopReason string
+			var reason, refs []byte
+			if err := rows.Scan(&d.SessionID, &d.Seq, &d.EngagementID, &kind, &outcome, &d.ActionID, &d.Tool, &d.Action, &d.Target, &d.Risk, &d.DecidedBy, &stopReason, &reason, &refs, &d.CreatedBy, &d.CreatedAt); err != nil {
+				return fmt.Errorf("scan agent decision: %w", err)
+			}
+			d.Kind, d.Outcome, d.StopReason = agent.DecisionKind(kind), agent.StepOutcome(outcome), agent.StopReason(stopReason)
+			if len(reason) > 0 {
+				_ = json.Unmarshal(reason, &d.Reason)
+			}
+			if len(refs) > 0 {
+				_ = json.Unmarshal(refs, &d.Refs)
+			}
+			out = append(out, d)
 		}
-		if len(refs) > 0 {
-			_ = json.Unmarshal(refs, &d.Refs)
-		}
-		out = append(out, d)
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }

--- a/internal/infrastructure/persistence/postgres/agent_plan_store.go
+++ b/internal/infrastructure/persistence/postgres/agent_plan_store.go
@@ -15,16 +15,10 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-// AgentPlanStore is the durable ports.PlanStore on PostgreSQL (migration 0031).
-// One plan per session (session_id UNIQUE → CreatePlan on a redelivery hits a
-// unique violation → ErrConflict, preventing a forked second plan). SavePlan is a guarded
-// UPDATE (… WHERE revision=$expected) that bumps the revision, so a node claim is an atomic
-// compare-and-swap; a lost CAS (0 rows) returns ErrConflict.
-type AgentPlanStore struct {
-	pool *pgxpool.Pool
-}
+// AgentPlanStore is the durable ports.PlanStore on PostgreSQL. Every operation
+// binds the authenticated or durable-job tenant for eventual RLS enforcement.
+type AgentPlanStore struct{ pool *pgxpool.Pool }
 
-// NewAgentPlanStore returns a Postgres-backed plan store.
 func NewAgentPlanStore(pool *pgxpool.Pool) *AgentPlanStore { return &AgentPlanStore{pool: pool} }
 
 var _ ports.PlanStore = (*AgentPlanStore)(nil)
@@ -39,10 +33,7 @@ func (s *AgentPlanStore) CreatePlan(ctx context.Context, p agent.Plan) error {
 		return fmt.Errorf("create agent plan: %w", shared.ErrValidation)
 	}
 	return WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx,
-			`INSERT INTO agent_plans (id, tenant_id, session_id, engagement_id, goal, status, revision, nodes, created_at, updated_at)
-			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-			p.ID.String(), tenantID.String(), p.SessionID.String(), p.EngagementID.String(), p.Goal, string(p.Status), p.Revision, nodes, p.CreatedAt, p.UpdatedAt)
+		_, err := tx.Exec(ctx, `INSERT INTO agent_plans (id, tenant_id, session_id, engagement_id, goal, status, revision, nodes, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, p.ID.String(), tenantID.String(), p.SessionID.String(), p.EngagementID.String(), p.Goal, string(p.Status), p.Revision, nodes, p.CreatedAt, p.UpdatedAt)
 		if err != nil {
 			var pgErr *pgconn.PgError
 			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
@@ -55,28 +46,30 @@ func (s *AgentPlanStore) CreatePlan(ctx context.Context, p agent.Plan) error {
 }
 
 func (s *AgentPlanStore) GetBySession(ctx context.Context, sessionID shared.ID) (agent.Plan, bool, error) {
-	var (
-		p      agent.Plan
-		status string
-		nodes  []byte
-	)
-	err := s.pool.QueryRow(ctx,
-		`SELECT id, session_id, engagement_id, goal, status, revision, nodes, created_at, updated_at
-		 FROM agent_plans WHERE session_id=$1`, sessionID.String()).
-		Scan(&p.ID, &p.SessionID, &p.EngagementID, &p.Goal, &status, &p.Revision, &nodes, &p.CreatedAt, &p.UpdatedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return agent.Plan{}, false, nil
-	}
-	if err != nil {
-		return agent.Plan{}, false, fmt.Errorf("get agent plan: %w", err)
-	}
-	p.Status = agent.PlanStatus(status)
-	if len(nodes) > 0 {
-		if err := json.Unmarshal(nodes, &p.Nodes); err != nil {
-			return agent.Plan{}, false, fmt.Errorf("unmarshal plan nodes: %w", err)
+	var out agent.Plan
+	found := false
+	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		var status string
+		var nodes []byte
+		err := tx.QueryRow(ctx, `SELECT id, session_id, engagement_id, goal, status, revision, nodes, created_at, updated_at FROM agent_plans WHERE session_id=$1`, sessionID.String()).Scan(&out.ID, &out.SessionID, &out.EngagementID, &out.Goal, &status, &out.Revision, &nodes, &out.CreatedAt, &out.UpdatedAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
 		}
+		if err != nil {
+			return fmt.Errorf("get agent plan: %w", err)
+		}
+		out.Status, found = agent.PlanStatus(status), true
+		if len(nodes) > 0 {
+			if err := json.Unmarshal(nodes, &out.Nodes); err != nil {
+				return fmt.Errorf("unmarshal plan nodes: %w", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return agent.Plan{}, false, err
 	}
-	return p, true, nil
+	return out, found, nil
 }
 
 func (s *AgentPlanStore) SavePlan(ctx context.Context, p agent.Plan) error {
@@ -84,17 +77,14 @@ func (s *AgentPlanStore) SavePlan(ctx context.Context, p agent.Plan) error {
 	if err != nil {
 		return fmt.Errorf("marshal plan nodes: %w", err)
 	}
-	tag, err := s.pool.Exec(ctx,
-		`UPDATE agent_plans SET status=$1, revision=revision+1, nodes=$2, updated_at=now()
-		 WHERE session_id=$3 AND revision=$4`,
-		string(p.Status), nodes, p.SessionID.String(), p.Revision)
-	if err != nil {
-		return fmt.Errorf("save agent plan: %w", err)
-	}
-	if tag.RowsAffected() == 0 {
-		// Either the row is gone or another driver advanced the revision first – both mean this
-		// driver's view is stale and must reload (lost-update guard / node-claim CAS).
-		return fmt.Errorf("plan for session %s revision %d is stale: %w", p.SessionID, p.Revision, shared.ErrConflict)
-	}
-	return nil
+	return WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE agent_plans SET status=$1, revision=revision+1, nodes=$2, updated_at=now() WHERE session_id=$3 AND revision=$4`, string(p.Status), nodes, p.SessionID.String(), p.Revision)
+		if err != nil {
+			return fmt.Errorf("save agent plan: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("plan for session %s revision %d is stale: %w", p.SessionID, p.Revision, shared.ErrConflict)
+		}
+		return nil
+	})
 }

--- a/internal/infrastructure/persistence/postgres/agent_plan_store.go
+++ b/internal/infrastructure/persistence/postgres/agent_plan_store.go
@@ -34,18 +34,24 @@ func (s *AgentPlanStore) CreatePlan(ctx context.Context, p agent.Plan) error {
 	if err != nil {
 		return fmt.Errorf("marshal plan nodes: %w", err)
 	}
-	_, err = s.pool.Exec(ctx,
-		`INSERT INTO agent_plans (id, session_id, engagement_id, goal, status, revision, nodes, created_at, updated_at)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
-		p.ID.String(), p.SessionID.String(), p.EngagementID.String(), p.Goal, string(p.Status), p.Revision, nodes, p.CreatedAt, p.UpdatedAt)
-	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" { // session_id UNIQUE – fork guard
-			return fmt.Errorf("plan for session %s already exists: %w", p.SessionID, shared.ErrConflict)
-		}
-		return fmt.Errorf("create agent plan: %w", err)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("create agent plan: %w", shared.ErrValidation)
 	}
-	return nil
+	return WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO agent_plans (id, tenant_id, session_id, engagement_id, goal, status, revision, nodes, created_at, updated_at)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+			p.ID.String(), tenantID.String(), p.SessionID.String(), p.EngagementID.String(), p.Goal, string(p.Status), p.Revision, nodes, p.CreatedAt, p.UpdatedAt)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return fmt.Errorf("plan for session %s already exists: %w", p.SessionID, shared.ErrConflict)
+			}
+			return fmt.Errorf("create agent plan: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *AgentPlanStore) GetBySession(ctx context.Context, sessionID shared.ID) (agent.Plan, bool, error) {

--- a/internal/infrastructure/persistence/postgres/agent_session_store.go
+++ b/internal/infrastructure/persistence/postgres/agent_session_store.go
@@ -19,9 +19,7 @@ import (
 // AgentSessionStore is the durable ports.AgentSessionStore on PostgreSQL:
 // agent_sessions + agent_messages (migration 0027). The (session_id, seq) primary key is
 // the transcript fork-guard – a duplicate seq is a unique violation → ErrConflict.
-type AgentSessionStore struct {
-	pool *pgxpool.Pool
-}
+type AgentSessionStore struct{ pool *pgxpool.Pool }
 
 // NewAgentSessionStore returns a Postgres-backed agent session store.
 func NewAgentSessionStore(pool *pgxpool.Pool) *AgentSessionStore {
@@ -31,27 +29,33 @@ func NewAgentSessionStore(pool *pgxpool.Pool) *AgentSessionStore {
 var _ ports.AgentSessionStore = (*AgentSessionStore)(nil)
 
 func (s *AgentSessionStore) SaveSession(ctx context.Context, e agent.Session) error {
-	_, err := s.pool.Exec(ctx,
-		`INSERT INTO agent_sessions
-		   (id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
-		 ON CONFLICT (id) DO UPDATE SET
-		   status=$8, steps=$9, tokens_used=$10, token_budget_max=$11, updated_at=$13`,
-		e.ID.String(), e.EngagementID.String(), e.InitiatedBy, e.Goal, e.Model, e.ProviderBase, e.PromptHash,
-		string(e.Status), e.Steps, e.TokensUsed, e.TokenBudgetMax, e.CreatedAt, e.UpdatedAt)
-	if err != nil {
-		return fmt.Errorf("save agent session: %w", err)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("save agent session: %w", shared.ErrValidation)
 	}
-	return nil
+	return WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO agent_sessions
+			   (id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+			 ON CONFLICT (id) DO UPDATE SET
+			   status=$9, steps=$10, tokens_used=$11, token_budget_max=$12, updated_at=$14`,
+			e.ID.String(), tenantID.String(), e.EngagementID.String(), e.InitiatedBy, e.Goal, e.Model, e.ProviderBase, e.PromptHash,
+			string(e.Status), e.Steps, e.TokensUsed, e.TokenBudgetMax, e.CreatedAt, e.UpdatedAt)
+		if err != nil {
+			return fmt.Errorf("save agent session: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *AgentSessionStore) GetSession(ctx context.Context, id shared.ID) (agent.Session, error) {
 	var e agent.Session
 	var status string
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
+		`SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
 		 FROM agent_sessions WHERE id=$1`, id.String()).
-		Scan(&e.ID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt)
+		Scan(&e.ID, &e.TenantID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return agent.Session{}, fmt.Errorf("agent session %s: %w", id, shared.ErrNotFound)
 	}
@@ -64,7 +68,7 @@ func (s *AgentSessionStore) GetSession(ctx context.Context, id shared.ID) (agent
 
 func (s *AgentSessionStore) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]agent.Session, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
+		`SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
 		 FROM agent_sessions WHERE engagement_id=$1 ORDER BY created_at`, engagementID.String())
 	if err != nil {
 		return nil, fmt.Errorf("list agent sessions: %w", err)
@@ -74,7 +78,7 @@ func (s *AgentSessionStore) ListByEngagement(ctx context.Context, engagementID s
 	for rows.Next() {
 		var e agent.Session
 		var status string
-		if err := rows.Scan(&e.ID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.TenantID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan agent session: %w", err)
 		}
 		e.Status = agent.Status(status)
@@ -88,7 +92,7 @@ func (s *AgentSessionStore) ListResumable(ctx context.Context, staleFor time.Dur
 		limit = 100
 	}
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
+		`SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
 		 FROM agent_sessions WHERE status IN ('running','awaiting_approval') AND updated_at < $1
 		 ORDER BY updated_at LIMIT $2`, now.Add(-staleFor), limit)
 	if err != nil {
@@ -99,7 +103,7 @@ func (s *AgentSessionStore) ListResumable(ctx context.Context, staleFor time.Dur
 	for rows.Next() {
 		var e agent.Session
 		var status string
-		if err := rows.Scan(&e.ID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.TenantID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan resumable session: %w", err)
 		}
 		e.Status = agent.Status(status)
@@ -113,13 +117,10 @@ func (s *AgentSessionStore) AppendMessage(ctx context.Context, sessionID shared.
 	if len(m.ToolCalls) > 0 {
 		toolCalls, _ = json.Marshal(m.ToolCalls)
 	}
-	_, err := s.pool.Exec(ctx,
-		`INSERT INTO agent_messages (session_id, seq, role, content, tool_calls, tool_call_id)
-		 VALUES ($1,$2,$3,$4,$5,$6)`,
-		sessionID.String(), seq, string(m.Role), m.Content, toolCalls, m.ToolCallID)
+	_, err := s.pool.Exec(ctx, `INSERT INTO agent_messages (session_id, seq, role, content, tool_calls, tool_call_id) VALUES ($1,$2,$3,$4,$5,$6)`, sessionID.String(), seq, string(m.Role), m.Content, toolCalls, m.ToolCallID)
 	if err != nil {
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" { // (session_id, seq) PK – fork guard
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
 			return fmt.Errorf("agent message (%s, seq %d) already exists: %w", sessionID, seq, shared.ErrConflict)
 		}
 		return fmt.Errorf("append agent message: %w", err)
@@ -128,8 +129,7 @@ func (s *AgentSessionStore) AppendMessage(ctx context.Context, sessionID shared.
 }
 
 func (s *AgentSessionStore) Messages(ctx context.Context, sessionID shared.ID) ([]agent.Message, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT role, content, tool_calls, tool_call_id FROM agent_messages WHERE session_id=$1 ORDER BY seq`, sessionID.String())
+	rows, err := s.pool.Query(ctx, `SELECT role, content, tool_calls, tool_call_id FROM agent_messages WHERE session_id=$1 ORDER BY seq`, sessionID.String())
 	if err != nil {
 		return nil, fmt.Errorf("list agent messages: %w", err)
 	}

--- a/internal/infrastructure/persistence/postgres/agent_session_store.go
+++ b/internal/infrastructure/persistence/postgres/agent_session_store.go
@@ -16,12 +16,8 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-// AgentSessionStore is the durable ports.AgentSessionStore on PostgreSQL:
-// agent_sessions + agent_messages (migration 0027). The (session_id, seq) primary key is
-// the transcript fork-guard – a duplicate seq is a unique violation → ErrConflict.
 type AgentSessionStore struct{ pool *pgxpool.Pool }
 
-// NewAgentSessionStore returns a Postgres-backed agent session store.
 func NewAgentSessionStore(pool *pgxpool.Pool) *AgentSessionStore {
 	return &AgentSessionStore{pool: pool}
 }
@@ -34,14 +30,7 @@ func (s *AgentSessionStore) SaveSession(ctx context.Context, e agent.Session) er
 		return fmt.Errorf("save agent session: %w", shared.ErrValidation)
 	}
 	return WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx,
-			`INSERT INTO agent_sessions
-			   (id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at)
-			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
-			 ON CONFLICT (id) DO UPDATE SET
-			   status=$9, steps=$10, tokens_used=$11, token_budget_max=$12, updated_at=$14`,
-			e.ID.String(), tenantID.String(), e.EngagementID.String(), e.InitiatedBy, e.Goal, e.Model, e.ProviderBase, e.PromptHash,
-			string(e.Status), e.Steps, e.TokensUsed, e.TokenBudgetMax, e.CreatedAt, e.UpdatedAt)
+		_, err := tx.Exec(ctx, `INSERT INTO agent_sessions (id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14) ON CONFLICT (id) DO UPDATE SET status=$9, steps=$10, tokens_used=$11, token_budget_max=$12, updated_at=$14`, e.ID.String(), tenantID.String(), e.EngagementID.String(), e.InitiatedBy, e.Goal, e.Model, e.ProviderBase, e.PromptHash, string(e.Status), e.Steps, e.TokensUsed, e.TokenBudgetMax, e.CreatedAt, e.UpdatedAt)
 		if err != nil {
 			return fmt.Errorf("save agent session: %w", err)
 		}
@@ -50,26 +39,27 @@ func (s *AgentSessionStore) SaveSession(ctx context.Context, e agent.Session) er
 }
 
 func (s *AgentSessionStore) GetSession(ctx context.Context, id shared.ID) (agent.Session, error) {
-	var e agent.Session
-	var status string
-	err := s.pool.QueryRow(ctx,
-		`SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
-		 FROM agent_sessions WHERE id=$1`, id.String()).
-		Scan(&e.ID, &e.TenantID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return agent.Session{}, fmt.Errorf("agent session %s: %w", id, shared.ErrNotFound)
-	}
+	var out agent.Session
+	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		var status string
+		err := tx.QueryRow(ctx, `SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at FROM agent_sessions WHERE id=$1`, id.String()).Scan(&out.ID, &out.TenantID, &out.EngagementID, &out.InitiatedBy, &out.Goal, &out.Model, &out.ProviderBase, &out.PromptHash, &status, &out.Steps, &out.TokensUsed, &out.TokenBudgetMax, &out.CreatedAt, &out.UpdatedAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("agent session %s: %w", id, shared.ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("get agent session: %w", err)
+		}
+		out.Status = agent.Status(status)
+		return nil
+	})
 	if err != nil {
-		return agent.Session{}, fmt.Errorf("get agent session: %w", err)
+		return agent.Session{}, err
 	}
-	e.Status = agent.Status(status)
-	return e, nil
+	return out, nil
 }
 
 func (s *AgentSessionStore) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]agent.Session, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
-		 FROM agent_sessions WHERE engagement_id=$1 ORDER BY created_at`, engagementID.String())
+	rows, err := s.pool.Query(ctx, `SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at FROM agent_sessions WHERE engagement_id=$1 ORDER BY created_at`, engagementID.String())
 	if err != nil {
 		return nil, fmt.Errorf("list agent sessions: %w", err)
 	}
@@ -91,10 +81,7 @@ func (s *AgentSessionStore) ListResumable(ctx context.Context, staleFor time.Dur
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := s.pool.Query(ctx,
-		`SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
-		 FROM agent_sessions WHERE status IN ('running','awaiting_approval') AND updated_at < $1
-		 ORDER BY updated_at LIMIT $2`, now.Add(-staleFor), limit)
+	rows, err := s.pool.Query(ctx, `SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at FROM agent_sessions WHERE status IN ('running','awaiting_approval') AND updated_at < $1 ORDER BY updated_at LIMIT $2`, now.Add(-staleFor), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list resumable sessions: %w", err)
 	}

--- a/internal/infrastructure/persistence/postgres/agent_session_store.go
+++ b/internal/infrastructure/persistence/postgres/agent_session_store.go
@@ -77,26 +77,54 @@ func (s *AgentSessionStore) ListByEngagement(ctx context.Context, engagementID s
 	return out, rows.Err()
 }
 
+// TenantIDs reads the tenant registry, not tenant-owned session rows; the worker
+// uses each returned ID to open a separately bound RLS transaction.
+func (s *AgentSessionStore) TenantIDs(ctx context.Context) ([]shared.ID, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id FROM tenants ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list agent session tenants: %w", err)
+	}
+	defer rows.Close()
+	var out []shared.ID
+	for rows.Next() {
+		var tenantID string
+		if err := rows.Scan(&tenantID); err != nil {
+			return nil, fmt.Errorf("scan agent session tenant: %w", err)
+		}
+		out = append(out, shared.ID(tenantID))
+	}
+	return out, rows.Err()
+}
+
 func (s *AgentSessionStore) ListResumable(ctx context.Context, staleFor time.Duration, now time.Time, limit int) ([]agent.Session, error) {
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := s.pool.Query(ctx, `SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at FROM agent_sessions WHERE status IN ('running','awaiting_approval') AND updated_at < $1 ORDER BY updated_at LIMIT $2`, now.Add(-staleFor), limit)
-	if err != nil {
-		return nil, fmt.Errorf("list resumable sessions: %w", err)
-	}
-	defer rows.Close()
 	var out []agent.Session
-	for rows.Next() {
-		var e agent.Session
-		var status string
-		if err := rows.Scan(&e.ID, &e.TenantID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt); err != nil {
-			return nil, fmt.Errorf("scan resumable session: %w", err)
+	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			`SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at
+			 FROM agent_sessions WHERE status IN ('running','awaiting_approval') AND updated_at < $1
+			 ORDER BY updated_at LIMIT $2`, now.Add(-staleFor), limit)
+		if err != nil {
+			return fmt.Errorf("list resumable sessions: %w", err)
 		}
-		e.Status = agent.Status(status)
-		out = append(out, e)
+		defer rows.Close()
+		for rows.Next() {
+			var e agent.Session
+			var status string
+			if err := rows.Scan(&e.ID, &e.TenantID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt); err != nil {
+				return fmt.Errorf("scan resumable session: %w", err)
+			}
+			e.Status = agent.Status(status)
+			out = append(out, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 func (s *AgentSessionStore) AppendMessage(ctx context.Context, sessionID shared.ID, seq int, m agent.Message) error {

--- a/internal/infrastructure/persistence/postgres/agent_session_store.go
+++ b/internal/infrastructure/persistence/postgres/agent_session_store.go
@@ -104,36 +104,45 @@ func (s *AgentSessionStore) AppendMessage(ctx context.Context, sessionID shared.
 	if len(m.ToolCalls) > 0 {
 		toolCalls, _ = json.Marshal(m.ToolCalls)
 	}
-	_, err := s.pool.Exec(ctx, `INSERT INTO agent_messages (session_id, seq, role, content, tool_calls, tool_call_id) VALUES ($1,$2,$3,$4,$5,$6)`, sessionID.String(), seq, string(m.Role), m.Content, toolCalls, m.ToolCallID)
-	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			return fmt.Errorf("agent message (%s, seq %d) already exists: %w", sessionID, seq, shared.ErrConflict)
+	return WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		tenantID, _ := shared.TenantFrom(ctx)
+		_, err := tx.Exec(ctx, `INSERT INTO agent_messages (tenant_id, session_id, seq, role, content, tool_calls, tool_call_id) VALUES ($1,$2,$3,$4,$5,$6,$7)`, tenantID.String(), sessionID.String(), seq, string(m.Role), m.Content, toolCalls, m.ToolCallID)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return fmt.Errorf("agent message (%s, seq %d) already exists: %w", sessionID, seq, shared.ErrConflict)
+			}
+			return fmt.Errorf("append agent message: %w", err)
 		}
-		return fmt.Errorf("append agent message: %w", err)
-	}
-	return nil
+		return nil
+	})
 }
 
 func (s *AgentSessionStore) Messages(ctx context.Context, sessionID shared.ID) ([]agent.Message, error) {
-	rows, err := s.pool.Query(ctx, `SELECT role, content, tool_calls, tool_call_id FROM agent_messages WHERE session_id=$1 ORDER BY seq`, sessionID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list agent messages: %w", err)
-	}
-	defer rows.Close()
 	var out []agent.Message
-	for rows.Next() {
-		var m agent.Message
-		var role string
-		var toolCalls []byte
-		if err := rows.Scan(&role, &m.Content, &toolCalls, &m.ToolCallID); err != nil {
-			return nil, fmt.Errorf("scan agent message: %w", err)
+	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT role, content, tool_calls, tool_call_id FROM agent_messages WHERE session_id=$1 ORDER BY seq`, sessionID.String())
+		if err != nil {
+			return fmt.Errorf("list agent messages: %w", err)
 		}
-		m.Role = agent.Role(role)
-		if len(toolCalls) > 0 {
-			_ = json.Unmarshal(toolCalls, &m.ToolCalls)
+		defer rows.Close()
+		for rows.Next() {
+			var m agent.Message
+			var role string
+			var toolCalls []byte
+			if err := rows.Scan(&role, &m.Content, &toolCalls, &m.ToolCallID); err != nil {
+				return fmt.Errorf("scan agent message: %w", err)
+			}
+			m.Role = agent.Role(role)
+			if len(toolCalls) > 0 {
+				_ = json.Unmarshal(toolCalls, &m.ToolCalls)
+			}
+			out = append(out, m)
 		}
-		out = append(out, m)
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }

--- a/internal/infrastructure/persistence/postgres/agent_session_store.go
+++ b/internal/infrastructure/persistence/postgres/agent_session_store.go
@@ -59,22 +59,28 @@ func (s *AgentSessionStore) GetSession(ctx context.Context, id shared.ID) (agent
 }
 
 func (s *AgentSessionStore) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]agent.Session, error) {
-	rows, err := s.pool.Query(ctx, `SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at FROM agent_sessions WHERE engagement_id=$1 ORDER BY created_at`, engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list agent sessions: %w", err)
-	}
-	defer rows.Close()
 	var out []agent.Session
-	for rows.Next() {
-		var e agent.Session
-		var status string
-		if err := rows.Scan(&e.ID, &e.TenantID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt); err != nil {
-			return nil, fmt.Errorf("scan agent session: %w", err)
+	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id, tenant_id, engagement_id, initiated_by, goal, model, provider_base, prompt_hash, status, steps, tokens_used, token_budget_max, created_at, updated_at FROM agent_sessions WHERE engagement_id=$1 ORDER BY created_at`, engagementID.String())
+		if err != nil {
+			return fmt.Errorf("list agent sessions: %w", err)
 		}
-		e.Status = agent.Status(status)
-		out = append(out, e)
+		defer rows.Close()
+		for rows.Next() {
+			var e agent.Session
+			var status string
+			if err := rows.Scan(&e.ID, &e.TenantID, &e.EngagementID, &e.InitiatedBy, &e.Goal, &e.Model, &e.ProviderBase, &e.PromptHash, &status, &e.Steps, &e.TokensUsed, &e.TokenBudgetMax, &e.CreatedAt, &e.UpdatedAt); err != nil {
+				return fmt.Errorf("scan agent session: %w", err)
+			}
+			e.Status = agent.Status(status)
+			out = append(out, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 // TenantIDs reads the tenant registry, not tenant-owned session rows; the worker

--- a/internal/infrastructure/persistence/postgres/approval_store.go
+++ b/internal/infrastructure/persistence/postgres/approval_store.go
@@ -49,6 +49,24 @@ func (s *ApprovalStore) Enqueue(ctx context.Context, a agent.ProposedAction) err
 	})
 }
 
+// TenantIDs reads registry identities for tenant-by-tenant timeout sweeping.
+func (s *ApprovalStore) TenantIDs(ctx context.Context) ([]shared.ID, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id FROM tenants ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list approval tenants: %w", err)
+	}
+	defer rows.Close()
+	var out []shared.ID
+	for rows.Next() {
+		var tenant string
+		if err := rows.Scan(&tenant); err != nil {
+			return nil, fmt.Errorf("scan approval tenant: %w", err)
+		}
+		out = append(out, shared.ID(tenant))
+	}
+	return out, rows.Err()
+}
+
 func (s *ApprovalStore) Pending(ctx context.Context, engagementID shared.ID) ([]agent.ProposedAction, error) {
 	var out []agent.ProposedAction
 	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
@@ -73,25 +91,28 @@ func (s *ApprovalStore) Pending(ctx context.Context, engagementID shared.ID) ([]
 	}
 	return out, nil
 }
-
 func (s *ApprovalStore) EngagementsWithPending(ctx context.Context) ([]shared.ID, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT DISTINCT engagement_id FROM agent_approvals WHERE decision_state='pending' ORDER BY engagement_id`)
-	if err != nil {
-		return nil, fmt.Errorf("list engagements with pending approvals: %w", err)
-	}
-	defer rows.Close()
 	var out []shared.ID
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("scan engagement id: %w", err)
+	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT DISTINCT engagement_id FROM agent_approvals WHERE decision_state='pending' ORDER BY engagement_id`)
+		if err != nil {
+			return fmt.Errorf("list engagements with pending approvals: %w", err)
 		}
-		out = append(out, shared.ID(id))
+		defer rows.Close()
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return fmt.Errorf("scan engagement id: %w", err)
+			}
+			out = append(out, shared.ID(id))
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }
-
 func (s *ApprovalStore) Get(ctx context.Context, actionID shared.ID) (agent.ProposedAction, agent.ApprovalDecision, error) {
 	var a agent.ProposedAction
 	d := agent.ApprovalDecision{ActionID: actionID}

--- a/internal/infrastructure/persistence/postgres/approval_store.go
+++ b/internal/infrastructure/persistence/postgres/approval_store.go
@@ -93,50 +93,58 @@ func (s *ApprovalStore) EngagementsWithPending(ctx context.Context) ([]shared.ID
 }
 
 func (s *ApprovalStore) Get(ctx context.Context, actionID shared.ID) (agent.ProposedAction, agent.ApprovalDecision, error) {
-	row := s.pool.QueryRow(ctx,
-		`SELECT action_id, session_id, engagement_id, tool, action, target_kind, target_value, argv, egress_preview, risk, rationale, proposed_at,
-		        decision_state, decided_by, decision_reason, COALESCE(decided_at, to_timestamp(0))
-		 FROM agent_approvals WHERE action_id=$1`, actionID.String())
-	var (
-		a                       agent.ProposedAction
-		tkind, tval             string
-		argv, egress            []byte
-		risk, state, by, reason string
-	)
+	var a agent.ProposedAction
 	d := agent.ApprovalDecision{ActionID: actionID}
-	err := row.Scan(&a.ID, &a.SessionID, &a.EngagementID, &a.Tool, &a.Action, &tkind, &tval, &argv, &egress, &risk, &a.Rationale, &a.ProposedAt,
-		&state, &by, &reason, &d.DecidedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return agent.ProposedAction{}, agent.ApprovalDecision{}, fmt.Errorf("approval %s: %w", actionID, shared.ErrNotFound)
-	}
+	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		var tkind, tval string
+		var argv, egress []byte
+		var risk, state, by, reason string
+		err := tx.QueryRow(ctx,
+			`SELECT action_id, session_id, engagement_id, tool, action, target_kind, target_value, argv, egress_preview, risk, rationale, proposed_at,
+			        decision_state, decided_by, decision_reason, COALESCE(decided_at, to_timestamp(0))
+			 FROM agent_approvals WHERE action_id=$1`, actionID.String()).
+			Scan(&a.ID, &a.SessionID, &a.EngagementID, &a.Tool, &a.Action, &tkind, &tval, &argv, &egress, &risk, &a.Rationale, &a.ProposedAt,
+				&state, &by, &reason, &d.DecidedAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("approval %s: %w", actionID, shared.ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("get approval: %w", err)
+		}
+		a.Target = engagement.Target{Kind: engagement.TargetKind(tkind), Value: tval}
+		a.Risk = agent.RiskClass(risk)
+		_ = json.Unmarshal(argv, &a.Argv)
+		_ = json.Unmarshal(egress, &a.EgressPreview)
+		d.State, d.DecidedBy, d.Reason = agent.ApprovalState(state), by, reason
+		return nil
+	})
 	if err != nil {
-		return agent.ProposedAction{}, agent.ApprovalDecision{}, fmt.Errorf("get approval: %w", err)
+		return agent.ProposedAction{}, agent.ApprovalDecision{}, err
 	}
-	a.Target = engagement.Target{Kind: engagement.TargetKind(tkind), Value: tval}
-	a.Risk = agent.RiskClass(risk)
-	_ = json.Unmarshal(argv, &a.Argv)
-	_ = json.Unmarshal(egress, &a.EgressPreview)
-	d.State, d.DecidedBy, d.Reason = agent.ApprovalState(state), by, reason
 	return a, d, nil
 }
 
 func (s *ApprovalStore) Decide(ctx context.Context, d agent.ApprovalDecision) error {
-	tag, err := s.pool.Exec(ctx,
-		`UPDATE agent_approvals SET decision_state=$2, decided_by=$3, decision_reason=$4, decided_at=$5
-		 WHERE action_id=$1 AND decision_state='pending'`,
-		d.ActionID.String(), string(d.State), d.DecidedBy, d.Reason, d.DecidedAt)
-	if err != nil {
-		return fmt.Errorf("decide approval: %w", err)
-	}
-	if tag.RowsAffected() == 0 {
-		// Either it does not exist, or it was already decided (the guarded WHERE missed).
+	return WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE agent_approvals SET decision_state=$2, decided_by=$3, decision_reason=$4, decided_at=$5
+			 WHERE action_id=$1 AND decision_state='pending'`,
+			d.ActionID.String(), string(d.State), d.DecidedBy, d.Reason, d.DecidedAt)
+		if err != nil {
+			return fmt.Errorf("decide approval: %w", err)
+		}
+		if tag.RowsAffected() != 0 {
+			return nil
+		}
 		var exists bool
-		if e := s.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM agent_approvals WHERE action_id=$1)`, d.ActionID.String()).Scan(&exists); e == nil && exists {
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM agent_approvals WHERE action_id=$1)`, d.ActionID.String()).Scan(&exists); err != nil {
+			return fmt.Errorf("check approval: %w", err)
+		}
+		if exists {
 			return fmt.Errorf("approval %s already decided: %w", d.ActionID, shared.ErrConflict)
 		}
 		return fmt.Errorf("approval %s: %w", d.ActionID, shared.ErrNotFound)
-	}
-	return nil
+	})
 }
 
 func scanProposed(rows pgx.Rows) (agent.ProposedAction, error) {

--- a/internal/infrastructure/persistence/postgres/approval_store.go
+++ b/internal/infrastructure/persistence/postgres/approval_store.go
@@ -50,22 +50,28 @@ func (s *ApprovalStore) Enqueue(ctx context.Context, a agent.ProposedAction) err
 }
 
 func (s *ApprovalStore) Pending(ctx context.Context, engagementID shared.ID) ([]agent.ProposedAction, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT action_id, session_id, engagement_id, tool, action, target_kind, target_value, argv, egress_preview, risk, rationale, proposed_at
-		 FROM agent_approvals WHERE engagement_id=$1 AND decision_state='pending' ORDER BY proposed_at`, engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list pending approvals: %w", err)
-	}
-	defer rows.Close()
 	var out []agent.ProposedAction
-	for rows.Next() {
-		a, err := scanProposed(rows)
+	err := WithContextTenantTx(ctx, s.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			`SELECT action_id, session_id, engagement_id, tool, action, target_kind, target_value, argv, egress_preview, risk, rationale, proposed_at
+			 FROM agent_approvals WHERE engagement_id=$1 AND decision_state='pending' ORDER BY proposed_at`, engagementID.String())
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("list pending approvals: %w", err)
 		}
-		out = append(out, a)
+		defer rows.Close()
+		for rows.Next() {
+			a, err := scanProposed(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, a)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 func (s *ApprovalStore) EngagementsWithPending(ctx context.Context) ([]shared.ID, error) {

--- a/internal/infrastructure/persistence/postgres/approval_store.go
+++ b/internal/infrastructure/persistence/postgres/approval_store.go
@@ -30,17 +30,23 @@ var _ ports.ApprovalStore = (*ApprovalStore)(nil)
 func (s *ApprovalStore) Enqueue(ctx context.Context, a agent.ProposedAction) error {
 	argv, _ := json.Marshal(a.Argv)
 	egress, _ := json.Marshal(a.EgressPreview)
-	_, err := s.pool.Exec(ctx,
-		`INSERT INTO agent_approvals
-		   (action_id, session_id, engagement_id, tool, action, target_kind, target_value, argv, egress_preview, risk, rationale, proposed_at, decision_state)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'pending')
-		 ON CONFLICT (action_id) DO NOTHING`, // idempotent re-enqueue on resume
-		a.ID.String(), a.SessionID.String(), a.EngagementID.String(), a.Tool, a.Action,
-		string(a.Target.Kind), a.Target.Value, argv, egress, string(a.Risk), a.Rationale, a.ProposedAt)
-	if err != nil {
-		return fmt.Errorf("enqueue approval: %w", err)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("enqueue approval: %w", shared.ErrValidation)
 	}
-	return nil
+	return WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO agent_approvals
+			   (action_id, tenant_id, session_id, engagement_id, tool, action, target_kind, target_value, argv, egress_preview, risk, rationale, proposed_at, decision_state)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,'pending')
+			 ON CONFLICT (action_id) DO NOTHING`,
+			a.ID.String(), tenantID.String(), a.SessionID.String(), a.EngagementID.String(), a.Tool, a.Action,
+			string(a.Target.Kind), a.Target.Value, argv, egress, string(a.Risk), a.Rationale, a.ProposedAt)
+		if err != nil {
+			return fmt.Errorf("enqueue approval: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *ApprovalStore) Pending(ctx context.Context, engagementID shared.ID) ([]agent.ProposedAction, error) {

--- a/internal/infrastructure/persistence/postgres/assessment.go
+++ b/internal/infrastructure/persistence/postgres/assessment.go
@@ -1,0 +1,116 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentRepository(pool *pgxpool.Pool) *AssessmentRepository {
+	return &AssessmentRepository{pool: pool}
+}
+
+var _ ports.AssessmentRepository = (*AssessmentRepository)(nil)
+
+func (r *AssessmentRepository) Create(ctx context.Context, a assessment.Assessment, children []*engagement.Engagement) error {
+	if err := a.Validate(); err != nil {
+		return err
+	}
+	if len(children) == 0 {
+		return fmt.Errorf("%w: assessment requires engagement", shared.ErrValidation)
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok || tenantID != a.TenantID {
+		return fmt.Errorf("%w: assessment tenant context", shared.ErrValidation)
+	}
+	roes := make([][]byte, len(children))
+	seen := make(map[shared.ID]struct{}, len(children))
+	for i, e := range children {
+		if e == nil || e.ID.IsZero() || e.TenantID != a.TenantID || e.AssessmentID != a.ID {
+			return fmt.Errorf("%w: invalid assessment engagement", shared.ErrValidation)
+		}
+		if _, duplicate := seen[e.ID]; duplicate {
+			return fmt.Errorf("assessment engagement: %w", shared.ErrConflict)
+		}
+		roe, err := json.Marshal(e.RoE)
+		if err != nil {
+			return err
+		}
+		seen[e.ID], roes[i] = struct{}{}, roe
+	}
+	policy, err := json.Marshal(a.Policy)
+	if err != nil {
+		return err
+	}
+	return WithTenantTx(ctx, r.pool, a.TenantID, func(tx pgx.Tx) error {
+		var one int
+		if err := tx.QueryRow(ctx, `SELECT 1 FROM appsec_business_services WHERE id=$1`, a.BusinessServiceID).Scan(&one); errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("business service %s: %w", a.BusinessServiceID, shared.ErrNotFound)
+		} else if err != nil {
+			return fmt.Errorf("read assessment business service: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO assessments (id,tenant_id,business_service_id,name,objective,status,policy,created_at,updated_at,created_by,updated_by) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, a.ID, a.TenantID, a.BusinessServiceID, a.Name, a.Objective, a.Status, policy, a.Audit.CreatedAt, a.Audit.UpdatedAt, a.Audit.CreatedBy, a.Audit.UpdatedBy); err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return fmt.Errorf("assessment name: %w", shared.ErrConflict)
+			}
+			return fmt.Errorf("create assessment: %w", err)
+		}
+		for i, e := range children {
+			if _, err := tx.Exec(ctx, `INSERT INTO engagements (id,tenant_id,assessment_id,project_id,name,client,status,authorized_from,authorized_to,created_at,updated_at,timezone,roe,live_recon,created_by,updated_by) VALUES ($1,$2,$3,NULLIF($4,''),$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`, e.ID, e.TenantID, a.ID, e.ProjectID, e.Name, e.Client, e.Status, e.AuthorizedFrom, e.AuthorizedTo, e.Audit.CreatedAt, e.Audit.UpdatedAt, e.Timezone, roes[i], e.LiveReconEnabled, e.Audit.CreatedBy, e.Audit.UpdatedBy); err != nil {
+				return fmt.Errorf("create assessment engagement: %w", err)
+			}
+		}
+		return nil
+	})
+}
+func (r *AssessmentRepository) Get(ctx context.Context, id shared.ID) (assessment.Assessment, error) {
+	var a assessment.Assessment
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		var policy []byte
+		err := tx.QueryRow(ctx, `SELECT id,tenant_id,business_service_id,name,objective,status,policy,created_at,updated_at,created_by,updated_by FROM assessments WHERE id=$1`, id).Scan(&a.ID, &a.TenantID, &a.BusinessServiceID, &a.Name, &a.Objective, &a.Status, &policy, &a.Audit.CreatedAt, &a.Audit.UpdatedAt, &a.Audit.CreatedBy, &a.Audit.UpdatedBy)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("assessment: %w", shared.ErrNotFound)
+		}
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(policy, &a.Policy)
+	})
+	return a, err
+}
+func (r *AssessmentRepository) ListByBusinessService(ctx context.Context, serviceID shared.ID) ([]assessment.Assessment, error) {
+	out := []assessment.Assessment{}
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id,tenant_id,business_service_id,name,objective,status,policy,created_at,updated_at,created_by,updated_by FROM assessments WHERE business_service_id=$1 ORDER BY created_at DESC,id`, serviceID)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var a assessment.Assessment
+			var policy []byte
+			if err := rows.Scan(&a.ID, &a.TenantID, &a.BusinessServiceID, &a.Name, &a.Objective, &a.Status, &policy, &a.Audit.CreatedAt, &a.Audit.UpdatedAt, &a.Audit.CreatedBy, &a.Audit.UpdatedBy); err != nil {
+				return err
+			}
+			if err := json.Unmarshal(policy, &a.Policy); err != nil {
+				return err
+			}
+			out = append(out, a)
+		}
+		return rows.Err()
+	})
+	return out, err
+}

--- a/internal/infrastructure/persistence/postgres/assessment_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_test.go
@@ -1,0 +1,51 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAssessmentRepositoryCreatesHierarchyAtomically(t *testing.T) {
+	dsn := testDSN(t)
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	suffix := fmt.Sprintf("assessment-%d", time.Now().UnixNano())
+	tenant := shared.ID(suffix + "-tenant")
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id,name) VALUES ($1,$1) ON CONFLICT (id) DO NOTHING`, tenant); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO appsec_business_services (id,tenant_id,name,description,criticality,lifecycle,created_at,updated_at) VALUES ($1,$2,'Assessment service','','high','active',now(),now())`, suffix+"-service", tenant); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	a, err := assessment.New(shared.ID(suffix+"-assessment"), tenant, shared.ID(suffix+"-service"), "Release", "", assessment.Policy{}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, err := engagement.New(shared.ID(suffix+"-engagement"), tenant, "Release execution", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.AssessmentID = a.ID
+	repo := NewAssessmentRepository(pool)
+	if err := repo.Create(shared.WithTenant(ctx, tenant), a, []*engagement.Engagement{e}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := repo.Get(shared.WithTenant(ctx, tenant), a.ID)
+	if err != nil || got.ID != a.ID {
+		t.Fatalf("get=%+v err=%v", got, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/asset_inventory.go
+++ b/internal/infrastructure/persistence/postgres/asset_inventory.go
@@ -1,0 +1,383 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssetInventoryRepository struct{ pool *pgxpool.Pool }
+
+func NewAssetInventoryRepository(pool *pgxpool.Pool) *AssetInventoryRepository {
+	return &AssetInventoryRepository{pool: pool}
+}
+
+var _ ports.AssetInventoryRepository = (*AssetInventoryRepository)(nil)
+
+const assetColumns = `id, tenant_id, name, category, identity_kind, identity_value, lifecycle, criticality, exposure, classification, version, created_at, updated_at, created_by, updated_by`
+
+func requireInventoryTenant(ctx context.Context, tenantID shared.ID) error {
+	currentTenant, ok := shared.TenantFrom(ctx)
+	if !ok || currentTenant != tenantID {
+		return fmt.Errorf("%w: tenant-scoped inventory command", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (r *AssetInventoryRepository) CreateAsset(ctx context.Context, a asset.Asset) error {
+	if err := a.Validate(); err != nil {
+		return err
+	}
+	if err := requireInventoryTenant(ctx, a.TenantID); err != nil {
+		return err
+	}
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO appsec_assets (`+assetColumns+`) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`, a.ID, a.TenantID, a.Name, a.Category, a.Identity.Kind, a.Identity.Value, a.Lifecycle, a.Criticality, a.Exposure, a.Classification, a.Version, a.Audit.CreatedAt, a.Audit.UpdatedAt, a.Audit.CreatedBy, a.Audit.UpdatedBy)
+		if err != nil {
+			return fmt.Errorf("create asset: %w", err)
+		}
+		return nil
+	})
+}
+func (r *AssetInventoryRepository) GetAsset(ctx context.Context, id shared.ID) (asset.Asset, error) {
+	var a asset.Asset
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		return scanAsset(tx.QueryRow(ctx, `SELECT `+assetColumns+` FROM appsec_assets WHERE id=$1`, id), &a)
+	})
+	return a, err
+}
+func (r *AssetInventoryRepository) ListAssets(ctx context.Context) ([]asset.Asset, error) {
+	out := []asset.Asset{}
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+assetColumns+` FROM appsec_assets ORDER BY name,id`)
+		if err != nil {
+			return fmt.Errorf("list assets: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var a asset.Asset
+			if err := scanAsset(rows, &a); err != nil {
+				return err
+			}
+			out = append(out, a)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+func (r *AssetInventoryRepository) UpdateAsset(ctx context.Context, a asset.Asset, v asset.Version) error {
+	if err := a.Validate(); err != nil {
+		return err
+	}
+	if err := v.Validate(); err != nil {
+		return err
+	}
+	if err := requireInventoryTenant(ctx, a.TenantID); err != nil {
+		return err
+	}
+	if v.TenantID != a.TenantID {
+		return fmt.Errorf("%w: asset version tenant mismatch", shared.ErrValidation)
+	}
+	snapshot := v.Snapshot
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE appsec_assets SET name=$2,lifecycle=$3,criticality=$4,exposure=$5,classification=$6,version=$7,updated_at=$8,updated_by=$9 WHERE id=$1 AND version=$10`, a.ID, a.Name, a.Lifecycle, a.Criticality, a.Exposure, a.Classification, a.Version, a.Audit.UpdatedAt, a.Audit.UpdatedBy, a.Version-1)
+		if err != nil {
+			return fmt.Errorf("update asset: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("asset %s: %w", a.ID, shared.ErrConflict)
+		}
+		_, err = tx.Exec(ctx, `INSERT INTO appsec_asset_versions (id,asset_id,tenant_id,number,snapshot,created_at,created_by) VALUES ($1,$2,$3,$4,$5,$6,$7)`, v.ID, v.AssetID, v.TenantID, v.Number, snapshot, v.CreatedAt, v.CreatedBy)
+		if err != nil {
+			return fmt.Errorf("create asset version: %w", err)
+		}
+		return nil
+	})
+}
+func (r *AssetInventoryRepository) ListAssetVersions(ctx context.Context, id shared.ID) ([]asset.Version, error) {
+	out := []asset.Version{}
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id,tenant_id,asset_id,number,snapshot,created_at,created_by FROM appsec_asset_versions WHERE asset_id=$1 ORDER BY number`, id)
+		if err != nil {
+			return fmt.Errorf("list asset versions: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var v asset.Version
+			var raw []byte
+			if err := rows.Scan(&v.ID, &v.TenantID, &v.AssetID, &v.Number, &raw, &v.CreatedAt, &v.CreatedBy); err != nil {
+				return err
+			}
+			if !json.Valid(raw) {
+				return fmt.Errorf("invalid stored asset version snapshot")
+			}
+			v.Snapshot = append(v.Snapshot[:0], raw...)
+			out = append(out, v)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+func (r *AssetInventoryRepository) CreateBusinessService(ctx context.Context, s asset.BusinessService) error {
+	if err := s.Validate(); err != nil {
+		return err
+	}
+	if err := requireInventoryTenant(ctx, s.TenantID); err != nil {
+		return err
+	}
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO appsec_business_services (id,tenant_id,name,description,criticality,lifecycle,created_at,updated_at,created_by,updated_by) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, s.ID, s.TenantID, s.Name, s.Description, s.Criticality, s.Lifecycle, s.Audit.CreatedAt, s.Audit.UpdatedAt, s.Audit.CreatedBy, s.Audit.UpdatedBy)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return fmt.Errorf("business service name: %w", shared.ErrConflict)
+			}
+			return fmt.Errorf("create business service: %w", err)
+		}
+		return nil
+	})
+}
+func (r *AssetInventoryRepository) GetBusinessService(ctx context.Context, id shared.ID) (asset.BusinessService, error) {
+	var s asset.BusinessService
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		return scanBusinessService(tx.QueryRow(ctx, `SELECT id,tenant_id,name,description,criticality,lifecycle,created_at,updated_at,created_by,updated_by FROM appsec_business_services WHERE id=$1`, id), &s)
+	})
+	return s, err
+}
+func (r *AssetInventoryRepository) ListBusinessServices(ctx context.Context) ([]asset.BusinessService, error) {
+	out := []asset.BusinessService{}
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id,tenant_id,name,description,criticality,lifecycle,created_at,updated_at,created_by,updated_by FROM appsec_business_services ORDER BY name,id`)
+		if err != nil {
+			return fmt.Errorf("list business services: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var s asset.BusinessService
+			if err := scanBusinessService(rows, &s); err != nil {
+				return err
+			}
+			out = append(out, s)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+func (r *AssetInventoryRepository) UpdateBusinessService(ctx context.Context, s asset.BusinessService) error {
+	if err := s.Validate(); err != nil {
+		return err
+	}
+	if err := requireInventoryTenant(ctx, s.TenantID); err != nil {
+		return err
+	}
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE appsec_business_services SET name=$2,description=$3,criticality=$4,lifecycle=$5,updated_at=$6,updated_by=$7 WHERE id=$1`, s.ID, s.Name, s.Description, s.Criticality, s.Lifecycle, s.Audit.UpdatedAt, s.Audit.UpdatedBy)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return fmt.Errorf("business service name: %w", shared.ErrConflict)
+			}
+			return fmt.Errorf("update business service: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("business service %s: %w", s.ID, shared.ErrNotFound)
+		}
+		return nil
+	})
+}
+func (r *AssetInventoryRepository) LinkBusinessServiceAsset(ctx context.Context, l asset.BusinessServiceAssetLink) error {
+	if err := l.Validate(); err != nil {
+		return err
+	}
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		var one int
+		if err := tx.QueryRow(ctx, `SELECT 1 FROM appsec_business_services WHERE id=$1`, l.BusinessServiceID).Scan(&one); errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("business service %s: %w", l.BusinessServiceID, shared.ErrNotFound)
+		} else if err != nil {
+			return fmt.Errorf("read business service for asset link: %w", err)
+		}
+		if err := tx.QueryRow(ctx, `SELECT 1 FROM appsec_assets WHERE id=$1`, l.AssetID).Scan(&one); errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("asset %s: %w", l.AssetID, shared.ErrNotFound)
+		} else if err != nil {
+			return fmt.Errorf("read asset for business service link: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO appsec_business_service_assets (business_service_id,asset_id,role,created_at,created_by) VALUES ($1,$2,$3,$4,$5)`, l.BusinessServiceID, l.AssetID, l.Role, l.CreatedAt, l.CreatedBy); err != nil {
+			return fmt.Errorf("link business service asset: %w", err)
+		}
+		return nil
+	})
+}
+func (r *AssetInventoryRepository) ListBusinessServiceAssets(ctx context.Context, id shared.ID) ([]asset.BusinessServiceAssetLink, error) {
+	out := []asset.BusinessServiceAssetLink{}
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT business_service_id,asset_id,role,created_at,created_by FROM appsec_business_service_assets WHERE business_service_id=$1 ORDER BY asset_id`, id)
+		if err != nil {
+			return fmt.Errorf("list service assets: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var l asset.BusinessServiceAssetLink
+			if err := rows.Scan(&l.BusinessServiceID, &l.AssetID, &l.Role, &l.CreatedAt, &l.CreatedBy); err != nil {
+				return err
+			}
+			out = append(out, l)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+func (r *AssetInventoryRepository) CreateRelationship(ctx context.Context, rel asset.Relationship) error {
+	if err := rel.Validate(); err != nil {
+		return err
+	}
+	if err := requireInventoryTenant(ctx, rel.TenantID); err != nil {
+		return err
+	}
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		if rel.Type == asset.RelationshipContains || rel.Type == asset.RelationshipPartOf {
+			var cycle bool
+			if err := tx.QueryRow(ctx, `WITH RECURSIVE reachable(id) AS (
+				SELECT $1::TEXT
+				UNION
+				SELECT relationship.to_asset_id
+				FROM appsec_asset_relationships relationship
+				JOIN reachable ON relationship.from_asset_id = reachable.id
+				WHERE relationship.relation_type IN ('contains', 'part_of')
+			) SELECT EXISTS (SELECT 1 FROM reachable WHERE id = $2)`, rel.ToAssetID, rel.FromAssetID).Scan(&cycle); err != nil {
+				return fmt.Errorf("check asset relationship cycle: %w", err)
+			}
+			if cycle {
+				return fmt.Errorf("%w: asset relationship cycle", shared.ErrValidation)
+			}
+		}
+		_, err := tx.Exec(ctx, `INSERT INTO appsec_asset_relationships (id,tenant_id,from_asset_id,to_asset_id,relation_type,created_at,created_by) VALUES ($1,$2,$3,$4,$5,$6,$7)`, rel.ID, rel.TenantID, rel.FromAssetID, rel.ToAssetID, rel.Type, rel.CreatedAt, rel.CreatedBy)
+		if err != nil {
+			return fmt.Errorf("create asset relationship: %w", err)
+		}
+		return nil
+	})
+}
+func (r *AssetInventoryRepository) ListRelationships(ctx context.Context, id shared.ID) ([]asset.Relationship, error) {
+	out := []asset.Relationship{}
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id,tenant_id,from_asset_id,to_asset_id,relation_type,created_at,created_by FROM appsec_asset_relationships WHERE from_asset_id=$1 ORDER BY created_at,id`, id)
+		if err != nil {
+			return fmt.Errorf("list asset relationships: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var rel asset.Relationship
+			if err := rows.Scan(&rel.ID, &rel.TenantID, &rel.FromAssetID, &rel.ToAssetID, &rel.Type, &rel.CreatedAt, &rel.CreatedBy); err != nil {
+				return err
+			}
+			out = append(out, rel)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+func (r *AssetInventoryRepository) AssignOwner(ctx context.Context, o asset.OwnershipAssignment) error {
+	if err := o.Validate(); err != nil {
+		return err
+	}
+	if err := requireInventoryTenant(ctx, o.TenantID); err != nil {
+		return err
+	}
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO appsec_asset_ownership_assignments (id,tenant_id,asset_id,principal,role,created_at,created_by) VALUES ($1,$2,$3,$4,$5,$6,$7)`, o.ID, o.TenantID, o.AssetID, o.Principal, o.Role, o.CreatedAt, o.CreatedBy)
+		if err != nil {
+			return fmt.Errorf("assign asset owner: %w", err)
+		}
+		return nil
+	})
+}
+func (r *AssetInventoryRepository) ListOwners(ctx context.Context, id shared.ID) ([]asset.OwnershipAssignment, error) {
+	out := []asset.OwnershipAssignment{}
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id,tenant_id,asset_id,principal,role,created_at,created_by FROM appsec_asset_ownership_assignments WHERE asset_id=$1 ORDER BY created_at,id`, id)
+		if err != nil {
+			return fmt.Errorf("list asset owners: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var o asset.OwnershipAssignment
+			if err := rows.Scan(&o.ID, &o.TenantID, &o.AssetID, &o.Principal, &o.Role, &o.CreatedAt, &o.CreatedBy); err != nil {
+				return err
+			}
+			out = append(out, o)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+type assetRow interface{ Scan(...any) error }
+
+func scanAsset(row assetRow, a *asset.Asset) error {
+	var cat, lifecycle, criticality, exposure string
+	err := row.Scan(&a.ID, &a.TenantID, &a.Name, &cat, &a.Identity.Kind, &a.Identity.Value, &lifecycle, &criticality, &exposure, &a.Classification, &a.Version, &a.Audit.CreatedAt, &a.Audit.UpdatedAt, &a.Audit.CreatedBy, &a.Audit.UpdatedBy)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("asset: %w", shared.ErrNotFound)
+	}
+	if err != nil {
+		return err
+	}
+	a.Category = asset.Category(cat)
+	a.Lifecycle = asset.Lifecycle(lifecycle)
+	a.Criticality = asset.Criticality(criticality)
+	a.Exposure = asset.Exposure(exposure)
+	return nil
+}
+func scanBusinessService(row assetRow, s *asset.BusinessService) error {
+	var criticality, lifecycle string
+	err := row.Scan(&s.ID, &s.TenantID, &s.Name, &s.Description, &criticality, &lifecycle, &s.Audit.CreatedAt, &s.Audit.UpdatedAt, &s.Audit.CreatedBy, &s.Audit.UpdatedBy)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("business service: %w", shared.ErrNotFound)
+	}
+	if err != nil {
+		return err
+	}
+	s.Criticality = asset.Criticality(criticality)
+	s.Lifecycle = asset.Lifecycle(lifecycle)
+	return nil
+}
+
+func (r *AssetInventoryRepository) DeleteAsset(ctx context.Context, id shared.ID) error {
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `DELETE FROM appsec_assets WHERE id=$1`, id)
+		if err != nil {
+			return fmt.Errorf("delete asset: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("asset %s: %w", id, shared.ErrNotFound)
+		}
+		return nil
+	})
+}
+
+func (r *AssetInventoryRepository) DeleteBusinessService(ctx context.Context, id shared.ID) error {
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `DELETE FROM appsec_business_services WHERE id=$1`, id)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+				return fmt.Errorf("business service assessments: %w", shared.ErrConflict)
+			}
+			return fmt.Errorf("delete business service: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("business service %s: %w", id, shared.ErrNotFound)
+		}
+		return nil
+	})
+}

--- a/internal/infrastructure/persistence/postgres/asset_inventory_test.go
+++ b/internal/infrastructure/persistence/postgres/asset_inventory_test.go
@@ -1,0 +1,83 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestAssetInventoryRLSIsolation(t *testing.T) {
+	dsn := testDSN(t)
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	admin, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(admin.Close)
+	if _, err := admin.Exec(ctx, `DELETE FROM assessments; DELETE FROM appsec_asset_ownership_assignments; DELETE FROM appsec_asset_relationships; DELETE FROM appsec_business_service_assets; DELETE FROM appsec_asset_versions; DELETE FROM appsec_business_services; DELETE FROM appsec_assets`); err != nil {
+		t.Fatal(err)
+	}
+	role := fmt.Sprintf("asset_runtime_%d", time.Now().UnixNano())
+	if _, err := admin.Exec(ctx, `CREATE ROLE `+role+` LOGIN PASSWORD 'asset-runtime-test'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec(ctx, `GRANT USAGE ON SCHEMA public TO `+role+`; GRANT SELECT, INSERT, UPDATE, DELETE ON appsec_assets, appsec_asset_versions, appsec_business_services, appsec_business_service_assets, appsec_asset_relationships, appsec_asset_ownership_assignments TO `+role); err != nil {
+		t.Fatal(err)
+	}
+	runtimeURL, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeURL.User = url.UserPassword(role, "asset-runtime-test")
+	runtime, err := Connect(ctx, runtimeURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { runtime.Close(); _, _ = admin.Exec(ctx, `DROP ROLE `+role) })
+	repo := NewAssetInventoryRepository(runtime)
+	now := time.Now().UTC()
+	ctxA := shared.WithTenant(ctx, "asset-tenant-a")
+	ctxB := shared.WithTenant(ctx, "asset-tenant-b")
+	for _, tenant := range []shared.ID{"asset-tenant-a", "asset-tenant-b"} {
+		if _, err := admin.Exec(ctx, `INSERT INTO tenants (id,name) VALUES ($1,$1) ON CONFLICT (id) DO NOTHING`, tenant); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a := mustPostgresAsset(t, "asset-a", "asset-tenant-a", now)
+	if err := repo.CreateAsset(ctxA, a); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.GetAsset(ctxB, a.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant get error=%v", err)
+	}
+	if list, err := repo.ListAssets(ctxB); err != nil || len(list) != 0 {
+		t.Fatalf("tenant B list=%+v err=%v", list, err)
+	}
+	service := asset.BusinessService{ID: "service-a", TenantID: "asset-tenant-a", Name: "Payments", Criticality: asset.CriticalityHigh, Lifecycle: asset.LifecycleActive, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}
+	if err := repo.CreateBusinessService(ctxA, service); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.LinkBusinessServiceAsset(ctxA, asset.BusinessServiceAssetLink{BusinessServiceID: service.ID, AssetID: a.ID, Role: asset.AssetLinkOwns, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.LinkBusinessServiceAsset(ctxB, asset.BusinessServiceAssetLink{BusinessServiceID: service.ID, AssetID: a.ID, Role: asset.AssetLinkUses, CreatedAt: now}); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant link error=%v", err)
+	}
+}
+
+func mustPostgresAsset(t *testing.T, id, tenant string, now time.Time) asset.Asset {
+	t.Helper()
+	a, err := asset.New(shared.ID(id), shared.ID(tenant), "Payments API", asset.CategoryAPI, asset.Identity{Kind: "url", Value: "https://payments.example.test"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
+}

--- a/internal/infrastructure/persistence/postgres/comment_repo.go
+++ b/internal/infrastructure/persistence/postgres/comment_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -23,37 +24,37 @@ var _ ports.CommentRepository = (*CommentRepository)(nil)
 
 // Add inserts a comment (append-only; comments are not edited or deleted in app code).
 func (r *CommentRepository) Add(ctx context.Context, c finding.Comment) error {
-	if _, err := r.pool.Exec(ctx,
-		`INSERT INTO finding_comments (id, tenant_id, engagement_id, finding_id, author, body, created_at)
-		 VALUES ($1, '', $2, $3, $4, $5, $6)`,
-		c.ID.String(), c.EngagementID.String(), c.FindingID.String(), c.Author, c.Body, c.CreatedAt); err != nil {
-		return fmt.Errorf("insert comment: %w", err)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("tenant context is required")
 	}
-	return nil
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO finding_comments (id, tenant_id, engagement_id, finding_id, author, body, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7)`, c.ID.String(), tenantID.String(), c.EngagementID.String(), c.FindingID.String(), c.Author, c.Body, c.CreatedAt); err != nil {
+			return fmt.Errorf("insert comment: %w", err)
+		}
+		return nil
+	})
 }
 
 // ListByEngagementFinding returns a finding's comments oldest-first, scoped to the
 // engagement (no cross-engagement read).
-func (r *CommentRepository) ListByEngagementFinding(ctx context.Context, engagementID, findingID shared.ID) ([]finding.Comment, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT id, engagement_id, finding_id, author, body, created_at
-		 FROM finding_comments WHERE finding_id=$1 AND engagement_id=$2 ORDER BY created_at ASC, id ASC`,
-		findingID.String(), engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list comments: %w", err)
-	}
-	defer rows.Close()
-	out := make([]finding.Comment, 0)
-	for rows.Next() {
-		var (
-			c            finding.Comment
-			id, eid, fid string
-		)
-		if err := rows.Scan(&id, &eid, &fid, &c.Author, &c.Body, &c.CreatedAt); err != nil {
-			return nil, fmt.Errorf("scan comment: %w", err)
+func (r *CommentRepository) ListByEngagementFinding(ctx context.Context, engagementID, findingID shared.ID) (out []finding.Comment, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id, engagement_id, finding_id, author, body, created_at FROM finding_comments WHERE finding_id=$1 AND engagement_id=$2 ORDER BY created_at ASC, id ASC`, findingID.String(), engagementID.String())
+		if err != nil {
+			return fmt.Errorf("list comments: %w", err)
 		}
-		c.ID, c.EngagementID, c.FindingID = shared.ID(id), shared.ID(eid), shared.ID(fid)
-		out = append(out, c)
-	}
-	return out, rows.Err()
+		defer rows.Close()
+		for rows.Next() {
+			var c finding.Comment
+			var id, eid, fid string
+			if err := rows.Scan(&id, &eid, &fid, &c.Author, &c.Body, &c.CreatedAt); err != nil {
+				return fmt.Errorf("scan comment: %w", err)
+			}
+			c.ID, c.EngagementID, c.FindingID = shared.ID(id), shared.ID(eid), shared.ID(fid)
+			out = append(out, c)
+		}
+		return rows.Err()
+	})
+	return out, err
 }

--- a/internal/infrastructure/persistence/postgres/db.go
+++ b/internal/infrastructure/persistence/postgres/db.go
@@ -87,6 +87,19 @@ func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	return ConnectPool(ctx, dsn, PoolConfig{})
 }
 
+// RequireNonSuperuser rejects a PostgreSQL superuser as the runtime role.
+// Superusers bypass RLS even when table owners are forced through policies.
+func RequireNonSuperuser(ctx context.Context, pool *pgxpool.Pool) error {
+	var isSuperuser bool
+	if err := pool.QueryRow(ctx, `SELECT rolsuper FROM pg_roles WHERE rolname = current_user`).Scan(&isSuperuser); err != nil {
+		return fmt.Errorf("check postgres application role: %w", err)
+	}
+	if isSuperuser {
+		return fmt.Errorf("postgres application role must not be a superuser when row-level security is enabled")
+	}
+	return nil
+}
+
 // singletonLockKey derives a stable advisory-lock key PER ROLE. Scoping by
 // role lets one synapse-api AND one synapse-worker run together (each a singleton in its
 // own role) while still refusing a second instance of the SAME role – the multi-process

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -30,46 +30,42 @@ var _ ports.EngagementRepository = (*EngagementRepository)(nil)
 
 // Create inserts the engagement and its scope targets in one transaction.
 func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagement) error {
-	tx, err := r.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	return WithTenantTx(ctx, r.pool, e.TenantID, func(tx pgx.Tx) error {
+		roeJSON, err := json.Marshal(e.RoE)
+		if err != nil {
+			return fmt.Errorf("marshal roe: %w", err)
+		}
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+			e.ID.String(), e.TenantID.String(), e.ProjectID.String(), e.Name, e.Client, string(e.Status),
+			e.AuthorizedFrom, e.AuthorizedTo, e.Audit.CreatedAt, e.Audit.UpdatedAt, e.Timezone, roeJSON, e.LiveReconEnabled,
+			e.Audit.CreatedBy, e.Audit.UpdatedBy); err != nil {
+			return fmt.Errorf("insert engagement: %w", err)
+		}
 
-	roeJSON, err := json.Marshal(e.RoE)
-	if err != nil {
-		return fmt.Errorf("marshal roe: %w", err)
-	}
-	if _, err := tx.Exec(ctx,
-		`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
-		e.ID.String(), e.TenantID.String(), e.ProjectID.String(), e.Name, e.Client, string(e.Status),
-		e.AuthorizedFrom, e.AuthorizedTo, e.Audit.CreatedAt, e.Audit.UpdatedAt, e.Timezone, roeJSON, e.LiveReconEnabled,
-		e.Audit.CreatedBy, e.Audit.UpdatedBy); err != nil {
-		return fmt.Errorf("insert engagement: %w", err)
-	}
-
-	// Insert-only path: deterministic scope_target PKs are fine here. A future
-	// "replace scope" path should switch to generated IDs (IDGenerator / gen_random_uuid).
-	i := 0
-	insert := func(targets []engagement.Target, inScope bool) error {
-		for _, t := range targets {
-			stID := e.ID.String() + "-st-" + strconv.Itoa(i)
-			i++
-			if _, err := tx.Exec(ctx,
-				`INSERT INTO scope_targets (id, engagement_id, in_scope, kind, value) VALUES ($1,$2,$3,$4,$5)`,
-				stID, e.ID.String(), inScope, string(t.Kind), t.Value); err != nil {
-				return fmt.Errorf("insert scope target: %w", err)
+		// Insert-only path: deterministic scope_target PKs are fine here. A future
+		// "replace scope" path should switch to generated IDs (IDGenerator / gen_random_uuid).
+		i := 0
+		insert := func(targets []engagement.Target, inScope bool) error {
+			for _, t := range targets {
+				stID := e.ID.String() + "-st-" + strconv.Itoa(i)
+				i++
+				if _, err := tx.Exec(ctx,
+					`INSERT INTO scope_targets (id, engagement_id, in_scope, kind, value) VALUES ($1,$2,$3,$4,$5)`,
+					stID, e.ID.String(), inScope, string(t.Kind), t.Value); err != nil {
+					return fmt.Errorf("insert scope target: %w", err)
+				}
 			}
+			return nil
+		}
+		if err := insert(e.Scope.InScope, true); err != nil {
+			return err
+		}
+		if err := insert(e.Scope.OutOfScope, false); err != nil {
+			return err
 		}
 		return nil
-	}
-	if err := insert(e.Scope.InScope, true); err != nil {
-		return err
-	}
-	if err := insert(e.Scope.OutOfScope, false); err != nil {
-		return err
-	}
-	return tx.Commit(ctx)
+	})
 }
 
 // Update persists an existing engagement aggregate: the engagement row and its
@@ -101,49 +97,46 @@ func (r *EngagementRepository) ProjectContexts(ctx context.Context, tenantID sha
 }
 
 func (r *EngagementRepository) Update(ctx context.Context, e *engagement.Engagement) error {
-	tx, err := r.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	return WithTenantTx(ctx, r.pool, e.TenantID, func(tx pgx.Tx) error {
 
-	roeJSON, err := json.Marshal(e.RoE)
-	if err != nil {
-		return fmt.Errorf("marshal roe: %w", err)
-	}
-	// created_by is intentionally NOT updated – the owner is immutable; only updated_by changes.
-	ct, err := tx.Exec(ctx,
-		`UPDATE engagements SET name=$2, client=$3, status=$4, authorized_from=$5, authorized_to=$6, timezone=$7, updated_at=$8, roe=$9, live_recon=$10, updated_by=$11 WHERE id=$1`,
-		e.ID.String(), e.Name, e.Client, string(e.Status),
-		e.AuthorizedFrom, e.AuthorizedTo, e.Timezone, e.Audit.UpdatedAt, roeJSON, e.LiveReconEnabled, e.Audit.UpdatedBy)
-	if err != nil {
-		return fmt.Errorf("update engagement: %w", err)
-	}
-	if ct.RowsAffected() == 0 {
-		return shared.ErrNotFound
-	}
+		roeJSON, err := json.Marshal(e.RoE)
+		if err != nil {
+			return fmt.Errorf("marshal roe: %w", err)
+		}
+		// created_by is intentionally NOT updated – the owner is immutable; only updated_by changes.
+		ct, err := tx.Exec(ctx,
+			`UPDATE engagements SET name=$2, client=$3, status=$4, authorized_from=$5, authorized_to=$6, timezone=$7, updated_at=$8, roe=$9, live_recon=$10, updated_by=$11 WHERE id=$1`,
+			e.ID.String(), e.Name, e.Client, string(e.Status),
+			e.AuthorizedFrom, e.AuthorizedTo, e.Timezone, e.Audit.UpdatedAt, roeJSON, e.LiveReconEnabled, e.Audit.UpdatedBy)
+		if err != nil {
+			return fmt.Errorf("update engagement: %w", err)
+		}
+		if ct.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
 
-	// Replace the scope atomically: clear then re-insert with generated PKs.
-	if _, err := tx.Exec(ctx, `DELETE FROM scope_targets WHERE engagement_id=$1`, e.ID.String()); err != nil {
-		return fmt.Errorf("clear scope: %w", err)
-	}
-	insert := func(targets []engagement.Target, inScope bool) error {
-		for _, t := range targets {
-			if _, err := tx.Exec(ctx,
-				`INSERT INTO scope_targets (id, engagement_id, in_scope, kind, value) VALUES (gen_random_uuid()::text,$1,$2,$3,$4)`,
-				e.ID.String(), inScope, string(t.Kind), t.Value); err != nil {
-				return fmt.Errorf("insert scope target: %w", err)
+		// Replace the scope atomically: clear then re-insert with generated PKs.
+		if _, err := tx.Exec(ctx, `DELETE FROM scope_targets WHERE engagement_id=$1`, e.ID.String()); err != nil {
+			return fmt.Errorf("clear scope: %w", err)
+		}
+		insert := func(targets []engagement.Target, inScope bool) error {
+			for _, t := range targets {
+				if _, err := tx.Exec(ctx,
+					`INSERT INTO scope_targets (id, engagement_id, in_scope, kind, value) VALUES (gen_random_uuid()::text,$1,$2,$3,$4)`,
+					e.ID.String(), inScope, string(t.Kind), t.Value); err != nil {
+					return fmt.Errorf("insert scope target: %w", err)
+				}
 			}
+			return nil
+		}
+		if err := insert(e.Scope.InScope, true); err != nil {
+			return err
+		}
+		if err := insert(e.Scope.OutOfScope, false); err != nil {
+			return err
 		}
 		return nil
-	}
-	if err := insert(e.Scope.InScope, true); err != nil {
-		return err
-	}
-	if err := insert(e.Scope.OutOfScope, false); err != nil {
-		return err
-	}
-	return tx.Commit(ctx)
+	})
 }
 
 // Delete removes an engagement; ON DELETE CASCADE drops its scope, findings,

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -142,36 +142,36 @@ func (r *EngagementRepository) Update(ctx context.Context, e *engagement.Engagem
 	})
 }
 
-// Delete removes an engagement; ON DELETE CASCADE drops its scope, findings,
-// comments, evidence, recon runs, and retests. Idempotent (no error if absent).
-// Used to roll back a partially-materialized import.
+// Delete removes an engagement only within an explicitly bound tenant context.
 func (r *EngagementRepository) Delete(ctx context.Context, id shared.ID) error {
-	if _, err := r.pool.Exec(ctx, `DELETE FROM engagements WHERE id=$1`, id.String()); err != nil {
-		return fmt.Errorf("delete engagement: %w", err)
-	}
-	return nil
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `DELETE FROM engagements WHERE id=$1`, id.String()); err != nil {
+			return fmt.Errorf("delete engagement: %w", err)
+		}
+		return nil
+	})
 }
 
-// GetByID returns the engagement with its full scope WITHOUT a tenant predicate. It is the
-// INTERNAL execution-gate read (see ports.EngagementRepository.GetByID): the scope/window/RoE
-// guard and the worker/agent execution paths, which act on an engagement a queued/authorized run
-// already belongs to. User-facing access uses GetByIDInTenant (below), which adds the tenant
-// predicate that blocks cross-tenant reads.
-func (r *EngagementRepository) GetByID(ctx context.Context, id shared.ID) (*engagement.Engagement, error) {
-	e, err := scanEngagement(r.pool.QueryRow(ctx,
-		`SELECT `+engagementCols+` FROM engagements WHERE id=$1`, id.String()))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, shared.ErrNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("select engagement: %w", err)
-	}
-	scope, err := r.loadScope(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	e.Scope = scope
-	return e, nil
+// GetByID is an internal execution-gate read. Its caller must bind the tenant
+// when admitting a durable job; an unbound context fails closed.
+func (r *EngagementRepository) GetByID(ctx context.Context, id shared.ID) (out *engagement.Engagement, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		e, err := scanEngagement(tx.QueryRow(ctx, `SELECT `+engagementCols+` FROM engagements WHERE id=$1`, id.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("select engagement: %w", err)
+		}
+		scope, err := loadScopeTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		e.Scope = scope
+		out = e
+		return nil
+	})
+	return out, err
 }
 
 // GetByIDInTenant loads an engagement scoped to tenantID (tenant isolation). A caller
@@ -239,37 +239,6 @@ func (r *EngagementRepository) List(ctx context.Context, tenantID shared.ID) (ou
 		return rows.Err()
 	})
 	return out, err
-}
-
-func (r *EngagementRepository) loadScope(ctx context.Context, id shared.ID) (engagement.Scope, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT in_scope, kind, value FROM scope_targets WHERE engagement_id=$1 ORDER BY id`, id.String())
-	if err != nil {
-		return engagement.Scope{}, fmt.Errorf("select scope: %w", err)
-	}
-	defer rows.Close()
-
-	var scope engagement.Scope
-	for rows.Next() {
-		var (
-			inScope     bool
-			kind, value string
-		)
-		if err := rows.Scan(&inScope, &kind, &value); err != nil {
-			return engagement.Scope{}, fmt.Errorf("scan scope: %w", err)
-		}
-		t := engagement.Target{Kind: engagement.TargetKind(kind), Value: value}
-		normalized, err := engagement.NormalizeTarget(t, true)
-		if err != nil {
-			return engagement.Scope{}, fmt.Errorf("normalize stored scope target kind=%q value=%q: %w", kind, value, err)
-		}
-		if inScope {
-			scope.InScope = append(scope.InScope, normalized)
-		} else {
-			scope.OutOfScope = append(scope.OutOfScope, normalized)
-		}
-	}
-	return scope, rows.Err()
 }
 
 func loadScopeTx(ctx context.Context, tx pgx.Tx, id shared.ID) (engagement.Scope, error) {

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -16,7 +16,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-const engagementCols = `id, tenant_id, project_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, created_by, updated_by`
+const engagementCols = `id, tenant_id, project_id, assessment_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, created_by, updated_by`
 
 // EngagementRepository persists engagements and their scope to PostgreSQL.
 type EngagementRepository struct{ pool *pgxpool.Pool }
@@ -36,8 +36,8 @@ func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagem
 			return fmt.Errorf("marshal roe: %w", err)
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
-			e.ID.String(), e.TenantID.String(), e.ProjectID.String(), e.Name, e.Client, string(e.Status),
+			`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),NULLIF($4,''),$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+			e.ID.String(), e.TenantID.String(), e.ProjectID.String(), e.AssessmentID.String(), e.Name, e.Client, string(e.Status),
 			e.AuthorizedFrom, e.AuthorizedTo, e.Audit.CreatedAt, e.Audit.UpdatedAt, e.Timezone, roeJSON, e.LiveReconEnabled,
 			e.Audit.CreatedBy, e.Audit.UpdatedBy); err != nil {
 			return fmt.Errorf("insert engagement: %w", err)
@@ -274,13 +274,13 @@ type rowScanner interface {
 
 func scanEngagement(row rowScanner) (*engagement.Engagement, error) {
 	var (
-		e              engagement.Engagement
-		idStr, ten, st string
-		projectID      pgtype.Text
-		af, at         pgtype.Timestamptz
-		roeJSON        []byte
+		e                       engagement.Engagement
+		idStr, ten, st          string
+		projectID, assessmentID pgtype.Text
+		af, at                  pgtype.Timestamptz
+		roeJSON                 []byte
 	)
-	if err := row.Scan(&idStr, &ten, &projectID, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.Audit.CreatedBy, &e.Audit.UpdatedBy); err != nil {
+	if err := row.Scan(&idStr, &ten, &projectID, &assessmentID, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.Audit.CreatedBy, &e.Audit.UpdatedBy); err != nil {
 		return nil, err
 	}
 	if len(roeJSON) > 0 {
@@ -292,6 +292,9 @@ func scanEngagement(row rowScanner) (*engagement.Engagement, error) {
 	e.TenantID = shared.ID(ten)
 	if projectID.Valid {
 		e.ProjectID = shared.ID(projectID.String)
+	}
+	if assessmentID.Valid {
+		e.AssessmentID = shared.ID(assessmentID.String)
 	}
 	e.Status = engagement.Status(st)
 	if af.Valid {

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -72,7 +72,7 @@ func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagem
 // full scope target set, replaced atomically in one transaction (E1 scope CRUD +
 // lifecycle). Returns shared.ErrNotFound if the engagement does not exist. Unlike
 // Create's deterministic scope PKs, the replace path uses generated IDs.
-func (r *EngagementRepository) ProjectContexts(ctx context.Context, tenantID shared.ID, projectIDs []shared.ID) (map[shared.ID]*engagement.Engagement, error) {
+func (r *EngagementRepository) ProjectContexts(ctx context.Context, tenantID shared.ID, projectIDs []shared.ID) (out map[shared.ID]*engagement.Engagement, err error) {
 	ids := make([]string, len(projectIDs))
 	for i, id := range projectIDs {
 		ids[i] = id.String()
@@ -80,20 +80,23 @@ func (r *EngagementRepository) ProjectContexts(ctx context.Context, tenantID sha
 	if len(ids) == 0 {
 		return map[shared.ID]*engagement.Engagement{}, nil
 	}
-	rows, err := r.pool.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE tenant_id=$1 AND project_id = ANY($2)`, tenantID.String(), ids)
-	if err != nil {
-		return nil, fmt.Errorf("list project contexts: %w", err)
-	}
-	defer rows.Close()
-	out := map[shared.ID]*engagement.Engagement{}
-	for rows.Next() {
-		e, err := scanEngagement(rows)
+	out = map[shared.ID]*engagement.Engagement{}
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE tenant_id=$1 AND project_id = ANY($2)`, tenantID.String(), ids)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("list project contexts: %w", err)
 		}
-		out[e.ProjectID] = e
-	}
-	return out, rows.Err()
+		defer rows.Close()
+		for rows.Next() {
+			e, err := scanEngagement(rows)
+			if err != nil {
+				return err
+			}
+			out[e.ProjectID] = e
+		}
+		return rows.Err()
+	})
+	return out, err
 }
 
 func (r *EngagementRepository) Update(ctx context.Context, e *engagement.Engagement) error {
@@ -175,79 +178,67 @@ func (r *EngagementRepository) GetByID(ctx context.Context, id shared.ID) (*enga
 // tenant of ” (single-tenant / default-tenant admin) matches any row; a non-empty tenant
 // matches only its own – tenant A cannot read tenant B's engagement (ErrNotFound, existence
 // not revealed).
-func (r *EngagementRepository) GetByIDInTenant(ctx context.Context, tenantID, id shared.ID) (*engagement.Engagement, error) {
-	e, err := scanEngagement(r.pool.QueryRow(ctx,
-		`SELECT `+engagementCols+` FROM engagements WHERE id=$1 AND project_id IS NULL AND (tenant_id=$2 OR $2='')`,
-		id.String(), tenantID.String()))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, shared.ErrNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("select engagement: %w", err)
-	}
-	scope, err := r.loadScope(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	e.Scope = scope
-	return e, nil
-}
-
-func (r *EngagementRepository) GetByProjectID(ctx context.Context, tenantID, projectID shared.ID) (*engagement.Engagement, error) {
-	e, err := scanEngagement(r.pool.QueryRow(ctx,
-		`SELECT `+engagementCols+` FROM engagements WHERE project_id=$1 AND (tenant_id=$2 OR $2='')`,
-		projectID.String(), tenantID.String()))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, shared.ErrNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("select project analysis context: %w", err)
-	}
-	scope, err := r.loadScope(ctx, e.ID)
-	if err != nil {
-		return nil, err
-	}
-	e.Scope = scope
-	return e, nil
-}
-
-// List returns the tenant's engagements, each with its scope loaded (consistent
-// with the in-memory repository; the UI and the scope gate both rely on scope).
-func (r *EngagementRepository) List(ctx context.Context, tenantID shared.ID) ([]*engagement.Engagement, error) {
-	var (
-		rows pgx.Rows
-		err  error
-	)
-	if tenantID.IsZero() {
-		rows, err = r.pool.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE project_id IS NULL ORDER BY created_at DESC`)
-	} else {
-		rows, err = r.pool.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE tenant_id=$1 AND project_id IS NULL ORDER BY created_at DESC`, tenantID.String())
-	}
-	if err != nil {
-		return nil, fmt.Errorf("list engagements: %w", err)
-	}
-	defer rows.Close()
-
-	out := make([]*engagement.Engagement, 0)
-	for rows.Next() {
-		e, err := scanEngagement(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan engagement: %w", err)
+func (r *EngagementRepository) GetByIDInTenant(ctx context.Context, tenantID, id shared.ID) (out *engagement.Engagement, err error) {
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		e, err := scanEngagement(tx.QueryRow(ctx, `SELECT `+engagementCols+` FROM engagements WHERE id=$1 AND project_id IS NULL AND tenant_id=$2`, id.String(), tenantID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
 		}
-		out = append(out, e)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("list engagements: %w", err)
-	}
-	// Rows are exhausted (auto-closed) here, so the pool conn is free to load scope.
-	for _, e := range out {
-		scope, err := r.loadScope(ctx, e.ID)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("select engagement: %w", err)
+		}
+		scope, err := loadScopeTx(ctx, tx, id)
+		if err != nil {
+			return err
 		}
 		e.Scope = scope
-	}
-	return out, nil
+		out = e
+		return nil
+	})
+	return out, err
+}
+func (r *EngagementRepository) GetByProjectID(ctx context.Context, tenantID, projectID shared.ID) (out *engagement.Engagement, err error) {
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		e, err := scanEngagement(tx.QueryRow(ctx, `SELECT `+engagementCols+` FROM engagements WHERE project_id=$1 AND tenant_id=$2`, projectID.String(), tenantID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("select project analysis context: %w", err)
+		}
+		scope, err := loadScopeTx(ctx, tx, e.ID)
+		if err != nil {
+			return err
+		}
+		e.Scope = scope
+		out = e
+		return nil
+	})
+	return out, err
+}
+
+func (r *EngagementRepository) List(ctx context.Context, tenantID shared.ID) (out []*engagement.Engagement, err error) {
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE tenant_id=$1 AND project_id IS NULL ORDER BY created_at DESC`, tenantID.String())
+		if err != nil {
+			return fmt.Errorf("list engagements: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			e, err := scanEngagement(rows)
+			if err != nil {
+				return fmt.Errorf("scan engagement: %w", err)
+			}
+			scope, err := loadScopeTx(ctx, tx, e.ID)
+			if err != nil {
+				return err
+			}
+			e.Scope = scope
+			out = append(out, e)
+		}
+		return rows.Err()
+	})
+	return out, err
 }
 
 func (r *EngagementRepository) loadScope(ctx context.Context, id shared.ID) (engagement.Scope, error) {
@@ -276,6 +267,32 @@ func (r *EngagementRepository) loadScope(ctx context.Context, id shared.ID) (eng
 			scope.InScope = append(scope.InScope, normalized)
 		} else {
 			scope.OutOfScope = append(scope.OutOfScope, normalized)
+		}
+	}
+	return scope, rows.Err()
+}
+
+func loadScopeTx(ctx context.Context, tx pgx.Tx, id shared.ID) (engagement.Scope, error) {
+	rows, err := tx.Query(ctx, `SELECT in_scope, kind, value FROM scope_targets WHERE engagement_id=$1 ORDER BY id`, id.String())
+	if err != nil {
+		return engagement.Scope{}, fmt.Errorf("select scope: %w", err)
+	}
+	defer rows.Close()
+	var scope engagement.Scope
+	for rows.Next() {
+		var inScope bool
+		var kind, value string
+		if err := rows.Scan(&inScope, &kind, &value); err != nil {
+			return engagement.Scope{}, fmt.Errorf("scan scope: %w", err)
+		}
+		target, err := engagement.NormalizeTarget(engagement.Target{Kind: engagement.TargetKind(kind), Value: value}, true)
+		if err != nil {
+			return engagement.Scope{}, fmt.Errorf("normalize stored scope target kind=%q value=%q: %w", kind, value, err)
+		}
+		if inScope {
+			scope.InScope = append(scope.InScope, target)
+		} else {
+			scope.OutOfScope = append(scope.OutOfScope, target)
 		}
 	}
 	return scope, rows.Err()

--- a/internal/infrastructure/persistence/postgres/engagement_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo_test.go
@@ -18,7 +18,7 @@ func TestEngagementRepository(t *testing.T) {
 	if dsn == "" {
 		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
 	}
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "")
 
 	if err := Migrate(ctx, dsn); err != nil {
 		t.Fatalf("migrate: %v", err)
@@ -159,17 +159,16 @@ func TestEngagementRepository(t *testing.T) {
 	if err := repo.Create(ctx, ea); err != nil {
 		t.Fatalf("create tenantA: %v", err)
 	}
-	// Owner (created_by/updated_by) round-trips.
-	if g, err := repo.GetByID(ctx, idA); err != nil || g.Audit.CreatedBy != "alice" || g.Audit.UpdatedBy != "alice" {
+	// Owner round-trips within the tenant-bound internal execution context.
+	ctxA := shared.WithTenant(context.Background(), tenA)
+	if g, err := repo.GetByID(ctxA, idA); err != nil || g.Audit.CreatedBy != "alice" || g.Audit.UpdatedBy != "alice" {
 		t.Fatalf("ownership round-trip: g=%+v err=%v", g, err)
 	}
-	// Same tenant reads it; a zero tenant (single-tenant / admin) reads it; tenant B cannot
-	// (ErrNotFound – existence is not revealed cross-tenant).
 	if _, err := repo.GetByIDInTenant(ctx, tenA, idA); err != nil {
 		t.Errorf("same-tenant GetByIDInTenant: %v", err)
 	}
-	if _, err := repo.GetByIDInTenant(ctx, "", idA); err != nil {
-		t.Errorf("zero-tenant GetByIDInTenant must see any row: %v", err)
+	if _, err := repo.GetByIDInTenant(ctx, "", idA); err != shared.ErrNotFound {
+		t.Errorf("default-tenant GetByIDInTenant = %v, want ErrNotFound", err)
 	}
 	if _, err := repo.GetByIDInTenant(ctx, tenB, idA); err != shared.ErrNotFound {
 		t.Errorf("cross-tenant GetByIDInTenant = %v, want ErrNotFound", err)
@@ -190,7 +189,7 @@ func TestEngagementRepository(t *testing.T) {
 	if err := repo.Update(ctx, &cp); err != nil {
 		t.Fatalf("update tenantA: %v", err)
 	}
-	if g, err := repo.GetByID(ctx, idA); err != nil || g.Audit.CreatedBy != "alice" || g.Audit.UpdatedBy != "bob" {
+	if g, err := repo.GetByID(ctxA, idA); err != nil || g.Audit.CreatedBy != "alice" || g.Audit.UpdatedBy != "bob" {
 		t.Fatalf("after update, owner must be immutable + updated_by=bob: g=%+v err=%v", g, err)
 	}
 }

--- a/internal/infrastructure/persistence/postgres/evidence_repo.go
+++ b/internal/infrastructure/persistence/postgres/evidence_repo.go
@@ -27,72 +27,66 @@ func (r *EvidenceStore) Append(ctx context.Context, items []evidence.Evidence) e
 	if len(items) == 0 {
 		return nil
 	}
-	tx, err := r.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin: %w", err)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("tenant context is required")
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
-	for _, e := range items {
-		var findingID any
-		if !e.FindingID.IsZero() {
-			findingID = e.FindingID.String()
-		}
-		if _, err := tx.Exec(ctx,
-			`INSERT INTO evidence (id, tenant_id, finding_id, engagement_id, kind, sha256, previous_hash, storage_ref, content, created_by, created_at)
-			 VALUES ($1, '', $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-			e.ID.String(), findingID, e.EngagementID.String(), e.Kind, e.Hash, e.PreviousHash, e.StorageRef, e.Content, e.CreatedBy, e.CreatedAt); err != nil {
-			// Fork guard: the unique(engagement, previous_hash) index rejects a
-			// second child for the same parent – surface as ErrConflict so the caller
-			// re-reads the advanced head + re-chains (keeps the chain strictly linear).
-			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-				return fmt.Errorf("evidence chain: parent already linked: %w", shared.ErrConflict)
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		for _, e := range items {
+			var findingID any
+			if !e.FindingID.IsZero() {
+				findingID = e.FindingID.String()
 			}
-			return fmt.Errorf("insert evidence: %w", err)
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO evidence (id, tenant_id, finding_id, engagement_id, kind, sha256, previous_hash, storage_ref, content, created_by, created_at)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+				e.ID.String(), tenantID.String(), findingID, e.EngagementID.String(), e.Kind, e.Hash, e.PreviousHash, e.StorageRef, e.Content, e.CreatedBy, e.CreatedAt); err != nil {
+				var pgErr *pgconn.PgError
+				if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+					return fmt.Errorf("evidence chain: parent already linked: %w", shared.ErrConflict)
+				}
+				return fmt.Errorf("insert evidence: %w", err)
+			}
 		}
-	}
-	return tx.Commit(ctx)
+		return nil
+	})
 }
 
 // ListByEngagement returns the engagement's evidence in chain order (oldest first).
-func (r *EvidenceStore) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]evidence.Evidence, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT id, COALESCE(finding_id,''), engagement_id, kind, sha256, COALESCE(previous_hash,''), COALESCE(storage_ref,''), content, COALESCE(created_by,''), created_at
-		 FROM evidence WHERE engagement_id=$1 ORDER BY seq ASC`, engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list evidence: %w", err)
-	}
-	defer rows.Close()
-	var out []evidence.Evidence
-	for rows.Next() {
-		var (
-			e            evidence.Evidence
-			id, fid, eid string
-		)
-		if err := rows.Scan(&id, &fid, &eid, &e.Kind, &e.Hash, &e.PreviousHash, &e.StorageRef, &e.Content, &e.CreatedBy, &e.CreatedAt); err != nil {
-			return nil, fmt.Errorf("scan evidence: %w", err)
+func (r *EvidenceStore) ListByEngagement(ctx context.Context, engagementID shared.ID) (out []evidence.Evidence, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id, COALESCE(finding_id,''), engagement_id, kind, sha256, COALESCE(previous_hash,''), COALESCE(storage_ref,''), content, COALESCE(created_by,''), created_at FROM evidence WHERE engagement_id=$1 ORDER BY seq ASC`, engagementID.String())
+		if err != nil {
+			return fmt.Errorf("list evidence: %w", err)
 		}
-		e.ID = shared.ID(id)
-		e.FindingID = shared.ID(fid)
-		e.EngagementID = shared.ID(eid)
-		out = append(out, e)
-	}
-	return out, rows.Err()
+		defer rows.Close()
+		for rows.Next() {
+			var e evidence.Evidence
+			var id, fid, eid string
+			if err := rows.Scan(&id, &fid, &eid, &e.Kind, &e.Hash, &e.PreviousHash, &e.StorageRef, &e.Content, &e.CreatedBy, &e.CreatedAt); err != nil {
+				return fmt.Errorf("scan evidence: %w", err)
+			}
+			e.ID, e.FindingID, e.EngagementID = shared.ID(id), shared.ID(fid), shared.ID(eid)
+			out = append(out, e)
+		}
+		return rows.Err()
+	})
+	return out, err
 }
 
 // Head returns the most recent sealed hash for an engagement ("" if the chain is
 // empty). A real query error is returned (NOT swallowed as "empty") so the caller
 // never forks the append-only chain on a transient DB failure.
-func (r *EvidenceStore) Head(ctx context.Context, engagementID shared.ID) (string, error) {
-	var head string
-	err := r.pool.QueryRow(ctx,
-		`SELECT sha256 FROM evidence WHERE engagement_id=$1 ORDER BY seq DESC LIMIT 1`,
-		engagementID.String()).Scan(&head)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return "", nil // genuinely empty chain
-	}
-	if err != nil {
-		return "", fmt.Errorf("head evidence: %w", err)
-	}
-	return head, nil
+func (r *EvidenceStore) Head(ctx context.Context, engagementID shared.ID) (head string, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		err := tx.QueryRow(ctx, `SELECT sha256 FROM evidence WHERE engagement_id=$1 ORDER BY seq DESC LIMIT 1`, engagementID.String()).Scan(&head)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("head evidence: %w", err)
+		}
+		return nil
+	})
+	return head, err
 }

--- a/internal/infrastructure/persistence/postgres/evidence_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/evidence_repo_test.go
@@ -15,7 +15,7 @@ import (
 // writers (API + worker) can never fork the hash chain. Gated on SYNAPSE_TEST_DB_DSN.
 func TestPostgresEvidenceForkGuard(t *testing.T) {
 	dsn := testDSN(t)
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "")
 	if err := Migrate(ctx, dsn); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestPostgresEvidenceForkGuard(t *testing.T) {
 // round-trip (the hash truncates the timestamp to µs to match timestamptz precision).
 func TestPostgresEvidenceVerifyRoundTrip(t *testing.T) {
 	dsn := testDSN(t)
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "")
 	if err := Migrate(ctx, dsn); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/finding_repo.go
+++ b/internal/infrastructure/persistence/postgres/finding_repo.go
@@ -71,35 +71,33 @@ func (r *FindingRepository) Upsert(ctx context.Context, findings []finding.Findi
 // UpdateStatus sets the triage status with optimistic concurrency: the row is
 // updated only if version matches expectedVersion, then version is bumped. On a
 // miss it distinguishes ErrConflict (exists, version moved) from ErrNotFound.
-func (r *FindingRepository) UpdateStatus(ctx context.Context, engagementID, findingID shared.ID, status finding.Status, expectedVersion int) (finding.Finding, error) {
-	f, err := scanFinding(r.pool.QueryRow(ctx,
-		`UPDATE findings SET status=$1, version=version+1, updated_at=now()
-		 WHERE id=$2 AND engagement_id=$3 AND version=$4
-		 RETURNING `+findingCols,
-		string(status), findingID.String(), engagementID.String(), expectedVersion))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return finding.Finding{}, r.classifyUpdateMiss(ctx, engagementID, findingID)
-	}
-	if err != nil {
-		return finding.Finding{}, fmt.Errorf("update finding status: %w", err)
-	}
-	return f, nil
+func (r *FindingRepository) UpdateStatus(ctx context.Context, engagementID, findingID shared.ID, status finding.Status, expectedVersion int) (out finding.Finding, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		out, err = scanFinding(tx.QueryRow(ctx, `UPDATE findings SET status=$1, version=version+1, updated_at=now() WHERE id=$2 AND engagement_id=$3 AND version=$4 RETURNING `+findingCols, string(status), findingID.String(), engagementID.String(), expectedVersion))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return classifyFindingUpdateMiss(ctx, tx, engagementID, findingID)
+		}
+		if err != nil {
+			return fmt.Errorf("update finding status: %w", err)
+		}
+		return nil
+	})
+	return out, err
 }
 
 // SetAssignee sets the assignee with the same optimistic-concurrency guard.
-func (r *FindingRepository) SetAssignee(ctx context.Context, engagementID, findingID shared.ID, assignee string, expectedVersion int) (finding.Finding, error) {
-	f, err := scanFinding(r.pool.QueryRow(ctx,
-		`UPDATE findings SET assignee=$1, version=version+1, updated_at=now()
-		 WHERE id=$2 AND engagement_id=$3 AND version=$4
-		 RETURNING `+findingCols,
-		assignee, findingID.String(), engagementID.String(), expectedVersion))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return finding.Finding{}, r.classifyUpdateMiss(ctx, engagementID, findingID)
-	}
-	if err != nil {
-		return finding.Finding{}, fmt.Errorf("set finding assignee: %w", err)
-	}
-	return f, nil
+func (r *FindingRepository) SetAssignee(ctx context.Context, engagementID, findingID shared.ID, assignee string, expectedVersion int) (out finding.Finding, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		out, err = scanFinding(tx.QueryRow(ctx, `UPDATE findings SET assignee=$1, version=version+1, updated_at=now() WHERE id=$2 AND engagement_id=$3 AND version=$4 RETURNING `+findingCols, assignee, findingID.String(), engagementID.String(), expectedVersion))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return classifyFindingUpdateMiss(ctx, tx, engagementID, findingID)
+		}
+		if err != nil {
+			return fmt.Errorf("set finding assignee: %w", err)
+		}
+		return nil
+	})
+	return out, err
 }
 
 // SetEvidenceScore sets a finding's evidence score with the same optimistic-concurrency
@@ -107,28 +105,25 @@ func (r *FindingRepository) SetAssignee(ctx context.Context, engagementID, findi
 // updated only if version matches, then version is bumped. Note the Upsert ON CONFLICT set
 // deliberately omits evidence_score, so this is the only path that moves it for an
 // already-stored finding.
-func (r *FindingRepository) SetEvidenceScore(ctx context.Context, engagementID, findingID shared.ID, score, expectedVersion int) (finding.Finding, error) {
-	f, err := scanFinding(r.pool.QueryRow(ctx,
-		`UPDATE findings SET evidence_score=$1, version=version+1, updated_at=now()
-		 WHERE id=$2 AND engagement_id=$3 AND version=$4
-		 RETURNING `+findingCols,
-		score, findingID.String(), engagementID.String(), expectedVersion))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return finding.Finding{}, r.classifyUpdateMiss(ctx, engagementID, findingID)
-	}
-	if err != nil {
-		return finding.Finding{}, fmt.Errorf("set finding evidence score: %w", err)
-	}
-	return f, nil
+func (r *FindingRepository) SetEvidenceScore(ctx context.Context, engagementID, findingID shared.ID, score, expectedVersion int) (out finding.Finding, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		out, err = scanFinding(tx.QueryRow(ctx, `UPDATE findings SET evidence_score=$1, version=version+1, updated_at=now() WHERE id=$2 AND engagement_id=$3 AND version=$4 RETURNING `+findingCols, score, findingID.String(), engagementID.String(), expectedVersion))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return classifyFindingUpdateMiss(ctx, tx, engagementID, findingID)
+		}
+		if err != nil {
+			return fmt.Errorf("set finding evidence score: %w", err)
+		}
+		return nil
+	})
+	return out, err
 }
 
 // classifyUpdateMiss maps a no-row optimistic UPDATE to ErrConflict (the finding
 // exists but its version moved – lost-update guard) or ErrNotFound.
-func (r *FindingRepository) classifyUpdateMiss(ctx context.Context, engagementID, findingID shared.ID) error {
+func classifyFindingUpdateMiss(ctx context.Context, tx pgx.Tx, engagementID, findingID shared.ID) error {
 	var exists bool
-	if err := r.pool.QueryRow(ctx,
-		`SELECT EXISTS(SELECT 1 FROM findings WHERE id=$1 AND engagement_id=$2)`,
-		findingID.String(), engagementID.String()).Scan(&exists); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM findings WHERE id=$1 AND engagement_id=$2)`, findingID.String(), engagementID.String()).Scan(&exists); err != nil {
 		return fmt.Errorf("classify update miss: %w", err)
 	}
 	if exists {
@@ -139,30 +134,23 @@ func (r *FindingRepository) classifyUpdateMiss(ctx context.Context, engagementID
 
 // ListByEngagement returns the engagement's findings, highest risk first
 // (CISA KEV, then EPSS x CVSS, then severity).
-func (r *FindingRepository) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]finding.Finding, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT `+findingCols+`
-		 FROM findings WHERE engagement_id=$1
-		 ORDER BY priority ASC, kev DESC, risk_score DESC,
-		          CASE severity
-		            WHEN 'critical' THEN 5 WHEN 'high' THEN 4 WHEN 'medium' THEN 3
-		            WHEN 'low' THEN 2 WHEN 'info' THEN 1 ELSE 0 END DESC,
-		          title COLLATE "C" ASC, COALESCE(dedup_key,'') COLLATE "C" ASC, id COLLATE "C" ASC`,
-		engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list findings: %w", err)
-	}
-	defer rows.Close()
-
-	out := make([]finding.Finding, 0)
-	for rows.Next() {
-		f, err := scanFinding(rows)
+func (r *FindingRepository) ListByEngagement(ctx context.Context, engagementID shared.ID) (out []finding.Finding, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+findingCols+` FROM findings WHERE engagement_id=$1 ORDER BY priority ASC, kev DESC, risk_score DESC, CASE severity WHEN 'critical' THEN 5 WHEN 'high' THEN 4 WHEN 'medium' THEN 3 WHEN 'low' THEN 2 WHEN 'info' THEN 1 ELSE 0 END DESC, title COLLATE "C" ASC, COALESCE(dedup_key,'') COLLATE "C" ASC, id COLLATE "C" ASC`, engagementID.String())
 		if err != nil {
-			return nil, fmt.Errorf("scan finding: %w", err)
+			return fmt.Errorf("list findings: %w", err)
 		}
-		out = append(out, f)
-	}
-	return out, rows.Err()
+		defer rows.Close()
+		for rows.Next() {
+			f, err := scanFinding(rows)
+			if err != nil {
+				return fmt.Errorf("scan finding: %w", err)
+			}
+			out = append(out, f)
+		}
+		return rows.Err()
+	})
+	return out, err
 }
 
 // ListPublishableByEngagement returns only the engagement's findings that clear the

--- a/internal/infrastructure/persistence/postgres/finding_repo.go
+++ b/internal/infrastructure/persistence/postgres/finding_repo.go
@@ -40,35 +40,32 @@ func (r *FindingRepository) Upsert(ctx context.Context, findings []finding.Findi
 	if len(findings) == 0 {
 		return nil
 	}
-	tx, err := r.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin: %w", err)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("tenant context is required")
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
-
-	for _, f := range findings {
-		// tenant_id '' = the seeded default tenant. Finding READS are tenant-isolated via the
-		// tenant-scoped engagement gate; deriving this row's tenant_id from the engagement
-		// is a remaining row-level follow-up and does not affect read isolation today.
-		if _, err := tx.Exec(ctx,
-			`INSERT INTO findings (id, tenant_id, engagement_id, title, description, severity, cvss_vector, cwe, status, evidence_score, dedup_key, kev, risk_score, created_at, updated_at, sources, confidence, class, scope, reachability, impact, priority, kind, assignee, version, proposed_by, class_reachability, rule_key)
-			 VALUES ($1, '', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
-			 ON CONFLICT (engagement_id, dedup_key) WHERE dedup_key IS NOT NULL
-			 DO UPDATE SET title = EXCLUDED.title, description = EXCLUDED.description,
-			               severity = EXCLUDED.severity, cvss_vector = EXCLUDED.cvss_vector, kev = EXCLUDED.kev, risk_score = EXCLUDED.risk_score,
-			               sources = EXCLUDED.sources, confidence = EXCLUDED.confidence, class = EXCLUDED.class,
-			               scope = EXCLUDED.scope, reachability = EXCLUDED.reachability, impact = EXCLUDED.impact, priority = EXCLUDED.priority,
-			               kind = EXCLUDED.kind, class_reachability = EXCLUDED.class_reachability,
-			               rule_key = EXCLUDED.rule_key, updated_at = EXCLUDED.updated_at`,
-			f.ID.String(), f.EngagementID.String(), f.Title, f.Description, string(f.Severity),
-			f.CVSSVector, f.CWE, string(f.Status), f.EvidenceScore, f.DedupKey,
-			f.KEV, f.RiskScore, f.Audit.CreatedAt, f.Audit.UpdatedAt, strings.Join(f.Sources, ","), f.Confidence, classOrDefault(f.Class),
-			scopeOrDefault(f.Scope), reachOrDefault(f.Reachability), f.Impact, priorityOrDefault(f.Priority), kindOrDefault(string(f.Kind)),
-			f.Assignee, versionOrDefault(f.Version), f.ProposedBy, f.ClassReachability, f.RuleKey); err != nil {
-			return fmt.Errorf("upsert finding: %w", err)
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		for _, f := range findings {
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO findings (id, tenant_id, engagement_id, title, description, severity, cvss_vector, cwe, status, evidence_score, dedup_key, kev, risk_score, created_at, updated_at, sources, confidence, class, scope, reachability, impact, priority, kind, assignee, version, proposed_by, class_reachability, rule_key)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
+				 ON CONFLICT (engagement_id, dedup_key) WHERE dedup_key IS NOT NULL
+				 DO UPDATE SET title = EXCLUDED.title, description = EXCLUDED.description,
+				               severity = EXCLUDED.severity, cvss_vector = EXCLUDED.cvss_vector, kev = EXCLUDED.kev, risk_score = EXCLUDED.risk_score,
+				               sources = EXCLUDED.sources, confidence = EXCLUDED.confidence, class = EXCLUDED.class,
+				               scope = EXCLUDED.scope, reachability = EXCLUDED.reachability, impact = EXCLUDED.impact, priority = EXCLUDED.priority,
+				               kind = EXCLUDED.kind, class_reachability = EXCLUDED.class_reachability,
+				               rule_key = EXCLUDED.rule_key, updated_at = EXCLUDED.updated_at`,
+				f.ID.String(), tenantID.String(), f.EngagementID.String(), f.Title, f.Description, string(f.Severity),
+				f.CVSSVector, f.CWE, string(f.Status), f.EvidenceScore, f.DedupKey,
+				f.KEV, f.RiskScore, f.Audit.CreatedAt, f.Audit.UpdatedAt, strings.Join(f.Sources, ","), f.Confidence, classOrDefault(f.Class),
+				scopeOrDefault(f.Scope), reachOrDefault(f.Reachability), f.Impact, priorityOrDefault(f.Priority), kindOrDefault(string(f.Kind)),
+				f.Assignee, versionOrDefault(f.Version), f.ProposedBy, f.ClassReachability, f.RuleKey); err != nil {
+				return fmt.Errorf("upsert finding: %w", err)
+			}
 		}
-	}
-	return tx.Commit(ctx)
+		return nil
+	})
 }
 
 // UpdateStatus sets the triage status with optimistic concurrency: the row is

--- a/internal/infrastructure/persistence/postgres/finding_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/finding_repo_test.go
@@ -16,7 +16,7 @@ func TestFindingRepository(t *testing.T) {
 	if dsn == "" {
 		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
 	}
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "")
 	if err := Migrate(ctx, dsn); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/imported_sbom_store.go
+++ b/internal/infrastructure/persistence/postgres/imported_sbom_store.go
@@ -28,48 +28,42 @@ func (s *ImportedSBOMStore) SaveActive(ctx context.Context, record importedsbom.
 	if err := record.Validate(); err != nil {
 		return err
 	}
-	_, err := s.pool.Exec(ctx, `
-		INSERT INTO imported_sboms (
-			id, tenant_id, engagement_id, filename, format, spec_version, target_ref,
-			component_count, dependency_count, sha256, raw_json, created_by, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-		ON CONFLICT (tenant_id, engagement_id) DO UPDATE SET
-			id = EXCLUDED.id,
-			filename = EXCLUDED.filename,
-			format = EXCLUDED.format,
-			spec_version = EXCLUDED.spec_version,
-			target_ref = EXCLUDED.target_ref,
-			component_count = EXCLUDED.component_count,
-			dependency_count = EXCLUDED.dependency_count,
-			sha256 = EXCLUDED.sha256,
-			raw_json = EXCLUDED.raw_json,
-			created_by = EXCLUDED.created_by,
-			created_at = EXCLUDED.created_at`,
-		record.ID.String(), record.TenantID.String(), record.EngagementID.String(), record.Filename,
-		record.Format, record.SpecVersion, record.TargetRef, record.ComponentCount, record.DependencyCount,
-		record.SHA256, record.RawJSON, record.CreatedBy, record.CreatedAt)
-	if err != nil {
-		return fmt.Errorf("save imported SBOM: %w", err)
-	}
-	return nil
+	return WithTenantTx(ctx, s.pool, record.TenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO imported_sboms (
+				id, tenant_id, engagement_id, filename, format, spec_version, target_ref,
+				component_count, dependency_count, sha256, raw_json, created_by, created_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+			ON CONFLICT (tenant_id, engagement_id) DO UPDATE SET
+				id = EXCLUDED.id, filename = EXCLUDED.filename, format = EXCLUDED.format,
+				spec_version = EXCLUDED.spec_version, target_ref = EXCLUDED.target_ref,
+				component_count = EXCLUDED.component_count, dependency_count = EXCLUDED.dependency_count,
+				sha256 = EXCLUDED.sha256, raw_json = EXCLUDED.raw_json,
+				created_by = EXCLUDED.created_by, created_at = EXCLUDED.created_at`,
+			record.ID.String(), record.TenantID.String(), record.EngagementID.String(), record.Filename,
+			record.Format, record.SpecVersion, record.TargetRef, record.ComponentCount, record.DependencyCount,
+			record.SHA256, record.RawJSON, record.CreatedBy, record.CreatedAt)
+		if err != nil {
+			return fmt.Errorf("save imported SBOM: %w", err)
+		}
+		return nil
+	})
 }
 
 // LatestByEngagement returns the active imported SBOM for a tenant-scoped engagement.
-func (s *ImportedSBOMStore) LatestByEngagement(ctx context.Context, tenantID, engagementID shared.ID) (importedsbom.Record, error) {
-	var record importedsbom.Record
-	err := s.pool.QueryRow(ctx, `
-		SELECT id, tenant_id, engagement_id, filename, format, spec_version, target_ref,
-		       component_count, dependency_count, sha256, raw_json, created_by, created_at
-		FROM imported_sboms
-		WHERE tenant_id = $1 AND engagement_id = $2`, tenantID.String(), engagementID.String()).Scan(
-		&record.ID, &record.TenantID, &record.EngagementID, &record.Filename, &record.Format,
-		&record.SpecVersion, &record.TargetRef, &record.ComponentCount, &record.DependencyCount,
-		&record.SHA256, &record.RawJSON, &record.CreatedBy, &record.CreatedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return importedsbom.Record{}, fmt.Errorf("imported SBOM for engagement %s: %w", engagementID, shared.ErrNotFound)
-	}
-	if err != nil {
-		return importedsbom.Record{}, fmt.Errorf("load imported SBOM: %w", err)
-	}
-	return record, nil
+func (s *ImportedSBOMStore) LatestByEngagement(ctx context.Context, tenantID, engagementID shared.ID) (record importedsbom.Record, err error) {
+	err = WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		err := tx.QueryRow(ctx, `SELECT id, tenant_id, engagement_id, filename, format, spec_version, target_ref, component_count, dependency_count, sha256, raw_json, created_by, created_at FROM imported_sboms WHERE tenant_id = $1 AND engagement_id = $2`, tenantID.String(), engagementID.String()).Scan(
+			&record.ID, &record.TenantID, &record.EngagementID, &record.Filename, &record.Format,
+			&record.SpecVersion, &record.TargetRef, &record.ComponentCount, &record.DependencyCount,
+			&record.SHA256, &record.RawJSON, &record.CreatedBy, &record.CreatedAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("imported SBOM for engagement %s: %w", engagementID, shared.ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("load imported SBOM: %w", err)
+		}
+		return nil
+	})
+	return record, err
 }

--- a/internal/infrastructure/persistence/postgres/jobqueue.go
+++ b/internal/infrastructure/persistence/postgres/jobqueue.go
@@ -111,70 +111,82 @@ func (q *JobQueue) Claim(ctx context.Context, visibility time.Duration, kinds ..
 }
 
 func (q *JobQueue) Heartbeat(ctx context.Context, id string, extend time.Duration) error {
-	tag, err := q.pool.Exec(ctx,
-		`UPDATE jobs SET claimed_until = now() + make_interval(secs => $2), updated_at = now()
-		 WHERE id = $1 AND status = 'claimed'`,
-		id, extend.Seconds())
-	if err != nil {
-		return fmt.Errorf("heartbeat job: %w", err)
-	}
-	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("job %s: %w", id, shared.ErrNotFound)
-	}
-	return nil
+	return WithContextTenantTx(ctx, q.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE jobs SET claimed_until = now() + make_interval(secs => $2), updated_at = now()
+			 WHERE id = $1 AND status = 'claimed'`,
+			id, extend.Seconds())
+		if err != nil {
+			return fmt.Errorf("heartbeat job: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("job %s: %w", id, shared.ErrNotFound)
+		}
+		return nil
+	})
 }
 
 func (q *JobQueue) Complete(ctx context.Context, id string) error {
-	tag, err := q.pool.Exec(ctx,
-		`UPDATE jobs SET status='done', claimed_until=NULL, updated_at=now() WHERE id=$1`, id)
-	if err != nil {
-		return fmt.Errorf("complete job: %w", err)
-	}
-	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("job %s: %w", id, shared.ErrNotFound)
-	}
-	return nil
+	return WithContextTenantTx(ctx, q.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE jobs SET status='done', claimed_until=NULL, updated_at=now() WHERE id=$1`, id)
+		if err != nil {
+			return fmt.Errorf("complete job: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("job %s: %w", id, shared.ErrNotFound)
+		}
+		return nil
+	})
 }
 
 func (q *JobQueue) Deadletter(ctx context.Context, id string) error {
-	tag, err := q.pool.Exec(ctx,
-		`UPDATE jobs SET status='failed', claimed_until=NULL, updated_at=now() WHERE id=$1`, id)
-	if err != nil {
-		return fmt.Errorf("deadletter job: %w", err)
-	}
-	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("job %s: %w", id, shared.ErrNotFound)
-	}
-	return nil
+	return WithContextTenantTx(ctx, q.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE jobs SET status='failed', claimed_until=NULL, updated_at=now() WHERE id=$1`, id)
+		if err != nil {
+			return fmt.Errorf("deadletter job: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("job %s: %w", id, shared.ErrNotFound)
+		}
+		return nil
+	})
 }
 
 // Depth counts not-yet-terminal jobs (queued or claimed) – the durable-backpressure
 // admission signal. 'done' and 'failed' are terminal and excluded. Optional kind filter.
 func (q *JobQueue) Depth(ctx context.Context, kinds ...string) (int, error) {
-	query := `SELECT count(*) FROM jobs WHERE status IN ('queued','claimed')`
-	var args []any
-	if len(kinds) > 0 {
-		query += ` AND kind = ANY($1)`
-		args = append(args, kinds)
-	}
 	var n int
-	if err := q.pool.QueryRow(ctx, query, args...).Scan(&n); err != nil {
-		return 0, fmt.Errorf("queue depth: %w", err)
+	err := WithContextTenantTx(ctx, q.pool, func(tx pgx.Tx) error {
+		query := `SELECT count(*) FROM jobs WHERE status IN ('queued','claimed')`
+		var args []any
+		if len(kinds) > 0 {
+			query += ` AND kind = ANY($1)`
+			args = append(args, kinds)
+		}
+		if err := tx.QueryRow(ctx, query, args...).Scan(&n); err != nil {
+			return fmt.Errorf("queue depth: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
 	}
 	return n, nil
 }
 
 func (q *JobQueue) Fail(ctx context.Context, id string, retryIn time.Duration) error {
-	tag, err := q.pool.Exec(ctx,
-		`UPDATE jobs SET status='queued', claimed_until=NULL,
-		        available_at = now() + make_interval(secs => $2), updated_at = now()
-		 WHERE id = $1`,
-		id, retryIn.Seconds())
-	if err != nil {
-		return fmt.Errorf("fail job: %w", err)
-	}
-	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("job %s: %w", id, shared.ErrNotFound)
-	}
-	return nil
+	return WithContextTenantTx(ctx, q.pool, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE jobs SET status='queued', claimed_until=NULL,
+			        available_at = now() + make_interval(secs => $2), updated_at = now()
+			 WHERE id = $1`,
+			id, retryIn.Seconds())
+		if err != nil {
+			return fmt.Errorf("fail job: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("job %s: %w", id, shared.ErrNotFound)
+		}
+		return nil
+	})
 }

--- a/internal/infrastructure/persistence/postgres/jobqueue.go
+++ b/internal/infrastructure/persistence/postgres/jobqueue.go
@@ -34,12 +34,16 @@ func (q *JobQueue) Enqueue(ctx context.Context, kind string, payload []byte) (st
 		return "", fmt.Errorf("%w: job kind is required", shared.ErrValidation)
 	}
 	id := q.ids.NewID().String()
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return "", fmt.Errorf("%w: tenant context is required for durable job", shared.ErrValidation)
+	}
 	if payload == nil {
 		payload = []byte{} // a nil []byte encodes as SQL NULL; the column is NOT NULL and empty is valid
 	}
 	if _, err := q.pool.Exec(ctx,
-		`INSERT INTO jobs (id, kind, payload, status, available_at) VALUES ($1, $2, $3, 'queued', now())`,
-		id, kind, payload); err != nil {
+		`INSERT INTO jobs (id, tenant_id, kind, payload, status, available_at) VALUES ($1, $2, $3, $4, 'queued', now())`,
+		id, tenantID.String(), kind, payload); err != nil {
 		return "", fmt.Errorf("enqueue job: %w", err)
 	}
 	return id, nil
@@ -65,8 +69,8 @@ func (q *JobQueue) Claim(ctx context.Context, visibility time.Duration, kinds ..
 		     FOR UPDATE SKIP LOCKED
 		     LIMIT 1
 		 )
-		 RETURNING id, kind, payload, attempts`,
-		args...).Scan(&j.ID, &j.Kind, &j.Payload, &j.Attempts)
+		 RETURNING id, tenant_id, kind, payload, attempts`,
+		args...).Scan(&j.ID, &j.TenantID, &j.Kind, &j.Payload, &j.Attempts)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil // nothing ready
 	}

--- a/internal/infrastructure/persistence/postgres/jobqueue.go
+++ b/internal/infrastructure/persistence/postgres/jobqueue.go
@@ -50,34 +50,64 @@ func (q *JobQueue) Enqueue(ctx context.Context, kind string, payload []byte) (st
 }
 
 func (q *JobQueue) Claim(ctx context.Context, visibility time.Duration, kinds ...string) (*ports.QueuedJob, error) {
-	// Optional kind filter: only claim the kinds this worker handles (empty = any).
-	kindFilter, args := "", []any{visibility.Seconds()}
-	if len(kinds) > 0 {
-		kindFilter = " AND kind = ANY($2)"
-		args = append(args, kinds)
-	}
-	var j ports.QueuedJob
-	err := q.pool.QueryRow(ctx,
-		`UPDATE jobs SET status='claimed', attempts=attempts+1,
-		        claimed_until = now() + make_interval(secs => $1), updated_at = now()
-		 WHERE id = (
-		     SELECT id FROM jobs
-		     WHERE status <> 'done'
-		       AND available_at <= now()
-		       AND (status = 'queued' OR claimed_until < now())`+kindFilter+`
-		     ORDER BY available_at
-		     FOR UPDATE SKIP LOCKED
-		     LIMIT 1
-		 )
-		 RETURNING id, tenant_id, kind, payload, attempts`,
-		args...).Scan(&j.ID, &j.TenantID, &j.Kind, &j.Payload, &j.Attempts)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil // nothing ready
-	}
+	tenantRows, err := q.pool.Query(ctx, `SELECT id FROM tenants ORDER BY id`)
 	if err != nil {
-		return nil, fmt.Errorf("claim job: %w", err)
+		return nil, fmt.Errorf("list queue tenants: %w", err)
 	}
-	return &j, nil
+	tenantIDs := []shared.ID{}
+	for tenantRows.Next() {
+		var tenant string
+		if err := tenantRows.Scan(&tenant); err != nil {
+			tenantRows.Close()
+			return nil, fmt.Errorf("scan queue tenant: %w", err)
+		}
+		tenantIDs = append(tenantIDs, shared.ID(tenant))
+	}
+	if err := tenantRows.Err(); err != nil {
+		tenantRows.Close()
+		return nil, fmt.Errorf("list queue tenants: %w", err)
+	}
+	tenantRows.Close()
+	for _, tenantID := range tenantIDs {
+		var job *ports.QueuedJob
+		err := WithTenantTx(ctx, q.pool, tenantID, func(tx pgx.Tx) error {
+			kindFilter, args := "", []any{visibility.Seconds()}
+			if len(kinds) > 0 {
+				kindFilter = " AND kind = ANY($2)"
+				args = append(args, kinds)
+			}
+			var claimed ports.QueuedJob
+			err := tx.QueryRow(ctx,
+				`UPDATE jobs SET status='claimed', attempts=attempts+1,
+				        claimed_until = now() + make_interval(secs => $1), updated_at = now()
+				 WHERE id = (
+				     SELECT id FROM jobs
+				     WHERE status <> 'done'
+				       AND available_at <= now()
+				       AND (status = 'queued' OR claimed_until < now())`+kindFilter+`
+				     ORDER BY available_at
+				     FOR UPDATE SKIP LOCKED
+				     LIMIT 1
+				 )
+				 RETURNING id, tenant_id, kind, payload, attempts`,
+				args...).Scan(&claimed.ID, &claimed.TenantID, &claimed.Kind, &claimed.Payload, &claimed.Attempts)
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("claim job: %w", err)
+			}
+			job = &claimed
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if job != nil {
+			return job, nil
+		}
+	}
+	return nil, nil
 }
 
 func (q *JobQueue) Heartbeat(ctx context.Context, id string, extend time.Duration) error {

--- a/internal/infrastructure/persistence/postgres/project_analysis_store.go
+++ b/internal/infrastructure/persistence/postgres/project_analysis_store.go
@@ -33,16 +33,19 @@ func (r *ProjectAnalysisStore) SaveWithResult(ctx context.Context, analysis proj
 	if err != nil {
 		return fmt.Errorf("marshal project analysis: %w", err)
 	}
-	_, err = r.pool.Exec(ctx, `INSERT INTO project_analyses (id, tenant_id, project_id, created_at, payload, result)
-		VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (id) DO NOTHING`,
-		analysis.ID, analysis.TenantID, analysis.ProjectID, analysis.CreatedAt, payload, result)
-	if err != nil {
-		return fmt.Errorf("insert project analysis: %w", err)
-	}
-	return nil
+	err = WithTenantTx(ctx, r.pool, shared.ID(analysis.TenantID), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO project_analyses (id, tenant_id, project_id, created_at, payload, result)
+			VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (id) DO NOTHING`,
+			analysis.ID, analysis.TenantID, analysis.ProjectID, analysis.CreatedAt, payload, result)
+		if err != nil {
+			return fmt.Errorf("insert project analysis: %w", err)
+		}
+		return nil
+	})
+	return err
 }
 
-func (r *ProjectAnalysisStore) LatestForProjects(ctx context.Context, tenantID shared.ID, projectIDs []shared.ID) (map[shared.ID]projectanalysis.Analysis, error) {
+func (r *ProjectAnalysisStore) LatestForProjects(ctx context.Context, tenantID shared.ID, projectIDs []shared.ID) (out map[shared.ID]projectanalysis.Analysis, err error) {
 	ids := make([]string, len(projectIDs))
 	for i, id := range projectIDs {
 		ids[i] = id.String()
@@ -50,102 +53,91 @@ func (r *ProjectAnalysisStore) LatestForProjects(ctx context.Context, tenantID s
 	if len(ids) == 0 {
 		return map[shared.ID]projectanalysis.Analysis{}, nil
 	}
-	rows, err := r.pool.Query(ctx, `SELECT DISTINCT ON (project_id) project_id, payload FROM project_analyses WHERE tenant_id=$1 AND project_id = ANY($2) ORDER BY project_id, created_at DESC, id COLLATE "C" DESC`, tenantID.String(), ids)
-	if err != nil {
-		return nil, fmt.Errorf("list latest project analyses: %w", err)
-	}
-	defer rows.Close()
-	out := map[shared.ID]projectanalysis.Analysis{}
-	for rows.Next() {
-		var id string
+	out = map[shared.ID]projectanalysis.Analysis{}
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT DISTINCT ON (project_id) project_id, payload FROM project_analyses WHERE tenant_id=$1 AND project_id = ANY($2) ORDER BY project_id, created_at DESC, id COLLATE "C" DESC`, tenantID.String(), ids)
+		if err != nil {
+			return fmt.Errorf("list latest project analyses: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id string
+			var payload []byte
+			if err := rows.Scan(&id, &payload); err != nil {
+				return fmt.Errorf("scan latest project analysis: %w", err)
+			}
+			var analysis projectanalysis.Analysis
+			if err := json.Unmarshal(payload, &analysis); err != nil {
+				return fmt.Errorf("decode project analysis: %w", err)
+			}
+			out[shared.ID(id)] = analysis
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+func (r *ProjectAnalysisStore) LatestWithResult(ctx context.Context, tenantID, projectID shared.ID) (analysis projectanalysis.Analysis, result []byte, err error) {
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
 		var payload []byte
-		if err := rows.Scan(&id, &payload); err != nil {
-			return nil, fmt.Errorf("scan latest project analysis: %w", err)
+		err := tx.QueryRow(ctx, `SELECT payload, result FROM project_analyses WHERE tenant_id=$1 AND project_id=$2 AND result IS NOT NULL ORDER BY created_at DESC, id COLLATE "C" DESC LIMIT 1`, tenantID.String(), projectID.String()).Scan(&payload, &result)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
 		}
-		var analysis projectanalysis.Analysis
+		if err != nil {
+			return fmt.Errorf("latest project analysis: %w", err)
+		}
 		if err := json.Unmarshal(payload, &analysis); err != nil {
-			return nil, fmt.Errorf("decode project analysis: %w", err)
+			return fmt.Errorf("decode project analysis: %w", err)
 		}
-		out[shared.ID(id)] = analysis
-	}
-	return out, rows.Err()
+		return nil
+	})
+	return analysis, result, err
 }
 
-func (r *ProjectAnalysisStore) LatestWithResult(ctx context.Context, tenantID, projectID shared.ID) (projectanalysis.Analysis, []byte, error) {
-	var row pgx.Row
-	if tenantID.IsZero() {
-		row = r.pool.QueryRow(ctx, `SELECT payload, result FROM project_analyses WHERE project_id=$1 AND result IS NOT NULL ORDER BY created_at DESC, id COLLATE "C" DESC LIMIT 1`, projectID.String())
-	} else {
-		row = r.pool.QueryRow(ctx, `SELECT payload, result FROM project_analyses WHERE tenant_id=$1 AND project_id=$2 AND result IS NOT NULL ORDER BY created_at DESC, id COLLATE "C" DESC LIMIT 1`, tenantID.String(), projectID.String())
-	}
-	var payload, result []byte
-	if err := row.Scan(&payload, &result); errors.Is(err, pgx.ErrNoRows) {
-		return projectanalysis.Analysis{}, nil, shared.ErrNotFound
-	} else if err != nil {
-		return projectanalysis.Analysis{}, nil, fmt.Errorf("latest project analysis: %w", err)
-	}
-	var analysis projectanalysis.Analysis
-	if err := json.Unmarshal(payload, &analysis); err != nil {
-		return projectanalysis.Analysis{}, nil, fmt.Errorf("decode project analysis: %w", err)
-	}
-	return analysis, result, nil
-}
-
-func (r *ProjectAnalysisStore) List(ctx context.Context, tenantID, projectID shared.ID, limit int, beforeCreatedAt time.Time, beforeID shared.ID) ([]projectanalysis.Analysis, bool, error) {
-	var (
-		rows pgx.Rows
-		err  error
-	)
+func (r *ProjectAnalysisStore) List(ctx context.Context, tenantID, projectID shared.ID, limit int, beforeCreatedAt time.Time, beforeID shared.ID) (out []projectanalysis.Analysis, hasMore bool, err error) {
 	cursor := beforeCreatedAt
 	if beforeCreatedAt.IsZero() {
 		cursor = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)
 	}
-	if tenantID.IsZero() {
-		rows, err = r.pool.Query(ctx, `SELECT payload FROM project_analyses
-			WHERE project_id=$1 AND (created_at < $2 OR (created_at = $2 AND id COLLATE "C" < $3))
-			ORDER BY created_at DESC, id COLLATE "C" DESC LIMIT $4`, projectID.String(), cursor, beforeID.String(), limit+1)
-	} else {
-		rows, err = r.pool.Query(ctx, `SELECT payload FROM project_analyses
-			WHERE tenant_id=$1 AND project_id=$2 AND (created_at < $3 OR (created_at = $3 AND id COLLATE "C" < $4))
-			ORDER BY created_at DESC, id COLLATE "C" DESC LIMIT $5`, tenantID.String(), projectID.String(), cursor, beforeID.String(), limit+1)
-	}
-	if err != nil {
-		return nil, false, fmt.Errorf("list project analyses: %w", err)
-	}
-	defer rows.Close()
-	out := make([]projectanalysis.Analysis, 0, limit+1)
-	for rows.Next() {
-		analysis, err := scanProjectAnalysis(rows)
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT payload FROM project_analyses WHERE tenant_id=$1 AND project_id=$2 AND (created_at < $3 OR (created_at = $3 AND id COLLATE "C" < $4)) ORDER BY created_at DESC, id COLLATE "C" DESC LIMIT $5`, tenantID.String(), projectID.String(), cursor, beforeID.String(), limit+1)
 		if err != nil {
-			return nil, false, err
+			return fmt.Errorf("list project analyses: %w", err)
 		}
-		out = append(out, analysis)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, false, err
-	}
-	hasMore := len(out) > limit
-	if hasMore {
-		out = out[:limit]
-	}
-	return out, hasMore, nil
+		defer rows.Close()
+		out = make([]projectanalysis.Analysis, 0, limit+1)
+		for rows.Next() {
+			analysis, err := scanProjectAnalysis(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, analysis)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		hasMore = len(out) > limit
+		if hasMore {
+			out = out[:limit]
+		}
+		return nil
+	})
+	return out, hasMore, err
 }
 
-func (r *ProjectAnalysisStore) Get(ctx context.Context, tenantID, projectID, analysisID shared.ID) (projectanalysis.Analysis, error) {
-	var row pgx.Row
-	if tenantID.IsZero() {
-		row = r.pool.QueryRow(ctx, `SELECT payload FROM project_analyses WHERE project_id=$1 AND id=$2`, projectID.String(), analysisID.String())
-	} else {
-		row = r.pool.QueryRow(ctx, `SELECT payload FROM project_analyses WHERE tenant_id=$1 AND project_id=$2 AND id=$3`, tenantID.String(), projectID.String(), analysisID.String())
-	}
-	analysis, err := scanProjectAnalysis(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return projectanalysis.Analysis{}, shared.ErrNotFound
-	}
-	if err != nil {
-		return projectanalysis.Analysis{}, fmt.Errorf("get project analysis: %w", err)
-	}
-	return analysis, nil
+func (r *ProjectAnalysisStore) Get(ctx context.Context, tenantID, projectID, analysisID shared.ID) (analysis projectanalysis.Analysis, err error) {
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		analysis, err = scanProjectAnalysis(tx.QueryRow(ctx, `SELECT payload FROM project_analyses WHERE tenant_id=$1 AND project_id=$2 AND id=$3`, tenantID.String(), projectID.String(), analysisID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get project analysis: %w", err)
+		}
+		return nil
+	})
+	return analysis, err
 }
 
 func scanProjectAnalysis(row rowScanner) (projectanalysis.Analysis, error) {

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store.go
@@ -162,75 +162,77 @@ func upsertHotspotsTx(ctx context.Context, tx pgx.Tx, analysis projectanalysis.A
 }
 
 func (r *ProjectAnalysisStore) ListHotspots(ctx context.Context, tenantID, projectID shared.ID, filter hotspot.ListFilter) (hotspot.Page, error) {
-	where, args, joins := hotspotWhere(tenantID, projectID, filter, true)
-	limit := filter.Limit
-	if limit <= 0 {
-		limit = 25
-	}
-	args = append(args, limit+1)
-	query := `SELECT ph.id, ph.tenant_id, ph.project_id, ph.hotspot_key, ph.finding_identity, ph.rule_key, ph.title, ph.description, ph.severity, ph.finding_kind, ph.cwe, ph.location, ph.source_file, ph.start_line, ph.end_line, ph.start_column, ph.end_column,
-		ph.status, ph.version, ph.first_seen_analysis_id, ph.last_seen_analysis_id, ph.first_seen_at, ph.last_seen_at, ph.created_at, ph.updated_at, ph.last_reviewed_by, ph.last_reviewed_at
-		FROM project_hotspots ph ` + joins + ` WHERE ` + where + ` ORDER BY ph.last_seen_at DESC, ph.id COLLATE "C" DESC LIMIT $` + fmt.Sprint(len(args))
-	rows, err := r.pool.Query(ctx, query, args...)
-	if err != nil {
-		return hotspot.Page{}, fmt.Errorf("list project hotspots: %w", err)
-	}
-	defer rows.Close()
-	items := make([]hotspot.Hotspot, 0, limit+1)
-	for rows.Next() {
-		item, err := scanHotspot(rows)
-		if err != nil {
-			return hotspot.Page{}, fmt.Errorf("scan project hotspot: %w", err)
+	var page hotspot.Page
+	err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		where, args, joins := hotspotWhere(tenantID, projectID, filter, true)
+		limit := filter.Limit
+		if limit <= 0 {
+			limit = 25
 		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
+		args = append(args, limit+1)
+		query := `SELECT ph.id, ph.tenant_id, ph.project_id, ph.hotspot_key, ph.finding_identity, ph.rule_key, ph.title, ph.description, ph.severity, ph.finding_kind, ph.cwe, ph.location, ph.source_file, ph.start_line, ph.end_line, ph.start_column, ph.end_column,
+			ph.status, ph.version, ph.first_seen_analysis_id, ph.last_seen_analysis_id, ph.first_seen_at, ph.last_seen_at, ph.created_at, ph.updated_at, ph.last_reviewed_by, ph.last_reviewed_at
+			FROM project_hotspots ph ` + joins + ` WHERE ` + where + ` ORDER BY ph.last_seen_at DESC, ph.id COLLATE "C" DESC LIMIT $` + fmt.Sprint(len(args))
+		rows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("list project hotspots: %w", err)
+		}
+		items := make([]hotspot.Hotspot, 0, limit+1)
+		for rows.Next() {
+			item, err := scanHotspot(rows)
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("scan project hotspot: %w", err)
+			}
+			items = append(items, item)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		rows.Close()
+		if len(items) > limit {
+			last := items[limit-1]
+			page.Next = &hotspot.Cursor{BeforeLastSeenAt: last.LastSeenAt, BeforeID: last.ID}
+			items = items[:limit]
+		}
+		page.Items = items
+		facetWhere, facetArgs, facetJoins := hotspotWhere(tenantID, projectID, filter, false)
+		var total, reviewed int
+		if err := tx.QueryRow(ctx, `SELECT count(*), count(*) FILTER (WHERE ph.status IN ('acknowledged', 'fixed', 'safe')) FROM project_hotspots ph `+facetJoins+` WHERE `+facetWhere, facetArgs...).Scan(&total, &reviewed); err != nil {
+			return fmt.Errorf("summary project hotspots: %w", err)
+		}
+		summary, _ := hotspot.NewSummary(total, reviewed)
+		page.Summary = summary
+		facetRows, err := tx.Query(ctx, `SELECT 'status' as kind, ph.status as value, count(*) FROM project_hotspots ph `+facetJoins+` WHERE `+facetWhere+` GROUP BY ph.status
+			UNION ALL SELECT 'rule', ph.rule_key, count(*) FROM project_hotspots ph `+facetJoins+` WHERE `+facetWhere+` GROUP BY ph.rule_key
+			UNION ALL SELECT 'severity', ph.severity, count(*) FROM project_hotspots ph `+facetJoins+` WHERE `+facetWhere+` GROUP BY ph.severity`, facetArgs...)
+		if err != nil {
+			return fmt.Errorf("facet project hotspots: %w", err)
+		}
+		defer facetRows.Close()
+		page.Facets = hotspot.Facets{Statuses: map[string]int{}, RuleKeys: map[string]int{}, Severities: map[string]int{}}
+		for facetRows.Next() {
+			var kind, value string
+			var count int
+			if err := facetRows.Scan(&kind, &value, &count); err != nil {
+				return fmt.Errorf("scan project hotspot facet: %w", err)
+			}
+			switch kind {
+			case "status":
+				page.Facets.Statuses[value] = count
+			case "rule":
+				page.Facets.RuleKeys[value] = count
+			case "severity":
+				page.Facets.Severities[value] = count
+			}
+		}
+		return facetRows.Err()
+	})
+	if err != nil {
 		return hotspot.Page{}, err
 	}
-	page := hotspot.Page{}
-	if len(items) > limit {
-		last := items[limit-1]
-		page.Next = &hotspot.Cursor{BeforeLastSeenAt: last.LastSeenAt, BeforeID: last.ID}
-		items = items[:limit]
-	}
-	page.Items = items
-
-	facetWhere, facetArgs, facetJoins := hotspotWhere(tenantID, projectID, filter, false)
-
-	// Query Summary
-	var total, reviewed int
-	err = r.pool.QueryRow(ctx, `SELECT count(*), count(*) FILTER (WHERE ph.status IN ('acknowledged', 'fixed', 'safe')) FROM project_hotspots ph `+facetJoins+` WHERE `+facetWhere, facetArgs...).Scan(&total, &reviewed)
-	if err != nil {
-		return hotspot.Page{}, fmt.Errorf("summary project hotspots: %w", err)
-	}
-
-	summary, _ := hotspot.NewSummary(total, reviewed)
-	page.Summary = summary
-
-	facetRows, err := r.pool.Query(ctx, `SELECT 'status' as kind, ph.status as value, count(*) FROM project_hotspots ph `+facetJoins+` WHERE `+facetWhere+` GROUP BY ph.status
-		UNION ALL SELECT 'rule', ph.rule_key, count(*) FROM project_hotspots ph `+facetJoins+` WHERE `+facetWhere+` GROUP BY ph.rule_key
-		UNION ALL SELECT 'severity', ph.severity, count(*) FROM project_hotspots ph `+facetJoins+` WHERE `+facetWhere+` GROUP BY ph.severity`, facetArgs...)
-	if err != nil {
-		return hotspot.Page{}, fmt.Errorf("facet project hotspots: %w", err)
-	}
-	defer facetRows.Close()
-	page.Facets = hotspot.Facets{Statuses: map[string]int{}, RuleKeys: map[string]int{}, Severities: map[string]int{}}
-	for facetRows.Next() {
-		var kind, value string
-		var count int
-		if err := facetRows.Scan(&kind, &value, &count); err != nil {
-			return hotspot.Page{}, fmt.Errorf("scan project hotspot facet: %w", err)
-		}
-		switch kind {
-		case "status":
-			page.Facets.Statuses[value] = count
-		case "rule":
-			page.Facets.RuleKeys[value] = count
-		case "severity":
-			page.Facets.Severities[value] = count
-		}
-	}
-	return page, facetRows.Err()
+	return page, nil
 }
 
 func hotspotSearchPattern(value string) string {

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store.go
@@ -540,35 +540,31 @@ func (r *ProjectAnalysisStore) ListAnalysisHotspots(ctx context.Context, tenantI
 }
 
 func (r *ProjectAnalysisStore) CurrentAnalysisHotspotSummary(ctx context.Context, tenantID, projectID, analysisID shared.ID, lens hotspot.Lens) (hotspot.Summary, error) {
-	// Query current statuses of hotspots that were in the analysis
-	q := `SELECT h.status FROM project_hotspots h JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id WHERE h.tenant_id=$1 AND h.project_id=$2 AND ah.analysis_id=$3`
-	if lens == hotspot.LensNewCode {
-		q += ` AND ah.is_new = true`
-	}
-
-	rows, err := r.pool.Query(ctx, q, tenantID.String(), projectID.String(), analysisID.String())
+	var total, reviewed int
+	err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		q := `SELECT h.status FROM project_hotspots h JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id WHERE h.tenant_id=$1 AND h.project_id=$2 AND ah.analysis_id=$3`
+		if lens == hotspot.LensNewCode {
+			q += ` AND ah.is_new = true`
+		}
+		rows, err := tx.Query(ctx, q, tenantID.String(), projectID.String(), analysisID.String())
+		if err != nil {
+			return fmt.Errorf("query analysis hotspot summary: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var status string
+			if err := rows.Scan(&status); err != nil {
+				return err
+			}
+			total++
+			if hotspot.Status(status).Reviewed() {
+				reviewed++
+			}
+		}
+		return rows.Err()
+	})
 	if err != nil {
-		return hotspot.Summary{}, fmt.Errorf("query analysis hotspot summary: %w", err)
-	}
-	defer rows.Close()
-
-	total := 0
-	reviewed := 0
-
-	for rows.Next() {
-		var status string
-		if err := rows.Scan(&status); err != nil {
-			return hotspot.Summary{}, err
-		}
-		total++
-		if hotspot.Status(status).Reviewed() {
-			reviewed++
-		}
-	}
-
-	if err := rows.Err(); err != nil {
 		return hotspot.Summary{}, err
 	}
-
 	return hotspot.NewSummary(total, reviewed)
 }

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store.go
@@ -318,6 +318,9 @@ func (r *ProjectAnalysisStore) TransitionHotspot(ctx context.Context, cmd hotspo
 		return hotspot.Hotspot{}, hotspot.ReviewEvent{}, fmt.Errorf("begin transition tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.tenant_id', $1, true)", cmd.TenantID.String()); err != nil {
+		return hotspot.Hotspot{}, hotspot.ReviewEvent{}, fmt.Errorf("set hotspot transition tenant context: %w", err)
+	}
 
 	// Lock the row
 	row := tx.QueryRow(ctx, `SELECT id, tenant_id, project_id, hotspot_key, finding_identity, rule_key, title, description, severity, finding_kind, cwe, location, source_file, start_line, end_line, start_column, end_column,

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store.go
@@ -275,15 +275,22 @@ func hotspotWhere(tenantID, projectID shared.ID, filter hotspot.ListFilter, curs
 	return strings.Join(parts, " AND "), args, joins
 }
 func (r *ProjectAnalysisStore) GetHotspot(ctx context.Context, tenantID, projectID, hotspotID shared.ID) (hotspot.Hotspot, error) {
-	row := r.pool.QueryRow(ctx, `SELECT id, tenant_id, project_id, hotspot_key, finding_identity, rule_key, title, description, severity, finding_kind, cwe, location, source_file, start_line, end_line, start_column, end_column,
-		status, version, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at, last_reviewed_by, last_reviewed_at
-		FROM project_hotspots WHERE tenant_id=$1 AND project_id=$2 AND id=$3`, tenantID.String(), projectID.String(), hotspotID.String())
-	item, err := scanHotspot(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return hotspot.Hotspot{}, shared.ErrNotFound
-	}
+	var item hotspot.Hotspot
+	err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		var err error
+		item, err = scanHotspot(tx.QueryRow(ctx, `SELECT id, tenant_id, project_id, hotspot_key, finding_identity, rule_key, title, description, severity, finding_kind, cwe, location, source_file, start_line, end_line, start_column, end_column,
+			status, version, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at, last_reviewed_by, last_reviewed_at
+			FROM project_hotspots WHERE tenant_id=$1 AND project_id=$2 AND id=$3`, tenantID.String(), projectID.String(), hotspotID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get project hotspot: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return hotspot.Hotspot{}, fmt.Errorf("get project hotspot: %w", err)
+		return hotspot.Hotspot{}, err
 	}
 	return item, nil
 }

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store.go
@@ -400,142 +400,104 @@ func (r *ProjectAnalysisStore) HotspotHistory(ctx context.Context, tenantID, pro
 }
 
 func (r *ProjectAnalysisStore) ListAnalysisHotspots(ctx context.Context, tenantID, projectID, analysisID shared.ID, lens hotspot.Lens, filter hotspot.ListFilter) (hotspot.Page, hotspot.Summary, error) {
-	// First compute summary
 	summary, err := r.CurrentAnalysisHotspotSummary(ctx, tenantID, projectID, analysisID, lens)
 	if err != nil {
 		return hotspot.Page{}, hotspot.Summary{}, err
 	}
-
-	// We join project_hotspots with project_analysis_hotspots.
-	// Since we need to use the mutable status for ListHotspots (as required by "Overview updates immediately after a review"),
-	// the list returns the CURRENT state of hotspots that were present in that analysis.
-	// We filter by `is_new` if lens == NewCode.
-
-	args := []any{tenantID.String(), projectID.String(), analysisID.String()}
-	parts := []string{"h.tenant_id = $1", "h.project_id = $2", "ah.analysis_id = $3"}
-	add := func(part string, value any) {
-		args = append(args, value)
-		parts = append(parts, fmt.Sprintf(part, len(args)))
-	}
-
-	if lens == hotspot.LensNewCode {
-		parts = append(parts, "ah.is_new = true")
-	}
-
-	if filter.Status != nil {
-		add("h.status = $%d", string(*filter.Status))
-	}
-	if filter.Severity != nil {
-		add("h.severity = $%d", string(*filter.Severity))
-	}
-	if filter.RuleKey != "" {
-		add("h.rule_key = $%d", filter.RuleKey)
-	}
-	if search := strings.TrimSpace(filter.Search); search != "" {
-		searchArg := len(args) + 1
-		pattern := hotspotSearchPattern(search)
-
-		args = append(args, pattern, pattern, pattern, pattern, pattern)
-		parts = append(parts, fmt.Sprintf(
-			`(h.hotspot_key ILIKE $%d OR
-			  h.rule_key ILIKE $%d OR
-			  h.title ILIKE $%d OR
-			  h.description ILIKE $%d OR
-			  h.location ILIKE $%d)`,
-			searchArg,
-			searchArg+1,
-			searchArg+2,
-			searchArg+3,
-			searchArg+4,
-		))
-	}
-
-	facetWhere := strings.Join(parts, " AND ")
-	facetArgs := append([]any(nil), args...)
-
-	if !filter.BeforeLastSeenAt.IsZero() {
-		args = append(
-			args,
-			filter.BeforeLastSeenAt,
-			filter.BeforeID.String(),
-		)
-		atArg := len(args) - 1
-		idArg := len(args)
-
-		parts = append(parts, fmt.Sprintf(
-			`(h.last_seen_at < $%d OR
-			  (h.last_seen_at = $%d AND h.id COLLATE "C" < $%d))`,
-			atArg,
-			atArg,
-			idArg,
-		))
-	}
-
-	listWhere := strings.Join(parts, " AND ")
-	limit := filter.Limit
-	if limit <= 0 {
-		limit = 25
-	}
-
-	query := `SELECT h.id, h.tenant_id, h.project_id, h.hotspot_key, h.finding_identity, h.rule_key, h.title, h.description, h.severity, h.finding_kind, h.cwe, h.location, h.source_file, h.start_line, h.end_line, h.start_column, h.end_column,
-		h.status, h.version, h.first_seen_analysis_id, h.last_seen_analysis_id, h.first_seen_at, h.last_seen_at, h.created_at, h.updated_at, h.last_reviewed_by, h.last_reviewed_at
-		FROM project_hotspots h
-		JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id
-		WHERE ` + listWhere + ` ORDER BY h.last_seen_at DESC, h.id COLLATE "C" DESC LIMIT $` + fmt.Sprint(len(args)+1)
-
-	args = append(args, limit+1)
-
-	rows, err := r.pool.Query(ctx, query, args...)
-	if err != nil {
-		return hotspot.Page{}, hotspot.Summary{}, fmt.Errorf("list analysis hotspots: %w", err)
-	}
-	defer rows.Close()
-
-	var items []hotspot.Hotspot
-	for rows.Next() {
-		item, err := scanHotspot(rows)
-		if err != nil {
-			return hotspot.Page{}, hotspot.Summary{}, fmt.Errorf("scan analysis hotspot: %w", err)
+	var page hotspot.Page
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		args := []any{tenantID.String(), projectID.String(), analysisID.String()}
+		parts := []string{"h.tenant_id = $1", "h.project_id = $2", "ah.analysis_id = $3"}
+		add := func(part string, value any) {
+			args = append(args, value)
+			parts = append(parts, fmt.Sprintf(part, len(args)))
 		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
+		if lens == hotspot.LensNewCode {
+			parts = append(parts, "ah.is_new = true")
+		}
+		if filter.Status != nil {
+			add("h.status = $%d", string(*filter.Status))
+		}
+		if filter.Severity != nil {
+			add("h.severity = $%d", string(*filter.Severity))
+		}
+		if filter.RuleKey != "" {
+			add("h.rule_key = $%d", filter.RuleKey)
+		}
+		if search := strings.TrimSpace(filter.Search); search != "" {
+			searchArg := len(args) + 1
+			pattern := hotspotSearchPattern(search)
+			args = append(args, pattern, pattern, pattern, pattern, pattern)
+			parts = append(parts, fmt.Sprintf(`(h.hotspot_key ILIKE $%d OR h.rule_key ILIKE $%d OR h.title ILIKE $%d OR h.description ILIKE $%d OR h.location ILIKE $%d)`, searchArg, searchArg+1, searchArg+2, searchArg+3, searchArg+4))
+		}
+		facetWhere := strings.Join(parts, " AND ")
+		facetArgs := append([]any(nil), args...)
+		if !filter.BeforeLastSeenAt.IsZero() {
+			args = append(args, filter.BeforeLastSeenAt, filter.BeforeID.String())
+			atArg, idArg := len(args)-1, len(args)
+			parts = append(parts, fmt.Sprintf(`(h.last_seen_at < $%d OR (h.last_seen_at = $%d AND h.id COLLATE "C" < $%d))`, atArg, atArg, idArg))
+		}
+		limit := filter.Limit
+		if limit <= 0 {
+			limit = 25
+		}
+		query := `SELECT h.id, h.tenant_id, h.project_id, h.hotspot_key, h.finding_identity, h.rule_key, h.title, h.description, h.severity, h.finding_kind, h.cwe, h.location, h.source_file, h.start_line, h.end_line, h.start_column, h.end_column,
+			h.status, h.version, h.first_seen_analysis_id, h.last_seen_analysis_id, h.first_seen_at, h.last_seen_at, h.created_at, h.updated_at, h.last_reviewed_by, h.last_reviewed_at
+			FROM project_hotspots h JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id
+			WHERE ` + strings.Join(parts, " AND ") + ` ORDER BY h.last_seen_at DESC, h.id COLLATE "C" DESC LIMIT $` + fmt.Sprint(len(args)+1)
+		args = append(args, limit+1)
+		rows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("list analysis hotspots: %w", err)
+		}
+		var items []hotspot.Hotspot
+		for rows.Next() {
+			item, err := scanHotspot(rows)
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("scan analysis hotspot: %w", err)
+			}
+			items = append(items, item)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		rows.Close()
+		if len(items) > limit {
+			last := items[limit-1]
+			page.Next = &hotspot.Cursor{BeforeLastSeenAt: last.LastSeenAt, BeforeID: last.ID}
+			items = items[:limit]
+		}
+		page.Items = items
+		facetRows, err := tx.Query(ctx, `SELECT 'status', h.status, count(*) FROM project_hotspots h JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id WHERE `+facetWhere+` GROUP BY h.status
+			UNION ALL SELECT 'rule', h.rule_key, count(*) FROM project_hotspots h JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id WHERE `+facetWhere+` GROUP BY h.rule_key
+			UNION ALL SELECT 'severity', h.severity, count(*) FROM project_hotspots h JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id WHERE `+facetWhere+` GROUP BY h.severity`, facetArgs...)
+		if err != nil {
+			return fmt.Errorf("facet analysis hotspots: %w", err)
+		}
+		defer facetRows.Close()
+		page.Facets = hotspot.Facets{Statuses: map[string]int{}, RuleKeys: map[string]int{}, Severities: map[string]int{}}
+		for facetRows.Next() {
+			var kind, value string
+			var count int
+			if err := facetRows.Scan(&kind, &value, &count); err != nil {
+				return fmt.Errorf("scan analysis hotspot facet: %w", err)
+			}
+			switch kind {
+			case "status":
+				page.Facets.Statuses[value] = count
+			case "rule":
+				page.Facets.RuleKeys[value] = count
+			case "severity":
+				page.Facets.Severities[value] = count
+			}
+		}
+		return facetRows.Err()
+	})
+	if err != nil {
 		return hotspot.Page{}, hotspot.Summary{}, err
 	}
-
-	page := hotspot.Page{}
-	if len(items) > limit {
-		last := items[limit-1]
-		page.Next = &hotspot.Cursor{BeforeLastSeenAt: last.LastSeenAt, BeforeID: last.ID}
-		items = items[:limit]
-	}
-	page.Items = items
-
-	// Facets (current statuses, etc)
-	facetRows, err := r.pool.Query(ctx, `SELECT 'status', h.status, count(*) FROM project_hotspots h JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id WHERE `+facetWhere+` GROUP BY h.status
-		UNION ALL SELECT 'rule', h.rule_key, count(*) FROM project_hotspots h JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id WHERE `+facetWhere+` GROUP BY h.rule_key
-		UNION ALL SELECT 'severity', h.severity, count(*) FROM project_hotspots h JOIN project_analysis_hotspots ah ON h.id = ah.hotspot_id WHERE `+facetWhere+` GROUP BY h.severity`, facetArgs...)
-	if err != nil {
-		return hotspot.Page{}, hotspot.Summary{}, fmt.Errorf("facet analysis hotspots: %w", err)
-	}
-	defer facetRows.Close()
-	page.Facets = hotspot.Facets{Statuses: map[string]int{}, RuleKeys: map[string]int{}, Severities: map[string]int{}}
-	for facetRows.Next() {
-		var kind, value string
-		var count int
-		if err := facetRows.Scan(&kind, &value, &count); err != nil {
-			return hotspot.Page{}, hotspot.Summary{}, fmt.Errorf("scan analysis hotspot facet: %w", err)
-		}
-		switch kind {
-		case "status":
-			page.Facets.Statuses[value] = count
-		case "rule":
-			page.Facets.RuleKeys[value] = count
-		case "severity":
-			page.Facets.Severities[value] = count
-		}
-	}
-
 	return page, summary, nil
 }
 

--- a/internal/infrastructure/persistence/postgres/project_hotspot_store.go
+++ b/internal/infrastructure/persistence/postgres/project_hotspot_store.go
@@ -369,31 +369,32 @@ func (r *ProjectAnalysisStore) TransitionHotspot(ctx context.Context, cmd hotspo
 }
 
 func (r *ProjectAnalysisStore) HotspotHistory(ctx context.Context, tenantID, projectID, hotspotID shared.ID) ([]hotspot.ReviewEvent, error) {
-	rows, err := r.pool.Query(ctx, `SELECT id, tenant_id, project_id, hotspot_id, from_status, to_status, actor, rationale, previous_version, version, created_at
-		FROM project_hotspot_review_events 
-		WHERE tenant_id=$1 AND project_id=$2 AND hotspot_id=$3 
-		ORDER BY version DESC, id COLLATE "C" DESC`, tenantID.String(), projectID.String(), hotspotID.String())
-	if err != nil {
-		return nil, fmt.Errorf("query review events: %w", err)
-	}
-	defer rows.Close()
-
 	var events []hotspot.ReviewEvent
-	for rows.Next() {
-		var e hotspot.ReviewEvent
-		var id, tID, pID, hID, from, to string
-		if err := rows.Scan(&id, &tID, &pID, &hID, &from, &to, &e.Actor, &e.Rationale, &e.PreviousVersion, &e.Version, &e.CreatedAt); err != nil {
-			return nil, fmt.Errorf("scan review event: %w", err)
+	err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id, tenant_id, project_id, hotspot_id, from_status, to_status, actor, rationale, previous_version, version, created_at
+			FROM project_hotspot_review_events
+			WHERE tenant_id=$1 AND project_id=$2 AND hotspot_id=$3
+			ORDER BY version DESC, id COLLATE "C" DESC`, tenantID.String(), projectID.String(), hotspotID.String())
+		if err != nil {
+			return fmt.Errorf("query review events: %w", err)
 		}
-		e.ID = shared.ID(id)
-		e.TenantID = shared.ID(tID)
-		e.ProjectID = shared.ID(pID)
-		e.HotspotID = shared.ID(hID)
-		e.From = hotspot.Status(from)
-		e.To = hotspot.Status(to)
-		events = append(events, e)
+		defer rows.Close()
+		for rows.Next() {
+			var e hotspot.ReviewEvent
+			var id, tID, pID, hID, from, to string
+			if err := rows.Scan(&id, &tID, &pID, &hID, &from, &to, &e.Actor, &e.Rationale, &e.PreviousVersion, &e.Version, &e.CreatedAt); err != nil {
+				return fmt.Errorf("scan review event: %w", err)
+			}
+			e.ID, e.TenantID, e.ProjectID, e.HotspotID = shared.ID(id), shared.ID(tID), shared.ID(pID), shared.ID(hID)
+			e.From, e.To = hotspot.Status(from), hotspot.Status(to)
+			events = append(events, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return events, rows.Err()
+	return events, nil
 }
 
 func (r *ProjectAnalysisStore) ListAnalysisHotspots(ctx context.Context, tenantID, projectID, analysisID shared.ID, lens hotspot.Lens, filter hotspot.ListFilter) (hotspot.Page, hotspot.Summary, error) {

--- a/internal/infrastructure/persistence/postgres/project_issue_store.go
+++ b/internal/infrastructure/persistence/postgres/project_issue_store.go
@@ -129,82 +129,85 @@ func upsertIssuesTx(ctx context.Context, tx pgx.Tx, items []issue.Issue) error {
 }
 
 func (r *ProjectAnalysisStore) ListIssues(ctx context.Context, tenantID, projectID shared.ID, filter issue.ListFilter) (issue.Page, error) {
-	where, args := issueWhere(tenantID, projectID, filter, true)
-	limit := filter.Limit
-	if limit <= 0 {
-		limit = 25
-	}
-	args = append(args, limit+1)
-	query := `SELECT id, tenant_id, project_id, issue_key, finding_identity, rule_key, issue_type, title, description, severity, finding_kind, cwe, language, file, location, source_file, start_line, end_line, start_column, end_column,
-		status, version, is_new, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at, last_reviewed_by, last_reviewed_at
-		FROM project_issues WHERE ` + where + ` ORDER BY last_seen_at DESC, id COLLATE "C" DESC LIMIT $` + fmt.Sprint(len(args))
-	rows, err := r.pool.Query(ctx, query, args...)
-	if err != nil {
-		return issue.Page{}, fmt.Errorf("list project issues: %w", err)
-	}
-	defer rows.Close()
-	items := make([]issue.Issue, 0, limit+1)
-	for rows.Next() {
-		item, err := scanIssue(rows)
-		if err != nil {
-			return issue.Page{}, fmt.Errorf("scan project issue: %w", err)
+	var page issue.Page
+	err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		where, args := issueWhere(tenantID, projectID, filter, true)
+		limit := filter.Limit
+		if limit <= 0 {
+			limit = 25
 		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
+		args = append(args, limit+1)
+		query := `SELECT id, tenant_id, project_id, issue_key, finding_identity, rule_key, issue_type, title, description, severity, finding_kind, cwe, language, file, location, source_file, start_line, end_line, start_column, end_column,
+			status, version, is_new, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at, last_reviewed_by, last_reviewed_at
+			FROM project_issues WHERE ` + where + ` ORDER BY last_seen_at DESC, id COLLATE "C" DESC LIMIT $` + fmt.Sprint(len(args))
+		rows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("list project issues: %w", err)
+		}
+		items := make([]issue.Issue, 0, limit+1)
+		for rows.Next() {
+			item, err := scanIssue(rows)
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("scan project issue: %w", err)
+			}
+			items = append(items, item)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		rows.Close()
+		if len(items) > limit {
+			last := items[limit-1]
+			page.Next = &issue.Cursor{BeforeLastSeenAt: last.LastSeenAt, BeforeID: last.ID}
+			items = items[:limit]
+		}
+		page.Items = items
+		facetWhere, facetArgs := issueWhere(tenantID, projectID, filter, false)
+		var total, open, resolved int
+		if err := tx.QueryRow(ctx, `SELECT count(*),
+			count(*) FILTER (WHERE status = 'open'),
+			count(*) FILTER (WHERE status IN ('accepted','false_positive','wont_fix'))
+			FROM project_issues WHERE `+facetWhere, facetArgs...).Scan(&total, &open, &resolved); err != nil {
+			return fmt.Errorf("summary project issues: %w", err)
+		}
+		page.Summary = issue.Summary{Total: total, Open: open, Resolved: resolved}
+		facetRows, err := tx.Query(ctx, `SELECT 'type' AS kind, issue_type AS value, count(*) FROM project_issues WHERE `+facetWhere+` GROUP BY issue_type
+			UNION ALL SELECT 'status', status, count(*) FROM project_issues WHERE `+facetWhere+` GROUP BY status
+			UNION ALL SELECT 'severity', severity, count(*) FROM project_issues WHERE `+facetWhere+` GROUP BY severity
+			UNION ALL SELECT 'rule', rule_key, count(*) FROM project_issues WHERE `+facetWhere+` GROUP BY rule_key
+			UNION ALL SELECT 'language', language, count(*) FROM project_issues WHERE `+facetWhere+` AND language <> '' GROUP BY language`, facetArgs...)
+		if err != nil {
+			return fmt.Errorf("facet project issues: %w", err)
+		}
+		defer facetRows.Close()
+		page.Facets = issue.Facets{Types: map[string]int{}, Statuses: map[string]int{}, Severities: map[string]int{}, RuleKeys: map[string]int{}, Languages: map[string]int{}}
+		for facetRows.Next() {
+			var kind, value string
+			var count int
+			if err := facetRows.Scan(&kind, &value, &count); err != nil {
+				return fmt.Errorf("scan project issue facet: %w", err)
+			}
+			switch kind {
+			case "type":
+				page.Facets.Types[value] = count
+			case "status":
+				page.Facets.Statuses[value] = count
+			case "severity":
+				page.Facets.Severities[value] = count
+			case "rule":
+				page.Facets.RuleKeys[value] = count
+			case "language":
+				page.Facets.Languages[value] = count
+			}
+		}
+		return facetRows.Err()
+	})
+	if err != nil {
 		return issue.Page{}, err
 	}
-	page := issue.Page{}
-	if len(items) > limit {
-		last := items[limit-1]
-		page.Next = &issue.Cursor{BeforeLastSeenAt: last.LastSeenAt, BeforeID: last.ID}
-		items = items[:limit]
-	}
-	page.Items = items
-
-	// Facets and summary are computed over the filtered (but unpaginated) set: the
-	// cursor is deliberately excluded so paging never shrinks the counts.
-	facetWhere, facetArgs := issueWhere(tenantID, projectID, filter, false)
-
-	var total, open, resolved int
-	if err := r.pool.QueryRow(ctx, `SELECT count(*),
-		count(*) FILTER (WHERE status = 'open'),
-		count(*) FILTER (WHERE status IN ('accepted','false_positive','wont_fix'))
-		FROM project_issues WHERE `+facetWhere, facetArgs...).Scan(&total, &open, &resolved); err != nil {
-		return issue.Page{}, fmt.Errorf("summary project issues: %w", err)
-	}
-	page.Summary = issue.Summary{Total: total, Open: open, Resolved: resolved}
-
-	facetRows, err := r.pool.Query(ctx, `SELECT 'type' AS kind, issue_type AS value, count(*) FROM project_issues WHERE `+facetWhere+` GROUP BY issue_type
-		UNION ALL SELECT 'status', status, count(*) FROM project_issues WHERE `+facetWhere+` GROUP BY status
-		UNION ALL SELECT 'severity', severity, count(*) FROM project_issues WHERE `+facetWhere+` GROUP BY severity
-		UNION ALL SELECT 'rule', rule_key, count(*) FROM project_issues WHERE `+facetWhere+` GROUP BY rule_key
-		UNION ALL SELECT 'language', language, count(*) FROM project_issues WHERE `+facetWhere+` AND language <> '' GROUP BY language`, facetArgs...)
-	if err != nil {
-		return issue.Page{}, fmt.Errorf("facet project issues: %w", err)
-	}
-	defer facetRows.Close()
-	page.Facets = issue.Facets{Types: map[string]int{}, Statuses: map[string]int{}, Severities: map[string]int{}, RuleKeys: map[string]int{}, Languages: map[string]int{}}
-	for facetRows.Next() {
-		var kind, value string
-		var count int
-		if err := facetRows.Scan(&kind, &value, &count); err != nil {
-			return issue.Page{}, fmt.Errorf("scan project issue facet: %w", err)
-		}
-		switch kind {
-		case "type":
-			page.Facets.Types[value] = count
-		case "status":
-			page.Facets.Statuses[value] = count
-		case "severity":
-			page.Facets.Severities[value] = count
-		case "rule":
-			page.Facets.RuleKeys[value] = count
-		case "language":
-			page.Facets.Languages[value] = count
-		}
-	}
-	return page, facetRows.Err()
+	return page, nil
 }
 
 func issueLikeEscape(value string) string {

--- a/internal/infrastructure/persistence/postgres/project_issue_store.go
+++ b/internal/infrastructure/persistence/postgres/project_issue_store.go
@@ -257,15 +257,22 @@ func issueWhere(tenantID, projectID shared.ID, filter issue.ListFilter, cursor b
 }
 
 func (r *ProjectAnalysisStore) GetIssue(ctx context.Context, tenantID, projectID, issueID shared.ID) (issue.Issue, error) {
-	row := r.pool.QueryRow(ctx, `SELECT id, tenant_id, project_id, issue_key, finding_identity, rule_key, issue_type, title, description, severity, finding_kind, cwe, language, file, location, source_file, start_line, end_line, start_column, end_column,
-		status, version, is_new, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at, last_reviewed_by, last_reviewed_at
-		FROM project_issues WHERE tenant_id=$1 AND project_id=$2 AND id=$3`, tenantID.String(), projectID.String(), issueID.String())
-	item, err := scanIssue(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return issue.Issue{}, shared.ErrNotFound
-	}
+	var item issue.Issue
+	err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		var err error
+		item, err = scanIssue(tx.QueryRow(ctx, `SELECT id, tenant_id, project_id, issue_key, finding_identity, rule_key, issue_type, title, description, severity, finding_kind, cwe, language, file, location, source_file, start_line, end_line, start_column, end_column,
+			status, version, is_new, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at, last_reviewed_by, last_reviewed_at
+			FROM project_issues WHERE tenant_id=$1 AND project_id=$2 AND id=$3`, tenantID.String(), projectID.String(), issueID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get project issue: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return issue.Issue{}, fmt.Errorf("get project issue: %w", err)
+		return issue.Issue{}, err
 	}
 	return item, nil
 }

--- a/internal/infrastructure/persistence/postgres/project_issue_store.go
+++ b/internal/infrastructure/persistence/postgres/project_issue_store.go
@@ -54,6 +54,9 @@ func (r *ProjectAnalysisStore) SaveWithResultAndProjections(ctx context.Context,
 		return fmt.Errorf("begin project analysis transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.tenant_id', $1, true)", analysis.TenantID); err != nil {
+		return fmt.Errorf("set project analysis tenant context: %w", err)
+	}
 
 	if _, err := tx.Exec(ctx, `INSERT INTO project_analyses (id, tenant_id, project_id, created_at, payload, result)
 		VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (id) DO NOTHING`,
@@ -298,6 +301,9 @@ func (r *ProjectAnalysisStore) TransitionIssue(ctx context.Context, cmd issue.Tr
 		return issue.Issue{}, issue.ReviewEvent{}, fmt.Errorf("begin issue transition tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.tenant_id', $1, true)", cmd.TenantID.String()); err != nil {
+		return issue.Issue{}, issue.ReviewEvent{}, fmt.Errorf("set issue transition tenant context: %w", err)
+	}
 
 	row := tx.QueryRow(ctx, `SELECT id, tenant_id, project_id, issue_key, finding_identity, rule_key, issue_type, title, description, severity, finding_kind, cwe, language, file, location, source_file, start_line, end_line, start_column, end_column,
 		status, version, is_new, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at, last_reviewed_by, last_reviewed_at

--- a/internal/infrastructure/persistence/postgres/project_issue_store.go
+++ b/internal/infrastructure/persistence/postgres/project_issue_store.go
@@ -403,37 +403,49 @@ func (r *ProjectAnalysisStore) CurrentFindingStatuses(ctx context.Context, tenan
 	if len(keys) == 0 {
 		return map[string]string{}, nil
 	}
-	rows, err := r.pool.Query(ctx, `SELECT issue_key, status FROM project_issues WHERE tenant_id=$1 AND project_id=$2 AND issue_key = ANY($3)
-		UNION ALL SELECT hotspot_key, status FROM project_hotspots WHERE tenant_id=$1 AND project_id=$2 AND hotspot_key = ANY($3)`, tenantID.String(), projectID.String(), keys)
-	if err != nil {
-		return nil, fmt.Errorf("query current finding statuses: %w", err)
-	}
-	defer rows.Close()
 	out := make(map[string]string, len(keys))
-	for rows.Next() {
-		var key, status string
-		if err := rows.Scan(&key, &status); err != nil {
-			return nil, fmt.Errorf("scan current finding status: %w", err)
+	err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT issue_key, status FROM project_issues WHERE tenant_id=$1 AND project_id=$2 AND issue_key = ANY($3)
+			UNION ALL SELECT hotspot_key, status FROM project_hotspots WHERE tenant_id=$1 AND project_id=$2 AND hotspot_key = ANY($3)`, tenantID.String(), projectID.String(), keys)
+		if err != nil {
+			return fmt.Errorf("query current finding statuses: %w", err)
 		}
-		out[key] = status
+		defer rows.Close()
+		for rows.Next() {
+			var key, status string
+			if err := rows.Scan(&key, &status); err != nil {
+				return fmt.Errorf("scan current finding status: %w", err)
+			}
+			out[key] = status
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 func (r *ProjectAnalysisStore) ResolvedIssueKeys(ctx context.Context, tenantID, projectID shared.ID) (map[string]bool, error) {
-	rows, err := r.pool.Query(ctx, `SELECT issue_key FROM project_issues
-		WHERE tenant_id=$1 AND project_id=$2 AND status IN ('accepted','false_positive','wont_fix')`, tenantID.String(), projectID.String())
-	if err != nil {
-		return nil, fmt.Errorf("query resolved issue keys: %w", err)
-	}
-	defer rows.Close()
 	out := map[string]bool{}
-	for rows.Next() {
-		var key string
-		if err := rows.Scan(&key); err != nil {
-			return nil, fmt.Errorf("scan resolved issue key: %w", err)
+	err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT issue_key FROM project_issues
+			WHERE tenant_id=$1 AND project_id=$2 AND status IN ('accepted','false_positive','wont_fix')`, tenantID.String(), projectID.String())
+		if err != nil {
+			return fmt.Errorf("query resolved issue keys: %w", err)
 		}
-		out[key] = true
+		defer rows.Close()
+		for rows.Next() {
+			var key string
+			if err := rows.Scan(&key); err != nil {
+				return fmt.Errorf("scan resolved issue key: %w", err)
+			}
+			out[key] = true
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }

--- a/internal/infrastructure/persistence/postgres/project_issue_store.go
+++ b/internal/infrastructure/persistence/postgres/project_issue_store.go
@@ -348,27 +348,32 @@ func (r *ProjectAnalysisStore) TransitionIssue(ctx context.Context, cmd issue.Tr
 }
 
 func (r *ProjectAnalysisStore) IssueHistory(ctx context.Context, tenantID, projectID, issueID shared.ID) ([]issue.ReviewEvent, error) {
-	rows, err := r.pool.Query(ctx, `SELECT id, tenant_id, project_id, issue_id, from_status, to_status, actor, rationale, previous_version, version, created_at
-		FROM project_issue_review_events
-		WHERE tenant_id=$1 AND project_id=$2 AND issue_id=$3
-		ORDER BY version DESC, id COLLATE "C" DESC`, tenantID.String(), projectID.String(), issueID.String())
-	if err != nil {
-		return nil, fmt.Errorf("query issue review events: %w", err)
-	}
-	defer rows.Close()
-
 	var events []issue.ReviewEvent
-	for rows.Next() {
-		var e issue.ReviewEvent
-		var id, tID, pID, iID, from, to string
-		if err := rows.Scan(&id, &tID, &pID, &iID, &from, &to, &e.Actor, &e.Rationale, &e.PreviousVersion, &e.Version, &e.CreatedAt); err != nil {
-			return nil, fmt.Errorf("scan issue review event: %w", err)
+	err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id, tenant_id, project_id, issue_id, from_status, to_status, actor, rationale, previous_version, version, created_at
+			FROM project_issue_review_events
+			WHERE tenant_id=$1 AND project_id=$2 AND issue_id=$3
+			ORDER BY version DESC, id COLLATE "C" DESC`, tenantID.String(), projectID.String(), issueID.String())
+		if err != nil {
+			return fmt.Errorf("query issue review events: %w", err)
 		}
-		e.ID, e.TenantID, e.ProjectID, e.IssueID = shared.ID(id), shared.ID(tID), shared.ID(pID), shared.ID(iID)
-		e.From, e.To = issue.Status(from), issue.Status(to)
-		events = append(events, e)
+		defer rows.Close()
+		for rows.Next() {
+			var e issue.ReviewEvent
+			var id, tID, pID, iID, from, to string
+			if err := rows.Scan(&id, &tID, &pID, &iID, &from, &to, &e.Actor, &e.Rationale, &e.PreviousVersion, &e.Version, &e.CreatedAt); err != nil {
+				return fmt.Errorf("scan issue review event: %w", err)
+			}
+			e.ID, e.TenantID, e.ProjectID, e.IssueID = shared.ID(id), shared.ID(tID), shared.ID(pID), shared.ID(iID)
+			e.From, e.To = issue.Status(from), issue.Status(to)
+			events = append(events, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return events, rows.Err()
+	return events, nil
 }
 
 func sourceLocationFields(location *finding.SourceLocation) (any, any, any, any, any) {

--- a/internal/infrastructure/persistence/postgres/project_repo.go
+++ b/internal/infrastructure/persistence/postgres/project_repo.go
@@ -27,7 +27,9 @@ func NewProjectRepository(pool *pgxpool.Pool) *ProjectRepository {
 var _ ports.ProjectRepository = (*ProjectRepository)(nil)
 
 func (r *ProjectRepository) Create(ctx context.Context, p *project.Project) error {
-	return insertProject(ctx, r.pool, p)
+	return WithTenantTx(ctx, r.pool, p.TenantID, func(tx pgx.Tx) error {
+		return insertProject(ctx, tx, p)
+	})
 }
 
 type projectExecer interface {
@@ -56,124 +58,110 @@ func insertProject(ctx context.Context, execer projectExecer, p *project.Project
 	return nil
 }
 
-func (r *ProjectRepository) List(ctx context.Context, tenantID shared.ID) ([]*project.Project, error) {
-	var (
-		rows pgx.Rows
-		err  error
-	)
-	if tenantID.IsZero() {
-		rows, err = r.pool.Query(ctx, `SELECT `+projectCols+` FROM projects ORDER BY created_at DESC, key`)
-	} else {
-		rows, err = r.pool.Query(ctx, `SELECT `+projectCols+` FROM projects WHERE tenant_id=$1 ORDER BY created_at DESC, key`, tenantID.String())
-	}
-	if err != nil {
-		return nil, fmt.Errorf("list projects: %w", err)
-	}
-	defer rows.Close()
-	out := make([]*project.Project, 0)
-	for rows.Next() {
-		p, err := scanProject(rows)
+func (r *ProjectRepository) List(ctx context.Context, tenantID shared.ID) (out []*project.Project, err error) {
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+projectCols+` FROM projects WHERE tenant_id=$1 ORDER BY created_at DESC, key`, tenantID.String())
 		if err != nil {
-			return nil, fmt.Errorf("scan project: %w", err)
+			return fmt.Errorf("list projects: %w", err)
 		}
-		out = append(out, p)
-	}
-	return out, rows.Err()
+		defer rows.Close()
+		for rows.Next() {
+			p, err := scanProject(rows)
+			if err != nil {
+				return fmt.Errorf("scan project: %w", err)
+			}
+			out = append(out, p)
+		}
+		return rows.Err()
+	})
+	return out, err
 }
 
-func (r *ProjectRepository) GetByKey(ctx context.Context, tenantID shared.ID, key string) (*project.Project, error) {
-	var row pgx.Row
-	if tenantID.IsZero() {
-		row = r.pool.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE key=$1 ORDER BY created_at, id LIMIT 1`, key)
-	} else {
-		row = r.pool.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
-	}
-	p, err := scanProject(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, shared.ErrNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("select project: %w", err)
-	}
-	return p, nil
+func (r *ProjectRepository) GetByKey(ctx context.Context, tenantID shared.ID, key string) (out *project.Project, err error) {
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		p, err := scanProject(tx.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("select project: %w", err)
+		}
+		out = p
+		return nil
+	})
+	return out, err
 }
 
-func (r *ProjectRepository) GetByID(ctx context.Context, tenantID, projectID shared.ID) (*project.Project, error) {
-	var row pgx.Row
-	if tenantID.IsZero() {
-		row = r.pool.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE id=$1`, projectID.String())
-	} else {
-		row = r.pool.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE tenant_id=$1 AND id=$2`, tenantID.String(), projectID.String())
-	}
-	p, err := scanProject(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, shared.ErrNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("select project: %w", err)
-	}
-	return p, nil
+func (r *ProjectRepository) GetByID(ctx context.Context, tenantID, projectID shared.ID) (out *project.Project, err error) {
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		p, err := scanProject(tx.QueryRow(ctx, `SELECT `+projectCols+` FROM projects WHERE tenant_id=$1 AND id=$2`, tenantID.String(), projectID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("select project: %w", err)
+		}
+		out = p
+		return nil
+	})
+	return out, err
 }
 
 func (r *ProjectRepository) UpdateGate(ctx context.Context, tenantID shared.ID, key, gateID string) error {
-	ct, err := r.pool.Exec(ctx, `UPDATE projects SET gate_id=$3, updated_at=now() WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key, gateID)
-	if err != nil {
-		return fmt.Errorf("update project gate: %w", err)
-	}
-	if ct.RowsAffected() == 0 {
-		return shared.ErrNotFound
-	}
-	return nil
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `UPDATE projects SET gate_id=$3, updated_at=now() WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key, gateID)
+		if err != nil {
+			return fmt.Errorf("update project gate: %w", err)
+		}
+		if ct.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
 }
 
 // AssignProfile sets or clears the quality profile for a language in the project's JSONB
 // default_profile_by_lang map, atomically at the column level (no read-modify-write race).
 func (r *ProjectRepository) AssignProfile(ctx context.Context, tenantID shared.ID, projectKey, language, profileKey string) error {
-	var (
-		ct  pgconn.CommandTag
-		err error
-	)
-	if strings.TrimSpace(profileKey) == "" {
-		ct, err = r.pool.Exec(ctx, `UPDATE projects SET default_profile_by_lang = coalesce(default_profile_by_lang, '{}'::jsonb) - $3::text, updated_at=now() WHERE tenant_id=$1 AND key=$2`,
-			tenantID.String(), projectKey, language)
-	} else {
-		ct, err = r.pool.Exec(ctx, `UPDATE projects SET default_profile_by_lang = jsonb_set(coalesce(default_profile_by_lang, '{}'::jsonb), ARRAY[$3::text], to_jsonb($4::text), true), updated_at=now() WHERE tenant_id=$1 AND key=$2`,
-			tenantID.String(), projectKey, language, profileKey)
-	}
-	if err != nil {
-		return fmt.Errorf("assign project profile: %w", err)
-	}
-	if ct.RowsAffected() == 0 {
-		return shared.ErrNotFound
-	}
-	return nil
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		var ct pgconn.CommandTag
+		var err error
+		if strings.TrimSpace(profileKey) == "" {
+			ct, err = tx.Exec(ctx, `UPDATE projects SET default_profile_by_lang = coalesce(default_profile_by_lang, '{}'::jsonb) - $3::text, updated_at=now() WHERE tenant_id=$1 AND key=$2`, tenantID.String(), projectKey, language)
+		} else {
+			ct, err = tx.Exec(ctx, `UPDATE projects SET default_profile_by_lang = jsonb_set(coalesce(default_profile_by_lang, '{}'::jsonb), ARRAY[$3::text], to_jsonb($4::text), true), updated_at=now() WHERE tenant_id=$1 AND key=$2`, tenantID.String(), projectKey, language, profileKey)
+		}
+		if err != nil {
+			return fmt.Errorf("assign project profile: %w", err)
+		}
+		if ct.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
 }
 
-func (r *ProjectRepository) CountByGate(ctx context.Context, tenantID shared.ID, gateID string) (int, error) {
-	var n int
-	if err := r.pool.QueryRow(ctx, `SELECT count(*) FROM projects WHERE tenant_id=$1 AND gate_id=$2`, tenantID.String(), gateID).Scan(&n); err != nil {
-		return 0, fmt.Errorf("count projects by gate: %w", err)
-	}
-	return n, nil
+func (r *ProjectRepository) CountByGate(ctx context.Context, tenantID shared.ID, gateID string) (n int, err error) {
+	err = WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM projects WHERE tenant_id=$1 AND gate_id=$2`, tenantID.String(), gateID).Scan(&n); err != nil {
+			return fmt.Errorf("count projects by gate: %w", err)
+		}
+		return nil
+	})
+	return n, err
 }
 
 func (r *ProjectRepository) DeleteByKey(ctx context.Context, tenantID shared.ID, key string) error {
-	var (
-		ct  pgconn.CommandTag
-		err error
-	)
-	if tenantID.IsZero() {
-		ct, err = r.pool.Exec(ctx, `DELETE FROM projects WHERE id=(SELECT id FROM projects WHERE key=$1 ORDER BY created_at, id LIMIT 1)`, key)
-	} else {
-		ct, err = r.pool.Exec(ctx, `DELETE FROM projects WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
-	}
-	if err != nil {
-		return fmt.Errorf("delete project: %w", err)
-	}
-	if ct.RowsAffected() == 0 {
-		return shared.ErrNotFound
-	}
-	return nil
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `DELETE FROM projects WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
+		if err != nil {
+			return fmt.Errorf("delete project: %w", err)
+		}
+		if ct.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
 }
 
 func scanProject(row rowScanner) (*project.Project, error) {

--- a/internal/infrastructure/persistence/postgres/quality_gate_mutator.go
+++ b/internal/infrastructure/persistence/postgres/quality_gate_mutator.go
@@ -28,7 +28,7 @@ func NewQualityGateMutator(pool *pgxpool.Pool) *QualityGateMutator {
 var _ ports.QualityGateMutator = (*QualityGateMutator)(nil)
 
 func (m *QualityGateMutator) CreateGate(ctx context.Context, tenantID shared.ID, gate qualitygate.Gate, audit ports.AuditEntry) error {
-	return m.inTx(ctx, func(tx pgx.Tx) error {
+	return m.inTx(ctx, tenantID, func(tx pgx.Tx) error {
 		if err := lockGate(ctx, tx, tenantID, gate.Key); err != nil {
 			return err
 		}
@@ -44,7 +44,7 @@ func (m *QualityGateMutator) CreateGate(ctx context.Context, tenantID shared.ID,
 }
 
 func (m *QualityGateMutator) UpdateGate(ctx context.Context, tenantID shared.ID, gate qualitygate.Gate, audit ports.AuditEntry) error {
-	return m.inTx(ctx, func(tx pgx.Tx) error {
+	return m.inTx(ctx, tenantID, func(tx pgx.Tx) error {
 		if err := lockGate(ctx, tx, tenantID, gate.Key); err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func (m *QualityGateMutator) UpdateGate(ctx context.Context, tenantID shared.ID,
 }
 
 func (m *QualityGateMutator) DeleteGate(ctx context.Context, tenantID shared.ID, key string, audit ports.AuditEntry) error {
-	return m.inTx(ctx, func(tx pgx.Tx) error {
+	return m.inTx(ctx, tenantID, func(tx pgx.Tx) error {
 		if err := lockGate(ctx, tx, tenantID, key); err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func (m *QualityGateMutator) DeleteGate(ctx context.Context, tenantID shared.ID,
 }
 
 func (m *QualityGateMutator) AssignProjectGate(ctx context.Context, tenantID shared.ID, projectKey, gateID string, audit ports.AuditEntry) error {
-	return m.inTx(ctx, func(tx pgx.Tx) error {
+	return m.inTx(ctx, tenantID, func(tx pgx.Tx) error {
 		gateID = strings.TrimSpace(gateID)
 		if err := requireCustomGate(ctx, tx, tenantID, gateID); err != nil {
 			return err
@@ -107,7 +107,7 @@ func (m *QualityGateMutator) AssignProjectGate(ctx context.Context, tenantID sha
 }
 
 func (m *QualityGateMutator) CreateProjectWithGate(ctx context.Context, p *project.Project) error {
-	return m.inTx(ctx, func(tx pgx.Tx) error {
+	return m.inTx(ctx, p.TenantID, func(tx pgx.Tx) error {
 		if err := requireCustomGate(ctx, tx, p.TenantID, p.GateID); err != nil {
 			return err
 		}
@@ -136,10 +136,10 @@ func requireCustomGate(ctx context.Context, tx pgx.Tx, tenantID shared.ID, key s
 	return nil
 }
 
-func (m *QualityGateMutator) inTx(ctx context.Context, fn func(pgx.Tx) error) error {
+func (m *QualityGateMutator) inTx(ctx context.Context, tenantID shared.ID, fn func(pgx.Tx) error) error {
 	const maxAttempts = 8
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		err := m.inTxOnce(ctx, fn)
+		err := m.inTxOnce(ctx, tenantID, fn)
 		if err == nil {
 			return nil
 		}
@@ -152,19 +152,8 @@ func (m *QualityGateMutator) inTx(ctx context.Context, fn func(pgx.Tx) error) er
 	return fmt.Errorf("quality gate mutation: %w after %d attempts", shared.ErrConflict, maxAttempts)
 }
 
-func (m *QualityGateMutator) inTxOnce(ctx context.Context, fn func(pgx.Tx) error) error {
-	tx, err := m.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("quality gate transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-	if err := fn(tx); err != nil {
-		return err
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("quality gate commit: %w", err)
-	}
-	return nil
+func (m *QualityGateMutator) inTxOnce(ctx context.Context, tenantID shared.ID, fn func(pgx.Tx) error) error {
+	return WithTenantTx(ctx, m.pool, tenantID, fn)
 }
 
 func lockGate(ctx context.Context, tx pgx.Tx, tenantID shared.ID, key string) error {

--- a/internal/infrastructure/persistence/postgres/quality_gate_store.go
+++ b/internal/infrastructure/persistence/postgres/quality_gate_store.go
@@ -27,43 +27,52 @@ func (s *QualityGateStore) Create(ctx context.Context, tenantID shared.ID, gate 
 	if err != nil {
 		return fmt.Errorf("marshal quality gate conditions: %w", err)
 	}
-	_, err = s.pool.Exec(ctx, `INSERT INTO quality_gates (tenant_id, key, name, conditions) VALUES ($1,$2,$3,$4)`, tenantID.String(), gate.Key, gate.Name, conditions)
-	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			return shared.ErrConflict
-		}
-		return fmt.Errorf("insert quality gate: %w", err)
-	}
-	return nil
-}
-
-func (s *QualityGateStore) List(ctx context.Context, tenantID shared.ID) ([]qualitygate.Gate, error) {
-	rows, err := s.pool.Query(ctx, `SELECT key, name, conditions FROM quality_gates WHERE tenant_id=$1 ORDER BY key`, tenantID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list quality gates: %w", err)
-	}
-	defer rows.Close()
-	out := make([]qualitygate.Gate, 0)
-	for rows.Next() {
-		gate, err := scanQualityGate(rows)
+	err = WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO quality_gates (tenant_id, key, name, conditions) VALUES ($1,$2,$3,$4)`, tenantID.String(), gate.Key, gate.Name, conditions)
 		if err != nil {
-			return nil, err
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return shared.ErrConflict
+			}
+			return fmt.Errorf("insert quality gate: %w", err)
 		}
-		out = append(out, gate)
-	}
-	return out, rows.Err()
+		return nil
+	})
+	return err
 }
 
-func (s *QualityGateStore) Get(ctx context.Context, tenantID shared.ID, key string) (qualitygate.Gate, error) {
-	gate, err := scanQualityGate(s.pool.QueryRow(ctx, `SELECT key, name, conditions FROM quality_gates WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return qualitygate.Gate{}, shared.ErrNotFound
-	}
-	if err != nil {
-		return qualitygate.Gate{}, fmt.Errorf("select quality gate: %w", err)
-	}
-	return gate, nil
+func (s *QualityGateStore) List(ctx context.Context, tenantID shared.ID) (out []qualitygate.Gate, err error) {
+	err = WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT key, name, conditions FROM quality_gates WHERE tenant_id=$1 ORDER BY key`, tenantID.String())
+		if err != nil {
+			return fmt.Errorf("list quality gates: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			gate, err := scanQualityGate(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, gate)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+func (s *QualityGateStore) Get(ctx context.Context, tenantID shared.ID, key string) (out qualitygate.Gate, err error) {
+	err = WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		gate, err := scanQualityGate(tx.QueryRow(ctx, `SELECT key, name, conditions FROM quality_gates WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("select quality gate: %w", err)
+		}
+		out = gate
+		return nil
+	})
+	return out, err
 }
 
 func (s *QualityGateStore) Update(ctx context.Context, tenantID shared.ID, gate qualitygate.Gate) error {
@@ -71,51 +80,53 @@ func (s *QualityGateStore) Update(ctx context.Context, tenantID shared.ID, gate 
 	if err != nil {
 		return fmt.Errorf("marshal quality gate conditions: %w", err)
 	}
-	ct, err := s.pool.Exec(ctx, `UPDATE quality_gates SET name=$3, conditions=$4, updated_at=now() WHERE tenant_id=$1 AND key=$2`, tenantID.String(), gate.Key, gate.Name, conditions)
-	if err != nil {
-		return fmt.Errorf("update quality gate: %w", err)
-	}
-	if ct.RowsAffected() == 0 {
-		return shared.ErrNotFound
-	}
-	return nil
+	err = WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `UPDATE quality_gates SET name=$3, conditions=$4, updated_at=now() WHERE tenant_id=$1 AND key=$2`, tenantID.String(), gate.Key, gate.Name, conditions)
+		if err != nil {
+			return fmt.Errorf("update quality gate: %w", err)
+		}
+		if ct.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
+	return err
 }
 
 func (s *QualityGateStore) Delete(ctx context.Context, tenantID shared.ID, key string) error {
-	ct, err := s.pool.Exec(ctx, `DELETE FROM quality_gates WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
-	if err != nil {
-		return fmt.Errorf("delete quality gate: %w", err)
-	}
-	if ct.RowsAffected() == 0 {
-		return shared.ErrNotFound
-	}
-	return nil
+	return WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `DELETE FROM quality_gates WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
+		if err != nil {
+			return fmt.Errorf("delete quality gate: %w", err)
+		}
+		if ct.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
 }
 
 func (s *QualityGateStore) DeleteIfUnassigned(ctx context.Context, tenantID shared.ID, key string) error {
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("quality gate delete transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-	var exists bool
-	if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM quality_gates WHERE tenant_id=$1 AND key=$2 FOR UPDATE)`, tenantID.String(), key).Scan(&exists); err != nil {
-		return fmt.Errorf("lock quality gate: %w", err)
-	}
-	if !exists {
-		return shared.ErrNotFound
-	}
-	var assigned bool
-	if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM projects WHERE tenant_id=$1 AND gate_id=$2)`, tenantID.String(), key).Scan(&assigned); err != nil {
-		return fmt.Errorf("check quality gate assignments: %w", err)
-	}
-	if assigned {
-		return shared.ErrConflict
-	}
-	if _, err := tx.Exec(ctx, `DELETE FROM quality_gates WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key); err != nil {
-		return fmt.Errorf("delete quality gate: %w", err)
-	}
-	return tx.Commit(ctx)
+	return WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		var exists bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM quality_gates WHERE tenant_id=$1 AND key=$2 FOR UPDATE)`, tenantID.String(), key).Scan(&exists); err != nil {
+			return fmt.Errorf("lock quality gate: %w", err)
+		}
+		if !exists {
+			return shared.ErrNotFound
+		}
+		var assigned bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM projects WHERE tenant_id=$1 AND gate_id=$2)`, tenantID.String(), key).Scan(&assigned); err != nil {
+			return fmt.Errorf("check quality gate assignments: %w", err)
+		}
+		if assigned {
+			return shared.ErrConflict
+		}
+		if _, err := tx.Exec(ctx, `DELETE FROM quality_gates WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key); err != nil {
+			return fmt.Errorf("delete quality gate: %w", err)
+		}
+		return nil
+	})
 }
 
 type qualityGateScanner interface{ Scan(...any) error }

--- a/internal/infrastructure/persistence/postgres/quality_profile_store.go
+++ b/internal/infrastructure/persistence/postgres/quality_profile_store.go
@@ -30,44 +30,53 @@ func (s *QualityProfileStore) Create(ctx context.Context, tenantID shared.ID, pr
 	if err != nil {
 		return fmt.Errorf("marshal profile rules: %w", err)
 	}
-	_, err = s.pool.Exec(ctx, `INSERT INTO quality_profiles (tenant_id, key, name, language, parent, activated_rules) VALUES ($1,$2,$3,$4,$5,$6)`,
-		tenantID.String(), profile.Key, profile.Name, profile.Language, profile.Parent, activated)
-	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			return shared.ErrConflict
-		}
-		return fmt.Errorf("insert quality profile: %w", err)
-	}
-	return nil
-}
-
-func (s *QualityProfileStore) List(ctx context.Context, tenantID shared.ID) ([]qualityprofile.Profile, error) {
-	rows, err := s.pool.Query(ctx, `SELECT key, name, language, parent, activated_rules FROM quality_profiles WHERE tenant_id=$1 ORDER BY key`, tenantID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list quality profiles: %w", err)
-	}
-	defer rows.Close()
-	out := make([]qualityprofile.Profile, 0)
-	for rows.Next() {
-		profile, err := scanQualityProfile(rows)
+	err = WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO quality_profiles (tenant_id, key, name, language, parent, activated_rules) VALUES ($1,$2,$3,$4,$5,$6)`,
+			tenantID.String(), profile.Key, profile.Name, profile.Language, profile.Parent, activated)
 		if err != nil {
-			return nil, err
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return shared.ErrConflict
+			}
+			return fmt.Errorf("insert quality profile: %w", err)
 		}
-		out = append(out, profile)
-	}
-	return out, rows.Err()
+		return nil
+	})
+	return err
 }
 
-func (s *QualityProfileStore) Get(ctx context.Context, tenantID shared.ID, key string) (qualityprofile.Profile, error) {
-	profile, err := scanQualityProfile(s.pool.QueryRow(ctx, `SELECT key, name, language, parent, activated_rules FROM quality_profiles WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return qualityprofile.Profile{}, shared.ErrNotFound
-	}
-	if err != nil {
-		return qualityprofile.Profile{}, fmt.Errorf("select quality profile: %w", err)
-	}
-	return profile, nil
+func (s *QualityProfileStore) List(ctx context.Context, tenantID shared.ID) (out []qualityprofile.Profile, err error) {
+	err = WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT key, name, language, parent, activated_rules FROM quality_profiles WHERE tenant_id=$1 ORDER BY key`, tenantID.String())
+		if err != nil {
+			return fmt.Errorf("list quality profiles: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			profile, err := scanQualityProfile(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, profile)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+func (s *QualityProfileStore) Get(ctx context.Context, tenantID shared.ID, key string) (out qualityprofile.Profile, err error) {
+	err = WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		profile, err := scanQualityProfile(tx.QueryRow(ctx, `SELECT key, name, language, parent, activated_rules FROM quality_profiles WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("select quality profile: %w", err)
+		}
+		out = profile
+		return nil
+	})
+	return out, err
 }
 
 func (s *QualityProfileStore) Update(ctx context.Context, tenantID shared.ID, profile qualityprofile.Profile) error {
@@ -75,26 +84,31 @@ func (s *QualityProfileStore) Update(ctx context.Context, tenantID shared.ID, pr
 	if err != nil {
 		return fmt.Errorf("marshal profile rules: %w", err)
 	}
-	ct, err := s.pool.Exec(ctx, `UPDATE quality_profiles SET name=$3, language=$4, parent=$5, activated_rules=$6, updated_at=now() WHERE tenant_id=$1 AND key=$2`,
-		tenantID.String(), profile.Key, profile.Name, profile.Language, profile.Parent, activated)
-	if err != nil {
-		return fmt.Errorf("update quality profile: %w", err)
-	}
-	if ct.RowsAffected() == 0 {
-		return shared.ErrNotFound
-	}
-	return nil
+	err = WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `UPDATE quality_profiles SET name=$3, language=$4, parent=$5, activated_rules=$6, updated_at=now() WHERE tenant_id=$1 AND key=$2`,
+			tenantID.String(), profile.Key, profile.Name, profile.Language, profile.Parent, activated)
+		if err != nil {
+			return fmt.Errorf("update quality profile: %w", err)
+		}
+		if ct.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
+	return err
 }
 
 func (s *QualityProfileStore) Delete(ctx context.Context, tenantID shared.ID, key string) error {
-	ct, err := s.pool.Exec(ctx, `DELETE FROM quality_profiles WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
-	if err != nil {
-		return fmt.Errorf("delete quality profile: %w", err)
-	}
-	if ct.RowsAffected() == 0 {
-		return shared.ErrNotFound
-	}
-	return nil
+	return WithTenantTx(ctx, s.pool, tenantID, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `DELETE FROM quality_profiles WHERE tenant_id=$1 AND key=$2`, tenantID.String(), key)
+		if err != nil {
+			return fmt.Errorf("delete quality profile: %w", err)
+		}
+		if ct.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
 }
 
 func scanQualityProfile(row rowScanner) (qualityprofile.Profile, error) {

--- a/internal/infrastructure/persistence/postgres/recon_run_repo.go
+++ b/internal/infrastructure/persistence/postgres/recon_run_repo.go
@@ -104,6 +104,6 @@ func scanReconRun(row rowScanner) (recon.Run, error) {
 	if err := row.Scan(&id, &tenant, &eng, &run.Tool, &run.Target, &status, &run.Stage, &run.Error, &run.ResultCount, &evID, &run.StartedAt, &finishedAt, &run.Containment); err != nil {
 		return recon.Run{}, err
 	}
-	run.ID, run.EngagementID, run.EvidenceID, run.Status, run.FinishedAt = shared.ID(id), shared.ID(eng), shared.ID(evID), recon.Status(status), finishedAt
+	run.ID, run.TenantID, run.EngagementID, run.EvidenceID, run.Status, run.FinishedAt = shared.ID(id), shared.ID(tenant), shared.ID(eng), shared.ID(evID), recon.Status(status), finishedAt
 	return run, nil
 }

--- a/internal/infrastructure/persistence/postgres/recon_run_repo.go
+++ b/internal/infrastructure/persistence/postgres/recon_run_repo.go
@@ -75,26 +75,54 @@ func (r *ReconRunStore) ListByEngagement(ctx context.Context, engagementID share
 	return out, nil
 }
 
-// ListStaleRunning is intentionally not RLS-backed yet: the global worker
-// reconciler must first enumerate tenant work before rebinding each row.
+// ListStaleRunning enumerates tenant identities from the registry, then queries
+// each tenant's rows in an RLS-bound transaction.
 func (r *ReconRunStore) ListStaleRunning(ctx context.Context, olderThan time.Time, limit int) ([]recon.Run, error) {
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := r.pool.Query(ctx, `SELECT `+reconRunCols+` FROM recon_runs WHERE status='running' AND started_at < $1 ORDER BY started_at LIMIT $2`, olderThan, limit)
+	tenantRows, err := r.pool.Query(ctx, `SELECT id FROM tenants ORDER BY id`)
 	if err != nil {
-		return nil, fmt.Errorf("list stale recon runs: %w", err)
+		return nil, fmt.Errorf("list recon tenants: %w", err)
 	}
-	defer rows.Close()
-	out := []recon.Run{}
-	for rows.Next() {
-		run, err := scanReconRun(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan recon run: %w", err)
+	tenantIDs := []shared.ID{}
+	for tenantRows.Next() {
+		var tenant string
+		if err := tenantRows.Scan(&tenant); err != nil {
+			tenantRows.Close()
+			return nil, fmt.Errorf("scan recon tenant: %w", err)
 		}
-		out = append(out, run)
+		tenantIDs = append(tenantIDs, shared.ID(tenant))
 	}
-	return out, rows.Err()
+	if err := tenantRows.Err(); err != nil {
+		tenantRows.Close()
+		return nil, fmt.Errorf("list recon tenants: %w", err)
+	}
+	tenantRows.Close()
+	out := []recon.Run{}
+	for _, tenantID := range tenantIDs {
+		if len(out) == limit {
+			break
+		}
+		if err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+			rows, err := tx.Query(ctx, `SELECT `+reconRunCols+` FROM recon_runs WHERE status='running' AND started_at < $1 ORDER BY started_at LIMIT $2`, olderThan, limit-len(out))
+			if err != nil {
+				return fmt.Errorf("list stale recon runs: %w", err)
+			}
+			defer rows.Close()
+			for rows.Next() {
+				run, err := scanReconRun(rows)
+				if err != nil {
+					return fmt.Errorf("scan recon run: %w", err)
+				}
+				out = append(out, run)
+			}
+			return rows.Err()
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
 }
 
 func scanReconRun(row rowScanner) (recon.Run, error) {

--- a/internal/infrastructure/persistence/postgres/recon_run_repo.go
+++ b/internal/infrastructure/persistence/postgres/recon_run_repo.go
@@ -14,72 +14,74 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-const reconRunCols = `id, engagement_id, tool, target, status, stage, error, result_count, evidence_id, started_at, finished_at, containment`
+const reconRunCols = `id, tenant_id, engagement_id, tool, target, status, stage, error, result_count, evidence_id, started_at, finished_at, containment`
 
-// ReconRunStore persists recon-run records.
 type ReconRunStore struct{ pool *pgxpool.Pool }
 
-// NewReconRunStore returns a store backed by the given pool.
 func NewReconRunStore(pool *pgxpool.Pool) *ReconRunStore { return &ReconRunStore{pool: pool} }
 
 var _ ports.ReconRunStore = (*ReconRunStore)(nil)
 
-// Save upserts a run (used on create and on every stage/status update).
 func (r *ReconRunStore) Save(ctx context.Context, run recon.Run) error {
-	_, err := r.pool.Exec(ctx,
-		`INSERT INTO recon_runs (`+reconRunCols+`)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
-		 ON CONFLICT (id) DO UPDATE SET status=EXCLUDED.status, stage=EXCLUDED.stage,
-		     error=EXCLUDED.error, result_count=EXCLUDED.result_count,
-		     evidence_id=EXCLUDED.evidence_id, finished_at=EXCLUDED.finished_at,
-		     containment=EXCLUDED.containment`,
-		run.ID.String(), run.EngagementID.String(), run.Tool, run.Target, string(run.Status),
-		run.Stage, run.Error, run.ResultCount, run.EvidenceID.String(), run.StartedAt, run.FinishedAt, run.Containment)
-	if err != nil {
-		return fmt.Errorf("save recon run: %w", err)
-	}
-	return nil
-}
-
-// Get returns a run by id, or shared.ErrNotFound.
-func (r *ReconRunStore) Get(ctx context.Context, id shared.ID) (recon.Run, error) {
-	run, err := scanReconRun(r.pool.QueryRow(ctx, `SELECT `+reconRunCols+` FROM recon_runs WHERE id=$1`, id.String()))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return recon.Run{}, fmt.Errorf("recon run %s: %w", id, shared.ErrNotFound)
-	}
-	if err != nil {
-		return recon.Run{}, fmt.Errorf("get recon run: %w", err)
-	}
-	return run, nil
-}
-
-// ListByEngagement returns an engagement's runs, newest first.
-func (r *ReconRunStore) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]recon.Run, error) {
-	rows, err := r.pool.Query(ctx, `SELECT `+reconRunCols+` FROM recon_runs WHERE engagement_id=$1 ORDER BY started_at DESC`, engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list recon runs: %w", err)
-	}
-	defer rows.Close()
-	out := []recon.Run{}
-	for rows.Next() {
-		run, err := scanReconRun(rows)
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		tenantID, _ := shared.TenantFrom(ctx)
+		_, err := tx.Exec(ctx, `INSERT INTO recon_runs (`+reconRunCols+`) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13) ON CONFLICT (id) DO UPDATE SET status=EXCLUDED.status, stage=EXCLUDED.stage, error=EXCLUDED.error, result_count=EXCLUDED.result_count, evidence_id=EXCLUDED.evidence_id, finished_at=EXCLUDED.finished_at, containment=EXCLUDED.containment`, run.ID.String(), tenantID.String(), run.EngagementID.String(), run.Tool, run.Target, string(run.Status), run.Stage, run.Error, run.ResultCount, run.EvidenceID.String(), run.StartedAt, run.FinishedAt, run.Containment)
 		if err != nil {
-			return nil, fmt.Errorf("scan recon run: %w", err)
+			return fmt.Errorf("save recon run: %w", err)
 		}
-		out = append(out, run)
-	}
-	return out, rows.Err()
+		return nil
+	})
 }
 
-// ListStaleRunning returns runs still 'running' that started before olderThan (≤ limit),
-// oldest first – the stale-run sweeper's input.
+func (r *ReconRunStore) Get(ctx context.Context, id shared.ID) (recon.Run, error) {
+	var out recon.Run
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		var err error
+		out, err = scanReconRun(tx.QueryRow(ctx, `SELECT `+reconRunCols+` FROM recon_runs WHERE id=$1`, id.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("recon run %s: %w", id, shared.ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("get recon run: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return recon.Run{}, err
+	}
+	return out, nil
+}
+
+func (r *ReconRunStore) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]recon.Run, error) {
+	var out []recon.Run
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+reconRunCols+` FROM recon_runs WHERE engagement_id=$1 ORDER BY started_at DESC`, engagementID.String())
+		if err != nil {
+			return fmt.Errorf("list recon runs: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			run, err := scanReconRun(rows)
+			if err != nil {
+				return fmt.Errorf("scan recon run: %w", err)
+			}
+			out = append(out, run)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ListStaleRunning is intentionally not RLS-backed yet: the global worker
+// reconciler must first enumerate tenant work before rebinding each row.
 func (r *ReconRunStore) ListStaleRunning(ctx context.Context, olderThan time.Time, limit int) ([]recon.Run, error) {
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := r.pool.Query(ctx,
-		`SELECT `+reconRunCols+` FROM recon_runs WHERE status='running' AND started_at < $1 ORDER BY started_at LIMIT $2`,
-		olderThan, limit)
+	rows, err := r.pool.Query(ctx, `SELECT `+reconRunCols+` FROM recon_runs WHERE status='running' AND started_at < $1 ORDER BY started_at LIMIT $2`, olderThan, limit)
 	if err != nil {
 		return nil, fmt.Errorf("list stale recon runs: %w", err)
 	}
@@ -96,20 +98,12 @@ func (r *ReconRunStore) ListStaleRunning(ctx context.Context, olderThan time.Tim
 }
 
 func scanReconRun(row rowScanner) (recon.Run, error) {
-	var (
-		run        recon.Run
-		id, eng    string
-		evID       string
-		status     string
-		finishedAt *time.Time
-	)
-	if err := row.Scan(&id, &eng, &run.Tool, &run.Target, &status, &run.Stage, &run.Error, &run.ResultCount, &evID, &run.StartedAt, &finishedAt, &run.Containment); err != nil {
+	var run recon.Run
+	var id, tenant, eng, evID, status string
+	var finishedAt *time.Time
+	if err := row.Scan(&id, &tenant, &eng, &run.Tool, &run.Target, &status, &run.Stage, &run.Error, &run.ResultCount, &evID, &run.StartedAt, &finishedAt, &run.Containment); err != nil {
 		return recon.Run{}, err
 	}
-	run.ID = shared.ID(id)
-	run.EngagementID = shared.ID(eng)
-	run.EvidenceID = shared.ID(evID)
-	run.Status = recon.Status(status)
-	run.FinishedAt = finishedAt
+	run.ID, run.EngagementID, run.EvidenceID, run.Status, run.FinishedAt = shared.ID(id), shared.ID(eng), shared.ID(evID), recon.Status(status), finishedAt
 	return run, nil
 }

--- a/internal/infrastructure/persistence/postgres/retest_repo.go
+++ b/internal/infrastructure/persistence/postgres/retest_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -23,39 +24,37 @@ var _ ports.RetestRepository = (*RetestRepository)(nil)
 
 // Add inserts a retest (append-only; retests are not edited or deleted in app code).
 func (r *RetestRepository) Add(ctx context.Context, rt finding.Retest) error {
-	if _, err := r.pool.Exec(ctx,
-		`INSERT INTO finding_retests (id, tenant_id, engagement_id, finding_id, outcome, note, tester, created_at)
-		 VALUES ($1, '', $2, $3, $4, $5, $6, $7)`,
-		rt.ID.String(), rt.EngagementID.String(), rt.FindingID.String(), string(rt.Outcome), rt.Note, rt.Tester, rt.At); err != nil {
-		return fmt.Errorf("insert retest: %w", err)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("tenant context is required")
 	}
-	return nil
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO finding_retests (id, tenant_id, engagement_id, finding_id, outcome, note, tester, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, rt.ID.String(), tenantID.String(), rt.EngagementID.String(), rt.FindingID.String(), string(rt.Outcome), rt.Note, rt.Tester, rt.At); err != nil {
+			return fmt.Errorf("insert retest: %w", err)
+		}
+		return nil
+	})
 }
 
 // ListByEngagementFinding returns a finding's retests oldest-first, scoped to the
 // engagement (no cross-engagement read).
-func (r *RetestRepository) ListByEngagementFinding(ctx context.Context, engagementID, findingID shared.ID) ([]finding.Retest, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT id, engagement_id, finding_id, outcome, note, tester, created_at
-		 FROM finding_retests WHERE finding_id=$1 AND engagement_id=$2 ORDER BY created_at ASC, id ASC`,
-		findingID.String(), engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list retests: %w", err)
-	}
-	defer rows.Close()
-	out := make([]finding.Retest, 0)
-	for rows.Next() {
-		var (
-			rt           finding.Retest
-			id, eid, fid string
-			outcome      string
-		)
-		if err := rows.Scan(&id, &eid, &fid, &outcome, &rt.Note, &rt.Tester, &rt.At); err != nil {
-			return nil, fmt.Errorf("scan retest: %w", err)
+func (r *RetestRepository) ListByEngagementFinding(ctx context.Context, engagementID, findingID shared.ID) (out []finding.Retest, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id, engagement_id, finding_id, outcome, note, tester, created_at FROM finding_retests WHERE finding_id=$1 AND engagement_id=$2 ORDER BY created_at ASC, id ASC`, findingID.String(), engagementID.String())
+		if err != nil {
+			return fmt.Errorf("list retests: %w", err)
 		}
-		rt.ID, rt.EngagementID, rt.FindingID = shared.ID(id), shared.ID(eid), shared.ID(fid)
-		rt.Outcome = finding.RetestOutcome(outcome)
-		out = append(out, rt)
-	}
-	return out, rows.Err()
+		defer rows.Close()
+		for rows.Next() {
+			var rt finding.Retest
+			var id, eid, fid, outcome string
+			if err := rows.Scan(&id, &eid, &fid, &outcome, &rt.Note, &rt.Tester, &rt.At); err != nil {
+				return fmt.Errorf("scan retest: %w", err)
+			}
+			rt.ID, rt.EngagementID, rt.FindingID, rt.Outcome = shared.ID(id), shared.ID(eid), shared.ID(fid), finding.RetestOutcome(outcome)
+			out = append(out, rt)
+		}
+		return rows.Err()
+	})
+	return out, err
 }

--- a/internal/infrastructure/persistence/postgres/scan_job_repo.go
+++ b/internal/infrastructure/persistence/postgres/scan_job_repo.go
@@ -68,72 +68,90 @@ func (r *ScanJobStore) Save(ctx context.Context, j ports.ScanJob) error {
 	return nil
 }
 
-// ListStaleRunning returns scan jobs still 'running' that started before olderThan (≤ limit),
-// oldest first – the stale-scan sweeper's input.
+// ListStaleRunning enumerates tenant identities before reading tenant-owned jobs.
 func (r *ScanJobStore) ListStaleRunning(ctx context.Context, olderThan time.Time, limit int) ([]ports.ScanJob, error) {
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := r.pool.Query(ctx,
-		`SELECT id, tenant_id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
-		 FROM scan_jobs WHERE status='running' AND started_at < $1 ORDER BY started_at LIMIT $2`,
-		olderThan, limit)
+	tenantRows, err := r.pool.Query(ctx, `SELECT id FROM tenants ORDER BY id`)
 	if err != nil {
-		return nil, fmt.Errorf("list stale scan jobs: %w", err)
+		return nil, fmt.Errorf("list scan job tenants: %w", err)
 	}
-	defer rows.Close()
-	out := []ports.ScanJob{}
-	for rows.Next() {
-		var (
-			j        ports.ScanJob
-			tenant   string
-			status   string
-			finished *time.Time
-		)
-		var debugEvents []byte
-		if err := rows.Scan(&j.ID, &tenant, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents); err != nil {
-			return nil, fmt.Errorf("scan scan job: %w", err)
+	tenantIDs := []shared.ID{}
+	for tenantRows.Next() {
+		var tenant string
+		if err := tenantRows.Scan(&tenant); err != nil {
+			tenantRows.Close()
+			return nil, fmt.Errorf("scan scan job tenant: %w", err)
 		}
-		j.Status = ports.ScanStatus(status)
-		j.TenantID = shared.ID(tenant)
-		j.FinishedAt = finished
-		if err := decodeScanDebugEvents(debugEvents, &j); err != nil {
+		tenantIDs = append(tenantIDs, shared.ID(tenant))
+	}
+	if err := tenantRows.Err(); err != nil {
+		tenantRows.Close()
+		return nil, fmt.Errorf("list scan job tenants: %w", err)
+	}
+	tenantRows.Close()
+	out := []ports.ScanJob{}
+	for _, tenantID := range tenantIDs {
+		if len(out) == limit {
+			break
+		}
+		if err := WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+			rows, err := tx.Query(ctx,
+				`SELECT id, tenant_id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
+				 FROM scan_jobs WHERE status='running' AND started_at < $1 ORDER BY started_at LIMIT $2`,
+				olderThan, limit-len(out))
+			if err != nil {
+				return fmt.Errorf("list stale scan jobs: %w", err)
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var j ports.ScanJob
+				var tenant, status string
+				var finished *time.Time
+				var debugEvents []byte
+				if err := rows.Scan(&j.ID, &tenant, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents); err != nil {
+					return fmt.Errorf("scan scan job: %w", err)
+				}
+				j.TenantID, j.Status, j.FinishedAt = shared.ID(tenant), ports.ScanStatus(status), finished
+				if err := decodeScanDebugEvents(debugEvents, &j); err != nil {
+					return err
+				}
+				out = append(out, j)
+			}
+			return rows.Err()
+		}); err != nil {
 			return nil, err
 		}
-		out = append(out, j)
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 // GetJob returns a scan job by its own id, or ErrNotFound.
 func (r *ScanJobStore) GetJob(ctx context.Context, id string) (ports.ScanJob, error) {
-	var (
-		j           ports.ScanJob
-		tenant      string
-		status      string
-		finished    *time.Time
-		debugEvents []byte
-	)
-	err := r.pool.QueryRow(ctx,
-		`SELECT id, tenant_id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
-		 FROM scan_jobs WHERE id=$1`, id).
-		Scan(&j.ID, &tenant, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return ports.ScanJob{}, fmt.Errorf("scan job %s: %w", id, shared.ErrNotFound)
-	}
+	var j ports.ScanJob
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		var tenant, status string
+		var finished *time.Time
+		var debugEvents []byte
+		err := tx.QueryRow(ctx,
+			`SELECT id, tenant_id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
+			 FROM scan_jobs WHERE id=$1`, id).
+			Scan(&j.ID, &tenant, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("scan job %s: %w", id, shared.ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("load scan job: %w", err)
+		}
+		j.TenantID, j.Status, j.FinishedAt = shared.ID(tenant), ports.ScanStatus(status), finished
+		return decodeScanDebugEvents(debugEvents, &j)
+	})
 	if err != nil {
-		return ports.ScanJob{}, fmt.Errorf("load scan job: %w", err)
-	}
-	j.Status = ports.ScanStatus(status)
-	j.TenantID = shared.ID(tenant)
-	j.FinishedAt = finished
-	if err := decodeScanDebugEvents(debugEvents, &j); err != nil {
 		return ports.ScanJob{}, err
 	}
 	return j, nil
 }
-
-// LatestForEngagement returns the engagement's most recent scan job, or ErrNotFound.
 func (r *ScanJobStore) LatestForEngagements(ctx context.Context, engagementIDs []shared.ID) (map[shared.ID]ports.ScanJob, error) {
 	ids := make([]string, len(engagementIDs))
 	for i, id := range engagementIDs {

--- a/internal/infrastructure/persistence/postgres/scan_job_repo.go
+++ b/internal/infrastructure/persistence/postgres/scan_job_repo.go
@@ -164,45 +164,51 @@ func (r *ScanJobStore) LatestForEngagements(ctx context.Context, engagementIDs [
 	if len(ids) == 0 {
 		return map[shared.ID]ports.ScanJob{}, nil
 	}
-	rows, err := r.pool.Query(ctx, `SELECT DISTINCT ON (engagement_id) id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at FROM scan_jobs WHERE engagement_id = ANY($1) ORDER BY engagement_id, started_at DESC, id DESC`, ids)
-	if err != nil {
-		return nil, fmt.Errorf("list latest scan jobs: %w", err)
-	}
-	defer rows.Close()
 	out := map[shared.ID]ports.ScanJob{}
-	for rows.Next() {
-		var j ports.ScanJob
-		var status string
-		var finished *time.Time
-		if err := rows.Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished); err != nil {
-			return nil, fmt.Errorf("scan latest scan job: %w", err)
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT DISTINCT ON (engagement_id) id, tenant_id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at FROM scan_jobs WHERE engagement_id = ANY($1) ORDER BY engagement_id, started_at DESC, id DESC`, ids)
+		if err != nil {
+			return fmt.Errorf("list latest scan jobs: %w", err)
 		}
-		j.Status, j.FinishedAt, j.DebugEvents = ports.ScanStatus(status), finished, []ports.ScanDebugEvent{}
-		out[shared.ID(j.EngagementID)] = j
+		defer rows.Close()
+		for rows.Next() {
+			var j ports.ScanJob
+			var tenant, status string
+			var finished *time.Time
+			if err := rows.Scan(&j.ID, &tenant, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished); err != nil {
+				return fmt.Errorf("scan latest scan job: %w", err)
+			}
+			j.TenantID, j.Status, j.FinishedAt, j.DebugEvents = shared.ID(tenant), ports.ScanStatus(status), finished, []ports.ScanDebugEvent{}
+			out[shared.ID(j.EngagementID)] = j
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 func (r *ScanJobStore) LatestForEngagement(ctx context.Context, engagementID shared.ID) (ports.ScanJob, error) {
-	var (
-		j           ports.ScanJob
-		status      string
-		finished    *time.Time
-		debugEvents []byte
-	)
-	err := r.pool.QueryRow(ctx,
-		`SELECT id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
-		 FROM scan_jobs WHERE engagement_id=$1 ORDER BY started_at DESC LIMIT 1`, engagementID.String()).
-		Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return ports.ScanJob{}, fmt.Errorf("scan job for %s: %w", engagementID, shared.ErrNotFound)
-	}
+	var j ports.ScanJob
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		var tenant, status string
+		var finished *time.Time
+		var debugEvents []byte
+		err := tx.QueryRow(ctx,
+			`SELECT id, tenant_id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
+			 FROM scan_jobs WHERE engagement_id=$1 ORDER BY started_at DESC LIMIT 1`, engagementID.String()).
+			Scan(&j.ID, &tenant, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("scan job for %s: %w", engagementID, shared.ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("load scan job: %w", err)
+		}
+		j.TenantID, j.Status, j.FinishedAt = shared.ID(tenant), ports.ScanStatus(status), finished
+		return decodeScanDebugEvents(debugEvents, &j)
+	})
 	if err != nil {
-		return ports.ScanJob{}, fmt.Errorf("load scan job: %w", err)
-	}
-	j.Status = ports.ScanStatus(status)
-	j.FinishedAt = finished
-	if err := decodeScanDebugEvents(debugEvents, &j); err != nil {
 		return ports.ScanJob{}, err
 	}
 	return j, nil

--- a/internal/infrastructure/persistence/postgres/scan_job_repo.go
+++ b/internal/infrastructure/persistence/postgres/scan_job_repo.go
@@ -28,9 +28,13 @@ func (r *ScanJobStore) CreateRunning(ctx context.Context, j ports.ScanJob) error
 	if err != nil {
 		return fmt.Errorf("marshal scan job debug events: %w", err)
 	}
-	_, err = r.pool.Exec(ctx, `INSERT INTO scan_jobs (id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
-		j.ID, j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("create scan job: %w", shared.ErrValidation)
+	}
+	_, err = r.pool.Exec(ctx, `INSERT INTO scan_jobs (id, tenant_id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+		j.ID, tenantID.String(), j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
@@ -47,13 +51,17 @@ func (r *ScanJobStore) Save(ctx context.Context, j ports.ScanJob) error {
 	if err != nil {
 		return fmt.Errorf("marshal scan job debug events: %w", err)
 	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("save scan job: %w", shared.ErrValidation)
+	}
 	_, err = r.pool.Exec(ctx,
-		`INSERT INTO scan_jobs (id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+		`INSERT INTO scan_jobs (id, tenant_id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
 		 ON CONFLICT (id) DO UPDATE SET status=EXCLUDED.status, stage=EXCLUDED.stage,
 		     progress=EXCLUDED.progress, error=EXCLUDED.error, finished_at=EXCLUDED.finished_at,
 		     debug_events=EXCLUDED.debug_events`,
-		j.ID, j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
+		j.ID, tenantID.String(), j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
 	if err != nil {
 		return fmt.Errorf("save scan job: %w", err)
 	}
@@ -67,7 +75,7 @@ func (r *ScanJobStore) ListStaleRunning(ctx context.Context, olderThan time.Time
 		limit = 100
 	}
 	rows, err := r.pool.Query(ctx,
-		`SELECT id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
+		`SELECT id, tenant_id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
 		 FROM scan_jobs WHERE status='running' AND started_at < $1 ORDER BY started_at LIMIT $2`,
 		olderThan, limit)
 	if err != nil {
@@ -78,14 +86,16 @@ func (r *ScanJobStore) ListStaleRunning(ctx context.Context, olderThan time.Time
 	for rows.Next() {
 		var (
 			j        ports.ScanJob
+			tenant   string
 			status   string
 			finished *time.Time
 		)
 		var debugEvents []byte
-		if err := rows.Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents); err != nil {
+		if err := rows.Scan(&j.ID, &tenant, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents); err != nil {
 			return nil, fmt.Errorf("scan scan job: %w", err)
 		}
 		j.Status = ports.ScanStatus(status)
+		j.TenantID = shared.ID(tenant)
 		j.FinishedAt = finished
 		if err := decodeScanDebugEvents(debugEvents, &j); err != nil {
 			return nil, err
@@ -99,14 +109,15 @@ func (r *ScanJobStore) ListStaleRunning(ctx context.Context, olderThan time.Time
 func (r *ScanJobStore) GetJob(ctx context.Context, id string) (ports.ScanJob, error) {
 	var (
 		j           ports.ScanJob
+		tenant      string
 		status      string
 		finished    *time.Time
 		debugEvents []byte
 	)
 	err := r.pool.QueryRow(ctx,
-		`SELECT id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
+		`SELECT id, tenant_id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
 		 FROM scan_jobs WHERE id=$1`, id).
-		Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents)
+		Scan(&j.ID, &tenant, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ports.ScanJob{}, fmt.Errorf("scan job %s: %w", id, shared.ErrNotFound)
 	}
@@ -114,6 +125,7 @@ func (r *ScanJobStore) GetJob(ctx context.Context, id string) (ports.ScanJob, er
 		return ports.ScanJob{}, fmt.Errorf("load scan job: %w", err)
 	}
 	j.Status = ports.ScanStatus(status)
+	j.TenantID = shared.ID(tenant)
 	j.FinishedAt = finished
 	if err := decodeScanDebugEvents(debugEvents, &j); err != nil {
 		return ports.ScanJob{}, err

--- a/internal/infrastructure/persistence/postgres/scan_job_repo.go
+++ b/internal/infrastructure/persistence/postgres/scan_job_repo.go
@@ -32,17 +32,19 @@ func (r *ScanJobStore) CreateRunning(ctx context.Context, j ports.ScanJob) error
 	if !ok {
 		return fmt.Errorf("create scan job: %w", shared.ErrValidation)
 	}
-	_, err = r.pool.Exec(ctx, `INSERT INTO scan_jobs (id, tenant_id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
-		j.ID, tenantID.String(), j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
-	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			return shared.ErrConflict
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO scan_jobs (id, tenant_id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+			j.ID, tenantID.String(), j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return shared.ErrConflict
+			}
+			return fmt.Errorf("create scan job: %w", err)
 		}
-		return fmt.Errorf("create scan job: %w", err)
-	}
-	return nil
+		return nil
+	})
 }
 
 // Save upserts a scan job (used on create and on every stage/status update).
@@ -55,17 +57,19 @@ func (r *ScanJobStore) Save(ctx context.Context, j ports.ScanJob) error {
 	if !ok {
 		return fmt.Errorf("save scan job: %w", shared.ErrValidation)
 	}
-	_, err = r.pool.Exec(ctx,
-		`INSERT INTO scan_jobs (id, tenant_id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
-		 ON CONFLICT (id) DO UPDATE SET status=EXCLUDED.status, stage=EXCLUDED.stage,
-		     progress=EXCLUDED.progress, error=EXCLUDED.error, finished_at=EXCLUDED.finished_at,
-		     debug_events=EXCLUDED.debug_events`,
-		j.ID, tenantID.String(), j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
-	if err != nil {
-		return fmt.Errorf("save scan job: %w", err)
-	}
-	return nil
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO scan_jobs (id, tenant_id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+			 ON CONFLICT (id) DO UPDATE SET status=EXCLUDED.status, stage=EXCLUDED.stage,
+			     progress=EXCLUDED.progress, error=EXCLUDED.error, finished_at=EXCLUDED.finished_at,
+			     debug_events=EXCLUDED.debug_events`,
+			j.ID, tenantID.String(), j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
+		if err != nil {
+			return fmt.Errorf("save scan job: %w", err)
+		}
+		return nil
+	})
 }
 
 // ListStaleRunning enumerates tenant identities before reading tenant-owned jobs.

--- a/internal/infrastructure/persistence/postgres/scan_run_repo.go
+++ b/internal/infrastructure/persistence/postgres/scan_run_repo.go
@@ -13,10 +13,9 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-// ScanRunStore persists scan-run manifests + finding keys.
+// ScanRunStore persists scan-run manifests + finding keys in tenant-bound transactions.
 type ScanRunStore struct{ pool *pgxpool.Pool }
 
-// NewScanRunStore returns a store backed by the given pool.
 func NewScanRunStore(pool *pgxpool.Pool) *ScanRunStore { return &ScanRunStore{pool: pool} }
 
 var _ ports.ScanRunStore = (*ScanRunStore)(nil)
@@ -30,54 +29,62 @@ func (r *ScanRunStore) Save(ctx context.Context, run ports.ScanRun) error {
 	if err != nil {
 		return fmt.Errorf("marshal finding keys: %w", err)
 	}
-	if _, err := r.pool.Exec(ctx,
-		`INSERT INTO scan_runs (id, engagement_id, created_at, manifest, finding_keys) VALUES ($1,$2,$3,$4,$5)`,
-		run.ID, run.EngagementID, run.CreatedAt, manifest, keys); err != nil {
-		return fmt.Errorf("insert scan run: %w", err)
-	}
-	return nil
+	return WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		tenantID, _ := shared.TenantFrom(ctx)
+		if _, err := tx.Exec(ctx, `INSERT INTO scan_runs (id, tenant_id, engagement_id, created_at, manifest, finding_keys) VALUES ($1,$2,$3,$4,$5,$6)`, run.ID, tenantID.String(), run.EngagementID, run.CreatedAt, manifest, keys); err != nil {
+			return fmt.Errorf("insert scan run: %w", err)
+		}
+		return nil
+	})
 }
 
 func (r *ScanRunStore) List(ctx context.Context, engagementID shared.ID) ([]ports.ScanRun, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT id, engagement_id, created_at, manifest, finding_keys
-		 FROM scan_runs WHERE engagement_id=$1 ORDER BY created_at DESC`, engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list scan runs: %w", err)
-	}
-	defer rows.Close()
 	var out []ports.ScanRun
-	for rows.Next() {
-		run, err := scanRunRow(rows)
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id, tenant_id, engagement_id, created_at, manifest, finding_keys FROM scan_runs WHERE engagement_id=$1 ORDER BY created_at DESC`, engagementID.String())
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("list scan runs: %w", err)
 		}
-		out = append(out, run)
+		defer rows.Close()
+		for rows.Next() {
+			run, err := scanRunRow(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, run)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 func (r *ScanRunStore) Get(ctx context.Context, runID string) (ports.ScanRun, error) {
-	row := r.pool.QueryRow(ctx,
-		`SELECT id, engagement_id, created_at, manifest, finding_keys FROM scan_runs WHERE id=$1`, runID)
-	run, err := scanRunRow(row)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return ports.ScanRun{}, fmt.Errorf("scan run %s: %w", runID, shared.ErrNotFound)
-	}
+	var out ports.ScanRun
+	err := WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		var err error
+		out, err = scanRunRow(tx.QueryRow(ctx, `SELECT id, tenant_id, engagement_id, created_at, manifest, finding_keys FROM scan_runs WHERE id=$1`, runID))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("scan run %s: %w", runID, shared.ErrNotFound)
+		}
+		return err
+	})
 	if err != nil {
-		return ports.ScanRun{}, fmt.Errorf("get scan run: %w", err)
+		return ports.ScanRun{}, err
 	}
-	return run, nil
+	return out, nil
 }
 
 func scanRunRow(row rowScanner) (ports.ScanRun, error) {
-	var (
-		run            ports.ScanRun
-		manifest, keys []byte
-	)
-	if err := row.Scan(&run.ID, &run.EngagementID, &run.CreatedAt, &manifest, &keys); err != nil {
+	var run ports.ScanRun
+	var tenant string
+	var manifest, keys []byte
+	if err := row.Scan(&run.ID, &tenant, &run.EngagementID, &run.CreatedAt, &manifest, &keys); err != nil {
 		return ports.ScanRun{}, err
 	}
+	run.TenantID = shared.ID(tenant)
 	if err := json.Unmarshal(manifest, &run.Manifest); err != nil {
 		return ports.ScanRun{}, fmt.Errorf("decode manifest: %w", err)
 	}

--- a/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
@@ -157,7 +157,10 @@ func TestTenantRLSIsolation(t *testing.T) {
 	if err := NewScanJobStore(runtime).CreateRunning(ctxA, ports.ScanJob{ID: suffix + "-scan", EngagementID: engagementID, Target: "example.test", Kind: "local", Status: ports.ScanRunning, StartedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("create tenant A scan job: %v", err)
 	}
-	for _, table := range []string{"recon_runs", "scan_jobs"} {
+	if err := NewScanRunStore(runtime).Save(ctxA, ports.ScanRun{ID: suffix + "-scan-run", EngagementID: engagementID, CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create tenant A scan run: %v", err)
+	}
+	for _, table := range []string{"recon_runs", "scan_jobs", "scan_runs"} {
 		if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
 			return tx.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE tenant_id=$1`, tenantA).Scan(&count)
 		}); err != nil {

--- a/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
@@ -151,6 +151,21 @@ func TestTenantRLSIsolation(t *testing.T) {
 		}
 	}
 
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantA), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO agent_approvals (action_id, tenant_id, session_id, engagement_id, tool, action, risk, proposed_at) VALUES ($1,$2,$3,$4,'subfinder','recon','read',now())`, suffix+"-approval", tenantA, sessionID, engagementID)
+		return err
+	}); err != nil {
+		t.Fatalf("create tenant A approval: %v", err)
+	}
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM agent_approvals WHERE tenant_id=$1`, tenantA).Scan(&count)
+	}); err != nil {
+		t.Fatalf("query tenant B approvals: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("tenant B exposed %d tenant A approvals", count)
+	}
+
 	if err := NewReconRunStore(runtime).Save(ctxA, recon.Run{ID: shared.ID(suffix + "-recon"), EngagementID: shared.ID(engagementID), Tool: "subfinder", Target: "example.test", Status: recon.StatusRunning, StartedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("create tenant A recon run: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
@@ -170,4 +170,19 @@ func TestTenantRLSIsolation(t *testing.T) {
 			t.Fatalf("tenant B exposed %d tenant A %s rows", count, table)
 		}
 	}
+
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantA), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO jobs (id, tenant_id, kind, payload) VALUES ($1,$2,'sca','{}')`, suffix+"-job", tenantA)
+		return err
+	}); err != nil {
+		t.Fatalf("create tenant A durable job: %v", err)
+	}
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM jobs WHERE tenant_id=$1`, tenantA).Scan(&count)
+	}); err != nil {
+		t.Fatalf("query tenant B jobs: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("tenant B exposed %d tenant A jobs", count)
+	}
 }

--- a/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
@@ -40,7 +41,7 @@ func TestTenantRLSIsolation(t *testing.T) {
 	}
 
 	suffix := fmt.Sprintf("rls-%d", time.Now().UnixNano())
-	tenantA, tenantB, projectID := suffix+"-a", suffix+"-b", suffix+"-project"
+	tenantA, tenantB, projectID, engagementID := suffix+"-a", suffix+"-b", suffix+"-project", suffix+"-engagement"
 	for _, tenant := range []string{tenantA, tenantB} {
 		if _, err := admin.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1, $2)`, tenant, tenant); err != nil {
 			t.Fatalf("insert tenant %q: %v", tenant, err)
@@ -48,6 +49,7 @@ func TestTenantRLSIsolation(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_, _ = admin.Exec(ctx, `DELETE FROM projects WHERE id=$1`, projectID)
+		_, _ = admin.Exec(ctx, `DELETE FROM engagements WHERE id=$1`, engagementID)
 		_, _ = admin.Exec(ctx, `DELETE FROM tenants WHERE id = ANY($1)`, []string{tenantA, tenantB})
 	})
 
@@ -80,5 +82,30 @@ func TestTenantRLSIsolation(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("tenant A count = %d, want 1", count)
+	}
+
+	eng, err := engagement.New(shared.ID(engagementID), shared.ID(tenantA), "RLS engagement", "", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("new engagement: %v", err)
+	}
+	eng.Scope = engagement.Scope{InScope: []engagement.Target{{Kind: engagement.TargetDomain, Value: "example.test"}}}
+	if err := NewEngagementRepository(runtime).Create(ctx, eng); err != nil {
+		t.Fatalf("create tenant A engagement: %v", err)
+	}
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM engagements WHERE id=$1`, engagementID).Scan(&count)
+	}); err != nil {
+		t.Fatalf("query tenant B engagement: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("tenant B exposed %d tenant A engagements", count)
+	}
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM scope_targets WHERE engagement_id=$1`, engagementID).Scan(&count)
+	}); err != nil {
+		t.Fatalf("query tenant B scope: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("tenant B exposed %d tenant A scope targets", count)
 	}
 }

--- a/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
@@ -107,5 +109,24 @@ func TestTenantRLSIsolation(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("tenant B exposed %d tenant A scope targets", count)
+	}
+
+	ctxA := shared.WithTenant(ctx, shared.ID(tenantA))
+	findingID := suffix + "-finding"
+	if err := NewFindingRepository(runtime).Upsert(ctxA, []finding.Finding{{ID: shared.ID(findingID), EngagementID: shared.ID(engagementID), Title: "RLS finding", Severity: shared.SeverityHigh, Status: finding.StatusOpen, DedupKey: suffix + "-dedup"}}); err != nil {
+		t.Fatalf("create tenant A finding: %v", err)
+	}
+	if err := NewEvidenceStore(runtime).Append(ctxA, []evidence.Evidence{{ID: shared.ID(suffix + "-evidence"), EngagementID: shared.ID(engagementID), FindingID: shared.ID(findingID), Kind: "scan", Content: []byte("rls evidence"), Hash: suffix + "-hash", CreatedAt: time.Now().UTC()}}); err != nil {
+		t.Fatalf("create tenant A evidence: %v", err)
+	}
+	for _, table := range []string{"findings", "evidence"} {
+		if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE engagement_id=$1`, engagementID).Scan(&count)
+		}); err != nil {
+			t.Fatalf("query tenant B %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("tenant B exposed %d tenant A %s rows", count, table)
+		}
 	}
 }

--- a/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TestTenantRLSIsolation exercises actual PostgreSQL policies. It is opt-in so
+// ordinary unit tests do not need a database. Supply a non-superuser runtime
+// DSN and a separate migration/admin DSN.
+func TestTenantRLSIsolation(t *testing.T) {
+	runtimeDSN := os.Getenv("SYNAPSE_TEST_POSTGRES_DSN")
+	adminDSN := os.Getenv("SYNAPSE_TEST_POSTGRES_MIGRATE_DSN")
+	if runtimeDSN == "" || adminDSN == "" {
+		t.Skip("set SYNAPSE_TEST_POSTGRES_DSN and SYNAPSE_TEST_POSTGRES_MIGRATE_DSN to run PostgreSQL RLS integration")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, adminDSN); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	admin, err := Connect(ctx, adminDSN)
+	if err != nil {
+		t.Fatalf("connect admin: %v", err)
+	}
+	defer admin.Close()
+	runtime, err := Connect(ctx, runtimeDSN)
+	if err != nil {
+		t.Fatalf("connect runtime: %v", err)
+	}
+	defer runtime.Close()
+	if err := RequireNonSuperuser(ctx, runtime); err != nil {
+		t.Fatalf("runtime role: %v", err)
+	}
+
+	suffix := fmt.Sprintf("rls-%d", time.Now().UnixNano())
+	tenantA, tenantB, projectID := suffix+"-a", suffix+"-b", suffix+"-project"
+	for _, tenant := range []string{tenantA, tenantB} {
+		if _, err := admin.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1, $2)`, tenant, tenant); err != nil {
+			t.Fatalf("insert tenant %q: %v", tenant, err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = admin.Exec(ctx, `DELETE FROM projects WHERE id=$1`, projectID)
+		_, _ = admin.Exec(ctx, `DELETE FROM tenants WHERE id = ANY($1)`, []string{tenantA, tenantB})
+	})
+
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantA), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO projects (id, tenant_id, name, key, source_binding, default_profile_by_lang, gate_id, created_at, updated_at, created_by, updated_by) VALUES ($1,$2,'RLS test',$3,'{}','{}','',now(),now(),'test','test')`, projectID, tenantA, suffix)
+		return err
+	}); err != nil {
+		t.Fatalf("insert tenant A project: %v", err)
+	}
+
+	var count int
+	if err := runtime.QueryRow(ctx, `SELECT count(*) FROM projects WHERE id=$1`, projectID).Scan(&count); err != nil {
+		t.Fatalf("query without tenant context: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("unset tenant context exposed %d rows", count)
+	}
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM projects WHERE id=$1`, projectID).Scan(&count)
+	}); err != nil {
+		t.Fatalf("query tenant B: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("tenant B exposed %d tenant A rows", count)
+	}
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantA), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM projects WHERE id=$1`, projectID).Scan(&count)
+	}); err != nil {
+		t.Fatalf("query tenant A: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("tenant A count = %d, want 1", count)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/recon"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 // TestTenantRLSIsolation exercises actual PostgreSQL policies. It is opt-in so
@@ -139,6 +141,23 @@ func TestTenantRLSIsolation(t *testing.T) {
 		t.Fatalf("create tenant A agent message: %v", err)
 	}
 	for _, table := range []string{"agent_sessions", "agent_messages"} {
+		if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE tenant_id=$1`, tenantA).Scan(&count)
+		}); err != nil {
+			t.Fatalf("query tenant B %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("tenant B exposed %d tenant A %s rows", count, table)
+		}
+	}
+
+	if err := NewReconRunStore(runtime).Save(ctxA, recon.Run{ID: shared.ID(suffix + "-recon"), EngagementID: shared.ID(engagementID), Tool: "subfinder", Target: "example.test", Status: recon.StatusRunning, StartedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create tenant A recon run: %v", err)
+	}
+	if err := NewScanJobStore(runtime).CreateRunning(ctxA, ports.ScanJob{ID: suffix + "-scan", EngagementID: engagementID, Target: "example.test", Kind: "local", Status: ports.ScanRunning, StartedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create tenant A scan job: %v", err)
+	}
+	for _, table := range []string{"recon_runs", "scan_jobs"} {
 		if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
 			return tx.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE tenant_id=$1`, tenantA).Scan(&count)
 		}); err != nil {

--- a/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
@@ -85,8 +85,29 @@ func TestTenantRLSIsolation(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("query tenant A: %v", err)
 	}
+
 	if count != 1 {
 		t.Fatalf("tenant A count = %d, want 1", count)
+	}
+	now := time.Now().UTC()
+	if err := WithTenantTx(ctx, runtime, shared.ID(tenantA), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO project_issues (id, tenant_id, project_id, issue_key, finding_identity, rule_key, issue_type, title, description, severity, finding_kind, file, location, status, version, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at) VALUES ($1,$2,$3,'issue','issue','rule','bug','RLS issue','desc','medium','sast','main.go','main.go:1','open',1,'analysis','analysis',$4,$4,$4,$4)`, suffix+"-project-issue", tenantA, projectID, now); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `INSERT INTO project_hotspots (id, tenant_id, project_id, hotspot_key, finding_identity, rule_key, title, description, severity, finding_kind, location, status, version, first_seen_analysis_id, last_seen_analysis_id, first_seen_at, last_seen_at, created_at, updated_at) VALUES ($1,$2,$3,'hotspot','hotspot','rule','RLS hotspot','desc','medium','sast','main.go:1','to_review',1,'analysis','analysis',$4,$4,$4,$4)`, suffix+"-project-hotspot", tenantA, projectID, now)
+		return err
+	}); err != nil {
+		t.Fatalf("create tenant A project artifacts: %v", err)
+	}
+	for _, table := range []string{"project_issues", "project_hotspots"} {
+		if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE tenant_id=$1`, tenantA).Scan(&count)
+		}); err != nil {
+			t.Fatalf("query tenant B %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("tenant B exposed %d tenant A %s rows", count, table)
+		}
 	}
 
 	eng, err := engagement.New(shared.ID(engagementID), shared.ID(tenantA), "RLS engagement", "", time.Now().UTC())

--- a/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -122,6 +123,24 @@ func TestTenantRLSIsolation(t *testing.T) {
 	for _, table := range []string{"findings", "evidence"} {
 		if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
 			return tx.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE engagement_id=$1`, engagementID).Scan(&count)
+		}); err != nil {
+			t.Fatalf("query tenant B %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("tenant B exposed %d tenant A %s rows", count, table)
+		}
+	}
+
+	sessionID := shared.ID(suffix + "-session")
+	if err := NewAgentSessionStore(runtime).SaveSession(ctxA, agent.Session{ID: sessionID, EngagementID: shared.ID(engagementID), InitiatedBy: "operator", Goal: "RLS session", Status: agent.StatusRunning, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create tenant A agent session: %v", err)
+	}
+	if err := NewAgentSessionStore(runtime).AppendMessage(ctxA, sessionID, 0, agent.Message{Role: agent.RoleUser, Content: "RLS message"}); err != nil {
+		t.Fatalf("create tenant A agent message: %v", err)
+	}
+	for _, table := range []string{"agent_sessions", "agent_messages"} {
+		if err := WithTenantTx(ctx, runtime, shared.ID(tenantB), func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE tenant_id=$1`, tenantA).Scan(&count)
 		}); err != nil {
 			t.Fatalf("query tenant B %s: %v", table, err)
 		}

--- a/internal/infrastructure/persistence/postgres/tenant_tx.go
+++ b/internal/infrastructure/persistence/postgres/tenant_tx.go
@@ -31,3 +31,14 @@ func WithTenantTx(ctx context.Context, pool *pgxpool.Pool, tenantID shared.ID, f
 	}
 	return nil
 }
+
+// WithContextTenantTx is for ports whose historic signature does not carry a
+// tenant ID. HTTP authentication and durable jobs must bind the context first;
+// missing context fails closed rather than becoming a cross-tenant wildcard.
+func WithContextTenantTx(ctx context.Context, pool *pgxpool.Pool, fn func(pgx.Tx) error) error {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("tenant context is required")
+	}
+	return WithTenantTx(ctx, pool, tenantID, fn)
+}

--- a/internal/infrastructure/persistence/postgres/tenant_tx.go
+++ b/internal/infrastructure/persistence/postgres/tenant_tx.go
@@ -1,0 +1,33 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// WithTenantTx runs fn in a transaction whose RLS tenant context cannot escape
+// to another pooled request. The empty ID is the existing default tenant; an
+// absent setting is intentionally impossible through this API.
+func WithTenantTx(ctx context.Context, pool *pgxpool.Pool, tenantID shared.ID, fn func(pgx.Tx) error) error {
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin tenant transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.tenant_id', $1, true)", tenantID.String()); err != nil {
+		return fmt.Errorf("set tenant context: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tenant transaction: %w", err)
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/writeupdraft_repo.go
+++ b/internal/infrastructure/persistence/postgres/writeupdraft_repo.go
@@ -28,60 +28,53 @@ func NewWriteupDraftRepository(pool *pgxpool.Pool) *WriteupDraftRepository {
 
 var _ ports.WriteupDraftStore = (*WriteupDraftRepository)(nil)
 
-// Save upserts a draft by id. Unlike a Judgment (insert-only), a Draft is mutable working data, so on
-// conflict the mutable fields (text, state, decided_by, updated_at) are replaced; the immutable fields
-// (engagement_id, finding_id, proposed_by, created_at) are never moved. tenant_id is written as the
-// empty-string default tenant (mirrors judgments/findings); reads are tenant-isolated via the engagement
-// gate, and the column is present so the P5/E22 row-scoping sweep covers it.
+// Save upserts a draft by id under the request or durable-job tenant context.
 func (r *WriteupDraftRepository) Save(ctx context.Context, d writeupdraft.Draft) error {
-	if _, err := r.pool.Exec(ctx,
-		`INSERT INTO writeup_drafts (id, tenant_id, engagement_id, finding_id, description, remediation, state, proposed_by, decided_by, created_at, updated_at)
-		 VALUES ($1, '', $2, $3, $4, $5, $6, $7, $8, $9, $10)
-		 ON CONFLICT (id) DO UPDATE SET
-		   description = EXCLUDED.description,
-		   remediation = EXCLUDED.remediation,
-		   state       = EXCLUDED.state,
-		   decided_by  = EXCLUDED.decided_by,
-		   updated_at  = EXCLUDED.updated_at`,
-		d.ID.String(), d.EngagementID.String(), d.FindingID.String(), d.Description, d.Remediation,
-		string(d.State), d.ProposedBy, d.DecidedBy, d.CreatedAt, d.UpdatedAt); err != nil {
-		return fmt.Errorf("save writeup draft: %w", err)
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("tenant context is required")
 	}
-	return nil
+	return WithTenantTx(ctx, r.pool, tenantID, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO writeup_drafts (id, tenant_id, engagement_id, finding_id, description, remediation, state, proposed_by, decided_by, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) ON CONFLICT (id) DO UPDATE SET description = EXCLUDED.description, remediation = EXCLUDED.remediation, state = EXCLUDED.state, decided_by = EXCLUDED.decided_by, updated_at = EXCLUDED.updated_at`, d.ID.String(), tenantID.String(), d.EngagementID.String(), d.FindingID.String(), d.Description, d.Remediation, string(d.State), d.ProposedBy, d.DecidedBy, d.CreatedAt, d.UpdatedAt); err != nil {
+			return fmt.Errorf("save writeup draft: %w", err)
+		}
+		return nil
+	})
 }
 
 // Get returns the engagement's draft by id, or shared.ErrNotFound.
-func (r *WriteupDraftRepository) Get(ctx context.Context, engagementID, id shared.ID) (writeupdraft.Draft, error) {
-	d, err := scanWriteupDraft(r.pool.QueryRow(ctx,
-		`SELECT `+writeupDraftCols+` FROM writeup_drafts WHERE id=$1 AND engagement_id=$2`,
-		id.String(), engagementID.String()))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return writeupdraft.Draft{}, fmt.Errorf("writeup draft %s: %w", id, shared.ErrNotFound)
-	}
-	if err != nil {
-		return writeupdraft.Draft{}, fmt.Errorf("get writeup draft: %w", err)
-	}
-	return d, nil
+func (r *WriteupDraftRepository) Get(ctx context.Context, engagementID, id shared.ID) (out writeupdraft.Draft, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		out, err = scanWriteupDraft(tx.QueryRow(ctx, `SELECT `+writeupDraftCols+` FROM writeup_drafts WHERE id=$1 AND engagement_id=$2`, id.String(), engagementID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("writeup draft %s: %w", id, shared.ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("get writeup draft: %w", err)
+		}
+		return nil
+	})
+	return out, err
 }
 
 // ListByEngagement returns the engagement's drafts, oldest first (deterministic order).
-func (r *WriteupDraftRepository) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]writeupdraft.Draft, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT `+writeupDraftCols+` FROM writeup_drafts WHERE engagement_id=$1 ORDER BY created_at ASC, id COLLATE "C" ASC`,
-		engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list writeup drafts: %w", err)
-	}
-	defer rows.Close()
-	out := make([]writeupdraft.Draft, 0)
-	for rows.Next() {
-		d, err := scanWriteupDraft(rows)
+func (r *WriteupDraftRepository) ListByEngagement(ctx context.Context, engagementID shared.ID) (out []writeupdraft.Draft, err error) {
+	err = WithContextTenantTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+writeupDraftCols+` FROM writeup_drafts WHERE engagement_id=$1 ORDER BY created_at ASC, id COLLATE "C" ASC`, engagementID.String())
 		if err != nil {
-			return nil, fmt.Errorf("scan writeup draft: %w", err)
+			return fmt.Errorf("list writeup drafts: %w", err)
 		}
-		out = append(out, d)
-	}
-	return out, rows.Err()
+		defer rows.Close()
+		for rows.Next() {
+			d, err := scanWriteupDraft(rows)
+			if err != nil {
+				return fmt.Errorf("scan writeup draft: %w", err)
+			}
+			out = append(out, d)
+		}
+		return rows.Err()
+	})
+	return out, err
 }
 
 // scanWriteupDraft scans a writeupDraftCols row into a Draft, fail-closed on a corrupted/hand-edited

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -24,8 +24,11 @@ type Config struct {
 	AUPFile string
 	// AuditFile is the append-only audit log (file-backed until Postgres).
 	AuditFile string
-	// DBDSN, when set, enables PostgreSQL persistence; empty = in-memory (dev).
+	// DBDSN is the non-superuser application DSN. Empty selects in-memory persistence in dev.
 	DBDSN string
+	// DBMigrateDSN is an optional privileged DSN used only to apply schema migrations.
+	// Production deployments should keep it distinct from DBDSN so the runtime role cannot bypass RLS.
+	DBMigrateDSN string
 	// SyftBin is the Syft executable used for SBOM generation (shell-out).
 	SyftBin string
 	// SBOMProducer selects the SBOM-generation producer: "syft" (default – the pinned
@@ -352,6 +355,7 @@ func Load() Config {
 		AUPFile:                          getenv("SYNAPSE_AUP_FILE", "data/aup-accepted.json"),
 		AuditFile:                        getenv("SYNAPSE_AUDIT_FILE", "data/audit.jsonl"),
 		DBDSN:                            getenv("SYNAPSE_DB_DSN", ""),
+		DBMigrateDSN:                     getenv("SYNAPSE_DB_MIGRATE_DSN", ""),
 		SyftBin:                          getenv("SYNAPSE_SYFT_BIN", "syft"),
 		SBOMProducer:                     getenv("SYNAPSE_SBOM_PRODUCER", "syft"),
 		GrypeBin:                         getenv("SYNAPSE_GRYPE_BIN", "grype"),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -37,6 +37,18 @@ func TestLoadNormalizesEnvironment(t *testing.T) {
 	}
 }
 
+func TestLoadDatabaseMigrationDSN(t *testing.T) {
+	t.Setenv("SYNAPSE_DB_DSN", "postgres://runtime.example/synapse")
+	t.Setenv("SYNAPSE_DB_MIGRATE_DSN", "postgres://migrator.example/synapse")
+	c := Load()
+	if c.DBDSN != "postgres://runtime.example/synapse" {
+		t.Fatalf("DBDSN = %q", c.DBDSN)
+	}
+	if c.DBMigrateDSN != "postgres://migrator.example/synapse" {
+		t.Fatalf("DBMigrateDSN = %q", c.DBMigrateDSN)
+	}
+}
+
 // TestFindingMinSeverityDefaultsToInfo pins the default vuln severity floor at "info" so EVERY
 // detected vulnerability is promoted to a finding (matching Grype/Trivy/OSV-Scanner). A higher
 // default silently hides detected vulns and reads as "missing vulns"; prioritization is by risk

--- a/internal/usecase/approval/service.go
+++ b/internal/usecase/approval/service.go
@@ -132,17 +132,24 @@ func (s *Service) SweepAllExpired(ctx context.Context) (int, error) {
 	if s.timeout <= 0 {
 		return 0, nil
 	}
-	engs, err := s.store.EngagementsWithPending(ctx)
+	tenantIDs, err := s.store.TenantIDs(ctx)
 	if err != nil {
 		return 0, err
 	}
 	total := 0
-	for _, e := range engs {
-		n, err := s.SweepExpired(ctx, e)
+	for _, tenantID := range tenantIDs {
+		tenantCtx := shared.WithTenant(ctx, tenantID)
+		engs, err := s.store.EngagementsWithPending(tenantCtx)
 		if err != nil {
 			return total, err
 		}
-		total += n
+		for _, engagementID := range engs {
+			n, err := s.SweepExpired(tenantCtx, engagementID)
+			if err != nil {
+				return total, err
+			}
+			total += n
+		}
 	}
 	return total, nil
 }

--- a/internal/usecase/assessmentuc/service.go
+++ b/internal/usecase/assessmentuc/service.go
@@ -1,0 +1,97 @@
+package assessmentuc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type BusinessServiceReader interface {
+	GetBusinessService(context.Context, shared.ID) (asset.BusinessService, error)
+}
+
+type Service struct {
+	repo             ports.AssessmentRepository
+	businessServices BusinessServiceReader
+	clock            ports.Clock
+	ids              ports.IDGenerator
+}
+
+func New(repo ports.AssessmentRepository, businessServices BusinessServiceReader, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if repo == nil || businessServices == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("assessment dependencies are required")
+	}
+	return &Service{repo: repo, businessServices: businessServices, clock: clock, ids: ids}, nil
+}
+
+type EngagementInput struct {
+	Name   string
+	Client string
+}
+
+type CreateInput struct {
+	TenantID, BusinessServiceID shared.ID
+	Actor, Name, Objective      string
+	Policy                      assessment.Policy
+	Engagements                 []EngagementInput
+}
+
+func (s *Service) Create(ctx context.Context, in CreateInput) (assessment.Assessment, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok || tenantID != in.TenantID {
+		return assessment.Assessment{}, fmt.Errorf("%w: assessment tenant context", shared.ErrValidation)
+	}
+	if len(in.Engagements) == 0 || len(in.Engagements) > 128 {
+		return assessment.Assessment{}, fmt.Errorf("%w: assessment requires 1-128 engagements", shared.ErrValidation)
+	}
+	if _, err := s.businessServices.GetBusinessService(ctx, in.BusinessServiceID); err != nil {
+		return assessment.Assessment{}, err
+	}
+	now := s.clock.Now()
+	a, err := assessment.New(s.ids.NewID(), in.TenantID, in.BusinessServiceID, in.Name, in.Objective, in.Policy, now)
+	if err != nil {
+		return assessment.Assessment{}, err
+	}
+	a.Audit.CreatedBy, a.Audit.UpdatedBy = in.Actor, in.Actor
+	children := make([]*engagement.Engagement, 0, len(in.Engagements))
+	for _, input := range in.Engagements {
+		e, err := engagement.New(s.ids.NewID(), in.TenantID, strings.TrimSpace(input.Name), strings.TrimSpace(input.Client), now)
+		if err != nil {
+			return assessment.Assessment{}, err
+		}
+		e.AssessmentID = a.ID
+		e.Audit.CreatedBy, e.Audit.UpdatedBy = in.Actor, in.Actor
+		children = append(children, e)
+	}
+	if err := s.repo.Create(ctx, a, children); err != nil {
+		return assessment.Assessment{}, err
+	}
+	return a, nil
+}
+
+func (s *Service) Get(ctx context.Context, businessServiceID, assessmentID shared.ID) (assessment.Assessment, error) {
+	if _, err := s.businessServices.GetBusinessService(ctx, businessServiceID); err != nil {
+		return assessment.Assessment{}, err
+	}
+	a, err := s.repo.Get(ctx, assessmentID)
+	if err != nil {
+		return assessment.Assessment{}, err
+	}
+	if a.BusinessServiceID != businessServiceID {
+		return assessment.Assessment{}, fmt.Errorf("assessment parent: %w", shared.ErrNotFound)
+	}
+	return a, nil
+}
+
+func (s *Service) List(ctx context.Context, businessServiceID shared.ID) ([]assessment.Assessment, error) {
+	if _, err := s.businessServices.GetBusinessService(ctx, businessServiceID); err != nil {
+		return nil, err
+	}
+	return s.repo.ListByBusinessService(ctx, businessServiceID)
+}

--- a/internal/usecase/assessmentuc/service.go
+++ b/internal/usecase/assessmentuc/service.go
@@ -30,7 +30,7 @@ func New(repo ports.AssessmentRepository, businessServices BusinessServiceReader
 	return &Service{repo: repo, businessServices: businessServices, clock: clock, ids: ids}, nil
 }
 
-type EngagementInput struct {
+type AssetInput struct {
 	Name   string
 	Client string
 }
@@ -39,7 +39,7 @@ type CreateInput struct {
 	TenantID, BusinessServiceID shared.ID
 	Actor, Name, Objective      string
 	Policy                      assessment.Policy
-	Engagements                 []EngagementInput
+	Assets                      []AssetInput
 }
 
 func (s *Service) Create(ctx context.Context, in CreateInput) (assessment.Assessment, error) {
@@ -47,8 +47,8 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (assessment.Assess
 	if !ok || tenantID != in.TenantID {
 		return assessment.Assessment{}, fmt.Errorf("%w: assessment tenant context", shared.ErrValidation)
 	}
-	if len(in.Engagements) == 0 || len(in.Engagements) > 128 {
-		return assessment.Assessment{}, fmt.Errorf("%w: assessment requires 1-128 engagements", shared.ErrValidation)
+	if len(in.Assets) == 0 || len(in.Assets) > 128 {
+		return assessment.Assessment{}, fmt.Errorf("%w: assessment requires 1-128 assets", shared.ErrValidation)
 	}
 	if _, err := s.businessServices.GetBusinessService(ctx, in.BusinessServiceID); err != nil {
 		return assessment.Assessment{}, err
@@ -59,8 +59,8 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (assessment.Assess
 		return assessment.Assessment{}, err
 	}
 	a.Audit.CreatedBy, a.Audit.UpdatedBy = in.Actor, in.Actor
-	children := make([]*engagement.Engagement, 0, len(in.Engagements))
-	for _, input := range in.Engagements {
+	children := make([]*engagement.Engagement, 0, len(in.Assets))
+	for _, input := range in.Assets {
 		e, err := engagement.New(s.ids.NewID(), in.TenantID, strings.TrimSpace(input.Name), strings.TrimSpace(input.Client), now)
 		if err != nil {
 			return assessment.Assessment{}, err

--- a/internal/usecase/assessmentuc/service_test.go
+++ b/internal/usecase/assessmentuc/service_test.go
@@ -1,0 +1,61 @@
+package assessmentuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+type testClock struct{ now time.Time }
+
+func (c testClock) Now() time.Time { return c.now }
+
+type testIDs struct{ n int }
+
+func (g *testIDs) NewID() shared.ID { g.n++; return shared.ID(string(rune('a' + g.n))) }
+
+func TestAssessmentHierarchyAndEngagementDefaults(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	clock := testClock{now: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}
+	services := memory.NewAssetInventoryRepository()
+	engagements := memory.NewEngagementRepository()
+	if err := services.CreateBusinessService(ctx, asset.BusinessService{ID: "service-a", TenantID: "tenant-a", Name: "Service", Criticality: asset.CriticalityMedium, Lifecycle: asset.LifecyclePlanned}); err != nil {
+		t.Fatal(err)
+	}
+	svc, err := New(memory.NewAssessmentRepository(services, engagements), services, clock, &testIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", BusinessServiceID: "missing", Name: "A", Engagements: []EngagementInput{{Name: "E"}}}); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("missing parent=%v", err)
+	}
+	if _, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", BusinessServiceID: "service-a", Name: "A"}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("zero children=%v", err)
+	}
+	created, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", BusinessServiceID: "service-a", Actor: "operator", Name: "A", Engagements: []EngagementInput{{Name: "E", Client: "Client"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	children, err := engagements.List(ctx, "tenant-a")
+	if err != nil || len(children) != 1 {
+		t.Fatalf("children=%v err=%v", children, err)
+	}
+	child := children[0]
+	if child.AssessmentID != created.ID || !child.ProjectID.IsZero() || child.Status != "draft" || child.LiveReconEnabled {
+		t.Fatalf("child=%+v", child)
+	}
+	if _, err := svc.Get(ctx, "other", created.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("wrong parent=%v", err)
+	}
+	if _, err := svc.List(ctx, "other"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("nonexistent parent list=%v", err)
+	}
+	if _, err := svc.Create(shared.WithTenant(context.Background(), "tenant-b"), CreateInput{TenantID: "tenant-b", BusinessServiceID: "service-a", Name: "Cross", Engagements: []EngagementInput{{Name: "E"}}}); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross parent=%v", err)
+	}
+}

--- a/internal/usecase/assessmentuc/service_test.go
+++ b/internal/usecase/assessmentuc/service_test.go
@@ -31,13 +31,13 @@ func TestAssessmentHierarchyAndEngagementDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", BusinessServiceID: "missing", Name: "A", Engagements: []EngagementInput{{Name: "E"}}}); !errors.Is(err, shared.ErrNotFound) {
+	if _, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", BusinessServiceID: "missing", Name: "A", Assets: []AssetInput{{Name: "E"}}}); !errors.Is(err, shared.ErrNotFound) {
 		t.Fatalf("missing parent=%v", err)
 	}
 	if _, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", BusinessServiceID: "service-a", Name: "A"}); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("zero children=%v", err)
 	}
-	created, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", BusinessServiceID: "service-a", Actor: "operator", Name: "A", Engagements: []EngagementInput{{Name: "E", Client: "Client"}}})
+	created, err := svc.Create(ctx, CreateInput{TenantID: "tenant-a", BusinessServiceID: "service-a", Actor: "operator", Name: "A", Assets: []AssetInput{{Name: "E", Client: "Client"}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestAssessmentHierarchyAndEngagementDefaults(t *testing.T) {
 	if _, err := svc.List(ctx, "other"); !errors.Is(err, shared.ErrNotFound) {
 		t.Fatalf("nonexistent parent list=%v", err)
 	}
-	if _, err := svc.Create(shared.WithTenant(context.Background(), "tenant-b"), CreateInput{TenantID: "tenant-b", BusinessServiceID: "service-a", Name: "Cross", Engagements: []EngagementInput{{Name: "E"}}}); !errors.Is(err, shared.ErrNotFound) {
+	if _, err := svc.Create(shared.WithTenant(context.Background(), "tenant-b"), CreateInput{TenantID: "tenant-b", BusinessServiceID: "service-a", Name: "Cross", Assets: []AssetInput{{Name: "E"}}}); !errors.Is(err, shared.ErrNotFound) {
 		t.Fatalf("cross parent=%v", err)
 	}
 }

--- a/internal/usecase/assetuc/service.go
+++ b/internal/usecase/assetuc/service.go
@@ -1,0 +1,193 @@
+// Package assetuc owns tenant-bound Asset Inventory commands.
+package assetuc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type Service struct {
+	repo  ports.AssetInventoryRepository
+	clock ports.Clock
+	ids   ports.IDGenerator
+}
+
+func New(repo ports.AssetInventoryRepository, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if repo == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("asset inventory dependencies are required")
+	}
+	return &Service{repo: repo, clock: clock, ids: ids}, nil
+}
+
+type CreateAssetInput struct {
+	TenantID       shared.ID
+	Actor, Name    string
+	Category       asset.Category
+	Identity       asset.Identity
+	Lifecycle      asset.Lifecycle
+	Criticality    asset.Criticality
+	Exposure       asset.Exposure
+	Classification string
+}
+
+func (s *Service) CreateAsset(ctx context.Context, in CreateAssetInput) (asset.Asset, error) {
+	now := s.clock.Now()
+	a, err := asset.New(s.ids.NewID(), in.TenantID, in.Name, in.Category, in.Identity, now)
+	if err != nil {
+		return asset.Asset{}, err
+	}
+	a.Lifecycle = in.Lifecycle
+	if a.Lifecycle == "" {
+		a.Lifecycle = asset.LifecyclePlanned
+	}
+	a.Criticality = in.Criticality
+	if a.Criticality == "" {
+		a.Criticality = asset.CriticalityMedium
+	}
+	a.Exposure = in.Exposure
+	if a.Exposure == "" {
+		a.Exposure = asset.ExposureInternal
+	}
+	a.Classification = strings.TrimSpace(in.Classification)
+	a.Audit.CreatedBy, a.Audit.UpdatedBy = in.Actor, in.Actor
+	if err := a.Validate(); err != nil {
+		return asset.Asset{}, err
+	}
+	if err := s.repo.CreateAsset(ctx, a); err != nil {
+		return asset.Asset{}, err
+	}
+	return a, nil
+}
+
+type CreateBusinessServiceInput struct {
+	TenantID                 shared.ID
+	Actor, Name, Description string
+	Criticality              asset.Criticality
+	Lifecycle                asset.Lifecycle
+}
+
+func (s *Service) CreateBusinessService(ctx context.Context, in CreateBusinessServiceInput) (asset.BusinessService, error) {
+	now := s.clock.Now()
+	b := asset.BusinessService{ID: s.ids.NewID(), TenantID: in.TenantID, Name: strings.TrimSpace(in.Name), Description: strings.TrimSpace(in.Description), Criticality: in.Criticality, Lifecycle: in.Lifecycle, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now, CreatedBy: in.Actor, UpdatedBy: in.Actor}}
+	if b.Criticality == "" {
+		b.Criticality = asset.CriticalityMedium
+	}
+	if b.Lifecycle == "" {
+		b.Lifecycle = asset.LifecyclePlanned
+	}
+	if err := b.Validate(); err != nil {
+		return asset.BusinessService{}, err
+	}
+	if err := s.repo.CreateBusinessService(ctx, b); err != nil {
+		return asset.BusinessService{}, err
+	}
+	return b, nil
+}
+func (s *Service) LinkAsset(ctx context.Context, actor string, serviceID, assetID shared.ID, role asset.AssetLinkRole) error {
+	return s.repo.LinkBusinessServiceAsset(ctx, asset.BusinessServiceAssetLink{BusinessServiceID: serviceID, AssetID: assetID, Role: role, CreatedAt: s.clock.Now(), CreatedBy: actor})
+}
+func (s *Service) Relate(ctx context.Context, tenant shared.ID, actor string, from, to shared.ID, typ asset.RelationshipType) error {
+	return s.repo.CreateRelationship(ctx, asset.Relationship{ID: s.ids.NewID(), TenantID: tenant, FromAssetID: from, ToAssetID: to, Type: typ, CreatedAt: s.clock.Now(), CreatedBy: actor})
+}
+func (s *Service) AssignOwner(ctx context.Context, tenant shared.ID, actor, principal, role string, assetID shared.ID) error {
+	return s.repo.AssignOwner(ctx, asset.OwnershipAssignment{ID: s.ids.NewID(), TenantID: tenant, AssetID: assetID, Principal: principal, Role: role, CreatedAt: s.clock.Now(), CreatedBy: actor})
+}
+func (s *Service) GetAsset(ctx context.Context, id shared.ID) (asset.Asset, error) {
+	return s.repo.GetAsset(ctx, id)
+}
+func (s *Service) ListAssets(ctx context.Context) ([]asset.Asset, error) {
+	return s.repo.ListAssets(ctx)
+}
+func (s *Service) GetBusinessService(ctx context.Context, id shared.ID) (asset.BusinessService, error) {
+	return s.repo.GetBusinessService(ctx, id)
+}
+func (s *Service) ListBusinessServices(ctx context.Context) ([]asset.BusinessService, error) {
+	return s.repo.ListBusinessServices(ctx)
+}
+
+func (s *Service) ListAssetVersions(ctx context.Context, id shared.ID) ([]asset.Version, error) {
+	return s.repo.ListAssetVersions(ctx, id)
+}
+
+func (s *Service) ListRelationships(ctx context.Context, id shared.ID) ([]asset.Relationship, error) {
+	return s.repo.ListRelationships(ctx, id)
+}
+
+func (s *Service) ListOwners(ctx context.Context, id shared.ID) ([]asset.OwnershipAssignment, error) {
+	return s.repo.ListOwners(ctx, id)
+}
+
+func (s *Service) ListBusinessServiceAssets(ctx context.Context, id shared.ID) ([]asset.BusinessServiceAssetLink, error) {
+	return s.repo.ListBusinessServiceAssets(ctx, id)
+}
+
+func (s *Service) DeleteAsset(ctx context.Context, id shared.ID) error {
+	return s.repo.DeleteAsset(ctx, id)
+}
+
+func (s *Service) DeleteBusinessService(ctx context.Context, id shared.ID) error {
+	return s.repo.DeleteBusinessService(ctx, id)
+}
+
+type UpdateBusinessServiceInput struct {
+	Actor, Name, Description string
+	Criticality              asset.Criticality
+	Lifecycle                asset.Lifecycle
+}
+
+func (s *Service) UpdateBusinessService(ctx context.Context, id shared.ID, in UpdateBusinessServiceInput) (asset.BusinessService, error) {
+	current, err := s.repo.GetBusinessService(ctx, id)
+	if err != nil {
+		return asset.BusinessService{}, err
+	}
+	current.Name = strings.TrimSpace(in.Name)
+	current.Description = strings.TrimSpace(in.Description)
+	current.Criticality = in.Criticality
+	current.Lifecycle = in.Lifecycle
+	current.Audit.UpdatedAt, current.Audit.UpdatedBy = s.clock.Now(), in.Actor
+	if err := current.Validate(); err != nil {
+		return asset.BusinessService{}, err
+	}
+	if err := s.repo.UpdateBusinessService(ctx, current); err != nil {
+		return asset.BusinessService{}, err
+	}
+	return current, nil
+}
+
+type UpdateAssetInput struct {
+	Actor           string
+	ExpectedVersion int
+	Lifecycle       asset.Lifecycle
+	Criticality     asset.Criticality
+	Exposure        asset.Exposure
+	Classification  string
+}
+
+func (s *Service) UpdateAsset(ctx context.Context, id shared.ID, in UpdateAssetInput) (asset.Asset, error) {
+	current, err := s.repo.GetAsset(ctx, id)
+	if err != nil {
+		return asset.Asset{}, err
+	}
+	if in.ExpectedVersion != current.Version {
+		return asset.Asset{}, fmt.Errorf("asset %s: %w", id, shared.ErrConflict)
+	}
+	current.Lifecycle, current.Criticality, current.Exposure = in.Lifecycle, in.Criticality, in.Exposure
+	current.Classification = strings.TrimSpace(in.Classification)
+	current.Version++
+	current.Audit.UpdatedAt, current.Audit.UpdatedBy = s.clock.Now(), in.Actor
+	snapshot, err := json.Marshal(current)
+	if err != nil {
+		return asset.Asset{}, err
+	}
+	version := asset.Version{ID: s.ids.NewID(), TenantID: current.TenantID, AssetID: current.ID, Number: current.Version, Snapshot: snapshot, CreatedAt: current.Audit.UpdatedAt, CreatedBy: in.Actor}
+	if err := s.repo.UpdateAsset(ctx, current, version); err != nil {
+		return asset.Asset{}, err
+	}
+	return current, nil
+}

--- a/internal/usecase/assetuc/service_test.go
+++ b/internal/usecase/assetuc/service_test.go
@@ -1,0 +1,70 @@
+package assetuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+type fixedClock struct{ now time.Time }
+
+func (c fixedClock) Now() time.Time { return c.now }
+
+type fixedIDs struct{ next int }
+
+func (g *fixedIDs) NewID() shared.ID { g.next++; return shared.ID(string(rune('a' + g.next))) }
+
+func TestUpdateBusinessServiceAndProtectedDelete(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant")
+	clock := fixedClock{now: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}
+	ids := &fixedIDs{}
+	services := memory.NewAssetInventoryRepository()
+	engagements := memory.NewEngagementRepository()
+	repo := memory.NewAssessmentRepository(services, engagements)
+	svc, err := New(services, clock, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := svc.CreateBusinessService(ctx, CreateBusinessServiceInput{TenantID: "tenant", Actor: "creator", Name: " First ", Description: " Initial ", Criticality: asset.CriticalityMedium, Lifecycle: asset.LifecyclePlanned})
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := svc.UpdateBusinessService(ctx, created.ID, UpdateBusinessServiceInput{Actor: "editor", Name: " Updated ", Description: " Changed ", Criticality: asset.CriticalityHigh, Lifecycle: asset.LifecycleActive})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "Updated" || updated.Description != "Changed" || updated.Criticality != asset.CriticalityHigh || updated.Lifecycle != asset.LifecycleActive || updated.ID != created.ID || updated.TenantID != created.TenantID || updated.Audit.CreatedAt != created.Audit.CreatedAt || updated.Audit.CreatedBy != "creator" || updated.Audit.UpdatedAt != clock.now || updated.Audit.UpdatedBy != "editor" {
+		t.Fatalf("updated=%+v created=%+v", updated, created)
+	}
+	if _, err := svc.CreateBusinessService(ctx, CreateBusinessServiceInput{TenantID: "tenant", Actor: "creator", Name: "Duplicate", Criticality: asset.CriticalityMedium, Lifecycle: asset.LifecyclePlanned}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateBusinessService(ctx, created.ID, UpdateBusinessServiceInput{Name: "Duplicate", Criticality: asset.CriticalityHigh, Lifecycle: asset.LifecycleActive}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate error=%v", err)
+	}
+	if _, err := svc.UpdateBusinessService(ctx, created.ID, UpdateBusinessServiceInput{Name: "", Criticality: asset.CriticalityHigh, Lifecycle: asset.LifecycleActive}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("invalid error=%v", err)
+	}
+	a, err := assessment.New("assessment", "tenant", created.ID, "Assessment", "", assessment.Policy{}, clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, err := engagement.New("engagement", "tenant", "Engagement", "", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.AssessmentID = a.ID
+	if err := repo.Create(ctx, a, []*engagement.Engagement{e}); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.DeleteBusinessService(ctx, created.ID); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("delete error=%v", err)
+	}
+}

--- a/internal/usecase/orchestrator/deadletter_test.go
+++ b/internal/usecase/orchestrator/deadletter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
 )
 
@@ -15,11 +16,11 @@ import (
 // it and the job/session states no longer permanently disagree.
 func TestFailStrandedJobFinalizesRunningSession(t *testing.T) {
 	orch, _, sessions := newOrch(t, loadLLM{}, &fakeExecutor{}, agent.ModeAuto, orchestrator.Config{MaxSteps: 4})
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "")
 	if err := sessions.SaveSession(ctx, agent.Session{ID: "s1", EngagementID: "eng-1", InitiatedBy: "alice", Goal: "g", Status: agent.StatusRunning}); err != nil {
 		t.Fatal(err)
 	}
-	payload, err := orchestrator.DriveJob("s1")
+	payload, err := orchestrator.DriveJob(ctx, "s1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,11 +40,11 @@ func TestFailStrandedJobFinalizesRunningSession(t *testing.T) {
 // already reached a terminal state (e.g. a concurrent delivery succeeded before the dead-letter).
 func TestFailStrandedJobNoOpsOnTerminal(t *testing.T) {
 	orch, _, sessions := newOrch(t, loadLLM{}, &fakeExecutor{}, agent.ModeAuto, orchestrator.Config{MaxSteps: 4})
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "")
 	if err := sessions.SaveSession(ctx, agent.Session{ID: "s1", EngagementID: "eng-1", InitiatedBy: "alice", Status: agent.StatusSucceeded}); err != nil {
 		t.Fatal(err)
 	}
-	payload, _ := orchestrator.DriveJob("s1")
+	payload, _ := orchestrator.DriveJob(ctx, "s1")
 	if err := orch.FailStrandedJob(ctx, payload, errors.New("boom")); err != nil {
 		t.Fatalf("FailStrandedJob: %v", err)
 	}
@@ -57,11 +58,11 @@ func TestFailStrandedJobNoOpsOnTerminal(t *testing.T) {
 // plus the reconciler can re-present the same dead-letter – leaving the session failed, no error.
 func TestFailStrandedJobIdempotent(t *testing.T) {
 	orch, _, sessions := newOrch(t, loadLLM{}, &fakeExecutor{}, agent.ModeAuto, orchestrator.Config{MaxSteps: 4})
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "")
 	if err := sessions.SaveSession(ctx, agent.Session{ID: "s1", EngagementID: "eng-1", InitiatedBy: "alice", Status: agent.StatusRunning}); err != nil {
 		t.Fatal(err)
 	}
-	payload, _ := orchestrator.DriveJob("s1")
+	payload, _ := orchestrator.DriveJob(ctx, "s1")
 	for i := 0; i < 2; i++ {
 		if err := orch.FailStrandedJob(ctx, payload, errors.New("boom")); err != nil {
 			t.Fatalf("FailStrandedJob #%d: %v", i+1, err)

--- a/internal/usecase/orchestrator/orchestrator.go
+++ b/internal/usecase/orchestrator/orchestrator.go
@@ -465,19 +465,30 @@ func lastPendingCall(transcript []agent.Message) (agent.ToolCall, bool) {
 
 // agentJob is the durable-queue payload for an agent run.
 type agentJob struct {
-	Op        string `json:"op"` // "drive" | "resume"
-	SessionID string `json:"session_id"`
-	ActionID  string `json:"action_id,omitempty"`
+	Op        string  `json:"op"` // "drive" | "resume"
+	TenantID  *string `json:"tenant_id"`
+	SessionID string  `json:"session_id"`
+	ActionID  string  `json:"action_id,omitempty"`
 }
 
-// DriveJob encodes a job that drives a started session to completion.
-func DriveJob(sessionID shared.ID) ([]byte, error) {
-	return json.Marshal(agentJob{Op: "drive", SessionID: sessionID.String()})
+// DriveJob encodes a tenant-bound job that drives a started session to completion.
+func DriveJob(ctx context.Context, sessionID shared.ID) ([]byte, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: tenant context is required for agent job", shared.ErrValidation)
+	}
+	tenant := tenantID.String()
+	return json.Marshal(agentJob{Op: "drive", TenantID: &tenant, SessionID: sessionID.String()})
 }
 
-// ResumeJob encodes a job that resumes a session after the given action was decided.
-func ResumeJob(sessionID, actionID shared.ID) ([]byte, error) {
-	return json.Marshal(agentJob{Op: "resume", SessionID: sessionID.String(), ActionID: actionID.String()})
+// ResumeJob encodes a tenant-bound job that resumes a session after the given action was decided.
+func ResumeJob(ctx context.Context, sessionID, actionID shared.ID) ([]byte, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: tenant context is required for agent job", shared.ErrValidation)
+	}
+	tenant := tenantID.String()
+	return json.Marshal(agentJob{Op: "resume", TenantID: &tenant, SessionID: sessionID.String(), ActionID: actionID.String()})
 }
 
 // RunJob is the worker handler (JobKind). It drives or resumes a session. A genuine
@@ -489,6 +500,10 @@ func (o *Orchestrator) RunJob(ctx context.Context, payload []byte) error {
 	if err := json.Unmarshal(payload, &j); err != nil {
 		return fmt.Errorf("%w: malformed agent job: %v", shared.ErrValidation, err)
 	}
+	if j.TenantID == nil {
+		return fmt.Errorf("%w: agent job is missing tenant context", shared.ErrValidation)
+	}
+	ctx = shared.WithTenant(ctx, shared.ID(*j.TenantID))
 	var sess agent.Session
 	var err error
 	switch j.Op {
@@ -514,6 +529,10 @@ func (o *Orchestrator) FailStrandedJob(ctx context.Context, payload []byte, caus
 	if err := json.Unmarshal(payload, &j); err != nil {
 		return fmt.Errorf("%w: malformed agent job: %v", shared.ErrValidation, err)
 	}
+	if j.TenantID == nil {
+		return fmt.Errorf("%w: agent job is missing tenant context", shared.ErrValidation)
+	}
+	ctx = shared.WithTenant(ctx, shared.ID(*j.TenantID))
 	sessionID := shared.ID(j.SessionID)
 	release, ok, err := o.lock(ctx, sessionID)
 	if err != nil {

--- a/internal/usecase/orchestrator/orchestrator_resume_test.go
+++ b/internal/usecase/orchestrator/orchestrator_resume_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/agenttools"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
@@ -145,7 +146,7 @@ func TestResumeAfterDenialFeedsBackNeverExecutes(t *testing.T) {
 // TestRunJobDispatches: the durable handler drives a started session to completion.
 func TestRunJobDispatches(t *testing.T) {
 	h := newResumeHarness(t, []ports.ChatResponse{chatStop("nothing to do")})
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "")
 	sess, err := h.orch.Start(ctx, "eng-1", "alice", "just answer")
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +154,7 @@ func TestRunJobDispatches(t *testing.T) {
 	if sess.Status != agent.StatusRunning {
 		t.Fatalf("Start must leave the session running, got %s", sess.Status)
 	}
-	payload, err := orchestrator.DriveJob(sess.ID)
+	payload, err := orchestrator.DriveJob(ctx, sess.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usecase/orchestrator/reconcile.go
+++ b/internal/usecase/orchestrator/reconcile.go
@@ -15,6 +15,7 @@ import (
 // here (not imported from usecase/worker) so the orchestrator stays off the worker package –
 // the concrete ports.JobQueue satisfies it.
 type resumableLister interface {
+	TenantIDs(ctx context.Context) ([]shared.ID, error)
 	ListResumable(ctx context.Context, staleFor time.Duration, now time.Time, limit int) ([]agent.Session, error)
 }
 type enqueuer interface {
@@ -54,28 +55,34 @@ func NewReconciler(sessions resumableLister, enqueue enqueuer, clock ports.Clock
 // re-enqueued. Idempotent: re-driving is safe (Drive no-ops a terminal session, the run lock
 // serializes, and fail-closed per-action idempotency prevents a double-run).
 func (r *Reconciler) ReconcileOnce(ctx context.Context) (int, error) {
-	sessions, err := r.sessions.ListResumable(ctx, r.staleFor, r.clock.Now(), r.limit)
+	tenantIDs, err := r.sessions.TenantIDs(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("list resumable sessions: %w", err)
+		return 0, fmt.Errorf("list session tenants: %w", err)
 	}
 	n := 0
-	for _, sess := range sessions {
-		if sess.Status == agent.StatusAwaitingApproval {
-			// A human owes a decision; never auto-drive an action that is awaiting approval.
-			r.log.Info("reconcile: session awaiting approval (not auto-driven)", "session", sess.ID.String())
-			continue
-		}
-		payload, err := DriveJob(shared.WithTenant(ctx, sess.TenantID), sess.ID)
+	for _, tenantID := range tenantIDs {
+		tenantCtx := shared.WithTenant(ctx, tenantID)
+		sessions, err := r.sessions.ListResumable(tenantCtx, r.staleFor, r.clock.Now(), r.limit)
 		if err != nil {
-			r.log.Error("reconcile: build drive job", "session", sess.ID.String(), "err", err)
-			continue
+			return n, fmt.Errorf("list resumable sessions for tenant %s: %w", tenantID, err)
 		}
-		if _, err := r.enqueue.Enqueue(ctx, JobKind, payload); err != nil {
-			r.log.Error("reconcile: re-enqueue drive job", "session", sess.ID.String(), "err", err)
-			continue
+		for _, sess := range sessions {
+			if sess.Status == agent.StatusAwaitingApproval {
+				r.log.Info("reconcile: session awaiting approval (not auto-driven)", "session", sess.ID.String())
+				continue
+			}
+			payload, err := DriveJob(tenantCtx, sess.ID)
+			if err != nil {
+				r.log.Error("reconcile: build drive job", "session", sess.ID.String(), "err", err)
+				continue
+			}
+			if _, err := r.enqueue.Enqueue(tenantCtx, JobKind, payload); err != nil {
+				r.log.Error("reconcile: re-enqueue drive job", "session", sess.ID.String(), "err", err)
+				continue
+			}
+			r.log.Info("reconcile: re-enqueued stranded running session", "session", sess.ID.String())
+			n++
 		}
-		r.log.Info("reconcile: re-enqueued stranded running session", "session", sess.ID.String())
-		n++
 	}
 	return n, nil
 }

--- a/internal/usecase/orchestrator/reconcile.go
+++ b/internal/usecase/orchestrator/reconcile.go
@@ -65,7 +65,7 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) (int, error) {
 			r.log.Info("reconcile: session awaiting approval (not auto-driven)", "session", sess.ID.String())
 			continue
 		}
-		payload, err := DriveJob(sess.ID)
+		payload, err := DriveJob(shared.WithTenant(ctx, sess.TenantID), sess.ID)
 		if err != nil {
 			r.log.Error("reconcile: build drive job", "session", sess.ID.String(), "err", err)
 			continue

--- a/internal/usecase/orchestrator/reconcile_test.go
+++ b/internal/usecase/orchestrator/reconcile_test.go
@@ -6,10 +6,15 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
 )
 
 type fakeResumableLister struct{ sessions []agent.Session }
+
+func (f fakeResumableLister) TenantIDs(_ context.Context) ([]shared.ID, error) {
+	return []shared.ID{""}, nil
+}
 
 func (f fakeResumableLister) ListResumable(_ context.Context, _ time.Duration, _ time.Time, _ int) ([]agent.Session, error) {
 	return f.sessions, nil

--- a/internal/usecase/ports/agent.go
+++ b/internal/usecase/ports/agent.go
@@ -35,11 +35,10 @@ type AgentSessionStore interface {
 type ApprovalStore interface {
 	Enqueue(ctx context.Context, a agent.ProposedAction) error
 	Pending(ctx context.Context, engagementID shared.ID) ([]agent.ProposedAction, error)
-	// Get returns the proposed action and its current decision (state ApprovalPending until decided).
+	// TenantIDs returns registry identities for timeout-sweeper fan-out.
+	TenantIDs(ctx context.Context) ([]shared.ID, error)
 	Get(ctx context.Context, actionID shared.ID) (agent.ProposedAction, agent.ApprovalDecision, error)
 	Decide(ctx context.Context, d agent.ApprovalDecision) error
-	// EngagementsWithPending lists the engagements that have at least one pending approval –
-	// so the prod timeout sweeper can fan out across them without a global scan.
 	EngagementsWithPending(ctx context.Context) ([]shared.ID, error)
 }
 

--- a/internal/usecase/ports/agent.go
+++ b/internal/usecase/ports/agent.go
@@ -19,6 +19,9 @@ type AgentSessionStore interface {
 	ListByEngagement(ctx context.Context, engagementID shared.ID) ([]agent.Session, error)
 	AppendMessage(ctx context.Context, sessionID shared.ID, seq int, m agent.Message) error
 	Messages(ctx context.Context, sessionID shared.ID) ([]agent.Message, error)
+	// TenantIDs returns tenant identities from the registry for worker fan-out.
+	// Callers must bind one before any tenant-scoped session query.
+	TenantIDs(ctx context.Context) ([]shared.ID, error)
 	// ListResumable returns non-terminal sessions (running / awaiting_approval) not updated
 	// since now-staleFor, oldest first, capped at limit – the startup reconciler's input for
 	// re-driving sessions a crash stranded.

--- a/internal/usecase/ports/assessment.go
+++ b/internal/usecase/ports/assessment.go
@@ -1,0 +1,17 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// AssessmentRepository persists a Business Service assessment atomically with its
+// required Engagement children.
+type AssessmentRepository interface {
+	Create(context.Context, assessment.Assessment, []*engagement.Engagement) error
+	Get(context.Context, shared.ID) (assessment.Assessment, error)
+	ListByBusinessService(context.Context, shared.ID) ([]assessment.Assessment, error)
+}

--- a/internal/usecase/ports/asset_inventory.go
+++ b/internal/usecase/ports/asset_inventory.go
@@ -1,0 +1,31 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// AssetInventoryRepository is the tenant-scoped persistence boundary for the
+// bounded AppSec inventory. Implementations MUST treat every referenced ID as
+// tenant-owned and reject cross-tenant relationship/link attempts as not found.
+type AssetInventoryRepository interface {
+	CreateAsset(context.Context, asset.Asset) error
+	GetAsset(context.Context, shared.ID) (asset.Asset, error)
+	ListAssets(context.Context) ([]asset.Asset, error)
+	UpdateAsset(context.Context, asset.Asset, asset.Version) error
+	DeleteAsset(context.Context, shared.ID) error
+	ListAssetVersions(context.Context, shared.ID) ([]asset.Version, error)
+	CreateBusinessService(context.Context, asset.BusinessService) error
+	GetBusinessService(context.Context, shared.ID) (asset.BusinessService, error)
+	ListBusinessServices(context.Context) ([]asset.BusinessService, error)
+	UpdateBusinessService(context.Context, asset.BusinessService) error
+	DeleteBusinessService(context.Context, shared.ID) error
+	LinkBusinessServiceAsset(context.Context, asset.BusinessServiceAssetLink) error
+	ListBusinessServiceAssets(context.Context, shared.ID) ([]asset.BusinessServiceAssetLink, error)
+	CreateRelationship(context.Context, asset.Relationship) error
+	ListRelationships(context.Context, shared.ID) ([]asset.Relationship, error)
+	AssignOwner(context.Context, asset.OwnershipAssignment) error
+	ListOwners(context.Context, shared.ID) ([]asset.OwnershipAssignment, error)
+}

--- a/internal/usecase/ports/jobqueue.go
+++ b/internal/usecase/ports/jobqueue.go
@@ -3,6 +3,8 @@ package ports
 import (
 	"context"
 	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
 // QueuedJob is a unit of deferred work claimed from the JobQueue. Payload is an opaque,
@@ -10,6 +12,7 @@ import (
 // been incremented for this claim), so a handler can give up after N tries.
 type QueuedJob struct {
 	ID       string
+	TenantID shared.ID
 	Kind     string // e.g. "recon" | "sca"
 	Payload  []byte
 	Attempts int

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -295,6 +295,7 @@ type ScanManifest struct {
 // keys, enough to list history and compute drift between two runs.
 type ScanRun struct {
 	ID           string       `json:"id"`
+	TenantID     shared.ID    `json:"-"`
 	EngagementID string       `json:"engagement_id"`
 	CreatedAt    time.Time    `json:"created_at"`
 	Manifest     ScanManifest `json:"manifest"`

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -354,6 +354,7 @@ type ScanDebugEvent struct {
 // progress bar and survive a page reload (the pipeline runs server-side).
 type ScanJob struct {
 	ID           string           `json:"id"`
+	TenantID     shared.ID        `json:"-"`
 	EngagementID string           `json:"engagement_id"`
 	Target       string           `json:"target"`
 	Kind         string           `json:"kind"`

--- a/internal/usecase/recon/service.go
+++ b/internal/usecase/recon/service.go
@@ -287,16 +287,17 @@ func (s *Service) SweepStaleRuns(ctx context.Context, staleFor time.Duration) (i
 	n := 0
 	for i := range runs {
 		run := runs[i]
-		release, ok, lerr := s.runLock.TryLock(ctx, run.ID.String())
+		tenantCtx := shared.WithTenant(ctx, run.TenantID)
+		release, ok, lerr := s.runLock.TryLock(tenantCtx, run.ID.String())
 		if lerr != nil || !ok {
 			continue // can't acquire (DB hiccup) or a live owner holds it → leave for next pass
 		}
 		// Re-read under the lock: a final delivery may have just finished it.
-		if fresh, gerr := s.runs.Get(ctx, run.ID); gerr == nil && fresh.Status.Terminal() {
+		if fresh, gerr := s.runs.Get(tenantCtx, run.ID); gerr == nil && fresh.Status.Terminal() {
 			release()
 			continue
 		}
-		s.finishFailed(ctx, &run, "swept", "run stranded running past staleFor with no live owner – reclaimed by sweeper")
+		s.finishFailed(tenantCtx, &run, "swept", "run stranded running past staleFor with no live owner – reclaimed by sweeper")
 		release()
 		n++
 	}

--- a/internal/usecase/recon/service.go
+++ b/internal/usecase/recon/service.go
@@ -134,12 +134,12 @@ func (s *Service) SetRunLock(l ports.RunLocker) { s.runLock = l }
 // JobKind is the queue Kind for a recon run.
 const JobKind = "recon"
 
-// reconJob is the durable-queue payload for one recon run.
 type reconJob struct {
-	Actor  string `json:"actor"`
-	RunID  string `json:"run_id"`
-	Tool   string `json:"tool"`
-	Target string `json:"target"`
+	Actor    string  `json:"actor"`
+	TenantID *string `json:"tenant_id"`
+	RunID    string  `json:"run_id"`
+	Tool     string  `json:"tool"`
+	Target   string  `json:"target"`
 }
 
 // SetQueue routes recon runs through the durable job queue: Start enqueues, and a
@@ -154,6 +154,10 @@ func (s *Service) RunJob(ctx context.Context, payload []byte) error {
 	if err := json.Unmarshal(payload, &j); err != nil {
 		return fmt.Errorf("%w: malformed recon job payload: %v", shared.ErrValidation, err)
 	}
+	if j.TenantID == nil {
+		return fmt.Errorf("%w: recon job is missing tenant context", shared.ErrValidation)
+	}
+	ctx = shared.WithTenant(ctx, shared.ID(*j.TenantID))
 	if err := engagement.ValidateTargetValue(j.Target); err != nil {
 		return fmt.Errorf("%w: invalid recon job target: %v", shared.ErrValidation, err)
 	}
@@ -411,7 +415,12 @@ func (s *Service) Start(ctx context.Context, actor string, engagementID shared.I
 	// it (survives restart; runs under the worker's sandbox/egress/privilege). Otherwise
 	// the in-process dispatcher runs it (dev / single-process).
 	if s.jobQueue != nil {
-		payload, err := json.Marshal(reconJob{Actor: actor, RunID: run.ID.String(), Tool: toolName, Target: target.Value})
+		tenantID, ok := shared.TenantFrom(ctx)
+		if !ok {
+			return recon.Run{}, fmt.Errorf("%w: tenant context is required for durable recon", shared.ErrValidation)
+		}
+		tenant := tenantID.String()
+		payload, err := json.Marshal(reconJob{Actor: actor, TenantID: &tenant, RunID: run.ID.String(), Tool: toolName, Target: target.Value})
 		if err != nil {
 			s.finishFailed(ctx, &run, "queue", "marshal job: "+err.Error())
 			return run, fmt.Errorf("marshal recon job: %w", err)

--- a/internal/usecase/recon/service_test.go
+++ b/internal/usecase/recon/service_test.go
@@ -379,7 +379,7 @@ func TestStartViaDurableQueue(t *testing.T) {
 	q := memory.NewJobQueue(&seqIDs{}, nil)
 	h.svc.SetQueue(q)
 
-	run, err := h.svc.Start(context.Background(), "alice", "e1", "subfinder", "example.com")
+	run, err := h.svc.Start(shared.WithTenant(context.Background(), ""), "alice", "e1", "subfinder", "example.com")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -416,7 +416,7 @@ func TestFailStrandedJobFinalizesRun(t *testing.T) {
 	q := memory.NewJobQueue(&seqIDs{}, nil)
 	h.svc.SetQueue(q)
 
-	run, err := h.svc.Start(context.Background(), "alice", "e1", "subfinder", "example.com")
+	run, err := h.svc.Start(shared.WithTenant(context.Background(), ""), "alice", "e1", "subfinder", "example.com")
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -527,12 +527,13 @@ func TestRunJobAbortsOnLeaseLoss(t *testing.T) {
 	h := newHarness(t, ctxRunner{}, subfinderTool(), false)
 	h.seedEngagement(t, true)
 	h.svc.SetRunLock(fakeLeaseLock{})
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "")
 	run := recon.Run{ID: "run-1", EngagementID: "e1", Tool: "subfinder", Target: "example.com", Status: recon.StatusRunning, StartedAt: time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)}
 	if err := h.runs.Save(ctx, run); err != nil {
 		t.Fatal(err)
 	}
-	payload, err := json.Marshal(reconJob{Actor: "alice", RunID: "run-1", Tool: "subfinder", Target: "example.com"})
+	tenant := ""
+	payload, err := json.Marshal(reconJob{Actor: "alice", TenantID: &tenant, RunID: "run-1", Tool: "subfinder", Target: "example.com"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -1174,8 +1174,13 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 	// defer to the durable queue when configured (an in-process or separate worker
 	// claims + runs the pipeline with syft/grype sandboxed) – replaces the bare goroutine,
 	// so queued work survives a restart. Without a queue, the in-process goroutine runs it.
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return ports.ScanJob{}, fmt.Errorf("%w: tenant context is required for scan execution", shared.ErrValidation)
+	}
+	tenant := tenantID.String()
 	if s.jobQueue != nil {
-		payload, mErr := json.Marshal(scaJobPayload{Actor: actor, EngagementID: engagementID.String(), Now: now, Req: req, Options: opts, Job: job})
+		payload, mErr := json.Marshal(scaJobPayload{Actor: actor, TenantID: &tenant, EngagementID: engagementID.String(), Now: now, Req: req, Options: opts, Job: job})
 		if mErr != nil {
 			return ports.ScanJob{}, fmt.Errorf("marshal scan job: %w", mErr)
 		}
@@ -1187,16 +1192,16 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 		}
 		return job, nil
 	}
-	go s.runScanJob(actor, engagementID, now, req, opts, job)
+	go s.runScanJob(shared.WithTenant(context.Background(), tenantID), actor, engagementID, now, req, opts, job)
 	return job, nil
 }
 
 // ScanJobKind is the durable-queue Kind for an SCA scan.
 const ScanJobKind = "sca"
 
-// scaJobPayload is the durable-queue payload for one SCA scan run.
 type scaJobPayload struct {
 	Actor        string               `json:"actor"`
+	TenantID     *string              `json:"tenant_id"`
 	EngagementID string               `json:"engagement_id"`
 	Now          time.Time            `json:"now"`
 	Req          ports.AcquireRequest `json:"req"`
@@ -1220,6 +1225,10 @@ func (s *Service) RunScanJob(ctx context.Context, payload []byte) error {
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return fmt.Errorf("%w: malformed scan job payload: %v", shared.ErrValidation, err)
 	}
+	if p.TenantID == nil {
+		return fmt.Errorf("%w: scan job is missing tenant context", shared.ErrValidation)
+	}
+	ctx = shared.WithTenant(ctx, shared.ID(*p.TenantID))
 	// single-active-execution lease at the JOB boundary (re-audit fix) – a lock ERROR
 	// returns an error so the queue REDELIVERS (never silently completes a never-run scan);
 	// a held lease means another delivery is running it → complete this one (nil).
@@ -1237,7 +1246,7 @@ func (s *Service) RunScanJob(ctx context.Context, payload []byte) error {
 	if err != nil {
 		return err
 	}
-	s.runScanJob(p.Actor, shared.ID(p.EngagementID), p.Now, p.Req, opts, p.Job)
+	s.runScanJob(ctx, p.Actor, shared.ID(p.EngagementID), p.Now, p.Req, opts, p.Job)
 	return nil
 }
 
@@ -1251,6 +1260,10 @@ func (s *Service) FailStrandedScanJob(ctx context.Context, payload []byte, cause
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return fmt.Errorf("%w: malformed scan job payload: %v", shared.ErrValidation, err)
 	}
+	if p.TenantID == nil {
+		return fmt.Errorf("%w: scan job is missing tenant context", shared.ErrValidation)
+	}
+	ctx = shared.WithTenant(ctx, shared.ID(*p.TenantID))
 	if s.jobs == nil {
 		return nil
 	}
@@ -1448,9 +1461,9 @@ func looksLikePath(v string) bool {
 	return filepath.IsAbs(v) || strings.HasPrefix(v, ".") || strings.ContainsAny(v, `/\`)
 }
 
-// runScanJob runs the pipeline on a detached background context (the request that
-// started the scan has returned), advancing + finishing the job.
-func (s *Service) runScanJob(actor string, engagementID shared.ID, now time.Time, req ports.AcquireRequest, opts ScanOptions, job ports.ScanJob) {
+// runScanJob runs the pipeline in the tenant-bound background context carried
+// by the enqueueing request or durable queue payload.
+func (s *Service) runScanJob(ctx context.Context, actor string, engagementID shared.ID, now time.Time, req ports.AcquireRequest, opts ScanOptions, job ports.ScanJob) {
 	// Idempotency (audit): the durable queue is at-least-once, so a redelivery can
 	// re-invoke a scan a prior delivery already finished. Re-running is read-only (findings
 	// dedup by advisory+component+version) but would seal a DUPLICATE "scan" evidence link
@@ -1458,7 +1471,7 @@ func (s *Service) runScanJob(actor string, engagementID shared.ID, now time.Time
 	// already terminal, skip – the worker then Completes the job. (A newer scan started
 	// between deliveries masks this guard; the only cost there is the duplicate seal.)
 	if s.jobs != nil {
-		if latest, err := s.jobs.LatestForEngagement(context.Background(), engagementID); err == nil &&
+		if latest, err := s.jobs.LatestForEngagement(ctx, engagementID); err == nil &&
 			latest.ID == job.ID && (latest.Status == ports.ScanSucceeded || latest.Status == ports.ScanFailed) {
 			return
 		}
@@ -1466,7 +1479,6 @@ func (s *Service) runScanJob(actor string, engagementID shared.ID, now time.Time
 	if opts.ProjectAnalysis {
 		opts.ProjectAnalysisID = job.ID
 	}
-	ctx := context.Background()
 	if s.timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, s.timeout)
@@ -1494,7 +1506,7 @@ func (s *Service) runScanJob(actor string, engagementID shared.ID, now time.Time
 
 	fin := s.clock.Now()
 	if err == nil && opts.ProjectAnalysis && s.projectAnalysisRecorder != nil {
-		completionCtx, cancel := context.WithTimeout(context.Background(), s.projectAnalysisCompletionTimeout)
+		completionCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.projectAnalysisCompletionTimeout)
 		err = s.projectAnalysisRecorder.RecordProjectAnalysis(completionCtx, engagementID, job.ID, fin, result)
 		cancel()
 	}
@@ -1506,7 +1518,7 @@ func (s *Service) runScanJob(actor string, engagementID shared.ID, now time.Time
 		job.Status, job.Stage = ports.ScanSucceeded, "done"
 	}
 	if s.jobs != nil {
-		_ = s.jobs.Save(context.Background(), job) // fresh ctx: the timeout ctx may be done
+		_ = s.jobs.Save(context.WithoutCancel(ctx), job)
 	}
 }
 

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -1316,18 +1316,19 @@ func (s *Service) SweepStaleScans(ctx context.Context, staleFor time.Duration) (
 	}
 	n := 0
 	for _, job := range stale {
-		release, ok, lerr := s.runLock.TryLock(ctx, job.ID)
+		tenantCtx := shared.WithTenant(ctx, job.TenantID)
+		release, ok, lerr := s.runLock.TryLock(tenantCtx, job.ID)
 		if lerr != nil || !ok {
 			continue // can't acquire or a live owner holds it → leave for next pass
 		}
-		if fresh, gerr := s.jobs.GetJob(ctx, job.ID); gerr == nil && (fresh.Status == ports.ScanSucceeded || fresh.Status == ports.ScanFailed) {
+		if fresh, gerr := s.jobs.GetJob(tenantCtx, job.ID); gerr == nil && (fresh.Status == ports.ScanSucceeded || fresh.Status == ports.ScanFailed) {
 			release()
 			continue
 		}
 		fin := s.clock.Now()
 		job.FinishedAt, job.Progress = &fin, 100
 		job.Status, job.Stage, job.Error = ports.ScanFailed, "swept", "scan stranded running past staleFor with no live owner – reclaimed by sweeper"
-		_ = s.jobs.Save(ctx, job)
+		_ = s.jobs.Save(tenantCtx, job)
 		release()
 		n++
 	}

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -554,7 +554,7 @@ func TestProjectAnalysisCapturesSourceWhenImportedSBOMIsActive(t *testing.T) {
 	svc.SetProjectAnalysisRecorder(recorder)
 	job := ports.ScanJob{ID: "analysis-1", EngagementID: "e1", Status: ports.ScanRunning, StartedAt: time.Unix(200, 0).UTC()}
 
-	svc.runScanJob("operator", "e1", time.Unix(200, 0).UTC(), ports.AcquireRequest{Kind: ports.TargetLocal, Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, ProjectAnalysis: true}, job)
+	svc.runScanJob(context.Background(), "operator", "e1", time.Unix(200, 0).UTC(), ports.AcquireRequest{Kind: ports.TargetLocal, Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, ProjectAnalysis: true}, job)
 
 	if !acq.called {
 		t.Fatal("Project analysis must acquire its configured source, not use the imported SBOM")
@@ -730,7 +730,7 @@ func TestStartScanWithOptionsLicenseOnlySkipsVulnerabilitySources(t *testing.T) 
 		[]ports.DetectionSource{vulnSrc}, nil, licScan, nil,
 	)
 
-	job, err := svc.StartScanWithOptions(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeLicenses})
+	job, err := svc.StartScanWithOptions(shared.WithTenant(context.Background(), ""), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeLicenses})
 	if err != nil {
 		t.Fatalf("StartScanWithOptions: %v", err)
 	}
@@ -1048,7 +1048,7 @@ func TestStartScanAsyncCompletes(t *testing.T) {
 	jobs := newFakeJobStore()
 	svc := newAsyncSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, acq, audit, &fakeDetector{}, jobs, fakeIDs{})
 
-	job, err := svc.StartScan(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"})
+	job, err := svc.StartScan(shared.WithTenant(context.Background(), ""), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"})
 	if err != nil {
 		t.Fatalf("StartScan: %v", err)
 	}
@@ -1097,7 +1097,7 @@ func TestProjectRecorderUsesFreshCompletionContext(t *testing.T) {
 	svc.SetProjectAnalysisRecorder(recorder)
 	job := ports.ScanJob{ID: "job-1", EngagementID: "e1", Status: ports.ScanRunning, StartedAt: time.Unix(0, 0).UTC()}
 
-	svc.runScanJob("operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, ProjectAnalysis: true}, job)
+	svc.runScanJob(context.Background(), "operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, ProjectAnalysis: true}, job)
 
 	final, err := jobs.LatestForEngagement(context.Background(), "e1")
 	if err != nil {
@@ -1121,7 +1121,7 @@ func TestProjectRecorderUsesConfiguredCompletionTimeout(t *testing.T) {
 	job := ports.ScanJob{ID: "job-1", EngagementID: "e1", Status: ports.ScanRunning, StartedAt: time.Unix(0, 0).UTC()}
 
 	start := time.Now()
-	svc.runScanJob("operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, ProjectAnalysis: true}, job)
+	svc.runScanJob(context.Background(), "operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, ProjectAnalysis: true}, job)
 	if !recorder.called || recorder.deadline.Sub(start) > time.Second {
 		t.Fatalf("recorder deadline=%s start=%s", recorder.deadline, start)
 	}
@@ -1138,7 +1138,7 @@ func TestOrdinaryScanSkipsProjectRecorder(t *testing.T) {
 	svc.SetProjectAnalysisRecorder(&contextRecorder{err: errors.New("snapshot unavailable")})
 	job := ports.ScanJob{ID: "job-1", EngagementID: "e1", Status: ports.ScanRunning, StartedAt: time.Unix(0, 0).UTC()}
 
-	svc.runScanJob("operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull}, job)
+	svc.runScanJob(context.Background(), "operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull}, job)
 
 	final, err := jobs.LatestForEngagement(context.Background(), "e1")
 	if err != nil {
@@ -1156,7 +1156,7 @@ func TestProjectRecorderFailureFailsJob(t *testing.T) {
 	svc.SetProjectAnalysisRecorder(&contextRecorder{err: errors.New("snapshot unavailable")})
 	job := ports.ScanJob{ID: "job-1", EngagementID: "e1", Status: ports.ScanRunning, StartedAt: time.Unix(0, 0).UTC()}
 
-	svc.runScanJob("operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, ProjectAnalysis: true}, job)
+	svc.runScanJob(context.Background(), "operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, ProjectAnalysis: true}, job)
 
 	final, err := jobs.LatestForEngagement(context.Background(), "e1")
 	if err != nil {
@@ -1186,11 +1186,12 @@ func TestFailStrandedScanJobFinalizes(t *testing.T) {
 	jobs := newFakeJobStore()
 	svc := newAsyncSvc(&fakeEngRepo{eng: engagementWithScope(t, "myrepo")}, fakeClock{t: time.Unix(100, 0).UTC()}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{}, jobs, fakeIDs{})
 	ctx := context.Background()
+	tenant := ""
 	job := ports.ScanJob{ID: "job-1", EngagementID: "e1", Status: ports.ScanRunning, Stage: "sbom", Progress: 40}
 	if err := jobs.Save(ctx, job); err != nil {
 		t.Fatal(err)
 	}
-	payload, err := json.Marshal(scaJobPayload{Actor: "operator", EngagementID: "e1", Job: job})
+	payload, err := json.Marshal(scaJobPayload{Actor: "operator", TenantID: &tenant, EngagementID: "e1", Job: job})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usecase/worker/worker.go
+++ b/internal/usecase/worker/worker.go
@@ -13,6 +13,7 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -128,51 +129,43 @@ func (w *Worker) safeHandle(ctx context.Context, h Handler, job ports.QueuedJob)
 // process dispatches one job, heartbeating its lease until the handler returns, then
 // Completes or Fails it.
 func (w *Worker) process(ctx context.Context, job ports.QueuedJob) {
+	jobCtx := shared.WithTenant(ctx, job.TenantID)
 	h, ok := w.handlers[job.Kind]
 	if !ok {
-		// Unknown kind: there is no handler in this build. Park it (Complete) so it does
-		// not spin forever, and log loudly – a silent drop would hide a misconfiguration.
 		w.log.Error("no handler for job kind – parking job", "kind", job.Kind, "job", job.ID)
-		w.complete(job.ID)
+		w.complete(jobCtx, job.ID)
 		return
 	}
 
-	hbCtx, stopHB := context.WithCancel(ctx)
+	hbCtx, stopHB := context.WithCancel(jobCtx)
 	go w.heartbeat(hbCtx, job.ID)
 
-	err := w.safeHandle(ctx, h, job)
+	err := w.safeHandle(jobCtx, h, job)
 	stopHB()
 
 	if err == nil {
-		w.complete(job.ID)
+		w.complete(jobCtx, job.ID)
 		return
 	}
 	if job.Attempts >= w.cfg.MaxAttempts {
 		w.log.Error("job failed permanently – dead-lettering", "kind", job.Kind, "job", job.ID, "attempts", job.Attempts, "err", err)
-		// Drive the backing domain entity terminal BEFORE flipping the job row, so a reconciler
-		// keyed on the entity's status (not the job's) stops re-enqueuing it – closing the
-		// dead-letter → re-drive livelock. Best-effort + logged; never blocks the dead-letter.
 		if dl, ok := h.(DeadLetterer); ok {
-			if derr := dl.OnDeadLetter(context.Background(), job, err); derr != nil {
+			if derr := dl.OnDeadLetter(context.WithoutCancel(jobCtx), job, err); derr != nil {
 				w.log.Error("dead-letter entity finalize failed", "kind", job.Kind, "job", job.ID, "err", derr)
 			}
 		}
-		// Terminal FAILED state (not done): an abandoned authorized scan stays operator-
-		// visible + queryable, never silently indistinguishable from a success.
-		if derr := w.queue.Deadletter(context.Background(), job.ID); derr != nil {
+		if derr := w.queue.Deadletter(context.WithoutCancel(jobCtx), job.ID); derr != nil {
 			w.log.Error("dead-letter failed", "job", job.ID, "err", derr)
 		}
 		return
 	}
 	w.log.Warn("job failed – requeueing with backoff", "kind", job.Kind, "job", job.ID, "attempt", job.Attempts, "err", err)
-	if ferr := w.queue.Fail(ctx, job.ID, w.cfg.Backoff); ferr != nil {
+	if ferr := w.queue.Fail(jobCtx, job.ID, w.cfg.Backoff); ferr != nil {
 		w.log.Error("requeue failed", "job", job.ID, "err", ferr)
 	}
 }
 
-// heartbeat extends the job's lease on an interval until its context is cancelled (the
-// handler returned). Uses context.Background for the extension call so a cancelled
-// parent (shutdown) still lets the in-flight handler finish under a valid lease.
+// heartbeat extends the job's lease until its handler returns.
 func (w *Worker) heartbeat(ctx context.Context, id string) {
 	t := time.NewTicker(w.cfg.Heartbeat)
 	defer t.Stop()
@@ -181,15 +174,15 @@ func (w *Worker) heartbeat(ctx context.Context, id string) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			if err := w.queue.Heartbeat(context.Background(), id, w.cfg.Visibility); err != nil {
+			if err := w.queue.Heartbeat(context.WithoutCancel(ctx), id, w.cfg.Visibility); err != nil {
 				w.log.Warn("heartbeat failed", "job", id, "err", err)
 			}
 		}
 	}
 }
 
-func (w *Worker) complete(id string) {
-	if err := w.queue.Complete(context.Background(), id); err != nil {
+func (w *Worker) complete(ctx context.Context, id string) {
+	if err := w.queue.Complete(context.WithoutCancel(ctx), id); err != nil {
 		w.log.Error("complete failed", "job", id, "err", err)
 	}
 }

--- a/migrations/0058_tenant_rls_context.sql
+++ b/migrations/0058_tenant_rls_context.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- Request adapters set app.tenant_id with set_config(..., true) inside the
+-- transaction that performs the query. NULL means no tenant context; RLS
+-- migrations use this function rather than defaulting an absent context.
+-- The empty string remains the existing single-tenant default context.
+CREATE OR REPLACE FUNCTION synapse_current_tenant_id() RETURNS TEXT
+LANGUAGE sql
+STABLE
+AS $$ SELECT current_setting('app.tenant_id', true) $$;
+
+-- +goose Down
+DROP FUNCTION synapse_current_tenant_id();

--- a/migrations/0059_projects_quality_rls.sql
+++ b/migrations/0059_projects_quality_rls.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- These repositories are fully migrated to WithTenantTx. Keep policies narrow:
+-- a table is enabled only after every runtime operation establishes a tenant
+-- context, preventing a partial rollout from breaking unrelated persistence.
+ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE projects FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON projects
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE quality_gates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE quality_gates FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON quality_gates
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE quality_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE quality_profiles FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON quality_profiles
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON quality_profiles;
+ALTER TABLE quality_profiles NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE quality_profiles DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON quality_gates;
+ALTER TABLE quality_gates NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE quality_gates DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON projects;
+ALTER TABLE projects NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE projects DISABLE ROW LEVEL SECURITY;

--- a/migrations/0060_project_analyses_rls.sql
+++ b/migrations/0060_project_analyses_rls.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- ProjectAnalysisStore establishes app.tenant_id through WithTenantTx for every operation.
+ALTER TABLE project_analyses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE project_analyses FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON project_analyses
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON project_analyses;
+ALTER TABLE project_analyses NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE project_analyses DISABLE ROW LEVEL SECURITY;

--- a/migrations/0061_engagements_scope_rls.sql
+++ b/migrations/0061_engagements_scope_rls.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- EngagementRepository binds both parent and scope-target operations to the
+-- same tenant transaction. Scope targets derive tenancy from their parent.
+ALTER TABLE engagements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE engagements FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON engagements
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE scope_targets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scope_targets FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON scope_targets
+    USING (EXISTS (
+        SELECT 1 FROM engagements e
+        WHERE e.id = engagement_id AND e.tenant_id = synapse_current_tenant_id()
+    ))
+    WITH CHECK (EXISTS (
+        SELECT 1 FROM engagements e
+        WHERE e.id = engagement_id AND e.tenant_id = synapse_current_tenant_id()
+    ));
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON scope_targets;
+ALTER TABLE scope_targets NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE scope_targets DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON engagements;
+ALTER TABLE engagements NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE engagements DISABLE ROW LEVEL SECURITY;

--- a/migrations/0062_finding_evidence_rls.sql
+++ b/migrations/0062_finding_evidence_rls.sql
@@ -1,0 +1,59 @@
+-- +goose Up
+-- Every repository for these tenant-scoped records now binds app.tenant_id via
+-- WithTenantTx or WithContextTenantTx; durable SCA and recon payloads preserve
+-- the same tenant context before entering their pipelines.
+ALTER TABLE findings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE findings FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON findings
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE evidence ENABLE ROW LEVEL SECURITY;
+ALTER TABLE evidence FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON evidence
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE finding_comments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE finding_comments FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON finding_comments
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE finding_retests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE finding_retests FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON finding_retests
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE imported_sboms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE imported_sboms FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON imported_sboms
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE writeup_drafts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE writeup_drafts FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON writeup_drafts
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON writeup_drafts;
+ALTER TABLE writeup_drafts NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE writeup_drafts DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON imported_sboms;
+ALTER TABLE imported_sboms NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE imported_sboms DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON finding_retests;
+ALTER TABLE finding_retests NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE finding_retests DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON finding_comments;
+ALTER TABLE finding_comments NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE finding_comments DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON evidence;
+ALTER TABLE evidence NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE evidence DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON findings;
+ALTER TABLE findings NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE findings DISABLE ROW LEVEL SECURITY;

--- a/migrations/0063_execution_tenant_columns.sql
+++ b/migrations/0063_execution_tenant_columns.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- Backfill durable execution records from their immutable engagement/session parent
+-- before applying RLS in the follow-up migration. Queue rows stay nullable during
+-- transition because historic opaque payloads cannot establish a trustworthy tenant.
+ALTER TABLE agent_messages ADD COLUMN tenant_id TEXT;
+UPDATE agent_messages m SET tenant_id = s.tenant_id FROM agent_sessions s WHERE s.id = m.session_id;
+ALTER TABLE agent_messages ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE agent_decisions ADD COLUMN tenant_id TEXT;
+UPDATE agent_decisions d SET tenant_id = s.tenant_id FROM agent_sessions s WHERE s.id = d.session_id;
+ALTER TABLE agent_decisions ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE recon_runs ADD COLUMN tenant_id TEXT;
+UPDATE recon_runs r SET tenant_id = e.tenant_id FROM engagements e WHERE e.id = r.engagement_id;
+ALTER TABLE recon_runs ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE scan_jobs ADD COLUMN tenant_id TEXT;
+UPDATE scan_jobs j SET tenant_id = e.tenant_id FROM engagements e WHERE e.id = j.engagement_id;
+ALTER TABLE scan_jobs ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE scan_runs ADD COLUMN tenant_id TEXT;
+UPDATE scan_runs r SET tenant_id = e.tenant_id FROM engagements e WHERE e.id = r.engagement_id;
+ALTER TABLE scan_runs ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE jobs ADD COLUMN tenant_id TEXT;
+CREATE INDEX idx_jobs_tenant_claimable ON jobs (tenant_id, available_at) WHERE status <> 'done';
+
+-- +goose Down
+DROP INDEX idx_jobs_tenant_claimable;
+ALTER TABLE jobs DROP COLUMN tenant_id;
+ALTER TABLE scan_runs DROP COLUMN tenant_id;
+ALTER TABLE scan_jobs DROP COLUMN tenant_id;
+ALTER TABLE recon_runs DROP COLUMN tenant_id;
+ALTER TABLE agent_decisions DROP COLUMN tenant_id;
+ALTER TABLE agent_messages DROP COLUMN tenant_id;

--- a/migrations/0064_agent_runtime_rls.sql
+++ b/migrations/0064_agent_runtime_rls.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- Agent sessions are reconciled tenant-by-tenant; message, plan, and decision
+-- repositories execute under the same context before accessing these tables.
+ALTER TABLE agent_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_sessions FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON agent_sessions
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE agent_messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_messages FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON agent_messages
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE agent_plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_plans FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON agent_plans
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE agent_decisions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_decisions FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON agent_decisions
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON agent_decisions;
+ALTER TABLE agent_decisions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE agent_decisions DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON agent_plans;
+ALTER TABLE agent_plans NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE agent_plans DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON agent_messages;
+ALTER TABLE agent_messages NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE agent_messages DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON agent_sessions;
+ALTER TABLE agent_sessions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE agent_sessions DISABLE ROW LEVEL SECURITY;

--- a/migrations/0065_recon_scan_job_rls.sql
+++ b/migrations/0065_recon_scan_job_rls.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- Recon and SCA stale recovery enumerate tenant registry IDs, then query each
+-- tenant in a bound transaction. All normal reads and writes are tenant-bound.
+ALTER TABLE recon_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE recon_runs FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON recon_runs
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE scan_jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scan_jobs FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON scan_jobs
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON scan_jobs;
+ALTER TABLE scan_jobs NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE scan_jobs DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON recon_runs;
+ALTER TABLE recon_runs NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE recon_runs DISABLE ROW LEVEL SECURITY;

--- a/migrations/0066_scan_run_rls.sql
+++ b/migrations/0066_scan_run_rls.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+ALTER TABLE scan_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scan_runs FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON scan_runs
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON scan_runs;
+ALTER TABLE scan_runs NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE scan_runs DISABLE ROW LEVEL SECURITY;

--- a/migrations/0067_jobs_rls.sql
+++ b/migrations/0067_jobs_rls.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Claim enumerates tenant registry IDs and every queue transition executes with
+-- the claimed job's tenant-bound context.
+ALTER TABLE jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE jobs FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON jobs
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON jobs;
+ALTER TABLE jobs NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE jobs DISABLE ROW LEVEL SECURITY;

--- a/migrations/0068_agent_approvals_rls.sql
+++ b/migrations/0068_agent_approvals_rls.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Approval timeout sweeping enumerates tenant registry IDs and executes pending
+-- engagement discovery and decisions in a context bound to each tenant.
+ALTER TABLE agent_approvals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_approvals FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON agent_approvals
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON agent_approvals;
+ALTER TABLE agent_approvals NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE agent_approvals DISABLE ROW LEVEL SECURITY;

--- a/migrations/0069_project_artifacts_rls.sql
+++ b/migrations/0069_project_artifacts_rls.sql
@@ -1,0 +1,49 @@
+-- +goose Up
+-- Project artifact repositories bind app.tenant_id for ingestion, list/detail,
+-- transition, review history, and analysis-projection reads.
+ALTER TABLE project_hotspots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE project_hotspots FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON project_hotspots
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE project_hotspot_review_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE project_hotspot_review_events FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON project_hotspot_review_events
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE project_analysis_hotspots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE project_analysis_hotspots FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON project_analysis_hotspots
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE project_issues ENABLE ROW LEVEL SECURITY;
+ALTER TABLE project_issues FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON project_issues
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+ALTER TABLE project_issue_review_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE project_issue_review_events FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON project_issue_review_events
+    USING (tenant_id = synapse_current_tenant_id())
+    WITH CHECK (tenant_id = synapse_current_tenant_id());
+
+-- +goose Down
+DROP POLICY synapse_tenant_isolation ON project_issue_review_events;
+ALTER TABLE project_issue_review_events NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE project_issue_review_events DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON project_issues;
+ALTER TABLE project_issues NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE project_issues DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON project_analysis_hotspots;
+ALTER TABLE project_analysis_hotspots NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE project_analysis_hotspots DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON project_hotspot_review_events;
+ALTER TABLE project_hotspot_review_events NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE project_hotspot_review_events DISABLE ROW LEVEL SECURITY;
+DROP POLICY synapse_tenant_isolation ON project_hotspots;
+ALTER TABLE project_hotspots NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE project_hotspots DISABLE ROW LEVEL SECURITY;

--- a/migrations/0071_appsec_asset_inventory.sql
+++ b/migrations/0071_appsec_asset_inventory.sql
@@ -1,0 +1,135 @@
+-- +goose Up
+-- Bounded tenant-owned AppSec inventory. Assets retain a stable category/identity
+-- pair; shared infrastructure is linked to many business services instead of
+-- duplicated. Child RLS policies derive tenancy from their asset/service parent.
+CREATE TABLE appsec_assets (
+    id             TEXT PRIMARY KEY,
+    tenant_id      TEXT NOT NULL,
+    name           TEXT NOT NULL,
+    category       TEXT NOT NULL,
+    identity_kind  TEXT NOT NULL,
+    identity_value TEXT NOT NULL,
+    lifecycle      TEXT NOT NULL,
+    criticality    TEXT NOT NULL,
+    exposure       TEXT NOT NULL,
+    classification TEXT NOT NULL DEFAULT '',
+    version        INTEGER NOT NULL CHECK (version > 0),
+    created_at     TIMESTAMPTZ NOT NULL,
+    updated_at     TIMESTAMPTZ NOT NULL,
+    created_by     TEXT NOT NULL DEFAULT '',
+    updated_by     TEXT NOT NULL DEFAULT '',
+    UNIQUE (tenant_id, category, identity_kind, identity_value)
+);
+CREATE INDEX appsec_assets_tenant_category_idx ON appsec_assets (tenant_id, category, name);
+
+CREATE TABLE appsec_asset_versions (
+    id         TEXT PRIMARY KEY,
+    asset_id   TEXT NOT NULL REFERENCES appsec_assets(id) ON DELETE CASCADE,
+    tenant_id  TEXT NOT NULL,
+    number     INTEGER NOT NULL CHECK (number > 0),
+    snapshot   JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    UNIQUE (asset_id, number)
+);
+
+CREATE TABLE appsec_business_services (
+    id          TEXT PRIMARY KEY,
+    tenant_id   TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    criticality TEXT NOT NULL,
+    lifecycle   TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL,
+    created_by  TEXT NOT NULL DEFAULT '',
+    updated_by  TEXT NOT NULL DEFAULT '',
+    UNIQUE (tenant_id, name)
+);
+
+CREATE TABLE appsec_business_service_assets (
+    business_service_id TEXT NOT NULL REFERENCES appsec_business_services(id) ON DELETE CASCADE,
+    asset_id            TEXT NOT NULL REFERENCES appsec_assets(id) ON DELETE CASCADE,
+    role                TEXT NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL,
+    created_by          TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (business_service_id, asset_id)
+);
+CREATE INDEX appsec_business_service_assets_asset_idx ON appsec_business_service_assets (asset_id);
+
+CREATE TABLE appsec_asset_relationships (
+    id            TEXT PRIMARY KEY,
+    tenant_id     TEXT NOT NULL,
+    from_asset_id TEXT NOT NULL REFERENCES appsec_assets(id) ON DELETE CASCADE,
+    to_asset_id   TEXT NOT NULL REFERENCES appsec_assets(id) ON DELETE CASCADE,
+    relation_type TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
+    created_by    TEXT NOT NULL DEFAULT '',
+    CHECK (from_asset_id <> to_asset_id),
+    UNIQUE (from_asset_id, to_asset_id, relation_type)
+);
+CREATE INDEX appsec_asset_relationships_from_idx ON appsec_asset_relationships (from_asset_id);
+
+CREATE TABLE appsec_asset_ownership_assignments (
+    id         TEXT PRIMARY KEY,
+    tenant_id  TEXT NOT NULL,
+    asset_id   TEXT NOT NULL REFERENCES appsec_assets(id) ON DELETE CASCADE,
+    principal  TEXT NOT NULL,
+    role       TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    UNIQUE (asset_id, principal, role)
+);
+
+ALTER TABLE appsec_assets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE appsec_assets FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON appsec_assets USING (tenant_id = synapse_current_tenant_id()) WITH CHECK (tenant_id = synapse_current_tenant_id());
+ALTER TABLE appsec_asset_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE appsec_asset_versions FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_parent_tenant_isolation ON appsec_asset_versions
+USING (EXISTS (SELECT 1 FROM appsec_assets a WHERE a.id = asset_id AND a.tenant_id = synapse_current_tenant_id()))
+WITH CHECK (tenant_id = synapse_current_tenant_id() AND EXISTS (SELECT 1 FROM appsec_assets a WHERE a.id = asset_id AND a.tenant_id = synapse_current_tenant_id()));
+ALTER TABLE appsec_business_services ENABLE ROW LEVEL SECURITY;
+ALTER TABLE appsec_business_services FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON appsec_business_services USING (tenant_id = synapse_current_tenant_id()) WITH CHECK (tenant_id = synapse_current_tenant_id());
+ALTER TABLE appsec_business_service_assets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE appsec_business_service_assets FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_parent_tenant_isolation ON appsec_business_service_assets
+USING (EXISTS (SELECT 1 FROM appsec_business_services s WHERE s.id = business_service_id AND s.tenant_id = synapse_current_tenant_id()))
+WITH CHECK (EXISTS (SELECT 1 FROM appsec_business_services s WHERE s.id = business_service_id AND s.tenant_id = synapse_current_tenant_id()) AND EXISTS (SELECT 1 FROM appsec_assets a WHERE a.id = asset_id AND a.tenant_id = synapse_current_tenant_id()));
+ALTER TABLE appsec_asset_relationships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE appsec_asset_relationships FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_parent_tenant_isolation ON appsec_asset_relationships
+USING (EXISTS (SELECT 1 FROM appsec_assets a WHERE a.id = from_asset_id AND a.tenant_id = synapse_current_tenant_id()))
+WITH CHECK (tenant_id = synapse_current_tenant_id() AND EXISTS (SELECT 1 FROM appsec_assets a WHERE a.id = from_asset_id AND a.tenant_id = synapse_current_tenant_id()) AND EXISTS (SELECT 1 FROM appsec_assets a WHERE a.id = to_asset_id AND a.tenant_id = synapse_current_tenant_id()));
+ALTER TABLE appsec_asset_ownership_assignments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE appsec_asset_ownership_assignments FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_parent_tenant_isolation ON appsec_asset_ownership_assignments
+USING (EXISTS (SELECT 1 FROM appsec_assets a WHERE a.id = asset_id AND a.tenant_id = synapse_current_tenant_id()))
+WITH CHECK (tenant_id = synapse_current_tenant_id() AND EXISTS (SELECT 1 FROM appsec_assets a WHERE a.id = asset_id AND a.tenant_id = synapse_current_tenant_id()));
+
+-- +goose Down
+DROP POLICY synapse_parent_tenant_isolation ON appsec_asset_ownership_assignments;
+ALTER TABLE appsec_asset_ownership_assignments NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE appsec_asset_ownership_assignments DISABLE ROW LEVEL SECURITY;
+DROP TABLE appsec_asset_ownership_assignments;
+DROP POLICY synapse_parent_tenant_isolation ON appsec_asset_relationships;
+ALTER TABLE appsec_asset_relationships NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE appsec_asset_relationships DISABLE ROW LEVEL SECURITY;
+DROP TABLE appsec_asset_relationships;
+DROP POLICY synapse_parent_tenant_isolation ON appsec_business_service_assets;
+ALTER TABLE appsec_business_service_assets NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE appsec_business_service_assets DISABLE ROW LEVEL SECURITY;
+DROP TABLE appsec_business_service_assets;
+DROP POLICY synapse_tenant_isolation ON appsec_business_services;
+ALTER TABLE appsec_business_services NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE appsec_business_services DISABLE ROW LEVEL SECURITY;
+DROP TABLE appsec_business_services;
+DROP POLICY synapse_parent_tenant_isolation ON appsec_asset_versions;
+ALTER TABLE appsec_asset_versions NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE appsec_asset_versions DISABLE ROW LEVEL SECURITY;
+DROP TABLE appsec_asset_versions;
+DROP POLICY synapse_tenant_isolation ON appsec_assets;
+ALTER TABLE appsec_assets NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE appsec_assets DISABLE ROW LEVEL SECURITY;
+DROP TABLE appsec_assets;

--- a/migrations/0073_assessment_hierarchy.sql
+++ b/migrations/0073_assessment_hierarchy.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+CREATE TABLE assessments (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    business_service_id TEXT NOT NULL REFERENCES appsec_business_services(id),
+    name TEXT NOT NULL,
+    objective TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL,
+    policy JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    created_by TEXT NOT NULL DEFAULT '',
+    updated_by TEXT NOT NULL DEFAULT '',
+    UNIQUE (tenant_id, business_service_id, name)
+);
+ALTER TABLE engagements ADD COLUMN assessment_id TEXT REFERENCES assessments(id);
+CREATE INDEX engagements_assessment_idx ON engagements (assessment_id);
+ALTER TABLE assessments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE assessments FORCE ROW LEVEL SECURITY;
+CREATE POLICY synapse_tenant_isolation ON assessments USING (tenant_id = synapse_current_tenant_id()) WITH CHECK (tenant_id = synapse_current_tenant_id());
+-- +goose Down
+DROP INDEX IF EXISTS engagements_assessment_idx;
+ALTER TABLE engagements DROP COLUMN assessment_id;
+DROP POLICY synapse_tenant_isolation ON assessments;
+ALTER TABLE assessments NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE assessments DISABLE ROW LEVEL SECURITY;
+DROP TABLE assessments;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,8 +37,10 @@ function Gate() {
   return (
     <Routes>
       <Route element={<Shell />}>
-        <Route index element={<Navigate to="/engagements" replace />} />
-        <Route path="engagements" element={<Engagements />} />
+        <Route index element={<Navigate to="/assets" replace />} />
+        <Route path="assets" element={<Engagements />} />
+        <Route path="assets/:id" element={<EngagementDetail />} />
+        <Route path="engagements" element={<Navigate to="/assets" replace />} />
         <Route path="engagements/:id" element={<EngagementDetail />} />
         <Route path="business-services" element={<BusinessServices />} />
         <Route path="code-quality" element={<CodeQualityProjects />} />
@@ -57,7 +59,7 @@ function Gate() {
         <Route path="rules/:key" element={<RuleDetail />} />
         <Route path="audit" element={<Audit />} />
         <Route path="team" element={<Team />} />
-        <Route path="*" element={<Navigate to="/engagements" replace />} />
+        <Route path="*" element={<Navigate to="/assets" replace />} />
       </Route>
     </Routes>
   )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import { ProjectMeasuresPage } from './pages/ProjectMeasuresPage'
 import { ProjectCodePage } from './pages/ProjectCodePage'
 import { QualityGates } from './pages/QualityGates'
 import { QualityProfiles } from './pages/QualityProfiles'
+import { BusinessServices } from './pages/BusinessServices'
 
 export default function App() {
   return (
@@ -39,6 +40,7 @@ function Gate() {
         <Route index element={<Navigate to="/engagements" replace />} />
         <Route path="engagements" element={<Engagements />} />
         <Route path="engagements/:id" element={<EngagementDetail />} />
+        <Route path="business-services" element={<BusinessServices />} />
         <Route path="code-quality" element={<CodeQualityProjects />} />
         <Route path="code-quality/gates" element={<QualityGates />} />
         <Route path="code-quality/profiles" element={<QualityProfiles />} />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Boxes, FileText, Gauge, Radar, ScrollText, Settings, Target, Users, X, Library, type LucideIcon } from 'lucide-react'
+import { FileText, Gauge, Radar, ScrollText, Settings, Target, Users, X, Library, BriefcaseBusiness, type LucideIcon } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
 import { cn } from './ui'
@@ -6,7 +6,6 @@ import logo from '../assets/logo.png'
 
 const SOON: { icon: LucideIcon; label: string }[] = [
   { icon: Radar, label: 'Recon' },
-  { icon: Boxes, label: 'Inventory' },
   { icon: FileText, label: 'Reports' },
   { icon: Settings, label: 'Settings' },
 ]
@@ -34,6 +33,22 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
         >
           <Target className="size-[18px]" />
           Engagements
+        </NavLink>
+
+        <NavLink
+          to="/business-services"
+          onClick={onNavigate}
+          className={({ isActive }) =>
+            cn(
+              'relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
+              isActive
+                ? 'bg-brand/10 font-semibold text-branddim before:absolute before:left-0 before:top-1/2 before:h-5 before:w-[3px] before:-translate-y-1/2 before:rounded-r-full before:bg-brand before:content-[""]'
+                : 'text-mutedfg hover:bg-elevated hover:text-foreground',
+            )
+          }
+        >
+          <BriefcaseBusiness className="size-[18px]" />
+          Business Services
         </NavLink>
 
         <NavLink

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -20,7 +20,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       </div>
       <nav className="flex-1 space-y-1 p-3">
         <NavLink
-          to="/engagements"
+          to="/assets"
           onClick={onNavigate}
           className={({ isActive }) =>
             cn(
@@ -32,7 +32,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
           }
         >
           <Target className="size-[18px]" />
-          Engagements
+          Assets
         </NavLink>
 
         <NavLink

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -71,6 +71,7 @@ import type {
   BusinessService,
   Assessment,
   AssessmentPolicy,
+  AssessmentAsset,
   ProjectCodeView,
 } from './types'
 import { mapProjectOverviewResponse, type ProjectOverview } from './projectOverview'
@@ -1037,12 +1038,15 @@ export const api = {
 
   createAssessment: async (
     serviceId: string,
-    input: { name: string; objective: string; policy: AssessmentPolicy; engagements: Array<{ name: string; client: string }> },
+    input: { name: string; objective: string; policy: AssessmentPolicy; assets: Array<{ name: string; client: string }> },
   ): Promise<Assessment> =>
     req(`/appsec/business-services/${encodeURIComponent(serviceId)}/assessments`, {
       method: 'POST',
       body: JSON.stringify(input),
     }),
+
+  listAssessmentAssets: async (serviceId: string, assessmentId: string): Promise<AssessmentAsset[]> =>
+    (await req(`/appsec/business-services/${encodeURIComponent(serviceId)}/assessments/${encodeURIComponent(assessmentId)}/assets`)) ?? [],
 
   // --- Quality gates ---
   listQualityGates: async (): Promise<QualityGate[]> =>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -68,6 +68,9 @@ import type {
   ProjectCodeFileIndex,
   ProjectCodeFileView,
   ProjectCodeRevision,
+  BusinessService,
+  Assessment,
+  AssessmentPolicy,
   ProjectCodeView,
 } from './types'
 import { mapProjectOverviewResponse, type ProjectOverview } from './projectOverview'
@@ -1014,6 +1017,32 @@ function mapProjectCodeDiffResponse(r: any): ProjectCodeDiffResponse {
 export const api = {
   projectMeasures,
   aup: (): Promise<AupStatus> => req('/aup'),
+
+  // --- Business Service management ---
+  listBusinessServices: async (): Promise<BusinessService[]> =>
+    (await req('/appsec/business-services')) ?? [],
+
+  createBusinessService: async (input: Omit<BusinessService, 'id'>): Promise<BusinessService> =>
+    req('/appsec/business-services', { method: 'POST', body: JSON.stringify(input) }),
+
+  updateBusinessService: async (id: string, input: Omit<BusinessService, 'id'>): Promise<BusinessService> =>
+    req(`/appsec/business-services/${encodeURIComponent(id)}`, { method: 'PUT', body: JSON.stringify(input) }),
+
+  deleteBusinessService: async (id: string): Promise<void> => {
+    await req(`/appsec/business-services/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  },
+
+  listAssessments: async (serviceId: string): Promise<Assessment[]> =>
+    (await req(`/appsec/business-services/${encodeURIComponent(serviceId)}/assessments`)) ?? [],
+
+  createAssessment: async (
+    serviceId: string,
+    input: { name: string; objective: string; policy: AssessmentPolicy; engagements: Array<{ name: string; client: string }> },
+  ): Promise<Assessment> =>
+    req(`/appsec/business-services/${encodeURIComponent(serviceId)}/assessments`, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    }),
 
   // --- Quality gates ---
   listQualityGates: async (): Promise<QualityGate[]> =>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1131,3 +1131,11 @@ export interface Assessment {
   status: 'draft' | 'active' | 'closed'
   policy: AssessmentPolicy
 }
+
+export interface AssessmentAsset {
+  id: string
+  assessmentId: string
+  name: string
+  client: string
+  status: string
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1104,3 +1104,30 @@ export interface ProjectCodeDiffResponse {
   capabilities: ProjectCodeDiffCapabilities
   diff: ProjectCodeDiffView
 }
+
+
+export type BusinessServiceCriticality = 'low' | 'medium' | 'high' | 'critical'
+export type BusinessServiceLifecycle = 'planned' | 'active' | 'retired'
+
+export interface BusinessService {
+  id: string
+  name: string
+  description: string
+  criticality: BusinessServiceCriticality
+  lifecycle: BusinessServiceLifecycle
+}
+
+export interface AssessmentPolicy {
+  cadence: string
+  release: string
+  environment: string
+}
+
+export interface Assessment {
+  id: string
+  businessServiceId: string
+  name: string
+  objective: string
+  status: 'draft' | 'active' | 'closed'
+  policy: AssessmentPolicy
+}

--- a/web/src/pages/BusinessServices.tsx
+++ b/web/src/pages/BusinessServices.tsx
@@ -1,0 +1,125 @@
+import { BriefcaseBusiness, ClipboardCheck, Pencil, Plus, Trash2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { api } from '../lib/api'
+import type { Assessment, BusinessService, BusinessServiceCriticality, BusinessServiceLifecycle } from '../lib/types'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Select, Spinner } from '../components/ui'
+
+const criticalityOptions = ['low', 'medium', 'high', 'critical'].map((value) => ({ value, label: value[0].toUpperCase() + value.slice(1) }))
+const lifecycleOptions = ['planned', 'active', 'retired'].map((value) => ({ value, label: value[0].toUpperCase() + value.slice(1) }))
+
+const emptyService = (): Omit<BusinessService, 'id'> => ({ name: '', description: '', criticality: 'medium', lifecycle: 'planned' })
+
+export function BusinessServices() {
+  const [services, setServices] = useState<BusinessService[] | null>(null)
+  const [selected, setSelected] = useState<BusinessService | null>(null)
+  const [assessments, setAssessments] = useState<Assessment[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [editing, setEditing] = useState<Omit<BusinessService, 'id'> | null>(null)
+  const [assessmentForm, setAssessmentForm] = useState(false)
+
+  async function load() {
+    try {
+      setError(null)
+      const next = await api.listBusinessServices()
+      setServices(next)
+      setSelected((current) => next.find((item) => item.id === current?.id) ?? next[0] ?? null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load business services')
+    }
+  }
+
+  async function loadAssessments(service: BusinessService | null) {
+    if (!service) { setAssessments(null); return }
+    try { setAssessments(await api.listAssessments(service.id)) }
+    catch (err) { setError(err instanceof Error ? err.message : 'Unable to load assessments') }
+  }
+
+  useEffect(() => { void load() }, [])
+  useEffect(() => { void loadAssessments(selected) }, [selected?.id])
+
+  async function remove(service: BusinessService) {
+    if (!window.confirm(`Delete ${service.name}? Services with Assessments cannot be deleted.`)) return
+    try { await api.deleteBusinessService(service.id); await load() }
+    catch (err) { setError(err instanceof Error ? err.message : 'Unable to delete business service') }
+  }
+
+  if (services === null) return <Spinner label="Loading Business Services…" className="mt-24" />
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 animate-fade-in">
+      <header className="flex flex-col gap-4 border-b border-border pb-6 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-brand"><BriefcaseBusiness className="size-5" /><span className="text-xs font-semibold uppercase tracking-widest">AppSec management</span></div>
+          <h1 className="text-2xl font-bold tracking-tight">Business Services</h1>
+          <p className="mt-1 max-w-2xl text-sm text-mutedfg">Define the services your program protects, then record the assessments and engagements that prove their coverage.</p>
+        </div>
+        <Button onClick={() => setEditing(emptyService())}><Plus className="size-4" /> Add service</Button>
+      </header>
+      {error && <ErrorState message={error} />}
+      <div className="grid gap-6 lg:grid-cols-[minmax(18rem,0.8fr)_minmax(0,1.2fr)]">
+        <Card title={`Services · ${services.length}`} bodyClass="p-3">
+          {services.length === 0 ? <EmptyState icon={BriefcaseBusiness} title="No Business Services" hint="Add the first service to begin organizing assessments." action={<Button onClick={() => setEditing(emptyService())}><Plus className="size-4" /> Add service</Button>} /> :
+            <div className="space-y-1">{services.map((service) => <button key={service.id} onClick={() => setSelected(service)} className={`w-full rounded-lg px-3 py-3 text-left transition-colors ${selected?.id === service.id ? 'bg-brand/10 ring-1 ring-brand/25' : 'hover:bg-elevated'}`}>
+              <div className="flex items-center justify-between gap-3"><span className="font-medium">{service.name}</span><Pill className={service.criticality === 'critical' ? 'bg-danger/10 text-danger' : service.criticality === 'high' ? 'bg-warning/10 text-warning' : 'bg-muted text-mutedfg'}>{service.criticality}</Pill></div>
+              <p className="mt-1 line-clamp-1 text-xs text-mutedfg">{service.description || 'No description'}</p>
+            </button>)}</div>}
+        </Card>
+        <section className="space-y-6">
+          {selected ? <>
+            <Card title={selected.name} actions={<div className="flex gap-2"><Button variant="ghost" aria-label={`Edit ${selected.name}`} onClick={() => setEditing({ name: selected.name, description: selected.description, criticality: selected.criticality, lifecycle: selected.lifecycle })}><Pencil className="size-4" /> Edit</Button><Button variant="danger" aria-label={`Delete ${selected.name}`} onClick={() => void remove(selected)}><Trash2 className="size-4" /> Delete</Button></div>}>
+              <div className="grid gap-4 sm:grid-cols-2"><div><p className="text-xs font-medium uppercase tracking-wide text-subtlefg">Criticality</p><p className="mt-1 font-medium capitalize">{selected.criticality}</p></div><div><p className="text-xs font-medium uppercase tracking-wide text-subtlefg">Lifecycle</p><p className="mt-1 font-medium capitalize">{selected.lifecycle}</p></div></div>
+              <p className="mt-5 whitespace-pre-wrap text-sm leading-6 text-mutedfg">{selected.description || 'No description has been provided.'}</p>
+            </Card>
+            <Card title="Assessments" actions={<Button variant="secondary" onClick={() => setAssessmentForm(true)}><Plus className="size-4" /> Add assessment</Button>}>
+              {assessments === null ? <Spinner label="Loading assessments…" /> : assessments.length === 0 ? <EmptyState icon={ClipboardCheck} title="No Assessments" hint="Create an assessment with at least one engagement to establish coverage." /> : <div className="divide-y divide-border">{assessments.map((assessment) => <div key={assessment.id} className="py-4 first:pt-0 last:pb-0"><div className="flex items-center justify-between gap-3"><p className="font-medium">{assessment.name}</p><Pill className="bg-info/10 text-info">{assessment.status}</Pill></div><p className="mt-1 text-sm text-mutedfg">{assessment.objective || 'No objective provided.'}</p>{(assessment.policy.release || assessment.policy.environment || assessment.policy.cadence) && <p className="mt-2 text-xs text-subtlefg">{[assessment.policy.release, assessment.policy.environment, assessment.policy.cadence].filter(Boolean).join(' · ')}</p>}</div>)}</div>}
+            </Card>
+          </> : <EmptyState icon={BriefcaseBusiness} title="Select a service" hint="Choose a Business Service to view its assessments." />}
+        </section>
+      </div>
+      {editing && <ServiceForm initial={editing} isUpdate={Boolean(selected && editing.name === selected.name)} onCancel={() => setEditing(null)} onSaved={async () => { setEditing(null); await load() }} serviceId={selected?.id} />}
+      {assessmentForm && selected && <AssessmentForm service={selected} onCancel={() => setAssessmentForm(false)} onSaved={async () => { setAssessmentForm(false); await loadAssessments(selected) }} />}
+    </div>
+  )
+}
+
+function ServiceForm({ initial, serviceId, isUpdate, onCancel, onSaved }: { initial: Omit<BusinessService, 'id'>; serviceId?: string; isUpdate: boolean; onCancel: () => void; onSaved: () => Promise<void> }) {
+  const [form, setForm] = useState(initial); const [error, setError] = useState<string | null>(null); const [saving, setSaving] = useState(false)
+  async function submit(event: React.FormEvent) { event.preventDefault(); setSaving(true); setError(null); try { if (isUpdate && serviceId) await api.updateBusinessService(serviceId, form); else await api.createBusinessService(form); onCancel(); await onSaved() } catch (err) { setError(err instanceof Error ? err.message : 'Unable to save service') } finally { setSaving(false) } }
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-labelledby="service-form-title">
+      <form onSubmit={submit} className="w-full max-w-xl rounded-xl border border-border bg-surface p-6 shadow-xl">
+        <h2 id="service-form-title" className="text-lg font-semibold">{isUpdate ? 'Edit Business Service' : 'Add Business Service'}</h2>
+        {error && <p role="alert" className="mt-3 text-sm text-danger">{error}</p>}
+        <div className="mt-5 space-y-4">
+          <Field label="Name" htmlFor="service-name"><Input id="service-name" required value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} /></Field>
+          <Field label="Description" htmlFor="service-description"><textarea id="service-description" className="min-h-24 w-full rounded-md border border-border bg-page px-3 py-2 text-sm outline-none focus:border-brand focus:ring-2 focus:ring-brand/25" value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} /></Field>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Criticality"><Select value={form.criticality} options={criticalityOptions} ariaLabel="Criticality" onValueChange={(value) => setForm({ ...form, criticality: value as BusinessServiceCriticality })} /></Field>
+            <Field label="Lifecycle"><Select value={form.lifecycle} options={lifecycleOptions} ariaLabel="Lifecycle" onValueChange={(value) => setForm({ ...form, lifecycle: value as BusinessServiceLifecycle })} /></Field>
+          </div>
+        </div>
+        <div className="mt-6 flex justify-end gap-3"><Button type="button" variant="ghost" onClick={onCancel}>Cancel</Button><Button type="submit" loading={saving}>{isUpdate ? 'Save changes' : 'Create service'}</Button></div>
+      </form>
+    </div>
+  )
+}
+
+function AssessmentForm({ service, onCancel, onSaved }: { service: BusinessService; onCancel: () => void; onSaved: () => Promise<void> }) {
+  const [name, setName] = useState(''); const [objective, setObjective] = useState(''); const [engagement, setEngagement] = useState(''); const [error, setError] = useState<string | null>(null); const [saving, setSaving] = useState(false)
+  async function submit(event: React.FormEvent) { event.preventDefault(); setSaving(true); setError(null); try { await api.createAssessment(service.id, { name, objective, policy: { cadence: '', release: '', environment: '' }, engagements: [{ name: engagement, client: '' }] }); onCancel(); await onSaved() } catch (err) { setError(err instanceof Error ? err.message : 'Unable to create assessment') } finally { setSaving(false) } }
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-labelledby="assessment-form-title">
+      <form onSubmit={submit} className="w-full max-w-xl rounded-xl border border-border bg-surface p-6 shadow-xl">
+        <h2 id="assessment-form-title" className="text-lg font-semibold">New Assessment</h2>
+        <p className="mt-1 text-sm text-mutedfg">{service.name} · an assessment must begin with one engagement.</p>
+        {error && <p role="alert" className="mt-3 text-sm text-danger">{error}</p>}
+        <div className="mt-5 space-y-4">
+          <Field label="Assessment name" htmlFor="assessment-name"><Input id="assessment-name" required value={name} onChange={(e) => setName(e.target.value)} /></Field>
+          <Field label="Objective" htmlFor="assessment-objective"><textarea id="assessment-objective" className="min-h-20 w-full rounded-md border border-border bg-page px-3 py-2 text-sm outline-none focus:border-brand focus:ring-2 focus:ring-brand/25" value={objective} onChange={(e) => setObjective(e.target.value)} /></Field>
+          <Field label="First engagement" hint="Required" htmlFor="assessment-engagement"><Input id="assessment-engagement" required value={engagement} onChange={(e) => setEngagement(e.target.value)} /></Field>
+        </div>
+        <div className="mt-6 flex justify-end gap-3"><Button type="button" variant="ghost" onClick={onCancel}>Cancel</Button><Button type="submit" loading={saving}>Create assessment</Button></div>
+      </form>
+    </div>
+  )
+}

--- a/web/src/pages/BusinessServices.tsx
+++ b/web/src/pages/BusinessServices.tsx
@@ -1,7 +1,7 @@
 import { BriefcaseBusiness, ClipboardCheck, Pencil, Plus, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { api } from '../lib/api'
-import type { Assessment, BusinessService, BusinessServiceCriticality, BusinessServiceLifecycle } from '../lib/types'
+import type { Assessment, AssessmentAsset, BusinessService, BusinessServiceCriticality, BusinessServiceLifecycle } from '../lib/types'
 import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Select, Spinner } from '../components/ui'
 
 const criticalityOptions = ['low', 'medium', 'high', 'critical'].map((value) => ({ value, label: value[0].toUpperCase() + value.slice(1) }))
@@ -51,7 +51,7 @@ export function BusinessServices() {
         <div>
           <div className="mb-2 flex items-center gap-2 text-brand"><BriefcaseBusiness className="size-5" /><span className="text-xs font-semibold uppercase tracking-widest">AppSec management</span></div>
           <h1 className="text-2xl font-bold tracking-tight">Business Services</h1>
-          <p className="mt-1 max-w-2xl text-sm text-mutedfg">Define the services your program protects, then record the assessments and engagements that prove their coverage.</p>
+          <p className="mt-1 max-w-2xl text-sm text-mutedfg">Define the services your program protects, then record assessments and their scoped assets.</p>
         </div>
         <Button onClick={() => setEditing(emptyService())}><Plus className="size-4" /> Add service</Button>
       </header>
@@ -71,7 +71,7 @@ export function BusinessServices() {
               <p className="mt-5 whitespace-pre-wrap text-sm leading-6 text-mutedfg">{selected.description || 'No description has been provided.'}</p>
             </Card>
             <Card title="Assessments" actions={<Button variant="secondary" onClick={() => setAssessmentForm(true)}><Plus className="size-4" /> Add assessment</Button>}>
-              {assessments === null ? <Spinner label="Loading assessments…" /> : assessments.length === 0 ? <EmptyState icon={ClipboardCheck} title="No Assessments" hint="Create an assessment with at least one engagement to establish coverage." /> : <div className="divide-y divide-border">{assessments.map((assessment) => <div key={assessment.id} className="py-4 first:pt-0 last:pb-0"><div className="flex items-center justify-between gap-3"><p className="font-medium">{assessment.name}</p><Pill className="bg-info/10 text-info">{assessment.status}</Pill></div><p className="mt-1 text-sm text-mutedfg">{assessment.objective || 'No objective provided.'}</p>{(assessment.policy.release || assessment.policy.environment || assessment.policy.cadence) && <p className="mt-2 text-xs text-subtlefg">{[assessment.policy.release, assessment.policy.environment, assessment.policy.cadence].filter(Boolean).join(' · ')}</p>}</div>)}</div>}
+              {assessments === null ? <Spinner label="Loading assessments…" /> : assessments.length === 0 ? <EmptyState icon={ClipboardCheck} title="No Assessments" hint="Create an assessment with at least one scoped asset to establish coverage." /> : <div className="divide-y divide-border">{assessments.map((assessment) => <AssessmentRow key={assessment.id} serviceId={selected.id} assessment={assessment} />)}</div>}
             </Card>
           </> : <EmptyState icon={BriefcaseBusiness} title="Select a service" hint="Choose a Business Service to view its assessments." />}
         </section>
@@ -105,21 +105,27 @@ function ServiceForm({ initial, serviceId, isUpdate, onCancel, onSaved }: { init
 }
 
 function AssessmentForm({ service, onCancel, onSaved }: { service: BusinessService; onCancel: () => void; onSaved: () => Promise<void> }) {
-  const [name, setName] = useState(''); const [objective, setObjective] = useState(''); const [engagement, setEngagement] = useState(''); const [error, setError] = useState<string | null>(null); const [saving, setSaving] = useState(false)
-  async function submit(event: React.FormEvent) { event.preventDefault(); setSaving(true); setError(null); try { await api.createAssessment(service.id, { name, objective, policy: { cadence: '', release: '', environment: '' }, engagements: [{ name: engagement, client: '' }] }); onCancel(); await onSaved() } catch (err) { setError(err instanceof Error ? err.message : 'Unable to create assessment') } finally { setSaving(false) } }
+  const [name, setName] = useState(''); const [objective, setObjective] = useState(''); const [assetName, setAssetName] = useState(''); const [error, setError] = useState<string | null>(null); const [saving, setSaving] = useState(false)
+  async function submit(event: React.FormEvent) { event.preventDefault(); setSaving(true); setError(null); try { await api.createAssessment(service.id, { name, objective, policy: { cadence: '', release: '', environment: '' }, assets: [{ name: assetName, client: '' }] }); onCancel(); await onSaved() } catch (err) { setError(err instanceof Error ? err.message : 'Unable to create assessment') } finally { setSaving(false) } }
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-labelledby="assessment-form-title">
       <form onSubmit={submit} className="w-full max-w-xl rounded-xl border border-border bg-surface p-6 shadow-xl">
         <h2 id="assessment-form-title" className="text-lg font-semibold">New Assessment</h2>
-        <p className="mt-1 text-sm text-mutedfg">{service.name} · an assessment must begin with one engagement.</p>
+        <p className="mt-1 text-sm text-mutedfg">{service.name} · an assessment must begin with one scoped asset.</p>
         {error && <p role="alert" className="mt-3 text-sm text-danger">{error}</p>}
         <div className="mt-5 space-y-4">
           <Field label="Assessment name" htmlFor="assessment-name"><Input id="assessment-name" required value={name} onChange={(e) => setName(e.target.value)} /></Field>
           <Field label="Objective" htmlFor="assessment-objective"><textarea id="assessment-objective" className="min-h-20 w-full rounded-md border border-border bg-page px-3 py-2 text-sm outline-none focus:border-brand focus:ring-2 focus:ring-brand/25" value={objective} onChange={(e) => setObjective(e.target.value)} /></Field>
-          <Field label="First engagement" hint="Required" htmlFor="assessment-engagement"><Input id="assessment-engagement" required value={engagement} onChange={(e) => setEngagement(e.target.value)} /></Field>
+          <Field label="First assessment asset" hint="Required" htmlFor="assessment-asset"><Input id="assessment-asset" required value={assetName} onChange={(e) => setAssetName(e.target.value)} /></Field>
         </div>
         <div className="mt-6 flex justify-end gap-3"><Button type="button" variant="ghost" onClick={onCancel}>Cancel</Button><Button type="submit" loading={saving}>Create assessment</Button></div>
       </form>
     </div>
   )
+}
+
+function AssessmentRow({ serviceId, assessment }: { serviceId: string; assessment: Assessment }) {
+  const [assets, setAssets] = useState<AssessmentAsset[] | null>(null)
+  useEffect(() => { void api.listAssessmentAssets(serviceId, assessment.id).then(setAssets).catch(() => setAssets([])) }, [assessment.id, serviceId])
+  return <div className="py-4 first:pt-0 last:pb-0"><div className="flex items-center justify-between gap-3"><p className="font-medium">{assessment.name}</p><Pill className="bg-info/10 text-info">{assessment.status}</Pill></div><p className="mt-1 text-sm text-mutedfg">{assessment.objective || 'No objective provided.'}</p><p className="mt-2 text-xs text-subtlefg">{assets === null ? 'Loading assets…' : assets.length === 0 ? 'No scoped assets' : `Assets · ${assets.map((asset) => asset.name).join(', ')}`}</p>{(assessment.policy.release || assessment.policy.environment || assessment.policy.cadence) && <p className="mt-1 text-xs text-subtlefg">{[assessment.policy.release, assessment.policy.environment, assessment.policy.cadence].filter(Boolean).join(' · ')}</p>}</div>
 }

--- a/web/src/pages/Engagements.tsx
+++ b/web/src/pages/Engagements.tsx
@@ -22,7 +22,7 @@ export function Engagements() {
     api
       .listEngagements()
       .then(setList)
-      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load engagements'))
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load assets'))
   }
   useEffect(load, [])
 
@@ -34,7 +34,7 @@ export function Engagements() {
     setImportErr(null)
     try {
       const eng = await api.importBundle(await file.text())
-      navigate(`/engagements/${eng.id}`)
+      navigate(`/assets/${eng.id}`)
     } catch (err) {
       setImportErr(err instanceof Error ? err.message : 'Import failed')
     } finally {
@@ -46,9 +46,9 @@ export function Engagements() {
     <div className="mx-auto max-w-6xl animate-fade-in">
       <header className="bg-hero mb-6 flex flex-wrap items-center justify-between gap-4 rounded-xl border border-border p-6">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Engagements</h1>
+          <h1 className="text-3xl font-bold tracking-tight">Assets</h1>
           <p className="mt-1.5 max-w-xl text-sm text-mutedfg">
-            Authorized testing scopes – every scan is gated by an engagement's scope and window, server-side.
+            Authorized testing assets – every scan is gated by an asset's scope and authorization window, server-side.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -63,7 +63,7 @@ export function Engagements() {
               </>
             ) : (
               <>
-                <Plus className="size-4" /> New engagement
+                <Plus className="size-4" /> New asset
               </>
             )}
           </Button>
@@ -88,15 +88,15 @@ export function Engagements() {
       )}
 
       {error && <ErrorState message={error} />}
-      {!list && !error && <Spinner label="Loading engagements…" />}
+      {!list && !error && <Spinner label="Loading assets…" />}
       {list && list.length === 0 && !creating && (
         <EmptyState
           icon={Target}
-          title="No engagements yet"
-          hint="Create one to define an authorized testing scope, then run an SCA scan against it."
+          title="No assets yet"
+          hint="Create one to define an authorized testing asset, then run an SCA scan against it."
           action={
             <Button variant="brand" onClick={() => setCreating(true)}>
-              <Plus className="size-4" /> New engagement
+              <Plus className="size-4" /> New asset
             </Button>
           }
         />
@@ -115,7 +115,7 @@ export function Engagements() {
 function EngagementCard({ e }: { e: Engagement }) {
   return (
     <Link
-      to={`/engagements/${e.id}`}
+      to={`/assets/${e.id}`}
       className="lift card-sheen elev group block rounded-xl border border-border bg-card p-5 hover:border-brand/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50"
     >
       <div className="flex items-start justify-between gap-2">
@@ -142,7 +142,7 @@ function EngagementCard({ e }: { e: Engagement }) {
 
 export function StatusPill({ status }: { status: string }) {
   const s = (status || 'draft').toLowerCase()
-  // Engagement lifecycle vocabulary: draft -> active -> completed -> archived.
+  // Asset lifecycle vocabulary: draft -> active -> completed -> archived.
   const tone =
     s === 'active'
       ? 'bg-accent/10 text-accent ring-accent/25'
@@ -206,14 +206,14 @@ function CreateForm({ onCreated }: { onCreated: () => void }) {
       })
       onCreated()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create engagement')
+      setError(err instanceof Error ? err.message : 'Failed to create asset')
     } finally {
       setSubmitting(false)
     }
   }
 
   return (
-    <Card title="New engagement" className="animate-fade-in">
+    <Card title="New asset" className="animate-fade-in">
       <form onSubmit={submit} className="space-y-4">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <Field label="Name">
@@ -273,7 +273,7 @@ function CreateForm({ onCreated }: { onCreated: () => void }) {
         {error && <ErrorState message={error} />}
         <div className="flex justify-end">
           <Button variant="brand" type="submit" loading={submitting}>
-            Create engagement
+            Create asset
           </Button>
         </div>
       </form>


### PR DESCRIPTION
## Summary

Implements #353 as a tenant-scoped Business Service → Assessment → Engagement management surface.

- Adds full Business Service create/list/read/PUT/delete, RBAC, conflict-safe deletion, and removes public Asset Inventory routes.
- Makes Assessment creation atomic with required Engagement children across memory and PostgreSQL; enforces nested parent tenant isolation.
- Documents the narrowed API in OpenAPI and adds behavioral coverage for update, RBAC, nested 404, rollback, and delete conflicts.

## Verification

- `go test ./internal/domain/assessment ./internal/usecase/assetuc ./internal/usecase/assessmentuc ./internal/infrastructure/persistence/memory ./internal/adapter/httpapi ./api`
- `go test ./...`
- `go test ./internal/infrastructure/persistence/postgres -run 'Test(AssetInventory|Assessment)' -count=1`\n\n`SYNAPSE_TEST_DB_DSN`, `SYNAPSE_TEST_POSTGRES_DSN`, and `SYNAPSE_TEST_POSTGRES_MIGRATE_DSN` were unavailable locally, so a fresh disposable PostgreSQL migration test and non-superuser RLS integration proof remain CI/environment-dependent.\n\nCloses #353