### PR TITLE
feat(fleet): wire cluster agent to enrol + report snapshots (#446)

### DIFF
--- a/cmd/synapse-agent/main.go
+++ b/cmd/synapse-agent/main.go
@@ -18,8 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net"
-	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -60,31 +58,23 @@ type config struct {
 	once       bool
 }
 
-// credential is the persisted agent identity. The token is a secret; the file is written 0600 and
-// its contents are never logged.
-type credential struct {
-	AgentID        string `json:"agent_id"`
-	Token          string `json:"token"`
-	CertificatePEM string `json:"certificate_pem,omitempty"`
-}
-
 func main() {
 	log.SetFlags(0)
 	cfg := parseConfig()
 	if cfg.baseURL == "" {
 		log.Fatal("synapse-agent: SYNAPSE_FLEET_URL (or -url) is required")
 	}
-	if err := validateControlPlaneURL(cfg.baseURL); err != nil {
+	if err := fleetclient.ValidateControlPlaneURL(cfg.baseURL); err != nil {
 		log.Fatalf("synapse-agent: %v", err)
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	r := &runner{
-		api:      fleetclient.New(cfg.baseURL, 30*time.Second),
-		collect:  hostinv.Collect,
-		cfg:      cfg,
-		hostname: hostname(),
+		api:     fleetclient.New(cfg.baseURL, 30*time.Second),
+		collect: hostinv.Collect,
+		cfg:     cfg,
+		store:   fleetclient.NewCredentialStore(cfg.stateDir),
 	}
 	if err := r.run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		log.Fatalf("synapse-agent: %v", err)
@@ -116,42 +106,12 @@ func parseConfig() config {
 	return cfg
 }
 
-// validateControlPlaneURL refuses a cleartext control-plane URL so the bearer credential cannot
-// traverse plaintext HTTP. http is allowed only for a loopback host (local development/testing).
-func validateControlPlaneURL(raw string) error {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return fmt.Errorf("invalid control-plane URL: %w", err)
-	}
-	switch u.Scheme {
-	case "https":
-		return nil
-	case "http":
-		if isLoopbackHost(u.Hostname()) {
-			return nil
-		}
-		return fmt.Errorf("refusing cleartext http:// control-plane URL %q (the agent token would traverse plaintext); use https, or a loopback host for local testing", raw)
-	default:
-		return fmt.Errorf("unsupported control-plane URL scheme %q (want https)", u.Scheme)
-	}
-}
-
-func isLoopbackHost(host string) bool {
-	if host == "localhost" {
-		return true
-	}
-	if ip := net.ParseIP(host); ip != nil {
-		return ip.IsLoopback()
-	}
-	return false
-}
-
 // runner holds the run-loop dependencies so the loop can be tested with a fake API + collector.
 type runner struct {
-	api      fleetAPI
-	collect  func(ctx context.Context, root string) (hostinventory.HostInventory, error)
-	cfg      config
-	hostname string
+	api     fleetAPI
+	collect func(ctx context.Context, root string) (hostinventory.HostInventory, error)
+	cfg     config
+	store   *fleetclient.CredentialStore
 }
 
 func (r *runner) run(ctx context.Context) error {
@@ -177,37 +137,18 @@ func (r *runner) run(ctx context.Context) error {
 	}
 }
 
-// ensureEnrolled loads a persisted credential or, on first run, generates a key + CSR and enrols.
-func (r *runner) ensureEnrolled(ctx context.Context) (credential, error) {
-	if cred, ok := r.loadCredential(); ok {
-		return cred, nil
-	}
-	if r.cfg.enrolToken == "" {
-		return credential{}, errors.New("no stored credential and no enrolment token provided")
-	}
-	csrPEM, keyPEM, err := fleetclient.GenerateKeyAndCSR(r.cfg.name)
-	if err != nil {
-		return credential{}, err
-	}
-	resp, err := r.api.Enrol(ctx, r.cfg.enrolToken, fleetclient.EnrolRequest{
+// ensureEnrolled loads a persisted credential or, on first run, generates a key + CSR and enrols,
+// using the shared fleetclient helper so credential persistence lives in one place.
+func (r *runner) ensureEnrolled(ctx context.Context) (fleetclient.Credential, error) {
+	return fleetclient.EnsureEnrolled(ctx, r.api, r.store, r.cfg.enrolToken, fleetclient.EnrolRequest{
 		Name:         r.cfg.name,
 		Platform:     runtime.GOOS,
 		AgentVersion: agentVersion,
 		Capabilities: []string{hostInventoryCapability},
-		CSRPEM:       string(csrPEM),
 	})
-	if err != nil {
-		return credential{}, fmt.Errorf("enrol: %w", err)
-	}
-	cred := credential{AgentID: resp.AgentID, Token: resp.Token, CertificatePEM: resp.CertificatePEM}
-	if err := r.persist(cred, keyPEM); err != nil {
-		return credential{}, err
-	}
-	log.Printf("enrolled as agent %s", cred.AgentID)
-	return cred, nil
 }
 
-func (r *runner) cycle(ctx context.Context, cred credential) error {
+func (r *runner) cycle(ctx context.Context, cred fleetclient.Credential) error {
 	if err := r.api.Heartbeat(ctx, cred.Token, fleetclient.EnrolRequest{
 		Name: r.cfg.name, Platform: runtime.GOOS, AgentVersion: agentVersion,
 	}); err != nil {
@@ -227,7 +168,7 @@ func (r *runner) cycle(ctx context.Context, cred credential) error {
 }
 
 // handle runs one order to completion, reporting a terminal result either way.
-func (r *runner) handle(ctx context.Context, cred credential, o fleetclient.Order) {
+func (r *runner) handle(ctx context.Context, cred fleetclient.Credential, o fleetclient.Order) {
 	if o.Capability != "" && o.Capability != hostInventoryCapability {
 		_ = r.api.SubmitResult(ctx, cred.Token, o.ID, "failed", "unsupported capability: "+o.Capability)
 		return
@@ -276,54 +217,11 @@ func summary(inv hostinventory.HostInventory) string {
 
 // --- state persistence ---------------------------------------------------
 
-func (r *runner) credentialPath() string { return filepath.Join(r.cfg.stateDir, "credential.json") }
-func (r *runner) keyPath() string        { return filepath.Join(r.cfg.stateDir, "agent.key") }
-
-func (r *runner) loadCredential() (credential, bool) {
-	b, err := os.ReadFile(r.credentialPath())
-	if err != nil {
-		return credential{}, false
-	}
-	var c credential
-	if err := json.Unmarshal(b, &c); err != nil || c.Token == "" {
-		return credential{}, false
-	}
-	return c, true
-}
-
-func (r *runner) persist(cred credential, keyPEM []byte) error {
-	if err := os.MkdirAll(r.cfg.stateDir, 0o700); err != nil {
-		return fmt.Errorf("state dir: %w", err)
-	}
-	if len(keyPEM) > 0 {
-		if err := writeSecret(r.keyPath(), keyPEM, 0o600); err != nil {
-			return fmt.Errorf("write key: %w", err)
-		}
-	}
-	b, err := json.MarshalIndent(cred, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal credential: %w", err)
-	}
-	if err := writeSecret(r.credentialPath(), b, 0o600); err != nil {
-		return fmt.Errorf("write credential: %w", err)
-	}
-	return nil
-}
-
-// writeSecret writes secret material and enforces the mode even if the file pre-existed with looser
-// permissions (os.WriteFile applies the mode only on create). The explicit Chmod closes the window
-// where a pre-seeded, world-readable credential/key file would keep its old mode after a rewrite.
-func writeSecret(path string, data []byte, mode os.FileMode) error {
-	if err := os.WriteFile(path, data, mode); err != nil {
-		return err
-	}
-	return os.Chmod(path, mode)
-}
-
 // buffer writes the collected inventory to the state dir as a local artifact and reports whether it
 // succeeded. The control plane's result endpoint records only the order outcome; this on-disk buffer
 // preserves the actual inventory for the forthcoming ingest surface and survives a transient
-// reporting failure.
+// reporting failure. It reuses fleetclient.WriteSecret (0600 + chmod) so on-disk-secret handling is
+// not duplicated.
 func (r *runner) buffer(orderID string, inv hostinventory.HostInventory) error {
 	if err := os.MkdirAll(r.cfg.stateDir, 0o700); err != nil {
 		return fmt.Errorf("state dir: %w", err)
@@ -332,7 +230,7 @@ func (r *runner) buffer(orderID string, inv hostinventory.HostInventory) error {
 	if err != nil {
 		return fmt.Errorf("marshal inventory: %w", err)
 	}
-	if err := writeSecret(filepath.Join(r.cfg.stateDir, "inventory-"+safe(orderID)+".json"), b, 0o600); err != nil {
+	if err := fleetclient.WriteSecret(filepath.Join(r.cfg.stateDir, "inventory-"+safe(orderID)+".json"), b, 0o600); err != nil {
 		return fmt.Errorf("write inventory: %w", err)
 	}
 	return nil

--- a/cmd/synapse-agent/main_test.go
+++ b/cmd/synapse-agent/main_test.go
@@ -54,6 +54,7 @@ func newRunner(t *testing.T, api fleetAPI, orders []fleetclient.Order, collect f
 		api:     api,
 		collect: collect,
 		cfg:     config{stateDir: dir, root: dir, name: "host1", enrolToken: "enrol", once: true, maxOrders: 8},
+		store:   fleetclient.NewCredentialStore(dir),
 	}
 }
 
@@ -74,10 +75,10 @@ func TestFirstRunEnrolsAndPersists(t *testing.T) {
 		t.Fatalf("first run must enrol")
 	}
 	// Credential + key persisted, key is 0600 and the token is not in the key file.
-	if _, err := os.Stat(r.keyPath()); err != nil {
+	if _, err := os.Stat(filepath.Join(r.cfg.stateDir, "agent.key")); err != nil {
 		t.Fatalf("key must be persisted: %v", err)
 	}
-	info, _ := os.Stat(r.credentialPath())
+	info, _ := os.Stat(filepath.Join(r.cfg.stateDir, "credential.json"))
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("credential must be 0600, got %v", info.Mode().Perm())
 	}
@@ -98,7 +99,7 @@ func TestSecondRunReusesCredentialNoEnrol(t *testing.T) {
 	api := &fakeAPI{enrolResp: fleetclient.EnrolResponse{AgentID: "a1", Token: "secret"}}
 	r := newRunner(t, api, nil, okCollect(hostinventory.HostInventory{}))
 	// Pre-persist a credential.
-	if err := r.persist(credential{AgentID: "a1", Token: "secret"}, []byte("KEY")); err != nil {
+	if err := r.store.Persist(fleetclient.Credential{AgentID: "a1", Token: "secret"}, []byte("KEY")); err != nil {
 		t.Fatal(err)
 	}
 	if err := r.run(context.Background()); err != nil {
@@ -170,7 +171,7 @@ func TestBufferFailureFailsOrder(t *testing.T) {
 	inv := hostinventory.HostInventory{Facts: hostinventory.HostFacts{OS: "linux"}}
 	r := newRunner(t, api, []fleetclient.Order{{ID: "o1", Capability: "scan.host"}}, okCollect(inv))
 	// Pre-seed a credential so enrolment is skipped and we reach the buffering step.
-	if err := r.persist(credential{AgentID: "a1", Token: "secret"}, []byte("KEY")); err != nil {
+	if err := r.store.Persist(fleetclient.Credential{AgentID: "a1", Token: "secret"}, []byte("KEY")); err != nil {
 		t.Fatal(err)
 	}
 	// Make ONLY the inventory-file write fail: create a directory exactly where the buffer file goes,
@@ -186,21 +187,6 @@ func TestBufferFailureFailsOrder(t *testing.T) {
 	}
 	if !strings.Contains(api.results[0].reason, "buffer") {
 		t.Fatalf("reason must indicate a buffer failure, got %q", api.results[0].reason)
-	}
-}
-
-func TestControlPlaneURLValidation(t *testing.T) {
-	ok := []string{"https://cp.example.com", "https://cp.example.com:8443/base", "http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"}
-	for _, u := range ok {
-		if err := validateControlPlaneURL(u); err != nil {
-			t.Errorf("%q should be accepted: %v", u, err)
-		}
-	}
-	bad := []string{"http://cp.example.com", "http://10.0.0.5:8080", "ftp://cp.example.com", "ws://localhost"}
-	for _, u := range bad {
-		if err := validateControlPlaneURL(u); err == nil {
-			t.Errorf("%q should be rejected (cleartext/unsupported scheme)", u)
-		}
 	}
 }
 

--- a/cmd/synapse-cluster-agent/main.go
+++ b/cmd/synapse-cluster-agent/main.go
@@ -1,20 +1,19 @@
-// Command synapse-cluster-agent is the Kubernetes cluster agent (#411, epic #405). It reads a live
-// cluster through the read-only collector (internal/infrastructure/k8sinv), maps it to the fleet
-// asset model, and emits the resulting inventory plus a coverage-honest summary. It runs with the
-// read-only ClusterRole shipped in deploy/k8s/cluster-agent.yaml.
+// Command synapse-cluster-agent is the Kubernetes cluster agent (#411/#446, epic #405). It reads a
+// live cluster through the read-only collector (internal/infrastructure/k8sinv), enrols with the
+// control plane's fleet API, and posts the collected snapshot each resync so the control plane maps
+// and persists it into the asset model. It runs with the read-only ClusterRole shipped in
+// deploy/k8s/cluster-agent.yaml. The private key is generated locally; only a CSR is sent.
 //
 // It is a composition root only: it loads Kubernetes config (in-cluster first, then a kubeconfig),
-// builds the collector, and calls the testable run() with it. Collection is read-only — the agent
-// never mutates the cluster.
+// builds the collector + fleet client, and calls the testable run(). Collection is read-only — the
+// agent never mutates the cluster.
 package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -27,36 +26,51 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	dci "github.com/KKloudTarus/synapse-ce/internal/domain/clusterinventory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/k8sinv"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
+const (
+	clusterAgentVersion = "0.1.0"
+	clusterCapability   = "scan.cluster"
+)
+
+// snapshotSender posts a cluster snapshot to the control plane; *fleetclient.Client satisfies it and
+// a test uses a fake.
+type snapshotSender interface {
+	SendClusterInventory(ctx context.Context, token string, snap any) error
+}
+
+type config struct {
+	cluster    string
+	namespaces string
+	kubeconfig string
+	baseURL    string
+	enrolToken string
+	stateDir   string
+	pageSize   int64
+	maxPages   int64
+	timeout    time.Duration
+	resync     time.Duration
+	once       bool
+}
+
 func main() {
 	log.SetFlags(0)
-	cluster := envOr("SYNAPSE_CLUSTER", "")
-	namespaces := envOr("SYNAPSE_CLUSTER_NAMESPACES", "")
-	kubeconfig := envOr("KUBECONFIG", "")
-	var pageSize int64 = 500
-	var maxPages int64 = 0 // 0 -> collector default
-	timeout := 2 * time.Minute
-	resync := envDuration("SYNAPSE_CLUSTER_RESYNC", 5*time.Minute)
-	once := false
+	cfg := parseConfig()
 
-	flag.StringVar(&cluster, "cluster", cluster, "cluster identity keyed into every asset (required)")
-	flag.StringVar(&namespaces, "namespaces", namespaces, "comma-separated namespace scope; empty = all")
-	flag.StringVar(&kubeconfig, "kubeconfig", kubeconfig, "path to a kubeconfig (used when not running in-cluster)")
-	flag.Int64Var(&pageSize, "page-size", pageSize, "List page size")
-	flag.Int64Var(&maxPages, "max-pages", maxPages, "max pages per resource (0 = collector default)")
-	flag.DurationVar(&timeout, "timeout", timeout, "per-collection deadline")
-	flag.DurationVar(&resync, "resync", resync, "interval between collections (long-running mode)")
-	flag.BoolVar(&once, "once", once, "collect once then exit")
-	flag.Parse()
-
-	if strings.TrimSpace(cluster) == "" {
+	if strings.TrimSpace(cfg.cluster) == "" {
 		log.Fatal("synapse-cluster-agent: -cluster (or SYNAPSE_CLUSTER) is required — it keys every asset")
 	}
+	if cfg.baseURL == "" {
+		log.Fatal("synapse-cluster-agent: -url (or SYNAPSE_FLEET_URL) is required")
+	}
+	if err := fleetclient.ValidateControlPlaneURL(cfg.baseURL); err != nil {
+		log.Fatalf("synapse-cluster-agent: %v", err)
+	}
 
-	restCfg, err := loadRESTConfig(kubeconfig)
+	restCfg, err := loadRESTConfig(cfg.kubeconfig)
 	if err != nil {
 		log.Fatalf("synapse-cluster-agent: kube config: %v", err)
 	}
@@ -64,63 +78,98 @@ func main() {
 	if err != nil {
 		log.Fatalf("synapse-cluster-agent: kube client: %v", err)
 	}
-	collector, err := k8sinv.New(client, k8sinv.Config{Namespaces: splitCSV(namespaces), PageSize: pageSize, MaxPages: maxPages})
+	collector, err := k8sinv.New(client, k8sinv.Config{Namespaces: splitCSV(cfg.namespaces), PageSize: cfg.pageSize, MaxPages: cfg.maxPages})
 	if err != nil {
 		log.Fatalf("synapse-cluster-agent: %v", err)
 	}
 
+	fleet := fleetclient.New(cfg.baseURL, 60*time.Second)
+	store := fleetclient.NewCredentialStore(cfg.stateDir)
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// One collection per resync interval (req 7), each bounded by its own deadline, until signalled.
-	// -once collects a single time (fail-fast for CI / kind tests).
+	cred, err := fleetclient.EnsureEnrolled(ctx, fleet, store, cfg.enrolToken, fleetclient.EnrolRequest{
+		Name:         cfg.cluster,
+		Platform:     "kubernetes",
+		AgentVersion: clusterAgentVersion,
+		Capabilities: []string{clusterCapability},
+	})
+	if err != nil {
+		log.Fatalf("synapse-cluster-agent: enrol: %v", err)
+	}
+
+	// One collect+report per resync interval, each bounded by its own deadline, until signalled.
 	for {
-		cctx, cancel := context.WithTimeout(ctx, timeout)
-		err := run(cctx, collector, cluster, os.Stdout)
+		cctx, cancel := context.WithTimeout(ctx, cfg.timeout)
+		err := run(cctx, collector, fleet, cred.Token, cfg.cluster)
 		cancel()
-		if once {
+		if cfg.once {
 			if err != nil {
 				log.Fatalf("synapse-cluster-agent: %v", err)
 			}
 			return
 		}
 		if err != nil {
-			log.Printf("synapse-cluster-agent: collection error (will retry in %s): %v", resync, err)
+			log.Printf("synapse-cluster-agent: sync error (will retry in %s): %v", cfg.resync, err)
 		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(resync):
+		case <-time.After(cfg.resync):
 		}
 	}
 }
 
-// run collects the cluster inventory and writes it as JSON to out, logging a coverage-honest summary.
-// It is separated from config loading so it can be tested with a fake SnapshotSource.
-func run(ctx context.Context, src ports.SnapshotSource, cluster string, out io.Writer) error {
+// run collects the cluster inventory and reports it to the control plane. It logs a coverage-honest
+// summary (the control plane re-maps against its scanned set). It is testable via the SnapshotSource
+// and snapshotSender interfaces.
+func run(ctx context.Context, src ports.SnapshotSource, snd snapshotSender, token, cluster string) error {
 	snap, err := src.Snapshot(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("collect snapshot: %w", err)
 	}
-	// Map to surface coverage gaps. Nothing is scanned from the agent's vantage point, so every running
-	// digest is reported as an unscanned gap here; the control plane re-maps against its scanned set.
 	inv := dci.Map(snap, nil)
 	log.Printf("cluster %q: %d namespace(s), %d asset(s), %d coverage gap(s)", cluster, len(snap.Namespaces), len(inv.Assets), len(inv.Gaps))
-	for _, g := range inv.Gaps {
-		log.Printf("  coverage gap [%s] %s: %s", g.Kind, g.Workload, g.Detail)
-	}
-
-	enc := json.NewEncoder(out)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(snap); err != nil {
-		return fmt.Errorf("encode snapshot: %w", err)
+	if err := snd.SendClusterInventory(ctx, token, snap); err != nil {
+		return fmt.Errorf("report snapshot: %w", err)
 	}
 	return nil
 }
 
+func parseConfig() config {
+	var cfg config
+	var enrolTokenFile string
+	cfg.pageSize = 500
+	cfg.timeout = 2 * time.Minute
+	cfg.resync = envDuration("SYNAPSE_CLUSTER_RESYNC", 5*time.Minute)
+
+	flag.StringVar(&cfg.cluster, "cluster", envOr("SYNAPSE_CLUSTER", ""), "cluster identity keyed into every asset (required)")
+	flag.StringVar(&cfg.namespaces, "namespaces", envOr("SYNAPSE_CLUSTER_NAMESPACES", ""), "comma-separated namespace scope; empty = all")
+	flag.StringVar(&cfg.kubeconfig, "kubeconfig", envOr("KUBECONFIG", ""), "path to a kubeconfig (used when not running in-cluster)")
+	flag.StringVar(&cfg.baseURL, "url", envOr("SYNAPSE_FLEET_URL", ""), "control plane fleet API base URL (https required, except a loopback host)")
+	flag.StringVar(&cfg.enrolToken, "enrol-token", os.Getenv("SYNAPSE_FLEET_ENROL_TOKEN"), "one-time enrolment token, first run only (DISCOURAGED: visible in ps; prefer -enrol-token-file)")
+	flag.StringVar(&enrolTokenFile, "enrol-token-file", os.Getenv("SYNAPSE_FLEET_ENROL_TOKEN_FILE"), "file to read the one-time enrolment token from (preferred over -enrol-token)")
+	flag.StringVar(&cfg.stateDir, "state-dir", envOr("SYNAPSE_AGENT_STATE_DIR", "/var/lib/synapse-cluster-agent"), "directory for the agent credential")
+	flag.Int64Var(&cfg.pageSize, "page-size", cfg.pageSize, "List page size")
+	flag.Int64Var(&cfg.maxPages, "max-pages", 0, "max pages per resource (0 = collector default)")
+	flag.DurationVar(&cfg.timeout, "timeout", cfg.timeout, "per-collection deadline")
+	flag.DurationVar(&cfg.resync, "resync", cfg.resync, "interval between collections")
+	flag.BoolVar(&cfg.once, "once", false, "collect + report once then exit")
+	flag.Parse()
+
+	if cfg.enrolToken == "" && enrolTokenFile != "" {
+		b, err := os.ReadFile(enrolTokenFile)
+		if err != nil {
+			log.Fatalf("synapse-cluster-agent: read enrol token file: %v", err)
+		}
+		cfg.enrolToken = strings.TrimSpace(string(b))
+	}
+	return cfg
+}
+
 // loadRESTConfig prefers in-cluster config (the normal deployment) and falls back to a kubeconfig
-// only when genuinely not running in a cluster — a malformed in-cluster token is a real error, not a
-// silent fall-through to kubeconfig.
+// only when genuinely not running in a cluster — a malformed in-cluster token is a real error.
 func loadRESTConfig(kubeconfig string) (*rest.Config, error) {
 	cfg, err := rest.InClusterConfig()
 	if err == nil {

--- a/cmd/synapse-cluster-agent/main_test.go
+++ b/cmd/synapse-cluster-agent/main_test.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -19,34 +16,62 @@ type fakeSource struct {
 
 func (f fakeSource) Snapshot(context.Context, string) (dci.Snapshot, error) { return f.snap, f.err }
 
-func TestRunEmitsSnapshotJSON(t *testing.T) {
-	src := fakeSource{snap: dci.Snapshot{
+type fakeSender struct {
+	calls int
+	token string
+	snap  any
+	err   error
+}
+
+func (f *fakeSender) SendClusterInventory(_ context.Context, token string, snap any) error {
+	f.calls++
+	f.token = token
+	f.snap = snap
+	return f.err
+}
+
+func sampleSnapshot() dci.Snapshot {
+	return dci.Snapshot{
 		Cluster: "prod-eu",
 		Namespaces: []dci.Namespace{{
 			Name:      "payments",
 			Workloads: []dci.Workload{{Kind: "Deployment", Name: "api", Containers: []dci.Container{{Name: "api", Image: "reg/api:v1", Digest: "sha256:aaa"}}}},
 		}},
-	}}
-	var out bytes.Buffer
-	if err := run(context.Background(), src, "prod-eu", &out); err != nil {
+	}
+}
+
+func TestRunCollectsAndReports(t *testing.T) {
+	src := fakeSource{snap: sampleSnapshot()}
+	snd := &fakeSender{}
+	if err := run(context.Background(), src, snd, "tok", "prod-eu"); err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	var decoded dci.Snapshot
-	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
-		t.Fatalf("output must be valid snapshot JSON: %v", err)
+	if snd.calls != 1 {
+		t.Fatalf("the snapshot must be reported exactly once, got %d", snd.calls)
 	}
-	if decoded.Cluster != "prod-eu" || len(decoded.Namespaces) != 1 {
-		t.Fatalf("snapshot not emitted faithfully: %+v", decoded)
+	if snd.token != "tok" {
+		t.Fatalf("report must carry the agent token, got %q", snd.token)
 	}
-	if !strings.Contains(out.String(), "sha256:aaa") {
-		t.Fatalf("resolved digest must appear in the emitted inventory")
+	got, ok := snd.snap.(dci.Snapshot)
+	if !ok || got.Cluster != "prod-eu" {
+		t.Fatalf("the collected snapshot must be sent, got %#v", snd.snap)
 	}
 }
 
 func TestRunPropagatesCollectError(t *testing.T) {
-	src := fakeSource{err: errors.New("forbidden: pods")}
-	if err := run(context.Background(), src, "prod-eu", &bytes.Buffer{}); err == nil {
-		t.Fatal("a collection failure must propagate (fail loud), not be swallowed")
+	snd := &fakeSender{}
+	if err := run(context.Background(), fakeSource{err: errors.New("forbidden: pods")}, snd, "tok", "prod-eu"); err == nil {
+		t.Fatal("a collection failure must fail loud, not be swallowed")
+	}
+	if snd.calls != 0 {
+		t.Fatal("nothing must be reported when collection fails")
+	}
+}
+
+func TestRunPropagatesSendError(t *testing.T) {
+	snd := &fakeSender{err: errors.New("503")}
+	if err := run(context.Background(), fakeSource{snap: sampleSnapshot()}, snd, "tok", "prod-eu"); err == nil {
+		t.Fatal("a report failure must surface (so the resync loop logs + retries)")
 	}
 }
 
@@ -78,11 +103,8 @@ func TestEnvDuration(t *testing.T) {
 	if got := envDuration("SYNAPSE_TEST_DUR", time.Minute); got != 30*time.Second {
 		t.Fatalf("envDuration = %v, want 30s", got)
 	}
-	t.Setenv("SYNAPSE_TEST_DUR", "not-a-duration")
+	t.Setenv("SYNAPSE_TEST_DUR", "bad")
 	if got := envDuration("SYNAPSE_TEST_DUR", time.Minute); got != time.Minute {
 		t.Fatalf("a bad duration must fall back to the default, got %v", got)
-	}
-	if got := envDuration("SYNAPSE_TEST_UNSET_DUR", time.Minute); got != time.Minute {
-		t.Fatalf("unset must use the default, got %v", got)
 	}
 }

--- a/deploy/k8s/cluster-agent.yaml
+++ b/deploy/k8s/cluster-agent.yaml
@@ -47,6 +47,26 @@ subjects:
     name: synapse-cluster-agent
     namespace: synapse
 ---
+# The one-time enrolment token is provisioned OUT OF BAND by an operator (never committed). Create the
+# Secret before applying this manifest, e.g.:
+#   kubectl -n synapse create secret generic synapse-cluster-agent-enrol \
+#     --from-literal=enrol-token="<one-time token minted by the control plane>"
+# It is consumed on first enrolment; the agent then persists a long-lived credential in its state
+# volume, so a restart does not re-enrol. The Deployment reads it via secretKeyRef below.
+---
+# Persists the agent credential across restarts (without it a restart would re-enrol with an
+# already-consumed one-time token and fail).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: synapse-cluster-agent-state
+  namespace: synapse
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 64Mi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,6 +76,8 @@ metadata:
     app.kubernetes.io/name: synapse-cluster-agent
 spec:
   replicas: 1
+  strategy:
+    type: Recreate # single writer of the state PVC
   selector:
     matchLabels:
       app.kubernetes.io/name: synapse-cluster-agent
@@ -69,18 +91,34 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
+        fsGroup: 65532 # so the agent can write the state PVC
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: agent
           image: ghcr.io/kkloudtarus/synapse-cluster-agent:latest # pin to a digest in production
-          args: ["-cluster", "$(SYNAPSE_CLUSTER)"]
           env:
             - name: SYNAPSE_CLUSTER
-              value: "REPLACE-with-unique-cluster-identity"
+              value: "REPLACE-with-unique-cluster-identity" # keys every asset; unique per cluster
+            # Control-plane fleet API. Must be https (a loopback host is the only http exception).
+            - name: SYNAPSE_FLEET_URL
+              value: "https://REPLACE-with-control-plane"
+            # One-time enrolment token, read from a mounted file (first run only). A file is preferred
+            # over an env var: an env secret is readable via /proc/<pid>/environ and can leak into
+            # crash dumps / child processes.
+            - name: SYNAPSE_FLEET_ENROL_TOKEN_FILE
+              value: /var/run/synapse/enrol-token
+            - name: SYNAPSE_AGENT_STATE_DIR
+              value: /var/lib/synapse-cluster-agent
             # Optional: restrict scope. Empty = all namespaces.
             - name: SYNAPSE_CLUSTER_NAMESPACES
               value: ""
+          volumeMounts:
+            - name: state
+              mountPath: /var/lib/synapse-cluster-agent
+            - name: enrol-token
+              mountPath: /var/run/synapse
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -93,3 +131,7 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: synapse-cluster-agent-state

--- a/internal/infrastructure/fleetclient/client.go
+++ b/internal/infrastructure/fleetclient/client.go
@@ -92,6 +92,13 @@ func (c *Client) SubmitResult(ctx context.Context, token, orderID, status, reaso
 		map[string]string{"status": status, "reason": reason}, nil)
 }
 
+// SendClusterInventory posts a collected Kubernetes cluster snapshot to the control plane, which maps
+// and persists it into the asset model (#446). snap must be a JSON-tagged clusterinventory.Snapshot;
+// the caller passes it as the marshalable value so this package keeps no domain dependency.
+func (c *Client) SendClusterInventory(ctx context.Context, token string, snap any) error {
+	return c.do(ctx, http.MethodPost, "/api/v1/fleet/inventory/cluster", token, snap, nil)
+}
+
 func (c *Client) do(ctx context.Context, method, path, token string, body, out any) error {
 	var reader io.Reader
 	if body != nil {

--- a/internal/infrastructure/fleetclient/credential.go
+++ b/internal/infrastructure/fleetclient/credential.go
@@ -1,0 +1,138 @@
+package fleetclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+)
+
+// ValidateControlPlaneURL refuses a cleartext control-plane URL so the bearer credential cannot
+// traverse plaintext HTTP. http is allowed only for a loopback host (local development/testing).
+// Shared by every agent binary so the transport-security rule is enforced identically.
+func ValidateControlPlaneURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid control-plane URL: %w", err)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+		return fmt.Errorf("refusing cleartext http:// control-plane URL %q (the agent token would traverse plaintext); use https, or a loopback host for local testing", raw)
+	default:
+		return fmt.Errorf("unsupported control-plane URL scheme %q (want https)", u.Scheme)
+	}
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// Credential is a persisted agent identity. Token is a secret: the file is written 0600 and its
+// contents are never logged.
+type Credential struct {
+	AgentID        string `json:"agent_id"`
+	Token          string `json:"token"`
+	CertificatePEM string `json:"certificate_pem,omitempty"`
+}
+
+// CredentialStore persists an agent credential + private key under a state directory. It is shared by
+// every agent binary so the security-sensitive persistence (0600, chmod on rewrite) lives in one place.
+type CredentialStore struct{ dir string }
+
+// NewCredentialStore returns a store rooted at dir.
+func NewCredentialStore(dir string) *CredentialStore { return &CredentialStore{dir: dir} }
+
+func (s *CredentialStore) credentialPath() string { return filepath.Join(s.dir, "credential.json") }
+func (s *CredentialStore) keyPath() string        { return filepath.Join(s.dir, "agent.key") }
+
+// Load returns a stored credential, or ok=false when none is present/usable.
+func (s *CredentialStore) Load() (Credential, bool) {
+	b, err := os.ReadFile(s.credentialPath())
+	if err != nil {
+		return Credential{}, false
+	}
+	var c Credential
+	if err := json.Unmarshal(b, &c); err != nil || c.Token == "" {
+		return Credential{}, false
+	}
+	return c, true
+}
+
+// Persist writes the credential (and the private key, when supplied) with 0600 permissions.
+func (s *CredentialStore) Persist(cred Credential, keyPEM []byte) error {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("state dir: %w", err)
+	}
+	if len(keyPEM) > 0 {
+		if err := WriteSecret(s.keyPath(), keyPEM, 0o600); err != nil {
+			return fmt.Errorf("write key: %w", err)
+		}
+	}
+	b, err := json.MarshalIndent(cred, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal credential: %w", err)
+	}
+	if err := WriteSecret(s.credentialPath(), b, 0o600); err != nil {
+		return fmt.Errorf("write credential: %w", err)
+	}
+	return nil
+}
+
+// WriteSecret writes secret material and enforces the mode even if the file pre-existed with looser
+// permissions (os.WriteFile applies the mode only on create). The explicit Chmod closes the window
+// where a pre-seeded, world-readable file would keep its old mode after a rewrite. Exported so agent
+// binaries reuse it for their own on-disk secrets (e.g. a buffered inventory) rather than duplicating it.
+func WriteSecret(path string, data []byte, mode os.FileMode) error {
+	if err := os.WriteFile(path, data, mode); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
+}
+
+// Enroller is the subset of the client EnsureEnrolled needs; *Client satisfies it, and an agent's
+// test fake can too.
+type Enroller interface {
+	Enrol(ctx context.Context, enrolToken string, req EnrolRequest) (EnrolResponse, error)
+}
+
+// EnsureEnrolled returns a stored credential, or on first run generates a P-256 key + CSR, enrols via
+// e using enrolToken, and persists the result. req carries the agent's name/platform/version/
+// capabilities; its CSRPEM is filled in here (the private key never leaves the host — only the CSR is
+// sent). It errors when there is neither a stored credential nor an enrolment token.
+func EnsureEnrolled(ctx context.Context, e Enroller, store *CredentialStore, enrolToken string, req EnrolRequest) (Credential, error) {
+	if cred, ok := store.Load(); ok {
+		return cred, nil
+	}
+	if enrolToken == "" {
+		return Credential{}, errors.New("fleetclient: no stored credential and no enrolment token provided")
+	}
+	csrPEM, keyPEM, err := GenerateKeyAndCSR(req.Name)
+	if err != nil {
+		return Credential{}, err
+	}
+	req.CSRPEM = string(csrPEM)
+	resp, err := e.Enrol(ctx, enrolToken, req)
+	if err != nil {
+		return Credential{}, fmt.Errorf("fleetclient: enrol: %w", err)
+	}
+	cred := Credential(resp)
+	if err := store.Persist(cred, keyPEM); err != nil {
+		return Credential{}, err
+	}
+	return cred, nil
+}

--- a/internal/infrastructure/fleetclient/credential_test.go
+++ b/internal/infrastructure/fleetclient/credential_test.go
@@ -1,0 +1,112 @@
+package fleetclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+type fakeEnroller struct {
+	calls  int
+	resp   EnrolResponse
+	gotReq EnrolRequest
+}
+
+func (f *fakeEnroller) Enrol(_ context.Context, _ string, req EnrolRequest) (EnrolResponse, error) {
+	f.calls++
+	f.gotReq = req
+	return f.resp, nil
+}
+
+func TestEnsureEnrolledFirstRunThenReuse(t *testing.T) {
+	dir := t.TempDir()
+	store := NewCredentialStore(dir)
+	enr := &fakeEnroller{resp: EnrolResponse{AgentID: "a1", Token: "secret", CertificatePEM: "PEM"}}
+	req := EnrolRequest{Name: "agent-1", Platform: "kubernetes", Capabilities: []string{"scan.cluster"}}
+
+	cred, err := EnsureEnrolled(context.Background(), enr, store, "enrol-tok", req)
+	if err != nil {
+		t.Fatalf("first enrol: %v", err)
+	}
+	if cred.Token != "secret" || enr.calls != 1 {
+		t.Fatalf("first run must enrol once, got cred=%+v calls=%d", cred, enr.calls)
+	}
+	// A CSR was generated and sent (private key stays local).
+	if enr.gotReq.CSRPEM == "" {
+		t.Fatalf("enrol must carry a generated CSR")
+	}
+	// credential + key persisted 0600.
+	info, err := os.Stat(store.credentialPath())
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("credential must be persisted 0600: %v", err)
+	}
+	if _, err := os.Stat(store.keyPath()); err != nil {
+		t.Fatalf("key must be persisted: %v", err)
+	}
+
+	// Second call loads the stored credential — no re-enrol.
+	cred2, err := EnsureEnrolled(context.Background(), enr, store, "enrol-tok", req)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if enr.calls != 1 {
+		t.Fatalf("a stored credential must not re-enrol, calls=%d", enr.calls)
+	}
+	if cred2.Token != "secret" {
+		t.Fatalf("second call must return the stored credential")
+	}
+}
+
+func TestValidateControlPlaneURL(t *testing.T) {
+	ok := []string{"https://cp.example.com", "https://cp.example.com:8443/base", "http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"}
+	for _, u := range ok {
+		if err := ValidateControlPlaneURL(u); err != nil {
+			t.Errorf("%q should be accepted: %v", u, err)
+		}
+	}
+	bad := []string{"http://cp.example.com", "http://10.0.0.5:8080", "ftp://cp.example.com", "ws://localhost"}
+	for _, u := range bad {
+		if err := ValidateControlPlaneURL(u); err == nil {
+			t.Errorf("%q should be rejected (cleartext/unsupported scheme)", u)
+		}
+	}
+}
+
+func TestEnsureEnrolledNoCredentialNoTokenErrors(t *testing.T) {
+	store := NewCredentialStore(t.TempDir())
+	if _, err := EnsureEnrolled(context.Background(), &fakeEnroller{}, store, "", EnrolRequest{Name: "a"}); err == nil {
+		t.Fatal("neither stored credential nor enrol token must error")
+	}
+}
+
+func TestSendClusterInventoryPostsSnapshot(t *testing.T) {
+	var gotPath, gotAuth, gotProto string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotProto = r.Header.Get(protoHeader)
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL, 5*time.Second)
+	snap := map[string]any{"cluster": "prod-eu"}
+	if err := c.SendClusterInventory(context.Background(), "tok", snap); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if gotPath != "/api/v1/fleet/inventory/cluster" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer tok" || gotProto != protoVersion {
+		t.Fatalf("auth/proto headers wrong: %q %q", gotAuth, gotProto)
+	}
+	if gotBody["cluster"] != "prod-eu" {
+		t.Fatalf("snapshot body not sent: %v", gotBody)
+	}
+}


### PR DESCRIPTION
## What

Wire the Kubernetes cluster agent to actually **enrol + report** its snapshot to the control plane — the agent-transport half of #446. After this, `synapse-cluster-agent` runs end-to-end: collect → POST → control plane persists into the asset model (#411 fully end-to-end). PR 2 of the #446 series.

## How

- **Shared agent transport/credential helpers** extracted into `fleetclient` (the package the epic said to share) so the security-sensitive logic lives **once**:
  - `Credential` + `CredentialStore` (Load/Persist, 0600 with chmod-on-rewrite),
  - `Enroller` interface + `EnsureEnrolled` (load-or-enrol: generate P-256 key + CSR locally, enrol, persist — the **private key never leaves the host**, only the CSR is sent),
  - `ValidateControlPlaneURL` (refuse cleartext http except loopback),
  - `Client.SendClusterInventory(token, snap)`.
- **`cmd/synapse-agent` refactored** to use those helpers — its private credential type / persist / writeSecret / loadCredential / URL-validation are gone (no duplicated credential logic).
- **`cmd/synapse-cluster-agent` rewritten**: enrol via `EnsureEnrolled`, then a resync loop that collects a snapshot and `SendClusterInventory`s it each interval (per-iteration deadline, `ctx` cancellation, `-once` for CI). `run()` is testable via the `SnapshotSource` + `snapshotSender` interfaces.
- **Deployment manifest** updated: `SYNAPSE_FLEET_URL`, the enrol token via `secretKeyRef` to an **operator-created** Secret (nothing secret committed), a **state PVC** so the long-lived credential survives restarts (a one-time enrol token would otherwise fail on re-enrol), `fsGroup` + `Recreate` strategy.

## Golden rules

Token + private key written 0600, never logged; the manifest embeds no secret (references an out-of-band Secret); https-only transport; read-only cluster access unchanged; no exec/shell. The refactor is behavior-identical to #410's original credential handling (same 0600/chmod/load-or-enrol/no-token-no-cred-error), covered by the moved + new tests.

## Deferred (remaining #446)

- PR3: VM host-inventory persist use case + `POST /api/v1/fleet/inventory/host`, wire `synapse-agent` to send.
- PR4: scanned-digest correlation source.

## Tests

`fleetclient`: `EnsureEnrolled` first-run-enrols-then-reuses + persists 0600, no-token+no-cred errors, `SendClusterInventory` posts to the right path with bearer + proto header, `ValidateControlPlaneURL` table. `synapse-agent`: existing suite green against the shared store. `synapse-cluster-agent`: `run` collects+reports once, propagates collect + send errors, CSV/duration parsing. `go build ./... && go vet ./...` clean; `golangci-lint` 0 issues; YAML validates (6 docs).
