### PR TITLE
feat(fleet): agent-facing API with agent identity and auth (#409)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -89,6 +89,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/jobs"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/agenttools"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
@@ -108,6 +109,8 @@ import (
 	exploitationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
 	exportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/export"
 	findingsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findings"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fptriage"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/llmverifier"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
@@ -168,6 +171,8 @@ func main() {
 	var repo ports.EngagementRepository
 	var projectRepo ports.ProjectRepository
 	var assetStore ports.AssetRepository
+	var workOrderStore ports.WorkOrderStore
+	var fleetAgentStore ports.FleetAgentStore
 	var findingRepo ports.FindingRepository
 	var judgmentStore analysisuc.Store // postgres or memory; satisfies both the narrow Store + ports.JudgmentStore
 	var commentRepo ports.CommentRepository
@@ -288,12 +293,14 @@ func main() {
 		threatModelStore = postgres.NewThreatModelRepository(pool)
 		writeupDraftStore = postgres.NewWriteupDraftRepository(pool)
 		assetStore = postgres.NewAssetRepository(pool)
-		// SECURITY (#431 req 6, #432): the fleet_assets tables are RLS-protected, but RLS is a
-		// silent no-op if the runtime DB role is SUPERUSER or holds BYPASSRLS. When the asset model
-		// is enabled we refuse to serve unless the role can actually enforce isolation.
-		if cfg.FleetAssetsEnabled {
+		workOrderStore = postgres.NewWorkOrderRepository(pool)
+		fleetAgentStore = postgres.NewFleetAgentRepository(pool)
+		// SECURITY (#431 req 6, #432, #409): the fleet_* tables are RLS-protected, but RLS is a
+		// silent no-op if the runtime DB role is SUPERUSER or holds BYPASSRLS. When any fleet
+		// feature is enabled we refuse to serve unless the role can actually enforce isolation.
+		if cfg.FleetAssetsEnabled || cfg.FleetEnabled {
 			if rerr := postgres.CheckRLSRuntimeRole(startup, pool); rerr != nil {
-				log.Error("fleet assets enabled but the DB role cannot enforce row level security – refusing to serve", "err", rerr)
+				log.Error("a fleet feature is enabled but the DB role cannot enforce row level security – refusing to serve", "err", rerr)
 				os.Exit(1)
 			}
 		}
@@ -318,6 +325,8 @@ func main() {
 		repo = memory.NewEngagementRepository()
 		projectRepo = memory.NewProjectRepository()
 		assetStore = memory.NewAssetStore()
+		workOrderStore = memory.NewWorkOrderStore()
+		fleetAgentStore = memory.NewFleetAgentStore()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
 		commentRepo = memory.NewCommentRepository()
@@ -1037,6 +1046,28 @@ func main() {
 		}
 		router.SetAssets(svc)
 		log.Info("fleet asset model ENABLED (multi-tenant, Postgres RLS-enforced)")
+	}
+	if cfg.FleetEnabled {
+		// SECURITY: a missing/short signer key fails startup closed rather than boot a forgeable
+		// work-order signer (worksign.New rejects keys under 32 bytes).
+		signer, serr := worksign.New([]byte(cfg.FleetSignerKey))
+		if serr != nil {
+			log.Error("fleet enabled but the work-order signer key is missing or too short – set SYNAPSE_FLEET_SIGNER_KEY (>=32 bytes)", "err", serr)
+			os.Exit(1)
+		}
+		agentSvc, aerr := fleetagentuc.NewService(fleetAgentStore, auditLog, clock, ids)
+		if aerr != nil {
+			log.Error("fleet agent service init failed", "err", aerr)
+			os.Exit(1)
+		}
+		workSvc, werr := fleetwork.NewService(workOrderStore, signer, auditLog, clock, ids)
+		if werr != nil {
+			log.Error("fleet work service init failed", "err", werr)
+			os.Exit(1)
+		}
+		router.SetFleet(agentSvc, workSvc, clock.Now)
+		router.SetFleetAdmin(agentSvc)
+		log.Info("fleet agent transport ENABLED (agent-auth plane; operator agent-admin routes)")
 	}
 	// deterministic Tier-2 reachability proof in the scan pipeline (opt-in). It mints reachability
 	// judgments, so it requires the judgment lifecycle. The govulncheck builder shares the SCA sandbox when

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -1,0 +1,344 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
+)
+
+// FleetProtoVersion is the only agent protocol version this server supports. An agent must send it
+// in X-Synapse-Fleet-Proto; a different value is refused rather than handled best-effort.
+const FleetProtoVersion = "1"
+
+const (
+	fleetBodyCap    = 1 << 20 // 1 MiB agent request cap
+	fleetMaxClaim   = 20      // maximum work orders per claim
+	fleetRatePerMin = 120     // per-agent requests per minute
+)
+
+// fleetAgentService is the narrow view of fleet agent identity the transport needs.
+type fleetAgentService interface {
+	Enrol(ctx context.Context, enrolToken string, in fleetagentuc.EnrolInput) (*fleetagent.Agent, string, error)
+	Authenticate(ctx context.Context, token string) (*fleetagent.Agent, error)
+	Heartbeat(ctx context.Context, agent *fleetagent.Agent, in fleetagentuc.HeartbeatInput) error
+}
+
+// fleetWorkService is the narrow view of the work order lifecycle the transport needs.
+type fleetWorkService interface {
+	Claim(ctx context.Context, actor string, tenantID, agentID shared.ID, max int) ([]*workorder.WorkOrder, error)
+	Transition(ctx context.Context, actor string, tenantID, id shared.ID, to workorder.State, reason string) error
+	GetByID(ctx context.Context, tenantID, id shared.ID) (*workorder.WorkOrder, error)
+}
+
+type fleetRouter struct {
+	agents  fleetAgentService
+	work    fleetWorkService
+	log     *slog.Logger
+	limiter *agentRateLimiter
+}
+
+// SetFleet wires the untrusted agent transport plane. When nil, /api/v1/fleet is not served.
+func (rt *Router) SetFleet(agents fleetAgentService, work fleetWorkService, now func() time.Time) {
+	rt.fleet = &fleetRouter{
+		agents:  agents,
+		work:    work,
+		log:     rt.log,
+		limiter: newAgentRateLimiter(fleetRatePerMin, now),
+	}
+}
+
+// fleetAdminService is the operator-facing (human, RBAC-gated) view of fleet agent management.
+type fleetAdminService interface {
+	MintEnrolToken(ctx context.Context, actor string, tenantID shared.ID, ttl time.Duration) (string, error)
+	Revoke(ctx context.Context, actor string, tenantID, id shared.ID) error
+	ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error)
+}
+
+// SetFleetAdmin wires the operator agent-admin routes (mint enrolment token, list, revoke).
+func (rt *Router) SetFleetAdmin(s fleetAdminService) { rt.fleetAdmin = s }
+
+const defaultEnrolTTL = 15 * time.Minute
+
+func (rt *Router) mintEnrolToken(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TTLSeconds int `json:"ttl_seconds"`
+	}
+	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, assetBodyCap)).Decode(&req)
+	ttl := time.Duration(req.TTLSeconds) * time.Second
+	if ttl <= 0 {
+		ttl = defaultEnrolTTL
+	}
+	tok, err := rt.fleetAdmin.MintEnrolToken(r.Context(), PrincipalFrom(r.Context()), fleetTenant(r.Context()), ttl)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	// The enrolment token is returned exactly once; it is never stored in the clear or logged.
+	writeJSON(w, http.StatusCreated, map[string]string{"enrolment_token": tok})
+}
+
+func (rt *Router) listFleetAgents(w http.ResponseWriter, r *http.Request) {
+	list, err := rt.fleetAdmin.ListAgents(r.Context(), fleetTenant(r.Context()))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if list == nil {
+		list = []*fleetagent.Agent{}
+	}
+	writeJSON(w, http.StatusOK, list)
+}
+
+func (rt *Router) revokeFleetAgent(w http.ResponseWriter, r *http.Request) {
+	id := shared.ID(r.PathValue("id"))
+	if err := rt.fleetAdmin.Revoke(r.Context(), PrincipalFrom(r.Context()), fleetTenant(r.Context()), id); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"agent_id": id.String(), "state": "revoked"})
+}
+
+type agentCtxKey int
+
+const agentKeyCtx agentCtxKey = iota
+
+func agentFrom(ctx context.Context) (*fleetagent.Agent, bool) {
+	a, ok := ctx.Value(agentKeyCtx).(*fleetagent.Agent)
+	return a, ok
+}
+
+// handler builds the agent-plane mux. Every route checks the protocol version; every route except
+// enrol requires a valid agent bearer credential (agent-auth, NOT the human RBAC plane).
+func (f *fleetRouter) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/fleet/enrol", f.version(f.enrol))
+	mux.HandleFunc("POST /api/v1/fleet/heartbeat", f.version(f.authed(f.heartbeat)))
+	mux.HandleFunc("POST /api/v1/fleet/work/claim", f.version(f.authed(f.claim)))
+	mux.HandleFunc("POST /api/v1/fleet/work/{id}/progress", f.version(f.authed(f.progress)))
+	mux.HandleFunc("POST /api/v1/fleet/work/{id}/result", f.version(f.authed(f.result)))
+	return mux
+}
+
+// version enforces the supported protocol version, returning 400 unsupported_version otherwise.
+func (f *fleetRouter) version(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Synapse-Fleet-Proto") != FleetProtoVersion {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "unsupported_version"})
+			return
+		}
+		next(w, r)
+	}
+}
+
+// authed resolves the agent bearer credential, rate-limits per agent, and stamps the agent into
+// the context. The tenant comes from the authenticated agent, never from the request.
+func (f *fleetRouter) authed(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token, ok := bearerToken(r)
+		if !ok {
+			writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
+			return
+		}
+		agent, err := f.agents.Authenticate(r.Context(), token)
+		if err != nil {
+			switch {
+			case errors.Is(err, fleetagentuc.ErrRevoked):
+				writeJSON(w, http.StatusForbidden, errorBody{Error: "revoked"})
+			case errors.Is(err, fleetagentuc.ErrUnauthenticated):
+				writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
+			default:
+				writeError(w, f.log, err)
+			}
+			return
+		}
+		if !f.limiter.allow(agent.ID.String()) {
+			w.Header().Set("Retry-After", "1")
+			writeJSON(w, http.StatusTooManyRequests, errorBody{Error: "rate_limited"})
+			return
+		}
+		ctx := context.WithValue(r.Context(), agentKeyCtx, agent)
+		next(w, r.WithContext(ctx))
+	}
+}
+
+func (f *fleetRouter) enrol(w http.ResponseWriter, r *http.Request) {
+	token, ok := bearerToken(r)
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
+		return
+	}
+	var req struct {
+		Name         string   `json:"name"`
+		Platform     string   `json:"platform"`
+		OSVersion    string   `json:"os_version"`
+		AgentVersion string   `json:"agent_version"`
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetBodyCap)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid enrol body"})
+		return
+	}
+	agent, agentToken, err := f.agents.Enrol(r.Context(), token, fleetagentuc.EnrolInput{
+		Name: req.Name, Platform: req.Platform, OSVersion: req.OSVersion,
+		AgentVersion: req.AgentVersion, Capabilities: req.Capabilities,
+	})
+	if err != nil {
+		if errors.Is(err, fleetagentuc.ErrUnauthenticated) {
+			writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
+			return
+		}
+		writeError(w, f.log, err)
+		return
+	}
+	// The agent token is returned exactly once here; it is never stored in the clear or logged.
+	writeJSON(w, http.StatusCreated, map[string]string{"agent_id": agent.ID.String(), "token": agentToken})
+}
+
+func (f *fleetRouter) heartbeat(w http.ResponseWriter, r *http.Request) {
+	agent, _ := agentFrom(r.Context())
+	var req struct {
+		Platform     string   `json:"platform"`
+		OSVersion    string   `json:"os_version"`
+		AgentVersion string   `json:"agent_version"`
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetBodyCap)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid heartbeat body"})
+		return
+	}
+	if err := f.agents.Heartbeat(r.Context(), agent, fleetagentuc.HeartbeatInput{
+		Platform: req.Platform, OSVersion: req.OSVersion, AgentVersion: req.AgentVersion, Capabilities: req.Capabilities,
+	}); err != nil {
+		writeError(w, f.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"proto": FleetProtoVersion})
+}
+
+func (f *fleetRouter) claim(w http.ResponseWriter, r *http.Request) {
+	agent, _ := agentFrom(r.Context())
+	var req struct {
+		Max int `json:"max"`
+	}
+	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetBodyCap)).Decode(&req)
+	max := req.Max
+	if max <= 0 || max > fleetMaxClaim {
+		max = fleetMaxClaim
+	}
+	orders, err := f.work.Claim(r.Context(), agent.ID.String(), agent.TenantID, agent.ID, max)
+	if err != nil {
+		writeError(w, f.log, err)
+		return
+	}
+	if orders == nil {
+		orders = []*workorder.WorkOrder{}
+	}
+	writeJSON(w, http.StatusOK, orders)
+}
+
+func (f *fleetRouter) progress(w http.ResponseWriter, r *http.Request) {
+	f.transitionTo(w, r, workorder.StateRunning, "")
+}
+
+func (f *fleetRouter) result(w http.ResponseWriter, r *http.Request) {
+	agent, _ := agentFrom(r.Context())
+	id := shared.ID(r.PathValue("id"))
+	var req struct {
+		Status string `json:"status"` // "succeeded" | "failed"
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetBodyCap)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid result body"})
+		return
+	}
+	to := workorder.State(req.Status)
+	if to != workorder.StateSucceeded && to != workorder.StateFailed {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "result status must be succeeded or failed"})
+		return
+	}
+	f.applyTransition(w, r, agent, id, to, req.Reason)
+}
+
+func (f *fleetRouter) transitionTo(w http.ResponseWriter, r *http.Request, to workorder.State, reason string) {
+	agent, _ := agentFrom(r.Context())
+	id := shared.ID(r.PathValue("id"))
+	f.applyTransition(w, r, agent, id, to, reason)
+}
+
+// applyTransition enforces that the order is addressed to the calling agent (cross-tenant or
+// mis-addressed => not_found, never leaking existence) and is idempotent: a transition to a state
+// the order is already in is a no-op 200.
+func (f *fleetRouter) applyTransition(w http.ResponseWriter, r *http.Request, agent *fleetagent.Agent, id shared.ID, to workorder.State, reason string) {
+	wo, err := f.work.GetByID(r.Context(), agent.TenantID, id)
+	if err != nil {
+		if errors.Is(err, shared.ErrNotFound) {
+			writeJSON(w, http.StatusNotFound, errorBody{Error: "not_found"})
+			return
+		}
+		writeError(w, f.log, err)
+		return
+	}
+	if wo.AgentID != agent.ID {
+		// Not addressed to this agent: 404, do not leak that it exists.
+		writeJSON(w, http.StatusNotFound, errorBody{Error: "not_found"})
+		return
+	}
+	if wo.State == to {
+		writeJSON(w, http.StatusOK, map[string]string{"state": string(to)})
+		return
+	}
+	if err := f.work.Transition(r.Context(), agent.ID.String(), agent.TenantID, id, to, reason); err != nil {
+		if errors.Is(err, shared.ErrValidation) {
+			writeJSON(w, http.StatusConflict, errorBody{Error: "illegal_transition"})
+			return
+		}
+		writeError(w, f.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"state": string(to)})
+}
+
+// agentRateLimiter is a minimal per-agent fixed-window limiter with an injectable clock.
+type agentRateLimiter struct {
+	mu      sync.Mutex
+	perMin  int
+	now     func() time.Time
+	windows map[string]*rateWindow
+}
+
+type rateWindow struct {
+	start time.Time
+	count int
+}
+
+func newAgentRateLimiter(perMin int, now func() time.Time) *agentRateLimiter {
+	if now == nil {
+		now = time.Now
+	}
+	return &agentRateLimiter{perMin: perMin, now: now, windows: map[string]*rateWindow{}}
+}
+
+func (l *agentRateLimiter) allow(agentID string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	t := l.now()
+	win, ok := l.windows[agentID]
+	if !ok || t.Sub(win.start) >= time.Minute {
+		l.windows[agentID] = &rateWindow{start: t, count: 1}
+		return true
+	}
+	if win.count >= l.perMin {
+		return false
+	}
+	win.count++
+	return true
+}

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -20,9 +21,10 @@ import (
 const FleetProtoVersion = "1"
 
 const (
-	fleetBodyCap    = 1 << 20 // 1 MiB agent request cap
-	fleetMaxClaim   = 20      // maximum work orders per claim
-	fleetRatePerMin = 120     // per-agent requests per minute
+	fleetBodyCap      = 1 << 20 // 1 MiB agent request cap
+	fleetMaxClaim     = 20      // maximum work orders per claim
+	fleetRatePerMin   = 120     // per-agent requests per minute (post-auth)
+	fleetIPRatePerMin = 60      // per-client-IP requests per minute (pre-auth: enrol + failed auth)
 )
 
 // fleetAgentService is the narrow view of fleet agent identity the transport needs.
@@ -40,19 +42,21 @@ type fleetWorkService interface {
 }
 
 type fleetRouter struct {
-	agents  fleetAgentService
-	work    fleetWorkService
-	log     *slog.Logger
-	limiter *agentRateLimiter
+	agents   fleetAgentService
+	work     fleetWorkService
+	log      *slog.Logger
+	agentLim *keyedLimiter // post-auth, keyed by agent id
+	ipLim    *keyedLimiter // pre-auth, keyed by client IP (throttles enrol + failed auth)
 }
 
 // SetFleet wires the untrusted agent transport plane. When nil, /api/v1/fleet is not served.
 func (rt *Router) SetFleet(agents fleetAgentService, work fleetWorkService, now func() time.Time) {
 	rt.fleet = &fleetRouter{
-		agents:  agents,
-		work:    work,
-		log:     rt.log,
-		limiter: newAgentRateLimiter(fleetRatePerMin, now),
+		agents:   agents,
+		work:     work,
+		log:      rt.log,
+		agentLim: newKeyedLimiter(fleetRatePerMin, now),
+		ipLim:    newKeyedLimiter(fleetIPRatePerMin, now),
 	}
 }
 
@@ -72,7 +76,7 @@ func (rt *Router) mintEnrolToken(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TTLSeconds int `json:"ttl_seconds"`
 	}
-	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, assetBodyCap)).Decode(&req)
+	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetBodyCap)).Decode(&req)
 	ttl := time.Duration(req.TTLSeconds) * time.Second
 	if ttl <= 0 {
 		ttl = defaultEnrolTTL
@@ -86,16 +90,43 @@ func (rt *Router) mintEnrolToken(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, map[string]string{"enrolment_token": tok})
 }
 
+// agentView is the transport DTO for an agent. It deliberately OMITS TokenHash: the credential
+// verifier material must never leave the server, even though its preimage is infeasible.
+type agentView struct {
+	ID           string    `json:"id"`
+	TenantID     string    `json:"tenant_id"`
+	Name         string    `json:"name"`
+	Platform     string    `json:"platform"`
+	OSVersion    string    `json:"os_version"`
+	AgentVersion string    `json:"agent_version"`
+	Capabilities []string  `json:"capabilities"`
+	State        string    `json:"state"`
+	LastSeenAt   time.Time `json:"last_seen_at"`
+}
+
+func toAgentView(a *fleetagent.Agent) agentView {
+	caps := a.Capabilities
+	if caps == nil {
+		caps = []string{}
+	}
+	return agentView{
+		ID: a.ID.String(), TenantID: a.TenantID.String(), Name: a.Name, Platform: a.Platform,
+		OSVersion: a.OSVersion, AgentVersion: a.AgentVersion, Capabilities: caps,
+		State: string(a.State), LastSeenAt: a.LastSeenAt,
+	}
+}
+
 func (rt *Router) listFleetAgents(w http.ResponseWriter, r *http.Request) {
 	list, err := rt.fleetAdmin.ListAgents(r.Context(), fleetTenant(r.Context()))
 	if err != nil {
 		writeError(w, rt.log, err)
 		return
 	}
-	if list == nil {
-		list = []*fleetagent.Agent{}
+	views := make([]agentView, 0, len(list))
+	for _, a := range list {
+		views = append(views, toAgentView(a))
 	}
-	writeJSON(w, http.StatusOK, list)
+	writeJSON(w, http.StatusOK, views)
 }
 
 func (rt *Router) revokeFleetAgent(w http.ResponseWriter, r *http.Request) {
@@ -120,23 +151,40 @@ func agentFrom(ctx context.Context) (*fleetagent.Agent, bool) {
 // enrol requires a valid agent bearer credential (agent-auth, NOT the human RBAC plane).
 func (f *fleetRouter) handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/fleet/enrol", f.version(f.enrol))
-	mux.HandleFunc("POST /api/v1/fleet/heartbeat", f.version(f.authed(f.heartbeat)))
-	mux.HandleFunc("POST /api/v1/fleet/work/claim", f.version(f.authed(f.claim)))
-	mux.HandleFunc("POST /api/v1/fleet/work/{id}/progress", f.version(f.authed(f.progress)))
-	mux.HandleFunc("POST /api/v1/fleet/work/{id}/result", f.version(f.authed(f.result)))
+	mux.HandleFunc("POST /api/v1/fleet/enrol", f.entry(f.enrol))
+	mux.HandleFunc("POST /api/v1/fleet/heartbeat", f.entry(f.authed(f.heartbeat)))
+	mux.HandleFunc("POST /api/v1/fleet/work/claim", f.entry(f.authed(f.claim)))
+	mux.HandleFunc("POST /api/v1/fleet/work/{id}/progress", f.entry(f.authed(f.progress)))
+	mux.HandleFunc("POST /api/v1/fleet/work/{id}/result", f.entry(f.authed(f.result)))
 	return mux
 }
 
-// version enforces the supported protocol version, returning 400 unsupported_version otherwise.
-func (f *fleetRouter) version(next http.HandlerFunc) http.HandlerFunc {
+// entry is the outermost wrapper on every fleet route. It throttles per client IP BEFORE any
+// database work (so unauthenticated enrol and failed-auth attempts cannot amplify into unbounded
+// DB lookups on this untrusted plane), then enforces the supported protocol version.
+func (f *fleetRouter) entry(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !f.ipLim.allow(clientIP(r)) {
+			w.Header().Set("Retry-After", "1")
+			writeJSON(w, http.StatusTooManyRequests, errorBody{Error: "rate_limited"})
+			return
+		}
 		if r.Header.Get("X-Synapse-Fleet-Proto") != FleetProtoVersion {
 			writeJSON(w, http.StatusBadRequest, errorBody{Error: "unsupported_version"})
 			return
 		}
 		next(w, r)
 	}
+}
+
+// clientIP returns the request's source host (no port). RemoteAddr is used rather than a spoofable
+// X-Forwarded-For header, because this is a throttling key, not an authorization input.
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
 }
 
 // authed resolves the agent bearer credential, rate-limits per agent, and stamps the agent into
@@ -160,7 +208,7 @@ func (f *fleetRouter) authed(next http.HandlerFunc) http.HandlerFunc {
 			}
 			return
 		}
-		if !f.limiter.allow(agent.ID.String()) {
+		if !f.agentLim.allow(agent.ID.String()) {
 			w.Header().Set("Retry-After", "1")
 			writeJSON(w, http.StatusTooManyRequests, errorBody{Error: "rate_limited"})
 			return
@@ -307,33 +355,40 @@ func (f *fleetRouter) applyTransition(w http.ResponseWriter, r *http.Request, ag
 	writeJSON(w, http.StatusOK, map[string]string{"state": string(to)})
 }
 
-// agentRateLimiter is a minimal per-agent fixed-window limiter with an injectable clock.
-type agentRateLimiter struct {
+// keyedLimiter is a minimal fixed-window rate limiter keyed by an arbitrary string (agent id or
+// client IP) with an injectable clock. Its key map is bounded: when it grows past maxKeys, expired
+// windows are pruned so an untrusted key space (client IPs) cannot grow it without bound.
+type keyedLimiter struct {
 	mu      sync.Mutex
 	perMin  int
 	now     func() time.Time
 	windows map[string]*rateWindow
 }
 
+const limiterMaxKeys = 8192
+
 type rateWindow struct {
 	start time.Time
 	count int
 }
 
-func newAgentRateLimiter(perMin int, now func() time.Time) *agentRateLimiter {
+func newKeyedLimiter(perMin int, now func() time.Time) *keyedLimiter {
 	if now == nil {
 		now = time.Now
 	}
-	return &agentRateLimiter{perMin: perMin, now: now, windows: map[string]*rateWindow{}}
+	return &keyedLimiter{perMin: perMin, now: now, windows: map[string]*rateWindow{}}
 }
 
-func (l *agentRateLimiter) allow(agentID string) bool {
+func (l *keyedLimiter) allow(key string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	t := l.now()
-	win, ok := l.windows[agentID]
+	win, ok := l.windows[key]
 	if !ok || t.Sub(win.start) >= time.Minute {
-		l.windows[agentID] = &rateWindow{start: t, count: 1}
+		if !ok && len(l.windows) >= limiterMaxKeys {
+			l.pruneLocked(t)
+		}
+		l.windows[key] = &rateWindow{start: t, count: 1}
 		return true
 	}
 	if win.count >= l.perMin {
@@ -341,4 +396,13 @@ func (l *agentRateLimiter) allow(agentID string) bool {
 	}
 	win.count++
 	return true
+}
+
+// pruneLocked drops windows whose fixed window has fully elapsed. Callers hold l.mu.
+func (l *keyedLimiter) pruneLocked(t time.Time) {
+	for k, w := range l.windows {
+		if t.Sub(w.start) >= time.Minute {
+			delete(l.windows, k)
+		}
+	}
 }

--- a/internal/adapter/httpapi/fleet_handler_test.go
+++ b/internal/adapter/httpapi/fleet_handler_test.go
@@ -1,0 +1,162 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type ftClock struct{}
+
+func (ftClock) Now() time.Time { return time.Now().UTC() }
+
+type ftIDs struct{ n int }
+
+func (g *ftIDs) NewID() shared.ID { g.n++; return shared.ID(fmt.Sprintf("fid-%d", g.n)) }
+
+type ftAudit struct{}
+
+func (ftAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+func setupFleet(t *testing.T) (http.Handler, *fleetagentuc.Service, *fleetwork.Service) {
+	t.Helper()
+	agentSvc, err := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatalf("agent svc: %v", err)
+	}
+	signer, err := worksign.New([]byte("0123456789012345678901234567890123"))
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	workSvc, err := fleetwork.NewService(memory.NewWorkOrderStore(), signer, ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatalf("work svc: %v", err)
+	}
+	rt := &Router{log: discardLog()}
+	rt.SetFleet(agentSvc, workSvc, func() time.Time { return time.Now().UTC() })
+	rt.SetFleetAdmin(agentSvc)
+	return rt.fleet.handler(), agentSvc, workSvc
+}
+
+func fleetCall(h http.Handler, method, path, token string, body any, proto bool) *httptest.ResponseRecorder {
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	if proto {
+		req.Header.Set("X-Synapse-Fleet-Proto", "1")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func TestFleetAPIEndToEnd(t *testing.T) {
+	h, agentSvc, workSvc := setupFleet(t)
+	ctx := context.Background()
+
+	// Version required.
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/enrol", "", map[string]string{"name": "a"}, false); w.Code != http.StatusBadRequest {
+		t.Fatalf("missing proto header should be 400, got %d", w.Code)
+	}
+
+	// Mint an enrolment token (operator action, done directly here).
+	enrolTok, err := agentSvc.MintEnrolToken(ctx, "op", "default", time.Hour)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	// Enrol.
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/enrol", enrolTok, map[string]any{"name": "agent-1", "platform": "linux"}, true)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("enrol should be 201, got %d (%s)", w.Code, w.Body.String())
+	}
+	var enrolResp struct {
+		AgentID string `json:"agent_id"`
+		Token   string `json:"token"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &enrolResp); err != nil {
+		t.Fatalf("enrol resp: %v", err)
+	}
+	if enrolResp.AgentID == "" || enrolResp.Token == "" {
+		t.Fatalf("enrol must return agent id + token")
+	}
+	agentTok := enrolResp.Token
+	agentID := shared.ID(enrolResp.AgentID)
+
+	// Heartbeat requires auth.
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/heartbeat", "", nil, true); w.Code != http.StatusUnauthorized {
+		t.Fatalf("heartbeat without auth should be 401, got %d", w.Code)
+	}
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/heartbeat", agentTok, map[string]string{"agent_version": "0.2.0"}, true); w.Code != http.StatusOK {
+		t.Fatalf("heartbeat should be 200, got %d", w.Code)
+	}
+
+	// Issue a work order addressed to this agent, then claim it over the API.
+	issue := func(agent shared.ID, idem string, bucket int64) *workorder.WorkOrder {
+		wo, err := workSvc.Issue(ctx, "op", fleetwork.IssueInput{
+			TenantID: "default", AssetID: "as1", AgentID: agent, Capability: "scan.source",
+			AuthorizationID: "eng1", IdempotencyKey: idem, NotAfter: time.Now().Add(time.Hour), TimeBucket: bucket,
+		})
+		if err != nil {
+			t.Fatalf("issue %s: %v", idem, err)
+		}
+		return wo
+	}
+	mine := issue(agentID, "idem-mine", 1)
+	other := issue("other-agent", "idem-other", 2)
+
+	// Claim returns only the order addressed to this agent.
+	w = fleetCall(h, http.MethodPost, "/api/v1/fleet/work/claim", agentTok, map[string]int{"max": 10}, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("claim should be 200, got %d", w.Code)
+	}
+	var claimed []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &claimed); err != nil {
+		t.Fatalf("claim resp: %v", err)
+	}
+	if len(claimed) != 1 || claimed[0]["ID"] != mine.ID.String() {
+		t.Fatalf("claim must return only the addressed order, got %v", claimed)
+	}
+
+	// Progress claimed -> running, then result running -> succeeded, idempotent on repeat.
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/work/"+mine.ID.String()+"/progress", agentTok, nil, true); w.Code != http.StatusOK {
+		t.Fatalf("progress should be 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/work/"+mine.ID.String()+"/result", agentTok, map[string]string{"status": "succeeded"}, true); w.Code != http.StatusOK {
+		t.Fatalf("result should be 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/work/"+mine.ID.String()+"/result", agentTok, map[string]string{"status": "succeeded"}, true); w.Code != http.StatusOK {
+		t.Fatalf("repeat result should be idempotent 200, got %d", w.Code)
+	}
+
+	// An order addressed to another agent is not_found for us (no existence leak).
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/work/"+other.ID.String()+"/result", agentTok, map[string]string{"status": "succeeded"}, true); w.Code != http.StatusNotFound {
+		t.Fatalf("mis-addressed order must be 404, got %d", w.Code)
+	}
+
+	// Revoke the agent; its credential no longer authenticates.
+	if err := agentSvc.Revoke(ctx, "op", "default", agentID); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/heartbeat", agentTok, map[string]string{}, true); w.Code != http.StatusForbidden {
+		t.Fatalf("revoked agent should be 403, got %d", w.Code)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -386,13 +386,14 @@ func (rt *Router) Handler() http.Handler {
 		"/api/v1/aup/accept": true,
 		"/api/v1/me":         true,
 	}
-	human := normalizePath(rt.auth.Middleware(public, rt.requireAUP(aupExempt, rt.routes())))
+	human := rt.auth.Middleware(public, rt.requireAUP(aupExempt, rt.routes()))
 	if rt.fleet == nil {
-		return human
+		return normalizePath(human)
 	}
 	// The untrusted agent transport is a SEPARATE auth plane: it must not pass through the human
 	// bearer-token authenticator or the AUP gate. Mount it at the top level so /api/v1/fleet is
-	// served by the agent-auth handler and everything else by the human chain.
+	// served by the agent-auth handler and everything else by the human chain. normalizePath wraps
+	// the whole top mux once, so both planes are normalized without double-wrapping.
 	top := http.NewServeMux()
 	top.Handle("/api/v1/fleet/", rt.fleet.handler())
 	top.Handle("/", human)

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -61,6 +61,8 @@ type Router struct {
 	drafts          writeupDraftService   // optional; nil ⇒ writeup-draft sign-off routes are not registered
 	projects        projectService        // optional; nil ⇒ project routes are not registered
 	assets          assetService          // optional; nil ⇒ fleet asset routes are not registered
+	fleet           *fleetRouter          // optional; nil ⇒ agent transport plane is not served
+	fleetAdmin      fleetAdminService     // optional; nil ⇒ operator agent-admin routes not registered
 	qualityGates    qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
 	qualityProfiles qualityProfileService // optional; nil ⇒ quality-profile routes are not registered
 	rules           rulesService          // optional; nil ⇒ rule catalog routes are not registered
@@ -219,6 +221,11 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/deactivate", rt.authz(userdom.PermOperate, rt.deactivateProfileRule))
 		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/severity", rt.authz(userdom.PermOperate, rt.setProfileRuleSeverity))
 		mux.HandleFunc("DELETE /api/v1/quality-profiles/{key}", rt.authz(userdom.PermOperate, rt.deleteQualityProfile))
+	}
+	if rt.fleetAdmin != nil {
+		mux.HandleFunc("POST /api/v1/agents/enrolment-tokens", rt.authz(userdom.PermAdminister, rt.mintEnrolToken))
+		mux.HandleFunc("GET /api/v1/agents", rt.authz(userdom.PermView, rt.listFleetAgents))
+		mux.HandleFunc("POST /api/v1/agents/{id}/revoke", rt.authz(userdom.PermAdminister, rt.revokeFleetAgent))
 	}
 	if rt.assets != nil {
 		mux.HandleFunc("POST /api/v1/assets", rt.authz(userdom.PermOperate, rt.createAsset))
@@ -379,7 +386,17 @@ func (rt *Router) Handler() http.Handler {
 		"/api/v1/aup/accept": true,
 		"/api/v1/me":         true,
 	}
-	return normalizePath(rt.auth.Middleware(public, rt.requireAUP(aupExempt, rt.routes())))
+	human := normalizePath(rt.auth.Middleware(public, rt.requireAUP(aupExempt, rt.routes())))
+	if rt.fleet == nil {
+		return human
+	}
+	// The untrusted agent transport is a SEPARATE auth plane: it must not pass through the human
+	// bearer-token authenticator or the AUP gate. Mount it at the top level so /api/v1/fleet is
+	// served by the agent-auth handler and everything else by the human chain.
+	top := http.NewServeMux()
+	top.Handle("/api/v1/fleet/", rt.fleet.handler())
+	top.Handle("/", human)
+	return normalizePath(top)
 }
 
 // normalizePath rejects non-canonical request paths (e.g. `/a//b`, `/a/../b`,

--- a/internal/domain/fleetagent/fleetagent.go
+++ b/internal/domain/fleetagent/fleetagent.go
@@ -1,0 +1,126 @@
+// Package fleetagent is the epic-#405 fleet agent identity model: an enrolled, addressable agent
+// and the single-use enrolment token that mints it. It is pure domain (imports only shared and the
+// stdlib). Secret material (the enrolment token and the agent bearer credential) is never stored in
+// the clear here; the domain carries only hashes, and the plaintext is returned to the caller once
+// at creation time and never persisted.
+//
+// This is the minimal, token-based identity that the agent-facing API (#409) requires. Mutual TLS
+// with per-agent client certificates is the hardening tracked under #408; this model is built so a
+// certificate fingerprint can replace the bearer-token hash without changing the lifecycle.
+package fleetagent
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// State is the agent lifecycle.
+type State string
+
+const (
+	StateActive  State = "active"
+	StateRevoked State = "revoked"
+)
+
+// Valid reports whether s is a known state.
+func (s State) Valid() bool { return s == StateActive || s == StateRevoked }
+
+// Agent is an enrolled fleet agent. TokenHash is the hash of the bearer credential presented on
+// every call; the plaintext is shown once at enrolment and never stored.
+type Agent struct {
+	ID           shared.ID
+	TenantID     shared.ID
+	Name         string
+	Platform     string
+	OSVersion    string
+	AgentVersion string
+	Capabilities []string
+	TokenHash    string
+	State        State
+	Audit        shared.Audit
+	LastSeenAt   time.Time
+}
+
+// NewAgent validates and constructs an active agent. tokenHash must be the (non-empty) hash of the
+// generated bearer credential; the plaintext is never passed to the domain.
+func NewAgent(id, tenantID shared.ID, name, platform, osVersion, agentVersion string, capabilities []string, tokenHash string, now time.Time) (*Agent, error) {
+	if id.IsZero() {
+		return nil, fmt.Errorf("%w: agent id is required", shared.ErrValidation)
+	}
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: agent tenant id is required (empty tenant is DENY under RLS)", shared.ErrValidation)
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: agent name is required", shared.ErrValidation)
+	}
+	if strings.TrimSpace(tokenHash) == "" {
+		return nil, fmt.Errorf("%w: agent token hash is required", shared.ErrValidation)
+	}
+	return &Agent{
+		ID:           id,
+		TenantID:     tenantID,
+		Name:         name,
+		Platform:     strings.TrimSpace(platform),
+		OSVersion:    strings.TrimSpace(osVersion),
+		AgentVersion: strings.TrimSpace(agentVersion),
+		Capabilities: dedupeCaps(capabilities),
+		TokenHash:    tokenHash,
+		State:        StateActive,
+		Audit:        shared.Audit{CreatedAt: now, UpdatedAt: now},
+		LastSeenAt:   now,
+	}, nil
+}
+
+// Revoked reports whether the agent may no longer act.
+func (a *Agent) Revoked() bool { return a.State == StateRevoked }
+
+// EnrolToken is a single-use, tenant-scoped, expiring token an operator issues so an agent can
+// enrol once. Only its hash is stored.
+type EnrolToken struct {
+	Hash      string
+	TenantID  shared.ID
+	IssuedBy  string
+	ExpiresAt time.Time
+	UsedAt    time.Time // zero until consumed
+	CreatedAt time.Time
+}
+
+// NewEnrolToken validates and constructs an enrolment token record from the token's hash.
+func NewEnrolToken(hash string, tenantID shared.ID, issuedBy string, expiresAt, now time.Time) (*EnrolToken, error) {
+	if strings.TrimSpace(hash) == "" {
+		return nil, fmt.Errorf("%w: enrol token hash is required", shared.ErrValidation)
+	}
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: enrol token tenant id is required (empty tenant is DENY under RLS)", shared.ErrValidation)
+	}
+	if !expiresAt.After(now) {
+		return nil, fmt.Errorf("%w: enrol token expiry must be in the future", shared.ErrValidation)
+	}
+	return &EnrolToken{Hash: hash, TenantID: tenantID, IssuedBy: strings.TrimSpace(issuedBy), ExpiresAt: expiresAt, CreatedAt: now}, nil
+}
+
+// Usable reports whether the token can still be consumed at now (not used, not expired).
+func (t *EnrolToken) Usable(now time.Time) bool {
+	return t.UsedAt.IsZero() && t.ExpiresAt.After(now)
+}
+
+func dedupeCaps(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, c := range in {
+		c = strings.TrimSpace(c)
+		if c == "" || seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	return out
+}

--- a/internal/domain/fleetagent/fleetagent_test.go
+++ b/internal/domain/fleetagent/fleetagent_test.go
@@ -1,0 +1,72 @@
+package fleetagent
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var tNow = time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+
+func TestNewAgent(t *testing.T) {
+	tests := []struct {
+		name              string
+		id, tenant, aName string
+		hash              string
+		wantErr           bool
+	}{
+		{"ok", "a1", "t1", "agent-1", "hash", false},
+		{"missing id", "", "t1", "agent-1", "hash", true},
+		{"empty tenant", "a1", "", "agent-1", "hash", true},
+		{"missing name", "a1", "t1", "  ", "hash", true},
+		{"missing hash", "a1", "t1", "agent-1", " ", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := NewAgent(shared.ID(tc.id), shared.ID(tc.tenant), tc.aName, "linux", "5.15", "0.1.0", []string{"scan.host", "scan.host", ""}, tc.hash, tNow)
+			if tc.wantErr {
+				if !errors.Is(err, shared.ErrValidation) {
+					t.Fatalf("expected ErrValidation, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if a.State != StateActive || a.Revoked() {
+				t.Fatalf("new agent should be active")
+			}
+			if len(a.Capabilities) != 1 || a.Capabilities[0] != "scan.host" {
+				t.Fatalf("capabilities should dedupe and drop empties, got %v", a.Capabilities)
+			}
+		})
+	}
+}
+
+func TestEnrolToken(t *testing.T) {
+	if _, err := NewEnrolToken("", "t1", "op", tNow.Add(time.Hour), tNow); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("empty hash should fail")
+	}
+	if _, err := NewEnrolToken("h", "", "op", tNow.Add(time.Hour), tNow); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("empty tenant should fail")
+	}
+	if _, err := NewEnrolToken("h", "t1", "op", tNow, tNow); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("non-future expiry should fail")
+	}
+	tok, err := NewEnrolToken("h", "t1", "op", tNow.Add(time.Hour), tNow)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if !tok.Usable(tNow) {
+		t.Fatalf("fresh token should be usable")
+	}
+	if tok.Usable(tNow.Add(2 * time.Hour)) {
+		t.Fatalf("expired token should not be usable")
+	}
+	tok.UsedAt = tNow
+	if tok.Usable(tNow) {
+		t.Fatalf("used token should not be usable")
+	}
+}

--- a/internal/infrastructure/persistence/memory/fleetagent_store.go
+++ b/internal/infrastructure/persistence/memory/fleetagent_store.go
@@ -1,0 +1,129 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// FleetAgentStore is an in-memory ports.FleetAgentStore for dev and tests.
+type FleetAgentStore struct {
+	mu     sync.Mutex
+	agents map[string]*fleetagent.Agent      // key: tenant|id
+	tokens map[string]*fleetagent.EnrolToken // key: tenant|hash
+}
+
+// NewFleetAgentStore returns an empty in-memory fleet agent store.
+func NewFleetAgentStore() *FleetAgentStore {
+	return &FleetAgentStore{agents: map[string]*fleetagent.Agent{}, tokens: map[string]*fleetagent.EnrolToken{}}
+}
+
+var _ ports.FleetAgentStore = (*FleetAgentStore)(nil)
+
+func agentKey(tenant, id shared.ID) string { return tenant.String() + "|" + id.String() }
+func tokKey(tenant shared.ID, hash string) string {
+	return tenant.String() + "|" + hash
+}
+
+func (s *FleetAgentStore) CreateEnrolToken(_ context.Context, t *fleetagent.EnrolToken) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *t
+	s.tokens[tokKey(t.TenantID, t.Hash)] = &cp
+	return nil
+}
+
+func (s *FleetAgentStore) ConsumeEnrolToken(_ context.Context, tenantID shared.ID, hash string, now time.Time) (*fleetagent.EnrolToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.tokens[tokKey(tenantID, hash)]
+	if !ok || !t.Usable(now) {
+		return nil, shared.ErrNotFound
+	}
+	t.UsedAt = now
+	cp := *t
+	return &cp, nil
+}
+
+func (s *FleetAgentStore) CreateAgent(_ context.Context, a *fleetagent.Agent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *a
+	cp.Capabilities = append([]string(nil), a.Capabilities...)
+	s.agents[agentKey(a.TenantID, a.ID)] = &cp
+	return nil
+}
+
+func (s *FleetAgentStore) GetAgent(_ context.Context, tenantID, id shared.ID) (*fleetagent.Agent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a, ok := s.agents[agentKey(tenantID, id)]
+	if !ok {
+		return nil, shared.ErrNotFound
+	}
+	cp := *a
+	cp.Capabilities = append([]string(nil), a.Capabilities...)
+	return &cp, nil
+}
+
+func (s *FleetAgentStore) Heartbeat(_ context.Context, tenantID, id shared.ID, platform, osVersion, agentVersion string, capabilities []string, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a, ok := s.agents[agentKey(tenantID, id)]
+	if !ok {
+		return shared.ErrNotFound
+	}
+	if platform != "" {
+		a.Platform = platform
+	}
+	if osVersion != "" {
+		a.OSVersion = osVersion
+	}
+	if agentVersion != "" {
+		a.AgentVersion = agentVersion
+	}
+	if capabilities != nil {
+		a.Capabilities = append([]string(nil), capabilities...)
+	}
+	a.LastSeenAt = now
+	a.Audit.UpdatedAt = now
+	return nil
+}
+
+func (s *FleetAgentStore) Revoke(_ context.Context, tenantID, id shared.ID, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a, ok := s.agents[agentKey(tenantID, id)]
+	if !ok {
+		return shared.ErrNotFound
+	}
+	a.State = fleetagent.StateRevoked
+	a.Audit.UpdatedAt = now
+	return nil
+}
+
+func (s *FleetAgentStore) ListAgents(_ context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*fleetagent.Agent
+	for _, a := range s.agents {
+		if a.TenantID != tenantID {
+			continue
+		}
+		cp := *a
+		cp.Capabilities = append([]string(nil), a.Capabilities...)
+		out = append(out, &cp)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}

--- a/internal/infrastructure/persistence/postgres/fleetagent_repo.go
+++ b/internal/infrastructure/persistence/postgres/fleetagent_repo.go
@@ -1,0 +1,211 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// FleetAgentRepository is the Postgres-backed fleet agent identity store. Every method runs through
+// WithTenant so Row Level Security (migration 0060 via the 0057 procedure) isolates by tenant. The
+// auth lookup is tenant-scoped because the agent credential carries a non-secret tenant prefix.
+type FleetAgentRepository struct{ pool *pgxpool.Pool }
+
+// NewFleetAgentRepository constructs the Postgres fleet agent repository.
+func NewFleetAgentRepository(pool *pgxpool.Pool) *FleetAgentRepository {
+	return &FleetAgentRepository{pool: pool}
+}
+
+var _ ports.FleetAgentStore = (*FleetAgentRepository)(nil)
+
+const fleetAgentCols = `id, tenant_id, name, platform, os_version, agent_version, capabilities, token_hash, state, created_at, updated_at, last_seen_at`
+
+func (r *FleetAgentRepository) CreateEnrolToken(ctx context.Context, t *fleetagent.EnrolToken) error {
+	return WithTenant(ctx, r.pool, t.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO fleet_enrol_tokens (tenant_id, hash, issued_by, expires_at, created_at)
+			VALUES ($1,$2,$3,$4,$5)`,
+			t.TenantID.String(), t.Hash, t.IssuedBy, t.ExpiresAt, t.CreatedAt)
+		return err
+	})
+}
+
+// ConsumeEnrolToken atomically marks a usable token used and returns it; shared.ErrNotFound if no
+// unused, unexpired token with that hash exists for the tenant.
+func (r *FleetAgentRepository) ConsumeEnrolToken(ctx context.Context, tenantID shared.ID, hash string, now time.Time) (*fleetagent.EnrolToken, error) {
+	var out *fleetagent.EnrolToken
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			UPDATE fleet_enrol_tokens SET used_at=$3
+			WHERE tenant_id=$1 AND hash=$2 AND used_at IS NULL AND expires_at > $3
+			RETURNING tenant_id, hash, issued_by, expires_at, used_at, created_at`,
+			tenantID.String(), hash, now)
+		t, e := scanEnrolToken(row)
+		if e != nil {
+			return e
+		}
+		out = t
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *FleetAgentRepository) CreateAgent(ctx context.Context, a *fleetagent.Agent) error {
+	caps, err := json.Marshal(a.Capabilities)
+	if err != nil {
+		return err
+	}
+	return WithTenant(ctx, r.pool, a.TenantID.String(), func(tx pgx.Tx) error {
+		_, e := tx.Exec(ctx, `
+			INSERT INTO fleet_agents (`+fleetAgentCols+`)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+			a.ID.String(), a.TenantID.String(), a.Name, a.Platform, a.OSVersion, a.AgentVersion,
+			caps, a.TokenHash, string(a.State), a.Audit.CreatedAt, a.Audit.UpdatedAt, a.LastSeenAt)
+		return e
+	})
+}
+
+func (r *FleetAgentRepository) GetAgent(ctx context.Context, tenantID, id shared.ID) (*fleetagent.Agent, error) {
+	var out *fleetagent.Agent
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		a, e := scanAgent(tx.QueryRow(ctx, `SELECT `+fleetAgentCols+` FROM fleet_agents WHERE tenant_id=$1 AND id=$2`,
+			tenantID.String(), id.String()))
+		if e != nil {
+			return e
+		}
+		out = a
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *FleetAgentRepository) Heartbeat(ctx context.Context, tenantID, id shared.ID, platform, osVersion, agentVersion string, capabilities []string, now time.Time) error {
+	var caps []byte
+	if capabilities != nil {
+		b, err := json.Marshal(capabilities)
+		if err != nil {
+			return err
+		}
+		caps = b
+	}
+	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, e := tx.Exec(ctx, `
+			UPDATE fleet_agents SET
+				platform = COALESCE(NULLIF($3,''), platform),
+				os_version = COALESCE(NULLIF($4,''), os_version),
+				agent_version = COALESCE(NULLIF($5,''), agent_version),
+				capabilities = COALESCE($6, capabilities),
+				last_seen_at = $7,
+				updated_at = $7
+			WHERE tenant_id=$1 AND id=$2`,
+			tenantID.String(), id.String(), platform, osVersion, agentVersion, caps, now)
+		if e != nil {
+			return e
+		}
+		if tag.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
+}
+
+func (r *FleetAgentRepository) Revoke(ctx context.Context, tenantID, id shared.ID, now time.Time) error {
+	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, e := tx.Exec(ctx, `UPDATE fleet_agents SET state='revoked', updated_at=$3 WHERE tenant_id=$1 AND id=$2`,
+			tenantID.String(), id.String(), now)
+		if e != nil {
+			return e
+		}
+		if tag.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
+}
+
+func (r *FleetAgentRepository) ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error) {
+	var out []*fleetagent.Agent
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, e := tx.Query(ctx, `SELECT `+fleetAgentCols+` FROM fleet_agents WHERE tenant_id=$1 ORDER BY name, id`, tenantID.String())
+		if e != nil {
+			return e
+		}
+		defer rows.Close()
+		for rows.Next() {
+			a, e := scanAgent(rows)
+			if e != nil {
+				return e
+			}
+			out = append(out, a)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func scanAgent(row rowScanner) (*fleetagent.Agent, error) {
+	var (
+		id, tid, name, platform, osv, ver, hash, state string
+		caps                                           []byte
+		a                                              fleetagent.Agent
+	)
+	if err := row.Scan(&id, &tid, &name, &platform, &osv, &ver, &caps, &hash, &state,
+		&a.Audit.CreatedAt, &a.Audit.UpdatedAt, &a.LastSeenAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, shared.ErrNotFound
+		}
+		return nil, err
+	}
+	a.ID = shared.ID(id)
+	a.TenantID = shared.ID(tid)
+	a.Name = name
+	a.Platform = platform
+	a.OSVersion = osv
+	a.AgentVersion = ver
+	a.TokenHash = hash
+	a.State = fleetagent.State(state)
+	if len(caps) > 0 {
+		if err := json.Unmarshal(caps, &a.Capabilities); err != nil {
+			return nil, err
+		}
+	}
+	return &a, nil
+}
+
+func scanEnrolToken(row rowScanner) (*fleetagent.EnrolToken, error) {
+	var (
+		tid, hash, issuedBy string
+		usedAt              *time.Time
+		t                   fleetagent.EnrolToken
+	)
+	if err := row.Scan(&tid, &hash, &issuedBy, &t.ExpiresAt, &usedAt, &t.CreatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, shared.ErrNotFound
+		}
+		return nil, err
+	}
+	t.TenantID = shared.ID(tid)
+	t.Hash = hash
+	t.IssuedBy = issuedBy
+	if usedAt != nil {
+		t.UsedAt = *usedAt
+	}
+	return &t, nil
+}

--- a/internal/infrastructure/persistence/postgres/fleetagent_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/fleetagent_repo_test.go
@@ -1,0 +1,140 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+func TestFleetAgentRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ('ft','FT') ON CONFLICT (id) DO NOTHING`); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM fleet_enrol_tokens WHERE tenant_id='ft'`)
+		_, _ = pool.Exec(bg, `DELETE FROM fleet_agents WHERE tenant_id='ft'`)
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id='ft'`)
+	})
+
+	repo := NewFleetAgentRepository(pool)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// FORCE RLS on both tables.
+	for _, tbl := range []string{"fleet_agents", "fleet_enrol_tokens"} {
+		var forced bool
+		if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE relname=$1`, tbl).Scan(&forced); err != nil {
+			t.Fatalf("relforce %s: %v", tbl, err)
+		}
+		if !forced {
+			t.Fatalf("FORCE RLS not set on %s", tbl)
+		}
+	}
+
+	// Enrol token: create, then single-use consume.
+	tok, err := fleetagent.NewEnrolToken("hash-1", "ft", "op", now.Add(time.Hour), now)
+	if err != nil {
+		t.Fatalf("new token: %v", err)
+	}
+	if err := repo.CreateEnrolToken(ctx, tok); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	if _, err := repo.ConsumeEnrolToken(ctx, "ft", "hash-1", now); err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if _, err := repo.ConsumeEnrolToken(ctx, "ft", "hash-1", now); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("second consume must fail (single-use), got %v", err)
+	}
+
+	// Agent: create, get, heartbeat, revoke.
+	agent, err := fleetagent.NewAgent("ag1", "ft", "agent-1", "linux", "5.15", "0.1.0", []string{"scan.host"}, "tokhash", now)
+	if err != nil {
+		t.Fatalf("new agent: %v", err)
+	}
+	if err := repo.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	got, err := repo.GetAgent(ctx, "ft", "ag1")
+	if err != nil || got.Name != "agent-1" || len(got.Capabilities) != 1 {
+		t.Fatalf("get agent mismatch: %+v err=%v", got, err)
+	}
+	if err := repo.Heartbeat(ctx, "ft", "ag1", "linux", "5.16", "0.2.0", []string{"scan.host", "detect.rules"}, now.Add(time.Minute)); err != nil {
+		t.Fatalf("heartbeat: %v", err)
+	}
+	got, _ = repo.GetAgent(ctx, "ft", "ag1")
+	if got.AgentVersion != "0.2.0" || len(got.Capabilities) != 2 {
+		t.Fatalf("heartbeat did not update: %+v", got)
+	}
+	if err := repo.Revoke(ctx, "ft", "ag1", now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	got, _ = repo.GetAgent(ctx, "ft", "ag1")
+	if !got.Revoked() {
+		t.Fatalf("agent should be revoked")
+	}
+	if _, err := repo.GetAgent(ctx, "ft", "missing"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for missing agent, got %v", err)
+	}
+}
+
+// TestMigration0060 exercises the migration down and back up.
+func TestMigration0060(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	db, err := goose.OpenDBWithDriver("pgx", dsn)
+	if err != nil {
+		t.Fatalf("goose open: %v", err)
+	}
+	defer db.Close()
+	goose.SetBaseFS(migrations.FS)
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatalf("dialect: %v", err)
+	}
+	if err := goose.DownTo(db, ".", 59); err != nil {
+		t.Fatalf("down to 59: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+	_, err = pool.Exec(ctx, `SELECT 1 FROM fleet_agents LIMIT 1`)
+	var pgErr *pgconn.PgError
+	if err == nil || !errors.As(err, &pgErr) || pgErr.Code != "42P01" {
+		t.Fatalf("fleet_agents should be undefined after down to 59, got %v", err)
+	}
+	if err := goose.UpTo(db, ".", 60); err != nil {
+		t.Fatalf("up to 60: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `SELECT 1 FROM fleet_agents LIMIT 1`); err != nil {
+		t.Fatalf("fleet_agents should exist after up to 60: %v", err)
+	}
+}

--- a/internal/platform/agenttoken/agenttoken.go
+++ b/internal/platform/agenttoken/agenttoken.go
@@ -1,0 +1,76 @@
+// Package agenttoken mints and parses fleet agent credentials. A credential is opaque to the agent
+// but carries a routable, non-secret prefix so the server can resolve the tenant (and agent) before
+// a Row-Level-Security lookup, then verify the secret by a constant-time hash comparison. Only the
+// hash of the secret is ever stored; the plaintext is shown once at creation.
+//
+// Format: "<kind>.<b64url(tenantID)>.<b64url(id)>.<b64url(secret)>". For an enrolment token id is
+// empty. The tenant/id parts are NOT secret (they just route the lookup); forging them fails the
+// hash comparison because the attacker cannot produce the matching secret.
+package agenttoken
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// Kinds of credential.
+const (
+	KindEnrol = "et" // single-use enrolment token
+	KindAgent = "fa" // long-lived agent bearer credential
+)
+
+const secretBytes = 32
+
+var enc = base64.RawURLEncoding
+
+// Mint generates a credential of the given kind for (tenantID, id) and returns the full plaintext
+// token plus the hash of its secret to store. id may be empty (enrolment tokens).
+func Mint(kind, tenantID, id string) (token, secretHash string, err error) {
+	if kind != KindEnrol && kind != KindAgent {
+		return "", "", fmt.Errorf("agenttoken: unknown kind %q", kind)
+	}
+	b := make([]byte, secretBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("agenttoken: generate secret: %w", err)
+	}
+	secret := enc.EncodeToString(b)
+	token = strings.Join([]string{kind, enc.EncodeToString([]byte(tenantID)), enc.EncodeToString([]byte(id)), secret}, ".")
+	return token, Hash(secret), nil
+}
+
+// Parse decodes a token into its parts. ok is false for any malformed token.
+func Parse(token string) (kind, tenantID, id, secret string, ok bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 4 {
+		return "", "", "", "", false
+	}
+	if parts[0] != KindEnrol && parts[0] != KindAgent {
+		return "", "", "", "", false
+	}
+	tb, err1 := enc.DecodeString(parts[1])
+	ib, err2 := enc.DecodeString(parts[2])
+	if err1 != nil || err2 != nil || parts[3] == "" {
+		return "", "", "", "", false
+	}
+	return parts[0], string(tb), string(ib), parts[3], true
+}
+
+// B64 encodes a routable (non-secret) token part with the same alphabet Mint uses. Exposed so
+// callers and tests can construct or inspect the tenant/id parts of a token.
+func B64(s string) string { return enc.EncodeToString([]byte(s)) }
+
+// Hash returns the hex SHA-256 of a secret. The stored hash is compared against this.
+func Hash(secret string) string {
+	sum := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(sum[:])
+}
+
+// Equal reports whether secret hashes to storedHash, in constant time.
+func Equal(secret, storedHash string) bool {
+	return subtle.ConstantTimeCompare([]byte(Hash(secret)), []byte(storedHash)) == 1
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -184,6 +184,13 @@ type Config struct {
 	// services) and its HTTP routes; off by default. When on with Postgres, startup refuses to
 	// serve unless the DB role can enforce Row Level Security (not SUPERUSER/BYPASSRLS).
 	FleetAssetsEnabled bool
+	// FleetEnabled turns on the agent-facing transport (#409: enrol/heartbeat/work) plus the
+	// operator agent-admin routes; off by default. When on with Postgres, startup fails closed
+	// unless the DB role can enforce RLS.
+	FleetEnabled bool
+	// FleetSignerKey is the HMAC key that signs agent work orders. Required and at least 32 bytes
+	// when FleetEnabled; a missing/short key fails startup closed rather than boot a forgeable signer.
+	FleetSignerKey string
 	// SASTEnabled turns on the deterministic pattern-SAST analyzer in the scan pipeline; off by default.
 	SASTEnabled bool
 	// SecretScanEnabled turns on the deterministic secret scanner in the scan pipeline; off by default.
@@ -431,6 +438,8 @@ func Load() Config {
 		SBOMCrossCheckEnabled:  getbool("SYNAPSE_SBOM_CROSSCHECK_ENABLED", true),
 		WriteupDraftsEnabled:   getbool("SYNAPSE_WRITEUP_DRAFTS_ENABLED", false), // needs agent → opt-in
 		FleetAssetsEnabled:     getbool("SYNAPSE_FLEET_ASSETS_ENABLED", false),
+		FleetEnabled:           getbool("SYNAPSE_FLEET_ENABLED", false),
+		FleetSignerKey:         getenv("SYNAPSE_FLEET_SIGNER_KEY", ""),
 		GovulncheckBin:         getenv("SYNAPSE_GOVULNCHECK_BIN", "govulncheck"),
 		GoModGraphEnabled:      getbool("SYNAPSE_GOMODGRAPH_ENABLED", true),
 		GoBin:                  getenv("SYNAPSE_GO_BIN", "go"),

--- a/internal/usecase/fleetagentuc/service.go
+++ b/internal/usecase/fleetagentuc/service.go
@@ -1,0 +1,173 @@
+// Package fleetagentuc is the use-case layer for fleet agent identity (#409, epic #405): an
+// operator mints a single-use enrolment token; an agent exchanges it for a long-lived bearer
+// credential; the API authenticates every subsequent call by that credential. Secret material is
+// generated and hashed here; only hashes reach the store, and the plaintext is returned once.
+package fleetagentuc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/agenttoken"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ErrUnauthenticated means the presented credential is missing, malformed, unknown, or its secret
+// does not match. ErrRevoked means the agent exists but has been revoked. Both are mapped to HTTP
+// at the adapter edge (401 / 403).
+var (
+	ErrUnauthenticated = errors.New("fleetagent: unauthenticated")
+	ErrRevoked         = errors.New("fleetagent: agent revoked")
+)
+
+// Service is the fleet agent identity use case.
+type Service struct {
+	store ports.FleetAgentStore
+	audit ports.AuditLogger
+	clock ports.Clock
+	ids   ports.IDGenerator
+}
+
+// NewService validates its dependencies and returns the service.
+func NewService(store ports.FleetAgentStore, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if store == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: fleet agent service needs store + audit + clock + ids", shared.ErrValidation)
+	}
+	return &Service{store: store, audit: audit, clock: clock, ids: ids}, nil
+}
+
+// MintEnrolToken issues a single-use enrolment token for tenantID valid for ttl, and returns the
+// plaintext once. Only its hash is stored. This is an operator action (RBAC-gated at the adapter).
+func (s *Service) MintEnrolToken(ctx context.Context, actor string, tenantID shared.ID, ttl time.Duration) (string, error) {
+	if tenantID.IsZero() {
+		return "", fmt.Errorf("%w: tenant id is required to mint an enrolment token", shared.ErrValidation)
+	}
+	now := s.clock.Now()
+	token, hash, err := agenttoken.Mint(agenttoken.KindEnrol, tenantID.String(), "")
+	if err != nil {
+		return "", fmt.Errorf("mint enrol token: %w", err)
+	}
+	rec, err := fleetagent.NewEnrolToken(hash, tenantID, actor, now.Add(ttl), now)
+	if err != nil {
+		return "", err
+	}
+	if err := s.store.CreateEnrolToken(ctx, rec); err != nil {
+		return "", fmt.Errorf("mint enrol token: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor, Action: "agent.enrol_token_minted", Target: tenantID.String(),
+		Metadata: map[string]string{"tenant_id": tenantID.String()}, At: now,
+	}); err != nil {
+		return "", fmt.Errorf("mint enrol token: audit: %w", err)
+	}
+	return token, nil
+}
+
+// EnrolInput describes the enrolling agent.
+type EnrolInput struct {
+	Name         string
+	Platform     string
+	OSVersion    string
+	AgentVersion string
+	Capabilities []string
+}
+
+// Enrol exchanges a valid enrolment token for a new agent identity and returns its bearer
+// credential once. The tenant is taken from the enrolment token, never from the caller.
+func (s *Service) Enrol(ctx context.Context, enrolToken string, in EnrolInput) (*fleetagent.Agent, string, error) {
+	kind, tenantStr, _, secret, ok := agenttoken.Parse(enrolToken)
+	if !ok || kind != agenttoken.KindEnrol {
+		return nil, "", ErrUnauthenticated
+	}
+	now := s.clock.Now()
+	tenantID := shared.ID(tenantStr)
+	if _, err := s.store.ConsumeEnrolToken(ctx, tenantID, agenttoken.Hash(secret), now); err != nil {
+		if errors.Is(err, shared.ErrNotFound) {
+			return nil, "", ErrUnauthenticated
+		}
+		return nil, "", fmt.Errorf("enrol: consume token: %w", err)
+	}
+	agentID := s.ids.NewID()
+	token, hash, err := agenttoken.Mint(agenttoken.KindAgent, tenantID.String(), agentID.String())
+	if err != nil {
+		return nil, "", fmt.Errorf("enrol: mint agent token: %w", err)
+	}
+	agent, err := fleetagent.NewAgent(agentID, tenantID, in.Name, in.Platform, in.OSVersion, in.AgentVersion, in.Capabilities, hash, now)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := s.store.CreateAgent(ctx, agent); err != nil {
+		return nil, "", fmt.Errorf("enrol: create agent: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor: agentID.String(), Action: "agent.enrolled", Target: agentID.String(),
+		Metadata: map[string]string{"tenant_id": tenantID.String(), "name": agent.Name, "platform": agent.Platform},
+		At:       now,
+	}); err != nil {
+		return nil, "", fmt.Errorf("enrol: audit: %w", err)
+	}
+	return agent, token, nil
+}
+
+// Authenticate resolves and verifies an agent bearer credential. It returns ErrUnauthenticated for
+// any missing/malformed/unknown credential or secret mismatch, and ErrRevoked for a revoked agent.
+func (s *Service) Authenticate(ctx context.Context, token string) (*fleetagent.Agent, error) {
+	kind, tenantStr, idStr, secret, ok := agenttoken.Parse(token)
+	if !ok || kind != agenttoken.KindAgent {
+		return nil, ErrUnauthenticated
+	}
+	agent, err := s.store.GetAgent(ctx, shared.ID(tenantStr), shared.ID(idStr))
+	if err != nil {
+		if errors.Is(err, shared.ErrNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("authenticate: %w", err)
+	}
+	if !agenttoken.Equal(secret, agent.TokenHash) {
+		return nil, ErrUnauthenticated
+	}
+	if agent.Revoked() {
+		return nil, ErrRevoked
+	}
+	return agent, nil
+}
+
+// HeartbeatInput carries the liveness-report fields.
+type HeartbeatInput struct {
+	Platform     string
+	OSVersion    string
+	AgentVersion string
+	Capabilities []string
+}
+
+// Heartbeat records liveness and refreshes the agent's reported attributes.
+func (s *Service) Heartbeat(ctx context.Context, agent *fleetagent.Agent, in HeartbeatInput) error {
+	if err := s.store.Heartbeat(ctx, agent.TenantID, agent.ID, in.Platform, in.OSVersion, in.AgentVersion, in.Capabilities, s.clock.Now()); err != nil {
+		return fmt.Errorf("heartbeat: %w", err)
+	}
+	return nil
+}
+
+// Revoke marks an agent revoked so its credential no longer authenticates.
+func (s *Service) Revoke(ctx context.Context, actor string, tenantID, id shared.ID) error {
+	now := s.clock.Now()
+	if err := s.store.Revoke(ctx, tenantID, id, now); err != nil {
+		return fmt.Errorf("revoke agent: %w", err)
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor, Action: "agent.revoked", Target: id.String(),
+		Metadata: map[string]string{"tenant_id": tenantID.String()}, At: now,
+	}); err != nil {
+		return fmt.Errorf("revoke agent: audit: %w", err)
+	}
+	return nil
+}
+
+// ListAgents returns the tenant's agents.
+func (s *Service) ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error) {
+	return s.store.ListAgents(ctx, tenantID)
+}

--- a/internal/usecase/fleetagentuc/service_test.go
+++ b/internal/usecase/fleetagentuc/service_test.go
@@ -1,0 +1,125 @@
+package fleetagentuc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/agenttoken"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeClock struct{ t time.Time }
+
+func (c fakeClock) Now() time.Time { return c.t }
+
+type fakeIDs struct{ n int }
+
+func (g *fakeIDs) NewID() shared.ID { g.n++; return shared.ID(fmt.Sprintf("ag-%d", g.n)) }
+
+type fakeAudit struct{ n int }
+
+func (a *fakeAudit) Record(context.Context, ports.AuditEntry) error { a.n++; return nil }
+
+func newSvc(t *testing.T) *Service {
+	t.Helper()
+	svc, err := NewService(memory.NewFleetAgentStore(), &fakeAudit{}, fakeClock{t: time.Unix(1000, 0).UTC()}, &fakeIDs{})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return svc
+}
+
+func TestEnrolAndAuthenticate(t *testing.T) {
+	svc := newSvc(t)
+	ctx := context.Background()
+
+	enrolTok, err := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	agent, agentTok, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "agent-1", Platform: "linux"})
+	if err != nil {
+		t.Fatalf("enrol: %v", err)
+	}
+	if agent.TenantID != "t1" {
+		t.Fatalf("agent tenant should come from the enrol token, got %q", agent.TenantID)
+	}
+
+	// The single-use enrol token cannot be used again.
+	if _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "agent-2"}); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("re-using an enrol token must fail unauthenticated, got %v", err)
+	}
+
+	// The agent credential authenticates.
+	got, err := svc.Authenticate(ctx, agentTok)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if got.ID != agent.ID {
+		t.Fatalf("authenticated the wrong agent: %q vs %q", got.ID, agent.ID)
+	}
+}
+
+func TestAuthenticateRejectsTamperedAndMalformed(t *testing.T) {
+	svc := newSvc(t)
+	ctx := context.Background()
+	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
+	_, agentTok, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"})
+	if err != nil {
+		t.Fatalf("enrol: %v", err)
+	}
+
+	for _, bad := range []string{"", "garbage", "fa.only.three", agentTok + "x", "et." + strings.TrimPrefix(agentTok, "fa.")} {
+		if _, err := svc.Authenticate(ctx, bad); !errors.Is(err, ErrUnauthenticated) {
+			t.Errorf("malformed/tampered token %q must be unauthenticated, got %v", bad, err)
+		}
+	}
+
+	// Tamper the tenant prefix: re-mint the routable parts for another tenant but keep the secret.
+	kind, _, id, secret, ok := agenttoken.Parse(agentTok)
+	if !ok {
+		t.Fatalf("parse own token failed")
+	}
+	forged := kind + "." + b64("t2") + "." + b64(id) + "." + secret
+	if _, err := svc.Authenticate(ctx, forged); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("cross-tenant forged token must be unauthenticated, got %v", err)
+	}
+}
+
+func TestAuthenticateRevoked(t *testing.T) {
+	svc := newSvc(t)
+	ctx := context.Background()
+	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
+	agent, agentTok, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"})
+	if err != nil {
+		t.Fatalf("enrol: %v", err)
+	}
+	if err := svc.Revoke(ctx, "op", "t1", agent.ID); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := svc.Authenticate(ctx, agentTok); !errors.Is(err, ErrRevoked) {
+		t.Fatalf("revoked agent must return ErrRevoked, got %v", err)
+	}
+}
+
+func TestExpiredEnrolTokenRejected(t *testing.T) {
+	svc := newSvc(t)
+	ctx := context.Background()
+	enrolTok, err := svc.MintEnrolToken(ctx, "op", "t1", time.Nanosecond)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	// fakeClock is fixed, but the token expiry is now+1ns; advance the service clock past it.
+	svc.clock = fakeClock{t: time.Unix(1000, 0).UTC().Add(time.Hour)}
+	if _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"}); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("expired enrol token must fail, got %v", err)
+	}
+}
+
+func b64(s string) string { return agenttoken.B64(s) }

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -15,6 +15,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/hotspot"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/importedsbom"
@@ -84,6 +85,21 @@ type WorkOrderStore interface {
 	GetByID(ctx context.Context, tenantID, id shared.ID) (*workorder.WorkOrder, error)
 	Claim(ctx context.Context, tenantID, agentID shared.ID, max int, now time.Time) ([]*workorder.WorkOrder, error)
 	Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State, now time.Time) error
+}
+
+// FleetAgentStore persists tenant-scoped fleet agent identities and their single-use enrolment
+// tokens. Postgres routes every method through WithTenant so Row Level Security isolates by tenant.
+// The auth lookup is tenant-scoped because the credential carries a (non-secret) tenant prefix.
+type FleetAgentStore interface {
+	CreateEnrolToken(ctx context.Context, t *fleetagent.EnrolToken) error
+	// ConsumeEnrolToken atomically marks a usable token used and returns it; shared.ErrNotFound if
+	// no usable (unused, unexpired) token with that hash exists for the tenant.
+	ConsumeEnrolToken(ctx context.Context, tenantID shared.ID, hash string, now time.Time) (*fleetagent.EnrolToken, error)
+	CreateAgent(ctx context.Context, a *fleetagent.Agent) error
+	GetAgent(ctx context.Context, tenantID, id shared.ID) (*fleetagent.Agent, error)
+	Heartbeat(ctx context.Context, tenantID, id shared.ID, platform, osVersion, agentVersion string, capabilities []string, now time.Time) error
+	Revoke(ctx context.Context, tenantID, id shared.ID, now time.Time) error
+	ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error)
 }
 
 // WorkOrderSigner signs and verifies the canonical signing payload of a work order. The

--- a/migrations/0060_fleet_agents.sql
+++ b/migrations/0060_fleet_agents.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+-- Fleet agent identity (#409, epic #405): enrolled agents and the single-use enrolment tokens that
+-- mint them. RLS-native via the 0057 procedure (tenant_id keys the policy; empty tenant = DENY, so
+-- agents and tokens use non-empty tenant ids). Only credential HASHES are stored; the plaintext
+-- enrolment token and agent bearer credential are shown once at creation and never persisted.
+CREATE TABLE fleet_agents (
+    id            TEXT PRIMARY KEY,
+    tenant_id     TEXT NOT NULL REFERENCES tenants(id),
+    name          TEXT NOT NULL,
+    platform      TEXT NOT NULL DEFAULT '',
+    os_version    TEXT NOT NULL DEFAULT '',
+    agent_version TEXT NOT NULL DEFAULT '',
+    capabilities  JSONB NOT NULL DEFAULT '[]',
+    token_hash    TEXT NOT NULL,
+    state         TEXT NOT NULL CHECK (state IN ('active', 'revoked')),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_fleet_agents_tenant ON fleet_agents (tenant_id, name);
+CALL synapse_enable_tenant_rls('fleet_agents');
+
+CREATE TABLE fleet_enrol_tokens (
+    tenant_id  TEXT NOT NULL REFERENCES tenants(id),
+    hash       TEXT NOT NULL,
+    issued_by  TEXT NOT NULL DEFAULT '',
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at    TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, hash)
+);
+CALL synapse_enable_tenant_rls('fleet_enrol_tokens');
+
+-- +goose Down
+DROP TABLE fleet_enrol_tokens;
+DROP TABLE fleet_agents;


### PR DESCRIPTION
Implements #409 (epic #405): the agent-facing transport, on a SEPARATE authentication plane from human RBAC.

## Scope decision (please read)
#409 cannot be safe without an agent identity/auth layer, and #408 (agent identity, mTLS) is not built. So this PR delivers the minimal **token-based** agent identity #409 requires, and defers the heavier pieces with references:
- Mutual TLS + CSR enrolment and revocation-at-the-transport-layer -> #408.
- Evidence upload and the update channel -> #412.
- Backpressure (503) -> follow-up.

The credential is a bearer token, not a client certificate, but the model is built so a certificate fingerprint can replace the token hash without changing the lifecycle.

## What this delivers
- **Domain** `internal/domain/fleetagent`: `Agent` + single-use `EnrolToken`; non-empty tenant required (empty = DENY under RLS); only credential hashes stored.
- **Credential** `internal/platform/agenttoken`: `"<kind>.<b64(tenant)>.<b64(id)>.<secret>"`. The non-secret tenant/id prefix routes the RLS-scoped lookup before verification; the 32-byte secret is stored only as a SHA-256 hash and compared in **constant time**. This resolves the auth chicken-and-egg (you must know the tenant to do an RLS read, but you learn it from the credential) without any cross-tenant scan; forging the prefix fails the hash compare.
- **Usecase** `internal/usecase/fleetagentuc`: MintEnrolToken (operator), Enrol (tenant from the token, never the caller), Authenticate (`ErrUnauthenticated`/`ErrRevoked`), Heartbeat, Revoke. Work orders reuse `fleetwork` (#407).
- **Stores**: memory + Postgres (`WithTenant`; migration 0060 RLS-enables `fleet_agents` + `fleet_enrol_tokens`; `ConsumeEnrolToken` is an atomic single-use `UPDATE ... RETURNING`).
- **Adapter**: `/api/v1/fleet` is mounted at the top level, **bypassing the human authenticator and AUP gate**. Its own middleware requires the protocol version header and a valid agent bearer credential (enrol excepted), rate-limits per agent, and stamps the agent + tenant into context. Endpoints: enrol, heartbeat, work/claim (addressed), work/{id}/progress, work/{id}/result (idempotent). A mis-addressed or cross-tenant order returns 404 (no existence leak). Operator routes `/api/v1/agents` (mint enrolment token, list, revoke) stay on the human RBAC plane (PermAdminister / PermView).
- **Config** `SYNAPSE_FLEET_ENABLED` (default off) + `SYNAPSE_FLEET_SIGNER_KEY`. When enabled with Postgres, startup fails closed unless the DB role can enforce RLS and the signer key is >= 32 bytes.

## Verification
- Domain + usecase tests: single-use enrol, tampered/forged/cross-tenant/revoked/expired rejection, constant-time compare.
- Postgres integration: single-use consume, agent CRUD, FORCE RLS on both tables, migration 0060 down/up.
- HTTP end-to-end: version required (400), enrol (201), auth required (401), addressed claim returns only the caller's order, progress->result idempotent (200 on repeat), mis-addressed order 404, revoked agent 403.
- `go build ./...`, `go vet ./...`, `go test ./...` (no DSN), gofmt all clean.

Refs #405
