### PR TITLE
feat(reachability): correlate JS/TS imports to SBOM components by exact purl (#400)

### DIFF
--- a/internal/domain/jsresolution/jsresolution.go
+++ b/internal/domain/jsresolution/jsresolution.go
@@ -112,6 +112,18 @@ type MetadataDeclaration struct {
 }
 
 // PackageMetadata is package.json-derived first-party package metadata.
+// DependencySpec is one declared dependency of a package: the name a source file imports, and the raw
+// specification the manifest declares for it.
+//
+// The spec matters for identity because npm lets a dependency be ALIASED
+// ("lodash": "npm:lodash-es@^4") or fetched from somewhere other than the registry (file:, link:,
+// workspace:, git+ssh:, github:, patch:). In both cases the imported name is NOT the package name, so
+// correlating a specifier to a same-named component would attach the wrong identity.
+type DependencySpec struct {
+	Name string
+	Spec string
+}
+
 type PackageMetadata struct {
 	Name       string
 	Version    string
@@ -119,6 +131,8 @@ type PackageMetadata struct {
 	Private    bool
 	Workspace  bool
 	DeclaredBy []MetadataDeclaration
+	// Dependencies are the package's declared dependencies, sorted by name and deduplicated.
+	Dependencies []DependencySpec
 }
 
 // Inventory is the deterministic offline package/workspace metadata inventory

--- a/internal/domain/jsresolution/normalize.go
+++ b/internal/domain/jsresolution/normalize.go
@@ -86,6 +86,7 @@ func NormalizeInventory(in Inventory) (Inventory, error) {
 			}
 		}
 		pkg.Version = strings.TrimSpace(pkg.Version)
+		pkg.Dependencies = normalizeDependencies(pkg.Dependencies)
 		pkg.DeclaredBy, err = normalizeDeclarations(pkg.DeclaredBy)
 		if err != nil {
 			return Inventory{}, fmt.Errorf("normalize declarations for %q: %w", loc, err)
@@ -171,8 +172,14 @@ func normalizeDeclarations(in []MetadataDeclaration) ([]MetadataDeclaration, err
 }
 
 func packageMetadataEqual(a, b PackageMetadata) bool {
-	if a.Name != b.Name || a.Version != b.Version || a.Path != b.Path || a.Private != b.Private || a.Workspace != b.Workspace || len(a.DeclaredBy) != len(b.DeclaredBy) {
+	if a.Name != b.Name || a.Version != b.Version || a.Path != b.Path || a.Private != b.Private || a.Workspace != b.Workspace ||
+		len(a.DeclaredBy) != len(b.DeclaredBy) || len(a.Dependencies) != len(b.Dependencies) {
 		return false
+	}
+	for i := range a.Dependencies {
+		if a.Dependencies[i] != b.Dependencies[i] {
+			return false
+		}
 	}
 	for i := range a.DeclaredBy {
 		if a.DeclaredBy[i] != b.DeclaredBy[i] {
@@ -193,4 +200,34 @@ func deduplicateCoverage(in []CoverageIssue) []CoverageIssue {
 		}
 	}
 	return out
+}
+
+// normalizeDependencies sorts declared dependencies by name and removes exact duplicates, so inventory
+// output does not depend on manifest key order.
+func normalizeDependencies(in []DependencySpec) []DependencySpec {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]DependencySpec, 0, len(in))
+	for _, dep := range in {
+		name := strings.TrimSpace(dep.Name)
+		if name == "" {
+			continue
+		}
+		out = append(out, DependencySpec{Name: name, Spec: strings.TrimSpace(dep.Spec)})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Spec < out[j].Spec
+	})
+	result := out[:0]
+	for i, dep := range out {
+		if i > 0 && dep == out[i-1] {
+			continue
+		}
+		result = append(result, dep)
+	}
+	return result
 }

--- a/internal/infrastructure/tools/jsimports/pipeline_contract_test.go
+++ b/internal/infrastructure/tools/jsimports/pipeline_contract_test.go
@@ -70,16 +70,15 @@ require(computed);
 	// Node built-ins must never be mistaken for npm dependencies.
 	assertContains(t, byStatus[jsresolution.StatusBuiltin], "node:fs")
 	assertContains(t, byStatus[jsresolution.StatusBuiltin], "path")
-	// A first-party workspace package must never be classified as a third-party component. At this
-	// phase the resolver reports it as AMBIGUOUS with a reason (workspace linking and a same-named
-	// registry package are indistinguishable without lockfile importer context, which phase R2C adds);
-	// what this test locks is that it is never silently a component.
+	// A first-party workspace package must never be classified as a third-party component. With no SBOM
+	// supplied the resolver cannot rule out a same-named registry package, so it reports AMBIGUOUS with
+	// a reason; what this test locks is that it is never silently a component.
 	assertContains(t, byStatus[jsresolution.StatusAmbiguous], "@workspace/shared")
 	if contains(byStatus[jsresolution.StatusComponent], "@workspace/shared") {
 		t.Error("a local workspace package must never resolve to a third-party component")
 	}
-	// Third-party specifiers stay unresolved at this phase: no SBOM was supplied, and R2C owns
-	// component correlation. What matters is that they are explicit, never silently dropped.
+	// Third-party specifiers stay unresolved here because no SBOM was supplied, so nothing can be
+	// correlated. What matters is that they are explicit, never silently dropped.
 	for _, specifier := range []string{"lodash", "some-types", "commonjs-pkg", "dynamic-pkg"} {
 		if !containsAny(byStatus, specifier) {
 			t.Errorf("specifier %q disappeared from resolution output", specifier)

--- a/internal/infrastructure/tools/jsresolve/aliases_tsconfig.go
+++ b/internal/infrastructure/tools/jsresolve/aliases_tsconfig.go
@@ -25,7 +25,7 @@ func parseTSConfigPaths(rel string, content []byte, limits aliasLimits) ([]alias
 	var issues []jsresolution.CoverageIssue
 	if rawExtends, ok := doc["extends"]; ok && !bytes.Equal(bytes.TrimSpace(rawExtends), []byte("null")) {
 		config.uncertain = true
-		issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: "tsconfig/jsconfig inheritance via extends is not resolved in R2B"})
+		issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: "tsconfig/jsconfig inheritance via extends is not resolved"})
 	}
 	selectionPresent := false
 	for _, key := range []string{"files", "include", "exclude"} {
@@ -68,7 +68,7 @@ func parseTSConfigPaths(rel string, content []byte, limits aliasLimits) ([]alias
 	_, hasBaseURL := compiler["baseUrl"]
 	if selectionPresent && (hasPaths || hasBaseURL) {
 		config.uncertain = true
-		issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: "tsconfig/jsconfig project files/include/exclude membership is not resolved in R2B"})
+		issues = append(issues, jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnsupportedAlias, Path: rel, Detail: "tsconfig/jsconfig project files/include/exclude membership is not resolved"})
 	}
 	configDir := path.Dir(rel)
 	baseDir := configDir

--- a/internal/infrastructure/tools/jsresolve/inventory.go
+++ b/internal/infrastructure/tools/jsresolve/inventory.go
@@ -104,6 +104,7 @@ type packageFile struct {
 	private        bool
 	patterns       []string
 	packageManager string
+	dependencies   []jsresolution.DependencySpec
 }
 
 type workspaceNegationMode uint8
@@ -376,7 +377,7 @@ func (b *InventoryBuilder) Build(ctx context.Context, root string) (jsresolution
 		}
 		inventory.Packages = append(inventory.Packages, jsresolution.PackageMetadata{
 			Name: pkg.name, Version: strings.TrimSpace(pkg.version), Path: dir, Private: pkg.private,
-			Workspace: isWorkspace, DeclaredBy: decls,
+			Workspace: isWorkspace, DeclaredBy: decls, Dependencies: pkg.dependencies,
 		})
 	}
 
@@ -765,20 +766,33 @@ func splitPathSegments(value string) []string {
 
 func parsePackageJSON(rel string, content []byte) (packageFile, error) {
 	var raw struct {
-		Name           string          `json:"name"`
-		Version        string          `json:"version"`
-		Private        bool            `json:"private"`
-		Workspaces     json.RawMessage `json:"workspaces"`
-		PackageManager string          `json:"packageManager"`
+		Name           string            `json:"name"`
+		Version        string            `json:"version"`
+		Private        bool              `json:"private"`
+		Workspaces     json.RawMessage   `json:"workspaces"`
+		PackageManager string            `json:"packageManager"`
+		Dependencies   map[string]string `json:"dependencies"`
+		DevDeps        map[string]string `json:"devDependencies"`
+		OptionalDeps   map[string]string `json:"optionalDependencies"`
+		PeerDeps       map[string]string `json:"peerDependencies"`
 	}
 	if err := json.Unmarshal(content, &raw); err != nil {
 		return packageFile{}, fmt.Errorf("parse package.json: %w", err)
 	}
 	patterns, workspaceErr := parseJSONWorkspaces(raw.Workspaces)
 	dir := path.Dir(rel)
+	// Dependency SPECS decide package identity, not just presence: npm lets a dependency be aliased
+	// ("lodash": "npm:lodash-es@^4") or fetched from outside the registry, in which case the imported
+	// name is not the package name.
+	var deps []jsresolution.DependencySpec
+	for _, group := range []map[string]string{raw.Dependencies, raw.DevDeps, raw.OptionalDeps, raw.PeerDeps} {
+		for name, spec := range group {
+			deps = append(deps, jsresolution.DependencySpec{Name: name, Spec: spec})
+		}
+	}
 	pkg := packageFile{
 		file: rel, dir: dir, name: raw.Name, version: raw.Version, private: raw.Private,
-		patterns: patterns, packageManager: raw.PackageManager,
+		patterns: patterns, packageManager: raw.PackageManager, dependencies: deps,
 	}
 	if workspaceErr != nil {
 		return pkg, workspaceErr

--- a/internal/infrastructure/tools/jsresolve/resolver.go
+++ b/internal/infrastructure/tools/jsresolve/resolver.go
@@ -11,10 +11,11 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
-// Resolve implements source-only R2B package identity resolution. The SBOM is
-// intentionally unused in this slice; exact component/PURL correlation belongs
-// to R2C and unresolved third-party package roots remain explicit until then.
-func (r *Resolver) Resolve(ctx context.Context, root string, graph modulegraph.Graph, _ *sbom.SBOM) (jsresolution.Result, error) {
+// Resolve implements source-only package identity resolution. Third-party package roots are correlated
+// to SBOM components by EXACT purl: one resolved version is a deterministic identity, several stay
+// ambiguous with every candidate preserved, and none stays explicitly unresolved. The resolver still
+// classifies identity only — it never decides reachability and never mints a judgment.
+func (r *Resolver) Resolve(ctx context.Context, root string, graph modulegraph.Graph, doc *sbom.SBOM) (jsresolution.Result, error) {
 	if ctx == nil {
 		return jsresolution.Result{}, fmt.Errorf("%w: context is required", shared.ErrValidation)
 	}
@@ -84,6 +85,7 @@ func (r *Resolver) Resolve(ctx context.Context, root string, graph modulegraph.G
 		modulePaths[module.Path] = struct{}{}
 	}
 	workspaceByName := indexWorkspacesByName(inventory.Packages)
+	components := newComponentIndex(doc, r.limits.maxComponents, r.limits.maxCandidates, &coverage)
 
 	result := jsresolution.Result{GraphCoverage: append([]modulegraph.CoverageIssue(nil), normalizedGraph.Coverage...)}
 	for _, edge := range normalizedGraph.Edges {
@@ -119,34 +121,33 @@ func (r *Resolver) Resolve(ctx context.Context, root string, graph modulegraph.G
 			resolution.Status = jsresolution.StatusBuiltin
 			resolution.Package = jsresolution.PackageIdentity{Name: classified.BuiltinName}
 		case jsresolution.SpecifierPackageImport:
-			resolution = r.resolvePackageImport(ctx, resolution, aliases.mappings, aliases.packageScopes, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, &aliasWork, &candidateWork, &coverage)
+			resolution = r.resolvePackageImport(ctx, resolution, aliases.mappings, aliases.packageScopes, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, components, &aliasWork, &candidateWork, &coverage)
 		case jsresolution.SpecifierPackage:
-			if aliasResolution, handled := r.resolveTSPaths(ctx, resolution, aliases.mappings, aliases.configs, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, modulePaths, &aliasWork, &candidateWork, &coverage); handled {
+			if aliasResolution, handled := r.resolveTSPaths(ctx, resolution, aliases.mappings, aliases.configs, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, components, modulePaths, &aliasWork, &candidateWork, &coverage); handled {
 				resolution = aliasResolution
 			} else if self, ok := packageForRepositoryTarget(inventory.Packages, resolution.From); ok && self.Name == classified.PackageName {
-				// A same-name bare import may be a Node package self-reference, whose
-				// legality and subpath identity depend on package.json exports. R2B
-				// does not implement exports maps, so do not let R2C mistake it for
-				// an ordinary third-party package with the same name.
+				// A same-name bare import may be a Node package self-reference, whose legality and
+				// subpath identity depend on package.json exports. Exports maps are not implemented, so
+				// this must not be mistaken for an ordinary third-party package of the same name.
 				resolution.Status = jsresolution.StatusUnresolved
 				resolution.Package = jsresolution.PackageIdentity{Name: classified.PackageName}
-				resolution.Reason = "same-package self-reference requires package.json exports semantics that R2B does not resolve"
+				resolution.Reason = "same-package self-reference requires package.json exports semantics this resolver does not implement"
 				coverage.add(jsresolution.CoverageIssue{
 					Kind: jsresolution.CoverageUnresolvedSpecifier, Path: resolution.From,
 					Detail: fmt.Sprintf("specifier %q may be a package self-reference", resolution.Specifier),
 				})
 			} else {
-				resolution = r.resolvePackageRoot(resolution, classified.PackageName, workspaceByName, &candidateWork, &coverage)
+				resolution = r.resolvePackageRoot(resolution, classified.PackageName, workspaceByName, inventory.Packages, components, &candidateWork, &coverage)
 			}
 		default:
-			if aliasResolution, handled := r.resolveTSPaths(ctx, resolution, aliases.mappings, aliases.configs, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, modulePaths, &aliasWork, &candidateWork, &coverage); handled {
+			if aliasResolution, handled := r.resolveTSPaths(ctx, resolution, aliases.mappings, aliases.configs, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, components, modulePaths, &aliasWork, &candidateWork, &coverage); handled {
 				resolution = aliasResolution
 			} else {
 				resolution.Status = jsresolution.StatusUnsupported
 				resolution.Reason = "unsupported module specifier form"
 				coverage.add(jsresolution.CoverageIssue{
 					Kind: jsresolution.CoverageUnsupportedSpecifier, Path: edge.From,
-					Detail: fmt.Sprintf("specifier %q is outside the supported source-only R2B forms", edge.Specifier),
+					Detail: fmt.Sprintf("specifier %q is outside the supported source-only specifier forms", edge.Specifier),
 				})
 			}
 		}

--- a/internal/infrastructure/tools/jsresolve/resolver_alias.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_alias.go
@@ -22,6 +22,7 @@ func (r *Resolver) resolveAliasMatches(
 	matches []aliasMapping,
 	workspaces map[string][]jsresolution.PackageIdentity,
 	packages []jsresolution.PackageMetadata,
+	components *componentIndex,
 	modulePaths map[string]struct{},
 	aliasWork *resolverWorkBudget,
 	candidateWork *resolverWorkBudget,
@@ -43,7 +44,7 @@ func (r *Resolver) resolveAliasMatches(
 				return base
 			}
 			expanded := substituteAliasTarget(target, capture)
-			resolved, failure := resolveAliasTargets(mapping, expanded, workspaces, packages, modulePaths, r.limits.maxCandidates)
+			resolved, failure := resolveAliasTargets(mapping, expanded, workspaces, packages, components, modulePaths, r.limits.maxCandidates)
 			if len(resolved) > 0 {
 				if !candidateWork.consumeN(len(resolved)) {
 					return markCandidateBudgetExceeded(base, candidateWork, coverage, r.limits.maxCandidateWork)
@@ -106,6 +107,7 @@ func resolveAliasTargets(
 	target string,
 	workspaces map[string][]jsresolution.PackageIdentity,
 	packages []jsresolution.PackageMetadata,
+	components *componentIndex,
 	modulePaths map[string]struct{},
 	maxCandidates int,
 ) ([]resolvedAliasTarget, jsresolution.CoverageIssueKind) {
@@ -116,24 +118,63 @@ func resolveAliasTargets(
 			return []resolvedAliasTarget{{status: jsresolution.StatusBuiltin, identity: jsresolution.PackageIdentity{Name: classified.BuiltinName}, reason: "resolved through package.json imports"}}, ""
 		case jsresolution.SpecifierPackage:
 			local := workspaces[classified.PackageName]
+			registry, _ := components.lookup(classified.PackageName)
 			if len(local) == 0 {
-				return []resolvedAliasTarget{{status: jsresolution.StatusUnresolved, identity: jsresolution.PackageIdentity{Name: classified.PackageName}, reason: "package.json imports target is an npm package root; SBOM correlation is deferred to R2C"}}, ""
+				// An imports target naming a third-party package is correlated exactly like a bare
+				// import: one component version is a deterministic identity, several stay ambiguous,
+				// and none degrades coverage rather than silently disappearing.
+				switch len(registry) {
+				case 0:
+					return []resolvedAliasTarget{{
+						status:   jsresolution.StatusUnresolved,
+						identity: jsresolution.PackageIdentity{Name: classified.PackageName},
+						reason:   "package.json imports target names an npm package with no matching sbom component",
+					}}, jsresolution.CoverageMissingSBOMComponent
+				case 1:
+					return []resolvedAliasTarget{{
+						status:   jsresolution.StatusComponent,
+						identity: registry[0],
+						reason:   "package.json imports target correlated to an sbom component",
+					}}, ""
+				default:
+					if len(registry) >= maxCandidates {
+						return nil, jsresolution.CoverageMetadataBudgetExceeded
+					}
+					out := make([]resolvedAliasTarget, 0, len(registry))
+					for _, candidate := range registry {
+						out = append(out, resolvedAliasTarget{
+							status:   jsresolution.StatusUnresolved,
+							identity: candidate,
+							reason:   "package.json imports target matches multiple sbom component versions",
+						})
+					}
+					return out, jsresolution.CoverageAmbiguousSBOMComponent
+				}
 			}
-			// A package.json imports target names a package, not a concrete
-			// workspace path. Without importer/lockfile selection, a same-name
-			// registry package remains viable just as it does for a bare import.
-			if len(local) >= maxCandidates {
+			// A package.json imports target names a package, not a concrete workspace path. Without
+			// importer/lockfile selection, a same-name registry package remains viable just as it does
+			// for a bare import.
+			if len(local)+len(registry) >= maxCandidates {
 				return nil, jsresolution.CoverageMetadataBudgetExceeded
 			}
-			out := make([]resolvedAliasTarget, 0, len(local)+1)
+			out := make([]resolvedAliasTarget, 0, len(local)+len(registry)+1)
 			for _, candidate := range local {
 				out = append(out, resolvedAliasTarget{status: jsresolution.StatusWorkspace, identity: candidate, reason: "package.json imports target matches a local workspace"})
 			}
-			out = append(out, resolvedAliasTarget{
-				status:   jsresolution.StatusUnresolved,
-				identity: jsresolution.PackageIdentity{Name: classified.PackageName},
-				reason:   "package.json imports target may resolve to a registry package; importer/lockfile correlation is deferred to R2C",
-			})
+			for _, candidate := range registry {
+				out = append(out, resolvedAliasTarget{
+					status:   jsresolution.StatusUnresolved,
+					identity: candidate,
+					reason:   "package.json imports target may resolve to this registry component; importer context is required to select one",
+				})
+			}
+			if len(registry) == 0 {
+				out = append(out, resolvedAliasTarget{
+					status:   jsresolution.StatusUnresolved,
+					identity: jsresolution.PackageIdentity{Name: classified.PackageName},
+					reason:   "package.json imports target may resolve to a registry package; importer context is required to select one",
+				})
+			}
 			return out, ""
 		default:
 			return nil, jsresolution.CoverageUnsupportedAlias

--- a/internal/infrastructure/tools/jsresolve/resolver_depspec.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_depspec.go
@@ -1,0 +1,117 @@
+package jsresolve
+
+import (
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+)
+
+// A dependency's declared SPEC decides which package an imported name really refers to. npm-family
+// managers support two families that break the "imported name == package name" assumption:
+//
+//   - an ALIAS ("lodash": "npm:lodash-es@^4.17.21"), where the import resolves to a different package;
+//   - a non-registry source (file:, link:, portal:, workspace:, git:, github:, http(s):, patch:), where
+//     the installed code is not the registry package of that name at all.
+//
+// Correlating either to a same-named SBOM component would attach the WRONG identity — and a wrong
+// identity that looks deterministic is worse than no identity, because it silently redirects a later
+// reachability conclusion onto the wrong package.
+
+// specOutcome is what a declared dependency spec means for identity.
+type specOutcome uint8
+
+const (
+	// specRegistry is a plain version range: the imported name IS the package name.
+	specRegistry specOutcome = iota
+	// specAliased redirects the imported name to a different registry package.
+	specAliased
+	// specForeign installs from somewhere other than the registry, so no component correlation is safe.
+	specForeign
+)
+
+// nonRegistryProtocols are dependency-spec prefixes that install from outside the npm registry.
+var nonRegistryProtocols = []string{
+	"file:", "link:", "portal:", "workspace:", "patch:",
+	"git:", "git+", "github:", "gitlab:", "bitbucket:",
+	"http:", "https:", "ssh:",
+}
+
+// classifyDependencySpec interprets a declared dependency spec. For an alias it returns the real
+// package name the import resolves to.
+func classifyDependencySpec(spec string) (specOutcome, string) {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" {
+		return specRegistry, ""
+	}
+	lower := strings.ToLower(trimmed)
+
+	if strings.HasPrefix(lower, "npm:") {
+		// "npm:name@range" — the alias target is everything before the LAST "@" that follows the name.
+		target := strings.TrimSpace(trimmed[len("npm:"):])
+		if target == "" {
+			return specForeign, ""
+		}
+		name := target
+		if at := strings.LastIndex(target, "@"); at > 0 {
+			name = target[:at]
+		}
+		normalized, err := jsresolution.NormalizePackageName(name)
+		if err != nil {
+			// An alias whose target is unusable must not fall back to the imported name.
+			return specForeign, ""
+		}
+		return specAliased, normalized
+	}
+
+	for _, protocol := range nonRegistryProtocols {
+		if strings.HasPrefix(lower, protocol) {
+			return specForeign, ""
+		}
+	}
+	// A bare "owner/repo" shorthand is a GitHub dependency, not a version range.
+	if !strings.ContainsAny(trimmed, "<>=^~*|") && strings.Count(trimmed, "/") == 1 &&
+		!strings.HasPrefix(trimmed, "@") && !startsWithDigit(trimmed) {
+		return specForeign, ""
+	}
+	return specRegistry, ""
+}
+
+func startsWithDigit(s string) bool {
+	return s != "" && s[0] >= '0' && s[0] <= '9'
+}
+
+// declaredSpecFor returns the dependency spec the importer's nearest package.json declares for a
+// package name, and whether that package.json declares it at all.
+func declaredSpecFor(packages []jsresolution.PackageMetadata, importer, packageName string) (string, bool) {
+	owner, ok := packageForRepositoryTarget(packages, importer)
+	if !ok {
+		return "", false
+	}
+	for _, dep := range owner.Dependencies {
+		if strings.EqualFold(dep.Name, packageName) {
+			return dep.Spec, true
+		}
+	}
+	return "", false
+}
+
+// resolveDeclaredIdentity applies the declared dependency spec to a package name before correlation. It
+// returns the name that should actually be correlated, and a non-empty refusal reason when no
+// correlation is safe.
+func resolveDeclaredIdentity(packages []jsresolution.PackageMetadata, importer, packageName string) (string, string) {
+	spec, declared := declaredSpecFor(packages, importer, packageName)
+	if !declared {
+		// The nearest package.json does not declare this dependency. That is normal for a transitive or
+		// hoisted package, and the imported name is then the package name.
+		return packageName, ""
+	}
+	outcome, target := classifyDependencySpec(spec)
+	switch outcome {
+	case specAliased:
+		return target, ""
+	case specForeign:
+		return "", "dependency is declared from a non-registry source, so a same-named component is not its identity"
+	default:
+		return packageName, ""
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_package.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_package.go
@@ -28,24 +28,35 @@ func (r *Resolver) resolvePackageRoot(
 	base jsresolution.ImportResolution,
 	packageName string,
 	workspaces map[string][]jsresolution.PackageIdentity,
+	packages []jsresolution.PackageMetadata,
+	components *componentIndex,
 	candidateWork *resolverWorkBudget,
 	coverage *resolutionCoverageSink,
 ) jsresolution.ImportResolution {
 	local := workspaces[packageName]
 	if len(local) == 0 {
-		base.Status = jsresolution.StatusUnresolved
-		base.Package = jsresolution.PackageIdentity{Name: packageName}
-		base.Reason = "npm package root classified; SBOM component correlation deferred to R2C"
-		return base
+		// The importer's declared dependency spec decides which package the imported NAME refers to: an
+		// npm alias redirects it, and a non-registry source means no component is its identity.
+		target, refusal := resolveDeclaredIdentity(packages, base.From, packageName)
+		if refusal != "" {
+			base.Status = jsresolution.StatusUnresolved
+			base.Package = jsresolution.PackageIdentity{Name: packageName}
+			base.Reason = refusal
+			coverage.add(jsresolution.CoverageIssue{
+				Kind: jsresolution.CoverageUnsupportedSpecifier, Path: base.From,
+				Detail: "dependency " + packageName + " is declared from a non-registry source",
+			})
+			return base
+		}
+		return r.correlateComponent(base, target, components, candidateWork, coverage)
 	}
 
 	// A workspace declaration proves that a local package with this name exists,
 	// but it does not prove that a particular importer resolves to that workspace.
 	// npm-family managers may install a registry package of the same name when an
 	// importer's requested range or lockfile context does not select the local
-	// workspace. R2C owns that importer/lockfile disambiguation. Until then,
-	// preserve both identities rather than turning workspace discovery into false
-	// package identity confidence.
+	// workspace. Preserve BOTH identities rather than turning workspace discovery
+	// into false package identity confidence.
 	if len(local) >= r.limits.maxCandidates {
 		base.Status = jsresolution.StatusUnresolved
 		base.Package = jsresolution.PackageIdentity{Name: packageName}
@@ -56,22 +67,45 @@ func (r *Resolver) resolvePackageRoot(
 		})
 		return base
 	}
-	if !candidateWork.consumeN(len(local) + 1) {
+	registry, _ := components.lookup(packageName)
+	if !candidateWork.consumeN(len(local) + len(registry) + 1) {
 		return markCandidateBudgetExceeded(base, candidateWork, coverage, r.limits.maxCandidateWork)
 	}
 
-	candidates := make([]jsresolution.PackageIdentity, 0, len(local)+1)
+	candidates := make([]jsresolution.PackageIdentity, 0, len(local)+len(registry)+1)
 	candidates = append(candidates, local...)
-	candidates = append(candidates, jsresolution.PackageIdentity{Name: packageName})
+	switch {
+	case len(registry) > 0:
+		// The SBOM names concrete registry versions; carry those exact identities as the alternative to
+		// the workspace rather than a bare name.
+		candidates = append(candidates, registry...)
+	case components.isSupplied() && components.isComplete():
+		// A COMPLETE SBOM that lists no package of this name is positive evidence that no registry
+		// package was installed, so the local workspace is the only identity that exists. Keeping a
+		// bare-name alternative here would leave the import permanently ambiguous and block every later
+		// negative conclusion for a perfectly observable monorepo.
+	default:
+		// Without an SBOM, or with a partial one, a same-named registry package remains viable and must
+		// stay in the candidate set.
+		candidates = append(candidates, jsresolution.PackageIdentity{Name: packageName})
+	}
 	sort.Slice(candidates, func(i, j int) bool { return identityLess(candidates[i], candidates[j]) })
 	candidates = deduplicatePackageIdentities(candidates)
 
+	if len(candidates) == 1 {
+		// Only the workspace remains: the local package is the identity.
+		base.Status = jsresolution.StatusWorkspace
+		base.Package = candidates[0]
+		base.Reason = ""
+		return base
+	}
+
 	base.Status = jsresolution.StatusAmbiguous
 	base.Candidates = candidates
-	base.Reason = "package name matches a local workspace, but importer and lockfile context are required to distinguish workspace linking from a registry package"
+	base.Reason = "package name matches a local workspace and a registry identity; importer and lockfile context are required to select one"
 	coverage.add(jsresolution.CoverageIssue{
 		Kind: jsresolution.CoverageUnresolvedSpecifier, Path: base.From,
-		Detail: fmt.Sprintf("specifier %q matches local workspace %q but importer/lockfile selection is deferred to R2C", base.Specifier, packageName),
+		Detail: fmt.Sprintf("specifier %q matches local workspace %q and a same-named registry identity", base.Specifier, packageName),
 	})
 	return base
 }
@@ -84,6 +118,7 @@ func (r *Resolver) resolvePackageImport(
 	scopeDiscoveryComplete bool,
 	workspaces map[string][]jsresolution.PackageIdentity,
 	packages []jsresolution.PackageMetadata,
+	components *componentIndex,
 	aliasWork *resolverWorkBudget,
 	candidateWork *resolverWorkBudget,
 	coverage *resolutionCoverageSink,
@@ -129,5 +164,5 @@ func (r *Resolver) resolvePackageImport(
 		coverage.add(jsresolution.CoverageIssue{Kind: jsresolution.CoverageUnresolvedAlias, Path: base.From, Detail: fmt.Sprintf("package import %q could not be resolved in package scope %q", base.Specifier, scope.scopeDir)})
 		return base
 	}
-	return r.resolveAliasMatches(ctx, base, matches, workspaces, packages, nil, aliasWork, candidateWork, coverage)
+	return r.resolveAliasMatches(ctx, base, matches, workspaces, packages, components, nil, aliasWork, candidateWork, coverage)
 }

--- a/internal/infrastructure/tools/jsresolve/resolver_sbom.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_sbom.go
@@ -1,0 +1,329 @@
+package jsresolve
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// npmPURLPrefix is the package-URL type prefix for the npm ecosystem. A component of any other
+// ecosystem must never be correlated to a JavaScript import.
+const npmPURLPrefix = "pkg:npm/"
+
+// componentIndex is the npm slice of a normalized SBOM, indexed by package name for exact-PURL
+// correlation (#400).
+//
+// Both sides of the comparison are normalized through jsresolution.NormalizePackageName, which lowercases:
+// a component PURL's name is normalized when the index is built, and a specifier's package root is
+// normalized when it is classified. Comparing the RAW forms would silently miss a mixed-case package, and a
+// silent miss here becomes a dependency that looks unused.
+type componentIndex struct {
+	// byName maps the component's EXACT package name to its identities, sorted and deduplicated.
+	byName map[string][]jsresolution.PackageIdentity
+	// byFoldedName maps the lowercased name to the exact names that fold to it. npm hosts distinct
+	// packages that differ only in case (JSONStream and jsonstream are different packages), so folding
+	// is a last-resort rescue that must be REPORTED, never a silent identity swap.
+	byFoldedName map[string][]string
+	// supplied records whether an SBOM was provided at all. Without one, correlation is IMPOSSIBLE,
+	// which is a different fact from "the SBOM does not contain this package".
+	supplied bool
+	// complete is false when the index itself is partial (budget exceeded, unparseable PURLs).
+	complete bool
+	// dropped records why a package name present in the SBOM produced no usable identity, so an import
+	// of it is not reported as "absent from the sbom" when the truth is subtler.
+	dropped map[string]string
+}
+
+// newComponentIndex builds the npm component index from doc. It never fails: a component it cannot
+// interpret produces a coverage issue rather than an error, because a partial index must degrade the
+// resolution rather than abort the scan.
+func newComponentIndex(doc *sbom.SBOM, maxComponents, maxCandidates int, coverage *resolutionCoverageSink) *componentIndex {
+	index := &componentIndex{
+		byName:       map[string][]jsresolution.PackageIdentity{},
+		byFoldedName: map[string][]string{},
+		dropped:      map[string]string{},
+		complete:     true,
+	}
+	if doc == nil {
+		return index
+	}
+	index.supplied = true
+
+	components := doc.Components
+	if len(components) > maxComponents {
+		// The SBOM is the only unbounded input here. Degrade rather than abort, but never index a
+		// truncated prefix silently: a package beyond the cut would look absent from the SBOM.
+		index.complete = false
+		components = components[:maxComponents]
+		coverage.add(jsresolution.CoverageIssue{
+			Kind:   jsresolution.CoverageMetadataBudgetExceeded,
+			Detail: fmt.Sprintf("sbom component budget exceeded (%d), so component correlation is partial", maxComponents),
+		})
+	}
+
+	unparseable := 0
+	unresolvedVersion := 0
+	for i := range components {
+		component := components[i]
+		if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(component.PURL)), npmPURLPrefix) {
+			// Another ecosystem, or a component with no PURL: not correlatable to a JS import.
+			continue
+		}
+		name, version, ok := parseNPMPURL(component.PURL)
+		if !ok {
+			unparseable++
+			continue
+		}
+		// A floating version ("latest", a range) is not a resolved identity, so it cannot be the exact
+		// subject a later reachability analyzer needs.
+		if !sbom.IsResolvedVersion(version) {
+			unresolvedVersion++
+			index.dropped[strings.ToLower(name)] = "listed only with an unresolved version"
+			continue
+		}
+		index.byName[name] = append(index.byName[name], jsresolution.PackageIdentity{
+			Name:    name,
+			Version: version,
+			PURL:    component.PURL,
+		})
+		folded := strings.ToLower(name)
+		if folded != name {
+			index.byFoldedName[folded] = append(index.byFoldedName[folded], name)
+		}
+	}
+
+	if unparseable > 0 {
+		index.complete = false
+		coverage.add(jsresolution.CoverageIssue{
+			Kind:   jsresolution.CoverageMissingSBOMComponent,
+			Detail: fmt.Sprintf("%d npm component purls could not be interpreted, so correlation is partial", unparseable),
+		})
+	}
+	if unresolvedVersion > 0 {
+		index.complete = false
+		coverage.add(jsresolution.CoverageIssue{
+			Kind:   jsresolution.CoverageAmbiguousSBOMComponent,
+			Detail: fmt.Sprintf("%d npm components carry an unresolved version and cannot be exact subjects", unresolvedVersion),
+		})
+	}
+
+	// Iterate in sorted name order: coverage issues land in a CAPPED sink, so map iteration order would
+	// decide which issues survive truncation and the output would stop being reproducible.
+	names := make([]string, 0, len(index.byName))
+	for name := range index.byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		identities := index.byName[name]
+		sort.Slice(identities, func(i, j int) bool { return identityLess(identities[i], identities[j]) })
+		identities = deduplicatePackageIdentities(identities)
+		if len(identities) > maxCandidates {
+			// Refuse to select from a truncated candidate set: keep the name unresolved instead, and
+			// remember why so the import's reason does not claim the package is absent from the SBOM.
+			index.complete = false
+			index.dropped[name] = "more component versions than the candidate budget allows"
+			coverage.add(jsresolution.CoverageIssue{
+				Kind:   jsresolution.CoverageAmbiguousSBOMComponent,
+				Detail: fmt.Sprintf("package %q has more component versions than the candidate budget allows", name),
+			})
+			delete(index.byName, name)
+			continue
+		}
+		index.byName[name] = identities
+	}
+	return index
+}
+
+// lookup returns the component identities for a package name, preferring an EXACT-case match.
+//
+// It reports foldedMatch when the result was found only by lowercasing. npm hosts distinct packages
+// whose names differ only in case, so a folded hit is a plausible-but-unproven identity: the caller must
+// degrade coverage rather than seal it as deterministic.
+func (c *componentIndex) lookup(packageName string) (identities []jsresolution.PackageIdentity, foldedMatch bool) {
+	if c == nil {
+		return nil, false
+	}
+	if exact := c.byName[packageName]; len(exact) > 0 {
+		return exact, false
+	}
+	folded := strings.ToLower(packageName)
+	names := c.byFoldedName[folded]
+	if len(names) == 0 {
+		// The specifier itself may be the mixed-case side.
+		if exact := c.byName[folded]; len(exact) > 0 && folded != packageName {
+			return exact, true
+		}
+		return nil, false
+	}
+	var out []jsresolution.PackageIdentity
+	for _, name := range names {
+		out = append(out, c.byName[name]...)
+	}
+	sort.Slice(out, func(i, j int) bool { return identityLess(out[i], out[j]) })
+	return deduplicatePackageIdentities(out), true
+}
+
+// isSupplied reports whether an SBOM was provided at all. Nil-safe, so every caller can use the same
+// contract as lookup.
+func (c *componentIndex) isSupplied() bool { return c != nil && c.supplied }
+
+// isComplete reports whether the index covers the whole SBOM.
+func (c *componentIndex) isComplete() bool { return c != nil && c.complete }
+
+// dropReason returns why a name present in the SBOM produced no usable identity, or "" when the SBOM
+// simply does not list it.
+func (c *componentIndex) dropReason(packageName string) string {
+	if c == nil {
+		return ""
+	}
+	return c.dropped[packageName]
+}
+
+// parseNPMPURL extracts the package name and version from an npm package URL.
+//
+// The repository's parsers encode a scoped package as "pkg:npm/%40scope/name@1.2.3": the scope's leading
+// "@" is percent-encoded, the separating "/" is literal, and the "@" before the version is literal. This
+// decodes that form back to "@scope/name" so it can be compared with a source specifier's package root.
+func parseNPMPURL(purl string) (string, string, bool) {
+	trimmed := strings.TrimSpace(purl)
+	if len(trimmed) <= len(npmPURLPrefix) || !strings.HasPrefix(strings.ToLower(trimmed), npmPURLPrefix) {
+		return "", "", false
+	}
+	body := trimmed[len(npmPURLPrefix):]
+
+	// Qualifiers and subpaths are not part of the identity.
+	if i := strings.IndexAny(body, "?#"); i >= 0 {
+		body = body[:i]
+	}
+	// The version follows the LAST "@": a scoped name's own "@" is percent-encoded, so any literal "@"
+	// that remains is the version separator.
+	at := strings.LastIndex(body, "@")
+	if at <= 0 || at == len(body)-1 {
+		return "", "", false
+	}
+	rawName, version := body[:at], body[at+1:]
+	name := purlDecodeName(rawName)
+	if name == "" || version == "" {
+		return "", "", false
+	}
+	// Validate the name through the domain normalizer (which lowercases) but RETURN the component's own
+	// casing: npm hosts distinct packages that differ only in case, so folding here would let one
+	// package's PURL be attached to another's import.
+	if _, err := jsresolution.NormalizePackageName(name); err != nil {
+		return "", "", false
+	}
+	return name, version, true
+}
+
+// purlDecodeName percent-decodes a PURL name segment. Only the encodings the repository's PURL builders
+// produce are decoded; an unrecognized escape leaves the name unchanged so it fails validation rather
+// than silently naming a different package.
+func purlDecodeName(raw string) string {
+	if !strings.Contains(raw, "%") {
+		return raw
+	}
+	var sb strings.Builder
+	for i := 0; i < len(raw); {
+		if raw[i] == '%' && i+2 < len(raw) {
+			hi, hiOK := hexValue(raw[i+1])
+			lo, loOK := hexValue(raw[i+2])
+			if hiOK && loOK {
+				sb.WriteByte(hi<<4 | lo)
+				i += 3
+				continue
+			}
+		}
+		sb.WriteByte(raw[i])
+		i++
+	}
+	return sb.String()
+}
+
+func hexValue(b byte) (byte, bool) {
+	switch {
+	case b >= '0' && b <= '9':
+		return b - '0', true
+	case b >= 'a' && b <= 'f':
+		return b - 'a' + 10, true
+	case b >= 'A' && b <= 'F':
+		return b - 'A' + 10, true
+	}
+	return 0, false
+}
+
+// correlateComponent resolves a third-party package name against the SBOM.
+//
+// Exactly one resolved component version is a deterministic identity and becomes StatusComponent, which
+// is what allows a later analyzer to use the exact PURL as its subject. Several versions stay AMBIGUOUS
+// with every viable candidate preserved — never the first by map or slice order — and no component at all
+// stays unresolved with an explicit reason. Each non-deterministic outcome degrades coverage, so a
+// negative reachability conclusion cannot rest on it.
+func (r *Resolver) correlateComponent(
+	base jsresolution.ImportResolution,
+	packageName string,
+	components *componentIndex,
+	candidateWork *resolverWorkBudget,
+	coverage *resolutionCoverageSink,
+) jsresolution.ImportResolution {
+	if !components.isSupplied() {
+		base.Status = jsresolution.StatusUnresolved
+		base.Package = jsresolution.PackageIdentity{Name: packageName}
+		base.Reason = "no sbom was supplied, so the package cannot be correlated to a component"
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageMissingSBOMComponent, Path: base.From,
+			Detail: fmt.Sprintf("package %q cannot be correlated without an sbom", packageName),
+		})
+		return base
+	}
+
+	matches, folded := components.lookup(packageName)
+	if !candidateWork.consumeN(len(matches) + 1) {
+		return markCandidateBudgetExceeded(base, candidateWork, coverage, r.limits.maxCandidateWork)
+	}
+
+	switch len(matches) {
+	case 0:
+		base.Status = jsresolution.StatusUnresolved
+		base.Package = jsresolution.PackageIdentity{Name: packageName}
+		if dropped := components.dropReason(packageName); dropped != "" {
+			base.Reason = "package is imported by first-party source but the sbom " + dropped
+		} else {
+			base.Reason = "package is imported by first-party source but is absent from the sbom"
+		}
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageMissingSBOMComponent, Path: base.From,
+			Detail: fmt.Sprintf("imported package %q has no usable sbom component", packageName),
+		})
+		return base
+	case 1:
+		if folded {
+			// The only match differs from the specifier in case. npm hosts distinct packages that
+			// differ only in case, so this is plausible, not proven: report it rather than seal it.
+			base.Status = jsresolution.StatusUnresolved
+			base.Package = jsresolution.PackageIdentity{Name: packageName}
+			base.Reason = "the only matching sbom component differs from the imported specifier in case"
+			coverage.add(jsresolution.CoverageIssue{
+				Kind: jsresolution.CoverageAmbiguousSBOMComponent, Path: base.From,
+				Detail: "imported package " + packageName + " matches an sbom component only by case folding",
+			})
+			return base
+		}
+		base.Status = jsresolution.StatusComponent
+		base.Package = matches[0]
+		base.Reason = ""
+		return base
+	default:
+		base.Status = jsresolution.StatusAmbiguous
+		base.Candidates = append([]jsresolution.PackageIdentity(nil), matches...)
+		base.Reason = "package name matches more than one sbom component version and importer context does not select one"
+		coverage.add(jsresolution.CoverageIssue{
+			Kind: jsresolution.CoverageAmbiguousSBOMComponent, Path: base.From,
+			Detail: fmt.Sprintf("imported package %q matches %d component versions", packageName, len(matches)),
+		})
+		return base
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_sbom_test.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_sbom_test.go
@@ -1,0 +1,604 @@
+package jsresolve
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// docWith builds an SBOM fixture from npm PURLs, mirroring the repository's PURL convention
+// (a scoped package encodes its leading "@" as %40).
+func docWith(purls ...string) *sbom.SBOM {
+	doc := &sbom.SBOM{}
+	for _, p := range purls {
+		doc.Components = append(doc.Components, sbom.Component{PURL: p})
+	}
+	return doc
+}
+
+// resolveWithSBOM scans a single external specifier from src/index.ts against doc.
+func resolveWithSBOM(t *testing.T, specifier string, doc *sbom.SBOM) jsresolution.ImportResolution {
+	t.Helper()
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+	graph := graphWithExternal("src/index.ts", specifier)
+
+	result, err := NewResolver().Resolve(context.Background(), root, graph, doc)
+	if err != nil {
+		t.Fatalf("resolve %q: %v", specifier, err)
+	}
+	got := resolutionsBySpecifier(result.Imports)[specifier]
+	if got.Specifier != specifier {
+		t.Fatalf("no resolution for %q: %+v", specifier, result.Imports)
+	}
+	return got
+}
+
+func TestParseNPMPURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		purl        string
+		wantName    string
+		wantVersion string
+		wantOK      bool
+	}{
+		{name: "plain package", purl: "pkg:npm/lodash@4.17.21", wantName: "lodash", wantVersion: "4.17.21", wantOK: true},
+		{name: "scoped package", purl: "pkg:npm/%40scope/pkg@1.2.3", wantName: "@scope/pkg", wantVersion: "1.2.3", wantOK: true},
+		// The component's OWN casing is preserved: npm hosts distinct packages whose names differ only in
+		// case (JSONStream and jsonstream), so folding here would let one package's purl be attached to
+		// another package's import.
+		{name: "mixed case is preserved", purl: "pkg:npm/%40Scope/Pkg@1.2.3", wantName: "@Scope/Pkg", wantVersion: "1.2.3", wantOK: true},
+		{name: "prerelease version", purl: "pkg:npm/pkg@1.0.0-beta.1", wantName: "pkg", wantVersion: "1.0.0-beta.1", wantOK: true},
+		{name: "qualifiers are ignored", purl: "pkg:npm/lodash@4.17.21?arch=x64", wantName: "lodash", wantVersion: "4.17.21", wantOK: true},
+		{name: "subpath is ignored", purl: "pkg:npm/lodash@4.17.21#fp", wantName: "lodash", wantVersion: "4.17.21", wantOK: true},
+		{name: "another ecosystem", purl: "pkg:pypi/requests@2.0.0", wantOK: false},
+		{name: "no version", purl: "pkg:npm/lodash", wantOK: false},
+		{name: "empty version", purl: "pkg:npm/lodash@", wantOK: false},
+		{name: "empty name", purl: "pkg:npm/@1.0.0", wantOK: false},
+		{name: "not a purl", purl: "lodash@4.17.21", wantOK: false},
+		{name: "empty", purl: "", wantOK: false},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			name, version, ok := parseNPMPURL(test.purl)
+			if ok != test.wantOK {
+				t.Fatalf("parseNPMPURL(%q) ok = %v, want %v (name %q version %q)", test.purl, ok, test.wantOK, name, version)
+			}
+			if !test.wantOK {
+				return
+			}
+			if name != test.wantName || version != test.wantVersion {
+				t.Fatalf("parseNPMPURL(%q) = (%q, %q), want (%q, %q)", test.purl, name, version, test.wantName, test.wantVersion)
+			}
+		})
+	}
+}
+
+func TestCorrelationExactComponent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unscoped package", func(t *testing.T) {
+		t.Parallel()
+		got := resolveWithSBOM(t, "lodash", docWith("pkg:npm/lodash@4.17.21"))
+		if got.Status != jsresolution.StatusComponent {
+			t.Fatalf("status = %q, want component (reason %q)", got.Status, got.Reason)
+		}
+		if got.Package.PURL != "pkg:npm/lodash@4.17.21" {
+			t.Fatalf("purl = %q, want the exact component purl", got.Package.PURL)
+		}
+		if got.Package.Version != "4.17.21" {
+			t.Fatalf("version = %q, want 4.17.21", got.Package.Version)
+		}
+	})
+
+	t.Run("scoped package", func(t *testing.T) {
+		t.Parallel()
+		got := resolveWithSBOM(t, "@scope/pkg", docWith("pkg:npm/%40scope/pkg@1.2.3"))
+		if got.Status != jsresolution.StatusComponent || got.Package.PURL != "pkg:npm/%40scope/pkg@1.2.3" {
+			t.Fatalf("a scoped package must correlate to its exact purl, got %+v", got)
+		}
+	})
+
+	t.Run("package subpath resolves to the package root", func(t *testing.T) {
+		t.Parallel()
+		got := resolveWithSBOM(t, "lodash/fp", docWith("pkg:npm/lodash@4.17.21"))
+		if got.Status != jsresolution.StatusComponent || got.Package.PURL != "pkg:npm/lodash@4.17.21" {
+			t.Fatalf("a subpath import must correlate to the package root, got %+v", got)
+		}
+	})
+
+	t.Run("scoped package subpath", func(t *testing.T) {
+		t.Parallel()
+		got := resolveWithSBOM(t, "@scope/pkg/deep/path", docWith("pkg:npm/%40scope/pkg@1.2.3"))
+		if got.Status != jsresolution.StatusComponent {
+			t.Fatalf("a scoped subpath must correlate to the package root, got %+v", got)
+		}
+	})
+
+	t.Run("other components are ignored", func(t *testing.T) {
+		t.Parallel()
+		doc := docWith("pkg:pypi/lodash@1.0.0", "pkg:golang/lodash@1.0.0", "pkg:npm/lodash@4.17.21")
+		got := resolveWithSBOM(t, "lodash", doc)
+		if got.Status != jsresolution.StatusComponent || got.Package.PURL != "pkg:npm/lodash@4.17.21" {
+			t.Fatalf("only the npm component may correlate, got %+v", got)
+		}
+	})
+}
+
+// TestCorrelationNeverGuesses is the safety gate for #400: a package that cannot be identified
+// deterministically must stay explicit, and every non-deterministic outcome must degrade coverage so no
+// later analyzer can draw a negative conclusion from it.
+func TestCorrelationNeverGuesses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("multiple versions stay ambiguous with every candidate", func(t *testing.T) {
+		t.Parallel()
+		doc := docWith("pkg:npm/lodash@4.17.21", "pkg:npm/lodash@3.10.1")
+		got := resolveWithSBOM(t, "lodash", doc)
+		if got.Status != jsresolution.StatusAmbiguous {
+			t.Fatalf("two versions must be ambiguous, got %q", got.Status)
+		}
+		if len(got.Candidates) != 2 {
+			t.Fatalf("both versions must be preserved, got %+v", got.Candidates)
+		}
+		if got.Package != (jsresolution.PackageIdentity{}) {
+			t.Fatalf("an ambiguous resolution must select no package, got %+v", got.Package)
+		}
+		// The candidate order must be deterministic, never slice or map order.
+		if got.Candidates[0].Version != "3.10.1" || got.Candidates[1].Version != "4.17.21" {
+			t.Fatalf("candidates must be deterministically ordered, got %+v", got.Candidates)
+		}
+	})
+
+	t.Run("absent component stays unresolved", func(t *testing.T) {
+		t.Parallel()
+		got := resolveWithSBOM(t, "never-installed", docWith("pkg:npm/lodash@4.17.21"))
+		if got.Status != jsresolution.StatusUnresolved {
+			t.Fatalf("an absent component must stay unresolved, got %q", got.Status)
+		}
+		if got.Reason == "" {
+			t.Fatal("an unresolved package must carry a reason")
+		}
+	})
+
+	t.Run("no sbom cannot correlate", func(t *testing.T) {
+		t.Parallel()
+		got := resolveWithSBOM(t, "lodash", nil)
+		if got.Status != jsresolution.StatusUnresolved {
+			t.Fatalf("without an sbom nothing may be correlated, got %q", got.Status)
+		}
+	})
+
+	t.Run("unresolved component version is never an identity", func(t *testing.T) {
+		t.Parallel()
+		// A floating version is not a resolved subject, so it must not become an exact identity.
+		got := resolveWithSBOM(t, "lodash", docWith("pkg:npm/lodash@latest"))
+		if got.Status == jsresolution.StatusComponent {
+			t.Fatalf("a floating version must never become an exact component identity, got %+v", got)
+		}
+	})
+}
+
+func TestCorrelationDegradesCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		specifier string
+		doc       *sbom.SBOM
+		wantKind  jsresolution.CoverageIssueKind
+	}{
+		{
+			name:      "missing component",
+			specifier: "absent-pkg",
+			doc:       docWith("pkg:npm/lodash@4.17.21"),
+			wantKind:  jsresolution.CoverageMissingSBOMComponent,
+		},
+		{
+			name:      "ambiguous component",
+			specifier: "lodash",
+			doc:       docWith("pkg:npm/lodash@4.17.21", "pkg:npm/lodash@3.10.1"),
+			wantKind:  jsresolution.CoverageAmbiguousSBOMComponent,
+		},
+		{
+			name:      "no sbom supplied",
+			specifier: "lodash",
+			doc:       nil,
+			wantKind:  jsresolution.CoverageMissingSBOMComponent,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+			graph := graphWithExternal("src/index.ts", test.specifier)
+
+			result, err := NewResolver().Resolve(context.Background(), root, graph, test.doc)
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			if !hasCoverageKind(result.Coverage, test.wantKind) {
+				t.Fatalf("expected coverage kind %q, got %+v", test.wantKind, result.Coverage)
+			}
+			// Any non-deterministic identity must leave the result incomplete, which is what stops a
+			// later analyzer from concluding a dependency is unreachable.
+			if result.Complete {
+				t.Fatal("a non-deterministic correlation must leave the result incomplete")
+			}
+		})
+	}
+}
+
+// TestCorrelationCompletesACleanProject proves the converse: when every import correlates
+// deterministically the result is Complete, which is the precondition for any negative proof.
+func TestCorrelationCompletesACleanProject(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{{Path: "src/index.ts", Dialect: modulegraph.DialectTypeScript}},
+		Edges: []modulegraph.Edge{
+			{From: "src/index.ts", Specifier: "lodash", Kind: modulegraph.ImportESMStatic},
+			{From: "src/index.ts", Specifier: "node:fs", Kind: modulegraph.ImportESMStatic},
+			{From: "src/index.ts", Specifier: "@scope/pkg", Kind: modulegraph.ImportESMStatic},
+		},
+	}
+	doc := docWith("pkg:npm/lodash@4.17.21", "pkg:npm/%40scope/pkg@1.2.3")
+
+	result, err := NewResolver().Resolve(context.Background(), root, graph, doc)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !result.Complete {
+		t.Fatalf("a fully correlated project must be complete, coverage %+v imports %+v", result.Coverage, result.Imports)
+	}
+	byName := resolutionsBySpecifier(result.Imports)
+	if byName["lodash"].Status != jsresolution.StatusComponent {
+		t.Errorf("lodash status = %q", byName["lodash"].Status)
+	}
+	if byName["node:fs"].Status != jsresolution.StatusBuiltin {
+		t.Errorf("node:fs must stay a builtin, got %q", byName["node:fs"].Status)
+	}
+	if byName["@scope/pkg"].Status != jsresolution.StatusComponent {
+		t.Errorf("@scope/pkg status = %q", byName["@scope/pkg"].Status)
+	}
+}
+
+// TestWorkspaceIsNeverAThirdPartyComponent locks the #400 criterion that a first-party workspace package
+// is never misclassified as a third-party component, even when the SBOM contains a same-named package.
+func TestWorkspaceIsNeverAThirdPartyComponent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "private": true, "workspaces": []string{"packages/*"}})
+	writeJSON(t, r2bJoin(root, "packages", "shared", "package.json"), map[string]any{"name": "@repo/shared", "version": "1.2.3"})
+	graph := graphWithExternal("src/index.ts", "@repo/shared")
+
+	t.Run("with a same-named registry component", func(t *testing.T) {
+		doc := docWith("pkg:npm/%40repo/shared@9.9.9")
+		result, err := NewResolver().Resolve(context.Background(), root, graph, doc)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		got := resolutionsBySpecifier(result.Imports)["@repo/shared"]
+		if got.Status == jsresolution.StatusComponent {
+			t.Fatalf("a local workspace must never resolve to a third-party component, got %+v", got)
+		}
+		if got.Status != jsresolution.StatusAmbiguous {
+			t.Fatalf("status = %q, want ambiguous", got.Status)
+		}
+		// Both the workspace and the concrete registry identity must be preserved.
+		var sawWorkspace, sawRegistry bool
+		for _, candidate := range got.Candidates {
+			if candidate.Workspace {
+				sawWorkspace = true
+			}
+			if candidate.PURL == "pkg:npm/%40repo/shared@9.9.9" {
+				sawRegistry = true
+			}
+		}
+		if !sawWorkspace || !sawRegistry {
+			t.Fatalf("both identities must be preserved, got %+v", got.Candidates)
+		}
+	})
+
+	t.Run("with no registry component", func(t *testing.T) {
+		result, err := NewResolver().Resolve(context.Background(), root, graph, docWith("pkg:npm/lodash@4.17.21"))
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		got := resolutionsBySpecifier(result.Imports)["@repo/shared"]
+		if got.Status == jsresolution.StatusComponent {
+			t.Fatalf("a local workspace must never resolve to a third-party component, got %+v", got)
+		}
+	})
+}
+
+func TestCorrelationIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+	graph := graphWithExternal("src/index.ts", "lodash")
+	// Component order in the SBOM must not affect the outcome.
+	forward := docWith("pkg:npm/lodash@4.17.21", "pkg:npm/lodash@3.10.1", "pkg:npm/lodash@2.4.2")
+	reverse := docWith("pkg:npm/lodash@2.4.2", "pkg:npm/lodash@3.10.1", "pkg:npm/lodash@4.17.21")
+
+	first, err := NewResolver().Resolve(context.Background(), root, graph, forward)
+	if err != nil {
+		t.Fatalf("resolve forward: %v", err)
+	}
+	second, err := NewResolver().Resolve(context.Background(), root, graph, reverse)
+	if err != nil {
+		t.Fatalf("resolve reverse: %v", err)
+	}
+	a := resolutionsBySpecifier(first.Imports)["lodash"]
+	b := resolutionsBySpecifier(second.Imports)["lodash"]
+	if len(a.Candidates) != len(b.Candidates) {
+		t.Fatalf("candidate count differs: %d vs %d", len(a.Candidates), len(b.Candidates))
+	}
+	for i := range a.Candidates {
+		if a.Candidates[i] != b.Candidates[i] {
+			t.Fatalf("candidate[%d] differs between component orderings: %+v vs %+v", i, a.Candidates[i], b.Candidates[i])
+		}
+	}
+}
+
+func TestCorrelationHandlesDuplicateComponents(t *testing.T) {
+	t.Parallel()
+
+	// The same component listed twice is one identity, not an ambiguity.
+	got := resolveWithSBOM(t, "lodash", docWith("pkg:npm/lodash@4.17.21", "pkg:npm/lodash@4.17.21"))
+	if got.Status != jsresolution.StatusComponent {
+		t.Fatalf("duplicate identical components must not create ambiguity, got %+v", got)
+	}
+}
+
+func TestCorrelationRejectsMalformedComponentPURLs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+	graph := graphWithExternal("src/index.ts", "lodash")
+	// A malformed npm PURL must degrade coverage rather than be silently skipped: the component it
+	// stands for may be the very package being imported.
+	doc := docWith("pkg:npm/lodash", "pkg:npm/lodash@4.17.21")
+
+	result, err := NewResolver().Resolve(context.Background(), root, graph, doc)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !hasCoverageKind(result.Coverage, jsresolution.CoverageMissingSBOMComponent) {
+		t.Fatalf("an uninterpretable component purl must degrade coverage, got %+v", result.Coverage)
+	}
+}
+
+func TestCorrelationMatchesAcrossCase(t *testing.T) {
+	t.Parallel()
+
+	// npm hosts DISTINCT packages whose names differ only in case (JSONStream and jsonstream are not the
+	// same package). A specifier's package root is lowercased during normalization, so a component that
+	// matches only after folding is plausible, not proven: it must be reported rather than sealed as a
+	// deterministic identity, or one package's purl would be attached to another package's import.
+	got := resolveWithSBOM(t, "@Scope/Pkg", docWith("pkg:npm/%40Scope/Pkg@1.2.3"))
+	if got.Status == jsresolution.StatusComponent {
+		t.Fatalf("a case-folded match must never be sealed as a deterministic component, got %+v", got)
+	}
+	if got.Reason == "" {
+		t.Fatal("a case-folded match must explain itself")
+	}
+}
+
+func TestCorrelationNeverFoldsDistinctPackages(t *testing.T) {
+	t.Parallel()
+
+	// The concrete hazard: JSONStream and jsonstream are different published packages. An import of one
+	// must never be given the other's purl.
+	got := resolveWithSBOM(t, "jsonstream", docWith("pkg:npm/JSONStream@1.3.5"))
+	if got.Status == jsresolution.StatusComponent {
+		t.Fatalf("an import of jsonstream must not be given JSONStream's identity, got %+v", got)
+	}
+}
+
+func TestDeclaredDependencySpecDecidesIdentity(t *testing.T) {
+	t.Parallel()
+
+	// An npm ALIAS means the imported name is not the package name. Correlating "lodash" to a
+	// same-named component here would attach the WRONG identity and leave the real package
+	// (lodash-es) named by no import — exactly the false-negative this phase exists to prevent.
+	t.Run("npm alias redirects to the real package", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+			"name": "app", "version": "1.0.0",
+			"dependencies": map[string]string{"lodash": "npm:lodash-es@^4.17.21"},
+		})
+		graph := graphWithExternal("src/index.ts", "lodash")
+		doc := docWith("pkg:npm/lodash-es@4.17.21", "pkg:npm/lodash@4.17.15")
+
+		result, err := NewResolver().Resolve(context.Background(), root, graph, doc)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		got := resolutionsBySpecifier(result.Imports)["lodash"]
+		if got.Status != jsresolution.StatusComponent {
+			t.Fatalf("an aliased dependency must correlate to its real package, got %+v", got)
+		}
+		if got.Package.PURL != "pkg:npm/lodash-es@4.17.21" {
+			t.Fatalf("purl = %q, want the ALIAS TARGET lodash-es, not the same-named component", got.Package.PURL)
+		}
+	})
+
+	nonRegistry := map[string]string{
+		"file":      "file:../local-copy",
+		"link":      "link:../sibling",
+		"workspace": "workspace:*",
+		"git":       "git+ssh://git@github.com/o/r.git",
+		"github":    "github:owner/repo",
+		"https":     "https://example.com/pkg.tgz",
+		"patch":     "patch:lodash@4.17.21#./fix.patch",
+		"shorthand": "owner/repo",
+	}
+	for label, spec := range nonRegistry {
+		label, spec := label, spec
+		t.Run("non-registry source refuses correlation: "+label, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+				"name": "app", "version": "1.0.0",
+				"dependencies": map[string]string{"lodash": spec},
+			})
+			graph := graphWithExternal("src/index.ts", "lodash")
+			// A same-named registry component exists, and must NOT be adopted.
+			doc := docWith("pkg:npm/lodash@4.17.21")
+
+			result, err := NewResolver().Resolve(context.Background(), root, graph, doc)
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			got := resolutionsBySpecifier(result.Imports)["lodash"]
+			if got.Status == jsresolution.StatusComponent {
+				t.Fatalf("a %s dependency must not adopt a same-named registry component, got %+v", label, got)
+			}
+			if result.Complete {
+				t.Fatal("a non-registry dependency must leave the result incomplete")
+			}
+		})
+	}
+
+	t.Run("a plain range still correlates", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+			"name": "app", "version": "1.0.0",
+			"dependencies": map[string]string{"lodash": "^4.17.21"},
+		})
+		graph := graphWithExternal("src/index.ts", "lodash")
+		result, err := NewResolver().Resolve(context.Background(), root, graph, docWith("pkg:npm/lodash@4.17.21"))
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		got := resolutionsBySpecifier(result.Imports)["lodash"]
+		if got.Status != jsresolution.StatusComponent {
+			t.Fatalf("a plain semver range must correlate normally, got %+v", got)
+		}
+	})
+}
+
+func TestPackageImportsAliasCorrelates(t *testing.T) {
+	t.Parallel()
+
+	// A package.json "imports" target naming a third-party package must correlate exactly like a bare
+	// import; leaving it unresolved would make any project using the feature permanently incomplete.
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{
+		"name": "app", "version": "1.0.0",
+		"imports": map[string]any{"#dep": "lodash"},
+	})
+	graph := graphWithExternal("src/index.ts", "#dep")
+
+	result, err := NewResolver().Resolve(context.Background(), root, graph, docWith("pkg:npm/lodash@4.17.21"))
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := resolutionsBySpecifier(result.Imports)["#dep"]
+	if got.Status != jsresolution.StatusComponent {
+		t.Fatalf("an imports target naming a package must correlate, got %+v", got)
+	}
+	if got.Package.PURL != "pkg:npm/lodash@4.17.21" {
+		t.Fatalf("purl = %q, want the correlated component", got.Package.PURL)
+	}
+}
+
+func TestWorkspaceOnlyIdentityWithACompleteSBOM(t *testing.T) {
+	t.Parallel()
+
+	// A COMPLETE sbom that lists no package of this name is positive evidence that no registry package
+	// was installed, so the workspace is the only identity. Keeping a bare-name alternative would leave
+	// every monorepo import permanently ambiguous and block all later negative conclusions.
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "private": true, "workspaces": []string{"packages/*"}})
+	writeJSON(t, r2bJoin(root, "packages", "shared", "package.json"), map[string]any{"name": "@repo/shared", "version": "1.2.3"})
+	graph := graphWithExternal("src/index.ts", "@repo/shared")
+
+	result, err := NewResolver().Resolve(context.Background(), root, graph, docWith("pkg:npm/lodash@4.17.21"))
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := resolutionsBySpecifier(result.Imports)["@repo/shared"]
+	if got.Status != jsresolution.StatusWorkspace {
+		t.Fatalf("status = %q, want workspace (reason %q candidates %+v)", got.Status, got.Reason, got.Candidates)
+	}
+	if !got.Package.Workspace || got.Package.Path == "" {
+		t.Fatalf("the workspace identity must carry its path, got %+v", got.Package)
+	}
+	if !result.Complete {
+		t.Fatalf("a monorepo whose imports all resolve must be complete, coverage %+v", result.Coverage)
+	}
+}
+
+func TestComponentBudgetDegradesRatherThanTruncatesSilently(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+	graph := graphWithExternal("src/index.ts", "lodash")
+
+	limits := defaultResolverLimits()
+	limits.maxComponents = 1
+	resolver := newResolverWithLimits(NewInventoryBuilder(), newAliasInventoryBuilder(), limits)
+	// lodash is past the cut, so it must NOT look absent from the sbom.
+	doc := docWith("pkg:npm/other@1.0.0", "pkg:npm/lodash@4.17.21")
+
+	result, err := resolver.Resolve(context.Background(), root, graph, doc)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !hasCoverageKind(result.Coverage, jsresolution.CoverageMetadataBudgetExceeded) {
+		t.Fatalf("a truncated sbom must degrade coverage, got %+v", result.Coverage)
+	}
+	if result.Complete {
+		t.Fatal("a truncated sbom must leave the result incomplete")
+	}
+}
+
+func TestPerNameCandidateBudgetIsReported(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+	graph := graphWithExternal("src/index.ts", "lodash")
+
+	limits := defaultResolverLimits()
+	limits.maxCandidates = 2
+	resolver := newResolverWithLimits(NewInventoryBuilder(), newAliasInventoryBuilder(), limits)
+	doc := docWith("pkg:npm/lodash@1.0.0", "pkg:npm/lodash@2.0.0", "pkg:npm/lodash@3.0.0")
+
+	result, err := resolver.Resolve(context.Background(), root, graph, doc)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := resolutionsBySpecifier(result.Imports)["lodash"]
+	if got.Status == jsresolution.StatusComponent {
+		t.Fatalf("an over-budget name must not produce a deterministic identity, got %+v", got)
+	}
+	// The reason must not claim the package is absent when the sbom lists many versions of it.
+	if got.Reason == "package is imported by first-party source but is absent from the sbom" {
+		t.Fatalf("an over-budget name must not be reported as absent from the sbom: %q", got.Reason)
+	}
+	if result.Complete {
+		t.Fatal("an over-budget name must leave the result incomplete")
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_ts.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_ts.go
@@ -18,6 +18,7 @@ func (r *Resolver) resolveTSPaths(
 	scopeDiscoveryComplete bool,
 	workspaces map[string][]jsresolution.PackageIdentity,
 	packages []jsresolution.PackageMetadata,
+	components *componentIndex,
 	modulePaths map[string]struct{},
 	aliasWork *resolverWorkBudget,
 	candidateWork *resolverWorkBudget,
@@ -42,7 +43,7 @@ func (r *Resolver) resolveTSPaths(
 		base.Reason = "applicable tsconfig/jsconfig context uses unsupported project-selection or inheritance semantics"
 		coverage.add(jsresolution.CoverageIssue{
 			Kind: jsresolution.CoverageUnsupportedAlias, Path: base.From,
-			Detail: fmt.Sprintf("specifier %q is under an alias context R2B cannot apply safely", base.Specifier),
+			Detail: fmt.Sprintf("specifier %q is under an alias context this resolver cannot apply safely", base.Specifier),
 		})
 		return base, true
 	case tsAliasContextAmbiguous:
@@ -57,7 +58,7 @@ func (r *Resolver) resolveTSPaths(
 	case tsAliasContextBaseURL:
 		base.Status = jsresolution.StatusUnresolved
 		base.Package = jsresolution.PackageIdentity{}
-		base.Reason = "tsconfig/jsconfig baseUrl may change bare-specifier identity and R2B does not reproduce TypeScript file resolution"
+		base.Reason = "tsconfig/jsconfig baseUrl may change bare-specifier identity and this resolver does not reproduce TypeScript file resolution"
 		coverage.add(jsresolution.CoverageIssue{
 			Kind: jsresolution.CoverageUnsupportedAlias, Path: base.From,
 			Detail: fmt.Sprintf("specifier %q is under a tsconfig/jsconfig baseUrl without a supported paths match", base.Specifier),
@@ -67,7 +68,7 @@ func (r *Resolver) resolveTSPaths(
 	if len(matches) == 0 {
 		return base, false
 	}
-	return r.resolveAliasMatches(ctx, base, matches, workspaces, packages, modulePaths, aliasWork, candidateWork, coverage), true
+	return r.resolveAliasMatches(ctx, base, matches, workspaces, packages, components, modulePaths, aliasWork, candidateWork, coverage), true
 }
 
 func bestAliasMatchesInScope(ctx context.Context, mappings []aliasMapping, kind aliasKind, scopeDir, specifier string, budget *resolverWorkBudget) ([]aliasMapping, bool) {

--- a/internal/infrastructure/tools/jsresolve/resolver_types.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_types.go
@@ -19,6 +19,7 @@ const (
 	defaultMaxResolverAliasWork          = 1000000
 	defaultMaxResolverCandidateWork      = 1000000
 	defaultMaxResolverCandidates         = 256
+	defaultMaxResolverComponents         = 200000
 	defaultMaxResolverCoverage           = 4096
 )
 
@@ -34,6 +35,7 @@ type resolverLimits struct {
 	maxAliasWork          int
 	maxCandidateWork      int
 	maxCandidates         int
+	maxComponents         int
 	maxCoverageIssues     int
 }
 
@@ -50,6 +52,7 @@ func defaultResolverLimits() resolverLimits {
 		maxAliasWork:          defaultMaxResolverAliasWork,
 		maxCandidateWork:      defaultMaxResolverCandidateWork,
 		maxCandidates:         defaultMaxResolverCandidates,
+		maxComponents:         defaultMaxResolverComponents,
 		maxCoverageIssues:     defaultMaxResolverCoverage,
 	}
 }
@@ -57,15 +60,15 @@ func defaultResolverLimits() resolverLimits {
 func (l resolverLimits) validate() error {
 	if l.maxModules <= 0 || l.maxEdges <= 0 || l.maxGraphCoverage <= 0 || l.maxBindingsPerEdge <= 0 ||
 		l.maxTotalBindings <= 0 || l.maxSpecifierBytes <= 0 || l.maxModulePathBytes <= 0 || l.maxModulePathSegments <= 0 ||
-		l.maxAliasWork <= 0 || l.maxCandidateWork <= 0 || l.maxCandidates <= 0 || l.maxCoverageIssues <= 0 {
+		l.maxAliasWork <= 0 || l.maxCandidateWork <= 0 || l.maxCandidates <= 0 ||
+		l.maxComponents <= 0 || l.maxCoverageIssues <= 0 {
 		return fmt.Errorf("%w: resolver limits must be positive", shared.ErrValidation)
 	}
 	return nil
 }
 
 // Resolver resolves source module specifiers to built-in, local, workspace, or
-// package-root identities. R2B deliberately leaves third-party SBOM component
-// correlation unresolved for R2C.
+// package-root identities, correlating third-party roots to SBOM components by exact purl.
 type Resolver struct {
 	inventory *InventoryBuilder
 	aliases   *aliasInventoryBuilder


### PR DESCRIPTION
Phase R2C of #400, building on #458.

## What

The resolver's `doc *sbom.SBOM` parameter was previously ignored. It now turns an observed package root into a **deterministic package identity** — the exact subject a later Tier-1 analyzer needs.

| Outcome | Status |
|---|---|
| Exactly one resolved component version | `StatusComponent` with the exact component PURL |
| Several versions | `StatusAmbiguous` preserving **every** viable candidate (never the first by map/slice order) |
| No component | `StatusUnresolved` with an explicit reason |

Every non-deterministic outcome emits a coverage issue, so `Result.Complete` — the only licence for a later negative conclusion — cannot be reached by guessing.

## The wrong-identity problem (found by security review)

The imported **name** is not always the package of that name, and getting this wrong is *worse* than getting no answer: it redirects a reachability conclusion onto the wrong package while looking deterministic.

```jsonc
// package.json
"dependencies": { "lodash": "npm:lodash-es@^4.17.21" }
```
Correlating `import ... from "lodash"` to a same-named component would attach `pkg:npm/lodash@4.17.15` while the **real** package `lodash-es` is named by no import at all → a Tier-1 analyzer concludes "unused" → `not_affected` on a real CVE.

So the importer's declared dependency spec now decides identity:
- an **npm alias** correlates to the **alias target**;
- a **non-registry source** (`file:`, `link:`, `portal:`, `workspace:`, `patch:`, `git+`, `github:`, `https:`, or an `owner/repo` shorthand) **refuses** correlation — the installed code is not the registry package of that name.

## Case folding (also from review)

npm hosts **distinct** packages whose names differ only in case (`JSONStream` and `jsonstream` are different packages). Names are now compared with the component's own casing; a match found only by folding is **reported as a coverage issue**, never sealed as an identity.

## Workspaces

A local workspace is never classified as a third-party component. When a **complete** SBOM lists no package of that name, the workspace is now the sole identity (`StatusWorkspace`) instead of a permanent ambiguity — previously every monorepo import would have blocked `Complete` forever, making the whole feature unusable on monorepos.

The `package.json` `"imports"` alias path correlates the same way, so a project using that feature is no longer permanently incomplete. (A reviewer caught that the alias path *received* the component index but never used it.)

## Bounds & determinism

`maxComponents` bounds the SBOM (the only previously unbounded input); an over-budget package name reports an **accurate** reason instead of "absent from the sbom"; component indexing iterates in sorted name order so a capped coverage sink keeps a reproducible subset.

## Verification

`go build ./...` · `go vet` · **golangci-lint 0 issues** · full suite **171 packages, 0 failures** · `-race` green. Both reviewers run; all findings applied.

## Remaining for #400

Importer/lockfile disambiguation (npm hoisting, yarn descriptors, pnpm `importers:`) to resolve the *multi-version* ambiguity uniquely — the delivery split the issue itself proposes. Ambiguity-preservation is the safe behaviour until then.
