### PR TITLE
feat(modulegraph): add Phase 5A domain types and JSImportScanner port

### DIFF
--- a/internal/domain/modulegraph/modulegraph.go
+++ b/internal/domain/modulegraph/modulegraph.go
@@ -1,0 +1,188 @@
+// Package modulegraph defines the deterministic, source-only JavaScript and
+// TypeScript module graph used by the first phase of import reachability.
+//
+// This package is intentionally pure domain code. It performs no filesystem,
+// parser, package-manager, network, SCA, judgment, or OpenVEX work.
+package modulegraph
+
+import "strings"
+
+// Dialect identifies the source grammar family associated with a module.
+type Dialect string
+
+const (
+	DialectJavaScript Dialect = "javascript"
+	DialectJSX        Dialect = "jsx"
+	DialectTypeScript Dialect = "typescript"
+	DialectTSX        Dialect = "tsx"
+)
+
+// Valid reports whether d is a supported source dialect.
+func (d Dialect) Valid() bool {
+	switch d {
+	case DialectJavaScript, DialectJSX, DialectTypeScript, DialectTSX:
+		return true
+	default:
+		return false
+	}
+}
+
+// Module is a first-party JavaScript or TypeScript source module.
+type Module struct {
+	// Path is a normalized repository-relative slash path.
+	Path string
+	// Dialect records the lexical grammar family selected from Path.
+	Dialect Dialect
+	// DeclarationOnly is true only for .d.ts, .d.mts, and .d.cts files.
+	DeclarationOnly bool
+}
+
+// ImportKind identifies a statically observed module-loading form.
+type ImportKind string
+
+const (
+	ImportESMStatic       ImportKind = "esm-static"
+	ImportESMDynamic      ImportKind = "esm-dynamic-literal"
+	ImportCommonJS        ImportKind = "commonjs-literal"
+	ImportReExport        ImportKind = "re-export"
+	ImportTypeScriptEqual ImportKind = "typescript-import-equals"
+)
+
+// Valid reports whether k is a supported import kind.
+func (k ImportKind) Valid() bool {
+	switch k {
+	case ImportESMStatic, ImportESMDynamic, ImportCommonJS, ImportReExport, ImportTypeScriptEqual:
+		return true
+	default:
+		return false
+	}
+}
+
+// Binding describes statically observable symbol binding information.
+type Binding struct {
+	Imported  string
+	Local     string
+	Default   bool
+	Namespace bool
+	TypeOnly  bool
+}
+
+// Position is a 1-based source position. Zero values mean unavailable.
+type Position struct {
+	Line   int
+	Column int
+}
+
+// Edge is an observed module relationship.
+type Edge struct {
+	// From is always a normalized repository-relative source path.
+	From string
+	// To is set only for a uniquely resolved first-party relative import.
+	// External or unresolved specifiers leave To empty.
+	To string
+	// Specifier preserves the scanner's normalized module specifier.
+	Specifier string
+	Kind      ImportKind
+	Bindings  []Binding
+	TypeOnly  bool
+	Position  Position
+}
+
+// CoverageIssueKind identifies a condition that prevents a later analyzer from
+// treating absence of an edge as a definitive negative proof.
+type CoverageIssueKind string
+
+const (
+	CoverageUnreadableFile            CoverageIssueKind = "unreadable-file"
+	CoverageSymlink                   CoverageIssueKind = "symlink"
+	CoverageInvalidUTF8               CoverageIssueKind = "invalid-utf8"
+	CoverageFileTooLarge              CoverageIssueKind = "file-too-large"
+	CoverageFileCountBudgetExceeded   CoverageIssueKind = "file-count-budget-exceeded"
+	CoverageTotalByteBudgetExceeded   CoverageIssueKind = "total-byte-budget-exceeded"
+	CoverageMalformedSource           CoverageIssueKind = "malformed-source"
+	CoverageUnsupportedSyntax         CoverageIssueKind = "unsupported-syntax"
+	CoverageDynamicRequire            CoverageIssueKind = "dynamic-require"
+	CoverageDynamicImport             CoverageIssueKind = "dynamic-import"
+	CoverageEval                      CoverageIssueKind = "eval"
+	CoverageNewFunction               CoverageIssueKind = "new-function"
+	CoverageRequireContext            CoverageIssueKind = "require-context"
+	CoverageImportMetaGlob            CoverageIssueKind = "import-meta-glob"
+	CoverageModuleCreateRequire       CoverageIssueKind = "module-create-require"
+	CoverageUnsupportedLoader         CoverageIssueKind = "unsupported-loader"
+	CoverageUnresolvedRelativeImport  CoverageIssueKind = "unresolved-relative-import"
+	CoverageAmbiguousRelativeImport   CoverageIssueKind = "ambiguous-relative-import"
+	CoverageRelativeImportEscapesRoot CoverageIssueKind = "relative-import-escapes-root"
+)
+
+// Valid reports whether k is a known R1 coverage issue kind.
+func (k CoverageIssueKind) Valid() bool {
+	switch k {
+	case CoverageUnreadableFile,
+		CoverageSymlink,
+		CoverageInvalidUTF8,
+		CoverageFileTooLarge,
+		CoverageFileCountBudgetExceeded,
+		CoverageTotalByteBudgetExceeded,
+		CoverageMalformedSource,
+		CoverageUnsupportedSyntax,
+		CoverageDynamicRequire,
+		CoverageDynamicImport,
+		CoverageEval,
+		CoverageNewFunction,
+		CoverageRequireContext,
+		CoverageImportMetaGlob,
+		CoverageModuleCreateRequire,
+		CoverageUnsupportedLoader,
+		CoverageUnresolvedRelativeImport,
+		CoverageAmbiguousRelativeImport,
+		CoverageRelativeImportEscapesRoot:
+		return true
+	default:
+		return false
+	}
+}
+
+// CoverageIssue records a deterministic and attributable coverage limitation.
+type CoverageIssue struct {
+	Kind   CoverageIssueKind
+	Path   string
+	Line   int
+	Detail string
+}
+
+// Graph is the normalized scanner output for one repository root.
+type Graph struct {
+	Modules []Module
+	Edges   []Edge
+	// Roots contains structural roots only: modules with no incoming resolved
+	// first-party edge. It is not a set of verified runtime entrypoints.
+	Roots        []string
+	Coverage     []CoverageIssue
+	FilesScanned int
+	BytesScanned int64
+}
+
+// DialectForPath returns the dialect selected by a supported source extension.
+func DialectForPath(p string) (Dialect, bool) {
+	lower := strings.ToLower(p)
+	switch {
+	case strings.HasSuffix(lower, ".tsx"):
+		return DialectTSX, true
+	case strings.HasSuffix(lower, ".jsx"):
+		return DialectJSX, true
+	case strings.HasSuffix(lower, ".ts"), strings.HasSuffix(lower, ".mts"), strings.HasSuffix(lower, ".cts"):
+		return DialectTypeScript, true
+	case strings.HasSuffix(lower, ".js"), strings.HasSuffix(lower, ".mjs"), strings.HasSuffix(lower, ".cjs"):
+		return DialectJavaScript, true
+	default:
+		return "", false
+	}
+}
+
+// IsDeclarationPath reports whether p is a TypeScript declaration source file.
+func IsDeclarationPath(p string) bool {
+	lower := strings.ToLower(p)
+	return strings.HasSuffix(lower, ".d.ts") ||
+		strings.HasSuffix(lower, ".d.mts") ||
+		strings.HasSuffix(lower, ".d.cts")
+}

--- a/internal/domain/modulegraph/normalize.go
+++ b/internal/domain/modulegraph/normalize.go
@@ -1,0 +1,294 @@
+package modulegraph
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+)
+
+// NormalizeRepositoryPath converts a scanner path into the canonical
+// repository-relative slash form and rejects absolute paths and root escapes.
+func NormalizeRepositoryPath(raw string) (string, error) {
+	if raw == "" {
+		return "", fmt.Errorf("modulegraph: empty repository path")
+	}
+	if strings.IndexByte(raw, 0) >= 0 {
+		return "", fmt.Errorf("modulegraph: repository path contains NUL")
+	}
+
+	slashed := strings.ReplaceAll(raw, "\\", "/")
+	if strings.HasPrefix(slashed, "/") || strings.HasPrefix(slashed, "//") || hasWindowsVolumePrefix(slashed) {
+		return "", fmt.Errorf("modulegraph: absolute repository path %q", raw)
+	}
+
+	cleaned := path.Clean(slashed)
+	if cleaned == "." || cleaned == "" {
+		return "", fmt.Errorf("modulegraph: repository path %q has no file component", raw)
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("modulegraph: repository path %q escapes the scan root", raw)
+	}
+	return strings.TrimPrefix(cleaned, "./"), nil
+}
+
+// Normalize validates, deduplicates, and deterministically sorts a graph. It
+// returns a new graph and does not mutate the input. Structural roots are
+// recomputed from resolved first-party edges.
+func Normalize(in Graph) (Graph, error) {
+	if in.FilesScanned < 0 {
+		return Graph{}, fmt.Errorf("modulegraph: negative files scanned: %d", in.FilesScanned)
+	}
+	if in.BytesScanned < 0 {
+		return Graph{}, fmt.Errorf("modulegraph: negative bytes scanned: %d", in.BytesScanned)
+	}
+
+	out := Graph{FilesScanned: in.FilesScanned, BytesScanned: in.BytesScanned}
+	moduleByPath := make(map[string]Module, len(in.Modules))
+
+	for _, module := range in.Modules {
+		normalizedPath, err := NormalizeRepositoryPath(module.Path)
+		if err != nil {
+			return Graph{}, fmt.Errorf("normalize module %q: %w", module.Path, err)
+		}
+		dialect, ok := DialectForPath(normalizedPath)
+		if !ok {
+			return Graph{}, fmt.Errorf("modulegraph: unsupported source extension for %q", normalizedPath)
+		}
+		if !module.Dialect.Valid() || module.Dialect != dialect {
+			return Graph{}, fmt.Errorf("modulegraph: dialect %q does not match %q", module.Dialect, normalizedPath)
+		}
+		declarationOnly := IsDeclarationPath(normalizedPath)
+		if module.DeclarationOnly != declarationOnly {
+			return Graph{}, fmt.Errorf("modulegraph: declaration-only flag does not match %q", normalizedPath)
+		}
+
+		normalized := Module{Path: normalizedPath, Dialect: module.Dialect, DeclarationOnly: module.DeclarationOnly}
+		if previous, exists := moduleByPath[normalizedPath]; exists {
+			if previous != normalized {
+				return Graph{}, fmt.Errorf("modulegraph: conflicting duplicate module %q", normalizedPath)
+			}
+			continue
+		}
+		moduleByPath[normalizedPath] = normalized
+	}
+
+	out.Modules = make([]Module, 0, len(moduleByPath))
+	for _, module := range moduleByPath {
+		out.Modules = append(out.Modules, module)
+	}
+	sort.Slice(out.Modules, func(i, j int) bool { return out.Modules[i].Path < out.Modules[j].Path })
+
+	out.Edges = make([]Edge, 0, len(in.Edges))
+	for _, edge := range in.Edges {
+		normalized, err := normalizeEdge(edge, moduleByPath)
+		if err != nil {
+			return Graph{}, err
+		}
+		out.Edges = append(out.Edges, normalized)
+	}
+	sort.Slice(out.Edges, func(i, j int) bool { return edgeLess(out.Edges[i], out.Edges[j]) })
+	out.Edges = deduplicateEdges(out.Edges)
+
+	out.Coverage = make([]CoverageIssue, 0, len(in.Coverage))
+	for _, issue := range in.Coverage {
+		if !issue.Kind.Valid() {
+			return Graph{}, fmt.Errorf("modulegraph: invalid coverage issue kind %q", issue.Kind)
+		}
+		if issue.Line < 0 {
+			return Graph{}, fmt.Errorf("modulegraph: negative coverage line for %q", issue.Path)
+		}
+		if issue.Path != "" {
+			normalizedPath, err := NormalizeRepositoryPath(issue.Path)
+			if err != nil {
+				return Graph{}, fmt.Errorf("normalize coverage path %q: %w", issue.Path, err)
+			}
+			issue.Path = normalizedPath
+		}
+		out.Coverage = append(out.Coverage, issue)
+	}
+	sort.Slice(out.Coverage, func(i, j int) bool { return coverageLess(out.Coverage[i], out.Coverage[j]) })
+	out.Coverage = deduplicateCoverage(out.Coverage)
+	out.Roots = structuralRoots(out.Modules, out.Edges)
+
+	return out, nil
+}
+
+func normalizeEdge(edge Edge, modules map[string]Module) (Edge, error) {
+	if !edge.Kind.Valid() {
+		return Edge{}, fmt.Errorf("modulegraph: invalid import kind %q", edge.Kind)
+	}
+	if edge.Position.Line < 0 || edge.Position.Column < 0 {
+		return Edge{}, fmt.Errorf("modulegraph: negative source position for edge from %q", edge.From)
+	}
+
+	from, err := NormalizeRepositoryPath(edge.From)
+	if err != nil {
+		return Edge{}, fmt.Errorf("normalize edge source %q: %w", edge.From, err)
+	}
+	if _, ok := modules[from]; !ok {
+		return Edge{}, fmt.Errorf("modulegraph: edge source %q is not a known module", from)
+	}
+	edge.From = from
+
+	if edge.To != "" {
+		to, err := NormalizeRepositoryPath(edge.To)
+		if err != nil {
+			return Edge{}, fmt.Errorf("normalize edge target %q: %w", edge.To, err)
+		}
+		if _, ok := modules[to]; !ok {
+			return Edge{}, fmt.Errorf("modulegraph: edge target %q is not a known module", to)
+		}
+		edge.To = to
+	}
+
+	edge.Bindings = append([]Binding(nil), edge.Bindings...)
+	sort.Slice(edge.Bindings, func(i, j int) bool { return bindingLess(edge.Bindings[i], edge.Bindings[j]) })
+	edge.Bindings = deduplicateBindings(edge.Bindings)
+	return edge, nil
+}
+
+func structuralRoots(modules []Module, edges []Edge) []string {
+	incoming := make(map[string]bool, len(modules))
+	for _, edge := range edges {
+		if edge.To != "" {
+			incoming[edge.To] = true
+		}
+	}
+	roots := make([]string, 0, len(modules))
+	for _, module := range modules {
+		if !incoming[module.Path] {
+			roots = append(roots, module.Path)
+		}
+	}
+	return roots
+}
+
+func hasWindowsVolumePrefix(p string) bool {
+	return len(p) >= 2 && ((p[0] >= 'a' && p[0] <= 'z') || (p[0] >= 'A' && p[0] <= 'Z')) && p[1] == ':'
+}
+
+func bindingLess(a, b Binding) bool {
+	if a.Imported != b.Imported {
+		return a.Imported < b.Imported
+	}
+	if a.Local != b.Local {
+		return a.Local < b.Local
+	}
+	if a.Default != b.Default {
+		return !a.Default && b.Default
+	}
+	if a.Namespace != b.Namespace {
+		return !a.Namespace && b.Namespace
+	}
+	if a.TypeOnly != b.TypeOnly {
+		return !a.TypeOnly && b.TypeOnly
+	}
+	return false
+}
+
+func edgeLess(a, b Edge) bool {
+	if a.From != b.From {
+		return a.From < b.From
+	}
+	if a.To != b.To {
+		return a.To < b.To
+	}
+	if a.Specifier != b.Specifier {
+		return a.Specifier < b.Specifier
+	}
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	if a.TypeOnly != b.TypeOnly {
+		return !a.TypeOnly && b.TypeOnly
+	}
+	if a.Position.Line != b.Position.Line {
+		return a.Position.Line < b.Position.Line
+	}
+	if a.Position.Column != b.Position.Column {
+		return a.Position.Column < b.Position.Column
+	}
+	return bindingsLess(a.Bindings, b.Bindings)
+}
+
+func bindingsLess(a, b []Binding) bool {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	for i := 0; i < limit; i++ {
+		if a[i] == b[i] {
+			continue
+		}
+		return bindingLess(a[i], b[i])
+	}
+	return len(a) < len(b)
+}
+
+func coverageLess(a, b CoverageIssue) bool {
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	if a.Path != b.Path {
+		return a.Path < b.Path
+	}
+	if a.Line != b.Line {
+		return a.Line < b.Line
+	}
+	return a.Detail < b.Detail
+}
+
+func deduplicateBindings(values []Binding) []Binding {
+	if len(values) < 2 {
+		return values
+	}
+	result := values[:1]
+	for _, value := range values[1:] {
+		if value != result[len(result)-1] {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func deduplicateEdges(values []Edge) []Edge {
+	if len(values) < 2 {
+		return values
+	}
+	result := values[:1]
+	for _, value := range values[1:] {
+		if !edgesEqual(value, result[len(result)-1]) {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func deduplicateCoverage(values []CoverageIssue) []CoverageIssue {
+	if len(values) < 2 {
+		return values
+	}
+	result := values[:1]
+	for _, value := range values[1:] {
+		if value != result[len(result)-1] {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func edgesEqual(a, b Edge) bool {
+	if a.From != b.From || a.To != b.To || a.Specifier != b.Specifier || a.Kind != b.Kind || a.TypeOnly != b.TypeOnly || a.Position != b.Position {
+		return false
+	}
+	if len(a.Bindings) != len(b.Bindings) {
+		return false
+	}
+	for i := range a.Bindings {
+		if a.Bindings[i] != b.Bindings[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/domain/modulegraph/normalize_test.go
+++ b/internal/domain/modulegraph/normalize_test.go
@@ -1,0 +1,214 @@
+package modulegraph
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeRepositoryPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "slash form", input: "src/app.ts", want: "src/app.ts"},
+		{name: "dot and backslash", input: `.\\src\\app.ts`, want: "src/app.ts"},
+		{name: "clean segments", input: "src/lib/../app.ts", want: "src/app.ts"},
+		{name: "empty", input: "", wantErr: true},
+		{name: "dot", input: ".", wantErr: true},
+		{name: "unix absolute", input: "/src/app.ts", wantErr: true},
+		{name: "windows absolute", input: `C:\\src\\app.ts`, wantErr: true},
+		{name: "root escape", input: "../app.ts", wantErr: true},
+		{name: "cleaned root escape", input: "src/../../app.ts", wantErr: true},
+		{name: "nul", input: "src/\x00app.ts", wantErr: true},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NormalizeRepositoryPath(test.input)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeRepositoryPath(%q) error = nil", test.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeRepositoryPath(%q): %v", test.input, err)
+			}
+			if got != test.want {
+				t.Fatalf("NormalizeRepositoryPath(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func TestDialectForPathAndDeclaration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path        string
+		dialect     Dialect
+		declaration bool
+	}{
+		{path: "a.js", dialect: DialectJavaScript},
+		{path: "a.mjs", dialect: DialectJavaScript},
+		{path: "a.cjs", dialect: DialectJavaScript},
+		{path: "a.jsx", dialect: DialectJSX},
+		{path: "a.ts", dialect: DialectTypeScript},
+		{path: "a.mts", dialect: DialectTypeScript},
+		{path: "a.cts", dialect: DialectTypeScript},
+		{path: "a.tsx", dialect: DialectTSX},
+		{path: "a.d.ts", dialect: DialectTypeScript, declaration: true},
+		{path: "a.d.mts", dialect: DialectTypeScript, declaration: true},
+		{path: "a.d.cts", dialect: DialectTypeScript, declaration: true},
+	}
+
+	for _, test := range tests {
+		got, ok := DialectForPath(test.path)
+		if !ok || got != test.dialect {
+			t.Fatalf("DialectForPath(%q) = %q, %v; want %q, true", test.path, got, ok, test.dialect)
+		}
+		if got := IsDeclarationPath(test.path); got != test.declaration {
+			t.Fatalf("IsDeclarationPath(%q) = %v, want %v", test.path, got, test.declaration)
+		}
+	}
+
+	if _, ok := DialectForPath("README.md"); ok {
+		t.Fatal("DialectForPath(README.md) unexpectedly supported")
+	}
+}
+
+func TestNormalizeDeterministicAndNonMutating(t *testing.T) {
+	t.Parallel()
+
+	bindingA := Binding{Imported: "z", Local: "localZ"}
+	bindingB := Binding{Imported: "a", Local: "localA", TypeOnly: true}
+	edge := Edge{
+		From:      `.\\src\\entry.ts`,
+		To:        "src/lib.ts",
+		Specifier: "./lib.js",
+		Kind:      ImportESMStatic,
+		Bindings:  []Binding{bindingA, bindingB, bindingA},
+		Position:  Position{Line: 3, Column: 1},
+	}
+	input := Graph{
+		Modules: []Module{
+			{Path: "types/index.d.ts", Dialect: DialectTypeScript, DeclarationOnly: true},
+			{Path: "src/lib.ts", Dialect: DialectTypeScript},
+			{Path: `.\\src\\entry.ts`, Dialect: DialectTypeScript},
+			{Path: "src/lib.ts", Dialect: DialectTypeScript},
+		},
+		Edges: []Edge{
+			edge,
+			{From: "src/entry.ts", Specifier: "pkg", Kind: ImportESMDynamic, Position: Position{Line: 8, Column: 7}},
+			edge,
+		},
+		Roots: []string{"do/not/trust/input.ts"},
+		Coverage: []CoverageIssue{
+			{Kind: CoverageDynamicImport, Path: `.\\src\\entry.ts`, Line: 9, Detail: "computed specifier"},
+			{Kind: CoverageDynamicImport, Path: "src/entry.ts", Line: 9, Detail: "computed specifier"},
+		},
+		FilesScanned: 3,
+		BytesScanned: 128,
+	}
+	before, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var canonical []byte
+	for i := 0; i < 100; i++ {
+		got, err := Normalize(input)
+		if err != nil {
+			t.Fatalf("Normalize: %v", err)
+		}
+		encoded, err := json.Marshal(got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i == 0 {
+			canonical = encoded
+		} else if !reflect.DeepEqual(encoded, canonical) {
+			t.Fatalf("run %d produced non-deterministic output\nfirst: %s\n got: %s", i, canonical, encoded)
+		}
+
+		wantRoots := []string{"src/entry.ts", "types/index.d.ts"}
+		if !reflect.DeepEqual(got.Roots, wantRoots) {
+			t.Fatalf("Roots = %#v, want %#v", got.Roots, wantRoots)
+		}
+		if len(got.Modules) != 3 || len(got.Edges) != 2 || len(got.Coverage) != 1 {
+			t.Fatalf("dedup counts = modules:%d edges:%d coverage:%d", len(got.Modules), len(got.Edges), len(got.Coverage))
+		}
+		if got.Edges[1].Bindings[0] != bindingB || got.Edges[1].Bindings[1] != bindingA {
+			t.Fatalf("bindings not normalized: %#v", got.Edges[1].Bindings)
+		}
+	}
+
+	after, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("Normalize mutated input\nbefore: %s\n after: %s", before, after)
+	}
+}
+
+func TestNormalizeCycleHasNoStructuralRoot(t *testing.T) {
+	t.Parallel()
+
+	got, err := Normalize(Graph{
+		Modules: []Module{
+			{Path: "a.ts", Dialect: DialectTypeScript},
+			{Path: "b.ts", Dialect: DialectTypeScript},
+		},
+		Edges: []Edge{
+			{From: "a.ts", To: "b.ts", Specifier: "./b", Kind: ImportESMStatic},
+			{From: "b.ts", To: "a.ts", Specifier: "./a", Kind: ImportESMStatic},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Roots) != 0 {
+		t.Fatalf("Roots = %#v, want none", got.Roots)
+	}
+}
+
+func TestNormalizeRejectsContractViolations(t *testing.T) {
+	t.Parallel()
+
+	validModule := Module{Path: "a.ts", Dialect: DialectTypeScript}
+	tests := []struct {
+		name  string
+		graph Graph
+		part  string
+	}{
+		{name: "negative files", graph: Graph{FilesScanned: -1}, part: "negative files"},
+		{name: "negative bytes", graph: Graph{BytesScanned: -1}, part: "negative bytes"},
+		{name: "unsupported extension", graph: Graph{Modules: []Module{{Path: "a.go", Dialect: DialectTypeScript}}}, part: "unsupported source extension"},
+		{name: "dialect mismatch", graph: Graph{Modules: []Module{{Path: "a.ts", Dialect: DialectJavaScript}}}, part: "does not match"},
+		{name: "declaration mismatch", graph: Graph{Modules: []Module{{Path: "a.d.ts", Dialect: DialectTypeScript}}}, part: "declaration-only"},
+		{name: "invalid kind", graph: Graph{Modules: []Module{validModule}, Edges: []Edge{{From: "a.ts", Kind: "mystery"}}}, part: "invalid import kind"},
+		{name: "missing source", graph: Graph{Modules: []Module{validModule}, Edges: []Edge{{From: "missing.ts", Kind: ImportESMStatic}}}, part: "not a known module"},
+		{name: "missing target", graph: Graph{Modules: []Module{validModule}, Edges: []Edge{{From: "a.ts", To: "missing.ts", Kind: ImportESMStatic}}}, part: "not a known module"},
+		{name: "invalid coverage kind", graph: Graph{Modules: []Module{validModule}, Coverage: []CoverageIssue{{Kind: "mystery"}}}, part: "invalid coverage issue kind"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Normalize(test.graph)
+			if err == nil || !strings.Contains(err.Error(), test.part) {
+				t.Fatalf("Normalize error = %v, want substring %q", err, test.part)
+			}
+		})
+	}
+}

--- a/internal/usecase/ports/jsimports.go
+++ b/internal/usecase/ports/jsimports.go
@@ -1,0 +1,18 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+// JSImportScanner builds a deterministic, source-only JavaScript and TypeScript
+// module graph beneath root.
+//
+// Implementations must not execute project code, package managers, bundlers, or
+// lifecycle scripts; must not access the network; must honor context
+// cancellation; and must surface incomplete observation as structured coverage
+// issues rather than silently converting unknown behavior into a negative.
+type JSImportScanner interface {
+	Scan(ctx context.Context, root string) (modulegraph.Graph, error)
+}

--- a/internal/usecase/ports/jsimports_test.go
+++ b/internal/usecase/ports/jsimports_test.go
@@ -1,0 +1,22 @@
+package ports
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+type compileTimeJSImportScanner struct{}
+
+func (compileTimeJSImportScanner) Scan(context.Context, string) (modulegraph.Graph, error) {
+	return modulegraph.Graph{}, nil
+}
+
+func TestJSImportScannerContract(t *testing.T) {
+	t.Parallel()
+	var scanner JSImportScanner = compileTimeJSImportScanner{}
+	if scanner == nil {
+		t.Fatal("scanner is nil")
+	}
+}

--- a/internal/usecase/ports/jsimports_test.go
+++ b/internal/usecase/ports/jsimports_test.go
@@ -2,7 +2,6 @@ package ports
 
 import (
 	"context"
-	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
 )
@@ -13,10 +12,4 @@ func (compileTimeJSImportScanner) Scan(context.Context, string) (modulegraph.Gra
 	return modulegraph.Graph{}, nil
 }
 
-func TestJSImportScannerContract(t *testing.T) {
-	t.Parallel()
-	var scanner JSImportScanner = compileTimeJSImportScanner{}
-	if scanner == nil {
-		t.Fatal("scanner is nil")
-	}
-}
+var _ JSImportScanner = compileTimeJSImportScanner{}


### PR DESCRIPTION
## Summary
Adds Phase 5A domain types (\internal/domain/modulegraph\) and driven scanner port (\internal/usecase/ports.JSImportScanner\) for JS/TS module import graph (Issue #379, Epic #378).

### Scope (5-file allowlist)
- \internal/domain/modulegraph/modulegraph.go\
- \internal/domain/modulegraph/normalize.go\
- \internal/domain/modulegraph/normalize_test.go\
- \internal/usecase/ports/jsimports.go\
- \internal/usecase/ports/jsimports_test.go\

### Status
**PARTIAL / STOPPED**
- Focused Phase 5A validation: **PASS** (100% 5/5 focused checks).
- Full repository validation: **INCOMPLETE**.
  - \make build\ and \make vet\: **PASS**.
  - \make test\: **STOPPED** at existing \internal/infrastructure/sandbox\ rootfs integration test.
  - \make typecheck\: **PASS** (run separately after \un-all.sh\ stopped).

### Baseline & Failure Analysis
- **Starting commit**: \5c3f4a8418202e3eef98d16ec8fc251807133b2f\
- **Ending commit**: \5c3f4a8418202e3eef98d16ec8fc251807133b2f\ (commit \dbb57bf\)
- **Failure Class**: \FULL_REPOSITORY_FAILURE_UNRELATED\
- **Baseline Reproduction Proof**: Tested \go test ./internal/infrastructure/sandbox\ on an un-patched baseline worktree at commit \5c3f4a8418202e3eef98d16ec8fc251807133b2f\; produced the exact same failure (\TestSandboxHidesHostSecrets\ - \sh: 1: Cannot fork\ due to WSL sandbox rootfs environment).

### Validation Results
- \sha256sum -c CHECKSUMS.sha256\: **PASS**
- \./source/scripts/verify-source-layout.sh\: **PASS**
- \git diff --check\: **PASS** (0 formatting/whitespace issues)
- \gofmt -l <five files>\: **PASS**
- \go test ./internal/domain/modulegraph ./internal/usecase/ports\: **PASS** (0.008s / 0.006s)
- \go vet ./internal/domain/modulegraph ./internal/usecase/ports\: **PASS**
- \CGO_ENABLED=0 go test ./internal/domain/modulegraph ./internal/usecase/ports\: **PASS**
- \make build\: **PASS**
- \make vet\: **PASS**
- \make test\: **FAIL (Stopped)** — \alidation/run-all.sh\ stopped here due to pre-existing \internal/infrastructure/sandbox\ rootfs integration test (outside Phase 5A scope; reproduced identically on clean baseline \5c3f4a8\).
- \make typecheck\: **PASS (Separate)** — executed separately after \un-all.sh\ stopped (\	sc --noEmit\ clean 100%).

### Safety & Contract Invariants
- Patch adds NO runtime JS/TS execution, package manager invocation, bundler invocation, or lifecycle script to the analyzer. (Repository validation \make typecheck\ runs existing \pnpm run typecheck\).
- Patch adds no network access. No network access was observed in validation logs.
- Unknown / no coverage semantics were not weakened.
- Structural roots are structural roots only, not described as runtime entrypoints.

Refs #379
