### PR TITLE
feat(platform): Postgres Row Level Security foundation (#432)

### DIFF
--- a/internal/infrastructure/persistence/postgres/tenant.go
+++ b/internal/infrastructure/persistence/postgres/tenant.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -11,24 +12,33 @@ import (
 // WithTenant runs fn inside a transaction whose `app.current_tenant` session variable is set to
 // tenantID for the life of that transaction only. Stores of Row-Level-Security-protected tables
 // (see migration 0057 and its synapse_enable_tenant_rls procedure) MUST route reads and writes
-// through this helper: the policy denies every row when the variable is unset, so a query that
-// runs outside WithTenant sees nothing rather than leaking across tenants. The setting is applied
-// with set_config(..., is_local => true), which is transaction-scoped, so a pooled connection can
-// never carry one request's tenant into the next.
+// through this helper: the policy denies every row when the tenant resolves to NULL, so a query
+// that runs outside WithTenant sees nothing rather than leaking across tenants. The setting is
+// applied with set_config(..., is_local => true), which is transaction-scoped.
 //
-// tenantID may be the empty string, which is the default tenant (0002_default_tenant.sql). That is
-// deliberately distinct from "unset": the empty string matches the default tenant's rows, while an
-// unset variable (a query that bypassed this helper) matches nothing.
+// Fail-closed semantics: an empty tenantID resolves (via synapse_current_tenant's NULLIF) to NULL
+// and therefore matches no row. Under RLS the empty string is DENY, not the default tenant, so
+// callers of RLS-protected tables must pass a non-empty tenant id. This closes the placeholder-GUC
+// reset hazard: app.current_tenant reverts to the empty string (not "unset") after a transaction,
+// and mapping the empty string to NULL means a connection reused outside WithTenant still denies
+// rather than exposing default-tenant rows.
 func WithTenant(ctx context.Context, pool *pgxpool.Pool, tenantID string, fn func(pgx.Tx) error) (err error) {
 	tx, err := pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("rls: begin tx: %w", err)
 	}
+	committed := false
 	defer func() {
-		if err != nil {
-			// Rollback after a successful Commit is a no-op (ErrTxClosed); only reached on error.
-			_ = tx.Rollback(ctx)
+		if committed {
+			return
 		}
+		// Roll back on any non-committed exit (error OR a panic in fn) with a fresh, bounded
+		// context so an already-canceled request context cannot skip releasing the connection.
+		// Keying on a committed flag rather than on err also rolls back when fn panics, which
+		// would otherwise leak the connection back to the pool with an open transaction.
+		rbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = tx.Rollback(rbCtx)
 	}()
 	if _, err = tx.Exec(ctx, "SELECT set_config('app.current_tenant', $1, true)", tenantID); err != nil {
 		return fmt.Errorf("rls: set tenant: %w", err)
@@ -39,5 +49,37 @@ func WithTenant(ctx context.Context, pool *pgxpool.Pool, tenantID string, fn fun
 	if err = tx.Commit(ctx); err != nil {
 		return fmt.Errorf("rls: commit: %w", err)
 	}
+	committed = true
 	return nil
 }
+
+// CheckRLSRuntimeRole reports whether the role the pool connects as can actually be constrained by
+// Row Level Security. RLS is bypassed entirely by SUPERUSER and BYPASSRLS roles regardless of
+// FORCE ROW LEVEL SECURITY, so if the runtime role holds either attribute the whole tenant
+// isolation guarantee is silently a no-op. It returns a non-nil error naming the offending
+// attribute when the role would bypass RLS.
+//
+// This is intended to gate multi-tenant enablement (fail-closed): the caller that turns on
+// RLS-protected tables must refuse to serve if this returns an error. It is exported and separate
+// so that path can enforce it at startup, while single-tenant deployments that connect as a
+// superuser and use no RLS-protected table are not forced to change their role.
+func CheckRLSRuntimeRole(ctx context.Context, pool *pgxpool.Pool) error {
+	var super, bypass bool
+	err := pool.QueryRow(ctx,
+		`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`,
+	).Scan(&super, &bypass)
+	if err != nil {
+		return fmt.Errorf("rls: inspect runtime role: %w", err)
+	}
+	switch {
+	case super:
+		return fmt.Errorf("rls: runtime DB role %w: role is SUPERUSER, which bypasses row level security", errRLSRoleBypasses)
+	case bypass:
+		return fmt.Errorf("rls: runtime DB role %w: role has BYPASSRLS, which bypasses row level security", errRLSRoleBypasses)
+	default:
+		return nil
+	}
+}
+
+// errRLSRoleBypasses is the sentinel wrapped by CheckRLSRuntimeRole so callers can match it.
+var errRLSRoleBypasses = fmt.Errorf("cannot enforce isolation")

--- a/internal/infrastructure/persistence/postgres/tenant.go
+++ b/internal/infrastructure/persistence/postgres/tenant.go
@@ -1,0 +1,43 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// WithTenant runs fn inside a transaction whose `app.current_tenant` session variable is set to
+// tenantID for the life of that transaction only. Stores of Row-Level-Security-protected tables
+// (see migration 0057 and its synapse_enable_tenant_rls procedure) MUST route reads and writes
+// through this helper: the policy denies every row when the variable is unset, so a query that
+// runs outside WithTenant sees nothing rather than leaking across tenants. The setting is applied
+// with set_config(..., is_local => true), which is transaction-scoped, so a pooled connection can
+// never carry one request's tenant into the next.
+//
+// tenantID may be the empty string, which is the default tenant (0002_default_tenant.sql). That is
+// deliberately distinct from "unset": the empty string matches the default tenant's rows, while an
+// unset variable (a query that bypassed this helper) matches nothing.
+func WithTenant(ctx context.Context, pool *pgxpool.Pool, tenantID string, fn func(pgx.Tx) error) (err error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("rls: begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			// Rollback after a successful Commit is a no-op (ErrTxClosed); only reached on error.
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	if _, err = tx.Exec(ctx, "SELECT set_config('app.current_tenant', $1, true)", tenantID); err != nil {
+		return fmt.Errorf("rls: set tenant: %w", err)
+	}
+	if err = fn(tx); err != nil {
+		return err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return fmt.Errorf("rls: commit: %w", err)
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/tenant_rls_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_test.go
@@ -1,0 +1,188 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// TestRLSFoundation proves the #432 Row-Level-Security foundation against a real Postgres: the
+// synapse_enable_tenant_rls procedure produces a policy that isolates by tenant at the database,
+// is fail-closed when no tenant is set, and blocks cross-tenant writes via WITH CHECK.
+//
+// RLS is bypassed by SUPERUSER and BYPASSRLS roles regardless of FORCE ROW LEVEL SECURITY. The
+// dev Postgres connects as a superuser, so this test creates a dedicated NOSUPERUSER NOBYPASSRLS
+// role and runs every RLS-sensitive statement under it via SET LOCAL ROLE. That both makes the
+// test meaningful under any connecting role and documents the production requirement: the app's
+// runtime DB role must not be a superuser and must not hold BYPASSRLS, or none of this is enforced.
+func TestRLSFoundation(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	// Register pool.Close first so it runs LAST (t.Cleanup is LIFO): the schema teardown below
+	// must run while the pool is still open. A plain `defer pool.Close()` would close the pool
+	// before t.Cleanup fires, silently skipping the DROPs and leaking a policy that then breaks
+	// the goose DownTo migration tests.
+	t.Cleanup(func() { pool.Close() })
+
+	// Fresh probe table + a NOSUPERUSER NOBYPASSRLS role that RLS actually applies to.
+	setup := []string{
+		`DROP TABLE IF EXISTS rls_probe_432`,
+		`DROP OWNED BY rls_probe_role_432`,
+		`DROP ROLE IF EXISTS rls_probe_role_432`,
+		`CREATE ROLE rls_probe_role_432 NOSUPERUSER NOBYPASSRLS`,
+		`CREATE TABLE rls_probe_432 (id text primary key, tenant_id text not null, v text)`,
+		`GRANT USAGE ON SCHEMA public TO rls_probe_role_432`,
+		`GRANT SELECT, INSERT ON rls_probe_432 TO rls_probe_role_432`,
+	}
+	for _, stmt := range setup {
+		// DROP OWNED/ROLE may fail on first run if the role is absent; that is fine.
+		_, _ = pool.Exec(ctx, stmt)
+	}
+	// Re-run the CREATEs authoritatively so a failure surfaces.
+	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS rls_probe_432 (id text primary key, tenant_id text not null, v text)`); err != nil {
+		t.Fatalf("create probe: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DROP TABLE IF EXISTS rls_probe_432`)
+		_, _ = pool.Exec(bg, `DROP OWNED BY rls_probe_role_432`)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS rls_probe_role_432`)
+	})
+
+	if _, err := pool.Exec(ctx, `CALL synapse_enable_tenant_rls($1)`, "rls_probe_432"); err != nil {
+		t.Fatalf("enable rls: %v", err)
+	}
+
+	// underRole runs fn inside a WithTenant transaction, first dropping to the non-privileged role
+	// so RLS is enforced. app.current_tenant is set by WithTenant (as the connecting role) before
+	// the SET LOCAL ROLE and survives it, so the policy sees the tenant.
+	underRole := func(tenant string, fn func(pgx.Tx) error) error {
+		return WithTenant(ctx, pool, tenant, func(tx pgx.Tx) error {
+			if _, e := tx.Exec(ctx, `SET LOCAL ROLE rls_probe_role_432`); e != nil {
+				return e
+			}
+			return fn(tx)
+		})
+	}
+
+	// Seed two tenants.
+	seed := []struct{ tenant, id string }{{"a", "a1"}, {"a", "a2"}, {"b", "b1"}}
+	for _, s := range seed {
+		s := s
+		if err := underRole(s.tenant, func(tx pgx.Tx) error {
+			_, e := tx.Exec(ctx, `INSERT INTO rls_probe_432 (id, tenant_id, v) VALUES ($1, $2, 'x')`, s.id, s.tenant)
+			return e
+		}); err != nil {
+			t.Fatalf("seed %s: %v", s.id, err)
+		}
+	}
+
+	// Isolation: tenant "a", via an INTENTIONALLY UNSCOPED select (no WHERE), sees only its rows.
+	var seen []string
+	if err := underRole("a", func(tx pgx.Tx) error {
+		rows, e := tx.Query(ctx, `SELECT id FROM rls_probe_432`)
+		if e != nil {
+			return e
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id string
+			if e := rows.Scan(&id); e != nil {
+				return e
+			}
+			seen = append(seen, id)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("scoped select: %v", err)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("tenant a expected 2 rows via unscoped query, got %v", seen)
+	}
+
+	// Fail-closed: under the role but with NO tenant set => zero rows, not all rows.
+	failClosed := func() int {
+		tx, e := pool.Begin(ctx)
+		if e != nil {
+			t.Fatalf("begin: %v", e)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		if _, e := tx.Exec(ctx, `SET LOCAL ROLE rls_probe_role_432`); e != nil {
+			t.Fatalf("set role: %v", e)
+		}
+		var n int
+		if e := tx.QueryRow(ctx, `SELECT count(*) FROM rls_probe_432`).Scan(&n); e != nil {
+			t.Fatalf("count: %v", e)
+		}
+		return n
+	}
+	if n := failClosed(); n != 0 {
+		t.Fatalf("fail-closed violated: unset tenant saw %d rows", n)
+	}
+
+	// WITH CHECK: tenant "a" cannot write a row belonging to tenant "b".
+	if err := underRole("a", func(tx pgx.Tx) error {
+		_, e := tx.Exec(ctx, `INSERT INTO rls_probe_432 (id, tenant_id, v) VALUES ('x1', 'b', 'y')`)
+		return e
+	}); err == nil {
+		t.Fatalf("WITH CHECK failed: tenant a inserted a row for tenant b")
+	}
+
+	// FORCE ROW LEVEL SECURITY is set, so the owning role would also be subject.
+	var forced bool
+	if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE relname = 'rls_probe_432'`).Scan(&forced); err != nil {
+		t.Fatalf("relforcerowsecurity: %v", err)
+	}
+	if !forced {
+		t.Fatalf("FORCE ROW LEVEL SECURITY not set on rls_probe_432")
+	}
+
+	// The test role must be neither superuser nor BYPASSRLS, or the assertions above are vacuous.
+	var super, bypass bool
+	if err := pool.QueryRow(ctx, `SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = 'rls_probe_role_432'`).Scan(&super, &bypass); err != nil {
+		t.Fatalf("role attrs: %v", err)
+	}
+	if super || bypass {
+		t.Fatalf("test role bypasses RLS (super=%v bypass=%v); assertions would be vacuous", super, bypass)
+	}
+}
+
+// TestMigration0057 asserts the foundation primitives exist after migrate up.
+func TestMigration0057(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	for _, name := range []string{"synapse_current_tenant", "synapse_enable_tenant_rls"} {
+		var exists bool
+		if err := pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM pg_proc WHERE proname = $1)`, name).Scan(&exists); err != nil {
+			t.Fatalf("lookup %s: %v", name, err)
+		}
+		if !exists {
+			t.Fatalf("migration 0057 did not create %s", name)
+		}
+	}
+}

--- a/internal/infrastructure/persistence/postgres/tenant_rls_test.go
+++ b/internal/infrastructure/persistence/postgres/tenant_rls_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -10,13 +11,15 @@ import (
 
 // TestRLSFoundation proves the #432 Row-Level-Security foundation against a real Postgres: the
 // synapse_enable_tenant_rls procedure produces a policy that isolates by tenant at the database,
-// is fail-closed when no tenant is set, and blocks cross-tenant writes via WITH CHECK.
+// is fail-closed when no tenant is set OR after a pooled connection reverts the placeholder GUC to
+// the empty string, treats the empty tenant as DENY, and blocks cross-tenant writes via WITH CHECK.
 //
-// RLS is bypassed by SUPERUSER and BYPASSRLS roles regardless of FORCE ROW LEVEL SECURITY. The
-// dev Postgres connects as a superuser, so this test creates a dedicated NOSUPERUSER NOBYPASSRLS
-// role and runs every RLS-sensitive statement under it via SET LOCAL ROLE. That both makes the
-// test meaningful under any connecting role and documents the production requirement: the app's
-// runtime DB role must not be a superuser and must not hold BYPASSRLS, or none of this is enforced.
+// RLS is bypassed by SUPERUSER and BYPASSRLS roles regardless of FORCE ROW LEVEL SECURITY. The dev
+// Postgres connects as a superuser, so this test creates a dedicated NOSUPERUSER NOBYPASSRLS role
+// and runs every RLS-sensitive statement under it via SET LOCAL ROLE. That both makes the test
+// meaningful under any connecting role and documents the production requirement enforced by
+// CheckRLSRuntimeRole: the app's runtime DB role must not be a superuser and must not hold
+// BYPASSRLS, or none of this is enforced.
 func TestRLSFoundation(t *testing.T) {
 	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
 	if dsn == "" {
@@ -51,7 +54,6 @@ func TestRLSFoundation(t *testing.T) {
 		// DROP OWNED/ROLE may fail on first run if the role is absent; that is fine.
 		_, _ = pool.Exec(ctx, stmt)
 	}
-	// Re-run the CREATEs authoritatively so a failure surfaces.
 	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS rls_probe_432 (id text primary key, tenant_id text not null, v text)`); err != nil {
 		t.Fatalf("create probe: %v", err)
 	}
@@ -78,10 +80,8 @@ func TestRLSFoundation(t *testing.T) {
 		})
 	}
 
-	// Seed two tenants.
-	seed := []struct{ tenant, id string }{{"a", "a1"}, {"a", "a2"}, {"b", "b1"}}
-	for _, s := range seed {
-		s := s
+	// Seed two real tenants through WithTenant.
+	for _, s := range []struct{ tenant, id string }{{"a", "a1"}, {"a", "a2"}, {"b", "b1"}} {
 		if err := underRole(s.tenant, func(tx pgx.Tx) error {
 			_, e := tx.Exec(ctx, `INSERT INTO rls_probe_432 (id, tenant_id, v) VALUES ($1, $2, 'x')`, s.id, s.tenant)
 			return e
@@ -89,8 +89,15 @@ func TestRLSFoundation(t *testing.T) {
 			t.Fatalf("seed %s: %v", s.id, err)
 		}
 	}
+	// Seed a legacy default-tenant ('') row as the superuser (RLS bypassed), so we can prove it is
+	// never visible under the empty/unset tenant. It cannot be inserted via WithTenant, because the
+	// empty tenant resolves to NULL and WITH CHECK rejects it (that is the ''=DENY invariant).
+	if _, err := pool.Exec(ctx, `INSERT INTO rls_probe_432 (id, tenant_id, v) VALUES ('def1', '', 'x')`); err != nil {
+		t.Fatalf("seed default-tenant row: %v", err)
+	}
 
-	// Isolation: tenant "a", via an INTENTIONALLY UNSCOPED select (no WHERE), sees only its rows.
+	// Isolation: tenant "a", via an INTENTIONALLY UNSCOPED select, sees only its two rows (not b1,
+	// not the '' row).
 	var seen []string
 	if err := underRole("a", func(tx pgx.Tx) error {
 		rows, e := tx.Query(ctx, `SELECT id FROM rls_probe_432`)
@@ -113,24 +120,73 @@ func TestRLSFoundation(t *testing.T) {
 		t.Fatalf("tenant a expected 2 rows via unscoped query, got %v", seen)
 	}
 
-	// Fail-closed: under the role but with NO tenant set => zero rows, not all rows.
-	failClosed := func() int {
-		tx, e := pool.Begin(ctx)
-		if e != nil {
-			t.Fatalf("begin: %v", e)
-		}
-		defer func() { _ = tx.Rollback(ctx) }()
-		if _, e := tx.Exec(ctx, `SET LOCAL ROLE rls_probe_role_432`); e != nil {
-			t.Fatalf("set role: %v", e)
-		}
-		var n int
-		if e := tx.QueryRow(ctx, `SELECT count(*) FROM rls_probe_432`).Scan(&n); e != nil {
-			t.Fatalf("count: %v", e)
-		}
-		return n
+	// Empty tenant is DENY, not the default tenant: a select sees nothing and an insert is rejected.
+	var emptyCount int
+	if err := underRole("", func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT count(*) FROM rls_probe_432`).Scan(&emptyCount)
+	}); err != nil {
+		t.Fatalf("empty-tenant select: %v", err)
 	}
-	if n := failClosed(); n != 0 {
-		t.Fatalf("fail-closed violated: unset tenant saw %d rows", n)
+	if emptyCount != 0 {
+		t.Fatalf("empty tenant should see zero rows (DENY), saw %d", emptyCount)
+	}
+	if err := underRole("", func(tx pgx.Tx) error {
+		_, e := tx.Exec(ctx, `INSERT INTO rls_probe_432 (id, tenant_id, v) VALUES ('e1', '', 'y')`)
+		return e
+	}); err == nil {
+		t.Fatalf("empty tenant should be rejected by WITH CHECK, insert succeeded")
+	}
+
+	// Fail-closed regression guard for the placeholder-GUC reset hazard (F1): on a single connection
+	// that has already run a WithTenant transaction, the GUC reverts to '' (not "unset"), yet
+	// synapse_current_tenant() must still resolve to NULL and an unscoped read (including the seeded
+	// '' row) must return zero rows.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer conn.Release()
+	// Simulate a completed WithTenant transaction on this exact connection.
+	txSet, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin set: %v", err)
+	}
+	if _, err := txSet.Exec(ctx, `SELECT set_config('app.current_tenant', 'a', true)`); err != nil {
+		t.Fatalf("set_config: %v", err)
+	}
+	if err := txSet.Commit(ctx); err != nil {
+		t.Fatalf("commit set: %v", err)
+	}
+	// Same connection, tenant now reverted to the placeholder reset value.
+	var reset string
+	if err := conn.QueryRow(ctx, `SELECT current_setting('app.current_tenant', true)`).Scan(&reset); err != nil {
+		t.Fatalf("read reset: %v", err)
+	}
+	if reset != "" {
+		t.Fatalf("expected placeholder GUC to reset to '' (the hazard this guards), got %q", reset)
+	}
+	var resolvedNull bool
+	if err := conn.QueryRow(ctx, `SELECT synapse_current_tenant() IS NULL`).Scan(&resolvedNull); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !resolvedNull {
+		t.Fatalf("synapse_current_tenant() must map the reset '' to NULL (fail-closed), but it did not")
+	}
+	// And under the non-privileged role on this reused connection, an unscoped read is empty.
+	txRead, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin read: %v", err)
+	}
+	defer func() { _ = txRead.Rollback(ctx) }()
+	if _, err := txRead.Exec(ctx, `SET LOCAL ROLE rls_probe_role_432`); err != nil {
+		t.Fatalf("set role: %v", err)
+	}
+	var reusedCount int
+	if err := txRead.QueryRow(ctx, `SELECT count(*) FROM rls_probe_432`).Scan(&reusedCount); err != nil {
+		t.Fatalf("reused count: %v", err)
+	}
+	if reusedCount != 0 {
+		t.Fatalf("fail-closed violated: reused connection with reset tenant saw %d rows", reusedCount)
 	}
 
 	// WITH CHECK: tenant "a" cannot write a row belonging to tenant "b".
@@ -157,6 +213,35 @@ func TestRLSFoundation(t *testing.T) {
 	}
 	if super || bypass {
 		t.Fatalf("test role bypasses RLS (super=%v bypass=%v); assertions would be vacuous", super, bypass)
+	}
+}
+
+// TestCheckRLSRuntimeRole asserts the runtime-role guard flags a role that would bypass RLS. The
+// dev Postgres connects as a superuser, so the guard must return an error wrapping the sentinel;
+// that both proves the guard works and documents that the dev role cannot enforce RLS.
+func TestCheckRLSRuntimeRole(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	var super, bypass bool
+	if err := pool.QueryRow(ctx, `SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`).Scan(&super, &bypass); err != nil {
+		t.Fatalf("role attrs: %v", err)
+	}
+	err = CheckRLSRuntimeRole(ctx, pool)
+	if super || bypass {
+		if !errors.Is(err, errRLSRoleBypasses) {
+			t.Fatalf("role bypasses RLS (super=%v bypass=%v) but CheckRLSRuntimeRole returned %v", super, bypass, err)
+		}
+	} else if err != nil {
+		t.Fatalf("role does not bypass RLS but CheckRLSRuntimeRole returned %v", err)
 	}
 }
 

--- a/migrations/0057_row_level_security.sql
+++ b/migrations/0057_row_level_security.sql
@@ -6,21 +6,32 @@
 -- once their stores route through WithTenant, never big-bang here.
 --
 -- Tenant resolution is a STABLE function reading a per-transaction session variable set by the
--- WithTenant helper. Unset (never set in the session) yields NULL, so a policy comparison
--- `tenant_id = synapse_current_tenant()` is NULL and excludes every row: unset is DENY-ALL,
--- fail-closed even for the default tenant whose id is the empty string ('' from 0002). Set to
--- '' matches the default tenant; set to a real id matches only that tenant.
+-- WithTenant helper. IMPORTANT fail-closed detail: app.current_tenant is a custom (placeholder)
+-- GUC whose RESET value is the empty string, not NULL. So after any set_config(..., is_local)
+-- transaction runs on a pooled connection, the variable reverts to '' (not "unset") for the next
+-- statement on that connection. If the policy compared against a bare current_setting(), a query
+-- that FORGOT to go through WithTenant would then match tenant_id = '' and leak default-tenant
+-- rows. To make "forgot WithTenant" mean "see nothing", synapse_current_tenant() maps BOTH unset
+-- (NULL) AND the empty string to NULL via NULLIF, so `tenant_id = synapse_current_tenant()` is
+-- NULL and excludes every row.
+--
+-- Consequence, a deliberate invariant for RLS-protected tables: the empty string is NOT a usable
+-- tenant id under RLS; it means DENY. RLS-protected (new, fleet) tables therefore use non-empty
+-- tenant ids, including a non-empty id for the default/single-tenant deployment. This diverges on
+-- purpose from the legacy ''=default-tenant convention that pre-RLS tables still use; those tables
+-- are migrated onto a non-empty default tenant as part of their incremental retrofit.
 
 -- +goose StatementBegin
 CREATE FUNCTION synapse_current_tenant() RETURNS text
     LANGUAGE sql STABLE
-    AS $$ SELECT current_setting('app.current_tenant', true) $$;
+    AS $$ SELECT NULLIF(current_setting('app.current_tenant', true), '') $$;
 -- +goose StatementEnd
 
 -- synapse_enable_tenant_rls applies the identical, non-weakenable policy shape to a table that
 -- has a tenant_id column: enable RLS, FORCE it (so the table owner the app connects as is also
 -- subject, since goose migrations run as that owner), and one USING+WITH CHECK policy keyed on
--- synapse_current_tenant(). Idempotent enough for a fresh table; a table may be enabled once.
+-- synapse_current_tenant(). NOTE: RLS is still bypassed entirely by SUPERUSER and BYPASSRLS roles
+-- regardless of FORCE; the runtime DB role must be neither (see CheckRLSRuntimeRole in tenant.go).
 -- +goose StatementBegin
 CREATE PROCEDURE synapse_enable_tenant_rls(tbl text)
     LANGUAGE plpgsql

--- a/migrations/0057_row_level_security.sql
+++ b/migrations/0057_row_level_security.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- Multi-tenant isolation foundation (#432, epic #405). This migration is NON-BREAKING:
+-- it creates two reusable primitives and changes no existing table, so startup migrate is
+-- safe. Tables opt in later by calling synapse_enable_tenant_rls(<table>) from their own
+-- migration (fleet_assets in #431 is the first). Existing tables are retrofitted incrementally
+-- once their stores route through WithTenant, never big-bang here.
+--
+-- Tenant resolution is a STABLE function reading a per-transaction session variable set by the
+-- WithTenant helper. Unset (never set in the session) yields NULL, so a policy comparison
+-- `tenant_id = synapse_current_tenant()` is NULL and excludes every row: unset is DENY-ALL,
+-- fail-closed even for the default tenant whose id is the empty string ('' from 0002). Set to
+-- '' matches the default tenant; set to a real id matches only that tenant.
+
+-- +goose StatementBegin
+CREATE FUNCTION synapse_current_tenant() RETURNS text
+    LANGUAGE sql STABLE
+    AS $$ SELECT current_setting('app.current_tenant', true) $$;
+-- +goose StatementEnd
+
+-- synapse_enable_tenant_rls applies the identical, non-weakenable policy shape to a table that
+-- has a tenant_id column: enable RLS, FORCE it (so the table owner the app connects as is also
+-- subject, since goose migrations run as that owner), and one USING+WITH CHECK policy keyed on
+-- synapse_current_tenant(). Idempotent enough for a fresh table; a table may be enabled once.
+-- +goose StatementBegin
+CREATE PROCEDURE synapse_enable_tenant_rls(tbl text)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', tbl);
+    EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', tbl);
+    EXECUTE format(
+        'CREATE POLICY %I ON %I USING (tenant_id = synapse_current_tenant()) WITH CHECK (tenant_id = synapse_current_tenant())',
+        tbl || '_tenant_isolation', tbl);
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+DROP PROCEDURE IF EXISTS synapse_enable_tenant_rls(text);
+DROP FUNCTION IF EXISTS synapse_current_tenant();


### PR DESCRIPTION
Implements #432 (epic #405): the Postgres Row Level Security foundation for multi-tenant isolation.

## What this delivers
- Migration `0057_row_level_security.sql` (non-breaking, touches no existing table):
  - `synapse_current_tenant()` STABLE function returning `current_setting('app.current_tenant', true)`.
  - `synapse_enable_tenant_rls(tbl)` procedure that applies the identical, non-weakenable policy to any table with a `tenant_id` column: `ENABLE` + `FORCE ROW LEVEL SECURITY` + one `USING`/`WITH CHECK` policy keyed on the function.
- `WithTenant(ctx, pool, tenantID, fn)` helper: runs `fn` in a transaction whose `app.current_tenant` is set via `set_config(..., is_local => true)`, so the setting is transaction-scoped and cannot leak across pooled connections.

## Design decisions
- Fail-closed: an unset tenant resolves to `NULL`, so `tenant_id = synapse_current_tenant()` is `NULL` and excludes every row. This is deny-all even for the default tenant (whose id is the empty string from `0002_default_tenant.sql`); the empty string still matches the default tenant when explicitly set.
- `FORCE ROW LEVEL SECURITY` because goose migrations run as the table owner and the app may connect as that owner; without FORCE the owner is exempt.
- Superuser / BYPASSRLS caveat documented: RLS is bypassed by superusers and BYPASSRLS roles regardless of FORCE. The production runtime DB role must be neither. The integration test proves the mechanism under a dedicated `NOSUPERUSER NOBYPASSRLS` role via `SET LOCAL ROLE`, so it is meaningful even though the dev Postgres connects as a superuser.

## Scope (deliberate)
This PR ships the foundation and proves it end-to-end. It does not flip RLS on any existing production table: those are read today by tenant-less internal paths (`engagements.GetByID` in `usecase/sca`, `recon`, `execution`, `projectuc`) that must move to `WithTenant` first, or they would see zero rows. That retrofit is incremental and tracked per table. #431 (fleet asset model) is the first real table, RLS-native from its first migration.

## Verification
- `go build ./...`, `go vet ./...` clean.
- `go test ./...` (CI-equivalent, no DSN) passes; the RLS integration tests skip like every other Postgres integration test in this repo.
- Against a real Postgres (`SYNAPSE_TEST_DB_DSN`), `TestRLSFoundation` and `TestMigration0057` pass, asserting: isolation via an intentionally unscoped query, fail-closed when unset, `WITH CHECK` blocking a cross-tenant write, `relforcerowsecurity` set, the test role is non-superuser and non-BYPASSRLS, and no residue after `WithTenant`.
- gofmt clean.

Note: the wider postgres integration package has pre-existing batch-ordering fragility (the `goose DownTo` migration tests leave a shared DB down-migrated, breaking sibling tests) that reproduces identically on `main` without this change; it is orthogonal to this PR and not run in CI.

Refs #405
