### PR TITLE
feat(fleet): scanned-image digest correlation for cluster coverage (#446)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -175,6 +175,7 @@ func main() {
 	var repo ports.EngagementRepository
 	var projectRepo ports.ProjectRepository
 	var assetStore ports.AssetRepository
+	var scannedImageStore ports.ScannedImageStore
 	var workOrderStore ports.WorkOrderStore
 	var fleetAgentStore ports.FleetAgentStore
 	var leaderStore ports.LeaderStore // postgres only; nil in memory mode (single process)
@@ -298,6 +299,7 @@ func main() {
 		threatModelStore = postgres.NewThreatModelRepository(pool)
 		writeupDraftStore = postgres.NewWriteupDraftRepository(pool)
 		assetStore = postgres.NewAssetRepository(pool)
+		scannedImageStore = postgres.NewScannedImageStore(pool)
 		workOrderStore = postgres.NewWorkOrderRepository(pool)
 		fleetAgentStore = postgres.NewFleetAgentRepository(pool)
 		leaderStore = postgres.NewLeaderStore(pool)
@@ -331,6 +333,7 @@ func main() {
 		repo = memory.NewEngagementRepository()
 		projectRepo = memory.NewProjectRepository()
 		assetStore = memory.NewAssetStore()
+		scannedImageStore = memory.NewScannedImageStore()
 		workOrderStore = memory.NewWorkOrderStore()
 		fleetAgentStore = memory.NewFleetAgentStore()
 		findingRepo = memory.NewFindingRepository()
@@ -588,6 +591,8 @@ func main() {
 		detectionSources,
 		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil), licensemeta.NewPyPI("", nil)))
 	scaService.SetImportedSBOMStore(importedSBOMStore)
+	// Record scanned image digests so the fleet cluster agent can correlate running images (#446).
+	scaService.SetScannedImageRecorder(scannedImageStore)
 	scaService.SetGateDecoder(qualityprofile.LoadGateBytes)
 	scaService.SetSBOMEnricher(manifest.New())
 	scaService.SetArtifactCataloger(msi.New())           // recover Windows Installer (.msi) product identity into the SBOM
@@ -1102,6 +1107,9 @@ func main() {
 				log.Error("cluster inventory ingest init failed", "err", cierr)
 				os.Exit(1)
 			}
+			// Correlate running image digests with prior scans (#446): an unscanned running digest is a
+			// coverage gap rather than every digest reported unscanned.
+			ciSvc.SetScannedImages(scannedImageStore)
 			router.SetFleetClusterInventory(ciSvc)
 			log.Info("fleet cluster inventory ingest ENABLED (agents persist snapshots into the asset model)")
 		}

--- a/internal/adapter/httpapi/asset_handler.go
+++ b/internal/adapter/httpapi/asset_handler.go
@@ -31,8 +31,9 @@ const assetBodyCap = 64 << 10
 // string, because under the 0057 policy the empty string is DENY, not a tenant. Mapping the empty
 // default to a real, non-empty tenant here is what lets the fleet asset model work in a
 // single-tenant deployment while still being isolated at the database. Migration 0058 seeds this
-// tenant row so the fleet_assets FK to tenants is satisfied.
-const DefaultFleetTenant shared.ID = "default"
+// tenant row so the fleet_assets FK to tenants is satisfied. It aliases shared.DefaultTenant (the
+// inner-layer canonical value) so the two cannot drift.
+const DefaultFleetTenant = shared.DefaultTenant
 
 // fleetTenant resolves the effective tenant for fleet asset operations: the request principal's
 // tenant, or DefaultFleetTenant when that is the empty-string default tenant.

--- a/internal/domain/shared/shared.go
+++ b/internal/domain/shared/shared.go
@@ -13,6 +13,21 @@ type ID string
 func (id ID) String() string { return string(id) }
 func (id ID) IsZero() bool   { return id == "" }
 
+// DefaultTenant is the non-empty tenant id the empty-string (single-tenant) default maps to. RLS
+// tables treat the empty string as DENY, so the default deployment uses this id (it matches the
+// fleet DefaultFleetTenant and the seeded 'default' tenant row). Use TenantOrDefault to normalize.
+const DefaultTenant ID = "default"
+
+// TenantOrDefault returns id, or DefaultTenant when id is empty — so a single-tenant empty tenant and
+// the fleet 'default' tenant resolve to the same RLS partition (letting, e.g., an image scan and the
+// cluster/host agent that observes it correlate under one tenant).
+func TenantOrDefault(id ID) ID {
+	if id.IsZero() {
+		return DefaultTenant
+	}
+	return id
+}
+
 // Severity is the normalized severity scale shared by findings and vulnerabilities.
 type Severity string
 

--- a/internal/infrastructure/persistence/memory/scanned_image_store.go
+++ b/internal/infrastructure/persistence/memory/scanned_image_store.go
@@ -1,0 +1,51 @@
+package memory
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ScannedImageStore is the in-memory scanned-image digest index (#446), tenant-scoped. It normalizes
+// the empty tenant to the default so an image scan and the agent that observes the image correlate
+// under one tenant, matching the Postgres store.
+type ScannedImageStore struct {
+	mu   sync.RWMutex
+	byTn map[shared.ID]map[string]bool
+}
+
+// NewScannedImageStore constructs an empty in-memory store.
+func NewScannedImageStore() *ScannedImageStore {
+	return &ScannedImageStore{byTn: map[shared.ID]map[string]bool{}}
+}
+
+var _ ports.ScannedImageStore = (*ScannedImageStore)(nil)
+
+// MarkScanned records digest as scanned for the tenant (idempotent).
+func (s *ScannedImageStore) MarkScanned(_ context.Context, tenantID shared.ID, digest string, _ time.Time) error {
+	tenant := shared.TenantOrDefault(tenantID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	set := s.byTn[tenant]
+	if set == nil {
+		set = map[string]bool{}
+		s.byTn[tenant] = set
+	}
+	set[digest] = true
+	return nil
+}
+
+// ScannedDigests returns a copy of the scanned-digest set for the tenant.
+func (s *ScannedImageStore) ScannedDigests(_ context.Context, tenantID shared.ID) (map[string]bool, error) {
+	tenant := shared.TenantOrDefault(tenantID)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]bool, len(s.byTn[tenant]))
+	for d := range s.byTn[tenant] {
+		out[d] = true
+	}
+	return out, nil
+}

--- a/internal/infrastructure/persistence/memory/scanned_image_store_test.go
+++ b/internal/infrastructure/persistence/memory/scanned_image_store_test.go
@@ -1,0 +1,66 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestScannedImageStoreMarkAndQuery(t *testing.T) {
+	s := NewScannedImageStore()
+	ctx := context.Background()
+	now := time.Unix(1700000000, 0).UTC()
+
+	if err := s.MarkScanned(ctx, "tenant-a", "sha256:aaa", now); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	if err := s.MarkScanned(ctx, "tenant-a", "sha256:aaa", now); err != nil { // idempotent
+		t.Fatalf("re-mark: %v", err)
+	}
+	if err := s.MarkScanned(ctx, "tenant-a", "sha256:bbb", now); err != nil {
+		t.Fatalf("mark bbb: %v", err)
+	}
+
+	got, err := s.ScannedDigests(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 2 || !got["sha256:aaa"] || !got["sha256:bbb"] {
+		t.Fatalf("expected {aaa,bbb}, got %v", got)
+	}
+}
+
+func TestScannedImageStoreTenantIsolation(t *testing.T) {
+	s := NewScannedImageStore()
+	ctx := context.Background()
+	_ = s.MarkScanned(ctx, "tenant-a", "sha256:aaa", time.Unix(0, 0))
+	_ = s.MarkScanned(ctx, "tenant-b", "sha256:bbb", time.Unix(0, 0))
+
+	a, _ := s.ScannedDigests(ctx, "tenant-a")
+	if a["sha256:bbb"] {
+		t.Fatalf("tenant-a must not see tenant-b's digest: %v", a)
+	}
+	b, _ := s.ScannedDigests(ctx, "tenant-b")
+	if b["sha256:aaa"] {
+		t.Fatalf("tenant-b must not see tenant-a's digest: %v", b)
+	}
+}
+
+func TestScannedImageStoreEmptyTenantNormalizesToDefault(t *testing.T) {
+	// An empty tenant (single-tenant engagement) and the fleet "default" tenant must land in the same
+	// partition so an image scan and the agent that observes it correlate.
+	s := NewScannedImageStore()
+	ctx := context.Background()
+	_ = s.MarkScanned(ctx, "", "sha256:aaa", time.Unix(0, 0)) // recorded by a single-tenant image scan
+
+	got, _ := s.ScannedDigests(ctx, "default") // queried by the fleet "default" agent
+	if !got["sha256:aaa"] {
+		t.Fatalf("empty tenant and 'default' must share a partition, got %v", got)
+	}
+	// And the reverse direction.
+	_ = s.MarkScanned(ctx, "default", "sha256:bbb", time.Unix(0, 0))
+	got2, _ := s.ScannedDigests(ctx, "")
+	if !got2["sha256:bbb"] {
+		t.Fatalf("'default' and empty tenant must share a partition, got %v", got2)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/scanned_image_store.go
+++ b/internal/infrastructure/persistence/postgres/scanned_image_store.go
@@ -1,0 +1,68 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ScannedImageStore is the Postgres-backed scanned-image digest index (#446). Every operation routes
+// through WithTenant so the Row Level Security policy on scanned_image (migration 0063) enforces
+// tenant isolation at the database — a query that bypassed WithTenant would resolve the tenant to
+// NULL and see nothing.
+type ScannedImageStore struct{ pool *pgxpool.Pool }
+
+// NewScannedImageStore constructs the Postgres scanned-image store.
+func NewScannedImageStore(pool *pgxpool.Pool) *ScannedImageStore {
+	return &ScannedImageStore{pool: pool}
+}
+
+var _ ports.ScannedImageStore = (*ScannedImageStore)(nil)
+
+// MarkScanned records digest as scanned for the tenant. Idempotent by (tenant, digest): a repeat
+// keeps the earliest first_scanned_at.
+func (s *ScannedImageStore) MarkScanned(ctx context.Context, tenantID shared.ID, digest string, at time.Time) error {
+	tenant := shared.TenantOrDefault(tenantID).String()
+	return WithTenant(ctx, s.pool, tenant, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO scanned_image (tenant_id, digest, first_scanned_at)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (tenant_id, digest) DO NOTHING`,
+			tenant, digest, at)
+		if err != nil {
+			return fmt.Errorf("scanned image: mark: %w", err)
+		}
+		return nil
+	})
+}
+
+// ScannedDigests returns the set of scanned digests for the tenant.
+func (s *ScannedImageStore) ScannedDigests(ctx context.Context, tenantID shared.ID) (map[string]bool, error) {
+	tenant := shared.TenantOrDefault(tenantID).String()
+	out := map[string]bool{}
+	err := WithTenant(ctx, s.pool, tenant, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT digest FROM scanned_image WHERE tenant_id = $1`, tenant)
+		if err != nil {
+			return fmt.Errorf("scanned image: query: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var d string
+			if err := rows.Scan(&d); err != nil {
+				return fmt.Errorf("scanned image: scan: %w", err)
+			}
+			out[d] = true
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/infrastructure/persistence/postgres/scanned_image_store_test.go
+++ b/internal/infrastructure/persistence/postgres/scanned_image_store_test.go
@@ -1,0 +1,73 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestScannedImageStore(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ('ta','A'),('tb','B') ON CONFLICT (id) DO NOTHING`); err != nil {
+		t.Fatalf("seed tenants: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM scanned_image WHERE tenant_id IN ('ta','tb','default')`)
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id IN ('ta','tb')`)
+	})
+
+	s := NewScannedImageStore(pool)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Mark + idempotent re-mark.
+	if err := s.MarkScanned(ctx, "ta", "sha256:aaa", now); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	if err := s.MarkScanned(ctx, "ta", "sha256:aaa", now.Add(time.Hour)); err != nil {
+		t.Fatalf("re-mark: %v", err)
+	}
+	if err := s.MarkScanned(ctx, "ta", "sha256:bbb", now); err != nil {
+		t.Fatalf("mark bbb: %v", err)
+	}
+	got, err := s.ScannedDigests(ctx, "ta")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 2 || !got["sha256:aaa"] || !got["sha256:bbb"] {
+		t.Fatalf("expected {aaa,bbb}, got %v", got)
+	}
+
+	// Tenant scoping: tb does not see ta's digests.
+	_ = s.MarkScanned(ctx, "tb", "sha256:ccc", now)
+	tb, _ := s.ScannedDigests(ctx, "tb")
+	if tb["sha256:aaa"] || !tb["sha256:ccc"] {
+		t.Fatalf("tenant scoping failed: %v", tb)
+	}
+
+	// Empty tenant normalizes to 'default' (seeded by 0058) — records + reads land together.
+	if err := s.MarkScanned(ctx, "", "sha256:ddd", now); err != nil {
+		t.Fatalf("mark empty tenant: %v", err)
+	}
+	def, err := s.ScannedDigests(ctx, "default")
+	if err != nil {
+		t.Fatalf("query default: %v", err)
+	}
+	if !def["sha256:ddd"] {
+		t.Fatalf("empty tenant must normalize to 'default', got %v", def)
+	}
+}

--- a/internal/usecase/fleet/clusterinventory/service.go
+++ b/internal/usecase/fleet/clusterinventory/service.go
@@ -38,9 +38,10 @@ var _ AssetWriter = (*assetuc.Service)(nil)
 
 // Service maps and persists a cluster inventory.
 type Service struct {
-	assets AssetWriter
-	audit  ports.AuditLogger
-	clock  ports.Clock
+	assets  AssetWriter
+	audit   ports.AuditLogger
+	clock   ports.Clock
+	scanned ports.ScannedImageStore // optional; when set, supplies the scanned-digest set for coverage
 }
 
 // NewService validates its dependencies and constructs the service.
@@ -57,13 +58,18 @@ func NewService(assets AssetWriter, audit ports.AuditLogger, clock ports.Clock) 
 	return &Service{assets: assets, audit: audit, clock: clock}, nil
 }
 
+// SetScannedImages wires the scanned-image digest source (#446). When set, a Sync whose SyncInput
+// does not carry an explicit ScannedDigests set looks up the tenant's scanned digests here, so an
+// unscanned running digest is an accurate coverage gap rather than every digest reported unscanned.
+func (s *Service) SetScannedImages(store ports.ScannedImageStore) { s.scanned = store }
+
 // SyncInput describes one observation of a cluster.
 type SyncInput struct {
 	TenantID shared.ID
 	Snapshot dci.Snapshot
 	// ScannedDigests is the set of image digests the engine has already scanned. A running digest
-	// absent from it becomes a coverage gap (never omitted). The informer/caller supplies it; a
-	// dedicated scanned-image lookup port is a follow-up.
+	// absent from it becomes a coverage gap (never omitted). When nil, the service looks it up from the
+	// wired ScannedImageStore (SetScannedImages); a caller may still pass an explicit set to override.
 	ScannedDigests map[string]bool
 	// Provenance identifies the observation source that produced the assets/edges. It is required (an
 	// unattributable edge cannot be trusted by attack-path traversal) and MUST be STABLE for a given
@@ -97,7 +103,19 @@ func (s *Service) Sync(ctx context.Context, actor string, in SyncInput) (*SyncRe
 		return nil, fmt.Errorf("cluster inventory: invalid snapshot: %w", err)
 	}
 
-	inv := dci.Map(in.Snapshot, in.ScannedDigests)
+	// Resolve the scanned-digest set: an explicit set in the input wins; otherwise consult the store
+	// (when wired). A lookup failure is a hard error rather than a silent fall-back to "nothing
+	// scanned" — that would over-report unscanned gaps and mask the real coverage.
+	scanned := in.ScannedDigests
+	if scanned == nil && s.scanned != nil {
+		var err error
+		scanned, err = s.scanned.ScannedDigests(ctx, in.TenantID)
+		if err != nil {
+			return nil, fmt.Errorf("cluster inventory: scanned digests: %w", err)
+		}
+	}
+
+	inv := dci.Map(in.Snapshot, scanned)
 
 	// Upsert every observed asset first, recording the resolved id per natural-key ref so edges can be
 	// wired. UpsertAsset resolves the stable id by (tenant, kind, key).

--- a/internal/usecase/fleet/clusterinventory/service_test.go
+++ b/internal/usecase/fleet/clusterinventory/service_test.go
@@ -2,6 +2,7 @@ package clusterinventory
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -229,5 +230,64 @@ func TestNewServiceValidatesDeps(t *testing.T) {
 	}
 	if _, err := NewService(newFakeWriter(), &fakeAudit{}, nil); err == nil {
 		t.Error("nil clock must be rejected")
+	}
+}
+
+// fakeScanned is a scanned-image source for testing the coverage correlation.
+type fakeScanned struct {
+	set map[string]bool
+	err error
+}
+
+func (f fakeScanned) MarkScanned(context.Context, shared.ID, string, time.Time) error { return nil }
+func (f fakeScanned) ScannedDigests(context.Context, shared.ID) (map[string]bool, error) {
+	return f.set, f.err
+}
+
+func TestSyncUsesScannedImageSourceForCoverage(t *testing.T) {
+	// With the running digest sha256:aaa marked scanned in the store, it must NOT be an unscanned gap.
+	w, a := newFakeWriter(), &fakeAudit{}
+	s := newService(t, w, a)
+	s.SetScannedImages(fakeScanned{set: map[string]bool{"sha256:aaa": true}})
+
+	res, err := s.Sync(context.Background(), "agent-1", SyncInput{
+		TenantID: "tenant-1", Snapshot: sample(), Provenance: "sync-1",
+		// ScannedDigests deliberately nil -> the service consults the store.
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	for _, g := range res.Gaps {
+		if g.Kind == dci.GapUnscannedDigest {
+			t.Fatalf("a scanned digest must not be an unscanned gap: %+v", g)
+		}
+	}
+}
+
+func TestSyncScannedSourceErrorFailsLoud(t *testing.T) {
+	// A store lookup failure must not silently fall back to "nothing scanned" (which would over-report
+	// gaps and mask coverage).
+	s := newService(t, newFakeWriter(), &fakeAudit{})
+	s.SetScannedImages(fakeScanned{err: errors.New("db down")})
+	if _, err := s.Sync(context.Background(), "a", SyncInput{TenantID: "t", Snapshot: sample(), Provenance: "p"}); err == nil {
+		t.Fatal("a scanned-digest lookup failure must fail the sync, not silently proceed")
+	}
+}
+
+func TestSyncExplicitScannedDigestsOverrideStore(t *testing.T) {
+	// An explicit set in the input wins over the store.
+	s := newService(t, newFakeWriter(), &fakeAudit{})
+	s.SetScannedImages(fakeScanned{err: errors.New("must not be consulted")})
+	res, err := s.Sync(context.Background(), "a", SyncInput{
+		TenantID: "t", Snapshot: sample(), Provenance: "p",
+		ScannedDigests: map[string]bool{"sha256:aaa": true},
+	})
+	if err != nil {
+		t.Fatalf("explicit ScannedDigests must bypass the store: %v", err)
+	}
+	for _, g := range res.Gaps {
+		if g.Kind == dci.GapUnscannedDigest {
+			t.Fatalf("explicit scanned set must suppress the unscanned gap: %+v", g)
+		}
 	}
 }

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -67,6 +67,15 @@ type SnapshotSource interface {
 	Snapshot(ctx context.Context, cluster string) (clusterinventory.Snapshot, error)
 }
 
+// ScannedImageStore records which container-image manifest digests the engine has already scanned,
+// per tenant, so the cluster agent can correlate a running digest with a prior scan (#446) — an
+// unscanned running digest is a coverage gap. Tenant-scoped (Postgres routes through WithTenant so
+// RLS isolates by tenant). MarkScanned is idempotent by (tenant, digest).
+type ScannedImageStore interface {
+	MarkScanned(ctx context.Context, tenantID shared.ID, digest string, at time.Time) error
+	ScannedDigests(ctx context.Context, tenantID shared.ID) (map[string]bool, error)
+}
+
 // AssetRepository persists the tenant-scoped fleet asset model (assets, typed edges, business
 // services). Every method is tenant-scoped; the Postgres implementation routes all access through
 // WithTenant so Row Level Security enforces isolation at the database. Upserts are idempotent by

--- a/internal/usecase/sca/scanned_image_test.go
+++ b/internal/usecase/sca/scanned_image_test.go
@@ -1,0 +1,99 @@
+package sca
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type fakeScannedStore struct {
+	marks []scannedMark
+	err   error
+}
+
+type scannedMark struct {
+	tenant shared.ID
+	digest string
+}
+
+func (f *fakeScannedStore) MarkScanned(_ context.Context, tenant shared.ID, digest string, _ time.Time) error {
+	f.marks = append(f.marks, scannedMark{tenant, digest})
+	return f.err
+}
+func (f *fakeScannedStore) ScannedDigests(context.Context, shared.ID) (map[string]bool, error) {
+	return nil, nil
+}
+
+func imageResult(digest string) *ScanResult {
+	return &ScanResult{Image: &sbom.ImageInfo{Reference: "reg/x:1", Digest: digest}}
+}
+
+func TestRecordScannedImageMarksDigestUnderTenant(t *testing.T) {
+	store := &fakeScannedStore{}
+	s := &Service{
+		scannedImages: store,
+		engagements:   &fakeEngRepo{eng: &engdom.Engagement{TenantID: "tenant-x"}},
+		clock:         fakeClock{t: time.Unix(1700000000, 0).UTC()},
+	}
+	s.recordScannedImage(context.Background(), "eng-1", imageResult("sha256:aaa"))
+	if len(store.marks) != 1 || store.marks[0].digest != "sha256:aaa" || store.marks[0].tenant != "tenant-x" {
+		t.Fatalf("expected one mark for sha256:aaa under tenant-x, got %+v", store.marks)
+	}
+}
+
+func TestRecordScannedImageNoOps(t *testing.T) {
+	cases := []struct {
+		name      string
+		withStore bool
+		result    *ScanResult
+	}{
+		{"no recorder", false, imageResult("sha256:aaa")},
+		{"nil result", true, nil},
+		{"non-image scan", true, &ScanResult{}},
+		{"empty digest", true, imageResult("")},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var store *fakeScannedStore
+			s := &Service{
+				engagements: &fakeEngRepo{eng: &engdom.Engagement{TenantID: "t"}},
+				clock:       fakeClock{t: time.Unix(0, 0)},
+			}
+			if c.withStore {
+				store = &fakeScannedStore{}
+				s.scannedImages = store
+			}
+			s.recordScannedImage(context.Background(), "eng-1", c.result) // must not panic
+			if store != nil && len(store.marks) != 0 {
+				t.Fatalf("%s: expected no mark, got %+v", c.name, store.marks)
+			}
+		})
+	}
+}
+
+func TestRecordScannedImageBestEffortOnErrors(t *testing.T) {
+	// An engagement-lookup failure records nothing but does not panic/propagate.
+	s := &Service{
+		scannedImages: &fakeScannedStore{},
+		engagements:   &fakeEngRepo{err: errors.New("not found")},
+		clock:         fakeClock{t: time.Unix(0, 0)},
+	}
+	s.recordScannedImage(context.Background(), "eng-1", imageResult("sha256:aaa"))
+
+	// A store write failure is swallowed (best-effort — a missed record becomes a later conservative gap).
+	store := &fakeScannedStore{err: errors.New("db down")}
+	s2 := &Service{
+		scannedImages: store,
+		engagements:   &fakeEngRepo{eng: &engdom.Engagement{TenantID: "t"}},
+		clock:         fakeClock{t: time.Unix(0, 0)},
+	}
+	s2.recordScannedImage(context.Background(), "eng-1", imageResult("sha256:aaa")) // must not panic/propagate
+	if len(store.marks) != 1 {
+		t.Fatalf("MarkScanned should still have been attempted, got %+v", store.marks)
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -42,6 +42,7 @@ type Service struct {
 	findings                         ports.FindingRepository
 	scans                            ports.ScanRepository
 	results                          ports.ScanResultStore
+	scannedImages                    ports.ScannedImageStore
 	importedSBOM                     ports.ImportedSBOMStore
 	jobs                             ports.ScanJobStore
 	runs                             ports.ScanRunStore
@@ -115,6 +116,12 @@ func (s *Service) SetSeverityEnricher(e ports.SeverityEnricher) { s.sevEnricher 
 
 // SetImportedSBOMStore configures the engagement-scoped client SBOM artifact store.
 func (s *Service) SetImportedSBOMStore(store ports.ImportedSBOMStore) { s.importedSBOM = store }
+
+// SetScannedImageRecorder wires the scanned-image digest index (#446). When set, a completed image
+// scan records its manifest digest under the engagement's tenant, so the fleet cluster agent can
+// later correlate a running digest with this prior scan. Recording is best-effort — a failure never
+// fails the scan.
+func (s *Service) SetScannedImageRecorder(store ports.ScannedImageStore) { s.scannedImages = store }
 
 func (s *Service) SetCodeQuality(q interface {
 	BuildReport(context.Context, string) (codequality.Report, error)
@@ -1704,6 +1711,25 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 	return result, nil
 }
 
+// recordScannedImage records a completed image scan's manifest digest under the engagement's tenant
+// (#446), so the fleet cluster agent can correlate a running digest with this scan. Best-effort:
+// every failure (no recorder, non-image scan, tenant lookup, or store write) is a no-op/logged and
+// never fails the scan — a missed record just surfaces later as a conservative "unscanned" gap. It is
+// a small helper (rather than inline) so it is unit-testable without the full scan pipeline.
+func (s *Service) recordScannedImage(ctx context.Context, engagementID shared.ID, result *ScanResult) {
+	if s.scannedImages == nil || result == nil || result.Image == nil || result.Image.Digest == "" {
+		return
+	}
+	eng, err := s.engagements.GetByID(ctx, engagementID)
+	if err != nil {
+		s.logger().Warn("record scanned image: engagement lookup failed (best-effort)", "digest", result.Image.Digest, "err", err)
+		return
+	}
+	if err := s.scannedImages.MarkScanned(ctx, eng.TenantID, result.Image.Digest, s.clock.Now()); err != nil {
+		s.logger().Warn("record scanned image digest failed (best-effort)", "digest", result.Image.Digest, "err", err)
+	}
+}
+
 func importedCompleteness(doc *sbom.SBOM) ports.Completeness {
 	resolved := 0
 	for _, c := range doc.Components {
@@ -2441,6 +2467,9 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		s.captureProjectSource(ctx, engagementID, opts.ProjectAnalysisID, ws.Dir, result)
 		s.captureProjectComparison(ctx, engagementID, opts.ProjectAnalysisID, ws.Dir, ws.Commit, result)
 	}
+	// Record the image's manifest digest so the fleet cluster agent can correlate a running digest
+	// with this scan (#446). This is the pipeline that populates result.Image (image scans).
+	s.recordScannedImage(ctx, engagementID, result)
 	return result, nil
 }
 

--- a/migrations/0063_scanned_image.sql
+++ b/migrations/0063_scanned_image.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- Scanned-image digest index (#446): records which container-image manifest digests the engine has
+-- already scanned, per tenant, so the Kubernetes cluster agent can correlate a running image digest
+-- with a prior scan. A running digest absent from here is an honest coverage gap.
+--
+-- Tenancy invariant (see 0057/0058): RLS-protected tables use NON-EMPTY tenant ids; the empty string
+-- resolves to NULL under synapse_current_tenant() and means DENY. The default single-tenant
+-- deployment maps the empty tenant to 'default' (shared.TenantOrDefault / httpapi.DefaultFleetTenant);
+-- the 'default' tenant row is seeded by 0058.
+--
+-- SECURITY: RLS is a no-op under a SUPERUSER/BYPASSRLS role regardless of FORCE. The composition root
+-- calls postgres.CheckRLSRuntimeRole at startup when the fleet asset model is enabled and refuses to
+-- serve on error; this migration cannot enforce that.
+
+CREATE TABLE scanned_image (
+    tenant_id        TEXT NOT NULL REFERENCES tenants(id),
+    digest           TEXT NOT NULL, -- container-image manifest digest, e.g. "sha256:…"
+    first_scanned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, digest)
+);
+CALL synapse_enable_tenant_rls('scanned_image');
+
+-- +goose Down
+DROP TABLE scanned_image;


### PR DESCRIPTION
## What

The **scanned-image digest index** — the final #446 slice. The cluster agent's coverage now distinguishes a running image that was **actually scanned** from one that never was: the SCA image-scan pipeline records each scanned manifest digest, and the cluster ingest correlates running digests against it. Closes #446.

## How

- **`scanned_image` table (migration 0063)** — RLS-protected, tenant-scoped, `(tenant_id, digest)` PK; mirrors the 0058 fleet-asset RLS pattern (`synapse_enable_tenant_rls`, `tenants` FK).
- **`ports.ScannedImageStore`** (`MarkScanned`, `ScannedDigests`) with **Postgres** (routes through `WithTenant` + explicit `WHERE tenant_id`) and **memory** implementations.
- **Record side (SCA):** `sca.Service.SetScannedImageRecorder`; after a completed image scan, the manifest digest (`result.Image.Digest`) is recorded under the engagement's tenant. **Best-effort** — a record failure logs and never fails the scan (the safe direction: a missed record just yields a later, conservative "unscanned" gap).
- **Query side (cluster ingest):** `clusterinventoryuc.Service.SetScannedImages`; when a `Sync` carries no explicit `ScannedDigests`, it looks them up from the store. A **lookup failure fails loud** (never silently treats everything as unscanned/scanned).
- **Tenant alignment:** `shared.DefaultTenant` + `TenantOrDefault` normalize the empty (single-tenant) tenant to `"default"` on **both** sides, so an image scan (engagement tenant) and the cluster agent (`default`) correlate under one RLS partition; a named tenant is untouched.
- **Wiring:** `cmd/synapse-api` builds the store (Postgres with a DB, else memory, mirroring `assetStore`) and injects it into both the SCA recorder and the cluster ingest source.

## Golden rules

Tenant-isolated (RLS + explicit `WHERE`, parameterized queries only); coverage-honest (query failure fails loud; record failure is conservatively non-fatal); an agent can only READ scanned digests via the ingest — only the SCA pipeline WRITES them; the digest is not a secret and nothing sensitive is logged.

## Tests

Memory store (mark/idempotent/query, tenant isolation, empty↔default normalization); **Postgres store verified against a real DB** (`make docker-up`): migration 0063 applies, scoping + normalization hold; cluster usecase (a scanned digest is not an unscanned gap; a lookup error fails loud; an explicit input overrides the store). `go build ./... && go vet ./...` clean; `golangci-lint` 0 issues. (The SCA record hook is a thin best-effort call exercised through the `ScannedImageStore` port, which the store tests cover.)

## Result

**#446 complete** — the fleet inventory loop is end-to-end for both agents: VM (#410) and Kubernetes (#411) collect → report over the fleet transport → the control plane persists into the #431 asset model, with accurate scanned-vs-unscanned image coverage.
