### PR TITLE
feat(redteam): record the offensive-policy review at two authority levels (closes #418)

### DIFF
--- a/docs/redteam/offensive-policy.md
+++ b/docs/redteam/offensive-policy.md
@@ -8,12 +8,14 @@ The differentiator this platform claims is not proof of exploitation — Horizon
 
 | Field | Value |
 |---|---|
-| Legal review status | **Not reviewed** |
-| Legal review date | — |
-| Review owner | Repository maintainer (`nghiadaulau`) until a named counsel is assigned |
+| Policy adoption (governance) | **Reviewed and adopted 2026-08-10** by `nghiadaulau` (repository maintainer, accountable owner) |
+| External legal counsel review | **Pending** — no counsel assigned; production clearance is gated on this |
+| Review owner | `nghiadaulau` |
 | Enforcement | `internal/domain/offensivepolicy` (register) + `internal/usecase/offensivepolicy` (enforcement, kill switch) |
 
-**Not reviewed is a real state, not a placeholder.** No technique in this register is marked production-safe while the review status is *Not reviewed*; `ProductionSafe` is refused for every entry until a named reviewer records a date here. That refusal is enforced by test, not by convention — see `TestRegisterRefusesProductionSafeBeforeLegalReview`.
+**These are two levels of authority and they are not interchangeable.** Adoption means the accountable owner has reviewed this policy and put it in force — a real, dated review event, recorded rather than asserted. It is *not* an external legal opinion.
+
+**Production clearance is gated on counsel review, not on adoption.** No technique in this register is marked production-safe while the external legal counsel review is *Pending*; `ProductionSafe` is refused for every entry until counsel records a date, and a maintainer adopting the policy cannot lift that gate. The refusal is enforced by test, not by convention — see `TestRegisterRefusesProductionSafeBeforeCounselReview`. This is deliberate: the owner can put the governance rules in force, but only counsel can clear a technique to run against a customer's production estate.
 
 ## 1. Scope and authority
 

--- a/internal/domain/offensivepolicy/policy.go
+++ b/internal/domain/offensivepolicy/policy.go
@@ -140,12 +140,25 @@ type TechniquePolicy struct {
 	ProductionSafe bool          `yaml:"production_safe"`
 }
 
-// LegalReview records the document's review status. ProductionSafe is refused for every technique while
-// Reviewed is false, so a register cannot quietly claim production readiness ahead of the review.
+// LegalReview records the policy's review status at TWO distinct levels, because they carry different
+// authority and conflating them would let the weaker one unlock what only the stronger should.
+//
+//   - Reviewed / Date / Owner: governance adoption. The accountable owner has reviewed the policy and
+//     put it in force. This is a real, dated review event — but it is the maintainer's adoption, not an
+//     external legal opinion.
+//   - CounselReviewed / CounselDate / CounselReviewer: external legal counsel review.
+//
+// ProductionSafe is gated on CounselReviewed, NOT on Reviewed. Adopting the governance policy puts it in
+// force; it does not by itself clear any technique to run against a customer's production estate. Only a
+// recorded counsel review lifts that gate, so a maintainer cannot self-authorise production use.
 type LegalReview struct {
-	Reviewed bool   `yaml:"reviewed"`
-	Date     string `yaml:"date"`
-	Owner    string `yaml:"owner"`
+	Reviewed        bool   `yaml:"reviewed"`
+	Date            string `yaml:"date"`
+	Owner           string `yaml:"owner"`
+	Reviewer        string `yaml:"reviewer"`
+	CounselReviewed bool   `yaml:"counsel_reviewed"`
+	CounselDate     string `yaml:"counsel_date"`
+	CounselReviewer string `yaml:"counsel_reviewer"`
 }
 
 // Register is the whole policy: the review status plus every classified technique.
@@ -220,12 +233,20 @@ func (r *Register) Validate() error {
 		if err := t.validateCleanup(name); err != nil {
 			return err
 		}
-		if t.ProductionSafe && !r.LegalReview.Reviewed {
-			return fmt.Errorf("%w: %s is marked production-safe before the legal review is recorded", shared.ErrValidation, name)
+		// Production clearance is gated on EXTERNAL COUNSEL review, not on the maintainer's adoption of
+		// the policy. Adopting the governance artifact does not clear a technique to run against a
+		// customer's production estate, so a maintainer cannot self-authorise it.
+		if t.ProductionSafe && !r.LegalReview.CounselReviewed {
+			return fmt.Errorf("%w: %s is marked production-safe before external legal counsel review is recorded", shared.ErrValidation, name)
 		}
 	}
-	if r.LegalReview.Reviewed && (strings.TrimSpace(r.LegalReview.Date) == "" || strings.TrimSpace(r.LegalReview.Owner) == "") {
-		return fmt.Errorf("%w: a recorded legal review needs both a date and an owner", shared.ErrValidation)
+	if r.LegalReview.Reviewed && (strings.TrimSpace(r.LegalReview.Date) == "" ||
+		strings.TrimSpace(r.LegalReview.Owner) == "" || strings.TrimSpace(r.LegalReview.Reviewer) == "") {
+		return fmt.Errorf("%w: a recorded policy adoption needs a date, an owner and a reviewer", shared.ErrValidation)
+	}
+	if r.LegalReview.CounselReviewed && (strings.TrimSpace(r.LegalReview.CounselDate) == "" ||
+		strings.TrimSpace(r.LegalReview.CounselReviewer) == "") {
+		return fmt.Errorf("%w: a recorded counsel review needs both a date and a named reviewer", shared.ErrValidation)
 	}
 	return nil
 }

--- a/internal/domain/offensivepolicy/policy.yaml
+++ b/internal/domain/offensivepolicy/policy.yaml
@@ -7,9 +7,18 @@
 # default, and the reason this list is short: entries are added when a technique is classified, not in
 # advance.
 legal_review:
-  reviewed: false
-  date: ""
-  owner: "Repository maintainer (nghiadaulau) until a named counsel is assigned"
+  # Governance adoption: the accountable owner reviewed this policy and put it in force. A real, dated
+  # review event -- but the maintainer's adoption, NOT external legal counsel.
+  reviewed: true
+  date: "2026-08-10"
+  owner: "nghiadaulau"
+  reviewer: "nghiadaulau (repository maintainer, accountable owner)"
+  # External legal counsel review. Still pending, and production_safe is gated on THIS rather than on
+  # adoption above -- so no technique may be marked production-safe until counsel signs off, regardless
+  # of who adopted the policy.
+  counsel_reviewed: false
+  counsel_date: ""
+  counsel_reviewer: ""
 
 techniques:
   - technique: recon.service_banner

--- a/internal/domain/offensivepolicy/policy_gen_test.go
+++ b/internal/domain/offensivepolicy/policy_gen_test.go
@@ -99,9 +99,16 @@ func TestLegalReviewStatusMatchesDocument(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load embedded register: %v", err)
 	}
-	docReviewed := !strings.Contains(raw, "| Legal review status | **Not reviewed** |")
-	if docReviewed != reg.LegalReview.Reviewed {
-		t.Fatalf("legal review status: register reviewed=%v, document reviewed=%v", reg.LegalReview.Reviewed, docReviewed)
+	// Both levels must agree with the document, in both directions. The register unlocks production
+	// clearance on counsel review, so a register that claimed counsel had reviewed while the document
+	// said "Pending" would open a gate the document says is shut.
+	docAdopted := strings.Contains(raw, "| Policy adoption (governance) | **Reviewed and adopted")
+	if docAdopted != reg.LegalReview.Reviewed {
+		t.Fatalf("adoption status: register reviewed=%v, document adopted=%v", reg.LegalReview.Reviewed, docAdopted)
+	}
+	docCounselPending := strings.Contains(raw, "| External legal counsel review | **Pending**")
+	if docCounselPending == reg.LegalReview.CounselReviewed {
+		t.Fatalf("counsel status: register counsel_reviewed=%v, document says pending=%v", reg.LegalReview.CounselReviewed, docCounselPending)
 	}
 }
 

--- a/internal/domain/offensivepolicy/policy_test.go
+++ b/internal/domain/offensivepolicy/policy_test.go
@@ -119,9 +119,11 @@ func TestRegisterRejectsApprovableProhibitedTechnique(t *testing.T) {
 	}
 }
 
-// TestRegisterRefusesProductionSafeBeforeLegalReview is referenced by name in the policy document's
-// Status section: "Not reviewed is a real state, not a placeholder."
-func TestRegisterRefusesProductionSafeBeforeLegalReview(t *testing.T) {
+// TestRegisterRefusesProductionSafeBeforeCounselReview is referenced by name in the policy document's
+// Status section. Production clearance is gated on EXTERNAL COUNSEL review, and the shipped register
+// records only maintainer adoption (counsel_reviewed: false) — so marking any technique production-safe
+// must still fail, proving that a maintainer adopting the policy does not lift the production gate.
+func TestRegisterRefusesProductionSafeBeforeCounselReview(t *testing.T) {
 	err := mutate(t, `    blast_radius: read_only
     cleanup:
       steps: []
@@ -131,8 +133,52 @@ func TestRegisterRefusesProductionSafeBeforeLegalReview(t *testing.T) {
       steps: []
       verification: ""
     production_safe: true`)
-	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "production-safe before the legal review") {
-		t.Fatalf("production-safe before a recorded legal review must fail validation, got %v", err)
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "before external legal counsel review") {
+		t.Fatalf("production-safe before a recorded counsel review must fail validation, got %v", err)
+	}
+}
+
+// TestAdoptionAloneDoesNotClearProductionSafe is the important negative: the shipped register IS adopted
+// (reviewed: true), and that must NOT be enough. If a future edit ever re-gated production_safe on
+// adoption instead of counsel, this fails.
+func TestAdoptionAloneDoesNotClearProductionSafe(t *testing.T) {
+	reg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reg.LegalReview.Reviewed {
+		t.Fatal("fixture expects the shipped policy to be adopted")
+	}
+	if reg.LegalReview.CounselReviewed {
+		t.Fatal("fixture expects counsel review to still be pending")
+	}
+	// Marking a technique production-safe under adoption-but-not-counsel must be refused.
+	if err := mutate(t, "    production_safe: false", "    production_safe: true"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("adoption alone must not clear production-safe, got %v", err)
+	}
+}
+
+// TestRecordedAdoptionNeedsDateOwnerAndReviewer: a recorded adoption that omits any of the three is not
+// a review, it is a claim.
+func TestRecordedAdoptionNeedsDateOwnerAndReviewer(t *testing.T) {
+	if err := mutate(t, `  date: "2026-08-10"`, `  date: ""`); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("adoption without a date must fail, got %v", err)
+	}
+	if err := mutate(t, `  reviewer: "nghiadaulau (repository maintainer, accountable owner)"`, `  reviewer: ""`); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("adoption without a reviewer must fail, got %v", err)
+	}
+}
+
+// TestRecordedCounselReviewNeedsDateAndReviewer: if counsel review is ever recorded, it must carry who
+// and when, or it unlocks production clearance on an anonymous, undated claim.
+func TestRecordedCounselReviewNeedsDateAndReviewer(t *testing.T) {
+	err := mutate(t, `  counsel_reviewed: false
+  counsel_date: ""
+  counsel_reviewer: ""`, `  counsel_reviewed: true
+  counsel_date: ""
+  counsel_reviewer: ""`)
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "counsel review needs") {
+		t.Fatalf("a recorded counsel review without a date and reviewer must fail, got %v", err)
 	}
 }
 

--- a/internal/usecase/offensivepolicy/enforce.go
+++ b/internal/usecase/offensivepolicy/enforce.go
@@ -115,17 +115,20 @@ type Decision struct {
 // sealedAuthorization is the evidence payload. It carries exactly what document 4 requires: the
 // approving humans, the technique, the target, the window and the timestamp.
 type sealedAuthorization struct {
-	Technique      string    `json:"technique"`
-	Target         string    `json:"target"`
-	RiskClass      string    `json:"risk_class"`
-	Approval       string    `json:"approval_mode"`
-	BlastRadius    string    `json:"blast_radius"`
-	Approvers      []string  `json:"approvers"`
-	WindowStart    time.Time `json:"window_start"`
-	WindowEnd      time.Time `json:"window_end"`
-	AuthorizedAt   time.Time `json:"authorized_at"`
-	Actor          string    `json:"actor"`
-	PolicyReviewed bool      `json:"policy_legal_review_recorded"`
+	Technique    string    `json:"technique"`
+	Target       string    `json:"target"`
+	RiskClass    string    `json:"risk_class"`
+	Approval     string    `json:"approval_mode"`
+	BlastRadius  string    `json:"blast_radius"`
+	Approvers    []string  `json:"approvers"`
+	WindowStart  time.Time `json:"window_start"`
+	WindowEnd    time.Time `json:"window_end"`
+	AuthorizedAt time.Time `json:"authorized_at"`
+	Actor        string    `json:"actor"`
+	// Both review levels are sealed, because an auditor of the action needs to know not just that a
+	// policy governed it but which authority stood behind that policy at the time.
+	PolicyAdopted         bool `json:"policy_adopted"`
+	PolicyCounselReviewed bool `json:"policy_counsel_reviewed"`
 }
 
 // EvidenceSealer is the narrow consumer-side interface this package needs: seal a payload and tell me
@@ -210,7 +213,7 @@ func (s *Service) Authorize(ctx context.Context, req Request) (Decision, error) 
 		Approval: string(policy.Approval), BlastRadius: string(policy.BlastRadius),
 		Approvers: approvers, WindowStart: req.RoE.WindowStart.UTC(), WindowEnd: req.RoE.WindowEnd.UTC(),
 		AuthorizedAt: now.UTC(), Actor: req.Actor,
-		PolicyReviewed: s.register.LegalReview.Reviewed,
+		PolicyAdopted: s.register.LegalReview.Reviewed, PolicyCounselReviewed: s.register.LegalReview.CounselReviewed,
 	})
 	if err != nil {
 		return Decision{}, fmt.Errorf("marshal offensive authorization: %w", err)

--- a/internal/usecase/offensivepolicy/enforce_test.go
+++ b/internal/usecase/offensivepolicy/enforce_test.go
@@ -345,8 +345,14 @@ func TestApprovalAppearsInTheEvidenceChain(t *testing.T) {
 	if !sealed.AuthorizedAt.Equal(testNow) {
 		t.Errorf("sealed timestamp = %v, want %v", sealed.AuthorizedAt, testNow)
 	}
-	if sealed.PolicyReviewed {
-		t.Error("the sealed record claims a recorded legal review; the shipped policy has none")
+	// The shipped policy is adopted by the maintainer but has no counsel review, and the seal must
+	// record that pair honestly: an auditor reading the evidence must be able to tell that no external
+	// counsel stood behind the action.
+	if !sealed.PolicyAdopted {
+		t.Error("the sealed record does not reflect that the policy is adopted")
+	}
+	if sealed.PolicyCounselReviewed {
+		t.Error("the sealed record claims a counsel review; the shipped policy has none")
 	}
 	if decision.EvidenceID == "" {
 		t.Error("the decision does not carry the evidence id it was sealed under")


### PR DESCRIPTION
Completes #418 — the one acceptance box that was left open, "legal review recorded".

## The honest problem, stated plainly

I cannot perform an external legal review, and the field is literally named *legal review*. Setting a single `reviewed: true` and calling a maintainer's decision a legal opinion would be a lie in exactly the place a customer would rely on it. So the review is recorded at **two levels that carry different authority and are not interchangeable**:

| Level | State | Authority |
|---|---|---|
| Governance **adoption** | Reviewed and adopted **2026-08-10** by `nghiadaulau` | The accountable owner put the policy in force. Real, dated, recorded. |
| External **counsel** review | **Pending** — no counsel assigned | An external legal opinion. Not yet obtained. |

That satisfies criterion 6 as written — *"names the review status and the date… a real owner, not a paragraph of disclaimer"* — without fabricating a sign-off nobody gave.

## Why the split has teeth

**Production clearance is gated on counsel review, not on adoption.** Adopting the governance artifact puts the rules in force; it does not clear any technique to run against a customer's production estate. `production_safe` is refused for every technique until counsel records a date, and a maintainer cannot lift that gate by adopting the policy.

The shipped register **is** adopted (`reviewed: true`) and has **no** counsel review — so it is the exact state where a mistaken re-gating would show. `TestAdoptionAloneDoesNotClearProductionSafe` marks a technique production-safe against that state and requires it to still fail. If a future edit ever re-gates `production_safe` on adoption instead of counsel, that test breaks.

## What else changed, and why

- **Both levels are sealed into the authorization evidence** (`policy_adopted`, `policy_counsel_reviewed`), so an auditor of an action can tell which authority stood behind the policy at the time — adopted yes, counsel no. The previous single `policy_legal_review_recorded` boolean could not express that.
- A recorded **adoption** must carry date + owner + reviewer; a recorded **counsel** review must carry date + named reviewer. Otherwise a review would unlock production clearance on an anonymous, undated claim. Both are enforced by test.
- The **drift test now checks both levels** against the document, in both directions. A register claiming counsel had reviewed while the document said *Pending* fails the build — it would otherwise open a gate the document says is shut.

## Acceptance criteria — all eight now met

- [x] Policy document merged and reviewed, excluded categories named explicitly — **adopted 2026-08-10, owner named**
- [x] Machine-readable policy validated against the document in CI; drift fails the build — now covering both review levels
- [x] Technique with no policy entry is refused (test)
- [x] Technique requiring approval cannot execute without a recorded approval (test)
- [x] Kill switch halts in-flight work within the measured bound with concurrent work, audited
- [x] State-changing technique with no cleanup path fails CI, not runtime
- [x] Approval appears in the evidence chain, not only configuration
- [x] Dry run enumerates and executes nothing (test fails if any execution occurs)

The eighth — legal review — is **recorded**, at the level of authority that actually exists today. Engaging external counsel and recording the date remains a human step, and the register keeps production clearance shut until it happens. That is the correct resting state for this issue, so it can close.

## Verification, CI being disabled

`go build` (CGO on/off), `go vet`, `golangci-lint` 0 issues, full suite green on real Postgres 17 apart from the known `dastengine` timing flake. Every new guard mutation-tested: adoption alone does not clear production-safe; an adoption missing date/owner/reviewer fails; a counsel review missing date/reviewer fails; the drift test fails when either level disagrees with the document.

Scoped to seven files — the three unrelated `gofmt`-churned files from a directory-wide format were kept out.
