### PR TITLE
feat(fleet): web views for agent health and per-asset coverage (#413)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,9 @@ import { ProjectMeasuresPage } from './pages/ProjectMeasuresPage'
 import { ProjectCodePage } from './pages/ProjectCodePage'
 import { QualityGates } from './pages/QualityGates'
 import { QualityProfiles } from './pages/QualityProfiles'
+import { FleetLayout } from './pages/FleetLayout'
+import { FleetCoverage } from './pages/FleetCoverage'
+import { FleetAgents } from './pages/FleetAgents'
 
 export default function App() {
   return (
@@ -50,6 +53,10 @@ function Gate() {
           <Route path="measures" element={<ProjectMeasuresPage />} />
           <Route path="analysis" element={<ProjectAnalysisPage />} />
           <Route path="activity" element={<ProjectActivityPage />} />
+        </Route>
+        <Route path="fleet" element={<FleetLayout />}>
+          <Route index element={<FleetCoverage />} />
+          <Route path="agents" element={<FleetAgents />} />
         </Route>
         <Route path="rules" element={<Rules />} />
         <Route path="rules/:key" element={<RuleDetail />} />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Boxes, FileText, Gauge, Radar, ScrollText, Settings, Target, Users, X, Library, type LucideIcon } from 'lucide-react'
+import { Boxes, FileText, Gauge, Radar, ScrollText, Server, Settings, Target, Users, X, Library, type LucideIcon } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
 import { cn } from './ui'
@@ -82,6 +82,22 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
         >
           <Gauge className="size-[18px]" />
           Code Quality
+        </NavLink>
+
+        <NavLink
+          to="/fleet"
+          onClick={onNavigate}
+          className={() =>
+            cn(
+              'relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
+              location.pathname.startsWith('/fleet')
+                ? 'bg-brand/10 font-semibold text-branddim before:absolute before:left-0 before:top-1/2 before:h-5 before:w-[3px] before:-translate-y-1/2 before:rounded-r-full before:bg-brand before:content-[""]'
+                : 'text-mutedfg hover:bg-elevated hover:text-foreground',
+            )
+          }
+        >
+          <Server className="size-[18px]" />
+          Fleet
         </NavLink>
 
         <NavLink

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -69,6 +69,11 @@ import type {
   ProjectCodeFileView,
   ProjectCodeRevision,
   ProjectCodeView,
+  FleetAgentHealth,
+  FleetAgentRow,
+  FleetAgentDetail,
+  FleetCoverageRow,
+  FleetCoverageSummary,
 } from './types'
 import { mapProjectOverviewResponse, type ProjectOverview } from './projectOverview'
 import { mapProjectMeasureResponse, type MeasuresQuery, type ProjectMeasureResponse } from './projectMeasures'
@@ -1011,6 +1016,30 @@ function mapProjectCodeDiffResponse(r: any): ProjectCodeDiffResponse {
   }
 }
 
+function mapFleetAgent(raw: any): FleetAgentRow {
+  return {
+    id: raw?.id ?? '',
+    name: raw?.name ?? '',
+    platform: raw?.platform ?? '',
+    agentVersion: raw?.agent_version ?? '',
+    state: (raw?.state ?? 'healthy') as FleetAgentHealth,
+    lastSeen: raw?.last_seen ?? '',
+    capabilities: Array.isArray(raw?.capabilities) ? raw.capabilities : [],
+    currentWork: raw?.current_work ?? 0,
+  }
+}
+
+function mapFleetCoverageRow(raw: any): FleetCoverageRow {
+  return {
+    assetId: raw?.asset_id ?? '',
+    capability: raw?.capability ?? '',
+    verdict: (raw?.verdict ?? 'never') as FleetCoverageRow['verdict'],
+    detail: raw?.detail ?? '',
+    lastRun: raw?.last_run ?? '',
+    agentId: raw?.agent_id ?? '',
+  }
+}
+
 export const api = {
   projectMeasures,
   aup: (): Promise<AupStatus> => req('/aup'),
@@ -1701,5 +1730,45 @@ export const api = {
   downloadArtifact: async (engagementId: string, sha: string, filename: string): Promise<void> => {
     const id = encodeURIComponent(engagementId)
     await blobDownload(`/api/v1/engagements/${id}/evidence/${encodeURIComponent(sha)}`, filename || `${sha.slice(0, 12)}.bin`)
+  },
+
+  // ---- Fleet coverage & agent health (#413) ----
+
+  listFleetAgents: async (state?: FleetAgentHealth): Promise<FleetAgentRow[]> => {
+    const q = new URLSearchParams()
+    if (state) q.set('state', state)
+    const qs = q.toString()
+    return ((await req(`/fleet/agents${qs ? `?${qs}` : ''}`)) ?? []).map(mapFleetAgent)
+  },
+
+  getFleetAgent: async (id: string): Promise<FleetAgentDetail> => {
+    const res = await req(`/fleet/agents/${encodeURIComponent(id)}`)
+    return {
+      agent: mapFleetAgent(res?.agent ?? {}),
+      recentWork: (res?.recent_work ?? []).map((r: any) => ({
+        id: r?.id ?? '',
+        capability: r?.capability ?? '',
+        assetId: r?.asset_id ?? '',
+        state: r?.state ?? '',
+        updatedAt: r?.updated_at ?? '',
+      })),
+    }
+  },
+
+  listFleetCoverage: async (): Promise<FleetCoverageRow[]> =>
+    ((await req('/fleet/coverage')) ?? []).map(mapFleetCoverageRow),
+
+  fleetCoverageSummary: async (): Promise<FleetCoverageSummary> => {
+    const res = await req('/fleet/coverage/summary')
+    return {
+      agentsByState: res?.agents_by_state ?? {},
+      rowsByVerdict: res?.rows_by_verdict ?? {},
+      oldestPerCapability: res?.oldest_per_capability ?? {},
+      assetsWithoutAgent: res?.assets_without_agent ?? 0,
+    }
+  },
+
+  exportFleetCoverage: async (): Promise<void> => {
+    await blobDownload('/api/v1/fleet/coverage/export', 'fleet-coverage.csv')
   },
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1104,3 +1104,58 @@ export interface ProjectCodeDiffResponse {
   capabilities: ProjectCodeDiffCapabilities
   diff: ProjectCodeDiffView
 }
+
+// ---- Fleet coverage & agent health (#413) ----
+
+export type FleetAgentHealth = 'healthy' | 'stale' | 'revoked'
+
+// The full verdict set the read model can emit. Order matters for the operator: unknown/stale/
+// refused/unauthorized/agent_missing are DISTINCT states, never collapsed into "covered".
+export type FleetVerdict =
+  | 'unauthorized'
+  | 'agent_missing'
+  | 'refused'
+  | 'never'
+  | 'stale'
+  | 'partial'
+  | 'covered'
+
+export interface FleetAgentRow {
+  id: string
+  name: string
+  platform: string
+  agentVersion: string
+  state: FleetAgentHealth
+  lastSeen: string
+  capabilities: string[]
+  currentWork: number
+}
+
+export interface FleetOrderBrief {
+  id: string
+  capability: string
+  assetId: string
+  state: string
+  updatedAt: string
+}
+
+export interface FleetAgentDetail {
+  agent: FleetAgentRow
+  recentWork: FleetOrderBrief[]
+}
+
+export interface FleetCoverageRow {
+  assetId: string
+  capability: string
+  verdict: FleetVerdict
+  detail: string
+  lastRun: string
+  agentId: string
+}
+
+export interface FleetCoverageSummary {
+  agentsByState: Record<string, number>
+  rowsByVerdict: Record<string, number>
+  oldestPerCapability: Record<string, string>
+  assetsWithoutAgent: number
+}

--- a/web/src/pages/FleetAgents.test.tsx
+++ b/web/src/pages/FleetAgents.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { api, ApiError } from '../lib/api'
+import type { FleetAgentRow } from '../lib/types'
+import { installVirtualViewport } from '../test/virtualize'
+import { FleetAgents } from './FleetAgents'
+
+vi.mock('../lib/api', () => {
+  class ApiError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.name = 'ApiError'
+      this.status = status
+    }
+  }
+  return {
+    ApiError,
+    api: {
+      listFleetAgents: vi.fn(),
+      getFleetAgent: vi.fn(),
+    },
+  }
+})
+
+const agent: FleetAgentRow = {
+  id: 'ag-1',
+  name: 'edge-01',
+  platform: 'linux/amd64',
+  agentVersion: '1.2.0',
+  state: 'healthy',
+  lastSeen: '2026-01-01T00:00:00Z',
+  capabilities: ['scan.host'],
+  currentWork: 2,
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <FleetAgents />
+    </MemoryRouter>,
+  )
+}
+
+describe('FleetAgents', () => {
+  let restoreViewport: () => void
+  beforeEach(() => {
+    vi.resetAllMocks()
+    restoreViewport = installVirtualViewport()
+  })
+  afterEach(() => restoreViewport())
+
+  it('shows a loading state while agents are in flight', () => {
+    vi.mocked(api.listFleetAgents).mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByText('Loading fleet agents…')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no agents', async () => {
+    vi.mocked(api.listFleetAgents).mockResolvedValue([])
+    renderPage()
+    expect(await screen.findByText('No agents')).toBeInTheDocument()
+  })
+
+  it('shows an error and retries', async () => {
+    vi.mocked(api.listFleetAgents).mockRejectedValueOnce(new ApiError(503, 'agents down')).mockResolvedValue([])
+    renderPage()
+    expect(await screen.findByText('agents down')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByText('No agents')).toBeInTheDocument()
+  })
+
+  it('applies the state filter', async () => {
+    vi.mocked(api.listFleetAgents).mockResolvedValue([])
+    renderPage()
+    await screen.findByText('No agents')
+    fireEvent.click(screen.getByRole('button', { name: 'Stale' }))
+    await waitFor(() => expect(api.listFleetAgents).toHaveBeenLastCalledWith('stale'))
+  })
+
+  it('opens agent detail with recent work on row click', async () => {
+    vi.mocked(api.listFleetAgents).mockResolvedValue([agent])
+    vi.mocked(api.getFleetAgent).mockResolvedValue({
+      agent,
+      recentWork: [{ id: 'wo-1', capability: 'scan.host', assetId: 'asset-A', state: 'succeeded', updatedAt: '2026-01-01T00:00:00Z' }],
+    })
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: 'ag-1' }))
+    expect(await screen.findByText('Recent work orders')).toBeInTheDocument()
+    expect(screen.getByText('asset-A')).toBeInTheDocument()
+    expect(api.getFleetAgent).toHaveBeenCalledWith('ag-1')
+  })
+})

--- a/web/src/pages/FleetAgents.tsx
+++ b/web/src/pages/FleetAgents.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react'
+import { ServerCog } from 'lucide-react'
+import { api, ApiError } from '../lib/api'
+import type { FleetAgentDetail, FleetAgentHealth, FleetAgentRow } from '../lib/types'
+import { Button, Card, cn, EmptyState, ErrorState, Pill, Spinner } from '../components/ui'
+import { VirtualTable, type Column } from '../components/VirtualTable'
+import { FleetStateBadge, formatFleetTime } from './fleetShared'
+
+type StateFilter = 'all' | FleetAgentHealth
+const FILTERS: { value: StateFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'healthy', label: 'Healthy' },
+  { value: 'stale', label: 'Stale' },
+  { value: 'revoked', label: 'Revoked' },
+]
+
+function AgentDetailCard({ id, onClose }: { id: string; onClose: () => void }) {
+  const [detail, setDetail] = useState<FleetAgentDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [reload, setReload] = useState(0)
+
+  useEffect(() => {
+    let active = true
+    setDetail(null)
+    setError(null)
+    api
+      .getFleetAgent(id)
+      .then((d) => {
+        if (active) setDetail(d)
+      })
+      .catch((e) => {
+        if (active) setError(e instanceof ApiError ? e.message : 'Failed to load agent')
+      })
+    return () => {
+      active = false
+    }
+  }, [id, reload])
+
+  return (
+    <Card
+      className="mt-6"
+      title={`Agent ${id}`}
+      actions={
+        <Button variant="ghost" onClick={onClose}>
+          Close
+        </Button>
+      }
+    >
+      {error && (
+        <div className="space-y-3">
+          <ErrorState message={error} />
+          <Button variant="secondary" onClick={() => setReload((n) => n + 1)}>
+            Retry
+          </Button>
+        </div>
+      )}
+      {!detail && !error && <Spinner label="Loading agent…" />}
+      {detail && (
+        <div>
+          <div className="mb-4 flex flex-wrap items-center gap-3 text-sm">
+            <FleetStateBadge state={detail.agent.state} />
+            <span className="text-mutedfg">
+              last seen <span className="tabular-nums text-subtlefg">{formatFleetTime(detail.agent.lastSeen)}</span>
+            </span>
+            {detail.agent.capabilities.map((c) => (
+              <Pill key={c}>{c}</Pill>
+            ))}
+          </div>
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-subtlefg">Recent work orders</div>
+          {detail.recentWork.length === 0 ? (
+            <p className="text-sm text-mutedfg">No recent work orders.</p>
+          ) : (
+            <ul className="divide-y divide-border/60 rounded-lg border border-border">
+              {detail.recentWork.map((w) => (
+                <li key={w.id} className="flex flex-wrap items-center justify-between gap-2 px-4 py-2 text-sm">
+                  <span className="font-mono text-[12px] text-foreground">{w.capability}</span>
+                  <span className="font-mono text-[12px] text-mutedfg">{w.assetId}</span>
+                  <span className="text-mutedfg">{w.state}</span>
+                  <span className="tabular-nums text-subtlefg">{formatFleetTime(w.updatedAt)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+export function FleetAgents() {
+  const [filter, setFilter] = useState<StateFilter>('all')
+  const [rows, setRows] = useState<FleetAgentRow[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<string | null>(null)
+
+  function load() {
+    setError(null)
+    setRows(null)
+    api
+      .listFleetAgents(filter === 'all' ? undefined : filter)
+      .then(setRows)
+      .catch((e) => setError(e instanceof ApiError ? e.message : 'Failed to load fleet agents'))
+  }
+  useEffect(load, [filter])
+
+  const columns: Column<FleetAgentRow>[] = [
+    {
+      header: 'Agent',
+      className: 'w-44',
+      cell: (a) => (
+        <button
+          type="button"
+          onClick={() => setSelected(a.id)}
+          title={a.id}
+          className="truncate rounded font-mono text-[12px] text-branddim hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        >
+          {a.id}
+        </button>
+      ),
+    },
+    { header: 'Name', className: 'flex-1', cell: (a) => <span className="text-foreground">{a.name || '—'}</span> },
+    { header: 'Platform', className: 'w-28', cell: (a) => <span className="text-mutedfg">{a.platform || '—'}</span> },
+    {
+      header: 'Version',
+      className: 'w-24 tabular-nums',
+      cell: (a) => <span className="font-mono text-[12px] text-mutedfg">{a.agentVersion || '—'}</span>,
+    },
+    { header: 'State', className: 'w-28', cell: (a) => <FleetStateBadge state={a.state} /> },
+    {
+      header: 'Last seen',
+      className: 'w-44 tabular-nums',
+      cell: (a) => (
+        <span className="text-mutedfg" title={a.lastSeen || undefined}>
+          {formatFleetTime(a.lastSeen)}
+        </span>
+      ),
+    },
+    {
+      header: 'Capabilities',
+      className: 'flex-1',
+      cell: (a) => <span className="text-mutedfg">{a.capabilities.length ? a.capabilities.join(', ') : '—'}</span>,
+    },
+    {
+      header: 'Work',
+      className: 'w-16 tabular-nums text-right',
+      cell: (a) => <span className="text-mutedfg">{a.currentWork.toLocaleString()}</span>,
+    },
+  ]
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap gap-1">
+        {FILTERS.map((f) => (
+          <button
+            key={f.value}
+            type="button"
+            onClick={() => {
+              setSelected(null)
+              setFilter(f.value)
+            }}
+            className={cn(
+              'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg',
+              filter === f.value ? 'bg-brand/10 text-branddim' : 'text-mutedfg hover:bg-elevated hover:text-foreground',
+            )}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="space-y-3">
+          <ErrorState message={error} />
+          <Button variant="secondary" onClick={load}>
+            Retry
+          </Button>
+        </div>
+      )}
+      {!rows && !error && <Spinner label="Loading fleet agents…" />}
+      {rows && rows.length === 0 && !error && (
+        <EmptyState
+          icon={ServerCog}
+          title="No agents"
+          hint={
+            filter === 'all'
+              ? 'No agents have enrolled for this tenant yet, or the fleet is not enabled.'
+              : `No agents are currently ${filter}.`
+          }
+        />
+      )}
+      {rows && rows.length > 0 && (
+        <Card bodyClass="p-0">
+          <VirtualTable
+            items={rows}
+            columns={columns}
+            rowKey={(a) => a.id}
+            maxHeightClass="max-h-[60vh]"
+            tableMinWidthClass="min-w-[72rem]"
+          />
+        </Card>
+      )}
+
+      {selected && <AgentDetailCard id={selected} onClose={() => setSelected(null)} />}
+    </div>
+  )
+}

--- a/web/src/pages/FleetCoverage.test.tsx
+++ b/web/src/pages/FleetCoverage.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { api, ApiError } from '../lib/api'
+import type { FleetCoverageSummary } from '../lib/types'
+import { installVirtualViewport } from '../test/virtualize'
+import { FleetCoverage } from './FleetCoverage'
+
+vi.mock('../lib/api', () => {
+  class ApiError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.name = 'ApiError'
+      this.status = status
+    }
+  }
+  return {
+    ApiError,
+    api: {
+      listFleetCoverage: vi.fn(),
+      fleetCoverageSummary: vi.fn(),
+      exportFleetCoverage: vi.fn(),
+    },
+  }
+})
+
+const emptySummary: FleetCoverageSummary = {
+  agentsByState: {},
+  rowsByVerdict: {},
+  oldestPerCapability: {},
+  assetsWithoutAgent: 0,
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <FleetCoverage />
+    </MemoryRouter>,
+  )
+}
+
+describe('FleetCoverage', () => {
+  let restoreViewport: () => void
+  beforeEach(() => {
+    vi.resetAllMocks()
+    restoreViewport = installVirtualViewport()
+    vi.mocked(api.fleetCoverageSummary).mockResolvedValue(emptySummary)
+  })
+  afterEach(() => restoreViewport())
+
+  it('shows a loading state while data is in flight', () => {
+    vi.mocked(api.listFleetCoverage).mockReturnValue(new Promise(() => {}))
+    vi.mocked(api.fleetCoverageSummary).mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByText('Loading fleet coverage…')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no coverage rows', async () => {
+    vi.mocked(api.listFleetCoverage).mockResolvedValue([])
+    renderPage()
+    expect(await screen.findByText('No coverage rows')).toBeInTheDocument()
+  })
+
+  it('shows an error and retries', async () => {
+    vi.mocked(api.listFleetCoverage)
+      .mockRejectedValueOnce(new ApiError(500, 'coverage exploded'))
+      .mockResolvedValue([])
+    renderPage()
+    expect(await screen.findByText('coverage exploded')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByText('No coverage rows')).toBeInTheDocument()
+  })
+
+  it('renders non-covered verdicts distinctly and exports CSV', async () => {
+    vi.mocked(api.listFleetCoverage).mockResolvedValue([
+      { assetId: 'asset-A', capability: 'scan.host', verdict: 'covered', detail: '', lastRun: '2026-01-01T00:00:00Z', agentId: 'ag1' },
+      { assetId: 'asset-B', capability: 'scan.host', verdict: 'unauthorized', detail: 'out of scope', lastRun: '', agentId: '' },
+    ])
+    vi.mocked(api.fleetCoverageSummary).mockResolvedValue({
+      ...emptySummary,
+      rowsByVerdict: { covered: 1, unauthorized: 1 },
+    })
+    renderPage()
+    expect(await screen.findByText('asset-A')).toBeInTheDocument()
+    expect(screen.getByText('asset-B')).toBeInTheDocument()
+    // The unauthorized verdict is surfaced as its own label, never folded into covered.
+    expect(screen.getAllByText('Unauthorized').length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByRole('button', { name: /Export CSV/ }))
+    await waitFor(() => expect(api.exportFleetCoverage).toHaveBeenCalledTimes(1))
+  })
+})

--- a/web/src/pages/FleetCoverage.tsx
+++ b/web/src/pages/FleetCoverage.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from 'react'
+import { Download, ShieldAlert } from 'lucide-react'
+import { api, ApiError } from '../lib/api'
+import type { FleetCoverageRow, FleetCoverageSummary, FleetVerdict } from '../lib/types'
+import { Button, Card, EmptyState, ErrorState, Spinner } from '../components/ui'
+import { VirtualTable, type Column } from '../components/VirtualTable'
+import { FLEET_VERDICT_ORDER, FleetVerdictBadge, formatFleetTime, verdictLabel } from './fleetShared'
+
+const COLUMNS: Column<FleetCoverageRow>[] = [
+  {
+    header: 'Asset',
+    className: 'w-52',
+    cell: (r) => (
+      <span className="font-mono text-[12px] text-foreground" title={r.assetId}>
+        {r.assetId}
+      </span>
+    ),
+  },
+  {
+    header: 'Capability',
+    className: 'w-40',
+    cell: (r) => (
+      <span className="font-mono text-[12px] text-mutedfg" title={r.capability || undefined}>
+        {r.capability || '—'}
+      </span>
+    ),
+  },
+  {
+    header: 'Verdict',
+    className: 'w-36',
+    cell: (r) => <FleetVerdictBadge verdict={r.verdict} />,
+  },
+  {
+    header: 'Detail',
+    className: 'flex-1',
+    cell: (r) => <span className="text-mutedfg">{r.detail || '—'}</span>,
+  },
+  {
+    header: 'Last run',
+    className: 'w-44 tabular-nums',
+    cell: (r) => (
+      <span className="text-mutedfg" title={r.lastRun || undefined}>
+        {formatFleetTime(r.lastRun)}
+      </span>
+    ),
+  },
+  {
+    header: 'Agent',
+    className: 'w-40',
+    cell: (r) => (
+      <span className="font-mono text-[12px] text-mutedfg" title={r.agentId || undefined}>
+        {r.agentId || '—'}
+      </span>
+    ),
+  },
+]
+
+function Stat({ label, value, tone }: { label: string; value: number; tone?: 'warn' }) {
+  return (
+    <div className="rounded-lg border border-border bg-elevated px-4 py-3">
+      <div className={tone === 'warn' && value > 0 ? 'text-2xl font-bold tabular-nums text-critical' : 'text-2xl font-bold tabular-nums text-foreground'}>
+        {value.toLocaleString()}
+      </div>
+      <div className="mt-0.5 text-xs text-mutedfg">{label}</div>
+    </div>
+  )
+}
+
+function SummaryCard({ summary }: { summary: FleetCoverageSummary }) {
+  const total = Object.values(summary.rowsByVerdict).reduce((a, b) => a + b, 0)
+  const covered = summary.rowsByVerdict['covered'] ?? 0
+  const notCovered = total - covered
+  const oldest = Object.entries(summary.oldestPerCapability).sort((a, b) => a[0].localeCompare(b[0]))
+  return (
+    <Card title="Coverage summary" className="mb-6">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Stat label="Assessed pairs" value={total} />
+        <Stat label="Covered" value={covered} />
+        <Stat label="Not covered" value={notCovered} tone="warn" />
+        <Stat label="Assets without an agent" value={summary.assetsWithoutAgent} tone="warn" />
+      </div>
+
+      <div className="mt-4">
+        <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-subtlefg">By verdict</div>
+        <div className="flex flex-wrap gap-2">
+          {FLEET_VERDICT_ORDER.filter((v) => (summary.rowsByVerdict[v] ?? 0) > 0).map((v) => (
+            <span key={v} className="inline-flex items-center gap-1.5">
+              <FleetVerdictBadge verdict={v as FleetVerdict} />
+              <span className="text-xs tabular-nums text-mutedfg">{summary.rowsByVerdict[v]}</span>
+            </span>
+          ))}
+          {total === 0 && <span className="text-xs text-mutedfg">No coverage rows.</span>}
+        </div>
+      </div>
+
+      {oldest.length > 0 && (
+        <div className="mt-4">
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-subtlefg">Oldest assessment per capability</div>
+          <ul className="space-y-1">
+            {oldest.map(([cap, ts]) => (
+              <li key={cap} className="flex items-center justify-between gap-3 text-xs">
+                <span className="font-mono text-mutedfg">{cap}</span>
+                <span className="tabular-nums text-subtlefg">{formatFleetTime(ts)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </Card>
+  )
+}
+
+export function FleetCoverage() {
+  const [rows, setRows] = useState<FleetCoverageRow[] | null>(null)
+  const [summary, setSummary] = useState<FleetCoverageSummary | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [exporting, setExporting] = useState(false)
+  const [exportError, setExportError] = useState<string | null>(null)
+
+  function load() {
+    setError(null)
+    setRows(null)
+    setSummary(null)
+    Promise.all([api.listFleetCoverage(), api.fleetCoverageSummary()])
+      .then(([r, s]) => {
+        setRows(r)
+        setSummary(s)
+      })
+      .catch((e) => setError(e instanceof ApiError ? e.message : 'Failed to load fleet coverage'))
+  }
+  useEffect(load, [])
+
+  async function onExport() {
+    setExportError(null)
+    setExporting(true)
+    try {
+      await api.exportFleetCoverage()
+    } catch (e) {
+      setExportError(e instanceof ApiError ? e.message : 'Export failed')
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-3">
+        <ErrorState message={error} />
+        <Button variant="secondary" onClick={load}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+  if (!rows || !summary) return <Spinner label="Loading fleet coverage…" />
+
+  return (
+    <div>
+      <SummaryCard summary={summary} />
+
+      {rows.length === 0 ? (
+        <EmptyState
+          icon={ShieldAlert}
+          title="No coverage rows"
+          hint="No assets are in scope for this tenant yet, or the fleet is not enabled. Enrol an agent and register assets to see per-capability coverage."
+        />
+      ) : (
+        <Card
+          title="Per-asset coverage"
+          bodyClass="p-0"
+          actions={
+            <Button variant="secondary" onClick={onExport} loading={exporting}>
+              <Download className="size-4" /> Export CSV
+            </Button>
+          }
+        >
+          {exportError && (
+            <div className="px-6 pt-4">
+              <ErrorState message={exportError} />
+            </div>
+          )}
+          <VirtualTable
+            items={rows}
+            columns={COLUMNS}
+            rowKey={(r, i) => `${r.assetId}:${r.capability}:${i}`}
+            maxHeightClass="max-h-[65vh]"
+            tableMinWidthClass="min-w-[64rem]"
+          />
+        </Card>
+      )}
+
+      <p className="mt-4 text-xs text-mutedfg">
+        Every state except <span className="font-semibold">{verdictLabel('covered')}</span> is a gap that is surfaced,
+        not hidden. Unknown, stale, refused and unauthorized are never counted as covered.
+      </p>
+    </div>
+  )
+}

--- a/web/src/pages/FleetLayout.tsx
+++ b/web/src/pages/FleetLayout.tsx
@@ -1,0 +1,41 @@
+import { NavLink, Outlet } from 'react-router-dom'
+import { cn } from '../components/ui'
+
+function FleetTab({ to, end, children }: { to: string; end?: boolean; children: React.ReactNode }) {
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) =>
+        cn(
+          'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg',
+          isActive ? 'bg-brand/10 text-branddim' : 'text-mutedfg hover:bg-elevated hover:text-foreground',
+        )
+      }
+    >
+      {children}
+    </NavLink>
+  )
+}
+
+export function FleetLayout() {
+  return (
+    <div className="mx-auto max-w-6xl animate-fade-in">
+      <header className="bg-hero mb-6 rounded-xl border border-border p-6">
+        <h1 className="text-3xl font-bold tracking-tight">Fleet</h1>
+        <p className="mt-1.5 max-w-2xl text-sm text-mutedfg">
+          Agent health and per-asset coverage. Unknown, stale, refused and unauthorized are shown as distinct
+          states — never counted as covered.
+        </p>
+        <nav className="mt-4 flex gap-1">
+          <FleetTab to="/fleet" end>
+            Coverage
+          </FleetTab>
+          <FleetTab to="/fleet/agents">Agents</FleetTab>
+        </nav>
+      </header>
+      <Outlet />
+    </div>
+  )
+}

--- a/web/src/pages/fleetShared.tsx
+++ b/web/src/pages/fleetShared.tsx
@@ -1,0 +1,79 @@
+import { cn } from '../components/ui'
+import type { FleetAgentHealth, FleetVerdict } from '../lib/types'
+
+// The order the read model resolves verdicts (worst first). Kept here so the UI legend and any
+// client-side ordering agree with the domain, and so "covered" is never the visual default.
+export const FLEET_VERDICT_ORDER: FleetVerdict[] = [
+  'unauthorized',
+  'agent_missing',
+  'refused',
+  'never',
+  'stale',
+  'partial',
+  'covered',
+]
+
+interface BadgeStyle {
+  label: string
+  soft: string
+  dot: string
+}
+
+// Only `covered` is green. Every other state is visually distinct and non-green, because a green
+// dashboard over an unassessed estate is the exact failure this view exists to prevent (#413).
+const VERDICT_STYLE: Record<FleetVerdict, BadgeStyle> = {
+  covered: { label: 'Covered', soft: 'bg-accent/10 text-accent ring-accent/30', dot: 'bg-accent' },
+  partial: { label: 'Partial', soft: 'bg-medium/10 text-medium ring-medium/30', dot: 'bg-medium' },
+  // `stale` must NOT be green: the `low` token is the same hex as `accent`, so it would read as
+  // covered. `info` (cyan) is the distinct "outdated, needs attention, not a failure" hue.
+  stale: { label: 'Stale', soft: 'bg-info/10 text-info ring-info/30', dot: 'bg-info' },
+  never: { label: 'Never', soft: 'bg-muted text-mutedfg ring-border', dot: 'bg-mutedfg' },
+  refused: { label: 'Refused', soft: 'bg-high/10 text-high ring-high/30', dot: 'bg-high' },
+  agent_missing: { label: 'Agent missing', soft: 'bg-critical/10 text-critical ring-critical/30', dot: 'bg-critical' },
+  unauthorized: { label: 'Unauthorized', soft: 'bg-critical/10 text-critical ring-critical/30', dot: 'bg-critical' },
+}
+
+const STATE_STYLE: Record<FleetAgentHealth, BadgeStyle> = {
+  healthy: { label: 'Healthy', soft: 'bg-accent/10 text-accent ring-accent/30', dot: 'bg-accent' },
+  // `stale` uses `info` (cyan), not `low`/`accent` green — a stale agent must never look healthy.
+  stale: { label: 'Stale', soft: 'bg-info/10 text-info ring-info/30', dot: 'bg-info' },
+  revoked: { label: 'Revoked', soft: 'bg-critical/10 text-critical ring-critical/30', dot: 'bg-critical' },
+}
+
+const FALLBACK: BadgeStyle = { label: 'Unknown', soft: 'bg-muted text-mutedfg ring-border', dot: 'bg-mutedfg' }
+
+function Badge({ style, raw }: { style: BadgeStyle | undefined; raw: string }) {
+  const s = style ?? { ...FALLBACK, label: raw || FALLBACK.label }
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-semibold ring-1 ring-inset',
+        s.soft,
+      )}
+    >
+      <span className={cn('size-1.5 rounded-full', s.dot)} />
+      {s.label}
+    </span>
+  )
+}
+
+export function FleetVerdictBadge({ verdict }: { verdict: FleetVerdict }) {
+  return <Badge style={VERDICT_STYLE[verdict]} raw={verdict} />
+}
+
+export function verdictLabel(verdict: FleetVerdict): string {
+  return VERDICT_STYLE[verdict]?.label ?? verdict
+}
+
+export function FleetStateBadge({ state }: { state: FleetAgentHealth }) {
+  return <Badge style={STATE_STYLE[state]} raw={state} />
+}
+
+// formatFleetTime renders an ISO timestamp, treating an empty value or the Go zero time
+// ("0001-01-01T00:00:00Z") as "never assessed" rather than a misleading year-1 date.
+export function formatFleetTime(iso: string): string {
+  if (!iso) return '—'
+  const t = new Date(iso)
+  if (Number.isNaN(t.getTime()) || t.getUTCFullYear() <= 1) return '—'
+  return t.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}

--- a/web/src/test/virtualize.ts
+++ b/web/src/test/virtualize.ts
@@ -1,0 +1,37 @@
+import { vi } from 'vitest'
+
+// installVirtualViewport gives jsdom a non-zero viewport so @tanstack/react-virtual actually renders
+// rows in tests (otherwise the scroll element measures 0×0 and no virtual items mount). Returns a
+// teardown to restore the originals. Mirrors the stub in VirtualRuleCards.test.tsx.
+export function installVirtualViewport(): () => void {
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect
+
+  window.ResizeObserver = class ResizeObserver {
+    constructor(private cb: ResizeObserverCallback) {}
+    observe(target: Element) {
+      this.cb([{ target, contentRect: target.getBoundingClientRect() } as ResizeObserverEntry], this)
+    }
+    unobserve() {}
+    disconnect() {}
+  }
+
+  Element.prototype.getBoundingClientRect = vi.fn(() => ({
+    width: 800,
+    height: 800,
+    top: 0,
+    left: 0,
+    bottom: 800,
+    right: 800,
+    x: 0,
+    y: 0,
+    toJSON: () => {},
+  })) as unknown as typeof Element.prototype.getBoundingClientRect
+
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 800 })
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 800 })
+
+  return () => {
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    delete (window as { ResizeObserver?: unknown }).ResizeObserver
+  }
+}


### PR DESCRIPTION
Closes the **web layer** of #413 (Epic #405, Phase 1). The coverage/agent-health backend shipped in #454; this makes it usable on the dashboard.

## What

- **FleetCoverage** (`/fleet`) — summary card (assessed pairs · covered · not-covered · assets-without-agent · per-verdict counts · oldest-per-capability) + a virtualized per-`(asset, capability)` verdict table + **CSV export**. Every state except `covered` renders in a distinct, non-green token.
- **FleetAgents** (`/fleet/agents`) — state filter (all/healthy/stale/revoked) + virtualized agent table + an agent-detail card with recent work orders.
- **fleetShared** — `FleetVerdictBadge` / `FleetStateBadge` / freshness-aware time formatter (Go zero-time → `—`).
- Wiring: a **Fleet** sidebar entry + nested `/fleet` routes.

## Acceptance criteria (web)

- [x] Theme tokens only (no raw hex), lucide icons only, `font-mono` + `tabular-nums` for ids/timestamps/counts.
- [x] Explicit **loading / empty / error(+retry)** states on every data view.
- [x] Tables virtualized via the shared `VirtualTable` (docs/04-ui-ux.md: > 50 rows).
- [x] **Coverage honesty** — only `covered` is green; unknown/stale/refused/unauthorized are visually distinct and never rendered as passing.
- [x] Frontend tests for empty + error states of each view (plus loading, retry, state-filter, agent-detail, and non-covered verdict rendering).

## Review

frontend-reviewer run; **all findings applied** — including a CRITICAL it caught: the `stale` badge used the `low` token, which is the *same hex* (`#22c55e`) as the `covered` green, so a stale/unassessed row read as covered — the exact honesty invariant this view exists to protect. Remapped `stale` → `info` (cyan). Also added focus-visible rings to custom controls, `title` attributes on truncated id cells, and a retry to the agent-detail error state.

Verified locally: `pnpm typecheck`, `pnpm test` (276 pass), `pnpm build`.
