### PR TITLE
feat(web): add security operations dashboard

### DIFF
--- a/web/src/App.rules.test.tsx
+++ b/web/src/App.rules.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import App from './App'
@@ -11,6 +11,7 @@ vi.mock('./lib/api', () => ({
     getRule: vi.fn(),
     listEngagements: vi.fn(),
     listBusinessAssets: vi.fn(),
+    fleetCoverageSummary: vi.fn(),
     listProjects: vi.fn(),
     getProject: vi.fn(),
     getAuditLogs: vi.fn(),
@@ -33,6 +34,7 @@ describe('App Routing - Rules', () => {
     vi.mocked(api.listRules).mockResolvedValue([])
     vi.mocked(api.listEngagements).mockResolvedValue([])
     vi.mocked(api.listBusinessAssets).mockResolvedValue({ items: [], total: 0, limit: 200, offset: 0 })
+    vi.mocked(api.fleetCoverageSummary).mockResolvedValue({ agentsByState: {}, rowsByVerdict: {}, oldestPerCapability: {}, assetsWithoutAgent: 0 })
     vi.mocked(api.listProjects).mockResolvedValue([])
     vi.mocked(api.getRule).mockResolvedValue({
       key: 'go:sql',
@@ -64,6 +66,16 @@ describe('App Routing - Rules', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Rules' })).toBeInTheDocument()
     })
+  })
+
+  it('renders Dashboard as the default route', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByRole('heading', { name: 'Security Operations' })).toBeInTheDocument()
   })
 
   it('renders RuleDetail page on /rules/:key route and decodes colon exactly once', async () => {
@@ -112,6 +124,16 @@ describe('App Routing - Rules', () => {
     expect(link.className).toMatch(/bg-navactive|text-white/)
   })
 
+  it('keeps Dashboard active in the command center', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Sidebar />
+      </MemoryRouter>
+    )
+    const link = screen.getByRole('link', { name: /Dashboard/i })
+    expect(link.className).toMatch(/bg-navactive|text-white/)
+  })
+
   it('supports collapsed navigation and theme switching', () => {
     render(
       <MemoryRouter initialEntries={['/assets']}>
@@ -125,6 +147,19 @@ describe('App Routing - Rules', () => {
     expect(document.documentElement.dataset.theme).toBe('dark')
     fireEvent.click(screen.getByRole('button', { name: 'Light theme' }))
     expect(document.documentElement.dataset.theme).toBe('light')
+  })
+
+  it('places New Engagement before the Engagement list', () => {
+    render(
+      <MemoryRouter initialEntries={['/assets']}>
+        <Sidebar />
+      </MemoryRouter>
+    )
+
+    const newEngagement = screen.getByRole('link', { name: 'New Engagement' })
+    const engagements = screen.getByRole('link', { name: 'Engagements' })
+    expect(newEngagement.getAttribute('href')).toBe('/engagements?create=1')
+    expect(newEngagement.compareDocumentPosition(engagements) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
   it('opens mobile navigation and navigates to Rules', async () => {
@@ -164,5 +199,19 @@ describe('App Routing - Rules', () => {
         screen.queryByRole('dialog', { name: /navigation/i }),
       ).not.toBeInTheDocument()
     })
+  })
+
+  it('switches theme from the mobile navigation', async () => {
+    render(
+      <MemoryRouter initialEntries={['/engagements']}>
+        <App />
+      </MemoryRouter>
+    )
+
+    await screen.findByRole('heading', { name: 'Engagements' })
+    fireEvent.click(screen.getByRole('button', { name: /open menu/i }))
+    const dialog = screen.getByRole('dialog', { name: /navigation/i })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Dark theme' }))
+    expect(document.documentElement.dataset.theme).toBe('dark')
   })
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,6 +26,7 @@ import { FleetCoverage } from './pages/FleetCoverage'
 import { FleetAgents } from './pages/FleetAgents'
 import { Assets } from './pages/Assets'
 import { AssetComponents, AssetCoverageView, AssetDetail, AssetEngagements, AssetFindings, AssetHistory, AssetOverview } from './pages/AssetDetail'
+import { Dashboard } from './pages/Dashboard'
 
 export default function App() {
   return (
@@ -41,7 +42,8 @@ function Gate() {
   return (
     <Routes>
       <Route element={<Shell />}>
-        <Route index element={<Navigate to="/engagements" replace />} />
+        <Route index element={<Navigate to="/dashboard" replace />} />
+        <Route path="dashboard" element={<Dashboard />} />
         <Route path="engagements" element={<Engagements />} />
         <Route path="engagements/:id" element={<EngagementDetail />} />
         <Route path="assets" element={<Assets />} />
@@ -73,7 +75,7 @@ function Gate() {
         <Route path="rules/:key" element={<RuleDetail />} />
         <Route path="audit" element={<Audit />} />
         <Route path="team" element={<Team />} />
-        <Route path="*" element={<Navigate to="/engagements" replace />} />
+        <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Route>
     </Routes>
   )

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,15 +1,18 @@
 import {
   Boxes,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   FileText,
   Gauge,
+  LayoutDashboard,
   Library,
   Moon,
   Radar,
   ScrollText,
   Server,
   Settings,
+  SquarePen,
   Sun,
   Target,
   Users,
@@ -23,27 +26,37 @@ import { cn } from './ui'
 
 const NAV_GROUPS: Array<{
   label: string
-  items: Array<{ icon: LucideIcon; label: string; to: string; prefix?: string }>
+  items: Array<{ icon: LucideIcon; label: string; to: string; prefix?: string; match?: 'new-engagement' | 'engagements'; action?: boolean }>
 }> = [
   {
-    label: 'Security operations',
+    label: 'Command center',
+    items: [{ icon: LayoutDashboard, label: 'Dashboard', to: '/dashboard' }],
+  },
+  {
+    label: 'Scope & inventory',
+    items: [{ icon: Boxes, label: 'Assets', to: '/assets', prefix: '/assets' }],
+  },
+  {
+    label: 'Assess risk',
     items: [
-      { icon: Boxes, label: 'Assets', to: '/assets', prefix: '/assets' },
-      { icon: Target, label: 'Engagements', to: '/engagements', prefix: '/engagements' },
-      { icon: ScrollText, label: 'Audit log', to: '/audit' },
+      { icon: SquarePen, label: 'New Engagement', to: '/engagements?create=1', match: 'new-engagement', action: true },
+      { icon: Target, label: 'Engagements', to: '/engagements', match: 'engagements' },
+      { icon: Library, label: 'Rules', to: '/rules', prefix: '/rules' },
     ],
   },
   {
-    label: 'Engineering',
+    label: 'Security engineering',
     items: [
       { icon: Gauge, label: 'Code Quality', to: '/code-quality', prefix: '/code-quality' },
-      { icon: Library, label: 'Rules', to: '/rules', prefix: '/rules' },
       { icon: Server, label: 'Fleet', to: '/fleet', prefix: '/fleet' },
     ],
   },
   {
-    label: 'Administration',
-    items: [{ icon: Users, label: 'Team', to: '/team' }],
+    label: 'Govern & evidence',
+    items: [
+      { icon: ScrollText, label: 'Audit log', to: '/audit' },
+      { icon: Users, label: 'Team', to: '/team' },
+    ],
   },
 ]
 
@@ -76,6 +89,7 @@ function currentTheme(): Theme {
 function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; onNavigate?: () => void }) {
   const location = useLocation()
   const [theme, setTheme] = useState<Theme>(currentTheme)
+  const creatingEngagement = location.pathname === '/engagements' && new URLSearchParams(location.search).get('create') === '1'
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme
@@ -89,10 +103,42 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
   }, [])
 
   function toggleTheme() {
-    setTheme((value) => {
-      const next = value === 'light' ? 'dark' : 'light'
-      window.dispatchEvent(new CustomEvent<Theme>('synapse-theme-change', { detail: next }))
-      return next
+    const next = theme === 'light' ? 'dark' : 'light'
+    window.dispatchEvent(new CustomEvent<Theme>('synapse-theme-change', { detail: next }))
+    setTheme(next)
+  }
+
+  function renderItems(items: (typeof NAV_GROUPS)[number]['items']) {
+    return items.map(({ icon: Icon, label, to, prefix, match, action }) => {
+      const active = match === 'new-engagement'
+        ? creatingEngagement
+        : match === 'engagements'
+          ? location.pathname.startsWith('/engagements') && !creatingEngagement
+          : prefix
+            ? location.pathname.startsWith(prefix)
+            : location.pathname === to
+      return (
+        <NavLink
+          key={to}
+          to={to}
+          title={collapsed ? label : undefined}
+          aria-label={collapsed ? label : undefined}
+          onClick={onNavigate}
+          className={cn(
+            'relative flex min-h-10 items-center rounded-lg text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/70',
+            collapsed ? 'justify-center px-2' : 'gap-3 px-3',
+            active
+              ? 'bg-navactive font-semibold text-white'
+              : action
+                ? 'border border-brand/30 bg-brand/10 font-semibold text-navfg hover:bg-brand/20'
+                : 'text-navmuted hover:bg-navhover hover:text-navfg',
+          )}
+        >
+          <Icon className={cn('size-[18px] shrink-0', action && !active && 'text-branddim')} aria-hidden="true" />
+          <span className={collapsed ? 'sr-only' : undefined}>{label}</span>
+          {active && <span className="absolute inset-y-2 left-0 w-0.5 rounded-r-full bg-brand" />}
+        </NavLink>
+      )
     })
   }
 
@@ -107,35 +153,16 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
       </div>
 
       <nav className="flex-1 overflow-y-auto px-3 py-4" aria-label="Primary navigation">
-        {NAV_GROUPS.map((group, index) => (
-          <div key={group.label} className={cn(index > 0 && 'mt-5')}>
-            <div className={cn('mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-[0.16em] text-navsubtle', collapsed && 'sr-only')}>
+        {NAV_GROUPS.map((group, index) => collapsed ? (
+          <div key={group.label} className={cn('space-y-1', index > 0 && 'mt-3')}>{renderItems(group.items)}</div>
+        ) : (
+          <details key={group.label} open className={cn('group', index > 0 && 'mt-4')}>
+            <summary className="mb-1.5 flex cursor-pointer list-none items-center justify-between rounded-md px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-navsubtle transition-colors hover:text-navmuted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/70 [&::-webkit-details-marker]:hidden">
               {group.label}
-            </div>
-            <div className="space-y-1">
-              {group.items.map(({ icon: Icon, label, to, prefix }) => {
-                const active = prefix ? location.pathname.startsWith(prefix) : location.pathname === to
-                return (
-                  <NavLink
-                    key={to}
-                    to={to}
-                    title={collapsed ? label : undefined}
-                    aria-label={collapsed ? label : undefined}
-                    onClick={onNavigate}
-                    className={cn(
-                      'relative flex min-h-10 items-center rounded-lg text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/70',
-                      collapsed ? 'justify-center px-2' : 'gap-3 px-3',
-                      active ? 'bg-navactive font-semibold text-white' : 'text-navmuted hover:bg-navhover hover:text-navfg',
-                    )}
-                  >
-                    <Icon className="size-[18px] shrink-0" aria-hidden="true" />
-                    <span className={collapsed ? 'sr-only' : undefined}>{label}</span>
-                    {active && <span className="absolute inset-y-2 left-0 w-0.5 rounded-r-full bg-brand" />}
-                  </NavLink>
-                )
-              })}
-            </div>
-          </div>
+              <ChevronDown className="size-3.5 transition-transform group-open:rotate-180" />
+            </summary>
+            <div className="space-y-1">{renderItems(group.items)}</div>
+          </details>
         ))}
 
         <div className="mt-5">

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { api } from '../lib/api'
+import type { BusinessAsset, Engagement, FleetCoverageSummary } from '../lib/types'
+import { Dashboard } from './Dashboard'
+
+vi.mock('../lib/api', () => ({
+  api: {
+    listBusinessAssets: vi.fn(),
+    listEngagements: vi.fn(),
+    fleetCoverageSummary: vi.fn(),
+  },
+}))
+
+const assets: BusinessAsset[] = [
+  {
+    id: 'asset-critical', key: 'payments', name: 'Payments Platform', description: '', type: 'system', criticality: 'critical', lifecycle: 'active', owner: 'Payments Security', metadata: {}, version: 1, createdAt: null, updatedAt: null, posture: 'critical',
+  },
+  {
+    id: 'asset-unknown', key: 'mobile', name: 'Mobile Banking', description: '', type: 'application', criticality: 'high', lifecycle: 'active', owner: 'Mobile Team', metadata: {}, version: 1, createdAt: null, updatedAt: null, posture: 'unknown',
+  },
+  {
+    id: 'asset-good', key: 'portal', name: 'Customer Portal', description: '', type: 'product', criticality: 'medium', lifecycle: 'active', owner: 'Web Team', metadata: {}, version: 1, createdAt: null, updatedAt: null, posture: 'good',
+  },
+]
+
+const engagements: Engagement[] = [
+  {
+    id: 'eng-active', name: 'Payment API Review', client: 'Internal', status: 'active', inScope: [{ kind: 'repo', value: 'payments' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, createdAt: '2026-08-01T00:00:00Z', businessAssetId: 'asset-critical',
+  },
+  {
+    id: 'eng-unassigned', name: 'New Service Review', client: 'Internal', status: 'draft', inScope: [{ kind: 'service', value: 'new-service' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, createdAt: '2026-08-02T00:00:00Z', businessAssetId: '',
+  },
+]
+
+const fleet: FleetCoverageSummary = {
+  agentsByState: { connected: 2 },
+  rowsByVerdict: { covered: 5, stale: 2, unauthorized: 1 },
+  oldestPerCapability: {},
+  assetsWithoutAgent: 1,
+}
+
+function renderDashboard() {
+  return render(<MemoryRouter><Dashboard /></MemoryRouter>)
+}
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.listBusinessAssets).mockResolvedValue({ items: assets, total: assets.length, limit: 200, offset: 0 })
+    vi.mocked(api.listEngagements).mockResolvedValue(engagements)
+    vi.mocked(api.fleetCoverageSummary).mockResolvedValue(fleet)
+  })
+
+  it('renders operational metrics and priority queues from API data', async () => {
+    renderDashboard()
+
+    expect(await screen.findByRole('heading', { name: 'Security Operations' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Total assets: 3')).toBeInTheDocument()
+    expect(screen.getByLabelText('High-risk assets: 1')).toBeInTheDocument()
+    expect(screen.getByLabelText('Active engagements: 1')).toBeInTheDocument()
+    expect(screen.getByLabelText('Coverage gaps: 3')).toBeInTheDocument()
+    expect(screen.getByLabelText('Unassigned: 1')).toBeInTheDocument()
+
+    const priorityAssets = screen.getByText('Priority Assets').closest('section')!
+    expect(within(priorityAssets).getByText('Payments Platform')).toBeInTheDocument()
+    expect(within(priorityAssets).getByText('Mobile Banking')).toBeInTheDocument()
+    expect(within(priorityAssets).queryByText('Customer Portal')).not.toBeInTheDocument()
+
+    expect(screen.getByText('Payment API Review')).toBeInTheDocument()
+    expect(screen.getByText('Payments Platform', { selector: 'p' })).toBeInTheDocument()
+    expect(screen.getByText('Unassigned Asset')).toBeInTheDocument()
+  })
+
+  it('keeps core operations visible when Fleet telemetry fails', async () => {
+    vi.mocked(api.fleetCoverageSummary).mockRejectedValue(new Error('fleet disabled'))
+    renderDashboard()
+
+    expect(await screen.findByLabelText('Total assets: 3')).toBeInTheDocument()
+    expect(screen.getByLabelText('Coverage gaps: —')).toBeInTheDocument()
+    expect(screen.getAllByText('Fleet telemetry unavailable').length).toBeGreaterThan(0)
+    expect(screen.getByText(/Coverage is not assumed clean/)).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,0 +1,322 @@
+import {
+  Activity,
+  AlertTriangle,
+  ArrowRight,
+  Boxes,
+  CheckCircle2,
+  CircleDot,
+  Gauge,
+  LayoutDashboard,
+  RadioTower,
+  ShieldAlert,
+  Target,
+  type LucideIcon,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Card, ErrorState, Spinner, cn } from '../components/ui'
+import { api } from '../lib/api'
+import type { BusinessAsset, Engagement, FleetCoverageSummary } from '../lib/types'
+import { PostureBadge } from './Assets'
+import { StatusPill } from './Engagements'
+
+type DashboardData = {
+  assets: BusinessAsset[]
+  assetTotal: number
+  engagements: Engagement[]
+}
+
+const POSTURE_ORDER = ['critical', 'high_risk', 'attention', 'unknown', 'good'] as const
+const ENGAGEMENT_ORDER = ['active', 'draft', 'completed', 'archived'] as const
+const POSTURE_WEIGHT: Record<string, number> = { critical: 5, high_risk: 4, attention: 3, unknown: 2, good: 1 }
+const CRITICALITY_WEIGHT: Record<BusinessAsset['criticality'], number> = { critical: 4, high: 3, medium: 2, low: 1 }
+
+export function Dashboard() {
+  const [data, setData] = useState<DashboardData | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [fleet, setFleet] = useState<FleetCoverageSummary | null>(null)
+  const [fleetUnavailable, setFleetUnavailable] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    setError(null)
+
+    Promise.all([loadAllAssets(), api.listEngagements()])
+      .then(([assetResult, engagements]) => {
+        if (active) setData({ ...assetResult, engagements })
+      })
+      .catch((nextError) => {
+        if (active) setError(nextError instanceof Error ? nextError.message : 'Failed to load dashboard')
+      })
+
+    api.fleetCoverageSummary()
+      .then((summary) => {
+        if (active) setFleet(summary)
+      })
+      .catch(() => {
+        if (active) setFleetUnavailable(true)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  if (error) return <div className="mx-auto max-w-[1600px]"><ErrorState message={error} /></div>
+  if (!data) return <Spinner label="Loading security operations…" />
+
+  const assetNames = Object.fromEntries(data.assets.map((asset) => [asset.id, asset.name]))
+  const highRiskAssets = data.assets.filter((asset) => ['critical', 'high_risk'].includes(asset.posture ?? 'unknown')).length
+  const activeEngagements = data.engagements.filter((engagement) => engagement.status.toLowerCase() === 'active').length
+  const unassignedEngagements = data.engagements.filter((engagement) => !engagement.businessAssetId).length
+  const coverageGaps = fleet ? Object.entries(fleet.rowsByVerdict).reduce((total, [verdict, count]) => total + (verdict === 'covered' ? 0 : count), 0) : null
+  const priorityAssets = [...data.assets]
+    .filter((asset) => (asset.posture ?? 'unknown') !== 'good' && asset.lifecycle !== 'retired')
+    .sort((left, right) => {
+      const postureDelta = (POSTURE_WEIGHT[right.posture ?? 'unknown'] ?? 0) - (POSTURE_WEIGHT[left.posture ?? 'unknown'] ?? 0)
+      return postureDelta || CRITICALITY_WEIGHT[right.criticality] - CRITICALITY_WEIGHT[left.criticality] || left.name.localeCompare(right.name)
+    })
+    .slice(0, 6)
+  const assessmentQueue = [...data.engagements]
+    .sort((left, right) => {
+      const leftStatus = ENGAGEMENT_ORDER.indexOf(left.status.toLowerCase() as (typeof ENGAGEMENT_ORDER)[number])
+      const rightStatus = ENGAGEMENT_ORDER.indexOf(right.status.toLowerCase() as (typeof ENGAGEMENT_ORDER)[number])
+      return (leftStatus < 0 ? ENGAGEMENT_ORDER.length : leftStatus) - (rightStatus < 0 ? ENGAGEMENT_ORDER.length : rightStatus)
+        || Date.parse(right.createdAt ?? '') - Date.parse(left.createdAt ?? '')
+    })
+    .slice(0, 6)
+
+  return (
+    <div className="mx-auto max-w-[1600px] animate-fade-in space-y-6">
+      <header className="bg-hero overflow-hidden rounded-2xl border border-border px-5 py-6 sm:px-7 sm:py-7">
+        <div className="flex flex-wrap items-end justify-between gap-6">
+          <div>
+            <p className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-branddim">
+              <LayoutDashboard className="size-4" aria-hidden="true" />Command center
+            </p>
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Security Operations</h1>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-mutedfg sm:text-base">
+              Monitor Asset posture, assessment activity, and coverage gaps from one operational workspace.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <QuickLink to="/engagements?create=1" label="New Engagement" icon={Target} />
+            <QuickLink to="/assets" label="Asset inventory" icon={Boxes} />
+            <QuickLink to="/code-quality" label="Code security" icon={Gauge} />
+          </div>
+        </div>
+      </header>
+
+      <section aria-label="Security operations summary" className="grid grid-cols-2 gap-3 lg:grid-cols-5">
+        <MetricCard icon={Boxes} label="Total assets" value={data.assetTotal} hint="Managed inventory" />
+        <MetricCard icon={ShieldAlert} label="High-risk assets" value={highRiskAssets} hint="Critical or high risk" tone={highRiskAssets ? 'critical' : 'accent'} />
+        <MetricCard icon={Activity} label="Active engagements" value={activeEngagements} hint={`${data.engagements.length} total assessments`} tone="brand" />
+        <MetricCard icon={RadioTower} label="Coverage gaps" value={coverageGaps ?? '—'} hint={fleetUnavailable ? 'Fleet telemetry unavailable' : 'All non-covered states'} tone={coverageGaps ? 'high' : 'accent'} />
+        <MetricCard icon={AlertTriangle} label="Unassigned" value={unassignedEngagements} hint="Engagements without Asset" tone={unassignedEngagements ? 'medium' : 'accent'} className="col-span-2 lg:col-span-1" />
+      </section>
+
+      <section aria-labelledby="analytics-title">
+        <SectionHeading eyebrow="Telemetry" title="Operations analytics" description="Current distribution across the Asset and assessment lifecycle." id="analytics-title" />
+        <div className="grid gap-4 xl:grid-cols-3">
+          <Card title="Asset posture" actions={<LinkArrow to="/assets" label="View inventory" />} bodyClass="space-y-4">
+            <Distribution rows={POSTURE_ORDER.map((value) => ({ label: labelize(value), value: data.assets.filter((asset) => (asset.posture ?? 'unknown') === value).length, tone: postureTone(value) }))} />
+            {data.assetTotal > data.assets.length && <p className="text-xs text-subtlefg">Posture distribution reflects the first {data.assets.length} loaded Assets.</p>}
+          </Card>
+
+          <Card title="Engagement pipeline" actions={<LinkArrow to="/engagements" label="View queue" />} bodyClass="space-y-4">
+            <Distribution rows={ENGAGEMENT_ORDER.map((value) => ({ label: labelize(value), value: data.engagements.filter((engagement) => engagement.status.toLowerCase() === value).length, tone: engagementTone(value) }))} />
+          </Card>
+
+          <Card title="Fleet readiness" actions={<LinkArrow to="/fleet" label="View coverage" />} bodyClass="space-y-4">
+            {fleet ? (
+              <>
+                <Distribution rows={fleetRows(fleet)} />
+                <div className="grid grid-cols-2 gap-3 border-t border-border pt-4 text-sm">
+                  <FleetStat label="Assets without agent" value={fleet.assetsWithoutAgent} warn />
+                  <FleetStat label="Connected agents" value={fleet.agentsByState.connected ?? 0} />
+                </div>
+              </>
+            ) : fleetUnavailable ? (
+              <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed border-border px-5 text-center">
+                <RadioTower className="size-6 text-subtlefg" aria-hidden="true" />
+                <p className="mt-3 text-sm font-medium">Fleet telemetry unavailable</p>
+                <p className="mt-1 text-xs leading-5 text-mutedfg">Asset and Engagement data remain available. Coverage is not assumed clean.</p>
+              </div>
+            ) : <Spinner label="Loading Fleet telemetry…" className="min-h-44" />}
+          </Card>
+        </div>
+      </section>
+
+      <section aria-labelledby="priority-title">
+        <SectionHeading eyebrow="Escalation" title="Prioritized work" description="Assets needing review and the latest assessment queue." id="priority-title" />
+        <div className="grid gap-4 xl:grid-cols-2">
+          <Card title="Priority Assets" actions={<LinkArrow to="/assets" label="All Assets" />} bodyClass="p-0">
+            {priorityAssets.length > 0 ? (
+              <div className="divide-y divide-border">
+                {priorityAssets.map((asset) => <PriorityAsset key={asset.id} asset={asset} />)}
+              </div>
+            ) : (
+              <QueueEmpty icon={CheckCircle2} title="No priority Assets" hint={data.assets.length ? 'All loaded Assets report good posture.' : 'Create an Asset to begin posture tracking.'} />
+            )}
+          </Card>
+
+          <Card title="Assessment activity" actions={<LinkArrow to="/engagements" label="All Engagements" />} bodyClass="p-0">
+            {assessmentQueue.length > 0 ? (
+              <div className="divide-y divide-border">
+                {assessmentQueue.map((engagement) => <AssessmentRow key={engagement.id} engagement={engagement} assetName={assetNames[engagement.businessAssetId]} />)}
+              </div>
+            ) : (
+              <QueueEmpty icon={Target} title="No Engagements yet" hint="Create an Engagement to define an authorized assessment scope." />
+            )}
+          </Card>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+async function loadAllAssets(): Promise<{ assets: BusinessAsset[]; assetTotal: number }> {
+  const first = await api.listBusinessAssets('limit=200')
+  if (first.total <= first.items.length) return { assets: first.items, assetTotal: first.total }
+  const offsets = Array.from({ length: Math.ceil(first.total / 200) - 1 }, (_, index) => (index + 1) * 200)
+  const pages = await Promise.all(offsets.map((offset) => api.listBusinessAssets(`limit=200&offset=${offset}`)))
+  return { assets: [first.items, ...pages.map((page) => page.items)].flat(), assetTotal: first.total }
+}
+
+function QuickLink({ to, label, icon: Icon }: { to: string; label: string; icon: LucideIcon }) {
+  return (
+    <Link to={to} className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-borderstrong bg-card/80 px-3.5 text-sm font-semibold text-foreground shadow-sm transition hover:border-brand/40 hover:bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60">
+      <Icon className="size-4 text-branddim" aria-hidden="true" />{label}
+    </Link>
+  )
+}
+
+function MetricCard({ icon: Icon, label, value, hint, tone = 'muted', className }: { icon: LucideIcon; label: string; value: number | string; hint: string; tone?: 'muted' | 'brand' | 'critical' | 'high' | 'medium' | 'accent'; className?: string }) {
+  const iconTone = {
+    muted: 'bg-muted text-mutedfg',
+    brand: 'bg-brand/10 text-branddim',
+    critical: 'bg-critical/10 text-critical',
+    high: 'bg-high/10 text-high',
+    medium: 'bg-medium/10 text-medium',
+    accent: 'bg-accent/10 text-accent',
+  }[tone]
+  return (
+    <div aria-label={`${label}: ${value}`} className={cn('card-sheen elev rounded-xl border border-border bg-card p-4', className)}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-2xl font-bold tabular-nums sm:text-3xl">{typeof value === 'number' ? value.toLocaleString() : value}</div>
+          <div className="mt-1 text-xs font-semibold sm:text-sm">{label}</div>
+        </div>
+        <span className={cn('flex size-9 shrink-0 items-center justify-center rounded-lg', iconTone)}><Icon className="size-4" aria-hidden="true" /></span>
+      </div>
+      <p className="mt-3 truncate text-xs text-subtlefg" title={hint}>{hint}</p>
+    </div>
+  )
+}
+
+function SectionHeading({ eyebrow, title, description, id }: { eyebrow: string; title: string; description: string; id: string }) {
+  return (
+    <div className="mb-3 flex flex-wrap items-end justify-between gap-3">
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-branddim">{eyebrow}</p>
+        <h2 id={id} className="mt-1 text-xl font-bold tracking-tight">{title}</h2>
+      </div>
+      <p className="max-w-xl text-xs leading-5 text-mutedfg sm:text-sm">{description}</p>
+    </div>
+  )
+}
+
+function Distribution({ rows }: { rows: Array<{ label: string; value: number; tone: string }> }) {
+  const total = rows.reduce((sum, row) => sum + row.value, 0)
+  return (
+    <div className="space-y-3">
+      {rows.map((row) => (
+        <div key={row.label}>
+          <div className="mb-1.5 flex items-center justify-between gap-3 text-xs">
+            <span className="font-medium text-mutedfg">{row.label}</span>
+            <span className="font-mono tabular-nums text-foreground">{row.value}</span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-muted">
+            <div className={cn('bar-grow h-full min-w-0 rounded-full', row.tone)} style={{ width: `${total ? Math.max(row.value ? 3 : 0, row.value / total * 100) : 0}%` }} />
+          </div>
+        </div>
+      ))}
+      {total === 0 && <p className="text-xs text-subtlefg">No data available.</p>}
+    </div>
+  )
+}
+
+function LinkArrow({ to, label }: { to: string; label: string }) {
+  return <Link to={to} className="inline-flex items-center gap-1 text-xs font-semibold text-branddim hover:text-brand"><span className="hidden sm:inline">{label}</span><ArrowRight className="size-3.5" aria-hidden="true" /></Link>
+}
+
+function PriorityAsset({ asset }: { asset: BusinessAsset }) {
+  return (
+    <Link to={`/assets/${encodeURIComponent(asset.id)}`} className="group grid gap-3 p-4 transition-colors hover:bg-elevated sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:px-5">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="truncate font-semibold group-hover:text-branddim">{asset.name}</h3>
+          <CriticalityBadge value={asset.criticality} />
+        </div>
+        <p className="mt-1 truncate text-xs text-mutedfg">{asset.owner || 'Owner not set'} · {labelize(asset.lifecycle)}</p>
+      </div>
+      <PostureBadge rating={asset.posture ?? 'unknown'} />
+    </Link>
+  )
+}
+
+function AssessmentRow({ engagement, assetName }: { engagement: Engagement; assetName?: string }) {
+  return (
+    <Link to={`/engagements/${encodeURIComponent(engagement.id)}`} className="group grid gap-3 p-4 transition-colors hover:bg-elevated sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:px-5">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="truncate font-semibold group-hover:text-branddim">{engagement.name || 'Untitled Engagement'}</h3>
+          <StatusPill status={engagement.status} />
+        </div>
+        <p className="mt-1 truncate text-xs text-mutedfg">{assetName || (engagement.businessAssetId ? engagement.businessAssetId : 'Unassigned Asset')}</p>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-subtlefg">
+        <Target className="size-3.5" aria-hidden="true" />{engagement.inScope.length} in scope
+      </div>
+    </Link>
+  )
+}
+
+function QueueEmpty({ icon: Icon, title, hint }: { icon: LucideIcon; title: string; hint: string }) {
+  return (
+    <div className="flex min-h-52 flex-col items-center justify-center px-6 text-center">
+      <span className="flex size-10 items-center justify-center rounded-full bg-muted text-mutedfg"><Icon className="size-5" /></span>
+      <p className="mt-3 text-sm font-medium">{title}</p>
+      <p className="mt-1 max-w-sm text-xs leading-5 text-mutedfg">{hint}</p>
+    </div>
+  )
+}
+
+function CriticalityBadge({ value }: { value: BusinessAsset['criticality'] }) {
+  const tone = value === 'critical' ? 'text-critical' : value === 'high' ? 'text-high' : value === 'medium' ? 'text-medium' : 'text-low'
+  return <span className={cn('inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide', tone)}><CircleDot className="size-3" />{value}</span>
+}
+
+function FleetStat({ label, value, warn = false }: { label: string; value: number; warn?: boolean }) {
+  return <div><div className={cn('text-xl font-bold tabular-nums', warn && value > 0 && 'text-high')}>{value.toLocaleString()}</div><div className="mt-0.5 text-xs text-mutedfg">{label}</div></div>
+}
+
+function fleetRows(summary: FleetCoverageSummary) {
+  const entries = Object.entries(summary.rowsByVerdict)
+  const preferred = ['covered', 'stale', 'not_assessed', 'failed', 'unauthorized', 'unknown']
+  return entries
+    .sort(([left], [right]) => preferred.indexOf(left) - preferred.indexOf(right))
+    .map(([verdict, value]) => ({ label: labelize(verdict), value, tone: verdict === 'covered' ? 'bg-accent' : verdict === 'failed' || verdict === 'unauthorized' ? 'bg-critical' : verdict === 'stale' ? 'bg-high' : 'bg-medium' }))
+}
+
+function postureTone(value: (typeof POSTURE_ORDER)[number]) {
+  return value === 'critical' ? 'bg-critical' : value === 'high_risk' ? 'bg-high' : value === 'attention' ? 'bg-medium' : value === 'good' ? 'bg-accent' : 'bg-subtlefg'
+}
+
+function engagementTone(value: (typeof ENGAGEMENT_ORDER)[number]) {
+  return value === 'active' ? 'bg-accent' : value === 'completed' ? 'bg-brand' : value === 'archived' ? 'bg-subtlefg' : 'bg-info'
+}
+
+function labelize(value: string) {
+  return value.replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+}


### PR DESCRIPTION
## Summary
- add a Synapse-native Security Operations dashboard using the existing UI components and design tokens
- aggregate real Asset, Engagement, and optional Fleet coverage data without hardcoded production metrics
- make `/dashboard` the default route and add `Command center → Dashboard` to the grouped sidebar
- preserve `New Engagement` before the Engagement list and fix mobile theme synchronization

## Asset Management relationship
Follow-up to #474, which was merged on August 9, 2026. The original PR and remote branch were already closed/deleted, so this PR reuses the same branch name on top of the latest `main`.

## Validation
- `pnpm run typecheck`
- `pnpm test` — 288 tests passed
- `pnpm run build`
- browser QA at 1440×900 and 390×844, including navigation, dark mode, empty states, Fleet-unavailable fallback, horizontal overflow, and console errors
