### PR TITLE
feat(ai-triage): add human-review API and UI (P1.2)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1006,6 +1006,68 @@ paths:
       requestBody: {required: true, content: {application/json: {schema: {type: object, required: [asset_id], properties: {asset_id: {type: string, description: Empty string clears assignment}}}}}}
       responses: {'204': {description: Assignment updated}, '400': {$ref: '#/components/responses/BadRequest'}, '404': {$ref: '#/components/responses/NotFound'}}
 
+  /api/v1/ai-triage/reviews:
+    get:
+      tags: [ai-triage]
+      operationId: listAITriageReviews
+      summary: List the tenant's durable human-review queue
+      parameters:
+      - {name: severity, in: query, schema: {type: string, enum: [critical, high, medium, low, info, unknown]}}
+      - {name: cwe, in: query, schema: {type: string}}
+      - {name: project, in: query, schema: {type: string}}
+      - {name: state, in: query, schema: {type: string, enum: [pending, accepted, rejected]}}
+      responses:
+        '200':
+          description: Review queue
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [reviews]
+                properties:
+                  reviews: {type: array, items: {$ref: '#/components/schemas/AITriageReview'}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+
+  /api/v1/ai-triage/reviews/{rid}/claim:
+    parameters: [{$ref: '#/components/parameters/AITriageReviewId'}]
+    post:
+      tags: [ai-triage]
+      operationId: claimAITriageReview
+      summary: Assign an unowned review to the authenticated reviewer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AITriageReviewClaimRequest'}
+      responses:
+        '200': {description: Claimed review, content: {application/json: {schema: {$ref: '#/components/schemas/AITriageReview'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Version or ownership conflict, content: {application/json: {schema: {$ref: '#/components/schemas/Error'}}}}
+
+  /api/v1/ai-triage/reviews/{rid}/decision:
+    parameters: [{$ref: '#/components/parameters/AITriageReviewId'}]
+    post:
+      tags: [ai-triage]
+      operationId: decideAITriageReview
+      summary: Accept or reject an owned AI false-positive recommendation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AITriageReviewDecisionRequest'}
+      responses:
+        '200': {description: Decided review, content: {application/json: {schema: {$ref: '#/components/schemas/AITriageReview'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Version, state, or ownership conflict, content: {application/json: {schema: {$ref: '#/components/schemas/Error'}}}}
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1020,6 +1082,11 @@ components:
       schema: {type: string}
     BusinessAssetId:
       name: assetID
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    AITriageReviewId:
+      name: rid
       in: path
       required: true
       schema: {type: string, minLength: 1}
@@ -1079,6 +1146,60 @@ components:
       type: object
       properties:
         error: {type: string}
+
+    AITriageReview:
+      type: object
+      required: [id, tenant_id, engagement_id, finding_id, dedup_key, title, severity, state, verdict, driver, confidence, suspected_fp, proposer_model, prompt_version, verified, policy_version, policy_reason, shadow, would_gate_exempt, gate_exempt, review_required, evidence_ref, created_at, updated_at, version]
+      properties:
+        id: {type: string}
+        tenant_id: {type: string}
+        engagement_id: {type: string}
+        project_id: {type: string}
+        finding_id: {type: string}
+        dedup_key: {type: string}
+        title: {type: string}
+        severity: {type: string, enum: [critical, high, medium, low, info, unknown]}
+        cwe: {type: string}
+        owner: {type: string}
+        state: {type: string, enum: [pending, accepted, rejected]}
+        verdict: {type: string}
+        driver: {type: string}
+        confidence: {type: integer, minimum: 0, maximum: 100}
+        suspected_fp: {type: boolean}
+        proposer_model: {type: string}
+        verifier_model: {type: string}
+        prompt_version: {type: string}
+        verified: {type: boolean}
+        verifier_verdict: {type: string}
+        verifier_driver: {type: string}
+        verifier_confidence: {type: integer, minimum: 0, maximum: 100}
+        policy_version: {type: string}
+        policy_reason: {type: string}
+        shadow: {type: boolean}
+        would_gate_exempt: {type: boolean}
+        gate_exempt: {type: boolean}
+        review_required: {type: boolean}
+        evidence_ref: {type: string}
+        decided_by: {type: string}
+        decision_rationale: {type: string}
+        created_at: {type: string, format: date-time}
+        updated_at: {type: string, format: date-time}
+        decided_at: {type: [string, 'null'], format: date-time}
+        version: {type: integer, minimum: 1}
+    AITriageReviewClaimRequest:
+      type: object
+      required: [version]
+      additionalProperties: false
+      properties:
+        version: {type: integer, minimum: 1}
+    AITriageReviewDecisionRequest:
+      type: object
+      required: [decision, rationale, version]
+      additionalProperties: false
+      properties:
+        decision: {type: string, enum: [accept, reject]}
+        rationale: {type: string, minLength: 3, maxLength: 4000}
+        version: {type: integer, minimum: 1}
 
     BusinessAsset:
       type: object

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -97,6 +97,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/agenttools"
+	aitriagereviewuc "github.com/KKloudTarus/synapse-ce/internal/usecase/aitriagereviewuc"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
@@ -203,6 +204,7 @@ func main() {
 	var auditReader ports.AuditReader
 	var scanRepo ports.ScanRepository
 	var scanResultStore ports.ScanResultStore
+	var aiTriageReviewStore ports.AITriageReviewStore
 	var importedSBOMStore ports.ImportedSBOMStore
 	var importedFindingStore ports.ImportedFindingStore // third-party (SARIF) findings under governance
 	var scanJobStore ports.ScanJobStore
@@ -304,6 +306,7 @@ func main() {
 		userRepo = postgres.NewUserRepository(pool)
 		scanRepo = postgres.NewScanRepository(pool)
 		scanResultStore = postgres.NewScanResultStore(pool)
+		aiTriageReviewStore = postgres.NewAITriageReviewRepository(pool)
 		importedSBOMStore = postgres.NewImportedSBOMStore(pool)
 		importedFindingStore = postgres.NewImportedFindingRepository(pool)
 		scanJobStore = postgres.NewScanJobStore(pool)
@@ -365,6 +368,7 @@ func main() {
 		userRepo = memory.NewUserRepository()
 		scanRepo = memory.NewScanRepository()
 		scanResultStore = memory.NewScanResultStore()
+		aiTriageReviewStore = memory.NewAITriageReviewStore()
 		importedSBOMStore = memory.NewImportedSBOMStore()
 		importedFindingStore = memory.NewImportedFindingStore()
 		scanJobStore = memory.NewScanJobStore()
@@ -809,6 +813,12 @@ func main() {
 	aupService := aupuc.NewService(aupStore, auditLog, clock, cfg.AUPVersion)
 	exportService := exportuc.NewService(findingRepo, clock, buildinfo.App())
 	findingsService := findingsuc.NewService(findingRepo, commentRepo, retestRepo, auditLog, clock, ids)
+	aiTriageReviewService, err := aitriagereviewuc.NewService(aiTriageReviewStore, repo, findingsService, auditLog, clock, ids)
+	if err != nil {
+		log.Error("AI-triage review service init failed", "err", err)
+		os.Exit(1)
+	}
+	scaService.SetAITriageReviewRecorder(aiTriageReviewService)
 	// Exploitation needs the SCORE-MUTATING finding store (SetEvidenceScore is on the concrete
 	// repo, NOT ports.FindingRepository – read-only consumers can't move a score). Both the
 	// postgres + memory concrete repos implement it; assert it from the interface-typed var.
@@ -969,6 +979,7 @@ func main() {
 		os.Exit(1)
 	}
 	router := httpapi.NewRouter(log, auth, engService, scaService, aupService, findingsService, exportService, reportService, evidenceService, reconService, logBroker, transferService, auditService, vexService, usersService, credentialsService)
+	router.SetAITriageReviews(aiTriageReviewService)
 	projectService.SetScanner(scaService)
 	scaService.SetProjectAnalysisRecorder(projectService)
 	scaService.SetProjectAnalysisCompletionTimeout(cfg.ProjectAnalysisCompletionTimeout)

--- a/internal/adapter/httpapi/aitriage_review_handler.go
+++ b/internal/adapter/httpapi/aitriage_review_handler.go
@@ -1,0 +1,72 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func (rt *Router) listAITriageReviews(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	filter := ports.AITriageReviewFilter{
+		Severity:  shared.Severity(strings.TrimSpace(q.Get("severity"))),
+		CWE:       strings.TrimSpace(q.Get("cwe")),
+		ProjectID: shared.ID(strings.TrimSpace(q.Get("project"))),
+		State:     aitriagereview.State(strings.TrimSpace(q.Get("state"))),
+	}
+	items, err := rt.aiTriageReviews.List(r.Context(), shared.ID(TenantFrom(r.Context())), filter)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"reviews": items})
+}
+
+func (rt *Router) decideAITriageReview(w http.ResponseWriter, r *http.Request) {
+	id := shared.ID(strings.TrimSpace(r.PathValue("rid")))
+	if id.IsZero() {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "review id is required"})
+		return
+	}
+	var body struct {
+		Decision  aitriagereview.Decision `json:"decision"`
+		Rationale string                  `json:"rationale"`
+		Version   int                     `json:"version"`
+	}
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<10))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	updated, err := rt.aiTriageReviews.Decide(r.Context(), shared.ID(TenantFrom(r.Context())), id,
+		PrincipalFrom(r.Context()), body.Decision, body.Rationale, body.Version)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (rt *Router) claimAITriageReview(w http.ResponseWriter, r *http.Request) {
+	id := shared.ID(strings.TrimSpace(r.PathValue("rid")))
+	var body struct {
+		Version int `json:"version"`
+	}
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 2<<10))
+	dec.DisallowUnknownFields()
+	if id.IsZero() || dec.Decode(&body) != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "review id and valid request body are required"})
+		return
+	}
+	updated, err := rt.aiTriageReviews.Claim(r.Context(), shared.ID(TenantFrom(r.Context())), id, PrincipalFrom(r.Context()), body.Version)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, updated)
+}

--- a/internal/adapter/httpapi/aitriage_review_handler_test.go
+++ b/internal/adapter/httpapi/aitriage_review_handler_test.go
@@ -1,0 +1,73 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type aiReviewFake struct {
+	listedTenant shared.ID
+	filter       ports.AITriageReviewFilter
+	decided      bool
+	actor        string
+}
+
+func (f *aiReviewFake) List(_ context.Context, tenantID shared.ID, filter ports.AITriageReviewFilter) ([]aitriagereview.Review, error) {
+	f.listedTenant, f.filter = tenantID, filter
+	return []aitriagereview.Review{{ID: "r1", State: aitriagereview.StatePending}}, nil
+}
+
+func (f *aiReviewFake) Decide(_ context.Context, _, id shared.ID, actor string, decision aitriagereview.Decision, rationale string, version int) (aitriagereview.Review, error) {
+	f.decided, f.actor = true, actor
+	return aitriagereview.Review{ID: id, State: aitriagereview.StateAccepted, DecidedBy: actor, DecisionRationale: rationale, Version: version + 1}, nil
+}
+
+func (f *aiReviewFake) Claim(_ context.Context, _, id shared.ID, actor string, version int) (aitriagereview.Review, error) {
+	f.actor = actor
+	return aitriagereview.Review{ID: id, Owner: actor, State: aitriagereview.StatePending, Version: version + 1}, nil
+}
+
+func TestAITriageReviewListMapsTenantAndFilters(t *testing.T) {
+	fake := &aiReviewFake{}
+	rt := &Router{log: logging.New("error")}
+	rt.SetAITriageReviews(fake)
+	req := withPrincipal(httptest.NewRequest(http.MethodGet, "/api/v1/ai-triage/reviews?severity=high&cwe=CWE-89&project=p1&state=pending", nil), "reader", "readonly")
+	req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "reader", Role: "readonly", TenantID: "tenant-a"}))
+	w := httptest.NewRecorder()
+	rt.authz(userdom.PermView, rt.listAITriageReviews)(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if fake.listedTenant != "tenant-a" || fake.filter.Severity != shared.SeverityHigh || fake.filter.CWE != "CWE-89" || fake.filter.ProjectID != "p1" || fake.filter.State != aitriagereview.StatePending {
+		t.Fatalf("filters not mapped: tenant=%s filter=%+v", fake.listedTenant, fake.filter)
+	}
+}
+
+func TestAITriageDecisionRBACBlocksMachineAndAttributesHuman(t *testing.T) {
+	fake := &aiReviewFake{}
+	rt := &Router{log: logging.New("error")}
+	rt.SetAITriageReviews(fake)
+	request := func(id, role string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/ai-triage/reviews/r1/decision", strings.NewReader(`{"decision":"accept","rationale":"fixture only","version":1}`))
+		req = withPrincipal(req, id, role)
+		req.SetPathValue("rid", "r1")
+		w := httptest.NewRecorder()
+		rt.authz(userdom.PermReview, rt.decideAITriageReview)(w, req)
+		return w
+	}
+	if w := request("bot", "agent"); w.Code != http.StatusForbidden || fake.decided {
+		t.Fatalf("machine decision reached service: %d", w.Code)
+	}
+	if w := request("alice", "reviewer"); w.Code != http.StatusOK || !fake.decided || fake.actor != "alice" {
+		t.Fatalf("human decision failed: status=%d actor=%q", w.Code, fake.actor)
+	}
+}

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -217,6 +217,7 @@ func TestHostileHarness(t *testing.T) {
 	rt.SetDASTWorkflow(&fakeDASTWorkflow{})
 	rt.SetThreatModel(&fakeThreatModel{})     // register the threat-model ingest/read routes so the harness guards their gates
 	rt.SetWriteupDrafts(&fakeWriteupDrafts{}) // register the writeup-draft sign-off routes so the harness guards their SoD gates
+	rt.SetAITriageReviews(&aiReviewFake{})    // register AI-triage queue read/claim/decision routes
 	rt.SetRules(&fakeRules{})                 // register rule catalog routes so the harness guards their gates
 	rt.SetFleetCoverage(harnessCoverage{})    // register #413 fleet-coverage routes so the harness guards their view/tenant gates
 	rt.SetSARIFIngest(harnessSARIF{})         // register the #415 import route so the harness guards its operate/tenant gates
@@ -320,6 +321,9 @@ func TestHostileHarness(t *testing.T) {
 		{"machine may not edit writeup draft (review)", "agent", "tenantA", true, http.MethodPost, "/api/v1/engagements/engA/writeup-drafts/d1/edit", http.StatusForbidden},
 		{"cross-tenant writeup-draft accept → 404", "reviewer", "tenantB", true, http.MethodPost, "/api/v1/engagements/engA/writeup-drafts/d1/accept", http.StatusNotFound},
 		{"readonly may list writeup drafts (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/writeup-drafts", http.StatusOK},
+		{"readonly may list AI-triage reviews (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/ai-triage/reviews", http.StatusOK},
+		{"machine may not claim AI-triage review (review/SoD)", "agent", "tenantA", true, http.MethodPost, "/api/v1/ai-triage/reviews/r1/claim", http.StatusForbidden},
+		{"consultant may not decide AI-triage review (review)", "consultant", "tenantA", true, http.MethodPost, "/api/v1/ai-triage/reviews/r1/decision", http.StatusForbidden},
 		// Rule Catalog (PermView): no tenant context required, but machine roles denied.
 		{"machine may not list rules (view/SoD)", "agent", "tenantA", true, http.MethodGet, "/api/v1/rules", http.StatusForbidden},
 		{"machine may not get rule (view/SoD)", "agent", "tenantA", true, http.MethodGet, "/api/v1/rules/go:sql-injection", http.StatusForbidden},

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
@@ -59,6 +60,7 @@ type Router struct {
 	autoVerifier      autoVerifierService   // optional; nil ⇒ the LLM auto-verify route is not registered
 	threatModels      threatModelService    // optional; nil ⇒ threat-model routes are not registered
 	drafts            writeupDraftService   // optional; nil ⇒ writeup-draft sign-off routes are not registered
+	aiTriageReviews   aiTriageReviewService // optional; nil ⇒ AI-triage review queue routes are not registered
 	projects          projectService        // optional; nil ⇒ project routes are not registered
 	assets            assetService          // optional; nil ⇒ fleet asset routes are not registered
 	businessAssets    businessAssetService  // optional; nil ⇒ business-level Asset routes are not registered
@@ -105,6 +107,12 @@ type writeupDraftService interface {
 	Reject(ctx context.Context, principal string, engagementID, id shared.ID) (writeupdraft.Draft, error)
 }
 
+type aiTriageReviewService interface {
+	List(ctx context.Context, tenantID shared.ID, filter ports.AITriageReviewFilter) ([]aitriagereview.Review, error)
+	Claim(ctx context.Context, tenantID, id shared.ID, actor string, expectedVersion int) (aitriagereview.Review, error)
+	Decide(ctx context.Context, tenantID, id shared.ID, actor string, decision aitriagereview.Decision, rationale string, expectedVersion int) (aitriagereview.Review, error)
+}
+
 // SetJudgments wires the AI judgment lifecycle endpoints. nil ⇒ routes are not registered.
 func (rt *Router) SetJudgments(s judgmentService) { rt.judgments = s }
 
@@ -144,6 +152,9 @@ func (rt *Router) SetThreatModel(s threatModelService) { rt.threatModels = s }
 
 // SetWriteupDrafts wires the human sign-off endpoints for AI-proposed write-up drafts. nil ⇒ not registered.
 func (rt *Router) SetWriteupDrafts(s writeupDraftService) { rt.drafts = s }
+
+// SetAITriageReviews wires the tenant-scoped human review queue.
+func (rt *Router) SetAITriageReviews(s aiTriageReviewService) { rt.aiTriageReviews = s }
 
 // qualityGateService is the HTTP slice for tenant-scoped gate management.
 type qualityGateService interface {
@@ -235,6 +246,11 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/deactivate", rt.authz(userdom.PermOperate, rt.deactivateProfileRule))
 		mux.HandleFunc("POST /api/v1/quality-profiles/{key}/severity", rt.authz(userdom.PermOperate, rt.setProfileRuleSeverity))
 		mux.HandleFunc("DELETE /api/v1/quality-profiles/{key}", rt.authz(userdom.PermOperate, rt.deleteQualityProfile))
+	}
+	if rt.aiTriageReviews != nil {
+		mux.HandleFunc("GET /api/v1/ai-triage/reviews", rt.authz(userdom.PermView, rt.listAITriageReviews))
+		mux.HandleFunc("POST /api/v1/ai-triage/reviews/{rid}/claim", rt.authz(userdom.PermReview, rt.claimAITriageReview))
+		mux.HandleFunc("POST /api/v1/ai-triage/reviews/{rid}/decision", rt.authz(userdom.PermReview, rt.decideAITriageReview))
 	}
 	if rt.fleetAdmin != nil {
 		mux.HandleFunc("POST /api/v1/agents/enrolment-tokens", rt.authz(userdom.PermAdminister, rt.mintEnrolToken))

--- a/internal/domain/aitriagereview/review.go
+++ b/internal/domain/aitriagereview/review.go
@@ -1,0 +1,198 @@
+// Package aitriagereview models the human decision that follows an AI false-positive
+// critique which the deterministic gate policy refused to authorize on its own.
+package aitriagereview
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// State is the closed lifecycle for an AI-triage review.
+type State string
+
+const (
+	StatePending  State = "pending"
+	StateAccepted State = "accepted" // a human accepts the AI false-positive recommendation
+	StateRejected State = "rejected" // a human rejects it; the finding remains in the gate
+)
+
+func (s State) Valid() bool {
+	switch s {
+	case StatePending, StateAccepted, StateRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+// Decision is the explicit reviewer action.
+type Decision string
+
+const (
+	DecisionAccept Decision = "accept"
+	DecisionReject Decision = "reject"
+)
+
+func (d Decision) Valid() bool { return d == DecisionAccept || d == DecisionReject }
+
+// Review is a durable snapshot of the finding, model verdicts, policy decision,
+// and evidence link that a human reviewed. Findings remain visible independently.
+type Review struct {
+	ID                 shared.ID       `json:"id"`
+	TenantID           shared.ID       `json:"tenant_id"`
+	EngagementID       shared.ID       `json:"engagement_id"`
+	ProjectID          shared.ID       `json:"project_id,omitempty"`
+	FindingID          shared.ID       `json:"finding_id"`
+	DedupKey           string          `json:"dedup_key"`
+	Title              string          `json:"title"`
+	Severity           shared.Severity `json:"severity"`
+	CWE                string          `json:"cwe,omitempty"`
+	Owner              string          `json:"owner,omitempty"`
+	State              State           `json:"state"`
+	Verdict            string          `json:"verdict"`
+	Driver             string          `json:"driver"`
+	Confidence         int             `json:"confidence"`
+	SuspectedFP        bool            `json:"suspected_fp"`
+	ProposerModel      string          `json:"proposer_model"`
+	VerifierModel      string          `json:"verifier_model,omitempty"`
+	PromptVersion      string          `json:"prompt_version"`
+	Verified           bool            `json:"verified"`
+	VerifierVerdict    string          `json:"verifier_verdict,omitempty"`
+	VerifierDriver     string          `json:"verifier_driver,omitempty"`
+	VerifierConfidence int             `json:"verifier_confidence,omitempty"`
+	PolicyVersion      string          `json:"policy_version"`
+	PolicyReason       string          `json:"policy_reason"`
+	Shadow             bool            `json:"shadow"`
+	WouldGateExempt    bool            `json:"would_gate_exempt"`
+	GateExempt         bool            `json:"gate_exempt"`
+	ReviewRequired     bool            `json:"review_required"`
+	EvidenceRef        shared.ID       `json:"evidence_ref"`
+	DecidedBy          string          `json:"decided_by,omitempty"`
+	DecisionRationale  string          `json:"decision_rationale,omitempty"`
+	CreatedAt          time.Time       `json:"created_at"`
+	UpdatedAt          time.Time       `json:"updated_at"`
+	DecidedAt          *time.Time      `json:"decided_at,omitempty"`
+	Version            int             `json:"version"`
+}
+
+// Input contains the immutable snapshot captured when a policy-held critique is queued.
+type Input struct {
+	ID, TenantID, EngagementID, ProjectID, FindingID, EvidenceRef shared.ID
+	DedupKey, Title, CWE                                          string
+	Severity                                                      shared.Severity
+	Verdict, Driver, ProposerModel, VerifierModel, PromptVersion  string
+	Confidence                                                    int
+	SuspectedFP, Verified                                         bool
+	VerifierVerdict, VerifierDriver                               string
+	VerifierConfidence                                            int
+	PolicyVersion, PolicyReason                                   string
+	Shadow, WouldGateExempt, GateExempt, ReviewRequired           bool
+}
+
+// NewPending validates and creates one pending review snapshot.
+func NewPending(in Input, now time.Time) (Review, error) {
+	r := Review{
+		ID: in.ID, TenantID: in.TenantID, EngagementID: in.EngagementID, ProjectID: in.ProjectID,
+		FindingID: in.FindingID, DedupKey: strings.TrimSpace(in.DedupKey), Title: strings.TrimSpace(in.Title),
+		Severity: in.Severity, CWE: strings.TrimSpace(in.CWE),
+		State: StatePending, Verdict: in.Verdict, Driver: in.Driver, Confidence: in.Confidence,
+		SuspectedFP: in.SuspectedFP, ProposerModel: strings.TrimSpace(in.ProposerModel),
+		VerifierModel: strings.TrimSpace(in.VerifierModel), PromptVersion: strings.TrimSpace(in.PromptVersion), Verified: in.Verified,
+		VerifierVerdict: in.VerifierVerdict, VerifierDriver: in.VerifierDriver,
+		VerifierConfidence: in.VerifierConfidence, PolicyVersion: strings.TrimSpace(in.PolicyVersion),
+		PolicyReason: strings.TrimSpace(in.PolicyReason), Shadow: in.Shadow, WouldGateExempt: in.WouldGateExempt, GateExempt: in.GateExempt,
+		ReviewRequired: in.ReviewRequired, EvidenceRef: in.EvidenceRef,
+		CreatedAt: now, UpdatedAt: now, Version: 1,
+	}
+	if r.ID.IsZero() || r.TenantID.IsZero() || r.EngagementID.IsZero() || r.FindingID.IsZero() || r.EvidenceRef.IsZero() {
+		return Review{}, fmt.Errorf("%w: AI-triage review requires id, tenant, engagement, finding, and evidence", shared.ErrValidation)
+	}
+	if r.DedupKey == "" || r.Title == "" || !r.Severity.Valid() {
+		return Review{}, fmt.Errorf("%w: AI-triage review requires finding identity, title, and severity", shared.ErrValidation)
+	}
+	if !r.ReviewRequired || r.GateExempt {
+		return Review{}, fmt.Errorf("%w: only policy-held, non-exempt critiques enter human review", shared.ErrValidation)
+	}
+	if r.ProposerModel == "" || r.PromptVersion == "" || r.PolicyVersion == "" || r.PolicyReason == "" || now.IsZero() {
+		return Review{}, fmt.Errorf("%w: AI-triage review requires model, prompt, policy, reason, and timestamp", shared.ErrValidation)
+	}
+	if r.Confidence < 0 || r.Confidence > 100 || r.VerifierConfidence < 0 || r.VerifierConfidence > 100 || (r.WouldGateExempt && !r.Shadow) {
+		return Review{}, fmt.Errorf("%w: invalid AI-triage confidence or rollout metadata", shared.ErrValidation)
+	}
+	return r, nil
+}
+
+// Decide transitions a pending review and enforces rationale, optimistic concurrency,
+// attribution, and defense-in-depth separation of duties.
+func (r Review) Decide(decision Decision, actor, rationale string, expectedVersion int, now time.Time) (Review, error) {
+	if r.State != StatePending {
+		return Review{}, fmt.Errorf("%w: AI-triage review is already %s", shared.ErrConflict, r.State)
+	}
+	if r.Version != expectedVersion {
+		return Review{}, fmt.Errorf("%w: AI-triage review version mismatch", shared.ErrConflict)
+	}
+	if !decision.Valid() {
+		return Review{}, fmt.Errorf("%w: unknown AI-triage review decision %q", shared.ErrValidation, decision)
+	}
+	actor = strings.TrimSpace(actor)
+	rationale = strings.TrimSpace(rationale)
+	if actor == "" || machineActor(actor) || sameIdentity(actor, r.ProposerModel) || sameIdentity(actor, r.VerifierModel) {
+		return Review{}, fmt.Errorf("%w: an AI or machine principal cannot decide its own triage review", shared.ErrValidation)
+	}
+	if r.Owner == "" || !strings.EqualFold(actor, r.Owner) {
+		return Review{}, fmt.Errorf("%w: AI-triage review must be decided by its assigned owner", shared.ErrConflict)
+	}
+	if len([]rune(rationale)) < 3 || len([]rune(rationale)) > 4000 {
+		return Review{}, fmt.Errorf("%w: rationale must contain 3 to 4000 characters", shared.ErrValidation)
+	}
+	for _, ch := range rationale {
+		if ch < 32 && ch != '\n' && ch != '\t' {
+			return Review{}, fmt.Errorf("%w: rationale contains invalid control characters", shared.ErrValidation)
+		}
+	}
+	if now.IsZero() {
+		return Review{}, fmt.Errorf("%w: decision timestamp is required", shared.ErrValidation)
+	}
+	if decision == DecisionAccept {
+		r.State = StateAccepted
+	} else {
+		r.State = StateRejected
+	}
+	r.DecidedBy, r.DecisionRationale = actor, rationale
+	r.DecidedAt, r.UpdatedAt = &now, now
+	r.Version++
+	return r, nil
+}
+
+// Claim assigns a pending review to the authenticated human reviewer.
+func (r Review) Claim(actor string, expectedVersion int, now time.Time) (Review, error) {
+	if r.State != StatePending || r.Version != expectedVersion {
+		return Review{}, fmt.Errorf("%w: AI-triage review changed", shared.ErrConflict)
+	}
+	actor = strings.TrimSpace(actor)
+	if actor == "" || machineActor(actor) || sameIdentity(actor, r.ProposerModel) || sameIdentity(actor, r.VerifierModel) {
+		return Review{}, fmt.Errorf("%w: an AI or machine principal cannot own its triage review", shared.ErrValidation)
+	}
+	if now.IsZero() {
+		return Review{}, fmt.Errorf("%w: claim timestamp is required", shared.ErrValidation)
+	}
+	if r.Owner != "" {
+		return Review{}, fmt.Errorf("%w: AI-triage review is already owned by %s", shared.ErrConflict, r.Owner)
+	}
+	r.Owner, r.UpdatedAt = actor, now
+	r.Version++
+	return r, nil
+}
+
+func machineActor(actor string) bool {
+	a := strings.ToLower(strings.TrimSpace(actor))
+	return strings.HasPrefix(a, "agent:") || strings.HasPrefix(a, "llm:") || strings.HasPrefix(a, "mcp:")
+}
+
+func sameIdentity(actor, model string) bool {
+	a, m := strings.TrimSpace(actor), strings.TrimSpace(model)
+	return m != "" && (strings.EqualFold(a, m) || strings.EqualFold(strings.TrimPrefix(strings.ToLower(a), "llm:"), strings.ToLower(m)))
+}

--- a/internal/domain/aitriagereview/review.go
+++ b/internal/domain/aitriagereview/review.go
@@ -187,9 +187,29 @@ func (r Review) Claim(actor string, expectedVersion int, now time.Time) (Review,
 	return r, nil
 }
 
+// machineActor reports whether actor is a non-human principal.
+//
+// This is the SECOND line: RBAC is the first, and machine roles are granted nothing on the human REST
+// API (user.rolePermissions), so a machine cannot reach Decide over HTTP at all. This exists for the
+// in-process callers that do not pass through that gate.
+//
+// It must therefore cover the prefixes this codebase actually mints, and "system:" is the largest family
+// of them -- system:dast-engine, system:dast-verifier, system:taint-scan, system:cross-check,
+// system:callgraph-engine and more are all reserved capability identities. Omitting it left the widest
+// class of machine principal able to decide a human review, which is exactly what this check exists to
+// prevent.
+//
+// A prefix DENYLIST fails open on the next identity scheme somebody invents. The durable fix is to
+// invert it -- require an actor to be a known human principal -- but that needs a definition of human
+// identity that this package does not own, so it is left as a follow-up rather than guessed at here.
 func machineActor(actor string) bool {
 	a := strings.ToLower(strings.TrimSpace(actor))
-	return strings.HasPrefix(a, "agent:") || strings.HasPrefix(a, "llm:") || strings.HasPrefix(a, "mcp:")
+	for _, prefix := range []string{"agent:", "llm:", "mcp:", "system:", "machine:", "bot:", "service:"} {
+		if strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func sameIdentity(actor, model string) bool {

--- a/internal/domain/aitriagereview/review_test.go
+++ b/internal/domain/aitriagereview/review_test.go
@@ -1,0 +1,86 @@
+package aitriagereview
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func validInput() Input {
+	return Input{ID: "r1", TenantID: "default", EngagementID: "e1", FindingID: "f1", EvidenceRef: "ev1",
+		DedupKey: "sast:key", Title: "SQL injection", Severity: shared.SeverityHigh,
+		Verdict: "refuted", Driver: "sanitizer", Confidence: 91, SuspectedFP: true,
+		ProposerModel: "model-a", VerifierModel: "model-b", Verified: true,
+		PromptVersion: "fp-triage-v1", VerifierVerdict: "refuted", VerifierConfidence: 90, PolicyVersion: "fp-gate-v3",
+		PolicyReason: "severity_requires_human", ReviewRequired: true}
+}
+
+func TestNewPendingRequiresPolicyHeldSealedCritique(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	for name, mutate := range map[string]func(*Input){
+		"missing evidence": func(in *Input) { in.EvidenceRef = "" },
+		"gate exempt":      func(in *Input) { in.GateExempt = true },
+		"not review":       func(in *Input) { in.ReviewRequired = false },
+	} {
+		t.Run(name, func(t *testing.T) {
+			in := validInput()
+			mutate(&in)
+			if _, err := NewPending(in, now); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestDecisionRequiresHumanRationaleAndKeepsClosedLifecycle(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	r, err := NewPending(validInput(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, actor := range []string{"llm:model-a", "agent:runner", "mcp:bot", "model-a", "MODEL-B"} {
+		if _, err := r.Decide(DecisionAccept, actor, "reviewed evidence", 1, now.Add(time.Second)); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("machine/model actor %q must be rejected, got %v", actor, err)
+		}
+	}
+	r, err = r.Claim("reviewer", 1, now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Decide(DecisionReject, "reviewer", "x", 2, now.Add(2*time.Second)); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("short rationale: %v", err)
+	}
+	updated, err := r.Decide(DecisionReject, "reviewer", "source is reachable", 2, now.Add(2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.State != StateRejected || updated.DecidedBy != "reviewer" || updated.Version != 3 {
+		t.Fatalf("unexpected decision: %+v", updated)
+	}
+	if _, err := updated.Decide(DecisionAccept, "other", "changed mind", 3, now.Add(3*time.Second)); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("terminal review changed: %v", err)
+	}
+}
+
+func TestClaimAssignsOnlyHumanReviewer(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	r, err := NewPending(validInput(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Claim("agent:bot", 1, now.Add(time.Second)); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("machine claim: %v", err)
+	}
+	claimed, err := r.Claim("reviewer", 1, now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed.Owner != "reviewer" || claimed.Version != 2 {
+		t.Fatalf("unexpected claim: %+v", claimed)
+	}
+	if _, err := claimed.Claim("other-reviewer", 2, now.Add(2*time.Second)); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("owned review was taken over: %v", err)
+	}
+}

--- a/internal/domain/aitriagereview/review_test.go
+++ b/internal/domain/aitriagereview/review_test.go
@@ -84,3 +84,35 @@ func TestClaimAssignsOnlyHumanReviewer(t *testing.T) {
 		t.Fatalf("owned review was taken over: %v", err)
 	}
 }
+
+// TestDecideRefusesEveryMachinePrincipalFamily pins the second line of the separation-of-duties check.
+// RBAC is the first line and machine roles hold no human-API permission, but in-process callers do not
+// pass through it -- so this must cover the prefixes the codebase actually mints. "system:" is the
+// largest family (system:dast-engine, system:taint-scan, system:cross-check, ...) and was missing, which
+// left the widest class of machine principal able to decide a human review.
+func TestDecideRefusesEveryMachinePrincipalFamily(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	base, err := NewPending(validInput(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, actor := range []string{
+		"system:dast-engine", "system:taint-scan", "system:cross-check",
+		"machine:worker", "bot:triage", "service:scanner",
+		"SYSTEM:DAST-ENGINE", "  system:dast-engine  ",
+	} {
+		// Claimed by the machine actor too, so the owner check cannot be what refuses it -- the point is
+		// that a machine principal is rejected on its own merits.
+		if _, err := base.Decide(DecisionAccept, actor, "reviewed evidence", 1, now.Add(time.Second)); !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("machine actor %q must be rejected as a machine, got %v", actor, err)
+		}
+	}
+	// A human owner must still be able to decide, or the check would refuse everyone.
+	claimed, err := base.Claim("alice", 1, now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := claimed.Decide(DecisionAccept, "alice", "verified unreachable", claimed.Version, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("a human owner must be able to decide: %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/aitriage_review_store.go
+++ b/internal/infrastructure/persistence/memory/aitriage_review_store.go
@@ -1,0 +1,103 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AITriageReviewStore struct {
+	mu   sync.RWMutex
+	data map[shared.ID]aitriagereview.Review
+}
+
+func NewAITriageReviewStore() *AITriageReviewStore {
+	return &AITriageReviewStore{data: map[shared.ID]aitriagereview.Review{}}
+}
+
+func (s *AITriageReviewStore) UpsertPending(_ context.Context, review aitriagereview.Review) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, current := range s.data {
+		if current.TenantID == review.TenantID && current.EngagementID == review.EngagementID &&
+			current.DedupKey == review.DedupKey && current.PolicyVersion == review.PolicyVersion &&
+			current.PromptVersion == review.PromptVersion && current.ProposerModel == review.ProposerModel &&
+			current.VerifierModel == review.VerifierModel {
+			if current.State == aitriagereview.StatePending {
+				review.ID, review.CreatedAt, review.Owner = current.ID, current.CreatedAt, current.Owner
+				review.Version = current.Version + 1
+				s.data[id] = review
+			}
+			return nil
+		}
+	}
+	s.data[review.ID] = review
+	return nil
+}
+
+func (s *AITriageReviewStore) Get(_ context.Context, tenantID, id shared.ID) (aitriagereview.Review, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	review, ok := s.data[id]
+	if !ok || review.TenantID != tenantID {
+		return aitriagereview.Review{}, shared.ErrNotFound
+	}
+	return review, nil
+}
+
+func (s *AITriageReviewStore) List(_ context.Context, tenantID shared.ID, filter ports.AITriageReviewFilter) ([]aitriagereview.Review, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]aitriagereview.Review, 0)
+	for _, review := range s.data {
+		if review.TenantID != tenantID || (filter.Severity != "" && review.Severity != filter.Severity) ||
+			(filter.ProjectID != "" && review.ProjectID != filter.ProjectID) || (filter.State != "" && review.State != filter.State) ||
+			(filter.CWE != "" && !strings.EqualFold(review.CWE, filter.CWE)) {
+			continue
+		}
+		out = append(out, review)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.After(out[j].CreatedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+func (s *AITriageReviewStore) SaveDecision(_ context.Context, review aitriagereview.Review, expectedVersion int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.data[review.ID]
+	if !ok || current.TenantID != review.TenantID {
+		return shared.ErrNotFound
+	}
+	if current.Version != expectedVersion || current.State != aitriagereview.StatePending {
+		return fmt.Errorf("%w: AI-triage review changed", shared.ErrConflict)
+	}
+	s.data[review.ID] = review
+	return nil
+}
+
+func (s *AITriageReviewStore) SaveOwner(_ context.Context, review aitriagereview.Review, expectedVersion int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.data[review.ID]
+	if !ok || current.TenantID != review.TenantID {
+		return shared.ErrNotFound
+	}
+	if current.Version != expectedVersion || current.State != aitriagereview.StatePending {
+		return fmt.Errorf("%w: AI-triage review changed", shared.ErrConflict)
+	}
+	s.data[review.ID] = review
+	return nil
+}
+
+var _ ports.AITriageReviewStore = (*AITriageReviewStore)(nil)

--- a/internal/infrastructure/persistence/postgres/aitriage_review_repo.go
+++ b/internal/infrastructure/persistence/postgres/aitriage_review_repo.go
@@ -1,0 +1,160 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const aiTriageReviewCols = `id, tenant_id, engagement_id, project_id, finding_id, dedup_key, title, severity, cwe, owner,
+ state, verdict, driver, confidence, suspected_fp, proposer_model, verifier_model, prompt_version, verified,
+ verifier_verdict, verifier_driver, verifier_confidence, policy_version, policy_reason, shadow, would_gate_exempt, gate_exempt,
+ review_required, evidence_ref, decided_by, decision_rationale, decided_at, version, created_at, updated_at`
+
+type AITriageReviewRepository struct{ pool *pgxpool.Pool }
+
+func NewAITriageReviewRepository(pool *pgxpool.Pool) *AITriageReviewRepository {
+	return &AITriageReviewRepository{pool: pool}
+}
+
+func (r *AITriageReviewRepository) UpsertPending(ctx context.Context, review aitriagereview.Review) error {
+	tenant := shared.TenantOrDefault(review.TenantID).String()
+	return WithTenant(ctx, r.pool, tenant, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO ai_triage_reviews (
+ id, tenant_id, engagement_id, project_id, finding_id, dedup_key, title, severity, cwe, owner,
+ state, verdict, driver, confidence, suspected_fp, proposer_model, verifier_model, prompt_version, verified,
+ verifier_verdict, verifier_driver, verifier_confidence, policy_version, policy_reason, shadow, would_gate_exempt, gate_exempt,
+ review_required, evidence_ref, decided_by, decision_rationale, decided_at, version, created_at, updated_at)
+ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35)
+ ON CONFLICT (tenant_id, engagement_id, dedup_key, policy_version, prompt_version, proposer_model, verifier_model) DO UPDATE SET
+   project_id=EXCLUDED.project_id, finding_id=EXCLUDED.finding_id, title=EXCLUDED.title,
+   severity=EXCLUDED.severity, cwe=EXCLUDED.cwe,
+   verdict=EXCLUDED.verdict, driver=EXCLUDED.driver, confidence=EXCLUDED.confidence,
+   suspected_fp=EXCLUDED.suspected_fp, proposer_model=EXCLUDED.proposer_model,
+   verifier_model=EXCLUDED.verifier_model, prompt_version=EXCLUDED.prompt_version, verified=EXCLUDED.verified,
+   verifier_verdict=EXCLUDED.verifier_verdict, verifier_driver=EXCLUDED.verifier_driver,
+   verifier_confidence=EXCLUDED.verifier_confidence, policy_reason=EXCLUDED.policy_reason,
+   shadow=EXCLUDED.shadow, would_gate_exempt=EXCLUDED.would_gate_exempt,
+   evidence_ref=EXCLUDED.evidence_ref, updated_at=EXCLUDED.updated_at,
+   version=ai_triage_reviews.version+1
+ WHERE ai_triage_reviews.state='pending'`,
+			review.ID.String(), tenant, review.EngagementID.String(), review.ProjectID.String(), review.FindingID.String(),
+			review.DedupKey, review.Title, string(review.Severity), review.CWE, review.Owner, string(review.State),
+			review.Verdict, review.Driver, review.Confidence, review.SuspectedFP, review.ProposerModel,
+			review.VerifierModel, review.PromptVersion, review.Verified, review.VerifierVerdict, review.VerifierDriver,
+			review.VerifierConfidence, review.PolicyVersion, review.PolicyReason, review.Shadow, review.WouldGateExempt,
+			review.GateExempt, review.ReviewRequired, review.EvidenceRef.String(), review.DecidedBy, review.DecisionRationale,
+			review.DecidedAt, review.Version, review.CreatedAt, review.UpdatedAt)
+		if err != nil {
+			return fmt.Errorf("upsert AI-triage review: %w", err)
+		}
+		return nil
+	})
+}
+
+func (r *AITriageReviewRepository) Get(ctx context.Context, tenantID, id shared.ID) (aitriagereview.Review, error) {
+	tenant := shared.TenantOrDefault(tenantID).String()
+	var out aitriagereview.Review
+	err := WithTenant(ctx, r.pool, tenant, func(tx pgx.Tx) error {
+		var err error
+		out, err = scanAITriageReview(tx.QueryRow(ctx, `SELECT `+aiTriageReviewCols+` FROM ai_triage_reviews WHERE tenant_id=$1 AND id=$2`, tenant, id.String()))
+		return err
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return aitriagereview.Review{}, shared.ErrNotFound
+	}
+	if err != nil {
+		return aitriagereview.Review{}, fmt.Errorf("get AI-triage review: %w", err)
+	}
+	return out, nil
+}
+
+func (r *AITriageReviewRepository) List(ctx context.Context, tenantID shared.ID, filter ports.AITriageReviewFilter) ([]aitriagereview.Review, error) {
+	tenant := shared.TenantOrDefault(tenantID).String()
+	out := make([]aitriagereview.Review, 0)
+	err := WithTenant(ctx, r.pool, tenant, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+aiTriageReviewCols+` FROM ai_triage_reviews
+ WHERE tenant_id=$1 AND ($2='' OR severity=$2) AND ($3='' OR upper(cwe)=upper($3))
+   AND ($4='' OR project_id=$4) AND ($5='' OR state=$5)
+ ORDER BY created_at DESC, id COLLATE "C" ASC LIMIT 1000`, tenant, string(filter.Severity), filter.CWE, filter.ProjectID.String(), string(filter.State))
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			review, err := scanAITriageReview(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, review)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list AI-triage reviews: %w", err)
+	}
+	return out, nil
+}
+
+func (r *AITriageReviewRepository) SaveDecision(ctx context.Context, review aitriagereview.Review, expectedVersion int) error {
+	tenant := shared.TenantOrDefault(review.TenantID).String()
+	return WithTenant(ctx, r.pool, tenant, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE ai_triage_reviews SET state=$1, decided_by=$2,
+ decision_rationale=$3, decided_at=$4, version=$5, updated_at=$6
+ WHERE tenant_id=$7 AND id=$8 AND state='pending' AND version=$9`, string(review.State), review.DecidedBy,
+			review.DecisionRationale, review.DecidedAt, review.Version, review.UpdatedAt, tenant, review.ID.String(), expectedVersion)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			return fmt.Errorf("%w: AI-triage review changed", shared.ErrConflict)
+		}
+		return nil
+	})
+}
+
+func (r *AITriageReviewRepository) SaveOwner(ctx context.Context, review aitriagereview.Review, expectedVersion int) error {
+	tenant := shared.TenantOrDefault(review.TenantID).String()
+	return WithTenant(ctx, r.pool, tenant, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE ai_triage_reviews SET owner=$1, version=$2, updated_at=$3
+ WHERE tenant_id=$4 AND id=$5 AND state='pending' AND version=$6`, review.Owner, review.Version,
+			review.UpdatedAt, tenant, review.ID.String(), expectedVersion)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			return fmt.Errorf("%w: AI-triage review changed", shared.ErrConflict)
+		}
+		return nil
+	})
+}
+
+func scanAITriageReview(row rowScanner) (aitriagereview.Review, error) {
+	var r aitriagereview.Review
+	var id, tenant, eng, project, findingID, severity, state, evidenceRef string
+	var decidedAt *time.Time
+	if err := row.Scan(&id, &tenant, &eng, &project, &findingID, &r.DedupKey, &r.Title, &severity, &r.CWE, &r.Owner,
+		&state, &r.Verdict, &r.Driver, &r.Confidence, &r.SuspectedFP, &r.ProposerModel, &r.VerifierModel,
+		&r.PromptVersion, &r.Verified, &r.VerifierVerdict, &r.VerifierDriver, &r.VerifierConfidence, &r.PolicyVersion,
+		&r.PolicyReason, &r.Shadow, &r.WouldGateExempt, &r.GateExempt, &r.ReviewRequired, &evidenceRef, &r.DecidedBy,
+		&r.DecisionRationale, &decidedAt, &r.Version, &r.CreatedAt, &r.UpdatedAt); err != nil {
+		return aitriagereview.Review{}, err
+	}
+	r.ID, r.TenantID, r.EngagementID, r.ProjectID = shared.ID(id), shared.ID(tenant), shared.ID(eng), shared.ID(project)
+	r.FindingID, r.EvidenceRef = shared.ID(findingID), shared.ID(evidenceRef)
+	r.Severity, r.State, r.DecidedAt = shared.Severity(severity), aitriagereview.State(state), decidedAt
+	if !r.State.Valid() || !r.Severity.Valid() {
+		return aitriagereview.Review{}, fmt.Errorf("%w: invalid stored AI-triage review", shared.ErrValidation)
+	}
+	return r, nil
+}
+
+var _ ports.AITriageReviewStore = (*AITriageReviewRepository)(nil)

--- a/internal/infrastructure/persistence/postgres/integrity_test.go
+++ b/internal/infrastructure/persistence/postgres/integrity_test.go
@@ -44,9 +44,22 @@ func TestAppendOnlyEnforcement(t *testing.T) {
 			t.Errorf("%s must be rejected as append-only, got %v", label, err)
 		}
 	}
+	// refused accepts EITHER mechanism. A plain TRUNCATE can be stopped by a foreign key from any table
+	// referencing evidence before the trigger is reached -- which is incidental protection: it depends on
+	// some other table happening to reference this one, and it disappears the day that table does not.
+	refused := func(label, q string, args ...any) {
+		if _, err := pool.Exec(ctx, q, args...); err == nil {
+			t.Errorf("%s must be refused, got nil", label)
+		}
+	}
 	rejects("DELETE evidence", `DELETE FROM evidence WHERE id=$1`, ev.ID.String())
 	rejects("UPDATE evidence", `UPDATE evidence SET content='y' WHERE id=$1`, ev.ID.String())
-	rejects("TRUNCATE evidence", `TRUNCATE evidence`)
+	refused("TRUNCATE evidence", `TRUNCATE evidence`)
+	// CASCADE is the variant that matters, and the one a foreign key cannot stop: it truncates the
+	// referencing tables too, so the FK objection evaporates and only the append-only trigger is left.
+	// Asserting on the trigger's own message keeps this test measuring the guarantee rather than a
+	// side effect of the current schema.
+	rejects("TRUNCATE evidence CASCADE", `TRUNCATE evidence CASCADE`)
 
 	action := "ao.action-" + randHex(t)
 	if err := NewAuditLog(pool).Record(ctx, ports.AuditEntry{Actor: "op", Action: action, Target: "t", At: time.Now().UTC()}); err != nil {

--- a/internal/infrastructure/persistence/postgres/migration_0067_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0067_test.go
@@ -1,0 +1,63 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestMigration0067PinsReviewEvidenceToOneTenant verifies the properties that
+// cannot be supplied by the use-case layer: forced RLS and composite parent
+// references for the finding and sealed evidence reviewed by a human.
+func TestMigration0067PinsReviewEvidenceToOneTenant(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	var forced bool
+	if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE relname='ai_triage_reviews'`).Scan(&forced); err != nil {
+		t.Fatalf("read RLS state: %v", err)
+	}
+	if !forced {
+		t.Fatal("ai_triage_reviews must FORCE row level security")
+	}
+
+	rows, err := pool.Query(ctx, `SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid='ai_triage_reviews'::regclass`)
+	if err != nil {
+		t.Fatalf("read constraints: %v", err)
+	}
+	defer rows.Close()
+	var definitions []string
+	for rows.Next() {
+		var definition string
+		if err := rows.Scan(&definition); err != nil {
+			t.Fatalf("scan constraint: %v", err)
+		}
+		definitions = append(definitions, strings.ToLower(definition))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate constraints: %v", err)
+	}
+	joined := strings.Join(definitions, "\n")
+	for _, required := range []string{
+		"foreign key (tenant_id, engagement_id, finding_id)",
+		"foreign key (tenant_id, engagement_id, evidence_ref)",
+		"review_required",
+		"not gate_exempt",
+	} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("migration is missing %q; constraints:\n%s", required, joined)
+		}
+	}
+}

--- a/internal/usecase/aitriagereviewuc/service.go
+++ b/internal/usecase/aitriagereviewuc/service.go
@@ -1,0 +1,167 @@
+// Package aitriagereviewuc implements the durable human-review workflow for
+// AI false-positive recommendations held back by the deterministic policy.
+package aitriagereviewuc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type Service struct {
+	decisionMu  sync.Mutex // API is single-instance; serialize queue refresh and review+finding mutation
+	store       ports.AITriageReviewStore
+	engagements ports.EngagementRepository
+	findings    ports.AITriageFindingDecision
+	audit       ports.AuditLogger
+	clock       ports.Clock
+	ids         ports.IDGenerator
+}
+
+func NewService(store ports.AITriageReviewStore, engagements ports.EngagementRepository, findings ports.AITriageFindingDecision, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if store == nil || engagements == nil || findings == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: AI-triage review service requires store, engagements, findings, audit, clock, and ids", shared.ErrValidation)
+	}
+	return &Service{store: store, engagements: engagements, findings: findings, audit: audit, clock: clock, ids: ids}, nil
+}
+
+// RecordScan materializes every ReviewRequired critique after the scan evidence is sealed.
+// UpsertPending is idempotent by finding plus policy/prompt/model identity.
+func (s *Service) RecordScan(ctx context.Context, engagementID, evidenceRef shared.ID, items []finding.Finding, critiques []ports.AICritique) error {
+	s.decisionMu.Lock()
+	defer s.decisionMu.Unlock()
+	if evidenceRef.IsZero() {
+		for _, c := range critiques {
+			if c.ReviewRequired {
+				return fmt.Errorf("%w: review-required AI triage has no sealed evidence reference", shared.ErrValidation)
+			}
+		}
+		return nil
+	}
+	e, err := s.engagements.GetByID(ctx, engagementID)
+	if err != nil {
+		return fmt.Errorf("load review engagement: %w", err)
+	}
+	byKey := make(map[string]finding.Finding, len(items))
+	for _, item := range items {
+		byKey[strings.TrimSpace(item.DedupKey)] = item
+	}
+	for _, c := range critiques {
+		if !c.ReviewRequired {
+			continue
+		}
+		item, ok := byKey[strings.TrimSpace(c.DedupKey)]
+		if !ok {
+			return fmt.Errorf("%w: review-required critique references an unknown finding", shared.ErrValidation)
+		}
+		review, err := aitriagereview.NewPending(aitriagereview.Input{
+			ID: s.ids.NewID(), TenantID: shared.TenantOrDefault(e.TenantID), EngagementID: engagementID,
+			ProjectID: e.ProjectID, FindingID: item.ID, EvidenceRef: evidenceRef,
+			DedupKey: item.DedupKey, Title: item.Title, Severity: item.Severity, CWE: item.CWE,
+			Verdict: c.Verdict, Driver: c.Driver, Confidence: c.Confidence, SuspectedFP: c.SuspectedFP,
+			ProposerModel: c.ProposerModel, VerifierModel: c.VerifierModel, PromptVersion: c.PromptVersion, Verified: c.Verified,
+			VerifierVerdict: c.VerifierVerdict, VerifierDriver: c.VerifierDriver, VerifierConfidence: c.VerifierConfidence,
+			PolicyVersion: c.PolicyVersion, PolicyReason: c.PolicyReason, Shadow: c.Shadow, WouldGateExempt: c.WouldGateExempt,
+			GateExempt: c.GateExempt, ReviewRequired: c.ReviewRequired,
+		}, s.clock.Now())
+		if err != nil {
+			return err
+		}
+		if err := s.store.UpsertPending(ctx, review); err != nil {
+			return fmt.Errorf("persist AI-triage review: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) List(ctx context.Context, tenantID shared.ID, filter ports.AITriageReviewFilter) ([]aitriagereview.Review, error) {
+	if filter.Severity != "" && !filter.Severity.Valid() {
+		return nil, fmt.Errorf("%w: invalid severity filter", shared.ErrValidation)
+	}
+	if filter.State != "" && !filter.State.Valid() {
+		return nil, fmt.Errorf("%w: invalid state filter", shared.ErrValidation)
+	}
+	filter.CWE = strings.TrimSpace(filter.CWE)
+	return s.store.List(ctx, shared.TenantOrDefault(tenantID), filter)
+}
+
+func (s *Service) Decide(ctx context.Context, tenantID, id shared.ID, actor string, decision aitriagereview.Decision, rationale string, expectedVersion int) (aitriagereview.Review, error) {
+	s.decisionMu.Lock()
+	defer s.decisionMu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	current, err := s.store.Get(ctx, tenantID, id)
+	if err != nil {
+		return aitriagereview.Review{}, err
+	}
+	updated, err := current.Decide(decision, actor, rationale, expectedVersion, s.clock.Now())
+	if err != nil {
+		return aitriagereview.Review{}, err
+	}
+	accepted := updated.State == aitriagereview.StateAccepted
+	auditEntry := ports.AuditEntry{
+		Actor: actor, Action: "ai_triage_review." + string(updated.State), Target: id.String(), At: updated.UpdatedAt,
+		Metadata: map[string]string{
+			"tenant": tenantID.String(), "engagement": updated.EngagementID.String(), "project": updated.ProjectID.String(),
+			"finding": updated.FindingID.String(), "decision": string(decision), "policy_version": updated.PolicyVersion,
+			"prompt_version": updated.PromptVersion, "proposer_model": updated.ProposerModel,
+			"verifier_model": updated.VerifierModel, "confidence": fmt.Sprintf("%d", updated.Confidence),
+			"verifier_confidence": fmt.Sprintf("%d", updated.VerifierConfidence), "evidence_ref": updated.EvidenceRef.String(),
+			"rationale": updated.DecisionRationale,
+		},
+	}
+	// Accept can remove the finding from subsequent gate counts, so its durable
+	// decision and evidence-linked audit must succeed before that mutation. Reject
+	// moves in the fail-safe direction (back to gating), so apply it first.
+	if accepted {
+		if err := s.store.SaveDecision(ctx, updated, expectedVersion); err != nil {
+			return aitriagereview.Review{}, fmt.Errorf("persist AI-triage decision: %w", err)
+		}
+		if err := s.audit.Record(ctx, auditEntry); err != nil {
+			return aitriagereview.Review{}, fmt.Errorf("audit AI-triage decision: %w", err)
+		}
+		if err := s.findings.ApplyAITriageReview(ctx, actor, updated.EngagementID, updated.FindingID, true, updated.DecisionRationale); err != nil {
+			return aitriagereview.Review{}, fmt.Errorf("apply AI-triage review to finding: %w", err)
+		}
+		return updated, nil
+	}
+	if err := s.findings.ApplyAITriageReview(ctx, actor, updated.EngagementID, updated.FindingID, false, updated.DecisionRationale); err != nil {
+		return aitriagereview.Review{}, fmt.Errorf("apply AI-triage review to finding: %w", err)
+	}
+	if err := s.store.SaveDecision(ctx, updated, expectedVersion); err != nil {
+		return aitriagereview.Review{}, fmt.Errorf("persist AI-triage decision: %w", err)
+	}
+	if err := s.audit.Record(ctx, auditEntry); err != nil {
+		return aitriagereview.Review{}, fmt.Errorf("audit AI-triage decision: %w", err)
+	}
+	return updated, nil
+}
+
+func (s *Service) Claim(ctx context.Context, tenantID, id shared.ID, actor string, expectedVersion int) (aitriagereview.Review, error) {
+	s.decisionMu.Lock()
+	defer s.decisionMu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	current, err := s.store.Get(ctx, tenantID, id)
+	if err != nil {
+		return aitriagereview.Review{}, err
+	}
+	updated, err := current.Claim(actor, expectedVersion, s.clock.Now())
+	if err != nil {
+		return aitriagereview.Review{}, err
+	}
+	if err := s.store.SaveOwner(ctx, updated, expectedVersion); err != nil {
+		return aitriagereview.Review{}, err
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: "ai_triage_review.claimed", Target: id.String(), At: updated.UpdatedAt,
+		Metadata: map[string]string{"tenant": tenantID.String(), "engagement": updated.EngagementID.String(), "finding": updated.FindingID.String(), "owner": updated.Owner, "evidence_ref": updated.EvidenceRef.String()}}); err != nil {
+		return aitriagereview.Review{}, fmt.Errorf("audit AI-triage review claim: %w", err)
+	}
+	return updated, nil
+}
+
+var _ ports.AITriageReviewRecorder = (*Service)(nil)

--- a/internal/usecase/aitriagereviewuc/service_test.go
+++ b/internal/usecase/aitriagereviewuc/service_test.go
@@ -1,0 +1,144 @@
+package aitriagereviewuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fixedClock struct{ now time.Time }
+
+func (c fixedClock) Now() time.Time { return c.now }
+
+type seqIDs struct{ n int }
+
+func (s *seqIDs) NewID() shared.ID { s.n++; return shared.ID("id-" + string(rune('0'+s.n))) }
+
+type auditFake struct{ entries []ports.AuditEntry }
+
+func (a *auditFake) Record(_ context.Context, e ports.AuditEntry) error {
+	a.entries = append(a.entries, e)
+	return nil
+}
+
+type findingDecisionFake struct {
+	accepted bool
+	calls    int
+}
+
+type decisionFailStore struct {
+	*memory.AITriageReviewStore
+	fail bool
+}
+
+func (s *decisionFailStore) SaveDecision(ctx context.Context, review aitriagereview.Review, expectedVersion int) error {
+	if s.fail {
+		return errors.New("decision store unavailable")
+	}
+	return s.AITriageReviewStore.SaveDecision(ctx, review, expectedVersion)
+}
+
+func (f *findingDecisionFake) ApplyAITriageReview(_ context.Context, _ string, _, _ shared.ID, accepted bool, _ string) error {
+	f.accepted = accepted
+	f.calls++
+	return nil
+}
+
+func TestAcceptNeverExemptsBeforeDecisionIsDurable(t *testing.T) {
+	ctx := context.Background()
+	now := time.Unix(100, 0).UTC()
+	engagements := memory.NewEngagementRepository()
+	e, err := engagement.New("e1", shared.DefaultTenant, "Project context", "client", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, e); err != nil {
+		t.Fatal(err)
+	}
+	store := &decisionFailStore{AITriageReviewStore: memory.NewAITriageReviewStore()}
+	decisions := &findingDecisionFake{}
+	svc, err := NewService(store, engagements, decisions, &auditFake{}, fixedClock{now}, &seqIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := finding.Finding{ID: "f1", EngagementID: "e1", DedupKey: "sast:key", Title: "SQL injection", Severity: shared.SeverityHigh, Kind: finding.KindSAST, Status: finding.StatusOpen}
+	critique := ports.AICritique{DedupKey: item.DedupKey, Verdict: "refuted", Driver: "sanitizer", Confidence: 90, SuspectedFP: true, ProposerModel: "model-a", PromptVersion: "fp-triage-v1", PolicyVersion: "fp-gate-v3", PolicyReason: "severity_requires_human", ReviewRequired: true}
+	if err := svc.RecordScan(ctx, e.ID, "ev1", []finding.Finding{item}, []ports.AICritique{critique}); err != nil {
+		t.Fatal(err)
+	}
+	queue, err := svc.List(ctx, shared.DefaultTenant, ports.AITriageReviewFilter{})
+	if err != nil || len(queue) != 1 {
+		t.Fatalf("queue=%+v err=%v", queue, err)
+	}
+	claimed, err := svc.Claim(ctx, shared.DefaultTenant, queue[0].ID, "reviewer", queue[0].Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.fail = true
+	if _, err := svc.Decide(ctx, shared.DefaultTenant, claimed.ID, "reviewer", aitriagereview.DecisionAccept, "fixture is unreachable", claimed.Version); err == nil {
+		t.Fatal("accept should fail when the durable decision cannot be written")
+	}
+	if decisions.calls != 0 {
+		t.Fatalf("finding was exempted before durable decision: calls=%d", decisions.calls)
+	}
+}
+
+func TestRecordAndDecideReview(t *testing.T) {
+	ctx := context.Background()
+	now := time.Unix(100, 0).UTC()
+	engagements := memory.NewEngagementRepository()
+	e, err := engagement.New("e1", shared.DefaultTenant, "Project context", "client", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.ProjectID = "p1"
+	if err := engagements.Create(ctx, e); err != nil {
+		t.Fatal(err)
+	}
+	store := memory.NewAITriageReviewStore()
+	audit := &auditFake{}
+	decisions := &findingDecisionFake{}
+	ids := &seqIDs{}
+	svc, err := NewService(store, engagements, decisions, audit, fixedClock{now}, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := finding.Finding{ID: "f1", EngagementID: "e1", DedupKey: "sast:key", Title: "SQL injection", Severity: shared.SeverityHigh, Kind: finding.KindSAST, Status: finding.StatusOpen}
+	critique := ports.AICritique{FindingID: "f1", DedupKey: "sast:key", Verdict: "refuted", Driver: "sanitizer", Confidence: 90, SuspectedFP: true, ProposerModel: "model-a", PromptVersion: "fp-triage-v1", PolicyVersion: "fp-gate-v3", PolicyReason: "severity_requires_human", ReviewRequired: true}
+	if err := svc.RecordScan(ctx, "e1", "ev1", []finding.Finding{item}, []ports.AICritique{critique}); err != nil {
+		t.Fatal(err)
+	}
+	queue, err := svc.List(ctx, "", ports.AITriageReviewFilter{State: aitriagereview.StatePending})
+	if err != nil || len(queue) != 1 {
+		t.Fatalf("queue=%+v err=%v", queue, err)
+	}
+	claimed, err := svc.Claim(ctx, "", queue[0].ID, "reviewer", queue[0].Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.RecordScan(ctx, "e1", "ev2", []finding.Finding{item}, []ports.AICritique{critique}); err != nil {
+		t.Fatal(err)
+	}
+	queue, err = svc.List(ctx, "", ports.AITriageReviewFilter{State: aitriagereview.StatePending})
+	if err != nil || len(queue) != 1 || queue[0].Owner != "reviewer" || queue[0].EvidenceRef != "ev2" || queue[0].Version != claimed.Version+1 {
+		t.Fatalf("rescan must preserve owner, refresh evidence, and invalidate stale versions: queue=%+v err=%v", queue, err)
+	}
+	updated, err := svc.Decide(ctx, "", queue[0].ID, "reviewer", aitriagereview.DecisionReject, "this path is reachable", queue[0].Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.State != aitriagereview.StateRejected || decisions.accepted || decisions.calls != 1 {
+		t.Fatalf("decision not applied: %+v fake=%+v", updated, decisions)
+	}
+	if len(audit.entries) != 2 || audit.entries[1].Metadata["evidence_ref"] != "ev2" || audit.entries[1].Metadata["prompt_version"] != "fp-triage-v1" {
+		t.Fatalf("decision audit missing evidence: %+v", audit.entries)
+	}
+}

--- a/internal/usecase/findings/service.go
+++ b/internal/usecase/findings/service.go
@@ -20,6 +20,7 @@ var _ ports.ConfirmedThreatRecorder = (*Service)(nil)
 var _ ports.ConfirmedSASTRecorder = (*Service)(nil)
 var _ ports.ConfirmedDASTRecorder = (*Service)(nil)
 var _ ports.FindingWriteupApplier = (*Service)(nil)
+var _ ports.AITriageFindingDecision = (*Service)(nil)
 
 // Service lists findings and applies authoring/triage/assignment/comment/retest changes.
 type Service struct {
@@ -233,6 +234,27 @@ func (s *Service) UpdateStatus(ctx context.Context, engagementID, findingID shar
 		return finding.Finding{}, err
 	}
 	return f, nil
+}
+
+// ApplyAITriageReview applies the human's decision to the authoritative finding.
+// Accept means the reviewer accepts the AI false-positive recommendation; Reject
+// explicitly reopens the finding so it is counted by subsequent gates.
+func (s *Service) ApplyAITriageReview(ctx context.Context, actor string, engagementID, findingID shared.ID, accepted bool, rationale string) error {
+	current, err := s.loadFinding(ctx, engagementID, findingID)
+	if err != nil {
+		return err
+	}
+	target := finding.StatusOpen
+	if accepted {
+		target = finding.StatusFalsePos
+	}
+	if current.Status == target {
+		return nil
+	}
+	if _, err := s.UpdateStatus(ctx, engagementID, findingID, target, rationale, actor, current.Version); err != nil {
+		return err
+	}
+	return nil
 }
 
 // SetAssignee assigns/unassigns a finding with the same optimistic-concurrency

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/advisory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/audit"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/aup"
@@ -498,6 +499,35 @@ type ScanJobStore interface {
 type ScanResultStore interface {
 	SaveResult(ctx context.Context, engagementID shared.ID, result []byte) error
 	LatestResult(ctx context.Context, engagementID shared.ID) ([]byte, error)
+}
+
+// AITriageReviewFilter is the tenant-scoped review-queue query.
+type AITriageReviewFilter struct {
+	Severity  shared.Severity
+	CWE       string
+	ProjectID shared.ID
+	State     aitriagereview.State
+}
+
+// AITriageReviewStore persists the mutable queue row. Decisions are separately
+// recorded in the append-only audit chain by the use case.
+type AITriageReviewStore interface {
+	UpsertPending(ctx context.Context, review aitriagereview.Review) error
+	Get(ctx context.Context, tenantID, id shared.ID) (aitriagereview.Review, error)
+	List(ctx context.Context, tenantID shared.ID, filter AITriageReviewFilter) ([]aitriagereview.Review, error)
+	SaveOwner(ctx context.Context, review aitriagereview.Review, expectedVersion int) error
+	SaveDecision(ctx context.Context, review aitriagereview.Review, expectedVersion int) error
+}
+
+// AITriageReviewRecorder is the narrow scan-pipeline sink. A scan only supplies
+// policy-held critiques after its evidence link has been sealed.
+type AITriageReviewRecorder interface {
+	RecordScan(ctx context.Context, engagementID, evidenceRef shared.ID, findings []finding.Finding, critiques []AICritique) error
+}
+
+// AITriageFindingDecision applies the human decision to the authoritative finding.
+type AITriageFindingDecision interface {
+	ApplyAITriageReview(ctx context.Context, actor string, engagementID, findingID shared.ID, accepted bool, rationale string) error
 }
 
 // ImportedSBOMStore persists the active client-supplied SBOM for an engagement.

--- a/internal/usecase/sca/sbom_import.go
+++ b/internal/usecase/sca/sbom_import.go
@@ -73,7 +73,7 @@ func (s *Service) ImportSBOMFile(ctx context.Context, actor string, tenantID, en
 		Manifest: ports.ScanManifest{SBOMSHA256: hashHex(data)},
 	}
 
-	if err := s.sealEvidence(ctx, actor, engagementID, now, res); err != nil {
+	if _, err := s.sealEvidence(ctx, actor, engagementID, now, res); err != nil {
 		return nil, err
 	}
 

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -74,6 +74,7 @@ type Service struct {
 	misconfig                        ports.MisconfigScanner                // optional deterministic IaC/config misconfig scan over the live workspace
 	fpTriager                        ports.FPTriager                       // optional LLM false-positive critique of production-scope source findings
 	fpTriageMode                     aiTriageMode                          // shadow by default; enforce must be selected explicitly
+	aiReviews                        ports.AITriageReviewRecorder          // optional durable human-review queue sink
 	osPkgCataloger                   ports.OSPackageCataloger              // optional owned OS-package cataloging (dpkg/apk) from an image rootfs
 	instCataloger                    ports.InstalledPackageCataloger       // optional owned installed-package cataloging (Go binaries, Python dist-info) from an image rootfs
 	artifactCataloger                ports.ArtifactCataloger               // optional owned standalone-artifact cataloging (.msi product identity) from the workspace dir
@@ -228,6 +229,10 @@ func (s *Service) SetFPTriageMode(mode string) {
 	}
 	s.fpTriageMode = aiTriageModeShadow
 }
+
+// SetAITriageReviewRecorder materializes policy-held critiques after their scan
+// evidence has been sealed. nil keeps CLI/standalone scans free of workflow state.
+func (s *Service) SetAITriageReviewRecorder(r ports.AITriageReviewRecorder) { s.aiReviews = r }
 
 // SetOSPackageCataloger configures optional owned OS-package cataloging (dpkg/apk) from a materialized image
 // rootfs (Workspace.RootFS). nil ⇒ no owned OS cataloging. It only runs when a rootfs was materialized.
@@ -1828,7 +1833,8 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 	applyDetectionPriority(result, opts.DetectionPriority)
 	s.attachCompliance(result)
 	result.ReproDigest = ReproDigest(result)
-	if err := s.sealEvidence(ctx, actor, engagementID, now, result); err != nil {
+	evidenceRef, err := s.sealEvidence(ctx, actor, engagementID, now, result)
+	if err != nil {
 		return nil, err
 	}
 	if s.runs != nil {
@@ -1852,6 +1858,11 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 	if s.findings != nil {
 		if err := s.findings.Upsert(ctx, result.Findings); err != nil {
 			return nil, fmt.Errorf("persist findings: %w", err)
+		}
+	}
+	if s.aiReviews != nil {
+		if err := s.aiReviews.RecordScan(ctx, engagementID, evidenceRef, result.Findings, result.AITriage); err != nil {
+			return nil, fmt.Errorf("record AI-triage reviews: %w", err)
 		}
 	}
 	if s.results != nil {
@@ -2602,7 +2613,8 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 
 	// Seal this scan into the engagement's append-only hash-chained evidence ledger
 	// before writing any run, scan, finding, or result state.
-	if err := s.sealEvidence(ctx, actor, engagementID, now, result); err != nil {
+	evidenceRef, err := s.sealEvidence(ctx, actor, engagementID, now, result)
+	if err != nil {
 		return nil, err
 	}
 	if s.runs != nil {
@@ -2644,6 +2656,11 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	if s.findings != nil {
 		if err := s.findings.Upsert(ctx, result.Findings); err != nil {
 			return nil, fmt.Errorf("persist findings: %w", err)
+		}
+	}
+	if s.aiReviews != nil {
+		if err := s.aiReviews.RecordScan(ctx, engagementID, evidenceRef, result.Findings, result.AITriage); err != nil {
+			return nil, fmt.Errorf("record AI-triage reviews: %w", err)
 		}
 	}
 	// Cache the full result so the UI can re-display it after a reload (best-effort;
@@ -3314,21 +3331,22 @@ func scanEvidenceContent(actor string, now time.Time, result *ScanResult) ([]byt
 // sealEvidence appends one tamper-evident link summarizing this scan to the engagement's hash chain.
 // Content covers every gate-affecting AI field as well as the deterministic finding/suppression set.
 // A configured ledger failure prevents result persistence, preserving the fail-closed contract.
-func (s *Service) sealEvidence(ctx context.Context, actor string, engagementID shared.ID, now time.Time, result *ScanResult) error {
+func (s *Service) sealEvidence(ctx context.Context, actor string, engagementID shared.ID, now time.Time, result *ScanResult) (shared.ID, error) {
 	if s.evidence == nil {
-		return nil
+		return "", nil
 	}
 	content, err := scanEvidenceContent(actor, now, result)
 	if err != nil {
-		return fmt.Errorf("marshal scan evidence: %w", err)
+		return "", fmt.Errorf("marshal scan evidence: %w", err)
 	}
 	// Append through the evidence vault – one tamper-evident chain + verify path per
 	// engagement. The vault binds the link to the current head; a transient
 	// Head failure fails the seal rather than forking the chain.
-	if _, err := s.evidence.Seal(ctx, engagementID, "scan", content, actor); err != nil {
-		return fmt.Errorf("seal scan evidence: %w", err)
+	link, err := s.evidence.Seal(ctx, engagementID, "scan", content, actor)
+	if err != nil {
+		return "", fmt.Errorf("seal scan evidence: %w", err)
 	}
-	return nil
+	return link.ID, nil
 }
 
 // ReportInsight assembles the scan-level context the executive report needs:

--- a/migrations/0067_ai_triage_reviews.sql
+++ b/migrations/0067_ai_triage_reviews.sql
@@ -1,0 +1,68 @@
+-- +goose Up
+-- P1.2: durable AI-triage human-review workflow.
+-- Durable human-review queue for AI false-positive recommendations held by the
+-- deterministic policy. The finding and scan remain authoritative and visible;
+-- this row only records workflow state and the sealed scan-evidence reference.
+ALTER TABLE evidence ADD CONSTRAINT evidence_tenant_engagement_id_unique
+    UNIQUE (tenant_id, engagement_id, id);
+
+CREATE TABLE ai_triage_reviews (
+    id                    TEXT PRIMARY KEY,
+    tenant_id             TEXT NOT NULL REFERENCES tenants(id),
+    engagement_id         TEXT NOT NULL,
+    project_id            TEXT NOT NULL DEFAULT '',
+    finding_id            TEXT NOT NULL,
+    dedup_key             TEXT NOT NULL,
+    title                 TEXT NOT NULL,
+    severity              TEXT NOT NULL CHECK (severity IN ('critical','high','medium','low','info','unknown')),
+    cwe                   TEXT NOT NULL DEFAULT '',
+    owner                 TEXT NOT NULL DEFAULT '',
+    state                 TEXT NOT NULL CHECK (state IN ('pending','accepted','rejected')),
+    verdict               TEXT NOT NULL,
+    driver                TEXT NOT NULL,
+    confidence            INTEGER NOT NULL CHECK (confidence BETWEEN 0 AND 100),
+    suspected_fp          BOOLEAN NOT NULL,
+    proposer_model        TEXT NOT NULL,
+    verifier_model        TEXT NOT NULL DEFAULT '',
+    prompt_version        TEXT NOT NULL,
+    verified              BOOLEAN NOT NULL,
+    verifier_verdict      TEXT NOT NULL DEFAULT '',
+    verifier_driver       TEXT NOT NULL DEFAULT '',
+    verifier_confidence   INTEGER NOT NULL DEFAULT 0 CHECK (verifier_confidence BETWEEN 0 AND 100),
+    policy_version        TEXT NOT NULL,
+    policy_reason         TEXT NOT NULL,
+    shadow                BOOLEAN NOT NULL DEFAULT false,
+    would_gate_exempt     BOOLEAN NOT NULL DEFAULT false,
+    gate_exempt           BOOLEAN NOT NULL DEFAULT false,
+    review_required       BOOLEAN NOT NULL DEFAULT true,
+    evidence_ref          TEXT NOT NULL,
+    decided_by            TEXT NOT NULL DEFAULT '',
+    decision_rationale    TEXT NOT NULL DEFAULT '',
+    decided_at            TIMESTAMPTZ,
+    version               INTEGER NOT NULL DEFAULT 1 CHECK (version > 0),
+    created_at            TIMESTAMPTZ NOT NULL,
+    updated_at            TIMESTAMPTZ NOT NULL,
+    UNIQUE (tenant_id, engagement_id, dedup_key, policy_version, prompt_version, proposer_model, verifier_model),
+    FOREIGN KEY (tenant_id, engagement_id)
+        REFERENCES engagements(tenant_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (tenant_id, engagement_id, finding_id)
+        REFERENCES findings(tenant_id, engagement_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (tenant_id, engagement_id, evidence_ref)
+        REFERENCES evidence(tenant_id, engagement_id, id),
+    CHECK (dedup_key <> '' AND title <> '' AND proposer_model <> '' AND prompt_version <> ''
+        AND policy_version <> '' AND policy_reason <> '' AND evidence_ref <> ''),
+    CHECK (review_required AND NOT gate_exempt),
+    CHECK (NOT would_gate_exempt OR shadow),
+    CHECK ((state = 'pending' AND decided_by = '' AND decision_rationale = '' AND decided_at IS NULL)
+        OR (state <> 'pending' AND decided_by <> '' AND decision_rationale <> '' AND decided_at IS NOT NULL))
+);
+
+CREATE INDEX ai_triage_reviews_queue ON ai_triage_reviews
+    (tenant_id, state, severity, created_at DESC);
+CREATE INDEX ai_triage_reviews_project ON ai_triage_reviews
+    (tenant_id, project_id, state, created_at DESC);
+CALL synapse_enable_tenant_rls('ai_triage_reviews');
+
+-- +goose Down
+DROP TABLE ai_triage_reviews;
+ALTER TABLE evidence DROP CONSTRAINT evidence_tenant_engagement_id_unique;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from './auth/AuthContext'
 import { MobileSidebar, Sidebar } from './components/Sidebar'
 import { Topbar } from './components/Topbar'
 import { Audit } from './pages/Audit'
+import { AITriageReviews } from './pages/AITriageReviews'
 import { Connect } from './pages/Connect'
 import { EngagementDetail } from './pages/EngagementDetail'
 import { Engagements } from './pages/Engagements'
@@ -72,6 +73,7 @@ function Gate() {
         <Route path="rules" element={<Rules />} />
         <Route path="rules/:key" element={<RuleDetail />} />
         <Route path="audit" element={<Audit />} />
+        <Route path="ai-triage/reviews" element={<AITriageReviews />} />
         <Route path="team" element={<Team />} />
         <Route path="*" element={<Navigate to="/engagements" replace />} />
       </Route>

--- a/web/src/components/AITriageBadges.tsx
+++ b/web/src/components/AITriageBadges.tsx
@@ -1,0 +1,25 @@
+import { Bot, CheckCheck, ShieldQuestion, Sparkles } from 'lucide-react'
+import type { ReactNode } from 'react'
+import type { AITriage } from '../lib/types'
+import { cn } from './ui'
+
+type TriageFlags = Pick<AITriage, 'suspectedFP' | 'verified' | 'gateExempt' | 'reviewRequired'>
+
+export function AITriageBadges({ triage }: { triage: TriageFlags }) {
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1.5" aria-label="AI triage status">
+      {triage.suspectedFP && <Badge icon={Sparkles} className="bg-brand/10 text-branddim ring-brand/25">Suspected FP</Badge>}
+      {triage.verified && <Badge icon={CheckCheck} className="bg-accent/10 text-accent ring-accent/25">Verified</Badge>}
+      {triage.gateExempt && <Badge icon={Bot} className="bg-medium/10 text-medium ring-medium/25">Gate exempt</Badge>}
+      {triage.reviewRequired && <Badge icon={ShieldQuestion} className="bg-critical/10 text-critical ring-critical/25">Review required</Badge>}
+    </span>
+  )
+}
+
+function Badge({ icon: Icon, className, children }: { icon: typeof Bot; className: string; children: ReactNode }) {
+  return (
+    <span className={cn('inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ring-inset', className)}>
+      <Icon className="size-3" aria-hidden="true" />{children}
+    </span>
+  )
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   ScrollText,
   Server,
   Settings,
+  ShieldQuestion,
   Sun,
   Target,
   Users,
@@ -30,6 +31,7 @@ const NAV_GROUPS: Array<{
     items: [
       { icon: Boxes, label: 'Assets', to: '/assets', prefix: '/assets' },
       { icon: Target, label: 'Engagements', to: '/engagements', prefix: '/engagements' },
+      { icon: ShieldQuestion, label: 'AI review queue', to: '/ai-triage/reviews', prefix: '/ai-triage/reviews' },
       { icon: ScrollText, label: 'Audit log', to: '/audit' },
     ],
   },

--- a/web/src/components/codequality/FindingExplorer.tsx
+++ b/web/src/components/codequality/FindingExplorer.tsx
@@ -6,7 +6,8 @@ import {
   ratedFindingDimensionValues,
   type RatedFindingDimension,
 } from '../../lib/ratedFindingDimensions'
-import type { Finding } from '../../lib/types'
+import type { AITriage, Finding } from '../../lib/types'
+import { AITriageBadges } from '../AITriageBadges'
 import { Card, EmptyState, Input, Pill, Select, SevBadge } from '../ui'
 
 const pageSize = 50
@@ -18,11 +19,13 @@ export function FindingExplorer({
   headingId,
   initialDimension = null,
   dimensionNavigationKey,
+  aiTriage = [],
 }: {
   findings: Finding[]
   headingId?: string
   initialDimension?: RatedFindingDimension | null
   dimensionNavigationKey?: string
+  aiTriage?: AITriage[]
 }) {
   const [query, setQuery] = useState('')
   const [severity, setSeverity] = useState('all')
@@ -30,6 +33,15 @@ export function FindingExplorer({
   const [selected, setSelected] = useState<Finding | null>(null)
   const [shown, setShown] = useState(pageSize)
   const kinds = useMemo(() => [...new Set(findings.map((finding) => finding.kind))].sort(), [findings])
+  const triageByFinding = useMemo(() => {
+    const map = new Map<string, AITriage>()
+    aiTriage.forEach((item) => {
+      if (item.findingId) map.set(item.findingId, item)
+      if (item.dedupKey) map.set(item.dedupKey, item)
+    })
+    return map
+  }, [aiTriage])
+  const triageFor = (finding: Finding) => triageByFinding.get(finding.id) ?? triageByFinding.get(finding.dedupKey)
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase()
     return findings.filter((finding) => (!needle || `${finding.title} ${finding.description} ${finding.cwe}`.toLowerCase().includes(needle)) && (severity === 'all' || finding.severity === severity) && matchesKindFilter(finding, kindFilter))
@@ -46,9 +58,33 @@ export function FindingExplorer({
   return <Card title="Analysis findings" titleId={headingId} titleTabIndex={headingId ? -1 : undefined} titleClassName={headingId ? 'scroll-mt-6 rounded-sm focus:outline-none focus:ring-2 focus:ring-brand/60' : undefined} actions={<Pill className="tabular-nums">{findings.length.toLocaleString()} findings</Pill>} bodyClass="p-0">
     {findings.length === 0 ? <div className="p-5"><EmptyState icon={Search} title="No analysis findings" hint="This analysis did not produce publishable findings." /></div> : <>
       <div className="grid gap-3 border-b border-border p-4 md:grid-cols-[1fr_10rem_12rem]"><label className="relative"><span className="sr-only">Search findings</span><Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-subtlefg" aria-hidden="true" /><Input className="pl-9" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search title, description, or CWE…" /></label><Select value={severity} onValueChange={setSeverity} ariaLabel="Filter findings by severity" options={[{ value: 'all', label: 'All severities' }, ...['critical', 'high', 'medium', 'low', 'info', 'unknown'].map((value) => ({ value, label: value }))]} /><Select value={kindFilter} onValueChange={(value) => setKindFilter(value as FindingKindFilter)} ariaLabel="Filter findings by kind" options={[{ value: 'all', label: 'All kinds' }, ...ratedFindingDimensionValues.map((dimension) => ({ value: `dimension:${dimension}`, label: ratedFindingDimensionLabel(dimension) })), ...kinds.map((value) => ({ value: `kind:${value}`, label: value || 'Legacy security kind' }))]} /></div>
-      <div className="grid min-h-64 md:grid-cols-[minmax(0,1fr)_22rem]"><div className="max-h-[34rem] overflow-y-auto divide-y divide-border">{visible.length === 0 ? <p className="p-5 text-sm text-mutedfg">No findings match these filters.</p> : <>{rendered.map((finding) => <button key={findingKey(finding)} type="button" onClick={() => setSelected(finding)} aria-pressed={selected !== null && findingKey(selected) === findingKey(finding)} className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-elevated/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand/60 aria-pressed:bg-brand/5"><SevBadge sev={finding.severity} /><div className="min-w-0 flex-1"><div className="text-sm font-medium text-foreground">{finding.title}</div><div className="mt-1 flex flex-wrap gap-2 text-xs text-mutedfg"><span>{finding.kind}</span>{finding.cwe && <span>{finding.cwe}</span>}<span className="capitalize">{finding.status}</span></div></div></button>)}{shown < visible.length && <div className="p-3"><button type="button" onClick={() => setShown((count) => Math.min(count + pageSize, visible.length))} className="w-full rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground hover:bg-elevated/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60">Load more findings</button></div>}</>}</div><aside className="border-t border-border bg-bg p-5 md:border-l md:border-t-0" aria-label="Finding details">{selected ? <div><div className="flex flex-wrap items-center gap-2"><SevBadge sev={selected.severity} /><Pill>{selected.kind}</Pill>{selected.cwe && <Pill>{selected.cwe}</Pill>}</div><h3 className="mt-4 font-semibold">{selected.title}</h3><p className="mt-3 whitespace-pre-wrap text-sm leading-relaxed text-mutedfg">{selected.description || 'No additional description was supplied.'}</p><dl className="mt-5 grid grid-cols-2 gap-3 text-xs"><div><dt className="text-subtlefg">Status</dt><dd className="mt-1 capitalize text-foreground">{selected.status}</dd></div><div><dt className="text-subtlefg">Priority</dt><dd className="mt-1 tabular-nums text-foreground">P{selected.priority || '—'}</dd></div><div><dt className="text-subtlefg">Scope</dt><dd className="mt-1 capitalize text-foreground">{selected.scope || 'Unspecified'}</dd></div><div><dt className="text-subtlefg">Reachability</dt><dd className="mt-1 capitalize text-foreground">{selected.reachability || 'Unknown'}</dd></div></dl></div> : <div className="flex h-full min-h-40 items-center justify-center text-center text-sm text-mutedfg">Select a finding to inspect its evidence and status.</div>}</aside></div>
+      <div className="grid min-h-64 md:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="max-h-[34rem] divide-y divide-border overflow-y-auto">
+          {visible.length === 0 ? <p className="p-5 text-sm text-mutedfg">No findings match these filters.</p> : <>
+            {rendered.map((finding) => {
+              const triage = triageFor(finding)
+              return <button key={findingKey(finding)} type="button" onClick={() => setSelected(finding)} aria-pressed={selected !== null && findingKey(selected) === findingKey(finding)} className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-elevated/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand/60 aria-pressed:bg-brand/5">
+                <SevBadge sev={finding.severity} />
+                <div className="min-w-0 flex-1"><div className="text-sm font-medium text-foreground">{finding.title}</div><div className="mt-1 flex flex-wrap gap-2 text-xs text-mutedfg"><span>{finding.kind}</span>{finding.cwe && <span>{finding.cwe}</span>}<span className="capitalize">{finding.status}</span></div>{triage && <div className="mt-2"><AITriageBadges triage={triage} /></div>}</div>
+              </button>
+            })}
+            {shown < visible.length && <div className="p-3"><button type="button" onClick={() => setShown((count) => Math.min(count + pageSize, visible.length))} className="w-full rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground hover:bg-elevated/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60">Load more findings</button></div>}
+          </>}
+        </div>
+        <aside className="border-t border-border bg-bg p-5 md:border-l md:border-t-0" aria-label="Finding details">
+          {selected ? <div><div className="flex flex-wrap items-center gap-2"><SevBadge sev={selected.severity} /><Pill>{selected.kind}</Pill>{selected.cwe && <Pill>{selected.cwe}</Pill>}</div>{triageFor(selected) && <div className="mt-3"><AITriageBadges triage={triageFor(selected)!} /></div>}<h3 className="mt-4 font-semibold">{selected.title}</h3><p className="mt-3 whitespace-pre-wrap text-sm leading-relaxed text-mutedfg">{selected.description || 'No additional description was supplied.'}</p>{triageFor(selected) && <AITriageDetails triage={triageFor(selected)!} />}<dl className="mt-5 grid grid-cols-2 gap-3 text-xs"><div><dt className="text-subtlefg">Status</dt><dd className="mt-1 capitalize text-foreground">{selected.status}</dd></div><div><dt className="text-subtlefg">Priority</dt><dd className="mt-1 tabular-nums text-foreground">P{selected.priority || '—'}</dd></div><div><dt className="text-subtlefg">Scope</dt><dd className="mt-1 capitalize text-foreground">{selected.scope || 'Unspecified'}</dd></div><div><dt className="text-subtlefg">Reachability</dt><dd className="mt-1 capitalize text-foreground">{selected.reachability || 'Unknown'}</dd></div></dl></div> : <div className="flex h-full min-h-40 items-center justify-center text-center text-sm text-mutedfg">Select a finding to inspect its evidence and status.</div>}
+        </aside>
+      </div>
     </>}
   </Card>
+}
+
+function AITriageDetails({ triage }: { triage: AITriage }) {
+  return <dl className="mt-4 grid grid-cols-1 gap-2 rounded-lg border border-border bg-card p-3 text-xs">
+    <div><dt className="text-subtlefg">Proposer</dt><dd className="mt-0.5 text-foreground">{triage.proposerModel} · {triage.verdict} · {triage.confidence}%</dd></div>
+    <div><dt className="text-subtlefg">Verifier</dt><dd className="mt-0.5 text-foreground">{triage.verifierModel ? `${triage.verifierModel} · ${triage.verifierVerdict || '—'} · ${triage.verifierConfidence}%` : 'Not attached'}</dd></div>
+    <div><dt className="text-subtlefg">Policy</dt><dd className="mt-0.5 text-foreground">{triage.policyVersion || '—'} · {(triage.policyReason || '—').replaceAll('_', ' ')}</dd></div>
+  </dl>
 }
 
 function dimensionFilter(dimension: RatedFindingDimension | null): FindingKindFilter {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,8 @@
 import type {
   AgentDecision,
+  AITriage,
+  AITriageReview,
+  AITriageReviewFilter,
   AgentReadiness,
   AgentPlan,
   AgentMessage,
@@ -672,6 +675,7 @@ function mapScanResult(r: any): ScanResult {
       components: l.components ?? [],
     })),
     findings: (r.findings ?? []).map(mapFinding),
+    aiTriage: (r.ai_triage ?? []).map(mapAITriage),
     toolVersions: r.tool_versions ?? {},
     vulnDBSnapshot: r.vuln_db_snapshot ?? '',
     completeness: {
@@ -713,6 +717,46 @@ function mapScanResult(r: any): ScanResult {
     },
     codeQuality: r.code_quality ? mapCodeQualityReport(r.code_quality) : undefined,
     debugEvents: (r.debug_events ?? []).map(mapScanDebugEvent),
+  }
+}
+
+function mapAITriage(r: any): AITriage {
+  return {
+    findingId: r.finding_id ?? '',
+    dedupKey: r.dedup_key ?? '',
+    verdict: r.verdict ?? '',
+    driver: r.driver ?? '',
+    confidence: r.confidence ?? 0,
+    suspectedFP: r.suspected_fp ?? false,
+    proposerModel: r.proposer_model ?? '',
+    verifierModel: r.verifier_model ?? '',
+    promptVersion: r.prompt_version ?? '',
+    policyVersion: r.policy_version ?? '',
+    policyReason: r.policy_reason ?? '',
+    shadow: r.shadow ?? false,
+    wouldGateExempt: r.would_gate_exempt ?? false,
+    gateExempt: r.gate_exempt ?? false,
+    reviewRequired: r.review_required ?? false,
+    verified: r.verified ?? false,
+    verifierVerdict: r.verifier_verdict ?? '',
+    verifierDriver: r.verifier_driver ?? '',
+    verifierConfidence: r.verifier_confidence ?? 0,
+  }
+}
+
+function mapAITriageReview(r: any): AITriageReview {
+  return {
+    id: r.id ?? '', tenantId: r.tenant_id ?? '', engagementId: r.engagement_id ?? '', projectId: r.project_id ?? '',
+    findingId: r.finding_id ?? '', dedupKey: r.dedup_key ?? '', title: r.title ?? '', severity: r.severity ?? 'unknown',
+    cwe: r.cwe ?? '', owner: r.owner ?? '', state: r.state ?? 'pending', verdict: r.verdict ?? '', driver: r.driver ?? '',
+    confidence: r.confidence ?? 0, suspectedFP: r.suspected_fp ?? false, proposerModel: r.proposer_model ?? '',
+    verifierModel: r.verifier_model ?? '', promptVersion: r.prompt_version ?? '', verified: r.verified ?? false, verifierVerdict: r.verifier_verdict ?? '',
+    verifierDriver: r.verifier_driver ?? '', verifierConfidence: r.verifier_confidence ?? 0,
+    policyVersion: r.policy_version ?? '', policyReason: r.policy_reason ?? '', shadow: r.shadow ?? false,
+    wouldGateExempt: r.would_gate_exempt ?? false, gateExempt: r.gate_exempt ?? false,
+    reviewRequired: r.review_required ?? false, evidenceRef: r.evidence_ref ?? '', decidedBy: r.decided_by ?? '',
+    decisionRationale: r.decision_rationale ?? '', createdAt: r.created_at ?? '', updatedAt: r.updated_at ?? '',
+    decidedAt: r.decided_at ?? null, version: r.version ?? 1,
   }
 }
 
@@ -1363,6 +1407,28 @@ export const api = {
       throw e
     }
   },
+
+  aiTriageReviews: async (filter: AITriageReviewFilter = {}): Promise<AITriageReview[]> => {
+    const q = new URLSearchParams()
+    if (filter.severity) q.set('severity', filter.severity)
+    if (filter.cwe) q.set('cwe', filter.cwe)
+    if (filter.project) q.set('project', filter.project)
+    if (filter.state) q.set('state', filter.state)
+    const encoded = q.toString()
+    const suffix = encoded ? `?${encoded}` : ''
+    const r = await req(`/ai-triage/reviews${suffix}`)
+    return (r?.reviews ?? []).map(mapAITriageReview)
+  },
+
+  decideAITriageReview: async (reviewId: string, decision: 'accept' | 'reject', rationale: string, version: number): Promise<AITriageReview> =>
+    mapAITriageReview(await req(`/ai-triage/reviews/${encodeURIComponent(reviewId)}/decision`, {
+      method: 'POST', body: JSON.stringify({ decision, rationale, version }),
+    })),
+
+  claimAITriageReview: async (reviewId: string, version: number): Promise<AITriageReview> =>
+    mapAITriageReview(await req(`/ai-triage/reviews/${encodeURIComponent(reviewId)}/claim`, {
+      method: 'POST', body: JSON.stringify({ version }),
+    })),
 
   verifyJudgment: async (
     engagementId: string,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -308,6 +308,7 @@ export interface ScanResult {
   vulnerabilities: Vulnerability[]
   licenses: LicenseFinding[]
   findings: Finding[]
+  aiTriage?: AITriage[]
   toolVersions: Record<string, string>
   vulnDBSnapshot: string
   completeness: Completeness
@@ -316,6 +317,75 @@ export interface ScanResult {
   findingQuality: FindingQuality
   codeQuality?: CodeQualityReport
   debugEvents: ScanDebugEvent[]
+}
+
+export interface AITriage {
+  findingId: string
+  dedupKey: string
+  verdict: string
+  driver: string
+  confidence: number
+  suspectedFP: boolean
+  proposerModel: string
+  verifierModel: string
+  promptVersion: string
+  policyVersion: string
+  policyReason: string
+  shadow: boolean
+  wouldGateExempt: boolean
+  gateExempt: boolean
+  reviewRequired: boolean
+  verified: boolean
+  verifierVerdict: string
+  verifierDriver: string
+  verifierConfidence: number
+}
+
+export type AITriageReviewState = 'pending' | 'accepted' | 'rejected'
+
+export interface AITriageReview {
+  id: string
+  tenantId: string
+  engagementId: string
+  projectId: string
+  findingId: string
+  dedupKey: string
+  title: string
+  severity: Severity
+  cwe: string
+  owner: string
+  state: AITriageReviewState
+  verdict: string
+  driver: string
+  confidence: number
+  suspectedFP: boolean
+  proposerModel: string
+  verifierModel: string
+  promptVersion: string
+  verified: boolean
+  verifierVerdict: string
+  verifierDriver: string
+  verifierConfidence: number
+  policyVersion: string
+  policyReason: string
+  shadow: boolean
+  wouldGateExempt: boolean
+  gateExempt: boolean
+  reviewRequired: boolean
+  evidenceRef: string
+  decidedBy: string
+  decisionRationale: string
+  createdAt: string
+  updatedAt: string
+  decidedAt: string | null
+  version: number
+}
+
+export interface AITriageReviewFilter {
+  severity?: Severity
+  cwe?: string
+  project?: string
+  state?: AITriageReviewState
 }
 
 export type ScanMode = 'full' | 'vulnerabilities' | 'licenses'

--- a/web/src/pages/AITriageReviews.test.tsx
+++ b/web/src/pages/AITriageReviews.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { api } from '../lib/api'
+import type { AITriageReview } from '../lib/types'
+import { AITriageReviews } from './AITriageReviews'
+
+vi.mock('../lib/api', () => ({
+  ApiError: class ApiError extends Error { constructor(public status: number, message: string) { super(message) } },
+  api: { aiTriageReviews: vi.fn(), decideAITriageReview: vi.fn(), claimAITriageReview: vi.fn(), listProjects: vi.fn(), me: vi.fn() },
+}))
+
+const review: AITriageReview = {
+  id: 'r1', tenantId: 'default', engagementId: 'e1', projectId: 'p1', findingId: 'f1', dedupKey: 'sast:key',
+  title: 'SQL injection', severity: 'high', cwe: 'CWE-89', owner: 'reviewer', state: 'pending', verdict: 'refuted',
+  driver: 'sanitizer', confidence: 91, suspectedFP: true, proposerModel: 'model-a', verifierModel: 'model-b',
+  promptVersion: 'fp-triage-v1', shadow: false, wouldGateExempt: false,
+  verified: true, verifierVerdict: 'refuted', verifierDriver: 'sanitizer', verifierConfidence: 90,
+  policyVersion: 'fp-gate-v3', policyReason: 'severity_requires_human', gateExempt: false, reviewRequired: true,
+  evidenceRef: 'ev1', decidedBy: '', decisionRationale: '', createdAt: '2026-08-09T00:00:00Z',
+  updatedAt: '2026-08-09T00:00:00Z', decidedAt: null, version: 1,
+}
+
+function renderPage() { return render(<MemoryRouter><AITriageReviews /></MemoryRouter>) }
+
+describe('AITriageReviews', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.aiTriageReviews).mockResolvedValue([review])
+    vi.mocked(api.listProjects).mockResolvedValue([{ id: 'p1', name: 'Synapse', key: 'synapse' } as any])
+    vi.mocked(api.me).mockResolvedValue({ id: 'reviewer', name: 'Reviewer', role: 'reviewer' })
+    vi.mocked(api.decideAITriageReview).mockResolvedValue({ ...review, state: 'rejected', decidedBy: 'reviewer', version: 2 })
+    vi.mocked(api.claimAITriageReview).mockResolvedValue({ ...review, owner: 'reviewer', version: 2 })
+  })
+
+  it('shows model, policy, evidence, and all applicable triage badges', async () => {
+    renderPage()
+    expect(await screen.findByText('SQL injection')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /SQL injection/i }))
+    expect(screen.getByText(/model-a · refuted · 91%/)).toBeInTheDocument()
+    expect(screen.getByText('fp-gate-v3')).toBeInTheDocument()
+    expect(screen.getByText('ev1')).toBeInTheDocument()
+    expect(screen.getAllByText('Suspected FP').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Verified').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Review required').length).toBeGreaterThan(0)
+  })
+
+  it('requires rationale and sends a rejection back to the gate workflow', async () => {
+    renderPage(); await screen.findByText('SQL injection')
+    fireEvent.click(screen.getByRole('button', { name: /SQL injection/i }))
+    const reject = screen.getByRole('button', { name: /Reject & gate/i })
+    expect(reject).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText(/Why should the AI recommendation/), { target: { value: 'The source reaches the sink' } })
+    fireEvent.click(reject)
+    await waitFor(() => expect(api.decideAITriageReview).toHaveBeenCalledWith('r1', 'reject', 'The source reaches the sink', 1))
+  })
+
+  it('does not allow an authorized reviewer to take over another owner', async () => {
+    vi.mocked(api.aiTriageReviews).mockResolvedValue([{ ...review, owner: 'alice' }])
+    renderPage(); await screen.findByText('SQL injection')
+    fireEvent.click(screen.getByRole('button', { name: /SQL injection/i }))
+    expect(screen.queryByRole('button', { name: /Claim review/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Accept FP/i })).toBeDisabled()
+  })
+})

--- a/web/src/pages/AITriageReviews.tsx
+++ b/web/src/pages/AITriageReviews.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Check, ExternalLink, ShieldQuestion, X } from 'lucide-react'
+import { AITriageBadges } from '../components/AITriageBadges'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Select, SevBadge, Spinner } from '../components/ui'
+import { api, ApiError } from '../lib/api'
+import type { AITriageReview, AITriageReviewFilter, AITriageReviewState, CurrentUser, Project, Severity } from '../lib/types'
+
+const severities: Severity[] = ['critical', 'high', 'medium', 'low', 'info', 'unknown']
+const states: AITriageReviewState[] = ['pending', 'accepted', 'rejected']
+
+export function AITriageReviews() {
+  const [params, setParams] = useSearchParams()
+  const [reviews, setReviews] = useState<AITriageReview[] | null>(null)
+  const [projects, setProjects] = useState<Project[]>([])
+  const [me, setMe] = useState<CurrentUser | null>(null)
+  const [error, setError] = useState('')
+  const [refresh, setRefresh] = useState(0)
+  const [selected, setSelected] = useState<AITriageReview | null>(null)
+
+  const filter = useMemo<AITriageReviewFilter>(() => ({
+    severity: (params.get('severity') as Severity) || undefined,
+    cwe: params.get('cwe') || undefined,
+    project: params.get('project') || undefined,
+    state: (params.get('state') as AITriageReviewState) || 'pending',
+  }), [params])
+
+  useEffect(() => {
+    let active = true
+    setReviews(null)
+    setError('')
+    Promise.all([api.aiTriageReviews(filter), api.listProjects().catch(() => []), api.me().catch(() => null)])
+      .then(([items, projectList, currentUser]) => {
+        if (!active) return
+        setReviews(items); setProjects(projectList); setMe(currentUser)
+        setSelected((current) => current ? items.find((item) => item.id === current.id) ?? null : null)
+      })
+      .catch((e) => { if (active) setError(e instanceof ApiError ? e.message : 'Failed to load AI-triage reviews') })
+    return () => { active = false }
+  }, [filter, refresh])
+
+  function patch(key: string, value: string) {
+    const next = new URLSearchParams(params)
+    if (value && !(key === 'state' && value === 'pending')) next.set(key, value)
+    else next.delete(key)
+    setParams(next, { replace: true })
+  }
+
+  const projectByID = useMemo(() => new Map(projects.map((p) => [p.id, p])), [projects])
+  const canReview = me?.role === 'admin' || me?.role === 'reviewer'
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">AI triage reviews</h1>
+        <p className="mt-1 text-sm text-mutedfg">Human decisions for false-positive recommendations that policy would not let AI exempt.</p>
+      </div>
+
+      <div className="grid gap-3 rounded-xl border border-border bg-card p-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Select value={filter.severity ?? 'all'} onValueChange={(v) => patch('severity', v === 'all' ? '' : v)} ariaLabel="Filter reviews by severity"
+          options={[{ value: 'all', label: 'All severities' }, ...severities.map((v) => ({ value: v, label: v }))]} />
+        <Input aria-label="Filter reviews by CWE" value={filter.cwe ?? ''} onChange={(e) => patch('cwe', e.target.value)} placeholder="CWE, e.g. CWE-89" />
+        <Select value={filter.project ?? 'all'} onValueChange={(v) => patch('project', v === 'all' ? '' : v)} ariaLabel="Filter reviews by project"
+          options={[{ value: 'all', label: 'All projects' }, ...projects.map((p) => ({ value: p.id, label: p.name }))]} />
+        <Select value={filter.state ?? 'pending'} onValueChange={(v) => patch('state', v)} ariaLabel="Filter reviews by state"
+          options={states.map((v) => ({ value: v, label: v[0].toUpperCase() + v.slice(1) }))} />
+      </div>
+
+      {error ? <div className="space-y-3"><ErrorState message={error} /><Button variant="secondary" onClick={() => setRefresh((v) => v + 1)}>Retry</Button></div>
+        : reviews === null ? <Spinner label="Loading AI-triage reviews…" />
+          : reviews.length === 0 ? <EmptyState icon={ShieldQuestion} title="No reviews match these filters" hint="Review-required findings appear here after an AI-triaged scan is sealed." />
+            : <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_25rem]">
+              <ul className="space-y-3" role="list">
+                {reviews.map((review) => {
+                  const project = projectByID.get(review.projectId)
+                  return <li key={review.id}>
+                    <button type="button" onClick={() => setSelected(review)} aria-pressed={selected?.id === review.id}
+                      className="w-full rounded-xl text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60">
+                      <Card bodyClass="p-4" className="transition-colors hover:border-borderstrong aria-pressed:border-brand">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-0 flex-1">
+                            <div className="flex flex-wrap items-center gap-2"><SevBadge sev={review.severity} /><Pill className="capitalize">{review.state}</Pill>{review.cwe && <Pill>{review.cwe}</Pill>}</div>
+                            <h2 className="mt-2 font-semibold text-foreground">{review.title}</h2>
+                            <div className="mt-2"><AITriageBadges triage={review} /></div>
+                          </div>
+                          <div className="text-right text-xs text-mutedfg">
+                            <div>{project?.name ?? (review.projectId ? review.projectId : 'Engagement')}</div>
+                            <div className="mt-1">Owner: <span className="text-foreground">{review.owner || 'Unassigned'}</span></div>
+                          </div>
+                        </div>
+                      </Card>
+                    </button>
+                  </li>
+                })}
+              </ul>
+              {selected && <ReviewPanel review={selected} project={projectByID.get(selected.projectId)} canReview={canReview} reviewerId={me?.id ?? ''}
+                onClosed={() => setSelected(null)} onDecided={() => { setSelected(null); setRefresh((v) => v + 1) }} />}
+            </div>}
+    </div>
+  )
+}
+
+function ReviewPanel({ review, project, canReview, reviewerId, onClosed, onDecided }: { review: AITriageReview; project?: Project; canReview: boolean; reviewerId: string; onClosed: () => void; onDecided: () => void }) {
+  const [rationale, setRationale] = useState('')
+  const [busy, setBusy] = useState<'accept' | 'reject' | 'claim' | ''>('')
+  const [error, setError] = useState('')
+  const pending = review.state === 'pending'
+
+  async function claim() {
+    setBusy('claim'); setError('')
+    try { await api.claimAITriageReview(review.id, review.version); onDecided() }
+    catch (e) { setError(e instanceof ApiError ? e.message : 'Claim failed') }
+    finally { setBusy('') }
+  }
+
+  async function decide(decision: 'accept' | 'reject') {
+    if (rationale.trim().length < 3) { setError('A rationale of at least 3 characters is required.'); return }
+    setBusy(decision); setError('')
+    try { await api.decideAITriageReview(review.id, decision, rationale.trim(), review.version); onDecided() }
+    catch (e) { setError(e instanceof ApiError ? e.message : 'Decision failed') }
+    finally { setBusy('') }
+  }
+
+  const sourceLink = project ? `/code-quality/projects/${encodeURIComponent(project.key)}/analysis` : `/engagements/${encodeURIComponent(review.engagementId)}`
+  return <aside className="h-fit rounded-xl border border-border bg-bg p-5" aria-label="AI triage review details">
+    <div className="flex items-start justify-between gap-2"><div><SevBadge sev={review.severity} /><h2 className="mt-3 text-lg font-semibold">{review.title}</h2></div>
+      <button type="button" onClick={onClosed} aria-label="Close review details" className="rounded-md p-1 text-mutedfg hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"><X className="size-4" /></button></div>
+    <AITriageBadges triage={review} />
+    <dl className="mt-5 grid grid-cols-2 gap-3 text-xs">
+      <Meta label="Proposer" value={`${review.proposerModel} · ${review.verdict} · ${review.confidence}%`} />
+      <Meta label="Verifier" value={review.verifierModel ? `${review.verifierModel} · ${review.verifierVerdict || '—'} · ${review.verifierConfidence}%` : 'Not attached'} />
+      <Meta label="Prompt" value={review.promptVersion} />
+      <Meta label="Policy" value={review.policyVersion} />
+      <Meta label="Policy reason" value={review.policyReason.replaceAll('_', ' ')} />
+      <Meta label="Rollout mode" value={review.shadow ? (review.wouldGateExempt ? 'Shadow · would exempt' : 'Shadow · held') : 'Enforce · held'} />
+      <Meta label="Evidence" value={review.evidenceRef} mono />
+      <Meta label="Owner" value={review.owner || 'Unassigned'} />
+    </dl>
+    <Link to={sourceLink} className="mt-4 inline-flex items-center gap-1.5 text-xs font-medium text-branddim hover:underline">Open finding context <ExternalLink className="size-3" /></Link>
+    {pending ? <div className="mt-5 border-t border-border pt-4">
+      {canReview && <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-border bg-card p-3 text-xs"><span>{review.owner === reviewerId ? 'Owned by you' : review.owner ? `Owned by ${review.owner}` : 'This review is unassigned.'}</span>{!review.owner && <Button variant="secondary" className="px-2.5 py-1.5 text-xs" loading={busy === 'claim'} disabled={Boolean(busy)} onClick={claim}>Claim review</Button>}</div>}
+      <Field label="Mandatory rationale"><textarea value={rationale} onChange={(e) => setRationale(e.target.value)} rows={4} disabled={Boolean(busy) || review.owner !== reviewerId} placeholder="Why should the AI recommendation be accepted or rejected?"
+        className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60" /></Field>
+      {!canReview && <p className="mt-2 text-xs text-medium">Reviewer or admin permission is required to decide.</p>}
+      {canReview && review.owner !== reviewerId && <p className="mt-2 text-xs text-medium">Claim this unassigned review before deciding. Reviews owned by another reviewer cannot be taken over.</p>}
+      {error && <p role="alert" className="mt-2 text-xs text-critical">{error}</p>}
+      <div className="mt-4 flex flex-wrap gap-2"><Button loading={busy === 'accept'} disabled={!canReview || review.owner !== reviewerId || Boolean(busy) || rationale.trim().length < 3} onClick={() => decide('accept')}><Check className="size-4" />Accept FP</Button>
+        <Button variant="danger" loading={busy === 'reject'} disabled={!canReview || review.owner !== reviewerId || Boolean(busy) || rationale.trim().length < 3} onClick={() => decide('reject')}><X className="size-4" />Reject & gate</Button></div>
+      <p className="mt-3 text-xs text-subtlefg">Accept marks the finding false-positive. Reject reopens it so subsequent gates count it.</p>
+    </div> : <div className="mt-5 rounded-lg border border-border bg-card p-3 text-sm"><div className="font-medium capitalize">{review.state} by {review.decidedBy}</div><p className="mt-1 whitespace-pre-wrap text-mutedfg">{review.decisionRationale}</p></div>}
+  </aside>
+}
+
+function Meta({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return <div className="min-w-0"><dt className="text-subtlefg">{label}</dt><dd className={`${mono ? 'break-all font-mono' : ''} mt-1 text-foreground`}>{value || '—'}</dd></div>
+}

--- a/web/src/pages/EngagementDetail.tsx
+++ b/web/src/pages/EngagementDetail.tsx
@@ -56,6 +56,7 @@ import {
   Spinner,
 } from '../components/ui'
 import { VirtualTable, type Column } from '../components/VirtualTable'
+import { AITriageBadges } from '../components/AITriageBadges'
 import { AgentTab } from './AgentTab'
 import { ThreatModelTab } from './ThreatModelTab'
 import { CodeQualityTab } from './CodeQualityTab'
@@ -1788,6 +1789,14 @@ function FindingsTab({
     for (const v of scan?.vulnerabilities ?? []) m.set(vulnKey(v), v)
     return m
   }, [scan])
+  const triageByKey = useMemo(() => {
+    const map = new Map<string, NonNullable<ScanResult['aiTriage']>[number]>()
+    for (const item of scan?.aiTriage ?? []) {
+      if (item.findingId) map.set(item.findingId, item)
+      if (item.dedupKey) map.set(item.dedupKey, item)
+    }
+    return map
+  }, [scan])
 
   if (findings === null) return <Spinner label="Loading findings…" />
 
@@ -1873,6 +1882,7 @@ function FindingsTab({
           <tbody>
             {rows.map((f) => {
               const v = vulnByKey.get(f.dedupKey)
+              const triage = triageByKey.get(f.id) ?? triageByKey.get(f.dedupKey)
               const isOpen = expanded.has(f.id)
               return (
                 <Fragment key={f.id}>
@@ -1907,6 +1917,7 @@ function FindingsTab({
                         {f.kev && <KevBadge />}
                         {f.kind && f.kind !== 'sca' && <KindBadge kind={f.kind} />}
                         {f.cwe && <span className="font-mono text-[11px] tabular-nums text-subtlefg">{f.cwe}</span>}
+                        {triage && <AITriageBadges triage={triage} />}
                         {v && !v.direct && v.path.length >= 2 && (
                           <span className="text-xs text-subtlefg" title={v.path.map(shortPkg).join(' › ')}>
                             via {shortPkg(v.path[v.path.length - 2])}

--- a/web/src/pages/ProjectAnalysisPage.tsx
+++ b/web/src/pages/ProjectAnalysisPage.tsx
@@ -182,7 +182,7 @@ function LatestAnalysisView({
           </p>
         )}
       </Card>
-      <FindingExplorer findings={scan.findings} headingId={projectAnalysisLandmarks.findings} initialDimension={dimension} dimensionNavigationKey={navigationKey} />
+      <FindingExplorer findings={scan.findings} aiTriage={scan.aiTriage} headingId={projectAnalysisLandmarks.findings} initialDimension={dimension} dimensionNavigationKey={navigationKey} />
       <CodeQualityReportView
         report={scan.codeQuality}
         empty={<Card title="Code quality"><EmptyState icon={ShieldAlert} title="Code quality unavailable" hint="This completed scan did not produce a code-quality report." /></Card>}


### PR DESCRIPTION
Closes #389
Parent epic: #387

## Summary

- materialize every `review_required` AI-triage result into a durable, tenant-scoped review queue after scan evidence is sealed
- add list, claim, accept, and reject APIs with RBAC, optimistic concurrency, ownership, separation of duties, and evidence-linked audit metadata
- persist policy/prompt/model identity and P1.1 shadow-rollout fields; preserve review owner and advance version on rescans
- add the review queue UI, filters, decision rationale, AI-triage badges, and full DTO mapping without hiding findings from existing views or reports
- add migration 0067 with composite tenant constraints and forced RLS, plus migration assertions

## Safety properties

- AI cannot approve its own recommendation; machine/model actors cannot decide
- accept is persisted and audited before a finding can be marked false-positive
- reject moves the finding back to gating first
- missing evidence, audit failures, store failures, stale versions, and owner mismatches fail closed
- this PR does not change the deterministic P0 gate policy

## Integration notes

- rebased onto latest `main`, including P1.1 (#477) and P1.3 (#479)
- the current frontend does not include `@tanstack/react-query` or `docs/04-ui-ux.md`; the queue follows the repository's existing API/loading patterns and design-system tokens

## Verification

- `go build ./...`
- `go vet ./...`
- all Go package tests across `cmd` and `internal`
- focused `go test -race` for AI review, SCA, and HTTP paths
- `golangci-lint v2.12.2 run` — 0 issues
- `pnpm typecheck`
- `pnpm test` — 35 files / 285 tests
- `pnpm build`
- `git diff --check`

The PostgreSQL migration integration test runs when `SYNAPSE_TEST_DB_DSN` is available; without it, the test compiles and skips locally.