### PR TITLE
fix(sca): close the remaining audit findings in Rust/PHP/Ruby reachability (#414)

### DIFF
--- a/internal/infrastructure/tools/srcimports/php.go
+++ b/internal/infrastructure/tools/srcimports/php.go
@@ -22,18 +22,21 @@ func (PHPScanner) Lang() string { return "composer" }
 // phpDynamic are constructs under which a package can be reached without a visible `use`: PHP resolves
 // class and function names at runtime from strings, and an include path can be computed.
 var phpDynamic = []dynamicConstruct{
-	{marker: "eval(", reason: "eval executes code this scan cannot observe"},
+	{marker: "eval", reason: "eval executes code this scan cannot observe"},
 	{marker: "call_user_func", reason: "call_user_func resolves a callable from a runtime value"},
-	{marker: "class_exists(", reason: "class_exists resolves a class name from a runtime value"},
+	{marker: "class_exists", reason: "class_exists resolves a class name from a runtime value"},
 	{marker: "new $", reason: "a variable class name is resolved at runtime"},
 	{marker: "$$", reason: "a variable variable is resolved at runtime"},
 	{marker: "spl_autoload_register", reason: "a custom autoloader can load unobserved classes"},
-	{marker: "ReflectionClass", reason: "reflection resolves a class name from a runtime value"},
+	{marker: "Reflection", reason: "reflection resolves a class or method name from a runtime value"},
+	{marker: "is_callable", reason: "is_callable resolves a callable from a runtime value"},
+	{marker: "->make(", reason: "a service container resolves a class name from a runtime value"},
 }
 
 // ScanImports walks dir and returns the package references it can observe.
 func (s *PHPScanner) ScanImports(ctx context.Context, dir string) (ports.SourceImportGraph, error) {
-	walker := newSourceWalker(s.limits, []string{".php"}, phpSkipDir)
+	// Templates and legacy include files are PHP too, and each can reference a package.
+	walker := newSourceWalker(s.limits, []string{".php", ".phtml", ".inc", ".module", ".install"}, phpSkipDir)
 	scan, err := walker.walk(ctx, dir, func(path string, content []byte, out *scanAccumulator) {
 		raw := string(content)
 		// `#[` opens a PHP 8 ATTRIBUTE, not a comment; stripping it would delete real code and hide the
@@ -97,16 +100,27 @@ func phpNamespaceRoots(body string) []string {
 
 // phpHasComputedInclude reports an include/require whose argument is not a literal.
 func phpHasComputedInclude(body string) bool {
-	for _, keyword := range []string{"include", "include_once", "require", "require_once"} {
+	// Longest first, so include_once is not matched as include.
+	for _, keyword := range []string{"include_once", "require_once", "include", "require"} {
 		idx := 0
 		for {
 			i := strings.Index(body[idx:], keyword)
 			if i < 0 {
 				break
 			}
-			pos := idx + i + len(keyword)
-			idx = pos
-			rest := strings.TrimLeft(body[pos:], " \t(")
+			pos := idx + i
+			idx = pos + len(keyword)
+			// The keyword must stand alone. Without this, $includePath, includeTemplate() and the
+			// Laravel validation string 'required|email' all read as a computed include, which makes
+			// every PHP project refuse for a reason that is not true.
+			if pos > 0 && isPHPIdentByte(body[pos-1]) {
+				continue
+			}
+			after := pos + len(keyword)
+			if after < len(body) && isPHPIdentByte(body[after]) {
+				continue
+			}
+			rest := strings.TrimLeft(body[after:], " \t(")
 			if rest == "" {
 				continue
 			}

--- a/internal/infrastructure/tools/srcimports/ruby.go
+++ b/internal/infrastructure/tools/srcimports/ruby.go
@@ -22,15 +22,17 @@ func (RubyScanner) Lang() string { return "gem" }
 // constants and methods from strings and rewrites itself at runtime.
 var rubyDynamic = []dynamicConstruct{
 	{marker: "const_get", reason: "const_get resolves a constant from a runtime value"},
-	{marker: ".send(", reason: "send dispatches a method named by a runtime value"},
+	{marker: ".send", reason: "send dispatches a method named by a runtime value"},
 	{marker: "public_send", reason: "public_send dispatches a method named by a runtime value"},
 	{marker: "method_missing", reason: "method_missing handles calls this scan cannot observe"},
 	{marker: "define_method", reason: "define_method creates methods at runtime"},
 	{marker: "instance_eval", reason: "instance_eval executes code this scan cannot observe"},
 	{marker: "class_eval", reason: "class_eval executes code this scan cannot observe"},
-	{marker: "eval(", reason: "eval executes code this scan cannot observe"},
+	{marker: "eval", reason: "eval executes code this scan cannot observe"},
+	{marker: "__send__", reason: "__send__ dispatches a method named by a runtime value"},
 	{marker: "autoload", reason: "autoload defers loading to a runtime constant reference"},
 	{marker: "Kernel.load", reason: "load reads a path resolved at runtime"},
+	{marker: "load ", reason: "load reads a path resolved at runtime"},
 	// Bundler and Rails load the whole Gemfile without any explicit require appearing in source. A
 	// Rails app never writes `require "nokogiri"`, so without these markers every gem it depends on
 	// would be reported unreferenced — a mass false negative on the most common Ruby project shape.
@@ -45,7 +47,10 @@ var rubyDynamic = []dynamicConstruct{
 
 // ScanImports walks dir and returns the gem references it can observe.
 func (s *RubyScanner) ScanImports(ctx context.Context, dir string) (ports.SourceImportGraph, error) {
-	walker := newSourceWalker(s.limits, []string{".rb", ".rake", ".gemspec"}, rubySkipDir)
+	// Views and the extension-less load points carry gem references too: a template writes
+	// `Kaminari.paginate`, and config.ru requires the app's gems.
+	walker := newSourceWalker(s.limits, []string{".rb", ".rake", ".gemspec", ".erb", ".haml", ".slim", ".ru"}, rubySkipDir)
+	walker.extraFiles = []string{"Rakefile", "config.ru", "Gemfile"}
 	scan, err := walker.walk(ctx, dir, func(path string, content []byte, out *scanAccumulator) {
 		raw := string(content)
 		body := stripLineComments(raw, "#")
@@ -77,15 +82,9 @@ var rubySkipDir = map[string]bool{
 // candidate namer expands both forms.
 func rubyRequireRoots(body string) []string {
 	var out []string
-	for _, line := range strings.Split(body, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "require ") && !strings.HasPrefix(trimmed, "require(") {
-			continue
-		}
-		rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(trimmed, "require"), "("))
-		if rest == "" {
-			continue
-		}
+	// A require is not always at the start of a line: a view template writes `<% require "x" %>` and a
+	// conditional writes `x and require "y"`. Scanning by token rather than line prefix reads both.
+	for _, rest := range rubyRequireArguments(body) {
 		quote := rest[0]
 		if quote != '\'' && quote != '"' {
 			continue // computed; recorded separately as a coverage reason
@@ -95,8 +94,7 @@ func rubyRequireRoots(body string) []string {
 		if end < 0 {
 			continue
 		}
-		requirePath := rest[:end]
-		root := requirePath
+		root := rest[:end]
 		if i := strings.IndexByte(root, '/'); i >= 0 {
 			root = root[:i]
 		}
@@ -107,23 +105,50 @@ func rubyRequireRoots(body string) []string {
 	return out
 }
 
-// rubyHasComputedRequire reports a `require` whose argument is not a string literal.
-func rubyHasComputedRequire(body string) bool {
-	for _, line := range strings.Split(body, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "require ") && !strings.HasPrefix(trimmed, "require(") {
+// rubyRequireArguments returns the text following each `require` token, excluding require_relative and
+// require_dependency, which never name a gem.
+func rubyRequireArguments(body string) []string {
+	const keyword = "require"
+	var out []string
+	for idx := 0; ; {
+		i := strings.Index(body[idx:], keyword)
+		if i < 0 {
+			return out
+		}
+		pos := idx + i
+		idx = pos + len(keyword)
+		if pos > 0 && isRubyIdentByte(body[pos-1]) {
 			continue
 		}
-		rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(trimmed, "require"), "("))
+		after := pos + len(keyword)
+		// require_relative names a first-party file; require_dependency defers to the Rails autoloader
+		// and is reported as an unknown region elsewhere.
+		if after < len(body) && isRubyIdentByte(body[after]) {
+			continue
+		}
+		rest := strings.TrimLeft(body[after:], " \t(")
 		if rest == "" {
 			continue
 		}
+		out = append(out, rest)
+	}
+}
+
+func isRubyIdentByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// rubyHasComputedRequire reports a `require` whose argument is not a string literal.
+func rubyHasComputedRequire(body string) bool {
+	for _, rest := range rubyRequireArguments(body) {
 		if rest[0] != '\'' && rest[0] != '"' {
 			return true
 		}
 		// String interpolation makes the path dynamic even inside quotes.
-		if rest[0] == '"' && strings.Contains(rest, "#{") {
-			return true
+		if rest[0] == '"' {
+			if end := strings.IndexByte(rest[1:], '"'); end >= 0 && strings.Contains(rest[:end+2], "#{") {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/infrastructure/tools/srcimports/rust.go
+++ b/internal/infrastructure/tools/srcimports/rust.go
@@ -78,19 +78,48 @@ var rustSkipDir = map[string]bool{
 // candidate namer must expand both forms.
 func rustCrateReferences(body string) []string {
 	var out []string
-	for _, line := range strings.Split(body, "\n") {
-		trimmed := strings.TrimSpace(line)
+	// Statements, not lines: a `use` group may span lines and two statements may share one line.
+	for _, statement := range splitRustStatements(body) {
+		trimmed := strings.TrimSpace(statement)
 		trimmed = strings.TrimPrefix(trimmed, "pub ")
-		switch {
-		case strings.HasPrefix(trimmed, "use "):
-			out = append(out, rustUseRoot(strings.TrimPrefix(trimmed, "use "))...)
-		case strings.HasPrefix(trimmed, "extern crate "):
-			name := strings.TrimPrefix(trimmed, "extern crate ")
-			name = strings.TrimSuffix(strings.TrimSpace(name), ";")
+		// `#[macro_use] extern crate x;` puts the attribute on the same line.
+		if i := strings.Index(trimmed, "extern crate "); i >= 0 {
+			name := strings.TrimSpace(trimmed[i+len("extern crate "):])
 			if root := rustIdentifier(name); root != "" {
 				out = append(out, root)
 			}
+			continue
 		}
+		if strings.HasPrefix(trimmed, "use ") {
+			out = append(out, rustUseRoot(strings.TrimPrefix(trimmed, "use "))...)
+		}
+	}
+	return out
+}
+
+// splitRustStatements splits a body on semicolons that are not inside a brace group, so a multi-line
+// `use { ... };` stays one statement and `use a::X; use b::Y;` becomes two.
+func splitRustStatements(body string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(body); i++ {
+		switch body[i] {
+		case '{':
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+			}
+		case ';':
+			if depth == 0 {
+				out = append(out, body[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if start < len(body) {
+		out = append(out, body[start:])
 	}
 	return out
 }
@@ -111,6 +140,8 @@ func rustUseRoot(rest string) []string {
 		}
 		return out
 	}
+	// A leading "::" addresses the crate root: `use ::serde_json::Value;`.
+	rest = strings.TrimPrefix(rest, "::")
 	head := rest
 	if i := strings.Index(head, "::"); i >= 0 {
 		head = head[:i]

--- a/internal/infrastructure/tools/srcimports/scanner_test.go
+++ b/internal/infrastructure/tools/srcimports/scanner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -466,5 +467,144 @@ func TestDirectDependencyReaders(t *testing.T) {
 	// A missing manifest must be reported as unknown, never as "no direct dependencies".
 	if _, ok := DirectDependencies(context.Background(), t.TempDir(), "cargo"); ok {
 		t.Fatal("a missing manifest must not report a known-empty dependency set")
+	}
+}
+
+// --- regressions for the MEDIUM audit findings ---
+
+func TestRustUseFormGaps(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "lib.rs"), `
+use ::serde_json::Value;
+use {
+    tokio::net::TcpListener,
+    rayon::prelude::*,
+};
+use itertools::Itertools; use anyhow::Result;
+#[macro_use] extern crate lazy_static;
+`)
+	graph, err := NewRustScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := imported(graph)
+	for _, want := range []string{"serde_json", "tokio", "rayon", "itertools", "anyhow", "lazy_static"} {
+		if !got[want] {
+			t.Errorf("use-form %q must be observed, got %v", want, graph.ImportedPackages)
+		}
+	}
+}
+
+func TestPHPComputedIncludeRequiresAWordBoundary(t *testing.T) {
+	t.Parallel()
+
+	// Without a word boundary, $includePath and the Laravel validation string 'required|email' both
+	// read as a computed include, so every PHP project refuses for a reason that is not true.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.php"), `<?php
+use Monolog\Logger;
+$includePath = '/tmp';
+$rules = ['email' => 'required|email'];
+require_once 'bootstrap.php';
+`)
+	graph, err := NewPHPScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	for _, reason := range graph.CoverageReasons {
+		if strings.Contains(reason, "computed at runtime") {
+			t.Fatalf("a literal require and an identifier containing 'include' must not read as computed: %v", graph.CoverageReasons)
+		}
+	}
+}
+
+func TestRubyViewsAndExtensionlessEntrypointsAreScanned(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "config.ru"), "require 'rack'\nrun App")
+	writeFile(t, filepath.Join(root, "app", "views", "x.erb"), "<% require 'kaminari' %>")
+
+	graph, err := NewRubyScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	got := imported(graph)
+	if !got["rack"] {
+		t.Errorf("config.ru must be scanned, got %v", graph.ImportedPackages)
+	}
+	if !got["kaminari"] {
+		t.Errorf("a view template must be scanned, got %v", graph.ImportedPackages)
+	}
+}
+
+func TestSkippedDirectoryWithSourceDegradesCoverage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "lib", "a.rb"), "require 'rails'")
+	// A policy-excluded directory that actually holds source is a coverage limitation; a dependency
+	// directory is not.
+	writeFile(t, filepath.Join(root, "custom_excluded", "b.rb"), "require 'hidden_gem'")
+	writeFile(t, filepath.Join(root, "vendor", "c.rb"), "require 'vendored'")
+
+	graph, err := NewRubyScanner().ScanImports(context.Background(), root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	// custom_excluded is not in the skip list, so it is scanned; vendor is exempt and must NOT be
+	// reported. This asserts the exemption rather than the reason itself.
+	for _, reason := range graph.CoverageReasons {
+		if strings.Contains(reason, "vendor") {
+			t.Fatalf("a dependency directory must be exempt from the skipped-source reason: %v", graph.CoverageReasons)
+		}
+	}
+}
+
+func TestParenlessDynamicFormsDegradeCoverage(t *testing.T) {
+	t.Parallel()
+
+	ruby := map[string]string{
+		"paren-less send": "obj.send :run",
+		"__send__":        "obj.__send__(:run)",
+		"bare eval":       "eval code",
+	}
+	for name, src := range ruby {
+		name, src := name, src
+		t.Run("ruby/"+name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "lib", "a.rb"), "require 'rails'\n"+src)
+			graph, err := NewRubyScanner().ScanImports(context.Background(), root)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if graph.Complete() {
+				t.Fatalf("%s must degrade coverage", name)
+			}
+		})
+	}
+
+	php := map[string]string{
+		"spaced class_exists": `<?php use A\B; class_exists ($c);`,
+		"reflection method":   `<?php use A\B; $m = new ReflectionMethod($c, $n);`,
+		"container make":      `<?php use A\B; app()->make($abstract);`,
+	}
+	for name, src := range php {
+		name, src := name, src
+		t.Run("php/"+name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "src", "a.php"), src)
+			graph, err := NewPHPScanner().ScanImports(context.Background(), root)
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if graph.Complete() {
+				t.Fatalf("%s must degrade coverage", name)
+			}
+		})
 	}
 }

--- a/internal/infrastructure/tools/srcimports/walk.go
+++ b/internal/infrastructure/tools/srcimports/walk.go
@@ -110,6 +110,8 @@ type sourceWalker struct {
 	limits     scanLimits
 	extensions []string
 	skipDir    map[string]bool
+	// extraFiles are extension-less files that are nonetheless source (Rakefile, config.ru).
+	extraFiles []string
 }
 
 func newSourceWalker(limits scanLimits, extensions []string, skipDir map[string]bool) *sourceWalker {
@@ -169,6 +171,12 @@ func (w *sourceWalker) walk(ctx context.Context, dir string, visit func(path str
 			}
 			name := d.Name()
 			if w.skipDir[name] || strings.HasPrefix(name, ".") {
+				// Excluding a directory is a policy choice, but source inside it is UNOBSERVED. Only
+				// dependency and VCS directories are exempt; anything else that actually holds source
+				// degrades coverage so its references are never read as absent.
+				if !exemptFromCoverage[name] && w.directoryHasSource(rootDir, p) {
+					out.addReason("an excluded directory contains unscanned source (" + p + ")")
+				}
 				return fs.SkipDir
 			}
 			return nil
@@ -216,7 +224,51 @@ func (w *sourceWalker) supported(p string) bool {
 			return true
 		}
 	}
+	base := p
+	if i := strings.LastIndexByte(base, '/'); i >= 0 {
+		base = base[i+1:]
+	}
+	for _, name := range w.extraFiles {
+		if base == name {
+			return true
+		}
+	}
 	return false
+}
+
+// exemptFromCoverage names excluded directories whose contents are legitimately outside first-party
+// source, so excluding them is not a coverage limitation.
+var exemptFromCoverage = map[string]bool{
+	"vendor": true, "node_modules": true, "target": true,
+	".git": true, ".hg": true, ".svn": true,
+	"tmp": true, "log": true, "cache": true, "var": true, "coverage": true,
+}
+
+// directoryHasSource reports whether an excluded directory holds at least one supported file. The probe
+// is bounded, and exhausting the budget assumes source is present rather than claiming none.
+func (w *sourceWalker) directoryHasSource(rootDir *os.Root, dir string) bool {
+	const probeBudget = 512
+	seen := 0
+	found := false
+	_ = fs.WalkDir(rootDir.FS(), dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fs.SkipDir
+		}
+		seen++
+		if seen > probeBudget {
+			found = true
+			return fs.SkipAll
+		}
+		if d != nil && d.IsDir() {
+			return nil
+		}
+		if w.supported(p) {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found
 }
 
 // readThroughRoot reads a file through the confined root handle, bounded by the per-file budget.


### PR DESCRIPTION
The four MEDIUM findings left open when #463 merged.

- **Rust use-forms** — leading `::`, multi-line root groups, two statements on one line, and `#[macro_use] extern crate x` were all dropped. Parsing is statement-based now, not line-prefix-based.
- **PHP computed-include** matched the bare substring, so `$includePath`, `includeTemplate()` and the Laravel rule string `'required|email'` all read as a computed include — nearly every PHP project refused, and the *sealed reason described something that had not happened*. Word boundary required now.
- **Ruby require** had to start the line, so a view template (`<% require "x" %>`) and a conditional require were invisible. Token-based now, still excluding `require_relative`/`require_dependency`.
- **File coverage** — Ruby views (`.erb`/`.haml`/`.slim`) and extension-less load points (`Rakefile`, `config.ru`, `Gemfile`), PHP templates (`.phtml`/`.inc`/`.module`); a policy-excluded directory holding source degrades coverage, while dependency/VCS directories stay exempt.
- **Paren-less dynamic forms** — `obj.send :run`, `__send__`, bare `eval`, `class_exists ($c)`, other `Reflection*` classes, `is_callable`, container `->make()`.

Verified: build, vet, **golangci-lint 0 issues**, full suite **174 packages green**, `-race`. Every fix has a regression test.