### PR TITLE
feat(ai-triage): annotate gate exemptions in SARIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **Visible AI gate exemptions in SARIF.** Retained findings exempted by the verified AI false-positive policy now carry a standards-based external suppression plus deterministic policy version/reason metadata in both CLI and stored engagement SARIF exports; advisory, review-required, stale, and high-risk decisions remain unmarked.
 - **Asset-centric security management.** Promotes the shipped `fleet_business_services` rows in place to stable-keyed Business Assets above Engagements, with tenant/RLS-safe Project and technical-asset memberships, Engagement assignment, Findings/Coverage/Posture/History roll-ups, and UI built from the existing application components. Third-party findings retain provenance and no-promotion authority, while reachability retains proof tier and first-class `unknown`.
 
 - **Immutable Project Code workspace.** Capture bounded analysis-time source and Git comparison artifacts so historical source, unified/split diffs, and finding locations remain inspectable without reconstructing mutable workspaces; large source and diff views use bounded windows or virtualization.

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -817,6 +817,7 @@ func main() {
 	}
 	aupService := aupuc.NewService(aupStore, auditLog, clock, cfg.AUPVersion)
 	exportService := exportuc.NewService(findingRepo, clock, buildinfo.App())
+	exportService.SetAIGateExemptions(scaService)
 	findingsService := findingsuc.NewService(findingRepo, commentRepo, retestRepo, auditLog, clock, ids)
 	// Both additions are independent; the tenant resolver is wired first because the review service
 	// takes findingsService as a dependency.

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1395,6 +1395,7 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	// Report advisory opinions separately from the smaller policy-authorized gate-exempt set.
 	fpSuspect := res.SuspectedFPKeys()
 	fpGateExempt := res.AIGateExemptKeys()
+	fpGateExemptions := res.AIGateExemptions()
 	fpWouldExempt := res.AIWouldGateExemptKeys()
 	fpReview := res.AIReviewRequiredKeys()
 	if len(res.AITriage) > 0 {
@@ -1457,7 +1458,13 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 			}
 		}
 		fixFor := func(f finding.Finding) string { return fixByKey[f.DedupKey] }
-		out, err := exportuc.MarshalSARIF(res.Findings, res.ToolVersions["synapse"], exportuc.SARIFOptions{Manifest: manifestFor, Fix: fixFor})
+		exemptionFor := func(f finding.Finding) (ports.AIGateExemption, bool) {
+			exemption, ok := fpGateExemptions[strings.TrimSpace(f.DedupKey)]
+			return exemption, ok
+		}
+		out, err := exportuc.MarshalSARIF(res.Findings, res.ToolVersions["synapse"], exportuc.SARIFOptions{
+			Manifest: manifestFor, Fix: fixFor, AIGateExemption: exemptionFor,
+		})
 		if err != nil {
 			return fmt.Errorf("encode sarif: %w", err)
 		}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -42,7 +42,7 @@ synapse-cli scan <path|image-ref> [flags]
 | `--ignore-unfixed` | Ignore vulnerabilities that have no fix available. |
 | `--detection-priority comprehensive\|precise` | `comprehensive` (default) reports every match. `precise` moves single-source, non-KEV findings into a needs-verify queue that does not trip `--fail-on`. |
 | `--json` | Print the full scan result as JSON to stdout, for machine consumption in CI. |
-| `--sarif` | Print a SARIF 2.1.0 report to stdout, ready to upload to GitHub code scanning. Covers every finding kind; SAST, secret and misconfig findings carry a file and line so the platform annotates the exact source line. `--fail-on` still sets the exit code. Cannot be combined with `--json`. |
+| `--sarif` | Print a SARIF 2.1.0 report to stdout, ready to upload to GitHub code scanning. Covers every finding kind; SAST, secret and misconfig findings carry a file and line so the platform annotates the exact source line. Findings exempted from the CI gate by verified AI consensus remain present and carry an external suppression with the policy version and reason. `--fail-on` still sets the exit code. Cannot be combined with `--json`. |
 
 ### Examples
 

--- a/internal/usecase/export/export_test.go
+++ b/internal/usecase/export/export_test.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vex"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 type fixedClock struct{}
@@ -28,6 +30,15 @@ type fakeJudgments struct{ js []judgment.Judgment }
 
 func (f *fakeJudgments) ListByEngagement(context.Context, shared.ID) ([]judgment.Judgment, error) {
 	return f.js, nil
+}
+
+type fakeAIGateExemptions struct {
+	items []ports.AIGateExemption
+	err   error
+}
+
+func (f fakeAIGateExemptions) AIGateExemptions(context.Context, shared.ID, []finding.Finding) ([]ports.AIGateExemption, error) {
+	return f.items, f.err
 }
 
 func mkJudg(subj string, st judgment.State, score int, r judgment.ReachabilityState, tier judgment.ReachabilityTier) judgment.Judgment {
@@ -216,5 +227,56 @@ func TestExportsApplyPublishabilityGate(t *testing.T) {
 		if s.Vulnerability.Name == "CVE-2099-0001" {
 			t.Error("OpenVEX leaked an unproven exploitation finding")
 		}
+	}
+}
+
+func TestStoredSARIFUsesRevalidatedAIGateExemptions(t *testing.T) {
+	repo := memory.NewFindingRepository()
+	ctx := context.Background()
+	item := finding.Finding{
+		ID: "f1", EngagementID: "e1", Title: "Weak hash", Kind: finding.KindSAST,
+		Severity: shared.SeverityMedium, Status: finding.StatusOpen, RuleKey: "weak-hash",
+		SourceLocation: &finding.SourceLocation{File: "app.go", StartLine: 7, EndLine: 7},
+		DedupKey:       "sast:weak-hash:app.go:7",
+	}
+	if err := repo.Upsert(ctx, []finding.Finding{item}); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewService(repo, fixedClock{}, "v1")
+	svc.SetAIGateExemptions(fakeAIGateExemptions{items: []ports.AIGateExemption{{
+		DedupKey: item.DedupKey, PolicyVersion: "fp-gate-v3", PolicyReason: "verified_consensus",
+	}}})
+
+	log, err := svc.SARIF(ctx, "e1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(log.Runs[0].Results) != 1 || len(log.Runs[0].Results[0].Suppressions) != 1 {
+		t.Fatalf("stored SARIF result/exemption = %+v", log.Runs[0].Results)
+	}
+}
+
+func TestStoredSARIFFailsOnUnreadableAIGateMetadataButAllowsMissingLegacyResult(t *testing.T) {
+	repo := memory.NewFindingRepository()
+	ctx := context.Background()
+	if err := repo.Upsert(ctx, []finding.Finding{{
+		ID: "f1", EngagementID: "e1", Title: "Weak hash", Kind: finding.KindSAST,
+		Severity: shared.SeverityMedium, Status: finding.StatusOpen, RuleKey: "weak-hash",
+		SourceLocation: &finding.SourceLocation{File: "app.go", StartLine: 7, EndLine: 7},
+		DedupKey:       "sast:weak-hash:app.go:7",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewService(repo, fixedClock{}, "v1")
+	svc.SetAIGateExemptions(fakeAIGateExemptions{err: shared.ErrNotFound})
+	if _, err := svc.SARIF(ctx, "e1"); err != nil {
+		t.Fatalf("legacy engagement with no scan result must still export: %v", err)
+	}
+
+	readErr := errors.New("scan result unavailable")
+	svc.SetAIGateExemptions(fakeAIGateExemptions{err: readErr})
+	if _, err := svc.SARIF(ctx, "e1"); !errors.Is(err, readErr) {
+		t.Fatalf("SARIF error = %v, want %v", err, readErr)
 	}
 }

--- a/internal/usecase/export/sarif.go
+++ b/internal/usecase/export/sarif.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 const (
@@ -54,11 +55,18 @@ type SARIFText struct {
 }
 
 type SARIFResult struct {
-	RuleID     string          `json:"ruleId"`
-	Level      string          `json:"level"`
-	Message    SARIFText       `json:"message"`
-	Locations  []SARIFLocation `json:"locations,omitempty"`
-	Properties map[string]any  `json:"properties,omitempty"`
+	RuleID       string             `json:"ruleId"`
+	Level        string             `json:"level"`
+	Message      SARIFText          `json:"message"`
+	Locations    []SARIFLocation    `json:"locations,omitempty"`
+	Suppressions []SARIFSuppression `json:"suppressions,omitempty"`
+	Properties   map[string]any     `json:"properties,omitempty"`
+}
+
+type SARIFSuppression struct {
+	Kind          string `json:"kind"`
+	Status        string `json:"status,omitempty"`
+	Justification string `json:"justification,omitempty"`
 }
 
 type SARIFLocation struct {
@@ -87,13 +95,17 @@ type SARIFLogicalLocation struct {
 	Kind string `json:"kind,omitempty"`
 }
 
-// SARIFOptions carries optional per-finding resolvers that enrich SCA results. Both fields are nil-safe.
+// SARIFOptions carries optional per-finding resolvers. Every field is nil-safe.
 type SARIFOptions struct {
 	// Manifest returns the repo-relative manifest/lockfile that declares a dependency finding's
 	// component, so the result gets a physical location a code-scanning UI can annotate. "" when unknown.
 	Manifest func(finding.Finding) string
 	// Fix returns the version that remediates a dependency finding. "" when there is no fix or it is unknown.
 	Fix func(finding.Finding) string
+	// AIGateExemption returns policy metadata only when the finding's exemption has already passed the
+	// server-owned authorization re-check. SARIF renders it as an external accepted suppression while
+	// retaining the result. Advisory or review-required opinions must return false.
+	AIGateExemption func(finding.Finding) (ports.AIGateExemption, bool)
 }
 
 func buildSARIF(findings []finding.Finding, version string, opts SARIFOptions) *SARIFLog {
@@ -189,6 +201,23 @@ func buildSARIF(findings []finding.Finding, version string, opts SARIFOptions) *
 			if fix := opts.Fix(f); fix != "" {
 				res.Properties["fixedVersion"] = fix
 				res.Message.Text = f.Title + " (fixed in " + fix + ")"
+			}
+		}
+		if opts.AIGateExemption != nil {
+			findingKey := strings.TrimSpace(f.DedupKey)
+			if exemption, ok := opts.AIGateExemption(f); ok && findingKey != "" &&
+				strings.TrimSpace(exemption.DedupKey) == findingKey &&
+				strings.TrimSpace(exemption.PolicyVersion) != "" && strings.TrimSpace(exemption.PolicyReason) != "" {
+				version := strings.TrimSpace(exemption.PolicyVersion)
+				reason := strings.TrimSpace(exemption.PolicyReason)
+				res.Suppressions = []SARIFSuppression{{
+					Kind:          "external",
+					Status:        "accepted",
+					Justification: "Synapse AI gate exemption: policy=" + version + "; reason=" + reason,
+				}}
+				res.Properties["synapse.aiGateExempt"] = true
+				res.Properties["synapse.aiPolicyVersion"] = version
+				res.Properties["synapse.aiPolicyReason"] = reason
 			}
 		}
 		results = append(results, res)
@@ -306,8 +335,9 @@ func ruleTitle(title string) string {
 // uploader (e.g. GitHub `codeql-action/upload-sarif`) consumes. It is deterministic and templated
 // purely from stored findings: no clock, no LLM (golden rule 5). version is the synapse driver
 // version recorded on the run's tool driver. opts carries optional per-finding resolvers: Manifest gives
-// SCA findings a physical location (a repo-relative manifest path), and Fix adds the remediating version.
-// Both are nil-safe; pass the zero SARIFOptions to enrich nothing.
+// SCA findings a physical location (a repo-relative manifest path), Fix adds the remediating version,
+// and AIGateExemption explains policy-authorized external suppression without removing the result.
+// All are nil-safe; pass the zero SARIFOptions to enrich nothing.
 func MarshalSARIF(findings []finding.Finding, version string, opts SARIFOptions) ([]byte, error) {
 	return json.MarshalIndent(buildSARIF(findings, version, opts), "", "  ")
 }

--- a/internal/usecase/export/sarif_test.go
+++ b/internal/usecase/export/sarif_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 // firstPartyFindings mixes the three first-party kinds (SAST/secret/misconfig) that carry a
@@ -229,6 +230,83 @@ func TestMarshalSARIFValidJSON(t *testing.T) {
 		if p := firstNonNilPhysical(r.Locations); p != nil && p.Region != nil && p.Region.StartLine < 1 {
 			t.Errorf("result %q has invalid startLine %d", r.RuleID, p.Region.StartLine)
 		}
+	}
+}
+
+func TestSARIFAIGateExemptionRetainsAndAnnotatesFinding(t *testing.T) {
+	findings := firstPartyFindings()
+	exemptKey := "misconfig:kubernetes-no-run-as-non-root:deploy/pod.yaml:17"
+	exemption := ports.AIGateExemption{
+		DedupKey: exemptKey, PolicyVersion: "fp-gate-v3", PolicyReason: "verified_consensus",
+	}
+	resolver := func(item finding.Finding) (ports.AIGateExemption, bool) {
+		return exemption, item.DedupKey == exemptKey
+	}
+
+	log := buildSARIF(findings, "v9", SARIFOptions{AIGateExemption: resolver})
+	if len(log.Runs[0].Results) != len(findings) {
+		t.Fatalf("AI gate exemption removed a result: got %d, want %d", len(log.Runs[0].Results), len(findings))
+	}
+	for _, result := range log.Runs[0].Results {
+		if result.RuleID != "kubernetes-no-run-as-non-root" {
+			if len(result.Suppressions) != 0 {
+				t.Errorf("unexempted result %q has suppression: %+v", result.RuleID, result.Suppressions)
+			}
+			if _, exists := result.Properties["synapse.aiGateExempt"]; exists {
+				t.Errorf("unexempted result %q has AI exemption properties: %+v", result.RuleID, result.Properties)
+			}
+			continue
+		}
+		if len(result.Suppressions) != 1 {
+			t.Fatalf("exempted result suppressions = %+v, want one", result.Suppressions)
+		}
+		suppression := result.Suppressions[0]
+		if suppression.Kind != "external" || suppression.Status != "accepted" ||
+			suppression.Justification != "Synapse AI gate exemption: policy=fp-gate-v3; reason=verified_consensus" {
+			t.Errorf("suppression = %+v", suppression)
+		}
+		if result.Properties["synapse.aiGateExempt"] != true ||
+			result.Properties["synapse.aiPolicyVersion"] != "fp-gate-v3" ||
+			result.Properties["synapse.aiPolicyReason"] != "verified_consensus" {
+			t.Errorf("AI exemption properties = %+v", result.Properties)
+		}
+	}
+
+	first, err := MarshalSARIF(findings, "v9", SARIFOptions{AIGateExemption: resolver})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := MarshalSARIF(findings, "v9", SARIFOptions{AIGateExemption: resolver})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("AI exemption serialization is not deterministic")
+	}
+}
+
+func TestSARIFAIGateExemptionRejectsIncompleteOrMismatchedMetadata(t *testing.T) {
+	findingItem := firstPartyFindings()[1]
+	tests := []struct {
+		name string
+		meta ports.AIGateExemption
+	}{
+		{name: "mismatched finding", meta: ports.AIGateExemption{DedupKey: "other", PolicyVersion: "fp-gate-v3", PolicyReason: "verified_consensus"}},
+		{name: "missing policy version", meta: ports.AIGateExemption{DedupKey: findingItem.DedupKey, PolicyReason: "verified_consensus"}},
+		{name: "missing policy reason", meta: ports.AIGateExemption{DedupKey: findingItem.DedupKey, PolicyVersion: "fp-gate-v3"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := buildSARIF([]finding.Finding{findingItem}, "v9", SARIFOptions{
+				AIGateExemption: func(finding.Finding) (ports.AIGateExemption, bool) { return test.meta, true },
+			}).Runs[0].Results[0]
+			if len(result.Suppressions) != 0 {
+				t.Errorf("invalid metadata produced suppression: %+v", result.Suppressions)
+			}
+			if _, exists := result.Properties["synapse.aiGateExempt"]; exists {
+				t.Errorf("invalid metadata produced marker properties: %+v", result.Properties)
+			}
+		})
 	}
 }
 

--- a/internal/usecase/export/service.go
+++ b/internal/usecase/export/service.go
@@ -4,6 +4,7 @@ package export
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -22,10 +23,11 @@ type judgmentReader interface {
 
 // Service renders an engagement's findings as SARIF or OpenVEX.
 type Service struct {
-	findings  ports.FindingRepository
-	judgments judgmentReader // optional: confirmed not_reachable judgments refine VEX justification
-	clock     ports.Clock
-	version   string // tool version recorded in the output
+	findings         ports.FindingRepository
+	judgments        judgmentReader // optional: confirmed not_reachable judgments refine VEX justification
+	aiGateExemptions ports.AIGateExemptionReader
+	clock            ports.Clock
+	version          string // tool version recorded in the output
 }
 
 // NewService wires the export use case.
@@ -37,6 +39,12 @@ func NewService(findings ports.FindingRepository, clock ports.Clock, version str
 // by reachability tier. nil ⇒ the default justification.
 func (s *Service) SetJudgments(j judgmentReader) { s.judgments = j }
 
+// SetAIGateExemptions wires the latest-scan policy projection used to annotate retained SARIF results.
+// nil keeps legacy exports unannotated.
+func (s *Service) SetAIGateExemptions(reader ports.AIGateExemptionReader) {
+	s.aiGateExemptions = reader
+}
+
 // SARIF returns the engagement's findings as a SARIF 2.1.0 log. It reads through the
 // publishability gate so an unproven exploitation finding never ships
 // in the exported log.
@@ -45,10 +53,26 @@ func (s *Service) SARIF(ctx context.Context, engagementID shared.ID) (*SARIFLog,
 	if err != nil {
 		return nil, err
 	}
+	exemptions := map[string]ports.AIGateExemption{}
+	if s.aiGateExemptions != nil {
+		items, readErr := s.aiGateExemptions.AIGateExemptions(ctx, engagementID, fs)
+		if readErr != nil && !errors.Is(readErr, shared.ErrNotFound) {
+			return nil, readErr
+		}
+		for _, exemption := range items {
+			if key := strings.TrimSpace(exemption.DedupKey); key != "" {
+				exemptions[key] = exemption
+			}
+		}
+	}
 	// The store-backed export path has findings only (no SBOM), so no resolvers: SCA findings become
 	// repo-level alerts rather than logical-only locations a code-scanning UI would reject, and carry no
-	// inline fix version.
-	return buildSARIF(fs, s.version, SARIFOptions{}), nil
+	// inline fix version. AI gate metadata comes from the same persisted scan result that authorized the
+	// exemption and is revalidated before it reaches this service.
+	return buildSARIF(fs, s.version, SARIFOptions{AIGateExemption: func(item finding.Finding) (ports.AIGateExemption, bool) {
+		exemption, ok := exemptions[strings.TrimSpace(item.DedupKey)]
+		return exemption, ok
+	}}), nil
 }
 
 // OpenVEX returns the engagement's vulnerability findings as an OpenVEX document. It

--- a/internal/usecase/ports/fptriage.go
+++ b/internal/usecase/ports/fptriage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
 // SourceSnippetReader returns a small source excerpt around file:line (1-based, radius lines each side)
@@ -44,6 +45,21 @@ type AICritique struct {
 	VerifierVerdict    string `json:"verifier_verdict,omitempty"`
 	VerifierDriver     string `json:"verifier_driver,omitempty"`
 	VerifierConfidence int    `json:"verifier_confidence,omitempty"`
+}
+
+// AIGateExemption is the minimal, policy-owned projection an output adapter may use to explain why
+// a retained finding did not affect the CI gate. It deliberately excludes model prose and scores:
+// exports describe the deterministic policy decision, not an untrusted model response.
+type AIGateExemption struct {
+	DedupKey      string
+	PolicyVersion string
+	PolicyReason  string
+}
+
+// AIGateExemptionReader returns only exemptions revalidated against the exact finding view being
+// exported. An exporter must not infer gate authority directly from the advisory AICritique fields.
+type AIGateExemptionReader interface {
+	AIGateExemptions(ctx context.Context, engagementID shared.ID, findings []finding.Finding) ([]AIGateExemption, error)
 }
 
 // FPTriager runs an LLM false-positive critique over candidate findings from a workspace and returns a

--- a/internal/usecase/sca/fptriage_test.go
+++ b/internal/usecase/sca/fptriage_test.go
@@ -1,6 +1,7 @@
 package sca
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -10,6 +11,13 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+type staticScanResultStore struct{ data []byte }
+
+func (s staticScanResultStore) SaveResult(context.Context, shared.ID, []byte) error { return nil }
+func (s staticScanResultStore) LatestResult(context.Context, shared.ID) ([]byte, error) {
+	return s.data, nil
+}
 
 func TestFPTriageCandidates(t *testing.T) {
 	fs := []finding.Finding{
@@ -290,6 +298,76 @@ func TestAIGateExemptKeysRevalidatesPersistedDecision(t *testing.T) {
 	}
 	if got := result.AIGateExemptKeys(); len(got) != 0 {
 		t.Fatalf("persisted gate flag must be revalidated against the high-risk floor: %v", got)
+	}
+}
+
+func TestAIGateExemptionsProjectsOnlyPolicyAuthorizedDecision(t *testing.T) {
+	findings := []finding.Finding{
+		{DedupKey: "safe", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+		{DedupKey: "high", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityHigh, CWE: "CWE-327"},
+		{DedupKey: "critical", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityCritical, CWE: "CWE-327"},
+		{DedupKey: "secret", Kind: finding.KindSecret, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+		{DedupKey: "protected-cwe", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-89"},
+		{DedupKey: "ineligible", Kind: finding.KindSCA, Class: finding.ClassThirdParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+	}
+	result := &ScanResult{Findings: findings}
+	for _, item := range findings {
+		result.AITriage = append(result.AITriage, verifiedCritique(item.DedupKey))
+	}
+	applyAIGatePolicy(result, true, aiTriageModeEnforce)
+
+	noLedger := findings[0]
+	noLedger.DedupKey = "no-ledger"
+	withoutLedger := &ScanResult{Findings: []finding.Finding{noLedger}, AITriage: []ports.AICritique{verifiedCritique("no-ledger")}}
+	applyAIGatePolicy(withoutLedger, false, aiTriageModeEnforce)
+	result.Findings = append(result.Findings, noLedger)
+	result.AITriage = append(result.AITriage, withoutLedger.AITriage[0])
+
+	got := result.AIGateExemptions()
+	if len(got) != 1 {
+		t.Fatalf("AI gate exemption projection = %+v, want only safe", got)
+	}
+	exemption, ok := got["safe"]
+	if !ok || exemption.DedupKey != "safe" || exemption.PolicyVersion != aiTriagePolicyVersion || exemption.PolicyReason != aiPolicyVerifiedConsensus {
+		t.Errorf("safe exemption metadata = %+v", exemption)
+	}
+	for _, key := range []string{"high", "critical", "secret", "protected-cwe", "ineligible", "no-ledger"} {
+		if _, exists := got[key]; exists {
+			t.Errorf("unsafe decision %q received export metadata", key)
+		}
+	}
+}
+
+func TestServiceAIGateExemptionsReadsLatestResultDeterministically(t *testing.T) {
+	result := &ScanResult{
+		Findings: []finding.Finding{
+			{DedupKey: "z-safe", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+			{DedupKey: "a-safe", Kind: finding.KindMisconfig, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityLow, CWE: "CWE-16"},
+		},
+		AITriage: []ports.AICritique{verifiedCritique("z-safe"), verifiedCritique("a-safe")},
+	}
+	applyAIGatePolicy(result, true, aiTriageModeEnforce)
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := &Service{results: staticScanResultStore{data: data}}
+
+	got, err := svc.AIGateExemptions(context.Background(), "e1", result.Findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].DedupKey != "a-safe" || got[1].DedupKey != "z-safe" {
+		t.Fatalf("stored exemption order = %+v, want a-safe then z-safe", got)
+	}
+	exportView := append([]finding.Finding(nil), result.Findings...)
+	exportView[0].Severity = shared.SeverityHigh
+	got, err = svc.AIGateExemptions(context.Background(), "e1", exportView)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].DedupKey != "a-safe" {
+		t.Fatalf("severity-escalated export view retained stale exemption: %+v", got)
 	}
 }
 

--- a/internal/usecase/sca/fptriage_test.go
+++ b/internal/usecase/sca/fptriage_test.go
@@ -301,6 +301,46 @@ func TestAIGateExemptKeysRevalidatesPersistedDecision(t *testing.T) {
 	}
 }
 
+// TestAIGateExemptionsNeverProjectAForgedShadowDecision guards the shadow boundary at the EXPORT seam.
+//
+// Shadow mode exists so AI triage can be observed without affecting a gate (P1.1). A shadow decision
+// reaching SARIF as an "external / accepted" suppression would tell a code-scanning UI the finding was
+// accepted while the policy deliberately had no authority to accept it -- the shadow guarantee leaking
+// into an artifact customers and CI read as fact.
+//
+// The critique here is FORGED: Shadow and GateExempt both true, which applyAIGatePolicy never produces
+// (it clears GateExempt before the shadow branch). That is the point -- !c.Shadow in
+// authorizedAIGateExemption is defence against a persisted or hand-built DTO, so only a forged input
+// exercises it. My first attempt at this test used applyAIGatePolicy and passed for the wrong reason:
+// GateExempt was already false, so removing !c.Shadow left it green.
+func TestAIGateExemptionsNeverProjectAForgedShadowDecision(t *testing.T) {
+	forged := verifiedCritique("safe")
+	forged.GateExempt = true
+	forged.Shadow = true
+	forged.PolicyVersion = aiTriagePolicyVersion
+	forged.PolicyReason = aiPolicyVerifiedConsensus
+	findings := []finding.Finding{
+		{DedupKey: "safe", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},
+	}
+	result := &ScanResult{Findings: findings, AITriage: []ports.AICritique{forged}}
+
+	if got := result.AIGateExemptions(); len(got) != 0 {
+		t.Fatalf("a shadow decision must never be exported as an accepted suppression: %v", got)
+	}
+	if got := result.AIGateExemptKeys(); len(got) != 0 {
+		t.Fatalf("a shadow decision must never authorize a gate: %v", got)
+	}
+
+	// The same decision with Shadow cleared MUST project, or this test would pass for the wrong reason
+	// again -- it has to be the shadow flag doing the refusing, not some other unmet condition.
+	enforced := forged
+	enforced.Shadow = false
+	ok := &ScanResult{Findings: findings, AITriage: []ports.AICritique{enforced}}
+	if got := ok.AIGateExemptions(); len(got) != 1 {
+		t.Fatalf("with Shadow cleared the same decision must project exactly one exemption: %v", got)
+	}
+}
+
 func TestAIGateExemptionsProjectsOnlyPolicyAuthorizedDecision(t *testing.T) {
 	findings := []finding.Finding{
 		{DedupKey: "safe", Kind: finding.KindSAST, Class: finding.ClassFirstParty, Scope: sbom.ScopeProduction, Severity: shared.SeverityMedium, CWE: "CWE-327"},

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -682,6 +682,36 @@ func (r *ScanResult) AIGateExemptKeys() map[string]bool {
 	return r.aiGateExemptKeys(r.Findings)
 }
 
+// AIGateExemptions returns export-safe metadata only for decisions that still pass the complete
+// server-owned authorization check. Consumers must use this projection instead of trusting persisted
+// GateExempt flags directly; severity/profile changes and forged or stale decisions fail closed here.
+func (r *ScanResult) AIGateExemptions() map[string]ports.AIGateExemption {
+	return r.aiGateExemptions(r.Findings)
+}
+
+func (r *ScanResult) aiGateExemptions(items []finding.Finding) map[string]ports.AIGateExemption {
+	findings := make(map[string]finding.Finding, len(items))
+	for _, item := range items {
+		if key := strings.TrimSpace(item.DedupKey); key != "" {
+			findings[key] = item
+		}
+	}
+	out := map[string]ports.AIGateExemption{}
+	for _, critique := range r.AITriage {
+		key := strings.TrimSpace(critique.DedupKey)
+		item, found := findings[key]
+		if !authorizedAIGateExemption(critique, item, found) {
+			continue
+		}
+		out[key] = ports.AIGateExemption{
+			DedupKey:      key,
+			PolicyVersion: critique.PolicyVersion,
+			PolicyReason:  critique.PolicyReason,
+		}
+	}
+	return out
+}
+
 // aiGateExemptKeys revalidates decisions against the exact finding view a gate will consume. Project
 // quality profiles may overlay severity, so using r.Findings here could exempt a finding the tenant
 // deliberately escalated to High/Critical.
@@ -696,15 +726,19 @@ func (r *ScanResult) aiGateExemptKeys(items []finding.Finding) map[string]bool {
 	for _, c := range r.AITriage {
 		key := strings.TrimSpace(c.DedupKey)
 		item, found := findings[key]
-		if !c.Shadow && c.GateExempt &&
-			c.PolicyVersion == aiTriagePolicyVersion &&
-			c.PolicyReason == aiPolicyVerifiedConsensus &&
-			hasVerifiedConsensus(c) &&
-			found && humanReviewFloor(item) == "" && isFPTriageEligible(item) {
+		if authorizedAIGateExemption(c, item, found) {
 			out[key] = true
 		}
 	}
 	return out
+}
+
+func authorizedAIGateExemption(c ports.AICritique, item finding.Finding, found bool) bool {
+	return !c.Shadow && c.GateExempt &&
+		c.PolicyVersion == aiTriagePolicyVersion &&
+		c.PolicyReason == aiPolicyVerifiedConsensus &&
+		hasVerifiedConsensus(c) &&
+		found && humanReviewFloor(item) == "" && isFPTriageEligible(item)
 }
 
 // AIWouldGateExemptKeys returns shadow observations that passed every enforced-policy check except the
@@ -3009,6 +3043,26 @@ func (s *Service) LatestResult(ctx context.Context, engagementID shared.ID) ([]b
 		return nil, fmt.Errorf("scan result: %w", shared.ErrNotFound)
 	}
 	return s.results.LatestResult(ctx, engagementID)
+}
+
+// AIGateExemptions reads the latest durable scan and returns a stable projection revalidated against
+// the exact findings being exported. Older scans with no AI triage naturally return an empty slice.
+func (s *Service) AIGateExemptions(ctx context.Context, engagementID shared.ID, findings []finding.Finding) ([]ports.AIGateExemption, error) {
+	data, err := s.LatestResult(ctx, engagementID)
+	if err != nil {
+		return nil, err
+	}
+	var result ScanResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("decode latest scan result: %w", err)
+	}
+	byKey := result.aiGateExemptions(findings)
+	out := make([]ports.AIGateExemption, 0, len(byKey))
+	for _, exemption := range byKey {
+		out = append(out, exemption)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].DedupKey < out[j].DedupKey })
+	return out, nil
 }
 
 func kindOrLocal(kind string) string {


### PR DESCRIPTION
## Summary

Expose policy-authorized AI false-positive gate exemptions in SARIF without removing the finding. This closes the visibility gap where CI could pass while the exported result did not explain that AI policy excluded it from the gate.

Closes #430.

## Changes

- Add a standards-based SARIF `external` / `accepted` suppression with a deterministic justification containing the AI policy version and reason.
- Keep exempted findings in `runs[].results` and add namespaced properties for consumers that do not render suppressions.
- Revalidate persisted decisions against the exact finding view being exported, so severity escalation, protected CWE, secret, ineligible, shadow, review-required, stale-policy, and no-evidence decisions remain unmarked.
- Apply the same projection to CLI SARIF and stored engagement SARIF exports.
- Document the output and add an Unreleased changelog entry.

## Safety

- The exporter never derives authority from advisory model output; it consumes a minimal server-owned projection after the full deterministic policy check.
- Findings are retained, never deleted.
- A missing legacy scan result produces an unannotated export; unreadable exemption metadata fails the export instead of silently misrepresenting gate state.
- Reports remain deterministic and no LLM runs in the export path.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `cd web && pnpm run typecheck`
- `cd web && pnpm test` (36 files, 291 tests)
- `cd web && pnpm build`

## Checklist

- [x] `make build vet test typecheck` equivalent commands pass
- [x] `cd web && pnpm build` passes
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets out of logs, deterministic reports, append-only evidence)
- [x] Documentation updated