### PR TITLE
feat(jsresolve): add R2B module specifier and alias resolution

### DIFF
--- a/internal/domain/jsresolution/jsresolution.go
+++ b/internal/domain/jsresolution/jsresolution.go
@@ -4,11 +4,15 @@ package jsresolution
 
 import "github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
 
-// Status is the explicit package-identity resolution state for an external import.
+// Status is the explicit package-identity resolution state for an observed import.
 type Status string
 
 const (
-	StatusBuiltin     Status = "builtin"
+	StatusBuiltin Status = "builtin"
+	// StatusLocal closes an external-looking alias back onto source inside the
+	// same non-workspace package. Keeping it explicit prevents supported local
+	// aliases from being mistaken for third-party npm dependencies.
+	StatusLocal       Status = "local"
 	StatusWorkspace   Status = "workspace"
 	StatusComponent   Status = "component"
 	StatusUnresolved  Status = "unresolved"
@@ -19,7 +23,7 @@ const (
 // Valid reports whether s is a supported resolution status.
 func (s Status) Valid() bool {
 	switch s {
-	case StatusBuiltin, StatusWorkspace, StatusComponent, StatusUnresolved, StatusAmbiguous, StatusUnsupported:
+	case StatusBuiltin, StatusLocal, StatusWorkspace, StatusComponent, StatusUnresolved, StatusAmbiguous, StatusUnsupported:
 		return true
 	default:
 		return false
@@ -62,6 +66,8 @@ const (
 	CoverageWorkspaceRootEscape       CoverageIssueKind = "workspace-root-escape"
 	CoverageSymlinkWorkspace          CoverageIssueKind = "symlink-workspace"
 	CoverageWorkspaceNameConflict     CoverageIssueKind = "workspace-name-conflict"
+	CoverageUnresolvedSpecifier       CoverageIssueKind = "unresolved-specifier"
+	CoverageUnsupportedSpecifier      CoverageIssueKind = "unsupported-specifier"
 	CoverageUnresolvedAlias           CoverageIssueKind = "unresolved-alias"
 	CoverageUnsupportedAlias          CoverageIssueKind = "unsupported-alias"
 	CoverageMissingSBOMComponent      CoverageIssueKind = "missing-sbom-component"
@@ -79,6 +85,8 @@ func (k CoverageIssueKind) Valid() bool {
 		CoverageWorkspaceRootEscape,
 		CoverageSymlinkWorkspace,
 		CoverageWorkspaceNameConflict,
+		CoverageUnresolvedSpecifier,
+		CoverageUnsupportedSpecifier,
 		CoverageUnresolvedAlias,
 		CoverageUnsupportedAlias,
 		CoverageMissingSBOMComponent,

--- a/internal/domain/jsresolution/result.go
+++ b/internal/domain/jsresolution/result.go
@@ -1,0 +1,337 @@
+package jsresolution
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+// NormalizeResult validates, deduplicates, and deterministically sorts package
+// resolution output without mutating the caller's slices. Complete is derived
+// from package-resolution coverage and explicit unresolved states. Source graph
+// coverage is preserved separately for the later reachability gate.
+func NormalizeResult(in Result) (Result, error) {
+	out := Result{}
+	out.Imports = make([]ImportResolution, 0, len(in.Imports))
+	for _, resolution := range in.Imports {
+		normalized, err := normalizeImportResolution(resolution)
+		if err != nil {
+			return Result{}, err
+		}
+		out.Imports = append(out.Imports, normalized)
+	}
+	sort.Slice(out.Imports, func(i, j int) bool { return importResolutionLess(out.Imports[i], out.Imports[j]) })
+	out.Imports = deduplicateImportResolutions(out.Imports)
+
+	out.Coverage = make([]CoverageIssue, 0, len(in.Coverage))
+	for _, issue := range in.Coverage {
+		if !issue.Kind.Valid() {
+			return Result{}, fmt.Errorf("jsresolution: invalid coverage issue kind %q", issue.Kind)
+		}
+		if issue.Path != "" {
+			loc, err := NormalizeRepositoryLocation(issue.Path)
+			if err != nil {
+				return Result{}, fmt.Errorf("normalize coverage path %q: %w", issue.Path, err)
+			}
+			issue.Path = loc
+		}
+		issue.Detail = strings.TrimSpace(issue.Detail)
+		out.Coverage = append(out.Coverage, issue)
+	}
+	sort.Slice(out.Coverage, func(i, j int) bool {
+		a, b := out.Coverage[i], out.Coverage[j]
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		return a.Detail < b.Detail
+	})
+	out.Coverage = deduplicateCoverage(out.Coverage)
+
+	out.GraphCoverage = make([]modulegraph.CoverageIssue, 0, len(in.GraphCoverage))
+	for _, issue := range in.GraphCoverage {
+		if !issue.Kind.Valid() {
+			return Result{}, fmt.Errorf("jsresolution: invalid graph coverage issue kind %q", issue.Kind)
+		}
+		if issue.Line < 0 {
+			return Result{}, fmt.Errorf("jsresolution: negative graph coverage line for %q", issue.Path)
+		}
+		if issue.Path != "" {
+			loc, err := modulegraph.NormalizeRepositoryPath(issue.Path)
+			if err != nil {
+				return Result{}, fmt.Errorf("normalize graph coverage path %q: %w", issue.Path, err)
+			}
+			issue.Path = loc
+		}
+		issue.Detail = strings.TrimSpace(issue.Detail)
+		out.GraphCoverage = append(out.GraphCoverage, issue)
+	}
+	sort.Slice(out.GraphCoverage, func(i, j int) bool {
+		a, b := out.GraphCoverage[i], out.GraphCoverage[j]
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		return a.Detail < b.Detail
+	})
+	out.GraphCoverage = deduplicateGraphCoverage(out.GraphCoverage)
+
+	out.Complete = len(out.Coverage) == 0
+	for _, resolution := range out.Imports {
+		switch resolution.Status {
+		case StatusBuiltin, StatusLocal, StatusWorkspace, StatusComponent:
+		default:
+			out.Complete = false
+		}
+	}
+	return out, nil
+}
+
+func normalizeImportResolution(in ImportResolution) (ImportResolution, error) {
+	if !in.Status.Valid() {
+		return ImportResolution{}, fmt.Errorf("jsresolution: invalid resolution status %q", in.Status)
+	}
+	if !in.Kind.Valid() {
+		return ImportResolution{}, fmt.Errorf("jsresolution: invalid import kind %q", in.Kind)
+	}
+	if in.Position.Line < 0 || in.Position.Column < 0 {
+		return ImportResolution{}, fmt.Errorf("jsresolution: negative source position for %q", in.From)
+	}
+	from, err := modulegraph.NormalizeRepositoryPath(in.From)
+	if err != nil {
+		return ImportResolution{}, fmt.Errorf("normalize resolution source %q: %w", in.From, err)
+	}
+	in.From = from
+	if in.Specifier == "" || strings.IndexByte(in.Specifier, 0) >= 0 {
+		return ImportResolution{}, fmt.Errorf("jsresolution: invalid empty or NUL module specifier from %q", from)
+	}
+	in.Package, err = normalizeIdentity(in.Package, in.Status == StatusBuiltin)
+	if err != nil {
+		return ImportResolution{}, fmt.Errorf("normalize package identity for %q: %w", in.Specifier, err)
+	}
+	in.Candidates = append([]PackageIdentity(nil), in.Candidates...)
+	for i := range in.Candidates {
+		in.Candidates[i], err = normalizeIdentity(in.Candidates[i], false)
+		if err != nil {
+			return ImportResolution{}, fmt.Errorf("normalize candidate for %q: %w", in.Specifier, err)
+		}
+	}
+	sort.Slice(in.Candidates, func(i, j int) bool { return identityLess(in.Candidates[i], in.Candidates[j]) })
+	in.Candidates = deduplicateIdentities(in.Candidates)
+	in.Reason = strings.TrimSpace(in.Reason)
+	if err := validateResolutionShape(in); err != nil {
+		return ImportResolution{}, fmt.Errorf("jsresolution: invalid resolution for %q: %w", in.Specifier, err)
+	}
+	return in, nil
+}
+
+func validateResolutionShape(in ImportResolution) error {
+	zeroPackage := PackageIdentity{}
+	switch in.Status {
+	case StatusBuiltin:
+		if !strings.HasPrefix(in.Package.Name, "node:") || in.Package.Path != "" || in.Package.Version != "" || in.Package.PURL != "" || in.Package.Workspace {
+			return fmt.Errorf("builtin status requires a canonical node: identity only")
+		}
+		if len(in.Candidates) != 0 {
+			return fmt.Errorf("builtin status cannot carry candidates")
+		}
+	case StatusLocal:
+		if in.Package.Path == "" || in.Package.Workspace || in.Package.PURL != "" {
+			return fmt.Errorf("local status requires a non-workspace repository path and no component PURL")
+		}
+		if len(in.Candidates) != 0 {
+			return fmt.Errorf("local status cannot carry candidates")
+		}
+	case StatusWorkspace:
+		if in.Package.Path == "" || !in.Package.Workspace || in.Package.PURL != "" {
+			return fmt.Errorf("workspace status requires a workspace repository path and no component PURL")
+		}
+		if len(in.Candidates) != 0 {
+			return fmt.Errorf("workspace status cannot carry candidates")
+		}
+	case StatusComponent:
+		if in.Package.PURL == "" || in.Package.Workspace {
+			return fmt.Errorf("component status requires a non-workspace PURL identity")
+		}
+		if len(in.Candidates) != 0 {
+			return fmt.Errorf("component status cannot carry candidates")
+		}
+	case StatusUnresolved:
+		if len(in.Candidates) != 0 || in.Package.Workspace || in.Package.PURL != "" || in.Package.Path != "" {
+			return fmt.Errorf("unresolved status may carry only an optional lexical package name")
+		}
+		if in.Reason == "" {
+			return fmt.Errorf("unresolved status requires a reason")
+		}
+	case StatusAmbiguous:
+		if in.Package != zeroPackage || len(in.Candidates) < 2 || in.Reason == "" {
+			return fmt.Errorf("ambiguous status requires at least two candidates, no selected package, and a reason")
+		}
+	case StatusUnsupported:
+		if in.Package != zeroPackage || len(in.Candidates) != 0 || in.Reason == "" {
+			return fmt.Errorf("unsupported status requires no package or candidates and a reason")
+		}
+	}
+	return nil
+}
+
+func normalizeIdentity(in PackageIdentity, builtin bool) (PackageIdentity, error) {
+	var err error
+	if in.Name != "" {
+		if builtin {
+			if !strings.HasPrefix(in.Name, "node:") {
+				return PackageIdentity{}, fmt.Errorf("builtin identity %q is not canonical node: form", in.Name)
+			}
+			name := strings.TrimPrefix(in.Name, "node:")
+			if !isNodeBuiltin(name) {
+				return PackageIdentity{}, fmt.Errorf("builtin identity %q is not a known Node built-in module", in.Name)
+			}
+		} else {
+			if strings.HasPrefix(in.Name, "node:") {
+				return PackageIdentity{}, fmt.Errorf("node: identity %q is only valid with builtin status", in.Name)
+			}
+			in.Name, err = NormalizePackageName(in.Name)
+			if err != nil {
+				return PackageIdentity{}, err
+			}
+		}
+	}
+	in.Version = strings.TrimSpace(in.Version)
+	in.PURL = strings.TrimSpace(in.PURL)
+	if in.Path != "" {
+		in.Path, err = NormalizeRepositoryLocation(in.Path)
+		if err != nil {
+			return PackageIdentity{}, err
+		}
+	}
+	return in, nil
+}
+
+func importResolutionLess(a, b ImportResolution) bool {
+	if a.From != b.From {
+		return a.From < b.From
+	}
+	if a.Specifier != b.Specifier {
+		return a.Specifier < b.Specifier
+	}
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	if a.Position.Line != b.Position.Line {
+		return a.Position.Line < b.Position.Line
+	}
+	if a.Position.Column != b.Position.Column {
+		return a.Position.Column < b.Position.Column
+	}
+	if a.TypeOnly != b.TypeOnly {
+		return !a.TypeOnly && b.TypeOnly
+	}
+	if a.DeclarationOnly != b.DeclarationOnly {
+		return !a.DeclarationOnly && b.DeclarationOnly
+	}
+	if a.Status != b.Status {
+		return a.Status < b.Status
+	}
+	if identityLess(a.Package, b.Package) {
+		return true
+	}
+	if identityLess(b.Package, a.Package) {
+		return false
+	}
+	if a.Reason != b.Reason {
+		return a.Reason < b.Reason
+	}
+	return identitiesLess(a.Candidates, b.Candidates)
+}
+
+func identityLess(a, b PackageIdentity) bool {
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	if a.Version != b.Version {
+		return a.Version < b.Version
+	}
+	if a.PURL != b.PURL {
+		return a.PURL < b.PURL
+	}
+	if a.Workspace != b.Workspace {
+		return !a.Workspace && b.Workspace
+	}
+	return a.Path < b.Path
+}
+
+func identitiesLess(a, b []PackageIdentity) bool {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	for i := 0; i < limit; i++ {
+		if a[i] == b[i] {
+			continue
+		}
+		return identityLess(a[i], b[i])
+	}
+	return len(a) < len(b)
+}
+
+func deduplicateIdentities(in []PackageIdentity) []PackageIdentity {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, value := range in[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func deduplicateImportResolutions(in []ImportResolution) []ImportResolution {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, value := range in[1:] {
+		if !importResolutionsEqual(value, out[len(out)-1]) {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func importResolutionsEqual(a, b ImportResolution) bool {
+	if a.From != b.From || a.Specifier != b.Specifier || a.Position != b.Position || a.Kind != b.Kind ||
+		a.TypeOnly != b.TypeOnly || a.DeclarationOnly != b.DeclarationOnly || a.Status != b.Status ||
+		a.Package != b.Package || a.Reason != b.Reason || len(a.Candidates) != len(b.Candidates) {
+		return false
+	}
+	for i := range a.Candidates {
+		if a.Candidates[i] != b.Candidates[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func deduplicateGraphCoverage(in []modulegraph.CoverageIssue) []modulegraph.CoverageIssue {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, value := range in[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/domain/jsresolution/result_test.go
+++ b/internal/domain/jsresolution/result_test.go
@@ -1,0 +1,83 @@
+package jsresolution
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+func TestNormalizeResultDeterministicAndComplete(t *testing.T) {
+	t.Parallel()
+	in := Result{
+		Imports: []ImportResolution{
+			{From: "src/z.ts", Specifier: "lodash/fp", Kind: modulegraph.ImportESMStatic, Status: StatusUnresolved, Package: PackageIdentity{Name: "lodash"}, Reason: "R2C deferred"},
+			{From: "src/a.ts", Specifier: "fs", Kind: modulegraph.ImportCommonJS, Status: StatusBuiltin, Package: PackageIdentity{Name: "node:fs"}},
+			{From: "src/a.ts", Specifier: "@scope/pkg/sub", Kind: modulegraph.ImportESMStatic, Status: StatusAmbiguous, Candidates: []PackageIdentity{{Name: "@scope/pkg", Version: "2"}, {Name: "@scope/pkg", Version: "1"}, {Name: "@scope/pkg", Version: "1"}}, Reason: "multiple versions"},
+		},
+		Coverage: []CoverageIssue{
+			{Kind: CoverageUnsupportedAlias, Path: "src/z.ts", Detail: "  unsupported  "},
+			{Kind: CoverageUnsupportedAlias, Path: "src/z.ts", Detail: "unsupported"},
+		},
+		GraphCoverage: []modulegraph.CoverageIssue{
+			{Kind: modulegraph.CoverageDynamicImport, Path: "src/z.ts", Line: 7, Detail: " dynamic "},
+		},
+	}
+	original := append([]ImportResolution(nil), in.Imports...)
+	got, err := NormalizeResult(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Complete {
+		t.Fatal("result with unresolved/ambiguous imports and coverage reported complete")
+	}
+	if len(got.Coverage) != 1 || got.Coverage[0].Detail != "unsupported" {
+		t.Fatalf("coverage normalization = %#v", got.Coverage)
+	}
+	if got.GraphCoverage[0].Detail != "dynamic" {
+		t.Fatalf("graph coverage normalization = %#v", got.GraphCoverage)
+	}
+	if got.Imports[0].Specifier != "@scope/pkg/sub" || got.Imports[1].Specifier != "fs" || got.Imports[2].Specifier != "lodash/fp" {
+		t.Fatalf("import order = %#v", got.Imports)
+	}
+	if len(got.Imports[0].Candidates) != 2 || got.Imports[0].Candidates[0].Version != "1" {
+		t.Fatalf("candidate normalization = %#v", got.Imports[0].Candidates)
+	}
+	if !reflect.DeepEqual(in.Imports, original) {
+		t.Fatal("NormalizeResult mutated input imports")
+	}
+}
+
+func TestNormalizeResultCanBeCompleteForResolvedPackageIdentities(t *testing.T) {
+	t.Parallel()
+	got, err := NormalizeResult(Result{Imports: []ImportResolution{
+		{From: "src/a.ts", Specifier: "node:fs", Kind: modulegraph.ImportESMStatic, Status: StatusBuiltin, Package: PackageIdentity{Name: "node:fs"}},
+		{From: "src/b.ts", Specifier: "@repo/shared", Kind: modulegraph.ImportESMStatic, Status: StatusWorkspace, Package: PackageIdentity{Name: "@repo/shared", Workspace: true, Path: "packages/shared"}},
+		{From: "src/local.ts", Specifier: "@app/config", Kind: modulegraph.ImportESMStatic, Status: StatusLocal, Package: PackageIdentity{Name: "root", Path: "."}},
+		{From: "src/c.ts", Specifier: "lodash", Kind: modulegraph.ImportESMStatic, Status: StatusComponent, Package: PackageIdentity{Name: "lodash", Version: "4.17.21", PURL: "pkg:npm/lodash@4.17.21"}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Complete {
+		t.Fatalf("resolved result unexpectedly incomplete: %#v", got)
+	}
+}
+
+func TestNormalizeResultRejectsStatusIdentityContractViolations(t *testing.T) {
+	t.Parallel()
+	cases := []ImportResolution{
+		{From: "src/a.ts", Specifier: "fs", Kind: modulegraph.ImportESMStatic, Status: StatusBuiltin, Package: PackageIdentity{Name: "fs"}},
+		{From: "src/a.ts", Specifier: "node:not-a-real-builtin", Kind: modulegraph.ImportESMStatic, Status: StatusBuiltin, Package: PackageIdentity{Name: "node:not-a-real-builtin"}},
+		{From: "src/a.ts", Specifier: "x", Kind: modulegraph.ImportESMStatic, Status: StatusUnresolved, Package: PackageIdentity{Name: "node:fs"}, Reason: "wrong status for node identity"},
+		{From: "src/a.ts", Specifier: "@repo/x", Kind: modulegraph.ImportESMStatic, Status: StatusWorkspace, Package: PackageIdentity{Name: "@repo/x", Path: "packages/x"}},
+		{From: "src/a.ts", Specifier: "lodash", Kind: modulegraph.ImportESMStatic, Status: StatusUnresolved},
+		{From: "src/a.ts", Specifier: "x", Kind: modulegraph.ImportESMStatic, Status: StatusAmbiguous, Candidates: []PackageIdentity{{Name: "a"}}, Reason: "one candidate is not ambiguity"},
+		{From: "src/a.ts", Specifier: "https://x", Kind: modulegraph.ImportESMStatic, Status: StatusUnsupported, Package: PackageIdentity{Name: "x"}, Reason: "unsupported"},
+	}
+	for _, resolution := range cases {
+		if _, err := NormalizeResult(Result{Imports: []ImportResolution{resolution}}); err == nil {
+			t.Fatalf("invalid resolution shape accepted: %#v", resolution)
+		}
+	}
+}

--- a/internal/domain/jsresolution/specifier.go
+++ b/internal/domain/jsresolution/specifier.go
@@ -1,0 +1,132 @@
+package jsresolution
+
+import "strings"
+
+// SpecifierKind is the source-only identity class of a module specifier before
+// workspace or SBOM correlation.
+type SpecifierKind string
+
+const (
+	SpecifierBuiltin       SpecifierKind = "builtin"
+	SpecifierPackage       SpecifierKind = "package"
+	SpecifierPackageImport SpecifierKind = "package-import"
+	SpecifierRelative      SpecifierKind = "relative"
+	SpecifierUnsupported   SpecifierKind = "unsupported"
+)
+
+// Valid reports whether k is a supported specifier kind.
+func (k SpecifierKind) Valid() bool {
+	switch k {
+	case SpecifierBuiltin, SpecifierPackage, SpecifierPackageImport, SpecifierRelative, SpecifierUnsupported:
+		return true
+	default:
+		return false
+	}
+}
+
+// ClassifiedSpecifier is the deterministic lexical classification of a module
+// specifier. PackageName is set only for npm package specifiers. BuiltinName is
+// canonicalized to the node: form.
+type ClassifiedSpecifier struct {
+	Raw         string
+	Kind        SpecifierKind
+	PackageName string
+	BuiltinName string
+}
+
+// ClassifySpecifier classifies one observed module specifier without consulting
+// the filesystem, package-manager state, or network.
+func ClassifySpecifier(raw string) ClassifiedSpecifier {
+	out := ClassifiedSpecifier{Raw: raw, Kind: SpecifierUnsupported}
+	if raw == "" || strings.IndexByte(raw, 0) >= 0 || strings.ContainsAny(raw, "\r\n\t ") {
+		return out
+	}
+	if raw == "." || raw == ".." || strings.HasPrefix(raw, "./") || strings.HasPrefix(raw, "../") {
+		out.Kind = SpecifierRelative
+		return out
+	}
+	if strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "\\") {
+		return out
+	}
+	if strings.HasPrefix(raw, "node:") {
+		name := strings.TrimPrefix(raw, "node:")
+		if name == "" || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "/") || strings.Contains(name, "\\") || !isNodeBuiltin(name) {
+			return out
+		}
+		out.Kind = SpecifierBuiltin
+		out.BuiltinName = raw
+		return out
+	}
+	if isBareNodeBuiltin(raw) {
+		out.Kind = SpecifierBuiltin
+		out.BuiltinName = "node:" + raw
+		return out
+	}
+	if strings.HasPrefix(raw, "#") {
+		if raw == "#" || strings.HasPrefix(raw, "#/") {
+			return out
+		}
+		out.Kind = SpecifierPackageImport
+		return out
+	}
+	if strings.Contains(raw, ":") {
+		return out
+	}
+
+	root := raw
+	if strings.HasPrefix(raw, "@") {
+		parts := strings.Split(raw, "/")
+		if len(parts) < 2 {
+			return out
+		}
+		root = parts[0] + "/" + parts[1]
+	} else if slash := strings.IndexByte(raw, '/'); slash >= 0 {
+		root = raw[:slash]
+	}
+	name, err := NormalizePackageName(root)
+	if err != nil {
+		return out
+	}
+	out.Kind = SpecifierPackage
+	out.PackageName = name
+	return out
+}
+
+// Bare built-ins intentionally excludes prefix-only modules. Those modules are
+// recognized only in node: form so an npm package with the same bare name is
+// never silently reclassified as a runtime built-in.
+var bareNodeBuiltins = map[string]struct{}{
+	"_http_agent": {}, "_http_client": {}, "_http_common": {}, "_http_incoming": {}, "_http_outgoing": {}, "_http_server": {},
+	"_stream_duplex": {}, "_stream_passthrough": {}, "_stream_readable": {}, "_stream_transform": {}, "_stream_wrap": {}, "_stream_writable": {},
+	"_tls_common": {}, "_tls_wrap": {},
+	"assert": {}, "assert/strict": {}, "async_hooks": {}, "buffer": {}, "child_process": {}, "cluster": {}, "console": {}, "constants": {},
+	"crypto": {}, "dgram": {}, "diagnostics_channel": {}, "dns": {}, "dns/promises": {}, "domain": {}, "events": {}, "fs": {}, "fs/promises": {},
+	"http": {}, "http2": {}, "https": {}, "inspector": {}, "inspector/promises": {}, "module": {}, "net": {}, "os": {}, "path": {},
+	"path/posix": {}, "path/win32": {}, "perf_hooks": {}, "process": {}, "punycode": {}, "querystring": {}, "readline": {}, "readline/promises": {},
+	"repl": {}, "stream": {}, "stream/consumers": {}, "stream/promises": {}, "stream/web": {}, "string_decoder": {}, "sys": {}, "timers": {},
+	"timers/promises": {}, "tls": {}, "trace_events": {}, "tty": {}, "url": {}, "util": {}, "util/types": {}, "v8": {}, "vm": {}, "wasi": {},
+	"worker_threads": {}, "zlib": {},
+}
+
+// Node reserves these modules for node:-prefixed loading. Keep this explicit
+// rather than trusting an arbitrary node:* string as a built-in identity.
+var prefixOnlyNodeBuiltins = map[string]struct{}{
+	"ffi":            {},
+	"sea":            {},
+	"sqlite":         {},
+	"test":           {},
+	"test/reporters": {},
+}
+
+func isNodeBuiltin(name string) bool {
+	if isBareNodeBuiltin(name) {
+		return true
+	}
+	_, ok := prefixOnlyNodeBuiltins[name]
+	return ok
+}
+
+func isBareNodeBuiltin(name string) bool {
+	_, ok := bareNodeBuiltins[name]
+	return ok
+}

--- a/internal/domain/jsresolution/specifier_test.go
+++ b/internal/domain/jsresolution/specifier_test.go
@@ -1,0 +1,40 @@
+package jsresolution
+
+import "testing"
+
+func TestClassifySpecifier(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		raw         string
+		kind        SpecifierKind
+		packageName string
+		builtinName string
+	}{
+		{name: "node builtin", raw: "node:fs", kind: SpecifierBuiltin, builtinName: "node:fs"},
+		{name: "bare builtin", raw: "fs/promises", kind: SpecifierBuiltin, builtinName: "node:fs/promises"},
+		{name: "prefix only builtin", raw: "node:test", kind: SpecifierBuiltin, builtinName: "node:test"},
+		{name: "prefix only builtin subpath", raw: "node:test/reporters", kind: SpecifierBuiltin, builtinName: "node:test/reporters"},
+		{name: "newer prefix only builtin", raw: "node:sqlite", kind: SpecifierBuiltin, builtinName: "node:sqlite"},
+		{name: "prefix only name remains package when bare", raw: "test", kind: SpecifierPackage, packageName: "test"},
+		{name: "sqlite remains package when bare", raw: "sqlite", kind: SpecifierPackage, packageName: "sqlite"},
+		{name: "unknown node scheme is unsupported", raw: "node:not-a-real-builtin", kind: SpecifierUnsupported},
+		{name: "unscoped subpath", raw: "lodash/fp", kind: SpecifierPackage, packageName: "lodash"},
+		{name: "scoped subpath", raw: "@scope/pkg/subpath", kind: SpecifierPackage, packageName: "@scope/pkg"},
+		{name: "package import", raw: "#internal/logger", kind: SpecifierPackageImport},
+		{name: "relative", raw: "../shared.js", kind: SpecifierRelative},
+		{name: "url unsupported", raw: "https://example.test/mod.js", kind: SpecifierUnsupported},
+		{name: "malformed scope", raw: "@scope", kind: SpecifierUnsupported},
+		{name: "whitespace unsupported", raw: "lodash /fp", kind: SpecifierUnsupported},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifySpecifier(tt.raw)
+			if got.Kind != tt.kind || got.PackageName != tt.packageName || got.BuiltinName != tt.builtinName || got.Raw != tt.raw {
+				t.Fatalf("ClassifySpecifier(%q) = %#v", tt.raw, got)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/aliases_budget_test.go
+++ b/internal/infrastructure/tools/jsresolve/aliases_budget_test.go
@@ -1,0 +1,118 @@
+package jsresolve
+
+import (
+	"context"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAliasInventoryBuilderPatternByteBudget(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.json"), `{"name":"root","imports":{"#abcdef":"./src/a"}}`)
+	limits := defaultAliasLimits()
+	limits.maxPatternBytes = 4
+	got, err := newAliasInventoryBuilderWithLimits(limits).Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCoverageKind(got.coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("oversized alias pattern did not produce coverage: %#v", got.coverage)
+	}
+}
+
+func TestAliasInventoryBuilderAcceptsUTF8BOMJSONC(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	content := append([]byte{0xef, 0xbb, 0xbf}, []byte(`{"compilerOptions":{"paths":{"@x/*":["src/*"]}}}`)...)
+	if err := os.WriteFile(filepath.Join(root, "tsconfig.json"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.mappings) != 1 || len(got.coverage) != 0 {
+		t.Fatalf("BOM JSONC parse = %#v", got)
+	}
+}
+
+func TestAliasInventoryBuilderTracksMalformedNestedPackageBoundary(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.json"), `{"name":"root","imports":{"#x":"lodash"}}`)
+	writeFile(t, filepath.Join(root, "packages", "app", "package.json"), `{not-json`)
+
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nested aliasPackageContext
+	found := false
+	for _, scope := range got.packageScopes {
+		if scope.scopeDir == "packages/app" {
+			nested, found = scope, true
+			break
+		}
+	}
+	if !found || !nested.uncertain {
+		t.Fatalf("malformed nested package boundary was not retained as uncertain: %#v", got.packageScopes)
+	}
+}
+
+func TestAliasInventoryBuilderUnsupportedImportsMakesWholeScopeUncertain(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.json"), `{
+  "name":"root",
+  "imports":{
+    "#x":{"default":"lodash"},
+    "#*":"left-pad"
+  }
+}`)
+
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.packageScopes) != 1 || !got.packageScopes[0].importsPresent || !got.packageScopes[0].uncertain {
+		t.Fatalf("partially unsupported imports scope was not marked uncertain: %#v", got.packageScopes)
+	}
+}
+
+func TestAliasInventoryBuilderPartialTSPathsMakesContextUncertain(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions":{"paths":{"@ok/*":["src/*"],"@bad/*":["node_modules/pkg/*"]}}
+}`)
+
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.configs) != 1 || !got.configs[0].uncertain {
+		t.Fatalf("partially unsupported paths config was not marked uncertain: %#v", got.configs)
+	}
+}
+
+func TestAliasInventoryBuilderMappingBudgetNeverStoresPartialSource(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.json"), `{"name":"root","imports":{"#a":"a","#b":"b"}}`)
+	limits := defaultAliasLimits()
+	limits.maxMappings = 1
+
+	got, err := newAliasInventoryBuilderWithLimits(limits).Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.mappings) != 0 || len(got.packageScopes) != 1 || !got.packageScopes[0].uncertain {
+		t.Fatalf("mapping budget retained a semantically partial source: mappings=%#v scopes=%#v", got.mappings, got.packageScopes)
+	}
+	if !hasCoverageKind(got.coverage, jsresolution.CoverageMetadataBudgetExceeded) {
+		t.Fatalf("mapping budget missing explicit coverage: %#v", got.coverage)
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/aliases_inventory.go
+++ b/internal/infrastructure/tools/jsresolve/aliases_inventory.go
@@ -1,0 +1,224 @@
+package jsresolve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"io/fs"
+	"os"
+	"path"
+	"sort"
+	"strings"
+)
+
+func (b *aliasInventoryBuilder) Build(ctx context.Context, root string) (aliasInventory, error) {
+	if ctx == nil {
+		return aliasInventory{}, fmt.Errorf("%w: context is required", shared.ErrValidation)
+	}
+	if b == nil {
+		return aliasInventory{}, fmt.Errorf("%w: alias inventory builder is required", shared.ErrValidation)
+	}
+	if err := b.limits.validate(); err != nil {
+		return aliasInventory{}, err
+	}
+	if strings.TrimSpace(root) == "" {
+		return aliasInventory{}, fmt.Errorf("%w: repository root is required", shared.ErrValidation)
+	}
+	if err := ctx.Err(); err != nil {
+		return aliasInventory{}, err
+	}
+	rootAbs, err := filepathAbsClean(root)
+	if err != nil {
+		return aliasInventory{}, fmt.Errorf("%w: resolve repository root: %v", shared.ErrValidation, err)
+	}
+	rootInfo, err := os.Lstat(rootAbs)
+	if err != nil {
+		return aliasInventory{}, fmt.Errorf("%w: repository root: %v", shared.ErrValidation, err)
+	}
+	if rootInfo.Mode()&os.ModeSymlink != 0 || !rootInfo.IsDir() {
+		return aliasInventory{}, fmt.Errorf("%w: repository root must be a real directory", shared.ErrValidation)
+	}
+	rootDir, err := os.OpenRoot(rootAbs)
+	if err != nil {
+		return aliasInventory{}, fmt.Errorf("%w: open repository root: %v", shared.ErrValidation, err)
+	}
+	defer func() { _ = rootDir.Close() }()
+
+	var mappings []aliasMapping
+	var configs []aliasConfigContext
+	var packageScopes []aliasPackageContext
+	coverage := aliasCoverageSink{limit: b.limits.maxCoverageIssues}
+	entries, files := 0, 0
+	bytesRead := int64(0)
+	scopeDiscoveryComplete := true
+	mappingBudgetExhausted := false
+	walkErr := fs.WalkDir(rootDir.FS(), ".", func(rel string, entry fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if walkErr != nil {
+			if rel == "." {
+				return fmt.Errorf("walk repository root: %w", walkErr)
+			}
+			scopeDiscoveryComplete = false
+			coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnreadableMetadata, Path: rel, Detail: "alias metadata entry could not be inspected"})
+			return nil
+		}
+		entries++
+		if entries > b.limits.maxEntries {
+			scopeDiscoveryComplete = false
+			coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageMetadataBudgetExceeded, Path: ".", Detail: fmt.Sprintf("alias filesystem entry budget exceeded (%d)", b.limits.maxEntries)})
+			return fs.SkipAll
+		}
+		if entry.IsDir() {
+			if rel != "." && skipMetadataDir(entry.Name()) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !isAliasMetadataFile(entry.Name()) {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if entry.Name() == "package.json" {
+				packageScopes = append(packageScopes, aliasPackageContext{source: rel, scopeDir: path.Dir(rel), uncertain: true})
+			}
+			if entry.Name() == "tsconfig.json" || entry.Name() == "jsconfig.json" {
+				configs = append(configs, aliasConfigContext{source: rel, scopeDir: path.Dir(rel), uncertain: true})
+			}
+			coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnreadableMetadata, Path: rel, Detail: "alias metadata is symlinked and was not followed"})
+			return nil
+		}
+		if files >= b.limits.maxFiles {
+			scopeDiscoveryComplete = false
+			coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageMetadataBudgetExceeded, Path: rel, Detail: fmt.Sprintf("alias metadata file budget exceeded (%d)", b.limits.maxFiles)})
+			return fs.SkipAll
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil || !info.Mode().IsRegular() {
+			if entry.Name() == "package.json" {
+				packageScopes = append(packageScopes, aliasPackageContext{source: rel, scopeDir: path.Dir(rel), uncertain: true})
+			}
+			if entry.Name() == "tsconfig.json" || entry.Name() == "jsconfig.json" {
+				configs = append(configs, aliasConfigContext{source: rel, scopeDir: path.Dir(rel), uncertain: true})
+			}
+			coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnreadableMetadata, Path: rel, Detail: "alias metadata entry is not a stable regular file"})
+			return nil
+		}
+		remaining := b.limits.maxTotalBytes - bytesRead
+		if remaining <= 0 || info.Size() > remaining {
+			scopeDiscoveryComplete = false
+			coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageMetadataBudgetExceeded, Path: rel, Detail: fmt.Sprintf("aggregate alias metadata byte budget exceeded (%d)", b.limits.maxTotalBytes)})
+			return fs.SkipAll
+		}
+		files++
+		content, readErr := readBoundedMetadata(rootDir, rel, info, b.limits.maxFileBytes, remaining)
+		if readErr != nil {
+			if entry.Name() == "package.json" {
+				packageScopes = append(packageScopes, aliasPackageContext{source: rel, scopeDir: path.Dir(rel), uncertain: true})
+			}
+			if entry.Name() == "tsconfig.json" || entry.Name() == "jsconfig.json" {
+				configs = append(configs, aliasConfigContext{source: rel, scopeDir: path.Dir(rel), uncertain: true})
+			}
+			kind := jsresolution.CoverageUnreadableMetadata
+			if errorsIsMetadataBudget(readErr) {
+				kind = jsresolution.CoverageMetadataBudgetExceeded
+			}
+			coverage.add(jsresolution.CoverageIssue{Kind: kind, Path: rel, Detail: readErr.Error()})
+			if errors.Is(readErr, errMetadataTotalBudget) {
+				scopeDiscoveryComplete = false
+				return fs.SkipAll
+			}
+			return nil
+		}
+		bytesRead += int64(len(content))
+
+		var parsed []aliasMapping
+		var issues []jsresolution.CoverageIssue
+		var packageContext aliasPackageContext
+		var config aliasConfigContext
+		isPackage := entry.Name() == "package.json"
+		isConfig := entry.Name() == "tsconfig.json" || entry.Name() == "jsconfig.json"
+		switch entry.Name() {
+		case "package.json":
+			parsed, packageContext, issues = parsePackageImports(rel, content, b.limits)
+		case "tsconfig.json", "jsconfig.json":
+			parsed, config, issues = parseTSConfigPaths(rel, content, b.limits)
+		}
+		coverage.addAll(issues)
+
+		remainingMappings := b.limits.maxMappings - len(mappings)
+		if mappingBudgetExhausted || len(parsed) > remainingMappings {
+			if len(parsed) > 0 {
+				if !mappingBudgetExhausted {
+					coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageMetadataBudgetExceeded, Path: rel, Detail: fmt.Sprintf("alias mapping budget exceeded (%d)", b.limits.maxMappings)})
+				}
+				mappingBudgetExhausted = true
+				if isPackage {
+					packageContext.uncertain = true
+				}
+				if isConfig {
+					config.uncertain = true
+				}
+				parsed = nil
+			}
+		}
+		if isPackage {
+			packageScopes = append(packageScopes, packageContext)
+		}
+		if isConfig {
+			configs = append(configs, config)
+		}
+		mappings = append(mappings, parsed...)
+		return nil
+	})
+	if walkErr != nil {
+		if err := ctx.Err(); err != nil {
+			return aliasInventory{}, err
+		}
+		return aliasInventory{}, fmt.Errorf("inventory javascript alias metadata: %w", walkErr)
+	}
+
+	sort.Slice(mappings, func(i, j int) bool { return aliasMappingLess(mappings[i], mappings[j]) })
+	mappings = deduplicateAliasMappings(mappings)
+	sort.Slice(configs, func(i, j int) bool {
+		if configs[i].scopeDir != configs[j].scopeDir {
+			return configs[i].scopeDir < configs[j].scopeDir
+		}
+		return configs[i].source < configs[j].source
+	})
+	configs = deduplicateAliasConfigs(configs)
+	sort.Slice(packageScopes, func(i, j int) bool {
+		if packageScopes[i].scopeDir != packageScopes[j].scopeDir {
+			return packageScopes[i].scopeDir < packageScopes[j].scopeDir
+		}
+		return packageScopes[i].source < packageScopes[j].source
+	})
+	packageScopes = deduplicateAliasPackageContexts(packageScopes)
+	out := aliasInventory{
+		mappings: mappings, configs: configs, packageScopes: packageScopes,
+		coverage: coverage.issues, scopeDiscoveryComplete: scopeDiscoveryComplete,
+	}
+	sort.Slice(out.coverage, func(i, j int) bool {
+		a, c := out.coverage[i], out.coverage[j]
+		if a.Kind != c.Kind {
+			return a.Kind < c.Kind
+		}
+		if a.Path != c.Path {
+			return a.Path < c.Path
+		}
+		return a.Detail < c.Detail
+	})
+	out.coverage = deduplicateAliasCoverage(out.coverage)
+	return out, nil
+}
+
+func errorsIsMetadataBudget(err error) bool {
+	return errors.Is(err, errMetadataTooLarge) || errors.Is(err, errMetadataTotalBudget)
+}
+
+func isAliasMetadataFile(name string) bool {
+	return name == "package.json" || name == "tsconfig.json" || name == "jsconfig.json"
+}

--- a/internal/infrastructure/tools/jsresolve/aliases_normalize.go
+++ b/internal/infrastructure/tools/jsresolve/aliases_normalize.go
@@ -1,0 +1,110 @@
+package jsresolve
+
+import (
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+)
+
+func aliasMappingLess(a, b aliasMapping) bool {
+	if a.kind != b.kind {
+		return a.kind < b.kind
+	}
+	if a.scopeDir != b.scopeDir {
+		return a.scopeDir < b.scopeDir
+	}
+	if a.source != b.source {
+		return a.source < b.source
+	}
+	if a.pattern != b.pattern {
+		return a.pattern < b.pattern
+	}
+	if a.baseDir != b.baseDir {
+		return a.baseDir < b.baseDir
+	}
+	if a.moduleResolution != b.moduleResolution {
+		return a.moduleResolution < b.moduleResolution
+	}
+	return stringSliceLess(a.targets, b.targets)
+}
+
+func stringSliceLess(a, b []string) bool {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	for i := 0; i < limit; i++ {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return len(a) < len(b)
+}
+
+func deduplicateAliasMappings(in []aliasMapping) []aliasMapping {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, value := range in[1:] {
+		last := out[len(out)-1]
+		if value.kind != last.kind || value.source != last.source || value.scopeDir != last.scopeDir || value.baseDir != last.baseDir ||
+			value.pattern != last.pattern || value.moduleResolution != last.moduleResolution || !equalStrings(value.targets, last.targets) {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func deduplicateAliasConfigs(in []aliasConfigContext) []aliasConfigContext {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, value := range in[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func deduplicateAliasPackageContexts(in []aliasPackageContext) []aliasPackageContext {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, value := range in[1:] {
+		last := &out[len(out)-1]
+		if value.source == last.source && value.scopeDir == last.scopeDir {
+			last.importsPresent = last.importsPresent || value.importsPresent
+			last.uncertain = last.uncertain || value.uncertain
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func deduplicateAliasCoverage(in []jsresolution.CoverageIssue) []jsresolution.CoverageIssue {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, value := range in[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/infrastructure/tools/jsresolve/aliases_package.go
+++ b/internal/infrastructure/tools/jsresolve/aliases_package.go
@@ -1,0 +1,95 @@
+package jsresolve
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"path"
+	"sort"
+	"strings"
+)
+
+func parsePackageImports(rel string, content []byte, limits aliasLimits) ([]aliasMapping, aliasPackageContext, []jsresolution.CoverageIssue) {
+	context := aliasPackageContext{source: rel, scopeDir: path.Dir(rel)}
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(content, &doc); err != nil {
+		context.uncertain = true
+		return nil, context, []jsresolution.CoverageIssue{{Kind: jsresolution.CoverageMalformedMetadata, Path: rel, Detail: "package.json alias metadata is malformed JSON"}}
+	}
+	raw, ok := doc["imports"]
+	if !ok {
+		return nil, context, nil
+	}
+	context.importsPresent = true
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		context.uncertain = true
+		return nil, context, []jsresolution.CoverageIssue{{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: "package.json imports must be an object for source-only resolution"}}
+	}
+	var values map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil || values == nil {
+		context.uncertain = true
+		return nil, context, []jsresolution.CoverageIssue{{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: "package.json imports must be an object for source-only resolution"}}
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	mappings := make([]aliasMapping, 0, len(keys))
+	var issues []jsresolution.CoverageIssue
+	for _, key := range keys {
+		if len(key) > limits.maxPatternBytes || !validPackageImportPattern(key) {
+			context.uncertain = true
+			issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: fmt.Sprintf("unsupported package imports key %q", key)})
+			continue
+		}
+		var target string
+		if err := json.Unmarshal(values[key], &target); err != nil {
+			context.uncertain = true
+			issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: fmt.Sprintf("package imports key %q uses conditional or fallback targets", key)})
+			continue
+		}
+		if len(target) > limits.maxPatternBytes || !validPackageImportTarget(key, target) {
+			context.uncertain = true
+			issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: fmt.Sprintf("unsupported package imports target for %q", key)})
+			continue
+		}
+		if strings.HasPrefix(target, "./") {
+			cleaned := path.Clean(target)
+			if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+				context.uncertain = true
+				issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageWorkspaceRootEscape, Path: rel, Detail: fmt.Sprintf("package imports target for %q escapes its package scope", key)})
+				continue
+			}
+			if containsPathSegment(cleaned, "node_modules") {
+				context.uncertain = true
+				issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: fmt.Sprintf("package imports target for %q traverses node_modules", key)})
+				continue
+			}
+		}
+		mappings = append(mappings, aliasMapping{
+			kind: aliasPackageImports, source: rel, scopeDir: path.Dir(rel), baseDir: path.Dir(rel), pattern: key, targets: []string{target},
+		})
+	}
+	return mappings, context, issues
+}
+
+func validPackageImportPattern(pattern string) bool {
+	return strings.HasPrefix(pattern, "#") && pattern != "#" && !strings.HasPrefix(pattern, "#/") &&
+		strings.IndexByte(pattern, 0) < 0 && !strings.ContainsAny(pattern, "\r\n\t ") && strings.Count(pattern, "*") <= 1
+}
+
+func validPackageImportTarget(pattern, target string) bool {
+	if target == "" || strings.IndexByte(target, 0) >= 0 || strings.ContainsAny(target, "\r\n\t") || strings.Count(target, "*") > 1 {
+		return false
+	}
+	if strings.Count(pattern, "*") == 0 && strings.Contains(target, "*") {
+		return false
+	}
+	if strings.HasPrefix(target, "./") {
+		return true
+	}
+	kind := jsresolution.ClassifySpecifier(target).Kind
+	return kind == jsresolution.SpecifierBuiltin || kind == jsresolution.SpecifierPackage
+}

--- a/internal/infrastructure/tools/jsresolve/aliases_safety_test.go
+++ b/internal/infrastructure/tools/jsresolve/aliases_safety_test.go
@@ -1,0 +1,87 @@
+package jsresolve
+
+import (
+	"context"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"path/filepath"
+	"testing"
+)
+
+func TestAliasInventoryBuilderTracksBaseURLWithoutPaths(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{"compilerOptions":{"baseUrl":"src"}}`)
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.configs) != 1 || !got.configs[0].hasBaseURL {
+		t.Fatalf("baseUrl context not retained: %#v", got.configs)
+	}
+}
+
+func TestAliasInventoryBuilderExtendsWithoutLocalPathsIsStillIncomplete(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{"extends":"./base.json"}`)
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCoverageKind(got.coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("extends without local paths silently looked complete: %#v", got.coverage)
+	}
+}
+
+func TestAliasInventoryBuilderRejectsNullAliasObjects(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.json"), `{"name":"root","imports":null}`)
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{"compilerOptions":{"paths":null}}`)
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCoverageKind(got.coverage, jsresolution.CoverageUnsupportedAlias) || !hasCoverageKind(got.coverage, jsresolution.CoverageMalformedMetadata) {
+		t.Fatalf("null alias metadata was not explicit coverage: %#v", got.coverage)
+	}
+}
+
+func TestAliasInventoryBuilderRejectsEscapingAndNodeModulesTargets(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.json"), `{"name":"root","imports":{"#escape":"./../outside","#nm":"./node_modules/x"}}`)
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCoverageKind(got.coverage, jsresolution.CoverageWorkspaceRootEscape) || !hasCoverageKind(got.coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("unsafe package imports targets were not rejected: %#v", got.coverage)
+	}
+}
+
+func TestAliasInventoryBuilderTSPathsRejectsNodeModulesTarget(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{"compilerOptions":{"paths":{"lodash":["node_modules/lodash"]}}}`)
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.mappings) != 0 || !hasCoverageKind(got.coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("node_modules path target was treated as first-party: %#v", got)
+	}
+}
+
+func TestAliasInventoryBuilderMarksProjectSelectionAliasContextUncertain(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{"include":["src/**"],"compilerOptions":{"paths":{"@x/*":["src/*"]}}}`)
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.configs) != 1 || !got.configs[0].uncertain || !hasCoverageKind(got.coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("project-selection alias context was treated as certain: %#v", got)
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/aliases_test.go
+++ b/internal/infrastructure/tools/jsresolve/aliases_test.go
@@ -1,0 +1,150 @@
+package jsresolve
+
+import (
+	"context"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestAliasInventoryBuilderParsesPackageImportsAndJSONCPaths(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.json"), `{
+  "name": "root",
+  "imports": {
+    "#shared/*": "./packages/shared/src/*",
+    "#dep": "lodash/fp"
+  }
+}`)
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  // JSONC comments and trailing commas are accepted.
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["packages/shared/src/*",],
+    },
+  },
+}`)
+
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.coverage) != 0 {
+		t.Fatalf("unexpected coverage: %#v", got.coverage)
+	}
+	if len(got.mappings) != 3 {
+		t.Fatalf("mapping count = %d, want 3: %#v", len(got.mappings), got.mappings)
+	}
+}
+
+func TestAliasInventoryBuilderUnsupportedConditionalImportIsExplicit(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.json"), `{
+  "name": "root",
+  "imports": {"#internal": {"node": "./node.js", "default": "./default.js"}}
+}`)
+
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.mappings) != 0 || !hasCoverageKind(got.coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("conditional imports were not explicit unsupported coverage: %#v", got)
+	}
+}
+
+func TestAliasInventoryBuilderTSConfigExtendsKeepsCoverageIncomplete(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "extends": "./base.json",
+  "compilerOptions": {"paths": {"@app/*": ["src/*"]}}
+}`)
+
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.mappings) != 1 || !hasCoverageKind(got.coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("extends coverage = %#v mappings=%#v", got.coverage, got.mappings)
+	}
+}
+
+func TestAliasInventoryBuilderRejectsEscapingBaseURL(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {"baseUrl": "../outside", "paths": {"@app/*": ["src/*"]}}
+}`)
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.mappings) != 0 || !hasCoverageKind(got.coverage, jsresolution.CoverageWorkspaceRootEscape) {
+		t.Fatalf("escaping baseUrl was not rejected: %#v", got)
+	}
+}
+
+func TestAliasInventoryBuilderBudgetsAreInjectable(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{
+  "compilerOptions": {"paths": {"a": ["src/a"], "b": ["src/b"]}}
+}`)
+	limits := defaultAliasLimits()
+	limits.maxMappings = 1
+	got, err := newAliasInventoryBuilderWithLimits(limits).Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCoverageKind(got.coverage, jsresolution.CoverageMetadataBudgetExceeded) {
+		t.Fatalf("mapping budget did not produce coverage: %#v", got.coverage)
+	}
+}
+
+func TestAliasInventoryBuilderMalformedJSONCIsIncomplete(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "tsconfig.json"), `{"compilerOptions":{"paths":{"a":["src/a"]}} /* never closes`)
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCoverageKind(got.coverage, jsresolution.CoverageMalformedMetadata) {
+		t.Fatalf("malformed JSONC did not produce coverage: %#v", got.coverage)
+	}
+}
+
+func TestAliasInventoryBuilderRefusesSymlinkedAliasMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "tsconfig.json")
+	writeFile(t, outside, `{"compilerOptions":{"paths":{"@x/*":["src/*"]}}}`)
+	if err := os.Symlink(outside, filepath.Join(root, "tsconfig.json")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := newAliasInventoryBuilder().Build(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.mappings) != 0 || !hasCoverageKind(got.coverage, jsresolution.CoverageUnreadableMetadata) {
+		t.Fatalf("symlinked alias metadata was not refused: %#v", got)
+	}
+}
+
+func hasCoverageKind(issues []jsresolution.CoverageIssue, kind jsresolution.CoverageIssueKind) bool {
+	for _, issue := range issues {
+		if issue.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/tools/jsresolve/aliases_tsconfig.go
+++ b/internal/infrastructure/tools/jsresolve/aliases_tsconfig.go
@@ -1,0 +1,175 @@
+package jsresolve
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"path"
+	"sort"
+	"strings"
+)
+
+func parseTSConfigPaths(rel string, content []byte, limits aliasLimits) ([]aliasMapping, aliasConfigContext, []jsresolution.CoverageIssue) {
+	config := aliasConfigContext{source: rel, scopeDir: path.Dir(rel)}
+	cleaned, err := sanitizeJSONC(content)
+	if err != nil {
+		config.uncertain = true
+		return nil, config, []jsresolution.CoverageIssue{{Kind: jsresolution.CoverageMalformedMetadata, Path: rel, Detail: err.Error()}}
+	}
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(cleaned, &doc); err != nil {
+		config.uncertain = true
+		return nil, config, []jsresolution.CoverageIssue{{Kind: jsresolution.CoverageMalformedMetadata, Path: rel, Detail: "tsconfig/jsconfig alias metadata is malformed JSONC"}}
+	}
+	var issues []jsresolution.CoverageIssue
+	if rawExtends, ok := doc["extends"]; ok && !bytes.Equal(bytes.TrimSpace(rawExtends), []byte("null")) {
+		config.uncertain = true
+		issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: "tsconfig/jsconfig inheritance via extends is not resolved in R2B"})
+	}
+	selectionPresent := false
+	for _, key := range []string{"files", "include", "exclude"} {
+		if raw, ok := doc[key]; ok && !bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			selectionPresent = true
+		}
+	}
+
+	rawCompiler, ok := doc["compilerOptions"]
+	if !ok {
+		return nil, config, issues
+	}
+	var compiler map[string]json.RawMessage
+	if err := json.Unmarshal(rawCompiler, &compiler); err != nil || compiler == nil {
+		config.uncertain = true
+		issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageMalformedMetadata, Path: rel, Detail: "compilerOptions must be an object"})
+		return nil, config, issues
+	}
+
+	moduleResolution := aliasModuleResolutionUnknown
+	if rawMode, ok := compiler["moduleResolution"]; ok {
+		var mode string
+		if err := json.Unmarshal(rawMode, &mode); err != nil {
+			config.uncertain = true
+			issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: "compilerOptions.moduleResolution must be a supported string for source-only paths resolution"})
+		} else {
+			switch strings.ToLower(strings.TrimSpace(mode)) {
+			case "bundler", "node", "node10", "classic":
+				moduleResolution = aliasModuleResolutionExtensionless
+			case "node16", "nodenext":
+				moduleResolution = aliasModuleResolutionStrictNode
+			default:
+				config.uncertain = true
+				issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: fmt.Sprintf("unsupported compilerOptions.moduleResolution %q", mode)})
+			}
+		}
+	}
+
+	_, hasPaths := compiler["paths"]
+	_, hasBaseURL := compiler["baseUrl"]
+	if selectionPresent && (hasPaths || hasBaseURL) {
+		config.uncertain = true
+		issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: "tsconfig/jsconfig project files/include/exclude membership is not resolved in R2B"})
+	}
+	configDir := path.Dir(rel)
+	baseDir := configDir
+	if rawBase, ok := compiler["baseUrl"]; ok {
+		config.hasBaseURL = true
+		var base string
+		if err := json.Unmarshal(rawBase, &base); err != nil || base == "" {
+			config.uncertain = true
+			issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageMalformedMetadata, Path: rel, Detail: "compilerOptions.baseUrl must be a non-empty string"})
+			return nil, config, issues
+		}
+		base = strings.ReplaceAll(base, "\\", "/")
+		joined := path.Clean(path.Join(configDir, base))
+		if joined == ".." || strings.HasPrefix(joined, "../") || strings.HasPrefix(base, "/") || hasDeclaredWindowsVolume(base) {
+			config.uncertain = true
+			issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageWorkspaceRootEscape, Path: rel, Detail: "tsconfig/jsconfig baseUrl escapes repository root"})
+			return nil, config, issues
+		}
+		baseDir = strings.TrimPrefix(joined, "./")
+		if baseDir == "" {
+			baseDir = "."
+		}
+	}
+
+	rawPaths, ok := compiler["paths"]
+	if !ok {
+		return nil, config, issues
+	}
+	var paths map[string]json.RawMessage
+	if err := json.Unmarshal(rawPaths, &paths); err != nil || paths == nil {
+		config.uncertain = true
+		issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageMalformedMetadata, Path: rel, Detail: "compilerOptions.paths must be an object"})
+		return nil, config, issues
+	}
+
+	keys := make([]string, 0, len(paths))
+	for key := range paths {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	mappings := make([]aliasMapping, 0, len(keys))
+	for _, key := range keys {
+		if len(key) > limits.maxPatternBytes || !validTSPathPattern(key) {
+			config.uncertain = true
+			issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: fmt.Sprintf("unsupported tsconfig/jsconfig paths key %q", key)})
+			continue
+		}
+		var targets []string
+		if err := json.Unmarshal(paths[key], &targets); err != nil || len(targets) == 0 {
+			config.uncertain = true
+			issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: fmt.Sprintf("paths key %q must map to a non-empty string array", key)})
+			continue
+		}
+		if len(targets) > limits.maxTargets {
+			config.uncertain = true
+			issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageMetadataBudgetExceeded, Path: rel, Detail: fmt.Sprintf("paths target budget exceeded for %q (%d)", key, limits.maxTargets)})
+			targets = targets[:limits.maxTargets]
+		}
+		validTargets := make([]string, 0, len(targets))
+		for _, target := range targets {
+			target = strings.ReplaceAll(target, "\\", "/")
+			if len(target) > limits.maxPatternBytes || !validTSPathTarget(key, target) {
+				config.uncertain = true
+				issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: fmt.Sprintf("unsupported paths target for %q", key)})
+				continue
+			}
+			if containsPathSegment(target, "node_modules") || strings.Contains(target, ":") {
+				config.uncertain = true
+				issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: fmt.Sprintf("paths target for %q uses an unsupported package/URL-like location", key)})
+				continue
+			}
+			joined := path.Clean(path.Join(baseDir, target))
+			if strings.HasPrefix(target, "/") || hasDeclaredWindowsVolume(target) || joined == ".." || strings.HasPrefix(joined, "../") {
+				config.uncertain = true
+				issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageWorkspaceRootEscape, Path: rel, Detail: fmt.Sprintf("paths target for %q escapes repository root", key)})
+				continue
+			}
+			validTargets = append(validTargets, target)
+		}
+		if len(validTargets) == 0 {
+			continue
+		}
+		mappings = append(mappings, aliasMapping{
+			kind: aliasTSConfigPaths, source: rel, scopeDir: configDir, baseDir: baseDir,
+			pattern: key, targets: validTargets, moduleResolution: moduleResolution,
+		})
+	}
+	return mappings, config, issues
+}
+
+func validTSPathPattern(pattern string) bool {
+	return pattern != "" && strings.IndexByte(pattern, 0) < 0 && !strings.ContainsAny(pattern, "\r\n\t") && strings.Count(pattern, "*") <= 1
+}
+
+func validTSPathTarget(pattern, target string) bool {
+	if target == "" || strings.IndexByte(target, 0) >= 0 || strings.ContainsAny(target, "\r\n\t") || strings.Count(target, "*") > 1 {
+		return false
+	}
+	return strings.Count(pattern, "*") != 0 || !strings.Contains(target, "*")
+}
+
+func hasDeclaredWindowsVolume(value string) bool {
+	return len(value) >= 2 && ((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) && value[1] == ':'
+}

--- a/internal/infrastructure/tools/jsresolve/aliases_types.go
+++ b/internal/infrastructure/tools/jsresolve/aliases_types.go
@@ -1,0 +1,145 @@
+package jsresolve
+
+import (
+	"fmt"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	defaultMaxAliasEntries       = 100000
+	defaultMaxAliasFiles         = 10000
+	defaultMaxAliasFileBytes     = int64(2 << 20)
+	defaultMaxAliasTotalBytes    = int64(32 << 20)
+	defaultMaxAliasMappings      = 8192
+	defaultMaxAliasTargets       = 64
+	defaultMaxAliasPatternBytes  = 4096
+	defaultMaxAliasCoverageIssue = 4096
+)
+
+type aliasLimits struct {
+	maxEntries        int
+	maxFiles          int
+	maxFileBytes      int64
+	maxTotalBytes     int64
+	maxMappings       int
+	maxTargets        int
+	maxPatternBytes   int
+	maxCoverageIssues int
+}
+
+func defaultAliasLimits() aliasLimits {
+	return aliasLimits{
+		maxEntries:        defaultMaxAliasEntries,
+		maxFiles:          defaultMaxAliasFiles,
+		maxFileBytes:      defaultMaxAliasFileBytes,
+		maxTotalBytes:     defaultMaxAliasTotalBytes,
+		maxMappings:       defaultMaxAliasMappings,
+		maxTargets:        defaultMaxAliasTargets,
+		maxPatternBytes:   defaultMaxAliasPatternBytes,
+		maxCoverageIssues: defaultMaxAliasCoverageIssue,
+	}
+}
+
+func (l aliasLimits) validate() error {
+	if l.maxEntries <= 0 || l.maxFiles <= 0 || l.maxFileBytes <= 0 || l.maxTotalBytes <= 0 ||
+		l.maxMappings <= 0 || l.maxTargets <= 0 || l.maxPatternBytes <= 0 || l.maxCoverageIssues <= 0 {
+		return fmt.Errorf("%w: alias limits must be positive", shared.ErrValidation)
+	}
+	return nil
+}
+
+type aliasKind uint8
+
+const (
+	aliasPackageImports aliasKind = iota + 1
+	aliasTSConfigPaths
+)
+
+type aliasModuleResolution uint8
+
+const (
+	aliasModuleResolutionUnknown aliasModuleResolution = iota
+	aliasModuleResolutionExtensionless
+	aliasModuleResolutionStrictNode
+)
+
+type aliasMapping struct {
+	kind             aliasKind
+	source           string
+	scopeDir         string
+	baseDir          string
+	pattern          string
+	targets          []string
+	moduleResolution aliasModuleResolution
+}
+
+type aliasConfigContext struct {
+	source     string
+	scopeDir   string
+	hasBaseURL bool
+	uncertain  bool
+}
+
+type aliasPackageContext struct {
+	source         string
+	scopeDir       string
+	importsPresent bool
+	uncertain      bool
+}
+
+type aliasInventory struct {
+	mappings               []aliasMapping
+	configs                []aliasConfigContext
+	packageScopes          []aliasPackageContext
+	coverage               []jsresolution.CoverageIssue
+	scopeDiscoveryComplete bool
+}
+
+type aliasInventoryBuilder struct {
+	limits aliasLimits
+}
+
+func newAliasInventoryBuilder() *aliasInventoryBuilder {
+	return &aliasInventoryBuilder{limits: defaultAliasLimits()}
+}
+
+func newAliasInventoryBuilderWithLimits(limits aliasLimits) *aliasInventoryBuilder {
+	return &aliasInventoryBuilder{limits: limits}
+}
+
+type aliasCoverageSink struct {
+	issues []jsresolution.CoverageIssue
+	limit  int
+	capped bool
+}
+
+func (s *aliasCoverageSink) add(issue jsresolution.CoverageIssue) {
+	if s.capped {
+		return
+	}
+	if len(s.issues) < s.limit-1 {
+		s.issues = append(s.issues, issue)
+		return
+	}
+	budget := jsresolution.CoverageIssue{
+		Kind:   jsresolution.CoverageMetadataBudgetExceeded,
+		Path:   ".",
+		Detail: fmt.Sprintf("alias coverage issue budget exceeded (%d)", s.limit),
+	}
+	if len(s.issues) < s.limit {
+		s.issues = append(s.issues, budget)
+	} else {
+		s.issues[s.limit-1] = budget
+	}
+	s.capped = true
+}
+
+func (s *aliasCoverageSink) addAll(issues []jsresolution.CoverageIssue) {
+	for _, issue := range issues {
+		s.add(issue)
+		if s.capped {
+			return
+		}
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/jsonc.go
+++ b/internal/infrastructure/tools/jsresolve/jsonc.go
@@ -1,0 +1,109 @@
+package jsresolve
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func sanitizeJSONC(in []byte) ([]byte, error) {
+	if bytes.HasPrefix(in, []byte{0xef, 0xbb, 0xbf}) {
+		in = in[3:]
+	}
+	withoutComments := make([]byte, 0, len(in))
+	inString := false
+	escaped := false
+	for i := 0; i < len(in); i++ {
+		c := in[i]
+		if inString {
+			withoutComments = append(withoutComments, c)
+			if escaped {
+				escaped = false
+				continue
+			}
+			if c == '\\' {
+				escaped = true
+			} else if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			withoutComments = append(withoutComments, c)
+			continue
+		}
+		if c == '/' && i+1 < len(in) {
+			switch in[i+1] {
+			case '/':
+				withoutComments = append(withoutComments, ' ', ' ')
+				i += 2
+				for ; i < len(in) && in[i] != '\n'; i++ {
+					withoutComments = append(withoutComments, ' ')
+				}
+				if i < len(in) {
+					withoutComments = append(withoutComments, '\n')
+				}
+				continue
+			case '*':
+				withoutComments = append(withoutComments, ' ', ' ')
+				i += 2
+				closed := false
+				for ; i < len(in); i++ {
+					if i+1 < len(in) && in[i] == '*' && in[i+1] == '/' {
+						withoutComments = append(withoutComments, ' ', ' ')
+						i++
+						closed = true
+						break
+					}
+					if in[i] == '\n' {
+						withoutComments = append(withoutComments, '\n')
+					} else {
+						withoutComments = append(withoutComments, ' ')
+					}
+				}
+				if !closed {
+					return nil, fmt.Errorf("unterminated block comment in tsconfig/jsconfig")
+				}
+				continue
+			}
+		}
+		withoutComments = append(withoutComments, c)
+	}
+	if inString {
+		return nil, fmt.Errorf("unterminated string in tsconfig/jsconfig")
+	}
+
+	out := make([]byte, 0, len(withoutComments))
+	inString = false
+	escaped = false
+	for i := 0; i < len(withoutComments); i++ {
+		c := withoutComments[i]
+		if inString {
+			out = append(out, c)
+			if escaped {
+				escaped = false
+			} else if c == '\\' {
+				escaped = true
+			} else if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			out = append(out, c)
+			continue
+		}
+		if c == ',' {
+			j := i + 1
+			for j < len(withoutComments) && (withoutComments[j] == ' ' || withoutComments[j] == '\t' || withoutComments[j] == '\r' || withoutComments[j] == '\n') {
+				j++
+			}
+			if j < len(withoutComments) && (withoutComments[j] == '}' || withoutComments[j] == ']') {
+				continue
+			}
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}

--- a/internal/infrastructure/tools/jsresolve/resolver.go
+++ b/internal/infrastructure/tools/jsresolve/resolver.go
@@ -1,0 +1,160 @@
+package jsresolve
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Resolve implements source-only R2B package identity resolution. The SBOM is
+// intentionally unused in this slice; exact component/PURL correlation belongs
+// to R2C and unresolved third-party package roots remain explicit until then.
+func (r *Resolver) Resolve(ctx context.Context, root string, graph modulegraph.Graph, _ *sbom.SBOM) (jsresolution.Result, error) {
+	if ctx == nil {
+		return jsresolution.Result{}, fmt.Errorf("%w: context is required", shared.ErrValidation)
+	}
+	if r == nil || r.inventory == nil || r.aliases == nil {
+		return jsresolution.Result{}, fmt.Errorf("%w: resolver is not initialized", shared.ErrValidation)
+	}
+	if err := r.limits.validate(); err != nil {
+		return jsresolution.Result{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return jsresolution.Result{}, err
+	}
+	if len(graph.Modules) == 0 {
+		return jsresolution.Result{}, fmt.Errorf("%w: module graph has no modules", shared.ErrValidation)
+	}
+	if len(graph.Modules) > r.limits.maxModules || len(graph.Edges) > r.limits.maxEdges || len(graph.Coverage) > r.limits.maxGraphCoverage {
+		return jsresolution.Result{}, fmt.Errorf("%w: module graph exceeds resolver budget", shared.ErrValidation)
+	}
+	for _, module := range graph.Modules {
+		if len(module.Path) > r.limits.maxModulePathBytes || repositorySegmentCount(module.Path) > r.limits.maxModulePathSegments {
+			return jsresolution.Result{}, fmt.Errorf("%w: module graph path exceeds resolver budget", shared.ErrValidation)
+		}
+	}
+	totalBindings := 0
+	for _, edge := range graph.Edges {
+		if edge.Specifier == "" || strings.IndexByte(edge.Specifier, 0) >= 0 ||
+			len(edge.From) > r.limits.maxModulePathBytes || len(edge.To) > r.limits.maxModulePathBytes ||
+			repositorySegmentCount(edge.From) > r.limits.maxModulePathSegments || repositorySegmentCount(edge.To) > r.limits.maxModulePathSegments ||
+			len(edge.Bindings) > r.limits.maxBindingsPerEdge || len(edge.Specifier) > r.limits.maxSpecifierBytes {
+			return jsresolution.Result{}, fmt.Errorf("%w: module graph edge exceeds resolver budget", shared.ErrValidation)
+		}
+		if len(edge.Bindings) > r.limits.maxTotalBindings-totalBindings {
+			return jsresolution.Result{}, fmt.Errorf("%w: module graph binding work exceeds resolver budget", shared.ErrValidation)
+		}
+		totalBindings += len(edge.Bindings)
+	}
+	normalizedGraph, err := modulegraph.Normalize(graph)
+	if err != nil {
+		return jsresolution.Result{}, fmt.Errorf("%w: invalid module graph: %v", shared.ErrValidation, err)
+	}
+	for _, edge := range normalizedGraph.Edges {
+		classified := jsresolution.ClassifySpecifier(edge.Specifier)
+		if edge.To != "" && classified.Kind != jsresolution.SpecifierRelative {
+			return jsresolution.Result{}, fmt.Errorf("%w: resolved graph edge %q -> %q has non-relative specifier %q", shared.ErrValidation, edge.From, edge.To, edge.Specifier)
+		}
+	}
+
+	inventory, err := r.inventory.Build(ctx, root)
+	if err != nil {
+		return jsresolution.Result{}, err
+	}
+	aliases, err := r.aliases.Build(ctx, root)
+	if err != nil {
+		return jsresolution.Result{}, err
+	}
+
+	coverage := resolutionCoverageSink{limit: r.limits.maxCoverageIssues}
+	aliasWork := resolverWorkBudget{remaining: r.limits.maxAliasWork}
+	candidateWork := resolverWorkBudget{remaining: r.limits.maxCandidateWork}
+	coverage.addAll(inventory.Coverage)
+	coverage.addAll(aliases.coverage)
+
+	moduleByPath := make(map[string]modulegraph.Module, len(normalizedGraph.Modules))
+	modulePaths := make(map[string]struct{}, len(normalizedGraph.Modules))
+	for _, module := range normalizedGraph.Modules {
+		moduleByPath[module.Path] = module
+		modulePaths[module.Path] = struct{}{}
+	}
+	workspaceByName := indexWorkspacesByName(inventory.Packages)
+
+	result := jsresolution.Result{GraphCoverage: append([]modulegraph.CoverageIssue(nil), normalizedGraph.Coverage...)}
+	for _, edge := range normalizedGraph.Edges {
+		if err := ctx.Err(); err != nil {
+			return jsresolution.Result{}, err
+		}
+		if edge.To != "" {
+			continue
+		}
+		classified := jsresolution.ClassifySpecifier(edge.Specifier)
+		if classified.Kind == jsresolution.SpecifierRelative {
+			// Relative source resolution remains owned by the module graph. Refuse
+			// an internally inconsistent graph rather than silently dropping an
+			// unresolved relative edge with no corresponding coverage limitation.
+			if !relativeEdgeHasCoverage(normalizedGraph.Coverage, edge) {
+				return jsresolution.Result{}, fmt.Errorf("%w: unresolved relative edge from %q has no graph coverage", shared.ErrValidation, edge.From)
+			}
+			continue
+		}
+		resolution := jsresolution.ImportResolution{
+			From:      edge.From,
+			Specifier: edge.Specifier,
+			Position:  edge.Position,
+			Kind:      edge.Kind,
+			TypeOnly:  edge.TypeOnly,
+		}
+		if module, ok := moduleByPath[edge.From]; ok {
+			resolution.DeclarationOnly = module.DeclarationOnly
+		}
+
+		switch classified.Kind {
+		case jsresolution.SpecifierBuiltin:
+			resolution.Status = jsresolution.StatusBuiltin
+			resolution.Package = jsresolution.PackageIdentity{Name: classified.BuiltinName}
+		case jsresolution.SpecifierPackageImport:
+			resolution = r.resolvePackageImport(ctx, resolution, aliases.mappings, aliases.packageScopes, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, &aliasWork, &candidateWork, &coverage)
+		case jsresolution.SpecifierPackage:
+			if aliasResolution, handled := r.resolveTSPaths(ctx, resolution, aliases.mappings, aliases.configs, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, modulePaths, &aliasWork, &candidateWork, &coverage); handled {
+				resolution = aliasResolution
+			} else if self, ok := packageForRepositoryTarget(inventory.Packages, resolution.From); ok && self.Name == classified.PackageName {
+				// A same-name bare import may be a Node package self-reference, whose
+				// legality and subpath identity depend on package.json exports. R2B
+				// does not implement exports maps, so do not let R2C mistake it for
+				// an ordinary third-party package with the same name.
+				resolution.Status = jsresolution.StatusUnresolved
+				resolution.Package = jsresolution.PackageIdentity{Name: classified.PackageName}
+				resolution.Reason = "same-package self-reference requires package.json exports semantics that R2B does not resolve"
+				coverage.add(jsresolution.CoverageIssue{
+					Kind: jsresolution.CoverageUnresolvedSpecifier, Path: resolution.From,
+					Detail: fmt.Sprintf("specifier %q may be a package self-reference", resolution.Specifier),
+				})
+			} else {
+				resolution = r.resolvePackageRoot(resolution, classified.PackageName, workspaceByName, &candidateWork, &coverage)
+			}
+		default:
+			if aliasResolution, handled := r.resolveTSPaths(ctx, resolution, aliases.mappings, aliases.configs, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, modulePaths, &aliasWork, &candidateWork, &coverage); handled {
+				resolution = aliasResolution
+			} else {
+				resolution.Status = jsresolution.StatusUnsupported
+				resolution.Reason = "unsupported module specifier form"
+				coverage.add(jsresolution.CoverageIssue{
+					Kind: jsresolution.CoverageUnsupportedSpecifier, Path: edge.From,
+					Detail: fmt.Sprintf("specifier %q is outside the supported source-only R2B forms", edge.Specifier),
+				})
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return jsresolution.Result{}, err
+		}
+		result.Imports = append(result.Imports, resolution)
+	}
+	result.Coverage = coverage.issues
+	return jsresolution.NormalizeResult(result)
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_alias.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_alias.go
@@ -1,0 +1,188 @@
+package jsresolve
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+)
+
+type resolvedAliasTarget struct {
+	status   jsresolution.Status
+	identity jsresolution.PackageIdentity
+	reason   string
+}
+
+func (r *Resolver) resolveAliasMatches(
+	ctx context.Context,
+	base jsresolution.ImportResolution,
+	matches []aliasMapping,
+	workspaces map[string][]jsresolution.PackageIdentity,
+	packages []jsresolution.PackageMetadata,
+	modulePaths map[string]struct{},
+	aliasWork *resolverWorkBudget,
+	candidateWork *resolverWorkBudget,
+	coverage *resolutionCoverageSink,
+) jsresolution.ImportResolution {
+	var outcomes []resolvedAliasTarget
+	for _, mapping := range matches {
+		capture, ok := aliasCapture(mapping.pattern, base.Specifier)
+		if !ok {
+			continue
+		}
+		for _, target := range mapping.targets {
+			if !aliasWork.consume() {
+				return markAliasBudgetExceeded(base, aliasWork, coverage, r.limits.maxAliasWork)
+			}
+			if err := ctx.Err(); err != nil {
+				base.Status = jsresolution.StatusUnresolved
+				base.Reason = err.Error()
+				return base
+			}
+			expanded := substituteAliasTarget(target, capture)
+			resolved, failure := resolveAliasTargets(mapping, expanded, workspaces, packages, modulePaths, r.limits.maxCandidates)
+			if len(resolved) > 0 {
+				if !candidateWork.consumeN(len(resolved)) {
+					return markCandidateBudgetExceeded(base, candidateWork, coverage, r.limits.maxCandidateWork)
+				}
+				outcomes = append(outcomes, resolved...)
+				if len(outcomes) > r.limits.maxCandidates {
+					base.Status = jsresolution.StatusUnresolved
+					base.Package = jsresolution.PackageIdentity{}
+					base.Candidates = nil
+					base.Reason = "alias identity candidate budget exceeded"
+					coverage.add(jsresolution.CoverageIssue{
+						Kind: jsresolution.CoverageMetadataBudgetExceeded, Path: base.From,
+						Detail: fmt.Sprintf("alias candidate budget exceeded for %q (%d)", base.Specifier, r.limits.maxCandidates),
+					})
+					return base
+				}
+				// TypeScript paths arrays are ordered fallbacks. Once one target
+				// resolves, later entries are not viable candidates.
+				if mapping.kind == aliasTSConfigPaths {
+					break
+				}
+			}
+			if failure != "" && !(mapping.kind == aliasTSConfigPaths && failure == jsresolution.CoverageUnresolvedAlias) {
+				coverage.add(jsresolution.CoverageIssue{
+					Kind: failure, Path: base.From,
+					Detail: fmt.Sprintf("alias %q target %q cannot be resolved safely", base.Specifier, expanded),
+				})
+			}
+		}
+	}
+	outcomes = deduplicateAliasOutcomes(outcomes)
+	if len(outcomes) == 0 {
+		base.Status = jsresolution.StatusUnresolved
+		base.Reason = "alias targets do not map to a supported package identity"
+		coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnresolvedAlias, Path: base.From, Detail: fmt.Sprintf("alias %q has no deterministic package identity", base.Specifier)})
+		return base
+	}
+	if len(outcomes) == 1 {
+		base.Status = outcomes[0].status
+		base.Package = outcomes[0].identity
+		base.Reason = outcomes[0].reason
+		return base
+	}
+
+	base.Status = jsresolution.StatusAmbiguous
+	base.Package = jsresolution.PackageIdentity{}
+	base.Candidates = make([]jsresolution.PackageIdentity, 0, len(outcomes))
+	for _, outcome := range outcomes {
+		base.Candidates = append(base.Candidates, outcome.identity)
+	}
+	sort.Slice(base.Candidates, func(i, j int) bool { return identityLess(base.Candidates[i], base.Candidates[j]) })
+	base.Candidates = deduplicatePackageIdentities(base.Candidates)
+	base.Reason = "alias maps to multiple viable package identities"
+	coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnresolvedAlias, Path: base.From, Detail: fmt.Sprintf("alias %q maps to multiple viable package identities", base.Specifier)})
+	return base
+}
+
+func resolveAliasTargets(
+	mapping aliasMapping,
+	target string,
+	workspaces map[string][]jsresolution.PackageIdentity,
+	packages []jsresolution.PackageMetadata,
+	modulePaths map[string]struct{},
+	maxCandidates int,
+) ([]resolvedAliasTarget, jsresolution.CoverageIssueKind) {
+	if mapping.kind == aliasPackageImports && !strings.HasPrefix(target, "./") {
+		classified := jsresolution.ClassifySpecifier(target)
+		switch classified.Kind {
+		case jsresolution.SpecifierBuiltin:
+			return []resolvedAliasTarget{{status: jsresolution.StatusBuiltin, identity: jsresolution.PackageIdentity{Name: classified.BuiltinName}, reason: "resolved through package.json imports"}}, ""
+		case jsresolution.SpecifierPackage:
+			local := workspaces[classified.PackageName]
+			if len(local) == 0 {
+				return []resolvedAliasTarget{{status: jsresolution.StatusUnresolved, identity: jsresolution.PackageIdentity{Name: classified.PackageName}, reason: "package.json imports target is an npm package root; SBOM correlation is deferred to R2C"}}, ""
+			}
+			// A package.json imports target names a package, not a concrete
+			// workspace path. Without importer/lockfile selection, a same-name
+			// registry package remains viable just as it does for a bare import.
+			if len(local) >= maxCandidates {
+				return nil, jsresolution.CoverageMetadataBudgetExceeded
+			}
+			out := make([]resolvedAliasTarget, 0, len(local)+1)
+			for _, candidate := range local {
+				out = append(out, resolvedAliasTarget{status: jsresolution.StatusWorkspace, identity: candidate, reason: "package.json imports target matches a local workspace"})
+			}
+			out = append(out, resolvedAliasTarget{
+				status:   jsresolution.StatusUnresolved,
+				identity: jsresolution.PackageIdentity{Name: classified.PackageName},
+				reason:   "package.json imports target may resolve to a registry package; importer/lockfile correlation is deferred to R2C",
+			})
+			return out, ""
+		default:
+			return nil, jsresolution.CoverageUnsupportedAlias
+		}
+	}
+
+	base := mapping.baseDir
+	joined := path.Clean(path.Join(base, target))
+	if strings.HasPrefix(target, "/") || hasDeclaredWindowsVolume(target) || joined == ".." || strings.HasPrefix(joined, "../") {
+		return nil, jsresolution.CoverageWorkspaceRootEscape
+	}
+	joined = strings.TrimPrefix(joined, "./")
+	if joined == "" {
+		joined = "."
+	}
+	if mapping.kind == aliasPackageImports {
+		// Node package-import targets beginning with ./ are confined to the
+		// declaring package and cannot traverse into node_modules.
+		if !pathWithin(mapping.scopeDir, joined) {
+			return nil, jsresolution.CoverageWorkspaceRootEscape
+		}
+		if containsPathSegment(joined, "node_modules") {
+			return nil, jsresolution.CoverageUnsupportedAlias
+		}
+	}
+	pkg, ok := packageForRepositoryTarget(packages, joined)
+	if !ok {
+		return nil, jsresolution.CoverageUnresolvedAlias
+	}
+	if mapping.kind == aliasTSConfigPaths && !observedTSAliasTarget(joined, modulePaths, mapping.moduleResolution) {
+		// TypeScript paths entries are substitutions followed by file resolution.
+		// If the substituted first-party target is not observable in the source
+		// graph, TypeScript may fall back to the original bare package specifier.
+		// Refuse to call it local without positive source evidence.
+		return nil, jsresolution.CoverageUnresolvedAlias
+	}
+	identity := packageMetadataIdentity(pkg)
+	if pkg.Workspace {
+		if pkg.Name == "" {
+			return nil, jsresolution.CoverageUnresolvedAlias
+		}
+		return []resolvedAliasTarget{{status: jsresolution.StatusWorkspace, identity: identity, reason: aliasResolutionReason(mapping.kind)}}, ""
+	}
+	return []resolvedAliasTarget{{status: jsresolution.StatusLocal, identity: identity, reason: aliasResolutionReason(mapping.kind)}}, ""
+}
+
+func aliasResolutionReason(kind aliasKind) string {
+	if kind == aliasPackageImports {
+		return "resolved through package.json imports"
+	}
+	return "resolved through tsconfig/jsconfig paths"
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_alias_test.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_alias_test.go
@@ -1,0 +1,177 @@
+package jsresolve
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestResolverDeterministicAcrossRepeatedRuns(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "workspaces": []string{"packages/*"}})
+	writeJSON(t, r2bJoin(root, "packages", "shared", "package.json"), map[string]any{"name": "@repo/shared"})
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript}},
+		Edges: []modulegraph.Edge{
+			{From: "src/index.ts", Specifier: "lodash/fp", Kind: modulegraph.ImportESMStatic},
+			{From: "src/index.ts", Specifier: "@repo/shared", Kind: modulegraph.ImportCommonJS},
+			{From: "src/index.ts", Specifier: "node:fs", Kind: modulegraph.ImportESMStatic},
+		},
+	}
+	resolver := NewResolver()
+	first, err := resolver.Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		got, err := resolver.Resolve(context.Background(), root, graph, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(first, got) {
+			t.Fatalf("run %d differs\nfirst=%#v\ngot=%#v", i, first, got)
+		}
+	}
+}
+
+func TestResolverHardFailuresForInvalidGraphAndCancellation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	resolver := NewResolver()
+	if _, err := resolver.Resolve(context.Background(), root, modulegraph.Graph{}, nil); err == nil || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("empty graph error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := resolver.Resolve(ctx, root, graphWithExternal("src/index.ts", "fs"), nil); err != context.Canceled {
+		t.Fatalf("canceled resolver error = %v", err)
+	}
+}
+
+func TestResolverTSPathsCanResolveNonNPMAliasSyntax(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{"compilerOptions":{"moduleResolution":"bundler","paths":{"@/*":["src/*"]}}}`)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "src/utils.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{{From: "src/index.ts", Specifier: "@/utils", Kind: modulegraph.ImportESMStatic}},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusLocal || got.Imports[0].Package.Path != "." || !got.Complete {
+		t.Fatalf("non-npm tsconfig alias resolution = %#v", got)
+	}
+}
+
+func TestResolverTSPathsMissingTargetCannotMasqueradeAsLocal(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{"compilerOptions":{"moduleResolution":"bundler","paths":{"*":["src/*"]}}}`)
+	got, err := NewResolver().Resolve(context.Background(), root, graphWithExternal("src/index.ts", "lodash"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := got.Imports[0]
+	if resolution.Status != jsresolution.StatusUnresolved || resolution.Package.Name != "" || !hasCoverageKind(got.Coverage, jsresolution.CoverageUnresolvedAlias) {
+		t.Fatalf("missing paths target was treated as local/package evidence: resolution=%#v coverage=%#v", resolution, got.Coverage)
+	}
+}
+
+func TestResolverBaseURLPreventsUnsafeBarePackageClassification(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{"compilerOptions":{"baseUrl":"src"}}`)
+	got, err := NewResolver().Resolve(context.Background(), root, graphWithExternal("src/index.ts", "lodash"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusUnresolved || got.Imports[0].Package.Name != "" || !hasCoverageKind(got.Coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("baseUrl bare package classification was not conservative: %#v", got)
+	}
+}
+
+func TestResolverMultipleTSConfigContextsDoNotGuess(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "workspaces": []string{"packages/*"}})
+	writeJSON(t, r2bJoin(root, "packages", "app", "package.json"), map[string]any{"name": "app"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{"compilerOptions":{"moduleResolution":"bundler","paths":{"@x/*":["src/*"]}}}`)
+	writeFile(t, r2bJoin(root, "packages", "app", "tsconfig.json"), `{"compilerOptions":{}}`)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "packages/app/src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "src/value.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{{From: "packages/app/src/index.ts", Specifier: "@x/value", Kind: modulegraph.ImportESMStatic}},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusUnresolved || !hasCoverageKind(got.Coverage, jsresolution.CoverageUnresolvedAlias) {
+		t.Fatalf("multiple tsconfig contexts were guessed: %#v", got)
+	}
+}
+
+func TestResolverTSConfigProjectSelectionDoesNotGuessAliasApplicability(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{"include":["src/special/**"],"compilerOptions":{"moduleResolution":"bundler","paths":{"@x/*":["src/*"]}}}`)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "src/value.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{{From: "src/index.ts", Specifier: "@x/value", Kind: modulegraph.ImportESMStatic}},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusUnresolved || !hasCoverageKind(got.Coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("explicit project selection was guessed: %#v", got)
+	}
+}
+
+func TestResolverPackageImportsPreservesWorkspaceAndRegistryAmbiguity(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+		"name": "root", "workspaces": []string{"packages/*"}, "imports": map[string]any{"#dup": "dup"},
+	})
+	writeJSON(t, r2bJoin(root, "packages", "a", "package.json"), map[string]any{"name": "dup"})
+	writeJSON(t, r2bJoin(root, "packages", "b", "package.json"), map[string]any{"name": "dup"})
+	got, err := NewResolver().Resolve(context.Background(), root, graphWithExternal("src/index.ts", "#dup"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := got.Imports[0]
+	if resolution.Status != jsresolution.StatusAmbiguous || len(resolution.Candidates) != 3 || !hasWorkspaceCandidate(resolution.Candidates, "dup", "packages/a") || !hasWorkspaceCandidate(resolution.Candidates, "dup", "packages/b") {
+		t.Fatalf("workspace/registry ambiguity was collapsed: %#v", resolution)
+	}
+	external := false
+	for _, candidate := range resolution.Candidates {
+		if candidate.Name == "dup" && !candidate.Workspace && candidate.Path == "" && candidate.Version == "" && candidate.PURL == "" {
+			external = true
+		}
+	}
+	if !external {
+		t.Fatalf("external package candidate was lost: %#v", resolution.Candidates)
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_contract_test.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_contract_test.go
@@ -1,0 +1,8 @@
+package jsresolve_test
+
+import (
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jsresolve"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.JSImportResolver = (*jsresolve.Resolver)(nil)

--- a/internal/infrastructure/tools/jsresolve/resolver_graph_test.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_graph_test.go
@@ -1,0 +1,198 @@
+package jsresolve
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestResolverRelativeEdgeRequiresGraphCoverage(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript}},
+		Edges:   []modulegraph.Edge{{From: "src/index.ts", Specifier: "./missing", Kind: modulegraph.ImportESMStatic}},
+	}
+	if _, err := NewResolver().Resolve(context.Background(), root, graph, nil); err == nil || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("uncovered unresolved relative edge error = %v", err)
+	}
+	graph.Coverage = []modulegraph.CoverageIssue{{Kind: modulegraph.CoverageUnresolvedRelativeImport, Path: "src/index.ts", Detail: "missing"}}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Imports) != 0 || len(got.GraphCoverage) != 1 {
+		t.Fatalf("covered unresolved relative edge handling = %#v", got)
+	}
+}
+
+func TestResolverRelativeCoverageMustMatchSourceLineWhenAvailable(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	graph := modulegraph.Graph{
+		Modules:  []modulegraph.Module{{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript}},
+		Edges:    []modulegraph.Edge{{From: "src/index.ts", Specifier: "./missing", Kind: modulegraph.ImportESMStatic, Position: modulegraph.Position{Line: 9, Column: 1}}},
+		Coverage: []modulegraph.CoverageIssue{{Kind: modulegraph.CoverageUnresolvedRelativeImport, Path: "src/index.ts", Line: 8, Detail: "different import"}},
+	}
+	if _, err := NewResolver().Resolve(context.Background(), root, graph, nil); err == nil || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("mismatched relative coverage line error = %v", err)
+	}
+}
+
+func TestResolverRejectsResolvedNonRelativeGraphEdge(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "src/local.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{{From: "src/index.ts", To: "src/local.ts", Specifier: "lodash", Kind: modulegraph.ImportESMStatic}},
+	}
+	if _, err := NewResolver().Resolve(context.Background(), root, graph, nil); err == nil || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("resolved non-relative edge error = %v", err)
+	}
+}
+
+func TestResolverLimitsAreInjectable(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	limits := defaultResolverLimits()
+	limits.maxEdges = 1
+	resolver := newResolverWithLimits(NewInventoryBuilder(), newAliasInventoryBuilder(), limits)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript}},
+		Edges: []modulegraph.Edge{
+			{From: "src/index.ts", Specifier: "fs", Kind: modulegraph.ImportESMStatic},
+			{From: "src/index.ts", Specifier: "path", Kind: modulegraph.ImportESMStatic},
+		},
+	}
+	if _, err := resolver.Resolve(context.Background(), root, graph, nil); err == nil || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("resolver edge budget error = %v", err)
+	}
+}
+
+func TestResolverRejectsAggregateBindingProduct(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	limits := defaultResolverLimits()
+	limits.maxTotalBindings = 1
+	resolver := newResolverWithLimits(NewInventoryBuilder(), newAliasInventoryBuilder(), limits)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript}},
+		Edges: []modulegraph.Edge{{
+			From: "src/index.ts", Specifier: "lodash", Kind: modulegraph.ImportESMStatic,
+			Bindings: []modulegraph.Binding{{Imported: "a", Local: "a"}, {Imported: "b", Local: "b"}},
+		}},
+	}
+	if _, err := resolver.Resolve(context.Background(), root, graph, nil); err == nil || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("aggregate binding budget error = %v", err)
+	}
+}
+
+func TestResolverRejectsExcessiveRepositoryPathDepth(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	limits := defaultResolverLimits()
+	limits.maxModulePathSegments = 3
+	resolver := newResolverWithLimits(NewInventoryBuilder(), newAliasInventoryBuilder(), limits)
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{{Path: "a/b/c/index.ts", Dialect: modulegraph.DialectTypeScript}}}
+	if _, err := resolver.Resolve(context.Background(), root, graph, nil); err == nil || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("path depth budget error = %v", err)
+	}
+}
+
+func TestResolverAliasWorkBudgetFailsClosed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+		"name":    "root",
+		"imports": map[string]any{"#a": "lodash", "#b": "react"},
+	})
+	limits := defaultResolverLimits()
+	limits.maxAliasWork = 1
+	resolver := newResolverWithLimits(NewInventoryBuilder(), newAliasInventoryBuilder(), limits)
+	got, err := resolver.Resolve(context.Background(), root, graphWithExternal("src/index.ts", "#b"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusUnresolved || !hasCoverageKind(got.Coverage, jsresolution.CoverageMetadataBudgetExceeded) {
+		t.Fatalf("alias work budget did not fail closed: %#v", got)
+	}
+}
+
+func TestResolverCandidateBudgetFailsClosedWithoutTruncating(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "workspaces": []string{"packages/*"}})
+	for _, name := range []string{"a", "b", "c"} {
+		writeJSON(t, r2bJoin(root, "packages", name, "package.json"), map[string]any{"name": "dup"})
+	}
+	limits := defaultResolverLimits()
+	limits.maxCandidates = 2
+	resolver := newResolverWithLimits(NewInventoryBuilder(), newAliasInventoryBuilder(), limits)
+	got, err := resolver.Resolve(context.Background(), root, graphWithExternal("src/index.ts", "dup"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := got.Imports[0]
+	if resolution.Status != jsresolution.StatusUnresolved || len(resolution.Candidates) != 0 || !hasCoverageKind(got.Coverage, jsresolution.CoverageMetadataBudgetExceeded) {
+		t.Fatalf("candidate overflow was truncated instead of failing closed: resolution=%#v coverage=%#v", resolution, got.Coverage)
+	}
+}
+
+func TestResolverAggregateCandidateWorkFailsClosed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "workspaces": []string{"packages/*"}})
+	writeJSON(t, r2bJoin(root, "packages", "shared", "package.json"), map[string]any{"name": "@repo/shared"})
+	limits := defaultResolverLimits()
+	limits.maxCandidateWork = 3
+	resolver := newResolverWithLimits(NewInventoryBuilder(), newAliasInventoryBuilder(), limits)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript}},
+		Edges: []modulegraph.Edge{
+			{From: "src/index.ts", Specifier: "@repo/shared", Kind: modulegraph.ImportESMStatic},
+			{From: "src/index.ts", Specifier: "@repo/shared/sub", Kind: modulegraph.ImportCommonJS},
+		},
+	}
+	got, err := resolver.Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ambiguous, budgeted := 0, 0
+	for _, resolution := range got.Imports {
+		switch {
+		case resolution.Status == jsresolution.StatusAmbiguous:
+			ambiguous++
+		case resolution.Status == jsresolution.StatusUnresolved && resolution.Reason == "package identity candidate work budget exceeded":
+			budgeted++
+		}
+	}
+	if ambiguous != 1 || budgeted != 1 || !hasCoverageKind(got.Coverage, jsresolution.CoverageMetadataBudgetExceeded) {
+		t.Fatalf("aggregate candidate work did not fail closed: %#v", got)
+	}
+}
+
+func TestResolverSamePackageNameDoesNotBecomeThirdPartyWithoutExportsSemantics(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "my-app"})
+	got, err := NewResolver().Resolve(context.Background(), root, graphWithExternal("src/index.ts", "my-app/subpath"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusUnresolved || got.Imports[0].Package.Name != "my-app" || !hasCoverageKind(got.Coverage, jsresolution.CoverageUnresolvedSpecifier) {
+		t.Fatalf("same-package self reference was treated as ordinary third-party: %#v", got)
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_helpers.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_helpers.go
@@ -1,0 +1,196 @@
+package jsresolve
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+// packageContextForImporter finds the nearest observed package.json boundary.
+// contexts are normalized and sorted by scopeDir by aliasInventoryBuilder, so
+// each ancestor lookup is logarithmic instead of scanning every package scope
+// for every import edge.
+func packageContextForImporter(contexts []aliasPackageContext, importer string) (aliasPackageContext, bool) {
+	for scope := repositoryDirectory(importer); ; {
+		if context, ok := packageContextAtScope(contexts, scope); ok {
+			return context, true
+		}
+		parent, ok := parentRepositoryLocation(scope)
+		if !ok {
+			return aliasPackageContext{}, false
+		}
+		scope = parent
+	}
+}
+
+func packageContextAtScope(contexts []aliasPackageContext, scope string) (aliasPackageContext, bool) {
+	i := sort.Search(len(contexts), func(i int) bool { return contexts[i].scopeDir >= scope })
+	if i < len(contexts) && contexts[i].scopeDir == scope {
+		return contexts[i], true
+	}
+	return aliasPackageContext{}, false
+}
+
+// packageForRepositoryTarget finds the deepest package containing target.
+// Inventory packages are normalized and sorted by Path, so walking the finite
+// ancestor chain and binary-searching exact roots avoids an edge×package scan.
+func packageForRepositoryTarget(packages []jsresolution.PackageMetadata, target string) (jsresolution.PackageMetadata, bool) {
+	for candidate := target; ; {
+		if pkg, ok := packageAtPath(packages, candidate); ok {
+			return pkg, true
+		}
+		parent, ok := parentRepositoryLocation(candidate)
+		if !ok {
+			return jsresolution.PackageMetadata{}, false
+		}
+		candidate = parent
+	}
+}
+
+func packageAtPath(packages []jsresolution.PackageMetadata, target string) (jsresolution.PackageMetadata, bool) {
+	i := sort.Search(len(packages), func(i int) bool { return packages[i].Path >= target })
+	if i < len(packages) && packages[i].Path == target {
+		return packages[i], true
+	}
+	return jsresolution.PackageMetadata{}, false
+}
+
+func packageMetadataIdentity(pkg jsresolution.PackageMetadata) jsresolution.PackageIdentity {
+	return jsresolution.PackageIdentity{
+		Name: pkg.Name, Version: pkg.Version, Workspace: pkg.Workspace, Path: pkg.Path,
+	}
+}
+
+func pathWithin(scope, candidate string) bool {
+	if scope == "" || scope == "." {
+		return candidate != "" && candidate != ".." && !strings.HasPrefix(candidate, "../")
+	}
+	return candidate == scope || strings.HasPrefix(candidate, scope+"/")
+}
+
+func containsPathSegment(value, segment string) bool {
+	for _, part := range strings.Split(value, "/") {
+		if part == segment {
+			return true
+		}
+	}
+	return false
+}
+
+func repositorySegmentCount(value string) int {
+	if value == "" {
+		return 0
+	}
+	return 1 + strings.Count(value, "/") + strings.Count(value, "\\")
+}
+
+func repositoryDirectory(value string) string {
+	if slash := strings.LastIndexByte(value, '/'); slash >= 0 {
+		if slash == 0 {
+			return "."
+		}
+		return value[:slash]
+	}
+	return "."
+}
+
+func parentRepositoryLocation(value string) (string, bool) {
+	if value == "" || value == "." {
+		return "", false
+	}
+	if slash := strings.LastIndexByte(value, '/'); slash >= 0 {
+		if slash == 0 {
+			return ".", true
+		}
+		return value[:slash], true
+	}
+	return ".", true
+}
+
+// relativeEdgeHasCoverage performs at most one binary search for each relevant
+// coverage kind. modulegraph.Normalize orders coverage by kind, path and line,
+// so unresolved relative edges do not create an edge×coverage scan.
+func relativeEdgeHasCoverage(coverage []modulegraph.CoverageIssue, edge modulegraph.Edge) bool {
+	for _, kind := range [...]modulegraph.CoverageIssueKind{
+		modulegraph.CoverageUnresolvedRelativeImport,
+		modulegraph.CoverageAmbiguousRelativeImport,
+		modulegraph.CoverageRelativeImportEscapesRoot,
+	} {
+		line := 0
+		if edge.Position.Line > 0 {
+			line = edge.Position.Line
+		}
+		i := sort.Search(len(coverage), func(i int) bool {
+			issue := coverage[i]
+			if issue.Kind != kind {
+				return issue.Kind > kind
+			}
+			if issue.Path != edge.From {
+				return issue.Path > edge.From
+			}
+			return issue.Line >= line
+		})
+		if i >= len(coverage) {
+			continue
+		}
+		issue := coverage[i]
+		if issue.Kind != kind || issue.Path != edge.From {
+			continue
+		}
+		if edge.Position.Line <= 0 || issue.Line == edge.Position.Line {
+			return true
+		}
+	}
+	return false
+}
+
+func identityLess(a, b jsresolution.PackageIdentity) bool {
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	if a.Version != b.Version {
+		return a.Version < b.Version
+	}
+	if a.PURL != b.PURL {
+		return a.PURL < b.PURL
+	}
+	if a.Workspace != b.Workspace {
+		return !a.Workspace && b.Workspace
+	}
+	return a.Path < b.Path
+}
+
+func deduplicatePackageIdentities(in []jsresolution.PackageIdentity) []jsresolution.PackageIdentity {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, value := range in[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func deduplicateAliasOutcomes(in []resolvedAliasTarget) []resolvedAliasTarget {
+	if len(in) < 2 {
+		return in
+	}
+	sort.Slice(in, func(i, j int) bool {
+		if in[i].status != in[j].status {
+			return in[i].status < in[j].status
+		}
+		return identityLess(in[i].identity, in[j].identity)
+	})
+	out := in[:1]
+	for _, value := range in[1:] {
+		last := out[len(out)-1]
+		if value.status != last.status || value.identity != last.identity {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_helpers_test.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_helpers_test.go
@@ -1,0 +1,96 @@
+package jsresolve
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+func graphWithExternal(from, specifier string) modulegraph.Graph {
+	return modulegraph.Graph{
+		Modules: []modulegraph.Module{{Path: from, Dialect: modulegraph.DialectTypeScript}},
+		Edges:   []modulegraph.Edge{{From: from, Specifier: specifier, Kind: modulegraph.ImportESMStatic}},
+	}
+}
+
+func resolutionsBySpecifier(values []jsresolution.ImportResolution) map[string]jsresolution.ImportResolution {
+	out := make(map[string]jsresolution.ImportResolution, len(values))
+	for _, value := range values {
+		out[value.Specifier] = value
+	}
+	return out
+}
+
+func r2bJoin(parts ...string) string {
+	return filepath.Join(parts...)
+}
+
+func TestPackageForRepositoryTargetUsesDeepestSortedAncestor(t *testing.T) {
+	t.Parallel()
+	packages := []jsresolution.PackageMetadata{
+		{Name: "root", Path: "."},
+		{Name: "container", Path: "packages"},
+		{Name: "app", Path: "packages/app"},
+	}
+	got, ok := packageForRepositoryTarget(packages, "packages/app/src/index.ts")
+	if !ok || got.Path != "packages/app" || got.Name != "app" {
+		t.Fatalf("nearest package = %#v, %v", got, ok)
+	}
+	got, ok = packageForRepositoryTarget(packages, "src/index.ts")
+	if !ok || got.Path != "." || got.Name != "root" {
+		t.Fatalf("root package = %#v, %v", got, ok)
+	}
+}
+
+func TestPackageContextForImporterUsesNearestSortedScope(t *testing.T) {
+	t.Parallel()
+	contexts := []aliasPackageContext{
+		{source: "package.json", scopeDir: ".", importsPresent: true},
+		{source: "packages/app/package.json", scopeDir: "packages/app", importsPresent: true},
+	}
+	got, ok := packageContextForImporter(contexts, "packages/app/src/index.ts")
+	if !ok || got.scopeDir != "packages/app" {
+		t.Fatalf("nearest package scope = %#v, %v", got, ok)
+	}
+	got, ok = packageContextForImporter(contexts, "src/index.ts")
+	if !ok || got.scopeDir != "." {
+		t.Fatalf("root package scope = %#v, %v", got, ok)
+	}
+}
+
+func TestRelativeEdgeCoverageLookupRequiresMatchingLineWhenPresent(t *testing.T) {
+	t.Parallel()
+	coverage := []modulegraph.CoverageIssue{
+		{Kind: modulegraph.CoverageUnresolvedRelativeImport, Path: "src/index.ts", Line: 8, Detail: "first"},
+		{Kind: modulegraph.CoverageUnresolvedRelativeImport, Path: "src/index.ts", Line: 9, Detail: "second"},
+	}
+	edge := modulegraph.Edge{From: "src/index.ts", Position: modulegraph.Position{Line: 9}}
+	if !relativeEdgeHasCoverage(coverage, edge) {
+		t.Fatal("matching line was not found")
+	}
+	edge.Position.Line = 10
+	if relativeEdgeHasCoverage(coverage, edge) {
+		t.Fatal("different line incorrectly matched coverage")
+	}
+	edge.Position.Line = 0
+	if !relativeEdgeHasCoverage(coverage, edge) {
+		t.Fatal("line-less edge did not match source coverage")
+	}
+}
+
+func TestResolverUnknownNodeSchemeDoesNotBecomeBuiltin(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	got, err := NewResolver().Resolve(context.Background(), root, graphWithExternal("src/index.ts", "node:not-a-real-builtin"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Imports) != 1 || got.Imports[0].Status != jsresolution.StatusUnsupported || got.Complete ||
+		!hasCoverageKind(got.Coverage, jsresolution.CoverageUnsupportedSpecifier) {
+		t.Fatalf("unknown node: specifier was trusted as builtin: %#v", got)
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_package.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_package.go
@@ -1,0 +1,133 @@
+package jsresolve
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+)
+
+func indexWorkspacesByName(packages []jsresolution.PackageMetadata) map[string][]jsresolution.PackageIdentity {
+	out := make(map[string][]jsresolution.PackageIdentity)
+	for _, pkg := range packages {
+		if !pkg.Workspace || pkg.Name == "" {
+			continue
+		}
+		identity := packageMetadataIdentity(pkg)
+		out[pkg.Name] = append(out[pkg.Name], identity)
+	}
+	for name := range out {
+		sort.Slice(out[name], func(i, j int) bool { return identityLess(out[name][i], out[name][j]) })
+		out[name] = deduplicatePackageIdentities(out[name])
+	}
+	return out
+}
+
+func (r *Resolver) resolvePackageRoot(
+	base jsresolution.ImportResolution,
+	packageName string,
+	workspaces map[string][]jsresolution.PackageIdentity,
+	candidateWork *resolverWorkBudget,
+	coverage *resolutionCoverageSink,
+) jsresolution.ImportResolution {
+	local := workspaces[packageName]
+	if len(local) == 0 {
+		base.Status = jsresolution.StatusUnresolved
+		base.Package = jsresolution.PackageIdentity{Name: packageName}
+		base.Reason = "npm package root classified; SBOM component correlation deferred to R2C"
+		return base
+	}
+
+	// A workspace declaration proves that a local package with this name exists,
+	// but it does not prove that a particular importer resolves to that workspace.
+	// npm-family managers may install a registry package of the same name when an
+	// importer's requested range or lockfile context does not select the local
+	// workspace. R2C owns that importer/lockfile disambiguation. Until then,
+	// preserve both identities rather than turning workspace discovery into false
+	// package identity confidence.
+	if len(local) >= r.limits.maxCandidates {
+		base.Status = jsresolution.StatusUnresolved
+		base.Package = jsresolution.PackageIdentity{Name: packageName}
+		base.Reason = "workspace plus external package identity candidate budget exceeded"
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageMetadataBudgetExceeded, Path: base.From,
+			Detail: fmt.Sprintf("workspace/importer candidate budget exceeded for %q (%d)", packageName, r.limits.maxCandidates),
+		})
+		return base
+	}
+	if !candidateWork.consumeN(len(local) + 1) {
+		return markCandidateBudgetExceeded(base, candidateWork, coverage, r.limits.maxCandidateWork)
+	}
+
+	candidates := make([]jsresolution.PackageIdentity, 0, len(local)+1)
+	candidates = append(candidates, local...)
+	candidates = append(candidates, jsresolution.PackageIdentity{Name: packageName})
+	sort.Slice(candidates, func(i, j int) bool { return identityLess(candidates[i], candidates[j]) })
+	candidates = deduplicatePackageIdentities(candidates)
+
+	base.Status = jsresolution.StatusAmbiguous
+	base.Candidates = candidates
+	base.Reason = "package name matches a local workspace, but importer and lockfile context are required to distinguish workspace linking from a registry package"
+	coverage.add(jsresolution.CoverageIssue{
+		Kind: jsresolution.CoverageUnresolvedSpecifier, Path: base.From,
+		Detail: fmt.Sprintf("specifier %q matches local workspace %q but importer/lockfile selection is deferred to R2C", base.Specifier, packageName),
+	})
+	return base
+}
+
+func (r *Resolver) resolvePackageImport(
+	ctx context.Context,
+	base jsresolution.ImportResolution,
+	mappings []aliasMapping,
+	packageScopes []aliasPackageContext,
+	scopeDiscoveryComplete bool,
+	workspaces map[string][]jsresolution.PackageIdentity,
+	packages []jsresolution.PackageMetadata,
+	aliasWork *resolverWorkBudget,
+	candidateWork *resolverWorkBudget,
+	coverage *resolutionCoverageSink,
+) jsresolution.ImportResolution {
+	if !scopeDiscoveryComplete {
+		base.Status = jsresolution.StatusUnresolved
+		base.Reason = "package scope discovery is incomplete, so a nearer package boundary may be unknown"
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageUnsupportedAlias, Path: base.From,
+			Detail: fmt.Sprintf("package import %q cannot be scoped safely because alias metadata discovery is incomplete", base.Specifier),
+		})
+		return base
+	}
+	scope, ok := packageContextForImporter(packageScopes, base.From)
+	if !ok {
+		base.Status = jsresolution.StatusUnresolved
+		base.Reason = "importer is not contained by an observed package.json boundary"
+		coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnresolvedAlias, Path: base.From, Detail: fmt.Sprintf("package import %q has no containing package scope", base.Specifier)})
+		return base
+	}
+	if scope.uncertain {
+		base.Status = jsresolution.StatusUnresolved
+		base.Reason = "nearest package.json boundary has incomplete or unsupported imports metadata"
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageUnsupportedAlias, Path: base.From,
+			Detail: fmt.Sprintf("package import %q cannot be resolved safely in package scope %q", base.Specifier, scope.scopeDir),
+		})
+		return base
+	}
+	if !scope.importsPresent {
+		base.Status = jsresolution.StatusUnresolved
+		base.Reason = "nearest package scope does not declare package.json imports"
+		coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnresolvedAlias, Path: base.From, Detail: fmt.Sprintf("package import %q is not declared in package scope %q", base.Specifier, scope.scopeDir)})
+		return base
+	}
+	matches, exhausted := bestAliasMatchesInScope(ctx, mappings, aliasPackageImports, scope.scopeDir, base.Specifier, aliasWork)
+	if exhausted {
+		return markAliasBudgetExceeded(base, aliasWork, coverage, r.limits.maxAliasWork)
+	}
+	if len(matches) == 0 {
+		base.Status = jsresolution.StatusUnresolved
+		base.Reason = "no supported package.json imports mapping exists in the nearest package scope"
+		coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnresolvedAlias, Path: base.From, Detail: fmt.Sprintf("package import %q could not be resolved in package scope %q", base.Specifier, scope.scopeDir)})
+		return base
+	}
+	return r.resolveAliasMatches(ctx, base, matches, workspaces, packages, nil, aliasWork, candidateWork, coverage)
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_safety_test.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_safety_test.go
@@ -1,0 +1,153 @@
+package jsresolve
+
+import (
+	"context"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"testing"
+)
+
+func TestResolverUnsupportedExactPackageImportCannotFallThroughToWildcard(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, r2bJoin(root, "package.json"), `{
+  "name":"root",
+  "imports":{
+    "#x":{"default":"lodash"},
+    "#*":"left-pad"
+  }
+}`)
+	got, err := NewResolver().Resolve(context.Background(), root, graphWithExternal("src/index.ts", "#x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := got.Imports[0]
+	if resolution.Status != jsresolution.StatusUnresolved || resolution.Package.Name != "" {
+		t.Fatalf("unsupported exact imports entry fell through to wildcard: %#v", resolution)
+	}
+	if !hasCoverageKind(got.Coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("missing unsupported alias coverage: %#v", got.Coverage)
+	}
+}
+
+func TestResolverMalformedNestedPackageBoundaryPreventsParentImportsLeak(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, r2bJoin(root, "package.json"), `{"name":"root","imports":{"#x":"lodash"}}`)
+	writeFile(t, r2bJoin(root, "packages", "app", "package.json"), `{not-json`)
+
+	got, err := NewResolver().Resolve(context.Background(), root, graphWithExternal("packages/app/src/index.ts", "#x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := got.Imports[0]
+	if resolution.Status != jsresolution.StatusUnresolved || resolution.Package.Name != "" {
+		t.Fatalf("parent imports mapping leaked through malformed nested package boundary: %#v", resolution)
+	}
+	if got.Complete || !hasCoverageKind(got.Coverage, jsresolution.CoverageMalformedMetadata) {
+		t.Fatalf("malformed nested package did not keep resolution incomplete: %#v", got)
+	}
+}
+
+func TestResolverPartialTSPathsConfigCannotProduceCertainAliasIdentity(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{
+  "compilerOptions":{"moduleResolution":"bundler","paths":{"@ok/*":["src/*"],"@bad/*":["node_modules/pkg/*"]}}
+}`)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "src/value.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{{From: "src/index.ts", Specifier: "@ok/value", Kind: modulegraph.ImportESMStatic}},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusUnresolved || got.Complete {
+		t.Fatalf("partial tsconfig paths produced a certain identity: %#v", got)
+	}
+}
+
+func TestResolverWorkspaceSelfReferenceRequiresExportsSemantics(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "private": true})
+	writeFile(t, r2bJoin(root, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n")
+
+	got, err := NewResolver().Resolve(context.Background(), root, graphWithExternal("src/index.ts", "root"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := got.Imports[0]
+	if resolution.Status != jsresolution.StatusUnresolved || resolution.Package.Name != "root" || !hasCoverageKind(got.Coverage, jsresolution.CoverageUnresolvedSpecifier) {
+		t.Fatalf("workspace self-reference bypassed exports uncertainty: resolution=%#v coverage=%#v", resolution, got.Coverage)
+	}
+}
+
+func TestResolverTSConfigPathsFallsBackAfterMissingFirstTarget(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "workspaces": []string{"packages/*"}})
+	writeJSON(t, r2bJoin(root, "packages", "b", "package.json"), map[string]any{"name": "b"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{"compilerOptions":{"moduleResolution":"bundler","paths":{"@alias/*":["missing/*","packages/b/*"]}}}`)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "packages/b/value.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{{From: "src/index.ts", Specifier: "@alias/value", Kind: modulegraph.ImportESMStatic}},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusWorkspace || got.Imports[0].Package.Path != "packages/b" || !got.Complete {
+		t.Fatalf("paths fallback after missing first target = %#v", got)
+	}
+}
+
+func TestResolverTSConfigUnknownResolutionModeDoesNotAssumeExtensionlessLookup(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{"compilerOptions":{"paths":{"@app/*":["src/*"]}}}`)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "src/value.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{{From: "src/index.ts", Specifier: "@app/value", Kind: modulegraph.ImportESMStatic}},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusUnresolved || !hasCoverageKind(got.Coverage, jsresolution.CoverageUnresolvedAlias) {
+		t.Fatalf("unknown moduleResolution guessed extensionless lookup: %#v", got)
+	}
+}
+
+func TestResolverTSConfigStrictNodeAllowsExplicitJSExtensionSubstitution(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{"compilerOptions":{"moduleResolution":"nodenext","paths":{"@app":["src/value.js"]}}}`)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "src/value.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{{From: "src/index.ts", Specifier: "@app", Kind: modulegraph.ImportESMStatic}},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Imports[0].Status != jsresolution.StatusLocal || got.Imports[0].Package.Path != "." || !got.Complete {
+		t.Fatalf("explicit .js extension substitution was not recognized conservatively: %#v", got)
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_test.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_test.go
@@ -1,0 +1,211 @@
+package jsresolve
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+func TestResolverClassifiesBuiltinsWorkspaceCandidatesPackagesAndPreservesEdgeSemantics(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+		"name":       "root-app",
+		"private":    true,
+		"workspaces": []string{"packages/*"},
+	})
+	writeJSON(t, r2bJoin(root, "packages", "shared", "package.json"), map[string]any{"name": "@repo/shared", "version": "1.2.3"})
+
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "types/api.d.ts", Dialect: modulegraph.DialectTypeScript, DeclarationOnly: true},
+			{Path: "src/local.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{
+			{From: "src/index.ts", Specifier: "fs/promises", Kind: modulegraph.ImportCommonJS, Position: modulegraph.Position{Line: 1, Column: 1}},
+			{From: "src/index.ts", Specifier: "lodash/fp", Kind: modulegraph.ImportESMStatic, Position: modulegraph.Position{Line: 2, Column: 1}},
+			{From: "src/index.ts", Specifier: "@repo/shared/subpath", Kind: modulegraph.ImportESMDynamic, Position: modulegraph.Position{Line: 3, Column: 1}},
+			{From: "types/api.d.ts", Specifier: "@repo/shared", Kind: modulegraph.ImportESMStatic, TypeOnly: true, Position: modulegraph.Position{Line: 1, Column: 1}},
+			{From: "src/index.ts", To: "src/local.ts", Specifier: "./local", Kind: modulegraph.ImportESMStatic},
+		},
+		Coverage: []modulegraph.CoverageIssue{{Kind: modulegraph.CoverageDynamicImport, Path: "src/index.ts", Line: 9, Detail: "dynamic import"}},
+	}
+
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Imports) != 4 {
+		t.Fatalf("imports = %#v", got.Imports)
+	}
+	bySpecifier := resolutionsBySpecifier(got.Imports)
+	if fs := bySpecifier["fs/promises"]; fs.Status != jsresolution.StatusBuiltin || fs.Package.Name != "node:fs/promises" {
+		t.Fatalf("builtin resolution = %#v", fs)
+	}
+	if lodash := bySpecifier["lodash/fp"]; lodash.Status != jsresolution.StatusUnresolved || lodash.Package.Name != "lodash" {
+		t.Fatalf("third-party package root = %#v", lodash)
+	}
+	if shared := bySpecifier["@repo/shared/subpath"]; shared.Status != jsresolution.StatusAmbiguous || !hasWorkspaceCandidate(shared.Candidates, "@repo/shared", "packages/shared") || shared.Kind != modulegraph.ImportESMDynamic {
+		t.Fatalf("workspace/external ambiguity = %#v", shared)
+	}
+	if decl := bySpecifier["@repo/shared"]; decl.Status != jsresolution.StatusAmbiguous || !decl.TypeOnly || !decl.DeclarationOnly || !hasWorkspaceCandidate(decl.Candidates, "@repo/shared", "packages/shared") {
+		t.Fatalf("declaration/type-only semantics = %#v", decl)
+	}
+	if !hasCoverageKind(got.Coverage, jsresolution.CoverageUnresolvedSpecifier) {
+		t.Fatalf("missing workspace/importer ambiguity coverage: %#v", got.Coverage)
+	}
+	if len(got.GraphCoverage) != 1 || got.GraphCoverage[0].Kind != modulegraph.CoverageDynamicImport {
+		t.Fatalf("graph coverage not preserved: %#v", got.GraphCoverage)
+	}
+	if got.Complete {
+		t.Fatal("R2B result with uncorrelated package identities reported complete")
+	}
+}
+
+func TestResolverPackageImportsUsesNearestPackageScope(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+		"name": "root", "imports": map[string]any{"#root": "lodash"},
+	})
+	writeJSON(t, r2bJoin(root, "packages", "app", "package.json"), map[string]any{"name": "app"})
+
+	graph := graphWithExternal("packages/app/src/index.ts", "#root")
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Imports) != 1 || got.Imports[0].Status != jsresolution.StatusUnresolved || got.Imports[0].Package.Name != "" {
+		t.Fatalf("ancestor package imports mapping leaked across package scope: %#v", got.Imports)
+	}
+	if !hasCoverageKind(got.Coverage, jsresolution.CoverageUnresolvedAlias) {
+		t.Fatalf("missing unresolved alias coverage: %#v", got.Coverage)
+	}
+}
+
+func TestResolverPackageImportsCanResolveWorkspacePathAndExternalPackage(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+		"name":       "root",
+		"workspaces": []string{"packages/*"},
+		"imports": map[string]any{
+			"#shared/*": "./packages/shared/src/*",
+			"#dep":      "lodash/fp",
+		},
+	})
+	writeJSON(t, r2bJoin(root, "packages", "shared", "package.json"), map[string]any{"name": "@repo/shared"})
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript}},
+		Edges: []modulegraph.Edge{
+			{From: "src/index.ts", Specifier: "#shared/util", Kind: modulegraph.ImportESMStatic},
+			{From: "src/index.ts", Specifier: "#dep", Kind: modulegraph.ImportESMStatic},
+		},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bySpecifier := resolutionsBySpecifier(got.Imports)
+	if shared := bySpecifier["#shared/util"]; shared.Status != jsresolution.StatusWorkspace || shared.Package.Name != "@repo/shared" {
+		t.Fatalf("package imports workspace resolution = %#v", shared)
+	}
+	if dep := bySpecifier["#dep"]; dep.Status != jsresolution.StatusUnresolved || dep.Package.Name != "lodash" {
+		t.Fatalf("package imports external resolution = %#v", dep)
+	}
+}
+
+func TestResolverTSConfigPathsSupportsJSONCWorkspaceAndLocalAliases(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+		"name": "root", "private": true, "workspaces": []string{"packages/*"},
+	})
+	writeJSON(t, r2bJoin(root, "packages", "shared", "package.json"), map[string]any{"name": "@repo/shared"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{
+  // ordinary JSONC is supported without executing tsc
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["packages/shared/src/*",],
+      "@app/*": ["src/*"],
+    },
+  },
+}`)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "src/config.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "packages/shared/src/logger.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{
+			{From: "src/index.ts", Specifier: "@shared/logger", Kind: modulegraph.ImportESMStatic},
+			{From: "src/index.ts", Specifier: "@app/config", Kind: modulegraph.ImportESMStatic},
+		},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bySpecifier := resolutionsBySpecifier(got.Imports)
+	if shared := bySpecifier["@shared/logger"]; shared.Status != jsresolution.StatusWorkspace || shared.Package.Path != "packages/shared" {
+		t.Fatalf("tsconfig workspace alias = %#v", shared)
+	}
+	if local := bySpecifier["@app/config"]; local.Status != jsresolution.StatusLocal || local.Package.Path != "." || local.Package.Workspace {
+		t.Fatalf("tsconfig local alias = %#v", local)
+	}
+	if !got.Complete {
+		t.Fatalf("fully local/builtin alias resolution unexpectedly incomplete: coverage=%#v imports=%#v", got.Coverage, got.Imports)
+	}
+}
+
+func TestResolverTSConfigPathsUsesFirstSuccessfulFallback(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "workspaces": []string{"packages/*"}})
+	writeJSON(t, r2bJoin(root, "packages", "a", "package.json"), map[string]any{"name": "a"})
+	writeJSON(t, r2bJoin(root, "packages", "b", "package.json"), map[string]any{"name": "b"})
+	writeFile(t, r2bJoin(root, "tsconfig.json"), `{"compilerOptions":{"moduleResolution":"bundler","paths":{"@alias/*":["packages/a/*","packages/b/*"]}}}`)
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{
+			{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "packages/a/value.ts", Dialect: modulegraph.DialectTypeScript},
+			{Path: "packages/b/value.ts", Dialect: modulegraph.DialectTypeScript},
+		},
+		Edges: []modulegraph.Edge{{From: "src/index.ts", Specifier: "@alias/value", Kind: modulegraph.ImportESMStatic}},
+	}
+	got, err := NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolution := got.Imports[0]
+	if resolution.Status != jsresolution.StatusWorkspace || resolution.Package.Path != "packages/a" || len(resolution.Candidates) != 0 {
+		t.Fatalf("paths fallback did not stop at the first successful target: %#v coverage=%#v", resolution, got.Coverage)
+	}
+}
+
+func TestResolverUnsupportedConditionalImportsCannotLookComplete(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeFile(t, r2bJoin(root, "package.json"), `{"name":"root","imports":{"#x":{"node":"./x.js","default":"./y.js"}}}`)
+	got, err := NewResolver().Resolve(context.Background(), root, graphWithExternal("src/index.ts", "#x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Complete || got.Imports[0].Status != jsresolution.StatusUnresolved || !hasCoverageKind(got.Coverage, jsresolution.CoverageUnsupportedAlias) {
+		t.Fatalf("unsupported conditional mapping looked complete: %#v", got)
+	}
+}
+
+func hasWorkspaceCandidate(values []jsresolution.PackageIdentity, name, path string) bool {
+	for _, candidate := range values {
+		if candidate.Name == name && candidate.Path == path && candidate.Workspace {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_ts.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_ts.go
@@ -1,0 +1,265 @@
+package jsresolve
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+)
+
+func (r *Resolver) resolveTSPaths(
+	ctx context.Context,
+	base jsresolution.ImportResolution,
+	mappings []aliasMapping,
+	configs []aliasConfigContext,
+	scopeDiscoveryComplete bool,
+	workspaces map[string][]jsresolution.PackageIdentity,
+	packages []jsresolution.PackageMetadata,
+	modulePaths map[string]struct{},
+	aliasWork *resolverWorkBudget,
+	candidateWork *resolverWorkBudget,
+	coverage *resolutionCoverageSink,
+) (jsresolution.ImportResolution, bool) {
+	if !scopeDiscoveryComplete {
+		base.Status = jsresolution.StatusUnresolved
+		base.Reason = "alias metadata discovery is incomplete, so a nearer tsconfig/jsconfig context may be unknown"
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageUnsupportedAlias, Path: base.From,
+			Detail: fmt.Sprintf("specifier %q cannot be classified safely because alias metadata discovery is incomplete", base.Specifier),
+		})
+		return base, true
+	}
+	matches, contextState := bestTSAliasMatches(ctx, mappings, configs, base.From, base.Specifier, aliasWork)
+	switch contextState {
+	case tsAliasContextBudget:
+		return markAliasBudgetExceeded(base, aliasWork, coverage, r.limits.maxAliasWork), true
+	case tsAliasContextUnsupported:
+		base.Status = jsresolution.StatusUnresolved
+		base.Package = jsresolution.PackageIdentity{}
+		base.Reason = "applicable tsconfig/jsconfig context uses unsupported project-selection or inheritance semantics"
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageUnsupportedAlias, Path: base.From,
+			Detail: fmt.Sprintf("specifier %q is under an alias context R2B cannot apply safely", base.Specifier),
+		})
+		return base, true
+	case tsAliasContextAmbiguous:
+		base.Status = jsresolution.StatusUnresolved
+		base.Package = jsresolution.PackageIdentity{}
+		base.Reason = "multiple applicable tsconfig/jsconfig contexts make alias selection ambiguous"
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageUnresolvedAlias, Path: base.From,
+			Detail: fmt.Sprintf("specifier %q has multiple applicable tsconfig/jsconfig contexts", base.Specifier),
+		})
+		return base, true
+	case tsAliasContextBaseURL:
+		base.Status = jsresolution.StatusUnresolved
+		base.Package = jsresolution.PackageIdentity{}
+		base.Reason = "tsconfig/jsconfig baseUrl may change bare-specifier identity and R2B does not reproduce TypeScript file resolution"
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageUnsupportedAlias, Path: base.From,
+			Detail: fmt.Sprintf("specifier %q is under a tsconfig/jsconfig baseUrl without a supported paths match", base.Specifier),
+		})
+		return base, true
+	}
+	if len(matches) == 0 {
+		return base, false
+	}
+	return r.resolveAliasMatches(ctx, base, matches, workspaces, packages, modulePaths, aliasWork, candidateWork, coverage), true
+}
+
+func bestAliasMatchesInScope(ctx context.Context, mappings []aliasMapping, kind aliasKind, scopeDir, specifier string, budget *resolverWorkBudget) ([]aliasMapping, bool) {
+	var scoped []aliasMapping
+	for _, mapping := range mappings {
+		if ctx.Err() != nil || !budget.consume() {
+			return nil, true
+		}
+		if mapping.kind != kind || mapping.scopeDir != scopeDir {
+			continue
+		}
+		if _, ok := aliasCapture(mapping.pattern, specifier); ok {
+			scoped = append(scoped, mapping)
+		}
+	}
+	return mostSpecificAliasMappings(scoped), false
+}
+
+type tsAliasContextState uint8
+
+const (
+	tsAliasContextNone tsAliasContextState = iota
+	tsAliasContextBaseURL
+	tsAliasContextAmbiguous
+	tsAliasContextUnsupported
+	tsAliasContextBudget
+)
+
+func bestTSAliasMatches(ctx context.Context, mappings []aliasMapping, configs []aliasConfigContext, importer, specifier string, budget *resolverWorkBudget) ([]aliasMapping, tsAliasContextState) {
+	var applicable []aliasConfigContext
+	for _, config := range configs {
+		if ctx.Err() != nil || !budget.consume() {
+			return nil, tsAliasContextBudget
+		}
+		if pathWithin(config.scopeDir, importer) {
+			applicable = append(applicable, config)
+		}
+	}
+	if len(applicable) == 0 {
+		return nil, tsAliasContextNone
+	}
+	for _, config := range applicable {
+		if config.uncertain {
+			return nil, tsAliasContextUnsupported
+		}
+	}
+
+	matchedBySource := make(map[string][]aliasMapping)
+	for _, mapping := range mappings {
+		if ctx.Err() != nil || !budget.consume() {
+			return nil, tsAliasContextBudget
+		}
+		if mapping.kind != aliasTSConfigPaths || !pathWithin(mapping.scopeDir, importer) {
+			continue
+		}
+		if _, ok := aliasCapture(mapping.pattern, specifier); ok {
+			matchedBySource[mapping.source] = append(matchedBySource[mapping.source], mapping)
+		}
+	}
+
+	if len(applicable) > 1 {
+		for _, config := range applicable {
+			if config.hasBaseURL {
+				return nil, tsAliasContextAmbiguous
+			}
+		}
+		if len(matchedBySource) > 0 {
+			return nil, tsAliasContextAmbiguous
+		}
+	}
+	if len(applicable) == 1 {
+		config := applicable[0]
+		if matches := matchedBySource[config.source]; len(matches) > 0 {
+			return mostSpecificAliasMappings(matches), tsAliasContextNone
+		}
+		if config.hasBaseURL {
+			return nil, tsAliasContextBaseURL
+		}
+	}
+	return nil, tsAliasContextNone
+}
+
+func mostSpecificAliasMappings(scoped []aliasMapping) []aliasMapping {
+	if len(scoped) < 2 {
+		return scoped
+	}
+	if scoped[0].kind == aliasTSConfigPaths {
+		bestPrefix := -1
+		var out []aliasMapping
+		for _, mapping := range scoped {
+			prefix, _ := aliasSpecificity(mapping.pattern)
+			if prefix > bestPrefix {
+				bestPrefix = prefix
+				out = out[:0]
+			}
+			if prefix == bestPrefix {
+				out = append(out, mapping)
+			}
+		}
+		sort.Slice(out, func(i, j int) bool { return aliasMappingLess(out[i], out[j]) })
+		return out
+	}
+
+	// Node package-import pattern precedence compares the prefix before '*' first
+	// and then the total pattern length (equivalent here to suffix length once
+	// the prefix is tied). Exact keys rank above patterns.
+	bestPrefix, bestSuffix := -1, -1
+	var out []aliasMapping
+	for _, mapping := range scoped {
+		prefix, suffix := aliasSpecificity(mapping.pattern)
+		if prefix > bestPrefix || (prefix == bestPrefix && suffix > bestSuffix) {
+			bestPrefix, bestSuffix = prefix, suffix
+			out = out[:0]
+		}
+		if prefix == bestPrefix && suffix == bestSuffix {
+			out = append(out, mapping)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return aliasMappingLess(out[i], out[j]) })
+	return out
+}
+
+func aliasSpecificity(pattern string) (int, int) {
+	star := strings.IndexByte(pattern, '*')
+	if star < 0 {
+		return len(pattern) + 1, len(pattern) + 1
+	}
+	return star, len(pattern) - star - 1
+}
+
+func aliasCapture(pattern, specifier string) (string, bool) {
+	star := strings.IndexByte(pattern, '*')
+	if star < 0 {
+		return "", pattern == specifier
+	}
+	prefix, suffix := pattern[:star], pattern[star+1:]
+	if !strings.HasPrefix(specifier, prefix) || !strings.HasSuffix(specifier, suffix) || len(specifier) < len(prefix)+len(suffix) {
+		return "", false
+	}
+	return specifier[len(prefix) : len(specifier)-len(suffix)], true
+}
+
+func substituteAliasTarget(target, capture string) string {
+	if star := strings.IndexByte(target, '*'); star >= 0 {
+		return target[:star] + capture + target[star+1:]
+	}
+	return target
+}
+
+func observedTSAliasTarget(target string, modules map[string]struct{}, mode aliasModuleResolution) bool {
+	if len(modules) == 0 {
+		return false
+	}
+	if _, ok := modules[target]; ok {
+		return true
+	}
+
+	// Extension substitution is valid across TypeScript module-resolution modes
+	// when the paths target names a JavaScript-family file explicitly.
+	var substitutions []string
+	switch {
+	case strings.HasSuffix(target, ".mjs"):
+		base := strings.TrimSuffix(target, ".mjs")
+		substitutions = []string{base + ".mts", base + ".d.mts"}
+	case strings.HasSuffix(target, ".cjs"):
+		base := strings.TrimSuffix(target, ".cjs")
+		substitutions = []string{base + ".cts", base + ".d.cts"}
+	case strings.HasSuffix(target, ".js"):
+		base := strings.TrimSuffix(target, ".js")
+		substitutions = []string{base + ".ts", base + ".tsx", base + ".d.ts"}
+	case strings.HasSuffix(target, ".jsx"):
+		base := strings.TrimSuffix(target, ".jsx")
+		substitutions = []string{base + ".tsx", base + ".d.ts"}
+	}
+	for _, candidate := range substitutions {
+		if _, ok := modules[candidate]; ok {
+			return true
+		}
+	}
+	if mode != aliasModuleResolutionExtensionless {
+		return false
+	}
+	if path.Ext(target) != "" {
+		return false
+	}
+	for _, ext := range [...]string{".ts", ".tsx", ".d.ts", ".js", ".jsx"} {
+		if _, ok := modules[target+ext]; ok {
+			return true
+		}
+		if _, ok := modules[path.Join(target, "index"+ext)]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_types.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_types.go
@@ -1,0 +1,174 @@
+package jsresolve
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	defaultMaxResolverModules            = 200000
+	defaultMaxResolverEdges              = 1000000
+	defaultMaxResolverGraphCoverage      = 200000
+	defaultMaxResolverBindingsPerEdge    = 4096
+	defaultMaxResolverTotalBindings      = 1000000
+	defaultMaxResolverSpecifierBytes     = 4096
+	defaultMaxResolverModulePathBytes    = 32768
+	defaultMaxResolverModulePathSegments = 256
+	defaultMaxResolverAliasWork          = 1000000
+	defaultMaxResolverCandidateWork      = 1000000
+	defaultMaxResolverCandidates         = 256
+	defaultMaxResolverCoverage           = 4096
+)
+
+type resolverLimits struct {
+	maxModules            int
+	maxEdges              int
+	maxGraphCoverage      int
+	maxBindingsPerEdge    int
+	maxTotalBindings      int
+	maxSpecifierBytes     int
+	maxModulePathBytes    int
+	maxModulePathSegments int
+	maxAliasWork          int
+	maxCandidateWork      int
+	maxCandidates         int
+	maxCoverageIssues     int
+}
+
+func defaultResolverLimits() resolverLimits {
+	return resolverLimits{
+		maxModules:            defaultMaxResolverModules,
+		maxEdges:              defaultMaxResolverEdges,
+		maxGraphCoverage:      defaultMaxResolverGraphCoverage,
+		maxBindingsPerEdge:    defaultMaxResolverBindingsPerEdge,
+		maxTotalBindings:      defaultMaxResolverTotalBindings,
+		maxSpecifierBytes:     defaultMaxResolverSpecifierBytes,
+		maxModulePathBytes:    defaultMaxResolverModulePathBytes,
+		maxModulePathSegments: defaultMaxResolverModulePathSegments,
+		maxAliasWork:          defaultMaxResolverAliasWork,
+		maxCandidateWork:      defaultMaxResolverCandidateWork,
+		maxCandidates:         defaultMaxResolverCandidates,
+		maxCoverageIssues:     defaultMaxResolverCoverage,
+	}
+}
+
+func (l resolverLimits) validate() error {
+	if l.maxModules <= 0 || l.maxEdges <= 0 || l.maxGraphCoverage <= 0 || l.maxBindingsPerEdge <= 0 ||
+		l.maxTotalBindings <= 0 || l.maxSpecifierBytes <= 0 || l.maxModulePathBytes <= 0 || l.maxModulePathSegments <= 0 ||
+		l.maxAliasWork <= 0 || l.maxCandidateWork <= 0 || l.maxCandidates <= 0 || l.maxCoverageIssues <= 0 {
+		return fmt.Errorf("%w: resolver limits must be positive", shared.ErrValidation)
+	}
+	return nil
+}
+
+// Resolver resolves source module specifiers to built-in, local, workspace, or
+// package-root identities. R2B deliberately leaves third-party SBOM component
+// correlation unresolved for R2C.
+type Resolver struct {
+	inventory *InventoryBuilder
+	aliases   *aliasInventoryBuilder
+	limits    resolverLimits
+}
+
+// NewResolver returns a bounded, deterministic and offline JS/TS specifier resolver.
+func NewResolver() *Resolver {
+	return &Resolver{
+		inventory: NewInventoryBuilder(),
+		aliases:   newAliasInventoryBuilder(),
+		limits:    defaultResolverLimits(),
+	}
+}
+
+func newResolverWithLimits(inventory *InventoryBuilder, aliases *aliasInventoryBuilder, limits resolverLimits) *Resolver {
+	return &Resolver{inventory: inventory, aliases: aliases, limits: limits}
+}
+
+type resolutionCoverageSink struct {
+	issues []jsresolution.CoverageIssue
+	limit  int
+	capped bool
+}
+
+func (s *resolutionCoverageSink) add(issue jsresolution.CoverageIssue) {
+	if s.capped {
+		return
+	}
+	if len(s.issues) < s.limit-1 {
+		s.issues = append(s.issues, issue)
+		return
+	}
+	budget := jsresolution.CoverageIssue{
+		Kind:   jsresolution.CoverageMetadataBudgetExceeded,
+		Path:   ".",
+		Detail: fmt.Sprintf("resolution coverage issue budget exceeded (%d)", s.limit),
+	}
+	if len(s.issues) < s.limit {
+		s.issues = append(s.issues, budget)
+	} else {
+		s.issues[s.limit-1] = budget
+	}
+	s.capped = true
+}
+
+func (s *resolutionCoverageSink) addAll(issues []jsresolution.CoverageIssue) {
+	for _, issue := range issues {
+		s.add(issue)
+		if s.capped {
+			return
+		}
+	}
+}
+
+type resolverWorkBudget struct {
+	remaining int
+	exceeded  bool
+	reported  bool
+}
+
+func (b *resolverWorkBudget) consume() bool {
+	return b.consumeN(1)
+}
+
+func (b *resolverWorkBudget) consumeN(n int) bool {
+	if b == nil || n == 0 {
+		return true
+	}
+	if n < 0 || b.remaining < n {
+		b.exceeded = true
+		return false
+	}
+	b.remaining -= n
+	return true
+}
+
+func markAliasBudgetExceeded(base jsresolution.ImportResolution, budget *resolverWorkBudget, coverage *resolutionCoverageSink, limit int) jsresolution.ImportResolution {
+	base.Status = jsresolution.StatusUnresolved
+	base.Package = jsresolution.PackageIdentity{}
+	base.Candidates = nil
+	base.Reason = "alias resolution work budget exceeded"
+	if budget != nil && !budget.reported {
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageMetadataBudgetExceeded, Path: ".",
+			Detail: fmt.Sprintf("alias resolution work budget exceeded (%d)", limit),
+		})
+		budget.reported = true
+	}
+	return base
+}
+
+func markCandidateBudgetExceeded(base jsresolution.ImportResolution, budget *resolverWorkBudget, coverage *resolutionCoverageSink, limit int) jsresolution.ImportResolution {
+	base.Status = jsresolution.StatusUnresolved
+	base.Package = jsresolution.PackageIdentity{}
+	base.Candidates = nil
+	base.Reason = "package identity candidate work budget exceeded"
+	if budget != nil && !budget.reported {
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageMetadataBudgetExceeded, Path: ".",
+			Detail: fmt.Sprintf("package identity candidate work budget exceeded (%d)", limit),
+		})
+		budget.reported = true
+	}
+	return base
+}


### PR DESCRIPTION
## Summary

Continues #400 with R2B: deterministic, source-only JavaScript/TypeScript module-specifier classification and alias resolution on top of the R2A workspace metadata foundation merged in #404.

This slice remains conservative by design: it resolves only identities supported by source metadata, preserves ambiguity/incomplete coverage, and does **not** make reachability judgments or emit OpenVEX.

### Included

* deterministic JS/TS module-specifier classification
* bounded offline `package.json#imports` and `tsconfig.json` / `jsconfig.json` alias inventory
* `baseUrl` and `paths` resolution with longest-prefix and ordered fallback behavior
* Node builtin, external package-root, scoped package-root, package-import, relative/local, and unsupported classification
* deterministic `ports.JSImportResolver` implementation preserving source edge metadata and graph coverage
* conservative workspace-vs-registry ambiguity handling until importer/lockfile evidence is available
* deterministic sorting/deduplication of resolutions, candidates, and coverage
* bounded metadata reads and explicit global work/candidate budgets
* no Node/package-manager/bundler/script execution and no network access

### Explicitly deferred to R2C

* lockfile importer/version disambiguation
* exact npm SBOM component/PURL correlation
* multiple-version correlation using importer/lockfile context
* final external-package component selection
* reachability judgments and OpenVEX

### Validation

Maintainer-style validation was run against the exact final R2B source:

* `gofmt`: PASS
* focused R2B tests: PASS
* focused race tests: PASS
* repeated shuffled tests (20x): PASS
* `golangci-lint`: PASS
* Linux build/vet/test: PASS
* CGO-disabled build: PASS
* `make build`: PASS
* `make vet`: PASS
* `make test`: PASS
* `make typecheck`: PASS
* web production build: PASS

The repository's standard CI currently has two unrelated baseline failures, both reproduced on a zero-diff branch whose tree is byte-identical to current upstream `main`:

1. Frontend `pnpm test` fails before executing tests with 29 Vitest worker-start errors rooted at:

   `TypeError: webidl.util.markAsUncloneable is not a function`

   in the jsdom/undici startup path.

2. Windows `go test ./...` fails in existing `cmd/synapse-agent` coverage:

   `TestFirstRunEnrolsAndPersists: credential must be 0600, got -rw-rw-rw-`

   The same failure occurs on the zero-diff upstream baseline. R2B packages themselves pass on Windows.

Neither baseline failure is introduced by this PR.

### Review notes

The implementation intentionally prefers `unresolved`, `ambiguous`, or incomplete coverage over inventing a unique package identity. In particular, workspace-name collisions are not treated as definitive workspace resolution until R2C has importer/lockfile evidence.

Refs #400
Parent #378
Depends on #379, merged via #399.
R2A merged via #404.
