### PR TITLE
feat(fleet): cluster-inventory usecase — persist mapped assets (#411)

### DIFF
--- a/internal/usecase/fleet/clusterinventory/service.go
+++ b/internal/usecase/fleet/clusterinventory/service.go
@@ -1,0 +1,161 @@
+// Package clusterinventory is the use-case layer for the Kubernetes cluster agent (#411, epic #405).
+// It takes a vendor-neutral cluster Snapshot (produced by the infrastructure informer — a follow-up),
+// maps it to the fleet asset model with the pure domain mapper, and persists the observed assets and
+// typed edges through the asset use case, reusing its idempotent upsert-by-natural-key + audit path.
+//
+// Coverage honesty is preserved end to end: the mapper's coverage gaps (unscanned/unresolved image
+// digests, workloads with no observed containers, out-of-scope and unobserved namespaces) are
+// returned to the caller and audited, never dropped. Re-syncing an unchanged cluster is idempotent —
+// producing no asset or edge churn — as long as the caller passes a STABLE per-cluster-source
+// Provenance (see SyncInput.Provenance): assets upsert by a provenance-free natural key, and edges
+// upsert by a natural key that INCLUDES provenance, so a stable provenance is what makes the edge set
+// converge instead of growing one row per observation.
+package clusterinventory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	dci "github.com/KKloudTarus/synapse-ce/internal/domain/clusterinventory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// AssetWriter is the subset of the asset use case this service needs: idempotent upsert of an asset
+// (resolving its stable id by natural key) and of a typed edge. assetuc.Service satisfies it; tests
+// use a fake. It is a consumer-side interface defined at the point of use so this package depends on
+// the asset service's behaviour, not its concrete type (it still references the assetuc input DTOs).
+type AssetWriter interface {
+	UpsertAsset(ctx context.Context, actor string, in assetuc.UpsertAssetInput) (*asset.Asset, error)
+	UpsertEdge(ctx context.Context, actor string, in assetuc.EdgeInput) error
+}
+
+// The concrete asset use case satisfies the consumer-side interface.
+var _ AssetWriter = (*assetuc.Service)(nil)
+
+// Service maps and persists a cluster inventory.
+type Service struct {
+	assets AssetWriter
+	audit  ports.AuditLogger
+	clock  ports.Clock
+}
+
+// NewService validates its dependencies and constructs the service.
+func NewService(assets AssetWriter, audit ports.AuditLogger, clock ports.Clock) (*Service, error) {
+	if assets == nil {
+		return nil, fmt.Errorf("%w: cluster inventory requires an asset writer", shared.ErrValidation)
+	}
+	if audit == nil {
+		return nil, fmt.Errorf("%w: cluster inventory requires an audit logger", shared.ErrValidation)
+	}
+	if clock == nil {
+		return nil, fmt.Errorf("%w: cluster inventory requires a clock", shared.ErrValidation)
+	}
+	return &Service{assets: assets, audit: audit, clock: clock}, nil
+}
+
+// SyncInput describes one observation of a cluster.
+type SyncInput struct {
+	TenantID shared.ID
+	Snapshot dci.Snapshot
+	// ScannedDigests is the set of image digests the engine has already scanned. A running digest
+	// absent from it becomes a coverage gap (never omitted). The informer/caller supplies it; a
+	// dedicated scanned-image lookup port is a follow-up.
+	ScannedDigests map[string]bool
+	// Provenance identifies the observation source that produced the assets/edges. It is required (an
+	// unattributable edge cannot be trusted by attack-path traversal) and MUST be STABLE for a given
+	// cluster source across syncs — e.g. derived from cluster identity, NOT a fresh per-sync id.
+	// assetuc keys an edge by (tenant, from, to, kind, provenance), so a per-sync provenance would mint
+	// a new edge row every observation (churn); a stable one lets the edge set converge.
+	Provenance shared.ID
+}
+
+// SyncResult reports what a sync produced. Gaps are the coverage gaps surfaced to the caller so a
+// partial inventory is visible, never silently treated as clean.
+type SyncResult struct {
+	Assets int
+	Edges  int
+	Gaps   []dci.CoverageGap
+}
+
+// Sync maps the snapshot to the asset model and persists it. It is idempotent: two syncs of an
+// unchanged cluster produce the same assets/edges and no churn.
+func (s *Service) Sync(ctx context.Context, actor string, in SyncInput) (*SyncResult, error) {
+	if strings.TrimSpace(actor) == "" {
+		return nil, fmt.Errorf("%w: cluster inventory actor is required", shared.ErrValidation)
+	}
+	if in.TenantID.IsZero() {
+		return nil, fmt.Errorf("%w: cluster inventory tenant id is required", shared.ErrValidation)
+	}
+	if in.Provenance.IsZero() {
+		return nil, fmt.Errorf("%w: cluster inventory provenance is required", shared.ErrValidation)
+	}
+	if err := in.Snapshot.Validate(); err != nil {
+		return nil, fmt.Errorf("cluster inventory: invalid snapshot: %w", err)
+	}
+
+	inv := dci.Map(in.Snapshot, in.ScannedDigests)
+
+	// Upsert every observed asset first, recording the resolved id per natural-key ref so edges can be
+	// wired. UpsertAsset resolves the stable id by (tenant, kind, key).
+	refToID := make(map[dci.AssetRef]shared.ID, len(inv.Assets))
+	for _, oa := range inv.Assets {
+		a, err := s.assets.UpsertAsset(ctx, actor, assetuc.UpsertAssetInput{
+			TenantID:   in.TenantID,
+			Kind:       oa.Kind,
+			Key:        oa.Key,
+			Name:       oa.Name,
+			Attributes: oa.Attributes,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("cluster inventory: upsert asset %s/%s: %w", oa.Kind, oa.Key, err)
+		}
+		refToID[oa.Ref()] = a.ID
+	}
+
+	edges := 0
+	for _, e := range inv.Edges {
+		from, okFrom := refToID[e.From]
+		to, okTo := refToID[e.To]
+		if !okFrom || !okTo {
+			// The mapper only emits edges between observed assets, so an unresolved endpoint means that
+			// invariant broke (a mapper bug/refactor). Fail loud rather than silently drop an attack-path
+			// edge — a silently incomplete graph is exactly the failure this platform must not produce.
+			return nil, fmt.Errorf("%w: cluster inventory: edge %s has an unresolved endpoint", shared.ErrValidation, e.Kind)
+		}
+		if err := s.assets.UpsertEdge(ctx, actor, assetuc.EdgeInput{
+			TenantID:   in.TenantID,
+			From:       from,
+			To:         to,
+			Kind:       e.Kind,
+			Provenance: in.Provenance,
+		}); err != nil {
+			return nil, fmt.Errorf("cluster inventory: upsert edge %s: %w", e.Kind, err)
+		}
+		edges++
+	}
+
+	// Audit the coverage gaps so a partial inventory is durably attributable, not just returned.
+	now := s.clock.Now()
+	for _, g := range inv.Gaps {
+		if err := s.audit.Record(ctx, ports.AuditEntry{
+			Actor:  actor,
+			Action: "cluster_inventory.coverage_gap",
+			Target: g.Workload,
+			Metadata: map[string]string{
+				"tenant_id": in.TenantID.String(),
+				"cluster":   inv.Cluster,
+				"gap_kind":  string(g.Kind),
+				"detail":    g.Detail,
+			},
+			At: now,
+		}); err != nil {
+			return nil, fmt.Errorf("cluster inventory: audit coverage gap: %w", err)
+		}
+	}
+
+	return &SyncResult{Assets: len(inv.Assets), Edges: edges, Gaps: inv.Gaps}, nil
+}

--- a/internal/usecase/fleet/clusterinventory/service_test.go
+++ b/internal/usecase/fleet/clusterinventory/service_test.go
@@ -1,0 +1,233 @@
+package clusterinventory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	dci "github.com/KKloudTarus/synapse-ce/internal/domain/clusterinventory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// fakeAssetWriter resolves a stable id per (kind,key) so re-observation reuses ids (idempotency),
+// and records edges.
+type fakeAssetWriter struct {
+	ids      map[string]shared.ID
+	next     int
+	upserts  int
+	edges    []assetuc.EdgeInput
+	edgeKeys map[string]bool // mirrors the store's idempotent edge natural key
+}
+
+func newFakeWriter() *fakeAssetWriter {
+	return &fakeAssetWriter{ids: map[string]shared.ID{}, edgeKeys: map[string]bool{}}
+}
+
+func (f *fakeAssetWriter) UpsertAsset(_ context.Context, _ string, in assetuc.UpsertAssetInput) (*asset.Asset, error) {
+	f.upserts++
+	k := string(in.Kind) + "|" + in.Key
+	id, ok := f.ids[k]
+	if !ok {
+		f.next++
+		id = shared.ID("id-" + itoa(f.next))
+		f.ids[k] = id
+	}
+	return &asset.Asset{ID: id, TenantID: in.TenantID, Kind: in.Kind, Key: in.Key, Name: in.Name}, nil
+}
+
+func (f *fakeAssetWriter) UpsertEdge(_ context.Context, _ string, in assetuc.EdgeInput) error {
+	// Mirror assetuc/store idempotency: an edge is identified by (tenant, from, to, kind, provenance).
+	key := in.TenantID.String() + "|" + in.From.String() + "|" + in.To.String() + "|" + string(in.Kind) + "|" + in.Provenance.String()
+	if !f.edgeKeys[key] {
+		f.edgeKeys[key] = true
+		f.edges = append(f.edges, in)
+	}
+	return nil
+}
+
+type fakeAudit struct{ entries []ports.AuditEntry }
+
+func (f *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	f.entries = append(f.entries, e)
+	return nil
+}
+
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func sample() dci.Snapshot {
+	return dci.Snapshot{
+		Cluster: "prod-eu",
+		Namespaces: []dci.Namespace{{
+			Name:            "payments",
+			ServiceAccounts: []string{"payments-sa"},
+			Workloads: []dci.Workload{{
+				Kind:           "Deployment",
+				Name:           "api",
+				ServiceAccount: "payments-sa",
+				Containers: []dci.Container{
+					{Name: "api", Image: "reg/api:v1", Digest: "sha256:aaa"},
+					{Name: "side", Image: "reg/x:latest", Digest: ""}, // unresolved -> gap
+				},
+			}},
+			Exposures: []dci.Exposure{{
+				Name: "api", Type: "LoadBalancer", Targets: []dci.Target{{Kind: "Deployment", Name: "api"}},
+			}},
+		}},
+	}
+}
+
+func newService(t *testing.T, w AssetWriter, a ports.AuditLogger) *Service {
+	t.Helper()
+	s, err := NewService(w, a, fixedClock{t: time.Unix(1700000000, 0).UTC()})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return s
+}
+
+func TestSyncUpsertsAssetsEdgesAndReturnsGaps(t *testing.T) {
+	w, a := newFakeWriter(), &fakeAudit{}
+	s := newService(t, w, a)
+
+	res, err := s.Sync(context.Background(), "agent-1", SyncInput{
+		TenantID:       "tenant-1",
+		Snapshot:       sample(),
+		ScannedDigests: map[string]bool{}, // nothing scanned -> sha256:aaa is an unscanned gap
+		Provenance:     "sync-1",
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if res.Assets == 0 || res.Edges == 0 {
+		t.Fatalf("expected assets and edges, got %+v", res)
+	}
+	// Edges must reference resolved (non-zero) ids and carry the provenance.
+	for _, e := range w.edges {
+		if e.From.IsZero() || e.To.IsZero() {
+			t.Fatalf("edge endpoints must be resolved ids: %+v", e)
+		}
+		if e.Provenance != "sync-1" {
+			t.Fatalf("edge must carry provenance, got %q", e.Provenance)
+		}
+	}
+	// Gaps returned: unscanned digest + unresolved digest, both present.
+	kinds := map[dci.GapKind]bool{}
+	for _, g := range res.Gaps {
+		kinds[g.Kind] = true
+	}
+	if !kinds[dci.GapUnscannedDigest] || !kinds[dci.GapUnresolvedDigest] {
+		t.Fatalf("expected unscanned + unresolved digest gaps, got %+v", res.Gaps)
+	}
+	// Every gap is audited.
+	audited := 0
+	for _, e := range a.entries {
+		if e.Action == "cluster_inventory.coverage_gap" {
+			audited++
+			if e.At.IsZero() {
+				t.Fatalf("audit entry must carry a timestamp")
+			}
+		}
+	}
+	if audited != len(res.Gaps) {
+		t.Fatalf("every coverage gap must be audited: audited=%d gaps=%d", audited, len(res.Gaps))
+	}
+}
+
+func TestSyncIsIdempotent(t *testing.T) {
+	w, a := newFakeWriter(), &fakeAudit{}
+	s := newService(t, w, a)
+	in := SyncInput{TenantID: "tenant-1", Snapshot: sample(), ScannedDigests: map[string]bool{"sha256:aaa": true}, Provenance: "sync-1"}
+
+	first, err := s.Sync(context.Background(), "agent-1", in)
+	if err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	idsAfterFirst := len(w.ids)
+	second, err := s.Sync(context.Background(), "agent-1", in)
+	if err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	edgesAfterFirst := len(w.edges)
+	// Same distinct assets, no new ids minted on the second sync (no churn).
+	if len(w.ids) != idsAfterFirst {
+		t.Fatalf("re-sync must not mint new asset ids: %d -> %d", idsAfterFirst, len(w.ids))
+	}
+	// With a STABLE provenance, the edge set converges: no new edge rows on the second sync.
+	if len(w.edges) != edgesAfterFirst {
+		t.Fatalf("re-sync with stable provenance must not mint new edges: %d -> %d", edgesAfterFirst, len(w.edges))
+	}
+	if first.Assets != second.Assets || first.Edges != second.Edges {
+		t.Fatalf("re-sync must produce identical counts: %+v vs %+v", first, second)
+	}
+}
+
+func TestDifferentProvenanceMintsNewEdges(t *testing.T) {
+	// A per-sync (changing) provenance is part of the edge natural key, so it churns edge rows — this
+	// documents WHY Provenance must be stable per cluster source.
+	w, a := newFakeWriter(), &fakeAudit{}
+	s := newService(t, w, a)
+	if _, err := s.Sync(context.Background(), "agent-1", SyncInput{TenantID: "t", Snapshot: sample(), Provenance: "sync-1"}); err != nil {
+		t.Fatal(err)
+	}
+	after1 := len(w.edges)
+	if _, err := s.Sync(context.Background(), "agent-1", SyncInput{TenantID: "t", Snapshot: sample(), Provenance: "sync-2"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(w.edges) <= after1 {
+		t.Fatalf("a changed provenance must create new edge rows (that is why stable provenance matters)")
+	}
+}
+
+func TestSyncValidation(t *testing.T) {
+	w, a := newFakeWriter(), &fakeAudit{}
+	s := newService(t, w, a)
+	ctx := context.Background()
+
+	cases := []struct {
+		name  string
+		actor string
+		in    SyncInput
+	}{
+		{"empty actor", "", SyncInput{TenantID: "t", Snapshot: sample(), Provenance: "p"}},
+		{"empty tenant", "agent-1", SyncInput{Snapshot: sample(), Provenance: "p"}},
+		{"empty provenance", "agent-1", SyncInput{TenantID: "t", Snapshot: sample()}},
+		{"invalid snapshot", "agent-1", SyncInput{TenantID: "t", Provenance: "p", Snapshot: dci.Snapshot{Cluster: ""}}},
+	}
+	for _, c := range cases {
+		if _, err := s.Sync(ctx, c.actor, c.in); err == nil {
+			t.Errorf("%s: expected a validation error", c.name)
+		}
+	}
+	if w.upserts != 0 {
+		t.Fatalf("no asset should be upserted when validation fails, got %d", w.upserts)
+	}
+}
+
+func TestNewServiceValidatesDeps(t *testing.T) {
+	if _, err := NewService(nil, &fakeAudit{}, fixedClock{}); err == nil {
+		t.Error("nil asset writer must be rejected")
+	}
+	if _, err := NewService(newFakeWriter(), nil, fixedClock{}); err == nil {
+		t.Error("nil audit logger must be rejected")
+	}
+	if _, err := NewService(newFakeWriter(), &fakeAudit{}, nil); err == nil {
+		t.Error("nil clock must be rejected")
+	}
+}


### PR DESCRIPTION
## What

The **cluster-inventory usecase** for the Kubernetes cluster agent (#411, epic #405) — PR 2 of 4 finishing #411 (after the pure mapping core, #441). It takes a vendor-neutral cluster `Snapshot`, maps it with the pure domain mapper, and **persists the observed assets + typed edges** through the existing asset usecase, surfacing and auditing every coverage gap. No new dependencies.

## How

`internal/usecase/fleet/clusterinventory`:
- **`Sync(ctx, actor, SyncInput) (*SyncResult, error)`** — validates the input (non-empty tenant, non-empty provenance, `Snapshot.Validate()`), maps `Snapshot → Inventory`, then:
  - upserts each observed asset via the asset usecase (which resolves the stable id by `(tenant, kind, key)`), recording a `AssetRef → id` map;
  - wires each edge by resolving its endpoints from that map and upserting with the caller's **provenance** (required — an unattributable edge can't be trusted by attack-path traversal);
  - returns the mapper's **coverage gaps** and **audits each one** (actor, tenant, cluster, gap kind, detail, timestamp) so a partial inventory is both visible and durably attributable, never dropped.
- Depends on the asset usecase through a **consumer-side `AssetWriter` interface** (`assetuc.Service` satisfies it — compile-time asserted), plus `ports.AuditLogger` + `ports.Clock`. No adapter/infrastructure import.
- **Idempotent:** assets upsert by natural key and the mapping is pure, so a re-sync of an unchanged cluster mints no new ids and produces identical counts — no asset churn.

## Golden rules

Tenant-scoped throughout (empty tenant rejected — empty = DENY under RLS); every mutation attributable (asset/edge upserts audited inside `assetuc`, coverage gaps audited here); a persistence or audit failure is a hard error, never swallowed. No exec/LLM/network/credential surface.

## Deferred (remaining #411 follow-ups)

- PR 3: `internal/infrastructure/k8sinv` — `k8s.io/client-go` informer producing the `Snapshot` (watch/poll, resync/page-size/memory ceiling, fail-loud on a missing RBAC permission); fake-clientset tests.
- PR 4: `deploy/k8s/cluster-agent.yaml` read-only `ClusterRole` + `cmd` composition; then the kind-based CI + 10k-pod scale tests, after which #411 closes.

## Tests

Fake `AssetWriter` (resolves stable ids by key so re-observation reuses them) + fake audit + fixed clock: assets/edges upserted with resolved non-zero endpoints carrying provenance; unscanned + unresolved digest gaps returned and every gap audited with a timestamp; idempotent re-sync (no new ids); validation (empty tenant / empty provenance / invalid snapshot → error, nothing upserted); nil-dependency rejection. `go build ./... && go vet ./...` clean; `golangci-lint` 0 issues.
