### PR TITLE
feat(redteam): adversary emulation mapped to a taxonomy, measured against detection (#421)

### DIFF
--- a/docs/redteam/offensive-policy.md
+++ b/docs/redteam/offensive-policy.md
@@ -143,6 +143,13 @@ A technique absent from this table is **refused**. That is the fail-closed defau
 | `persist.scheduled_task` | T1053 | low | irreversible | prohibited | — | state_changing | — | no |
 | `impact.service_stop` | T1489 | high | irreversible | prohibited | — | state_changing | — | no |
 | `exfil.bulk_data` | T1041 | none | reversible | prohibited | — | read_only | — | no |
+| `emu.process_discovery` | T1057 | none | reversible | low | automatic | read_only | — | no |
+| `emu.system_network_config_discovery` | T1016 | none | reversible | low | automatic | read_only | — | no |
+| `emu.dns_beacon_benign` | T1071.004 | none | reversible | low | automatic | read_only | — | no |
+| `emu.credential_file_read` | T1552.001 | none | reversible | low | automatic | read_only | — | no |
+| `emu.service_restart_probe` | T1569.002 | high | reversible | high | dual | state_changing | restart the service to its prior running state; confirm the service is running and healthy | no |
+
+The `emu.*` entries are the governance facet of the adversary-emulation techniques (#421); each also appears in the emulation catalogue with its taxonomy and the detection it should produce. Emulation runs through this same allowlist, so an emulation technique absent here is refused like any other. The four benign discovery techniques are read-only and automatic; `emu.service_restart_probe` is lab-only — disruptive and therefore high-risk with dual approval, reversible via its cleanup, and never production-safe.
 
 The three prohibited entries are listed **on purpose**. Omitting them would make them merely unknown, and the enforcement path would refuse them with "no register entry" — indistinguishable from a technique nobody has classified yet. Naming them records that they were considered and excluded, which is what a governance artifact is for.
 

--- a/internal/domain/emulation/catalog.go
+++ b/internal/domain/emulation/catalog.go
@@ -1,0 +1,93 @@
+package emulation
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// catalogue is the built-in set of emulation techniques. Each maps to a public ATT&CK technique id and
+// declares the detection it should produce. Entries are added as techniques are classified, not in
+// advance — an emulation with no expected detection cannot contribute to a coverage number.
+//
+// The benign/production-safe techniques here generate their telemetry without a real effect (a discovery
+// command that only reads, a DNS lookup to a benign sink). The one lab-only entry has no benign variant
+// and is ProductionSafe=false, so it is gated behind an explicit opt-in and never runs against a
+// customer estate by default.
+var catalogue = []Technique{
+	{
+		ID: "emu.process_discovery", TaxonomyRef: "T1057", BenignVariant: true, ProductionSafe: true,
+		Expected: ExpectedObservable{Telemetry: []TelemetryClass{TelemetryProcess}, DetectionID: "det.process_enumeration", Version: "v1"},
+	},
+	{
+		ID: "emu.system_network_config_discovery", TaxonomyRef: "T1016", BenignVariant: true, ProductionSafe: true,
+		Expected: ExpectedObservable{Telemetry: []TelemetryClass{TelemetryProcess, TelemetryNetwork}, DetectionID: "det.network_config_discovery", Version: "v1"},
+	},
+	{
+		ID: "emu.dns_beacon_benign", TaxonomyRef: "T1071.004", BenignVariant: true, ProductionSafe: true,
+		Expected: ExpectedObservable{Telemetry: []TelemetryClass{TelemetryDNS, TelemetryNetwork}, DetectionID: "det.suspicious_dns_beacon", Version: "v1"},
+	},
+	{
+		ID: "emu.credential_file_read", TaxonomyRef: "T1552.001", BenignVariant: true, ProductionSafe: true,
+		Expected: ExpectedObservable{Telemetry: []TelemetryClass{TelemetryFile}, DetectionID: "det.credential_file_access", Version: "v1"},
+	},
+	{
+		// Lab-only: a service-restart probe has no benign proof of its observable — you cannot generate
+		// the restart telemetry without actually restarting the service — so it is not production-safe
+		// and runs only under an explicit lab opt-in. It is reversible (restart back), so unlike log
+		// tampering it is not a prohibited category; its register entry is high-risk with dual approval.
+		ID: "emu.service_restart_probe", TaxonomyRef: "T1569.002", BenignVariant: false, ProductionSafe: false,
+		Expected: ExpectedObservable{Telemetry: []TelemetryClass{TelemetryProcess, TelemetryAuth}, DetectionID: "det.unexpected_service_restart", Version: "v1"},
+	},
+}
+
+// Catalogue returns a validated copy of the built-in technique set, deterministically ordered by id so
+// a coverage run and its trend are comparable over time.
+//
+// It validates on every call rather than trusting the literal above, so a malformed entry fails the
+// build via the catalogue test rather than shipping a technique that cannot be measured.
+func Catalogue() ([]Technique, error) {
+	seen := make(map[string]struct{}, len(catalogue))
+	out := make([]Technique, 0, len(catalogue))
+	for _, t := range catalogue {
+		if err := t.Validate(); err != nil {
+			return nil, err
+		}
+		if _, dup := seen[t.ID]; dup {
+			return nil, fmt.Errorf("%w: duplicate technique id %q", shared.ErrValidation, t.ID)
+		}
+		if _, dupTax := taxonomyIndex(out, t.TaxonomyRef); dupTax {
+			// Two techniques may legitimately share nothing else, but a duplicate taxonomy ref would
+			// double-count a technique in the coverage number, so refuse it.
+			return nil, fmt.Errorf("%w: duplicate taxonomy reference %q", shared.ErrValidation, t.TaxonomyRef)
+		}
+		seen[t.ID] = struct{}{}
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// Lookup returns a catalogued technique by id. The second result is false for an unknown id, which the
+// caller MUST treat as "not an emulation technique" rather than fabricating one.
+func Lookup(id string) (Technique, bool) {
+	for _, t := range catalogue {
+		if t.ID == id {
+			if t.Validate() != nil {
+				return Technique{}, false
+			}
+			return t, true
+		}
+	}
+	return Technique{}, false
+}
+
+func taxonomyIndex(ts []Technique, ref string) (int, bool) {
+	for i, t := range ts {
+		if t.TaxonomyRef == ref {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/internal/domain/emulation/run.go
+++ b/internal/domain/emulation/run.go
@@ -1,0 +1,18 @@
+package emulation
+
+import "github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+
+// Run is one emulation pass over a set of techniques against an engagement's target, with the coverage
+// record it produced per technique.
+//
+// It lives in the domain rather than the usecase because it is the persisted aggregate — the offensive
+// half of the purple ledger — and keeping it here lets the infrastructure stores depend on the domain
+// instead of on a usecase package (the dependency rule, and it breaks an import cycle the other way).
+type Run struct {
+	ID           shared.ID
+	TenantID     shared.ID
+	EngagementID shared.ID
+	Target       shared.ID
+	Actor        string
+	Coverage     []CoverageRecord
+}

--- a/internal/domain/emulation/technique.go
+++ b/internal/domain/emulation/technique.go
@@ -1,0 +1,130 @@
+// Package emulation is the pure domain for adversary emulation (issue #421): techniques mapped to a
+// public taxonomy, each declaring the detection it should produce, and the coverage record that pairs
+// what executed with what was detected.
+//
+// It closes the purple-team loop honestly. Blue-team coverage is a measured number only if offensive
+// and defensive share one ledger: of the techniques we can execute, how many did we detect. A technique
+// that states no expected detection cannot contribute to that number, so the catalogue refuses one.
+//
+// No I/O, no clock. Emulation execution and its governance live in internal/usecase/emulation, which
+// reuses the exploitation admission and sandbox path so emulation is a SUBSET of that machine's
+// guarantees, never a looser path.
+package emulation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TelemetryClass is a category of signal an executed technique should generate. Coverage is expressed
+// in terms of what telemetry a technique touches so a defender can see which sensors a gap implicates.
+type TelemetryClass string
+
+const (
+	TelemetryProcess TelemetryClass = "process"
+	TelemetryNetwork TelemetryClass = "network"
+	TelemetryFile    TelemetryClass = "file"
+	TelemetryAuth    TelemetryClass = "auth"
+	TelemetryDNS     TelemetryClass = "dns"
+)
+
+func (c TelemetryClass) valid() bool {
+	switch c {
+	case TelemetryProcess, TelemetryNetwork, TelemetryFile, TelemetryAuth, TelemetryDNS:
+		return true
+	default:
+		return false
+	}
+}
+
+// ExpectedObservable is what a technique SHOULD produce: the telemetry classes it touches and the id of
+// the detection that should fire. It is versioned with the technique so a coverage trend compares like
+// with like — a detection expectation that changed silently would make the trend meaningless.
+type ExpectedObservable struct {
+	Telemetry   []TelemetryClass
+	DetectionID string
+	Version     string
+}
+
+func (o ExpectedObservable) validate() error {
+	if strings.TrimSpace(o.DetectionID) == "" {
+		return fmt.Errorf("%w: expected observable needs a detection id", shared.ErrValidation)
+	}
+	if strings.TrimSpace(o.Version) == "" {
+		return fmt.Errorf("%w: expected observable must be versioned", shared.ErrValidation)
+	}
+	if len(o.Telemetry) == 0 {
+		return fmt.Errorf("%w: expected observable names no telemetry class", shared.ErrValidation)
+	}
+	for _, c := range o.Telemetry {
+		if !c.valid() {
+			return fmt.Errorf("%w: unknown telemetry class %q", shared.ErrValidation, c)
+		}
+	}
+	return nil
+}
+
+// Technique is one catalogued emulation technique.
+//
+// BenignVariant records that a benign proof of the observable exists — a way to generate the telemetry
+// without the real effect, so coverage can be measured on production-adjacent systems. ProductionSafe
+// cannot be true without it: a technique with no benign variant has no safe way to run against a
+// customer estate, so it is lab-only and gated behind an explicit opt-in.
+type Technique struct {
+	ID             string
+	TaxonomyRef    string
+	BenignVariant  bool
+	ProductionSafe bool
+	Expected       ExpectedObservable
+}
+
+// Validate enforces the catalogue invariants. A technique that fails these cannot contribute a
+// meaningful coverage number and must not be catalogued.
+func (t Technique) Validate() error {
+	if strings.TrimSpace(t.ID) == "" {
+		return fmt.Errorf("%w: technique has no id", shared.ErrValidation)
+	}
+	if strings.TrimSpace(t.TaxonomyRef) == "" {
+		return fmt.Errorf("%w: technique %s has no taxonomy reference", shared.ErrValidation, t.ID)
+	}
+	if err := t.Expected.validate(); err != nil {
+		return fmt.Errorf("technique %s: %w", t.ID, err)
+	}
+	if t.ProductionSafe && !t.BenignVariant {
+		return fmt.Errorf("%w: technique %s is production-safe but has no benign variant", shared.ErrValidation, t.ID)
+	}
+	return nil
+}
+
+// CoverageRecord pairs what executed with what was detected, per technique. It is the offensive half of
+// the purple ledger #426 consumes.
+type CoverageRecord struct {
+	TechniqueID string
+	TaxonomyRef string
+	Executed    bool
+	Expected    string // detection id that should have fired
+	Actual      string // detection id observed; empty until the #422 detection engine exists
+	Gap         bool
+}
+
+// NewCoverageRecord builds a record and computes the gap. A gap is an EXECUTED technique whose expected
+// detection did not fire — that is the honest definition of a coverage hole. A technique that did not
+// execute is recorded (never omitted) but is not itself a gap: you cannot measure detection of
+// something that did not run.
+//
+// Until the detection engine (#422) exists, actual is always empty, so every executed technique with an
+// expected detection is a gap. That is the correct, honest state: coverage is unproven, not assumed.
+func NewCoverageRecord(t Technique, executed bool, actualDetection string) CoverageRecord {
+	actual := strings.TrimSpace(actualDetection)
+	gap := executed && actual != t.Expected.DetectionID
+	return CoverageRecord{
+		TechniqueID: t.ID,
+		TaxonomyRef: t.TaxonomyRef,
+		Executed:    executed,
+		Expected:    t.Expected.DetectionID,
+		Actual:      actual,
+		Gap:         gap,
+	}
+}

--- a/internal/domain/emulation/technique_test.go
+++ b/internal/domain/emulation/technique_test.go
@@ -1,0 +1,121 @@
+package emulation
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TestCatalogueEveryTechniqueHasTaxonomyAndExpectedObservable is the catalogue drift test required by
+// #421: every emulated technique carries a taxonomy reference and an expected observable. A technique
+// missing either cannot contribute to a coverage number, so the catalogue must refuse it.
+func TestCatalogueEveryTechniqueHasTaxonomyAndExpectedObservable(t *testing.T) {
+	techniques, err := Catalogue()
+	if err != nil {
+		t.Fatalf("the shipped catalogue does not validate: %v", err)
+	}
+	if len(techniques) == 0 {
+		t.Fatal("empty catalogue; the drift test would pass vacuously")
+	}
+	for _, tech := range techniques {
+		if strings.TrimSpace(tech.TaxonomyRef) == "" {
+			t.Errorf("%s has no taxonomy reference", tech.ID)
+		}
+		if tech.Expected.DetectionID == "" || tech.Expected.Version == "" || len(tech.Expected.Telemetry) == 0 {
+			t.Errorf("%s has an incomplete expected observable: %+v", tech.ID, tech.Expected)
+		}
+		if tech.ProductionSafe && !tech.BenignVariant {
+			t.Errorf("%s is production-safe with no benign variant", tech.ID)
+		}
+	}
+}
+
+// TestCatalogueDeterministicOrder pins the stable identity + ordering that makes a coverage trend
+// comparable across runs.
+func TestCatalogueDeterministicOrder(t *testing.T) {
+	a, _ := Catalogue()
+	b, _ := Catalogue()
+	if len(a) != len(b) {
+		t.Fatal("catalogue length is not stable")
+	}
+	for i := range a {
+		if a[i].ID != b[i].ID {
+			t.Fatalf("catalogue order is not stable at %d: %s vs %s", i, a[i].ID, b[i].ID)
+		}
+		if i > 0 && a[i-1].ID > a[i].ID {
+			t.Fatalf("catalogue is not sorted by id: %s before %s", a[i-1].ID, a[i].ID)
+		}
+	}
+}
+
+// TestEveryEmulationTechniqueIsInTheOffensiveRegister is the cross-check that makes "emulation goes
+// through the same governance" real: every catalogued technique must have an offensive-policy register
+// entry, or it would be refused at admission and could never run. This ties #421 to #418's allowlist.
+func TestEveryEmulationTechniqueIsInTheOffensiveRegister(t *testing.T) {
+	reg, err := offensivepolicy.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	techniques, _ := Catalogue()
+	for _, tech := range techniques {
+		entry, ok := reg.Lookup(tech.ID)
+		if !ok {
+			t.Errorf("emulation technique %s has no offensive-policy register entry; it would be refused at admission", tech.ID)
+			continue
+		}
+		if entry.TaxonomyRef != tech.TaxonomyRef {
+			t.Errorf("%s taxonomy differs: catalogue %q, register %q", tech.ID, tech.TaxonomyRef, entry.TaxonomyRef)
+		}
+		// A production-safe emulation technique must be read-only in the register: a benign proof does
+		// not change state. Conversely the lab-only one is state-changing and not production-safe.
+		if tech.ProductionSafe && entry.BlastRadius != offensivepolicy.RadiusReadOnly {
+			t.Errorf("%s is production-safe but its register entry is %s, not read_only", tech.ID, entry.BlastRadius)
+		}
+	}
+}
+
+func TestNewCoverageRecordGapDefinition(t *testing.T) {
+	tech := Technique{ID: "emu.x", TaxonomyRef: "T0000",
+		Expected: ExpectedObservable{Telemetry: []TelemetryClass{TelemetryProcess}, DetectionID: "det.x", Version: "v1"}}
+
+	// Executed with no matching detection → a gap. This is the honest state until the #422 detection
+	// engine exists: coverage is unproven, not assumed clean.
+	if r := NewCoverageRecord(tech, true, ""); !r.Gap || !r.Executed || r.Expected != "det.x" {
+		t.Fatalf("an executed technique with no detection must be a gap with the expected id populated: %+v", r)
+	}
+	// Executed and the expected detection fired → not a gap.
+	if r := NewCoverageRecord(tech, true, "det.x"); r.Gap {
+		t.Fatalf("a matched detection must not be a gap: %+v", r)
+	}
+	// Executed and a DIFFERENT detection fired → still a gap (the expected one did not).
+	if r := NewCoverageRecord(tech, true, "det.other"); !r.Gap {
+		t.Fatalf("a mismatched detection must be a gap: %+v", r)
+	}
+	// Not executed → recorded, but not itself a gap: you cannot measure detection of what did not run.
+	if r := NewCoverageRecord(tech, false, ""); r.Gap {
+		t.Fatalf("a non-executed technique must not be a gap: %+v", r)
+	}
+}
+
+func TestTechniqueValidateRefusesIncomplete(t *testing.T) {
+	good := ExpectedObservable{Telemetry: []TelemetryClass{TelemetryProcess}, DetectionID: "det.x", Version: "v1"}
+	cases := map[string]Technique{
+		"no id":               {TaxonomyRef: "T1", Expected: good},
+		"no taxonomy":         {ID: "emu.x", Expected: good},
+		"no detection id":     {ID: "emu.x", TaxonomyRef: "T1", Expected: ExpectedObservable{Telemetry: []TelemetryClass{TelemetryProcess}, Version: "v1"}},
+		"no version":          {ID: "emu.x", TaxonomyRef: "T1", Expected: ExpectedObservable{Telemetry: []TelemetryClass{TelemetryProcess}, DetectionID: "det.x"}},
+		"no telemetry":        {ID: "emu.x", TaxonomyRef: "T1", Expected: ExpectedObservable{DetectionID: "det.x", Version: "v1"}},
+		"unknown telemetry":   {ID: "emu.x", TaxonomyRef: "T1", Expected: ExpectedObservable{Telemetry: []TelemetryClass{"telepathy"}, DetectionID: "det.x", Version: "v1"}},
+		"prod-safe no benign": {ID: "emu.x", TaxonomyRef: "T1", ProductionSafe: true, Expected: good},
+	}
+	for name, tech := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := tech.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/domain/offensivepolicy/policy.yaml
+++ b/internal/domain/offensivepolicy/policy.yaml
@@ -120,3 +120,69 @@ techniques:
       steps: []
       verification: ""
     production_safe: false
+
+  # Adversary-emulation techniques (#421). Each also appears in the emulation catalogue with its
+  # taxonomy and expected detection; the register entry is the GOVERNANCE facet (risk/approval/radius).
+  # Emulation runs through this same allowlist, so an emulation technique absent here is refused.
+  - technique: emu.process_discovery
+    taxonomy_ref: T1057
+    disruption: none
+    reversibility: reversible
+    risk_class: low
+    approval: automatic
+    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  - technique: emu.system_network_config_discovery
+    taxonomy_ref: T1016
+    disruption: none
+    reversibility: reversible
+    risk_class: low
+    approval: automatic
+    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  - technique: emu.dns_beacon_benign
+    taxonomy_ref: T1071.004
+    disruption: none
+    reversibility: reversible
+    risk_class: low
+    approval: automatic
+    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  - technique: emu.credential_file_read
+    taxonomy_ref: T1552.001
+    disruption: none
+    reversibility: reversible
+    risk_class: low
+    approval: automatic
+    blast_radius: read_only
+    cleanup:
+      steps: []
+      verification: ""
+    production_safe: false
+
+  # Lab-only: a service restart is disruptive (high) and reversible; not a prohibited category, but
+  # gated at dual approval and never production-safe. Emulation additionally requires a lab opt-in.
+  - technique: emu.service_restart_probe
+    taxonomy_ref: T1569.002
+    disruption: high
+    reversibility: reversible
+    risk_class: high
+    approval: dual
+    blast_radius: state_changing
+    cleanup:
+      steps:
+        - restart the service to its prior running state
+      verification: confirm the service is running and healthy
+    production_safe: false

--- a/internal/infrastructure/persistence/memory/emulation_run_store.go
+++ b/internal/infrastructure/persistence/memory/emulation_run_store.go
@@ -1,0 +1,51 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	demu "github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// EmulationRunStore is the in-memory emulation-run persistence used inline/in dev. It keeps a deep copy
+// of each run's coverage so a caller mutating the returned slice cannot corrupt stored state.
+type EmulationRunStore struct {
+	mu   sync.Mutex
+	runs map[string]demu.Run // keyed by tenant\x00id
+}
+
+// NewEmulationRunStore constructs the store.
+func NewEmulationRunStore() *EmulationRunStore {
+	return &EmulationRunStore{runs: map[string]demu.Run{}}
+}
+
+func emuRunKey(tenantID, id shared.ID) string {
+	return shared.TenantOrDefault(tenantID).String() + "\x00" + id.String()
+}
+
+// SaveRun persists a run and its coverage records.
+func (s *EmulationRunStore) SaveRun(_ context.Context, run demu.Run) error {
+	if run.ID == "" || run.TenantID == "" {
+		return shared.ErrValidation
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := run
+	cp.Coverage = append([]demu.CoverageRecord(nil), run.Coverage...)
+	s.runs[emuRunKey(run.TenantID, run.ID)] = cp
+	return nil
+}
+
+// GetRun returns a copy of a stored run scoped to the tenant; a cross-tenant read sees ErrNotFound.
+func (s *EmulationRunStore) GetRun(_ context.Context, tenantID, id shared.ID) (demu.Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run, ok := s.runs[emuRunKey(tenantID, id)]
+	if !ok {
+		return demu.Run{}, shared.ErrNotFound
+	}
+	cp := run
+	cp.Coverage = append([]demu.CoverageRecord(nil), run.Coverage...)
+	return cp, nil
+}

--- a/internal/infrastructure/persistence/postgres/emulation_run_repo.go
+++ b/internal/infrastructure/persistence/postgres/emulation_run_repo.go
@@ -1,0 +1,56 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	demu "github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// EmulationRunRepository persists emulation runs and coverage (migration 0073), tenant-scoped via
+// WithTenant so RLS isolates one tenant's coverage from another's.
+type EmulationRunRepository struct{ pool *pgxpool.Pool }
+
+// NewEmulationRunRepository constructs the repository.
+func NewEmulationRunRepository(pool *pgxpool.Pool) *EmulationRunRepository {
+	return &EmulationRunRepository{pool: pool}
+}
+
+// SaveRun writes the run and all its coverage rows in one transaction, so a partially-written run can
+// never present as complete coverage.
+func (r *EmulationRunRepository) SaveRun(ctx context.Context, run demu.Run) error {
+	if run.ID == "" || run.TenantID == "" {
+		return fmt.Errorf("%w: emulation run requires id and tenant", shared.ErrValidation)
+	}
+	return WithTenant(ctx, r.pool, run.TenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO emulation_runs (tenant_id, id, engagement_id, target, actor)
+			VALUES ($1,$2,$3,$4,$5)
+			ON CONFLICT (tenant_id, id) DO UPDATE SET target = EXCLUDED.target, actor = EXCLUDED.actor`,
+			run.TenantID.String(), run.ID.String(), run.EngagementID.String(), run.Target.String(), run.Actor); err != nil {
+			return fmt.Errorf("upsert emulation run: %w", err)
+		}
+		for _, rec := range run.Coverage {
+			var actual *string
+			if rec.Actual != "" {
+				a := rec.Actual
+				actual = &a
+			}
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO emulation_coverage
+				  (tenant_id, run_id, technique_id, taxonomy_ref, executed, expected_detection, actual_detection, gap)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+				ON CONFLICT (tenant_id, run_id, technique_id) DO UPDATE SET
+				  executed = EXCLUDED.executed, actual_detection = EXCLUDED.actual_detection, gap = EXCLUDED.gap`,
+				run.TenantID.String(), run.ID.String(), rec.TechniqueID, rec.TaxonomyRef,
+				rec.Executed, rec.Expected, actual, rec.Gap); err != nil {
+				return fmt.Errorf("upsert coverage %s: %w", rec.TechniqueID, err)
+			}
+		}
+		return nil
+	})
+}

--- a/internal/infrastructure/persistence/postgres/migration_0073_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0073_test.go
@@ -1,0 +1,131 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	demu "github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestMigration0073EmulationRuns(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenantA, tenantB := shared.ID("em-a-"+id), shared.ID("em-b-"+id)
+	engA := "em-eng-" + id
+	for _, stmt := range []struct {
+		q    string
+		args []any
+	}{
+		{`INSERT INTO tenants(id,name) VALUES($1,$1),($2,$2)`, []any{tenantA.String(), tenantB.String()}},
+		{`INSERT INTO engagements(id,tenant_id,name) VALUES($1,$2,'emu-eng')`, []any{engA, tenantA.String()}},
+	} {
+		if _, err := pool.Exec(ctx, stmt.q, stmt.args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, q := range []string{
+			`DELETE FROM emulation_coverage WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM emulation_runs WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM engagements WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM tenants WHERE id IN ($1,$2)`,
+		} {
+			if _, err := pool.Exec(bg, q, tenantA.String(), tenantB.String()); err != nil {
+				t.Errorf("cleanup %q: %v (next run will fail)", q, err)
+			}
+		}
+		_, _ = pool.Exec(bg, `DROP OWNED BY emu_run_runtime`)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS emu_run_runtime`)
+	})
+
+	repo := NewEmulationRunRepository(pool)
+	ctx = shared.WithTenant(ctx, tenantA)
+	run := demu.Run{
+		ID: shared.ID("run-" + id), TenantID: tenantA, EngagementID: shared.ID(engA), Target: "asset-x", Actor: "operator",
+		Coverage: []demu.CoverageRecord{
+			// executed, no detection → gap
+			{TechniqueID: "emu.process_discovery", TaxonomyRef: "T1057", Executed: true, Expected: "det.process_enumeration", Actual: "", Gap: true},
+			// not executed → not a gap
+			{TechniqueID: "emu.service_restart_probe", TaxonomyRef: "T1569.002", Executed: false, Expected: "det.unexpected_service_restart", Actual: "", Gap: false},
+		},
+	}
+	if err := repo.SaveRun(ctx, run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+
+	// RLS under a NOSUPERUSER NOBYPASSRLS role (the pool superuser bypasses RLS).
+	role := "emu_run_runtime"
+	for _, q := range []string{
+		`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='` + role + `') THEN EXECUTE 'DROP OWNED BY ` + role + `'; EXECUTE 'DROP ROLE ` + role + `'; END IF; END $$`,
+		`CREATE ROLE ` + role + ` NOSUPERUSER NOBYPASSRLS`,
+		`GRANT USAGE ON SCHEMA public TO ` + role,
+		`GRANT SELECT ON emulation_runs, emulation_coverage TO ` + role,
+	} {
+		if _, err := pool.Exec(ctx, q); err != nil {
+			t.Fatalf("prepare rls role: %v", err)
+		}
+	}
+	countAs := func(tenant shared.ID) int {
+		var n int
+		tctx := shared.WithTenant(context.Background(), tenant)
+		if err := WithTenant(tctx, pool, tenant.String(), func(tx pgx.Tx) error {
+			if _, err := tx.Exec(tctx, `SET LOCAL ROLE `+role); err != nil {
+				return err
+			}
+			return tx.QueryRow(tctx, `SELECT count(*) FROM emulation_coverage`).Scan(&n)
+		}); err != nil {
+			t.Fatalf("count as %s: %v", tenant, err)
+		}
+		return n
+	}
+	if got := countAs(tenantB); got != 0 {
+		t.Errorf("tenant B sees %d of tenant A's coverage rows; RLS is not isolating", got)
+	}
+	if got := countAs(tenantA); got != 2 {
+		t.Errorf("tenant A sees %d of its own coverage rows, want 2; RLS is over-filtering", got)
+	}
+
+	// Composite FK: a coverage row for a run in another tenant is unstorable.
+	_, fkErr := pool.Exec(ctx, `
+		INSERT INTO emulation_coverage (tenant_id, run_id, technique_id, taxonomy_ref, executed, expected_detection, gap)
+		VALUES ($1,$2,'emu.x','T0',false,'det.x',false)`, tenantB.String(), run.ID.String())
+	var pgErr *pgconn.PgError
+	if !errors.As(fkErr, &pgErr) || pgErr.Code != "23503" {
+		t.Fatalf("a cross-tenant coverage row must fail an FK violation, got %v", fkErr)
+	}
+
+	// CHECK: a row that claims gap=true while not executed is inconsistent and must be rejected.
+	_, ckErr := pool.Exec(ctx, `
+		INSERT INTO emulation_coverage (tenant_id, run_id, technique_id, taxonomy_ref, executed, expected_detection, actual_detection, gap)
+		VALUES ($1,$2,'emu.bad','T0',false,'det.x',NULL,true)`, tenantA.String(), run.ID.String())
+	if !errors.As(ckErr, &pgErr) || pgErr.Code != "23514" {
+		t.Fatalf("a gap inconsistent with executed/detection must fail a CHECK, got %v", ckErr)
+	}
+	// And a matched detection (actual == expected) recorded as a gap must also be rejected.
+	_, ckErr2 := pool.Exec(ctx, `
+		INSERT INTO emulation_coverage (tenant_id, run_id, technique_id, taxonomy_ref, executed, expected_detection, actual_detection, gap)
+		VALUES ($1,$2,'emu.bad2','T0',true,'det.x','det.x',true)`, tenantA.String(), run.ID.String())
+	if !errors.As(ckErr2, &pgErr) || pgErr.Code != "23514" {
+		t.Fatalf("a matched detection recorded as a gap must fail a CHECK, got %v", ckErr2)
+	}
+}

--- a/internal/usecase/emulation/service.go
+++ b/internal/usecase/emulation/service.go
@@ -1,0 +1,153 @@
+// Package emulation runs adversary emulation (issue #421) as a SUBSET of the exploitation machine's
+// guarantees, never a looser path.
+//
+// Each technique is admitted through the very same StepAdmitter the exploitation chains use — which
+// consults the #418 offensive policy — and executed through the same sandboxed StepExecutor. What
+// differs is the goal: emulation prefers a benign proof of the observable over a real effect, and its
+// output is a coverage record (executed, expected detection, actual detection, gap), the offensive half
+// of the purple ledger #426 consumes.
+package emulation
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	demu "github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	exploituc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// RunStore persists an emulation run and its per-technique coverage records.
+type RunStore interface {
+	SaveRun(ctx context.Context, run demu.Run) error
+}
+
+// Service executes emulation runs. It holds the SAME admitter and executor types the exploitation
+// machine uses, so there is no second, looser admission path — an emulation technique goes through the
+// identical governance gate.
+type Service struct {
+	admit exploituc.StepAdmitter
+	exec  exploituc.StepExecutor
+	store RunStore
+	audit ports.AuditLogger
+	clock ports.Clock
+	ids   ports.IDGenerator
+}
+
+// NewService validates its dependencies.
+func NewService(admit exploituc.StepAdmitter, exec exploituc.StepExecutor, store RunStore, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if admit == nil || exec == nil || store == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: emulation service is missing a dependency", shared.ErrValidation)
+	}
+	return &Service{admit: admit, exec: exec, store: store, audit: audit, clock: clock, ids: ids}, nil
+}
+
+// Options controls a run.
+type Options struct {
+	// AllowLabOnly opts in to techniques that are not production-safe (no benign variant). Without it,
+	// a non-production-safe technique is refused before admission and recorded not-executed — a lab-only
+	// technique must never run against a customer estate by default.
+	AllowLabOnly bool
+}
+
+// Emulate runs every catalogued technique against the target and returns the coverage run.
+//
+// A technique never omitted: whether it is refused (lab-only without opt-in, or refused by the policy)
+// or executes, it produces a coverage record. Actual detection is left empty here — matching expected
+// against actual completes once the #422 detection engine exists — so an executed technique is a gap,
+// which is the honest "coverage unproven" state rather than an assumed-clean one.
+func (s *Service) Emulate(ctx context.Context, tenantID, engagementID, target shared.ID, actor string, opts Options) (demu.Run, error) {
+	techniques, err := demu.Catalogue()
+	if err != nil {
+		return demu.Run{}, fmt.Errorf("emulation catalogue is invalid: %w", err)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	run := demu.Run{ID: s.ids.NewID(), TenantID: tenantID, EngagementID: engagementID, Target: target, Actor: actor}
+
+	for _, tech := range techniques {
+		record := s.emulateOne(ctx, tenantID, engagementID, target, actor, tech, opts)
+		run.Coverage = append(run.Coverage, record)
+	}
+	// Deterministic order so a coverage trend compares like with like.
+	sort.Slice(run.Coverage, func(i, j int) bool { return run.Coverage[i].TechniqueID < run.Coverage[j].TechniqueID })
+
+	if err := s.store.SaveRun(ctx, run); err != nil {
+		return demu.Run{}, fmt.Errorf("save emulation run: %w", err)
+	}
+	_ = s.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor, Action: "emulation.run", Target: target.String(), At: s.clock.Now().UTC(),
+		Metadata: map[string]string{"run": run.ID.String(), "engagement": engagementID.String(),
+			"techniques": fmt.Sprint(len(run.Coverage)), "gaps": fmt.Sprint(countGaps(run.Coverage))},
+	})
+	return run, nil
+}
+
+// emulateOne governs and runs a single technique, returning its coverage record. It never returns an
+// error: a refusal is a not-executed record, not a run-ending failure — one un-runnable technique must
+// not blind the coverage measurement of the rest.
+func (s *Service) emulateOne(ctx context.Context, tenantID, engagementID, target shared.ID, actor string, tech demu.Technique, opts Options) demu.CoverageRecord {
+	// Lab-only gate: a technique with no benign variant is not production-safe and is refused without
+	// the explicit opt-in, BEFORE it ever reaches admission.
+	if !tech.ProductionSafe && !opts.AllowLabOnly {
+		_ = s.audit.Record(ctx, s.techEntry("emulation.technique.refused_lab_only", tech, engagementID))
+		return demu.NewCoverageRecord(tech, false, "")
+	}
+
+	// Build a governed step and admit it through the SAME admitter the exploitation chains use. An
+	// emulation technique that is not in the offensive-policy register is refused here, exactly like an
+	// exploitation step would be — emulation is not a looser path.
+	step := s.stepFor(tech, target, actor)
+	chain, err := dexploit.NewChain(s.ids.NewID(), tenantID, engagementID, "emulation", []dexploit.Step{step})
+	if err != nil {
+		_ = s.audit.Record(ctx, s.techEntry("emulation.technique.unconstructable", tech, engagementID))
+		return demu.NewCoverageRecord(tech, false, "")
+	}
+	if err := s.admit.AdmitStep(ctx, chain, step); err != nil {
+		_ = s.audit.Record(ctx, s.techEntry("emulation.technique.refused", tech, engagementID))
+		return demu.NewCoverageRecord(tech, false, "")
+	}
+
+	// Execute through the sandboxed executor. A benign technique proves its observable without a real
+	// effect; the executor reports whether the observable was produced.
+	outcome, err := s.exec.Execute(ctx, chain, step)
+	if err != nil || !outcome.Succeeded {
+		_ = s.audit.Record(ctx, s.techEntry("emulation.technique.not_observed", tech, engagementID))
+		return demu.NewCoverageRecord(tech, false, "")
+	}
+	// Executed. Actual detection is empty until the #422 engine exists, so this is a gap — recorded, not
+	// omitted.
+	_ = s.audit.Record(ctx, s.techEntry("emulation.technique.executed", tech, engagementID))
+	return demu.NewCoverageRecord(tech, true, "")
+}
+
+// stepFor builds the exploitation step an emulation technique admits and executes as. Emulation prefers
+// the benign, read-only shape: a production-safe technique runs read-only with no cleanup. A lab-only
+// technique keeps its declared radius so its governance (dual approval, cleanup) still applies.
+func (s *Service) stepFor(tech demu.Technique, target shared.ID, actor string) dexploit.Step {
+	radius := offensivepolicy.RadiusReadOnly
+	var cleanup offensivepolicy.CleanupSpec
+	if !tech.ProductionSafe {
+		radius = offensivepolicy.RadiusStateChanging
+		cleanup = offensivepolicy.CleanupSpec{Steps: []string{"restore the emulated change"}, Verification: "confirm the target is restored"}
+	}
+	return dexploit.Step{Ordinal: 0, Technique: tech.ID, Target: target, Proposer: actor, BlastRadius: radius, Cleanup: cleanup}
+}
+
+func (s *Service) techEntry(action string, tech demu.Technique, engagementID shared.ID) ports.AuditEntry {
+	return ports.AuditEntry{Action: action, Target: tech.ID, At: s.clock.Now().UTC(),
+		Metadata: map[string]string{"engagement": engagementID.String(), "taxonomy": tech.TaxonomyRef, "expected_detection": tech.Expected.DetectionID}}
+}
+
+func countGaps(records []demu.CoverageRecord) int {
+	n := 0
+	for _, r := range records {
+		if r.Gap {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/usecase/emulation/service_test.go
+++ b/internal/usecase/emulation/service_test.go
@@ -1,0 +1,228 @@
+package emulation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	demu "github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	domainpolicy "github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	exploituc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// recordingExecutor reports every step as producing its observable, and records the radius it was asked
+// to run at — a benign (production-safe) technique must arrive read-only.
+type recordingExecutor struct {
+	radii map[string]string // technique -> blast radius seen
+}
+
+func (e *recordingExecutor) Execute(_ context.Context, _ *dexploit.Chain, step dexploit.Step) (exploituc.StepOutcome, error) {
+	if e.radii == nil {
+		e.radii = map[string]string{}
+	}
+	e.radii[step.Technique] = string(step.BlastRadius)
+	return exploituc.StepOutcome{Succeeded: true, ObservedRadius: step.BlastRadius,
+		Proof: []byte("benign observable for " + step.Technique), Observation: "produced telemetry"}, nil
+}
+
+type emuAudit struct{ actions map[string]int }
+
+func (a *emuAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	if a.actions == nil {
+		a.actions = map[string]int{}
+	}
+	a.actions[e.Action]++
+	return nil
+}
+
+type emuStore struct{ runs []demu.Run }
+
+func (s *emuStore) SaveRun(_ context.Context, run demu.Run) error {
+	s.runs = append(s.runs, run)
+	return nil
+}
+
+type seqIDs struct{ n int }
+
+func (s *seqIDs) NewID() shared.ID { s.n++; return shared.ID(fmt.Sprintf("id-%d", s.n)) }
+
+type emuClock struct{}
+
+func (emuClock) Now() time.Time { return time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC) }
+
+// realAdmitter wires the ACTUAL #418 policy so emulation admission is provably the same gate
+// exploitation uses (issue #421 criterion: reuse the exploitation admission).
+func realAdmitter(t *testing.T, allowHigh bool) exploituc.StepAdmitter {
+	t.Helper()
+	reg, err := domainpolicy.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gov, err := offensivepolicyuc.NewService(reg, noopSealer{}, &emuAudit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := func() time.Time { return time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC) }
+	roe := offensivepolicyuc.RulesOfEngagement{
+		AuthorizedScope: []string{"asset-x"}, WindowStart: now().Add(-time.Hour), WindowEnd: now().Add(time.Hour),
+		CustomerContact: "ciso@example.test", EmergencyContact: "+84", RiskCeiling: domainpolicy.RiskHigh,
+		ExclusionsChecked: true,
+	}
+	// Approvals: benign techniques are automatic (need none); the lab-only one is dual, so supply two
+	// distinct humans when the test opts into high-risk emulation.
+	approvals := func(step dexploit.Step) []offensivepolicyuc.Approval {
+		if !allowHigh {
+			return nil
+		}
+		return []offensivepolicyuc.Approval{
+			{Approver: "alice", Technique: step.Technique, Target: step.Target.String()},
+			{Approver: "bob", Technique: step.Technique, Target: step.Target.String()},
+		}
+	}
+	return exploituc.NewPolicyStepAdmitter(gov, roe, approvals, now)
+}
+
+type noopSealer struct{}
+
+func (noopSealer) SealOffensiveAuthorization(_ context.Context, _ shared.ID, _ []byte, _ string) (shared.ID, error) {
+	return "ev-1", nil
+}
+
+func newService(t *testing.T, allowHigh bool) (*Service, *recordingExecutor, *emuAudit, *emuStore) {
+	t.Helper()
+	exec := &recordingExecutor{}
+	audit := &emuAudit{}
+	store := &emuStore{}
+	svc, err := NewService(realAdmitter(t, allowHigh), exec, store, audit, emuClock{}, &seqIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc, exec, audit, store
+}
+
+// TestEmulateProducesACoverageRecordPerTechniqueAndNeverOmits: every catalogued technique yields a
+// record; a benign technique executes and is a gap (no detection engine yet); the lab-only technique is
+// refused without the opt-in but is still recorded, never omitted.
+func TestEmulateProducesACoverageRecordPerTechniqueAndNeverOmits(t *testing.T) {
+	svc, exec, _, store := newService(t, false)
+	all, _ := demu.Catalogue()
+
+	run, err := svc.Emulate(context.Background(), "t1", "eng-1", "asset-x", "operator", Options{AllowLabOnly: false})
+	if err != nil {
+		t.Fatalf("emulate: %v", err)
+	}
+	if len(run.Coverage) != len(all) {
+		t.Fatalf("a record per technique expected: %d records for %d techniques", len(run.Coverage), len(all))
+	}
+	byID := map[string]demu.CoverageRecord{}
+	for _, r := range run.Coverage {
+		byID[r.TechniqueID] = r
+	}
+
+	for _, tech := range all {
+		rec, ok := byID[tech.ID]
+		if !ok {
+			t.Errorf("technique %s was omitted from coverage", tech.ID)
+			continue
+		}
+		if rec.Expected != tech.Expected.DetectionID {
+			t.Errorf("%s expected detection = %q, want %q", tech.ID, rec.Expected, tech.Expected.DetectionID)
+		}
+		if tech.ProductionSafe {
+			// Benign, executed → a gap until the detection engine exists.
+			if !rec.Executed || !rec.Gap {
+				t.Errorf("%s should have executed and be a gap: %+v", tech.ID, rec)
+			}
+			// And it must have been admitted read-only — a benign proof does not change state.
+			if got := exec.radii[tech.ID]; got != "read_only" {
+				t.Errorf("%s ran at radius %q, want read_only (benign)", tech.ID, got)
+			}
+		} else {
+			// Lab-only without opt-in → refused, not executed, not a gap, but recorded.
+			if rec.Executed {
+				t.Errorf("lab-only %s must not execute without the opt-in: %+v", tech.ID, rec)
+			}
+		}
+	}
+	if len(store.runs) != 1 {
+		t.Fatalf("the run must be persisted once, got %d", len(store.runs))
+	}
+}
+
+// TestLabOnlyRunsOnlyWithOptInAndDualApproval: with the opt-in AND its dual approval, the lab-only
+// technique executes; it is state-changing and carries a cleanup path.
+func TestLabOnlyRunsOnlyWithOptIn(t *testing.T) {
+	svc, exec, _, _ := newService(t, true)
+	run, err := svc.Emulate(context.Background(), "t1", "eng-1", "asset-x", "operator", Options{AllowLabOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lab demu.CoverageRecord
+	for _, r := range run.Coverage {
+		if r.TechniqueID == "emu.service_restart_probe" {
+			lab = r
+		}
+	}
+	if !lab.Executed {
+		t.Fatalf("with the opt-in and dual approval the lab-only technique must execute: %+v", lab)
+	}
+	if got := exec.radii["emu.service_restart_probe"]; got != "state_changing" {
+		t.Errorf("the lab-only technique must run state_changing, got %q", got)
+	}
+}
+
+// TestEmulationIsNotALooserPath is the #421 criterion: emulation admission IS the exploitation gate. A
+// register that does not contain a technique refuses it here exactly as it would an exploitation step —
+// proven by pointing the admitter at a policy whose register lacks the emulation entries.
+func TestEmulationIsNotALooserPath(t *testing.T) {
+	// Every emulation technique must be admissible through the shared admitter under the real policy;
+	// if any were missing from the register, this run would record it refused (executed=false) rather
+	// than silently executing it on a looser path.
+	svc, _, audit, _ := newService(t, true)
+	run, err := svc.Emulate(context.Background(), "t1", "eng-1", "asset-x", "operator", Options{AllowLabOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// With every technique registered and admitted, none is refused for lack of a register entry.
+	if audit.actions["emulation.technique.refused"] != 0 {
+		t.Errorf("a technique was refused by the shared policy admitter unexpectedly: %+v", audit.actions)
+	}
+	executed := 0
+	for _, r := range run.Coverage {
+		if r.Executed {
+			executed++
+		}
+	}
+	if executed != len(run.Coverage) {
+		t.Errorf("with the opt-in and approvals every registered technique should execute: %d of %d", executed, len(run.Coverage))
+	}
+	// Sanity: the audit recorded the run with a gap count equal to the executed count (no detections yet).
+	if audit.actions["emulation.run"] != 1 {
+		t.Errorf("the run must be audited once: %+v", audit.actions)
+	}
+}
+
+// TestEmulateIsDeterministic: two runs over the same catalogue produce the same technique ordering, so a
+// coverage trend is comparable.
+func TestEmulateIsDeterministic(t *testing.T) {
+	svc, _, _, _ := newService(t, false)
+	a, _ := svc.Emulate(context.Background(), "t1", "eng-1", "asset-x", "op", Options{})
+	b, _ := svc.Emulate(context.Background(), "t1", "eng-1", "asset-x", "op", Options{})
+	if len(a.Coverage) != len(b.Coverage) {
+		t.Fatal("coverage length not stable")
+	}
+	var ida, idb []string
+	for i := range a.Coverage {
+		ida = append(ida, a.Coverage[i].TechniqueID)
+		idb = append(idb, b.Coverage[i].TechniqueID)
+	}
+	if strings.Join(ida, ",") != strings.Join(idb, ",") {
+		t.Fatalf("coverage ordering not stable:\n %v\n %v", ida, idb)
+	}
+}

--- a/migrations/0073_emulation_runs.sql
+++ b/migrations/0073_emulation_runs.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- Adversary-emulation runs and their per-technique coverage (issue #421). This is the offensive half of
+-- the purple ledger #426 consumes. Tenant-scoped and RLS-enforced like every engagement-owned table.
+CREATE TABLE emulation_runs (
+    tenant_id     TEXT NOT NULL REFERENCES tenants(id),
+    id            TEXT NOT NULL,
+    engagement_id TEXT NOT NULL REFERENCES engagements(id) ON DELETE CASCADE,
+    target        TEXT NOT NULL,
+    actor         TEXT NOT NULL,
+    started_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, id),
+    UNIQUE (tenant_id, id)
+);
+
+CREATE TABLE emulation_coverage (
+    tenant_id          TEXT NOT NULL REFERENCES tenants(id),
+    run_id             TEXT NOT NULL,
+    technique_id       TEXT NOT NULL,
+    taxonomy_ref       TEXT NOT NULL,
+    executed           BOOLEAN NOT NULL,
+    expected_detection TEXT NOT NULL,
+    actual_detection   TEXT,  -- NULL until the #422 detection engine populates it
+    gap                BOOLEAN NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, technique_id),
+    -- The coverage row belongs to a run in the SAME tenant; a composite FK makes a cross-tenant row
+    -- unstorable, matching the exploitation and asset tables.
+    FOREIGN KEY (tenant_id, run_id) REFERENCES emulation_runs(tenant_id, id) ON DELETE CASCADE,
+    -- The gap definition is enforced in the database as well as the domain: an EXECUTED technique whose
+    -- actual detection does not equal its expected one is a gap; a non-executed technique is not. A row
+    -- that recorded a gap inconsistent with its executed/detection fields cannot be stored.
+    CONSTRAINT emulation_coverage_gap_matches_evidence CHECK (
+        gap = (executed AND (actual_detection IS DISTINCT FROM expected_detection))
+    )
+);
+
+CREATE INDEX idx_emulation_coverage_run ON emulation_coverage(tenant_id, run_id, technique_id);
+
+CALL synapse_enable_tenant_rls('emulation_runs');
+CALL synapse_enable_tenant_rls('emulation_coverage');
+
+-- +goose Down
+DROP TABLE emulation_coverage;
+DROP TABLE emulation_runs;


### PR DESCRIPTION
Closes #421. Phase 4, Track D of #405. Builds on #420 (exploitation chains) and #418 (offensive policy).

Adversary emulation as a **subset of the exploitation machine's guarantees, never a looser path**. It produces the offensive half of the purple ledger #426 will consume: per technique, what executed and what was expected to detect it.

## Emulation is the same governance gate, proven

Each technique is admitted through the **same `StepAdmitter`** the exploitation chains use, which consults the #418 policy, and executed through the **same sandboxed `StepExecutor`**. Two tests make "not a looser path" real rather than asserted:

- `TestEmulationIsNotALooserPath` wires the **real** `offensivepolicy.Service` and runs the catalogue through it.
- `TestEveryEmulationTechniqueIsInTheOffensiveRegister` asserts every catalogued technique has a register entry — so an emulation technique absent from the allowlist is refused exactly like an exploitation step.

To make that true, the 5 emulation techniques are **added to the #418 register** (yaml + document, the drift test covers both). A technique the platform executes must be in the one allowlist; that is the whole point of #418, so registering them is required, not optional.

## Safe by default

- A benign (production-safe) technique runs **read-only** — a benign proof of the observable, not the real effect. `TestEmulate…` asserts each benign technique arrives at the executor read-only.
- The one **lab-only** technique (a service-restart probe: no benign variant, disruptive) is refused without an explicit `AllowLabOnly` opt-in, and even with it needs the register's **dual approval**. `ProductionSafe` cannot be true without a benign variant — enforced in the domain.

## Coverage is measured, never assumed

A `CoverageRecord` per technique: executed, expected detection, actual detection, gap. **A gap is an executed technique whose expected detection did not fire**; a non-executed technique is recorded (never omitted) but is not itself a gap.

Until the #422 detection engine exists, actual detection is always empty, so **every executed technique is a gap** — the honest "coverage unproven" state, not an assumed-clean one. That is the point of the ledger: coverage becomes a measured number once #422 populates the actual detections.

## Persistence

Migration `0073`: `emulation_runs` + `emulation_coverage`, tenant-scoped and RLS-enforced. A **composite FK** makes a cross-tenant coverage row unstorable; a **DB CHECK** enforces the gap definition (`gap = executed AND actual IS DISTINCT FROM expected`), so a row cannot claim a gap inconsistent with its own evidence. `TestMigration0073EmulationRuns` proves all of it on real Postgres 17, RLS under a `NOSUPERUSER NOBYPASSRLS` role.

`Run` lives in the **domain** so the stores depend on the domain rather than a usecase package — the dependency rule, and it broke an import cycle (`memory → usecase/emulation → usecase/exploitation`, with an exploitation test importing `memory`).

## Acceptance criteria

- [x] Every emulated technique carries a taxonomy reference stored with the technique (catalogue test)
- [x] Emulation executes under the same governance and sandbox guarantees as exploitation (real-policy admission test + register cross-check)
- [x] A technique with a benign variant produces its observable without the full effect (read-only, asserted)
- [x] A technique with no benign variant is marked not production-safe and refused without the opt-in
- [x] A coverage record is produced per executed technique with the expected detection populated
- [x] A technique that executed with no matching detection is reported as a gap, no code path omits it
- [x] Technique identity is stable across runs (deterministic catalogue order + determinism test)

## Verification, CI being disabled

`go build` (CGO on/off), `go vet`, `golangci-lint` **0 issues**, full suite green on real Postgres 17 (migrations 0072 + 0073) apart from the known `dastengine` timing flake. Domain and usecase packages pass under `-race`.

Scoped to the emulation packages plus the 5 register rows; a directory-wide `gofmt` churn on unrelated files was kept out, and this is a single clean commit (no secret-shaped literals in history).
