### PR TITLE
feat(fleet): VM host inventory ingest into the asset model (#446)

### DIFF
--- a/cmd/synapse-agent/main.go
+++ b/cmd/synapse-agent/main.go
@@ -45,6 +45,7 @@ type fleetAPI interface {
 	ClaimWork(ctx context.Context, token string, max int) ([]fleetclient.Order, error)
 	Progress(ctx context.Context, token, orderID string) error
 	SubmitResult(ctx context.Context, token, orderID, status, reason string) error
+	SendHostInventory(ctx context.Context, token string, inv any) error
 }
 
 type config struct {
@@ -181,19 +182,25 @@ func (r *runner) handle(ctx context.Context, cred fleetclient.Credential, o flee
 		_ = r.api.SubmitResult(ctx, cred.Token, o.ID, "failed", "collect: "+err.Error())
 		return
 	}
-	// The control-plane result endpoint records only the outcome; this on-disk buffer is the ONLY
-	// place the actual inventory (including its machine-readable coverage) is preserved for the
-	// forthcoming ingest surface. If buffering fails the inventory is lost, so the order is not a
-	// success — fail it rather than report a green order with nothing behind it.
+	// Keep a durable local copy first (the buffer survives a transient reporting failure). If buffering
+	// fails the inventory is lost, so the order is not a success.
 	if err := r.buffer(o.ID, inv); err != nil {
 		log.Printf("order %s: buffer: %v", o.ID, err)
 		_ = r.api.SubmitResult(ctx, cred.Token, o.ID, "failed", "buffer inventory: "+err.Error())
 		return
 	}
+	// Report the inventory to the control plane, which persists the host into the asset model (#446).
+	// The control plane records the coverage/degraded flags on the asset. If reporting fails the data
+	// did not land, so the order is not a clean success — fail it (the local buffer preserves the data).
+	if err := r.api.SendHostInventory(ctx, cred.Token, inv); err != nil {
+		log.Printf("order %s: report inventory: %v", o.ID, err)
+		_ = r.api.SubmitResult(ctx, cred.Token, o.ID, "failed", "report inventory: "+err.Error())
+		return
+	}
 	// Fail closed when the collected package data is untrustworthy (a package DB that exists but could
 	// not be read): a consumer must never treat a poisoned inventory as a clean success. An inventory
 	// that is merely incomplete for expected reasons (dimensions not yet collected) still succeeds, with
-	// the incompleteness stated in the reason and preserved structurally in the buffered inventory.
+	// the incompleteness stated in the reason and preserved on the persisted asset.
 	status := "succeeded"
 	if inv.Degraded() {
 		status = "failed"

--- a/cmd/synapse-agent/main_test.go
+++ b/cmd/synapse-agent/main_test.go
@@ -20,6 +20,8 @@ type fakeAPI struct {
 	results     []result
 	progressed  []string
 	heartbeats  int
+	sent        int
+	sendErr     error
 }
 
 type result struct{ orderID, status, reason string }
@@ -42,6 +44,10 @@ func (f *fakeAPI) Progress(_ context.Context, _, orderID string) error {
 func (f *fakeAPI) SubmitResult(_ context.Context, _, orderID, status, reason string) error {
 	f.results = append(f.results, result{orderID, status, reason})
 	return nil
+}
+func (f *fakeAPI) SendHostInventory(_ context.Context, _ string, _ any) error {
+	f.sent++
+	return f.sendErr
 }
 
 func newRunner(t *testing.T, api fleetAPI, orders []fleetclient.Order, collect func(context.Context, string) (hostinventory.HostInventory, error)) *runner {
@@ -85,6 +91,10 @@ func TestFirstRunEnrolsAndPersists(t *testing.T) {
 	// The order was progressed and reported succeeded with a coverage-honest summary.
 	if len(api.results) != 1 || api.results[0].status != "succeeded" {
 		t.Fatalf("expected one succeeded result, got %+v", api.results)
+	}
+	// The inventory was reported to the control plane (persisted into the asset model).
+	if api.sent != 1 {
+		t.Fatalf("the collected inventory must be reported to the control plane, sent=%d", api.sent)
 	}
 	if len(api.progressed) != 1 {
 		t.Fatalf("order should be moved to running, got %v", api.progressed)
@@ -147,6 +157,21 @@ func TestNoCredentialNoTokenErrors(t *testing.T) {
 	r.cfg.enrolToken = ""
 	if err := r.run(context.Background()); err == nil {
 		t.Fatalf("run with neither credential nor enrol token must error")
+	}
+}
+
+func TestReportFailureFailsOrder(t *testing.T) {
+	api := &fakeAPI{enrolResp: fleetclient.EnrolResponse{AgentID: "a1", Token: "secret"}, sendErr: errors.New("503")}
+	inv := hostinventory.HostInventory{Facts: hostinventory.HostFacts{OS: "linux"}}
+	r := newRunner(t, api, []fleetclient.Order{{ID: "o1", Capability: "scan.host"}}, okCollect(inv))
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(api.results) != 1 || api.results[0].status != "failed" {
+		t.Fatalf("a failed report to the control plane must fail the order, got %+v", api.results)
+	}
+	if !strings.Contains(api.results[0].reason, "report inventory") {
+		t.Fatalf("reason must indicate a reporting failure, got %q", api.results[0].reason)
 	}
 }
 

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -111,6 +111,7 @@ import (
 	exportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/export"
 	findingsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findings"
 	clusterinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/clusterinventory"
+	hostinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/hostinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fptriage"
@@ -1103,6 +1104,22 @@ func main() {
 			}
 			router.SetFleetClusterInventory(ciSvc)
 			log.Info("fleet cluster inventory ingest ENABLED (agents persist snapshots into the asset model)")
+		}
+
+		// VM host snapshot ingest (#446): agents POST a collected host inventory persisted as a
+		// Kind=host asset. Gated by its own flag AND requires the asset model.
+		if cfg.FleetHostIngestEnabled {
+			if assetSvc == nil {
+				log.Error("SYNAPSE_FLEET_HOST_INGEST_ENABLED requires the fleet asset model – set SYNAPSE_FLEET_ASSETS_ENABLED")
+				os.Exit(1)
+			}
+			hiSvc, hierr := hostinventoryuc.NewService(assetSvc, auditLog, clock)
+			if hierr != nil {
+				log.Error("host inventory ingest init failed", "err", hierr)
+				os.Exit(1)
+			}
+			router.SetFleetHostInventory(hiSvc)
+			log.Info("fleet host inventory ingest ENABLED (VM agents persist host inventories into the asset model)")
 		}
 	}
 	// deterministic Tier-2 reachability proof in the scan pipeline (opt-in). It mints reachability

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -16,9 +16,11 @@ import (
 
 	dci "github.com/KKloudTarus/synapse-ce/internal/domain/clusterinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	dhi "github.com/KKloudTarus/synapse-ce/internal/domain/hostinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
 	clusterinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/clusterinventory"
+	hostinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/hostinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
 )
 
@@ -56,10 +58,17 @@ type fleetClusterInventory interface {
 	Sync(ctx context.Context, actor string, in clusterinventoryuc.SyncInput) (*clusterinventoryuc.SyncResult, error)
 }
 
+// fleetHostInventory persists a VM host inventory an agent reports (#446). The host-inventory use
+// case implements it; nil means the host ingest route is not served.
+type fleetHostInventory interface {
+	Sync(ctx context.Context, actor string, in hostinventoryuc.SyncInput) (*hostinventoryuc.SyncResult, error)
+}
+
 type fleetRouter struct {
 	agents           fleetAgentService
 	work             fleetWorkService
 	clusterInv       fleetClusterInventory // optional; nil ⇒ cluster inventory ingest is not served
+	hostInv          fleetHostInventory    // optional; nil ⇒ host inventory ingest is not served
 	log              *slog.Logger
 	agentLim         *keyedLimiter // post-auth, keyed by agent id
 	ipLim            *keyedLimiter // pre-auth, keyed by client IP (throttles enrol + failed auth)
@@ -131,6 +140,14 @@ func (rt *Router) SetFleetAdmin(s fleetAdminService) { rt.fleetAdmin = s }
 func (rt *Router) SetFleetClusterInventory(s fleetClusterInventory) {
 	if rt.fleet != nil {
 		rt.fleet.clusterInv = s
+	}
+}
+
+// SetFleetHostInventory wires the VM host inventory ingest use case onto the agent transport plane.
+// It must be called after SetFleet; a nil fleet (transport disabled) makes it a no-op.
+func (rt *Router) SetFleetHostInventory(s fleetHostInventory) {
+	if rt.fleet != nil {
+		rt.fleet.hostInv = s
 	}
 }
 
@@ -225,6 +242,7 @@ func (f *fleetRouter) handler() http.Handler {
 	mux.HandleFunc("POST /api/v1/fleet/work/{id}/progress", f.entry(f.authed(f.progress)))
 	mux.HandleFunc("POST /api/v1/fleet/work/{id}/result", f.entry(f.authed(f.result)))
 	mux.HandleFunc("POST /api/v1/fleet/inventory/cluster", f.entry(f.authed(f.clusterInventory)))
+	mux.HandleFunc("POST /api/v1/fleet/inventory/host", f.entry(f.authed(f.hostInventory)))
 	return mux
 }
 
@@ -440,6 +458,38 @@ func (f *fleetRouter) clusterInventory(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]int{
 		"assets": res.Assets, "edges": res.Edges, "coverage_gaps": len(res.Gaps),
+	})
+}
+
+// hostInventory ingests a VM host inventory the agent collected and persists the host into the asset
+// model via the host-inventory use case. Tenant and actor come from the authenticated agent (never
+// the request body). The coverage summary (complete/degraded/gaps) is returned so a partial host
+// inventory is visible, never silently treated as clean.
+func (f *fleetRouter) hostInventory(w http.ResponseWriter, r *http.Request) {
+	if f.hostInv == nil {
+		writeJSON(w, http.StatusNotFound, errorBody{Error: "host inventory ingest not enabled"})
+		return
+	}
+	agent, ok := agentFrom(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
+		return
+	}
+	var inv dhi.HostInventory
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetInventoryCap)).Decode(&inv); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid host inventory body"})
+		return
+	}
+	res, err := f.hostInv.Sync(r.Context(), agent.ID.String(), hostinventoryuc.SyncInput{
+		TenantID:  agent.TenantID,
+		Inventory: inv,
+	})
+	if err != nil {
+		writeError(w, f.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"asset_id": res.AssetID.String(), "complete": res.Complete, "degraded": res.Degraded, "coverage_gaps": res.Coverage,
 	})
 }
 

--- a/internal/adapter/httpapi/fleet_ingest_test.go
+++ b/internal/adapter/httpapi/fleet_ingest_test.go
@@ -8,10 +8,12 @@ import (
 	"time"
 
 	dci "github.com/KKloudTarus/synapse-ce/internal/domain/clusterinventory"
+	dhi "github.com/KKloudTarus/synapse-ce/internal/domain/hostinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
 	clusterinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/clusterinventory"
+	hostinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/hostinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
 )
@@ -41,10 +43,15 @@ func setupFleetWithIngest(t *testing.T) (http.Handler, *fleetagentuc.Service, *m
 	if err != nil {
 		t.Fatalf("cluster inventory svc: %v", err)
 	}
+	hiSvc, err := hostinventoryuc.NewService(assetSvc, ftAudit{}, ftClock{})
+	if err != nil {
+		t.Fatalf("host inventory svc: %v", err)
+	}
 	rt := &Router{log: discardLog()}
 	rt.SetFleet(agentSvc, workSvc, func() time.Time { return time.Now().UTC() }, "")
 	rt.SetFleetAdmin(agentSvc)
 	rt.SetFleetClusterInventory(ciSvc)
+	rt.SetFleetHostInventory(hiSvc)
 	return rt.fleet.handler(), agentSvc, store
 }
 
@@ -171,5 +178,52 @@ func TestClusterInventoryIngestNotEnabled(t *testing.T) {
 	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/inventory/cluster", token, sampleClusterSnapshot(), true)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("ingest without the use case wired must be 404, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func sampleHostInventory() dhi.HostInventory {
+	return dhi.HostInventory{
+		Facts:    dhi.HostFacts{Hostname: "web01", OS: "linux", OSVersion: "12", MachineID: "abc123"},
+		Complete: true,
+	}
+}
+
+func TestHostInventoryIngestPersists(t *testing.T) {
+	h, agentSvc, store := setupFleetWithIngest(t)
+	token := enrolAgentToken(t, h, agentSvc)
+
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/inventory/host", token, sampleHostInventory(), true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("host ingest should be 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	assets, err := store.ListAssets(context.Background(), "default")
+	if err != nil {
+		t.Fatalf("list assets: %v", err)
+	}
+	var haveHost bool
+	for _, a := range assets {
+		if a.Kind == "host" && a.Key == "machine-id/abc123" {
+			haveHost = true
+		}
+	}
+	if !haveHost {
+		t.Fatalf("expected the host asset persisted under tenant default, got %d assets", len(assets))
+	}
+}
+
+func TestHostInventoryIngestRequiresAuth(t *testing.T) {
+	h, _, _ := setupFleetWithIngest(t)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/inventory/host", "", sampleHostInventory(), true)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated host ingest must be 401, got %d", w.Code)
+	}
+}
+
+func TestHostInventoryIngestNotEnabled(t *testing.T) {
+	h, agentSvc, _ := setupFleet(t)
+	token := enrolAgentToken(t, h, agentSvc)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/inventory/host", token, sampleHostInventory(), true)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("host ingest without the use case wired must be 404, got %d", w.Code)
 	}
 }

--- a/internal/domain/hostinventory/hostinventory.go
+++ b/internal/domain/hostinventory/hostinventory.go
@@ -50,30 +50,31 @@ func (k CoverageKind) Degraded() bool {
 	return k == CoverageUnreadableDB
 }
 
-// CoverageIssue is one reason the inventory is not fully trustworthy.
+// CoverageIssue is one reason the inventory is not fully trustworthy. The json tags are the wire
+// contract shared by the agent (encoder) and the control-plane ingest endpoint (decoder).
 type CoverageIssue struct {
-	Kind   CoverageKind
-	Detail string
+	Kind   CoverageKind `json:"kind"`
+	Detail string       `json:"detail,omitempty"`
 }
 
 // HostFacts identify the host and are the substrate for the asset inventory (#431).
 type HostFacts struct {
-	Hostname      string
-	OS            string // e.g. linux
-	OSVersion     string // from /etc/os-release
-	Kernel        string
-	Arch          string
-	MachineID     string // stable per-host identifier
-	CloudInstance string // cloud instance id when available; empty otherwise
+	Hostname      string `json:"hostname,omitempty"`
+	OS            string `json:"os,omitempty"`         // e.g. linux
+	OSVersion     string `json:"os_version,omitempty"` // from /etc/os-release
+	Kernel        string `json:"kernel,omitempty"`
+	Arch          string `json:"arch,omitempty"`
+	MachineID     string `json:"machine_id,omitempty"`     // stable per-host identifier
+	CloudInstance string `json:"cloud_instance,omitempty"` // cloud instance id when available; empty otherwise
 }
 
 // HostInventory is a point-in-time host assessment. Complete is derived from Coverage: it is true
 // only when there are no coverage issues.
 type HostInventory struct {
-	Facts    HostFacts
-	Packages []sbom.Component
-	Coverage []CoverageIssue
-	Complete bool
+	Facts    HostFacts        `json:"facts"`
+	Packages []sbom.Component `json:"packages,omitempty"`
+	Coverage []CoverageIssue  `json:"coverage,omitempty"`
+	Complete bool             `json:"complete"`
 }
 
 // Normalize deterministically orders packages and coverage and derives Complete. It never mutates

--- a/internal/infrastructure/fleetclient/client.go
+++ b/internal/infrastructure/fleetclient/client.go
@@ -99,6 +99,13 @@ func (c *Client) SendClusterInventory(ctx context.Context, token string, snap an
 	return c.do(ctx, http.MethodPost, "/api/v1/fleet/inventory/cluster", token, snap, nil)
 }
 
+// SendHostInventory posts a collected VM host inventory to the control plane, which persists the host
+// into the asset model (#446). inv must be a JSON-tagged hostinventory.HostInventory; the caller
+// passes it as the marshalable value so this package keeps no domain dependency.
+func (c *Client) SendHostInventory(ctx context.Context, token string, inv any) error {
+	return c.do(ctx, http.MethodPost, "/api/v1/fleet/inventory/host", token, inv, nil)
+}
+
 func (c *Client) do(ctx context.Context, method, path, token string, body, out any) error {
 	var reader io.Reader
 	if body != nil {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -192,6 +192,10 @@ type Config struct {
 	// POSTs a Kubernetes snapshot that is persisted into the asset model. Off by default. It requires
 	// both FleetEnabled (transport) and FleetAssetsEnabled (persistence); it is a no-op otherwise.
 	FleetClusterIngestEnabled bool
+	// FleetHostIngestEnabled turns on the host-inventory ingest endpoint (#446), where a VM agent POSTs
+	// its collected host inventory (facts + packages + coverage) to be persisted as a Kind=host asset.
+	// Off by default; requires FleetEnabled + FleetAssetsEnabled.
+	FleetHostIngestEnabled bool
 	// FleetSignerKey is the HMAC key that signs agent work orders. Required and at least 32 bytes
 	// when FleetEnabled; a missing/short key fails startup closed rather than boot a forgeable signer.
 	FleetSignerKey string
@@ -462,6 +466,7 @@ func Load() Config {
 		FleetAssetsEnabled:        getbool("SYNAPSE_FLEET_ASSETS_ENABLED", false),
 		FleetEnabled:              getbool("SYNAPSE_FLEET_ENABLED", false),
 		FleetClusterIngestEnabled: getbool("SYNAPSE_FLEET_CLUSTER_INGEST_ENABLED", false),
+		FleetHostIngestEnabled:    getbool("SYNAPSE_FLEET_HOST_INGEST_ENABLED", false),
 		FleetSignerKey:            getenv("SYNAPSE_FLEET_SIGNER_KEY", ""),
 		FleetCACertPEM:            getenv("SYNAPSE_FLEET_CA_CERT", ""),
 		FleetCAKeyPEM:             getenv("SYNAPSE_FLEET_CA_KEY", ""),

--- a/internal/usecase/fleet/hostinventory/service.go
+++ b/internal/usecase/fleet/hostinventory/service.go
@@ -1,0 +1,158 @@
+// Package hostinventory is the use-case layer for the VM host agent (#410/#446, epic #405). It takes
+// a host inventory an agent collected (facts + installed OS packages + coverage) and persists the
+// host as a Kind=host asset in the fleet asset model (#431), reusing the asset use case's idempotent
+// upsert-by-natural-key + audit path.
+//
+// Coverage honesty is preserved: the inventory's coverage issues are recorded (count + degraded flag
+// on the asset, each issue audited), so a partial host inventory is never presented as complete. The
+// package LIST feeds the SCA vulnerability pipeline separately; the asset model records the host
+// identity, its facts, and a package count — it is not a package table.
+package hostinventory
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	dhi "github.com/KKloudTarus/synapse-ce/internal/domain/hostinventory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// AssetWriter is the subset of the asset use case this service needs (idempotent host upsert).
+// assetuc.Service satisfies it; tests use a fake.
+type AssetWriter interface {
+	UpsertAsset(ctx context.Context, actor string, in assetuc.UpsertAssetInput) (*asset.Asset, error)
+}
+
+// The concrete asset use case satisfies the consumer-side interface.
+var _ AssetWriter = (*assetuc.Service)(nil)
+
+// Service maps and persists a host inventory.
+type Service struct {
+	assets AssetWriter
+	audit  ports.AuditLogger
+	clock  ports.Clock
+}
+
+// NewService validates its dependencies and constructs the service.
+func NewService(assets AssetWriter, audit ports.AuditLogger, clock ports.Clock) (*Service, error) {
+	if assets == nil {
+		return nil, fmt.Errorf("%w: host inventory requires an asset writer", shared.ErrValidation)
+	}
+	if audit == nil {
+		return nil, fmt.Errorf("%w: host inventory requires an audit logger", shared.ErrValidation)
+	}
+	if clock == nil {
+		return nil, fmt.Errorf("%w: host inventory requires a clock", shared.ErrValidation)
+	}
+	return &Service{assets: assets, audit: audit, clock: clock}, nil
+}
+
+// SyncInput describes one observation of a host.
+type SyncInput struct {
+	TenantID  shared.ID
+	Inventory dhi.HostInventory
+}
+
+// SyncResult reports what a sync produced.
+type SyncResult struct {
+	AssetID  shared.ID
+	Complete bool
+	Degraded bool
+	Coverage int
+}
+
+// Sync persists the host as a Kind=host asset. It is idempotent: two syncs of an unchanged host reuse
+// the asset id (keyed by the host's stable identity) and produce no churn.
+func (s *Service) Sync(ctx context.Context, actor string, in SyncInput) (*SyncResult, error) {
+	if strings.TrimSpace(actor) == "" {
+		return nil, fmt.Errorf("%w: host inventory actor is required", shared.ErrValidation)
+	}
+	if in.TenantID.IsZero() {
+		return nil, fmt.Errorf("%w: host inventory tenant id is required", shared.ErrValidation)
+	}
+	inv := in.Inventory.Normalize()
+
+	key := hostKey(inv.Facts)
+	if key == "" {
+		return nil, fmt.Errorf("%w: host has no stable identity (machine id or hostname required)", shared.ErrValidation)
+	}
+	degraded := inv.Degraded()
+
+	a, err := s.assets.UpsertAsset(ctx, actor, assetuc.UpsertAssetInput{
+		TenantID:   in.TenantID,
+		Kind:       asset.KindHost,
+		Key:        key,
+		Name:       displayName(inv.Facts, key),
+		Attributes: attributes(inv, degraded),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("host inventory: upsert host asset: %w", err)
+	}
+
+	// Audit each coverage gap so a partial host inventory is durably attributable, not just implied.
+	now := s.clock.Now()
+	for _, c := range inv.Coverage {
+		if err := s.audit.Record(ctx, ports.AuditEntry{
+			Actor:  actor,
+			Action: "host_inventory.coverage_gap",
+			Target: key,
+			Metadata: map[string]string{
+				"tenant_id": in.TenantID.String(),
+				"gap_kind":  string(c.Kind),
+				"detail":    c.Detail,
+			},
+			At: now,
+		}); err != nil {
+			return nil, fmt.Errorf("host inventory: audit coverage gap: %w", err)
+		}
+	}
+
+	return &SyncResult{AssetID: a.ID, Complete: inv.Complete, Degraded: degraded, Coverage: len(inv.Coverage)}, nil
+}
+
+// hostKey is the host's stable natural key: the machine id when known (survives hostname changes),
+// else a hostname-derived key, else empty (unidentifiable).
+func hostKey(f dhi.HostFacts) string {
+	if f.MachineID != "" {
+		return "machine-id/" + f.MachineID
+	}
+	if f.Hostname != "" {
+		return "hostname/" + f.Hostname
+	}
+	return ""
+}
+
+func displayName(f dhi.HostFacts, key string) string {
+	if f.Hostname != "" {
+		return f.Hostname
+	}
+	return key
+}
+
+func attributes(inv dhi.HostInventory, degraded bool) map[string]string {
+	f := inv.Facts
+	attrs := map[string]string{
+		"os":             f.OS,
+		"os_version":     f.OSVersion,
+		"kernel":         f.Kernel,
+		"arch":           f.Arch,
+		"machine_id":     f.MachineID,
+		"cloud_instance": f.CloudInstance,
+		"packages":       strconv.Itoa(len(inv.Packages)),
+		"complete":       strconv.FormatBool(inv.Complete),
+		"degraded":       strconv.FormatBool(degraded),
+		"coverage_gaps":  strconv.Itoa(len(inv.Coverage)),
+	}
+	// Drop empty fact values so the asset attributes stay clean.
+	for k, v := range attrs {
+		if v == "" {
+			delete(attrs, k)
+		}
+	}
+	return attrs
+}

--- a/internal/usecase/fleet/hostinventory/service_test.go
+++ b/internal/usecase/fleet/hostinventory/service_test.go
@@ -1,0 +1,182 @@
+package hostinventory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	dhi "github.com/KKloudTarus/synapse-ce/internal/domain/hostinventory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeAssetWriter struct {
+	ids     map[string]shared.ID
+	next    int
+	upserts int
+	last    assetuc.UpsertAssetInput
+}
+
+func newFakeWriter() *fakeAssetWriter { return &fakeAssetWriter{ids: map[string]shared.ID{}} }
+
+func (f *fakeAssetWriter) UpsertAsset(_ context.Context, _ string, in assetuc.UpsertAssetInput) (*asset.Asset, error) {
+	f.upserts++
+	f.last = in
+	k := string(in.Kind) + "|" + in.Key
+	id, ok := f.ids[k]
+	if !ok {
+		f.next++
+		id = shared.ID("id-" + itoa(f.next))
+		f.ids[k] = id
+	}
+	return &asset.Asset{ID: id, TenantID: in.TenantID, Kind: in.Kind, Key: in.Key, Name: in.Name}, nil
+}
+
+type fakeAudit struct{ gaps int }
+
+func (f *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	if e.Action == "host_inventory.coverage_gap" {
+		f.gaps++
+	}
+	return nil
+}
+
+type fixedClock struct{}
+
+func (fixedClock) Now() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func newService(t *testing.T, w AssetWriter, a ports.AuditLogger) *Service {
+	t.Helper()
+	s, err := NewService(w, a, fixedClock{})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return s
+}
+
+func completeHost() dhi.HostInventory {
+	return dhi.HostInventory{
+		Facts:    dhi.HostFacts{Hostname: "web01", OS: "linux", OSVersion: "12", MachineID: "abc123"},
+		Packages: []sbom.Component{{Name: "acl", Version: "1"}, {Name: "zlib", Version: "2"}},
+	}
+}
+
+func TestSyncPersistsHostAsset(t *testing.T) {
+	w, a := newFakeWriter(), &fakeAudit{}
+	s := newService(t, w, a)
+	res, err := s.Sync(context.Background(), "agent-1", SyncInput{TenantID: "tenant-1", Inventory: completeHost()})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if w.upserts != 1 || w.last.Kind != asset.KindHost {
+		t.Fatalf("expected one host asset upsert, got %d kind=%s", w.upserts, w.last.Kind)
+	}
+	// Machine-id keys the host (survives hostname changes).
+	if w.last.Key != "machine-id/abc123" {
+		t.Fatalf("host key = %q", w.last.Key)
+	}
+	if w.last.Attributes["packages"] != "2" || w.last.Attributes["os_version"] != "12" {
+		t.Fatalf("facts/package count not in attributes: %+v", w.last.Attributes)
+	}
+	if !res.Complete || res.Degraded {
+		t.Fatalf("a clean host must be complete + not degraded: %+v", res)
+	}
+}
+
+func TestSyncFallsBackToHostnameKey(t *testing.T) {
+	w := newFakeWriter()
+	s := newService(t, w, &fakeAudit{})
+	inv := dhi.HostInventory{Facts: dhi.HostFacts{Hostname: "web01", OS: "linux"}}
+	if _, err := s.Sync(context.Background(), "a", SyncInput{TenantID: "t", Inventory: inv}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if w.last.Key != "hostname/web01" {
+		t.Fatalf("without a machine id the host must key by hostname, got %q", w.last.Key)
+	}
+}
+
+func TestSyncNoIdentityRejected(t *testing.T) {
+	w := newFakeWriter()
+	s := newService(t, w, &fakeAudit{})
+	inv := dhi.HostInventory{Facts: dhi.HostFacts{OS: "linux"}} // no machine id, no hostname
+	if _, err := s.Sync(context.Background(), "a", SyncInput{TenantID: "t", Inventory: inv}); err == nil {
+		t.Fatal("a host with no stable identity must be rejected")
+	}
+	if w.upserts != 0 {
+		t.Fatal("nothing must be persisted when the host is unidentifiable")
+	}
+}
+
+func TestSyncCoverageAuditedAndDegraded(t *testing.T) {
+	w, a := newFakeWriter(), &fakeAudit{}
+	s := newService(t, w, a)
+	inv := completeHost()
+	inv.AddIssue(dhi.CoverageUnreadableDB, "/var/lib/rpm unreadable")
+	inv.AddIssue(dhi.CoverageNotCollected, "listening-sockets")
+	res, err := s.Sync(context.Background(), "agent-1", SyncInput{TenantID: "t", Inventory: inv})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if !res.Degraded || res.Complete {
+		t.Fatalf("an unreadable DB must be degraded + incomplete: %+v", res)
+	}
+	if a.gaps != 2 {
+		t.Fatalf("every coverage gap must be audited, got %d", a.gaps)
+	}
+	if w.last.Attributes["degraded"] != "true" {
+		t.Fatalf("the host asset must record degraded=true, got %v", w.last.Attributes)
+	}
+}
+
+func TestSyncIdempotent(t *testing.T) {
+	w := newFakeWriter()
+	s := newService(t, w, &fakeAudit{})
+	in := SyncInput{TenantID: "t", Inventory: completeHost()}
+	first, _ := s.Sync(context.Background(), "a", in)
+	ids := len(w.ids)
+	second, _ := s.Sync(context.Background(), "a", in)
+	if len(w.ids) != ids {
+		t.Fatalf("re-sync must reuse the host asset id (no churn): %d -> %d", ids, len(w.ids))
+	}
+	if first.AssetID != second.AssetID {
+		t.Fatalf("re-sync must resolve the same asset id")
+	}
+}
+
+func TestSyncValidation(t *testing.T) {
+	s := newService(t, newFakeWriter(), &fakeAudit{})
+	ctx := context.Background()
+	if _, err := s.Sync(ctx, "", SyncInput{TenantID: "t", Inventory: completeHost()}); err == nil {
+		t.Error("empty actor must be rejected")
+	}
+	if _, err := s.Sync(ctx, "a", SyncInput{Inventory: completeHost()}); err == nil {
+		t.Error("empty tenant must be rejected")
+	}
+}
+
+func TestNewServiceValidatesDeps(t *testing.T) {
+	if _, err := NewService(nil, &fakeAudit{}, fixedClock{}); err == nil {
+		t.Error("nil asset writer must be rejected")
+	}
+	if _, err := NewService(newFakeWriter(), nil, fixedClock{}); err == nil {
+		t.Error("nil audit must be rejected")
+	}
+	if _, err := NewService(newFakeWriter(), &fakeAudit{}, nil); err == nil {
+		t.Error("nil clock must be rejected")
+	}
+}


### PR DESCRIPTION
## What

The **VM host-inventory ingest path** — mirror of the cluster ingest (#447) for hosts, making **#410 end-to-end**: `synapse-agent` now reports its collected host inventory to the control plane, which persists the host as a `Kind=host` asset (#431). PR 3 of the #446 series.

## How

- **`internal/usecase/fleet/hostinventory`** — persists a host inventory as a `Kind=host` asset via the asset use case (consumer-side `AssetWriter`, `assetuc.Service` satisfies it). Key = the machine id when known (`machine-id/<id>`, survives hostname changes), else `hostname/<name>`, else **rejected** (no unidentifiable asset). Facts + package **count** + `complete`/`degraded`/coverage-gap count become asset attributes; each coverage gap is audited. Idempotent by natural key (no churn on re-sync).
- **`POST /api/v1/fleet/inventory/host`** on the agent transport plane, behind the same `entry`→`authed` guard; tenant + actor come from the authenticated agent (never the body); 16 MiB body cap; returns a coverage-honest summary (`asset_id`, `complete`, `degraded`, `coverage_gaps`). `fleetHostInventory` consumer interface + `SetFleetHostInventory` setter; route 404s when unwired.
- **`SYNAPSE_FLEET_HOST_INGEST_ENABLED`** flag; wired in `synapse-api` (requires the asset model, fails startup closed otherwise).
- **`synapse-agent`** now calls `SendHostInventory` after buffering; a failed report **fails the order** (the local buffer preserves the data), and a degraded inventory still fails closed.
- Host inventory domain types carry snake_case `json` tags (wire contract shared by the agent encoder + server decoder), matching the cluster Snapshot.

## Why package count, not a package table

The #431 asset model has no "package" kind. The host asset records identity + facts + a package **count** + coverage; the package **list** feeds the existing SCA vulnerability pipeline separately. Representing the host this way keeps the asset graph clean and honest.

## Golden rules

Authenticated + tenant-isolated (agent-derived tenant only; empty = DENY under RLS); coverage-honest (gaps audited, degraded flagged, never a silent clean success); bounded body; nothing sensitive logged; no exec/shell.

## Deferred (last #446 follow-up)

PR4: a scanned-image-digest source so an unscanned running digest in the cluster ingest is an accurate coverage gap (until then it conservatively reports all as unscanned). Then #446 closes.

## Tests

Host usecase: persists KindHost, machine-id vs hostname key, no-identity rejected, coverage audited + degraded, idempotent, validation, nil-deps. httptest: enrol → POST host inventory → `Kind=host` asset persisted under the agent tenant; unauthenticated → 401; not-wired → 404. `synapse-agent`: reports the inventory on success; a report failure fails the order. `go build ./... && go vet ./...` clean; `golangci-lint` 0 issues.
