### PR TITLE
fix(llm): enforce output token limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ capabilities below are already shipped on `main`.
 
 ### Fixed
 
+- **Bounded LLM output.** `ChatRequest.MaxTokens` was set by the agent, false-positive triage, and
+  judgment-verifier call sites but never reached the OpenAI-compatible wire request, so provider defaults
+  could exceed the intended output budget. The adapter now sends the current `max_completion_tokens`
+  field, negotiates and caches the deprecated `max_tokens` spelling only when a legacy gateway explicitly
+  rejects the current field, and fails closed on `finish_reason=length` rather than parsing a potentially
+  truncated structured verdict.
 - **Deterministic AI adjudication.** An explicit `temperature: 0` never reached the provider: the
   OpenAI-compatible adapter only sent the field when it was greater than zero, so the value a
   deterministic caller asks for was indistinguishable from "unset" and was dropped from the request. The

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
@@ -22,14 +23,26 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-// ErrUnavailable is a TRANSIENT provider failure (timeout / 429 / 5xx / upstream cooldown):
-// the orchestrator may back off + retry. A malformed request maps to shared.ErrValidation.
-var ErrUnavailable = errors.New("llm provider unavailable")
+var (
+	// ErrUnavailable is a TRANSIENT provider failure (timeout / 429 / 5xx / upstream cooldown):
+	// the orchestrator may back off + retry. A malformed request maps to shared.ErrValidation.
+	ErrUnavailable = errors.New("llm provider unavailable")
+	// ErrOutputTruncated means the provider stopped because the configured output-token limit was
+	// reached. Callers must not parse or act on the potentially partial structured response.
+	ErrOutputTruncated = errors.New("llm output truncated")
+)
 
 const (
 	defaultTimeout = 60 * time.Second
 	maxRespBytes   = 8 << 20 // cap the provider response we read
 	retries        = 2       // bounded retries on transient errors
+)
+
+type maxTokensDialect uint32
+
+const (
+	maxTokensCompletion maxTokensDialect = iota + 1 // current OpenAI Chat Completions: max_completion_tokens
+	maxTokensLegacy                                 // legacy OpenAI-compatible gateways: max_tokens
 )
 
 // Client is an OpenAI-compatible Chat Completions client.
@@ -38,6 +51,9 @@ type Client struct {
 	key   string // bearer token; never logged
 	model string // default model id (a ChatRequest.Model overrides)
 	http  *http.Client
+	// maxTokensDialects learns the field per model because one gateway may route both current and
+	// legacy model families. Values are maxTokensDialect; sync.Map keeps concurrent triage calls safe.
+	maxTokensDialects sync.Map
 }
 
 var _ ports.LLM = (*Client)(nil)
@@ -61,12 +77,14 @@ func (c *Client) BaseURL() string { return c.base }
 // --- wire types (OpenAI Chat Completions shape) ---
 
 type wireReq struct {
-	Model          string       `json:"model"`
-	Messages       []wireMsg    `json:"messages"`
-	Tools          []wireTool   `json:"tools,omitempty"`
-	ToolChoice     string       `json:"tool_choice,omitempty"`
-	ResponseFormat *wireRespFmt `json:"response_format,omitempty"`
-	Temperature    *float64     `json:"temperature,omitempty"`
+	Model               string       `json:"model"`
+	Messages            []wireMsg    `json:"messages"`
+	Tools               []wireTool   `json:"tools,omitempty"`
+	ToolChoice          string       `json:"tool_choice,omitempty"`
+	ResponseFormat      *wireRespFmt `json:"response_format,omitempty"`
+	Temperature         *float64     `json:"temperature,omitempty"`
+	MaxCompletionTokens *int         `json:"max_completion_tokens,omitempty"`
+	MaxTokens           *int         `json:"max_tokens,omitempty"`
 }
 type wireMsg struct {
 	Role       string         `json:"role"`
@@ -130,15 +148,58 @@ func (c *Client) Chat(ctx context.Context, req ports.ChatRequest) (ports.ChatRes
 		t := *req.Temperature
 		body.Temperature = &t
 	}
-	// NOTE: no max_tokens/max_completion_tokens – the field name differs across OpenAI model
-	// generations (the upstream is a large model). The agent budget is enforced on OUR side
-	// (max-steps + token accounting), so we don't risk a provider-specific field here.
 
-	raw, err := json.Marshal(body)
+	dialect := maxTokensCompletion
+	if learned, ok := c.maxTokensDialects.Load(model); ok {
+		dialect = learned.(maxTokensDialect)
+	}
+	raw, err := marshalWireRequest(body, req.MaxTokens, dialect)
 	if err != nil {
-		return ports.ChatResponse{}, fmt.Errorf("%w: marshal chat request: %v", shared.ErrValidation, err)
+		return ports.ChatResponse{}, err
+	}
+	resp, err := c.chatRaw(ctx, raw)
+	if err == nil {
+		if req.MaxTokens > 0 {
+			c.maxTokensDialects.Store(model, dialect)
+		}
+		return resp, nil
+	}
+	if req.MaxTokens <= 0 || dialect != maxTokensCompletion || !rejectsMaxCompletionTokens(err) {
+		return resp, err
 	}
 
+	// Some otherwise OpenAI-compatible gateways still expose only the deprecated max_tokens field.
+	// Retry once only when the 400 response explicitly names max_completion_tokens as unsupported;
+	// never retry an unrelated bad request, auth failure, or truncated completion.
+	legacyRaw, marshalErr := marshalWireRequest(body, req.MaxTokens, maxTokensLegacy)
+	if marshalErr != nil {
+		return ports.ChatResponse{}, marshalErr
+	}
+	resp, err = c.chatRaw(ctx, legacyRaw)
+	if err == nil {
+		c.maxTokensDialects.Store(model, maxTokensLegacy)
+	}
+	return resp, err
+}
+
+func marshalWireRequest(body wireReq, maxTokens int, dialect maxTokensDialect) ([]byte, error) {
+	if maxTokens > 0 {
+		limit := maxTokens
+		switch dialect {
+		case maxTokensLegacy:
+			body.MaxTokens = &limit
+		default:
+			body.MaxCompletionTokens = &limit
+		}
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: marshal chat request: %v", shared.ErrValidation, err)
+	}
+	return raw, nil
+}
+
+func (c *Client) chatRaw(ctx context.Context, raw []byte) (ports.ChatResponse, error) {
 	var lastErr error
 	for attempt := 0; attempt <= retries; attempt++ {
 		resp, rerr := c.do(ctx, raw)
@@ -147,7 +208,7 @@ func (c *Client) Chat(ctx context.Context, req ports.ChatRequest) (ports.ChatRes
 		}
 		lastErr = rerr
 		if !errors.Is(rerr, ErrUnavailable) || ctx.Err() != nil {
-			return ports.ChatResponse{}, rerr // terminal (bad request/auth) or cancelled
+			return resp, rerr // terminal (bad request/auth/truncation) or cancelled
 		}
 		// transient: brief backoff, then retry
 		select {
@@ -157,6 +218,35 @@ func (c *Client) Chat(ctx context.Context, req ports.ChatRequest) (ports.ChatRes
 		}
 	}
 	return ports.ChatResponse{}, lastErr
+}
+
+type providerStatusError struct {
+	status int
+	detail string
+	cause  error
+}
+
+func (e *providerStatusError) Error() string {
+	return fmt.Sprintf("%v: provider status %d: %s", e.cause, e.status, e.detail)
+}
+
+func (e *providerStatusError) Unwrap() error { return e.cause }
+
+func rejectsMaxCompletionTokens(err error) bool {
+	var statusErr *providerStatusError
+	if !errors.As(err, &statusErr) || statusErr.status != http.StatusBadRequest {
+		return false
+	}
+	detail := strings.ToLower(statusErr.detail)
+	if !strings.Contains(detail, "max_completion_tokens") {
+		return false
+	}
+	for _, marker := range []string{"unsupported", "not supported", "unknown", "unrecognized", "unexpected", "not permitted", "extra field"} {
+		if strings.Contains(detail, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) do(ctx context.Context, raw []byte) (ports.ChatResponse, error) {
@@ -176,12 +266,12 @@ func (c *Client) do(ctx context.Context, raw []byte) (ports.ChatResponse, error)
 	data, _ := io.ReadAll(io.LimitReader(httpResp.Body, maxRespBytes))
 
 	if httpResp.StatusCode == http.StatusTooManyRequests || httpResp.StatusCode >= 500 {
-		return ports.ChatResponse{}, fmt.Errorf("%w: provider status %d: %s", ErrUnavailable, httpResp.StatusCode, snippet(data))
+		return ports.ChatResponse{}, &providerStatusError{status: httpResp.StatusCode, detail: snippet(data), cause: ErrUnavailable}
 	}
 	if httpResp.StatusCode != http.StatusOK {
 		// 400/401/403 etc. – surface the provider message (which may carry a cooldown hint),
 		// but NEVER echo the request (it never contains secrets anyway). Treat as terminal.
-		return ports.ChatResponse{}, fmt.Errorf("%w: provider status %d: %s", shared.ErrValidation, httpResp.StatusCode, snippet(data))
+		return ports.ChatResponse{}, &providerStatusError{status: httpResp.StatusCode, detail: snippet(data), cause: shared.ErrValidation}
 	}
 	var wr wireResp
 	if err := json.Unmarshal(data, &wr); err != nil {
@@ -203,6 +293,9 @@ func (c *Client) do(ctx context.Context, raw []byte) (ports.ChatResponse, error)
 		// OpenAI sends function.arguments as a JSON string; store its raw JSON bytes so the
 		// orchestrator can unmarshal directly into the tool's typed params.
 		out.ToolCalls = append(out.ToolCalls, agent.ToolCall{ID: tc.ID, Name: tc.Function.Name, Arguments: json.RawMessage(tc.Function.Arguments)})
+	}
+	if out.FinishReason == "length" {
+		return out, fmt.Errorf("%w: provider reached the configured output-token limit", ErrOutputTruncated)
 	}
 	return out, nil
 }

--- a/internal/infrastructure/llm/openai/client_test.go
+++ b/internal/infrastructure/llm/openai/client_test.go
@@ -126,6 +126,134 @@ func TestChatOmitsTemperatureWhenUnset(t *testing.T) {
 	}
 }
 
+// TestChatSendsCurrentOutputTokenLimit pins the current OpenAI Chat Completions contract:
+// MaxTokens is a provider-neutral port field, and the adapter spells it max_completion_tokens.
+func TestChatSendsCurrentOutputTokenLimit(t *testing.T) {
+	body := captureChatBody(t, ports.ChatRequest{
+		MaxTokens: 512,
+		Messages:  []agent.Message{{Role: agent.RoleUser, Content: "hi"}},
+	})
+	if got := body["max_completion_tokens"]; got != float64(512) {
+		t.Errorf("max_completion_tokens = %v, want 512", got)
+	}
+	if got, ok := body["max_tokens"]; ok {
+		t.Errorf("deprecated max_tokens also sent: %v", got)
+	}
+}
+
+func TestChatOmitsNonPositiveOutputTokenLimit(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		body := captureChatBody(t, ports.ChatRequest{
+			MaxTokens: limit,
+			Messages:  []agent.Message{{Role: agent.RoleUser, Content: "hi"}},
+		})
+		if got, ok := body["max_completion_tokens"]; ok {
+			t.Errorf("limit %d sent max_completion_tokens=%v", limit, got)
+		}
+		if got, ok := body["max_tokens"]; ok {
+			t.Errorf("limit %d sent max_tokens=%v", limit, got)
+		}
+	}
+}
+
+func TestChatFallsBackToLegacyOutputTokenLimitAndCachesDialect(t *testing.T) {
+	var bodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		bodies = append(bodies, body)
+		if _, modern := body["max_completion_tokens"]; modern && body["model"] == "m" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"unknown field max_completion_tokens; use max_tokens"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := New(srv.URL, "", "m", time.Second)
+	req := ports.ChatRequest{MaxTokens: 64, Messages: []agent.Message{{Role: agent.RoleUser, Content: "hi"}}}
+	for i := 0; i < 2; i++ {
+		resp, err := c.Chat(context.Background(), req)
+		if err != nil || resp.Content != "OK" {
+			t.Fatalf("call %d: resp=%+v err=%v", i+1, resp, err)
+		}
+	}
+	// Dialect learning is per model. A current model routed through the same gateway must still start
+	// with max_completion_tokens rather than inheriting the legacy model's max_tokens spelling.
+	modernReq := req
+	modernReq.Model = "current-model"
+	if _, err := c.Chat(context.Background(), modernReq); err != nil {
+		t.Fatalf("current model after legacy negotiation: %v", err)
+	}
+	if len(bodies) != 4 {
+		t.Fatalf("requests = %d, want modern probe + legacy retry + cached legacy call + current-model call", len(bodies))
+	}
+	if got := bodies[0]["max_completion_tokens"]; got != float64(64) {
+		t.Errorf("modern probe max_completion_tokens = %v, want 64", got)
+	}
+	for i := 1; i < len(bodies); i++ {
+		if i == 3 {
+			if got := bodies[i]["max_completion_tokens"]; got != float64(64) {
+				t.Errorf("current model max_completion_tokens = %v, want 64", got)
+			}
+			if got, ok := bodies[i]["max_tokens"]; ok {
+				t.Errorf("current model inherited legacy max_tokens=%v", got)
+			}
+			continue
+		}
+		if got := bodies[i]["max_tokens"]; got != float64(64) {
+			t.Errorf("legacy request %d max_tokens = %v, want 64", i, got)
+		}
+		if got, ok := bodies[i]["max_completion_tokens"]; ok {
+			t.Errorf("legacy request %d also sent max_completion_tokens=%v", i, got)
+		}
+	}
+}
+
+func TestChatDoesNotFallbackOnUnrelatedBadRequest(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"messages are invalid"}}`))
+	}))
+	defer srv.Close()
+	c, _ := New(srv.URL, "", "m", time.Second)
+
+	_, err := c.Chat(context.Background(), ports.ChatRequest{
+		MaxTokens: 64,
+		Messages:  []agent.Message{{Role: agent.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unrelated 400 must remain terminal validation error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("unrelated 400 was retried %d time(s)", got)
+	}
+}
+
+func TestChatFailsClosedOnTruncatedOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"{\"score\": 90"},"finish_reason":"length"}],"usage":{"completion_tokens":16}}`))
+	}))
+	defer srv.Close()
+	c, _ := New(srv.URL, "", "m", time.Second)
+
+	resp, err := c.Chat(context.Background(), ports.ChatRequest{
+		MaxTokens: 16,
+		Messages:  []agent.Message{{Role: agent.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, ErrOutputTruncated) {
+		t.Fatalf("finish_reason=length error = %v, want ErrOutputTruncated", err)
+	}
+	if resp.FinishReason != "length" || resp.Usage.CompletionTokens != 16 {
+		t.Errorf("truncated response metadata lost: %+v", resp)
+	}
+}
+
 // captureChatBody runs one Chat against a stub gateway and returns the decoded request body.
 func captureChatBody(t *testing.T, req ports.ChatRequest) map[string]any {
 	t.Helper()

--- a/internal/usecase/ports/llm.go
+++ b/internal/usecase/ports/llm.go
@@ -29,7 +29,10 @@ type ChatRequest struct {
 	// choice to the provider default, non-nil is sent verbatim – and 0 means greedy decoding, which
 	// is what a caller whose verdict must be reproducible asks for. Use Temp.
 	Temperature *float64
-	MaxTokens   int
+	// MaxTokens bounds generated output. The OpenAI adapter sends the current max_completion_tokens
+	// field and negotiates the deprecated max_tokens spelling only for a legacy-compatible gateway.
+	// Non-positive leaves the provider default unchanged.
+	MaxTokens int
 }
 
 // Temp returns a pointer to v for ChatRequest.Temperature, so a deterministic caller can ask for an


### PR DESCRIPTION
## Summary

`ChatRequest.MaxTokens` was populated by the agent, false-positive triage, and judgment verifier, but the OpenAI-compatible adapter never serialized it. Provider defaults could therefore exceed the output budget the callers requested.

This change makes the limit effective while preserving compatibility across model generations. It follows the current Chat Completions field, `max_completion_tokens`; the deprecated `max_tokens` spelling is used only after a legacy gateway explicitly rejects the current field.

Refs #392.

## Changes

- send positive `ChatRequest.MaxTokens` as `max_completion_tokens`
- leave non-positive limits unset so provider-default behavior is unchanged
- on an explicit field-unsupported 400, retry once with legacy `max_tokens`
- cache the negotiated dialect per model ID, since one gateway may route both current and legacy model families
- keep unrelated 400/auth errors terminal and preserve existing bounded transient retries
- return `ErrOutputTruncated` on `finish_reason=length`, so a partial structured verdict cannot reach triage or a judgment gate
- add wire-level regression coverage and an Unreleased changelog entry

Current field reference: https://platform.openai.com/docs/api-reference/chat

## Safety

- no prompt, source context, request body, or API key is added to logs
- fallback occurs only when a 400 response both names `max_completion_tokens` and identifies it as unsupported
- a token-truncated reply fails closed instead of being parsed or acted upon
- proposer/verifier semantics and the deterministic report path are unchanged

## Verification

- `go test ./internal/infrastructure/llm/openai ./internal/usecase/fptriage ./internal/usecase/llmverifier ./internal/usecase/orchestrator ./internal/usecase/agenttools`
- `go vet ./internal/infrastructure/llm/openai ./internal/usecase/ports ./internal/usecase/fptriage ./internal/usecase/llmverifier ./internal/usecase/orchestrator ./internal/usecase/agenttools`
- `git diff upstream/main...HEAD --check`

The race test could not run locally because this Windows Go environment has CGO disabled. Full repository CI is left to the Linux workflow; local Windows Defender quarantines the pre-existing `internal/infrastructure/tools/sast/php_lex_test.go` fixture, which is not part of this commit.

## Checklist

- [ ] `make build vet test typecheck` passes (targeted Go test/vet commands above pass; full Linux CI pending)
- [x] `cd web && pnpm build` is not applicable (no dashboard changes)
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets out of logs, deterministic reports, append-only evidence)
- [x] Documentation updated via `CHANGELOG.md`
