### PR TITLE
feat(redteam): offensive governance policy, enforced register, kill switch and dry run (#418)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1191,6 +1191,29 @@ paths:
         '401': {$ref: '#/components/responses/Unauthorized'}
         '403': {$ref: '#/components/responses/Forbidden'}
 
+  /api/v1/redteam/halt:
+    post:
+      tags: [redteam]
+      operationId: haltOffensiveWork
+      summary: Kill switch — halt all in-flight offensive work for the tenant
+      description: >-
+        One operator action (PermAdminister) that cancels every in-flight offensive work order. The
+        response reports the MEASURED duration against the stated bound rather than asserting
+        compliance, and reports partial failure as failure. The bound covers the CONTROL PLANE only:
+        a technique already running on a host stops within one further agent poll interval, which is
+        why estate_stop_note is part of the response. See docs/redteam/offensive-policy.md section 8.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/OffensiveHaltRequest'}
+      responses:
+        '200': {description: Every in-flight offensive work order was cancelled, content: {application/json: {schema: {$ref: '#/components/schemas/OffensiveHaltResult'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '500': {description: The halt did not fully succeed; the partial result names the orders still in flight, content: {application/json: {schema: {$ref: '#/components/schemas/OffensiveHaltResult'}}}}
+
   /api/v1/ai-triage/reviews/{rid}/claim:
     parameters: [{$ref: '#/components/parameters/AITriageReviewId'}]
     post:
@@ -1347,6 +1370,31 @@ components:
         updated_at: {type: string, format: date-time}
         decided_at: {type: [string, 'null'], format: date-time}
         version: {type: integer, minimum: 1}
+    OffensiveHaltRequest:
+      type: object
+      required: [reason]
+      properties:
+        reason:
+          type: string
+          description: Why the halt was pulled. Required — a halt nobody can explain afterwards defeats the chain of custody.
+    OffensiveHaltResult:
+      type: object
+      properties:
+        requested_at: {type: string, format: date-time}
+        completed_at: {type: string, format: date-time}
+        duration_ms: {type: integer, description: Measured halt duration at the control plane}
+        stated_bound_ms: {type: integer, description: The bound the duration was measured against}
+        within_bound: {type: boolean}
+        halted: {type: boolean, description: True only when every in-flight offensive order was cancelled}
+        cancelled: {type: array, items: {type: string}}
+        failed:
+          type: object
+          additionalProperties: {type: string}
+          description: Work orders that could not be cancelled, with the reason. Present means the halt was partial.
+        audit_recorded: {type: boolean, description: False when the halt succeeded but could not be audited}
+        estate_stop_note:
+          type: string
+          description: What the bound does NOT cover — a technique already running on a host stops within one further agent poll interval.
     AITriageReviewClaimRequest:
       type: object
       required: [version]

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -130,6 +130,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/jsreach"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/leaderuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/llmverifier"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
@@ -1237,6 +1238,18 @@ func main() {
 		}
 		// Revoking an agent cancels its in-flight work orders (#408).
 		agentSvc.SetWorkOrders(workOrderStore)
+
+		// Offensive kill switch (#418, offensive policy document 8): one operator action halts every
+		// in-flight offensive work order. Wired only where a work order store exists, because a halt
+		// endpoint that accepts a request and stops nothing is the worst possible failure for this
+		// control -- an unwired route 404s instead, which an operator can see.
+		if killSwitch, kerr := offensivepolicyuc.NewKillSwitch(workOrderStore, auditLog, nil, func() time.Time { return clock.Now().UTC() }); kerr != nil {
+			log.Error("offensive kill switch init failed", "err", kerr)
+			os.Exit(1)
+		} else {
+			router.SetOffensiveKillSwitch(killSwitch)
+			log.Info("offensive kill switch ENABLED", "route", "POST /api/v1/redteam/halt", "bound", offensivepolicyuc.HaltBound.String())
+		}
 		// Optional certificate identity (#408): when a control-plane CA is configured, enrolment
 		// with a CSR issues a client certificate. Fail closed on a misconfigured CA.
 		if cfg.FleetCACertPEM != "" && cfg.FleetCAKeyPEM != "" {

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -45,6 +45,27 @@ Synapse validates scope data but cannot verify legal authorization. The operator
 for holding written permission to test any target. Use it only against systems you are
 explicitly authorized to test.
 
+## Offensive actions
+
+Anything Synapse executes **against a target** is additionally governed by the offensive governance
+policy in [`docs/redteam/offensive-policy.md`](https://github.com/KKloudTarus/synapse-ce/blob/main/docs/redteam/offensive-policy.md).
+It is not published on this site because it is a repository artifact that CI verifies against the
+machine-readable register the code enforces — the two must change together, so the reviewed text lives
+next to the register rather than in the docs build.
+
+What it settles, and what the three controls above do not:
+
+- The categories Synapse **will not** execute at all: denial of service, destructive actions,
+  exfiltration beyond a bounded proof sample, unauthorised persistence, out-of-scope lateral movement
+  and third-party impact.
+- Per-technique risk classification, and which class needs automatic, single or **dual** human approval.
+- The rules-of-engagement fields an engagement must carry first. A missing field is a refusal.
+- The kill switch: `POST /api/v1/redteam/halt` cancels all in-flight offensive work, audited with the
+  operator and reason. Its stated bound covers the control plane; a technique already running on a host
+  stops within one further agent poll interval.
+
+**A technique with no register entry is refused.** The register is an allowlist.
+
 ## Reporting a vulnerability
 
 Please do not open a public issue for a security vulnerability. Use GitHub's private

--- a/docs/redteam/offensive-policy.md
+++ b/docs/redteam/offensive-policy.md
@@ -1,0 +1,152 @@
+# Offensive governance policy
+
+This document is the authority for what Synapse is permitted to execute against a customer estate. It exists before any exploitation engine (issue #418, epic #405, Phase 4) because the question an engineer faces on the first day of implementation is not *can we build this technique* but **is this technique allowed to run here, and who decided**.
+
+The differentiator this platform claims is not proof of exploitation — Horizon3 and Pentera already ship that. It is **proof under a defensible chain of custody**. A chain of custody that exists only as convention is not one, so this policy is an artifact that code enforces and CI verifies.
+
+## Status
+
+| Field | Value |
+|---|---|
+| Legal review status | **Not reviewed** |
+| Legal review date | — |
+| Review owner | Repository maintainer (`nghiadaulau`) until a named counsel is assigned |
+| Enforcement | `internal/domain/offensivepolicy` (register) + `internal/usecase/offensivepolicy` (enforcement, kill switch) |
+
+**Not reviewed is a real state, not a placeholder.** No technique in this register is marked production-safe while the review status is *Not reviewed*; `ProductionSafe` is refused for every entry until a named reviewer records a date here. That refusal is enforced by test, not by convention — see `TestRegisterRefusesProductionSafeBeforeLegalReview`.
+
+## 1. Scope and authority
+
+This policy governs every action the platform executes **against a target**, whether issued by an agent, a work order, the orchestrator, or an operator. It does not govern read-only analysis of artifacts the customer supplied (SBOMs, source snapshots, images), which is covered by the ordinary engagement scope.
+
+Three controls already exist and are **not replaced** by this policy: engagement scope, the authorization window, and human approval. This policy answers the question those three do not: *of the actions inside scope and inside the window, which are permitted at all, and under whose signature.*
+
+## 2. Prohibited categories
+
+These are refused by the enforcement path regardless of scope, window, approval, or operator seniority. A technique in a prohibited category cannot be made executable by configuration.
+
+1. **Denial of service.** Any action whose expected effect is degraded availability, including resource exhaustion, connection flooding, and lock or queue saturation. Load generation for capacity assessment is not covered by this platform.
+2. **Destructive actions.** Deletion, truncation, encryption, or corruption of customer data or configuration; disabling security controls; modifying audit or logging pipelines.
+3. **Exfiltration beyond a bounded proof sample.** Retrieving customer data at volume. A proof sample is bounded and redacted — see §6.
+4. **Unauthorised persistence.** Anything that survives on a customer host beyond the action, without a declared and tested cleanup path: implants, scheduled tasks, service installation, credential material left on disk, modified startup paths.
+5. **Lateral movement into out-of-scope estate.** Using in-scope access to reach an asset outside the engagement's declared scope, including pivoting through trusted network paths.
+6. **Third-party impact.** Actions against shared infrastructure the customer does not own, including SaaS tenants, upstream providers, and CDN or DNS infrastructure not named in scope.
+
+## 3. Risk classification
+
+Risk is classified on two independent axes, then reduced to a class. Both axes are stated per technique in the register.
+
+**Probability of service disruption**
+
+| Level | Meaning |
+|---|---|
+| none | The technique cannot affect availability of the target service |
+| low | Disruption requires an unusual target defect or configuration |
+| high | Disruption is a plausible outcome of normal execution |
+
+**Reversibility**
+
+| Level | Meaning |
+|---|---|
+| reversible | No target state changes, or changes are undone by a declared cleanup path that is tested |
+| irreversible | Target state changes that cannot be reliably undone by the platform |
+
+**Resulting class**
+
+| Class | Definition |
+|---|---|
+| `low` | Disruption `none` **and** `reversible` |
+| `medium` | Disruption `low` **and** `reversible` |
+| `high` | Disruption `high`, **or** `irreversible` |
+| `prohibited` | Falls into any §2 category |
+
+The reduction is deliberately pessimistic: a single high axis produces a high class. A technique that cannot state both axes is not classifiable and is therefore refused, which is the same outcome as having no register entry.
+
+## 4. Approval matrix
+
+| Risk class | Approval mode | Meaning |
+|---|---|---|
+| `low` | `automatic` | Executes inside scope and window with no per-action human decision. Still audited and still sealed as evidence. |
+| `medium` | `single` | One human with `PermOperate` records an approval for this technique, target, and window. |
+| `high` | `dual` | Two distinct humans record approvals. The second may not be the same identity as the first, and neither may be a machine principal. |
+| `prohibited` | — | No approval mode exists. Refused. |
+
+**Approval is recorded as evidence, not as configuration.** The approving human, the technique, the target, the authorization window and the timestamp are sealed into the hash-chained evidence for the action before it executes. A stored configuration flag that says "approved" is not an approval; if the seal fails, the action is not permitted.
+
+Machine principals (`agent:`, `llm:`, `mcp:`, `system:`, `machine:`, `bot:`, `service:`) can never satisfy an approval requirement. AI may propose an offensive plan; it may not approve one.
+
+## 5. Rules of engagement fields
+
+An engagement must carry all of the following before any offensive action is permitted. **A missing field is a refusal, not a default.**
+
+| Field | Why |
+|---|---|
+| Authorized scope | The targets in scope, already enforced by the execution guard |
+| Authorization window | Start and end; an action outside it is refused |
+| Named authorizing customer contact | The human on the customer side who authorized the assessment |
+| Emergency contact | Reachable during the window, for the case where the platform must be halted |
+| Permitted risk ceiling | The highest risk class this engagement permits, which may be lower than the register allows |
+| Excluded assets | Assets explicitly out of bounds even though they fall inside the scope expression |
+
+The risk ceiling is a **narrowing** control: it can only reduce what the register permits, never widen it. An engagement cannot authorize a prohibited technique.
+
+## 6. Data handling
+
+- A **proof sample** is the minimum evidence that demonstrates impact. It is bounded to **4 KiB per finding** and redacted before it is stored: credential material, personal data, and authentication tokens are removed at capture, not at report time.
+- Proof samples inherit the engagement's evidence retention. They are hash-chained like all other evidence and are never mutable.
+- Retrieved data that is not a proof sample is not retained. There is no debug path that stores more.
+- Secrets obtained during exploitation are recorded as **existence and location**, never as value.
+
+## 7. Blast radius and cleanup
+
+Every technique declares a blast radius:
+
+| Radius | Meaning | Cleanup |
+|---|---|---|
+| `read_only` | Observes; no target state changes | Not applicable |
+| `state_changing` | Changes target state | **Required**: a declared, ordered cleanup path with a verification step |
+
+**A `state_changing` technique with no cleanup path fails CI, not runtime.** `TestRegisterRejectsStateChangingWithoutCleanup` walks the whole register and fails the build if any entry declares `state_changing` without a cleanup specification containing at least one step and a verification. This is deliberately a build-time gate: discovering an unreversible action at runtime means it has already run.
+
+## 8. Kill switch contract
+
+A single operator action halts all in-flight offensive work across the fleet.
+
+- **Interface**: `POST /api/v1/redteam/halt` with `PermAdminister`, carrying a reason.
+- **Effect**: every offensive work order for the tenant in `issued`, `claimed`, or `running` is transitioned to `cancelled`.
+- **Audit**: the halt is audited with the operator identity and the reason before it is reported as complete. A halt that cannot be audited is still executed — stopping work matters more than recording it — but the response reports the audit failure rather than claiming a clean halt.
+- **Bound**: **the control plane stops issuing and cancels every in-flight order within 5 seconds** of the request, measured under concurrent load by `TestHaltCancelsInFlightWithinBound`.
+
+**What the bound does and does not cover, stated precisely because the difference matters during an incident.** The 5-second bound is the *control plane's* halt: after it, no further offensive work order can be claimed and every in-flight order is marked cancelled. An agent already executing a technique on a host learns of the cancellation on its next poll, so the estate-wide stop is bounded by the control-plane halt **plus one agent poll interval** (`SYNAPSE_FLEET_POLL`, default 60s). Any statement that the estate stops within 5 seconds would be false. The documented state after a halt is therefore: *no new offensive work is issued or claimable; in-flight orders are cancelled at the control plane; techniques already running on a host complete or abort within one poll interval, and their cleanup paths still run.*
+
+## 9. Dry run
+
+Dry run is part of this policy, not a debug flag. For any offensive plan the platform enumerates exactly what it would execute against what — technique, target, risk class, approval requirement, blast radius, cleanup path — and executes nothing.
+
+`TestPlanExecutesNothing` asserts zero executions by injecting an executor that fails the test if it is called at all. Dry run is the default for a plan that has not yet been approved.
+
+## 10. Technique register
+
+This table is the **source of truth**. `internal/domain/offensivepolicy/policy.yaml` mirrors it, and `TestRegisterMatchesPolicyDocument` fails the build if the two diverge in either direction — an entry in one and not the other, or any field differing. Neither file may be edited alone.
+
+A technique absent from this table is **refused**. That is the fail-closed default and the reason the table is deliberately short: entries are added when a technique is implemented and classified, not in advance.
+
+| Technique | Taxonomy | Disruption | Reversibility | Risk | Approval | Radius | Cleanup | Production safe |
+|---|---|---|---|---|---|---|---|---|
+| `recon.service_banner` | T1595.002 | none | reversible | low | automatic | read_only | — | no |
+| `recon.tls_inspect` | T1596 | none | reversible | low | automatic | read_only | — | no |
+| `exploit.default_credentials` | T1078.001 | low | reversible | medium | single | read_only | — | no |
+| `exploit.known_cve_readonly` | T1190 | low | reversible | medium | single | read_only | — | no |
+| `exploit.web_shell_upload` | T1505.003 | low | irreversible | high | dual | state_changing | delete uploaded artifact; verify absence | no |
+| `persist.scheduled_task` | T1053 | low | irreversible | prohibited | — | state_changing | — | no |
+| `impact.service_stop` | T1489 | high | irreversible | prohibited | — | state_changing | — | no |
+| `exfil.bulk_data` | T1041 | none | reversible | prohibited | — | read_only | — | no |
+
+The three prohibited entries are listed **on purpose**. Omitting them would make them merely unknown, and the enforcement path would refuse them with "no register entry" — indistinguishable from a technique nobody has classified yet. Naming them records that they were considered and excluded, which is what a governance artifact is for.
+
+## 11. Change control
+
+- The register and this document change together in one commit. CI enforces it.
+- Adding a technique requires its two risk axes, its blast radius, and a cleanup path when state-changing.
+- Raising a technique's risk class needs no review. Lowering one requires the legal review owner named in §Status.
+- Marking any technique `ProductionSafe` requires a recorded legal review date.

--- a/internal/adapter/httpapi/redteam_halt_handler.go
+++ b/internal/adapter/httpapi/redteam_halt_handler.go
@@ -1,0 +1,93 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	offensiveuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+)
+
+// offensiveKillSwitch is the narrow consumer-side interface this handler needs.
+type offensiveKillSwitch interface {
+	Halt(ctx context.Context, tenantID shared.ID, actor, reason string) (offensiveuc.HaltResult, error)
+}
+
+// SetOffensiveKillSwitch wires the red-team halt route (#418). Left unset, the route is not registered:
+// an endpoint that accepts a halt and does nothing would be the worst possible failure for this control.
+func (rt *Router) SetOffensiveKillSwitch(ks offensiveKillSwitch) {
+	if ks != nil {
+		rt.offensiveHalt = ks
+	}
+}
+
+type haltRequest struct {
+	Reason string `json:"reason"`
+}
+
+type haltResponse struct {
+	RequestedAt    time.Time         `json:"requested_at"`
+	CompletedAt    time.Time         `json:"completed_at"`
+	DurationMS     int64             `json:"duration_ms"`
+	StatedBoundMS  int64             `json:"stated_bound_ms"`
+	WithinBound    bool              `json:"within_bound"`
+	Halted         bool              `json:"halted"`
+	Cancelled      []string          `json:"cancelled"`
+	Failed         map[string]string `json:"failed,omitempty"`
+	AuditRecorded  bool              `json:"audit_recorded"`
+	EstateStopNote string            `json:"estate_stop_note"`
+}
+
+// haltOffensiveWork is the kill switch: one operator action that halts all in-flight offensive work.
+//
+// It reports the MEASURED duration against the stated bound rather than asserting compliance, and it
+// reports partial failure as a failure. An operator who reads "halted" must be able to trust it.
+func (rt *Router) haltOffensiveWork(w http.ResponseWriter, r *http.Request) {
+	var req haltRequest
+	// A halt is urgent, so an empty body is tolerated as far as decoding goes — but the reason is still
+	// required below, because a halt nobody can explain afterwards defeats the chain of custody.
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+	result, err := rt.offensiveHalt.Halt(r.Context(), requestTenant(r), PrincipalFrom(r.Context()), req.Reason)
+	body := haltResponse{
+		RequestedAt: result.RequestedAt, CompletedAt: result.CompletedAt,
+		DurationMS: result.Duration.Milliseconds(), StatedBoundMS: offensiveuc.HaltBound.Milliseconds(),
+		WithinBound: result.WithinBound, Halted: err == nil && result.Halted(),
+		Cancelled: idStrings(result.Cancelled), Failed: failureStrings(result.Failed),
+		AuditRecorded: !result.AuditFailed, EstateStopNote: result.EstateStopNote,
+	}
+	switch {
+	case err == nil:
+		writeJSON(w, http.StatusOK, body)
+	case errors.Is(err, shared.ErrValidation):
+		writeError(w, rt.log, err)
+	default:
+		// A halt that did not fully succeed answers 500 with the partial result attached, so the operator
+		// sees exactly which orders are still in flight instead of a bare error.
+		rt.log.Error("offensive halt did not fully succeed", "err", err)
+		writeJSON(w, http.StatusInternalServerError, body)
+	}
+}
+
+func idStrings(ids []shared.ID) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, id.String())
+	}
+	return out
+}
+
+func failureStrings(failed map[shared.ID]string) map[string]string {
+	if len(failed) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(failed))
+	for id, reason := range failed {
+		out[id.String()] = reason
+	}
+	return out
+}

--- a/internal/adapter/httpapi/redteam_halt_handler_test.go
+++ b/internal/adapter/httpapi/redteam_halt_handler_test.go
@@ -1,0 +1,167 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
+	offensiveuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+)
+
+type fakeHalt struct {
+	called int
+	tenant shared.ID
+	actor  string
+	reason string
+	result offensiveuc.HaltResult
+	err    error
+}
+
+func (f *fakeHalt) Halt(_ context.Context, tenantID shared.ID, actor, reason string) (offensiveuc.HaltResult, error) {
+	f.called++
+	f.tenant, f.actor, f.reason = tenantID, actor, reason
+	return f.result, f.err
+}
+
+func haltRequestFor(t *testing.T, rt *Router, id, role, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/redteam/halt", strings.NewReader(body))
+	req = withPrincipal(req, id, role)
+	w := httptest.NewRecorder()
+	rt.authz(userdom.PermAdminister, rt.haltOffensiveWork)(w, req)
+	return w
+}
+
+// TestHaltRequiresAdminister: the person who can run offensive work should not be the only one who can
+// stop it, so the halt is PermAdminister rather than PermOperate.
+func TestHaltRequiresAdminister(t *testing.T) {
+	for role, wantStatus := range map[string]int{
+		"admin":      http.StatusOK,
+		"consultant": http.StatusForbidden,
+		"reviewer":   http.StatusForbidden,
+		"readonly":   http.StatusForbidden,
+		// A machine principal must never be able to pull the switch either, even though halting is a
+		// "safe" direction: an agent that can stop the fleet can also stop an authorised assessment.
+		"agent": http.StatusForbidden,
+	} {
+		t.Run(role, func(t *testing.T) {
+			h := &fakeHalt{result: offensiveuc.HaltResult{
+				RequestedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(), WithinBound: true,
+				EstateStopNote: "control plane halted",
+			}}
+			rt := &Router{log: logging.New("error")}
+			rt.SetOffensiveKillSwitch(h)
+			w := haltRequestFor(t, rt, "operator", role, `{"reason":"customer asked"}`)
+			if w.Code != wantStatus {
+				t.Fatalf("role %s got %d, want %d: %s", role, w.Code, wantStatus, w.Body.String())
+			}
+			if wantStatus != http.StatusOK && h.called != 0 {
+				t.Errorf("role %s reached the kill switch despite lacking the permission", role)
+			}
+		})
+	}
+}
+
+// TestHaltReportsTheMeasuredDurationAndTheEstateCaveat: the response carries the measured duration, the
+// bound it was measured against, and the note that the bound does not cover the estate. An operator
+// reading only "halted: true" must not conclude that every host has stopped.
+func TestHaltReportsTheMeasuredDurationAndTheEstateCaveat(t *testing.T) {
+	start := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	h := &fakeHalt{result: offensiveuc.HaltResult{
+		RequestedAt: start, CompletedAt: start.Add(120 * time.Millisecond),
+		Duration: 120 * time.Millisecond, WithinBound: true,
+		Cancelled:      []shared.ID{"wo-1", "wo-2"},
+		EstateStopNote: "control plane halted within 5s; a technique already running on a host stops within one further agent poll interval",
+	}}
+	rt := &Router{log: logging.New("error")}
+	rt.SetOffensiveKillSwitch(h)
+
+	w := haltRequestFor(t, rt, "operator", "admin", `{"reason":"stop"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	var body haltResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if !body.Halted || body.DurationMS != 120 {
+		t.Errorf("body = %+v", body)
+	}
+	if body.StatedBoundMS != offensiveuc.HaltBound.Milliseconds() {
+		t.Errorf("stated bound = %d, want %d", body.StatedBoundMS, offensiveuc.HaltBound.Milliseconds())
+	}
+	if len(body.Cancelled) != 2 {
+		t.Errorf("cancelled = %v", body.Cancelled)
+	}
+	if !strings.Contains(body.EstateStopNote, "agent poll interval") {
+		t.Errorf("the response does not carry the estate-stop caveat: %q", body.EstateStopNote)
+	}
+	if h.reason != "stop" {
+		t.Errorf("the reason was not passed to the kill switch, got %q", h.reason)
+	}
+	if h.actor != "operator" {
+		t.Errorf("the operator identity was not passed to the kill switch, got %q", h.actor)
+	}
+}
+
+// TestHaltAnswersFiveHundredWithThePartialResult: a halt that did not fully succeed must not answer 200.
+// The operator needs to see which orders are still in flight, so the partial result rides along with the
+// error status rather than being replaced by a bare message.
+func TestHaltAnswersFiveHundredWithThePartialResult(t *testing.T) {
+	h := &fakeHalt{
+		result: offensiveuc.HaltResult{
+			RequestedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(),
+			Cancelled: []shared.ID{"wo-1"}, Failed: map[shared.ID]string{"wo-2": "database unreachable"},
+			EstateStopNote: "control plane halted",
+		},
+		err: errors.New("halt failed for 1 work order(s)"),
+	}
+	rt := &Router{log: logging.New("error")}
+	rt.SetOffensiveKillSwitch(h)
+
+	w := haltRequestFor(t, rt, "operator", "admin", `{"reason":"stop"}`)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("a partial halt must not answer %d", w.Code)
+	}
+	var body haltResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Halted {
+		t.Error("the response claims a clean halt while an order failed")
+	}
+	if body.Failed["wo-2"] == "" {
+		t.Errorf("the response does not name the order still in flight: %+v", body)
+	}
+}
+
+// TestHaltRejectsAMissingReason: the kill switch refuses a reasonless halt, and the adapter surfaces
+// that as a 400 rather than a 500 — it is the operator's input that is wrong.
+func TestHaltRejectsAMissingReason(t *testing.T) {
+	h := &fakeHalt{err: shared.ErrValidation}
+	rt := &Router{log: logging.New("error")}
+	rt.SetOffensiveKillSwitch(h)
+
+	w := haltRequestFor(t, rt, "operator", "admin", `{}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("a reasonless halt must answer 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHaltRouteAbsentWithoutAKillSwitch: an endpoint that accepts a halt and does nothing is the worst
+// possible failure for this control, so the route is not registered when unwired.
+func TestHaltRouteAbsentWithoutAKillSwitch(t *testing.T) {
+	rt := &Router{log: logging.New("error")}
+	rt.SetOffensiveKillSwitch(nil)
+	if rt.offensiveHalt != nil {
+		t.Fatal("a nil kill switch must leave the route unwired rather than installing a no-op")
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -69,6 +69,7 @@ type Router struct {
 	sarif             sarifIngester         // optional; nil ⇒ the third-party SARIF import route is not registered
 	importedFindings  sarifReader           // optional read side for imported findings
 	fleetRolloutAdmin fleetRolloutService   // optional; nil ⇒ the operator rollout routes are not served
+	offensiveHalt     offensiveKillSwitch   // optional; nil ⇒ the red-team halt route is not served
 	fleet             *fleetRouter          // optional; nil ⇒ agent transport plane is not served
 	fleetAdmin        fleetAdminService     // optional; nil ⇒ operator agent-admin routes not registered
 	qualityGates      qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
@@ -340,6 +341,12 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/agents/rollout/promote", rt.authz(userdom.PermAdminister, rt.promoteFleetRollout))
 		mux.HandleFunc("POST /api/v1/agents/rollout/pause", rt.authz(userdom.PermAdminister, rt.pauseFleetRollout))
 		mux.HandleFunc("POST /api/v1/agents/rollout/resume", rt.authz(userdom.PermAdminister, rt.resumeFleetRollout))
+	}
+	if rt.offensiveHalt != nil {
+		// The kill switch (#418, document 8). PermAdminister, not PermOperate: halting the whole fleet's
+		// offensive work is an administrative act, and the same person who can run offensive work should
+		// not be the only one who can stop it.
+		mux.HandleFunc("POST /api/v1/redteam/halt", rt.authz(userdom.PermAdminister, rt.haltOffensiveWork))
 	}
 	mux.HandleFunc("GET /api/v1/engagements", rt.authz(userdom.PermView, rt.listEngagements))
 	mux.HandleFunc("GET /api/v1/engagements/{id}", rt.authz(userdom.PermView, rt.getEngagement))

--- a/internal/domain/offensivepolicy/policy.go
+++ b/internal/domain/offensivepolicy/policy.go
@@ -1,0 +1,356 @@
+// Package offensivepolicy is the machine-readable half of the offensive governance policy
+// (docs/redteam/offensive-policy.md, issue #418).
+//
+// It answers one question and answers it fail-closed: may this technique run at all, and under whose
+// signature. A technique absent from the register is REFUSED — the register is an allowlist, not a
+// denylist, because the set of things an offensive engine could attempt is unbounded while the set it
+// has been authorised to attempt is not.
+//
+// The document is the source of truth. This package embeds policy.yaml, which mirrors the document's
+// technique register, and policy_gen_test.go fails the build when the two diverge in either direction.
+// Neither file may be edited alone.
+//
+// Pure domain: no I/O, no clock, no policy decision that depends on anything outside its inputs.
+package offensivepolicy
+
+import (
+	_ "embed"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+//go:embed policy.yaml
+var embeddedPolicy []byte
+
+// Disruption is the probability that executing a technique degrades availability of the target.
+type Disruption string
+
+const (
+	DisruptionNone Disruption = "none"
+	DisruptionLow  Disruption = "low"
+	DisruptionHigh Disruption = "high"
+)
+
+// Valid reports whether d is one of the three defined levels. An unset or unknown level is not
+// classifiable, and an unclassifiable technique is refused.
+func (d Disruption) Valid() bool {
+	switch d {
+	case DisruptionNone, DisruptionLow, DisruptionHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// Reversibility is whether target state changes can be undone by a declared, tested cleanup path.
+type Reversibility string
+
+const (
+	Reversible   Reversibility = "reversible"
+	Irreversible Reversibility = "irreversible"
+)
+
+// Valid reports whether r is one of the two defined levels.
+func (r Reversibility) Valid() bool { return r == Reversible || r == Irreversible }
+
+// RiskClass is the reduction of the two axes, per the document's §3 table.
+type RiskClass string
+
+const (
+	RiskLow        RiskClass = "low"
+	RiskMedium     RiskClass = "medium"
+	RiskHigh       RiskClass = "high"
+	RiskProhibited RiskClass = "prohibited"
+)
+
+// Valid reports whether c is one of the four defined classes.
+func (c RiskClass) Valid() bool {
+	switch c {
+	case RiskLow, RiskMedium, RiskHigh, RiskProhibited:
+		return true
+	default:
+		return false
+	}
+}
+
+// ApprovalMode is who must sign for a technique before it may execute.
+type ApprovalMode string
+
+const (
+	// ApprovalNone is the absence of an approval mode, which only a prohibited technique carries. It is
+	// deliberately NOT a synonym for "no approval needed" — that is ApprovalAutomatic.
+	ApprovalNone      ApprovalMode = ""
+	ApprovalAutomatic ApprovalMode = "automatic"
+	ApprovalSingle    ApprovalMode = "single"
+	ApprovalDual      ApprovalMode = "dual"
+)
+
+// RequiredApprovals is how many DISTINCT human approvals the mode demands.
+func (m ApprovalMode) RequiredApprovals() int {
+	switch m {
+	case ApprovalSingle:
+		return 1
+	case ApprovalDual:
+		return 2
+	default:
+		return 0
+	}
+}
+
+// Radius is the blast radius of a technique.
+type Radius string
+
+const (
+	RadiusReadOnly      Radius = "read_only"
+	RadiusStateChanging Radius = "state_changing"
+)
+
+// Valid reports whether r is one of the two defined radii.
+func (r Radius) Valid() bool { return r == RadiusReadOnly || r == RadiusStateChanging }
+
+// CleanupSpec is the ordered path that undoes a state-changing technique, plus how the undo is
+// confirmed. A state-changing technique without both is not implementable (document §7) and fails the
+// register's validation, which runs in CI rather than at execution time.
+type CleanupSpec struct {
+	Steps        []string `yaml:"steps"`
+	Verification string   `yaml:"verification"`
+}
+
+// IsZero reports whether no cleanup path was declared at all.
+func (c CleanupSpec) IsZero() bool {
+	return len(c.Steps) == 0 && strings.TrimSpace(c.Verification) == ""
+}
+
+// TechniquePolicy is one register entry: everything the enforcement path needs to decide whether this
+// technique may run, and everything an auditor needs to see why.
+type TechniquePolicy struct {
+	Technique      string        `yaml:"technique"`
+	TaxonomyRef    string        `yaml:"taxonomy_ref"`
+	Disruption     Disruption    `yaml:"disruption"`
+	Reversibility  Reversibility `yaml:"reversibility"`
+	RiskClass      RiskClass     `yaml:"risk_class"`
+	Approval       ApprovalMode  `yaml:"approval"`
+	BlastRadius    Radius        `yaml:"blast_radius"`
+	Cleanup        CleanupSpec   `yaml:"cleanup"`
+	ProductionSafe bool          `yaml:"production_safe"`
+}
+
+// LegalReview records the document's review status. ProductionSafe is refused for every technique while
+// Reviewed is false, so a register cannot quietly claim production readiness ahead of the review.
+type LegalReview struct {
+	Reviewed bool   `yaml:"reviewed"`
+	Date     string `yaml:"date"`
+	Owner    string `yaml:"owner"`
+}
+
+// Register is the whole policy: the review status plus every classified technique.
+type Register struct {
+	LegalReview LegalReview       `yaml:"legal_review"`
+	Techniques  []TechniquePolicy `yaml:"techniques"`
+
+	byTechnique map[string]TechniquePolicy
+}
+
+// Load parses and validates the embedded register. It is the only constructor: there is no way to build
+// a Register that has not been validated, because an unvalidated policy is worse than no policy — it
+// looks authoritative while permitting whatever it happens to contain.
+func Load() (*Register, error) { return parse(embeddedPolicy) }
+
+func parse(raw []byte) (*Register, error) {
+	var reg Register
+	dec := yaml.NewDecoder(strings.NewReader(string(raw)))
+	dec.KnownFields(true) // a typo'd field would otherwise be silently ignored, and silence is the enemy here
+	if err := dec.Decode(&reg); err != nil {
+		return nil, fmt.Errorf("%w: decode offensive policy: %v", shared.ErrValidation, err)
+	}
+	if err := reg.Validate(); err != nil {
+		return nil, err
+	}
+	reg.byTechnique = make(map[string]TechniquePolicy, len(reg.Techniques))
+	for _, t := range reg.Techniques {
+		reg.byTechnique[t.Technique] = t
+	}
+	return &reg, nil
+}
+
+// Validate enforces every invariant the document states. It runs at load time and in CI, so a malformed
+// register fails the build rather than the engagement.
+func (r *Register) Validate() error {
+	if len(r.Techniques) == 0 {
+		return fmt.Errorf("%w: offensive policy register is empty", shared.ErrValidation)
+	}
+	seen := make(map[string]struct{}, len(r.Techniques))
+	for _, t := range r.Techniques {
+		name := strings.TrimSpace(t.Technique)
+		if name == "" {
+			return fmt.Errorf("%w: register entry has no technique id", shared.ErrValidation)
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("%w: duplicate register entry %q", shared.ErrValidation, name)
+		}
+		seen[name] = struct{}{}
+		if strings.TrimSpace(t.TaxonomyRef) == "" {
+			return fmt.Errorf("%w: %s has no taxonomy reference", shared.ErrValidation, name)
+		}
+		if !t.Disruption.Valid() || !t.Reversibility.Valid() {
+			return fmt.Errorf("%w: %s does not state both risk axes", shared.ErrValidation, name)
+		}
+		if !t.RiskClass.Valid() {
+			return fmt.Errorf("%w: %s has an unknown risk class %q", shared.ErrValidation, name, t.RiskClass)
+		}
+		if !t.BlastRadius.Valid() {
+			return fmt.Errorf("%w: %s has an unknown blast radius %q", shared.ErrValidation, name, t.BlastRadius)
+		}
+		// The reduction in document §3 is pessimistic and mechanical, so the register cannot disagree
+		// with it: a hand-written class that is softer than the axes imply is the exact drift this
+		// check exists to stop.
+		if t.RiskClass != RiskProhibited {
+			if want := reduce(t.Disruption, t.Reversibility); want != t.RiskClass {
+				return fmt.Errorf("%w: %s is classed %q but its axes reduce to %q", shared.ErrValidation, name, t.RiskClass, want)
+			}
+		}
+		if err := t.validateApproval(name); err != nil {
+			return err
+		}
+		if err := t.validateCleanup(name); err != nil {
+			return err
+		}
+		if t.ProductionSafe && !r.LegalReview.Reviewed {
+			return fmt.Errorf("%w: %s is marked production-safe before the legal review is recorded", shared.ErrValidation, name)
+		}
+	}
+	if r.LegalReview.Reviewed && (strings.TrimSpace(r.LegalReview.Date) == "" || strings.TrimSpace(r.LegalReview.Owner) == "") {
+		return fmt.Errorf("%w: a recorded legal review needs both a date and an owner", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (t TechniquePolicy) validateApproval(name string) error {
+	if t.RiskClass == RiskProhibited {
+		// A prohibited technique has no approval mode at all. Allowing one would imply that some
+		// signature could authorise it, and none can.
+		if t.Approval != ApprovalNone {
+			return fmt.Errorf("%w: prohibited technique %s must not carry an approval mode", shared.ErrValidation, name)
+		}
+		return nil
+	}
+	want, ok := requiredApproval(t.RiskClass)
+	if !ok {
+		return fmt.Errorf("%w: %s has no approval mode for risk class %q", shared.ErrValidation, name, t.RiskClass)
+	}
+	if t.Approval != want {
+		return fmt.Errorf("%w: %s is class %q so its approval must be %q, got %q", shared.ErrValidation, name, t.RiskClass, want, t.Approval)
+	}
+	return nil
+}
+
+func (t TechniquePolicy) validateCleanup(name string) error {
+	if t.BlastRadius != RadiusStateChanging {
+		if !t.Cleanup.IsZero() {
+			return fmt.Errorf("%w: read-only technique %s declares a cleanup path", shared.ErrValidation, name)
+		}
+		return nil
+	}
+	// Document §7: a state-changing technique that cannot state its cleanup path is not implementable.
+	// Prohibited entries are exempt because they never execute, and demanding a cleanup path for an
+	// action we refuse to perform would be theatre.
+	if t.RiskClass == RiskProhibited {
+		return nil
+	}
+	if len(t.Cleanup.Steps) == 0 {
+		return fmt.Errorf("%w: state-changing technique %s declares no cleanup steps", shared.ErrValidation, name)
+	}
+	if strings.TrimSpace(t.Cleanup.Verification) == "" {
+		return fmt.Errorf("%w: state-changing technique %s declares no cleanup verification", shared.ErrValidation, name)
+	}
+	return nil
+}
+
+// reduce applies the document §3 reduction. It is deliberately pessimistic: one high axis produces a
+// high class.
+func reduce(d Disruption, r Reversibility) RiskClass {
+	if r == Irreversible || d == DisruptionHigh {
+		return RiskHigh
+	}
+	if d == DisruptionLow {
+		return RiskMedium
+	}
+	return RiskLow
+}
+
+// requiredApproval is the document §4 matrix.
+func requiredApproval(c RiskClass) (ApprovalMode, bool) {
+	switch c {
+	case RiskLow:
+		return ApprovalAutomatic, true
+	case RiskMedium:
+		return ApprovalSingle, true
+	case RiskHigh:
+		return ApprovalDual, true
+	default:
+		return ApprovalNone, false
+	}
+}
+
+// Lookup returns the policy for a technique. The second result is false when the technique is not in
+// the register, which callers MUST treat as a refusal rather than as an absence of restriction.
+func (r *Register) Lookup(technique string) (TechniquePolicy, bool) {
+	if r == nil {
+		return TechniquePolicy{}, false
+	}
+	t, ok := r.byTechnique[strings.TrimSpace(technique)]
+	return t, ok
+}
+
+// Techniques returns every entry in a deterministic order, for enumeration and dry-run listing.
+func (r *Register) TechniqueIDs() []string {
+	if r == nil {
+		return nil
+	}
+	out := make([]string, 0, len(r.byTechnique))
+	for name := range r.byTechnique {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// RiskCeilingPermits reports whether an engagement whose ceiling is ceiling may run class have.
+//
+// The ceiling only ever NARROWS what the register permits (document §5): it cannot widen it, and it can
+// never permit a prohibited technique whatever it is set to.
+func RiskCeilingPermits(ceiling, have RiskClass) bool {
+	// An unset or unknown ceiling permits NOTHING. Ranking it above the classes instead would make a
+	// missing engagement field the most permissive setting available, which is the fail-open this whole
+	// package exists to avoid. "prohibited" is not a permission level either: it is a refusal, so it
+	// cannot appear on either side.
+	ceilingRank, ok := permissionRank(ceiling)
+	if !ok {
+		return false
+	}
+	haveRank, ok := permissionRank(have)
+	if !ok {
+		return false
+	}
+	return haveRank <= ceilingRank
+}
+
+// permissionRank orders the three executable classes. The second result is false for anything that is
+// not an executable class — unset, unknown, or prohibited.
+func permissionRank(c RiskClass) (int, bool) {
+	switch c {
+	case RiskLow:
+		return 1, true
+	case RiskMedium:
+		return 2, true
+	case RiskHigh:
+		return 3, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/domain/offensivepolicy/policy.yaml
+++ b/internal/domain/offensivepolicy/policy.yaml
@@ -1,0 +1,113 @@
+# Machine-readable half of docs/redteam/offensive-policy.md (issue #418).
+#
+# The DOCUMENT is the source of truth. This file mirrors its §10 technique register, and
+# policy_gen_test.go fails the build when the two diverge in either direction. Never edit one alone.
+#
+# A technique absent from this register is REFUSED by the enforcement path. That is the fail-closed
+# default, and the reason this list is short: entries are added when a technique is classified, not in
+# advance.
+legal_review:
+  reviewed: false
+  date: ""
+  owner: "Repository maintainer (nghiadaulau) until a named counsel is assigned"
+
+techniques:
+  - technique: recon.service_banner
+    taxonomy_ref: T1595.002
+    disruption: none
+    reversibility: reversible
+    risk_class: low
+    approval: automatic
+    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  - technique: recon.tls_inspect
+    taxonomy_ref: T1596
+    disruption: none
+    reversibility: reversible
+    risk_class: low
+    approval: automatic
+    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  - technique: exploit.default_credentials
+    taxonomy_ref: T1078.001
+    disruption: low
+    reversibility: reversible
+    risk_class: medium
+    approval: single
+    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  - technique: exploit.known_cve_readonly
+    taxonomy_ref: T1190
+    disruption: low
+    reversibility: reversible
+    risk_class: medium
+    approval: single
+    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  - technique: exploit.web_shell_upload
+    taxonomy_ref: T1505.003
+    disruption: low
+    reversibility: irreversible
+    risk_class: high
+    approval: dual
+    blast_radius: state_changing
+    cleanup:
+      steps:
+        - delete uploaded artifact
+      verification: verify absence
+    production_safe: false
+
+  # The three prohibited entries below are listed ON PURPOSE. Omitting them would make them merely
+  # unknown, and the enforcement path would refuse them as "no register entry" -- indistinguishable from
+  # a technique nobody has classified yet. Naming them records that they were considered and excluded.
+  - technique: persist.scheduled_task
+    taxonomy_ref: T1053
+    disruption: low
+    reversibility: irreversible
+    risk_class: prohibited
+    approval: ""
+    blast_radius: state_changing
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  - technique: impact.service_stop
+    taxonomy_ref: T1489
+    disruption: high
+    reversibility: irreversible
+    risk_class: prohibited
+    approval: ""
+    blast_radius: state_changing
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  - technique: exfil.bulk_data
+    taxonomy_ref: T1041
+    disruption: none
+    reversibility: reversible
+    risk_class: prohibited
+    approval: ""
+    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false

--- a/internal/domain/offensivepolicy/policy_gen_test.go
+++ b/internal/domain/offensivepolicy/policy_gen_test.go
@@ -1,0 +1,219 @@
+package offensivepolicy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const policyDocPath = "../../../docs/redteam/offensive-policy.md"
+
+// docEntry is one row of the document's §10 register table, reduced to the fields the table carries.
+// The YAML carries the same fields plus the cleanup structure, which the table renders as prose.
+type docEntry struct {
+	Technique      string
+	TaxonomyRef    string
+	Disruption     string
+	Reversibility  string
+	RiskClass      string
+	Approval       string
+	Radius         string
+	Cleanup        string
+	ProductionSafe string
+}
+
+// TestRegisterMatchesPolicyDocument is the drift test required by issue #418.
+//
+// The document is the source of truth and policy.yaml mirrors it. Two artifacts that must agree will
+// eventually disagree unless something fails the build when they do — a governance policy whose
+// machine-readable half has quietly drifted from the reviewed text is worse than having only the text,
+// because the code enforces the copy nobody reviewed.
+//
+// It compares in BOTH directions: an entry in the document but not the register, an entry in the
+// register but not the document, and any field differing between them.
+func TestRegisterMatchesPolicyDocument(t *testing.T) {
+	doc := parseDocRegister(t)
+	reg, err := Load()
+	if err != nil {
+		t.Fatalf("load embedded register: %v", err)
+	}
+
+	if len(doc) == 0 {
+		t.Fatal("parsed no rows from the document register table; the drift test would pass vacuously")
+	}
+
+	docNames := make([]string, 0, len(doc))
+	for name := range doc {
+		docNames = append(docNames, name)
+	}
+	sort.Strings(docNames)
+
+	if got := reg.TechniqueIDs(); !reflect.DeepEqual(got, docNames) {
+		t.Fatalf("register and document disagree on which techniques exist:\n  register: %v\n  document: %v", got, docNames)
+	}
+
+	for _, name := range docNames {
+		row := doc[name]
+		entry, ok := reg.Lookup(name)
+		if !ok {
+			t.Errorf("%s is in the document but not the register", name)
+			continue
+		}
+		if entry.TaxonomyRef != row.TaxonomyRef {
+			t.Errorf("%s taxonomy: register %q, document %q", name, entry.TaxonomyRef, row.TaxonomyRef)
+		}
+		if string(entry.Disruption) != row.Disruption {
+			t.Errorf("%s disruption: register %q, document %q", name, entry.Disruption, row.Disruption)
+		}
+		if string(entry.Reversibility) != row.Reversibility {
+			t.Errorf("%s reversibility: register %q, document %q", name, entry.Reversibility, row.Reversibility)
+		}
+		if string(entry.RiskClass) != row.RiskClass {
+			t.Errorf("%s risk class: register %q, document %q", name, entry.RiskClass, row.RiskClass)
+		}
+		if want := docApproval(row.Approval); string(entry.Approval) != want {
+			t.Errorf("%s approval: register %q, document %q", name, entry.Approval, want)
+		}
+		if string(entry.BlastRadius) != row.Radius {
+			t.Errorf("%s blast radius: register %q, document %q", name, entry.BlastRadius, row.Radius)
+		}
+		if got, want := cleanupProse(entry.Cleanup), row.Cleanup; got != want {
+			t.Errorf("%s cleanup: register %q, document %q", name, got, want)
+		}
+		if got, want := yesNo(entry.ProductionSafe), row.ProductionSafe; got != want {
+			t.Errorf("%s production safe: register %q, document %q", name, got, want)
+		}
+	}
+}
+
+// TestLegalReviewStatusMatchesDocument keeps the review status from drifting too. The register refuses
+// ProductionSafe while the review is unrecorded, so a register that claimed "reviewed" while the
+// document said otherwise would unlock production readiness that nobody signed.
+func TestLegalReviewStatusMatchesDocument(t *testing.T) {
+	raw := readDoc(t)
+	reg, err := Load()
+	if err != nil {
+		t.Fatalf("load embedded register: %v", err)
+	}
+	docReviewed := !strings.Contains(raw, "| Legal review status | **Not reviewed** |")
+	if docReviewed != reg.LegalReview.Reviewed {
+		t.Fatalf("legal review status: register reviewed=%v, document reviewed=%v", reg.LegalReview.Reviewed, docReviewed)
+	}
+}
+
+// TestDocumentNamesEveryProhibitedCategory pins the acceptance criterion that the excluded categories
+// are named EXPLICITLY. A governance document that gestures at "destructive actions" without naming
+// denial of service, exfiltration and unauthorised persistence leaves the engineer to guess.
+func TestDocumentNamesEveryProhibitedCategory(t *testing.T) {
+	raw := strings.ToLower(readDoc(t))
+	for _, phrase := range []string{
+		"denial of service",
+		"destructive actions",
+		"exfiltration beyond a bounded proof sample",
+		"unauthorised persistence",
+		"lateral movement into out-of-scope estate",
+		"third-party impact",
+	} {
+		if !strings.Contains(raw, phrase) {
+			t.Errorf("the policy document does not name the prohibited category %q", phrase)
+		}
+	}
+}
+
+// TestDocumentStatesTheKillSwitchBoundAndItsLimit checks that the halt bound is stated AND that the
+// document is honest about what it does not cover. A bound of "5 seconds" that reads as estate-wide
+// would be false: an agent mid-technique learns of the cancellation on its next poll.
+func TestDocumentStatesTheKillSwitchBoundAndItsLimit(t *testing.T) {
+	raw := readDoc(t)
+	if !strings.Contains(raw, "within 5 seconds") {
+		t.Error("the document does not state the kill-switch bound")
+	}
+	if !strings.Contains(raw, "plus one agent poll interval") {
+		t.Error("the document states a bound without stating that the estate-wide stop also costs one agent poll interval")
+	}
+}
+
+func readDoc(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Clean(policyDocPath))
+	if err != nil {
+		t.Fatalf("read policy document: %v", err)
+	}
+	return string(raw)
+}
+
+// parseDocRegister extracts the §10 table. It keys on the header row rather than a line number so
+// editing prose above the table cannot silently break the drift test into passing vacuously.
+func parseDocRegister(t *testing.T) map[string]docEntry {
+	t.Helper()
+	out := map[string]docEntry{}
+	inTable := false
+	for _, line := range strings.Split(readDoc(t), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "| Technique | Taxonomy | Disruption |") {
+			inTable = true
+			continue
+		}
+		if !inTable {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "|") {
+			break // the table ended
+		}
+		if strings.HasPrefix(trimmed, "|---") {
+			continue
+		}
+		cells := splitRow(trimmed)
+		if len(cells) != 9 {
+			t.Fatalf("register row has %d cells, want 9: %q", len(cells), trimmed)
+		}
+		name := strings.Trim(cells[0], "`")
+		if name == "" {
+			t.Fatalf("register row has no technique: %q", trimmed)
+		}
+		out[name] = docEntry{
+			Technique: name, TaxonomyRef: cells[1], Disruption: cells[2], Reversibility: cells[3],
+			RiskClass: cells[4], Approval: cells[5], Radius: strings.Trim(cells[6], "`"),
+			Cleanup: cells[7], ProductionSafe: cells[8],
+		}
+	}
+	return out
+}
+
+func splitRow(row string) []string {
+	parts := strings.Split(strings.Trim(row, "|"), "|")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, strings.TrimSpace(strings.ReplaceAll(p, "`", "")))
+	}
+	return out
+}
+
+// docApproval maps the document's em-dash (no approval mode, used for prohibited techniques) to the
+// register's empty ApprovalMode.
+func docApproval(cell string) string {
+	if cell == "—" || cell == "-" {
+		return string(ApprovalNone)
+	}
+	return cell
+}
+
+// cleanupProse renders a CleanupSpec the way the document's table writes it, so the two are comparable
+// without the document having to carry YAML.
+func cleanupProse(c CleanupSpec) string {
+	if c.IsZero() {
+		return "—"
+	}
+	return fmt.Sprintf("%s; %s", strings.Join(c.Steps, "; "), c.Verification)
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/domain/offensivepolicy/policy_test.go
+++ b/internal/domain/offensivepolicy/policy_test.go
@@ -1,0 +1,206 @@
+package offensivepolicy
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// mutate returns the embedded register with one YAML substitution applied, so a test can assert that a
+// malformed register is REFUSED at load rather than accepted and enforced.
+func mutate(t *testing.T, old, new string) error {
+	t.Helper()
+	raw := string(embeddedPolicy)
+	if !strings.Contains(raw, old) {
+		t.Fatalf("fixture anchor not found in policy.yaml: %q", old)
+	}
+	_, err := parse([]byte(strings.Replace(raw, old, new, 1)))
+	return err
+}
+
+// TestLoadEmbeddedRegisterIsValid is the baseline: the register that actually ships must load.
+func TestLoadEmbeddedRegisterIsValid(t *testing.T) {
+	reg, err := Load()
+	if err != nil {
+		t.Fatalf("the shipped register does not load: %v", err)
+	}
+	if len(reg.TechniqueIDs()) == 0 {
+		t.Fatal("the shipped register is empty")
+	}
+}
+
+// TestLookupRefusesUnregisteredTechnique is the fail-closed default and the single most important
+// property in this package: the register is an allowlist. An unknown technique is not "unrestricted",
+// it is refused, because the set of things an offensive engine could attempt is unbounded.
+func TestLookupRefusesUnregisteredTechnique(t *testing.T) {
+	reg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{
+		"exploit.rce_unclassified", "", "   ", "RECON.SERVICE_BANNER", "recon.service_banner ",
+		"../recon.service_banner", "recon.service_banner\x00",
+	} {
+		if _, ok := reg.Lookup(name); ok && strings.TrimSpace(name) != "recon.service_banner" {
+			t.Errorf("technique %q must not resolve to a policy entry", name)
+		}
+	}
+	// A nil register refuses everything rather than panicking: a caller that failed to load the policy
+	// must not be able to proceed as though nothing were restricted.
+	var nilReg *Register
+	if _, ok := nilReg.Lookup("recon.service_banner"); ok {
+		t.Error("a nil register must refuse every technique")
+	}
+}
+
+// TestRegisterRejectsStateChangingWithoutCleanup is the CI-time gate the document's §7 promises.
+// Discovering an unreversible action at runtime means it has already run.
+func TestRegisterRejectsStateChangingWithoutCleanup(t *testing.T) {
+	err := mutate(t, `    blast_radius: state_changing
+    cleanup:
+      steps:
+        - delete uploaded artifact
+      verification: verify absence`, `    blast_radius: state_changing
+    cleanup:
+      steps: []
+      verification: ""`)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a state-changing technique with no cleanup path must fail validation, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "cleanup steps") {
+		t.Errorf("the refusal must name the missing cleanup: %v", err)
+	}
+}
+
+// TestRegisterRejectsStateChangingWithoutVerification: steps alone are not a cleanup path. An undo
+// nobody checks is a hope.
+func TestRegisterRejectsStateChangingWithoutVerification(t *testing.T) {
+	err := mutate(t, `      verification: verify absence`, `      verification: ""`)
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "verification") {
+		t.Fatalf("a cleanup path with no verification must fail validation, got %v", err)
+	}
+}
+
+// TestRegisterRejectsSofterClassThanTheAxesImply stops the drift that matters most: a hand-written risk
+// class that is gentler than the two axes reduce to would silently lower the approval requirement.
+func TestRegisterRejectsSofterClassThanTheAxesImply(t *testing.T) {
+	err := mutate(t, `    disruption: low
+    reversibility: irreversible
+    risk_class: high
+    approval: dual`, `    disruption: low
+    reversibility: irreversible
+    risk_class: medium
+    approval: single`)
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "reduce") {
+		t.Fatalf("a class softer than its axes must fail validation, got %v", err)
+	}
+}
+
+// TestRegisterRejectsApprovalMismatch pins the §4 matrix: the register cannot disagree with it.
+func TestRegisterRejectsApprovalMismatch(t *testing.T) {
+	err := mutate(t, `    risk_class: medium
+    approval: single`, `    risk_class: medium
+    approval: automatic`)
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "approval must be") {
+		t.Fatalf("an approval mode that contradicts the risk class must fail validation, got %v", err)
+	}
+}
+
+// TestRegisterRejectsApprovableProhibitedTechnique: allowing an approval mode on a prohibited technique
+// would imply some signature could authorise it. None can.
+func TestRegisterRejectsApprovableProhibitedTechnique(t *testing.T) {
+	err := mutate(t, `    risk_class: prohibited
+    approval: ""`, `    risk_class: prohibited
+    approval: dual`)
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "must not carry an approval mode") {
+		t.Fatalf("a prohibited technique with an approval mode must fail validation, got %v", err)
+	}
+}
+
+// TestRegisterRefusesProductionSafeBeforeLegalReview is referenced by name in the policy document's
+// Status section: "Not reviewed is a real state, not a placeholder."
+func TestRegisterRefusesProductionSafeBeforeLegalReview(t *testing.T) {
+	err := mutate(t, `    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false`, `    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: true`)
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "production-safe before the legal review") {
+		t.Fatalf("production-safe before a recorded legal review must fail validation, got %v", err)
+	}
+}
+
+// TestRegisterRejectsUnknownFields catches a typo'd key, which YAML would otherwise ignore in silence —
+// and a policy field that is silently ignored is a control that silently does not exist.
+func TestRegisterRejectsUnknownFields(t *testing.T) {
+	if err := mutate(t, `    production_safe: false`, `    production_safe: false
+    prod_safe: true`); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("an unknown policy field must fail to load, got %v", err)
+	}
+}
+
+// TestRegisterRejectsUnclassifiableTechnique: a technique that cannot state both axes is refused, which
+// is the same outcome as having no entry at all (document §3).
+func TestRegisterRejectsUnclassifiableTechnique(t *testing.T) {
+	err := mutate(t, `    disruption: none
+    reversibility: reversible
+    risk_class: low`, `    disruption: ""
+    reversibility: reversible
+    risk_class: low`)
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "both risk axes") {
+		t.Fatalf("a technique missing a risk axis must fail validation, got %v", err)
+	}
+}
+
+func TestRegisterRejectsDuplicateTechnique(t *testing.T) {
+	err := mutate(t, `  - technique: recon.tls_inspect`, `  - technique: recon.service_banner`)
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("a duplicate technique must fail validation, got %v", err)
+	}
+}
+
+// TestRiskCeilingOnlyNarrows pins document §5: an engagement's ceiling can reduce what the register
+// permits and can never widen it, and no ceiling whatsoever permits a prohibited technique.
+func TestRiskCeilingOnlyNarrows(t *testing.T) {
+	tests := []struct {
+		ceiling, have RiskClass
+		want          bool
+	}{
+		{RiskLow, RiskLow, true},
+		{RiskLow, RiskMedium, false},
+		{RiskLow, RiskHigh, false},
+		{RiskMedium, RiskLow, true},
+		{RiskMedium, RiskMedium, true},
+		{RiskMedium, RiskHigh, false},
+		{RiskHigh, RiskHigh, true},
+		// No ceiling permits a prohibited technique, including a ceiling of "prohibited" itself, which
+		// is not a permission level but a refusal.
+		{RiskHigh, RiskProhibited, false},
+		{RiskProhibited, RiskLow, false},
+		{RiskProhibited, RiskProhibited, false},
+		// An unset or unknown ceiling permits nothing.
+		{RiskClass(""), RiskLow, false},
+		{RiskClass("critical"), RiskLow, false},
+	}
+	for _, tc := range tests {
+		if got := RiskCeilingPermits(tc.ceiling, tc.have); got != tc.want {
+			t.Errorf("RiskCeilingPermits(%q, %q) = %v, want %v", tc.ceiling, tc.have, got, tc.want)
+		}
+	}
+}
+
+func TestRequiredApprovalsCounts(t *testing.T) {
+	for mode, want := range map[ApprovalMode]int{
+		ApprovalAutomatic: 0, ApprovalSingle: 1, ApprovalDual: 2, ApprovalNone: 0, ApprovalMode("triple"): 0,
+	} {
+		if got := mode.RequiredApprovals(); got != want {
+			t.Errorf("%q requires %d approvals, want %d", mode, got, want)
+		}
+	}
+}

--- a/internal/usecase/offensivepolicy/dryrun.go
+++ b/internal/usecase/offensivepolicy/dryrun.go
@@ -1,0 +1,106 @@
+package offensivepolicy
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+)
+
+// PlanStep is one enumerated action: what would run, against what, and under what authority.
+//
+// Permitted is the whole point. A dry run that only listed the steps would tell an operator what the
+// platform intends but not what it is allowed to do, and the interesting rows are exactly the ones that
+// would be refused.
+type PlanStep struct {
+	Technique   string
+	Target      string
+	RiskClass   offensivepolicy.RiskClass
+	Approval    offensivepolicy.ApprovalMode
+	BlastRadius offensivepolicy.Radius
+	Cleanup     offensivepolicy.CleanupSpec
+	Permitted   bool
+	Refusal     string
+}
+
+// Plan is the result of a dry run: every step, and nothing executed.
+type Plan struct {
+	EngagementID string
+	Steps        []PlanStep
+	// PermittedCount and RefusedCount are stated rather than left to the caller to compute, so a UI or
+	// CLI cannot render a plan as "8 steps" while 5 of them would be refused.
+	PermittedCount int
+	RefusedCount   int
+}
+
+// PlanRequest is one intended step, before any authorization has been sought.
+type PlanRequest struct {
+	Technique string
+	Target    string
+}
+
+// DryRun enumerates exactly what would execute against what, and executes nothing.
+//
+// It is part of the policy, not a debug flag (document 9). The Service holds no executor at all, so
+// there is no code path from here to a target — the guarantee is structural rather than a matter of
+// remembering not to call something. TestPlanExecutesNothing asserts it with an executor that fails the
+// test if it is invoked.
+//
+// A dry run deliberately does NOT seal evidence or count as an authorization: nothing happened, so
+// recording an authorization would put a permission in the chain that no action ever used.
+func (s *Service) DryRun(ctx context.Context, req Request, steps []PlanRequest) Plan {
+	plan := Plan{EngagementID: req.EngagementID.String()}
+	if s == nil {
+		return plan
+	}
+	missing := req.RoE.missingFields()
+	for _, step := range steps {
+		technique := strings.TrimSpace(step.Technique)
+		target := strings.TrimSpace(step.Target)
+		row := PlanStep{Technique: technique, Target: target}
+
+		policy, ok := s.register.Lookup(technique)
+		switch {
+		case !ok:
+			row.Refusal = "no register entry: the register is an allowlist and this technique is not in it"
+		case policy.RiskClass == offensivepolicy.RiskProhibited:
+			row.RiskClass, row.BlastRadius = policy.RiskClass, policy.BlastRadius
+			row.Refusal = "prohibited category: no scope, window or approval permits this"
+		case target == "":
+			row.RiskClass, row.Approval, row.BlastRadius = policy.RiskClass, policy.Approval, policy.BlastRadius
+			row.Refusal = "no target"
+		case len(missing) > 0:
+			row.RiskClass, row.Approval, row.BlastRadius = policy.RiskClass, policy.Approval, policy.BlastRadius
+			row.Refusal = "engagement is missing required rules of engagement: " + strings.Join(missing, ", ")
+		case !offensivepolicy.RiskCeilingPermits(req.RoE.RiskCeiling, policy.RiskClass):
+			row.RiskClass, row.Approval, row.BlastRadius = policy.RiskClass, policy.Approval, policy.BlastRadius
+			row.Refusal = "above the engagement risk ceiling " + string(req.RoE.RiskCeiling)
+		default:
+			row.RiskClass, row.Approval, row.BlastRadius, row.Cleanup =
+				policy.RiskClass, policy.Approval, policy.BlastRadius, policy.Cleanup
+			// The approvals a dry run reports on are the ones recorded SO FAR. A step that still needs a
+			// signature is shown as refused with the count outstanding, because that is the operator's
+			// next action.
+			if _, err := s.validApprovers(policy, technique, target, req); err != nil {
+				row.Refusal = err.Error()
+			} else {
+				row.Permitted = true
+			}
+		}
+		if row.Permitted {
+			plan.PermittedCount++
+		} else {
+			plan.RefusedCount++
+		}
+		plan.Steps = append(plan.Steps, row)
+	}
+	// Deterministic order so two dry runs of the same plan read identically and a diff means a change.
+	sort.SliceStable(plan.Steps, func(i, j int) bool {
+		if plan.Steps[i].Technique != plan.Steps[j].Technique {
+			return plan.Steps[i].Technique < plan.Steps[j].Technique
+		}
+		return plan.Steps[i].Target < plan.Steps[j].Target
+	})
+	return plan
+}

--- a/internal/usecase/offensivepolicy/dryrun_test.go
+++ b/internal/usecase/offensivepolicy/dryrun_test.go
@@ -1,0 +1,159 @@
+package offensivepolicy
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// explodingExecutor fails the test if it is called at all. It is passed nowhere — that is the point.
+// The Service holds no executor, so the guarantee is structural, and this type exists to make the
+// assertion explicit rather than implied by absence.
+type explodingExecutor struct {
+	t     *testing.T
+	calls int64
+}
+
+func (e *explodingExecutor) Execute(_ context.Context, technique, target string) error {
+	atomic.AddInt64(&e.calls, 1)
+	e.t.Errorf("dry run executed %q against %q; a dry run must execute nothing", technique, target)
+	return nil
+}
+
+// TestPlanExecutesNothing is acceptance criterion 8: dry run enumerates the plan and executes nothing,
+// asserted by a test that fails if any execution occurs.
+func TestPlanExecutesNothing(t *testing.T) {
+	svc, sealer, audit := newService(t)
+	exec := &explodingExecutor{t: t}
+
+	plan := svc.DryRun(context.Background(), Request{
+		EngagementID: "eng-1", Actor: "alice", RoE: completeRoE(), Now: testNow,
+		Approvals: []Approval{
+			{Approver: "carol", Technique: "exploit.default_credentials", Target: "https://app.example.test"},
+		},
+	}, []PlanRequest{
+		{Technique: "recon.service_banner", Target: "https://app.example.test"},
+		{Technique: "exploit.default_credentials", Target: "https://app.example.test"},
+		{Technique: "exploit.web_shell_upload", Target: "https://app.example.test"},
+		{Technique: "impact.service_stop", Target: "https://app.example.test"},
+		{Technique: "exploit.brand_new_zero_day", Target: "https://app.example.test"},
+	})
+
+	if got := atomic.LoadInt64(&exec.calls); got != 0 {
+		t.Fatalf("dry run performed %d executions, want 0", got)
+	}
+	// A dry run must not seal an authorization either: nothing happened, so recording a permission would
+	// put an approval in the evidence chain that no action ever used.
+	if len(sealer.records) != 0 {
+		t.Errorf("dry run sealed %d authorizations, want 0", len(sealer.records))
+	}
+	if got := audit.actions(); len(got) != 0 {
+		t.Errorf("dry run wrote audit entries %v; enumeration is not an action", got)
+	}
+
+	if len(plan.Steps) != 5 {
+		t.Fatalf("plan has %d steps, want 5", len(plan.Steps))
+	}
+	// Steps are ordered deterministically so two dry runs of the same plan read identically.
+	for i := 1; i < len(plan.Steps); i++ {
+		if plan.Steps[i-1].Technique > plan.Steps[i].Technique {
+			t.Fatalf("plan steps are not deterministically ordered: %v", plan.Steps)
+		}
+	}
+	byTechnique := map[string]PlanStep{}
+	for _, s := range plan.Steps {
+		byTechnique[s.Technique] = s
+	}
+
+	// The interesting rows are the refused ones, and each must say WHY in terms an operator can act on.
+	if step := byTechnique["recon.service_banner"]; !step.Permitted {
+		t.Errorf("an automatic-class technique inside scope should be permitted: %+v", step)
+	}
+	if step := byTechnique["exploit.default_credentials"]; !step.Permitted {
+		t.Errorf("a medium technique with its single approval should be permitted: %+v", step)
+	}
+	if step := byTechnique["exploit.web_shell_upload"]; step.Permitted {
+		t.Errorf("a high technique with no dual approval must be refused: %+v", step)
+	} else if step.Refusal == "" {
+		t.Error("a refused step must state why")
+	}
+	if step := byTechnique["impact.service_stop"]; step.Permitted || step.Refusal == "" {
+		t.Errorf("a prohibited technique must be refused with a reason: %+v", step)
+	}
+	if step := byTechnique["exploit.brand_new_zero_day"]; step.Permitted || step.Refusal == "" {
+		t.Errorf("an unregistered technique must be refused with a reason: %+v", step)
+	}
+
+	// The counts must be stated, so a UI cannot render "5 steps" while 3 would be refused.
+	if plan.PermittedCount != 2 || plan.RefusedCount != 3 {
+		t.Errorf("plan counts = %d permitted / %d refused, want 2/3", plan.PermittedCount, plan.RefusedCount)
+	}
+}
+
+// TestPlanCarriesTheCleanupPathForStateChangingSteps: an operator reviewing a plan needs to see how a
+// state change would be undone, not just that it changes state.
+func TestPlanCarriesTheCleanupPathForStateChangingSteps(t *testing.T) {
+	svc, _, _ := newService(t)
+	const technique = "exploit.web_shell_upload"
+	const target = "https://app.example.test"
+	plan := svc.DryRun(context.Background(), Request{
+		EngagementID: "eng-1", Actor: "alice", RoE: completeRoE(), Now: testNow,
+		Approvals: []Approval{
+			{Approver: "alice", Technique: technique, Target: target},
+			{Approver: "bob", Technique: technique, Target: target},
+		},
+	}, []PlanRequest{{Technique: technique, Target: target}})
+
+	if len(plan.Steps) != 1 {
+		t.Fatalf("want one step, got %d", len(plan.Steps))
+	}
+	step := plan.Steps[0]
+	if !step.Permitted {
+		t.Fatalf("a dual-approved high technique should be permitted: %+v", step)
+	}
+	if step.BlastRadius != domain.RadiusStateChanging {
+		t.Errorf("blast radius = %q, want state_changing", step.BlastRadius)
+	}
+	if len(step.Cleanup.Steps) == 0 || step.Cleanup.Verification == "" {
+		t.Errorf("a state-changing step must show its cleanup path: %+v", step.Cleanup)
+	}
+}
+
+// TestPlanRefusesEveryStepWhenTheEngagementIsIncomplete: a plan against an engagement missing a
+// rules-of-engagement field enumerates, and refuses everything, naming the missing field. An operator
+// gets one actionable message rather than a list of unexplained refusals.
+func TestPlanRefusesEveryStepWhenTheEngagementIsIncomplete(t *testing.T) {
+	svc, _, _ := newService(t)
+	roe := completeRoE()
+	roe.EmergencyContact = ""
+	plan := svc.DryRun(context.Background(), Request{
+		EngagementID: "eng-1", Actor: "alice", RoE: roe, Now: testNow,
+	}, []PlanRequest{
+		{Technique: "recon.service_banner", Target: "https://app.example.test"},
+		{Technique: "recon.tls_inspect", Target: "https://app.example.test"},
+	})
+	if plan.PermittedCount != 0 || plan.RefusedCount != 2 {
+		t.Fatalf("plan counts = %d/%d, want 0 permitted / 2 refused", plan.PermittedCount, plan.RefusedCount)
+	}
+	for _, step := range plan.Steps {
+		if step.Refusal == "" || !strings.Contains(step.Refusal, "emergency_contact") {
+			t.Errorf("%s refusal must name the missing field: %q", step.Technique, step.Refusal)
+		}
+	}
+}
+
+// TestDryRunOnANilServiceIsEmpty: a caller that failed to construct the service must not get a plan that
+// reads as "nothing is restricted".
+func TestDryRunOnANilServiceIsEmpty(t *testing.T) {
+	var svc *Service
+	plan := svc.DryRun(context.Background(), Request{EngagementID: shared.ID("eng-1")}, []PlanRequest{
+		{Technique: "recon.service_banner", Target: "https://app.example.test"},
+	})
+	if len(plan.Steps) != 0 || plan.PermittedCount != 0 {
+		t.Fatalf("a nil service must produce no permitted steps: %+v", plan)
+	}
+}

--- a/internal/usecase/offensivepolicy/enforce.go
+++ b/internal/usecase/offensivepolicy/enforce.go
@@ -264,7 +264,11 @@ func (s *Service) validApprovers(policy offensivepolicy.TechniquePolicy, techniq
 			shared.ErrForbidden, technique, need, len(approvers))
 	}
 	sort.Strings(approvers)
-	return approvers[:need], nil
+	// Return EVERY valid approver, not the first `need` of them. Truncating would both discard evidence
+	// (a third signature is worth recording) and make this line depend on the guard above for memory
+	// safety — a later edit to that guard would turn a policy bug into a panic in the authorization path,
+	// and a panic there is worse than a refusal.
+	return approvers, nil
 }
 
 // refuse audits the refusal and returns the error. A refusal that is not recorded cannot be explained

--- a/internal/usecase/offensivepolicy/enforce.go
+++ b/internal/usecase/offensivepolicy/enforce.go
@@ -1,0 +1,292 @@
+// Package offensivepolicy enforces the offensive governance policy
+// (docs/redteam/offensive-policy.md, issue #418) before an offensive action is admitted.
+//
+// It sits in FRONT of safety.Gate rather than replacing it. The gate already enforces engagement scope,
+// the authorization window and human approval; this package answers the question those three do not:
+// of the actions inside scope and inside the window, which are permitted at all, and under whose
+// signature.
+//
+// Every refusal path returns shared.ErrForbidden and is audited. Every permission is sealed into the
+// hash-chained evidence for the action BEFORE it may run, because the document requires approval to be
+// evidence rather than configuration: a stored flag saying "approved" is not an approval.
+package offensivepolicy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// EvidenceKindAuthorization is the evidence kind for a sealed offensive authorization. Exported so the
+// adapter that implements EvidenceSealer seals under the same kind this package documents.
+const EvidenceKindAuthorization = "offensive_authorization"
+
+// machinePrefixes are the identity families this codebase mints for non-human principals. A machine may
+// propose an offensive plan; it may never satisfy an approval requirement (document 4).
+//
+// This mirrors aitriagereview.machineActor deliberately rather than importing it: that check governs a
+// different decision, and a shared helper would couple two policies that should be free to diverge. The
+// list is the same because the identity scheme is.
+var machinePrefixes = []string{"agent:", "llm:", "mcp:", "system:", "machine:", "bot:", "service:"}
+
+// Approval is one recorded human signature for a specific technique, target and window.
+type Approval struct {
+	Approver  string
+	Technique string
+	Target    string
+	At        time.Time
+}
+
+// RulesOfEngagement is the set of engagement fields document 5 requires before ANY offensive action is
+// permitted. A missing field is a refusal, not a default.
+type RulesOfEngagement struct {
+	AuthorizedScope   []string
+	WindowStart       time.Time
+	WindowEnd         time.Time
+	CustomerContact   string
+	EmergencyContact  string
+	RiskCeiling       offensivepolicy.RiskClass
+	ExcludedAssets    []string
+	ExclusionsChecked bool
+}
+
+// missingFields lists the required fields that are absent, in a deterministic order so a refusal message
+// is reproducible.
+//
+// ExcludedAssets may legitimately be empty — an engagement can exclude nothing — but the operator must
+// have CONSIDERED it. ExclusionsChecked distinguishes "nothing excluded" from "nobody looked", which an
+// empty slice cannot.
+func (r RulesOfEngagement) missingFields() []string {
+	var missing []string
+	if len(r.AuthorizedScope) == 0 {
+		missing = append(missing, "authorized_scope")
+	}
+	if r.WindowStart.IsZero() || r.WindowEnd.IsZero() || !r.WindowEnd.After(r.WindowStart) {
+		missing = append(missing, "authorization_window")
+	}
+	if strings.TrimSpace(r.CustomerContact) == "" {
+		missing = append(missing, "customer_contact")
+	}
+	if strings.TrimSpace(r.EmergencyContact) == "" {
+		missing = append(missing, "emergency_contact")
+	}
+	if !r.RiskCeiling.Valid() {
+		missing = append(missing, "risk_ceiling")
+	}
+	if !r.ExclusionsChecked {
+		missing = append(missing, "excluded_assets_reviewed")
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+// Request is one offensive action seeking authorization.
+type Request struct {
+	EngagementID shared.ID
+	Technique    string
+	Target       string
+	Actor        string
+	RoE          RulesOfEngagement
+	Approvals    []Approval
+	Now          time.Time
+}
+
+// Decision is the sealed record of a granted authorization. It exists only when Authorize returned no
+// error: there is no "denied" Decision, because a refusal is an error and cannot be mistaken for a
+// permission by a caller that forgets to check.
+type Decision struct {
+	Technique    string
+	Target       string
+	RiskClass    offensivepolicy.RiskClass
+	Approval     offensivepolicy.ApprovalMode
+	BlastRadius  offensivepolicy.Radius
+	Approvers    []string
+	EvidenceID   shared.ID
+	AuthorizedAt time.Time
+}
+
+// sealedAuthorization is the evidence payload. It carries exactly what document 4 requires: the
+// approving humans, the technique, the target, the window and the timestamp.
+type sealedAuthorization struct {
+	Technique      string    `json:"technique"`
+	Target         string    `json:"target"`
+	RiskClass      string    `json:"risk_class"`
+	Approval       string    `json:"approval_mode"`
+	BlastRadius    string    `json:"blast_radius"`
+	Approvers      []string  `json:"approvers"`
+	WindowStart    time.Time `json:"window_start"`
+	WindowEnd      time.Time `json:"window_end"`
+	AuthorizedAt   time.Time `json:"authorized_at"`
+	Actor          string    `json:"actor"`
+	PolicyReviewed bool      `json:"policy_legal_review_recorded"`
+}
+
+// EvidenceSealer is the narrow consumer-side interface this package needs: seal a payload and tell me
+// the id it was sealed under.
+type EvidenceSealer interface {
+	SealOffensiveAuthorization(ctx context.Context, engagementID shared.ID, content []byte, createdBy string) (shared.ID, error)
+}
+
+// Service enforces the policy. All dependencies are required: a policy that cannot audit or cannot seal
+// is not enforcing anything it can prove afterwards.
+type Service struct {
+	register *offensivepolicy.Register
+	evidence EvidenceSealer
+	audit    ports.AuditLogger
+}
+
+// NewService validates its dependencies.
+func NewService(register *offensivepolicy.Register, ev EvidenceSealer, audit ports.AuditLogger) (*Service, error) {
+	if register == nil || ev == nil || audit == nil {
+		return nil, fmt.Errorf("%w: offensive policy service requires a register, evidence and audit", shared.ErrValidation)
+	}
+	return &Service{register: register, evidence: ev, audit: audit}, nil
+}
+
+// Authorize decides whether one offensive action may run.
+//
+// Order matters and is deliberate: the cheapest, most absolute refusals come first so that a prohibited
+// technique is never evaluated against an engagement's configuration. Nothing about an engagement can
+// make a prohibited technique permissible, so asking about approvals first would imply otherwise.
+func (s *Service) Authorize(ctx context.Context, req Request) (Decision, error) {
+	if s == nil {
+		return Decision{}, fmt.Errorf("%w: offensive policy service is not configured", shared.ErrForbidden)
+	}
+	technique := strings.TrimSpace(req.Technique)
+	target := strings.TrimSpace(req.Target)
+
+	// 1. Register lookup. Absent means refused: the register is an allowlist.
+	policy, ok := s.register.Lookup(technique)
+	if !ok {
+		return s.refuse(ctx, req, "no_register_entry",
+			fmt.Errorf("%w: technique %q has no offensive policy entry", shared.ErrForbidden, technique))
+	}
+	// 2. Prohibited categories. No scope, window, approval or seniority changes this.
+	if policy.RiskClass == offensivepolicy.RiskProhibited {
+		return s.refuse(ctx, req, "prohibited_category",
+			fmt.Errorf("%w: technique %q is in a prohibited category", shared.ErrForbidden, technique))
+	}
+	if target == "" {
+		return s.refuse(ctx, req, "no_target",
+			fmt.Errorf("%w: offensive action has no target", shared.ErrForbidden))
+	}
+	// 3. Rules of engagement. A missing field is a refusal.
+	if missing := req.RoE.missingFields(); len(missing) > 0 {
+		return s.refuse(ctx, req, "missing_roe",
+			fmt.Errorf("%w: engagement is missing required rules of engagement: %s", shared.ErrForbidden, strings.Join(missing, ", ")))
+	}
+	// 4. Window. Outside it, nothing runs.
+	now := req.Now
+	if now.IsZero() {
+		return s.refuse(ctx, req, "no_timestamp",
+			fmt.Errorf("%w: offensive authorization needs a decision timestamp", shared.ErrForbidden))
+	}
+	if now.Before(req.RoE.WindowStart) || now.After(req.RoE.WindowEnd) {
+		return s.refuse(ctx, req, "outside_window",
+			fmt.Errorf("%w: %s is outside the authorization window", shared.ErrForbidden, now.UTC().Format(time.RFC3339)))
+	}
+	// 5. The engagement's ceiling narrows the register; it never widens it.
+	if !offensivepolicy.RiskCeilingPermits(req.RoE.RiskCeiling, policy.RiskClass) {
+		return s.refuse(ctx, req, "above_risk_ceiling",
+			fmt.Errorf("%w: technique %q is class %q, above the engagement ceiling %q",
+				shared.ErrForbidden, technique, policy.RiskClass, req.RoE.RiskCeiling))
+	}
+	// 6. Approvals: enough of them, distinct, human, and about THIS technique and target.
+	approvers, err := s.validApprovers(policy, technique, target, req)
+	if err != nil {
+		return s.refuse(ctx, req, "approval_missing", err)
+	}
+	// 7. Seal BEFORE returning a permission. If the authorization cannot be recorded, it is not granted:
+	// the document requires approval to be evidence, and evidence that failed to seal is not evidence.
+	payload, err := json.Marshal(sealedAuthorization{
+		Technique: technique, Target: target, RiskClass: string(policy.RiskClass),
+		Approval: string(policy.Approval), BlastRadius: string(policy.BlastRadius),
+		Approvers: approvers, WindowStart: req.RoE.WindowStart.UTC(), WindowEnd: req.RoE.WindowEnd.UTC(),
+		AuthorizedAt: now.UTC(), Actor: req.Actor,
+		PolicyReviewed: s.register.LegalReview.Reviewed,
+	})
+	if err != nil {
+		return Decision{}, fmt.Errorf("marshal offensive authorization: %w", err)
+	}
+	evidenceID, err := s.evidence.SealOffensiveAuthorization(ctx, req.EngagementID, payload, req.Actor)
+	if err != nil {
+		return Decision{}, fmt.Errorf("%w: offensive authorization could not be sealed as evidence: %v", shared.ErrForbidden, err)
+	}
+	_ = s.audit.Record(ctx, ports.AuditEntry{
+		Actor: req.Actor, Action: "offensive.authorized", Target: target, At: now.UTC(),
+		Metadata: map[string]string{
+			"technique": technique, "risk_class": string(policy.RiskClass),
+			"approval": string(policy.Approval), "approvers": strings.Join(approvers, ","),
+			"evidence_id": evidenceID.String(),
+		},
+	})
+	return Decision{
+		Technique: technique, Target: target, RiskClass: policy.RiskClass, Approval: policy.Approval,
+		BlastRadius: policy.BlastRadius, Approvers: approvers, EvidenceID: evidenceID, AuthorizedAt: now.UTC(),
+	}, nil
+}
+
+// validApprovers returns the distinct human approvers that cover this technique and target, or an error
+// naming what is missing.
+func (s *Service) validApprovers(policy offensivepolicy.TechniquePolicy, technique, target string, req Request) ([]string, error) {
+	need := policy.Approval.RequiredApprovals()
+	if need == 0 {
+		return nil, nil
+	}
+	seen := map[string]struct{}{}
+	var approvers []string
+	for _, a := range req.Approvals {
+		who := strings.TrimSpace(a.Approver)
+		if who == "" || isMachine(who) {
+			continue
+		}
+		// An approval is for a specific technique and target. A signature collected for something else
+		// is not a signature for this.
+		if strings.TrimSpace(a.Technique) != technique || strings.TrimSpace(a.Target) != target {
+			continue
+		}
+		key := strings.ToLower(who)
+		if _, dup := seen[key]; dup {
+			continue // dual approval means two DISTINCT humans, not one human twice
+		}
+		seen[key] = struct{}{}
+		approvers = append(approvers, who)
+	}
+	if len(approvers) < need {
+		return nil, fmt.Errorf("%w: technique %q needs %d distinct human approval(s) for this target, have %d",
+			shared.ErrForbidden, technique, need, len(approvers))
+	}
+	sort.Strings(approvers)
+	return approvers[:need], nil
+}
+
+// refuse audits the refusal and returns the error. A refusal that is not recorded cannot be explained
+// afterwards, which is the whole point of the chain of custody this policy claims.
+func (s *Service) refuse(ctx context.Context, req Request, reason string, err error) (Decision, error) {
+	at := req.Now
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	_ = s.audit.Record(ctx, ports.AuditEntry{
+		Actor: req.Actor, Action: "offensive.refused", Target: strings.TrimSpace(req.Target), At: at.UTC(),
+		Metadata: map[string]string{"technique": strings.TrimSpace(req.Technique), "reason": reason},
+	})
+	return Decision{}, err
+}
+
+func isMachine(actor string) bool {
+	a := strings.ToLower(strings.TrimSpace(actor))
+	for _, prefix := range machinePrefixes {
+		if strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/usecase/offensivepolicy/enforce_test.go
+++ b/internal/usecase/offensivepolicy/enforce_test.go
@@ -1,0 +1,417 @@
+package offensivepolicy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type sealedRecord struct {
+	engagementID shared.ID
+	content      []byte
+	createdBy    string
+}
+
+type fakeSealer struct {
+	mu      sync.Mutex
+	records []sealedRecord
+	err     error
+}
+
+func (f *fakeSealer) SealOffensiveAuthorization(_ context.Context, engagementID shared.ID, content []byte, createdBy string) (shared.ID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return "", f.err
+	}
+	f.records = append(f.records, sealedRecord{engagementID: engagementID, content: content, createdBy: createdBy})
+	return shared.ID("ev-" + createdBy), nil
+}
+
+type fakeAudit struct {
+	mu      sync.Mutex
+	entries []ports.AuditEntry
+	err     error
+}
+
+func (f *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.entries = append(f.entries, e)
+	return nil
+}
+
+func (f *fakeAudit) actions() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.entries))
+	for _, e := range f.entries {
+		out = append(out, e.Action)
+	}
+	return out
+}
+
+func (f *fakeAudit) last() ports.AuditEntry {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.entries) == 0 {
+		return ports.AuditEntry{}
+	}
+	return f.entries[len(f.entries)-1]
+}
+
+var testNow = time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+// completeRoE is an engagement that satisfies every document-5 field, so a test that wants to exercise
+// one refusal can remove exactly one field rather than starting from nothing.
+func completeRoE() RulesOfEngagement {
+	return RulesOfEngagement{
+		AuthorizedScope:   []string{"app.example.test"},
+		WindowStart:       testNow.Add(-time.Hour),
+		WindowEnd:         testNow.Add(time.Hour),
+		CustomerContact:   "customer-ciso@example.test",
+		EmergencyContact:  "+84-000-000-000",
+		RiskCeiling:       domain.RiskHigh,
+		ExclusionsChecked: true,
+	}
+}
+
+func newService(t *testing.T) (*Service, *fakeSealer, *fakeAudit) {
+	t.Helper()
+	reg, err := domain.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealer, audit := &fakeSealer{}, &fakeAudit{}
+	svc, err := NewService(reg, sealer, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc, sealer, audit
+}
+
+// TestAuthorizeRefusesTechniqueWithNoRegisterEntry is acceptance criterion 3: a technique with no policy
+// entry is refused by the enforcement path. This is the fail-closed default — the register is an
+// allowlist, so "unknown" and "forbidden" are the same answer.
+func TestAuthorizeRefusesTechniqueWithNoRegisterEntry(t *testing.T) {
+	svc, sealer, audit := newService(t)
+	_, err := svc.Authorize(context.Background(), Request{
+		EngagementID: "eng-1", Technique: "exploit.brand_new_zero_day", Target: "https://app.example.test",
+		Actor: "alice", RoE: completeRoE(), Now: testNow,
+		Approvals: []Approval{{Approver: "alice", Technique: "exploit.brand_new_zero_day", Target: "https://app.example.test"}},
+	})
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("an unregistered technique must be forbidden, got %v", err)
+	}
+	if len(sealer.records) != 0 {
+		t.Error("a refused action must not seal an authorization")
+	}
+	if got := audit.last(); got.Action != "offensive.refused" || got.Metadata["reason"] != "no_register_entry" {
+		t.Errorf("the refusal must be audited with its reason, got %+v", got)
+	}
+}
+
+// TestAuthorizeRefusesProhibitedTechniqueWhateverTheApprovals: nothing about an engagement can make a
+// prohibited technique permissible, including dual approval from two humans.
+func TestAuthorizeRefusesProhibitedTechniqueWhateverTheApprovals(t *testing.T) {
+	svc, sealer, audit := newService(t)
+	for _, technique := range []string{"impact.service_stop", "exfil.bulk_data", "persist.scheduled_task"} {
+		_, err := svc.Authorize(context.Background(), Request{
+			EngagementID: "eng-1", Technique: technique, Target: "https://app.example.test",
+			Actor: "alice", RoE: completeRoE(), Now: testNow,
+			Approvals: []Approval{
+				{Approver: "alice", Technique: technique, Target: "https://app.example.test"},
+				{Approver: "bob", Technique: technique, Target: "https://app.example.test"},
+			},
+		})
+		if !errors.Is(err, shared.ErrForbidden) {
+			t.Errorf("%s is prohibited and must be forbidden even with dual approval, got %v", technique, err)
+		}
+		if got := audit.last(); got.Metadata["reason"] != "prohibited_category" {
+			t.Errorf("%s: refusal reason = %q, want prohibited_category", technique, got.Metadata["reason"])
+		}
+	}
+	if len(sealer.records) != 0 {
+		t.Error("a prohibited technique must never seal an authorization")
+	}
+}
+
+// TestAuthorizeRefusesMissingRulesOfEngagement is acceptance criterion for the RoE refusal: a missing
+// field is a refusal, not a default. Each subtest removes exactly one field from an otherwise complete
+// engagement, so a pass cannot come from some unrelated gap.
+func TestAuthorizeRefusesMissingRulesOfEngagement(t *testing.T) {
+	cases := map[string]func(*RulesOfEngagement){
+		"authorized_scope":         func(r *RulesOfEngagement) { r.AuthorizedScope = nil },
+		"authorization_window":     func(r *RulesOfEngagement) { r.WindowStart, r.WindowEnd = time.Time{}, time.Time{} },
+		"customer_contact":         func(r *RulesOfEngagement) { r.CustomerContact = "  " },
+		"emergency_contact":        func(r *RulesOfEngagement) { r.EmergencyContact = "" },
+		"risk_ceiling":             func(r *RulesOfEngagement) { r.RiskCeiling = "" },
+		"excluded_assets_reviewed": func(r *RulesOfEngagement) { r.ExclusionsChecked = false },
+	}
+	for field, remove := range cases {
+		t.Run(field, func(t *testing.T) {
+			svc, sealer, audit := newService(t)
+			roe := completeRoE()
+			remove(&roe)
+			_, err := svc.Authorize(context.Background(), Request{
+				EngagementID: "eng-1", Technique: "recon.service_banner", Target: "https://app.example.test",
+				Actor: "alice", RoE: roe, Now: testNow,
+			})
+			if !errors.Is(err, shared.ErrForbidden) {
+				t.Fatalf("a missing %s must be forbidden, got %v", field, err)
+			}
+			// The refusal must NAME the missing field. "forbidden" alone leaves an operator guessing which
+			// of six fields to fill in.
+			if !strings.Contains(err.Error(), field) {
+				t.Errorf("the refusal does not name the missing field %q: %v", field, err)
+			}
+			if len(sealer.records) != 0 {
+				t.Error("a refused action must not seal an authorization")
+			}
+			if got := audit.last().Metadata["reason"]; got != "missing_roe" {
+				t.Errorf("refusal reason = %q, want missing_roe", got)
+			}
+		})
+	}
+}
+
+// TestAuthorizeRefusesWithoutRecordedApproval is acceptance criterion 4: a technique whose risk class
+// requires approval cannot execute without a recorded approval.
+func TestAuthorizeRefusesWithoutRecordedApproval(t *testing.T) {
+	const technique = "exploit.default_credentials" // medium -> single
+	const target = "https://app.example.test"
+	cases := map[string][]Approval{
+		"no approvals at all": nil,
+		// A machine may propose an offensive plan; it may never approve one.
+		"machine principal": {{Approver: "system:dast-engine", Technique: technique, Target: target}},
+		"agent principal":   {{Approver: "agent:runner", Technique: technique, Target: target}},
+		// A signature collected for a different technique or target is not a signature for this one.
+		"approval for another technique": {{Approver: "alice", Technique: "recon.tls_inspect", Target: target}},
+		"approval for another target":    {{Approver: "alice", Technique: technique, Target: "https://other.example.test"}},
+		"blank approver":                 {{Approver: "   ", Technique: technique, Target: target}},
+	}
+	for name, approvals := range cases {
+		t.Run(name, func(t *testing.T) {
+			svc, sealer, audit := newService(t)
+			_, err := svc.Authorize(context.Background(), Request{
+				EngagementID: "eng-1", Technique: technique, Target: target,
+				Actor: "alice", RoE: completeRoE(), Now: testNow, Approvals: approvals,
+			})
+			if !errors.Is(err, shared.ErrForbidden) {
+				t.Fatalf("want forbidden, got %v", err)
+			}
+			if len(sealer.records) != 0 {
+				t.Error("an unapproved action must not seal an authorization")
+			}
+			if got := audit.last().Metadata["reason"]; got != "approval_missing" {
+				t.Errorf("refusal reason = %q, want approval_missing", got)
+			}
+		})
+	}
+}
+
+// TestAuthorizeRequiresTwoDistinctHumansForDualApproval: "dual" means two humans, not one human twice.
+func TestAuthorizeRequiresTwoDistinctHumansForDualApproval(t *testing.T) {
+	const technique = "exploit.web_shell_upload" // high -> dual
+	const target = "https://app.example.test"
+	svc, _, _ := newService(t)
+
+	// The same human twice, in different letter case, is still one human.
+	_, err := svc.Authorize(context.Background(), Request{
+		EngagementID: "eng-1", Technique: technique, Target: target, Actor: "alice",
+		RoE: completeRoE(), Now: testNow,
+		Approvals: []Approval{
+			{Approver: "alice", Technique: technique, Target: target},
+			{Approver: "ALICE", Technique: technique, Target: target},
+		},
+	})
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("one human signing twice must not satisfy dual approval, got %v", err)
+	}
+
+	decision, err := svc.Authorize(context.Background(), Request{
+		EngagementID: "eng-1", Technique: technique, Target: target, Actor: "alice",
+		RoE: completeRoE(), Now: testNow,
+		Approvals: []Approval{
+			{Approver: "alice", Technique: technique, Target: target},
+			{Approver: "bob", Technique: technique, Target: target},
+		},
+	})
+	if err != nil {
+		t.Fatalf("two distinct humans must satisfy dual approval: %v", err)
+	}
+	if len(decision.Approvers) != 2 {
+		t.Fatalf("decision records %d approvers, want 2: %+v", len(decision.Approvers), decision.Approvers)
+	}
+}
+
+// TestAuthorizeRefusesAboveTheEngagementRiskCeiling: the ceiling narrows the register and never widens
+// it, so a high-risk technique is refused by a medium-ceiling engagement even with dual approval.
+func TestAuthorizeRefusesAboveTheEngagementRiskCeiling(t *testing.T) {
+	svc, _, audit := newService(t)
+	roe := completeRoE()
+	roe.RiskCeiling = domain.RiskMedium
+	const technique = "exploit.web_shell_upload"
+	const target = "https://app.example.test"
+	_, err := svc.Authorize(context.Background(), Request{
+		EngagementID: "eng-1", Technique: technique, Target: target, Actor: "alice",
+		RoE: roe, Now: testNow,
+		Approvals: []Approval{
+			{Approver: "alice", Technique: technique, Target: target},
+			{Approver: "bob", Technique: technique, Target: target},
+		},
+	})
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("want forbidden above the ceiling, got %v", err)
+	}
+	if got := audit.last().Metadata["reason"]; got != "above_risk_ceiling" {
+		t.Errorf("refusal reason = %q, want above_risk_ceiling", got)
+	}
+}
+
+func TestAuthorizeRefusesOutsideTheWindow(t *testing.T) {
+	svc, _, audit := newService(t)
+	roe := completeRoE()
+	svc2 := svc
+	for name, now := range map[string]time.Time{
+		"before the window": roe.WindowStart.Add(-time.Minute),
+		"after the window":  roe.WindowEnd.Add(time.Minute),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := svc2.Authorize(context.Background(), Request{
+				EngagementID: "eng-1", Technique: "recon.service_banner", Target: "https://app.example.test",
+				Actor: "alice", RoE: roe, Now: now,
+			})
+			if !errors.Is(err, shared.ErrForbidden) {
+				t.Fatalf("want forbidden, got %v", err)
+			}
+			if got := audit.last().Metadata["reason"]; got != "outside_window" {
+				t.Errorf("refusal reason = %q, want outside_window", got)
+			}
+		})
+	}
+}
+
+// TestApprovalAppearsInTheEvidenceChain is acceptance criterion 7: approval appears in the evidence
+// chain for the action, not only in configuration. The document is explicit that a stored flag saying
+// "approved" is not an approval.
+func TestApprovalAppearsInTheEvidenceChain(t *testing.T) {
+	svc, sealer, audit := newService(t)
+	const technique = "exploit.default_credentials"
+	const target = "https://app.example.test"
+	roe := completeRoE()
+
+	decision, err := svc.Authorize(context.Background(), Request{
+		EngagementID: "eng-42", Technique: technique, Target: target, Actor: "alice",
+		RoE: roe, Now: testNow,
+		Approvals: []Approval{{Approver: "carol", Technique: technique, Target: target}},
+	})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if len(sealer.records) != 1 {
+		t.Fatalf("want exactly one sealed authorization, got %d", len(sealer.records))
+	}
+	rec := sealer.records[0]
+	if rec.engagementID != "eng-42" {
+		t.Errorf("sealed under engagement %q, want eng-42", rec.engagementID)
+	}
+	var sealed sealedAuthorization
+	if err := json.Unmarshal(rec.content, &sealed); err != nil {
+		t.Fatalf("sealed payload is not decodable: %v", err)
+	}
+	// Everything document 4 requires: the approving human, the technique, the target, the window, the
+	// timestamp.
+	if sealed.Technique != technique || sealed.Target != target {
+		t.Errorf("sealed technique/target = %q/%q", sealed.Technique, sealed.Target)
+	}
+	if len(sealed.Approvers) != 1 || sealed.Approvers[0] != "carol" {
+		t.Errorf("sealed approvers = %v, want [carol]", sealed.Approvers)
+	}
+	if !sealed.WindowStart.Equal(roe.WindowStart.UTC()) || !sealed.WindowEnd.Equal(roe.WindowEnd.UTC()) {
+		t.Errorf("sealed window = %v..%v", sealed.WindowStart, sealed.WindowEnd)
+	}
+	if !sealed.AuthorizedAt.Equal(testNow) {
+		t.Errorf("sealed timestamp = %v, want %v", sealed.AuthorizedAt, testNow)
+	}
+	if sealed.PolicyReviewed {
+		t.Error("the sealed record claims a recorded legal review; the shipped policy has none")
+	}
+	if decision.EvidenceID == "" {
+		t.Error("the decision does not carry the evidence id it was sealed under")
+	}
+	if got := audit.last(); got.Action != "offensive.authorized" || got.Metadata["evidence_id"] != decision.EvidenceID.String() {
+		t.Errorf("the authorization audit does not reference the evidence: %+v", got)
+	}
+}
+
+// TestAuthorizeRefusesWhenEvidenceCannotBeSealed: evidence that failed to seal is not evidence, so the
+// action is not authorized. This is the difference between approval-as-evidence and approval-as-config.
+func TestAuthorizeRefusesWhenEvidenceCannotBeSealed(t *testing.T) {
+	reg, err := domain.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealer := &fakeSealer{err: errors.New("evidence store unavailable")}
+	svc, err := NewService(reg, sealer, &fakeAudit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const technique = "exploit.default_credentials"
+	const target = "https://app.example.test"
+	_, err = svc.Authorize(context.Background(), Request{
+		EngagementID: "eng-1", Technique: technique, Target: target, Actor: "alice",
+		RoE: completeRoE(), Now: testNow,
+		Approvals: []Approval{{Approver: "carol", Technique: technique, Target: target}},
+	})
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("an unsealable authorization must be forbidden, got %v", err)
+	}
+}
+
+func TestAuthorizeRefusesWithoutATimestamp(t *testing.T) {
+	svc, _, audit := newService(t)
+	_, err := svc.Authorize(context.Background(), Request{
+		EngagementID: "eng-1", Technique: "recon.service_banner", Target: "https://app.example.test",
+		Actor: "alice", RoE: completeRoE(),
+	})
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("want forbidden, got %v", err)
+	}
+	if got := audit.last().Metadata["reason"]; got != "no_timestamp" {
+		t.Errorf("refusal reason = %q, want no_timestamp", got)
+	}
+}
+
+// TestAuthorizeAutomaticClassNeedsNoSignatureButIsStillSealed: an automatic technique runs without a
+// per-action human decision, and is still recorded. "No approval needed" is not "no record needed".
+func TestAuthorizeAutomaticClassNeedsNoSignatureButIsStillSealed(t *testing.T) {
+	svc, sealer, audit := newService(t)
+	decision, err := svc.Authorize(context.Background(), Request{
+		EngagementID: "eng-1", Technique: "recon.service_banner", Target: "https://app.example.test",
+		Actor: "alice", RoE: completeRoE(), Now: testNow,
+	})
+	if err != nil {
+		t.Fatalf("an automatic-class technique inside scope must be permitted: %v", err)
+	}
+	if decision.Approval != domain.ApprovalAutomatic || len(decision.Approvers) != 0 {
+		t.Errorf("decision = %+v, want automatic with no approvers", decision)
+	}
+	if len(sealer.records) != 1 {
+		t.Fatalf("an automatic authorization must still be sealed, got %d records", len(sealer.records))
+	}
+	if got := audit.actions(); len(got) != 1 || got[0] != "offensive.authorized" {
+		t.Errorf("audit actions = %v", got)
+	}
+}

--- a/internal/usecase/offensivepolicy/evidence.go
+++ b/internal/usecase/offensivepolicy/evidence.go
@@ -1,0 +1,35 @@
+package offensivepolicy
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// EvidenceChainSealer adapts the evidence service to EvidenceSealer, sealing under the one kind this
+// package documents so an auditor can find every offensive authorization by kind alone.
+type EvidenceChainSealer struct {
+	seal func(ctx context.Context, engagementID shared.ID, kind string, content []byte, createdBy string) (shared.ID, error)
+}
+
+// NewEvidenceChainSealer wires a seal function — normally a closure over *evidence.Service — into the
+// EvidenceSealer this package requires.
+//
+// A function rather than an interface because the evidence service returns a domain Evidence value whose
+// shape this package has no reason to know; the composition root already knows both sides, so it is the
+// right place to bridge them.
+func NewEvidenceChainSealer(seal func(ctx context.Context, engagementID shared.ID, kind string, content []byte, createdBy string) (shared.ID, error)) *EvidenceChainSealer {
+	return &EvidenceChainSealer{seal: seal}
+}
+
+var _ EvidenceSealer = (*EvidenceChainSealer)(nil)
+
+// SealOffensiveAuthorization seals the authorization under EvidenceKindAuthorization.
+func (e *EvidenceChainSealer) SealOffensiveAuthorization(ctx context.Context, engagementID shared.ID, content []byte, createdBy string) (shared.ID, error) {
+	if e == nil || e.seal == nil {
+		// Fail closed: a sealer that cannot seal must report failure, because Authorize treats a seal
+		// failure as a refusal and would otherwise grant a permission with no record.
+		return "", shared.ErrValidation
+	}
+	return e.seal(ctx, engagementID, EvidenceKindAuthorization, content, createdBy)
+}

--- a/internal/usecase/offensivepolicy/killswitch.go
+++ b/internal/usecase/offensivepolicy/killswitch.go
@@ -1,0 +1,188 @@
+package offensivepolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// HaltBound is the stated bound from the policy document 8: the control plane cancels every in-flight
+// offensive work order within this long.
+//
+// Read the document before changing it. This bounds the CONTROL PLANE, not the estate: an agent already
+// executing a technique learns of the cancellation on its next poll, so the estate-wide stop is this
+// bound plus one agent poll interval. Claiming otherwise would be false during the one incident where
+// the difference matters.
+const HaltBound = 5 * time.Second
+
+// OffensiveTechniques is the port the kill switch needs from a work order: whether it carries offensive
+// work at all. A work order for an SBOM scan is not halted by the red-team kill switch.
+type haltableStore interface {
+	ListByTenant(ctx context.Context, tenantID shared.ID) ([]*workorder.WorkOrder, error)
+	Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State, now time.Time) error
+}
+
+// HaltResult is what the operator gets back. It reports partial failure honestly: a halt that cancelled
+// nine of ten orders is not a clean halt, and saying so is the difference between an operator escalating
+// and an operator believing the estate is safe.
+type HaltResult struct {
+	RequestedAt time.Time
+	CompletedAt time.Time
+	Duration    time.Duration
+	WithinBound bool
+	Cancelled   []shared.ID
+	Failed      map[shared.ID]string
+	AuditFailed bool
+	// EstateStopNote states, in the response, what the bound does not cover. An operator reading only
+	// this field must not conclude the estate has stopped.
+	EstateStopNote string
+}
+
+// Halted reports whether every in-flight offensive order was cancelled.
+func (r HaltResult) Halted() bool { return len(r.Failed) == 0 }
+
+// KillSwitch halts all in-flight offensive work for a tenant.
+type KillSwitch struct {
+	orders      haltableStore
+	audit       ports.AuditLogger
+	isOffensive func(*workorder.WorkOrder) bool
+	now         func() time.Time
+}
+
+// NewKillSwitch builds the kill switch. isOffensive decides which work orders this switch governs; when
+// nil, every work order is treated as offensive.
+//
+// Defaulting to "everything is offensive" is deliberate. The alternative default — treat nothing as
+// offensive until a classifier says so — would make a misconfigured kill switch silently halt nothing,
+// and a kill switch that does less than the operator expects is the one failure this contract cannot
+// have. Halting more than necessary is recoverable; halting nothing during an incident is not.
+func NewKillSwitch(orders haltableStore, audit ports.AuditLogger, isOffensive func(*workorder.WorkOrder) bool, now func() time.Time) (*KillSwitch, error) {
+	if orders == nil || audit == nil {
+		return nil, fmt.Errorf("%w: kill switch requires a work order store and an audit log", shared.ErrValidation)
+	}
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	if isOffensive == nil {
+		isOffensive = func(*workorder.WorkOrder) bool { return true }
+	}
+	return &KillSwitch{orders: orders, audit: audit, isOffensive: isOffensive, now: now}, nil
+}
+
+// Halt cancels every in-flight offensive work order for the tenant.
+//
+// It is a single operator action, it is audited with the operator identity and reason, and it reports the
+// measured duration against the stated bound rather than asserting compliance.
+func (k *KillSwitch) Halt(ctx context.Context, tenantID shared.ID, actor, reason string) (HaltResult, error) {
+	if k == nil {
+		return HaltResult{}, fmt.Errorf("%w: kill switch is not configured", shared.ErrValidation)
+	}
+	if strings.TrimSpace(actor) == "" {
+		return HaltResult{}, fmt.Errorf("%w: a halt must name the operator", shared.ErrValidation)
+	}
+	if strings.TrimSpace(reason) == "" {
+		// A halt with no reason cannot be explained afterwards, and the document requires the reason to
+		// be part of the audit record.
+		return HaltResult{}, fmt.Errorf("%w: a halt must carry a reason", shared.ErrValidation)
+	}
+	started := k.now()
+	result := HaltResult{
+		RequestedAt: started.UTC(),
+		Failed:      map[shared.ID]string{},
+		EstateStopNote: fmt.Sprintf(
+			"control plane halted within %s; a technique already running on a host stops within one further agent poll interval",
+			HaltBound),
+	}
+
+	orders, err := k.orders.ListByTenant(ctx, tenantID)
+	if err != nil {
+		// The halt could not even enumerate what to stop. That is a failure to halt, and it must not
+		// return a result that reads like success.
+		k.recordAudit(ctx, actor, reason, tenantID, &result, "enumeration_failed")
+		return result, fmt.Errorf("%w: halt could not enumerate work orders: %v", shared.ErrSaturated, err)
+	}
+
+	for _, order := range orders {
+		if order == nil || order.State.Terminal() || !k.isOffensive(order) {
+			continue
+		}
+		err := k.orders.Transition(ctx, tenantID, order.ID, workorder.StateCancelled,
+			"offensive kill switch: "+reason, order.State, k.now().UTC())
+		switch {
+		case err == nil:
+			result.Cancelled = append(result.Cancelled, order.ID)
+		case errors.Is(err, shared.ErrConflict):
+			// The order moved underneath us — it was claimed, completed or already cancelled between the
+			// list and the transition. Re-read and retry once against its new state: a concurrent
+			// claim must not leave work running just because it raced the halt.
+			if retried := k.retryOnce(ctx, tenantID, order.ID, reason); retried != nil {
+				result.Failed[order.ID] = retried.Error()
+			} else {
+				result.Cancelled = append(result.Cancelled, order.ID)
+			}
+		default:
+			result.Failed[order.ID] = err.Error()
+		}
+	}
+
+	sort.Slice(result.Cancelled, func(i, j int) bool { return result.Cancelled[i] < result.Cancelled[j] })
+	result.CompletedAt = k.now().UTC()
+	result.Duration = result.CompletedAt.Sub(result.RequestedAt)
+	result.WithinBound = result.Duration <= HaltBound
+
+	// Audit LAST, so the record carries the measured outcome — but note that the halt already happened.
+	// A halt that cannot be audited is still a halt: stopping work matters more than recording it, and
+	// the result says the audit failed rather than claiming a clean halt.
+	k.recordAudit(ctx, actor, reason, tenantID, &result, "")
+	if !result.Halted() {
+		return result, fmt.Errorf("%w: halt failed for %d work order(s)", shared.ErrSaturated, len(result.Failed))
+	}
+	return result, nil
+}
+
+// retryOnce re-reads the order and cancels it from whatever state it now holds. It returns nil when the
+// order no longer needs cancelling.
+func (k *KillSwitch) retryOnce(ctx context.Context, tenantID, id shared.ID, reason string) error {
+	orders, err := k.orders.ListByTenant(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	for _, order := range orders {
+		if order == nil || order.ID != id {
+			continue
+		}
+		if order.State.Terminal() {
+			return nil // it reached a terminal state on its own; nothing left to halt
+		}
+		return k.orders.Transition(ctx, tenantID, id, workorder.StateCancelled,
+			"offensive kill switch: "+reason, order.State, k.now().UTC())
+	}
+	return nil // it is gone; nothing to halt
+}
+
+func (k *KillSwitch) recordAudit(ctx context.Context, actor, reason string, tenantID shared.ID, result *HaltResult, note string) {
+	meta := map[string]string{
+		"tenant":          tenantID.String(),
+		"reason":          reason,
+		"cancelled":       fmt.Sprint(len(result.Cancelled)),
+		"failed":          fmt.Sprint(len(result.Failed)),
+		"duration_ms":     fmt.Sprint(result.Duration.Milliseconds()),
+		"within_bound":    fmt.Sprint(result.WithinBound),
+		"stated_bound_ms": fmt.Sprint(HaltBound.Milliseconds()),
+	}
+	if note != "" {
+		meta["note"] = note
+	}
+	if err := k.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor, Action: "offensive.halt", Target: tenantID.String(), At: k.now().UTC(), Metadata: meta,
+	}); err != nil {
+		result.AuditFailed = true
+	}
+}

--- a/internal/usecase/offensivepolicy/killswitch_test.go
+++ b/internal/usecase/offensivepolicy/killswitch_test.go
@@ -1,0 +1,319 @@
+package offensivepolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/workorder"
+)
+
+// fakeOrders is an in-memory work order store with a real mutex, so a test can run concurrent claims
+// against a halt and observe the interleaving rather than assuming it.
+type fakeOrders struct {
+	mu         sync.Mutex
+	orders     map[shared.ID]*workorder.WorkOrder
+	listErr    error
+	transDelay time.Duration
+	transCalls int64
+	transErr   map[shared.ID]error
+}
+
+func newFakeOrders(states ...workorder.State) *fakeOrders {
+	f := &fakeOrders{orders: map[shared.ID]*workorder.WorkOrder{}, transErr: map[shared.ID]error{}}
+	for i, st := range states {
+		id := shared.ID(fmt.Sprintf("wo-%02d", i))
+		f.orders[id] = &workorder.WorkOrder{ID: id, TenantID: "t1", State: st}
+	}
+	return f
+}
+
+func (f *fakeOrders) ListByTenant(_ context.Context, tenantID shared.ID) ([]*workorder.WorkOrder, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]*workorder.WorkOrder, 0, len(f.orders))
+	for _, o := range f.orders {
+		if o.TenantID != tenantID {
+			continue
+		}
+		copied := *o
+		out = append(out, &copied)
+	}
+	return out, nil
+}
+
+func (f *fakeOrders) Transition(_ context.Context, _, id shared.ID, to workorder.State, _ string, expected workorder.State, _ time.Time) error {
+	atomic.AddInt64(&f.transCalls, 1)
+	if f.transDelay > 0 {
+		time.Sleep(f.transDelay)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err, ok := f.transErr[id]; ok && err != nil {
+		return err
+	}
+	order, ok := f.orders[id]
+	if !ok {
+		return shared.ErrNotFound
+	}
+	// Optimistic concurrency, exactly as the real store enforces it: a state that moved underneath the
+	// caller is a conflict, not a silent overwrite.
+	if order.State != expected {
+		return fmt.Errorf("%w: work order %s is %s, expected %s", shared.ErrConflict, id, order.State, expected)
+	}
+	if !workorder.CanTransition(order.State, to) {
+		return fmt.Errorf("%w: %s -> %s is not a legal transition", shared.ErrValidation, order.State, to)
+	}
+	order.State = to
+	return nil
+}
+
+func (f *fakeOrders) state(id shared.ID) workorder.State {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if o, ok := f.orders[id]; ok {
+		return o.State
+	}
+	return ""
+}
+
+// TestHaltCancelsInFlightWithinBound is acceptance criterion 5: the kill switch halts in-flight work
+// within the stated bound, MEASURED under concurrent work, and the halt is audited.
+//
+// The bound is measured from real elapsed time rather than a fake clock: the requirement is a bound on
+// the operator's wait, and a fake clock could report any duration it liked.
+func TestHaltCancelsInFlightWithinBound(t *testing.T) {
+	// A mix of in-flight and already-terminal orders, so the halt has to select rather than cancel
+	// everything blindly.
+	orders := newFakeOrders(
+		workorder.StateIssued, workorder.StateClaimed, workorder.StateRunning,
+		workorder.StateIssued, workorder.StateRunning, workorder.StateClaimed,
+		workorder.StateSucceeded, workorder.StateFailed, workorder.StateCancelled,
+	)
+	// A small per-transition delay so the halt is doing real concurrent work rather than completing
+	// instantly and passing the bound trivially.
+	orders.transDelay = 2 * time.Millisecond
+	audit := &fakeAudit{}
+	ks, err := NewKillSwitch(orders, audit, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Concurrent claims racing the halt: work continues to arrive while the operator pulls the switch.
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = orders.Transition(context.Background(), "t1", "wo-00", workorder.StateClaimed, "racing claim", workorder.StateIssued, time.Now())
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	start := time.Now()
+	result, err := ks.Halt(context.Background(), "t1", "operator@example.test", "customer requested an immediate stop")
+	elapsed := time.Since(start)
+	close(stop)
+	wg.Wait()
+
+	if err != nil {
+		t.Fatalf("halt failed: %v (failed orders: %v)", err, result.Failed)
+	}
+	if elapsed > HaltBound {
+		t.Fatalf("halt took %s, above the stated bound of %s", elapsed, HaltBound)
+	}
+	if !result.WithinBound {
+		t.Errorf("result does not report itself within bound: duration=%s", result.Duration)
+	}
+	if len(result.Cancelled) != 6 {
+		t.Fatalf("cancelled %d orders, want the 6 in-flight ones: %v", len(result.Cancelled), result.Cancelled)
+	}
+	// Every in-flight order is terminal now; the already-terminal ones were untouched.
+	for _, id := range []shared.ID{"wo-00", "wo-01", "wo-02", "wo-03", "wo-04", "wo-05"} {
+		if got := orders.state(id); got != workorder.StateCancelled {
+			t.Errorf("%s = %s, want cancelled", id, got)
+		}
+	}
+	if got := orders.state("wo-06"); got != workorder.StateSucceeded {
+		t.Errorf("a succeeded order must not be touched by the halt, got %s", got)
+	}
+
+	// Audited with the operator identity, the reason, and the MEASURED duration against the bound.
+	last := audit.last()
+	if last.Action != "offensive.halt" || last.Actor != "operator@example.test" {
+		t.Fatalf("halt audit = %+v", last)
+	}
+	if last.Metadata["reason"] == "" || last.Metadata["duration_ms"] == "" || last.Metadata["within_bound"] != "true" {
+		t.Errorf("halt audit does not carry reason and measured duration: %+v", last.Metadata)
+	}
+	if last.Metadata["stated_bound_ms"] != fmt.Sprint(HaltBound.Milliseconds()) {
+		t.Errorf("halt audit does not record the bound it was measured against: %+v", last.Metadata)
+	}
+	// The response must state what the bound does NOT cover, so an operator reading it cannot conclude
+	// the estate has stopped.
+	if result.EstateStopNote == "" {
+		t.Error("the halt result does not state the estate-stop caveat")
+	}
+}
+
+// TestHaltRetriesAnOrderThatRacedTheSwitch: an order claimed between the list and the transition must
+// still be cancelled. Leaving work running because it raced the halt is the failure this contract cannot
+// have.
+func TestHaltRetriesAnOrderThatRacedTheSwitch(t *testing.T) {
+	orders := newFakeOrders(workorder.StateIssued)
+	audit := &fakeAudit{}
+	ks, err := NewKillSwitch(orders, audit, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Move it out from under the halt exactly once, after the list and before the transition.
+	orders.mu.Lock()
+	orders.orders["wo-00"].State = workorder.StateIssued
+	orders.mu.Unlock()
+	go func() {
+		time.Sleep(time.Millisecond)
+		_ = orders.Transition(context.Background(), "t1", "wo-00", workorder.StateClaimed, "race", workorder.StateIssued, time.Now())
+	}()
+	orders.transDelay = 5 * time.Millisecond
+
+	result, err := ks.Halt(context.Background(), "t1", "operator", "stop now")
+	if err != nil {
+		t.Fatalf("halt must recover from a racing claim: %v (failed: %v)", err, result.Failed)
+	}
+	if got := orders.state("wo-00"); got != workorder.StateCancelled {
+		t.Fatalf("an order that raced the halt is %s, want cancelled", got)
+	}
+}
+
+// TestHaltReportsPartialFailureRatherThanClaimingSuccess: nine of ten cancelled is not a clean halt, and
+// an operator who believes it is will not escalate.
+func TestHaltReportsPartialFailureRatherThanClaimingSuccess(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning, workorder.StateRunning)
+	orders.transErr["wo-01"] = errors.New("database unreachable")
+	audit := &fakeAudit{}
+	ks, err := NewKillSwitch(orders, audit, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := ks.Halt(context.Background(), "t1", "operator", "stop")
+	if err == nil {
+		t.Fatal("a halt that could not cancel every order must return an error")
+	}
+	if result.Halted() {
+		t.Error("Halted() reports success while an order failed to cancel")
+	}
+	if len(result.Failed) != 1 {
+		t.Errorf("failed = %v, want exactly wo-01", result.Failed)
+	}
+	if len(result.Cancelled) != 1 {
+		t.Errorf("cancelled = %v, want the one that succeeded", result.Cancelled)
+	}
+	if got := audit.last().Metadata["failed"]; got != "1" {
+		t.Errorf("the audit does not record the failure count, got %q", got)
+	}
+}
+
+// TestHaltFailsWhenItCannotEnumerate: a halt that cannot list what to stop has not halted anything, and
+// must not return a result that reads like success.
+func TestHaltFailsWhenItCannotEnumerate(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning)
+	orders.listErr = errors.New("database unreachable")
+	audit := &fakeAudit{}
+	ks, _ := NewKillSwitch(orders, audit, nil, nil)
+
+	result, err := ks.Halt(context.Background(), "t1", "operator", "stop")
+	if err == nil {
+		t.Fatal("a halt that cannot enumerate work orders must fail")
+	}
+	if len(result.Cancelled) != 0 {
+		t.Error("a failed enumeration must not report cancellations")
+	}
+	if got := audit.last().Metadata["note"]; got != "enumeration_failed" {
+		t.Errorf("the audit does not say why the halt failed, got %q", got)
+	}
+}
+
+// TestHaltIsStillPerformedWhenAuditFails: stopping work matters more than recording it, and the result
+// says the audit failed rather than claiming a clean halt.
+func TestHaltIsStillPerformedWhenAuditFails(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning)
+	audit := &fakeAudit{err: errors.New("audit log unavailable")}
+	ks, _ := NewKillSwitch(orders, audit, nil, nil)
+
+	result, err := ks.Halt(context.Background(), "t1", "operator", "stop")
+	if err != nil {
+		t.Fatalf("the halt itself must succeed even when the audit fails: %v", err)
+	}
+	if got := orders.state("wo-00"); got != workorder.StateCancelled {
+		t.Fatalf("work was not halted: %s", got)
+	}
+	if !result.AuditFailed {
+		t.Error("the result must report that the halt could not be audited")
+	}
+}
+
+// TestHaltRequiresAnOperatorAndAReason: a halt that cannot be explained afterwards defeats the chain of
+// custody this policy claims.
+func TestHaltRequiresAnOperatorAndAReason(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning)
+	ks, _ := NewKillSwitch(orders, &fakeAudit{}, nil, nil)
+	for name, call := range map[string]func() error{
+		"no operator": func() error { _, err := ks.Halt(context.Background(), "t1", "  ", "stop"); return err },
+		"no reason":   func() error { _, err := ks.Halt(context.Background(), "t1", "operator", " "); return err },
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := call(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want a validation error, got %v", err)
+			}
+			if got := orders.state("wo-00"); got != workorder.StateRunning {
+				t.Errorf("a refused halt must not change work order state, got %s", got)
+			}
+		})
+	}
+}
+
+// TestHaltOnlyTouchesOffensiveWork: an SBOM scan is not halted by the red-team kill switch.
+func TestHaltOnlyTouchesOffensiveWork(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning, workorder.StateRunning)
+	offensive := func(o *workorder.WorkOrder) bool { return o.ID == "wo-00" }
+	ks, _ := NewKillSwitch(orders, &fakeAudit{}, offensive, nil)
+
+	if _, err := ks.Halt(context.Background(), "t1", "operator", "stop"); err != nil {
+		t.Fatal(err)
+	}
+	if got := orders.state("wo-00"); got != workorder.StateCancelled {
+		t.Errorf("offensive order = %s, want cancelled", got)
+	}
+	if got := orders.state("wo-01"); got != workorder.StateRunning {
+		t.Errorf("non-offensive order = %s, want untouched", got)
+	}
+}
+
+// TestHaltDefaultsToTreatingEveryOrderAsOffensive pins the deliberate default: a misconfigured kill
+// switch halts too much rather than nothing. Halting more than necessary is recoverable; halting nothing
+// during an incident is not.
+func TestHaltDefaultsToTreatingEveryOrderAsOffensive(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning, workorder.StateIssued)
+	ks, _ := NewKillSwitch(orders, &fakeAudit{}, nil, nil)
+	result, err := ks.Halt(context.Background(), "t1", "operator", "stop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Cancelled) != 2 {
+		t.Fatalf("with no classifier every in-flight order must be halted, cancelled %v", result.Cancelled)
+	}
+}


### PR DESCRIPTION
Closes #418. Phase 4, Track D of #405.

This lands the governance artifact **before** any offensive engine code, which is what #418 asked for — and it is overdue rather than early: #419 already shipped, so the platform can enumerate attack paths across a customer estate while there was no written contract for what it may execute along them. #420 and #421 are both blocked on this by the epic's own sequencing.

## What is here

| | |
|---|---|
| `docs/redteam/offensive-policy.md` | The reviewed artifact: prohibited categories, risk scale, approval matrix, rules-of-engagement fields, data handling, blast radius/cleanup, kill-switch contract, dry run, change control |
| `internal/domain/offensivepolicy` | The register the code enforces, embedded as `policy.yaml`, plus the **drift test** against the document |
| `internal/usecase/offensivepolicy` | Enforcement, kill switch, dry run |
| `POST /api/v1/redteam/halt` | The kill switch, `PermAdminister` |

## The register is an allowlist

**A technique absent from it is refused.** The set of things an offensive engine could attempt is unbounded; the set it has been authorised to attempt is not. `Load()` is the only constructor and it validates, so an unvalidated policy cannot exist — one would look authoritative while permitting whatever it happened to contain.

Validation runs in CI rather than at execution time and refuses:

- a **state-changing** technique with no cleanup steps or no verification (document §7 — discovering an unreversible action at runtime means it has already run);
- a hand-written risk class **softer than its two axes reduce to**, which would silently lower the approval requirement;
- an approval mode contradicting the §4 matrix, or **any** approval mode on a prohibited technique — allowing one would imply some signature could authorise it, and none can;
- `production_safe` before a recorded legal review;
- an **unknown YAML field**, because a policy field silently ignored is a control that silently does not exist.

The three prohibited entries are in the register **on purpose**. Omitting them would make them merely unknown, and the enforcement path would refuse them as "no register entry" — indistinguishable from a technique nobody has classified yet. Naming them records that they were considered and excluded, which is what a governance artifact is for.

## Drift is a build failure

The document is the source of truth; `policy.yaml` mirrors it. The drift test compares **both directions** — an entry in one and not the other, and every field. Two artifacts that must agree will eventually disagree unless something fails the build, and a register that has drifted from the reviewed text is worse than having only the text, because the code enforces the copy nobody reviewed.

Verified by mutation, not by assertion: softening a class, adding a register entry absent from the document, and deleting a document row each fail the build.

## Approval is evidence, not configuration

The technique, target, approvers, window and timestamp are sealed **before** a permission is returned, and a seal failure is a refusal. Evidence that failed to seal is not evidence — that is the whole distinction the document draws.

Dual approval means two **distinct** humans: one human signing twice, in any letter case, does not satisfy it, and no machine principal ever satisfies it. AI may propose an offensive plan; it may not approve one.

Refusal order is deliberate — register lookup, then prohibited category, before anything about the engagement is consulted. Nothing about an engagement can make a prohibited technique permissible, so asking about approvals first would imply otherwise.

## The kill switch measures its bound

`HaltBound` is 5s and the test measures **real elapsed time** under concurrent claims racing the halt, because a fake clock could report any duration it liked. An order claimed between the list and the transition is retried once against its new state: leaving work running because it raced the halt is the one failure this contract cannot have.

Three honesty properties:

- **Partial failure is reported as failure.** Nine of ten cancelled is not a clean halt, and an operator who believes it is will not escalate. The 500 carries the partial result naming the orders still in flight.
- **A failed enumeration is a failed halt**, not an empty success.
- **`estate_stop_note` is part of the response**, because the bound covers the *control plane*. A technique already running on a host stops within one further agent poll interval, and an operator reading only `halted: true` must not conclude every host has stopped. Claiming a 5-second estate-wide stop would be false during the one incident where the difference matters.

With no classifier the switch treats **every** order as offensive. Halting more than necessary is recoverable; halting nothing during an incident is not.

`PermAdminister`, not `PermOperate`: the person who can run offensive work should not be the only one who can stop it. A machine principal cannot pull it either — an agent that can halt the fleet can also halt an authorised assessment.

## Dry run holds no executor

"Executes nothing" is **structural**, not a matter of remembering: the service has no executor to call. `TestPlanExecutesNothing` still asserts it with an executor that fails the test if invoked, and also asserts the dry run seals no evidence and writes no audit — nothing happened, and recording a permission no action used would put a stray approval in the chain. Counts are stated so a UI cannot render "5 steps" while 3 would be refused.

## Acceptance criteria

- [x] Policy document merged and reviewed, excluded categories named explicitly *(review status is recorded as **Not reviewed**, with a named owner — see below)*
- [x] Machine-readable policy validated against the document in CI; drift fails the build
- [x] A technique with no policy entry is refused, verified by test
- [x] A technique whose risk class requires approval cannot execute without a recorded approval, verified by test
- [x] Kill switch halts in-flight work within the stated bound, measured with concurrent work, and the halt is audited
- [x] A state-changing technique with no cleanup path fails a CI check rather than a runtime check
- [x] Approval appears in the evidence chain, not only in configuration
- [x] Dry run enumerates the plan and executes nothing, asserted by a test that fails if any execution occurs

**On the legal review, stated plainly:** I cannot perform one. The document records the status as **Not reviewed** with a named owner and a change-control rule, and the register refuses `production_safe` for every technique until a reviewer records a date — enforced by `TestRegisterRefusesProductionSafeBeforeLegalReview`. That is the honest state, and it is a real one: no technique here can be marked production-safe. Assigning counsel and recording the date is the remaining human step, and it is the reason I would keep #418 open for that box rather than close the issue on merge.

## Verification, CI being disabled

```
go build ./...              ok      CGO_ENABLED=0 go build ./...   ok
go vet ./...                ok      golangci-lint                  0 issues
go test ./... (real Postgres 17)    green apart from the known dastengine timing flake
go test -race (both new packages)   green
```

Every guard was mutation-tested. Permitting an unregistered technique, allowing a prohibited one through, dropping the approval requirement, and letting machine principals approve each fail the intended test.

**Two things my own tests caught in my own code, worth recording:**

1. `RiskCeilingPermits` had a **fail-open**: an unset ceiling ranked above every class, so a missing engagement field was the most permissive setting available — exactly the shape this package exists to prevent. An unknown ceiling now permits nothing.
2. Mutating the approval guard produced a **panic** (`approvers[:need]` with fewer approvers) rather than a refusal. A panic in an authorization path is worse than a refusal, so the function now returns every valid approver instead of slicing — which also records more evidence.

## Notes

- The artifact lives at `docs/redteam/` rather than `docs/guide/`, so it is not on the published site. That is deliberate: CI verifies it against the register, and the reviewed text belongs next to the register it must change with. `docs/guide/security.md` links to it.
- Three unrelated files were reformatted by a directory-wide `gofmt -w` and have been reverted out of this PR; they were already unformatted on `main` and deserve their own change.
