### PR TITLE
feat(appsec): add sanctioned source snapshot publishing

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -333,6 +333,69 @@ paths:
         "404": {$ref: "#/components/responses/NotFound"}
         "500": {$ref: "#/components/responses/InternalServerError"}
 
+  /api/v1/projects/{key}/analyses/{id}/source:
+    parameters:
+    - $ref: '#/components/parameters/ProjectKey'
+    - $ref: '#/components/parameters/AnalysisId'
+    post:
+      tags: [projects]
+      summary: Publish an immutable source snapshot for one server-owned Project analysis
+      operationId: publishProjectAnalysisSource
+      description: >
+        Authenticated CI contribution path for Code Quality source. The server derives tenant
+        and actor from the bearer token, re-resolves the analysis under that tenant/project,
+        applies configured source-capture policy and limits, and creates the snapshot once.
+      parameters:
+      - name: X-Synapse-Tool-Version
+        in: header
+        required: true
+        schema: {type: string, minLength: 1}
+      requestBody:
+        required: true
+        content:
+          application/x-tar:
+            schema: {type: string, format: binary}
+      responses:
+        "201":
+          description: Source snapshot published and attached to the immutable analysis
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [files, writer, digest]
+                properties:
+                  files:
+                    type: array
+                    items:
+                      type: object
+                      required: [path, bytes, lines, generated, available]
+                      properties:
+                        path: {type: string, minLength: 1}
+                        digest: {type: string}
+                        bytes: {type: integer, format: int64, minimum: 0}
+                        lines: {type: integer, minimum: 0}
+                        generated: {type: boolean}
+                        available: {type: boolean}
+                        reason: {type: string}
+                  truncated: {type: boolean}
+                  writer:
+                    type: object
+                    required: [actor, tool_version, published_at]
+                    properties:
+                      actor: {type: string, minLength: 1}
+                      tool_version: {type: string, minLength: 1}
+                      published_at: {type: string, format: date-time}
+                  digest: {type: string, pattern: '^sha256:[0-9a-f]{64}$'}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Analysis already has source or source artifact state conflicts}
+        "413": {description: Source archive exceeds the transport upload limit}
+        "415": {description: Content-Type is not application/x-tar}
+        "500": {$ref: "#/components/responses/InternalServerError"}
+        "503": {description: Source artifact storage is temporarily unavailable}
+
   /api/v1/projects/{key}/analyses/{id}/code/files:
     parameters:
     - $ref: '#/components/parameters/ProjectKey'

--- a/api/openapi_source_publish_test.go
+++ b/api/openapi_source_publish_test.go
@@ -1,0 +1,63 @@
+package api_test
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestSourcePublishOpenAPIContract(t *testing.T) {
+	b, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	paths, ok := doc["paths"].(map[string]any)
+	if !ok {
+		t.Fatal("OpenAPI paths missing")
+	}
+	route, ok := paths["/api/v1/projects/{key}/analyses/{id}/source"].(map[string]any)
+	if !ok {
+		t.Fatal("sanctioned source publish path missing from OpenAPI")
+	}
+	post, ok := route["post"].(map[string]any)
+	if !ok {
+		t.Fatal("sanctioned source publish POST missing from OpenAPI")
+	}
+	if got := post["operationId"]; got != "publishProjectAnalysisSource" {
+		t.Fatalf("operationId=%v, want publishProjectAnalysisSource", got)
+	}
+	params, _ := post["parameters"].([]any)
+	foundToolVersion := false
+	for _, raw := range params {
+		p, _ := raw.(map[string]any)
+		if p["name"] == "X-Synapse-Tool-Version" && p["in"] == "header" && p["required"] == true {
+			foundToolVersion = true
+		}
+	}
+	if !foundToolVersion {
+		t.Fatal("required X-Synapse-Tool-Version header missing from OpenAPI")
+	}
+	requestBody, _ := post["requestBody"].(map[string]any)
+	content, _ := requestBody["content"].(map[string]any)
+	if _, ok := content["application/x-tar"]; !ok {
+		t.Fatal("application/x-tar request contract missing")
+	}
+	responses, _ := post["responses"].(map[string]any)
+	for _, status := range []string{"201", "400", "401", "403", "404", "409", "413", "415", "500", "503"} {
+		if _, ok := responses[status]; !ok {
+			t.Fatalf("response %s missing from source publish OpenAPI contract", status)
+		}
+	}
+	response201 := responses["201"].(map[string]any)
+	responseContent := response201["content"].(map[string]any)["application/json"].(map[string]any)
+	schema := responseContent["schema"].(map[string]any)
+	digest := schema["properties"].(map[string]any)["digest"].(map[string]any)
+	if digest["pattern"] != "^sha256:[0-9a-f]{64}$" {
+		t.Fatalf("manifest digest pattern=%v", digest["pattern"])
+	}
+}

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -996,6 +996,7 @@ func main() {
 	projectService.SetProjectAnalysisCompletionTimeout(cfg.ProjectAnalysisCompletionTimeout)
 	scaService.SetLogger(log)
 	sourceArtifacts := sourceartifact.New(cfg.ProjectSourceArtifactDir, cfg.ProjectSourceMaxFileBytes, cfg.ProjectSourceMaxFiles, cfg.ProjectSourceMaxBytes)
+	sourceArtifacts.SetRetention(cfg.ProjectSourceRetention)
 	projectService.SetSourceArtifactStore(sourceArtifacts)
 	scaService.SetProjectSourceArtifactStore(sourceArtifacts)
 	scaService.SetProjectComparisonSource(&gitdiff.ComparisonSource{})

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -95,6 +95,11 @@ func main() {
 		}
 	case "scan":
 		runScan()
+	case "publish-source":
+		if err := runPublishSource(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "synapse-cli:", err)
+			os.Exit(1)
+		}
 	// validate-sarif is named for what it does: it reports what the server would accept or refuse and
 	// writes nothing. `import-sarif` is kept as an alias so an existing invocation still works, but it
 	// prints the same "persisted: false" contract rather than implying an ingest happened.
@@ -985,6 +990,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "      --image    treat the argument as a container image reference (pulled via crane) instead of a local path")
 	fmt.Fprintln(os.Stderr, "      --offline  skip the live OSV.dev source; detect with Grype's offline DB only (air-gapped / fast)")
 	fmt.Fprintln(os.Stderr, "      --include-test  also fail the gate on findings in test/fixture/example paths (default: reported but exempt)")
+	fmt.Fprintln(os.Stderr, "  synapse-cli publish-source [path] --server URL --project KEY --analysis ID  # stream server-inventoried source; token from SYNAPSE_API_TOKEN")
 	fmt.Fprintln(os.Stderr, "  synapse-cli inventory <path>             # per-language code-size inventory (files, code/comment/blank lines, functions) – no DB")
 	fmt.Fprintln(os.Stderr, "  synapse-cli metrics <path> [--fail-on-complexity N] [--top N]  # per-function cyclomatic+cognitive complexity (needs the synapse-ast sidecar)")
 	fmt.Fprintln(os.Stderr, "  synapse-cli duplication <path> [--min-tokens N] [--fail-on-duplication PCT] [--top N]  # copy-paste detection (blocks, lines, density) – no DB")

--- a/cmd/synapse-cli/publishsource.go
+++ b/cmd/synapse-cli/publishsource.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/buildinfo"
+)
+
+func runPublishSource(args []string) error {
+	fs := flag.NewFlagSet("publish-source", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	server := fs.String("server", strings.TrimSpace(os.Getenv("SYNAPSE_API_URL")), "Synapse API base URL")
+	projectKey := fs.String("project", "", "server-owned project key")
+	analysisID := fs.String("analysis", "", "server-owned analysis id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 1 {
+		return fmt.Errorf("publish-source accepts at most one source directory")
+	}
+	root := "."
+	if fs.NArg() == 1 {
+		root = fs.Arg(0)
+	}
+	token := strings.TrimSpace(os.Getenv("SYNAPSE_API_TOKEN"))
+	if strings.TrimSpace(*server) == "" || strings.TrimSpace(*projectKey) == "" || strings.TrimSpace(*analysisID) == "" || token == "" {
+		return fmt.Errorf("publish-source requires --server, --project, --analysis and SYNAPSE_API_TOKEN")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	manifest, err := publishSourceFromAnalysis(ctx, http.DefaultClient, *server, token, *projectKey, *analysisID, root, buildinfo.App())
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(manifest)
+}
+
+func publishSourceFromAnalysis(ctx context.Context, client *http.Client, server, token, projectKey, analysisID, root, toolVersion string) (projectanalysis.SourceManifest, error) {
+	if client == nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("http client is required")
+	}
+	client = sourcePublishNoRedirectClient(client)
+	base, err := sourcePublishBaseURL(server)
+	if err != nil {
+		return projectanalysis.SourceManifest{}, err
+	}
+	if strings.TrimSpace(token) == "" || strings.TrimSpace(projectKey) == "" || strings.TrimSpace(analysisID) == "" || strings.TrimSpace(toolVersion) == "" {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("source publication identity is incomplete")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("resolve source directory: %w", err)
+	}
+	info, err := os.Lstat(absRoot)
+	if err != nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("inspect source directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("publish-source target must be a source directory")
+	}
+
+	analysisURL := sourcePublishURL(base, projectKey, analysisID, false)
+	analysis, err := fetchPublishAnalysis(ctx, client, analysisURL, token)
+	if err != nil {
+		return projectanalysis.SourceManifest{}, err
+	}
+	if analysis.ID != analysisID || analysis.ProjectKey != projectKey || !analysis.SourceRevision.Kind.Valid() {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("server returned an incompatible source analysis")
+	}
+	paths := retainableAnalysisPaths(analysis)
+	if len(paths) == 0 {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("analysis has no retainable source files")
+	}
+
+	pr, pw := io.Pipe()
+	writeErr := make(chan error, 1)
+	go func() {
+		err := writeAnalysisSourceTar(absRoot, paths, pw)
+		_ = pw.CloseWithError(err)
+		writeErr <- err
+	}()
+
+	publishURL := sourcePublishURL(base, projectKey, analysisID, true)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, publishURL, pr)
+	if err != nil {
+		_ = pr.CloseWithError(err)
+		<-writeErr
+		return projectanalysis.SourceManifest{}, fmt.Errorf("build source publish request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/x-tar")
+	req.Header.Set("X-Synapse-Tool-Version", toolVersion)
+	resp, err := client.Do(req)
+	if err != nil {
+		_ = pr.CloseWithError(err)
+		<-writeErr
+		return projectanalysis.SourceManifest{}, fmt.Errorf("publish source: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_ = pr.Close()
+	streamErr := <-writeErr
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return projectanalysis.SourceManifest{}, sourcePublishHTTPError(resp)
+	}
+	if streamErr != nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("stream source archive: %w", streamErr)
+	}
+	var manifest projectanalysis.SourceManifest
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&manifest); err != nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("decode source publish response: %w", err)
+	}
+	if manifest.Digest == "" || manifest.Digest != manifest.ArtifactDigest() || manifest.Writer == nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("server returned an invalid source manifest")
+	}
+	return manifest, nil
+}
+
+func sourcePublishNoRedirectClient(client *http.Client) *http.Client {
+	clone := *client
+	clone.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &clone
+}
+
+func sourcePublishBaseURL(raw string) (*url.URL, error) {
+	base, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || base.Host == "" || (base.Scheme != "http" && base.Scheme != "https") || base.User != nil {
+		return nil, fmt.Errorf("invalid Synapse API URL")
+	}
+	base.RawQuery, base.Fragment = "", ""
+	return base, nil
+}
+
+func sourcePublishURL(base *url.URL, projectKey, analysisID string, source bool) string {
+	u := base.JoinPath("api", "v1", "projects", projectKey, "analyses", analysisID)
+	if source {
+		u = u.JoinPath("source")
+	}
+	return u.String()
+}
+
+func fetchPublishAnalysis(ctx context.Context, client *http.Client, endpoint, token string) (projectanalysis.Analysis, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return projectanalysis.Analysis{}, fmt.Errorf("build analysis request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return projectanalysis.Analysis{}, fmt.Errorf("fetch analysis: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return projectanalysis.Analysis{}, sourcePublishHTTPError(resp)
+	}
+	var analysis projectanalysis.Analysis
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 8<<20)).Decode(&analysis); err != nil {
+		return projectanalysis.Analysis{}, fmt.Errorf("decode analysis: %w", err)
+	}
+	return analysis, nil
+}
+
+func sourcePublishHTTPError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &payload) == nil && strings.TrimSpace(payload.Error) != "" {
+		return fmt.Errorf("synapse API returned %s: %s", resp.Status, strings.TrimSpace(payload.Error))
+	}
+	return fmt.Errorf("synapse API returned %s", resp.Status)
+}
+
+func retainableAnalysisPaths(analysis projectanalysis.Analysis) []string {
+	seen := make(map[string]struct{})
+	paths := make([]string, 0, len(analysis.Snapshot.Nodes))
+	for _, node := range analysis.Snapshot.Nodes {
+		if node.Kind != measure.NodeFile || !sourcepolicy.RetainPath(node.Path) {
+			continue
+		}
+		if _, ok := seen[node.Path]; ok {
+			continue
+		}
+		seen[node.Path] = struct{}{}
+		paths = append(paths, node.Path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func writeAnalysisSourceTar(absRoot string, paths []string, dst io.Writer) error {
+	root, err := os.OpenRoot(absRoot)
+	if err != nil {
+		return fmt.Errorf("open source directory: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+	tw := tar.NewWriter(dst)
+	for _, canonical := range paths {
+		if !sourcepolicy.RetainPath(canonical) {
+			continue
+		}
+		name := filepath.FromSlash(canonical)
+		before, err := root.Lstat(name)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			_ = tw.Close()
+			return fmt.Errorf("inspect source file %q: %w", canonical, err)
+		}
+		if !before.Mode().IsRegular() {
+			continue
+		}
+		file, err := root.Open(name)
+		if err != nil {
+			_ = tw.Close()
+			return fmt.Errorf("open source file %q: %w", canonical, err)
+		}
+		after, err := file.Stat()
+		if err != nil {
+			_ = file.Close()
+			_ = tw.Close()
+			return fmt.Errorf("stat source file %q: %w", canonical, err)
+		}
+		if !after.Mode().IsRegular() || !os.SameFile(before, after) {
+			_ = file.Close()
+			_ = tw.Close()
+			return fmt.Errorf("source file %q changed type while publishing", canonical)
+		}
+		hdr := &tar.Header{Name: canonical, Mode: 0o600, Size: after.Size(), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			_ = file.Close()
+			_ = tw.Close()
+			return fmt.Errorf("write source archive header: %w", err)
+		}
+		if _, err := io.CopyN(tw, file, after.Size()); err != nil {
+			_ = file.Close()
+			_ = tw.Close()
+			return fmt.Errorf("stream source file %q: %w", canonical, err)
+		}
+		if err := file.Close(); err != nil {
+			_ = tw.Close()
+			return fmt.Errorf("close source file %q: %w", canonical, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("close source archive: %w", err)
+	}
+	return nil
+}

--- a/cmd/synapse-cli/publishsource_redirect_test.go
+++ b/cmd/synapse-cli/publishsource_redirect_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+)
+
+func TestPublishSourceFromAnalysisRefusesRedirects(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	analysis := projectanalysis.Analysis{
+		ID: "analysis", ProjectKey: "project",
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Snapshot:       measure.Snapshot{Nodes: []measure.Node{{Path: "main.go", Kind: measure.NodeFile}}},
+	}
+	var redirected atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirected.Add(1)
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("bearer credential reached redirect target")
+		}
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(analysis)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		writer := projectanalysis.SourceWriter{Actor: "redirect-target", ToolVersion: "test", PublishedAt: time.Unix(1_700_000_000, 0).UTC()}
+		manifest := projectanalysis.SourceManifest{Writer: &writer, Files: []projectanalysis.SourceFile{{Path: "main.go", Digest: "fixture", Bytes: 13, Lines: 1, Available: true}}}
+		manifest.SetArtifactDigest()
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(manifest)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+r.URL.Path, http.StatusTemporaryRedirect)
+	}))
+	defer redirector.Close()
+
+	_, err := publishSourceFromAnalysis(context.Background(), redirector.Client(), redirector.URL, "token", "project", "analysis", root, "test")
+	if err == nil || !strings.Contains(err.Error(), "307") {
+		t.Fatalf("redirect error=%v, want explicit 307 refusal", err)
+	}
+	if got := redirected.Load(); got != 0 {
+		t.Fatalf("redirect target received %d request(s), want 0", got)
+	}
+}

--- a/cmd/synapse-cli/publishsource_test.go
+++ b/cmd/synapse-cli/publishsource_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+)
+
+func TestPublishSourceFromAnalysisStreamsOnlyRetainableInventory(t *testing.T) {
+	root := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("src/main.go", "package main\n")
+	write(".env", "fixture-blocked-by-path\n")
+	write("keys/private.pem", "fixture-blocked-by-path\n")
+	write("ignored.txt", "scanner did not inventory this\n")
+
+	analysis := projectanalysis.Analysis{
+		ID: "analysis", ProjectKey: "project",
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{
+			{Path: "", Kind: measure.NodeProject},
+			{Path: "src/main.go", Kind: measure.NodeFile},
+			// Deliberately model scanner inventory drift: credential denylist still wins.
+			{Path: ".env", Kind: measure.NodeFile},
+			{Path: "keys/private.pem", Kind: measure.NodeFile},
+		}},
+	}
+	var (
+		mu       sync.Mutex
+		uploaded []string
+		bodies   = map[string]string{}
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			t.Errorf("authorization=%q", r.Header.Get("Authorization"))
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/project/analyses/analysis":
+			_ = json.NewEncoder(w).Encode(analysis)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/project/analyses/analysis/source":
+			if r.Header.Get("Content-Type") != "application/x-tar" || r.Header.Get("X-Synapse-Tool-Version") != "test-version" {
+				t.Errorf("publish headers content-type=%q version=%q", r.Header.Get("Content-Type"), r.Header.Get("X-Synapse-Tool-Version"))
+			}
+			tr := tar.NewReader(r.Body)
+			for {
+				hdr, err := tr.Next()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Errorf("tar: %v", err)
+					return
+				}
+				data, err := io.ReadAll(tr)
+				if err != nil {
+					t.Errorf("read tar file: %v", err)
+					return
+				}
+				mu.Lock()
+				uploaded = append(uploaded, hdr.Name)
+				bodies[hdr.Name] = string(data)
+				mu.Unlock()
+			}
+			writer := projectanalysis.SourceWriter{Actor: "ci-user", ToolVersion: "test-version", PublishedAt: time.Unix(1_700_000_000, 0).UTC()}
+			manifest := projectanalysis.SourceManifest{Writer: &writer, Files: []projectanalysis.SourceFile{{Path: "src/main.go", Digest: "fixture", Bytes: 13, Lines: 1, Available: true}}}
+			manifest.SetArtifactDigest()
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(manifest)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	manifest, err := publishSourceFromAnalysis(context.Background(), server.Client(), server.URL, "token", "project", "analysis", root, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Writer == nil || manifest.Writer.Actor != "ci-user" {
+		t.Fatalf("manifest=%+v", manifest)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(uploaded, []string{"src/main.go"}) {
+		t.Fatalf("uploaded=%v, want only scanner-inventoried non-secret source", uploaded)
+	}
+	if bodies["src/main.go"] != "package main\n" {
+		t.Fatalf("main.go body=%q", bodies["src/main.go"])
+	}
+	for _, forbidden := range []string{".env", "keys/private.pem", "ignored.txt"} {
+		if _, ok := bodies[forbidden]; ok {
+			t.Fatalf("forbidden file %q crossed the publish transport", forbidden)
+		}
+	}
+}
+
+func TestPublishSourceFromAnalysisPropagatesServerRefusal(t *testing.T) {
+	analysis := projectanalysis.Analysis{
+		ID: "analysis", ProjectKey: "project",
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{{Path: "main.go", Kind: measure.NodeFile}}},
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(analysis)
+			return
+		}
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, `{"error":"source snapshot already retained"}`)
+	}))
+	defer server.Close()
+
+	_, err := publishSourceFromAnalysis(context.Background(), server.Client(), server.URL, "token", "project", "analysis", root, "test")
+	if err == nil || !strings.Contains(err.Error(), "409") || !strings.Contains(err.Error(), "already retained") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestPublishSourceFromAnalysisRejectsNonDirectoryBeforeNetwork(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "app.jar")
+	if err := os.WriteFile(root, []byte("jar"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	_, err := publishSourceFromAnalysis(context.Background(), server.Client(), server.URL, "token", "project", "analysis", root, "test")
+	if err == nil || !strings.Contains(err.Error(), "source directory") {
+		t.Fatalf("error=%v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("network calls=%d, want 0", calls)
+	}
+}

--- a/internal/adapter/httpapi/project_source_publish_handler.go
+++ b/internal/adapter/httpapi/project_source_publish_handler.go
@@ -1,0 +1,67 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"mime"
+	"net/http"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
+)
+
+const (
+	projectSourcePublishMediaType   = "application/x-tar"
+	projectSourceToolVersionHeader = "X-Synapse-Tool-Version"
+	// The retained source default is 500 MiB. Keep an independent transport ceiling above that
+	// budget so tar headers/padding fit, while ignored-path streams still cannot be unbounded.
+	projectSourcePublishMaxBody = int64(600 << 20)
+)
+
+type projectSourcePublisher interface {
+	PublishSource(context.Context, projectuc.PublishSourceInput) (projectanalysis.SourceManifest, error)
+}
+
+func (rt *Router) publishProjectSource(w http.ResponseWriter, r *http.Request) {
+	rt.publishProjectSourceWithLimit(w, r, projectSourcePublishMaxBody)
+}
+
+func (rt *Router) publishProjectSourceWithLimit(w http.ResponseWriter, r *http.Request, maxBody int64) {
+	publisher, ok := rt.projects.(projectSourcePublisher)
+	if !ok {
+		writeJSON(w, http.StatusNotImplemented, errorBody{Error: "source publication is not configured"})
+		return
+	}
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != projectSourcePublishMediaType {
+		writeJSON(w, http.StatusUnsupportedMediaType, errorBody{Error: "Content-Type must be application/x-tar"})
+		return
+	}
+	toolVersion := strings.TrimSpace(r.Header.Get(projectSourceToolVersionHeader))
+	if toolVersion == "" {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: projectSourceToolVersionHeader + " is required"})
+		return
+	}
+	body := http.MaxBytesReader(w, r.Body, maxBody)
+	defer func() { _ = body.Close() }()
+	manifest, err := publisher.PublishSource(r.Context(), projectuc.PublishSourceInput{
+		TenantID:    shared.ID(TenantFrom(r.Context())),
+		ProjectKey:  r.PathValue("key"),
+		AnalysisID:  r.PathValue("id"),
+		Actor:       PrincipalFrom(r.Context()),
+		ToolVersion: toolVersion,
+		Archive:     body,
+	})
+	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorBody{Error: "source archive exceeds upload limit"})
+			return
+		}
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, manifest)
+}

--- a/internal/adapter/httpapi/project_source_publish_handler_test.go
+++ b/internal/adapter/httpapi/project_source_publish_handler_test.go
@@ -1,0 +1,103 @@
+package httpapi
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
+)
+
+type sourcePublishHTTPStub struct {
+	projectService
+	input  projectuc.PublishSourceInput
+	called int
+	read   bool
+}
+
+func (s *sourcePublishHTTPStub) PublishSource(_ context.Context, in projectuc.PublishSourceInput) (projectanalysis.SourceManifest, error) {
+	s.called++
+	s.input = in
+	if s.read {
+		if _, err := io.Copy(io.Discard, in.Archive); err != nil {
+			return projectanalysis.SourceManifest{}, fmt.Errorf("consume archive: %w", err)
+		}
+	}
+	return projectanalysis.SourceManifest{Digest: "sha256:test"}, nil
+}
+
+func TestPublishProjectSourceDerivesTenantAndActorFromAuthenticatedContext(t *testing.T) {
+	stub := &sourcePublishHTTPStub{}
+	rt := &Router{log: slog.New(slog.NewTextHandler(io.Discard, nil)), projects: stub}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects/project/analyses/analysis/source", strings.NewReader("tar-bytes"))
+	req.Header.Set("Content-Type", "application/x-tar")
+	req.Header.Set(projectSourceToolVersionHeader, "v1.2.3")
+	req.SetPathValue("key", "project")
+	req.SetPathValue("id", "analysis")
+	req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "ci-user", TenantID: "tenant-auth", Role: "operator"}))
+	res := httptest.NewRecorder()
+
+	rt.publishProjectSource(res, req)
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", res.Code, res.Body.String())
+	}
+	if stub.called != 1 {
+		t.Fatalf("publish calls=%d, want 1", stub.called)
+	}
+	if stub.input.TenantID.String() != "tenant-auth" || stub.input.Actor != "ci-user" || stub.input.ProjectKey != "project" || stub.input.AnalysisID != "analysis" || stub.input.ToolVersion != "v1.2.3" {
+		t.Fatalf("unexpected publish input: %+v", stub.input)
+	}
+}
+
+func TestPublishProjectSourceFailsClosedOnTransportContract(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		toolVersion string
+		wantStatus  int
+	}{
+		{name: "wrong media type", contentType: "application/json", toolVersion: "v1", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "missing tool version", contentType: "application/x-tar", wantStatus: http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &sourcePublishHTTPStub{}
+			rt := &Router{log: slog.New(slog.NewTextHandler(io.Discard, nil)), projects: stub}
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
+			req.Header.Set("Content-Type", tc.contentType)
+			if tc.toolVersion != "" {
+				req.Header.Set(projectSourceToolVersionHeader, tc.toolVersion)
+			}
+			res := httptest.NewRecorder()
+			rt.publishProjectSourceWithLimit(res, req, 16)
+			if res.Code != tc.wantStatus {
+				t.Fatalf("status=%d body=%s", res.Code, res.Body.String())
+			}
+			if stub.called != 0 {
+				t.Fatalf("invalid request reached publisher %d time(s)", stub.called)
+			}
+		})
+	}
+}
+
+func TestPublishProjectSourceRejectsOversizedArchiveBeforeSuccess(t *testing.T) {
+	stub := &sourcePublishHTTPStub{read: true}
+	rt := &Router{log: slog.New(slog.NewTextHandler(io.Discard, nil)), projects: stub}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("0123456789abcdef"))
+	req.Header.Set("Content-Type", "application/x-tar")
+	req.Header.Set(projectSourceToolVersionHeader, "v1")
+	res := httptest.NewRecorder()
+
+	rt.publishProjectSourceWithLimit(res, req, 8)
+	if res.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d body=%s", res.Code, res.Body.String())
+	}
+	if stub.called != 1 {
+		t.Fatalf("publisher calls=%d, want 1", stub.called)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -317,6 +317,7 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/projects/{key}/analyses", rt.authz(userdom.PermOperate, rt.startProjectAnalysis))
 		mux.HandleFunc("GET /api/v1/projects/{key}/analyses", rt.authz(userdom.PermView, rt.listProjectAnalyses))
 		mux.HandleFunc("GET /api/v1/projects/{key}/analyses/{id}", rt.authz(userdom.PermView, rt.getProjectAnalysis))
+		mux.HandleFunc("POST /api/v1/projects/{key}/analyses/{id}/source", rt.authz(userdom.PermOperate, rt.publishProjectSource))
 		mux.HandleFunc("GET /api/v1/projects/{key}/analyses/{id}/code/files", rt.authz(userdom.PermView, rt.listProjectCodeFiles))
 		mux.HandleFunc("GET /api/v1/projects/{key}/analyses/{id}/code/file", rt.authz(userdom.PermView, rt.getProjectCodeFile))
 		mux.HandleFunc("GET /api/v1/projects/{key}/analyses/{id}/code/diff", rt.authz(userdom.PermView, rt.getProjectCodeDiff))

--- a/internal/domain/projectanalysis/source.go
+++ b/internal/domain/projectanalysis/source.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
@@ -38,6 +39,7 @@ type UnavailableReason string
 const (
 	UnavailableNotRetained       UnavailableReason = "not_retained"
 	UnavailableCaptureFailed     UnavailableReason = "capture_failed"
+	UnavailableAlreadyRetained   UnavailableReason = "already_retained"
 	UnavailableFirstAnalysis     UnavailableReason = "first_analysis"
 	UnavailableNoComparableBase  UnavailableReason = "no_comparable_base"
 	UnavailableUnsupportedTarget UnavailableReason = "unsupported_target"
@@ -48,7 +50,7 @@ const (
 
 func (r UnavailableReason) Valid() bool {
 	switch r {
-	case UnavailableNotRetained, UnavailableCaptureFailed, UnavailableFirstAnalysis,
+	case UnavailableNotRetained, UnavailableCaptureFailed, UnavailableAlreadyRetained, UnavailableFirstAnalysis,
 		UnavailableNoComparableBase, UnavailableUnsupportedTarget, UnavailableLimitExceeded,
 		UnavailableBinary, UnavailableNonUTF8:
 		return true
@@ -251,11 +253,28 @@ func (f SourceFile) Validate() error {
 	return nil
 }
 
+// SourceWriter is the authenticated provenance of a sanctioned source contribution.
+// It lives inside manifest.json so the manifest digest seals who published it, with which
+// client version, and when the server accepted the contribution.
+type SourceWriter struct {
+	Actor       string    `json:"actor"`
+	ToolVersion string    `json:"tool_version"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+func (w SourceWriter) Validate() error {
+	if strings.TrimSpace(w.Actor) == "" || strings.TrimSpace(w.ToolVersion) == "" || w.PublishedAt.IsZero() {
+		return fmt.Errorf("source writer provenance is invalid")
+	}
+	return nil
+}
+
 // SourceManifest is the analysis-owned source capture inventory. It is immutable after
 // publication and reconciled against measure.Snapshot.Nodes before persistence.
 type SourceManifest struct {
 	Files     []SourceFile `json:"files"`
 	Truncated bool         `json:"truncated,omitempty"`
+	Writer    *SourceWriter `json:"writer,omitempty"`
 	Digest    string       `json:"digest,omitempty"`
 }
 

--- a/internal/domain/sourcepolicy/policy.go
+++ b/internal/domain/sourcepolicy/policy.go
@@ -1,0 +1,47 @@
+// Package sourcepolicy defines the server-authoritative policy for durable Code source snapshots.
+package sourcepolicy
+
+import (
+	"path"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+)
+
+var ignoredSegments = map[string]struct{}{
+	".git": {}, ".hg": {}, ".svn": {}, ".idea": {}, ".vscode": {}, ".tox": {},
+	".venv": {}, "venv": {}, "__pycache__": {}, "node_modules": {}, "vendor": {},
+	"dist": {}, "build": {}, "target": {},
+}
+
+// RetainPath reports whether a canonical, scanner-owned source path is safe to retain durably.
+// The analysis snapshot remains the primary allowlist. This policy mirrors the inventory's heavy
+// state/vendor exclusions and adds credential-shaped files that must never become source artifacts,
+// even if a producer's inventory drifts.
+func RetainPath(p string) bool {
+	canonical, err := measure.CanonicalPath(p)
+	if err != nil || canonical == "" || canonical != p {
+		return false
+	}
+	segments := strings.Split(canonical, "/")
+	for _, segment := range segments {
+		lower := strings.ToLower(segment)
+		if _, ignored := ignoredSegments[lower]; ignored {
+			return false
+		}
+	}
+	name := strings.ToLower(path.Base(canonical))
+	if name == ".env" || strings.HasPrefix(name, ".env.") {
+		return false
+	}
+	switch name {
+	case ".netrc", ".npmrc", ".pypirc", ".git-credentials", "credentials.json",
+		"id_rsa", "id_dsa", "id_ecdsa", "id_ed25519":
+		return false
+	}
+	switch strings.ToLower(path.Ext(name)) {
+	case ".pem", ".key", ".p12", ".pfx", ".jks":
+		return false
+	}
+	return true
+}

--- a/internal/domain/sourcepolicy/policy_test.go
+++ b/internal/domain/sourcepolicy/policy_test.go
@@ -1,0 +1,23 @@
+package sourcepolicy
+
+import "testing"
+
+func TestRetainPathFailsClosedForCredentialAndStateFiles(t *testing.T) {
+	for _, path := range []string{
+		".env", ".env.production", "config/.env.local", ".netrc", ".npmrc", ".pypirc",
+		".git-credentials", "credentials.json", "secrets/credentials.json",
+		"id_rsa", "ssh/id_ed25519", "certs/server.pem", "certs/server.key", "certs/client.p12", "keystore/app.jks",
+		"node_modules/pkg/index.js", "vendor/pkg/source.go", "build/generated.js", "dist/app.js", "target/classes/App.java",
+		".venv/lib/site.py", "venv/lib/site.py", "pkg/__pycache__/cache.py", ".git/hooks/pre-commit", ".hg/store/data",
+		"../escape.go", "/absolute.go", "C:/absolute.go",
+	} {
+		if RetainPath(path) {
+			t.Fatalf("RetainPath(%q)=true, want false", path)
+		}
+	}
+	for _, path := range []string{"main.go", "src/app.ts", "config/example.env", "docs/key-management.md", "keys/public.pub"} {
+		if !RetainPath(path) {
+			t.Fatalf("RetainPath(%q)=false, want true", path)
+		}
+	}
+}

--- a/internal/infrastructure/persistence/memory/project_analysis_store.go
+++ b/internal/infrastructure/persistence/memory/project_analysis_store.go
@@ -228,6 +228,15 @@ func cloneProjectAnalysis(in projectanalysis.Analysis) projectanalysis.Analysis 
 	out.Gate.Results = slices.Clone(in.Gate.Results)
 	out.InternalIssues = slices.Clone(in.InternalIssues)
 	out.SourceManifest.Files = slices.Clone(in.SourceManifest.Files)
+	if in.SourceManifest.Writer != nil {
+		writer := *in.SourceManifest.Writer
+		out.SourceManifest.Writer = &writer
+	}
+	out.Comparison.BaseManifest.Files = slices.Clone(in.Comparison.BaseManifest.Files)
+	if in.Comparison.BaseManifest.Writer != nil {
+		writer := *in.Comparison.BaseManifest.Writer
+		out.Comparison.BaseManifest.Writer = &writer
+	}
 	out.FileChanges = slices.Clone(in.FileChanges)
 	out.Annotations = slices.Clone(in.Annotations)
 	for i := range out.Annotations {

--- a/internal/infrastructure/persistence/postgres/project_analysis_source.go
+++ b/internal/infrastructure/persistence/postgres/project_analysis_source.go
@@ -1,0 +1,136 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.ProjectAnalysisSourceAtomicMutator = (*ProjectAnalysisStore)(nil)
+
+func (r *ProjectAnalysisStore) AttachSourceWithAudit(ctx context.Context, tenantID, projectID, analysisID shared.ID, capture projectanalysis.SourceCapture, audit ports.AuditEntry) error {
+	if tenantID.IsZero() || projectID.IsZero() || analysisID.IsZero() {
+		return fmt.Errorf("%w: source attachment scope is required", shared.ErrValidation)
+	}
+	if err := validatePublishedCapture(capture); err != nil {
+		return err
+	}
+	if err := validateSourcePublishAudit(audit, analysisID, capture); err != nil {
+		return err
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin source attachment: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var payload []byte
+	if err := tx.QueryRow(ctx, `SELECT payload FROM project_analyses WHERE tenant_id=$1 AND project_id=$2 AND id=$3 FOR UPDATE`, tenantID.String(), projectID.String(), analysisID.String()).Scan(&payload); errors.Is(err, pgx.ErrNoRows) {
+		return shared.ErrNotFound
+	} else if err != nil {
+		return fmt.Errorf("lock project analysis for source attachment: %w", err)
+	}
+	var analysis projectanalysis.Analysis
+	if err := json.Unmarshal(payload, &analysis); err != nil {
+		return fmt.Errorf("decode project analysis for source attachment: %w", err)
+	}
+	if analysis.Capabilities.Source.Available || analysis.SourceManifest.Digest != "" || len(analysis.SourceManifest.Files) != 0 || analysis.SourceManifest.Writer != nil {
+		return shared.ErrConflict
+	}
+	if err := validateCaptureAgainstAnalysis(analysis, capture.Manifest); err != nil {
+		return err
+	}
+
+	analysis.SourceManifest = capture.Manifest
+	analysis.Capabilities.Source = projectanalysis.Capability{Available: true}
+	analysis.Capabilities.Highlighting = projectanalysis.Capability{Available: true}
+	updated, err := json.Marshal(analysis)
+	if err != nil {
+		return fmt.Errorf("marshal project analysis source attachment: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE project_analyses SET payload=$4 WHERE tenant_id=$1 AND project_id=$2 AND id=$3`, tenantID.String(), projectID.String(), analysisID.String(), updated); err != nil {
+		return fmt.Errorf("attach project analysis source: %w", err)
+	}
+	if err := appendAudit(ctx, tx, audit); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		// Once COMMIT has been sent, a transport failure can make its durable outcome unknowable.
+		// The caller must not compensate by deleting the artifact: the DB row and audit may already
+		// be committed. An orphan is safe to retain and later reap; missing committed bytes are not.
+		return fmt.Errorf("%w: commit project analysis source attachment: %v", ports.ErrProjectSourceCommitUncertain, err)
+	}
+	return nil
+}
+
+func validatePublishedCapture(capture projectanalysis.SourceCapture) error {
+	if !capture.Capabilities.Source.Available {
+		return fmt.Errorf("%w: published source capability must be available", shared.ErrValidation)
+	}
+	if capture.Manifest.Writer == nil {
+		return fmt.Errorf("%w: source writer provenance is required", shared.ErrValidation)
+	}
+	if err := capture.Manifest.Writer.Validate(); err != nil {
+		return fmt.Errorf("%w: %v", shared.ErrValidation, err)
+	}
+	if capture.Manifest.Digest == "" || capture.Manifest.Digest != capture.Manifest.ArtifactDigest() {
+		return fmt.Errorf("%w: source manifest digest is invalid", shared.ErrValidation)
+	}
+	available := 0
+	for _, file := range capture.Manifest.Files {
+		if err := file.Validate(); err != nil {
+			return fmt.Errorf("%w: %v", shared.ErrValidation, err)
+		}
+		if file.Available {
+			available++
+		}
+	}
+	if available == 0 {
+		return fmt.Errorf("%w: published source manifest contains no retained source bytes", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validateSourcePublishAudit(audit ports.AuditEntry, analysisID shared.ID, capture projectanalysis.SourceCapture) error {
+	writer := capture.Manifest.Writer
+	if writer == nil || audit.Actor != writer.Actor || !audit.At.Equal(writer.PublishedAt) {
+		return fmt.Errorf("%w: source audit provenance does not match manifest writer", shared.ErrValidation)
+	}
+	if audit.Action != ports.ProjectSourcePublishAuditAction || audit.Target != analysisID.String() {
+		return fmt.Errorf("%w: source audit action or target is invalid", shared.ErrValidation)
+	}
+	if audit.Metadata["artifact_digest"] != capture.Manifest.Digest || audit.Metadata["tool_version"] != writer.ToolVersion {
+		return fmt.Errorf("%w: source audit metadata does not match manifest", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validateCaptureAgainstAnalysis(analysis projectanalysis.Analysis, manifest projectanalysis.SourceManifest) error {
+	allowed := make(map[string]struct{})
+	for _, node := range analysis.Snapshot.Nodes {
+		if node.Kind == measure.NodeFile && sourcepolicy.RetainPath(node.Path) {
+			allowed[node.Path] = struct{}{}
+		}
+	}
+	seen := make(map[string]struct{}, len(manifest.Files))
+	for _, file := range manifest.Files {
+		if _, ok := allowed[file.Path]; !ok {
+			return fmt.Errorf("%w: published source path is not part of the analysis snapshot", shared.ErrValidation)
+		}
+		if _, duplicate := seen[file.Path]; duplicate {
+			return fmt.Errorf("%w: duplicate published source path", shared.ErrValidation)
+		}
+		seen[file.Path] = struct{}{}
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/project_analysis_source_concurrency_test.go
+++ b/internal/infrastructure/persistence/postgres/project_analysis_source_concurrency_test.go
@@ -1,0 +1,134 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestProjectAnalysisSourceAttachmentConcurrentCASHasOneWinner(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	tenantID := shared.ID("tenant-source-cas-" + uuid.NewString())
+	projectID := shared.ID("project-source-cas-" + uuid.NewString())
+	analysisID := shared.ID("analysis-source-cas-" + uuid.NewString())
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1, 'source-publish-cas-test')`, tenantID.String()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO projects (id, tenant_id, name, key, source_binding) VALUES ($1,$2,'source-publish-cas-test',$3,'{}'::jsonb)`, projectID.String(), tenantID.String(), "source-cas-"+uuid.NewString()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanup := context.Background()
+		if _, err := pool.Exec(cleanup, `DELETE FROM project_analyses WHERE id=$1`, analysisID.String()); err != nil {
+			t.Errorf("cleanup analysis: %v", err)
+		}
+		if _, err := pool.Exec(cleanup, `DELETE FROM projects WHERE id=$1`, projectID.String()); err != nil {
+			t.Errorf("cleanup project: %v", err)
+		}
+		if _, err := pool.Exec(cleanup, `DELETE FROM tenants WHERE id=$1`, tenantID.String()); err != nil {
+			t.Errorf("cleanup tenant: %v", err)
+		}
+	})
+
+	store := NewProjectAnalysisStore(pool)
+	analysis := projectanalysis.Analysis{
+		ID: analysisID.String(), TenantID: tenantID.String(), ProjectID: projectID.String(), ProjectKey: "source-cas-test", CreatedAt: now,
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Capabilities: projectanalysis.SourceCapabilities{
+			Source:       projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+			Comparison:   projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			UnifiedDiff:  projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			SplitDiff:    projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			Highlighting: projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+		},
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}, {Path: "main.go", Kind: measure.NodeFile}}},
+	}
+	if err := store.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+
+	captureA := sourceAttachmentFixture(now)
+	captureB := sourceAttachmentFixture(now.Add(time.Microsecond))
+	writerB := *captureB.Manifest.Writer
+	writerB.Actor = "ci-bot-2"
+	captureB.Manifest.Writer = &writerB
+	captureB.Manifest.SetArtifactDigest()
+	auditA := sourceAttachmentAudit(analysisID, captureA)
+	auditB := sourceAttachmentAudit(analysisID, captureB)
+
+	type result struct {
+		digest string
+		err    error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	for _, contender := range []struct {
+		capture projectanalysis.SourceCapture
+		audit   ports.AuditEntry
+	}{{captureA, auditA}, {captureB, auditB}} {
+		contender := contender
+		go func() {
+			<-start
+			err := store.AttachSourceWithAudit(ctx, tenantID, projectID, analysisID, contender.capture, contender.audit)
+			results <- result{digest: contender.capture.Manifest.Digest, err: err}
+		}()
+	}
+	close(start)
+
+	winner := ""
+	conflicts := 0
+	for range 2 {
+		got := <-results
+		switch {
+		case got.err == nil:
+			if winner != "" {
+				t.Fatalf("multiple DB source publishers succeeded: %q and %q", winner, got.digest)
+			}
+			winner = got.digest
+		case errors.Is(got.err, shared.ErrConflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected concurrent DB attach error: %v", got.err)
+		}
+	}
+	if winner == "" || conflicts != 1 {
+		t.Fatalf("winner=%q conflicts=%d, want one winner and one conflict", winner, conflicts)
+	}
+	got, err := store.Get(ctx, tenantID, projectID, analysisID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SourceManifest.Digest != winner || !got.Capabilities.Source.Available {
+		t.Fatalf("persisted source digest=%q, winning digest=%q", got.SourceManifest.Digest, winner)
+	}
+	var auditCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM audit_log WHERE action=$1 AND target=$2`, ports.ProjectSourcePublishAuditAction, analysisID.String()).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 1 {
+		t.Fatalf("concurrent CAS emitted %d audit rows, want 1", auditCount)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/project_analysis_source_test.go
+++ b/internal/infrastructure/persistence/postgres/project_analysis_source_test.go
@@ -1,0 +1,221 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestProjectAnalysisSourceAttachmentIsCreateOnlyAndAudited(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	tenantID := shared.ID("tenant-source-" + uuid.NewString())
+	projectID := shared.ID("project-source-" + uuid.NewString())
+	analysisID := shared.ID("analysis-source-" + uuid.NewString())
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1, 'source-publish-test')`, tenantID.String()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO projects (id, tenant_id, name, key, source_binding) VALUES ($1,$2,'source-publish-test',$3,'{}'::jsonb)`, projectID.String(), tenantID.String(), "source-"+uuid.NewString()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanup := context.Background()
+		if _, err := pool.Exec(cleanup, `DELETE FROM project_analyses WHERE id=$1`, analysisID.String()); err != nil {
+			t.Errorf("cleanup analysis: %v", err)
+		}
+		if _, err := pool.Exec(cleanup, `DELETE FROM projects WHERE id=$1`, projectID.String()); err != nil {
+			t.Errorf("cleanup project: %v", err)
+		}
+		if _, err := pool.Exec(cleanup, `DELETE FROM tenants WHERE id=$1`, tenantID.String()); err != nil {
+			t.Errorf("cleanup tenant: %v", err)
+		}
+	})
+
+	store := NewProjectAnalysisStore(pool)
+	analysis := projectanalysis.Analysis{
+		ID: analysisID.String(), TenantID: tenantID.String(), ProjectID: projectID.String(), ProjectKey: "source-test", CreatedAt: now,
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Capabilities: projectanalysis.SourceCapabilities{
+			Source: projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+			Comparison: projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			UnifiedDiff: projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			SplitDiff: projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			Highlighting: projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+		},
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}, {Path: "main.go", Kind: measure.NodeFile, Language: "Go"}}},
+	}
+	if err := store.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+	capture := sourceAttachmentFixture(now)
+	audit := sourceAttachmentAudit(analysisID, capture)
+	if err := store.AttachSourceWithAudit(ctx, tenantID, projectID, analysisID, capture, audit); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.Get(ctx, tenantID, projectID, analysisID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Capabilities.Source.Available || !got.Capabilities.Highlighting.Available || got.SourceManifest.Digest != capture.Manifest.Digest {
+		t.Fatalf("source attachment not persisted: %+v", got.SourceManifest)
+	}
+	// Late source publication must not manufacture diff capabilities.
+	if got.Capabilities.Comparison.Available || got.Capabilities.UnifiedDiff.Available || got.Capabilities.SplitDiff.Available {
+		t.Fatalf("source attachment changed comparison capabilities: %+v", got.Capabilities)
+	}
+	var auditCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM audit_log WHERE action=$1 AND target=$2`, ports.ProjectSourcePublishAuditAction, analysisID.String()).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 1 {
+		t.Fatalf("audit count=%d, want 1", auditCount)
+	}
+	if err := store.AttachSourceWithAudit(ctx, tenantID, projectID, analysisID, capture, audit); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate attach error=%v, want conflict", err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM audit_log WHERE action=$1 AND target=$2`, ports.ProjectSourcePublishAuditAction, analysisID.String()).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 1 {
+		t.Fatalf("duplicate attach emitted audit: count=%d", auditCount)
+	}
+	if err := store.AttachSourceWithAudit(ctx, shared.ID("foreign-tenant"), projectID, analysisID, capture, audit); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("foreign tenant attach error=%v, want not found", err)
+	}
+}
+
+func TestProjectAnalysisSourceAttachmentRollsBackWhenAuditAppendFails(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	tenantID := shared.ID("tenant-source-rollback-" + uuid.NewString())
+	projectID := shared.ID("project-source-rollback-" + uuid.NewString())
+	analysisID := shared.ID("analysis-source-rollback-" + uuid.NewString())
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1, 'source-publish-rollback-test')`, tenantID.String()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO projects (id, tenant_id, name, key, source_binding) VALUES ($1,$2,'source-publish-rollback-test',$3,'{}'::jsonb)`, projectID.String(), tenantID.String(), "source-rollback-"+uuid.NewString()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanup := context.Background()
+		if _, err := pool.Exec(cleanup, `DELETE FROM project_analyses WHERE id=$1`, analysisID.String()); err != nil {
+			t.Errorf("cleanup analysis: %v", err)
+		}
+		if _, err := pool.Exec(cleanup, `DELETE FROM projects WHERE id=$1`, projectID.String()); err != nil {
+			t.Errorf("cleanup project: %v", err)
+		}
+		if _, err := pool.Exec(cleanup, `DELETE FROM tenants WHERE id=$1`, tenantID.String()); err != nil {
+			t.Errorf("cleanup tenant: %v", err)
+		}
+	})
+
+	store := NewProjectAnalysisStore(pool)
+	analysis := projectanalysis.Analysis{
+		ID: analysisID.String(), TenantID: tenantID.String(), ProjectID: projectID.String(), ProjectKey: "source-rollback-test", CreatedAt: now,
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Capabilities: projectanalysis.SourceCapabilities{
+			Source: projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+			Comparison: projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			UnifiedDiff: projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			SplitDiff: projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			Highlighting: projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+		},
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}, {Path: "main.go", Kind: measure.NodeFile}}},
+	}
+	if err := store.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold the same session-level advisory lock that appendAudit requests transactionally.
+	// The source transaction can update payload, but its audit append must block until the
+	// deadline and then roll the entire transaction back.
+	lockConn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lockConn.Release()
+	if _, err := lockConn.Exec(ctx, `SELECT pg_advisory_lock($1)`, auditChainLock); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = lockConn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, auditChainLock) }()
+
+	capture := sourceAttachmentFixture(now)
+	audit := sourceAttachmentAudit(analysisID, capture)
+	deadlineCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	defer cancel()
+	if err := store.AttachSourceWithAudit(deadlineCtx, tenantID, projectID, analysisID, capture, audit); err == nil {
+		t.Fatal("AttachSourceWithAudit unexpectedly succeeded while audit chain was locked")
+	}
+	got, err := store.Get(ctx, tenantID, projectID, analysisID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Capabilities.Source.Available || got.SourceManifest.Digest != "" || len(got.SourceManifest.Files) != 0 || got.SourceManifest.Writer != nil {
+		t.Fatalf("analysis payload escaped rolled-back transaction: %+v", got.SourceManifest)
+	}
+	var auditCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM audit_log WHERE action=$1 AND target=$2`, ports.ProjectSourcePublishAuditAction, analysisID.String()).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 0 {
+		t.Fatalf("rolled-back source attachment emitted %d audit rows", auditCount)
+	}
+}
+
+func sourceAttachmentFixture(at time.Time) projectanalysis.SourceCapture {
+	writer := projectanalysis.SourceWriter{Actor: "ci-bot", ToolVersion: "synapse-cli/test", PublishedAt: at}
+	manifest := projectanalysis.SourceManifest{Writer: &writer, Files: []projectanalysis.SourceFile{{Path: "main.go", Digest: "fixture-digest", Bytes: 13, Lines: 1, Available: true}}}
+	manifest.SetArtifactDigest()
+	return projectanalysis.SourceCapture{
+		Capabilities: projectanalysis.SourceCapabilities{
+			Source: projectanalysis.Capability{Available: true},
+			Comparison: projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			UnifiedDiff: projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			SplitDiff: projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			Highlighting: projectanalysis.Capability{Available: true},
+		},
+		Manifest: manifest,
+	}
+}
+
+func sourceAttachmentAudit(analysisID shared.ID, capture projectanalysis.SourceCapture) ports.AuditEntry {
+	return ports.AuditEntry{
+		Actor: capture.Manifest.Writer.Actor, Action: ports.ProjectSourcePublishAuditAction, Target: analysisID.String(), At: capture.Manifest.Writer.PublishedAt,
+		Metadata: map[string]string{"artifact_digest": capture.Manifest.Digest, "tool_version": capture.Manifest.Writer.ToolVersion},
+	}
+}

--- a/internal/infrastructure/persistence/postgres/project_analysis_source_validation_test.go
+++ b/internal/infrastructure/persistence/postgres/project_analysis_source_validation_test.go
@@ -1,0 +1,33 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestValidatePublishedCaptureRejectsZeroRetainedSource(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		files []projectanalysis.SourceFile
+	}{
+		{name: "empty manifest"},
+		{name: "unavailable only", files: []projectanalysis.SourceFile{{Path: "main.go", Bytes: 13, Reason: projectanalysis.UnavailableLimitExceeded}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			writer := projectanalysis.SourceWriter{Actor: "ci-bot", ToolVersion: "synapse-cli/test", PublishedAt: time.Unix(1_700_000_000, 0).UTC()}
+			manifest := projectanalysis.SourceManifest{Writer: &writer, Files: tc.files}
+			manifest.SetArtifactDigest()
+			capture := projectanalysis.SourceCapture{
+				Capabilities: projectanalysis.SourceCapabilities{Source: projectanalysis.Capability{Available: true}},
+				Manifest:     manifest,
+			}
+			if err := validatePublishedCapture(capture); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("validatePublishedCapture() error=%v, want validation", err)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/sourceartifact/capture_policy_test.go
+++ b/internal/infrastructure/sourceartifact/capture_policy_test.go
@@ -1,0 +1,89 @@
+package sourceartifact
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestCaptureSkipsSecretBearingPaths(t *testing.T) {
+	workspace := t.TempDir()
+	for name, body := range map[string]string{
+		"main.go":          "package main\n",
+		".env":             "fixture-blocked-by-path\n",
+		"server.key":       "fixture-blocked-by-path\n",
+		"credentials.json": "fixture-blocked-by-path\n",
+	} {
+		if err := os.WriteFile(filepath.Join(workspace, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store := New(filepath.Join(t.TempDir(), "source"), 0, 0, 0)
+	capture, err := store.Capture(context.Background(), "tenant", "project", "analysis", workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.Manifest.Files) != 1 || capture.Manifest.Files[0].Path != "main.go" {
+		t.Fatalf("captured files=%+v", capture.Manifest.Files)
+	}
+	for _, name := range []string{".env", "server.key", "credentials.json"} {
+		if _, _, err := store.Load(context.Background(), "tenant", "project", "analysis", name); !errors.Is(err, projectanalysis.ErrSourceNotRetained) {
+			t.Fatalf("Load(%q) error=%v, want not retained", name, err)
+		}
+	}
+}
+
+func TestCaptureBaseSkipsSecretBearingPaths(t *testing.T) {
+	store := New(filepath.Join(t.TempDir(), "source"), 0, 0, 0)
+	manifest, err := store.CaptureBase(context.Background(), "tenant", "project", "analysis", map[string][]byte{
+		"main.go":    []byte("package main\n"),
+		".env":       []byte("fixture-blocked-by-path\n"),
+		"server.pem": []byte("fixture-blocked-by-path\n"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.Files) != 1 || manifest.Files[0].Path != "main.go" {
+		t.Fatalf("base files=%+v", manifest.Files)
+	}
+	for _, name := range []string{".env", "server.pem"} {
+		if _, _, err := store.LoadBase(context.Background(), "tenant", "project", "analysis", name); !errors.Is(err, projectanalysis.ErrSourceNotRetained) {
+			t.Fatalf("LoadBase(%q) error=%v, want not retained", name, err)
+		}
+	}
+}
+
+func TestCaptureIsCreateOnly(t *testing.T) {
+	ctx := context.Background()
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "main.go")
+	if err := os.WriteFile(path, []byte("first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := New(filepath.Join(t.TempDir(), "source"), 0, 0, 0)
+	if _, err := store.Capture(ctx, "tenant", "project", "analysis", workspace); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("replacement\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.Capture(ctx, "tenant", "project", "analysis", workspace)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("second Capture() error=%v, want conflict", err)
+	}
+	if second.Capabilities.Source.Reason != projectanalysis.UnavailableAlreadyRetained {
+		t.Fatalf("second capture reason=%q, want %q", second.Capabilities.Source.Reason, projectanalysis.UnavailableAlreadyRetained)
+	}
+	data, _, err := store.Load(ctx, "tenant", "project", "analysis", "main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "first\n" {
+		t.Fatalf("existing capture was overwritten: %q", data)
+	}
+}

--- a/internal/infrastructure/sourceartifact/publish.go
+++ b/internal/infrastructure/sourceartifact/publish.go
@@ -1,0 +1,202 @@
+package sourceartifact
+
+import (
+	"archive/tar"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.ProjectSourceArtifactPublisher = (*Store)(nil)
+
+// PublishArchive consumes an untrusted tar stream into the server-owned artifact namespace.
+// The destination directory is claimed with an atomic mkdir, so a second publisher can never
+// replace an existing snapshot. manifest.json is written last and the use case attaches the
+// manifest to the analysis only after this method returns successfully.
+func (s *Store) PublishArchive(ctx context.Context, tenantID, projectID shared.ID, analysisID string, writer projectanalysis.SourceWriter, allowedPaths []string, src io.Reader) (projectanalysis.SourceCapture, error) {
+	unavailable := func(reason projectanalysis.UnavailableReason) projectanalysis.SourceCapture {
+		return projectanalysis.SourceCapture{Capabilities: unavailableCapabilities(reason)}
+	}
+	if err := s.validateAnalysisContext(projectID, analysisID); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), err
+	}
+	if err := s.validateWriteRoot(); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), err
+	}
+	if err := s.cleanupBeforeWrite(ctx); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), err
+	}
+	if err := writer.Validate(); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("%w: %v", shared.ErrValidation, err)
+	}
+	if src == nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("%w: source archive is required", shared.ErrValidation)
+	}
+	allowed := make(map[string]struct{}, len(allowedPaths))
+	for _, candidate := range allowedPaths {
+		canonical, err := measure.CanonicalPath(candidate)
+		if err != nil || canonical == "" || canonical != candidate {
+			return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("%w: analysis source path is invalid", shared.ErrValidation)
+		}
+		if sourcepolicy.RetainPath(canonical) {
+			allowed[canonical] = struct{}{}
+		}
+	}
+	if len(allowed) == 0 {
+		return unavailable(projectanalysis.UnavailableNotRetained), fmt.Errorf("%w: analysis has no retainable source files", shared.ErrValidation)
+	}
+	if err := ctx.Err(); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), err
+	}
+
+	captureRoot := s.analysisDir(tenantID, projectID, analysisID)
+	if err := os.MkdirAll(filepath.Dir(captureRoot), 0o700); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("create source artifact parent: %w", err)
+	}
+	if err := os.Mkdir(captureRoot, 0o700); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return unavailable(projectanalysis.UnavailableAlreadyRetained), shared.ErrConflict
+		}
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("claim source artifact: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(captureRoot)
+		}
+	}()
+	if err := os.Mkdir(filepath.Join(captureRoot, "blobs"), 0o700); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("create source blob directory: %w", err)
+	}
+
+	manifest := projectanalysis.SourceManifest{Writer: &writer}
+	seen := make(map[string]struct{}, len(allowed))
+	var total int64
+	tr := tar.NewReader(src)
+	for {
+		if err := ctx.Err(); err != nil {
+			return unavailable(projectanalysis.UnavailableCaptureFailed), err
+		}
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("read source archive: %w", err)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			continue
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("%w: source archive contains a non-regular entry", shared.ErrValidation)
+		}
+		canonical, err := measure.CanonicalPath(hdr.Name)
+		if err != nil || canonical == "" || canonical != hdr.Name {
+			return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("%w: source archive path is invalid", shared.ErrValidation)
+		}
+		if _, ok := allowed[canonical]; !ok || !sourcepolicy.RetainPath(canonical) {
+			continue
+		}
+		if _, duplicate := seen[canonical]; duplicate {
+			return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("%w: duplicate source archive path %q", shared.ErrValidation, canonical)
+		}
+		seen[canonical] = struct{}{}
+		if len(manifest.Files) >= s.maxFiles {
+			manifest.Truncated = true
+			continue
+		}
+		if hdr.Size < 0 || hdr.Size > s.maxFileBytes {
+			manifest.Files = append(manifest.Files, unavailableFile(canonical, max(hdr.Size, 0), projectanalysis.UnavailableLimitExceeded))
+			manifest.Truncated = true
+			continue
+		}
+		if total+hdr.Size > s.maxBytes {
+			manifest.Files = append(manifest.Files, unavailableFile(canonical, hdr.Size, projectanalysis.UnavailableLimitExceeded))
+			manifest.Truncated = true
+			continue
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("read source file %q: %w", canonical, err)
+		}
+		if int64(len(data)) != hdr.Size {
+			return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("%w: source archive entry size mismatch", shared.ErrValidation)
+		}
+		if !utf8.Valid(data) || bytesContainNUL(data) {
+			manifest.Files = append(manifest.Files, unavailableFile(canonical, int64(len(data)), binaryReason(data)))
+			continue
+		}
+		digest := sha256.Sum256(data)
+		digestHex := hex.EncodeToString(digest[:])
+		if err := writeGzip(filepath.Join(captureRoot, "blobs", digestHex+".gz"), data); err != nil && !errors.Is(err, fs.ErrExist) {
+			return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("write source artifact: %w", err)
+		}
+		manifest.Files = append(manifest.Files, projectanalysis.SourceFile{
+			Path: canonical, Digest: digestHex, Bytes: int64(len(data)), Lines: lineCount(data), Generated: isGenerated(canonical, data), Available: true,
+		})
+		total += int64(len(data))
+	}
+
+	for candidate := range allowed {
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		if len(manifest.Files) >= s.maxFiles {
+			manifest.Truncated = true
+			break
+		}
+		manifest.Files = append(manifest.Files, unavailableFile(candidate, 0, projectanalysis.UnavailableNotRetained))
+	}
+	sort.Slice(manifest.Files, func(i, j int) bool { return manifest.Files[i].Path < manifest.Files[j].Path })
+	retained := false
+	for _, file := range manifest.Files {
+		if file.Available {
+			retained = true
+			break
+		}
+	}
+	if !retained {
+		return unavailable(projectanalysis.UnavailableNotRetained), fmt.Errorf("%w: source archive retained no analysis files", shared.ErrValidation)
+	}
+	manifest.SetArtifactDigest()
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("marshal source manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(captureRoot, "manifest.json"), manifestData, 0o600); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("write source manifest: %w", err)
+	}
+	committed = true
+	return projectanalysis.SourceCapture{Capabilities: availableCapabilities(), Manifest: manifest}, nil
+}
+
+// DiscardPublished removes only the v2 directory claimed by PublishArchive. It is used as a
+// compensation action when the subsequent analysis+audit transaction fails; legacy capture
+// locations are deliberately untouched.
+func (s *Store) DiscardPublished(ctx context.Context, tenantID, projectID shared.ID, analysisID string) error {
+	if err := s.validateAnalysisContext(projectID, analysisID); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(s.analysisDir(tenantID, projectID, analysisID)); err != nil {
+		return fmt.Errorf("discard published source artifact: %w", err)
+	}
+	return nil
+}

--- a/internal/infrastructure/sourceartifact/publish_empty_test.go
+++ b/internal/infrastructure/sourceartifact/publish_empty_test.go
@@ -1,0 +1,23 @@
+package sourceartifact
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestPublishArchiveRejectsZeroRetainedFilesAndReleasesClaim(t *testing.T) {
+	ctx := context.Background()
+	store := New(t.TempDir(), 0, 0, 0)
+	analysisID := "empty-retained"
+	_, err := store.PublishArchive(ctx, "tenant", "project", analysisID, testWriter(), []string{"main.go"}, publishTar(t, []tarEntry{{name: "outside.txt", body: "not in analysis\n"}}))
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("zero-retained publish error=%v, want validation", err)
+	}
+	// A false-success attempt must not reserve the immutable namespace.
+	if _, err := store.PublishArchive(ctx, "tenant", "project", analysisID, testWriter(), []string{"main.go"}, publishTar(t, []tarEntry{{name: "main.go", body: "package main\n"}})); err != nil {
+		t.Fatalf("corrected retry failed after zero-retained archive: %v", err)
+	}
+}

--- a/internal/infrastructure/sourceartifact/publish_inventory_test.go
+++ b/internal/infrastructure/sourceartifact/publish_inventory_test.go
@@ -1,0 +1,32 @@
+package sourceartifact
+
+import (
+	"context"
+	"testing"
+)
+
+// TestPublishArchiveStoresOnlyInventoryListedFiles pins the sharpest property of the publish endpoint:
+// the server decides WHICH files it will accept, from the persisted scanner-owned inventory, and a
+// client cannot introduce a file the scanner never saw. "evil.go" below is canonical, a regular file,
+// and passes sourcepolicy.RetainPath -- it fails only because it is not in the allowlist. Nothing
+// asserted that: dropping the allowlist term left this behaviour untested.
+func TestPublishArchiveStoresOnlyInventoryListedFiles(t *testing.T) {
+	store := New(t.TempDir(), 0, 0, 0)
+	result, err := store.PublishArchive(context.Background(), "tenant", "project", "analysis", testWriter(),
+		[]string{"main.go"},
+		publishTar(t, []tarEntry{
+			{name: "main.go", body: "listed\n"},
+			{name: "evil.go", body: "never inventoried\n"},
+		}))
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	for _, file := range result.Manifest.Files {
+		if file.Path == "evil.go" {
+			t.Fatalf("a path absent from the scanner inventory was stored: %+v", result.Manifest.Files)
+		}
+	}
+	if len(result.Manifest.Files) != 1 || result.Manifest.Files[0].Path != "main.go" {
+		t.Fatalf("manifest must contain exactly the inventoried file, got %+v", result.Manifest.Files)
+	}
+}

--- a/internal/infrastructure/sourceartifact/publish_test.go
+++ b/internal/infrastructure/sourceartifact/publish_test.go
@@ -1,0 +1,175 @@
+package sourceartifact
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func publishTar(t *testing.T, entries []tarEntry) *bytes.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, entry := range entries {
+		typeflag := entry.typeflag
+		if typeflag == 0 {
+			typeflag = tar.TypeReg
+		}
+		data := []byte(entry.body)
+		hdr := &tar.Header{Name: entry.name, Mode: 0o600, Size: int64(len(data)), Typeflag: typeflag, Linkname: entry.linkname}
+		if typeflag != tar.TypeReg {
+			hdr.Size = 0
+			data = nil
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if len(data) > 0 {
+			if _, err := tw.Write(data); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}
+
+type tarEntry struct {
+	name     string
+	body     string
+	typeflag byte
+	linkname string
+}
+
+func testWriter() projectanalysis.SourceWriter {
+	return projectanalysis.SourceWriter{Actor: "ci-bot", ToolVersion: "synapse-cli/test", PublishedAt: time.Unix(1_700_000_000, 0).UTC()}
+}
+
+func TestPublishArchiveIsCreateOnlyAndSealsWriterProvenance(t *testing.T) {
+	ctx := context.Background()
+	store := New(t.TempDir(), 0, 0, 0)
+	first, err := store.PublishArchive(ctx, "tenant", "project", "analysis", testWriter(), []string{"main.go"}, publishTar(t, []tarEntry{{name: "main.go", body: "first\n"}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Manifest.Writer == nil || first.Manifest.Digest == "" || first.Manifest.Digest != first.Manifest.ArtifactDigest() {
+		t.Fatalf("manifest=%+v", first.Manifest)
+	}
+	tampered := first.Manifest
+	writer := *tampered.Writer
+	writer.Actor = "mallory"
+	tampered.Writer = &writer
+	if tampered.ArtifactDigest() == first.Manifest.Digest {
+		t.Fatal("writer provenance is not covered by the manifest digest")
+	}
+
+	second, err := store.PublishArchive(ctx, "tenant", "project", "analysis", testWriter(), []string{"main.go"}, publishTar(t, []tarEntry{{name: "main.go", body: "replacement\n"}}))
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("second publish error=%v, want conflict", err)
+	}
+	if second.Capabilities.Source.Reason != projectanalysis.UnavailableAlreadyRetained {
+		t.Fatalf("second publish reason=%q, want %q", second.Capabilities.Source.Reason, projectanalysis.UnavailableAlreadyRetained)
+	}
+	data, _, err := store.Load(ctx, "tenant", "project", "analysis", "main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "first\n" {
+		t.Fatalf("existing artifact was clobbered: %q", data)
+	}
+}
+
+func TestPublishArchiveConcurrentPublishersHaveExactlyOneWinner(t *testing.T) {
+	ctx := context.Background()
+	store := New(t.TempDir(), 0, 0, 0)
+	const contenders = 8
+	type result struct {
+		body string
+		err  error
+	}
+	archives := make([]*bytes.Reader, contenders)
+	bodies := make([]string, contenders)
+	for i := range contenders {
+		bodies[i] = fmt.Sprintf("winner-%d\n", i)
+		archives[i] = publishTar(t, []tarEntry{{name: "main.go", body: bodies[i]}})
+	}
+	start := make(chan struct{})
+	results := make(chan result, contenders)
+	for i := range contenders {
+		go func(i int) {
+			<-start
+			_, err := store.PublishArchive(ctx, "tenant", "project", "concurrent-analysis", testWriter(), []string{"main.go"}, archives[i])
+			results <- result{body: bodies[i], err: err}
+		}(i)
+	}
+	close(start)
+
+	winner := ""
+	conflicts := 0
+	for range contenders {
+		got := <-results
+		switch {
+		case got.err == nil:
+			if winner != "" {
+				t.Fatalf("more than one publisher succeeded: %q and %q", winner, got.body)
+			}
+			winner = got.body
+		case errors.Is(got.err, shared.ErrConflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected concurrent publish error: %v", got.err)
+		}
+	}
+	if winner == "" || conflicts != contenders-1 {
+		t.Fatalf("winner=%q conflicts=%d, want one winner and %d conflicts", winner, conflicts, contenders-1)
+	}
+	data, _, err := store.Load(ctx, "tenant", "project", "concurrent-analysis", "main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != winner {
+		t.Fatalf("retained bytes=%q, winning publisher sent %q", data, winner)
+	}
+}
+
+func TestPublishArchiveRejectsUnsafeTransportAndRollsBackClaim(t *testing.T) {
+	ctx := context.Background()
+	store := New(t.TempDir(), 0, 0, 0)
+	for _, tc := range []struct {
+		name    string
+		entries []tarEntry
+	}{
+		{name: "traversal", entries: []tarEntry{{name: "../main.go", body: "bad"}}},
+		{name: "symlink", entries: []tarEntry{{name: "main.go", typeflag: tar.TypeSymlink, linkname: "/etc/passwd"}}},
+		{name: "duplicate", entries: []tarEntry{{name: "main.go", body: "one"}, {name: "main.go", body: "two"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			analysisID := "bad-" + tc.name
+			if _, err := store.PublishArchive(ctx, "tenant", "project", analysisID, testWriter(), []string{"main.go"}, publishTar(t, tc.entries)); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("error=%v, want validation", err)
+			}
+			// A rejected archive must release its filesystem claim; otherwise a corrected retry
+			// would be permanently blocked by a half-published directory.
+			if _, err := store.PublishArchive(ctx, "tenant", "project", analysisID, testWriter(), []string{"main.go"}, publishTar(t, []tarEntry{{name: "main.go", body: "fixed\n"}})); err != nil {
+				t.Fatalf("corrected retry failed after rejected archive: %v", err)
+			}
+		})
+	}
+}
+
+func TestPublishArchiveRequiresAbsoluteOperatorOwnedRoot(t *testing.T) {
+	store := New("relative/artifacts", 0, 0, 0)
+	_, err := store.PublishArchive(context.Background(), "tenant", "project", "analysis", testWriter(), []string{"main.go"}, publishTar(t, []tarEntry{{name: "main.go", body: "package main\n"}}))
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("error=%v, want validation", err)
+	}
+}

--- a/internal/infrastructure/sourceartifact/retention_write_test.go
+++ b/internal/infrastructure/sourceartifact/retention_write_test.go
@@ -1,0 +1,103 @@
+package sourceartifact
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestSnapshotWritersRunRetentionCleanupBeforeWrite(t *testing.T) {
+	tenantID := shared.ID("tenant-retention")
+	projectID := shared.ID("project-retention")
+
+	t.Run("capture", func(t *testing.T) {
+		store, expired := retentionTestStore(t, tenantID, projectID)
+		sourceDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(sourceDir, "main.go"), []byte("package main\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Capture(context.Background(), tenantID, projectID, "fresh-capture", sourceDir); err != nil {
+			t.Fatalf("Capture: %v", err)
+		}
+		assertRetentionRemoved(t, expired)
+	})
+
+	t.Run("capture base", func(t *testing.T) {
+		store, expired := retentionTestStore(t, tenantID, projectID)
+		if _, err := store.CaptureBase(context.Background(), tenantID, projectID, "fresh-base", map[string][]byte{"main.go": []byte("package main\n")}); err != nil {
+			t.Fatalf("CaptureBase: %v", err)
+		}
+		assertRetentionRemoved(t, expired)
+	})
+
+	t.Run("sanctioned publish", func(t *testing.T) {
+		store, expired := retentionTestStore(t, tenantID, projectID)
+		var archive bytes.Buffer
+		tw := tar.NewWriter(&archive)
+		body := []byte("package main\n")
+		if err := tw.WriteHeader(&tar.Header{Name: "main.go", Mode: 0o600, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		writer := projectanalysis.SourceWriter{Actor: "operator", ToolVersion: "test", PublishedAt: time.Now().UTC()}
+		if _, err := store.PublishArchive(context.Background(), tenantID, projectID, "fresh-publish", writer, []string{"main.go"}, &archive); err != nil {
+			t.Fatalf("PublishArchive: %v", err)
+		}
+		assertRetentionRemoved(t, expired)
+	})
+}
+
+func TestCleanupExpiredRemovesStaleIncompleteClaims(t *testing.T) {
+	store := New(t.TempDir(), 0, 0, 0)
+	tenantID := shared.ID("tenant-incomplete")
+	projectID := shared.ID("project-incomplete")
+	claim := store.analysisDir(tenantID, projectID, "interrupted-publish")
+	if err := os.MkdirAll(filepath.Join(claim, "blobs"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(claim, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CleanupExpired(context.Background(), time.Now().Add(-time.Hour)); err != nil {
+		t.Fatalf("CleanupExpired: %v", err)
+	}
+	assertRetentionRemoved(t, claim)
+}
+
+func retentionTestStore(t *testing.T, tenantID, projectID shared.ID) (*Store, string) {
+	t.Helper()
+	store := New(t.TempDir(), 0, 0, 0)
+	store.SetRetention(time.Hour)
+	expired := store.analysisDir(tenantID, projectID, "expired-analysis")
+	if err := os.MkdirAll(expired, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(expired, "manifest.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(expired, old, old); err != nil {
+		t.Fatal(err)
+	}
+	return store, expired
+}
+
+func assertRetentionRemoved(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expired source artifact still exists after write: stat err=%v", err)
+	}
+}

--- a/internal/infrastructure/sourceartifact/root.go
+++ b/internal/infrastructure/sourceartifact/root.go
@@ -1,0 +1,102 @@
+package sourceartifact
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// validateWriteRoot fails closed before any source artifact write. In particular, a caller may not
+// rely on the process working directory to turn an untrusted relative path into durable evidence.
+func (s *Store) validateWriteRoot() error {
+	if !filepath.IsAbs(s.root) {
+		return fmt.Errorf("%w: source artifact root must be absolute", shared.ErrValidation)
+	}
+	if err := os.MkdirAll(s.root, 0o700); err != nil {
+		return fmt.Errorf("create source artifact root: %w", err)
+	}
+	info, err := os.Lstat(s.root)
+	if err != nil {
+		return fmt.Errorf("inspect source artifact root: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: source artifact root must be a configured directory, not a symlink", shared.ErrValidation)
+	}
+	return nil
+}
+
+// validateSourceIsolation runs before validateWriteRoot so a bad configuration cannot create even
+// an empty artifact directory inside the tree being scanned. It resolves existing parent symlinks
+// for a not-yet-created artifact path, preventing a lexically external path from aliasing the tree.
+func (s *Store) validateSourceIsolation(sourceDir string) error {
+	if !filepath.IsAbs(s.root) {
+		return fmt.Errorf("%w: source artifact root must be absolute", shared.ErrValidation)
+	}
+	source, err := filepath.Abs(sourceDir)
+	if err != nil {
+		return fmt.Errorf("resolve scanned source root: %w", err)
+	}
+	source, err = filepath.EvalSymlinks(source)
+	if err != nil {
+		return fmt.Errorf("resolve scanned source root symlinks: %w", err)
+	}
+	root, err := resolveProspectivePath(s.root)
+	if err != nil {
+		return fmt.Errorf("resolve source artifact root: %w", err)
+	}
+	inside, err := pathWithin(source, root)
+	if err != nil {
+		return fmt.Errorf("compare source artifact root with scanned tree: %w", err)
+	}
+	if inside {
+		return fmt.Errorf("%w: source artifact root must not resolve inside the scanned tree", shared.ErrValidation)
+	}
+	return nil
+}
+
+func resolveProspectivePath(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	absolute = filepath.Clean(absolute)
+	current := absolute
+	var suffix []string
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			parts := append([]string{resolved}, suffix...)
+			return filepath.Clean(filepath.Join(parts...)), nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", err
+		}
+		suffix = append([]string{filepath.Base(current)}, suffix...)
+		current = parent
+	}
+}
+
+func pathWithin(parent, candidate string) (bool, error) {
+	parent = filepath.Clean(parent)
+	candidate = filepath.Clean(candidate)
+	if parent == candidate {
+		return true, nil
+	}
+	if filepath.VolumeName(parent) != filepath.VolumeName(candidate) {
+		return false, nil
+	}
+	rel, err := filepath.Rel(parent, candidate)
+	if err != nil {
+		return false, err
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)), nil
+}

--- a/internal/infrastructure/sourceartifact/root_isolation_test.go
+++ b/internal/infrastructure/sourceartifact/root_isolation_test.go
@@ -1,0 +1,45 @@
+package sourceartifact
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestCaptureRejectsArtifactRootInsideScannedTreeBeforeWriting(t *testing.T) {
+	source := t.TempDir()
+	root := filepath.Join(source, ".synapse-artifacts")
+	store := New(root, 0, 0, 0)
+	_, err := store.Capture(context.Background(), "tenant", "project", "analysis", source)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("capture error=%v, want validation", err)
+	}
+	if _, err := os.Lstat(root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("artifact root was created inside scanned tree: %v", err)
+	}
+}
+
+func TestCaptureRejectsArtifactRootWhoseParentSymlinkResolvesInsideTree(t *testing.T) {
+	base := t.TempDir()
+	source := filepath.Join(base, "source")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(base, "artifact-parent")
+	if err := os.Symlink(source, alias); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	root := filepath.Join(alias, "retained")
+	store := New(root, 0, 0, 0)
+	_, err := store.Capture(context.Background(), "tenant", "project", "analysis", source)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("capture error=%v, want validation", err)
+	}
+	if _, err := os.Lstat(filepath.Join(source, "retained")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("resolved artifact root was created inside scanned tree: %v", err)
+	}
+}

--- a/internal/infrastructure/sourceartifact/root_test.go
+++ b/internal/infrastructure/sourceartifact/root_test.go
@@ -1,0 +1,19 @@
+package sourceartifact
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAllSourceArtifactWritersRejectRelativeRoot(t *testing.T) {
+	store := New("relative/project-source-artifacts", 0, 0, 0)
+	if _, err := store.Capture(context.Background(), "tenant", "project", "analysis", t.TempDir()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("Capture relative-root error=%v, want validation", err)
+	}
+	if _, err := store.CaptureBase(context.Background(), "tenant", "project", "analysis", map[string][]byte{"main.go": []byte("package main\n")}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("CaptureBase relative-root error=%v, want validation", err)
+	}
+}

--- a/internal/infrastructure/sourceartifact/store.go
+++ b/internal/infrastructure/sourceartifact/store.go
@@ -22,6 +22,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepolicy"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -41,6 +42,7 @@ type Store struct {
 	maxFileBytes int64
 	maxFiles     int
 	maxBytes     int64
+	retention    time.Duration
 }
 
 func New(root string, maxFileBytes int64, maxFiles int, maxBytes int64) *Store {
@@ -56,6 +58,29 @@ func New(root string, maxFileBytes int64, maxFiles int, maxBytes int64) *Store {
 	return &Store{root: root, maxFileBytes: maxFileBytes, maxFiles: maxFiles, maxBytes: maxBytes}
 }
 
+// SetRetention makes retention a write-path invariant, not merely a startup task.
+// A non-positive duration disables age-based cleanup.
+func (s *Store) SetRetention(retention time.Duration) {
+	if retention > 0 {
+		s.retention = retention
+		return
+	}
+	s.retention = 0
+}
+
+func (s *Store) cleanupBeforeWrite(ctx context.Context) error {
+	if s.retention <= 0 {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := s.CleanupExpired(ctx, time.Now().Add(-s.retention)); err != nil {
+		return fmt.Errorf("clean expired source artifacts: %w", err)
+	}
+	return nil
+}
+
 var _ ports.ProjectSourceArtifactStore = (*Store)(nil)
 
 func (s *Store) Capture(ctx context.Context, tenantID, projectID shared.ID, analysisID, sourceDir string) (projectanalysis.SourceCapture, error) {
@@ -64,6 +89,15 @@ func (s *Store) Capture(ctx context.Context, tenantID, projectID shared.ID, anal
 	}
 	if err := s.validateAnalysisContext(projectID, analysisID); err != nil || strings.TrimSpace(sourceDir) == "" {
 		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("%w: source capture context is required", shared.ErrValidation)
+	}
+	if err := s.validateSourceIsolation(sourceDir); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), err
+	}
+	if err := s.validateWriteRoot(); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), err
+	}
+	if err := s.cleanupBeforeWrite(ctx); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), err
 	}
 	if err := ctx.Err(); err != nil {
 		return unavailable(projectanalysis.UnavailableCaptureFailed), err
@@ -114,6 +148,9 @@ func (s *Store) Capture(ctx context.Context, tenantID, projectID shared.ID, anal
 		if err != nil || path == "" {
 			return fmt.Errorf("invalid source path: %w", err)
 		}
+		if !sourcepolicy.RetainPath(path) {
+			return nil
+		}
 		if len(manifest.Files) >= s.maxFiles {
 			manifest.Truncated = true
 			return nil
@@ -163,12 +200,25 @@ func (s *Store) Capture(ctx context.Context, tenantID, projectID shared.ID, anal
 	if err := os.WriteFile(filepath.Join(tmp, "manifest.json"), manifestData, 0o600); err != nil {
 		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("write source manifest: %w", err)
 	}
-	if err := os.RemoveAll(captureRoot); err != nil {
-		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("replace source artifact: %w", err)
+	if err := os.Mkdir(captureRoot, 0o700); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return unavailable(projectanalysis.UnavailableAlreadyRetained), shared.ErrConflict
+		}
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("claim source artifact: %w", err)
 	}
-	if err := os.Rename(tmp, captureRoot); err != nil {
-		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("publish source artifact: %w", err)
+	published := false
+	defer func() {
+		if !published {
+			_ = os.RemoveAll(captureRoot)
+		}
+	}()
+	if err := os.Rename(filepath.Join(tmp, "blobs"), filepath.Join(captureRoot, "blobs")); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("publish source blobs: %w", err)
 	}
+	if err := os.Rename(filepath.Join(tmp, "manifest.json"), filepath.Join(captureRoot, "manifest.json")); err != nil {
+		return unavailable(projectanalysis.UnavailableCaptureFailed), fmt.Errorf("publish source manifest: %w", err)
+	}
+	published = true
 	return projectanalysis.SourceCapture{Capabilities: availableCapabilities(), Manifest: manifest}, nil
 }
 
@@ -181,6 +231,12 @@ func (s *Store) Load(ctx context.Context, tenantID, projectID shared.ID, analysi
 func (s *Store) CaptureBase(ctx context.Context, tenantID, projectID shared.ID, analysisID string, files map[string][]byte) (projectanalysis.SourceManifest, error) {
 	manifest := projectanalysis.SourceManifest{}
 	if err := s.validateAnalysisContext(projectID, analysisID); err != nil {
+		return manifest, err
+	}
+	if err := s.validateWriteRoot(); err != nil {
+		return manifest, err
+	}
+	if err := s.cleanupBeforeWrite(ctx); err != nil {
 		return manifest, err
 	}
 	if len(files) == 0 {
@@ -205,7 +261,14 @@ func (s *Store) CaptureBase(ctx context.Context, tenantID, projectID shared.ID, 
 		if err != nil || canonical == "" || canonical != path {
 			return projectanalysis.SourceManifest{}, fmt.Errorf("%w: base source path is invalid", shared.ErrValidation)
 		}
+		if !sourcepolicy.RetainPath(path) {
+			continue
+		}
 		paths = append(paths, path)
+	}
+	if len(paths) == 0 {
+		manifest.SetArtifactDigest()
+		return manifest, nil
 	}
 	sort.Strings(paths)
 	var total int64
@@ -243,12 +306,25 @@ func (s *Store) CaptureBase(ctx context.Context, tenantID, projectID shared.ID, 
 	if err := os.WriteFile(filepath.Join(tmp, "manifest.json"), data, 0o600); err != nil {
 		return projectanalysis.SourceManifest{}, fmt.Errorf("write base source manifest: %w", err)
 	}
-	if err := os.RemoveAll(root); err != nil {
-		return projectanalysis.SourceManifest{}, fmt.Errorf("replace base source artifact: %w", err)
+	if err := os.Mkdir(root, 0o700); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return projectanalysis.SourceManifest{}, shared.ErrConflict
+		}
+		return projectanalysis.SourceManifest{}, fmt.Errorf("claim base source artifact: %w", err)
 	}
-	if err := os.Rename(tmp, root); err != nil {
-		return projectanalysis.SourceManifest{}, fmt.Errorf("publish base source artifact: %w", err)
+	published := false
+	defer func() {
+		if !published {
+			_ = os.RemoveAll(root)
+		}
+	}()
+	if err := os.Rename(filepath.Join(tmp, "blobs"), filepath.Join(root, "blobs")); err != nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("publish base source blobs: %w", err)
 	}
+	if err := os.Rename(filepath.Join(tmp, "manifest.json"), filepath.Join(root, "manifest.json")); err != nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("publish base source manifest: %w", err)
+	}
+	published = true
 	return manifest, nil
 }
 
@@ -398,15 +474,16 @@ func (s *Store) cleanupExpiredAt(root string, before time.Time) error {
 					continue
 				}
 				analysisDir := filepath.Join(analysisRoot, analysis.Name())
-				if _, err := os.Stat(filepath.Join(analysisDir, "manifest.json")); os.IsNotExist(err) {
-					continue
-				} else if err != nil {
-					return fmt.Errorf("stat source artifact manifest: %w", err)
-				}
 				info, err := analysis.Info()
 				if err != nil {
 					return err
 				}
+				if _, err := os.Stat(filepath.Join(analysisDir, "manifest.json")); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("stat source artifact manifest: %w", err)
+				}
+				// A process may die after atomically claiming the analysis directory but before
+				// writing manifest.json. Treat an old manifest-less claim as managed stale state
+				// so it cannot block publication forever.
 				if info.ModTime().Before(before) {
 					if err := os.RemoveAll(analysisDir); err != nil {
 						return fmt.Errorf("remove expired source artifacts: %w", err)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -475,7 +475,7 @@ func Load() Config {
 		Offline:                   getbool("SYNAPSE_OFFLINE", false),
 		MaxWorkspaceBytes:         getint64("SYNAPSE_MAX_WORKSPACE_BYTES", 2<<30),
 		ProjectUploadDir:          getenv("SYNAPSE_PROJECT_UPLOAD_DIR", "data/project-uploads"),
-		ProjectSourceArtifactDir:  getenv("SYNAPSE_PROJECT_SOURCE_ARTIFACT_DIR", "data/project-source-artifacts"),
+		ProjectSourceArtifactDir:  projectSourceArtifactDir(),
 		ProjectSourceRetention:    getduration("SYNAPSE_PROJECT_SOURCE_RETENTION", 90*24*time.Hour),
 		ProjectSourceMaxFileBytes: getint64("SYNAPSE_PROJECT_SOURCE_MAX_FILE_BYTES", 2<<20),
 		ProjectSourceMaxFiles:     getint("SYNAPSE_PROJECT_SOURCE_MAX_FILES", 10_000),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -192,7 +193,7 @@ func TestProjectSourceCaptureDefaults(t *testing.T) {
 		t.Setenv(key, "")
 	}
 	cfg := Load()
-	if cfg.ProjectSourceArtifactDir != "data/project-source-artifacts" || cfg.ProjectSourceRetention != 90*24*time.Hour || cfg.ProjectSourceMaxFileBytes != 2<<20 || cfg.ProjectSourceMaxFiles != 10_000 || cfg.ProjectSourceMaxBytes != 500<<20 {
+	if !filepath.IsAbs(cfg.ProjectSourceArtifactDir) || cfg.ProjectSourceRetention != 90*24*time.Hour || cfg.ProjectSourceMaxFileBytes != 2<<20 || cfg.ProjectSourceMaxFiles != 10_000 || cfg.ProjectSourceMaxBytes != 500<<20 {
 		t.Fatalf("source capture defaults = %+v", cfg)
 	}
 }

--- a/internal/platform/config/project_source_artifact_dir.go
+++ b/internal/platform/config/project_source_artifact_dir.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// projectSourceArtifactDir returns an operator-owned absolute default outside the process working
+// tree. An explicit environment value is preserved so write adapters can fail closed on a relative
+// configuration instead of silently rebasing it into an attacker-controlled checkout.
+func projectSourceArtifactDir() string {
+	if configured := strings.TrimSpace(os.Getenv("SYNAPSE_PROJECT_SOURCE_ARTIFACT_DIR")); configured != "" {
+		return configured
+	}
+	if cache, err := os.UserCacheDir(); err == nil && filepath.IsAbs(cache) {
+		return filepath.Join(cache, "synapse", "project-source-artifacts")
+	}
+	if tmp := os.TempDir(); filepath.IsAbs(tmp) {
+		return filepath.Join(tmp, "synapse", "project-source-artifacts")
+	}
+	// filepath.Abs is the final portability fallback. It should be unreachable on supported hosts,
+	// but still guarantees the downstream write-root invariant instead of returning a relative path.
+	absolute, err := filepath.Abs(filepath.Join("data", "project-source-artifacts"))
+	if err != nil {
+		return ""
+	}
+	return absolute
+}

--- a/internal/usecase/ports/project_source_publish.go
+++ b/internal/usecase/ports/project_source_publish.go
@@ -1,0 +1,35 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const ProjectSourcePublishAuditAction = "project.source.publish"
+
+// ErrProjectSourceCommitUncertain marks a commit-phase failure whose durable outcome cannot be
+// proven by the caller. The filesystem artifact must be preserved in this case: deleting it could
+// corrupt an analysis+audit transaction that actually committed. Retention can safely reclaim an
+// orphan later if the transaction did roll back.
+var ErrProjectSourceCommitUncertain = errors.New("project source commit outcome is uncertain")
+
+// ProjectSourceArtifactPublisher consumes a tar stream supplied by a contributor and publishes
+// a server-owned, immutable artifact. allowedPaths comes from the persisted analysis snapshot;
+// callers never trust the contributor to choose the durable source inventory.
+type ProjectSourceArtifactPublisher interface {
+	PublishArchive(ctx context.Context, tenantID, projectID shared.ID, analysisID string, writer projectanalysis.SourceWriter, allowedPaths []string, src io.Reader) (projectanalysis.SourceCapture, error)
+	// DiscardPublished removes only the v2 artifact claimed by PublishArchive. It is a narrow
+	// compensation hook for a failed DB+audit commit and must not delete legacy capture paths.
+	DiscardPublished(ctx context.Context, tenantID, projectID shared.ID, analysisID string) error
+}
+
+// ProjectAnalysisSourceAtomicMutator combines source attachment and its audit entry in one durable
+// transaction. The sanctioned path requires this interface so durable source metadata can never be
+// acknowledged without its matching audit record.
+type ProjectAnalysisSourceAtomicMutator interface {
+	AttachSourceWithAudit(ctx context.Context, tenantID, projectID, analysisID shared.ID, capture projectanalysis.SourceCapture, audit AuditEntry) error
+}

--- a/internal/usecase/projectuc/code_source_integrity.go
+++ b/internal/usecase/projectuc/code_source_integrity.go
@@ -1,0 +1,16 @@
+package projectuc
+
+import "github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+
+func persistedSourceFileForRead(analysis projectanalysis.Analysis, path string, base bool) (projectanalysis.SourceFile, bool) {
+	manifest := analysis.SourceManifest
+	if base {
+		manifest = analysis.Comparison.BaseManifest
+	}
+	for _, file := range manifest.Files {
+		if file.Path == path {
+			return file, true
+		}
+	}
+	return projectanalysis.SourceFile{}, false
+}

--- a/internal/usecase/projectuc/code_viewer.go
+++ b/internal/usecase/projectuc/code_viewer.go
@@ -178,6 +178,10 @@ func (s *Service) ReadCodeFile(ctx context.Context, tenantID shared.ID, key, ana
 	if err != nil {
 		return CodeFileView{}, analysis.Capabilities, err
 	}
+	expectedSource, found := persistedSourceFileForRead(analysis, canonical, baseSide)
+	if !found || source != expectedSource {
+		return CodeFileView{}, analysis.Capabilities, projectanalysis.ErrSourceIntegrity
+	}
 	lines := splitCodeLines(string(data))
 	if fromLine < 1 {
 		fromLine = 1

--- a/internal/usecase/projectuc/code_viewer_test.go
+++ b/internal/usecase/projectuc/code_viewer_test.go
@@ -143,7 +143,7 @@ func TestReadCodeFileComposesImmutableLineState(t *testing.T) {
 	svc, analyses, p := newCodeService(t, artifacts)
 	saveCodeAnalysis(t, analyses, p, projectanalysis.Analysis{
 		Capabilities:   projectanalysis.SourceCapabilities{Source: projectanalysis.Capability{Available: true}},
-		SourceManifest: projectanalysis.SourceManifest{Files: []projectanalysis.SourceFile{{Path: "main.go", Digest: "digest", Lines: 3, Available: true}}},
+		SourceManifest: projectanalysis.SourceManifest{Files: []projectanalysis.SourceFile{{Path: "main.go", Digest: "digest", Bytes: int64(len(artifacts.data)), Lines: 3, Available: true}}},
 		FileChanges:    []projectanalysis.FileChange{{Status: projectanalysis.FileStatusModified, OldPath: "main.go", NewPath: "main.go", Added: []projectanalysis.LineRange{{Start: 2, End: 2}}}},
 		Coverage:       &measure.CoverageReport{Lines: measure.LineCoverage{"main.go": {1: true, 2: false}}},
 		Duplication:    measure.DuplicationReport{Blocks: []measure.DuplicationBlock{{Occurrences: []measure.CodeRange{{File: "main.go", StartLine: 3, EndLine: 3}}}}},
@@ -164,7 +164,7 @@ func TestReadCodeFileUsesBaseArtifactForDeletedFile(t *testing.T) {
 	svc, analyses, p := newCodeService(t, artifacts)
 	saveCodeAnalysis(t, analyses, p, projectanalysis.Analysis{
 		Capabilities: projectanalysis.SourceCapabilities{Source: projectanalysis.Capability{Available: true}},
-		Comparison:   projectanalysis.Comparison{Available: true, BaseCommit: "base", MergeBase: "base", BaseManifest: projectanalysis.SourceManifest{Files: []projectanalysis.SourceFile{{Path: "deleted.go", Digest: "base-digest", Lines: 1, Available: true}}}},
+		Comparison:   projectanalysis.Comparison{Available: true, BaseCommit: "base", MergeBase: "base", BaseManifest: projectanalysis.SourceManifest{Files: []projectanalysis.SourceFile{{Path: "deleted.go", Digest: "base-digest", Bytes: int64(len(artifacts.baseData)), Lines: 1, Available: true}}}},
 		FileChanges:  []projectanalysis.FileChange{{Status: projectanalysis.FileStatusDeleted, OldPath: "deleted.go"}},
 		Snapshot:     measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}}},
 	})

--- a/internal/usecase/projectuc/source_publish.go
+++ b/internal/usecase/projectuc/source_publish.go
@@ -1,0 +1,116 @@
+package projectuc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const sourcePublishCompensationTimeout = 5 * time.Second
+
+// PublishSourceInput contains only contributor-controlled facts that are safe to accept.
+// Tenant and project identity are resolved by the authenticated server path, never from the archive.
+type PublishSourceInput struct {
+	TenantID    shared.ID
+	ProjectKey  string
+	AnalysisID  string
+	Actor       string
+	ToolVersion string
+	Archive     io.Reader
+}
+
+// PublishSource contributes source bytes to an already-created server-owned analysis.
+// It never creates an analysis and never lets the caller choose an artifact namespace.
+func (s *Service) PublishSource(ctx context.Context, in PublishSourceInput) (projectanalysis.SourceManifest, error) {
+	if err := requireActor(in.Actor); err != nil {
+		return projectanalysis.SourceManifest{}, err
+	}
+	if strings.TrimSpace(in.ProjectKey) == "" || strings.TrimSpace(in.AnalysisID) == "" || strings.TrimSpace(in.ToolVersion) == "" || in.Archive == nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("%w: source publish input is incomplete", shared.ErrValidation)
+	}
+	if s.analyses == nil || s.sourceArtifacts == nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("%w: source publication is not configured", shared.ErrValidation)
+	}
+	publisher, ok := s.sourceArtifacts.(ports.ProjectSourceArtifactPublisher)
+	if !ok {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("%w: source publication is not configured", shared.ErrValidation)
+	}
+	mutator, ok := s.analyses.(ports.ProjectAnalysisSourceAtomicMutator)
+	if !ok {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("%w: transactional source publication is not configured", shared.ErrValidation)
+	}
+
+	project, err := s.repo.GetByKey(ctx, in.TenantID, in.ProjectKey)
+	if err != nil {
+		return projectanalysis.SourceManifest{}, err
+	}
+	analysisID := shared.ID(in.AnalysisID)
+	analysis, err := s.analyses.Get(ctx, in.TenantID, project.ID, analysisID)
+	if err != nil {
+		return projectanalysis.SourceManifest{}, err
+	}
+	if analysis.TenantID != in.TenantID.String() || analysis.ProjectID != project.ID.String() || analysis.ProjectKey != project.Key {
+		return projectanalysis.SourceManifest{}, shared.ErrNotFound
+	}
+	if !analysis.SourceRevision.Kind.Valid() {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("%w: analysis target cannot retain source", shared.ErrValidation)
+	}
+	if analysis.Capabilities.Source.Available || analysis.SourceManifest.Digest != "" || len(analysis.SourceManifest.Files) != 0 || analysis.SourceManifest.Writer != nil {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("%w: source snapshot already retained", shared.ErrConflict)
+	}
+
+	allowed := make([]string, 0, len(analysis.Snapshot.Nodes))
+	for _, node := range analysis.Snapshot.Nodes {
+		if node.Kind == measure.NodeFile && sourcepolicy.RetainPath(node.Path) {
+			allowed = append(allowed, node.Path)
+		}
+	}
+	// Image scans, a single JAR/archive, and other package-only targets have no scanner-owned
+	// source-file inventory. Refuse them here, before the artifact adapter can claim a namespace.
+	if len(allowed) == 0 {
+		return projectanalysis.SourceManifest{}, fmt.Errorf("%w: analysis target has no retainable source files", shared.ErrValidation)
+	}
+	now := s.clock.Now().UTC()
+	writer := projectanalysis.SourceWriter{Actor: in.Actor, ToolVersion: strings.TrimSpace(in.ToolVersion), PublishedAt: now}
+	capture, err := publisher.PublishArchive(ctx, in.TenantID, project.ID, analysis.ID, writer, allowed, in.Archive)
+	if err != nil {
+		return projectanalysis.SourceManifest{}, err
+	}
+	audit := ports.AuditEntry{
+		Actor:  in.Actor,
+		Action: ports.ProjectSourcePublishAuditAction,
+		Target: analysis.ID,
+		Metadata: map[string]string{
+			"project":         project.Key,
+			"artifact_digest": capture.Manifest.Digest,
+			"tool_version":    writer.ToolVersion,
+		},
+		At: now,
+	}
+	if err := mutator.AttachSourceWithAudit(ctx, in.TenantID, project.ID, analysisID, capture, audit); err != nil {
+		if errors.Is(err, ports.ErrProjectSourceCommitUncertain) {
+			// COMMIT may already be durable. Never destroy bytes that a committed analysis+audit can
+			// reference; if the transaction actually rolled back, retention can reap the orphan later.
+			return projectanalysis.SourceManifest{}, err
+		}
+		// The mutator may fail because the request context itself expired. Compensation must still
+		// get a short bounded opportunity to remove the artifact that this call just published.
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sourcePublishCompensationTimeout)
+		cleanupErr := publisher.DiscardPublished(cleanupCtx, in.TenantID, project.ID, analysis.ID)
+		cancel()
+		if cleanupErr != nil {
+			return projectanalysis.SourceManifest{}, errors.Join(err, fmt.Errorf("rollback published artifact: %w", cleanupErr))
+		}
+		return projectanalysis.SourceManifest{}, err
+	}
+	return capture.Manifest, nil
+}

--- a/internal/usecase/projectuc/source_publish_audit_test.go
+++ b/internal/usecase/projectuc/source_publish_audit_test.go
@@ -1,0 +1,47 @@
+package projectuc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceartifact"
+)
+
+func TestPublishSourceFailsClosedWithoutTransactionalAuditStore(t *testing.T) {
+	ctx := context.Background()
+	projects := memory.NewProjectRepository()
+	analyses := memory.NewProjectAnalysisStore()
+	artifacts := sourceartifact.New(t.TempDir(), 0, 0, 0)
+	svc := NewService(projects, memory.NewEngagementRepository(), sourcePublishTestClock(), fixedIDs{}, &captureAudit{}, true)
+	svc.SetAnalysisStore(analyses)
+	svc.SetSourceArtifactStore(artifacts)
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysis := projectanalysis.Analysis{
+		ID: "analysis", TenantID: p.TenantID.String(), ProjectID: p.ID.String(), ProjectKey: p.Key,
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Snapshot:       measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}, {Path: "main.go", Kind: measure.NodeFile}}},
+	}
+	if err := analyses.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+	_, err = svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: p.TenantID, ProjectKey: p.Key, AnalysisID: analysis.ID,
+		Actor: "ci-bot", ToolVersion: "test", Archive: sourceTar(t, map[string]string{"main.go": "package main\n"}),
+	})
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "transactional source publication") {
+		t.Fatalf("error=%v, want fail-closed transactional-audit validation", err)
+	}
+	if _, _, err := artifacts.Load(ctx, p.TenantID, p.ID, analysis.ID, "main.go"); !errors.Is(err, projectanalysis.ErrSourceNotRetained) {
+		t.Fatalf("source artifact exists without durable audit support: %v", err)
+	}
+}

--- a/internal/usecase/projectuc/source_publish_commit_uncertain_test.go
+++ b/internal/usecase/projectuc/source_publish_commit_uncertain_test.go
@@ -1,0 +1,68 @@
+package projectuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceartifact"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type uncertainCommitAnalysisStore struct {
+	*memory.ProjectAnalysisStore
+}
+
+func (*uncertainCommitAnalysisStore) AttachSourceWithAudit(context.Context, shared.ID, shared.ID, shared.ID, projectanalysis.SourceCapture, ports.AuditEntry) error {
+	return ports.ErrProjectSourceCommitUncertain
+}
+
+func TestPublishSourcePreservesArtifactWhenCommitOutcomeIsUncertain(t *testing.T) {
+	ctx := context.Background()
+	projects := memory.NewProjectRepository()
+	analyses := &uncertainCommitAnalysisStore{ProjectAnalysisStore: memory.NewProjectAnalysisStore()}
+	artifacts := sourceartifact.New(t.TempDir(), 0, 0, 0)
+	svc := NewService(projects, memory.NewEngagementRepository(), sourcePublishTestClock(), fixedIDs{}, &captureAudit{}, true)
+	svc.SetAnalysisStore(analyses)
+	svc.SetSourceArtifactStore(artifacts)
+
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysis := projectanalysis.Analysis{
+		ID: "uncertain-analysis", TenantID: p.TenantID.String(), ProjectID: p.ID.String(), ProjectKey: p.Key,
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Capabilities: projectanalysis.SourceCapabilities{
+			Source:       projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+			Comparison:   projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			UnifiedDiff:  projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			SplitDiff:    projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			Highlighting: projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+		},
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}, {Path: "main.go", Kind: measure.NodeFile}}},
+	}
+	if err := analyses.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: p.TenantID, ProjectKey: p.Key, AnalysisID: analysis.ID,
+		Actor: "ci-bot", ToolVersion: "test", Archive: sourceTar(t, map[string]string{"main.go": "package main\n"}),
+	})
+	if !errors.Is(err, ports.ErrProjectSourceCommitUncertain) {
+		t.Fatalf("PublishSource() error=%v, want uncertain commit", err)
+	}
+	data, _, loadErr := artifacts.Load(ctx, p.TenantID, p.ID, analysis.ID, "main.go")
+	if loadErr != nil {
+		t.Fatalf("published artifact was destructively compensated: %v", loadErr)
+	}
+	if string(data) != "package main\n" {
+		t.Fatalf("retained data=%q", data)
+	}
+}

--- a/internal/usecase/projectuc/source_publish_compensation_test.go
+++ b/internal/usecase/projectuc/source_publish_compensation_test.go
@@ -1,0 +1,74 @@
+package projectuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceartifact"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type cancelingSourceAnalysisStore struct {
+	*memory.ProjectAnalysisStore
+	cancel context.CancelFunc
+}
+
+func (s *cancelingSourceAnalysisStore) AttachSourceWithAudit(context.Context, shared.ID, shared.ID, shared.ID, projectanalysis.SourceCapture, ports.AuditEntry) error {
+	s.cancel()
+	return context.Canceled
+}
+
+func TestPublishSourceCompensatesArtifactAfterRequestCancellation(t *testing.T) {
+	projects := memory.NewProjectRepository()
+	baseAnalyses := memory.NewProjectAnalysisStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	analyses := &cancelingSourceAnalysisStore{ProjectAnalysisStore: baseAnalyses, cancel: cancel}
+	artifacts := sourceartifact.New(t.TempDir(), 0, 0, 0)
+	svc := NewService(projects, memory.NewEngagementRepository(), sourcePublishTestClock(), fixedIDs{}, &captureAudit{}, true)
+	svc.SetAnalysisStore(analyses)
+	svc.SetSourceArtifactStore(artifacts)
+
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysis := projectanalysis.Analysis{
+		ID: "cancel-analysis", TenantID: p.TenantID.String(), ProjectID: p.ID.String(), ProjectKey: p.Key,
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Capabilities: projectanalysis.SourceCapabilities{
+			Source:       projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+			Comparison:   projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			UnifiedDiff:  projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			SplitDiff:    projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			Highlighting: projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+		},
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}, {Path: "main.go", Kind: measure.NodeFile}}},
+	}
+	if err := baseAnalyses.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: p.TenantID, ProjectKey: p.Key, AnalysisID: analysis.ID,
+		Actor: "ci-bot", ToolVersion: "test", Archive: sourceTar(t, map[string]string{"main.go": "package main\n"}),
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("publish error=%v, want canceled attach", err)
+	}
+	if _, _, err := artifacts.Load(context.Background(), p.TenantID, p.ID, analysis.ID, "main.go"); !errors.Is(err, projectanalysis.ErrSourceNotRetained) {
+		t.Fatalf("artifact survived canceled DB/audit attach: %v", err)
+	}
+	got, err := baseAnalyses.Get(context.Background(), p.TenantID, p.ID, shared.ID(analysis.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Capabilities.Source.Available || got.SourceManifest.Digest != "" {
+		t.Fatalf("analysis changed despite canceled attach: %+v", got.SourceManifest)
+	}
+}

--- a/internal/usecase/projectuc/source_publish_target_test.go
+++ b/internal/usecase/projectuc/source_publish_target_test.go
@@ -1,0 +1,48 @@
+package projectuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceartifact"
+)
+
+func TestPublishSourceRejectsPackageOnlyAnalysisInUsecase(t *testing.T) {
+	ctx := context.Background()
+	projects := memory.NewProjectRepository()
+	analyses := &sourceAuditAnalysisStore{ProjectAnalysisStore: memory.NewProjectAnalysisStore()}
+	artifacts := sourceartifact.New(t.TempDir(), 0, 0, 0)
+	svc := NewService(projects, memory.NewEngagementRepository(), sourcePublishTestClock(), fixedIDs{}, &captureAudit{}, true)
+	svc.SetAnalysisStore(analyses)
+	svc.SetSourceArtifactStore(artifacts)
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysis := projectanalysis.Analysis{
+		ID: "package-only", TenantID: p.TenantID.String(), ProjectID: p.ID.String(), ProjectKey: p.Key,
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindArchive, Head: "app.jar"},
+		Snapshot:       measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}}},
+	}
+	if err := analyses.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: p.TenantID, ProjectKey: p.Key, AnalysisID: analysis.ID,
+		Actor: "ci-bot", ToolVersion: "test", Archive: sourceTar(t, map[string]string{"app.jar": "not source"}),
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("package-only publish error=%v, want validation", err)
+	}
+	if len(analyses.audits) != 0 {
+		t.Fatalf("package-only target emitted audit: %+v", analyses.audits)
+	}
+	if _, _, err := artifacts.Load(ctx, p.TenantID, p.ID, analysis.ID, "app.jar"); !errors.Is(err, projectanalysis.ErrSourceNotRetained) {
+		t.Fatalf("package-only target created artifact: %v", err)
+	}
+}

--- a/internal/usecase/projectuc/source_publish_test.go
+++ b/internal/usecase/projectuc/source_publish_test.go
@@ -1,0 +1,218 @@
+package projectuc
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceartifact"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func sourcePublishTestClock() fixedClock {
+	return fixedClock{now: time.Date(2026, 8, 10, 2, 0, 0, 0, time.UTC)}
+}
+
+type sourceAuditAnalysisStore struct {
+	*memory.ProjectAnalysisStore
+	mu      sync.Mutex
+	sources map[string]projectanalysis.SourceCapture
+	audits  []ports.AuditEntry
+}
+
+func sourceAttachmentKey(tenantID, projectID, analysisID shared.ID) string {
+	return tenantID.String() + "\x00" + projectID.String() + "\x00" + analysisID.String()
+}
+
+func (s *sourceAuditAnalysisStore) AttachSourceWithAudit(ctx context.Context, tenantID, projectID, analysisID shared.ID, capture projectanalysis.SourceCapture, audit ports.AuditEntry) error {
+	writer := capture.Manifest.Writer
+	if writer == nil || audit.Actor != writer.Actor || !audit.At.Equal(writer.PublishedAt) || audit.Action != ports.ProjectSourcePublishAuditAction || audit.Target != analysisID.String() || audit.Metadata["artifact_digest"] != capture.Manifest.Digest || audit.Metadata["tool_version"] != writer.ToolVersion {
+		return shared.ErrValidation
+	}
+	analysis, err := s.ProjectAnalysisStore.Get(ctx, tenantID, projectID, analysisID)
+	if err != nil {
+		return err
+	}
+	if analysis.Capabilities.Source.Available || analysis.SourceManifest.Digest != "" {
+		return shared.ErrConflict
+	}
+	key := sourceAttachmentKey(tenantID, projectID, analysisID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sources == nil {
+		s.sources = make(map[string]projectanalysis.SourceCapture)
+	}
+	if _, exists := s.sources[key]; exists {
+		return shared.ErrConflict
+	}
+	s.sources[key] = capture
+	s.audits = append(s.audits, audit)
+	return nil
+}
+
+func (s *sourceAuditAnalysisStore) Get(ctx context.Context, tenantID, projectID, analysisID shared.ID) (projectanalysis.Analysis, error) {
+	analysis, err := s.ProjectAnalysisStore.Get(ctx, tenantID, projectID, analysisID)
+	if err != nil {
+		return projectanalysis.Analysis{}, err
+	}
+	key := sourceAttachmentKey(tenantID, projectID, analysisID)
+	s.mu.Lock()
+	capture, ok := s.sources[key]
+	s.mu.Unlock()
+	if ok {
+		analysis.SourceManifest = capture.Manifest
+		analysis.Capabilities.Source = projectanalysis.Capability{Available: true}
+		analysis.Capabilities.Highlighting = projectanalysis.Capability{Available: true}
+	}
+	return analysis, nil
+}
+
+func sourceTar(t *testing.T, files map[string]string) *bytes.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for name, body := range files {
+		data := []byte(body)
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(data)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}
+
+func TestPublishSourceIsServedThroughReadCodeFileAndExcludesSecrets(t *testing.T) {
+	ctx := context.Background()
+	projects := memory.NewProjectRepository()
+	analyses := &sourceAuditAnalysisStore{ProjectAnalysisStore: memory.NewProjectAnalysisStore()}
+	artifacts := sourceartifact.New(t.TempDir(), 0, 0, 0)
+	svc := NewService(projects, memory.NewEngagementRepository(), sourcePublishTestClock(), fixedIDs{}, &captureAudit{}, true)
+	svc.SetAnalysisStore(analyses)
+	svc.SetSourceArtifactStore(artifacts)
+
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysis := projectanalysis.Analysis{
+		ID:             "analysis",
+		TenantID:       p.TenantID.String(),
+		ProjectID:      p.ID.String(),
+		ProjectKey:     p.Key,
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Capabilities: projectanalysis.SourceCapabilities{
+			Source:       projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+			Comparison:   projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			UnifiedDiff:  projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			SplitDiff:    projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			Highlighting: projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+		},
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{
+			{Path: "", Kind: measure.NodeProject},
+			{Path: "src/main.go", Kind: measure.NodeFile, Language: "Go"},
+			// These deliberately model scanner-inventory drift: durable publication must still deny them.
+			{Path: ".env", Kind: measure.NodeFile},
+			{Path: "deploy/private.pem", Kind: measure.NodeFile},
+		}},
+	}
+	if err := analyses.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: p.TenantID, ProjectKey: p.Key, AnalysisID: analysis.ID,
+		Actor: "ci-bot", ToolVersion: "synapse-cli/test", Archive: sourceTar(t, map[string]string{
+			"src/main.go":        "package main\n\nfunc main() {}\n",
+			".env":               "fixture-blocked-by-path\n",
+			"deploy/private.pem": "fixture-blocked-by-path\n",
+			"outside.txt":        "not part of scanner inventory\n",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Writer == nil || manifest.Writer.Actor != "ci-bot" || manifest.Writer.ToolVersion != "synapse-cli/test" || manifest.Digest == "" || manifest.Digest != manifest.ArtifactDigest() {
+		t.Fatalf("manifest provenance/digest not sealed: %+v", manifest)
+	}
+	if len(manifest.Files) != 1 || manifest.Files[0].Path != "src/main.go" || !manifest.Files[0].Available {
+		t.Fatalf("unexpected retained files: %+v", manifest.Files)
+	}
+	if len(analyses.audits) != 1 || analyses.audits[0].Actor != "ci-bot" || analyses.audits[0].Action != ports.ProjectSourcePublishAuditAction || analyses.audits[0].Metadata["artifact_digest"] != manifest.Digest {
+		t.Fatalf("audit=%+v", analyses.audits)
+	}
+
+	// This is the acceptance test PR #403 lacked: prove the contributed bytes travel through
+	// the production project use-case read path, not merely Store.Load.
+	view, caps, err := svc.ReadCodeFile(ctx, p.TenantID, p.Key, analysis.ID, "src/main.go", 1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !caps.Source.Available || view.File.Path != "src/main.go" || len(view.Lines) != 3 || view.Lines[0].Content != "package main" {
+		t.Fatalf("view=%+v caps=%+v", view, caps)
+	}
+	for _, forbidden := range []string{".env", "deploy/private.pem", "outside.txt"} {
+		if _, _, err := artifacts.Load(ctx, p.TenantID, p.ID, analysis.ID, forbidden); !errors.Is(err, projectanalysis.ErrSourceNotRetained) {
+			t.Fatalf("%s load error=%v, want not retained", forbidden, err)
+		}
+	}
+
+	if _, err := svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: p.TenantID, ProjectKey: p.Key, AnalysisID: analysis.ID,
+		Actor: "ci-bot", ToolVersion: "synapse-cli/test", Archive: sourceTar(t, map[string]string{"src/main.go": "replacement\n"}),
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate publish error=%v, want conflict", err)
+	}
+	if len(analyses.audits) != 1 {
+		t.Fatalf("duplicate publish emitted audit: %+v", analyses.audits)
+	}
+
+	if _, err := svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: "other-tenant", ProjectKey: p.Key, AnalysisID: analysis.ID,
+		Actor: "mallory", ToolVersion: "synapse-cli/test", Archive: sourceTar(t, map[string]string{"src/main.go": "foreign\n"}),
+	}); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("foreign-tenant publish error=%v, want not found", err)
+	}
+}
+
+func TestPublishSourceRejectsUnsupportedAnalysisBeforeArtifactCreation(t *testing.T) {
+	ctx := context.Background()
+	projects := memory.NewProjectRepository()
+	analyses := &sourceAuditAnalysisStore{ProjectAnalysisStore: memory.NewProjectAnalysisStore()}
+	artifacts := sourceartifact.New(t.TempDir(), 0, 0, 0)
+	svc := NewService(projects, memory.NewEngagementRepository(), sourcePublishTestClock(), fixedIDs{}, &captureAudit{}, true)
+	svc.SetAnalysisStore(analyses)
+	svc.SetSourceArtifactStore(artifacts)
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysis := projectanalysis.Analysis{
+		ID: "unsupported", TenantID: p.TenantID.String(), ProjectID: p.ID.String(), ProjectKey: p.Key,
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}, {Path: "main.go", Kind: measure.NodeFile}}},
+	}
+	if err := analyses.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: p.TenantID, ProjectKey: p.Key, AnalysisID: analysis.ID, Actor: "ci-bot", ToolVersion: "test", Archive: sourceTar(t, map[string]string{"main.go": "package main\n"}),
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unsupported target error=%v, want validation", err)
+	}
+	if len(analyses.audits) != 0 {
+		t.Fatalf("unsupported target emitted audit: %+v", analyses.audits)
+	}
+}

--- a/internal/usecase/projectuc/source_publish_unknown_test.go
+++ b/internal/usecase/projectuc/source_publish_unknown_test.go
@@ -1,0 +1,41 @@
+package projectuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceartifact"
+)
+
+func TestPublishSourceRejectsUnknownAnalysisBeforeArtifactCreation(t *testing.T) {
+	ctx := context.Background()
+	projects := memory.NewProjectRepository()
+	analyses := &sourceAuditAnalysisStore{ProjectAnalysisStore: memory.NewProjectAnalysisStore()}
+	artifacts := sourceartifact.New(t.TempDir(), 0, 0, 0)
+	svc := NewService(projects, memory.NewEngagementRepository(), sourcePublishTestClock(), fixedIDs{}, &captureAudit{}, true)
+	svc.SetAnalysisStore(analyses)
+	svc.SetSourceArtifactStore(artifacts)
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const missingAnalysis = "missing-analysis"
+	_, err = svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: p.TenantID, ProjectKey: p.Key, AnalysisID: missingAnalysis,
+		Actor: "ci-bot", ToolVersion: "test", Archive: sourceTar(t, map[string]string{"main.go": "package main\n"}),
+	})
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("unknown analysis error=%v, want not found", err)
+	}
+	if len(analyses.audits) != 0 {
+		t.Fatalf("unknown analysis emitted audit: %+v", analyses.audits)
+	}
+	if _, _, err := artifacts.Load(ctx, p.TenantID, p.ID, missingAnalysis, "main.go"); !errors.Is(err, projectanalysis.ErrSourceNotRetained) {
+		t.Fatalf("unknown analysis created artifact: %v", err)
+	}
+}

--- a/internal/usecase/projectuc/source_read_integrity_test.go
+++ b/internal/usecase/projectuc/source_read_integrity_test.go
@@ -1,0 +1,75 @@
+package projectuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceartifact"
+)
+
+type tamperingSourceStore struct {
+	*sourceartifact.Store
+	tamper bool
+}
+
+func (s *tamperingSourceStore) Load(ctx context.Context, tenantID, projectID interfaceID, analysisID, path string) ([]byte, projectanalysis.SourceFile, error) {
+	data, file, err := s.Store.Load(ctx, tenantID, projectID, analysisID, path)
+	if err != nil || !s.tamper {
+		return data, file, err
+	}
+	forged := file
+	forged.Digest = "forged-digest"
+	forged.Bytes = int64(len("tampered\n"))
+	return []byte("tampered\n"), forged, nil
+}
+
+// interfaceID aliases shared.ID only to keep the override signature visually focused on the
+// tampering behavior while still exactly satisfying ports.ProjectSourceArtifactStore.
+type interfaceID = shared.ID
+
+func TestReadCodeFileRejectsArtifactDetachedFromPersistedManifest(t *testing.T) {
+	ctx := context.Background()
+	projects := memory.NewProjectRepository()
+	analyses := &sourceAuditAnalysisStore{ProjectAnalysisStore: memory.NewProjectAnalysisStore()}
+	artifacts := &tamperingSourceStore{Store: sourceartifact.New(t.TempDir(), 0, 0, 0)}
+	svc := NewService(projects, memory.NewEngagementRepository(), sourcePublishTestClock(), fixedIDs{}, &captureAudit{}, true)
+	svc.SetAnalysisStore(analyses)
+	svc.SetSourceArtifactStore(artifacts)
+
+	p, err := svc.Create(ctx, CreateInput{TenantID: "tenant", CreatedBy: "alice", Name: "Project", Key: "project", SourceBinding: project.SourceBinding{Kind: project.SourceLocal, Value: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysis := projectanalysis.Analysis{
+		ID: "integrity-analysis", TenantID: p.TenantID.String(), ProjectID: p.ID.String(), ProjectKey: p.Key,
+		SourceRevision: projectanalysis.SourceRevision{Kind: projectanalysis.ScanKindLocal, Head: "workspace"},
+		Capabilities: projectanalysis.SourceCapabilities{
+			Source:       projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+			Comparison:   projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			UnifiedDiff:  projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			SplitDiff:    projectanalysis.Capability{Reason: projectanalysis.UnavailableNoComparableBase},
+			Highlighting: projectanalysis.Capability{Reason: projectanalysis.UnavailableNotRetained},
+		},
+		Snapshot: measure.Snapshot{Nodes: []measure.Node{{Path: "", Kind: measure.NodeProject}, {Path: "main.go", Kind: measure.NodeFile}}},
+	}
+	if err := analyses.Save(ctx, analysis); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.PublishSource(ctx, PublishSourceInput{
+		TenantID: p.TenantID, ProjectKey: p.Key, AnalysisID: analysis.ID,
+		Actor: "ci-bot", ToolVersion: "test", Archive: sourceTar(t, map[string]string{"main.go": "package main\n"}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	artifacts.tamper = true
+	if _, _, err := svc.ReadCodeFile(ctx, p.TenantID, p.Key, analysis.ID, "main.go", 1, 10); !errors.Is(err, projectanalysis.ErrSourceIntegrity) {
+		t.Fatalf("tampered read error=%v, want source integrity", err)
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -2799,7 +2799,9 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	// workspace cleanup. Capture failure is explicit metadata, never a scan failure.
 	if opts.ProjectAnalysis {
 		s.captureProjectSource(ctx, engagementID, opts.ProjectAnalysisID, ws.Dir, result)
-		s.captureProjectComparison(ctx, engagementID, opts.ProjectAnalysisID, ws.Dir, ws.Commit, result)
+		if result.SourceCapture != nil && result.SourceCapture.Capabilities.Source.Available {
+			s.captureProjectComparison(ctx, engagementID, opts.ProjectAnalysisID, ws.Dir, ws.Commit, result)
+		}
 	}
 	// Record the image's manifest digest so the fleet cluster agent can correlate a running digest
 	// with this scan (#446). This is the pipeline that populates result.Image (image scans).


### PR DESCRIPTION
## Summary

Adds a sanctioned, authenticated path for CI to contribute Code Quality source snapshots to an existing server-owned analysis.

* add `synapse-cli publish-source` to fetch the persisted analysis inventory and stream only retainable source files
* add `POST /api/v1/projects/{key}/analyses/{id}/source`
* store source under the server-owned artifact namespace and attach the resulting `SourceManifest` to the existing analysis
* expose the endpoint in the OpenAPI contract
* keep existing Code Quality reads on `ReadCodeFile`; no parallel source-serving path is introduced

## Security and integrity

The publish path is fail-closed across the transport, artifact, persistence, and read boundaries:

* derive tenant and actor from the authenticated request rather than client-supplied identity
* re-resolve the project and analysis inside that tenant before accepting source
* refuse unknown, cross-project, non-source, or already-captured analyses
* derive the upload allowlist from the persisted scanner-owned analysis inventory
* exclude credential-bearing and state/vendor paths such as `.env`, private keys, `.git`, `node_modules`, build output, and virtual environments
* require an absolute server-owned artifact root outside the scanned checkout
* create final artifact directories atomically and never overwrite an existing snapshot
* include writer actor, tool version, and publication timestamp in the manifest digest
* require at least one actually retained source file before persistence can mark source available
* attach the `SourceManifest` and durable audit record atomically in Postgres
* compensate known persistence failures while preserving artifacts when COMMIT outcome is uncertain
* bind `ReadCodeFile` results back to the persisted manifest before serving source
* refuse authenticated HTTP redirects so bearer credentials cannot be forwarded to a redirect target
* run configured source retention before every snapshot writer, including the sanctioned publish path
* reap expired manifest-less artifact claims left by an interrupted writer so stale claims cannot block publication indefinitely

Existing legacy head/base capture paths are only hardened to respect the same create-only and source-retention policy; this PR does not add a new comparison-source feature.

## API

`POST /api/v1/projects/{key}/analyses/{id}/source`

* requires the normal authenticated operator permission
* accepts `application/x-tar`
* requires `X-Synapse-Tool-Version`
* returns the persisted source manifest on creation
* documents conflict, authentication, validation, upload-limit, media-type, and server error responses in OpenAPI

## Scope guarantees

* no scan-path database read is introduced
* no scan upload toggle or implicit source publication is introduced
* package/image/non-source analyses remain ineligible
* source publication is an explicit CI contribution step against an already persisted analysis

## Validation

Validated after rebasing onto current `main` (`0a8ee424`).

The exact submitted tree passed:

* Go build and vet
* full `go test -count=1 ./...` with PostgreSQL 17
* same-database Postgres package rerun
* CGO-disabled command builds
* golangci-lint
* Windows build, vet, and tests
* frontend tests, typecheck, and build
* Agent Package Matrix

The validated staging merge and final clean commit have the same tree SHA:
`2c9479880cc88701a6f4eed9b3ebd14da62cd3d8`.

Additional negative proof deliberately removed load-bearing guards. Standard CI failed at the intended tests when:

* write-path retention was disabled
* the sanctioned OpenAPI route was removed
* stale manifest-less claim cleanup was disabled
* read-side manifest binding was removed
* durable source-publication audit was removed
* create-only artifact claiming was removed
* persistence was allowed to accept zero retained source bytes
* authenticated redirects were allowed
* uncertain COMMIT outcomes were compensated destructively
* legacy capture overwrite protection was removed
* secret/state path filtering was removed

Closes #402.
