### PR TITLE
feat(fleet): work order model, addressed, signed and RLS-enforced (#407)

### DIFF
--- a/internal/domain/workorder/workorder.go
+++ b/internal/domain/workorder/workorder.go
@@ -1,0 +1,140 @@
+// Package workorder is the epic-#405 fleet work order model: a unit of work addressed to a
+// specific agent identity, authorised by an engagement, signed by the control plane, and driven
+// through an explicit state machine. It is pure domain: it imports only shared and the stdlib.
+//
+// The signing itself lives outside the domain (a platform signer holds the key); the domain only
+// defines the canonical, deterministic payload that is signed, so the authorising fields cannot
+// drift between issue and verify.
+package workorder
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// State is the lifecycle of a work order. Terminal states never transition again.
+type State string
+
+const (
+	StateIssued    State = "issued"
+	StateClaimed   State = "claimed"
+	StateRunning   State = "running"
+	StateSucceeded State = "succeeded"
+	StateFailed    State = "failed"
+	StateExpired   State = "expired"
+	StateCancelled State = "cancelled"
+	StateRefused   State = "refused"
+)
+
+// Valid reports whether s is a known state.
+func (s State) Valid() bool {
+	switch s {
+	case StateIssued, StateClaimed, StateRunning, StateSucceeded, StateFailed,
+		StateExpired, StateCancelled, StateRefused:
+		return true
+	default:
+		return false
+	}
+}
+
+// Terminal reports whether s is a final state.
+func (s State) Terminal() bool {
+	switch s {
+	case StateSucceeded, StateFailed, StateExpired, StateCancelled, StateRefused:
+		return true
+	default:
+		return false
+	}
+}
+
+// allowedTransitions is the closed transition graph. Anything not listed is rejected.
+var allowedTransitions = map[State]map[State]bool{
+	StateIssued:  {StateClaimed: true, StateExpired: true, StateCancelled: true},
+	StateClaimed: {StateRunning: true, StateRefused: true, StateExpired: true, StateCancelled: true},
+	StateRunning: {StateSucceeded: true, StateFailed: true, StateCancelled: true},
+}
+
+// CanTransition reports whether from -> to is a legal transition.
+func CanTransition(from, to State) bool {
+	return allowedTransitions[from][to]
+}
+
+// WorkOrder is one addressed, signed, authorised unit of work.
+type WorkOrder struct {
+	ID              shared.ID
+	TenantID        shared.ID
+	AssetID         shared.ID
+	AgentID         shared.ID // the addressed recipient; only this agent may claim it
+	Capability      string    // e.g. scan.source, scan.host, detect.rules
+	AuthorizationID shared.ID // the engagement/assessment that authorises the work
+	IdempotencyKey  string
+	NotAfter        time.Time // expiry; the order cannot be claimed after this
+	TimeBucket      int64     // unix bucket for the in-flight uniqueness guard
+	State           State
+	RefuseReason    string // non-empty only when State == StateRefused
+	Signature       string // control-plane signature over SigningPayload()
+	Audit           shared.Audit
+}
+
+// New validates and constructs a work order in the issued state. Signature is set separately by
+// the issuing service after signing SigningPayload().
+func New(id, tenantID, assetID, agentID shared.ID, capability string, authorizationID shared.ID, idempotencyKey string, notAfter time.Time, timeBucket int64, now time.Time) (*WorkOrder, error) {
+	if id.IsZero() {
+		return nil, fmt.Errorf("%w: work order id is required", shared.ErrValidation)
+	}
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: work order tenant id is required (empty tenant is DENY under RLS)", shared.ErrValidation)
+	}
+	if assetID.IsZero() {
+		return nil, fmt.Errorf("%w: work order asset id is required", shared.ErrValidation)
+	}
+	if agentID.IsZero() {
+		return nil, fmt.Errorf("%w: work order agent id is required (orders are addressed)", shared.ErrValidation)
+	}
+	capability = strings.TrimSpace(capability)
+	if capability == "" {
+		return nil, fmt.Errorf("%w: work order capability is required", shared.ErrValidation)
+	}
+	if authorizationID.IsZero() {
+		return nil, fmt.Errorf("%w: work order authorization id is required", shared.ErrValidation)
+	}
+	idempotencyKey = strings.TrimSpace(idempotencyKey)
+	if idempotencyKey == "" {
+		return nil, fmt.Errorf("%w: work order idempotency key is required", shared.ErrValidation)
+	}
+	if notAfter.IsZero() {
+		return nil, fmt.Errorf("%w: work order expiry (not_after) is required", shared.ErrValidation)
+	}
+	return &WorkOrder{
+		ID:              id,
+		TenantID:        tenantID,
+		AssetID:         assetID,
+		AgentID:         agentID,
+		Capability:      capability,
+		AuthorizationID: authorizationID,
+		IdempotencyKey:  idempotencyKey,
+		NotAfter:        notAfter,
+		TimeBucket:      timeBucket,
+		State:           StateIssued,
+		Audit:           shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}, nil
+}
+
+// SigningPayload is the canonical, deterministic representation of the authorising fields that the
+// control plane signs and the agent verifies. Order and separators are fixed so the signature is
+// stable. It deliberately covers the identity, the capability, the authorising engagement and the
+// expiry, so a tampered target, capability, authorization or expiry invalidates the signature.
+func (w *WorkOrder) SigningPayload() string {
+	return strings.Join([]string{
+		w.ID.String(),
+		w.TenantID.String(),
+		w.AssetID.String(),
+		w.AgentID.String(),
+		w.Capability,
+		w.AuthorizationID.String(),
+		w.NotAfter.UTC().Format(time.RFC3339Nano),
+	}, "\n")
+}

--- a/internal/domain/workorder/workorder_test.go
+++ b/internal/domain/workorder/workorder_test.go
@@ -1,0 +1,128 @@
+package workorder
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var (
+	testNow      = time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	testNotAfter = testNow.Add(time.Hour)
+)
+
+func newValid(t *testing.T) *WorkOrder {
+	t.Helper()
+	w, err := New("wo1", "t1", "as1", "ag1", "scan.source", "eng1", "idem1", testNotAfter, 42, testNow)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return w
+}
+
+func TestNewValidation(t *testing.T) {
+	tests := []struct {
+		name                                      string
+		id, tenant, asset, agent, cap, auth, idem string
+		notAfter                                  time.Time
+		wantErr                                   bool
+	}{
+		{"ok", "wo1", "t1", "as1", "ag1", "scan.source", "eng1", "idem1", testNotAfter, false},
+		{"missing id", "", "t1", "as1", "ag1", "scan.source", "eng1", "idem1", testNotAfter, true},
+		{"empty tenant deny", "wo1", "", "as1", "ag1", "scan.source", "eng1", "idem1", testNotAfter, true},
+		{"missing asset", "wo1", "t1", "", "ag1", "scan.source", "eng1", "idem1", testNotAfter, true},
+		{"missing agent", "wo1", "t1", "as1", "", "scan.source", "eng1", "idem1", testNotAfter, true},
+		{"missing capability", "wo1", "t1", "as1", "ag1", "  ", "eng1", "idem1", testNotAfter, true},
+		{"missing authorization", "wo1", "t1", "as1", "ag1", "scan.source", "", "idem1", testNotAfter, true},
+		{"missing idempotency", "wo1", "t1", "as1", "ag1", "scan.source", "eng1", " ", testNotAfter, true},
+		{"missing not_after", "wo1", "t1", "as1", "ag1", "scan.source", "eng1", "idem1", time.Time{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := New(shared.ID(tc.id), shared.ID(tc.tenant), shared.ID(tc.asset), shared.ID(tc.agent),
+				tc.cap, shared.ID(tc.auth), tc.idem, tc.notAfter, 1, testNow)
+			if tc.wantErr {
+				if !errors.Is(err, shared.ErrValidation) {
+					t.Fatalf("expected ErrValidation, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if w.State != StateIssued {
+				t.Fatalf("new order should be issued, got %q", w.State)
+			}
+		})
+	}
+}
+
+func TestStateValidAndTerminal(t *testing.T) {
+	all := []State{StateIssued, StateClaimed, StateRunning, StateSucceeded, StateFailed, StateExpired, StateCancelled, StateRefused}
+	for _, s := range all {
+		if !s.Valid() {
+			t.Errorf("%q should be valid", s)
+		}
+	}
+	if State("bogus").Valid() {
+		t.Errorf("bogus should be invalid")
+	}
+	terminal := map[State]bool{StateSucceeded: true, StateFailed: true, StateExpired: true, StateCancelled: true, StateRefused: true}
+	for _, s := range all {
+		if s.Terminal() != terminal[s] {
+			t.Errorf("%q terminal mismatch", s)
+		}
+	}
+}
+
+func TestCanTransition(t *testing.T) {
+	legal := map[State][]State{
+		StateIssued:  {StateClaimed, StateExpired, StateCancelled},
+		StateClaimed: {StateRunning, StateRefused, StateExpired, StateCancelled},
+		StateRunning: {StateSucceeded, StateFailed, StateCancelled},
+	}
+	all := []State{StateIssued, StateClaimed, StateRunning, StateSucceeded, StateFailed, StateExpired, StateCancelled, StateRefused}
+	for _, from := range all {
+		for _, to := range all {
+			want := false
+			for _, ok := range legal[from] {
+				if ok == to {
+					want = true
+				}
+			}
+			if got := CanTransition(from, to); got != want {
+				t.Errorf("CanTransition(%q,%q)=%v want %v", from, to, got, want)
+			}
+		}
+	}
+	// terminal states never transition
+	for s := range map[State]bool{StateSucceeded: true, StateFailed: true, StateExpired: true, StateCancelled: true, StateRefused: true} {
+		for _, to := range all {
+			if CanTransition(s, to) {
+				t.Errorf("terminal %q should not transition to %q", s, to)
+			}
+		}
+	}
+}
+
+func TestSigningPayloadStableAndCoversFields(t *testing.T) {
+	w := newValid(t)
+	p1 := w.SigningPayload()
+	if p1 != w.SigningPayload() {
+		t.Fatalf("signing payload must be deterministic")
+	}
+	// A tampered capability changes the payload (so it invalidates any signature over it).
+	w2 := newValid(t)
+	w2.Capability = "scan.host"
+	if w2.SigningPayload() == p1 {
+		t.Fatalf("changing capability must change the signing payload")
+	}
+	// A tampered expiry changes the payload.
+	w3 := newValid(t)
+	w3.NotAfter = testNotAfter.Add(time.Hour)
+	if w3.SigningPayload() == p1 {
+		t.Fatalf("changing not_after must change the signing payload")
+	}
+}

--- a/internal/infrastructure/persistence/memory/workorder_store.go
+++ b/internal/infrastructure/persistence/memory/workorder_store.go
@@ -94,8 +94,9 @@ func (s *WorkOrderStore) Claim(_ context.Context, tenantID, agentID shared.ID, m
 	return out, nil
 }
 
-// Transition applies to with an optimistic expected-state check (shared.ErrConflict on mismatch).
-func (s *WorkOrderStore) Transition(_ context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State) error {
+// Transition applies to with an optimistic expected-state check: shared.ErrNotFound when the order
+// does not exist under the tenant, shared.ErrConflict when its state no longer matches expected.
+func (s *WorkOrderStore) Transition(_ context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	o, ok := s.byID[woKey(tenantID, id)]
@@ -107,6 +108,7 @@ func (s *WorkOrderStore) Transition(_ context.Context, tenantID, id shared.ID, t
 	}
 	o.State = to
 	o.RefuseReason = reason
+	o.Audit.UpdatedAt = now
 	return nil
 }
 

--- a/internal/infrastructure/persistence/memory/workorder_store.go
+++ b/internal/infrastructure/persistence/memory/workorder_store.go
@@ -1,0 +1,115 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// WorkOrderStore is an in-memory ports.WorkOrderStore for dev and tests. It mirrors the Postgres
+// store's idempotency, in-flight uniqueness and CAS-transition semantics.
+type WorkOrderStore struct {
+	mu     sync.Mutex
+	byID   map[string]*workorder.WorkOrder // key: tenant|id
+	byIdem map[string]string               // key: tenant|idem -> id
+}
+
+// NewWorkOrderStore returns an empty in-memory work order store.
+func NewWorkOrderStore() *WorkOrderStore {
+	return &WorkOrderStore{byID: map[string]*workorder.WorkOrder{}, byIdem: map[string]string{}}
+}
+
+var _ ports.WorkOrderStore = (*WorkOrderStore)(nil)
+
+func woKey(tenant, id shared.ID) string { return tenant.String() + "|" + id.String() }
+func idemKey(tenant shared.ID, idem string) string {
+	return tenant.String() + "|" + idem
+}
+
+// Issue stores wo. It is idempotent by (tenant, idempotency key) and rejects a second live order
+// for the same (tenant, asset, capability, time bucket) with shared.ErrConflict.
+func (s *WorkOrderStore) Issue(_ context.Context, wo *workorder.WorkOrder) (*workorder.WorkOrder, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existingID, ok := s.byIdem[idemKey(wo.TenantID, wo.IdempotencyKey)]; ok {
+		cp := *s.byID[woKey(wo.TenantID, shared.ID(existingID))]
+		return &cp, nil
+	}
+	for _, o := range s.byID {
+		if o.TenantID == wo.TenantID && o.AssetID == wo.AssetID && o.Capability == wo.Capability &&
+			o.TimeBucket == wo.TimeBucket && isLive(o.State) {
+			return nil, shared.ErrConflict
+		}
+	}
+	cp := *wo
+	s.byID[woKey(wo.TenantID, wo.ID)] = &cp
+	s.byIdem[idemKey(wo.TenantID, wo.IdempotencyKey)] = wo.ID.String()
+	out := *wo
+	return &out, nil
+}
+
+// GetByID returns the order or shared.ErrNotFound.
+func (s *WorkOrderStore) GetByID(_ context.Context, tenantID, id shared.ID) (*workorder.WorkOrder, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	o, ok := s.byID[woKey(tenantID, id)]
+	if !ok {
+		return nil, shared.ErrNotFound
+	}
+	cp := *o
+	return &cp, nil
+}
+
+// Claim atomically moves up to max unexpired issued orders addressed to agentID into claimed.
+func (s *WorkOrderStore) Claim(_ context.Context, tenantID, agentID shared.ID, max int, now time.Time) ([]*workorder.WorkOrder, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var eligible []*workorder.WorkOrder
+	for _, o := range s.byID {
+		if o.TenantID == tenantID && o.AgentID == agentID && o.State == workorder.StateIssued && o.NotAfter.After(now) {
+			eligible = append(eligible, o)
+		}
+	}
+	sort.Slice(eligible, func(i, j int) bool {
+		if !eligible[i].Audit.CreatedAt.Equal(eligible[j].Audit.CreatedAt) {
+			return eligible[i].Audit.CreatedAt.Before(eligible[j].Audit.CreatedAt)
+		}
+		return eligible[i].ID < eligible[j].ID
+	})
+	var out []*workorder.WorkOrder
+	for _, o := range eligible {
+		if len(out) >= max {
+			break
+		}
+		o.State = workorder.StateClaimed
+		o.Audit.UpdatedAt = now
+		cp := *o
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+// Transition applies to with an optimistic expected-state check (shared.ErrConflict on mismatch).
+func (s *WorkOrderStore) Transition(_ context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	o, ok := s.byID[woKey(tenantID, id)]
+	if !ok {
+		return shared.ErrNotFound
+	}
+	if o.State != expected {
+		return shared.ErrConflict
+	}
+	o.State = to
+	o.RefuseReason = reason
+	return nil
+}
+
+func isLive(s workorder.State) bool {
+	return s == workorder.StateIssued || s == workorder.StateClaimed || s == workorder.StateRunning
+}

--- a/internal/infrastructure/persistence/postgres/workorder_repo.go
+++ b/internal/infrastructure/persistence/postgres/workorder_repo.go
@@ -1,0 +1,179 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// WorkOrderRepository is the Postgres-backed fleet work order store. Every method runs through
+// WithTenant so Row Level Security (migration 0059 via the 0057 procedure) isolates by tenant.
+type WorkOrderRepository struct{ pool *pgxpool.Pool }
+
+// NewWorkOrderRepository constructs the Postgres work order repository.
+func NewWorkOrderRepository(pool *pgxpool.Pool) *WorkOrderRepository {
+	return &WorkOrderRepository{pool: pool}
+}
+
+var _ ports.WorkOrderStore = (*WorkOrderRepository)(nil)
+
+const workOrderCols = `id, tenant_id, asset_id, agent_id, capability, authorization_id, idempotency_key, not_after, time_bucket, state, refuse_reason, signature, created_at, updated_at`
+
+// Issue inserts wo. It is idempotent by (tenant, idempotency key): a duplicate returns the existing
+// order. A second LIVE order for the same (tenant, asset, capability, time bucket) returns
+// shared.ErrConflict (the partial unique index).
+func (r *WorkOrderRepository) Issue(ctx context.Context, wo *workorder.WorkOrder) (*workorder.WorkOrder, error) {
+	// Idempotency first: if an order already exists for this (tenant, idempotency key), return it.
+	// Doing this before the insert is what makes a re-issue idempotent rather than colliding with
+	// the in-flight uniqueness index (both constraints would fire for the same key, and Postgres
+	// reports only one, non-deterministically).
+	if existing, err := r.getByIdem(ctx, wo.TenantID, wo.IdempotencyKey); err == nil {
+		return existing, nil
+	} else if !errors.Is(err, shared.ErrNotFound) {
+		return nil, err
+	}
+	insertErr := WithTenant(ctx, r.pool, wo.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO work_orders (`+workOrderCols+`)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+			wo.ID.String(), wo.TenantID.String(), wo.AssetID.String(), wo.AgentID.String(), wo.Capability,
+			wo.AuthorizationID.String(), wo.IdempotencyKey, wo.NotAfter, wo.TimeBucket, string(wo.State),
+			wo.RefuseReason, wo.Signature, wo.Audit.CreatedAt, wo.Audit.UpdatedAt)
+		return err
+	})
+	if insertErr == nil {
+		out := *wo
+		return &out, nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(insertErr, &pgErr) && pgErr.Code == "23505" {
+		switch pgErr.ConstraintName {
+		case "work_orders_idem":
+			// Idempotent issue: return the existing order.
+			return r.getByIdem(ctx, wo.TenantID, wo.IdempotencyKey)
+		case "work_orders_inflight":
+			return nil, shared.ErrConflict
+		}
+	}
+	return nil, insertErr
+}
+
+func (r *WorkOrderRepository) getByIdem(ctx context.Context, tenantID shared.ID, idem string) (*workorder.WorkOrder, error) {
+	var out *workorder.WorkOrder
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		wo, e := scanWorkOrder(tx.QueryRow(ctx, `SELECT `+workOrderCols+` FROM work_orders WHERE tenant_id=$1 AND idempotency_key=$2`,
+			tenantID.String(), idem))
+		if e != nil {
+			return e
+		}
+		out = wo
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetByID returns the order for (tenantID, id) or shared.ErrNotFound.
+func (r *WorkOrderRepository) GetByID(ctx context.Context, tenantID, id shared.ID) (*workorder.WorkOrder, error) {
+	var out *workorder.WorkOrder
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		wo, e := scanWorkOrder(tx.QueryRow(ctx, `SELECT `+workOrderCols+` FROM work_orders WHERE tenant_id=$1 AND id=$2`,
+			tenantID.String(), id.String()))
+		if e != nil {
+			return e
+		}
+		out = wo
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Claim atomically moves up to max unexpired issued orders addressed to agentID into claimed and
+// returns them, using FOR UPDATE SKIP LOCKED so concurrent claimers never double-claim.
+func (r *WorkOrderRepository) Claim(ctx context.Context, tenantID, agentID shared.ID, max int, now time.Time) ([]*workorder.WorkOrder, error) {
+	var out []*workorder.WorkOrder
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, e := tx.Query(ctx, `
+			UPDATE work_orders SET state='claimed', updated_at=$4
+			WHERE id IN (
+				SELECT id FROM work_orders
+				WHERE tenant_id=$1 AND agent_id=$2 AND state='issued' AND not_after > $4
+				ORDER BY created_at, id
+				LIMIT $3
+				FOR UPDATE SKIP LOCKED
+			)
+			RETURNING `+workOrderCols, tenantID.String(), agentID.String(), max, now)
+		if e != nil {
+			return e
+		}
+		defer rows.Close()
+		for rows.Next() {
+			wo, e := scanWorkOrder(rows)
+			if e != nil {
+				return e
+			}
+			out = append(out, wo)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Transition applies to with an optimistic expected-state check. It returns shared.ErrConflict when
+// no row matched (the state changed concurrently or the order does not exist under this tenant).
+func (r *WorkOrderRepository) Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State) error {
+	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `
+			UPDATE work_orders SET state=$3, refuse_reason=$4, updated_at=now()
+			WHERE tenant_id=$1 AND id=$2 AND state=$5`,
+			tenantID.String(), id.String(), string(to), reason, string(expected))
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return shared.ErrConflict
+		}
+		return nil
+	})
+}
+
+func scanWorkOrder(row rowScanner) (*workorder.WorkOrder, error) {
+	var (
+		id, tid, asset, agent, cap, auth, idem, state, reason, sig string
+		wo                                                         workorder.WorkOrder
+	)
+	if err := row.Scan(&id, &tid, &asset, &agent, &cap, &auth, &idem, &wo.NotAfter, &wo.TimeBucket,
+		&state, &reason, &sig, &wo.Audit.CreatedAt, &wo.Audit.UpdatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, shared.ErrNotFound
+		}
+		return nil, err
+	}
+	wo.ID = shared.ID(id)
+	wo.TenantID = shared.ID(tid)
+	wo.AssetID = shared.ID(asset)
+	wo.AgentID = shared.ID(agent)
+	wo.Capability = cap
+	wo.AuthorizationID = shared.ID(auth)
+	wo.IdempotencyKey = idem
+	wo.State = workorder.State(state)
+	wo.RefuseReason = reason
+	wo.Signature = sig
+	return &wo, nil
+}

--- a/internal/infrastructure/persistence/postgres/workorder_repo.go
+++ b/internal/infrastructure/persistence/postgres/workorder_repo.go
@@ -55,13 +55,17 @@ func (r *WorkOrderRepository) Issue(ctx context.Context, wo *workorder.WorkOrder
 	}
 	var pgErr *pgconn.PgError
 	if errors.As(insertErr, &pgErr) && pgErr.Code == "23505" {
-		switch pgErr.ConstraintName {
-		case "work_orders_idem":
-			// Idempotent issue: return the existing order.
-			return r.getByIdem(ctx, wo.TenantID, wo.IdempotencyKey)
-		case "work_orders_inflight":
-			return nil, shared.ErrConflict
+		// A concurrent issue committed between our pre-check and this insert. Regardless of which
+		// unique index Postgres reported (idempotency vs in-flight are checked in index-OID order,
+		// which we do not want to depend on), prefer returning the existing same-key order so an
+		// idempotent retry is idempotent; only a genuinely different order colliding on the
+		// in-flight slot is a conflict.
+		if existing, gerr := r.getByIdem(ctx, wo.TenantID, wo.IdempotencyKey); gerr == nil {
+			return existing, nil
+		} else if !errors.Is(gerr, shared.ErrNotFound) {
+			return nil, gerr
 		}
+		return nil, shared.ErrConflict
 	}
 	return nil, insertErr
 }
@@ -137,16 +141,26 @@ func (r *WorkOrderRepository) Claim(ctx context.Context, tenantID, agentID share
 
 // Transition applies to with an optimistic expected-state check. It returns shared.ErrConflict when
 // no row matched (the state changed concurrently or the order does not exist under this tenant).
-func (r *WorkOrderRepository) Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State) error {
+func (r *WorkOrderRepository) Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State, now time.Time) error {
 	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
-			UPDATE work_orders SET state=$3, refuse_reason=$4, updated_at=now()
+			UPDATE work_orders SET state=$3, refuse_reason=$4, updated_at=$6
 			WHERE tenant_id=$1 AND id=$2 AND state=$5`,
-			tenantID.String(), id.String(), string(to), reason, string(expected))
+			tenantID.String(), id.String(), string(to), reason, string(expected), now)
 		if err != nil {
 			return err
 		}
 		if tag.RowsAffected() == 0 {
+			// Distinguish "no such order under this tenant" (ErrNotFound) from "state no longer
+			// matches expected" (ErrConflict), matching the memory store's contract.
+			var exists bool
+			if e := tx.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM work_orders WHERE tenant_id=$1 AND id=$2)`,
+				tenantID.String(), id.String()).Scan(&exists); e != nil {
+				return e
+			}
+			if !exists {
+				return shared.ErrNotFound
+			}
 			return shared.ErrConflict
 		}
 		return nil

--- a/internal/infrastructure/persistence/postgres/workorder_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/workorder_repo_test.go
@@ -102,12 +102,17 @@ func TestWorkOrderRepository(t *testing.T) {
 	}
 
 	// Transition CAS: claimed -> running with correct expected state.
-	if err := repo.Transition(ctx, "wt", wo.ID, workorder.StateRunning, "", workorder.StateClaimed); err != nil {
+	tnow := time.Now().UTC()
+	if err := repo.Transition(ctx, "wt", wo.ID, workorder.StateRunning, "", workorder.StateClaimed, tnow); err != nil {
 		t.Fatalf("claimed->running: %v", err)
 	}
 	// Stale expected state now conflicts.
-	if err := repo.Transition(ctx, "wt", wo.ID, workorder.StateSucceeded, "", workorder.StateClaimed); !errors.Is(err, shared.ErrConflict) {
+	if err := repo.Transition(ctx, "wt", wo.ID, workorder.StateSucceeded, "", workorder.StateClaimed, tnow); !errors.Is(err, shared.ErrConflict) {
 		t.Fatalf("stale expected state must ErrConflict, got %v", err)
+	}
+	// A transition on a non-existent order is ErrNotFound, not ErrConflict.
+	if err := repo.Transition(ctx, "wt", "missing", workorder.StateRunning, "", workorder.StateClaimed, tnow); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("transition on missing order must ErrNotFound, got %v", err)
 	}
 
 	// GetByID + not found.

--- a/internal/infrastructure/persistence/postgres/workorder_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/workorder_repo_test.go
@@ -1,0 +1,160 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+func newWO(t *testing.T, idem string, bucket int64) *workorder.WorkOrder {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	wo, err := workorder.New(shared.ID("wo-"+idem), "wt", "as1", "ag1", "scan.source", "eng1", idem, now.Add(time.Hour), bucket, now)
+	if err != nil {
+		t.Fatalf("new wo: %v", err)
+	}
+	wo.Signature = "sig"
+	return wo
+}
+
+func TestWorkOrderRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ('wt','WT') ON CONFLICT (id) DO NOTHING`); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM work_orders WHERE tenant_id='wt'`)
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id='wt'`)
+	})
+
+	repo := NewWorkOrderRepository(pool)
+
+	// FORCE RLS on the table.
+	var forced bool
+	if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE relname='work_orders'`).Scan(&forced); err != nil {
+		t.Fatalf("relforce: %v", err)
+	}
+	if !forced {
+		t.Fatalf("FORCE ROW LEVEL SECURITY not set on work_orders")
+	}
+
+	// Issue + roundtrip.
+	wo := newWO(t, "idem1", 1)
+	got, err := repo.Issue(ctx, wo)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if got.ID != wo.ID || got.State != workorder.StateIssued {
+		t.Fatalf("issue roundtrip mismatch: %+v", got)
+	}
+
+	// Idempotent re-issue: same order id, no conflict.
+	again, err := repo.Issue(ctx, newWO(t, "idem1", 1))
+	if err != nil {
+		t.Fatalf("re-issue: %v", err)
+	}
+	if again.ID != wo.ID {
+		t.Fatalf("idempotent issue must return the same order: %q vs %q", again.ID, wo.ID)
+	}
+
+	// In-flight conflict: different idempotency key, same (asset, capability, bucket) while live.
+	conflict := newWO(t, "idem2", 1)
+	if _, err := repo.Issue(ctx, conflict); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("expected in-flight ErrConflict, got %v", err)
+	}
+
+	// Claim addressed to the agent; another agent claims nothing.
+	none, err := repo.Claim(ctx, "wt", "other-agent", 10, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("claim other: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("other agent must claim nothing, got %d", len(none))
+	}
+	claimed, err := repo.Claim(ctx, "wt", "ag1", 10, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("claim ag1: %v", err)
+	}
+	if len(claimed) != 1 || claimed[0].State != workorder.StateClaimed {
+		t.Fatalf("ag1 should claim one order into claimed, got %+v", claimed)
+	}
+
+	// Transition CAS: claimed -> running with correct expected state.
+	if err := repo.Transition(ctx, "wt", wo.ID, workorder.StateRunning, "", workorder.StateClaimed); err != nil {
+		t.Fatalf("claimed->running: %v", err)
+	}
+	// Stale expected state now conflicts.
+	if err := repo.Transition(ctx, "wt", wo.ID, workorder.StateSucceeded, "", workorder.StateClaimed); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale expected state must ErrConflict, got %v", err)
+	}
+
+	// GetByID + not found.
+	if _, err := repo.GetByID(ctx, "wt", wo.ID); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if _, err := repo.GetByID(ctx, "wt", "missing"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// TestMigration0059 exercises the migration down and back up.
+func TestMigration0059(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	db, err := goose.OpenDBWithDriver("pgx", dsn)
+	if err != nil {
+		t.Fatalf("goose open: %v", err)
+	}
+	defer db.Close()
+	goose.SetBaseFS(migrations.FS)
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatalf("dialect: %v", err)
+	}
+	if err := goose.DownTo(db, ".", 58); err != nil {
+		t.Fatalf("down to 58: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+	_, err = pool.Exec(ctx, `SELECT 1 FROM work_orders LIMIT 1`)
+	var pgErr *pgconn.PgError
+	if err == nil || !errors.As(err, &pgErr) || pgErr.Code != "42P01" {
+		t.Fatalf("work_orders should be undefined after down to 58, got %v", err)
+	}
+	if err := goose.UpTo(db, ".", 59); err != nil {
+		t.Fatalf("up to 59: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `SELECT 1 FROM work_orders LIMIT 1`); err != nil {
+		t.Fatalf("work_orders should exist after up to 59: %v", err)
+	}
+}

--- a/internal/platform/worksign/worksign.go
+++ b/internal/platform/worksign/worksign.go
@@ -1,0 +1,37 @@
+// Package worksign is the platform adapter that signs and verifies fleet work order payloads with
+// an HMAC-SHA256 keyed MAC. It holds the key so the key material never reaches the domain or the
+// use case, which depend only on the ports.WorkOrderSigner interface.
+package worksign
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// Signer is an HMAC-SHA256 work order signer.
+type Signer struct {
+	key []byte
+}
+
+// New returns a Signer keyed with key. The caller supplies the key from the credential vault or
+// configuration; it is never logged.
+func New(key []byte) *Signer {
+	// Copy so the caller cannot mutate the key after construction.
+	k := make([]byte, len(key))
+	copy(k, key)
+	return &Signer{key: k}
+}
+
+// Sign returns the base64 HMAC-SHA256 of payload.
+func (s *Signer) Sign(payload string) string {
+	mac := hmac.New(sha256.New, s.key)
+	mac.Write([]byte(payload))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// Verify reports whether signature is a valid MAC for payload, in constant time.
+func (s *Signer) Verify(payload, signature string) bool {
+	expected := s.Sign(payload)
+	return hmac.Equal([]byte(signature), []byte(expected))
+}

--- a/internal/platform/worksign/worksign.go
+++ b/internal/platform/worksign/worksign.go
@@ -7,20 +7,33 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
+	"fmt"
 )
+
+// MinKeyLen is the minimum HMAC key length. A short or empty key would make the MAC forgeable, so
+// the constructor fails closed below it.
+const MinKeyLen = 32
+
+// ErrWeakKey is returned when the signing key is shorter than MinKeyLen.
+var ErrWeakKey = errors.New("worksign: signing key too short")
 
 // Signer is an HMAC-SHA256 work order signer.
 type Signer struct {
 	key []byte
 }
 
-// New returns a Signer keyed with key. The caller supplies the key from the credential vault or
-// configuration; it is never logged.
-func New(key []byte) *Signer {
+// New returns a Signer keyed with key. It fails closed on a key shorter than MinKeyLen so a
+// missing or misconfigured key cannot boot a forgeable signer. The caller supplies the key from
+// the credential vault or configuration; it is never logged.
+func New(key []byte) (*Signer, error) {
+	if len(key) < MinKeyLen {
+		return nil, fmt.Errorf("%w: need at least %d bytes, got %d", ErrWeakKey, MinKeyLen, len(key))
+	}
 	// Copy so the caller cannot mutate the key after construction.
 	k := make([]byte, len(key))
 	copy(k, key)
-	return &Signer{key: k}
+	return &Signer{key: k}, nil
 }
 
 // Sign returns the base64 HMAC-SHA256 of payload.

--- a/internal/platform/worksign/worksign_test.go
+++ b/internal/platform/worksign/worksign_test.go
@@ -1,0 +1,56 @@
+package worksign
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNewRejectsWeakKey(t *testing.T) {
+	for _, k := range [][]byte{nil, []byte(""), []byte("short"), make([]byte, MinKeyLen-1)} {
+		if _, err := New(k); !errors.Is(err, ErrWeakKey) {
+			t.Fatalf("key of len %d should be rejected, got %v", len(k), err)
+		}
+	}
+	if _, err := New(make([]byte, MinKeyLen)); err != nil {
+		t.Fatalf("key of len %d should be accepted, got %v", MinKeyLen, err)
+	}
+}
+
+func TestSignVerify(t *testing.T) {
+	s, err := New([]byte(strings.Repeat("k", MinKeyLen)))
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	sig := s.Sign("payload-1")
+	if sig == "" {
+		t.Fatalf("empty signature")
+	}
+	if !s.Verify("payload-1", sig) {
+		t.Fatalf("valid signature must verify")
+	}
+	if s.Verify("payload-2", sig) {
+		t.Fatalf("signature must not verify for a different payload")
+	}
+	if s.Verify("payload-1", sig+"x") {
+		t.Fatalf("tampered signature must not verify")
+	}
+	// A different key produces a different, non-verifying signature.
+	other, _ := New([]byte(strings.Repeat("j", MinKeyLen)))
+	if other.Verify("payload-1", sig) {
+		t.Fatalf("signature from another key must not verify")
+	}
+}
+
+func TestNewCopiesKey(t *testing.T) {
+	key := []byte(strings.Repeat("k", MinKeyLen))
+	s, err := New(key)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	sig := s.Sign("p")
+	key[0] = 'z' // mutate caller's slice after construction
+	if s.Sign("p") != sig {
+		t.Fatalf("signer must copy the key so caller mutation does not change signatures")
+	}
+}

--- a/internal/usecase/fleetwork/service.go
+++ b/internal/usecase/fleetwork/service.go
@@ -86,6 +86,11 @@ func (s *Service) Verify(wo *workorder.WorkOrder) bool {
 // Claim atomically claims up to max unexpired orders addressed to agentID, moving them from issued
 // to claimed, and audits each claim.
 func (s *Service) Claim(ctx context.Context, actor string, tenantID, agentID shared.ID, max int) ([]*workorder.WorkOrder, error) {
+	if max <= 0 {
+		// Nothing to claim; return empty consistently rather than letting a negative LIMIT diverge
+		// between the Postgres and memory stores.
+		return nil, nil
+	}
 	now := s.clock.Now()
 	claimed, err := s.store.Claim(ctx, tenantID, agentID, max, now)
 	if err != nil {
@@ -122,7 +127,7 @@ func (s *Service) Transition(ctx context.Context, actor string, tenantID, id sha
 	if to == workorder.StateRefused && reason == "" {
 		return fmt.Errorf("%w: a refusal requires a reason", shared.ErrValidation)
 	}
-	if err := s.store.Transition(ctx, tenantID, id, to, reason, current.State); err != nil {
+	if err := s.store.Transition(ctx, tenantID, id, to, reason, current.State, now); err != nil {
 		return fmt.Errorf("work order transition: %w", err)
 	}
 	if err := s.audit.Record(ctx, ports.AuditEntry{

--- a/internal/usecase/fleetwork/service.go
+++ b/internal/usecase/fleetwork/service.go
@@ -1,0 +1,148 @@
+// Package fleetwork is the use-case layer for the fleet work order lifecycle (#407, epic #405):
+// issue a signed, addressed, authorised order; let an agent claim orders addressed to it; and
+// drive orders through the validated state machine. It audits every mutation and keeps the domain
+// pure. The store enforces tenant isolation (RLS), idempotency and the in-flight uniqueness guard;
+// this layer signs, validates transitions, and audits.
+package fleetwork
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Service is the work order use case.
+type Service struct {
+	store  ports.WorkOrderStore
+	signer ports.WorkOrderSigner
+	audit  ports.AuditLogger
+	clock  ports.Clock
+	ids    ports.IDGenerator
+}
+
+// NewService validates its dependencies and returns the service.
+func NewService(store ports.WorkOrderStore, signer ports.WorkOrderSigner, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if store == nil || signer == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: fleetwork service needs store + signer + audit + clock + ids", shared.ErrValidation)
+	}
+	return &Service{store: store, signer: signer, audit: audit, clock: clock, ids: ids}, nil
+}
+
+// IssueInput describes a work order to issue. TenantID must be non-empty (empty is DENY under RLS).
+type IssueInput struct {
+	TenantID        shared.ID
+	AssetID         shared.ID
+	AgentID         shared.ID
+	Capability      string
+	AuthorizationID shared.ID
+	IdempotencyKey  string
+	NotAfter        time.Time
+	TimeBucket      int64
+}
+
+// Issue builds, signs and persists a work order. It is idempotent by (tenant, idempotency key):
+// re-issuing returns the existing order. A second live order for the same
+// (tenant, asset, capability, time bucket) is rejected by the store with shared.ErrConflict.
+func (s *Service) Issue(ctx context.Context, actor string, in IssueInput) (*workorder.WorkOrder, error) {
+	now := s.clock.Now()
+	wo, err := workorder.New(s.ids.NewID(), in.TenantID, in.AssetID, in.AgentID, in.Capability,
+		in.AuthorizationID, in.IdempotencyKey, in.NotAfter, in.TimeBucket, now)
+	if err != nil {
+		return nil, err
+	}
+	wo.Signature = s.signer.Sign(wo.SigningPayload())
+
+	stored, err := s.store.Issue(ctx, wo)
+	if err != nil {
+		return nil, fmt.Errorf("work order issue: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor:  actor,
+		Action: "work_order.issued",
+		Target: stored.ID.String(),
+		Metadata: map[string]string{
+			"tenant_id":  stored.TenantID.String(),
+			"asset_id":   stored.AssetID.String(),
+			"agent_id":   stored.AgentID.String(),
+			"capability": stored.Capability,
+		},
+		At: now,
+	}); err != nil {
+		return nil, fmt.Errorf("work order issue: audit: %w", err)
+	}
+	return stored, nil
+}
+
+// Verify reports whether the order's signature matches its current authorising fields. The agent
+// runtime (a later issue) uses this before acting; exposed here so the signing contract is testable.
+func (s *Service) Verify(wo *workorder.WorkOrder) bool {
+	return s.signer.Verify(wo.SigningPayload(), wo.Signature)
+}
+
+// Claim atomically claims up to max unexpired orders addressed to agentID, moving them from issued
+// to claimed, and audits each claim.
+func (s *Service) Claim(ctx context.Context, actor string, tenantID, agentID shared.ID, max int) ([]*workorder.WorkOrder, error) {
+	now := s.clock.Now()
+	claimed, err := s.store.Claim(ctx, tenantID, agentID, max, now)
+	if err != nil {
+		return nil, fmt.Errorf("work order claim: %w", err)
+	}
+	for _, wo := range claimed {
+		if err := s.audit.Record(ctx, ports.AuditEntry{
+			Actor:  actor,
+			Action: "work_order.claimed",
+			Target: wo.ID.String(),
+			Metadata: map[string]string{
+				"tenant_id": wo.TenantID.String(),
+				"agent_id":  wo.AgentID.String(),
+			},
+			At: now,
+		}); err != nil {
+			return nil, fmt.Errorf("work order claim: audit: %w", err)
+		}
+	}
+	return claimed, nil
+}
+
+// Transition moves an order to a new state after validating the transition is legal for its current
+// state, using an optimistic expected-state check in the store. reason is required for a refusal.
+func (s *Service) Transition(ctx context.Context, actor string, tenantID, id shared.ID, to workorder.State, reason string) error {
+	now := s.clock.Now()
+	current, err := s.store.GetByID(ctx, tenantID, id)
+	if err != nil {
+		return fmt.Errorf("work order transition: %w", err)
+	}
+	if !workorder.CanTransition(current.State, to) {
+		return fmt.Errorf("%w: illegal work order transition %s -> %s", shared.ErrValidation, current.State, to)
+	}
+	if to == workorder.StateRefused && reason == "" {
+		return fmt.Errorf("%w: a refusal requires a reason", shared.ErrValidation)
+	}
+	if err := s.store.Transition(ctx, tenantID, id, to, reason, current.State); err != nil {
+		return fmt.Errorf("work order transition: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor:  actor,
+		Action: "work_order.transitioned",
+		Target: id.String(),
+		Metadata: map[string]string{
+			"tenant_id": tenantID.String(),
+			"from":      string(current.State),
+			"to":        string(to),
+			"reason":    reason,
+		},
+		At: now,
+	}); err != nil {
+		return fmt.Errorf("work order transition: audit: %w", err)
+	}
+	return nil
+}
+
+// GetByID returns the order or shared.ErrNotFound.
+func (s *Service) GetByID(ctx context.Context, tenantID, id shared.ID) (*workorder.WorkOrder, error) {
+	return s.store.GetByID(ctx, tenantID, id)
+}

--- a/internal/usecase/fleetwork/service_test.go
+++ b/internal/usecase/fleetwork/service_test.go
@@ -26,9 +26,17 @@ type fakeAudit struct{ n int }
 
 func (a *fakeAudit) Record(context.Context, ports.AuditEntry) error { a.n++; return nil }
 
+// compile-time check that the concrete signer satisfies the port (the package itself is
+// deliberately stdlib-only, so the assertion lives here where ports is already imported).
+var _ ports.WorkOrderSigner = (*worksign.Signer)(nil)
+
 func newSvc(t *testing.T) *Service {
 	t.Helper()
-	svc, err := NewService(memory.NewWorkOrderStore(), worksign.New([]byte("test-key")), &fakeAudit{}, fakeClock{t: time.Unix(1000, 0).UTC()}, &fakeIDs{})
+	signer, err := worksign.New([]byte("test-key-32-bytes-000000000000000"))
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	svc, err := NewService(memory.NewWorkOrderStore(), signer, &fakeAudit{}, fakeClock{t: time.Unix(1000, 0).UTC()}, &fakeIDs{})
 	if err != nil {
 		t.Fatalf("new service: %v", err)
 	}

--- a/internal/usecase/fleetwork/service_test.go
+++ b/internal/usecase/fleetwork/service_test.go
@@ -1,0 +1,155 @@
+package fleetwork
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeClock struct{ t time.Time }
+
+func (c fakeClock) Now() time.Time { return c.t }
+
+type fakeIDs struct{ n int }
+
+func (g *fakeIDs) NewID() shared.ID { g.n++; return shared.ID(fmt.Sprintf("wo-%d", g.n)) }
+
+type fakeAudit struct{ n int }
+
+func (a *fakeAudit) Record(context.Context, ports.AuditEntry) error { a.n++; return nil }
+
+func newSvc(t *testing.T) *Service {
+	t.Helper()
+	svc, err := NewService(memory.NewWorkOrderStore(), worksign.New([]byte("test-key")), &fakeAudit{}, fakeClock{t: time.Unix(1000, 0).UTC()}, &fakeIDs{})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return svc
+}
+
+func issueInput(idem string, bucket int64) IssueInput {
+	return IssueInput{
+		TenantID: "t1", AssetID: "as1", AgentID: "ag1", Capability: "scan.source",
+		AuthorizationID: "eng1", IdempotencyKey: idem, NotAfter: time.Unix(9999, 0).UTC(), TimeBucket: bucket,
+	}
+}
+
+func TestIssueSignsAndVerifies(t *testing.T) {
+	svc := newSvc(t)
+	wo, err := svc.Issue(context.Background(), "actor", issueInput("idem1", 1))
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if wo.Signature == "" {
+		t.Fatalf("issued order must be signed")
+	}
+	if !svc.Verify(wo) {
+		t.Fatalf("issued order must verify")
+	}
+	// Tampering with an authorising field invalidates the signature.
+	wo.Capability = "scan.host"
+	if svc.Verify(wo) {
+		t.Fatalf("tampered order must not verify")
+	}
+}
+
+func TestIssueIdempotent(t *testing.T) {
+	svc := newSvc(t)
+	ctx := context.Background()
+	first, err := svc.Issue(ctx, "actor", issueInput("idem1", 1))
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := svc.Issue(ctx, "actor", issueInput("idem1", 1))
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("idempotent issue must return the same order: %q vs %q", first.ID, second.ID)
+	}
+}
+
+func TestIssueInFlightConflict(t *testing.T) {
+	svc := newSvc(t)
+	ctx := context.Background()
+	if _, err := svc.Issue(ctx, "actor", issueInput("idem1", 1)); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// Different idempotency key, same (asset, capability, bucket) while the first is live.
+	_, err := svc.Issue(ctx, "actor", issueInput("idem2", 1))
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("expected in-flight conflict, got %v", err)
+	}
+}
+
+func TestClaimIsAddressed(t *testing.T) {
+	svc := newSvc(t)
+	ctx := context.Background()
+	if _, err := svc.Issue(ctx, "actor", issueInput("idem1", 1)); err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	// Another agent claims nothing.
+	got, err := svc.Claim(ctx, "actor", "t1", "ag2", 10)
+	if err != nil {
+		t.Fatalf("claim ag2: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ag2 must not claim ag1's order, got %d", len(got))
+	}
+	// The addressed agent claims it and it becomes claimed.
+	got, err = svc.Claim(ctx, "actor", "t1", "ag1", 10)
+	if err != nil {
+		t.Fatalf("claim ag1: %v", err)
+	}
+	if len(got) != 1 || got[0].State != workorder.StateClaimed {
+		t.Fatalf("ag1 should claim one order into claimed, got %+v", got)
+	}
+	// Re-claim returns nothing (already claimed).
+	got, err = svc.Claim(ctx, "actor", "t1", "ag1", 10)
+	if err != nil {
+		t.Fatalf("re-claim: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("no issued orders left to claim, got %d", len(got))
+	}
+}
+
+func TestTransitionRules(t *testing.T) {
+	svc := newSvc(t)
+	ctx := context.Background()
+	wo, err := svc.Issue(ctx, "actor", issueInput("idem1", 1))
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	// Illegal: issued -> succeeded.
+	if err := svc.Transition(ctx, "actor", "t1", wo.ID, workorder.StateSucceeded, ""); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("expected illegal-transition validation error, got %v", err)
+	}
+	// Legal: issued -> claimed -> running -> succeeded.
+	if err := svc.Transition(ctx, "actor", "t1", wo.ID, workorder.StateClaimed, ""); err != nil {
+		t.Fatalf("issued->claimed: %v", err)
+	}
+	if err := svc.Transition(ctx, "actor", "t1", wo.ID, workorder.StateRunning, ""); err != nil {
+		t.Fatalf("claimed->running: %v", err)
+	}
+	if err := svc.Transition(ctx, "actor", "t1", wo.ID, workorder.StateSucceeded, ""); err != nil {
+		t.Fatalf("running->succeeded: %v", err)
+	}
+	// Refusal requires a reason.
+	wo2, _ := svc.Issue(ctx, "actor", issueInput("idem2", 2))
+	_ = svc.Transition(ctx, "actor", "t1", wo2.ID, workorder.StateClaimed, "")
+	if err := svc.Transition(ctx, "actor", "t1", wo2.ID, workorder.StateRefused, ""); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("refusal without reason must fail, got %v", err)
+	}
+	if err := svc.Transition(ctx, "actor", "t1", wo2.ID, workorder.StateRefused, "unsupported capability"); err != nil {
+		t.Fatalf("refusal with reason: %v", err)
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -83,7 +83,7 @@ type WorkOrderStore interface {
 	Issue(ctx context.Context, wo *workorder.WorkOrder) (*workorder.WorkOrder, error)
 	GetByID(ctx context.Context, tenantID, id shared.ID) (*workorder.WorkOrder, error)
 	Claim(ctx context.Context, tenantID, agentID shared.ID, max int, now time.Time) ([]*workorder.WorkOrder, error)
-	Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State) error
+	Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State, now time.Time) error
 }
 
 // WorkOrderSigner signs and verifies the canonical signing payload of a work order. The

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -30,6 +30,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/threatmodel"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vex"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/writeupdraft"
 )
 
@@ -71,6 +72,26 @@ type AssetRepository interface {
 	UpsertBusinessService(ctx context.Context, s *asset.BusinessService) error
 	GetBusinessServiceByName(ctx context.Context, tenantID shared.ID, name string) (*asset.BusinessService, error)
 	ListBusinessServices(ctx context.Context, tenantID shared.ID) ([]*asset.BusinessService, error)
+}
+
+// WorkOrderStore persists the tenant-scoped fleet work order lifecycle. Postgres routes every
+// method through WithTenant so Row Level Security isolates by tenant at the database. Issue is
+// idempotent by (tenant, idempotency key) and rejects a second live order for the same
+// (tenant, asset, capability, time bucket) with shared.ErrConflict. Claim returns only unexpired
+// orders addressed to the given agent.
+type WorkOrderStore interface {
+	Issue(ctx context.Context, wo *workorder.WorkOrder) (*workorder.WorkOrder, error)
+	GetByID(ctx context.Context, tenantID, id shared.ID) (*workorder.WorkOrder, error)
+	Claim(ctx context.Context, tenantID, agentID shared.ID, max int, now time.Time) ([]*workorder.WorkOrder, error)
+	Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State) error
+}
+
+// WorkOrderSigner signs and verifies the canonical signing payload of a work order. The
+// implementation holds the key; the control plane signs at issue time and the agent verifies
+// before acting. Kept as a port so the key material stays in an infrastructure/platform adapter.
+type WorkOrderSigner interface {
+	Sign(payload string) string
+	Verify(payload, signature string) bool
 }
 
 // QualityGateStore persists tenant-scoped custom gate definitions.

--- a/migrations/0059_work_orders.sql
+++ b/migrations/0059_work_orders.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+-- Fleet work order model (#407, epic #405): addressed, signed, authorised units of work driven
+-- through a state machine. RLS-native via the 0057 procedure (tenant_id keys the policy; empty
+-- tenant = DENY, so orders use non-empty tenant ids).
+--
+-- asset_id, agent_id and authorization_id are logical cross-aggregate references validated at the
+-- application layer, not DB foreign keys: the fleet agent table (#408) does not exist yet, and
+-- work orders must be issuable before every referenced aggregate has its own table. tenant_id does
+-- FK to tenants so RLS and tenant integrity hold.
+CREATE TABLE work_orders (
+    id               TEXT PRIMARY KEY,
+    tenant_id        TEXT NOT NULL REFERENCES tenants(id),
+    asset_id         TEXT NOT NULL,
+    agent_id         TEXT NOT NULL,
+    capability       TEXT NOT NULL,
+    authorization_id TEXT NOT NULL,
+    idempotency_key  TEXT NOT NULL,
+    not_after        TIMESTAMPTZ NOT NULL,
+    time_bucket      BIGINT NOT NULL,
+    state            TEXT NOT NULL CHECK (state IN
+        ('issued','claimed','running','succeeded','failed','expired','cancelled','refused')),
+    refuse_reason    TEXT NOT NULL DEFAULT '',
+    signature        TEXT NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Idempotent issue by (tenant, idempotency key).
+CREATE UNIQUE INDEX work_orders_idem ON work_orders (tenant_id, idempotency_key);
+
+-- At most one LIVE order per (tenant, asset, capability, time bucket): a second live order for the
+-- same work is rejected, so duplicate scheduler ticks cannot double-dispatch.
+CREATE UNIQUE INDEX work_orders_inflight ON work_orders (tenant_id, asset_id, capability, time_bucket)
+    WHERE state IN ('issued', 'claimed', 'running');
+
+CREATE INDEX work_orders_agent_state ON work_orders (tenant_id, agent_id, state);
+
+CALL synapse_enable_tenant_rls('work_orders');
+
+-- +goose Down
+DROP TABLE work_orders;


### PR DESCRIPTION
Implements #407 (epic #405): the fleet work order model. An order addressed to a specific agent, authorised by an engagement, signed by the control plane, driven through an explicit state machine, and isolated per tenant by Row Level Security (building on #432/#431).

## What this delivers
- **Domain** `internal/domain/workorder`: closed `State` set + a closed transition graph (`CanTransition`), a `New` constructor requiring a non-empty tenant (empty = DENY under RLS) plus asset/agent/capability/authorization/idempotency-key/expiry, and a deterministic `SigningPayload` over the authorising fields so a tampered field invalidates the signature.
- **Signer** `internal/platform/worksign`: HMAC-SHA256, constant-time verify; the key stays behind `ports.WorkOrderSigner`.
- **Port** `ports.WorkOrderStore` + **usecase** `internal/usecase/fleetwork`: issue (signs; idempotent by `(tenant, idempotency_key)`; rejects a second live order for the same `(tenant, asset, capability, bucket)` with `ErrConflict`), claim (atomic, addressed, unexpired), transition (validates the transition, then CAS on the expected state), all audited.
- **Stores**: memory + Postgres. Postgres routes every method through `WithTenant` so RLS isolates at the database; claim uses `FOR UPDATE SKIP LOCKED`; issue checks idempotency before insert so a re-issue never collides with the in-flight index.
- **Migration** `0059_work_orders.sql`: unique `(tenant, idempotency_key)`, a PARTIAL unique in-flight index over `(tenant, asset, capability, time_bucket) WHERE state IN ('issued','claimed','running')`, and RLS via `CALL synapse_enable_tenant_rls`.

## Scope
`asset_id`, `agent_id` and `authorization_id` are logical cross-aggregate references validated at the app layer, not DB FKs, because the fleet agent table (#408) does not exist yet. The HTTP surface and composition-root wiring land with the agent-facing API (#409); this PR delivers the tested model, stores and service (the migration applies at startup, so the schema is live).

## Verification
- Domain state-machine + signing tests; usecase tests (idempotency, in-flight conflict, addressed claim, transition rules, sign/verify/tamper).
- Postgres integration: roundtrip, idempotent re-issue, in-flight `ErrConflict`, addressed atomic claim, CAS transition (stale expected -> conflict), `FORCE` RLS on the table, migration down/up.
- `go build ./...`, `go vet ./...`, `go test ./...` (no DSN, CI-equivalent), gofmt all clean.

Refs #405
