### PR TITLE
feat(blueteam): agent-side detection engine, wired into the VM agent (#422 phase 3)

### DIFF
--- a/cmd/synapse-agent/detect.go
+++ b/cmd/synapse-agent/detect.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/detectsink"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/ebpf"
+	detectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detect"
+)
+
+// startDetection launches the agent-side detection engine (#422) in the background when configured. It
+// is strictly best-effort and isolated from the inventory loop: on a host where the eBPF sensor cannot
+// run (non-Linux, no root, missing kernel features) it logs the reason and returns, leaving the agent's
+// normal work untouched. Detection is OFF unless -detect-classes / SYNAPSE_DETECT_CLASSES is set.
+func (r *runner) startDetection(ctx context.Context) {
+	classes, err := parseDetectClasses(r.cfg.detectClasses)
+	if err != nil {
+		log.Printf("detection: %v; detection engine disabled", err)
+		return
+	}
+	if len(classes) == 0 {
+		return // off by default
+	}
+
+	host := shared.ID(r.cfg.name)
+	agent := shared.ID("agent:" + r.cfg.name)
+	sinkPath := filepath.Join(r.cfg.stateDir, "detections.jsonl")
+	sink, err := detectsink.New(sinkPath)
+	if err != nil {
+		log.Printf("detection: %v; detection engine disabled", err)
+		return
+	}
+	sensor := ebpf.NewSensor(host, agent, classes)
+	eng, err := detectuc.NewEngine(sensor, sink, host, agent, detectuc.Options{
+		Classes:       classes,
+		CPUCeilingPct: r.cfg.detectCeiling,
+	})
+	if err != nil {
+		log.Printf("detection: %v; detection engine disabled", err)
+		_ = sink.Close()
+		return
+	}
+
+	log.Printf("detection engine starting: classes=%s ceiling=%.0f%% sink=%s", r.cfg.detectClasses, r.cfg.detectCeiling, sinkPath)
+	// One-shot coverage report shortly after start, so the operator can see which classes actually came
+	// up on this host and which are gaps — never silently assume a class is observing.
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-time.After(3 * time.Second):
+			log.Printf("detection coverage: %s", formatCoverage(eng.Coverage()))
+		}
+	}()
+	go func() {
+		err := eng.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Printf("detection engine stopped: %v", err)
+		}
+		_ = sink.Close()
+	}()
+}
+
+// parseDetectClasses turns the comma-separated config into validated classes. An unknown class is a
+// configuration error (the whole engine stays off) rather than a silently-ignored typo.
+func parseDetectClasses(s string) ([]detection.Class, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	var out []detection.Class
+	for _, part := range strings.Split(s, ",") {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		c := detection.Class(p)
+		if !c.Valid() {
+			return nil, fmt.Errorf("unknown detection class %q (want any of process,network,file,privilege)", p)
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// parseCeiling reads the CPU-ceiling percent from the environment; a missing or invalid value disables
+// load shedding (0), which is the safe default (shed only on a deliberate, valid setting).
+func parseCeiling(s string) float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil || v < 0 {
+		log.Printf("detection: ignoring invalid SYNAPSE_DETECT_CPU_CEIL_PCT %q", s)
+		return 0
+	}
+	return v
+}
+
+// formatCoverage renders a per-class coverage line: active classes and, explicitly, the gaps.
+func formatCoverage(cov []detection.ClassCoverage) string {
+	parts := make([]string, 0, len(cov))
+	for _, c := range cov {
+		state := string(c.State)
+		if c.IsObservationGap() && c.Reason != "" {
+			state = fmt.Sprintf("%s(%s)", c.State, c.Reason)
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", c.Class, state))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, " ")
+}

--- a/cmd/synapse-agent/detect_integration_linux_test.go
+++ b/cmd/synapse-agent/detect_integration_linux_test.go
@@ -1,0 +1,102 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/detectsink"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/ebpf"
+	detectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detect"
+)
+
+// TestDetectionPipelineEndToEndOnKernel wires the REAL eBPF sensor to the engine and the file sink —
+// the exact composition the agent uses — and proves the whole Phase-3 chain on a live kernel: a real
+// `ps` exec is captured, matched into det.process_enumeration, and written to the JSONL sink. Skips
+// unless root (unprivileged eBPF is disabled).
+func TestDetectionPipelineEndToEndOnKernel(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("detection pipeline needs root (unprivileged eBPF is disabled); run under sudo")
+	}
+	dir := t.TempDir()
+	sinkPath := filepath.Join(dir, "detections.jsonl")
+	sink, err := detectsink.New(sinkPath)
+	if err != nil {
+		t.Fatalf("sink: %v", err)
+	}
+	sensor := ebpf.NewSensor("host-it", "agent:it", detection.Classes())
+	eng, err := detectuc.NewEngine(sensor, sink, "host-it", "agent:it", detectuc.Options{})
+	if err != nil {
+		t.Fatalf("engine: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx) }()
+
+	time.Sleep(500 * time.Millisecond) // let the sensor attach
+	// Generate fixtures until the detection lands or we time out.
+	found := false
+	deadline := time.After(6 * time.Second)
+	for !found {
+		_ = exec.Command("ps", "-ef").Run()
+		select {
+		case <-deadline:
+			cancel()
+			<-done
+			_ = sink.Close()
+			t.Fatal("no det.process_enumeration written to the sink within the window")
+		case <-time.After(300 * time.Millisecond):
+		}
+		found = sinkHasRule(t, sinkPath, "det.process_enumeration")
+	}
+
+	cancel()
+	<-done
+	if err := sink.Close(); err != nil {
+		t.Errorf("sink close: %v", err)
+	}
+	// Every written line must be a valid, fully-attributed detection.
+	for _, d := range readDetections(t, sinkPath) {
+		if err := d.Validate(); err != nil {
+			t.Errorf("sink wrote an invalid detection: %v", err)
+		}
+	}
+}
+
+func sinkHasRule(t *testing.T, path, ruleID string) bool {
+	t.Helper()
+	for _, d := range readDetections(t, path) {
+		if d.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+func readDetections(t *testing.T, path string) []detection.Detection {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	var out []detection.Detection
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1<<20), 1<<20)
+	for sc.Scan() {
+		var d detection.Detection
+		if json.Unmarshal(sc.Bytes(), &d) == nil {
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/cmd/synapse-agent/detect_test.go
+++ b/cmd/synapse-agent/detect_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+)
+
+func TestParseDetectClasses(t *testing.T) {
+	got, err := parseDetectClasses(" process , file ,network")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 || got[0] != detection.ClassProcess || got[1] != detection.ClassFile || got[2] != detection.ClassNetwork {
+		t.Fatalf("wrong parse: %v", got)
+	}
+	// Empty → off, no error.
+	if g, err := parseDetectClasses("  "); err != nil || len(g) != 0 {
+		t.Fatalf("empty must be off with no error, got %v %v", g, err)
+	}
+	// Unknown class → error (the engine stays off rather than silently ignore a typo).
+	if _, err := parseDetectClasses("process,telepathy"); err == nil {
+		t.Fatal("an unknown class must be a configuration error")
+	}
+}
+
+func TestParseCeiling(t *testing.T) {
+	cases := map[string]float64{"": 0, "3": 3, "12.5": 12.5, "-1": 0, "abc": 0}
+	for in, want := range cases {
+		if got := parseCeiling(in); got != want {
+			t.Errorf("parseCeiling(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestFormatCoverageShowsGapsWithReason(t *testing.T) {
+	cov := []detection.ClassCoverage{
+		{Class: detection.ClassProcess, State: detection.StateActive},
+		{Class: detection.ClassFile, State: detection.StateFailed, Reason: "load failed"},
+	}
+	s := formatCoverage(cov)
+	if !strings.Contains(s, "process=active") {
+		t.Errorf("active class missing: %q", s)
+	}
+	if !strings.Contains(s, "file=failed(load failed)") {
+		t.Errorf("gap must show its reason: %q", s)
+	}
+}

--- a/cmd/synapse-agent/main.go
+++ b/cmd/synapse-agent/main.go
@@ -57,14 +57,16 @@ type fleetAPI interface {
 }
 
 type config struct {
-	baseURL    string
-	enrolToken string
-	stateDir   string
-	root       string
-	name       string
-	poll       time.Duration
-	maxOrders  int
-	once       bool
+	baseURL       string
+	enrolToken    string
+	stateDir      string
+	root          string
+	name          string
+	poll          time.Duration
+	maxOrders     int
+	once          bool
+	detectClasses string  // SYNAPSE_DETECT_CLASSES; empty = detection engine off
+	detectCeiling float64 // SYNAPSE_DETECT_CPU_CEIL_PCT; 0 = no load shedding
 }
 
 func main() {
@@ -116,6 +118,8 @@ func parseConfig() config {
 	flag.DurationVar(&cfg.poll, "poll", 60*time.Second, "poll interval between claim cycles")
 	flag.IntVar(&cfg.maxOrders, "max-orders", 8, "max work orders to claim per cycle")
 	flag.BoolVar(&cfg.once, "once", false, "run a single cycle then exit")
+	flag.StringVar(&cfg.detectClasses, "detect-classes", os.Getenv("SYNAPSE_DETECT_CLASSES"), "comma-separated eBPF detection classes to run (process,network,file,privilege); empty = detection engine off (#422, Linux+root only)")
+	flag.Float64Var(&cfg.detectCeiling, "detect-ceiling", parseCeiling(os.Getenv("SYNAPSE_DETECT_CPU_CEIL_PCT")), "CPU ceiling percent for the detection engine; over it, classes are shed in a defined order (0 = no shedding)")
 	flag.Parse()
 	if cfg.enrolToken == "" {
 		// An absent token file is NOT fatal: it is the normal state after enrolment, once the
@@ -142,6 +146,9 @@ func (r *runner) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Agent-side detection engine (#422): a continuous background observer, separate from the
+	// per-work-order inventory cycle below. Best-effort — it never blocks or fails the inventory loop.
+	r.startDetection(ctx)
 	for {
 		if err := r.cycle(ctx, cred); err != nil {
 			if errors.Is(err, context.Canceled) {

--- a/internal/infrastructure/detectsink/filesink.go
+++ b/internal/infrastructure/detectsink/filesink.go
@@ -1,0 +1,68 @@
+// Package detectsink provides the milestone-1 landing spot for the detections the agent-side engine
+// (#422) emits: an append-only JSONL file on the host. Shipping detections to the control plane and
+// sealing them as hash-chained evidence is issue #423; until then the agent records them locally so the
+// pipeline is real end-to-end and nothing is silently dropped.
+package detectsink
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// FileSink appends each detection as one JSON line. It is safe for concurrent Emit (the engine is
+// single-goroutine today, but a sink that corrupts under concurrency would be a silent evidence loss).
+type FileSink struct {
+	mu sync.Mutex
+	f  *os.File
+}
+
+var _ ports.DetectionSink = (*FileSink)(nil)
+
+// New opens (creating parent dirs) the JSONL file for append. A sink that cannot open its file is an
+// error, not a silent no-op: the engine must know its detections have nowhere to go.
+func New(path string) (*FileSink, error) {
+	if path == "" {
+		return nil, fmt.Errorf("%w: detection sink needs a file path", shared.ErrValidation)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("detection sink dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open detection sink: %w", err)
+	}
+	return &FileSink{f: f}, nil
+}
+
+// Emit writes one detection as a JSON line. The detection is validated first, so a malformed record
+// never reaches the file.
+func (s *FileSink) Emit(_ context.Context, d detection.Detection) error {
+	if err := d.Validate(); err != nil {
+		return fmt.Errorf("detection sink: refusing invalid detection: %w", err)
+	}
+	line, err := json.Marshal(d)
+	if err != nil {
+		return fmt.Errorf("detection sink: marshal: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.f.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("detection sink: write: %w", err)
+	}
+	return nil
+}
+
+// Close closes the underlying file.
+func (s *FileSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.f.Close()
+}

--- a/internal/infrastructure/detectsink/filesink_test.go
+++ b/internal/infrastructure/detectsink/filesink_test.go
@@ -1,0 +1,90 @@
+package detectsink
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+)
+
+func validDetection(t *testing.T) detection.Detection {
+	t.Helper()
+	r, ok := detection.Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("expected det.process_enumeration in the catalogue")
+	}
+	ev := detection.Event{Class: detection.ClassProcess, At: time.Unix(1, 0), Host: "h",
+		Process: &detection.ProcessEvent{PID: 1, Comm: "ps", Path: "/usr/bin/ps"}}
+	d, err := detection.NewDetection(r, "host-1", "agent:1", []detection.Event{ev}, time.Unix(1000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func TestFileSinkAppendsJSONLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "detections.jsonl")
+	s, err := New(path)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	d := validDetection(t)
+	if err := s.Emit(context.Background(), d); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if err := s.Emit(context.Background(), d); err != nil {
+		t.Fatalf("emit 2: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	n := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var got detection.Detection
+		if err := json.Unmarshal(sc.Bytes(), &got); err != nil {
+			t.Fatalf("line %d is not valid JSON: %v", n, err)
+		}
+		if got.RuleID != "det.process_enumeration" {
+			t.Errorf("line %d wrong rule: %q", n, got.RuleID)
+		}
+		n++
+	}
+	if n != 2 {
+		t.Fatalf("want 2 JSON lines, got %d", n)
+	}
+}
+
+func TestFileSinkRefusesInvalidDetection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "detections.jsonl")
+	s, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	// A zero detection has no attribution and must be refused, not written.
+	if err := s.Emit(context.Background(), detection.Detection{}); err == nil {
+		t.Fatal("an invalid detection must be refused")
+	}
+	fi, _ := os.Stat(path)
+	if fi.Size() != 0 {
+		t.Fatalf("nothing should have been written, file is %d bytes", fi.Size())
+	}
+}
+
+func TestNewRejectsEmptyPath(t *testing.T) {
+	if _, err := New(""); err == nil {
+		t.Fatal("empty path must be rejected")
+	}
+}

--- a/internal/infrastructure/ebpf/detect_linux.go
+++ b/internal/infrastructure/ebpf/detect_linux.go
@@ -31,7 +31,12 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+// The sensor is consumed by the agent-side engine through ports.DetectionSensor, never as a concrete
+// type — the dependency points inward (usecase ← infrastructure).
+var _ ports.DetectionSensor = (*Sensor)(nil)
 
 // Rebuild the embedded objects after editing the .bpf.c sources (on a Linux host with clang +
 // libbpf-devel; netconn also needs a vmlinux.h from `bpftool btf dump file /sys/kernel/btf/vmlinux

--- a/internal/infrastructure/ebpf/detect_other.go
+++ b/internal/infrastructure/ebpf/detect_other.go
@@ -12,7 +12,11 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+// The off-Linux stub satisfies the same port as the Linux sensor, so composition compiles everywhere.
+var _ ports.DetectionSensor = (*Sensor)(nil)
 
 // ErrSensorUnavailable means the detection sensor cannot run here (Linux only).
 var ErrSensorUnavailable = errors.New("ebpf detection sensor unavailable: Linux only")

--- a/internal/usecase/fleet/detect/engine.go
+++ b/internal/usecase/fleet/detect/engine.go
@@ -1,0 +1,308 @@
+// Package detect is the agent-side detection engine (issue #422, phase 3). It runs ON THE AGENT: it
+// consumes the per-class event stream from a DetectionSensor, evaluates the clean-room rule catalogue
+// against each event, and emits a detection — with a bounded context window — for every match.
+//
+// It is deterministic-first and observe-only: the engine matches typed rules and emits detections; it
+// never executes anything (golden rule 1). It enforces a CPU ceiling by SHEDDING whole event classes in
+// a defined order and reporting that it did, and it reports per-class coverage that folds in the
+// sensor's gaps, its own shedding, and back-pressure drops — so a class the agent is not fully observing
+// is never presented as clean.
+package detect
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// LoadSampler reports the CPU cost currently attributable to detection, as a percentage of one core. The
+// engine samples it to decide whether to shed load. A real implementation reads getrusage; tests inject
+// a deterministic one.
+type LoadSampler interface {
+	CPUPercent() float64
+}
+
+// nopSampler always reports zero load — the default when the caller wires no sampler. With it the engine
+// never sheds, which is the safe default (shed only on a measured, wired signal).
+type nopSampler struct{}
+
+func (nopSampler) CPUPercent() float64 { return 0 }
+
+// shedOrder is the DEFINED order in which classes are shed under CPU pressure: highest-volume / lowest
+// marginal value first, most security-critical last. File opens are the loudest and cheapest to lose;
+// privilege changes are the rarest and most important, so they are shed only as a last resort.
+var shedOrder = []detection.Class{
+	detection.ClassFile,
+	detection.ClassNetwork,
+	detection.ClassProcess,
+	detection.ClassPrivilege,
+}
+
+// ShedEvent records that a class was shed to stay under the CPU ceiling, so the action is auditable and
+// visible rather than a silent drop in coverage.
+type ShedEvent struct {
+	Class      detection.Class
+	At         time.Time
+	CPUAtShed  float64
+	CeilingPct float64
+}
+
+// Options configures an engine.
+type Options struct {
+	Classes        []detection.Class // classes to evaluate; defaults to all
+	CPUCeilingPct  float64           // shed when the sampler exceeds this; 0 disables shedding
+	Sampler        LoadSampler       // load source; nil → never sheds
+	SampleInterval time.Duration     // minimum spacing between load samples; 0 → sample every event
+	ContextWindow  int               // events of context kept per class; defaults to DefaultContextWindow
+	Clock          ports.Clock
+}
+
+// DefaultContextWindow is how many recent same-class events accompany a detection as bounded context.
+const DefaultContextWindow = 16
+
+// Engine ties a sensor to the rule catalogue.
+type Engine struct {
+	sensor   ports.DetectionSensor
+	sink     ports.DetectionSink
+	host     shared.ID
+	agentID  shared.ID
+	rules    map[detection.Class][]detection.Rule
+	enabled  map[detection.Class]bool
+	ceiling  float64
+	sampler  LoadSampler
+	interval time.Duration
+	window   int
+	clock    ports.Clock
+
+	mu         sync.Mutex
+	started    bool
+	shed       map[detection.Class]bool
+	shedLog    []ShedEvent
+	ctxBuf     map[detection.Class][]detection.Event
+	emitFail   map[detection.Class]uint64
+	lastSample time.Time
+}
+
+// NewEngine validates dependencies and loads the rule catalogue for the enabled classes.
+func NewEngine(sensor ports.DetectionSensor, sink ports.DetectionSink, host, agentID shared.ID, opts Options) (*Engine, error) {
+	if sensor == nil || sink == nil {
+		return nil, fmt.Errorf("%w: detection engine needs a sensor and a sink", shared.ErrValidation)
+	}
+	if host == "" || agentID == "" {
+		return nil, fmt.Errorf("%w: detection engine needs a host and agent identity", shared.ErrValidation)
+	}
+	classes := opts.Classes
+	if len(classes) == 0 {
+		classes = detection.Classes()
+	}
+	enabled := make(map[detection.Class]bool, len(classes))
+	rules := make(map[detection.Class][]detection.Rule, len(classes))
+	for _, c := range classes {
+		if !c.Valid() {
+			return nil, fmt.Errorf("%w: unknown detection class %q", shared.ErrValidation, c)
+		}
+		enabled[c] = true
+		rs, err := detection.CatalogueByClass(c)
+		if err != nil {
+			return nil, fmt.Errorf("load rules for %s: %w", c, err)
+		}
+		rules[c] = rs
+	}
+	sampler := opts.Sampler
+	if sampler == nil {
+		sampler = nopSampler{}
+	}
+	clock := opts.Clock
+	if clock == nil {
+		clock = systemClock{}
+	}
+	window := opts.ContextWindow
+	if window <= 0 {
+		window = DefaultContextWindow
+	}
+	return &Engine{
+		sensor: sensor, sink: sink, host: host, agentID: agentID,
+		rules: rules, enabled: enabled, ceiling: opts.CPUCeilingPct, sampler: sampler,
+		interval: opts.SampleInterval, window: window, clock: clock,
+		shed: map[detection.Class]bool{}, ctxBuf: map[detection.Class][]detection.Event{},
+		emitFail: map[detection.Class]uint64{},
+	}, nil
+}
+
+// Run starts the sensor and processes events until the context is cancelled or the sensor's event stream
+// closes. It always closes the sensor on return. It is a single blocking call; do not call it twice.
+func (e *Engine) Run(ctx context.Context) (err error) {
+	e.mu.Lock()
+	if e.started {
+		e.mu.Unlock()
+		return fmt.Errorf("%w: detection engine already run", shared.ErrValidation)
+	}
+	e.started = true
+	e.mu.Unlock()
+
+	if serr := e.sensor.Start(ctx); serr != nil {
+		return fmt.Errorf("start sensor: %w", serr)
+	}
+	// Surface a failed detach rather than swallowing it — but only when Run has no more pressing error
+	// to report (a cancel or a start failure takes precedence).
+	defer func() {
+		if cerr := e.sensor.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close sensor: %w", cerr)
+		}
+	}()
+
+	events := e.sensor.Events()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-events:
+			if !ok {
+				return nil // sensor closed its stream
+			}
+			e.process(ctx, ev)
+		}
+	}
+}
+
+// process handles one event: sample load (maybe shed), then — unless the class is shed or disabled —
+// buffer it as context and evaluate every rule for its class, emitting a detection per match.
+func (e *Engine) process(ctx context.Context, ev detection.Event) {
+	if !e.enabled[ev.Class] {
+		return
+	}
+	e.maybeShed(ev.Class)
+
+	e.mu.Lock()
+	if e.shed[ev.Class] {
+		e.mu.Unlock()
+		return // this class is shed to stay under the ceiling; its events are not evaluated
+	}
+	window := e.pushContextLocked(ev)
+	rules := e.rules[ev.Class]
+	e.mu.Unlock()
+
+	for _, r := range rules {
+		if !r.Match(ev) {
+			continue
+		}
+		d, err := detection.NewDetection(r, e.host, e.agentID, window, e.clock.Now().UTC())
+		if err != nil {
+			// A malformed event cannot produce a detection. Skip rather than emit a bad one, but COUNT
+			// it — a matched rule that produced nothing is a coverage signal, not a silent miss.
+			e.recordEmitFailure(ev.Class)
+			continue
+		}
+		if err := e.sink.Emit(ctx, d); err != nil {
+			// The detection was confirmed but could not be recorded. That is not silent: it is counted and
+			// folds into Coverage as a degraded class, so an operator sees the class's record is incomplete.
+			e.recordEmitFailure(ev.Class)
+		}
+	}
+}
+
+// recordEmitFailure counts a matched rule whose detection could not be built or emitted, per class.
+func (e *Engine) recordEmitFailure(c detection.Class) {
+	e.mu.Lock()
+	e.emitFail[c]++
+	e.mu.Unlock()
+}
+
+// pushContextLocked appends the event to its class's bounded ring and returns the current window (a copy)
+// to accompany a detection. The window is the recent same-class events ending with the trigger — bounded
+// so a detection stays small (the domain further caps it at detection.MaxEvidence).
+func (e *Engine) pushContextLocked(ev detection.Event) []detection.Event {
+	buf := append(e.ctxBuf[ev.Class], ev)
+	if len(buf) > e.window {
+		buf = buf[len(buf)-e.window:]
+	}
+	e.ctxBuf[ev.Class] = buf
+	out := make([]detection.Event, len(buf))
+	copy(out, buf)
+	return out
+}
+
+// maybeShed samples the load (respecting the minimum sample interval) and, if it exceeds the ceiling,
+// sheds the next class in the defined order that is enabled and not already shed. It records the action.
+func (e *Engine) maybeShed(_ detection.Class) {
+	if e.ceiling <= 0 {
+		return // shedding disabled
+	}
+	now := e.clock.Now()
+	e.mu.Lock()
+	if e.interval > 0 && !e.lastSample.IsZero() && now.Sub(e.lastSample) < e.interval {
+		e.mu.Unlock()
+		return
+	}
+	e.lastSample = now
+	e.mu.Unlock()
+
+	cpu := e.sampler.CPUPercent()
+	if cpu <= e.ceiling {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, c := range shedOrder {
+		if e.enabled[c] && !e.shed[c] {
+			e.shed[c] = true
+			e.shedLog = append(e.shedLog, ShedEvent{Class: c, At: now.UTC(), CPUAtShed: cpu, CeilingPct: e.ceiling})
+			return // shed exactly one class per breach; re-check on the next sample
+		}
+	}
+}
+
+// ShedLog returns the classes shed under load pressure, in order — the report that shedding occurred.
+func (e *Engine) ShedLog() []ShedEvent {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]ShedEvent, len(e.shedLog))
+	copy(out, e.shedLog)
+	return out
+}
+
+// Coverage returns the honest per-class observation status: the sensor's coverage, with a class the
+// engine has shed downgraded to a degraded gap, and a class the sensor is dropping under back-pressure
+// likewise downgraded. A class the engine does not evaluate is never reported as cleanly observed.
+func (e *Engine) Coverage() []detection.ClassCoverage {
+	sensorCov := e.sensor.Coverage()
+	dropped := e.sensor.Dropped()
+
+	e.mu.Lock()
+	shed := make(map[detection.Class]bool, len(e.shed))
+	for c, v := range e.shed {
+		shed[c] = v
+	}
+	emitFail := make(map[detection.Class]uint64, len(e.emitFail))
+	for c, v := range e.emitFail {
+		emitFail[c] = v
+	}
+	e.mu.Unlock()
+
+	out := make([]detection.ClassCoverage, 0, len(sensorCov))
+	for _, cc := range sensorCov {
+		switch {
+		case shed[cc.Class]:
+			cc.State = detection.StateDegraded
+			cc.Reason = "shed by the engine to stay under the CPU ceiling"
+		case dropped[cc.Class] > 0 && cc.State == detection.StateActive:
+			cc.State = detection.StateDegraded
+			cc.Reason = fmt.Sprintf("dropping events under back-pressure (%d dropped)", dropped[cc.Class])
+		case emitFail[cc.Class] > 0 && cc.State == detection.StateActive:
+			cc.State = detection.StateDegraded
+			cc.Reason = fmt.Sprintf("%d detection(s) matched but could not be recorded", emitFail[cc.Class])
+		}
+		out = append(out, cc)
+	}
+	return out
+}
+
+// systemClock is the default wall clock.
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now().UTC() }

--- a/internal/usecase/fleet/detect/engine_test.go
+++ b/internal/usecase/fleet/detect/engine_test.go
@@ -1,0 +1,328 @@
+package detect
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ---- fakes ------------------------------------------------------------------------------------------
+
+type fakeSensor struct {
+	events   chan detection.Event
+	coverage []detection.ClassCoverage
+	dropped  map[detection.Class]uint64
+	started  bool
+	startErr error
+}
+
+func newFakeSensor() *fakeSensor {
+	return &fakeSensor{events: make(chan detection.Event, 64), dropped: map[detection.Class]uint64{}}
+}
+func (f *fakeSensor) Start(context.Context) error         { f.started = true; return f.startErr }
+func (f *fakeSensor) Events() <-chan detection.Event      { return f.events }
+func (f *fakeSensor) Coverage() []detection.ClassCoverage { return f.coverage }
+func (f *fakeSensor) Dropped() map[detection.Class]uint64 { return f.dropped }
+func (f *fakeSensor) Close() error                        { return nil }
+
+type fakeSink struct {
+	mu   sync.Mutex
+	got  []detection.Detection
+	fail bool
+}
+
+func (s *fakeSink) Emit(_ context.Context, d detection.Detection) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fail {
+		return errors.New("sink down")
+	}
+	s.got = append(s.got, d)
+	return nil
+}
+func (s *fakeSink) detections() []detection.Detection {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]detection.Detection(nil), s.got...)
+}
+
+type fixedSampler struct{ pct float64 }
+
+func (s fixedSampler) CPUPercent() float64 { return s.pct }
+
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+func procEvent(comm string, args ...string) detection.Event {
+	return detection.Event{Class: detection.ClassProcess, At: time.Unix(1, 0), Host: "h",
+		Process: &detection.ProcessEvent{PID: 1, Comm: comm, Path: "/usr/bin/" + comm, Args: args}}
+}
+
+func newEngine(t *testing.T, sensor *fakeSensor, sink *fakeSink, opts Options) *Engine {
+	t.Helper()
+	if opts.Clock == nil {
+		opts.Clock = fixedClock{t: time.Unix(1000, 0)}
+	}
+	e, err := NewEngine(sensor, sink, "host-1", "agent:1", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+// ---- tests ------------------------------------------------------------------------------------------
+
+func TestNewEngineValidation(t *testing.T) {
+	s, k := newFakeSensor(), &fakeSink{}
+	cases := map[string]func() (*Engine, error){
+		"nil sensor": func() (*Engine, error) { return NewEngine(nil, k, "h", "a", Options{}) },
+		"nil sink":   func() (*Engine, error) { return NewEngine(s, nil, "h", "a", Options{}) },
+		"no host":    func() (*Engine, error) { return NewEngine(s, k, "", "a", Options{}) },
+		"no agent":   func() (*Engine, error) { return NewEngine(s, k, "h", "", Options{}) },
+		"bad class": func() (*Engine, error) {
+			return NewEngine(s, k, "h", "a", Options{Classes: []detection.Class{"telepathy"}})
+		},
+	}
+	for name, call := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := call(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestEngineEmitsDetectionOnMatch: a captured `ps` exec becomes a det.process_enumeration detection with
+// the triggering event as evidence and full attribution.
+func TestEngineEmitsDetectionOnMatch(t *testing.T) {
+	sensor, sink := newFakeSensor(), &fakeSink{}
+	e := newEngine(t, sensor, sink, Options{})
+	e.process(context.Background(), procEvent("ps", "-ef"))
+
+	got := sink.detections()
+	if len(got) != 1 {
+		t.Fatalf("want one detection, got %d", len(got))
+	}
+	d := got[0]
+	if d.RuleID != "det.process_enumeration" || d.HostID != "host-1" || d.AgentID != "agent:1" {
+		t.Fatalf("detection attribution wrong: %+v", d)
+	}
+	if len(d.Evidence) != 1 || d.Evidence[0].Process.Comm != "ps" {
+		t.Fatalf("detection must carry the triggering event as evidence: %+v", d.Evidence)
+	}
+}
+
+// TestEngineIgnoresNonMatchingAndDisabled: a non-matching command produces nothing, and an event of a
+// disabled class is never evaluated.
+func TestEngineIgnoresNonMatchingAndDisabled(t *testing.T) {
+	sensor, sink := newFakeSensor(), &fakeSink{}
+	e := newEngine(t, sensor, sink, Options{Classes: []detection.Class{detection.ClassProcess}})
+
+	e.process(context.Background(), procEvent("bash")) // no process rule matches bash
+	// A file event while only the process class is enabled must be ignored.
+	e.process(context.Background(), detection.Event{Class: detection.ClassFile, At: time.Unix(1, 0), Host: "h",
+		File: &detection.FileEvent{Path: "/etc/shadow", Op: "read"}})
+
+	if got := sink.detections(); len(got) != 0 {
+		t.Fatalf("no detection expected, got %d: %+v", len(got), got)
+	}
+}
+
+// TestEngineContextWindowIsBounded: a detection carries recent same-class events as bounded context,
+// ending with the trigger.
+func TestEngineContextWindowIsBounded(t *testing.T) {
+	sensor, sink := newFakeSensor(), &fakeSink{}
+	e := newEngine(t, sensor, sink, Options{Classes: []detection.Class{detection.ClassProcess}, ContextWindow: 4})
+
+	// Feed several non-matching execs to fill context, then a matching `ps`.
+	for _, c := range []string{"bash", "sh", "env", "cat", "ls"} {
+		e.process(context.Background(), procEvent(c))
+	}
+	e.process(context.Background(), procEvent("ps"))
+
+	got := sink.detections()
+	if len(got) != 1 {
+		t.Fatalf("want one detection, got %d", len(got))
+	}
+	ev := got[0].Evidence
+	if len(ev) != 4 {
+		t.Fatalf("context window must be bounded to 4, got %d", len(ev))
+	}
+	if ev[len(ev)-1].Process.Comm != "ps" {
+		t.Fatalf("window must end with the trigger, got %q", ev[len(ev)-1].Process.Comm)
+	}
+}
+
+// TestEngineShedsClassesInDefinedOrderUnderLoad: sustained over-ceiling load sheds classes in the
+// defined order (file, network, process, privilege), records each, and stops the shed class being
+// evaluated. Shedding is reported, not silent.
+func TestEngineShedsClassesInDefinedOrderUnderLoad(t *testing.T) {
+	sensor, sink := newFakeSensor(), &fakeSink{}
+	e := newEngine(t, sensor, sink, Options{CPUCeilingPct: 50, Sampler: fixedSampler{pct: 90}})
+
+	// Four over-ceiling samples shed the four classes in order.
+	for i := 0; i < 5; i++ {
+		e.process(context.Background(), procEvent("bash"))
+	}
+	log := e.ShedLog()
+	want := []detection.Class{detection.ClassFile, detection.ClassNetwork, detection.ClassProcess, detection.ClassPrivilege}
+	if len(log) != len(want) {
+		t.Fatalf("want %d shed events, got %d: %+v", len(want), len(log), log)
+	}
+	for i, c := range want {
+		if log[i].Class != c {
+			t.Fatalf("shed order wrong at %d: got %s want %s", i, log[i].Class, c)
+		}
+		if log[i].CPUAtShed != 90 || log[i].CeilingPct != 50 {
+			t.Errorf("shed event must record the measured cpu and ceiling: %+v", log[i])
+		}
+	}
+
+	// A now-shed process class must not produce detections.
+	sinkBefore := len(sink.detections())
+	e.process(context.Background(), procEvent("ps"))
+	if len(sink.detections()) != sinkBefore {
+		t.Error("a shed class must not be evaluated into detections")
+	}
+}
+
+func TestEngineDoesNotShedWhenUnderCeiling(t *testing.T) {
+	sensor, sink := newFakeSensor(), &fakeSink{}
+	e := newEngine(t, sensor, sink, Options{CPUCeilingPct: 50, Sampler: fixedSampler{pct: 10}})
+	for i := 0; i < 10; i++ {
+		e.process(context.Background(), procEvent("ps"))
+	}
+	if len(e.ShedLog()) != 0 {
+		t.Fatalf("no shedding expected under the ceiling, got %+v", e.ShedLog())
+	}
+	if len(sink.detections()) != 10 {
+		t.Fatalf("every ps should have produced a detection, got %d", len(sink.detections()))
+	}
+}
+
+// TestEngineCoverageFoldsGapsShedAndDrops is the coverage-honesty end state: the engine's coverage
+// reflects the sensor's gaps, its own shedding, and back-pressure drops — a class not fully observed is
+// never reported as clean.
+func TestEngineCoverageFoldsSensorGapsShedAndDrops(t *testing.T) {
+	sensor, sink := newFakeSensor(), &fakeSink{}
+	sensor.coverage = []detection.ClassCoverage{
+		{Class: detection.ClassProcess, HostID: "host-1", State: detection.StateActive},
+		{Class: detection.ClassFile, HostID: "host-1", State: detection.StateFailed, Reason: "load failed"},
+		{Class: detection.ClassNetwork, HostID: "host-1", State: detection.StateActive},
+		{Class: detection.ClassPrivilege, HostID: "host-1", State: detection.StateActive},
+	}
+	sensor.dropped = map[detection.Class]uint64{detection.ClassNetwork: 7}
+	e := newEngine(t, sensor, sink, Options{CPUCeilingPct: 50, Sampler: fixedSampler{pct: 90}})
+
+	// Shed the first class (file) — but file is already failed at the sensor; shed the process class too
+	// by forcing two breaches.
+	e.process(context.Background(), procEvent("bash")) // sheds file
+	e.process(context.Background(), procEvent("bash")) // sheds network
+
+	cov := e.Coverage()
+	byClass := map[detection.Class]detection.ClassCoverage{}
+	for _, c := range cov {
+		byClass[c.Class] = c
+	}
+	// process: active (not shed, not dropped) — the only cleanly observed class.
+	if byClass[detection.ClassProcess].State != detection.StateActive {
+		t.Errorf("process should remain active: %+v", byClass[detection.ClassProcess])
+	}
+	// file: sensor-failed gap (shed overlays but the sensor state was already a gap; either way not clean).
+	if !byClass[detection.ClassFile].IsObservationGap() {
+		t.Errorf("file must be a gap: %+v", byClass[detection.ClassFile])
+	}
+	// network: shed by the engine → degraded gap (shed takes precedence over the drop annotation).
+	nw := byClass[detection.ClassNetwork]
+	if nw.State != detection.StateDegraded || !nw.IsObservationGap() {
+		t.Errorf("network was shed and must be a degraded gap: %+v", nw)
+	}
+	// Every class present; none silently clean.
+	if len(cov) != len(detection.Classes()) {
+		t.Fatalf("coverage must report every class, got %d", len(cov))
+	}
+}
+
+// TestEngineCountsEmitFailures: a confirmed detection the sink cannot record is not silently lost — it
+// is counted and folds the class into a degraded coverage state.
+func TestEngineCountsEmitFailures(t *testing.T) {
+	sensor := newFakeSensor()
+	sensor.coverage = []detection.ClassCoverage{{Class: detection.ClassProcess, HostID: "host-1", State: detection.StateActive}}
+	sink := &fakeSink{fail: true}
+	e := newEngine(t, sensor, sink, Options{Classes: []detection.Class{detection.ClassProcess}})
+
+	e.process(context.Background(), procEvent("ps")) // matches, but the sink fails
+
+	if len(sink.detections()) != 0 {
+		t.Fatal("the sink rejected the emit; nothing should be recorded")
+	}
+	cov := e.Coverage()
+	var proc detection.ClassCoverage
+	for _, c := range cov {
+		if c.Class == detection.ClassProcess {
+			proc = c
+		}
+	}
+	if proc.State != detection.StateDegraded || proc.IsObservationGap() != true {
+		t.Fatalf("a class whose detections cannot be recorded must be degraded, got %+v", proc)
+	}
+}
+
+// TestEngineRunIsSingleCall: Run refuses a second invocation rather than double-processing.
+func TestEngineRunIsSingleCall(t *testing.T) {
+	sensor, sink := newFakeSensor(), &fakeSink{}
+	e := newEngine(t, sensor, sink, Options{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- e.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+	if err := e.Run(context.Background()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a second Run must be refused with a validation error, got %v", err)
+	}
+}
+
+// TestEngineRunLoopProcessesThenStops drives the full Run loop with the fake sensor and a cancel.
+func TestEngineRunLoopProcessesThenStops(t *testing.T) {
+	sensor, sink := newFakeSensor(), &fakeSink{}
+	e := newEngine(t, sensor, sink, Options{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- e.Run(ctx) }()
+
+	sensor.events <- procEvent("ps", "-ef")
+	// Give the loop a moment, then close the stream to end Run.
+	deadline := time.After(2 * time.Second)
+	for {
+		if len(sink.detections()) > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("Run did not process the event")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	close(sensor.events)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after the stream closed")
+	}
+	_ = cancel
+	if !sensor.started {
+		t.Error("Run must start the sensor")
+	}
+}

--- a/internal/usecase/ports/detection.go
+++ b/internal/usecase/ports/detection.go
@@ -1,0 +1,35 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+)
+
+// DetectionSensor is the agent-side event source the detection engine consumes: a set of per-class eBPF
+// observers. The engine depends on THIS interface, not the concrete infrastructure sensor, so the
+// dependency points inward (usecase ← infrastructure) and the engine is testable with a fake source.
+//
+// The infrastructure implementation lives in internal/infrastructure/ebpf (Linux) with a non-Linux stub.
+type DetectionSensor interface {
+	// Start begins observation for the configured classes. It fails closed (error) when no class can be
+	// observed at all; a per-class failure is reported through Coverage, not this error.
+	Start(ctx context.Context) error
+	// Events streams decoded domain events from every active class until Close.
+	Events() <-chan detection.Event
+	// Coverage reports the per-class observation status — one entry per class, a gap for any class not
+	// actively observing (never a silent absence, never a clean host for an unobserved class).
+	Coverage() []detection.ClassCoverage
+	// Dropped reports observed-but-dropped events per class caused by back-pressure, so the engine can
+	// treat a class under pressure as degraded rather than fully observed.
+	Dropped() map[detection.Class]uint64
+	// Close detaches every observer and stops the streams. Idempotent.
+	Close() error
+}
+
+// DetectionSink receives the detections the engine confirms. Implemented by an adapter that ships them to
+// the control plane / seals them as evidence (issue #423). Kept narrow so the engine depends only on
+// "somewhere to emit a detection", not on how it is stored or transported.
+type DetectionSink interface {
+	Emit(ctx context.Context, d detection.Detection) error
+}


### PR DESCRIPTION
## What

Phase 3 (final) of #422: the **agent-side detection engine**, wired into the VM agent. Phase 1 shipped the pure domain (rules/events/coverage honesty), Phase 2 the host-wide eBPF sensor; this phase ties them together and runs them on the agent.

## Pieces

- **`internal/usecase/ports`** — `DetectionSensor` (Start/Events/Coverage/Dropped/Close) and `DetectionSink` (Emit). The engine depends on these interfaces, never the concrete eBPF sensor; the sensor asserts `DetectionSensor` on both build tags.
- **`internal/usecase/fleet/detect`** — the `Engine`: consumes the per-class event stream, evaluates the clean-room catalogue per class, and emits a detection with a **bounded context window** for every match. It is observe-only (matches typed rules, executes nothing). Under a CPU ceiling it **sheds whole classes in a defined order** (file → network → process → privilege; privilege last) via an injected `LoadSampler`, and **records each shed** (`ShedLog`) rather than dropping silently. Its `Coverage()` folds the sensor's gaps, its own shedding, and back-pressure drops into an honest per-class status — a class it is not fully evaluating is never reported clean.
- **`internal/infrastructure/detectsink`** — `FileSink`: append-only JSONL (0600), validating each detection before writing. The milestone-1 landing spot; shipping to the control plane + hash-chained evidence is #423.
- **`cmd/synapse-agent`** — composition-root wiring: `run()` starts the engine in a **background goroutine** (separate from the inventory cycle), gated by `-detect-classes` / `SYNAPSE_DETECT_CLASSES` (**off by default**) and `SYNAPSE_DETECT_CPU_CEIL_PCT`. Best-effort: any failure (non-Linux, no root, missing feature) logs and leaves the agent's normal work untouched. A one-shot coverage line logs which classes came up and which are gaps.

## Validated end-to-end on a real 6.1 kernel (under sudo)

`TestDetectionPipelineEndToEndOnKernel` wires the **real** eBPF sensor → engine → file sink (the exact agent composition) and confirms a real `ps` exec is captured, matched into `det.process_enumeration`, and written to the JSONL sink as a fully-attributed detection.

## Safety

Observe-only — the engine and sink execute nothing (golden rule 1); `os/exec` is test-only. Detection is opt-in and fails closed. Detection contents (process args, file paths) are never logged — they go only to the 0600 sink. Coverage honesty is preserved end-to-end.

## Reviews & verification

- Reviewed by `go-arch-reviewer` (dependency rule; engine↔ports; concurrency) and `security-auditor` (observe-only, coverage honesty, evidence integrity, fail-closed).
- `go build ./...` (darwin + linux cross), `go vet`, `gofmt` clean, `go test -race` on the detect/sink/agent packages, plus the on-kernel integration test above. CI stays disabled per repo config.

With this, #422 is complete across all three phases (domain #501, sensor #503, engine — this PR).
