### PR TITLE
fix(llm): send an explicit temperature 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ capabilities below are already shipped on `main`.
 
 ### Fixed
 
+- **Deterministic AI adjudication.** An explicit `temperature: 0` never reached the provider: the
+  OpenAI-compatible adapter only sent the field when it was greater than zero, so the value a
+  deterministic caller asks for was indistinguishable from "unset" and was dropped from the request. The
+  AI false-positive proposer, its distinct verifier, and the automated judgment verifier all request 0 and
+  were therefore adjudicating at the provider's default sampling — the same finding could land on either
+  side of the evidence threshold across two runs, so a gate exemption and a sealed verdict were not
+  reproducible. `ChatRequest.Temperature` is now a `*float64` (nil leaves the provider default; a non-nil
+  value, including 0, is sent verbatim), so those three call sites decode greedily as intended. The agent
+  orchestrator is unchanged: it still leaves sampling to the provider unless a run configures one.
 - **Config docs.** `docs/guide/configuration.md` listed the analysis-brain flags (judgments, SAST,
   reachability, secret and misconfig scanning, cross-check, compliance, scan cache, image rootfs, owned
   advisory, gomodgraph) as default `false`; they ship `true`. Corrected the defaults to match the code.

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -126,8 +126,8 @@ func (c *Client) Chat(ctx context.Context, req ports.ChatRequest) (ports.ChatRes
 		// 400; the orchestrator may retry without the schema (tool-calling still works).
 		body.ResponseFormat = &wireRespFmt{Type: "json_schema", JSONSchema: req.ResponseSchema}
 	}
-	if req.Temperature > 0 {
-		t := req.Temperature
+	if req.Temperature != nil {
+		t := *req.Temperature
 		body.Temperature = &t
 	}
 	// NOTE: no max_tokens/max_completion_tokens – the field name differs across OpenAI model

--- a/internal/infrastructure/llm/openai/client_test.go
+++ b/internal/infrastructure/llm/openai/client_test.go
@@ -97,6 +97,57 @@ func TestChatTerminalOnBadRequest(t *testing.T) {
 	}
 }
 
+// TestChatSendsExplicitTemperatureZero pins the wire contract deterministic callers depend on: an
+// explicit temperature 0 (greedy decoding) must reach the provider. Dropping it silently falls back to
+// the provider default (~1.0), which is the difference between a reproducible verdict and a sampled one
+// — the FP-triage proposer/verifier and the judgment verifier all ask for 0.
+func TestChatSendsExplicitTemperatureZero(t *testing.T) {
+	body := captureChatBody(t, ports.ChatRequest{
+		Temperature: ports.Temp(0),
+		Messages:    []agent.Message{{Role: agent.RoleUser, Content: "hi"}},
+	})
+	got, ok := body["temperature"]
+	if !ok {
+		t.Fatal("temperature omitted from the request – the provider default applies")
+	}
+	if got != float64(0) {
+		t.Errorf("temperature = %v, want 0", got)
+	}
+}
+
+// TestChatOmitsTemperatureWhenUnset is the other half of that contract: a caller expressing no
+// preference must not be forced onto 0 – the provider default still applies.
+func TestChatOmitsTemperatureWhenUnset(t *testing.T) {
+	body := captureChatBody(t, ports.ChatRequest{
+		Messages: []agent.Message{{Role: agent.RoleUser, Content: "hi"}},
+	})
+	if v, ok := body["temperature"]; ok {
+		t.Errorf("temperature sent (%v) although the caller expressed no preference", v)
+	}
+}
+
+// captureChatBody runs one Chat against a stub gateway and returns the decoded request body.
+func captureChatBody(t *testing.T, req ports.ChatRequest) map[string]any {
+	t.Helper()
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(b, &body); err != nil {
+			t.Errorf("request body is not JSON: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"{}"},"finish_reason":"stop"}],"usage":{}}`))
+	}))
+	defer srv.Close()
+	c, err := New(srv.URL, "", "m", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Chat(context.Background(), req); err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	return body
+}
+
 func TestNewValidates(t *testing.T) {
 	if _, err := New("", "k", "m", 0); !errors.Is(err, shared.ErrValidation) {
 		t.Error("empty base must fail validation")

--- a/internal/usecase/analysis/livedemo_ai_test.go
+++ b/internal/usecase/analysis/livedemo_ai_test.go
@@ -78,7 +78,7 @@ func TestLiveAIRuntimeConfirmToDAST(t *testing.T) {
 	// The model proposes the typed SAST hypothesis (mirrors the agent's propose_sast_validation tool).
 	resp, cerr := llm.Chat(context.Background(), ports.ChatRequest{
 		Model:       model,
-		Temperature: 0,
+		Temperature: ports.Temp(0),
 		MaxTokens:   300,
 		Messages: []agent.Message{
 			{Role: agent.RoleSystem, Content: "You are a SAST triage assistant. Output ONLY a JSON object " +

--- a/internal/usecase/fptriage/coordinator.go
+++ b/internal/usecase/fptriage/coordinator.go
@@ -166,8 +166,8 @@ func (c *Coordinator) assessOne(ctx context.Context, f finding.Finding, src Sour
 	}
 	req := ports.ChatRequest{
 		Model:          c.model,
-		Temperature:    0,
-		MaxTokens:      512, // headroom if the model emits a short rationale field before the JSON object
+		Temperature:    ports.Temp(0), // greedy: the same finding must critique the same way twice
+		MaxTokens:      512,           // headroom if the model emits a short rationale field before the JSON object
 		ResponseSchema: critiqueSchema,
 		Messages: []agent.Message{
 			{Role: "system", Content: systemPrompt},
@@ -205,7 +205,7 @@ func (c *Coordinator) verify(ctx context.Context, f finding.Finding, snippet str
 	}
 	resp, err := c.verifier.Chat(ctx, ports.ChatRequest{
 		Model:          c.verifierModel,
-		Temperature:    0,
+		Temperature:    ports.Temp(0), // greedy: consensus is only meaningful if the verifier is reproducible
 		MaxTokens:      512,
 		ResponseSchema: critiqueSchema,
 		Messages: []agent.Message{

--- a/internal/usecase/fptriage/coordinator_test.go
+++ b/internal/usecase/fptriage/coordinator_test.go
@@ -128,6 +128,41 @@ func TestVerifierConsensus(t *testing.T) {
 	}
 }
 
+// recordingLLM answers like roleLLM but keeps every request, so a test can assert what the coordinator
+// actually asked the provider for.
+type recordingLLM struct {
+	reply string
+	reqs  []ports.ChatRequest
+}
+
+func (r *recordingLLM) Chat(_ context.Context, req ports.ChatRequest) (ports.ChatResponse, error) {
+	r.reqs = append(r.reqs, req)
+	return ports.ChatResponse{Content: r.reply, FinishReason: "stop"}, nil
+}
+
+// TestCritiqueRequestsAreGreedy guards the determinism the gate exemption rests on: both the proposer
+// and the distinct verifier must ask for temperature 0 explicitly. A nil temperature would leave the
+// adjudication to the provider's default sampling, so the same finding could land on either side of the
+// confidence bar across two runs.
+func TestCritiqueRequestsAreGreedy(t *testing.T) {
+	llm := &recordingLLM{reply: `{"verdict":"refuted","driver":"not_reachable","confidence":92}`}
+	c := New(llm, "proposer-model").WithVerifier(llm, "verifier-model")
+	c.Assess(context.Background(), []finding.Finding{mkFinding("1", "X (a/b.go:1)")}, nil)
+
+	if len(llm.reqs) != 2 {
+		t.Fatalf("want a proposer and a verifier call, got %d", len(llm.reqs))
+	}
+	for i, req := range llm.reqs {
+		if req.Temperature == nil {
+			t.Errorf("request %d (%s) left temperature unset – the provider default applies", i, req.Model)
+			continue
+		}
+		if *req.Temperature != 0 {
+			t.Errorf("request %d (%s) temperature = %v, want 0", i, req.Model, *req.Temperature)
+		}
+	}
+}
+
 func TestAssessBestEffortOnLLMError(t *testing.T) {
 	cands := []finding.Finding{mkFinding("1", "X (a/b.go:1)")}
 	got := New(fakeLLM{err: errors.New("gateway 503")}, "m").Assess(context.Background(), cands, nil)

--- a/internal/usecase/llmverifier/assess.go
+++ b/internal/usecase/llmverifier/assess.go
@@ -73,7 +73,7 @@ func (c *Coordinator) assess(ctx context.Context, j judgment.Judgment) (int, str
 
 	resp, err := c.llm.Chat(ctx, ports.ChatRequest{
 		Model:          c.model,
-		Temperature:    0,
+		Temperature:    ports.Temp(0), // greedy: a sealed verdict must be reproducible from the audit record
 		MaxTokens:      maxTokens,
 		ResponseSchema: responseSchema,
 		Messages: []agent.Message{

--- a/internal/usecase/llmverifier/coordinator_test.go
+++ b/internal/usecase/llmverifier/coordinator_test.go
@@ -114,6 +114,38 @@ func TestAutoVerifyBestEffortOnLLMError(t *testing.T) {
 	}
 }
 
+// recordingLLM keeps every request so a test can assert what the verifier asked the provider for.
+type recordingLLM struct {
+	content string
+	reqs    []ports.ChatRequest
+}
+
+func (r *recordingLLM) Chat(_ context.Context, req ports.ChatRequest) (ports.ChatResponse, error) {
+	r.reqs = append(r.reqs, req)
+	return ports.ChatResponse{Content: r.content}, nil
+}
+
+// TestAssessRequestIsGreedy pins the sampling this verifier seals a verdict with: an explicit
+// temperature 0. Left unset, the provider's default applies and the same claim could score either side
+// of the 75 bar across runs — a sealed verdict must be reproducible from the audit record.
+func TestAssessRequestIsGreedy(t *testing.T) {
+	llm := &recordingLLM{content: `{"score":90,"rationale":"clearly a false positive"}`}
+	c := New(llm, "cx/verifier", &fakeVerifier{},
+		fakeLister{js: []judgment.Judgment{critique("1", "agent:x", judgment.StateProposed)}})
+	if _, err := c.AutoVerify(context.Background(), "eng", "human:tester"); err != nil {
+		t.Fatalf("AutoVerify: %v", err)
+	}
+	if len(llm.reqs) != 1 {
+		t.Fatalf("want 1 assess call, got %d", len(llm.reqs))
+	}
+	if llm.reqs[0].Temperature == nil {
+		t.Fatal("assess left temperature unset – the provider default applies")
+	}
+	if *llm.reqs[0].Temperature != 0 {
+		t.Errorf("temperature = %v, want 0", *llm.reqs[0].Temperature)
+	}
+}
+
 func TestParseVerdict(t *testing.T) {
 	for _, bad := range []string{"", "no json", `{"rationale":"x"}` /* no score */} {
 		if _, _, ok := parseVerdict(bad); ok {

--- a/internal/usecase/orchestrator/orchestrator.go
+++ b/internal/usecase/orchestrator/orchestrator.go
@@ -119,7 +119,7 @@ type Config struct {
 	Model               string
 	ProviderBase        string // recorded on the session for attribution; NEVER the API key
 	SystemPrompt        string // optional; defaults to DefaultSystemPrompt
-	Temperature         float64
+	Temperature         float64       // 0 = provider default (not sent)
 	MaxTokens           int           // per Chat call (0 = provider default)
 	MaxSteps            int           // hard cap on planning turns (default 16)
 	TokenBudget         int           // session token budget (0 = unbounded)
@@ -288,13 +288,19 @@ func (o *Orchestrator) loop(ctx context.Context, sess agent.Session) (agent.Sess
 		sess.Status = agent.StatusRunning
 	}
 
+	// The agent leaves sampling to the provider unless the run explicitly configured a temperature.
+	var temperature *float64
+	if o.cfg.Temperature > 0 {
+		temperature = ports.Temp(o.cfg.Temperature)
+	}
+
 	for {
 		if over, why := o.overBudget(ctx, sess); over {
 			return o.finish(ctx, sess, agent.StatusFailed, why)
 		}
 		resp, err := o.llm.Chat(ctx, ports.ChatRequest{
 			Model: o.cfg.Model, Messages: transcript, Tools: tools,
-			Temperature: o.cfg.Temperature, MaxTokens: o.cfg.MaxTokens,
+			Temperature: temperature, MaxTokens: o.cfg.MaxTokens,
 		})
 		if err != nil {
 			return o.fail(ctx, sess, fmt.Errorf("llm chat: %w", err))

--- a/internal/usecase/ports/llm.go
+++ b/internal/usecase/ports/llm.go
@@ -25,9 +25,16 @@ type ChatRequest struct {
 	Messages       []agent.Message
 	Tools          []agent.ToolSchema // the catalog advertised as function-calling tools
 	ResponseSchema json.RawMessage    // optional JSON Schema for a constrained response
-	Temperature    float64
-	MaxTokens      int
+	// Temperature is a pointer so an explicit 0 is distinguishable from "unset": nil leaves the
+	// choice to the provider default, non-nil is sent verbatim – and 0 means greedy decoding, which
+	// is what a caller whose verdict must be reproducible asks for. Use Temp.
+	Temperature *float64
+	MaxTokens   int
 }
+
+// Temp returns a pointer to v for ChatRequest.Temperature, so a deterministic caller can ask for an
+// explicit 0 without declaring a local variable at every call site.
+func Temp(v float64) *float64 { return &v }
 
 // ChatResponse is the model's turn. ToolCalls are PROPOSALS – the orchestrator decides what
 // (if anything) runs. FinishReason is the provider's stop reason ("stop"|"tool_calls"|"length").

--- a/internal/usecase/pyreach/livedemo_ai_test.go
+++ b/internal/usecase/pyreach/livedemo_ai_test.go
@@ -74,7 +74,7 @@ func TestLiveAIPyReachAuthoritative(t *testing.T) {
 	// is what gets sealed + consumed by OpenVEX. We log its verdict and whether it corroborated.
 	resp, cerr := llm.Chat(context.Background(), ports.ChatRequest{
 		Model:       model,
-		Temperature: 0,
+		Temperature: ports.Temp(0),
 		MaxTokens:   50,
 		Messages: []agent.Message{
 			{Role: agent.RoleSystem, Content: "Answer with a single word: YES or NO."},

--- a/internal/usecase/report/livedemo_ai_test.go
+++ b/internal/usecase/report/livedemo_ai_test.go
@@ -88,7 +88,7 @@ func TestLiveAIRiskNarrativeToReport(t *testing.T) {
 
 	resp, err := llm.Chat(context.Background(), ports.ChatRequest{
 		Model:       model,
-		Temperature: 0,
+		Temperature: ports.Temp(0),
 		MaxTokens:   400,
 		Messages: []agent.Message{
 			{Role: agent.RoleSystem, Content: sys},


### PR DESCRIPTION
Fixes #384.

## The bug

`ports.ChatRequest.Temperature` was a plain `float64`, and the adapter only marshalled the field when it was greater than zero:

```go
if req.Temperature > 0 {   // client.go:129
```

The wire field is `*float64` with `omitempty` (`client.go:69`), so an explicit `0` — the value a deterministic caller asks for — was indistinguishable from "unset" and never reached the provider. The provider default applied instead.

Three call sites with gate authority were affected, and all three explicitly ask for `0`:

| Call site | Role |
| --- | --- |
| `internal/usecase/fptriage/coordinator.go:169` | FP-triage proposer |
| `internal/usecase/fptriage/coordinator.go:208` | the distinct verifier |
| `internal/usecase/llmverifier/assess.go:76` | the sealing judgment verifier |

Each adjudicates against `verdict.EvidenceThreshold`, so at the provider default the same finding could land on either side of the bar across two runs: a `--fail-on` gate exemption and a sealed verdict were not reproducible. That reproducibility is the premise the propose → verify → confirm design rests on, and there was no error and no log line when it did not hold.

## The change

`ChatRequest.Temperature` becomes a `*float64`: `nil` leaves the choice to the provider, a non-nil value is sent verbatim, and `0` now reaches the wire as greedy decoding. A `ports.Temp(v)` helper keeps the three deterministic call sites to one line each. Changing the port type rather than special-casing the adapter means any future adapter behind `ports.LLM` surfaces at compile time; today there is only one (`internal/infrastructure/llm/openai`).

**The agent orchestrator is deliberately unchanged.** No composition root in `cmd/` sets `orchestrator.Config.Temperature`, so it is `0` in production today and no temperature is sent. It keeps exactly that behaviour — it now builds a pointer only when a run configured a positive temperature. This PR is only "the three deterministic call sites now really send 0".

## Tests

- `client_test.go` pins the wire contract in both directions: an explicit `0` is **present** in the body with value `0`, and an unset temperature stays **absent** (so a caller expressing no preference is not silently forced onto `0`).
- `fptriage/coordinator_test.go` asserts both the proposer and the distinct verifier request temperature `0`.
- `llmverifier/coordinator_test.go` asserts the same for the sealing verifier.

The first test fails on `main` (`temperature omitted from the request – the provider default applies`) and passes here.

Raw bodies captured against a stub gateway:

```
explicit zero  -> {"model":"m1","messages":[...],"temperature":0}
explicit 0.7   -> {"model":"m1","messages":[...],"temperature":0.7}
unset (nil)    -> {"model":"m1","messages":[...]}
```

## Verification

`gofmt -l .` clean, `go build ./...`, `go vet ./...`, and `go test ./...` pass (Go 1.26, `CGO_ENABLED=0`).

Two notes in the interest of full disclosure: `internal/infrastructure/toolrunner`'s `TestRunTimeoutKillsProcessGroup` fails in my containerised toolchain, but it fails identically on an unmodified `main` — a PID-namespace artifact of my environment, unrelated to this change. And I did not run `cd web && pnpm build`: this PR touches no file under `web/`, and I do not have pnpm locally.

## On the review notes in #384

1. **Regression test** — included, as described above.
2. **`seed` / `top_p`** — agreed that temperature 0 is necessary but not always sufficient for bit-exact reproducibility. Left out of this PR to keep it single-purpose; happy to open a follow-up if you want it pursued.
3. **Other fields with the same zero-value-omitted trap** — I audited every `ChatRequest` field. `Temperature` was the only one. `Model == ""` is a documented, deliberate fall-back to the client's default model. There is no `TopP` or `seed` field yet — the `*float64` pattern is the guard when one is added. `MaxTokens` has a *different* problem: it is set at four call sites but the adapter never sends it at all, by an explicit decision recorded in the NOTE at `client.go:133` (the field name differs across model generations). That is not a zero-value trap and it touches a choice you made on purpose, so I have not changed it here — I will raise it as its own issue, linked to #392, unless you would rather it stayed as documented.

Related: #387 lists #384 as a blocking dependency for the P0.2 distinct-verifier consensus and the P1.3 blind verifier (#390).
