### PR TITLE
ci: run Postgres integration tests fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,24 @@ jobs:
   backend:
     name: Backend (Go)
     runs-on: ubuntu-latest
+    env:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${{ github.run_id }}
+      POSTGRES_DB: synapse
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ${{ github.run_id }}
+          POSTGRES_DB: synapse
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d synapse"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v7
 
@@ -39,6 +57,16 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Configure Postgres integration database
+        run: echo "SYNAPSE_TEST_DB_DSN=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}?sslmode=disable" >> "$GITHUB_ENV"
+
+      - name: Require Postgres integration database
+        run: |
+          if [ -z "${SYNAPSE_TEST_DB_DSN:-}" ]; then
+            echo "SYNAPSE_TEST_DB_DSN is required in CI; refusing to silently skip Postgres integration tests"
+            exit 1
+          fi
+
       - name: Build
         run: go build ./...
 
@@ -46,7 +74,10 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test ./...
+        run: go test -count=1 ./...
+
+      - name: Test Postgres suite again on the same database
+        run: go test -count=1 ./internal/infrastructure/persistence/postgres
 
       - name: Build (CGO disabled – distroless parity)
         run: CGO_ENABLED=0 go build ./cmd/...

--- a/internal/infrastructure/persistence/postgres/advisory_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/advisory_repo_test.go
@@ -24,11 +24,16 @@ func TestAdvisoryRepository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer pool.Close()
+	// t.Cleanup is LIFO. Register Close first so fixture deletion runs while the pool is still usable.
+	t.Cleanup(pool.Close)
 
 	repo := NewAdvisoryRepository(pool)
 	id := "GHSA-" + randHex(t)
-	t.Cleanup(func() { _, _ = pool.Exec(ctx, "DELETE FROM advisories WHERE id=$1", id) })
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(), "DELETE FROM advisories WHERE id=$1", id); err != nil {
+			t.Errorf("cleanup advisory %s: %v", id, err)
+		}
+	})
 
 	a := advisory.Advisory{
 		ID: id, Aliases: []string{"CVE-2024-9"}, Summary: "rce", CVSSScore: 9.8,

--- a/internal/infrastructure/persistence/postgres/migration_0044_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0044_test.go
@@ -7,11 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pressly/goose/v3"
 
-	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
-	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/migrations"
 )
 
@@ -22,7 +19,8 @@ func TestMigration0044(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	// 1. Connect to DB and migrate DOWN to 43 to test 44 Up
+	// Start from the current schema so this test is safe to run against the same CI database as the
+	// rest of the integration suite. The cleanup below restores current HEAD again before returning.
 	if err := Migrate(ctx, dsn); err != nil {
 		t.Fatalf("initial migrate up: %v", err)
 	}
@@ -31,12 +29,19 @@ func TestMigration0044(t *testing.T) {
 	if err != nil {
 		t.Fatalf("goose open db: %v", err)
 	}
-	defer db.Close()
+	t.Cleanup(func() { _ = db.Close() })
 
 	goose.SetBaseFS(migrations.FS)
 	if err := goose.SetDialect("postgres"); err != nil {
 		t.Fatalf("goose set dialect: %v", err)
 	}
+	// A migration test must not leave the shared integration database pinned to an old version even
+	// when an assertion fails midway through the test.
+	t.Cleanup(func() {
+		if err := Migrate(context.Background(), dsn); err != nil {
+			t.Errorf("restore latest schema: %v", err)
+		}
+	})
 
 	if err := goose.DownTo(db, ".", 43); err != nil {
 		t.Fatalf("goose down to 43: %v", err)
@@ -46,23 +51,26 @@ func TestMigration0044(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 
 	eidString := uuid.New().String()
-	eid := shared.ID(eidString)
-	e, err := engagement.New(eid, "", "test", "", time.Now().UTC())
-	if err != nil {
-		t.Fatalf("new engagement: %v", err)
-	}
-	if err := NewEngagementRepository(pool).Create(ctx, e); err != nil {
-		t.Fatalf("insert engagement: %v", err)
+	// Seed the v43 schema directly. Using the current EngagementRepository here is invalid because
+	// repositories evolve with HEAD (for example project_id and business_asset_id were added after
+	// v43), while this test intentionally exercises a historical schema.
+	if _, err := pool.Exec(ctx, `INSERT INTO engagements (id, tenant_id, name, client, status, created_at, updated_at)
+		VALUES ($1, '', 'test', '', 'draft', $2, $2)`, eidString, time.Now().UTC()); err != nil {
+		t.Fatalf("insert v43 engagement fixture: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = pool.Exec(ctx, "DELETE FROM findings WHERE engagement_id=$1", eidString)
-		_, _ = pool.Exec(ctx, "DELETE FROM engagements WHERE id=$1", eidString)
+		if _, err := pool.Exec(context.Background(), "DELETE FROM findings WHERE engagement_id=$1", eidString); err != nil {
+			t.Errorf("cleanup findings: %v", err)
+		}
+		if _, err := pool.Exec(context.Background(), "DELETE FROM engagements WHERE id=$1", eidString); err != nil {
+			t.Errorf("cleanup engagement: %v", err)
+		}
 	})
 
-	// 2. Insert the fixture matrix (legacy rows without rule_key column since we are at v43)
+	// Insert the fixture matrix without rule_key, which does not exist at v43.
 	fixtures := []struct {
 		id       string
 		kind     string
@@ -98,12 +106,10 @@ func TestMigration0044(t *testing.T) {
 		}
 	}
 
-	// 3. Apply 0044 Up
 	if err := goose.UpTo(db, ".", 44); err != nil {
 		t.Fatalf("goose up to 44: %v", err)
 	}
 
-	// 4. Assert row states
 	for _, f := range fixtures {
 		var gotRule string
 		if err := pool.QueryRow(ctx, "SELECT rule_key FROM findings WHERE id=$1", f.id).Scan(&gotRule); err != nil {
@@ -115,30 +121,27 @@ func TestMigration0044(t *testing.T) {
 		}
 	}
 
-	// 5. Apply Down
 	if err := goose.DownTo(db, ".", 43); err != nil {
 		t.Fatalf("goose down to 43: %v", err)
 	}
 
-	// Assert rule_key is gone
-	var scanVal string
-	err = pool.QueryRow(ctx, "SELECT rule_key FROM findings WHERE id=$1", fixtures[0].id).Scan(&scanVal)
-	if err == nil {
+	// Assert the schema contract directly rather than depending on whether pgx reports an undefined
+	// column as PgError or wraps it in a PrepareError.
+	var ruleKeyExists bool
+	if err := pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_schema='public' AND table_name='findings' AND column_name='rule_key'
+	)`).Scan(&ruleKeyExists); err != nil {
+		t.Fatalf("inspect findings schema after down: %v", err)
+	}
+	if ruleKeyExists {
 		t.Error("rule_key column still exists after Down")
-	} else if pgErr, ok := err.(*pgconn.PgError); ok {
-		if pgErr.Code != "42703" { // undefined_column
-			t.Errorf("expected undefined_column error, got: %v", pgErr.Code)
-		}
-	} else {
-		t.Errorf("expected pgx error, got: %T %v", err, err)
 	}
 
-	// 6. Apply Up again
 	if err := goose.UpTo(db, ".", 44); err != nil {
 		t.Fatalf("goose up to 44 (second time): %v", err)
 	}
 
-	// Assert column exists and backfill is correct again
 	for _, f := range fixtures {
 		var gotRule string
 		if err := pool.QueryRow(ctx, "SELECT rule_key FROM findings WHERE id=$1", f.id).Scan(&gotRule); err != nil {

--- a/internal/infrastructure/persistence/postgres/migration_0056_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0056_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pressly/goose/v3"
 
 	"github.com/KKloudTarus/synapse-ce/migrations"
@@ -26,11 +25,18 @@ func TestMigration0056BackfillsOnlyCanonicalRelativePaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("goose open db: %v", err)
 	}
-	defer func() { _ = db.Close() }()
+	t.Cleanup(func() { _ = db.Close() })
 	goose.SetBaseFS(migrations.FS)
 	if err := goose.SetDialect("postgres"); err != nil {
 		t.Fatalf("goose set dialect: %v", err)
 	}
+	// Migration tests share the integration database with repository tests. Always restore current
+	// HEAD, including when an assertion fails after a historical DownTo.
+	t.Cleanup(func() {
+		if err := Migrate(context.Background(), dsn); err != nil {
+			t.Errorf("restore latest schema: %v", err)
+		}
+	})
 	if err := goose.DownTo(db, ".", 55); err != nil {
 		t.Fatalf("goose down to 55: %v", err)
 	}
@@ -38,7 +44,7 @@ func TestMigration0056BackfillsOnlyCanonicalRelativePaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 
 	tenantID, projectID := uuid.New().String(), uuid.New().String()
 	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1, 'migration-0056')`, tenantID); err != nil {
@@ -48,15 +54,35 @@ func TestMigration0056BackfillsOnlyCanonicalRelativePaths(t *testing.T) {
 		t.Fatalf("insert project: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = pool.Exec(ctx, "DELETE FROM projects WHERE id=$1", projectID)
-		_, _ = pool.Exec(ctx, "DELETE FROM tenants WHERE id=$1", tenantID)
+		cleanupCtx := context.Background()
+		if _, err := pool.Exec(cleanupCtx, "DELETE FROM project_hotspots WHERE project_id=$1", projectID); err != nil {
+			t.Errorf("cleanup project hotspots: %v", err)
+		}
+		if _, err := pool.Exec(cleanupCtx, "DELETE FROM project_issues WHERE project_id=$1", projectID); err != nil {
+			t.Errorf("cleanup project issues: %v", err)
+		}
+		if _, err := pool.Exec(cleanupCtx, "DELETE FROM projects WHERE id=$1", projectID); err != nil {
+			t.Errorf("cleanup project: %v", err)
+		}
+		if _, err := pool.Exec(cleanupCtx, "DELETE FROM tenants WHERE id=$1", tenantID); err != nil {
+			t.Errorf("cleanup tenant: %v", err)
+		}
 	})
 
 	paths := []struct {
-		path     string
-		location string
-		want     *string
-	}{{"src/main.go", "src/main.go:7", stringPtr("src/main.go")}, {"/etc/passwd", "/etc/passwd:7", nil}, {"./main.go", "./main.go:7", nil}, {"../main.go", "../main.go:7", nil}, {"src/stale.go", "src/current.go:7", nil}}
+		path        string
+		location    string
+		issueWant   *string
+		hotspotWant *string
+	}{
+		{"src/main.go", "src/main.go:7", stringPtr("src/main.go"), stringPtr("src/main.go")},
+		{"/etc/passwd", "/etc/passwd:7", nil, nil},
+		{"./main.go", "./main.go:7", nil, nil},
+		{"../main.go", "../main.go:7", nil, nil},
+		// project_issues has both file and location and therefore refuses a mismatch. Hotspots only had
+		// location before v56, so the same canonical location is sufficient evidence to backfill it.
+		{"src/stale.go", "src/current.go:7", nil, stringPtr("src/current.go")},
+	}
 	now := time.Now().UTC()
 	for index, fixture := range paths {
 		issueID, hotspotID := uuid.New().String(), uuid.New().String()
@@ -78,26 +104,40 @@ func TestMigration0056BackfillsOnlyCanonicalRelativePaths(t *testing.T) {
 	}
 	for index, fixture := range paths {
 		ids := splitFixtureIDs(fixture.path)
-		for _, query := range []struct {
+		queries := []struct {
 			table string
 			id    string
-		}{{"project_issues", ids[0]}, {"project_hotspots", ids[1]}} {
+			want  *string
+		}{
+			{"project_issues", ids[0], fixture.issueWant},
+			{"project_hotspots", ids[1], fixture.hotspotWant},
+		}
+		for _, query := range queries {
 			var got *string
 			if err := pool.QueryRow(ctx, "SELECT source_file FROM "+query.table+" WHERE id=$1", query.id).Scan(&got); err != nil {
 				t.Fatalf("query %s %d: %v", query.table, index, err)
 			}
-			if (got == nil) != (fixture.want == nil) || got != nil && *got != *fixture.want {
-				t.Errorf("%s fixture %d source_file=%v, want %v", query.table, index, got, fixture.want)
+			if (got == nil) != (query.want == nil) || got != nil && *got != *query.want {
+				t.Errorf("%s fixture %d source_file=%v, want %v", query.table, index, got, query.want)
 			}
 		}
 	}
 	if err := goose.DownTo(db, ".", 55); err != nil {
 		t.Fatalf("goose down to 55: %v", err)
 	}
-	var value *string
-	err = pool.QueryRow(ctx, "SELECT source_file FROM project_issues LIMIT 1").Scan(&value)
-	if pgErr, ok := err.(*pgconn.PgError); !ok || pgErr.Code != "42703" {
-		t.Fatalf("source_file exists after down: %T %v", err, err)
+	// Check schema state directly instead of depending on whether pgx reports an undefined column as
+	// PgError or wraps it in a PrepareError. The contract is simply that Down removed the columns.
+	for _, table := range []string{"project_issues", "project_hotspots"} {
+		var exists bool
+		if err := pool.QueryRow(ctx, `SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema='public' AND table_name=$1 AND column_name='source_file'
+		)`, table).Scan(&exists); err != nil {
+			t.Fatalf("inspect %s schema after down: %v", table, err)
+		}
+		if exists {
+			t.Errorf("source_file still exists on %s after Down", table)
+		}
 	}
 	if err := goose.UpTo(db, ".", 56); err != nil {
 		t.Fatalf("goose up to 56 again: %v", err)

--- a/internal/infrastructure/persistence/postgres/scan_job_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/scan_job_repo_test.go
@@ -22,7 +22,9 @@ func TestScanJobStorePersistsDebugEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer pool.Close()
+	// t.Cleanup is LIFO. Close must be registered before fixture cleanup so a second suite run sees
+	// the same database state as the first one did.
+	t.Cleanup(pool.Close)
 
 	store := NewScanJobStore(pool)
 	job := ports.ScanJob{
@@ -46,7 +48,11 @@ func TestScanJobStorePersistsDebugEvents(t *testing.T) {
 	if err := store.Save(ctx, job); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	t.Cleanup(func() { _, _ = pool.Exec(ctx, "DELETE FROM scan_jobs WHERE id=$1", job.ID) })
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(), "DELETE FROM scan_jobs WHERE id=$1", job.ID); err != nil {
+			t.Errorf("cleanup scan job %s: %v", job.ID, err)
+		}
+	})
 
 	got, err := store.GetJob(ctx, job.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary

* run `Backend (Go)` against PostgreSQL 17 with `SYNAPSE_TEST_DB_DSN` configured
* fail immediately when the DSN is missing instead of silently skipping database integration tests
* fix `TestMigration0044` by seeding the historical v43 schema directly rather than using the current repository API
* correct `TestMigration0056BackfillsOnlyCanonicalRelativePaths` expectations and assert rollback by schema state without modifying the shipped migration
* make advisory and scan-job fixtures clean up before their pools close
* rerun the Postgres package with `-count=1` on the same database so persistent-state leaks cannot hide behind a fresh DB or Go's test cache

## Validation

Validated from current main (249dd80) on the exact rebased head:

* `go build ./...`
* `go vet ./...`
* `go test -count=1 ./...` against PostgreSQL 17
* `go test -count=1 ./internal/infrastructure/persistence/postgres` immediately afterward on the same database
* `CGO_ENABLED=0 go build ./cmd/...`
* `golangci-lint`
* Windows build / vet / test
* frontend test / typecheck / build

All four CI jobs are green on the validated tree.

## Negative proof

The fail-closed paths were deliberately broken and run in Actions:

1. Removed only the DSN configuration step: `Backend (Go)` failed at `Require Postgres integration database` before tests could silently skip.
2. Removed only the Postgres service while keeping the DSN configured: build and vet passed, then the full test step failed when integration tests could not connect.
3. Restored the old advisory cleanup ordering so its fixture leaked: the first full suite passed, then the explicit same-database Postgres rerun failed `TestAdvisoryRepository` on the leaked row.

The live database run also exercises the append-only evidence/audit and RLS/tenant-isolation failure paths rather than skipping them.

Closes #478.
