### PR TITLE
feat(dast): add governed authenticated scanning and crawling (#416, #417)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,16 @@ builds:
     goarch: *build_goarch
     ignore: *build_ignore
 
+  - id: synapse-dast-helper
+    main: ./cmd/synapse-dast-helper
+    binary: synapse-dast-helper
+    env: *build_env
+    flags: *build_flags
+    ldflags: *build_ldflags
+    goos: *build_goos
+    goarch: *build_goarch
+    ignore: *build_ignore
+
   - id: synapse-worker
     main: ./cmd/synapse-worker
     binary: synapse-worker
@@ -88,6 +98,7 @@ archives:
     ids:
       - synapse-cli
       - synapse-api
+      - synapse-dast-helper
       - synapse-worker
       - synapse-callgraph
       - synapse-mcp

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -27,6 +27,8 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/acquire"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/cache/sbomcache"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/dastchecks"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/dastengine"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/ebpf"
 	egressinfra "github.com/KKloudTarus/synapse-ce/internal/infrastructure/egress"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetca"
@@ -104,6 +106,7 @@ import (
 	credentialsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/credentials"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/crosscheckjudge"
 	dastrunneruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
+	dastsessionuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastsession"
 	dastverifieruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastverifier"
 	dastworkflowuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastworkflow"
 	egresspolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/egress"
@@ -1038,13 +1041,31 @@ func main() {
 					log.Error("DAST safe verifier runner init failed", "err", derr)
 					os.Exit(1)
 				}
-				dastWorkflowSvc, werr := dastworkflowuc.NewService(safetyGate, approvalSvc, approvalStore, dastRunnerSvc, clock, ids)
+				dastWorkflowSvc, werr := dastworkflowuc.NewService(safetyGate, approvalSvc, approvalStore, dastRunnerSvc, evidenceService, clock, ids)
 				if werr != nil {
 					log.Error("DAST verifier workflow init failed", "err", werr)
 					os.Exit(1)
 				}
 				router.SetDASTWorkflow(dastWorkflowSvc)
-				log.Info("DAST verifier workflow ENABLED (sandbox egress-enforced)")
+				engine, eerr := dastengine.New(reconRunner, cfg.DASTHelperBin, cfg.DASTMaxWallClock, cfg.ReconMaxOutput)
+				if eerr != nil {
+					log.Error("authenticated DAST engine init failed", "err", eerr)
+					os.Exit(1)
+				}
+				sessionSvc, serr := dastsessionuc.NewService(engine, reconGuard, evidenceService)
+				if serr != nil {
+					log.Error("authenticated DAST session init failed", "err", serr)
+					os.Exit(1)
+				}
+				ceilings := dastworkflowuc.DefaultScanCeilings()
+				ceilings.MaxReauth, ceilings.RatePerSec, ceilings.Concurrency = cfg.DASTMaxReauth, cfg.DASTRatePerSec, cfg.DASTConcurrency
+				ceilings.Limits.Depth, ceilings.Limits.Pages, ceilings.Limits.Requests, ceilings.Limits.WallClock = cfg.DASTMaxDepth, cfg.DASTMaxPages, cfg.DASTMaxRequests, cfg.DASTMaxWallClock
+				if err := dastWorkflowSvc.SetScan(sessionSvc, cfg.DASTHelperBin, evidenceService, dastchecks.NewEvaluator(), dastchecks.NewEvaluator(), judgmentSvc, runtimeVerifierSvc, ceilings); err != nil {
+					log.Error("authenticated DAST scan workflow init failed", "err", err)
+					os.Exit(1)
+				}
+				router.SetDASTScan(dastWorkflowSvc)
+				log.Info("DAST verifier and authenticated scan workflows ENABLED (sandbox egress-enforced)")
 			} else {
 				log.Warn("DAST verifier workflow DISABLED: sandbox kernel egress enforcement is unavailable")
 			}

--- a/cmd/synapse-dast-helper/main.go
+++ b/cmd/synapse-dast-helper/main.go
@@ -1,0 +1,23 @@
+// synapse-dast-helper owns HTTP clients and authenticated session state outside the API process.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/dastengine"
+)
+
+func main() {
+	if len(os.Args) != 3 || os.Args[1] != "run" || !strings.HasPrefix(os.Args[2], "--config-sha256=") || len(strings.TrimPrefix(os.Args[2], "--config-sha256=")) != 64 {
+		fmt.Fprintln(os.Stderr, "usage: synapse-dast-helper run --config-sha256=<hex>")
+		os.Exit(2)
+	}
+	if err := dastengine.RunHelper(context.Background(), os.Stdin, os.Stdout); err != nil {
+		// RunHelper errors deliberately omit request headers, response bodies, and secrets.
+		fmt.Fprintln(os.Stderr, "synapse-dast-helper:", err)
+		os.Exit(1)
+	}
+}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,7 +19,8 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -o /out/synapse-api ./cmd/synapse-api
+RUN CGO_ENABLED=0 go build -trimpath -o /out/synapse-api ./cmd/synapse-api \
+    && CGO_ENABLED=0 go build -trimpath -o /out/synapse-dast-helper ./cmd/synapse-dast-helper
 # synapse-cli is bundled too so the image doubles as a cross-platform scanner
 # (`docker run … synapse-cli scan /scan`) – the SCA path runs identically on any host
 # that runs Linux containers (Windows/macOS via Docker Desktop, Linux natively).
@@ -49,6 +50,7 @@ RUN apt-get update \
     && mkdir -p /home/synapse/.m2 /home/synapse/.gradle /home/synapse/project-source-artifacts \
     && chown -R synapse:synapse /home/synapse
 COPY --from=build /out/synapse-api /usr/local/bin/synapse-api
+COPY --from=build /out/synapse-dast-helper /usr/local/bin/synapse-dast-helper
 COPY --from=build /out/synapse-cli /usr/local/bin/synapse-cli
 COPY --from=syft /syft /usr/local/bin/syft
 COPY --from=grype /grype /usr/local/bin/grype
@@ -71,6 +73,7 @@ ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/synapse-api"]
 # ---------------------------------------------------------------------------
 FROM gcr.io/distroless/static-debian12:nonroot AS api
 COPY --from=build /out/synapse-api /synapse-api
+COPY --from=build /out/synapse-dast-helper /synapse-dast-helper
 COPY --from=build /out/synapse-cli /synapse-cli
 COPY --from=syft /syft /usr/local/bin/syft
 COPY --from=grype /grype /usr/local/bin/grype

--- a/internal/adapter/httpapi/dast_scan_handler.go
+++ b/internal/adapter/httpapi/dast_scan_handler.go
@@ -1,0 +1,140 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastcrawl"
+	dastworkflowuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastworkflow"
+)
+
+// dastScanBody accepts only secret-free configuration. Credential values must already
+// be stored in the engagement credential vault and are named by reference.
+type dastScanBody struct {
+	Target           string      `json:"target"`
+	Session          sessionBody `json:"session"`
+	Crawler          crawlerBody `json:"crawler"`
+	SelectedCheckIDs []string    `json:"selected_check_ids"`
+}
+
+type sessionBody struct {
+	Scheme       dastsession.Scheme `json:"scheme"`
+	Credentials  []credentialBody   `json:"credentials"`
+	LoginRequest requestBody        `json:"login_request"`
+	Success      successBody        `json:"success"`
+	CheckRequest requestBody        `json:"check_request"`
+	DenyPaths    []string           `json:"deny_paths"`
+	MaxReauth    int                `json:"max_reauth"`
+}
+
+type credentialBody struct {
+	Name      string `json:"name"`
+	Reference string `json:"reference"`
+	Field     string `json:"field"`
+}
+
+type requestBody struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+}
+
+type successBody struct {
+	StatusCode    int    `json:"status_code"`
+	BodyContains  string `json:"body_contains"`
+	HeaderPresent string `json:"header_present"`
+	CookiePresent string `json:"cookie_present"`
+}
+
+type crawlerBody struct {
+	Seeds       []dastsurface.Request `json:"seeds"`
+	Robots      string                `json:"robots"`
+	Sitemaps    []string              `json:"sitemaps"`
+	OpenAPI     []string              `json:"openapi"`
+	GraphQL     []string              `json:"graphql"`
+	RatePerSec  int                   `json:"rate_per_sec"`
+	Concurrency int                   `json:"concurrency"`
+	MaxDepth    int                   `json:"max_depth"`
+	MaxPages    int                   `json:"max_pages"`
+	MaxRequests int                   `json:"max_requests"`
+	WallClock   string                `json:"wall_clock"`
+}
+
+func (b dastScanBody) config() (dastworkflowuc.ScanConfig, error) {
+	wallClock := time.Duration(0)
+	if b.Crawler.WallClock != "" {
+		var err error
+		wallClock, err = time.ParseDuration(b.Crawler.WallClock)
+		if err != nil {
+			return dastworkflowuc.ScanConfig{}, err
+		}
+	}
+	credentials := make([]dastsession.CredentialBinding, len(b.Session.Credentials))
+	for i, c := range b.Session.Credentials {
+		credentials[i] = dastsession.CredentialBinding{Name: c.Name, Reference: c.Reference, Field: c.Field}
+	}
+	return dastworkflowuc.ScanConfig{
+		Target: b.Target,
+		Session: dastsession.Config{Scheme: b.Session.Scheme, Credentials: credentials,
+			LoginRequest: dastsession.Request{Method: b.Session.LoginRequest.Method, Path: b.Session.LoginRequest.Path},
+			Success:      dastsession.SuccessSignal{StatusCode: b.Session.Success.StatusCode, BodyContains: b.Session.Success.BodyContains, HeaderPresent: b.Session.Success.HeaderPresent, CookiePresent: b.Session.Success.CookiePresent},
+			CheckRequest: dastsession.Request{Method: b.Session.CheckRequest.Method, Path: b.Session.CheckRequest.Path},
+			DenyPaths:    b.Session.DenyPaths, MaxReauth: b.Session.MaxReauth},
+		Crawler:    dastcrawl.Input{Target: b.Target, Seeds: b.Crawler.Seeds, Robots: b.Crawler.Robots, Sitemaps: b.Crawler.Sitemaps, OpenAPI: b.Crawler.OpenAPI, GraphQL: b.Crawler.GraphQL},
+		Limits:     dastcrawl.Limits{Depth: b.Crawler.MaxDepth, Pages: b.Crawler.MaxPages, Requests: b.Crawler.MaxRequests, WallClock: wallClock},
+		RatePerSec: b.Crawler.RatePerSec, Concurrency: b.Crawler.Concurrency, SelectedCheckIDs: b.SelectedCheckIDs,
+	}, nil
+}
+
+func decodeDASTScan(w http.ResponseWriter, r *http.Request) (dastworkflowuc.ScanConfig, error) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 256<<10))
+	if err != nil {
+		return dastworkflowuc.ScanConfig{}, err
+	}
+	if strings.Contains(strings.ToLower(string(body)), "{{secret:") {
+		return dastworkflowuc.ScanConfig{}, shared.ErrValidation
+	}
+	var request dastScanBody
+	dec := json.NewDecoder(strings.NewReader(string(body)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&request); err != nil {
+		return dastworkflowuc.ScanConfig{}, err
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return dastworkflowuc.ScanConfig{}, shared.ErrValidation
+	}
+	return request.config()
+}
+
+func (rt *Router) proposeDASTScan(w http.ResponseWriter, r *http.Request) {
+	config, err := decodeDASTScan(w, r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid DAST scan configuration"})
+		return
+	}
+	out, err := rt.dastScan.ProposeScan(r.Context(), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), config)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, out)
+}
+
+func (rt *Router) runDASTScan(w http.ResponseWriter, r *http.Request) {
+	config, err := decodeDASTScan(w, r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid DAST scan configuration"})
+		return
+	}
+	out, err := rt.dastScan.RunScan(r.Context(), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), shared.ID(r.PathValue("aid")), config)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/internal/adapter/httpapi/dast_scan_handler_test.go
+++ b/internal/adapter/httpapi/dast_scan_handler_test.go
@@ -1,0 +1,57 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	dastworkflowuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastworkflow"
+)
+
+type recordingDASTScan struct{ proposed dastworkflowuc.ScanConfig }
+
+func (s *recordingDASTScan) ProposeScan(_ context.Context, _ string, _ shared.ID, c dastworkflowuc.ScanConfig) (dastworkflowuc.Proposal, error) {
+	s.proposed = c
+	return dastworkflowuc.Proposal{}, nil
+}
+func (s *recordingDASTScan) Decide(context.Context, string, shared.ID, shared.ID, bool, string) (agent.ApprovalDecision, error) {
+	return agent.ApprovalDecision{}, nil
+}
+func (s *recordingDASTScan) RunScan(context.Context, string, shared.ID, shared.ID, dastworkflowuc.ScanConfig) (dastworkflowuc.ScanResult, error) {
+	return dastworkflowuc.ScanResult{}, nil
+}
+
+func TestDASTScanHandlerRejectsSecretsAndUnknownFields(t *testing.T) {
+	for _, body := range []string{
+		`{"target":"https://app.test","unknown":true}`,
+		`{"target":"https://app.test","session":{"credentials":[{"name":"token","reference":"{{secret:token}}"}]}}`,
+	} {
+		rt := &Router{log: discardLog()}
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/engagements/e/dast/proposals", strings.NewReader(body))
+		req.SetPathValue("id", "e")
+		rec := httptest.NewRecorder()
+		rt.proposeDASTScan(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestDASTScanHandlerMapsVaultReferences(t *testing.T) {
+	scan := &recordingDASTScan{}
+	rt := &Router{log: discardLog()}
+	rt.SetDASTScan(scan)
+	body := `{"target":"https://app.test","session":{"scheme":"bearer","credentials":[{"name":"token","reference":"login-token"}],"login_request":{"method":"GET","path":"/"},"success":{"status_code":200},"check_request":{"method":"GET","path":"/"}},"crawler":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/engagements/e/dast/proposals", strings.NewReader(body))
+	req.SetPathValue("id", "e")
+	req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "alice"}))
+	rec := httptest.NewRecorder()
+	rt.proposeDASTScan(rec, req)
+	if rec.Code != http.StatusAccepted || len(scan.proposed.Session.Credentials) != 1 || scan.proposed.Session.Credentials[0].Reference != "login-token" {
+		t.Fatalf("status=%d proposed=%+v", rec.Code, scan.proposed)
+	}
+}

--- a/internal/adapter/httpapi/dast_workflow_handler.go
+++ b/internal/adapter/httpapi/dast_workflow_handler.go
@@ -52,16 +52,18 @@ func (rt *Router) decideRuntimeVerification(w http.ResponseWriter, r *http.Reque
 		Approve bool   `json:"approve"`
 		Reason  string `json:"reason"`
 	}
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<10)).Decode(&body); err != nil {
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<10))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
 		return
 	}
-	dec, err := rt.dastWorkflow.Decide(r.Context(), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), shared.ID(r.PathValue("aid")), body.Approve, body.Reason)
+	out, err := rt.dastWorkflow.Decide(r.Context(), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), shared.ID(r.PathValue("aid")), body.Approve, body.Reason)
 	if err != nil {
 		writeError(w, rt.log, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, dec)
+	writeJSON(w, http.StatusOK, out)
 }
 
 func (rt *Router) runRuntimeVerification(w http.ResponseWriter, r *http.Request) {

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -70,6 +70,7 @@ type Router struct {
 	qualityGates      qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
 	qualityProfiles   qualityProfileService // optional; nil ⇒ quality-profile routes are not registered
 	rules             rulesService          // optional; nil ⇒ rule catalog routes are not registered
+	dastScan          dastScanService
 }
 
 // findingVerifier is the narrow slice of the exploitation use-case the verify endpoint needs:
@@ -128,6 +129,14 @@ type dastWorkflowService interface {
 
 // SetDASTWorkflow wires the governed safe-DAST proposal/approval/run endpoints.
 func (rt *Router) SetDASTWorkflow(s dastWorkflowService) { rt.dastWorkflow = s }
+
+type dastScanService interface {
+	ProposeScan(context.Context, string, shared.ID, dastworkflowuc.ScanConfig) (dastworkflowuc.Proposal, error)
+	RunScan(context.Context, string, shared.ID, shared.ID, dastworkflowuc.ScanConfig) (dastworkflowuc.ScanResult, error)
+}
+
+// SetDASTScan wires secret-free authenticated DAST scan endpoints.
+func (rt *Router) SetDASTScan(s dastScanService) { rt.dastScan = s }
 
 // SetThreatModel wires the architecture threat-model ingest/read endpoints. nil ⇒ not registered.
 func (rt *Router) SetThreatModel(s threatModelService) { rt.threatModels = s }
@@ -341,6 +350,10 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/engagements/{id}/judgments/{jid}/runtime-verification/proposals", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.proposeRuntimeVerification)))
 		mux.HandleFunc("POST /api/v1/engagements/{id}/dast/approvals/{aid}/decide", rt.authz(userdom.PermReview, rt.withEngTenant(rt.decideRuntimeVerification)))
 		mux.HandleFunc("POST /api/v1/engagements/{id}/judgments/{jid}/runtime-verification/proposals/{aid}/run", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.runRuntimeVerification)))
+	}
+	if rt.dastScan != nil {
+		mux.HandleFunc("POST /api/v1/engagements/{id}/dast/proposals", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.proposeDASTScan)))
+		mux.HandleFunc("POST /api/v1/engagements/{id}/dast/proposals/{aid}/run", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.runDASTScan)))
 	}
 	if rt.threatModels != nil { // architecture threat-model ingest (PermOperate) + read (PermView)
 		mux.HandleFunc("PUT /api/v1/engagements/{id}/threat-model", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.putThreatModel)))

--- a/internal/domain/agent/agent.go
+++ b/internal/domain/agent/agent.go
@@ -173,6 +173,7 @@ const (
 	ApprovalApproved ApprovalState = "approved"
 	ApprovalDenied   ApprovalState = "denied"
 	ApprovalTimeout  ApprovalState = "timeout" // undecided within the window → fail-closed deny
+	ApprovalConsumed ApprovalState = "consumed"
 )
 
 // Admitted reports whether the decision permits execution (only an explicit human approval).

--- a/internal/domain/dastcheck/catalog.go
+++ b/internal/domain/dastcheck/catalog.go
@@ -1,0 +1,20 @@
+package dastcheck
+
+// Catalog is the complete production-safe DAST corpus. Entries deliberately
+// cover passive response observations only; injection and state-changing probes
+// are never included.
+var Catalog = []CatalogEntry{
+	{ID: "auth-configured-weakness", CWE: "CWE-287", Class: ClassAuthenticationWeakness, Title: "Configured authentication weakness", Description: "A configured, deterministic authentication weakness signature was observed.", Remediation: "Remove the weak authentication behavior and require the intended authentication control."},
+	{ID: "cookie-security-flags", CWE: "CWE-614", Class: ClassMisconfiguration, Title: "Cookie security flags", Description: "An observed cookie omitted a configured transport, script, or cross-site protection flag.", Remediation: "Set Secure, HttpOnly, and an appropriate SameSite attribute on session cookies."},
+	{ID: "security-headers", CWE: "CWE-693", Class: ClassMisconfiguration, Title: "Security response headers", Description: "A supported HTTP response omitted a required security header.", Remediation: "Set the required response security headers at the application or edge."},
+	{ID: "sensitive-public-artifact", CWE: "CWE-200", Class: ClassSensitiveDataExposure, Title: "Sensitive public artifact", Description: "A deterministic source-map or well-known sensitive artifact signature was exposed.", Remediation: "Remove the artifact from public deployment or restrict it to authorized users."},
+}
+
+// Checks is the executable counterpart of Catalog. ValidateParity keeps the
+// public catalog and implementation set from drifting apart.
+var Checks = []Check{
+	{ID: "auth-configured-weakness", CWE: "CWE-287", Class: ClassAuthenticationWeakness, BlastRadius: RadiusReadOnly, ProductionSafe: true, ProofClass: "configured_signature"},
+	{ID: "cookie-security-flags", CWE: "CWE-614", Class: ClassMisconfiguration, BlastRadius: RadiusReadOnly, ProductionSafe: true, ProofClass: "cookie_flags"},
+	{ID: "security-headers", CWE: "CWE-693", Class: ClassMisconfiguration, BlastRadius: RadiusReadOnly, ProductionSafe: true, ProofClass: "response_headers"},
+	{ID: "sensitive-public-artifact", CWE: "CWE-200", Class: ClassSensitiveDataExposure, BlastRadius: RadiusReadOnly, ProductionSafe: true, ProofClass: "artifact_signature"},
+}

--- a/internal/domain/dastcheck/check.go
+++ b/internal/domain/dastcheck/check.go
@@ -1,0 +1,122 @@
+// Package dastcheck defines the metadata contract for first-party DAST checks.
+package dastcheck
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var idRE = regexp.MustCompile(`^[a-z][a-z0-9-]{2,63}$`)
+
+// Class is a clean-room DAST check category.
+type Class string
+
+const (
+	ClassInjection               Class = "injection"
+	ClassBrokenAccessControl     Class = "broken_access_control"
+	ClassSSRF                    Class = "ssrf"
+	ClassInsecureDeserialization Class = "insecure_deserialization"
+	ClassMisconfiguration        Class = "security_misconfiguration"
+	ClassSensitiveDataExposure   Class = "sensitive_data_exposure"
+	ClassAuthenticationWeakness  Class = "authentication_weakness"
+)
+
+func (c Class) Valid() bool {
+	switch c {
+	case ClassInjection, ClassBrokenAccessControl, ClassSSRF, ClassInsecureDeserialization, ClassMisconfiguration, ClassSensitiveDataExposure, ClassAuthenticationWeakness:
+		return true
+	}
+	return false
+}
+
+// BlastRadius identifies whether a check can modify application state.
+type BlastRadius string
+
+const (
+	RadiusReadOnly      BlastRadius = "read_only"
+	RadiusStateChanging BlastRadius = "state_changing"
+)
+
+func (r BlastRadius) Valid() bool { return r == RadiusReadOnly || r == RadiusStateChanging }
+
+// Check is the executable check contract. ProofClass names the required evidence
+// observation; checks without a proof must not create a finding.
+type Check struct {
+	ID             string
+	CWE            string
+	Class          Class
+	BlastRadius    BlastRadius
+	ProductionSafe bool
+	ProofClass     string
+}
+
+func (c Check) Validate() error {
+	if !idRE.MatchString(c.ID) || strings.TrimSpace(c.CWE) == "" || !c.Class.Valid() || !c.BlastRadius.Valid() || strings.TrimSpace(c.ProofClass) == "" {
+		return fmt.Errorf("%w: invalid DAST check metadata", shared.ErrValidation)
+	}
+	if c.BlastRadius == RadiusStateChanging && c.ProductionSafe {
+		return fmt.Errorf("%w: state-changing DAST check cannot be production-safe", shared.ErrValidation)
+	}
+	return nil
+}
+
+// CatalogEntry is non-executable check metadata published to operators.
+type CatalogEntry struct {
+	ID          string
+	CWE         string
+	Class       Class
+	Title       string
+	Description string
+	Remediation string
+}
+
+func (e CatalogEntry) Validate() error {
+	if !idRE.MatchString(e.ID) || strings.TrimSpace(e.CWE) == "" || !e.Class.Valid() || strings.TrimSpace(e.Title) == "" || strings.TrimSpace(e.Description) == "" || strings.TrimSpace(e.Remediation) == "" {
+		return fmt.Errorf("%w: invalid DAST catalog metadata", shared.ErrValidation)
+	}
+	return nil
+}
+
+// ValidateParity rejects catalog drift: each implemented check must have exactly
+// one catalog entry with the same stable ID and class, and vice versa.
+func ValidateParity(catalog []CatalogEntry, checks []Check) error {
+	catalogByID := make(map[string]CatalogEntry, len(catalog))
+	for _, entry := range catalog {
+		if err := entry.Validate(); err != nil {
+			return err
+		}
+		if _, exists := catalogByID[entry.ID]; exists {
+			return fmt.Errorf("%w: duplicate DAST catalog ID %q", shared.ErrValidation, entry.ID)
+		}
+		catalogByID[entry.ID] = entry
+	}
+	checkByID := make(map[string]Check, len(checks))
+	for _, check := range checks {
+		if err := check.Validate(); err != nil {
+			return err
+		}
+		if _, exists := checkByID[check.ID]; exists {
+			return fmt.Errorf("%w: duplicate DAST check ID %q", shared.ErrValidation, check.ID)
+		}
+		checkByID[check.ID] = check
+		entry, found := catalogByID[check.ID]
+		if !found || entry.Class != check.Class || entry.CWE != check.CWE {
+			return fmt.Errorf("%w: DAST check %q has no matching catalog entry", shared.ErrValidation, check.ID)
+		}
+	}
+	if len(catalogByID) != len(checkByID) {
+		return fmt.Errorf("%w: DAST catalog and checks differ", shared.ErrValidation)
+	}
+	return nil
+}
+
+// SortedCatalog returns a deterministic copy for response and fixture generation.
+func SortedCatalog(catalog []CatalogEntry) []CatalogEntry {
+	out := append([]CatalogEntry(nil), catalog...)
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}

--- a/internal/domain/dastcheck/check_test.go
+++ b/internal/domain/dastcheck/check_test.go
@@ -1,0 +1,27 @@
+package dastcheck
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestValidateParity(t *testing.T) {
+	catalog := []CatalogEntry{{ID: "header-leak", CWE: "CWE-200", Class: ClassMisconfiguration, Title: "Header leak", Description: "A response reveals a server header.", Remediation: "Remove the header."}}
+	checks := []Check{{ID: "header-leak", CWE: "CWE-200", Class: ClassMisconfiguration, BlastRadius: RadiusReadOnly, ProductionSafe: true, ProofClass: "response_header"}}
+	if err := ValidateParity(catalog, checks); err != nil {
+		t.Fatalf("ValidateParity: %v", err)
+	}
+	checks[0].Class = ClassInjection
+	if err := ValidateParity(catalog, checks); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("drift = %v, want ErrValidation", err)
+	}
+}
+
+func TestCheckRejectsUnsafeProductionMetadata(t *testing.T) {
+	check := Check{ID: "state-change", CWE: "CWE-89", Class: ClassInjection, BlastRadius: RadiusStateChanging, ProductionSafe: true, ProofClass: "response_delta"}
+	if err := check.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("Validate() = %v, want ErrValidation", err)
+	}
+}

--- a/internal/domain/dastsession/config.go
+++ b/internal/domain/dastsession/config.go
@@ -1,0 +1,192 @@
+// Package dastsession defines secret-free authenticated DAST session configuration.
+package dastsession
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const DefaultMaxReauth = 2
+
+var bindingNameRE = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]{0,63}$`)
+
+// Scheme is the supported authentication mechanism. Credential values are resolved
+// only by the execution layer from their vault references.
+type Scheme string
+
+const (
+	SchemeForm   Scheme = "form"
+	SchemeBasic  Scheme = "basic"
+	SchemeBearer Scheme = "bearer"
+	SchemeHeader Scheme = "header"
+	SchemeCookie Scheme = "cookie"
+)
+
+func (s Scheme) Valid() bool {
+	switch s {
+	case SchemeForm, SchemeBasic, SchemeBearer, SchemeHeader, SchemeCookie:
+		return true
+	}
+	return false
+}
+
+// CredentialBinding identifies one credential by vault reference. It never carries
+// plaintext credential material.
+type CredentialBinding struct {
+	Name      string
+	Reference string
+	Field     string
+}
+
+func (b CredentialBinding) Validate() error {
+	if !bindingNameRE.MatchString(b.Name) {
+		return fmt.Errorf("%w: credential binding name is invalid", shared.ErrValidation)
+	}
+	if strings.TrimSpace(b.Reference) == "" {
+		return fmt.Errorf("%w: credential binding %q needs a vault reference", shared.ErrValidation, b.Name)
+	}
+	if b.Field != "" && !bindingNameRE.MatchString(b.Field) {
+		return fmt.Errorf("%w: credential binding field is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+// Request describes a secret-free request template. Path is an absolute URL path;
+// request bodies and credential values stay in the vault-backed execution layer.
+type Request struct {
+	Method string
+	Path   string
+}
+
+func (r Request) Validate() error {
+	if strings.TrimSpace(r.Method) == "" {
+		return fmt.Errorf("%w: request method is required", shared.ErrValidation)
+	}
+	if !validPath(r.Path) {
+		return fmt.Errorf("%w: request path must be absolute and clean", shared.ErrValidation)
+	}
+	return nil
+}
+
+// SuccessSignal is the deterministic assertion that proves an authentication attempt succeeded.
+type SuccessSignal struct {
+	StatusCode    int
+	BodyContains  string
+	HeaderPresent string
+	CookiePresent string
+}
+
+func (s SuccessSignal) Validate() error {
+	if s.StatusCode < 0 || s.StatusCode > 999 {
+		return fmt.Errorf("%w: success status code is invalid", shared.ErrValidation)
+	}
+	if s.StatusCode == 0 && strings.TrimSpace(s.BodyContains) == "" && strings.TrimSpace(s.HeaderPresent) == "" && strings.TrimSpace(s.CookiePresent) == "" {
+		return fmt.Errorf("%w: authentication success signal is required", shared.ErrValidation)
+	}
+	return nil
+}
+
+// Config defines an authenticated scan without credential values. CheckRequest is
+// performed before probe batches; MaxReauth bounds retries after session loss.
+type Config struct {
+	Scheme       Scheme
+	Credentials  []CredentialBinding
+	LoginRequest Request
+	Success      SuccessSignal
+	CheckRequest Request
+	DenyPaths    []string
+	MaxReauth    int
+}
+
+func (c Config) Validate() error {
+	if !c.Scheme.Valid() {
+		return fmt.Errorf("%w: unsupported DAST auth scheme %q", shared.ErrValidation, c.Scheme)
+	}
+	if len(c.Credentials) == 0 {
+		return fmt.Errorf("%w: at least one vault credential binding is required", shared.ErrValidation)
+	}
+	seen := make(map[string]struct{}, len(c.Credentials))
+	for _, binding := range c.Credentials {
+		if err := binding.Validate(); err != nil {
+			return err
+		}
+		if _, ok := seen[binding.Name]; ok {
+			return fmt.Errorf("%w: duplicate credential binding %q", shared.ErrValidation, binding.Name)
+		}
+		seen[binding.Name] = struct{}{}
+	}
+	if c.Scheme == SchemeBasic && len(c.Credentials) != 2 {
+		return fmt.Errorf("%w: basic authentication requires username and password bindings", shared.ErrValidation)
+	}
+	if c.Scheme == SchemeBearer && len(c.Credentials) != 1 {
+		return fmt.Errorf("%w: bearer authentication requires one credential binding", shared.ErrValidation)
+	}
+	if err := c.LoginRequest.Validate(); err != nil {
+		return fmt.Errorf("validate login request: %w", err)
+	}
+	loginMethod := strings.ToUpper(c.LoginRequest.Method)
+	if c.Scheme == SchemeForm {
+		if loginMethod != "POST" {
+			return fmt.Errorf("%w: form authentication requires a POST login request", shared.ErrValidation)
+		}
+	} else if loginMethod != "GET" && loginMethod != "HEAD" && loginMethod != "POST" {
+		return fmt.Errorf("%w: login request method is not supported", shared.ErrValidation)
+	}
+	if err := c.Success.Validate(); err != nil {
+		return err
+	}
+	if err := c.CheckRequest.Validate(); err != nil {
+		return fmt.Errorf("validate session check request: %w", err)
+	}
+	checkMethod := strings.ToUpper(c.CheckRequest.Method)
+	if checkMethod != "GET" && checkMethod != "HEAD" {
+		return fmt.Errorf("%w: session check must use GET or HEAD", shared.ErrValidation)
+	}
+	if c.MaxReauth < 0 {
+		return fmt.Errorf("%w: max reauthentication cannot be negative", shared.ErrValidation)
+	}
+	for _, p := range c.DenyPaths {
+		if !validPath(p) {
+			return fmt.Errorf("%w: deny path must be absolute and clean", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+// DeniesPath reports whether p is an operator-denied or default destructive path.
+// Matching uses path segments so /logout does not deny /logout-preview.
+func (c Config) DeniesPath(p string) bool {
+	if !validPath(p) {
+		return true
+	}
+	for _, denied := range c.DenyPaths {
+		if pathPrefix(denied, p) {
+			return true
+		}
+	}
+	for segment := range strings.SplitSeq(strings.Trim(path.Clean(p), "/"), "/") {
+		s := strings.ToLower(segment)
+		if s == "logout" || s == "signout" || s == "sign-out" || s == "delete" || s == "purge" || s == "destroy" || s == "remove" {
+			return true
+		}
+	}
+	return false
+}
+
+func validPath(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.IsAbs() || u.Host != "" || u.Path == "" || !strings.HasPrefix(u.Path, "/") {
+		return false
+	}
+	return path.Clean(u.Path) == u.Path
+}
+
+func pathPrefix(parent, child string) bool {
+	parent, child = path.Clean(parent), path.Clean(child)
+	return parent == "/" || child == parent || strings.HasPrefix(child, strings.TrimRight(parent, "/")+"/")
+}

--- a/internal/domain/dastsession/config_test.go
+++ b/internal/domain/dastsession/config_test.go
@@ -1,0 +1,76 @@
+package dastsession
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func validConfig() Config {
+	return Config{
+		Scheme:       SchemeForm,
+		Credentials:  []CredentialBinding{{Name: "username", Reference: "vault:operator-login"}},
+		LoginRequest: Request{Method: "POST", Path: "/login"},
+		Success:      SuccessSignal{StatusCode: 302},
+		CheckRequest: Request{Method: "GET", Path: "/account"},
+		MaxReauth:    DefaultMaxReauth,
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	if err := validConfig().Validate(); err != nil {
+		t.Fatalf("valid config: %v", err)
+	}
+	for name, mutate := range map[string]func(*Config){
+		"unknown scheme":                      func(c *Config) { c.Scheme = "oauth" },
+		"no binding":                          func(c *Config) { c.Credentials = nil },
+		"credential value field cannot exist": func(c *Config) { c.Credentials[0].Reference = "" },
+		"missing success":                     func(c *Config) { c.Success = SuccessSignal{} },
+		"missing check":                       func(c *Config) { c.CheckRequest = Request{} },
+		"negative reauth":                     func(c *Config) { c.MaxReauth = -1 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := validConfig()
+			mutate(&c)
+			if err := c.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("Validate() = %v, want ErrValidation", err)
+			}
+		})
+	}
+}
+
+func TestValidateRejectsUnsafeMethods(t *testing.T) {
+	for name, mutate := range map[string]func(*Config){
+		"form login": func(c *Config) { c.LoginRequest.Method = "GET" },
+		"login": func(c *Config) {
+			c.Scheme = SchemeBearer
+			c.Credentials = []CredentialBinding{{Name: "token", Reference: "vault:token"}}
+			c.LoginRequest.Method = "DELETE"
+		},
+		"liveness": func(c *Config) { c.CheckRequest.Method = "DELETE" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := validConfig()
+			mutate(&config)
+			if err := config.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("Validate err=%v", err)
+			}
+		})
+	}
+}
+
+func TestConfigDeniesPath(t *testing.T) {
+	c := validConfig()
+	c.DenyPaths = []string{"/billing/remove"}
+	for _, blocked := range []string{"/logout", "/account/sign-out", "/api/delete/user", "/billing/remove/card"} {
+		if !c.DeniesPath(blocked) {
+			t.Errorf("DeniesPath(%q) = false, want true", blocked)
+		}
+	}
+	for _, allowed := range []string{"/logout-preview", "/billing/removal", "/account"} {
+		if c.DeniesPath(allowed) {
+			t.Errorf("DeniesPath(%q) = true, want false", allowed)
+		}
+	}
+}

--- a/internal/domain/dastsurface/surface.go
+++ b/internal/domain/dastsurface/surface.go
@@ -1,0 +1,150 @@
+// Package dastsurface models the deterministic, bounded DAST application surface.
+package dastsurface
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var ignoredQueryKeys = map[string]struct{}{
+	"cursor": {}, "limit": {}, "offset": {}, "page": {}, "pagesize": {},
+	"jsessionid": {}, "phpsessid": {}, "session": {}, "sessionid": {}, "sid": {}, "token": {},
+}
+
+// Request is one discovered request. URL is normalized before it enters a surface.
+type Source string
+
+const (
+	SourceSeed    Source = "seed"
+	SourceHTML    Source = "html"
+	SourceForm    Source = "form"
+	SourceScript  Source = "script"
+	SourceRobots  Source = "robots"
+	SourceSitemap Source = "sitemap"
+	SourceOpenAPI Source = "openapi"
+	SourceGraphQL Source = "graphql"
+)
+
+// Request is one discovered request. URL deduplicates; ExecutionURL retains first concrete target.
+type Request struct {
+	Method       string
+	URL          string
+	ExecutionURL string
+	Source       Source
+}
+
+func (r Request) Key() string { return strings.ToUpper(r.Method) + " " + r.URL }
+
+// NormalizeRequest normalizes a URL and removes common pagination/session query
+// keys before deduplication. It never performs network I/O.
+func NormalizeRequest(method, rawURL string) (Request, error) {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	if method == "" {
+		return Request{}, fmt.Errorf("%w: request method is required", shared.ErrValidation)
+	}
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || !u.IsAbs() || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") || u.User != nil {
+		return Request{}, fmt.Errorf("%w: request URL must be absolute HTTP(S) without userinfo", shared.ErrValidation)
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	u.Path = path.Clean("/" + strings.TrimPrefix(u.Path, "/"))
+	if u.Path == "." {
+		u.Path = "/"
+	}
+	q := u.Query()
+	for key := range q {
+		if _, ignored := ignoredQueryKeys[strings.ToLower(key)]; ignored {
+			q.Del(key)
+		}
+	}
+	u.RawQuery = q.Encode()
+	u.Fragment = ""
+	return Request{Method: method, URL: u.String()}, nil
+}
+
+// Surface contains unique normalized requests in deterministic order.
+type Surface struct{ Requests []Request }
+
+func NewSurface(discovered []Request) (Surface, error) {
+	unique := make(map[string]Request, len(discovered))
+	for _, request := range discovered {
+		normalized, err := NormalizeRequest(request.Method, request.URL)
+		if err != nil {
+			return Surface{}, err
+		}
+		if request.ExecutionURL != "" {
+			normalized.ExecutionURL = request.ExecutionURL
+		}
+		normalized.Source = request.Source
+		if _, exists := unique[normalized.Key()]; !exists {
+			unique[normalized.Key()] = normalized
+		}
+	}
+	requests := make([]Request, 0, len(unique))
+	for _, request := range unique {
+		requests = append(requests, request)
+	}
+	sort.Slice(requests, func(i, j int) bool { return requests[i].Key() < requests[j].Key() })
+	return Surface{Requests: requests}, nil
+}
+
+// CoverageStatus explains whether a discovered request was issued or skipped.
+type CoverageStatus string
+
+const (
+	CoverageRequested  CoverageStatus = "requested"
+	CoverageSkipped    CoverageStatus = "skipped"
+	CoverageOutOfScope CoverageStatus = "out_of_scope"
+	CoverageLimited    CoverageStatus = "limited"
+)
+
+func (s CoverageStatus) Valid() bool {
+	switch s {
+	case CoverageRequested, CoverageSkipped, CoverageOutOfScope, CoverageLimited:
+		return true
+	}
+	return false
+}
+
+// CoverageEntry preserves the decision for one normalized request.
+type CoverageEntry struct {
+	Request Request
+	Status  CoverageStatus
+	Reason  string
+	Source  Source
+}
+
+// Coverage is a deterministic deduplicated surface map. A request may appear once;
+// conflicting records fail closed rather than silently choosing a completion state.
+type Coverage struct{ Entries []CoverageEntry }
+
+func NewCoverage(entries []CoverageEntry) (Coverage, error) {
+	unique := make(map[string]CoverageEntry, len(entries))
+	for _, entry := range entries {
+		normalized, err := NormalizeRequest(entry.Request.Method, entry.Request.URL)
+		if err != nil {
+			return Coverage{}, err
+		}
+		if !entry.Status.Valid() || (entry.Status != CoverageRequested && strings.TrimSpace(entry.Reason) == "") {
+			return Coverage{}, fmt.Errorf("%w: coverage status and reason are invalid", shared.ErrValidation)
+		}
+		entry.Request = normalized
+		key := normalized.Key()
+		if prior, exists := unique[key]; exists && prior != entry {
+			return Coverage{}, fmt.Errorf("%w: conflicting coverage for %s", shared.ErrValidation, key)
+		}
+		unique[key] = entry
+	}
+	out := make([]CoverageEntry, 0, len(unique))
+	for _, entry := range unique {
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Request.Key() < out[j].Request.Key() })
+	return Coverage{Entries: out}, nil
+}

--- a/internal/domain/dastsurface/surface_test.go
+++ b/internal/domain/dastsurface/surface_test.go
@@ -1,0 +1,37 @@
+package dastsurface
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestNewSurfaceNormalizesPaginationAndSessionDedup(t *testing.T) {
+	surface, err := NewSurface([]Request{
+		{Method: "get", URL: "https://APP.example.test/orders?page=1&sid=abc&sort=date"},
+		{Method: "GET", URL: "https://app.example.test/orders?page=2&sid=def&sort=date"},
+		{Method: "GET", URL: "https://app.example.test/orders?sort=date#section"},
+	})
+	if err != nil {
+		t.Fatalf("NewSurface: %v", err)
+	}
+	want := []Request{{Method: "GET", URL: "https://app.example.test/orders?sort=date"}}
+	if !reflect.DeepEqual(surface.Requests, want) {
+		t.Fatalf("surface = %#v, want %#v", surface.Requests, want)
+	}
+}
+
+func TestNewCoverageDeterministicAndConflictSafe(t *testing.T) {
+	entry := CoverageEntry{Request: Request{Method: "GET", URL: "https://app.test/a?page=1"}, Status: CoverageLimited, Reason: "page limit"}
+	coverage, err := NewCoverage([]CoverageEntry{entry, entry})
+	if err != nil || len(coverage.Entries) != 1 {
+		t.Fatalf("deduplicated coverage = %#v, %v", coverage, err)
+	}
+	conflict := entry
+	conflict.Status, conflict.Reason = CoverageSkipped, "deny path"
+	if _, err := NewCoverage([]CoverageEntry{entry, conflict}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("conflict = %v, want ErrValidation", err)
+	}
+}

--- a/internal/domain/engagement/scope.go
+++ b/internal/domain/engagement/scope.go
@@ -2,6 +2,7 @@ package engagement
 
 import (
 	"net/netip"
+	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
@@ -47,12 +48,11 @@ func (s Scope) Allows(value string) bool {
 	return s.AllowsTarget(Target{Kind: InferTargetKind(value), Value: value})
 }
 
-// AllowsTarget reports whether the requested target is permitted. In-scope URL
-// entries authorize only their canonical scheme, host, and effective port. An
-// out-of-scope URL is intentionally broader: it denies its host for every request
-// kind, scheme, and port. Out-of-scope always wins, and an invalid deny entry makes
-// the scope unenforceable and therefore denies every request. Enforced server-side
-// before any tool runs.
+// AllowsTarget reports whether the requested target is permitted. URL scope entries
+// match their canonical scheme, host, effective port, and a segment-aligned path
+// prefix. Out-of-scope always wins, and an invalid deny entry makes the scope
+// unenforceable and therefore denies every request. Enforced server-side before
+// any tool runs.
 func (s Scope) AllowsTarget(req Target) bool {
 	if strings.TrimSpace(req.Value) == "" {
 		return false
@@ -70,15 +70,17 @@ func (s Scope) AllowsTarget(req Target) bool {
 	return false
 }
 
-// matchesDenyTarget applies the conservative carve-out semantics. A malformed
-// deny cannot be enforced reliably, so it matches every request. URL denies are
-// host-wide even though URL allows are scheme-and-port specific.
+// matchesDenyTarget applies conservative carve-out semantics. A malformed deny
+// cannot be enforced reliably, so it matches every request.
 func matchesDenyTarget(scopeT, req Target) bool {
 	normalized, err := NormalizeTarget(scopeT, true)
 	if err != nil {
 		return true
 	}
 	if normalized.Kind == TargetURL {
+		if req.Kind == TargetURL {
+			return matchScopeTarget(normalized, req)
+		}
 		identity, err := NormalizeURL(normalized.Value)
 		return err == nil && identity.Host == targetHost(req)
 	}
@@ -144,8 +146,7 @@ func matchesAllowTarget(scopeT, req Target) bool {
 
 // matchScopeTarget compares a normalized scope entry with a request. Repo/image
 // values retain their established comparisons; network requests are parsed without
-// DNS resolution. URL entries use the strict allow identity here; deny-side URL
-// host matching is handled separately by matchesDenyTarget.
+// DNS resolution. URL entries match a segment-aligned path prefix.
 func matchScopeTarget(scopeT, req Target) bool {
 	if strings.TrimSpace(req.Value) == "" {
 		return false
@@ -189,9 +190,33 @@ func matchScopeTarget(scopeT, req Target) bool {
 			return false
 		}
 		scopeURL, err := NormalizeURL(scopeT.Value)
-		return err == nil && scopeURL.Scheme == reqURL.Scheme && scopeURL.Host == reqURL.Host && scopeURL.Port == reqURL.Port
+		return err == nil && scopeURL.Scheme == reqURL.Scheme && scopeURL.Host == reqURL.Host && scopeURL.Port == reqURL.Port && urlPathContains(scopeURL.URL, reqURL.URL)
 	}
 	return false
+}
+
+// urlPathContains reports whether child has parent as a segment prefix. Query
+// strings and fragments never affect URL scope authorization.
+func urlPathContains(parent, child string) bool {
+	p, err := NormalizeURL(parent)
+	if err != nil {
+		return false
+	}
+	c, err := NormalizeURL(child)
+	if err != nil {
+		return false
+	}
+	parentPath := path.Clean(pURLPath(p.URL))
+	childPath := path.Clean(pURLPath(c.URL))
+	return parentPath == "/" || childPath == parentPath || strings.HasPrefix(childPath, strings.TrimRight(parentPath, "/")+"/")
+}
+
+func pURLPath(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Path == "" {
+		return "/"
+	}
+	return u.Path
 }
 
 func localPathContains(parent, child string) bool {

--- a/internal/domain/engagement/scope_test.go
+++ b/internal/domain/engagement/scope_test.go
@@ -76,27 +76,19 @@ func TestScopeOutOfScopeWins(t *testing.T) {
 	}
 }
 
-func TestScopeOutOfScopeURLDeniesHostWide(t *testing.T) {
+func TestScopeURLDenyIsPathAware(t *testing.T) {
 	s := Scope{
-		InScope:    []Target{{Kind: TargetDomain, Value: "*.acme.io"}},
-		OutOfScope: []Target{{Kind: TargetURL, Value: "https://payments.acme.io/"}},
+		InScope:    []Target{{Kind: TargetURL, Value: "https://payments.acme.io/"}},
+		OutOfScope: []Target{{Kind: TargetURL, Value: "https://payments.acme.io/admin"}},
 	}
-	cases := []Target{
-		{Kind: TargetURL, Value: "https://payments.acme.io/checkout"},
-		{Kind: TargetURL, Value: "http://payments.acme.io/checkout"},
-		{Kind: TargetURL, Value: "https://payments.acme.io:8443/checkout"},
-		{Kind: TargetDomain, Value: "payments.acme.io"},
+	if s.AllowsTarget(Target{Kind: TargetURL, Value: "https://payments.acme.io/admin/users"}) {
+		t.Error("out-of-scope URL path must deny its descendants")
 	}
-	for _, req := range cases {
-		if s.AllowsTarget(req) {
-			t.Errorf("out-of-scope URL host must deny %+v", req)
-		}
+	if !s.AllowsTarget(Target{Kind: TargetURL, Value: "https://payments.acme.io/checkout"}) {
+		t.Error("URL deny must not deny a sibling path")
 	}
-	if s.Allows("payments.acme.io") {
-		t.Error("value-only matching must preserve the URL host carve-out")
-	}
-	if !s.Allows("api.acme.io") {
-		t.Error("the carve-out must not deny a different in-scope host")
+	if !s.AllowsTarget(Target{Kind: TargetURL, Value: "https://payments.acme.io/administrator"}) {
+		t.Error("URL deny must use path segments, not string prefixes")
 	}
 }
 
@@ -106,6 +98,7 @@ func TestScopeInScopeURLRemainsSchemeAndPortSpecific(t *testing.T) {
 		req  Target
 		want bool
 	}{
+		{req: Target{Kind: TargetURL, Value: "https://app.acme.io/login/reset"}, want: true},
 		{req: Target{Kind: TargetURL, Value: "https://app.acme.io/other"}, want: true},
 		{req: Target{Kind: TargetURL, Value: "https://app.acme.io:443/other"}, want: true},
 		{req: Target{Kind: TargetURL, Value: "http://app.acme.io/other"}, want: false},
@@ -240,7 +233,8 @@ func TestScopeAllowsTarget(t *testing.T) {
 		{"subdomain of exact host not covered", Target{Kind: TargetDomain, Value: "x.host.example.com"}, false},
 		{"exact ip", Target{Kind: TargetIP, Value: "192.168.1.5"}, true},
 		{"url host falls inside cidr", Target{Kind: TargetURL, Value: "http://10.0.0.9:8080/x"}, true},
-		{"url matches URL entry by scheme host and effective port", Target{Kind: TargetURL, Value: "https://app.acme.io/other"}, true},
+		{"url matches URL entry path prefix", Target{Kind: TargetURL, Value: "https://app.acme.io/login/reset"}, true},
+		{"domain scope remains host-wide alongside URL path scope", Target{Kind: TargetURL, Value: "https://app.acme.io/other"}, true},
 		{"domain scope remains intentionally host-wide", Target{Kind: TargetURL, Value: "http://app.acme.io/other"}, true},
 		{"userinfo is rejected", Target{Kind: TargetURL, Value: "https://app.acme.io@evil.com/x"}, false},
 		{"unrelated host", Target{Kind: TargetDomain, Value: "evil.com"}, false},

--- a/internal/domain/finding/dast.go
+++ b/internal/domain/finding/dast.go
@@ -15,11 +15,13 @@ import (
 // runtime twin of SASTInput — the SAME structured claim, but confirmed at runtime rather than by a static
 // verifier, so it earns a distinct Kind (stronger, dynamically-proven evidence).
 type DASTInput struct {
-	JudgmentID string          // the confirmed CapSAST judgment (dedup anchor – re-confirming updates in place)
-	CWE        string          // the weakness, e.g. "CWE-89"
-	Location   string          // where: "path[:line]" or the importPath.Symbol of the sink-using function
-	Rule       string          // the taint rule that fired, e.g. "taint-sqli"
-	Severity   shared.Severity // optional; defaults to Unknown (re-triaged via the normal finding workflow)
+	JudgmentID  string          // confirmed judgment ID; legacy CapSAST runtime projections use this as the dedup anchor
+	CWE         string          // the weakness, e.g. "CWE-89"
+	Location    string          // where: URL path or deterministic check location
+	Rule        string          // the check or taint rule that fired
+	Source      string          // stable check source token for native CapDAST findings
+	Fingerprint string          // stable check fingerprint for native CapDAST findings
+	Severity    shared.Severity // optional; defaults to Unknown (re-triaged via the normal finding workflow)
 }
 
 // NewDAST builds a runtime-confirmed DAST finding (Kind=dast) from a judgment a DISTINCT runtime verifier
@@ -37,11 +39,16 @@ func NewDAST(id, engagementID shared.ID, in DASTInput, now time.Time) (Finding, 
 	loc := strings.TrimSpace(in.Location)
 	rule := strings.TrimSpace(in.Rule)
 	anchor := strings.TrimSpace(in.JudgmentID)
+	source := strings.TrimSpace(in.Source)
+	fingerprint := strings.TrimSpace(in.Fingerprint)
 	if cwe == "" || loc == "" || rule == "" {
 		return Finding{}, fmt.Errorf("%w: dast finding needs a CWE, location, and rule", shared.ErrValidation)
 	}
-	if anchor == "" {
-		return Finding{}, fmt.Errorf("%w: dast finding needs a source judgment id (dedup anchor)", shared.ErrValidation)
+	if (source == "") != (fingerprint == "") {
+		return Finding{}, fmt.Errorf("%w: dast finding source and fingerprint must be supplied together", shared.ErrValidation)
+	}
+	if source == "" && anchor == "" {
+		return Finding{}, fmt.Errorf("%w: dast finding needs a source judgment id or a source and fingerprint", shared.ErrValidation)
 	}
 	sev := in.Severity
 	if sev == "" {
@@ -64,9 +71,16 @@ func NewDAST(id, engagementID shared.ID, in DASTInput, now time.Time) (Finding, 
 		Priority:     priorityForSeverity(sev),
 		Status:       StatusOpen,
 		Kind:         KindDAST,
-		DedupKey:     "dast:ai:" + anchor,
+		DedupKey:     dastDedupKey(anchor, source, fingerprint),
 		// ProposedBy LEFT EMPTY (the judgment-layer gate already ran) – see the doc above.
 		Version: 1,
 		Audit:   shared.Audit{CreatedAt: now, UpdatedAt: now},
 	}, nil
+}
+
+func dastDedupKey(judgmentID, source, fingerprint string) string {
+	if source != "" {
+		return "dast:" + source + ":" + fingerprint
+	}
+	return "dast:ai:" + judgmentID
 }

--- a/internal/domain/judgment/claim.go
+++ b/internal/domain/judgment/claim.go
@@ -16,6 +16,7 @@ import (
 // model can never smuggle a free-text sentence into the one []string field of a Claim (so
 // no LLM prose reaches a deliverable).
 var driverRE = regexp.MustCompile(`^[a-z][a-z0-9_]*((<=|>=|==|!=|<|>)[0-9]+(\.[0-9]+)?)?$`)
+var fingerprintRE = regexp.MustCompile(`^[a-z][a-z0-9_]{0,31}$|^[a-z][a-z0-9_]{0,15}_[a-f0-9]{64}$`)
 
 // maxClaimPathElems / maxClaimPathElemLen bound a reachability claim's call/dependency path so a
 // hostile or runaway proposer (agent or HTTP) cannot seal an unbounded path into the evidence ledger
@@ -136,6 +137,35 @@ type SASTClaim struct {
 	CWE      string `json:"cwe"`
 	Location string `json:"location"` // path[:line]
 	Rule     string `json:"rule"`
+}
+
+// DASTClaim is the typed result of a dynamic check. Source and Fingerprint are
+// stable tokens supplied by the first-party check corpus and identify the exact
+// runtime observation without carrying response content or credentials.
+type DASTClaim struct {
+	CWE             string `json:"cwe"`
+	Location        string `json:"location"`
+	Rule            string `json:"rule"`
+	Source          string `json:"source"`
+	Fingerprint     string `json:"fingerprint"`
+	ProofEvidenceID string `json:"proof_evidence_id"`
+}
+
+// Capability identifies this claim's brain.
+func (DASTClaim) Capability() Capability { return CapDAST }
+
+// Validate requires structured finding fields and stable, secret-free dedup tokens.
+func (c DASTClaim) Validate() error {
+	if strings.TrimSpace(c.CWE) == "" || strings.TrimSpace(c.Location) == "" || strings.TrimSpace(c.Rule) == "" {
+		return fmt.Errorf("%w: dast claim requires a CWE, location, and rule", shared.ErrValidation)
+	}
+	if !driverRE.MatchString(c.Source) || !fingerprintRE.MatchString(c.Fingerprint) {
+		return fmt.Errorf("%w: dast claim source and fingerprint must be lowercase tokens", shared.ErrValidation)
+	}
+	if strings.TrimSpace(c.ProofEvidenceID) == "" {
+		return fmt.Errorf("%w: dast claim requires sealed proof evidence", shared.ErrValidation)
+	}
+	return nil
 }
 
 // Capability identifies this claim's brain.
@@ -377,6 +407,12 @@ func UnmarshalClaim(data []byte) (Claim, error) {
 			return nil, err
 		}
 		c = sc
+	case CapDAST:
+		var dc DASTClaim
+		if err := strictDecode(env.Claim, &dc); err != nil {
+			return nil, err
+		}
+		c = dc
 	case CapCritique:
 		var cc CritiqueClaim
 		if err := strictDecode(env.Claim, &cc); err != nil {

--- a/internal/domain/judgment/claim_test.go
+++ b/internal/domain/judgment/claim_test.go
@@ -13,6 +13,7 @@ func TestClaimRoundTrip(t *testing.T) {
 	claims := []Claim{
 		ReachabilityClaim{Reachable: Reachable, Tier: Tier2, Path: []string{"main", "vuln"}, Confidence: 95},
 		SASTClaim{CWE: "CWE-327", Location: "auth.go:42", Rule: "weak-hash-md5"},
+		DASTClaim{CWE: "CWE-79", Location: "/search", Rule: "reflected-xss", Source: "first_party", Fingerprint: "search_reflection", ProofEvidenceID: "proof-1"},
 		RiskNarrativeClaim{Drivers: []string{"kev", "cvss>=9"}, Priority: 1},
 		CritiqueClaim{Verdict: CritiqueRefuted, Driver: "version_mismatch", Confidence: 85},
 		ThreatClaim{Category: InfoDisclosure, Asset: "pii"},
@@ -31,6 +32,25 @@ func TestClaimRoundTrip(t *testing.T) {
 		}
 		if got.Capability() != c.Capability() {
 			t.Fatalf("capability changed: %s != %s", got.Capability(), c.Capability())
+		}
+	}
+}
+
+func TestDASTClaimStrictDecode(t *testing.T) {
+	valid := []byte(`{"capability":"dast","claim":{"cwe":"CWE-79","location":"/search","rule":"reflected-xss","source":"first_party","fingerprint":"search_reflection","proof_evidence_id":"proof-1"}}`)
+	claim, err := UnmarshalClaim(valid)
+	if err != nil {
+		t.Fatalf("UnmarshalClaim: %v", err)
+	}
+	if _, ok := claim.(DASTClaim); !ok {
+		t.Fatalf("claim type = %T, want DASTClaim", claim)
+	}
+	for _, raw := range [][]byte{
+		[]byte(`{"capability":"dast","claim":{"cwe":"CWE-79","location":"/search","rule":"x","source":"first_party","fingerprint":"f","notes":"no"}}`),
+		[]byte(`{"capability":"dast","claim":{"cwe":"CWE-79","location":"/search","rule":"x","source":"not valid","fingerprint":"f"}}`),
+	} {
+		if _, err := UnmarshalClaim(raw); err == nil {
+			t.Fatalf("UnmarshalClaim(%s) succeeded", raw)
 		}
 	}
 }

--- a/internal/domain/judgment/judgment.go
+++ b/internal/domain/judgment/judgment.go
@@ -23,6 +23,7 @@ type Capability string
 const (
 	CapReachability     Capability = "reachability"      // gated
 	CapSAST             Capability = "sast"              // gated
+	CapDAST             Capability = "dast"              // gated
 	CapCritique         Capability = "critique"          // gated (adversarial refutation of a finding)
 	CapRiskNarrative    Capability = "risk_narrative"    // NOT gated (explains, doesn't prove)
 	CapThreat           Capability = "threat"            // gated (STRIDE threat over the model, human-ratified)
@@ -33,7 +34,7 @@ const (
 // Valid reports whether c is a known capability.
 func (c Capability) Valid() bool {
 	switch c {
-	case CapReachability, CapSAST, CapCritique, CapRiskNarrative, CapThreat, CapCorrelation, CapVexJustification:
+	case CapReachability, CapSAST, CapDAST, CapCritique, CapRiskNarrative, CapThreat, CapCorrelation, CapVexJustification:
 		return true
 	}
 	return false
@@ -45,7 +46,7 @@ func (c Capability) Valid() bool {
 // cross-check disagreement) have no "refuted at 75" semantics; they are human-accepted, not score-gated.
 func (c Capability) Gated() bool {
 	switch c {
-	case CapReachability, CapSAST, CapCritique, CapThreat, CapVexJustification:
+	case CapReachability, CapSAST, CapDAST, CapCritique, CapThreat, CapVexJustification:
 		return true
 	}
 	return false

--- a/internal/infrastructure/dastchecks/registry.go
+++ b/internal/infrastructure/dastchecks/registry.go
@@ -1,0 +1,201 @@
+// Package dastchecks evaluates deterministic, passive DAST observations.
+package dastchecks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastcheck"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var checks = append([]dastcheck.Check(nil), dastcheck.Checks...)
+
+type Evaluator struct{ checks []dastcheck.Check }
+
+var _ ports.DASTCheckEvaluator = (*Evaluator)(nil)
+
+func NewEvaluator() *Evaluator { return &Evaluator{checks: append([]dastcheck.Check(nil), checks...)} }
+
+func (e *Evaluator) Evaluate(observations []ports.DASTObservation, selected []string) ([]ports.DASTFinding, error) {
+	if err := dastcheck.ValidateParity(dastcheck.Catalog, e.checks); err != nil {
+		return nil, err
+	}
+	allowed := make(map[string]bool, len(e.checks))
+	for _, check := range e.checks {
+		allowed[check.ID] = true
+	}
+	if len(selected) == 0 {
+		for id := range allowed {
+			allowed[id] = true
+		}
+	} else {
+		for id := range allowed {
+			allowed[id] = false
+		}
+		for _, id := range selected {
+			if !e.dastcheckID(id) {
+				return nil, fmt.Errorf("%w: unknown DAST check %q", shared.ErrValidation, id)
+			}
+			allowed[id] = true
+		}
+	}
+	var findings []ports.DASTFinding
+	for _, observation := range observations {
+		endpoint, err := normalizeEndpoint(observation.URL)
+		if err != nil {
+			continue
+		}
+		for _, result := range evaluate(observation, endpoint, allowed) {
+			findings = append(findings, result)
+		}
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].CheckID != findings[j].CheckID {
+			return findings[i].CheckID < findings[j].CheckID
+		}
+		return findings[i].Endpoint < findings[j].Endpoint
+	})
+	return findings, nil
+}
+
+func (e *Evaluator) dastcheckID(id string) bool {
+	for _, check := range e.checks {
+		if check.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func evaluate(o ports.DASTObservation, endpoint string, allowed map[string]bool) []ports.DASTFinding {
+	headers := normalizedHeaders(o.Headers)
+	var results []ports.DASTFinding
+	add := func(id, signature string, proofHeaders []string, predicateTokens ...string) {
+		if allowed[id] {
+			results = append(results, newFinding(id, endpoint, o, signature, proofHeaders, predicateTokens...))
+		}
+	}
+	if len(headers) > 0 && !hasPrefix(headers, "strict-transport-security") {
+		add("security-headers", "missing:strict-transport-security", nil)
+	}
+	for _, header := range headers {
+		if strings.HasPrefix(header, "set-cookie:") {
+			flags := strings.ToLower(header)
+			if !strings.Contains(flags, "secure") || !strings.Contains(flags, "httponly") || !strings.Contains(flags, "samesite=") {
+				add("cookie-security-flags", "missing_cookie_flag", []string{"set-cookie"})
+				break
+			}
+		}
+	}
+	path := strings.ToLower(mustPath(endpoint))
+	body := strings.ToLower(o.BodyExcerpt)
+	if strings.HasSuffix(path, ".map") {
+		add("sensitive-public-artifact", "public_artifact", nil, "source_map_path")
+	} else if strings.Contains(path, "/.well-known/") && strings.Contains(body, "source") {
+		add("sensitive-public-artifact", "public_artifact", nil, "well_known_path", "body:source")
+	} else if strings.Contains(path, "/.well-known/") && strings.Contains(body, "private") {
+		add("sensitive-public-artifact", "public_artifact", nil, "well_known_path", "body:private")
+	}
+	if strings.Contains(body, "synapse-auth-weakness") {
+		add("auth-configured-weakness", "configured_auth_weakness", nil, "body:synapse-auth-weakness")
+	} else if hasPrefix(headers, "x-synapse-auth-weakness:") {
+		add("auth-configured-weakness", "configured_auth_weakness", nil, "header:x-synapse-auth-weakness")
+	}
+	return results
+}
+
+func newFinding(id, endpoint string, o ports.DASTObservation, signature string, headers []string, predicateTokens ...string) ports.DASTFinding {
+	proof := ports.DASTProof{CheckID: id, Version: 1, NormalizedEndpoint: endpoint, Observation: ports.DASTClosedObservation{
+		Method: strings.ToUpper(o.Method), Status: o.Status, BodySHA256: o.BodySHA256,
+		Headers: headers, Signature: signature, PredicateTokens: predicateTokens,
+	}}
+	raw := proof.CheckID + "\n" + proof.NormalizedEndpoint + "\n" + proof.Observation.Method + "\n" + fmt.Sprint(proof.Observation.Status) + "\n" + proof.Observation.BodySHA256 + "\n" + strings.Join(proof.Observation.Headers, ",") + "\n" + proof.Observation.Signature + "\n" + strings.Join(proof.Observation.PredicateTokens, ",")
+	hash := sha256.Sum256([]byte(raw))
+	proof.Hash = hex.EncodeToString(hash[:])
+	return ports.DASTFinding{CheckID: id, CWE: checkCWE(id), Version: 1, Endpoint: endpoint, Proof: proof}
+}
+
+func checkCWE(id string) string {
+	for _, check := range checks {
+		if check.ID == id {
+			return check.CWE
+		}
+	}
+	return ""
+}
+
+func (e *Evaluator) VerifyProof(p ports.DASTProof) error {
+	if !e.dastcheckID(p.CheckID) || checkCWE(p.CheckID) == "" || p.Version != 1 || p.NormalizedEndpoint == "" || p.Observation.Method == "" || p.Observation.Status < 100 || p.Observation.Status > 599 || len(p.Observation.BodySHA256) != 64 {
+		return fmt.Errorf("%w: invalid closed DAST proof", shared.ErrValidation)
+	}
+	for _, token := range p.Observation.PredicateTokens {
+		if strings.TrimSpace(token) == "" || strings.ContainsAny(token, "\r\n") {
+			return fmt.Errorf("%w: invalid DAST predicate token", shared.ErrValidation)
+		}
+	}
+	switch p.CheckID {
+	case "security-headers":
+		if p.Observation.Signature != "missing:strict-transport-security" || len(p.Observation.Headers) != 0 || len(p.Observation.PredicateTokens) != 0 {
+			return fmt.Errorf("%w: DAST security-header predicate did not match", shared.ErrValidation)
+		}
+	case "cookie-security-flags":
+		if p.Observation.Signature != "missing_cookie_flag" || len(p.Observation.Headers) != 1 || p.Observation.Headers[0] != "set-cookie" || len(p.Observation.PredicateTokens) != 0 {
+			return fmt.Errorf("%w: DAST cookie predicate did not match", shared.ErrValidation)
+		}
+	case "sensitive-public-artifact":
+		path := strings.ToLower(mustPath(p.NormalizedEndpoint))
+		valid := len(p.Observation.Headers) == 0 && p.Observation.Signature == "public_artifact" && (len(p.Observation.PredicateTokens) == 1 && p.Observation.PredicateTokens[0] == "source_map_path" && strings.HasSuffix(path, ".map") || len(p.Observation.PredicateTokens) == 2 && p.Observation.PredicateTokens[0] == "well_known_path" && strings.Contains(path, "/.well-known/") && (p.Observation.PredicateTokens[1] == "body:source" || p.Observation.PredicateTokens[1] == "body:private"))
+		if !valid {
+			return fmt.Errorf("%w: DAST artifact predicate did not match", shared.ErrValidation)
+		}
+	case "auth-configured-weakness":
+		if p.Observation.Signature != "configured_auth_weakness" || len(p.Observation.Headers) != 0 || len(p.Observation.PredicateTokens) != 1 || p.Observation.PredicateTokens[0] != "body:synapse-auth-weakness" && p.Observation.PredicateTokens[0] != "header:x-synapse-auth-weakness" {
+			return fmt.Errorf("%w: DAST authentication predicate did not match", shared.ErrValidation)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported DAST proof check", shared.ErrValidation)
+	}
+	want := newFinding(p.CheckID, p.NormalizedEndpoint, ports.DASTObservation{Method: p.Observation.Method, Status: p.Observation.Status, BodySHA256: p.Observation.BodySHA256}, p.Observation.Signature, p.Observation.Headers, p.Observation.PredicateTokens...).Proof.Hash
+	if p.Hash != want {
+		return fmt.Errorf("%w: closed DAST proof hash mismatch", shared.ErrValidation)
+	}
+	return nil
+}
+
+func normalizeEndpoint(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.User != nil {
+		return "", fmt.Errorf("invalid endpoint")
+	}
+	u.Fragment = ""
+	u.RawQuery = ""
+	u.ForceQuery = false
+	return u.String(), nil
+}
+func mustPath(raw string) string { u, _ := url.Parse(raw); return u.Path }
+func normalizedHeaders(headers []string) []string {
+	out := make([]string, 0, len(headers))
+	for _, h := range headers {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" || strings.HasPrefix(h, "authorization:") || strings.HasPrefix(h, "cookie:") {
+			continue
+		}
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out
+}
+func hasPrefix(values []string, prefix string) bool {
+	for _, value := range values {
+		if strings.HasPrefix(value, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/dastchecks/registry.go
+++ b/internal/infrastructure/dastchecks/registry.go
@@ -51,9 +51,7 @@ func (e *Evaluator) Evaluate(observations []ports.DASTObservation, selected []st
 		if err != nil {
 			continue
 		}
-		for _, result := range evaluate(observation, endpoint, allowed) {
-			findings = append(findings, result)
-		}
+		findings = append(findings, evaluate(observation, endpoint, allowed)...)
 	}
 	sort.Slice(findings, func(i, j int) bool {
 		if findings[i].CheckID != findings[j].CheckID {

--- a/internal/infrastructure/dastchecks/registry_test.go
+++ b/internal/infrastructure/dastchecks/registry_test.go
@@ -1,0 +1,57 @@
+package dastchecks
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastcheck"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestCatalogParity(t *testing.T) {
+	if err := dastcheck.ValidateParity(dastcheck.Catalog, checks); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEvaluateVulnerableAndCleanFixtures(t *testing.T) {
+	vulnerable := ports.DASTObservation{Method: "GET", URL: "https://app.example/.well-known/private", Status: 200, BodySHA256: strings.Repeat("a", 64), BodyExcerpt: "private synapse-auth-weakness", Headers: []string{"Set-Cookie: Secure", "X-Synapse-Auth-Weakness: configured"}}
+	evaluator := NewEvaluator()
+	findings, err := evaluator.Evaluate([]ports.DASTObservation{vulnerable}, nil)
+	if err != nil || len(findings) != 4 {
+		t.Fatalf("findings=%+v err=%v", findings, err)
+	}
+	for _, finding := range findings {
+		if err := evaluator.VerifyProof(finding.Proof); err != nil {
+			t.Fatal(err)
+		}
+		raw, _ := json.Marshal(finding.Proof)
+		text := string(raw)
+		for _, forbidden := range []string{"Authorization", "Cookie:", "Set-Cookie:"} {
+			if strings.Contains(text, forbidden) {
+				t.Fatalf("proof leaked %q: %s", forbidden, text)
+			}
+		}
+	}
+	clean := ports.DASTObservation{Method: "GET", URL: "https://app.example/", Status: 200, BodySHA256: strings.Repeat("b", 64), Headers: []string{"Strict-Transport-Security: max-age=1", "Set-Cookie: Secure; HttpOnly; SameSite=Lax"}}
+	findings, err = evaluator.Evaluate([]ports.DASTObservation{clean}, nil)
+	if err != nil || len(findings) != 0 {
+		t.Fatalf("clean findings=%+v err=%v", findings, err)
+	}
+}
+
+func TestVerifyProofRejectsPredicateMismatch(t *testing.T) {
+	evaluator := NewEvaluator()
+	for name, finding := range map[string]ports.DASTFinding{
+		"check signature": newFinding("security-headers", "https://app.example/", ports.DASTObservation{Method: "GET", Status: 200, BodySHA256: strings.Repeat("a", 64)}, "configured_auth_weakness", nil),
+		"artifact path":   newFinding("sensitive-public-artifact", "https://app.example/public.txt", ports.DASTObservation{Method: "GET", Status: 200, BodySHA256: strings.Repeat("b", 64)}, "public_artifact", nil, "source_map_path"),
+		"auth token":      newFinding("auth-configured-weakness", "https://app.example/", ports.DASTObservation{Method: "GET", Status: 200, BodySHA256: strings.Repeat("c", 64)}, "configured_auth_weakness", nil, "body:private"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := evaluator.VerifyProof(finding.Proof); err == nil {
+				t.Fatal("hash-valid proof with a mismatched check predicate was accepted")
+			}
+		})
+	}
+}

--- a/internal/infrastructure/dastengine/engine.go
+++ b/internal/infrastructure/dastengine/engine.go
@@ -76,12 +76,12 @@ func (e *Engine) Run(ctx context.Context, plan ports.DASTPlan, secretEnv []strin
 	if err != nil {
 		return ports.DASTOutcome{}, fmt.Errorf("open DAST authorization request pipe: %w", err)
 	}
-	defer requestR.Close()
+	defer func() { _ = requestR.Close() }()
 	decisionR, decisionW, err := os.Pipe()
 	if err != nil {
 		return ports.DASTOutcome{}, fmt.Errorf("open DAST authorization decision pipe: %w", err)
 	}
-	defer decisionR.Close()
+	defer func() { _ = decisionR.Close() }()
 
 	var authErr error
 	var authOnce sync.Once

--- a/internal/infrastructure/dastengine/engine.go
+++ b/internal/infrastructure/dastengine/engine.go
@@ -1,0 +1,144 @@
+// Package dastengine runs authenticated DAST plans through a dedicated helper.
+package dastengine
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.DASTEngine = (*Engine)(nil)
+
+// Engine uses a ToolRunner; it never creates an HTTP client in the API process.
+type Engine struct {
+	runner  ports.ToolRunner
+	helper  string
+	timeout time.Duration
+	maxOut  int
+}
+
+func New(runner ports.ToolRunner, helper string, timeout time.Duration, maxOut int) (*Engine, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("%w: DAST engine requires a tool runner", shared.ErrValidation)
+	}
+	if strings.TrimSpace(helper) == "" {
+		helper = "synapse-dast-helper"
+	}
+	if timeout <= 0 {
+		timeout = ports.DefaultDASTTimeout
+	}
+	if maxOut <= 0 {
+		maxOut = 128 << 10
+	}
+	return &Engine{runner: runner, helper: helper, timeout: timeout, maxOut: maxOut}, nil
+}
+
+func (e *Engine) Run(ctx context.Context, plan ports.DASTPlan, secretEnv []string, authorize func(context.Context, ports.DASTRequest) error) (ports.DASTOutcome, error) {
+	if authorize == nil {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: DAST request authorization is required", shared.ErrValidation)
+	}
+	if err := plan.Session.Validate(); err != nil {
+		return ports.DASTOutcome{}, fmt.Errorf("validate DAST session: %w", err)
+	}
+	if strings.TrimSpace(plan.Target) == "" {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: DAST target is required", shared.ErrValidation)
+	}
+	if plan.HelperBin != "" && plan.HelperBin != e.helper {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: approved DAST helper does not match configured helper", shared.ErrValidation)
+	}
+	if len(plan.ConfigDigest) != 64 {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: approved DAST configuration digest is required", shared.ErrValidation)
+	}
+	if plan.RatePerSec <= 0 {
+		plan.RatePerSec = ports.DefaultDASTRatePerSec
+	}
+	if plan.Concurrency <= 0 {
+		plan.Concurrency = ports.DefaultDASTConcurrency
+	}
+	if plan.RatePerSec > ports.DefaultDASTRatePerSec || plan.Concurrency > ports.DefaultDASTConcurrency {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: DAST rate and concurrency cannot exceed conservative defaults", shared.ErrValidation)
+	}
+	stdin, err := json.Marshal(plan)
+	if err != nil {
+		return ports.DASTOutcome{}, fmt.Errorf("encode DAST plan: %w", err)
+	}
+	requestR, requestW, err := os.Pipe()
+	if err != nil {
+		return ports.DASTOutcome{}, fmt.Errorf("open DAST authorization request pipe: %w", err)
+	}
+	defer requestR.Close()
+	decisionR, decisionW, err := os.Pipe()
+	if err != nil {
+		return ports.DASTOutcome{}, fmt.Errorf("open DAST authorization decision pipe: %w", err)
+	}
+	defer decisionR.Close()
+
+	var authErr error
+	var authOnce sync.Once
+	authDone := make(chan struct{})
+	go func() {
+		defer close(authDone)
+		decoder := json.NewDecoder(bufio.NewReader(requestR))
+		encoder := json.NewEncoder(decisionW)
+		for {
+			var request ports.DASTRequest
+			if err := decoder.Decode(&request); err != nil {
+				if err != io.EOF {
+					authOnce.Do(func() { authErr = fmt.Errorf("read DAST authorization request: %w", err) })
+				}
+				return
+			}
+			if err := authorize(ctx, request); err != nil {
+				if err := encoder.Encode(ports.DASTAuthorization{}); err != nil {
+					authOnce.Do(func() { authErr = fmt.Errorf("write DAST authorization decision: %w", err) })
+				}
+				continue
+			}
+			if err := encoder.Encode(ports.DASTAuthorization{Allowed: true}); err != nil {
+				authOnce.Do(func() { authErr = fmt.Errorf("write DAST authorization decision: %w", err) })
+				return
+			}
+		}
+	}()
+
+	res, runErr := e.runner.Run(ctx, ports.ToolSpec{
+		Name:           e.helper,
+		Args:           []string{"run", "--config-sha256=" + plan.ConfigDigest},
+		Stdin:          stdin,
+		Timeout:        e.timeout,
+		MaxOutputBytes: e.maxOut,
+		// The sandbox places caller files after its seccomp fd: request=4, decision=5.
+		Env:          append([]string{"SYNAPSE_DAST_AUTH_REQUEST_FD=4", "SYNAPSE_DAST_AUTH_DECISION_FD=5"}, secretEnv...),
+		ExtraFiles:   []*os.File{requestW, decisionR},
+		EngagementID: plan.EngagementID,
+		EgressPolicy: plan.EgressPolicy,
+	})
+	_ = requestW.Close()
+	_ = decisionR.Close()
+	<-authDone
+	_ = decisionW.Close()
+	if authErr != nil {
+		return ports.DASTOutcome{}, authErr
+	}
+	if runErr != nil {
+		return ports.DASTOutcome{}, fmt.Errorf("run DAST helper: %w", runErr)
+	}
+	if res.ExitCode != 0 || res.TimedOut || res.Truncated {
+		return ports.DASTOutcome{}, fmt.Errorf("DAST helper failed: exit=%d timeout=%t truncated=%t", res.ExitCode, res.TimedOut, res.Truncated)
+	}
+	var outcome ports.DASTOutcome
+	if err := json.NewDecoder(bytes.NewReader(res.Stdout)).Decode(&outcome); err != nil {
+		return ports.DASTOutcome{}, fmt.Errorf("decode DAST helper result: %w", err)
+	}
+	return outcome, nil
+}

--- a/internal/infrastructure/dastengine/engine_test.go
+++ b/internal/infrastructure/dastengine/engine_test.go
@@ -1,0 +1,103 @@
+package dastengine
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type engineRunner struct{ spec ports.ToolSpec }
+
+func (r *engineRunner) Run(_ context.Context, spec ports.ToolSpec) (ports.ToolResult, error) {
+	r.spec = spec
+	return ports.ToolResult{Stdout: []byte(`{"observations":[],"incomplete":false}`)}, nil
+}
+
+func TestEngineUsesSecretEnvAndAuthorizationPipes(t *testing.T) {
+	runner := &engineRunner{}
+	engine, err := New(runner, "helper", time.Second, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := ports.DASTPlan{HelperBin: "helper", ConfigDigest: strings.Repeat("a", 64), Target: "https://example.test", Session: dastsession.Config{Scheme: dastsession.SchemeBearer, Credentials: []dastsession.CredentialBinding{{Name: "token", Reference: "vault-token"}}, LoginRequest: dastsession.Request{Method: "POST", Path: "/login"}, CheckRequest: dastsession.Request{Method: "GET", Path: "/live"}, Success: dastsession.SuccessSignal{StatusCode: 200}}}
+	_, err = engine.Run(context.Background(), plan, []string{"SYNAPSE_DAST_SECRET_TOKEN=" + ports.SecretPlaceholder("vault-token")}, func(context.Context, ports.DASTRequest) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.spec.ExtraFiles) != 2 || runner.spec.Args[0] != "run" {
+		t.Fatalf("spec=%#v", runner.spec)
+	}
+	for _, item := range runner.spec.Env {
+		if item == "SYNAPSE_DAST_SECRET_TOKEN=plain" {
+			t.Fatal("plaintext credential in environment spec")
+		}
+	}
+	for _, file := range runner.spec.ExtraFiles {
+		_ = file.Close()
+	}
+}
+
+func TestEngineBindsApprovedHelperAndDigest(t *testing.T) {
+	runner := &engineRunner{}
+	engine, err := New(runner, "helper", time.Second, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := ports.DASTPlan{HelperBin: "other", ConfigDigest: strings.Repeat("a", 64), Target: "https://example.test", Session: dastsession.Config{Scheme: dastsession.SchemeBearer, Credentials: []dastsession.CredentialBinding{{Name: "token", Reference: "vault-token"}}, LoginRequest: dastsession.Request{Method: "POST", Path: "/login"}, CheckRequest: dastsession.Request{Method: "GET", Path: "/live"}, Success: dastsession.SuccessSignal{StatusCode: 200}}}
+	if _, err := engine.Run(context.Background(), plan, nil, func(context.Context, ports.DASTRequest) error { return nil }); err == nil {
+		t.Fatal("mismatched approved helper was accepted")
+	}
+	plan.HelperBin = "helper"
+	if _, err := engine.Run(context.Background(), plan, nil, func(context.Context, ports.DASTRequest) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.spec.Args) != 2 || runner.spec.Args[0] != "run" || runner.spec.Args[1] != "--config-sha256="+plan.ConfigDigest {
+		t.Fatalf("helper args=%v", runner.spec.Args)
+	}
+}
+
+func TestEngineRejectsMissingAuthorization(t *testing.T) {
+	engine, err := New(&engineRunner{}, "helper", time.Second, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = engine.Run(context.Background(), ports.DASTPlan{}, nil, nil)
+	if err == nil {
+		t.Fatal("missing authorization accepted")
+	}
+}
+
+func TestDASTPlanIsSecretFreeJSON(t *testing.T) {
+	plan := ports.DASTPlan{Target: "https://example.test", Requests: []dastsurface.Request{{Method: "GET", URL: "https://example.test/a"}}}
+	encoded, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) == "" {
+		t.Fatal("empty plan")
+	}
+}
+
+type badProtocolRunner struct{}
+
+func (badProtocolRunner) Run(_ context.Context, spec ports.ToolSpec) (ports.ToolResult, error) {
+	_, _ = spec.ExtraFiles[0].Write([]byte("not-json\n"))
+	return ports.ToolResult{Stdout: []byte(`{"observations":[]}`)}, nil
+}
+
+func TestEngineSurfacesAuthorizationProtocolError(t *testing.T) {
+	engine, err := New(badProtocolRunner{}, "helper", time.Second, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := ports.DASTPlan{HelperBin: "helper", ConfigDigest: strings.Repeat("a", 64), Target: "https://example.test", Session: dastsession.Config{Scheme: dastsession.SchemeBearer, Credentials: []dastsession.CredentialBinding{{Name: "token", Reference: "vault-token"}}, LoginRequest: dastsession.Request{Method: "POST", Path: "/login"}, CheckRequest: dastsession.Request{Method: "GET", Path: "/live"}, Success: dastsession.SuccessSignal{StatusCode: 200}}}
+	if _, err := engine.Run(context.Background(), plan, nil, func(context.Context, ports.DASTRequest) error { return nil }); err == nil {
+		t.Fatal("authorization protocol error was not surfaced")
+	}
+}

--- a/internal/infrastructure/dastengine/helper.go
+++ b/internal/infrastructure/dastengine/helper.go
@@ -1,0 +1,518 @@
+package dastengine
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"sort"
+
+	"golang.org/x/net/html"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastcrawl"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const maxProofBodyBytes = 4096
+
+var bodySecret = regexp.MustCompile(`(?i)(authorization|cookie|set-cookie|token|secret|password|session)[[:space:]]*[:=][[:space:]]*[^[:space:]"'&<,;]+`)
+
+// RunHelper accepts the public plan on stdin. Its request authorization protocol is
+// intentionally separate from stdin so credentials cannot cross the control channel.
+func RunHelper(ctx context.Context, in io.Reader, out io.Writer) error {
+	var plan ports.DASTPlan
+	if err := json.NewDecoder(io.LimitReader(in, 1<<20)).Decode(&plan); err != nil {
+		return fmt.Errorf("decode DAST plan: %w", err)
+	}
+	if err := plan.Session.Validate(); err != nil {
+		return fmt.Errorf("validate DAST session: %w", err)
+	}
+	base, err := url.Parse(plan.Target)
+	if err != nil || base == nil || base.Scheme == "" || base.Host == "" || base.User != nil {
+		return errors.New("invalid DAST target")
+	}
+	if plan.RatePerSec <= 0 {
+		plan.RatePerSec = ports.DefaultDASTRatePerSec
+	}
+	if plan.Concurrency <= 0 {
+		plan.Concurrency = ports.DefaultDASTConcurrency
+	}
+	if plan.RatePerSec > ports.DefaultDASTRatePerSec || plan.Concurrency > ports.DefaultDASTConcurrency {
+		return errors.New("invalid DAST limits")
+	}
+	authorize, err := helperAuthorizer()
+	if err != nil {
+		return err
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return fmt.Errorf("create cookie jar: %w", err)
+	}
+	client := &http.Client{
+		Jar:           jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Timeout:       ports.DefaultDASTTimeout,
+	}
+	runner := helperRunner{base: base, client: client, session: plan.Session, authorize: authorize, interval: time.Second / time.Duration(plan.RatePerSec)}
+	if err := runner.authenticate(ctx); err != nil {
+		return json.NewEncoder(out).Encode(ports.DASTOutcome{Incomplete: true, Reason: "authentication_failed"})
+	}
+	if plan.Crawl != nil {
+		outcome, err := runCrawl(ctx, &runner, *plan.Crawl)
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(out).Encode(outcome)
+	}
+	outcome := ports.DASTOutcome{}
+	for _, candidate := range plan.Requests {
+		observation, incomplete, reason := runner.runCandidate(ctx, candidate)
+		if incomplete {
+			outcome.Incomplete, outcome.Reason = true, reason
+			break
+		}
+		if observation.URL != "" {
+			outcome.Observations = append(outcome.Observations, observation)
+		}
+	}
+	return json.NewEncoder(out).Encode(outcome)
+}
+
+func runCrawl(ctx context.Context, r *helperRunner, plan ports.DASTCrawlPlan) (ports.DASTOutcome, error) {
+	if plan.WallClock > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, plan.WallClock)
+		defer cancel()
+	}
+	result, err := dastcrawl.Crawl(ctx, dastcrawl.Input{
+		Target: plan.Target, Seeds: plan.Seeds, Robots: plan.Robots, Sitemaps: plan.Sitemaps,
+		OpenAPI: plan.OpenAPI, GraphQL: plan.GraphQL,
+	}, dastcrawl.Limits{Depth: plan.Depth, Pages: plan.Pages, Requests: plan.Requests, WallClock: plan.WallClock}, func(ctx context.Context, candidates []dastsurface.Request) (ports.DASTOutcome, error) {
+		outcome := ports.DASTOutcome{}
+		for _, candidate := range candidates {
+			if r.session.DeniesPath(requestPath(candidate.ExecutionURL)) {
+				outcome.Coverage.Entries = append(outcome.Coverage.Entries, dastsurface.CoverageEntry{
+					Request: candidate, Status: dastsurface.CoverageSkipped, Reason: "deny_path", Source: candidate.Source,
+				})
+				continue
+			}
+			observation, incomplete, reason := r.runCandidate(ctx, candidate)
+			if incomplete {
+				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					reason = "wall_clock"
+				}
+				outcome.Incomplete, outcome.Reason = true, reason
+				return outcome, nil
+			}
+			if observation.URL != "" {
+				outcome.Observations = append(outcome.Observations, observation)
+			}
+		}
+		return outcome, nil
+	})
+	if err != nil {
+		return ports.DASTOutcome{}, err
+	}
+	reason := result.Reason
+	if reason == "context_cancelled" && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		reason = "wall_clock"
+	}
+	return ports.DASTOutcome{Observations: result.Observations, Surface: result.Surface, Coverage: result.Coverage, Incomplete: result.Incomplete, Reason: reason}, nil
+}
+
+var errAuthorizationDenied = errors.New("DAST request authorization denied")
+
+type helperRunner struct {
+	base      *url.URL
+	client    *http.Client
+	session   dastsession.Config
+	authorize func(context.Context, ports.DASTRequest) error
+	reauth    int
+	interval  time.Duration
+	last      time.Time
+}
+
+func (r *helperRunner) runCandidate(ctx context.Context, candidate dastsurface.Request) (ports.DASTObservation, bool, string) {
+	request, err := dastsurface.NormalizeRequest(candidate.Method, candidate.URL)
+	executionURL := candidate.ExecutionURL
+	if executionURL == "" {
+		executionURL = candidate.URL
+	}
+	execution, executionErr := dastsurface.NormalizeRequest(candidate.Method, executionURL)
+	if err != nil || executionErr != nil || !sameOrigin(r.base, executionURL) || execution.Key() != request.Key() || r.session.DeniesPath(requestPath(executionURL)) {
+		return ports.DASTObservation{}, false, ""
+	}
+	method := strings.ToUpper(request.Method)
+	if method != http.MethodGet && method != http.MethodHead {
+		return ports.DASTObservation{}, false, ""
+	}
+	if err := r.live(ctx); err != nil && !r.reauthenticate(ctx) {
+		return ports.DASTObservation{}, true, "session_lost"
+	}
+	observation, err := r.request(ctx, method, executionURL)
+	if err != nil {
+		if errors.Is(err, errAuthorizationDenied) {
+			return ports.DASTObservation{}, true, "request_not_authorized"
+		}
+		return ports.DASTObservation{}, true, "request_failed"
+	}
+	return observation, false, ""
+}
+
+func (r *helperRunner) authenticate(ctx context.Context) error {
+	loginURL, err := r.resolve(r.session.LoginRequest.Path)
+	if err != nil {
+		return err
+	}
+	response, err := r.do(ctx, r.session.LoginRequest.Method, loginURL, true)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	return success(response, r.session.Success)
+}
+
+func (r *helperRunner) reauthenticate(ctx context.Context) bool {
+	max := r.session.MaxReauth
+	if max == 0 {
+		max = dastsession.DefaultMaxReauth
+	}
+	for r.reauth < max {
+		r.reauth++
+		if r.authenticate(ctx) == nil && r.live(ctx) == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *helperRunner) live(ctx context.Context) error {
+	checkURL, err := r.resolve(r.session.CheckRequest.Path)
+	if err != nil {
+		return err
+	}
+	response, err := r.do(ctx, r.session.CheckRequest.Method, checkURL, false)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	return success(response, r.session.Success)
+}
+
+func (r *helperRunner) request(ctx context.Context, method, rawURL string) (ports.DASTObservation, error) {
+	response, err := r.do(ctx, method, rawURL, false)
+	if err != nil {
+		return ports.DASTObservation{}, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxProofBodyBytes+1))
+	if err != nil {
+		return ports.DASTObservation{}, errors.New("read DAST response")
+	}
+	truncated := len(body) > maxProofBodyBytes
+	if truncated {
+		body = body[:maxProofBodyBytes]
+	}
+	hash := sha256.Sum256(body)
+	return ports.DASTObservation{
+		Method: method, URL: proofURL(rawURL), Status: response.StatusCode,
+		BodySHA256: hex.EncodeToString(hash[:]), BodyBytes: len(body), BodyTruncated: truncated,
+		BodyExcerpt: redactExcerpt(body), Headers: redactHeaders(response.Header),
+	}, nil
+}
+
+func (r *helperRunner) do(ctx context.Context, method, rawURL string, login bool) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, strings.ToUpper(method), rawURL, nil)
+	if err != nil {
+		return nil, errors.New("build DAST request")
+	}
+	if login && r.session.Scheme == dastsession.SchemeForm {
+		values := url.Values{}
+		for _, binding := range r.session.Credentials {
+			field := binding.Field
+			if field == "" {
+				field = binding.Name
+			}
+			values.Set(field, os.Getenv(secretEnvName(binding.Name)))
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		encoded := values.Encode()
+		req.Body = io.NopCloser(strings.NewReader(encoded))
+		req.ContentLength = int64(len(encoded))
+	}
+	r.applyAuth(req)
+	if err := r.authorize(ctx, canonicalRequest(req)); err != nil {
+		return nil, errAuthorizationDenied
+	}
+	if !r.last.IsZero() {
+		if delay := r.interval - time.Since(r.last); delay > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+	r.last = time.Now()
+	response, err := r.client.Do(req)
+	if err != nil {
+		if errors.Is(err, errAuthorizationDenied) {
+			return nil, errAuthorizationDenied
+		}
+		return nil, errors.New("send DAST request")
+	}
+	if response.StatusCode >= 300 && response.StatusCode < 400 && response.Header.Get("Location") != "" {
+		redirect, err := response.Location()
+		if err != nil {
+			response.Body.Close()
+			return nil, errors.New("invalid DAST redirect")
+		}
+		if err := r.authorize(ctx, ports.DASTRequest{Method: http.MethodGet, URL: proofURL(redirect.String())}); err != nil {
+			response.Body.Close()
+			return nil, errAuthorizationDenied
+		}
+	}
+	return response, nil
+}
+
+func (r *helperRunner) applyAuth(req *http.Request) {
+	credential := func(i int) string {
+		if i >= len(r.session.Credentials) {
+			return ""
+		}
+		return os.Getenv(secretEnvName(r.session.Credentials[i].Name))
+	}
+	switch r.session.Scheme {
+	case dastsession.SchemeBasic:
+		req.SetBasicAuth(credential(0), credential(1))
+	case dastsession.SchemeBearer:
+		req.Header.Set("Authorization", "Bearer "+credential(0))
+	case dastsession.SchemeHeader:
+		for _, binding := range r.session.Credentials {
+			field := binding.Field
+			if field == "" {
+				field = binding.Name
+			}
+			req.Header.Set(field, os.Getenv(secretEnvName(binding.Name)))
+		}
+	case dastsession.SchemeCookie:
+		for _, binding := range r.session.Credentials {
+			field := binding.Field
+			if field == "" {
+				field = binding.Name
+			}
+			req.AddCookie(&http.Cookie{Name: field, Value: os.Getenv(secretEnvName(binding.Name))})
+		}
+	}
+}
+
+func (r *helperRunner) resolve(p string) (string, error) {
+	u, err := r.base.Parse(p)
+	if err != nil || !sameOrigin(r.base, u.String()) || r.session.DeniesPath(u.Path) {
+		return "", errors.New("invalid DAST session path")
+	}
+	return u.String(), nil
+}
+
+func success(response *http.Response, signal dastsession.SuccessSignal) error {
+	if signal.StatusCode != 0 && response.StatusCode != signal.StatusCode {
+		return errors.New("session signal did not match")
+	}
+	if signal.HeaderPresent != "" && response.Header.Get(signal.HeaderPresent) == "" {
+		return errors.New("session signal did not match")
+	}
+	if signal.CookiePresent != "" {
+		present := false
+		for _, cookie := range response.Cookies() {
+			if cookie.Name == signal.CookiePresent {
+				present = true
+			}
+		}
+		if !present {
+			return errors.New("session signal did not match")
+		}
+	}
+	if signal.BodyContains != "" {
+		body, err := io.ReadAll(io.LimitReader(response.Body, maxProofBodyBytes+1))
+		if err != nil || !strings.Contains(string(body), signal.BodyContains) {
+			return errors.New("session signal did not match")
+		}
+	}
+	return nil
+}
+
+func helperAuthorizer() (func(context.Context, ports.DASTRequest) error, error) {
+	requestFD, err := strconv.Atoi(os.Getenv("SYNAPSE_DAST_AUTH_REQUEST_FD"))
+	if err != nil || requestFD < 3 {
+		return nil, errors.New("DAST authorization channel unavailable")
+	}
+	decisionFD, err := strconv.Atoi(os.Getenv("SYNAPSE_DAST_AUTH_DECISION_FD"))
+	if err != nil || decisionFD < 3 {
+		return nil, errors.New("DAST authorization channel unavailable")
+	}
+	requests := json.NewEncoder(os.NewFile(uintptr(requestFD), "dast-auth-request"))
+	decisions := json.NewDecoder(bufio.NewReader(os.NewFile(uintptr(decisionFD), "dast-auth-decision")))
+	return func(_ context.Context, request ports.DASTRequest) error {
+		if err := requests.Encode(request); err != nil {
+			return errAuthorizationDenied
+		}
+		var decision ports.DASTAuthorization
+		if err := decisions.Decode(&decision); err != nil || !decision.Allowed {
+			return errAuthorizationDenied
+		}
+		return nil
+	}, nil
+}
+
+func canonicalRequest(request *http.Request) ports.DASTRequest {
+	return ports.DASTRequest{Method: request.Method, URL: proofURL(request.URL.String())}
+}
+
+func proofURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	u.User = nil
+	query := u.Query()
+	for key := range query {
+		query[key] = []string{"[REDACTED]"}
+	}
+	u.RawQuery = query.Encode()
+	u.Fragment = ""
+	return u.String()
+}
+
+func discover(base *url.URL, observation ports.DASTObservation) []dastsurface.Request {
+	root, err := html.Parse(strings.NewReader(observation.BodyExcerpt))
+	if err != nil {
+		return nil
+	}
+	var requests []dastsurface.Request
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.ElementNode {
+			for _, attr := range node.Attr {
+				if (node.Data == "a" || node.Data == "area" || node.Data == "link") && strings.EqualFold(attr.Key, "href") {
+					if request, ok := discoveredRequest(base, observation.URL, attr.Val); ok {
+						requests = append(requests, request)
+					}
+				}
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(root)
+	sort.Slice(requests, func(i, j int) bool { return requests[i].Key() < requests[j].Key() })
+	return requests
+}
+
+func discoveredRequest(base *url.URL, page, raw string) (dastsurface.Request, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || raw == "" || strings.HasPrefix(raw, "#") || strings.HasPrefix(strings.ToLower(raw), "javascript:") {
+		return dastsurface.Request{}, false
+	}
+	pageURL, err := url.Parse(page)
+	if err != nil {
+		return dastsurface.Request{}, false
+	}
+	u = pageURL.ResolveReference(u)
+	if !sameOrigin(base, u.String()) {
+		return dastsurface.Request{}, false
+	}
+	request, err := dastsurface.NormalizeRequest(http.MethodGet, u.String())
+	return request, err == nil
+}
+
+func sameOrigin(base *url.URL, raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.User != nil {
+		return false
+	}
+	return canonicalOrigin(base) == canonicalOrigin(u)
+}
+
+func canonicalOrigin(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		if strings.EqualFold(u.Scheme, "https") {
+			port = "443"
+		} else if strings.EqualFold(u.Scheme, "http") {
+			port = "80"
+		}
+	}
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Hostname()) + ":" + port
+}
+
+func requestPath(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "/"
+	}
+	return path.Clean("/" + strings.TrimPrefix(u.Path, "/"))
+}
+
+func secretEnvName(name string) string {
+	return "SYNAPSE_DAST_SECRET_" + strings.ToUpper(strings.NewReplacer("-", "_", ".", "_").Replace(name))
+}
+
+func redactExcerpt(body []byte) string {
+	text := bodySecret.ReplaceAllString(string(body), "$1=[REDACTED]")
+	for _, value := range os.Environ() {
+		name, secret, ok := strings.Cut(value, "=")
+		if ok && strings.HasPrefix(name, "SYNAPSE_DAST_SECRET_") && secret != "" {
+			text = strings.ReplaceAll(text, secret, "[REDACTED]")
+		}
+	}
+	return text
+}
+
+// redactHeaders preserves header names and non-secret values needed by passive checks.
+func redactHeaders(headers http.Header) []string {
+	out := make([]string, 0, len(headers))
+	for name, values := range headers {
+		switch {
+		case strings.EqualFold(name, "Set-Cookie"):
+			for _, value := range values {
+				flags := map[string]bool{}
+				for _, part := range strings.Split(value, ";")[1:] {
+					name, _, _ := strings.Cut(strings.ToLower(strings.TrimSpace(part)), "=")
+					switch name {
+					case "secure", "httponly", "samesite":
+						flags[name] = true
+					}
+				}
+				var names []string
+				for _, name := range []string{"secure", "httponly", "samesite"} {
+					if flags[name] {
+						names = append(names, name)
+					}
+				}
+				out = append(out, "Set-Cookie: "+strings.Join(names, ";"))
+			}
+		case strings.EqualFold(name, "Strict-Transport-Security"):
+			out = append(out, "Strict-Transport-Security")
+		case strings.EqualFold(name, "X-Synapse-Auth-Weakness"):
+			out = append(out, "X-Synapse-Auth-Weakness")
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/infrastructure/dastengine/helper.go
+++ b/internal/infrastructure/dastengine/helper.go
@@ -17,7 +17,6 @@ import (
 	"regexp"
 	"sort"
 
-	"golang.org/x/net/html"
 	"strconv"
 	"strings"
 	"time"
@@ -183,7 +182,7 @@ func (r *helperRunner) authenticate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	return success(response, r.session.Success)
 }
 
@@ -210,7 +209,7 @@ func (r *helperRunner) live(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	return success(response, r.session.Success)
 }
 
@@ -219,7 +218,7 @@ func (r *helperRunner) request(ctx context.Context, method, rawURL string) (port
 	if err != nil {
 		return ports.DASTObservation{}, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	body, err := io.ReadAll(io.LimitReader(response.Body, maxProofBodyBytes+1))
 	if err != nil {
 		return ports.DASTObservation{}, errors.New("read DAST response")
@@ -279,11 +278,11 @@ func (r *helperRunner) do(ctx context.Context, method, rawURL string, login bool
 	if response.StatusCode >= 300 && response.StatusCode < 400 && response.Header.Get("Location") != "" {
 		redirect, err := response.Location()
 		if err != nil {
-			response.Body.Close()
+			_ = response.Body.Close()
 			return nil, errors.New("invalid DAST redirect")
 		}
 		if err := r.authorize(ctx, ports.DASTRequest{Method: http.MethodGet, URL: proofURL(redirect.String())}); err != nil {
-			response.Body.Close()
+			_ = response.Body.Close()
 			return nil, errAuthorizationDenied
 		}
 	}
@@ -316,7 +315,9 @@ func (r *helperRunner) applyAuth(req *http.Request) {
 			if field == "" {
 				field = binding.Name
 			}
-			req.AddCookie(&http.Cookie{Name: field, Value: os.Getenv(secretEnvName(binding.Name))})
+			// Request cookie, not a Set-Cookie: Secure/HttpOnly/SameSite are response directives and
+			// AddCookie serialises only Name=Value, so they would have no effect on the wire.
+			req.AddCookie(&http.Cookie{Name: field, Value: os.Getenv(secretEnvName(binding.Name))}) //nolint:gosec // G124 does not apply to an outgoing request cookie
 		}
 	}
 }
@@ -396,49 +397,6 @@ func proofURL(raw string) string {
 	u.RawQuery = query.Encode()
 	u.Fragment = ""
 	return u.String()
-}
-
-func discover(base *url.URL, observation ports.DASTObservation) []dastsurface.Request {
-	root, err := html.Parse(strings.NewReader(observation.BodyExcerpt))
-	if err != nil {
-		return nil
-	}
-	var requests []dastsurface.Request
-	var walk func(*html.Node)
-	walk = func(node *html.Node) {
-		if node.Type == html.ElementNode {
-			for _, attr := range node.Attr {
-				if (node.Data == "a" || node.Data == "area" || node.Data == "link") && strings.EqualFold(attr.Key, "href") {
-					if request, ok := discoveredRequest(base, observation.URL, attr.Val); ok {
-						requests = append(requests, request)
-					}
-				}
-			}
-		}
-		for child := node.FirstChild; child != nil; child = child.NextSibling {
-			walk(child)
-		}
-	}
-	walk(root)
-	sort.Slice(requests, func(i, j int) bool { return requests[i].Key() < requests[j].Key() })
-	return requests
-}
-
-func discoveredRequest(base *url.URL, page, raw string) (dastsurface.Request, bool) {
-	u, err := url.Parse(raw)
-	if err != nil || raw == "" || strings.HasPrefix(raw, "#") || strings.HasPrefix(strings.ToLower(raw), "javascript:") {
-		return dastsurface.Request{}, false
-	}
-	pageURL, err := url.Parse(page)
-	if err != nil {
-		return dastsurface.Request{}, false
-	}
-	u = pageURL.ResolveReference(u)
-	if !sameOrigin(base, u.String()) {
-		return dastsurface.Request{}, false
-	}
-	request, err := dastsurface.NormalizeRequest(http.MethodGet, u.String())
-	return request, err == nil
 }
 
 func sameOrigin(base *url.URL, raw string) bool {

--- a/internal/infrastructure/dastengine/helper_test.go
+++ b/internal/infrastructure/dastengine/helper_test.go
@@ -1,0 +1,363 @@
+//go:build !windows
+
+package dastengine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestRunHelperAuthSchemesAndSecretFreeProof(t *testing.T) {
+	const secret = "plain-secret-must-not-leak"
+	for _, scheme := range []dastsession.Scheme{dastsession.SchemeForm, dastsession.SchemeBasic, dastsession.SchemeBearer, dastsession.SchemeHeader, dastsession.SchemeCookie} {
+		t.Run(string(scheme), func(t *testing.T) {
+			var requests []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests = append(requests, r.URL.Path)
+				ok := false
+				switch scheme {
+				case dastsession.SchemeForm:
+					if r.URL.Path == "/login" {
+						ok = r.FormValue("credential") == secret
+					} else {
+						cookie, err := r.Cookie("session")
+						ok = err == nil && cookie.Value == "s"
+					}
+				case dastsession.SchemeBasic:
+					user, password, present := r.BasicAuth()
+					ok = present && user == secret && password == "second"
+				case dastsession.SchemeBearer:
+					ok = r.Header.Get("Authorization") == "Bearer "+secret
+				case dastsession.SchemeHeader:
+					ok = r.Header.Get("credential") == secret
+				case dastsession.SchemeCookie:
+					cookie, err := r.Cookie("credential")
+					ok = err == nil && cookie.Value == secret
+				}
+				if !ok {
+					http.Error(w, "bad auth "+secret, http.StatusUnauthorized)
+					return
+				}
+				if r.URL.Path == "/login" {
+					http.SetCookie(w, &http.Cookie{Name: "session", Value: "s"})
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("live " + secret))
+			}))
+			defer server.Close()
+			bindings := []dastsession.CredentialBinding{{Name: "credential", Reference: "first"}}
+			if scheme == dastsession.SchemeBasic {
+				bindings = append(bindings, dastsession.CredentialBinding{Name: "password", Reference: "second"})
+			}
+			plan := ports.DASTPlan{Target: server.URL, Session: dastsession.Config{Scheme: scheme, Credentials: bindings, LoginRequest: dastsession.Request{Method: "POST", Path: "/login"}, CheckRequest: dastsession.Request{Method: "GET", Path: "/live"}, Success: dastsession.SuccessSignal{StatusCode: 200, BodyContains: "live"}, MaxReauth: 1}, Requests: []dastsurface.Request{{Method: "GET", URL: server.URL + "/profile?api_key=" + secret}}}
+			outcome, raw := runHelper(t, plan, map[string]string{"credential": secret, "password": "second"}, func(request ports.DASTRequest) bool {
+				return !strings.Contains(request.URL, "/profile") || !strings.Contains(request.URL, secret)
+			})
+			if outcome.Incomplete || len(outcome.Observations) != 1 {
+				t.Fatalf("outcome = %#v, raw=%s", outcome, raw)
+			}
+			if strings.Contains(raw, secret) || strings.Contains(outcome.Observations[0].URL, secret) {
+				t.Fatalf("secret leaked in output: %s", raw)
+			}
+			if len(requests) < 3 {
+				t.Fatalf("requests=%v, want login/liveness/probe", requests)
+			}
+		})
+	}
+}
+
+func TestRunHelperWrongCredentialsAndReauthExhaustion(t *testing.T) {
+	for name, handler := range map[string]http.HandlerFunc{
+		"wrong credentials": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "bad plain-secret-must-not-leak", http.StatusUnauthorized)
+		},
+		"reauth exhausted": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/login" {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("live"))
+				return
+			}
+			http.Error(w, "dead", http.StatusUnauthorized)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			plan := func() ports.DASTPlan {
+				p := testPlan(server.URL, dastsession.SchemeBearer)
+				p.Session.Success = dastsession.SuccessSignal{StatusCode: 200}
+				return p
+			}()
+			outcome, raw := runHelper(t, plan, map[string]string{"credential": "plain-secret-must-not-leak"}, func(ports.DASTRequest) bool { return true })
+			if !outcome.Incomplete || strings.Contains(raw, "plain-secret-must-not-leak") {
+				t.Fatalf("outcome=%#v raw=%s", outcome, raw)
+			}
+		})
+	}
+}
+
+func TestRunHelperAvoidsLogoutAndSeparatelyAuthorizesRedirect(t *testing.T) {
+	var logoutCalls, redirectCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/logout":
+			logoutCalls++
+		case "/go":
+			redirectCalls++
+			w.Header().Set("Location", "/other")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("live"))
+	}))
+	defer server.Close()
+	plan := testPlan(server.URL, dastsession.SchemeBearer)
+	plan.Requests = []dastsurface.Request{{Method: "GET", URL: server.URL + "/logout"}, {Method: "GET", URL: server.URL + "/go"}}
+	outcome, _ := runHelper(t, plan, map[string]string{"credential": "x"}, func(request ports.DASTRequest) bool { return !strings.HasSuffix(request.URL, "/other") })
+	if logoutCalls != 0 || redirectCalls != 1 || !outcome.Incomplete || outcome.Reason != "request_not_authorized" {
+		t.Fatalf("logout=%d redirects=%d outcome=%#v", logoutCalls, redirectCalls, outcome)
+	}
+}
+
+func TestRunHelperRateLimit(t *testing.T) {
+	var mu sync.Mutex
+	var starts []time.Time
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		starts = append(starts, time.Now())
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("live"))
+	}))
+	defer server.Close()
+	plan := testPlan(server.URL, dastsession.SchemeBearer)
+	plan.Requests = []dastsurface.Request{{Method: "GET", URL: server.URL + "/one"}, {Method: "GET", URL: server.URL + "/two"}, {Method: "GET", URL: server.URL + "/three"}}
+	outcome, _ := runHelper(t, plan, map[string]string{"credential": "x"}, func(ports.DASTRequest) bool { return true })
+	if outcome.Incomplete || len(outcome.Observations) != 3 {
+		t.Fatalf("outcome=%#v", outcome)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(starts) < 7 || starts[len(starts)-1].Sub(starts[0]) < 350*time.Millisecond {
+		t.Fatalf("rate was not bounded: %v", starts)
+	}
+}
+
+func TestRunHelperCrawlWallClockCancelsBlockedIO(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not interrupt blocked helper HTTP reads")
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/slow" {
+			<-r.Context().Done()
+			return
+		}
+		_, _ = w.Write([]byte("live"))
+	}))
+	defer server.Close()
+	plan := testPlan(server.URL, dastsession.SchemeBearer)
+	plan.Requests = nil
+	plan.Crawl = &ports.DASTCrawlPlan{Target: server.URL, Seeds: []dastsurface.Request{{Method: "GET", URL: server.URL + "/slow"}}, Depth: 4, Pages: 10, Requests: 20, WallClock: time.Second}
+	started := time.Now()
+	outcome, _ := runHelper(t, plan, map[string]string{"credential": "token"}, func(ports.DASTRequest) bool { return true })
+	if !outcome.Incomplete || outcome.Reason != "wall_clock" || time.Since(started) > 2*time.Second {
+		t.Fatalf("elapsed=%s outcome=%+v", time.Since(started), outcome)
+	}
+}
+
+func TestRunHelperCrawlKeepsOneAuthenticatedSession(t *testing.T) {
+	var mu sync.Mutex
+	loginCalls := 0
+	requests := map[string]int{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests[r.URL.Path]++
+		mu.Unlock()
+		switch r.URL.Path {
+		case "/login":
+			mu.Lock()
+			loginCalls++
+			mu.Unlock()
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "derived-session", Path: "/"})
+			_, _ = w.Write([]byte("live"))
+		case "/live":
+			if cookie, err := r.Cookie("session"); err != nil || cookie.Value != "derived-session" {
+				http.Error(w, "lost", http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte("live"))
+		case "/one":
+			_, _ = w.Write([]byte(`<a href="/two">next</a>`))
+		case "/two":
+			_, _ = w.Write([]byte("done"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	plan := testPlan(server.URL, dastsession.SchemeBearer)
+	plan.Requests = nil
+	plan.Crawl = &ports.DASTCrawlPlan{Target: server.URL, Seeds: []dastsurface.Request{{Method: "GET", URL: server.URL + "/one"}}, Depth: 4, Pages: 10, Requests: 20, WallClock: 3 * time.Second}
+	outcome, raw := runHelper(t, plan, map[string]string{"credential": "token"}, func(ports.DASTRequest) bool { return true })
+	if outcome.Incomplete || len(outcome.Observations) != 2 || len(outcome.Surface.Requests) != 2 {
+		t.Fatalf("outcome=%+v", outcome)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if loginCalls != 1 || requests["/one"] != 1 || requests["/two"] != 1 {
+		t.Fatalf("login=%d requests=%v", loginCalls, requests)
+	}
+	if strings.Contains(raw, "derived-session") {
+		t.Fatalf("crawl output leaked derived session: %s", raw)
+	}
+}
+
+func TestRunHelperCrawlSharesBoundedReauthentication(t *testing.T) {
+	var mu sync.Mutex
+	loginCalls, generation, liveCalls := 0, 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.URL.Path {
+		case "/login":
+			loginCalls++
+			generation++
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: strconv.Itoa(generation), Path: "/"})
+			_, _ = w.Write([]byte("live"))
+		case "/live":
+			liveCalls++
+			cookie, err := r.Cookie("session")
+			if err != nil || cookie.Value != strconv.Itoa(generation) || generation == 1 && liveCalls > 1 {
+				http.Error(w, "expired", http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte("live"))
+		case "/one":
+			_, _ = w.Write([]byte(`<a href="/two">next</a>`))
+		case "/two":
+			_, _ = w.Write([]byte("done"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	plan := testPlan(server.URL, dastsession.SchemeBearer)
+	plan.Session.MaxReauth = 2
+	plan.Requests = nil
+	plan.Crawl = &ports.DASTCrawlPlan{Target: server.URL, Seeds: []dastsurface.Request{{Method: "GET", URL: server.URL + "/one"}}, Depth: 4, Pages: 10, Requests: 20, WallClock: 3 * time.Second}
+	outcome, _ := runHelper(t, plan, map[string]string{"credential": "token"}, func(ports.DASTRequest) bool { return true })
+	mu.Lock()
+	defer mu.Unlock()
+	if outcome.Incomplete || len(outcome.Observations) != 2 || loginCalls != 2 || liveCalls < 3 {
+		t.Fatalf("outcome=%+v login_calls=%d live_calls=%d", outcome, loginCalls, liveCalls)
+	}
+}
+
+func TestRunHelperCrawlReportsDeniedPathsAsSkipped(t *testing.T) {
+	logoutCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/logout" {
+			logoutCalls++
+		}
+		_, _ = w.Write([]byte("live"))
+	}))
+	defer server.Close()
+	plan := testPlan(server.URL, dastsession.SchemeBearer)
+	plan.Requests = nil
+	plan.Crawl = &ports.DASTCrawlPlan{Target: server.URL, Seeds: []dastsurface.Request{{Method: "GET", URL: server.URL + "/logout"}}, Depth: 4, Pages: 10, Requests: 20, WallClock: time.Second}
+	outcome, _ := runHelper(t, plan, map[string]string{"credential": "token"}, func(ports.DASTRequest) bool { return true })
+	if outcome.Incomplete || logoutCalls != 0 || len(outcome.Surface.Requests) != 1 || len(outcome.Coverage.Entries) != 1 || outcome.Coverage.Entries[0].Status != dastsurface.CoverageSkipped || outcome.Coverage.Entries[0].Reason != "deny_path" {
+		t.Fatalf("logout_calls=%d outcome=%+v", logoutCalls, outcome)
+	}
+}
+
+func testPlan(target string, scheme dastsession.Scheme) ports.DASTPlan {
+	return ports.DASTPlan{Target: target, Session: dastsession.Config{Scheme: scheme, Credentials: []dastsession.CredentialBinding{{Name: "credential", Reference: "credential"}}, LoginRequest: dastsession.Request{Method: "POST", Path: "/login"}, CheckRequest: dastsession.Request{Method: "GET", Path: "/live"}, Success: dastsession.SuccessSignal{StatusCode: 200, BodyContains: "live"}, MaxReauth: 1}, Requests: []dastsurface.Request{{Method: "GET", URL: target + "/one"}}}
+}
+
+func runHelper(t *testing.T, plan ports.DASTPlan, credentials map[string]string, allow func(ports.DASTRequest) bool) (ports.DASTOutcome, string) {
+	t.Helper()
+	requestR, requestW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decisionR, decisionW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer requestR.Close()
+	defer requestW.Close()
+	defer decisionR.Close()
+	defer decisionW.Close()
+	oldRequest, oldDecision := os.Getenv("SYNAPSE_DAST_AUTH_REQUEST_FD"), os.Getenv("SYNAPSE_DAST_AUTH_DECISION_FD")
+	t.Setenv("SYNAPSE_DAST_AUTH_REQUEST_FD", strconv.Itoa(int(requestW.Fd())))
+	t.Setenv("SYNAPSE_DAST_AUTH_DECISION_FD", strconv.Itoa(int(decisionR.Fd())))
+	for name, value := range credentials {
+		t.Setenv(secretEnvName(name), value)
+	}
+	defer os.Setenv("SYNAPSE_DAST_AUTH_REQUEST_FD", oldRequest)
+	defer os.Setenv("SYNAPSE_DAST_AUTH_DECISION_FD", oldDecision)
+	go func() {
+		decoder, encoder := json.NewDecoder(requestR), json.NewEncoder(decisionW)
+		for {
+			var request ports.DASTRequest
+			if decoder.Decode(&request) != nil {
+				return
+			}
+			if encoder.Encode(ports.DASTAuthorization{Allowed: allow(request)}) != nil {
+				return
+			}
+		}
+	}()
+	input, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunHelper(context.Background(), bytes.NewReader(input), &output); err != nil {
+		t.Fatal(err)
+	}
+	var outcome ports.DASTOutcome
+	if err := json.Unmarshal(output.Bytes(), &outcome); err != nil {
+		t.Fatal(err)
+	}
+	return outcome, output.String()
+}
+
+func TestRunHelperRedactsResponseSecretsAndDerivedCookies(t *testing.T) {
+	const secret = "raw-vault-secret"
+	const derived = "derived-session-token"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login" {
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: derived})
+		}
+		w.Header().Set("Location", "/next?access_token="+secret)
+		w.Header().Set("X-Api-Key", secret)
+		w.Header().Add("Set-Cookie", "id=x; Secure; Debug-Token="+secret)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("live token=" + secret + " cookie=" + derived + " authorization: Bearer " + secret))
+	}))
+	defer server.Close()
+	outcome, raw := runHelper(t, testPlan(server.URL, dastsession.SchemeBearer), map[string]string{"credential": secret}, func(ports.DASTRequest) bool { return true })
+	if outcome.Incomplete || len(outcome.Observations) != 1 || strings.Contains(raw, secret) || strings.Contains(raw, derived) || strings.Contains(outcome.Observations[0].BodyExcerpt, secret) || strings.Contains(outcome.Observations[0].BodyExcerpt, derived) {
+		t.Fatalf("secret leaked: %#v raw=%s", outcome, raw)
+	}
+}

--- a/internal/infrastructure/dastengine/helper_test.go
+++ b/internal/infrastructure/dastengine/helper_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -159,9 +158,6 @@ func TestRunHelperRateLimit(t *testing.T) {
 }
 
 func TestRunHelperCrawlWallClockCancelsBlockedIO(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows does not interrupt blocked helper HTTP reads")
-	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/slow" {
 			<-r.Context().Done()

--- a/internal/infrastructure/egress/applier.go
+++ b/internal/infrastructure/egress/applier.go
@@ -22,6 +22,8 @@ import (
 	"net/netip"
 	"os"
 	"os/exec"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -184,7 +186,9 @@ func (a *Applier) Setup(ctx context.Context, name string, idx int, p ports.Egres
 	// dynamic subdomain pinning is a follow-up).
 	denyRules := filterRules(p.Rules, false)
 	allowRules := filterRules(p.Rules, true)
-	hosts, allowDomainRules := a.resolvePins(ctx, domainRules(p.AllowDomains, p.AllowDomainRules))
+	hosts := pinnedHosts(p.PinnedHosts)
+	resolvedHosts, allowDomainRules := a.resolvePins(ctx, domainRules(p.AllowDomains, p.AllowDomainRules))
+	hosts += resolvedHosts
 	allowRules = append(allowRules, allowDomainRules...)
 	ns.AllowedRules = allowRules // expose the resolved allow-set for the connection-observer verdict
 	if _, deny := a.resolvePins(ctx, domainRules(p.DenyDomains, p.DenyDomainRules)); len(deny) > 0 {
@@ -254,7 +258,8 @@ func (a *Applier) resolvePins(ctx context.Context, domains []ports.DomainRule) (
 			rules = append(rules, ports.EgressRule{Allow: true, Net: netip.PrefixFrom(ip, ip.BitLen()), Ports: domain.Ports})
 			line := ip.String() + " " + host
 			if !seen[line] {
-				b.WriteString(line + "\n")
+				b.WriteString(line)
+				b.WriteByte('\n')
 				seen[line] = true
 			}
 		}
@@ -282,6 +287,28 @@ func writeHostsFile(pinned string) (string, error) {
 }
 
 // filterRules returns the rules with the given Allow value, preserving order.
+func pinnedHosts(pins map[string][]netip.Addr) string {
+	if len(pins) == 0 {
+		return ""
+	}
+	hosts := make([]string, 0, len(pins))
+	for host := range pins {
+		hosts = append(hosts, host)
+	}
+	sort.Strings(hosts)
+	var b strings.Builder
+	for _, host := range hosts {
+		addrs := append([]netip.Addr(nil), pins[host]...)
+		slices.SortFunc(addrs, func(a, b netip.Addr) int { return a.Compare(b) })
+		for _, addr := range addrs {
+			if addr.IsValid() {
+				fmt.Fprintf(&b, "%s %s\n", addr.Unmap(), host)
+			}
+		}
+	}
+	return b.String()
+}
+
 func filterRules(rules []ports.EgressRule, allow bool) []ports.EgressRule {
 	var out []ports.EgressRule
 	for _, r := range rules {

--- a/internal/infrastructure/egress/applier_test.go
+++ b/internal/infrastructure/egress/applier_test.go
@@ -2,6 +2,7 @@ package egress
 
 import (
 	"context"
+	"net/netip"
 	"os/exec"
 	"runtime"
 	"testing"
@@ -10,6 +11,17 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	egresspolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/egress"
 )
+
+func TestPinnedHostsAreDeterministic(t *testing.T) {
+	got := pinnedHosts(map[string][]netip.Addr{
+		"b.example": {netip.MustParseAddr("203.0.113.2")},
+		"a.example": {netip.MustParseAddr("203.0.113.3"), netip.MustParseAddr("203.0.113.1")},
+	})
+	want := "203.0.113.1 a.example\n203.0.113.3 a.example\n203.0.113.2 b.example\n"
+	if got != want {
+		t.Fatalf("pinnedHosts()=%q want=%q", got, want)
+	}
+}
 
 func TestLinkAddrsDistinctPerIndex(t *testing.T) {
 	h0, p0, s0 := linkAddrs(0)

--- a/internal/infrastructure/persistence/memory/agent_store_test.go
+++ b/internal/infrastructure/persistence/memory/agent_store_test.go
@@ -50,3 +50,25 @@ func TestMemApprovalIdempotentDecide(t *testing.T) {
 		t.Error("decided action must leave the pending queue")
 	}
 }
+
+func TestMemApprovalConsumeIsSingleUse(t *testing.T) {
+	st := NewApprovalStore()
+	ctx := context.Background()
+	p := agent.ProposedAction{ID: "a1", EngagementID: "e1", Risk: agent.RiskActive, ProposedAt: time.Unix(1, 0)}
+	if err := st.Enqueue(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Decide(ctx, agent.ApprovalDecision{ActionID: "a1", State: agent.ApprovalApproved, DecidedBy: "bob"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Consume(ctx, "a1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Consume(ctx, "a1"); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("a second consume must be ErrConflict, got %v", err)
+	}
+	_, decision, err := st.Get(ctx, "a1")
+	if err != nil || decision.State != agent.ApprovalConsumed || decision.State.Admitted() {
+		t.Fatalf("consumed approval must not remain admitted: %+v err=%v", decision, err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/approval_store.go
+++ b/internal/infrastructure/persistence/memory/approval_store.go
@@ -89,3 +89,18 @@ func (s *ApprovalStore) Decide(_ context.Context, d agent.ApprovalDecision) erro
 	s.decisions[d.ActionID] = d
 	return nil
 }
+
+func (s *ApprovalStore) Consume(_ context.Context, actionID shared.ID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur, ok := s.decisions[actionID]
+	if !ok {
+		return fmt.Errorf("approval %s: %w", actionID, shared.ErrNotFound)
+	}
+	if cur.State != agent.ApprovalApproved {
+		return fmt.Errorf("approval %s cannot be consumed from state %s: %w", actionID, cur.State, shared.ErrConflict)
+	}
+	cur.State = agent.ApprovalConsumed
+	s.decisions[actionID] = cur
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/agent_store_test.go
+++ b/internal/infrastructure/persistence/postgres/agent_store_test.go
@@ -74,4 +74,14 @@ func TestPostgresAgentStores(t *testing.T) {
 	if dec.State != agent.ApprovalApproved || dec.DecidedBy != "bob" {
 		t.Fatalf("decision round-trip wrong: %+v", dec)
 	}
+	if err := as.Consume(ctx, "actA"); err != nil {
+		t.Fatal(err)
+	}
+	if err := as.Consume(ctx, "actA"); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("2nd consume must be ErrConflict, got %v", err)
+	}
+	_, dec, _ = as.Get(ctx, "actA")
+	if dec.State != agent.ApprovalConsumed || dec.State.Admitted() {
+		t.Fatalf("consumed approval must not remain admitted: %+v", dec)
+	}
 }

--- a/internal/infrastructure/persistence/postgres/approval_store.go
+++ b/internal/infrastructure/persistence/postgres/approval_store.go
@@ -127,6 +127,23 @@ func (s *ApprovalStore) Decide(ctx context.Context, d agent.ApprovalDecision) er
 	return nil
 }
 
+func (s *ApprovalStore) Consume(ctx context.Context, actionID shared.ID) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE agent_approvals SET decision_state='consumed'
+		 WHERE action_id=$1 AND decision_state='approved'`, actionID.String())
+	if err != nil {
+		return fmt.Errorf("consume approval: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		var exists bool
+		if e := s.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM agent_approvals WHERE action_id=$1)`, actionID.String()).Scan(&exists); e == nil && exists {
+			return fmt.Errorf("approval %s cannot be consumed: %w", actionID, shared.ErrConflict)
+		}
+		return fmt.Errorf("approval %s: %w", actionID, shared.ErrNotFound)
+	}
+	return nil
+}
+
 func scanProposed(rows pgx.Rows) (agent.ProposedAction, error) {
 	var (
 		a            agent.ProposedAction

--- a/internal/infrastructure/sandbox/runner.go
+++ b/internal/infrastructure/sandbox/runner.go
@@ -241,6 +241,10 @@ func (r *Runner) Run(ctx context.Context, spec ports.ToolSpec) (ports.ToolResult
 	}
 	const seccompChildFD = 3 // ExtraFiles[0] → child fd 3 (CgroupFD is a SysProcAttr fd, not counted)
 	argv := r.command(spec, egressNS, hostsFile, seccompChildFD, runCG != nil)
+	// Keep seccomp at fd 3. Caller descriptors follow in stable order at fd 4+.
+	extraFiles := make([]*os.File, 0, 1+len(spec.ExtraFiles))
+	extraFiles = append(extraFiles, seccompF)
+	extraFiles = append(extraFiles, spec.ExtraFiles...)
 	wrapped := ports.ToolSpec{
 		Name:           argv[0],
 		Args:           argv[1:],
@@ -248,7 +252,7 @@ func (r *Runner) Run(ctx context.Context, spec ports.ToolSpec) (ports.ToolResult
 		Timeout:        spec.Timeout,
 		MaxOutputBytes: spec.MaxOutputBytes,
 		Env:            env,
-		ExtraFiles:     []*os.File{seccompF},
+		ExtraFiles:     extraFiles,
 	}
 	// Clone the tool into the limit cgroup (preferred) or, failing that, the logger's own.
 	if runCG != nil {

--- a/internal/infrastructure/toolrunner/procgroup_unix_test.go
+++ b/internal/infrastructure/toolrunner/procgroup_unix_test.go
@@ -4,6 +4,7 @@ package toolrunner
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -69,5 +70,20 @@ func readPID(t *testing.T, path string) int {
 
 // alive reports whether pid exists (signal 0 probes without killing).
 func alive(pid int) bool {
-	return syscall.Kill(pid, 0) == nil
+	if syscall.Kill(pid, 0) != nil {
+		return false
+	}
+	// kill(pid, 0) succeeds for zombies, which can linger under a container PID 1
+	// that does not reap children. A zombie cannot execute after the group kill.
+	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return true
+	}
+	prefix := fmt.Sprintf("%d (", pid)
+	rest, ok := strings.CutPrefix(string(stat), prefix)
+	if !ok {
+		return true
+	}
+	i := strings.LastIndex(rest, ") ")
+	return i < 0 || !strings.HasPrefix(rest[i+2:], "Z")
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -127,6 +127,15 @@ type Config struct {
 	// trust-on-first-use alone cannot (TOFU only detects post-first-run replacement). Empty
 	// = TOFU only. Parsed from SYNAPSE_TOOL_HASHES.
 	ToolHashes map[string]string
+	// DAST authenticated scan execution ceilings. Per-run values may only lower these.
+	DASTHelperBin    string
+	DASTMaxReauth    int
+	DASTRatePerSec   int
+	DASTConcurrency  int
+	DASTMaxDepth     int
+	DASTMaxPages     int
+	DASTMaxRequests  int
+	DASTMaxWallClock time.Duration
 	// VaultMasterKey is the AES-256 master key for the credential vault: 64 hex
 	// chars or base64 of 32 bytes. Empty = an ephemeral key (dev only; stored secrets do
 	// not survive restart). Required in production. Never logged.
@@ -407,6 +416,16 @@ type Config struct {
 
 // Load reads configuration from environment variables with sane defaults.
 func Load() Config {
+	maxReauth := getint("SYNAPSE_DAST_MAX_REAUTH", 2)
+	ratePerSec := getint("SYNAPSE_DAST_RATE_PER_SEC", 5)
+	concurrency := getint("SYNAPSE_DAST_CONCURRENCY", 4)
+	maxDepth := getint("SYNAPSE_DAST_MAX_DEPTH", 8)
+	maxPages := getint("SYNAPSE_DAST_MAX_PAGES", 2000)
+	maxRequests := getint("SYNAPSE_DAST_MAX_REQUESTS", 20000)
+	maxWallClock := getduration("SYNAPSE_DAST_MAX_WALL_CLOCK", 30*time.Minute)
+	if maxReauth < 0 || maxReauth > 2 || ratePerSec < 1 || ratePerSec > 5 || concurrency < 1 || concurrency > 4 || maxDepth < 1 || maxDepth > 8 || maxPages < 1 || maxPages > 2000 || maxRequests < 1 || maxRequests > 20000 || maxWallClock < time.Second || maxWallClock > 30*time.Minute {
+		maxReauth, ratePerSec, concurrency, maxDepth, maxPages, maxRequests, maxWallClock = 2, 5, 4, 8, 2000, 20000, 30*time.Minute
+	}
 	scanTimeout := getduration("SYNAPSE_SCAN_TIMEOUT", 10*time.Minute)
 	completionTimeout := scanTimeout
 	if completionTimeout <= 0 {
@@ -472,6 +491,14 @@ func Load() Config {
 		SandboxEnabled:      getbool("SYNAPSE_SANDBOX_ENABLED", false),
 		SandboxMemMax:       int64(getint("SYNAPSE_SANDBOX_MEM_MAX", 512<<20)),
 		SandboxPidsMax:      getint("SYNAPSE_SANDBOX_PIDS_MAX", 256),
+		DASTHelperBin:       getenv("SYNAPSE_DAST_HELPER_BIN", "synapse-dast-helper"),
+		DASTMaxReauth:       maxReauth,
+		DASTRatePerSec:      ratePerSec,
+		DASTConcurrency:     concurrency,
+		DASTMaxDepth:        maxDepth,
+		DASTMaxPages:        maxPages,
+		DASTMaxRequests:     maxRequests,
+		DASTMaxWallClock:    maxWallClock,
 		VaultMasterKey:      getenv("SYNAPSE_VAULT_MASTER_KEY", ""),
 		ReconViaWorker:      getbool("SYNAPSE_RECON_VIA_WORKER", false),
 		ToolHashes:          parsePins(getenv("SYNAPSE_TOOL_HASHES", "")),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -186,3 +186,17 @@ func TestLoadMaxWorkspaceBytes(t *testing.T) {
 		t.Errorf("MaxWorkspaceBytes from env = %d, want 8589934592", got)
 	}
 }
+
+func TestLoadDASTCeilingsFailClosed(t *testing.T) {
+	t.Setenv("SYNAPSE_DAST_MAX_REAUTH", "3")
+	t.Setenv("SYNAPSE_DAST_RATE_PER_SEC", "6")
+	t.Setenv("SYNAPSE_DAST_CONCURRENCY", "5")
+	t.Setenv("SYNAPSE_DAST_MAX_DEPTH", "9")
+	t.Setenv("SYNAPSE_DAST_MAX_PAGES", "2001")
+	t.Setenv("SYNAPSE_DAST_MAX_REQUESTS", "20001")
+	t.Setenv("SYNAPSE_DAST_MAX_WALL_CLOCK", "31m")
+	config := Load()
+	if config.DASTMaxReauth != 2 || config.DASTRatePerSec != 5 || config.DASTConcurrency != 4 || config.DASTMaxDepth != 8 || config.DASTMaxPages != 2000 || config.DASTMaxRequests != 20000 || config.DASTMaxWallClock != 30*time.Minute {
+		t.Fatalf("DAST ceilings did not fail closed: %+v", config)
+	}
+}

--- a/internal/usecase/analysis/dast_hook_test.go
+++ b/internal/usecase/analysis/dast_hook_test.go
@@ -42,6 +42,25 @@ func TestVerifyRuntimeConfirmedSASTEmitsDASTNotSAST(t *testing.T) {
 	}
 }
 
+func TestVerifyConfirmedNativeDASTEmitsDAST(t *testing.T) {
+	svc, _, _, _ := newSvc()
+	dast := &fakeDASTRecorder{}
+	sast := &fakeSASTRecorder{}
+	svc.SetDASTRecorder(dast)
+	svc.SetSASTRecorder(sast)
+	claim := judgment.DASTClaim{CWE: "CWE-79", Location: "/search", Rule: "reflected-xss", Source: "first_party", Fingerprint: "search_reflection", ProofEvidenceID: "proof-1"}
+	j, err := svc.Propose(context.Background(), "system:dast", "e1", judgment.CapDAST, judgment.SubjectEngagement, "e1", claim)
+	if err != nil {
+		t.Fatalf("propose: %v", err)
+	}
+	if _, err := svc.Verify(context.Background(), "human:bob", "e1", j.ID, 85, "redacted proof observed", j.Version); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if len(dast.calls) != 1 || len(sast.calls) != 0 {
+		t.Fatalf("native DAST promotion = dast:%d sast:%d", len(dast.calls), len(sast.calls))
+	}
+}
+
 // The STATIC path (Verify) confirming a CapSAST judgment fires the SAST recorder, NOT the DAST one — proving
 // the two paths are cleanly separated and neither double-emits.
 func TestVerifyStaticConfirmedSASTEmitsSASTNotDAST(t *testing.T) {

--- a/internal/usecase/analysis/service.go
+++ b/internal/usecase/analysis/service.go
@@ -141,11 +141,9 @@ func (s *Service) Verify(ctx context.Context, verifier string, engagementID, jud
 	return s.verify(ctx, verifier, engagementID, judgmentID, score, rationale, expectedVersion, false)
 }
 
-// VerifyRuntime is Verify for a verdict produced by a RUNTIME probe (the safe HTTP DAST verifier). It is
-// identical to Verify EXCEPT that a confirmed CapSAST judgment auto-emits a Kind=dast finding (dynamically
-// proven) instead of Kind=sast (statically/LLM confirmed). The runtime-probe path (dastverifier) calls this;
-// the static/LLM path (human review, llmverifier) calls Verify. The distinct verifier, score bar, verdict
-// sealing, and self-confirm guard are all unchanged — only the finding projection differs.
+// VerifyRuntime is Verify for a verdict produced by a runtime probe. It keeps the
+// legacy CapSAST runtime projection as Kind=dast; native CapDAST judgments promote
+// through Verify regardless of verdict transport.
 func (s *Service) VerifyRuntime(ctx context.Context, verifier string, engagementID, judgmentID shared.ID, score int, rationale string, expectedVersion int) (judgment.Judgment, error) {
 	return s.verify(ctx, verifier, engagementID, judgmentID, score, rationale, expectedVersion, true)
 }
@@ -194,26 +192,22 @@ func (s *Service) verify(ctx context.Context, verifier string, engagementID, jud
 			})
 		}
 	}
-	// a verifier-confirmed CapSAST (taint) judgment auto-emits a finding. Best-effort, same contract as the
-	// threat promoter – the judgment is already confirmed + audited; a failed emit is audited, not rolled
-	// back (the finding is a re-derivable projection of the source-of-truth judgment). The verdict's PROOF
-	// METHOD picks the Kind: a RUNTIME probe (VerifyRuntime) → Kind=dast (dynamically proven); a static/LLM
-	// verdict (Verify) → Kind=sast. Exactly one fires per confirmation, so there is never a duplicate.
-	if saved.State == judgment.StateConfirmed && saved.Capability == judgment.CapSAST {
-		if runtimeProof && s.dastRecorder != nil {
-			if rerr := s.dastRecorder.RecordConfirmedDAST(ctx, verifier, saved); rerr != nil {
-				_ = s.audit.Record(ctx, ports.AuditEntry{
-					Actor: verifier, Action: "dast_finding.emit_failed", Target: judgmentID.String(),
-					Metadata: map[string]string{"engagement": engagementID.String()}, At: s.clock.Now(),
-				})
-			}
-		} else if !runtimeProof && s.sastRecorder != nil {
-			if rerr := s.sastRecorder.RecordConfirmedSAST(ctx, verifier, saved); rerr != nil {
-				_ = s.audit.Record(ctx, ports.AuditEntry{
-					Actor: verifier, Action: "sast_finding.emit_failed", Target: judgmentID.String(),
-					Metadata: map[string]string{"engagement": engagementID.String()}, At: s.clock.Now(),
-				})
-			}
+	// Native CapDAST judgments always project to DAST. Legacy runtime-confirmed
+	// CapSAST judgments retain their existing projection, while normal CapSAST
+	// verification remains a SAST finding.
+	if saved.State == judgment.StateConfirmed && (saved.Capability == judgment.CapDAST || (saved.Capability == judgment.CapSAST && runtimeProof)) && s.dastRecorder != nil {
+		if rerr := s.dastRecorder.RecordConfirmedDAST(ctx, verifier, saved); rerr != nil {
+			_ = s.audit.Record(ctx, ports.AuditEntry{
+				Actor: verifier, Action: "dast_finding.emit_failed", Target: judgmentID.String(),
+				Metadata: map[string]string{"engagement": engagementID.String()}, At: s.clock.Now(),
+			})
+		}
+	} else if saved.State == judgment.StateConfirmed && saved.Capability == judgment.CapSAST && !runtimeProof && s.sastRecorder != nil {
+		if rerr := s.sastRecorder.RecordConfirmedSAST(ctx, verifier, saved); rerr != nil {
+			_ = s.audit.Record(ctx, ports.AuditEntry{
+				Actor: verifier, Action: "sast_finding.emit_failed", Target: judgmentID.String(),
+				Metadata: map[string]string{"engagement": engagementID.String()}, At: s.clock.Now(),
+			})
 		}
 	}
 	return saved, nil

--- a/internal/usecase/dastcrawl/crawl.go
+++ b/internal/usecase/dastcrawl/crawl.go
@@ -1,0 +1,430 @@
+// Package dastcrawl derives a bounded, deterministic HTTP surface from authenticated observations.
+package dastcrawl
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	DefaultDepth     = 8
+	DefaultPages     = 2000
+	DefaultRequests  = 20000
+	DefaultWallClock = 30 * time.Minute
+)
+
+type Limits struct {
+	Depth, Pages, Requests int
+	WallClock              time.Duration
+}
+
+func (l Limits) normalized() (Limits, error) {
+	if l.Depth == 0 {
+		l.Depth = DefaultDepth
+	}
+	if l.Pages == 0 {
+		l.Pages = DefaultPages
+	}
+	if l.Requests == 0 {
+		l.Requests = DefaultRequests
+	}
+	if l.WallClock == 0 {
+		l.WallClock = DefaultWallClock
+	}
+	if l.Depth < 1 || l.Depth > DefaultDepth || l.Pages < 1 || l.Pages > DefaultPages || l.Requests < 1 || l.Requests > DefaultRequests || l.WallClock < time.Second || l.WallClock > DefaultWallClock {
+		return Limits{}, fmt.Errorf("%w: invalid DAST crawl limits", shared.ErrValidation)
+	}
+	return l, nil
+}
+
+type Input struct {
+	Target   string
+	Seeds    []dastsurface.Request
+	Robots   string
+	Sitemaps []string
+	OpenAPI  []string
+	GraphQL  []string // Explicitly operator-permitted introspection response JSON.
+}
+
+type Batch func(context.Context, []dastsurface.Request) (ports.DASTOutcome, error)
+
+type Result struct {
+	Surface      dastsurface.Surface
+	Coverage     dastsurface.Coverage
+	Observations []ports.DASTObservation
+	Incomplete   bool
+	Reason       string
+}
+
+type queued struct {
+	request dastsurface.Request
+	depth   int
+}
+
+func Crawl(ctx context.Context, input Input, limits Limits, run Batch) (Result, error) {
+	if run == nil {
+		return Result{}, fmt.Errorf("%w: DAST crawl batch runner is required", shared.ErrValidation)
+	}
+	limits, err := limits.normalized()
+	if err != nil {
+		return Result{}, err
+	}
+	base, err := url.Parse(input.Target)
+	if err != nil || base.Scheme == "" || base.Host == "" || base.User != nil {
+		return Result{}, fmt.Errorf("%w: DAST crawl target is invalid", shared.ErrValidation)
+	}
+	crawlCtx, cancel := context.WithTimeout(ctx, limits.WallClock)
+	defer cancel()
+	var coverage []dastsurface.CoverageEntry
+	queue := append([]queued{}, sourceRequests(base, input.Seeds, dastsurface.SourceSeed, &coverage)...)
+	queue = append(queue, sourceRequests(base, parseRobots(input.Robots), dastsurface.SourceRobots, &coverage)...)
+	for _, doc := range input.Sitemaps {
+		queue = append(queue, sourceRequests(base, parseSitemap(doc), dastsurface.SourceSitemap, &coverage)...)
+	}
+	for _, doc := range input.OpenAPI {
+		queue = append(queue, sourceRequests(base, parseOpenAPI(doc), dastsurface.SourceOpenAPI, &coverage)...)
+	}
+	for _, doc := range input.GraphQL {
+		queue = append(queue, sourceRequests(base, parseGraphQL(doc), dastsurface.SourceGraphQL, &coverage)...)
+	}
+	sortQueue(queue)
+	seen := map[string]bool{}
+	var executed []dastsurface.Request
+	var observations []ports.DASTObservation
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return finish(executed, observations, coverage, true, "context_cancelled")
+		}
+		if err := crawlCtx.Err(); err != nil {
+			return finish(executed, observations, appendLimited(queue, coverage, "wall_clock"), true, "wall_clock")
+		}
+		q := queue[0]
+		queue = queue[1:]
+		if seen[q.request.Key()] {
+			continue
+		}
+		seen[q.request.Key()] = true
+		if q.depth > limits.Depth {
+			coverage = append(coverage, entry(q.request, dastsurface.CoverageLimited, "depth"))
+			continue
+		}
+		if len(executed) >= limits.Pages || len(executed) >= limits.Requests {
+			return finish(executed, observations, appendLimited(append([]queued{q}, queue...), coverage, "page_or_request_limit"), true, "page_or_request_limit")
+		}
+		outcome, runErr := run(crawlCtx, []dastsurface.Request{q.request})
+		if ctx.Err() != nil {
+			return finish(executed, observations, coverage, true, "context_cancelled")
+		}
+		if crawlCtx.Err() != nil {
+			return finish(executed, observations, appendLimited(append([]queued{q}, queue...), coverage, "wall_clock"), true, "wall_clock")
+		}
+		if runErr != nil {
+			return Result{}, fmt.Errorf("run DAST crawl request: %w", runErr)
+		}
+		if len(outcome.Coverage.Entries) == 0 {
+			coverage = append(coverage, entry(q.request, dastsurface.CoverageRequested, ""))
+		} else {
+			coverage = append(coverage, outcome.Coverage.Entries...)
+		}
+		executed = append(executed, q.request)
+		observations = append(observations, outcome.Observations...)
+		if outcome.Incomplete {
+			return finish(executed, observations, coverage, true, outcome.Reason)
+		}
+		for _, observation := range outcome.Observations {
+			for _, discovered := range parseObservation(base, observation) {
+				if discovered.Method != "GET" && discovered.Method != "HEAD" {
+					coverage = append(coverage, entry(discovered, dastsurface.CoverageSkipped, "form"))
+					continue
+				}
+				discovered.Source = dastsurface.SourceHTML
+				next := sourceRequests(base, []dastsurface.Request{discovered}, discovered.Source, &coverage)
+				for i := range next {
+					next[i].depth = q.depth + 1
+				}
+				queue = append(queue, next...)
+			}
+		}
+		sortQueue(queue)
+	}
+	return finish(executed, observations, coverage, false, "")
+}
+
+func finish(requests []dastsurface.Request, observations []ports.DASTObservation, entries []dastsurface.CoverageEntry, incomplete bool, reason string) (Result, error) {
+	surface, err := dastsurface.NewSurface(requests)
+	if err != nil {
+		return Result{}, err
+	}
+	coverage, err := dastsurface.NewCoverage(entries)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Surface: surface, Coverage: coverage, Observations: observations, Incomplete: incomplete, Reason: reason}, nil
+}
+func entry(r dastsurface.Request, status dastsurface.CoverageStatus, reason string) dastsurface.CoverageEntry {
+	return dastsurface.CoverageEntry{Request: r, Status: status, Reason: reason, Source: r.Source}
+}
+func appendLimited(q []queued, entries []dastsurface.CoverageEntry, reason string) []dastsurface.CoverageEntry {
+	for _, v := range q {
+		entries = append(entries, entry(v.request, dastsurface.CoverageLimited, reason))
+	}
+	return entries
+}
+func sortQueue(q []queued) {
+	sort.Slice(q, func(i, j int) bool {
+		if q[i].depth != q[j].depth {
+			return q[i].depth < q[j].depth
+		}
+		return q[i].request.Key() < q[j].request.Key()
+	})
+}
+func sourceRequests(base *url.URL, requests []dastsurface.Request, source dastsurface.Source, coverage *[]dastsurface.CoverageEntry) []queued {
+	out := make([]queued, 0, len(requests))
+	for _, r := range requests {
+		raw := r.URL
+		parsed, parseErr := url.Parse(raw)
+		if parseErr != nil {
+			continue
+		}
+		if !parsed.IsAbs() {
+			raw = base.ResolveReference(parsed).String()
+		}
+		n, err := dastsurface.NormalizeRequest(r.Method, raw)
+		if err != nil {
+			continue
+		}
+		executionURL := raw
+		if r.ExecutionURL != "" {
+			executionURL = r.ExecutionURL
+		}
+		if executionURL == "" {
+			executionURL = r.URL
+		}
+		executionURLParsed, executionErr := url.Parse(executionURL)
+		if executionErr != nil || executionURLParsed.User != nil {
+			continue
+		}
+		executionURLParsed.Scheme = strings.ToLower(executionURLParsed.Scheme)
+		executionURLParsed.Host = strings.ToLower(executionURLParsed.Host)
+		executionURLParsed.Fragment = ""
+		n.ExecutionURL = executionURLParsed.String()
+		n.Source = source
+		if !sameOrigin(base, n.URL) {
+			*coverage = append(*coverage, entry(n, dastsurface.CoverageOutOfScope, "origin"))
+			continue
+		}
+		if n.Method != "GET" && n.Method != "HEAD" {
+			*coverage = append(*coverage, entry(n, dastsurface.CoverageSkipped, "discovery_method"))
+			continue
+		}
+		out = append(out, queued{request: n})
+	}
+	return out
+}
+func sameOrigin(base *url.URL, raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.User != nil {
+		return false
+	}
+	return canonicalOrigin(base) == canonicalOrigin(u)
+}
+
+func canonicalOrigin(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		if strings.EqualFold(u.Scheme, "https") {
+			port = "443"
+		} else if strings.EqualFold(u.Scheme, "http") {
+			port = "80"
+		}
+	}
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Hostname()) + ":" + port
+}
+
+func parseObservation(base *url.URL, o ports.DASTObservation) []dastsurface.Request {
+	return append(parseHTML(base, o.URL, o.BodyExcerpt), parseJS(base, o.URL, scriptText(o.BodyExcerpt))...)
+}
+func resolve(base *url.URL, page, raw string) (dastsurface.Request, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || raw == "" || strings.HasPrefix(raw, "#") || strings.HasPrefix(strings.ToLower(raw), "javascript:") {
+		return dastsurface.Request{}, false
+	}
+	pageURL, _ := url.Parse(page)
+	u = pageURL.ResolveReference(u)
+	if !sameOrigin(base, u.String()) {
+		return dastsurface.Request{}, false
+	}
+	r, err := dastsurface.NormalizeRequest("GET", u.String())
+	return r, err == nil
+}
+
+func parseHTML(base *url.URL, page, body string) []dastsurface.Request {
+	root, err := html.Parse(strings.NewReader(body))
+	if err != nil {
+		return nil
+	}
+	var out []dastsurface.Request
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			var attr string
+			switch strings.ToLower(n.Data) {
+			case "a", "area", "link", "script":
+				attr = "href"
+				if n.Data == "script" {
+					attr = "src"
+				}
+			case "form":
+				for _, a := range n.Attr {
+					if strings.EqualFold(a.Key, "action") {
+						attr = a.Val
+					}
+				}
+				if attr != "" {
+					if r, ok := resolve(base, page, attr); ok {
+						r.Method = "POST"
+						r.Source = dastsurface.SourceForm
+						out = append(out, r)
+					}
+				}
+				attr = ""
+			}
+			if attr != "" {
+				for _, a := range n.Attr {
+					if strings.EqualFold(a.Key, attr) {
+						if r, ok := resolve(base, page, a.Val); ok {
+							out = append(out, r)
+						}
+					}
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(root)
+	return out
+}
+
+var jsEndpoint = regexp.MustCompile(`(?i)["']((?:/|https?://)[^"'\\\s]{1,512})["']`)
+
+func parseJS(base *url.URL, page, body string) []dastsurface.Request {
+	var out []dastsurface.Request
+	for _, m := range jsEndpoint.FindAllStringSubmatch(body, -1) {
+		if r, ok := resolve(base, page, m[1]); ok {
+			r.Source = dastsurface.SourceScript
+			out = append(out, r)
+		}
+	}
+	return out
+}
+func parseRobots(doc string) []dastsurface.Request {
+	var out []dastsurface.Request
+	for _, line := range strings.Split(doc, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if ok && strings.EqualFold(strings.TrimSpace(key), "sitemap") {
+			out = append(out, dastsurface.Request{Method: "GET", URL: strings.TrimSpace(value)})
+		}
+	}
+	return out
+}
+
+type sitemap struct {
+	XMLName xml.Name `xml:"urlset"`
+	URLs    []struct {
+		Loc string `xml:"loc"`
+	} `xml:"url"`
+	Maps []struct {
+		Loc string `xml:"loc"`
+	} `xml:"sitemap"`
+}
+
+func parseSitemap(doc string) []dastsurface.Request {
+	var s sitemap
+	if xml.Unmarshal([]byte(doc), &s) != nil {
+		return nil
+	}
+	var out []dastsurface.Request
+	for _, u := range s.URLs {
+		out = append(out, dastsurface.Request{Method: "GET", URL: strings.TrimSpace(u.Loc)})
+	}
+	for _, u := range s.Maps {
+		out = append(out, dastsurface.Request{Method: "GET", URL: strings.TrimSpace(u.Loc)})
+	}
+	return out
+}
+func parseOpenAPI(doc string) []dastsurface.Request {
+	var raw struct {
+		Paths map[string]json.RawMessage `json:"paths"`
+	}
+	if json.Unmarshal([]byte(doc), &raw) == nil {
+		var out []dastsurface.Request
+		for p, methods := range raw.Paths {
+			var ms map[string]json.RawMessage
+			_ = json.Unmarshal(methods, &ms)
+			for method := range ms {
+				if method == "get" || method == "head" {
+					out = append(out, dastsurface.Request{Method: strings.ToUpper(method), URL: p})
+				}
+			}
+		}
+		return out
+	}
+	var out []dastsurface.Request
+	for _, line := range strings.Split(doc, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "/") && strings.HasSuffix(line, ":") {
+			out = append(out, dastsurface.Request{Method: "GET", URL: strings.TrimSuffix(line, ":")})
+		}
+	}
+	return out
+}
+func parseGraphQL(doc string) []dastsurface.Request {
+	var raw any
+	if json.Unmarshal([]byte(doc), &raw) != nil {
+		return nil
+	}
+	encoded, _ := json.Marshal(raw)
+	var out []dastsurface.Request
+	for _, m := range jsEndpoint.FindAllStringSubmatch(string(encoded), -1) {
+		out = append(out, dastsurface.Request{Method: "GET", URL: m[1]})
+	}
+	return out
+}
+
+func scriptText(body string) string {
+	root, err := html.Parse(strings.NewReader(body))
+	if err != nil {
+		return ""
+	}
+	var parts []string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && strings.EqualFold(n.Data, "script") {
+			for child := n.FirstChild; child != nil; child = child.NextSibling {
+				if child.Type == html.TextNode {
+					parts = append(parts, child.Data)
+				}
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(root)
+	return strings.Join(parts, "\n")
+}

--- a/internal/usecase/dastcrawl/crawl_test.go
+++ b/internal/usecase/dastcrawl/crawl_test.go
@@ -1,0 +1,111 @@
+package dastcrawl
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestCrawlSourcesAndSafety(t *testing.T) {
+	var contacted []string
+	run := func(_ context.Context, requests []dastsurface.Request) (ports.DASTOutcome, error) {
+		contacted = append(contacted, requests[0].ExecutionURL)
+		body := ""
+		if requests[0].URL == "https://app.test/" {
+			body = `<a href="/b">b</a><a href="https://outside.test/no">no</a><form action="/submit" method="post"></form><script>fetch('/literal')</script><script>fetch('/' + dynamic)</script>`
+		}
+		return ports.DASTOutcome{Observations: []ports.DASTObservation{{URL: requests[0].ExecutionURL, BodyExcerpt: body}}}, nil
+	}
+	result, err := Crawl(context.Background(), Input{Target: "https://app.test", Seeds: []dastsurface.Request{{Method: "GET", URL: "https://app.test/?page=1"}, {Method: "POST", URL: "https://app.test/post"}, {Method: "GET", URL: "https://outside.test/no"}}, Robots: "Sitemap: https://app.test/robots-map", Sitemaps: []string{`<urlset><url><loc>https://app.test/site</loc></url></urlset>`}, OpenAPI: []string{`{"paths":{"/api":{"get":{}},"/write":{"post":{}}}}`}, GraphQL: []string{`{"data":{"url":"/graphql-doc"}}`}}, Limits{}, run)
+	if err != nil || result.Incomplete {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	want := []string{"https://app.test/?page=1", "https://app.test/api", "https://app.test/graphql-doc", "https://app.test/robots-map", "https://app.test/site", "https://app.test/b", "https://app.test/literal"}
+	if !reflect.DeepEqual(contacted, want) {
+		t.Fatalf("contacted=%v want=%v", contacted, want)
+	}
+	for _, c := range result.Coverage.Entries {
+		if c.Status == dastsurface.CoverageOutOfScope && c.Request.URL == "https://outside.test/no" {
+			return
+		}
+	}
+	t.Fatal("out-of-scope link was not recorded")
+}
+
+func TestCrawlRecordsEngineSkippedRequests(t *testing.T) {
+	requested := false
+	result, err := Crawl(context.Background(), Input{
+		Target: "https://app.test",
+		Seeds:  []dastsurface.Request{{Method: "GET", URL: "https://app.test/logout"}},
+	}, Limits{}, func(_ context.Context, requests []dastsurface.Request) (ports.DASTOutcome, error) {
+		requested = true
+		return ports.DASTOutcome{Coverage: dastsurface.Coverage{Entries: []dastsurface.CoverageEntry{{
+			Request: requests[0], Status: dastsurface.CoverageSkipped, Reason: "deny_path", Source: requests[0].Source,
+		}}}}, nil
+	})
+	if err != nil || !requested || len(result.Coverage.Entries) != 1 || result.Coverage.Entries[0].Status != dastsurface.CoverageSkipped || result.Coverage.Entries[0].Reason != "deny_path" {
+		t.Fatalf("requested=%t result=%+v err=%v", requested, result, err)
+	}
+	for _, entry := range result.Coverage.Entries {
+		if entry.Status == dastsurface.CoverageRequested {
+			t.Fatalf("engine-skipped request was reported as requested: %+v", entry)
+		}
+	}
+}
+
+func TestCrawlBoundsAndCancellation(t *testing.T) {
+	seed := []dastsurface.Request{{Method: "GET", URL: "https://app.test/a"}, {Method: "GET", URL: "https://app.test/b"}}
+	for name, tc := range map[string]struct {
+		ctx    context.Context
+		limits Limits
+		want   string
+	}{
+		"page":    {context.Background(), Limits{Pages: 1}, "page_or_request_limit"},
+		"request": {context.Background(), Limits{Requests: 1}, "page_or_request_limit"},
+		"depth":   {context.Background(), Limits{Depth: 1}, ""},
+		"cancel":  {func() context.Context { c, cancel := context.WithCancel(context.Background()); cancel(); return c }(), Limits{}, "context_cancelled"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := Crawl(tc.ctx, Input{Target: "https://app.test", Seeds: seed}, tc.limits, func(_ context.Context, r []dastsurface.Request) (ports.DASTOutcome, error) {
+				return ports.DASTOutcome{}, nil
+			})
+			if err != nil || !result.Incomplete && tc.want != "" || result.Reason != tc.want {
+				t.Fatalf("result=%#v err=%v", result, err)
+			}
+		})
+	}
+	started := time.Now()
+	result, err := Crawl(context.Background(), Input{Target: "https://app.test", Seeds: seed}, Limits{WallClock: time.Second}, func(ctx context.Context, _ []dastsurface.Request) (ports.DASTOutcome, error) {
+		<-ctx.Done()
+		return ports.DASTOutcome{}, nil
+	})
+	if err != nil || !result.Incomplete || result.Reason != "wall_clock" || time.Since(started) > 2*time.Second {
+		t.Fatalf("elapsed=%s result=%#v err=%v", time.Since(started), result, err)
+	}
+}
+
+func TestCrawlPathologicalPaginatorRetainsFirstExecutionURL(t *testing.T) {
+	var got []string
+	_, err := Crawl(context.Background(), Input{Target: "https://app.test", Seeds: []dastsurface.Request{{Method: "GET", URL: "https://app.test/list?page=1"}, {Method: "GET", URL: "https://app.test/list?page=2"}}}, Limits{}, func(_ context.Context, r []dastsurface.Request) (ports.DASTOutcome, error) {
+		got = append(got, r[0].ExecutionURL)
+		return ports.DASTOutcome{}, nil
+	})
+	if err != nil || !reflect.DeepEqual(got, []string{"https://app.test/list?page=1"}) {
+		t.Fatalf("got=%v err=%v", got, err)
+	}
+}
+
+func TestCrawlPropagatesEngineError(t *testing.T) {
+	want := errors.New("sandbox unavailable")
+	_, err := Crawl(context.Background(), Input{Target: "https://app.test", Seeds: []dastsurface.Request{{Method: "GET", URL: "https://app.test/"}}}, Limits{}, func(context.Context, []dastsurface.Request) (ports.DASTOutcome, error) {
+		return ports.DASTOutcome{}, want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/usecase/dastrunner/service.go
+++ b/internal/usecase/dastrunner/service.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/netip"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -97,6 +98,7 @@ type sealedResult struct {
 	Status            int    `json:"status,omitempty"`
 	BodySHA256        string `json:"body_sha256,omitempty"`
 	BodyTruncated     bool   `json:"body_truncated,omitempty"`
+	BodyExcerpt       string `json:"body_excerpt,omitempty"`
 	BodyMarkerMatched bool   `json:"body_marker_matched"`
 	ProofClass        string `json:"proof_class"`
 	RunnerExitCode    int    `json:"runner_exit_code"`
@@ -150,6 +152,9 @@ func (s *Service) Execute(ctx context.Context, admitted safety.AdmittedAction, p
 	status, body := splitCurlStatus(res.Stdout)
 	markerMatched := probe.ExpectedBodyContains == "" || bytes.Contains(body, []byte(probe.ExpectedBodyContains))
 	proof := classify(runErr, status, markerMatched, probe.ExpectedStatus)
+	if res.Truncated {
+		proof = dastverifier.ProofClassNeedsMoreProof
+	}
 	bodyHash := sha256.Sum256(body)
 	sealed, err := json.Marshal(sealedResult{
 		JudgmentID:        probe.JudgmentID.String(),
@@ -160,6 +165,7 @@ func (s *Service) Execute(ctx context.Context, admitted safety.AdmittedAction, p
 		Status:            status,
 		BodySHA256:        hex.EncodeToString(bodyHash[:]),
 		BodyTruncated:     res.Truncated,
+		BodyExcerpt:       redactProbeExcerpt(body),
 		BodyMarkerMatched: markerMatched,
 		ProofClass:        string(proof),
 		RunnerExitCode:    res.ExitCode,
@@ -327,4 +333,16 @@ func classify(runErr error, status int, markerMatched bool, expectedStatus int) 
 		return dastverifier.ProofClassRuntimeConfirmed
 	}
 	return dastverifier.ProofClassRuntimeRefuted
+}
+
+func redactProbeExcerpt(body []byte) string {
+	const max = 1024
+	if len(body) > max {
+		body = body[:max]
+	}
+	text := redact.String(string(body), nil)
+	for _, key := range []string{"token", "session", "api_key", "key", "secret", "password", "auth", "signature", "cookie"} {
+		text = regexp.MustCompile("(?i)"+key+"[[:space:]]*[:=][[:space:]]*[^[:space:]&<,;]+").ReplaceAllString(text, key+"=[REDACTED]")
+	}
+	return text
 }

--- a/internal/usecase/dastsession/service.go
+++ b/internal/usecase/dastsession/service.go
@@ -43,13 +43,25 @@ func NewService(engine ports.DASTEngine, guard *execution.Guard, ev *evidence.Se
 	return &Service{engine: engine, guard: guard, evidence: ev}, nil
 }
 
-// Execute requires an already admitted action, then reauthorizes every actual
-// helper request. The helper receives credentials only as vault placeholders in env.
-func (s *Service) Execute(ctx context.Context, admitted safety.AdmittedAction, config dastsession.Config, requests []dastsurface.Request) (ports.DASTOutcome, error) {
-	return s.execute(ctx, admitted, config, requests, ports.DefaultDASTRatePerSec, ports.DefaultDASTConcurrency)
+// Execute refuses, for the same reason Crawl does: without an approval-bound helper and configuration
+// digest there is nothing tying this run to what a human approved, and dastengine.Engine rightly rejects
+// such a plan. Refusing HERE names the missing binding instead of failing deep inside the engine with a
+// message about a digest the caller was never asked to supply.
+//
+// Use ExecuteWithBinding, passing the helper and digest from the approval whose argv commits to them --
+// exactly as dastworkflow/scan.go already does for CrawlWithRate.
+func (s *Service) Execute(_ context.Context, _ safety.AdmittedAction, _ dastsession.Config, _ []dastsurface.Request) (ports.DASTOutcome, error) {
+	return ports.DASTOutcome{}, fmt.Errorf("%w: DAST replay requires an approval-bound helper and configuration digest", shared.ErrValidation)
 }
 
-func (s *Service) execute(ctx context.Context, admitted safety.AdmittedAction, config dastsession.Config, requests []dastsurface.Request, ratePerSec, concurrency int) (ports.DASTOutcome, error) {
+// ExecuteWithBinding replays an approved request set. It reauthorizes every actual helper request; the
+// helper receives credentials only as vault placeholders in env. helperBin and configDigest come from
+// the approval that authorized this exact configuration.
+func (s *Service) ExecuteWithBinding(ctx context.Context, admitted safety.AdmittedAction, helperBin, configDigest string, config dastsession.Config, requests []dastsurface.Request) (ports.DASTOutcome, error) {
+	return s.execute(ctx, admitted, helperBin, configDigest, config, requests, ports.DefaultDASTRatePerSec, ports.DefaultDASTConcurrency)
+}
+
+func (s *Service) execute(ctx context.Context, admitted safety.AdmittedAction, helperBin, configDigest string, config dastsession.Config, requests []dastsurface.Request, ratePerSec, concurrency int) (ports.DASTOutcome, error) {
 	action := admitted.Action()
 	if action.Tool != ToolAuthenticatedDAST || action.Action != ActionAuthenticatedDAST || action.Target.Kind != engagement.TargetURL {
 		return ports.DASTOutcome{}, fmt.Errorf("%w: admitted action is not an authenticated DAST scan", shared.ErrValidation)
@@ -73,6 +85,7 @@ func (s *Service) execute(ctx context.Context, admitted safety.AdmittedAction, c
 		return ports.DASTOutcome{}, err
 	}
 	outcome, runErr := s.engine.Run(ctx, ports.DASTPlan{
+		HelperBin: helperBin, ConfigDigest: configDigest,
 		Target: action.Target.Value, Session: config, Requests: requests,
 		RatePerSec: ratePerSec, Concurrency: concurrency,
 		EngagementID: action.EngagementID, EgressPolicy: egressPolicy,

--- a/internal/usecase/dastsession/service.go
+++ b/internal/usecase/dastsession/service.go
@@ -1,0 +1,225 @@
+// Package dastsession executes approved, authenticated DAST request batches.
+package dastsession
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastcrawl"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
+)
+
+const (
+	ToolAuthenticatedDAST   = "run_authenticated_dast"
+	ActionAuthenticatedDAST = "dast.authenticated_scan"
+	evidenceKindSession     = "dast_authenticated_session"
+)
+
+// Service delegates all HTTP to the sandboxed helper and authorizes every request
+// through the shared execution guard before the helper can issue it.
+type Service struct {
+	engine   ports.DASTEngine
+	guard    *execution.Guard
+	evidence *evidence.Service
+}
+
+func NewService(engine ports.DASTEngine, guard *execution.Guard, ev *evidence.Service) (*Service, error) {
+	if engine == nil || guard == nil || ev == nil {
+		return nil, fmt.Errorf("%w: DAST session service requires engine, guard, and evidence", shared.ErrValidation)
+	}
+	return &Service{engine: engine, guard: guard, evidence: ev}, nil
+}
+
+// Execute requires an already admitted action, then reauthorizes every actual
+// helper request. The helper receives credentials only as vault placeholders in env.
+func (s *Service) Execute(ctx context.Context, admitted safety.AdmittedAction, config dastsession.Config, requests []dastsurface.Request) (ports.DASTOutcome, error) {
+	return s.execute(ctx, admitted, config, requests, ports.DefaultDASTRatePerSec, ports.DefaultDASTConcurrency)
+}
+
+func (s *Service) execute(ctx context.Context, admitted safety.AdmittedAction, config dastsession.Config, requests []dastsurface.Request, ratePerSec, concurrency int) (ports.DASTOutcome, error) {
+	action := admitted.Action()
+	if action.Tool != ToolAuthenticatedDAST || action.Action != ActionAuthenticatedDAST || action.Target.Kind != engagement.TargetURL {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: admitted action is not an authenticated DAST scan", shared.ErrValidation)
+	}
+	if admitted.DecidedBy() == "" || admitted.DecidedBy() == "auto" {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: authenticated DAST requires explicit human approval", shared.ErrForbidden)
+	}
+	if err := config.Validate(); err != nil {
+		return ports.DASTOutcome{}, err
+	}
+	base, err := url.Parse(action.Target.Value)
+	if err != nil || base.User != nil || base.Scheme == "" || base.Host == "" {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: DAST action target must be an absolute HTTP URL", shared.ErrValidation)
+	}
+	secretEnv := make([]string, 0, len(config.Credentials))
+	for _, binding := range config.Credentials {
+		secretEnv = append(secretEnv, secretEnvName(binding.Name)+"="+ports.SecretPlaceholder(binding.Reference))
+	}
+	egressPolicy, err := sessionEgressPolicy(ctx, base)
+	if err != nil {
+		return ports.DASTOutcome{}, err
+	}
+	outcome, runErr := s.engine.Run(ctx, ports.DASTPlan{
+		Target: action.Target.Value, Session: config, Requests: requests,
+		RatePerSec: ratePerSec, Concurrency: concurrency,
+		EngagementID: action.EngagementID, EgressPolicy: egressPolicy,
+	}, secretEnv, func(ctx context.Context, request ports.DASTRequest) error {
+		target, err := requestTarget(base, request.URL)
+		if err != nil {
+			return err
+		}
+		_, err = s.guard.Authorize(ctx, execution.Request{
+			Actor: admitted.DecidedBy(), EngagementID: action.EngagementID, Action: ActionAuthenticatedDAST,
+			Target: target, Metadata: map[string]string{"method": strings.ToUpper(request.Method), "session": action.SessionID.String()},
+		})
+		return err
+	})
+	payload, err := json.Marshal(outcome)
+	if err != nil {
+		return ports.DASTOutcome{}, fmt.Errorf("marshal DAST evidence: %w", err)
+	}
+	if _, err := s.evidence.Seal(ctx, action.EngagementID, evidenceKindSession, payload, admitted.DecidedBy()); err != nil {
+		return ports.DASTOutcome{}, fmt.Errorf("seal DAST evidence: %w", err)
+	}
+	if runErr != nil {
+		return outcome, fmt.Errorf("run authenticated DAST: %w", runErr)
+	}
+	return outcome, nil
+}
+
+func sessionEgressPolicy(ctx context.Context, base *url.URL) (*ports.EgressPolicy, error) {
+	port := 80
+	if base.Scheme == "https" {
+		port = 443
+	}
+	if base.Port() != "" {
+		parsed, err := strconv.Atoi(base.Port())
+		if err != nil || parsed < 1 || parsed > 65535 {
+			return nil, fmt.Errorf("%w: invalid DAST target port", shared.ErrValidation)
+		}
+		port = parsed
+	}
+	var addrs []netip.Addr
+	if ip := net.ParseIP(base.Hostname()); ip != nil {
+		addr, ok := netip.AddrFromSlice(ip)
+		if !ok {
+			return nil, fmt.Errorf("%w: invalid DAST target address", shared.ErrValidation)
+		}
+		addrs = []netip.Addr{addr.Unmap()}
+	} else {
+		resolved, err := net.DefaultResolver.LookupNetIP(ctx, "ip", base.Hostname())
+		if err != nil || len(resolved) == 0 {
+			return nil, fmt.Errorf("%w: DAST target could not be resolved safely", shared.ErrValidation)
+		}
+		addrs = resolved
+	}
+	policy := &ports.EgressPolicy{Rules: make([]ports.EgressRule, 0, len(addrs)), PinnedHosts: map[string][]netip.Addr{base.Hostname(): {}}}
+	seen := map[netip.Addr]bool{}
+	for _, addr := range addrs {
+		addr = addr.Unmap()
+		if forbiddenAddress(addr) {
+			return nil, fmt.Errorf("%w: DAST target resolves to a forbidden address", shared.ErrValidation)
+		}
+		if seen[addr] {
+			continue
+		}
+		seen[addr] = true
+		policy.Rules = append(policy.Rules, ports.EgressRule{Allow: true, Net: netip.PrefixFrom(addr, addr.BitLen()), Ports: []uint16{uint16(port)}})
+		policy.PinnedHosts[base.Hostname()] = append(policy.PinnedHosts[base.Hostname()], addr)
+	}
+	return policy, nil
+}
+
+func forbiddenAddress(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return !addr.IsValid() || addr.IsUnspecified() || addr.IsLoopback() || addr.IsPrivate() ||
+		addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsMulticast()
+}
+
+func requestTarget(base *url.URL, raw string) (engagement.Target, error) {
+	u, err := url.Parse(raw)
+	if err != nil || u.User != nil || !strings.EqualFold(base.Scheme, u.Scheme) || !strings.EqualFold(base.Host, u.Host) {
+		return engagement.Target{}, fmt.Errorf("%w: DAST request leaves admitted target origin", shared.ErrForbidden)
+	}
+	return engagement.Target{Kind: engagement.TargetURL, Value: u.String()}, nil
+}
+
+func secretEnvName(name string) string {
+	return "SYNAPSE_DAST_SECRET_" + strings.ToUpper(strings.NewReplacer("-", "_", ".", "_").Replace(name))
+}
+
+// Crawl submits each discovered GET/HEAD request through Execute, retaining its
+// per-request authorization and sandbox helper boundary.
+func (s *Service) Crawl(ctx context.Context, admitted safety.AdmittedAction, config dastsession.Config, input dastcrawl.Input, limits dastcrawl.Limits) (dastcrawl.Result, error) {
+	return dastcrawl.Result{}, fmt.Errorf("%w: DAST crawl requires an approval-bound helper and configuration digest", shared.ErrValidation)
+}
+
+func (s *Service) CrawlWithRate(ctx context.Context, admitted safety.AdmittedAction, helperBin, configDigest string, config dastsession.Config, input dastcrawl.Input, limits dastcrawl.Limits, ratePerSec, concurrency int) (dastcrawl.Result, error) {
+	action := admitted.Action()
+	if action.Tool != ToolAuthenticatedDAST || action.Action != ActionAuthenticatedDAST || action.Target.Kind != engagement.TargetURL {
+		return dastcrawl.Result{}, fmt.Errorf("%w: admitted action is not an authenticated DAST scan", shared.ErrValidation)
+	}
+	if admitted.DecidedBy() == "" || admitted.DecidedBy() == "auto" {
+		return dastcrawl.Result{}, fmt.Errorf("%w: authenticated DAST requires explicit human approval", shared.ErrForbidden)
+	}
+	if err := config.Validate(); err != nil {
+		return dastcrawl.Result{}, err
+	}
+	base, err := url.Parse(action.Target.Value)
+	if err != nil || base.User != nil || base.Scheme == "" || base.Host == "" {
+		return dastcrawl.Result{}, fmt.Errorf("%w: DAST action target must be an absolute HTTP URL", shared.ErrValidation)
+	}
+	secretEnv := make([]string, 0, len(config.Credentials))
+	for _, binding := range config.Credentials {
+		secretEnv = append(secretEnv, secretEnvName(binding.Name)+"="+ports.SecretPlaceholder(binding.Reference))
+	}
+	egressPolicy, err := sessionEgressPolicy(ctx, base)
+	if err != nil {
+		return dastcrawl.Result{}, err
+	}
+	outcome, runErr := s.engine.Run(ctx, ports.DASTPlan{
+		HelperBin: helperBin, ConfigDigest: configDigest,
+		Target: action.Target.Value, Session: config,
+		Crawl: &ports.DASTCrawlPlan{
+			Target: input.Target, Seeds: input.Seeds, Robots: input.Robots, Sitemaps: input.Sitemaps,
+			OpenAPI: input.OpenAPI, GraphQL: input.GraphQL, Depth: limits.Depth, Pages: limits.Pages,
+			Requests: limits.Requests, WallClock: limits.WallClock,
+		},
+		RatePerSec: ratePerSec, Concurrency: concurrency,
+		EngagementID: action.EngagementID, EgressPolicy: egressPolicy,
+	}, secretEnv, func(ctx context.Context, request ports.DASTRequest) error {
+		target, err := requestTarget(base, request.URL)
+		if err != nil {
+			return err
+		}
+		_, err = s.guard.Authorize(ctx, execution.Request{
+			Actor: admitted.DecidedBy(), EngagementID: action.EngagementID, Action: ActionAuthenticatedDAST,
+			Target: target, Metadata: map[string]string{"method": strings.ToUpper(request.Method), "session": action.SessionID.String()},
+		})
+		return err
+	})
+	payload, err := json.Marshal(outcome)
+	if err != nil {
+		return dastcrawl.Result{}, fmt.Errorf("marshal DAST evidence: %w", err)
+	}
+	if _, err := s.evidence.Seal(ctx, action.EngagementID, evidenceKindSession, payload, admitted.DecidedBy()); err != nil {
+		return dastcrawl.Result{}, fmt.Errorf("seal DAST evidence: %w", err)
+	}
+	if runErr != nil {
+		return dastcrawl.Result{}, fmt.Errorf("run authenticated DAST crawl: %w", runErr)
+	}
+	return dastcrawl.Result{Surface: outcome.Surface, Coverage: outcome.Coverage, Observations: outcome.Observations, Incomplete: outcome.Incomplete, Reason: outcome.Reason}, nil
+}

--- a/internal/usecase/dastsession/service_test.go
+++ b/internal/usecase/dastsession/service_test.go
@@ -1,0 +1,170 @@
+package dastsession
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
+)
+
+type testClock struct{ now time.Time }
+
+func (c *testClock) Now() time.Time { return c.now }
+
+type testAudit struct{ entries []ports.AuditEntry }
+
+func (a *testAudit) Record(_ context.Context, entry ports.AuditEntry) error {
+	a.entries = append(a.entries, entry)
+	return nil
+}
+
+type testIDs struct{ next int }
+
+func (i *testIDs) NewID() shared.ID {
+	i.next++
+	return shared.ID("evidence-" + string(rune('0'+i.next)))
+}
+
+type authorizingEngine struct {
+	requests []ports.DASTRequest
+	before   func(int)
+}
+
+func (e *authorizingEngine) Run(ctx context.Context, _ ports.DASTPlan, _ []string, authorize func(context.Context, ports.DASTRequest) error) (ports.DASTOutcome, error) {
+	for i, request := range e.requests {
+		if e.before != nil {
+			e.before(i)
+		}
+		if err := authorize(ctx, request); err != nil {
+			return ports.DASTOutcome{}, err
+		}
+	}
+	return ports.DASTOutcome{}, nil
+}
+
+func sessionFixture(t *testing.T, engine ports.DASTEngine) (*Service, safety.AdmittedAction, *testClock, *testAudit) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Unix(1_700_100_000, 0).UTC()
+	clock := &testClock{now: now}
+	audit := &testAudit{}
+	eng, err := engagement.New("eng-1", "", "Acme", "Acme", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng.Status = engagement.StatusActive
+	from, to := now.Add(-time.Hour), now.Add(time.Hour)
+	if err := eng.SetAuthorizationWindow(&from, &to, "UTC", now); err != nil {
+		t.Fatal(err)
+	}
+	eng.Scope = engagement.Scope{InScope: []engagement.Target{{Kind: engagement.TargetURL, Value: "https://203.0.113.10/"}}}
+	repo := memory.NewEngagementRepository()
+	if err := repo.Create(ctx, eng); err != nil {
+		t.Fatal(err)
+	}
+	guard, err := execution.NewGuard(repo, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := memory.NewApprovalStore()
+	approvals, err := approval.NewService(store, audit, clock, agent.ModeManual, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev, err := evidence.NewService(memory.NewEvidenceStore(), nil, audit, clock, &testIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gate, err := safety.NewGate(guard, approvals, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	action := agent.ProposedAction{
+		ID: "action-1", SessionID: "session-1", EngagementID: "eng-1",
+		Tool: ToolAuthenticatedDAST, Action: ActionAuthenticatedDAST,
+		Target: engagement.Target{Kind: engagement.TargetURL, Value: "https://203.0.113.10/"}, Risk: agent.RiskIntrusive,
+	}
+	if _, err := gate.Admit(ctx, action, "alice"); !errors.Is(err, safety.ErrPendingApproval) {
+		t.Fatalf("initial admission err=%v", err)
+	}
+	if _, err := approvals.Decide(ctx, "bob", action.ID, true, "approved test scan"); err != nil {
+		t.Fatal(err)
+	}
+	admitted, err := gate.Admit(ctx, action, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService(engine, guard, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return service, admitted, clock, audit
+}
+
+func validSession() domain.Config {
+	return domain.Config{
+		Scheme:       domain.SchemeBearer,
+		Credentials:  []domain.CredentialBinding{{Name: "token", Reference: "vault-token"}},
+		LoginRequest: domain.Request{Method: "GET", Path: "/login"},
+		CheckRequest: domain.Request{Method: "GET", Path: "/live"},
+		Success:      domain.SuccessSignal{StatusCode: 200},
+	}
+}
+
+func TestExecuteAuthorizesEveryRequest(t *testing.T) {
+	engine := &authorizingEngine{requests: []ports.DASTRequest{
+		{Method: "GET", URL: "https://203.0.113.10/login"},
+		{Method: "GET", URL: "https://203.0.113.10/live"},
+		{Method: "GET", URL: "https://203.0.113.10/one"},
+	}}
+	service, admitted, _, audit := sessionFixture(t, engine)
+	if _, err := service.Execute(context.Background(), admitted, validSession(), []dastsurface.Request{{Method: "GET", URL: "https://203.0.113.10/one"}}); err != nil {
+		t.Fatal(err)
+	}
+	authorized := 0
+	for _, entry := range audit.entries {
+		if entry.Metadata["method"] != "" {
+			authorized++
+		}
+	}
+	if authorized != len(engine.requests) {
+		t.Fatalf("per-request authorizations=%d want=%d audit=%+v", authorized, len(engine.requests), audit.entries)
+	}
+}
+
+func TestExecuteRejectsOriginAndWindowChanges(t *testing.T) {
+	for name, configure := range map[string]func(*authorizingEngine, *testClock){
+		"origin": func(engine *authorizingEngine, _ *testClock) {
+			engine.requests = []ports.DASTRequest{{Method: "GET", URL: "https://outside.example/"}}
+		},
+		"window": func(engine *authorizingEngine, clock *testClock) {
+			engine.requests = []ports.DASTRequest{{Method: "GET", URL: "https://203.0.113.10/one"}, {Method: "GET", URL: "https://203.0.113.10/two"}}
+			engine.before = func(i int) {
+				if i == 1 {
+					clock.now = clock.now.Add(2 * time.Hour)
+				}
+			}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			engine := &authorizingEngine{}
+			service, admitted, clock, _ := sessionFixture(t, engine)
+			configure(engine, clock)
+			if _, err := service.Execute(context.Background(), admitted, validSession(), nil); !errors.Is(err, shared.ErrForbidden) {
+				t.Fatalf("Execute err=%v", err)
+			}
+		})
+	}
+}

--- a/internal/usecase/dastsession/service_test.go
+++ b/internal/usecase/dastsession/service_test.go
@@ -3,6 +3,8 @@ package dastsession
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,12 +39,31 @@ func (i *testIDs) NewID() shared.ID {
 	return shared.ID("evidence-" + string(rune('0'+i.next)))
 }
 
+const (
+	// The helper name the engine is configured with, and a 64-hex digest standing in for the hash of an
+	// approved configuration (dastworkflow/scan.go derives the real one and binds it into the approval).
+	testHelperBin    = "synapse-dast-helper"
+	testConfigDigest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+)
+
 type authorizingEngine struct {
 	requests []ports.DASTRequest
 	before   func(int)
 }
 
-func (e *authorizingEngine) Run(ctx context.Context, _ ports.DASTPlan, _ []string, authorize func(context.Context, ports.DASTRequest) error) (ports.DASTOutcome, error) {
+// Run mirrors the REAL engine's plan validation before doing anything else. A fake that accepts any
+// plan cannot disagree with dastengine.Engine about what a valid plan is -- which is exactly how a
+// service building a plan with no ConfigDigest passed its tests while being unable to execute.
+func (e *authorizingEngine) Run(ctx context.Context, plan ports.DASTPlan, _ []string, authorize func(context.Context, ports.DASTRequest) error) (ports.DASTOutcome, error) {
+	if err := plan.Session.Validate(); err != nil {
+		return ports.DASTOutcome{}, err
+	}
+	if strings.TrimSpace(plan.Target) == "" {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: DAST target is required", shared.ErrValidation)
+	}
+	if len(plan.ConfigDigest) != 64 {
+		return ports.DASTOutcome{}, fmt.Errorf("%w: approved DAST configuration digest is required", shared.ErrValidation)
+	}
 	for i, request := range e.requests {
 		if e.before != nil {
 			e.before(i)
@@ -130,7 +151,7 @@ func TestExecuteAuthorizesEveryRequest(t *testing.T) {
 		{Method: "GET", URL: "https://203.0.113.10/one"},
 	}}
 	service, admitted, _, audit := sessionFixture(t, engine)
-	if _, err := service.Execute(context.Background(), admitted, validSession(), []dastsurface.Request{{Method: "GET", URL: "https://203.0.113.10/one"}}); err != nil {
+	if _, err := service.ExecuteWithBinding(context.Background(), admitted, testHelperBin, testConfigDigest, validSession(), []dastsurface.Request{{Method: "GET", URL: "https://203.0.113.10/one"}}); err != nil {
 		t.Fatal(err)
 	}
 	authorized := 0
@@ -162,7 +183,7 @@ func TestExecuteRejectsOriginAndWindowChanges(t *testing.T) {
 			engine := &authorizingEngine{}
 			service, admitted, clock, _ := sessionFixture(t, engine)
 			configure(engine, clock)
-			if _, err := service.Execute(context.Background(), admitted, validSession(), nil); !errors.Is(err, shared.ErrForbidden) {
+			if _, err := service.ExecuteWithBinding(context.Background(), admitted, testHelperBin, testConfigDigest, validSession(), nil); !errors.Is(err, shared.ErrForbidden) {
 				t.Fatalf("Execute err=%v", err)
 			}
 		})

--- a/internal/usecase/dastworkflow/scan.go
+++ b/internal/usecase/dastworkflow/scan.go
@@ -1,0 +1,278 @@
+package dastworkflow
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/verdict"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastcrawl"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastverifier"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
+)
+
+const (
+	ToolAuthenticatedScan   = "run_authenticated_dast"
+	ActionAuthenticatedScan = "dast.authenticated_scan"
+	evidenceKindScanProofs  = "dast_scan_proofs"
+	evidenceKindScanProof   = "dast_scan_proof"
+	scanProposerIdentity    = "system:dast-engine"
+	scanVerifierIdentity    = "system:dast-verifier"
+)
+
+type scanSession interface {
+	CrawlWithRate(context.Context, safety.AdmittedAction, string, string, dastsession.Config, dastcrawl.Input, dastcrawl.Limits, int, int) (dastcrawl.Result, error)
+}
+
+type scanJudgmentProposer interface {
+	Propose(context.Context, string, shared.ID, judgment.Capability, judgment.SubjectKind, shared.ID, judgment.Claim) (judgment.Judgment, error)
+}
+
+type scanProofVerifier interface {
+	Apply(context.Context, shared.ID, dastverifier.Result) (judgment.Judgment, error)
+}
+
+type ScanCeilings struct {
+	MaxReauth   int
+	RatePerSec  int
+	Concurrency int
+	Limits      dastcrawl.Limits
+}
+
+func DefaultScanCeilings() ScanCeilings {
+	return ScanCeilings{MaxReauth: dastsession.DefaultMaxReauth, RatePerSec: ports.DefaultDASTRatePerSec, Concurrency: ports.DefaultDASTConcurrency,
+		Limits: dastcrawl.Limits{Depth: dastcrawl.DefaultDepth, Pages: dastcrawl.DefaultPages, Requests: dastcrawl.DefaultRequests, WallClock: dastcrawl.DefaultWallClock}}
+}
+
+// ScanConfig is the complete secret-free DAST run input. Credential references are
+// names in the engagement vault; plaintext values and secret placeholders are invalid.
+type ScanConfig struct {
+	Target           string             `json:"target"`
+	Session          dastsession.Config `json:"session"`
+	Crawler          dastcrawl.Input    `json:"crawler"`
+	Limits           dastcrawl.Limits   `json:"limits"`
+	RatePerSec       int                `json:"rate_per_sec"`
+	Concurrency      int                `json:"concurrency"`
+	SelectedCheckIDs []string           `json:"selected_check_ids,omitempty"`
+}
+
+type ScanResult struct {
+	Digest     string               `json:"config_sha256"`
+	Surface    dastsurface.Surface  `json:"surface"`
+	Coverage   dastsurface.Coverage `json:"coverage"`
+	Incomplete bool                 `json:"incomplete"`
+	Reason     string               `json:"reason,omitempty"`
+	Proofs     []ports.DASTProof    `json:"proofs"`
+}
+
+func (c ScanConfig) canonical(ceilings ScanCeilings) ([]byte, error) {
+	if strings.TrimSpace(c.Target) == "" || c.Target != c.Crawler.Target {
+		return nil, fmt.Errorf("%w: DAST target must match crawler target", shared.ErrValidation)
+	}
+	if err := validateDASTURL(c.Target); err != nil {
+		return nil, err
+	}
+	if strings.Contains(strings.ToLower(string(mustJSON(c))), "{{secret:") {
+		return nil, fmt.Errorf("%w: DAST configuration cannot contain secret placeholders", shared.ErrValidation)
+	}
+	if c.Session.MaxReauth == 0 {
+		c.Session.MaxReauth = ceilings.MaxReauth
+	}
+	if c.RatePerSec == 0 {
+		c.RatePerSec = ceilings.RatePerSec
+	}
+	if c.Concurrency == 0 {
+		c.Concurrency = ceilings.Concurrency
+	}
+	if c.Limits.Depth == 0 {
+		c.Limits.Depth = ceilings.Limits.Depth
+	}
+	if c.Limits.Pages == 0 {
+		c.Limits.Pages = ceilings.Limits.Pages
+	}
+	if c.Limits.Requests == 0 {
+		c.Limits.Requests = ceilings.Limits.Requests
+	}
+	if c.Limits.WallClock == 0 {
+		c.Limits.WallClock = ceilings.Limits.WallClock
+	}
+	if c.Session.MaxReauth < 0 || c.Session.MaxReauth > ceilings.MaxReauth || c.RatePerSec < 1 || c.RatePerSec > ceilings.RatePerSec || c.Concurrency < 1 || c.Concurrency > ceilings.Concurrency || c.Limits.Depth < 1 || c.Limits.Depth > ceilings.Limits.Depth || c.Limits.Pages < 1 || c.Limits.Pages > ceilings.Limits.Pages || c.Limits.Requests < 1 || c.Limits.Requests > ceilings.Limits.Requests || c.Limits.WallClock < 1 || c.Limits.WallClock > ceilings.Limits.WallClock {
+		return nil, fmt.Errorf("%w: DAST scan configuration exceeds configured ceilings", shared.ErrValidation)
+	}
+	if err := c.Session.Validate(); err != nil {
+		return nil, err
+	}
+	for _, binding := range c.Session.Credentials {
+		if strings.Contains(binding.Reference, "{{") || strings.ContainsAny(binding.Reference, "\r\n") {
+			return nil, fmt.Errorf("%w: invalid vault credential reference", shared.ErrValidation)
+		}
+	}
+	seen := map[string]struct{}{}
+	for _, id := range c.SelectedCheckIDs {
+		if _, exists := seen[id]; exists {
+			return nil, fmt.Errorf("%w: duplicate DAST check %q", shared.ErrValidation, id)
+		}
+		seen[id] = struct{}{}
+	}
+	sort.Strings(c.SelectedCheckIDs)
+	return json.Marshal(c)
+}
+
+func mustJSON(v any) []byte { b, _ := json.Marshal(v); return b }
+
+func (s *Service) SetScan(session scanSession, helperBin string, ev *evidence.Service, evaluator ports.DASTCheckEvaluator, proofVerifier ports.DASTProofVerifier, judgments scanJudgmentProposer, verifier scanProofVerifier, ceilings ScanCeilings) error {
+	if session == nil || strings.TrimSpace(helperBin) == "" || ev == nil || evaluator == nil || proofVerifier == nil || judgments == nil || verifier == nil || ceilings.MaxReauth < 0 || ceilings.RatePerSec < 1 || ceilings.Concurrency < 1 || ceilings.Limits.Depth < 1 || ceilings.Limits.Pages < 1 || ceilings.Limits.Requests < 1 || ceilings.Limits.WallClock < 1 {
+		return fmt.Errorf("%w: DAST scan configuration is invalid", shared.ErrValidation)
+	}
+	s.session, s.helperBin, s.evaluator, s.proofVerifier, s.judgments, s.verifier, s.ceilings = session, helperBin, evaluator, proofVerifier, judgments, verifier, ceilings
+	return nil
+}
+
+func (s *Service) normalizeScanConfig(config ScanConfig) ScanConfig {
+	if config.Session.MaxReauth == 0 {
+		config.Session.MaxReauth = s.ceilings.MaxReauth
+	}
+	if config.RatePerSec == 0 {
+		config.RatePerSec = s.ceilings.RatePerSec
+	}
+	if config.Concurrency == 0 {
+		config.Concurrency = s.ceilings.Concurrency
+	}
+	if config.Limits.Depth == 0 {
+		config.Limits.Depth = s.ceilings.Limits.Depth
+	}
+	if config.Limits.Pages == 0 {
+		config.Limits.Pages = s.ceilings.Limits.Pages
+	}
+	if config.Limits.Requests == 0 {
+		config.Limits.Requests = s.ceilings.Limits.Requests
+	}
+	if config.Limits.WallClock == 0 {
+		config.Limits.WallClock = s.ceilings.Limits.WallClock
+	}
+	return config
+}
+
+func (s *Service) ProposeScan(ctx context.Context, actor string, engagementID shared.ID, config ScanConfig) (Proposal, error) {
+	if s.session == nil || s.evaluator == nil {
+		return Proposal{}, fmt.Errorf("%w: DAST scan workflow is unavailable", shared.ErrNotFound)
+	}
+	config = s.normalizeScanConfig(config)
+	canonical, err := config.canonical(s.ceilings)
+	if err != nil {
+		return Proposal{}, err
+	}
+	digest := sha256.Sum256(canonical)
+	encoded := hex.EncodeToString(digest[:])
+	p := agent.ProposedAction{ID: s.ids.NewID(), SessionID: shared.ID("dast-scan:" + encoded), EngagementID: engagementID,
+		Tool: ToolAuthenticatedScan, Action: ActionAuthenticatedScan, Target: engagement.Target{Kind: engagement.TargetURL, Value: config.Target},
+		Argv: []string{s.helperBin, "run", "--config-sha256=" + encoded}, Risk: agent.RiskIntrusive, Rationale: "authenticated DAST scan", ProposedAt: s.clock.Now()}
+	_, err = s.gate.Admit(ctx, p, actor)
+	if err != nil && !errors.Is(err, safety.ErrPendingApproval) {
+		return Proposal{}, err
+	}
+	_, dec, err := s.store.Get(ctx, p.ID)
+	if err != nil {
+		return Proposal{}, err
+	}
+	return Proposal{Action: p, Decision: dec}, nil
+}
+
+func (s *Service) RunScan(ctx context.Context, actor string, engagementID, actionID shared.ID, config ScanConfig) (ScanResult, error) {
+	if s.session == nil {
+		return ScanResult{}, fmt.Errorf("%w: DAST scan workflow is unavailable", shared.ErrNotFound)
+	}
+	config = s.normalizeScanConfig(config)
+	canonical, err := config.canonical(s.ceilings)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	digest := sha256.Sum256(canonical)
+	encoded := hex.EncodeToString(digest[:])
+	p, _, err := s.store.Get(ctx, actionID)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	if p.EngagementID != engagementID || p.Tool != ToolAuthenticatedScan || p.Action != ActionAuthenticatedScan || len(p.Argv) != 3 || p.Argv[0] != s.helperBin || p.Argv[1] != "run" || subtle.ConstantTimeCompare([]byte(p.Argv[2]), []byte("--config-sha256="+encoded)) != 1 {
+		return ScanResult{}, fmt.Errorf("%w: DAST approval does not bind this scan configuration", shared.ErrValidation)
+	}
+	admitted, err := s.gate.Admit(ctx, p, actor)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	if err := s.consume(ctx, engagementID, actionID, actor); err != nil {
+		return ScanResult{}, err
+	}
+	result, err := s.session.CrawlWithRate(ctx, admitted, p.Argv[0], encoded, config.Session, config.Crawler, config.Limits, config.RatePerSec, config.Concurrency)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	if result.Incomplete {
+		return ScanResult{Digest: encoded, Surface: result.Surface, Coverage: result.Coverage, Incomplete: true, Reason: result.Reason}, nil
+	}
+	findings, err := s.evaluator.Evaluate(result.Observations, config.SelectedCheckIDs)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	proofs := make([]ports.DASTProof, 0, len(findings))
+	for _, finding := range findings {
+		proofPayload, err := json.Marshal(finding.Proof)
+		if err != nil {
+			return ScanResult{}, fmt.Errorf("marshal DAST proof: %w", err)
+		}
+		proofEvidence, err := s.evidence.Seal(ctx, engagementID, evidenceKindScanProof, proofPayload, scanProposerIdentity)
+		if err != nil {
+			return ScanResult{}, fmt.Errorf("seal DAST proof: %w", err)
+		}
+		sealedProof, err := s.evidence.Get(ctx, engagementID, proofEvidence.ID)
+		if err != nil {
+			return ScanResult{}, fmt.Errorf("load sealed DAST proof: %w", err)
+		}
+		var verifierProof ports.DASTProof
+		if err := json.Unmarshal(sealedProof.Content, &verifierProof); err != nil {
+			return ScanResult{}, fmt.Errorf("decode sealed DAST proof: %w", err)
+		}
+		if err := s.proofVerifier.VerifyProof(verifierProof); err != nil {
+			return ScanResult{}, fmt.Errorf("verify DAST proof: %w", err)
+		}
+		claim := judgment.DASTClaim{
+			CWE: finding.CWE, Location: finding.Endpoint, Rule: finding.CheckID,
+			Source: "first_party", Fingerprint: "sha256_" + finding.Proof.Hash, ProofEvidenceID: proofEvidence.ID.String(),
+		}
+		proposed, err := s.judgments.Propose(ctx, scanProposerIdentity, engagementID, judgment.CapDAST, judgment.SubjectEngagement, engagementID, claim)
+		if err != nil {
+			return ScanResult{}, fmt.Errorf("propose DAST judgment: %w", err)
+		}
+		if _, err := s.verifier.Apply(ctx, engagementID, dastverifier.Result{
+			JudgmentID: proposed.ID, Verifier: scanVerifierIdentity, Score: verdict.EvidenceThreshold,
+			ProofClass: dastverifier.ProofClassRuntimeConfirmed,
+			Rationale:  "closed first-party proof re-evaluated from sealed evidence " + proofEvidence.ID.String(), ExpectedVersion: proposed.Version,
+		}); err != nil {
+			return ScanResult{}, fmt.Errorf("apply DAST verifier judgment: %w", err)
+		}
+		proofs = append(proofs, finding.Proof)
+	}
+	payload, err := json.Marshal(proofs)
+	if err != nil {
+		return ScanResult{}, fmt.Errorf("marshal DAST proofs: %w", err)
+	}
+	if _, err := s.evidence.Seal(ctx, engagementID, evidenceKindScanProofs, payload, admitted.DecidedBy()); err != nil {
+		return ScanResult{}, fmt.Errorf("seal DAST proofs: %w", err)
+	}
+	return ScanResult{Digest: encoded, Surface: result.Surface, Coverage: result.Coverage, Proofs: proofs}, nil
+}

--- a/internal/usecase/dastworkflow/scan_test.go
+++ b/internal/usecase/dastworkflow/scan_test.go
@@ -1,0 +1,224 @@
+package dastworkflow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastcrawl"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
+)
+
+func validScanConfig() ScanConfig {
+	return ScanConfig{Target: "https://203.0.113.10", Crawler: dastcrawl.Input{Target: "https://203.0.113.10"}, Session: dastsession.Config{Scheme: dastsession.SchemeBearer, Credentials: []dastsession.CredentialBinding{{Name: "token", Reference: "token"}}, LoginRequest: dastsession.Request{Method: "GET", Path: "/"}, CheckRequest: dastsession.Request{Method: "GET", Path: "/"}, Success: dastsession.SuccessSignal{StatusCode: 200}}}
+}
+
+func TestScanConfigCanonicalizesDefaultsAndRejectsSecrets(t *testing.T) {
+	canonical, err := validScanConfig().canonical(DefaultScanCeilings())
+	if err != nil || len(canonical) == 0 {
+		t.Fatalf("canonical=%q err=%v", canonical, err)
+	}
+	bad := validScanConfig()
+	bad.Session.Credentials[0].Reference = "{{secret:token}}"
+	if _, err := bad.canonical(DefaultScanCeilings()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("secret placeholder err=%v", err)
+	}
+	for name, mutate := range map[string]func(*ScanConfig){
+		"reauth":      func(c *ScanConfig) { c.Session.MaxReauth = DefaultScanCeilings().MaxReauth + 1 },
+		"rate":        func(c *ScanConfig) { c.RatePerSec = DefaultScanCeilings().RatePerSec + 1 },
+		"concurrency": func(c *ScanConfig) { c.Concurrency = DefaultScanCeilings().Concurrency + 1 },
+		"depth":       func(c *ScanConfig) { c.Limits.Depth = DefaultScanCeilings().Limits.Depth + 1 },
+		"pages":       func(c *ScanConfig) { c.Limits.Pages = DefaultScanCeilings().Limits.Pages + 1 },
+		"requests":    func(c *ScanConfig) { c.Limits.Requests = DefaultScanCeilings().Limits.Requests + 1 },
+		"wall clock":  func(c *ScanConfig) { c.Limits.WallClock = DefaultScanCeilings().Limits.WallClock + time.Second },
+	} {
+		t.Run(name, func(t *testing.T) {
+			bad := validScanConfig()
+			mutate(&bad)
+			if _, err := bad.canonical(DefaultScanCeilings()); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("canonical err=%v", err)
+			}
+		})
+	}
+}
+
+func TestRunScanRequiresMatchingDigest(t *testing.T) {
+	wf, _ := workflowForTest(t, &fakeRunner{}, &fakeApplier{})
+	if err := wf.SetScan(nil, "", nil, nil, nil, nil, nil, DefaultScanCeilings()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("SetScan err=%v", err)
+	}
+	if _, err := wf.RunScan(context.Background(), "alice", "eng-1", "missing", validScanConfig()); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("RunScan err=%v", err)
+	}
+}
+
+func TestRunScanPromotesOnlyAfterDistinctProofVerification(t *testing.T) {
+	wf, store := workflowForTest(t, &fakeRunner{}, &fakeApplier{})
+	config := validScanConfig()
+	config.Crawler.Seeds = []dastsurface.Request{{Method: "GET", URL: config.Target + "/"}}
+	proof := ports.DASTProof{
+		CheckID: "security-headers", Version: 1, NormalizedEndpoint: config.Target + "/",
+		Observation: ports.DASTClosedObservation{Method: "GET", Status: 200, BodySHA256: strings.Repeat("a", 64), Signature: "missing:strict-transport-security"},
+		Hash:        strings.Repeat("b", 64),
+	}
+	session := &fakeScanSession{result: dastcrawl.Result{Observations: []ports.DASTObservation{{Method: "GET", URL: config.Target + "/", Status: 200}}}}
+	evaluator := &fakeScanEvaluator{findings: []ports.DASTFinding{{CheckID: proof.CheckID, CWE: "CWE-693", Version: 1, Endpoint: proof.NormalizedEndpoint, Proof: proof}}}
+	judgments := &fakeScanJudgments{}
+	verifier := &fakeScanVerifier{}
+	if err := wf.SetScan(session, "synapse-dast-helper", wf.evidence, evaluator, evaluator, judgments, verifier, DefaultScanCeilings()); err != nil {
+		t.Fatal(err)
+	}
+	proposal, err := wf.ProposeScan(context.Background(), "alice", "eng-1", config)
+	if err != nil && !errors.Is(err, safety.ErrPendingApproval) {
+		t.Fatalf("propose: %v", err)
+	}
+	if err := store.Decide(context.Background(), agent.ApprovalDecision{ActionID: proposal.Action.ID, State: agent.ApprovalApproved, DecidedBy: "bob", DecidedAt: time.Unix(1_700_100_000, 0)}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := wf.RunScan(context.Background(), "alice", "eng-1", proposal.Action.ID, config)
+	if err != nil {
+		t.Fatalf("RunScan: %v", err)
+	}
+	if session.calls != 1 || evaluator.calls != 1 || len(judgments.proposed) != 1 || len(verifier.results) != 1 || len(result.Proofs) != 1 {
+		t.Fatalf("session=%d proof_checks=%d judgments=%d verdicts=%d proofs=%d", session.calls, evaluator.calls, len(judgments.proposed), len(verifier.results), len(result.Proofs))
+	}
+	claim, ok := judgments.proposed[0].Claim.(judgment.DASTClaim)
+	if !ok || claim.ProofEvidenceID == "" || judgments.proposed[0].ProposedBy == scanVerifierIdentity || verifier.results[0].Verifier != scanVerifierIdentity {
+		t.Fatalf("distinct verifier custody failed: judgment=%+v result=%+v", judgments.proposed[0], verifier.results[0])
+	}
+}
+
+func TestRunScanRejectsProofBeforeJudgmentPromotion(t *testing.T) {
+	wf, store := workflowForTest(t, &fakeRunner{}, &fakeApplier{})
+	config := validScanConfig()
+	proof := ports.DASTProof{CheckID: "security-headers", Version: 1, NormalizedEndpoint: config.Target, Observation: ports.DASTClosedObservation{Method: "GET", Status: 200, BodySHA256: strings.Repeat("a", 64)}, Hash: "bad"}
+	session := &fakeScanSession{}
+	evaluator := &fakeScanEvaluator{findings: []ports.DASTFinding{{CheckID: proof.CheckID, CWE: "CWE-693", Endpoint: config.Target, Proof: proof}}, verify: shared.ErrValidation}
+	judgments := &fakeScanJudgments{}
+	verifier := &fakeScanVerifier{}
+	if err := wf.SetScan(session, "synapse-dast-helper", wf.evidence, evaluator, evaluator, judgments, verifier, DefaultScanCeilings()); err != nil {
+		t.Fatal(err)
+	}
+	proposal, err := wf.ProposeScan(context.Background(), "alice", "eng-1", config)
+	if err != nil && !errors.Is(err, safety.ErrPendingApproval) {
+		t.Fatalf("propose: %v", err)
+	}
+	if err := store.Decide(context.Background(), agent.ApprovalDecision{ActionID: proposal.Action.ID, State: agent.ApprovalApproved, DecidedBy: "bob", DecidedAt: time.Unix(1_700_100_000, 0)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wf.RunScan(context.Background(), "alice", "eng-1", proposal.Action.ID, config); err == nil {
+		t.Fatal("invalid proof was accepted")
+	}
+	if len(judgments.proposed) != 0 || len(verifier.results) != 0 {
+		t.Fatalf("invalid proof reached promotion: judgments=%d verdicts=%d", len(judgments.proposed), len(verifier.results))
+	}
+}
+
+func TestRunScanDoesNotPromoteIncompleteObservations(t *testing.T) {
+	wf, store := workflowForTest(t, &fakeRunner{}, &fakeApplier{})
+	config := validScanConfig()
+	proof := ports.DASTProof{CheckID: "security-headers", Version: 1, NormalizedEndpoint: config.Target, Observation: ports.DASTClosedObservation{Method: "GET", Status: 200, BodySHA256: strings.Repeat("a", 64), Signature: "missing:strict-transport-security"}, Hash: strings.Repeat("b", 64)}
+	session := &fakeScanSession{result: dastcrawl.Result{Incomplete: true, Reason: "session_lost", Observations: []ports.DASTObservation{{Method: "GET", URL: config.Target, Status: 200}}}}
+	evaluator := &fakeScanEvaluator{findings: []ports.DASTFinding{{CheckID: proof.CheckID, CWE: "CWE-693", Endpoint: config.Target, Proof: proof}}}
+	judgments := &fakeScanJudgments{}
+	verifier := &fakeScanVerifier{}
+	if err := wf.SetScan(session, "synapse-dast-helper", wf.evidence, evaluator, evaluator, judgments, verifier, DefaultScanCeilings()); err != nil {
+		t.Fatal(err)
+	}
+	proposal, err := wf.ProposeScan(context.Background(), "alice", "eng-1", config)
+	if err != nil && !errors.Is(err, safety.ErrPendingApproval) {
+		t.Fatal(err)
+	}
+	if proposal.Action.Argv[1] != "run" {
+		t.Fatalf("approved argv=%v", proposal.Action.Argv)
+	}
+	if err := store.Decide(context.Background(), agent.ApprovalDecision{ActionID: proposal.Action.ID, State: agent.ApprovalApproved, DecidedBy: "bob", DecidedAt: time.Unix(1_700_100_000, 0)}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := wf.RunScan(context.Background(), "alice", "eng-1", proposal.Action.ID, config)
+	if err != nil || !result.Incomplete || result.Reason != "session_lost" || evaluator.calls != 0 || len(judgments.proposed) != 0 || len(verifier.results) != 0 {
+		t.Fatalf("result=%+v evaluator=%d judgments=%d verifier=%d err=%v", result, evaluator.calls, len(judgments.proposed), len(verifier.results), err)
+	}
+}
+
+func TestRunScanDoesNotPromoteCleanObservations(t *testing.T) {
+	wf, store := workflowForTest(t, &fakeRunner{}, &fakeApplier{})
+	config := validScanConfig()
+	session := &fakeScanSession{result: dastcrawl.Result{Observations: []ports.DASTObservation{{
+		Method: "GET", URL: config.Target + "/", Status: 200, BodySHA256: strings.Repeat("a", 64),
+		Headers: []string{"Strict-Transport-Security: max-age=1", "Set-Cookie: Secure; HttpOnly; SameSite=Lax"},
+	}}}}
+	evaluator := &fakeScanEvaluator{}
+	judgments := &fakeScanJudgments{}
+	verifier := &fakeScanVerifier{}
+	if err := wf.SetScan(session, "synapse-dast-helper", wf.evidence, evaluator, evaluator, judgments, verifier, DefaultScanCeilings()); err != nil {
+		t.Fatal(err)
+	}
+	proposal, err := wf.ProposeScan(context.Background(), "alice", "eng-1", config)
+	if err != nil && !errors.Is(err, safety.ErrPendingApproval) {
+		t.Fatalf("propose: %v", err)
+	}
+	if err := store.Decide(context.Background(), agent.ApprovalDecision{ActionID: proposal.Action.ID, State: agent.ApprovalApproved, DecidedBy: "bob", DecidedAt: time.Unix(1_700_100_000, 0)}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := wf.RunScan(context.Background(), "alice", "eng-1", proposal.Action.ID, config)
+	if err != nil || len(result.Proofs) != 0 || len(judgments.proposed) != 0 || len(verifier.results) != 0 {
+		t.Fatalf("result=%+v judgments=%d verdicts=%d err=%v", result, len(judgments.proposed), len(verifier.results), err)
+	}
+}
+
+func TestRunScanSealsApprovalConsumption(t *testing.T) {
+	wf, store := workflowForTest(t, &fakeRunner{}, &fakeApplier{})
+	config := validScanConfig()
+	evaluator := &fakeScanEvaluator{}
+	if err := wf.SetScan(&fakeScanSession{}, "synapse-dast-helper", wf.evidence, evaluator, evaluator, &fakeScanJudgments{}, &fakeScanVerifier{}, DefaultScanCeilings()); err != nil {
+		t.Fatal(err)
+	}
+	proposal, err := wf.ProposeScan(context.Background(), "alice", "eng-1", config)
+	if err != nil && !errors.Is(err, safety.ErrPendingApproval) {
+		t.Fatal(err)
+	}
+	if err := store.Decide(context.Background(), agent.ApprovalDecision{ActionID: proposal.Action.ID, State: agent.ApprovalApproved, DecidedBy: "bob", DecidedAt: time.Unix(1_700_100_000, 0)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wf.RunScan(context.Background(), "alice", "eng-1", proposal.Action.ID, config); err != nil {
+		t.Fatal(err)
+	}
+	items, err := wf.evidence.List(context.Background(), "eng-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, item := range items {
+		if item.Kind == "agent_approval_consumed" && item.CreatedBy == "alice" && strings.Contains(string(item.Content), proposal.Action.ID.String()) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("approval consumption evidence missing: %+v", items)
+	}
+	if _, err := wf.RunScan(context.Background(), "alice", "eng-1", proposal.Action.ID, config); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("second run err=%v", err)
+	}
+	items, err = wf.evidence.List(context.Background(), "eng-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	records := 0
+	for _, item := range items {
+		if item.Kind == "agent_approval_consumed" && strings.Contains(string(item.Content), proposal.Action.ID.String()) {
+			records++
+		}
+	}
+	if records != 1 {
+		t.Fatalf("consumption records=%d want=1", records)
+	}
+}

--- a/internal/usecase/dastworkflow/service.go
+++ b/internal/usecase/dastworkflow/service.go
@@ -8,8 +8,12 @@ package dastworkflow
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
@@ -17,24 +21,33 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
 )
 
 type Service struct {
-	gate      *safety.Gate
-	approvals *approval.Service
-	store     ports.ApprovalStore
-	runner    *dastrunner.Service
-	clock     ports.Clock
-	ids       ports.IDGenerator
+	gate          *safety.Gate
+	approvals     *approval.Service
+	store         ports.ApprovalStore
+	runner        *dastrunner.Service
+	clock         ports.Clock
+	ids           ports.IDGenerator
+	session       scanSession
+	helperBin     string
+	evidence      *evidence.Service
+	ceilings      ScanCeilings
+	evaluator     ports.DASTCheckEvaluator
+	proofVerifier ports.DASTProofVerifier
+	judgments     scanJudgmentProposer
+	verifier      scanProofVerifier
 }
 
-func NewService(gate *safety.Gate, approvals *approval.Service, store ports.ApprovalStore, runner *dastrunner.Service, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
-	if gate == nil || approvals == nil || store == nil || runner == nil || clock == nil || ids == nil {
-		return nil, fmt.Errorf("%w: dast workflow requires gate, approvals, store, runner, clock, and ids", shared.ErrValidation)
+func NewService(gate *safety.Gate, approvals *approval.Service, store ports.ApprovalStore, runner *dastrunner.Service, ev *evidence.Service, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if gate == nil || approvals == nil || store == nil || runner == nil || ev == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: dast workflow requires gate, approvals, store, runner, evidence, clock, and ids", shared.ErrValidation)
 	}
-	return &Service{gate: gate, approvals: approvals, store: store, runner: runner, clock: clock, ids: ids}, nil
+	return &Service{gate: gate, approvals: approvals, store: store, runner: runner, evidence: ev, clock: clock, ids: ids}, nil
 }
 
 type Proposal struct {
@@ -53,14 +66,18 @@ func (s *Service) Propose(ctx context.Context, actor string, engagementID shared
 	if method == "" {
 		method = "GET"
 	}
+	probe.URL = strings.TrimSpace(probe.URL)
+	if err := validateDASTURL(probe.URL); err != nil {
+		return Proposal{}, err
+	}
 	p := agent.ProposedAction{
 		ID:           s.ids.NewID(),
 		SessionID:    shared.ID("dast:" + probe.JudgmentID.String()),
 		EngagementID: engagementID,
 		Tool:         dastrunner.ToolRunDASTVerifier,
 		Action:       dastrunner.ActionSafeHTTPProbe,
-		Target:       engagement.Target{Kind: engagement.TargetURL, Value: strings.TrimSpace(probe.URL)},
-		Argv:         []string{"curl", "-X", method, strings.TrimSpace(probe.URL)},
+		Target:       engagement.Target{Kind: engagement.TargetURL, Value: probe.URL},
+		Argv:         []string{"synapse-dast-probe", "--config-sha256=" + probeDigest(probe, method)},
 		Risk:         agent.RiskIntrusive,
 		Rationale:    strings.TrimSpace(probe.Rationale),
 		ProposedAt:   s.clock.Now(),
@@ -78,13 +95,12 @@ func (s *Service) Propose(ctx context.Context, actor string, engagementID shared
 	}
 	return Proposal{Action: p, Decision: dec}, nil
 }
-
 func (s *Service) Decide(ctx context.Context, human string, engagementID, actionID shared.ID, approve bool, reason string) (agent.ApprovalDecision, error) {
 	p, _, err := s.store.Get(ctx, actionID)
 	if err != nil {
 		return agent.ApprovalDecision{}, err
 	}
-	if p.EngagementID != engagementID || p.Tool != dastrunner.ToolRunDASTVerifier || p.Action != dastrunner.ActionSafeHTTPProbe {
+	if p.EngagementID != engagementID || !isDASTAction(p) {
 		return agent.ApprovalDecision{}, fmt.Errorf("%w: DAST approval not found for this engagement", shared.ErrNotFound)
 	}
 	return s.approvals.Decide(ctx, human, actionID, approve, reason)
@@ -98,12 +114,69 @@ func (s *Service) Run(ctx context.Context, actor string, engagementID, actionID 
 	if p.EngagementID != engagementID || p.Tool != dastrunner.ToolRunDASTVerifier || p.Action != dastrunner.ActionSafeHTTPProbe {
 		return dastrunner.Result{}, fmt.Errorf("%w: DAST approval not found for this engagement", shared.ErrNotFound)
 	}
-	if probe.URL != p.Target.Value {
-		return dastrunner.Result{}, fmt.Errorf("%w: probe URL must match the approved DAST action target", shared.ErrValidation)
+	method := strings.ToUpper(strings.TrimSpace(probe.Method))
+	if method == "" {
+		method = "GET"
+	}
+	if err := validateDASTURL(probe.URL); err != nil {
+		return dastrunner.Result{}, err
+	}
+	if len(p.Argv) != 2 || p.Argv[0] != "synapse-dast-probe" || subtle.ConstantTimeCompare([]byte(p.Argv[1]), []byte("--config-sha256="+probeDigest(probe, method))) != 1 {
+		return dastrunner.Result{}, fmt.Errorf("%w: DAST approval does not bind this probe configuration", shared.ErrValidation)
 	}
 	adm, err := s.gate.Admit(ctx, p, actor)
 	if err != nil {
 		return dastrunner.Result{}, err
 	}
+	if err := s.consume(ctx, engagementID, actionID, actor); err != nil {
+		return dastrunner.Result{}, err
+	}
 	return s.runner.Execute(ctx, adm, probe)
+}
+
+func (s *Service) consume(ctx context.Context, engagementID, actionID shared.ID, actor string) error {
+	if err := s.store.Consume(ctx, actionID); err != nil {
+		if errors.Is(err, shared.ErrConflict) {
+			return fmt.Errorf("%w: DAST approval was already consumed", shared.ErrForbidden)
+		}
+		return err
+	}
+	payload := fmt.Appendf(nil, `{"action_id":%q,"actor":%q}`, actionID.String(), actor)
+	if _, err := s.evidence.Seal(ctx, engagementID, "agent_approval_consumed", payload, actor); err != nil {
+		return fmt.Errorf("seal DAST approval consumption: %w", err)
+	}
+	return nil
+}
+
+func isDASTAction(p agent.ProposedAction) bool {
+	return (p.Tool == dastrunner.ToolRunDASTVerifier && p.Action == dastrunner.ActionSafeHTTPProbe) || (p.Tool == ToolAuthenticatedScan && p.Action == ActionAuthenticatedScan)
+}
+
+func probeDigest(probe dastrunner.Probe, method string) string {
+	payload := strings.Join([]string{probe.JudgmentID.String(), probe.URL, method, fmt.Sprint(probe.ExpectedStatus), probe.ExpectedBodyContains, fmt.Sprint(probe.ScoreIfConfirmed), fmt.Sprint(probe.ScoreIfRefuted), fmt.Sprint(probe.ExpectedVersion), probe.Rationale}, "\n")
+	digest := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(digest[:])
+}
+
+func validateDASTURL(raw string) error {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u == nil || u.User != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("%w: invalid DAST target URL", shared.ErrValidation)
+	}
+	for key := range u.Query() {
+		if sensitiveDASTQueryKey(key) {
+			return fmt.Errorf("%w: DAST target URL cannot contain credential-like query keys", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func sensitiveDASTQueryKey(key string) bool {
+	key = strings.ToLower(key)
+	for _, sensitive := range []string{"token", "session", "api_key", "key", "secret", "password", "auth", "signature", "sig"} {
+		if strings.Contains(key, sensitive) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/usecase/dastworkflow/service_test.go
+++ b/internal/usecase/dastworkflow/service_test.go
@@ -3,15 +3,18 @@ package dastworkflow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastcrawl"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastverifier"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
@@ -49,6 +52,53 @@ type fakeApplier struct {
 	calls []dastverifier.Result
 }
 
+type fakeScanSession struct {
+	result dastcrawl.Result
+	err    error
+	calls  int
+}
+
+func (f *fakeScanSession) CrawlWithRate(context.Context, safety.AdmittedAction, string, string, dastsession.Config, dastcrawl.Input, dastcrawl.Limits, int, int) (dastcrawl.Result, error) {
+	f.calls++
+	return f.result, f.err
+}
+
+type fakeScanEvaluator struct {
+	findings []ports.DASTFinding
+	verify   error
+	calls    int
+}
+
+func (f *fakeScanEvaluator) Evaluate([]ports.DASTObservation, []string) ([]ports.DASTFinding, error) {
+	return f.findings, nil
+}
+
+func (f *fakeScanEvaluator) VerifyProof(ports.DASTProof) error {
+	f.calls++
+	return f.verify
+}
+
+type fakeScanJudgments struct {
+	proposed []judgment.Judgment
+}
+
+func (f *fakeScanJudgments) Propose(_ context.Context, proposer string, engagementID shared.ID, capability judgment.Capability, subjectKind judgment.SubjectKind, subjectID shared.ID, claim judgment.Claim) (judgment.Judgment, error) {
+	j, err := judgment.New(shared.ID(fmt.Sprintf("judgment-%d", len(f.proposed)+1)), engagementID, capability, subjectKind, subjectID, claim, proposer, time.Unix(1, 0))
+	if err == nil {
+		f.proposed = append(f.proposed, j)
+	}
+	return j, err
+}
+
+type fakeScanVerifier struct {
+	results []dastverifier.Result
+}
+
+func (f *fakeScanVerifier) Apply(_ context.Context, _ shared.ID, result dastverifier.Result) (judgment.Judgment, error) {
+	f.results = append(f.results, result)
+	return judgment.Judgment{ID: result.JudgmentID, State: judgment.StateConfirmed}, nil
+}
+
 func (a *fakeApplier) Apply(_ context.Context, engagementID shared.ID, r dastverifier.Result) (judgment.Judgment, error) {
 	a.calls = append(a.calls, r)
 	return judgment.Judgment{ID: r.JudgmentID, EngagementID: engagementID, Capability: judgment.CapSAST, State: judgment.StateConfirmed, EvidenceScore: r.Score}, nil
@@ -61,7 +111,7 @@ func workflowForTest(t *testing.T, runner *fakeRunner, applier *fakeApplier) (*S
 	eng.Status = engagement.StatusActive
 	from, to := now.Add(-time.Hour), now.Add(time.Hour)
 	_ = eng.SetAuthorizationWindow(&from, &to, "UTC", now)
-	eng.Scope = engagement.Scope{InScope: []engagement.Target{{Kind: engagement.TargetURL, Value: "https://203.0.113.10/search?q=synapse-canary"}}}
+	eng.Scope = engagement.Scope{InScope: []engagement.Target{{Kind: engagement.TargetURL, Value: "https://203.0.113.10/"}}}
 	repo := memory.NewEngagementRepository()
 	if err := repo.Create(context.Background(), eng); err != nil {
 		t.Fatal(err)
@@ -90,10 +140,11 @@ func workflowForTest(t *testing.T, runner *fakeRunner, applier *fakeApplier) (*S
 	if err != nil {
 		t.Fatal(err)
 	}
-	wf, err := NewService(gate, approvals, approvalStore, dr, clock, ids)
+	wf, err := NewService(gate, approvals, approvalStore, dr, ev, clock, ids)
 	if err != nil {
 		t.Fatal(err)
 	}
+	wf.evidence = ev
 	return wf, approvalStore
 }
 
@@ -166,5 +217,35 @@ func TestRunRejectsMismatchedProbeURL(t *testing.T) {
 	p.URL = "https://203.0.113.11/search?q=synapse-canary"
 	if _, err := wf.Run(context.Background(), "alice", "eng-1", prop.Action.ID, p); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("mismatched run URL must be ErrValidation, got %v", err)
+	}
+}
+
+func TestProposeRejectsSensitiveQuery(t *testing.T) {
+	wf, _ := workflowForTest(t, &fakeRunner{}, &fakeApplier{})
+	probe := testProbe()
+	probe.URL = "https://203.0.113.10/search?api_key=secret"
+	if _, err := wf.Propose(context.Background(), "alice", "eng-1", probe); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("sensitive query accepted: %v", err)
+	}
+}
+
+func TestRunBindsFullProbeAndConsumesApproval(t *testing.T) {
+	runner := &fakeRunner{out: []byte("synapse-canary\nSYNAPSE_HTTP_STATUS:200\n")}
+	wf, _ := workflowForTest(t, runner, &fakeApplier{})
+	probe := testProbe()
+	prop, _ := wf.Propose(context.Background(), "alice", "eng-1", probe)
+	if _, err := wf.Decide(context.Background(), "bob", "eng-1", prop.Action.ID, true, "ok"); err != nil {
+		t.Fatal(err)
+	}
+	changed := probe
+	changed.ExpectedStatus = 201
+	if _, err := wf.Run(context.Background(), "alice", "eng-1", prop.Action.ID, changed); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("changed probe accepted: %v", err)
+	}
+	if _, err := wf.Run(context.Background(), "alice", "eng-1", prop.Action.ID, probe); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wf.Run(context.Background(), "alice", "eng-1", prop.Action.ID, probe); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("repeated approval ran: %v", err)
 	}
 }

--- a/internal/usecase/evidence/service.go
+++ b/internal/usecase/evidence/service.go
@@ -315,6 +315,20 @@ func (s *Service) List(ctx context.Context, engagementID shared.ID) ([]evdom.Evi
 	return s.store.ListByEngagement(ctx, engagementID)
 }
 
+// Get returns one evidence item only when it belongs to engagementID.
+func (s *Service) Get(ctx context.Context, engagementID, evidenceID shared.ID) (evdom.Evidence, error) {
+	items, err := s.store.ListByEngagement(ctx, engagementID)
+	if err != nil {
+		return evdom.Evidence{}, fmt.Errorf("list evidence: %w", err)
+	}
+	for _, item := range items {
+		if item.ID == evidenceID {
+			return item, nil
+		}
+	}
+	return evdom.Evidence{}, fmt.Errorf("evidence %s: %w", evidenceID, shared.ErrNotFound)
+}
+
 var _ ports.ReportEvidenceProvider = (*Service)(nil)
 
 // ListArtifacts returns the captured binary artifacts in the engagement's chain

--- a/internal/usecase/findings/dast_recorder_test.go
+++ b/internal/usecase/findings/dast_recorder_test.go
@@ -43,6 +43,21 @@ func TestRecordConfirmedDAST(t *testing.T) {
 	}
 }
 
+func TestRecordConfirmedNativeDAST(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := newSvc(repo, &fakeComments{}, &fakeAudit{})
+	j := judgment.Judgment{
+		ID: "j-native", EngagementID: "eng-1", Capability: judgment.CapDAST,
+		Claim: judgment.DASTClaim{CWE: "CWE-79", Location: "/search", Rule: "reflected-xss", Source: "first_party", Fingerprint: "search_reflection", ProofEvidenceID: "proof-1"},
+	}
+	if err := svc.RecordConfirmedDAST(context.Background(), "human:bob", j); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if got := repo.upserted[0].DedupKey; got != "dast:first_party:search_reflection" {
+		t.Fatalf("DedupKey = %q", got)
+	}
+}
+
 func TestRecordConfirmedDASTRejectsWrongInput(t *testing.T) {
 	svc := newSvc(&fakeRepo{}, &fakeComments{}, &fakeAudit{})
 	// not a sast capability

--- a/internal/usecase/findings/service.go
+++ b/internal/usecase/findings/service.go
@@ -101,37 +101,35 @@ func (s *Service) RecordConfirmedSAST(ctx context.Context, verifier string, j ju
 		map[string]string{"judgment": j.ID.String(), "cwe": sc.CWE, "rule": sc.Rule, "location": sc.Location})
 }
 
-// RecordConfirmedDAST promotes a RUNTIME-verifier-confirmed CapSAST judgment to a persisted Kind=dast
-// finding (auto-emit on runtime confirm). It is the runtime twin of RecordConfirmedSAST — the same
-// verifier-confirmed CapSAST judgment, but the confirming verdict came from a safe runtime probe rather
-// than a static/LLM verifier, so it projects to a distinct, dynamically-proven Kind=dast finding.
-// Idempotent via the dast:ai:<judgmentID> dedup key – a re-confirm updates in place. The finding is built
-// DETERMINISTICALLY from the typed SASTClaim (no LLM); severity starts Unknown so a human triages it
-// through the normal finding workflow. Audited.
+// RecordConfirmedDAST promotes a confirmed CapDAST judgment to a persisted
+// Kind=dast finding. Runtime CapSAST confirmations remain supported for the
+// existing safe-probe path and retain their judgment-anchored dedup key.
 func (s *Service) RecordConfirmedDAST(ctx context.Context, verifier string, j judgment.Judgment) error {
-	if j.Capability != judgment.CapSAST {
-		return fmt.Errorf("%w: not a sast judgment (%s)", shared.ErrValidation, j.Capability)
+	in := finding.DASTInput{JudgmentID: j.ID.String()}
+	switch claim := j.Claim.(type) {
+	case judgment.DASTClaim:
+		if j.Capability != judgment.CapDAST {
+			return fmt.Errorf("%w: DAST claim has capability %s", shared.ErrValidation, j.Capability)
+		}
+		in.CWE, in.Location, in.Rule = claim.CWE, claim.Location, claim.Rule
+		in.Source, in.Fingerprint = claim.Source, claim.Fingerprint
+	case judgment.SASTClaim:
+		if j.Capability != judgment.CapSAST {
+			return fmt.Errorf("%w: SAST claim has capability %s", shared.ErrValidation, j.Capability)
+		}
+		in.CWE, in.Location, in.Rule = claim.CWE, claim.Location, claim.Rule
+	default:
+		return fmt.Errorf("%w: DAST judgment %s carries no supported DAST claim", shared.ErrValidation, j.ID)
 	}
-	sc, ok := j.Claim.(judgment.SASTClaim)
-	if !ok {
-		return fmt.Errorf("%w: sast judgment %s carries no SASTClaim", shared.ErrValidation, j.ID)
-	}
-	f, err := finding.NewDAST(s.ids.NewID(), j.EngagementID, finding.DASTInput{
-		JudgmentID: j.ID.String(),
-		CWE:        sc.CWE,
-		Location:   sc.Location,
-		Rule:       sc.Rule,
-	}, s.clock.Now())
+	f, err := finding.NewDAST(s.ids.NewID(), j.EngagementID, in, s.clock.Now())
 	if err != nil {
 		return err
 	}
 	if err := s.repo.Upsert(ctx, []finding.Finding{f}); err != nil {
 		return fmt.Errorf("persist dast finding: %w", err)
 	}
-	// Attribute the promotion to the VERIFIER whose runtime probe confirmed the judgment (the trigger), not
-	// the system proposer – the judgment's own verdict audit already records the proposer.
 	return s.record(ctx, verifier, "finding.dast_promoted", j.EngagementID, f.ID,
-		map[string]string{"judgment": j.ID.String(), "cwe": sc.CWE, "rule": sc.Rule, "location": sc.Location})
+		map[string]string{"judgment": j.ID.String(), "cwe": in.CWE, "rule": in.Rule, "location": in.Location})
 }
 
 // ApplyWriteupDraft applies an accepted, human-signed-off write-up draft to its finding: it sets the

--- a/internal/usecase/ports/agent.go
+++ b/internal/usecase/ports/agent.go
@@ -35,6 +35,9 @@ type ApprovalStore interface {
 	// Get returns the proposed action and its current decision (state ApprovalPending until decided).
 	Get(ctx context.Context, actionID shared.ID) (agent.ProposedAction, agent.ApprovalDecision, error)
 	Decide(ctx context.Context, d agent.ApprovalDecision) error
+	// Consume atomically marks an approved action as used. The first caller wins;
+	// later callers receive shared.ErrConflict.
+	Consume(ctx context.Context, actionID shared.ID) error
 	// EngagementsWithPending lists the engagements that have at least one pending approval –
 	// so the prod timeout sweeper can fan out across them without a global scan.
 	EngagementsWithPending(ctx context.Context) ([]shared.ID, error)

--- a/internal/usecase/ports/dast.go
+++ b/internal/usecase/ports/dast.go
@@ -1,0 +1,124 @@
+// Package ports defines application boundaries.
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsession"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastsurface"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// DASTRequest is the request a helper must obtain approval for before network I/O.
+// URL is canonical and never contains credentials.
+type DASTRequest struct {
+	Method string `json:"method"`
+	URL    string `json:"url"`
+}
+
+// DASTAuthorization is the parent-to-helper decision for one request.
+type DASTAuthorization struct {
+	Allowed bool `json:"allowed"`
+}
+
+// DASTPlan contains only public configuration. Credentials are named environment
+// variables whose values are substituted by the sandbox credential vault.
+// DASTCrawlPlan is the secret-free, bounded crawl configuration executed by one helper process.
+type DASTCrawlPlan struct {
+	Target    string                `json:"target"`
+	Seeds     []dastsurface.Request `json:"seeds"`
+	Robots    string                `json:"robots,omitempty"`
+	Sitemaps  []string              `json:"sitemaps,omitempty"`
+	OpenAPI   []string              `json:"openapi,omitempty"`
+	GraphQL   []string              `json:"graphql,omitempty"`
+	Depth     int                   `json:"depth"`
+	Pages     int                   `json:"pages"`
+	Requests  int                   `json:"requests"`
+	WallClock time.Duration         `json:"wall_clock"`
+}
+
+type DASTPlan struct {
+	HelperBin    string                `json:"-"`
+	ConfigDigest string                `json:"-"`
+	Target       string                `json:"target"`
+	Session      dastsession.Config    `json:"session"`
+	Requests     []dastsurface.Request `json:"requests"`
+	Crawl        *DASTCrawlPlan        `json:"crawl,omitempty"`
+	RatePerSec   int                   `json:"rate_per_sec"`
+	Concurrency  int                   `json:"concurrency"`
+	EngagementID shared.ID             `json:"-"`
+	EgressPolicy *EgressPolicy         `json:"-"`
+}
+
+// DASTObservation is bounded, secret-free proof of one completed request.
+type DASTObservation struct {
+	Method        string   `json:"method"`
+	URL           string   `json:"url"`
+	Status        int      `json:"status"`
+	BodySHA256    string   `json:"body_sha256"`
+	BodyBytes     int      `json:"body_bytes"`
+	BodyTruncated bool     `json:"body_truncated"`
+	BodyExcerpt   string   `json:"body_excerpt,omitempty"`
+	Headers       []string `json:"headers,omitempty"`
+}
+
+// DASTOutcome is emitted by the helper. Incomplete denotes a bounded authentication
+// or liveness failure; it is not a successful scan.
+type DASTOutcome struct {
+	Observations []DASTObservation    `json:"observations"`
+	Surface      dastsurface.Surface  `json:"surface"`
+	Coverage     dastsurface.Coverage `json:"coverage"`
+	Incomplete   bool                 `json:"incomplete"`
+	Reason       string               `json:"reason,omitempty"`
+}
+
+// DASTFinding is a deterministic passive-check finding, kept at the use-case boundary.
+type DASTFinding struct {
+	CheckID  string    `json:"check_id"`
+	CWE      string    `json:"cwe"`
+	Version  int       `json:"version"`
+	Endpoint string    `json:"endpoint"`
+	Proof    DASTProof `json:"proof"`
+}
+
+// DASTProof is closed, secret-free evidence for a passive DAST finding.
+type DASTProof struct {
+	CheckID            string                `json:"check_id"`
+	Version            int                   `json:"version"`
+	NormalizedEndpoint string                `json:"normalized_endpoint"`
+	Observation        DASTClosedObservation `json:"observation"`
+	Hash               string                `json:"hash"`
+}
+
+type DASTClosedObservation struct {
+	Method          string   `json:"method"`
+	Status          int      `json:"status"`
+	BodySHA256      string   `json:"body_sha256"`
+	Headers         []string `json:"headers,omitempty"`
+	Signature       string   `json:"signature,omitempty"`
+	PredicateTokens []string `json:"predicate_tokens,omitempty"`
+}
+
+// DASTCheckEvaluator evaluates observations using an immutable check catalog.
+type DASTCheckEvaluator interface {
+	Evaluate([]DASTObservation, []string) ([]DASTFinding, error)
+}
+
+// DASTProofVerifier independently re-evaluates a closed first-party proof.
+type DASTProofVerifier interface {
+	VerifyProof(DASTProof) error
+}
+
+// DASTEngine executes a secret-free plan in a helper process. It never performs
+// HTTP in the caller process.
+type DASTEngine interface {
+	Run(ctx context.Context, plan DASTPlan, secretEnv []string, authorize func(context.Context, DASTRequest) error) (DASTOutcome, error)
+}
+
+// DASTDefaults keep each canonical target conservative by default.
+const (
+	DefaultDASTRatePerSec  = 5
+	DefaultDASTConcurrency = 4
+	DefaultDASTTimeout     = 30 * time.Second
+)

--- a/internal/usecase/ports/egress.go
+++ b/internal/usecase/ports/egress.go
@@ -32,4 +32,5 @@ type EgressPolicy struct {
 	DenyDomains      []string // hostname-wide out-of-scope domains to resolve + deny
 	AllowDomainRules []DomainRule
 	DenyDomainRules  []DomainRule
+	PinnedHosts      map[string][]netip.Addr // prevalidated host-to-address bindings; no second DNS lookup
 }


### PR DESCRIPTION
## Summary

Adds governed authenticated DAST scanning with credential-vault sessions, bounded crawling, first-party checks, and sealed proof promotion. This combines and closes #416 and #417 while preserving server-side authorization and secret-handling invariants.

## Changes

- Add form, basic, bearer, header, and cookie session configuration backed by credential-vault references.
- Add the isolated `synapse-dast-helper`, per-request authorization pipes, pinned egress, redaction, shared session state, rate limits, and bounded reauthentication.
- Add deterministic bounded crawling with depth, page, request, and wall-clock limits plus coverage accounting.
- Add first-party DAST checks, sealed proof custody, distinct proof verification, and finding promotion.
- Add durable atomic approval consumption for memory and PostgreSQL stores.
- Wire authenticated DAST into the API, analysis pipeline, release packaging, and container image.
- Add domain, use-case, infrastructure, HTTP, persistence, and platform regression coverage.
- Make Unix permission assertions platform-aware and process-group tests container-correct.

## Checklist

- [x] `make build vet test typecheck` passes
- [x] `cd web && pnpm build` passes (dashboard unchanged; build verified)
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets
      out of logs, deterministic reports, append-only evidence) – see CONTRIBUTING.md
- [x] Documentation updated if needed (no documentation changes required)