### PR TITLE
fix(ai-triage): finish P0 review follow-ups

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1330,6 +1330,9 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 			if cfg.VerifierModel != "" && cfg.VerifierModel != cfg.FPTriageModel {
 				if vllm, verr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.VerifierModel, cfg.LLMTimeout); verr == nil {
 					coord.WithVerifier(vllm, cfg.VerifierModel)
+					if coord.VerifierModel() == "" {
+						fmt.Fprintf(os.Stderr, "synapse-cli: verifier model %q aliases the proposer after canonicalization; AI triage remains advisory-only\n", cfg.VerifierModel)
+					}
 				} else {
 					fmt.Fprintf(os.Stderr, "synapse-cli: verifier model %q unavailable; AI triage remains advisory-only: %v\n", cfg.VerifierModel, verr)
 				}

--- a/internal/usecase/ports/fptriage.go
+++ b/internal/usecase/ports/fptriage.go
@@ -44,7 +44,11 @@ type AICritique struct {
 // FPTriager runs an LLM false-positive critique over candidate findings from a workspace and returns a
 // per-candidate advisory verdict. It is best-effort and PROPOSE-ONLY: it never mutates or deletes a
 // finding. The caller applies the deterministic gate policy; only a verified critique that clears the
-// human-review floor can be retain-and-mark gate-exempt. Injected optionally into the scan pipeline;
+// human-review floor can be retain-and-mark gate-exempt.
+//
+// FPTriager is a trusted in-process boundary. The caller defensively revalidates its DTOs to contain a
+// buggy implementation or forged decision fields; it does not sandbox a malicious implementation that
+// already has the process's memory/filesystem authority. Injected optionally into the scan pipeline;
 // nil = no triage.
 type FPTriager interface {
 	Triage(ctx context.Context, candidates []finding.Finding, workspaceDir string) []AICritique

--- a/internal/usecase/sca/fptriage_policy.go
+++ b/internal/usecase/sca/fptriage_policy.go
@@ -2,6 +2,7 @@ package sca
 
 import (
 	"strings"
+	"unicode"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -131,6 +132,13 @@ func humanReviewFloor(item finding.Finding) string {
 		if _, protected := humanReviewCWEs[token]; protected {
 			return aiPolicyDangerousCWEFloor
 		}
+		// A token that claims to be a CWE but is not well-formed CWE-<digits> after canonicalization
+		// (e.g. "CWE-79:" from an embedded separator, "CWE-79A", or a bare "CWE-") must fail closed to
+		// human review rather than be treated as a known-but-unprotected weakness — otherwise a
+		// dangerous class could slip the floor on a malformed spelling.
+		if isMalformedCWE(token) {
+			return aiPolicyDangerousCWEFloor
+		}
 	}
 	// Unknown weakness identity is not evidence that a source/config finding is low risk. Until a
 	// producer supplies a CWE, keep it in human review rather than defaulting to exemptible.
@@ -141,13 +149,41 @@ func humanReviewFloor(item finding.Finding) string {
 }
 
 func cweTokens(value string) []string {
+	// Split on every listed delimiter plus ALL unicode whitespace (incl. NBSP/\f/\v) and the
+	// punctuation that commonly trails a CWE id in imported text ("CWE-79: XSS", "CWE-79."). The
+	// separator set must be at least as wide as the canonicalizer's tolerance, or a dangerous CWE
+	// spelled with an embedded separator would slip the human-review floor.
 	tokens := strings.FieldsFunc(strings.ToUpper(value), func(r rune) bool {
-		return r == ',' || r == ';' || r == '|' || r == '/' || r == ' ' || r == '\t' || r == '\n'
+		switch r {
+		case ',', ';', '|', '/', ':', '.', '(', ')':
+			return true
+		}
+		return unicode.IsSpace(r)
 	})
 	for i := range tokens {
 		tokens[i] = canonicalCWEToken(tokens[i])
 	}
 	return tokens
+}
+
+// isMalformedCWE reports a token that claims to be a CWE ("CWE-" prefix) but is not well-formed
+// CWE-<digits>. Such a token is treated as unparseable and fails closed to human review rather than
+// being read as a known-but-unprotected weakness (#452 review follow-up, defense in depth).
+func isMalformedCWE(token string) bool {
+	const prefix = "CWE-"
+	if !strings.HasPrefix(token, prefix) {
+		return false
+	}
+	digits := strings.TrimPrefix(token, prefix)
+	if digits == "" {
+		return true
+	}
+	for _, r := range digits {
+		if r < '0' || r > '9' {
+			return true
+		}
+	}
+	return false
 }
 
 // canonicalCWEToken normalizes numeric CWE aliases without weakening exact-token matching. Synapse's

--- a/internal/usecase/sca/fptriage_policy.go
+++ b/internal/usecase/sca/fptriage_policy.go
@@ -141,9 +141,37 @@ func humanReviewFloor(item finding.Finding) string {
 }
 
 func cweTokens(value string) []string {
-	return strings.FieldsFunc(strings.ToUpper(value), func(r rune) bool {
+	tokens := strings.FieldsFunc(strings.ToUpper(value), func(r rune) bool {
 		return r == ',' || r == ';' || r == '|' || r == '/' || r == ' ' || r == '\t' || r == '\n'
 	})
+	for i := range tokens {
+		tokens[i] = canonicalCWEToken(tokens[i])
+	}
+	return tokens
+}
+
+// canonicalCWEToken normalizes numeric CWE aliases without weakening exact-token matching. Synapse's
+// rule catalog emits canonical IDs, but imported findings may spell CWE-79 as CWE-0079. Malformed and
+// non-CWE tokens are left intact so normalization never guesses at an identifier.
+func canonicalCWEToken(token string) string {
+	const prefix = "CWE-"
+	if !strings.HasPrefix(token, prefix) {
+		return token
+	}
+	digits := strings.TrimPrefix(token, prefix)
+	if digits == "" {
+		return token
+	}
+	for _, r := range digits {
+		if r < '0' || r > '9' {
+			return token
+		}
+	}
+	digits = strings.TrimLeft(digits, "0")
+	if digits == "" {
+		digits = "0"
+	}
+	return prefix + digits
 }
 
 func hasCredentialCWE(value string) bool {

--- a/internal/usecase/sca/fptriage_test.go
+++ b/internal/usecase/sca/fptriage_test.go
@@ -184,6 +184,41 @@ func TestCWETokensCanonicalizeLeadingZerosWithoutSubstringMatching(t *testing.T)
 	}
 }
 
+func TestHumanReviewFloorFailsClosedOnEmbeddedSeparatorsAndMalformedCWE(t *testing.T) {
+	// A dangerous CWE spelled with an embedded separator/punctuation, or a malformed CWE token, must
+	// still be held for human review — the tokenizer's separators are as wide as the canonicalizer's
+	// tolerance, and any unparseable CWE-* token fails closed.
+	protected := []struct {
+		name, cwe string
+	}{
+		{"colon-space suffix", "CWE-79: Cross-site Scripting"},
+		{"trailing dot", "CWE-89."},
+		{"parenthesized", "CWE-798 (hard-coded credentials)"},
+		{"nbsp separator", "CWE-89 notes"},
+		{"form-feed separator", "CWE-89\fnotes"},
+		{"zero-padded with suffix", "CWE-0022: path traversal"},
+		{"malformed non-digit suffix", "CWE-79A"},
+		{"bare prefix", "CWE-"},
+	}
+	for _, tc := range protected {
+		item := finding.Finding{Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: tc.cwe}
+		if got := humanReviewFloor(item); got != aiPolicyDangerousCWEFloor {
+			t.Errorf("%s (%q): floor = %q, want %q (must fail closed)", tc.name, tc.cwe, got, aiPolicyDangerousCWEFloor)
+		}
+	}
+
+	// A genuinely benign, well-formed, non-protected CWE still clears the CWE floor (no over-blocking).
+	benign := finding.Finding{Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-327"}
+	if got := humanReviewFloor(benign); got != "" {
+		t.Errorf("well-formed non-protected CWE must not trip the floor, got %q", got)
+	}
+
+	// Credential CWEs are detected even with embedded punctuation.
+	if !hasCredentialCWE("CWE-798: hard-coded credentials") {
+		t.Error("credential CWE with a colon suffix must still be detected")
+	}
+}
+
 func TestApplyAIGatePolicyRequiresEvidenceLedger(t *testing.T) {
 	result := &ScanResult{
 		Findings: []finding.Finding{{DedupKey: "safe", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"}},

--- a/internal/usecase/sca/fptriage_test.go
+++ b/internal/usecase/sca/fptriage_test.go
@@ -159,6 +159,31 @@ func TestApplyAIGatePolicyRejectsForgedVerifiedFlag(t *testing.T) {
 	}
 }
 
+func TestCWETokensCanonicalizeLeadingZerosWithoutSubstringMatching(t *testing.T) {
+	got := cweTokens(" cwe-0079, CWE-0890 / CWE-0798 | custom-token ")
+	want := []string{"CWE-79", "CWE-890", "CWE-798", "CUSTOM-TOKEN"}
+	if len(got) != len(want) {
+		t.Fatalf("cweTokens = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("cweTokens[%d] = %q, want %q (%v)", i, got[i], want[i], got)
+		}
+	}
+
+	protected := finding.Finding{Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-0079"}
+	if got := humanReviewFloor(protected); got != aiPolicyDangerousCWEFloor {
+		t.Fatalf("zero-padded protected CWE bypassed human-review floor: %q", got)
+	}
+	nonCollision := finding.Finding{Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-0890"}
+	if got := humanReviewFloor(nonCollision); got != "" {
+		t.Fatalf("CWE-0890 must canonicalize to exact CWE-890, not collide with CWE-89: %q", got)
+	}
+	if !hasCredentialCWE("CWE-0798") {
+		t.Fatal("zero-padded credential CWE must remain excluded from LLM candidate selection")
+	}
+}
+
 func TestApplyAIGatePolicyRequiresEvidenceLedger(t *testing.T) {
 	result := &ScanResult{
 		Findings: []finding.Finding{{DedupKey: "safe", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"}},

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -211,7 +211,8 @@ func (s *Service) SetIncludeTestSecrets(v bool) { s.includeTestSecrets = v }
 // production-scope first-party source findings after they are built and records the advisory verdicts on
 // ScanResult.AITriage. The deterministic AI gate policy separately decides whether a verified consensus
 // clears the human-review floor; a suspected-FP opinion alone has no gate authority. Best-effort; nil =
-// no triage.
+// no triage. Implementations are trusted in-process components; policy revalidation contains buggy DTOs,
+// not malicious code that already holds process authority.
 func (s *Service) SetFPTriage(t ports.FPTriager) { s.fpTriager = t }
 
 // SetOSPackageCataloger configures optional owned OS-package cataloging (dpkg/apk) from a materialized image


### PR DESCRIPTION
Follow-up to #398
Parent epic: #387

## Summary

Completes the three non-blocking follow-ups from the final safety review on #398:

1. **CLI/API operator-warning parity**
   - after `WithVerifier`, the CLI now checks `coord.VerifierModel()` exactly like the API
   - canonical aliases remain advisory-only and emit a clear warning

2. **Zero-padded CWE canonicalization**
   - numeric identifiers such as `CWE-0079` normalize to `CWE-79`
   - exact-token matching is preserved: `CWE-0890` becomes `CWE-890` and does not collide with protected `CWE-89`
   - zero-padded credential IDs such as `CWE-0798` remain excluded from LLM candidate selection
   - malformed/non-CWE tokens are left unchanged rather than guessed

3. **Explicit FPTriager trust boundary**
   - documents that injected implementations are trusted in-process components
   - deterministic policy revalidation contains buggy/forged DTO fields, but is not a sandbox for malicious code that already has process authority

## Verification

- `go test -race ./internal/usecase/fptriage ./internal/usecase/sca`
- `go vet ./internal/usecase/fptriage ./internal/usecase/sca`
- `git diff --check`

Regression tests cover protected zero-padded CWE matching, exact non-collision, and credential-CWE candidate exclusion.

The local Windows Defender installation blocks reading the pre-existing `internal/infrastructure/tools/sast/php_lex_test.go` signature, so the aggregate CLI package could not be compiled locally; that file is restored and unchanged, and CI can compile it on Linux.
