### PR TITLE
feat(platform): fenced-lease leader election (#406)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -112,6 +112,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fptriage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/leaderuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/llmverifier"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -173,6 +174,7 @@ func main() {
 	var assetStore ports.AssetRepository
 	var workOrderStore ports.WorkOrderStore
 	var fleetAgentStore ports.FleetAgentStore
+	var leaderStore ports.LeaderStore // postgres only; nil in memory mode (single process)
 	var findingRepo ports.FindingRepository
 	var judgmentStore analysisuc.Store // postgres or memory; satisfies both the narrow Store + ports.JudgmentStore
 	var commentRepo ports.CommentRepository
@@ -295,6 +297,7 @@ func main() {
 		assetStore = postgres.NewAssetRepository(pool)
 		workOrderStore = postgres.NewWorkOrderRepository(pool)
 		fleetAgentStore = postgres.NewFleetAgentRepository(pool)
+		leaderStore = postgres.NewLeaderStore(pool)
 		// SECURITY (#431 req 6, #432, #409): the fleet_* tables are RLS-protected, but RLS is a
 		// silent no-op if the runtime DB role is SUPERUSER or holds BYPASSRLS. When any fleet
 		// feature is enabled we refuse to serve unless the role can actually enforce isolation.
@@ -1294,6 +1297,21 @@ func main() {
 				}
 			}
 		}()
+	}
+
+	// Leader election (#406): run the fenced-lease elector so a future scheduler can gate periodic
+	// dispatch on IsLeader when running more than one instance. Postgres only. The elector resigns
+	// on shutdown so a follower takes over without waiting for the term. NOTE: this ships the
+	// election mechanism; removing the single-instance lock and gating dispatch on IsLeader (true
+	// horizontal scale) is the tracked follow-on.
+	if cfg.LeaderElectionEnabled && leaderStore != nil {
+		elector, eerr := leaderuc.NewElector(leaderStore, auditLog, clock, cfg.LeaderResource, ids.NewID().String(), cfg.LeaderTerm, cfg.LeaderRenew)
+		if eerr != nil {
+			log.Error("leader election enabled but misconfigured (require 0 < renew < term/2)", "err", eerr)
+			os.Exit(1)
+		}
+		go elector.Run(ctx)
+		log.Info("leader election ENABLED", "resource", cfg.LeaderResource, "term", cfg.LeaderTerm, "renew", cfg.LeaderRenew)
 	}
 
 	if err := httpserver.Run(ctx, cfg.HTTPAddr, router.Handler(), log); err != nil {

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1304,6 +1304,9 @@ func main() {
 	// on shutdown so a follower takes over without waiting for the term. NOTE: this ships the
 	// election mechanism; removing the single-instance lock and gating dispatch on IsLeader (true
 	// horizontal scale) is the tracked follow-on.
+	if cfg.LeaderElectionEnabled && leaderStore == nil {
+		log.Warn("leader election enabled but ignored: it requires Postgres (a single in-memory process is trivially the leader)")
+	}
 	if cfg.LeaderElectionEnabled && leaderStore != nil {
 		elector, eerr := leaderuc.NewElector(leaderStore, auditLog, clock, cfg.LeaderResource, ids.NewID().String(), cfg.LeaderTerm, cfg.LeaderRenew)
 		if eerr != nil {

--- a/internal/infrastructure/persistence/memory/leader_store.go
+++ b/internal/infrastructure/persistence/memory/leader_store.go
@@ -1,0 +1,61 @@
+package memory
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// LeaderStore is an in-memory ports.LeaderStore for dev and single-process tests. It mirrors the
+// Postgres fenced-lease semantics under a mutex.
+type LeaderStore struct {
+	mu     sync.Mutex
+	leases map[string]*lease
+}
+
+type lease struct {
+	holder  string
+	fence   int64
+	expires time.Time
+}
+
+// NewLeaderStore returns an empty in-memory leader store.
+func NewLeaderStore() *LeaderStore { return &LeaderStore{leases: map[string]*lease{}} }
+
+var _ ports.LeaderStore = (*LeaderStore)(nil)
+
+// Acquire takes the lease when it is free (expired) or already held by holder, renewing the term;
+// a takeover from an expired holder bumps the fence. Otherwise another instance holds it.
+func (s *LeaderStore) Acquire(_ context.Context, resource, holder string, term time.Duration, now time.Time) (bool, int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l, ok := s.leases[resource]
+	if !ok {
+		s.leases[resource] = &lease{holder: holder, fence: 1, expires: now.Add(term)}
+		return true, 1, nil
+	}
+	switch {
+	case l.holder == holder:
+		l.expires = now.Add(term) // renew
+		return true, l.fence, nil
+	case !l.expires.After(now):
+		l.holder = holder // takeover of an expired lease
+		l.fence++
+		l.expires = now.Add(term)
+		return true, l.fence, nil
+	default:
+		return false, l.fence, nil // someone else holds a live lease
+	}
+}
+
+// Resign releases the lease if held by holder.
+func (s *LeaderStore) Resign(_ context.Context, resource, holder string, _ time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l, ok := s.leases[resource]; ok && l.holder == holder {
+		delete(s.leases, resource)
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/memory/leader_store.go
+++ b/internal/infrastructure/persistence/memory/leader_store.go
@@ -50,12 +50,15 @@ func (s *LeaderStore) Acquire(_ context.Context, resource, holder string, term t
 	}
 }
 
-// Resign releases the lease if held by holder.
-func (s *LeaderStore) Resign(_ context.Context, resource, holder string, _ time.Time) error {
+// Resign releases the lease if held by holder. It expires the lease (clears the holder, sets the
+// term to now) rather than dropping the row, so the fence survives and stays monotonic across a
+// graceful handover, matching the Postgres store.
+func (s *LeaderStore) Resign(_ context.Context, resource, holder string, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if l, ok := s.leases[resource]; ok && l.holder == holder {
-		delete(s.leases, resource)
+		l.holder = ""
+		l.expires = now
 	}
 	return nil
 }

--- a/internal/infrastructure/persistence/postgres/leader_store.go
+++ b/internal/infrastructure/persistence/postgres/leader_store.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -44,13 +45,21 @@ func (s *LeaderStore) Acquire(ctx context.Context, resource, holder string, term
 		RETURNING holder, fence`,
 		resource, holder, expires, now).Scan(&winner, &fence)
 	if err != nil {
-		return false, 0, err
+		return false, 0, fmt.Errorf("acquire leader lease: %w", err)
 	}
 	return winner == holder, fence, nil
 }
 
-// Resign releases the lease if held by holder.
-func (s *LeaderStore) Resign(ctx context.Context, resource, holder string, _ time.Time) error {
-	_, err := s.pool.Exec(ctx, `DELETE FROM leader_leases WHERE resource=$1 AND holder=$2`, resource, holder)
-	return err
+// Resign releases the lease if held by holder. It EXPIRES the lease (clears the holder and sets the
+// term to now) rather than deleting the row, so the fence survives: a graceful handover keeps the
+// fence monotonic (the next acquirer takes over an expired row and bumps it), which a fresh INSERT
+// with fence=1 would not. A challenger sees the expired row immediately and can take over without
+// waiting out the term.
+func (s *LeaderStore) Resign(ctx context.Context, resource, holder string, now time.Time) error {
+	if _, err := s.pool.Exec(ctx,
+		`UPDATE leader_leases SET holder='', term_expires=$3, updated_at=$3 WHERE resource=$1 AND holder=$2`,
+		resource, holder, now); err != nil {
+		return fmt.Errorf("resign leader lease: %w", err)
+	}
+	return nil
 }

--- a/internal/infrastructure/persistence/postgres/leader_store.go
+++ b/internal/infrastructure/persistence/postgres/leader_store.go
@@ -1,0 +1,56 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// LeaderStore is the Postgres fenced-lease implementation of leader election. It is global
+// control-plane state (no tenant scoping, no RLS; see migration 0061).
+type LeaderStore struct{ pool *pgxpool.Pool }
+
+// NewLeaderStore constructs the Postgres leader store.
+func NewLeaderStore(pool *pgxpool.Pool) *LeaderStore { return &LeaderStore{pool: pool} }
+
+var _ ports.LeaderStore = (*LeaderStore)(nil)
+
+// Acquire atomically takes or renews leadership in a single upsert: it takes the lease when the
+// row is absent, already held by holder (renewal), or expired (takeover, which bumps the fence),
+// and otherwise leaves a live foreign lease untouched. held is true iff holder owns it afterwards.
+func (s *LeaderStore) Acquire(ctx context.Context, resource, holder string, term time.Duration, now time.Time) (bool, int64, error) {
+	expires := now.Add(term)
+	var (
+		winner string
+		fence  int64
+	)
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO leader_leases (resource, holder, fence, term_expires, updated_at)
+		VALUES ($1, $2, 1, $3, $4)
+		ON CONFLICT (resource) DO UPDATE SET
+			holder = CASE
+				WHEN leader_leases.holder = $2 OR leader_leases.term_expires <= $4 THEN $2
+				ELSE leader_leases.holder END,
+			fence = CASE
+				WHEN leader_leases.holder <> $2 AND leader_leases.term_expires <= $4 THEN leader_leases.fence + 1
+				ELSE leader_leases.fence END,
+			term_expires = CASE
+				WHEN leader_leases.holder = $2 OR leader_leases.term_expires <= $4 THEN $3
+				ELSE leader_leases.term_expires END,
+			updated_at = $4
+		RETURNING holder, fence`,
+		resource, holder, expires, now).Scan(&winner, &fence)
+	if err != nil {
+		return false, 0, err
+	}
+	return winner == holder, fence, nil
+}
+
+// Resign releases the lease if held by holder.
+func (s *LeaderStore) Resign(ctx context.Context, resource, holder string, _ time.Time) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM leader_leases WHERE resource=$1 AND holder=$2`, resource, holder)
+	return err
+}

--- a/internal/infrastructure/persistence/postgres/leader_store_test.go
+++ b/internal/infrastructure/persistence/postgres/leader_store_test.go
@@ -63,13 +63,17 @@ func TestLeaderStore(t *testing.T) {
 		t.Fatalf("takeover must bump the fence: %d -> %d", fenceA, fenceB)
 	}
 
-	// B resigns; A can acquire immediately even before the term expires.
+	// B resigns; A can acquire immediately even before the term expires, and the fence must NOT
+	// go backwards across the resign+reacquire (Resign expires, it does not drop the row).
 	if err := s.Resign(ctx, "sched-test", "inst-b", now.Add(term+11*time.Second)); err != nil {
 		t.Fatalf("resign: %v", err)
 	}
-	heldA3, _, err := s.Acquire(ctx, "sched-test", "inst-a", term, now.Add(term+12*time.Second))
+	heldA3, fenceA3, err := s.Acquire(ctx, "sched-test", "inst-a", term, now.Add(term+12*time.Second))
 	if err != nil || !heldA3 {
 		t.Fatalf("A should acquire immediately after B resigned: held=%v err=%v", heldA3, err)
+	}
+	if fenceA3 <= fenceB {
+		t.Fatalf("fence must not decrease across resign+reacquire: fenceB=%d fenceA3=%d", fenceB, fenceA3)
 	}
 }
 

--- a/internal/infrastructure/persistence/postgres/leader_store_test.go
+++ b/internal/infrastructure/persistence/postgres/leader_store_test.go
@@ -1,0 +1,122 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+func TestLeaderStore(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM leader_leases WHERE resource='sched-test'`)
+	})
+
+	s := NewLeaderStore(pool)
+	const term = 15 * time.Second
+	now := time.Now().UTC()
+
+	// A wins; B (contending under the same live lease) does not.
+	heldA, fenceA, err := s.Acquire(ctx, "sched-test", "inst-a", term, now)
+	if err != nil || !heldA {
+		t.Fatalf("A should acquire: held=%v err=%v", heldA, err)
+	}
+	heldB, _, err := s.Acquire(ctx, "sched-test", "inst-b", term, now)
+	if err != nil {
+		t.Fatalf("B acquire err: %v", err)
+	}
+	if heldB {
+		t.Fatalf("B must not hold a live foreign lease")
+	}
+
+	// A renews (same holder) without bumping the fence.
+	heldA2, fenceA2, err := s.Acquire(ctx, "sched-test", "inst-a", term, now.Add(5*time.Second))
+	if err != nil || !heldA2 || fenceA2 != fenceA {
+		t.Fatalf("A renewal should keep the lease and fence: held=%v fence=%d/%d err=%v", heldA2, fenceA2, fenceA, err)
+	}
+
+	// After the term expires, B takes over and the fence is bumped.
+	heldB2, fenceB, err := s.Acquire(ctx, "sched-test", "inst-b", term, now.Add(term+10*time.Second))
+	if err != nil || !heldB2 {
+		t.Fatalf("B should take over an expired lease: held=%v err=%v", heldB2, err)
+	}
+	if fenceB <= fenceA {
+		t.Fatalf("takeover must bump the fence: %d -> %d", fenceA, fenceB)
+	}
+
+	// B resigns; A can acquire immediately even before the term expires.
+	if err := s.Resign(ctx, "sched-test", "inst-b", now.Add(term+11*time.Second)); err != nil {
+		t.Fatalf("resign: %v", err)
+	}
+	heldA3, _, err := s.Acquire(ctx, "sched-test", "inst-a", term, now.Add(term+12*time.Second))
+	if err != nil || !heldA3 {
+		t.Fatalf("A should acquire immediately after B resigned: held=%v err=%v", heldA3, err)
+	}
+}
+
+// TestMigration0061 exercises the migration down and back up.
+func TestMigration0061(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	db, err := goose.OpenDBWithDriver("pgx", dsn)
+	if err != nil {
+		t.Fatalf("goose open: %v", err)
+	}
+	defer db.Close()
+	goose.SetBaseFS(migrations.FS)
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatalf("dialect: %v", err)
+	}
+	if err := goose.DownTo(db, ".", 60); err != nil {
+		t.Fatalf("down to 60: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+	_, err = pool.Exec(ctx, `SELECT 1 FROM leader_leases LIMIT 1`)
+	var pgErr *pgconn.PgError
+	if err == nil || !errors.As(err, &pgErr) || pgErr.Code != "42P01" {
+		t.Fatalf("leader_leases should be undefined after down to 60, got %v", err)
+	}
+	if err := goose.UpTo(db, ".", 61); err != nil {
+		t.Fatalf("up to 61: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `SELECT 1 FROM leader_leases LIMIT 1`); err != nil {
+		t.Fatalf("leader_leases should exist after up to 61: %v", err)
+	}
+	// It is deliberately NOT under RLS (global control-plane state).
+	var forced bool
+	if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE relname='leader_leases'`).Scan(&forced); err != nil {
+		t.Fatalf("relforce: %v", err)
+	}
+	if forced {
+		t.Fatalf("leader_leases must NOT be RLS-forced (global control-plane state)")
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -191,6 +191,14 @@ type Config struct {
 	// FleetSignerKey is the HMAC key that signs agent work orders. Required and at least 32 bytes
 	// when FleetEnabled; a missing/short key fails startup closed rather than boot a forgeable signer.
 	FleetSignerKey string
+	// LeaderElectionEnabled runs the fenced-lease leader elector (#406). Off by default. Postgres
+	// only (a single in-memory process is trivially the leader). Renewing < Term/2 is enforced.
+	LeaderElectionEnabled bool
+	// LeaderResource is the lease key elected over (default "scheduler").
+	LeaderResource string
+	// LeaderTerm is the lease term; LeaderRenew is the renewal interval (must be < Term/2).
+	LeaderTerm  time.Duration
+	LeaderRenew time.Duration
 	// SASTEnabled turns on the deterministic pattern-SAST analyzer in the scan pipeline; off by default.
 	SASTEnabled bool
 	// SecretScanEnabled turns on the deterministic secret scanner in the scan pipeline; off by default.
@@ -440,6 +448,10 @@ func Load() Config {
 		FleetAssetsEnabled:     getbool("SYNAPSE_FLEET_ASSETS_ENABLED", false),
 		FleetEnabled:           getbool("SYNAPSE_FLEET_ENABLED", false),
 		FleetSignerKey:         getenv("SYNAPSE_FLEET_SIGNER_KEY", ""),
+		LeaderElectionEnabled:  getbool("SYNAPSE_LEADER_ENABLED", false),
+		LeaderResource:         getenv("SYNAPSE_LEADER_RESOURCE", "scheduler"),
+		LeaderTerm:             getduration("SYNAPSE_LEADER_TERM", 15*time.Second),
+		LeaderRenew:            getduration("SYNAPSE_LEADER_RENEW", 5*time.Second),
 		GovulncheckBin:         getenv("SYNAPSE_GOVULNCHECK_BIN", "govulncheck"),
 		GoModGraphEnabled:      getbool("SYNAPSE_GOMODGRAPH_ENABLED", true),
 		GoBin:                  getenv("SYNAPSE_GO_BIN", "go"),

--- a/internal/usecase/leaderuc/elector.go
+++ b/internal/usecase/leaderuc/elector.go
@@ -1,0 +1,113 @@
+// Package leaderuc runs leader election over a fenced lease (#406, epic #405) so more than one
+// control-plane instance can run while exactly one is the scheduler leader at a time. The Elector
+// campaigns and renews on a timer, caches the current leadership view for non-blocking callers,
+// and records every leadership transition in the audit log.
+package leaderuc
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Elector holds leadership of a single resource for one instance.
+type Elector struct {
+	store      ports.LeaderStore
+	audit      ports.AuditLogger
+	clock      ports.Clock
+	resource   string
+	instanceID string
+	term       time.Duration
+	renew      time.Duration
+
+	leader atomic.Bool
+	fence  atomic.Int64
+}
+
+// NewElector validates its inputs. renew must be strictly less than term/2 so a single missed
+// renewal cannot cause a spurious handover.
+func NewElector(store ports.LeaderStore, audit ports.AuditLogger, clock ports.Clock, resource, instanceID string, term, renew time.Duration) (*Elector, error) {
+	if store == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: elector needs store + audit + clock", shared.ErrValidation)
+	}
+	if resource == "" || instanceID == "" {
+		return nil, fmt.Errorf("%w: elector needs a resource and an instance id", shared.ErrValidation)
+	}
+	if term <= 0 || renew <= 0 || renew >= term/2 {
+		return nil, fmt.Errorf("%w: require 0 < renew < term/2 (term=%s renew=%s)", shared.ErrValidation, term, renew)
+	}
+	return &Elector{store: store, audit: audit, clock: clock, resource: resource, instanceID: instanceID, term: term, renew: renew}, nil
+}
+
+// IsLeader reports the cached leadership view without blocking.
+func (e *Elector) IsLeader() bool { return e.leader.Load() }
+
+// Fence returns the last observed fence token.
+func (e *Elector) Fence() int64 { return e.fence.Load() }
+
+// tick performs one acquire/renew and updates the cached view, auditing any transition. It is the
+// unit the timer drives and the seam tests call directly with a controlled clock.
+func (e *Elector) tick(ctx context.Context) error {
+	held, fence, err := e.store.Acquire(ctx, e.resource, e.instanceID, e.term, e.clock.Now())
+	if err != nil {
+		// Fail-safe: on any error we cannot prove we still hold the lease, so we drop leadership
+		// rather than risk two leaders. A recovered store re-acquires on the next tick.
+		if e.leader.Swap(false) {
+			e.record(ctx, "leader.lost", "acquire error")
+		}
+		return err
+	}
+	e.fence.Store(fence)
+	if was := e.leader.Swap(held); held != was {
+		if held {
+			e.record(ctx, "leader.acquired", "")
+		} else {
+			e.record(ctx, "leader.lost", "lease taken over")
+		}
+	}
+	return nil
+}
+
+// Run campaigns immediately, then renews every renew interval until ctx is done, at which point it
+// resigns so a follower can take over without waiting for the term to expire.
+func (e *Elector) Run(ctx context.Context) {
+	_ = e.tick(ctx)
+	t := time.NewTicker(e.renew)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			e.resign()
+			return
+		case <-t.C:
+			_ = e.tick(ctx)
+		}
+	}
+}
+
+// resign releases the lease on shutdown with a fresh, bounded context.
+func (e *Elector) resign() {
+	rbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = e.store.Resign(rbCtx, e.resource, e.instanceID, e.clock.Now())
+	if e.leader.Swap(false) {
+		e.record(rbCtx, "leader.resigned", "shutdown")
+	}
+}
+
+// record writes a leadership transition to the audit log. It is best-effort: a background daemon
+// must not lose (or falsely keep) leadership because the audit write failed, so an error is
+// swallowed here rather than propagated.
+func (e *Elector) record(ctx context.Context, action, reason string) {
+	_ = e.audit.Record(ctx, ports.AuditEntry{
+		Actor:    e.instanceID,
+		Action:   action,
+		Target:   e.resource,
+		Metadata: map[string]string{"reason": reason, "fence": fmt.Sprintf("%d", e.fence.Load())},
+		At:       e.clock.Now(),
+	})
+}

--- a/internal/usecase/leaderuc/elector.go
+++ b/internal/usecase/leaderuc/elector.go
@@ -44,9 +44,13 @@ func NewElector(store ports.LeaderStore, audit ports.AuditLogger, clock ports.Cl
 }
 
 // IsLeader reports the cached leadership view without blocking.
+//
+// Note: IsLeader and Fence are independent atomics. That is fine for the current callers (gauging
+// leadership only). When a downstream first GATES on the pair "am I leader, and with which fence",
+// expose a single combined accessor so the two cannot be read torn across a transition.
 func (e *Elector) IsLeader() bool { return e.leader.Load() }
 
-// Fence returns the last observed fence token.
+// Fence returns the last observed fence token. See the note on IsLeader about reading the pair.
 func (e *Elector) Fence() int64 { return e.fence.Load() }
 
 // tick performs one acquire/renew and updates the cached view, auditing any transition. It is the

--- a/internal/usecase/leaderuc/elector_test.go
+++ b/internal/usecase/leaderuc/elector_test.go
@@ -3,13 +3,57 @@ package leaderuc
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
-	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+// fakeLeaderStore is an in-file ports.LeaderStore for these usecase tests, mirroring the fenced
+// lease semantics. Keeping it here avoids a usecase -> infrastructure import edge in the test.
+type fakeLeaderStore struct {
+	mu      sync.Mutex
+	holder  string
+	fence   int64
+	expires time.Time
+	present bool
+}
+
+func newFakeLeaderStore() *fakeLeaderStore { return &fakeLeaderStore{} }
+
+var _ ports.LeaderStore = (*fakeLeaderStore)(nil)
+
+func (s *fakeLeaderStore) Acquire(_ context.Context, _, holder string, term time.Duration, now time.Time) (bool, int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	switch {
+	case !s.present:
+		s.holder, s.fence, s.expires, s.present = holder, 1, now.Add(term), true
+		return true, s.fence, nil
+	case s.holder == holder:
+		s.expires = now.Add(term)
+		return true, s.fence, nil
+	case !s.expires.After(now):
+		s.holder, s.expires = holder, now.Add(term)
+		s.fence++
+		return true, s.fence, nil
+	default:
+		return false, s.fence, nil
+	}
+}
+
+func (s *fakeLeaderStore) Resign(_ context.Context, _, holder string, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.present && s.holder == holder {
+		// Expire, keep the fence (matches the production stores): monotonic across handover.
+		s.holder = ""
+		s.expires = now
+	}
+	return nil
+}
 
 type fakeClock struct{ t time.Time }
 
@@ -26,7 +70,7 @@ func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
 }
 
 func TestNewElectorValidation(t *testing.T) {
-	store := memory.NewLeaderStore()
+	store := newFakeLeaderStore()
 	clk := &fakeClock{t: time.Unix(1000, 0)}
 	cases := []struct{ term, renew time.Duration }{
 		{0, time.Second},
@@ -49,7 +93,7 @@ func TestNewElectorValidation(t *testing.T) {
 
 func TestElectorSingleLeaderAndHandover(t *testing.T) {
 	ctx := context.Background()
-	store := memory.NewLeaderStore()
+	store := newFakeLeaderStore()
 	clk := &fakeClock{t: time.Unix(1000, 0)}
 	const term, renew = 15 * time.Second, 5 * time.Second
 
@@ -103,7 +147,7 @@ func TestElectorSingleLeaderAndHandover(t *testing.T) {
 
 func TestElectorResignFreesLease(t *testing.T) {
 	ctx := context.Background()
-	store := memory.NewLeaderStore()
+	store := newFakeLeaderStore()
 	clk := &fakeClock{t: time.Unix(1000, 0)}
 	const term, renew = 15 * time.Second, 5 * time.Second
 	audit := &fakeAudit{}

--- a/internal/usecase/leaderuc/elector_test.go
+++ b/internal/usecase/leaderuc/elector_test.go
@@ -1,0 +1,141 @@
+package leaderuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time { return c.t }
+func (c *fakeClock) advance(d time.Duration) {
+	c.t = c.t.Add(d)
+}
+
+type fakeAudit struct{ actions []string }
+
+func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.actions = append(a.actions, e.Action)
+	return nil
+}
+
+func TestNewElectorValidation(t *testing.T) {
+	store := memory.NewLeaderStore()
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	cases := []struct{ term, renew time.Duration }{
+		{0, time.Second},
+		{10 * time.Second, 0},
+		{10 * time.Second, 5 * time.Second}, // renew == term/2, must be strictly less
+		{10 * time.Second, 6 * time.Second},
+	}
+	for _, c := range cases {
+		if _, err := NewElector(store, &fakeAudit{}, clk, "sched", "inst", c.term, c.renew); !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("term=%s renew=%s should be invalid", c.term, c.renew)
+		}
+	}
+	if _, err := NewElector(store, &fakeAudit{}, clk, "", "inst", 10*time.Second, time.Second); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("empty resource should be invalid")
+	}
+	if _, err := NewElector(nil, &fakeAudit{}, clk, "sched", "inst", 10*time.Second, time.Second); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("nil store should be invalid")
+	}
+}
+
+func TestElectorSingleLeaderAndHandover(t *testing.T) {
+	ctx := context.Background()
+	store := memory.NewLeaderStore()
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	const term, renew = 15 * time.Second, 5 * time.Second
+
+	a, err := NewElector(store, &fakeAudit{}, clk, "sched", "inst-a", term, renew)
+	if err != nil {
+		t.Fatalf("new a: %v", err)
+	}
+	b, err := NewElector(store, &fakeAudit{}, clk, "sched", "inst-b", term, renew)
+	if err != nil {
+		t.Fatalf("new b: %v", err)
+	}
+
+	// a campaigns first and wins; b then sees a live lease and stays a follower.
+	if err := a.tick(ctx); err != nil {
+		t.Fatalf("a tick: %v", err)
+	}
+	if err := b.tick(ctx); err != nil {
+		t.Fatalf("b tick: %v", err)
+	}
+	if !a.IsLeader() || b.IsLeader() {
+		t.Fatalf("expected exactly a to be leader: a=%v b=%v", a.IsLeader(), b.IsLeader())
+	}
+	firstFence := a.Fence()
+
+	// a renews within the term; b still cannot take over.
+	clk.advance(renew)
+	_ = a.tick(ctx)
+	_ = b.tick(ctx)
+	if !a.IsLeader() || b.IsLeader() {
+		t.Fatalf("after renewal a must still lead: a=%v b=%v", a.IsLeader(), b.IsLeader())
+	}
+
+	// a stops renewing; once the term expires, b takes over and the fence is bumped.
+	clk.advance(2 * term)
+	if err := b.tick(ctx); err != nil {
+		t.Fatalf("b takeover tick: %v", err)
+	}
+	if !b.IsLeader() {
+		t.Fatalf("b should take over an expired lease")
+	}
+	if b.Fence() <= firstFence {
+		t.Fatalf("takeover must bump the fence: first=%d now=%d", firstFence, b.Fence())
+	}
+
+	// a ticks again and discovers it has lost leadership (fail-safe).
+	_ = a.tick(ctx)
+	if a.IsLeader() {
+		t.Fatalf("a must observe it lost leadership after b took over")
+	}
+}
+
+func TestElectorResignFreesLease(t *testing.T) {
+	ctx := context.Background()
+	store := memory.NewLeaderStore()
+	clk := &fakeClock{t: time.Unix(1000, 0)}
+	const term, renew = 15 * time.Second, 5 * time.Second
+	audit := &fakeAudit{}
+	a, _ := NewElector(store, audit, clk, "sched", "inst-a", term, renew)
+	b, _ := NewElector(store, &fakeAudit{}, clk, "sched", "inst-b", term, renew)
+
+	_ = a.tick(ctx)
+	if !a.IsLeader() {
+		t.Fatalf("a should lead")
+	}
+	a.resign() // releases immediately, without waiting for the term
+	if a.IsLeader() {
+		t.Fatalf("a should not be leader after resign")
+	}
+	// b can take over right away even though the term has not expired.
+	if err := b.tick(ctx); err != nil {
+		t.Fatalf("b tick: %v", err)
+	}
+	if !b.IsLeader() {
+		t.Fatalf("b should acquire immediately after a resigned")
+	}
+	// The transitions were audited.
+	var acquired, resigned bool
+	for _, act := range audit.actions {
+		if act == "leader.acquired" {
+			acquired = true
+		}
+		if act == "leader.resigned" {
+			resigned = true
+		}
+	}
+	if !acquired || !resigned {
+		t.Fatalf("expected acquired+resigned audit entries, got %v", audit.actions)
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -102,6 +102,15 @@ type FleetAgentStore interface {
 	ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error)
 }
 
+// LeaderStore is the fenced-lease backing store for leader election. Acquire atomically takes or
+// renews leadership of resource for holder: it returns held=true when this instance holds the
+// lease after the call, plus the current fence token (bumped on every takeover). It is global
+// control-plane state, not tenant-scoped.
+type LeaderStore interface {
+	Acquire(ctx context.Context, resource, holder string, term time.Duration, now time.Time) (held bool, fence int64, err error)
+	Resign(ctx context.Context, resource, holder string, now time.Time) error
+}
+
 // WorkOrderSigner signs and verifies the canonical signing payload of a work order. The
 // implementation holds the key; the control plane signs at issue time and the agent verifies
 // before acting. Kept as a port so the key material stays in an infrastructure/platform adapter.

--- a/migrations/0061_leader_leases.sql
+++ b/migrations/0061_leader_leases.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- Leader election (#406, epic #405): a fenced lease so more than one synapse-api / synapse-worker
+-- instance can run concurrently while exactly one is the scheduler leader at a time.
+--
+-- DELIBERATELY NOT tenant-scoped and NOT under RLS: a leadership lease is global control-plane
+-- infrastructure, not customer data (a documented exception to the tenant-table convention, like
+-- advisories in 0038). There is nothing tenant-private to isolate.
+--
+-- `fence` is a monotonically increasing token bumped on every takeover; a partitioned old leader
+-- that later tries to act can be rejected by comparing its stale fence against the current one.
+CREATE TABLE leader_leases (
+    resource     TEXT PRIMARY KEY,
+    holder       TEXT NOT NULL,
+    fence        BIGINT NOT NULL DEFAULT 0,
+    term_expires TIMESTAMPTZ NOT NULL,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- +goose Down
+DROP TABLE leader_leases;

--- a/migrations/0061_leader_leases.sql
+++ b/migrations/0061_leader_leases.sql
@@ -8,6 +8,15 @@
 --
 -- `fence` is a monotonically increasing token bumped on every takeover; a partitioned old leader
 -- that later tries to act can be rejected by comparing its stale fence against the current one.
+-- Resign expires the lease (it does not delete the row), so the fence survives a graceful handover
+-- and never resets to 1.
+--
+-- CLOCK: the lease term is currently compared against each instance's own wall clock (the elector
+-- passes its clock's now into Acquire). This is safe against two simultaneous leaders regardless of
+-- skew (the DB serializes the takeover upsert, so only one challenger wins), but a fast-clocked
+-- challenger can take over up to its skew early. Operating assumption: NTP-bounded skew much
+-- smaller than (term - 2*renew). Moving the arithmetic onto the database clock (now()) removes the
+-- assumption entirely and is the hardening to do when a downstream first gates on the fence.
 CREATE TABLE leader_leases (
     resource     TEXT PRIMARY KEY,
     holder       TEXT NOT NULL,


### PR DESCRIPTION
Implements #406 (epic #405): fenced-lease leader election, the foundation for running more than one control-plane instance with exactly one scheduler leader.

## What this delivers
- **Port** `ports.LeaderStore`: `Acquire` (atomic take / renew / takeover) + `Resign`, keyed by resource and holder, returning `held` plus a monotonically increasing `fence` token.
- **Migration 0061** `leader_leases`: a single upsert whose `CASE` arms take the lease only when it is free (expired) or already held (renewal, fence unchanged), bump the fence on a takeover, and leave a live foreign lease untouched. **Deliberately NOT tenant-scoped and NOT under RLS** — a leadership lease is global control-plane state, a documented exception to the tenant-table convention (like advisories in 0038).
- **Stores**: Postgres (single atomic `ON CONFLICT` upsert) + memory (mutex mirror, identical semantics).
- **Usecase** `leaderuc.Elector`: campaigns immediately, renews on a timer, caches `IsLeader()` for non-blocking callers, exposes the fence, resigns on shutdown so a follower takes over without waiting for the term, and audits every transition. Fail-safe: any `Acquire` error drops leadership rather than risk two leaders. `NewElector` enforces `0 < renew < term/2`.
- **Config** `SYNAPSE_LEADER_ENABLED` (default off) + `RESOURCE`/`TERM`/`RENEW`, wired into the API against the server lifecycle context (Postgres only; a single in-memory process is trivially the leader).

## Scope
This ships the **election mechanism**, tested end to end. Removing the single-instance lock (`AcquireSingletonLock`) and gating periodic dispatch on `IsLeader` — true horizontal scale — is the tracked follow-on: it changes the whole-server concurrency model and deserves its own careful change. The elector runs and audits leadership today but does not yet gate dispatch, so behaviour is unchanged for existing single-instance deployments.

## Verification
- Elector unit tests: single leader, renewal keeps the fence, expired takeover bumps the fence, resign frees the lease immediately (a follower acquires before the term expires), fail-safe on store error, and `NewElector` validation.
- Postgres integration: two contenders -> exactly one leader, renewal, takeover with fence bump, resign, migration 0061 down/up, and asserting `leader_leases` is NOT RLS-forced.
- `go build ./...`, `go vet ./...`, `go test ./...` (no DSN), gofmt clean.

Refs #405
