### PR TITLE
feat(ai): guard false-positive quality-gate exemptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,12 +175,12 @@ SYNAPSE_SANDBOX_ENABLED=false
 # gate a human reviewer uses (verifier identity "llm:<model>", never the proposer → no self-confirm). It
 # also enables the FP-triage two-model consensus. Defaults to SYNAPSE_LLM_MODEL (= no distinct verifier).
 # SYNAPSE_VERIFIER_MODEL=
-# AI false-positive gate: after a scan, the model critiques the remaining production-scope first-party
-# source findings (SAST/secret/misconfig). A high-confidence "refuted" verdict marks the finding a
-# suspected false positive — retain-and-mark (still reported + sealed, held back from the --fail-on gate),
-# never deleted. Off by default; needs an LLM endpoint above. Model defaults to SYNAPSE_LLM_MODEL.
-# When SYNAPSE_VERIFIER_MODEL (above) names a DIFFERENT model, a refutation must be independently
-# confirmed by it before it exempts the gate (two-model consensus; a single model can't flip the gate).
+# AI false-positive analysis: after a scan, the proposer critiques production-scope first-party findings.
+# A high-confidence "refuted" verdict is advisory and never deletes a finding. Gate exemption requires a
+# DIFFERENT SYNAPSE_VERIFIER_MODEL to independently refute at/above the bar. Even then, high/critical,
+# secret, and dangerous-CWE findings stay gating for human review. The typed proposer/verifier verdicts,
+# model IDs, prompt version, policy decision, and gate authorization are sealed with the scan evidence.
+# Without a distinct verifier the feature remains useful for triage, but cannot change a gate.
 # SYNAPSE_FP_TRIAGE_ENABLED=false
 # SYNAPSE_FP_TRIAGE_MODEL=
 # HITL approval: manual (human approves every action) | filter | auto.

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -692,27 +692,26 @@ func main() {
 		log.Info("misconfig scanning ENABLED (Dockerfile + Kubernetes + Terraform); " + helmMode)
 	}
 	// AI false-positive triage in the scan pipeline (opt-in, best-effort, PROPOSE-ONLY). Independent of
-	// the agent: it critiques production-scope source findings and marks suspected FPs retain-and-mark
-	// (held back from the gate via ScanResult.SuspectedFPKeys, still reported + sealed). A distinct
-	// SYNAPSE_VERIFIER_MODEL enables two-model consensus.
+	// the agent: it critiques production-scope source findings. Single-model output is advisory-only; a
+	// distinct verifier is required before the deterministic high-risk floor may grant a gate exemption.
 	if cfg.FPTriageEnabled && strings.TrimSpace(cfg.FPTriageModel) != "" {
 		if tllm, terr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.FPTriageModel, cfg.LLMTimeout); terr != nil {
 			log.Warn("AI false-positive triage DISABLED (LLM unavailable)", "err", terr)
 		} else {
 			coord := fptriage.New(tllm, cfg.FPTriageModel)
-			mode := "single-model"
+			mode := "advisory-only (distinct verifier required for gate exemption)"
 			if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
 				if vllm, verr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.VerifierModel, cfg.LLMTimeout); verr == nil {
 					coord.WithVerifier(vllm, cfg.VerifierModel)
 					mode = "verified by " + cfg.VerifierModel
 				} else {
-					log.Warn("AI FP-triage verifier unavailable, single-model", "err", verr)
+					log.Warn("AI FP-triage verifier unavailable; triage remains advisory-only", "err", verr)
 				}
 			}
 			scaService.SetFPTriage(fptriage.NewTriager(coord, func(root string) ports.SourceSnippetReader {
 				return sourcesnippet.Reader{Root: root}
 			}))
-			log.Info("AI false-positive triage ENABLED ("+mode+"); suspected FPs held back from the gate, still reported", "model", cfg.FPTriageModel)
+			log.Info("AI false-positive triage ENABLED ("+mode+"); only verified low-risk consensus can affect gates", "model", cfg.FPTriageModel)
 		}
 	}
 	if cfg.SuppressionEnabled {

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1319,9 +1319,9 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	sca.SetIgnoreUnfixed(ignoreUnfixed || cfg.IgnoreUnfixed)
 
 	// AI false-positive triage (opt-in). Inject an LLM critic the scan pipeline runs over the remaining
-	// production-scope first-party source findings; a "refuted" verdict marks the finding suspected-FP
-	// (retain-and-mark, held back from the gate below), never a deletion. Propose-only + best-effort. A
-	// distinct SYNAPSE_VERIFIER_MODEL enables two-model consensus. Skipped for image targets (no source).
+	// production-scope first-party source findings. A refutation is advisory unless a distinct verifier
+	// agrees and the deterministic human-review floor allows a gate exemption. High/critical, secrets,
+	// and dangerous CWEs always keep gating. Findings are never deleted. Skipped for image targets.
 	if cfg.FPTriageEnabled && strings.TrimSpace(cfg.FPTriageModel) != "" && !image {
 		if llm, lerr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.FPTriageModel, cfg.LLMTimeout); lerr != nil {
 			fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage disabled: %v\n", lerr)
@@ -1331,7 +1331,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 				if vllm, verr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.VerifierModel, cfg.LLMTimeout); verr == nil {
 					coord.WithVerifier(vllm, cfg.VerifierModel)
 				} else {
-					fmt.Fprintf(os.Stderr, "synapse-cli: verifier model %q unavailable, falling back to single-model triage: %v\n", cfg.VerifierModel, verr)
+					fmt.Fprintf(os.Stderr, "synapse-cli: verifier model %q unavailable; AI triage remains advisory-only: %v\n", cfg.VerifierModel, verr)
 				}
 			}
 			sca.SetFPTriage(fptriage.NewTriager(coord, func(root string) ports.SourceSnippetReader {
@@ -1368,15 +1368,20 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		return fmt.Errorf("scan: %w", err)
 	}
 
-	// The scan pipeline ran the AI false-positive triage (if injected above); report the outcome. A
-	// suspected-FP is held back from the --fail-on gate (retain-and-mark), still reported in ai_triage.
+	// Report advisory opinions separately from the smaller policy-authorized gate-exempt set.
 	fpSuspect := res.SuspectedFPKeys()
+	fpGateExempt := res.AIGateExemptKeys()
+	fpReview := res.AIReviewRequiredKeys()
 	if len(res.AITriage) > 0 {
-		mode := "single-model"
-		if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
-			mode = "verified by " + cfg.VerifierModel
+		mode := "advisory-only"
+		for _, critique := range res.AITriage {
+			if critique.VerifierModel != "" {
+				mode = "verified by " + critique.VerifierModel
+				break
+			}
 		}
-		fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage (%s, %s): critiqued %d finding(s), %d suspected false positive(s) held back from the gate\n", cfg.FPTriageModel, mode, len(res.AITriage), len(fpSuspect))
+		fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage (%s, %s): critiqued %d, suspected %d, gate-exempt %d, human-review %d\n",
+			cfg.FPTriageModel, mode, len(res.AITriage), len(fpSuspect), len(fpGateExempt), len(fpReview))
 	}
 
 	switch {
@@ -1438,7 +1443,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	verify := res.NeedsVerifyKeys()  // precise-mode needs-verify: lower-confidence, exempt from the gate too
 	over := 0
 	bgExempt := 0 // background-scope (test/fixture/example/...) findings held back from the gate
-	fpExempt := 0 // AI-critiqued suspected false positives held back from the gate
+	fpExempt := 0 // verified low-risk AI consensus findings held back from the gate
 	for _, f := range res.Findings {
 		if accepted[f.DedupKey] || verify[f.DedupKey] {
 			continue
@@ -1453,8 +1458,9 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 			bgExempt++
 			continue
 		}
-		// The AI critique refuted this finding (retain-and-mark: reported above, held back from the gate).
-		if fpSuspect[f.DedupKey] {
+		// Only a distinct-model consensus that cleared the deterministic human-review floor may affect
+		// the gate. A single-model or high-risk suspected-FP remains visible AND gating.
+		if fpGateExempt[f.DedupKey] {
 			fpExempt++
 			continue
 		}
@@ -1464,7 +1470,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		fmt.Fprintf(os.Stderr, "synapse-cli: %d background/test-scope finding(s) at or above %s reported but exempt from the gate (use --include-test to gate them)\n", bgExempt, failOn)
 	}
 	if fpExempt > 0 {
-		fmt.Fprintf(os.Stderr, "synapse-cli: %d suspected false positive(s) at or above %s held back from the gate by AI triage (reported with a verdict; not deleted)\n", fpExempt, failOn)
+		fmt.Fprintf(os.Stderr, "synapse-cli: %d verified low-risk false-positive candidate(s) at or above %s held back from the gate by policy (reported + evidence-sealed; not deleted)\n", fpExempt, failOn)
 	}
 	if over > 0 {
 		return fmt.Errorf("%d finding(s) at or above %s", over, failOn)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -79,15 +79,15 @@ stays in the report, it is only held back from the `--fail-on` gate).
    (`SYNAPSE_LLM_BASE_URL`, `SYNAPSE_LLM_API_KEY`, and `SYNAPSE_FP_TRIAGE_MODEL` or `SYNAPSE_LLM_MODEL`).
    After the deterministic pass, the model adjudicates the remaining production-scope first-party source
    findings (SAST/secret/misconfig) and returns a typed verdict — `refuted` (suspected false positive),
-   `sound`, or `uncertain` — with a confidence. The model only proposes: a `refuted` verdict at or above
-   the confidence bar marks the finding a suspected false positive and holds it back from the gate; it is
-   still reported (see `ai_triage` in `--json`) and sealed, never deleted, and an `uncertain` verdict
-   keeps the finding gating. Best-effort: if the model can't be reached the scan proceeds unchanged.
+   `sound`, or `uncertain` — with a confidence. The proposer only advises: single-model output can never
+   change the gate. Set `SYNAPSE_VERIFIER_MODEL` to a **different** model to enable consensus. A finding is
+   gate-exempt only when both models independently refute it at/above the bar and the deterministic
+   human-review floor permits it. High/critical findings, secrets, and dangerous injection/auth/access-
+   control/SSRF/traversal/upload/deserialization CWEs always stay gating.
 
-   For a stricter, hallucination-resistant gate, set `SYNAPSE_VERIFIER_MODEL` to a **different** model:
-   a refutation then only exempts the gate if that distinct verifier independently agrees (two-model
-   consensus — a single model cannot flip the gate on its own). `ai_triage` entries confirmed this way
-   carry `"verified": true`.
+   Every finding remains in JSON/SARIF/compliance. The `ai_triage` JSON separates `suspected_fp`,
+   `verified`, `gate_exempt`, and `review_required`, and carries model/prompt/policy metadata. These
+   fields are sealed into the scan evidence hash-chain. Model or verifier failure leaves the gate unchanged.
 
 ```bash
 export SYNAPSE_LLM_BASE_URL=http://localhost:8081/v1
@@ -96,12 +96,9 @@ SYNAPSE_FP_TRIAGE_ENABLED=true SYNAPSE_FP_TRIAGE_MODEL=<model> \
   synapse-cli scan . --fail-on high --json
 ```
 
-The AI critique reads the target's own source into the prompt, so treat it as a trusted-local convenience:
-on a scan of an **untrusted PR**, a contributor could add a comment that tries to talk the model into
-refuting their finding. The blast radius is bounded — the finding is still reported and in the SARIF/JSON
-(only the `--fail-on` exit code is affected), the model only proposes (a gate exemption, never a sealed
-suppression or a deletion), and the run prints how many findings were held back — but for gating untrusted
-PRs, upload the SARIF to code-scanning (which shows every finding) and treat the AI verdict as advisory.
+The AI critique reads the target's own source into the prompt, so an **untrusted PR** can still try prompt
+injection through comments or strings. Distinct consensus and the human-review floor bound the risk, and
+the finding always remains in SARIF/JSON, but treat AI triage as advisory for untrusted contributor code.
 
 ## Container image (Docker)
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -80,6 +80,9 @@ Most of these ship ON by default (safe, best-effort). See [Features](features.md
 | --- | --- | --- |
 | `SYNAPSE_SECRET_SCAN_ENABLED` | `true` | Secret scanning over the workspace (regex plus entropy). Matches are redacted; the raw secret never reaches logs, evidence, or the report. |
 | `SYNAPSE_MISCONFIG_ENABLED` | `true` | Misconfiguration and IaC scanning of Dockerfiles and Kubernetes manifests. |
+| `SYNAPSE_FP_TRIAGE_ENABLED` | `false` | Enable advisory LLM false-positive analysis over production-scope SAST/secret/misconfig findings. A proposer alone never changes a gate. |
+| `SYNAPSE_FP_TRIAGE_MODEL` | `SYNAPSE_LLM_MODEL` | Proposer model for false-positive analysis. |
+| `SYNAPSE_VERIFIER_MODEL` | `SYNAPSE_LLM_MODEL` | Must name a different model for AI gate exemptions. Two-model consensus is still subject to high/critical, secret, and dangerous-CWE human-review floors. |
 | `SYNAPSE_DETECTION_PRIORITY` | `comprehensive` | `comprehensive` reports every match. `precise` quarantines single-source, non-KEV findings into a needs-verify queue that is still reported and sealed but exempt from the `--fail-on` gate. |
 | `SYNAPSE_OFFLINE` | `false` | Skip the live advisory source and detect with the offline database only. |
 | `SYNAPSE_IGNORE_UNFIXED` | `false` | Drop vulnerabilities that have no fixed version. |

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -120,6 +120,11 @@ with a lifecycle of propose, verify, confirm. Gated capabilities promote only on
 verifier's sealed verdict above the evidence threshold. Ungated ones need a human accept. The
 agent can never confirm its own claim, and no model ever sits in the report path.
 
+False-positive triage keeps the opinion/authorization boundary explicit: a single model can mark a
+finding `suspected_fp` but cannot affect a gate. A distinct verifier must agree, then a deterministic
+policy keeps high/critical, secret, and dangerous-CWE findings in human review. The full typed decision
+and model/prompt/policy metadata are sealed into the scan evidence chain.
+
 Capabilities include reachability proposals, pattern SAST, a taint engine over the call graph,
 threat modeling over an architecture seam, AI critique and risk narrative, and human-gated
 write-up drafts.

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -146,9 +146,10 @@ type Config struct {
 	LLMModel   string
 	LLMTimeout time.Duration
 
-	// FPTriageEnabled turns on the opt-in LLM false-positive gate: after a scan, the configured model
-	// critiques the remaining production-scope first-party source findings and a "refuted" verdict marks
-	// the finding suspected-FP (retain-and-mark, exempt from the gate). Off by default; needs an LLM.
+	// FPTriageEnabled turns on opt-in LLM false-positive analysis. A proposer may mark a finding
+	// suspected-FP, but it remains advisory unless a distinct verifier agrees and the deterministic
+	// human-review floor permits a gate exemption. High/critical, secrets, and dangerous CWEs always gate.
+	// Off by default; needs an LLM.
 	// FPTriageModel is the model to critique with (defaults to LLMModel).
 	FPTriageEnabled bool
 	FPTriageModel   string

--- a/internal/usecase/fptriage/coordinator.go
+++ b/internal/usecase/fptriage/coordinator.go
@@ -48,10 +48,9 @@ type Critique struct {
 	Err             error
 }
 
-// SuspectedFP reports whether this critique refutes the finding with at least minConfidence — the only
-// condition under which the caller exempts it from the gate. When a distinct verifier was required
-// (VerifyAttempted), BOTH the proposer and the verifier must refute at/above the bar; a verifier that
-// disagreed, was inconclusive, or failed to respond keeps the finding gating (conservative, fail-safe).
+// SuspectedFP reports the AI's advisory false-positive opinion. When a distinct verifier was attempted,
+// BOTH models must refute at/above the bar. In single-model mode it can still return true for visibility,
+// but the scan's deterministic policy never grants a gate exemption unless VerifiedConsensus is true.
 func (c Critique) SuspectedFP(minConfidence int) bool {
 	if c.Err != nil {
 		return false
@@ -64,6 +63,15 @@ func (c Critique) SuspectedFP(minConfidence int) bool {
 		return true // single-model mode: no distinct verifier configured
 	}
 	return c.Verifier != nil && c.Verifier.Verdict == judgment.CritiqueRefuted && c.Verifier.Confidence >= minConfidence
+}
+
+// VerifiedConsensus reports whether two distinct configured model IDs independently refuted the finding
+// at/above the confidence bar. This is necessary, but not sufficient, for a gate exemption: the scan policy
+// also applies severity/kind/CWE floors that force dangerous classes to human review.
+func (c Critique) VerifiedConsensus(minConfidence int) bool {
+	return c.Err == nil && c.VerifyAttempted && c.Verifier != nil &&
+		c.Claim.Verdict == judgment.CritiqueRefuted && c.Claim.Confidence >= minConfidence &&
+		c.Verifier.Verdict == judgment.CritiqueRefuted && c.Verifier.Confidence >= minConfidence
 }
 
 // Coordinator critiques findings through an LLM proposer, and (when configured) a DISTINCT verifier.
@@ -96,10 +104,9 @@ func (c *Coordinator) WithMinConfidence(n int) *Coordinator {
 	return c
 }
 
-// WithVerifier attaches a DISTINCT verifier model: after the proposer refutes a finding at/above the
-// bar, the verifier independently re-assesses and the refutation only stands (exempts the gate) if the
-// verifier agrees — mirroring the judgment gate's distinct-verifier rule in the stateless CLI. A no-op
-// if llm is nil or the verifier model equals the proposer model (not a distinct verifier).
+// WithVerifier attaches a DISTINCT verifier model. Agreement creates VerifiedConsensus, which the
+// scan policy may authorize only after applying severity/kind/CWE human-review floors. A no-op if llm
+// is nil or the verifier model equals the proposer model (not a distinct verifier).
 func (c *Coordinator) WithVerifier(llm ports.LLM, model string) *Coordinator {
 	model = strings.TrimSpace(model)
 	if llm != nil && model != "" && model != c.model {
@@ -111,6 +118,9 @@ func (c *Coordinator) WithVerifier(llm ports.LLM, model string) *Coordinator {
 
 // VerifierModel returns the distinct verifier model in effect, or "" when single-model.
 func (c *Coordinator) VerifierModel() string { return c.verifierModel }
+
+// ProposerModel returns the configured proposer model ID for audit metadata.
+func (c *Coordinator) ProposerModel() string { return c.model }
 
 // MinConfidence is the confidence bar in effect.
 func (c *Coordinator) MinConfidence() int { return c.minConf }

--- a/internal/usecase/fptriage/coordinator_test.go
+++ b/internal/usecase/fptriage/coordinator_test.go
@@ -73,6 +73,9 @@ func TestAssessAppliesVerdicts(t *testing.T) {
 	if !got[3].SuspectedFP(75) {
 		t.Errorf("constant-input refutation must be a suspected FP: %+v", got[3])
 	}
+	if got[1].VerifiedConsensus(75) || got[3].VerifiedConsensus(75) {
+		t.Error("single-model suspected FPs must remain advisory, never verified consensus")
+	}
 }
 
 // roleLLM answers differently for the proposer vs the verifier pass (the verifier user prompt carries
@@ -107,7 +110,7 @@ func TestVerifierConsensus(t *testing.T) {
 		return c.Assess(context.Background(), cand, nil)[0]
 	}
 	// Both agree → suspected FP, verified.
-	if got := run(roleLLM{proposer: refuted, verifier: `{"verdict":"refuted","driver":"not_reachable","confidence":85}`}); !got.SuspectedFP(75) || !got.VerifyAttempted || got.Verifier == nil {
+	if got := run(roleLLM{proposer: refuted, verifier: `{"verdict":"refuted","driver":"not_reachable","confidence":85}`}); !got.SuspectedFP(75) || !got.VerifiedConsensus(75) || !got.VerifyAttempted || got.Verifier == nil {
 		t.Errorf("consensus refuted must be suspected-FP + verified: %+v", got)
 	}
 	// Verifier disagrees (sound) → NOT suspected FP (finding gates).

--- a/internal/usecase/fptriage/livedemo_ai_test.go
+++ b/internal/usecase/fptriage/livedemo_ai_test.go
@@ -3,9 +3,9 @@ package fptriage_test
 // Live-AI demonstration for #165 (AI false-positive triage in the scan pipeline, with the #156 distinct-
 // verifier consensus). It drives the REAL Coordinator against a live OpenAI-compatible gateway (9router):
 // a clearly PARAMETERIZED query (not injectable) is critiqued as a false positive by the proposer AND
-// confirmed by a DISTINCT verifier → suspected-FP (retain-and-mark, exempt from the gate); a clearly
-// INJECTABLE string-concatenation stays gating (not refuted). This proves the pipeline's FP gate + the
-// two-model consensus are effective end-to-end, and — critically — that a real weakness is NOT dismissed.
+// confirmed by a DISTINCT verifier → verified suspected-FP (eligible for the separate deterministic
+// gate policy); a clearly INJECTABLE string-concatenation stays gating. This proves the model-consensus
+// seam and — critically — that a real weakness is NOT dismissed.
 //
 // Gated behind SYNAPSE_LIVE_AI=1 so the normal suite stays hermetic. Run:
 //   SYNAPSE_LIVE_AI=1 SYNAPSE_LLM_BASE_URL=http://localhost:20128/v1 \

--- a/internal/usecase/fptriage/prompt.go
+++ b/internal/usecase/fptriage/prompt.go
@@ -10,6 +10,10 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 )
 
+// promptVersion is persisted with every critique so an audit can identify the exact prompt contract
+// that produced a decision without retaining raw source or model chain-of-thought.
+const promptVersion = "fp-triage-v1"
+
 // systemPrompt frames the model as a propose-only false-positive adjudicator. It must answer ONLY with
 // the schema-constrained JSON — the driver is a closed token, so no prose can reach a deliverable.
 const systemPrompt = `You are a security false-positive adjudicator for a static analysis tool.

--- a/internal/usecase/fptriage/triager.go
+++ b/internal/usecase/fptriage/triager.go
@@ -46,16 +46,24 @@ func (t *Triager) Triage(ctx context.Context, candidates []finding.Finding, work
 		if c.Err != nil {
 			continue
 		}
-		fp := c.SuspectedFP(t.minConf)
-		out = append(out, ports.AICritique{
-			FindingID:   c.FindingID,
-			DedupKey:    c.DedupKey,
-			Verdict:     string(c.Claim.Verdict),
-			Driver:      c.Claim.Driver,
-			Confidence:  c.Claim.Confidence,
-			SuspectedFP: fp,
-			Verified:    fp && c.VerifyAttempted, // a suspected-FP a DISTINCT verifier confirmed
-		})
+		critique := ports.AICritique{
+			FindingID:     c.FindingID,
+			DedupKey:      c.DedupKey,
+			Verdict:       string(c.Claim.Verdict),
+			Driver:        c.Claim.Driver,
+			Confidence:    c.Claim.Confidence,
+			SuspectedFP:   c.SuspectedFP(t.minConf),
+			Verified:      c.VerifiedConsensus(t.minConf),
+			ProposerModel: t.coord.ProposerModel(),
+			VerifierModel: t.coord.VerifierModel(),
+			PromptVersion: promptVersion,
+		}
+		if c.Verifier != nil {
+			critique.VerifierVerdict = string(c.Verifier.Verdict)
+			critique.VerifierDriver = c.Verifier.Driver
+			critique.VerifierConfidence = c.Verifier.Confidence
+		}
+		out = append(out, critique)
 	}
 	return out
 }

--- a/internal/usecase/fptriage/triager_test.go
+++ b/internal/usecase/fptriage/triager_test.go
@@ -37,6 +37,9 @@ func TestTriagerMapsToPortsDTO(t *testing.T) {
 	if byKey["dk-1"].Verified {
 		t.Error("single-model refutation must not be marked verified")
 	}
+	if c := byKey["dk-1"]; c.GateExempt || c.ProposerModel != "m" || c.VerifierModel != "" || c.PromptVersion != promptVersion {
+		t.Errorf("single-model DTO must be advisory with audit metadata, got %+v", c)
+	}
 }
 
 func TestTriagerNilSafe(t *testing.T) {

--- a/internal/usecase/ports/fptriage.go
+++ b/internal/usecase/ports/fptriage.go
@@ -15,26 +15,37 @@ type SourceSnippetReader interface {
 }
 
 // AICritique is one finding's LLM false-positive verdict (propose-only, advisory). Verdict and Driver use
-// the closed judgment.CritiqueClaim vocabulary (no free prose). SuspectedFP is set when a "refuted"
-// verdict clears the confidence bar — and, when a distinct verifier is configured, it independently
-// confirmed. It is retain-and-mark: a suspected-FP finding stays reported and sealed and is only held
-// back from the CI gate, never deleted.
+// the closed judgment.CritiqueClaim vocabulary (no free prose). SuspectedFP records the model's opinion;
+// it NEVER grants a gate exemption by itself. GateExempt is a separate, server-owned policy decision that
+// requires distinct-model consensus and must also clear the human-review floor. The complete decision and
+// model metadata are retained in the scan result and its tamper-evident evidence link.
 type AICritique struct {
-	FindingID   string `json:"finding_id"`
-	DedupKey    string `json:"dedup_key"`
-	Verdict     string `json:"verdict"`
-	Driver      string `json:"driver"`
-	Confidence  int    `json:"confidence"`
-	SuspectedFP bool   `json:"suspected_fp"`
+	FindingID      string `json:"finding_id"`
+	DedupKey       string `json:"dedup_key"`
+	Verdict        string `json:"verdict"`
+	Driver         string `json:"driver"`
+	Confidence     int    `json:"confidence"`
+	SuspectedFP    bool   `json:"suspected_fp"`
+	ProposerModel  string `json:"proposer_model"`
+	VerifierModel  string `json:"verifier_model,omitempty"`
+	PromptVersion  string `json:"prompt_version"`
+	PolicyVersion  string `json:"policy_version,omitempty"`
+	PolicyReason   string `json:"policy_reason,omitempty"`
+	GateExempt     bool   `json:"gate_exempt"`
+	ReviewRequired bool   `json:"review_required"`
 	// Verified is true when a DISTINCT verifier model independently confirmed the refutation (two-model
-	// consensus). Omitted when no verifier was configured (single-model triage).
-	Verified bool `json:"verified,omitempty"`
+	// consensus). Single-model triage can set SuspectedFP but can never set Verified or GateExempt.
+	Verified           bool   `json:"verified"`
+	VerifierVerdict    string `json:"verifier_verdict,omitempty"`
+	VerifierDriver     string `json:"verifier_driver,omitempty"`
+	VerifierConfidence int    `json:"verifier_confidence,omitempty"`
 }
 
 // FPTriager runs an LLM false-positive critique over candidate findings from a workspace and returns a
 // per-candidate advisory verdict. It is best-effort and PROPOSE-ONLY: it never mutates or deletes a
-// finding; the caller applies a suspected-FP as retain-and-mark (held back from the --fail-on gate,
-// still reported and evidence-sealed). Injected optionally into the scan pipeline; nil = no triage.
+// finding. The caller applies the deterministic gate policy; only a verified critique that clears the
+// human-review floor can be retain-and-mark gate-exempt. Injected optionally into the scan pipeline;
+// nil = no triage.
 type FPTriager interface {
 	Triage(ctx context.Context, candidates []finding.Finding, workspaceDir string) []AICritique
 }

--- a/internal/usecase/sca/fptriage_policy.go
+++ b/internal/usecase/sca/fptriage_policy.go
@@ -1,0 +1,120 @@
+package sca
+
+import (
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/verdict"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// aiTriagePolicyVersion is sealed with every scan that carries AI triage. Bump it whenever the
+// authorization contract changes so an audit can replay which policy could affect a CI gate.
+const aiTriagePolicyVersion = "fp-gate-v1"
+
+const (
+	aiPolicyNotSuspected      = "not_suspected_false_positive"
+	aiPolicyVerifierRequired  = "distinct_verifier_required"
+	aiPolicyFindingMissing    = "finding_not_found"
+	aiPolicySeverityFloor     = "severity_requires_human"
+	aiPolicySecretFloor       = "secret_requires_human"
+	aiPolicyDangerousCWEFloor = "cwe_requires_human"
+	aiPolicyVerifiedConsensus = "verified_consensus"
+)
+
+// humanReviewCWEs are weakness classes where a false negative can directly expose an execution,
+// injection, authentication/authorization, request-forgery, traversal, upload, or deserialization
+// boundary. Even two agreeing models can only advise on these classes; they never exempt the gate.
+var humanReviewCWEs = map[string]struct{}{
+	"CWE-22":  {}, // path traversal
+	"CWE-23":  {},
+	"CWE-36":  {},
+	"CWE-78":  {}, // OS command injection
+	"CWE-79":  {}, // XSS / output injection
+	"CWE-89":  {}, // SQL injection
+	"CWE-94":  {}, // code injection
+	"CWE-284": {}, // access control
+	"CWE-285": {},
+	"CWE-287": {}, // authentication
+	"CWE-306": {},
+	"CWE-434": {}, // unrestricted upload
+	"CWE-502": {}, // unsafe deserialization
+	"CWE-862": {},
+	"CWE-863": {},
+	"CWE-918": {}, // SSRF
+}
+
+// applyAIGatePolicy separates an AI opinion from authorization to change a gate. It is the single
+// policy point used by both CLI and API scans. The triager may propose SuspectedFP, but only a complete
+// distinct-model consensus that clears the human-review floor receives GateExempt.
+func applyAIGatePolicy(result *ScanResult) {
+	if result == nil || len(result.AITriage) == 0 {
+		return
+	}
+	findings := make(map[string]finding.Finding, len(result.Findings))
+	for _, item := range result.Findings {
+		if key := strings.TrimSpace(item.DedupKey); key != "" {
+			findings[key] = item
+		}
+	}
+	for i := range result.AITriage {
+		critique := &result.AITriage[i]
+		critique.PolicyVersion = aiTriagePolicyVersion
+		critique.GateExempt = false
+		critique.ReviewRequired = false
+
+		if !critique.SuspectedFP {
+			critique.PolicyReason = aiPolicyNotSuspected
+			continue
+		}
+		if !hasVerifiedConsensus(*critique) {
+			critique.PolicyReason = aiPolicyVerifierRequired
+			critique.ReviewRequired = true
+			continue
+		}
+		item, ok := findings[strings.TrimSpace(critique.DedupKey)]
+		if !ok {
+			critique.PolicyReason = aiPolicyFindingMissing
+			critique.ReviewRequired = true
+			continue
+		}
+		if reason := humanReviewFloor(item); reason != "" {
+			critique.PolicyReason = reason
+			critique.ReviewRequired = true
+			continue
+		}
+		critique.PolicyReason = aiPolicyVerifiedConsensus
+		critique.GateExempt = true
+	}
+}
+
+// hasVerifiedConsensus validates the full DTO rather than trusting its Verified boolean. This keeps a
+// buggy or alternate FPTriager implementation from granting itself gate authority by setting one field.
+func hasVerifiedConsensus(c ports.AICritique) bool {
+	proposer := strings.TrimSpace(c.ProposerModel)
+	verifierModel := strings.TrimSpace(c.VerifierModel)
+	return c.Verified &&
+		proposer != "" && verifierModel != "" && proposer != verifierModel &&
+		c.Verdict == string(judgment.CritiqueRefuted) && c.Confidence >= verdict.EvidenceThreshold &&
+		c.VerifierVerdict == string(judgment.CritiqueRefuted) &&
+		c.VerifierConfidence >= verdict.EvidenceThreshold
+}
+
+func humanReviewFloor(item finding.Finding) string {
+	if item.Severity == shared.SeverityCritical || item.Severity == shared.SeverityHigh {
+		return aiPolicySeverityFloor
+	}
+	if item.Kind == finding.KindSecret {
+		return aiPolicySecretFloor
+	}
+	for _, token := range strings.FieldsFunc(strings.ToUpper(item.CWE), func(r rune) bool {
+		return r == ',' || r == ';' || r == '|' || r == '/' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		if _, protected := humanReviewCWEs[token]; protected {
+			return aiPolicyDangerousCWEFloor
+		}
+	}
+	return ""
+}

--- a/internal/usecase/sca/fptriage_test.go
+++ b/internal/usecase/sca/fptriage_test.go
@@ -1,10 +1,13 @@
 package sca
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -29,13 +32,155 @@ func TestFPTriageCandidates(t *testing.T) {
 }
 
 func TestSuspectedFPKeys(t *testing.T) {
+	consensus := verifiedCritique("c")
+	consensus.GateExempt = true
+	consensus.PolicyVersion = aiTriagePolicyVersion
+	consensus.PolicyReason = aiPolicyVerifiedConsensus
 	res := &ScanResult{AITriage: []ports.AICritique{
-		{DedupKey: "a", SuspectedFP: true},
+		{DedupKey: "a", SuspectedFP: true, GateExempt: false},
 		{DedupKey: "b", SuspectedFP: false},
-		{DedupKey: "c", SuspectedFP: true},
-	}}
+		consensus,
+	}, Findings: []finding.Finding{{DedupKey: "c", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"}}}
 	keys := res.SuspectedFPKeys()
 	if len(keys) != 2 || !keys["a"] || !keys["c"] || keys["b"] {
 		t.Errorf("SuspectedFPKeys = %v, want {a,c}", keys)
+	}
+	exempt := res.AIGateExemptKeys()
+	if len(exempt) != 1 || !exempt["c"] || exempt["a"] {
+		t.Errorf("AIGateExemptKeys = %v, want only {c}", exempt)
+	}
+}
+
+func verifiedCritique(key string) ports.AICritique {
+	return ports.AICritique{
+		DedupKey:           key,
+		Verdict:            "refuted",
+		Confidence:         95,
+		SuspectedFP:        true,
+		ProposerModel:      "proposer-a",
+		VerifierModel:      "verifier-b",
+		Verified:           true,
+		VerifierVerdict:    "refuted",
+		VerifierConfidence: 93,
+		PromptVersion:      "fp-triage-v1",
+	}
+}
+
+func TestApplyAIGatePolicy(t *testing.T) {
+	single := verifiedCritique("single")
+	single.Verified = false
+	single.VerifierModel = ""
+	single.VerifierVerdict = ""
+	single.VerifierConfidence = 0
+
+	result := &ScanResult{
+		Findings: []finding.Finding{
+			{DedupKey: "safe-medium", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "single", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "high", Kind: finding.KindSAST, Severity: shared.SeverityHigh, CWE: "CWE-327"},
+			{DedupKey: "secret", Kind: finding.KindSecret, Severity: shared.SeverityMedium, CWE: "CWE-798"},
+			{DedupKey: "sqli", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-89"},
+		},
+		AITriage: []ports.AICritique{
+			verifiedCritique("safe-medium"),
+			single,
+			verifiedCritique("high"),
+			verifiedCritique("secret"),
+			verifiedCritique("sqli"),
+			{DedupKey: "sound", Verdict: "sound", Confidence: 99, ProposerModel: "proposer-a"},
+			verifiedCritique("missing"),
+		},
+	}
+
+	applyAIGatePolicy(result)
+	byKey := map[string]ports.AICritique{}
+	for _, c := range result.AITriage {
+		byKey[c.DedupKey] = c
+		if c.PolicyVersion != aiTriagePolicyVersion {
+			t.Errorf("%s policy version = %q", c.DedupKey, c.PolicyVersion)
+		}
+	}
+	if c := byKey["safe-medium"]; !c.GateExempt || c.ReviewRequired || c.PolicyReason != aiPolicyVerifiedConsensus {
+		t.Errorf("verified low-risk consensus should be gate-exempt: %+v", c)
+	}
+	for key, reason := range map[string]string{
+		"single":  aiPolicyVerifierRequired,
+		"high":    aiPolicySeverityFloor,
+		"secret":  aiPolicySecretFloor,
+		"sqli":    aiPolicyDangerousCWEFloor,
+		"missing": aiPolicyFindingMissing,
+	} {
+		c := byKey[key]
+		if c.GateExempt || !c.ReviewRequired || c.PolicyReason != reason {
+			t.Errorf("%s must remain gating for %s: %+v", key, reason, c)
+		}
+	}
+	if c := byKey["sound"]; c.GateExempt || c.ReviewRequired || c.PolicyReason != aiPolicyNotSuspected {
+		t.Errorf("non-refuted critique should be informational only: %+v", c)
+	}
+}
+
+func TestApplyAIGatePolicyRejectsForgedVerifiedFlag(t *testing.T) {
+	cases := []ports.AICritique{
+		verifiedCritique("same-model"),
+		verifiedCritique("low-verifier"),
+		verifiedCritique("wrong-verdict"),
+	}
+	cases[0].VerifierModel = cases[0].ProposerModel
+	cases[1].VerifierConfidence = 74
+	cases[2].VerifierVerdict = "sound"
+	result := &ScanResult{
+		Findings: []finding.Finding{
+			{DedupKey: "same-model", Kind: finding.KindSAST, Severity: shared.SeverityMedium},
+			{DedupKey: "low-verifier", Kind: finding.KindSAST, Severity: shared.SeverityMedium},
+			{DedupKey: "wrong-verdict", Kind: finding.KindSAST, Severity: shared.SeverityMedium},
+		},
+		AITriage: cases,
+	}
+	applyAIGatePolicy(result)
+	if got := result.AIGateExemptKeys(); len(got) != 0 {
+		t.Fatalf("forged/incomplete consensus must never receive gate authority: %v", got)
+	}
+}
+
+func TestAIGateExemptKeysRevalidatesPersistedDecision(t *testing.T) {
+	forged := verifiedCritique("high")
+	forged.GateExempt = true
+	forged.PolicyVersion = aiTriagePolicyVersion
+	forged.PolicyReason = aiPolicyVerifiedConsensus
+	result := &ScanResult{
+		Findings: []finding.Finding{{DedupKey: "high", Kind: finding.KindSAST, Severity: shared.SeverityHigh}},
+		AITriage: []ports.AICritique{forged},
+	}
+	if got := result.AIGateExemptKeys(); len(got) != 0 {
+		t.Fatalf("persisted gate flag must be revalidated against the high-risk floor: %v", got)
+	}
+}
+
+func TestScanEvidenceContentSealsAIDecisions(t *testing.T) {
+	result := &ScanResult{
+		Findings: []finding.Finding{{DedupKey: "z"}, {DedupKey: "a"}},
+		Manifest: ports.ScanManifest{SBOMSHA256: "sha256:abc"},
+		AITriage: []ports.AICritique{
+			{DedupKey: "z", FindingID: "fz", ProposerModel: "p", PolicyVersion: aiTriagePolicyVersion, PolicyReason: aiPolicyVerifierRequired, ReviewRequired: true},
+			{DedupKey: "a", FindingID: "fa", ProposerModel: "p", VerifierModel: "v", PolicyVersion: aiTriagePolicyVersion, PolicyReason: aiPolicyVerifiedConsensus, Verified: true, GateExempt: true},
+		},
+	}
+	content, err := scanEvidenceContent("tester", time.Date(2026, 8, 3, 1, 2, 3, 0, time.UTC), result)
+	if err != nil {
+		t.Fatalf("scanEvidenceContent: %v", err)
+	}
+	var payload scanEvidencePayload
+	if err := json.Unmarshal(content, &payload); err != nil {
+		t.Fatalf("decode evidence payload: %v", err)
+	}
+	if payload.AITriagePolicy != aiTriagePolicyVersion || len(payload.AITriage) != 2 {
+		t.Fatalf("AI policy/decisions missing from sealed payload: %+v", payload)
+	}
+	if payload.Findings[0] != "a" || payload.AITriage[0].DedupKey != "a" {
+		t.Errorf("evidence payload must sort findings and AI decisions canonically: %+v", payload)
+	}
+	if !payload.AITriage[0].GateExempt || !payload.AITriage[0].Verified || !payload.AITriage[1].ReviewRequired {
+		t.Errorf("gate/verifier/review metadata not sealed: %+v", payload.AITriage)
 	}
 }

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -202,8 +202,9 @@ func (s *Service) SetIncludeTestSecrets(v bool) { s.includeTestSecrets = v }
 
 // SetFPTriage injects the optional LLM false-positive triager. When set, the pipeline critiques the
 // production-scope first-party source findings after they are built and records the advisory verdicts on
-// ScanResult.AITriage; a suspected-FP is retain-and-mark (gate-exempt via SuspectedFPKeys, still
-// reported + sealed). Best-effort; nil = no triage.
+// ScanResult.AITriage. The deterministic AI gate policy separately decides whether a verified consensus
+// clears the human-review floor; a suspected-FP opinion alone has no gate authority. Best-effort; nil =
+// no triage.
 func (s *Service) SetFPTriage(t ports.FPTriager) { s.fpTriager = t }
 
 // SetOSPackageCataloger configures optional owned OS-package cataloging (dpkg/apk) from a materialized image
@@ -566,11 +567,10 @@ type ScanResult struct {
 	// producer + pinned advisory/DB snapshot ⇒ same digest. Excludes timestamps + per-run metadata.
 	ReproDigest string                 `json:"repro_digest"`
 	DebugEvents []ports.ScanDebugEvent `json:"debug_events"`
-	// AITriage holds an optional LLM false-positive critique of first-party source findings (opt-in,
-	// best-effort). Each entry is the model's PROPOSED verdict; a suspected-FP entry is retain-and-mark
-	// (the finding stays reported here and sealed, it is only held back from the CI gate), never a
-	// deletion. Populated by the injected ports.FPTriager for BOTH the CLI and the durable API scan job;
-	// empty unless the FP-triage gate ran.
+	// AITriage holds optional LLM false-positive critiques plus the deterministic policy decision for each
+	// finding. SuspectedFP is advisory; only GateExempt=true may affect a CI/project gate, and that requires
+	// distinct-model consensus plus clearance of the high-risk human-review floor. Findings are never
+	// deleted. The complete array is sealed into the scan evidence link.
 	AITriage []ports.AICritique `json:"ai_triage,omitempty"`
 	// SourceCapture is analysis-owned source availability metadata. Content is held by
 	// ProjectSourceArtifactStore, never embedded in this scan result.
@@ -581,9 +581,8 @@ type ScanResult struct {
 	FileChanges []projectanalysis.FileChange `json:"file_changes,omitempty"`
 }
 
-// SuspectedFPKeys returns the set of finding DedupKeys the AI triage marked as suspected false positives
-// (retain-and-mark). A --fail-on gate exempts these (still reported + sealed), the same way it exempts
-// accepted-risk and needs-verify findings.
+// SuspectedFPKeys returns advisory model opinions. Consumers MUST NOT use this set to authorize a gate
+// exemption; use AIGateExemptKeys, whose values have passed the deterministic P0 policy.
 func (r *ScanResult) SuspectedFPKeys() map[string]bool {
 	out := map[string]bool{}
 	for _, c := range r.AITriage {
@@ -594,10 +593,46 @@ func (r *ScanResult) SuspectedFPKeys() map[string]bool {
 	return out
 }
 
+// AIGateExemptKeys returns only AI critiques that the server-owned policy authorized to affect a gate.
+func (r *ScanResult) AIGateExemptKeys() map[string]bool {
+	out := map[string]bool{}
+	findings := make(map[string]finding.Finding, len(r.Findings))
+	for _, item := range r.Findings {
+		if key := strings.TrimSpace(item.DedupKey); key != "" {
+			findings[key] = item
+		}
+	}
+	for _, c := range r.AITriage {
+		key := strings.TrimSpace(c.DedupKey)
+		item, found := findings[key]
+		if c.GateExempt &&
+			c.PolicyVersion == aiTriagePolicyVersion &&
+			c.PolicyReason == aiPolicyVerifiedConsensus &&
+			hasVerifiedConsensus(c) &&
+			found && humanReviewFloor(item) == "" {
+			out[key] = true
+		}
+	}
+	return out
+}
+
+// AIReviewRequiredKeys returns suspected false positives held in the human-review floor.
+func (r *ScanResult) AIReviewRequiredKeys() map[string]bool {
+	out := map[string]bool{}
+	for _, c := range r.AITriage {
+		if c.ReviewRequired {
+			if key := strings.TrimSpace(c.DedupKey); key != "" {
+				out[key] = true
+			}
+		}
+	}
+	return out
+}
+
 // GateExemptKeys returns retain-and-mark findings excluded from a Project quality gate.
 func (r *ScanResult) GateExemptKeys(items []finding.Finding) map[string]bool {
 	exempt := map[string]bool{}
-	for _, keys := range []map[string]bool{r.SuppressedKeys(), r.NeedsVerifyKeys(), r.SuspectedFPKeys()} {
+	for _, keys := range []map[string]bool{r.SuppressedKeys(), r.NeedsVerifyKeys(), r.AIGateExemptKeys()} {
 		for key := range keys {
 			if key = strings.TrimSpace(key); key != "" {
 				exempt[key] = true
@@ -2297,14 +2332,21 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		}
 	}
 	// AI false-positive triage (opt-in, best-effort, PROPOSE-ONLY). After the deterministic pass, the
-	// injected triager critiques the remaining production-scope first-party source findings and records
-	// advisory verdicts on AITriage; a suspected-FP is retain-and-mark (held back from the gate via
-	// SuspectedFPKeys, still reported + sealed). Runs for BOTH the CLI and the durable API scan job.
+	// injected triager critiques production-scope first-party findings. The server-owned policy then
+	// separates advisory suspected-FP opinions from verified, low-risk gate exemptions. Single-model,
+	// high/critical, secret, and dangerous-CWE refutations stay gating for human review.
 	if s.fpTriager != nil {
 		if cands := fpTriageCandidates(result.Findings); len(cands) > 0 {
 			tstep := trace.start(stageFindings, "ai-fp-triage", "fp-triager", "AI false-positive triage", map[string]int{"candidates": len(cands)})
 			result.AITriage = s.fpTriager.Triage(ctx, cands, ws.Dir)
-			trace.succeed(tstep, "AI false-positive triage", map[string]int{"candidates": len(cands), "critiqued": len(result.AITriage), "suspected_fp": len(result.SuspectedFPKeys())})
+			applyAIGatePolicy(result)
+			trace.succeed(tstep, "AI false-positive triage", map[string]int{
+				"candidates":      len(cands),
+				"critiqued":       len(result.AITriage),
+				"suspected_fp":    len(result.SuspectedFPKeys()),
+				"gate_exempt":     len(result.AIGateExemptKeys()),
+				"review_required": len(result.AIReviewRequiredKeys()),
+			})
 		}
 	}
 	result.MinSeverity = s.minSeverity
@@ -2885,14 +2927,21 @@ func isPinnedVersion(v string) bool {
 // job.Error – a second layer beyond the acquirer's own redaction.
 var credInErr = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@\s]+@`)
 
-// sealEvidence appends one tamper-evident link summarizing this scan to the
-// engagement's hash chain. Content is a canonical digest of the run:
-// SBOM hash, finding keys, and the manifest – so any later tampering is detectable
-// by re-verification. Best-effort: a ledger write must not fail a good scan.
-func (s *Service) sealEvidence(ctx context.Context, actor string, engagementID shared.ID, now time.Time, result *ScanResult) {
-	if s.evidence == nil {
-		return
-	}
+type scanEvidencePayload struct {
+	SBOMSHA256     string             `json:"sbom_sha256"`
+	Findings       []string           `json:"findings"`
+	Suppressed     []string           `json:"suppressed,omitempty"`
+	AITriagePolicy string             `json:"ai_triage_policy,omitempty"`
+	AITriage       []ports.AICritique `json:"ai_triage,omitempty"`
+	Manifest       ports.ScanManifest `json:"manifest"`
+	SealedAt       string             `json:"sealed_at"`
+	Actor          string             `json:"actor"`
+}
+
+// scanEvidenceContent builds the canonical scan evidence payload. AI decisions are sorted and sealed
+// alongside findings, so changing a verdict, verifier identity, policy reason, or gate authorization is
+// detectable even when the finding set itself is unchanged.
+func scanEvidenceContent(actor string, now time.Time, result *ScanResult) ([]byte, error) {
 	keys := make([]string, 0, len(result.Findings))
 	for _, f := range result.Findings {
 		keys = append(keys, f.DedupKey)
@@ -2906,15 +2955,40 @@ func (s *Service) sealEvidence(ctx context.Context, actor string, engagementID s
 		suppressed = append(suppressed, sf.RuleID+"="+sf.DedupKey)
 	}
 	sort.Strings(suppressed)
-	payload := struct {
-		SBOMSHA256 string             `json:"sbom_sha256"`
-		Findings   []string           `json:"findings"`
-		Suppressed []string           `json:"suppressed,omitempty"`
-		Manifest   ports.ScanManifest `json:"manifest"`
-		SealedAt   string             `json:"sealed_at"`
-		Actor      string             `json:"actor"`
-	}{result.Manifest.SBOMSHA256, keys, suppressed, result.Manifest, now.UTC().Format(time.RFC3339), actor}
-	content, err := json.Marshal(payload)
+	aiTriage := append([]ports.AICritique(nil), result.AITriage...)
+	sort.Slice(aiTriage, func(i, j int) bool {
+		if aiTriage[i].DedupKey != aiTriage[j].DedupKey {
+			return aiTriage[i].DedupKey < aiTriage[j].DedupKey
+		}
+		if aiTriage[i].FindingID != aiTriage[j].FindingID {
+			return aiTriage[i].FindingID < aiTriage[j].FindingID
+		}
+		return aiTriage[i].ProposerModel < aiTriage[j].ProposerModel
+	})
+	policyVersion := ""
+	if len(aiTriage) > 0 {
+		policyVersion = aiTriagePolicyVersion
+	}
+	return json.Marshal(scanEvidencePayload{
+		SBOMSHA256:     result.Manifest.SBOMSHA256,
+		Findings:       keys,
+		Suppressed:     suppressed,
+		AITriagePolicy: policyVersion,
+		AITriage:       aiTriage,
+		Manifest:       result.Manifest,
+		SealedAt:       now.UTC().Format(time.RFC3339),
+		Actor:          actor,
+	})
+}
+
+// sealEvidence appends one tamper-evident link summarizing this scan to the engagement's hash chain.
+// Best-effort: a ledger write must not fail a good scan, but any written link covers every gate-affecting
+// AI field as well as the deterministic finding/suppression set.
+func (s *Service) sealEvidence(ctx context.Context, actor string, engagementID shared.ID, now time.Time, result *ScanResult) {
+	if s.evidence == nil {
+		return
+	}
+	content, err := scanEvidenceContent(actor, now, result)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary

Adds P0 safety guardrails for AI-assisted false-positive triage without allowing a single model opinion to silently remove a real finding.

- keeps single-model triage advisory-only
- requires high-confidence consensus from a distinct verifier model before AI can affect a quality gate
- forces high/critical findings, secrets, and dangerous CWE classes to human review
- revalidates gate-exemption metadata server-side instead of trusting persisted flags
- seals proposer/verifier verdicts, confidence, model IDs, prompt version, policy version, and policy reason in scan evidence
- reports suspected, gate-exempt, and review-required counts separately in the CLI/API logs

Findings remain present in JSON, SARIF, compliance output, and evidence even when the deterministic policy grants a gate exemption.

## Safety contract for review

Please confirm these product decisions:

1. Low/medium findings may be gate-exempt only when two differently named models independently return refuted at or above the evidence threshold.
2. High/critical findings, secret findings, and protected CWE classes always remain gating and require human review.
3. A missing, unavailable, failing, or non-distinct verifier makes triage advisory-only.
4. review_required is metadata in this P0; the durable review queue and UI workflow are explicitly deferred to P1.

## Implementation notes

- Introduces versioned policy fp-gate-v1 and prompt contract fp-triage-v1.
- Separates suspected_fp, verified, gate_exempt, and review_required.
- Adds defensive revalidation in every gate-exemption read path.
- Includes adversarial tests for forged consensus, same-model verification, low confidence, verifier disagreement, protected severity/kind/CWE floors, missing findings, and evidence ordering/content.

## Verification

- go build ./...
- go vet ./...
- go test ./...
- CGO_ENABLED=0 go build ./cmd/...
- frontend pnpm test: 29 files / 267 tests passed
- frontend pnpm run typecheck
- frontend pnpm build
- git diff --check

The opt-in live LLM test was not run because no live model endpoint/API key was configured.

## Out of scope / P1 follow-ups

- shadow-mode evaluation dataset and quality metrics
- durable human-review queue and frontend decision UI
- blind verifier evaluation and provider/family independence
- fail-closed evidence behavior when an AI exemption cannot be sealed
- cost, latency, drift, and disagreement observability