### PR TITLE
feat(reachability): implement the JS/TS module import scanner (#379)

### DIFF
--- a/internal/domain/jsresolution/candidates.go
+++ b/internal/domain/jsresolution/candidates.go
@@ -1,0 +1,79 @@
+package jsresolution
+
+import (
+	"path"
+	"strings"
+)
+
+// Module file-resolution candidates are pure lexical rules shared by every phase of JavaScript and
+// TypeScript resolution. They live in the domain because the source scanner (phase R1) and the package
+// resolver (phase R2) must agree: if one orders candidates differently from the other, the same specifier
+// can resolve to two different modules and the graph becomes internally inconsistent.
+
+// moduleSourceExtensions is the ordered candidate extension list for a module specifier that carries no
+// extension. The order mirrors TypeScript's documented precedence — TypeScript sources first, then
+// declarations, then JavaScript — so exactly one candidate wins and resolution stays deterministic.
+var moduleSourceExtensions = []string{
+	".ts", ".tsx", ".mts", ".cts",
+	".d.ts", ".d.mts", ".d.cts",
+	".js", ".jsx", ".mjs", ".cjs",
+}
+
+// emittedExtensionRewrites maps the EMITTED extension a TypeScript project writes in a specifier to the
+// source extensions that actually hold the code: an ESM TypeScript project imports "./util.js" for the
+// file authored as util.ts.
+var emittedExtensionRewrites = map[string][]string{
+	".js":  {".ts", ".tsx", ".d.ts"},
+	".jsx": {".tsx", ".d.ts"},
+	".mjs": {".mts", ".d.mts"},
+	".cjs": {".cts", ".d.cts"},
+}
+
+// ModuleSourceExtensions returns the ordered extension candidates for an extensionless specifier.
+func ModuleSourceExtensions() []string {
+	return append([]string(nil), moduleSourceExtensions...)
+}
+
+// EmittedExtensionCandidates returns the source extensions an emitted specifier extension may map to.
+// It returns nil when ext is not an emitted JavaScript extension.
+func EmittedExtensionCandidates(ext string) []string {
+	rewrites, ok := emittedExtensionRewrites[strings.ToLower(ext)]
+	if !ok {
+		return nil
+	}
+	return append([]string(nil), rewrites...)
+}
+
+// ModuleFileCandidates returns the ordered module paths a resolved base path may refer to: the path as
+// written, its emitted-extension rewrites, the extension candidates, and finally the directory index
+// forms. base is a normalized repository-relative path; an empty base means the repository root.
+//
+// The returned order is the resolution order: the first candidate that exists wins.
+func ModuleFileCandidates(base string) []string {
+	base = strings.TrimSuffix(base, "/")
+	out := make([]string, 0, 2*len(moduleSourceExtensions)+len(emittedExtensionRewrites)+1)
+
+	if base != "" {
+		if ext := path.Ext(base); ext != "" {
+			// A specifier written with an extension resolves as written first, then through the
+			// emitted-extension rewrite.
+			out = append(out, base)
+			stem := strings.TrimSuffix(base, ext)
+			for _, rewrite := range EmittedExtensionCandidates(ext) {
+				out = append(out, stem+rewrite)
+			}
+		}
+		for _, ext := range moduleSourceExtensions {
+			out = append(out, base+ext)
+		}
+	}
+
+	indexBase := "index"
+	if base != "" {
+		indexBase = base + "/index"
+	}
+	for _, ext := range moduleSourceExtensions {
+		out = append(out, indexBase+ext)
+	}
+	return out
+}

--- a/internal/domain/jsresolution/candidates_test.go
+++ b/internal/domain/jsresolution/candidates_test.go
@@ -1,0 +1,141 @@
+package jsresolution
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestModuleSourceExtensionsIsACopy(t *testing.T) {
+	t.Parallel()
+
+	first := ModuleSourceExtensions()
+	first[0] = "MUTATED"
+	if ModuleSourceExtensions()[0] == "MUTATED" {
+		t.Fatal("ModuleSourceExtensions must return a copy; a caller must not be able to reorder resolution")
+	}
+}
+
+func TestModuleSourceExtensionsPrecedence(t *testing.T) {
+	t.Parallel()
+
+	got := ModuleSourceExtensions()
+	// TypeScript sources must precede declarations, which must precede JavaScript: the first existing
+	// candidate wins, so this order IS the resolution semantics.
+	indexOf := func(ext string) int {
+		for i, v := range got {
+			if v == ext {
+				return i
+			}
+		}
+		t.Fatalf("extension %q missing from the candidate list", ext)
+		return -1
+	}
+	if indexOf(".ts") >= indexOf(".d.ts") {
+		t.Error(".ts must be preferred over .d.ts")
+	}
+	if indexOf(".d.ts") >= indexOf(".js") {
+		t.Error(".d.ts must be preferred over .js")
+	}
+	if indexOf(".ts") >= indexOf(".tsx") {
+		t.Error(".ts must be preferred over .tsx")
+	}
+}
+
+func TestEmittedExtensionCandidates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ext  string
+		want []string
+	}{
+		{ext: ".js", want: []string{".ts", ".tsx", ".d.ts"}},
+		{ext: ".jsx", want: []string{".tsx", ".d.ts"}},
+		{ext: ".mjs", want: []string{".mts", ".d.mts"}},
+		{ext: ".cjs", want: []string{".cts", ".d.cts"}},
+		{ext: ".JS", want: []string{".ts", ".tsx", ".d.ts"}},
+		{ext: ".ts", want: nil},
+		{ext: ".css", want: nil},
+		{ext: "", want: nil},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.ext, func(t *testing.T) {
+			t.Parallel()
+			got := EmittedExtensionCandidates(test.ext)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("EmittedExtensionCandidates(%q) = %v, want %v", test.ext, got, test.want)
+			}
+		})
+	}
+}
+
+func TestModuleFileCandidates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extensionless base", func(t *testing.T) {
+		t.Parallel()
+		got := ModuleFileCandidates("src/util")
+		if got[0] != "src/util.ts" {
+			t.Fatalf("first candidate = %q, want src/util.ts", got[0])
+		}
+		if !contains(got, "src/util/index.ts") {
+			t.Fatalf("directory index candidate missing: %v", got)
+		}
+		// The base itself is not a candidate when it carries no extension: a file with no extension is
+		// not a module this scanner supports.
+		if contains(got, "src/util") {
+			t.Fatalf("an extensionless path must not be its own candidate: %v", got)
+		}
+	})
+
+	t.Run("emitted extension", func(t *testing.T) {
+		t.Parallel()
+		got := ModuleFileCandidates("src/util.js")
+		if got[0] != "src/util.js" {
+			t.Fatalf("a written extension must be tried first, got %q", got[0])
+		}
+		// The rewrite must come before the generic extension candidates so "./util.js" prefers util.ts
+		// over, say, util.js.ts.
+		rewriteAt, genericAt := indexOf(got, "src/util.ts"), indexOf(got, "src/util.js.ts")
+		if rewriteAt < 0 {
+			t.Fatalf("emitted-extension rewrite missing: %v", got)
+		}
+		if genericAt >= 0 && rewriteAt > genericAt {
+			t.Fatalf("the rewrite must precede the generic candidates: %v", got)
+		}
+	})
+
+	t.Run("repository root", func(t *testing.T) {
+		t.Parallel()
+		got := ModuleFileCandidates("")
+		if got[0] != "index.ts" {
+			t.Fatalf("root candidates must start at index.ts, got %q", got[0])
+		}
+		for _, candidate := range got {
+			if candidate == ".ts" || candidate == "" {
+				t.Fatalf("root candidates must not include a bare extension: %v", got)
+			}
+		}
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		t.Parallel()
+		if !reflect.DeepEqual(ModuleFileCandidates("a/b"), ModuleFileCandidates("a/b")) {
+			t.Fatal("candidate generation must be deterministic")
+		}
+	})
+}
+
+func contains(values []string, want string) bool {
+	return indexOf(values, want) >= 0
+}
+
+func indexOf(values []string, want string) int {
+	for i, v := range values {
+		if v == want {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/domain/modulegraph/modulegraph.go
+++ b/internal/domain/modulegraph/modulegraph.go
@@ -112,6 +112,15 @@ const (
 	CoverageUnresolvedRelativeImport  CoverageIssueKind = "unresolved-relative-import"
 	CoverageAmbiguousRelativeImport   CoverageIssueKind = "ambiguous-relative-import"
 	CoverageRelativeImportEscapesRoot CoverageIssueKind = "relative-import-escapes-root"
+	// The remaining budgets are distinct kinds so a consumer can tell WHICH bound fired. Reusing one
+	// kind for several bounds hides, for example, a truncated coverage list behind a file-count message.
+	CoverageEntryBudgetExceeded CoverageIssueKind = "entry-budget-exceeded"
+	CoverageEdgeBudgetExceeded  CoverageIssueKind = "edge-budget-exceeded"
+	CoverageIssueBudgetExceeded CoverageIssueKind = "issue-budget-exceeded"
+	// CoverageSkippedDirectory records a directory excluded from the scan that nonetheless contained
+	// supported source. Excluding build output or a tool directory is a policy choice, but the modules
+	// inside it are unobserved, so their imports must not be read as absent.
+	CoverageSkippedDirectory CoverageIssueKind = "skipped-directory"
 )
 
 // Valid reports whether k is a known R1 coverage issue kind.
@@ -135,7 +144,11 @@ func (k CoverageIssueKind) Valid() bool {
 		CoverageUnsupportedLoader,
 		CoverageUnresolvedRelativeImport,
 		CoverageAmbiguousRelativeImport,
-		CoverageRelativeImportEscapesRoot:
+		CoverageRelativeImportEscapesRoot,
+		CoverageEntryBudgetExceeded,
+		CoverageEdgeBudgetExceeded,
+		CoverageIssueBudgetExceeded,
+		CoverageSkippedDirectory:
 		return true
 	default:
 		return false

--- a/internal/infrastructure/tools/jsimports/extract.go
+++ b/internal/infrastructure/tools/jsimports/extract.go
@@ -1,0 +1,664 @@
+package jsimports
+
+import "github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+
+// rawImport is one statically observed module-loading site, before path resolution.
+type rawImport struct {
+	specifier string
+	kind      modulegraph.ImportKind
+	bindings  []modulegraph.Binding
+	typeOnly  bool
+	position  modulegraph.Position
+}
+
+// extraction is everything one source file yields: its import sites and its coverage hazards.
+type extraction struct {
+	imports []rawImport
+	hazards []hazard
+}
+
+// indirectLoaders are call-shaped module loaders this scanner does not extract specifiers from. Each one
+// really loads a module, so seeing it must degrade coverage: otherwise a dependency loaded through, say,
+// an AMD define() would look unused and could be reported unreachable.
+var indirectLoaders = map[string]string{
+	"define":                  "amd define",
+	"requirejs":               "requirejs loader",
+	"importScripts":           "worker importScripts",
+	"__non_webpack_require__": "webpack require escape hatch",
+	"__webpack_require__":     "webpack runtime require",
+	"requireActual":           "test-runner requireActual",
+	"requireMock":             "test-runner requireMock",
+	"dlopen":                  "native addon dlopen",
+}
+
+// referenceIsEnough names loaders whose mere REFERENCE degrades coverage, because aliasing one
+// (`const wr = __webpack_require__; wr(4)`) loads a module just as calling it does. Names common as
+// first-party identifiers (define) stay call-only so ordinary code is not flagged.
+var referenceIsEnough = map[string]bool{
+	"__webpack_require__": true, "__non_webpack_require__": true,
+	"importScripts": true, "requirejs": true, "createRequire": true,
+	"requireActual": true, "requireMock": true, "dlopen": true,
+}
+
+// loaderNames are the loader identifiers recognised through a computed member access
+// (`module["require"](...)`), which produces no identifier token at all.
+var loaderNames = map[string]bool{
+	"require": true, "eval": true, "Function": true, "import": true,
+	"importScripts": true, "define": true, "requirejs": true, "createRequire": true,
+	"__webpack_require__": true, "__non_webpack_require__": true, "dlopen": true,
+}
+
+// memberReachableLoaders are loaders that are still loaders when called through a receiver, because the
+// receiver is the loader's own namespace (jest.requireActual, process.dlopen) rather than an unrelated
+// object that happens to expose a same-named method.
+var memberReachableLoaders = map[string]bool{
+	"requireActual": true, "requireMock": true, "dlopen": true,
+}
+
+// globalObjects are receivers through which the global evaluator is still the global evaluator.
+var globalObjects = map[string]bool{
+	"globalThis": true, "window": true, "global": true, "self": true,
+}
+
+// requireReceivers are receivers whose `.require(...)` is a genuine Node module loader rather than an
+// unrelated method that happens to be called require.
+var requireReceivers = map[string]bool{
+	"module": true, "mainModule": true, "main": true,
+}
+
+// extractor turns a token stream into import sites. It is a focused recogniser, not a full parser: it
+// matches the module-loading forms in the epic's scope and records anything else that could load a module
+// as a hazard, so an unrecognised construct degrades coverage instead of silently disappearing.
+type extractor struct {
+	lex *lexer
+	// buf holds tokens pushed back by the recognisers (single-token lookahead is not always enough).
+	buf []token
+	out extraction
+}
+
+func newExtractor(src []byte, jsxAware bool) *extractor {
+	return &extractor{lex: newLexer(src, jsxAware)}
+}
+
+func (e *extractor) next() token {
+	if n := len(e.buf); n > 0 {
+		t := e.buf[n-1]
+		e.buf = e.buf[:n-1]
+		return t
+	}
+	return e.lex.next()
+}
+
+func (e *extractor) push(t token) { e.buf = append(e.buf, t) }
+
+// peek returns the next token without consuming it.
+func (e *extractor) peek() token {
+	t := e.next()
+	e.push(t)
+	return t
+}
+
+func (e *extractor) addHazard(kind hazardKind, line int, detail string) {
+	e.out.hazards = append(e.out.hazards, hazard{kind: kind, line: line, detail: detail})
+}
+
+// addImport records an import site. A specifier whose literal contained an escape this lexer does not
+// decode is NOT recorded as an edge: its decoded value is not the runtime specifier, so resolving it
+// could name the wrong package. It degrades coverage instead.
+func (e *extractor) addImport(imp rawImport, undecodedEscape bool) {
+	if undecodedEscape {
+		e.addHazard(hazardUnsupportedLoader, imp.position.Line, "module specifier contains an undecoded escape")
+		return
+	}
+	e.out.imports = append(e.out.imports, imp)
+}
+
+// run walks the whole file. Every token is examined; only the recognised module-loading forms and the
+// hazards produce output.
+func (e *extractor) run() extraction {
+	// prev and prev2 track the two previous significant tokens so member expressions
+	// (`module.require`, `require.main.require`, `globalThis.eval`) can be recognised.
+	var prev, prev2 token
+	var havePrev bool
+
+	for {
+		t := e.next()
+		if t.kind == tokenEOF {
+			break
+		}
+
+		switch {
+		case t.kind == tokenIdent && t.text == "import":
+			e.handleImportKeyword(t, prev, havePrev)
+		case t.kind == tokenIdent && t.text == "export":
+			e.handleExportKeyword(t)
+		case t.kind == tokenIdent && t.text == "require":
+			e.handleRequire(t, prev, prev2, havePrev)
+		case t.kind == tokenIdent && t.text == "eval":
+			e.handleEval(t, prev, prev2, havePrev)
+		case t.kind == tokenIdent && t.text == "Function":
+			// `new Function(src)` and a bare `Function(src)` both compile a string into code that can
+			// require anything, and `const F = Function` aliases the same power. A type position
+			// (`x: Function`) or a prototype read (`x instanceof Function`) is harmless.
+			switch {
+			case e.peekIsCall():
+				e.addHazard(hazardNewFunction, t.line, "Function constructor")
+			case havePrev && prev.kind == tokenPunct && (prev.text == "=" || prev.text == "(" || prev.text == ","):
+				// Aliased or passed as an argument; a TypeScript type position (`cb: Function`) has
+				// prev == ":" and is deliberately excluded.
+				e.addHazard(hazardNewFunction, t.line, "Function constructor aliased")
+			}
+		case t.kind == tokenIdent && t.text == "createRequire":
+			// A reference is enough: `const cr = createRequire` aliases a factory that mints a real
+			// loader, so the module it later loads is just as unobservable.
+			e.addHazard(hazardModuleCreateRequire, t.line, "module.createRequire")
+		case t.kind == tokenIdent && t.text == "Worker":
+			// A worker entry module is loaded at runtime and is not statically resolvable here.
+			if havePrev && prev.kind == tokenIdent && prev.text == "new" && e.peekIsCall() {
+				e.addHazard(hazardUnsupportedLoader, t.line, "worker constructor")
+			}
+		case t.kind == tokenIdent && t.text == "System":
+			// `System.import(...)` is the SystemJS loader.
+			if e.peekIsMember("import") {
+				e.addHazard(hazardUnsupportedLoader, t.line, "systemjs loader")
+			}
+		case t.kind == tokenIdent:
+			// A member call such as db.define(...) merely shares a loader's name; only a bare call is
+			// the loader itself. jest.requireActual is the deliberate exception: its receiver is the
+			// test runner and the call really does load a module.
+			memberCall := havePrev && prev.kind == tokenPunct && (prev.text == "." || prev.text == "?.")
+			if detail, ok := indirectLoaders[t.text]; ok {
+				// For most of these a mere reference is enough, because aliasing the loader loads a
+				// module just as calling it does.
+				if e.peekIsCall() || referenceIsEnough[t.text] {
+					if !memberCall || memberReachableLoaders[t.text] {
+						e.addHazard(hazardUnsupportedLoader, t.line, detail)
+					}
+				}
+			}
+		case t.kind == tokenString && havePrev && prev.kind == tokenPunct && prev.text == "[":
+			// A computed member access (module["require"](...)) produces no loader IDENTIFIER token, so
+			// the handlers above never run. The property name is the only observable signal.
+			if loaderNames[t.text] {
+				e.addHazard(hazardUnsupportedLoader, t.line, "computed loader access")
+			}
+		}
+
+		prev2, prev, havePrev = prev, t, true
+	}
+
+	e.out.hazards = append(e.out.hazards, e.lex.hazards...)
+	return e.out
+}
+
+// peekIsCall reports whether the next token opens a call argument list, including an optional call.
+func (e *extractor) peekIsCall() bool {
+	t := e.peek()
+	if t.kind != tokenPunct {
+		return false
+	}
+	return t.text == "(" || t.text == "?."
+}
+
+// peekIsMember reports whether the next two tokens are `.name`.
+func (e *extractor) peekIsMember(name string) bool {
+	dot := e.next()
+	if dot.kind != tokenPunct || dot.text != "." {
+		e.push(dot)
+		return false
+	}
+	prop := e.next()
+	matched := prop.kind == tokenIdent && prop.text == name
+	e.push(prop)
+	e.push(dot)
+	return matched
+}
+
+// handleEval recognises every shape through which the global evaluator can run code. eval can load a
+// module through a string, so any reference to it — not just a direct call — degrades coverage.
+func (e *extractor) handleEval(t, prev, prev2 token, havePrev bool) {
+	isMember := havePrev && prev.kind == tokenPunct && (prev.text == "." || prev.text == "?.")
+	if isMember {
+		// `globalThis.eval(...)` IS global eval; `sandbox.eval(...)` is an unrelated method.
+		if prev2.kind == tokenIdent && globalObjects[prev2.text] {
+			e.addHazard(hazardEval, t.line, "global eval via global object")
+		}
+		return
+	}
+	// A bare `eval` reference, called or aliased (`const e = eval; e(src)`), is a hazard either way.
+	e.addHazard(hazardEval, t.line, "eval reference")
+}
+
+// handleImportKeyword recognises every `import`-led form: `import.meta...`, dynamic `import(...)`,
+// TypeScript `import x = require(...)`, and the static ESM declarations.
+func (e *extractor) handleImportKeyword(kw, prev token, havePrev bool) {
+	// `foo.import` is a property access; `System.import(...)` is reported by the caller's loader table.
+	if havePrev && prev.kind == tokenPunct && (prev.text == "." || prev.text == "?.") {
+		return
+	}
+
+	t := e.next()
+	switch {
+	case t.kind == tokenPunct && t.text == ":":
+		// An object key named `import` (`{ import: 1 }`) is not a declaration.
+		e.push(t)
+		return
+	case t.kind == tokenPunct && t.text == ".":
+		// import.meta — only `import.meta.glob(...)` matters (a bundler-expanded multi-module load).
+		meta := e.next()
+		if meta.kind == tokenIdent && meta.text == "meta" {
+			dot := e.next()
+			if dot.kind == tokenPunct && dot.text == "." {
+				prop := e.next()
+				if prop.kind == tokenIdent && (prop.text == "glob" || prop.text == "globEager") && e.peekIsCall() {
+					e.addHazard(hazardImportMetaGlob, kw.line, "import.meta."+prop.text)
+					return
+				}
+				e.push(prop)
+				return
+			}
+			e.push(dot)
+			return
+		}
+		e.push(meta)
+	case t.kind == tokenPunct && (t.text == "(" || t.text == "?."):
+		if t.text == "?." {
+			if open := e.next(); open.kind != tokenPunct || open.text != "(" {
+				e.push(open)
+				return
+			}
+		}
+		e.handleDynamicImport(kw)
+	case t.kind == tokenString:
+		// Side-effect import: `import "mod"`.
+		e.addImport(rawImport{
+			specifier: t.text,
+			kind:      modulegraph.ImportESMStatic,
+			position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+		}, t.undecodedEscape)
+	case t.kind == tokenTemplate:
+		// `import \`mod\`` is not valid ESM; treat as unsupported rather than guess.
+		e.addHazard(hazardUnsupportedLoader, kw.line, "template literal import specifier")
+	default:
+		e.push(t)
+		e.handleStaticImportClause(kw)
+	}
+}
+
+// handleDynamicImport handles `import( ... )`. A literal specifier yields a dynamic-literal edge; any
+// non-literal argument is a hazard, because the loaded module cannot be named statically.
+func (e *extractor) handleDynamicImport(kw token) {
+	if spec, escaped, ok := e.readLiteralCallArgument(); ok {
+		e.addImport(rawImport{
+			specifier: spec,
+			kind:      modulegraph.ImportESMDynamic,
+			position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+		}, escaped)
+		return
+	}
+	e.addHazard(hazardDynamicImport, kw.line, "non-literal dynamic import specifier")
+}
+
+// readLiteralCallArgument reads the first argument of a call that has just consumed its "(". It succeeds
+// only when the argument is a COMPLETE literal — a string or substitution-free template immediately
+// followed by "," or ")".
+//
+// The terminator check is what makes `require("a" + b)` a hazard rather than a false edge to "a": a
+// concatenated specifier is computed at runtime, so its real target is unobservable and treating the
+// first fragment as the module would be a silently wrong dependency edge.
+func (e *extractor) readLiteralCallArgument() (string, bool, bool) {
+	arg := e.next()
+	isLiteral := arg.kind == tokenString || (arg.kind == tokenTemplate && !arg.hasSubstitution)
+	if !isLiteral {
+		e.push(arg)
+		return "", false, false
+	}
+	// A literal specifier may be followed only by the end of the argument list or by a second argument
+	// (ESM import attributes: `import("m", { with: { type: "json" } })`).
+	terminator := e.peek()
+	if terminator.kind != tokenPunct || (terminator.text != ")" && terminator.text != ",") {
+		return "", false, false
+	}
+	return arg.text, arg.undecodedEscape, true
+}
+
+// handleStaticImportClause consumes an ESM import declaration's clause and its `from "specifier"`.
+// It also recognises the TypeScript `import name = require("mod")` form.
+func (e *extractor) handleStaticImportClause(kw token) {
+	first := e.next()
+
+	// `import type ...` — but `import type from "m"` / `import type, {x} from "m"` bind a value named
+	// "type", so the modifier reading only applies when the following token is neither.
+	typeOnly := false
+	if first.kind == tokenIdent && first.text == "type" {
+		lookahead := e.peek()
+		isBindingName := lookahead.kind == tokenIdent && lookahead.text == "from"
+		isBindingName = isBindingName || (lookahead.kind == tokenPunct && lookahead.text == ",")
+		if !isBindingName {
+			typeOnly = true
+			first = e.next()
+		}
+	}
+
+	// TypeScript import-equals: `import fs = require("fs")`.
+	if first.kind == tokenIdent {
+		if eq := e.peek(); eq.kind == tokenPunct && eq.text == "=" {
+			e.next() // consume '='
+			e.handleImportEquals(kw, first)
+			return
+		}
+	}
+
+	e.push(first)
+	bindings, ok := e.readImportBindings()
+	if !ok {
+		e.addHazard(hazardUnsupportedLoader, kw.line, "unrecognised import clause")
+		return
+	}
+
+	specifier, escaped, sok := e.readFromSpecifier(kw, "import")
+	if !sok {
+		return
+	}
+	e.addImport(rawImport{
+		specifier: specifier,
+		kind:      modulegraph.ImportESMStatic,
+		bindings:  bindings,
+		typeOnly:  typeOnly || allBindingsTypeOnly(bindings),
+		position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+	}, escaped)
+}
+
+// handleImportEquals handles `import name = require("mod")` and `import name = A.B` (an alias, no module).
+func (e *extractor) handleImportEquals(kw, name token) {
+	req := e.next()
+	if req.kind != tokenIdent || req.text != "require" {
+		// A namespace alias such as `import X = A.B` loads no module.
+		e.push(req)
+		return
+	}
+	open := e.next()
+	if open.kind != tokenPunct || open.text != "(" {
+		e.push(open)
+		return
+	}
+	spec, escaped, ok := e.readLiteralCallArgument()
+	if !ok {
+		e.addHazard(hazardDynamicRequire, kw.line, "non-literal import-equals require")
+		return
+	}
+	e.addImport(rawImport{
+		specifier: spec,
+		kind:      modulegraph.ImportTypeScriptEqual,
+		bindings:  []modulegraph.Binding{{Local: name.text, Namespace: true}},
+		position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+	}, escaped)
+}
+
+// readImportBindings consumes the binding clause of an import declaration. It returns false when the
+// clause is not one of the recognised shapes, so the caller can degrade coverage.
+func (e *extractor) readImportBindings() ([]modulegraph.Binding, bool) {
+	var bindings []modulegraph.Binding
+	for {
+		t := e.next()
+		switch {
+		case t.kind == tokenIdent && t.text == "from":
+			e.push(t)
+			return bindings, true
+		case t.kind == tokenIdent:
+			// Default binding.
+			bindings = append(bindings, modulegraph.Binding{Imported: "default", Local: t.text, Default: true})
+		case t.kind == tokenPunct && t.text == "*":
+			as := e.next()
+			if as.kind == tokenIdent && as.text == "as" {
+				local := e.next()
+				if local.kind != tokenIdent {
+					e.push(local)
+					return nil, false
+				}
+				bindings = append(bindings, modulegraph.Binding{Local: local.text, Namespace: true})
+			} else {
+				e.push(as)
+				bindings = append(bindings, modulegraph.Binding{Namespace: true})
+			}
+		case t.kind == tokenPunct && t.text == "{":
+			named, ok := e.readNamedBindings()
+			if !ok {
+				return nil, false
+			}
+			bindings = append(bindings, named...)
+		case t.kind == tokenPunct && t.text == ",":
+			// Separator between default and named/namespace clauses.
+		default:
+			e.push(t)
+			return nil, false
+		}
+	}
+}
+
+// readNamedBindings consumes `{ a, b as c, type D }` after the opening brace.
+func (e *extractor) readNamedBindings() ([]modulegraph.Binding, bool) {
+	var bindings []modulegraph.Binding
+	for {
+		t := e.next()
+		switch {
+		case t.kind == tokenPunct && t.text == "}":
+			return bindings, true
+		case t.kind == tokenPunct && t.text == ",":
+			continue
+		case t.kind == tokenIdent || t.kind == tokenString:
+			// `type X` / `type X as Y` marks a single inline type-only binding; `type as X` and
+			// `type` alone are ordinary bindings named "type".
+			memberTypeOnly := false
+			name := t
+			if t.kind == tokenIdent && t.text == "type" {
+				lookahead := e.peek()
+				if (lookahead.kind == tokenIdent && lookahead.text != "as") || lookahead.kind == tokenString {
+					memberTypeOnly = true
+					name = e.next()
+				}
+			}
+			binding := modulegraph.Binding{Imported: name.text, Local: name.text, TypeOnly: memberTypeOnly}
+			if as := e.peek(); as.kind == tokenIdent && as.text == "as" {
+				e.next()
+				local := e.next()
+				if local.kind != tokenIdent && local.kind != tokenString {
+					e.push(local)
+					return nil, false
+				}
+				binding.Local = local.text
+			}
+			bindings = append(bindings, binding)
+		default:
+			e.push(t)
+			return nil, false
+		}
+	}
+}
+
+// readFromSpecifier consumes `from "specifier"`, recording a hazard when the specifier is not literal.
+func (e *extractor) readFromSpecifier(kw token, form string) (string, bool, bool) {
+	from := e.next()
+	if from.kind != tokenIdent || from.text != "from" {
+		e.push(from)
+		e.addHazard(hazardUnsupportedLoader, kw.line, "missing from clause in "+form)
+		return "", false, false
+	}
+	spec := e.next()
+	switch {
+	case spec.kind == tokenString:
+		return spec.text, spec.undecodedEscape, true
+	case spec.kind == tokenTemplate && !spec.hasSubstitution:
+		return spec.text, false, true
+	default:
+		e.push(spec)
+		e.addHazard(hazardUnsupportedLoader, kw.line, "non-literal "+form+" specifier")
+		return "", false, false
+	}
+}
+
+// handleExportKeyword recognises the re-export forms that create a module edge:
+// `export ... from "m"`, `export * from "m"`, `export * as ns from "m"`, and their type-only variants.
+// A local export (`export const x = 1`) creates no edge and is skipped.
+func (e *extractor) handleExportKeyword(kw token) {
+	t := e.next()
+
+	typeOnly := false
+	if t.kind == tokenIdent && t.text == "type" {
+		lookahead := e.peek()
+		// `export type {X} from "m"` / `export type * from "m"` are type-only re-exports;
+		// `export type X = ...` is a local type alias with no specifier.
+		if lookahead.kind == tokenPunct && (lookahead.text == "{" || lookahead.text == "*") {
+			typeOnly = true
+			t = e.next()
+		}
+	}
+
+	switch {
+	case t.kind == tokenPunct && t.text == "*":
+		var bindings []modulegraph.Binding
+		if as := e.peek(); as.kind == tokenIdent && as.text == "as" {
+			e.next()
+			local := e.next()
+			if local.kind == tokenIdent || local.kind == tokenString {
+				bindings = append(bindings, modulegraph.Binding{Local: local.text, Namespace: true, TypeOnly: typeOnly})
+			} else {
+				e.push(local)
+			}
+		} else {
+			bindings = append(bindings, modulegraph.Binding{Namespace: true, TypeOnly: typeOnly})
+		}
+		specifier, escaped, ok := e.readFromSpecifier(kw, "export")
+		if !ok {
+			return
+		}
+		e.addImport(rawImport{
+			specifier: specifier,
+			kind:      modulegraph.ImportReExport,
+			bindings:  bindings,
+			typeOnly:  typeOnly,
+			position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+		}, escaped)
+	case t.kind == tokenPunct && t.text == "{":
+		bindings, ok := e.readNamedBindings()
+		if !ok {
+			e.addHazard(hazardUnsupportedLoader, kw.line, "unrecognised export clause")
+			return
+		}
+		// A local re-export list (`export {a}`) has no `from` and creates no module edge.
+		if from := e.peek(); from.kind != tokenIdent || from.text != "from" {
+			return
+		}
+		specifier, escaped, sok := e.readFromSpecifier(kw, "export")
+		if !sok {
+			return
+		}
+		e.addImport(rawImport{
+			specifier: specifier,
+			kind:      modulegraph.ImportReExport,
+			bindings:  bindings,
+			typeOnly:  typeOnly || allBindingsTypeOnly(bindings),
+			position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+		}, escaped)
+	default:
+		// `export default ...`, `export const ...`, `export = ...`: no module specifier.
+		e.push(t)
+	}
+}
+
+// handleRequire recognises every shape of the CommonJS loader.
+//
+// A `require` that is neither a direct call nor a known member form is itself a hazard: aliasing it
+// (`const r = require; r("pkg")`), reaching it indirectly (`(0, require)("pkg")`) or calling it through a
+// receiver (`module.require("pkg")`) all load a module that this scanner cannot name.
+func (e *extractor) handleRequire(kw, prev, prev2 token, havePrev bool) {
+	if havePrev && prev.kind == tokenPunct && (prev.text == "." || prev.text == "?.") {
+		// `module.require(...)` / `require.main.require(...)` are genuine loaders; an unrelated
+		// `vm.require(...)` method is not.
+		if prev2.kind == tokenIdent && requireReceivers[prev2.text] {
+			e.addHazard(hazardDynamicRequire, kw.line, "require through a module receiver")
+		}
+		return
+	}
+
+	t := e.next()
+	switch {
+	case t.kind == tokenPunct && t.text == ".":
+		prop := e.next()
+		if prop.kind == tokenIdent {
+			switch prop.text {
+			case "context", "ensure":
+				// A reference is enough: `const ctx = require.context` aliases the loader.
+				e.addHazard(hazardRequireContext, kw.line, "require."+prop.text)
+				return
+			case "resolve":
+				// require.resolve locates a module without loading it, but a LITERAL argument still
+				// names a real dependency of first-party code, so it is honest evidence of use. Only a
+				// computed argument degrades coverage.
+				if open := e.next(); open.kind == tokenPunct && open.text == "(" {
+					if spec, escaped, ok := e.readLiteralCallArgument(); ok {
+						e.addImport(rawImport{
+							specifier: spec,
+							kind:      modulegraph.ImportCommonJS,
+							position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+						}, escaped)
+						return
+					}
+				} else {
+					e.push(open)
+				}
+				e.addHazard(hazardUnsupportedLoader, kw.line, "require.resolve")
+				return
+			case "main", "cache", "extensions":
+				// require.main.require(...) and friends reach the loader indirectly.
+				e.addHazard(hazardDynamicRequire, kw.line, "require internals accessed")
+				return
+			}
+		}
+		e.push(prop)
+		e.addHazard(hazardDynamicRequire, kw.line, "unrecognised require property")
+	case t.kind == tokenPunct && (t.text == "(" || t.text == "?."):
+		if t.text == "?." {
+			// Optional call `require?.("pkg")` still loads the module.
+			if open := e.next(); open.kind != tokenPunct || open.text != "(" {
+				e.push(open)
+				e.addHazard(hazardDynamicRequire, kw.line, "require referenced outside a call")
+				return
+			}
+		}
+		if spec, escaped, ok := e.readLiteralCallArgument(); ok {
+			e.addImport(rawImport{
+				specifier: spec,
+				kind:      modulegraph.ImportCommonJS,
+				position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+			}, escaped)
+			return
+		}
+		e.addHazard(hazardDynamicRequire, kw.line, "non-literal require specifier")
+	case t.kind == tokenPunct && t.text == ":":
+		// An object key named require (`{ require: fn }`) is not the loader.
+		//
+		// A PARAMETER named require — the UMD wrapper `function (require, exports, module) {}` — is
+		// deliberately NOT excluded: lexically it is indistinguishable from `register(require)`, which
+		// passes the real loader somewhere this scanner cannot follow. The false hazard costs coverage
+		// utility; missing the indirection would cost a suppressed vulnerability.
+		e.push(t)
+	default:
+		e.push(t)
+		e.addHazard(hazardDynamicRequire, kw.line, "require referenced outside a call")
+	}
+}
+
+// allBindingsTypeOnly reports whether a non-empty binding list is entirely type-only, which makes the
+// whole edge type-only: no runtime module load survives compilation.
+func allBindingsTypeOnly(bindings []modulegraph.Binding) bool {
+	if len(bindings) == 0 {
+		return false
+	}
+	for _, b := range bindings {
+		if !b.TypeOnly {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/infrastructure/tools/jsimports/extract_test.go
+++ b/internal/infrastructure/tools/jsimports/extract_test.go
@@ -1,0 +1,419 @@
+package jsimports
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+// extractSpecifiers is a test helper returning the specifier/kind/type-only triple of every import.
+type extracted struct {
+	specifier string
+	kind      modulegraph.ImportKind
+	typeOnly  bool
+	line      int
+}
+
+func extractAll(t *testing.T, src string) extraction {
+	t.Helper()
+	return newExtractor([]byte(src), false).run()
+}
+
+// extractJSX runs the extractor with JSX element handling enabled (the .jsx/.tsx dialects).
+func extractJSX(t *testing.T, src string) extraction {
+	t.Helper()
+	return newExtractor([]byte(src), true).run()
+}
+
+func specifiersOf(t *testing.T, src string) []extracted {
+	t.Helper()
+	result := extractAll(t, src)
+	out := make([]extracted, 0, len(result.imports))
+	for _, imp := range result.imports {
+		out = append(out, extracted{specifier: imp.specifier, kind: imp.kind, typeOnly: imp.typeOnly, line: imp.position.Line})
+	}
+	return out
+}
+
+func hazardKindsOf(t *testing.T, src string) map[hazardKind]bool {
+	t.Helper()
+	out := map[hazardKind]bool{}
+	for _, h := range extractAll(t, src).hazards {
+		out[h.kind] = true
+	}
+	return out
+}
+
+func TestExtractImportForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want []extracted
+	}{
+		{
+			name: "side-effect import",
+			src:  `import "polyfill";`,
+			want: []extracted{{specifier: "polyfill", kind: modulegraph.ImportESMStatic, line: 1}},
+		},
+		{
+			name: "default import",
+			src:  `import lodash from "lodash";`,
+			want: []extracted{{specifier: "lodash", kind: modulegraph.ImportESMStatic, line: 1}},
+		},
+		{
+			name: "named imports",
+			src:  `import { map, filter as f } from "lodash/fp";`,
+			want: []extracted{{specifier: "lodash/fp", kind: modulegraph.ImportESMStatic, line: 1}},
+		},
+		{
+			name: "namespace import",
+			src:  `import * as path from "node:path";`,
+			want: []extracted{{specifier: "node:path", kind: modulegraph.ImportESMStatic, line: 1}},
+		},
+		{
+			name: "default plus named",
+			src:  `import React, { useState } from "react";`,
+			want: []extracted{{specifier: "react", kind: modulegraph.ImportESMStatic, line: 1}},
+		},
+		{
+			name: "scoped package with subpath",
+			src:  `import x from "@scope/pkg/deep/path";`,
+			want: []extracted{{specifier: "@scope/pkg/deep/path", kind: modulegraph.ImportESMStatic, line: 1}},
+		},
+		{
+			name: "commonjs require",
+			src:  `const parser = require("@scope/parser");`,
+			want: []extracted{{specifier: "@scope/parser", kind: modulegraph.ImportCommonJS, line: 1}},
+		},
+		{
+			name: "dynamic import literal",
+			src:  `await import("chart.js");`,
+			want: []extracted{{specifier: "chart.js", kind: modulegraph.ImportESMDynamic, line: 1}},
+		},
+		{
+			name: "dynamic import substitution-free template",
+			src:  "await import(`chart.js`);",
+			want: []extracted{{specifier: "chart.js", kind: modulegraph.ImportESMDynamic, line: 1}},
+		},
+		{
+			name: "re-export named",
+			src:  `export { a, b } from "./local";`,
+			want: []extracted{{specifier: "./local", kind: modulegraph.ImportReExport, line: 1}},
+		},
+		{
+			name: "re-export star",
+			src:  `export * from "shared-lib";`,
+			want: []extracted{{specifier: "shared-lib", kind: modulegraph.ImportReExport, line: 1}},
+		},
+		{
+			name: "re-export star as namespace",
+			src:  `export * as helpers from "shared-lib";`,
+			want: []extracted{{specifier: "shared-lib", kind: modulegraph.ImportReExport, line: 1}},
+		},
+		{
+			name: "typescript import equals",
+			src:  `import fs = require("fs");`,
+			want: []extracted{{specifier: "fs", kind: modulegraph.ImportTypeScriptEqual, line: 1}},
+		},
+		{
+			name: "multiline import clause keeps keyword line",
+			src:  "import {\n  a,\n  b,\n} from \"multi\";",
+			want: []extracted{{specifier: "multi", kind: modulegraph.ImportESMStatic, line: 1}},
+		},
+		{
+			name: "several imports across lines",
+			src:  "import a from \"one\";\nimport b from \"two\";",
+			want: []extracted{
+				{specifier: "one", kind: modulegraph.ImportESMStatic, line: 1},
+				{specifier: "two", kind: modulegraph.ImportESMStatic, line: 2},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := specifiersOf(t, test.src)
+			if len(got) != len(test.want) {
+				t.Fatalf("extracted %d imports, want %d: %+v", len(got), len(test.want), got)
+			}
+			for i := range test.want {
+				if got[i] != test.want[i] {
+					t.Fatalf("import[%d] = %+v, want %+v", i, got[i], test.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExtractTypeOnlyClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		src          string
+		wantTypeOnly bool
+	}{
+		{name: "import type clause", src: `import type { T } from "pkg";`, wantTypeOnly: true},
+		{name: "import type default", src: `import type T from "pkg";`, wantTypeOnly: true},
+		{name: "export type clause", src: `export type { T } from "pkg";`, wantTypeOnly: true},
+		{name: "all inline type members", src: `import { type A, type B } from "pkg";`, wantTypeOnly: true},
+		{name: "mixed inline members stay runtime", src: `import { type A, b } from "pkg";`, wantTypeOnly: false},
+		{name: "value import", src: `import { a } from "pkg";`, wantTypeOnly: false},
+		// A binding literally named "type" is a VALUE import, not a type-only modifier. Reading it as
+		// type-only would drop a real runtime dependency edge.
+		{name: "default binding named type", src: `import type from "pkg";`, wantTypeOnly: false},
+		{name: "binding named type with named clause", src: `import type, { a } from "pkg";`, wantTypeOnly: false},
+		{name: "member named type", src: `import { type } from "pkg";`, wantTypeOnly: false},
+		{name: "member type aliased", src: `import { type as kind } from "pkg";`, wantTypeOnly: false},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := specifiersOf(t, test.src)
+			if len(got) != 1 {
+				t.Fatalf("expected exactly one import, got %+v", got)
+			}
+			if got[0].typeOnly != test.wantTypeOnly {
+				t.Fatalf("typeOnly = %v, want %v (src %q)", got[0].typeOnly, test.wantTypeOnly, test.src)
+			}
+		})
+	}
+}
+
+func TestExtractNoEdgeForLocalDeclarations(t *testing.T) {
+	t.Parallel()
+
+	sources := []string{
+		`export const x = 1;`,
+		`export default function main() {}`,
+		`export { local };`,
+		`export type Alias = string;`,
+		`import X = Namespace.Inner;`,
+		`const meta = import.meta.url;`,
+		`obj.require("not-the-loader");`,
+		`obj.import("also-not");`,
+	}
+	for _, src := range sources {
+		src := src
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			if got := specifiersOf(t, src); len(got) != 0 {
+				t.Fatalf("expected no import edge for %q, got %+v", src, got)
+			}
+		})
+	}
+}
+
+func TestExtractHazards(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want hazardKind
+	}{
+		{name: "non-literal require", src: `require(name);`, want: hazardDynamicRequire},
+		{name: "concatenated require", src: `require("a" + b);`, want: hazardDynamicRequire},
+		{name: "template require with substitution", src: "require(`pkg/${name}`);", want: hazardDynamicRequire},
+		{name: "non-literal dynamic import", src: `import(spec);`, want: hazardDynamicImport},
+		{name: "template dynamic import with substitution", src: "import(`./pages/${page}`);", want: hazardDynamicImport},
+		{name: "eval", src: `eval("code");`, want: hazardEval},
+		{name: "new Function", src: `new Function("return 1")();`, want: hazardNewFunction},
+		{name: "require.context", src: `require.context("./dir", true);`, want: hazardRequireContext},
+		{name: "require.ensure", src: `require.ensure([], function () {});`, want: hazardRequireContext},
+		{name: "import.meta.glob", src: `import.meta.glob("./mods/*.ts");`, want: hazardImportMetaGlob},
+		{name: "createRequire", src: `const req = createRequire(import.meta.url);`, want: hazardModuleCreateRequire},
+		{name: "computed require.resolve", src: `require.resolve(name);`, want: hazardUnsupportedLoader},
+		{name: "unterminated string", src: `import a from "unterminated`, want: hazardMalformedSource},
+		{name: "unterminated block comment", src: "/* never closed", want: hazardMalformedSource},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := hazardKindsOf(t, test.src)
+			if !got[test.want] {
+				t.Fatalf("expected hazard %v for %q, got %+v", test.want, test.src, got)
+			}
+		})
+	}
+}
+
+func TestExtractIgnoresNonGlobalEvalAndRequire(t *testing.T) {
+	t.Parallel()
+
+	// A member access is not the global loader/evaluator: flagging it would degrade coverage for every
+	// project that happens to have a method called eval or require.
+	sources := []string{`sandbox.eval("x");`, `vm.require("x");`, `a?.eval("x");`}
+	for _, src := range sources {
+		src := src
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			got := hazardKindsOf(t, src)
+			if got[hazardEval] || got[hazardDynamicRequire] {
+				t.Fatalf("member access must not raise a global loader hazard for %q: %+v", src, got)
+			}
+		})
+	}
+}
+
+func TestExtractLexerHostileSources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		src           string
+		wantSpecifier string
+		wantCount     int
+	}{
+		{
+			name:          "import inside line comment is ignored",
+			src:           "// import evil from \"attacker\";\nimport ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "import inside block comment is ignored",
+			src:           "/* import evil from \"attacker\"; */ import ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "import inside string literal is ignored",
+			src:           "const s = \"import evil from 'attacker'\";\nimport ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "import inside template literal is ignored",
+			src:           "const s = `import evil from \"attacker\"`;\nimport ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "regex containing quotes does not break lexing",
+			src:           "const re = /[\"']import.*from/g;\nimport ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "regex containing a slash in a character class",
+			src:           "const re = /[/]/;\nimport ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "division is not a regex",
+			src:           "const ratio = a / b / c;\nimport ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "escaped quote inside string",
+			src:           "const s = \"he said \\\"import\\\"\";\nimport ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "nested template substitution with braces",
+			src:           "const s = `${ {a: `${b}`} }`;\nimport ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "shebang line",
+			src:           "#!/usr/bin/env node\nimport ok from \"real\";",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+		{
+			name:          "jsx does not confuse the lexer",
+			src:           "import ok from \"real\";\nconst el = <div a=\"b\">{x < y ? 1 : 2}</div>;",
+			wantSpecifier: "real",
+			wantCount:     1,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := specifiersOf(t, test.src)
+			if len(got) != test.wantCount {
+				t.Fatalf("extracted %d imports, want %d: %+v (src %q)", len(got), test.wantCount, got, test.src)
+			}
+			if test.wantCount > 0 && got[0].specifier != test.wantSpecifier {
+				t.Fatalf("specifier = %q, want %q", got[0].specifier, test.wantSpecifier)
+			}
+		})
+	}
+}
+
+func TestExtractComputedSpecifierProducesNoEdge(t *testing.T) {
+	t.Parallel()
+
+	// A concatenated or interpolated specifier must produce NO edge. Recording the first literal
+	// fragment ("pkg/") as the module would be a silently wrong dependency edge, and the runtime target
+	// is unobservable — so the only honest output is a hazard and no edge.
+	sources := []string{
+		`require("pkg/" + name);`,
+		`import("pkg/" + name);`,
+		"require(`pkg/${name}`);",
+		"import(`./pages/${page}.js`);",
+		`import mod = require("pkg/" + name);`,
+	}
+	for _, src := range sources {
+		src := src
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			result := extractAll(t, src)
+			if len(result.imports) != 0 {
+				t.Fatalf("computed specifier must yield no edge, got %+v", result.imports)
+			}
+			if len(result.hazards) == 0 {
+				t.Fatalf("computed specifier must yield a hazard so coverage degrades")
+			}
+		})
+	}
+}
+
+func TestExtractImportAttributesKeepLiteralSpecifier(t *testing.T) {
+	t.Parallel()
+
+	// ESM import attributes add a second argument; the specifier is still a literal.
+	got := specifiersOf(t, `await import("data.json", { with: { type: "json" } });`)
+	if len(got) != 1 || got[0].specifier != "data.json" {
+		t.Fatalf("expected the literal specifier to survive import attributes, got %+v", got)
+	}
+}
+
+func TestExtractDeterministicAcrossRuns(t *testing.T) {
+	t.Parallel()
+
+	src := `
+import a from "one";
+import { b } from "two";
+const c = require("three");
+await import("four");
+export * from "five";
+require(dynamic);
+`
+	first := extractAll(t, src)
+	second := extractAll(t, src)
+	if len(first.imports) != len(second.imports) || len(first.hazards) != len(second.hazards) {
+		t.Fatalf("extraction is not deterministic: %d/%d vs %d/%d imports/hazards",
+			len(first.imports), len(first.hazards), len(second.imports), len(second.hazards))
+	}
+	for i := range first.imports {
+		if first.imports[i].specifier != second.imports[i].specifier || first.imports[i].kind != second.imports[i].kind {
+			t.Fatalf("import[%d] differs between runs", i)
+		}
+	}
+}

--- a/internal/infrastructure/tools/jsimports/hazard_test.go
+++ b/internal/infrastructure/tools/jsimports/hazard_test.go
@@ -1,0 +1,531 @@
+package jsimports
+
+import (
+	"strings"
+	"testing"
+)
+
+// The tests in this file are the anti-false-negative gate. Each case is a construct that really loads a
+// module (or really can) but that this scanner does not extract a specifier from. Every one MUST produce a
+// hazard, because a silent miss becomes "no import edge", which a later analyzer is allowed to read as
+// proof the dependency is unused — suppressing a real vulnerability.
+
+func TestIndirectRequireIsNeverSilent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "aliased require", src: `const r = require; r("lodash");`},
+		{name: "sequence-expression indirection", src: `(0, require)("lodash");`},
+		{name: "require passed as a value", src: `register(require);`},
+		{name: "require in a typeof guard", src: `if (typeof require !== "undefined") {}`},
+		{name: "module receiver", src: `module.require("lodash");`},
+		{name: "require.main receiver", src: `require.main.require("lodash");`},
+		{name: "require.cache access", src: `delete require.cache[key];`},
+		{name: "unknown require property", src: `require.somethingElse("lodash");`},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := extractAll(t, test.src)
+			if len(result.hazards) == 0 {
+				t.Fatalf("indirect require must degrade coverage, got no hazard for %q", test.src)
+			}
+		})
+	}
+}
+
+func TestOptionalCallRequireStillYieldsAnEdge(t *testing.T) {
+	t.Parallel()
+
+	// `require?.("pkg")` loads the module, so it is a real edge rather than merely a hazard.
+	got := specifiersOf(t, `require?.("lodash");`)
+	if len(got) != 1 || got[0].specifier != "lodash" {
+		t.Fatalf("optional-call require must produce an edge, got %+v", got)
+	}
+}
+
+func TestEscapedIdentifierIsNeverSilent(t *testing.T) {
+	t.Parallel()
+
+	// A unicode-escaped identifier is valid JavaScript, so `require(...)` is a real require the
+	// keyword matcher cannot see.
+	for _, src := range []string{`\u0072equire("lodash");`, `\u0065val(payload);`} {
+		src := src
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			result := extractAll(t, src)
+			if len(result.hazards) == 0 {
+				t.Fatalf("escaped identifier must degrade coverage: %q", src)
+			}
+		})
+	}
+}
+
+func TestGlobalEvaluatorShapesAreNeverSilent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "aliased eval", src: `const e = eval; e(payload);`},
+		{name: "sequence eval", src: `(0, eval)(payload);`},
+		{name: "globalThis eval", src: `globalThis.eval(payload);`},
+		{name: "window eval", src: `window.eval(payload);`},
+		{name: "Function without new", src: `Function('return require("lodash")')();`},
+		{name: "aliased Function", src: `const F = Function; F(src)();`},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := extractAll(t, test.src)
+			if len(result.hazards) == 0 {
+				t.Fatalf("a global evaluator reference must degrade coverage: %q", test.src)
+			}
+		})
+	}
+}
+
+func TestUnrelatedMethodsNamedLikeLoadersStaySilent(t *testing.T) {
+	t.Parallel()
+
+	// The converse of the tests above: a method that merely shares a loader's NAME is not a loader, and
+	// flagging it would degrade coverage for every project that has one.
+	for _, src := range []string{`sandbox.eval("x");`, `vm.require("x");`, `db.define("users", {});`} {
+		src := src
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			if result := extractAll(t, src); len(result.hazards) != 0 {
+				t.Fatalf("an unrelated method must not raise a hazard: %q → %+v", src, result.hazards)
+			}
+		})
+	}
+}
+
+func TestIndirectLoaderFamiliesAreNeverSilent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "amd define", src: `define(["lodash"], function (l) {});`},
+		{name: "requirejs", src: `requirejs(["lodash"], cb);`},
+		{name: "worker importScripts", src: `importScripts("./worker-dep.js");`},
+		{name: "webpack escape hatch", src: `__non_webpack_require__("lodash");`},
+		{name: "webpack runtime", src: `__webpack_require__("lodash");`},
+		{name: "systemjs", src: `System.import("lodash");`},
+		{name: "jest requireActual", src: `jest.requireActual("lodash");`},
+		{name: "worker constructor", src: `new Worker(new URL("./worker.js", import.meta.url));`},
+		{name: "native addon", src: `process.dlopen(module, "./addon.node");`},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := extractAll(t, test.src)
+			if len(result.hazards) == 0 {
+				t.Fatalf("an indirect loader must degrade coverage: %q", test.src)
+			}
+		})
+	}
+}
+
+func TestUndecodedEscapeSpecifierYieldsNoEdge(t *testing.T) {
+	t.Parallel()
+
+	// A specifier containing an escape this lexer does not decode must NOT become an edge: decoding
+	// "\154odash" as "l154odash" would name a package that does not exist while the real dependency
+	// (lodash) gets no edge at all — a silently wrong graph.
+	result := extractAll(t, `require("\154odash");`)
+	if len(result.imports) != 0 {
+		t.Fatalf("an undecoded-escape specifier must not become an edge, got %+v", result.imports)
+	}
+	if len(result.hazards) == 0 {
+		t.Fatal("an undecoded-escape specifier must degrade coverage")
+	}
+}
+
+func TestJSXTextDoesNotSwallowLoaders(t *testing.T) {
+	t.Parallel()
+
+	// The apostrophe in "Bob's" would open a string literal that closes at the apostrophe in "that's",
+	// swallowing the expression container between them — including its require call. With JSX element
+	// handling the text is skipped as text, so the container is still lexed as code.
+	src := `export const A = () => <p>Bob's {require("lodash")} — that's it</p>;`
+
+	result := extractJSX(t, src)
+	found := false
+	for _, imp := range result.imports {
+		if imp.specifier == "lodash" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("jsx prose must not swallow a loader call, got imports %+v hazards %+v", result.imports, result.hazards)
+	}
+}
+
+func TestJSXProseProducesNoFalseCoverage(t *testing.T) {
+	t.Parallel()
+
+	// Valid JSX whose text contains apostrophes, quotes and a closing tag on its own line must be
+	// completely clean: a single apostrophe in UI copy must not make the whole project incomplete.
+	src := strings.Join([]string{
+		`import React from "react";`,
+		`export function Panel() {`,
+		`  return (`,
+		`    <div className="panel">`,
+		`      <p>This engagement's scope can't be edited — it "belongs" to the client.</p>`,
+		`      <span>{count} items</span>`,
+		`    </div>`,
+		`  );`,
+		`}`,
+	}, "\n")
+
+	result := extractJSX(t, src)
+	if len(result.hazards) != 0 {
+		t.Fatalf("valid jsx prose must produce no hazards, got %+v", result.hazards)
+	}
+	if len(result.imports) != 1 || result.imports[0].specifier != "react" {
+		t.Fatalf("expected the react import to survive, got %+v", result.imports)
+	}
+}
+
+func TestJSXClosingTagDoesNotStartARegex(t *testing.T) {
+	t.Parallel()
+
+	// The '/' of a closing tag must not be lexed as a regex opener: the old behaviour consumed to the
+	// newline and then discarded the remainder of the file, losing every later import.
+	src := strings.Join([]string{
+		`export function View() {`,
+		`  return (`,
+		`    <div>`,
+		`    </div>`,
+		`  );`,
+		`}`,
+		`const late = require("late-pkg");`,
+		`export const lazy = () => import("heavy-chart");`,
+	}, "\n")
+
+	for _, jsxAware := range []bool{true, false} {
+		jsxAware := jsxAware
+		t.Run(map[bool]string{true: "jsx dialect", false: "non-jsx dialect"}[jsxAware], func(t *testing.T) {
+			t.Parallel()
+			result := newExtractor([]byte(src), jsxAware).run()
+			specs := map[string]bool{}
+			for _, imp := range result.imports {
+				specs[imp.specifier] = true
+			}
+			if !specs["late-pkg"] || !specs["heavy-chart"] {
+				t.Fatalf("imports after a closing tag must survive, got %+v (hazards %+v)", result.imports, result.hazards)
+			}
+		})
+	}
+}
+
+func TestDivisionAfterComparisonIsNotARegex(t *testing.T) {
+	t.Parallel()
+
+	// `a > b / c` and `a < b / c` must lex as division; treating '/' as a regex opener would consume to
+	// the newline and swallow the following statement.
+	src := "const ok = a > b / c;\nconst also = a < b / c;\nconst late = require(\"late-pkg\");"
+	result := extractAll(t, src)
+	if len(result.imports) != 1 || result.imports[0].specifier != "late-pkg" {
+		t.Fatalf("division must not swallow the following import, got %+v", result.imports)
+	}
+	if len(result.hazards) != 0 {
+		t.Fatalf("division must not raise a hazard, got %+v", result.hazards)
+	}
+}
+
+func TestDeeplyNestedTemplatesAreBounded(t *testing.T) {
+	t.Parallel()
+
+	// A hostile file of nested template substitutions must not exhaust the memory of this in-process
+	// scanner; it must terminate and degrade coverage instead.
+	// Genuine nesting: each `${ opens a substitution that contains the next template.
+	depth := maxFrameDepth + 20
+	src := "const x = " + strings.Repeat("`${", depth) + "a" + strings.Repeat("}`", depth) + ";"
+	result := extractAll(t, src)
+	if len(result.hazards) == 0 {
+		t.Fatal("template nesting past the depth bound must degrade coverage")
+	}
+}
+
+func TestObjectKeyNamedImportIsNotADeclaration(t *testing.T) {
+	t.Parallel()
+
+	if result := extractAll(t, `const opts = { import: 1, export: 2 };`); len(result.hazards) != 0 {
+		t.Fatalf("an object key named import must not raise a hazard, got %+v", result.hazards)
+	}
+}
+
+// --- second-round anti-false-negative gate: regions the lexer must LEX rather than skip ---
+
+func TestTemplateSubstitutionIsLexedAsCode(t *testing.T) {
+	t.Parallel()
+
+	// A loader inside `${ ... }` must be seen. Consuming the substitution byte-wise would hide
+	// `require("./package.json").version` in a version banner — a real-world pattern.
+	t.Run("require inside a substitution yields an edge", func(t *testing.T) {
+		t.Parallel()
+		result := extractAll(t, "const banner = `myapp v${require(\"lodash\").version}`;")
+		found := false
+		for _, imp := range result.imports {
+			if imp.specifier == "lodash" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("a require inside a template substitution must yield an edge, got %+v (hazards %+v)", result.imports, result.hazards)
+		}
+	})
+
+	t.Run("dynamic import inside a substitution yields an edge", func(t *testing.T) {
+		t.Parallel()
+		result := extractAll(t, "const html = `${await import(\"./tpl.js\")}`;")
+		if len(result.imports) == 0 {
+			t.Fatalf("an import inside a template substitution must be observed, got hazards %+v", result.hazards)
+		}
+	})
+
+	t.Run("eval inside a substitution degrades coverage", func(t *testing.T) {
+		t.Parallel()
+		if result := extractAll(t, "const boom = `${eval(payload)}`;"); len(result.hazards) == 0 {
+			t.Fatal("an eval inside a template substitution must degrade coverage")
+		}
+	})
+
+	t.Run("substitution-free template stays a literal specifier", func(t *testing.T) {
+		t.Parallel()
+		got := specifiersOf(t, "await import(`chart.js`);")
+		if len(got) != 1 || got[0].specifier != "chart.js" {
+			t.Fatalf("a substitution-free template must remain a literal specifier, got %+v", got)
+		}
+	})
+
+	t.Run("template escapes never become a specifier", func(t *testing.T) {
+		t.Parallel()
+		// Template escapes are not decoded, so the value is not the runtime specifier.
+		result := extractAll(t, "require(`\\154odash`);")
+		for _, imp := range result.imports {
+			if imp.specifier == "154odash" {
+				t.Fatalf("an undecoded template escape must not become an edge: %+v", result.imports)
+			}
+		}
+		if len(result.hazards) == 0 {
+			t.Fatal("an undecoded template escape must degrade coverage")
+		}
+	})
+}
+
+func TestJSXAttributeExpressionIsLexedAsCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		src       string
+		wantEdge  string
+		wantHazrd bool
+	}{
+		{name: "lazy route import keeps its edge", src: `<Route element={lazy(() => import("./pages/Admin"))} />`, wantEdge: "./pages/Admin"},
+		{name: "spread require keeps its edge", src: `<Foo {...require("./defaults")} />`, wantEdge: "./defaults"},
+		{name: "eval in an attribute degrades coverage", src: `<Foo onClick={() => eval(payload)} />`, wantHazrd: true},
+		{name: "webpack require in an attribute degrades coverage", src: `<Foo x={__webpack_require__(4)} />`, wantHazrd: true},
+		{name: "requireActual in an attribute degrades coverage", src: `<Foo x={jest.requireActual("lodash")} />`, wantHazrd: true},
+		{name: "createRequire in an attribute degrades coverage", src: `<Foo x={createRequire(import.meta.url)} />`, wantHazrd: true},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := extractJSX(t, test.src)
+			if test.wantEdge != "" {
+				found := false
+				for _, imp := range result.imports {
+					if imp.specifier == test.wantEdge {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("expected edge %q from an attribute expression, got %+v (hazards %+v)", test.wantEdge, result.imports, result.hazards)
+				}
+			}
+			if test.wantHazrd && len(result.hazards) == 0 {
+				t.Fatalf("expected a hazard from %q", test.src)
+			}
+		})
+	}
+}
+
+func TestJSXInPlainJavaScriptIsHandled(t *testing.T) {
+	t.Parallel()
+
+	// JSX in a .js file is the majority of the React ecosystem. Scanning it non-JSX re-opens the
+	// apostrophe-pair silent miss, so every dialect except plain TypeScript is JSX-aware.
+	src := `export const A = () => <p>Bob's {require("lodash")} — that's it</p>;`
+	result := newExtractor([]byte(src), true).run()
+	found := false
+	for _, imp := range result.imports {
+		if imp.specifier == "lodash" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("jsx in plain javascript must not swallow a loader, got %+v (hazards %+v)", result.imports, result.hazards)
+	}
+}
+
+func TestLoaderAliasingIsNeverSilent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "webpack require aliased", src: `const wr = __webpack_require__; wr(4);`},
+		{name: "importScripts aliased", src: `const is = importScripts; is("./dep.js");`},
+		{name: "createRequire aliased", src: `const cr = createRequire; const r = cr(import.meta.url);`},
+		{name: "requirejs aliased", src: `const rj = requirejs; rj(["lodash"], cb);`},
+		{name: "require.context aliased", src: `const ctx = require.context;`},
+		{name: "require.ensure aliased", src: `const ens = require.ensure;`},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if result := extractAll(t, test.src); len(result.hazards) == 0 {
+				t.Fatalf("aliasing a loader must degrade coverage: %q", test.src)
+			}
+		})
+	}
+}
+
+func TestComputedLoaderAccessIsNeverSilent(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range []string{
+		`module["require"]("lodash");`,
+		`globalThis["eval"](payload);`,
+		`process["dlopen"](module, path);`,
+	} {
+		src := src
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			if result := extractAll(t, src); len(result.hazards) == 0 {
+				t.Fatalf("a computed loader access must degrade coverage: %q", src)
+			}
+		})
+	}
+}
+
+func TestCarriageReturnLineEndings(t *testing.T) {
+	t.Parallel()
+
+	// CR is an ECMAScript line terminator. Treating only LF as one made a CR-only file's first line
+	// comment run to EOF, silently discarding the whole file.
+	t.Run("cr terminates a line comment", func(t *testing.T) {
+		t.Parallel()
+		src := "// header\rconst lodash = require(\"lodash\");\rmodule.exports = lodash;"
+		got := specifiersOf(t, src)
+		if len(got) != 1 || got[0].specifier != "lodash" {
+			t.Fatalf("a CR-terminated comment must not swallow the file, got %+v", got)
+		}
+	})
+
+	t.Run("crlf is one line break", func(t *testing.T) {
+		t.Parallel()
+		src := "import a from \"one\";\r\nimport b from \"two\";"
+		got := specifiersOf(t, src)
+		if len(got) != 2 {
+			t.Fatalf("expected both imports, got %+v", got)
+		}
+		if got[1].line != 2 {
+			t.Fatalf("CRLF must count as one line break; second import reported at line %d", got[1].line)
+		}
+	})
+
+	t.Run("unicode line separator terminates a comment", func(t *testing.T) {
+		t.Parallel()
+		src := "// note const x = require(\"lodash\");"
+		got := specifiersOf(t, src)
+		if len(got) != 1 {
+			t.Fatalf("U+2028 must terminate a line comment, got %+v", got)
+		}
+	})
+}
+
+func TestTypeScriptGenericArrowIsNotJSX(t *testing.T) {
+	t.Parallel()
+
+	// Reading `<T,>(x) => x` as a JSX element would consume the function body as element text.
+	tests := []string{
+		"const identity = <T,>(x: T): T => x;\nconst late = require(\"late-pkg\");",
+		"const id2 = <T extends unknown>(x: T) => x;\nconst late = require(\"late-pkg\");",
+		"const id3 = <T>(x: T) => x;\nconst late = require(\"late-pkg\");",
+	}
+	for _, src := range tests {
+		src := src
+		t.Run(src[:24], func(t *testing.T) {
+			t.Parallel()
+			result := newExtractor([]byte(src), true).run()
+			found := false
+			for _, imp := range result.imports {
+				if imp.specifier == "late-pkg" {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("a generic arrow must not be read as JSX, got %+v (hazards %+v)", result.imports, result.hazards)
+			}
+		})
+	}
+}
+
+func TestHTMLLikeCommentsProduceNoFalseEdge(t *testing.T) {
+	t.Parallel()
+
+	// Annex-B HTML-like comments are line comments to a real engine, so lexing them as code would
+	// invent an edge from commented-out source.
+	src := "<!-- require(\"commented-out\")\nconst real = require(\"real-pkg\");\n--> require(\"also-commented\")"
+	result := extractAll(t, src)
+	for _, imp := range result.imports {
+		if imp.specifier == "commented-out" || imp.specifier == "also-commented" {
+			t.Fatalf("a commented-out loader must not become an edge: %+v", result.imports)
+		}
+	}
+}
+
+func TestJSXProseContainingLoaderWordsProducesNoFalseCoverage(t *testing.T) {
+	t.Parallel()
+
+	// English words that merely CONTAIN a loader name must not degrade coverage: a bare "require"
+	// signature matches "required", which would mark every project with that word in its UI as
+	// permanently incomplete and make a negative reachability proof impossible.
+	sources := []string{
+		`<span>Approvals required ({approvals.length})</span>`,
+		`<p>This import is a requirement of the export process.</p>`,
+		`<td>Evaluation of the function requires review</td>`,
+		`<p>Data imported from "the archive" was defined earlier.</p>`,
+	}
+	for _, src := range sources {
+		src := src
+		t.Run(src[:24], func(t *testing.T) {
+			t.Parallel()
+			if result := extractJSX(t, src); len(result.hazards) != 0 {
+				t.Fatalf("prose containing a loader word must not raise a hazard: %q → %+v", src, result.hazards)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/tools/jsimports/lexer.go
+++ b/internal/infrastructure/tools/jsimports/lexer.go
@@ -1,0 +1,915 @@
+package jsimports
+
+import "strings"
+
+// tokenKind identifies the lexical class of a scanned token. The lexer is deliberately coarse: it
+// classifies only what import extraction needs (identifiers/keywords, string literals, punctuation) and
+// skips only what cannot contain code (comments, JSX element text).
+type tokenKind uint8
+
+const (
+	tokenEOF tokenKind = iota
+	// tokenIdent covers identifiers, keywords and numeric literals; import extraction only ever
+	// compares them against fixed keywords, so no further split is needed.
+	tokenIdent
+	// tokenString is a single- or double-quoted literal with its value already unescaped.
+	tokenString
+	// tokenTemplate is a backtick template literal. A substitution-free template carries its literal
+	// value; one with `${` carries hasSubstitution and no value, and its substitution BODIES are
+	// tokenized as ordinary code so a loader inside them is still seen.
+	tokenTemplate
+	// tokenPunct is any operator or punctuator, held verbatim (".", "(", "{", "=>", "?.", ...).
+	tokenPunct
+)
+
+// token is one lexical unit with its 1-based source position.
+type token struct {
+	kind tokenKind
+	// text is the identifier/punctuator verbatim, or the DECODED value of a string/template literal.
+	text string
+	// hasSubstitution marks a template literal containing `${`: its runtime value is not static, so it
+	// must never be read as a literal module specifier.
+	hasSubstitution bool
+	// undecodedEscape marks a literal that contained an escape this lexer does not decode. Its value is
+	// therefore not the runtime specifier, so it must not become a resolved module edge.
+	undecodedEscape bool
+	line            int
+	column          int
+}
+
+// hazard is a lexically observed construct that can load a module invisibly, or a condition under which
+// a load could have been missed. Each one degrades coverage: a later analyzer must not read "no edge" as
+// proof of absence when any hazard is present.
+type hazard struct {
+	kind hazardKind
+	line int
+	// detail is a short, non-source-quoting label. Scanner output is sealed into judgments, so it must
+	// never carry target source text (golden rule 3).
+	detail string
+}
+
+type hazardKind uint8
+
+const (
+	hazardDynamicRequire hazardKind = iota
+	hazardDynamicImport
+	hazardEval
+	hazardNewFunction
+	hazardRequireContext
+	hazardImportMetaGlob
+	hazardModuleCreateRequire
+	hazardUnsupportedLoader
+	hazardMalformedSource
+)
+
+// maxFrameDepth bounds the lexer's context stack (nested JSX elements, expression containers and
+// template substitutions). A hostile file of deeply nested constructs must terminate, and the stack is a
+// slice rather than recursion so exceeding the bound fails loudly instead of exhausting memory.
+const maxFrameDepth = 256
+
+// loaderSignatures betray module-loading code. They are a BACKSTOP only: they are checked against JSX
+// element text, which is the single remaining region this lexer skips without tokenizing. Everything that
+// can contain code — template substitutions, JSX expression containers, JSX attribute expressions — is
+// lexed as code instead, so the extractor's full loader vocabulary applies there.
+//
+// Each signature is LOADER-SHAPED — it includes the punctuation that follows the name — so ordinary
+// prose does not match. A bare "require" would match the English word "required" and permanently mark
+// every project with that word in its UI copy as incomplete, which would make a negative reachability
+// proof impossible for the very projects the feature exists to serve.
+var loaderSignatures = []string{
+	"require(", "require (", "require.", "require[",
+	"import(", "import (", "import \"", "import '", "import{", "import {",
+	"importScripts(", "define(", "eval(", "Function(",
+	"__webpack_require__", "__non_webpack_require__", "createRequire(",
+	"export {", "export*", "export *",
+}
+
+// frameKind is one entry on the lexer's context stack.
+type frameKind uint8
+
+const (
+	// frameJSXChildren is JSX element content: text is skipped so prose cannot open a string literal.
+	frameJSXChildren frameKind = iota
+	// frameJSXTag is the inside of an opening tag, where attribute values are strings or expressions.
+	frameJSXTag
+	// frameExpr is a brace-delimited expression region (a JSX container or a template substitution)
+	// whose body is lexed as ordinary code.
+	frameExpr
+	// frameTemplate is a template literal with substitutions, resumed after each substitution closes.
+	frameTemplate
+)
+
+type frame struct {
+	kind frameKind
+	// braceDepth counts nested braces inside an expression region.
+	braceDepth int
+}
+
+// lexer walks a source buffer producing tokens. It never executes or evaluates anything; it only
+// classifies bytes.
+//
+// Three lexical hazards get explicit care, because misreading any of them could swallow a real import and
+// produce a SILENT MISS — the one failure this package must never have:
+//
+//   - regex versus division: decided from the previous significant token, and a candidate regex that
+//     turns out to be division is REWOUND rather than treated as an error;
+//   - JSX element text: prose containing an apostrophe ("Bob's") must not open a string literal, because
+//     the matching apostrophe later in the sentence would swallow everything between them;
+//   - regions that can contain code (template substitutions, JSX expression and attribute containers)
+//     are LEXED, never skipped, so the extractor sees every loader inside them.
+type lexer struct {
+	src []byte
+	pos int
+	// line/col track the 1-based position of src[pos].
+	line int
+	col  int
+	// prevSignificant is the last token emitted, used for the regex-versus-JSX-versus-division decision.
+	prevSignificant token
+	hasPrev         bool
+	// jsxAware enables JSX element handling. It is on for every dialect except plain TypeScript, where
+	// `<Foo>x` is a type assertion rather than an element.
+	jsxAware bool
+	// frames is the open context stack.
+	frames []frame
+	// hazards collects lexical coverage limitations discovered while scanning.
+	hazards []hazard
+	// malformed records an unterminated construct: the rest of the file cannot be trusted.
+	malformed bool
+}
+
+func newLexer(src []byte, jsxAware bool) *lexer {
+	return &lexer{src: src, line: 1, col: 1, jsxAware: jsxAware}
+}
+
+func (l *lexer) atEnd() bool { return l.pos >= len(l.src) }
+
+// cursor is a saved lexer position, used to rewind a speculative scan.
+type cursor struct {
+	pos  int
+	line int
+	col  int
+}
+
+func (l *lexer) mark() cursor   { return cursor{pos: l.pos, line: l.line, col: l.col} }
+func (l *lexer) reset(c cursor) { l.pos, l.line, l.col = c.pos, c.line, c.col }
+
+func (l *lexer) addHazard(k hazardKind, line int, detail string) {
+	l.hazards = append(l.hazards, hazard{kind: k, line: line, detail: detail})
+}
+
+// pushFrame adds a context frame, reporting a hazard and refusing once the depth bound is reached.
+func (l *lexer) pushFrame(f frame) bool {
+	if len(l.frames) >= maxFrameDepth {
+		l.markMalformed(l.line, "nesting depth bound exceeded")
+		return false
+	}
+	l.frames = append(l.frames, f)
+	return true
+}
+
+func (l *lexer) popFrame() {
+	if n := len(l.frames); n > 0 {
+		l.frames = l.frames[:n-1]
+	}
+}
+
+func (l *lexer) top() *frame {
+	if n := len(l.frames); n > 0 {
+		return &l.frames[n-1]
+	}
+	return nil
+}
+
+// advance consumes one byte, maintaining the line/column counters. CR, LF and CRLF each count as one
+// line break so every reported position stays accurate.
+func (l *lexer) advance() byte {
+	b := l.src[l.pos]
+	l.pos++
+	switch {
+	case b == '\r':
+		if l.pos < len(l.src) && l.src[l.pos] == '\n' {
+			l.pos++
+		}
+		l.line++
+		l.col = 1
+	case b == '\n':
+		l.line++
+		l.col = 1
+	default:
+		l.col++
+	}
+	return b
+}
+
+// isUnicodeLineSeparator reports whether the cursor sits on U+2028 or U+2029, which are ECMAScript line
+// terminators encoded as three UTF-8 bytes.
+func (l *lexer) isUnicodeLineSeparator() bool {
+	return l.peek() == 0xE2 && l.peekAt(1) == 0x80 && (l.peekAt(2) == 0xA8 || l.peekAt(2) == 0xA9)
+}
+
+// atLineTerminator reports whether the cursor sits on any ECMAScript line terminator: LF, CR, U+2028 or
+// U+2029. Testing only for LF would let a CR-only file hide the whole remainder of a line comment.
+func (l *lexer) atLineTerminator() bool {
+	if l.atEnd() {
+		return false
+	}
+	b := l.peek()
+	return b == '\n' || b == '\r' || l.isUnicodeLineSeparator()
+}
+
+// advanceLineTerminator consumes one line terminator of any encoding.
+func (l *lexer) advanceLineTerminator() {
+	if l.isUnicodeLineSeparator() {
+		l.pos += 3
+		l.line++
+		l.col = 1
+		return
+	}
+	l.advance()
+}
+
+// peekAt returns the byte n positions ahead of the cursor, or 0 past the end.
+func (l *lexer) peekAt(n int) byte {
+	if l.pos+n >= len(l.src) {
+		return 0
+	}
+	return l.src[l.pos+n]
+}
+
+func (l *lexer) peek() byte { return l.peekAt(0) }
+
+// next returns the next significant token.
+func (l *lexer) next() token {
+	for {
+		// A context frame may own the cursor: JSX children skip text, a JSX tag scans attributes, and a
+		// template resumes after each substitution.
+		if top := l.top(); top != nil {
+			switch top.kind {
+			case frameJSXChildren:
+				if l.atEnd() {
+					l.addHazard(hazardUnsupportedLoader, l.line, "unterminated jsx element")
+					l.frames = nil
+					return token{kind: tokenEOF, line: l.line, column: l.col}
+				}
+				if t, emitted := l.stepJSXChildren(); emitted {
+					return t
+				}
+				continue
+			case frameJSXTag:
+				if l.atEnd() {
+					l.addHazard(hazardUnsupportedLoader, l.line, "unterminated jsx tag")
+					l.frames = nil
+					return token{kind: tokenEOF, line: l.line, column: l.col}
+				}
+				if t, emitted := l.stepJSXTag(); emitted {
+					return t
+				}
+				continue
+			case frameTemplate:
+				if l.atEnd() {
+					l.markMalformed(l.line, "unterminated template literal")
+					return token{kind: tokenEOF, line: l.line, column: l.col}
+				}
+				if t, emitted := l.stepTemplate(); emitted {
+					return t
+				}
+				continue
+			}
+		}
+
+		l.skipTrivia()
+		if l.atEnd() {
+			return token{kind: tokenEOF, line: l.line, column: l.col}
+		}
+
+		startLine, startCol := l.line, l.col
+		b := l.peek()
+
+		switch {
+		case b == '"' || b == '\'':
+			value, escaped, outcome := l.readQuoted(b)
+			switch outcome {
+			case quotedNotAString:
+				// The quote did not open a string (an apostrophe in prose). readQuoted rewound; emit the
+				// quote as punctuation and carry on rather than discarding the rest of the file.
+				l.advance()
+				return l.emit(token{kind: tokenPunct, text: string(b), line: startLine, column: startCol})
+			case quotedTruncated:
+				l.markMalformed(startLine, "unterminated string literal")
+				return token{kind: tokenEOF, line: startLine, column: startCol}
+			}
+			return l.emit(token{kind: tokenString, text: value, undecodedEscape: escaped, line: startLine, column: startCol})
+		case b == '`':
+			return l.startTemplate(startLine, startCol)
+		case b == '\\':
+			// An identifier written with a unicode escape (require) is valid JavaScript but is not
+			// recognisable by the keyword matcher, so a loader could hide behind it.
+			l.advance()
+			l.addHazard(hazardUnsupportedLoader, startLine, "escaped identifier")
+			continue
+		case isIdentStart(b):
+			return l.emit(token{kind: tokenIdent, text: l.readIdent(), line: startLine, column: startCol})
+		case b >= '0' && b <= '9':
+			return l.emit(token{kind: tokenIdent, text: l.readNumberLike(), line: startLine, column: startCol})
+		case b == '<' && l.jsxAware && l.jsxElementAhead():
+			l.advance() // '<'
+			if !l.pushFrame(frame{kind: frameJSXTag}) {
+				return token{kind: tokenEOF, line: startLine, column: startCol}
+			}
+			continue
+		default:
+			t := l.emit(token{kind: tokenPunct, text: l.readPunct(), line: startLine, column: startCol})
+			l.trackExprBraces(t)
+			return t
+		}
+	}
+}
+
+func (l *lexer) emit(t token) token {
+	l.prevSignificant = t
+	l.hasPrev = true
+	return t
+}
+
+// emitValueLike sets the previous-token state to something that ends an expression, so a following '/'
+// lexes as division and a following '<' is not read as a new JSX element.
+func (l *lexer) emitValueLike() {
+	l.prevSignificant = token{kind: tokenPunct, text: ")", line: l.line, column: l.col}
+	l.hasPrev = true
+}
+
+// trackExprBraces maintains the brace depth of an open expression region so its closing brace is
+// recognised and the enclosing JSX or template context resumes after it.
+func (l *lexer) trackExprBraces(t token) {
+	top := l.top()
+	if top == nil || top.kind != frameExpr || t.kind != tokenPunct {
+		return
+	}
+	switch t.text {
+	case "{":
+		top.braceDepth++
+	case "}":
+		if top.braceDepth == 0 {
+			l.popFrame()
+			return
+		}
+		top.braceDepth--
+	}
+}
+
+// markMalformed records an unterminated construct and stops lexing: after it, every token would be
+// unreliable. It is reached only for constructs that legitimately span lines (templates, block comments)
+// or for a literal truncated at end of input — never for a quote that simply was not a string.
+func (l *lexer) markMalformed(line int, detail string) {
+	if !l.malformed {
+		l.malformed = true
+		l.addHazard(hazardMalformedSource, line, detail)
+	}
+	l.pos = len(l.src)
+	l.frames = nil
+}
+
+// skipTrivia consumes whitespace, comments and regex literals.
+func (l *lexer) skipTrivia() {
+	for !l.atEnd() {
+		b := l.peek()
+		switch {
+		case b == ' ' || b == '\t' || b == '\v' || b == '\f':
+			l.advance()
+		case l.atLineTerminator():
+			l.advanceLineTerminator()
+		case b == 0xEF && l.peekAt(1) == 0xBB && l.peekAt(2) == 0xBF:
+			// UTF-8 BOM.
+			l.pos += 3
+			l.col++
+		case b == '/' && l.peekAt(1) == '/':
+			for !l.atEnd() && !l.atLineTerminator() {
+				l.advance()
+			}
+		case b == '/' && l.peekAt(1) == '*':
+			startLine := l.line
+			l.advance()
+			l.advance()
+			closed := false
+			for !l.atEnd() {
+				if l.peek() == '*' && l.peekAt(1) == '/' {
+					l.advance()
+					l.advance()
+					closed = true
+					break
+				}
+				l.advance()
+			}
+			if !closed {
+				l.markMalformed(startLine, "unterminated block comment")
+				return
+			}
+		case b == '#' && l.pos == 0 && l.peekAt(1) == '!':
+			// Node shebang line.
+			for !l.atEnd() && !l.atLineTerminator() {
+				l.advance()
+			}
+		case b == '<' && l.peekAt(1) == '!' && l.peekAt(2) == '-' && l.peekAt(3) == '-':
+			// Annex-B HTML-like comment: a real engine treats it as a line comment, so lexing it as
+			// code could invent a false edge from commented-out source.
+			for !l.atEnd() && !l.atLineTerminator() {
+				l.advance()
+			}
+		case b == '-' && l.peekAt(1) == '-' && l.peekAt(2) == '>' && l.atLineStart():
+			for !l.atEnd() && !l.atLineTerminator() {
+				l.advance()
+			}
+		case b == '/' && l.regexAllowed():
+			if !l.skipRegex() {
+				// Not a regex after all; leave the '/' for the caller to lex as a punctuator.
+				return
+			}
+		default:
+			return
+		}
+	}
+}
+
+// atLineStart reports whether only whitespace precedes the cursor on its line, which is required for the
+// Annex-B closing HTML-like comment.
+func (l *lexer) atLineStart() bool {
+	for i := l.pos - 1; i >= 0; i-- {
+		switch l.src[i] {
+		case '\n', '\r':
+			return true
+		case ' ', '\t', '\v', '\f':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// regexAllowed reports whether a '/' at the cursor starts a regex literal rather than a division
+// operator, using the previous significant token. When in doubt it answers false (division), because a
+// speculative regex scan is rewound while a swallowed statement would be a silent miss.
+func (l *lexer) regexAllowed() bool {
+	if !l.hasPrev {
+		return true
+	}
+	prev := l.prevSignificant
+	switch prev.kind {
+	case tokenString, tokenTemplate:
+		return false
+	case tokenIdent:
+		// After a value-producing identifier '/' is division; after a keyword it starts a regex.
+		return regexPrecedingKeywords[prev.text]
+	case tokenPunct:
+		switch prev.text {
+		case ")", "]", "}", "++", "--", ">", "<":
+			// These end an expression, so '/' divides. ">" and "<" also cover a JSX closing tag in a
+			// file where the JSX scanner did not claim the element.
+			return false
+		default:
+			return true
+		}
+	}
+	return true
+}
+
+// regexPrecedingKeywords are keywords after which a '/' begins a regex literal.
+var regexPrecedingKeywords = map[string]bool{
+	"return": true, "typeof": true, "instanceof": true, "in": true, "of": true, "new": true,
+	"delete": true, "void": true, "throw": true, "case": true, "do": true, "else": true,
+	"yield": true, "await": true,
+}
+
+// skipRegex speculatively consumes a regex literal including its character classes and flags. A regex
+// literal cannot span a line, so hitting a line terminator (or the end of input) proves the '/' was
+// division: the cursor is REWOUND and false returned, leaving the '/' to be lexed as a punctuator.
+func (l *lexer) skipRegex() bool {
+	start := l.mark()
+	l.advance() // opening '/'
+	inClass := false
+	for !l.atEnd() {
+		switch {
+		case l.peek() == '\\':
+			l.advance()
+			if !l.atEnd() {
+				l.advance()
+			}
+		case l.atLineTerminator():
+			l.reset(start)
+			return false
+		case l.peek() == '[':
+			inClass = true
+			l.advance()
+		case l.peek() == ']':
+			inClass = false
+			l.advance()
+		case l.peek() == '/' && !inClass:
+			l.advance()
+			for !l.atEnd() && isIdentPart(l.peek()) {
+				l.advance()
+			}
+			return true
+		default:
+			l.advance()
+		}
+	}
+	l.reset(start)
+	return false
+}
+
+// quotedOutcome distinguishes the three ways a quote can end, because they mean different things for
+// coverage: a quote followed by a raw line terminator was never a string (an apostrophe in prose), while a
+// quote that runs to the end of the file is genuinely truncated source.
+type quotedOutcome uint8
+
+const (
+	quotedOK quotedOutcome = iota
+	quotedNotAString
+	quotedTruncated
+)
+
+// readQuoted consumes a quoted string literal and returns its decoded value plus whether it contained an
+// escape this lexer does not decode.
+//
+// Only the escapes that can appear in a module specifier are decoded. Anything else sets the
+// undecodedEscape flag so the value is never treated as a resolvable specifier: silently mis-decoding
+// "\154odash" into a wrong package name would be worse than reporting the specifier as unusable.
+func (l *lexer) readQuoted(quote byte) (string, bool, quotedOutcome) {
+	start := l.mark()
+	l.advance() // opening quote
+	var sb strings.Builder
+	escaped := false
+	for !l.atEnd() {
+		if l.atLineTerminator() {
+			l.reset(start)
+			return "", false, quotedNotAString
+		}
+		b := l.peek()
+		switch b {
+		case quote:
+			l.advance()
+			return sb.String(), escaped, quotedOK
+		case '\\':
+			l.advance()
+			if l.atEnd() {
+				l.reset(start)
+				return "", false, quotedTruncated
+			}
+			if l.atLineTerminator() {
+				// Line continuation contributes nothing to the value.
+				l.advanceLineTerminator()
+				continue
+			}
+			esc := l.advance()
+			switch esc {
+			case 'n':
+				sb.WriteByte('\n')
+			case 't':
+				sb.WriteByte('\t')
+			case 'r':
+				sb.WriteByte('\r')
+			case '\\', '\'', '"', '/', '`', '$':
+				sb.WriteByte(esc)
+			default:
+				// Unicode, hex and legacy octal escapes are not decoded.
+				escaped = true
+				sb.WriteByte(esc)
+			}
+		default:
+			sb.WriteByte(l.advance())
+		}
+	}
+	l.reset(start)
+	return "", false, quotedTruncated
+}
+
+// startTemplate begins a template literal at the cursor.
+//
+// A substitution-free template is emitted as a literal value, so `import(`pkg`)` still resolves. As soon
+// as a `${` is found the template is emitted as a NON-literal token and its substitution bodies are
+// tokenized as ordinary code, so a loader inside one is seen by the extractor rather than skipped.
+func (l *lexer) startTemplate(startLine, startCol int) token {
+	l.advance() // opening backtick
+	var sb strings.Builder
+	escaped := false
+	for !l.atEnd() {
+		b := l.peek()
+		switch {
+		case b == '`':
+			l.advance()
+			return l.emit(token{kind: tokenTemplate, text: sb.String(), undecodedEscape: escaped, line: startLine, column: startCol})
+		case b == '\\':
+			l.advance()
+			if l.atEnd() {
+				l.markMalformed(startLine, "unterminated template literal")
+				return token{kind: tokenEOF, line: startLine, column: startCol}
+			}
+			// Template escapes are not decoded, so the value must never be used as a specifier.
+			escaped = true
+			sb.WriteByte(l.advance())
+		case b == '$' && l.peekAt(1) == '{':
+			l.advance()
+			l.advance()
+			if !l.pushFrame(frame{kind: frameTemplate}) {
+				return token{kind: tokenEOF, line: startLine, column: startCol}
+			}
+			if !l.pushFrame(frame{kind: frameExpr}) {
+				return token{kind: tokenEOF, line: startLine, column: startCol}
+			}
+			return l.emit(token{kind: tokenTemplate, hasSubstitution: true, line: startLine, column: startCol})
+		default:
+			sb.WriteByte(l.advance())
+		}
+	}
+	l.markMalformed(startLine, "unterminated template literal")
+	return token{kind: tokenEOF, line: startLine, column: startCol}
+}
+
+// stepTemplate resumes a template literal after one of its substitutions closed.
+func (l *lexer) stepTemplate() (token, bool) {
+	for !l.atEnd() {
+		b := l.peek()
+		switch {
+		case b == '`':
+			l.advance()
+			l.popFrame()
+			l.emitValueLike()
+			return token{}, false
+		case b == '\\':
+			l.advance()
+			if !l.atEnd() {
+				l.advance()
+			}
+		case b == '$' && l.peekAt(1) == '{':
+			l.advance()
+			l.advance()
+			if !l.pushFrame(frame{kind: frameExpr}) {
+				return token{kind: tokenEOF}, true
+			}
+			return token{}, false
+		default:
+			l.advance()
+		}
+	}
+	l.markMalformed(l.line, "unterminated template literal")
+	return token{kind: tokenEOF}, true
+}
+
+// jsxElementAhead reports whether the '<' at the cursor opens a JSX element rather than a comparison, a
+// TypeScript type-argument list, or a generic arrow function. It requires an expression position and a
+// name/fragment/closing character immediately after the '<' (no space), which excludes `a < b`,
+// `Map<string>` and `foo<T>()`.
+func (l *lexer) jsxElementAhead() bool {
+	if !l.expressionPosition() {
+		return false
+	}
+	next := l.peekAt(1)
+	if !(isIdentStart(next) || next == '>' || next == '/') {
+		return false
+	}
+	return !l.genericArrowAhead()
+}
+
+// genericArrowAhead reports whether the '<' begins a TypeScript generic parameter list of an arrow
+// function (`<T,>(x) => x`, `<T extends U>(x) => x`). Reading one as a JSX element would consume the
+// function body as element text.
+func (l *lexer) genericArrowAhead() bool {
+	i := l.pos + 1
+	// Skip the type-parameter name.
+	for i < len(l.src) && isIdentPart(l.src[i]) {
+		i++
+	}
+	if i == l.pos+1 {
+		return false
+	}
+	for i < len(l.src) && (l.src[i] == ' ' || l.src[i] == '\t') {
+		i++
+	}
+	if i >= len(l.src) {
+		return false
+	}
+	switch {
+	case l.src[i] == ',':
+		// `<T,>` is unambiguously a generic parameter list.
+		return true
+	case strings.HasPrefix(string(l.src[i:]), "extends"):
+		return true
+	}
+	// `<T>(` — a generic arrow rather than an element with no attributes.
+	if l.src[i] == '>' && i+1 < len(l.src) && l.src[i+1] == '(' {
+		return true
+	}
+	return false
+}
+
+// expressionPosition reports whether the cursor sits where an expression may begin.
+func (l *lexer) expressionPosition() bool {
+	if !l.hasPrev {
+		return true
+	}
+	prev := l.prevSignificant
+	switch prev.kind {
+	case tokenString, tokenTemplate:
+		return false
+	case tokenIdent:
+		return regexPrecedingKeywords[prev.text]
+	case tokenPunct:
+		switch prev.text {
+		case ")", "]", "}", "++", "--", ">":
+			return false
+		default:
+			return true
+		}
+	}
+	return true
+}
+
+// stepJSXTag scans one unit of an opening tag. Attribute VALUES that are expression containers are lexed
+// as code (the container's tokens reach the extractor), so a loader in an attribute is never skipped.
+func (l *lexer) stepJSXTag() (token, bool) {
+	// angleDepth guards a generic type argument in a tag name (`<Select<Option> ...>`) so the tag scan
+	// closes on the tag's own '>' rather than the generic's.
+	for !l.atEnd() {
+		b := l.peek()
+		switch {
+		case b == '/' && l.peekAt(1) == '>':
+			l.advance()
+			l.advance()
+			l.popFrame()
+			l.emitValueLike()
+			return token{}, false
+		case b == '>':
+			l.advance()
+			l.popFrame()
+			// A non-self-closing tag opens a children context.
+			if !l.pushFrame(frame{kind: frameJSXChildren}) {
+				return token{kind: tokenEOF}, true
+			}
+			return token{}, false
+		case b == '<':
+			// A generic type argument inside the tag name; consume it with angle matching.
+			depth := 0
+			for !l.atEnd() {
+				if l.peek() == '<' {
+					depth++
+				} else if l.peek() == '>' {
+					depth--
+					if depth == 0 {
+						l.advance()
+						break
+					}
+				}
+				l.advance()
+			}
+		case b == '"' || b == '\'':
+			if _, _, outcome := l.readQuoted(b); outcome != quotedOK {
+				l.advance()
+			}
+		case b == '{':
+			// Lex the attribute expression as code so its tokens reach the extractor.
+			line, col := l.line, l.col
+			l.advance()
+			if !l.pushFrame(frame{kind: frameExpr}) {
+				return token{kind: tokenEOF}, true
+			}
+			return l.emit(token{kind: tokenPunct, text: "{", line: line, column: col}), true
+		case l.isUnicodeLineSeparator():
+			l.advanceLineTerminator()
+		default:
+			l.advance()
+		}
+	}
+	return token{}, false
+}
+
+// stepJSXChildren consumes one unit of JSX element content: a closing tag (which pops the frame), a
+// nested element, the start of an expression container, or a run of element text.
+//
+// Element TEXT is the only region this lexer still skips without tokenizing, so an apostrophe in prose
+// cannot open a string literal whose closing apostrophe later in the sentence would swallow an expression
+// container. Because skipping text could hide a real import if a comparison were misjudged as JSX, any
+// skipped text containing a module-loading signature degrades coverage.
+func (l *lexer) stepJSXChildren() (token, bool) {
+	switch {
+	case l.peek() == '<' && l.peekAt(1) == '/':
+		for !l.atEnd() && l.peek() != '>' {
+			l.advance()
+		}
+		if !l.atEnd() {
+			l.advance()
+		}
+		l.popFrame()
+		l.emitValueLike()
+		return token{}, false
+	case l.peek() == '<' && l.peekAt(1) == '!' && l.peekAt(2) == '-' && l.peekAt(3) == '-':
+		// A JSX comment written HTML-style; consume to its terminator.
+		for !l.atEnd() {
+			if l.peek() == '-' && l.peekAt(1) == '-' && l.peekAt(2) == '>' {
+				l.advance()
+				l.advance()
+				l.advance()
+				break
+			}
+			l.advance()
+		}
+		return token{}, false
+	case l.peek() == '<' && (isIdentStart(l.peekAt(1)) || l.peekAt(1) == '>'):
+		l.advance()
+		if !l.pushFrame(frame{kind: frameJSXTag}) {
+			return token{kind: tokenEOF}, true
+		}
+		return token{}, false
+	case l.peek() == '{':
+		// Return the opening brace as a real token and switch to code mode: everything inside the
+		// container must reach the extractor.
+		line, col := l.line, l.col
+		l.advance()
+		if !l.pushFrame(frame{kind: frameExpr}) {
+			return token{kind: tokenEOF}, true
+		}
+		return l.emit(token{kind: tokenPunct, text: "{", line: line, column: col}), true
+	default:
+		l.skipJSXText()
+		return token{}, false
+	}
+}
+
+// skipJSXText consumes element text up to the next '<' or '{'.
+func (l *lexer) skipJSXText() {
+	start := l.pos
+	startLine := l.line
+	for !l.atEnd() {
+		b := l.peek()
+		if b == '<' || b == '{' {
+			break
+		}
+		if l.isUnicodeLineSeparator() {
+			l.advanceLineTerminator()
+			continue
+		}
+		l.advance()
+	}
+	l.reportSkippedLoaders(string(l.src[start:l.pos]), startLine)
+}
+
+// reportSkippedLoaders degrades coverage when a region this lexer skipped without tokenizing contains a
+// module-loading signature: skipping is only safe if nothing loadable was in it.
+func (l *lexer) reportSkippedLoaders(text string, line int) {
+	for _, signature := range loaderSignatures {
+		if strings.Contains(text, signature) {
+			l.addHazard(hazardUnsupportedLoader, line, "module-loading signature inside skipped jsx text")
+			return
+		}
+	}
+}
+
+func (l *lexer) readIdent() string {
+	start := l.pos
+	for !l.atEnd() && isIdentPart(l.peek()) {
+		l.advance()
+	}
+	return string(l.src[start:l.pos])
+}
+
+// readNumberLike consumes a numeric literal loosely. Import extraction never inspects numbers; it only
+// needs them to not be mistaken for identifiers or punctuation.
+func (l *lexer) readNumberLike() string {
+	start := l.pos
+	for !l.atEnd() {
+		b := l.peek()
+		if isIdentPart(b) || b == '.' {
+			l.advance()
+			continue
+		}
+		break
+	}
+	return string(l.src[start:l.pos])
+}
+
+// multiCharPuncts are the multi-byte punctuators the extractor must see as single tokens, ordered
+// LONGEST FIRST so a prefix never shadows a longer operator.
+var multiCharPuncts = []string{
+	"...", "===", "!==", "**=", "??=", "&&=", "||=", "?.",
+	"=>", "==", "!=", "<=", ">=", "&&", "||", "??", "**", "++", "--",
+}
+
+func (l *lexer) readPunct() string {
+	remaining := l.src[l.pos:]
+	for _, candidate := range multiCharPuncts {
+		if len(remaining) >= len(candidate) && string(remaining[:len(candidate)]) == candidate {
+			for range candidate {
+				l.advance()
+			}
+			return candidate
+		}
+	}
+	return string(l.advance())
+}
+
+func isIdentStart(b byte) bool {
+	return b == '_' || b == '$' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b >= 0x80
+}
+
+func isIdentPart(b byte) bool {
+	return isIdentStart(b) || (b >= '0' && b <= '9')
+}

--- a/internal/infrastructure/tools/jsimports/pipeline_contract_test.go
+++ b/internal/infrastructure/tools/jsimports/pipeline_contract_test.go
@@ -1,0 +1,151 @@
+package jsimports_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jsimports"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jsresolve"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.JSImportScanner = (*jsimports.Scanner)(nil)
+
+func write(t *testing.T, file, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(file, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestScannerGraphIsAcceptedByTheResolver is the load-bearing contract between phase R1 (this scanner)
+// and phase R2 (jsresolve.Resolver). The resolver REFUSES an internally inconsistent graph — in
+// particular an unresolved relative edge with no matching coverage issue at the same line — so this test
+// proves the scanner's coverage attribution satisfies the resolver rather than merely looking plausible.
+func TestScannerGraphIsAcceptedByTheResolver(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	write(t, filepath.Join(root, "package.json"), `{"name":"app","version":"1.0.0","workspaces":["packages/*"]}`)
+	write(t, filepath.Join(root, "packages", "shared", "package.json"), `{"name":"@workspace/shared","version":"0.1.0"}`)
+	write(t, filepath.Join(root, "packages", "shared", "src", "index.ts"), `export const shared = 1;`)
+	write(t, filepath.Join(root, "src", "index.ts"), `
+import lodash from "lodash";
+import * as fs from "node:fs";
+import path from "path";
+import { shared } from "@workspace/shared";
+import { local } from "./local";
+import type { T } from "some-types";
+export * from "./reexported";
+const cjs = require("commonjs-pkg");
+await import("dynamic-pkg");
+import missing from "./absent";
+require(computed);
+`)
+	write(t, filepath.Join(root, "src", "local.ts"), `export const local = 1;`)
+	write(t, filepath.Join(root, "src", "reexported.ts"), `export const re = 1;`)
+
+	graph, err := jsimports.New().Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	// The resolver validates the graph shape and errors on an inconsistency.
+	result, err := jsresolve.NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatalf("resolver rejected the scanner graph: %v", err)
+	}
+
+	byStatus := map[jsresolution.Status][]string{}
+	for _, imp := range result.Imports {
+		byStatus[imp.Status] = append(byStatus[imp.Status], imp.Specifier)
+	}
+
+	// Node built-ins must never be mistaken for npm dependencies.
+	assertContains(t, byStatus[jsresolution.StatusBuiltin], "node:fs")
+	assertContains(t, byStatus[jsresolution.StatusBuiltin], "path")
+	// A first-party workspace package must never be classified as a third-party component. At this
+	// phase the resolver reports it as AMBIGUOUS with a reason (workspace linking and a same-named
+	// registry package are indistinguishable without lockfile importer context, which phase R2C adds);
+	// what this test locks is that it is never silently a component.
+	assertContains(t, byStatus[jsresolution.StatusAmbiguous], "@workspace/shared")
+	if contains(byStatus[jsresolution.StatusComponent], "@workspace/shared") {
+		t.Error("a local workspace package must never resolve to a third-party component")
+	}
+	// Third-party specifiers stay unresolved at this phase: no SBOM was supplied, and R2C owns
+	// component correlation. What matters is that they are explicit, never silently dropped.
+	for _, specifier := range []string{"lodash", "some-types", "commonjs-pkg", "dynamic-pkg"} {
+		if !containsAny(byStatus, specifier) {
+			t.Errorf("specifier %q disappeared from resolution output", specifier)
+		}
+	}
+
+	// The unobservable computed require and the unresolved relative import must both leave the
+	// combined result incomplete, so no analyzer can draw a negative conclusion from this graph.
+	if result.Complete {
+		t.Fatal("a graph containing a computed require and an unresolved relative import must not be complete")
+	}
+	if len(result.GraphCoverage) == 0 {
+		t.Fatal("scanner coverage issues must survive into the resolver result")
+	}
+}
+
+// TestScannerCleanProjectYieldsCompleteResolution proves the converse: a fully observable project
+// produces no coverage issues, which is the precondition for any later negative reachability proof.
+func TestScannerCleanProjectYieldsCompleteResolution(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	write(t, filepath.Join(root, "package.json"), `{"name":"clean","version":"1.0.0"}`)
+	write(t, filepath.Join(root, "src", "index.ts"), "import * as fs from \"node:fs\";\nimport { helper } from \"./helper\";\nexport const run = () => helper(fs);\n")
+	write(t, filepath.Join(root, "src", "helper.ts"), "export const helper = (x: unknown) => x;\n")
+
+	graph, err := jsimports.New().Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(graph.Coverage) != 0 {
+		t.Fatalf("a fully observable project must produce no coverage issues, got %+v", graph.Coverage)
+	}
+
+	result, err := jsresolve.NewResolver().Resolve(context.Background(), root, graph, nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !result.Complete {
+		t.Fatalf("expected complete resolution for a clean project, got coverage %+v", result.Coverage)
+	}
+}
+
+func assertContains(t *testing.T, values []string, want string) {
+	t.Helper()
+	if !contains(values, want) {
+		t.Errorf("expected %q among %v", want, values)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAny(byStatus map[jsresolution.Status][]string, want string) bool {
+	for _, values := range byStatus {
+		for _, value := range values {
+			if value == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/tools/jsimports/resolve_test.go
+++ b/internal/infrastructure/tools/jsimports/resolve_test.go
@@ -1,0 +1,297 @@
+package jsimports
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+// newResolveState builds a scanState with a synthetic file set, so relative resolution can be tested
+// directly without touching the filesystem.
+func newResolveState(modules, assets, components []string) *scanState {
+	sc := &scanState{
+		limits:          defaultLimits(),
+		coverage:        newCoverageSink(defaultMaxCoverage),
+		moduleSet:       map[string]bool{},
+		lowerIndex:      map[string][]string{},
+		assetSet:        map[string]bool{},
+		codeCarryingSet: map[string]bool{},
+	}
+	for _, m := range modules {
+		sc.moduleSet[m] = true
+		lower := toLower(m)
+		sc.lowerIndex[lower] = append(sc.lowerIndex[lower], m)
+	}
+	for _, a := range assets {
+		sc.assetSet[a] = true
+	}
+	for _, c := range components {
+		sc.codeCarryingSet[c] = true
+	}
+	return sc
+}
+
+func toLower(s string) string {
+	out := []byte(s)
+	for i := range out {
+		if out[i] >= 'A' && out[i] <= 'Z' {
+			out[i] += 'a' - 'A'
+		}
+	}
+	return string(out)
+}
+
+func outcomeName(o relativeOutcome) string {
+	switch o {
+	case relativeResolved:
+		return "resolved"
+	case relativeAsset:
+		return "asset"
+	case relativeCodeCarrying:
+		return "code-carrying"
+	case relativeAmbiguous:
+		return "ambiguous"
+	case relativeEscapesRoot:
+		return "escapes-root"
+	default:
+		return "unresolved"
+	}
+}
+
+func TestResolveRelativeTable(t *testing.T) {
+	t.Parallel()
+
+	modules := []string{
+		"src/index.ts",
+		"src/plain.ts",
+		"src/emitted.ts",
+		"src/dir/index.ts",
+		"src/only-js.js",
+		"src/Cased.ts",
+		"src/types.d.ts",
+	}
+	assets := []string{"src/styles.css", "src/data.json"}
+	components := []string{"src/Widget.vue"}
+
+	tests := []struct {
+		name        string
+		from        string
+		specifier   string
+		wantTarget  string
+		wantOutcome relativeOutcome
+	}{
+		{name: "sibling extensionless", from: "src/index.ts", specifier: "./plain", wantTarget: "src/plain.ts", wantOutcome: relativeResolved},
+		{name: "explicit extension", from: "src/index.ts", specifier: "./plain.ts", wantTarget: "src/plain.ts", wantOutcome: relativeResolved},
+		{name: "emitted extension rewrite", from: "src/index.ts", specifier: "./emitted.js", wantTarget: "src/emitted.ts", wantOutcome: relativeResolved},
+		{name: "directory index", from: "src/index.ts", specifier: "./dir", wantTarget: "src/dir/index.ts", wantOutcome: relativeResolved},
+		{name: "javascript sibling", from: "src/index.ts", specifier: "./only-js", wantTarget: "src/only-js.js", wantOutcome: relativeResolved},
+		{name: "declaration sibling", from: "src/index.ts", specifier: "./types", wantTarget: "src/types.d.ts", wantOutcome: relativeResolved},
+		{name: "parent traversal within root", from: "src/dir/index.ts", specifier: "../plain", wantTarget: "src/plain.ts", wantOutcome: relativeResolved},
+		{name: "stylesheet is not a module", from: "src/index.ts", specifier: "./styles.css", wantOutcome: relativeAsset},
+		{name: "json is not a module", from: "src/index.ts", specifier: "./data.json", wantOutcome: relativeAsset},
+		{name: "component hides code", from: "src/index.ts", specifier: "./Widget.vue", wantOutcome: relativeCodeCarrying},
+		{name: "case-only match is ambiguous", from: "src/index.ts", specifier: "./cased", wantOutcome: relativeAmbiguous},
+		{name: "escapes the scan root", from: "src/index.ts", specifier: "../../outside/x", wantOutcome: relativeEscapesRoot},
+		{name: "missing module", from: "src/index.ts", specifier: "./absent", wantOutcome: relativeUnresolved},
+		{name: "bundler query suffix is stripped", from: "src/index.ts", specifier: "./plain?raw", wantTarget: "src/plain.ts", wantOutcome: relativeResolved},
+		{name: "fragment suffix is stripped", from: "src/index.ts", specifier: "./plain#frag", wantTarget: "src/plain.ts", wantOutcome: relativeResolved},
+		{name: "self directory resolves to index", from: "src/dir/index.ts", specifier: ".", wantTarget: "src/dir/index.ts", wantOutcome: relativeResolved},
+	}
+
+	sc := newResolveState(modules, assets, components)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			target, outcome := sc.resolveRelative(test.from, test.specifier)
+			if outcome != test.wantOutcome {
+				t.Fatalf("outcome = %s, want %s (target %q)", outcomeName(outcome), outcomeName(test.wantOutcome), target)
+			}
+			if test.wantOutcome == relativeResolved && target != test.wantTarget {
+				t.Fatalf("target = %q, want %q", target, test.wantTarget)
+			}
+		})
+	}
+}
+
+// TestResolveRelativePrefersTypeScriptOverJavaScript locks the precedence that makes resolution
+// deterministic: when both a .ts and a .js sibling exist, exactly one candidate wins and it is the one
+// the TypeScript compiler would choose.
+func TestResolveRelativePrefersTypeScriptOverJavaScript(t *testing.T) {
+	t.Parallel()
+
+	sc := newResolveState([]string{"src/index.ts", "src/dual.ts", "src/dual.js"}, nil, nil)
+	target, outcome := sc.resolveRelative("src/index.ts", "./dual")
+	if outcome != relativeResolved || target != "src/dual.ts" {
+		t.Fatalf("expected src/dual.ts to win, got %q (%s)", target, outcomeName(outcome))
+	}
+}
+
+// TestBackslashSpecifierNeverSetsATarget is the regression for a contract break with the package
+// resolver: the domain classifies a backslash specifier as UNSUPPORTED, not relative. If the scanner
+// treated it as relative and set Edge.To, the resolver would reject the ENTIRE graph, so one
+// Windows-style import anywhere in a repository would abort every scan.
+func TestBackslashSpecifierNeverSetsATarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.ts"), `import u from ".\\util";`)
+	writeFile(t, filepath.Join(root, "util.ts"), `export default 1;`)
+
+	graph := scan(t, root)
+
+	edge, ok := edgeFor(graph, "a.ts", `.\util`)
+	if !ok {
+		t.Fatalf("expected an edge for the backslash specifier, got %+v", graph.Edges)
+	}
+	if edge.To != "" {
+		t.Fatalf("a specifier the domain calls unsupported must not be resolved to %q", edge.To)
+	}
+}
+
+func TestCoverageSinkReportsItsOwnTruncation(t *testing.T) {
+	t.Parallel()
+
+	sink := newCoverageSink(3)
+	for i := 0; i < 10; i++ {
+		sink.add(modulegraph.CoverageIssue{Kind: modulegraph.CoverageDynamicRequire, Path: "a.ts", Line: i + 1})
+	}
+	issues := sink.issues()
+	if len(issues) != 3 {
+		t.Fatalf("sink must cap at its budget, got %d issues", len(issues))
+	}
+	// A truncated coverage list must never look like a clean scan: the final slot says so, with its own
+	// distinct kind rather than borrowing another budget's kind.
+	last := issues[len(issues)-1]
+	if last.Kind != modulegraph.CoverageIssueBudgetExceeded {
+		t.Fatalf("truncation marker kind = %q, want %q", last.Kind, modulegraph.CoverageIssueBudgetExceeded)
+	}
+}
+
+func TestScanEntryAndEdgeBudgets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("entry budget", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		for _, name := range []string{"a.ts", "b.ts", "c.ts", "d.ts"} {
+			writeFile(t, filepath.Join(root, "deep", "nested", name), `import x from "pkg";`)
+		}
+		limits := defaultLimits()
+		limits.maxEntries = 3
+		scanner, err := newWithLimits(limits)
+		if err != nil {
+			t.Fatalf("newWithLimits: %v", err)
+		}
+		graph, err := scanner.Scan(context.Background(), root)
+		if err != nil {
+			// With a tiny entry budget the walk may find no source at all, which is itself a
+			// no-coverage error rather than a clean empty graph.
+			return
+		}
+		if !coverageKinds(graph)[modulegraph.CoverageEntryBudgetExceeded] {
+			t.Fatalf("exceeding the entry budget must degrade coverage, got %+v", graph.Coverage)
+		}
+	})
+
+	t.Run("edge budget", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "many.ts"), `import a from "p1"; import b from "p2"; import c from "p3"; import d from "p4";`)
+		limits := defaultLimits()
+		limits.maxEdges = 2
+		scanner, err := newWithLimits(limits)
+		if err != nil {
+			t.Fatalf("newWithLimits: %v", err)
+		}
+		graph, err := scanner.Scan(context.Background(), root)
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !coverageKinds(graph)[modulegraph.CoverageEdgeBudgetExceeded] {
+			t.Fatalf("exceeding the edge budget must degrade coverage, got %+v", graph.Coverage)
+		}
+		if len(graph.Edges) > 2 {
+			t.Fatalf("edge budget not enforced: %d edges", len(graph.Edges))
+		}
+	})
+}
+
+func TestScanSkippedDirectoryWithSourceDegradesCoverage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "app.ts"), `import x from "pkg";`)
+	// Build output is excluded by policy, but it CAN contain first-party imports, so excluding it is a
+	// coverage limitation that must be reported.
+	writeFile(t, filepath.Join(root, "dist", "bundle.js"), `require("built-only-dep");`)
+	// A dependency directory is exempt: a dependency's own imports are not first-party evidence.
+	writeFile(t, filepath.Join(root, "node_modules", "dep", "index.js"), `require("transitive");`)
+
+	graph := scan(t, root)
+
+	var skipped []string
+	for _, issue := range graph.Coverage {
+		if issue.Kind == modulegraph.CoverageSkippedDirectory {
+			skipped = append(skipped, issue.Path)
+		}
+	}
+	if len(skipped) != 1 || skipped[0] != "dist" {
+		t.Fatalf("expected exactly the dist directory to be reported, got %v (all: %+v)", skipped, graph.Coverage)
+	}
+}
+
+func TestScanFileGrowingDuringReadIsNotSilentlyTruncated(t *testing.T) {
+	t.Parallel()
+
+	// A file whose size exceeds the per-file budget at READ time (not at stat time) must not have its
+	// prefix parsed silently: the imports past the cut would vanish with no coverage issue.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "ok.ts"), `import a from "p";`)
+	writeFile(t, filepath.Join(root, "big.ts"), `import b from "pkg2"; // `+strings.Repeat("x", 200))
+
+	limits := defaultLimits()
+	// Between the two file sizes: ok.ts is parsed, big.ts is over budget.
+	limits.maxFileBytes = 64
+	scanner, err := newWithLimits(limits)
+	if err != nil {
+		t.Fatalf("newWithLimits: %v", err)
+	}
+	graph, err := scanner.Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	kinds := coverageKinds(graph)
+	if !kinds[modulegraph.CoverageFileTooLarge] && !kinds[modulegraph.CoverageUnreadableFile] {
+		t.Fatalf("an over-budget file must degrade coverage, got %+v", graph.Coverage)
+	}
+	// Whatever happened, no edge may have been invented from a truncated read.
+	for _, edge := range graph.Edges {
+		if edge.From == "big.ts" {
+			t.Fatalf("an over-budget file must not contribute edges: %+v", edge)
+		}
+	}
+}
+
+func TestScanRejectsNonRegularRootEntries(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "app.ts"), `import x from "pkg";`)
+	if err := os.Mkdir(filepath.Join(root, "weird.ts"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	graph := scan(t, root)
+
+	// A directory named like a source file must never become a module.
+	for _, m := range graph.Modules {
+		if m.Path == "weird.ts" {
+			t.Fatal("a directory must not be scanned as a source module")
+		}
+	}
+}

--- a/internal/infrastructure/tools/jsimports/scanner.go
+++ b/internal/infrastructure/tools/jsimports/scanner.go
@@ -1,0 +1,762 @@
+// Package jsimports implements the deterministic, source-only JavaScript and TypeScript module-import
+// scanner behind ports.JSImportScanner (epic #378 phase R1).
+//
+// It reads source bytes and nothing else: it never executes project code, package managers, bundlers or
+// lifecycle scripts, never resolves through a registry, and never touches the network. Because it only
+// lexes text it runs in-process like the Python import scanner, rather than inside the sandbox that
+// confines toolchains which compile untrusted source.
+//
+// The load-bearing rule is that an unobservable module load must degrade COVERAGE rather than vanish: a
+// later analyzer may treat "no edge" as proof of absence only when the graph reports no coverage issues.
+// Every bound, unreadable file, dynamic loader and unresolved specifier therefore emits a structured
+// modulegraph.CoverageIssue.
+package jsimports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Default bounds. They cap worst-case work on a hostile or simply enormous repository; exceeding one is
+// recorded as a coverage issue so the caller learns the graph is partial instead of silently truncated.
+const (
+	defaultMaxFiles      = 50000
+	defaultMaxFileBytes  = 2 << 20   // 2 MiB per source file
+	defaultMaxTotalBytes = 512 << 20 // 512 MiB across the scan
+	defaultMaxEntries    = 500000    // directory entries visited
+	defaultMaxEdges      = 250000    // import edges retained
+	defaultMaxCoverage   = 4096
+)
+
+// scannerLimits are the tunable bounds; tests inject small values to exercise every budget path.
+type scannerLimits struct {
+	maxFiles      int
+	maxFileBytes  int64
+	maxTotalBytes int64
+	maxEntries    int
+	maxEdges      int
+	maxCoverage   int
+}
+
+func defaultLimits() scannerLimits {
+	return scannerLimits{
+		maxFiles:      defaultMaxFiles,
+		maxFileBytes:  defaultMaxFileBytes,
+		maxTotalBytes: defaultMaxTotalBytes,
+		maxEntries:    defaultMaxEntries,
+		maxEdges:      defaultMaxEdges,
+		maxCoverage:   defaultMaxCoverage,
+	}
+}
+
+func (l scannerLimits) validate() error {
+	if l.maxFiles <= 0 || l.maxFileBytes <= 0 || l.maxTotalBytes <= 0 || l.maxEntries <= 0 || l.maxEdges <= 0 || l.maxCoverage <= 0 {
+		return fmt.Errorf("%w: jsimports limits must be positive", shared.ErrValidation)
+	}
+	return nil
+}
+
+// Scanner builds a first-party JavaScript and TypeScript module graph for a repository root.
+type Scanner struct {
+	limits scannerLimits
+}
+
+var _ ports.JSImportScanner = (*Scanner)(nil)
+
+// New returns a Scanner with production bounds.
+func New() *Scanner { return &Scanner{limits: defaultLimits()} }
+
+// newWithLimits is the test seam for exercising the budget paths.
+func newWithLimits(l scannerLimits) (*Scanner, error) {
+	if err := l.validate(); err != nil {
+		return nil, err
+	}
+	return &Scanner{limits: l}, nil
+}
+
+// skipDir names directories that never hold first-party source. node_modules is excluded because the
+// graph is first-party only: a dependency's own imports are not evidence that FIRST-PARTY code uses it.
+var skipDir = map[string]bool{
+	"node_modules": true,
+	".git":         true, ".hg": true, ".svn": true,
+	"dist": true, "build": true, "out": true, "coverage": true,
+	".next": true, ".nuxt": true, ".svelte-kit": true, ".turbo": true, ".cache": true,
+	"bower_components": true, "jspm_packages": true, "vendor": true,
+}
+
+// exemptFromCoverage names the excluded directories whose contents are legitimately outside the
+// first-party graph, so excluding them is not a coverage limitation. Everything else in skipDir is a
+// policy exclusion: build output, tool config and vendored code CAN contain first-party imports, so a
+// skipped directory holding source degrades coverage.
+var exemptFromCoverage = map[string]bool{
+	"node_modules": true, "bower_components": true, "jspm_packages": true,
+	".git": true, ".hg": true, ".svn": true,
+}
+
+// assetExtensions are non-executable imports (data and styling). A relative import of one of these
+// cannot hide a JavaScript package import, so it resolves to "not a module" without degrading coverage.
+var assetExtensions = map[string]bool{
+	".css": true, ".scss": true, ".sass": true, ".less": true, ".styl": true,
+	".json": true, ".json5": true, ".jsonc": true, ".yaml": true, ".yml": true, ".toml": true,
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".svg": true, ".webp": true, ".avif": true, ".ico": true, ".bmp": true,
+	".woff": true, ".woff2": true, ".ttf": true, ".otf": true, ".eot": true,
+	".mp3": true, ".mp4": true, ".webm": true, ".wav": true, ".ogg": true,
+	".txt": true, ".md": true, ".mdx": true, ".html": true, ".htm": true,
+	".wasm": true, ".graphql": true, ".gql": true, ".proto": true, ".csv": true, ".xml": true,
+	".sql": true, ".sh": true, ".pdf": true, ".zip": true,
+}
+
+// codeCarryingExtensions are single-file component formats whose bodies contain JavaScript or TypeScript
+// this scanner cannot parse. Importing one hides real imports, so it degrades coverage explicitly.
+var codeCarryingExtensions = map[string]bool{
+	".vue": true, ".svelte": true, ".astro": true, ".marko": true, ".riot": true,
+	".coffee": true, ".litcoffee": true, ".res": true, ".re": true, ".elm": true,
+}
+
+// Scan walks root and returns the normalized first-party module graph.
+//
+// It returns an error only for a hard no-coverage condition: an unusable root, a cancelled context, a
+// budget so small it invalidates the walk, or no supported source at all. Every partial observation is
+// reported in Graph.Coverage instead.
+func (s *Scanner) Scan(ctx context.Context, root string) (modulegraph.Graph, error) {
+	if ctx == nil {
+		return modulegraph.Graph{}, fmt.Errorf("%w: jsimports scan requires a context", shared.ErrValidation)
+	}
+	if err := s.limits.validate(); err != nil {
+		return modulegraph.Graph{}, err
+	}
+	trimmed := strings.TrimSpace(root)
+	if trimmed == "" {
+		return modulegraph.Graph{}, fmt.Errorf("%w: jsimports scan root is required", shared.ErrValidation)
+	}
+
+	// Reject a symlinked or non-directory root outright: os.OpenRoot below confines traversal, but the
+	// root itself must be a real directory for repository-relative paths to mean anything.
+	// The OS error carries the ABSOLUTE host path, which must never reach a log, a judgment or the
+	// audit trail (golden rule 3): classify it and drop the original.
+	info, err := os.Lstat(trimmed)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return modulegraph.Graph{}, fmt.Errorf("%w: jsimports scan root does not exist", shared.ErrNotFound)
+		}
+		return modulegraph.Graph{}, fmt.Errorf("%w: jsimports scan root is not readable", shared.ErrValidation)
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return modulegraph.Graph{}, fmt.Errorf("%w: jsimports scan root is a symlink", shared.ErrValidation)
+	}
+	if !info.IsDir() {
+		return modulegraph.Graph{}, fmt.Errorf("%w: jsimports scan root is not a directory", shared.ErrValidation)
+	}
+
+	rootDir, err := os.OpenRoot(trimmed)
+	if err != nil {
+		return modulegraph.Graph{}, fmt.Errorf("%w: jsimports scan root could not be opened", shared.ErrValidation)
+	}
+	defer func() { _ = rootDir.Close() }()
+
+	sc := &scanState{
+		limits:   s.limits,
+		rootDir:  rootDir,
+		coverage: newCoverageSink(s.limits.maxCoverage),
+	}
+	if err := sc.walk(ctx); err != nil {
+		return modulegraph.Graph{}, err
+	}
+	if len(sc.sources) == 0 {
+		// No supported source at all is a no-coverage condition, not an empty proof: the target simply
+		// is not a JavaScript or TypeScript project.
+		return modulegraph.Graph{}, fmt.Errorf("%w: no javascript or typescript source under scan root (no coverage)", shared.ErrNotFound)
+	}
+	if err := sc.parseAll(ctx); err != nil {
+		return modulegraph.Graph{}, err
+	}
+
+	graph := modulegraph.Graph{
+		Modules:      sc.modules,
+		Edges:        sc.edges,
+		Coverage:     sc.coverage.issues(),
+		FilesScanned: sc.filesScanned,
+		BytesScanned: sc.bytesScanned,
+	}
+	normalized, err := modulegraph.Normalize(graph)
+	if err != nil {
+		return modulegraph.Graph{}, fmt.Errorf("jsimports: normalize graph: %w", err)
+	}
+	return normalized, nil
+}
+
+// sourceFile is a discovered first-party module awaiting parse.
+type sourceFile struct {
+	// relPath is the normalized repository-relative slash path.
+	relPath string
+	size    int64
+}
+
+// scanState carries one scan's mutable state.
+type scanState struct {
+	limits  scannerLimits
+	rootDir *os.Root
+
+	sources []sourceFile
+	// moduleSet indexes discovered modules by repository-relative path for relative resolution.
+	moduleSet map[string]bool
+	// lowerIndex maps the lowercased path to its real casing, so a case-only mismatch is reported as
+	// ambiguous instead of silently resolving on a case-insensitive filesystem.
+	lowerIndex map[string][]string
+	// assetSet and codeCarryingSet index non-JS files that a relative import may target.
+	assetSet        map[string]bool
+	codeCarryingSet map[string]bool
+
+	modules []modulegraph.Module
+	edges   []modulegraph.Edge
+
+	coverage     *coverageSink
+	filesScanned int
+	bytesScanned int64
+	entriesSeen  int
+
+	filesBudgetHit bool
+	bytesBudgetHit bool
+	edgesBudgetHit bool
+}
+
+// walk discovers every candidate file under the root without following symlinks.
+func (sc *scanState) walk(ctx context.Context) error {
+	sc.moduleSet = map[string]bool{}
+	sc.lowerIndex = map[string][]string{}
+	sc.assetSet = map[string]bool{}
+	sc.codeCarryingSet = map[string]bool{}
+
+	walkErr := fs.WalkDir(sc.rootDir.FS(), ".", func(p string, d fs.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if err != nil {
+			// An unreadable directory is a coverage limitation, not a scan failure.
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageUnreadableFile,
+				Path:   normalizeOrEmpty(p),
+				Detail: "directory entry could not be read",
+			})
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		sc.entriesSeen++
+		if sc.entriesSeen > sc.limits.maxEntries {
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageEntryBudgetExceeded,
+				Detail: "directory entry budget exceeded; traversal stopped",
+			})
+			return fs.SkipAll
+		}
+
+		name := d.Name()
+		if d.IsDir() {
+			if p == "." {
+				return nil
+			}
+			if skipDir[name] || strings.HasPrefix(name, ".") {
+				// Excluding a directory is a policy choice, but modules inside it are UNOBSERVED. Only
+				// dependency and VCS directories are exempt (a dependency's own imports are not
+				// evidence that first-party code uses it); anything else that actually contains source
+				// degrades coverage so its imports are never read as absent.
+				if !exemptFromCoverage[name] && sc.directoryHasSource(p) {
+					sc.coverage.add(modulegraph.CoverageIssue{
+						Kind:   modulegraph.CoverageSkippedDirectory,
+						Path:   normalizeOrEmpty(p),
+						Detail: "excluded directory contains unscanned source",
+					})
+				}
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		// Symlinks are never followed: a link can point outside the repository or create a cycle. It is
+		// recorded so a later analyzer knows a module may be unobserved.
+		if d.Type()&fs.ModeSymlink != 0 {
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageSymlink,
+				Path:   normalizeOrEmpty(p),
+				Detail: "symlink not followed",
+			})
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		ext := strings.ToLower(path.Ext(p))
+		switch {
+		case assetExtensions[ext]:
+			sc.assetSet[p] = true
+			return nil
+		case codeCarryingExtensions[ext]:
+			// A single-file component carries JavaScript this scanner cannot parse. Recording it only
+			// when some scanned module imports it would leave a component-only project silently
+			// unobserved, so the file itself degrades coverage on discovery.
+			sc.codeCarryingSet[p] = true
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageUnsupportedSyntax,
+				Path:   normalizeOrEmpty(p),
+				Detail: "single-file component source is not parsed",
+			})
+			return nil
+		}
+		if _, ok := modulegraph.DialectForPath(p); !ok {
+			// An extension-less executable script (the package.json "bin" shape) holds real imports and
+			// would otherwise be dropped without a trace.
+			if ext == "" && sc.hasShebang(p) {
+				sc.coverage.add(modulegraph.CoverageIssue{
+					Kind:   modulegraph.CoverageUnsupportedSyntax,
+					Path:   normalizeOrEmpty(p),
+					Detail: "extension-less executable script is not parsed",
+				})
+			}
+			return nil
+		}
+
+		if len(sc.sources) >= sc.limits.maxFiles {
+			if !sc.filesBudgetHit {
+				sc.filesBudgetHit = true
+				sc.coverage.add(modulegraph.CoverageIssue{
+					Kind:   modulegraph.CoverageFileCountBudgetExceeded,
+					Detail: "source file budget exceeded; some modules were not scanned",
+				})
+			}
+			return nil
+		}
+
+		info, ierr := d.Info()
+		if ierr != nil {
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageUnreadableFile,
+				Path:   normalizeOrEmpty(p),
+				Detail: "file metadata could not be read",
+			})
+			return nil
+		}
+		if info.Size() > sc.limits.maxFileBytes {
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageFileTooLarge,
+				Path:   normalizeOrEmpty(p),
+				Detail: "source file exceeds the per-file byte budget",
+			})
+			return nil
+		}
+
+		normalized, nerr := modulegraph.NormalizeRepositoryPath(p)
+		if nerr != nil {
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageUnreadableFile,
+				Path:   "",
+				Detail: "source path could not be normalized",
+			})
+			return nil
+		}
+		sc.sources = append(sc.sources, sourceFile{relPath: normalized, size: info.Size()})
+		sc.moduleSet[normalized] = true
+		lower := strings.ToLower(normalized)
+		sc.lowerIndex[lower] = append(sc.lowerIndex[lower], normalized)
+		return nil
+	})
+	if walkErr != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("jsimports: scan cancelled: %w", ctxErr)
+		}
+		// Drop the OS error: it embeds absolute host paths.
+		return fmt.Errorf("%w: jsimports could not walk the scan root", shared.ErrValidation)
+	}
+
+	// Deterministic parse order regardless of filesystem ordering.
+	sort.Slice(sc.sources, func(i, j int) bool { return sc.sources[i].relPath < sc.sources[j].relPath })
+	return nil
+}
+
+// parseAll lexes every discovered source file and records its edges and hazards.
+func (sc *scanState) parseAll(ctx context.Context) error {
+	sc.modules = make([]modulegraph.Module, 0, len(sc.sources))
+	for _, src := range sc.sources {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("jsimports: scan cancelled: %w", err)
+		}
+
+		dialect, ok := modulegraph.DialectForPath(src.relPath)
+		if !ok {
+			continue
+		}
+		module := modulegraph.Module{
+			Path:            src.relPath,
+			Dialect:         dialect,
+			DeclarationOnly: modulegraph.IsDeclarationPath(src.relPath),
+		}
+		sc.modules = append(sc.modules, module)
+
+		if sc.bytesBudgetHit {
+			// Past the total-byte budget the module is known to exist but its imports are unobserved.
+			continue
+		}
+		if sc.bytesScanned+src.size > sc.limits.maxTotalBytes {
+			sc.bytesBudgetHit = true
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageTotalByteBudgetExceeded,
+				Detail: "total byte budget exceeded; remaining modules were not parsed",
+			})
+			continue
+		}
+
+		data, rerr := sc.readSource(src)
+		if rerr != nil {
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageUnreadableFile,
+				Path:   src.relPath,
+				Detail: "source file could not be read",
+			})
+			continue
+		}
+		sc.filesScanned++
+		sc.bytesScanned += int64(len(data))
+
+		if !utf8.Valid(data) {
+			// A non-UTF-8 module cannot be lexed reliably; its imports are unobserved.
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageInvalidUTF8,
+				Path:   src.relPath,
+				Detail: "source is not valid UTF-8",
+			})
+			continue
+		}
+
+		// JSX appears in .js/.mjs/.cjs as well (Babel, CRA and Next projects), and missing it there
+		// re-opens the apostrophe-swallowing silent miss. Only plain TypeScript is scanned non-JSX,
+		// because there `<Foo>x` is a type assertion rather than an element.
+		result := newExtractor(data, dialect != modulegraph.DialectTypeScript).run()
+		sc.recordHazards(src.relPath, result.hazards)
+		for _, imp := range result.imports {
+			sc.recordImport(src.relPath, imp)
+		}
+	}
+	return nil
+}
+
+// readSource reads one file through the confined root handle, bounded by the per-file budget.
+func (sc *scanState) readSource(src sourceFile) ([]byte, error) {
+	f, err := sc.rootDir.Open(src.relPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Re-stat through the open handle: the entry could have changed between walk and read, and a
+	// non-regular file must never be read as source.
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("jsimports: %q is not a regular file", src.relPath)
+	}
+	if info.Size() > sc.limits.maxFileBytes {
+		return nil, fmt.Errorf("jsimports: %q exceeds the per-file byte budget", src.relPath)
+	}
+	// Read one byte PAST the budget so growth between the stat and the read is detectable: silently
+	// parsing a truncated prefix would drop the imports after the cut with no coverage issue.
+	data, err := io.ReadAll(io.LimitReader(f, sc.limits.maxFileBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > sc.limits.maxFileBytes {
+		return nil, fmt.Errorf("jsimports: %q grew past the per-file byte budget during the read", src.relPath)
+	}
+	return data, nil
+}
+
+// hazardCoverageKind maps a lexical hazard to its coverage kind.
+func hazardCoverageKind(k hazardKind) modulegraph.CoverageIssueKind {
+	switch k {
+	case hazardDynamicRequire:
+		return modulegraph.CoverageDynamicRequire
+	case hazardDynamicImport:
+		return modulegraph.CoverageDynamicImport
+	case hazardEval:
+		return modulegraph.CoverageEval
+	case hazardNewFunction:
+		return modulegraph.CoverageNewFunction
+	case hazardRequireContext:
+		return modulegraph.CoverageRequireContext
+	case hazardImportMetaGlob:
+		return modulegraph.CoverageImportMetaGlob
+	case hazardModuleCreateRequire:
+		return modulegraph.CoverageModuleCreateRequire
+	case hazardMalformedSource:
+		return modulegraph.CoverageMalformedSource
+	default:
+		return modulegraph.CoverageUnsupportedLoader
+	}
+}
+
+func (sc *scanState) recordHazards(modulePath string, hazards []hazard) {
+	for _, h := range hazards {
+		line := h.line
+		if line < 0 {
+			line = 0
+		}
+		sc.coverage.add(modulegraph.CoverageIssue{
+			Kind:   hazardCoverageKind(h.kind),
+			Path:   modulePath,
+			Line:   line,
+			Detail: h.detail,
+		})
+	}
+}
+
+// recordImport turns one extracted import site into a graph edge, resolving relative specifiers to
+// first-party modules. External specifiers deliberately leave Edge.To empty: package identity is the
+// resolver's job, not the scanner's.
+func (sc *scanState) recordImport(from string, imp rawImport) {
+	// Bound the retained edge set: this scanner runs in-process, and a hostile repository of
+	// `require("a");` lines would otherwise exhaust memory here and again inside Normalize.
+	if len(sc.edges) >= sc.limits.maxEdges {
+		if !sc.edgesBudgetHit {
+			sc.edgesBudgetHit = true
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageEdgeBudgetExceeded,
+				Detail: "import edge budget exceeded; further imports were not recorded",
+			})
+		}
+		return
+	}
+
+	specifier := strings.TrimSpace(imp.specifier)
+	if specifier == "" {
+		sc.coverage.add(modulegraph.CoverageIssue{
+			Kind:   modulegraph.CoverageUnsupportedLoader,
+			Path:   from,
+			Line:   imp.position.Line,
+			Detail: "empty module specifier",
+		})
+		return
+	}
+
+	edge := modulegraph.Edge{
+		From:      from,
+		Specifier: specifier,
+		Kind:      imp.kind,
+		Bindings:  imp.bindings,
+		TypeOnly:  imp.typeOnly,
+		Position:  imp.position,
+	}
+
+	// The domain classifier is the single source of truth: if the scanner called a specifier relative
+	// while the resolver did not, it would set Edge.To on an edge the resolver rejects, and the resolver
+	// hard-errors on the WHOLE graph. One divergent specifier would abort every scan.
+	if jsresolution.ClassifySpecifier(specifier).Kind == jsresolution.SpecifierRelative {
+		target, outcome := sc.resolveRelative(from, specifier)
+		switch outcome {
+		case relativeResolved:
+			edge.To = target
+		case relativeAsset:
+			// A data or styling import carries no JavaScript, so it cannot hide a package import.
+			// The edge is kept for provenance with no target and no coverage penalty.
+		case relativeCodeCarrying:
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageUnsupportedSyntax,
+				Path:   from,
+				Line:   imp.position.Line,
+				Detail: "relative import of an unparsed single-file component",
+			})
+		case relativeAmbiguous:
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageAmbiguousRelativeImport,
+				Path:   from,
+				Line:   imp.position.Line,
+				Detail: "relative specifier matches more than one module",
+			})
+		case relativeEscapesRoot:
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageRelativeImportEscapesRoot,
+				Path:   from,
+				Line:   imp.position.Line,
+				Detail: "relative specifier escapes the scan root",
+			})
+		default:
+			sc.coverage.add(modulegraph.CoverageIssue{
+				Kind:   modulegraph.CoverageUnresolvedRelativeImport,
+				Path:   from,
+				Line:   imp.position.Line,
+				Detail: "relative specifier did not resolve to a scanned module",
+			})
+		}
+	}
+
+	sc.edges = append(sc.edges, edge)
+}
+
+type relativeOutcome uint8
+
+const (
+	relativeUnresolved relativeOutcome = iota
+	relativeResolved
+	relativeAsset
+	relativeCodeCarrying
+	relativeAmbiguous
+	relativeEscapesRoot
+)
+
+// resolveRelative resolves a relative specifier against the discovered file set. It is a deterministic
+// subset of Node and TypeScript resolution: ordered extension candidates then directory indexes, with a
+// case-only match reported as ambiguous because it resolves on a case-insensitive filesystem only.
+func (sc *scanState) resolveRelative(from, specifier string) (string, relativeOutcome) {
+	// Bundler-specific suffixes (`./x?raw`, `./x#frag`) are not part of the module path.
+	clean := specifier
+	if i := strings.IndexAny(clean, "?#"); i >= 0 {
+		clean = clean[:i]
+	}
+	clean = strings.ReplaceAll(clean, "\\", "/")
+	if clean == "" {
+		return "", relativeUnresolved
+	}
+
+	base := path.Join(path.Dir(from), clean)
+	if base == ".." || strings.HasPrefix(base, "../") {
+		return "", relativeEscapesRoot
+	}
+	base = strings.TrimPrefix(path.Clean(base), "./")
+	if base == "." {
+		base = ""
+	}
+
+	// A specifier with an explicit asset or component extension is classified by that extension, so a
+	// missing stylesheet does not look like a missing module.
+	ext := strings.ToLower(path.Ext(base))
+	if assetExtensions[ext] {
+		return "", relativeAsset
+	}
+	if codeCarryingExtensions[ext] {
+		return "", relativeCodeCarrying
+	}
+
+	// The candidate order is owned by the domain so this scanner and the package resolver can never
+	// resolve the same specifier to different modules. Build the list once and use it for both passes.
+	candidates := jsresolution.ModuleFileCandidates(base)
+	for _, candidate := range candidates {
+		if sc.moduleSet[candidate] {
+			return candidate, relativeResolved
+		}
+	}
+
+	// Exact-case resolution failed. A case-insensitive hit means the build may resolve this import on a
+	// case-insensitive filesystem but not on Linux — genuinely ambiguous, never a clean negative.
+	for _, candidate := range candidates {
+		if _, ok := sc.lowerIndex[strings.ToLower(candidate)]; ok {
+			return "", relativeAmbiguous
+		}
+	}
+
+	// A directory import with no index file, or a path that exists only as an asset/component.
+	if sc.assetSet[base] {
+		return "", relativeAsset
+	}
+	if sc.codeCarryingSet[base] {
+		return "", relativeCodeCarrying
+	}
+	return "", relativeUnresolved
+}
+
+// hasShebang reports whether a file begins with "#!", read through the confined root handle. It is a
+// two-byte peek: the file is never parsed, only classified.
+func (sc *scanState) hasShebang(rel string) bool {
+	f, err := sc.rootDir.Open(rel)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	var head [2]byte
+	n, _ := io.ReadFull(f, head[:])
+	return n == 2 && head[0] == '#' && head[1] == '!'
+}
+
+// directoryHasSource reports whether an excluded directory contains at least one supported source file,
+// so only a directory that actually hides modules degrades coverage. The probe is bounded: an excluded
+// tree may be enormous, and exhausting the budget assumes source is present rather than claiming none.
+func (sc *scanState) directoryHasSource(dir string) bool {
+	const probeBudget = 512
+	seen := 0
+	found := false
+	_ = fs.WalkDir(sc.rootDir.FS(), dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fs.SkipDir
+		}
+		seen++
+		if seen > probeBudget {
+			found = true
+			return fs.SkipAll
+		}
+		if d != nil && d.IsDir() {
+			return nil
+		}
+		if _, ok := modulegraph.DialectForPath(p); ok {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// coverageSink collects coverage issues under a hard cap, reserving the last slot to report that the cap
+// itself was reached — a truncated coverage list must never look like a clean scan.
+type coverageSink struct {
+	max       int
+	collected []modulegraph.CoverageIssue
+	truncated bool
+}
+
+func newCoverageSink(max int) *coverageSink {
+	return &coverageSink{max: max}
+}
+
+func (c *coverageSink) add(issue modulegraph.CoverageIssue) {
+	if c.truncated {
+		return
+	}
+	if len(c.collected) >= c.max-1 {
+		c.truncated = true
+		c.collected = append(c.collected, modulegraph.CoverageIssue{
+			Kind:   modulegraph.CoverageIssueBudgetExceeded,
+			Detail: "coverage issue budget exceeded; additional issues were not recorded",
+		})
+		return
+	}
+	c.collected = append(c.collected, issue)
+}
+
+func (c *coverageSink) issues() []modulegraph.CoverageIssue {
+	return append([]modulegraph.CoverageIssue(nil), c.collected...)
+}
+
+// normalizeOrEmpty normalizes a path for coverage attribution, returning "" when it cannot be
+// represented as a repository-relative path (the issue is then recorded without a path).
+func normalizeOrEmpty(p string) string {
+	normalized, err := modulegraph.NormalizeRepositoryPath(p)
+	if err != nil {
+		return ""
+	}
+	return normalized
+}

--- a/internal/infrastructure/tools/jsimports/scanner_test.go
+++ b/internal/infrastructure/tools/jsimports/scanner_test.go
@@ -1,0 +1,528 @@
+package jsimports
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func writeFile(t *testing.T, file, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(file), err)
+	}
+	if err := os.WriteFile(file, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", file, err)
+	}
+}
+
+func scan(t *testing.T, root string) modulegraph.Graph {
+	t.Helper()
+	graph, err := New().Scan(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan %s: %v", root, err)
+	}
+	return graph
+}
+
+// coverageKinds indexes a graph's coverage issues by kind.
+func coverageKinds(graph modulegraph.Graph) map[modulegraph.CoverageIssueKind]bool {
+	out := map[modulegraph.CoverageIssueKind]bool{}
+	for _, issue := range graph.Coverage {
+		out[issue.Kind] = true
+	}
+	return out
+}
+
+// edgeFor returns the first edge with the given source and specifier.
+func edgeFor(graph modulegraph.Graph, from, specifier string) (modulegraph.Edge, bool) {
+	for _, edge := range graph.Edges {
+		if edge.From == from && edge.Specifier == specifier {
+			return edge, true
+		}
+	}
+	return modulegraph.Edge{}, false
+}
+
+func TestScanBuildsFirstPartyGraph(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "index.ts"), `
+import { service } from "./service";
+import lodash from "lodash";
+`)
+	writeFile(t, filepath.Join(root, "src", "service.ts"), `
+import { helper } from "./util/helper";
+export const service = helper;
+`)
+	writeFile(t, filepath.Join(root, "src", "util", "helper.ts"), `export const helper = 1;`)
+
+	graph := scan(t, root)
+
+	wantModules := []string{"src/index.ts", "src/service.ts", "src/util/helper.ts"}
+	gotModules := make([]string, 0, len(graph.Modules))
+	for _, m := range graph.Modules {
+		gotModules = append(gotModules, m.Path)
+	}
+	if !reflect.DeepEqual(gotModules, wantModules) {
+		t.Fatalf("modules = %v, want %v", gotModules, wantModules)
+	}
+
+	// A relative import resolves to a first-party module; an external one deliberately leaves To empty
+	// because package identity belongs to the resolver, not the scanner.
+	local, ok := edgeFor(graph, "src/index.ts", "./service")
+	if !ok || local.To != "src/service.ts" {
+		t.Fatalf("relative edge did not resolve: %+v (ok=%v)", local, ok)
+	}
+	external, ok := edgeFor(graph, "src/index.ts", "lodash")
+	if !ok || external.To != "" {
+		t.Fatalf("external edge must have an empty target: %+v (ok=%v)", external, ok)
+	}
+
+	if len(graph.Coverage) != 0 {
+		t.Fatalf("a fully observable project must have no coverage issues, got %+v", graph.Coverage)
+	}
+	if graph.FilesScanned != 3 {
+		t.Fatalf("FilesScanned = %d, want 3", graph.FilesScanned)
+	}
+	// index.ts is the only module with no incoming resolved edge.
+	if !reflect.DeepEqual(graph.Roots, []string{"src/index.ts"}) {
+		t.Fatalf("Roots = %v, want [src/index.ts]", graph.Roots)
+	}
+}
+
+func TestScanRelativeResolution(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "app.ts"), `
+import a from "./plain";
+import b from "./dir";
+import c from "./emitted.js";
+import d from "./explicit.ts";
+import e from "./styles.css";
+import f from "./data.json";
+`)
+	writeFile(t, filepath.Join(root, "plain.ts"), `export default 1;`)
+	writeFile(t, filepath.Join(root, "dir", "index.ts"), `export default 1;`)
+	// A TypeScript ESM project writes the EMITTED extension: "./emitted.js" is authored as emitted.ts.
+	writeFile(t, filepath.Join(root, "emitted.ts"), `export default 1;`)
+	writeFile(t, filepath.Join(root, "explicit.ts"), `export default 1;`)
+	writeFile(t, filepath.Join(root, "styles.css"), `body{}`)
+	writeFile(t, filepath.Join(root, "data.json"), `{}`)
+
+	graph := scan(t, root)
+
+	wantTargets := map[string]string{
+		"./plain":       "plain.ts",
+		"./dir":         "dir/index.ts",
+		"./emitted.js":  "emitted.ts",
+		"./explicit.ts": "explicit.ts",
+		// Asset imports carry no JavaScript, so they resolve to no module WITHOUT degrading coverage.
+		"./styles.css": "",
+		"./data.json":  "",
+	}
+	for specifier, want := range wantTargets {
+		edge, ok := edgeFor(graph, "app.ts", specifier)
+		if !ok {
+			t.Fatalf("no edge for specifier %q", specifier)
+		}
+		if edge.To != want {
+			t.Errorf("specifier %q resolved to %q, want %q", specifier, edge.To, want)
+		}
+	}
+	if len(graph.Coverage) != 0 {
+		t.Fatalf("asset imports must not degrade coverage, got %+v", graph.Coverage)
+	}
+}
+
+// TestScanUnresolvedRelativeImportDegradesCoverageAtTheEdgeLine locks the contract the package resolver
+// depends on: an unresolved relative edge must carry a coverage issue whose Line equals the edge's line.
+func TestScanUnresolvedRelativeImportDegradesCoverageAtTheEdgeLine(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "app.ts"), "import a from \"lodash\";\nimport b from \"./missing\";\n")
+
+	graph := scan(t, root)
+
+	edge, ok := edgeFor(graph, "app.ts", "./missing")
+	if !ok {
+		t.Fatal("expected an edge for the unresolved relative specifier")
+	}
+	if edge.To != "" {
+		t.Fatalf("unresolved relative edge must have no target, got %q", edge.To)
+	}
+	var matched bool
+	for _, issue := range graph.Coverage {
+		if issue.Kind == modulegraph.CoverageUnresolvedRelativeImport && issue.Path == "app.ts" && issue.Line == edge.Position.Line {
+			matched = true
+		}
+	}
+	if !matched {
+		t.Fatalf("expected an unresolved-relative-import issue at line %d, got %+v", edge.Position.Line, graph.Coverage)
+	}
+}
+
+func TestScanRelativeImportEscapingRootDegradesCoverage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "app.ts"), `import a from "../outside/secret";`)
+
+	graph := scan(t, root)
+
+	if !coverageKinds(graph)[modulegraph.CoverageRelativeImportEscapesRoot] {
+		t.Fatalf("a root-escaping relative import must degrade coverage, got %+v", graph.Coverage)
+	}
+	edge, ok := edgeFor(graph, "app.ts", "../outside/secret")
+	if !ok || edge.To != "" {
+		t.Fatalf("root-escaping edge must exist with no target: %+v (ok=%v)", edge, ok)
+	}
+}
+
+func TestScanCaseOnlyMatchIsAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	// "./Helper" matches helper.ts only on a case-insensitive filesystem, so the build is
+	// platform-dependent: honest output is ambiguous, never a clean resolution or a clean miss.
+	writeFile(t, filepath.Join(root, "app.ts"), `import h from "./Helper";`)
+	writeFile(t, filepath.Join(root, "helper.ts"), `export default 1;`)
+
+	graph := scan(t, root)
+
+	if !coverageKinds(graph)[modulegraph.CoverageAmbiguousRelativeImport] {
+		t.Fatalf("a case-only relative match must be ambiguous, got %+v", graph.Coverage)
+	}
+}
+
+func TestScanUnparsedComponentImportDegradesCoverage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	// A .vue/.svelte body contains JavaScript this scanner cannot parse, so it can hide package
+	// imports — unlike a stylesheet, it must degrade coverage.
+	writeFile(t, filepath.Join(root, "app.ts"), `import C from "./Widget.vue";`)
+	writeFile(t, filepath.Join(root, "Widget.vue"), `<script>import axios from "axios";</script>`)
+
+	graph := scan(t, root)
+
+	if !coverageKinds(graph)[modulegraph.CoverageUnsupportedSyntax] {
+		t.Fatalf("importing an unparsed component must degrade coverage, got %+v", graph.Coverage)
+	}
+	for _, m := range graph.Modules {
+		if strings.HasSuffix(m.Path, ".vue") {
+			t.Fatalf("a .vue file must not become a graph module: %+v", graph.Modules)
+		}
+	}
+}
+
+func TestScanHazardsDegradeCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want modulegraph.CoverageIssueKind
+	}{
+		{name: "dynamic require", src: `const m = require(name);`, want: modulegraph.CoverageDynamicRequire},
+		{name: "dynamic import", src: `await import(spec);`, want: modulegraph.CoverageDynamicImport},
+		{name: "eval", src: `eval("code");`, want: modulegraph.CoverageEval},
+		{name: "new Function", src: `new Function("x")();`, want: modulegraph.CoverageNewFunction},
+		{name: "require.context", src: `require.context("./x", true);`, want: modulegraph.CoverageRequireContext},
+		{name: "import.meta.glob", src: `import.meta.glob("./x/*.ts");`, want: modulegraph.CoverageImportMetaGlob},
+		{name: "createRequire", src: `const r = createRequire(import.meta.url);`, want: modulegraph.CoverageModuleCreateRequire},
+		{name: "malformed source", src: `import a from "unterminated`, want: modulegraph.CoverageMalformedSource},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "app.ts"), test.src)
+
+			graph := scan(t, root)
+			if !coverageKinds(graph)[test.want] {
+				t.Fatalf("expected coverage kind %q, got %+v", test.want, graph.Coverage)
+			}
+		})
+	}
+}
+
+func TestScanSkipsDependencyAndBuildDirectories(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "app.ts"), `import a from "lodash";`)
+	// A dependency's own imports are not evidence that FIRST-PARTY code uses it.
+	writeFile(t, filepath.Join(root, "node_modules", "lodash", "index.js"), `require("hidden-transitive");`)
+	writeFile(t, filepath.Join(root, "dist", "bundle.js"), `require("built-artifact");`)
+	writeFile(t, filepath.Join(root, ".git", "hook.js"), `require("git-internal");`)
+
+	graph := scan(t, root)
+
+	if len(graph.Modules) != 1 || graph.Modules[0].Path != "src/app.ts" {
+		t.Fatalf("only first-party source may be scanned, got %+v", graph.Modules)
+	}
+	for _, edge := range graph.Edges {
+		if edge.Specifier == "hidden-transitive" || edge.Specifier == "built-artifact" || edge.Specifier == "git-internal" {
+			t.Fatalf("edge from an excluded directory leaked into the graph: %+v", edge)
+		}
+	}
+}
+
+func TestScanDeclarationOnlyModules(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "types.d.ts"), `import type { T } from "some-types";`)
+	writeFile(t, filepath.Join(root, "app.ts"), `export const x = 1;`)
+
+	graph := scan(t, root)
+
+	var declaration *modulegraph.Module
+	for i := range graph.Modules {
+		if graph.Modules[i].Path == "types.d.ts" {
+			declaration = &graph.Modules[i]
+		}
+	}
+	if declaration == nil || !declaration.DeclarationOnly {
+		t.Fatalf("types.d.ts must be flagged declaration-only, got %+v", graph.Modules)
+	}
+	// The edge is preserved for provenance and marked type-only; a later analyzer decides it is not
+	// runtime evidence.
+	edge, ok := edgeFor(graph, "types.d.ts", "some-types")
+	if !ok || !edge.TypeOnly {
+		t.Fatalf("declaration import must be recorded type-only: %+v (ok=%v)", edge, ok)
+	}
+}
+
+func TestScanSymlinksAreNeverFollowed(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is restricted on windows")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "secret.ts"), `import a from "exfiltrated";`)
+	writeFile(t, filepath.Join(root, "app.ts"), `export const x = 1;`)
+	if err := os.Symlink(filepath.Join(outside, "secret.ts"), filepath.Join(root, "linked.ts")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	graph := scan(t, root)
+
+	for _, m := range graph.Modules {
+		if m.Path == "linked.ts" {
+			t.Fatal("a symlinked file must never be scanned as a module")
+		}
+	}
+	for _, edge := range graph.Edges {
+		if edge.Specifier == "exfiltrated" {
+			t.Fatal("a symlink was followed outside the scan root")
+		}
+	}
+	if !coverageKinds(graph)[modulegraph.CoverageSymlink] {
+		t.Fatalf("an unfollowed symlink must be recorded as coverage, got %+v", graph.Coverage)
+	}
+}
+
+func TestScanInvalidUTF8DegradesCoverage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "app.ts"), `export const x = 1;`)
+	if err := os.WriteFile(filepath.Join(root, "broken.ts"), []byte{0xff, 0xfe, 'i', 'm', 'p', 0x80}, 0o600); err != nil {
+		t.Fatalf("write invalid utf-8: %v", err)
+	}
+
+	graph := scan(t, root)
+
+	if !coverageKinds(graph)[modulegraph.CoverageInvalidUTF8] {
+		t.Fatalf("non-UTF-8 source must degrade coverage, got %+v", graph.Coverage)
+	}
+}
+
+func TestScanBudgets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("file count budget", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		for _, name := range []string{"a.ts", "b.ts", "c.ts"} {
+			writeFile(t, filepath.Join(root, name), `import x from "pkg";`)
+		}
+		limits := defaultLimits()
+		limits.maxFiles = 2
+		scanner, err := newWithLimits(limits)
+		if err != nil {
+			t.Fatalf("newWithLimits: %v", err)
+		}
+		graph, err := scanner.Scan(context.Background(), root)
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !coverageKinds(graph)[modulegraph.CoverageFileCountBudgetExceeded] {
+			t.Fatalf("exceeding the file budget must degrade coverage, got %+v", graph.Coverage)
+		}
+	})
+
+	t.Run("per-file byte budget", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "small.ts"), `import x from "pkg";`)
+		writeFile(t, filepath.Join(root, "big.ts"), strings.Repeat("// padding\n", 200))
+		limits := defaultLimits()
+		limits.maxFileBytes = 64
+		scanner, err := newWithLimits(limits)
+		if err != nil {
+			t.Fatalf("newWithLimits: %v", err)
+		}
+		graph, err := scanner.Scan(context.Background(), root)
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !coverageKinds(graph)[modulegraph.CoverageFileTooLarge] {
+			t.Fatalf("an oversized file must degrade coverage, got %+v", graph.Coverage)
+		}
+	})
+
+	t.Run("total byte budget", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		for _, name := range []string{"a.ts", "b.ts", "c.ts"} {
+			writeFile(t, filepath.Join(root, name), strings.Repeat("// pad\n", 20))
+		}
+		limits := defaultLimits()
+		limits.maxTotalBytes = 100
+		scanner, err := newWithLimits(limits)
+		if err != nil {
+			t.Fatalf("newWithLimits: %v", err)
+		}
+		graph, err := scanner.Scan(context.Background(), root)
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !coverageKinds(graph)[modulegraph.CoverageTotalByteBudgetExceeded] {
+			t.Fatalf("exceeding the total byte budget must degrade coverage, got %+v", graph.Coverage)
+		}
+		// The unparsed modules are still reported as modules: they exist, their imports are unknown.
+		if len(graph.Modules) != 3 {
+			t.Fatalf("modules beyond the byte budget must still be listed, got %d", len(graph.Modules))
+		}
+	})
+
+	t.Run("invalid limits are rejected", func(t *testing.T) {
+		t.Parallel()
+		limits := defaultLimits()
+		limits.maxFiles = 0
+		if _, err := newWithLimits(limits); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("expected ErrValidation for non-positive limits, got %v", err)
+		}
+	})
+}
+
+func TestScanHardNoCoverageConditions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty root", func(t *testing.T) {
+		t.Parallel()
+		if _, err := New().Scan(context.Background(), "  "); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("expected ErrValidation for a blank root, got %v", err)
+		}
+	})
+
+	t.Run("nil context", func(t *testing.T) {
+		t.Parallel()
+		//lint:ignore SA1012 deliberately asserting the nil-context guard
+		if _, err := New().Scan(nil, t.TempDir()); !errors.Is(err, shared.ErrValidation) { //nolint:staticcheck
+			t.Fatalf("expected ErrValidation for a nil context, got %v", err)
+		}
+	})
+
+	t.Run("missing root", func(t *testing.T) {
+		t.Parallel()
+		if _, err := New().Scan(context.Background(), filepath.Join(t.TempDir(), "absent")); err == nil {
+			t.Fatal("expected an error for a missing root")
+		}
+	})
+
+	t.Run("file as root", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		file := filepath.Join(root, "app.ts")
+		writeFile(t, file, `export const x = 1;`)
+		if _, err := New().Scan(context.Background(), file); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("expected ErrValidation when the root is a file, got %v", err)
+		}
+	})
+
+	t.Run("no javascript source", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "main.go"), `package main`)
+		// No JS/TS at all is NO COVERAGE (not a JavaScript project), never an empty clean graph that a
+		// later analyzer could read as "nothing is imported".
+		if _, err := New().Scan(context.Background(), root); !errors.Is(err, shared.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound when there is no JS/TS source, got %v", err)
+		}
+	})
+
+	t.Run("cancelled context", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "app.ts"), `export const x = 1;`)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, err := New().Scan(ctx, root); !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	})
+}
+
+func TestScanIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.ts"), `import x from "pkg-a"; import "./b";`)
+	writeFile(t, filepath.Join(root, "src", "b.ts"), `import y from "pkg-b"; import "./c";`)
+	writeFile(t, filepath.Join(root, "src", "c.ts"), `import z from "pkg-c"; require(dynamic);`)
+	writeFile(t, filepath.Join(root, "src", "z.tsx"), `import w from "pkg-d";`)
+
+	first := scan(t, root)
+	second := scan(t, root)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("repeated scans of the same tree must produce identical graphs")
+	}
+}
+
+func TestScanCycleIsRepresentable(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.ts"), `import "./b"; import x from "pkg";`)
+	writeFile(t, filepath.Join(root, "b.ts"), `import "./a";`)
+
+	graph := scan(t, root)
+
+	// Every module in a cycle has an incoming edge, so a cyclic project has no structural roots. This
+	// must not crash or loop; a later analyzer handles rootless graphs.
+	if len(graph.Roots) != 0 {
+		t.Fatalf("a pure cycle has no structural roots, got %v", graph.Roots)
+	}
+	if len(graph.Edges) != 3 {
+		t.Fatalf("expected 3 edges (a→b, b→a, a→pkg), got %d: %+v", len(graph.Edges), graph.Edges)
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_ts.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_ts.go
@@ -226,25 +226,15 @@ func observedTSAliasTarget(target string, modules map[string]struct{}, mode alia
 	}
 
 	// Extension substitution is valid across TypeScript module-resolution modes
-	// when the paths target names a JavaScript-family file explicitly.
-	var substitutions []string
-	switch {
-	case strings.HasSuffix(target, ".mjs"):
-		base := strings.TrimSuffix(target, ".mjs")
-		substitutions = []string{base + ".mts", base + ".d.mts"}
-	case strings.HasSuffix(target, ".cjs"):
-		base := strings.TrimSuffix(target, ".cjs")
-		substitutions = []string{base + ".cts", base + ".d.cts"}
-	case strings.HasSuffix(target, ".js"):
-		base := strings.TrimSuffix(target, ".js")
-		substitutions = []string{base + ".ts", base + ".tsx", base + ".d.ts"}
-	case strings.HasSuffix(target, ".jsx"):
-		base := strings.TrimSuffix(target, ".jsx")
-		substitutions = []string{base + ".tsx", base + ".d.ts"}
-	}
-	for _, candidate := range substitutions {
-		if _, ok := modules[candidate]; ok {
-			return true
+	// when the paths target names a JavaScript-family file explicitly. The rewrite
+	// table lives in the domain so the source scanner (phase R1) and this resolver
+	// cannot disagree about which file a specifier names.
+	if ext := path.Ext(target); ext != "" {
+		base := strings.TrimSuffix(target, ext)
+		for _, rewrite := range jsresolution.EmittedExtensionCandidates(ext) {
+			if _, ok := modules[base+rewrite]; ok {
+				return true
+			}
 		}
 	}
 	if mode != aliasModuleResolutionExtensionless {
@@ -253,7 +243,7 @@ func observedTSAliasTarget(target string, modules map[string]struct{}, mode alia
 	if path.Ext(target) != "" {
 		return false
 	}
-	for _, ext := range [...]string{".ts", ".tsx", ".d.ts", ".js", ".jsx"} {
+	for _, ext := range jsresolution.ModuleSourceExtensions() {
 		if _, ok := modules[target+ext]; ok {
 			return true
 		}

--- a/internal/usecase/fleetagentuc/service_test.go
+++ b/internal/usecase/fleetagentuc/service_test.go
@@ -148,6 +148,9 @@ func (f *fakeCanceller) Claim(context.Context, shared.ID, shared.ID, int, time.T
 func (f *fakeCanceller) Transition(context.Context, shared.ID, shared.ID, workorder.State, string, workorder.State, time.Time) error {
 	return nil
 }
+func (f *fakeCanceller) ListByTenant(context.Context, shared.ID) ([]*workorder.WorkOrder, error) {
+	return nil, nil
+}
 func (f *fakeCanceller) CancelForAgent(_ context.Context, _, _ shared.ID, _ string, _ time.Time) (int, error) {
 	f.cancelled++
 	return 3, nil


### PR DESCRIPTION
Parent epic: #378. Unblocks #400, #401 and the later integration phases.

## Why this PR exists

#379 is closed, but it shipped only the `modulegraph` **domain types** and the `ports.JSImportScanner` **port** — there was no implementation. The port had **zero implementers**, so nothing in the repository could produce a `modulegraph.Graph`, and every downstream phase of #378 had nothing to consume. This adds the scanner.

Source-only and in-process, like `pyimports`: it lexes bytes and never executes project code, package managers, bundlers or lifecycle scripts, never touches the network, and never leaves the scan root.

## The load-bearing invariant

An unobservable module load must degrade **coverage**, never vanish. A later analyzer may read "no edge" as proof a dependency is unused **only** when the graph reports no coverage issues — because a silent miss becomes a false `unreachable`, which suppresses a real vulnerability.

Two review rounds (security + architecture) attacked exactly this. Every construct below is now a hazard with a regression test:

- indirect `require` — aliased, sequence-expression, optional-call (which stays a real **edge**), passed as a value, `typeof` guard
- `module.require`, `require.main.require`, `require.cache`, unknown `require.*`
- unicode-escaped identifiers (`require`)
- every `eval`/`Function` shape, **including aliasing** (`const F = Function`) and `globalThis.eval`
- the AMD / `requirejs` / `importScripts` / webpack / SystemJS / `Worker` / `dlopen` families **and their aliases**
- computed loader access (`module["require"](...)`)
- undecoded escapes in a specifier → **no edge** (a wrong package name is worse than none) + hazard
- unparsed single-file components (`.vue`/`.svelte`), extension-less executables, and skipped directories that contain source

And the converse is tested too: unrelated methods (`vm.require`, `db.define`), and prose containing loader **words** (`Approvals required (`) must **not** degrade coverage — a false hazard would make a negative proof impossible for the very projects this serves.

## Notable defects the reviews caught

- **JSX closing tag `</div>` was lexed as a regex opener**, and the failure path discarded the rest of the file — measured on this repo's own frontend: **68 of 106 modules** falsely `malformed-source`, losing real edges.
- **A backslash specifier** (`.\util`) made the scanner disagree with the domain classifier; the resolver rejects the **whole graph** on that mismatch, so one Windows-style import anywhere would abort every scan.
- **Regions the lexer skipped** (template substitutions, JSX attribute expressions) were validated by a substring list narrower than the loader vocabulary. Fixed structurally: every region that can contain code is now **lexed as code**, so `` `v${require("lodash")}` `` and `<Route element={lazy(() => import("./x"))} />` yield real edges.
- Unbounded edge set (in-process OOM), unbounded nesting, absolute host paths in errors (golden rule 3), silent truncation when a file grows mid-read.

## Also in this PR

- **Hoisted the module-candidate and emitted-extension tables into `domain/jsresolution`** and consumed them from both the scanner and the existing resolver. They had **diverged** (different orderings), so the same specifier could resolve to different modules across phases.
- **Fixed a build break I introduced in #454**: a fake in `fleetagentuc` was missing `WorkOrderStore.ListByTenant`. `main` was red for that package.

## Verification

Measured on this repository's own frontend (106 modules): **495 edges, 308 resolved, 2 coverage issues** — both genuine (a `.tmp` build-artifact path that does not exist; `web/dist`).

`go build ./...` · `go vet ./...` · **golangci-lint 0 issues** · full suite **171 packages, 0 failures** · **213 subtests** under `-race` · plus an end-to-end contract test proving the graph is *accepted* by the already-merged resolver (which hard-errors on an inconsistent graph) and that a clean project yields `Complete: true`, the precondition for any negative proof.
