### PR TITLE
feat(redteam): fleet-wide chain kill-switch registry (#418/#420 follow-up)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1247,8 +1247,14 @@ func main() {
 			log.Error("offensive kill switch init failed", "err", kerr)
 			os.Exit(1)
 		} else {
+			// Second layer of the kill switch (#418 follow-up on #420): an in-process registry of running
+			// exploitation chains, so a halt reaches a chain executing in memory and not only a work order.
+			// A chain driver registers its Machine here (via RunTracked); the registry is process-scoped,
+			// which for this single-process deployment is the whole control plane.
+			chainRegistry := exploitationuc.NewChainRegistry()
+			killSwitch.SetChainHalter(chainRegistry)
 			router.SetOffensiveKillSwitch(killSwitch)
-			log.Info("offensive kill switch ENABLED", "route", "POST /api/v1/redteam/halt", "bound", offensivepolicyuc.HaltBound.String())
+			log.Info("offensive kill switch ENABLED", "route", "POST /api/v1/redteam/halt", "bound", offensivepolicyuc.HaltBound.String(), "chain_registry", true)
 		}
 		// Optional certificate identity (#408): when a control-plane CA is configured, enrolment
 		// with a CSR issues a client certificate. Fail closed on a misconfigured CA.

--- a/internal/adapter/httpapi/redteam_halt_handler.go
+++ b/internal/adapter/httpapi/redteam_halt_handler.go
@@ -37,6 +37,9 @@ type haltResponse struct {
 	Halted         bool              `json:"halted"`
 	Cancelled      []string          `json:"cancelled"`
 	Failed         map[string]string `json:"failed,omitempty"`
+	ChainsHalted   []string          `json:"chains_halted,omitempty"`
+	ChainsFailed   map[string]string `json:"chains_failed,omitempty"`
+	ChainHaltError string            `json:"chain_halt_error,omitempty"`
 	AuditRecorded  bool              `json:"audit_recorded"`
 	EstateStopNote string            `json:"estate_stop_note"`
 }
@@ -58,7 +61,9 @@ func (rt *Router) haltOffensiveWork(w http.ResponseWriter, r *http.Request) {
 		DurationMS: result.Duration.Milliseconds(), StatedBoundMS: offensiveuc.HaltBound.Milliseconds(),
 		WithinBound: result.WithinBound, Halted: err == nil && result.Halted(),
 		Cancelled: idStrings(result.Cancelled), Failed: failureStrings(result.Failed),
-		AuditRecorded: !result.AuditFailed, EstateStopNote: result.EstateStopNote,
+		ChainsHalted: idStrings(result.Chains.Halted), ChainsFailed: failureStrings(result.Chains.Failed),
+		ChainHaltError: result.ChainHaltError,
+		AuditRecorded:  !result.AuditFailed, EstateStopNote: result.EstateStopNote,
 	}
 	switch {
 	case err == nil:

--- a/internal/usecase/exploitation/chain.go
+++ b/internal/usecase/exploitation/chain.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 
 	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
@@ -67,6 +68,11 @@ type stepSealer interface {
 // executes, seals, verifies and advances, and it runs cleanup on any halt or failure. No agent tool is
 // registered that reaches Run or Halt, so a model can propose a chain but never drives one.
 type Machine struct {
+	// mu serialises one step of Run against a concurrent Halt. A Halt (from the kill-switch registry,
+	// running on a different goroutine than Run) can only interpose at a step boundary, never mid-step:
+	// it acquires mu, so it waits for the current step to finish and then sees a consistent chain state.
+	// This is why the registry can stop a running chain safely without racing the domain state machine.
+	mu       sync.Mutex
 	chain    *dexploit.Chain
 	admit    StepAdmitter
 	exec     StepExecutor
@@ -88,10 +94,17 @@ func NewMachine(chain *dexploit.Chain, admit StepAdmitter, exec StepExecutor, v 
 	return &Machine{chain: chain, admit: admit, exec: exec, verifier: v, cleanup: cleanup, sealer: sealer, store: store, audit: audit, clock: clock}, nil
 }
 
-// State returns the current chain state.
-func (m *Machine) State() dexploit.ChainState { return m.chain.State }
+// State returns the current chain state. It takes the machine lock so a caller can read the state while
+// Run is executing on another goroutine (e.g. the kill-switch registry deciding what to halt).
+func (m *Machine) State() dexploit.ChainState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.chain.State
+}
 
-// Chain exposes the underlying chain for inspection (read-only intent).
+// Chain exposes the underlying chain for inspection (read-only intent). It returns the live pointer and
+// does NOT take the machine lock, so it is safe only before Run starts or after it returns — never
+// concurrently with a running Run or a Halt. Use State() for a lock-guarded read while a chain is live.
 func (m *Machine) Chain() *dexploit.Chain { return m.chain }
 
 // Run drives the chain to a terminal state: step by step, admit → execute → seal → verify → advance,
@@ -100,93 +113,125 @@ func (m *Machine) Chain() *dexploit.Chain { return m.chain }
 // A refusal at any step (admission, blast-radius violation, missing evidence, sub-bar or self verdict)
 // halts the chain and triggers cleanup rather than continuing. Run is idempotent on a terminal chain.
 func (m *Machine) Run(ctx context.Context) (dexploit.ChainState, error) {
-	for !m.chain.State.Terminal() {
-		if err := ctx.Err(); err != nil {
-			return m.haltAndClean(ctx, "context: "+err.Error())
+	for {
+		state, done, err := m.runStep(ctx)
+		if done {
+			return state, err
 		}
-		step, ok := m.chain.CurrentStep()
-		if !ok {
-			break
-		}
-		s := *step
+	}
+}
 
-		// 1. Admit THIS step individually. A chain does not carry blanket permission.
-		if err := m.admit.AdmitStep(ctx, m.chain, s); err != nil {
-			_ = m.audit.Record(ctx, m.entry("exploitation.step.refused", s, map[string]string{"error": err.Error()}))
-			m.chain.FailCurrentStep()
-			return m.cleanAfterFailure(ctx)
-		}
+// runStep drives the chain by exactly one step, under the machine lock. Holding the lock for the whole
+// step is deliberate: it means a concurrent Halt (from the kill-switch registry) can only take the lock
+// between steps, so it never observes or mutates the chain mid-step. The cost is that a Halt waits for
+// the current step to reach its boundary — which is the honest bound, since a technique already running
+// on a host cannot be interrupted safely partway through.
+//
+// It returns done=true with the terminal state when the chain is finished (already terminal, halted on
+// context cancellation, or failed/cleaned), and done=false to ask Run for another step.
+func (m *Machine) runStep(ctx context.Context) (state dexploit.ChainState, done bool, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-		// 2. Begin + execute argv-only in the sandbox.
-		if err := m.chain.BeginStep(); err != nil {
-			return m.chain.State, err
+	if m.chain.State.Terminal() {
+		if m.chain.State == dexploit.StateSucceeded {
+			_ = m.audit.Record(ctx, m.entry("exploitation.chain.succeeded", dexploit.Step{}, map[string]string{"steps": fmt.Sprint(len(m.chain.Steps))}))
 		}
-		_ = m.store.SaveChain(ctx, m.chain)
-		outcome, err := m.exec.Execute(ctx, m.chain, s)
-		if err != nil {
-			// Execution error is not evidence of success. Record no evidence → the domain fails the step.
-			_ = m.chain.RecordExecuted("", false)
-			_ = m.audit.Record(ctx, m.entry("exploitation.step.exec_error", s, map[string]string{"error": err.Error()}))
-			return m.cleanAfterFailure(ctx)
-		}
+		return m.chain.State, true, nil
+	}
+	if e := ctx.Err(); e != nil {
+		s, ce := m.haltAndClean(ctx, "context: "+e.Error())
+		return s, true, ce
+	}
+	step, ok := m.chain.CurrentStep()
+	if !ok {
+		return m.chain.State, true, nil
+	}
+	s := *step
 
-		// 3. Enforce blast radius at EXECUTION, not only at declaration. A step whose actual effect
-		//    exceeds what it declared is a policy violation and halts the chain.
-		if radiusExceeded(s.BlastRadius, outcome.ObservedRadius) {
-			_ = m.audit.Record(ctx, m.entry("exploitation.step.blast_radius_violation", s, map[string]string{
-				"declared": string(s.BlastRadius), "observed": string(outcome.ObservedRadius),
-			}))
-			_ = m.chain.RecordExecuted("", false) // treated as failed; then cleaned
-			return m.cleanAfterFailure(ctx)
-		}
+	// 1. Admit THIS step individually. A chain does not carry blanket permission.
+	if err := m.admit.AdmitStep(ctx, m.chain, s); err != nil {
+		_ = m.audit.Record(ctx, m.entry("exploitation.step.refused", s, map[string]string{"error": err.Error()}))
+		m.chain.FailCurrentStep()
+		st, e := m.cleanAfterFailure(ctx)
+		return st, true, e
+	}
 
-		// 4. Seal the bounded, redacted proof as this step's evidence. No seal → no evidence → failed.
-		evidenceID, sealErr := m.sealStep(ctx, s, outcome)
-		if sealErr != nil {
-			_ = m.chain.RecordExecuted("", false)
-			_ = m.audit.Record(ctx, m.entry("exploitation.step.seal_failed", s, map[string]string{"error": sealErr.Error()}))
-			return m.cleanAfterFailure(ctx)
-		}
-		if err := m.chain.RecordExecuted(evidenceID, outcome.Succeeded); err != nil {
-			_ = m.store.SaveChain(ctx, m.chain)
-			return m.cleanAfterFailure(ctx)
-		}
-		_ = m.store.SaveChain(ctx, m.chain)
+	// 2. Begin + execute argv-only in the sandbox.
+	if err := m.chain.BeginStep(); err != nil {
+		return m.chain.State, true, err
+	}
+	_ = m.store.SaveChain(ctx, m.chain)
+	outcome, err := m.exec.Execute(ctx, m.chain, s)
+	if err != nil {
+		// Execution error is not evidence of success. Record no evidence → the domain fails the step.
+		_ = m.chain.RecordExecuted("", false)
+		_ = m.audit.Record(ctx, m.entry("exploitation.step.exec_error", s, map[string]string{"error": err.Error()}))
+		st, e := m.cleanAfterFailure(ctx)
+		return st, true, e
+	}
 
-		// 5. A distinct verifier's sealed verdict decides whether the chain proceeds.
-		vd, err := m.verifier.Verify(ctx, m.chain, s, outcome)
-		if err != nil {
-			m.chain.FailCurrentStep()
-			return m.cleanAfterFailure(ctx)
-		}
-		if verr := vd.Validate(); verr != nil {
-			m.chain.FailCurrentStep()
-			return m.cleanAfterFailure(ctx)
-		}
-		distinct := !verdict.SelfConfirm(vd.Verifier, s.Proposer)
-		if err := m.chain.Advance(vd.Verifier, vd.Score, verdict.MeetsBar(vd.Score), distinct); err != nil {
-			_ = m.audit.Record(ctx, m.entry("exploitation.step.not_advanced", s, map[string]string{"error": err.Error(), "verifier": vd.Verifier}))
-			// A sub-bar verdict already failed the chain inside Advance; a self verdict left it verifying
-			// (Advance refuses rather than fails, so the state is preserved for inspection). Fail the step
-			// explicitly here so cleanup can run and the chain reaches a terminal cleaned state either way.
-			m.chain.FailCurrentStep()
-			return m.cleanAfterFailure(ctx)
-		}
-		_ = m.audit.Record(ctx, m.entry("exploitation.step.advanced", s, map[string]string{
-			"verifier": vd.Verifier, "score": fmt.Sprint(vd.Score), "evidence_id": evidenceID.String(),
+	// 3. Enforce blast radius at EXECUTION, not only at declaration. A step whose actual effect
+	//    exceeds what it declared is a policy violation and halts the chain.
+	if radiusExceeded(s.BlastRadius, outcome.ObservedRadius) {
+		_ = m.audit.Record(ctx, m.entry("exploitation.step.blast_radius_violation", s, map[string]string{
+			"declared": string(s.BlastRadius), "observed": string(outcome.ObservedRadius),
 		}))
-		_ = m.store.SaveChain(ctx, m.chain)
+		_ = m.chain.RecordExecuted("", false) // treated as failed; then cleaned
+		st, e := m.cleanAfterFailure(ctx)
+		return st, true, e
 	}
 
-	if m.chain.State == dexploit.StateSucceeded {
-		_ = m.audit.Record(ctx, m.entry("exploitation.chain.succeeded", dexploit.Step{}, map[string]string{"steps": fmt.Sprint(len(m.chain.Steps))}))
+	// 4. Seal the bounded, redacted proof as this step's evidence. No seal → no evidence → failed.
+	evidenceID, sealErr := m.sealStep(ctx, s, outcome)
+	if sealErr != nil {
+		_ = m.chain.RecordExecuted("", false)
+		_ = m.audit.Record(ctx, m.entry("exploitation.step.seal_failed", s, map[string]string{"error": sealErr.Error()}))
+		st, e := m.cleanAfterFailure(ctx)
+		return st, true, e
 	}
-	return m.chain.State, nil
+	if err := m.chain.RecordExecuted(evidenceID, outcome.Succeeded); err != nil {
+		_ = m.store.SaveChain(ctx, m.chain)
+		st, e := m.cleanAfterFailure(ctx)
+		return st, true, e
+	}
+	_ = m.store.SaveChain(ctx, m.chain)
+
+	// 5. A distinct verifier's sealed verdict decides whether the chain proceeds.
+	vd, err := m.verifier.Verify(ctx, m.chain, s, outcome)
+	if err != nil {
+		m.chain.FailCurrentStep()
+		st, e := m.cleanAfterFailure(ctx)
+		return st, true, e
+	}
+	if verr := vd.Validate(); verr != nil {
+		m.chain.FailCurrentStep()
+		st, e := m.cleanAfterFailure(ctx)
+		return st, true, e
+	}
+	distinct := !verdict.SelfConfirm(vd.Verifier, s.Proposer)
+	if err := m.chain.Advance(vd.Verifier, vd.Score, verdict.MeetsBar(vd.Score), distinct); err != nil {
+		_ = m.audit.Record(ctx, m.entry("exploitation.step.not_advanced", s, map[string]string{"error": err.Error(), "verifier": vd.Verifier}))
+		// A sub-bar verdict already failed the chain inside Advance; a self verdict left it verifying
+		// (Advance refuses rather than fails, so the state is preserved for inspection). Fail the step
+		// explicitly here so cleanup can run and the chain reaches a terminal cleaned state either way.
+		m.chain.FailCurrentStep()
+		st, e := m.cleanAfterFailure(ctx)
+		return st, true, e
+	}
+	_ = m.audit.Record(ctx, m.entry("exploitation.step.advanced", s, map[string]string{
+		"verifier": vd.Verifier, "score": fmt.Sprint(vd.Score), "evidence_id": evidenceID.String(),
+	}))
+	_ = m.store.SaveChain(ctx, m.chain)
+	return m.chain.State, false, nil
 }
 
 // Halt is the kill switch's entry point for a running chain: stop, run cleanup for every completed
-// state-changing step, and audit. It returns the terminal state.
+// state-changing step, and audit. It returns the terminal state. It takes the machine lock, so a Halt
+// racing Run interposes at a step boundary and sees a consistent chain.
 func (m *Machine) Halt(ctx context.Context, actor, reason string) (dexploit.ChainState, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.chain.State.Terminal() {
 		return m.chain.State, nil
 	}

--- a/internal/usecase/exploitation/registry.go
+++ b/internal/usecase/exploitation/registry.go
@@ -1,0 +1,140 @@
+package exploitation
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+)
+
+// ChainRegistry tracks the exploitation chains currently running IN THIS PROCESS, so the offensive kill
+// switch (issue #418, follow-up on #420) can reach them.
+//
+// The work-order layer of the kill switch cancels queued and claimed offensive work orders. A chain
+// already executing in memory is not a work order, so without this registry a running chain would be the
+// one thing an operator's halt could not stop. The registry closes that gap: a Machine registers itself
+// while it runs and the kill switch halts every registered chain for the tenant.
+//
+// Scope honesty. This registry covers the process it lives in. In the current single-process deployment
+// that is the whole estate's control plane. Under horizontal scale (P5) a chain runs on one node and a
+// fleet-wide halt must fan out to every node's registry — a P5 concern this type does not pretend to
+// solve. It never claims to reach a chain running in another process.
+//
+// It implements offensivepolicyuc.ChainHalter. The interface is defined in the offensivepolicy package
+// (the consumer) and implemented here; the dependency points from exploitation to offensivepolicy, the
+// same direction admission already uses, so there is no import cycle.
+type ChainRegistry struct {
+	mu      sync.Mutex
+	running map[shared.ID]map[shared.ID]*Machine // tenant -> chainID -> machine
+}
+
+var _ offensivepolicyuc.ChainHalter = (*ChainRegistry)(nil)
+
+// NewChainRegistry constructs an empty registry.
+func NewChainRegistry() *ChainRegistry {
+	return &ChainRegistry{running: map[shared.ID]map[shared.ID]*Machine{}}
+}
+
+// Register records a running chain under its tenant. It is idempotent and safe for concurrent use.
+func (r *ChainRegistry) Register(m *Machine) {
+	if r == nil || m == nil || m.chain == nil {
+		return
+	}
+	tenant := shared.TenantOrDefault(m.chain.TenantID)
+	id := m.chain.ID
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.running[tenant] == nil {
+		r.running[tenant] = map[shared.ID]*Machine{}
+	}
+	r.running[tenant][id] = m
+}
+
+// Unregister drops a chain from the registry (its run finished or it was halted). It is idempotent.
+func (r *ChainRegistry) Unregister(tenant, chainID shared.ID) {
+	if r == nil {
+		return
+	}
+	tenant = shared.TenantOrDefault(tenant)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if set := r.running[tenant]; set != nil {
+		delete(set, chainID)
+		if len(set) == 0 {
+			delete(r.running, tenant)
+		}
+	}
+}
+
+// RunTracked registers the machine, runs it to a terminal state, and unregisters it — even if Run
+// panics or returns an error. Any goroutine that drives a chain should use this so the chain is haltable
+// for exactly as long as it is running, and never leaks into the registry afterwards.
+func (r *ChainRegistry) RunTracked(ctx context.Context, m *Machine) (dexploit.ChainState, error) {
+	if m == nil {
+		return "", nil
+	}
+	r.Register(m)
+	defer r.Unregister(m.chain.TenantID, m.chain.ID)
+	return m.Run(ctx)
+}
+
+// HaltChains halts every chain this process is running for the tenant, runs each one's cleanup, and
+// reports the outcome. It satisfies offensivepolicyuc.ChainHalter.
+//
+// A halted chain reaches a terminal state and unregisters itself here, so a second halt is a no-op. A
+// chain that FAILS to halt (cleanup error) stays registered and is reported in Failed — a human must
+// look, and a retry must not silently spin on it.
+//
+// A chain that registers WHILE a halt is in progress is still caught: the halt re-scans until no
+// haltable chain remains, stopping only when a pass makes no progress (everything left is a recorded
+// failure). This bounds the work to the chains that actually exist and cannot livelock.
+func (r *ChainRegistry) HaltChains(ctx context.Context, tenantID shared.ID, actor, reason string) (offensivepolicyuc.ChainHaltSummary, error) {
+	summary := offensivepolicyuc.ChainHaltSummary{Failed: map[shared.ID]string{}}
+	if r == nil {
+		return summary, nil
+	}
+	tenant := shared.TenantOrDefault(tenantID)
+
+	for {
+		// Snapshot the haltable machines under the lock, then release it before calling Halt: Halt does
+		// I/O (cleanup) and would deadlock against a chain that finishes on its own and calls Unregister.
+		// Skip chains we already recorded as failed, or the loop would spin on them forever.
+		r.mu.Lock()
+		machines := make([]*Machine, 0, len(r.running[tenant]))
+		for id, m := range r.running[tenant] {
+			if _, failed := summary.Failed[id]; failed {
+				continue
+			}
+			machines = append(machines, m)
+		}
+		r.mu.Unlock()
+		if len(machines) == 0 {
+			break
+		}
+
+		// Deterministic order so the summary and audit read the same across runs.
+		sort.Slice(machines, func(i, j int) bool { return machines[i].chain.ID < machines[j].chain.ID })
+
+		progressed := false
+		for _, m := range machines {
+			id := m.chain.ID
+			if _, err := m.Halt(ctx, actor, reason); err != nil {
+				summary.Failed[id] = err.Error()
+				continue
+			}
+			summary.Halted = append(summary.Halted, id)
+			r.Unregister(tenant, id)
+			progressed = true
+		}
+		if !progressed {
+			// Every remaining chain failed to halt; a re-scan would only retry the same failures.
+			break
+		}
+	}
+
+	sort.Slice(summary.Halted, func(i, j int) bool { return summary.Halted[i] < summary.Halted[j] })
+	return summary, nil
+}

--- a/internal/usecase/exploitation/registry_test.go
+++ b/internal/usecase/exploitation/registry_test.go
@@ -1,0 +1,243 @@
+package exploitation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// haltableMachine builds a machine whose chain has one completed state-changing step, so a halt has a
+// real cleanup obligation to run. This mirrors the #420 direct-halt fixture, wrapped for the registry.
+func haltableMachine(t *testing.T, tenant, id shared.ID, cleanup *fakeCleanup, audit *fakeAudit) *Machine {
+	t.Helper()
+	chain, err := dexploit.NewChain(id, tenant, "e1", "p1", []dexploit.Step{scStep(0, "exploit.web_shell_upload", "agent:planner")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = chain.BeginStep()
+	_ = chain.RecordExecuted("ev-0", true) // completed + holds a cleanup obligation
+	m, err := NewMachine(chain, &fakeAdmit{}, &fakeExec{}, &fakeVerifier{score: 90}, cleanup, &chainSealerFake{}, &fakeStore{}, audit, chainClock{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+// TestChainRegistryHaltStopsTenantChains: one operator halt stops every chain THIS process is running
+// for the tenant, runs each one's cleanup, audits each, is measured, and leaves other tenants untouched.
+func TestChainRegistryHaltStopsTenantChains(t *testing.T) {
+	reg := NewChainRegistry()
+	clA1, clA2, clB := &fakeCleanup{fail: map[int]error{}}, &fakeCleanup{fail: map[int]error{}}, &fakeCleanup{fail: map[int]error{}}
+	auA1, auA2, auB := &fakeAudit{}, &fakeAudit{}, &fakeAudit{}
+	a1 := haltableMachine(t, "tenant-A", "chain-1", clA1, auA1)
+	a2 := haltableMachine(t, "tenant-A", "chain-2", clA2, auA2)
+	b1 := haltableMachine(t, "tenant-B", "chain-9", clB, auB)
+	reg.Register(a1)
+	reg.Register(a2)
+	reg.Register(b1)
+
+	start := time.Now()
+	summary, err := reg.HaltChains(context.Background(), "tenant-A", "operator@example.test", "customer requested a stop")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("halt chains: %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("halting registered chains took %s, unexpectedly slow", elapsed)
+	}
+	// Both tenant-A chains halted, in deterministic sorted order, none failed.
+	if len(summary.Halted) != 2 || len(summary.Failed) != 0 {
+		t.Fatalf("want 2 halted / 0 failed, got halted=%v failed=%v", summary.Halted, summary.Failed)
+	}
+	if summary.Halted[0] != "chain-1" || summary.Halted[1] != "chain-2" {
+		t.Fatalf("halted set not deterministic/sorted: %v", summary.Halted)
+	}
+	if a1.State() != dexploit.StateCleaned || a2.State() != dexploit.StateCleaned {
+		t.Fatalf("halted chains must be cleaned, got %s and %s", a1.State(), a2.State())
+	}
+	if len(clA1.cleaned()) != 1 || len(clA2.cleaned()) != 1 {
+		t.Fatalf("halt must run cleanup for each completed state-changing step: %v %v", clA1.cleaned(), clA2.cleaned())
+	}
+	if !auA1.has("exploitation.chain.halted") || !auA2.has("exploitation.chain.halted") {
+		t.Error("each halted chain must be audited")
+	}
+	// Tenant B is untouched: a halt is per tenant, never fleet-wide across tenants.
+	if b1.State() == dexploit.StateCleaned || b1.State() == dexploit.StateHalted {
+		t.Fatalf("a tenant-A halt stopped a tenant-B chain: %s", b1.State())
+	}
+	if len(clB.cleaned()) != 0 {
+		t.Error("a tenant-A halt ran a tenant-B chain's cleanup")
+	}
+	// The halted chains left the registry, so a second halt for the tenant finds nothing.
+	again, err := reg.HaltChains(context.Background(), "tenant-A", "operator@example.test", "again")
+	if err != nil {
+		t.Fatalf("second halt: %v", err)
+	}
+	if len(again.Halted) != 0 || len(again.Failed) != 0 {
+		t.Fatalf("a second halt should find nothing running, got halted=%v failed=%v", again.Halted, again.Failed)
+	}
+}
+
+// TestChainRegistryHaltReportsCleanupFailure: a chain whose cleanup fails does NOT read as halted. It is
+// reported in Failed (a human must look), it stays registered, and the halt does not spin retrying it.
+func TestChainRegistryHaltReportsCleanupFailure(t *testing.T) {
+	reg := NewChainRegistry()
+	badCleanup := &fakeCleanup{fail: map[int]error{0: errors.New("host unreachable")}}
+	m := haltableMachine(t, "t1", "chain-x", badCleanup, &fakeAudit{})
+	reg.Register(m)
+
+	summary, _ := reg.HaltChains(context.Background(), "t1", "operator@example.test", "stop")
+	if len(summary.Failed) != 1 {
+		t.Fatalf("a cleanup failure must be reported as failed, got halted=%v failed=%v", summary.Halted, summary.Failed)
+	}
+	if _, ok := summary.Failed["chain-x"]; !ok {
+		t.Errorf("the stuck chain id must be in Failed: %v", summary.Failed)
+	}
+	if len(summary.Halted) != 0 {
+		t.Errorf("a chain whose cleanup failed must not read as cleanly halted: %v", summary.Halted)
+	}
+	// It is still registered so an operator/re-halt can see it; a re-halt still does not read it as halted.
+	summary2, _ := reg.HaltChains(context.Background(), "t1", "operator@example.test", "again")
+	if len(summary2.Halted) != 0 {
+		t.Errorf("a stuck chain must never read as cleanly halted on retry: %v", summary2.Halted)
+	}
+}
+
+// registeringCleanup registers another machine into the registry the first time it runs — simulating a
+// chain that starts WHILE a halt is in progress. The re-scan in HaltChains must still catch it.
+type registeringCleanup struct {
+	reg   *ChainRegistry
+	toAdd *Machine
+	once  sync.Once
+	inner *fakeCleanup
+}
+
+func (c *registeringCleanup) Cleanup(ctx context.Context, chain *dexploit.Chain, step dexploit.Step) error {
+	c.once.Do(func() { c.reg.Register(c.toAdd) })
+	return c.inner.Cleanup(ctx, chain, step)
+}
+
+// TestChainRegistryHaltCatchesChainRegisteredMidHalt: a chain that appears in the registry during the
+// halt (here, while the first chain's cleanup runs) is still halted by the re-scan.
+func TestChainRegistryHaltCatchesChainRegisteredMidHalt(t *testing.T) {
+	reg := NewChainRegistry()
+
+	// The late arrival: a planned chain, not yet registered.
+	late := haltableMachine(t, "t1", "chain-late", &fakeCleanup{fail: map[int]error{}}, &fakeAudit{})
+
+	first := &registeringCleanup{reg: reg, toAdd: late, inner: &fakeCleanup{fail: map[int]error{}}}
+	firstChain, err := dexploit.NewChain("chain-first", "t1", "e1", "p1", []dexploit.Step{scStep(0, "exploit.web_shell_upload", "agent:planner")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = firstChain.BeginStep()
+	_ = firstChain.RecordExecuted("ev-0", true)
+	m, err := NewMachine(firstChain, &fakeAdmit{}, &fakeExec{}, &fakeVerifier{score: 90}, first, &chainSealerFake{}, &fakeStore{}, &fakeAudit{}, chainClock{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg.Register(m)
+
+	summary, err := reg.HaltChains(context.Background(), "t1", "operator@example.test", "stop")
+	if err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+	// Both the first chain and the one that appeared mid-halt were halted.
+	if len(summary.Halted) != 2 {
+		t.Fatalf("the chain registered mid-halt must also be halted, got %v", summary.Halted)
+	}
+	if late.State() != dexploit.StateCleaned {
+		t.Fatalf("the late-registered chain was not halted: %s", late.State())
+	}
+}
+
+// TestChainRegistryConcurrentRunAndHalt drives several chains concurrently and halts them mid-flight.
+// Run with -race, it proves the machine lock serialises a step against a concurrent halt: every chain
+// reaches a terminal state and there is no data race on the domain chain.
+func TestChainRegistryConcurrentRunAndHalt(t *testing.T) {
+	reg := NewChainRegistry()
+	const n = 8
+	machines := make([]*Machine, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		steps := []dexploit.Step{
+			scStep(0, "exploit.a", "agent:planner"),
+			scStep(1, "exploit.b", "agent:planner"),
+			roStep(2, "recon.service_banner", "agent:planner"),
+		}
+		chain, err := dexploit.NewChain(shared.ID(fmt.Sprintf("c-%d", i)), "t1", "e1", "p1", steps)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ex := &fakeExec{
+			observed: map[string]offensivepolicy.Radius{}, fail: map[string]bool{}, execErr: map[string]error{},
+			delay: 20 * time.Millisecond, // keep each chain running long enough to be caught mid-flight
+		}
+		m, err := NewMachine(chain, &fakeAdmit{refuse: map[string]error{}}, ex, &fakeVerifier{score: 90},
+			&fakeCleanup{fail: map[int]error{}}, &chainSealerFake{}, &fakeStore{}, &fakeAudit{}, chainClock{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		machines[i] = m
+		wg.Add(1)
+		go func(m *Machine) {
+			defer wg.Done()
+			_, _ = reg.RunTracked(context.Background(), m)
+		}(m)
+	}
+
+	time.Sleep(10 * time.Millisecond) // let the first step of each chain get going
+	if _, err := reg.HaltChains(context.Background(), "t1", "operator@example.test", "concurrent stop"); err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+	wg.Wait()
+
+	for i, m := range machines {
+		if !m.State().Terminal() {
+			t.Fatalf("chain %d did not reach a terminal state after halt+run: %s", i, m.State())
+		}
+	}
+	// Every chain finished, so RunTracked unregistered them all: nothing is left to halt.
+	final, _ := reg.HaltChains(context.Background(), "t1", "operator@example.test", "final")
+	if len(final.Halted) != 0 || len(final.Failed) != 0 {
+		t.Fatalf("no chain should remain registered after all runs finished, got halted=%v failed=%v", final.Halted, final.Failed)
+	}
+}
+
+// TestRunTrackedRegistersForItsLifetimeOnly: a chain is haltable while it runs and gone from the
+// registry the instant it finishes.
+func TestRunTrackedRegistersForItsLifetimeOnly(t *testing.T) {
+	reg := NewChainRegistry()
+	h := newHarness(t, []dexploit.Step{roStep(0, "recon.service_banner", "agent:planner")}, nil)
+	state, err := reg.RunTracked(context.Background(), h.m)
+	if err != nil {
+		t.Fatalf("run tracked: %v", err)
+	}
+	if state != dexploit.StateSucceeded {
+		t.Fatalf("want succeeded, got %s", state)
+	}
+	summary, _ := reg.HaltChains(context.Background(), "t1", "operator@example.test", "stop")
+	if len(summary.Halted) != 0 || len(summary.Failed) != 0 {
+		t.Fatalf("a finished chain must not remain registered, got halted=%v failed=%v", summary.Halted, summary.Failed)
+	}
+}
+
+// TestHaltChainsOnEmptyRegistryIsCleanNoOp: halting a tenant with nothing running is a clean, empty
+// success — not an error.
+func TestHaltChainsOnEmptyRegistryIsCleanNoOp(t *testing.T) {
+	reg := NewChainRegistry()
+	summary, err := reg.HaltChains(context.Background(), "t1", "operator@example.test", "stop")
+	if err != nil {
+		t.Fatalf("halt on empty registry: %v", err)
+	}
+	if len(summary.Halted) != 0 || len(summary.Failed) != 0 {
+		t.Fatalf("empty registry halt should report nothing, got halted=%v failed=%v", summary.Halted, summary.Failed)
+	}
+}

--- a/internal/usecase/offensivepolicy/killswitch.go
+++ b/internal/usecase/offensivepolicy/killswitch.go
@@ -29,6 +29,27 @@ type haltableStore interface {
 	Transition(ctx context.Context, tenantID, id shared.ID, to workorder.State, reason string, expected workorder.State, now time.Time) error
 }
 
+// ChainHaltSummary reports the outcome of halting the in-memory exploitation chains a process is
+// running. It is kept separate from the work-order fields so an operator can see which layer of the kill
+// switch stopped what: queued/claimed work orders, or chains executing in memory.
+type ChainHaltSummary struct {
+	Halted []shared.ID
+	Failed map[shared.ID]string
+}
+
+// clean reports whether every running chain was halted (or there were none).
+func (c ChainHaltSummary) clean() bool { return len(c.Failed) == 0 }
+
+// ChainHalter halts every exploitation chain running IN THE CURRENT PROCESS for a tenant. It is the
+// second layer of the kill switch: work orders cover queued and claimed offensive work, this covers a
+// chain already executing in memory, which is not a work order and would otherwise be unreachable.
+//
+// It is optional. A deployment that never drives chains in-process wires nil, and the kill switch then
+// covers work orders alone — honestly, because the response says so.
+type ChainHalter interface {
+	HaltChains(ctx context.Context, tenantID shared.ID, actor, reason string) (ChainHaltSummary, error)
+}
+
 // HaltResult is what the operator gets back. It reports partial failure honestly: a halt that cancelled
 // nine of ten orders is not a clean halt, and saying so is the difference between an operator escalating
 // and an operator believing the estate is safe.
@@ -40,13 +61,22 @@ type HaltResult struct {
 	Cancelled   []shared.ID
 	Failed      map[shared.ID]string
 	AuditFailed bool
+	// Chains reports the in-memory exploitation chains this halt stopped. Its zero value means the chain
+	// layer was not wired (no ChainHalter) — distinct from "wired and found nothing running".
+	Chains ChainHaltSummary
+	// ChainHaltError is set when the chain layer could not be driven at all (not a per-chain failure,
+	// which lands in Chains.Failed). It is a failure to halt and must not read like success.
+	ChainHaltError string
 	// EstateStopNote states, in the response, what the bound does not cover. An operator reading only
 	// this field must not conclude the estate has stopped.
 	EstateStopNote string
 }
 
-// Halted reports whether every in-flight offensive order was cancelled.
-func (r HaltResult) Halted() bool { return len(r.Failed) == 0 }
+// Halted reports whether every in-flight offensive order AND every running chain was cancelled. A halt
+// that stopped every work order but left a chain running is not a clean halt.
+func (r HaltResult) Halted() bool {
+	return len(r.Failed) == 0 && r.Chains.clean() && r.ChainHaltError == ""
+}
 
 // KillSwitch halts all in-flight offensive work for a tenant.
 type KillSwitch struct {
@@ -54,6 +84,17 @@ type KillSwitch struct {
 	audit       ports.AuditLogger
 	isOffensive func(*workorder.WorkOrder) bool
 	now         func() time.Time
+	chains      ChainHalter
+}
+
+// SetChainHalter wires the in-process chain registry so a halt also stops exploitation chains executing
+// in memory, not only work orders. Optional: left unset, the kill switch covers work orders alone and
+// the result's Chains field stays zero to say so. Wired at the composition root, where the registry the
+// chain machines register into is constructed.
+func (k *KillSwitch) SetChainHalter(ch ChainHalter) {
+	if k != nil {
+		k.chains = ch
+	}
 }
 
 // NewKillSwitch builds the kill switch. isOffensive decides which work orders this switch governs; when
@@ -101,10 +142,28 @@ func (k *KillSwitch) Halt(ctx context.Context, tenantID shared.ID, actor, reason
 			HaltBound),
 	}
 
+	// Halt the in-memory exploitation chains FIRST, and unconditionally. This layer does not depend on
+	// the work-order store, and a chain executing techniques in memory is the most dangerous thing the
+	// kill switch must reach. Gating it behind the work-order enumeration would mean a degraded store —
+	// exactly when an operator pulls the switch — leaves a running chain untouched while the result still
+	// read as if chains were never in play. Done inside the measured window, because stopping a running
+	// chain is part of the halt the operator asked for, not a follow-up.
+	if k.chains != nil {
+		summary, cerr := k.chains.HaltChains(ctx, tenantID, actor, reason)
+		result.Chains = summary
+		if cerr != nil {
+			result.ChainHaltError = cerr.Error()
+		}
+	}
+
 	orders, err := k.orders.ListByTenant(ctx, tenantID)
 	if err != nil {
 		// The halt could not even enumerate what to stop. That is a failure to halt, and it must not
-		// return a result that reads like success.
+		// return a result that reads like success. The chain layer above already ran, so its outcome is
+		// carried in the result and the audit rather than being lost to this early return.
+		result.CompletedAt = k.now().UTC()
+		result.Duration = result.CompletedAt.Sub(result.RequestedAt)
+		result.WithinBound = result.Duration <= HaltBound
 		k.recordAudit(ctx, actor, reason, tenantID, &result, "enumeration_failed")
 		return result, fmt.Errorf("%w: halt could not enumerate work orders: %v", shared.ErrSaturated, err)
 	}
@@ -142,7 +201,12 @@ func (k *KillSwitch) Halt(ctx context.Context, tenantID shared.ID, actor, reason
 	// the result says the audit failed rather than claiming a clean halt.
 	k.recordAudit(ctx, actor, reason, tenantID, &result, "")
 	if !result.Halted() {
-		return result, fmt.Errorf("%w: halt failed for %d work order(s)", shared.ErrSaturated, len(result.Failed))
+		if result.ChainHaltError != "" {
+			return result, fmt.Errorf("%w: halt failed for %d work order(s) and could not drive chain halt: %s",
+				shared.ErrSaturated, len(result.Failed), result.ChainHaltError)
+		}
+		return result, fmt.Errorf("%w: halt failed for %d work order(s) and %d chain(s)",
+			shared.ErrSaturated, len(result.Failed), len(result.Chains.Failed))
 	}
 	return result, nil
 }
@@ -173,9 +237,14 @@ func (k *KillSwitch) recordAudit(ctx context.Context, actor, reason string, tena
 		"reason":          reason,
 		"cancelled":       fmt.Sprint(len(result.Cancelled)),
 		"failed":          fmt.Sprint(len(result.Failed)),
+		"chains_halted":   fmt.Sprint(len(result.Chains.Halted)),
+		"chains_failed":   fmt.Sprint(len(result.Chains.Failed)),
 		"duration_ms":     fmt.Sprint(result.Duration.Milliseconds()),
 		"within_bound":    fmt.Sprint(result.WithinBound),
 		"stated_bound_ms": fmt.Sprint(HaltBound.Milliseconds()),
+	}
+	if result.ChainHaltError != "" {
+		meta["chain_halt_error"] = result.ChainHaltError
 	}
 	if note != "" {
 		meta["note"] = note

--- a/internal/usecase/offensivepolicy/killswitch_test.go
+++ b/internal/usecase/offensivepolicy/killswitch_test.go
@@ -317,3 +317,137 @@ func TestHaltDefaultsToTreatingEveryOrderAsOffensive(t *testing.T) {
 		t.Fatalf("with no classifier every in-flight order must be halted, cancelled %v", result.Cancelled)
 	}
 }
+
+// fakeChainHalter stands in for the exploitation chain registry, so the kill switch can be tested for
+// the second halt layer without importing the exploitation usecase.
+type fakeChainHalter struct {
+	summary   ChainHaltSummary
+	err       error
+	called    bool
+	gotTenant shared.ID
+	gotActor  string
+	gotReason string
+}
+
+func (f *fakeChainHalter) HaltChains(_ context.Context, tenantID shared.ID, actor, reason string) (ChainHaltSummary, error) {
+	f.called = true
+	f.gotTenant, f.gotActor, f.gotReason = tenantID, actor, reason
+	return f.summary, f.err
+}
+
+// TestHaltAlsoStopsRunningChains: with a chain halter wired, one operator halt stops both the in-flight
+// work orders and the chains executing in memory, forwarding the same tenant/operator/reason, and the
+// chain outcome is reported and audited alongside the work-order outcome.
+func TestHaltAlsoStopsRunningChains(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning)
+	audit := &fakeAudit{}
+	ks, err := NewKillSwitch(orders, audit, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch := &fakeChainHalter{summary: ChainHaltSummary{Halted: []shared.ID{"chain-1", "chain-2"}, Failed: map[shared.ID]string{}}}
+	ks.SetChainHalter(ch)
+
+	result, err := ks.Halt(context.Background(), "t1", "operator@example.test", "stop everything")
+	if err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+	if !result.Halted() {
+		t.Error("a halt that stopped every work order and every chain must read as halted")
+	}
+	if got := orders.state("wo-00"); got != workorder.StateCancelled {
+		t.Errorf("work order not cancelled: %s", got)
+	}
+	if len(result.Chains.Halted) != 2 {
+		t.Errorf("the chain layer's result must be reported, got %v", result.Chains.Halted)
+	}
+	// The same operator action, forwarded verbatim to the chain layer.
+	if !ch.called || ch.gotTenant != "t1" || ch.gotActor != "operator@example.test" || ch.gotReason != "stop everything" {
+		t.Errorf("chain halter not called with the operator's identity/reason: %+v", ch)
+	}
+	last := audit.last()
+	if last.Metadata["chains_halted"] != "2" || last.Metadata["chains_failed"] != "0" {
+		t.Errorf("the audit must record the chain halt counts: %+v", last.Metadata)
+	}
+}
+
+// TestHaltReportsChainFailureAsNotHalted: a chain the kill switch could not stop makes the whole halt a
+// partial failure, even when every work order was cancelled. An operator must not read it as clean.
+func TestHaltReportsChainFailureAsNotHalted(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning)
+	ks, _ := NewKillSwitch(orders, &fakeAudit{}, nil, nil)
+	ks.SetChainHalter(&fakeChainHalter{summary: ChainHaltSummary{Failed: map[shared.ID]string{"chain-9": "host unreachable"}}})
+
+	result, err := ks.Halt(context.Background(), "t1", "operator@example.test", "stop")
+	if err == nil {
+		t.Fatal("a halt that left a chain running must return an error")
+	}
+	if result.Halted() {
+		t.Error("Halted() must be false while a chain failed to stop, even though the work order cancelled")
+	}
+	if got := orders.state("wo-00"); got != workorder.StateCancelled {
+		t.Errorf("the work order should still have been cancelled: %s", got)
+	}
+}
+
+// TestHaltStillStopsChainsWhenWorkOrderEnumerationFails: the in-memory chain layer does not depend on
+// the work-order store, so a store outage — exactly when an operator hits the kill switch — must not
+// leave a chain executing techniques in memory. The overall halt still fails, but the chains are stopped
+// and their outcome is reported and audited rather than lost to the early return.
+func TestHaltStillStopsChainsWhenWorkOrderEnumerationFails(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning)
+	orders.listErr = errors.New("database unreachable")
+	audit := &fakeAudit{}
+	ks, _ := NewKillSwitch(orders, audit, nil, nil)
+	ch := &fakeChainHalter{summary: ChainHaltSummary{Halted: []shared.ID{"chain-1"}, Failed: map[shared.ID]string{}}}
+	ks.SetChainHalter(ch)
+
+	result, err := ks.Halt(context.Background(), "t1", "operator@example.test", "stop")
+	if err == nil {
+		t.Fatal("a halt that cannot enumerate work orders must still fail overall")
+	}
+	if !ch.called {
+		t.Fatal("the chain layer was skipped when the work-order store failed — a running chain would be left executing")
+	}
+	if len(result.Chains.Halted) != 1 {
+		t.Errorf("the chain halt outcome must be reported even on enumeration failure, got %v", result.Chains.Halted)
+	}
+	if got := audit.last().Metadata["chains_halted"]; got != "1" {
+		t.Errorf("the audit must record the chain halt count on the enumeration-failure path, got %q", got)
+	}
+}
+
+// TestHaltReportsChainHalterError: if the chain layer cannot be driven at all, that is a failure to halt
+// and must surface, not be swallowed.
+func TestHaltReportsChainHalterError(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning)
+	ks, _ := NewKillSwitch(orders, &fakeAudit{}, nil, nil)
+	ks.SetChainHalter(&fakeChainHalter{err: errors.New("registry unavailable")})
+
+	result, err := ks.Halt(context.Background(), "t1", "operator@example.test", "stop")
+	if err == nil {
+		t.Fatal("a chain layer that could not be driven must make the halt fail")
+	}
+	if result.ChainHaltError == "" || result.Halted() {
+		t.Errorf("the chain-halt error must be reported and the halt not read as clean: %+v", result)
+	}
+}
+
+// TestHaltWithoutChainHalterCoversWorkOrdersOnly: unwired, the kill switch halts work orders and the
+// result's chain fields stay zero — honestly saying the chain layer did not run, not that it found
+// nothing.
+func TestHaltWithoutChainHalterCoversWorkOrdersOnly(t *testing.T) {
+	orders := newFakeOrders(workorder.StateRunning)
+	ks, _ := NewKillSwitch(orders, &fakeAudit{}, nil, nil)
+
+	result, err := ks.Halt(context.Background(), "t1", "operator@example.test", "stop")
+	if err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+	if !result.Halted() {
+		t.Error("a work-order-only halt with no chains must still read as halted")
+	}
+	if len(result.Chains.Halted) != 0 || len(result.Chains.Failed) != 0 || result.ChainHaltError != "" {
+		t.Errorf("with no chain halter wired the chain fields must be zero: %+v", result.Chains)
+	}
+}


### PR DESCRIPTION
## What

Adds the **fleet-wide chain kill-switch registry** — the follow-up flagged on #420 for the offensive governance kill switch (#418).

Before this change, `POST /api/v1/redteam/halt` reached only **in-flight work orders**. An `exploitation.Machine` chain executing techniques **in memory** is not a work order, so it was the one target the kill switch could not stop. This adds a per-tenant, in-process registry as the switch's second layer.

## How

- **`exploitation.Machine` is now concurrency-safe.** A `sync.Mutex` serialises one step of `Run` against a concurrent `Halt`, so a halt interposes only at a **step boundary** — never mid-step. `Run` is refactored into a locked per-step loop (`runStep`); `Halt` and `State()` take the lock. This is the honest bound: a technique already running on a host cannot be interrupted safely partway through.
- **`exploitation.ChainRegistry`** tracks running chains per tenant. `RunTracked` registers a chain for exactly its lifetime and unregisters it on completion (even on panic/error). `HaltChains` snapshots under its own lock, halts each `Machine` outside that lock (no lock-order inversion with the machine lock), re-scans to catch a chain that registers **mid-halt**, and cannot livelock.
- **No import cycle.** `ChainHalter` + `ChainHaltSummary` are **consumer-defined in `offensivepolicy`** and implemented in `exploitation` (which already depends on `offensivepolicy` via admission). `var _ offensivepolicyuc.ChainHalter = (*ChainRegistry)(nil)` sits on the implementation side.
- **`KillSwitch.Halt` runs the chain layer first and unconditionally.** A work-order store outage — exactly when an operator pulls the switch — must not leave a chain executing. `Halted()`, the audit metadata (`chains_halted`/`chains_failed`), and the HTTP response all report the chain outcome; a chain left running **never reads as a clean halt**.
- Wired at the composition root (`cmd/synapse-api/main.go`).

## Counsel review

Left **pending on purpose** — production stays locked (`ProductionSafe && !CounselReviewed` refuses). Counsel sign-off is a human legal action, not code, and there is no counsel yet. This PR does not touch `policy.yaml`.

## Scope honesty

The registry is **process-scoped** — for the current single-process deployment that is the whole control plane. A true multi-node fleet halt (fan-out across nodes) is a **P5** concern the type is candid about and does not pretend to solve. No in-process chain *driver* exists yet, so the wired layer registers nothing in production today; it is the control-plane seam a future driver plugs into via `RunTracked`.

## Safety

Control-plane only — no exec, no shell, no LLM in the path. Tenant-isolated (`shared.TenantOrDefault` on every registry op; `HaltChains` iterates only the requested tenant). Halt is attributable to the operator + reason and audited per chain and overall.

## Verification (CI stays disabled per repo config — verified locally)

- `go build ./...` (cgo default **and** `CGO_ENABLED=0`)
- `go vet ./...`
- `gofmt` clean on all changed files
- **`go test -race ./...`** — full suite green, incl. a concurrent run-and-halt test over 8 chains
- Hostile harness (`TestHostileHarness`) green
- Reviewed by `go-arch-reviewer` (dependency rule PASS, deadlock-free) and `security-auditor` (found + **fixed** the enumeration-failure-skips-chains gap now covered by a regression test)
