### PR TITLE
feat(fleet): cluster-inventory to asset mapping core (#411)

### DIFF
--- a/internal/domain/clusterinventory/clusterinventory.go
+++ b/internal/domain/clusterinventory/clusterinventory.go
@@ -1,0 +1,95 @@
+// Package clusterinventory is the pure-domain core of the Kubernetes cluster agent (#411, epic
+// #405): it maps a vendor-neutral snapshot of a cluster to the fleet asset model (domain/asset).
+//
+// It is deliberately free of any Kubernetes type. The dependency rule (see CLAUDE.md) forbids a k8s
+// type in a domain package; the live client-go informer lives in infrastructure (a follow-up) and
+// converts API objects into the neutral Snapshot defined here, then this package maps that Snapshot
+// to asset kinds. Keeping the mapping pure makes the normative asset table testable without a cluster.
+//
+// Two invariants this package exists to hold:
+//   - Multi-cluster identity. Cluster identity is part of every non-image asset key, so two clusters
+//     with identical namespace/workload names never collide (requirement 9). Image keys are the bare
+//     digest, shared with image scanning (requirement 2).
+//   - Coverage honesty. A running image digest that was never scanned, a container whose digest could
+//     not be resolved, and a namespace outside the configured scope are all emitted as explicit
+//     coverage gaps naming the workload — never silently omitted or reported as clean (requirements
+//     2 and 8).
+package clusterinventory
+
+import (
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+)
+
+// GapKind classifies a cluster-inventory coverage gap.
+type GapKind string
+
+const (
+	// GapUnscannedDigest: a running container's image digest has no prior scan in the engine.
+	GapUnscannedDigest GapKind = "unscanned-digest"
+	// GapUnresolvedDigest: a running container exposes only a mutable tag; its digest is unknown, so
+	// what is actually running cannot be identified.
+	GapUnresolvedDigest GapKind = "unresolved-digest"
+	// GapOutOfScopeNamespace: a namespace exists on the cluster but is outside the configured scope,
+	// so it is reported out of scope rather than as clean.
+	GapOutOfScopeNamespace GapKind = "out-of-scope-namespace"
+	// GapNoContainers: a workload was observed with no containers, so what it runs could not be
+	// enumerated. Reported so "couldn't read the pod template" is never indistinguishable from
+	// "assessed and running nothing".
+	GapNoContainers GapKind = "no-containers"
+	// GapNamespaceNotObserved: a namespace the operator put in scope was never seen in the snapshot,
+	// so an expected-but-unobserved namespace is not mistaken for "in scope and empty".
+	GapNamespaceNotObserved GapKind = "namespace-not-observed"
+)
+
+// Valid reports whether g is a known gap kind.
+func (g GapKind) Valid() bool {
+	switch g {
+	case GapUnscannedDigest, GapUnresolvedDigest, GapOutOfScopeNamespace, GapNoContainers, GapNamespaceNotObserved:
+		return true
+	default:
+		return false
+	}
+}
+
+// CoverageGap is one reason the cluster inventory is not fully trustworthy. Workload names the
+// affected workload (or namespace) so an operator can act; empty when not workload-scoped.
+type CoverageGap struct {
+	Kind     GapKind
+	Workload string // "<namespace>/<kind>/<name>" or a namespace, whichever the gap concerns
+	Detail   string
+}
+
+// AssetRef is a natural-key reference to an asset: the mapper does not mint surrogate ids or resolve
+// edge endpoints (those come from the store's upsert-by-(kind,key)); it emits (Kind, Key) references
+// that a usecase later resolves to ids when persisting.
+type AssetRef struct {
+	Kind asset.Kind
+	Key  string
+}
+
+// ObservedAsset is an asset the mapper observed, addressed by its natural key. A usecase upserts it
+// via (TenantID, Kind, Key); Name defaults to Key downstream when empty.
+type ObservedAsset struct {
+	Kind       asset.Kind
+	Key        string
+	Name       string
+	Attributes map[string]string
+}
+
+// Ref returns the natural-key reference to this observed asset.
+func (o ObservedAsset) Ref() AssetRef { return AssetRef{Kind: o.Kind, Key: o.Key} }
+
+// ObservedEdge is a typed relationship between two observed assets, addressed by natural key.
+type ObservedEdge struct {
+	From AssetRef
+	To   AssetRef
+	Kind asset.EdgeKind
+}
+
+// Inventory is the mapper's output: the observed assets, their relationships, and the coverage gaps.
+type Inventory struct {
+	Cluster string
+	Assets  []ObservedAsset
+	Edges   []ObservedEdge
+	Gaps    []CoverageGap
+}

--- a/internal/domain/clusterinventory/mapper.go
+++ b/internal/domain/clusterinventory/mapper.go
@@ -1,0 +1,318 @@
+package clusterinventory
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Snapshot is the vendor-neutral view of a cluster the infrastructure informer produces and this
+// package maps. No Kubernetes type appears here — that is the whole point of the boundary.
+type Snapshot struct {
+	Cluster    string      // cluster identity; part of every non-image asset key (multi-cluster)
+	InScope    []string    // namespaces in scope; empty means every namespace is in scope
+	Namespaces []Namespace // observed namespaces (both in and out of scope)
+}
+
+// Namespace is one observed namespace and its contents.
+type Namespace struct {
+	Name             string
+	HasNetworkPolicy bool // whether any NetworkPolicy exists in the namespace (exposure posture)
+	Workloads        []Workload
+	Exposures        []Exposure
+	ServiceAccounts  []string // service account names declared in the namespace
+}
+
+// Workload is a controller (Deployment/StatefulSet/DaemonSet/...) and its containers.
+type Workload struct {
+	Kind           string // controller kind
+	Name           string
+	ServiceAccount string // service account the pods run as; empty means "default"
+	Containers     []Container
+}
+
+// Container is one running container, with the resolved image digest when known.
+type Container struct {
+	Name   string
+	Image  string // image reference as declared (may be a mutable tag)
+	Digest string // resolved image digest; empty means unresolved
+}
+
+// Exposure is a Service or Ingress and the workloads it fronts.
+type Exposure struct {
+	Name    string
+	Type    string   // ClusterIP / NodePort / LoadBalancer / Ingress
+	Hosts   []string // ingress hosts, when any
+	Targets []Target // workloads this exposure fronts
+}
+
+// Target references the workload an exposure fronts, by controller kind + name (same namespace).
+type Target struct {
+	Kind string
+	Name string
+}
+
+// Validate reports whether the snapshot can be mapped: cluster identity is mandatory because it is
+// part of every asset key, and an empty tenant/cluster would poison the multi-cluster invariant.
+func (s Snapshot) Validate() error {
+	c := strings.TrimSpace(s.Cluster)
+	if c == "" {
+		return fmt.Errorf("%w: cluster identity is required (it keys every asset)", shared.ErrValidation)
+	}
+	// Cluster identity is the one operator-controlled key segment; a '/' in it would let a crafted
+	// cluster name forge another cluster's namespaced keys, so the separator is rejected here rather
+	// than relying on the key builder to escape.
+	if strings.Contains(c, "/") {
+		return fmt.Errorf("%w: cluster identity must not contain '/'", shared.ErrValidation)
+	}
+	return nil
+}
+
+// Map maps a snapshot to observed assets, edges, and coverage gaps. scannedDigests is the set of
+// image digests the engine has already scanned; a running digest absent from it is a coverage gap.
+// Map assumes the snapshot is valid (see Validate); it is a pure, total function of its inputs, so
+// two calls on an unchanged snapshot yield identical, normalized output (idempotency).
+func Map(snap Snapshot, scannedDigests map[string]bool) Inventory {
+	cluster := strings.TrimSpace(snap.Cluster)
+	m := &mapping{
+		cluster:  cluster,
+		scanned:  scannedDigests,
+		assets:   map[AssetRef]ObservedAsset{},
+		edgeSeen: map[string]struct{}{},
+		gapSeen:  map[string]struct{}{},
+		inScope:  scopeSet(snap.InScope),
+	}
+
+	// The cluster itself.
+	clusterRef := m.addAsset(asset.KindCluster, cluster, cluster, map[string]string{})
+
+	observed := map[string]bool{}
+	for _, ns := range snap.Namespaces {
+		observed[ns.Name] = true
+		if !m.namespaceInScope(ns.Name) {
+			m.addGap(GapOutOfScopeNamespace, ns.Name, "namespace outside the configured scope; reported out of scope, not clean")
+			continue
+		}
+		m.mapNamespace(clusterRef, ns)
+	}
+	// A namespace the operator put in scope but the snapshot never contained is expected-but-unobserved,
+	// not "in scope and empty" — record it so a missed namespace is never mistaken for a clean one.
+	for ns := range m.inScope {
+		if !observed[ns] {
+			m.addGap(GapNamespaceNotObserved, ns, "namespace is in scope but was not observed in the cluster snapshot")
+		}
+	}
+
+	inv := Inventory{Cluster: cluster}
+	for _, a := range m.assets {
+		inv.Assets = append(inv.Assets, a)
+	}
+	inv.Edges = m.edges
+	inv.Gaps = m.gaps
+	return inv.Normalize()
+}
+
+type mapping struct {
+	cluster  string
+	scanned  map[string]bool
+	inScope  map[string]bool // nil means all in scope
+	assets   map[AssetRef]ObservedAsset
+	edges    []ObservedEdge
+	edgeSeen map[string]struct{}
+	gaps     []CoverageGap
+	gapSeen  map[string]struct{}
+}
+
+func (m *mapping) namespaceInScope(name string) bool {
+	if m.inScope == nil {
+		return true
+	}
+	return m.inScope[name]
+}
+
+func (m *mapping) mapNamespace(clusterRef AssetRef, ns Namespace) {
+	nsKey := joinKey(m.cluster, ns.Name)
+	m.addAsset(asset.KindNamespace, nsKey, ns.Name, map[string]string{
+		"cluster":        m.cluster,
+		"network_policy": presentAbsent(ns.HasNetworkPolicy),
+	})
+
+	// Identity assets for every declared service account, even ones no workload mounts.
+	for _, sa := range ns.ServiceAccounts {
+		m.addServiceAccount(ns.Name, sa)
+	}
+
+	for _, w := range ns.Workloads {
+		wlLabel := workloadLabel(ns.Name, w.Kind, w.Name)
+		wlKey := joinKey(m.cluster, ns.Name, w.Kind, w.Name)
+		wlRef := m.addAsset(asset.KindWorkload, wlKey, w.Name, map[string]string{
+			"cluster":         m.cluster,
+			"namespace":       ns.Name,
+			"controller_kind": w.Kind,
+			"service_account": defaultSA(w.ServiceAccount),
+		})
+		// cluster runs workload.
+		m.addEdge(clusterRef, wlRef, asset.EdgeRuns)
+
+		// workload mounts its service account identity.
+		idRef := m.addServiceAccount(ns.Name, defaultSA(w.ServiceAccount))
+		m.addEdge(wlRef, idRef, asset.EdgeMounts)
+
+		// A workload observed with no containers means what it runs could not be enumerated; record it
+		// so "couldn't read the pod template" is never indistinguishable from "running nothing".
+		if len(w.Containers) == 0 {
+			m.addGap(GapNoContainers, wlLabel, "workload has no observed containers; what it runs is unknown")
+		}
+		for _, c := range w.Containers {
+			digest := strings.TrimSpace(c.Digest)
+			if digest == "" {
+				m.addGap(GapUnresolvedDigest, wlLabel, "container "+c.Name+" image "+c.Image+" has no resolved digest")
+				continue
+			}
+			// The image asset is keyed by the bare digest and shared across clusters. The "image"
+			// attribute is a display hint only and is first-writer-wins on dedup — two references to the
+			// same digest under different tags keep whichever was mapped first; the digest is the identity.
+			imgRef := m.addAsset(asset.KindImage, digest, digest, map[string]string{"image": c.Image})
+			m.addEdge(wlRef, imgRef, asset.EdgeDependsOn)
+			if !m.scanned[digest] {
+				m.addGap(GapUnscannedDigest, wlLabel, "running digest "+digest+" ("+c.Image+") has no prior scan")
+			}
+		}
+	}
+
+	for _, e := range ns.Exposures {
+		// The exposure type is part of the key: a Service and an Ingress in one namespace may share a
+		// name, and without the type discriminator they would collide into one exposure asset.
+		exKey := joinKey(m.cluster, ns.Name, e.Type, e.Name)
+		exRef := m.addAsset(asset.KindExposure, exKey, e.Name, map[string]string{
+			"cluster":   m.cluster,
+			"namespace": ns.Name,
+			"type":      e.Type,
+			"hosts":     strings.Join(e.Hosts, ","),
+		})
+		for _, t := range e.Targets {
+			targetRef := AssetRef{Kind: asset.KindWorkload, Key: joinKey(m.cluster, ns.Name, t.Kind, t.Name)}
+			// exposure exposes workload — only when the target workload was actually observed, so the
+			// emitted graph is self-consistent (no edge to an asset that was never mapped). A stale or
+			// cross-namespace selector target is intentionally skipped rather than emitting a dangling edge.
+			if _, ok := m.assets[targetRef]; ok {
+				m.addEdge(exRef, targetRef, asset.EdgeExposes)
+			}
+		}
+	}
+}
+
+func (m *mapping) addServiceAccount(namespace, sa string) AssetRef {
+	sa = defaultSA(sa)
+	key := joinKey(m.cluster, namespace, sa)
+	return m.addAsset(asset.KindIdentity, key, sa, map[string]string{
+		"cluster":         m.cluster,
+		"namespace":       namespace,
+		"service_account": sa,
+	})
+}
+
+// addAsset registers an observed asset, deduplicating by natural key, and returns its ref.
+func (m *mapping) addAsset(kind asset.Kind, key, name string, attrs map[string]string) AssetRef {
+	ref := AssetRef{Kind: kind, Key: key}
+	if _, ok := m.assets[ref]; !ok {
+		m.assets[ref] = ObservedAsset{Kind: kind, Key: key, Name: name, Attributes: attrs}
+	}
+	return ref
+}
+
+// addEdge registers an edge, deduplicating by (from, to, kind).
+func (m *mapping) addEdge(from, to AssetRef, kind asset.EdgeKind) {
+	sig := string(from.Kind) + "|" + from.Key + "=>" + string(to.Kind) + "|" + to.Key + "#" + string(kind)
+	if _, ok := m.edgeSeen[sig]; ok {
+		return
+	}
+	m.edgeSeen[sig] = struct{}{}
+	m.edges = append(m.edges, ObservedEdge{From: from, To: to, Kind: kind})
+}
+
+func (m *mapping) addGap(kind GapKind, workload, detail string) {
+	sig := string(kind) + "|" + workload + "|" + detail
+	if _, ok := m.gapSeen[sig]; ok {
+		return
+	}
+	m.gapSeen[sig] = struct{}{}
+	m.gaps = append(m.gaps, CoverageGap{Kind: kind, Workload: workload, Detail: detail})
+}
+
+// Normalize deterministically orders assets, edges, and gaps so the mapping is idempotent: the same
+// snapshot always produces byte-identical output, which is what lets a re-sync avoid asset churn.
+func (inv Inventory) Normalize() Inventory {
+	out := inv
+	out.Assets = append([]ObservedAsset(nil), inv.Assets...)
+	sort.Slice(out.Assets, func(i, j int) bool {
+		if out.Assets[i].Kind != out.Assets[j].Kind {
+			return out.Assets[i].Kind < out.Assets[j].Kind
+		}
+		return out.Assets[i].Key < out.Assets[j].Key
+	})
+	out.Edges = append([]ObservedEdge(nil), inv.Edges...)
+	sort.Slice(out.Edges, func(i, j int) bool {
+		return edgeSortKey(out.Edges[i]) < edgeSortKey(out.Edges[j])
+	})
+	out.Gaps = append([]CoverageGap(nil), inv.Gaps...)
+	sort.Slice(out.Gaps, func(i, j int) bool {
+		if out.Gaps[i].Kind != out.Gaps[j].Kind {
+			return out.Gaps[i].Kind < out.Gaps[j].Kind
+		}
+		if out.Gaps[i].Workload != out.Gaps[j].Workload {
+			return out.Gaps[i].Workload < out.Gaps[j].Workload
+		}
+		return out.Gaps[i].Detail < out.Gaps[j].Detail
+	})
+	return out
+}
+
+func edgeSortKey(e ObservedEdge) string {
+	return string(e.From.Kind) + "|" + e.From.Key + "=>" + string(e.To.Kind) + "|" + e.To.Key + "#" + string(e.Kind)
+}
+
+// --- helpers ---
+
+func scopeSet(in []string) map[string]bool {
+	if len(in) == 0 {
+		return nil // empty = all in scope
+	}
+	s := make(map[string]bool, len(in))
+	for _, n := range in {
+		if n = strings.TrimSpace(n); n != "" {
+			s[n] = true
+		}
+	}
+	if len(s) == 0 {
+		return nil
+	}
+	return s
+}
+
+func joinKey(parts ...string) string {
+	clean := make([]string, 0, len(parts))
+	for _, p := range parts {
+		clean = append(clean, strings.TrimSpace(p))
+	}
+	return strings.Join(clean, "/")
+}
+
+func workloadLabel(namespace, kind, name string) string { return joinKey(namespace, kind, name) }
+
+func defaultSA(sa string) string {
+	if sa = strings.TrimSpace(sa); sa != "" {
+		return sa
+	}
+	return "default"
+}
+
+func presentAbsent(b bool) string {
+	if b {
+		return "present"
+	}
+	return "absent"
+}

--- a/internal/domain/clusterinventory/mapper_test.go
+++ b/internal/domain/clusterinventory/mapper_test.go
@@ -1,0 +1,291 @@
+package clusterinventory
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// sample builds a representative one-namespace snapshot for the given cluster.
+func sample(cluster string) Snapshot {
+	return Snapshot{
+		Cluster: cluster,
+		Namespaces: []Namespace{{
+			Name:             "payments",
+			HasNetworkPolicy: false,
+			ServiceAccounts:  []string{"default", "payments-sa"},
+			Workloads: []Workload{{
+				Kind:           "Deployment",
+				Name:           "api",
+				ServiceAccount: "payments-sa",
+				Containers: []Container{
+					{Name: "api", Image: "reg/api:v1", Digest: "sha256:aaa"},
+					{Name: "sidecar", Image: "reg/proxy:latest", Digest: ""}, // unresolved
+				},
+			}},
+			Exposures: []Exposure{{
+				Name:    "api-lb",
+				Type:    "LoadBalancer",
+				Hosts:   []string{"api.example.com"},
+				Targets: []Target{{Kind: "Deployment", Name: "api"}},
+			}},
+		}},
+	}
+}
+
+func assetByKind(inv Inventory, kind asset.Kind) []ObservedAsset {
+	var out []ObservedAsset
+	for _, a := range inv.Assets {
+		if a.Kind == kind {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func hasGap(inv Inventory, kind GapKind, workload string) bool {
+	for _, g := range inv.Gaps {
+		if g.Kind == kind && g.Workload == workload {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEdge(inv Inventory, k asset.EdgeKind, fromKind asset.Kind, toKind asset.Kind) bool {
+	for _, e := range inv.Edges {
+		if e.Kind == k && e.From.Kind == fromKind && e.To.Kind == toKind {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMapAssetsAndEdges(t *testing.T) {
+	inv := Map(sample("prod-eu"), map[string]bool{"sha256:aaa": true})
+
+	// One of each kind we expect.
+	for _, k := range []asset.Kind{asset.KindCluster, asset.KindNamespace, asset.KindWorkload, asset.KindImage, asset.KindExposure, asset.KindIdentity} {
+		if len(assetByKind(inv, k)) == 0 {
+			t.Errorf("expected at least one %q asset", k)
+		}
+	}
+	// The normative edges.
+	if !hasEdge(inv, asset.EdgeRuns, asset.KindCluster, asset.KindWorkload) {
+		t.Error("cluster runs workload edge missing")
+	}
+	if !hasEdge(inv, asset.EdgeDependsOn, asset.KindWorkload, asset.KindImage) {
+		t.Error("workload depends_on image edge missing")
+	}
+	if !hasEdge(inv, asset.EdgeExposes, asset.KindExposure, asset.KindWorkload) {
+		t.Error("exposure exposes workload edge missing")
+	}
+	if !hasEdge(inv, asset.EdgeMounts, asset.KindWorkload, asset.KindIdentity) {
+		t.Error("workload mounts identity edge missing")
+	}
+	// The workload key carries cluster + namespace + kind + name.
+	wls := assetByKind(inv, asset.KindWorkload)
+	if wls[0].Key != "prod-eu/payments/Deployment/api" {
+		t.Errorf("workload key = %q", wls[0].Key)
+	}
+	// The image key is the bare digest (shared with image scanning), NOT cluster-scoped.
+	imgs := assetByKind(inv, asset.KindImage)
+	if imgs[0].Key != "sha256:aaa" {
+		t.Errorf("image key must be the bare digest, got %q", imgs[0].Key)
+	}
+}
+
+func TestUnscannedAndUnresolvedDigestsAreGaps(t *testing.T) {
+	// api container's digest is NOT in the scanned set -> unscanned gap; sidecar has no digest ->
+	// unresolved gap. Both name the workload.
+	inv := Map(sample("prod-eu"), map[string]bool{}) // nothing scanned
+	if !hasGap(inv, GapUnscannedDigest, "payments/Deployment/api") {
+		t.Fatalf("a running digest with no prior scan must be a coverage gap naming the workload: %+v", inv.Gaps)
+	}
+	if !hasGap(inv, GapUnresolvedDigest, "payments/Deployment/api") {
+		t.Fatalf("a container with no resolved digest must be a coverage gap: %+v", inv.Gaps)
+	}
+	// When the digest IS scanned, no unscanned gap for it.
+	inv2 := Map(sample("prod-eu"), map[string]bool{"sha256:aaa": true})
+	if hasGap(inv2, GapUnscannedDigest, "payments/Deployment/api") {
+		t.Fatalf("a scanned digest must not be reported as unscanned: %+v", inv2.Gaps)
+	}
+}
+
+func TestOutOfScopeNamespaceReportedNotClean(t *testing.T) {
+	snap := sample("prod-eu")
+	snap.Namespaces = append(snap.Namespaces, Namespace{
+		Name:      "kube-system",
+		Workloads: []Workload{{Kind: "DaemonSet", Name: "kproxy", Containers: []Container{{Name: "c", Digest: "sha256:zzz"}}}},
+	})
+	snap.InScope = []string{"payments"} // kube-system is out of scope
+
+	inv := Map(snap, map[string]bool{})
+	if !hasGap(inv, GapOutOfScopeNamespace, "kube-system") {
+		t.Fatalf("an out-of-scope namespace must be reported as a gap, not silently clean: %+v", inv.Gaps)
+	}
+	// Its contents must NOT be mapped to assets (no kproxy workload, no sha256:zzz image).
+	for _, a := range inv.Assets {
+		if a.Kind == asset.KindWorkload && a.Name == "kproxy" {
+			t.Fatalf("out-of-scope workload must not be mapped: %+v", a)
+		}
+		if a.Kind == asset.KindImage && a.Key == "sha256:zzz" {
+			t.Fatalf("out-of-scope image must not be mapped: %+v", a)
+		}
+	}
+}
+
+func TestMultiClusterAssetsDoNotCollide(t *testing.T) {
+	// Two clusters with identical namespace + workload names must produce DISTINCT workload/namespace
+	// assets (cluster-scoped keys), but SHARE the image asset (bare digest).
+	a := Map(sample("prod-eu"), map[string]bool{"sha256:aaa": true})
+	b := Map(sample("prod-us"), map[string]bool{"sha256:aaa": true})
+
+	keyA := assetByKind(a, asset.KindWorkload)[0].Key
+	keyB := assetByKind(b, asset.KindWorkload)[0].Key
+	if keyA == keyB {
+		t.Fatalf("workload keys from different clusters must differ: %q == %q", keyA, keyB)
+	}
+	if got := assetByKind(a, asset.KindImage)[0].Key; got != assetByKind(b, asset.KindImage)[0].Key {
+		t.Fatalf("the same digest across clusters must be one shared image asset key")
+	}
+}
+
+func TestIdempotentMapping(t *testing.T) {
+	// Two syncs of an unchanged snapshot must produce identical output (no asset churn on resync).
+	scanned := map[string]bool{"sha256:aaa": true}
+	first := Map(sample("prod-eu"), scanned)
+	second := Map(sample("prod-eu"), scanned)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("mapping must be deterministic/idempotent")
+	}
+}
+
+func TestEmittedAssetsAreValidDomainAssets(t *testing.T) {
+	// Every observed asset must be constructible via asset.New (non-empty key, valid kind), so the
+	// downstream upsert cannot reject a mapped asset.
+	inv := Map(sample("prod-eu"), map[string]bool{"sha256:aaa": true})
+	tenant := shared.ID("tenant-1")
+	now := time.Unix(0, 0).UTC()
+	for _, oa := range inv.Assets {
+		if _, err := asset.New(shared.ID("id-x"), tenant, oa.Kind, oa.Key, oa.Name, oa.Attributes, now); err != nil {
+			t.Errorf("observed asset %+v is not a valid domain asset: %v", oa, err)
+		}
+	}
+}
+
+func TestValidateRequiresCluster(t *testing.T) {
+	if err := (Snapshot{Cluster: "  "}).Validate(); err == nil {
+		t.Fatal("a blank cluster identity must be rejected")
+	}
+	if err := (Snapshot{Cluster: "prod-eu"}).Validate(); err != nil {
+		t.Fatalf("a valid cluster must pass: %v", err)
+	}
+	// A '/' in the cluster identity is rejected so it cannot forge another cluster's namespaced keys.
+	if err := (Snapshot{Cluster: "prod/evil"}).Validate(); err == nil {
+		t.Fatal("a cluster identity containing '/' must be rejected")
+	}
+}
+
+func TestServiceAndIngressSameNameDoNotCollide(t *testing.T) {
+	// A Service and an Ingress named "api" in one namespace must produce two distinct exposure assets.
+	snap := Snapshot{
+		Cluster: "prod-eu",
+		Namespaces: []Namespace{{
+			Name: "payments",
+			Exposures: []Exposure{
+				{Name: "api", Type: "ClusterIP"},
+				{Name: "api", Type: "Ingress"},
+			},
+		}},
+	}
+	inv := Map(snap, map[string]bool{})
+	if got := len(assetByKind(inv, asset.KindExposure)); got != 2 {
+		t.Fatalf("a Service and an Ingress named api must be 2 exposure assets, got %d: %+v", got, assetByKind(inv, asset.KindExposure))
+	}
+}
+
+func TestEmptyContainersWorkloadIsAGap(t *testing.T) {
+	snap := Snapshot{
+		Cluster: "prod-eu",
+		Namespaces: []Namespace{{
+			Name:      "payments",
+			Workloads: []Workload{{Kind: "Deployment", Name: "ghost", Containers: nil}},
+		}},
+	}
+	inv := Map(snap, map[string]bool{})
+	if !hasGap(inv, GapNoContainers, "payments/Deployment/ghost") {
+		t.Fatalf("a workload with no containers must be a coverage gap, not silently clean: %+v", inv.Gaps)
+	}
+}
+
+func TestInScopeButUnobservedNamespaceIsAGap(t *testing.T) {
+	snap := sample("prod-eu")
+	snap.InScope = []string{"payments", "billing"} // billing is in scope but not in the snapshot
+	inv := Map(snap, map[string]bool{"sha256:aaa": true})
+	if !hasGap(inv, GapNamespaceNotObserved, "billing") {
+		t.Fatalf("an in-scope namespace never observed must be a coverage gap: %+v", inv.Gaps)
+	}
+	if hasGap(inv, GapNamespaceNotObserved, "payments") {
+		t.Fatalf("an observed in-scope namespace must not be flagged unobserved: %+v", inv.Gaps)
+	}
+}
+
+func TestExposesEdgeOnlyToObservedWorkload(t *testing.T) {
+	// An exposure targeting a workload that was never observed must NOT emit a dangling edge.
+	snap := Snapshot{
+		Cluster: "prod-eu",
+		Namespaces: []Namespace{{
+			Name: "payments",
+			Exposures: []Exposure{{
+				Name:    "api-lb",
+				Type:    "LoadBalancer",
+				Targets: []Target{{Kind: "Deployment", Name: "does-not-exist"}},
+			}},
+		}},
+	}
+	inv := Map(snap, map[string]bool{})
+	for _, e := range inv.Edges {
+		if e.Kind == asset.EdgeExposes {
+			t.Fatalf("no exposes edge should be emitted to an unobserved workload: %+v", e)
+		}
+	}
+}
+
+func TestGapsAreDeduplicated(t *testing.T) {
+	// Two identical containers (same name/image/digest, unscanned) must not double the gap.
+	snap := Snapshot{
+		Cluster: "prod-eu",
+		Namespaces: []Namespace{{
+			Name: "payments",
+			Workloads: []Workload{{Kind: "Deployment", Name: "api", Containers: []Container{
+				{Name: "c", Image: "reg/x:1", Digest: "sha256:dup"},
+				{Name: "c", Image: "reg/x:1", Digest: "sha256:dup"},
+			}}},
+		}},
+	}
+	inv := Map(snap, map[string]bool{})
+	n := 0
+	for _, g := range inv.Gaps {
+		if g.Kind == GapUnscannedDigest {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("identical unscanned-digest gaps must be deduplicated, got %d", n)
+	}
+}
+
+func TestGapKindValid(t *testing.T) {
+	for _, g := range []GapKind{GapUnscannedDigest, GapUnresolvedDigest, GapOutOfScopeNamespace} {
+		if !g.Valid() {
+			t.Errorf("%q should be valid", g)
+		}
+	}
+	if GapKind("bogus").Valid() {
+		t.Error("bogus gap kind should be invalid")
+	}
+}


### PR DESCRIPTION
## What

The pure-domain **cluster-inventory → fleet-asset mapping core** for the Kubernetes cluster agent (#411, epic #405). This is the first slice of a large issue: the normative asset-mapping table, the multi-cluster identity invariant, and coverage honesty — all as a pure, fully unit-tested function, with **no new dependencies**.

The live `client-go` informer, the read-only `ClusterRole` deployment manifest, the live config-rule evaluation, and the kind-based CI integration test are deferred follow-ups (see below). #411 stays open.

## Why domain-first / no client-go yet

The issue's engineering spec is explicit: *"No k8s type crosses into a domain package; map to asset domain types at the infra boundary."* So this package defines a **vendor-neutral `Snapshot`** (namespaces, workloads, containers+digests, exposures, service accounts — no `k8s.io` types) and maps it to the existing `domain/asset` model. A future `internal/infrastructure/k8sinv` informer will convert client-go objects into this `Snapshot`; keeping the mapping pure makes the normative table testable without a cluster and defers the heavyweight `client-go` supply-chain decision to the PR that actually needs it.

## How

`internal/domain/clusterinventory`:
- **Snapshot → assets/edges/gaps.** `Map(snap, scannedDigests)` emits `ObservedAsset`/`ObservedEdge` addressed by **natural key** (Kind+Key) — it does *not* mint surrogate IDs or resolve edge endpoints, because `assetuc.UpsertAsset` already resolves IDs by `(TenantID, Kind, Key)` on upsert. A later usecase wires these in.
- **Normative asset table** (from the issue): `cluster`, `namespace`, `workload`, `image`, `exposure`, `identity`, with edges `cluster runs workload`, `workload depends_on image`, `exposure exposes workload`, `workload mounts identity`.
- **Multi-cluster (req 9):** cluster identity is part of every non-image key (`<cluster>/<ns>/<kind>/<name>`), so two clusters with identical names never collide. Image keys are the **bare digest**, shared with image scanning (req 2).
- **Coverage honesty (reqs 2 & 8):** an unscanned running digest → `GapUnscannedDigest` (names the workload); an unresolved digest (mutable tag only) → `GapUnresolvedDigest`; an out-of-scope namespace → `GapOutOfScopeNamespace` *and its contents are not mapped* — reported out of scope, never as clean.
- **Idempotency (req: no resync churn):** `Map` is pure/total and `Normalize` sorts deterministically, so two syncs of an unchanged snapshot are byte-identical.

## Golden rules

Pure domain — no exec, no shell, no credentials, no LLM, no external I/O. Imports only `domain/asset`, `domain/shared`, and stdlib (dependency rule holds). Coverage honesty is the whole point of the gap model.

## Deferred (follow-ups on #411, which stays open)

- `internal/infrastructure/k8sinv` — client-go informers → `Snapshot` (watch/poll, page size, memory ceiling; reqs 3,7).
- `deploy/k8s/cluster-agent.yaml` — read-only `ClusterRole`; fail-loud on a missing permission (req 6).
- Live cluster-config evaluation via the existing `tools/misconfig` k8s rule pack on live objects (req 3).
- `cmd` composition (`--mode=cluster` or a sibling binary) + the usecase that upserts the mapped assets via `assetuc`.
- The kind-based CI integration test + the 10k-pod scale test (env-gated where a cluster exists).

## Tests

Table-driven: asset/edge production, unscanned + unresolved digest gaps naming the workload, out-of-scope namespace (gap + contents-not-mapped), multi-cluster non-collision + shared image, idempotency (`DeepEqual` across two syncs), a cross-check that every emitted `ObservedAsset` is constructible via `asset.New`, and `Validate`/`GapKind.Valid`. `go build ./... && go vet ./...` clean; `golangci-lint` 0 issues.
