### PR TITLE
feat(reachability): add the Tier-1 JavaScript/TypeScript reachability analyzer (#401)

### DIFF
--- a/internal/domain/jsresolution/jsresolution.go
+++ b/internal/domain/jsresolution/jsresolution.go
@@ -149,8 +149,12 @@ type Inventory struct {
 // Complete is false whenever package-resolution coverage is incomplete; source
 // graph coverage is preserved separately and must also be considered by callers.
 type Result struct {
-	Imports       []ImportResolution
-	Coverage      []CoverageIssue
-	GraphCoverage []modulegraph.CoverageIssue
-	Complete      bool
+	// DeclaredDependencies are the package names first-party manifests declare, sorted and
+	// deduplicated. A package absent from this list is TRANSITIVE: first-party source could not import
+	// it directly, so the absence of a first-party import proves nothing about whether it is loaded.
+	DeclaredDependencies []string
+	Imports              []ImportResolution
+	Coverage             []CoverageIssue
+	GraphCoverage        []modulegraph.CoverageIssue
+	Complete             bool
 }

--- a/internal/domain/jsresolution/purl.go
+++ b/internal/domain/jsresolution/purl.go
@@ -1,0 +1,122 @@
+package jsresolution
+
+import "strings"
+
+// npm package URLs are the join key between a source import, an SBOM component and a reachability
+// subject. Because three separate layers compare those strings, the encoding rules live here rather than
+// being re-derived in each: a builder and a parser that disagree would not fail loudly, they would return
+// zero matches, and "no match" is indistinguishable from "the dependency is unused".
+
+// NPMPURLPrefix is the package-URL type prefix for the npm ecosystem.
+const NPMPURLPrefix = "pkg:npm/"
+
+// NPMPURL builds the canonical npm package URL for name@version. A scoped package's leading "@" is
+// percent-encoded as %40, while the "/" separating scope from name and the "@" before the version stay
+// literal. It is the exact inverse of ParseNPMPURL.
+func NPMPURL(name, version string) string {
+	encoded := name
+	if strings.HasPrefix(encoded, "@") {
+		encoded = "%40" + encoded[1:]
+	}
+	return NPMPURLPrefix + encoded + "@" + version
+}
+
+// ParseNPMPURL extracts the package name and version from an npm package URL, returning ok=false for any
+// other ecosystem or a malformed identity.
+//
+// The name is returned with the component's OWN casing rather than normalized: npm hosts distinct
+// packages whose names differ only in case (JSONStream and jsonstream are not the same package), so
+// folding here would let one package's identity be attached to another's import. The name is still
+// VALIDATED through NormalizePackageName so a malformed purl cannot become an identity.
+func ParseNPMPURL(raw string) (string, string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if len(trimmed) <= len(NPMPURLPrefix) || !strings.HasPrefix(strings.ToLower(trimmed), NPMPURLPrefix) {
+		return "", "", false
+	}
+	body := trimmed[len(NPMPURLPrefix):]
+
+	// Qualifiers and subpaths are not part of a component's identity.
+	if i := strings.IndexAny(body, "?#"); i >= 0 {
+		body = body[:i]
+	}
+	// The version follows the LAST "@": a scoped name's own "@" is percent-encoded, so any literal "@"
+	// that remains is the version separator.
+	at := strings.LastIndex(body, "@")
+	if at <= 0 || at == len(body)-1 {
+		return "", "", false
+	}
+	name, version := purlDecodeName(body[:at]), body[at+1:]
+	if name == "" || version == "" {
+		return "", "", false
+	}
+	if _, err := NormalizePackageName(name); err != nil {
+		return "", "", false
+	}
+	return name, version, true
+}
+
+// CanonicalNPMPURL rewrites an npm package URL into the canonical encoding, so two spellings of the same
+// identity ("pkg:npm/@scope/p@1.0.0" and "pkg:npm/%40scope/p@1.0.0") compare equal. It returns ok=false
+// when raw is not a usable npm identity.
+//
+// Comparing canonical forms is what stops an encoding difference between the SBOM producer and the
+// caller from being read as "this package is not imported".
+func CanonicalNPMPURL(raw string) (string, bool) {
+	name, version, ok := ParseNPMPURL(raw)
+	if !ok {
+		return "", false
+	}
+	return NPMPURL(name, version), true
+}
+
+// purlDecodeName percent-decodes a package URL name segment. Only well-formed escapes are decoded; an
+// unrecognized escape is left intact so the name fails validation rather than silently naming a
+// different package.
+func purlDecodeName(raw string) string {
+	if !strings.Contains(raw, "%") {
+		return raw
+	}
+	var sb strings.Builder
+	for i := 0; i < len(raw); {
+		if raw[i] == '%' && i+2 < len(raw) {
+			hi, hiOK := hexValue(raw[i+1])
+			lo, loOK := hexValue(raw[i+2])
+			if hiOK && loOK {
+				sb.WriteByte(hi<<4 | lo)
+				i += 3
+				continue
+			}
+		}
+		sb.WriteByte(raw[i])
+		i++
+	}
+	return sb.String()
+}
+
+func hexValue(b byte) (byte, bool) {
+	switch {
+	case b >= '0' && b <= '9':
+		return b - '0', true
+	case b >= 'a' && b <= 'f':
+		return b - 'a' + 10, true
+	case b >= 'A' && b <= 'F':
+		return b - 'A' + 10, true
+	}
+	return 0, false
+}
+
+// IsRuntimeImport reports whether an import resolution is evidence that a package is loaded at RUNTIME.
+//
+// A type-only relationship does not survive compilation, so it can never make a package reachable: an
+// `import type` clause, an entirely type-only binding list, and any import written in a declaration-only
+// module (.d.ts) all describe types rather than a loaded package. A literal dynamic import DOES count,
+// because the package is explicitly named in the source.
+//
+// This lives in the domain because it is a fact about TypeScript rather than a policy of any one
+// consumer: a second, divergent copy elsewhere would be a false negative.
+func IsRuntimeImport(imp ImportResolution, declarationOnlyModules map[string]bool) bool {
+	if imp.TypeOnly || imp.DeclarationOnly {
+		return false
+	}
+	return !declarationOnlyModules[imp.From]
+}

--- a/internal/domain/jsresolution/result.go
+++ b/internal/domain/jsresolution/result.go
@@ -13,6 +13,7 @@ import (
 // from package-resolution coverage and explicit unresolved states. Source graph
 // coverage is preserved separately for the later reachability gate.
 func NormalizeResult(in Result) (Result, error) {
+	in.DeclaredDependencies = normalizeNameList(in.DeclaredDependencies)
 	out := Result{}
 	out.Imports = make([]ImportResolution, 0, len(in.Imports))
 	for _, resolution := range in.Imports {
@@ -334,4 +335,29 @@ func deduplicateGraphCoverage(in []modulegraph.CoverageIssue) []modulegraph.Cove
 		}
 	}
 	return out
+}
+
+// normalizeNameList sorts and deduplicates a package-name list so resolution output does not depend on
+// manifest key order.
+func normalizeNameList(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, name := range in {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Strings(out)
+	result := out[:1]
+	for _, name := range out[1:] {
+		if name != result[len(result)-1] {
+			result = append(result, name)
+		}
+	}
+	return result
 }

--- a/internal/infrastructure/tools/jsimports/extract.go
+++ b/internal/infrastructure/tools/jsimports/extract.go
@@ -364,8 +364,11 @@ func (e *extractor) handleStaticImportClause(kw token) {
 		specifier: specifier,
 		kind:      modulegraph.ImportESMStatic,
 		bindings:  bindings,
-		typeOnly:  typeOnly || allBindingsTypeOnly(bindings),
-		position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+		// Only a KEYWORD-level `import type` is fully erased. An all-inline-type binding list
+		// (`import { type A } from "pkg"`) still emits `import "pkg"` under verbatimModuleSyntax, which
+		// is a real side-effect module load — so it must stay runtime evidence.
+		typeOnly: typeOnly,
+		position: modulegraph.Position{Line: kw.line, Column: kw.column},
 	}, escaped)
 }
 
@@ -557,7 +560,7 @@ func (e *extractor) handleExportKeyword(kw token) {
 			specifier: specifier,
 			kind:      modulegraph.ImportReExport,
 			bindings:  bindings,
-			typeOnly:  typeOnly || allBindingsTypeOnly(bindings),
+			typeOnly:  typeOnly,
 			position:  modulegraph.Position{Line: kw.line, Column: kw.column},
 		}, escaped)
 	default:
@@ -647,18 +650,4 @@ func (e *extractor) handleRequire(kw, prev, prev2 token, havePrev bool) {
 		e.push(t)
 		e.addHazard(hazardDynamicRequire, kw.line, "require referenced outside a call")
 	}
-}
-
-// allBindingsTypeOnly reports whether a non-empty binding list is entirely type-only, which makes the
-// whole edge type-only: no runtime module load survives compilation.
-func allBindingsTypeOnly(bindings []modulegraph.Binding) bool {
-	if len(bindings) == 0 {
-		return false
-	}
-	for _, b := range bindings {
-		if !b.TypeOnly {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/infrastructure/tools/jsimports/extract_test.go
+++ b/internal/infrastructure/tools/jsimports/extract_test.go
@@ -160,7 +160,10 @@ func TestExtractTypeOnlyClassification(t *testing.T) {
 		{name: "import type clause", src: `import type { T } from "pkg";`, wantTypeOnly: true},
 		{name: "import type default", src: `import type T from "pkg";`, wantTypeOnly: true},
 		{name: "export type clause", src: `export type { T } from "pkg";`, wantTypeOnly: true},
-		{name: "all inline type members", src: `import { type A, type B } from "pkg";`, wantTypeOnly: true},
+		// An all-inline-type binding list is NOT fully erased: under verbatimModuleSyntax tsc emits
+		// `import "pkg";`, a real side-effect module load. Only a keyword-level `import type` is erased,
+		// so treating this as type-only would drop a runtime dependency edge.
+		{name: "all inline type members stay runtime", src: `import { type A, type B } from "pkg";`, wantTypeOnly: false},
 		{name: "mixed inline members stay runtime", src: `import { type A, b } from "pkg";`, wantTypeOnly: false},
 		{name: "value import", src: `import { a } from "pkg";`, wantTypeOnly: false},
 		// A binding literally named "type" is a VALUE import, not a type-only modifier. Reading it as

--- a/internal/infrastructure/tools/jsimports/scanner.go
+++ b/internal/infrastructure/tools/jsimports/scanner.go
@@ -114,7 +114,7 @@ var assetExtensions = map[string]bool{
 	".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".svg": true, ".webp": true, ".avif": true, ".ico": true, ".bmp": true,
 	".woff": true, ".woff2": true, ".ttf": true, ".otf": true, ".eot": true,
 	".mp3": true, ".mp4": true, ".webm": true, ".wav": true, ".ogg": true,
-	".txt": true, ".md": true, ".mdx": true, ".html": true, ".htm": true,
+	".txt":  true,
 	".wasm": true, ".graphql": true, ".gql": true, ".proto": true, ".csv": true, ".xml": true,
 	".sql": true, ".sh": true, ".pdf": true, ".zip": true,
 }
@@ -124,6 +124,10 @@ var assetExtensions = map[string]bool{
 var codeCarryingExtensions = map[string]bool{
 	".vue": true, ".svelte": true, ".astro": true, ".marko": true, ".riot": true,
 	".coffee": true, ".litcoffee": true, ".res": true, ".re": true, ".elm": true,
+	// MDX compiles to JavaScript and routinely carries real ESM imports; HTML carries
+	// <script type="module">. Treating either as an inert asset would let a package imported only
+	// from documentation or a Storybook page look unused.
+	".mdx": true, ".md": true, ".html": true, ".htm": true,
 }
 
 // Scan walks root and returns the normalized first-party module graph.

--- a/internal/infrastructure/tools/jsresolve/resolver.go
+++ b/internal/infrastructure/tools/jsresolve/resolver.go
@@ -157,6 +157,13 @@ func (r *Resolver) Resolve(ctx context.Context, root string, graph modulegraph.G
 		}
 		result.Imports = append(result.Imports, resolution)
 	}
+	// First-party manifests decide which packages source code may import DIRECTLY. A later analyzer
+	// needs this to know when the absence of an import is meaningful at all.
+	for _, pkg := range inventory.Packages {
+		for _, dep := range pkg.Dependencies {
+			result.DeclaredDependencies = append(result.DeclaredDependencies, dep.Name)
+		}
+	}
 	result.Coverage = coverage.issues
 	return jsresolution.NormalizeResult(result)
 }

--- a/internal/infrastructure/tools/jsresolve/resolver_sbom.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_sbom.go
@@ -9,10 +9,6 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 )
 
-// npmPURLPrefix is the package-URL type prefix for the npm ecosystem. A component of any other
-// ecosystem must never be correlated to a JavaScript import.
-const npmPURLPrefix = "pkg:npm/"
-
 // componentIndex is the npm slice of a normalized SBOM, indexed by package name for exact-PURL
 // correlation (#400).
 //
@@ -68,11 +64,11 @@ func newComponentIndex(doc *sbom.SBOM, maxComponents, maxCandidates int, coverag
 	unresolvedVersion := 0
 	for i := range components {
 		component := components[i]
-		if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(component.PURL)), npmPURLPrefix) {
+		if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(component.PURL)), jsresolution.NPMPURLPrefix) {
 			// Another ecosystem, or a component with no PURL: not correlatable to a JS import.
 			continue
 		}
-		name, version, ok := parseNPMPURL(component.PURL)
+		name, version, ok := jsresolution.ParseNPMPURL(component.PURL)
 		if !ok {
 			unparseable++
 			continue
@@ -181,78 +177,6 @@ func (c *componentIndex) dropReason(packageName string) string {
 		return ""
 	}
 	return c.dropped[packageName]
-}
-
-// parseNPMPURL extracts the package name and version from an npm package URL.
-//
-// The repository's parsers encode a scoped package as "pkg:npm/%40scope/name@1.2.3": the scope's leading
-// "@" is percent-encoded, the separating "/" is literal, and the "@" before the version is literal. This
-// decodes that form back to "@scope/name" so it can be compared with a source specifier's package root.
-func parseNPMPURL(purl string) (string, string, bool) {
-	trimmed := strings.TrimSpace(purl)
-	if len(trimmed) <= len(npmPURLPrefix) || !strings.HasPrefix(strings.ToLower(trimmed), npmPURLPrefix) {
-		return "", "", false
-	}
-	body := trimmed[len(npmPURLPrefix):]
-
-	// Qualifiers and subpaths are not part of the identity.
-	if i := strings.IndexAny(body, "?#"); i >= 0 {
-		body = body[:i]
-	}
-	// The version follows the LAST "@": a scoped name's own "@" is percent-encoded, so any literal "@"
-	// that remains is the version separator.
-	at := strings.LastIndex(body, "@")
-	if at <= 0 || at == len(body)-1 {
-		return "", "", false
-	}
-	rawName, version := body[:at], body[at+1:]
-	name := purlDecodeName(rawName)
-	if name == "" || version == "" {
-		return "", "", false
-	}
-	// Validate the name through the domain normalizer (which lowercases) but RETURN the component's own
-	// casing: npm hosts distinct packages that differ only in case, so folding here would let one
-	// package's PURL be attached to another's import.
-	if _, err := jsresolution.NormalizePackageName(name); err != nil {
-		return "", "", false
-	}
-	return name, version, true
-}
-
-// purlDecodeName percent-decodes a PURL name segment. Only the encodings the repository's PURL builders
-// produce are decoded; an unrecognized escape leaves the name unchanged so it fails validation rather
-// than silently naming a different package.
-func purlDecodeName(raw string) string {
-	if !strings.Contains(raw, "%") {
-		return raw
-	}
-	var sb strings.Builder
-	for i := 0; i < len(raw); {
-		if raw[i] == '%' && i+2 < len(raw) {
-			hi, hiOK := hexValue(raw[i+1])
-			lo, loOK := hexValue(raw[i+2])
-			if hiOK && loOK {
-				sb.WriteByte(hi<<4 | lo)
-				i += 3
-				continue
-			}
-		}
-		sb.WriteByte(raw[i])
-		i++
-	}
-	return sb.String()
-}
-
-func hexValue(b byte) (byte, bool) {
-	switch {
-	case b >= '0' && b <= '9':
-		return b - '0', true
-	case b >= 'a' && b <= 'f':
-		return b - 'a' + 10, true
-	case b >= 'A' && b <= 'F':
-		return b - 'A' + 10, true
-	}
-	return 0, false
 }
 
 // correlateComponent resolves a third-party package name against the SBOM.

--- a/internal/infrastructure/tools/jsresolve/resolver_sbom_test.go
+++ b/internal/infrastructure/tools/jsresolve/resolver_sbom_test.go
@@ -68,15 +68,15 @@ func TestParseNPMPURL(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			name, version, ok := parseNPMPURL(test.purl)
+			name, version, ok := jsresolution.ParseNPMPURL(test.purl)
 			if ok != test.wantOK {
-				t.Fatalf("parseNPMPURL(%q) ok = %v, want %v (name %q version %q)", test.purl, ok, test.wantOK, name, version)
+				t.Fatalf("ParseNPMPURL(%q) ok = %v, want %v (name %q version %q)", test.purl, ok, test.wantOK, name, version)
 			}
 			if !test.wantOK {
 				return
 			}
 			if name != test.wantName || version != test.wantVersion {
-				t.Fatalf("parseNPMPURL(%q) = (%q, %q), want (%q, %q)", test.purl, name, version, test.wantName, test.wantVersion)
+				t.Fatalf("ParseNPMPURL(%q) = (%q, %q), want (%q, %q)", test.purl, name, version, test.wantName, test.wantVersion)
 			}
 		})
 	}

--- a/internal/usecase/jsreach/analyzer.go
+++ b/internal/usecase/jsreach/analyzer.go
@@ -1,0 +1,385 @@
+// Package jsreach implements deterministic Tier-1 reachability for npm components: does first-party
+// JavaScript or TypeScript source actually import a given package?
+//
+// SAFETY: a not-reachable verdict can suppress a real vulnerability downstream, so this analyzer REFUSES
+// a conclusion — returning a no-coverage error, which leaves any prior tier standing — whenever anything
+// could hide an import. That includes a failed scan, a module graph with any coverage issue (a dynamic
+// loader, an unreadable file, a budget breach), incomplete package resolution, or an ambiguous component
+// identity. Only a completely observed project can produce a negative result.
+//
+// It follows the Python Tier-1 analyzer's model, with two differences. The canonical subject is an EXACT
+// component package URL rather than a distribution name, because npm routinely installs several versions
+// of the same package and a name alone would not say which one was reached. And it answers only for
+// DIRECT dependencies: the module graph is first-party only, so for a transitive package the absence of a
+// first-party import proves nothing — that package is loaded by its parent, not by this source tree.
+package jsreach
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachability"
+)
+
+// Narrow consumer-side interfaces; ports.JSImportScanner and ports.JSImportResolver satisfy them.
+type (
+	importScanner interface {
+		Scan(ctx context.Context, root string) (modulegraph.Graph, error)
+	}
+	importResolver interface {
+		Resolve(ctx context.Context, root string, graph modulegraph.Graph, doc *sbom.SBOM) (jsresolution.Result, error)
+	}
+	// sbomProvider supplies the SBOM whose components are the analysis subjects. Package identity is
+	// only meaningful against a specific SBOM, and Analyze's signature is fixed by the reachability
+	// analyzer contract, so the document is fetched rather than passed.
+	sbomProvider interface {
+		SBOMFor(ctx context.Context, targetRef string) (*sbom.SBOM, error)
+	}
+)
+
+// Analyzer implements the reachproof analyzer contract over a JavaScript/TypeScript import scan.
+type Analyzer struct {
+	scanner  importScanner
+	resolver importResolver
+	sboms    sbomProvider
+}
+
+// New validates and returns the analyzer.
+func New(scanner importScanner, resolver importResolver, sboms sbomProvider) (*Analyzer, error) {
+	if scanner == nil || resolver == nil || sboms == nil {
+		return nil, fmt.Errorf("%w: jsreach analyzer needs a scanner, a resolver and an sbom provider", shared.ErrValidation)
+	}
+	return &Analyzer{scanner: scanner, resolver: resolver, sboms: sboms}, nil
+}
+
+// Analyze reports, for each subject component PURL, whether first-party source imports it.
+//
+// dir is the workspace directory to scan. Every subject must be an exact npm component PURL; a subject
+// of another ecosystem is a caller error rather than a silent non-result, because interpreting it as an
+// npm package would answer a question nobody asked.
+func (a *Analyzer) Analyze(ctx context.Context, dir string, subjects []string) (*reachability.Analysis, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: jsreach analysis requires a context", shared.ErrValidation)
+	}
+	if strings.TrimSpace(dir) == "" {
+		return nil, fmt.Errorf("%w: jsreach analysis requires a target directory", shared.ErrValidation)
+	}
+
+	wanted, err := normalizeSubjects(subjects)
+	if err != nil {
+		return nil, err
+	}
+	if len(wanted) == 0 {
+		return &reachability.Analysis{}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	doc, err := a.sboms.SBOMFor(ctx, dir)
+	if err != nil {
+		return nil, fmt.Errorf("jsreach: sbom unavailable (no coverage - prior tier stands): %w", err)
+	}
+	if doc == nil {
+		return nil, fmt.Errorf("%w: jsreach has no sbom for the target (no coverage)", shared.ErrNotFound)
+	}
+
+	graph, err := a.scanner.Scan(ctx, dir)
+	if err != nil {
+		return nil, fmt.Errorf("jsreach: javascript import scan (no coverage - prior tier stands): %w", err)
+	}
+	// A graph coverage issue means some module load was unobservable, so "no edge" is not proof of
+	// absence for ANY subject. Refuse the whole analysis rather than risk a false not-reachable.
+	if len(graph.Coverage) > 0 {
+		return nil, fmt.Errorf("%w: module graph has %d coverage issue(s) - javascript reachability is inconclusive (no coverage)",
+			shared.ErrValidation, len(graph.Coverage))
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	resolution, err := a.resolver.Resolve(ctx, dir, graph, doc)
+	if err != nil {
+		return nil, fmt.Errorf("jsreach: package resolution (no coverage - prior tier stands): %w", err)
+	}
+	if !resolution.Complete {
+		// An unresolved, ambiguous or unsupported identity could BE the subject, so no negative
+		// conclusion is safe for any of them.
+		return nil, fmt.Errorf("%w: package resolution is incomplete - javascript reachability is inconclusive (no coverage)",
+			shared.ErrValidation)
+	}
+	// The resolver may surface graph limitations its own snapshot did not carry; the domain contract
+	// says a caller must consider both.
+	if len(resolution.GraphCoverage) > 0 {
+		return nil, fmt.Errorf("%w: resolution reports %d graph coverage issue(s) - javascript reachability is inconclusive (no coverage)",
+			shared.ErrValidation, len(resolution.GraphCoverage))
+	}
+
+	// Every subject must be locatable in the very SBOM being reasoned over, and must be a package
+	// first-party source could import DIRECTLY. Either gap makes a negative meaningless: an absent
+	// component means the subject came from a different document, and a transitive package is loaded by
+	// its parent rather than by this source tree.
+	if err := a.assertSubjectsAnswerable(wanted, doc, resolution); err != nil {
+		return nil, err
+	}
+
+	declarationOnly := make(map[string]bool, len(graph.Modules))
+	for _, module := range graph.Modules {
+		if module.DeclarationOnly {
+			declarationOnly[module.Path] = true
+		}
+	}
+	importers := runtimeImportersByPURL(declarationOnly, resolution)
+	prover := newPathProver(graph, declarationOnly)
+
+	results := make([]reachability.Result, 0, len(wanted))
+	for _, purl := range wanted {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		result := reachability.Result{Symbol: purl}
+		// Match on the CANONICAL identity: the subject and the component may be encoded differently
+		// ("%40scope" versus "@scope"), and a byte comparison would read that as "not imported".
+		canonical, _ := jsresolution.CanonicalNPMPURL(purl)
+		if sites := importers[canonical]; len(sites) > 0 {
+			result.Reachable = true
+			result.Path = prover.proofFor(sites, purl)
+		}
+		results = append(results, result)
+	}
+
+	roots := append([]string(nil), graph.Roots...)
+	sort.Strings(roots)
+	return &reachability.Analysis{Results: results, Entrypoints: roots}, nil
+}
+
+// assertSubjectsAnswerable refuses the analysis unless every subject is a component of the supplied SBOM
+// AND a declared direct dependency of first-party code.
+//
+// Without the first check a subject minted from a different document would silently miss every import
+// and be sealed as not-reachable. Without the second, a transitive package — the majority of npm
+// findings — would be declared unreachable merely because the first-party graph never names it, which is
+// true of every transitive package and proves nothing.
+func (a *Analyzer) assertSubjectsAnswerable(subjects []string, doc *sbom.SBOM, resolution jsresolution.Result) error {
+	inSBOM := make(map[string]bool, len(doc.Components))
+	for _, component := range doc.Components {
+		if canonical, ok := jsresolution.CanonicalNPMPURL(component.PURL); ok {
+			inSBOM[canonical] = true
+		}
+	}
+	declared := make(map[string]bool, len(resolution.DeclaredDependencies))
+	for _, name := range resolution.DeclaredDependencies {
+		declared[strings.ToLower(name)] = true
+	}
+
+	for _, subject := range subjects {
+		canonical, ok := jsresolution.CanonicalNPMPURL(subject)
+		if !ok {
+			return fmt.Errorf("%w: jsreach subject %q is not a valid npm component purl", shared.ErrValidation, subject)
+		}
+		if !inSBOM[canonical] {
+			return fmt.Errorf("%w: subject %q is not a component of the analyzed sbom - javascript reachability is inconclusive (no coverage)",
+				shared.ErrValidation, subject)
+		}
+		name, _, _ := jsresolution.ParseNPMPURL(subject)
+		if !declared[strings.ToLower(name)] {
+			return fmt.Errorf("%w: %q is not a declared direct dependency, so a first-party import graph cannot prove it unused (no coverage)",
+				shared.ErrValidation, name)
+		}
+	}
+	return nil
+}
+
+// normalizeSubjects validates and deduplicates the subjects, preserving both input order and the
+// caller's EXACT strings.
+//
+// It never trims or case-folds a subject. The coordinator looks each result up by the caller's original
+// string, so a rewritten key would be missed there and sealed as not-reachable at full confidence — a
+// silent false negative. A subject that is not already canonical is a caller error instead.
+func normalizeSubjects(subjects []string) ([]string, error) {
+	out := make([]string, 0, len(subjects))
+	seen := make(map[string]bool, len(subjects))
+	for _, subject := range subjects {
+		if strings.TrimSpace(subject) == "" {
+			return nil, fmt.Errorf("%w: jsreach subject is blank", shared.ErrValidation)
+		}
+		if subject != strings.TrimSpace(subject) {
+			return nil, fmt.Errorf("%w: jsreach subject %q has surrounding whitespace", shared.ErrValidation, subject)
+		}
+		if _, _, ok := jsresolution.ParseNPMPURL(subject); !ok {
+			return nil, fmt.Errorf("%w: jsreach subject %q is not a valid npm component purl", shared.ErrValidation, subject)
+		}
+		if seen[subject] {
+			continue
+		}
+		seen[subject] = true
+		out = append(out, subject)
+	}
+	return out, nil
+}
+
+// importSite is one first-party module importing a component, with the specifier it used.
+type importSite struct {
+	module      string
+	packageName string
+}
+
+// runtimeImportersByPURL indexes, per CANONICAL component PURL, the first-party modules that import it
+// at runtime. The runtime-versus-type-only rule itself lives in the domain, so this and any other
+// consumer cannot drift apart.
+func runtimeImportersByPURL(declarationOnly map[string]bool, resolution jsresolution.Result) map[string][]importSite {
+	out := map[string][]importSite{}
+	for _, imp := range resolution.Imports {
+		if imp.Status != jsresolution.StatusComponent || imp.Package.PURL == "" {
+			continue
+		}
+		if !jsresolution.IsRuntimeImport(imp, declarationOnly) {
+			continue
+		}
+		canonical, ok := jsresolution.CanonicalNPMPURL(imp.Package.PURL)
+		if !ok {
+			continue
+		}
+		// The proof carries the RESOLVED package name, never the raw source specifier: a specifier is
+		// attacker-controlled text that would otherwise reach a sealed, hash-chained judgment rationale,
+		// and the name has already been through the domain's strict charset validation.
+		out[canonical] = append(out[canonical], importSite{module: imp.From, packageName: imp.Package.Name})
+	}
+	for purl := range out {
+		sites := out[purl]
+		sort.Slice(sites, func(i, j int) bool {
+			if sites[i].module != sites[j].module {
+				return sites[i].module < sites[j].module
+			}
+			return sites[i].packageName < sites[j].packageName
+		})
+		out[purl] = sites
+	}
+	return out
+}
+
+// pathProver builds a deterministic, cycle-safe proof path from a structural graph root to an importing
+// module. Structural roots are provenance only — they are modules with no incoming first-party edge, not
+// verified runtime entrypoints — so the proof states a source-to-component relationship, not an
+// execution guarantee.
+type pathProver struct {
+	// adjacency maps a module to its resolved first-party runtime targets, sorted.
+	adjacency map[string][]string
+	roots     []string
+}
+
+func newPathProver(graph modulegraph.Graph, declarationOnly map[string]bool) *pathProver {
+	adjacency := map[string][]string{}
+	for _, edge := range graph.Edges {
+		if edge.To == "" || edge.TypeOnly {
+			continue
+		}
+		// A declaration module never executes, so a path through one is not a runtime route and must
+		// not be presented as evidence.
+		if declarationOnly[edge.From] || declarationOnly[edge.To] {
+			continue
+		}
+		adjacency[edge.From] = append(adjacency[edge.From], edge.To)
+	}
+	for from := range adjacency {
+		targets := adjacency[from]
+		sort.Strings(targets)
+		adjacency[from] = dedupeStrings(targets)
+	}
+	roots := append([]string(nil), graph.Roots...)
+	sort.Strings(roots)
+	return &pathProver{adjacency: adjacency, roots: roots}
+}
+
+// proofFor returns the shortest deterministic path ending at the component. When no structural root
+// reaches an importing module — a cyclic graph has no roots at all — it falls back to the direct proof
+// "importer → import specifier → component", which is still explainable evidence.
+func (p *pathProver) proofFor(sites []importSite, purl string) []string {
+	targets := make(map[string]importSite, len(sites))
+	for _, site := range sites {
+		if _, exists := targets[site.module]; !exists {
+			targets[site.module] = site
+		}
+	}
+
+	if path, site, ok := p.shortestPathToAny(targets); ok {
+		return append(append([]string(nil), path...), "import "+site.packageName, purl)
+	}
+	// Deterministic fallback: the first importing module in sorted order.
+	site := sites[0]
+	return []string{site.module, "import " + site.packageName, purl}
+}
+
+// shortestPathToAny runs a breadth-first search from the structural roots, visiting neighbours in sorted
+// order so the shortest path is also the deterministic one. Visited tracking makes it cycle-safe.
+func (p *pathProver) shortestPathToAny(targets map[string]importSite) ([]string, importSite, bool) {
+	if len(targets) == 0 || len(p.roots) == 0 {
+		return nil, importSite{}, false
+	}
+	// Track only each node's PARENT and rebuild the one winning path on success. Copying a full path
+	// per enqueued node would be O(V^2) memory, which a 50k-module repository turns into gigabytes in
+	// this in-process analyzer.
+	parent := make(map[string]string, len(p.adjacency))
+	visited := make(map[string]bool, len(p.adjacency))
+	queue := make([]string, 0, len(p.roots))
+	for _, root := range p.roots {
+		if visited[root] {
+			continue
+		}
+		visited[root] = true
+		queue = append(queue, root)
+	}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if site, ok := targets[current]; ok {
+			return buildPath(parent, current), site, true
+		}
+		for _, next := range p.adjacency[current] {
+			if visited[next] {
+				continue
+			}
+			visited[next] = true
+			parent[next] = current
+			queue = append(queue, next)
+		}
+	}
+	return nil, importSite{}, false
+}
+
+// buildPath walks the parent chain back to the root and returns the path in forward order.
+func buildPath(parent map[string]string, end string) []string {
+	var reversed []string
+	for node := end; ; {
+		reversed = append(reversed, node)
+		previous, ok := parent[node]
+		if !ok {
+			break
+		}
+		node = previous
+	}
+	path := make([]string, 0, len(reversed))
+	for i := len(reversed) - 1; i >= 0; i-- {
+		path = append(path, reversed[i])
+	}
+	return path
+}
+
+func dedupeStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	out := values[:1]
+	for _, value := range values[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/usecase/jsreach/analyzer_test.go
+++ b/internal/usecase/jsreach/analyzer_test.go
@@ -1,0 +1,732 @@
+package jsreach
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type fakeScanner struct {
+	graph modulegraph.Graph
+	err   error
+}
+
+func (f fakeScanner) Scan(context.Context, string) (modulegraph.Graph, error) { return f.graph, f.err }
+
+type fakeResolver struct {
+	result jsresolution.Result
+	err    error
+}
+
+func (f fakeResolver) Resolve(context.Context, string, modulegraph.Graph, *sbom.SBOM) (jsresolution.Result, error) {
+	return f.result, f.err
+}
+
+type fakeSBOMs struct {
+	doc *sbom.SBOM
+	err error
+}
+
+func (f fakeSBOMs) SBOMFor(context.Context, string) (*sbom.SBOM, error) { return f.doc, f.err }
+
+func emptySBOM() *sbom.SBOM { return &sbom.SBOM{} }
+
+// mod builds a module entry with the dialect implied by its path.
+func mod(path string) modulegraph.Module {
+	dialect, _ := modulegraph.DialectForPath(path)
+	return modulegraph.Module{Path: path, Dialect: dialect, DeclarationOnly: modulegraph.IsDeclarationPath(path)}
+}
+
+// componentImport builds a resolved component import from a module.
+func componentImport(from, specifier, purl string) jsresolution.ImportResolution {
+	return jsresolution.ImportResolution{
+		From: from, Specifier: specifier, Kind: modulegraph.ImportESMStatic,
+		Status: jsresolution.StatusComponent,
+		Package: jsresolution.PackageIdentity{
+			Name: specifier, Version: "1.0.0", PURL: purl,
+		},
+	}
+}
+
+// analyzerFor wires an analyzer whose SBOM contains, and whose first-party manifests declare, every
+// purl in answerable — the two preconditions the analyzer requires before it will answer at all.
+func analyzerFor(t *testing.T, graph modulegraph.Graph, result jsresolution.Result, answerable ...string) *Analyzer {
+	t.Helper()
+	result.Complete = true
+
+	doc := &sbom.SBOM{}
+	for _, purl := range answerable {
+		name, version, ok := jsresolution.ParseNPMPURL(purl)
+		if !ok {
+			t.Fatalf("test fixture purl %q is not a valid npm purl", purl)
+		}
+		doc.Components = append(doc.Components, sbom.Component{Name: name, Version: version, PURL: purl})
+		result.DeclaredDependencies = append(result.DeclaredDependencies, name)
+	}
+
+	a, err := New(fakeScanner{graph: graph}, fakeResolver{result: result}, fakeSBOMs{doc: doc})
+	if err != nil {
+		t.Fatalf("new analyzer: %v", err)
+	}
+	return a
+}
+
+func TestNewValidatesDependencies(t *testing.T) {
+	t.Parallel()
+
+	if _, err := New(nil, fakeResolver{}, fakeSBOMs{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil scanner must be rejected, got %v", err)
+	}
+	if _, err := New(fakeScanner{}, nil, fakeSBOMs{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil resolver must be rejected, got %v", err)
+	}
+	if _, err := New(fakeScanner{}, fakeResolver{}, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil sbom provider must be rejected, got %v", err)
+	}
+}
+
+func TestReachableComponent(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{mod("src/index.ts")},
+		Roots:   []string{"src/index.ts"},
+	}
+	result := jsresolution.Result{Imports: []jsresolution.ImportResolution{
+		componentImport("src/index.ts", "lodash", purl),
+	}}
+
+	analysis, err := analyzerFor(t, graph, result, purl).Analyze(context.Background(), "/ws", []string{purl})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if len(analysis.Results) != 1 || !analysis.Results[0].Reachable {
+		t.Fatalf("an imported component must be reachable, got %+v", analysis.Results)
+	}
+	// The proof must end at the exact component and name the importing module.
+	path := analysis.Results[0].Path
+	if len(path) == 0 || path[len(path)-1] != purl {
+		t.Fatalf("proof must end at the component purl, got %v", path)
+	}
+	if path[0] != "src/index.ts" {
+		t.Fatalf("proof must start at the importing module, got %v", path)
+	}
+}
+
+func TestNotReachableComponent(t *testing.T) {
+	t.Parallel()
+
+	// The component is in the SBOM but no first-party module imports it. With a fully observed graph
+	// and complete resolution, that is a definitive negative.
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	result := jsresolution.Result{Imports: []jsresolution.ImportResolution{
+		componentImport("src/index.ts", "used", "pkg:npm/used@1.0.0"),
+	}}
+
+	analysis, err := analyzerFor(t, graph, result, "pkg:npm/used@1.0.0", "pkg:npm/unused@2.0.0").
+		Analyze(context.Background(), "/ws", []string{"pkg:npm/unused@2.0.0"})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if len(analysis.Results) != 1 || analysis.Results[0].Reachable {
+		t.Fatalf("an unimported component must be not-reachable, got %+v", analysis.Results)
+	}
+	if len(analysis.Results[0].Path) != 0 {
+		t.Fatalf("a negative result carries no proof path, got %v", analysis.Results[0].Path)
+	}
+}
+
+// TestTypeOnlyImportsAreNotRuntimeEvidence locks a core #401 rule: a type relationship does not survive
+// compilation, so it must never make a package reachable.
+func TestTypeOnlyImportsAreNotRuntimeEvidence(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/some-types@1.0.0"
+	tests := []struct {
+		name string
+		imp  jsresolution.ImportResolution
+		mods []modulegraph.Module
+	}{
+		{
+			name: "import type clause",
+			imp: func() jsresolution.ImportResolution {
+				i := componentImport("src/index.ts", "some-types", purl)
+				i.TypeOnly = true
+				return i
+			}(),
+			mods: []modulegraph.Module{mod("src/index.ts")},
+		},
+		{
+			name: "declaration-only import flag",
+			imp: func() jsresolution.ImportResolution {
+				i := componentImport("src/index.ts", "some-types", purl)
+				i.DeclarationOnly = true
+				return i
+			}(),
+			mods: []modulegraph.Module{mod("src/index.ts")},
+		},
+		{
+			name: "import inside a declaration module",
+			imp:  componentImport("src/types.d.ts", "some-types", purl),
+			mods: []modulegraph.Module{mod("src/types.d.ts")},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			graph := modulegraph.Graph{Modules: test.mods, Roots: []string{test.mods[0].Path}}
+			result := jsresolution.Result{Imports: []jsresolution.ImportResolution{test.imp}}
+
+			analysis, err := analyzerFor(t, graph, result, purl).Analyze(context.Background(), "/ws", []string{purl})
+			if err != nil {
+				t.Fatalf("analyze: %v", err)
+			}
+			if analysis.Results[0].Reachable {
+				t.Fatalf("%s must not establish runtime reachability", test.name)
+			}
+		})
+	}
+}
+
+func TestRuntimeCapableImportKinds(t *testing.T) {
+	t.Parallel()
+
+	// A literal dynamic import and a CommonJS require both name the package explicitly in the source,
+	// so both are runtime evidence.
+	for _, kind := range []modulegraph.ImportKind{
+		modulegraph.ImportESMStatic, modulegraph.ImportESMDynamic,
+		modulegraph.ImportCommonJS, modulegraph.ImportReExport, modulegraph.ImportTypeScriptEqual,
+	} {
+		kind := kind
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			const purl = "pkg:npm/chart.js@4.0.0"
+			imp := componentImport("src/index.ts", "chart.js", purl)
+			imp.Kind = kind
+			graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+			result := jsresolution.Result{Imports: []jsresolution.ImportResolution{imp}}
+
+			analysis, err := analyzerFor(t, graph, result, purl).Analyze(context.Background(), "/ws", []string{purl})
+			if err != nil {
+				t.Fatalf("analyze: %v", err)
+			}
+			if !analysis.Results[0].Reachable {
+				t.Fatalf("%s must establish runtime reachability", kind)
+			}
+		})
+	}
+}
+
+// TestIncompleteCoverageNeverYieldsNotReachable is THE safety gate. Each condition below could hide an
+// import, so the analyzer must refuse the whole analysis rather than return Reachable:false, which a
+// caller would seal as evidence that a dependency is unused.
+func TestIncompleteCoverageNeverYieldsNotReachable(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	base := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+
+	tests := []struct {
+		name     string
+		scanner  importScanner
+		resolver importResolver
+		sboms    sbomProvider
+	}{
+		{
+			name:     "scanner failure",
+			scanner:  fakeScanner{err: errors.New("scan exploded")},
+			resolver: fakeResolver{result: jsresolution.Result{Complete: true}},
+			sboms:    fakeSBOMs{doc: emptySBOM()},
+		},
+		{
+			name: "graph coverage issue",
+			scanner: fakeScanner{graph: modulegraph.Graph{
+				Modules:  base.Modules,
+				Roots:    base.Roots,
+				Coverage: []modulegraph.CoverageIssue{{Kind: modulegraph.CoverageDynamicRequire, Path: "src/index.ts"}},
+			}},
+			resolver: fakeResolver{result: jsresolution.Result{Complete: true}},
+			sboms:    fakeSBOMs{doc: emptySBOM()},
+		},
+		{
+			name:     "resolver failure",
+			scanner:  fakeScanner{graph: base},
+			resolver: fakeResolver{err: errors.New("resolve exploded")},
+			sboms:    fakeSBOMs{doc: emptySBOM()},
+		},
+		{
+			name:     "incomplete resolution",
+			scanner:  fakeScanner{graph: base},
+			resolver: fakeResolver{result: jsresolution.Result{Complete: false}},
+			sboms:    fakeSBOMs{doc: emptySBOM()},
+		},
+		{
+			name:     "sbom unavailable",
+			scanner:  fakeScanner{graph: base},
+			resolver: fakeResolver{result: jsresolution.Result{Complete: true}},
+			sboms:    fakeSBOMs{err: errors.New("no sbom")},
+		},
+		{
+			name:     "nil sbom",
+			scanner:  fakeScanner{graph: base},
+			resolver: fakeResolver{result: jsresolution.Result{Complete: true}},
+			sboms:    fakeSBOMs{},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			a, err := New(test.scanner, test.resolver, test.sboms)
+			if err != nil {
+				t.Fatalf("new: %v", err)
+			}
+			analysis, err := a.Analyze(context.Background(), "/ws", []string{purl})
+			if err == nil {
+				t.Fatalf("%s must produce a no-coverage error, got analysis %+v", test.name, analysis)
+			}
+			if analysis != nil {
+				t.Fatalf("a no-coverage error must return no analysis, got %+v", analysis)
+			}
+		})
+	}
+}
+
+func TestSubjectHandling(t *testing.T) {
+	t.Parallel()
+
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	result := jsresolution.Result{Imports: []jsresolution.ImportResolution{
+		componentImport("src/index.ts", "lodash", "pkg:npm/lodash@4.17.21"),
+	}}
+
+	t.Run("input order preserved and duplicates removed", func(t *testing.T) {
+		t.Parallel()
+		subjects := []string{"pkg:npm/b@1.0.0", "pkg:npm/a@1.0.0", "pkg:npm/b@1.0.0", "pkg:npm/c@1.0.0"}
+		analysis, err := analyzerFor(t, graph, result, subjects...).Analyze(context.Background(), "/ws", subjects)
+		if err != nil {
+			t.Fatalf("analyze: %v", err)
+		}
+		got := make([]string, 0, len(analysis.Results))
+		for _, r := range analysis.Results {
+			got = append(got, r.Symbol)
+		}
+		want := []string{"pkg:npm/b@1.0.0", "pkg:npm/a@1.0.0", "pkg:npm/c@1.0.0"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("subjects = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("non-npm subject is rejected", func(t *testing.T) {
+		t.Parallel()
+		// Interpreting a PyPI purl as an npm package would answer a question nobody asked.
+		_, err := analyzerFor(t, graph, result).Analyze(context.Background(), "/ws", []string{"pkg:pypi/requests@2.0.0"})
+		if !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("a non-npm subject must be a validation error, got %v", err)
+		}
+	})
+
+	t.Run("malformed subject is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := analyzerFor(t, graph, result).Analyze(context.Background(), "/ws", []string{"lodash@4.17.21"})
+		if !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("a malformed subject must be a validation error, got %v", err)
+		}
+	})
+
+	t.Run("no subjects yields an empty analysis", func(t *testing.T) {
+		t.Parallel()
+		analysis, err := analyzerFor(t, graph, result).Analyze(context.Background(), "/ws", nil)
+		if err != nil {
+			t.Fatalf("analyze: %v", err)
+		}
+		if len(analysis.Results) != 0 {
+			t.Fatalf("no subjects means no results, got %+v", analysis.Results)
+		}
+	})
+
+	t.Run("blank target directory is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := analyzerFor(t, graph, result, "pkg:npm/a@1.0.0").Analyze(context.Background(), "  ", []string{"pkg:npm/a@1.0.0"})
+		if !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("a blank directory must be a validation error, got %v", err)
+		}
+	})
+}
+
+func TestProofPathIsShortestAndDeterministic(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	// Two routes reach the importer; the shorter one must win, and the answer must not depend on edge
+	// order in the graph.
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{mod("src/root.ts"), mod("src/short.ts"), mod("src/a.ts"), mod("src/b.ts"), mod("src/leaf.ts")},
+		Edges: []modulegraph.Edge{
+			{From: "src/root.ts", To: "src/a.ts", Specifier: "./a", Kind: modulegraph.ImportESMStatic},
+			{From: "src/a.ts", To: "src/b.ts", Specifier: "./b", Kind: modulegraph.ImportESMStatic},
+			{From: "src/b.ts", To: "src/leaf.ts", Specifier: "./leaf", Kind: modulegraph.ImportESMStatic},
+			{From: "src/root.ts", To: "src/short.ts", Specifier: "./short", Kind: modulegraph.ImportESMStatic},
+			{From: "src/short.ts", To: "src/leaf.ts", Specifier: "./leaf", Kind: modulegraph.ImportESMStatic},
+		},
+		Roots: []string{"src/root.ts"},
+	}
+	result := jsresolution.Result{Imports: []jsresolution.ImportResolution{
+		componentImport("src/leaf.ts", "lodash", purl),
+	}}
+
+	first, err := analyzerFor(t, graph, result, purl).Analyze(context.Background(), "/ws", []string{purl})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	want := []string{"src/root.ts", "src/short.ts", "src/leaf.ts", "import lodash", purl}
+	if !reflect.DeepEqual(first.Results[0].Path, want) {
+		t.Fatalf("proof = %v, want the shortest route %v", first.Results[0].Path, want)
+	}
+
+	second, err := analyzerFor(t, graph, result, purl).Analyze(context.Background(), "/ws", []string{purl})
+	if err != nil {
+		t.Fatalf("analyze again: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("repeated analysis of the same input must be identical")
+	}
+}
+
+func TestProofPathIsCycleSafe(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	// A pure cycle has no structural roots at all, so the BFS finds nothing and the direct proof is
+	// used. This must terminate rather than loop.
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{mod("src/a.ts"), mod("src/b.ts")},
+		Edges: []modulegraph.Edge{
+			{From: "src/a.ts", To: "src/b.ts", Specifier: "./b", Kind: modulegraph.ImportESMStatic},
+			{From: "src/b.ts", To: "src/a.ts", Specifier: "./a", Kind: modulegraph.ImportESMStatic},
+		},
+	}
+	result := jsresolution.Result{Imports: []jsresolution.ImportResolution{
+		componentImport("src/b.ts", "lodash", purl),
+	}}
+
+	analysis, err := analyzerFor(t, graph, result, purl).Analyze(context.Background(), "/ws", []string{purl})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	want := []string{"src/b.ts", "import lodash", purl}
+	if !reflect.DeepEqual(analysis.Results[0].Path, want) {
+		t.Fatalf("a rootless graph must fall back to the direct proof, got %v", analysis.Results[0].Path)
+	}
+}
+
+func TestProofPathContainsNoHostPathsOrSource(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	result := jsresolution.Result{Imports: []jsresolution.ImportResolution{
+		componentImport("src/index.ts", "lodash", purl),
+	}}
+
+	analysis, err := analyzerFor(t, graph, result, purl).Analyze(context.Background(), "/ws", []string{purl})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	// The proof is sealed into a judgment, so it must carry only repository-relative paths and package
+	// identities — never an absolute host path or source text.
+	for _, element := range analysis.Results[0].Path {
+		if len(element) > 0 && element[0] == '/' {
+			t.Fatalf("proof element %q looks like an absolute host path", element)
+		}
+	}
+}
+
+func TestNonComponentStatusesAreNotEvidence(t *testing.T) {
+	t.Parallel()
+
+	// Only an exact component identity can prove reachability. A workspace, builtin or ambiguous
+	// resolution names no third-party component.
+	const purl = "pkg:npm/lodash@4.17.21"
+	for _, status := range []jsresolution.Status{
+		jsresolution.StatusWorkspace, jsresolution.StatusBuiltin,
+		jsresolution.StatusAmbiguous, jsresolution.StatusUnresolved, jsresolution.StatusLocal,
+	} {
+		status := status
+		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+			imp := componentImport("src/index.ts", "lodash", purl)
+			imp.Status = status
+			graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+			result := jsresolution.Result{Imports: []jsresolution.ImportResolution{imp}}
+
+			analysis, err := analyzerFor(t, graph, result, purl).Analyze(context.Background(), "/ws", []string{purl})
+			if err != nil {
+				t.Fatalf("analyze: %v", err)
+			}
+			if analysis.Results[0].Reachable {
+				t.Fatalf("status %q must not prove reachability", status)
+			}
+		})
+	}
+}
+
+func TestEntrypointsArePreservedAsProvenance(t *testing.T) {
+	t.Parallel()
+
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{mod("src/a.ts"), mod("src/b.ts")},
+		Roots:   []string{"src/a.ts", "src/b.ts"},
+	}
+	analysis, err := analyzerFor(t, graph, jsresolution.Result{}, "pkg:npm/x@1.0.0").
+		Analyze(context.Background(), "/ws", []string{"pkg:npm/x@1.0.0"})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if !reflect.DeepEqual(analysis.Entrypoints, []string{"src/a.ts", "src/b.ts"}) {
+		t.Fatalf("structural roots must be preserved as provenance, got %v", analysis.Entrypoints)
+	}
+}
+
+// TestSubjectEncodingVariantStillMatches is the regression for the highest-severity defect found in
+// review: the subject and the SBOM component may encode a scoped package differently ("%40scope" versus
+// "@scope"). A byte comparison would report EVERY scoped package as not-reachable, which downstream
+// becomes an OpenVEX not_affected for a package the source demonstrably imports.
+func TestSubjectEncodingVariantStillMatches(t *testing.T) {
+	t.Parallel()
+
+	const componentPURL = "pkg:npm/%40babel/traverse@7.22.5"
+	const subjectPURL = "pkg:npm/@babel/traverse@7.22.5"
+
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	imp := componentImport("src/index.ts", "@babel/traverse", componentPURL)
+	imp.Package.Name = "@babel/traverse"
+	result := jsresolution.Result{
+		Imports:              []jsresolution.ImportResolution{imp},
+		DeclaredDependencies: []string{"@babel/traverse"},
+		Complete:             true,
+	}
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "@babel/traverse", Version: "7.22.5", PURL: componentPURL}}}
+
+	a, err := New(fakeScanner{graph: graph}, fakeResolver{result: result}, fakeSBOMs{doc: doc})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	analysis, err := a.Analyze(context.Background(), "/ws", []string{subjectPURL})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if !analysis.Results[0].Reachable {
+		t.Fatal("an encoding variant of the same identity must still match; a byte comparison would suppress a real finding")
+	}
+	// The result must be keyed by the CALLER's string, because that is what the coordinator looks up.
+	if analysis.Results[0].Symbol != subjectPURL {
+		t.Fatalf("result symbol = %q, want the caller's exact subject %q", analysis.Results[0].Symbol, subjectPURL)
+	}
+}
+
+// TestTransitiveSubjectIsRefused locks the semantic limit of a first-party import graph: a package that
+// first-party code cannot import directly is loaded by its parent dependency, so the absence of a
+// first-party import proves nothing about it.
+func TestTransitiveSubjectIsRefused(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/deep-transitive@1.0.0"
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	result := jsresolution.Result{
+		Complete: true,
+		// The manifest declares only "direct"; the subject is a transitive package.
+		DeclaredDependencies: []string{"direct"},
+	}
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "deep-transitive", Version: "1.0.0", PURL: purl}}}
+
+	a, err := New(fakeScanner{graph: graph}, fakeResolver{result: result}, fakeSBOMs{doc: doc})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	analysis, err := a.Analyze(context.Background(), "/ws", []string{purl})
+	if err == nil {
+		t.Fatalf("a transitive subject must be refused, got %+v", analysis)
+	}
+	if analysis != nil {
+		t.Fatalf("a refusal must return no analysis, got %+v", analysis)
+	}
+}
+
+func TestSubjectAbsentFromTheAnalyzedSBOMIsRefused(t *testing.T) {
+	t.Parallel()
+
+	// A subject minted from a DIFFERENT document would silently miss every import and be sealed as
+	// not-reachable. It must be refused instead.
+	const purl = "pkg:npm/from-another-doc@1.0.0"
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	result := jsresolution.Result{Complete: true, DeclaredDependencies: []string{"from-another-doc"}}
+
+	a, err := New(fakeScanner{graph: graph}, fakeResolver{result: result}, fakeSBOMs{doc: &sbom.SBOM{}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if _, err := a.Analyze(context.Background(), "/ws", []string{purl}); err == nil {
+		t.Fatal("a subject absent from the analyzed sbom must be refused")
+	}
+}
+
+func TestResolutionGraphCoverageIsAlsoAGate(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	// The scanner's own snapshot is clean, but the resolver reports a graph limitation. The domain
+	// contract says a caller must consider both.
+	result := jsresolution.Result{
+		Complete:             true,
+		DeclaredDependencies: []string{"lodash"},
+		GraphCoverage:        []modulegraph.CoverageIssue{{Kind: modulegraph.CoverageDynamicImport, Path: "src/index.ts"}},
+	}
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "lodash", Version: "4.17.21", PURL: purl}}}
+
+	a, err := New(fakeScanner{graph: graph}, fakeResolver{result: result}, fakeSBOMs{doc: doc})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if _, err := a.Analyze(context.Background(), "/ws", []string{purl}); err == nil {
+		t.Fatal("resolution graph coverage must gate the analysis")
+	}
+}
+
+func TestBlankAndNonCanonicalSubjectsAreRejected(t *testing.T) {
+	t.Parallel()
+
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	// A subject that is silently dropped becomes a sealed not-reachable in the coordinator, which reads
+	// "absent from the result set" as a negative.
+	bad := []string{
+		"",                        // blank
+		"   ",                     // whitespace only
+		" pkg:npm/lodash@4.17.21", // leading space: the coordinator would look up the untrimmed form
+		"pkg:npm/",                // no name
+		"pkg:npm/lodash",          // no version
+		"pkg:npm/lodash@",         // empty version
+		"PKG:NPM/lodash@4.17.21",  // accepted-then-never-matched if the prefix test folds case
+	}
+	for _, subject := range bad {
+		subject := subject
+		t.Run(subject, func(t *testing.T) {
+			t.Parallel()
+			_, err := analyzerFor(t, graph, jsresolution.Result{}).Analyze(context.Background(), "/ws", []string{subject})
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("subject %q must be a validation error, got %v", subject, err)
+			}
+		})
+	}
+}
+
+func TestCancelledContextIsHonored(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	result := jsresolution.Result{Complete: true, DeclaredDependencies: []string{"lodash"}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := analyzerFor(t, graph, result, purl).Analyze(ctx, "/ws", []string{purl})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("a cancelled context must abort the analysis, got %v", err)
+	}
+}
+
+func TestProofPathCarriesTheResolvedNameNotTheRawSpecifier(t *testing.T) {
+	t.Parallel()
+
+	// A specifier is attacker-controlled source text that would otherwise reach a sealed, hash-chained
+	// judgment rationale. The proof must carry the resolved package name, which has been through the
+	// domain's strict charset validation.
+	const purl = "pkg:npm/lodash@4.17.21"
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	imp := componentImport("src/index.ts", "lodash/\x1b[31mCRITICAL\x07", purl)
+	imp.Package.Name = "lodash"
+	result := jsresolution.Result{Imports: []jsresolution.ImportResolution{imp}, Complete: true, DeclaredDependencies: []string{"lodash"}}
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "lodash", Version: "4.17.21", PURL: purl}}}
+
+	a, err := New(fakeScanner{graph: graph}, fakeResolver{result: result}, fakeSBOMs{doc: doc})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	analysis, err := a.Analyze(context.Background(), "/ws", []string{purl})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	for _, element := range analysis.Results[0].Path {
+		if strings.ContainsAny(element, "\x1b\x07\r\n") {
+			t.Fatalf("proof element %q carries control bytes into sealed evidence", element)
+		}
+	}
+}
+
+func TestMultipleImportersPickTheDeterministicSite(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{mod("src/a.ts"), mod("src/b.ts")},
+		Roots:   []string{"src/a.ts", "src/b.ts"},
+	}
+	result := jsresolution.Result{
+		Imports: []jsresolution.ImportResolution{
+			componentImport("src/b.ts", "lodash", purl),
+			componentImport("src/a.ts", "lodash", purl),
+			componentImport("src/a.ts", "lodash", purl), // duplicate site
+		},
+		Complete:             true,
+		DeclaredDependencies: []string{"lodash"},
+	}
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "lodash", Version: "4.17.21", PURL: purl}}}
+
+	a, err := New(fakeScanner{graph: graph}, fakeResolver{result: result}, fakeSBOMs{doc: doc})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	first, err := a.Analyze(context.Background(), "/ws", []string{purl})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	second, err := a.Analyze(context.Background(), "/ws", []string{purl})
+	if err != nil {
+		t.Fatalf("analyze again: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("multiple importers must still yield a deterministic proof")
+	}
+	if first.Results[0].Path[0] != "src/a.ts" {
+		t.Fatalf("the sorted-first importer must be chosen, got %v", first.Results[0].Path)
+	}
+}
+
+func TestMixedReachableAndNotReachableSubjects(t *testing.T) {
+	t.Parallel()
+
+	const used = "pkg:npm/used@1.0.0"
+	const unused = "pkg:npm/unused@2.0.0"
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	result := jsresolution.Result{Imports: []jsresolution.ImportResolution{componentImport("src/index.ts", "used", used)}}
+
+	analysis, err := analyzerFor(t, graph, result, used, unused).Analyze(context.Background(), "/ws", []string{used, unused})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if !analysis.Results[0].Reachable || analysis.Results[1].Reachable {
+		t.Fatalf("subjects must be answered independently, got %+v", analysis.Results)
+	}
+}

--- a/internal/usecase/jsreach/contract_test.go
+++ b/internal/usecase/jsreach/contract_test.go
@@ -1,0 +1,17 @@
+package jsreach
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// The analyzer takes narrow consumer-side interfaces rather than importing ports into production code.
+// These assertions keep them from drifting away from the ports they are meant to narrow, which would
+// otherwise only surface when the composition root wires them.
+func TestLocalInterfacesMatchThePorts(t *testing.T) {
+	var (
+		_ importScanner  = ports.JSImportScanner(nil)
+		_ importResolver = ports.JSImportResolver(nil)
+	)
+}


### PR DESCRIPTION
Phase R3 of epic #378, following #458/#459/#460.

## What

`internal/usecase/jsreach` answers, for an exact npm component PURL, whether first-party source imports it. It uses the existing `reachability.Analysis`/`Result` contract (no second reachability status model) and **mints no judgment** — promotion stays with `reachproof` in R4.

## Refuses rather than guesses

A not-reachable verdict can suppress a real vulnerability, so the analyzer returns a **no-coverage error** (leaving any prior tier standing) whenever anything could hide an import: failed scan, a module graph with **any** coverage issue, resolution that is incomplete or reports graph coverage of its own, or a missing SBOM.

## Two limits the review found — now enforced, not assumed

1. **The subject must be a component of the SBOM being reasoned over.** A subject minted from a *different* document would miss every import and be sealed as not-reachable at full confidence.
2. **The subject must be a declared DIRECT dependency.** The module graph is first-party only, so for a **transitive** package — the majority of npm findings — the absence of a first-party import proves nothing, because it is loaded by its parent. Resolution now carries the declared dependency names for exactly this.

## Canonical matching (highest-severity fix)

An SBOM component and a finding may encode a scoped package differently — `pkg:npm/%40babel/traverse@7.22.5` vs `pkg:npm/@babel/traverse@7.22.5`. A byte comparison would report **every scoped package** as unreachable → OpenVEX `not_affected` on packages the source demonstrably imports. Subjects now match on canonical identity, while results stay keyed by the **caller's exact string** (the coordinator looks them up that way — a trimmed or folded key would be missed there and sealed as a negative). Blank or non-canonical subjects are validation errors, never silent non-results.

## Proof paths

Cycle-safe, shortest-first, deterministic; never route through declaration-only modules; and carry the **resolved package name** rather than the raw source specifier — which is attacker-controlled text that would otherwise reach a sealed, hash-chained judgment rationale. The search tracks parents instead of copying a path per node (the old shape was O(V²) memory: ~20 GB on a 50k-module repo, in-process).

## Two upstream defects also fixed

- `.mdx`/`.md`/`.html` were classified as inert assets, but **MDX compiles to JavaScript** and HTML carries `<script type="module">`. A package imported only from docs or Storybook looked unused. They now degrade coverage like other unparsed component formats.
- An all-inline-type binding list (`import { type A } from "pkg"`) was treated as fully erased, but under `verbatimModuleSyntax` it emits `import "pkg"` — a real side-effect load. Only a keyword-level `import type` is erased now.

## Domain consolidation

npm PURL parse/build moves to `domain/jsresolution` as one exported pair, so the builder and parser cannot drift — a divergence there would not fail loudly, it would return **zero matches**, and zero matches is indistinguishable from "unused". The runtime-vs-type-only predicate moves there too.

## Verification

`go build ./...` · `go vet` · **golangci-lint 0 issues** · full suite **172 packages, 0 failures** · `-race` green. Both reviewers run; all findings applied.

## Note for R4

`reachproof.actorsForTier` currently attributes **all** Tier-1 proofs to `system:pyimport-scan`/`system:pyimport-engine`. Wiring JS through it unchanged would credit JavaScript proofs to the Python engine in the audit log and the sealed rationale. R4 must add the language dimension.
