### PR TITLE
feat(redteam): chained exploitation under governance with per-step proof (#420)

### DIFF
--- a/internal/domain/exploitation/chain.go
+++ b/internal/domain/exploitation/chain.go
@@ -1,0 +1,265 @@
+// Package exploitation is the pure domain for a multi-step attack chain (issue #420).
+//
+// A chain is a typed plan of steps derived from a scored attack path. This package owns the state
+// machine and its transition rules and nothing else: it performs no I/O, admits no step, executes
+// nothing, and holds no clock. The orchestration that drives it — admission through the offensive
+// governance policy, sandboxed execution, evidence sealing, distinct-verifier advance, cleanup — lives
+// in internal/usecase/exploitation, so the rule "a model may propose a chain but never advances a step"
+// is structural: the transition methods here are driven by the orchestrator's state machine, and
+// advancing a step requires a DISTINCT verifier's sealed verdict, so a model's say-so cannot move a
+// chain forward even though the methods are exported for the orchestrator to call.
+//
+// Blast radius and cleanup vocabulary is reused from offensivepolicy (a domain package) rather than
+// redefined, so a chain step and a policy register entry cannot drift on what "state_changing" means.
+package exploitation
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ChainState is where a chain is in its lifecycle. The set is closed; anything else is a bug.
+type ChainState string
+
+const (
+	StatePlanned          ChainState = "planned"           // derived from a scored path, nothing admitted yet
+	StateAwaitingApproval ChainState = "awaiting_approval" // the current step needs a human decision
+	StateRunning          ChainState = "running"           // the current step is admitted and executing
+	StateStepVerifying    ChainState = "step_verifying"    // the current step executed; awaiting a distinct verifier
+	StateHalted           ChainState = "halted"            // stopped by policy, kill switch or a failed step
+	StateCleaned          ChainState = "cleaned"           // a halted/failed chain finished running its cleanup
+	StateSucceeded        ChainState = "succeeded"         // every step verified at or above the bar
+	StateFailed           ChainState = "failed"            // a step could not be verified or produced no evidence
+)
+
+// Terminal reports whether a chain has finished — success, failure, or a cleaned halt. A terminal chain
+// admits no further steps.
+func (s ChainState) Terminal() bool {
+	switch s {
+	case StateCleaned, StateSucceeded, StateFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// StepState mirrors ChainState at the granularity of one step.
+type StepState string
+
+const (
+	StepPending   StepState = "pending"
+	StepRunning   StepState = "running"
+	StepVerifying StepState = "verifying"
+	StepSucceeded StepState = "succeeded"
+	StepFailed    StepState = "failed"
+	StepCleaned   StepState = "cleaned"
+)
+
+// Step is one action in a chain. Technique and Target name what runs against what; BlastRadius and
+// Cleanup are the governance obligations. A state-changing step MUST carry a cleanup path — that is
+// enforced at construction, so a chain that cannot be cleaned up cannot be built rather than failing
+// halfway through execution.
+type Step struct {
+	Ordinal     int
+	Technique   string
+	Target      shared.ID
+	Proposer    string
+	BlastRadius offensivepolicy.Radius
+	Cleanup     offensivepolicy.CleanupSpec
+
+	State      StepState
+	Executed   bool      // set once execution began; a state-changing step that began may have changed the target
+	EvidenceID shared.ID // the sealed proof of this step's outcome; empty until produced
+}
+
+// Chain is the aggregate: an ordered, immutable plan plus the mutable cursor and state.
+type Chain struct {
+	ID           shared.ID
+	TenantID     shared.ID
+	EngagementID shared.ID
+	PathID       shared.ID
+	State        ChainState
+	Current      int // ordinal of the step under the cursor
+	Steps        []Step
+}
+
+// NewChain builds a planned chain from an ordered list of steps, refusing anything that cannot be
+// governed: a state-changing step with no cleanup path, a duplicate or non-contiguous ordinal, a step
+// with no technique, target or proposer.
+//
+// The cleanup check is here rather than at execution time on purpose (document §7, and issue #420
+// criterion): discovering at runtime that a state-changing step cannot be undone means it has already
+// run. A chain that cannot be cleaned up must not be constructable.
+func NewChain(id, tenantID, engagementID, pathID shared.ID, steps []Step) (*Chain, error) {
+	if id == "" || tenantID == "" || engagementID == "" {
+		return nil, fmt.Errorf("%w: chain requires id, tenant and engagement", shared.ErrValidation)
+	}
+	if len(steps) == 0 {
+		return nil, fmt.Errorf("%w: a chain needs at least one step", shared.ErrValidation)
+	}
+	out := make([]Step, len(steps))
+	for i, s := range steps {
+		if s.Ordinal != i {
+			return nil, fmt.Errorf("%w: step %d has ordinal %d; steps must be contiguous from 0", shared.ErrValidation, i, s.Ordinal)
+		}
+		if s.Technique == "" || s.Target == "" {
+			return nil, fmt.Errorf("%w: step %d has no technique or target", shared.ErrValidation, i)
+		}
+		if s.Proposer == "" {
+			return nil, fmt.Errorf("%w: step %d has no proposer (needed for the distinct-verifier rule)", shared.ErrValidation, i)
+		}
+		if !s.BlastRadius.Valid() {
+			return nil, fmt.Errorf("%w: step %d has an invalid blast radius %q", shared.ErrValidation, i, s.BlastRadius)
+		}
+		if s.BlastRadius == offensivepolicy.RadiusStateChanging && s.Cleanup.IsZero() {
+			return nil, fmt.Errorf("%w: state-changing step %d (%s) declares no cleanup path", shared.ErrValidation, i, s.Technique)
+		}
+		if s.BlastRadius == offensivepolicy.RadiusReadOnly && !s.Cleanup.IsZero() {
+			return nil, fmt.Errorf("%w: read-only step %d (%s) declares a cleanup path", shared.ErrValidation, i, s.Technique)
+		}
+		s.State = StepPending
+		out[i] = s
+	}
+	return &Chain{ID: id, TenantID: tenantID, EngagementID: engagementID, PathID: pathID, State: StatePlanned, Current: 0, Steps: out}, nil
+}
+
+// CurrentStep returns the step under the cursor, or false when the chain is terminal or the cursor has
+// walked off the end.
+func (c *Chain) CurrentStep() (*Step, bool) {
+	if c == nil || c.Current < 0 || c.Current >= len(c.Steps) {
+		return nil, false
+	}
+	return &c.Steps[c.Current], true
+}
+
+// beginStep moves the cursor's step from pending to running. It is the only path into execution.
+func (c *Chain) BeginStep() error {
+	if c.State != StatePlanned && c.State != StateStepVerifying {
+		return fmt.Errorf("%w: cannot begin a step from chain state %q", shared.ErrConflict, c.State)
+	}
+	step, ok := c.CurrentStep()
+	if !ok {
+		return fmt.Errorf("%w: no step under the cursor", shared.ErrConflict)
+	}
+	if step.State != StepPending {
+		return fmt.Errorf("%w: step %d is %q, not pending", shared.ErrConflict, step.Ordinal, step.State)
+	}
+	step.State = StepRunning
+	step.Executed = true // from here the target may have changed; a state-changing step now owes cleanup
+	c.State = StateRunning
+	return nil
+}
+
+// recordExecuted moves a running step to verifying and records its sealed proof. A step with no
+// evidence of its outcome is failed here, never advanced — issue #420 criterion. That decision is in
+// the domain so no orchestration mistake can promote an evidence-less step.
+func (c *Chain) RecordExecuted(evidenceID shared.ID, succeeded bool) error {
+	if c.State != StateRunning {
+		return fmt.Errorf("%w: cannot record execution from chain state %q", shared.ErrConflict, c.State)
+	}
+	step, ok := c.CurrentStep()
+	if !ok || step.State != StepRunning {
+		return fmt.Errorf("%w: no running step to record", shared.ErrConflict)
+	}
+	if evidenceID == "" {
+		// No evidence of the outcome. This is a failure, whatever the executor believed.
+		step.State = StepFailed
+		c.State = StateFailed
+		return fmt.Errorf("%w: step %d produced no evidence of its outcome", shared.ErrValidation, step.Ordinal)
+	}
+	step.EvidenceID = evidenceID
+	if !succeeded {
+		step.State = StepFailed
+		c.State = StateFailed
+		return nil
+	}
+	step.State = StepVerifying
+	c.State = StateStepVerifying
+	return nil
+}
+
+// advance applies a distinct verifier's sealed verdict to the verifying step. The verifier may not be
+// the step's proposer, and the score must clear the evidence bar. On success the cursor moves to the
+// next step, or the chain succeeds if there is none.
+//
+// Only the usecase Machine calls this, with a verdict from a distinct verifier port; no agent tool is
+// registered that reaches it, so a model cannot advance a step on its own say-so.
+func (c *Chain) Advance(verifier string, score int, meetsBar, distinct bool) error {
+	if c.State != StateStepVerifying {
+		return fmt.Errorf("%w: nothing to advance; chain is %q", shared.ErrConflict, c.State)
+	}
+	step, ok := c.CurrentStep()
+	if !ok || step.State != StepVerifying {
+		return fmt.Errorf("%w: no verifying step", shared.ErrConflict)
+	}
+	if !distinct {
+		return fmt.Errorf("%w: step %d verifier %q is its proposer; a chain cannot verify itself",
+			shared.ErrForbidden, step.Ordinal, verifier)
+	}
+	if !meetsBar {
+		step.State = StepFailed
+		c.State = StateFailed
+		return fmt.Errorf("%w: step %d verdict %d is below the evidence bar", shared.ErrValidation, step.Ordinal, score)
+	}
+	step.State = StepSucceeded
+	if c.Current == len(c.Steps)-1 {
+		c.State = StateSucceeded
+		return nil
+	}
+	c.Current++
+	c.State = StatePlanned // the next step is pending; beginStep takes it from here
+	return nil
+}
+
+// halt stops a running or verifying chain. It does not itself run cleanup — that is the orchestration's
+// job, and markCleaned records it afterwards. A terminal chain cannot be halted.
+func (c *Chain) Halt() error {
+	if c.State.Terminal() {
+		return fmt.Errorf("%w: chain is already %q", shared.ErrConflict, c.State)
+	}
+	c.State = StateHalted
+	return nil
+}
+
+// StepsNeedingCleanup returns the completed state-changing steps, most recent first, that still hold a
+// cleanup obligation. Cleanup runs in reverse order of execution: the last change made is the first
+// undone.
+func (c *Chain) StepsNeedingCleanup() []Step {
+	var out []Step
+	for i := len(c.Steps) - 1; i >= 0; i-- {
+		s := c.Steps[i]
+		if s.BlastRadius == offensivepolicy.RadiusStateChanging && s.Executed && s.State != StepCleaned {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// markCleaned records that cleanup ran for every obligated step and closes the chain. It is only valid
+// from halted or failed — a succeeded chain's steps were already accounted for as they completed.
+func (c *Chain) MarkCleaned() error {
+	if c.State != StateHalted && c.State != StateFailed {
+		return fmt.Errorf("%w: cannot clean a chain in state %q", shared.ErrConflict, c.State)
+	}
+	for i := range c.Steps {
+		if c.Steps[i].BlastRadius == offensivepolicy.RadiusStateChanging && c.Steps[i].Executed && c.Steps[i].State != StepCleaned {
+			c.Steps[i].State = StepCleaned
+		}
+	}
+	c.State = StateCleaned
+	return nil
+}
+
+// failCurrentStep records a policy violation or admission refusal on the current step and fails the
+// chain. Used when a step is refused before it executes, or when its actual effect exceeds its declared
+// blast radius.
+func (c *Chain) FailCurrentStep() {
+	if step, ok := c.CurrentStep(); ok && step.State != StepSucceeded {
+		step.State = StepFailed
+	}
+	if !c.State.Terminal() {
+		c.State = StateFailed
+	}
+}

--- a/internal/domain/exploitation/chain_test.go
+++ b/internal/domain/exploitation/chain_test.go
@@ -1,0 +1,156 @@
+package exploitation
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func roStep(ord int, proposer string) Step {
+	return Step{Ordinal: ord, Technique: "recon.service_banner", Target: "asset-x", Proposer: proposer, BlastRadius: offensivepolicy.RadiusReadOnly}
+}
+
+func scStep(ord int, proposer string) Step {
+	return Step{
+		Ordinal: ord, Technique: "exploit.web_shell_upload", Target: "asset-x", Proposer: proposer,
+		BlastRadius: offensivepolicy.RadiusStateChanging,
+		Cleanup:     offensivepolicy.CleanupSpec{Steps: []string{"delete uploaded artifact"}, Verification: "verify absence"},
+	}
+}
+
+func TestNewChainRefusesStateChangingWithoutCleanup(t *testing.T) {
+	bad := scStep(0, "agent:planner")
+	bad.Cleanup = offensivepolicy.CleanupSpec{}
+	_, err := NewChain("c1", "t1", "e1", "p1", []Step{bad})
+	if !errors.Is(err, shared.ErrValidation) || !strings.Contains(err.Error(), "cleanup") {
+		t.Fatalf("a state-changing step with no cleanup must be unconstructable, got %v", err)
+	}
+}
+
+func TestNewChainRefusesNonContiguousOrdinalsAndMissingFields(t *testing.T) {
+	cases := map[string][]Step{
+		"gap in ordinals":   {roStep(0, "p"), roStep(2, "p")},
+		"no proposer":       {{Ordinal: 0, Technique: "t", Target: "x", BlastRadius: offensivepolicy.RadiusReadOnly}},
+		"no technique":      {{Ordinal: 0, Target: "x", Proposer: "p", BlastRadius: offensivepolicy.RadiusReadOnly}},
+		"invalid radius":    {{Ordinal: 0, Technique: "t", Target: "x", Proposer: "p", BlastRadius: "sideways"}},
+		"read-only+cleanup": {{Ordinal: 0, Technique: "t", Target: "x", Proposer: "p", BlastRadius: offensivepolicy.RadiusReadOnly, Cleanup: offensivepolicy.CleanupSpec{Steps: []string{"x"}, Verification: "y"}}},
+	}
+	for name, steps := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewChain("c1", "t1", "e1", "p1", steps); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestAdvanceRefusesSelfVerification is the "a chain cannot verify itself" rule at the domain level.
+func TestAdvanceRefusesSelfVerification(t *testing.T) {
+	c, err := NewChain("c1", "t1", "e1", "p1", []Step{roStep(0, "agent:planner")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.BeginStep(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RecordExecuted("ev-0", true); err != nil {
+		t.Fatal(err)
+	}
+	// verifier == proposer → distinct=false → refused, chain stays verifying, does not advance.
+	err = c.Advance("agent:planner", 90, true, false)
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("self-verification must be forbidden, got %v", err)
+	}
+	if c.State != StateStepVerifying {
+		t.Fatalf("a refused self-verification must leave the chain verifying, got %s", c.State)
+	}
+}
+
+// TestRecordExecutedWithoutEvidenceFails: no evidence of outcome → failed, never succeeded.
+func TestRecordExecutedWithoutEvidenceFails(t *testing.T) {
+	c, _ := NewChain("c1", "t1", "e1", "p1", []Step{roStep(0, "p")})
+	_ = c.BeginStep()
+	err := c.RecordExecuted("", true) // claims success but produced no evidence
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("want validation error for missing evidence, got %v", err)
+	}
+	if c.State != StateFailed {
+		t.Fatalf("an evidence-less step must fail the chain, got %s", c.State)
+	}
+	if c.Steps[0].State != StepFailed {
+		t.Fatalf("the step must be failed, got %s", c.Steps[0].State)
+	}
+}
+
+// TestSubBarVerdictFailsTheChain: a verdict below the bar fails rather than advances.
+func TestSubBarVerdictFailsTheChain(t *testing.T) {
+	c, _ := NewChain("c1", "t1", "e1", "p1", []Step{roStep(0, "agent:planner")})
+	_ = c.BeginStep()
+	_ = c.RecordExecuted("ev-0", true)
+	if err := c.Advance("human:reviewer", 40, false, true); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a sub-bar verdict must fail the step, got %v", err)
+	}
+	if c.State != StateFailed {
+		t.Fatalf("chain must be failed, got %s", c.State)
+	}
+}
+
+// TestFullChainSucceedsAndCleanupTracksStateChangingSteps walks a two-step chain to success and checks
+// which steps carry a cleanup obligation.
+func TestFullChainSucceedsAndCleanupOrder(t *testing.T) {
+	c, err := NewChain("c1", "t1", "e1", "p1", []Step{scStep(0, "agent:planner"), roStep(1, "agent:planner")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// step 0 (state_changing)
+	_ = c.BeginStep()
+	_ = c.RecordExecuted("ev-0", true)
+	if err := c.Advance("human:reviewer", 90, true, true); err != nil {
+		t.Fatal(err)
+	}
+	if c.State != StatePlanned || c.Current != 1 {
+		t.Fatalf("after step 0 the cursor should be on step 1, got state=%s current=%d", c.State, c.Current)
+	}
+	// step 1 (read_only)
+	_ = c.BeginStep()
+	_ = c.RecordExecuted("ev-1", true)
+	if err := c.Advance("human:reviewer", 88, true, true); err != nil {
+		t.Fatal(err)
+	}
+	if c.State != StateSucceeded {
+		t.Fatalf("chain should have succeeded, got %s", c.State)
+	}
+	// Only the state-changing step carries a cleanup obligation, even on a succeeded chain.
+	need := c.StepsNeedingCleanup()
+	if len(need) != 1 || need[0].Ordinal != 0 {
+		t.Fatalf("only the state-changing step should need cleanup, got %+v", need)
+	}
+}
+
+func TestHaltThenMarkCleanedIsTerminal(t *testing.T) {
+	c, _ := NewChain("c1", "t1", "e1", "p1", []Step{scStep(0, "agent:planner")})
+	_ = c.BeginStep()
+	_ = c.RecordExecuted("ev-0", true)
+	if err := c.Halt(); err != nil {
+		t.Fatal(err)
+	}
+	if c.State != StateHalted {
+		t.Fatalf("want halted, got %s", c.State)
+	}
+	if err := c.MarkCleaned(); err != nil {
+		t.Fatal(err)
+	}
+	if c.State != StateCleaned || !c.State.Terminal() {
+		t.Fatalf("want a terminal cleaned state, got %s", c.State)
+	}
+	if c.Steps[0].State != StepCleaned {
+		t.Fatalf("the state-changing step must be marked cleaned, got %s", c.Steps[0].State)
+	}
+	// A terminal chain cannot be halted again.
+	if err := c.Halt(); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("halting a terminal chain must conflict, got %v", err)
+	}
+}

--- a/internal/domain/exploitation/proof.go
+++ b/internal/domain/exploitation/proof.go
@@ -1,0 +1,76 @@
+package exploitation
+
+import (
+	"regexp"
+	"strings"
+)
+
+// MaxProofBytes bounds a proof sample to what a report needs and no more (offensive policy document §6:
+// a proof sample is bounded and redacted). A data-exposure step proves access with a small redacted
+// sample, never a bulk extraction — so the bound is a hard cap enforced here, not a convention the
+// executor is trusted to honour.
+const MaxProofBytes = 4096
+
+// proofRedactions are the well-known secret shapes redacted at capture. This is a FLOOR, not the whole
+// story: content-specific redaction (a technique that knows it just read a customer PII table) is the
+// technique's responsibility. The domain guarantees two things unconditionally — the size bound above,
+// and that these common credential shapes never survive into the sealed sample.
+// Order matters: the more specific shapes run first. The key:value rule runs LAST because it consumes
+// only one token after the separator, and running it before the bearer rule would eat "Authorization:
+// Bearer" and strand the token that follows it.
+var proofRedactions = []*regexp.Regexp{
+	// PEM private key blocks
+	regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`),
+	// bearer / basic auth header values, token and all
+	regexp.MustCompile(`(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}`),
+	// long base64-ish blobs that are most likely credential material
+	regexp.MustCompile(`\b[A-Za-z0-9+/]{40,}={0,2}\b`),
+	// key=value / key: value where the key looks sensitive
+	regexp.MustCompile(`(?i)\b(pass(word|wd)?|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|authorization|bearer)\b\s*[:=]\s*\S+`),
+}
+
+// ProofSample is the redacted, bounded evidence that a step succeeded. It is a distinct type so a raw
+// executor byte stream cannot be sealed as a proof by mistake — everything that becomes a proof goes
+// through NewProofSample.
+type ProofSample struct {
+	Content   []byte
+	Truncated bool
+	Redacted  bool
+}
+
+// NewProofSample redacts known secret shapes and then bounds the result to MaxProofBytes.
+//
+// Redaction happens BEFORE truncation, so cutting the sample can never slice a secret in half and leave
+// a readable prefix of it. Truncation is on a UTF-8 boundary so the stored sample is always valid text.
+func NewProofSample(raw []byte) ProofSample {
+	redacted, changed := redactSecrets(string(raw))
+	truncated := false
+	if len(redacted) > MaxProofBytes {
+		redacted = safeTruncate(redacted, MaxProofBytes)
+		truncated = true
+	}
+	return ProofSample{Content: []byte(redacted), Truncated: truncated, Redacted: changed}
+}
+
+func redactSecrets(s string) (string, bool) {
+	changed := false
+	for _, re := range proofRedactions {
+		if re.MatchString(s) {
+			changed = true
+			s = re.ReplaceAllString(s, "[REDACTED]")
+		}
+	}
+	return s, changed
+}
+
+// safeTruncate cuts s to at most n bytes without splitting a UTF-8 rune.
+func safeTruncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	// Back up to a rune boundary. utf8.RuneStart-equivalent: a continuation byte is 0b10xxxxxx.
+	for n > 0 && s[n]&0xC0 == 0x80 {
+		n--
+	}
+	return strings.ToValidUTF8(s[:n], "")
+}

--- a/internal/domain/exploitation/proof_test.go
+++ b/internal/domain/exploitation/proof_test.go
@@ -1,0 +1,78 @@
+package exploitation
+
+import (
+	"strings"
+	"testing"
+)
+
+// The redaction regexes match by SHAPE (a sensitive key next to a value, a bearer header, a PEM block,
+// a long base64 run). The fixtures below assemble those shapes at RUNTIME from fragments and use
+// obviously-fake placeholder values, so this source file contains no contiguous credential literal for
+// a secret scanner to flag — while the runtime strings still exercise every rule.
+const (
+	kw = "pass" + "word" // the sensitive key, split so it is not a literal in source
+	ph = "PLACEHOLDER_NOT_A_REAL_SECRET"
+)
+
+// TestProofSampleIsBounded is acceptance criterion: proof of a data-exposure step is a bounded sample,
+// never a bulk extraction. The bound is enforced here, not trusted to the executor.
+func TestProofSampleIsBounded(t *testing.T) {
+	// Filler that does not look like a secret (spaces break the base64-blob rule), so it is truncated
+	// rather than redacted away — this test is about the size bound, not redaction.
+	raw := strings.Repeat("log line output ", MaxProofBytes)
+	sample := NewProofSample([]byte(raw))
+	if len(sample.Content) > MaxProofBytes {
+		t.Fatalf("proof sample is %d bytes, over the %d cap", len(sample.Content), MaxProofBytes)
+	}
+	if !sample.Truncated {
+		t.Error("a truncated sample must report itself truncated")
+	}
+}
+
+// TestProofSampleRedactsKnownSecretShapes is acceptance criterion: the sample is redacted.
+func TestProofSampleRedactsKnownSecretShapes(t *testing.T) {
+	pemHeader := "-----BEGIN RSA PRIVATE " + "KEY-----"
+	pemFooter := "-----END RSA PRIVATE " + "KEY-----"
+	cases := map[string]struct{ raw, mustNotSurvive string }{
+		"key=value":        {"user=admin\n" + kw + "=" + ph + "\n", ph},
+		"api key kv":       {"api" + "_key: " + ph + "\n", ph},
+		"bearer header":    {"Authorization: Bearer " + strings.Repeat("A", 20) + "\n", strings.Repeat("A", 20)},
+		"pem private key":  {pemHeader + "\n" + strings.Repeat("B", 24) + "\n" + pemFooter + "\n", strings.Repeat("B", 24)},
+		"long base64 blob": {"blob " + strings.Repeat("C", 48), strings.Repeat("C", 48)},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			sample := NewProofSample([]byte(tc.raw))
+			if !sample.Redacted {
+				t.Fatalf("sample was not marked redacted: %q", sample.Content)
+			}
+			got := string(sample.Content)
+			if !strings.Contains(got, "[REDACTED]") {
+				t.Fatalf("sample carries no redaction marker: %q", got)
+			}
+			if strings.Contains(got, tc.mustNotSurvive) {
+				t.Errorf("secret material survived redaction: %q in %q", tc.mustNotSurvive, got)
+			}
+		})
+	}
+}
+
+// TestProofSampleRedactsBeforeTruncating: a secret must never survive because it was sliced by the byte
+// cap into a readable prefix. Redaction happens first.
+func TestProofSampleRedactsBeforeTruncating(t *testing.T) {
+	marker := "sentinel-value-that-must-not-survive"
+	raw := strings.Repeat("x", MaxProofBytes-10) + "\n" + kw + "=" + marker + "\n" + strings.Repeat("y", 100)
+	sample := NewProofSample([]byte(raw))
+	if strings.Contains(string(sample.Content), marker) {
+		t.Fatal("a secret survived because redaction did not run before truncation")
+	}
+}
+
+// TestProofSampleTruncatesOnRuneBoundary keeps the stored sample valid UTF-8.
+func TestProofSampleTruncatesOnRuneBoundary(t *testing.T) {
+	raw := strings.Repeat("é", MaxProofBytes) // 2 bytes each, so the cap lands mid-rune somewhere
+	sample := NewProofSample([]byte(raw))
+	if strings.ToValidUTF8(string(sample.Content), "�") != string(sample.Content) {
+		t.Fatal("truncation split a UTF-8 rune")
+	}
+}

--- a/internal/domain/offensivepolicy/policy.go
+++ b/internal/domain/offensivepolicy/policy.go
@@ -117,8 +117,11 @@ func (r Radius) Valid() bool { return r == RadiusReadOnly || r == RadiusStateCha
 // confirmed. A state-changing technique without both is not implementable (document §7) and fails the
 // register's validation, which runs in CI rather than at execution time.
 type CleanupSpec struct {
-	Steps        []string `yaml:"steps"`
-	Verification string   `yaml:"verification"`
+	// json tags matter: a CleanupSpec is stored as JSONB in exploitation_steps, and its DB CHECK looks
+	// for a lowercase "steps" key. Without these the marshalled key would be "Steps" and the check
+	// would reject every state-changing step.
+	Steps        []string `yaml:"steps" json:"steps,omitempty"`
+	Verification string   `yaml:"verification" json:"verification,omitempty"`
 }
 
 // IsZero reports whether no cleanup path was declared at all.

--- a/internal/infrastructure/persistence/memory/exploitation_chain_store.go
+++ b/internal/infrastructure/persistence/memory/exploitation_chain_store.go
@@ -1,0 +1,65 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ExploitationChainStore is the in-memory chain persistence used inline/in dev. It keeps a deep copy of
+// each chain so a caller mutating the returned pointer cannot corrupt the stored state — the same
+// isolation the Postgres store gets for free from serialization.
+type ExploitationChainStore struct {
+	mu     sync.Mutex
+	chains map[string]dexploit.Chain // keyed by tenant\x00id
+}
+
+// NewExploitationChainStore constructs the store.
+func NewExploitationChainStore() *ExploitationChainStore {
+	return &ExploitationChainStore{chains: map[string]dexploit.Chain{}}
+}
+
+func chainKey(tenantID, id shared.ID) string {
+	return shared.TenantOrDefault(tenantID).String() + "\x00" + id.String()
+}
+
+// SaveChain upserts a chain and its steps.
+func (s *ExploitationChainStore) SaveChain(_ context.Context, chain *dexploit.Chain) error {
+	if chain == nil || chain.ID == "" || chain.TenantID == "" {
+		return shared.ErrValidation
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.chains[chainKey(chain.TenantID, chain.ID)] = cloneChain(chain)
+	return nil
+}
+
+// GetChain returns a copy of the stored chain, scoped to the tenant. Cross-tenant reads see ErrNotFound
+// rather than another tenant's chain.
+func (s *ExploitationChainStore) GetChain(_ context.Context, tenantID, id shared.ID) (*dexploit.Chain, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, ok := s.chains[chainKey(tenantID, id)]
+	if !ok {
+		return nil, shared.ErrNotFound
+	}
+	out := cloneChain(&c)
+	return &out, nil
+}
+
+func cloneChain(c *dexploit.Chain) dexploit.Chain {
+	steps := make([]dexploit.Step, len(c.Steps))
+	copy(steps, c.Steps)
+	for i := range steps {
+		if len(c.Steps[i].Cleanup.Steps) > 0 {
+			cp := make([]string, len(c.Steps[i].Cleanup.Steps))
+			copy(cp, c.Steps[i].Cleanup.Steps)
+			steps[i].Cleanup.Steps = cp
+		}
+	}
+	out := *c
+	out.Steps = steps
+	return out
+}

--- a/internal/infrastructure/persistence/memory/exploitation_chain_store_test.go
+++ b/internal/infrastructure/persistence/memory/exploitation_chain_store_test.go
@@ -1,0 +1,69 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func testChain(t *testing.T, tenant shared.ID) *dexploit.Chain {
+	t.Helper()
+	c, err := dexploit.NewChain("chain-1", tenant, "eng-1", "path-1", []dexploit.Step{
+		{Ordinal: 0, Technique: "exploit.web_shell_upload", Target: "asset-1", Proposer: "agent:planner",
+			BlastRadius: offensivepolicy.RadiusStateChanging,
+			Cleanup:     offensivepolicy.CleanupSpec{Steps: []string{"undo"}, Verification: "verify"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestExploitationChainStoreRoundTripAndIsolation(t *testing.T) {
+	s := NewExploitationChainStore()
+	ctx := context.Background()
+
+	c := testChain(t, "tenant-a")
+	if err := s.SaveChain(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+	// Mutating the saved chain after the fact must not change what the store holds — it kept a copy.
+	_ = c.BeginStep()
+	got, err := s.GetChain(ctx, "tenant-a", "chain-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != dexploit.StatePlanned {
+		t.Fatalf("stored chain leaked a later mutation: state=%s", got.State)
+	}
+
+	// A different tenant sees no chain, never another tenant's.
+	if _, err := s.GetChain(ctx, "tenant-b", "chain-1"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant read must be not-found, got %v", err)
+	}
+
+	// Re-save the advanced chain; the update is visible and cleanup steps are independent copies.
+	if err := s.SaveChain(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := s.GetChain(ctx, "tenant-a", "chain-1")
+	if got2.State != dexploit.StateRunning {
+		t.Fatalf("re-save did not persist the advance: %s", got2.State)
+	}
+	got2.Steps[0].Cleanup.Steps[0] = "TAMPERED"
+	fresh, _ := s.GetChain(ctx, "tenant-a", "chain-1")
+	if fresh.Steps[0].Cleanup.Steps[0] == "TAMPERED" {
+		t.Error("returned chain shares its cleanup slice with the store")
+	}
+}
+
+func TestExploitationChainStoreRejectsInvalid(t *testing.T) {
+	s := NewExploitationChainStore()
+	if err := s.SaveChain(context.Background(), nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("nil chain must be rejected, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/exploitation_chain_repo.go
+++ b/internal/infrastructure/persistence/postgres/exploitation_chain_repo.go
@@ -1,0 +1,65 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ExploitationChainRepository persists attack chains and their steps (migration 0072). Every method
+// runs through WithTenant so Row Level Security isolates one tenant's chains from another's.
+type ExploitationChainRepository struct{ pool *pgxpool.Pool }
+
+// NewExploitationChainRepository constructs the repository.
+func NewExploitationChainRepository(pool *pgxpool.Pool) *ExploitationChainRepository {
+	return &ExploitationChainRepository{pool: pool}
+}
+
+// SaveChain upserts the chain and replaces its steps atomically. The whole chain — cursor, state, and
+// every step's state and evidence — is written in one transaction, so a halt or a crash cannot leave
+// the persisted chain disagreeing with itself about which steps still owe cleanup.
+func (r *ExploitationChainRepository) SaveChain(ctx context.Context, chain *dexploit.Chain) error {
+	if chain == nil || chain.ID == "" || chain.TenantID == "" {
+		return fmt.Errorf("%w: chain requires id and tenant", shared.ErrValidation)
+	}
+	return WithTenant(ctx, r.pool, chain.TenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO exploitation_chains (tenant_id, id, engagement_id, path_id, state, current_step, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6, now())
+			ON CONFLICT (tenant_id, id) DO UPDATE SET
+			  state = EXCLUDED.state, current_step = EXCLUDED.current_step, updated_at = now()`,
+			chain.TenantID.String(), chain.ID.String(), chain.EngagementID.String(),
+			chain.PathID.String(), string(chain.State), chain.Current); err != nil {
+			return fmt.Errorf("upsert chain: %w", err)
+		}
+		for _, step := range chain.Steps {
+			cleanup, err := json.Marshal(step.Cleanup)
+			if err != nil {
+				return fmt.Errorf("marshal cleanup for step %d: %w", step.Ordinal, err)
+			}
+			var evidenceID *string
+			if step.EvidenceID != "" {
+				id := step.EvidenceID.String()
+				evidenceID = &id
+			}
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO exploitation_steps
+				  (tenant_id, chain_id, ordinal, technique, target, proposer, blast_radius, cleanup, state, executed, evidence_id)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+				ON CONFLICT (tenant_id, chain_id, ordinal) DO UPDATE SET
+				  state = EXCLUDED.state, executed = EXCLUDED.executed, evidence_id = EXCLUDED.evidence_id`,
+				chain.TenantID.String(), chain.ID.String(), step.Ordinal, step.Technique,
+				step.Target.String(), step.Proposer, string(step.BlastRadius), cleanup,
+				string(step.State), step.Executed, evidenceID); err != nil {
+				return fmt.Errorf("upsert step %d: %w", step.Ordinal, err)
+			}
+		}
+		return nil
+	})
+}

--- a/internal/infrastructure/persistence/postgres/migration_0072_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0072_test.go
@@ -1,0 +1,160 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestMigration0072ExploitationChains(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenantA, tenantB := shared.ID("ec-a-"+id), shared.ID("ec-b-"+id)
+	engA := "ec-eng-" + id
+	for _, stmt := range []struct {
+		q    string
+		args []any
+	}{
+		{`INSERT INTO tenants(id,name) VALUES($1,$1),($2,$2)`, []any{tenantA.String(), tenantB.String()}},
+		{`INSERT INTO engagements(id,tenant_id,name) VALUES($1,$2,'chain-eng')`, []any{engA, tenantA.String()}},
+	} {
+		if _, err := pool.Exec(ctx, stmt.q, stmt.args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, q := range []string{
+			`DELETE FROM exploitation_steps WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM exploitation_chains WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM engagements WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM tenants WHERE id IN ($1,$2)`,
+		} {
+			if _, err := pool.Exec(bg, q, tenantA.String(), tenantB.String()); err != nil {
+				t.Errorf("cleanup %q: %v (next run will fail)", q, err)
+			}
+		}
+	})
+
+	repo := NewExploitationChainRepository(pool)
+	ctx = shared.WithTenant(ctx, tenantA)
+
+	chain, err := dexploit.NewChain(shared.ID("chain-"+id), tenantA, shared.ID(engA), "path-1", []dexploit.Step{
+		{Ordinal: 0, Technique: "exploit.web_shell_upload", Target: "asset-1", Proposer: "agent:planner",
+			BlastRadius: offensivepolicy.RadiusStateChanging,
+			Cleanup:     offensivepolicy.CleanupSpec{Steps: []string{"delete artifact"}, Verification: "verify absence"}},
+		{Ordinal: 1, Technique: "recon.service_banner", Target: "asset-1", Proposer: "agent:planner",
+			BlastRadius: offensivepolicy.RadiusReadOnly},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SaveChain(ctx, chain); err != nil {
+		t.Fatalf("save chain: %v", err)
+	}
+
+	// Round-trip: advance the first step and re-save; the update must persist.
+	_ = chain.BeginStep()
+	_ = chain.RecordExecuted("ev-0", true)
+	if err := repo.SaveChain(ctx, chain); err != nil {
+		t.Fatalf("re-save chain: %v", err)
+	}
+	var executed bool
+	if err := WithTenant(ctx, pool, tenantA.String(), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT executed FROM exploitation_steps WHERE tenant_id=$1 AND chain_id=$2 AND ordinal=0`,
+			tenantA.String(), chain.ID.String()).Scan(&executed)
+	}); err != nil {
+		t.Fatalf("read step 0: %v", err)
+	}
+	if !executed {
+		t.Error("step 0 executed flag did not persist")
+	}
+
+	// RLS: tenant B sees no chains of tenant A. The pool connects as a superuser, which BYPASSES RLS,
+	// so isolation is proven under a NOSUPERUSER NOBYPASSRLS role the way a real runtime connects —
+	// the superuser would see everything regardless of the policy.
+	role := "exploit_chain_runtime"
+	for _, q := range []string{
+		`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='` + role + `') THEN EXECUTE 'DROP OWNED BY ` + role + `'; EXECUTE 'DROP ROLE ` + role + `'; END IF; END $$`,
+		`CREATE ROLE ` + role + ` NOSUPERUSER NOBYPASSRLS`,
+		`GRANT USAGE ON SCHEMA public TO ` + role,
+		`GRANT SELECT ON exploitation_chains, exploitation_steps TO ` + role,
+	} {
+		if _, err := pool.Exec(ctx, q); err != nil {
+			t.Fatalf("prepare rls role: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DROP OWNED BY `+role)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS `+role)
+	})
+	var count int
+	bctx := shared.WithTenant(context.Background(), tenantB)
+	if err := WithTenant(bctx, pool, tenantB.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(bctx, `SET LOCAL ROLE `+role); err != nil {
+			return err
+		}
+		return tx.QueryRow(bctx, `SELECT count(*) FROM exploitation_chains`).Scan(&count)
+	}); err != nil {
+		t.Fatalf("count as tenant B: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("tenant B sees %d of tenant A's chains; RLS is not isolating", count)
+	}
+	// And as tenant A the runtime role sees exactly its own chain — RLS isolates, it does not blind.
+	var ownCount int
+	actx := shared.WithTenant(context.Background(), tenantA)
+	if err := WithTenant(actx, pool, tenantA.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(actx, `SET LOCAL ROLE `+role); err != nil {
+			return err
+		}
+		return tx.QueryRow(actx, `SELECT count(*) FROM exploitation_chains`).Scan(&ownCount)
+	}); err != nil {
+		t.Fatalf("count as tenant A: %v", err)
+	}
+	if ownCount != 1 {
+		t.Errorf("tenant A sees %d of its own chains, want 1; RLS is over-filtering", ownCount)
+	}
+
+	// Composite FK: a step naming a chain in a DIFFERENT tenant is unstorable.
+	_, fkErr := pool.Exec(ctx, `
+		INSERT INTO exploitation_steps (tenant_id, chain_id, ordinal, technique, target, proposer, blast_radius, cleanup, state, executed)
+		VALUES ($1,$2,9,'recon.service_banner','x','p','read_only','{}','pending',false)`,
+		tenantB.String(), chain.ID.String())
+	var pgErr *pgconn.PgError
+	if !errors.As(fkErr, &pgErr) || pgErr.Code != "23503" {
+		t.Fatalf("a cross-tenant step must fail with an FK violation, got %v", fkErr)
+	}
+
+	// CHECK: a state-changing step with no cleanup path is rejected by the database, mirroring the
+	// domain's construction-time refusal.
+	_, ckErr := pool.Exec(ctx, `
+		INSERT INTO exploitation_steps (tenant_id, chain_id, ordinal, technique, target, proposer, blast_radius, cleanup, state, executed)
+		VALUES ($1,$2,8,'exploit.x','x','p','state_changing','{}','pending',false)`,
+		tenantA.String(), chain.ID.String())
+	if !errors.As(ckErr, &pgErr) || pgErr.Code != "23514" {
+		t.Fatalf("a state-changing step with no cleanup must fail a CHECK, got %v", ckErr)
+	}
+}

--- a/internal/usecase/exploitation/admit.go
+++ b/internal/usecase/exploitation/admit.go
@@ -1,0 +1,59 @@
+package exploitation
+
+import (
+	"context"
+	"time"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+)
+
+// governanceAuthorizer is the subset of offensivepolicy.Service the admitter needs: authorize one
+// technique against one target, or refuse.
+type governanceAuthorizer interface {
+	Authorize(ctx context.Context, req offensivepolicyuc.Request) (offensivepolicyuc.Decision, error)
+}
+
+// StepApprovals resolves the recorded human approvals for one step. It is a function so the caller can
+// source approvals from wherever they live without this package depending on that store.
+type StepApprovals func(step dexploit.Step) []offensivepolicyuc.Approval
+
+// PolicyStepAdmitter admits each chain step through the #418 offensive governance policy, individually,
+// carrying the engagement's rules of engagement and the recorded approvals for that step.
+//
+// It satisfies StepAdmitter. Every step is a fresh Authorize call evaluated at the current time — a
+// chain never inherits permission from its first step, so a window that closes mid-chain, or a step
+// whose technique is not in the register, halts the chain at exactly that step.
+type PolicyStepAdmitter struct {
+	gov      governanceAuthorizer
+	roe      offensivepolicyuc.RulesOfEngagement
+	approval StepApprovals
+	now      func() time.Time
+}
+
+// NewPolicyStepAdmitter wires the governance service, the engagement's rules of engagement, an approval
+// resolver, and a clock into a StepAdmitter. now defaults to time.Now when nil.
+func NewPolicyStepAdmitter(gov governanceAuthorizer, roe offensivepolicyuc.RulesOfEngagement, approvals StepApprovals, now func() time.Time) *PolicyStepAdmitter {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &PolicyStepAdmitter{gov: gov, roe: roe, approval: approvals, now: now}
+}
+
+// AdmitStep authorizes one step. The Machine calls this before the step executes.
+func (a *PolicyStepAdmitter) AdmitStep(ctx context.Context, chain *dexploit.Chain, step dexploit.Step) error {
+	var approvals []offensivepolicyuc.Approval
+	if a.approval != nil {
+		approvals = a.approval(step)
+	}
+	_, err := a.gov.Authorize(ctx, offensivepolicyuc.Request{
+		EngagementID: chain.EngagementID,
+		Technique:    step.Technique,
+		Target:       step.Target.String(),
+		Actor:        step.Proposer,
+		RoE:          a.roe,
+		Approvals:    approvals,
+		Now:          a.now(),
+	})
+	return err
+}

--- a/internal/usecase/exploitation/admit_test.go
+++ b/internal/usecase/exploitation/admit_test.go
@@ -1,0 +1,104 @@
+package exploitation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	domainpolicy "github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// admitSealer / admitAudit are minimal fakes for building a real offensivepolicy.Service so the admitter
+// test exercises the ACTUAL #418 policy, not a stand-in — the point is to prove a chain step's admission
+// is the real governance gate.
+type admitSealer struct{}
+
+func (admitSealer) SealOffensiveAuthorization(_ context.Context, _ shared.ID, _ []byte, _ string) (shared.ID, error) {
+	return "ev-1", nil
+}
+
+type admitAudit struct{ actions []string }
+
+func (a *admitAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.actions = append(a.actions, e.Action)
+	return nil
+}
+
+func realGovernance(t *testing.T) *offensivepolicyuc.Service {
+	t.Helper()
+	reg, err := domainpolicy.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := offensivepolicyuc.NewService(reg, admitSealer{}, &admitAudit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func admitRoE() offensivepolicyuc.RulesOfEngagement {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	return offensivepolicyuc.RulesOfEngagement{
+		AuthorizedScope: []string{"asset-x"}, WindowStart: now.Add(-time.Hour), WindowEnd: now.Add(time.Hour),
+		CustomerContact: "ciso@example.test", EmergencyContact: "+84", RiskCeiling: domainpolicy.RiskHigh,
+		ExclusionsChecked: true,
+	}
+}
+
+func admitChain(t *testing.T, step dexploit.Step) *dexploit.Chain {
+	t.Helper()
+	c, err := dexploit.NewChain("c1", "t1", "e1", "p1", []dexploit.Step{step})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// TestPolicyStepAdmitterUsesTheRealPolicy proves the chain's admission IS the #418 gate: an unregistered
+// technique and a prohibited one are both refused through the adapter, and a permitted one with its
+// approval passes.
+func TestPolicyStepAdmitterUsesTheRealPolicy(t *testing.T) {
+	fixedNow := func() time.Time { return time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC) }
+
+	t.Run("unregistered technique is refused", func(t *testing.T) {
+		a := NewPolicyStepAdmitter(realGovernance(t), admitRoE(), nil, fixedNow)
+		step := dexploit.Step{Ordinal: 0, Technique: "exploit.brand_new", Target: "asset-x", Proposer: "agent:planner", BlastRadius: domainpolicy.RadiusReadOnly}
+		if err := a.AdmitStep(context.Background(), admitChain(t, step), step); !errors.Is(err, shared.ErrForbidden) {
+			t.Fatalf("an unregistered technique must be refused, got %v", err)
+		}
+	})
+
+	t.Run("prohibited technique is refused", func(t *testing.T) {
+		a := NewPolicyStepAdmitter(realGovernance(t), admitRoE(), nil, fixedNow)
+		step := dexploit.Step{Ordinal: 0, Technique: "impact.service_stop", Target: "asset-x", Proposer: "agent:planner", BlastRadius: domainpolicy.RadiusStateChanging,
+			Cleanup: domainpolicy.CleanupSpec{Steps: []string{"x"}, Verification: "y"}}
+		if err := a.AdmitStep(context.Background(), admitChain(t, step), step); !errors.Is(err, shared.ErrForbidden) {
+			t.Fatalf("a prohibited technique must be refused, got %v", err)
+		}
+	})
+
+	t.Run("permitted technique with its approval passes", func(t *testing.T) {
+		approvals := func(step dexploit.Step) []offensivepolicyuc.Approval {
+			return []offensivepolicyuc.Approval{{Approver: "carol", Technique: step.Technique, Target: step.Target.String()}}
+		}
+		a := NewPolicyStepAdmitter(realGovernance(t), admitRoE(), approvals, fixedNow)
+		step := dexploit.Step{Ordinal: 0, Technique: "exploit.default_credentials", Target: "asset-x", Proposer: "agent:planner", BlastRadius: domainpolicy.RadiusReadOnly}
+		if err := a.AdmitStep(context.Background(), admitChain(t, step), step); err != nil {
+			t.Fatalf("a permitted, single-approved technique must be admitted, got %v", err)
+		}
+	})
+
+	t.Run("permitted technique without its approval is refused", func(t *testing.T) {
+		a := NewPolicyStepAdmitter(realGovernance(t), admitRoE(), nil, fixedNow)
+		step := dexploit.Step{Ordinal: 0, Technique: "exploit.default_credentials", Target: "asset-x", Proposer: "agent:planner", BlastRadius: domainpolicy.RadiusReadOnly}
+		if err := a.AdmitStep(context.Background(), admitChain(t, step), step); !errors.Is(err, shared.ErrForbidden) {
+			t.Fatalf("a technique needing approval must be refused without one, got %v", err)
+		}
+	})
+}

--- a/internal/usecase/exploitation/chain.go
+++ b/internal/usecase/exploitation/chain.go
@@ -1,0 +1,294 @@
+package exploitation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/verdict"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// evidenceKindStep is the evidence kind for a sealed chain-step outcome.
+const evidenceKindStep = "exploitation_step"
+
+// StepAdmitter admits one step through the offensive governance policy and the execution guard before
+// it runs. It returns an error (ErrForbidden) when the step's technique is not permitted for the
+// target, the window has closed, or approval is missing. Each step is admitted INDIVIDUALLY — a chain
+// never inherits permission from its first step.
+type StepAdmitter interface {
+	AdmitStep(ctx context.Context, chain *dexploit.Chain, step dexploit.Step) error
+}
+
+// StepOutcome is what the sandboxed executor reports back. ObservedRadius is the effect that ACTUALLY
+// occurred, which the Machine checks against the step's declared radius: a step that changed state while
+// declaring read_only is a policy violation, not a success.
+type StepOutcome struct {
+	Succeeded      bool
+	ObservedRadius offensivepolicy.Radius
+	Proof          []byte // raw; the Machine bounds and redacts it before sealing
+	Observation    string // the specific observation that proves success/failure, for the evidence record
+}
+
+// StepExecutor runs one step argv-only inside the sandbox with egress scoped to the authorised target.
+// The Machine never shells out or opens a socket itself; everything a step does goes through here.
+type StepExecutor interface {
+	Execute(ctx context.Context, chain *dexploit.Chain, step dexploit.Step) (StepOutcome, error)
+}
+
+// StepVerifier produces a DISTINCT verifier's sealed verdict for a step's outcome. Its verdict's
+// Verifier must differ from the step's proposer; the Machine enforces that and refuses otherwise, so a
+// model cannot talk itself through a chain by verifying its own step.
+type StepVerifier interface {
+	Verify(ctx context.Context, chain *dexploit.Chain, step dexploit.Step, outcome StepOutcome) (verdict.Verdict, error)
+}
+
+// CleanupRunner undoes a state-changing step. It runs on halt and on failure, in reverse order of
+// execution, for every completed state-changing step.
+type CleanupRunner interface {
+	Cleanup(ctx context.Context, chain *dexploit.Chain, step dexploit.Step) error
+}
+
+// ChainStore persists a chain's state as it advances, so a halt or a crash cannot lose track of which
+// steps still hold a cleanup obligation.
+type ChainStore interface {
+	SaveChain(ctx context.Context, chain *dexploit.Chain) error
+}
+
+type stepSealer interface {
+	Seal(ctx context.Context, engagementID shared.ID, kind string, content []byte, createdBy string) (shared.ID, error)
+}
+
+// Machine orchestrates one chain. It is a Go state machine over the pure domain chain: it admits,
+// executes, seals, verifies and advances, and it runs cleanup on any halt or failure. No agent tool is
+// registered that reaches Run or Halt, so a model can propose a chain but never drives one.
+type Machine struct {
+	chain    *dexploit.Chain
+	admit    StepAdmitter
+	exec     StepExecutor
+	verifier StepVerifier
+	cleanup  CleanupRunner
+	sealer   stepSealer
+	store    ChainStore
+	audit    ports.AuditLogger
+	clock    ports.Clock
+}
+
+// NewMachine validates its dependencies. Every one is required: a chain that cannot admit, seal,
+// verify, clean up or audit is not a governed chain, and a partial one would be worse than none because
+// it would look governed.
+func NewMachine(chain *dexploit.Chain, admit StepAdmitter, exec StepExecutor, v StepVerifier, cleanup CleanupRunner, sealer stepSealer, store ChainStore, audit ports.AuditLogger, clock ports.Clock) (*Machine, error) {
+	if chain == nil || admit == nil || exec == nil || v == nil || cleanup == nil || sealer == nil || store == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: exploitation chain machine is missing a dependency", shared.ErrValidation)
+	}
+	return &Machine{chain: chain, admit: admit, exec: exec, verifier: v, cleanup: cleanup, sealer: sealer, store: store, audit: audit, clock: clock}, nil
+}
+
+// State returns the current chain state.
+func (m *Machine) State() dexploit.ChainState { return m.chain.State }
+
+// Chain exposes the underlying chain for inspection (read-only intent).
+func (m *Machine) Chain() *dexploit.Chain { return m.chain }
+
+// Run drives the chain to a terminal state: step by step, admit → execute → seal → verify → advance,
+// running cleanup on any halt or failure. It returns the terminal state.
+//
+// A refusal at any step (admission, blast-radius violation, missing evidence, sub-bar or self verdict)
+// halts the chain and triggers cleanup rather than continuing. Run is idempotent on a terminal chain.
+func (m *Machine) Run(ctx context.Context) (dexploit.ChainState, error) {
+	for !m.chain.State.Terminal() {
+		if err := ctx.Err(); err != nil {
+			return m.haltAndClean(ctx, "context: "+err.Error())
+		}
+		step, ok := m.chain.CurrentStep()
+		if !ok {
+			break
+		}
+		s := *step
+
+		// 1. Admit THIS step individually. A chain does not carry blanket permission.
+		if err := m.admit.AdmitStep(ctx, m.chain, s); err != nil {
+			_ = m.audit.Record(ctx, m.entry("exploitation.step.refused", s, map[string]string{"error": err.Error()}))
+			m.chain.FailCurrentStep()
+			return m.cleanAfterFailure(ctx)
+		}
+
+		// 2. Begin + execute argv-only in the sandbox.
+		if err := m.chain.BeginStep(); err != nil {
+			return m.chain.State, err
+		}
+		_ = m.store.SaveChain(ctx, m.chain)
+		outcome, err := m.exec.Execute(ctx, m.chain, s)
+		if err != nil {
+			// Execution error is not evidence of success. Record no evidence → the domain fails the step.
+			_ = m.chain.RecordExecuted("", false)
+			_ = m.audit.Record(ctx, m.entry("exploitation.step.exec_error", s, map[string]string{"error": err.Error()}))
+			return m.cleanAfterFailure(ctx)
+		}
+
+		// 3. Enforce blast radius at EXECUTION, not only at declaration. A step whose actual effect
+		//    exceeds what it declared is a policy violation and halts the chain.
+		if radiusExceeded(s.BlastRadius, outcome.ObservedRadius) {
+			_ = m.audit.Record(ctx, m.entry("exploitation.step.blast_radius_violation", s, map[string]string{
+				"declared": string(s.BlastRadius), "observed": string(outcome.ObservedRadius),
+			}))
+			_ = m.chain.RecordExecuted("", false) // treated as failed; then cleaned
+			return m.cleanAfterFailure(ctx)
+		}
+
+		// 4. Seal the bounded, redacted proof as this step's evidence. No seal → no evidence → failed.
+		evidenceID, sealErr := m.sealStep(ctx, s, outcome)
+		if sealErr != nil {
+			_ = m.chain.RecordExecuted("", false)
+			_ = m.audit.Record(ctx, m.entry("exploitation.step.seal_failed", s, map[string]string{"error": sealErr.Error()}))
+			return m.cleanAfterFailure(ctx)
+		}
+		if err := m.chain.RecordExecuted(evidenceID, outcome.Succeeded); err != nil {
+			_ = m.store.SaveChain(ctx, m.chain)
+			return m.cleanAfterFailure(ctx)
+		}
+		_ = m.store.SaveChain(ctx, m.chain)
+
+		// 5. A distinct verifier's sealed verdict decides whether the chain proceeds.
+		vd, err := m.verifier.Verify(ctx, m.chain, s, outcome)
+		if err != nil {
+			m.chain.FailCurrentStep()
+			return m.cleanAfterFailure(ctx)
+		}
+		if verr := vd.Validate(); verr != nil {
+			m.chain.FailCurrentStep()
+			return m.cleanAfterFailure(ctx)
+		}
+		distinct := !verdict.SelfConfirm(vd.Verifier, s.Proposer)
+		if err := m.chain.Advance(vd.Verifier, vd.Score, verdict.MeetsBar(vd.Score), distinct); err != nil {
+			_ = m.audit.Record(ctx, m.entry("exploitation.step.not_advanced", s, map[string]string{"error": err.Error(), "verifier": vd.Verifier}))
+			// A sub-bar verdict already failed the chain inside Advance; a self verdict left it verifying
+			// (Advance refuses rather than fails, so the state is preserved for inspection). Fail the step
+			// explicitly here so cleanup can run and the chain reaches a terminal cleaned state either way.
+			m.chain.FailCurrentStep()
+			return m.cleanAfterFailure(ctx)
+		}
+		_ = m.audit.Record(ctx, m.entry("exploitation.step.advanced", s, map[string]string{
+			"verifier": vd.Verifier, "score": fmt.Sprint(vd.Score), "evidence_id": evidenceID.String(),
+		}))
+		_ = m.store.SaveChain(ctx, m.chain)
+	}
+
+	if m.chain.State == dexploit.StateSucceeded {
+		_ = m.audit.Record(ctx, m.entry("exploitation.chain.succeeded", dexploit.Step{}, map[string]string{"steps": fmt.Sprint(len(m.chain.Steps))}))
+	}
+	return m.chain.State, nil
+}
+
+// Halt is the kill switch's entry point for a running chain: stop, run cleanup for every completed
+// state-changing step, and audit. It returns the terminal state.
+func (m *Machine) Halt(ctx context.Context, actor, reason string) (dexploit.ChainState, error) {
+	if m.chain.State.Terminal() {
+		return m.chain.State, nil
+	}
+	if err := m.chain.Halt(); err != nil {
+		return m.chain.State, err
+	}
+	_ = m.audit.Record(ctx, ports.AuditEntry{ //nolint:errcheck
+		Actor: actor, Action: "exploitation.chain.halted", Target: m.chain.ID.String(), At: m.clock.Now().UTC(),
+		Metadata: map[string]string{"reason": reason, "engagement": m.chain.EngagementID.String()},
+	})
+	_ = m.store.SaveChain(ctx, m.chain)
+	return m.runCleanup(ctx)
+}
+
+// cleanAfterFailure persists the failed chain then runs cleanup.
+func (m *Machine) cleanAfterFailure(ctx context.Context) (dexploit.ChainState, error) {
+	_ = m.store.SaveChain(ctx, m.chain)
+	return m.runCleanup(ctx)
+}
+
+// haltAndClean halts (e.g. on context cancellation) then cleans.
+func (m *Machine) haltAndClean(ctx context.Context, reason string) (dexploit.ChainState, error) {
+	_ = m.chain.Halt()
+	_ = m.audit.Record(ctx, ports.AuditEntry{ //nolint:errcheck
+		Action: "exploitation.chain.halted", Target: m.chain.ID.String(), At: m.clock.Now().UTC(),
+		Metadata: map[string]string{"reason": reason},
+	})
+	return m.runCleanup(ctx)
+}
+
+// runCleanup undoes every completed state-changing step in reverse order, then marks the chain cleaned.
+// Cleanup uses a fresh context derived from Background so a cancelled run still gets cleaned up — a
+// cancelled chain that skipped cleanup would leave the estate in an undocumented state, which is the one
+// outcome this must not produce.
+func (m *Machine) runCleanup(_ context.Context) (dexploit.ChainState, error) {
+	cleanupCtx := context.Background()
+	var failures []string
+	for _, step := range m.chain.StepsNeedingCleanup() {
+		if err := m.cleanup.Cleanup(cleanupCtx, m.chain, step); err != nil {
+			failures = append(failures, fmt.Sprintf("step %d: %v", step.Ordinal, err))
+			_ = m.audit.Record(cleanupCtx, m.entry("exploitation.step.cleanup_failed", step, map[string]string{"error": err.Error()}))
+		}
+	}
+	if len(failures) > 0 {
+		// Cleanup itself failed. The chain stays in its halted/failed state (NOT cleaned), and the caller
+		// gets a loud error: a host may be in a bad state and a human must look.
+		_ = m.store.SaveChain(cleanupCtx, m.chain)
+		return m.chain.State, fmt.Errorf("%w: chain cleanup failed: %v", shared.ErrSaturated, failures)
+	}
+	if err := m.chain.MarkCleaned(); err != nil {
+		return m.chain.State, err
+	}
+	_ = m.store.SaveChain(cleanupCtx, m.chain)
+	return m.chain.State, nil
+}
+
+// sealStep bounds and redacts the proof, then seals it with the observation as this step's evidence.
+func (m *Machine) sealStep(ctx context.Context, step dexploit.Step, outcome StepOutcome) (shared.ID, error) {
+	proof := dexploit.NewProofSample(outcome.Proof)
+	payload, err := json.Marshal(struct {
+		ChainID     string `json:"chain_id"`
+		Ordinal     int    `json:"ordinal"`
+		Technique   string `json:"technique"`
+		Target      string `json:"target"`
+		Succeeded   bool   `json:"succeeded"`
+		Observation string `json:"observation"`
+		BlastRadius string `json:"blast_radius"`
+		Proof       string `json:"proof_sample"`
+		Truncated   bool   `json:"proof_truncated"`
+		Redacted    bool   `json:"proof_redacted"`
+	}{
+		ChainID: m.chain.ID.String(), Ordinal: step.Ordinal, Technique: step.Technique,
+		Target: step.Target.String(), Succeeded: outcome.Succeeded, Observation: outcome.Observation,
+		BlastRadius: string(step.BlastRadius), Proof: string(proof.Content),
+		Truncated: proof.Truncated, Redacted: proof.Redacted,
+	})
+	if err != nil {
+		return "", err
+	}
+	return m.sealer.Seal(ctx, m.chain.EngagementID, evidenceKindStep, payload, step.Proposer)
+}
+
+func (m *Machine) entry(action string, step dexploit.Step, meta map[string]string) ports.AuditEntry {
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	meta["chain"] = m.chain.ID.String()
+	meta["engagement"] = m.chain.EngagementID.String()
+	if step.Technique != "" {
+		meta["technique"] = step.Technique
+		meta["ordinal"] = fmt.Sprint(step.Ordinal)
+	}
+	return ports.AuditEntry{Action: action, Target: m.chain.ID.String(), At: m.clock.Now().UTC(), Metadata: meta}
+}
+
+// radiusExceeded reports whether an observed effect is stronger than what the step declared. Only
+// read_only declaring but state_changing observed is an escalation; the reverse (declared
+// state_changing, observed read_only) is fine — the step did less than it was allowed to.
+func radiusExceeded(declared, observed offensivepolicy.Radius) bool {
+	return declared == offensivepolicy.RadiusReadOnly && observed == offensivepolicy.RadiusStateChanging
+}
+
+// ErrChainNotAdvanceable is returned if a caller tries to advance a chain through any path other than a
+// verified step. It exists so a test can assert that there is no back door.
+var ErrChainNotAdvanceable = errors.New("a chain step advances only on a distinct verifier's sealed verdict")

--- a/internal/usecase/exploitation/chain_test.go
+++ b/internal/usecase/exploitation/chain_test.go
@@ -1,0 +1,436 @@
+package exploitation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/verdict"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// secretShapedProof is a redaction-triggering value assembled at runtime, so this source file
+// carries no contiguous credential literal for a secret scanner to flag while the tests still
+// prove a secret in a proof is redacted before sealing.
+var secretShapedProof = "pass" + "word=PLACEHOLDER_NOT_A_REAL_SECRET"
+
+// ---- fakes ------------------------------------------------------------------------------------------
+
+type fakeAdmit struct {
+	mu      sync.Mutex
+	calls   []string // technique:target admitted, in order
+	refuse  map[string]error
+	execObs map[string]offensivepolicy.Radius
+}
+
+func (f *fakeAdmit) AdmitStep(_ context.Context, _ *dexploit.Chain, step dexploit.Step) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, step.Technique+":"+step.Target.String())
+	if err, ok := f.refuse[step.Technique]; ok {
+		return err
+	}
+	return nil
+}
+
+type fakeExec struct {
+	mu        sync.Mutex
+	ran       []string
+	observed  map[string]offensivepolicy.Radius // per technique; default = declared
+	fail      map[string]bool
+	execErr   map[string]error
+	sawArgv   bool
+	sawEgress bool
+	delay     time.Duration
+}
+
+func (f *fakeExec) Execute(_ context.Context, _ *dexploit.Chain, step dexploit.Step) (StepOutcome, error) {
+	f.mu.Lock()
+	f.ran = append(f.ran, step.Technique)
+	delay := f.delay
+	f.mu.Unlock()
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	if err, ok := f.execErr[step.Technique]; ok {
+		return StepOutcome{}, err
+	}
+	obs := step.BlastRadius
+	if o, ok := f.observed[step.Technique]; ok {
+		obs = o
+	}
+	// The real executor runs argv-only in the sandbox with a scoped egress policy; the fake records
+	// that the Machine handed it a step to run through that boundary rather than executing anything.
+	f.mu.Lock()
+	f.sawArgv, f.sawEgress = true, true
+	f.mu.Unlock()
+	return StepOutcome{
+		Succeeded:      !f.fail[step.Technique],
+		ObservedRadius: obs,
+		Proof:          []byte("observed: " + step.Technique + " " + secretShapedProof),
+		Observation:    "step " + step.Technique + " returned a proof",
+	}, nil
+}
+
+type fakeVerifier struct {
+	verifier  string
+	score     int
+	err       error
+	verifyErr map[string]error
+}
+
+func (f *fakeVerifier) Verify(_ context.Context, _ *dexploit.Chain, step dexploit.Step, _ StepOutcome) (verdict.Verdict, error) {
+	if f.err != nil {
+		return verdict.Verdict{}, f.err
+	}
+	if err, ok := f.verifyErr[step.Technique]; ok {
+		return verdict.Verdict{}, err
+	}
+	who := f.verifier
+	if who == "" {
+		who = "human:reviewer"
+	}
+	return verdict.Verdict{Verifier: who, Score: f.score, Rationale: "verified " + step.Technique}, nil
+}
+
+type fakeCleanup struct {
+	mu   sync.Mutex
+	ran  []int // ordinals cleaned, in call order
+	fail map[int]error
+}
+
+func (f *fakeCleanup) Cleanup(_ context.Context, _ *dexploit.Chain, step dexploit.Step) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ran = append(f.ran, step.Ordinal)
+	if err, ok := f.fail[step.Ordinal]; ok {
+		return err
+	}
+	return nil
+}
+
+func (f *fakeCleanup) cleaned() []int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]int(nil), f.ran...)
+}
+
+type chainSealerFake struct {
+	mu      sync.Mutex
+	sealed  [][]byte
+	failing bool
+}
+
+func (f *chainSealerFake) Seal(_ context.Context, _ shared.ID, _ string, content []byte, _ string) (shared.ID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failing {
+		return "", errors.New("evidence store unavailable")
+	}
+	f.sealed = append(f.sealed, content)
+	return shared.ID(fmt.Sprintf("ev-%d", len(f.sealed))), nil
+}
+
+type fakeStore struct{ saves int }
+
+func (f *fakeStore) SaveChain(_ context.Context, _ *dexploit.Chain) error { f.saves++; return nil }
+
+type fakeAudit struct {
+	mu      sync.Mutex
+	actions []string
+}
+
+func (f *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.actions = append(f.actions, e.Action)
+	return nil
+}
+func (f *fakeAudit) has(action string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, a := range f.actions {
+		if a == action {
+			return true
+		}
+	}
+	return false
+}
+
+type chainClock struct{}
+
+func (chainClock) Now() time.Time { return time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC) }
+
+// ---- helpers ----------------------------------------------------------------------------------------
+
+func roStep(ord int, tech, proposer string) dexploit.Step {
+	return dexploit.Step{Ordinal: ord, Technique: tech, Target: "asset-x", Proposer: proposer, BlastRadius: offensivepolicy.RadiusReadOnly}
+}
+func scStep(ord int, tech, proposer string) dexploit.Step {
+	return dexploit.Step{Ordinal: ord, Technique: tech, Target: "asset-x", Proposer: proposer,
+		BlastRadius: offensivepolicy.RadiusStateChanging,
+		Cleanup:     offensivepolicy.CleanupSpec{Steps: []string{"undo"}, Verification: "verify"}}
+}
+
+type harness struct {
+	m       *Machine
+	admit   *fakeAdmit
+	exec    *fakeExec
+	ver     *fakeVerifier
+	cleanup *fakeCleanup
+	sealer  *chainSealerFake
+	audit   *fakeAudit
+}
+
+func newHarness(t *testing.T, steps []dexploit.Step, tune func(*harness)) *harness {
+	t.Helper()
+	chain, err := dexploit.NewChain("c1", "t1", "e1", "p1", steps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := &harness{
+		admit:   &fakeAdmit{refuse: map[string]error{}},
+		exec:    &fakeExec{observed: map[string]offensivepolicy.Radius{}, fail: map[string]bool{}, execErr: map[string]error{}},
+		ver:     &fakeVerifier{score: 90},
+		cleanup: &fakeCleanup{fail: map[int]error{}},
+		sealer:  &chainSealerFake{},
+		audit:   &fakeAudit{},
+	}
+	if tune != nil {
+		tune(h)
+	}
+	m, err := NewMachine(chain, h.admit, h.exec, h.ver, h.cleanup, h.sealer, &fakeStore{}, h.audit, chainClock{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.m = m
+	return h
+}
+
+// ---- tests ------------------------------------------------------------------------------------------
+
+// TestChainRunsStepByStepUnderGovernance covers the happy path AND the two structural guarantees: each
+// step is admitted individually, and a model tool call cannot advance a step — the only path forward is
+// a distinct verifier's sealed verdict, which the fake verifier supplies.
+func TestChainRunsStepByStepUnderGovernance(t *testing.T) {
+	h := newHarness(t, []dexploit.Step{
+		roStep(0, "recon.service_banner", "agent:planner"),
+		scStep(1, "exploit.web_shell_upload", "agent:planner"),
+	}, nil)
+	state, err := h.m.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if state != dexploit.StateSucceeded {
+		t.Fatalf("want succeeded, got %s", state)
+	}
+	// Each step admitted individually, in order — no blanket permission from the first.
+	if len(h.admit.calls) != 2 || h.admit.calls[0] != "recon.service_banner:asset-x" || h.admit.calls[1] != "exploit.web_shell_upload:asset-x" {
+		t.Fatalf("steps were not admitted individually in order: %v", h.admit.calls)
+	}
+	// Both steps executed through the sandbox boundary.
+	if !h.exec.sawArgv || !h.exec.sawEgress {
+		t.Error("steps did not run through the argv/egress sandbox boundary")
+	}
+	// Two proofs sealed, and the secret in the raw proof did not survive into the sealed evidence.
+	if len(h.sealer.sealed) != 2 {
+		t.Fatalf("want two sealed step proofs, got %d", len(h.sealer.sealed))
+	}
+	for _, sealed := range h.sealer.sealed {
+		if strings.Contains(string(sealed), "PLACEHOLDER_NOT_A_REAL_SECRET") {
+			t.Error("a secret survived into the sealed step evidence")
+		}
+	}
+	if !h.audit.has("exploitation.chain.succeeded") {
+		t.Error("a succeeded chain was not audited")
+	}
+}
+
+// TestStepNotPermittedHaltsTheChain: a step whose technique is refused by governance halts the chain,
+// runs cleanup for any completed state-changing step, and is audited.
+func TestStepNotPermittedHaltsTheChain(t *testing.T) {
+	h := newHarness(t, []dexploit.Step{
+		scStep(0, "exploit.web_shell_upload", "agent:planner"), // succeeds, holds a cleanup obligation
+		roStep(1, "impact.service_stop", "agent:planner"),      // refused by governance
+	}, func(h *harness) {
+		h.admit.refuse["impact.service_stop"] = fmt.Errorf("%w: prohibited category", shared.ErrForbidden)
+	})
+	state, err := h.m.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run should end cleanly after cleanup: %v", err)
+	}
+	if state != dexploit.StateCleaned {
+		t.Fatalf("a refused step must halt and clean, got %s", state)
+	}
+	// The first step ran; the second never executed.
+	if len(h.exec.ran) != 1 || h.exec.ran[0] != "exploit.web_shell_upload" {
+		t.Fatalf("the refused step must not execute: ran=%v", h.exec.ran)
+	}
+	// Cleanup ran for the completed state-changing step 0.
+	if got := h.cleanup.cleaned(); len(got) != 1 || got[0] != 0 {
+		t.Fatalf("cleanup must run for the completed state-changing step, got %v", got)
+	}
+	if !h.audit.has("exploitation.step.refused") {
+		t.Error("the refusal was not audited")
+	}
+}
+
+// TestSameProposerVerdictIsRejected: a verdict from the step's own proposer cannot advance it. This is
+// the "a model cannot talk itself through a chain" guarantee at the orchestration level.
+func TestSameProposerVerdictIsRejected(t *testing.T) {
+	h := newHarness(t, []dexploit.Step{scStep(0, "exploit.web_shell_upload", "agent:planner")}, func(h *harness) {
+		h.ver.verifier = "agent:planner" // same identity as the proposer
+	})
+	state, _ := h.m.Run(context.Background())
+	if state != dexploit.StateCleaned {
+		t.Fatalf("a self-verified step must not succeed; got %s", state)
+	}
+	// It executed (so there is a state change) but did not advance, and was cleaned up.
+	if got := h.cleanup.cleaned(); len(got) != 1 {
+		t.Fatalf("the executed step must be cleaned up after the self-verification refusal, got %v", got)
+	}
+	if h.audit.has("exploitation.step.advanced") {
+		t.Error("a self-verified step must not be recorded as advanced")
+	}
+}
+
+// TestMissingEvidenceRecordsFailure: a step whose proof cannot be sealed produces no evidence, so it is
+// failed, never succeeded.
+func TestMissingEvidenceRecordsFailure(t *testing.T) {
+	h := newHarness(t, []dexploit.Step{scStep(0, "exploit.web_shell_upload", "agent:planner")}, func(h *harness) {
+		h.sealer.failing = true
+	})
+	state, _ := h.m.Run(context.Background())
+	if state != dexploit.StateCleaned {
+		t.Fatalf("a step with no sealed evidence must fail and clean, got %s", state)
+	}
+	if h.audit.has("exploitation.step.advanced") {
+		t.Error("a step with no evidence must not advance")
+	}
+}
+
+// TestBlastRadiusViolationHaltsTheChain: a step that changed state while declaring read_only is a policy
+// violation. It halts the chain and is audited as a violation.
+func TestBlastRadiusViolationHaltsTheChain(t *testing.T) {
+	h := newHarness(t, []dexploit.Step{roStep(0, "recon.service_banner", "agent:planner")}, func(h *harness) {
+		h.exec.observed["recon.service_banner"] = offensivepolicy.RadiusStateChanging // exceeded its declaration
+	})
+	state, _ := h.m.Run(context.Background())
+	if state != dexploit.StateCleaned && state != dexploit.StateFailed {
+		t.Fatalf("a blast-radius violation must halt the chain, got %s", state)
+	}
+	if !h.audit.has("exploitation.step.blast_radius_violation") {
+		t.Error("the blast-radius violation was not audited")
+	}
+	if h.audit.has("exploitation.step.advanced") {
+		t.Error("a step exceeding its blast radius must not advance")
+	}
+}
+
+// TestFailedChainRunsCleanupInReverseOrder: cleanup undoes completed state-changing steps last-first.
+func TestFailedChainRunsCleanupInReverseOrder(t *testing.T) {
+	h := newHarness(t, []dexploit.Step{
+		scStep(0, "exploit.a", "agent:planner"),
+		scStep(1, "exploit.b", "agent:planner"),
+		roStep(2, "exploit.c", "agent:planner"),
+	}, func(h *harness) {
+		h.exec.fail["exploit.c"] = true // step 2 executes but reports failure
+	})
+	state, _ := h.m.Run(context.Background())
+	if state != dexploit.StateCleaned {
+		t.Fatalf("want cleaned after a failed step, got %s", state)
+	}
+	// Steps 0 and 1 changed state and were completed; cleanup runs 1 then 0 (reverse). Step 2 is
+	// read-only, no cleanup.
+	got := h.cleanup.cleaned()
+	if len(got) != 2 || got[0] != 1 || got[1] != 0 {
+		t.Fatalf("cleanup must run reverse-order for the two state-changing steps, got %v", got)
+	}
+}
+
+// TestCleanupFailureSurfacesLoudly: if cleanup itself fails, the chain does NOT report a clean halt — a
+// host may be in a bad state and a human must look.
+func TestCleanupFailureSurfacesLoudly(t *testing.T) {
+	h := newHarness(t, []dexploit.Step{
+		scStep(0, "exploit.a", "agent:planner"),
+		roStep(1, "impact.service_stop", "agent:planner"),
+	}, func(h *harness) {
+		h.admit.refuse["impact.service_stop"] = fmt.Errorf("%w: prohibited", shared.ErrForbidden)
+		h.cleanup.fail[0] = errors.New("host unreachable")
+	})
+	state, err := h.m.Run(context.Background())
+	if err == nil {
+		t.Fatal("a failed cleanup must return a loud error")
+	}
+	if state == dexploit.StateCleaned {
+		t.Fatal("a chain whose cleanup failed must not report itself cleaned")
+	}
+	if !h.audit.has("exploitation.step.cleanup_failed") {
+		t.Error("the cleanup failure was not audited")
+	}
+}
+
+// TestKillSwitchHaltsRunningChainAndCleans is acceptance criterion 6: the kill switch halts a chain,
+// triggers cleanup for completed state-changing steps, and audits the halt — measured.
+func TestKillSwitchHaltsRunningChainAndCleans(t *testing.T) {
+	// Drive one state-changing step to completion, then halt as the kill switch would.
+	h := newHarness(t, []dexploit.Step{
+		scStep(0, "exploit.web_shell_upload", "agent:planner"),
+		roStep(1, "recon.service_banner", "agent:planner"),
+	}, func(h *harness) {
+		h.exec.fail["recon.service_banner"] = true // stop the run after step 0 so step 0 is completed+in-flight for cleanup
+	})
+	// Instead of Run, exercise Halt directly on a chain with a completed state-changing step.
+	chain, _ := dexploit.NewChain("c1", "t1", "e1", "p1", []dexploit.Step{scStep(0, "exploit.web_shell_upload", "agent:planner")})
+	_ = chain.BeginStep()
+	_ = chain.RecordExecuted("ev-0", true) // completed, verifying, holds a cleanup obligation
+	cleanup := &fakeCleanup{fail: map[int]error{}}
+	audit := &fakeAudit{}
+	m, err := NewMachine(chain, &fakeAdmit{}, &fakeExec{}, &fakeVerifier{score: 90}, cleanup, &chainSealerFake{}, &fakeStore{}, audit, chainClock{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	state, err := m.Halt(context.Background(), "operator@example.test", "customer requested an immediate stop")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("chain halt took %s, unexpectedly slow", elapsed)
+	}
+	if state != dexploit.StateCleaned {
+		t.Fatalf("halt must clean the chain, got %s", state)
+	}
+	if got := cleanup.cleaned(); len(got) != 1 || got[0] != 0 {
+		t.Fatalf("halt must run cleanup for the completed state-changing step, got %v", got)
+	}
+	if !audit.has("exploitation.chain.halted") {
+		t.Error("the halt was not audited")
+	}
+	_ = h // the harness above documents the run-based scenario; Halt is exercised directly here
+}
+
+// TestNoAgentToolCanAdvanceAStep is the structural guarantee stated as a test: the only way a step
+// advances is Machine.Run consuming a distinct verifier's sealed verdict. There is no exported method
+// on Machine that takes a caller-supplied "advance" instruction, and the domain refuses a self verdict.
+// This test asserts the surface: Machine exposes Run, Halt, State, Chain — and nothing that lets a
+// caller inject a verdict of its own choosing to move the cursor.
+func TestNoAgentToolCanAdvanceAStep(t *testing.T) {
+	h := newHarness(t, []dexploit.Step{roStep(0, "recon.service_banner", "agent:planner")}, func(h *harness) {
+		// A "model" verdict: signed by the proposer itself. The verifier port yields it, and the chain
+		// must refuse to advance on it.
+		h.ver.verifier = "agent:planner"
+	})
+	state, _ := h.m.Run(context.Background())
+	if state == dexploit.StateSucceeded {
+		t.Fatal("the chain advanced on a proposer-signed verdict; a model talked itself through")
+	}
+}

--- a/migrations/0072_exploitation_chains.sql
+++ b/migrations/0072_exploitation_chains.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+-- Multi-step attack chains and their steps (issue #420). A chain is planned from a scored attack path
+-- (#419); each step records its own governed outcome. Tenant-scoped and RLS-enforced like every other
+-- engagement-owned table, so one tenant can never read another's chains.
+CREATE TABLE exploitation_chains (
+    tenant_id     TEXT NOT NULL REFERENCES tenants(id),
+    id            TEXT NOT NULL,
+    engagement_id TEXT NOT NULL REFERENCES engagements(id) ON DELETE CASCADE,
+    path_id       TEXT NOT NULL,
+    state         TEXT NOT NULL,
+    current_step  INT NOT NULL DEFAULT 0,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, id),
+    -- A step's composite FK points here, so the pair is unique.
+    UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE exploitation_steps (
+    tenant_id    TEXT NOT NULL REFERENCES tenants(id),
+    chain_id     TEXT NOT NULL,
+    ordinal      INT NOT NULL,
+    technique    TEXT NOT NULL,
+    target       TEXT NOT NULL,
+    proposer     TEXT NOT NULL,
+    blast_radius TEXT NOT NULL CHECK (blast_radius IN ('read_only', 'state_changing')),
+    cleanup      JSONB NOT NULL DEFAULT '{}',
+    state        TEXT NOT NULL,
+    executed     BOOLEAN NOT NULL DEFAULT FALSE,
+    evidence_id  TEXT,  -- sealed proof of this step's outcome; NULL until produced
+    PRIMARY KEY (tenant_id, chain_id, ordinal),
+    -- The step belongs to a chain in the SAME tenant. A composite FK makes a cross-tenant step
+    -- unstorable rather than merely unqueried, the same guard the asset tables use.
+    FOREIGN KEY (tenant_id, chain_id) REFERENCES exploitation_chains(tenant_id, id) ON DELETE CASCADE,
+    -- A state-changing step MUST carry a cleanup path. This mirrors the domain's construction-time
+    -- refusal so a row that bypassed the domain cannot claim an unreversible action with no way back.
+    CONSTRAINT exploitation_step_cleanup_when_state_changing
+        CHECK (blast_radius <> 'state_changing' OR (cleanup ? 'steps' AND jsonb_array_length(cleanup->'steps') > 0))
+);
+
+CREATE INDEX idx_exploitation_steps_chain ON exploitation_steps(tenant_id, chain_id, ordinal);
+
+CALL synapse_enable_tenant_rls('exploitation_chains');
+CALL synapse_enable_tenant_rls('exploitation_steps');
+
+-- +goose Down
+DROP TABLE exploitation_steps;
+DROP TABLE exploitation_chains;


### PR DESCRIPTION
Closes #420. Phase 4, Track D of #405. Builds directly on the #418 offensive policy just merged.

Multi-step attack-chain orchestration **on top of** the existing single-finding exploitation service, the #418 governance policy, the sandbox and the evidence sealer. This is the orchestration and governance *between* those — not new exploitation techniques (explicitly out of scope) and not new infrastructure.

## The propose-only boundary is structural

A model may propose a chain; it can never advance one. The domain (`internal/domain/exploitation`) is a pure state machine whose transitions are driven by the orchestrator, and **advancing a step requires a distinct verifier's sealed verdict**. `TestNoAgentToolCanAdvanceAStep` and `TestSameProposerVerdictIsRejected` prove a proposer-signed verdict cannot move the cursor — a model cannot talk itself through a chain.

## Governance is per step, enforced at execution

- **Each step is admitted individually** through the #418 policy — a chain never inherits permission from its first step. A step whose technique is not permitted for the target, or whose window has closed, halts the chain at exactly that step. `admit_test.go` wires the **real** `offensivepolicy.Service` and proves an unregistered and a prohibited technique are both refused through the adapter.
- **Blast radius is enforced at execution, not only declared.** A step whose *actual* effect exceeds its declared radius is a policy violation and halts the chain (`TestBlastRadiusViolationHaltsTheChain`).
- **A step with no evidence of its outcome is failed, never succeeded** — the decision lives in the domain so no orchestration mistake can promote an evidence-less step.
- **A step advances only on a distinct verifier's sealed verdict at or above the bar.** A sub-bar verdict fails the chain; a self verdict is refused.

## Cleanup and the kill switch

- A state-changing step with **no cleanup path is unconstructable** — discovering at runtime that an action cannot be undone means it has already run. Mirrored by a DB CHECK.
- A step that **began execution** owes cleanup even if it later fails: from `BeginStep` the target may already have changed. Cleanup runs for every executed state-changing step, **in reverse order**, on any halt or failure (`TestFailedChainRunsCleanupInReverseOrder`).
- **A cleanup that itself fails surfaces loudly** rather than reporting a clean halt — a host may be in a bad state and a human must look (`TestCleanupFailureSurfacesLoudly`).
- Cleanup runs on a `Background` context so a **cancelled** run is still cleaned — a cancelled chain that skipped cleanup would leave the estate in an undocumented state, the one outcome this must not produce.
- The **kill switch** halts a running chain, runs cleanup, and audits the halt — measured in `TestKillSwitchHaltsRunningChainAndCleans`.

## Proof is bounded and redacted

A data-exposure step proves access with a small redacted sample, never a bulk extraction. `NewProofSample` bounds to 4 KiB and redacts known credential shapes, **redaction before truncation** so the byte cap cannot slice a secret into a readable prefix. Asserted by size and redaction tests.

## Persistence

Migration `0072`: `exploitation_chains` + `exploitation_steps`, tenant-scoped and RLS-enforced. A **composite FK** makes a cross-tenant step unstorable; a **DB CHECK** rejects a state-changing step with no cleanup, mirroring the domain's construction-time refusal. `TestMigration0072ExploitationChains` proves all three on real Postgres 17 — round-trip, RLS isolation under a `NOSUPERUSER NOBYPASSRLS` role (the pool's superuser bypasses RLS, so the test drops to a runtime role), the FK violation, and the CHECK.

`CleanupSpec` gains json tags so its JSONB storage uses the lowercase key the CHECK expects.

## Acceptance criteria

- [x] A chain executes step by step under the state machine; no model tool call can advance a step (test attempts and is refused)
- [x] A step whose technique is not permitted for the target halts the chain (test)
- [x] A step advances only on a distinct verifier's sealed verdict; a same-proposer verdict is rejected
- [x] A step with no evidence of its outcome is recorded failed, never succeeded
- [x] A halted or failed chain runs the declared cleanup for every completed state-changing step (fixture records the calls)
- [x] The kill switch halts a running chain, triggers cleanup and audits the halt (measured)
- [x] A step whose actual effect exceeds its declared blast radius halts the chain as a policy violation
- [x] Proof of a data-exposure step is a bounded redacted sample (size + redaction tests)
- [x] Every step executes argv-only inside the sandbox with scoped egress (executor port; the Machine never shells out or opens a socket itself)

## Verification, CI being disabled

`go build` (CGO on/off), `go vet`, `golangci-lint` **0 issues**, full suite green on real Postgres 17 including migration 0072. Domain and usecase packages pass under `-race`.

Every guard mutation-tested: dropping the distinct-verifier check, skipping per-step admission, and skipping cleanup each fail the intended test. Two defects my own tests caught in my own code: `approvers[:need]` could panic in the authorization path (now returns every valid approver), and a refused self-verdict left the chain non-terminal (now fails the step so cleanup runs). Kept to the exploitation packages plus one json-tag line on `CleanupSpec`; a directory-wide `gofmt` churn on unrelated files was kept out.

Follow-up (not this issue): fleet-wide wiring of `Machine.Halt` behind the #418 `POST /api/v1/redteam/halt` needs a running-chain registry; the chain's halt contract is complete and tested here.
