### PR TITLE
fix(k8s): declare the enrol-token volume, and stop treating a spent token as fatal

### DIFF
--- a/cmd/synapse-agent/main.go
+++ b/cmd/synapse-agent/main.go
@@ -22,7 +22,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"syscall"
 	"time"
 
@@ -118,12 +117,14 @@ func parseConfig() config {
 	flag.IntVar(&cfg.maxOrders, "max-orders", 8, "max work orders to claim per cycle")
 	flag.BoolVar(&cfg.once, "once", false, "run a single cycle then exit")
 	flag.Parse()
-	if cfg.enrolToken == "" && enrolTokenFile != "" {
-		b, err := os.ReadFile(enrolTokenFile)
+	if cfg.enrolToken == "" {
+		// An absent token file is NOT fatal: it is the normal state after enrolment, once the
+		// one-time secret has been cleaned up. EnsureEnrolled decides from the stored credential.
+		tok, err := fleetclient.ReadEnrolTokenFile(enrolTokenFile)
 		if err != nil {
-			log.Fatalf("synapse-agent: read enrol token file: %v", err)
+			log.Fatalf("synapse-agent: %v", err)
 		}
-		cfg.enrolToken = strings.TrimSpace(string(b))
+		cfg.enrolToken = tok
 	}
 	return cfg
 }

--- a/cmd/synapse-cluster-agent/main.go
+++ b/cmd/synapse-cluster-agent/main.go
@@ -158,12 +158,14 @@ func parseConfig() config {
 	flag.BoolVar(&cfg.once, "once", false, "collect + report once then exit")
 	flag.Parse()
 
-	if cfg.enrolToken == "" && enrolTokenFile != "" {
-		b, err := os.ReadFile(enrolTokenFile)
+	if cfg.enrolToken == "" {
+		// An absent token file is NOT fatal: it is the normal state after enrolment, once the
+		// one-time secret has been cleaned up. EnsureEnrolled decides from the stored credential.
+		tok, err := fleetclient.ReadEnrolTokenFile(enrolTokenFile)
 		if err != nil {
-			log.Fatalf("synapse-cluster-agent: read enrol token file: %v", err)
+			log.Fatalf("synapse-cluster-agent: %v", err)
 		}
-		cfg.enrolToken = strings.TrimSpace(string(b))
+		cfg.enrolToken = tok
 	}
 	return cfg
 }

--- a/deploy/k8s/cluster-agent.yaml
+++ b/deploy/k8s/cluster-agent.yaml
@@ -51,8 +51,13 @@ subjects:
 # Secret before applying this manifest, e.g.:
 #   kubectl -n synapse create secret generic synapse-cluster-agent-enrol \
 #     --from-literal=enrol-token="<one-time token minted by the control plane>"
-# It is consumed on first enrolment; the agent then persists a long-lived credential in its state
-# volume, so a restart does not re-enrol. The Deployment reads it via secretKeyRef below.
+# It is consumed on first enrolment; the agent then persists a long-lived credential in the state PVC,
+# so a restart does not re-enrol. The Deployment mounts it as a FILE (see the enrol-token volume below),
+# not as an env var: an env secret is readable through /proc/<pid>/environ and follows child processes.
+#
+# Once enrolment has happened the Secret is dead weight and DELETING IT IS THE RIGHT THING TO DO. The
+# mount is therefore `optional: true` and the agent treats an absent token file as "no token supplied"
+# rather than as an error — otherwise that correct hygiene would leave a pod that can never restart.
 ---
 # Persists the agent credential across restarts (without it a restart would re-enrol with an
 # already-consumed one-time token and fail).
@@ -135,3 +140,20 @@ spec:
         - name: state
           persistentVolumeClaim:
             claimName: synapse-cluster-agent-state
+        # The one-time enrolment token, mounted read-only as a file.
+        #
+        # optional: true so the pod still starts once the consumed Secret has been deleted — the agent
+        # has its credential in the state PVC by then and an absent token file is not an error. Without
+        # this the correct cleanup of a spent one-time secret would permanently wedge the deployment.
+        #
+        # defaultMode 0440, not 0400: files in a Secret volume are owned root:fsGroup, so owner-only
+        # would lock out the container's own user (65532). 0440 lets the agent read it through fsGroup
+        # and nobody else read it at all.
+        - name: enrol-token
+          secret:
+            secretName: synapse-cluster-agent-enrol
+            optional: true
+            defaultMode: 0440
+            items:
+              - key: enrol-token
+                path: enrol-token

--- a/deploy/k8s/manifest_test.go
+++ b/deploy/k8s/manifest_test.go
@@ -1,0 +1,125 @@
+// Package k8s_test guards the shipped Kubernetes manifests against defects that otherwise only surface
+// when a real API server rejects them.
+//
+// This exists because `deploy/k8s/cluster-agent.yaml` shipped with a volumeMount naming a volume that
+// was never declared. Nothing in the Go build or in `kubectl apply --dry-run=client` looks at that: the
+// API server caught it, which meant the defect lived on main until a kind job spun up a cluster. These
+// checks are cheap, run in the ordinary Go job, and fail with a message that names the problem.
+package k8s_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func bytesReader(b []byte) io.Reader { return bytes.NewReader(b) }
+
+const manifestPath = "cluster-agent.yaml"
+
+type manifestDoc struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Template struct {
+			Spec struct {
+				Containers []struct {
+					Name         string `yaml:"name"`
+					VolumeMounts []struct {
+						Name      string `yaml:"name"`
+						MountPath string `yaml:"mountPath"`
+					} `yaml:"volumeMounts"`
+				} `yaml:"containers"`
+				Volumes []struct {
+					Name   string `yaml:"name"`
+					Secret *struct {
+						SecretName  string `yaml:"secretName"`
+						Optional    *bool  `yaml:"optional"`
+						DefaultMode *int   `yaml:"defaultMode"`
+					} `yaml:"secret"`
+				} `yaml:"volumes"`
+			} `yaml:"spec"`
+		} `yaml:"template"`
+	} `yaml:"spec"`
+}
+
+func loadDeployment(t *testing.T) manifestDoc {
+	t.Helper()
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", manifestPath, err)
+	}
+	dec := yaml.NewDecoder(bytesReader(raw))
+	for {
+		var doc manifestDoc
+		err := dec.Decode(&doc)
+		if err != nil {
+			break
+		}
+		if doc.Kind == "Deployment" {
+			return doc
+		}
+	}
+	t.Fatalf("%s contains no Deployment", manifestPath)
+	return manifestDoc{}
+}
+
+// TestEveryVolumeMountResolves is the check that was missing. A mount naming an undeclared volume makes
+// the API server refuse the whole Deployment ("volumeMounts[1].name: Not found"), so the agent is not
+// merely misconfigured — it never exists.
+func TestEveryVolumeMountResolves(t *testing.T) {
+	dep := loadDeployment(t)
+	spec := dep.Spec.Template.Spec
+
+	declared := make(map[string]bool, len(spec.Volumes))
+	for _, v := range spec.Volumes {
+		declared[v.Name] = true
+	}
+	if len(spec.Containers) == 0 {
+		t.Fatal("the Deployment declares no containers")
+	}
+	for _, c := range spec.Containers {
+		if len(c.VolumeMounts) == 0 {
+			continue
+		}
+		for _, m := range c.VolumeMounts {
+			if !declared[m.Name] {
+				t.Errorf("container %q mounts volume %q at %s, but no such volume is declared (the API server will reject this Deployment)",
+					c.Name, m.Name, m.MountPath)
+			}
+		}
+	}
+}
+
+// TestEnrolTokenSecretStaysOptional pins a property that reads like a loose end and is not one.
+//
+// The enrolment token is consumed once; afterwards the agent holds a long-lived credential on its state
+// volume and the Secret is dead weight, so deleting it is correct hygiene. If the mount were required,
+// that correct cleanup would leave a pod that can never restart. Anyone "tightening" this to
+// optional: false should have to delete this test and read why first.
+func TestEnrolTokenSecretStaysOptional(t *testing.T) {
+	spec := loadDeployment(t).Spec.Template.Spec
+	for _, v := range spec.Volumes {
+		if v.Secret == nil {
+			continue
+		}
+		if v.Secret.Optional == nil || !*v.Secret.Optional {
+			t.Errorf("secret volume %q (%s) is not optional: the pod could not restart after the spent one-time token is deleted",
+				v.Name, v.Secret.SecretName)
+		}
+		// Files in a Secret volume are owned root:fsGroup, so an owner-only mode locks out the
+		// container's own non-root user. 0440 is readable through fsGroup and by nobody else.
+		if v.Secret.DefaultMode == nil {
+			t.Errorf("secret volume %q sets no defaultMode; a token would default to world-readable 0644", v.Name)
+			continue
+		}
+		if mode := *v.Secret.DefaultMode; mode&0o007 != 0 {
+			t.Errorf("secret volume %q has mode %#o, which grants access to other: a bearer token must not be world-readable", v.Name, mode)
+		}
+	}
+}

--- a/internal/infrastructure/fleetclient/credential.go
+++ b/internal/infrastructure/fleetclient/credential.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // ValidateControlPlaneURL refuses a cleartext control-plane URL so the bearer credential cannot
@@ -134,6 +136,33 @@ func WriteSecret(path string, data []byte, mode os.FileMode) error {
 // It is false on Windows, where os.Chmod only toggles the read-only attribute. Callers use it to
 // state the guarantee they actually have rather than the one they wrote down.
 func SecretModeEnforced() bool { return runtime.GOOS != "windows" }
+
+// ReadEnrolTokenFile reads a one-time enrolment token from path, treating an ABSENT file as "no token
+// supplied" rather than as an error.
+//
+// The distinction is the whole point. An enrolment token is consumed on first use, after which the
+// agent holds a long-lived credential and the token is dead weight — so an operator deleting the
+// consumed secret is doing the right thing. If a missing file were fatal, that correct hygiene would
+// mean the agent could never restart, which is how a Kubernetes deployment ends up unable to come back
+// after its Secret is cleaned up. EnsureEnrolled already decides correctly from here: a stored
+// credential wins, and only "no credential AND no token" is an error.
+//
+// Every OTHER read failure stays an error. A file that exists but cannot be read — wrong mode, a
+// directory, a broken mount — is a misconfiguration, and silently treating it as "no token" would
+// convert it into a confusing enrolment failure somewhere further away.
+func ReadEnrolTokenFile(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	b, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("fleetclient: read enrolment token file: %w", err)
+	}
+	return strings.TrimSpace(string(b)), nil
+}
 
 // Enroller is the subset of the client EnsureEnrolled needs; *Client satisfies it, and an agent's
 // test fake can too.

--- a/internal/infrastructure/fleetclient/enrol_token_file_test.go
+++ b/internal/infrastructure/fleetclient/enrol_token_file_test.go
@@ -1,0 +1,79 @@
+package fleetclient
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestReadEnrolTokenFile(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("no path configured is not an error", func(t *testing.T) {
+		tok, err := ReadEnrolTokenFile("")
+		if err != nil || tok != "" {
+			t.Fatalf("got (%q, %v), want empty and no error", tok, err)
+		}
+	})
+
+	// The case the Kubernetes deployment depends on. After enrolment the one-time Secret is dead
+	// weight, so an operator deleting it is right; if that made this fatal, the pod could never
+	// restart even though its credential is on the state volume.
+	t.Run("an absent file is not an error, because a spent token gets deleted", func(t *testing.T) {
+		tok, err := ReadEnrolTokenFile(filepath.Join(dir, "does-not-exist"))
+		if err != nil {
+			t.Fatalf("absent file must not be an error, got %v", err)
+		}
+		if tok != "" {
+			t.Fatalf("got token %q from an absent file", tok)
+		}
+	})
+
+	t.Run("a token is read and trimmed", func(t *testing.T) {
+		path := filepath.Join(dir, "token")
+		// Trailing newlines are what `kubectl create secret --from-file` and shell redirection produce;
+		// an untrimmed token fails enrolment with an authentication error that looks like a bad secret.
+		if err := os.WriteFile(path, []byte("  one-time-token-value\n\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		tok, err := ReadEnrolTokenFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tok != "one-time-token-value" {
+			t.Fatalf("got %q, want the trimmed token", tok)
+		}
+	})
+
+	// A file that exists but cannot be read is a MISCONFIGURATION, and must not be silently reported as
+	// "no token": that would surface far away as an unexplained enrolment failure.
+	t.Run("a directory in place of the file is an error", func(t *testing.T) {
+		path := filepath.Join(dir, "as-a-directory")
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReadEnrolTokenFile(path); err == nil {
+			t.Fatal("want an error when the path is a directory, got nil")
+		}
+	})
+
+	t.Run("an unreadable file is an error, not an absent token", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows uses ACLs, not permission bits; os.Chmod cannot make a file unreadable here")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses permission bits, so this case cannot be provoked")
+		}
+		path := filepath.Join(dir, "unreadable")
+		if err := os.WriteFile(path, []byte("secret"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReadEnrolTokenFile(path); err == nil {
+			t.Fatal("want an error for an existing but unreadable file, got nil")
+		}
+	})
+}


### PR DESCRIPTION
Fixes the `K8s Integration (kind)` failure on `main` ([run 31312564360](https://github.com/KKloudTarus/synapse-ce/actions/runs/31312564360)).

## What was broken

The API server refuses the whole Deployment:

```
spec.template.spec.containers[0].volumeMounts[1].name: Not found: "enrol-token"
```

The container mounts an `enrol-token` volume that **was never declared**. So the cluster agent does not start misconfigured — it never exists at all. `kubectl apply` fails before a pod is ever created.

This shipped in #448 and sat on `main` because **the workflow had never run once**: Actions were disabled at the time. Its first run is the merge of #472, which is why an unrelated PR looks like the culprit. It is not.

## The defect behind the defect

Declaring the volume made the pod startable, and that surfaced the more interesting bug. `parseConfig` did:

```go
b, err := os.ReadFile(enrolTokenFile)
if err != nil { log.Fatalf(...) }
```

which **pre-empts `EnsureEnrolled`** — and `EnsureEnrolled` already gets this right: a stored credential wins, and only *"no credential AND no token"* is an error.

An enrolment token is consumed **once**. After that the agent holds a long-lived credential on its state PVC and the Secret is dead weight, so an operator deleting it is doing the right thing. With that `Fatalf`, **correct hygiene produced a pod that could never restart** — holding a perfectly valid credential the whole time.

So an **absent** token file is no longer an error. Every **other** read failure still is — wrong mode, a directory, a broken mount — because that is misconfiguration, and silently reading it as "no token" would resurface as an unexplained enrolment failure somewhere far away. Both the host agent and the cluster agent carried the same bug and now share one helper.

Two smaller points, both deliberate:

- `optional: true` on the mount, for the same restart-after-cleanup reason. There is a test whose only job is to make someone who "tightens" this to `false` read why first.
- `defaultMode: 0440`, **not** `0400`. Files in a Secret volume are owned `root:fsGroup`, so owner-only locks out the container's own non-root user (65532). 0440 is readable through `fsGroup` and by nobody else.

## Why the guards are in the ordinary Go job

A dangling `volumeMount` is invisible to the Go build **and** to `kubectl apply --dry-run=client` — only a real API server rejects it. That is exactly how this reached `main`: the check that would have caught it needed a cluster, and the cluster job was off.

`deploy/k8s/manifest_test.go` runs in `Backend (Go)`, needs no cluster, and fails with a message that names the volume and the mount path. **Both guards were confirmed to fail against the exact manifest that shipped** — the dangling-mount case reproduces the API server's complaint, and flipping `optional` to `false` trips the other. A guard that has never been seen failing is not yet a guard.

## Verification

- `go build ./...` · `go vet ./...` clean · `golangci-lint` 0 issues
- `TestReadEnrolTokenFile` — absent / trimmed / directory-in-place-of-file / unreadable
- `TestEveryVolumeMountResolves`, `TestEnrolTokenSecretStaysOptional` — both verified to fail on the pre-fix manifest
- The `kind` job itself runs on this PR (`deploy/k8s/cluster-agent.yaml` is in its `paths` filter), which is the acceptance evidence for the apply.
