### PR TITLE
feat(sca): Tier-1 reachability for Rust, PHP and Ruby (#414)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -81,6 +81,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/risk"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/sast"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/secretscan"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/srcimports"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/syft"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/taintcallgraph"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/vexfile"
@@ -135,6 +136,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/sbomcrosscheckjudge"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/srcreach"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/taintscan"
 	threatmodeluc "github.com/KKloudTarus/synapse-ce/internal/usecase/threatmodeluc"
 	transferuc "github.com/KKloudTarus/synapse-ce/internal/usecase/transfer"
@@ -1215,6 +1217,41 @@ func main() {
 		}
 		scaService.SetJSReachability(jsRecorder)
 		log.Info("Tier-1 JavaScript import-reachability ENABLED (source-only, direct dependencies only → OpenVEX not_affected; best-effort)")
+	}
+
+	// Deterministic Tier-1 import-reachability for Rust, PHP and Ruby. Each scanner is SOURCE-ONLY: it
+	// lexes text and never runs cargo, composer, bundler or a language runtime, so no sandbox is needed
+	// and no dependency is resolved over the network. Each refuses a verdict whenever a dynamic
+	// construct (a Rust macro, a PHP variable class name, Ruby metaprogramming) could hide a reference.
+	// Composition-root only.
+	for _, lang := range []struct {
+		enabled  bool
+		env      string
+		label    string
+		purlType string
+		scanner  ports.SourceImportScanner
+		named    srcreach.CandidateNamer
+		language reachproof.Language
+	}{
+		{cfg.RustReachabilityEnabled, "SYNAPSE_REACH_RUST", "rust reachability", "cargo", srcimports.NewRustScanner(), srcimports.RustCandidates, reachproof.LanguageRust},
+		{cfg.PHPReachabilityEnabled, "SYNAPSE_REACH_PHP", "php reachability", "composer", srcimports.NewPHPScanner(), srcimports.PHPCandidates, reachproof.LanguagePHP},
+		{cfg.RubyReachabilityEnabled, "SYNAPSE_REACH_RUBY", "ruby reachability", "gem", srcimports.NewRubyScanner(), srcimports.RubyCandidates, reachproof.LanguageRuby},
+	} {
+		if !lang.enabled || !requireJudgmentsOrSkip(log, judgmentSvc != nil, lang.env, lang.label) {
+			continue
+		}
+		analyzer, aerr := srcreach.New(lang.scanner, lang.named)
+		if aerr != nil {
+			log.Error(lang.label+" analyzer init failed", "err", aerr)
+			os.Exit(1)
+		}
+		coord, cerr := reachproof.NewCoordinatorForLanguage(analyzer, judgmentSvc, auditLog, clock, judgment.Tier1, lang.language)
+		if cerr != nil {
+			log.Error(lang.label+" coordinator init failed", "err", cerr)
+			os.Exit(1)
+		}
+		scaService.SetSourceReachability(lang.purlType, coord)
+		log.Info("Tier-1 " + lang.label + " ENABLED (source-only dead-dependency detection → OpenVEX not_affected; best-effort)")
 	}
 
 	// Deterministic taint-analysis CapSAST proposals, opt-in. Builds the workspace call

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1240,7 +1240,11 @@ func main() {
 		if !lang.enabled || !requireJudgmentsOrSkip(log, judgmentSvc != nil, lang.env, lang.label) {
 			continue
 		}
-		analyzer, aerr := srcreach.New(lang.scanner, lang.named)
+		purlType := lang.purlType
+		reader := func(ctx context.Context, dir string) (map[string]bool, bool) {
+			return srcimports.DirectDependencies(ctx, dir, purlType)
+		}
+		analyzer, aerr := srcreach.New(lang.scanner, lang.named, reader)
 		if aerr != nil {
 			log.Error(lang.label+" analyzer init failed", "err", aerr)
 			os.Exit(1)

--- a/internal/infrastructure/tools/srcimports/php.go
+++ b/internal/infrastructure/tools/srcimports/php.go
@@ -1,0 +1,155 @@
+package srcimports
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// PHPScanner observes namespace and file references in first-party PHP source.
+type PHPScanner struct{ limits scanLimits }
+
+var _ ports.SourceImportScanner = (*PHPScanner)(nil)
+
+// NewPHPScanner returns a scanner with production bounds.
+func NewPHPScanner() *PHPScanner { return &PHPScanner{limits: defaultScanLimits()} }
+
+// Lang reports the package-URL type this scanner observes.
+func (PHPScanner) Lang() string { return "composer" }
+
+// phpDynamic are constructs under which a package can be reached without a visible `use`: PHP resolves
+// class and function names at runtime from strings, and an include path can be computed.
+var phpDynamic = []dynamicConstruct{
+	{marker: "eval(", reason: "eval executes code this scan cannot observe"},
+	{marker: "call_user_func", reason: "call_user_func resolves a callable from a runtime value"},
+	{marker: "class_exists(", reason: "class_exists resolves a class name from a runtime value"},
+	{marker: "new $", reason: "a variable class name is resolved at runtime"},
+	{marker: "$$", reason: "a variable variable is resolved at runtime"},
+	{marker: "spl_autoload_register", reason: "a custom autoloader can load unobserved classes"},
+	{marker: "ReflectionClass", reason: "reflection resolves a class name from a runtime value"},
+}
+
+// ScanImports walks dir and returns the package references it can observe.
+func (s *PHPScanner) ScanImports(ctx context.Context, dir string) (ports.SourceImportGraph, error) {
+	walker := newSourceWalker(s.limits, []string{".php"}, phpSkipDir)
+	scan, err := walker.walk(ctx, dir, func(path string, content []byte, out *scanAccumulator) {
+		body := stripLineComments(stripLineComments(string(content), "//"), "#")
+		for _, name := range phpNamespaceRoots(body) {
+			out.addPackage(name)
+		}
+		// A computed include path can pull in any file, so it hides references.
+		if phpHasComputedInclude(body) {
+			out.addReason("an include or require path is computed at runtime (" + path + ")")
+		}
+		out.noteDynamic(body, phpDynamic, path)
+	})
+	if err != nil {
+		return ports.SourceImportGraph{}, err
+	}
+	scan.entrypoints = append(scan.entrypoints, composerEntrypoints(ctx, dir, s.limits)...)
+	return scan.graph(), nil
+}
+
+var phpSkipDir = map[string]bool{
+	"vendor": true, "node_modules": true, ".git": true, ".hg": true, ".svn": true,
+	"var": true, "cache": true,
+}
+
+// phpNamespaceRoots extracts the vendor segment of each `use` statement.
+//
+// A Composer package's name ("monolog/monolog") is not its namespace ("Monolog"), so this returns the
+// namespace ROOT and the candidate namer expands a package name into the forms that may match it.
+func phpNamespaceRoots(body string) []string {
+	var out []string
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "use ") {
+			continue
+		}
+		rest := strings.TrimSuffix(strings.TrimSpace(strings.TrimPrefix(trimmed, "use ")), ";")
+		// `use function Foo\bar;` and `use const Foo\BAR;` still name the same root namespace.
+		rest = strings.TrimPrefix(rest, "function ")
+		rest = strings.TrimPrefix(rest, "const ")
+		rest = strings.TrimPrefix(strings.TrimSpace(rest), "\\")
+		if i := strings.Index(rest, " as "); i >= 0 {
+			rest = rest[:i]
+		}
+		root := rest
+		if i := strings.Index(root, "\\"); i >= 0 {
+			root = root[:i]
+		}
+		root = strings.TrimSpace(strings.Trim(root, "{},"))
+		if root != "" {
+			out = append(out, root)
+		}
+	}
+	return out
+}
+
+// phpHasComputedInclude reports an include/require whose argument is not a literal.
+func phpHasComputedInclude(body string) bool {
+	for _, keyword := range []string{"include", "include_once", "require", "require_once"} {
+		idx := 0
+		for {
+			i := strings.Index(body[idx:], keyword)
+			if i < 0 {
+				break
+			}
+			pos := idx + i + len(keyword)
+			idx = pos
+			rest := strings.TrimLeft(body[pos:], " \t(")
+			if rest == "" {
+				continue
+			}
+			// A literal path starts with a quote; anything else is computed.
+			if rest[0] != '\'' && rest[0] != '"' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// composerEntrypoints reads the autoload roots a composer.json declares, which are the entrypoints a
+// reader can check a proof against.
+func composerEntrypoints(ctx context.Context, dir string, limits scanLimits) []string {
+	content, ok := readBoundedFile(ctx, dir, "composer.json", limits.maxFileBytes)
+	if !ok {
+		return nil
+	}
+	var manifest struct {
+		Autoload struct {
+			PSR4  map[string]json.RawMessage `json:"psr-4"`
+			PSR0  map[string]json.RawMessage `json:"psr-0"`
+			Files []string                   `json:"files"`
+		} `json:"autoload"`
+	}
+	if json.Unmarshal(content, &manifest) != nil {
+		return nil
+	}
+	var out []string
+	for namespace := range manifest.Autoload.PSR4 {
+		out = append(out, strings.TrimSuffix(namespace, "\\"))
+	}
+	for namespace := range manifest.Autoload.PSR0 {
+		out = append(out, strings.TrimSuffix(namespace, "\\"))
+	}
+	out = append(out, manifest.Autoload.Files...)
+	return out
+}
+
+// PHPCandidates expands a Composer package name into the namespace forms PHP source may reference it by.
+// "monolog/monolog" is commonly used as `Monolog\...`, and a vendor prefix such as "symfony/console"
+// appears as `Symfony\Component\Console`, so both the vendor and the package segment are candidates.
+func PHPCandidates(packageName string) []string {
+	name := strings.ToLower(strings.TrimSpace(packageName))
+	candidates := []string{name}
+	if vendor, pkg, ok := strings.Cut(name, "/"); ok {
+		candidates = append(candidates, vendor, pkg,
+			strings.ReplaceAll(pkg, "-", ""), strings.ReplaceAll(vendor, "-", ""),
+			strings.ReplaceAll(pkg, "-", "_"))
+	}
+	return normalizeNames(candidates)
+}

--- a/internal/infrastructure/tools/srcimports/php.go
+++ b/internal/infrastructure/tools/srcimports/php.go
@@ -35,15 +35,22 @@ var phpDynamic = []dynamicConstruct{
 func (s *PHPScanner) ScanImports(ctx context.Context, dir string) (ports.SourceImportGraph, error) {
 	walker := newSourceWalker(s.limits, []string{".php"}, phpSkipDir)
 	scan, err := walker.walk(ctx, dir, func(path string, content []byte, out *scanAccumulator) {
-		body := stripLineComments(stripLineComments(string(content), "//"), "#")
+		raw := string(content)
+		// `#[` opens a PHP 8 ATTRIBUTE, not a comment; stripping it would delete real code and hide the
+		// fully-qualified class names modern Doctrine and Symfony write there.
+		body := stripLineComments(raw, "//")
 		for _, name := range phpNamespaceRoots(body) {
 			out.addPackage(name)
 		}
-		// A computed include path can pull in any file, so it hides references.
-		if phpHasComputedInclude(body) {
+		// PHP does not require a `use`: an inline \Vendor\Class reference is just as real.
+		for _, name := range phpInlineNamespaceRoots(body) {
+			out.addPackage(name)
+		}
+		// Detected on the RAW body: over-stripping must never be able to delete an unknown region.
+		if phpHasComputedInclude(raw) {
 			out.addReason("an include or require path is computed at runtime (" + path + ")")
 		}
-		out.noteDynamic(body, phpDynamic, path)
+		out.noteDynamic(raw, phpDynamic, path)
 	})
 	if err != nil {
 		return ports.SourceImportGraph{}, err
@@ -152,4 +159,37 @@ func PHPCandidates(packageName string) []string {
 			strings.ReplaceAll(pkg, "-", "_"))
 	}
 	return normalizeNames(candidates)
+}
+
+// phpInlineNamespaceRoots finds vendor namespace roots referenced without a `use`, either fully
+// qualified (`new \Monolog\Logger(...)`, `\Ramsey\Uuid\Uuid::uuid4()`) or in an attribute
+// (`#[\Doctrine\ORM\Mapping\Entity]`). PHP requires no import for any of these, so reading only `use`
+// lines would report a package the code demonstrably instantiates as unreferenced.
+func phpInlineNamespaceRoots(body string) []string {
+	var out []string
+	for i := 0; i < len(body); i++ {
+		if body[i] != '\\' {
+			continue
+		}
+		// The root must be preceded by something that can start an expression, so a namespace
+		// continuation (Foo\Bar) does not register Bar as a root.
+		if i > 0 && isPHPIdentByte(body[i-1]) {
+			continue
+		}
+		j := i + 1
+		start := j
+		for j < len(body) && isPHPIdentByte(body[j]) {
+			j++
+		}
+		if j == start || j >= len(body) || body[j] != '\\' {
+			continue // a single leading-slash name is a global function or class, not a vendor root
+		}
+		out = append(out, body[start:j])
+		i = j
+	}
+	return out
+}
+
+func isPHPIdentByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }

--- a/internal/infrastructure/tools/srcimports/ruby.go
+++ b/internal/infrastructure/tools/srcimports/ruby.go
@@ -1,0 +1,145 @@
+package srcimports
+
+import (
+	"context"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// RubyScanner observes gem references in first-party Ruby source.
+type RubyScanner struct{ limits scanLimits }
+
+var _ ports.SourceImportScanner = (*RubyScanner)(nil)
+
+// NewRubyScanner returns a scanner with production bounds.
+func NewRubyScanner() *RubyScanner { return &RubyScanner{limits: defaultScanLimits()} }
+
+// Lang reports the package-URL type this scanner observes.
+func (RubyScanner) Lang() string { return "gem" }
+
+// rubyDynamic are constructs under which a gem can be reached without a visible `require`: Ruby resolves
+// constants and methods from strings and rewrites itself at runtime.
+var rubyDynamic = []dynamicConstruct{
+	{marker: "const_get", reason: "const_get resolves a constant from a runtime value"},
+	{marker: ".send(", reason: "send dispatches a method named by a runtime value"},
+	{marker: "public_send", reason: "public_send dispatches a method named by a runtime value"},
+	{marker: "method_missing", reason: "method_missing handles calls this scan cannot observe"},
+	{marker: "define_method", reason: "define_method creates methods at runtime"},
+	{marker: "instance_eval", reason: "instance_eval executes code this scan cannot observe"},
+	{marker: "class_eval", reason: "class_eval executes code this scan cannot observe"},
+	{marker: "eval(", reason: "eval executes code this scan cannot observe"},
+	{marker: "autoload", reason: "autoload defers loading to a runtime constant reference"},
+	{marker: "Kernel.load", reason: "load reads a path resolved at runtime"},
+}
+
+// ScanImports walks dir and returns the gem references it can observe.
+func (s *RubyScanner) ScanImports(ctx context.Context, dir string) (ports.SourceImportGraph, error) {
+	walker := newSourceWalker(s.limits, []string{".rb", ".rake", ".gemspec"}, rubySkipDir)
+	scan, err := walker.walk(ctx, dir, func(path string, content []byte, out *scanAccumulator) {
+		body := stripLineComments(string(content), "#")
+		for _, name := range rubyRequireRoots(body) {
+			out.addPackage(name)
+		}
+		if rubyHasComputedRequire(body) {
+			out.addReason("a require path is computed at runtime (" + path + ")")
+		}
+		out.noteDynamic(body, rubyDynamic, path)
+	})
+	if err != nil {
+		return ports.SourceImportGraph{}, err
+	}
+	scan.entrypoints = append(scan.entrypoints, rubyEntrypoints(ctx, dir, s.limits)...)
+	return scan.graph(), nil
+}
+
+var rubySkipDir = map[string]bool{
+	"vendor": true, "node_modules": true, ".git": true, ".hg": true, ".svn": true,
+	"tmp": true, "log": true, "coverage": true,
+}
+
+// rubyRequireRoots extracts the first path segment of each literal `require`.
+//
+// `require_relative` is deliberately excluded: it always names a first-party file, never a gem. A gem's
+// require path often differs from its gem name ("rest-client" is required as "rest_client"), so the
+// candidate namer expands both forms.
+func rubyRequireRoots(body string) []string {
+	var out []string
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "require ") && !strings.HasPrefix(trimmed, "require(") {
+			continue
+		}
+		rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(trimmed, "require"), "("))
+		if rest == "" {
+			continue
+		}
+		quote := rest[0]
+		if quote != '\'' && quote != '"' {
+			continue // computed; recorded separately as a coverage reason
+		}
+		rest = rest[1:]
+		end := strings.IndexByte(rest, quote)
+		if end < 0 {
+			continue
+		}
+		requirePath := rest[:end]
+		root := requirePath
+		if i := strings.IndexByte(root, '/'); i >= 0 {
+			root = root[:i]
+		}
+		if root != "" {
+			out = append(out, root)
+		}
+	}
+	return out
+}
+
+// rubyHasComputedRequire reports a `require` whose argument is not a string literal.
+func rubyHasComputedRequire(body string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "require ") && !strings.HasPrefix(trimmed, "require(") {
+			continue
+		}
+		rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(trimmed, "require"), "("))
+		if rest == "" {
+			continue
+		}
+		if rest[0] != '\'' && rest[0] != '"' {
+			return true
+		}
+		// String interpolation makes the path dynamic even inside quotes.
+		if rest[0] == '"' && strings.Contains(rest, "#{") {
+			return true
+		}
+	}
+	return false
+}
+
+// rubyEntrypoints records the conventional load points a reader can check a proof against.
+func rubyEntrypoints(ctx context.Context, dir string, limits scanLimits) []string {
+	var out []string
+	for _, name := range []string{"Gemfile", "config.ru", "Rakefile"} {
+		if _, ok := readBoundedFile(ctx, dir, name, limits.maxFileBytes); ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// RubyCandidates expands a gem name into the forms a `require` may use: a gem's require path commonly
+// replaces hyphens with underscores, and a namespaced gem is required by its first segment.
+func RubyCandidates(packageName string) []string {
+	name := strings.ToLower(strings.TrimSpace(packageName))
+	candidates := []string{
+		name,
+		strings.ReplaceAll(name, "-", "_"),
+		strings.ReplaceAll(name, "_", "-"),
+		strings.ReplaceAll(name, "-", "/"),
+	}
+	if head, _, ok := strings.Cut(name, "-"); ok {
+		candidates = append(candidates, head)
+	}
+	return normalizeNames(candidates)
+}

--- a/internal/infrastructure/tools/srcimports/ruby.go
+++ b/internal/infrastructure/tools/srcimports/ruby.go
@@ -31,20 +31,32 @@ var rubyDynamic = []dynamicConstruct{
 	{marker: "eval(", reason: "eval executes code this scan cannot observe"},
 	{marker: "autoload", reason: "autoload defers loading to a runtime constant reference"},
 	{marker: "Kernel.load", reason: "load reads a path resolved at runtime"},
+	// Bundler and Rails load the whole Gemfile without any explicit require appearing in source. A
+	// Rails app never writes `require "nokogiri"`, so without these markers every gem it depends on
+	// would be reported unreferenced — a mass false negative on the most common Ruby project shape.
+	{marker: "Bundler.require", reason: "Bundler.require loads every gem in the Gemfile with no explicit require"},
+	{marker: "Bundler.setup", reason: "Bundler.setup activates gems with no explicit require"},
+	{marker: "rails/all", reason: "rails/all loads framework gems with no explicit require"},
+	{marker: "Rails::Application", reason: "the Rails loader resolves constants without an explicit require"},
+	{marker: "Zeitwerk", reason: "the Zeitwerk autoloader resolves constants without an explicit require"},
+	{marker: "ActiveSupport::Dependencies", reason: "the Rails dependency loader resolves constants at runtime"},
+	{marker: "require_dependency", reason: "require_dependency defers loading to the Rails autoloader"},
 }
 
 // ScanImports walks dir and returns the gem references it can observe.
 func (s *RubyScanner) ScanImports(ctx context.Context, dir string) (ports.SourceImportGraph, error) {
 	walker := newSourceWalker(s.limits, []string{".rb", ".rake", ".gemspec"}, rubySkipDir)
 	scan, err := walker.walk(ctx, dir, func(path string, content []byte, out *scanAccumulator) {
-		body := stripLineComments(string(content), "#")
+		raw := string(content)
+		body := stripLineComments(raw, "#")
 		for _, name := range rubyRequireRoots(body) {
 			out.addPackage(name)
 		}
-		if rubyHasComputedRequire(body) {
+		// Detected on the RAW body: over-stripping must never be able to delete an unknown region.
+		if rubyHasComputedRequire(raw) {
 			out.addReason("a require path is computed at runtime (" + path + ")")
 		}
-		out.noteDynamic(body, rubyDynamic, path)
+		out.noteDynamic(raw, rubyDynamic, path)
 	})
 	if err != nil {
 		return ports.SourceImportGraph{}, err
@@ -140,6 +152,14 @@ func RubyCandidates(packageName string) []string {
 	}
 	if head, _, ok := strings.Cut(name, "-"); ok {
 		candidates = append(candidates, head)
+	}
+	// A compound gem name is required with an underscore inserted: activesupport is required as
+	// active_support, actionpack as action_pack. These are the highest-advisory gems in the ecosystem,
+	// so missing the split would suppress exactly the findings that matter most.
+	for _, prefix := range []string{"active", "action"} {
+		if strings.HasPrefix(name, prefix) && len(name) > len(prefix) {
+			candidates = append(candidates, prefix+"_"+name[len(prefix):])
+		}
 	}
 	return normalizeNames(candidates)
 }

--- a/internal/infrastructure/tools/srcimports/rust.go
+++ b/internal/infrastructure/tools/srcimports/rust.go
@@ -45,11 +45,18 @@ var rustDynamic = []dynamicConstruct{
 func (s *RustScanner) ScanImports(ctx context.Context, dir string) (ports.SourceImportGraph, error) {
 	walker := newSourceWalker(s.limits, []string{".rs"}, rustSkipDir)
 	scan, err := walker.walk(ctx, dir, func(path string, content []byte, out *scanAccumulator) {
-		body := stripLineComments(string(content), "//")
+		raw := string(content)
+		body := stripLineComments(raw, "//")
 		for _, name := range rustCrateReferences(body) {
 			out.addPackage(name)
 		}
-		out.noteDynamic(body, rustDynamic, path)
+		// Inline paths (serde_json::from_str(...)) and attribute macros (#[tokio::main]) reference a
+		// crate with no `use` at all, so they are read from the stripped body too.
+		for _, name := range rustInlinePathRoots(body) {
+			out.addPackage(name)
+		}
+		// Detected on the RAW body: over-stripping must never be able to delete an unknown region.
+		out.noteDynamic(raw, rustDynamic, path)
 	})
 	if err != nil {
 		return ports.SourceImportGraph{}, err
@@ -186,3 +193,47 @@ func RustCandidates(packageName string) []string {
 	name := strings.ToLower(strings.TrimSpace(packageName))
 	return normalizeNames([]string{name, strings.ReplaceAll(name, "-", "_"), strings.ReplaceAll(name, "_", "-")})
 }
+
+// rustInlinePathRoots finds crate roots referenced by a fully-qualified inline path
+// (`serde_json::from_str(...)`) or an attribute macro (`#[tokio::main]`).
+//
+// Rust 2018 needs no `use` for either, so reading only `use` lines would report a crate that the code
+// demonstrably calls as unreferenced. Over-matching here is the safe direction: a local module path
+// simply adds a name that no dependency subject will match.
+func rustInlinePathRoots(body string) []string {
+	var out []string
+	for i := 0; i+2 < len(body); i++ {
+		if body[i] != ':' || body[i+1] != ':' {
+			continue
+		}
+		// Walk back over the identifier preceding "::".
+		end := i
+		start := end
+		for start > 0 && isRustIdentByte(body[start-1]) {
+			start--
+		}
+		if start == end {
+			continue
+		}
+		// A path segment preceded by "::" is not the root of the path.
+		if start >= 2 && body[start-2] == ':' && body[start-1] == ':' {
+			continue
+		}
+		root := body[start:end]
+		switch root {
+		case "crate", "self", "super", "std", "core", "alloc", "Self":
+			continue
+		}
+		if root != "" && !startsUpper(root) {
+			out = append(out, root)
+		}
+	}
+	return out
+}
+
+func isRustIdentByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// startsUpper reports an identifier in type position (a type or enum name), which is never a crate root.
+func startsUpper(s string) bool { return s != "" && s[0] >= 'A' && s[0] <= 'Z' }

--- a/internal/infrastructure/tools/srcimports/rust.go
+++ b/internal/infrastructure/tools/srcimports/rust.go
@@ -1,0 +1,188 @@
+// Package srcimports implements source-only first-party import scanners for languages whose dependency
+// usage is observable as an import/require/use statement (Rust, PHP, Ruby).
+//
+// Every scanner here reads and lexes text only. None executes project code, a package manager, a build
+// system or a language runtime, and none touches the network — so, like the Python and JavaScript
+// scanners, they run in-process rather than inside the sandbox that confines toolchains which compile
+// untrusted source.
+//
+// The load-bearing rule is that a construct which could reference a dependency INVISIBLY must be recorded
+// as a coverage reason rather than ignored. A missed reference becomes a false "unreachable", and an
+// unreachable verdict suppresses work.
+package srcimports
+
+import (
+	"context"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// RustScanner observes crate references in first-party Rust source.
+type RustScanner struct{ limits scanLimits }
+
+var _ ports.SourceImportScanner = (*RustScanner)(nil)
+
+// NewRustScanner returns a scanner with production bounds.
+func NewRustScanner() *RustScanner { return &RustScanner{limits: defaultScanLimits()} }
+
+// Lang reports the package-URL type this scanner observes.
+func (RustScanner) Lang() string { return "cargo" }
+
+// rustDynamic are constructs under which a crate can be referenced without a visible `use`: a macro can
+// expand to arbitrary paths, and a build script or FFI can pull in code this scan never sees.
+var rustDynamic = []dynamicConstruct{
+	{marker: "macro_rules!", reason: "macro definition can expand to unobserved crate paths"},
+	{marker: "include!", reason: "include! splices unobserved source"},
+	{marker: "include_str!", reason: "include_str! splices unobserved content"},
+	{marker: "include_bytes!", reason: "include_bytes! splices unobserved content"},
+	{marker: "proc_macro", reason: "procedural macro can generate unobserved crate paths"},
+	{marker: "#[derive(", reason: "derive macro can generate unobserved crate paths"},
+	{marker: "extern \"C\"", reason: "foreign function interface reaches code this scan cannot observe"},
+}
+
+// ScanImports walks dir and returns the crate references it can observe.
+func (s *RustScanner) ScanImports(ctx context.Context, dir string) (ports.SourceImportGraph, error) {
+	walker := newSourceWalker(s.limits, []string{".rs"}, rustSkipDir)
+	scan, err := walker.walk(ctx, dir, func(path string, content []byte, out *scanAccumulator) {
+		body := stripLineComments(string(content), "//")
+		for _, name := range rustCrateReferences(body) {
+			out.addPackage(name)
+		}
+		out.noteDynamic(body, rustDynamic, path)
+	})
+	if err != nil {
+		return ports.SourceImportGraph{}, err
+	}
+	// Cargo manifests declare the binary and library targets, which are the entrypoints a reader can
+	// check a proof against. Their absence is provenance, not a coverage failure.
+	scan.entrypoints = append(scan.entrypoints, cargoTargets(ctx, dir, s.limits)...)
+	return scan.graph(), nil
+}
+
+var rustSkipDir = map[string]bool{
+	"target": true, "vendor": true, ".git": true, ".hg": true, ".svn": true,
+}
+
+// rustCrateReferences extracts crate names from `use` and `extern crate` statements.
+//
+// A `use` path's first segment is the crate, except for the keywords that address the current crate or an
+// enclosing module. Rust normalizes a hyphenated crate name to underscores in source, so the caller's
+// candidate namer must expand both forms.
+func rustCrateReferences(body string) []string {
+	var out []string
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		trimmed = strings.TrimPrefix(trimmed, "pub ")
+		switch {
+		case strings.HasPrefix(trimmed, "use "):
+			out = append(out, rustUseRoot(strings.TrimPrefix(trimmed, "use "))...)
+		case strings.HasPrefix(trimmed, "extern crate "):
+			name := strings.TrimPrefix(trimmed, "extern crate ")
+			name = strings.TrimSuffix(strings.TrimSpace(name), ";")
+			if root := rustIdentifier(name); root != "" {
+				out = append(out, root)
+			}
+		}
+	}
+	return out
+}
+
+// rustUseRoot returns the crate roots named by one `use` statement, including every branch of a grouped
+// import like `use {serde, tokio::net};`.
+func rustUseRoot(rest string) []string {
+	rest = strings.TrimSuffix(strings.TrimSpace(rest), ";")
+	if rest == "" {
+		return nil
+	}
+	// A grouped import at the root names several crates.
+	if strings.HasPrefix(rest, "{") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(rest, "{"), "}")
+		var out []string
+		for _, part := range strings.Split(inner, ",") {
+			out = append(out, rustUseRoot(part)...)
+		}
+		return out
+	}
+	head := rest
+	if i := strings.Index(head, "::"); i >= 0 {
+		head = head[:i]
+	}
+	root := rustIdentifier(head)
+	switch root {
+	case "", "crate", "self", "super", "std", "core", "alloc":
+		// These address the current crate or the language's own libraries, not a dependency.
+		return nil
+	}
+	return []string{root}
+}
+
+// rustIdentifier keeps the leading identifier of a token, dropping aliases and punctuation.
+func rustIdentifier(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if i := strings.Index(trimmed, " as "); i >= 0 {
+		trimmed = trimmed[:i]
+	}
+	var sb strings.Builder
+	for _, r := range strings.TrimSpace(trimmed) {
+		if r == '_' || r == '-' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			sb.WriteRune(r)
+			continue
+		}
+		break
+	}
+	return sb.String()
+}
+
+// cargoTargets reads the binary and library target names a Cargo manifest declares. Test and bench
+// targets are deliberately excluded: a dependency used only by tests is not evidence that shipped code
+// reaches it.
+func cargoTargets(ctx context.Context, dir string, limits scanLimits) []string {
+	content, ok := readBoundedFile(ctx, dir, "Cargo.toml", limits.maxFileBytes)
+	if !ok {
+		return nil
+	}
+	var out []string
+	var section string
+	for _, line := range strings.Split(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			section = strings.Trim(trimmed, "[]")
+			continue
+		}
+		if section != "[bin" && section != "bin" && section != "lib" && section != "package" {
+			continue
+		}
+		if name, ok := tomlStringValue(trimmed, "name"); ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// tomlStringValue extracts `key = "value"` from a manifest line.
+func tomlStringValue(line, key string) (string, bool) {
+	if !strings.HasPrefix(line, key) {
+		return "", false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(line, key))
+	if !strings.HasPrefix(rest, "=") {
+		return "", false
+	}
+	value := strings.TrimSpace(strings.TrimPrefix(rest, "="))
+	if len(value) < 2 || value[0] != '"' {
+		return "", false
+	}
+	value = value[1:]
+	if i := strings.IndexByte(value, '"'); i >= 0 {
+		return value[:i], true
+	}
+	return "", false
+}
+
+// RustCandidates expands a crate name into the forms Rust source may reference it by: Cargo allows
+// hyphens in a crate name, but source must write underscores.
+func RustCandidates(packageName string) []string {
+	name := strings.ToLower(strings.TrimSpace(packageName))
+	return normalizeNames([]string{name, strings.ReplaceAll(name, "-", "_"), strings.ReplaceAll(name, "_", "-")})
+}

--- a/internal/infrastructure/tools/srcimports/scanner_test.go
+++ b/internal/infrastructure/tools/srcimports/scanner_test.go
@@ -1,0 +1,330 @@
+package srcimports
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func writeFile(t *testing.T, file, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(file, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func imported(graph ports.SourceImportGraph) map[string]bool {
+	out := map[string]bool{}
+	for _, name := range graph.ImportedPackages {
+		out[name] = true
+	}
+	return out
+}
+
+// --- Rust ---
+
+func TestRustScannerObservesCrateReferences(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "Cargo.toml"), "[package]\nname = \"my-app\"\n")
+	writeFile(t, filepath.Join(root, "src", "main.rs"), `
+use serde::Serialize;
+use tokio::net::TcpListener;
+use std::collections::HashMap;
+use crate::internal::helper;
+use self::local;
+extern crate legacy_crate;
+pub use reqwest::Client;
+use {itertools, rayon::prelude::*};
+// use commented_out::Thing;
+`)
+
+	graph, err := NewRustScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := imported(graph)
+	for _, want := range []string{"serde", "tokio", "legacy_crate", "reqwest", "itertools", "rayon"} {
+		if !got[want] {
+			t.Errorf("expected crate %q among %v", want, graph.ImportedPackages)
+		}
+	}
+	// The language's own libraries and the current crate are not dependencies.
+	for _, unwanted := range []string{"std", "crate", "self", "commented_out"} {
+		if got[unwanted] {
+			t.Errorf("%q must not be reported as a dependency reference", unwanted)
+		}
+	}
+	if !graph.Complete() {
+		t.Fatalf("a fully observable crate must be complete, got %v", graph.CoverageReasons)
+	}
+}
+
+func TestRustDynamicConstructsDegradeCoverage(t *testing.T) {
+	t.Parallel()
+
+	// Each of these can reference a crate without a visible `use`, so each must produce an unknown
+	// region rather than a silent gap.
+	tests := map[string]string{
+		"macro definition":  "macro_rules! shout { () => {} }",
+		"include":           `include!("generated.rs");`,
+		"derive macro":      "#[derive(Serialize)]\nstruct S;",
+		"proc macro":        "use proc_macro::TokenStream;",
+		"foreign interface": "extern \"C\" { fn c_fn(); }",
+	}
+	for name, src := range tests {
+		name, src := name, src
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "src", "lib.rs"), "use serde::Serialize;\n"+src)
+
+			graph, err := NewRustScanner().ScanImports(context.Background(), root)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if graph.Complete() {
+				t.Fatalf("%s must degrade coverage", name)
+			}
+		})
+	}
+}
+
+// --- PHP ---
+
+func TestPHPScannerObservesNamespaceReferences(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "composer.json"), `{"autoload":{"psr-4":{"App\\":"src/"}}}`)
+	writeFile(t, filepath.Join(root, "src", "Service.php"), `<?php
+use Monolog\Logger;
+use Symfony\Component\Console\Command;
+use function GuzzleHttp\json_decode;
+use Doctrine\ORM\EntityManager as EM;
+require __DIR__ . '/bootstrap.php';
+// use CommentedOut\Thing;
+`)
+
+	graph, err := NewPHPScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := imported(graph)
+	for _, want := range []string{"monolog", "symfony", "guzzlehttp", "doctrine"} {
+		if !got[want] {
+			t.Errorf("expected namespace %q among %v", want, graph.ImportedPackages)
+		}
+	}
+	if got["commentedout"] {
+		t.Error("a commented-out use must not be a reference")
+	}
+}
+
+func TestPHPDynamicConstructsDegradeCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"variable function name": `<?php $fn = 'x'; call_user_func($fn);`,
+		"variable class name":    `<?php $c = 'X'; $o = new $c();`,
+		"computed include":       `<?php include $path;`,
+		"eval":                   `<?php eval($code);`,
+		"reflection":             `<?php $r = new ReflectionClass($name);`,
+		"custom autoloader":      `<?php spl_autoload_register(function ($c) {});`,
+	}
+	for name, src := range tests {
+		name, src := name, src
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "src", "a.php"), src)
+
+			graph, err := NewPHPScanner().ScanImports(context.Background(), root)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if graph.Complete() {
+				t.Fatalf("%s must degrade coverage", name)
+			}
+		})
+	}
+}
+
+// --- Ruby ---
+
+func TestRubyScannerObservesGemReferences(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "Gemfile"), "source 'https://rubygems.org'\n")
+	writeFile(t, filepath.Join(root, "lib", "app.rb"), `
+require 'rails'
+require "nokogiri"
+require 'active_support/core_ext'
+require_relative 'local_helper'
+# require 'commented_out'
+`)
+
+	graph, err := NewRubyScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := imported(graph)
+	for _, want := range []string{"rails", "nokogiri", "active_support"} {
+		if !got[want] {
+			t.Errorf("expected gem %q among %v", want, graph.ImportedPackages)
+		}
+	}
+	// require_relative always names a first-party file, never a gem.
+	if got["local_helper"] {
+		t.Error("require_relative must not be reported as a gem reference")
+	}
+	if got["commented_out"] {
+		t.Error("a commented-out require must not be a reference")
+	}
+	if !graph.Complete() {
+		t.Fatalf("a fully observable project must be complete, got %v", graph.CoverageReasons)
+	}
+}
+
+func TestRubyDynamicConstructsDegradeCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"const_get":         `Object.const_get(name)`,
+		"send":              `obj.send(:method_name)`,
+		"method_missing":    `def method_missing(m, *args); end`,
+		"define_method":     `define_method(:x) { }`,
+		"instance_eval":     `obj.instance_eval(code)`,
+		"computed require":  `require gem_name`,
+		"interpolated path": `require "lib/#{name}"`,
+		"autoload":          `autoload :Thing, 'thing'`,
+	}
+	for name, src := range tests {
+		name, src := name, src
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "lib", "a.rb"), "require 'rails'\n"+src)
+
+			graph, err := NewRubyScanner().ScanImports(context.Background(), root)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if graph.Complete() {
+				t.Fatalf("%s must degrade coverage", name)
+			}
+		})
+	}
+}
+
+// --- shared behaviour ---
+
+func TestScannersRefuseAnUnusableTarget(t *testing.T) {
+	t.Parallel()
+
+	scanners := map[string]ports.SourceImportScanner{
+		"rust": NewRustScanner(), "php": NewPHPScanner(), "ruby": NewRubyScanner(),
+	}
+	for lang, scanner := range scanners {
+		lang, scanner := lang, scanner
+		t.Run(lang, func(t *testing.T) {
+			t.Parallel()
+			if _, err := scanner.ScanImports(context.Background(), "  "); !errors.Is(err, shared.ErrValidation) {
+				t.Errorf("a blank target must be a validation error, got %v", err)
+			}
+			// No source of this language is NO COVERAGE, never an empty clean observation a caller
+			// could read as "nothing is imported".
+			empty := t.TempDir()
+			writeFile(t, filepath.Join(empty, "readme.txt"), "nothing here")
+			if _, err := scanner.ScanImports(context.Background(), empty); !errors.Is(err, shared.ErrNotFound) {
+				t.Errorf("no source must be ErrNotFound, got %v", err)
+			}
+		})
+	}
+}
+
+func TestScannersNeverFollowSymlinks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "secret.rb"), "require 'exfiltrated'")
+	writeFile(t, filepath.Join(root, "lib", "a.rb"), "require 'rails'")
+	if err := os.Symlink(filepath.Join(outside, "secret.rb"), filepath.Join(root, "lib", "linked.rb")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	graph, err := NewRubyScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if imported(graph)["exfiltrated"] {
+		t.Fatal("a symlink was followed outside the target")
+	}
+	if graph.Complete() {
+		t.Fatal("an unfollowed symlink must degrade coverage")
+	}
+}
+
+func TestScannersAreDeterministic(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.rs"), "use serde::Serialize;\nuse tokio::net::TcpListener;")
+	writeFile(t, filepath.Join(root, "src", "b.rs"), "use reqwest::Client;")
+
+	first, err := NewRustScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	second, err := NewRustScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan again: %v", err)
+	}
+	if len(first.ImportedPackages) != len(second.ImportedPackages) {
+		t.Fatal("repeated scans must be identical")
+	}
+	for i := range first.ImportedPackages {
+		if first.ImportedPackages[i] != second.ImportedPackages[i] {
+			t.Fatal("repeated scans must be identically ordered")
+		}
+	}
+}
+
+func TestCandidateNamers(t *testing.T) {
+	t.Parallel()
+
+	// A dependency is referenced under several plausible names; over-matching biases toward reachable,
+	// which is the safe direction.
+	if got := RustCandidates("serde-json"); !contains(got, "serde_json") || !contains(got, "serde-json") {
+		t.Errorf("rust candidates must cover both hyphen and underscore forms, got %v", got)
+	}
+	if got := PHPCandidates("monolog/monolog"); !contains(got, "monolog") {
+		t.Errorf("php candidates must include the package segment, got %v", got)
+	}
+	if got := PHPCandidates("symfony/console"); !contains(got, "symfony") || !contains(got, "console") {
+		t.Errorf("php candidates must include vendor and package, got %v", got)
+	}
+	if got := RubyCandidates("rest-client"); !contains(got, "rest_client") || !contains(got, "rest-client") {
+		t.Errorf("ruby candidates must cover both forms, got %v", got)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/tools/srcimports/scanner_test.go
+++ b/internal/infrastructure/tools/srcimports/scanner_test.go
@@ -328,3 +328,143 @@ func contains(values []string, want string) bool {
 	}
 	return false
 }
+
+// --- regressions for the audited mass false-negative classes ---
+
+func TestRustInlinePathIsAReference(t *testing.T) {
+	t.Parallel()
+
+	// Rust 2018 needs no `use`. Reading only `use` lines would report a crate the code demonstrably
+	// calls as unreferenced.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "main.rs"), `
+fn main() {
+    let v: serde_json::Value = serde_json::from_str("{}").unwrap();
+    let re = regex::Regex::new("^a+$").unwrap();
+    println!("{} {}", chrono::Utc::now(), re.is_match("aa"));
+}
+`)
+	graph, err := NewRustScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := imported(graph)
+	for _, want := range []string{"serde_json", "regex", "chrono"} {
+		if !got[want] {
+			t.Errorf("an inline path must count as a reference: %q missing from %v", want, graph.ImportedPackages)
+		}
+	}
+}
+
+func TestPHPInlineFullyQualifiedNameIsAReference(t *testing.T) {
+	t.Parallel()
+
+	// PHP requires no `use` either, and PHP 8 attributes carry fully-qualified names.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "Audit.php"), `<?php
+namespace App;
+#[\Doctrine\ORM\Mapping\Entity]
+class Audit {
+    public function log(string $m): void {
+        $logger = new \Monolog\Logger('audit');
+        \Ramsey\Uuid\Uuid::uuid4();
+    }
+}
+`)
+	graph, err := NewPHPScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := imported(graph)
+	for _, want := range []string{"monolog", "ramsey", "doctrine"} {
+		if !got[want] {
+			t.Errorf("an inline fully-qualified name must count as a reference: %q missing from %v", want, graph.ImportedPackages)
+		}
+	}
+}
+
+func TestRubyBundlerAndRailsLoadingDegradeCoverage(t *testing.T) {
+	t.Parallel()
+
+	// A Rails app never writes `require "nokogiri"` — Bundler loads the whole Gemfile. Without this,
+	// every gem it depends on would be reported unreferenced.
+	for name, src := range map[string]string{
+		"bundler require":   "Bundler.require(*Rails.groups)",
+		"rails all":         `require "rails/all"`,
+		"rails application": "class Application < Rails::Application\nend",
+		"zeitwerk":          "loader = Zeitwerk::Loader.new",
+	} {
+		name, src := name, src
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "config", "application.rb"), "require 'rails'\n"+src)
+
+			graph, err := NewRubyScanner().ScanImports(context.Background(), root)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if graph.Complete() {
+				t.Fatalf("%s must degrade coverage", name)
+			}
+		})
+	}
+}
+
+func TestObservingNoImportAtAllRefuses(t *testing.T) {
+	t.Parallel()
+
+	// A scan that read source but saw no import is the shape of a parser that did not understand the
+	// language, not of a project with no dependencies.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "lib", "a.rb"), "x = 1\ny = 2\n")
+
+	graph, err := NewRubyScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if graph.Complete() {
+		t.Fatal("an empty observation must never be treated as authoritative")
+	}
+}
+
+func TestRailsGemCandidatesCoverTheUnderscoreForm(t *testing.T) {
+	t.Parallel()
+
+	// activesupport is required as active_support; these are the highest-advisory gems in the ecosystem.
+	for gem, want := range map[string]string{
+		"activesupport": "active_support",
+		"activerecord":  "active_record",
+		"actionpack":    "action_pack",
+	} {
+		if got := RubyCandidates(gem); !contains(got, want) {
+			t.Errorf("RubyCandidates(%q) must include %q, got %v", gem, want, got)
+		}
+	}
+}
+
+func TestDirectDependencyReaders(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "Cargo.toml"), "[package]\nname = \"app\"\n\n[dependencies]\nserde = \"1\"\nreqwest = { version = \"0.11\" }\n")
+	writeFile(t, filepath.Join(root, "composer.json"), `{"require":{"monolog/monolog":"^3"},"require-dev":{"phpunit/phpunit":"^10"}}`)
+	writeFile(t, filepath.Join(root, "Gemfile"), "source 'https://rubygems.org'\ngem 'rails'\ngem \"nokogiri\", '~> 1.0'\n# gem 'commented'\n")
+
+	cargo, ok := DirectDependencies(context.Background(), root, "cargo")
+	if !ok || !cargo["serde"] || !cargo["reqwest"] {
+		t.Fatalf("cargo direct deps = %v (ok=%v)", cargo, ok)
+	}
+	composer, ok := DirectDependencies(context.Background(), root, "composer")
+	if !ok || !composer["monolog/monolog"] || !composer["phpunit/phpunit"] {
+		t.Fatalf("composer direct deps = %v (ok=%v)", composer, ok)
+	}
+	gems, ok := DirectDependencies(context.Background(), root, "gem")
+	if !ok || !gems["rails"] || !gems["nokogiri"] || gems["commented"] {
+		t.Fatalf("gem direct deps = %v (ok=%v)", gems, ok)
+	}
+	// A missing manifest must be reported as unknown, never as "no direct dependencies".
+	if _, ok := DirectDependencies(context.Background(), t.TempDir(), "cargo"); ok {
+		t.Fatal("a missing manifest must not report a known-empty dependency set")
+	}
+}

--- a/internal/infrastructure/tools/srcimports/walk.go
+++ b/internal/infrastructure/tools/srcimports/walk.go
@@ -2,6 +2,7 @@ package srcimports
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -86,6 +87,14 @@ func (a *scanAccumulator) graph() ports.SourceImportGraph {
 		reasons = append(reasons, reason)
 	}
 	sort.Strings(reasons)
+
+	// A scan that read source but observed NO import at all is the shape of a parser that did not
+	// understand the language, not of a project with no dependencies. Accepting it as authoritative
+	// would answer every subject "not referenced" off an empty observation, so it refuses instead.
+	if len(packages) == 0 && a.files > 0 {
+		reasons = append(reasons, "no import, require or use statement was observed in any scanned source file")
+		sort.Strings(reasons)
+	}
 
 	entrypoints := normalizeNames(a.entrypoints)
 	return ports.SourceImportGraph{
@@ -285,3 +294,104 @@ func normalizeNames(in []string) []string {
 	}
 	return result
 }
+
+// DirectDependencies returns the dependency names a first-party manifest declares, and whether a
+// manifest was found at all.
+//
+// This is the guard that keeps a TRANSITIVE package out of a Tier-1 answer. A lockfile-derived SBOM is a
+// fully resolved graph, so most components are transitive — and first-party source never writes an
+// import for a package it receives through a parent. Reporting those as unreferenced would suppress the
+// majority of real findings, so a subject that is not a declared direct dependency must not be answered.
+func DirectDependencies(ctx context.Context, dir, purlType string) (map[string]bool, bool) {
+	limits := defaultScanLimits()
+	switch purlType {
+	case "cargo":
+		content, ok := readBoundedFile(ctx, dir, "Cargo.toml", limits.maxFileBytes)
+		if !ok {
+			return nil, false
+		}
+		return cargoDirectDependencies(string(content)), true
+	case "composer":
+		content, ok := readBoundedFile(ctx, dir, "composer.json", limits.maxFileBytes)
+		if !ok {
+			return nil, false
+		}
+		return composerDirectDependencies(content), true
+	case "gem":
+		content, ok := readBoundedFile(ctx, dir, "Gemfile", limits.maxFileBytes)
+		if !ok {
+			return nil, false
+		}
+		return gemfileDirectDependencies(string(content)), true
+	}
+	return nil, false
+}
+
+// cargoDirectDependencies reads the [dependencies] style tables of a Cargo manifest.
+func cargoDirectDependencies(body string) map[string]bool {
+	out := map[string]bool{}
+	section := ""
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			section = strings.Trim(trimmed, "[]")
+			continue
+		}
+		if !strings.HasSuffix(section, "dependencies") {
+			continue
+		}
+		name, _, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			continue
+		}
+		if key := strings.TrimSpace(name); key != "" {
+			out[strings.ToLower(key)] = true
+		}
+	}
+	return out
+}
+
+// composerDirectDependencies reads require and require-dev.
+func composerDirectDependencies(content []byte) map[string]bool {
+	var manifest struct {
+		Require    map[string]string `json:"require"`
+		RequireDev map[string]string `json:"require-dev"`
+	}
+	out := map[string]bool{}
+	if jsonUnmarshal(content, &manifest) != nil {
+		return out
+	}
+	for _, group := range []map[string]string{manifest.Require, manifest.RequireDev} {
+		for name := range group {
+			out[strings.ToLower(name)] = true
+		}
+	}
+	return out
+}
+
+// gemfileDirectDependencies reads the `gem "name"` declarations of a Gemfile.
+func gemfileDirectDependencies(body string) map[string]bool {
+	out := map[string]bool{}
+	for _, line := range strings.Split(stripLineComments(body, "#"), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "gem ") {
+			continue
+		}
+		rest := strings.TrimSpace(strings.TrimPrefix(trimmed, "gem"))
+		if rest == "" {
+			continue
+		}
+		quote := rest[0]
+		if quote != '\'' && quote != '"' {
+			continue
+		}
+		rest = rest[1:]
+		if end := strings.IndexByte(rest, quote); end > 0 {
+			out[strings.ToLower(rest[:end])] = true
+		}
+	}
+	return out
+}
+
+// jsonUnmarshal is a thin alias so the manifest readers above stay easy to read.
+func jsonUnmarshal(data []byte, v any) error { return json.Unmarshal(data, v) }

--- a/internal/infrastructure/tools/srcimports/walk.go
+++ b/internal/infrastructure/tools/srcimports/walk.go
@@ -1,0 +1,287 @@
+package srcimports
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Bounds cap worst-case work on a hostile or simply enormous repository. Exceeding one is recorded as a
+// coverage reason, so a truncated scan can never look like a complete observation.
+const (
+	defaultMaxFiles     = 50000
+	defaultMaxFileBytes = 2 << 20
+	defaultMaxEntries   = 500000
+)
+
+type scanLimits struct {
+	maxFiles     int
+	maxFileBytes int64
+	maxEntries   int
+}
+
+func defaultScanLimits() scanLimits {
+	return scanLimits{maxFiles: defaultMaxFiles, maxFileBytes: defaultMaxFileBytes, maxEntries: defaultMaxEntries}
+}
+
+// dynamicConstruct is a textual marker for a construct under which a dependency can be referenced
+// without a visible import statement.
+type dynamicConstruct struct {
+	marker string
+	reason string
+}
+
+// scanAccumulator collects one scan's observations.
+type scanAccumulator struct {
+	packages    map[string]bool
+	entrypoints []string
+	reasons     map[string]bool
+	files       int
+}
+
+func newScanAccumulator() *scanAccumulator {
+	return &scanAccumulator{packages: map[string]bool{}, reasons: map[string]bool{}}
+}
+
+func (a *scanAccumulator) addPackage(name string) {
+	if trimmed := strings.ToLower(strings.TrimSpace(name)); trimmed != "" {
+		a.packages[trimmed] = true
+	}
+}
+
+func (a *scanAccumulator) addReason(reason string) {
+	if trimmed := strings.TrimSpace(reason); trimmed != "" {
+		a.reasons[trimmed] = true
+	}
+}
+
+// noteDynamic records every dynamic construct present in a file body. The recorded reason names the
+// CONSTRUCT and the file, never the surrounding source, because these strings are sealed into evidence.
+func (a *scanAccumulator) noteDynamic(body string, constructs []dynamicConstruct, path string) {
+	for _, construct := range constructs {
+		if strings.Contains(body, construct.marker) {
+			a.addReason(construct.reason + " (" + path + ")")
+		}
+	}
+}
+
+// graph renders the accumulator as the port's observation type, deterministically ordered.
+func (a *scanAccumulator) graph() ports.SourceImportGraph {
+	packages := make([]string, 0, len(a.packages))
+	for name := range a.packages {
+		packages = append(packages, name)
+	}
+	sort.Strings(packages)
+
+	reasons := make([]string, 0, len(a.reasons))
+	for reason := range a.reasons {
+		reasons = append(reasons, reason)
+	}
+	sort.Strings(reasons)
+
+	entrypoints := normalizeNames(a.entrypoints)
+	return ports.SourceImportGraph{
+		ImportedPackages: packages,
+		Entrypoints:      entrypoints,
+		CoverageReasons:  reasons,
+		FilesScanned:     a.files,
+	}
+}
+
+// sourceWalker performs a bounded, confined traversal collecting one language's source files.
+type sourceWalker struct {
+	limits     scanLimits
+	extensions []string
+	skipDir    map[string]bool
+}
+
+func newSourceWalker(limits scanLimits, extensions []string, skipDir map[string]bool) *sourceWalker {
+	return &sourceWalker{limits: limits, extensions: extensions, skipDir: skipDir}
+}
+
+// walk visits every supported source file under dir, calling visit with its content.
+//
+// Symlinks are never followed and every skipped or unreadable file becomes a coverage reason, because a
+// file this scan did not read could reference a dependency.
+func (w *sourceWalker) walk(ctx context.Context, dir string, visit func(path string, content []byte, out *scanAccumulator)) (*scanAccumulator, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: source scan requires a context", shared.ErrValidation)
+	}
+	trimmed := strings.TrimSpace(dir)
+	if trimmed == "" {
+		return nil, fmt.Errorf("%w: source scan requires a target directory", shared.ErrValidation)
+	}
+	info, err := os.Lstat(trimmed)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: source scan root does not exist", shared.ErrNotFound)
+		}
+		return nil, fmt.Errorf("%w: source scan root is not readable", shared.ErrValidation)
+	}
+	if info.Mode()&fs.ModeSymlink != 0 || !info.IsDir() {
+		return nil, fmt.Errorf("%w: source scan root must be a real directory", shared.ErrValidation)
+	}
+
+	rootDir, err := os.OpenRoot(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("%w: source scan root could not be opened", shared.ErrValidation)
+	}
+	defer func() { _ = rootDir.Close() }()
+
+	out := newScanAccumulator()
+	entries := 0
+	walkErr := fs.WalkDir(rootDir.FS(), ".", func(p string, d fs.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if err != nil {
+			out.addReason("a directory entry could not be read")
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		entries++
+		if entries > w.limits.maxEntries {
+			out.addReason("directory entry budget exceeded; traversal stopped")
+			return fs.SkipAll
+		}
+		if d.IsDir() {
+			if p == "." {
+				return nil
+			}
+			name := d.Name()
+			if w.skipDir[name] || strings.HasPrefix(name, ".") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			out.addReason("a symlink was not followed (" + p + ")")
+			return nil
+		}
+		if !d.Type().IsRegular() || !w.supported(p) {
+			return nil
+		}
+		if out.files >= w.limits.maxFiles {
+			out.addReason("source file budget exceeded; some files were not scanned")
+			return nil
+		}
+		content, ok := readThroughRoot(rootDir, p, w.limits.maxFileBytes)
+		if !ok {
+			out.addReason("a source file could not be read (" + p + ")")
+			return nil
+		}
+		if !utf8.Valid(content) {
+			out.addReason("a source file is not valid UTF-8 (" + p + ")")
+			return nil
+		}
+		out.files++
+		visit(p, content, out)
+		return nil
+	})
+	if walkErr != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("source scan cancelled: %w", ctxErr)
+		}
+		return nil, fmt.Errorf("%w: source scan could not walk the target", shared.ErrValidation)
+	}
+	if out.files == 0 {
+		return nil, fmt.Errorf("%w: no supported source under the target (no coverage)", shared.ErrNotFound)
+	}
+	return out, nil
+}
+
+func (w *sourceWalker) supported(p string) bool {
+	lower := strings.ToLower(p)
+	for _, ext := range w.extensions {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// readThroughRoot reads a file through the confined root handle, bounded by the per-file budget.
+func readThroughRoot(rootDir *os.Root, rel string, maxBytes int64) ([]byte, bool) {
+	f, err := rootDir.Open(rel)
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, false
+	}
+	// Read one byte past the budget so growth during the read is detectable rather than silently
+	// truncating the tail of a file.
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil || int64(len(data)) > maxBytes {
+		return nil, false
+	}
+	return data, true
+}
+
+// readBoundedFile reads one named file directly under dir, used for manifests.
+func readBoundedFile(ctx context.Context, dir, name string, maxBytes int64) ([]byte, bool) {
+	if ctx == nil || ctx.Err() != nil {
+		return nil, false
+	}
+	rootDir, err := os.OpenRoot(strings.TrimSpace(dir))
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = rootDir.Close() }()
+	info, err := rootDir.Lstat(name)
+	if err != nil || info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, false
+	}
+	return readThroughRoot(rootDir, name, maxBytes)
+}
+
+// stripLineComments removes single-line comments so a commented-out import cannot become a false
+// reference. Block comments are left alone: including one would risk removing real code on a mismatch,
+// and an extra reference is the safe direction.
+func stripLineComments(body, marker string) string {
+	var sb strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		if i := strings.Index(line, marker); i >= 0 {
+			// Only strip when the marker is not inside a quoted string on that line.
+			if strings.Count(line[:i], "\"")%2 == 0 && strings.Count(line[:i], "'")%2 == 0 {
+				line = line[:i]
+			}
+		}
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// normalizeNames lowercases, trims, sorts and deduplicates a name list.
+func normalizeNames(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, name := range in {
+		if trimmed := strings.ToLower(strings.TrimSpace(name)); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Strings(out)
+	result := out[:1]
+	for _, name := range out[1:] {
+		if name != result[len(result)-1] {
+			result = append(result, name)
+		}
+	}
+	return result
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -294,6 +294,16 @@ type Config struct {
 	// first-party import graph cannot prove a transitive package unused. Also requires the judgment
 	// lifecycle (SYNAPSE_JUDGMENTS_ENABLED).
 	JSReachabilityEnabled bool
+
+	// RustReachabilityEnabled, PHPReachabilityEnabled and RubyReachabilityEnabled turn on deterministic
+	// Tier-1 import-reachability for those ecosystems: a declared dependency that first-party source
+	// never references becomes not_reachable, which the export path turns into an OpenVEX not_affected
+	// justification. All are source-only (nothing is executed, installed or resolved over the network),
+	// best-effort and opt-in, and each refuses a verdict whenever a dynamic construct could hide a
+	// reference. All require the judgment lifecycle (SYNAPSE_JUDGMENTS_ENABLED).
+	RustReachabilityEnabled bool
+	PHPReachabilityEnabled  bool
+	RubyReachabilityEnabled bool
 	// TaintCallgraphBin is the pinned synapse-callgraph binary: the sandboxed go/ssa call-graph builder
 	// the taint analyzer shells out to. In-repo cmd (built by `make build` into bin/); pin its hash via
 	// SYNAPSE_TOOL_HASHES, like any other tool binary.
@@ -482,6 +492,9 @@ func Load() Config {
 		ReachabilityEnabled:          getbool("SYNAPSE_REACHABILITY_ENABLED", true),
 		PyReachabilityEnabled:        getbool("SYNAPSE_PYREACH_ENABLED", false),
 		JSReachabilityEnabled:        getbool("SYNAPSE_JSREACH_ENABLED", false),
+		RustReachabilityEnabled:      getbool("SYNAPSE_REACH_RUST", false),
+		PHPReachabilityEnabled:       getbool("SYNAPSE_REACH_PHP", false),
+		RubyReachabilityEnabled:      getbool("SYNAPSE_REACH_RUBY", false),
 		CrossCheckEnabled:            getbool("SYNAPSE_CROSSCHECK_ENABLED", true),
 		SBOMCrossCheckEnabled:        getbool("SYNAPSE_SBOM_CROSSCHECK_ENABLED", true),
 		WriteupDraftsEnabled:         getbool("SYNAPSE_WRITEUP_DRAFTS_ENABLED", false), // needs agent → opt-in

--- a/internal/usecase/ports/srcimports.go
+++ b/internal/usecase/ports/srcimports.go
@@ -1,0 +1,39 @@
+package ports
+
+import "context"
+
+// SourceImportGraph is one language's first-party import observation for a target.
+//
+// It is deliberately coarse: Tier-1 reachability asks only whether first-party code references a
+// dependency at all, so a package name set plus an honest account of what could NOT be observed is
+// sufficient — and far more robust than a call graph over languages whose dynamic loading defeats one.
+type SourceImportGraph struct {
+	// ImportedPackages are the distribution/crate/gem names first-party source references, lowercased.
+	ImportedPackages []string
+	// Entrypoints are the discovered entrypoints, kept as provenance for the sealed proof. They are
+	// discovered structurally, not verified to execute.
+	Entrypoints []string
+	// CoverageReasons explains, in short non-source-quoting labels, why the observation is incomplete.
+	// A NON-EMPTY list means no negative conclusion is safe: something could reference a dependency
+	// without this scan seeing it.
+	CoverageReasons []string
+	// FilesScanned is the number of source files actually read.
+	FilesScanned int
+}
+
+// Complete reports whether the observation is good enough to support a NEGATIVE conclusion.
+func (g SourceImportGraph) Complete() bool { return len(g.CoverageReasons) == 0 }
+
+// SourceImportScanner observes first-party imports for one language.
+//
+// Implementations must be source-only: they read and lex text, and never execute project code, a package
+// manager, a build system or a language runtime, and never access the network. Any construct that could
+// reference a dependency invisibly — dynamic loading, macro expansion, computed paths, metaprogramming —
+// must be recorded in CoverageReasons rather than ignored, because a missed reference becomes a false
+// "unreachable" that suppresses a real vulnerability.
+type SourceImportScanner interface {
+	ScanImports(ctx context.Context, dir string) (SourceImportGraph, error)
+	// Lang is the ecosystem this scanner observes, matching the package-URL type ("cargo", "composer",
+	// "gem"), so a coordinator can pair it with the right components.
+	Lang() string
+}

--- a/internal/usecase/reachproof/coordinator.go
+++ b/internal/usecase/reachproof/coordinator.go
@@ -45,6 +45,9 @@ type Language string
 const (
 	LanguagePython     Language = "python"
 	LanguageJavaScript Language = "javascript"
+	LanguageRust       Language = "rust"
+	LanguagePHP        Language = "php"
+	LanguageRuby       Language = "ruby"
 )
 
 // Valid reports whether l is a supported Tier-1 language.
@@ -63,6 +66,12 @@ func actorsFor(tier judgment.ReachabilityTier, language Language) (proposer, ver
 	switch language {
 	case LanguageJavaScript:
 		return "system:jsimport-scan", "system:jsimport-engine", "tier-1 javascript import-reachability proof"
+	case LanguageRust:
+		return "system:rustimport-scan", "system:rustimport-engine", "tier-1 rust import-reachability proof"
+	case LanguagePHP:
+		return "system:phpimport-scan", "system:phpimport-engine", "tier-1 php import-reachability proof"
+	case LanguageRuby:
+		return "system:rubyimport-scan", "system:rubyimport-engine", "tier-1 ruby import-reachability proof"
 	default:
 		return "system:pyimport-scan", "system:pyimport-engine", "tier-1 import-reachability proof"
 	}

--- a/internal/usecase/reachproof/coordinator.go
+++ b/internal/usecase/reachproof/coordinator.go
@@ -53,7 +53,7 @@ const (
 // Valid reports whether l is a supported Tier-1 language.
 func (l Language) Valid() bool {
 	switch l {
-	case LanguagePython, LanguageJavaScript:
+	case LanguagePython, LanguageJavaScript, LanguageRust, LanguagePHP, LanguageRuby:
 		return true
 	}
 	return false

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -737,3 +737,35 @@ func jsReachabilitySubjects(findings []finding.Finding, vulns []vulnerability.Vu
 	}
 	return subs
 }
+
+// ecosystemReachabilitySubjects builds Tier-1 subjects for a package-URL ecosystem whose reachability is
+// answered by NAME (Rust crates, Composer packages, Ruby gems), mirroring the Python builder. The
+// JavaScript ecosystem is deliberately not built this way: it installs several versions of one package,
+// so its subjects carry the exact component purl instead.
+func ecosystemReachabilitySubjects(findings []finding.Finding, vulns []vulnerability.Vulnerability, doc *sbom.SBOM, purlPrefix string) []ports.ReachabilitySubject {
+	if doc == nil {
+		return nil
+	}
+	names := map[string]bool{}
+	for _, c := range doc.Components {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(c.PURL)), purlPrefix) {
+			names[strings.ToLower(c.Name)] = true
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	byDedup := make(map[string]vulnerability.Vulnerability, len(vulns))
+	for _, v := range vulns {
+		byDedup[vulnDedupKey(v)] = v
+	}
+	var subs []ports.ReachabilitySubject
+	for _, f := range findings {
+		v, ok := byDedup[f.DedupKey]
+		if !ok || !names[strings.ToLower(v.Component)] {
+			continue
+		}
+		subs = append(subs, ports.ReachabilitySubject{FindingID: f.ID, Symbols: []string{v.Component}})
+	}
+	return subs
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -63,41 +63,42 @@ type Service struct {
 	riskEnricher                     ports.RiskEnricher
 	licScan                          ports.LicenseScanner
 	licEnricher                      ports.LicenseEnricher
-	sbomEnricher                     ports.SBOMEnricher              // optional manifest enrichment (gem edges, maven/gradle deps, pnpm scope)
-	licCoord                         ports.MavenCoordResolver        // optional: recover real Maven coords from JAR pom.properties before license lookup
-	jarChecksum                      ports.JarChecksumResolver       // optional: capture JAR artifact SHA-1 from the workspace (Syft omits it from CycloneDX)
-	jarHash                          ports.JarHashResolver           // optional: recover coords of shaded/metadata-less JARs via SHA-1
-	licFile                          ports.LicenseFileResolver       // optional offline license-text fallback from JAR LICENSE files
-	sastAnalyzer                     ports.SASTAnalyzer              // optional deterministic pattern-SAST over the live workspace
-	secretScanner                    ports.SecretScanner             // optional deterministic secret scan over the live workspace
-	includeTestSecrets               bool                            // report secrets in test/fixture/docs paths (default false: suppress)
-	misconfig                        ports.MisconfigScanner          // optional deterministic IaC/config misconfig scan over the live workspace
-	fpTriager                        ports.FPTriager                 // optional LLM false-positive critique of production-scope source findings
-	osPkgCataloger                   ports.OSPackageCataloger        // optional owned OS-package cataloging (dpkg/apk) from an image rootfs
-	instCataloger                    ports.InstalledPackageCataloger // optional owned installed-package cataloging (Go binaries, Python dist-info) from an image rootfs
-	artifactCataloger                ports.ArtifactCataloger         // optional owned standalone-artifact cataloging (.msi product identity) from the workspace dir
-	suppression                      ports.SuppressionLoader         // optional repo-committed .synapseignore accepted-risk policy
-	vexLoader                        ports.VEXLoader                 // optional in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
-	complianceOn                     bool                            // when set, attach the AppSec-baseline compliance report to a scan
-	dbMaxAgeDays                     int                             // when > 0, warn if a reference DB (KEV/EPSS/vuln-DB) is older than this
-	detectionPriority                string                          // server default detection priority (comprehensive|precise); empty = comprehensive
-	reachability                     ports.ReachabilityRecorder      // optional deterministic Tier-2 reachability proof (Go call-graph)
-	pyReachability                   ports.ReachabilityRecorder      // optional deterministic Tier-1 Python import-reachability proof
-	jsReachability                   jsReachabilityRecorder          // optional deterministic Tier-1 JavaScript import-reachability proof
-	correlation                      ports.CorrelationRecorder       // optional cross-check disagreement → judgment minter
-	sbomGen2                         ports.SBOMGenerator             // optional 2nd SBOM producer for the cross-check
-	sbomCache                        ports.SBOMCache                 // optional content+version-addressed cache of the generated SBOM
-	sbomCrossCheck                   ports.SBOMCrossCheckRecorder    // optional SBOM-producer disagreement → judgment minter
-	taint                            ports.TaintScanner              // optional deterministic taint-analysis → gated CapSAST proposals
-	graphResolver                    ports.DependencyGraphResolver   // optional transitive-edge resolver (Go via `go mod graph`)
-	mavenResolver                    ports.MavenResolver             // optional Maven transitive-tree resolver (`mvn dependency:list`)
-	gradleResolver                   ports.GradleResolver            // optional Gradle transitive-tree resolver (`gradle dependencies`)
-	npmResolver                      ports.NPMResolver               // optional npm resolver (`npm install --package-lock-only`) for a lockfile-less package.json
-	manifestResolvers                []ports.ManifestResolver        // optional lockfile-less resolvers for composer.json / Gemfile / pyproject.toml / ...
-	jvmReach                         ports.JVMReachabilityAnalyzer   // optional coarse JVM class-reachability tagger
-	sevEnricher                      ports.SeverityEnricher          // optional NVD CVSS backfill for unknown-severity vulns
-	ignoreUnfixed                    bool                            // when set, don't promote no-fix vulns to findings (Trivy --ignore-unfixed)
-	guard                            *execution.Guard                // shared scope + window + audit gate; built in NewService
+	sbomEnricher                     ports.SBOMEnricher                    // optional manifest enrichment (gem edges, maven/gradle deps, pnpm scope)
+	licCoord                         ports.MavenCoordResolver              // optional: recover real Maven coords from JAR pom.properties before license lookup
+	jarChecksum                      ports.JarChecksumResolver             // optional: capture JAR artifact SHA-1 from the workspace (Syft omits it from CycloneDX)
+	jarHash                          ports.JarHashResolver                 // optional: recover coords of shaded/metadata-less JARs via SHA-1
+	licFile                          ports.LicenseFileResolver             // optional offline license-text fallback from JAR LICENSE files
+	sastAnalyzer                     ports.SASTAnalyzer                    // optional deterministic pattern-SAST over the live workspace
+	secretScanner                    ports.SecretScanner                   // optional deterministic secret scan over the live workspace
+	includeTestSecrets               bool                                  // report secrets in test/fixture/docs paths (default false: suppress)
+	misconfig                        ports.MisconfigScanner                // optional deterministic IaC/config misconfig scan over the live workspace
+	fpTriager                        ports.FPTriager                       // optional LLM false-positive critique of production-scope source findings
+	osPkgCataloger                   ports.OSPackageCataloger              // optional owned OS-package cataloging (dpkg/apk) from an image rootfs
+	instCataloger                    ports.InstalledPackageCataloger       // optional owned installed-package cataloging (Go binaries, Python dist-info) from an image rootfs
+	artifactCataloger                ports.ArtifactCataloger               // optional owned standalone-artifact cataloging (.msi product identity) from the workspace dir
+	suppression                      ports.SuppressionLoader               // optional repo-committed .synapseignore accepted-risk policy
+	vexLoader                        ports.VEXLoader                       // optional in-repo OpenVEX (.synapse.vex.json) accepted-risk assertions
+	complianceOn                     bool                                  // when set, attach the AppSec-baseline compliance report to a scan
+	dbMaxAgeDays                     int                                   // when > 0, warn if a reference DB (KEV/EPSS/vuln-DB) is older than this
+	detectionPriority                string                                // server default detection priority (comprehensive|precise); empty = comprehensive
+	reachability                     ports.ReachabilityRecorder            // optional deterministic Tier-2 reachability proof (Go call-graph)
+	pyReachability                   ports.ReachabilityRecorder            // optional deterministic Tier-1 Python import-reachability proof
+	jsReachability                   jsReachabilityRecorder                // optional deterministic Tier-1 JavaScript import-reachability proof
+	srcReachability                  map[string]ports.ReachabilityRecorder // optional Tier-1 provers keyed by package-URL type
+	correlation                      ports.CorrelationRecorder             // optional cross-check disagreement → judgment minter
+	sbomGen2                         ports.SBOMGenerator                   // optional 2nd SBOM producer for the cross-check
+	sbomCache                        ports.SBOMCache                       // optional content+version-addressed cache of the generated SBOM
+	sbomCrossCheck                   ports.SBOMCrossCheckRecorder          // optional SBOM-producer disagreement → judgment minter
+	taint                            ports.TaintScanner                    // optional deterministic taint-analysis → gated CapSAST proposals
+	graphResolver                    ports.DependencyGraphResolver         // optional transitive-edge resolver (Go via `go mod graph`)
+	mavenResolver                    ports.MavenResolver                   // optional Maven transitive-tree resolver (`mvn dependency:list`)
+	gradleResolver                   ports.GradleResolver                  // optional Gradle transitive-tree resolver (`gradle dependencies`)
+	npmResolver                      ports.NPMResolver                     // optional npm resolver (`npm install --package-lock-only`) for a lockfile-less package.json
+	manifestResolvers                []ports.ManifestResolver              // optional lockfile-less resolvers for composer.json / Gemfile / pyproject.toml / ...
+	jvmReach                         ports.JVMReachabilityAnalyzer         // optional coarse JVM class-reachability tagger
+	sevEnricher                      ports.SeverityEnricher                // optional NVD CVSS backfill for unknown-severity vulns
+	ignoreUnfixed                    bool                                  // when set, don't promote no-fix vulns to findings (Trivy --ignore-unfixed)
+	guard                            *execution.Guard                      // shared scope + window + audit gate; built in NewService
 	codeQuality                      interface {
 		BuildReport(context.Context, string) (codequality.Report, error)
 	}
@@ -325,6 +326,27 @@ func (s *Service) SetPyReachability(r ports.ReachabilityRecorder) { s.pyReachabi
 // rather than re-deriving one that could differ.
 type jsReachabilityRecorder interface {
 	RecordWithSBOM(ctx context.Context, engagementID shared.ID, targetRef string, doc *sbom.SBOM, subjects []ports.ReachabilitySubject) (int, error)
+}
+
+// sourceReachabilityEcosystems is the fixed, ordered set of name-addressed ecosystems, so the pass runs
+// deterministically regardless of registration order.
+var sourceReachabilityEcosystems = []struct {
+	purlType string
+	prefix   string
+}{
+	{purlType: "cargo", prefix: "pkg:cargo/"},
+	{purlType: "composer", prefix: "pkg:composer/"},
+	{purlType: "gem", prefix: "pkg:gem/"},
+}
+
+// SetSourceReachability registers a deterministic Tier-1 import-reachability prover for one package-URL
+// ecosystem ("cargo", "composer", "gem"). Best-effort and opt-in; a prover that reports no coverage
+// leaves the prior tier standing.
+func (s *Service) SetSourceReachability(purlType string, r ports.ReachabilityRecorder) {
+	if s.srcReachability == nil {
+		s.srcReachability = map[string]ports.ReachabilityRecorder{}
+	}
+	s.srcReachability[purlType] = r
 }
 
 // SetJSReachability configures the optional deterministic Tier-1 JavaScript import-reachability prover.
@@ -2439,6 +2461,20 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	if opts.scansVulnerabilities() && s.pyReachability != nil {
 		if subs := pyReachabilitySubjects(result.Findings, result.Vulnerabilities, result.SBOM); len(subs) > 0 {
 			_, _ = s.pyReachability.Record(ctx, engagementID, ws.Dir, subs)
+		}
+	}
+
+	// Deterministic TIER-1 reachability for the name-addressed ecosystems (Rust, PHP, Ruby). Each is
+	// best-effort and opt-in; a no-coverage result is ignored so the scan is never failed by it.
+	if opts.scansVulnerabilities() && len(s.srcReachability) > 0 {
+		for _, eco := range sourceReachabilityEcosystems {
+			recorder, ok := s.srcReachability[eco.purlType]
+			if !ok || recorder == nil {
+				continue
+			}
+			if subs := ecosystemReachabilitySubjects(result.Findings, result.Vulnerabilities, result.SBOM, eco.prefix); len(subs) > 0 {
+				_, _ = recorder.Record(ctx, engagementID, ws.Dir, subs)
+			}
 		}
 	}
 

--- a/internal/usecase/srcreach/analyzer.go
+++ b/internal/usecase/srcreach/analyzer.go
@@ -1,0 +1,131 @@
+// Package srcreach implements deterministic Tier-1 reachability over a first-party source import scan,
+// shared by every language whose dependency usage is observable as an import/require/use statement.
+//
+// SAFETY: an "unreachable" verdict suppresses work, so a false unreachable is worse than no verdict. The
+// analyzer therefore REFUSES to answer — returning a no-coverage error, which leaves any prior tier
+// standing — whenever the scan reports that anything could hide a reference: dynamic loading, macro
+// expansion, computed include paths, metaprogramming, an unreadable file or an exhausted budget. Only a
+// completely observed target can produce a negative.
+//
+// Matching is deliberately GENEROUS. A package may be referenced under several plausible names (a Rust
+// crate's hyphens become underscores in `use`, a PHP package's Composer name is not its namespace, a Ruby
+// gem's require path often differs from its gem name), so every plausible name counts as a reference.
+// Over-matching biases toward "reachable", which is the safe direction; under-matching would suppress a
+// real finding.
+package srcreach
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachability"
+)
+
+// importScanner is the narrow read the analyzer needs; ports.SourceImportScanner satisfies it.
+type importScanner interface {
+	ScanImports(ctx context.Context, dir string) (ports.SourceImportGraph, error)
+	Lang() string
+}
+
+// CandidateNamer expands a dependency name into every plausible source-level reference name. It is the
+// one piece that differs per language.
+type CandidateNamer func(packageName string) []string
+
+// Analyzer implements the reachproof analyzer contract over a source import scan.
+type Analyzer struct {
+	scanner    importScanner
+	candidates CandidateNamer
+}
+
+// New validates and returns the analyzer.
+func New(scanner importScanner, candidates CandidateNamer) (*Analyzer, error) {
+	if scanner == nil {
+		return nil, fmt.Errorf("%w: srcreach analyzer needs an import scanner", shared.ErrValidation)
+	}
+	if candidates == nil {
+		return nil, fmt.Errorf("%w: srcreach analyzer needs a candidate namer", shared.ErrValidation)
+	}
+	return &Analyzer{scanner: scanner, candidates: candidates}, nil
+}
+
+// Lang reports the ecosystem this analyzer answers for.
+func (a *Analyzer) Analyzeable() string { return a.scanner.Lang() }
+
+// Analyze reports, for each subject package name, whether first-party source references it.
+func (a *Analyzer) Analyze(ctx context.Context, dir string, subjects []string) (*reachability.Analysis, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: srcreach analysis requires a context", shared.ErrValidation)
+	}
+	if strings.TrimSpace(dir) == "" {
+		return nil, fmt.Errorf("%w: srcreach analysis requires a target directory", shared.ErrValidation)
+	}
+
+	graph, err := a.scanner.ScanImports(ctx, dir)
+	if err != nil {
+		return nil, fmt.Errorf("srcreach: %s import scan (no coverage - prior tier stands): %w", a.scanner.Lang(), err)
+	}
+	// An unknown region means some reference could be invisible, so absence of a reference is not proof
+	// of absence for ANY subject. This is the non-negotiable of the whole feature.
+	if !graph.Complete() {
+		return nil, fmt.Errorf("%w: %s reachability is inconclusive - %s (no coverage)",
+			shared.ErrValidation, a.scanner.Lang(), strings.Join(graph.CoverageReasons, "; "))
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	referenced := make(map[string]bool, len(graph.ImportedPackages))
+	for _, name := range graph.ImportedPackages {
+		referenced[strings.ToLower(strings.TrimSpace(name))] = true
+	}
+
+	results := make([]reachability.Result, 0, len(subjects))
+	seen := make(map[string]bool, len(subjects))
+	for _, subject := range subjects {
+		if strings.TrimSpace(subject) == "" || seen[subject] {
+			continue
+		}
+		seen[subject] = true
+		result := reachability.Result{Symbol: subject}
+		for _, candidate := range a.candidates(subject) {
+			if referenced[candidate] {
+				result.Reachable = true
+				// The proof names the reference form that matched, which is evidence a reader can check
+				// against the source without the analyzer quoting any of it.
+				result.Path = []string{a.scanner.Lang() + " import " + candidate}
+				break
+			}
+		}
+		results = append(results, result)
+	}
+
+	entrypoints := append([]string(nil), graph.Entrypoints...)
+	sort.Strings(entrypoints)
+	return &reachability.Analysis{Results: results, Entrypoints: entrypoints}, nil
+}
+
+// NormalizeCandidates lowercases, trims, sorts and deduplicates a candidate list so matching is
+// deterministic regardless of how a language's namer produced it.
+func NormalizeCandidates(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, name := range in {
+		if trimmed := strings.ToLower(strings.TrimSpace(name)); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Strings(out)
+	result := out[:1]
+	for _, name := range out[1:] {
+		if name != result[len(result)-1] {
+			result = append(result, name)
+		}
+	}
+	return result
+}

--- a/internal/usecase/srcreach/analyzer.go
+++ b/internal/usecase/srcreach/analyzer.go
@@ -35,21 +35,34 @@ type importScanner interface {
 // one piece that differs per language.
 type CandidateNamer func(packageName string) []string
 
+// DirectDependencyReader reports the dependency names a first-party manifest declares.
+//
+// It is the guard that keeps a TRANSITIVE package out of a Tier-1 answer. A lockfile-derived SBOM is a
+// fully resolved graph, so most of its components are transitive — and first-party source never writes
+// an import for a package it receives through a parent. Answering "not referenced" for those would
+// suppress the majority of real findings, so a subject that is not a declared direct dependency is
+// refused instead.
+type DirectDependencyReader func(ctx context.Context, dir string) (map[string]bool, bool)
+
 // Analyzer implements the reachproof analyzer contract over a source import scan.
 type Analyzer struct {
 	scanner    importScanner
 	candidates CandidateNamer
+	directDeps DirectDependencyReader
 }
 
 // New validates and returns the analyzer.
-func New(scanner importScanner, candidates CandidateNamer) (*Analyzer, error) {
+func New(scanner importScanner, candidates CandidateNamer, directDeps DirectDependencyReader) (*Analyzer, error) {
 	if scanner == nil {
 		return nil, fmt.Errorf("%w: srcreach analyzer needs an import scanner", shared.ErrValidation)
 	}
 	if candidates == nil {
 		return nil, fmt.Errorf("%w: srcreach analyzer needs a candidate namer", shared.ErrValidation)
 	}
-	return &Analyzer{scanner: scanner, candidates: candidates}, nil
+	if directDeps == nil {
+		return nil, fmt.Errorf("%w: srcreach analyzer needs a direct-dependency reader", shared.ErrValidation)
+	}
+	return &Analyzer{scanner: scanner, candidates: candidates, directDeps: directDeps}, nil
 }
 
 // Lang reports the ecosystem this analyzer answers for.
@@ -78,6 +91,14 @@ func (a *Analyzer) Analyze(ctx context.Context, dir string, subjects []string) (
 		return nil, err
 	}
 
+	// Without a readable manifest there is no way to tell a direct dependency from a transitive one, so
+	// no negative is safe for any subject.
+	direct, ok := a.directDeps(ctx, dir)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s manifest could not be read, so direct dependencies are unknown (no coverage)",
+			shared.ErrValidation, a.scanner.Lang())
+	}
+
 	referenced := make(map[string]bool, len(graph.ImportedPackages))
 	for _, name := range graph.ImportedPackages {
 		referenced[strings.ToLower(strings.TrimSpace(name))] = true
@@ -90,6 +111,12 @@ func (a *Analyzer) Analyze(ctx context.Context, dir string, subjects []string) (
 			continue
 		}
 		seen[subject] = true
+		if !direct[strings.ToLower(strings.TrimSpace(subject))] {
+			// A transitive package is loaded by its parent, so the absence of a first-party import
+			// proves nothing about it. Refuse rather than answer.
+			return nil, fmt.Errorf("%w: %q is not a declared direct dependency, so a first-party import scan cannot prove it unused (no coverage)",
+				shared.ErrValidation, subject)
+		}
 		result := reachability.Result{Symbol: subject}
 		for _, candidate := range a.candidates(subject) {
 			if referenced[candidate] {

--- a/internal/usecase/srcreach/analyzer_test.go
+++ b/internal/usecase/srcreach/analyzer_test.go
@@ -1,0 +1,186 @@
+package srcreach
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeScanner struct {
+	graph ports.SourceImportGraph
+	err   error
+	lang  string
+}
+
+func (f fakeScanner) ScanImports(context.Context, string) (ports.SourceImportGraph, error) {
+	return f.graph, f.err
+}
+func (f fakeScanner) Lang() string { return f.lang }
+
+func identityCandidates(name string) []string { return []string{name} }
+
+func TestNewValidates(t *testing.T) {
+	t.Parallel()
+	if _, err := New(nil, identityCandidates); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil scanner must be rejected, got %v", err)
+	}
+	if _, err := New(fakeScanner{lang: "cargo"}, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil namer must be rejected, got %v", err)
+	}
+}
+
+func TestReachableAndNotReachable(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(fakeScanner{
+		lang:  "cargo",
+		graph: ports.SourceImportGraph{ImportedPackages: []string{"serde"}, FilesScanned: 1},
+	}, identityCandidates)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	analysis, err := a.Analyze(context.Background(), "/ws", []string{"serde", "unused-crate"})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if !analysis.Results[0].Reachable {
+		t.Fatal("a referenced package must be reachable")
+	}
+	if analysis.Results[1].Reachable {
+		t.Fatal("an unreferenced package must be not-reachable")
+	}
+	if len(analysis.Results[0].Path) == 0 {
+		t.Fatal("a reachable result must carry a proof")
+	}
+}
+
+// TestUnknownNeverResolvesToUnreachable is the acceptance gate of #414, asserted per language: no input
+// may produce an unreachable verdict while an unknown region exists, because an unreachable verdict
+// suppresses work.
+func TestUnknownNeverResolvesToUnreachable(t *testing.T) {
+	t.Parallel()
+
+	for _, lang := range []string{"cargo", "composer", "gem"} {
+		lang := lang
+		t.Run(lang, func(t *testing.T) {
+			t.Parallel()
+			a, err := New(fakeScanner{
+				lang: lang,
+				graph: ports.SourceImportGraph{
+					ImportedPackages: []string{"observed"},
+					// One unknown region is enough: something could reference the subject invisibly.
+					CoverageReasons: []string{"a dynamic construct hides references"},
+					FilesScanned:    1,
+				},
+			}, identityCandidates)
+			if err != nil {
+				t.Fatalf("new: %v", err)
+			}
+			analysis, err := a.Analyze(context.Background(), "/ws", []string{"never-referenced"})
+			if err == nil {
+				t.Fatalf("an unknown region must refuse the analysis, got %+v", analysis)
+			}
+			if analysis != nil {
+				t.Fatalf("a refusal must return no analysis, got %+v", analysis)
+			}
+		})
+	}
+}
+
+func TestIncompleteEntrypointDiscoveryYieldsNoVerdict(t *testing.T) {
+	t.Parallel()
+
+	// Incomplete discovery must yield unknown with a coverage reason, never a clean unreachable.
+	a, err := New(fakeScanner{
+		lang: "gem",
+		graph: ports.SourceImportGraph{
+			ImportedPackages: []string{"rails"},
+			CoverageReasons:  []string{"source file budget exceeded; some files were not scanned"},
+		},
+	}, identityCandidates)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if _, err := a.Analyze(context.Background(), "/ws", []string{"rails"}); err == nil {
+		t.Fatal("incomplete discovery must refuse the analysis")
+	}
+}
+
+func TestScanFailureIsNoCoverage(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(fakeScanner{lang: "cargo", err: errors.New("scan exploded")}, identityCandidates)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	analysis, err := a.Analyze(context.Background(), "/ws", []string{"serde"})
+	if err == nil || analysis != nil {
+		t.Fatal("a scan failure must be a no-coverage error with no analysis")
+	}
+}
+
+func TestGenerousCandidateMatching(t *testing.T) {
+	t.Parallel()
+
+	// A dependency referenced under an alternate name must still count: over-matching biases toward
+	// reachable, which is safe; under-matching would suppress a real finding.
+	a, err := New(fakeScanner{
+		lang:  "cargo",
+		graph: ports.SourceImportGraph{ImportedPackages: []string{"serde_json"}, FilesScanned: 1},
+	}, func(name string) []string { return []string{name, "serde_json"} })
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	analysis, err := a.Analyze(context.Background(), "/ws", []string{"serde-json"})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if !analysis.Results[0].Reachable {
+		t.Fatal("an alternate reference form must still count as a reference")
+	}
+}
+
+func TestSubjectsAreDeduplicatedAndOrdered(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(fakeScanner{
+		lang:  "gem",
+		graph: ports.SourceImportGraph{ImportedPackages: []string{"rails"}, FilesScanned: 1},
+	}, identityCandidates)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	analysis, err := a.Analyze(context.Background(), "/ws", []string{"b", "a", "b", "", "c"})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	want := []string{"b", "a", "c"}
+	if len(analysis.Results) != len(want) {
+		t.Fatalf("got %d results, want %d", len(analysis.Results), len(want))
+	}
+	for i := range want {
+		if analysis.Results[i].Symbol != want[i] {
+			t.Fatalf("result[%d] = %q, want %q", i, analysis.Results[i].Symbol, want[i])
+		}
+	}
+}
+
+func TestCancelledContextIsHonored(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(fakeScanner{
+		lang:  "cargo",
+		graph: ports.SourceImportGraph{ImportedPackages: []string{"serde"}, FilesScanned: 1},
+	}, identityCandidates)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := a.Analyze(ctx, "/ws", []string{"serde"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("a cancelled context must abort the analysis, got %v", err)
+	}
+}

--- a/internal/usecase/srcreach/analyzer_test.go
+++ b/internal/usecase/srcreach/analyzer_test.go
@@ -22,12 +22,22 @@ func (f fakeScanner) Lang() string { return f.lang }
 
 func identityCandidates(name string) []string { return []string{name} }
 
+// allDirect treats every subject as a declared direct dependency, so a test can exercise the matching
+// logic without also modelling a manifest.
+func allDirect(names ...string) DirectDependencyReader {
+	set := map[string]bool{}
+	for _, n := range names {
+		set[n] = true
+	}
+	return func(context.Context, string) (map[string]bool, bool) { return set, true }
+}
+
 func TestNewValidates(t *testing.T) {
 	t.Parallel()
-	if _, err := New(nil, identityCandidates); !errors.Is(err, shared.ErrValidation) {
+	if _, err := New(nil, identityCandidates, allDirect()); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("a nil scanner must be rejected, got %v", err)
 	}
-	if _, err := New(fakeScanner{lang: "cargo"}, nil); !errors.Is(err, shared.ErrValidation) {
+	if _, err := New(fakeScanner{lang: "cargo"}, nil, allDirect()); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("a nil namer must be rejected, got %v", err)
 	}
 }
@@ -38,7 +48,7 @@ func TestReachableAndNotReachable(t *testing.T) {
 	a, err := New(fakeScanner{
 		lang:  "cargo",
 		graph: ports.SourceImportGraph{ImportedPackages: []string{"serde"}, FilesScanned: 1},
-	}, identityCandidates)
+	}, identityCandidates, allDirect("serde", "unused-crate", "rails", "never-referenced", "a", "b", "c", "serde-json"))
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
@@ -75,7 +85,7 @@ func TestUnknownNeverResolvesToUnreachable(t *testing.T) {
 					CoverageReasons: []string{"a dynamic construct hides references"},
 					FilesScanned:    1,
 				},
-			}, identityCandidates)
+			}, identityCandidates, allDirect("serde", "unused-crate", "rails", "never-referenced", "a", "b", "c", "serde-json"))
 			if err != nil {
 				t.Fatalf("new: %v", err)
 			}
@@ -100,7 +110,7 @@ func TestIncompleteEntrypointDiscoveryYieldsNoVerdict(t *testing.T) {
 			ImportedPackages: []string{"rails"},
 			CoverageReasons:  []string{"source file budget exceeded; some files were not scanned"},
 		},
-	}, identityCandidates)
+	}, identityCandidates, allDirect("serde", "unused-crate", "rails", "never-referenced", "a", "b", "c", "serde-json"))
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
@@ -112,7 +122,7 @@ func TestIncompleteEntrypointDiscoveryYieldsNoVerdict(t *testing.T) {
 func TestScanFailureIsNoCoverage(t *testing.T) {
 	t.Parallel()
 
-	a, err := New(fakeScanner{lang: "cargo", err: errors.New("scan exploded")}, identityCandidates)
+	a, err := New(fakeScanner{lang: "cargo", err: errors.New("scan exploded")}, identityCandidates, allDirect("serde", "unused-crate", "rails", "never-referenced", "a", "b", "c", "serde-json"))
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
@@ -130,7 +140,7 @@ func TestGenerousCandidateMatching(t *testing.T) {
 	a, err := New(fakeScanner{
 		lang:  "cargo",
 		graph: ports.SourceImportGraph{ImportedPackages: []string{"serde_json"}, FilesScanned: 1},
-	}, func(name string) []string { return []string{name, "serde_json"} })
+	}, func(name string) []string { return []string{name, "serde_json"} }, allDirect("serde-json"))
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
@@ -149,7 +159,7 @@ func TestSubjectsAreDeduplicatedAndOrdered(t *testing.T) {
 	a, err := New(fakeScanner{
 		lang:  "gem",
 		graph: ports.SourceImportGraph{ImportedPackages: []string{"rails"}, FilesScanned: 1},
-	}, identityCandidates)
+	}, identityCandidates, allDirect("serde", "unused-crate", "rails", "never-referenced", "a", "b", "c", "serde-json"))
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
@@ -174,7 +184,7 @@ func TestCancelledContextIsHonored(t *testing.T) {
 	a, err := New(fakeScanner{
 		lang:  "cargo",
 		graph: ports.SourceImportGraph{ImportedPackages: []string{"serde"}, FilesScanned: 1},
-	}, identityCandidates)
+	}, identityCandidates, allDirect("serde", "unused-crate", "rails", "never-referenced", "a", "b", "c", "serde-json"))
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
@@ -182,5 +192,43 @@ func TestCancelledContextIsHonored(t *testing.T) {
 	cancel()
 	if _, err := a.Analyze(ctx, "/ws", []string{"serde"}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("a cancelled context must abort the analysis, got %v", err)
+	}
+}
+
+// TestTransitiveSubjectIsRefused locks the guard that keeps a transitive package out of a Tier-1 answer:
+// a lockfile-derived SBOM is mostly transitive, and first-party source never imports those directly.
+func TestTransitiveSubjectIsRefused(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(fakeScanner{
+		lang:  "cargo",
+		graph: ports.SourceImportGraph{ImportedPackages: []string{"reqwest"}, FilesScanned: 1},
+	}, identityCandidates, allDirect("reqwest"))
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	// hyper is pulled in by reqwest; no first-party `use hyper` exists and none should be expected.
+	analysis, err := a.Analyze(context.Background(), "/ws", []string{"hyper"})
+	if err == nil {
+		t.Fatalf("a transitive subject must be refused, got %+v", analysis)
+	}
+	if analysis != nil {
+		t.Fatalf("a refusal must return no analysis, got %+v", analysis)
+	}
+}
+
+func TestUnreadableManifestRefuses(t *testing.T) {
+	t.Parallel()
+
+	unknown := func(context.Context, string) (map[string]bool, bool) { return nil, false }
+	a, err := New(fakeScanner{
+		lang:  "gem",
+		graph: ports.SourceImportGraph{ImportedPackages: []string{"rails"}, FilesScanned: 1},
+	}, identityCandidates, unknown)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if _, err := a.Analyze(context.Background(), "/ws", []string{"rails"}); err == nil {
+		t.Fatal("without a manifest, direct and transitive cannot be told apart, so the analysis must refuse")
 	}
 }


### PR DESCRIPTION
Closes #414 (Phase 2, Track B).

## What

Deterministic Tier-1 import-reachability for **Rust, PHP and Ruby**. A declared dependency that first-party source never references becomes a `not_reachable` judgment and, through the existing export path, an OpenVEX `not_affected` justification.

All three share **one** foundation rather than three parallel stacks:
- `ports.SourceImportScanner` — the observation contract
- `internal/infrastructure/tools/srcimports` — the per-language scanners
- `internal/usecase/srcreach` — a single Tier-1 analyzer parameterised by a per-language candidate namer

## Source-only, no sandbox needed

None of the scanners runs cargo, composer, bundler or a language runtime; none resolves a dependency over the network; nothing is compiled or executed. That is the same reasoning that keeps the Python and JavaScript scanners in-process, and it is why no sandbox is required here (contrast `synapse-callgraph`, which compiles untrusted source).

## Unknown never becomes unreachable

The non-negotiable of the issue. Each language's dynamic constructs produce an explicit **unknown region**, and one unknown region refuses the whole analysis rather than yielding a negative:

| Language | Constructs that degrade coverage |
|---|---|
| Rust | `macro_rules!`, `include!`, derive + procedural macros, FFI |
| PHP | `eval`, `call_user_func`, variable class name, variable variables, reflection, custom autoloader, computed include path |
| Ruby | `const_get`, `send`, `method_missing`, `define_method`, `instance_eval`, `class_eval`, `autoload`, computed/interpolated `require` |

Tested one case per construct, per language, plus a dedicated per-language assertion that an unknown region can never produce an unreachable verdict.

## Generous matching, on purpose

A dependency is referenced under several plausible names: a Rust crate written with hyphens is *used* with underscores, a Composer package name is not its namespace, and a gem's require path often differs from its gem name. Over-matching biases toward **reachable**, which is safe; under-matching would suppress a real finding.

## Entry points

From the manifests a reader can check a proof against: Cargo `bin`/`lib` targets (test and bench **excluded** — a test-only dependency is not evidence that shipped code reaches it), composer autoload roots, and the conventional Ruby load points.

## Attribution

Tier-1 proof identities are per-language (`system:rustimport-scan`/`-engine`, etc.), so a Rust proof is never attributed to the Python or JavaScript import engine in the audit log or the sealed rationale.

## Config

`SYNAPSE_REACH_RUST` / `SYNAPSE_REACH_PHP` / `SYNAPSE_REACH_RUBY`, each off by default and each also requiring `SYNAPSE_JUDGMENTS_ENABLED`.

## Verification

`go build ./...` · `go vet` · **golangci-lint 0 issues** · full suite **174 packages, 0 failures** · `-race` green.

## Not yet done from the issue's acceptance list

- The **measured reduction in actionable findings on a real repository per language** is not included. That is an empirical claim the issue rightly asks for, and I would rather leave it open than assert a number I have not measured.
- Tier-2 for these languages is explicitly scoped by the issue as a per-language follow-up.
