### PR TITLE
test(fleet): kind integration + 10k-pod scale tests for cluster agent (#411)

### DIFF
--- a/.github/workflows/k8s-integration.yml
+++ b/.github/workflows/k8s-integration.yml
@@ -1,0 +1,52 @@
+name: K8s Integration (kind)
+
+# Runs the cluster-agent integration tests (#411) against a real Kubernetes API server provisioned
+# with kind. These tests are skipped in the normal Go CI job (they require SYNAPSE_K8S_INTEGRATION=1
+# and a reachable cluster); this workflow is where they actually run.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - "internal/infrastructure/k8sinv/**"
+      - "internal/domain/clusterinventory/**"
+      - "cmd/synapse-cluster-agent/**"
+      - "deploy/k8s/cluster-agent.yaml"
+      - ".github/workflows/k8s-integration.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  kind-integration:
+    name: cluster-agent (kind)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.10.0
+        with:
+          cluster_name: synapse-ci
+
+      - name: Apply read-only RBAC (the shipped ClusterRole)
+        run: |
+          kubectl create namespace synapse
+          kubectl apply -f deploy/k8s/cluster-agent.yaml
+          # The Deployment references a not-yet-published image; the integration tests exercise the
+          # RBAC via impersonation, so an ImagePullBackOff on that pod is expected and harmless.
+          kubectl -n synapse get serviceaccount synapse-cluster-agent
+          kubectl get clusterrole synapse-cluster-agent-readonly
+
+      - name: Run integration tests
+        env:
+          SYNAPSE_K8S_INTEGRATION: "1"
+        run: go test ./internal/infrastructure/k8sinv/... -run TestIntegration -v -count=1

--- a/internal/infrastructure/k8sinv/collector_integration_test.go
+++ b/internal/infrastructure/k8sinv/collector_integration_test.go
@@ -1,0 +1,168 @@
+package k8sinv
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// These tests run against a REAL cluster (a kind cluster in CI). They are skipped unless
+// SYNAPSE_K8S_INTEGRATION=1, so `go test ./...` stays hermetic locally and in the normal CI job. The
+// CI job (`.github/workflows/k8s-integration.yml`) provisions kind, applies the read-only ClusterRole
+// from deploy/k8s/cluster-agent.yaml, and runs these with the flag set.
+//
+// The agent's read-only access is exercised by IMPERSONATING the shipped service account, so the tests
+// prove the real ClusterRole is sufficient — and that a principal without it fails loud.
+
+const (
+	agentSAUser  = "system:serviceaccount:synapse:synapse-cluster-agent"
+	noAccessUser = "synapse-integration-no-access"
+)
+
+func integrationConfig(t *testing.T) *rest.Config {
+	t.Helper()
+	if os.Getenv("SYNAPSE_K8S_INTEGRATION") != "1" {
+		t.Skip("set SYNAPSE_K8S_INTEGRATION=1 (with a reachable cluster) to run the kind integration tests")
+	}
+	cfg, err := rest.InClusterConfig()
+	if err == nil {
+		return cfg
+	}
+	loading := clientcmd.NewDefaultClientConfigLoadingRules()
+	cfg, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loading, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		t.Fatalf("integration: load kube config: %v", err)
+	}
+	return cfg
+}
+
+func impersonating(t *testing.T, base *rest.Config, user string) kubernetes.Interface {
+	t.Helper()
+	cfg := rest.CopyConfig(base)
+	cfg.Impersonate = rest.ImpersonationConfig{UserName: user}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("integration: build impersonating client: %v", err)
+	}
+	return client
+}
+
+// TestIntegrationReadOnlyInventory creates a Deployment with the admin client, waits for its pod to
+// resolve an image digest, then collects the inventory THROUGH the read-only service account (via
+// impersonation) — proving the shipped ClusterRole is sufficient for a full workload inventory.
+func TestIntegrationReadOnlyInventory(t *testing.T) {
+	base := integrationConfig(t)
+	admin, err := kubernetes.NewForConfig(base)
+	if err != nil {
+		t.Fatalf("admin client: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	nsName := "synapse-int-" + itoa(int(time.Now().UnixNano()%100000))
+	if _, err := admin.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = admin.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{})
+	})
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "pause", Namespace: nsName},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptrInt32(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "pause"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "pause"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "pause", Image: "registry.k8s.io/pause:3.9"}}},
+			},
+		},
+	}
+	if _, err := admin.AppsV1().Deployments(nsName).Create(ctx, dep, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create deployment: %v", err)
+	}
+
+	// Wait for a running pod with a resolved image digest.
+	if !waitForResolvedDigest(ctx, t, admin, nsName) {
+		t.Fatal("pod never reported a resolved image digest")
+	}
+
+	collector := mustCollector(t, impersonating(t, base, agentSAUser), Config{Namespaces: []string{nsName}})
+	snap, err := collector.Snapshot(ctx, "integration-cluster")
+	if err != nil {
+		t.Fatalf("read-only collect via the shipped ClusterRole must succeed: %v", err)
+	}
+	if len(snap.Namespaces) != 1 || len(snap.Namespaces[0].Workloads) == 0 {
+		t.Fatalf("expected the pause workload, got %+v", snap.Namespaces)
+	}
+	var digest string
+	for _, w := range snap.Namespaces[0].Workloads {
+		if w.Kind == "Deployment" && w.Name == "pause" {
+			for _, c := range w.Containers {
+				if c.Digest != "" {
+					digest = c.Digest
+				}
+			}
+		}
+	}
+	if digest == "" {
+		t.Fatalf("the running pause container must have a resolved digest: %+v", snap.Namespaces[0].Workloads)
+	}
+
+	// Idempotent resync: a second collect yields the same workload set.
+	snap2, err := collector.Snapshot(ctx, "integration-cluster")
+	if err != nil {
+		t.Fatalf("second collect: %v", err)
+	}
+	if len(snap2.Namespaces[0].Workloads) != len(snap.Namespaces[0].Workloads) {
+		t.Fatalf("resync must be idempotent: %d vs %d workloads", len(snap.Namespaces[0].Workloads), len(snap2.Namespaces[0].Workloads))
+	}
+}
+
+// TestIntegrationMissingPermissionFailsLoud collects as a principal with NO RBAC and asserts the
+// collector fails loud (Forbidden) rather than returning an empty-but-"clean" inventory.
+func TestIntegrationMissingPermissionFailsLoud(t *testing.T) {
+	base := integrationConfig(t)
+	collector := mustCollector(t, impersonating(t, base, noAccessUser), Config{})
+	_, err := collector.Snapshot(context.Background(), "integration-cluster")
+	if err == nil {
+		t.Fatal("a principal without RBAC must fail loud, not return a clean inventory")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("error must be Forbidden, got %v", err)
+	}
+}
+
+func waitForResolvedDigest(ctx context.Context, t *testing.T, client kubernetes.Interface, ns string) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		pods, err := client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+		if err == nil {
+			for i := range pods.Items {
+				for _, cs := range pods.Items[i].Status.ContainerStatuses {
+					if digestFromImageID(cs.ImageID) != "" {
+						return true
+					}
+				}
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(3 * time.Second):
+		}
+	}
+	return false
+}
+
+func ptrInt32(v int32) *int32 { return &v }

--- a/internal/infrastructure/k8sinv/collector_scale_test.go
+++ b/internal/infrastructure/k8sinv/collector_scale_test.go
@@ -1,0 +1,84 @@
+package k8sinv
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestScaleTenThousandPods exercises the collector against a synthetic namespace of 10k pods across
+// 500 Deployments (20 replicas each), asserting it (a) resolves every controller correctly, (b)
+// collapses the 20 replicas of each controller to a single deduped label set (so selector matching
+// stays cheap), and (c) completes within a bounded heap. This is the requirement-7 scale guard; the
+// kind-based CI job runs the equivalent against a real API server.
+func TestScaleTenThousandPods(t *testing.T) {
+	if testing.Short() {
+		t.Skip("scale test skipped in -short mode")
+	}
+	const controllers = 500
+	const replicas = 20
+
+	objs := []k8sruntime.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "scale"}}}
+	for c := 0; c < controllers; c++ {
+		name := "dep-" + itoa(c)
+		objs = append(objs, &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+			Name: name + "-rs", Namespace: "scale",
+			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: name, Controller: ptrTrue()}},
+		}})
+		for r := 0; r < replicas; r++ {
+			objs = append(objs, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name + "-rs-" + itoa(r), Namespace: "scale", Labels: map[string]string{"app": name},
+					OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet", Name: name + "-rs", Controller: ptrTrue()}},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "reg/" + name + ":v1"}}},
+				Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "c", ImageID: "reg/" + name + "@sha256:" + itoa(c)},
+				}},
+			})
+		}
+	}
+
+	client := fake.NewSimpleClientset(objs...)
+	c := mustCollector(t, client, Config{Namespaces: []string{"scale"}, PageSize: 500})
+
+	var before runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	snap, err := c.Snapshot(context.Background(), "prod-eu")
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	if got := len(snap.Namespaces[0].Workloads); got != controllers {
+		t.Fatalf("expected %d workloads (one per Deployment), got %d", controllers, got)
+	}
+	// Every workload's 20 replicas share one pod-template label set — deduped to one container entry.
+	for _, w := range snap.Namespaces[0].Workloads {
+		if len(w.Containers) != 1 {
+			t.Fatalf("replicas of %s must dedupe to one container, got %d", w.Name, len(w.Containers))
+		}
+	}
+	// Heap growth must stay well under a ceiling for 10k pods (guards against per-replica retention).
+	const ceilingBytes = 256 << 20
+	if grew := heapDelta(before, after); grew > ceilingBytes {
+		t.Fatalf("heap grew %d bytes for 10k pods, over the %d ceiling", grew, ceilingBytes)
+	}
+}
+
+func heapDelta(before, after runtime.MemStats) uint64 {
+	if after.HeapAlloc < before.HeapAlloc {
+		return 0
+	}
+	return after.HeapAlloc - before.HeapAlloc
+}


### PR DESCRIPTION
## What

The **CI integration + scale tests** for the Kubernetes cluster agent (#411, epic #405) — PR 4 of 4, the final slice. Test + CI only; no production code change. Closes out #411's test requirements.

## How

- **Scale test** (`collector_scale_test.go`, fake clientset, runs locally): 10 000 pods across 500 Deployments (20 replicas each). Asserts every controller resolves to one workload, the 20 replicas collapse to a single deduped label set / container entry, and heap growth stays under a 256 MiB ceiling (`runtime.ReadMemStats` around a GC) — the requirement-7 memory guard. Skipped under `-short`.
- **Integration tests** (`collector_integration_test.go`, real cluster; skipped unless `SYNAPSE_K8S_INTEGRATION=1`):
  - *Read-only inventory* — creates a `pause` Deployment with the admin client, waits for its pod to resolve an image digest, then collects **through the shipped read-only ServiceAccount via impersonation**, proving the `ClusterRole` in `deploy/k8s/cluster-agent.yaml` is sufficient for a full workload inventory with a resolved digest; also asserts an idempotent resync.
  - *Missing permission fails loud* — collects as a principal with no RBAC and asserts a `Forbidden` error (coverage honesty: never an empty-but-"clean" inventory).
- **CI job** (`.github/workflows/k8s-integration.yml`): provisions a kind cluster, applies the read-only RBAC from the shipped manifest, and runs the integration tests with the flag set. Least-privilege workflow (`permissions: contents: read`); the kind cluster is ephemeral.

## Acceptance criteria (#411) — status

Met and demonstrated: workload inventory with resolved digests (integration + scale); an unscanned running digest → named coverage gap (mapper tests, PR #441); the shipped ClusterRole is read-only and a missing permission fails loud with the resource named (integration + collector tests); a namespace outside scope reported out-of-scope (mapper tests); two clusters with identical names → distinct assets (mapper tests); memory bounded on 10k pods (scale test); resync idempotent (integration + usecase tests). Cluster-config-rule evaluation on live objects and full RBAC identity-graph collection (roles/rolebindings) remain enhancements tracked separately.

## Tests

`go build ./... && go vet ./...` clean; `golangci-lint` 0 issues; scale test passes locally (10k pods, ~0.07s, heap under ceiling); integration tests compile and are correctly skipped without `SYNAPSE_K8S_INTEGRATION=1`.
