### PR TITLE
feat(reachability): select a package version from lockfile importer context (#400)

### DIFF
--- a/internal/infrastructure/tools/jsresolve/resolver.go
+++ b/internal/infrastructure/tools/jsresolve/resolver.go
@@ -86,6 +86,7 @@ func (r *Resolver) Resolve(ctx context.Context, root string, graph modulegraph.G
 	}
 	workspaceByName := indexWorkspacesByName(inventory.Packages)
 	components := newComponentIndex(doc, r.limits.maxComponents, r.limits.maxCandidates, &coverage)
+	resolutions := r.readImporterResolutions(ctx, root, &coverage)
 
 	result := jsresolution.Result{GraphCoverage: append([]modulegraph.CoverageIssue(nil), normalizedGraph.Coverage...)}
 	for _, edge := range normalizedGraph.Edges {
@@ -137,7 +138,7 @@ func (r *Resolver) Resolve(ctx context.Context, root string, graph modulegraph.G
 					Detail: fmt.Sprintf("specifier %q may be a package self-reference", resolution.Specifier),
 				})
 			} else {
-				resolution = r.resolvePackageRoot(resolution, classified.PackageName, workspaceByName, inventory.Packages, components, &candidateWork, &coverage)
+				resolution = r.resolvePackageRoot(resolution, classified.PackageName, workspaceByName, inventory.Packages, components, resolutions, &candidateWork, &coverage)
 			}
 		default:
 			if aliasResolution, handled := r.resolveTSPaths(ctx, resolution, aliases.mappings, aliases.configs, aliases.scopeDiscoveryComplete, workspaceByName, inventory.Packages, components, modulePaths, &aliasWork, &candidateWork, &coverage); handled {

--- a/internal/infrastructure/tools/jsresolve/resolver_lockfile.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_lockfile.go
@@ -1,0 +1,309 @@
+package jsresolve
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+// Importer context is what turns a multi-version ambiguity into a deterministic identity. When a
+// repository installs two versions of the same package, the SBOM alone cannot say which one a given
+// source file gets — but the lockfile can, because it records the resolution per importer (per workspace
+// for pnpm, per install path for npm's hoisting rules).
+//
+// This reader is deliberately offline and read-only: it parses committed lockfiles and never runs a
+// package manager. A lockfile it cannot interpret degrades coverage; it never guesses a version.
+
+const (
+	npmLockfileName  = "package-lock.json"
+	pnpmLockfileName = "pnpm-lock.yaml"
+	yarnLockfileName = "yarn.lock"
+)
+
+// importerResolutions answers "which version of package P does importer directory D resolve to?".
+type importerResolutions struct {
+	// byImporter maps a repository-relative importer directory to package name -> resolved version.
+	byImporter map[string]map[string]string
+	// present records that at least one supported lockfile was read.
+	present bool
+}
+
+// selectVersion returns the version an importer resolves for a package name. It walks outward from the
+// importer's own directory, mirroring how a workspace inherits the root install context.
+func (i *importerResolutions) selectVersion(importerDir, packageName string) (string, bool) {
+	if i == nil || !i.present {
+		return "", false
+	}
+	dir := importerDir
+	for {
+		if versions, ok := i.byImporter[dir]; ok {
+			if version, ok := versions[packageName]; ok && version != "" {
+				return version, true
+			}
+		}
+		if dir == "." || dir == "" {
+			return "", false
+		}
+		parent := path.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// readImporterResolutions parses the committed lockfiles beneath root.
+func (r *Resolver) readImporterResolutions(ctx context.Context, root string, coverage *resolutionCoverageSink) *importerResolutions {
+	out := &importerResolutions{byImporter: map[string]map[string]string{}}
+
+	rootDir, err := os.OpenRoot(root)
+	if err != nil {
+		return out
+	}
+	defer func() { _ = rootDir.Close() }()
+
+	for _, name := range []string{pnpmLockfileName, npmLockfileName, yarnLockfileName} {
+		if err := ctx.Err(); err != nil {
+			return out
+		}
+		data, ok := readBoundedLockfile(rootDir, name, r.limits.maxLockfileBytes)
+		if !ok {
+			continue
+		}
+		switch name {
+		case pnpmLockfileName:
+			if parsePnpmImporters(data, out) {
+				out.present = true
+			} else {
+				coverage.add(jsresolution.CoverageIssue{
+					Kind: jsresolution.CoverageUnsupportedPackageManager, Path: name,
+					Detail: "pnpm lockfile importers could not be interpreted, so per-importer version selection is unavailable",
+				})
+			}
+		case npmLockfileName:
+			if parseNPMImporters(data, out) {
+				out.present = true
+			} else {
+				coverage.add(jsresolution.CoverageIssue{
+					Kind: jsresolution.CoverageUnsupportedPackageManager, Path: name,
+					Detail: "npm lockfile could not be interpreted, so per-importer version selection is unavailable",
+				})
+			}
+		case yarnLockfileName:
+			// A yarn lockfile records descriptors, not importers: a workspace's own resolution is not
+			// recoverable without also reading every workspace manifest's ranges and re-implementing
+			// yarn's descriptor matching. Report it rather than pretend the repository is unlocked.
+			coverage.add(jsresolution.CoverageIssue{
+				Kind: jsresolution.CoverageUnsupportedPackageManager, Path: name,
+				Detail: "yarn lockfiles do not record per-importer resolutions, so version selection stays ambiguous",
+			})
+		}
+	}
+	return out
+}
+
+// readBoundedLockfile reads a lockfile through the confined root handle, refusing a symlink, a
+// non-regular file, or a file past the byte budget.
+func readBoundedLockfile(rootDir *os.Root, name string, maxBytes int64) ([]byte, bool) {
+	info, err := rootDir.Lstat(name)
+	if err != nil || info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() > maxBytes {
+		return nil, false
+	}
+	f, err := rootDir.Open(name)
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil || int64(len(data)) > maxBytes {
+		return nil, false
+	}
+	return data, true
+}
+
+// parsePnpmImporters reads the `importers:` block of a pnpm lockfile, which maps each workspace
+// directory to the exact version it resolves for every declared dependency. This is the strongest
+// importer signal any npm-family lockfile provides.
+func parsePnpmImporters(data []byte, out *importerResolutions) bool {
+	lock := struct {
+		Importers map[string]struct {
+			Dependencies         map[string]pnpmLockDep `yaml:"dependencies"`
+			DevDependencies      map[string]pnpmLockDep `yaml:"devDependencies"`
+			OptionalDependencies map[string]pnpmLockDep `yaml:"optionalDependencies"`
+		} `yaml:"importers"`
+		Dependencies    map[string]pnpmLockDep `yaml:"dependencies"`
+		DevDependencies map[string]pnpmLockDep `yaml:"devDependencies"`
+	}{}
+	if err := yaml.Unmarshal(data, &lock); err != nil {
+		return false
+	}
+
+	record := func(dir string, groups ...map[string]pnpmLockDep) {
+		normalized := normalizeImporterDir(dir)
+		for _, group := range groups {
+			for name, dep := range group {
+				version := pnpmVersion(dep.Version)
+				if version == "" || !sbom.IsResolvedVersion(version) {
+					continue
+				}
+				if out.byImporter[normalized] == nil {
+					out.byImporter[normalized] = map[string]string{}
+				}
+				out.byImporter[normalized][name] = version
+			}
+		}
+	}
+
+	for dir, importer := range lock.Importers {
+		record(dir, importer.Dependencies, importer.DevDependencies, importer.OptionalDependencies)
+	}
+	// A single-package repository puts its dependencies at the top level instead of under importers.
+	record(".", lock.Dependencies, lock.DevDependencies)
+	return len(out.byImporter) > 0
+}
+
+type pnpmLockDep struct {
+	Version string `yaml:"version"`
+}
+
+// pnpmVersion strips pnpm's peer-dependency suffix, e.g. "18.2.0(react@18.2.0)" -> "18.2.0".
+func pnpmVersion(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if i := strings.IndexByte(trimmed, '('); i >= 0 {
+		trimmed = trimmed[:i]
+	}
+	// A pnpm link to a local workspace is not a registry version.
+	if strings.HasPrefix(trimmed, "link:") || strings.HasPrefix(trimmed, "file:") {
+		return ""
+	}
+	return strings.TrimSpace(trimmed)
+}
+
+// npmLockPackage is the subset of a lockfileVersion 2/3 `packages` entry this reader needs.
+type npmLockPackage struct {
+	Version      string            `json:"version"`
+	Dependencies map[string]string `json:"dependencies"`
+	DevDeps      map[string]string `json:"devDependencies"`
+	OptionalDeps map[string]string `json:"optionalDependencies"`
+	Link         bool              `json:"link"`
+	Resolved     string            `json:"resolved"`
+}
+
+// parseNPMImporters reads a lockfileVersion 2/3 `packages` map and resolves, for each importer, the
+// install that satisfies each declared dependency using npm's nearest-wins hoisting rule.
+func parseNPMImporters(data []byte, out *importerResolutions) bool {
+	lock := struct {
+		LockfileVersion int                       `json:"lockfileVersion"`
+		Packages        map[string]npmLockPackage `json:"packages"`
+	}{}
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return false
+	}
+	if len(lock.Packages) == 0 {
+		// lockfileVersion 1 has no `packages` map and no install paths, so hoisting is not recoverable.
+		return false
+	}
+
+	// An importer is the root project ("") or a workspace, which appears as a bare non-node_modules key.
+	for key, pkg := range lock.Packages {
+		if strings.Contains(key, "node_modules/") {
+			continue
+		}
+		dir := normalizeImporterDir(key)
+		for _, group := range []map[string]string{pkg.Dependencies, pkg.DevDeps, pkg.OptionalDeps} {
+			for name := range group {
+				installPath := resolveHoistedInstall(key, name, lock.Packages)
+				if installPath == "" {
+					continue
+				}
+				installed := lock.Packages[installPath]
+				if installed.Link || !sbom.IsResolvedVersion(installed.Version) {
+					// A link points at a local workspace, not a registry version.
+					continue
+				}
+				if out.byImporter[dir] == nil {
+					out.byImporter[dir] = map[string]string{}
+				}
+				out.byImporter[dir][name] = installed.Version
+			}
+		}
+	}
+	return len(out.byImporter) > 0
+}
+
+// resolveHoistedInstall applies npm's resolution rule: search the importer's own node_modules first,
+// then each ancestor install context outward, ending at the root. The nearest match wins. It returns ""
+// when no installed package satisfies the name, which is treated as no signal rather than a guess.
+func resolveHoistedInstall(fromPath, depName string, packages map[string]npmLockPackage) string {
+	cur := fromPath
+	for {
+		candidate := "node_modules/" + depName
+		if cur != "" {
+			candidate = cur + "/node_modules/" + depName
+		}
+		if _, ok := packages[candidate]; ok {
+			return candidate
+		}
+		if cur == "" {
+			return ""
+		}
+		if idx := strings.LastIndex(cur, "/node_modules/"); idx >= 0 {
+			cur = cur[:idx]
+			continue
+		}
+		cur = ""
+	}
+}
+
+// normalizeImporterDir converts a lockfile importer key to the repository-relative directory form the
+// resolver uses for module paths.
+func normalizeImporterDir(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.TrimPrefix(trimmed, "./")
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" {
+		return "."
+	}
+	return path.Clean(trimmed)
+}
+
+// disambiguateByImporter selects the single candidate whose version the importer resolves. It returns
+// false when the importer offers no signal or the selected version matches no candidate, so ambiguity is
+// preserved rather than resolved by guesswork.
+func disambiguateByImporter(
+	candidates []jsresolution.PackageIdentity,
+	resolutions *importerResolutions,
+	packages []jsresolution.PackageMetadata,
+	importer, packageName string,
+) (jsresolution.PackageIdentity, bool) {
+	if len(candidates) < 2 || resolutions == nil || !resolutions.present {
+		return jsresolution.PackageIdentity{}, false
+	}
+	importerDir := "."
+	if owner, ok := packageForRepositoryTarget(packages, importer); ok && owner.Path != "" {
+		importerDir = owner.Path
+	}
+	version, ok := resolutions.selectVersion(importerDir, packageName)
+	if !ok {
+		return jsresolution.PackageIdentity{}, false
+	}
+	var selected []jsresolution.PackageIdentity
+	for _, candidate := range candidates {
+		if candidate.Version == version {
+			selected = append(selected, candidate)
+		}
+	}
+	if len(selected) != 1 {
+		return jsresolution.PackageIdentity{}, false
+	}
+	return selected[0], true
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_lockfile_test.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_lockfile_test.go
@@ -1,0 +1,182 @@
+package jsresolve
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+// graphFrom builds a one-edge graph from an arbitrary importer module.
+func graphFrom(from, specifier string) modulegraph.Graph {
+	return modulegraph.Graph{
+		Modules: []modulegraph.Module{{Path: from, Dialect: modulegraph.DialectTypeScript}},
+		Edges:   []modulegraph.Edge{{From: from, Specifier: specifier, Kind: modulegraph.ImportESMStatic}},
+	}
+}
+
+// TestPnpmImporterSelectsTheVersion is the point of the whole phase: two versions of one package are
+// installed, so the SBOM alone is ambiguous, but the lockfile records which one EACH workspace resolves.
+func TestPnpmImporterSelectsTheVersion(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "private": true, "workspaces": []string{"packages/*"}})
+	writeJSON(t, r2bJoin(root, "packages", "api", "package.json"), map[string]any{"name": "@repo/api", "version": "1.0.0", "dependencies": map[string]string{"lodash": "^4.17.21"}})
+	writeJSON(t, r2bJoin(root, "packages", "web", "package.json"), map[string]any{"name": "@repo/web", "version": "1.0.0", "dependencies": map[string]string{"lodash": "^3.10.1"}})
+	writeFile(t, r2bJoin(root, "pnpm-lock.yaml"), `
+importers:
+  packages/api:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+  packages/web:
+    dependencies:
+      lodash:
+        specifier: ^3.10.1
+        version: 3.10.1
+`)
+	doc := docWith("pkg:npm/lodash@4.17.21", "pkg:npm/lodash@3.10.1")
+
+	tests := []struct {
+		importer    string
+		wantVersion string
+	}{
+		{importer: "packages/api/src/index.ts", wantVersion: "4.17.21"},
+		{importer: "packages/web/src/index.ts", wantVersion: "3.10.1"},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.importer, func(t *testing.T) {
+			t.Parallel()
+			result, err := NewResolver().Resolve(context.Background(), root, graphFrom(test.importer, "lodash"), doc)
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			got := resolutionsBySpecifier(result.Imports)["lodash"]
+			if got.Status != jsresolution.StatusComponent {
+				t.Fatalf("importer context must select one version, got %q (candidates %+v)", got.Status, got.Candidates)
+			}
+			if got.Package.Version != test.wantVersion {
+				t.Fatalf("version = %q, want %q", got.Package.Version, test.wantVersion)
+			}
+		})
+	}
+}
+
+func TestNPMHoistingSelectsTheVersion(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "root", "private": true, "workspaces": []string{"packages/*"}})
+	writeJSON(t, r2bJoin(root, "packages", "api", "package.json"), map[string]any{"name": "@repo/api", "version": "1.0.0", "dependencies": map[string]string{"lodash": "^3.10.1"}})
+	// packages/api pins its own nested copy; the root hoists a different version.
+	writeJSON(t, r2bJoin(root, "package-lock.json"), map[string]any{
+		"name": "root", "lockfileVersion": 3,
+		"packages": map[string]any{
+			"":                                 map[string]any{"dependencies": map[string]string{"lodash": "^4.17.21"}},
+			"packages/api":                     map[string]any{"name": "@repo/api", "version": "1.0.0", "dependencies": map[string]string{"lodash": "^3.10.1"}},
+			"node_modules/lodash":              map[string]any{"version": "4.17.21"},
+			"packages/api/node_modules/lodash": map[string]any{"version": "3.10.1"},
+		},
+	})
+	doc := docWith("pkg:npm/lodash@4.17.21", "pkg:npm/lodash@3.10.1")
+
+	// The nested install wins for the workspace (npm's nearest-wins rule).
+	result, err := NewResolver().Resolve(context.Background(), root, graphFrom("packages/api/src/index.ts", "lodash"), doc)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := resolutionsBySpecifier(result.Imports)["lodash"]
+	if got.Status != jsresolution.StatusComponent || got.Package.Version != "3.10.1" {
+		t.Fatalf("npm hoisting must select the nested version 3.10.1, got %+v", got)
+	}
+}
+
+func TestImporterDisambiguationNeverGuesses(t *testing.T) {
+	t.Parallel()
+
+	doc := docWith("pkg:npm/lodash@4.17.21", "pkg:npm/lodash@3.10.1")
+
+	t.Run("no lockfile leaves ambiguity", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+		result, err := NewResolver().Resolve(context.Background(), root, graphFrom("src/index.ts", "lodash"), doc)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		got := resolutionsBySpecifier(result.Imports)["lodash"]
+		if got.Status != jsresolution.StatusAmbiguous {
+			t.Fatalf("without a lockfile the ambiguity must stand, got %q", got.Status)
+		}
+	})
+
+	t.Run("lockfile version matching no candidate leaves ambiguity", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0", "dependencies": map[string]string{"lodash": "^2"}})
+		writeFile(t, r2bJoin(root, "pnpm-lock.yaml"), "importers:\n  .:\n    dependencies:\n      lodash:\n        specifier: ^2\n        version: 2.4.2\n")
+		result, err := NewResolver().Resolve(context.Background(), root, graphFrom("src/index.ts", "lodash"), doc)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		got := resolutionsBySpecifier(result.Imports)["lodash"]
+		if got.Status != jsresolution.StatusAmbiguous {
+			t.Fatalf("a lockfile version matching no sbom candidate must not select one, got %+v", got)
+		}
+	})
+
+	t.Run("yarn lockfiles report their limitation", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+		writeFile(t, r2bJoin(root, "yarn.lock"), "# yarn lockfile v1\nlodash@^4:\n  version \"4.17.21\"\n")
+		result, err := NewResolver().Resolve(context.Background(), root, graphFrom("src/index.ts", "lodash"), doc)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if !hasCoverageKind(result.Coverage, jsresolution.CoverageUnsupportedPackageManager) {
+			t.Fatalf("a yarn lockfile must report that per-importer selection is unavailable, got %+v", result.Coverage)
+		}
+	})
+
+	t.Run("a pnpm link is not a registry version", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeJSON(t, r2bJoin(root, "package.json"), map[string]any{"name": "app", "version": "1.0.0"})
+		writeFile(t, r2bJoin(root, "pnpm-lock.yaml"), "importers:\n  .:\n    dependencies:\n      lodash:\n        specifier: workspace:*\n        version: link:../local\n")
+		result, err := NewResolver().Resolve(context.Background(), root, graphFrom("src/index.ts", "lodash"), doc)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		got := resolutionsBySpecifier(result.Imports)["lodash"]
+		if got.Status == jsresolution.StatusComponent {
+			t.Fatalf("a link: resolution must not select a registry component, got %+v", got)
+		}
+	})
+}
+
+func TestPnpmVersionStripsPeerSuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"18.2.0":               "18.2.0",
+		"18.2.0(react@18.2.0)": "18.2.0",
+		"1.0.0(a@1)(b@2)":      "1.0.0",
+		"  4.17.21  ":          "4.17.21",
+		"link:../local":        "",
+		"file:../tarball.tgz":  "",
+	}
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			if got := pnpmVersion(input); got != want {
+				t.Fatalf("pnpmVersion(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/tools/jsresolve/resolver_package.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_package.go
@@ -30,6 +30,7 @@ func (r *Resolver) resolvePackageRoot(
 	workspaces map[string][]jsresolution.PackageIdentity,
 	packages []jsresolution.PackageMetadata,
 	components *componentIndex,
+	resolutions *importerResolutions,
 	candidateWork *resolverWorkBudget,
 	coverage *resolutionCoverageSink,
 ) jsresolution.ImportResolution {
@@ -48,7 +49,7 @@ func (r *Resolver) resolvePackageRoot(
 			})
 			return base
 		}
-		return r.correlateComponent(base, target, components, candidateWork, coverage)
+		return r.correlateComponent(base, target, components, resolutions, packages, candidateWork, coverage)
 	}
 
 	// A workspace declaration proves that a local package with this name exists,

--- a/internal/infrastructure/tools/jsresolve/resolver_sbom.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_sbom.go
@@ -266,6 +266,8 @@ func (r *Resolver) correlateComponent(
 	base jsresolution.ImportResolution,
 	packageName string,
 	components *componentIndex,
+	resolutions *importerResolutions,
+	packages []jsresolution.PackageMetadata,
 	candidateWork *resolverWorkBudget,
 	coverage *resolutionCoverageSink,
 ) jsresolution.ImportResolution {
@@ -317,6 +319,15 @@ func (r *Resolver) correlateComponent(
 		base.Reason = ""
 		return base
 	default:
+		// Several versions are installed. The lockfile records which one THIS importer resolves, so
+		// consult it before giving up: that is the difference between an actionable identity and a
+		// permanent ambiguity in any monorepo that pins two versions.
+		if selected, ok := disambiguateByImporter(matches, resolutions, packages, base.From, packageName); ok && !folded {
+			base.Status = jsresolution.StatusComponent
+			base.Package = selected
+			base.Reason = ""
+			return base
+		}
 		base.Status = jsresolution.StatusAmbiguous
 		base.Candidates = append([]jsresolution.PackageIdentity(nil), matches...)
 		base.Reason = "package name matches more than one sbom component version and importer context does not select one"

--- a/internal/infrastructure/tools/jsresolve/resolver_types.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_types.go
@@ -20,6 +20,7 @@ const (
 	defaultMaxResolverCandidateWork      = 1000000
 	defaultMaxResolverCandidates         = 256
 	defaultMaxResolverComponents         = 200000
+	defaultMaxResolverLockfileBytes      = 32 << 20
 	defaultMaxResolverCoverage           = 4096
 )
 
@@ -36,6 +37,7 @@ type resolverLimits struct {
 	maxCandidateWork      int
 	maxCandidates         int
 	maxComponents         int
+	maxLockfileBytes      int64
 	maxCoverageIssues     int
 }
 
@@ -53,6 +55,7 @@ func defaultResolverLimits() resolverLimits {
 		maxCandidateWork:      defaultMaxResolverCandidateWork,
 		maxCandidates:         defaultMaxResolverCandidates,
 		maxComponents:         defaultMaxResolverComponents,
+		maxLockfileBytes:      defaultMaxResolverLockfileBytes,
 		maxCoverageIssues:     defaultMaxResolverCoverage,
 	}
 }
@@ -61,7 +64,7 @@ func (l resolverLimits) validate() error {
 	if l.maxModules <= 0 || l.maxEdges <= 0 || l.maxGraphCoverage <= 0 || l.maxBindingsPerEdge <= 0 ||
 		l.maxTotalBindings <= 0 || l.maxSpecifierBytes <= 0 || l.maxModulePathBytes <= 0 || l.maxModulePathSegments <= 0 ||
 		l.maxAliasWork <= 0 || l.maxCandidateWork <= 0 || l.maxCandidates <= 0 ||
-		l.maxComponents <= 0 || l.maxCoverageIssues <= 0 {
+		l.maxComponents <= 0 || l.maxLockfileBytes <= 0 || l.maxCoverageIssues <= 0 {
 		return fmt.Errorf("%w: resolver limits must be positive", shared.ErrValidation)
 	}
 	return nil


### PR DESCRIPTION
Completes #400. Follows #459.

## The gap this closes

When a repository installs **two versions of the same package**, the SBOM alone cannot say which one a given source file gets, so correlation stopped at `ambiguous`. In a monorepo that meant *permanently* ambiguous — and therefore no later reachability conclusion at all, for exactly the repositories where reachability matters most.

The lockfile does record it, **per importer**. This reads committed lockfiles offline (no package manager is ever run) and uses that to select:

| Manager | Signal |
|---|---|
| **pnpm** | the `importers:` block maps each workspace directory to the exact version it resolves for every declared dependency — the strongest importer signal any npm-family lockfile provides |
| **npm** | `lockfileVersion` 2/3 `packages` install paths, resolved with npm's **nearest-wins hoisting** rule, so a workspace's nested pin beats the root hoist |
| **yarn** | a yarn lockfile records *descriptors*, not importers; a workspace's own resolution is not recoverable without re-implementing yarn's descriptor matching. That limitation is **reported as coverage**, never silently treated as an unlocked repository |

## Selection never guesses

Ambiguity stands whenever:
- there is no lockfile;
- the lockfile has no entry for this importer;
- the recorded version matches **no** SBOM candidate;
- the recorded resolution is a `link:`/`file:` local package rather than a registry version;
- the component matched only by case folding (never a proven identity — see #459).

## Safety

Lockfile reads are confined to the scan root (`os.OpenRoot`), refuse symlinks and non-regular files, and are bounded by a byte budget.

## Verification

`go build ./...` · `go vet` · **golangci-lint 0 issues** · full suite **171 packages, 0 failures** · `-race` green.

New tests prove two workspaces pinning different versions each resolve to **their own** version — for both pnpm importers and npm hoisting — and that every no-signal path preserves ambiguity.

With this, every acceptance criterion of #400 is met.
