### PR TITLE
feat(reachability): Tier-2 JavaScript affected-export reachability (#378 R5)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1237,22 +1237,31 @@ func main() {
 	// dependencies: a first-party import graph cannot prove a TRANSITIVE package unused, because that
 	// package is loaded by its parent. Requires the judgment lifecycle. Composition-root only.
 	if cfg.JSReachabilityEnabled && requireJudgmentsOrSkip(log, judgmentSvc != nil, "SYNAPSE_JSREACH_ENABLED", "javascript reachability") {
-		jsRecorder, jerr := jsreach.NewRecorder(jsimports.New(), jsresolve.NewResolver(), judgmentSvc, auditLog, clock)
+		// One scanner and one resolver serve both tiers: they are stateless, and a second pair would
+		// mean a second full lex of the source tree per scan.
+		jsScanner, jsResolver := jsimports.New(), jsresolve.NewResolver()
+		jsRecorder, jerr := jsreach.NewRecorder(jsScanner, jsResolver, judgmentSvc, auditLog, clock)
 		if jerr != nil {
 			log.Error("javascript reachability recorder init failed", "err", jerr)
 			os.Exit(1)
 		}
 		scaService.SetJSReachability(jsRecorder)
 		log.Info("Tier-1 JavaScript import-reachability ENABLED (source-only, direct dependencies only → OpenVEX not_affected; best-effort)")
-	}
-	if cfg.JSSymbolReachabilityEnabled && requireJudgmentsOrSkip(log, judgmentSvc != nil, "SYNAPSE_JSREACH_TIER2_ENABLED", "javascript affected-export reachability") {
-		jsSymbolRecorder, serr := jsreach.NewSymbolRecorder(jsimports.New(), jsresolve.NewResolver(), judgmentSvc, auditLog, clock)
-		if serr != nil {
-			log.Error("javascript tier-2 reachability init failed", "err", serr)
-			os.Exit(1)
+
+		// Tier-2 rides on Tier-1. Every safety statement it makes ends "…leaves the Tier-1 judgment
+		// standing", so enabling it alone would leave nothing standing; the dependency is enforced here
+		// rather than documented.
+		if cfg.JSSymbolReachabilityEnabled {
+			jsSymbolRecorder, serr := jsreach.NewSymbolRecorder(jsScanner, jsResolver, judgmentSvc, auditLog, clock)
+			if serr != nil {
+				log.Error("javascript tier-2 reachability init failed", "err", serr)
+				os.Exit(1)
+			}
+			scaService.SetJSSymbolReachability(jsSymbolRecorder)
+			log.Info("javascript TIER-2 affected-export reachability ENABLED (a binding that escapes observation yields no conclusion, never not-reachable)")
 		}
-		scaService.SetJSSymbolReachability(jsSymbolRecorder)
-		log.Info("javascript TIER-2 affected-export reachability ENABLED (a binding that escapes observation yields no conclusion, never not-reachable)")
+	} else if cfg.JSSymbolReachabilityEnabled {
+		log.Warn("SYNAPSE_JSREACH_TIER2_ENABLED is set but tier-1 javascript reachability is off - tier-2 is SKIPPED, because a tier-2 refusal is only safe when a tier-1 judgment can stand in its place")
 	}
 
 	// Deterministic Tier-1 import-reachability for Rust, PHP and Ruby. Each scanner is SOURCE-ONLY: it

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1245,6 +1245,15 @@ func main() {
 		scaService.SetJSReachability(jsRecorder)
 		log.Info("Tier-1 JavaScript import-reachability ENABLED (source-only, direct dependencies only → OpenVEX not_affected; best-effort)")
 	}
+	if cfg.JSSymbolReachabilityEnabled && requireJudgmentsOrSkip(log, judgmentSvc != nil, "SYNAPSE_JSREACH_TIER2_ENABLED", "javascript affected-export reachability") {
+		jsSymbolRecorder, serr := jsreach.NewSymbolRecorder(jsimports.New(), jsresolve.NewResolver(), judgmentSvc, auditLog, clock)
+		if serr != nil {
+			log.Error("javascript tier-2 reachability init failed", "err", serr)
+			os.Exit(1)
+		}
+		scaService.SetJSSymbolReachability(jsSymbolRecorder)
+		log.Info("javascript TIER-2 affected-export reachability ENABLED (a binding that escapes observation yields no conclusion, never not-reachable)")
+	}
 
 	// Deterministic Tier-1 import-reachability for Rust, PHP and Ruby. Each scanner is SOURCE-ONLY: it
 	// lexes text and never runs cargo, composer, bundler or a language runtime, so no sandbox is needed

--- a/internal/domain/jsresolution/purl.go
+++ b/internal/domain/jsresolution/purl.go
@@ -120,3 +120,34 @@ func IsRuntimeImport(imp ImportResolution, declarationOnlyModules map[string]boo
 	}
 	return !declarationOnlyModules[imp.From]
 }
+
+// A Tier-2 subject names both a component and one of its exports, because "is this package used" and
+// "is this export reached" are different questions with different answers. The fragment form keeps the
+// component PURL intact and appends the symbol, so a Tier-1 subject and a Tier-2 subject can never be
+// mistaken for one another and neither can be silently reinterpreted as the other.
+
+// NPMSymbolSubject renders the Tier-2 subject for one export of one component.
+func NPMSymbolSubject(purl, symbol string) string {
+	return purl + "#" + symbol
+}
+
+// ParseNPMSymbolSubject splits a Tier-2 subject back into its component PURL and export name.
+//
+// It is strict: the PURL half must itself be a valid npm component PURL and the symbol half must be
+// non-empty and free of the separator. A subject that does not round-trip is REFUSED rather than
+// half-interpreted, because a subject whose symbol was misread would be compared against export names it
+// can never equal and would come back not-reachable for every package.
+func ParseNPMSymbolSubject(raw string) (string, string, bool) {
+	hash := strings.LastIndexByte(raw, '#')
+	if hash <= 0 || hash == len(raw)-1 {
+		return "", "", false
+	}
+	purl, symbol := raw[:hash], raw[hash+1:]
+	if strings.ContainsAny(symbol, "#") || strings.TrimSpace(symbol) != symbol {
+		return "", "", false
+	}
+	if _, _, ok := ParseNPMPURL(purl); !ok {
+		return "", "", false
+	}
+	return purl, symbol, true
+}

--- a/internal/domain/jsresolution/purl.go
+++ b/internal/domain/jsresolution/purl.go
@@ -120,34 +120,3 @@ func IsRuntimeImport(imp ImportResolution, declarationOnlyModules map[string]boo
 	}
 	return !declarationOnlyModules[imp.From]
 }
-
-// A Tier-2 subject names both a component and one of its exports, because "is this package used" and
-// "is this export reached" are different questions with different answers. The fragment form keeps the
-// component PURL intact and appends the symbol, so a Tier-1 subject and a Tier-2 subject can never be
-// mistaken for one another and neither can be silently reinterpreted as the other.
-
-// NPMSymbolSubject renders the Tier-2 subject for one export of one component.
-func NPMSymbolSubject(purl, symbol string) string {
-	return purl + "#" + symbol
-}
-
-// ParseNPMSymbolSubject splits a Tier-2 subject back into its component PURL and export name.
-//
-// It is strict: the PURL half must itself be a valid npm component PURL and the symbol half must be
-// non-empty and free of the separator. A subject that does not round-trip is REFUSED rather than
-// half-interpreted, because a subject whose symbol was misread would be compared against export names it
-// can never equal and would come back not-reachable for every package.
-func ParseNPMSymbolSubject(raw string) (string, string, bool) {
-	hash := strings.LastIndexByte(raw, '#')
-	if hash <= 0 || hash == len(raw)-1 {
-		return "", "", false
-	}
-	purl, symbol := raw[:hash], raw[hash+1:]
-	if strings.ContainsAny(symbol, "#") || strings.TrimSpace(symbol) != symbol {
-		return "", "", false
-	}
-	if _, _, ok := ParseNPMPURL(purl); !ok {
-		return "", "", false
-	}
-	return purl, symbol, true
-}

--- a/internal/domain/jssymbols/jssymbols.go
+++ b/internal/domain/jssymbols/jssymbols.go
@@ -21,8 +21,48 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
+
+// A Tier-2 subject names both a component and one of its exports, because "is this package used" and
+// "is this export reached" are different questions with different answers. The fragment form keeps the
+// component PURL intact and appends the export, so a Tier-1 subject and a Tier-2 subject can never be
+// mistaken for one another and neither can be silently reinterpreted as the other.
+
+// Subject renders the Tier-2 subject for one export of one component, or reports that it cannot.
+//
+// It validates rather than concatenating, so the writer is the exact mirror of the reader: a constructor
+// that could mint a subject its own parser rejects would produce a claim nothing can ever match, which
+// resolves to not-reachable for every package.
+func Subject(purl, symbol string) (string, bool) {
+	if _, _, ok := jsresolution.ParseNPMPURL(purl); !ok {
+		return "", false
+	}
+	if !isIdentifier(strings.TrimSpace(symbol)) {
+		return "", false
+	}
+	return purl + "#" + strings.TrimSpace(symbol), true
+}
+
+// ParseSubject splits a Tier-2 subject back into its component PURL and export name.
+//
+// It is strict: the PURL half must itself be a valid npm component PURL and the export half must be a
+// plain identifier. A subject that does not round-trip is REFUSED rather than half-interpreted.
+func ParseSubject(raw string) (string, string, bool) {
+	hash := strings.LastIndexByte(raw, '#')
+	if hash <= 0 || hash == len(raw)-1 {
+		return "", "", false
+	}
+	purl, symbol := raw[:hash], raw[hash+1:]
+	if !isIdentifier(symbol) {
+		return "", "", false
+	}
+	if _, _, ok := jsresolution.ParseNPMPURL(purl); !ok {
+		return "", "", false
+	}
+	return purl, symbol, true
+}
 
 // UseKind classifies how first-party source touches an imported package.
 type UseKind string
@@ -137,15 +177,26 @@ func Decide(symbol string, uses []Use) Decision {
 	var reaching, opaque []string
 	opaqueReason := ""
 	for _, use := range uses {
-		switch use.Kind {
-		case UseOpaque:
+		// A use that does not satisfy its own invariants is treated as opaque rather than skipped. A
+		// skipped use contributes nothing, and "contributes nothing" is what turns an unknown into a
+		// negative — the one direction this function must never move in.
+		if err := use.Validate(); err != nil {
 			opaque = append(opaque, use.Module)
 			if opaqueReason == "" {
-				opaqueReason = use.Reason
+				opaqueReason = "a recorded reference was not interpretable"
 			}
+			continue
+		}
+		switch use.Kind {
 		case UseNamed, UseMember:
 			if use.Symbol == wanted {
 				reaching = append(reaching, use.Module)
+			}
+		default:
+			// UseOpaque, and any kind added later that this function has not been taught about.
+			opaque = append(opaque, use.Module)
+			if opaqueReason == "" {
+				opaqueReason = use.Reason
 			}
 		}
 	}

--- a/internal/domain/jssymbols/jssymbols.go
+++ b/internal/domain/jssymbols/jssymbols.go
@@ -1,0 +1,234 @@
+// Package jssymbols holds the decision rules for Tier-2 JavaScript and TypeScript reachability: given
+// what first-party source statically does with an imported npm package, can a specific AFFECTED SYMBOL
+// of that package be reached?
+//
+// Tier-1 answers "is this package imported at all". Tier-2 is strictly narrower and strictly more
+// dangerous: concluding that a package IS imported but the vulnerable export is never touched suppresses
+// a real vulnerability if the analysis missed a single reference. Every rule here is therefore written to
+// fail towards UNKNOWN, and the package is pure domain code — no filesystem, parser, resolver or
+// judgment work happens in it, so the rules can be read and tested on their own.
+//
+// The central idea is OPACITY. A named import (`import {template} from 'lodash'`) tells us exactly which
+// export is bound. A namespace import (`import * as _ from 'lodash'`), a default import of a CommonJS
+// module, or `const _ = require('lodash')` binds the WHOLE module object; the symbols actually used are
+// then only knowable if every reference to that local is an observable property read. The moment such a
+// local escapes — passed to a function, spread, indexed with a computed key, re-exported — any export
+// could be reached, and this package says so rather than guessing.
+package jssymbols
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// UseKind classifies how first-party source touches an imported package.
+type UseKind string
+
+const (
+	// UseNamed is a binding that names one export: `import {template}`, `export {template} from`,
+	// `const {template} = require(...)`. The symbol is known exactly.
+	UseNamed UseKind = "named"
+	// UseMember is a property read on a whole-module local: `_.template`. The symbol is known exactly,
+	// but only because every other reference to that local was also observed.
+	UseMember UseKind = "member"
+	// UseOpaque is a reference to a whole-module local that could reach ANY export: the local is passed
+	// somewhere, indexed with a computed key, re-exported, or used in a form this analysis does not
+	// model. It carries no symbol, and its presence alone makes the package unanswerable.
+	UseOpaque UseKind = "opaque"
+)
+
+// Valid reports whether k is a known use kind.
+func (k UseKind) Valid() bool {
+	switch k {
+	case UseNamed, UseMember, UseOpaque:
+		return true
+	}
+	return false
+}
+
+// Use is one statically observed interaction between a first-party module and an imported package.
+type Use struct {
+	// Module is the normalized repository-relative path of the first-party module.
+	Module string
+	// PURL is the canonical package URL of the imported component.
+	PURL string
+	// Symbol is the export named by the use. It is empty for UseOpaque, and MUST be empty for it: an
+	// opaque reference is precisely one whose symbol is unknown.
+	Symbol string
+	Kind   UseKind
+	// Reason explains an opaque use in words a reader can act on ("namespace passed as an argument").
+	// It never carries source text, which is untrusted input on its way to a sealed judgment rationale.
+	Reason string
+}
+
+// Validate reports whether u is internally consistent.
+func (u Use) Validate() error {
+	if strings.TrimSpace(u.Module) == "" {
+		return fmt.Errorf("%w: a symbol use needs the module that made it", shared.ErrValidation)
+	}
+	if strings.TrimSpace(u.PURL) == "" {
+		return fmt.Errorf("%w: a symbol use needs the package it touches", shared.ErrValidation)
+	}
+	if !u.Kind.Valid() {
+		return fmt.Errorf("%w: %q is not a known symbol use kind", shared.ErrValidation, u.Kind)
+	}
+	if u.Kind == UseOpaque && strings.TrimSpace(u.Symbol) != "" {
+		return fmt.Errorf("%w: an opaque use cannot name a symbol - its symbol is what is unknown", shared.ErrValidation)
+	}
+	if u.Kind != UseOpaque && strings.TrimSpace(u.Symbol) == "" {
+		return fmt.Errorf("%w: a %s use must name the symbol it binds", shared.ErrValidation, u.Kind)
+	}
+	return nil
+}
+
+// Verdict is the Tier-2 answer for one (package, symbol) pair.
+type Verdict string
+
+const (
+	// VerdictReachable means first-party source binds or reads the affected symbol.
+	VerdictReachable Verdict = "reachable"
+	// VerdictNotReachable means every reference to the package was observed and none of them can reach
+	// the affected symbol. This is the only conclusion that can suppress a finding, so it is issued only
+	// when nothing opaque was seen.
+	VerdictNotReachable Verdict = "not-reachable"
+	// VerdictUnknown means something could hide a use. It is NOT a negative: the caller must leave any
+	// weaker existing judgment standing rather than record an absence of proof as proof of absence.
+	VerdictUnknown Verdict = "unknown"
+)
+
+// Decision is a verdict plus the evidence a reader needs to check it.
+type Decision struct {
+	Verdict Verdict
+	// Modules are the first-party modules that justify the verdict: the ones that reach the symbol for
+	// a positive, the ones holding an opaque reference for an unknown. Sorted and deduplicated.
+	Modules []string
+	// Reason explains a non-positive verdict.
+	Reason string
+}
+
+// Decide answers whether symbol can be reached, given every observed use of one package.
+//
+// The order of the rules is the safety property, not a detail:
+//
+//  1. a use that names the symbol wins immediately — a positive is always safe to report;
+//  2. otherwise ANY opaque reference makes the answer unknown, because the symbol could be reached
+//     through it and nothing observed rules that out;
+//  3. only when every reference was named and none matched is a negative issued.
+//
+// Callers must pass EVERY use of the package, not a filtered subset: a caller that filters first and then
+// asks would hide exactly the opaque reference this function exists to notice. An empty set means the
+// package is not imported at all, which is a Tier-1 question and is reported unknown here rather than
+// being answered twice at two different strengths.
+func Decide(symbol string, uses []Use) Decision {
+	wanted := strings.TrimSpace(symbol)
+	if wanted == "" {
+		return Decision{Verdict: VerdictUnknown, Reason: "no affected symbol was supplied"}
+	}
+	if len(uses) == 0 {
+		return Decision{
+			Verdict: VerdictUnknown,
+			Reason:  "no observed use of the package: package-level absence is a tier-1 conclusion, not a symbol-level one",
+		}
+	}
+
+	var reaching, opaque []string
+	opaqueReason := ""
+	for _, use := range uses {
+		switch use.Kind {
+		case UseOpaque:
+			opaque = append(opaque, use.Module)
+			if opaqueReason == "" {
+				opaqueReason = use.Reason
+			}
+		case UseNamed, UseMember:
+			if use.Symbol == wanted {
+				reaching = append(reaching, use.Module)
+			}
+		}
+	}
+
+	if len(reaching) > 0 {
+		return Decision{Verdict: VerdictReachable, Modules: sortedUnique(reaching)}
+	}
+	if len(opaque) > 0 {
+		reason := "the package is bound as a whole module and that binding escapes observation, so any export could be reached"
+		if opaqueReason != "" {
+			reason = "the package is bound as a whole module and " + opaqueReason + ", so any export could be reached"
+		}
+		return Decision{Verdict: VerdictUnknown, Modules: sortedUnique(opaque), Reason: reason}
+	}
+	return Decision{
+		Verdict: VerdictNotReachable,
+		Reason:  "every reference to the package names an export, and none of them is the affected symbol",
+	}
+}
+
+// NormalizeAffectedSymbol maps an advisory's affected-symbol string onto the export name this analysis
+// can reason about, for a package with the given npm name.
+//
+// Advisories write the same export in several shapes: a bare export (`template`), a
+// package-qualified one (`lodash.template`), or a scoped package's (`@scope/pkg.method`). Anything
+// else — a deep import path (`lodash/template`), a prototype or instance path (`Class.prototype.m`), an
+// empty or wildcard entry — returns ok=false.
+//
+// A false return means the SUBJECT is unanswerable and the caller must drop it. That is deliberate: a
+// symbol this function cannot place would otherwise be compared against export names it can never equal,
+// and would come back not-reachable for every package — a systematic false negative.
+func NormalizeAffectedSymbol(packageName, raw string) (string, bool) {
+	symbol := strings.TrimSpace(raw)
+	if symbol == "" {
+		return "", false
+	}
+	// The package prefix is stripped BEFORE the shape check, because a scoped package's own name
+	// contains the characters the check rejects (`@scope/pkg.method`). It is stripped only when the
+	// prefix really is this package's name; stripping any dotted prefix would turn `foo.bar` into `bar`
+	// for an unrelated package.
+	if pkg := strings.TrimSpace(packageName); pkg != "" && strings.HasPrefix(symbol, pkg+".") {
+		symbol = strings.TrimPrefix(symbol, pkg+".")
+	}
+	if symbol == "" || strings.Contains(symbol, ".") {
+		// A remaining dot is a nested path (`Class.prototype.method`). Reaching the outer binding says
+		// nothing about the nested one, so the subject is not answerable at this granularity.
+		return "", false
+	}
+	if !isIdentifier(symbol) {
+		return "", false
+	}
+	return symbol, true
+}
+
+// isIdentifier reports whether s is a plain JavaScript identifier-shaped name. It is deliberately
+// stricter than the language: an exotic but legal identifier is refused (unanswerable) rather than
+// admitted into a comparison whose outcome could suppress a finding.
+func isIdentifier(s string) bool {
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_', r == '$':
+		case r >= '0' && r <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return s != ""
+}
+
+func sortedUnique(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	deduped := out[:1]
+	for _, value := range out[1:] {
+		if value != deduped[len(deduped)-1] {
+			deduped = append(deduped, value)
+		}
+	}
+	return deduped
+}

--- a/internal/domain/jssymbols/jssymbols_test.go
+++ b/internal/domain/jssymbols/jssymbols_test.go
@@ -195,3 +195,49 @@ func TestUseValidate(t *testing.T) {
 		}
 	}
 }
+
+// TestDecideTreatsAnUninterpretableUseAsOpaque locks that Decide is TOTAL. A use it cannot interpret must
+// contribute opacity, not silence: silence is what turns an unknown into a negative, and a negative is
+// what suppresses a finding.
+func TestDecideTreatsAnUninterpretableUseAsOpaque(t *testing.T) {
+	t.Parallel()
+
+	invalid := []Use{
+		{Module: "src/a.ts", PURL: purl, Kind: "a-kind-added-later"},
+		{Module: "src/a.ts", PURL: purl, Kind: UseMember},                     // member use naming no symbol
+		{Module: "src/a.ts", PURL: purl, Kind: UseOpaque, Symbol: "template"}, // opaque naming a symbol
+	}
+	for _, use := range invalid {
+		got := Decide("template", append([]Use{named("src/b.ts", "merge")}, use))
+		if got.Verdict != VerdictUnknown {
+			t.Fatalf("use %+v must make the answer unknown, got %q", use, got.Verdict)
+		}
+	}
+}
+
+func TestSubjectRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	subject, ok := Subject("pkg:npm/lodash@4.17.15", "template")
+	if !ok {
+		t.Fatal("a valid component and export must be mintable")
+	}
+	gotPURL, gotSymbol, ok := ParseSubject(subject)
+	if !ok || gotPURL != "pkg:npm/lodash@4.17.15" || gotSymbol != "template" {
+		t.Fatalf("round trip gave (%q, %q, %v)", gotPURL, gotSymbol, ok)
+	}
+	// The writer refuses exactly what the reader refuses.
+	for _, bad := range []struct{ purl, symbol string }{
+		{"pkg:pypi/flask@1.0", "run"}, {"not-a-purl", "x"}, {"pkg:npm/lodash@1.0.0", "a.b"},
+		{"pkg:npm/lodash@1.0.0", ""}, {"pkg:npm/lodash@1.0.0", "with space"},
+	} {
+		if _, ok := Subject(bad.purl, bad.symbol); ok {
+			t.Fatalf("Subject(%q, %q) must be refused", bad.purl, bad.symbol)
+		}
+	}
+	for _, malformed := range []string{"pkg:npm/lodash@1.0.0", "#x", "pkg:npm/lodash@1.0.0#", "pkg:npm/lodash@1.0.0#a.b"} {
+		if _, _, ok := ParseSubject(malformed); ok {
+			t.Fatalf("%q must not parse as a subject", malformed)
+		}
+	}
+}

--- a/internal/domain/jssymbols/jssymbols_test.go
+++ b/internal/domain/jssymbols/jssymbols_test.go
@@ -1,0 +1,197 @@
+package jssymbols
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const purl = "pkg:npm/lodash@4.17.15"
+
+func named(module, symbol string) Use {
+	return Use{Module: module, PURL: purl, Symbol: symbol, Kind: UseNamed}
+}
+
+func member(module, symbol string) Use {
+	return Use{Module: module, PURL: purl, Symbol: symbol, Kind: UseMember}
+}
+
+func opaque(module, reason string) Use {
+	return Use{Module: module, PURL: purl, Kind: UseOpaque, Reason: reason}
+}
+
+func TestDecide(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		symbol  string
+		uses    []Use
+		want    Verdict
+		modules []string
+	}{
+		{
+			name:    "a named import of the affected symbol is reachable",
+			symbol:  "template",
+			uses:    []Use{named("src/a.ts", "template")},
+			want:    VerdictReachable,
+			modules: []string{"src/a.ts"},
+		},
+		{
+			name:    "a member read of the affected symbol is reachable",
+			symbol:  "template",
+			uses:    []Use{member("src/b.ts", "template")},
+			want:    VerdictReachable,
+			modules: []string{"src/b.ts"},
+		},
+		{
+			name:   "named imports of other symbols only are not reachable",
+			symbol: "template",
+			uses:   []Use{named("src/a.ts", "merge"), member("src/b.ts", "cloneDeep")},
+			want:   VerdictNotReachable,
+		},
+		{
+			// The safety rule that matters most: an opaque reference could reach the affected symbol, so
+			// the absence of a matching named use proves nothing.
+			name:    "an opaque reference makes a non-match unknown, never negative",
+			symbol:  "template",
+			uses:    []Use{named("src/a.ts", "merge"), opaque("src/c.ts", "the namespace is passed as an argument")},
+			want:    VerdictUnknown,
+			modules: []string{"src/c.ts"},
+		},
+		{
+			// A positive is always safe, so it wins even when something else is unobservable.
+			name:    "a positive wins over an opaque reference",
+			symbol:  "template",
+			uses:    []Use{opaque("src/c.ts", "spread"), named("src/a.ts", "template")},
+			want:    VerdictReachable,
+			modules: []string{"src/a.ts"},
+		},
+		{
+			name:   "no observed use is a tier-1 question, answered unknown here",
+			symbol: "template",
+			uses:   nil,
+			want:   VerdictUnknown,
+		},
+		{
+			name:   "a blank symbol is unknown, not a negative",
+			symbol: "  ",
+			uses:   []Use{named("src/a.ts", "merge")},
+			want:   VerdictUnknown,
+		},
+		{
+			name:    "reaching modules are deduplicated and sorted",
+			symbol:  "template",
+			uses:    []Use{named("src/z.ts", "template"), named("src/a.ts", "template"), named("src/z.ts", "template")},
+			want:    VerdictReachable,
+			modules: []string{"src/a.ts", "src/z.ts"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := Decide(test.symbol, test.uses)
+			if got.Verdict != test.want {
+				t.Fatalf("Decide(%q) = %q (%s), want %q", test.symbol, got.Verdict, got.Reason, test.want)
+			}
+			if len(test.modules) > 0 {
+				if len(got.Modules) != len(test.modules) {
+					t.Fatalf("modules = %v, want %v", got.Modules, test.modules)
+				}
+				for i := range test.modules {
+					if got.Modules[i] != test.modules[i] {
+						t.Fatalf("modules = %v, want %v", got.Modules, test.modules)
+					}
+				}
+			}
+			if got.Verdict != VerdictReachable && got.Reason == "" {
+				t.Fatal("a non-positive verdict must explain itself: an unexplained unknown is indistinguishable from a bug")
+			}
+		})
+	}
+}
+
+// The symbol comparison must be exact. A case-insensitive or prefix match would let `Template` satisfy a
+// query for `template`, or worse, let `templateSettings` mask it.
+func TestSymbolMatchingIsExact(t *testing.T) {
+	t.Parallel()
+
+	for _, bound := range []string{"Template", "templateSettings", "tem", "template2"} {
+		if got := Decide("template", []Use{named("src/a.ts", bound)}); got.Verdict != VerdictNotReachable {
+			t.Fatalf("binding %q must not satisfy a query for template, got %q", bound, got.Verdict)
+		}
+	}
+}
+
+func TestNormalizeAffectedSymbol(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		pkg, raw string
+		want     string
+		ok       bool
+	}{
+		{"lodash", "template", "template", true},
+		{"lodash", "lodash.template", "template", true},
+		{"@scope/pkg", "@scope/pkg.method", "method", true},
+		{"lodash", "  template  ", "template", true},
+		{"lodash", "$", "$", true},
+		{"lodash", "_private", "_private", true},
+		// A deep import path is a different module, not an export of this one.
+		{"lodash", "lodash/template", "", false},
+		// A nested path: reaching the outer binding says nothing about the nested member.
+		{"lodash", "Class.prototype.method", "", false},
+		{"lodash", "a.b", "", false},
+		// A prefix that is NOT this package's name must not be stripped, or foo.bar would become bar for
+		// an unrelated package.
+		{"lodash", "other.template", "", false},
+		{"lodash", "", "", false},
+		{"lodash", "*", "", false},
+		{"lodash", "fn()", "", false},
+		{"lodash", "1abc", "", false},
+		{"lodash", "with space", "", false},
+	}
+
+	for _, test := range tests {
+		got, ok := NormalizeAffectedSymbol(test.pkg, test.raw)
+		if ok != test.ok || got != test.want {
+			t.Fatalf("NormalizeAffectedSymbol(%q, %q) = (%q, %v), want (%q, %v)", test.pkg, test.raw, got, ok, test.want, test.ok)
+		}
+	}
+}
+
+func TestUseValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		use  Use
+		ok   bool
+	}{
+		{"named use", named("src/a.ts", "template"), true},
+		{"opaque use", opaque("src/a.ts", "spread"), true},
+		{"no module", Use{PURL: purl, Symbol: "x", Kind: UseNamed}, false},
+		{"no package", Use{Module: "src/a.ts", Symbol: "x", Kind: UseNamed}, false},
+		{"unknown kind", Use{Module: "src/a.ts", PURL: purl, Symbol: "x", Kind: "guess"}, false},
+		// An opaque use that names a symbol is a contradiction: its symbol is exactly what is unknown.
+		{"opaque with a symbol", Use{Module: "src/a.ts", PURL: purl, Symbol: "x", Kind: UseOpaque}, false},
+		{"named without a symbol", Use{Module: "src/a.ts", PURL: purl, Kind: UseNamed}, false},
+	}
+
+	for _, test := range tests {
+		err := test.use.Validate()
+		if test.ok && err != nil {
+			t.Fatalf("%s: unexpected error %v", test.name, err)
+		}
+		if !test.ok {
+			if err == nil {
+				t.Fatalf("%s: expected a validation error", test.name)
+			}
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("%s: error %v must wrap ErrValidation", test.name, err)
+			}
+		}
+	}
+}

--- a/internal/domain/modulegraph/modulegraph.go
+++ b/internal/domain/modulegraph/modulegraph.go
@@ -88,6 +88,51 @@ type Edge struct {
 	Position  Position
 }
 
+// LocalUseKind classifies what a module does with a local name bound by an import.
+//
+// It exists for Tier-2 (affected-symbol) reachability: a named import already says which export is
+// bound, but a whole-module binding (`import * as _`, `import _ from`, `const _ = require(...)`) reaches
+// a specific export only through what the module then DOES with that local.
+type LocalUseKind string
+
+const (
+	// LocalUseProperty is an observable property read: `_.template`. It names one export.
+	LocalUseProperty LocalUseKind = "property"
+	// LocalUseOpaque is any other reference to the local. The whole module object escapes, so ANY export
+	// could be reached through it and no symbol-level negative is safe.
+	LocalUseOpaque LocalUseKind = "opaque"
+)
+
+// Valid reports whether k is a known local use kind.
+func (k LocalUseKind) Valid() bool {
+	switch k {
+	case LocalUseProperty, LocalUseOpaque:
+		return true
+	default:
+		return false
+	}
+}
+
+// LocalUse is one observed reference to a local name inside a module.
+//
+// The scanner emits these for EVERY local it sees, without knowing which locals are import bindings —
+// the join to a package happens later, against the edges' bindings. Emitting them unfiltered is what
+// keeps the scanner from having to decide what matters, and it means a local that is rebound or shadowed
+// still contributes its references rather than disappearing.
+type LocalUse struct {
+	// Module is the normalized repository-relative path of the referencing module.
+	Module string
+	// Local is the identifier being referenced.
+	Local string
+	// Property is the member name for LocalUseProperty, empty otherwise.
+	Property string
+	Kind     LocalUseKind
+	// Detail explains an opaque reference in words ("indexed with a computed key"). It never carries
+	// source text.
+	Detail string
+	Line   int
+}
+
 // CoverageIssueKind identifies a condition that prevents a later analyzer from
 // treating absence of an edge as a definitive negative proof.
 type CoverageIssueKind string
@@ -169,7 +214,10 @@ type Graph struct {
 	Edges   []Edge
 	// Roots contains structural roots only: modules with no incoming resolved
 	// first-party edge. It is not a set of verified runtime entrypoints.
-	Roots        []string
+	Roots []string
+	// LocalUses records what each module does with its local names. It is populated only for the
+	// Tier-2 symbol pass; a Tier-1 consumer ignores it, and an empty slice is not evidence of absence.
+	LocalUses    []LocalUse
 	Coverage     []CoverageIssue
 	FilesScanned int
 	BytesScanned int64

--- a/internal/domain/modulegraph/modulegraph.go
+++ b/internal/domain/modulegraph/modulegraph.go
@@ -115,10 +115,10 @@ func (k LocalUseKind) Valid() bool {
 
 // LocalUse is one observed reference to a local name inside a module.
 //
-// The scanner emits these for EVERY local it sees, without knowing which locals are import bindings —
-// the join to a package happens later, against the edges' bindings. Emitting them unfiltered is what
-// keeps the scanner from having to decide what matters, and it means a local that is rebound or shadowed
-// still contributes its references rather than disappearing.
+// The scanner emits one per reference to a local that some import in the same module binds. A local no
+// import binds could never contribute evidence, so filtering those out is a memory decision rather than
+// a semantic one; a local that is rebound or shadowed still contributes ALL its references, which
+// over-approximates toward reachable.
 type LocalUse struct {
 	// Module is the normalized repository-relative path of the referencing module.
 	Module string
@@ -166,6 +166,9 @@ const (
 	// supported source. Excluding build output or a tool directory is a policy choice, but the modules
 	// inside it are unobserved, so their imports must not be read as absent.
 	CoverageSkippedDirectory CoverageIssueKind = "skipped-directory"
+	// CoverageSymbolEvidenceIncomplete records that a module's symbol references could not be fully
+	// enumerated. It appears only in SymbolEvidence.Coverage: the import graph is unaffected.
+	CoverageSymbolEvidenceIncomplete CoverageIssueKind = "symbol-evidence-incomplete"
 )
 
 // Valid reports whether k is a known R1 coverage issue kind.
@@ -193,7 +196,8 @@ func (k CoverageIssueKind) Valid() bool {
 		CoverageEntryBudgetExceeded,
 		CoverageEdgeBudgetExceeded,
 		CoverageIssueBudgetExceeded,
-		CoverageSkippedDirectory:
+		CoverageSkippedDirectory,
+		CoverageSymbolEvidenceIncomplete:
 		return true
 	default:
 		return false
@@ -215,13 +219,35 @@ type Graph struct {
 	// Roots contains structural roots only: modules with no incoming resolved
 	// first-party edge. It is not a set of verified runtime entrypoints.
 	Roots []string
-	// LocalUses records what each module does with its local names. It is populated only for the
-	// Tier-2 symbol pass; a Tier-1 consumer ignores it, and an empty slice is not evidence of absence.
-	LocalUses    []LocalUse
-	Coverage     []CoverageIssue
-	FilesScanned int
-	BytesScanned int64
+	// SymbolEvidence is the Tier-2 view: what each module does with the locals its imports bind. It is
+	// a POINTER so "not collected" and "collected and empty" are different states — the distinction is
+	// the whole safety property, because only the second one permits a negative conclusion. Use
+	// Complete() rather than testing the slice.
+	SymbolEvidence *SymbolEvidence
+	Coverage       []CoverageIssue
+	FilesScanned   int
+	BytesScanned   int64
 }
+
+// SymbolEvidence carries the Tier-2 symbol observations for one scan.
+type SymbolEvidence struct {
+	// Uses are the observed references, deterministically ordered.
+	Uses []LocalUse
+	// JSXModules are the modules that actually contain JSX, whatever their extension. JSX desugars into
+	// calls on the runtime binding that never appear as source tokens, so a whole-module binding in one
+	// of these modules cannot be narrowed by its visible property reads.
+	JSXModules []string
+	// Coverage records limitations of the SYMBOL evidence specifically.
+	//
+	// It is deliberately separate from Graph.Coverage. A Tier-2 budget breach says nothing about whether
+	// the import graph is complete, and folding it into the graph's coverage would make a Tier-2-only
+	// limitation refuse a Tier-1 answer that is still perfectly sound.
+	Coverage []CoverageIssue
+}
+
+// Complete reports whether the symbol evidence may be used to conclude that an export is NOT reached.
+// A nil receiver (never collected) and any coverage limitation both mean no.
+func (e *SymbolEvidence) Complete() bool { return e != nil && len(e.Coverage) == 0 }
 
 // DialectForPath returns the dialect selected by a supported source extension.
 func DialectForPath(p string) (Dialect, bool) {

--- a/internal/domain/modulegraph/normalize.go
+++ b/internal/domain/modulegraph/normalize.go
@@ -112,17 +112,47 @@ func Normalize(in Graph) (Graph, error) {
 
 	// Tier-2 symbol evidence is normalized like every other member. A use whose module is not a scanned
 	// module is an error rather than a dropped record: silently discarding a reference is how a symbol
-	// that IS reached comes to look unused.
-	out.LocalUses = make([]LocalUse, 0, len(in.LocalUses))
-	for _, use := range in.LocalUses {
-		normalized, err := normalizeLocalUse(use, moduleByPath)
-		if err != nil {
-			return Graph{}, err
+	// that IS reached comes to look unused. A nil SymbolEvidence stays nil — "not collected" is a
+	// distinct state from "collected and empty".
+	if in.SymbolEvidence != nil {
+		evidence := &SymbolEvidence{
+			Uses:       make([]LocalUse, 0, len(in.SymbolEvidence.Uses)),
+			JSXModules: make([]string, 0, len(in.SymbolEvidence.JSXModules)),
+			Coverage:   make([]CoverageIssue, 0, len(in.SymbolEvidence.Coverage)),
 		}
-		out.LocalUses = append(out.LocalUses, normalized)
+		for _, use := range in.SymbolEvidence.Uses {
+			normalized, err := normalizeLocalUse(use, moduleByPath)
+			if err != nil {
+				return Graph{}, err
+			}
+			evidence.Uses = append(evidence.Uses, normalized)
+		}
+		sort.Slice(evidence.Uses, func(i, j int) bool { return localUseLess(evidence.Uses[i], evidence.Uses[j]) })
+		evidence.Uses = deduplicateLocalUses(evidence.Uses)
+
+		for _, module := range in.SymbolEvidence.JSXModules {
+			normalizedPath, err := NormalizeRepositoryPath(module)
+			if err != nil {
+				return Graph{}, fmt.Errorf("normalize jsx module %q: %w", module, err)
+			}
+			if _, ok := moduleByPath[normalizedPath]; !ok {
+				return Graph{}, fmt.Errorf("modulegraph: jsx module %q is not a known module", normalizedPath)
+			}
+			evidence.JSXModules = append(evidence.JSXModules, normalizedPath)
+		}
+		sort.Strings(evidence.JSXModules)
+		evidence.JSXModules = dedupeSortedStrings(evidence.JSXModules)
+
+		for _, issue := range in.SymbolEvidence.Coverage {
+			if !issue.Kind.Valid() {
+				return Graph{}, fmt.Errorf("modulegraph: invalid symbol coverage kind %q", issue.Kind)
+			}
+			evidence.Coverage = append(evidence.Coverage, issue)
+		}
+		sort.Slice(evidence.Coverage, func(i, j int) bool { return coverageLess(evidence.Coverage[i], evidence.Coverage[j]) })
+		evidence.Coverage = deduplicateCoverage(evidence.Coverage)
+		out.SymbolEvidence = evidence
 	}
-	sort.Slice(out.LocalUses, func(i, j int) bool { return localUseLess(out.LocalUses[i], out.LocalUses[j]) })
-	out.LocalUses = deduplicateLocalUses(out.LocalUses)
 
 	out.Roots = structuralRoots(out.Modules, out.Edges)
 
@@ -156,6 +186,19 @@ func normalizeLocalUse(use LocalUse, modules map[string]Module) (LocalUse, error
 	}
 	use.Module = module
 	return use, nil
+}
+
+func dedupeSortedStrings(sorted []string) []string {
+	if len(sorted) < 2 {
+		return sorted
+	}
+	out := sorted[:1]
+	for _, value := range sorted[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
 }
 
 func localUseLess(a, b LocalUse) bool {

--- a/internal/domain/modulegraph/normalize.go
+++ b/internal/domain/modulegraph/normalize.go
@@ -109,9 +109,92 @@ func Normalize(in Graph) (Graph, error) {
 	}
 	sort.Slice(out.Coverage, func(i, j int) bool { return coverageLess(out.Coverage[i], out.Coverage[j]) })
 	out.Coverage = deduplicateCoverage(out.Coverage)
+
+	// Tier-2 symbol evidence is normalized like every other member. A use whose module is not a scanned
+	// module is an error rather than a dropped record: silently discarding a reference is how a symbol
+	// that IS reached comes to look unused.
+	out.LocalUses = make([]LocalUse, 0, len(in.LocalUses))
+	for _, use := range in.LocalUses {
+		normalized, err := normalizeLocalUse(use, moduleByPath)
+		if err != nil {
+			return Graph{}, err
+		}
+		out.LocalUses = append(out.LocalUses, normalized)
+	}
+	sort.Slice(out.LocalUses, func(i, j int) bool { return localUseLess(out.LocalUses[i], out.LocalUses[j]) })
+	out.LocalUses = deduplicateLocalUses(out.LocalUses)
+
 	out.Roots = structuralRoots(out.Modules, out.Edges)
 
 	return out, nil
+}
+
+func normalizeLocalUse(use LocalUse, modules map[string]Module) (LocalUse, error) {
+	if !use.Kind.Valid() {
+		return LocalUse{}, fmt.Errorf("modulegraph: invalid local use kind %q", use.Kind)
+	}
+	if use.Line < 0 {
+		return LocalUse{}, fmt.Errorf("modulegraph: negative local use line in %q", use.Module)
+	}
+	if strings.TrimSpace(use.Local) == "" {
+		return LocalUse{}, fmt.Errorf("modulegraph: local use in %q names no local", use.Module)
+	}
+	// A property use must name the property, and an opaque use must not: an opaque reference is exactly
+	// one whose reached symbol is unknown, so carrying a property would misrepresent it as observed.
+	if use.Kind == LocalUseProperty && strings.TrimSpace(use.Property) == "" {
+		return LocalUse{}, fmt.Errorf("modulegraph: property use of %q names no property", use.Local)
+	}
+	if use.Kind == LocalUseOpaque && strings.TrimSpace(use.Property) != "" {
+		return LocalUse{}, fmt.Errorf("modulegraph: opaque use of %q must not name a property", use.Local)
+	}
+	module, err := NormalizeRepositoryPath(use.Module)
+	if err != nil {
+		return LocalUse{}, fmt.Errorf("normalize local use module %q: %w", use.Module, err)
+	}
+	if _, ok := modules[module]; !ok {
+		return LocalUse{}, fmt.Errorf("modulegraph: local use module %q is not a known module", module)
+	}
+	use.Module = module
+	return use, nil
+}
+
+func localUseLess(a, b LocalUse) bool {
+	if a.Module != b.Module {
+		return a.Module < b.Module
+	}
+	if a.Local != b.Local {
+		return a.Local < b.Local
+	}
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	if a.Property != b.Property {
+		return a.Property < b.Property
+	}
+	if a.Detail != b.Detail {
+		return a.Detail < b.Detail
+	}
+	return a.Line < b.Line
+}
+
+// deduplicateLocalUses collapses references that carry identical evidence, keeping the FIRST line so a
+// reader is pointed at the earliest occurrence.
+func deduplicateLocalUses(sorted []LocalUse) []LocalUse {
+	if len(sorted) < 2 {
+		return sorted
+	}
+	same := func(a, b LocalUse) bool {
+		return a.Module == b.Module && a.Local == b.Local && a.Kind == b.Kind &&
+			a.Property == b.Property && a.Detail == b.Detail
+	}
+	out := sorted[:1]
+	for _, use := range sorted[1:] {
+		if same(out[len(out)-1], use) {
+			continue
+		}
+		out = append(out, use)
+	}
+	return out
 }
 
 func normalizeEdge(edge Edge, modules map[string]Module) (Edge, error) {

--- a/internal/domain/modulegraph/symbolevidence_test.go
+++ b/internal/domain/modulegraph/symbolevidence_test.go
@@ -1,0 +1,115 @@
+package modulegraph
+
+import (
+	"strings"
+	"testing"
+)
+
+func moduleGraphWith(evidence *SymbolEvidence) Graph {
+	return Graph{
+		Modules:        []Module{{Path: "src/a.ts", Dialect: DialectTypeScript}},
+		SymbolEvidence: evidence,
+	}
+}
+
+// TestSymbolEvidenceCompleteDistinguishesNotCollectedFromEmpty is the safety property the pointer
+// exists for: only "collected, and nothing limited it" permits a negative conclusion.
+func TestSymbolEvidenceCompleteDistinguishesNotCollectedFromEmpty(t *testing.T) {
+	t.Parallel()
+
+	var uncollected *SymbolEvidence
+	if uncollected.Complete() {
+		t.Fatal("evidence that was never collected is not complete evidence")
+	}
+	if (&SymbolEvidence{Coverage: []CoverageIssue{{Kind: CoverageSymbolEvidenceIncomplete}}}).Complete() {
+		t.Fatal("evidence with a coverage limitation is not complete")
+	}
+	if !(&SymbolEvidence{}).Complete() {
+		t.Fatal("evidence that was collected and found nothing IS complete — that is the whole distinction")
+	}
+}
+
+// A use whose module was never scanned is an ERROR, not a dropped record: silently discarding a
+// reference is how an export that IS reached comes to look unused.
+func TestNormalizeRefusesAUseFromAnUnknownModule(t *testing.T) {
+	t.Parallel()
+
+	_, err := Normalize(moduleGraphWith(&SymbolEvidence{Uses: []LocalUse{
+		{Module: "src/ghost.ts", Local: "_", Kind: LocalUseOpaque},
+	}}))
+	if err == nil {
+		t.Fatal("a reference from a module that was never scanned must be refused, not dropped")
+	}
+	if !strings.Contains(err.Error(), "not a known module") {
+		t.Fatalf("error %q must name the problem", err)
+	}
+
+	if _, err := Normalize(moduleGraphWith(&SymbolEvidence{JSXModules: []string{"src/ghost.ts"}})); err == nil {
+		t.Fatal("a jsx module that was never scanned must be refused")
+	}
+}
+
+func TestNormalizeValidatesLocalUses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		use  LocalUse
+	}{
+		{"unknown kind", LocalUse{Module: "src/a.ts", Local: "_", Kind: "guess"}},
+		{"negative line", LocalUse{Module: "src/a.ts", Local: "_", Kind: LocalUseOpaque, Line: -1}},
+		{"no local", LocalUse{Module: "src/a.ts", Kind: LocalUseOpaque}},
+		// A property use must name the property, and an opaque use must NOT: an opaque reference is
+		// exactly one whose reached export is unknown, so carrying a property would misrepresent it.
+		{"property use with no property", LocalUse{Module: "src/a.ts", Local: "_", Kind: LocalUseProperty}},
+		{"opaque use with a property", LocalUse{Module: "src/a.ts", Local: "_", Property: "x", Kind: LocalUseOpaque}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Normalize(moduleGraphWith(&SymbolEvidence{Uses: []LocalUse{test.use}})); err == nil {
+				t.Fatalf("%s must be refused", test.name)
+			}
+		})
+	}
+}
+
+// Normalization is deterministic: identical evidence collapses, and the FIRST line survives so a reader
+// is pointed at the earliest occurrence.
+func TestNormalizeDeduplicatesAndOrdersSymbolEvidence(t *testing.T) {
+	t.Parallel()
+
+	graph := Graph{
+		Modules: []Module{{Path: "src/a.ts", Dialect: DialectTypeScript}, {Path: "src/b.ts", Dialect: DialectTypeScript}},
+		SymbolEvidence: &SymbolEvidence{
+			Uses: []LocalUse{
+				{Module: "src/b.ts", Local: "_", Property: "merge", Kind: LocalUseProperty, Line: 9},
+				{Module: "src/a.ts", Local: "_", Property: "merge", Kind: LocalUseProperty, Line: 7},
+				{Module: "src/a.ts", Local: "_", Property: "merge", Kind: LocalUseProperty, Line: 3},
+			},
+			JSXModules: []string{"src/b.ts", "src/a.ts", "src/b.ts"},
+		},
+	}
+	out, err := Normalize(graph)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(out.SymbolEvidence.Uses) != 2 {
+		t.Fatalf("identical evidence must collapse, got %+v", out.SymbolEvidence.Uses)
+	}
+	if out.SymbolEvidence.Uses[0].Module != "src/a.ts" || out.SymbolEvidence.Uses[0].Line != 3 {
+		t.Fatalf("the earliest occurrence must survive in sorted order, got %+v", out.SymbolEvidence.Uses[0])
+	}
+	if len(out.SymbolEvidence.JSXModules) != 2 || out.SymbolEvidence.JSXModules[0] != "src/a.ts" {
+		t.Fatalf("jsx modules = %v, want sorted and deduplicated", out.SymbolEvidence.JSXModules)
+	}
+
+	// Nil stays nil: "not collected" must survive normalization as a distinct state.
+	empty, err := Normalize(moduleGraphWith(nil))
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if empty.SymbolEvidence != nil {
+		t.Fatal("uncollected symbol evidence must stay uncollected")
+	}
+}

--- a/internal/infrastructure/tools/jsimports/extract.go
+++ b/internal/infrastructure/tools/jsimports/extract.go
@@ -17,6 +17,10 @@ type extraction struct {
 	imports   []rawImport
 	localUses []rawLocalUse
 	hazards   []hazard
+	// sawJSX records that this file actually contains JSX, whatever its extension.
+	sawJSX bool
+	// symbolBudgetHit records that the file's symbol references could not be fully enumerated.
+	symbolBudgetHit bool
 }
 
 // indirectLoaders are call-shaped module loaders this scanner does not extract specifiers from. Each one
@@ -77,9 +81,11 @@ type extractor struct {
 	buf []token
 	// history is the recently consumed main-loop tokens, used to recover a CommonJS binding pattern
 	// (`const { a } = require('pkg')`) whose left-hand side has already been passed.
-	history           []token
-	localUseBudgetHit bool
-	out               extraction
+	history []token
+	// seenLocalUses deduplicates references at the point of record, so the budget counts evidence
+	// rather than occurrences.
+	seenLocalUses map[rawLocalUse]bool
+	out           extraction
 }
 
 func newExtractor(src []byte, jsxAware bool) *extractor {
@@ -201,6 +207,7 @@ func (e *extractor) run() extraction {
 	}
 
 	e.out.hazards = append(e.out.hazards, e.lex.hazards...)
+	e.out.sawJSX = e.lex.sawJSX
 	e.out.localUses = keepImportedLocals(e.out.imports, e.out.localUses)
 	return e.out
 }
@@ -562,8 +569,24 @@ func (e *extractor) handleExportKeyword(kw token) {
 			e.addHazard(hazardUnsupportedLoader, kw.line, "unrecognised export clause")
 			return
 		}
-		// A local re-export list (`export {a}`) has no `from` and creates no module edge.
+		// A local re-export list (`export {a}`) creates no module edge — but it is NOT nothing. Re-exporting
+		// a namespace local republishes every export of the package to every consumer, and the identifiers
+		// were consumed by readNamedBindings so they never reach observeLocal. Recording them as escaping
+		// is what stops `import * as _; export { _ }` from looking like an unused package.
 		if from := e.peek(); from.kind != tokenIdent || from.text != "from" {
+			for _, binding := range bindings {
+				// In an EXPORT clause the roles are reversed relative to an import: `export { local as
+				// public }` parses as Imported="local", Local="public", and it is `local` that holds the
+				// package.
+				local := binding.Imported
+				if local == "" {
+					local = binding.Local
+				}
+				if local != "" {
+					e.addLocalUse(rawLocalUse{local: local, kind: modulegraph.LocalUseOpaque,
+						detail: "the binding is re-exported", line: kw.line})
+				}
+			}
 			return
 		}
 		specifier, escaped, sok := e.readFromSpecifier(kw, "export")
@@ -644,13 +667,27 @@ func (e *extractor) handleRequire(kw, prev, prev2 token, havePrev bool) {
 			}
 		}
 		if spec, escaped, ok := e.readLiteralCallArgument(); ok {
+			// A call whose result is immediately navigated (`require('x').y`, `require('x')()`) binds a
+			// sub-object, not the module. The argument reader leaves the call's own ")" pending, so the
+			// look-ahead has to step past it and then put both tokens back.
+			navigated := false
+			closing := e.next()
+			if closing.kind == tokenPunct && closing.text == ")" {
+				if next := e.peek(); next.kind == tokenPunct {
+					switch next.text {
+					case ".", "?.", "[", "(":
+						navigated = true
+					}
+				}
+			}
+			e.push(closing)
 			e.addImport(rawImport{
 				specifier: spec,
 				kind:      modulegraph.ImportCommonJS,
 				// The binding pattern is recovered from the tokens already consumed. When it cannot be
 				// modelled the bindings are nil, which downstream means the whole module object is bound
 				// and any export could be reached.
-				bindings: commonJSBindings(e.history),
+				bindings: commonJSBindings(e.history, navigated),
 				position: modulegraph.Position{Line: kw.line, Column: kw.column},
 			}, escaped)
 			return

--- a/internal/infrastructure/tools/jsimports/extract.go
+++ b/internal/infrastructure/tools/jsimports/extract.go
@@ -11,10 +11,12 @@ type rawImport struct {
 	position  modulegraph.Position
 }
 
-// extraction is everything one source file yields: its import sites and its coverage hazards.
+// extraction is everything one source file yields: its import sites, the references it makes to its own
+// locals (Tier-2 symbol evidence) and its coverage hazards.
 type extraction struct {
-	imports []rawImport
-	hazards []hazard
+	imports   []rawImport
+	localUses []rawLocalUse
+	hazards   []hazard
 }
 
 // indirectLoaders are call-shaped module loaders this scanner does not extract specifiers from. Each one
@@ -73,7 +75,11 @@ type extractor struct {
 	lex *lexer
 	// buf holds tokens pushed back by the recognisers (single-token lookahead is not always enough).
 	buf []token
-	out extraction
+	// history is the recently consumed main-loop tokens, used to recover a CommonJS binding pattern
+	// (`const { a } = require('pkg')`) whose left-hand side has already been passed.
+	history           []token
+	localUseBudgetHit bool
+	out               extraction
 }
 
 func newExtractor(src []byte, jsxAware bool) *extractor {
@@ -125,6 +131,12 @@ func (e *extractor) run() extraction {
 		t := e.next()
 		if t.kind == tokenEOF {
 			break
+		}
+
+		// Tier-2 symbol evidence. Identifiers consumed inside an import clause never reach here, so a
+		// binding site introduces a local without also counting as a use of it.
+		if t.kind == tokenIdent {
+			e.observeLocal(t, prev, havePrev)
 		}
 
 		switch {
@@ -184,10 +196,12 @@ func (e *extractor) run() extraction {
 			}
 		}
 
+		e.recordHistory(t)
 		prev2, prev, havePrev = prev, t, true
 	}
 
 	e.out.hazards = append(e.out.hazards, e.lex.hazards...)
+	e.out.localUses = keepImportedLocals(e.out.imports, e.out.localUses)
 	return e.out
 }
 
@@ -633,7 +647,11 @@ func (e *extractor) handleRequire(kw, prev, prev2 token, havePrev bool) {
 			e.addImport(rawImport{
 				specifier: spec,
 				kind:      modulegraph.ImportCommonJS,
-				position:  modulegraph.Position{Line: kw.line, Column: kw.column},
+				// The binding pattern is recovered from the tokens already consumed. When it cannot be
+				// modelled the bindings are nil, which downstream means the whole module object is bound
+				// and any export could be reached.
+				bindings: commonJSBindings(e.history),
+				position: modulegraph.Position{Line: kw.line, Column: kw.column},
 			}, escaped)
 			return
 		}

--- a/internal/infrastructure/tools/jsimports/lexer.go
+++ b/internal/infrastructure/tools/jsimports/lexer.go
@@ -133,6 +133,11 @@ type lexer struct {
 	frames []frame
 	// hazards collects lexical coverage limitations discovered while scanning.
 	hazards []hazard
+	// sawJSX records that a JSX element was actually lexed. Tier-2 needs this fact rather than the file
+	// extension: JSX is routine in .js under Babel, CRA and Next, and JSX desugars into calls on the
+	// runtime binding that never appear as source tokens — so a whole-module binding in such a module
+	// cannot be narrowed by its visible property reads.
+	sawJSX bool
 	// malformed records an unterminated construct: the rest of the file cannot be trusted.
 	malformed bool
 }
@@ -313,6 +318,7 @@ func (l *lexer) next() token {
 			return l.emit(token{kind: tokenIdent, text: l.readNumberLike(), line: startLine, column: startCol})
 		case b == '<' && l.jsxAware && l.jsxElementAhead():
 			l.advance() // '<'
+			l.sawJSX = true
 			if !l.pushFrame(frame{kind: frameJSXTag}) {
 				return token{kind: tokenEOF, line: startLine, column: startCol}
 			}

--- a/internal/infrastructure/tools/jsimports/scanner.go
+++ b/internal/infrastructure/tools/jsimports/scanner.go
@@ -191,6 +191,7 @@ func (s *Scanner) Scan(ctx context.Context, root string) (modulegraph.Graph, err
 	graph := modulegraph.Graph{
 		Modules:      sc.modules,
 		Edges:        sc.edges,
+		LocalUses:    sc.localUses,
 		Coverage:     sc.coverage.issues(),
 		FilesScanned: sc.filesScanned,
 		BytesScanned: sc.bytesScanned,
@@ -226,6 +227,8 @@ type scanState struct {
 
 	modules []modulegraph.Module
 	edges   []modulegraph.Edge
+	// localUses is Tier-2 symbol evidence: what each module does with its own local names.
+	localUses []modulegraph.LocalUse
 
 	coverage     *coverageSink
 	filesScanned int
@@ -455,6 +458,7 @@ func (sc *scanState) parseAll(ctx context.Context) error {
 		for _, imp := range result.imports {
 			sc.recordImport(src.relPath, imp)
 		}
+		sc.recordLocalUses(src.relPath, result.localUses)
 	}
 	return nil
 }

--- a/internal/infrastructure/tools/jsimports/scanner.go
+++ b/internal/infrastructure/tools/jsimports/scanner.go
@@ -189,9 +189,13 @@ func (s *Scanner) Scan(ctx context.Context, root string) (modulegraph.Graph, err
 	}
 
 	graph := modulegraph.Graph{
-		Modules:      sc.modules,
-		Edges:        sc.edges,
-		LocalUses:    sc.localUses,
+		Modules: sc.modules,
+		Edges:   sc.edges,
+		SymbolEvidence: &modulegraph.SymbolEvidence{
+			Uses:       sc.localUses,
+			JSXModules: sc.jsxModules,
+			Coverage:   sc.symbolCoverage,
+		},
 		Coverage:     sc.coverage.issues(),
 		FilesScanned: sc.filesScanned,
 		BytesScanned: sc.bytesScanned,
@@ -227,8 +231,12 @@ type scanState struct {
 
 	modules []modulegraph.Module
 	edges   []modulegraph.Edge
-	// localUses is Tier-2 symbol evidence: what each module does with its own local names.
-	localUses []modulegraph.LocalUse
+	// Tier-2 symbol evidence: what each module does with the locals its imports bind, which modules
+	// actually contain JSX, and any limitation of that evidence (kept apart from the graph's own
+	// coverage so a Tier-2 budget cannot refuse a Tier-1 answer).
+	localUses      []modulegraph.LocalUse
+	jsxModules     []string
+	symbolCoverage []modulegraph.CoverageIssue
 
 	coverage     *coverageSink
 	filesScanned int
@@ -458,7 +466,7 @@ func (sc *scanState) parseAll(ctx context.Context) error {
 		for _, imp := range result.imports {
 			sc.recordImport(src.relPath, imp)
 		}
-		sc.recordLocalUses(src.relPath, result.localUses)
+		sc.recordLocalUses(src.relPath, result)
 	}
 	return nil
 }

--- a/internal/infrastructure/tools/jsimports/symbols.go
+++ b/internal/infrastructure/tools/jsimports/symbols.go
@@ -114,7 +114,15 @@ func (e *extractor) observeLocal(t, prev token, havePrev bool) {
 		// (`const x = require(...)`) also lands here and is likewise not a use.
 		return
 	case ":":
-		// An object literal key or a TypeScript type annotation position.
+		// `{ key: value }` and `x: Type` bind or annotate a name; `cond ? a : b` READS one. The three are
+		// only distinguishable by what precedes the identifier, and an identifier that is not provably in
+		// a key or annotation position is treated as a read — the ternary consequent is an ordinary
+		// escaping reference, and calling it a key would lose it.
+		if havePrev && prev.kind == tokenPunct && (prev.text == "{" || prev.text == "," || prev.text == ";" || prev.text == "(") {
+			return
+		}
+		e.addLocalUse(rawLocalUse{local: t.text, kind: modulegraph.LocalUseOpaque,
+			detail: "the binding escapes as a value", line: t.line})
 		return
 	default:
 		// Passed as an argument, spread, returned, compared, awaited: the module object escapes.
@@ -123,32 +131,47 @@ func (e *extractor) observeLocal(t, prev token, havePrev bool) {
 	}
 }
 
+// addLocalUse records one reference, deduplicated at the point of record.
+//
+// The budget is charged against DISTINCT records, not raw occurrences: a file that reads `_.merge` twenty
+// thousand times carries exactly one piece of evidence, and charging it twenty thousand times would
+// declare a benign file unobservable. Deduplicating here is safe precisely because identical records
+// carry identical evidence.
 func (e *extractor) addLocalUse(use rawLocalUse) {
-	if len(e.out.localUses) >= maxLocalUsesPerFile {
-		// The budget is a coverage issue, not a silent truncation: a dropped reference could be the one
-		// that reaches the affected symbol, so the whole file's symbol evidence becomes untrustworthy.
-		if !e.localUseBudgetHit {
-			e.localUseBudgetHit = true
-			e.addHazard(hazardUnsupportedLoader, use.line, "local reference budget exceeded")
-		}
+	key := rawLocalUse{local: use.local, property: use.property, kind: use.kind, detail: use.detail}
+	if e.seenLocalUses == nil {
+		e.seenLocalUses = map[rawLocalUse]bool{}
+	}
+	if e.seenLocalUses[key] {
 		return
 	}
+	if len(e.out.localUses) >= maxLocalUsesPerFile {
+		// A dropped reference could be the one that reaches the affected symbol, so the file's symbol
+		// evidence becomes untrustworthy. It is recorded as a SYMBOL limitation, not a graph hazard: the
+		// import graph is unaffected, and a Tier-2 budget must not refuse a sound Tier-1 answer.
+		e.out.symbolBudgetHit = true
+		return
+	}
+	e.seenLocalUses[key] = true
 	e.out.localUses = append(e.out.localUses, use)
 }
 
-// maxLocalUsesPerFile bounds per-file symbol evidence. A file that overruns it degrades coverage rather
-// than contributing a partial reference list.
+// maxLocalUsesPerFile bounds per-file symbol evidence, counted in distinct records.
 const maxLocalUsesPerFile = 20000
 
 // commonJSBindings recovers the binding pattern of a `... = require('pkg')` declaration by looking back
 // over the tokens the main loop has already consumed.
 //
 // It returns nil when the pattern is anything it does not fully understand — a rest element, a default
-// value, a nested pattern, a bare call whose result is not bound. nil means "whole module bound
-// opaquely", which is the conservative reading: downstream, a require edge with no named bindings can
-// reach any export.
-func commonJSBindings(history []token) []modulegraph.Binding {
-	if len(history) == 0 {
+// value, a nested pattern, a member-assignment target, a bare call whose result is not bound. nil means
+// "whole module bound opaquely", which is the conservative reading: downstream, a require edge with no
+// named bindings can reach any export.
+//
+// followedByNavigation reports whether the require CALL is further navigated (`require('x').y`,
+// `require('x')()`); in that case whatever is bound is a sub-object, not the module, and claiming it as
+// the module's own local would attribute the sub-object's property reads to the wrong thing.
+func commonJSBindings(history []token, followedByNavigation bool) []modulegraph.Binding {
+	if len(history) == 0 || followedByNavigation {
 		return nil
 	}
 	last := history[len(history)-1]
@@ -161,8 +184,16 @@ func commonJSBindings(history []token) []modulegraph.Binding {
 		return nil
 	}
 
-	// A single identifier: `const ns = require('pkg')`.
+	// A single identifier: `const ns = require('pkg')`. It must be a genuine DECLARATION, not a member
+	// assignment: `exports.lodash = require('lodash')` publishes the whole module somewhere this scanner
+	// cannot follow, and recording `lodash` as a local would silently model that escape as a binding
+	// nothing ever reads.
 	if tail := pattern[len(pattern)-1]; isLocalName(tail) {
+		if len(pattern) >= 2 {
+			if before := pattern[len(pattern)-2]; before.kind == tokenPunct && (before.text == "." || before.text == "?." || before.text == "[") {
+				return nil
+			}
+		}
 		return []modulegraph.Binding{{Local: tail.text, Namespace: true}}
 	}
 
@@ -239,24 +270,43 @@ func (e *extractor) recordHistory(t token) {
 // Deduplication is safe here and nowhere else: two identical (local, property, kind) references from the
 // same module carry the same evidence, so collapsing them cannot hide a distinct reference. The line is
 // dropped for a duplicate because the FIRST occurrence is the one a reader is pointed at.
-func (sc *scanState) recordLocalUses(modulePath string, uses []rawLocalUse) {
-	seen := make(map[modulegraph.LocalUse]bool, len(uses))
-	for _, use := range uses {
-		record := modulegraph.LocalUse{
+func (sc *scanState) recordLocalUses(modulePath string, result extraction) {
+	if result.sawJSX {
+		sc.jsxModules = append(sc.jsxModules, modulePath)
+	}
+	if result.symbolBudgetHit {
+		sc.symbolCoverage = append(sc.symbolCoverage, modulegraph.CoverageIssue{
+			Kind:   modulegraph.CoverageSymbolEvidenceIncomplete,
+			Path:   modulePath,
+			Detail: "distinct local reference budget exceeded",
+		})
+		return
+	}
+	// A scan-wide bound as well as the per-file one: a hostile repository of many small files would
+	// otherwise exhaust memory that no single file's budget notices. A breach makes the whole scan's
+	// symbol evidence untrustworthy, so it is reported rather than silently truncated.
+	if len(sc.localUses) >= maxLocalUsesPerScan {
+		sc.symbolCoverage = append(sc.symbolCoverage, modulegraph.CoverageIssue{
+			Kind:   modulegraph.CoverageSymbolEvidenceIncomplete,
+			Path:   modulePath,
+			Detail: "scan-wide local reference budget exceeded",
+		})
+		return
+	}
+	for _, use := range result.localUses {
+		sc.localUses = append(sc.localUses, modulegraph.LocalUse{
 			Module:   modulePath,
 			Local:    use.local,
 			Property: use.property,
 			Kind:     use.kind,
 			Detail:   use.detail,
-		}
-		if seen[record] {
-			continue
-		}
-		seen[record] = true
-		record.Line = use.line
-		sc.localUses = append(sc.localUses, record)
+			Line:     use.line,
+		})
 	}
 }
+
+// maxLocalUsesPerScan bounds symbol evidence across the whole scan.
+const maxLocalUsesPerScan = 2_000_000
 
 // keepImportedLocals drops references to locals that no import binds.
 //

--- a/internal/infrastructure/tools/jsimports/symbols.go
+++ b/internal/infrastructure/tools/jsimports/symbols.go
@@ -1,0 +1,287 @@
+package jsimports
+
+import "github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+
+// Tier-2 symbol observation.
+//
+// Tier-1 only needs to know THAT a module imports a package. Tier-2 needs to know which EXPORT is
+// reached, and for a whole-module binding (`const _ = require('lodash')`, `import * as _`) that is
+// knowable only if every reference to the local is an observable property read. This file records those
+// references. It deliberately over-reports: an unrecognised reference shape becomes an opaque use, which
+// downstream means "unknown", never "unused".
+
+// rawLocalUse is one observed reference to a local name, before the module path is known.
+type rawLocalUse struct {
+	local    string
+	property string
+	kind     modulegraph.LocalUseKind
+	detail   string
+	line     int
+}
+
+// historyLimit bounds the look-back window used to recover a CommonJS binding pattern. It is a fixed
+// cost per file and far longer than any real destructuring clause; a pattern that overruns it yields NO
+// bindings, which downstream reads as a whole-module binding — the conservative direction.
+const historyLimit = 128
+
+// jsKeywords are identifier-shaped tokens that are never a local binding. The lexer emits keywords and
+// numeric literals as tokenIdent, so without this list `if`, `return` and `42` would each be recorded as
+// a reference to a local of that name. That would be harmless noise for the join (no import binds them)
+// but it would also mean a genuine local named, say, `from` is treated inconsistently, so the list is
+// applied uniformly.
+var jsKeywords = map[string]bool{
+	"await": true, "break": true, "case": true, "catch": true, "class": true, "const": true,
+	"continue": true, "debugger": true, "default": true, "delete": true, "do": true, "else": true,
+	"enum": true, "export": true, "extends": true, "false": true, "finally": true, "for": true,
+	"function": true, "if": true, "implements": true, "import": true, "in": true, "instanceof": true,
+	"interface": true, "let": true, "new": true, "null": true, "package": true, "private": true,
+	"protected": true, "public": true, "return": true, "static": true, "super": true, "switch": true,
+	"this": true, "throw": true, "true": true, "try": true, "typeof": true, "var": true, "void": true,
+	"while": true, "with": true, "yield": true,
+	// TypeScript-only modifiers and type keywords that appear in positions a local never does.
+	"abstract": true, "as": true, "asserts": true, "declare": true, "is": true, "keyof": true,
+	"namespace": true, "readonly": true, "satisfies": true, "type": true, "infer": true,
+}
+
+// bindingKeywords introduce a name rather than reference one, so the identifier that follows is a
+// declaration site and not a use.
+var bindingKeywords = map[string]bool{
+	"const": true, "let": true, "var": true, "function": true, "class": true,
+	"interface": true, "enum": true, "namespace": true, "type": true,
+}
+
+// isLocalName reports whether t can name a local binding.
+func isLocalName(t token) bool {
+	if t.kind != tokenIdent || t.text == "" {
+		return false
+	}
+	if jsKeywords[t.text] {
+		return false
+	}
+	first := t.text[0]
+	if first >= '0' && first <= '9' {
+		return false
+	}
+	return true
+}
+
+// observeLocal records what the module does with one identifier occurrence.
+//
+// It is called for every identifier the main loop sees. Identifiers consumed inside an import clause
+// never reach it, which is exactly right: a binding site introduces the local, it does not use it.
+func (e *extractor) observeLocal(t, prev token, havePrev bool) {
+	if !isLocalName(t) {
+		return
+	}
+	// `a.b` — b is a property name, not a reference to a local called b. The member use was already
+	// recorded when a was seen.
+	if havePrev && prev.kind == tokenPunct && (prev.text == "." || prev.text == "?.") {
+		return
+	}
+	// `const x = ...`, `function x(...)`, `class x` — a declaration site.
+	if havePrev && prev.kind == tokenIdent && bindingKeywords[prev.text] {
+		return
+	}
+
+	next := e.peek()
+	if next.kind != tokenPunct {
+		e.addLocalUse(rawLocalUse{local: t.text, kind: modulegraph.LocalUseOpaque,
+			detail: "referenced without a property access", line: t.line})
+		return
+	}
+
+	switch next.text {
+	case ".", "?.":
+		dot := e.next()
+		prop := e.next()
+		// `a?.()` is an optional CALL, not a member read: the whole binding is invoked.
+		if isLocalName(prop) {
+			e.addLocalUse(rawLocalUse{local: t.text, property: prop.text,
+				kind: modulegraph.LocalUseProperty, line: t.line})
+		} else {
+			e.addLocalUse(rawLocalUse{local: t.text, kind: modulegraph.LocalUseOpaque,
+				detail: "member access with a non-identifier property", line: t.line})
+		}
+		// Restore the stream. push is LIFO, so the property goes back first.
+		e.push(prop)
+		e.push(dot)
+	case "[":
+		// `a[name]` can read ANY export, including the affected one.
+		e.addLocalUse(rawLocalUse{local: t.text, kind: modulegraph.LocalUseOpaque,
+			detail: "indexed with a computed key", line: t.line})
+	case "=":
+		// An assignment TARGET rebinds the name; it is not a read of the imported module. A declaration
+		// (`const x = require(...)`) also lands here and is likewise not a use.
+		return
+	case ":":
+		// An object literal key or a TypeScript type annotation position.
+		return
+	default:
+		// Passed as an argument, spread, returned, compared, awaited: the module object escapes.
+		e.addLocalUse(rawLocalUse{local: t.text, kind: modulegraph.LocalUseOpaque,
+			detail: "the binding escapes as a value", line: t.line})
+	}
+}
+
+func (e *extractor) addLocalUse(use rawLocalUse) {
+	if len(e.out.localUses) >= maxLocalUsesPerFile {
+		// The budget is a coverage issue, not a silent truncation: a dropped reference could be the one
+		// that reaches the affected symbol, so the whole file's symbol evidence becomes untrustworthy.
+		if !e.localUseBudgetHit {
+			e.localUseBudgetHit = true
+			e.addHazard(hazardUnsupportedLoader, use.line, "local reference budget exceeded")
+		}
+		return
+	}
+	e.out.localUses = append(e.out.localUses, use)
+}
+
+// maxLocalUsesPerFile bounds per-file symbol evidence. A file that overruns it degrades coverage rather
+// than contributing a partial reference list.
+const maxLocalUsesPerFile = 20000
+
+// commonJSBindings recovers the binding pattern of a `... = require('pkg')` declaration by looking back
+// over the tokens the main loop has already consumed.
+//
+// It returns nil when the pattern is anything it does not fully understand — a rest element, a default
+// value, a nested pattern, a bare call whose result is not bound. nil means "whole module bound
+// opaquely", which is the conservative reading: downstream, a require edge with no named bindings can
+// reach any export.
+func commonJSBindings(history []token) []modulegraph.Binding {
+	if len(history) == 0 {
+		return nil
+	}
+	last := history[len(history)-1]
+	if last.kind != tokenPunct || last.text != "=" {
+		// Not bound to anything this scanner can name: `foo(require('x'))`, `require('x').y`.
+		return nil
+	}
+	pattern := history[:len(history)-1]
+	if len(pattern) == 0 {
+		return nil
+	}
+
+	// A single identifier: `const ns = require('pkg')`.
+	if tail := pattern[len(pattern)-1]; isLocalName(tail) {
+		return []modulegraph.Binding{{Local: tail.text, Namespace: true}}
+	}
+
+	// A destructuring clause: `const { a, b: c } = require('pkg')`.
+	if closing := pattern[len(pattern)-1]; closing.kind != tokenPunct || closing.text != "}" {
+		return nil
+	}
+	open := -1
+	for i := len(pattern) - 2; i >= 0; i-- {
+		t := pattern[i]
+		if t.kind == tokenPunct && t.text == "}" {
+			// A nested pattern; not modelled.
+			return nil
+		}
+		if t.kind == tokenPunct && t.text == "{" {
+			open = i
+			break
+		}
+	}
+	if open < 0 {
+		return nil
+	}
+	return destructuredBindings(pattern[open+1 : len(pattern)-1])
+}
+
+// destructuredBindings parses the inside of `{ ... }`. Any element it does not fully understand aborts
+// the whole clause, because a partial binding list would look like a complete one.
+func destructuredBindings(inner []token) []modulegraph.Binding {
+	var out []modulegraph.Binding
+	i := 0
+	for i < len(inner) {
+		t := inner[i]
+		if t.kind == tokenPunct && t.text == "," {
+			i++
+			continue
+		}
+		if !isLocalName(t) {
+			return nil
+		}
+		binding := modulegraph.Binding{Imported: t.text, Local: t.text}
+		i++
+		if i < len(inner) && inner[i].kind == tokenPunct && inner[i].text == ":" {
+			i++
+			if i >= len(inner) || !isLocalName(inner[i]) {
+				return nil
+			}
+			binding.Local = inner[i].text
+			i++
+		}
+		// A default value (`{ a = fallback }`) or anything else is not modelled.
+		if i < len(inner) && !(inner[i].kind == tokenPunct && inner[i].text == ",") {
+			return nil
+		}
+		out = append(out, binding)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// recordHistory keeps the main loop's recent tokens. Only the main loop feeds it: tokens consumed inside
+// a recogniser are part of a construct that has already been interpreted, and mixing them in would make
+// the look-back window describe something other than the statement's left-hand side.
+func (e *extractor) recordHistory(t token) {
+	e.history = append(e.history, t)
+	if len(e.history) > historyLimit {
+		e.history = e.history[len(e.history)-historyLimit:]
+	}
+}
+
+// recordLocalUses attaches one file's local references to the graph, deduplicated.
+//
+// Deduplication is safe here and nowhere else: two identical (local, property, kind) references from the
+// same module carry the same evidence, so collapsing them cannot hide a distinct reference. The line is
+// dropped for a duplicate because the FIRST occurrence is the one a reader is pointed at.
+func (sc *scanState) recordLocalUses(modulePath string, uses []rawLocalUse) {
+	seen := make(map[modulegraph.LocalUse]bool, len(uses))
+	for _, use := range uses {
+		record := modulegraph.LocalUse{
+			Module:   modulePath,
+			Local:    use.local,
+			Property: use.property,
+			Kind:     use.kind,
+			Detail:   use.detail,
+		}
+		if seen[record] {
+			continue
+		}
+		seen[record] = true
+		record.Line = use.line
+		sc.localUses = append(sc.localUses, record)
+	}
+}
+
+// keepImportedLocals drops references to locals that no import binds.
+//
+// The observer records every identifier it sees, because at the time it sees one it does not yet know
+// which locals will turn out to be import bindings (a `require` can appear anywhere in the file). The
+// join downstream only ever looks up bindings, so the rest is noise — and on a large repository it is
+// noise measured in millions of records. Filtering here is a memory decision, not a semantic one: a
+// local no import binds could never have contributed evidence.
+func keepImportedLocals(imports []rawImport, uses []rawLocalUse) []rawLocalUse {
+	bound := map[string]bool{}
+	for _, imp := range imports {
+		for _, binding := range imp.bindings {
+			if binding.Local != "" {
+				bound[binding.Local] = true
+			}
+		}
+	}
+	if len(bound) == 0 {
+		return nil
+	}
+	kept := uses[:0]
+	for _, use := range uses {
+		if bound[use.local] {
+			kept = append(kept, use)
+		}
+	}
+	return kept
+}

--- a/internal/infrastructure/tools/jsimports/symbols_test.go
+++ b/internal/infrastructure/tools/jsimports/symbols_test.go
@@ -1,0 +1,241 @@
+package jsimports
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+)
+
+// usesFor indexes a module's local references by local name.
+func usesFor(graph modulegraph.Graph, module string) map[string][]modulegraph.LocalUse {
+	out := map[string][]modulegraph.LocalUse{}
+	for _, use := range graph.LocalUses {
+		if use.Module == module {
+			out[use.Local] = append(out[use.Local], use)
+		}
+	}
+	return out
+}
+
+func hasProperty(uses []modulegraph.LocalUse, property string) bool {
+	for _, use := range uses {
+		if use.Kind == modulegraph.LocalUseProperty && use.Property == property {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOpaque(uses []modulegraph.LocalUse) bool {
+	for _, use := range uses {
+		if use.Kind == modulegraph.LocalUseOpaque {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNamespaceMemberReadsAreObserved is the positive case Tier-2 depends on: a whole-module binding
+// whose every reference is a plain property read tells us exactly which exports are reached.
+func TestNamespaceMemberReadsAreObserved(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.ts"), `
+import * as lodash from "lodash";
+
+export function render(input) {
+  const compiled = lodash.template(input);
+  return lodash.escape(compiled);
+}
+`)
+	graph := scan(t, root)
+	uses := usesFor(graph, "src/a.ts")["lodash"]
+	if !hasProperty(uses, "template") || !hasProperty(uses, "escape") {
+		t.Fatalf("both property reads must be observed, got %+v", uses)
+	}
+	if hasOpaque(uses) {
+		t.Fatalf("a namespace used only through property reads must not be opaque, got %+v", uses)
+	}
+}
+
+// TestEscapingBindingsAreOpaque is the safety case: every one of these can reach ANY export, so none of
+// them may leave the analysis able to conclude a symbol is unused.
+func TestEscapingBindingsAreOpaque(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"passed as an argument", `register(lodash);`},
+		{"spread into an object", `const all = { ...lodash };`},
+		{"indexed with a computed key", `const fn = lodash[name];`},
+		{"returned", `export function get() { return lodash; }`},
+		{"assigned to another binding", `const alias = lodash;`},
+		{"invoked directly", `lodash();`},
+		{"awaited", `await lodash;`},
+		{"compared", `if (lodash) { report(); }`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "src", "a.ts"), "import * as lodash from \"lodash\";\n"+test.body+"\n")
+			graph := scan(t, root)
+			uses := usesFor(graph, "src/a.ts")["lodash"]
+			if !hasOpaque(uses) {
+				t.Fatalf("%s must make the binding opaque, got %+v", test.name, uses)
+			}
+		})
+	}
+}
+
+// TestCommonJSDestructuringYieldsNamedBindings locks the CommonJS half: `const {template} = require(...)`
+// names one export exactly, the same as an ESM named import.
+func TestCommonJSDestructuringYieldsNamedBindings(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.js"), `
+const { template, escape: esc } = require("lodash");
+module.exports = { template, esc };
+`)
+	graph := scan(t, root)
+	edge := mustEdge(t, graph, "src/a.js", "lodash")
+	got := map[string]string{}
+	for _, binding := range edge.Bindings {
+		got[binding.Imported] = binding.Local
+	}
+	if got["template"] != "template" || got["escape"] != "esc" {
+		t.Fatalf("destructured bindings = %+v, want template->template and escape->esc", edge.Bindings)
+	}
+	for _, binding := range edge.Bindings {
+		if binding.Namespace {
+			t.Fatalf("a destructured binding is not a namespace binding: %+v", binding)
+		}
+	}
+}
+
+func TestCommonJSWholeModuleBindingIsANamespace(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.js"), `
+const lodash = require("lodash");
+exports.run = (x) => lodash.template(x);
+`)
+	graph := scan(t, root)
+	edge := mustEdge(t, graph, "src/a.js", "lodash")
+	if len(edge.Bindings) != 1 || !edge.Bindings[0].Namespace || edge.Bindings[0].Local != "lodash" {
+		t.Fatalf("bindings = %+v, want one namespace binding for lodash", edge.Bindings)
+	}
+	if !hasProperty(usesFor(graph, "src/a.js")["lodash"], "template") {
+		t.Fatalf("the property read must be observed, got %+v", usesFor(graph, "src/a.js")["lodash"])
+	}
+}
+
+// A binding pattern this scanner does not model must yield NO bindings, which downstream reads as a
+// whole-module binding — never as "these are all the exports that are used".
+func TestUnmodelledCommonJSPatternsYieldNoBindings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct{ name, source string }{
+		{"rest element", `const { template, ...rest } = require("lodash");`},
+		{"default value", `const { template = fallback } = require("lodash");`},
+		{"nested pattern", `const { a: { b } } = require("lodash");`},
+		{"immediately invoked", `require("lodash")();`},
+		{"member read on the call", `const t = require("lodash").template;`},
+		{"passed straight on", `register(require("lodash"));`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, "src", "a.js"), test.source+"\n")
+			graph := scan(t, root)
+			edge := mustEdge(t, graph, "src/a.js", "lodash")
+			for _, binding := range edge.Bindings {
+				if binding.Imported != "" {
+					t.Fatalf("%s must not produce a named binding, got %+v", test.name, edge.Bindings)
+				}
+			}
+		})
+	}
+}
+
+// A property name must never be recorded as a reference to a local of the same name: `config.template`
+// says nothing about a local called template.
+func TestPropertyNamesAreNotLocalReferences(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.ts"), `
+import { template } from "lodash";
+const config = { template: 1 };
+report(config.template);
+`)
+	graph := scan(t, root)
+	for _, use := range graph.LocalUses {
+		if use.Local == "template" && use.Kind == modulegraph.LocalUseOpaque && use.Detail == "referenced without a property access" {
+			// `report(config.template)` must not have produced this; the only legitimate opaque use of
+			// `template` here would come from a bare reference, and there is none.
+			t.Fatalf("a property name was recorded as a local reference: %+v", use)
+		}
+	}
+}
+
+// Declaration sites introduce a name; they are not uses of it. Without this the local of every
+// `const x = require(...)` would immediately look like an escaping reference.
+func TestDeclarationSitesAreNotUses(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.js"), `
+const lodash = require("lodash");
+lodash.template("x");
+`)
+	graph := scan(t, root)
+	uses := usesFor(graph, "src/a.js")["lodash"]
+	if hasOpaque(uses) {
+		t.Fatalf("the declaration site must not count as an escaping use, got %+v", uses)
+	}
+	if !hasProperty(uses, "template") {
+		t.Fatalf("the property read must still be observed, got %+v", uses)
+	}
+}
+
+// Symbol observation must not disturb import extraction: the same file's edges are still found.
+func TestSymbolObservationDoesNotDisturbImportExtraction(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.tsx"), `
+import * as lodash from "lodash";
+import React from "react";
+import { helper } from "./helper";
+
+export const App = () => <div onClick={() => lodash.template(helper())} />;
+`)
+	writeFile(t, filepath.Join(root, "src", "helper.ts"), `export function helper() { return "x"; }`)
+	graph := scan(t, root)
+	for _, specifier := range []string{"lodash", "react", "./helper"} {
+		mustEdge(t, graph, "src/a.tsx", specifier)
+	}
+	if len(graph.Coverage) != 0 {
+		t.Fatalf("this file has no unobservable construct, got coverage %+v", graph.Coverage)
+	}
+}
+
+// mustEdge returns the edge for a specifier, failing the test when it is absent.
+func mustEdge(t *testing.T, graph modulegraph.Graph, from, specifier string) modulegraph.Edge {
+	t.Helper()
+	edge, ok := edgeFor(graph, from, specifier)
+	if !ok {
+		t.Fatalf("no edge from %s for %q", from, specifier)
+	}
+	return edge
+}

--- a/internal/infrastructure/tools/jsimports/symbols_test.go
+++ b/internal/infrastructure/tools/jsimports/symbols_test.go
@@ -2,6 +2,7 @@ package jsimports
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
@@ -10,7 +11,7 @@ import (
 // usesFor indexes a module's local references by local name.
 func usesFor(graph modulegraph.Graph, module string) map[string][]modulegraph.LocalUse {
 	out := map[string][]modulegraph.LocalUse{}
-	for _, use := range graph.LocalUses {
+	for _, use := range graph.SymbolEvidence.Uses {
 		if use.Module == module {
 			out[use.Local] = append(out[use.Local], use)
 		}
@@ -179,7 +180,7 @@ const config = { template: 1 };
 report(config.template);
 `)
 	graph := scan(t, root)
-	for _, use := range graph.LocalUses {
+	for _, use := range graph.SymbolEvidence.Uses {
 		if use.Local == "template" && use.Kind == modulegraph.LocalUseOpaque && use.Detail == "referenced without a property access" {
 			// `report(config.template)` must not have produced this; the only legitimate opaque use of
 			// `template` here would come from a bare reference, and there is none.
@@ -238,4 +239,133 @@ func mustEdge(t *testing.T, graph modulegraph.Graph, from, specifier string) mod
 		t.Fatalf("no edge from %s for %q", from, specifier)
 	}
 	return edge
+}
+
+// TestLocalReExportIsRecordedAsEscaping is the regression for the worst hole found in review: the
+// identifiers of a `from`-less export clause are consumed by the clause reader, so they never reach the
+// observer. `import * as _; export { _ }` republishes the ENTIRE package to every consumer, and
+// recording nothing made that module look like it used no export at all.
+func TestLocalReExportIsRecordedAsEscaping(t *testing.T) {
+	t.Parallel()
+
+	for _, source := range []string{
+		"import * as lodash from \"lodash\";\nexport { lodash };\n",
+		"import * as lodash from \"lodash\";\nexport { lodash as l };\n",
+		"import * as lodash from \"lodash\";\nexport { lodash as default };\n",
+	} {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "src", "a.ts"), source)
+		graph := scan(t, root)
+		if !hasOpaque(usesFor(graph, "src/a.ts")["lodash"]) {
+			t.Fatalf("re-exporting a namespace must be recorded as escaping:\n%s\ngot %+v",
+				source, usesFor(graph, "src/a.ts")["lodash"])
+		}
+	}
+}
+
+// TestTernaryConsequentIsAReadNotAKey: an identifier followed by ":" is an object key OR a type
+// annotation OR the consequent of a conditional. Treating them all as keys lost the read.
+func TestTernaryConsequentIsAReadNotAKey(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "a.ts"), `
+import * as lodash from "lodash";
+const lib = useReal ? lodash : stubs;
+lodash.map(xs);
+`)
+	graph := scan(t, root)
+	if !hasOpaque(usesFor(graph, "src/a.ts")["lodash"]) {
+		t.Fatalf("a ternary consequent is an escaping read, got %+v", usesFor(graph, "src/a.ts")["lodash"])
+	}
+
+	// A genuine object key must still not be a reference.
+	root2 := t.TempDir()
+	writeFile(t, filepath.Join(root2, "src", "b.ts"), `
+import * as lodash from "lodash";
+const table = { lodash: 1, other: 2 };
+lodash.map(xs);
+`)
+	graph2 := scan(t, root2)
+	if hasOpaque(usesFor(graph2, "src/b.ts")["lodash"]) {
+		t.Fatalf("an object literal key is not a reference, got %+v", usesFor(graph2, "src/b.ts")["lodash"])
+	}
+}
+
+// TestJSXIsDetectedByContentNotExtension: JSX in .js is routine under Babel, CRA and Next, and JSX
+// desugars into calls on the runtime binding that never appear as source tokens.
+func TestJSXIsDetectedByContentNotExtension(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "App.js"), `
+import React from "react";
+export default function App() {
+  const [n] = React.useState(0);
+  return <div>{n}</div>;
+}
+`)
+	writeFile(t, filepath.Join(root, "src", "plain.js"), `
+import React from "react";
+export const value = React.version;
+`)
+	graph := scan(t, root)
+	jsx := map[string]bool{}
+	for _, module := range graph.SymbolEvidence.JSXModules {
+		jsx[module] = true
+	}
+	if !jsx["src/App.js"] {
+		t.Fatalf("a .js file containing JSX must be reported as a JSX module, got %v", graph.SymbolEvidence.JSXModules)
+	}
+	if jsx["src/plain.js"] {
+		t.Fatalf("a .js file with no JSX must not be, got %v", graph.SymbolEvidence.JSXModules)
+	}
+}
+
+// TestMemberAssignmentIsNotALocalBinding: `exports.lodash = require('lodash')` publishes the whole
+// module somewhere unobservable. Recording `lodash` as a local made that escape look like a binding
+// nothing reads.
+func TestMemberAssignmentIsNotALocalBinding(t *testing.T) {
+	t.Parallel()
+
+	for _, source := range []string{
+		`exports.lodash = require("lodash");`,
+		`module.exports.lodash = require("lodash");`,
+		`this.lodash = require("lodash");`,
+		`const settings = require("lodash").templateSettings;`,
+		`const fn = require("lodash")();`,
+	} {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "src", "a.js"), source+"\n")
+		graph := scan(t, root)
+		edge := mustEdge(t, graph, "src/a.js", "lodash")
+		if len(edge.Bindings) != 0 {
+			t.Fatalf("%s must bind nothing this scanner can follow, got %+v", source, edge.Bindings)
+		}
+	}
+}
+
+// A benign file that repeats one reference many times must not exhaust the symbol budget: the budget
+// counts distinct evidence, and charging occurrences would declare ordinary code unobservable — and
+// worse, would refuse the Tier-1 answer, which is unaffected by a Tier-2 limitation.
+func TestRepeatedReferencesDoNotExhaustTheSymbolBudget(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	b.WriteString("const lodash = require(\"lodash\");\n")
+	for i := 0; i < 25000; i++ {
+		b.WriteString("lodash.merge;\n")
+	}
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "big.js"), b.String())
+	graph := scan(t, root)
+	if len(graph.Coverage) != 0 {
+		t.Fatalf("a tier-2 budget must never degrade the import graph's coverage, got %+v", graph.Coverage)
+	}
+	if !graph.SymbolEvidence.Complete() {
+		t.Fatalf("25000 identical references are one piece of evidence, got %+v", graph.SymbolEvidence.Coverage)
+	}
+	if !hasProperty(usesFor(graph, "src/big.js")["lodash"], "merge") {
+		t.Fatal("the property read must still be observed")
+	}
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -295,6 +295,12 @@ type Config struct {
 	// lifecycle (SYNAPSE_JUDGMENTS_ENABLED).
 	JSReachabilityEnabled bool
 
+	// JSSymbolReachabilityEnabled turns on the TIER-2 JavaScript/TypeScript pass: not "is this package
+	// imported" but "is the affected EXPORT reached". It is a strictly stronger and strictly more
+	// dangerous claim — a wrong negative suppresses a real vulnerability — so it is separately gated and
+	// refuses to answer whenever a binding escapes observation.
+	JSSymbolReachabilityEnabled bool
+
 	// RustReachabilityEnabled, PHPReachabilityEnabled and RubyReachabilityEnabled turn on deterministic
 	// Tier-1 import-reachability for those ecosystems: a declared dependency that first-party source
 	// never references becomes not_reachable, which the export path turns into an OpenVEX not_affected
@@ -492,6 +498,7 @@ func Load() Config {
 		ReachabilityEnabled:          getbool("SYNAPSE_REACHABILITY_ENABLED", true),
 		PyReachabilityEnabled:        getbool("SYNAPSE_PYREACH_ENABLED", false),
 		JSReachabilityEnabled:        getbool("SYNAPSE_JSREACH_ENABLED", false),
+		JSSymbolReachabilityEnabled:  getbool("SYNAPSE_JSREACH_TIER2_ENABLED", false),
 		RustReachabilityEnabled:      getbool("SYNAPSE_REACH_RUST", false),
 		PHPReachabilityEnabled:       getbool("SYNAPSE_REACH_PHP", false),
 		RubyReachabilityEnabled:      getbool("SYNAPSE_REACH_RUBY", false),

--- a/internal/usecase/jsreach/analyzer.go
+++ b/internal/usecase/jsreach/analyzer.go
@@ -126,7 +126,7 @@ func (a *Analyzer) Analyze(ctx context.Context, dir string, subjects []string) (
 	// first-party source could import DIRECTLY. Either gap makes a negative meaningless: an absent
 	// component means the subject came from a different document, and a transitive package is loaded by
 	// its parent rather than by this source tree.
-	if err := a.assertSubjectsAnswerable(wanted, doc, resolution); err != nil {
+	if err := subjectsAnswerable(wanted, doc, resolution); err != nil {
 		return nil, err
 	}
 
@@ -167,7 +167,7 @@ func (a *Analyzer) Analyze(ctx context.Context, dir string, subjects []string) (
 // and be sealed as not-reachable. Without the second, a transitive package — the majority of npm
 // findings — would be declared unreachable merely because the first-party graph never names it, which is
 // true of every transitive package and proves nothing.
-func (a *Analyzer) assertSubjectsAnswerable(subjects []string, doc *sbom.SBOM, resolution jsresolution.Result) error {
+func subjectsAnswerable(subjects []string, doc *sbom.SBOM, resolution jsresolution.Result) error {
 	inSBOM := make(map[string]bool, len(doc.Components))
 	for _, component := range doc.Components {
 		if canonical, ok := jsresolution.CanonicalNPMPURL(component.PURL); ok {
@@ -413,7 +413,7 @@ func (a *Analyzer) answerableSubjects(ctx context.Context, dir string, subjects 
 	for _, subject := range subjects {
 		symbols := make([]string, 0, len(subject.Symbols))
 		for _, symbol := range subject.Symbols {
-			if a.assertSubjectsAnswerable([]string{symbol}, doc, resolution) == nil {
+			if subjectsAnswerable([]string{symbol}, doc, resolution) == nil {
 				symbols = append(symbols, symbol)
 			}
 		}

--- a/internal/usecase/jsreach/symbolrecorder.go
+++ b/internal/usecase/jsreach/symbolrecorder.go
@@ -1,0 +1,71 @@
+package jsreach
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachproof"
+)
+
+// SymbolRecorder runs the Tier-2 JavaScript pass and promotes its results through the existing judgment
+// gate, minting Tier-2 claims.
+//
+// The tier is honest per analyzer. A Tier-1 import proof answers "is this package used at all"; this
+// answers "is this affected export reached", which is a strictly stronger statement, so it is minted at
+// Tier-2 and supersedes the Tier-1 judgment for the same subject under the existing stronger-tier-wins
+// rule. It is NOT inflated further: this is a binding-and-property-read proof over a first-party module
+// graph, not an interprocedural call graph, and the sealed rationale says so.
+type SymbolRecorder struct {
+	scanner   importScanner
+	resolver  importResolver
+	judgments recorderPort
+	audit     ports.AuditLogger
+	clock     ports.Clock
+}
+
+// NewSymbolRecorder validates and returns the Tier-2 recorder.
+func NewSymbolRecorder(scanner importScanner, resolver importResolver, judgments recorderPort, audit ports.AuditLogger, clock ports.Clock) (*SymbolRecorder, error) {
+	if scanner == nil || resolver == nil || judgments == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: jsreach symbol recorder is missing a dependency", shared.ErrValidation)
+	}
+	return &SymbolRecorder{scanner: scanner, resolver: resolver, judgments: judgments, audit: audit, clock: clock}, nil
+}
+
+// RecordWithSBOM analyses the target against doc and mints Tier-2 JavaScript reachability judgments.
+//
+// The SBOM is handed over rather than re-derived, for the same reason as Tier-1: a component PURL is
+// only meaningful relative to one document, and regenerating it could legitimately produce different
+// identities, at which point every subject would miss and be sealed as not-reachable.
+//
+// Subjects the analyzer cannot answer — a transitive package, one absent from this document, or an
+// export whose reachability is UNKNOWN because something escaped observation — are DROPPED before
+// minting. The coordinator mints a claim for every subject it is given and reads "no result" as
+// not-reachable, so an unanswerable subject must never reach it: dropping leaves the Tier-1 judgment
+// standing, while passing it through would seal a false negative at full confidence.
+func (r *SymbolRecorder) RecordWithSBOM(ctx context.Context, engagementID shared.ID, targetRef string, doc *sbom.SBOM, subjects []ports.ReachabilitySubject) (int, error) {
+	if doc == nil {
+		return 0, fmt.Errorf("%w: jsreach symbol recorder needs the sbom the subjects were minted from", shared.ErrValidation)
+	}
+	analyzer, err := NewSymbolAnalyzer(r.scanner, r.resolver, staticSBOM{doc: doc})
+	if err != nil {
+		return 0, err
+	}
+
+	answerable, err := analyzer.answerableSymbolSubjects(ctx, targetRef, subjects)
+	if err != nil {
+		return 0, err
+	}
+	if len(answerable) == 0 {
+		return 0, nil
+	}
+
+	coordinator, err := reachproof.NewCoordinatorForTier(analyzer, r.judgments, r.audit, r.clock, judgment.Tier2)
+	if err != nil {
+		return 0, err
+	}
+	return coordinator.Record(ctx, engagementID, targetRef, answerable)
+}

--- a/internal/usecase/jsreach/symbolrecorder.go
+++ b/internal/usecase/jsreach/symbolrecorder.go
@@ -63,7 +63,7 @@ func (r *SymbolRecorder) RecordWithSBOM(ctx context.Context, engagementID shared
 		return 0, nil
 	}
 
-	coordinator, err := reachproof.NewCoordinatorForTier(analyzer, r.judgments, r.audit, r.clock, judgment.Tier2)
+	coordinator, err := reachproof.NewCoordinatorForLanguage(analyzer, r.judgments, r.audit, r.clock, judgment.Tier2, reachproof.LanguageJavaScript)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/usecase/jsreach/symbolrecorder_test.go
+++ b/internal/usecase/jsreach/symbolrecorder_test.go
@@ -1,0 +1,121 @@
+package jsreach
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// symbolRecorderFor wires a Tier-2 recorder over a one-module fixture.
+func symbolRecorderFor(t *testing.T, graph modulegraph.Graph, result jsresolution.Result) (*SymbolRecorder, *fakeJudgments, *sbom.SBOM) {
+	t.Helper()
+	result.Complete = true
+	result.DeclaredDependencies = append(result.DeclaredDependencies, "lodash")
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "lodash", Version: "4.17.15", PURL: lodashPURL}}}
+
+	judgments := &fakeJudgments{}
+	r, err := NewSymbolRecorder(fakeScanner{graph: graph}, fakeResolver{result: result}, judgments, fakeAudit{}, fixedClock{})
+	if err != nil {
+		t.Fatalf("new symbol recorder: %v", err)
+	}
+	return r, judgments, doc
+}
+
+// TestSymbolRecorderAttributesToTheSymbolEngine is the regression for a Tier-2 JavaScript proof being
+// sealed as a Go CALL-GRAPH proof.
+//
+// Tier-2 is a strength of claim, not an engine: two different engines reach it. A sealed rationale that
+// named the wrong one would make this module-graph proof indistinguishable from an interprocedural one
+// in the report and in the audit trail, which is exactly what the reserved identities exist to prevent.
+func TestSymbolRecorderAttributesToTheSymbolEngine(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{namedEdge("src/a.ts", "template")}, nil)
+	r, judgments, doc := symbolRecorderFor(t, graph, result)
+
+	minted, err := r.RecordWithSBOM(context.Background(), "eng1", "/ws", doc, []ports.ReachabilitySubject{
+		{FindingID: "f1", Symbols: []string{mustSubject(t, lodashPURL, "template")}},
+	})
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if minted != 1 || len(judgments.minted) != 1 {
+		t.Fatalf("expected exactly one judgment, got minted=%d recorded=%d", minted, len(judgments.minted))
+	}
+	got := judgments.minted[0]
+	if got.proposer != "system:jssymbol-scan" {
+		t.Fatalf("proposer = %q, want the javascript affected-export engine, not the call-graph one", got.proposer)
+	}
+	if got.verifier != "system:jssymbol-engine" {
+		t.Fatalf("verifier = %q, want the javascript affected-export engine", got.verifier)
+	}
+	if got.proposer == got.verifier {
+		t.Fatal("proposer and verifier must be distinct so a proof never self-confirms")
+	}
+	if got.claim.Tier != judgment.Tier2 {
+		t.Fatalf("tier = %q, want tier-2: an affected-export answer is stronger than an import answer", got.claim.Tier)
+	}
+	if got.claim.Reachable != judgment.Reachable {
+		t.Fatalf("claim = %+v, want reachable", got.claim)
+	}
+}
+
+// A subject the analyzer cannot answer must be DROPPED before minting, not sealed as not-reachable.
+func TestSymbolRecorderDropsUnanswerableSubjects(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts",
+		[]modulegraph.Edge{namespaceEdge("src/a.ts", "_")},
+		[]modulegraph.LocalUse{
+			{Module: "src/a.ts", Local: "_", Kind: modulegraph.LocalUseOpaque, Detail: "the binding escapes as a value"},
+		})
+	r, judgments, doc := symbolRecorderFor(t, graph, result)
+
+	minted, err := r.RecordWithSBOM(context.Background(), "eng1", "/ws", doc, []ports.ReachabilitySubject{
+		{FindingID: "f1", Symbols: []string{mustSubject(t, lodashPURL, "template")}},
+	})
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if minted != 0 || len(judgments.minted) != 0 {
+		t.Fatalf("an unanswerable subject must mint nothing, got %d", minted)
+	}
+}
+
+// No coverage anywhere in the graph means nothing is minted at all: the prior tier stands.
+func TestSymbolRecorderMintsNothingWhenCoverageIsIncomplete(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{namedEdge("src/a.ts", "template")}, nil)
+	graph.Coverage = []modulegraph.CoverageIssue{{Kind: modulegraph.CoverageEval, Path: "src/a.ts"}}
+	r, judgments, doc := symbolRecorderFor(t, graph, result)
+
+	if _, err := r.RecordWithSBOM(context.Background(), "eng1", "/ws", doc, []ports.ReachabilitySubject{
+		{FindingID: "f1", Symbols: []string{mustSubject(t, lodashPURL, "template")}},
+	}); err == nil {
+		t.Fatal("a coverage issue must abort the pass rather than mint a judgment")
+	}
+	if len(judgments.minted) != 0 {
+		t.Fatalf("nothing may be minted from an incomplete scan, got %d", len(judgments.minted))
+	}
+}
+
+func TestSymbolRecorderValidatesDependencies(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewSymbolRecorder(nil, fakeResolver{}, &fakeJudgments{}, fakeAudit{}, fixedClock{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil scanner must be rejected, got %v", err)
+	}
+	graph, result := graphWith("src/a.ts", nil, nil)
+	r, _, _ := symbolRecorderFor(t, graph, result)
+	if _, err := r.RecordWithSBOM(context.Background(), "eng1", "/ws", nil, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("recording without the sbom the subjects were minted from must be refused, got %v", err)
+	}
+}

--- a/internal/usecase/jsreach/symbols.go
+++ b/internal/usecase/jsreach/symbols.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/jssymbols"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachability"
@@ -34,6 +35,13 @@ type SymbolAnalyzer struct {
 	scanner  importScanner
 	resolver importResolver
 	sboms    sbomProvider
+	// cached is this analyzer's ONE view of the target. The analyzer is constructed per pass, so
+	// memoising here does two things: it removes three redundant full lexes of the source tree, and it
+	// guarantees the subject filter and the verdict are computed from the SAME snapshot — otherwise a
+	// subject admitted as answerable could be decided on evidence that changed underneath it.
+	cached    *symbolEvidence
+	cachedDir string
+	cachedErr error
 }
 
 // NewSymbolAnalyzer validates and returns the Tier-2 analyzer.
@@ -62,7 +70,7 @@ func (a *SymbolAnalyzer) Analyze(ctx context.Context, dir string, subjects []str
 		return &reachability.Analysis{}, nil
 	}
 
-	evidence, err := a.gather(ctx, dir)
+	evidence, err := a.evidenceFor(ctx, dir)
 	if err != nil {
 		return nil, err
 	}
@@ -78,11 +86,14 @@ func (a *SymbolAnalyzer) Analyze(ctx context.Context, dir string, subjects []str
 		}
 		seen[subject] = true
 
-		purl, symbol, ok := jsresolution.ParseNPMSymbolSubject(subject)
+		purl, symbol, ok := jssymbols.ParseSubject(subject)
 		if !ok {
 			return nil, fmt.Errorf("%w: jsreach symbol subject %q is not a component purl with an export", shared.ErrValidation, subject)
 		}
-		canonical, _ := jsresolution.CanonicalNPMPURL(purl)
+		canonical, ok := jsresolution.CanonicalNPMPURL(purl)
+		if !ok {
+			return nil, fmt.Errorf("%w: jsreach symbol subject %q does not carry a canonical component identity", shared.ErrValidation, subject)
+		}
 		decision := jssymbols.Decide(symbol, evidence.uses[canonical])
 
 		result := reachability.Result{Symbol: subject}
@@ -107,11 +118,24 @@ func (a *SymbolAnalyzer) Analyze(ctx context.Context, dir string, subjects []str
 	return &reachability.Analysis{Results: results, Entrypoints: roots}, nil
 }
 
-// symbolEvidence is one scan's Tier-2 view: what every module does with every imported package.
+// symbolEvidence is one scan's Tier-2 view: what every module does with every imported package, plus
+// the document and resolution the subjects must be checked against.
 type symbolEvidence struct {
-	uses   map[string][]jssymbols.Use
-	prover *pathProver
-	roots  []string
+	uses       map[string][]jssymbols.Use
+	prover     *pathProver
+	roots      []string
+	doc        *sbom.SBOM
+	resolution jsresolution.Result
+}
+
+// evidenceFor returns the analyzer's single view of dir, computing it at most once.
+func (a *SymbolAnalyzer) evidenceFor(ctx context.Context, dir string) (symbolEvidence, error) {
+	if a.cached != nil && a.cachedDir == dir {
+		return *a.cached, a.cachedErr
+	}
+	evidence, err := a.gather(ctx, dir)
+	a.cached, a.cachedDir, a.cachedErr = &evidence, dir, err
+	return evidence, err
 }
 
 // gather scans, resolves and joins. It refuses — returning a no-coverage error that leaves any prior
@@ -145,26 +169,38 @@ func (a *SymbolAnalyzer) gather(ctx context.Context, dir string) (symbolEvidence
 			shared.ErrValidation, len(resolution.GraphCoverage))
 	}
 
+	// The symbol evidence is a SEPARATE completeness question from the import graph's. A nil evidence
+	// block means it was never collected, and a coverage entry means some module's references could not
+	// be enumerated; in both cases "no reference to this export" is not a fact.
+	if !graph.SymbolEvidence.Complete() {
+		return symbolEvidence{}, fmt.Errorf("%w: symbol evidence is incomplete - javascript symbol reachability is inconclusive (no coverage)",
+			shared.ErrValidation)
+	}
+
 	declarationOnly := make(map[string]bool, len(graph.Modules))
-	dialects := make(map[string]modulegraph.Dialect, len(graph.Modules))
 	for _, module := range graph.Modules {
 		if module.DeclarationOnly {
 			declarationOnly[module.Path] = true
 		}
-		dialects[module.Path] = module.Dialect
+	}
+	jsx := make(map[string]bool, len(graph.SymbolEvidence.JSXModules))
+	for _, module := range graph.SymbolEvidence.JSXModules {
+		jsx[module] = true
 	}
 
 	return symbolEvidence{
-		uses:   collectSymbolUses(graph, resolution, declarationOnly, dialects),
-		prover: newPathProver(graph, declarationOnly),
-		roots:  graph.Roots,
+		uses:       collectSymbolUses(graph, resolution, declarationOnly, jsx),
+		prover:     newPathProver(graph, declarationOnly),
+		roots:      graph.Roots,
+		doc:        doc,
+		resolution: resolution,
 	}, nil
 }
 
 // collectSymbolUses joins the import edges (which name the package and the local bindings) with the
 // module's own references to those locals (which name the exports actually read).
 func collectSymbolUses(graph modulegraph.Graph, resolution jsresolution.Result,
-	declarationOnly map[string]bool, dialects map[string]modulegraph.Dialect) map[string][]jssymbols.Use {
+	declarationOnly map[string]bool, jsx map[string]bool) map[string][]jssymbols.Use {
 	// Index the resolved package identity by (module, specifier); an edge carries the specifier, the
 	// resolution carries the PURL.
 	purlOf := make(map[[2]string]string, len(resolution.Imports))
@@ -181,8 +217,8 @@ func collectSymbolUses(graph modulegraph.Graph, resolution jsresolution.Result,
 	}
 
 	// Index the module's references to its locals.
-	localUses := make(map[[2]string][]modulegraph.LocalUse, len(graph.LocalUses))
-	for _, use := range graph.LocalUses {
+	localUses := make(map[[2]string][]modulegraph.LocalUse, len(graph.SymbolEvidence.Uses))
+	for _, use := range graph.SymbolEvidence.Uses {
 		key := [2]string{use.Module, use.Local}
 		localUses[key] = append(localUses[key], use)
 	}
@@ -220,7 +256,11 @@ func collectSymbolUses(graph modulegraph.Graph, resolution jsresolution.Result,
 			if binding.TypeOnly {
 				continue
 			}
-			if binding.Imported != "" && !binding.Namespace && !binding.Default {
+			// A binding whose imported name is literally "default" binds the module's default export,
+			// which for a CommonJS package IS the module object — `const {default: axios} =
+			// require('axios')` then reaches every export through it. The Default FLAG is not set on that
+			// shape, so the name has to be tested too.
+			if binding.Imported != "" && binding.Imported != "default" && !binding.Namespace && !binding.Default {
 				add(jssymbols.Use{Module: edge.From, PURL: purl, Symbol: binding.Imported, Kind: jssymbols.UseNamed})
 				continue
 			}
@@ -235,12 +275,26 @@ func collectSymbolUses(graph modulegraph.Graph, resolution jsresolution.Result,
 			// JSX desugars into calls on the runtime binding — createElement, jsx, Fragment — that this
 			// scanner never sees as source tokens, so a whole-module binding in a JSX module cannot be
 			// enumerated by its visible property reads.
-			if dialect := dialects[edge.From]; dialect == modulegraph.DialectJSX || dialect == modulegraph.DialectTSX {
+			// The test is whether the module ACTUALLY contains JSX, not what its extension is: JSX is
+			// routine in .js under Babel, CRA and Next, and keying on the extension would leave every
+			// such module narrowable by its visible property reads alone.
+			if jsx[edge.From] {
 				add(jssymbols.Use{Module: edge.From, PURL: purl, Kind: jssymbols.UseOpaque,
 					Reason: "the module contains JSX, which desugars into calls this scanner does not observe"})
 				continue
 			}
-			for _, use := range localUses[[2]string{edge.From, local}] {
+			references := localUses[[2]string{edge.From, local}]
+			if len(references) == 0 {
+				// "Every reference was enumerated and none names this export" and "the binding was never
+				// mentioned again" are different facts, and only the first permits a negative. A
+				// whole-module binding with no observed reference is therefore opaque, not silence:
+				// otherwise a second module's named import would be the only evidence and would decide
+				// the verdict for a package this module holds in full.
+				add(jssymbols.Use{Module: edge.From, PURL: purl, Kind: jssymbols.UseOpaque,
+					Reason: "no reference to the whole-module binding was enumerated"})
+				continue
+			}
+			for _, use := range references {
 				switch use.Kind {
 				case modulegraph.LocalUseProperty:
 					add(jssymbols.Use{Module: edge.From, PURL: purl, Symbol: use.Property, Kind: jssymbols.UseMember})
@@ -295,39 +349,32 @@ func (p *pathProver) proofForModules(modules []string, symbol, subject string) [
 // missing result as not-reachable, so an unanswerable subject reaching it would be sealed as a false
 // negative at full confidence.
 func (a *SymbolAnalyzer) answerableSymbolSubjects(ctx context.Context, dir string, subjects []ports.ReachabilitySubject) ([]ports.ReachabilitySubject, error) {
-	doc, err := a.sboms.SBOMFor(ctx, dir)
-	if err != nil {
-		return nil, fmt.Errorf("jsreach: sbom unavailable (no coverage - prior tier stands): %w", err)
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: jsreach symbol analysis requires a context", shared.ErrValidation)
 	}
-	if doc == nil {
-		return nil, fmt.Errorf("%w: jsreach has no sbom for the target (no coverage)", shared.ErrNotFound)
-	}
-	evidence, err := a.gather(ctx, dir)
+	evidence, err := a.evidenceFor(ctx, dir)
 	if err != nil {
 		return nil, err
 	}
-	graph, err := a.scanner.Scan(ctx, dir)
-	if err != nil {
-		return nil, fmt.Errorf("jsreach: javascript import scan (no coverage - prior tier stands): %w", err)
-	}
-	resolution, err := a.resolver.Resolve(ctx, dir, graph, doc)
-	if err != nil {
-		return nil, fmt.Errorf("jsreach: package resolution (no coverage - prior tier stands): %w", err)
-	}
-	gate := &Analyzer{scanner: a.scanner, resolver: a.resolver, sboms: a.sboms}
 
 	out := make([]ports.ReachabilitySubject, 0, len(subjects))
 	for _, subject := range subjects {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		symbols := make([]string, 0, len(subject.Symbols))
 		for _, raw := range subject.Symbols {
-			purl, symbol, ok := jsresolution.ParseNPMSymbolSubject(raw)
+			purl, symbol, ok := jssymbols.ParseSubject(raw)
 			if !ok {
 				continue
 			}
-			if gate.assertSubjectsAnswerable([]string{purl}, doc, resolution) != nil {
+			if subjectsAnswerable([]string{purl}, evidence.doc, evidence.resolution) != nil {
 				continue
 			}
-			canonical, _ := jsresolution.CanonicalNPMPURL(purl)
+			canonical, ok := jsresolution.CanonicalNPMPURL(purl)
+			if !ok {
+				continue
+			}
 			if jssymbols.Decide(symbol, evidence.uses[canonical]).Verdict == jssymbols.VerdictUnknown {
 				continue
 			}

--- a/internal/usecase/jsreach/symbols.go
+++ b/internal/usecase/jsreach/symbols.go
@@ -1,0 +1,341 @@
+package jsreach
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jssymbols"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachability"
+)
+
+// SymbolAnalyzer answers the Tier-2 question: does first-party source reach a SPECIFIC affected export
+// of an imported npm package?
+//
+// It is strictly narrower than Tier-1 and strictly more dangerous. Concluding that a package is imported
+// but its vulnerable export is never touched SUPPRESSES a real vulnerability if the analysis missed one
+// reference, so the rules are arranged so that anything unobservable produces UNKNOWN — which the caller
+// drops, leaving the weaker Tier-1 judgment standing — rather than a negative.
+//
+// The evidence is the import binding plus what the module then does with it:
+//
+//   - a named import binds one export exactly (`import {template} from 'lodash'`);
+//   - a whole-module binding (`import * as _`, a default import, `const _ = require(...)`) reaches an
+//     export only through an observable property read, so it is answerable only when EVERY reference to
+//     that local was seen — one escaping reference and the package becomes unanswerable;
+//   - a re-export republishes the whole module, and a JSX module desugars into calls this scanner does
+//     not see, so both are treated as escaping.
+type SymbolAnalyzer struct {
+	scanner  importScanner
+	resolver importResolver
+	sboms    sbomProvider
+}
+
+// NewSymbolAnalyzer validates and returns the Tier-2 analyzer.
+func NewSymbolAnalyzer(scanner importScanner, resolver importResolver, sboms sbomProvider) (*SymbolAnalyzer, error) {
+	if scanner == nil || resolver == nil || sboms == nil {
+		return nil, fmt.Errorf("%w: jsreach symbol analyzer needs a scanner, a resolver and an sbom provider", shared.ErrValidation)
+	}
+	return &SymbolAnalyzer{scanner: scanner, resolver: resolver, sboms: sboms}, nil
+}
+
+// Analyze reports, for each `pkg:npm/name@version#symbol` subject, whether first-party source reaches
+// that export.
+//
+// Every subject reaching this point has already been filtered by answerableSubjects, so a subject whose
+// verdict is unknown must not appear here. If one does it is reported as REACHABLE rather than not:
+// over-approximating toward reachable is the acceptable error, and the coordinator reads a missing
+// result as not-reachable.
+func (a *SymbolAnalyzer) Analyze(ctx context.Context, dir string, subjects []string) (*reachability.Analysis, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: jsreach symbol analysis requires a context", shared.ErrValidation)
+	}
+	if strings.TrimSpace(dir) == "" {
+		return nil, fmt.Errorf("%w: jsreach symbol analysis requires a target directory", shared.ErrValidation)
+	}
+	if len(subjects) == 0 {
+		return &reachability.Analysis{}, nil
+	}
+
+	evidence, err := a.gather(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]reachability.Result, 0, len(subjects))
+	seen := make(map[string]bool, len(subjects))
+	for _, subject := range subjects {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if seen[subject] {
+			continue
+		}
+		seen[subject] = true
+
+		purl, symbol, ok := jsresolution.ParseNPMSymbolSubject(subject)
+		if !ok {
+			return nil, fmt.Errorf("%w: jsreach symbol subject %q is not a component purl with an export", shared.ErrValidation, subject)
+		}
+		canonical, _ := jsresolution.CanonicalNPMPURL(purl)
+		decision := jssymbols.Decide(symbol, evidence.uses[canonical])
+
+		result := reachability.Result{Symbol: subject}
+		switch decision.Verdict {
+		case jssymbols.VerdictNotReachable:
+			// Leave Reachable false: every reference to the package was observed and none reaches this
+			// export.
+		case jssymbols.VerdictReachable:
+			result.Reachable = true
+			result.Path = evidence.prover.proofForModules(decision.Modules, symbol, subject)
+		default:
+			// Unknown should have been filtered out. Reaching it means the caller minted a claim this
+			// analyzer cannot answer, and the safe answer is the one that suppresses nothing.
+			result.Reachable = true
+			result.Path = []string{"reachability could not be determined for this export; treated as reachable", subject}
+		}
+		results = append(results, result)
+	}
+
+	roots := append([]string(nil), evidence.roots...)
+	sort.Strings(roots)
+	return &reachability.Analysis{Results: results, Entrypoints: roots}, nil
+}
+
+// symbolEvidence is one scan's Tier-2 view: what every module does with every imported package.
+type symbolEvidence struct {
+	uses   map[string][]jssymbols.Use
+	prover *pathProver
+	roots  []string
+}
+
+// gather scans, resolves and joins. It refuses — returning a no-coverage error that leaves any prior
+// tier standing — whenever anything could hide a use.
+func (a *SymbolAnalyzer) gather(ctx context.Context, dir string) (symbolEvidence, error) {
+	doc, err := a.sboms.SBOMFor(ctx, dir)
+	if err != nil {
+		return symbolEvidence{}, fmt.Errorf("jsreach: sbom unavailable (no coverage - prior tier stands): %w", err)
+	}
+	if doc == nil {
+		return symbolEvidence{}, fmt.Errorf("%w: jsreach has no sbom for the target (no coverage)", shared.ErrNotFound)
+	}
+	graph, err := a.scanner.Scan(ctx, dir)
+	if err != nil {
+		return symbolEvidence{}, fmt.Errorf("jsreach: javascript import scan (no coverage - prior tier stands): %w", err)
+	}
+	if len(graph.Coverage) > 0 {
+		return symbolEvidence{}, fmt.Errorf("%w: module graph has %d coverage issue(s) - javascript symbol reachability is inconclusive (no coverage)",
+			shared.ErrValidation, len(graph.Coverage))
+	}
+	resolution, err := a.resolver.Resolve(ctx, dir, graph, doc)
+	if err != nil {
+		return symbolEvidence{}, fmt.Errorf("jsreach: package resolution (no coverage - prior tier stands): %w", err)
+	}
+	if !resolution.Complete {
+		return symbolEvidence{}, fmt.Errorf("%w: package resolution is incomplete - javascript symbol reachability is inconclusive (no coverage)",
+			shared.ErrValidation)
+	}
+	if len(resolution.GraphCoverage) > 0 {
+		return symbolEvidence{}, fmt.Errorf("%w: resolution reports %d graph coverage issue(s) - javascript symbol reachability is inconclusive (no coverage)",
+			shared.ErrValidation, len(resolution.GraphCoverage))
+	}
+
+	declarationOnly := make(map[string]bool, len(graph.Modules))
+	dialects := make(map[string]modulegraph.Dialect, len(graph.Modules))
+	for _, module := range graph.Modules {
+		if module.DeclarationOnly {
+			declarationOnly[module.Path] = true
+		}
+		dialects[module.Path] = module.Dialect
+	}
+
+	return symbolEvidence{
+		uses:   collectSymbolUses(graph, resolution, declarationOnly, dialects),
+		prover: newPathProver(graph, declarationOnly),
+		roots:  graph.Roots,
+	}, nil
+}
+
+// collectSymbolUses joins the import edges (which name the package and the local bindings) with the
+// module's own references to those locals (which name the exports actually read).
+func collectSymbolUses(graph modulegraph.Graph, resolution jsresolution.Result,
+	declarationOnly map[string]bool, dialects map[string]modulegraph.Dialect) map[string][]jssymbols.Use {
+	// Index the resolved package identity by (module, specifier); an edge carries the specifier, the
+	// resolution carries the PURL.
+	purlOf := make(map[[2]string]string, len(resolution.Imports))
+	for _, imp := range resolution.Imports {
+		if imp.Status != jsresolution.StatusComponent || imp.Package.PURL == "" {
+			continue
+		}
+		if !jsresolution.IsRuntimeImport(imp, declarationOnly) {
+			continue
+		}
+		if canonical, ok := jsresolution.CanonicalNPMPURL(imp.Package.PURL); ok {
+			purlOf[[2]string{imp.From, imp.Specifier}] = canonical
+		}
+	}
+
+	// Index the module's references to its locals.
+	localUses := make(map[[2]string][]modulegraph.LocalUse, len(graph.LocalUses))
+	for _, use := range graph.LocalUses {
+		key := [2]string{use.Module, use.Local}
+		localUses[key] = append(localUses[key], use)
+	}
+
+	out := map[string][]jssymbols.Use{}
+	add := func(use jssymbols.Use) { out[use.PURL] = append(out[use.PURL], use) }
+
+	for _, edge := range graph.Edges {
+		if edge.TypeOnly || declarationOnly[edge.From] {
+			// A type-only import and a declaration module never execute, so neither can reach an export
+			// at runtime.
+			continue
+		}
+		purl, ok := purlOf[[2]string{edge.From, edge.Specifier}]
+		if !ok {
+			continue
+		}
+
+		// A re-export republishes whatever the package exports, under names this scanner cannot
+		// enumerate, so it reaches everything.
+		if edge.Kind == modulegraph.ImportReExport {
+			add(jssymbols.Use{Module: edge.From, PURL: purl, Kind: jssymbols.UseOpaque,
+				Reason: "the module re-exports the package"})
+			continue
+		}
+		// A module-loading form with no binding clause at all — a bare `require('pkg')` or a dynamic
+		// import whose result is not bound — still executes the module and may reach anything.
+		if len(edge.Bindings) == 0 {
+			add(jssymbols.Use{Module: edge.From, PURL: purl, Kind: jssymbols.UseOpaque,
+				Reason: "the package is loaded without a binding this scanner can follow"})
+			continue
+		}
+
+		for _, binding := range edge.Bindings {
+			if binding.TypeOnly {
+				continue
+			}
+			if binding.Imported != "" && !binding.Namespace && !binding.Default {
+				add(jssymbols.Use{Module: edge.From, PURL: purl, Symbol: binding.Imported, Kind: jssymbols.UseNamed})
+				continue
+			}
+			// Everything else binds the WHOLE module object: a namespace import, and a default import,
+			// which for a CommonJS package IS the module object.
+			local := strings.TrimSpace(binding.Local)
+			if local == "" {
+				add(jssymbols.Use{Module: edge.From, PURL: purl, Kind: jssymbols.UseOpaque,
+					Reason: "the package is bound without a local name"})
+				continue
+			}
+			// JSX desugars into calls on the runtime binding — createElement, jsx, Fragment — that this
+			// scanner never sees as source tokens, so a whole-module binding in a JSX module cannot be
+			// enumerated by its visible property reads.
+			if dialect := dialects[edge.From]; dialect == modulegraph.DialectJSX || dialect == modulegraph.DialectTSX {
+				add(jssymbols.Use{Module: edge.From, PURL: purl, Kind: jssymbols.UseOpaque,
+					Reason: "the module contains JSX, which desugars into calls this scanner does not observe"})
+				continue
+			}
+			for _, use := range localUses[[2]string{edge.From, local}] {
+				switch use.Kind {
+				case modulegraph.LocalUseProperty:
+					add(jssymbols.Use{Module: edge.From, PURL: purl, Symbol: use.Property, Kind: jssymbols.UseMember})
+				case modulegraph.LocalUseOpaque:
+					add(jssymbols.Use{Module: edge.From, PURL: purl, Kind: jssymbols.UseOpaque, Reason: use.Detail})
+				}
+			}
+		}
+	}
+
+	for purl := range out {
+		uses := out[purl]
+		sort.Slice(uses, func(i, j int) bool {
+			if uses[i].Module != uses[j].Module {
+				return uses[i].Module < uses[j].Module
+			}
+			if uses[i].Kind != uses[j].Kind {
+				return uses[i].Kind < uses[j].Kind
+			}
+			return uses[i].Symbol < uses[j].Symbol
+		})
+		out[purl] = uses
+	}
+	return out
+}
+
+// proofForModules builds a path from a structural root to one of the modules that reaches the export.
+func (p *pathProver) proofForModules(modules []string, symbol, subject string) []string {
+	if len(modules) == 0 {
+		return []string{"uses " + symbol, subject}
+	}
+	targets := make(map[string]importSite, len(modules))
+	for _, module := range modules {
+		if _, exists := targets[module]; !exists {
+			targets[module] = importSite{module: module}
+		}
+	}
+	if path, _, ok := p.shortestPathToAny(targets); ok {
+		return append(append([]string(nil), path...), "uses "+symbol, subject)
+	}
+	sorted := append([]string(nil), modules...)
+	sort.Strings(sorted)
+	return []string{sorted[0], "uses " + symbol, subject}
+}
+
+// answerableSymbolSubjects drops every subject this analyzer cannot answer, BEFORE the coordinator mints
+// a claim for it.
+//
+// A subject is answerable only when it is a component of the analyzed SBOM, a declared direct dependency
+// (a first-party import graph can never prove a transitive package unused), and its export produces a
+// decision other than unknown. The coordinator mints a claim for everything it is handed and reads a
+// missing result as not-reachable, so an unanswerable subject reaching it would be sealed as a false
+// negative at full confidence.
+func (a *SymbolAnalyzer) answerableSymbolSubjects(ctx context.Context, dir string, subjects []ports.ReachabilitySubject) ([]ports.ReachabilitySubject, error) {
+	doc, err := a.sboms.SBOMFor(ctx, dir)
+	if err != nil {
+		return nil, fmt.Errorf("jsreach: sbom unavailable (no coverage - prior tier stands): %w", err)
+	}
+	if doc == nil {
+		return nil, fmt.Errorf("%w: jsreach has no sbom for the target (no coverage)", shared.ErrNotFound)
+	}
+	evidence, err := a.gather(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	graph, err := a.scanner.Scan(ctx, dir)
+	if err != nil {
+		return nil, fmt.Errorf("jsreach: javascript import scan (no coverage - prior tier stands): %w", err)
+	}
+	resolution, err := a.resolver.Resolve(ctx, dir, graph, doc)
+	if err != nil {
+		return nil, fmt.Errorf("jsreach: package resolution (no coverage - prior tier stands): %w", err)
+	}
+	gate := &Analyzer{scanner: a.scanner, resolver: a.resolver, sboms: a.sboms}
+
+	out := make([]ports.ReachabilitySubject, 0, len(subjects))
+	for _, subject := range subjects {
+		symbols := make([]string, 0, len(subject.Symbols))
+		for _, raw := range subject.Symbols {
+			purl, symbol, ok := jsresolution.ParseNPMSymbolSubject(raw)
+			if !ok {
+				continue
+			}
+			if gate.assertSubjectsAnswerable([]string{purl}, doc, resolution) != nil {
+				continue
+			}
+			canonical, _ := jsresolution.CanonicalNPMPURL(purl)
+			if jssymbols.Decide(symbol, evidence.uses[canonical]).Verdict == jssymbols.VerdictUnknown {
+				continue
+			}
+			symbols = append(symbols, raw)
+		}
+		if len(symbols) > 0 {
+			out = append(out, ports.ReachabilitySubject{FindingID: subject.FindingID, Symbols: symbols})
+		}
+	}
+	return out, nil
+}

--- a/internal/usecase/jsreach/symbols_test.go
+++ b/internal/usecase/jsreach/symbols_test.go
@@ -1,0 +1,350 @@
+package jsreach
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const lodashPURL = "pkg:npm/lodash@4.17.15"
+
+// symbolAnalyzerFor wires a Tier-2 analyzer whose SBOM contains, and whose manifests declare, every purl
+// in answerable — the preconditions the analyzer requires before it will answer at all.
+func symbolAnalyzerFor(t *testing.T, graph modulegraph.Graph, result jsresolution.Result, answerable ...string) *SymbolAnalyzer {
+	t.Helper()
+	result.Complete = true
+
+	doc := &sbom.SBOM{}
+	for _, purl := range answerable {
+		name, version, ok := jsresolution.ParseNPMPURL(purl)
+		if !ok {
+			t.Fatalf("test fixture purl %q is not a valid npm purl", purl)
+		}
+		doc.Components = append(doc.Components, sbom.Component{Name: name, Version: version, PURL: purl})
+		result.DeclaredDependencies = append(result.DeclaredDependencies, name)
+	}
+
+	a, err := NewSymbolAnalyzer(fakeScanner{graph: graph}, fakeResolver{result: result}, fakeSBOMs{doc: doc})
+	if err != nil {
+		t.Fatalf("new symbol analyzer: %v", err)
+	}
+	return a
+}
+
+// graphWith assembles a one-module graph plus its resolution.
+func graphWith(module string, edges []modulegraph.Edge, uses []modulegraph.LocalUse) (modulegraph.Graph, jsresolution.Result) {
+	graph := modulegraph.Graph{
+		Modules:   []modulegraph.Module{mod(module)},
+		Edges:     edges,
+		Roots:     []string{module},
+		LocalUses: uses,
+	}
+	result := jsresolution.Result{}
+	for _, edge := range edges {
+		result.Imports = append(result.Imports, jsresolution.ImportResolution{
+			From: edge.From, Specifier: edge.Specifier, Kind: edge.Kind,
+			Status:  jsresolution.StatusComponent,
+			Package: jsresolution.PackageIdentity{Name: "lodash", Version: "4.17.15", PURL: lodashPURL},
+		})
+	}
+	return graph, result
+}
+
+func namedEdge(module, symbol string) modulegraph.Edge {
+	return modulegraph.Edge{
+		From: module, Specifier: "lodash", Kind: modulegraph.ImportESMStatic,
+		Bindings: []modulegraph.Binding{{Imported: symbol, Local: symbol}},
+	}
+}
+
+func namespaceEdge(module, local string) modulegraph.Edge {
+	return modulegraph.Edge{
+		From: module, Specifier: "lodash", Kind: modulegraph.ImportESMStatic,
+		Bindings: []modulegraph.Binding{{Local: local, Namespace: true}},
+	}
+}
+
+func analyzeOne(t *testing.T, a *SymbolAnalyzer, subject string) (bool, []string) {
+	t.Helper()
+	analysis, err := a.Analyze(context.Background(), "/repo", []string{subject})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if len(analysis.Results) != 1 {
+		t.Fatalf("expected one result, got %d", len(analysis.Results))
+	}
+	return analysis.Results[0].Reachable, analysis.Results[0].Path
+}
+
+// TestNamedImportOfTheAffectedExportIsReachable is the positive case: a named import binds one export
+// exactly, so reaching it needs no further evidence.
+func TestNamedImportOfTheAffectedExportIsReachable(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{namedEdge("src/a.ts", "template")}, nil)
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+
+	reachable, path := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "template"))
+	if !reachable {
+		t.Fatal("a named import of the affected export is reachable")
+	}
+	if len(path) == 0 || !strings.Contains(strings.Join(path, " → "), "uses template") {
+		t.Fatalf("the proof must name the export that was reached, got %v", path)
+	}
+}
+
+// TestNamedImportsOfOtherExportsAreNotReachable is the value Tier-2 adds over Tier-1: the package IS
+// imported, and the affected export still is not reached.
+func TestNamedImportsOfOtherExportsAreNotReachable(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{
+		namedEdge("src/a.ts", "merge"),
+		namedEdge("src/a.ts", "cloneDeep"),
+	}, nil)
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+
+	if reachable, _ := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "template")); reachable {
+		t.Fatal("an export nothing imports must not be reachable when every reference was observed")
+	}
+	// And the exports that ARE imported stay reachable — the negative is specific, not blanket.
+	if reachable, _ := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "merge")); !reachable {
+		t.Fatal("an imported export must remain reachable")
+	}
+}
+
+// TestObservedPropertyReadsNarrowANamespace: a whole-module binding is answerable exactly when every
+// reference to its local was an observable property read.
+func TestObservedPropertyReadsNarrowANamespace(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts",
+		[]modulegraph.Edge{namespaceEdge("src/a.ts", "_")},
+		[]modulegraph.LocalUse{
+			{Module: "src/a.ts", Local: "_", Property: "merge", Kind: modulegraph.LocalUseProperty},
+			{Module: "src/a.ts", Local: "_", Property: "escape", Kind: modulegraph.LocalUseProperty},
+		})
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+
+	if reachable, _ := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "merge")); !reachable {
+		t.Fatal("an observed property read reaches its export")
+	}
+	if reachable, _ := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "template")); reachable {
+		t.Fatal("an export no observed property read names must not be reachable")
+	}
+}
+
+// TestAnEscapingBindingMakesTheSubjectUnanswerable is the safety property. The subject is dropped before
+// minting rather than answered, so the weaker Tier-1 judgment stands instead of a false negative.
+func TestAnEscapingBindingMakesTheSubjectUnanswerable(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts",
+		[]modulegraph.Edge{namespaceEdge("src/a.ts", "_")},
+		[]modulegraph.LocalUse{
+			{Module: "src/a.ts", Local: "_", Property: "merge", Kind: modulegraph.LocalUseProperty},
+			{Module: "src/a.ts", Local: "_", Kind: modulegraph.LocalUseOpaque, Detail: "the binding escapes as a value"},
+		})
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "template")}}
+	answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
+	if err != nil {
+		t.Fatalf("answerable: %v", err)
+	}
+	if len(answerable) != 0 {
+		t.Fatalf("an escaping binding must make the export unanswerable, got %+v", answerable)
+	}
+
+	// The export the escaping module DOES read is still answerable, because a positive is always safe.
+	positive := ports.ReachabilitySubject{FindingID: "f-2", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "merge")}}
+	answerable, err = a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{positive})
+	if err != nil {
+		t.Fatalf("answerable: %v", err)
+	}
+	if len(answerable) != 1 {
+		t.Fatalf("an observed positive stays answerable, got %+v", answerable)
+	}
+}
+
+// Each of these binds or reaches the whole module, so none of them may leave a symbol answerable as
+// not-reached.
+func TestWholeModuleFormsAreUnanswerable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		edges []modulegraph.Edge
+		uses  []modulegraph.LocalUse
+	}{
+		{
+			name: "re-export republishes every export",
+			edges: []modulegraph.Edge{{
+				From: "src/a.ts", Specifier: "lodash", Kind: modulegraph.ImportReExport,
+				Bindings: []modulegraph.Binding{{Namespace: true}},
+			}},
+		},
+		{
+			name: "a bare load binds nothing this scanner can follow",
+			edges: []modulegraph.Edge{{
+				From: "src/a.ts", Specifier: "lodash", Kind: modulegraph.ImportCommonJS,
+			}},
+		},
+		{
+			name: "a default import of a commonjs package is the module object",
+			edges: []modulegraph.Edge{{
+				From: "src/a.ts", Specifier: "lodash", Kind: modulegraph.ImportESMStatic,
+				Bindings: []modulegraph.Binding{{Imported: "default", Local: "_", Default: true}},
+			}},
+			uses: []modulegraph.LocalUse{
+				{Module: "src/a.ts", Local: "_", Kind: modulegraph.LocalUseOpaque, Detail: "indexed with a computed key"},
+			},
+		},
+		{
+			name:  "a namespace with no observed reference at all",
+			edges: []modulegraph.Edge{namespaceEdge("src/a.ts", "_")},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			graph, result := graphWith("src/a.ts", test.edges, test.uses)
+			a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+			subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "template")}}
+			answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
+			if err != nil {
+				t.Fatalf("answerable: %v", err)
+			}
+			if len(answerable) != 0 {
+				t.Fatalf("%s must leave the export unanswerable, got %+v", test.name, answerable)
+			}
+		})
+	}
+}
+
+// TestJSXModulesCannotNarrowAWholeModuleBinding: JSX desugars into calls on the runtime binding that
+// never appear as source tokens, so the visible property reads are not the complete set.
+func TestJSXModulesCannotNarrowAWholeModuleBinding(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/App.tsx",
+		[]modulegraph.Edge{namespaceEdge("src/App.tsx", "React")},
+		[]modulegraph.LocalUse{
+			{Module: "src/App.tsx", Local: "React", Property: "useState", Kind: modulegraph.LocalUseProperty},
+		})
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "createElement")}}
+	answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
+	if err != nil {
+		t.Fatalf("answerable: %v", err)
+	}
+	if len(answerable) != 0 {
+		t.Fatal("a whole-module binding in a JSX module must not be narrowed by its visible property reads")
+	}
+}
+
+// A type-only import and a declaration module never execute, so neither reaches an export at runtime —
+// but they must also not be the ONLY evidence, which would leave the package looking unimported.
+func TestTypeOnlyAndDeclarationBindingsAreNotRuntimeUses(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{{
+		From: "src/a.ts", Specifier: "lodash", Kind: modulegraph.ImportESMStatic, TypeOnly: true,
+		Bindings: []modulegraph.Binding{{Imported: "template", Local: "template", TypeOnly: true}},
+	}}, nil)
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+
+	// No runtime use at all: the package-level question is Tier-1's, so this is unanswerable here
+	// rather than answered "not reached".
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "template")}}
+	answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
+	if err != nil {
+		t.Fatalf("answerable: %v", err)
+	}
+	if len(answerable) != 0 {
+		t.Fatalf("a type-only import is not a runtime use and cannot answer a symbol query, got %+v", answerable)
+	}
+}
+
+// TestCoverageIssuesRefuseTheWholeAnalysis: anything unobserved means "no edge" is not proof of absence
+// for ANY subject, so the pass returns a no-coverage error and mints nothing.
+func TestCoverageIssuesRefuseTheWholeAnalysis(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{namedEdge("src/a.ts", "merge")}, nil)
+	graph.Coverage = []modulegraph.CoverageIssue{{Kind: modulegraph.CoverageDynamicRequire, Path: "src/a.ts"}}
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+
+	if _, err := a.Analyze(context.Background(), "/repo", []string{jsresolution.NPMSymbolSubject(lodashPURL, "template")}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a coverage issue must refuse the analysis, got %v", err)
+	}
+}
+
+// A transitive package cannot be answered by a first-party graph — the absence of an import proves
+// nothing about a package its parent loads.
+func TestTransitivePackagesAreUnanswerable(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{namedEdge("src/a.ts", "merge")}, nil)
+	// The purl is in the SBOM but NOT declared as a direct dependency.
+	result.Complete = true
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "lodash", Version: "4.17.15", PURL: lodashPURL}}}
+	a, err := NewSymbolAnalyzer(fakeScanner{graph: graph}, fakeResolver{result: result}, fakeSBOMs{doc: doc})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "merge")}}
+	answerable, aerr := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
+	if aerr != nil {
+		t.Fatalf("answerable: %v", aerr)
+	}
+	if len(answerable) != 0 {
+		t.Fatalf("a package that is not a declared direct dependency must be unanswerable, got %+v", answerable)
+	}
+}
+
+// The subject encoding must round-trip exactly, and a malformed subject must be refused rather than
+// half-interpreted into a symbol that can never match.
+func TestSymbolSubjectRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct{ purl, symbol string }{
+		{"pkg:npm/lodash@4.17.15", "template"},
+		{"pkg:npm/%40scope%2Fpkg@1.0.0", "method"},
+	} {
+		subject := jsresolution.NPMSymbolSubject(test.purl, test.symbol)
+		purl, symbol, ok := jsresolution.ParseNPMSymbolSubject(subject)
+		if !ok || purl != test.purl || symbol != test.symbol {
+			t.Fatalf("round trip of %q gave (%q, %q, %v)", subject, purl, symbol, ok)
+		}
+	}
+	for _, malformed := range []string{"pkg:npm/lodash@1.0.0", "#template", "pkg:npm/lodash@1.0.0#", "not-a-purl#x", "pkg:npm/lodash@1.0.0# x"} {
+		if _, _, ok := jsresolution.ParseNPMSymbolSubject(malformed); ok {
+			t.Fatalf("%q must not parse as a symbol subject", malformed)
+		}
+	}
+}
+
+func TestNewSymbolAnalyzerValidatesDependencies(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewSymbolAnalyzer(nil, fakeResolver{}, fakeSBOMs{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil scanner must be rejected, got %v", err)
+	}
+	if _, err := NewSymbolAnalyzer(fakeScanner{}, nil, fakeSBOMs{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil resolver must be rejected, got %v", err)
+	}
+	if _, err := NewSymbolAnalyzer(fakeScanner{}, fakeResolver{}, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a nil sbom provider must be rejected, got %v", err)
+	}
+}

--- a/internal/usecase/jsreach/symbols_test.go
+++ b/internal/usecase/jsreach/symbols_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jssymbols"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/modulegraph"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -41,10 +42,10 @@ func symbolAnalyzerFor(t *testing.T, graph modulegraph.Graph, result jsresolutio
 // graphWith assembles a one-module graph plus its resolution.
 func graphWith(module string, edges []modulegraph.Edge, uses []modulegraph.LocalUse) (modulegraph.Graph, jsresolution.Result) {
 	graph := modulegraph.Graph{
-		Modules:   []modulegraph.Module{mod(module)},
-		Edges:     edges,
-		Roots:     []string{module},
-		LocalUses: uses,
+		Modules:        []modulegraph.Module{mod(module)},
+		Edges:          edges,
+		Roots:          []string{module},
+		SymbolEvidence: &modulegraph.SymbolEvidence{Uses: uses},
 	}
 	result := jsresolution.Result{}
 	for _, edge := range edges {
@@ -91,7 +92,7 @@ func TestNamedImportOfTheAffectedExportIsReachable(t *testing.T) {
 	graph, result := graphWith("src/a.ts", []modulegraph.Edge{namedEdge("src/a.ts", "template")}, nil)
 	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
 
-	reachable, path := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "template"))
+	reachable, path := analyzeOne(t, a, mustSubject(t, lodashPURL, "template"))
 	if !reachable {
 		t.Fatal("a named import of the affected export is reachable")
 	}
@@ -111,11 +112,11 @@ func TestNamedImportsOfOtherExportsAreNotReachable(t *testing.T) {
 	}, nil)
 	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
 
-	if reachable, _ := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "template")); reachable {
+	if reachable, _ := analyzeOne(t, a, mustSubject(t, lodashPURL, "template")); reachable {
 		t.Fatal("an export nothing imports must not be reachable when every reference was observed")
 	}
 	// And the exports that ARE imported stay reachable — the negative is specific, not blanket.
-	if reachable, _ := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "merge")); !reachable {
+	if reachable, _ := analyzeOne(t, a, mustSubject(t, lodashPURL, "merge")); !reachable {
 		t.Fatal("an imported export must remain reachable")
 	}
 }
@@ -133,10 +134,10 @@ func TestObservedPropertyReadsNarrowANamespace(t *testing.T) {
 		})
 	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
 
-	if reachable, _ := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "merge")); !reachable {
+	if reachable, _ := analyzeOne(t, a, mustSubject(t, lodashPURL, "merge")); !reachable {
 		t.Fatal("an observed property read reaches its export")
 	}
-	if reachable, _ := analyzeOne(t, a, jsresolution.NPMSymbolSubject(lodashPURL, "template")); reachable {
+	if reachable, _ := analyzeOne(t, a, mustSubject(t, lodashPURL, "template")); reachable {
 		t.Fatal("an export no observed property read names must not be reachable")
 	}
 }
@@ -154,7 +155,7 @@ func TestAnEscapingBindingMakesTheSubjectUnanswerable(t *testing.T) {
 		})
 	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
 
-	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "template")}}
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{mustSubject(t, lodashPURL, "template")}}
 	answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
 	if err != nil {
 		t.Fatalf("answerable: %v", err)
@@ -164,7 +165,7 @@ func TestAnEscapingBindingMakesTheSubjectUnanswerable(t *testing.T) {
 	}
 
 	// The export the escaping module DOES read is still answerable, because a positive is always safe.
-	positive := ports.ReachabilitySubject{FindingID: "f-2", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "merge")}}
+	positive := ports.ReachabilitySubject{FindingID: "f-2", Symbols: []string{mustSubject(t, lodashPURL, "merge")}}
 	answerable, err = a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{positive})
 	if err != nil {
 		t.Fatalf("answerable: %v", err)
@@ -218,7 +219,7 @@ func TestWholeModuleFormsAreUnanswerable(t *testing.T) {
 			t.Parallel()
 			graph, result := graphWith("src/a.ts", test.edges, test.uses)
 			a := symbolAnalyzerFor(t, graph, result, lodashPURL)
-			subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "template")}}
+			subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{mustSubject(t, lodashPURL, "template")}}
 			answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
 			if err != nil {
 				t.Fatalf("answerable: %v", err)
@@ -235,14 +236,17 @@ func TestWholeModuleFormsAreUnanswerable(t *testing.T) {
 func TestJSXModulesCannotNarrowAWholeModuleBinding(t *testing.T) {
 	t.Parallel()
 
-	graph, result := graphWith("src/App.tsx",
-		[]modulegraph.Edge{namespaceEdge("src/App.tsx", "React")},
+	// A .js file: the guard must key on the module ACTUALLY containing JSX, not on its extension, since
+	// JSX in .js is routine under Babel, CRA and Next.
+	graph, result := graphWith("src/App.js",
+		[]modulegraph.Edge{namespaceEdge("src/App.js", "React")},
 		[]modulegraph.LocalUse{
-			{Module: "src/App.tsx", Local: "React", Property: "useState", Kind: modulegraph.LocalUseProperty},
+			{Module: "src/App.js", Local: "React", Property: "useState", Kind: modulegraph.LocalUseProperty},
 		})
+	graph.SymbolEvidence.JSXModules = []string{"src/App.js"}
 	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
 
-	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "createElement")}}
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{mustSubject(t, lodashPURL, "createElement")}}
 	answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
 	if err != nil {
 		t.Fatalf("answerable: %v", err)
@@ -265,7 +269,7 @@ func TestTypeOnlyAndDeclarationBindingsAreNotRuntimeUses(t *testing.T) {
 
 	// No runtime use at all: the package-level question is Tier-1's, so this is unanswerable here
 	// rather than answered "not reached".
-	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "template")}}
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{mustSubject(t, lodashPURL, "template")}}
 	answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
 	if err != nil {
 		t.Fatalf("answerable: %v", err)
@@ -284,7 +288,7 @@ func TestCoverageIssuesRefuseTheWholeAnalysis(t *testing.T) {
 	graph.Coverage = []modulegraph.CoverageIssue{{Kind: modulegraph.CoverageDynamicRequire, Path: "src/a.ts"}}
 	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
 
-	if _, err := a.Analyze(context.Background(), "/repo", []string{jsresolution.NPMSymbolSubject(lodashPURL, "template")}); !errors.Is(err, shared.ErrValidation) {
+	if _, err := a.Analyze(context.Background(), "/repo", []string{mustSubject(t, lodashPURL, "template")}); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("a coverage issue must refuse the analysis, got %v", err)
 	}
 }
@@ -303,7 +307,7 @@ func TestTransitivePackagesAreUnanswerable(t *testing.T) {
 		t.Fatalf("new: %v", err)
 	}
 
-	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{jsresolution.NPMSymbolSubject(lodashPURL, "merge")}}
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{mustSubject(t, lodashPURL, "merge")}}
 	answerable, aerr := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
 	if aerr != nil {
 		t.Fatalf("answerable: %v", aerr)
@@ -322,14 +326,26 @@ func TestSymbolSubjectRoundTrips(t *testing.T) {
 		{"pkg:npm/lodash@4.17.15", "template"},
 		{"pkg:npm/%40scope%2Fpkg@1.0.0", "method"},
 	} {
-		subject := jsresolution.NPMSymbolSubject(test.purl, test.symbol)
-		purl, symbol, ok := jsresolution.ParseNPMSymbolSubject(subject)
+		subject, ok := jssymbols.Subject(test.purl, test.symbol)
+		if !ok {
+			t.Fatalf("Subject(%q, %q) must be mintable", test.purl, test.symbol)
+		}
+		purl, symbol, ok := jssymbols.ParseSubject(subject)
 		if !ok || purl != test.purl || symbol != test.symbol {
 			t.Fatalf("round trip of %q gave (%q, %q, %v)", subject, purl, symbol, ok)
 		}
 	}
+	// The writer is the mirror of the reader: a subject it refuses to mint is one the parser refuses.
+	for _, bad := range []struct{ purl, symbol string }{
+		{"not-a-purl", "template"}, {"pkg:npm/lodash@1.0.0", ""}, {"pkg:npm/lodash@1.0.0", "a.b"},
+		{"pkg:npm/lodash@1.0.0", "with space"}, {"pkg:npm/lodash@1.0.0", "1abc"},
+	} {
+		if _, ok := jssymbols.Subject(bad.purl, bad.symbol); ok {
+			t.Fatalf("Subject(%q, %q) must be refused", bad.purl, bad.symbol)
+		}
+	}
 	for _, malformed := range []string{"pkg:npm/lodash@1.0.0", "#template", "pkg:npm/lodash@1.0.0#", "not-a-purl#x", "pkg:npm/lodash@1.0.0# x"} {
-		if _, _, ok := jsresolution.ParseNPMSymbolSubject(malformed); ok {
+		if _, _, ok := jssymbols.ParseSubject(malformed); ok {
 			t.Fatalf("%q must not parse as a symbol subject", malformed)
 		}
 	}
@@ -347,4 +363,135 @@ func TestNewSymbolAnalyzerValidatesDependencies(t *testing.T) {
 	if _, err := NewSymbolAnalyzer(fakeScanner{}, fakeResolver{}, nil); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("a nil sbom provider must be rejected, got %v", err)
 	}
+}
+
+// mustSubject mints a Tier-2 subject, failing the test if the fixture is not mintable.
+func mustSubject(t *testing.T, purl, symbol string) string {
+	t.Helper()
+	subject, ok := jssymbols.Subject(purl, symbol)
+	if !ok {
+		t.Fatalf("fixture subject (%q, %q) is not mintable", purl, symbol)
+	}
+	return subject
+}
+
+// TestAnUnobservedWholeModuleBindingInAnotherModuleBlocksTheNegative is the cross-module regression.
+// Module A names one export; module B holds the whole package and never mentions it again. Treating B's
+// silence as "no reference" left A's named use as the only evidence, and the verdict came back
+// not-reachable for a package B holds in full.
+func TestAnUnobservedWholeModuleBindingInAnotherModuleBlocksTheNegative(t *testing.T) {
+	t.Parallel()
+
+	graph := modulegraph.Graph{
+		Modules: []modulegraph.Module{mod("src/a.ts"), mod("src/b.ts")},
+		Edges: []modulegraph.Edge{
+			namedEdge("src/a.ts", "merge"),
+			namespaceEdge("src/b.ts", "_"), // bound, never referenced again
+		},
+		Roots:          []string{"src/a.ts", "src/b.ts"},
+		SymbolEvidence: &modulegraph.SymbolEvidence{},
+	}
+	result := jsresolution.Result{}
+	for _, edge := range graph.Edges {
+		result.Imports = append(result.Imports, jsresolution.ImportResolution{
+			From: edge.From, Specifier: edge.Specifier, Kind: edge.Kind,
+			Status:  jsresolution.StatusComponent,
+			Package: jsresolution.PackageIdentity{Name: "lodash", Version: "4.17.15", PURL: lodashPURL},
+		})
+	}
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{mustSubject(t, lodashPURL, "template")}}
+	answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
+	if err != nil {
+		t.Fatalf("answerable: %v", err)
+	}
+	if len(answerable) != 0 {
+		t.Fatal("a whole-module binding nobody enumerated must block the negative, even from another module")
+	}
+}
+
+// A default-named binding binds the module object for a CommonJS package, so it can reach any export.
+func TestDefaultNamedBindingIsWholeModule(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{{
+		From: "src/a.ts", Specifier: "lodash", Kind: modulegraph.ImportCommonJS,
+		Bindings: []modulegraph.Binding{{Imported: "default", Local: "axios"}},
+	}}, []modulegraph.LocalUse{
+		{Module: "src/a.ts", Local: "axios", Property: "get", Kind: modulegraph.LocalUseProperty},
+	})
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+
+	// `get` is observed, so it is reachable...
+	if reachable, _ := analyzeOne(t, a, mustSubject(t, lodashPURL, "get")); !reachable {
+		t.Fatal("an observed property read of the default binding reaches its export")
+	}
+	// ...and an export it does NOT name is still answerable, because every reference was enumerated.
+	if reachable, _ := analyzeOne(t, a, mustSubject(t, lodashPURL, "post")); reachable {
+		t.Fatal("an export no observed read names must not be reachable when all references were seen")
+	}
+}
+
+// TestIncompleteSymbolEvidenceRefusesWithoutTouchingTheImportGraph: a Tier-2 limitation must refuse
+// Tier-2 and nothing else.
+func TestIncompleteSymbolEvidenceRefusesWithoutTouchingTheImportGraph(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{namedEdge("src/a.ts", "merge")}, nil)
+	graph.SymbolEvidence.Coverage = []modulegraph.CoverageIssue{{
+		Kind: modulegraph.CoverageSymbolEvidenceIncomplete, Path: "src/a.ts",
+	}}
+	a := symbolAnalyzerFor(t, graph, result, lodashPURL)
+	if _, err := a.Analyze(context.Background(), "/repo", []string{mustSubject(t, lodashPURL, "template")}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("incomplete symbol evidence must refuse the tier-2 analysis, got %v", err)
+	}
+
+	// Symbol evidence that was never collected at all is likewise not a fact about anything.
+	graph2, result2 := graphWith("src/a.ts", []modulegraph.Edge{namedEdge("src/a.ts", "merge")}, nil)
+	graph2.SymbolEvidence = nil
+	b := symbolAnalyzerFor(t, graph2, result2, lodashPURL)
+	if _, err := b.Analyze(context.Background(), "/repo", []string{mustSubject(t, lodashPURL, "template")}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("uncollected symbol evidence must refuse the tier-2 analysis, got %v", err)
+	}
+}
+
+// TestTheTargetIsScannedOnce locks the single-gather contract: the subject filter and the verdict must
+// be computed from the SAME snapshot, or a subject admitted as answerable could be decided on evidence
+// that changed underneath it.
+func TestTheTargetIsScannedOnce(t *testing.T) {
+	t.Parallel()
+
+	graph, result := graphWith("src/a.ts", []modulegraph.Edge{namedEdge("src/a.ts", "merge")}, nil)
+	result.Complete = true
+	doc := &sbom.SBOM{Components: []sbom.Component{{Name: "lodash", Version: "4.17.15", PURL: lodashPURL}}}
+	result.DeclaredDependencies = []string{"lodash"}
+
+	counting := &countingScanner{graph: graph}
+	a, err := NewSymbolAnalyzer(counting, fakeResolver{result: result}, fakeSBOMs{doc: doc})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	subject := ports.ReachabilitySubject{FindingID: "f-1", Symbols: []string{mustSubject(t, lodashPURL, "merge")}}
+	answerable, err := a.answerableSymbolSubjects(context.Background(), "/repo", []ports.ReachabilitySubject{subject})
+	if err != nil {
+		t.Fatalf("answerable: %v", err)
+	}
+	if _, err := a.Analyze(context.Background(), "/repo", answerable[0].Symbols); err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if counting.calls != 1 {
+		t.Fatalf("the target was scanned %d times; the filter and the verdict must share one snapshot", counting.calls)
+	}
+}
+
+type countingScanner struct {
+	graph modulegraph.Graph
+	calls int
+}
+
+func (c *countingScanner) Scan(context.Context, string) (modulegraph.Graph, error) {
+	c.calls++
+	return c.graph, nil
 }

--- a/internal/usecase/reachproof/coordinator.go
+++ b/internal/usecase/reachproof/coordinator.go
@@ -61,6 +61,13 @@ func (l Language) Valid() bool {
 
 func actorsFor(tier judgment.ReachabilityTier, language Language) (proposer, verifier, proofLabel string) {
 	if tier == judgment.Tier2 {
+		// Tier-2 is a STRENGTH of claim, not an engine. Two different engines reach it — the Go call
+		// graph and the JavaScript binding-and-property-read analysis — and a sealed rationale that
+		// named the wrong one would make a module-graph proof indistinguishable from an interprocedural
+		// one in the report and in the audit trail.
+		if language == LanguageJavaScript {
+			return "system:jssymbol-scan", "system:jssymbol-engine", "tier-2 javascript affected-export proof"
+		}
 		return "system:callgraph-scan", "system:callgraph-engine", "tier-2 call-graph proof"
 	}
 	switch language {

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jssymbols"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vex"
@@ -734,6 +736,61 @@ func jsReachabilitySubjects(findings []finding.Finding, vulns []vulnerability.Vu
 			continue
 		}
 		subs = append(subs, ports.ReachabilitySubject{FindingID: f.ID, Symbols: []string{purl}})
+	}
+	return subs
+}
+
+// jsSymbolReachabilitySubjects builds TIER-2 JavaScript subjects: one per (component, affected export)
+// pair, encoded as `pkg:npm/name@version#export`.
+//
+// It runs only for findings whose advisory names affected symbols. A vulnerability with no symbol has no
+// Tier-2 question to ask — "which export" is the whole point — and asking it anyway would compare the
+// package name against export names and come back not-reached for everything.
+//
+// A symbol the domain cannot place onto an export name (a deep import path, a nested member) is DROPPED
+// rather than passed through, for the same reason: it could never match, so it would be sealed as a
+// false negative at full confidence.
+func jsSymbolReachabilitySubjects(findings []finding.Finding, vulns []vulnerability.Vulnerability, doc *sbom.SBOM) []ports.ReachabilitySubject {
+	if doc == nil {
+		return nil
+	}
+	purlByComponent := map[string]string{}
+	for _, c := range doc.Components {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(c.PURL)), "pkg:npm/") {
+			purlByComponent[strings.ToLower(c.Name)+"\x00"+c.Version] = c.PURL
+		}
+	}
+	if len(purlByComponent) == 0 {
+		return nil
+	}
+	byDedup := make(map[string]vulnerability.Vulnerability, len(vulns))
+	for _, v := range vulns {
+		byDedup[vulnDedupKey(v)] = v
+	}
+
+	var subs []ports.ReachabilitySubject
+	for _, f := range findings {
+		v, ok := byDedup[f.DedupKey]
+		if !ok || len(v.AffectedSymbols) == 0 {
+			continue
+		}
+		purl, ok := purlByComponent[strings.ToLower(v.Component)+"\x00"+v.Version]
+		if !ok {
+			continue
+		}
+		symbols := make([]string, 0, len(v.AffectedSymbols))
+		seen := map[string]bool{}
+		for _, raw := range v.AffectedSymbols {
+			export, ok := jssymbols.NormalizeAffectedSymbol(v.Component, raw)
+			if !ok || seen[export] {
+				continue
+			}
+			seen[export] = true
+			symbols = append(symbols, jsresolution.NPMSymbolSubject(purl, export))
+		}
+		if len(symbols) > 0 {
+			subs = append(subs, ports.ReachabilitySubject{FindingID: f.ID, Symbols: symbols})
+		}
 	}
 	return subs
 }

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/ignore"
-	"github.com/KKloudTarus/synapse-ce/internal/domain/jsresolution"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/jssymbols"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -778,17 +777,33 @@ func jsSymbolReachabilitySubjects(findings []finding.Finding, vulns []vulnerabil
 		if !ok {
 			continue
 		}
+		// Every affected symbol must be placeable, or the finding gets NO tier-2 subject at all.
+		//
+		// Dropping only the unplaceable ones would leave the rest forming a subject, and the coordinator
+		// concludes not-reachable when none of the symbols it was handed is reached — so an advisory
+		// listing ["template", "Class.prototype.escape"] would be sealed not-reachable on the strength of
+		// `template` alone, with the symbol nobody could evaluate silently discarded.
 		symbols := make([]string, 0, len(v.AffectedSymbols))
 		seen := map[string]bool{}
+		placeable := true
 		for _, raw := range v.AffectedSymbols {
 			export, ok := jssymbols.NormalizeAffectedSymbol(v.Component, raw)
-			if !ok || seen[export] {
+			if !ok {
+				placeable = false
+				break
+			}
+			subject, ok := jssymbols.Subject(purl, export)
+			if !ok {
+				placeable = false
+				break
+			}
+			if seen[export] {
 				continue
 			}
 			seen[export] = true
-			symbols = append(symbols, jsresolution.NPMSymbolSubject(purl, export))
+			symbols = append(symbols, subject)
 		}
-		if len(symbols) > 0 {
+		if placeable && len(symbols) > 0 {
 			subs = append(subs, ports.ReachabilitySubject{FindingID: f.ID, Symbols: symbols})
 		}
 	}

--- a/internal/usecase/sca/jssymbolsubjects_test.go
+++ b/internal/usecase/sca/jssymbolsubjects_test.go
@@ -1,0 +1,94 @@
+package sca
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+)
+
+func npmDoc() *sbom.SBOM {
+	return &sbom.SBOM{Components: []sbom.Component{
+		{Name: "lodash", Version: "4.17.15", PURL: "pkg:npm/lodash@4.17.15"},
+		{Name: "left-pad", Version: "1.0.0", PURL: "pkg:npm/left-pad@1.0.0"},
+	}}
+}
+
+func vulnWith(component, version string, symbols ...string) vulnerability.Vulnerability {
+	return vulnerability.Vulnerability{
+		ID: "GHSA-" + component, Component: component, Version: version,
+		AffectedSymbols: symbols,
+	}
+}
+
+func findingFor(id string, v vulnerability.Vulnerability) finding.Finding {
+	return finding.Finding{ID: shared.ID(id), DedupKey: vulnDedupKey(v)}
+}
+
+// TestJSSymbolSubjectsAreBuiltOnlyForAdvisoriesWithSymbols locks the precondition: Tier-2 asks "which
+// export", so an advisory with no affected symbol has no Tier-2 question. Asking it anyway would compare
+// a package name against export names and come back not-reached for everything.
+func TestJSSymbolSubjectsAreBuiltOnlyForAdvisoriesWithSymbols(t *testing.T) {
+	t.Parallel()
+
+	withSymbols := vulnWith("lodash", "4.17.15", "template")
+	without := vulnWith("left-pad", "1.0.0")
+	findings := []finding.Finding{findingFor("f-1", withSymbols), findingFor("f-2", without)}
+	vulns := []vulnerability.Vulnerability{withSymbols, without}
+
+	subs := jsSymbolReachabilitySubjects(findings, vulns, npmDoc())
+	if len(subs) != 1 {
+		t.Fatalf("only the advisory naming an export gets a tier-2 subject, got %+v", subs)
+	}
+	if subs[0].FindingID != "f-1" {
+		t.Fatalf("subject is keyed by the real finding id, got %q", subs[0].FindingID)
+	}
+	if len(subs[0].Symbols) != 1 || subs[0].Symbols[0] != "pkg:npm/lodash@4.17.15#template" {
+		t.Fatalf("symbols = %v, want the exact component purl with the export appended", subs[0].Symbols)
+	}
+}
+
+// A symbol that cannot be placed onto an export name is DROPPED rather than passed through: it could
+// never match an export, so it would be sealed as a false negative at full confidence.
+func TestUnplaceableSymbolsAreDropped(t *testing.T) {
+	t.Parallel()
+
+	v := vulnWith("lodash", "4.17.15", "lodash/template", "Class.prototype.method", "*", "lodash.merge", "template")
+	subs := jsSymbolReachabilitySubjects([]finding.Finding{findingFor("f-1", v)}, []vulnerability.Vulnerability{v}, npmDoc())
+	if len(subs) != 1 {
+		t.Fatalf("expected one subject, got %+v", subs)
+	}
+	want := map[string]bool{
+		"pkg:npm/lodash@4.17.15#merge":    true,
+		"pkg:npm/lodash@4.17.15#template": true,
+	}
+	if len(subs[0].Symbols) != len(want) {
+		t.Fatalf("symbols = %v, want only the two placeable exports", subs[0].Symbols)
+	}
+	for _, symbol := range subs[0].Symbols {
+		if !want[symbol] {
+			t.Fatalf("unexpected symbol %q", symbol)
+		}
+	}
+}
+
+// A component with no exact identity in this document has no subject to answer for — the version the
+// advisory names must be the version the SBOM records, or the verdict would be about a different build.
+func TestSubjectsNeedAnExactComponentIdentity(t *testing.T) {
+	t.Parallel()
+
+	v := vulnWith("lodash", "4.17.21", "template") // a version the document does not contain
+	if subs := jsSymbolReachabilitySubjects([]finding.Finding{findingFor("f-1", v)}, []vulnerability.Vulnerability{v}, npmDoc()); len(subs) != 0 {
+		t.Fatalf("a version absent from the document must yield no subject, got %+v", subs)
+	}
+	if subs := jsSymbolReachabilitySubjects([]finding.Finding{findingFor("f-1", v)}, []vulnerability.Vulnerability{v}, nil); len(subs) != 0 {
+		t.Fatalf("no document means no subject, got %+v", subs)
+	}
+	// A non-npm document produces nothing either.
+	other := &sbom.SBOM{Components: []sbom.Component{{Name: "flask", Version: "1.0", PURL: "pkg:pypi/flask@1.0"}}}
+	if subs := jsSymbolReachabilitySubjects([]finding.Finding{findingFor("f-1", v)}, []vulnerability.Vulnerability{v}, other); len(subs) != 0 {
+		t.Fatalf("a document with no npm components must yield no subject, got %+v", subs)
+	}
+}

--- a/internal/usecase/sca/jssymbolsubjects_test.go
+++ b/internal/usecase/sca/jssymbolsubjects_test.go
@@ -50,27 +50,27 @@ func TestJSSymbolSubjectsAreBuiltOnlyForAdvisoriesWithSymbols(t *testing.T) {
 	}
 }
 
-// A symbol that cannot be placed onto an export name is DROPPED rather than passed through: it could
-// never match an export, so it would be sealed as a false negative at full confidence.
-func TestUnplaceableSymbolsAreDropped(t *testing.T) {
+// TestAnUnplaceableSymbolDropsTheWholeFinding is the safety rule. The coordinator concludes
+// not-reachable when NONE of the symbols it was handed is reached, so keeping the placeable subset would
+// seal a finding not-reachable on the strength of the symbols that happened to be interpretable — with
+// the one nobody could evaluate silently discarded.
+func TestAnUnplaceableSymbolDropsTheWholeFinding(t *testing.T) {
 	t.Parallel()
 
-	v := vulnWith("lodash", "4.17.15", "lodash/template", "Class.prototype.method", "*", "lodash.merge", "template")
-	subs := jsSymbolReachabilitySubjects([]finding.Finding{findingFor("f-1", v)}, []vulnerability.Vulnerability{v}, npmDoc())
-	if len(subs) != 1 {
-		t.Fatalf("expected one subject, got %+v", subs)
-	}
-	want := map[string]bool{
-		"pkg:npm/lodash@4.17.15#merge":    true,
-		"pkg:npm/lodash@4.17.15#template": true,
-	}
-	if len(subs[0].Symbols) != len(want) {
-		t.Fatalf("symbols = %v, want only the two placeable exports", subs[0].Symbols)
-	}
-	for _, symbol := range subs[0].Symbols {
-		if !want[symbol] {
-			t.Fatalf("unexpected symbol %q", symbol)
+	for _, unplaceable := range []string{"lodash/template", "Class.prototype.method", "*", "with space"} {
+		v := vulnWith("lodash", "4.17.15", "template", unplaceable)
+		subs := jsSymbolReachabilitySubjects([]finding.Finding{findingFor("f-1", v)}, []vulnerability.Vulnerability{v}, npmDoc())
+		if len(subs) != 0 {
+			t.Fatalf("an advisory containing %q must yield no tier-2 subject at all, got %+v", unplaceable, subs)
 		}
+	}
+
+	// When every symbol IS placeable the subject is built, deduplicated, in the package-qualified form
+	// as well as the bare one.
+	v := vulnWith("lodash", "4.17.15", "template", "lodash.template", "merge")
+	subs := jsSymbolReachabilitySubjects([]finding.Finding{findingFor("f-1", v)}, []vulnerability.Vulnerability{v}, npmDoc())
+	if len(subs) != 1 || len(subs[0].Symbols) != 2 {
+		t.Fatalf("placeable symbols must deduplicate to two subjects, got %+v", subs)
 	}
 }
 

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -84,6 +84,7 @@ type Service struct {
 	reachability                     ports.ReachabilityRecorder            // optional deterministic Tier-2 reachability proof (Go call-graph)
 	pyReachability                   ports.ReachabilityRecorder            // optional deterministic Tier-1 Python import-reachability proof
 	jsReachability                   jsReachabilityRecorder                // optional deterministic Tier-1 JavaScript import-reachability proof
+	jsSymbolReachability             jsReachabilityRecorder                // optional deterministic Tier-2 JavaScript affected-export proof
 	srcReachability                  map[string]ports.ReachabilityRecorder // optional Tier-1 provers keyed by package-URL type
 	correlation                      ports.CorrelationRecorder             // optional cross-check disagreement → judgment minter
 	sbomGen2                         ports.SBOMGenerator                   // optional 2nd SBOM producer for the cross-check
@@ -353,6 +354,13 @@ func (s *Service) SetSourceReachability(purlType string, r ports.ReachabilityRec
 // A dependency declared but never imported becomes not_reachable, which the export path turns into an
 // OpenVEX not_affected justification. Best-effort and opt-in; nil disables it.
 func (s *Service) SetJSReachability(r jsReachabilityRecorder) { s.jsReachability = r }
+
+// SetJSSymbolReachability configures the optional deterministic TIER-2 JavaScript prover: not "is this
+// package imported" but "is the affected EXPORT reached". It runs alongside Tier-1 rather than replacing
+// it — a Tier-2 answer supersedes the Tier-1 judgment for the same subject under the existing
+// stronger-tier-wins rule, and a subject Tier-2 cannot answer leaves the Tier-1 judgment standing.
+// Best-effort and opt-in; nil disables it.
+func (s *Service) SetJSSymbolReachability(r jsReachabilityRecorder) { s.jsSymbolReachability = r }
 
 // SetCorrelation configures the optional cross-check disagreement→judgment minter. nil ⇒ no
 // correlation judgments. Best-effort + opt-in: a recorder error is ignored (the scan never fails). A setter
@@ -2481,6 +2489,13 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	// Deterministic TIER-1 JavaScript import-reachability, best-effort + opt-in. The scan's own SBOM is
 	// handed over so the subjects and the analysis reason over the SAME document. A no-coverage result
 	// is IGNORED here: reachability is an enhancement, so the prior tier stands and the scan never fails.
+	if opts.scansVulnerabilities() && s.jsSymbolReachability != nil {
+		// Tier-2 runs FIRST so the stronger proof is minted before the weaker one; the supersession rule
+		// is order-independent, but recording the specific answer first keeps the audit trail readable.
+		if subs := jsSymbolReachabilitySubjects(result.Findings, result.Vulnerabilities, result.SBOM); len(subs) > 0 {
+			_, _ = s.jsSymbolReachability.RecordWithSBOM(ctx, engagementID, ws.Dir, result.SBOM, subs)
+		}
+	}
 	if opts.scansVulnerabilities() && s.jsReachability != nil {
 		if subs := jsReachabilitySubjects(result.Findings, result.Vulnerabilities, result.SBOM); len(subs) > 0 {
 			_, _ = s.jsReachability.RecordWithSBOM(ctx, engagementID, ws.Dir, result.SBOM, subs)

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -83,8 +83,8 @@ type Service struct {
 	detectionPriority                string                                // server default detection priority (comprehensive|precise); empty = comprehensive
 	reachability                     ports.ReachabilityRecorder            // optional deterministic Tier-2 reachability proof (Go call-graph)
 	pyReachability                   ports.ReachabilityRecorder            // optional deterministic Tier-1 Python import-reachability proof
-	jsReachability                   jsReachabilityRecorder                // optional deterministic Tier-1 JavaScript import-reachability proof
-	jsSymbolReachability             jsReachabilityRecorder                // optional deterministic Tier-2 JavaScript affected-export proof
+	jsReachability                   jsSBOMReachabilityRecorder            // optional deterministic Tier-1 JavaScript import-reachability proof
+	jsSymbolReachability             jsSBOMReachabilityRecorder            // optional deterministic Tier-2 JavaScript affected-export proof
 	srcReachability                  map[string]ports.ReachabilityRecorder // optional Tier-1 provers keyed by package-URL type
 	correlation                      ports.CorrelationRecorder             // optional cross-check disagreement → judgment minter
 	sbomGen2                         ports.SBOMGenerator                   // optional 2nd SBOM producer for the cross-check
@@ -321,11 +321,14 @@ func (s *Service) SetReachability(r ports.ReachabilityRecorder) { s.reachability
 // "not reachable"). Kept distinct from the Go call-graph prover: it is a WEAKER (Tier-1, import-level) proof.
 func (s *Service) SetPyReachability(r ports.ReachabilityRecorder) { s.pyReachability = r }
 
-// jsReachabilityRecorder is the narrow slice of the JavaScript Tier-1 recorder this service needs. It
-// takes the SBOM explicitly because a component purl is only meaningful relative to one document: the
+// jsSBOMReachabilityRecorder is the narrow slice of a JavaScript reachability recorder this service
+// needs. BOTH tiers satisfy it — the name is deliberately tier-neutral, because Go interfaces are
+// structural and a tier-specific name would imply a distinction the type system does not enforce.
+//
+// It takes the SBOM explicitly because a component purl is only meaningful relative to one document: the
 // subjects are minted from the scan's own SBOM, so the analysis must reason over that same document
 // rather than re-deriving one that could differ.
-type jsReachabilityRecorder interface {
+type jsSBOMReachabilityRecorder interface {
 	RecordWithSBOM(ctx context.Context, engagementID shared.ID, targetRef string, doc *sbom.SBOM, subjects []ports.ReachabilitySubject) (int, error)
 }
 
@@ -353,14 +356,14 @@ func (s *Service) SetSourceReachability(purlType string, r ports.ReachabilityRec
 // SetJSReachability configures the optional deterministic Tier-1 JavaScript import-reachability prover.
 // A dependency declared but never imported becomes not_reachable, which the export path turns into an
 // OpenVEX not_affected justification. Best-effort and opt-in; nil disables it.
-func (s *Service) SetJSReachability(r jsReachabilityRecorder) { s.jsReachability = r }
+func (s *Service) SetJSReachability(r jsSBOMReachabilityRecorder) { s.jsReachability = r }
 
 // SetJSSymbolReachability configures the optional deterministic TIER-2 JavaScript prover: not "is this
 // package imported" but "is the affected EXPORT reached". It runs alongside Tier-1 rather than replacing
 // it — a Tier-2 answer supersedes the Tier-1 judgment for the same subject under the existing
 // stronger-tier-wins rule, and a subject Tier-2 cannot answer leaves the Tier-1 judgment standing.
 // Best-effort and opt-in; nil disables it.
-func (s *Service) SetJSSymbolReachability(r jsReachabilityRecorder) { s.jsSymbolReachability = r }
+func (s *Service) SetJSSymbolReachability(r jsSBOMReachabilityRecorder) { s.jsSymbolReachability = r }
 
 // SetCorrelation configures the optional cross-check disagreement→judgment minter. nil ⇒ no
 // correlation judgments. Best-effort + opt-in: a recorder error is ignored (the scan never fails). A setter
@@ -2489,16 +2492,19 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	// Deterministic TIER-1 JavaScript import-reachability, best-effort + opt-in. The scan's own SBOM is
 	// handed over so the subjects and the analysis reason over the SAME document. A no-coverage result
 	// is IGNORED here: reachability is an enhancement, so the prior tier stands and the scan never fails.
-	if opts.scansVulnerabilities() && s.jsSymbolReachability != nil {
-		// Tier-2 runs FIRST so the stronger proof is minted before the weaker one; the supersession rule
-		// is order-independent, but recording the specific answer first keeps the audit trail readable.
-		if subs := jsSymbolReachabilitySubjects(result.Findings, result.Vulnerabilities, result.SBOM); len(subs) > 0 {
-			_, _ = s.jsSymbolReachability.RecordWithSBOM(ctx, engagementID, ws.Dir, result.SBOM, subs)
-		}
-	}
 	if opts.scansVulnerabilities() && s.jsReachability != nil {
 		if subs := jsReachabilitySubjects(result.Findings, result.Vulnerabilities, result.SBOM); len(subs) > 0 {
 			_, _ = s.jsReachability.RecordWithSBOM(ctx, engagementID, ws.Dir, result.SBOM, subs)
+		}
+	}
+
+	// Deterministic TIER-2 JavaScript affected-export reachability. It runs AFTER Tier-1 on purpose:
+	// supersession is rank-ordered, so a Tier-2 judgment minted first would stop Tier-1 minting at all
+	// and the audit trail would lose the "the package is imported" record entirely. Running it second
+	// leaves both records, with the stronger one superseding.
+	if opts.scansVulnerabilities() && s.jsSymbolReachability != nil {
+		if subs := jsSymbolReachabilitySubjects(result.Findings, result.Vulnerabilities, result.SBOM); len(subs) > 0 {
+			_, _ = s.jsSymbolReachability.RecordWithSBOM(ctx, engagementID, ws.Dir, result.SBOM, subs)
 		}
 	}
 


### PR DESCRIPTION
Closes the last open item of **#378** (R5, Tier-2).

## The question

Tier-1 answers *"is this package imported at all"*. This answers the one the epic set out: **is the export an advisory names actually reached from first-party source?**

That is a strictly stronger claim and a strictly more dangerous one. A Tier-2 negative becomes an OpenVEX `not_affected`, so saying "the package is imported but its vulnerable export is never touched" **suppresses a real vulnerability** if the analysis missed a single reference. Every rule here is arranged to produce **unknown** — which the caller drops, leaving the Tier-1 judgment standing — rather than a negative.

## What counts as evidence

The import binding, plus what the module then does with it:

- **A named import binds one export exactly.** `import {template} from 'lodash'` needs no further evidence.
- **A whole-module binding** — `import * as _`, a default import, `const _ = require(...)` — reaches an export only through an observable property read. It is answerable **only when every reference to that local was seen**. One reference that escapes (passed somewhere, indexed with a computed key, spread, re-exported, used in a ternary) and the package becomes unanswerable.
- **A module containing JSX** is treated the same way: JSX desugars into calls on the runtime binding that never appear as source tokens.

The decision rules are pure domain code (`domain/jssymbols`) and the **order of the rules is the safety property**: a use naming the symbol wins immediately, otherwise any opaque reference makes the answer unknown, and only when every reference was named and none matched is a negative issued. `Decide` is total and validates its input — a use it cannot interpret contributes opacity, never silence.

## Scanner

It now records what a module does with the locals its imports bind: property reads with their property name, everything else as an opaque reference with a reason. CommonJS binding patterns are recovered too — `const {template} = require('lodash')` names one export exactly, while a rest element, a default value, a nested pattern, a member-assignment target or a navigated call (`require('x').y`) yields **no** bindings, which reads downstream as whole-module.

Symbol evidence lives in `Graph.SymbolEvidence`, a **pointer** so *"not collected"* and *"collected and empty"* are different states — only the second permits a negative — with its own coverage list, so a Tier-2 budget can never refuse a sound Tier-1 answer.

## Subjects and governance

Subjects are `pkg:npm/name@version#export`, minted through a validating constructor that is the exact mirror of the parser, so a Tier-1 and a Tier-2 subject can never be confused. Only advisories naming affected symbols produce them, and **if any** affected symbol cannot be placed onto an export name the whole finding gets no Tier-2 subject — keeping the placeable rest would seal it not-reachable on the strength of the symbols that happened to be interpretable.

Minted at `judgment.Tier2` with its **own** reserved identities (`system:jssymbol-scan` / `system:jssymbol-engine`), so a module-graph proof is never mistaken for an interprocedural call-graph one in the report or the audit trail. Gated behind `SYNAPSE_JSREACH_TIER2_ENABLED`, and it **requires Tier-1**: every safety statement it makes ends "…leaves the Tier-1 judgment standing", so enabling it alone would leave nothing standing. It runs **after** Tier-1 because supersession is rank-ordered — minting Tier-2 first would mean Tier-1 never mints and the audit trail loses the "the package is imported" record.

## Review found five ways to suppress a vulnerability

Every one is ordinary code, and every one now has a regression test.

| Construct | Why it was a false negative |
|---|---|
| `import * as _; export { _ }` | the clause reader consumed the identifiers, so re-publishing the whole package was recorded nowhere |
| `cond ? _ : other` | an identifier before `:` was assumed to be an object key; this one is a read that escapes |
| JSX in a `.js` file | the guard keyed on the extension, but JSX in `.js` is routine under Babel/CRA/Next |
| `exports.lodash = require('lodash')` | recorded as a local binding nothing reads, so the escape into `exports` was modelled nowhere |
| `const { default: axios } = require('axios')` | for CommonJS the default export **is** the module object; the `Default` flag is not set on that shape |

Plus a sixth of the same class: a whole-module binding with **no** observed reference was silent, so another module's named import became the only evidence and decided the verdict for a package this module holds in full.

## Verification

`go build ./...` · `go vet` · **golangci-lint 0 issues** · full suite **177 packages, 0 failures** · `-race` green.

Measured on this repository's own frontend (103 modules, 487 edges, **zero coverage issues**): **608 named bindings**, all exactly answerable, against only **5** whole-module bindings. Modern TypeScript imports by name, so the analysis answers in the common case rather than degenerating into unknown.

## Not in this PR

No UI surface for a Tier-2 judgment beyond what the existing reachability views already render, and no Tier-2 for the other Tier-1 ecosystems (Python, Rust, PHP, Ruby) — the binding model here is npm-specific. Flagging rather than quietly omitting.
