### PR TITLE
fix(ai-triage): fail closed on exemption evidence failure

### DIFF
--- a/internal/usecase/sca/fptriage_budget.go
+++ b/internal/usecase/sca/fptriage_budget.go
@@ -12,12 +12,16 @@ import (
 
 // AITriageBudget records bounded per-scan AI coverage. The cap is on findings, so a configured
 // distinct verifier can make at most two LLM calls per attempted finding. Unattempted findings retain
-// their normal gate effect.
+// their normal gate effect. EvidenceSealFailures and EvidenceRevokedExemptions are in-memory failure
+// accounting for the revocation boundary; the scan fails before ScanResult persistence, so the
+// operator-visible metric is emitted separately as a stable structured event by sealEvidenceFailClosed.
 type AITriageBudget struct {
-	MaxFindings       int `json:"max_findings"`
-	EligibleFindings  int `json:"eligible_findings"`
-	AttemptedFindings int `json:"attempted_findings"`
-	SkippedFindings   int `json:"skipped_findings"`
+	MaxFindings               int `json:"max_findings"`
+	EligibleFindings          int `json:"eligible_findings"`
+	AttemptedFindings         int `json:"attempted_findings"`
+	SkippedFindings           int `json:"skipped_findings"`
+	EvidenceSealFailures      int `json:"evidence_seal_failures,omitempty"`
+	EvidenceRevokedExemptions int `json:"evidence_revoked_exemptions,omitempty"`
 }
 
 func (s *Service) runFPTriage(ctx context.Context, result *ScanResult, workspaceDir string, trace *scanDebugTrace) {

--- a/internal/usecase/sca/fptriage_evidence.go
+++ b/internal/usecase/sca/fptriage_evidence.go
@@ -1,0 +1,173 @@
+package sca
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	aiPolicyEvidenceSealFailed       = "evidence_seal_failed"
+	aiEvidenceSealFailureAuditAction = "sca.ai_triage.evidence_seal_failed"
+	aiEvidenceSealFailureMetricName  = "synapse_sca_ai_triage_evidence_seal_failures_total"
+	aiEvidenceSealFailureWarning     = "AI gate exemption revoked because scan evidence could not be sealed; affected findings remain gating. Retry after the evidence ledger recovers."
+	aiEvidenceFailureAuditTimeout    = 5 * time.Second
+)
+
+// AIEvidenceSealError is returned when an evidence failure revoked AI gate authority.
+// The scan remains failed before result persistence; callers may retry after the ledger recovers.
+type AIEvidenceSealError struct {
+	RevokedExemptions int
+	Err               error
+}
+
+func (e *AIEvidenceSealError) Error() string {
+	if e == nil {
+		return "AI evidence seal failure"
+	}
+	return fmt.Sprintf("AI gate exemption evidence failed closed after revoking %d exemption(s); findings remain gating and the scan can be retried: %v", e.RevokedExemptions, e.Err)
+}
+
+func (e *AIEvidenceSealError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// sealEvidenceFailClosed preserves the #386 boundary: any configured evidence failure still
+// fails the scan before run, finding, review, or result persistence. #391 adds the narrower
+// authority cleanup before that error escapes. When an active AI exemption cannot be sealed,
+// clear every positive GateExempt bit in-memory, mark the finding for review, emit a stable
+// operator-visible metric event plus warning, and append an audit event. Do not retry the evidence
+// write here: Evidence.Service already owns the bounded chain-head retry, while a generic Append
+// error can be commit-ambiguous. The operator retries the whole scan after the ledger recovers.
+func (s *Service) sealEvidenceFailClosed(ctx context.Context, actor string, engagementID shared.ID, now time.Time, result *ScanResult) (shared.ID, error) {
+	ref, sealErr := s.sealEvidence(ctx, actor, engagementID, now, result)
+	if sealErr == nil {
+		return ref, nil
+	}
+
+	revoked := revokeAIGateExemptions(result)
+	if revoked == 0 {
+		return "", sealErr
+	}
+
+	recordAIEvidenceSealFailureAccounting(result, revoked)
+	appendSourceWarningOnce(result, aiEvidenceSealFailureWarning)
+	s.emitAIEvidenceSealFailureMetric(ctx, engagementID, revoked)
+
+	if s.audit == nil {
+		return "", &AIEvidenceSealError{
+			RevokedExemptions: revoked,
+			Err: errors.Join(
+				sealErr,
+				fmt.Errorf("audit AI evidence revocation: %w", shared.ErrValidation),
+			),
+		}
+	}
+	auditAt := now
+	if s.clock != nil {
+		auditAt = s.clock.Now()
+	}
+	// A request timeout can be the reason the evidence path failed. The failure audit is
+	// compensating state and must get its own bounded chance to persist after cancellation,
+	// while retaining request values such as tenant/actor context.
+	auditCtx, cancelAudit := context.WithTimeout(context.WithoutCancel(ctx), aiEvidenceFailureAuditTimeout)
+	auditErr := s.audit.Record(auditCtx, ports.AuditEntry{
+		Actor:  actor,
+		Action: aiEvidenceSealFailureAuditAction,
+		Target: engagementID.String(),
+		Metadata: map[string]string{
+			"engagement":             engagementID.String(),
+			"evidence_seal_failures": "1",
+			"revoked_exemptions":     strconv.Itoa(revoked),
+		},
+		At: auditAt,
+	})
+	cancelAudit()
+	if auditErr != nil {
+		return "", &AIEvidenceSealError{
+			RevokedExemptions: revoked,
+			Err: errors.Join(
+				sealErr,
+				fmt.Errorf("audit AI evidence revocation: %w", auditErr),
+			),
+		}
+	}
+
+	return "", &AIEvidenceSealError{RevokedExemptions: revoked, Err: sealErr}
+}
+
+// emitAIEvidenceSealFailureMetric emits a stable structured counter event before the failed
+// ScanResult is discarded. P1.5 owns the broader telemetry/exporter surface; this narrow event is
+// deliberately log-derived so #391 does not introduce a second metrics stack. It is logged at ERROR
+// because every supported log configuration retains errors, including an operator-selected error-only
+// threshold. WithoutCancel keeps a request timeout from suppressing the compensating observation for the
+// failure it caused.
+func (s *Service) emitAIEvidenceSealFailureMetric(ctx context.Context, engagementID shared.ID, revoked int) {
+	if revoked <= 0 {
+		return
+	}
+	s.logger().LogAttrs(
+		context.WithoutCancel(ctx),
+		slog.LevelError,
+		"AI gate exemption revoked after evidence seal failure",
+		slog.String("metric", aiEvidenceSealFailureMetricName),
+		slog.String("metric_kind", "counter"),
+		slog.Int("metric_value", 1),
+		slog.String("engagement", engagementID.String()),
+		slog.Int("revoked_exemptions", revoked),
+	)
+}
+
+// revokeAIGateExemptions clears every stored GateExempt bit, including malformed/forged DTOs that
+// would already fail server-side revalidation. The evidence precondition failed globally, so retaining
+// any positive authority bit would be misleading even when another guard currently ignores it.
+func revokeAIGateExemptions(result *ScanResult) int {
+	if result == nil {
+		return 0
+	}
+	revoked := 0
+	for i := range result.AITriage {
+		critique := &result.AITriage[i]
+		if !critique.GateExempt {
+			continue
+		}
+		critique.GateExempt = false
+		critique.ReviewRequired = true
+		critique.PolicyReason = aiPolicyEvidenceSealFailed
+		revoked++
+	}
+	return revoked
+}
+
+func recordAIEvidenceSealFailureAccounting(result *ScanResult, revoked int) {
+	if result == nil || revoked <= 0 {
+		return
+	}
+	if result.AITriageBudget == nil {
+		result.AITriageBudget = &AITriageBudget{}
+	}
+	result.AITriageBudget.EvidenceSealFailures++
+	result.AITriageBudget.EvidenceRevokedExemptions += revoked
+}
+
+func appendSourceWarningOnce(result *ScanResult, warning string) {
+	if result == nil || strings.TrimSpace(warning) == "" {
+		return
+	}
+	for _, existing := range result.SourceWarnings {
+		if existing == warning {
+			return
+		}
+	}
+	result.SourceWarnings = append(result.SourceWarnings, warning)
+}

--- a/internal/usecase/sca/fptriage_evidence_metric_test.go
+++ b/internal/usecase/sca/fptriage_evidence_metric_test.go
@@ -1,0 +1,197 @@
+package sca
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAIEvidenceSealFailureEmitsMetricOutsideDiscardedResult(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	storageErr := errors.New("storage unavailable")
+	store.appendFailures[1] = storageErr
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	var logs bytes.Buffer
+	svc.SetLogger(slog.New(slog.NewJSONHandler(&logs, nil)))
+	result := aiEvidenceGateExemptResult(t)
+
+	ref, err := svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-metric", time.Unix(100, 0).UTC(), result)
+	assertTypedAIEvidenceFailure(t, ref, err, 1)
+	if !errors.Is(err, storageErr) {
+		t.Fatalf("typed error must preserve storage failure: %v", err)
+	}
+
+	got := logs.String()
+	for _, want := range []string{
+		`"level":"ERROR"`,
+		`"metric":"` + aiEvidenceSealFailureMetricName + `"`,
+		`"metric_kind":"counter"`,
+		`"metric_value":1`,
+		`"engagement":"eng-metric"`,
+		`"revoked_exemptions":1`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("failure metric missing %s: %s", want, got)
+		}
+	}
+}
+
+func TestAIEvidenceSealFailureMetricSurvivesErrorOnlyLogLevel(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	store.appendFailures[1] = errors.New("storage unavailable")
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	var logs bytes.Buffer
+	svc.SetLogger(slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelError})))
+	result := aiEvidenceGateExemptResult(t)
+
+	_, err := svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-metric-error-level", time.Unix(100, 0).UTC(), result)
+	if err == nil {
+		t.Fatal("evidence failure must remain fatal")
+	}
+	if got := strings.Count(logs.String(), `"metric":"`+aiEvidenceSealFailureMetricName+`"`); got != 1 {
+		t.Fatalf("error-only logger suppressed failure metric: count=%d logs=%s", got, logs.String())
+	}
+}
+
+func TestAIEvidenceSealFailureMetricUsesLiveContextAfterRequestCancellation(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	store.headFailures[1] = context.Canceled
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	handler := &aiEvidenceContextHandler{}
+	svc.SetLogger(slog.New(handler))
+	result := aiEvidenceGateExemptResult(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ref, err := svc.sealEvidenceFailClosed(ctx, "operator", "eng-metric-canceled", time.Unix(100, 0).UTC(), result)
+	assertTypedAIEvidenceFailure(t, ref, err, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("typed error must preserve request cancellation: %v", err)
+	}
+	if handler.calls != 1 {
+		t.Fatalf("metric handler calls=%d, want 1", handler.calls)
+	}
+	if handler.ctxErr != nil {
+		t.Fatalf("metric inherited canceled request context: %v", handler.ctxErr)
+	}
+}
+
+func TestAIEvidenceMetricSurvivesAuditFailure(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	store.appendFailures[1] = errors.New("storage unavailable")
+	audit := &aiEvidenceTestAudit{err: errors.New("audit unavailable")}
+	svc := newAIEvidenceService(t, store, audit)
+	var logs bytes.Buffer
+	svc.SetLogger(slog.New(slog.NewJSONHandler(&logs, nil)))
+	result := aiEvidenceGateExemptResult(t)
+
+	_, err := svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-metric-audit", time.Unix(100, 0).UTC(), result)
+	if err == nil {
+		t.Fatal("audit failure must remain fatal")
+	}
+	if got := strings.Count(logs.String(), `"metric":"`+aiEvidenceSealFailureMetricName+`"`); got != 1 {
+		t.Fatalf("metric count=%d, want 1 despite audit failure: %s", got, logs.String())
+	}
+}
+
+func TestAIEvidenceMetricDoesNotDoubleEmitAfterRevocation(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	store.appendAlways = errors.New("storage unavailable")
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	var logs bytes.Buffer
+	svc.SetLogger(slog.New(slog.NewJSONHandler(&logs, nil)))
+	result := aiEvidenceGateExemptResult(t)
+
+	_, _ = svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-metric-repeat", time.Unix(100, 0).UTC(), result)
+	if got := strings.Count(logs.String(), `"metric":"`+aiEvidenceSealFailureMetricName+`"`); got != 1 {
+		t.Fatalf("first metric count=%d, want 1: %s", got, logs.String())
+	}
+	_, err := svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-metric-repeat", time.Unix(100, 0).UTC(), result)
+	if err == nil {
+		t.Fatal("evidence outage must remain fatal after authority was already revoked")
+	}
+	if got := strings.Count(logs.String(), `"metric":"`+aiEvidenceSealFailureMetricName+`"`); got != 1 {
+		t.Fatalf("retry double-emitted metric: count=%d logs=%s", got, logs.String())
+	}
+}
+
+func TestAIEvidenceMetricIsNotEmittedWithoutAIExemption(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	store.appendFailures[1] = errors.New("storage unavailable")
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	var logs bytes.Buffer
+	svc.SetLogger(slog.New(slog.NewJSONHandler(&logs, nil)))
+	result := &ScanResult{Findings: []finding.Finding{{DedupKey: "ordinary"}}}
+
+	_, err := svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-metric-ordinary", time.Unix(100, 0).UTC(), result)
+	if err == nil {
+		t.Fatal("general evidence failure must remain fatal")
+	}
+	if strings.Contains(logs.String(), aiEvidenceSealFailureMetricName) {
+		t.Fatalf("non-AI evidence failure emitted AI metric: %s", logs.String())
+	}
+}
+
+func TestAIEvidenceMissingAuditFailsClosed(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	storageErr := errors.New("storage unavailable")
+	store.appendFailures[1] = storageErr
+	backingAudit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, backingAudit)
+	svc.audit = nil
+	result := aiEvidenceGateExemptResult(t)
+
+	ref, err := svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-no-audit", time.Unix(100, 0).UTC(), result)
+	assertTypedAIEvidenceFailure(t, ref, err, 1)
+	if !errors.Is(err, storageErr) || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing audit must retain the seal failure and fail validation: %v", err)
+	}
+	assertAIEvidenceRevoked(t, result)
+}
+
+func TestAIEvidenceAuditFallsBackToProvidedTimeWithoutServiceClock(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	store.appendFailures[1] = errors.New("storage unavailable")
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	svc.clock = nil
+	result := aiEvidenceGateExemptResult(t)
+	now := time.Unix(123, 456).UTC()
+
+	ref, err := svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-no-clock", now, result)
+	assertTypedAIEvidenceFailure(t, ref, err, 1)
+	if len(audit.entries) != 1 {
+		t.Fatalf("audit entries=%d, want 1", len(audit.entries))
+	}
+	if got := audit.entries[0].At; !got.Equal(now) {
+		t.Fatalf("audit time=%v, want provided time %v", got, now)
+	}
+}
+
+type aiEvidenceContextHandler struct {
+	calls  int
+	ctxErr error
+}
+
+func (h *aiEvidenceContextHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *aiEvidenceContextHandler) Handle(ctx context.Context, _ slog.Record) error {
+	h.calls++
+	h.ctxErr = ctx.Err()
+	return nil
+}
+
+func (h *aiEvidenceContextHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *aiEvidenceContextHandler) WithGroup(string) slog.Handler      { return h }

--- a/internal/usecase/sca/fptriage_evidence_test.go
+++ b/internal/usecase/sca/fptriage_evidence_test.go
@@ -1,0 +1,441 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+	"time"
+
+	evdom "github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type aiEvidenceScriptStore struct {
+	items          map[shared.ID][]evdom.Evidence
+	headCalls      int
+	appendCalls    int
+	headFailures   map[int]error
+	appendFailures map[int]error
+	conflictCalls  int
+	appendAlways   error
+}
+
+func newAIEvidenceScriptStore() *aiEvidenceScriptStore {
+	return &aiEvidenceScriptStore{
+		items:          map[shared.ID][]evdom.Evidence{},
+		headFailures:   map[int]error{},
+		appendFailures: map[int]error{},
+	}
+}
+
+func (s *aiEvidenceScriptStore) Head(_ context.Context, engagementID shared.ID) (string, error) {
+	s.headCalls++
+	if err := s.headFailures[s.headCalls]; err != nil {
+		return "", err
+	}
+	chain := s.items[engagementID]
+	if len(chain) == 0 {
+		return "", nil
+	}
+	return chain[len(chain)-1].Hash, nil
+}
+
+func (s *aiEvidenceScriptStore) Append(_ context.Context, items []evdom.Evidence) error {
+	s.appendCalls++
+	if s.appendCalls <= s.conflictCalls {
+		return fmt.Errorf("scripted parent conflict: %w", shared.ErrConflict)
+	}
+	if err := s.appendFailures[s.appendCalls]; err != nil {
+		return err
+	}
+	if s.appendAlways != nil {
+		return s.appendAlways
+	}
+	for _, item := range items {
+		s.items[item.EngagementID] = append(s.items[item.EngagementID], item)
+	}
+	return nil
+}
+
+func (s *aiEvidenceScriptStore) ListByEngagement(_ context.Context, engagementID shared.ID) ([]evdom.Evidence, error) {
+	out := make([]evdom.Evidence, len(s.items[engagementID]))
+	copy(out, s.items[engagementID])
+	return out, nil
+}
+
+type aiEvidenceTestClock struct{ now time.Time }
+
+func (c aiEvidenceTestClock) Now() time.Time { return c.now }
+
+type aiEvidenceTestIDs struct{ n int }
+
+func (g *aiEvidenceTestIDs) NewID() shared.ID {
+	g.n++
+	return shared.ID("ai-evidence-" + strconv.Itoa(g.n))
+}
+
+type aiEvidenceTestAudit struct {
+	entries []ports.AuditEntry
+	err     error
+	ctxErr  error
+}
+
+func (a *aiEvidenceTestAudit) Record(ctx context.Context, entry ports.AuditEntry) error {
+	a.ctxErr = ctx.Err()
+	if a.err != nil {
+		return a.err
+	}
+	a.entries = append(a.entries, entry)
+	return nil
+}
+
+func newAIEvidenceService(t *testing.T, store ports.EvidenceStore, audit *aiEvidenceTestAudit) *Service {
+	t.Helper()
+	clock := aiEvidenceTestClock{now: time.Unix(1_700_000_000, 0).UTC()}
+	vault, err := evidenceuc.NewService(store, nil, audit, clock, &aiEvidenceTestIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Service{evidence: vault, audit: audit, clock: clock}
+}
+
+func aiEvidenceGateExemptResult(t *testing.T) *ScanResult {
+	t.Helper()
+	result := &ScanResult{
+		Target: "repo",
+		Findings: []finding.Finding{{
+			DedupKey: "safe-medium",
+			Kind:     finding.KindSAST,
+			Class:    finding.ClassFirstParty,
+			Scope:    sbom.ScopeProduction,
+			Severity: shared.SeverityMedium,
+			CWE:      "CWE-327",
+		}},
+		AITriage:       []ports.AICritique{verifiedCritique("safe-medium")},
+		AITriageBudget: &AITriageBudget{MaxFindings: 1, EligibleFindings: 1, AttemptedFindings: 1},
+	}
+	applyAIGatePolicy(result, true, aiTriageModeEnforce)
+	if got := result.AIGateExemptKeys(); len(got) != 1 || !got["safe-medium"] {
+		t.Fatalf("test setup: expected one authorized AI exemption, got %v", got)
+	}
+	return result
+}
+
+func assertAIEvidenceRevoked(t *testing.T, result *ScanResult) {
+	t.Helper()
+	if len(result.Findings) != 1 || result.Findings[0].DedupKey != "safe-medium" {
+		t.Fatalf("evidence failure must retain the finding: %+v", result.Findings)
+	}
+	if got := result.AIGateExemptKeys(); len(got) != 0 {
+		t.Fatalf("evidence failure must revoke all AI gate authority: %v", got)
+	}
+	if len(result.AITriage) != 1 {
+		t.Fatalf("critique must be retained, got %d", len(result.AITriage))
+	}
+	critique := result.AITriage[0]
+	if critique.GateExempt || !critique.ReviewRequired || critique.PolicyReason != aiPolicyEvidenceSealFailed {
+		t.Fatalf("revoked critique = %+v", critique)
+	}
+	if critique.PolicyVersion != aiTriagePolicyVersion {
+		t.Fatalf("revocation changed policy identity: %q", critique.PolicyVersion)
+	}
+	if result.AITriageBudget == nil || result.AITriageBudget.EvidenceSealFailures != 1 || result.AITriageBudget.EvidenceRevokedExemptions != 1 {
+		t.Fatalf("evidence failure metrics = %+v", result.AITriageBudget)
+	}
+	warnings := 0
+	for _, warning := range result.SourceWarnings {
+		if warning == aiEvidenceSealFailureWarning {
+			warnings++
+		}
+	}
+	if warnings != 1 {
+		t.Fatalf("operator warning count = %d, want 1; warnings=%v", warnings, result.SourceWarnings)
+	}
+}
+
+func assertTypedAIEvidenceFailure(t *testing.T, ref shared.ID, err error, revoked int) *AIEvidenceSealError {
+	t.Helper()
+	if err == nil || !ref.IsZero() {
+		t.Fatalf("evidence failure must stop before persistence: ref=%q err=%v", ref, err)
+	}
+	var typed *AIEvidenceSealError
+	if !errors.As(err, &typed) || typed.RevokedExemptions != revoked {
+		t.Fatalf("want AIEvidenceSealError with %d revoked exemption(s), got %T %v", revoked, err, err)
+	}
+	return typed
+}
+
+func assertSingleAIEvidenceAudit(t *testing.T, audit *aiEvidenceTestAudit, engagementID shared.ID) {
+	t.Helper()
+	if len(audit.entries) != 1 {
+		t.Fatalf("audit entries = %d, want 1: %+v", len(audit.entries), audit.entries)
+	}
+	entry := audit.entries[0]
+	if entry.Action != aiEvidenceSealFailureAuditAction || entry.Target != engagementID.String() ||
+		entry.Metadata["evidence_seal_failures"] != "1" || entry.Metadata["revoked_exemptions"] != "1" {
+		t.Fatalf("unexpected AI evidence audit entry: %+v", entry)
+	}
+}
+
+func assertNoEvidence(t *testing.T, store *aiEvidenceScriptStore, engagementID shared.ID) {
+	t.Helper()
+	items, err := store.ListByEngagement(context.Background(), engagementID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("failed scan must not create a second/recovery evidence link: %+v", items)
+	}
+}
+
+func TestAIEvidenceSuccessfulSealPreservesAuthorizedExemption(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	result := aiEvidenceGateExemptResult(t)
+	engagementID := shared.ID("eng-success")
+
+	ref, err := svc.sealEvidenceFailClosed(context.Background(), "operator", engagementID, time.Unix(100, 0).UTC(), result)
+	if err != nil || ref.IsZero() {
+		t.Fatalf("successful evidence seal: ref=%q err=%v", ref, err)
+	}
+	if got := result.AIGateExemptKeys(); len(got) != 1 || !got["safe-medium"] {
+		t.Fatalf("successful seal must preserve authorized exemption: %v", got)
+	}
+	items, err := store.ListByEngagement(context.Background(), engagementID)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("evidence items=%d err=%v", len(items), err)
+	}
+	var payload scanEvidencePayload
+	if err := json.Unmarshal(items[0].Content, &payload); err != nil {
+		t.Fatalf("decode evidence: %v", err)
+	}
+	if len(payload.AITriage) != 1 || !payload.AITriage[0].GateExempt || payload.AITriage[0].PolicyReason != aiPolicyVerifiedConsensus {
+		t.Fatalf("authorized exemption was not sealed exactly: %+v", payload.AITriage)
+	}
+}
+
+func TestAIEvidenceSealFailureRevokesOnVaultHeadTimeout(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	store.headFailures[1] = context.DeadlineExceeded
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	result := aiEvidenceGateExemptResult(t)
+	engagementID := shared.ID("eng-head")
+
+	ref, err := svc.sealEvidenceFailClosed(context.Background(), "operator", engagementID, time.Unix(100, 0).UTC(), result)
+	assertTypedAIEvidenceFailure(t, ref, err, 1)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("typed error must preserve vault failure: %v", err)
+	}
+	if store.headCalls != 1 || store.appendCalls != 0 {
+		t.Fatalf("outer layer retried evidence unexpectedly: heads=%d appends=%d", store.headCalls, store.appendCalls)
+	}
+	assertAIEvidenceRevoked(t, result)
+	assertSingleAIEvidenceAudit(t, audit, engagementID)
+	assertNoEvidence(t, store, engagementID)
+}
+
+func TestAIEvidenceFailureAuditSurvivesCanceledRequestContext(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	store.headFailures[1] = context.Canceled
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	result := aiEvidenceGateExemptResult(t)
+	engagementID := shared.ID("eng-canceled")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ref, err := svc.sealEvidenceFailClosed(ctx, "operator", engagementID, time.Unix(100, 0).UTC(), result)
+	assertTypedAIEvidenceFailure(t, ref, err, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("typed error must preserve request cancellation: %v", err)
+	}
+	assertAIEvidenceRevoked(t, result)
+	assertSingleAIEvidenceAudit(t, audit, engagementID)
+	if audit.ctxErr != nil {
+		t.Fatalf("failure audit inherited canceled request context: %v", audit.ctxErr)
+	}
+}
+
+func TestAIEvidenceSealFailureRevokesOnStorageFailureWithoutOuterRetry(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	storageErr := errors.New("storage unavailable")
+	store.appendFailures[1] = storageErr
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	result := aiEvidenceGateExemptResult(t)
+	engagementID := shared.ID("eng-storage")
+
+	ref, err := svc.sealEvidenceFailClosed(context.Background(), "operator", engagementID, time.Unix(100, 0).UTC(), result)
+	assertTypedAIEvidenceFailure(t, ref, err, 1)
+	if !errors.Is(err, storageErr) {
+		t.Fatalf("typed error must preserve storage failure: %v", err)
+	}
+	if store.appendCalls != 1 {
+		t.Fatalf("generic Append failure must never be retried by the pipeline: appends=%d", store.appendCalls)
+	}
+	assertAIEvidenceRevoked(t, result)
+	assertSingleAIEvidenceAudit(t, audit, engagementID)
+	assertNoEvidence(t, store, engagementID)
+}
+
+func TestAIEvidenceSealFailureRevokesAfterChainHeadConflictExhaustion(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	// Evidence.Service owns bounded parent-conflict retries. Seventeen conflicts exhaust that
+	// loop; #391 must revoke authority and return the error rather than starting a second loop.
+	store.conflictCalls = 17
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	result := aiEvidenceGateExemptResult(t)
+	engagementID := shared.ID("eng-conflict")
+
+	ref, err := svc.sealEvidenceFailClosed(context.Background(), "operator", engagementID, time.Unix(100, 0).UTC(), result)
+	assertTypedAIEvidenceFailure(t, ref, err, 1)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("typed error must preserve chain-head conflict: %v", err)
+	}
+	if store.appendCalls != 17 {
+		t.Fatalf("pipeline added an outer conflict retry: appends=%d, want 17 evidence-service attempts", store.appendCalls)
+	}
+	assertAIEvidenceRevoked(t, result)
+	assertSingleAIEvidenceAudit(t, audit, engagementID)
+	assertNoEvidence(t, store, engagementID)
+}
+
+func TestAIEvidenceAuditFailureJoinsOriginalSealError(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	storageErr := errors.New("storage unavailable")
+	store.appendFailures[1] = storageErr
+	auditErr := errors.New("audit unavailable")
+	audit := &aiEvidenceTestAudit{err: auditErr}
+	svc := newAIEvidenceService(t, store, audit)
+	result := aiEvidenceGateExemptResult(t)
+
+	ref, err := svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-audit", time.Unix(100, 0).UTC(), result)
+	assertTypedAIEvidenceFailure(t, ref, err, 1)
+	if !errors.Is(err, storageErr) || !errors.Is(err, auditErr) {
+		t.Fatalf("audit failure must retain both causes: %v", err)
+	}
+	if store.appendCalls != 1 {
+		t.Fatalf("audit failure unexpectedly retried evidence: appends=%d", store.appendCalls)
+	}
+	assertAIEvidenceRevoked(t, result)
+}
+
+func TestAIEvidenceFailureAccountingIsIdempotentAfterRevocation(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	store.appendAlways = errors.New("storage unavailable")
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	result := aiEvidenceGateExemptResult(t)
+	engagementID := shared.ID("eng-repeat")
+
+	_, _ = svc.sealEvidenceFailClosed(context.Background(), "operator", engagementID, time.Unix(100, 0).UTC(), result)
+	firstMetric := result.AITriageBudget.EvidenceSealFailures
+	firstRevoked := result.AITriageBudget.EvidenceRevokedExemptions
+	firstAudits := len(audit.entries)
+	firstWarnings := len(result.SourceWarnings)
+
+	_, err := svc.sealEvidenceFailClosed(context.Background(), "operator", engagementID, time.Unix(100, 0).UTC(), result)
+	if err == nil {
+		t.Fatal("evidence outage must remain fatal after authority was already revoked")
+	}
+	var typed *AIEvidenceSealError
+	if errors.As(err, &typed) {
+		t.Fatalf("already-revoked retry should preserve the underlying #386 error, got %+v", typed)
+	}
+	if result.AITriageBudget.EvidenceSealFailures != firstMetric || result.AITriageBudget.EvidenceRevokedExemptions != firstRevoked {
+		t.Fatalf("retry double-counted metrics: %+v", result.AITriageBudget)
+	}
+	if len(audit.entries) != firstAudits || len(result.SourceWarnings) != firstWarnings {
+		t.Fatalf("retry duplicated audit/warning: audits=%d warnings=%v", len(audit.entries), result.SourceWarnings)
+	}
+}
+
+func TestEvidenceFailureWithoutAIExemptionPreservesGeneralFailClosedBehavior(t *testing.T) {
+	store := newAIEvidenceScriptStore()
+	storageErr := errors.New("storage unavailable")
+	store.appendFailures[1] = storageErr
+	audit := &aiEvidenceTestAudit{}
+	svc := newAIEvidenceService(t, store, audit)
+	result := &ScanResult{Findings: []finding.Finding{{DedupKey: "ordinary"}}}
+
+	ref, err := svc.sealEvidenceFailClosed(context.Background(), "operator", "eng-ordinary", time.Unix(100, 0).UTC(), result)
+	if err == nil || !ref.IsZero() || !errors.Is(err, storageErr) {
+		t.Fatalf("non-AI evidence failure must remain the original #386 failure: ref=%q err=%v", ref, err)
+	}
+	var typed *AIEvidenceSealError
+	if errors.As(err, &typed) {
+		t.Fatalf("non-AI failure unexpectedly entered AI recovery: %+v", typed)
+	}
+	if len(audit.entries) != 0 || result.AITriageBudget != nil || len(result.SourceWarnings) != 0 {
+		t.Fatalf("non-AI failure mutated AI state: audits=%d budget=%+v warnings=%v", len(audit.entries), result.AITriageBudget, result.SourceWarnings)
+	}
+}
+
+func TestRevokeAIGateExemptionsClearsForgedPositiveFlags(t *testing.T) {
+	result := &ScanResult{AITriage: []ports.AICritique{
+		{DedupKey: "forged", GateExempt: true, PolicyVersion: "forged", PolicyReason: "forged"},
+		{DedupKey: "ordinary", GateExempt: false, PolicyReason: aiPolicyShadowMode},
+	}}
+	if got := revokeAIGateExemptions(result); got != 1 {
+		t.Fatalf("revoked=%d, want 1", got)
+	}
+	if result.AITriage[0].GateExempt || !result.AITriage[0].ReviewRequired || result.AITriage[0].PolicyReason != aiPolicyEvidenceSealFailed {
+		t.Fatalf("forged positive flag survived revocation: %+v", result.AITriage[0])
+	}
+	if result.AITriage[1].PolicyReason != aiPolicyShadowMode {
+		t.Fatalf("non-exempt critique was mutated: %+v", result.AITriage[1])
+	}
+}
+
+func TestScanPipelinesUseFailClosedAIEvidenceBoundary(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "service.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, function := range []string{"runPipeline", "runImportedSBOMPipeline"} {
+		var target *ast.FuncDecl
+		for _, decl := range file.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == function {
+				target = fn
+				break
+			}
+		}
+		if target == nil {
+			t.Fatalf("%s not found", function)
+		}
+		failClosedCalls, rawSealCalls := 0, 0
+		ast.Inspect(target.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			switch selector.Sel.Name {
+			case "sealEvidenceFailClosed":
+				failClosedCalls++
+			case "sealEvidence":
+				rawSealCalls++
+			}
+			return true
+		})
+		if failClosedCalls != 1 || rawSealCalls != 0 {
+			t.Fatalf("%s evidence boundary: failClosed=%d raw=%d, want 1/0", function, failClosedCalls, rawSealCalls)
+		}
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -1900,7 +1900,7 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 	applyDetectionPriority(result, opts.DetectionPriority)
 	s.attachCompliance(result)
 	result.ReproDigest = ReproDigest(result)
-	evidenceRef, err := s.sealEvidence(ctx, actor, engagementID, now, result)
+	evidenceRef, err := s.sealEvidenceFailClosed(ctx, actor, engagementID, now, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2741,7 +2741,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 
 	// Seal this scan into the engagement's append-only hash-chained evidence ledger
 	// before writing any run, scan, finding, or result state.
-	evidenceRef, err := s.sealEvidence(ctx, actor, engagementID, now, result)
+	evidenceRef, err := s.sealEvidenceFailClosed(ctx, actor, engagementID, now, result)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fixes #391 by making AI gate exemptions fail closed when scan evidence cannot be sealed.

An AI-generated exemption is now valid only when the corresponding scan decision is successfully committed to the evidence chain. If evidence sealing fails after an exemption has been authorized, the scan:

* revokes every active AI `GateExempt` decision;
* keeps the affected findings present and gating;
* marks the critiques as `ReviewRequired`;
* records `evidence_seal_failed` as the policy reason without changing the policy version;
* returns a typed `AIEvidenceSealError` while preserving the underlying evidence failure;
* emits an operator-visible structured failure metric;
* records an audit event for the revocation;
* fails before scan-result, finding, review-queue, or run persistence.

The existing #386 fail-closed evidence boundary remains authoritative. This change does not add an outer evidence retry: chain-head conflicts continue to be retried only by the evidence service, while generic storage errors remain fatal because their commit state may be ambiguous.

The failure metric is emitted independently of `ScanResult` persistence so it remains observable even though the failed result is discarded. It is logged at `ERROR` level so it is retained even when an operator configures error-only logging.

Compensating audit and metric reporting detach from request cancellation while remaining bounded, so an evidence failure caused by a canceled or timed-out request still has an opportunity to be observed and audited.

Both the normal source-scan pipeline and imported-SBOM pipeline are required by regression tests to use the same fail-closed AI evidence boundary.

## Tests

Coverage includes:

* successful sealing preserves and seals the authorized exemption;
* evidence vault/head timeout;
* generic evidence storage failure;
* exhausted chain-head conflict retries;
* canceled request context;
* audit failure while preserving the original evidence error;
* missing audit dependency;
* clock fallback for audit timestamp;
* forged/stale positive `GateExempt` flags;
* finding retention and `ReviewRequired` fallback;
* policy-version preservation;
* no outer evidence retry;
* no recovery/duplicate evidence append;
* metric emission outside the discarded scan result;
* metric visibility with an error-only logger;
* metric survival when audit recording fails;
* no duplicate metric emission after revocation;
* no AI metric for ordinary evidence failures;
* both SCA pipeline entry points using the fail-closed wrapper.

The branch is rebased on the current upstream `main` and contains one focused commit with changes limited to the SCA use case.

Closes #391
