### PR TITLE
feat(reachability): integrate JavaScript Tier-1 reachability with SCA and judgments (#378 R4)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -58,6 +58,8 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarchecksum"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarhash"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jarlicense"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jsimports"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jsresolve"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/jvmreach"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/license"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/licensefile"
@@ -116,6 +118,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fptriage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/jsreach"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/leaderuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/llmverifier"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
@@ -1198,6 +1201,20 @@ func main() {
 		}
 		scaService.SetPyReachability(pyCoord)
 		log.Info("Tier-1 Python import-reachability ENABLED (source-only dead-dependency detection → OpenVEX not_affected; best-effort)")
+	}
+
+	// Deterministic Tier-1 JavaScript/TypeScript import-reachability, opt-in. Source-only like the Python
+	// path (the scanner only lexes text, so it needs no sandbox), and it answers only for DIRECT
+	// dependencies: a first-party import graph cannot prove a TRANSITIVE package unused, because that
+	// package is loaded by its parent. Requires the judgment lifecycle. Composition-root only.
+	if cfg.JSReachabilityEnabled && requireJudgmentsOrSkip(log, judgmentSvc != nil, "SYNAPSE_JSREACH_ENABLED", "javascript reachability") {
+		jsRecorder, jerr := jsreach.NewRecorder(jsimports.New(), jsresolve.NewResolver(), judgmentSvc, auditLog, clock)
+		if jerr != nil {
+			log.Error("javascript reachability recorder init failed", "err", jerr)
+			os.Exit(1)
+		}
+		scaService.SetJSReachability(jsRecorder)
+		log.Info("Tier-1 JavaScript import-reachability ENABLED (source-only, direct dependencies only → OpenVEX not_affected; best-effort)")
 	}
 
 	// Deterministic taint-analysis CapSAST proposals, opt-in. Builds the workspace call

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -286,6 +286,14 @@ type Config struct {
 	// dynamic-import / no-coverage target leaves the prior tier standing, never a false "not reachable").
 	// Also requires the judgment lifecycle (SYNAPSE_JUDGMENTS_ENABLED).
 	PyReachabilityEnabled bool
+
+	// JSReachabilityEnabled turns on deterministic Tier-1 JavaScript/TypeScript import-reachability: a
+	// declared npm dependency that first-party source never imports becomes not_reachable, which the
+	// export path turns into an OpenVEX not_affected justification. Source-only (nothing is executed or
+	// installed), best-effort and opt-in, and it answers only for DIRECT dependencies because a
+	// first-party import graph cannot prove a transitive package unused. Also requires the judgment
+	// lifecycle (SYNAPSE_JUDGMENTS_ENABLED).
+	JSReachabilityEnabled bool
 	// TaintCallgraphBin is the pinned synapse-callgraph binary: the sandboxed go/ssa call-graph builder
 	// the taint analyzer shells out to. In-repo cmd (built by `make build` into bin/); pin its hash via
 	// SYNAPSE_TOOL_HASHES, like any other tool binary.
@@ -473,6 +481,7 @@ func Load() Config {
 		OwnedAdvisoryEnabled:         getbool("SYNAPSE_OWNED_ADVISORY", true),
 		ReachabilityEnabled:          getbool("SYNAPSE_REACHABILITY_ENABLED", true),
 		PyReachabilityEnabled:        getbool("SYNAPSE_PYREACH_ENABLED", false),
+		JSReachabilityEnabled:        getbool("SYNAPSE_JSREACH_ENABLED", false),
 		CrossCheckEnabled:            getbool("SYNAPSE_CROSSCHECK_ENABLED", true),
 		SBOMCrossCheckEnabled:        getbool("SYNAPSE_SBOM_CROSSCHECK_ENABLED", true),
 		WriteupDraftsEnabled:         getbool("SYNAPSE_WRITEUP_DRAFTS_ENABLED", false), // needs agent → opt-in

--- a/internal/usecase/jsreach/analyzer.go
+++ b/internal/usecase/jsreach/analyzer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachability"
 )
 
@@ -382,4 +383,43 @@ func dedupeStrings(values []string) []string {
 		}
 	}
 	return out
+}
+
+// answerableSubjects returns the subset of subjects this analyzer can answer for: every symbol must be a
+// component of the analyzed SBOM and a declared direct dependency. A subject that fails either test is
+// dropped, because the caller mints a claim for everything it passes on and would otherwise seal an
+// unanswerable subject as not-reachable.
+//
+// A subject-level drop is not a coverage failure — the analysis of the remaining subjects is still sound
+// — so this reports an error only when the scan or resolution itself could not be completed.
+func (a *Analyzer) answerableSubjects(ctx context.Context, dir string, subjects []ports.ReachabilitySubject) ([]ports.ReachabilitySubject, error) {
+	doc, err := a.sboms.SBOMFor(ctx, dir)
+	if err != nil {
+		return nil, fmt.Errorf("jsreach: sbom unavailable (no coverage - prior tier stands): %w", err)
+	}
+	if doc == nil {
+		return nil, fmt.Errorf("%w: jsreach has no sbom for the target (no coverage)", shared.ErrNotFound)
+	}
+	graph, err := a.scanner.Scan(ctx, dir)
+	if err != nil {
+		return nil, fmt.Errorf("jsreach: javascript import scan (no coverage - prior tier stands): %w", err)
+	}
+	resolution, err := a.resolver.Resolve(ctx, dir, graph, doc)
+	if err != nil {
+		return nil, fmt.Errorf("jsreach: package resolution (no coverage - prior tier stands): %w", err)
+	}
+
+	out := make([]ports.ReachabilitySubject, 0, len(subjects))
+	for _, subject := range subjects {
+		symbols := make([]string, 0, len(subject.Symbols))
+		for _, symbol := range subject.Symbols {
+			if a.assertSubjectsAnswerable([]string{symbol}, doc, resolution) == nil {
+				symbols = append(symbols, symbol)
+			}
+		}
+		if len(symbols) > 0 {
+			out = append(out, ports.ReachabilitySubject{FindingID: subject.FindingID, Symbols: symbols})
+		}
+	}
+	return out, nil
 }

--- a/internal/usecase/jsreach/recorder.go
+++ b/internal/usecase/jsreach/recorder.go
@@ -1,0 +1,83 @@
+package jsreach
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachproof"
+)
+
+// Recorder runs a Tier-1 JavaScript reachability pass against the SBOM the caller just produced, and
+// promotes the results through the existing judgment gate.
+//
+// The SBOM is HANDED OVER rather than re-derived. A component purl is only meaningful relative to one
+// document: if the analyzer regenerated its own SBOM it could legitimately differ from the one the
+// subjects were minted from (a different producer, different enrichment, different cache state), and
+// every subject would then miss and be sealed as not-reachable. Handing the document over makes that
+// class of false negative impossible rather than unlikely.
+type Recorder struct {
+	scanner   importScanner
+	resolver  importResolver
+	judgments recorderPort
+	audit     ports.AuditLogger
+	clock     ports.Clock
+}
+
+// recorderPort is the narrow judgment-lifecycle slice the reachproof coordinator needs.
+type recorderPort interface {
+	Propose(ctx context.Context, proposer string, engagementID shared.ID, capability judgment.Capability, subjectKind judgment.SubjectKind, subjectID shared.ID, claim judgment.Claim) (judgment.Judgment, error)
+	Verify(ctx context.Context, verifier string, engagementID, judgmentID shared.ID, score int, rationale string, expectedVersion int) (judgment.Judgment, error)
+	List(ctx context.Context, engagementID shared.ID) ([]judgment.Judgment, error)
+}
+
+// NewRecorder validates and returns the recorder.
+func NewRecorder(scanner importScanner, resolver importResolver, judgments recorderPort, audit ports.AuditLogger, clock ports.Clock) (*Recorder, error) {
+	if scanner == nil || resolver == nil || judgments == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: jsreach recorder is missing a dependency", shared.ErrValidation)
+	}
+	return &Recorder{scanner: scanner, resolver: resolver, judgments: judgments, audit: audit, clock: clock}, nil
+}
+
+// RecordWithSBOM analyses the target against doc and mints Tier-1 JavaScript reachability judgments.
+//
+// Subjects the analyzer cannot answer for — a transitive package, or one absent from this document — are
+// DROPPED before minting rather than allowed to fail the pass. The coordinator mints a claim for every
+// subject it is given and reads "no result" as not-reachable, so an unanswerable subject must never reach
+// it: dropping leaves the prior tier standing, while passing it through would seal a false negative.
+//
+// A fresh analyzer is built per call so the handed-over document is never shared between concurrent
+// scans. A no-coverage error aborts the whole pass and mints nothing.
+func (r *Recorder) RecordWithSBOM(ctx context.Context, engagementID shared.ID, targetRef string, doc *sbom.SBOM, subjects []ports.ReachabilitySubject) (int, error) {
+	if doc == nil {
+		return 0, fmt.Errorf("%w: jsreach recorder needs the sbom the subjects were minted from", shared.ErrValidation)
+	}
+	analyzer, err := New(r.scanner, r.resolver, staticSBOM{doc: doc})
+	if err != nil {
+		return 0, err
+	}
+
+	answerable, err := analyzer.answerableSubjects(ctx, targetRef, subjects)
+	if err != nil {
+		return 0, err
+	}
+	if len(answerable) == 0 {
+		return 0, nil
+	}
+
+	coordinator, err := reachproof.NewCoordinatorForLanguage(
+		analyzer, r.judgments, r.audit, r.clock, judgment.Tier1, reachproof.LanguageJavaScript,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return coordinator.Record(ctx, engagementID, targetRef, answerable)
+}
+
+// staticSBOM hands the caller's document to the analyzer unchanged.
+type staticSBOM struct{ doc *sbom.SBOM }
+
+func (s staticSBOM) SBOMFor(context.Context, string) (*sbom.SBOM, error) { return s.doc, nil }

--- a/internal/usecase/jsreach/recorder_test.go
+++ b/internal/usecase/jsreach/recorder_test.go
@@ -1,0 +1,187 @@
+package jsreach
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type recordedJudgment struct {
+	proposer string
+	verifier string
+	claim    judgment.ReachabilityClaim
+}
+
+type fakeJudgments struct {
+	minted []recordedJudgment
+}
+
+func (f *fakeJudgments) Propose(_ context.Context, proposer string, _ shared.ID, _ judgment.Capability, _ judgment.SubjectKind, subjectID shared.ID, claim judgment.Claim) (judgment.Judgment, error) {
+	rc, _ := claim.(judgment.ReachabilityClaim)
+	f.minted = append(f.minted, recordedJudgment{proposer: proposer, claim: rc})
+	return judgment.Judgment{ID: subjectID, Version: 1}, nil
+}
+
+func (f *fakeJudgments) Verify(_ context.Context, verifier string, _, _ shared.ID, _ int, _ string, _ int) (judgment.Judgment, error) {
+	if len(f.minted) > 0 {
+		f.minted[len(f.minted)-1].verifier = verifier
+	}
+	return judgment.Judgment{}, nil
+}
+
+func (f *fakeJudgments) List(context.Context, shared.ID) ([]judgment.Judgment, error) {
+	return nil, nil
+}
+
+type fakeAudit struct{}
+
+func (fakeAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+type fixedClock struct{}
+
+func (fixedClock) Now() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+func recorderFor(t *testing.T, graph modulegraph.Graph, result jsresolution.Result, doc *sbom.SBOM) (*Recorder, *fakeJudgments) {
+	t.Helper()
+	judgments := &fakeJudgments{}
+	r, err := NewRecorder(fakeScanner{graph: graph}, fakeResolver{result: result}, judgments, fakeAudit{}, fixedClock{})
+	if err != nil {
+		t.Fatalf("new recorder: %v", err)
+	}
+	_ = doc
+	return r, judgments
+}
+
+func TestRecorderValidatesDependencies(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewRecorder(nil, fakeResolver{}, &fakeJudgments{}, fakeAudit{}, fixedClock{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil scanner must be rejected, got %v", err)
+	}
+	r, err := NewRecorder(fakeScanner{}, fakeResolver{}, &fakeJudgments{}, fakeAudit{}, fixedClock{})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	// The SBOM the subjects were minted from is mandatory: reasoning over a different document would
+	// silently miss every subject.
+	if _, err := r.RecordWithSBOM(context.Background(), "eng1", "/ws", nil, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil sbom must be rejected, got %v", err)
+	}
+}
+
+// TestRecorderDropsUnanswerableSubjects is the load-bearing R4 behaviour. The coordinator mints a claim
+// for EVERY subject it is given and reads "no result" as not-reachable, so a subject the analyzer cannot
+// answer must never reach it — otherwise a transitive package would be sealed as unused.
+func TestRecorderDropsUnanswerableSubjects(t *testing.T) {
+	t.Parallel()
+
+	const direct = "pkg:npm/direct-dep@1.0.0"
+	const transitive = "pkg:npm/transitive-dep@2.0.0"
+
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	result := jsresolution.Result{
+		Complete: true,
+		// Only direct-dep is declared by a first-party manifest.
+		DeclaredDependencies: []string{"direct-dep"},
+	}
+	doc := &sbom.SBOM{Components: []sbom.Component{
+		{Name: "direct-dep", Version: "1.0.0", PURL: direct},
+		{Name: "transitive-dep", Version: "2.0.0", PURL: transitive},
+	}}
+
+	judgments := &fakeJudgments{}
+	r, err := NewRecorder(fakeScanner{graph: graph}, fakeResolver{result: result}, judgments, fakeAudit{}, fixedClock{})
+	if err != nil {
+		t.Fatalf("new recorder: %v", err)
+	}
+	minted, err := r.RecordWithSBOM(context.Background(), "eng1", "/ws", doc, []ports.ReachabilitySubject{
+		{FindingID: "f-direct", Symbols: []string{direct}},
+		{FindingID: "f-transitive", Symbols: []string{transitive}},
+	})
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	// Exactly one judgment: the transitive subject was dropped, not sealed as not-reachable.
+	if minted != 1 {
+		t.Fatalf("minted = %d, want exactly 1 (the direct dependency)", minted)
+	}
+	if len(judgments.minted) != 1 {
+		t.Fatalf("expected one judgment, got %d", len(judgments.minted))
+	}
+}
+
+// TestRecorderAttributesToTheJavaScriptEngine prevents a JavaScript proof from being credited to the
+// Python import engine in the audit trail and the sealed rationale.
+func TestRecorderAttributesToTheJavaScriptEngine(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	graph := modulegraph.Graph{Modules: []modulegraph.Module{mod("src/index.ts")}, Roots: []string{"src/index.ts"}}
+	imp := componentImport("src/index.ts", "lodash", purl)
+	result := jsresolution.Result{
+		Imports:              []jsresolution.ImportResolution{imp},
+		Complete:             true,
+		DeclaredDependencies: []string{"lodash"},
+	}
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "lodash", Version: "4.17.21", PURL: purl}}}
+
+	judgments := &fakeJudgments{}
+	r, err := NewRecorder(fakeScanner{graph: graph}, fakeResolver{result: result}, judgments, fakeAudit{}, fixedClock{})
+	if err != nil {
+		t.Fatalf("new recorder: %v", err)
+	}
+	if _, err := r.RecordWithSBOM(context.Background(), "eng1", "/ws", doc, []ports.ReachabilitySubject{
+		{FindingID: "f1", Symbols: []string{purl}},
+	}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if len(judgments.minted) != 1 {
+		t.Fatalf("expected one judgment, got %d", len(judgments.minted))
+	}
+	got := judgments.minted[0]
+	if got.proposer != "system:jsimport-scan" {
+		t.Fatalf("proposer = %q, want the javascript import engine", got.proposer)
+	}
+	if got.verifier != "system:jsimport-engine" {
+		t.Fatalf("verifier = %q, want the javascript import engine", got.verifier)
+	}
+	if got.proposer == got.verifier {
+		t.Fatal("proposer and verifier must be distinct so a proof never self-confirms")
+	}
+	if got.claim.Reachable != judgment.Reachable || got.claim.Tier != judgment.Tier1 {
+		t.Fatalf("claim = %+v, want a reachable Tier-1 claim", got.claim)
+	}
+}
+
+func TestRecorderMintsNothingWhenCoverageIsIncomplete(t *testing.T) {
+	t.Parallel()
+
+	const purl = "pkg:npm/lodash@4.17.21"
+	graph := modulegraph.Graph{
+		Modules:  []modulegraph.Module{mod("src/index.ts")},
+		Roots:    []string{"src/index.ts"},
+		Coverage: []modulegraph.CoverageIssue{{Kind: modulegraph.CoverageDynamicRequire, Path: "src/index.ts"}},
+	}
+	result := jsresolution.Result{Complete: true, DeclaredDependencies: []string{"lodash"}}
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "lodash", Version: "4.17.21", PURL: purl}}}
+
+	judgments := &fakeJudgments{}
+	r, err := NewRecorder(fakeScanner{graph: graph}, fakeResolver{result: result}, judgments, fakeAudit{}, fixedClock{})
+	if err != nil {
+		t.Fatalf("new recorder: %v", err)
+	}
+	minted, _ := r.RecordWithSBOM(context.Background(), "eng1", "/ws", doc, []ports.ReachabilitySubject{
+		{FindingID: "f1", Symbols: []string{purl}},
+	})
+	if minted != 0 || len(judgments.minted) != 0 {
+		t.Fatalf("an unobservable module load must mint nothing, got %d judgments", len(judgments.minted))
+	}
+}

--- a/internal/usecase/reachproof/coordinator.go
+++ b/internal/usecase/reachproof/coordinator.go
@@ -34,10 +34,36 @@ import (
 // false. Neither is mintable by the agent/human actor factories. The identities + proof label are
 // tier-specific so a Tier-1 IMPORT proof is never attributed to the call-graph engine (audit accuracy).
 func actorsForTier(tier judgment.ReachabilityTier) (proposer, verifier, proofLabel string) {
-	switch tier {
-	case judgment.Tier2:
+	return actorsFor(tier, LanguagePython)
+}
+
+// Language identifies which source language produced a Tier-1 import proof. Tier-1 identities are
+// per-language for the same reason they are per-tier: an audit reader must not see a JavaScript proof
+// attributed to the Python import engine.
+type Language string
+
+const (
+	LanguagePython     Language = "python"
+	LanguageJavaScript Language = "javascript"
+)
+
+// Valid reports whether l is a supported Tier-1 language.
+func (l Language) Valid() bool {
+	switch l {
+	case LanguagePython, LanguageJavaScript:
+		return true
+	}
+	return false
+}
+
+func actorsFor(tier judgment.ReachabilityTier, language Language) (proposer, verifier, proofLabel string) {
+	if tier == judgment.Tier2 {
 		return "system:callgraph-scan", "system:callgraph-engine", "tier-2 call-graph proof"
-	default: // Tier-1 source-import reachability (e.g. Python)
+	}
+	switch language {
+	case LanguageJavaScript:
+		return "system:jsimport-scan", "system:jsimport-engine", "tier-1 javascript import-reachability proof"
+	default:
 		return "system:pyimport-scan", "system:pyimport-engine", "tier-1 import-reachability proof"
 	}
 }
@@ -94,6 +120,20 @@ func NewCoordinatorForTier(a analyzer, r recorder, audit ports.AuditLogger, cloc
 	}
 	proposer, verifier, label := actorsForTier(tier)
 	return &Coordinator{analyzer: a, recorder: r, audit: audit, clock: clock, tier: tier, proposer: proposer, verifier: verifier, proofLabel: label}, nil
+}
+
+// NewCoordinatorForLanguage is NewCoordinatorForTier with an explicit Tier-1 source language, so the
+// sealed proof and the audit trail name the engine that actually produced it.
+func NewCoordinatorForLanguage(a analyzer, r recorder, audit ports.AuditLogger, clock ports.Clock, tier judgment.ReachabilityTier, language Language) (*Coordinator, error) {
+	coordinator, err := NewCoordinatorForTier(a, r, audit, clock, tier)
+	if err != nil {
+		return nil, err
+	}
+	if !language.Valid() {
+		return nil, fmt.Errorf("%w: reachproof coordinator needs a valid tier-1 language, got %q", shared.ErrValidation, language)
+	}
+	coordinator.proposer, coordinator.verifier, coordinator.proofLabel = actorsFor(tier, language)
+	return coordinator, nil
 }
 
 // Record runs the analyzer over the engagement target ONCE and mints a deterministic reachability judgment

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -698,3 +698,42 @@ func detectionSourceNames(sources []ports.DetectionSource) []string {
 	}
 	return out
 }
+
+// jsReachabilitySubjects builds Tier-1 JavaScript reachability subjects. Unlike the Python builder, the
+// symbol is the EXACT component purl rather than the package name: npm routinely installs several
+// versions of one package, so a name alone would not say which one a reachability verdict is about.
+func jsReachabilitySubjects(findings []finding.Finding, vulns []vulnerability.Vulnerability, doc *sbom.SBOM) []ports.ReachabilitySubject {
+	if doc == nil {
+		return nil
+	}
+	// component name + version -> exact purl, for the npm slice of the document.
+	purlByComponent := map[string]string{}
+	for _, c := range doc.Components {
+		if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(c.PURL)), "pkg:npm/") {
+			continue
+		}
+		purlByComponent[strings.ToLower(c.Name)+"\x00"+c.Version] = c.PURL
+	}
+	if len(purlByComponent) == 0 {
+		return nil
+	}
+	byDedup := make(map[string]vulnerability.Vulnerability, len(vulns))
+	for _, v := range vulns {
+		byDedup[vulnDedupKey(v)] = v
+	}
+	var subs []ports.ReachabilitySubject
+	for _, f := range findings {
+		v, ok := byDedup[f.DedupKey]
+		if !ok {
+			continue
+		}
+		purl, ok := purlByComponent[strings.ToLower(v.Component)+"\x00"+v.Version]
+		if !ok {
+			// Without an exact component identity there is no subject to answer for; saying nothing is
+			// the honest outcome.
+			continue
+		}
+		subs = append(subs, ports.ReachabilitySubject{FindingID: f.ID, Symbols: []string{purl}})
+	}
+	return subs
+}

--- a/internal/usecase/sca/jsreach_subjects_test.go
+++ b/internal/usecase/sca/jsreach_subjects_test.go
@@ -1,0 +1,61 @@
+package sca
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+)
+
+func TestJSReachabilitySubjectsUseExactPURLs(t *testing.T) {
+	t.Parallel()
+
+	doc := &sbom.SBOM{Components: []sbom.Component{
+		{Name: "lodash", Version: "4.17.21", PURL: "pkg:npm/lodash@4.17.21"},
+		{Name: "lodash", Version: "3.10.1", PURL: "pkg:npm/lodash@3.10.1"},
+		{Name: "requests", Version: "2.0.0", PURL: "pkg:pypi/requests@2.0.0"},
+	}}
+	vulns := []vulnerability.Vulnerability{
+		{ID: "A1", Component: "lodash", Version: "4.17.21"},
+		{ID: "A2", Component: "requests", Version: "2.0.0"},
+	}
+	findings := []finding.Finding{
+		{ID: "f1", DedupKey: vulnDedupKey(vulns[0])},
+		{ID: "f2", DedupKey: vulnDedupKey(vulns[1])},
+	}
+
+	subs := jsReachabilitySubjects(findings, vulns, doc)
+	if len(subs) != 1 {
+		t.Fatalf("only the npm finding may produce a subject, got %+v", subs)
+	}
+	// The subject must name the EXACT version, not just the package: two versions of lodash are
+	// installed, and a name alone would not say which one a verdict is about.
+	if subs[0].Symbols[0] != "pkg:npm/lodash@4.17.21" {
+		t.Fatalf("subject = %q, want the exact component purl", subs[0].Symbols[0])
+	}
+	if subs[0].FindingID != "f1" {
+		t.Fatalf("subject finding = %q, want f1", subs[0].FindingID)
+	}
+}
+
+func TestJSReachabilitySubjectsSkipUnmatchedComponents(t *testing.T) {
+	t.Parallel()
+
+	// Without an exact component identity there is no subject to answer for; inventing one would let a
+	// verdict be attached to the wrong package.
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "lodash", Version: "4.17.21", PURL: "pkg:npm/lodash@4.17.21"}}}
+	vulns := []vulnerability.Vulnerability{{ID: "A1", Component: "lodash", Version: "9.9.9"}}
+	findings := []finding.Finding{{ID: "f1", DedupKey: vulnDedupKey(vulns[0])}}
+
+	if subs := jsReachabilitySubjects(findings, vulns, doc); len(subs) != 0 {
+		t.Fatalf("a version with no matching component must yield no subject, got %+v", subs)
+	}
+}
+
+func TestJSReachabilitySubjectsHandleNoSBOM(t *testing.T) {
+	t.Parallel()
+	if subs := jsReachabilitySubjects(nil, nil, nil); subs != nil {
+		t.Fatalf("no sbom means no subjects, got %+v", subs)
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -83,6 +83,7 @@ type Service struct {
 	detectionPriority                string                          // server default detection priority (comprehensive|precise); empty = comprehensive
 	reachability                     ports.ReachabilityRecorder      // optional deterministic Tier-2 reachability proof (Go call-graph)
 	pyReachability                   ports.ReachabilityRecorder      // optional deterministic Tier-1 Python import-reachability proof
+	jsReachability                   jsReachabilityRecorder          // optional deterministic Tier-1 JavaScript import-reachability proof
 	correlation                      ports.CorrelationRecorder       // optional cross-check disagreement → judgment minter
 	sbomGen2                         ports.SBOMGenerator             // optional 2nd SBOM producer for the cross-check
 	sbomCache                        ports.SBOMCache                 // optional content+version-addressed cache of the generated SBOM
@@ -317,6 +318,19 @@ func (s *Service) SetReachability(r ports.ReachabilityRecorder) { s.reachability
 // SetReachability (a no-coverage / dynamic-import target leaves the prior tier standing, never a false
 // "not reachable"). Kept distinct from the Go call-graph prover: it is a WEAKER (Tier-1, import-level) proof.
 func (s *Service) SetPyReachability(r ports.ReachabilityRecorder) { s.pyReachability = r }
+
+// jsReachabilityRecorder is the narrow slice of the JavaScript Tier-1 recorder this service needs. It
+// takes the SBOM explicitly because a component purl is only meaningful relative to one document: the
+// subjects are minted from the scan's own SBOM, so the analysis must reason over that same document
+// rather than re-deriving one that could differ.
+type jsReachabilityRecorder interface {
+	RecordWithSBOM(ctx context.Context, engagementID shared.ID, targetRef string, doc *sbom.SBOM, subjects []ports.ReachabilitySubject) (int, error)
+}
+
+// SetJSReachability configures the optional deterministic Tier-1 JavaScript import-reachability prover.
+// A dependency declared but never imported becomes not_reachable, which the export path turns into an
+// OpenVEX not_affected justification. Best-effort and opt-in; nil disables it.
+func (s *Service) SetJSReachability(r jsReachabilityRecorder) { s.jsReachability = r }
 
 // SetCorrelation configures the optional cross-check disagreement→judgment minter. nil ⇒ no
 // correlation judgments. Best-effort + opt-in: a recorder error is ignored (the scan never fails). A setter
@@ -2425,6 +2439,15 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	if opts.scansVulnerabilities() && s.pyReachability != nil {
 		if subs := pyReachabilitySubjects(result.Findings, result.Vulnerabilities, result.SBOM); len(subs) > 0 {
 			_, _ = s.pyReachability.Record(ctx, engagementID, ws.Dir, subs)
+		}
+	}
+
+	// Deterministic TIER-1 JavaScript import-reachability, best-effort + opt-in. The scan's own SBOM is
+	// handed over so the subjects and the analysis reason over the SAME document. A no-coverage result
+	// is IGNORED here: reachability is an enhancement, so the prior tier stands and the scan never fails.
+	if opts.scansVulnerabilities() && s.jsReachability != nil {
+		if subs := jsReachabilitySubjects(result.Findings, result.Vulnerabilities, result.SBOM); len(subs) > 0 {
+			_, _ = s.jsReachability.RecordWithSBOM(ctx, engagementID, ws.Dir, result.SBOM, subs)
 		}
 	}
 


### PR DESCRIPTION
Phase R4 of epic #378, following #461.

## What

Wires the Tier-1 analyzer into the scan pipeline. A declared npm dependency that first-party source never imports becomes a Tier-1 `not_reachable` judgment and, through the existing export path, an OpenVEX `not_affected` justification. Gated by `SYNAPSE_JSREACH_ENABLED` (which also requires the judgment lifecycle); off by default.

## The SBOM is handed over, not re-derived

A component PURL is only meaningful relative to **one** document. If the analyzer regenerated its own SBOM it could legitimately differ from the one the subjects were minted from — different producer (`SYNAPSE_SBOM_PRODUCER`), different enrichment, different cache state — and then **every subject would miss and be sealed as not-reachable**. `jsreach.Recorder` takes the scan's own document and builds a fresh analyzer per call, so concurrent scans never share it.

## Unanswerable subjects are dropped before minting

This is the load-bearing behaviour. `reachproof.Coordinator` mints a claim for **every** subject it is given and reads "no result" as not-reachable. So a subject the analyzer cannot answer — a **transitive** package, or one absent from this document — must never reach it. Transitive packages are the *majority* of npm findings and a first-party import graph can never prove one unused, because it is loaded by its parent. Dropping leaves the prior tier standing; passing it through would seal a false negative.

## Per-language proof identity

`reachproof.NewCoordinatorForLanguage` attributes a JavaScript proof to `system:jsimport-scan` / `system:jsimport-engine` instead of crediting it to the **Python** import engine in the audit log and the sealed rationale (the existing `actorsForTier` returned the Python identities for all of Tier-1). The two identities stay mutually distinct, so a proof can never self-confirm.

## Exact-version subjects

Subjects carry the exact component PURL rather than a package name: npm routinely installs several versions of one package, and a name alone would not say which version a verdict is about. A finding whose component matches no exact SBOM component yields **no subject at all** rather than an invented one.

## Verification

`go build ./...` · `go vet` · **golangci-lint 0 issues** · full suite **172 packages, 0 failures** · `-race` green. New tests cover the drop-unanswerable behaviour, the JavaScript engine attribution, minting nothing on incomplete coverage, and exact-PURL subject construction.
