### PR TITLE
feat(fleet): fleet asset model, multi-tenant and RLS-enforced (#431)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -92,6 +92,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/agenttools"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
 	audituc "github.com/KKloudTarus/synapse-ce/internal/usecase/audit"
 	aupuc "github.com/KKloudTarus/synapse-ce/internal/usecase/aup"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/codequality"
@@ -166,6 +167,7 @@ func main() {
 	// Persistence: PostgreSQL when configured, else file + in-memory (dev).
 	var repo ports.EngagementRepository
 	var projectRepo ports.ProjectRepository
+	var assetStore ports.AssetRepository
 	var findingRepo ports.FindingRepository
 	var judgmentStore analysisuc.Store // postgres or memory; satisfies both the narrow Store + ports.JudgmentStore
 	var commentRepo ports.CommentRepository
@@ -285,6 +287,16 @@ func main() {
 		advisoryStore = postgres.NewAdvisoryRepository(pool)
 		threatModelStore = postgres.NewThreatModelRepository(pool)
 		writeupDraftStore = postgres.NewWriteupDraftRepository(pool)
+		assetStore = postgres.NewAssetRepository(pool)
+		// SECURITY (#431 req 6, #432): the fleet_assets tables are RLS-protected, but RLS is a
+		// silent no-op if the runtime DB role is SUPERUSER or holds BYPASSRLS. When the asset model
+		// is enabled we refuse to serve unless the role can actually enforce isolation.
+		if cfg.FleetAssetsEnabled {
+			if rerr := postgres.CheckRLSRuntimeRole(startup, pool); rerr != nil {
+				log.Error("fleet assets enabled but the DB role cannot enforce row level security – refusing to serve", "err", rerr)
+				os.Exit(1)
+			}
+		}
 		aupStore = postgres.NewAUPStore(pool)
 		pgAudit := postgres.NewAuditLog(pool)
 		auditLog, auditReader = pgAudit, pgAudit
@@ -305,6 +317,7 @@ func main() {
 	} else {
 		repo = memory.NewEngagementRepository()
 		projectRepo = memory.NewProjectRepository()
+		assetStore = memory.NewAssetStore()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
 		commentRepo = memory.NewCommentRepository()
@@ -1015,6 +1028,15 @@ func main() {
 		writeupDraftSvc.SetFindingWriteupApplier(findingsService) // on accept, apply the draft's prose to its finding (validated finding∈engagement + audited)
 		router.SetWriteupDrafts(writeupDraftSvc)                  // human sign-off HTTP routes (list/edit/accept/reject; PermReview + SoD + withEngTenant)
 		log.Info("writeup draft proposals ENABLED (agent proposes prose; a distinct human signs off)")
+	}
+	if cfg.FleetAssetsEnabled {
+		svc, derr := assetuc.NewService(assetStore, auditLog, clock, ids)
+		if derr != nil {
+			log.Error("asset service init failed", "err", derr)
+			os.Exit(1)
+		}
+		router.SetAssets(svc)
+		log.Info("fleet asset model ENABLED (multi-tenant, Postgres RLS-enforced)")
 	}
 	// deterministic Tier-2 reachability proof in the scan pipeline (opt-in). It mints reachability
 	// judgments, so it requires the judgment lifecycle. The govulncheck builder shares the SCA sandbox when

--- a/internal/adapter/httpapi/asset_handler.go
+++ b/internal/adapter/httpapi/asset_handler.go
@@ -1,0 +1,130 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
+)
+
+// assetService is the narrow view of the asset use case the HTTP layer needs. It is optional: when
+// nil, the asset routes are not registered (see router.go).
+type assetService interface {
+	UpsertAsset(context.Context, string, assetuc.UpsertAssetInput) (*asset.Asset, error)
+	ListAssets(context.Context, shared.ID) ([]*asset.Asset, error)
+	UpsertEdge(context.Context, string, assetuc.EdgeInput) error
+	ListEdges(context.Context, shared.ID) ([]*asset.Edge, error)
+	UpsertBusinessService(context.Context, string, assetuc.BusinessServiceInput) (*asset.BusinessService, error)
+	ListBusinessServices(context.Context, shared.ID) ([]*asset.BusinessService, error)
+}
+
+// SetAssets wires the asset service and enables the asset routes.
+func (rt *Router) SetAssets(s assetService) { rt.assets = s }
+
+const assetBodyCap = 64 << 10
+
+type upsertAssetRequest struct {
+	Kind       string            `json:"kind"`
+	Key        string            `json:"key"`
+	Name       string            `json:"name"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+func (rt *Router) createAsset(w http.ResponseWriter, r *http.Request) {
+	var req upsertAssetRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, assetBodyCap)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid asset body"})
+		return
+	}
+	a, err := rt.assets.UpsertAsset(r.Context(), PrincipalFrom(r.Context()), assetuc.UpsertAssetInput{
+		TenantID:   shared.ID(TenantFrom(r.Context())),
+		Kind:       asset.Kind(req.Kind),
+		Key:        req.Key,
+		Name:       req.Name,
+		Attributes: req.Attributes,
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, a)
+}
+
+func (rt *Router) listAssets(w http.ResponseWriter, r *http.Request) {
+	list, err := rt.assets.ListAssets(r.Context(), shared.ID(TenantFrom(r.Context())))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, list)
+}
+
+type upsertEdgeRequest struct {
+	From       string `json:"from"`
+	To         string `json:"to"`
+	Kind       string `json:"kind"`
+	Provenance string `json:"provenance"`
+}
+
+func (rt *Router) createAssetEdge(w http.ResponseWriter, r *http.Request) {
+	var req upsertEdgeRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, assetBodyCap)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid edge body"})
+		return
+	}
+	if err := rt.assets.UpsertEdge(r.Context(), PrincipalFrom(r.Context()), assetuc.EdgeInput{
+		TenantID:   shared.ID(TenantFrom(r.Context())),
+		From:       shared.ID(req.From),
+		To:         shared.ID(req.To),
+		Kind:       asset.EdgeKind(req.Kind),
+		Provenance: shared.ID(req.Provenance),
+	}); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (rt *Router) listAssetEdges(w http.ResponseWriter, r *http.Request) {
+	list, err := rt.assets.ListEdges(r.Context(), shared.ID(TenantFrom(r.Context())))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, list)
+}
+
+type upsertServiceRequest struct {
+	Name  string `json:"name"`
+	Owner string `json:"owner"`
+}
+
+func (rt *Router) createBusinessService(w http.ResponseWriter, r *http.Request) {
+	var req upsertServiceRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, assetBodyCap)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid business service body"})
+		return
+	}
+	svc, err := rt.assets.UpsertBusinessService(r.Context(), PrincipalFrom(r.Context()), assetuc.BusinessServiceInput{
+		TenantID: shared.ID(TenantFrom(r.Context())),
+		Name:     req.Name,
+		Owner:    req.Owner,
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, svc)
+}
+
+func (rt *Router) listBusinessServices(w http.ResponseWriter, r *http.Request) {
+	list, err := rt.assets.ListBusinessServices(r.Context(), shared.ID(TenantFrom(r.Context())))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, list)
+}

--- a/internal/adapter/httpapi/asset_handler.go
+++ b/internal/adapter/httpapi/asset_handler.go
@@ -26,6 +26,23 @@ func (rt *Router) SetAssets(s assetService) { rt.assets = s }
 
 const assetBodyCap = 64 << 10
 
+// DefaultFleetTenant is the non-empty tenant id used when the principal is on the empty-string
+// default tenant (single-tenant deployments). RLS-protected fleet tables cannot use the empty
+// string, because under the 0057 policy the empty string is DENY, not a tenant. Mapping the empty
+// default to a real, non-empty tenant here is what lets the fleet asset model work in a
+// single-tenant deployment while still being isolated at the database. Migration 0058 seeds this
+// tenant row so the fleet_assets FK to tenants is satisfied.
+const DefaultFleetTenant shared.ID = "default"
+
+// fleetTenant resolves the effective tenant for fleet asset operations: the request principal's
+// tenant, or DefaultFleetTenant when that is the empty-string default tenant.
+func fleetTenant(ctx context.Context) shared.ID {
+	if t := TenantFrom(ctx); t != "" {
+		return shared.ID(t)
+	}
+	return DefaultFleetTenant
+}
+
 type upsertAssetRequest struct {
 	Kind       string            `json:"kind"`
 	Key        string            `json:"key"`
@@ -40,7 +57,7 @@ func (rt *Router) createAsset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	a, err := rt.assets.UpsertAsset(r.Context(), PrincipalFrom(r.Context()), assetuc.UpsertAssetInput{
-		TenantID:   shared.ID(TenantFrom(r.Context())),
+		TenantID:   fleetTenant(r.Context()),
 		Kind:       asset.Kind(req.Kind),
 		Key:        req.Key,
 		Name:       req.Name,
@@ -54,10 +71,13 @@ func (rt *Router) createAsset(w http.ResponseWriter, r *http.Request) {
 }
 
 func (rt *Router) listAssets(w http.ResponseWriter, r *http.Request) {
-	list, err := rt.assets.ListAssets(r.Context(), shared.ID(TenantFrom(r.Context())))
+	list, err := rt.assets.ListAssets(r.Context(), fleetTenant(r.Context()))
 	if err != nil {
 		writeError(w, rt.log, err)
 		return
+	}
+	if list == nil {
+		list = []*asset.Asset{}
 	}
 	writeJSON(w, http.StatusOK, list)
 }
@@ -76,7 +96,7 @@ func (rt *Router) createAssetEdge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := rt.assets.UpsertEdge(r.Context(), PrincipalFrom(r.Context()), assetuc.EdgeInput{
-		TenantID:   shared.ID(TenantFrom(r.Context())),
+		TenantID:   fleetTenant(r.Context()),
 		From:       shared.ID(req.From),
 		To:         shared.ID(req.To),
 		Kind:       asset.EdgeKind(req.Kind),
@@ -89,10 +109,13 @@ func (rt *Router) createAssetEdge(w http.ResponseWriter, r *http.Request) {
 }
 
 func (rt *Router) listAssetEdges(w http.ResponseWriter, r *http.Request) {
-	list, err := rt.assets.ListEdges(r.Context(), shared.ID(TenantFrom(r.Context())))
+	list, err := rt.assets.ListEdges(r.Context(), fleetTenant(r.Context()))
 	if err != nil {
 		writeError(w, rt.log, err)
 		return
+	}
+	if list == nil {
+		list = []*asset.Edge{}
 	}
 	writeJSON(w, http.StatusOK, list)
 }
@@ -109,7 +132,7 @@ func (rt *Router) createBusinessService(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	svc, err := rt.assets.UpsertBusinessService(r.Context(), PrincipalFrom(r.Context()), assetuc.BusinessServiceInput{
-		TenantID: shared.ID(TenantFrom(r.Context())),
+		TenantID: fleetTenant(r.Context()),
 		Name:     req.Name,
 		Owner:    req.Owner,
 	})
@@ -121,10 +144,13 @@ func (rt *Router) createBusinessService(w http.ResponseWriter, r *http.Request) 
 }
 
 func (rt *Router) listBusinessServices(w http.ResponseWriter, r *http.Request) {
-	list, err := rt.assets.ListBusinessServices(r.Context(), shared.ID(TenantFrom(r.Context())))
+	list, err := rt.assets.ListBusinessServices(r.Context(), fleetTenant(r.Context()))
 	if err != nil {
 		writeError(w, rt.log, err)
 		return
+	}
+	if list == nil {
+		list = []*asset.BusinessService{}
 	}
 	writeJSON(w, http.StatusOK, list)
 }

--- a/internal/adapter/httpapi/asset_handler_test.go
+++ b/internal/adapter/httpapi/asset_handler_test.go
@@ -1,0 +1,64 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
+)
+
+type fakeAssetService struct{}
+
+func (fakeAssetService) UpsertAsset(context.Context, string, assetuc.UpsertAssetInput) (*asset.Asset, error) {
+	return &asset.Asset{}, nil
+}
+func (fakeAssetService) ListAssets(context.Context, shared.ID) ([]*asset.Asset, error) {
+	return nil, nil
+}
+func (fakeAssetService) UpsertEdge(context.Context, string, assetuc.EdgeInput) error { return nil }
+func (fakeAssetService) ListEdges(context.Context, shared.ID) ([]*asset.Edge, error) { return nil, nil }
+func (fakeAssetService) UpsertBusinessService(context.Context, string, assetuc.BusinessServiceInput) (*asset.BusinessService, error) {
+	return &asset.BusinessService{}, nil
+}
+func (fakeAssetService) ListBusinessServices(context.Context, shared.ID) ([]*asset.BusinessService, error) {
+	return nil, nil
+}
+
+func TestRouter_AssetRoutePresence(t *testing.T) {
+	rt := &Router{log: discardLog()}
+
+	call := func(method, path string) int {
+		req := httptest.NewRequest(method, path, nil)
+		w := httptest.NewRecorder()
+		rt.routes().ServeHTTP(w, req)
+		return w.Code
+	}
+
+	paths := []struct {
+		method, path string
+	}{
+		{http.MethodGet, "/api/v1/assets"},
+		{http.MethodGet, "/api/v1/assets/edges"},
+		{http.MethodGet, "/api/v1/assets/services"},
+	}
+
+	// Not registered before SetAssets.
+	for _, p := range paths {
+		if code := call(p.method, p.path); code != http.StatusNotFound {
+			t.Errorf("%s %s: expected 404 before SetAssets, got %d", p.method, p.path, code)
+		}
+	}
+
+	rt.SetAssets(fakeAssetService{})
+
+	// Present after SetAssets.
+	for _, p := range paths {
+		if code := call(p.method, p.path); code == http.StatusNotFound {
+			t.Errorf("%s %s: expected route present after SetAssets, got 404", p.method, p.path)
+		}
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -60,6 +60,7 @@ type Router struct {
 	threatModels    threatModelService    // optional; nil ⇒ threat-model routes are not registered
 	drafts          writeupDraftService   // optional; nil ⇒ writeup-draft sign-off routes are not registered
 	projects        projectService        // optional; nil ⇒ project routes are not registered
+	assets          assetService          // optional; nil ⇒ fleet asset routes are not registered
 	qualityGates    qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
 	qualityProfiles qualityProfileService // optional; nil ⇒ quality-profile routes are not registered
 	rules           rulesService          // optional; nil ⇒ rule catalog routes are not registered
@@ -218,6 +219,14 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/deactivate", rt.authz(userdom.PermOperate, rt.deactivateProfileRule))
 		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/severity", rt.authz(userdom.PermOperate, rt.setProfileRuleSeverity))
 		mux.HandleFunc("DELETE /api/v1/quality-profiles/{key}", rt.authz(userdom.PermOperate, rt.deleteQualityProfile))
+	}
+	if rt.assets != nil {
+		mux.HandleFunc("POST /api/v1/assets", rt.authz(userdom.PermOperate, rt.createAsset))
+		mux.HandleFunc("GET /api/v1/assets", rt.authz(userdom.PermView, rt.listAssets))
+		mux.HandleFunc("POST /api/v1/assets/edges", rt.authz(userdom.PermOperate, rt.createAssetEdge))
+		mux.HandleFunc("GET /api/v1/assets/edges", rt.authz(userdom.PermView, rt.listAssetEdges))
+		mux.HandleFunc("POST /api/v1/assets/services", rt.authz(userdom.PermOperate, rt.createBusinessService))
+		mux.HandleFunc("GET /api/v1/assets/services", rt.authz(userdom.PermView, rt.listBusinessServices))
 	}
 	if rt.projects != nil {
 		mux.HandleFunc("POST /api/v1/projects", rt.authz(userdom.PermOperate, rt.createProject))

--- a/internal/domain/asset/asset.go
+++ b/internal/domain/asset/asset.go
@@ -1,0 +1,185 @@
+// Package asset is the epic-#405 fleet asset model: one canonical identity per real thing (a
+// host, a workload, an image, a cloud resource), the typed relationships between them, and a
+// business-service grouping. It is pure domain: it imports only shared and the stdlib.
+//
+// Tenancy invariant: every aggregate carries a NON-EMPTY TenantID. Under Row Level Security
+// (migration 0057) the empty string means DENY, not the default tenant, so an empty tenant id is
+// rejected at construction. The default single-tenant deployment supplies a non-empty tenant id.
+package asset
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Kind is the closed set of asset kinds. It is extended deliberately, never by free string.
+type Kind string
+
+const (
+	KindHost         Kind = "host"
+	KindWorkload     Kind = "workload"
+	KindImage        Kind = "image"
+	KindCloudAccount Kind = "cloud_account"
+	KindStorage      Kind = "storage"
+	KindExposure     Kind = "exposure"
+	KindIdentity     Kind = "identity"
+	KindNamespace    Kind = "namespace"
+	KindCluster      Kind = "cluster"
+)
+
+// Valid reports whether k is a known kind.
+func (k Kind) Valid() bool {
+	switch k {
+	case KindHost, KindWorkload, KindImage, KindCloudAccount, KindStorage,
+		KindExposure, KindIdentity, KindNamespace, KindCluster:
+		return true
+	default:
+		return false
+	}
+}
+
+// Asset is one canonical thing in the estate. (TenantID, Kind, Key) is its natural identity: the
+// same real thing observed by two producers resolves to one asset via that tuple.
+type Asset struct {
+	ID         shared.ID
+	TenantID   shared.ID
+	Kind       Kind
+	Key        string // deterministic natural key per kind (e.g. an image digest)
+	Name       string
+	Attributes map[string]string
+	Audit      shared.Audit
+}
+
+// New validates and constructs an Asset. Name defaults to Key when empty. Attributes are copied
+// so the caller cannot mutate the aggregate's map after construction.
+func New(id, tenantID shared.ID, kind Kind, key, name string, attributes map[string]string, now time.Time) (*Asset, error) {
+	if id.IsZero() {
+		return nil, fmt.Errorf("%w: asset id is required", shared.ErrValidation)
+	}
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: asset tenant id is required (empty tenant is DENY under RLS)", shared.ErrValidation)
+	}
+	if !kind.Valid() {
+		return nil, fmt.Errorf("%w: invalid asset kind %q", shared.ErrValidation, kind)
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, fmt.Errorf("%w: asset key is required", shared.ErrValidation)
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = key
+	}
+	return &Asset{
+		ID:         id,
+		TenantID:   tenantID,
+		Kind:       kind,
+		Key:        key,
+		Name:       name,
+		Attributes: copyAttrs(attributes),
+		Audit:      shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}, nil
+}
+
+// EdgeKind is the closed set of typed relationships between assets.
+type EdgeKind string
+
+const (
+	EdgeRuns       EdgeKind = "runs"        // host/cluster runs workload
+	EdgeExposes    EdgeKind = "exposes"     // exposure exposes workload
+	EdgeDependsOn  EdgeKind = "depends_on"  // workload depends on component
+	EdgeCanAssume  EdgeKind = "can_assume"  // identity can assume identity
+	EdgeReaches    EdgeKind = "reaches"     // reachability edge
+	EdgeAffectedBy EdgeKind = "affected_by" // asset affected by a finding
+	EdgeMounts     EdgeKind = "mounts"      // workload mounts identity/secret
+	EdgeMemberOf   EdgeKind = "member_of"   // asset is a member of a business service
+)
+
+// Valid reports whether e is a known edge kind.
+func (e EdgeKind) Valid() bool {
+	switch e {
+	case EdgeRuns, EdgeExposes, EdgeDependsOn, EdgeCanAssume, EdgeReaches,
+		EdgeAffectedBy, EdgeMounts, EdgeMemberOf:
+		return true
+	default:
+		return false
+	}
+}
+
+// Edge is a typed, provenance-carrying relationship. Provenance references the observation that
+// produced the edge; an edge without provenance is invalid, because an unattributable edge cannot
+// be trusted by the attack-path traversal that consumes it.
+type Edge struct {
+	TenantID   shared.ID
+	From       shared.ID
+	To         shared.ID
+	Kind       EdgeKind
+	Provenance shared.ID
+}
+
+// NewEdge validates and constructs an Edge.
+func NewEdge(tenantID, from, to shared.ID, kind EdgeKind, provenance shared.ID) (*Edge, error) {
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: edge tenant id is required (empty tenant is DENY under RLS)", shared.ErrValidation)
+	}
+	if from.IsZero() || to.IsZero() {
+		return nil, fmt.Errorf("%w: edge from and to asset ids are required", shared.ErrValidation)
+	}
+	if !kind.Valid() {
+		return nil, fmt.Errorf("%w: invalid edge kind %q", shared.ErrValidation, kind)
+	}
+	if provenance.IsZero() {
+		return nil, fmt.Errorf("%w: edge provenance is required", shared.ErrValidation)
+	}
+	return &Edge{TenantID: tenantID, From: from, To: to, Kind: kind, Provenance: provenance}, nil
+}
+
+// BusinessService groups assets into a named service with an owner so findings and risk can be
+// rolled up to something a stakeholder recognises. Membership is expressed as an EdgeMemberOf
+// edge from an asset to the service.
+type BusinessService struct {
+	ID       shared.ID
+	TenantID shared.ID
+	Name     string
+	Owner    string
+	Audit    shared.Audit
+}
+
+// NewBusinessService validates and constructs a BusinessService.
+func NewBusinessService(id, tenantID shared.ID, name, owner string, now time.Time) (*BusinessService, error) {
+	if id.IsZero() {
+		return nil, fmt.Errorf("%w: business service id is required", shared.ErrValidation)
+	}
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: business service tenant id is required (empty tenant is DENY under RLS)", shared.ErrValidation)
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: business service name is required", shared.ErrValidation)
+	}
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return nil, fmt.Errorf("%w: business service owner is required", shared.ErrValidation)
+	}
+	return &BusinessService{
+		ID:       id,
+		TenantID: tenantID,
+		Name:     name,
+		Owner:    owner,
+		Audit:    shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}, nil
+}
+
+func copyAttrs(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/domain/asset/asset_test.go
+++ b/internal/domain/asset/asset_test.go
@@ -1,0 +1,136 @@
+package asset
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var testNow = time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+
+func TestKindValid(t *testing.T) {
+	for _, k := range []Kind{KindHost, KindWorkload, KindImage, KindCloudAccount, KindStorage, KindExposure, KindIdentity, KindNamespace, KindCluster} {
+		if !k.Valid() {
+			t.Errorf("kind %q should be valid", k)
+		}
+	}
+	for _, k := range []Kind{"", "server", "vm", "HOST"} {
+		if k.Valid() {
+			t.Errorf("kind %q should be invalid", k)
+		}
+	}
+}
+
+func TestNewAsset(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      shared.ID
+		tenant  shared.ID
+		kind    Kind
+		key     string
+		wantErr bool
+	}{
+		{"ok", "a1", "t1", KindImage, "sha256:abc", false},
+		{"missing id", "", "t1", KindImage, "sha256:abc", true},
+		{"empty tenant is deny", "a1", "", KindImage, "sha256:abc", true},
+		{"invalid kind", "a1", "t1", "server", "sha256:abc", true},
+		{"missing key", "a1", "t1", KindImage, "   ", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := New(tc.id, tc.tenant, tc.kind, tc.key, "", nil, testNow)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !errors.Is(err, shared.ErrValidation) {
+					t.Fatalf("expected ErrValidation, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Name != tc.key {
+				t.Errorf("name should default to key %q, got %q", tc.key, got.Name)
+			}
+			if got.Attributes == nil {
+				t.Errorf("attributes should be non-nil")
+			}
+		})
+	}
+}
+
+func TestNewAssetCopiesAttributes(t *testing.T) {
+	in := map[string]string{"os": "linux"}
+	a, err := New("a1", "t1", KindHost, "host-1", "Host 1", in, testNow)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	in["os"] = "windows" // mutate caller's map
+	if a.Attributes["os"] != "linux" {
+		t.Fatalf("asset must copy attributes, got %q", a.Attributes["os"])
+	}
+}
+
+func TestNewEdge(t *testing.T) {
+	tests := []struct {
+		name       string
+		tenant     shared.ID
+		from, to   shared.ID
+		kind       EdgeKind
+		provenance shared.ID
+		wantErr    bool
+	}{
+		{"ok", "t1", "a1", "a2", EdgeRuns, "obs1", false},
+		{"empty tenant", "", "a1", "a2", EdgeRuns, "obs1", true},
+		{"missing from", "t1", "", "a2", EdgeRuns, "obs1", true},
+		{"missing to", "t1", "a1", "", EdgeRuns, "obs1", true},
+		{"invalid kind", "t1", "a1", "a2", "points_to", "obs1", true},
+		{"missing provenance", "t1", "a1", "a2", EdgeRuns, "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewEdge(tc.tenant, tc.from, tc.to, tc.kind, tc.provenance)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if tc.wantErr && !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("expected ErrValidation, got %v", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewBusinessService(t *testing.T) {
+	tests := []struct {
+		name, svcName, owner string
+		id, tenant           shared.ID
+		wantErr              bool
+	}{
+		{"ok", "payments", "team-a", "s1", "t1", false},
+		{"missing id", "payments", "team-a", "", "t1", true},
+		{"empty tenant", "payments", "team-a", "s1", "", true},
+		{"missing name", "  ", "team-a", "s1", "t1", true},
+		{"missing owner", "payments", "  ", "s1", "t1", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewBusinessService(tc.id, tc.tenant, tc.svcName, tc.owner, testNow)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if tc.wantErr && !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("expected ErrValidation, got %v", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/persistence/memory/asset_store.go
+++ b/internal/infrastructure/persistence/memory/asset_store.go
@@ -1,0 +1,173 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.AssetRepository = (*AssetStore)(nil)
+
+// AssetStore is an in-memory ports.AssetRepository for dev and tests. It mirrors the Postgres
+// store's tenant scoping and deterministic ordering so behaviour matches across backends.
+type AssetStore struct {
+	mu       sync.Mutex
+	assets   map[string]*asset.Asset           // key: tenant|kind|key
+	edges    map[string]*asset.Edge            // key: tenant|from|to|kind|provenance
+	services map[string]*asset.BusinessService // key: tenant|name
+}
+
+// NewAssetStore returns an empty in-memory asset repository.
+func NewAssetStore() *AssetStore {
+	return &AssetStore{
+		assets:   map[string]*asset.Asset{},
+		edges:    map[string]*asset.Edge{},
+		services: map[string]*asset.BusinessService{},
+	}
+}
+
+func assetKey(tenant shared.ID, kind asset.Kind, key string) string {
+	return tenant.String() + "|" + string(kind) + "|" + key
+}
+
+func edgeKey(e *asset.Edge) string {
+	return e.TenantID.String() + "|" + e.From.String() + "|" + e.To.String() + "|" + string(e.Kind) + "|" + e.Provenance.String()
+}
+
+func serviceKey(tenant shared.ID, name string) string {
+	return tenant.String() + "|" + name
+}
+
+// UpsertAsset stores a by its natural key, replacing any prior value for that key.
+func (s *AssetStore) UpsertAsset(_ context.Context, a *asset.Asset) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *a
+	cp.Attributes = cloneMap(a.Attributes)
+	s.assets[assetKey(a.TenantID, a.Kind, a.Key)] = &cp
+	return nil
+}
+
+// GetAssetByKey returns the asset for (tenantID, kind, key) or shared.ErrNotFound.
+func (s *AssetStore) GetAssetByKey(_ context.Context, tenantID shared.ID, kind asset.Kind, key string) (*asset.Asset, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a, ok := s.assets[assetKey(tenantID, kind, key)]
+	if !ok {
+		return nil, shared.ErrNotFound
+	}
+	cp := *a
+	cp.Attributes = cloneMap(a.Attributes)
+	return &cp, nil
+}
+
+// ListAssets returns the tenant's assets ordered by (kind, key).
+func (s *AssetStore) ListAssets(_ context.Context, tenantID shared.ID) ([]*asset.Asset, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*asset.Asset
+	for _, a := range s.assets {
+		if a.TenantID != tenantID {
+			continue
+		}
+		cp := *a
+		cp.Attributes = cloneMap(a.Attributes)
+		out = append(out, &cp)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out, nil
+}
+
+// UpsertEdge stores e by its natural key.
+func (s *AssetStore) UpsertEdge(_ context.Context, e *asset.Edge) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *e
+	s.edges[edgeKey(e)] = &cp
+	return nil
+}
+
+// ListEdges returns the tenant's edges ordered by (from, to, kind, provenance).
+func (s *AssetStore) ListEdges(_ context.Context, tenantID shared.ID) ([]*asset.Edge, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*asset.Edge
+	for _, e := range s.edges {
+		if e.TenantID != tenantID {
+			continue
+		}
+		cp := *e
+		out = append(out, &cp)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		switch {
+		case a.From != b.From:
+			return a.From < b.From
+		case a.To != b.To:
+			return a.To < b.To
+		case a.Kind != b.Kind:
+			return a.Kind < b.Kind
+		default:
+			return a.Provenance < b.Provenance
+		}
+	})
+	return out, nil
+}
+
+// UpsertBusinessService stores svc by (tenant, name).
+func (s *AssetStore) UpsertBusinessService(_ context.Context, svc *asset.BusinessService) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *svc
+	s.services[serviceKey(svc.TenantID, svc.Name)] = &cp
+	return nil
+}
+
+// GetBusinessServiceByName returns the service for (tenantID, name) or shared.ErrNotFound.
+func (s *AssetStore) GetBusinessServiceByName(_ context.Context, tenantID shared.ID, name string) (*asset.BusinessService, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	svc, ok := s.services[serviceKey(tenantID, name)]
+	if !ok {
+		return nil, shared.ErrNotFound
+	}
+	cp := *svc
+	return &cp, nil
+}
+
+// ListBusinessServices returns the tenant's services ordered by name.
+func (s *AssetStore) ListBusinessServices(_ context.Context, tenantID shared.ID) ([]*asset.BusinessService, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*asset.BusinessService
+	for _, svc := range s.services {
+		if svc.TenantID != tenantID {
+			continue
+		}
+		cp := *svc
+		out = append(out, &cp)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func cloneMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/infrastructure/persistence/postgres/asset_repo.go
+++ b/internal/infrastructure/persistence/postgres/asset_repo.go
@@ -1,0 +1,234 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// AssetRepository is the Postgres-backed fleet asset model. It is the first store to route every
+// operation through WithTenant, so the Row Level Security policies on fleet_assets,
+// fleet_asset_edges and fleet_business_services (migration 0058, using the 0057 procedure) enforce
+// tenant isolation at the database. A query that bypassed WithTenant would resolve the tenant to
+// NULL and see nothing.
+type AssetRepository struct{ pool *pgxpool.Pool }
+
+// NewAssetRepository constructs the Postgres asset repository.
+func NewAssetRepository(pool *pgxpool.Pool) *AssetRepository { return &AssetRepository{pool: pool} }
+
+var _ ports.AssetRepository = (*AssetRepository)(nil)
+
+const assetCols = `id, tenant_id, kind, "key", name, attributes, created_at, updated_at`
+
+// UpsertAsset inserts or updates by the (tenant_id, kind, key) natural key, preserving the id and
+// created_at of an existing row so re-observation does not churn identity.
+func (r *AssetRepository) UpsertAsset(ctx context.Context, a *asset.Asset) error {
+	attrs, err := json.Marshal(a.Attributes)
+	if err != nil {
+		return fmt.Errorf("asset: marshal attributes: %w", err)
+	}
+	return WithTenant(ctx, r.pool, a.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO fleet_assets (`+assetCols+`)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			ON CONFLICT (tenant_id, kind, "key") DO UPDATE
+			SET name = EXCLUDED.name, attributes = EXCLUDED.attributes, updated_at = EXCLUDED.updated_at`,
+			a.ID.String(), a.TenantID.String(), string(a.Kind), a.Key, a.Name, attrs,
+			a.Audit.CreatedAt, a.Audit.UpdatedAt)
+		return err
+	})
+}
+
+// GetAssetByKey returns the asset for (tenantID, kind, key) or shared.ErrNotFound.
+func (r *AssetRepository) GetAssetByKey(ctx context.Context, tenantID shared.ID, kind asset.Kind, key string) (*asset.Asset, error) {
+	var out *asset.Asset
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		a, e := scanAsset(tx.QueryRow(ctx, `SELECT `+assetCols+` FROM fleet_assets WHERE tenant_id = $1 AND kind = $2 AND "key" = $3`,
+			tenantID.String(), string(kind), key))
+		if e != nil {
+			return e
+		}
+		out = a
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ListAssets returns the tenant's assets ordered by (kind, key).
+func (r *AssetRepository) ListAssets(ctx context.Context, tenantID shared.ID) ([]*asset.Asset, error) {
+	var out []*asset.Asset
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, e := tx.Query(ctx, `SELECT `+assetCols+` FROM fleet_assets WHERE tenant_id = $1 ORDER BY kind, "key"`, tenantID.String())
+		if e != nil {
+			return e
+		}
+		defer rows.Close()
+		for rows.Next() {
+			a, e := scanAsset(rows)
+			if e != nil {
+				return e
+			}
+			out = append(out, a)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// UpsertEdge inserts the edge idempotently by its full natural key.
+func (r *AssetRepository) UpsertEdge(ctx context.Context, e *asset.Edge) error {
+	return WithTenant(ctx, r.pool, e.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO fleet_asset_edges (tenant_id, from_asset, to_asset, kind, provenance)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (tenant_id, from_asset, to_asset, kind, provenance) DO NOTHING`,
+			e.TenantID.String(), e.From.String(), e.To.String(), string(e.Kind), e.Provenance.String())
+		return err
+	})
+}
+
+// ListEdges returns the tenant's edges ordered by (from, to, kind, provenance).
+func (r *AssetRepository) ListEdges(ctx context.Context, tenantID shared.ID) ([]*asset.Edge, error) {
+	var out []*asset.Edge
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, e := tx.Query(ctx, `
+			SELECT tenant_id, from_asset, to_asset, kind, provenance FROM fleet_asset_edges
+			WHERE tenant_id = $1 ORDER BY from_asset, to_asset, kind, provenance`, tenantID.String())
+		if e != nil {
+			return e
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var tid, from, to, kind, prov string
+			if e := rows.Scan(&tid, &from, &to, &kind, &prov); e != nil {
+				return e
+			}
+			out = append(out, &asset.Edge{
+				TenantID:   shared.ID(tid),
+				From:       shared.ID(from),
+				To:         shared.ID(to),
+				Kind:       asset.EdgeKind(kind),
+				Provenance: shared.ID(prov),
+			})
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// UpsertBusinessService inserts or updates by (tenant_id, name), preserving id and created_at.
+func (r *AssetRepository) UpsertBusinessService(ctx context.Context, s *asset.BusinessService) error {
+	return WithTenant(ctx, r.pool, s.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO fleet_business_services (id, tenant_id, name, owner, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (tenant_id, name) DO UPDATE
+			SET owner = EXCLUDED.owner, updated_at = EXCLUDED.updated_at`,
+			s.ID.String(), s.TenantID.String(), s.Name, s.Owner, s.Audit.CreatedAt, s.Audit.UpdatedAt)
+		return err
+	})
+}
+
+// GetBusinessServiceByName returns the service for (tenantID, name) or shared.ErrNotFound.
+func (r *AssetRepository) GetBusinessServiceByName(ctx context.Context, tenantID shared.ID, name string) (*asset.BusinessService, error) {
+	var out *asset.BusinessService
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		s, e := scanBusinessService(tx.QueryRow(ctx,
+			`SELECT id, tenant_id, name, owner, created_at, updated_at FROM fleet_business_services WHERE tenant_id = $1 AND name = $2`,
+			tenantID.String(), name))
+		if e != nil {
+			return e
+		}
+		out = s
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ListBusinessServices returns the tenant's services ordered by name.
+func (r *AssetRepository) ListBusinessServices(ctx context.Context, tenantID shared.ID) ([]*asset.BusinessService, error) {
+	var out []*asset.BusinessService
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, e := tx.Query(ctx,
+			`SELECT id, tenant_id, name, owner, created_at, updated_at FROM fleet_business_services WHERE tenant_id = $1 ORDER BY name`,
+			tenantID.String())
+		if e != nil {
+			return e
+		}
+		defer rows.Close()
+		for rows.Next() {
+			s, e := scanBusinessService(rows)
+			if e != nil {
+				return e
+			}
+			out = append(out, s)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func scanAsset(row rowScanner) (*asset.Asset, error) {
+	var (
+		id, tid, kind, key, name string
+		attrs                    []byte
+		a                        asset.Asset
+	)
+	if err := row.Scan(&id, &tid, &kind, &key, &name, &attrs, &a.Audit.CreatedAt, &a.Audit.UpdatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, shared.ErrNotFound
+		}
+		return nil, err
+	}
+	a.ID = shared.ID(id)
+	a.TenantID = shared.ID(tid)
+	a.Kind = asset.Kind(kind)
+	a.Key = key
+	a.Name = name
+	a.Attributes = map[string]string{}
+	if len(attrs) > 0 {
+		if err := json.Unmarshal(attrs, &a.Attributes); err != nil {
+			return nil, fmt.Errorf("asset: unmarshal attributes: %w", err)
+		}
+	}
+	return &a, nil
+}
+
+func scanBusinessService(row rowScanner) (*asset.BusinessService, error) {
+	var id, tid, name, owner string
+	var s asset.BusinessService
+	if err := row.Scan(&id, &tid, &name, &owner, &s.Audit.CreatedAt, &s.Audit.UpdatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, shared.ErrNotFound
+		}
+		return nil, err
+	}
+	s.ID = shared.ID(id)
+	s.TenantID = shared.ID(tid)
+	s.Name = name
+	s.Owner = owner
+	return &s, nil
+}

--- a/internal/infrastructure/persistence/postgres/asset_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/asset_repo_test.go
@@ -86,8 +86,15 @@ func TestAssetRepository(t *testing.T) {
 		t.Fatalf("tenant scoping failed: %+v", list)
 	}
 
+	// A second asset in tenant ta so the edge references two assets in the SAME tenant (the
+	// composite FK forbids cross-tenant edges).
+	a3, _ := asset.New("as3", "ta", asset.KindWorkload, "wl-1", "wl", nil, now)
+	if err := repo.UpsertAsset(ctx, a3); err != nil {
+		t.Fatalf("upsert as3: %v", err)
+	}
+
 	// Edge roundtrip + idempotency (ON CONFLICT DO NOTHING).
-	e, _ := asset.NewEdge("ta", "as1", "as2", asset.EdgeRuns, "obs1")
+	e, _ := asset.NewEdge("ta", "as1", "as3", asset.EdgeRuns, "obs1")
 	if err := repo.UpsertEdge(ctx, e); err != nil {
 		t.Fatalf("upsert edge: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/asset_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/asset_repo_test.go
@@ -1,0 +1,127 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAssetRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	// Seed two tenants (FK target). Clean asset rows then tenants (FK order) at the end.
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ('ta','A'),('tb','B') ON CONFLICT (id) DO NOTHING`); err != nil {
+		t.Fatalf("seed tenants: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM fleet_asset_edges WHERE tenant_id IN ('ta','tb')`)
+		_, _ = pool.Exec(bg, `DELETE FROM fleet_business_services WHERE tenant_id IN ('ta','tb')`)
+		_, _ = pool.Exec(bg, `DELETE FROM fleet_assets WHERE tenant_id IN ('ta','tb')`)
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id IN ('ta','tb')`)
+	})
+
+	repo := NewAssetRepository(pool)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Roundtrip.
+	a, err := asset.New("as1", "ta", asset.KindImage, "sha256:x", "img", map[string]string{"os": "linux"}, now)
+	if err != nil {
+		t.Fatalf("new asset: %v", err)
+	}
+	if err := repo.UpsertAsset(ctx, a); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, err := repo.GetAssetByKey(ctx, "ta", asset.KindImage, "sha256:x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ID != "as1" || got.Name != "img" || got.Attributes["os"] != "linux" {
+		t.Fatalf("roundtrip mismatch: %+v", got)
+	}
+
+	// Idempotent upsert: same natural key -> one row, id preserved.
+	if err := repo.UpsertAsset(ctx, a); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	list, err := repo.ListAssets(ctx, "ta")
+	if err != nil {
+		t.Fatalf("list ta: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("idempotent upsert should keep one row, got %d", len(list))
+	}
+
+	// Not found.
+	if _, err := repo.GetAssetByKey(ctx, "ta", asset.KindImage, "sha256:missing"); err == nil {
+		t.Fatalf("expected ErrNotFound for missing key")
+	}
+
+	// Query-level tenant scoping: tenant tb's asset is not in ta's list.
+	b, _ := asset.New("as2", "tb", asset.KindImage, "sha256:y", "img2", nil, now)
+	if err := repo.UpsertAsset(ctx, b); err != nil {
+		t.Fatalf("upsert tb: %v", err)
+	}
+	list, err = repo.ListAssets(ctx, "ta")
+	if err != nil {
+		t.Fatalf("list ta again: %v", err)
+	}
+	if len(list) != 1 || list[0].TenantID != "ta" {
+		t.Fatalf("tenant scoping failed: %+v", list)
+	}
+
+	// Edge roundtrip + idempotency (ON CONFLICT DO NOTHING).
+	e, _ := asset.NewEdge("ta", "as1", "as2", asset.EdgeRuns, "obs1")
+	if err := repo.UpsertEdge(ctx, e); err != nil {
+		t.Fatalf("upsert edge: %v", err)
+	}
+	if err := repo.UpsertEdge(ctx, e); err != nil {
+		t.Fatalf("re-upsert edge: %v", err)
+	}
+	edges, err := repo.ListEdges(ctx, "ta")
+	if err != nil {
+		t.Fatalf("list edges: %v", err)
+	}
+	if len(edges) != 1 || edges[0].Kind != asset.EdgeRuns {
+		t.Fatalf("expected one runs edge, got %+v", edges)
+	}
+
+	// Business service roundtrip + idempotency.
+	svc, _ := asset.NewBusinessService("s1", "ta", "payments", "team-a", now)
+	if err := repo.UpsertBusinessService(ctx, svc); err != nil {
+		t.Fatalf("upsert svc: %v", err)
+	}
+	svc2, _ := asset.NewBusinessService("s1", "ta", "payments", "team-b", now)
+	if err := repo.UpsertBusinessService(ctx, svc2); err != nil {
+		t.Fatalf("re-upsert svc: %v", err)
+	}
+	svcs, err := repo.ListBusinessServices(ctx, "ta")
+	if err != nil {
+		t.Fatalf("list svcs: %v", err)
+	}
+	if len(svcs) != 1 || svcs[0].Owner != "team-b" {
+		t.Fatalf("expected one service with updated owner, got %+v", svcs)
+	}
+
+	// Empty tenant is rejected by the domain before it ever reaches the DB.
+	if _, err := asset.New("z", "", asset.KindHost, "h", "h", nil, now); err == nil {
+		t.Fatalf("empty tenant asset should be rejected by domain")
+	}
+	_ = shared.ID("")
+}

--- a/internal/infrastructure/persistence/postgres/migration_0058_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0058_test.go
@@ -1,0 +1,150 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+// TestFleetAssetsRLS proves tenant isolation on fleet_assets is enforced by the DATABASE (Row
+// Level Security), not by the query's WHERE clause: it reads with an intentionally unscoped
+// SELECT under a NOSUPERUSER NOBYPASSRLS role and still sees only the current tenant's rows, and
+// sees nothing when no tenant is set.
+func TestFleetAssetsRLS(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	// FORCE ROW LEVEL SECURITY is set on every fleet table.
+	for _, tbl := range []string{"fleet_assets", "fleet_asset_edges", "fleet_business_services"} {
+		var forced bool
+		if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE relname = $1`, tbl).Scan(&forced); err != nil {
+			t.Fatalf("relforcerowsecurity %s: %v", tbl, err)
+		}
+		if !forced {
+			t.Fatalf("FORCE ROW LEVEL SECURITY not set on %s", tbl)
+		}
+	}
+
+	// A role RLS actually applies to.
+	for _, stmt := range []string{
+		`DROP OWNED BY rls_asset_role_432`,
+		`DROP ROLE IF EXISTS rls_asset_role_432`,
+		`CREATE ROLE rls_asset_role_432 NOSUPERUSER NOBYPASSRLS`,
+		`GRANT USAGE ON SCHEMA public TO rls_asset_role_432`,
+		`GRANT SELECT ON fleet_assets TO rls_asset_role_432`,
+	} {
+		_, _ = pool.Exec(ctx, stmt)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ('rlsa','A'),('rlsb','B') ON CONFLICT (id) DO NOTHING`); err != nil {
+		t.Fatalf("seed tenants: %v", err)
+	}
+	// Seed as the superuser (RLS bypassed) so both tenants have rows to (not) leak.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO fleet_assets (id, tenant_id, kind, "key", name) VALUES
+		('ra1','rlsa','host','h1','h1'),('ra2','rlsa','host','h2','h2'),('rb1','rlsb','host','h3','h3')`); err != nil {
+		t.Fatalf("seed assets: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM fleet_assets WHERE tenant_id IN ('rlsa','rlsb')`)
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id IN ('rlsa','rlsb')`)
+		_, _ = pool.Exec(bg, `DROP OWNED BY rls_asset_role_432`)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS rls_asset_role_432`)
+	})
+
+	// countUnscoped runs an UNSCOPED count under the non-privileged role, optionally setting the
+	// tenant session variable. RLS, not the query, decides visibility.
+	countUnscoped := func(setTenant bool, tenant string) int {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		if setTenant {
+			if _, err := tx.Exec(ctx, `SELECT set_config('app.current_tenant', $1, true)`, tenant); err != nil {
+				t.Fatalf("set_config: %v", err)
+			}
+		}
+		if _, err := tx.Exec(ctx, `SET LOCAL ROLE rls_asset_role_432`); err != nil {
+			t.Fatalf("set role: %v", err)
+		}
+		var n int
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM fleet_assets`).Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		return n
+	}
+
+	if got := countUnscoped(true, "rlsa"); got != 2 {
+		t.Fatalf("tenant rlsa should see 2 rows via unscoped query, got %d", got)
+	}
+	if got := countUnscoped(true, "rlsb"); got != 1 {
+		t.Fatalf("tenant rlsb should see 1 row via unscoped query, got %d", got)
+	}
+	if got := countUnscoped(false, ""); got != 0 {
+		t.Fatalf("no tenant set must see 0 rows (fail-closed), got %d", got)
+	}
+}
+
+// TestMigration0058 exercises the migration down and back up and asserts the table is gone after
+// down and present after up.
+func TestMigration0058(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	db, err := goose.OpenDBWithDriver("pgx", dsn)
+	if err != nil {
+		t.Fatalf("goose open: %v", err)
+	}
+	defer db.Close()
+	goose.SetBaseFS(migrations.FS)
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatalf("dialect: %v", err)
+	}
+
+	if err := goose.DownTo(db, ".", 57); err != nil {
+		t.Fatalf("down to 57: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+	_, err = pool.Exec(ctx, `SELECT 1 FROM fleet_assets LIMIT 1`)
+	if err == nil {
+		t.Fatalf("fleet_assets should not exist after down to 57")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "42P01" { // undefined_table
+		t.Fatalf("expected undefined_table after down, got %v", err)
+	}
+
+	if err := goose.UpTo(db, ".", 58); err != nil {
+		t.Fatalf("up to 58: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `SELECT 1 FROM fleet_assets LIMIT 1`); err != nil {
+		t.Fatalf("fleet_assets should exist after up to 58: %v", err)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -180,6 +180,10 @@ type Config struct {
 
 	// JudgmentsEnabled turns on the AI judgment lifecycle HTTP routes; off by default.
 	JudgmentsEnabled bool
+	// FleetAssetsEnabled turns on the multi-tenant fleet asset model (assets, edges, business
+	// services) and its HTTP routes; off by default. When on with Postgres, startup refuses to
+	// serve unless the DB role can enforce Row Level Security (not SUPERUSER/BYPASSRLS).
+	FleetAssetsEnabled bool
 	// SASTEnabled turns on the deterministic pattern-SAST analyzer in the scan pipeline; off by default.
 	SASTEnabled bool
 	// SecretScanEnabled turns on the deterministic secret scanner in the scan pipeline; off by default.
@@ -426,6 +430,7 @@ func Load() Config {
 		CrossCheckEnabled:      getbool("SYNAPSE_CROSSCHECK_ENABLED", true),
 		SBOMCrossCheckEnabled:  getbool("SYNAPSE_SBOM_CROSSCHECK_ENABLED", true),
 		WriteupDraftsEnabled:   getbool("SYNAPSE_WRITEUP_DRAFTS_ENABLED", false), // needs agent → opt-in
+		FleetAssetsEnabled:     getbool("SYNAPSE_FLEET_ASSETS_ENABLED", false),
 		GovulncheckBin:         getenv("SYNAPSE_GOVULNCHECK_BIN", "govulncheck"),
 		GoModGraphEnabled:      getbool("SYNAPSE_GOMODGRAPH_ENABLED", true),
 		GoBin:                  getenv("SYNAPSE_GO_BIN", "go"),

--- a/internal/usecase/assetuc/service.go
+++ b/internal/usecase/assetuc/service.go
@@ -93,6 +93,7 @@ type EdgeInput struct {
 // UpsertEdge validates and persists an edge. It is idempotent by natural key
 // (tenant, from, to, kind, provenance).
 func (s *Service) UpsertEdge(ctx context.Context, actor string, in EdgeInput) error {
+	now := s.clock.Now()
 	e, err := asset.NewEdge(in.TenantID, in.From, in.To, in.Kind, in.Provenance)
 	if err != nil {
 		return err
@@ -110,7 +111,7 @@ func (s *Service) UpsertEdge(ctx context.Context, actor string, in EdgeInput) er
 			"kind":       string(e.Kind),
 			"provenance": e.Provenance.String(),
 		},
-		At: s.clock.Now(),
+		At: now,
 	}); err != nil {
 		return fmt.Errorf("asset edge upsert: audit: %w", err)
 	}

--- a/internal/usecase/assetuc/service.go
+++ b/internal/usecase/assetuc/service.go
@@ -1,0 +1,179 @@
+// Package assetuc is the use-case layer for the fleet asset model (#431, epic #405). It
+// orchestrates the AssetRepository plus the audit log, clock and id generator ports, keeps the
+// domain pure, and audits every mutation. Upserts are idempotent by natural key: re-observing an
+// unchanged asset reuses its id and produces no duplicate row.
+package assetuc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Service is the asset-model use case.
+type Service struct {
+	repo  ports.AssetRepository
+	audit ports.AuditLogger
+	clock ports.Clock
+	ids   ports.IDGenerator
+}
+
+// NewService validates its dependencies and returns the service.
+func NewService(repo ports.AssetRepository, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if repo == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: asset service needs repo + audit + clock + ids", shared.ErrValidation)
+	}
+	return &Service{repo: repo, audit: audit, clock: clock, ids: ids}, nil
+}
+
+// UpsertAssetInput describes an observed asset. TenantID must be non-empty (empty is DENY under
+// RLS). Kind+Key are the natural identity; Name defaults to Key.
+type UpsertAssetInput struct {
+	TenantID   shared.ID
+	Kind       asset.Kind
+	Key        string
+	Name       string
+	Attributes map[string]string
+}
+
+// UpsertAsset creates or updates the asset identified by (TenantID, Kind, Key). It reuses the
+// existing id and creation time when the asset already exists, so ids are stable across
+// re-observation and no duplicate row is created.
+func (s *Service) UpsertAsset(ctx context.Context, actor string, in UpsertAssetInput) (*asset.Asset, error) {
+	now := s.clock.Now()
+	id := s.ids.NewID()
+	existing, err := s.repo.GetAssetByKey(ctx, in.TenantID, in.Kind, in.Key)
+	switch {
+	case err == nil:
+		id = existing.ID
+	case errors.Is(err, shared.ErrNotFound):
+		// new asset; keep the freshly generated id
+	default:
+		return nil, fmt.Errorf("asset upsert: lookup: %w", err)
+	}
+	a, err := asset.New(id, in.TenantID, in.Kind, in.Key, in.Name, in.Attributes, now)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		a.Audit.CreatedAt = existing.Audit.CreatedAt
+	}
+	if err := s.repo.UpsertAsset(ctx, a); err != nil {
+		return nil, fmt.Errorf("asset upsert: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor:  actor,
+		Action: "asset.upserted",
+		Target: a.ID.String(),
+		Metadata: map[string]string{
+			"tenant_id": a.TenantID.String(),
+			"kind":      string(a.Kind),
+			"key":       a.Key,
+		},
+		At: now,
+	}); err != nil {
+		return nil, fmt.Errorf("asset upsert: audit: %w", err)
+	}
+	return a, nil
+}
+
+// EdgeInput describes a typed, provenance-carrying relationship between two assets.
+type EdgeInput struct {
+	TenantID   shared.ID
+	From       shared.ID
+	To         shared.ID
+	Kind       asset.EdgeKind
+	Provenance shared.ID
+}
+
+// UpsertEdge validates and persists an edge. It is idempotent by natural key
+// (tenant, from, to, kind, provenance).
+func (s *Service) UpsertEdge(ctx context.Context, actor string, in EdgeInput) error {
+	e, err := asset.NewEdge(in.TenantID, in.From, in.To, in.Kind, in.Provenance)
+	if err != nil {
+		return err
+	}
+	if err := s.repo.UpsertEdge(ctx, e); err != nil {
+		return fmt.Errorf("asset edge upsert: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor:  actor,
+		Action: "asset.edge_upserted",
+		Target: e.From.String(),
+		Metadata: map[string]string{
+			"tenant_id":  e.TenantID.String(),
+			"to":         e.To.String(),
+			"kind":       string(e.Kind),
+			"provenance": e.Provenance.String(),
+		},
+		At: s.clock.Now(),
+	}); err != nil {
+		return fmt.Errorf("asset edge upsert: audit: %w", err)
+	}
+	return nil
+}
+
+// BusinessServiceInput describes a business service grouping.
+type BusinessServiceInput struct {
+	TenantID shared.ID
+	Name     string
+	Owner    string
+}
+
+// UpsertBusinessService creates or updates a business service by (TenantID, Name).
+func (s *Service) UpsertBusinessService(ctx context.Context, actor string, in BusinessServiceInput) (*asset.BusinessService, error) {
+	now := s.clock.Now()
+	id := s.ids.NewID()
+	existing, err := s.repo.GetBusinessServiceByName(ctx, in.TenantID, in.Name)
+	switch {
+	case err == nil:
+		id = existing.ID
+	case errors.Is(err, shared.ErrNotFound):
+		// new service; keep the freshly generated id
+	default:
+		return nil, fmt.Errorf("business service upsert: lookup: %w", err)
+	}
+	svc, err := asset.NewBusinessService(id, in.TenantID, in.Name, in.Owner, now)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		svc.Audit.CreatedAt = existing.Audit.CreatedAt
+	}
+	if err := s.repo.UpsertBusinessService(ctx, svc); err != nil {
+		return nil, fmt.Errorf("business service upsert: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor:  actor,
+		Action: "asset.business_service_upserted",
+		Target: svc.ID.String(),
+		Metadata: map[string]string{
+			"tenant_id": svc.TenantID.String(),
+			"name":      svc.Name,
+			"owner":     svc.Owner,
+		},
+		At: now,
+	}); err != nil {
+		return nil, fmt.Errorf("business service upsert: audit: %w", err)
+	}
+	return svc, nil
+}
+
+// ListAssets returns the tenant's assets, deterministically ordered.
+func (s *Service) ListAssets(ctx context.Context, tenantID shared.ID) ([]*asset.Asset, error) {
+	return s.repo.ListAssets(ctx, tenantID)
+}
+
+// ListEdges returns the tenant's edges, deterministically ordered.
+func (s *Service) ListEdges(ctx context.Context, tenantID shared.ID) ([]*asset.Edge, error) {
+	return s.repo.ListEdges(ctx, tenantID)
+}
+
+// ListBusinessServices returns the tenant's business services, deterministically ordered.
+func (s *Service) ListBusinessServices(ctx context.Context, tenantID shared.ID) ([]*asset.BusinessService, error) {
+	return s.repo.ListBusinessServices(ctx, tenantID)
+}

--- a/internal/usecase/assetuc/service_test.go
+++ b/internal/usecase/assetuc/service_test.go
@@ -1,0 +1,148 @@
+package assetuc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeClock struct{ t time.Time }
+
+func (c fakeClock) Now() time.Time { return c.t }
+
+type fakeIDs struct{ n int }
+
+func (g *fakeIDs) NewID() shared.ID {
+	g.n++
+	return shared.ID(fmt.Sprintf("id-%d", g.n))
+}
+
+type fakeAudit struct{ entries []ports.AuditEntry }
+
+func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.entries = append(a.entries, e)
+	return nil
+}
+
+func newTestService(t *testing.T) (*Service, *fakeAudit) {
+	t.Helper()
+	audit := &fakeAudit{}
+	svc, err := NewService(memory.NewAssetStore(), audit, fakeClock{t: time.Unix(1000, 0).UTC()}, &fakeIDs{})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return svc, audit
+}
+
+func TestNewServiceRejectsNilDeps(t *testing.T) {
+	if _, err := NewService(nil, &fakeAudit{}, fakeClock{}, &fakeIDs{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("expected ErrValidation for nil repo, got %v", err)
+	}
+}
+
+func TestUpsertAssetIsIdempotent(t *testing.T) {
+	svc, audit := newTestService(t)
+	ctx := context.Background()
+	in := UpsertAssetInput{TenantID: "t1", Kind: asset.KindImage, Key: "sha256:abc", Name: "img"}
+
+	first, err := svc.UpsertAsset(ctx, "actor", in)
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	second, err := svc.UpsertAsset(ctx, "actor", in)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("re-observed asset must keep its id: %q vs %q", first.ID, second.ID)
+	}
+	list, err := svc.ListAssets(ctx, "t1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("idempotent upsert must not churn: got %d assets", len(list))
+	}
+	if len(audit.entries) != 2 {
+		t.Fatalf("expected 2 audit entries, got %d", len(audit.entries))
+	}
+	if audit.entries[0].Action != "asset.upserted" {
+		t.Fatalf("unexpected audit action %q", audit.entries[0].Action)
+	}
+}
+
+func TestUpsertEdgeRequiresProvenance(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	err := svc.UpsertEdge(ctx, "actor", EdgeInput{TenantID: "t1", From: "a1", To: "a2", Kind: asset.EdgeRuns})
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("edge without provenance must fail validation, got %v", err)
+	}
+}
+
+func TestUpsertEdgePersistsAndAudits(t *testing.T) {
+	svc, audit := newTestService(t)
+	ctx := context.Background()
+	if err := svc.UpsertEdge(ctx, "actor", EdgeInput{TenantID: "t1", From: "a1", To: "a2", Kind: asset.EdgeRuns, Provenance: "obs1"}); err != nil {
+		t.Fatalf("upsert edge: %v", err)
+	}
+	edges, err := svc.ListEdges(ctx, "t1")
+	if err != nil {
+		t.Fatalf("list edges: %v", err)
+	}
+	if len(edges) != 1 || edges[0].Kind != asset.EdgeRuns {
+		t.Fatalf("expected one runs edge, got %+v", edges)
+	}
+	if len(audit.entries) != 1 || audit.entries[0].Action != "asset.edge_upserted" {
+		t.Fatalf("expected edge audit entry, got %+v", audit.entries)
+	}
+}
+
+func TestUpsertBusinessServiceIsIdempotent(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	in := BusinessServiceInput{TenantID: "t1", Name: "payments", Owner: "team-a"}
+	first, err := svc.UpsertBusinessService(ctx, "actor", in)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := svc.UpsertBusinessService(ctx, "actor", BusinessServiceInput{TenantID: "t1", Name: "payments", Owner: "team-b"})
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("service upsert must keep id: %q vs %q", first.ID, second.ID)
+	}
+	list, err := svc.ListBusinessServices(ctx, "t1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 || list[0].Owner != "team-b" {
+		t.Fatalf("expected one service with updated owner, got %+v", list)
+	}
+}
+
+func TestListAssetsTenantScoped(t *testing.T) {
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	if _, err := svc.UpsertAsset(ctx, "actor", UpsertAssetInput{TenantID: "t1", Kind: asset.KindHost, Key: "h1"}); err != nil {
+		t.Fatalf("t1: %v", err)
+	}
+	if _, err := svc.UpsertAsset(ctx, "actor", UpsertAssetInput{TenantID: "t2", Kind: asset.KindHost, Key: "h2"}); err != nil {
+		t.Fatalf("t2: %v", err)
+	}
+	list, err := svc.ListAssets(ctx, "t1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 || list[0].Key != "h1" {
+		t.Fatalf("tenant t1 should see only its asset, got %+v", list)
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/advisory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/audit"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/aup"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/callgraph"
@@ -54,6 +55,22 @@ type ProjectRepository interface {
 	// AssignProfile sets (or clears, with an empty profileKey) the quality profile assigned to a
 	// language for a project (project.DefaultProfileByLang[language]).
 	AssignProfile(ctx context.Context, tenantID shared.ID, projectKey, language, profileKey string) error
+}
+
+// AssetRepository persists the tenant-scoped fleet asset model (assets, typed edges, business
+// services). Every method is tenant-scoped; the Postgres implementation routes all access through
+// WithTenant so Row Level Security enforces isolation at the database. Upserts are idempotent by
+// natural key so re-observing an unchanged asset produces no churn. Lists return deterministically
+// ordered results.
+type AssetRepository interface {
+	UpsertAsset(ctx context.Context, a *asset.Asset) error
+	GetAssetByKey(ctx context.Context, tenantID shared.ID, kind asset.Kind, key string) (*asset.Asset, error)
+	ListAssets(ctx context.Context, tenantID shared.ID) ([]*asset.Asset, error)
+	UpsertEdge(ctx context.Context, e *asset.Edge) error
+	ListEdges(ctx context.Context, tenantID shared.ID) ([]*asset.Edge, error)
+	UpsertBusinessService(ctx context.Context, s *asset.BusinessService) error
+	GetBusinessServiceByName(ctx context.Context, tenantID shared.ID, name string) (*asset.BusinessService, error)
+	ListBusinessServices(ctx context.Context, tenantID shared.ID) ([]*asset.BusinessService, error)
 }
 
 // QualityGateStore persists tenant-scoped custom gate definitions.

--- a/migrations/0058_fleet_assets.sql
+++ b/migrations/0058_fleet_assets.sql
@@ -1,0 +1,53 @@
+-- +goose Up
+-- Fleet asset model (#431, epic #405): canonical assets, typed provenance-carrying edges, and a
+-- business-service grouping. These are the FIRST tables to adopt Row Level Security via the 0057
+-- procedure, which is what that migration was built for.
+--
+-- Tenancy invariant (see 0057): RLS-protected tables use NON-EMPTY tenant ids. The empty string
+-- resolves to NULL under synapse_current_tenant() and means DENY, so the default single-tenant
+-- deployment must supply a non-empty tenant id for these tables.
+--
+-- SECURITY: RLS is silently a no-op if the runtime DB role is SUPERUSER or has BYPASSRLS,
+-- regardless of FORCE. The server MUST call postgres.CheckRLSRuntimeRole at startup when the
+-- fleet asset model is enabled and refuse to serve on error (#431 requirement 6, #432). This
+-- migration cannot enforce that; the composition root does.
+
+CREATE TABLE fleet_assets (
+    id          TEXT PRIMARY KEY,
+    tenant_id   TEXT NOT NULL REFERENCES tenants(id),
+    kind        TEXT NOT NULL,
+    "key"       TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    attributes  JSONB NOT NULL DEFAULT '{}',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, kind, "key")
+);
+CREATE INDEX idx_fleet_assets_tenant_created ON fleet_assets(tenant_id, created_at DESC);
+CALL synapse_enable_tenant_rls('fleet_assets');
+
+CREATE TABLE fleet_asset_edges (
+    tenant_id  TEXT NOT NULL REFERENCES tenants(id),
+    from_asset TEXT NOT NULL,
+    to_asset   TEXT NOT NULL,
+    kind       TEXT NOT NULL,
+    provenance TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, from_asset, to_asset, kind, provenance)
+);
+CALL synapse_enable_tenant_rls('fleet_asset_edges');
+
+CREATE TABLE fleet_business_services (
+    id         TEXT PRIMARY KEY,
+    tenant_id  TEXT NOT NULL REFERENCES tenants(id),
+    name       TEXT NOT NULL,
+    owner      TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, name)
+);
+CALL synapse_enable_tenant_rls('fleet_business_services');
+
+-- +goose Down
+DROP TABLE fleet_business_services;
+DROP TABLE fleet_asset_edges;
+DROP TABLE fleet_assets;

--- a/migrations/0058_fleet_assets.sql
+++ b/migrations/0058_fleet_assets.sql
@@ -12,6 +12,11 @@
 -- fleet asset model is enabled and refuse to serve on error (#431 requirement 6, #432). This
 -- migration cannot enforce that; the composition root does.
 
+-- Seed the non-empty default fleet tenant. RLS-protected tables cannot use the empty-string
+-- default tenant (empty = DENY), so the single-tenant / default deployment maps the empty
+-- principal tenant to 'default' (see httpapi.DefaultFleetTenant); this row satisfies the FK.
+INSERT INTO tenants (id, name) VALUES ('default', 'default fleet tenant') ON CONFLICT (id) DO NOTHING;
+
 CREATE TABLE fleet_assets (
     id          TEXT PRIMARY KEY,
     tenant_id   TEXT NOT NULL REFERENCES tenants(id),
@@ -21,18 +26,26 @@ CREATE TABLE fleet_assets (
     attributes  JSONB NOT NULL DEFAULT '{}',
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-    UNIQUE (tenant_id, kind, "key")
+    UNIQUE (tenant_id, kind, "key"),
+    -- FK target for the composite edge references below (id is already unique via the PK, but a
+    -- composite FK needs a unique constraint on exactly (tenant_id, id)).
+    UNIQUE (tenant_id, id)
 );
 CREATE INDEX idx_fleet_assets_tenant_created ON fleet_assets(tenant_id, created_at DESC);
 CALL synapse_enable_tenant_rls('fleet_assets');
 
+-- Edges reference assets via a COMPOSITE FK that includes tenant_id, so an edge can only point at
+-- assets in its own tenant. Referential-integrity checks bypass RLS in PostgreSQL, so the tenant_id
+-- in the FK is what prevents a cross-tenant reference; it also rejects dangling edges.
 CREATE TABLE fleet_asset_edges (
     tenant_id  TEXT NOT NULL REFERENCES tenants(id),
     from_asset TEXT NOT NULL,
     to_asset   TEXT NOT NULL,
     kind       TEXT NOT NULL,
     provenance TEXT NOT NULL,
-    PRIMARY KEY (tenant_id, from_asset, to_asset, kind, provenance)
+    PRIMARY KEY (tenant_id, from_asset, to_asset, kind, provenance),
+    FOREIGN KEY (tenant_id, from_asset) REFERENCES fleet_assets(tenant_id, id),
+    FOREIGN KEY (tenant_id, to_asset) REFERENCES fleet_assets(tenant_id, id)
 );
 CALL synapse_enable_tenant_rls('fleet_asset_edges');
 


### PR DESCRIPTION
Implements #431 (epic #405): the fleet asset model, multi-tenant and RLS-enforced. First real adopter of the #432 Row Level Security foundation.

## What this delivers
- **Domain** `internal/domain/asset`: pure aggregate. Closed `Kind` set (host, workload, image, cloud_account, storage, exposure, identity, namespace, cluster), closed `EdgeKind` set, an `Edge` whose `Provenance` is required, and a `BusinessService`. Every aggregate requires a NON-EMPTY tenant id (under RLS the empty string is DENY, per #432).
- **Port** `ports.AssetRepository`; **usecase** `assetuc.Service` audits every mutation and makes upserts idempotent by natural key (re-observation reuses the id, no churn).
- **Stores**: memory + Postgres. The Postgres store is the first to route every operation through `WithTenant`, so RLS enforces isolation at the database.
- **Migration** `0058_fleet_assets.sql`: `fleet_assets`, `fleet_asset_edges`, `fleet_business_services`, each `CALL synapse_enable_tenant_rls(...)`.
- **HTTP**: `/api/v1/assets`, `/assets/edges`, `/assets/services` behind the `authz` RBAC chokepoint, tenant from context; optional, registered only when enabled.
- **Config** `SYNAPSE_FLEET_ASSETS_ENABLED` (default off).

## SECURITY: the mandatory RLS runtime-role gate (#431 req 6)
RLS is silently a no-op if the runtime DB role is SUPERUSER or has BYPASSRLS, regardless of FORCE. This PR wires `CheckRLSRuntimeRole` fail-closed: when the asset model is enabled with Postgres, startup refuses to serve (os.Exit) if the role cannot enforce RLS. A `// SECURITY:` marker sits at the `synapse_enable_tenant_rls` call site and in the composition root. This is the follow-through the #432 re-audit required before the first table went live.

## Verification
- `go build ./...`, `go vet ./...`, gofmt clean.
- `go test ./...` (CI-equivalent, no DSN) passes; the integration tests skip like every other Postgres integration test.
- Against a real Postgres (`SYNAPSE_TEST_DB_DSN`):
  - `TestAssetRepository`: store roundtrip, idempotent upsert (one row, stable id), query-level tenant scoping, edge and business-service roundtrip + idempotency, ErrNotFound.
  - `TestFleetAssetsRLS`: FORCE set on all three tables; DB-level isolation proven via an INTENTIONALLY UNSCOPED `SELECT` under a `NOSUPERUSER NOBYPASSRLS` role (tenant A sees only its rows, tenant B only its own, zero when unset).
  - `TestMigration0058`: migration down to 57 (table gone) and up to 58 (table back).
  - Domain, usecase (memory-backed), and route-presence tests.

## Scope
Consumers (attack path #419, cluster/cloud producers #411/#429, risk story #427, fleet coverage #413) are separate issues that read/write this model. This PR is the model plus its governed write/read surface.

Refs #405
