### PR TITLE
feat(blueteam): detection engine domain — rules, events, coverage honesty (#422 phase 1)

### DIFF
--- a/internal/domain/detection/catalog.go
+++ b/internal/domain/detection/catalog.go
@@ -1,0 +1,119 @@
+package detection
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// catalogue is the built-in, clean-room detection rule set. Each rule is a typed matcher over one event
+// class — never a shell expression. Five of the ids are the detection ids the emulation catalogue (#421)
+// names as expected observables, so an executed emulation technique can be reconciled against a real
+// detection by id (the purple ledger, #426); the sixth is a privilege-class rule that gives that class a
+// shipped detection and is not tied to an emulation technique.
+//
+// Rule matchers are intentionally coarse for milestone one: they fire on the observable an emulation
+// technique produces. Rate- and sequence-based refinement (e.g. a true DNS beacon cadence) waits for the
+// on-host event window the engine assembles; a single-event matcher cannot count.
+var catalogue = []Rule{
+	{
+		ID: "det.process_enumeration", Version: 1, Class: ClassProcess,
+		Title: "Process enumeration (T1057)", Severity: shared.SeverityLow,
+		Matcher: Matcher{Class: ClassProcess, All: []Predicate{
+			{Field: FieldProcComm, Op: OpIn, Values: []string{"ps", "pgrep", "top", "htop", "tasklist"}},
+		}},
+	},
+	{
+		ID: "det.network_config_discovery", Version: 1, Class: ClassProcess,
+		Title: "Network configuration discovery (T1016)", Severity: shared.SeverityLow,
+		Matcher: Matcher{Class: ClassProcess, All: []Predicate{
+			{Field: FieldProcComm, Op: OpIn, Values: []string{"ip", "ifconfig", "ipconfig", "route", "netstat", "ss", "arp"}},
+		}},
+	},
+	{
+		ID: "det.suspicious_dns_beacon", Version: 1, Class: ClassNetwork,
+		Title: "DNS egress (T1071.004)", Severity: shared.SeverityMedium,
+		Matcher: Matcher{Class: ClassNetwork, All: []Predicate{
+			{Field: FieldNetProto, Op: OpEquals, Value: "udp"},
+			{Field: FieldNetRemotePort, Op: OpEquals, Value: "53"},
+			{Field: FieldNetDirection, Op: OpEquals, Value: "egress"},
+		}},
+	},
+	{
+		ID: "det.credential_file_access", Version: 1, Class: ClassFile,
+		Title: "Credential file access (T1552.001)", Severity: shared.SeverityHigh,
+		Matcher: Matcher{Class: ClassFile, All: []Predicate{
+			{Field: FieldFilePath, Op: OpIn, Values: []string{"/etc/shadow", "/etc/gshadow", "/root/.ssh/id_rsa", "/root/.aws/credentials"}},
+			{Field: FieldFileOp, Op: OpIn, Values: []string{"read", "open"}},
+		}},
+	},
+	{
+		ID: "det.unexpected_service_restart", Version: 1, Class: ClassProcess,
+		Title: "Service restart (T1569.002)", Severity: shared.SeverityMedium,
+		Matcher: Matcher{Class: ClassProcess, All: []Predicate{
+			{Field: FieldProcComm, Op: OpEquals, Value: "systemctl"},
+			{Field: FieldProcArg, Op: OpEquals, Value: "restart"},
+		}},
+	},
+	{
+		ID: "det.privilege_escalation_to_root", Version: 1, Class: ClassPrivilege,
+		Title: "Privilege escalation to root (T1548)", Severity: shared.SeverityHigh,
+		Matcher: Matcher{Class: ClassPrivilege, All: []Predicate{
+			{Field: FieldPrivToUID, Op: OpEquals, Value: "0"},
+			{Field: FieldPrivKind, Op: OpIn, Values: []string{"setuid", "capset"}},
+		}},
+	},
+}
+
+// Catalogue returns a validated copy of the built-in rule set, deterministically ordered by id so a
+// coverage report and its trend compare like with like. It validates on every call rather than trusting
+// the literal above, so a malformed rule fails the build via the catalogue drift test rather than
+// shipping a rule that cannot produce a trustworthy detection.
+func Catalogue() ([]Rule, error) {
+	seen := make(map[string]struct{}, len(catalogue))
+	out := make([]Rule, 0, len(catalogue))
+	for _, r := range catalogue {
+		if err := r.Validate(); err != nil {
+			return nil, err
+		}
+		if _, dup := seen[r.ID]; dup {
+			return nil, fmt.Errorf("%w: duplicate rule id %q", shared.ErrValidation, r.ID)
+		}
+		seen[r.ID] = struct{}{}
+		out = append(out, r.clone())
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// Lookup returns a catalogued rule by id. The second result is false for an unknown id, which the caller
+// MUST treat as "not a known detection" rather than fabricating one.
+func Lookup(id string) (Rule, bool) {
+	for _, r := range catalogue {
+		if r.ID == id {
+			if r.Validate() != nil {
+				return Rule{}, false
+			}
+			return r.clone(), true
+		}
+	}
+	return Rule{}, false
+}
+
+// CatalogueByClass returns the catalogued rules for one event class, deterministically ordered. The
+// agent-side engine (issue #422, later phase) evaluates only the rules for the classes it can actually
+// observe on a given host, so a disabled or degraded class runs no rules and reports a coverage gap.
+func CatalogueByClass(c Class) ([]Rule, error) {
+	all, err := Catalogue()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Rule, 0, len(all))
+	for _, r := range all {
+		if r.Class == c {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}

--- a/internal/domain/detection/catalog_test.go
+++ b/internal/domain/detection/catalog_test.go
@@ -1,0 +1,146 @@
+package detection
+
+import (
+	"testing"
+	"time"
+
+	demu "github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+)
+
+// TestCatalogueValidatesAndIsDeterministic is the drift test mirroring the SAST/emulation catalogues:
+// the shipped rule set must validate, have no duplicate ids, and be stably ordered, or the build fails
+// here rather than shipping a rule that cannot produce a trustworthy detection.
+func TestCatalogueValidatesAndIsDeterministic(t *testing.T) {
+	a, err := Catalogue()
+	if err != nil {
+		t.Fatalf("the shipped catalogue does not validate: %v", err)
+	}
+	if len(a) == 0 {
+		t.Fatal("empty catalogue; the drift test would pass vacuously")
+	}
+	b, _ := Catalogue()
+	for i := range a {
+		if a[i].ID != b[i].ID {
+			t.Fatalf("catalogue order is not stable at %d: %s vs %s", i, a[i].ID, b[i].ID)
+		}
+		if i > 0 && a[i-1].ID > a[i].ID {
+			t.Fatalf("catalogue is not sorted by id: %s before %s", a[i-1].ID, a[i].ID)
+		}
+	}
+}
+
+// TestEveryClassHasARule ensures each event class ships at least one detection, so the per-class engine
+// (and its per-class load/disable tests in the eBPF phase) has something to evaluate.
+func TestEveryClassHasARule(t *testing.T) {
+	for _, cls := range Classes() {
+		rules, err := CatalogueByClass(cls)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rules) == 0 {
+			t.Errorf("class %s has no catalogued rule", cls)
+		}
+	}
+}
+
+// TestCatalogueReturnsAreImmutable proves a caller cannot reach through a returned rule and mutate the
+// package-level catalogue — a runtime-mutable detection rule set would be a security defect, not just a
+// style one. It mutates the matcher predicates of a returned rule and confirms a fresh read is unchanged.
+func TestCatalogueReturnsAreImmutable(t *testing.T) {
+	first, err := Catalogue()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range first {
+		for j := range first[i].Matcher.All {
+			first[i].Matcher.All[j].Value = "TAMPERED"
+			for k := range first[i].Matcher.All[j].Values {
+				first[i].Matcher.All[j].Values[k] = "TAMPERED"
+			}
+		}
+	}
+	// Lookup and a fresh Catalogue must be untouched.
+	r, ok := Lookup("det.credential_file_access")
+	if !ok {
+		t.Fatal("expected det.credential_file_access")
+	}
+	for _, p := range r.Matcher.All {
+		if p.Value == "TAMPERED" {
+			t.Fatal("mutating a returned rule's predicate Value leaked into the catalogue")
+		}
+		for _, v := range p.Values {
+			if v == "TAMPERED" {
+				t.Fatal("mutating a returned rule's predicate Values leaked into the catalogue")
+			}
+		}
+	}
+	// And the mutated returned rule must no longer match a fixture it originally matched, proving the
+	// tamper stayed local to the caller's copy.
+	fresh, _ := Catalogue()
+	if len(fresh) != len(first) {
+		t.Fatal("catalogue length changed across reads")
+	}
+}
+
+// TestRuleMatchesFixturePerClass is #422's acceptance criterion at the domain level: for each event
+// class, a fixture event matches a catalogued rule and yields a detection carrying that evidence. The
+// on-kernel load test for each class is a separate infra-phase acceptance.
+func TestRuleMatchesFixturePerClass(t *testing.T) {
+	now := time.Unix(1000, 0)
+	fixtures := []struct {
+		ruleID string
+		event  Event
+	}{
+		{"det.process_enumeration", Event{Class: ClassProcess, At: now, Host: "h",
+			Process: &ProcessEvent{PID: 2, Comm: "ps", Path: "/usr/bin/ps", Args: []string{"-ef"}}}},
+		{"det.suspicious_dns_beacon", Event{Class: ClassNetwork, At: now, Host: "h",
+			Network: &NetworkEvent{Proto: "udp", RemoteAddr: "8.8.8.8", RemotePort: 53, Direction: "egress", PID: 3, Comm: "curl"}}},
+		{"det.credential_file_access", Event{Class: ClassFile, At: now, Host: "h",
+			File: &FileEvent{Path: "/etc/shadow", Op: "read", PID: 4, Comm: "cat"}}},
+		{"det.privilege_escalation_to_root", Event{Class: ClassPrivilege, At: now, Host: "h",
+			Privilege: &PrivilegeEvent{PID: 5, Comm: "sudo", FromUID: 1000, ToUID: 0, Kind: "setuid"}}},
+	}
+	for _, f := range fixtures {
+		t.Run(f.ruleID, func(t *testing.T) {
+			r, ok := Lookup(f.ruleID)
+			if !ok {
+				t.Fatalf("rule %s not catalogued", f.ruleID)
+			}
+			if r.Class != f.event.Class {
+				t.Fatalf("fixture class %s does not match rule class %s", f.event.Class, r.Class)
+			}
+			if !r.Match(f.event) {
+				t.Fatalf("rule %s did not match its fixture event", f.ruleID)
+			}
+			d, err := NewDetection(r, "host-1", "agent:vm-1", []Event{f.event}, now)
+			if err != nil {
+				t.Fatalf("emitting a detection failed: %v", err)
+			}
+			if d.RuleID != f.ruleID || len(d.Evidence) != 1 {
+				t.Fatalf("detection did not carry the matched evidence: %+v", d)
+			}
+		})
+	}
+}
+
+// TestEmulationExpectedDetectionsAreCatalogued is the purple linkage (#426 depends on it): every
+// detection an emulation technique (#421) expects must exist as a catalogued rule of a real event class.
+// Without this, an executed technique could never be reconciled against a detection and would be a
+// permanent, unexplained coverage gap.
+func TestEmulationExpectedDetectionsAreCatalogued(t *testing.T) {
+	techniques, err := demu.Catalogue()
+	if err != nil {
+		t.Fatalf("emulation catalogue: %v", err)
+	}
+	for _, tech := range techniques {
+		id := tech.Expected.DetectionID
+		r, ok := Lookup(id)
+		if !ok {
+			t.Errorf("emulation technique %s expects detection %q, which has no catalogued rule", tech.ID, id)
+			continue
+		}
+		if !r.Class.Valid() {
+			t.Errorf("detection %s for emulation %s has an invalid class %q", id, tech.ID, r.Class)
+		}
+	}
+}

--- a/internal/domain/detection/class.go
+++ b/internal/domain/detection/class.go
@@ -1,0 +1,44 @@
+// Package detection is the pure domain for the agent-side blue-team detection engine (issue #422): the
+// typed event classes an eBPF sensor observes, the clean-room rules that match over them, the detection
+// a match emits, and the coverage honesty that says a class the agent could not observe is a GAP, never
+// a clean host.
+//
+// It has no I/O, no clock, and no eBPF: the kernel programs, their loaders and the agent-side engine
+// live in internal/infrastructure/ebpf and internal/usecase/fleet/detect, which depend on this domain.
+// A rule Matcher is TYPED DATA evaluated by Go — never a shell expression or an eval'd string (golden
+// rule 1): the engine observes and matches, it never executes anything.
+//
+// Milestone one ships DETECTIONS, not raw events. This package models the detection and the bounded
+// evidence window that travels with it; the raw event stream stays on the host (issue #424).
+package detection
+
+// Class is a category of host activity the engine observes. Each class is backed by its own eBPF program
+// with its own bounded map and can be loaded, disabled and fail INDEPENDENTLY — a missing kernel feature
+// takes out one class with a coverage report, never the whole engine (#422 requirement 6).
+//
+// The set mirrors the telemetry classes the emulation catalogue (#421) expects a detection for, so the
+// purple ledger (#426) can reconcile "what we executed" against "what we detected" by detection id.
+type Class string
+
+const (
+	ClassProcess   Class = "process"   // process execution (exec/fork)
+	ClassNetwork   Class = "network"   // outbound/inbound connect
+	ClassFile      Class = "file"      // file access to sensitive paths
+	ClassPrivilege Class = "privilege" // privilege / capability change
+)
+
+// Valid reports whether c is a known event class.
+func (c Class) Valid() bool {
+	switch c {
+	case ClassProcess, ClassNetwork, ClassFile, ClassPrivilege:
+		return true
+	default:
+		return false
+	}
+}
+
+// Classes returns every event class in a stable order, so a per-class coverage report and its trend are
+// comparable across runs and across hosts.
+func Classes() []Class {
+	return []Class{ClassProcess, ClassNetwork, ClassFile, ClassPrivilege}
+}

--- a/internal/domain/detection/coverage.go
+++ b/internal/domain/detection/coverage.go
@@ -1,0 +1,133 @@
+package detection
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ClassState is whether a host is actually observing a given event class right now.
+//
+// The whole point of this type is honesty about the negative case. A host that reports NO detections for
+// a class is ambiguous: either nothing happened, or the sensor was not watching. StateActive is the only
+// state under which "no detections" means "nothing detected". Every other state is an OBSERVATION GAP —
+// the host is not clean for that class, it is unobserved, and a coverage number must say so (#422
+// requirements 4, 5 and 6).
+type ClassState string
+
+const (
+	StateActive   ClassState = "active"   // program loaded, map bound, events flowing
+	StateDegraded ClassState = "degraded" // a required kernel feature is missing; this class is disabled
+	StateFailed   ClassState = "failed"   // the program failed to load or attach on a supported kernel
+	StateDisabled ClassState = "disabled" // switched off by configuration (SYNAPSE_DETECT_CLASSES)
+)
+
+func (s ClassState) valid() bool {
+	switch s {
+	case StateActive, StateDegraded, StateFailed, StateDisabled:
+		return true
+	default:
+		return false
+	}
+}
+
+// ClassCoverage is the observation status of one event class on one host, over a window. It is the input
+// to the coverage report the purple ledger (#426) and the detections-as-evidence issue (#423) consume.
+type ClassCoverage struct {
+	Class   Class
+	HostID  shared.ID
+	AgentID shared.ID
+	State   ClassState
+	Reason  string // required when the state is not active/disabled: WHY the class is not observing
+	Since   time.Time
+}
+
+// Observing reports whether this class is actually watching. Only StateActive observes; a caller must
+// never treat any other state as "no activity".
+func (c ClassCoverage) Observing() bool { return c.State == StateActive }
+
+// IsObservationGap reports whether this class is an observation gap — a window during which the host was
+// NOT observing this class. StateDisabled is a gap too: a class switched off by config still means the
+// host is not covered for it, and hiding that would let a config change quietly erase coverage.
+func (c ClassCoverage) IsObservationGap() bool { return c.State != StateActive }
+
+// Validate ensures a coverage record is meaningful. A non-active, non-disabled state MUST carry a reason,
+// so a gap can always be explained to an operator rather than appearing as an unexplained hole.
+func (c ClassCoverage) Validate() error {
+	if !c.Class.Valid() {
+		return fmt.Errorf("%w: coverage has an unknown class %q", shared.ErrValidation, c.Class)
+	}
+	if c.HostID == "" {
+		return fmt.Errorf("%w: coverage must name a host", shared.ErrValidation)
+	}
+	if !c.State.valid() {
+		return fmt.Errorf("%w: coverage has an unknown state %q", shared.ErrValidation, c.State)
+	}
+	if (c.State == StateDegraded || c.State == StateFailed) && c.Reason == "" {
+		return fmt.Errorf("%w: coverage class %s is %s but gives no reason", shared.ErrValidation, c.Class, c.State)
+	}
+	return nil
+}
+
+// HostCoverage is the per-host roll-up across every event class. Building it from ClassCoverage records
+// makes the honest default structural: a class with no record at all is reported as an unknown gap, not
+// silently omitted — you cannot accidentally drop a class and make a host look more covered than it is.
+type HostCoverage struct {
+	HostID  shared.ID
+	Classes []ClassCoverage // exactly one per Class(), in Classes() order
+}
+
+// NewHostCoverage assembles a host roll-up from whatever class records were reported. Any class in
+// Classes() with no reported record is filled in as StateFailed with an explicit "no report" reason —
+// the absence of a report is itself an observation gap, never treated as clean.
+func NewHostCoverage(host shared.ID, reported []ClassCoverage) (HostCoverage, error) {
+	if host == "" {
+		return HostCoverage{}, fmt.Errorf("%w: host coverage must name a host", shared.ErrValidation)
+	}
+	byClass := make(map[Class]ClassCoverage, len(reported))
+	for _, c := range reported {
+		if err := c.Validate(); err != nil {
+			return HostCoverage{}, err
+		}
+		if c.HostID != host {
+			return HostCoverage{}, fmt.Errorf("%w: coverage for host %q supplied to roll-up for host %q",
+				shared.ErrValidation, c.HostID, host)
+		}
+		if _, dup := byClass[c.Class]; dup {
+			// Two conflicting records for one class would let the last one silently win and could erase a
+			// gap (e.g. failed then active). Refuse it — a coverage roll-up must be order-independent.
+			return HostCoverage{}, fmt.Errorf("%w: duplicate coverage record for class %s", shared.ErrValidation, c.Class)
+		}
+		byClass[c.Class] = c
+	}
+	out := HostCoverage{HostID: host}
+	for _, cls := range Classes() {
+		if c, ok := byClass[cls]; ok {
+			out.Classes = append(out.Classes, c)
+			continue
+		}
+		out.Classes = append(out.Classes, ClassCoverage{
+			Class: cls, HostID: host, State: StateFailed,
+			Reason: "no coverage reported for this class; treated as an observation gap, not as clean",
+		})
+	}
+	sort.Slice(out.Classes, func(i, j int) bool { return out.Classes[i].Class < out.Classes[j].Class })
+	return out, nil
+}
+
+// Gaps returns the classes this host is NOT observing. An empty result means every class is actively
+// observed; anything else is the honest list of where "no detections" cannot be trusted.
+func (h HostCoverage) Gaps() []ClassCoverage {
+	var gaps []ClassCoverage
+	for _, c := range h.Classes {
+		if c.IsObservationGap() {
+			gaps = append(gaps, c)
+		}
+	}
+	return gaps
+}
+
+// FullyObserved reports whether every event class is actively observed on this host.
+func (h HostCoverage) FullyObserved() bool { return len(h.Gaps()) == 0 }

--- a/internal/domain/detection/coverage_test.go
+++ b/internal/domain/detection/coverage_test.go
@@ -1,0 +1,84 @@
+package detection
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TestOnlyActiveClassIsObserving is the core honesty property: no state other than active counts as
+// observing, so "no detections" only means "nothing detected" under StateActive.
+func TestOnlyActiveClassIsObserving(t *testing.T) {
+	for _, st := range []ClassState{StateDegraded, StateFailed, StateDisabled} {
+		c := ClassCoverage{Class: ClassProcess, HostID: "h", State: st, Reason: "x"}
+		if c.Observing() {
+			t.Errorf("state %s must not report as observing", st)
+		}
+		if !c.IsObservationGap() {
+			t.Errorf("state %s must report as an observation gap", st)
+		}
+	}
+	active := ClassCoverage{Class: ClassProcess, HostID: "h", State: StateActive}
+	if !active.Observing() || active.IsObservationGap() {
+		t.Error("an active class must observe and not be a gap")
+	}
+}
+
+func TestClassCoverageRequiresReasonForFailure(t *testing.T) {
+	for _, st := range []ClassState{StateDegraded, StateFailed} {
+		c := ClassCoverage{Class: ClassProcess, HostID: "h", State: st}
+		if err := c.Validate(); !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("state %s with no reason must fail validation, got %v", st, err)
+		}
+	}
+}
+
+// TestNewHostCoverageFillsMissingClassesAsGaps is the "unknown is never clean" invariant made
+// structural: a class with no reported record becomes a failed gap, never silently omitted, so a host
+// can never look more covered than its reports justify.
+func TestNewHostCoverageFillsMissingClassesAsGaps(t *testing.T) {
+	// Report only the process class as active; the other three are unreported.
+	reported := []ClassCoverage{{Class: ClassProcess, HostID: "h", State: StateActive, Since: time.Unix(1, 0)}}
+	hc, err := NewHostCoverage("h", reported)
+	if err != nil {
+		t.Fatalf("host coverage: %v", err)
+	}
+	if len(hc.Classes) != len(Classes()) {
+		t.Fatalf("roll-up must contain every class, got %d", len(hc.Classes))
+	}
+	if hc.FullyObserved() {
+		t.Fatal("a host with three unreported classes must not read as fully observed")
+	}
+	gaps := hc.Gaps()
+	if len(gaps) != len(Classes())-1 {
+		t.Fatalf("want %d gaps for the unreported classes, got %d", len(Classes())-1, len(gaps))
+	}
+	for _, g := range gaps {
+		if g.State != StateFailed || g.Reason == "" {
+			t.Errorf("an unreported class must be a failed gap with a reason: %+v", g)
+		}
+	}
+}
+
+func TestHostCoverageFullyObserved(t *testing.T) {
+	var reported []ClassCoverage
+	for _, cls := range Classes() {
+		reported = append(reported, ClassCoverage{Class: cls, HostID: "h", State: StateActive})
+	}
+	hc, err := NewHostCoverage("h", reported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hc.FullyObserved() || len(hc.Gaps()) != 0 {
+		t.Fatalf("every class active should be fully observed: %+v", hc.Gaps())
+	}
+}
+
+func TestNewHostCoverageRejectsForeignHost(t *testing.T) {
+	reported := []ClassCoverage{{Class: ClassProcess, HostID: "other", State: StateActive}}
+	if _, err := NewHostCoverage("h", reported); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("coverage for a different host must be rejected, got %v", err)
+	}
+}

--- a/internal/domain/detection/detection.go
+++ b/internal/domain/detection/detection.go
@@ -1,0 +1,122 @@
+package detection
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// MaxEvidence bounds the context window that travels with a detection. Milestone one ships the detection
+// plus a bounded window of surrounding events, never the raw stream — this cap is what keeps a detection
+// small enough for Postgres to remain the system of record (the columnar tier for full telemetry is
+// #424). Evidence beyond the cap is dropped from the shipped detection, not from the on-host ring buffer.
+const MaxEvidence = 64
+
+// Detection is what a matched rule emits. It carries full attribution — the host, the agent identity,
+// the rule id and version, the matched evidence and the time — because the next issue (#423) turns these
+// into hash-chained, attributable evidence, and evidence with a hole in its provenance is not evidence.
+type Detection struct {
+	RuleID      string
+	RuleVersion int
+	Class       Class
+	Severity    shared.Severity
+	HostID      shared.ID
+	AgentID     shared.ID
+	Evidence    []Event // bounded (MaxEvidence); the triggering event plus surrounding context
+	// Truncated records that the evidence window was capped: the shipped Evidence is not the complete
+	// sequence. It is a field, not just a constructor return, so the incompleteness travels with the
+	// stored/hash-chained record (#423) and a reconstructed detection cannot present a bounded window as
+	// the whole story. Observed count is the number of events seen before truncation (>= len(Evidence)).
+	Truncated     bool
+	ObservedCount int
+	Observed      time.Time
+}
+
+// NewDetection builds a detection from a rule and the observed evidence, deep-copying and bounding the
+// evidence defensively so a caller mutating its slice OR the payloads it points at afterwards cannot
+// alter the sealed record. The rule must validate and there must be at least one evidence event — a
+// detection with no evidence is a claim, not a detection.
+//
+// If more than MaxEvidence events are supplied, the MOST RECENT MaxEvidence are kept (the tail), because
+// the triggering event and its immediate lead-up are the useful context; the drop is recorded in the
+// detection's Truncated/ObservedCount fields so a caller never presents a bounded window as complete.
+func NewDetection(r Rule, host, agent shared.ID, evidence []Event, at time.Time) (Detection, error) {
+	if err := r.Validate(); err != nil {
+		return Detection{}, fmt.Errorf("detection needs a valid rule: %w", err)
+	}
+	if host == "" || agent == "" {
+		return Detection{}, fmt.Errorf("%w: a detection must attribute a host and an agent", shared.ErrValidation)
+	}
+	if at.IsZero() {
+		return Detection{}, fmt.Errorf("%w: a detection must carry an observation time", shared.ErrValidation)
+	}
+	if len(evidence) == 0 {
+		return Detection{}, fmt.Errorf("%w: a detection must carry at least one evidence event", shared.ErrValidation)
+	}
+	for i, e := range evidence {
+		if err := e.Validate(); err != nil {
+			return Detection{}, fmt.Errorf("%w: detection evidence[%d] is malformed", shared.ErrValidation, i)
+		}
+	}
+
+	observedCount := len(evidence)
+	truncated := false
+	kept := evidence
+	if len(kept) > MaxEvidence {
+		kept = kept[len(kept)-MaxEvidence:]
+		truncated = true
+	}
+	cp := make([]Event, len(kept))
+	for i := range kept {
+		cp[i] = kept[i].clone()
+	}
+
+	return Detection{
+		RuleID:        r.ID,
+		RuleVersion:   r.Version,
+		Class:         r.Class,
+		Severity:      r.Severity,
+		HostID:        host,
+		AgentID:       agent,
+		Evidence:      cp,
+		Truncated:     truncated,
+		ObservedCount: observedCount,
+		Observed:      at.UTC(),
+	}, nil
+}
+
+// Validate re-checks a detection's attribution, so a detection reconstructed from storage (rather than
+// built through NewDetection) cannot present without a full provenance.
+func (d Detection) Validate() error {
+	if d.RuleID == "" || d.RuleVersion < 1 {
+		return fmt.Errorf("%w: detection is missing its rule identity", shared.ErrValidation)
+	}
+	if !d.Class.Valid() {
+		return fmt.Errorf("%w: detection %s has an unknown class", shared.ErrValidation, d.RuleID)
+	}
+	if !d.Severity.Valid() || d.Severity == shared.SeverityUnknown {
+		return fmt.Errorf("%w: detection %s has an invalid severity", shared.ErrValidation, d.RuleID)
+	}
+	if d.HostID == "" || d.AgentID == "" {
+		return fmt.Errorf("%w: detection %s is missing host/agent attribution", shared.ErrValidation, d.RuleID)
+	}
+	if len(d.Evidence) == 0 {
+		return fmt.Errorf("%w: detection %s carries no evidence", shared.ErrValidation, d.RuleID)
+	}
+	// A detection reconstructed from storage must hold the same evidence invariants the constructor
+	// enforces, so a tampered or corrupt record cannot pass with malformed or oversized evidence.
+	if len(d.Evidence) > MaxEvidence {
+		return fmt.Errorf("%w: detection %s carries %d evidence events, over the cap of %d",
+			shared.ErrValidation, d.RuleID, len(d.Evidence), MaxEvidence)
+	}
+	for i, e := range d.Evidence {
+		if err := e.Validate(); err != nil {
+			return fmt.Errorf("%w: detection %s evidence[%d] is malformed", shared.ErrValidation, d.RuleID, i)
+		}
+	}
+	if d.Observed.IsZero() {
+		return fmt.Errorf("%w: detection %s has no observation time", shared.ErrValidation, d.RuleID)
+	}
+	return nil
+}

--- a/internal/domain/detection/detection_test.go
+++ b/internal/domain/detection/detection_test.go
@@ -1,0 +1,131 @@
+package detection
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func sampleRule(t *testing.T) Rule {
+	t.Helper()
+	r, ok := Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("expected det.process_enumeration in the catalogue")
+	}
+	return r
+}
+
+func TestNewDetectionCarriesFullAttribution(t *testing.T) {
+	r := sampleRule(t)
+	ev := procEvent("ps", "-ef")
+	now := time.Unix(1000, 0)
+
+	d, err := NewDetection(r, "host-1", "agent:vm-9", []Event{ev}, now)
+	if err != nil {
+		t.Fatalf("new detection: %v", err)
+	}
+	if d.Truncated {
+		t.Error("one evidence event should not be truncated")
+	}
+	if d.RuleID != r.ID || d.RuleVersion != r.Version || d.Class != r.Class || d.Severity != r.Severity {
+		t.Errorf("detection did not inherit rule identity: %+v", d)
+	}
+	if d.HostID != "host-1" || d.AgentID != "agent:vm-9" {
+		t.Errorf("detection is missing host/agent attribution: %+v", d)
+	}
+	if len(d.Evidence) != 1 || d.Observed.IsZero() {
+		t.Errorf("detection must carry evidence and an observation time: %+v", d)
+	}
+	if err := d.Validate(); err != nil {
+		t.Errorf("a well-formed detection must validate: %v", err)
+	}
+}
+
+// TestNewDetectionDefensivelyCopiesEvidence: a caller mutating its evidence slice OR the payload the
+// event points at — including the argv slice — after the fact must not alter the sealed detection.
+func TestNewDetectionDefensivelyCopiesEvidence(t *testing.T) {
+	r := sampleRule(t)
+	orig := procEvent("ps", "-ef")
+	ev := []Event{orig}
+	d, err := NewDetection(r, "h", "a", ev, time.Unix(1, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mutate the slice element, the pointed-at payload, and the argv backing array.
+	ev[0] = procEvent("mutated")
+	orig.Process.Comm = "mutated"
+	orig.Process.Args[0] = "mutated"
+	if d.Evidence[0].Process.Comm != "ps" {
+		t.Fatal("mutating the caller's payload pointer changed the sealed evidence")
+	}
+	if d.Evidence[0].Process.Args[0] != "-ef" {
+		t.Fatal("mutating the caller's argv slice changed the sealed evidence")
+	}
+}
+
+func TestNewDetectionBoundsEvidenceAndReportsTruncation(t *testing.T) {
+	r := sampleRule(t)
+	many := make([]Event, MaxEvidence+10)
+	for i := range many {
+		many[i] = procEvent("ps")
+	}
+	// Tag the last event so we can confirm the TAIL (most recent) is kept.
+	many[len(many)-1] = procEvent("trigger")
+
+	d, err := NewDetection(r, "h", "a", many, time.Unix(1, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.Truncated {
+		t.Fatal("over-long evidence must report truncation, not silently drop")
+	}
+	if d.ObservedCount != len(many) {
+		t.Errorf("ObservedCount must record the pre-truncation total: got %d, want %d", d.ObservedCount, len(many))
+	}
+	if len(d.Evidence) != MaxEvidence {
+		t.Fatalf("evidence not bounded: %d, want %d", len(d.Evidence), MaxEvidence)
+	}
+	if d.Evidence[len(d.Evidence)-1].Process.Comm != "trigger" {
+		t.Error("truncation kept the wrong window; the most recent events (the trigger) must survive")
+	}
+	// The truncation flag must survive a re-validation of a reconstructed record.
+	if err := d.Validate(); err != nil {
+		t.Errorf("a bounded, well-formed detection must validate: %v", err)
+	}
+}
+
+func TestNewDetectionRefusesIncomplete(t *testing.T) {
+	r := sampleRule(t)
+	good := procEvent("ps")
+	cases := map[string]func() (Detection, error){
+		"no host":     func() (Detection, error) { return NewDetection(r, "", "a", []Event{good}, time.Unix(1, 0)) },
+		"no agent":    func() (Detection, error) { return NewDetection(r, "h", "", []Event{good}, time.Unix(1, 0)) },
+		"no time":     func() (Detection, error) { return NewDetection(r, "h", "a", []Event{good}, time.Time{}) },
+		"no evidence": func() (Detection, error) { return NewDetection(r, "h", "a", nil, time.Unix(1, 0)) },
+		"bad evidence": func() (Detection, error) {
+			return NewDetection(r, "h", "a", []Event{{Class: ClassProcess, At: time.Unix(1, 0)}}, time.Unix(1, 0))
+		},
+	}
+	for name, call := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := call(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEventValidateRejectsAmbiguousPayload(t *testing.T) {
+	// A process class carrying a network payload, or two payloads, is malformed — it must never match.
+	mixed := Event{Class: ClassProcess, At: time.Unix(1, 0), Host: "h",
+		Process: &ProcessEvent{Comm: "ps"}, Network: &NetworkEvent{Proto: "udp"}}
+	if err := mixed.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("an event with two payloads must be rejected, got %v", err)
+	}
+	none := Event{Class: ClassProcess, At: time.Unix(1, 0), Host: "h"}
+	if err := none.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("an event with no payload must be rejected, got %v", err)
+	}
+}

--- a/internal/domain/detection/event.go
+++ b/internal/domain/detection/event.go
@@ -1,0 +1,216 @@
+package detection
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Event is one observed host activity, typed by Class. Exactly one of the per-class payloads is set —
+// the one matching Class. The payloads are deliberately small and bounded: milestone one ships a
+// detection plus a bounded window of these, never the raw stream.
+//
+// Fields are TYPED, not a free-form map, so a rule matches over a closed, known set (see Field). That is
+// what keeps a rule from being an arbitrary expression over untrusted keys.
+type Event struct {
+	Class Class
+	At    time.Time
+	Host  shared.ID
+
+	Process   *ProcessEvent
+	Network   *NetworkEvent
+	File      *FileEvent
+	Privilege *PrivilegeEvent
+}
+
+// ProcessEvent is an exec/fork observation.
+type ProcessEvent struct {
+	PID  int
+	PPID int
+	Comm string   // short command name (kernel comm)
+	Path string   // resolved executable path
+	Args []string // bounded argv
+	UID  int
+}
+
+// NetworkEvent is a connect observation.
+type NetworkEvent struct {
+	Proto      string // tcp | udp
+	RemoteAddr string
+	RemotePort int
+	Direction  string // egress | ingress
+	PID        int
+	Comm       string
+}
+
+// FileEvent is a sensitive-path access observation.
+type FileEvent struct {
+	Path string
+	Op   string // read | write | open | unlink
+	PID  int
+	Comm string
+}
+
+// PrivilegeEvent is a privilege/capability change observation.
+type PrivilegeEvent struct {
+	PID     int
+	Comm    string
+	FromUID int
+	ToUID   int
+	Cap     string // capability gained, if any
+	Kind    string // setuid | setgid | capset
+}
+
+// payloadClass reports which class actually carries a payload, and whether exactly one does. An event
+// whose payload does not match its Class (or sets none/several) cannot be matched and is rejected by
+// Validate — a malformed event must never silently match or silently miss.
+func (e Event) payloadClass() (Class, bool) {
+	set := make([]Class, 0, 1)
+	if e.Process != nil {
+		set = append(set, ClassProcess)
+	}
+	if e.Network != nil {
+		set = append(set, ClassNetwork)
+	}
+	if e.File != nil {
+		set = append(set, ClassFile)
+	}
+	if e.Privilege != nil {
+		set = append(set, ClassPrivilege)
+	}
+	if len(set) != 1 {
+		return "", false
+	}
+	return set[0], true
+}
+
+// Validate enforces that an event is well-formed: a known class, a non-zero timestamp, and exactly the
+// one payload its class names.
+func (e Event) Validate() error {
+	if !e.Class.Valid() {
+		return fmt.Errorf("%w: event has an unknown class %q", shared.ErrValidation, e.Class)
+	}
+	if e.At.IsZero() {
+		return fmt.Errorf("%w: event of class %s has no timestamp", shared.ErrValidation, e.Class)
+	}
+	pc, ok := e.payloadClass()
+	if !ok || pc != e.Class {
+		return fmt.Errorf("%w: event of class %s must carry exactly its own payload", shared.ErrValidation, e.Class)
+	}
+	return nil
+}
+
+// clone returns a deep copy of the event: the per-class payload pointers and the argv slice are copied,
+// not aliased, so a detection that sealed this event as evidence cannot be mutated by a caller (or a
+// sensor pooling/reusing event structs) touching the original afterwards. Evidence that can change after
+// it is sealed is not evidence.
+func (e Event) clone() Event {
+	c := e
+	if e.Process != nil {
+		p := *e.Process
+		p.Args = append([]string(nil), e.Process.Args...)
+		c.Process = &p
+	}
+	if e.Network != nil {
+		n := *e.Network
+		c.Network = &n
+	}
+	if e.File != nil {
+		f := *e.File
+		c.File = &f
+	}
+	if e.Privilege != nil {
+		pr := *e.Privilege
+		c.Privilege = &pr
+	}
+	return c
+}
+
+// stringField returns the string form of a known field, and whether the field applies to this event's
+// class. An unknown field, or a field belonging to another class, returns ok=false — never a zero value
+// that could accidentally match.
+func (e Event) stringField(f Field) (string, bool) {
+	switch f {
+	case FieldProcComm:
+		if e.Process != nil {
+			return e.Process.Comm, true
+		}
+	case FieldProcPath:
+		if e.Process != nil {
+			return e.Process.Path, true
+		}
+	case FieldNetProto:
+		if e.Network != nil {
+			return e.Network.Proto, true
+		}
+	case FieldNetRemoteAddr:
+		if e.Network != nil {
+			return e.Network.RemoteAddr, true
+		}
+	case FieldNetDirection:
+		if e.Network != nil {
+			return e.Network.Direction, true
+		}
+	case FieldFilePath:
+		if e.File != nil {
+			return e.File.Path, true
+		}
+	case FieldFileOp:
+		if e.File != nil {
+			return e.File.Op, true
+		}
+	case FieldFileComm:
+		if e.File != nil {
+			return e.File.Comm, true
+		}
+	case FieldPrivComm:
+		if e.Privilege != nil {
+			return e.Privilege.Comm, true
+		}
+	case FieldPrivCap:
+		if e.Privilege != nil {
+			return e.Privilege.Cap, true
+		}
+	case FieldPrivKind:
+		if e.Privilege != nil {
+			return e.Privilege.Kind, true
+		}
+	}
+	return "", false
+}
+
+// stringFields returns every string value a field can take on this event. It exists for the one
+// repeated field, a process's argv: a predicate over FieldProcArg matches if ANY arg satisfies it, so a
+// scalar accessor would miss.
+func (e Event) stringFields(f Field) ([]string, bool) {
+	if f == FieldProcArg {
+		if e.Process != nil {
+			return e.Process.Args, true
+		}
+		return nil, false
+	}
+	if v, ok := e.stringField(f); ok {
+		return []string{v}, true
+	}
+	return nil, false
+}
+
+// intField returns the integer form of a known numeric field, and whether it applies to this class.
+func (e Event) intField(f Field) (int, bool) {
+	switch f {
+	case FieldProcUID:
+		if e.Process != nil {
+			return e.Process.UID, true
+		}
+	case FieldNetRemotePort:
+		if e.Network != nil {
+			return e.Network.RemotePort, true
+		}
+	case FieldPrivToUID:
+		if e.Privilege != nil {
+			return e.Privilege.ToUID, true
+		}
+	}
+	return 0, false
+}

--- a/internal/domain/detection/matcher.go
+++ b/internal/domain/detection/matcher.go
@@ -1,0 +1,208 @@
+package detection
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Field is a closed enumeration of the event fields a rule may match over. It is deliberately NOT a
+// free-form string key: a rule matches over this known set only, which is what stops a rule from being an
+// arbitrary expression over untrusted input. Each field belongs to exactly one Class.
+type Field string
+
+const (
+	// process
+	FieldProcComm Field = "proc.comm"
+	FieldProcPath Field = "proc.path"
+	FieldProcArg  Field = "proc.arg" // repeated: matches if ANY argv element satisfies the predicate
+	FieldProcUID  Field = "proc.uid" // numeric
+
+	// network
+	FieldNetProto      Field = "net.proto"
+	FieldNetRemoteAddr Field = "net.remote_addr"
+	FieldNetRemotePort Field = "net.remote_port" // numeric
+	FieldNetDirection  Field = "net.direction"
+
+	// file
+	FieldFilePath Field = "file.path"
+	FieldFileOp   Field = "file.op"
+	FieldFileComm Field = "file.comm"
+
+	// privilege
+	FieldPrivComm  Field = "priv.comm"
+	FieldPrivCap   Field = "priv.cap"
+	FieldPrivKind  Field = "priv.kind"
+	FieldPrivToUID Field = "priv.to_uid" // numeric
+)
+
+// fieldClass maps a field to the one class it belongs to. The bool is false for an unknown field.
+func fieldClass(f Field) (Class, bool) {
+	switch f {
+	case FieldProcComm, FieldProcPath, FieldProcArg, FieldProcUID:
+		return ClassProcess, true
+	case FieldNetProto, FieldNetRemoteAddr, FieldNetRemotePort, FieldNetDirection:
+		return ClassNetwork, true
+	case FieldFilePath, FieldFileOp, FieldFileComm:
+		return ClassFile, true
+	case FieldPrivComm, FieldPrivCap, FieldPrivKind, FieldPrivToUID:
+		return ClassPrivilege, true
+	default:
+		return "", false
+	}
+}
+
+// fieldIsNumeric reports whether a field is compared as an integer rather than a string.
+func fieldIsNumeric(f Field) bool {
+	switch f {
+	case FieldProcUID, FieldNetRemotePort, FieldPrivToUID:
+		return true
+	default:
+		return false
+	}
+}
+
+// Op is a comparison operator. The set is small and total: every op has a defined meaning for the field
+// type it is used with, checked by Matcher.validate.
+type Op string
+
+const (
+	OpEquals   Op = "eq"       // string or numeric equality
+	OpPrefix   Op = "prefix"   // string has prefix
+	OpContains Op = "contains" // string contains
+	OpIn       Op = "in"       // string is one of Values
+	OpGTE      Op = "gte"      // numeric >=
+)
+
+func (o Op) numeric() bool { return o == OpEquals || o == OpGTE }
+func (o Op) stringy() bool {
+	switch o {
+	case OpEquals, OpPrefix, OpContains, OpIn:
+		return true
+	default:
+		return false
+	}
+}
+
+// Predicate is one field comparison. Value is used by every op except OpIn, which uses Values.
+type Predicate struct {
+	Field  Field
+	Op     Op
+	Value  string
+	Values []string
+}
+
+// Matcher is the AND of its predicates over one event class. A rule needing OR is expressed as two
+// rules — milestone one keeps the matcher language small and total on purpose. An empty predicate list is
+// refused: a matcher that matches every event of a class is not a detection rule, it is a firehose.
+type Matcher struct {
+	Class Class
+	All   []Predicate
+}
+
+func (m Matcher) validate() error {
+	if !m.Class.Valid() {
+		return fmt.Errorf("%w: matcher has an unknown class %q", shared.ErrValidation, m.Class)
+	}
+	if len(m.All) == 0 {
+		return fmt.Errorf("%w: matcher for class %s has no predicates", shared.ErrValidation, m.Class)
+	}
+	for i, p := range m.All {
+		cls, ok := fieldClass(p.Field)
+		if !ok {
+			return fmt.Errorf("%w: predicate %d references unknown field %q", shared.ErrValidation, i, p.Field)
+		}
+		if cls != m.Class {
+			return fmt.Errorf("%w: predicate %d field %q belongs to class %s, not the matcher's class %s",
+				shared.ErrValidation, i, p.Field, cls, m.Class)
+		}
+		numericField := fieldIsNumeric(p.Field)
+		switch {
+		case numericField && !p.Op.numeric():
+			return fmt.Errorf("%w: predicate %d op %q is not valid on numeric field %q", shared.ErrValidation, i, p.Op, p.Field)
+		case !numericField && !p.Op.stringy():
+			return fmt.Errorf("%w: predicate %d op %q is not valid on string field %q", shared.ErrValidation, i, p.Op, p.Field)
+		}
+		if p.Op == OpIn {
+			if len(p.Values) == 0 {
+				return fmt.Errorf("%w: predicate %d op in needs a non-empty value set", shared.ErrValidation, i)
+			}
+		} else if strings.TrimSpace(p.Value) == "" {
+			return fmt.Errorf("%w: predicate %d op %q needs a value", shared.ErrValidation, i, p.Op)
+		}
+		if numericField {
+			if _, err := strconv.Atoi(strings.TrimSpace(p.Value)); err != nil {
+				return fmt.Errorf("%w: predicate %d numeric field %q needs an integer value, got %q", shared.ErrValidation, i, p.Field, p.Value)
+			}
+		}
+	}
+	return nil
+}
+
+// Match reports whether the event satisfies every predicate. A cross-class event, or one missing the
+// field a predicate names, does not match — a rule never matches something it cannot see.
+func (m Matcher) Match(e Event) bool {
+	if e.Class != m.Class {
+		return false
+	}
+	for _, p := range m.All {
+		if !p.match(e) {
+			return false
+		}
+	}
+	return true
+}
+
+func (p Predicate) match(e Event) bool {
+	if fieldIsNumeric(p.Field) {
+		got, ok := e.intField(p.Field)
+		if !ok {
+			return false
+		}
+		want, err := strconv.Atoi(strings.TrimSpace(p.Value))
+		if err != nil {
+			return false
+		}
+		switch p.Op {
+		case OpEquals:
+			return got == want
+		case OpGTE:
+			return got >= want
+		default:
+			return false
+		}
+	}
+
+	values, ok := e.stringFields(p.Field)
+	if !ok {
+		return false
+	}
+	for _, v := range values {
+		if p.matchString(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p Predicate) matchString(v string) bool {
+	switch p.Op {
+	case OpEquals:
+		return v == p.Value
+	case OpPrefix:
+		return strings.HasPrefix(v, p.Value)
+	case OpContains:
+		return strings.Contains(v, p.Value)
+	case OpIn:
+		for _, cand := range p.Values {
+			if v == cand {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}

--- a/internal/domain/detection/matcher_test.go
+++ b/internal/domain/detection/matcher_test.go
@@ -1,0 +1,98 @@
+package detection
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func procEvent(comm string, args ...string) Event {
+	return Event{Class: ClassProcess, At: time.Unix(1, 0), Host: "h1",
+		Process: &ProcessEvent{PID: 10, PPID: 1, Comm: comm, Path: "/usr/bin/" + comm, Args: args, UID: 1000}}
+}
+
+func TestMatcherRefusesEmptyOrCrossClassPredicates(t *testing.T) {
+	cases := map[string]Matcher{
+		"no predicates":     {Class: ClassProcess},
+		"unknown class":     {Class: "telepathy", All: []Predicate{{Field: FieldProcComm, Op: OpEquals, Value: "ps"}}},
+		"field wrong class": {Class: ClassProcess, All: []Predicate{{Field: FieldNetProto, Op: OpEquals, Value: "udp"}}},
+		"string op on num":  {Class: ClassProcess, All: []Predicate{{Field: FieldProcUID, Op: OpPrefix, Value: "10"}}},
+		"num op on string":  {Class: ClassProcess, All: []Predicate{{Field: FieldProcComm, Op: OpGTE, Value: "ps"}}},
+		"in without values": {Class: ClassProcess, All: []Predicate{{Field: FieldProcComm, Op: OpIn}}},
+		"empty value":       {Class: ClassProcess, All: []Predicate{{Field: FieldProcComm, Op: OpEquals}}},
+		"non-int numeric":   {Class: ClassProcess, All: []Predicate{{Field: FieldProcUID, Op: OpEquals, Value: "root"}}},
+	}
+	for name, m := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := m.validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestMatchNeverMatchesAcrossClass is the safety property: a matcher for one class never matches an event
+// of another, even if the other event happens to have a field with the sought value. A rule matches only
+// what it can actually see.
+func TestMatchNeverMatchesAcrossClass(t *testing.T) {
+	m := Matcher{Class: ClassNetwork, All: []Predicate{{Field: FieldNetProto, Op: OpEquals, Value: "udp"}}}
+	if m.Match(procEvent("ps")) {
+		t.Fatal("a network matcher matched a process event")
+	}
+}
+
+func TestMatchStringOps(t *testing.T) {
+	e := procEvent("systemctl", "restart", "nginx")
+	tests := []struct {
+		name string
+		p    Predicate
+		want bool
+	}{
+		{"equals hit", Predicate{Field: FieldProcComm, Op: OpEquals, Value: "systemctl"}, true},
+		{"equals miss", Predicate{Field: FieldProcComm, Op: OpEquals, Value: "ps"}, false},
+		{"prefix hit", Predicate{Field: FieldProcPath, Op: OpPrefix, Value: "/usr/bin/"}, true},
+		{"contains hit", Predicate{Field: FieldProcPath, Op: OpContains, Value: "systemctl"}, true},
+		{"in hit", Predicate{Field: FieldProcComm, Op: OpIn, Values: []string{"ps", "systemctl"}}, true},
+		{"arg any-hit", Predicate{Field: FieldProcArg, Op: OpEquals, Value: "restart"}, true},
+		{"arg no-hit", Predicate{Field: FieldProcArg, Op: OpEquals, Value: "stop"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Matcher{Class: ClassProcess, All: []Predicate{tt.p}}
+			if got := m.Match(e); got != tt.want {
+				t.Fatalf("match = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchNumericOps(t *testing.T) {
+	e := Event{Class: ClassPrivilege, At: time.Unix(1, 0), Host: "h1",
+		Privilege: &PrivilegeEvent{PID: 5, Comm: "sudo", FromUID: 1000, ToUID: 0, Kind: "setuid"}}
+	if !(Matcher{Class: ClassPrivilege, All: []Predicate{{Field: FieldPrivToUID, Op: OpEquals, Value: "0"}}}).Match(e) {
+		t.Error("to_uid == 0 should match a setuid-to-root event")
+	}
+	// A predicate over a field the event's class does not carry must not match.
+	if (Matcher{Class: ClassPrivilege, All: []Predicate{{Field: FieldPrivToUID, Op: OpGTE, Value: "1"}}}).Match(e) {
+		t.Error("to_uid >= 1 should not match to_uid 0")
+	}
+}
+
+// TestMatchAllPredicatesAreAnded: every predicate must hold. A credential-file rule that names the path
+// AND the op must not fire on the right path with the wrong op.
+func TestMatchAllPredicatesAreAnded(t *testing.T) {
+	m := Matcher{Class: ClassFile, All: []Predicate{
+		{Field: FieldFilePath, Op: OpEquals, Value: "/etc/shadow"},
+		{Field: FieldFileOp, Op: OpEquals, Value: "read"},
+	}}
+	read := Event{Class: ClassFile, At: time.Unix(1, 0), Host: "h1", File: &FileEvent{Path: "/etc/shadow", Op: "read"}}
+	write := Event{Class: ClassFile, At: time.Unix(1, 0), Host: "h1", File: &FileEvent{Path: "/etc/shadow", Op: "write"}}
+	if !m.Match(read) {
+		t.Error("both predicates satisfied should match")
+	}
+	if m.Match(write) {
+		t.Error("one predicate failing must not match (AND semantics)")
+	}
+}

--- a/internal/domain/detection/rule.go
+++ b/internal/domain/detection/rule.go
@@ -1,0 +1,79 @@
+package detection
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Rule is a typed, versioned, clean-room detection definition. It matches over one event class and, on a
+// match, the engine emits a Detection carrying the matched evidence. Rules are catalogued exactly like
+// the SAST catalogue, with a drift test that fails the build if the shipped catalogue does not validate.
+//
+// ID is stable and public-facing: it is the detection id the emulation catalogue (#421) names as the
+// expected observable, so the purple ledger (#426) can reconcile executed techniques against detections
+// by this id. Changing an ID breaks that linkage, so IDs are append-only in practice.
+type Rule struct {
+	ID       string // stable, catalogued; matches an emulation ExpectedObservable.DetectionID
+	Version  int
+	Class    Class
+	Title    string
+	Severity shared.Severity
+	Matcher  Matcher
+}
+
+// Validate enforces the invariants a catalogued rule must hold. A rule that fails these cannot produce a
+// trustworthy detection and must not ship.
+func (r Rule) Validate() error {
+	if strings.TrimSpace(r.ID) == "" {
+		return fmt.Errorf("%w: rule has no id", shared.ErrValidation)
+	}
+	if r.Version < 1 {
+		return fmt.Errorf("%w: rule %s must be versioned (>=1)", shared.ErrValidation, r.ID)
+	}
+	if !r.Class.Valid() {
+		return fmt.Errorf("%w: rule %s has an unknown class %q", shared.ErrValidation, r.ID, r.Class)
+	}
+	if strings.TrimSpace(r.Title) == "" {
+		return fmt.Errorf("%w: rule %s has no title", shared.ErrValidation, r.ID)
+	}
+	// A detection with severity "unknown" cannot be prioritised, so a rule must carry a concrete one.
+	if !r.Severity.Valid() || r.Severity == shared.SeverityUnknown {
+		return fmt.Errorf("%w: rule %s has an invalid severity %q", shared.ErrValidation, r.ID, r.Severity)
+	}
+	if r.Matcher.Class != r.Class {
+		return fmt.Errorf("%w: rule %s class %s does not match its matcher's class %s",
+			shared.ErrValidation, r.ID, r.Class, r.Matcher.Class)
+	}
+	if err := r.Matcher.validate(); err != nil {
+		return fmt.Errorf("rule %s: %w", r.ID, err)
+	}
+	return nil
+}
+
+// Match reports whether an event satisfies this rule. It observes and matches only — it never executes
+// anything (golden rule 1); the Matcher is typed data, not a shell expression.
+func (r Rule) Match(e Event) bool {
+	return r.Matcher.Match(e)
+}
+
+// clone returns a deep copy of the rule: the Matcher's predicate slice and each predicate's Values slice
+// are copied, not aliased. The catalogue accessors return clones so a caller cannot reach through a
+// returned rule and mutate the package-level rule set — a runtime-mutable detection catalogue would be a
+// security defect, not just a style one.
+func (r Rule) clone() Rule {
+	c := r
+	if r.Matcher.All != nil {
+		preds := make([]Predicate, len(r.Matcher.All))
+		for i, p := range r.Matcher.All {
+			pc := p
+			if p.Values != nil {
+				pc.Values = append([]string(nil), p.Values...)
+			}
+			preds[i] = pc
+		}
+		c.Matcher.All = preds
+	}
+	return c
+}


### PR DESCRIPTION
## What

Phase 1 of #422 (agent-side blue-team detection engine): the **pure `internal/domain/detection` package** — the typed event classes an eBPF sensor observes, the clean-room rules that match over them, the detection a match emits, and the coverage-honesty types. No eBPF and no I/O yet; those are the next phases (Linux, validated on a real kernel).

Splitting #422 this way keeps the foundation — which every later phase builds on and which encodes the safety invariants — fully verifiable on any platform, before the Linux-only eBPF work.

## What's in it

- **`Class`** — process · network · file · privilege. Each is independently loadable/disableable (the eBPF phase honours that); the set mirrors the emulation telemetry classes so purple (#426) reconciles by detection id.
- **`Event`** — a typed observation with exactly one per-class payload (process/network/file/privilege). `Validate()` rejects an event whose payload doesn't match its class, or that sets none/several — a malformed event must never silently match or silently miss.
- **`Matcher`** — the rule language: a closed `Field` enum + `Op` (eq/prefix/contains/in/gte) + `Predicate`, AND-combined over one class. It is **typed data evaluated by Go** — no shell, no eval, no regex-from-rule-input (golden rule 1). A predicate over a field the event's class doesn't carry, or a cross-class event, never matches.
- **`Rule`** — catalogued, versioned; `ID` is the public detection id an emulation technique names as its expected observable.
- **`Detection`** — full attribution (host, agent, rule id+version, evidence, time); evidence is defensively copied and bounded (`MaxEvidence`), truncation reported not silent — the precursor to detections-as-evidence (#423).
- **Coverage honesty** — `ClassCoverage`/`HostCoverage`: only `StateActive` counts as observing; a missing/failed/disabled class is an **observation gap**, never "clean"; `NewHostCoverage` fills an unreported class as a gap rather than omitting it, so a host can never look more covered than its reports justify (#422 reqs 4/5/6).
- **`catalog.go`** — six clean-room rules, ≥1 per class. Five ids are exactly the `det.*` the emulation catalogue (#421) expects, so the purple ledger can reconcile executed-vs-detected; a catalogue drift test + a linkage test enforce that.

## Purple linkage made real

`TestEmulationExpectedDetectionsAreCatalogued` asserts every emulation `ExpectedObservable.DetectionID` resolves to a catalogued rule. This is what lets #426 turn the emulation coverage record's currently-empty `Actual` into a measured expected-vs-actual once the engine (later phase) fires detections.

## Phasing (each a separate PR, merge before next)

1. **This PR** — pure domain + catalogue + tests (local-verifiable).
2. eBPF programs + loaders per class (Linux, build-tagged), observation-gap on load failure, overhead measured on a real kernel (`ssh nghiahuynh.coder`).
3. Agent-side engine (`usecase/fleet/detect`): consume ringbuf events, evaluate the catalogue, emit detections + bounded context, CPU ceiling + load shedding, per-class coverage; wire into the VM agent (#410).

## Safety

Pure domain — no exec, no LLM, no credentials, no network. The matcher observes and matches only; nothing in the package or its evaluation path can execute anything (asserted structurally by the closed Field/Op enums and by test).

## Verification (CI disabled per repo config — verified locally)

- `go build ./...`, `go vet ./internal/domain/detection/...`, `gofmt` clean
- `go test -race ./internal/domain/detection/...` — full package green (matcher AND/cross-class, per-class fixture→detection, evidence bounding/truncation, coverage honesty, drift + emulation linkage)
- Dependency rule confirmed: non-test files import only `internal/domain/shared` + stdlib
- Reviewed by `go-arch-reviewer` and `security-auditor`
