### PR TITLE
feat(ai-triage): enforce P0 gate-exemption policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,12 +175,13 @@ SYNAPSE_SANDBOX_ENABLED=false
 # gate a human reviewer uses (verifier identity "llm:<model>", never the proposer → no self-confirm). It
 # also enables the FP-triage two-model consensus. Defaults to SYNAPSE_LLM_MODEL (= no distinct verifier).
 # SYNAPSE_VERIFIER_MODEL=
-# AI false-positive analysis: after a scan, the proposer critiques production-scope first-party findings.
+# AI false-positive analysis: after a scan, the proposer critiques production-scope first-party
+# SAST/misconfig findings. Secret findings and their raw source context never enter the LLM transcript.
 # A high-confidence "refuted" verdict is advisory and never deletes a finding. Gate exemption requires a
 # DIFFERENT SYNAPSE_VERIFIER_MODEL to independently refute at/above the bar. Even then, high/critical,
 # secret, and dangerous-CWE findings stay gating for human review. The typed proposer/verifier verdicts,
 # model IDs, prompt version, policy decision, and gate authorization are sealed with the scan evidence.
-# Without a distinct verifier the feature remains useful for triage, but cannot change a gate.
+# Without a distinct verifier OR a configured evidence ledger the feature remains advisory-only.
 # SYNAPSE_FP_TRIAGE_ENABLED=false
 # SYNAPSE_FP_TRIAGE_MODEL=
 # HITL approval: manual (human approves every action) | filter | auto.

--- a/.env.example
+++ b/.env.example
@@ -175,12 +175,12 @@ SYNAPSE_SANDBOX_ENABLED=false
 # gate a human reviewer uses (verifier identity "llm:<model>", never the proposer → no self-confirm). It
 # also enables the FP-triage two-model consensus. Defaults to SYNAPSE_LLM_MODEL (= no distinct verifier).
 # SYNAPSE_VERIFIER_MODEL=
-# AI false-positive gate: after a scan, the model critiques the remaining production-scope first-party
-# source findings (SAST/secret/misconfig). A high-confidence "refuted" verdict marks the finding a
-# suspected false positive — retain-and-mark (still reported + sealed, held back from the --fail-on gate),
-# never deleted. Off by default; needs an LLM endpoint above. Model defaults to SYNAPSE_LLM_MODEL.
-# When SYNAPSE_VERIFIER_MODEL (above) names a DIFFERENT model, a refutation must be independently
-# confirmed by it before it exempts the gate (two-model consensus; a single model can't flip the gate).
+# AI false-positive analysis: after a scan, the proposer critiques production-scope first-party findings.
+# A high-confidence "refuted" verdict is advisory and never deletes a finding. Gate exemption requires a
+# DIFFERENT SYNAPSE_VERIFIER_MODEL to independently refute at/above the bar. Even then, high/critical,
+# secret, and dangerous-CWE findings stay gating for human review. The typed proposer/verifier verdicts,
+# model IDs, prompt version, policy decision, and gate authorization are sealed with the scan evidence.
+# Without a distinct verifier the feature remains useful for triage, but cannot change a gate.
 # SYNAPSE_FP_TRIAGE_ENABLED=false
 # SYNAPSE_FP_TRIAGE_MODEL=
 # HITL approval: manual (human approves every action) | filter | auto.

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -703,7 +703,11 @@ func main() {
 			if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
 				if vllm, verr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.VerifierModel, cfg.LLMTimeout); verr == nil {
 					coord.WithVerifier(vllm, cfg.VerifierModel)
-					mode = "verified by " + cfg.VerifierModel
+					if coord.VerifierModel() != "" {
+						mode = "verified by " + coord.VerifierModel()
+					} else {
+						log.Warn("AI FP-triage verifier aliases the proposer after canonicalization; triage remains advisory-only", "verifier_model", cfg.VerifierModel)
+					}
 				} else {
 					log.Warn("AI FP-triage verifier unavailable; triage remains advisory-only", "err", verr)
 				}

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -692,27 +692,26 @@ func main() {
 		log.Info("misconfig scanning ENABLED (Dockerfile + Kubernetes + Terraform); " + helmMode)
 	}
 	// AI false-positive triage in the scan pipeline (opt-in, best-effort, PROPOSE-ONLY). Independent of
-	// the agent: it critiques production-scope source findings and marks suspected FPs retain-and-mark
-	// (held back from the gate via ScanResult.SuspectedFPKeys, still reported + sealed). A distinct
-	// SYNAPSE_VERIFIER_MODEL enables two-model consensus.
+	// the agent: it critiques production-scope source findings. Single-model output is advisory-only; a
+	// distinct verifier is required before the deterministic high-risk floor may grant a gate exemption.
 	if cfg.FPTriageEnabled && strings.TrimSpace(cfg.FPTriageModel) != "" {
 		if tllm, terr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.FPTriageModel, cfg.LLMTimeout); terr != nil {
 			log.Warn("AI false-positive triage DISABLED (LLM unavailable)", "err", terr)
 		} else {
 			coord := fptriage.New(tllm, cfg.FPTriageModel)
-			mode := "single-model"
+			mode := "advisory-only (distinct verifier required for gate exemption)"
 			if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
 				if vllm, verr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.VerifierModel, cfg.LLMTimeout); verr == nil {
 					coord.WithVerifier(vllm, cfg.VerifierModel)
 					mode = "verified by " + cfg.VerifierModel
 				} else {
-					log.Warn("AI FP-triage verifier unavailable, single-model", "err", verr)
+					log.Warn("AI FP-triage verifier unavailable; triage remains advisory-only", "err", verr)
 				}
 			}
 			scaService.SetFPTriage(fptriage.NewTriager(coord, func(root string) ports.SourceSnippetReader {
 				return sourcesnippet.Reader{Root: root}
 			}))
-			log.Info("AI false-positive triage ENABLED ("+mode+"); suspected FPs held back from the gate, still reported", "model", cfg.FPTriageModel)
+			log.Info("AI false-positive triage ENABLED ("+mode+"); only verified low-risk consensus can affect gates", "model", cfg.FPTriageModel)
 		}
 	}
 	if cfg.SuppressionEnabled {

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1470,7 +1470,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		fmt.Fprintf(os.Stderr, "synapse-cli: %d background/test-scope finding(s) at or above %s reported but exempt from the gate (use --include-test to gate them)\n", bgExempt, failOn)
 	}
 	if fpExempt > 0 {
-		fmt.Fprintf(os.Stderr, "synapse-cli: %d verified low-risk false-positive candidate(s) at or above %s held back from the gate by policy (reported + evidence-sealed; not deleted)\n", fpExempt, failOn)
+		fmt.Fprintf(os.Stderr, "synapse-cli: %d verified low-risk false-positive candidate(s) at or above %s held back from the gate by policy (reported; not deleted)\n", fpExempt, failOn)
 	}
 	if over > 0 {
 		return fmt.Errorf("%d finding(s) at or above %s", over, failOn)

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1319,9 +1319,9 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	sca.SetIgnoreUnfixed(ignoreUnfixed || cfg.IgnoreUnfixed)
 
 	// AI false-positive triage (opt-in). Inject an LLM critic the scan pipeline runs over the remaining
-	// production-scope first-party source findings; a "refuted" verdict marks the finding suspected-FP
-	// (retain-and-mark, held back from the gate below), never a deletion. Propose-only + best-effort. A
-	// distinct SYNAPSE_VERIFIER_MODEL enables two-model consensus. Skipped for image targets (no source).
+	// production-scope first-party source findings. A refutation is advisory unless a distinct verifier
+	// agrees and the deterministic human-review floor allows a gate exemption. High/critical, secrets,
+	// and dangerous CWEs always keep gating. Findings are never deleted. Skipped for image targets.
 	if cfg.FPTriageEnabled && strings.TrimSpace(cfg.FPTriageModel) != "" && !image {
 		if llm, lerr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.FPTriageModel, cfg.LLMTimeout); lerr != nil {
 			fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage disabled: %v\n", lerr)
@@ -1331,7 +1331,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 				if vllm, verr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.VerifierModel, cfg.LLMTimeout); verr == nil {
 					coord.WithVerifier(vllm, cfg.VerifierModel)
 				} else {
-					fmt.Fprintf(os.Stderr, "synapse-cli: verifier model %q unavailable, falling back to single-model triage: %v\n", cfg.VerifierModel, verr)
+					fmt.Fprintf(os.Stderr, "synapse-cli: verifier model %q unavailable; AI triage remains advisory-only: %v\n", cfg.VerifierModel, verr)
 				}
 			}
 			sca.SetFPTriage(fptriage.NewTriager(coord, func(root string) ports.SourceSnippetReader {
@@ -1368,15 +1368,20 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		return fmt.Errorf("scan: %w", err)
 	}
 
-	// The scan pipeline ran the AI false-positive triage (if injected above); report the outcome. A
-	// suspected-FP is held back from the --fail-on gate (retain-and-mark), still reported in ai_triage.
+	// Report advisory opinions separately from the smaller policy-authorized gate-exempt set.
 	fpSuspect := res.SuspectedFPKeys()
+	fpGateExempt := res.AIGateExemptKeys()
+	fpReview := res.AIReviewRequiredKeys()
 	if len(res.AITriage) > 0 {
-		mode := "single-model"
-		if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
-			mode = "verified by " + cfg.VerifierModel
+		mode := "advisory-only"
+		for _, critique := range res.AITriage {
+			if critique.VerifierModel != "" {
+				mode = "verified by " + critique.VerifierModel
+				break
+			}
 		}
-		fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage (%s, %s): critiqued %d finding(s), %d suspected false positive(s) held back from the gate\n", cfg.FPTriageModel, mode, len(res.AITriage), len(fpSuspect))
+		fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage (%s, %s): critiqued %d, suspected %d, gate-exempt %d, human-review %d\n",
+			cfg.FPTriageModel, mode, len(res.AITriage), len(fpSuspect), len(fpGateExempt), len(fpReview))
 	}
 
 	switch {
@@ -1438,7 +1443,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	verify := res.NeedsVerifyKeys()  // precise-mode needs-verify: lower-confidence, exempt from the gate too
 	over := 0
 	bgExempt := 0 // background-scope (test/fixture/example/...) findings held back from the gate
-	fpExempt := 0 // AI-critiqued suspected false positives held back from the gate
+	fpExempt := 0 // verified low-risk AI consensus findings held back from the gate
 	for _, f := range res.Findings {
 		if accepted[f.DedupKey] || verify[f.DedupKey] {
 			continue
@@ -1453,8 +1458,9 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 			bgExempt++
 			continue
 		}
-		// The AI critique refuted this finding (retain-and-mark: reported above, held back from the gate).
-		if fpSuspect[f.DedupKey] {
+		// Only a distinct-model consensus that cleared the deterministic human-review floor may affect
+		// the gate. A single-model or high-risk suspected-FP remains visible AND gating.
+		if fpGateExempt[f.DedupKey] {
 			fpExempt++
 			continue
 		}
@@ -1464,7 +1470,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		fmt.Fprintf(os.Stderr, "synapse-cli: %d background/test-scope finding(s) at or above %s reported but exempt from the gate (use --include-test to gate them)\n", bgExempt, failOn)
 	}
 	if fpExempt > 0 {
-		fmt.Fprintf(os.Stderr, "synapse-cli: %d suspected false positive(s) at or above %s held back from the gate by AI triage (reported with a verdict; not deleted)\n", fpExempt, failOn)
+		fmt.Fprintf(os.Stderr, "synapse-cli: %d verified low-risk false-positive candidate(s) at or above %s held back from the gate by policy (reported + evidence-sealed; not deleted)\n", fpExempt, failOn)
 	}
 	if over > 0 {
 		return fmt.Errorf("%d finding(s) at or above %s", over, failOn)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -78,7 +78,7 @@ stays in the report, it is only held back from the `--fail-on` gate).
 2. **AI critique (opt-in).** Set `SYNAPSE_FP_TRIAGE_ENABLED=true` with an LLM endpoint configured
    (`SYNAPSE_LLM_BASE_URL`, `SYNAPSE_LLM_API_KEY`, and `SYNAPSE_FP_TRIAGE_MODEL` or `SYNAPSE_LLM_MODEL`).
    After the deterministic pass, the model adjudicates the remaining production-scope first-party source
-   findings (SAST/secret/misconfig) and returns a typed verdict — `refuted` (suspected false positive),
+   findings (SAST/misconfig; secret findings are never sent to the LLM) and returns a typed verdict — `refuted` (suspected false positive),
    `sound`, or `uncertain` — with a confidence. The proposer only advises: single-model output can never
    change the gate. Set `SYNAPSE_VERIFIER_MODEL` to a **different** model to enable consensus. A finding is
    gate-exempt only when both models independently refute it at/above the bar and the deterministic
@@ -87,7 +87,9 @@ stays in the report, it is only held back from the `--fail-on` gate).
 
    Every finding remains in JSON/SARIF/compliance. The `ai_triage` JSON separates `suspected_fp`,
    `verified`, `gate_exempt`, and `review_required`, and carries model/prompt/policy metadata. These
-   fields are sealed into the scan evidence hash-chain. Model or verifier failure leaves the gate unchanged.
+   fields are sealed into the scan evidence hash-chain when a ledger is configured. The standalone CLI
+   currently has no evidence vault, so AI triage there is advisory-only and never exempts the gate. Model,
+   verifier, or evidence availability failure leaves the gate unchanged.
 
 ```bash
 export SYNAPSE_LLM_BASE_URL=http://localhost:8081/v1

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -79,15 +79,15 @@ stays in the report, it is only held back from the `--fail-on` gate).
    (`SYNAPSE_LLM_BASE_URL`, `SYNAPSE_LLM_API_KEY`, and `SYNAPSE_FP_TRIAGE_MODEL` or `SYNAPSE_LLM_MODEL`).
    After the deterministic pass, the model adjudicates the remaining production-scope first-party source
    findings (SAST/secret/misconfig) and returns a typed verdict — `refuted` (suspected false positive),
-   `sound`, or `uncertain` — with a confidence. The model only proposes: a `refuted` verdict at or above
-   the confidence bar marks the finding a suspected false positive and holds it back from the gate; it is
-   still reported (see `ai_triage` in `--json`) and sealed, never deleted, and an `uncertain` verdict
-   keeps the finding gating. Best-effort: if the model can't be reached the scan proceeds unchanged.
+   `sound`, or `uncertain` — with a confidence. The proposer only advises: single-model output can never
+   change the gate. Set `SYNAPSE_VERIFIER_MODEL` to a **different** model to enable consensus. A finding is
+   gate-exempt only when both models independently refute it at/above the bar and the deterministic
+   human-review floor permits it. High/critical findings, secrets, and dangerous injection/auth/access-
+   control/SSRF/traversal/upload/deserialization CWEs always stay gating.
 
-   For a stricter, hallucination-resistant gate, set `SYNAPSE_VERIFIER_MODEL` to a **different** model:
-   a refutation then only exempts the gate if that distinct verifier independently agrees (two-model
-   consensus — a single model cannot flip the gate on its own). `ai_triage` entries confirmed this way
-   carry `"verified": true`.
+   Every finding remains in JSON/SARIF/compliance. The `ai_triage` JSON separates `suspected_fp`,
+   `verified`, `gate_exempt`, and `review_required`, and carries model/prompt/policy metadata. These
+   fields are sealed into the scan evidence hash-chain. Model or verifier failure leaves the gate unchanged.
 
 ```bash
 export SYNAPSE_LLM_BASE_URL=http://localhost:8081/v1
@@ -96,12 +96,9 @@ SYNAPSE_FP_TRIAGE_ENABLED=true SYNAPSE_FP_TRIAGE_MODEL=<model> \
   synapse-cli scan . --fail-on high --json
 ```
 
-The AI critique reads the target's own source into the prompt, so treat it as a trusted-local convenience:
-on a scan of an **untrusted PR**, a contributor could add a comment that tries to talk the model into
-refuting their finding. The blast radius is bounded — the finding is still reported and in the SARIF/JSON
-(only the `--fail-on` exit code is affected), the model only proposes (a gate exemption, never a sealed
-suppression or a deletion), and the run prints how many findings were held back — but for gating untrusted
-PRs, upload the SARIF to code-scanning (which shows every finding) and treat the AI verdict as advisory.
+The AI critique reads the target's own source into the prompt, so an **untrusted PR** can still try prompt
+injection through comments or strings. Distinct consensus and the human-review floor bound the risk, and
+the finding always remains in SARIF/JSON, but treat AI triage as advisory for untrusted contributor code.
 
 ## Container image (Docker)
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -80,6 +80,9 @@ Most of these ship ON by default (safe, best-effort). See [Features](features.md
 | --- | --- | --- |
 | `SYNAPSE_SECRET_SCAN_ENABLED` | `true` | Secret scanning over the workspace (regex plus entropy). Matches are redacted; the raw secret never reaches logs, evidence, or the report. |
 | `SYNAPSE_MISCONFIG_ENABLED` | `true` | Misconfiguration and IaC scanning of Dockerfiles and Kubernetes manifests. |
+| `SYNAPSE_FP_TRIAGE_ENABLED` | `false` | Enable advisory LLM false-positive analysis over production-scope SAST/secret/misconfig findings. A proposer alone never changes a gate. |
+| `SYNAPSE_FP_TRIAGE_MODEL` | `SYNAPSE_LLM_MODEL` | Proposer model for false-positive analysis. |
+| `SYNAPSE_VERIFIER_MODEL` | `SYNAPSE_LLM_MODEL` | Must name a different model for AI gate exemptions. Two-model consensus is still subject to high/critical, secret, and dangerous-CWE human-review floors. |
 | `SYNAPSE_DETECTION_PRIORITY` | `comprehensive` | `comprehensive` reports every match. `precise` quarantines single-source, non-KEV findings into a needs-verify queue that is still reported and sealed but exempt from the `--fail-on` gate. |
 | `SYNAPSE_OFFLINE` | `false` | Skip the live advisory source and detect with the offline database only. |
 | `SYNAPSE_IGNORE_UNFIXED` | `false` | Drop vulnerabilities that have no fixed version. |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -80,7 +80,7 @@ Most of these ship ON by default (safe, best-effort). See [Features](features.md
 | --- | --- | --- |
 | `SYNAPSE_SECRET_SCAN_ENABLED` | `true` | Secret scanning over the workspace (regex plus entropy). Matches are redacted; the raw secret never reaches logs, evidence, or the report. |
 | `SYNAPSE_MISCONFIG_ENABLED` | `true` | Misconfiguration and IaC scanning of Dockerfiles and Kubernetes manifests. |
-| `SYNAPSE_FP_TRIAGE_ENABLED` | `false` | Enable advisory LLM false-positive analysis over production-scope SAST/secret/misconfig findings. A proposer alone never changes a gate. |
+| `SYNAPSE_FP_TRIAGE_ENABLED` | `false` | Enable advisory LLM false-positive analysis over production-scope SAST/misconfig findings. Secrets never enter the LLM. A proposer alone or a scan without an evidence ledger never changes a gate. |
 | `SYNAPSE_FP_TRIAGE_MODEL` | `SYNAPSE_LLM_MODEL` | Proposer model for false-positive analysis. |
 | `SYNAPSE_VERIFIER_MODEL` | `SYNAPSE_LLM_MODEL` | Must name a different model for AI gate exemptions. Two-model consensus is still subject to high/critical, secret, and dangerous-CWE human-review floors. |
 | `SYNAPSE_DETECTION_PRIORITY` | `comprehensive` | `comprehensive` reports every match. `precise` quarantines single-source, non-KEV findings into a needs-verify queue that is still reported and sealed but exempt from the `--fail-on` gate. |

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -123,7 +123,9 @@ agent can never confirm its own claim, and no model ever sits in the report path
 False-positive triage keeps the opinion/authorization boundary explicit: a single model can mark a
 finding `suspected_fp` but cannot affect a gate. A distinct verifier must agree, then a deterministic
 policy keeps high/critical, secret, and dangerous-CWE findings in human review. The full typed decision
-and model/prompt/policy metadata are sealed into the scan evidence chain.
+and model/prompt/policy metadata are sealed into the scan evidence chain before an exemption can take
+effect. Without an evidence ledger the decision remains advisory-only. Secret findings are never sent to
+the LLM because even a redacted finding description cannot make its raw source context safe to transmit.
 
 Capabilities include reachability proposals, pattern SAST, a taint engine over the call graph,
 threat modeling over an architecture seam, AI critique and risk narrative, and human-gated

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -120,6 +120,11 @@ with a lifecycle of propose, verify, confirm. Gated capabilities promote only on
 verifier's sealed verdict above the evidence threshold. Ungated ones need a human accept. The
 agent can never confirm its own claim, and no model ever sits in the report path.
 
+False-positive triage keeps the opinion/authorization boundary explicit: a single model can mark a
+finding `suspected_fp` but cannot affect a gate. A distinct verifier must agree, then a deterministic
+policy keeps high/critical, secret, and dangerous-CWE findings in human review. The full typed decision
+and model/prompt/policy metadata are sealed into the scan evidence chain.
+
 Capabilities include reachability proposals, pattern SAST, a taint engine over the call graph,
 threat modeling over an architecture seam, AI critique and risk narrative, and human-gated
 write-up drafts.

--- a/internal/domain/agent/llm.go
+++ b/internal/domain/agent/llm.go
@@ -7,7 +7,10 @@
 // inside the sandboxed child at exec time and never enter a Message.
 package agent
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // Role is a chat message author. Mirrors the OpenAI-compatible roles so the provider
 // adapter is a thin mapping, but it is provider-agnostic domain vocabulary.
@@ -53,4 +56,42 @@ type Usage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+}
+
+// CanonicalModelID normalizes a configured model identity for separation-of-duties checks.
+// Routers commonly accept both "provider/model" and "model", and model identifiers are
+// case-insensitive in the supported OpenAI-compatible APIs. Treating those spellings as distinct
+// would let one model verify its own proposal.
+func CanonicalModelID(id string) string {
+	id = strings.ToLower(strings.TrimSpace(id))
+	if slash := strings.LastIndexByte(id, '/'); slash >= 0 {
+		id = strings.TrimSpace(id[slash+1:])
+	}
+	// OpenAI-style dated aliases (model-YYYY-MM-DD) often point at the same weights as the
+	// corresponding rolling model name. Conservatively collapse that spelling too.
+	if n := len(id); n > 11 && id[n-11] == '-' &&
+		allASCIIDigits(id[n-10:n-6]) && id[n-6] == '-' &&
+		allASCIIDigits(id[n-5:n-3]) && id[n-3] == '-' &&
+		allASCIIDigits(id[n-2:]) {
+		id = id[:n-11]
+	}
+	return id
+}
+
+func allASCIIDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := range len(s) {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// SameModel reports whether two non-empty configured identifiers resolve to the same canonical model.
+func SameModel(a, b string) bool {
+	a, b = CanonicalModelID(a), CanonicalModelID(b)
+	return a != "" && b != "" && a == b
 }

--- a/internal/domain/agent/llm_test.go
+++ b/internal/domain/agent/llm_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import "testing"
+
+func TestSameModelNormalizesCaseAndProviderPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		a, b string
+		same bool
+	}{
+		{"gpt-4o", "GPT-4O", true},
+		{"openai/gpt-4o", "gpt-4o", true},
+		{"router/openai/gpt-4o", "OPENAI/GPT-4O", true},
+		{"gpt-4o", "openai/gpt-4o-2024-08-06", true},
+		{"gpt-4o", "gpt-4.1", false},
+		{"", "", false},
+	} {
+		if got := SameModel(tc.a, tc.b); got != tc.same {
+			t.Errorf("SameModel(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.same)
+		}
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -146,9 +146,10 @@ type Config struct {
 	LLMModel   string
 	LLMTimeout time.Duration
 
-	// FPTriageEnabled turns on the opt-in LLM false-positive gate: after a scan, the configured model
-	// critiques the remaining production-scope first-party source findings and a "refuted" verdict marks
-	// the finding suspected-FP (retain-and-mark, exempt from the gate). Off by default; needs an LLM.
+	// FPTriageEnabled turns on opt-in LLM false-positive analysis. A proposer may mark a finding
+	// suspected-FP, but it remains advisory unless a distinct verifier agrees and the deterministic
+	// human-review floor permits a gate exemption. High/critical, secrets, and dangerous CWEs always gate.
+	// Off by default; needs an LLM.
 	// FPTriageModel is the model to critique with (defaults to LLMModel).
 	FPTriageEnabled bool
 	FPTriageModel   string

--- a/internal/usecase/fptriage/coordinator.go
+++ b/internal/usecase/fptriage/coordinator.go
@@ -1,5 +1,6 @@
-// Package fptriage runs an LLM-assisted false-positive critique over first-party source-analysis
-// findings (SAST, secret, misconfig). It fits the judgment model exactly: the model is a PROPOSER
+// Package fptriage runs an LLM-assisted false-positive critique over safe-to-transmit first-party
+// source-analysis findings (SAST and misconfig). Secret findings are excluded before this layer so raw
+// credential-bearing source context never enters an LLM transcript. The model is a PROPOSER
 // only — it returns a typed judgment.CritiqueClaim (verdict ∈ refuted|sound|uncertain, a closed driver
 // token, a 0..100 confidence), NEVER free prose and NEVER a suppression. The caller applies a "refuted"
 // verdict as retain-and-mark: the finding stays reported and sealed, it is only held back from the CI
@@ -109,7 +110,7 @@ func (c *Coordinator) WithMinConfidence(n int) *Coordinator {
 // is nil or the verifier model equals the proposer model (not a distinct verifier).
 func (c *Coordinator) WithVerifier(llm ports.LLM, model string) *Coordinator {
 	model = strings.TrimSpace(model)
-	if llm != nil && model != "" && model != c.model {
+	if llm != nil && model != "" && !agent.SameModel(model, c.model) {
 		c.verifier = llm
 		c.verifierModel = model
 	}
@@ -126,7 +127,7 @@ func (c *Coordinator) ProposerModel() string { return c.model }
 func (c *Coordinator) MinConfidence() int { return c.minConf }
 
 // Assess critiques every candidate finding concurrently (bounded). The caller passes only the findings
-// worth spending a model call on (typically production-scope first-party SAST/secret/misconfig). Order
+// worth spending a model call on (production-scope first-party SAST/misconfig; never secrets). Order
 // of the returned slice matches candidates. Best-effort: a per-finding failure is captured as
 // Critique.Err, never returned as a batch error.
 func (c *Coordinator) Assess(ctx context.Context, candidates []finding.Finding, src SourceReader) []Critique {

--- a/internal/usecase/fptriage/coordinator.go
+++ b/internal/usecase/fptriage/coordinator.go
@@ -48,10 +48,9 @@ type Critique struct {
 	Err             error
 }
 
-// SuspectedFP reports whether this critique refutes the finding with at least minConfidence — the only
-// condition under which the caller exempts it from the gate. When a distinct verifier was required
-// (VerifyAttempted), BOTH the proposer and the verifier must refute at/above the bar; a verifier that
-// disagreed, was inconclusive, or failed to respond keeps the finding gating (conservative, fail-safe).
+// SuspectedFP reports the AI's advisory false-positive opinion. When a distinct verifier was attempted,
+// BOTH models must refute at/above the bar. In single-model mode it can still return true for visibility,
+// but the scan's deterministic policy never grants a gate exemption unless VerifiedConsensus is true.
 func (c Critique) SuspectedFP(minConfidence int) bool {
 	if c.Err != nil {
 		return false
@@ -64,6 +63,15 @@ func (c Critique) SuspectedFP(minConfidence int) bool {
 		return true // single-model mode: no distinct verifier configured
 	}
 	return c.Verifier != nil && c.Verifier.Verdict == judgment.CritiqueRefuted && c.Verifier.Confidence >= minConfidence
+}
+
+// VerifiedConsensus reports whether two distinct configured model IDs independently refuted the finding
+// at/above the confidence bar. This is necessary, but not sufficient, for a gate exemption: the scan policy
+// also applies severity/kind/CWE floors that force dangerous classes to human review.
+func (c Critique) VerifiedConsensus(minConfidence int) bool {
+	return c.Err == nil && c.VerifyAttempted && c.Verifier != nil &&
+		c.Claim.Verdict == judgment.CritiqueRefuted && c.Claim.Confidence >= minConfidence &&
+		c.Verifier.Verdict == judgment.CritiqueRefuted && c.Verifier.Confidence >= minConfidence
 }
 
 // Coordinator critiques findings through an LLM proposer, and (when configured) a DISTINCT verifier.
@@ -96,10 +104,9 @@ func (c *Coordinator) WithMinConfidence(n int) *Coordinator {
 	return c
 }
 
-// WithVerifier attaches a DISTINCT verifier model: after the proposer refutes a finding at/above the
-// bar, the verifier independently re-assesses and the refutation only stands (exempts the gate) if the
-// verifier agrees — mirroring the judgment gate's distinct-verifier rule in the stateless CLI. A no-op
-// if llm is nil or the verifier model equals the proposer model (not a distinct verifier).
+// WithVerifier attaches a DISTINCT verifier model. Agreement creates VerifiedConsensus, which the
+// scan policy may authorize only after applying severity/kind/CWE human-review floors. A no-op if llm
+// is nil or the verifier model equals the proposer model (not a distinct verifier).
 func (c *Coordinator) WithVerifier(llm ports.LLM, model string) *Coordinator {
 	model = strings.TrimSpace(model)
 	if llm != nil && model != "" && model != c.model {
@@ -111,6 +118,9 @@ func (c *Coordinator) WithVerifier(llm ports.LLM, model string) *Coordinator {
 
 // VerifierModel returns the distinct verifier model in effect, or "" when single-model.
 func (c *Coordinator) VerifierModel() string { return c.verifierModel }
+
+// ProposerModel returns the configured proposer model ID for audit metadata.
+func (c *Coordinator) ProposerModel() string { return c.model }
 
 // MinConfidence is the confidence bar in effect.
 func (c *Coordinator) MinConfidence() int { return c.minConf }

--- a/internal/usecase/fptriage/coordinator_test.go
+++ b/internal/usecase/fptriage/coordinator_test.go
@@ -73,6 +73,9 @@ func TestAssessAppliesVerdicts(t *testing.T) {
 	if !got[3].SuspectedFP(75) {
 		t.Errorf("constant-input refutation must be a suspected FP: %+v", got[3])
 	}
+	if got[1].VerifiedConsensus(75) || got[3].VerifiedConsensus(75) {
+		t.Error("single-model suspected FPs must remain advisory, never verified consensus")
+	}
 }
 
 // roleLLM answers differently for the proposer vs the verifier pass (the verifier user prompt carries
@@ -107,7 +110,7 @@ func TestVerifierConsensus(t *testing.T) {
 		return c.Assess(context.Background(), cand, nil)[0]
 	}
 	// Both agree → suspected FP, verified.
-	if got := run(roleLLM{proposer: refuted, verifier: `{"verdict":"refuted","driver":"not_reachable","confidence":85}`}); !got.SuspectedFP(75) || !got.VerifyAttempted || got.Verifier == nil {
+	if got := run(roleLLM{proposer: refuted, verifier: `{"verdict":"refuted","driver":"not_reachable","confidence":85}`}); !got.SuspectedFP(75) || !got.VerifiedConsensus(75) || !got.VerifyAttempted || got.Verifier == nil {
 		t.Errorf("consensus refuted must be suspected-FP + verified: %+v", got)
 	}
 	// Verifier disagrees (sound) → NOT suspected FP (finding gates).

--- a/internal/usecase/fptriage/coordinator_test.go
+++ b/internal/usecase/fptriage/coordinator_test.go
@@ -131,6 +131,16 @@ func TestVerifierConsensus(t *testing.T) {
 	}
 }
 
+func TestVerifierMustBeCanonicallyDistinct(t *testing.T) {
+	llm := roleLLM{}
+	for _, verifier := range []string{"PROPOSER-MODEL", "openai/proposer-model", "router/openai/PROPOSER-MODEL"} {
+		c := New(llm, "proposer-model").WithVerifier(llm, verifier)
+		if c.VerifierModel() != "" {
+			t.Errorf("verifier %q self-confirmed proposer through an alias", verifier)
+		}
+	}
+}
+
 // recordingLLM answers like roleLLM but keeps every request, so a test can assert what the coordinator
 // actually asked the provider for.
 type recordingLLM struct {

--- a/internal/usecase/fptriage/livedemo_ai_test.go
+++ b/internal/usecase/fptriage/livedemo_ai_test.go
@@ -3,9 +3,9 @@ package fptriage_test
 // Live-AI demonstration for #165 (AI false-positive triage in the scan pipeline, with the #156 distinct-
 // verifier consensus). It drives the REAL Coordinator against a live OpenAI-compatible gateway (9router):
 // a clearly PARAMETERIZED query (not injectable) is critiqued as a false positive by the proposer AND
-// confirmed by a DISTINCT verifier → suspected-FP (retain-and-mark, exempt from the gate); a clearly
-// INJECTABLE string-concatenation stays gating (not refuted). This proves the pipeline's FP gate + the
-// two-model consensus are effective end-to-end, and — critically — that a real weakness is NOT dismissed.
+// confirmed by a DISTINCT verifier → verified suspected-FP (eligible for the separate deterministic
+// gate policy); a clearly INJECTABLE string-concatenation stays gating. This proves the model-consensus
+// seam and — critically — that a real weakness is NOT dismissed.
 //
 // Gated behind SYNAPSE_LIVE_AI=1 so the normal suite stays hermetic. Run:
 //   SYNAPSE_LIVE_AI=1 SYNAPSE_LLM_BASE_URL=http://localhost:20128/v1 \

--- a/internal/usecase/fptriage/prompt.go
+++ b/internal/usecase/fptriage/prompt.go
@@ -10,6 +10,10 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 )
 
+// promptVersion is persisted with every critique so an audit can identify the exact prompt contract
+// that produced a decision without retaining raw source or model chain-of-thought.
+const promptVersion = "fp-triage-v1"
+
 // systemPrompt frames the model as a propose-only false-positive adjudicator. It must answer ONLY with
 // the schema-constrained JSON — the driver is a closed token, so no prose can reach a deliverable.
 const systemPrompt = `You are a security false-positive adjudicator for a static analysis tool.

--- a/internal/usecase/fptriage/triager.go
+++ b/internal/usecase/fptriage/triager.go
@@ -46,16 +46,24 @@ func (t *Triager) Triage(ctx context.Context, candidates []finding.Finding, work
 		if c.Err != nil {
 			continue
 		}
-		fp := c.SuspectedFP(t.minConf)
-		out = append(out, ports.AICritique{
-			FindingID:   c.FindingID,
-			DedupKey:    c.DedupKey,
-			Verdict:     string(c.Claim.Verdict),
-			Driver:      c.Claim.Driver,
-			Confidence:  c.Claim.Confidence,
-			SuspectedFP: fp,
-			Verified:    fp && c.VerifyAttempted, // a suspected-FP a DISTINCT verifier confirmed
-		})
+		critique := ports.AICritique{
+			FindingID:     c.FindingID,
+			DedupKey:      c.DedupKey,
+			Verdict:       string(c.Claim.Verdict),
+			Driver:        c.Claim.Driver,
+			Confidence:    c.Claim.Confidence,
+			SuspectedFP:   c.SuspectedFP(t.minConf),
+			Verified:      c.VerifiedConsensus(t.minConf),
+			ProposerModel: t.coord.ProposerModel(),
+			VerifierModel: t.coord.VerifierModel(),
+			PromptVersion: promptVersion,
+		}
+		if c.Verifier != nil {
+			critique.VerifierVerdict = string(c.Verifier.Verdict)
+			critique.VerifierDriver = c.Verifier.Driver
+			critique.VerifierConfidence = c.Verifier.Confidence
+		}
+		out = append(out, critique)
 	}
 	return out
 }

--- a/internal/usecase/fptriage/triager_test.go
+++ b/internal/usecase/fptriage/triager_test.go
@@ -37,6 +37,9 @@ func TestTriagerMapsToPortsDTO(t *testing.T) {
 	if byKey["dk-1"].Verified {
 		t.Error("single-model refutation must not be marked verified")
 	}
+	if c := byKey["dk-1"]; c.GateExempt || c.ProposerModel != "m" || c.VerifierModel != "" || c.PromptVersion != promptVersion {
+		t.Errorf("single-model DTO must be advisory with audit metadata, got %+v", c)
+	}
 }
 
 func TestTriagerNilSafe(t *testing.T) {

--- a/internal/usecase/ports/fptriage.go
+++ b/internal/usecase/ports/fptriage.go
@@ -15,26 +15,37 @@ type SourceSnippetReader interface {
 }
 
 // AICritique is one finding's LLM false-positive verdict (propose-only, advisory). Verdict and Driver use
-// the closed judgment.CritiqueClaim vocabulary (no free prose). SuspectedFP is set when a "refuted"
-// verdict clears the confidence bar — and, when a distinct verifier is configured, it independently
-// confirmed. It is retain-and-mark: a suspected-FP finding stays reported and sealed and is only held
-// back from the CI gate, never deleted.
+// the closed judgment.CritiqueClaim vocabulary (no free prose). SuspectedFP records the model's opinion;
+// it NEVER grants a gate exemption by itself. GateExempt is a separate, server-owned policy decision that
+// requires distinct-model consensus and must also clear the human-review floor. The complete decision and
+// model metadata are retained in the scan result and its tamper-evident evidence link.
 type AICritique struct {
-	FindingID   string `json:"finding_id"`
-	DedupKey    string `json:"dedup_key"`
-	Verdict     string `json:"verdict"`
-	Driver      string `json:"driver"`
-	Confidence  int    `json:"confidence"`
-	SuspectedFP bool   `json:"suspected_fp"`
+	FindingID      string `json:"finding_id"`
+	DedupKey       string `json:"dedup_key"`
+	Verdict        string `json:"verdict"`
+	Driver         string `json:"driver"`
+	Confidence     int    `json:"confidence"`
+	SuspectedFP    bool   `json:"suspected_fp"`
+	ProposerModel  string `json:"proposer_model"`
+	VerifierModel  string `json:"verifier_model,omitempty"`
+	PromptVersion  string `json:"prompt_version"`
+	PolicyVersion  string `json:"policy_version,omitempty"`
+	PolicyReason   string `json:"policy_reason,omitempty"`
+	GateExempt     bool   `json:"gate_exempt"`
+	ReviewRequired bool   `json:"review_required"`
 	// Verified is true when a DISTINCT verifier model independently confirmed the refutation (two-model
-	// consensus). Omitted when no verifier was configured (single-model triage).
-	Verified bool `json:"verified,omitempty"`
+	// consensus). Single-model triage can set SuspectedFP but can never set Verified or GateExempt.
+	Verified           bool   `json:"verified"`
+	VerifierVerdict    string `json:"verifier_verdict,omitempty"`
+	VerifierDriver     string `json:"verifier_driver,omitempty"`
+	VerifierConfidence int    `json:"verifier_confidence,omitempty"`
 }
 
 // FPTriager runs an LLM false-positive critique over candidate findings from a workspace and returns a
 // per-candidate advisory verdict. It is best-effort and PROPOSE-ONLY: it never mutates or deletes a
-// finding; the caller applies a suspected-FP as retain-and-mark (held back from the --fail-on gate,
-// still reported and evidence-sealed). Injected optionally into the scan pipeline; nil = no triage.
+// finding. The caller applies the deterministic gate policy; only a verified critique that clears the
+// human-review floor can be retain-and-mark gate-exempt. Injected optionally into the scan pipeline;
+// nil = no triage.
 type FPTriager interface {
 	Triage(ctx context.Context, candidates []finding.Finding, workspaceDir string) []AICritique
 }

--- a/internal/usecase/sca/fptriage_policy.go
+++ b/internal/usecase/sca/fptriage_policy.go
@@ -3,6 +3,7 @@ package sca
 import (
 	"strings"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -12,15 +13,17 @@ import (
 
 // aiTriagePolicyVersion is sealed with every scan that carries AI triage. Bump it whenever the
 // authorization contract changes so an audit can replay which policy could affect a CI gate.
-const aiTriagePolicyVersion = "fp-gate-v1"
+const aiTriagePolicyVersion = "fp-gate-v2"
 
 const (
 	aiPolicyNotSuspected      = "not_suspected_false_positive"
 	aiPolicyVerifierRequired  = "distinct_verifier_required"
 	aiPolicyFindingMissing    = "finding_not_found"
+	aiPolicyFindingIneligible = "finding_not_eligible"
 	aiPolicySeverityFloor     = "severity_requires_human"
 	aiPolicySecretFloor       = "secret_requires_human"
 	aiPolicyDangerousCWEFloor = "cwe_requires_human"
+	aiPolicyEvidenceRequired  = "evidence_ledger_required"
 	aiPolicyVerifiedConsensus = "verified_consensus"
 )
 
@@ -35,12 +38,16 @@ var humanReviewCWEs = map[string]struct{}{
 	"CWE-79":  {}, // XSS / output injection
 	"CWE-89":  {}, // SQL injection
 	"CWE-94":  {}, // code injection
+	"CWE-259": {}, // hard-coded password
+	"CWE-321": {}, // hard-coded cryptographic key
 	"CWE-284": {}, // access control
 	"CWE-285": {},
 	"CWE-287": {}, // authentication
 	"CWE-306": {},
 	"CWE-434": {}, // unrestricted upload
 	"CWE-502": {}, // unsafe deserialization
+	"CWE-522": {}, // insufficiently protected credentials
+	"CWE-798": {}, // hard-coded credentials
 	"CWE-862": {},
 	"CWE-863": {},
 	"CWE-918": {}, // SSRF
@@ -49,7 +56,7 @@ var humanReviewCWEs = map[string]struct{}{
 // applyAIGatePolicy separates an AI opinion from authorization to change a gate. It is the single
 // policy point used by both CLI and API scans. The triager may propose SuspectedFP, but only a complete
 // distinct-model consensus that clears the human-review floor receives GateExempt.
-func applyAIGatePolicy(result *ScanResult) {
+func applyAIGatePolicy(result *ScanResult, evidenceAvailable bool) {
 	if result == nil || len(result.AITriage) == 0 {
 		return
 	}
@@ -85,6 +92,16 @@ func applyAIGatePolicy(result *ScanResult) {
 			critique.ReviewRequired = true
 			continue
 		}
+		if !isFPTriageEligible(item) {
+			critique.PolicyReason = aiPolicyFindingIneligible
+			critique.ReviewRequired = true
+			continue
+		}
+		if !evidenceAvailable {
+			critique.PolicyReason = aiPolicyEvidenceRequired
+			critique.ReviewRequired = true
+			continue
+		}
 		critique.PolicyReason = aiPolicyVerifiedConsensus
 		critique.GateExempt = true
 	}
@@ -93,8 +110,8 @@ func applyAIGatePolicy(result *ScanResult) {
 // hasVerifiedConsensus validates the full DTO rather than trusting its Verified boolean. This keeps a
 // buggy or alternate FPTriager implementation from granting itself gate authority by setting one field.
 func hasVerifiedConsensus(c ports.AICritique) bool {
-	proposer := strings.TrimSpace(c.ProposerModel)
-	verifierModel := strings.TrimSpace(c.VerifierModel)
+	proposer := agent.CanonicalModelID(c.ProposerModel)
+	verifierModel := agent.CanonicalModelID(c.VerifierModel)
 	return c.Verified &&
 		proposer != "" && verifierModel != "" && proposer != verifierModel &&
 		c.Verdict == string(judgment.CritiqueRefuted) && c.Confidence >= verdict.EvidenceThreshold &&
@@ -109,12 +126,32 @@ func humanReviewFloor(item finding.Finding) string {
 	if item.Kind == finding.KindSecret {
 		return aiPolicySecretFloor
 	}
-	for _, token := range strings.FieldsFunc(strings.ToUpper(item.CWE), func(r rune) bool {
-		return r == ',' || r == ';' || r == '|' || r == '/' || r == ' ' || r == '\t' || r == '\n'
-	}) {
+	tokens := cweTokens(item.CWE)
+	for _, token := range tokens {
 		if _, protected := humanReviewCWEs[token]; protected {
 			return aiPolicyDangerousCWEFloor
 		}
 	}
+	// Unknown weakness identity is not evidence that a source/config finding is low risk. Until a
+	// producer supplies a CWE, keep it in human review rather than defaulting to exemptible.
+	if len(tokens) == 0 && (item.Kind == finding.KindSAST || item.Kind == finding.KindMisconfig) {
+		return aiPolicyDangerousCWEFloor
+	}
 	return ""
+}
+
+func cweTokens(value string) []string {
+	return strings.FieldsFunc(strings.ToUpper(value), func(r rune) bool {
+		return r == ',' || r == ';' || r == '|' || r == '/' || r == ' ' || r == '\t' || r == '\n'
+	})
+}
+
+func hasCredentialCWE(value string) bool {
+	for _, token := range cweTokens(value) {
+		switch token {
+		case "CWE-259", "CWE-321", "CWE-522", "CWE-798":
+			return true
+		}
+	}
+	return false
 }

--- a/internal/usecase/sca/fptriage_policy.go
+++ b/internal/usecase/sca/fptriage_policy.go
@@ -1,0 +1,120 @@
+package sca
+
+import (
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/verdict"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// aiTriagePolicyVersion is sealed with every scan that carries AI triage. Bump it whenever the
+// authorization contract changes so an audit can replay which policy could affect a CI gate.
+const aiTriagePolicyVersion = "fp-gate-v1"
+
+const (
+	aiPolicyNotSuspected      = "not_suspected_false_positive"
+	aiPolicyVerifierRequired  = "distinct_verifier_required"
+	aiPolicyFindingMissing    = "finding_not_found"
+	aiPolicySeverityFloor     = "severity_requires_human"
+	aiPolicySecretFloor       = "secret_requires_human"
+	aiPolicyDangerousCWEFloor = "cwe_requires_human"
+	aiPolicyVerifiedConsensus = "verified_consensus"
+)
+
+// humanReviewCWEs are weakness classes where a false negative can directly expose an execution,
+// injection, authentication/authorization, request-forgery, traversal, upload, or deserialization
+// boundary. Even two agreeing models can only advise on these classes; they never exempt the gate.
+var humanReviewCWEs = map[string]struct{}{
+	"CWE-22":  {}, // path traversal
+	"CWE-23":  {},
+	"CWE-36":  {},
+	"CWE-78":  {}, // OS command injection
+	"CWE-79":  {}, // XSS / output injection
+	"CWE-89":  {}, // SQL injection
+	"CWE-94":  {}, // code injection
+	"CWE-284": {}, // access control
+	"CWE-285": {},
+	"CWE-287": {}, // authentication
+	"CWE-306": {},
+	"CWE-434": {}, // unrestricted upload
+	"CWE-502": {}, // unsafe deserialization
+	"CWE-862": {},
+	"CWE-863": {},
+	"CWE-918": {}, // SSRF
+}
+
+// applyAIGatePolicy separates an AI opinion from authorization to change a gate. It is the single
+// policy point used by both CLI and API scans. The triager may propose SuspectedFP, but only a complete
+// distinct-model consensus that clears the human-review floor receives GateExempt.
+func applyAIGatePolicy(result *ScanResult) {
+	if result == nil || len(result.AITriage) == 0 {
+		return
+	}
+	findings := make(map[string]finding.Finding, len(result.Findings))
+	for _, item := range result.Findings {
+		if key := strings.TrimSpace(item.DedupKey); key != "" {
+			findings[key] = item
+		}
+	}
+	for i := range result.AITriage {
+		critique := &result.AITriage[i]
+		critique.PolicyVersion = aiTriagePolicyVersion
+		critique.GateExempt = false
+		critique.ReviewRequired = false
+
+		if !critique.SuspectedFP {
+			critique.PolicyReason = aiPolicyNotSuspected
+			continue
+		}
+		if !hasVerifiedConsensus(*critique) {
+			critique.PolicyReason = aiPolicyVerifierRequired
+			critique.ReviewRequired = true
+			continue
+		}
+		item, ok := findings[strings.TrimSpace(critique.DedupKey)]
+		if !ok {
+			critique.PolicyReason = aiPolicyFindingMissing
+			critique.ReviewRequired = true
+			continue
+		}
+		if reason := humanReviewFloor(item); reason != "" {
+			critique.PolicyReason = reason
+			critique.ReviewRequired = true
+			continue
+		}
+		critique.PolicyReason = aiPolicyVerifiedConsensus
+		critique.GateExempt = true
+	}
+}
+
+// hasVerifiedConsensus validates the full DTO rather than trusting its Verified boolean. This keeps a
+// buggy or alternate FPTriager implementation from granting itself gate authority by setting one field.
+func hasVerifiedConsensus(c ports.AICritique) bool {
+	proposer := strings.TrimSpace(c.ProposerModel)
+	verifierModel := strings.TrimSpace(c.VerifierModel)
+	return c.Verified &&
+		proposer != "" && verifierModel != "" && proposer != verifierModel &&
+		c.Verdict == string(judgment.CritiqueRefuted) && c.Confidence >= verdict.EvidenceThreshold &&
+		c.VerifierVerdict == string(judgment.CritiqueRefuted) &&
+		c.VerifierConfidence >= verdict.EvidenceThreshold
+}
+
+func humanReviewFloor(item finding.Finding) string {
+	if item.Severity == shared.SeverityCritical || item.Severity == shared.SeverityHigh {
+		return aiPolicySeverityFloor
+	}
+	if item.Kind == finding.KindSecret {
+		return aiPolicySecretFloor
+	}
+	for _, token := range strings.FieldsFunc(strings.ToUpper(item.CWE), func(r rune) bool {
+		return r == ',' || r == ';' || r == '|' || r == '/' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		if _, protected := humanReviewCWEs[token]; protected {
+			return aiPolicyDangerousCWEFloor
+		}
+	}
+	return ""
+}

--- a/internal/usecase/sca/fptriage_test.go
+++ b/internal/usecase/sca/fptriage_test.go
@@ -1,10 +1,13 @@
 package sca
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -29,13 +32,155 @@ func TestFPTriageCandidates(t *testing.T) {
 }
 
 func TestSuspectedFPKeys(t *testing.T) {
+	consensus := verifiedCritique("c")
+	consensus.GateExempt = true
+	consensus.PolicyVersion = aiTriagePolicyVersion
+	consensus.PolicyReason = aiPolicyVerifiedConsensus
 	res := &ScanResult{AITriage: []ports.AICritique{
-		{DedupKey: "a", SuspectedFP: true},
+		{DedupKey: "a", SuspectedFP: true, GateExempt: false},
 		{DedupKey: "b", SuspectedFP: false},
-		{DedupKey: "c", SuspectedFP: true},
-	}}
+		consensus,
+	}, Findings: []finding.Finding{{DedupKey: "c", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"}}}
 	keys := res.SuspectedFPKeys()
 	if len(keys) != 2 || !keys["a"] || !keys["c"] || keys["b"] {
 		t.Errorf("SuspectedFPKeys = %v, want {a,c}", keys)
+	}
+	exempt := res.AIGateExemptKeys()
+	if len(exempt) != 1 || !exempt["c"] || exempt["a"] {
+		t.Errorf("AIGateExemptKeys = %v, want only {c}", exempt)
+	}
+}
+
+func verifiedCritique(key string) ports.AICritique {
+	return ports.AICritique{
+		DedupKey:           key,
+		Verdict:            "refuted",
+		Confidence:         95,
+		SuspectedFP:        true,
+		ProposerModel:      "proposer-a",
+		VerifierModel:      "verifier-b",
+		Verified:           true,
+		VerifierVerdict:    "refuted",
+		VerifierConfidence: 93,
+		PromptVersion:      "fp-triage-v1",
+	}
+}
+
+func TestApplyAIGatePolicy(t *testing.T) {
+	single := verifiedCritique("single")
+	single.Verified = false
+	single.VerifierModel = ""
+	single.VerifierVerdict = ""
+	single.VerifierConfidence = 0
+
+	result := &ScanResult{
+		Findings: []finding.Finding{
+			{DedupKey: "safe-medium", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "single", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "high", Kind: finding.KindSAST, Severity: shared.SeverityHigh, CWE: "CWE-327"},
+			{DedupKey: "secret", Kind: finding.KindSecret, Severity: shared.SeverityMedium, CWE: "CWE-798"},
+			{DedupKey: "sqli", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-89"},
+		},
+		AITriage: []ports.AICritique{
+			verifiedCritique("safe-medium"),
+			single,
+			verifiedCritique("high"),
+			verifiedCritique("secret"),
+			verifiedCritique("sqli"),
+			{DedupKey: "sound", Verdict: "sound", Confidence: 99, ProposerModel: "proposer-a"},
+			verifiedCritique("missing"),
+		},
+	}
+
+	applyAIGatePolicy(result)
+	byKey := map[string]ports.AICritique{}
+	for _, c := range result.AITriage {
+		byKey[c.DedupKey] = c
+		if c.PolicyVersion != aiTriagePolicyVersion {
+			t.Errorf("%s policy version = %q", c.DedupKey, c.PolicyVersion)
+		}
+	}
+	if c := byKey["safe-medium"]; !c.GateExempt || c.ReviewRequired || c.PolicyReason != aiPolicyVerifiedConsensus {
+		t.Errorf("verified low-risk consensus should be gate-exempt: %+v", c)
+	}
+	for key, reason := range map[string]string{
+		"single":  aiPolicyVerifierRequired,
+		"high":    aiPolicySeverityFloor,
+		"secret":  aiPolicySecretFloor,
+		"sqli":    aiPolicyDangerousCWEFloor,
+		"missing": aiPolicyFindingMissing,
+	} {
+		c := byKey[key]
+		if c.GateExempt || !c.ReviewRequired || c.PolicyReason != reason {
+			t.Errorf("%s must remain gating for %s: %+v", key, reason, c)
+		}
+	}
+	if c := byKey["sound"]; c.GateExempt || c.ReviewRequired || c.PolicyReason != aiPolicyNotSuspected {
+		t.Errorf("non-refuted critique should be informational only: %+v", c)
+	}
+}
+
+func TestApplyAIGatePolicyRejectsForgedVerifiedFlag(t *testing.T) {
+	cases := []ports.AICritique{
+		verifiedCritique("same-model"),
+		verifiedCritique("low-verifier"),
+		verifiedCritique("wrong-verdict"),
+	}
+	cases[0].VerifierModel = cases[0].ProposerModel
+	cases[1].VerifierConfidence = 74
+	cases[2].VerifierVerdict = "sound"
+	result := &ScanResult{
+		Findings: []finding.Finding{
+			{DedupKey: "same-model", Kind: finding.KindSAST, Severity: shared.SeverityMedium},
+			{DedupKey: "low-verifier", Kind: finding.KindSAST, Severity: shared.SeverityMedium},
+			{DedupKey: "wrong-verdict", Kind: finding.KindSAST, Severity: shared.SeverityMedium},
+		},
+		AITriage: cases,
+	}
+	applyAIGatePolicy(result)
+	if got := result.AIGateExemptKeys(); len(got) != 0 {
+		t.Fatalf("forged/incomplete consensus must never receive gate authority: %v", got)
+	}
+}
+
+func TestAIGateExemptKeysRevalidatesPersistedDecision(t *testing.T) {
+	forged := verifiedCritique("high")
+	forged.GateExempt = true
+	forged.PolicyVersion = aiTriagePolicyVersion
+	forged.PolicyReason = aiPolicyVerifiedConsensus
+	result := &ScanResult{
+		Findings: []finding.Finding{{DedupKey: "high", Kind: finding.KindSAST, Severity: shared.SeverityHigh}},
+		AITriage: []ports.AICritique{forged},
+	}
+	if got := result.AIGateExemptKeys(); len(got) != 0 {
+		t.Fatalf("persisted gate flag must be revalidated against the high-risk floor: %v", got)
+	}
+}
+
+func TestScanEvidenceContentSealsAIDecisions(t *testing.T) {
+	result := &ScanResult{
+		Findings: []finding.Finding{{DedupKey: "z"}, {DedupKey: "a"}},
+		Manifest: ports.ScanManifest{SBOMSHA256: "sha256:abc"},
+		AITriage: []ports.AICritique{
+			{DedupKey: "z", FindingID: "fz", ProposerModel: "p", PolicyVersion: aiTriagePolicyVersion, PolicyReason: aiPolicyVerifierRequired, ReviewRequired: true},
+			{DedupKey: "a", FindingID: "fa", ProposerModel: "p", VerifierModel: "v", PolicyVersion: aiTriagePolicyVersion, PolicyReason: aiPolicyVerifiedConsensus, Verified: true, GateExempt: true},
+		},
+	}
+	content, err := scanEvidenceContent("tester", time.Date(2026, 8, 3, 1, 2, 3, 0, time.UTC), result)
+	if err != nil {
+		t.Fatalf("scanEvidenceContent: %v", err)
+	}
+	var payload scanEvidencePayload
+	if err := json.Unmarshal(content, &payload); err != nil {
+		t.Fatalf("decode evidence payload: %v", err)
+	}
+	if payload.AITriagePolicy != aiTriagePolicyVersion || len(payload.AITriage) != 2 {
+		t.Fatalf("AI policy/decisions missing from sealed payload: %+v", payload)
+	}
+	if payload.Findings[0] != "a" || payload.AITriage[0].DedupKey != "a" {
+		t.Errorf("evidence payload must sort findings and AI decisions canonically: %+v", payload)
+	}
+	if !payload.AITriage[0].GateExempt || !payload.AITriage[0].Verified || !payload.AITriage[1].ReviewRequired {
+		t.Errorf("gate/verifier/review metadata not sealed: %+v", payload.AITriage)
 	}
 }

--- a/internal/usecase/sca/fptriage_test.go
+++ b/internal/usecase/sca/fptriage_test.go
@@ -13,19 +13,23 @@ import (
 
 func TestFPTriageCandidates(t *testing.T) {
 	fs := []finding.Finding{
-		{DedupKey: "sast-prod", Kind: finding.KindSAST, Scope: sbom.ScopeProduction},
-		{DedupKey: "secret-prod", Kind: finding.KindSecret, Scope: sbom.ScopeProduction},
-		{DedupKey: "misconfig-prod", Kind: finding.KindMisconfig, Scope: sbom.ScopeProduction},
-		{DedupKey: "sast-test", Kind: finding.KindSAST, Scope: sbom.ScopeTest},       // background → skip
-		{DedupKey: "sca-prod", Kind: finding.KindSCA, Scope: sbom.ScopeProduction},   // SCA → skip (DB-backed fact)
-		{DedupKey: "sast-fixture", Kind: finding.KindSAST, Scope: sbom.ScopeFixture}, // background → skip
+		{DedupKey: "sast-prod", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction},
+		{DedupKey: "secret-prod", Kind: finding.KindSecret, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction}, // raw secret context must never enter an LLM
+		{DedupKey: "misconfig-prod", Kind: finding.KindMisconfig, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction},
+		{DedupKey: "credential-sast", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, CWE: "CWE-798"},
+		{DedupKey: "sast-test", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeTest},       // background → skip
+		{DedupKey: "sca-prod", Kind: finding.KindSCA, Class: finding.ClassThirdParty, Scope: sbom.ScopeProduction},   // SCA → skip (DB-backed fact)
+		{DedupKey: "sast-fixture", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeFixture}, // background → skip
+		{DedupKey: "sast-development", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeDevelopment},
+		{DedupKey: "sast-unknown", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeUnknown},
+		{DedupKey: "wrong-class", Kind: finding.KindSAST, Class: finding.ClassThirdParty, Scope: sbom.ScopeProduction},
 	}
 	got := fpTriageCandidates(fs)
-	if len(got) != 3 {
-		t.Fatalf("want 3 production source candidates, got %d: %+v", len(got), got)
+	if len(got) != 2 {
+		t.Fatalf("want 2 safe-to-transmit production source candidates, got %d: %+v", len(got), got)
 	}
 	for _, c := range got {
-		if sbom.IsBackgroundScope(c.Scope) || c.Kind == finding.KindSCA {
+		if sbom.IsBackgroundScope(c.Scope) || c.Kind == finding.KindSCA || c.Kind == finding.KindSecret || c.Class != finding.ClassFirstParty {
 			t.Errorf("unexpected candidate: %+v", c)
 		}
 	}
@@ -40,7 +44,7 @@ func TestSuspectedFPKeys(t *testing.T) {
 		{DedupKey: "a", SuspectedFP: true, GateExempt: false},
 		{DedupKey: "b", SuspectedFP: false},
 		consensus,
-	}, Findings: []finding.Finding{{DedupKey: "c", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"}}}
+	}, Findings: []finding.Finding{{DedupKey: "c", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"}}}
 	keys := res.SuspectedFPKeys()
 	if len(keys) != 2 || !keys["a"] || !keys["c"] || keys["b"] {
 		t.Errorf("SuspectedFPKeys = %v, want {a,c}", keys)
@@ -75,11 +79,13 @@ func TestApplyAIGatePolicy(t *testing.T) {
 
 	result := &ScanResult{
 		Findings: []finding.Finding{
-			{DedupKey: "safe-medium", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"},
-			{DedupKey: "single", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"},
-			{DedupKey: "high", Kind: finding.KindSAST, Severity: shared.SeverityHigh, CWE: "CWE-327"},
-			{DedupKey: "secret", Kind: finding.KindSecret, Severity: shared.SeverityMedium, CWE: "CWE-798"},
-			{DedupKey: "sqli", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-89"},
+			{DedupKey: "safe-medium", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "single", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "high", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityHigh, CWE: "CWE-327"},
+			{DedupKey: "secret", Kind: finding.KindSecret, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-798"},
+			{DedupKey: "sqli", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-89"},
+			{DedupKey: "credential", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-798"},
+			{DedupKey: "unknown-cwe", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium},
 		},
 		AITriage: []ports.AICritique{
 			verifiedCritique("safe-medium"),
@@ -87,12 +93,14 @@ func TestApplyAIGatePolicy(t *testing.T) {
 			verifiedCritique("high"),
 			verifiedCritique("secret"),
 			verifiedCritique("sqli"),
+			verifiedCritique("credential"),
+			verifiedCritique("unknown-cwe"),
 			{DedupKey: "sound", Verdict: "sound", Confidence: 99, ProposerModel: "proposer-a"},
 			verifiedCritique("missing"),
 		},
 	}
 
-	applyAIGatePolicy(result)
+	applyAIGatePolicy(result, true)
 	byKey := map[string]ports.AICritique{}
 	for _, c := range result.AITriage {
 		byKey[c.DedupKey] = c
@@ -104,11 +112,13 @@ func TestApplyAIGatePolicy(t *testing.T) {
 		t.Errorf("verified low-risk consensus should be gate-exempt: %+v", c)
 	}
 	for key, reason := range map[string]string{
-		"single":  aiPolicyVerifierRequired,
-		"high":    aiPolicySeverityFloor,
-		"secret":  aiPolicySecretFloor,
-		"sqli":    aiPolicyDangerousCWEFloor,
-		"missing": aiPolicyFindingMissing,
+		"single":      aiPolicyVerifierRequired,
+		"high":        aiPolicySeverityFloor,
+		"secret":      aiPolicySecretFloor,
+		"sqli":        aiPolicyDangerousCWEFloor,
+		"credential":  aiPolicyDangerousCWEFloor,
+		"unknown-cwe": aiPolicyDangerousCWEFloor,
+		"missing":     aiPolicyFindingMissing,
 	} {
 		c := byKey[key]
 		if c.GateExempt || !c.ReviewRequired || c.PolicyReason != reason {
@@ -123,23 +133,67 @@ func TestApplyAIGatePolicy(t *testing.T) {
 func TestApplyAIGatePolicyRejectsForgedVerifiedFlag(t *testing.T) {
 	cases := []ports.AICritique{
 		verifiedCritique("same-model"),
+		verifiedCritique("case-alias"),
+		verifiedCritique("provider-alias"),
 		verifiedCritique("low-verifier"),
 		verifiedCritique("wrong-verdict"),
 	}
 	cases[0].VerifierModel = cases[0].ProposerModel
-	cases[1].VerifierConfidence = 74
-	cases[2].VerifierVerdict = "sound"
+	cases[1].VerifierModel = "PROPOSER-A"
+	cases[2].VerifierModel = "openai/proposer-a"
+	cases[3].VerifierConfidence = 74
+	cases[4].VerifierVerdict = "sound"
 	result := &ScanResult{
 		Findings: []finding.Finding{
-			{DedupKey: "same-model", Kind: finding.KindSAST, Severity: shared.SeverityMedium},
-			{DedupKey: "low-verifier", Kind: finding.KindSAST, Severity: shared.SeverityMedium},
-			{DedupKey: "wrong-verdict", Kind: finding.KindSAST, Severity: shared.SeverityMedium},
+			{DedupKey: "same-model", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "case-alias", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "provider-alias", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "low-verifier", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "wrong-verdict", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
 		},
 		AITriage: cases,
 	}
-	applyAIGatePolicy(result)
+	applyAIGatePolicy(result, true)
 	if got := result.AIGateExemptKeys(); len(got) != 0 {
 		t.Fatalf("forged/incomplete consensus must never receive gate authority: %v", got)
+	}
+}
+
+func TestApplyAIGatePolicyRequiresEvidenceLedger(t *testing.T) {
+	result := &ScanResult{
+		Findings: []finding.Finding{{DedupKey: "safe", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"}},
+		AITriage: []ports.AICritique{verifiedCritique("safe")},
+	}
+	applyAIGatePolicy(result, false)
+	c := result.AITriage[0]
+	if c.GateExempt || !c.ReviewRequired || c.PolicyReason != aiPolicyEvidenceRequired {
+		t.Fatalf("no-ledger scan must remain gating: %+v", c)
+	}
+}
+
+func TestApplyAIGatePolicyRejectsIneligibleAlternateTriagerResult(t *testing.T) {
+	result := &ScanResult{
+		Findings: []finding.Finding{{DedupKey: "sca", Kind: finding.KindSCA, Class: finding.ClassThirdParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"}},
+		AITriage: []ports.AICritique{verifiedCritique("sca")},
+	}
+	applyAIGatePolicy(result, true)
+	c := result.AITriage[0]
+	if c.GateExempt || !c.ReviewRequired || c.PolicyReason != aiPolicyFindingIneligible {
+		t.Fatalf("alternate triager cannot grant authority outside the candidate set: %+v", c)
+	}
+}
+
+func TestGateExemptKeysRevalidatesOverlaidSeverity(t *testing.T) {
+	base := finding.Finding{DedupKey: "profiled", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"}
+	result := &ScanResult{Findings: []finding.Finding{base}, AITriage: []ports.AICritique{verifiedCritique("profiled")}}
+	applyAIGatePolicy(result, true)
+	if !result.AIGateExemptKeys()["profiled"] {
+		t.Fatal("baseline medium finding should pass the low-risk policy")
+	}
+	overlaid := base
+	overlaid.Severity = shared.SeverityHigh
+	if result.GateExemptKeys([]finding.Finding{overlaid})["profiled"] {
+		t.Fatal("tenant severity overlay to high must revoke the AI gate exemption")
 	}
 }
 
@@ -159,7 +213,10 @@ func TestAIGateExemptKeysRevalidatesPersistedDecision(t *testing.T) {
 
 func TestScanEvidenceContentSealsAIDecisions(t *testing.T) {
 	result := &ScanResult{
-		Findings: []finding.Finding{{DedupKey: "z"}, {DedupKey: "a"}},
+		Findings: []finding.Finding{
+			{DedupKey: "z", Severity: shared.SeverityHigh, CWE: "CWE-89", Kind: finding.KindSAST, Scope: sbom.ScopeProduction, Class: finding.ClassFirstParty},
+			{DedupKey: "a", Severity: shared.SeverityMedium, CWE: "CWE-327", Kind: finding.KindSAST, Scope: sbom.ScopeProduction, Class: finding.ClassFirstParty},
+		},
 		Manifest: ports.ScanManifest{SBOMSHA256: "sha256:abc"},
 		AITriage: []ports.AICritique{
 			{DedupKey: "z", FindingID: "fz", ProposerModel: "p", PolicyVersion: aiTriagePolicyVersion, PolicyReason: aiPolicyVerifierRequired, ReviewRequired: true},
@@ -182,5 +239,10 @@ func TestScanEvidenceContentSealsAIDecisions(t *testing.T) {
 	}
 	if !payload.AITriage[0].GateExempt || !payload.AITriage[0].Verified || !payload.AITriage[1].ReviewRequired {
 		t.Errorf("gate/verifier/review metadata not sealed: %+v", payload.AITriage)
+	}
+	if len(payload.AITriageFindings) != 2 || payload.AITriageFindings[0].DedupKey != "a" ||
+		payload.AITriageFindings[0].Severity != shared.SeverityMedium ||
+		payload.AITriageFindings[1].CWE != "CWE-89" || payload.AITriageFindings[1].Kind != finding.KindSAST {
+		t.Errorf("gate-floor inputs missing or non-canonical in evidence: %+v", payload.AITriageFindings)
 	}
 }

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -202,8 +202,9 @@ func (s *Service) SetIncludeTestSecrets(v bool) { s.includeTestSecrets = v }
 
 // SetFPTriage injects the optional LLM false-positive triager. When set, the pipeline critiques the
 // production-scope first-party source findings after they are built and records the advisory verdicts on
-// ScanResult.AITriage; a suspected-FP is retain-and-mark (gate-exempt via SuspectedFPKeys, still
-// reported + sealed). Best-effort; nil = no triage.
+// ScanResult.AITriage. The deterministic AI gate policy separately decides whether a verified consensus
+// clears the human-review floor; a suspected-FP opinion alone has no gate authority. Best-effort; nil =
+// no triage.
 func (s *Service) SetFPTriage(t ports.FPTriager) { s.fpTriager = t }
 
 // SetOSPackageCataloger configures optional owned OS-package cataloging (dpkg/apk) from a materialized image
@@ -566,11 +567,10 @@ type ScanResult struct {
 	// producer + pinned advisory/DB snapshot ⇒ same digest. Excludes timestamps + per-run metadata.
 	ReproDigest string                 `json:"repro_digest"`
 	DebugEvents []ports.ScanDebugEvent `json:"debug_events"`
-	// AITriage holds an optional LLM false-positive critique of first-party source findings (opt-in,
-	// best-effort). Each entry is the model's PROPOSED verdict; a suspected-FP entry is retain-and-mark
-	// (the finding stays reported here and sealed, it is only held back from the CI gate), never a
-	// deletion. Populated by the injected ports.FPTriager for BOTH the CLI and the durable API scan job;
-	// empty unless the FP-triage gate ran.
+	// AITriage holds optional LLM false-positive critiques plus the deterministic policy decision for each
+	// finding. SuspectedFP is advisory; only GateExempt=true may affect a CI/project gate, and that requires
+	// distinct-model consensus plus clearance of the high-risk human-review floor. Findings are never
+	// deleted. The complete array is sealed into the scan evidence link.
 	AITriage []ports.AICritique `json:"ai_triage,omitempty"`
 	// SourceCapture is analysis-owned source availability metadata. Content is held by
 	// ProjectSourceArtifactStore, never embedded in this scan result.
@@ -581,9 +581,8 @@ type ScanResult struct {
 	FileChanges []projectanalysis.FileChange `json:"file_changes,omitempty"`
 }
 
-// SuspectedFPKeys returns the set of finding DedupKeys the AI triage marked as suspected false positives
-// (retain-and-mark). A --fail-on gate exempts these (still reported + sealed), the same way it exempts
-// accepted-risk and needs-verify findings.
+// SuspectedFPKeys returns advisory model opinions. Consumers MUST NOT use this set to authorize a gate
+// exemption; use AIGateExemptKeys, whose values have passed the deterministic P0 policy.
 func (r *ScanResult) SuspectedFPKeys() map[string]bool {
 	out := map[string]bool{}
 	for _, c := range r.AITriage {
@@ -594,10 +593,46 @@ func (r *ScanResult) SuspectedFPKeys() map[string]bool {
 	return out
 }
 
+// AIGateExemptKeys returns only AI critiques that the server-owned policy authorized to affect a gate.
+func (r *ScanResult) AIGateExemptKeys() map[string]bool {
+	out := map[string]bool{}
+	findings := make(map[string]finding.Finding, len(r.Findings))
+	for _, item := range r.Findings {
+		if key := strings.TrimSpace(item.DedupKey); key != "" {
+			findings[key] = item
+		}
+	}
+	for _, c := range r.AITriage {
+		key := strings.TrimSpace(c.DedupKey)
+		item, found := findings[key]
+		if c.GateExempt &&
+			c.PolicyVersion == aiTriagePolicyVersion &&
+			c.PolicyReason == aiPolicyVerifiedConsensus &&
+			hasVerifiedConsensus(c) &&
+			found && humanReviewFloor(item) == "" {
+			out[key] = true
+		}
+	}
+	return out
+}
+
+// AIReviewRequiredKeys returns suspected false positives held in the human-review floor.
+func (r *ScanResult) AIReviewRequiredKeys() map[string]bool {
+	out := map[string]bool{}
+	for _, c := range r.AITriage {
+		if c.ReviewRequired {
+			if key := strings.TrimSpace(c.DedupKey); key != "" {
+				out[key] = true
+			}
+		}
+	}
+	return out
+}
+
 // GateExemptKeys returns retain-and-mark findings excluded from a Project quality gate.
 func (r *ScanResult) GateExemptKeys(items []finding.Finding) map[string]bool {
 	exempt := map[string]bool{}
-	for _, keys := range []map[string]bool{r.SuppressedKeys(), r.NeedsVerifyKeys(), r.SuspectedFPKeys()} {
+	for _, keys := range []map[string]bool{r.SuppressedKeys(), r.NeedsVerifyKeys(), r.AIGateExemptKeys()} {
 		for key := range keys {
 			if key = strings.TrimSpace(key); key != "" {
 				exempt[key] = true
@@ -2302,14 +2337,21 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		}
 	}
 	// AI false-positive triage (opt-in, best-effort, PROPOSE-ONLY). After the deterministic pass, the
-	// injected triager critiques the remaining production-scope first-party source findings and records
-	// advisory verdicts on AITriage; a suspected-FP is retain-and-mark (held back from the gate via
-	// SuspectedFPKeys, still reported + sealed). Runs for BOTH the CLI and the durable API scan job.
+	// injected triager critiques production-scope first-party findings. The server-owned policy then
+	// separates advisory suspected-FP opinions from verified, low-risk gate exemptions. Single-model,
+	// high/critical, secret, and dangerous-CWE refutations stay gating for human review.
 	if s.fpTriager != nil {
 		if cands := fpTriageCandidates(result.Findings); len(cands) > 0 {
 			tstep := trace.start(stageFindings, "ai-fp-triage", "fp-triager", "AI false-positive triage", map[string]int{"candidates": len(cands)})
 			result.AITriage = s.fpTriager.Triage(ctx, cands, ws.Dir)
-			trace.succeed(tstep, "AI false-positive triage", map[string]int{"candidates": len(cands), "critiqued": len(result.AITriage), "suspected_fp": len(result.SuspectedFPKeys())})
+			applyAIGatePolicy(result)
+			trace.succeed(tstep, "AI false-positive triage", map[string]int{
+				"candidates":      len(cands),
+				"critiqued":       len(result.AITriage),
+				"suspected_fp":    len(result.SuspectedFPKeys()),
+				"gate_exempt":     len(result.AIGateExemptKeys()),
+				"review_required": len(result.AIReviewRequiredKeys()),
+			})
 		}
 	}
 	result.MinSeverity = s.minSeverity
@@ -2984,14 +3026,21 @@ func isPinnedVersion(v string) bool {
 // job.Error – a second layer beyond the acquirer's own redaction.
 var credInErr = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@\s]+@`)
 
-// sealEvidence appends one tamper-evident link summarizing this scan to the
-// engagement's hash chain. Content is a canonical digest of the run:
-// SBOM hash, finding keys, and the manifest – so any later tampering is detectable
-// by re-verification. A configured ledger failure prevents result persistence.
-func (s *Service) sealEvidence(ctx context.Context, actor string, engagementID shared.ID, now time.Time, result *ScanResult) error {
-	if s.evidence == nil {
-		return nil
-	}
+type scanEvidencePayload struct {
+	SBOMSHA256     string             `json:"sbom_sha256"`
+	Findings       []string           `json:"findings"`
+	Suppressed     []string           `json:"suppressed,omitempty"`
+	AITriagePolicy string             `json:"ai_triage_policy,omitempty"`
+	AITriage       []ports.AICritique `json:"ai_triage,omitempty"`
+	Manifest       ports.ScanManifest `json:"manifest"`
+	SealedAt       string             `json:"sealed_at"`
+	Actor          string             `json:"actor"`
+}
+
+// scanEvidenceContent builds the canonical scan evidence payload. AI decisions are sorted and sealed
+// alongside findings, so changing a verdict, verifier identity, policy reason, or gate authorization is
+// detectable even when the finding set itself is unchanged.
+func scanEvidenceContent(actor string, now time.Time, result *ScanResult) ([]byte, error) {
 	keys := make([]string, 0, len(result.Findings))
 	for _, f := range result.Findings {
 		keys = append(keys, f.DedupKey)
@@ -3005,15 +3054,40 @@ func (s *Service) sealEvidence(ctx context.Context, actor string, engagementID s
 		suppressed = append(suppressed, sf.RuleID+"="+sf.DedupKey)
 	}
 	sort.Strings(suppressed)
-	payload := struct {
-		SBOMSHA256 string             `json:"sbom_sha256"`
-		Findings   []string           `json:"findings"`
-		Suppressed []string           `json:"suppressed,omitempty"`
-		Manifest   ports.ScanManifest `json:"manifest"`
-		SealedAt   string             `json:"sealed_at"`
-		Actor      string             `json:"actor"`
-	}{result.Manifest.SBOMSHA256, keys, suppressed, result.Manifest, now.UTC().Format(time.RFC3339), actor}
-	content, err := json.Marshal(payload)
+	aiTriage := append([]ports.AICritique(nil), result.AITriage...)
+	sort.Slice(aiTriage, func(i, j int) bool {
+		if aiTriage[i].DedupKey != aiTriage[j].DedupKey {
+			return aiTriage[i].DedupKey < aiTriage[j].DedupKey
+		}
+		if aiTriage[i].FindingID != aiTriage[j].FindingID {
+			return aiTriage[i].FindingID < aiTriage[j].FindingID
+		}
+		return aiTriage[i].ProposerModel < aiTriage[j].ProposerModel
+	})
+	policyVersion := ""
+	if len(aiTriage) > 0 {
+		policyVersion = aiTriagePolicyVersion
+	}
+	return json.Marshal(scanEvidencePayload{
+		SBOMSHA256:     result.Manifest.SBOMSHA256,
+		Findings:       keys,
+		Suppressed:     suppressed,
+		AITriagePolicy: policyVersion,
+		AITriage:       aiTriage,
+		Manifest:       result.Manifest,
+		SealedAt:       now.UTC().Format(time.RFC3339),
+		Actor:          actor,
+	})
+}
+
+// sealEvidence appends one tamper-evident link summarizing this scan to the engagement's hash chain.
+// Content covers every gate-affecting AI field as well as the deterministic finding/suppression set.
+// A configured ledger failure prevents result persistence, preserving the fail-closed contract.
+func (s *Service) sealEvidence(ctx context.Context, actor string, engagementID shared.ID, now time.Time, result *ScanResult) error {
+	if s.evidence == nil {
+		return nil
+	}
+	content, err := scanEvidenceContent(actor, now, result)
 	if err != nil {
 		return fmt.Errorf("marshal scan evidence: %w", err)
 	}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -595,9 +595,16 @@ func (r *ScanResult) SuspectedFPKeys() map[string]bool {
 
 // AIGateExemptKeys returns only AI critiques that the server-owned policy authorized to affect a gate.
 func (r *ScanResult) AIGateExemptKeys() map[string]bool {
+	return r.aiGateExemptKeys(r.Findings)
+}
+
+// aiGateExemptKeys revalidates decisions against the exact finding view a gate will consume. Project
+// quality profiles may overlay severity, so using r.Findings here could exempt a finding the tenant
+// deliberately escalated to High/Critical.
+func (r *ScanResult) aiGateExemptKeys(items []finding.Finding) map[string]bool {
 	out := map[string]bool{}
-	findings := make(map[string]finding.Finding, len(r.Findings))
-	for _, item := range r.Findings {
+	findings := make(map[string]finding.Finding, len(items))
+	for _, item := range items {
 		if key := strings.TrimSpace(item.DedupKey); key != "" {
 			findings[key] = item
 		}
@@ -609,7 +616,7 @@ func (r *ScanResult) AIGateExemptKeys() map[string]bool {
 			c.PolicyVersion == aiTriagePolicyVersion &&
 			c.PolicyReason == aiPolicyVerifiedConsensus &&
 			hasVerifiedConsensus(c) &&
-			found && humanReviewFloor(item) == "" {
+			found && humanReviewFloor(item) == "" && isFPTriageEligible(item) {
 			out[key] = true
 		}
 	}
@@ -632,7 +639,7 @@ func (r *ScanResult) AIReviewRequiredKeys() map[string]bool {
 // GateExemptKeys returns retain-and-mark findings excluded from a Project quality gate.
 func (r *ScanResult) GateExemptKeys(items []finding.Finding) map[string]bool {
 	exempt := map[string]bool{}
-	for _, keys := range []map[string]bool{r.SuppressedKeys(), r.NeedsVerifyKeys(), r.AIGateExemptKeys()} {
+	for _, keys := range []map[string]bool{r.SuppressedKeys(), r.NeedsVerifyKeys(), r.aiGateExemptKeys(items)} {
 		for key := range keys {
 			if key = strings.TrimSpace(key); key != "" {
 				exempt[key] = true
@@ -652,17 +659,24 @@ func (r *ScanResult) GateExemptKeys(items []finding.Finding) map[string]bool {
 	return exempt
 }
 
-// fpTriageCandidates selects the findings worth an LLM critique: production-scope, first-party source
-// analysis (SAST/secret/misconfig). Background-scope findings are already gate-exempt deterministically,
-// and SCA/advisory findings are DB-backed facts, so neither is critiqued.
+// isFPTriageEligible is shared by candidate selection and the authorization re-check. Secrets are
+// deliberately excluded: even a redacted finding description cannot make the surrounding raw source
+// snippet safe to send to an external model.
+func isFPTriageEligible(f finding.Finding) bool {
+	if f.Class != finding.ClassFirstParty || f.Scope != sbom.ScopeProduction ||
+		f.Kind == finding.KindSecret || hasCredentialCWE(f.CWE) {
+		return false
+	}
+	return f.Kind == finding.KindSAST || f.Kind == finding.KindMisconfig
+}
+
+// fpTriageCandidates selects production-scope first-party SAST/misconfig findings worth an LLM
+// critique. Background findings are already gate-exempt deterministically; SCA findings are DB-backed
+// facts; secret source context must never enter an LLM transcript.
 func fpTriageCandidates(fs []finding.Finding) []finding.Finding {
 	out := make([]finding.Finding, 0, len(fs))
 	for _, f := range fs {
-		if sbom.IsBackgroundScope(f.Scope) {
-			continue
-		}
-		switch f.Kind {
-		case finding.KindSAST, finding.KindSecret, finding.KindMisconfig:
+		if isFPTriageEligible(f) {
 			out = append(out, f)
 		}
 	}
@@ -2344,7 +2358,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		if cands := fpTriageCandidates(result.Findings); len(cands) > 0 {
 			tstep := trace.start(stageFindings, "ai-fp-triage", "fp-triager", "AI false-positive triage", map[string]int{"candidates": len(cands)})
 			result.AITriage = s.fpTriager.Triage(ctx, cands, ws.Dir)
-			applyAIGatePolicy(result)
+			applyAIGatePolicy(result, s.evidence != nil)
 			trace.succeed(tstep, "AI false-positive triage", map[string]int{
 				"candidates":      len(cands),
 				"critiqued":       len(result.AITriage),
@@ -3027,14 +3041,26 @@ func isPinnedVersion(v string) bool {
 var credInErr = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@\s]+@`)
 
 type scanEvidencePayload struct {
-	SBOMSHA256     string             `json:"sbom_sha256"`
-	Findings       []string           `json:"findings"`
-	Suppressed     []string           `json:"suppressed,omitempty"`
-	AITriagePolicy string             `json:"ai_triage_policy,omitempty"`
-	AITriage       []ports.AICritique `json:"ai_triage,omitempty"`
-	Manifest       ports.ScanManifest `json:"manifest"`
-	SealedAt       string             `json:"sealed_at"`
-	Actor          string             `json:"actor"`
+	SBOMSHA256       string                  `json:"sbom_sha256"`
+	Findings         []string                `json:"findings"`
+	Suppressed       []string                `json:"suppressed,omitempty"`
+	AITriagePolicy   string                  `json:"ai_triage_policy,omitempty"`
+	AITriage         []ports.AICritique      `json:"ai_triage,omitempty"`
+	AITriageFindings []scanEvidenceAIFinding `json:"ai_triage_findings,omitempty"`
+	Manifest         ports.ScanManifest      `json:"manifest"`
+	SealedAt         string                  `json:"sealed_at"`
+	Actor            string                  `json:"actor"`
+}
+
+// scanEvidenceAIFinding seals every input the gate policy reads. Sealing a dedup key alone would not
+// detect a later severity/CWE/kind/scope/class mutation that changes the human-review floor.
+type scanEvidenceAIFinding struct {
+	DedupKey string          `json:"dedup_key"`
+	Severity shared.Severity `json:"severity"`
+	CWE      string          `json:"cwe,omitempty"`
+	Kind     finding.Kind    `json:"kind"`
+	Scope    string          `json:"scope,omitempty"`
+	Class    string          `json:"class,omitempty"`
 }
 
 // scanEvidenceContent builds the canonical scan evidence payload. AI decisions are sorted and sealed
@@ -3055,7 +3081,7 @@ func scanEvidenceContent(actor string, now time.Time, result *ScanResult) ([]byt
 	}
 	sort.Strings(suppressed)
 	aiTriage := append([]ports.AICritique(nil), result.AITriage...)
-	sort.Slice(aiTriage, func(i, j int) bool {
+	sort.SliceStable(aiTriage, func(i, j int) bool {
 		if aiTriage[i].DedupKey != aiTriage[j].DedupKey {
 			return aiTriage[i].DedupKey < aiTriage[j].DedupKey
 		}
@@ -3064,19 +3090,59 @@ func scanEvidenceContent(actor string, now time.Time, result *ScanResult) ([]byt
 		}
 		return aiTriage[i].ProposerModel < aiTriage[j].ProposerModel
 	})
+	triagedKeys := make(map[string]struct{}, len(aiTriage))
+	for _, critique := range aiTriage {
+		if key := strings.TrimSpace(critique.DedupKey); key != "" {
+			triagedKeys[key] = struct{}{}
+		}
+	}
+	var aiFindings []scanEvidenceAIFinding
+	for _, item := range result.Findings {
+		key := strings.TrimSpace(item.DedupKey)
+		if _, triaged := triagedKeys[key]; !triaged {
+			continue
+		}
+		aiFindings = append(aiFindings, scanEvidenceAIFinding{
+			DedupKey: key,
+			Severity: item.Severity,
+			CWE:      item.CWE,
+			Kind:     item.Kind,
+			Scope:    item.Scope,
+			Class:    item.Class,
+		})
+	}
+	sort.SliceStable(aiFindings, func(i, j int) bool {
+		if aiFindings[i].DedupKey != aiFindings[j].DedupKey {
+			return aiFindings[i].DedupKey < aiFindings[j].DedupKey
+		}
+		if aiFindings[i].Severity != aiFindings[j].Severity {
+			return aiFindings[i].Severity < aiFindings[j].Severity
+		}
+		if aiFindings[i].CWE != aiFindings[j].CWE {
+			return aiFindings[i].CWE < aiFindings[j].CWE
+		}
+		if aiFindings[i].Kind != aiFindings[j].Kind {
+			return aiFindings[i].Kind < aiFindings[j].Kind
+		}
+		if aiFindings[i].Scope != aiFindings[j].Scope {
+			return aiFindings[i].Scope < aiFindings[j].Scope
+		}
+		return aiFindings[i].Class < aiFindings[j].Class
+	})
 	policyVersion := ""
 	if len(aiTriage) > 0 {
 		policyVersion = aiTriagePolicyVersion
 	}
 	return json.Marshal(scanEvidencePayload{
-		SBOMSHA256:     result.Manifest.SBOMSHA256,
-		Findings:       keys,
-		Suppressed:     suppressed,
-		AITriagePolicy: policyVersion,
-		AITriage:       aiTriage,
-		Manifest:       result.Manifest,
-		SealedAt:       now.UTC().Format(time.RFC3339),
-		Actor:          actor,
+		SBOMSHA256:       result.Manifest.SBOMSHA256,
+		Findings:         keys,
+		Suppressed:       suppressed,
+		AITriagePolicy:   policyVersion,
+		AITriage:         aiTriage,
+		AITriageFindings: aiFindings,
+		Manifest:         result.Manifest,
+		SealedAt:         now.UTC().Format(time.RFC3339),
+		Actor:            actor,
 	})
 }
 


### PR DESCRIPTION
## Summary

Implements the P0 safety foundation from #387 on top of current main, including the fail-closed evidence changes merged in #386.

This is a fresh replacement for the closed, unmerged draft #376. It is based on main at b47f6d0 rather than reopening the stale branch.

Part of #387.
#384 was resolved by #397; this branch is rebased on the fix.

## Safety contract

- A single-model false-positive opinion is advisory-only and cannot affect a quality gate.
- A gate exemption requires two canonically distinct models to independently return refuted at or above verdict.EvidenceThreshold.
- High/Critical findings, secret findings, and protected CWE classes always remain gating for human review.
- Missing, failed, unavailable, or non-distinct verifier paths fail safe.
- Findings remain present in JSON, SARIF, compliance output, and evidence.
- Server-side readers revalidate the complete consensus and finding risk floor instead of trusting persisted GateExempt metadata.

## Implementation

- Adds versioned authorization policy fp-gate-v2 and prompt contract fp-triage-v1.
- Separates suspected_fp, verified, gate_exempt, and review_required.
- Records proposer/verifier identity, verdict, confidence, prompt version, policy version, and policy reason.
- Uses AIGateExemptKeys as the only AI authority consumed by CLI and project quality gates.
- Seals all gate-affecting AI metadata and policy inputs (severity, CWE, kind, scope, class) in canonical scan evidence.
- Preserves #386: a configured evidence-ledger failure returns an error and prevents result persistence.
- Adds adversarial tests for forged flags, same-model verification, low confidence, verifier disagreement, protected risk floors, missing findings, and evidence content/order.

## P0 policy decisions for PM/Security sign-off

1. Only Low/Medium findings outside protected CWE classes may be AI gate-exempt.
2. High/Critical, secrets, and protected CWEs always require human review.
3. A missing or failing verifier leaves triage advisory-only.
4. review_required is metadata in P0; the durable API/UI workflow is P1.2 (#389).

## Security review remediation

Commit aaa5966 addresses the requested changes:

- Blocker 1: protects CWE-798, CWE-259, CWE-321, and CWE-522; secret and credential-bearing findings are excluded from LLM candidate selection.
- Blocker 2: the policy now requires an evidence ledger before setting gate_exempt. The standalone CLI has no vault, so it remains advisory-only and the misleading evidence-sealed message was removed.
- Blocker 3: proposer/verifier identities are canonicalized across case, provider/router prefixes, and dated aliases in both coordinator attachment and policy revalidation.
- Severity overlays are threaded through the gate re-check.
- Empty-CWE SAST/misconfig findings default to human review.
- Kind, first-party class, and exact production scope are revalidated.
- Gate-floor inputs are sealed and evidence ordering uses stable sorts.
- SARIF marking is tracked separately in #430.

Regression tests cover every bypass and negative path above.
## Verification

Passed locally on current main:

- go test ./internal/usecase/fptriage ./internal/usecase/sca
- go test ./internal/usecase/...
- go vet ./internal/usecase/fptriage ./internal/usecase/sca ./internal/usecase/projectuc
- frontend pnpm test: 29 files / 267 tests passed
- frontend pnpm run typecheck
- frontend pnpm build
- git diff origin/main...HEAD --check

The full cmd/synapse-cli and cmd/synapse-api package test was blocked locally by Windows Defender quarantining the upstream file internal/infrastructure/tools/sast/php_lex_test.go as potentially unwanted software. That file is unchanged by this PR and was restored before push; CI should provide the authoritative full-suite result.

## Rollout

The feature remains off by default. Until PM/Security approve the P0 contract, deployments should keep AI triage disabled or advisory-only.
