### PR TITLE
feat(fleet): agent certificate identity and revocation (#408)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/cache/sbomcache"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/ebpf"
 	egressinfra "github.com/KKloudTarus/synapse-ce/internal/infrastructure/egress"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetca"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/llm/openai"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/logstream"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/file"
@@ -1068,7 +1069,20 @@ func main() {
 			log.Error("fleet work service init failed", "err", werr)
 			os.Exit(1)
 		}
-		router.SetFleet(agentSvc, workSvc, clock.Now)
+		// Revoking an agent cancels its in-flight work orders (#408).
+		agentSvc.SetWorkOrders(workOrderStore)
+		// Optional certificate identity (#408): when a control-plane CA is configured, enrolment
+		// with a CSR issues a client certificate. Fail closed on a misconfigured CA.
+		if cfg.FleetCACertPEM != "" && cfg.FleetCAKeyPEM != "" {
+			ca, cerr := fleetca.New([]byte(cfg.FleetCACertPEM), []byte(cfg.FleetCAKeyPEM), cfg.FleetCertTTL)
+			if cerr != nil {
+				log.Error("fleet CA configured but invalid – check SYNAPSE_FLEET_CA_CERT/KEY", "err", cerr)
+				os.Exit(1)
+			}
+			agentSvc.SetCA(ca)
+			log.Info("fleet agent certificate identity ENABLED (CSR enrolment issues client certs)")
+		}
+		router.SetFleet(agentSvc, workSvc, clock.Now, cfg.FleetClientCertHeader)
 		router.SetFleetAdmin(agentSvc)
 		log.Info("fleet agent transport ENABLED (agent-auth plane; operator agent-admin routes)")
 	}

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -2,9 +2,7 @@ package httpapi
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/x509"
-	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -92,13 +90,18 @@ func (f *fleetRouter) authByClientCert(ctx context.Context, headerVal string) (*
 	if err != nil {
 		return nil, fleetagentuc.ErrUnauthenticated
 	}
+	// Enforce the certificate validity window at the app layer too, not only at the proxy handshake:
+	// a stored fingerprint outlives the cert, so an expired certificate must not authenticate.
+	now := time.Now()
+	if now.Before(cert.NotBefore) || now.After(cert.NotAfter) {
+		return nil, fleetagentuc.ErrUnauthenticated
+	}
 	agentID := cert.Subject.CommonName
 	if agentID == "" || len(cert.Subject.OrganizationalUnit) == 0 || cert.Subject.OrganizationalUnit[0] == "" {
 		return nil, fleetagentuc.ErrUnauthenticated
 	}
 	tenant := cert.Subject.OrganizationalUnit[0]
-	sum := sha256.Sum256(cert.Raw)
-	fingerprint := hex.EncodeToString(sum[:])
+	fingerprint := fleetagent.CertFingerprint(cert.Raw)
 	return f.agents.AuthenticateCertificate(ctx, shared.ID(tenant), shared.ID(agentID), fingerprint)
 }
 
@@ -246,6 +249,9 @@ func (f *fleetRouter) authed(next http.HandlerFunc) http.HandlerFunc {
 		// trusted only because the operator asserts (via config) that a trusted proxy verifies mTLS
 		// and STRIPS any client-supplied value; the app must not be directly reachable. When the
 		// header is absent we fall back to the bearer credential.
+		// When the cert header is configured but absent, we fall back to the bearer token (a
+		// reasonable migration posture). A strict certificate-required mode that refuses the bearer
+		// fallback is a documented follow-up for deployments where mTLS supersedes the token.
 		if f.clientCertHeader != "" && r.Header.Get(f.clientCertHeader) != "" {
 			agent, err = f.authByClientCert(r.Context(), r.Header.Get(f.clientCertHeader))
 		} else {

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -2,11 +2,17 @@ package httpapi
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -29,8 +35,9 @@ const (
 
 // fleetAgentService is the narrow view of fleet agent identity the transport needs.
 type fleetAgentService interface {
-	Enrol(ctx context.Context, enrolToken string, in fleetagentuc.EnrolInput) (*fleetagent.Agent, string, error)
+	Enrol(ctx context.Context, enrolToken string, in fleetagentuc.EnrolInput) (*fleetagent.Agent, string, []byte, error)
 	Authenticate(ctx context.Context, token string) (*fleetagent.Agent, error)
+	AuthenticateCertificate(ctx context.Context, tenantID, agentID shared.ID, fingerprint string) (*fleetagent.Agent, error)
 	Heartbeat(ctx context.Context, agent *fleetagent.Agent, in fleetagentuc.HeartbeatInput) error
 }
 
@@ -42,28 +49,63 @@ type fleetWorkService interface {
 }
 
 type fleetRouter struct {
-	agents   fleetAgentService
-	work     fleetWorkService
-	log      *slog.Logger
-	agentLim *keyedLimiter // post-auth, keyed by agent id
-	ipLim    *keyedLimiter // pre-auth, keyed by client IP (throttles enrol + failed auth)
+	agents           fleetAgentService
+	work             fleetWorkService
+	log              *slog.Logger
+	agentLim         *keyedLimiter // post-auth, keyed by agent id
+	ipLim            *keyedLimiter // pre-auth, keyed by client IP (throttles enrol + failed auth)
+	clientCertHeader string        // when set, a trusted proxy passes the verified client cert here
 }
 
 // SetFleet wires the untrusted agent transport plane. When nil, /api/v1/fleet is not served.
-func (rt *Router) SetFleet(agents fleetAgentService, work fleetWorkService, now func() time.Time) {
+// clientCertHeader, when non-empty, is the header a trusted mutual-TLS-terminating proxy uses to
+// pass the verified client certificate; empty disables certificate auth and uses the bearer token.
+func (rt *Router) SetFleet(agents fleetAgentService, work fleetWorkService, now func() time.Time, clientCertHeader string) {
 	rt.fleet = &fleetRouter{
-		agents:   agents,
-		work:     work,
-		log:      rt.log,
-		agentLim: newKeyedLimiter(fleetRatePerMin, now),
-		ipLim:    newKeyedLimiter(fleetIPRatePerMin, now),
+		agents:           agents,
+		work:             work,
+		log:              rt.log,
+		agentLim:         newKeyedLimiter(fleetRatePerMin, now),
+		ipLim:            newKeyedLimiter(fleetIPRatePerMin, now),
+		clientCertHeader: clientCertHeader,
 	}
+}
+
+// authByClientCert authenticates an agent from a verified client certificate the trusted proxy
+// passed in a header. It reads the tenant (OU) and agent id (CN) from the certificate subject and
+// verifies the fingerprint against the stored one. Parsing failure is an unauthenticated result,
+// never a 500, so a malformed header cannot be distinguished from a wrong credential.
+func (f *fleetRouter) authByClientCert(ctx context.Context, headerVal string) (*fleetagent.Agent, error) {
+	raw := headerVal
+	// A raw PEM already contains the literal header; only URL-unescape when it does not (some proxies
+	// pass the certificate URL-escaped). Unescaping a raw PEM would corrupt its base64 '+' bytes.
+	if !strings.Contains(raw, "BEGIN CERTIFICATE") {
+		if unesc, err := url.QueryUnescape(headerVal); err == nil {
+			raw = unesc
+		}
+	}
+	block, _ := pem.Decode([]byte(raw))
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fleetagentuc.ErrUnauthenticated
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fleetagentuc.ErrUnauthenticated
+	}
+	agentID := cert.Subject.CommonName
+	if agentID == "" || len(cert.Subject.OrganizationalUnit) == 0 || cert.Subject.OrganizationalUnit[0] == "" {
+		return nil, fleetagentuc.ErrUnauthenticated
+	}
+	tenant := cert.Subject.OrganizationalUnit[0]
+	sum := sha256.Sum256(cert.Raw)
+	fingerprint := hex.EncodeToString(sum[:])
+	return f.agents.AuthenticateCertificate(ctx, shared.ID(tenant), shared.ID(agentID), fingerprint)
 }
 
 // fleetAdminService is the operator-facing (human, RBAC-gated) view of fleet agent management.
 type fleetAdminService interface {
 	MintEnrolToken(ctx context.Context, actor string, tenantID shared.ID, ttl time.Duration) (string, error)
-	Revoke(ctx context.Context, actor string, tenantID, id shared.ID) error
+	Revoke(ctx context.Context, actor string, tenantID, id shared.ID, reason string) error
 	ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error)
 }
 
@@ -131,7 +173,11 @@ func (rt *Router) listFleetAgents(w http.ResponseWriter, r *http.Request) {
 
 func (rt *Router) revokeFleetAgent(w http.ResponseWriter, r *http.Request) {
 	id := shared.ID(r.PathValue("id"))
-	if err := rt.fleetAdmin.Revoke(r.Context(), PrincipalFrom(r.Context()), fleetTenant(r.Context()), id); err != nil {
+	var req struct {
+		Reason string `json:"reason"`
+	}
+	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetBodyCap)).Decode(&req)
+	if err := rt.fleetAdmin.Revoke(r.Context(), PrincipalFrom(r.Context()), fleetTenant(r.Context()), id, req.Reason); err != nil {
 		writeError(w, rt.log, err)
 		return
 	}
@@ -191,12 +237,25 @@ func clientIP(r *http.Request) string {
 // the context. The tenant comes from the authenticated agent, never from the request.
 func (f *fleetRouter) authed(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		token, ok := bearerToken(r)
-		if !ok {
-			writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
-			return
+		var (
+			agent *fleetagent.Agent
+			err   error
+		)
+		// Certificate identity takes precedence when the mutual-TLS-terminating proxy is configured
+		// to pass the verified client certificate in clientCertHeader. SECURITY: this header is
+		// trusted only because the operator asserts (via config) that a trusted proxy verifies mTLS
+		// and STRIPS any client-supplied value; the app must not be directly reachable. When the
+		// header is absent we fall back to the bearer credential.
+		if f.clientCertHeader != "" && r.Header.Get(f.clientCertHeader) != "" {
+			agent, err = f.authByClientCert(r.Context(), r.Header.Get(f.clientCertHeader))
+		} else {
+			token, ok := bearerToken(r)
+			if !ok {
+				writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
+				return
+			}
+			agent, err = f.agents.Authenticate(r.Context(), token)
 		}
-		agent, err := f.agents.Authenticate(r.Context(), token)
 		if err != nil {
 			switch {
 			case errors.Is(err, fleetagentuc.ErrRevoked):
@@ -230,14 +289,15 @@ func (f *fleetRouter) enrol(w http.ResponseWriter, r *http.Request) {
 		OSVersion    string   `json:"os_version"`
 		AgentVersion string   `json:"agent_version"`
 		Capabilities []string `json:"capabilities"`
+		CSRPEM       string   `json:"csr_pem"` // optional PEM CSR for certificate identity (#408)
 	}
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetBodyCap)).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid enrol body"})
 		return
 	}
-	agent, agentToken, err := f.agents.Enrol(r.Context(), token, fleetagentuc.EnrolInput{
+	agent, agentToken, certPEM, err := f.agents.Enrol(r.Context(), token, fleetagentuc.EnrolInput{
 		Name: req.Name, Platform: req.Platform, OSVersion: req.OSVersion,
-		AgentVersion: req.AgentVersion, Capabilities: req.Capabilities,
+		AgentVersion: req.AgentVersion, Capabilities: req.Capabilities, CSRPEM: []byte(req.CSRPEM),
 	})
 	if err != nil {
 		if errors.Is(err, fleetagentuc.ErrUnauthenticated) {
@@ -247,8 +307,12 @@ func (f *fleetRouter) enrol(w http.ResponseWriter, r *http.Request) {
 		writeError(w, f.log, err)
 		return
 	}
-	// The agent token is returned exactly once here; it is never stored in the clear or logged.
-	writeJSON(w, http.StatusCreated, map[string]string{"agent_id": agent.ID.String(), "token": agentToken})
+	// The agent token and certificate are returned exactly once here; never stored in the clear or logged.
+	resp := map[string]string{"agent_id": agent.ID.String(), "token": agentToken}
+	if len(certPEM) > 0 {
+		resp["certificate_pem"] = string(certPEM)
+	}
+	writeJSON(w, http.StatusCreated, resp)
 }
 
 func (f *fleetRouter) heartbeat(w http.ResponseWriter, r *http.Request) {

--- a/internal/adapter/httpapi/fleet_handler_test.go
+++ b/internal/adapter/httpapi/fleet_handler_test.go
@@ -3,7 +3,14 @@ package httpapi
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +19,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetca"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
@@ -46,7 +54,7 @@ func setupFleet(t *testing.T) (http.Handler, *fleetagentuc.Service, *fleetwork.S
 		t.Fatalf("work svc: %v", err)
 	}
 	rt := &Router{log: discardLog()}
-	rt.SetFleet(agentSvc, workSvc, func() time.Time { return time.Now().UTC() })
+	rt.SetFleet(agentSvc, workSvc, func() time.Time { return time.Now().UTC() }, "")
 	rt.SetFleetAdmin(agentSvc)
 	return rt.fleet.handler(), agentSvc, workSvc
 }
@@ -153,10 +161,53 @@ func TestFleetAPIEndToEnd(t *testing.T) {
 	}
 
 	// Revoke the agent; its credential no longer authenticates.
-	if err := agentSvc.Revoke(ctx, "op", "default", agentID); err != nil {
+	if err := agentSvc.Revoke(ctx, "op", "default", agentID, "test revoke"); err != nil {
 		t.Fatalf("revoke: %v", err)
 	}
 	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/heartbeat", agentTok, map[string]string{}, true); w.Code != http.StatusForbidden {
 		t.Fatalf("revoked agent should be 403, got %d", w.Code)
+	}
+}
+
+func TestFleetAuthByClientCert(t *testing.T) {
+	ctx := context.Background()
+	// Real CA so the issued certificate parses and its fingerprint matches what the agent stores.
+	caCertPEM, caKeyPEM, err := fleetca.GenerateCA("test-ca", time.Hour, time.Now())
+	if err != nil {
+		t.Fatalf("gen ca: %v", err)
+	}
+	ca, err := fleetca.New(caCertPEM, caKeyPEM, time.Hour)
+	if err != nil {
+		t.Fatalf("new ca: %v", err)
+	}
+	agentSvc, _ := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
+	agentSvc.SetCA(ca)
+
+	enrolTok, _ := agentSvc.MintEnrolToken(ctx, "op", "default", time.Hour)
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	csrDER, _ := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{Subject: pkix.Name{CommonName: "agent"}}, key)
+	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+	agent, _, certPEM, err := agentSvc.Enrol(ctx, enrolTok, fleetagentuc.EnrolInput{Name: "a", CSRPEM: csrPEM})
+	if err != nil || len(certPEM) == 0 {
+		t.Fatalf("enrol with csr: err=%v certlen=%d", err, len(certPEM))
+	}
+
+	f := &fleetRouter{agents: agentSvc, clientCertHeader: "X-Client-Cert", log: discardLog()}
+
+	// The issued certificate authenticates the agent.
+	got, err := f.authByClientCert(ctx, string(certPEM))
+	if err != nil || got.ID != agent.ID {
+		t.Fatalf("cert auth should succeed: got=%v err=%v", got, err)
+	}
+	// A malformed header is unauthenticated, never a 500.
+	if _, err := f.authByClientCert(ctx, "not a cert"); !errors.Is(err, fleetagentuc.ErrUnauthenticated) {
+		t.Fatalf("malformed cert must be unauthenticated, got %v", err)
+	}
+	// After revocation the certificate no longer authenticates.
+	if err := agentSvc.Revoke(ctx, "op", "default", agent.ID, "test"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := f.authByClientCert(ctx, string(certPEM)); !errors.Is(err, fleetagentuc.ErrRevoked) {
+		t.Fatalf("revoked cert must return ErrRevoked, got %v", err)
 	}
 }

--- a/internal/adapter/httpapi/fleet_handler_test.go
+++ b/internal/adapter/httpapi/fleet_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -209,5 +210,27 @@ func TestFleetAuthByClientCert(t *testing.T) {
 	}
 	if _, err := f.authByClientCert(ctx, string(certPEM)); !errors.Is(err, fleetagentuc.ErrRevoked) {
 		t.Fatalf("revoked cert must return ErrRevoked, got %v", err)
+	}
+}
+
+func TestFleetAuthByClientCertRejectsExpired(t *testing.T) {
+	ctx := context.Background()
+	agentSvc, _ := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
+	f := &fleetRouter{agents: agentSvc, clientCertHeader: "X-Client-Cert", log: discardLog()}
+
+	// A self-signed certificate whose validity window is entirely in the past.
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "ag", OrganizationalUnit: []string{"default"}},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     time.Now().Add(-1 * time.Hour),
+	}
+	der, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	// Expiry is rejected before any store lookup, so the result is unauthenticated.
+	if _, err := f.authByClientCert(ctx, string(certPEM)); !errors.Is(err, fleetagentuc.ErrUnauthenticated) {
+		t.Fatalf("expired certificate must be unauthenticated, got %v", err)
 	}
 }

--- a/internal/domain/fleetagent/fleetagent.go
+++ b/internal/domain/fleetagent/fleetagent.go
@@ -22,11 +22,12 @@ type State string
 
 const (
 	StateActive  State = "active"
+	StateStale   State = "stale" // last seen longer ago than the freshness threshold (computed by fleet coverage)
 	StateRevoked State = "revoked"
 )
 
 // Valid reports whether s is a known state.
-func (s State) Valid() bool { return s == StateActive || s == StateRevoked }
+func (s State) Valid() bool { return s == StateActive || s == StateStale || s == StateRevoked }
 
 // Agent is an enrolled fleet agent. TokenHash is the hash of the bearer credential presented on
 // every call; the plaintext is shown once at enrolment and never stored.
@@ -39,9 +40,28 @@ type Agent struct {
 	AgentVersion string
 	Capabilities []string
 	TokenHash    string
+	// Fingerprint is the SHA-256 of the agent's issued client certificate (#408). Empty until a
+	// certificate is issued from a CSR; it is the cryptographic identity used by mutual-TLS auth.
+	Fingerprint  string
 	State        State
 	Audit        shared.Audit
 	LastSeenAt   time.Time
+	RevokedAt    *time.Time
+	RevokedBy    shared.ID
+	RevokeReason string
+}
+
+// AttestCertificate records the SHA-256 fingerprint of the client certificate issued to the agent.
+func (a *Agent) AttestCertificate(fingerprint string) { a.Fingerprint = fingerprint }
+
+// Revoke marks the agent revoked with attribution, so its credential no longer authenticates.
+func (a *Agent) Revoke(by shared.ID, reason string, now time.Time) {
+	a.State = StateRevoked
+	a.RevokedBy = by
+	a.RevokeReason = reason
+	t := now
+	a.RevokedAt = &t
+	a.Audit.UpdatedAt = now
 }
 
 // NewAgent validates and constructs an active agent. tokenHash must be the (non-empty) hash of the

--- a/internal/domain/fleetagent/fleetagent.go
+++ b/internal/domain/fleetagent/fleetagent.go
@@ -10,12 +10,22 @@
 package fleetagent
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
+
+// CertFingerprint is the canonical agent certificate fingerprint: the hex SHA-256 of the
+// certificate DER. It is the single source of truth shared by the issuing CA (infrastructure) and
+// the authentication path (adapter), so the two can never drift.
+func CertFingerprint(der []byte) string {
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:])
+}
 
 // State is the agent lifecycle.
 type State string

--- a/internal/infrastructure/fleetca/ca.go
+++ b/internal/infrastructure/fleetca/ca.go
@@ -11,15 +11,14 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"math/big"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -46,6 +45,9 @@ func New(certPEM, keyPEM []byte, ttl time.Duration) (*CA, error) {
 	}
 	if !cert.IsCA {
 		return nil, fmt.Errorf("fleetca: signing certificate is not a CA")
+	}
+	if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return nil, fmt.Errorf("fleetca: signing certificate lacks the certificate-sign key usage")
 	}
 	key, err := parseKeyPEM(keyPEM)
 	if err != nil {
@@ -95,10 +97,10 @@ func (c *CA) Issue(csrPEM []byte, agentID, tenantID string, now time.Time) (cert
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), FingerprintDER(der), nil
 }
 
-// FingerprintDER returns the hex SHA-256 of a certificate's DER bytes.
+// FingerprintDER returns the certificate fingerprint. It delegates to the domain's single
+// definition so the CA and the auth path can never compute it differently.
 func FingerprintDER(der []byte) string {
-	sum := sha256.Sum256(der)
-	return hex.EncodeToString(sum[:])
+	return fleetagent.CertFingerprint(der)
 }
 
 func checkKeyStrength(pub any) error {
@@ -109,6 +111,9 @@ func checkKeyStrength(pub any) error {
 		}
 		return nil
 	case *ecdsa.PublicKey:
+		if k.Curve.Params().BitSize < 256 {
+			return fmt.Errorf("fleetca: ecdsa curve too small (%d bits, need >= 256)", k.Curve.Params().BitSize)
+		}
 		return nil
 	default:
 		return fmt.Errorf("fleetca: unsupported csr public key type %T (use RSA >= 2048 or ECDSA)", pub)

--- a/internal/infrastructure/fleetca/ca.go
+++ b/internal/infrastructure/fleetca/ca.go
@@ -1,0 +1,177 @@
+// Package fleetca is the control-plane certificate authority for fleet agents (#408). It verifies a
+// certificate signing request an agent generates locally (the agent's private key never leaves the
+// host) and issues a short-lived client certificate whose subject encodes the agent id and tenant.
+// The SHA-256 fingerprint of the issued certificate is the agent's cryptographic identity used by
+// mutual-TLS authentication. This is a control-plane issued intermediate, not an external PKI.
+package fleetca
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.CertificateIssuer = (*CA)(nil)
+
+// minRSABits is the smallest RSA key the CA will sign a certificate for; weaker keys are refused.
+const minRSABits = 2048
+
+// CA issues client certificates from a control-plane signing certificate and key.
+type CA struct {
+	cert *x509.Certificate
+	key  crypto.Signer
+	ttl  time.Duration
+}
+
+// New builds a CA from PEM-encoded certificate and private key and a certificate lifetime.
+func New(certPEM, keyPEM []byte, ttl time.Duration) (*CA, error) {
+	if ttl <= 0 {
+		return nil, fmt.Errorf("fleetca: certificate ttl must be positive")
+	}
+	cert, err := parseCertPEM(certPEM)
+	if err != nil {
+		return nil, err
+	}
+	if !cert.IsCA {
+		return nil, fmt.Errorf("fleetca: signing certificate is not a CA")
+	}
+	key, err := parseKeyPEM(keyPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &CA{cert: cert, key: key, ttl: ttl}, nil
+}
+
+// Issue verifies csrPEM and issues a client certificate bound to (agentID, tenantID). It returns
+// the certificate PEM and its SHA-256 fingerprint. The CSR's signature is checked and its public
+// key must meet the strength floor; the agent's private key is never seen.
+func (c *CA) Issue(csrPEM []byte, agentID, tenantID string, now time.Time) (certPEM []byte, fingerprint string, err error) {
+	if agentID == "" || tenantID == "" {
+		return nil, "", fmt.Errorf("fleetca: agent id and tenant id are required")
+	}
+	block, _ := pem.Decode(csrPEM)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, "", fmt.Errorf("fleetca: not a PEM certificate request")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, "", fmt.Errorf("fleetca: parse csr: %w", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		return nil, "", fmt.Errorf("fleetca: csr signature invalid: %w", err)
+	}
+	if err := checkKeyStrength(csr.PublicKey); err != nil {
+		return nil, "", err
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, "", fmt.Errorf("fleetca: serial: %w", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		// CN = agent id, OU = tenant id: the auth path reads both from the verified certificate.
+		Subject:     pkix.Name{CommonName: agentID, OrganizationalUnit: []string{tenantID}},
+		NotBefore:   now.Add(-time.Minute), // small backdate for clock skew
+		NotAfter:    now.Add(c.ttl),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, c.cert, csr.PublicKey, c.key)
+	if err != nil {
+		return nil, "", fmt.Errorf("fleetca: create certificate: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), FingerprintDER(der), nil
+}
+
+// FingerprintDER returns the hex SHA-256 of a certificate's DER bytes.
+func FingerprintDER(der []byte) string {
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:])
+}
+
+func checkKeyStrength(pub any) error {
+	switch k := pub.(type) {
+	case *rsa.PublicKey:
+		if k.N.BitLen() < minRSABits {
+			return fmt.Errorf("fleetca: rsa key too small (%d bits, need >= %d)", k.N.BitLen(), minRSABits)
+		}
+		return nil
+	case *ecdsa.PublicKey:
+		return nil
+	default:
+		return fmt.Errorf("fleetca: unsupported csr public key type %T (use RSA >= 2048 or ECDSA)", pub)
+	}
+}
+
+func parseCertPEM(p []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(p)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("fleetca: not a PEM certificate")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+func parseKeyPEM(p []byte) (crypto.Signer, error) {
+	block, _ := pem.Decode(p)
+	if block == nil {
+		return nil, fmt.Errorf("fleetca: not a PEM private key")
+	}
+	if k, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		if s, ok := k.(crypto.Signer); ok {
+			return s, nil
+		}
+		return nil, fmt.Errorf("fleetca: PKCS8 key is not a signer")
+	}
+	if k, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	return nil, fmt.Errorf("fleetca: unsupported private key format")
+}
+
+// GenerateCA creates a fresh self-signed control-plane CA (ECDSA P-256) valid for validity. It is
+// used to bootstrap a dev/test CA and to let operators mint one; the returned key PEM is secret.
+func GenerateCA(commonName string, validity time.Duration, now time.Time) (certPEM, keyPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fleetca: generate ca key: %w", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(validity),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fleetca: create ca cert: %w", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fleetca: marshal ca key: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}

--- a/internal/infrastructure/fleetca/ca_test.go
+++ b/internal/infrastructure/fleetca/ca_test.go
@@ -1,0 +1,126 @@
+package fleetca
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func testCA(t *testing.T) *CA {
+	t.Helper()
+	now := time.Now()
+	certPEM, keyPEM, err := GenerateCA("synapse-fleet-ca", 24*time.Hour, now)
+	if err != nil {
+		t.Fatalf("generate ca: %v", err)
+	}
+	ca, err := New(certPEM, keyPEM, time.Hour)
+	if err != nil {
+		t.Fatalf("new ca: %v", err)
+	}
+	return ca
+}
+
+func makeCSR(t *testing.T, key any) []byte {
+	t.Helper()
+	der, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: "agent"},
+	}, key)
+	if err != nil {
+		t.Fatalf("create csr: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
+}
+
+func TestIssueAndVerify(t *testing.T) {
+	ca := testCA(t)
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	csr := makeCSR(t, key)
+
+	certPEM, fp, err := ca.Issue(csr, "ag-1", "tenant-1", time.Now())
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	block, _ := pem.Decode(certPEM)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse issued cert: %v", err)
+	}
+	if cert.Subject.CommonName != "ag-1" {
+		t.Fatalf("CN should be agent id, got %q", cert.Subject.CommonName)
+	}
+	if len(cert.Subject.OrganizationalUnit) != 1 || cert.Subject.OrganizationalUnit[0] != "tenant-1" {
+		t.Fatalf("OU should be tenant id, got %v", cert.Subject.OrganizationalUnit)
+	}
+	if FingerprintDER(cert.Raw) != fp {
+		t.Fatalf("returned fingerprint must match the issued cert")
+	}
+	// Client-auth EKU present.
+	var clientAuth bool
+	for _, u := range cert.ExtKeyUsage {
+		if u == x509.ExtKeyUsageClientAuth {
+			clientAuth = true
+		}
+	}
+	if !clientAuth {
+		t.Fatalf("issued cert must carry client-auth EKU")
+	}
+	// Verifiable against the CA.
+	roots := x509.NewCertPool()
+	roots.AddCert(ca.cert)
+	if _, err := cert.Verify(x509.VerifyOptions{Roots: roots, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
+		t.Fatalf("issued cert must verify against the CA: %v", err)
+	}
+}
+
+func TestIssueRejects(t *testing.T) {
+	ca := testCA(t)
+	ecKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	// Not a CSR PEM.
+	if _, _, err := ca.Issue([]byte("garbage"), "ag", "t", time.Now()); err == nil {
+		t.Fatalf("non-CSR PEM must be rejected")
+	}
+	// Missing identity.
+	if _, _, err := ca.Issue(makeCSR(t, ecKey), "", "t", time.Now()); err == nil {
+		t.Fatalf("missing agent id must be rejected")
+	}
+	// Weak RSA key.
+	weak, _ := rsa.GenerateKey(rand.Reader, 1024)
+	if _, _, err := ca.Issue(makeCSR(t, weak), "ag", "t", time.Now()); err == nil {
+		t.Fatalf("weak RSA key must be rejected")
+	}
+	// Strong RSA key is accepted.
+	strong, _ := rsa.GenerateKey(rand.Reader, 2048)
+	if _, _, err := ca.Issue(makeCSR(t, strong), "ag", "t", time.Now()); err != nil {
+		t.Fatalf("2048-bit RSA should be accepted: %v", err)
+	}
+}
+
+func TestNewRejectsNonCA(t *testing.T) {
+	// A leaf (non-CA) cert used as a signer must be rejected.
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	leafDER, _ := x509.CreateCertificate(rand.Reader, &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "leaf"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+	}, &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "leaf"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+	}, &key.PublicKey, key)
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+	keyDER, _ := x509.MarshalPKCS8PrivateKey(key)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	if _, err := New(leafPEM, keyPEM, time.Hour); err == nil {
+		t.Fatalf("a non-CA signing certificate must be rejected")
+	}
+}

--- a/internal/infrastructure/persistence/memory/fleetagent_store.go
+++ b/internal/infrastructure/persistence/memory/fleetagent_store.go
@@ -95,15 +95,26 @@ func (s *FleetAgentStore) Heartbeat(_ context.Context, tenantID, id shared.ID, p
 	return nil
 }
 
-func (s *FleetAgentStore) Revoke(_ context.Context, tenantID, id shared.ID, now time.Time) error {
+func (s *FleetAgentStore) SetFingerprint(_ context.Context, tenantID, id shared.ID, fingerprint string, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	a, ok := s.agents[agentKey(tenantID, id)]
 	if !ok {
 		return shared.ErrNotFound
 	}
-	a.State = fleetagent.StateRevoked
+	a.Fingerprint = fingerprint
 	a.Audit.UpdatedAt = now
+	return nil
+}
+
+func (s *FleetAgentStore) Revoke(_ context.Context, tenantID, id, by shared.ID, reason string, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a, ok := s.agents[agentKey(tenantID, id)]
+	if !ok {
+		return shared.ErrNotFound
+	}
+	a.Revoke(by, reason, now)
 	return nil
 }
 

--- a/internal/infrastructure/persistence/memory/workorder_store.go
+++ b/internal/infrastructure/persistence/memory/workorder_store.go
@@ -112,6 +112,22 @@ func (s *WorkOrderStore) Transition(_ context.Context, tenantID, id shared.ID, t
 	return nil
 }
 
+// CancelForAgent cancels every live order addressed to agentID and returns the count.
+func (s *WorkOrderStore) CancelForAgent(_ context.Context, tenantID, agentID shared.ID, reason string, now time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, o := range s.byID {
+		if o.TenantID == tenantID && o.AgentID == agentID && isLive(o.State) {
+			o.State = workorder.StateCancelled
+			o.RefuseReason = reason
+			o.Audit.UpdatedAt = now
+			n++
+		}
+	}
+	return n, nil
+}
+
 func isLive(s workorder.State) bool {
 	return s == workorder.StateIssued || s == workorder.StateClaimed || s == workorder.StateRunning
 }

--- a/internal/infrastructure/persistence/postgres/fleetagent_repo.go
+++ b/internal/infrastructure/persistence/postgres/fleetagent_repo.go
@@ -26,7 +26,7 @@ func NewFleetAgentRepository(pool *pgxpool.Pool) *FleetAgentRepository {
 
 var _ ports.FleetAgentStore = (*FleetAgentRepository)(nil)
 
-const fleetAgentCols = `id, tenant_id, name, platform, os_version, agent_version, capabilities, token_hash, state, created_at, updated_at, last_seen_at`
+const fleetAgentCols = `id, tenant_id, name, platform, os_version, agent_version, capabilities, token_hash, state, created_at, updated_at, last_seen_at, fingerprint, revoked_at, revoked_by, revoke_reason`
 
 func (r *FleetAgentRepository) CreateEnrolToken(ctx context.Context, t *fleetagent.EnrolToken) error {
 	return WithTenant(ctx, r.pool, t.TenantID.String(), func(tx pgx.Tx) error {
@@ -69,9 +69,10 @@ func (r *FleetAgentRepository) CreateAgent(ctx context.Context, a *fleetagent.Ag
 	return WithTenant(ctx, r.pool, a.TenantID.String(), func(tx pgx.Tx) error {
 		_, e := tx.Exec(ctx, `
 			INSERT INTO fleet_agents (`+fleetAgentCols+`)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
 			a.ID.String(), a.TenantID.String(), a.Name, a.Platform, a.OSVersion, a.AgentVersion,
-			caps, a.TokenHash, string(a.State), a.Audit.CreatedAt, a.Audit.UpdatedAt, a.LastSeenAt)
+			caps, a.TokenHash, string(a.State), a.Audit.CreatedAt, a.Audit.UpdatedAt, a.LastSeenAt,
+			a.Fingerprint, a.RevokedAt, a.RevokedBy.String(), a.RevokeReason)
 		return e
 	})
 }
@@ -123,10 +124,26 @@ func (r *FleetAgentRepository) Heartbeat(ctx context.Context, tenantID, id share
 	})
 }
 
-func (r *FleetAgentRepository) Revoke(ctx context.Context, tenantID, id shared.ID, now time.Time) error {
+func (r *FleetAgentRepository) SetFingerprint(ctx context.Context, tenantID, id shared.ID, fingerprint string, now time.Time) error {
 	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
-		tag, e := tx.Exec(ctx, `UPDATE fleet_agents SET state='revoked', updated_at=$3 WHERE tenant_id=$1 AND id=$2`,
-			tenantID.String(), id.String(), now)
+		tag, e := tx.Exec(ctx, `UPDATE fleet_agents SET fingerprint=$3, updated_at=$4 WHERE tenant_id=$1 AND id=$2`,
+			tenantID.String(), id.String(), fingerprint, now)
+		if e != nil {
+			return e
+		}
+		if tag.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
+}
+
+func (r *FleetAgentRepository) Revoke(ctx context.Context, tenantID, id, by shared.ID, reason string, now time.Time) error {
+	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, e := tx.Exec(ctx, `UPDATE fleet_agents
+			SET state='revoked', revoked_at=$3, revoked_by=$4, revoke_reason=$5, updated_at=$3
+			WHERE tenant_id=$1 AND id=$2`,
+			tenantID.String(), id.String(), now, by.String(), reason)
 		if e != nil {
 			return e
 		}
@@ -163,11 +180,14 @@ func (r *FleetAgentRepository) ListAgents(ctx context.Context, tenantID shared.I
 func scanAgent(row rowScanner) (*fleetagent.Agent, error) {
 	var (
 		id, tid, name, platform, osv, ver, hash, state string
+		fingerprint, revokedBy, revokeReason           string
+		revokedAt                                      *time.Time
 		caps                                           []byte
 		a                                              fleetagent.Agent
 	)
 	if err := row.Scan(&id, &tid, &name, &platform, &osv, &ver, &caps, &hash, &state,
-		&a.Audit.CreatedAt, &a.Audit.UpdatedAt, &a.LastSeenAt); err != nil {
+		&a.Audit.CreatedAt, &a.Audit.UpdatedAt, &a.LastSeenAt,
+		&fingerprint, &revokedAt, &revokedBy, &revokeReason); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, shared.ErrNotFound
 		}
@@ -181,6 +201,10 @@ func scanAgent(row rowScanner) (*fleetagent.Agent, error) {
 	a.AgentVersion = ver
 	a.TokenHash = hash
 	a.State = fleetagent.State(state)
+	a.Fingerprint = fingerprint
+	a.RevokedAt = revokedAt
+	a.RevokedBy = shared.ID(revokedBy)
+	a.RevokeReason = revokeReason
 	if len(caps) > 0 {
 		if err := json.Unmarshal(caps, &a.Capabilities); err != nil {
 			return nil, err

--- a/internal/infrastructure/persistence/postgres/fleetagent_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/fleetagent_repo_test.go
@@ -87,7 +87,7 @@ func TestFleetAgentRepository(t *testing.T) {
 	if got.AgentVersion != "0.2.0" || len(got.Capabilities) != 2 {
 		t.Fatalf("heartbeat did not update: %+v", got)
 	}
-	if err := repo.Revoke(ctx, "ft", "ag1", now.Add(2*time.Minute)); err != nil {
+	if err := repo.Revoke(ctx, "ft", "ag1", "op", "test", now.Add(2*time.Minute)); err != nil {
 		t.Fatalf("revoke: %v", err)
 	}
 	got, _ = repo.GetAgent(ctx, "ft", "ag1")

--- a/internal/infrastructure/persistence/postgres/workorder_repo.go
+++ b/internal/infrastructure/persistence/postgres/workorder_repo.go
@@ -167,6 +167,23 @@ func (r *WorkOrderRepository) Transition(ctx context.Context, tenantID, id share
 	})
 }
 
+// CancelForAgent cancels every live order addressed to agentID (used on agent revocation).
+func (r *WorkOrderRepository) CancelForAgent(ctx context.Context, tenantID, agentID shared.ID, reason string, now time.Time) (int, error) {
+	var n int
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, e := tx.Exec(ctx, `
+			UPDATE work_orders SET state='cancelled', refuse_reason=$3, updated_at=$4
+			WHERE tenant_id=$1 AND agent_id=$2 AND state IN ('issued','claimed','running')`,
+			tenantID.String(), agentID.String(), reason, now)
+		if e != nil {
+			return e
+		}
+		n = int(tag.RowsAffected())
+		return nil
+	})
+	return n, err
+}
+
 func scanWorkOrder(row rowScanner) (*workorder.WorkOrder, error) {
 	var (
 		id, tid, asset, agent, cap, auth, idem, state, reason, sig string

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -191,6 +191,16 @@ type Config struct {
 	// FleetSignerKey is the HMAC key that signs agent work orders. Required and at least 32 bytes
 	// when FleetEnabled; a missing/short key fails startup closed rather than boot a forgeable signer.
 	FleetSignerKey string
+	// FleetCACertPEM / FleetCAKeyPEM are the control-plane CA that issues agent client certificates
+	// (#408). When both are set and FleetEnabled, enrolment with a CSR returns a client certificate.
+	FleetCACertPEM string
+	FleetCAKeyPEM  string
+	// FleetCertTTL is the issued client certificate lifetime (default 720h).
+	FleetCertTTL time.Duration
+	// FleetClientCertHeader, when set, is the header a trusted mutual-TLS-terminating proxy uses to
+	// pass the verified client certificate to the agent plane. Empty = certificate auth disabled
+	// (bearer token only). Trust it ONLY behind a proxy that strips any client-supplied value.
+	FleetClientCertHeader string
 	// LeaderElectionEnabled runs the fenced-lease leader elector (#406). Off by default. Postgres
 	// only (a single in-memory process is trivially the leader). Renewing < Term/2 is enforced.
 	LeaderElectionEnabled bool
@@ -448,6 +458,10 @@ func Load() Config {
 		FleetAssetsEnabled:     getbool("SYNAPSE_FLEET_ASSETS_ENABLED", false),
 		FleetEnabled:           getbool("SYNAPSE_FLEET_ENABLED", false),
 		FleetSignerKey:         getenv("SYNAPSE_FLEET_SIGNER_KEY", ""),
+		FleetCACertPEM:         getenv("SYNAPSE_FLEET_CA_CERT", ""),
+		FleetCAKeyPEM:          getenv("SYNAPSE_FLEET_CA_KEY", ""),
+		FleetCertTTL:           getduration("SYNAPSE_FLEET_CERT_TTL", 720*time.Hour),
+		FleetClientCertHeader:  getenv("SYNAPSE_FLEET_CLIENT_CERT_HEADER", ""),
 		LeaderElectionEnabled:  getbool("SYNAPSE_LEADER_ENABLED", false),
 		LeaderResource:         getenv("SYNAPSE_LEADER_RESOURCE", "scheduler"),
 		LeaderTerm:             getduration("SYNAPSE_LEADER_TERM", 15*time.Second),

--- a/internal/usecase/fleetagentuc/service.go
+++ b/internal/usecase/fleetagentuc/service.go
@@ -6,6 +6,7 @@ package fleetagentuc
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"time"
@@ -26,10 +27,12 @@ var (
 
 // Service is the fleet agent identity use case.
 type Service struct {
-	store ports.FleetAgentStore
-	audit ports.AuditLogger
-	clock ports.Clock
-	ids   ports.IDGenerator
+	store      ports.FleetAgentStore
+	audit      ports.AuditLogger
+	clock      ports.Clock
+	ids        ports.IDGenerator
+	ca         ports.CertificateIssuer // optional; enables CSR-based certificate identity (#408)
+	workOrders ports.WorkOrderStore    // optional; enables cancelling a revoked agent's in-flight orders
 }
 
 // NewService validates its dependencies and returns the service.
@@ -39,6 +42,12 @@ func NewService(store ports.FleetAgentStore, audit ports.AuditLogger, clock port
 	}
 	return &Service{store: store, audit: audit, clock: clock, ids: ids}, nil
 }
+
+// SetCA wires the control-plane certificate issuer, enabling CSR-based certificate identity.
+func (s *Service) SetCA(ca ports.CertificateIssuer) { s.ca = ca }
+
+// SetWorkOrders wires the work order store so revoking an agent cancels its in-flight orders.
+func (s *Service) SetWorkOrders(store ports.WorkOrderStore) { s.workOrders = store }
 
 // MintEnrolToken issues a single-use enrolment token for tenantID valid for ttl, and returns the
 // plaintext once. Only its hash is stored. This is an operator action (RBAC-gated at the adapter).
@@ -74,43 +83,93 @@ type EnrolInput struct {
 	OSVersion    string
 	AgentVersion string
 	Capabilities []string
+	// CSRPEM is an optional PEM certificate signing request. When present and a CA is configured,
+	// the control plane issues a client certificate and records its fingerprint; the returned
+	// certificate PEM is the agent's cryptographic identity for mutual-TLS auth (#408).
+	CSRPEM []byte
 }
 
 // Enrol exchanges a valid enrolment token for a new agent identity and returns its bearer
 // credential once. The tenant is taken from the enrolment token, never from the caller.
-func (s *Service) Enrol(ctx context.Context, enrolToken string, in EnrolInput) (*fleetagent.Agent, string, error) {
+func (s *Service) Enrol(ctx context.Context, enrolToken string, in EnrolInput) (*fleetagent.Agent, string, []byte, error) {
 	kind, tenantStr, _, secret, ok := agenttoken.Parse(enrolToken)
 	if !ok || kind != agenttoken.KindEnrol {
-		return nil, "", ErrUnauthenticated
+		return nil, "", nil, ErrUnauthenticated
 	}
 	now := s.clock.Now()
 	tenantID := shared.ID(tenantStr)
 	if _, err := s.store.ConsumeEnrolToken(ctx, tenantID, agenttoken.Hash(secret), now); err != nil {
 		if errors.Is(err, shared.ErrNotFound) {
-			return nil, "", ErrUnauthenticated
+			return nil, "", nil, ErrUnauthenticated
 		}
-		return nil, "", fmt.Errorf("enrol: consume token: %w", err)
+		return nil, "", nil, fmt.Errorf("enrol: consume token: %w", err)
 	}
 	agentID := s.ids.NewID()
 	token, hash, err := agenttoken.Mint(agenttoken.KindAgent, tenantID.String(), agentID.String())
 	if err != nil {
-		return nil, "", fmt.Errorf("enrol: mint agent token: %w", err)
+		return nil, "", nil, fmt.Errorf("enrol: mint agent token: %w", err)
 	}
 	agent, err := fleetagent.NewAgent(agentID, tenantID, in.Name, in.Platform, in.OSVersion, in.AgentVersion, in.Capabilities, hash, now)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 	if err := s.store.CreateAgent(ctx, agent); err != nil {
-		return nil, "", fmt.Errorf("enrol: create agent: %w", err)
+		return nil, "", nil, fmt.Errorf("enrol: create agent: %w", err)
 	}
 	if err := s.audit.Record(ctx, ports.AuditEntry{
 		Actor: agentID.String(), Action: "agent.enrolled", Target: agentID.String(),
 		Metadata: map[string]string{"tenant_id": tenantID.String(), "name": agent.Name, "platform": agent.Platform},
 		At:       now,
 	}); err != nil {
-		return nil, "", fmt.Errorf("enrol: audit: %w", err)
+		return nil, "", nil, fmt.Errorf("enrol: audit: %w", err)
 	}
-	return agent, token, nil
+
+	// Optional certificate identity: if the agent sent a CSR and a CA is configured, issue a client
+	// certificate and record its fingerprint. The agent's private key is never seen.
+	var certPEM []byte
+	if len(in.CSRPEM) > 0 && s.ca != nil {
+		cp, fp, cerr := s.ca.Issue(in.CSRPEM, agentID.String(), tenantID.String(), now)
+		if cerr != nil {
+			return nil, "", nil, fmt.Errorf("enrol: issue certificate: %w", cerr)
+		}
+		if err := s.store.SetFingerprint(ctx, tenantID, agentID, fp, now); err != nil {
+			return nil, "", nil, fmt.Errorf("enrol: record fingerprint: %w", err)
+		}
+		agent.AttestCertificate(fp)
+		certPEM = cp
+		if err := s.audit.Record(ctx, ports.AuditEntry{
+			Actor: agentID.String(), Action: "agent.certificate_issued", Target: agentID.String(),
+			Metadata: map[string]string{"tenant_id": tenantID.String(), "fingerprint": fp}, At: now,
+		}); err != nil {
+			return nil, "", nil, fmt.Errorf("enrol: audit certificate: %w", err)
+		}
+	}
+	return agent, token, certPEM, nil
+}
+
+// AuthenticateCertificate resolves and verifies an agent by its client-certificate identity
+// (tenant and agent id read from the verified certificate subject, plus the certificate
+// fingerprint). It returns ErrUnauthenticated for an unknown agent, an agent with no certificate,
+// or a fingerprint mismatch, and ErrRevoked for a revoked agent. The fingerprint comparison is
+// constant time.
+func (s *Service) AuthenticateCertificate(ctx context.Context, tenantID, agentID shared.ID, fingerprint string) (*fleetagent.Agent, error) {
+	if fingerprint == "" {
+		return nil, ErrUnauthenticated
+	}
+	agent, err := s.store.GetAgent(ctx, tenantID, agentID)
+	if err != nil {
+		if errors.Is(err, shared.ErrNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("authenticate certificate: %w", err)
+	}
+	if agent.Fingerprint == "" || subtle.ConstantTimeCompare([]byte(fingerprint), []byte(agent.Fingerprint)) != 1 {
+		return nil, ErrUnauthenticated
+	}
+	if agent.Revoked() {
+		return nil, ErrRevoked
+	}
+	return agent, nil
 }
 
 // Authenticate resolves and verifies an agent bearer credential. It returns ErrUnauthenticated for
@@ -152,15 +211,25 @@ func (s *Service) Heartbeat(ctx context.Context, agent *fleetagent.Agent, in Hea
 	return nil
 }
 
-// Revoke marks an agent revoked so its credential no longer authenticates.
-func (s *Service) Revoke(ctx context.Context, actor string, tenantID, id shared.ID) error {
+// Revoke marks an agent revoked (so its bearer token and certificate no longer authenticate) with
+// operator attribution and a reason, and cancels the agent's in-flight work orders.
+func (s *Service) Revoke(ctx context.Context, actor string, tenantID, id shared.ID, reason string) error {
 	now := s.clock.Now()
-	if err := s.store.Revoke(ctx, tenantID, id, now); err != nil {
+	if err := s.store.Revoke(ctx, tenantID, id, shared.ID(actor), reason, now); err != nil {
 		return fmt.Errorf("revoke agent: %w", err)
+	}
+	cancelled := 0
+	if s.workOrders != nil {
+		// Best-effort: a revoked agent must stop, but a failure to cancel its orders should not
+		// leave it un-revoked. The orders also expire on their own NotAfter.
+		if n, cerr := s.workOrders.CancelForAgent(ctx, tenantID, id, "agent revoked", now); cerr == nil {
+			cancelled = n
+		}
 	}
 	if err := s.audit.Record(ctx, ports.AuditEntry{
 		Actor: actor, Action: "agent.revoked", Target: id.String(),
-		Metadata: map[string]string{"tenant_id": tenantID.String()}, At: now,
+		Metadata: map[string]string{"tenant_id": tenantID.String(), "reason": reason, "cancelled_orders": fmt.Sprintf("%d", cancelled)},
+		At:       now,
 	}); err != nil {
 		return fmt.Errorf("revoke agent: audit: %w", err)
 	}

--- a/internal/usecase/fleetagentuc/service.go
+++ b/internal/usecase/fleetagentuc/service.go
@@ -98,20 +98,40 @@ func (s *Service) Enrol(ctx context.Context, enrolToken string, in EnrolInput) (
 	}
 	now := s.clock.Now()
 	tenantID := shared.ID(tenantStr)
+	agentID := s.ids.NewID()
+	token, hash, err := agenttoken.Mint(agenttoken.KindAgent, tenantID.String(), agentID.String())
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("enrol: mint agent token: %w", err)
+	}
+
+	// Issue the certificate FIRST (before consuming the single-use token or creating the agent) so a
+	// malformed/weak CSR is a clean validation error with no side effect: the enrol token is not
+	// burned and no orphan agent row is left behind.
+	var (
+		certPEM     []byte
+		fingerprint string
+	)
+	if len(in.CSRPEM) > 0 && s.ca != nil {
+		cp, fp, cerr := s.ca.Issue(in.CSRPEM, agentID.String(), tenantID.String(), now)
+		if cerr != nil {
+			return nil, "", nil, fmt.Errorf("%w: enrol: invalid certificate signing request: %s", shared.ErrValidation, cerr.Error())
+		}
+		certPEM, fingerprint = cp, fp
+	}
+
+	// Consume the single-use enrol token only after the CSR has been accepted.
 	if _, err := s.store.ConsumeEnrolToken(ctx, tenantID, agenttoken.Hash(secret), now); err != nil {
 		if errors.Is(err, shared.ErrNotFound) {
 			return nil, "", nil, ErrUnauthenticated
 		}
 		return nil, "", nil, fmt.Errorf("enrol: consume token: %w", err)
 	}
-	agentID := s.ids.NewID()
-	token, hash, err := agenttoken.Mint(agenttoken.KindAgent, tenantID.String(), agentID.String())
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("enrol: mint agent token: %w", err)
-	}
 	agent, err := fleetagent.NewAgent(agentID, tenantID, in.Name, in.Platform, in.OSVersion, in.AgentVersion, in.Capabilities, hash, now)
 	if err != nil {
 		return nil, "", nil, err
+	}
+	if fingerprint != "" {
+		agent.AttestCertificate(fingerprint) // persisted in the single CreateAgent insert
 	}
 	if err := s.store.CreateAgent(ctx, agent); err != nil {
 		return nil, "", nil, fmt.Errorf("enrol: create agent: %w", err)
@@ -123,23 +143,10 @@ func (s *Service) Enrol(ctx context.Context, enrolToken string, in EnrolInput) (
 	}); err != nil {
 		return nil, "", nil, fmt.Errorf("enrol: audit: %w", err)
 	}
-
-	// Optional certificate identity: if the agent sent a CSR and a CA is configured, issue a client
-	// certificate and record its fingerprint. The agent's private key is never seen.
-	var certPEM []byte
-	if len(in.CSRPEM) > 0 && s.ca != nil {
-		cp, fp, cerr := s.ca.Issue(in.CSRPEM, agentID.String(), tenantID.String(), now)
-		if cerr != nil {
-			return nil, "", nil, fmt.Errorf("enrol: issue certificate: %w", cerr)
-		}
-		if err := s.store.SetFingerprint(ctx, tenantID, agentID, fp, now); err != nil {
-			return nil, "", nil, fmt.Errorf("enrol: record fingerprint: %w", err)
-		}
-		agent.AttestCertificate(fp)
-		certPEM = cp
+	if fingerprint != "" {
 		if err := s.audit.Record(ctx, ports.AuditEntry{
 			Actor: agentID.String(), Action: "agent.certificate_issued", Target: agentID.String(),
-			Metadata: map[string]string{"tenant_id": tenantID.String(), "fingerprint": fp}, At: now,
+			Metadata: map[string]string{"tenant_id": tenantID.String(), "fingerprint": fingerprint}, At: now,
 		}); err != nil {
 			return nil, "", nil, fmt.Errorf("enrol: audit certificate: %w", err)
 		}

--- a/internal/usecase/fleetagentuc/service_test.go
+++ b/internal/usecase/fleetagentuc/service_test.go
@@ -221,3 +221,25 @@ func TestRevokeCancelsInFlightOrders(t *testing.T) {
 		t.Fatalf("revoke must cancel the agent's in-flight orders, calls=%d", canceller.cancelled)
 	}
 }
+
+type failCA struct{}
+
+func (failCA) Issue([]byte, string, string, time.Time) ([]byte, string, error) {
+	return nil, "", errors.New("bad csr")
+}
+
+func TestBadCSRDoesNotBurnEnrolToken(t *testing.T) {
+	svc := newSvc(t)
+	svc.SetCA(failCA{})
+	ctx := context.Background()
+	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
+	// A bad CSR fails as a validation error, with no side effect (token not consumed).
+	if _, _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a", CSRPEM: []byte("bad")}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("bad CSR should be a validation error, got %v", err)
+	}
+	// The same enrol token still works afterwards (it was not burned).
+	svc.SetCA(&fakeCA{})
+	if _, _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"}); err != nil {
+		t.Fatalf("enrol token must survive a failed CSR, got %v", err)
+	}
+}

--- a/internal/usecase/fleetagentuc/service_test.go
+++ b/internal/usecase/fleetagentuc/service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/agenttoken"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -43,7 +44,7 @@ func TestEnrolAndAuthenticate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mint: %v", err)
 	}
-	agent, agentTok, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "agent-1", Platform: "linux"})
+	agent, agentTok, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "agent-1", Platform: "linux"})
 	if err != nil {
 		t.Fatalf("enrol: %v", err)
 	}
@@ -52,7 +53,7 @@ func TestEnrolAndAuthenticate(t *testing.T) {
 	}
 
 	// The single-use enrol token cannot be used again.
-	if _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "agent-2"}); !errors.Is(err, ErrUnauthenticated) {
+	if _, _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "agent-2"}); !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("re-using an enrol token must fail unauthenticated, got %v", err)
 	}
 
@@ -70,7 +71,7 @@ func TestAuthenticateRejectsTamperedAndMalformed(t *testing.T) {
 	svc := newSvc(t)
 	ctx := context.Background()
 	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
-	_, agentTok, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"})
+	_, agentTok, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"})
 	if err != nil {
 		t.Fatalf("enrol: %v", err)
 	}
@@ -96,11 +97,11 @@ func TestAuthenticateRevoked(t *testing.T) {
 	svc := newSvc(t)
 	ctx := context.Background()
 	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
-	agent, agentTok, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"})
+	agent, agentTok, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"})
 	if err != nil {
 		t.Fatalf("enrol: %v", err)
 	}
-	if err := svc.Revoke(ctx, "op", "t1", agent.ID); err != nil {
+	if err := svc.Revoke(ctx, "op", "t1", agent.ID, "test"); err != nil {
 		t.Fatalf("revoke: %v", err)
 	}
 	if _, err := svc.Authenticate(ctx, agentTok); !errors.Is(err, ErrRevoked) {
@@ -117,9 +118,106 @@ func TestExpiredEnrolTokenRejected(t *testing.T) {
 	}
 	// fakeClock is fixed, but the token expiry is now+1ns; advance the service clock past it.
 	svc.clock = fakeClock{t: time.Unix(1000, 0).UTC().Add(time.Hour)}
-	if _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"}); !errors.Is(err, ErrUnauthenticated) {
+	if _, _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"}); !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expired enrol token must fail, got %v", err)
 	}
 }
 
 func b64(s string) string { return agenttoken.B64(s) }
+
+// fakeCA is an in-file ports.CertificateIssuer for #408 tests: deterministic fingerprint per agent.
+type fakeCA struct{ issued int }
+
+func (c *fakeCA) Issue(_ []byte, agentID, tenantID string, _ time.Time) ([]byte, string, error) {
+	c.issued++
+	return []byte("CERT:" + agentID), "fp-" + tenantID + "-" + agentID, nil
+}
+
+// fakeCanceller implements ports.WorkOrderStore; only CancelForAgent is exercised here.
+type fakeCanceller struct{ cancelled int }
+
+func (f *fakeCanceller) Issue(context.Context, *workorder.WorkOrder) (*workorder.WorkOrder, error) {
+	return nil, nil
+}
+func (f *fakeCanceller) GetByID(context.Context, shared.ID, shared.ID) (*workorder.WorkOrder, error) {
+	return nil, shared.ErrNotFound
+}
+func (f *fakeCanceller) Claim(context.Context, shared.ID, shared.ID, int, time.Time) ([]*workorder.WorkOrder, error) {
+	return nil, nil
+}
+func (f *fakeCanceller) Transition(context.Context, shared.ID, shared.ID, workorder.State, string, workorder.State, time.Time) error {
+	return nil
+}
+func (f *fakeCanceller) CancelForAgent(_ context.Context, _, _ shared.ID, _ string, _ time.Time) (int, error) {
+	f.cancelled++
+	return 3, nil
+}
+
+var _ ports.WorkOrderStore = (*fakeCanceller)(nil)
+
+func TestEnrolIssuesCertificateAndAuthenticates(t *testing.T) {
+	svc := newSvc(t)
+	svc.SetCA(&fakeCA{})
+	ctx := context.Background()
+	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
+	agent, _, certPEM, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a", CSRPEM: []byte("csr")})
+	if err != nil {
+		t.Fatalf("enrol: %v", err)
+	}
+	if len(certPEM) == 0 {
+		t.Fatalf("enrol with a CSR + CA must return a certificate")
+	}
+	if agent.Fingerprint == "" {
+		t.Fatalf("agent must record its certificate fingerprint")
+	}
+	// Certificate identity authenticates with the matching fingerprint.
+	got, err := svc.AuthenticateCertificate(ctx, "t1", agent.ID, agent.Fingerprint)
+	if err != nil || got.ID != agent.ID {
+		t.Fatalf("cert auth should succeed: got=%v err=%v", got, err)
+	}
+	// A wrong fingerprint is unauthenticated.
+	if _, err := svc.AuthenticateCertificate(ctx, "t1", agent.ID, "fp-wrong"); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("wrong fingerprint must be unauthenticated, got %v", err)
+	}
+	// A revoked agent's certificate no longer authenticates.
+	if err := svc.Revoke(ctx, "op", "t1", agent.ID, "test"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := svc.AuthenticateCertificate(ctx, "t1", agent.ID, agent.Fingerprint); !errors.Is(err, ErrRevoked) {
+		t.Fatalf("revoked cert must return ErrRevoked, got %v", err)
+	}
+}
+
+func TestEnrolWithoutCANoCertificate(t *testing.T) {
+	svc := newSvc(t) // no CA wired
+	ctx := context.Background()
+	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
+	_, tok, certPEM, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a", CSRPEM: []byte("csr")})
+	if err != nil {
+		t.Fatalf("enrol: %v", err)
+	}
+	if tok == "" {
+		t.Fatalf("bearer token should still be issued")
+	}
+	if len(certPEM) != 0 {
+		t.Fatalf("no CA configured: no certificate should be issued")
+	}
+}
+
+func TestRevokeCancelsInFlightOrders(t *testing.T) {
+	svc := newSvc(t)
+	canceller := &fakeCanceller{}
+	svc.SetWorkOrders(canceller)
+	ctx := context.Background()
+	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
+	agent, _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"})
+	if err != nil {
+		t.Fatalf("enrol: %v", err)
+	}
+	if err := svc.Revoke(ctx, "op", "t1", agent.ID, "compromised"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if canceller.cancelled != 1 {
+		t.Fatalf("revoke must cancel the agent's in-flight orders, calls=%d", canceller.cancelled)
+	}
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -85,6 +85,9 @@ type WorkOrderStore interface {
 	GetByID(ctx context.Context, tenantID, id shared.ID) (*workorder.WorkOrder, error)
 	Claim(ctx context.Context, tenantID, agentID shared.ID, max int, now time.Time) ([]*workorder.WorkOrder, error)
 	Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State, now time.Time) error
+	// CancelForAgent moves every live (issued/claimed/running) order addressed to agentID into the
+	// cancelled state, returning how many were cancelled. Used when an agent is revoked.
+	CancelForAgent(ctx context.Context, tenantID, agentID shared.ID, reason string, now time.Time) (int, error)
 }
 
 // FleetAgentStore persists tenant-scoped fleet agent identities and their single-use enrolment
@@ -98,7 +101,10 @@ type FleetAgentStore interface {
 	CreateAgent(ctx context.Context, a *fleetagent.Agent) error
 	GetAgent(ctx context.Context, tenantID, id shared.ID) (*fleetagent.Agent, error)
 	Heartbeat(ctx context.Context, tenantID, id shared.ID, platform, osVersion, agentVersion string, capabilities []string, now time.Time) error
-	Revoke(ctx context.Context, tenantID, id shared.ID, now time.Time) error
+	// SetFingerprint records the SHA-256 of the client certificate issued to the agent from a CSR.
+	SetFingerprint(ctx context.Context, tenantID, id shared.ID, fingerprint string, now time.Time) error
+	// Revoke marks the agent revoked with operator attribution and a reason.
+	Revoke(ctx context.Context, tenantID, id, by shared.ID, reason string, now time.Time) error
 	ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error)
 }
 
@@ -109,6 +115,14 @@ type FleetAgentStore interface {
 type LeaderStore interface {
 	Acquire(ctx context.Context, resource, holder string, term time.Duration, now time.Time) (held bool, fence int64, err error)
 	Resign(ctx context.Context, resource, holder string, now time.Time) error
+}
+
+// CertificateIssuer issues a client certificate for a fleet agent from a certificate signing
+// request, binding it to (agentID, tenantID) and returning the certificate PEM and its SHA-256
+// fingerprint. Implemented by the control-plane CA in infrastructure; the usecase depends only on
+// this port. The agent's private key is never seen (only its CSR).
+type CertificateIssuer interface {
+	Issue(csrPEM []byte, agentID, tenantID string, now time.Time) (certPEM []byte, fingerprint string, err error)
 }
 
 // WorkOrderSigner signs and verifies the canonical signing payload of a work order. The

--- a/migrations/0062_fleet_agent_certs.sql
+++ b/migrations/0062_fleet_agent_certs.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+-- Certificate identity for fleet agents (#408): a SHA-256 certificate fingerprint (the agent's
+-- cryptographic identity issued from the control-plane CA via a CSR) plus revocation attribution.
+-- Also widens the agent state set to include 'stale' (last-seen-based, computed by fleet coverage).
+ALTER TABLE fleet_agents ADD COLUMN fingerprint TEXT NOT NULL DEFAULT '';
+ALTER TABLE fleet_agents ADD COLUMN revoked_at TIMESTAMPTZ;
+ALTER TABLE fleet_agents ADD COLUMN revoked_by TEXT NOT NULL DEFAULT '';
+ALTER TABLE fleet_agents ADD COLUMN revoke_reason TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE fleet_agents DROP CONSTRAINT fleet_agents_state_check;
+ALTER TABLE fleet_agents ADD CONSTRAINT fleet_agents_state_check CHECK (state IN ('active', 'stale', 'revoked'));
+
+-- Fingerprint auth resolves the agent by (tenant, fingerprint); a partial index skips agents with
+-- no certificate issued yet. Tenant is read from the verified certificate's subject, so this stays
+-- an RLS-scoped lookup.
+CREATE INDEX idx_fleet_agents_fingerprint ON fleet_agents (tenant_id, fingerprint) WHERE fingerprint <> '';
+
+-- +goose Down
+DROP INDEX idx_fleet_agents_fingerprint;
+ALTER TABLE fleet_agents DROP CONSTRAINT fleet_agents_state_check;
+ALTER TABLE fleet_agents ADD CONSTRAINT fleet_agents_state_check CHECK (state IN ('active', 'revoked'));
+ALTER TABLE fleet_agents DROP COLUMN revoke_reason;
+ALTER TABLE fleet_agents DROP COLUMN revoked_by;
+ALTER TABLE fleet_agents DROP COLUMN revoked_at;
+ALTER TABLE fleet_agents DROP COLUMN fingerprint;


### PR DESCRIPTION
Implements #408 (epic #405): cryptographic agent identity + revocation, on top of the #409 token-based identity.

## Scope note
The server runs plaintext behind a TLS-terminating proxy today (no in-process TLS), so full in-process mutual TLS is a P5 transport-topology decision. This PR delivers the **certificate identity mechanism** and binds it to the transport via the standard trusted-proxy pattern (the proxy verifies mTLS and passes the client certificate in a header). All of it is unit/fixture/Postgres tested.

## What this delivers
- **CA** `internal/infrastructure/fleetca` (behind `ports.CertificateIssuer`): verifies a CSR (signature + key-strength floor: RSA >= 2048 or ECDSA) and issues a short-lived client certificate whose subject encodes agent id (CN) and tenant (OU); returns the PEM + SHA-256 fingerprint. The agent's private key never leaves the host. `GenerateCA` bootstraps a dev/test CA.
- **Domain**: `Fingerprint`, a `stale` state, and revocation attribution (`RevokedAt/By/Reason`) with a `Revoke` method.
- **Migration 0062**: fingerprint + revoke columns, widened state CHECK, partial fingerprint index (RLS-scoped cert lookup).
- **Usecase**: `Enrol` accepts an optional CSR and (with a CA) issues a certificate + records the fingerprint; `AuthenticateCertificate` verifies `(tenant, agent id, fingerprint)` with a constant-time compare and refuses a revoked agent; `Revoke` takes operator + reason and cancels the agent's in-flight work orders (new `WorkOrderStore.CancelForAgent`).
- **Transport**: the agent plane authenticates by client certificate when a trusted proxy passes it in `SYNAPSE_FLEET_CLIENT_CERT_HEADER` — it reads tenant+agent from the subject and verifies the fingerprint, falling back to the bearer token otherwise. **SECURITY / trust boundary**: this header is trusted only because the operator asserts a trusted proxy verifies mTLS and strips any client-supplied value, and the app is not directly reachable. Documented in code + here.
- **Config** `SYNAPSE_FLEET_CA_CERT/KEY`, `SYNAPSE_FLEET_CERT_TTL`, `SYNAPSE_FLEET_CLIENT_CERT_HEADER`; the CA fails startup closed if configured but invalid.

## Deferred (referenced)
In-process mTLS listener / CSR-over-mTLS bootstrap and certificate rotation are P5 transport-topology work; the fingerprint identity is built so a cert can replace the token without lifecycle changes.

## Verification
- CA unit tests: issue + verify subject/fingerprint/client-auth-EKU/verify-against-CA; reject non-CSR, missing identity, weak RSA (1024), and a non-CA signer.
- Usecase tests: CSR->cert at enrol, cert auth success, wrong-fingerprint and revoked rejection, no-CA path, revoke-cancels-in-flight-orders.
- HTTP test: the client-cert header path (issued cert authenticates; malformed header unauthenticated, not 500; revoked cert 403) — this caught and fixed a raw-PEM URL-unescape corruption bug.
- Postgres integration: fingerprint + revoke persistence, single-use consume, migration 0062 down/up.
- `go build`/`go vet`/`go test ./...` (no DSN)/gofmt clean.

Refs #405
