### PR TITLE
Dashboard: add security operations analytics

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -36,6 +36,8 @@ tags:
   description: Built-in code-quality and security rule catalog
 - name: assets
   description: Business-level Asset Management and security posture
+- name: dashboard
+  description: Tenant-scoped security operations summaries
 
 paths:
   /healthz:
@@ -959,6 +961,26 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/dashboard/security-operations:
+    get:
+      tags: [dashboard]
+      operationId: getDashboardSecurityOperations
+      summary: Get tenant-scoped Asset and Finding analytics for the Dashboard
+      parameters:
+      - name: range
+        in: query
+        schema: {type: string, enum: [7d, 30d, 90d], default: 30d}
+      responses:
+        '200':
+          description: Security operations summary
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/DashboardSecurityOperations'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '500': {$ref: '#/components/responses/InternalServerError'}
+
   /api/v1/appsec/assets:
     get:
       tags: [assets]
@@ -1276,6 +1298,56 @@ components:
         decision: {type: string, enum: [accept, reject]}
         rationale: {type: string, minLength: 3, maxLength: 4000}
         version: {type: integer, minimum: 1}
+
+    DashboardPostureCounts:
+      type: object
+      required: [critical, high_risk, attention, unknown, good]
+      properties:
+        critical: {type: integer, minimum: 0}
+        high_risk: {type: integer, minimum: 0}
+        attention: {type: integer, minimum: 0}
+        unknown: {type: integer, minimum: 0}
+        good: {type: integer, minimum: 0}
+    DashboardCriticalityCounts:
+      type: object
+      required: [critical, high, medium, low]
+      properties:
+        critical: {type: integer, minimum: 0}
+        high: {type: integer, minimum: 0}
+        medium: {type: integer, minimum: 0}
+        low: {type: integer, minimum: 0}
+    DashboardSeverityCounts:
+      type: object
+      required: [critical, high, medium, low, info, unknown]
+      properties:
+        critical: {type: integer, minimum: 0}
+        high: {type: integer, minimum: 0}
+        medium: {type: integer, minimum: 0}
+        low: {type: integer, minimum: 0}
+        info: {type: integer, minimum: 0}
+        unknown: {type: integer, minimum: 0}
+    DashboardTrendPoint:
+      type: object
+      required: [date, counts]
+      properties:
+        date: {type: string, format: date}
+        counts: {$ref: '#/components/schemas/DashboardSeverityCounts'}
+    DashboardSecurityOperations:
+      type: object
+      required: [range_days, generated_at, asset_posture, assets_by_criticality, active_findings_by_severity, findings_over_time, findings_without_timestamp, external_findings_included]
+      properties:
+        range_days: {type: integer, enum: [7, 30, 90]}
+        generated_at: {type: string, format: date-time}
+        asset_posture: {$ref: '#/components/schemas/DashboardPostureCounts'}
+        assets_by_criticality: {$ref: '#/components/schemas/DashboardCriticalityCounts'}
+        active_findings_by_severity: {$ref: '#/components/schemas/DashboardSeverityCounts'}
+        findings_over_time:
+          type: array
+          minItems: 7
+          maxItems: 90
+          items: {$ref: '#/components/schemas/DashboardTrendPoint'}
+        findings_without_timestamp: {type: integer, minimum: 0}
+        external_findings_included: {type: boolean}
 
     BusinessAsset:
       type: object

--- a/internal/adapter/httpapi/dashboard_handler.go
+++ b/internal/adapter/httpapi/dashboard_handler.go
@@ -1,0 +1,183 @@
+package httpapi
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/businessassetuc"
+)
+
+type dashboardFinding struct {
+	ID        shared.ID
+	Severity  shared.Severity
+	Status    finding.Status
+	Class     string
+	CreatedAt time.Time
+}
+
+type dashboardTrendPoint struct {
+	Date   string         `json:"date"`
+	Counts map[string]int `json:"counts"`
+}
+
+type securityOperationsSummary struct {
+	RangeDays                int                   `json:"range_days"`
+	GeneratedAt              time.Time             `json:"generated_at"`
+	AssetPosture             map[string]int        `json:"asset_posture"`
+	AssetsByCriticality      map[string]int        `json:"assets_by_criticality"`
+	ActiveFindingsBySeverity map[string]int        `json:"active_findings_by_severity"`
+	FindingsOverTime         []dashboardTrendPoint `json:"findings_over_time"`
+	FindingsWithoutTimestamp int                   `json:"findings_without_timestamp"`
+	ExternalFindingsIncluded bool                  `json:"external_findings_included"`
+}
+
+func (rt *Router) dashboardSecurityOperations(w http.ResponseWriter, r *http.Request) {
+	days, ok := dashboardRangeDays(r.URL.Query().Get("range"))
+	if !ok {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "range must be 7d, 30d, or 90d"})
+		return
+	}
+
+	tenantID := requestTenant(r)
+	ctx := shared.WithTenant(r.Context(), tenantID)
+	assets, err := rt.businessAssets.List(ctx, tenantID, businessassetuc.Filter{})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	postures := make(map[shared.ID]string, len(assets))
+	for _, item := range assets {
+		posture, postureErr := rt.businessAssets.Posture(ctx, tenantID, item.ID)
+		if postureErr != nil {
+			writeError(w, rt.log, postureErr)
+			return
+		}
+		postures[item.ID] = posture.Rating
+	}
+
+	engagements, err := rt.eng.List(ctx, tenantID)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	rows := make([]dashboardFinding, 0)
+	seen := map[shared.ID]bool{}
+	// ponytail: this read model fans out over tenant engagements; replace it with repository-level
+	// aggregate queries when dashboard volume makes the bounded server-side fan-out measurable.
+	for _, engagement := range engagements {
+		canonical, findingErr := rt.findings.List(ctx, engagement.ID)
+		if findingErr != nil {
+			writeError(w, rt.log, findingErr)
+			return
+		}
+		for _, item := range finding.Publishable(canonical) {
+			if seen[item.ID] {
+				continue
+			}
+			seen[item.ID] = true
+			rows = append(rows, dashboardFinding{ID: item.ID, Severity: item.Severity, Status: item.Status, Class: item.Class, CreatedAt: item.Audit.CreatedAt})
+		}
+		if rt.importedFindings == nil {
+			continue
+		}
+		external, findingErr := rt.importedFindings.ListByEngagement(ctx, tenantID, engagement.ID)
+		if findingErr != nil {
+			writeError(w, rt.log, findingErr)
+			return
+		}
+		for _, item := range external {
+			if (!item.FindingID.IsZero() && seen[item.FindingID]) || seen[item.ID] {
+				continue
+			}
+			seen[item.ID] = true
+			rows = append(rows, dashboardFinding{ID: item.ID, Severity: item.Severity, Status: finding.StatusOpen, Class: finding.ClassThirdParty, CreatedAt: item.Audit.CreatedAt})
+		}
+	}
+
+	writeJSON(w, http.StatusOK, buildSecurityOperationsSummary(assets, postures, rows, days, time.Now().UTC(), rt.importedFindings != nil))
+}
+
+func dashboardRangeDays(value string) (int, bool) {
+	switch strings.TrimSpace(value) {
+	case "", "30d":
+		return 30, true
+	case "7d":
+		return 7, true
+	case "90d":
+		return 90, true
+	default:
+		return 0, false
+	}
+}
+
+func buildSecurityOperationsSummary(assets []*asset.BusinessAsset, postures map[shared.ID]string, findings []dashboardFinding, days int, now time.Time, externalIncluded bool) securityOperationsSummary {
+	postureCounts := counts("critical", "high_risk", "attention", "unknown", "good")
+	criticalityCounts := counts("critical", "high", "medium", "low")
+	severityCounts := counts("critical", "high", "medium", "low", "info", "unknown")
+	for _, item := range assets {
+		posture := postures[item.ID]
+		if _, known := postureCounts[posture]; !known {
+			posture = "unknown"
+		}
+		postureCounts[posture]++
+		criticality := string(item.Criticality)
+		if _, known := criticalityCounts[criticality]; known {
+			criticalityCounts[criticality]++
+		}
+	}
+
+	end := time.Date(now.UTC().Year(), now.UTC().Month(), now.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	start := end.AddDate(0, 0, -(days - 1))
+	trend := make([]dashboardTrendPoint, days)
+	trendByDate := make(map[string]map[string]int, days)
+	for index := 0; index < days; index++ {
+		date := start.AddDate(0, 0, index).Format("2006-01-02")
+		trend[index] = dashboardTrendPoint{Date: date, Counts: counts("critical", "high", "medium", "low", "info", "unknown")}
+		trendByDate[date] = trend[index].Counts
+	}
+
+	withoutTimestamp := 0
+	for _, item := range findings {
+		if item.Class == finding.ClassFirstPartyHistoric {
+			continue
+		}
+		severity := string(item.Severity)
+		if _, known := severityCounts[severity]; !known {
+			severity = "unknown"
+		}
+		if activeFindingStatus(item.Status) {
+			severityCounts[severity]++
+		}
+		if item.CreatedAt.IsZero() {
+			withoutTimestamp++
+			continue
+		}
+		date := item.CreatedAt.UTC().Format("2006-01-02")
+		if bucket := trendByDate[date]; bucket != nil {
+			bucket[severity]++
+		}
+	}
+
+	return securityOperationsSummary{
+		RangeDays: days, GeneratedAt: now.UTC(), AssetPosture: postureCounts,
+		AssetsByCriticality: criticalityCounts, ActiveFindingsBySeverity: severityCounts,
+		FindingsOverTime: trend, FindingsWithoutTimestamp: withoutTimestamp,
+		ExternalFindingsIncluded: externalIncluded,
+	}
+}
+
+func activeFindingStatus(status finding.Status) bool {
+	return status == finding.StatusOpen || status == finding.StatusTriage || status == finding.StatusConfirmed
+}
+
+func counts(keys ...string) map[string]int {
+	out := make(map[string]int, len(keys))
+	for _, key := range keys {
+		out[key] = 0
+	}
+	return out
+}

--- a/internal/adapter/httpapi/dashboard_handler_test.go
+++ b/internal/adapter/httpapi/dashboard_handler_test.go
@@ -1,0 +1,147 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/businessassetuc"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	findingsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findings"
+)
+
+func TestDashboardRangeDays(t *testing.T) {
+	for input, want := range map[string]int{"": 30, "7d": 7, "30d": 30, "90d": 90} {
+		got, ok := dashboardRangeDays(input)
+		if !ok || got != want {
+			t.Fatalf("range %q = %d,%v want %d,true", input, got, ok, want)
+		}
+	}
+	if _, ok := dashboardRangeDays("365d"); ok {
+		t.Fatal("unbounded range must be rejected")
+	}
+}
+
+func TestBuildSecurityOperationsSummary(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	assets := []*asset.BusinessAsset{
+		{ID: "a1", Criticality: asset.CriticalityCritical},
+		{ID: "a2", Criticality: asset.CriticalityHigh},
+		{ID: "a3", Criticality: asset.CriticalityLow},
+	}
+	postures := map[shared.ID]string{"a1": "critical", "a2": "good", "a3": "unexpected"}
+	rows := []dashboardFinding{
+		{ID: "critical", Severity: shared.SeverityCritical, Status: finding.StatusOpen, CreatedAt: now.AddDate(0, 0, -1)},
+		{ID: "high", Severity: shared.SeverityHigh, Status: finding.StatusConfirmed, CreatedAt: now},
+		{ID: "remediated", Severity: shared.SeverityMedium, Status: finding.StatusRemediated, CreatedAt: now},
+		{ID: "historical", Severity: shared.SeverityCritical, Status: finding.StatusOpen, Class: finding.ClassFirstPartyHistoric, CreatedAt: now},
+		{ID: "unknown-date", Severity: shared.SeverityUnknown, Status: finding.StatusTriage},
+	}
+
+	summary := buildSecurityOperationsSummary(assets, postures, rows, 7, now, true)
+	if summary.AssetPosture["critical"] != 1 || summary.AssetPosture["good"] != 1 || summary.AssetPosture["unknown"] != 1 {
+		t.Fatalf("posture counts = %#v", summary.AssetPosture)
+	}
+	if summary.AssetsByCriticality["critical"] != 1 || summary.AssetsByCriticality["high"] != 1 || summary.AssetsByCriticality["low"] != 1 {
+		t.Fatalf("criticality counts = %#v", summary.AssetsByCriticality)
+	}
+	if summary.ActiveFindingsBySeverity["critical"] != 1 || summary.ActiveFindingsBySeverity["high"] != 1 || summary.ActiveFindingsBySeverity["medium"] != 0 || summary.ActiveFindingsBySeverity["unknown"] != 1 {
+		t.Fatalf("active severity counts = %#v", summary.ActiveFindingsBySeverity)
+	}
+	if summary.FindingsOverTime[5].Counts["critical"] != 1 || summary.FindingsOverTime[6].Counts["high"] != 1 || summary.FindingsOverTime[6].Counts["medium"] != 1 {
+		t.Fatalf("trend = %#v", summary.FindingsOverTime)
+	}
+	if summary.FindingsWithoutTimestamp != 1 || !summary.ExternalFindingsIncluded {
+		t.Fatalf("coverage metadata = %#v", summary)
+	}
+}
+
+func TestDashboardSecurityOperationsRouteRBACRangeAndTenantIsolation(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	engagements := memory.NewEngagementRepository()
+	assets := memory.NewAssetStore()
+	assets.SetEngagementRepository(engagements)
+	findings := memory.NewFindingRepository()
+	imported := memory.NewImportedFindingStore()
+	assetService, err := businessassetuc.NewService(assets, findings, imported, memory.NewJudgmentStore(), memory.NewRetestRepository(), &fakeAudit{}, fixedClock{t: now}, engIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range []*asset.BusinessAsset{
+		{ID: "asset-a", TenantID: "tenant-a", Key: "asset-a", Name: "Tenant A Asset", Type: asset.BusinessAssetApplication, Criticality: asset.CriticalityCritical, Lifecycle: asset.BusinessAssetActive, Owner: "team-a", Version: 1},
+		{ID: "asset-b", TenantID: "tenant-b", Key: "asset-b", Name: "Tenant B Asset", Type: asset.BusinessAssetSystem, Criticality: asset.CriticalityLow, Lifecycle: asset.BusinessAssetActive, Owner: "team-b", Version: 1},
+	} {
+		if err := assets.CreateBusinessAsset(context.Background(), item); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, item := range []*engdom.Engagement{
+		{ID: "eng-a", TenantID: "tenant-a", BusinessAssetID: "asset-a", Name: "Tenant A Engagement", Client: "A", Status: engdom.StatusActive, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}},
+		{ID: "eng-b", TenantID: "tenant-b", BusinessAssetID: "asset-b", Name: "Tenant B Engagement", Client: "B", Status: engdom.StatusActive, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}},
+	} {
+		if err := engagements.Create(context.Background(), item); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tenantAFinding, err := finding.NewManual("finding-a", "eng-a", finding.ManualInput{Title: "Tenant A only", Severity: shared.SeverityCritical}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := findings.Upsert(context.Background(), []finding.Finding{tenantAFinding}); err != nil {
+		t.Fatal(err)
+	}
+
+	routes := (&Router{
+		log:            discardLog(),
+		businessAssets: assetService,
+		eng:            enguc.NewService(engagements, fixedClock{t: now}, engIDs{}, &fakeAudit{}),
+		findings:       findingsuc.NewService(findings, nil, nil, &fakeAudit{}, fixedClock{t: now}, engIDs{}),
+	}).routes()
+	call := func(role, tenant, target string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "alice", Role: role, TenantID: tenant}))
+		rec := httptest.NewRecorder()
+		routes.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := call("agent", "tenant-a", "/api/v1/dashboard/security-operations"); rec.Code != http.StatusForbidden {
+		t.Fatalf("machine role status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := call("readonly", "tenant-a", "/api/v1/dashboard/security-operations?range=365d"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid range status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	tenantA := call("readonly", "tenant-a", "/api/v1/dashboard/security-operations?range=7d")
+	if tenantA.Code != http.StatusOK {
+		t.Fatalf("tenant A read status=%d body=%s", tenantA.Code, tenantA.Body.String())
+	}
+	var tenantASummary securityOperationsSummary
+	if err := json.Unmarshal(tenantA.Body.Bytes(), &tenantASummary); err != nil {
+		t.Fatal(err)
+	}
+	if tenantASummary.ActiveFindingsBySeverity["critical"] != 1 {
+		t.Fatalf("tenant A finding missing from own summary=%#v", tenantASummary)
+	}
+	rec := call("readonly", "tenant-b", "/api/v1/dashboard/security-operations?range=7d")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("same-tenant read status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var summary securityOperationsSummary
+	if err := json.Unmarshal(rec.Body.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.RangeDays != 7 || summary.AssetsByCriticality["low"] != 1 {
+		t.Fatalf("tenant B asset summary=%#v", summary)
+	}
+	if summary.AssetsByCriticality["critical"] != 0 || summary.ActiveFindingsBySeverity["critical"] != 0 {
+		t.Fatalf("tenant A data leaked into tenant B summary=%#v", summary)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -265,6 +265,9 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/assets/edges", rt.authz(userdom.PermView, rt.listAssetEdges))
 	}
 	if rt.businessAssets != nil {
+		if rt.eng != nil && rt.findings != nil {
+			mux.HandleFunc("GET /api/v1/dashboard/security-operations", rt.authz(userdom.PermView, rt.dashboardSecurityOperations))
+		}
 		mux.HandleFunc("POST /api/v1/appsec/assets", rt.authz(userdom.PermOperate, rt.createBusinessAsset))
 		mux.HandleFunc("GET /api/v1/appsec/assets", rt.authz(userdom.PermView, rt.listBusinessAssets))
 		mux.HandleFunc("GET /api/v1/appsec/assets/{assetID}", rt.authz(userdom.PermView, rt.getBusinessAsset))

--- a/web/src/App.rules.test.tsx
+++ b/web/src/App.rules.test.tsx
@@ -12,6 +12,7 @@ vi.mock('./lib/api', () => ({
     listEngagements: vi.fn(),
     listBusinessAssets: vi.fn(),
     fleetCoverageSummary: vi.fn(),
+    dashboardSecurityOperations: vi.fn(),
     listProjects: vi.fn(),
     getProject: vi.fn(),
     getAuditLogs: vi.fn(),
@@ -35,6 +36,7 @@ describe('App Routing - Rules', () => {
     vi.mocked(api.listEngagements).mockResolvedValue([])
     vi.mocked(api.listBusinessAssets).mockResolvedValue({ items: [], total: 0, limit: 200, offset: 0 })
     vi.mocked(api.fleetCoverageSummary).mockResolvedValue({ agentsByState: {}, rowsByVerdict: {}, oldestPerCapability: {}, assetsWithoutAgent: 0 })
+    vi.mocked(api.dashboardSecurityOperations).mockResolvedValue({ rangeDays: 30, generatedAt: '', assetPosture: {}, assetsByCriticality: {}, activeFindingsBySeverity: {}, findingsOverTime: [], findingsWithoutTimestamp: 0, externalFindingsIncluded: true })
     vi.mocked(api.listProjects).mockResolvedValue([])
     vi.mocked(api.getRule).mockResolvedValue({
       key: 'go:sql',

--- a/web/src/components/DashboardCharts.tsx
+++ b/web/src/components/DashboardCharts.tsx
@@ -1,0 +1,128 @@
+import { cn } from './ui'
+import type { DashboardTrendPoint } from '../lib/types'
+
+export type ChartDatum = { key: string; label: string; value: number; color: string }
+
+const CIRCUMFERENCE = 2 * Math.PI * 46
+
+export function DonutChart({ title, centerLabel, data }: { title: string; centerLabel: string; data: ChartDatum[] }) {
+  const total = data.reduce((sum, item) => sum + item.value, 0)
+  let offset = 0
+  return (
+    <div className="grid min-h-64 items-center gap-5 sm:grid-cols-[minmax(150px,0.7fr)_minmax(200px,1fr)]">
+      <figure className="mx-auto size-44" aria-label={`${title}: ${total} total`}>
+        <svg viewBox="0 0 120 120" role="img" className="size-full" aria-label={`${title} donut chart`}>
+          <title>{title}</title>
+          <circle cx="60" cy="60" r="46" fill="none" stroke="var(--color-muted)" strokeWidth="14" />
+          {data.map((item) => {
+            const length = total ? item.value / total * CIRCUMFERENCE : 0
+            const segment = (
+              <circle
+                key={item.key}
+                cx="60"
+                cy="60"
+                r="46"
+                fill="none"
+                stroke={item.color}
+                strokeWidth="14"
+                strokeDasharray={`${length} ${CIRCUMFERENCE - length}`}
+                strokeDashoffset={-offset}
+                strokeLinecap={item.value === total ? 'round' : 'butt'}
+                transform="rotate(-90 60 60)"
+              >
+                <title>{item.label}: {item.value} ({percentage(item.value, total)}%)</title>
+              </circle>
+            )
+            offset += length
+            return segment
+          })}
+          <text x="60" y="57" textAnchor="middle" className="fill-foreground text-[18px] font-bold tabular-nums">{total}</text>
+          <text x="60" y="74" textAnchor="middle" className="fill-mutedfg text-[8px] font-semibold uppercase tracking-wider">{centerLabel}</text>
+        </svg>
+      </figure>
+      <ul className="space-y-3">
+        {data.map((item) => (
+          <li key={item.key} className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 text-xs">
+            <span className="flex min-w-0 items-center gap-2 font-medium text-mutedfg"><span className="size-2.5 shrink-0 rounded-full" style={{ backgroundColor: item.color }} /><span className="truncate">{item.label}</span></span>
+            <span className="font-mono font-semibold tabular-nums text-foreground">{item.value}</span>
+            <span className="w-10 text-right font-mono tabular-nums text-subtlefg">{percentage(item.value, total)}%</span>
+          </li>
+        ))}
+        {total === 0 && <li className="text-xs text-subtlefg">No data available.</li>}
+      </ul>
+    </div>
+  )
+}
+
+export function HorizontalBarChart({ title, data }: { title: string; data: ChartDatum[] }) {
+  const total = data.reduce((sum, item) => sum + item.value, 0)
+  const max = Math.max(1, ...data.map((item) => item.value))
+  return (
+    <figure aria-label={title} className="min-h-64 space-y-5 py-2">
+      <figcaption className="sr-only">{title}</figcaption>
+      {data.map((item) => (
+        <div key={item.key} className="grid grid-cols-[5.5rem_minmax(0,1fr)_2.5rem] items-center gap-3 text-xs sm:grid-cols-[7rem_minmax(0,1fr)_3rem]">
+          <span className="truncate font-medium text-mutedfg">{item.label}</span>
+          <div className="h-3 overflow-hidden rounded-full bg-muted">
+            <div className="bar-grow h-full rounded-full" style={{ width: `${item.value / max * 100}%`, backgroundColor: item.color }} />
+          </div>
+          <span className="text-right font-mono font-semibold tabular-nums">{item.value}</span>
+          <span className="col-start-2 -mt-2 text-right font-mono text-[10px] tabular-nums text-subtlefg">{percentage(item.value, total)}%</span>
+        </div>
+      ))}
+      {total === 0 && <p className="text-xs text-subtlefg">No data available.</p>}
+    </figure>
+  )
+}
+
+export function FindingsTrendChart({ points, series }: { points: DashboardTrendPoint[]; series: ChartDatum[] }) {
+  const width = 720
+  const height = 250
+  const left = 38
+  const right = 12
+  const top = 16
+  const bottom = 34
+  const plotWidth = width - left - right
+  const plotHeight = height - top - bottom
+  const max = Math.max(1, ...points.flatMap((point) => series.map((item) => point.counts[item.key] ?? 0)))
+  const x = (index: number) => left + (points.length <= 1 ? 0 : index / (points.length - 1) * plotWidth)
+  const y = (value: number) => top + plotHeight - value / max * plotHeight
+  const labelIndexes = new Set([0, Math.floor((points.length - 1) / 2), points.length - 1])
+  const total = points.reduce((sum, point) => sum + series.reduce((row, item) => row + (point.counts[item.key] ?? 0), 0), 0)
+
+  return (
+    <div className="min-h-64">
+      <div className="mb-3 flex flex-wrap justify-end gap-3">
+        {series.map((item) => <span key={item.key} className="inline-flex items-center gap-1.5 text-[10px] font-semibold text-mutedfg"><span className="size-2 rounded-full" style={{ backgroundColor: item.color }} />{item.label}</span>)}
+      </div>
+      <figure aria-label={`Findings over time: ${total} created findings`} className="overflow-x-auto">
+        <svg viewBox={`0 0 ${width} ${height}`} role="img" className="h-64 min-w-[36rem] w-full">
+          <title>Findings created by day and severity</title>
+          {[0, 0.5, 1].map((ratio) => <line key={ratio} x1={left} x2={width - right} y1={top + ratio * plotHeight} y2={top + ratio * plotHeight} stroke="var(--color-border)" strokeWidth="1" />)}
+          <text x={left - 8} y={top + 4} textAnchor="end" className="fill-subtlefg text-[9px]">{max}</text>
+          <text x={left - 8} y={top + plotHeight + 4} textAnchor="end" className="fill-subtlefg text-[9px]">0</text>
+          {series.map((item) => {
+            const coordinates = points.map((point, index) => ({ x: x(index), y: y(point.counts[item.key] ?? 0), value: point.counts[item.key] ?? 0, date: point.date }))
+            return (
+              <g key={item.key}>
+                {coordinates.length > 1 && <polyline points={coordinates.map((point) => `${point.x},${point.y}`).join(' ')} fill="none" stroke={item.color} strokeWidth="2.5" strokeLinejoin="round" strokeLinecap="round" />}
+                {coordinates.filter((point) => point.value > 0).map((point) => <circle key={`${point.date}-${item.key}`} cx={point.x} cy={point.y} r="4" fill={item.color}><title>{point.date} · {item.label}: {point.value}</title></circle>)}
+              </g>
+            )
+          })}
+          {points.map((point, index) => labelIndexes.has(index) && <text key={point.date} x={x(index)} y={height - 8} textAnchor={index === 0 ? 'start' : index === points.length - 1 ? 'end' : 'middle'} className="fill-subtlefg text-[9px]">{shortDate(point.date)}</text>)}
+        </svg>
+        <figcaption className={cn('mt-1 text-center text-xs text-subtlefg', total > 0 && 'sr-only')}>{total ? `${total} created findings in range.` : 'No dated findings in this range.'}</figcaption>
+      </figure>
+    </div>
+  )
+}
+
+function percentage(value: number, total: number) {
+  return total ? Math.round(value / total * 100) : 0
+}
+
+function shortDate(value: string) {
+  const [, month, day] = value.split('-')
+  return `${Number(month)}/${Number(day)}`
+}

--- a/web/src/lib/api.dashboard.test.ts
+++ b/web/src/lib/api.dashboard.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api } from './api'
+
+describe('dashboardSecurityOperations', () => {
+  let fetchSpy: any
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  function respond(body: unknown) {
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 200, json: async () => body } as unknown as Response)
+  }
+
+  // The completeness flags decide whether the dashboard tells the operator that part of the picture is
+  // missing. Their DEFAULTS therefore matter as much as their values: an older or partial server
+  // response must not be read as "everything was included", because the charts would then present an
+  // incomplete risk mix as the whole one.
+  it('defaults completeness fields to the honest answer when the server omits them', async () => {
+    respond({ range_days: 30 })
+
+    const summary = await api.dashboardSecurityOperations()
+
+    expect(summary.externalFindingsIncluded).toBe(false)
+    expect(summary.findingsWithoutTimestamp).toBe(0)
+  })
+
+  it(`carries the server completeness answer through unchanged`, async () => {
+    respond({ range_days: 7, findings_without_timestamp: 4, external_findings_included: true })
+
+    const summary = await api.dashboardSecurityOperations(7)
+
+    expect(summary.rangeDays).toBe(7)
+    expect(summary.findingsWithoutTimestamp).toBe(4)
+    expect(summary.externalFindingsIncluded).toBe(true)
+  })
+
+  it('requests the range the caller asked for', async () => {
+    respond({})
+
+    await api.dashboardSecurityOperations(90)
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/dashboard/security-operations?range=90d', expect.any(Object))
+  })
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -77,6 +77,7 @@ import type {
   FleetAgentDetail,
   FleetCoverageRow,
   FleetCoverageSummary,
+  DashboardSecurityOperations,
   BusinessAsset,
   BusinessAssetInput,
   BusinessAssetPage,
@@ -1869,6 +1870,20 @@ export const api = {
       rowsByVerdict: res?.rows_by_verdict ?? {},
       oldestPerCapability: res?.oldest_per_capability ?? {},
       assetsWithoutAgent: res?.assets_without_agent ?? 0,
+    }
+  },
+
+  dashboardSecurityOperations: async (rangeDays = 30): Promise<DashboardSecurityOperations> => {
+    const res = await req(`/dashboard/security-operations?range=${rangeDays}d`)
+    return {
+      rangeDays: res?.range_days ?? rangeDays,
+      generatedAt: res?.generated_at ?? '',
+      assetPosture: res?.asset_posture ?? {},
+      assetsByCriticality: res?.assets_by_criticality ?? {},
+      activeFindingsBySeverity: res?.active_findings_by_severity ?? {},
+      findingsOverTime: (res?.findings_over_time ?? []).map((point: any) => ({ date: point?.date ?? '', counts: point?.counts ?? {} })),
+      findingsWithoutTimestamp: res?.findings_without_timestamp ?? 0,
+      externalFindingsIncluded: res?.external_findings_included ?? false,
     }
   },
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1249,3 +1249,19 @@ export interface FleetCoverageSummary {
   oldestPerCapability: Record<string, string>
   assetsWithoutAgent: number
 }
+
+export interface DashboardTrendPoint {
+  date: string
+  counts: Record<string, number>
+}
+
+export interface DashboardSecurityOperations {
+  rangeDays: number
+  generatedAt: string
+  assetPosture: Record<string, number>
+  assetsByCriticality: Record<string, number>
+  activeFindingsBySeverity: Record<string, number>
+  findingsOverTime: DashboardTrendPoint[]
+  findingsWithoutTimestamp: number
+  externalFindingsIncluded: boolean
+}

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -96,6 +96,16 @@ describe('Dashboard', () => {
     expect(screen.getByText(/excluded from the trend/)).toBeInTheDocument()
   })
 
+  // The completeness disclosures are the point of these charts: a trend that quietly omits rows, or a
+  // risk mix that quietly omits third-party findings, reads as the whole picture. The undated-findings
+  // notice is covered above; this covers the other one, and the fail-closed default behind it.
+  it('says so when third-party findings are not included', async () => {
+    vi.mocked(api.dashboardSecurityOperations).mockResolvedValue({ ...analytics, externalFindingsIncluded: false })
+    renderDashboard()
+
+    expect(await screen.findByText(/third-party findings are not included/)).toBeInTheDocument()
+  })
+
   it('keeps core operations visible when Fleet telemetry fails', async () => {
     vi.mocked(api.fleetCoverageSummary).mockRejectedValue(new Error('fleet disabled'))
     renderDashboard()

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { api } from '../lib/api'
-import type { BusinessAsset, Engagement, FleetCoverageSummary } from '../lib/types'
+import type { BusinessAsset, DashboardSecurityOperations, Engagement, FleetCoverageSummary } from '../lib/types'
 import { Dashboard } from './Dashboard'
 
 vi.mock('../lib/api', () => ({
@@ -10,6 +10,7 @@ vi.mock('../lib/api', () => ({
     listBusinessAssets: vi.fn(),
     listEngagements: vi.fn(),
     fleetCoverageSummary: vi.fn(),
+    dashboardSecurityOperations: vi.fn(),
   },
 }))
 
@@ -41,6 +42,20 @@ const fleet: FleetCoverageSummary = {
   assetsWithoutAgent: 1,
 }
 
+const analytics: DashboardSecurityOperations = {
+  rangeDays: 30,
+  generatedAt: '2026-08-10T00:00:00Z',
+  assetPosture: { critical: 1, high_risk: 0, attention: 0, unknown: 1, good: 1 },
+  assetsByCriticality: { critical: 1, high: 1, medium: 1, low: 0 },
+  activeFindingsBySeverity: { critical: 1, high: 2, medium: 3, low: 0, info: 0, unknown: 1 },
+  findingsOverTime: [
+    { date: '2026-08-09', counts: { critical: 0, high: 1, medium: 0, low: 0 } },
+    { date: '2026-08-10', counts: { critical: 1, high: 0, medium: 2, low: 0 } },
+  ],
+  findingsWithoutTimestamp: 1,
+  externalFindingsIncluded: true,
+}
+
 function renderDashboard() {
   return render(<MemoryRouter><Dashboard /></MemoryRouter>)
 }
@@ -51,6 +66,7 @@ describe('Dashboard', () => {
     vi.mocked(api.listBusinessAssets).mockResolvedValue({ items: assets, total: assets.length, limit: 200, offset: 0 })
     vi.mocked(api.listEngagements).mockResolvedValue(engagements)
     vi.mocked(api.fleetCoverageSummary).mockResolvedValue(fleet)
+    vi.mocked(api.dashboardSecurityOperations).mockResolvedValue(analytics)
   })
 
   it('renders operational metrics and priority queues from API data', async () => {
@@ -71,6 +87,13 @@ describe('Dashboard', () => {
     expect(screen.getByText('Payment API Review')).toBeInTheDocument()
     expect(screen.getByText('Payments Platform', { selector: 'p' })).toBeInTheDocument()
     expect(screen.getByText('Unassigned Asset')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Asset Security Posture' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Findings Over Time' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Active Finding Risk Mix' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Assets by Criticality' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Asset Security Posture: 3 total')).toBeInTheDocument()
+    expect(screen.getByLabelText('Active Finding Risk Mix: 7 total')).toBeInTheDocument()
+    expect(screen.getByText(/excluded from the trend/)).toBeInTheDocument()
   })
 
   it('keeps core operations visible when Fleet telemetry fails', async () => {
@@ -80,6 +103,19 @@ describe('Dashboard', () => {
     expect(await screen.findByLabelText('Total assets: 3')).toBeInTheDocument()
     expect(screen.getByLabelText('Coverage gaps: —')).toBeInTheDocument()
     expect(screen.getAllByText('Fleet telemetry unavailable').length).toBeGreaterThan(0)
-    expect(screen.getByText(/Coverage is not assumed clean/)).toBeInTheDocument()
+  })
+
+  it('reloads the finding trend for a selected range', async () => {
+    renderDashboard()
+    await screen.findByRole('heading', { name: 'Findings Over Time' })
+    screen.getByRole('button', { name: '90d' }).click()
+    await waitFor(() => expect(api.dashboardSecurityOperations).toHaveBeenLastCalledWith(90))
+  })
+
+  it('keeps the operational dashboard visible when analytics fails', async () => {
+    vi.mocked(api.dashboardSecurityOperations).mockRejectedValue(new Error('analytics unavailable'))
+    renderDashboard()
+    expect(await screen.findByLabelText('Total assets: 3')).toBeInTheDocument()
+    expect(await screen.findByText('analytics unavailable')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -15,8 +15,9 @@ import {
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Card, ErrorState, Spinner, cn } from '../components/ui'
+import { DonutChart, FindingsTrendChart, HorizontalBarChart, type ChartDatum } from '../components/DashboardCharts'
 import { api } from '../lib/api'
-import type { BusinessAsset, Engagement, FleetCoverageSummary } from '../lib/types'
+import type { BusinessAsset, DashboardSecurityOperations, Engagement, FleetCoverageSummary } from '../lib/types'
 import { PostureBadge } from './Assets'
 import { StatusPill } from './Engagements'
 
@@ -26,7 +27,6 @@ type DashboardData = {
   engagements: Engagement[]
 }
 
-const POSTURE_ORDER = ['critical', 'high_risk', 'attention', 'unknown', 'good'] as const
 const ENGAGEMENT_ORDER = ['active', 'draft', 'completed', 'archived'] as const
 const POSTURE_WEIGHT: Record<string, number> = { critical: 5, high_risk: 4, attention: 3, unknown: 2, good: 1 }
 const CRITICALITY_WEIGHT: Record<BusinessAsset['criticality'], number> = { critical: 4, high: 3, medium: 2, low: 1 }
@@ -36,6 +36,9 @@ export function Dashboard() {
   const [error, setError] = useState<string | null>(null)
   const [fleet, setFleet] = useState<FleetCoverageSummary | null>(null)
   const [fleetUnavailable, setFleetUnavailable] = useState(false)
+  const [analytics, setAnalytics] = useState<DashboardSecurityOperations | null>(null)
+  const [analyticsError, setAnalyticsError] = useState<string | null>(null)
+  const [rangeDays, setRangeDays] = useState(30)
 
   useEffect(() => {
     let active = true
@@ -61,6 +64,22 @@ export function Dashboard() {
       active = false
     }
   }, [])
+
+  useEffect(() => {
+    let active = true
+    setAnalytics(null)
+    setAnalyticsError(null)
+    api.dashboardSecurityOperations(rangeDays)
+      .then((summary) => {
+        if (active) setAnalytics(summary)
+      })
+      .catch((nextError) => {
+        if (active) setAnalyticsError(nextError instanceof Error ? nextError.message : 'Failed to load dashboard analytics')
+      })
+    return () => {
+      active = false
+    }
+  }, [rangeDays])
 
   if (error) return <div className="mx-auto max-w-[1600px]"><ErrorState message={error} /></div>
   if (!data) return <Spinner label="Loading security operations…" />
@@ -116,35 +135,30 @@ export function Dashboard() {
       </section>
 
       <section aria-labelledby="analytics-title">
-        <SectionHeading eyebrow="Telemetry" title="Operations analytics" description="Current distribution across the Asset and assessment lifecycle." id="analytics-title" />
-        <div className="grid gap-4 xl:grid-cols-3">
-          <Card title="Asset posture" actions={<LinkArrow to="/assets" label="View inventory" />} bodyClass="space-y-4">
-            <Distribution rows={POSTURE_ORDER.map((value) => ({ label: labelize(value), value: data.assets.filter((asset) => (asset.posture ?? 'unknown') === value).length, tone: postureTone(value) }))} />
-            {data.assetTotal > data.assets.length && <p className="text-xs text-subtlefg">Posture distribution reflects the first {data.assets.length} loaded Assets.</p>}
-          </Card>
+        <SectionHeading eyebrow="Telemetry" title="Operations analytics" description="Live distribution across Asset posture, finding risk, and security inventory." id="analytics-title" />
+        {analyticsError && <ErrorState message={analyticsError} />}
+        {!analytics && !analyticsError && <Spinner label="Loading operations analytics…" className="min-h-64" />}
+        {analytics && (
+          <div className="grid gap-4 xl:grid-cols-2">
+            <ChartCard title="Asset Security Posture" description="Current posture derived from findings and coverage." action={<LinkArrow to="/assets" label="View inventory" />}>
+              <DonutChart title="Asset Security Posture" centerLabel="Assets" data={postureChart(analytics.assetPosture)} />
+            </ChartCard>
 
-          <Card title="Engagement pipeline" actions={<LinkArrow to="/engagements" label="View queue" />} bodyClass="space-y-4">
-            <Distribution rows={ENGAGEMENT_ORDER.map((value) => ({ label: labelize(value), value: data.engagements.filter((engagement) => engagement.status.toLowerCase() === value).length, tone: engagementTone(value) }))} />
-          </Card>
+            <ChartCard title="Findings Over Time" description="New publishable findings grouped by UTC day and severity." action={<RangeSelector value={rangeDays} onChange={setRangeDays} />}>
+              <FindingsTrendChart points={analytics.findingsOverTime} series={severityChart({}, false)} />
+              {analytics.findingsWithoutTimestamp > 0 && <p className="mt-2 text-xs text-medium">{analytics.findingsWithoutTimestamp} finding{analytics.findingsWithoutTimestamp === 1 ? '' : 's'} excluded from the trend because no creation timestamp is available.</p>}
+            </ChartCard>
 
-          <Card title="Fleet readiness" actions={<LinkArrow to="/fleet" label="View coverage" />} bodyClass="space-y-4">
-            {fleet ? (
-              <>
-                <Distribution rows={fleetRows(fleet)} />
-                <div className="grid grid-cols-2 gap-3 border-t border-border pt-4 text-sm">
-                  <FleetStat label="Assets without agent" value={fleet.assetsWithoutAgent} warn />
-                  <FleetStat label="Connected agents" value={fleet.agentsByState.connected ?? 0} />
-                </div>
-              </>
-            ) : fleetUnavailable ? (
-              <div className="flex min-h-44 flex-col items-center justify-center rounded-lg border border-dashed border-border px-5 text-center">
-                <RadioTower className="size-6 text-subtlefg" aria-hidden="true" />
-                <p className="mt-3 text-sm font-medium">Fleet telemetry unavailable</p>
-                <p className="mt-1 text-xs leading-5 text-mutedfg">Asset and Engagement data remain available. Coverage is not assumed clean.</p>
-              </div>
-            ) : <Spinner label="Loading Fleet telemetry…" className="min-h-44" />}
-          </Card>
-        </div>
+            <ChartCard title="Active Finding Risk Mix" description="Open, triage, and confirmed actionable findings." action={<LinkArrow to="/assets" label="Review Assets" />}>
+              <DonutChart title="Active Finding Risk Mix" centerLabel="Active" data={severityChart(analytics.activeFindingsBySeverity, true)} />
+              {!analytics.externalFindingsIncluded && <p className="mt-2 text-xs text-medium">External finding storage is unavailable; third-party findings are not included.</p>}
+            </ChartCard>
+
+            <ChartCard title="Assets by Criticality" description="Managed Assets grouped by business criticality." action={<LinkArrow to="/assets" label="View inventory" />}>
+              <HorizontalBarChart title="Assets by Criticality" data={criticalityChart(analytics.assetsByCriticality)} />
+            </ChartCard>
+          </div>
+        )}
       </section>
 
       <section aria-labelledby="priority-title">
@@ -226,26 +240,6 @@ function SectionHeading({ eyebrow, title, description, id }: { eyebrow: string; 
   )
 }
 
-function Distribution({ rows }: { rows: Array<{ label: string; value: number; tone: string }> }) {
-  const total = rows.reduce((sum, row) => sum + row.value, 0)
-  return (
-    <div className="space-y-3">
-      {rows.map((row) => (
-        <div key={row.label}>
-          <div className="mb-1.5 flex items-center justify-between gap-3 text-xs">
-            <span className="font-medium text-mutedfg">{row.label}</span>
-            <span className="font-mono tabular-nums text-foreground">{row.value}</span>
-          </div>
-          <div className="h-2 overflow-hidden rounded-full bg-muted">
-            <div className={cn('bar-grow h-full min-w-0 rounded-full', row.tone)} style={{ width: `${total ? Math.max(row.value ? 3 : 0, row.value / total * 100) : 0}%` }} />
-          </div>
-        </div>
-      ))}
-      {total === 0 && <p className="text-xs text-subtlefg">No data available.</p>}
-    </div>
-  )
-}
-
 function LinkArrow({ to, label }: { to: string; label: string }) {
   return <Link to={to} className="inline-flex items-center gap-1 text-xs font-semibold text-branddim hover:text-brand"><span className="hidden sm:inline">{label}</span><ArrowRight className="size-3.5" aria-hidden="true" /></Link>
 }
@@ -297,26 +291,56 @@ function CriticalityBadge({ value }: { value: BusinessAsset['criticality'] }) {
   return <span className={cn('inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide', tone)}><CircleDot className="size-3" />{value}</span>
 }
 
-function FleetStat({ label, value, warn = false }: { label: string; value: number; warn?: boolean }) {
-  return <div><div className={cn('text-xl font-bold tabular-nums', warn && value > 0 && 'text-high')}>{value.toLocaleString()}</div><div className="mt-0.5 text-xs text-mutedfg">{label}</div></div>
-}
-
-function fleetRows(summary: FleetCoverageSummary) {
-  const entries = Object.entries(summary.rowsByVerdict)
-  const preferred = ['covered', 'stale', 'not_assessed', 'failed', 'unauthorized', 'unknown']
-  return entries
-    .sort(([left], [right]) => preferred.indexOf(left) - preferred.indexOf(right))
-    .map(([verdict, value]) => ({ label: labelize(verdict), value, tone: verdict === 'covered' ? 'bg-accent' : verdict === 'failed' || verdict === 'unauthorized' ? 'bg-critical' : verdict === 'stale' ? 'bg-high' : 'bg-medium' }))
-}
-
-function postureTone(value: (typeof POSTURE_ORDER)[number]) {
-  return value === 'critical' ? 'bg-critical' : value === 'high_risk' ? 'bg-high' : value === 'attention' ? 'bg-medium' : value === 'good' ? 'bg-accent' : 'bg-subtlefg'
-}
-
-function engagementTone(value: (typeof ENGAGEMENT_ORDER)[number]) {
-  return value === 'active' ? 'bg-accent' : value === 'completed' ? 'bg-brand' : value === 'archived' ? 'bg-subtlefg' : 'bg-info'
-}
-
 function labelize(value: string) {
   return value.replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function ChartCard({ title, description, action, children }: { title: string; description: string; action?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <Card title={<div><span className="block">{title}</span><span aria-hidden="true" className="mt-1 block text-xs font-normal text-subtlefg">{description}</span></div>} actions={action} bodyClass="p-5 sm:p-6">
+      {children}
+    </Card>
+  )
+}
+
+function RangeSelector({ value, onChange }: { value: number; onChange: (value: number) => void }) {
+  return (
+    <div className="flex rounded-lg border border-border bg-bg p-0.5" aria-label="Finding trend range">
+      {[7, 30, 90].map((days) => <button key={days} type="button" onClick={() => onChange(days)} className={cn('rounded-md px-2 py-1 text-[10px] font-semibold transition-colors', value === days ? 'bg-brand text-brandfg' : 'text-mutedfg hover:text-foreground')}>{days}d</button>)}
+    </div>
+  )
+}
+
+function postureChart(counts: Record<string, number>): ChartDatum[] {
+  return [
+    chartItem('critical', 'Critical', counts, 'var(--color-critical)'),
+    chartItem('high_risk', 'High Risk', counts, 'var(--color-high)'),
+    chartItem('attention', 'Attention', counts, 'var(--color-medium)'),
+    chartItem('unknown', 'Unknown', counts, 'var(--color-subtlefg)'),
+    chartItem('good', 'Good', counts, 'var(--color-accent)'),
+  ]
+}
+
+function severityChart(counts: Record<string, number>, includeUnknown: boolean): ChartDatum[] {
+  const rows = [
+    chartItem('critical', 'Critical', counts, 'var(--color-critical)'),
+    chartItem('high', 'High', counts, 'var(--color-high)'),
+    chartItem('medium', 'Medium', counts, 'var(--color-medium)'),
+    chartItem('low', 'Low', counts, 'var(--color-low)'),
+  ]
+  if (includeUnknown) rows.push(chartItem('info', 'Info', counts, 'var(--color-infosev)'), chartItem('unknown', 'Unknown', counts, 'var(--color-subtlefg)'))
+  return rows
+}
+
+function criticalityChart(counts: Record<string, number>): ChartDatum[] {
+  return [
+    chartItem('critical', 'Critical', counts, 'var(--color-critical)'),
+    chartItem('high', 'High', counts, 'var(--color-high)'),
+    chartItem('medium', 'Medium', counts, 'var(--color-medium)'),
+    chartItem('low', 'Low', counts, 'var(--color-low)'),
+  ]
+}
+
+function chartItem(key: string, label: string, counts: Record<string, number>, color: string): ChartDatum {
+  return { key, label, value: counts[key] ?? 0, color }
 }


### PR DESCRIPTION
## Summary
- add a tenant-scoped `GET /api/v1/dashboard/security-operations` read endpoint with bounded `7d`, `30d`, and `90d` ranges
- add four responsive Dashboard visualizations using native SVG and existing design tokens: Asset posture, Findings over time, Active finding risk mix, and Assets by criticality
- preserve first-class `unknown`, exclude non-actionable historical advisories, deduplicate imported/canonical findings, and keep existing KPI/queue surfaces available when analytics fail
- document the endpoint in OpenAPI and add aggregation, RBAC, range, tenant-isolation, frontend loading/error, and interaction tests

## Issue
Tracks the Dashboard telemetry increment documented in #405. This PR does not close the platform Epic.

## Validation
- `go test ./...`
- `go vet ./...`
- `cd web && pnpm test` — 36 files, 293 tests
- `cd web && pnpm run typecheck`
- `cd web && pnpm run build`
- `git diff --check`
- localhost browser QA at 1440×900 and 390×844
- verified light/dark modes, four chart surfaces, 7d/30d/90d switching, empty states, no document horizontal overflow, and no new console errors
