### PR TITLE
feat(blueteam): detections as hash-chained, attributable evidence (#423)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -122,6 +122,7 @@ import (
 	findingsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findings"
 	clusterinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/clusterinventory"
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
+	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
 	hostinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/hostinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetrolloutuc"
@@ -211,6 +212,7 @@ func main() {
 	var aiTriageReviewStore ports.AITriageReviewStore
 	var importedSBOMStore ports.ImportedSBOMStore
 	var importedFindingStore ports.ImportedFindingStore // third-party (SARIF) findings under governance
+	var detectionRecordStore ports.DetectionRecordStore // #423 detection ledger projection
 	var scanJobStore ports.ScanJobStore
 	var scanRunStore ports.ScanRunStore
 	var projectAnalysisStore ports.ProjectAnalysisStore
@@ -313,6 +315,7 @@ func main() {
 		aiTriageReviewStore = postgres.NewAITriageReviewRepository(pool)
 		importedSBOMStore = postgres.NewImportedSBOMStore(pool)
 		importedFindingStore = postgres.NewImportedFindingRepository(pool)
+		detectionRecordStore = postgres.NewDetectionRecordRepository(pool)
 		scanJobStore = postgres.NewScanJobStore(pool)
 		scanRunStore = postgres.NewScanRunStore(pool)
 		projectAnalysisStore = postgres.NewProjectAnalysisStore(pool)
@@ -377,6 +380,7 @@ func main() {
 		aiTriageReviewStore = memory.NewAITriageReviewStore()
 		importedSBOMStore = memory.NewImportedSBOMStore()
 		importedFindingStore = memory.NewImportedFindingStore()
+		detectionRecordStore = memory.NewDetectionRecordStore()
 		scanJobStore = memory.NewScanJobStore()
 		scanRunStore = memory.NewScanRunStore()
 		projectAnalysisStore = memory.NewProjectAnalysisStore()
@@ -1208,6 +1212,16 @@ func main() {
 		}
 		router.SetSARIFIngest(sarifSvc)
 		router.SetImportedFindings(importedFindingStore)
+		// #423 detection ledger read routes. The write/ingest path (Service.Ingest → seal into the
+		// evidence chain) plugs the same detectionRecordStore into detectledger.NewService once the
+		// agent→control-plane batch transport + agent signing-key resolver land; the read surface is live
+		// now so a detection is queryable and tenant-scoped through the same chokepoint.
+		if detectionReader, drerr := detectledger.NewReader(detectionRecordStore); drerr != nil {
+			log.Error("detection ledger reader init failed", "err", drerr)
+			os.Exit(1)
+		} else {
+			router.SetDetectionReader(detectionReader)
+		}
 		// The ingest writes an append-only audit entry asserting that N external results entered an
 		// engagement. Without Postgres those rows live only in this process, so the banner says so
 		// rather than letting the audit trail imply a durability the deployment does not have.

--- a/internal/adapter/httpapi/detection_handler.go
+++ b/internal/adapter/httpapi/detection_handler.go
@@ -1,0 +1,52 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// detectionReader is the narrow read side the HTTP layer needs for the detection ledger (#423): the
+// engagement's chained detections and their incident rollup. *detectledger.Service satisfies it. Reads
+// are tenant-gated by withEngTenant + the store's RLS, so a cross-tenant read returns nothing.
+type detectionReader interface {
+	ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error)
+	Incidents(ctx context.Context, engagementID shared.ID) ([]detection.Incident, error)
+}
+
+// SetDetectionReader wires the detection read routes (#423). Left unset, the routes report an empty
+// ledger rather than 500 — the feature is simply not enabled.
+func (rt *Router) SetDetectionReader(r detectionReader) {
+	if r != nil {
+		rt.detections = r
+	}
+}
+
+// listDetections returns the engagement's chained detections, or — with ?view=incidents — the incident
+// rollup over them (the individual detections remain the ledger underneath). PermView + withEngTenant;
+// a cross-tenant engagement is already a 404 before this runs.
+func (rt *Router) listDetections(w http.ResponseWriter, r *http.Request) {
+	engID := shared.ID(r.PathValue("id"))
+	if rt.detections == nil {
+		// Not wired: an empty, honest answer (not a 500), consistent with the read being optional.
+		writeJSON(w, http.StatusOK, map[string]any{"detections": []detection.Record{}})
+		return
+	}
+	if r.URL.Query().Get("view") == "incidents" {
+		inc, err := rt.detections.Incidents(r.Context(), engID)
+		if err != nil {
+			writeError(w, rt.log, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"incidents": inc})
+		return
+	}
+	recs, err := rt.detections.ListDetections(r.Context(), engID)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"detections": recs})
+}

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	ap "github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetcoverage"
@@ -112,6 +113,26 @@ func (harnessRollout) Resume(context.Context, shared.ID, string, shared.ID) (*fl
 type harnessImportedFindings struct{}
 
 func (harnessImportedFindings) ListByEngagement(context.Context, shared.ID, shared.ID) ([]importedfinding.ImportedFinding, error) {
+	return nil, nil
+}
+
+// harnessDetections is the #423 detection-ledger read side: it returns one tenant-A detection carrying a
+// marker asset, so the harness proves a cross-tenant read (blocked by withEngTenant → 404) never reaches
+// it, while a same-tenant read does.
+type harnessDetections struct{}
+
+func (harnessDetections) ListDetections(_ context.Context, engagementID shared.ID) ([]detection.Record, error) {
+	r, _ := detection.Lookup("det.process_enumeration")
+	ev := detection.Event{Class: detection.ClassProcess, At: time.Unix(1, 0), Host: "host-A",
+		Process: &detection.ProcessEvent{PID: 1, Comm: "ps", Path: "/usr/bin/ps"}}
+	d, _ := detection.NewDetection(r, "host-A", "agent:A", []detection.Event{ev}, time.Unix(500, 0))
+	return []detection.Record{{
+		ID: "det-A", TenantID: "tenantA", EngagementID: engagementID, AssetID: "asset-A", AgentID: "agent:A",
+		Detection: d, EvidenceID: "ev-A", BatchSeq: 1, RecordedAt: time.Unix(1000, 0),
+	}}, nil
+}
+
+func (harnessDetections) Incidents(_ context.Context, _ shared.ID) ([]detection.Incident, error) {
 	return nil, nil
 }
 
@@ -264,6 +285,7 @@ func TestHostileHarness(t *testing.T) {
 	rt.SetAttackPaths(attackSvc)              // real #419 service proves cross-tenant derived data isolation
 	rt.SetSARIFIngest(harnessSARIF{})         // register the #415 import route so the harness guards its operate/tenant gates
 	rt.SetImportedFindings(harnessImportedFindings{})
+	rt.SetDetectionReader(harnessDetections{}) // register the #423 detection-ledger read route
 	rt.SetFleetRolloutAdmin(harnessRollout{})
 	rt.EnableAgent(nil, nil, nil, nil, nil, 1, 8)
 	mux := rt.routes()
@@ -390,6 +412,9 @@ func TestHostileHarness(t *testing.T) {
 		{"readonly may read imported findings (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/imported-findings", http.StatusOK},
 		{"cross-tenant imported-finding read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/imported-findings", http.StatusNotFound},
 		{"principal-less imported-finding read is denied", "", "", false, http.MethodGet, "/api/v1/engagements/engA/imported-findings", http.StatusForbidden},
+		{"readonly may read detections (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/detections", http.StatusOK},
+		{"cross-tenant detection read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/detections", http.StatusNotFound},
+		{"principal-less detection read is denied", "", "", false, http.MethodGet, "/api/v1/engagements/engA/detections", http.StatusForbidden},
 		// Fleet coverage (#413, PermView): machine roles denied; readonly may read; cross-tenant agent
 		// detail is 404 (never an existence-revealing 403). The cross-tenant LIST emptiness (a 200 that
 		// leaks nothing) is asserted on the body just below the table.
@@ -413,6 +438,15 @@ func TestHostileHarness(t *testing.T) {
 	if code, body := send("readonly", "tenantA", http.MethodGet, "/api/v1/attack-paths", true); code != http.StatusOK || !strings.Contains(body, "tenant-A-secret-marker") {
 		t.Fatalf("tenantA must see its own attack path marker (code=%d body=%s)", code, body)
 	}
+	// #423 detection ledger: tenantA sees its own detection (asset-A marker); a cross-tenant read of the
+	// engagement-scoped route returns NOTHING (404 via withEngTenant), so tenantA's marker can never leak.
+	if code, body := send("readonly", "tenantA", http.MethodGet, "/api/v1/engagements/engA/detections", true); code != http.StatusOK || !strings.Contains(body, "asset-A") {
+		t.Fatalf("tenantA must see its own detections (code=%d body=%s)", code, body)
+	}
+	if code, body := send("consultant", "tenantB", http.MethodGet, "/api/v1/engagements/engA/detections", true); code != http.StatusNotFound || strings.Contains(body, "asset-A") {
+		t.Errorf("cross-tenant detection read must be 404 with no tenantA data (code=%d body=%s)", code, body)
+	}
+
 	if code, body := send("readonly", "tenantB", http.MethodGet, "/api/v1/attack-paths", true); code != http.StatusOK || strings.Contains(body, "tenant-A-secret-marker") {
 		t.Errorf("tenantB attack paths leaked tenantA data (code=%d body=%s)", code, body)
 	}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -70,6 +70,7 @@ type Router struct {
 	importedFindings  sarifReader           // optional read side for imported findings
 	fleetRolloutAdmin fleetRolloutService   // optional; nil ⇒ the operator rollout routes are not served
 	offensiveHalt     offensiveKillSwitch   // optional; nil ⇒ the red-team halt route is not served
+	detections        detectionReader       // optional read side for the detection ledger (#423)
 	fleet             *fleetRouter          // optional; nil ⇒ agent transport plane is not served
 	fleetAdmin        fleetAdminService     // optional; nil ⇒ operator agent-admin routes not registered
 	qualityGates      qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
@@ -366,6 +367,7 @@ func (rt *Router) routes() *http.ServeMux {
 		// it is: every row carries its provenance and states that it is external and cannot promote
 		// itself, rather than the governance claim being made by a method nothing calls.
 		mux.HandleFunc("GET /api/v1/engagements/{id}/imported-findings", rt.authz(userdom.PermView, rt.withEngTenant(rt.listImportedFindings)))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/detections", rt.authz(userdom.PermView, rt.withEngTenant(rt.listDetections)))
 	}
 	mux.HandleFunc("GET /api/v1/engagements/{id}/scan", rt.authz(userdom.PermView, rt.withEngTenant(rt.latestScan)))
 	mux.HandleFunc("GET /api/v1/engagements/{id}/scan-status", rt.authz(userdom.PermView, rt.withEngTenant(rt.scanStatus)))

--- a/internal/domain/detection/record.go
+++ b/internal/domain/detection/record.go
@@ -1,0 +1,107 @@
+package detection
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Record is a detection as it lives in the control-plane ledger (#423): the detection itself, bound to
+// the evidence-chain link that sealed it, the asset it was observed on, the agent that produced it, and
+// the agent batch sequence it arrived in. The evidence-chain link is the tamper-evident ledger; this
+// Record is the queryable projection over it (and the one subject to retention — the chain link is
+// permanent, this row is not).
+type Record struct {
+	ID           shared.ID
+	TenantID     shared.ID
+	EngagementID shared.ID
+	AssetID      shared.ID // the asset the detection was observed on, so it joins the asset risk story
+	AgentID      shared.ID
+	Detection    Detection
+	EvidenceID   shared.ID // the evidence-chain link that sealed this detection
+	BatchSeq     uint64    // the agent batch sequence it arrived in
+	RecordedAt   time.Time
+	ExpiresAt    time.Time // zero = never expires; a set value is enforced by audited retention
+}
+
+// Validate enforces the binding invariants: a record with no evidence link, asset, tenant, or a
+// malformed detection is not a chained, attributable record and must not be stored.
+func (r Record) Validate() error {
+	if r.ID == "" {
+		return fmt.Errorf("%w: detection record has no id", shared.ErrValidation)
+	}
+	if r.TenantID == "" || r.EngagementID == "" {
+		return fmt.Errorf("%w: detection record %s is missing tenant/engagement scope", shared.ErrValidation, r.ID)
+	}
+	if r.AssetID == "" {
+		return fmt.Errorf("%w: detection record %s must reference the asset it was observed on", shared.ErrValidation, r.ID)
+	}
+	if r.EvidenceID == "" {
+		return fmt.Errorf("%w: detection record %s must reference its evidence-chain link", shared.ErrValidation, r.ID)
+	}
+	if r.AgentID == "" {
+		return fmt.Errorf("%w: detection record %s has no agent attribution", shared.ErrValidation, r.ID)
+	}
+	if err := r.Detection.Validate(); err != nil {
+		return fmt.Errorf("detection record %s: %w", r.ID, err)
+	}
+	return nil
+}
+
+// Expired reports whether the record's retention window has elapsed at now. A zero ExpiresAt never
+// expires. Expiry removes the projection row (an audited action); the sealed chain link remains.
+func (r Record) Expired(now time.Time) bool {
+	return !r.ExpiresAt.IsZero() && !now.Before(r.ExpiresAt)
+}
+
+// Incident is an incident-level rollup of repeated detections of the same rule on the same asset. It is
+// a VIEW: it never replaces the underlying records, which remain the ledger. DetectionIDs lists every
+// record folded in, so an auditor can always descend from the incident to the individual, attributable,
+// hash-chained detections beneath it.
+type Incident struct {
+	Key          string // stable dedup key: rule + asset
+	RuleID       string
+	AssetID      shared.ID
+	Severity     shared.Severity // the most severe among the folded detections
+	Count        int
+	First        time.Time
+	Last         time.Time
+	DetectionIDs []shared.ID // the underlying records, preserved
+}
+
+// Rollup folds records into incidents by (rule, asset), preserving every underlying record id. The
+// result is deterministically ordered (by key) so an incident view and its trend compare across runs.
+// It is a pure projection — it neither drops nor mutates the records it summarises.
+func Rollup(records []Record) []Incident {
+	byKey := map[string]*Incident{}
+	var order []string
+	for _, r := range records {
+		key := r.Detection.RuleID + "\x00" + r.AssetID.String()
+		inc, ok := byKey[key]
+		if !ok {
+			inc = &Incident{Key: key, RuleID: r.Detection.RuleID, AssetID: r.AssetID,
+				Severity: r.Detection.Severity, First: r.Detection.Observed, Last: r.Detection.Observed}
+			byKey[key] = inc
+			order = append(order, key)
+		}
+		inc.Count++
+		inc.DetectionIDs = append(inc.DetectionIDs, r.ID)
+		if shared.SeverityRank(r.Detection.Severity) > shared.SeverityRank(inc.Severity) {
+			inc.Severity = r.Detection.Severity
+		}
+		if r.Detection.Observed.Before(inc.First) {
+			inc.First = r.Detection.Observed
+		}
+		if r.Detection.Observed.After(inc.Last) {
+			inc.Last = r.Detection.Observed
+		}
+	}
+	sort.Strings(order)
+	out := make([]Incident, 0, len(order))
+	for _, k := range order {
+		out = append(out, *byKey[k])
+	}
+	return out
+}

--- a/internal/domain/detection/record_test.go
+++ b/internal/domain/detection/record_test.go
@@ -1,0 +1,108 @@
+package detection
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func recDetection(t *testing.T, comm string) Detection {
+	t.Helper()
+	r, ok := Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("expected det.process_enumeration")
+	}
+	ev := Event{Class: ClassProcess, At: time.Unix(1, 0), Host: "h", Process: &ProcessEvent{PID: 1, Comm: comm, Path: "/usr/bin/" + comm}}
+	d, err := NewDetection(r, "host-1", "agent:1", []Event{ev}, time.Unix(1000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func validRecord(t *testing.T) Record {
+	t.Helper()
+	return Record{
+		ID: "rec-1", TenantID: "t1", EngagementID: "e1", AssetID: "asset-1", AgentID: "agent:1",
+		Detection: recDetection(t, "ps"), EvidenceID: "ev-1", BatchSeq: 1, RecordedAt: time.Unix(1000, 0),
+	}
+}
+
+func TestRecordValidate(t *testing.T) {
+	good := validRecord(t)
+	if err := good.Validate(); err != nil {
+		t.Fatalf("a well-formed record must validate: %v", err)
+	}
+	mut := map[string]func(*Record){
+		"no id":         func(r *Record) { r.ID = "" },
+		"no tenant":     func(r *Record) { r.TenantID = "" },
+		"no engagement": func(r *Record) { r.EngagementID = "" },
+		"no asset":      func(r *Record) { r.AssetID = "" },
+		"no evidence":   func(r *Record) { r.EvidenceID = "" },
+		"no agent":      func(r *Record) { r.AgentID = "" },
+	}
+	for name, m := range mut {
+		t.Run(name, func(t *testing.T) {
+			r := validRecord(t)
+			m(&r)
+			if err := r.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRecordExpired(t *testing.T) {
+	r := validRecord(t)
+	if r.Expired(time.Unix(9999, 0)) {
+		t.Error("a record with no ExpiresAt must never expire")
+	}
+	r.ExpiresAt = time.Unix(2000, 0)
+	if r.Expired(time.Unix(1999, 0)) {
+		t.Error("not yet at the cutoff")
+	}
+	if !r.Expired(time.Unix(2000, 0)) {
+		t.Error("at the cutoff it is expired")
+	}
+}
+
+// TestRollupPreservesUnderlyingDetections is #423 requirement 6: the incident rollup dedups repeated
+// detections but never loses the individual attributable records beneath it.
+func TestRollupPreservesUnderlyingDetections(t *testing.T) {
+	mk := func(id, asset, comm string, sev shared.Severity, at time.Time) Record {
+		d := recDetection(t, comm)
+		d.Severity = sev
+		d.Observed = at
+		return Record{ID: shared.ID(id), TenantID: "t1", EngagementID: "e1", AssetID: shared.ID(asset),
+			AgentID: "agent:1", Detection: d, EvidenceID: shared.ID("ev-" + id), BatchSeq: 1, RecordedAt: at}
+	}
+	// Two detections of the same rule on asset-A (fold into one incident), one on asset-B.
+	recs := []Record{
+		mk("r1", "asset-A", "ps", shared.SeverityLow, time.Unix(100, 0)),
+		mk("r2", "asset-A", "ps", shared.SeverityHigh, time.Unix(300, 0)),
+		mk("r3", "asset-B", "ps", shared.SeverityLow, time.Unix(200, 0)),
+	}
+	inc := Rollup(recs)
+	if len(inc) != 2 {
+		t.Fatalf("want 2 incidents (asset-A folded, asset-B separate), got %d", len(inc))
+	}
+	// Deterministic order by key (rule+asset): asset-A before asset-B.
+	a := inc[0]
+	if a.AssetID != "asset-A" || a.Count != 2 {
+		t.Fatalf("asset-A incident wrong: %+v", a)
+	}
+	if len(a.DetectionIDs) != 2 || a.DetectionIDs[0] != "r1" || a.DetectionIDs[1] != "r2" {
+		t.Fatalf("underlying detections must be preserved: %v", a.DetectionIDs)
+	}
+	if a.Severity != shared.SeverityHigh {
+		t.Fatalf("incident severity must be the max of its members, got %s", a.Severity)
+	}
+	if !a.First.Equal(time.Unix(100, 0)) || !a.Last.Equal(time.Unix(300, 0)) {
+		t.Fatalf("incident first/last wrong: %v..%v", a.First, a.Last)
+	}
+	if inc[1].AssetID != "asset-B" || inc[1].Count != 1 {
+		t.Fatalf("asset-B incident wrong: %+v", inc[1])
+	}
+}

--- a/internal/domain/fleetagent/batch.go
+++ b/internal/domain/fleetagent/batch.go
@@ -1,0 +1,158 @@
+package fleetagent
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ErrBadBatchSignature is returned when an agent detection batch's signature does not verify.
+var ErrBadBatchSignature = errors.New("detection batch signature invalid")
+
+// batchContext is the domain-separation tag for a detection-batch signature, mirroring the evidence /
+// audit attestation tags: the same agent key might sign other things, so the signed bytes are prefixed
+// with a per-purpose tag and a version so a batch signature can never be replayed as anything else.
+const batchContext = "synapse-detection-batch:v1"
+
+const batchSep = "\x1e"
+
+// DetectionRef binds a detection id to a digest of its content, so the batch signature covers WHAT each
+// detection is, not merely its id. ContentSHA256 is the hex sha256 the agent computed over the exact
+// bytes it is shipping (see DetectionContentHash); the control plane recomputes it and refuses a
+// mismatch, so a transport that swaps a detection's body for a known id is rejected before sealing.
+type DetectionRef struct {
+	ID            shared.ID
+	ContentSHA256 string
+}
+
+// AgentBatch is a sequenced, signed set of detections an agent shipped to the control plane (#423). The
+// sequence is monotonic PER AGENT, so a gap in the sequence is a detectable potential loss rather than a
+// silently-missing batch. The signature is over the batch's canonical membership (id AND content digest)
+// AND its sequence, so neither the membership, the ordinal, nor a detection's CONTENT can be altered
+// without breaking it.
+type AgentBatch struct {
+	AgentID      shared.ID
+	EngagementID shared.ID
+	Sequence     uint64
+	Signature    string // base64 ed25519 over BatchMessage
+	Detections   []DetectionRef
+}
+
+// DetectionContentHash is the shared digest both the agent and the control plane compute over a
+// detection's shipped bytes plus the asset it was observed on, so the two sides agree on what the
+// signature binds. Keeping it here (domain) means there is one definition, not two that can drift.
+func DetectionContentHash(content []byte, assetID shared.ID) string {
+	h := sha256.New()
+	h.Write(content)
+	h.Write([]byte(batchSep))
+	h.Write([]byte(assetID.String()))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Validate checks a batch is well-formed. An empty batch, or one missing its agent/engagement/sequence,
+// or a ref missing its id or content digest, cannot be sequenced/attributed/tamper-checked and is refused.
+func (b AgentBatch) Validate() error {
+	if b.AgentID == "" {
+		return fmt.Errorf("%w: batch has no agent id", shared.ErrValidation)
+	}
+	if b.EngagementID == "" {
+		return fmt.Errorf("%w: batch has no engagement id", shared.ErrValidation)
+	}
+	if b.Sequence == 0 {
+		return fmt.Errorf("%w: batch sequence must be >= 1 (0 is reserved for 'no batch yet')", shared.ErrValidation)
+	}
+	if len(b.Detections) == 0 {
+		return fmt.Errorf("%w: batch carries no detections", shared.ErrValidation)
+	}
+	for i, ref := range b.Detections {
+		if ref.ID == "" {
+			return fmt.Errorf("%w: batch detection[%d] has no id", shared.ErrValidation, i)
+		}
+		if ref.ContentSHA256 == "" {
+			return fmt.Errorf("%w: batch detection[%d] has no content digest", shared.ErrValidation, i)
+		}
+	}
+	return nil
+}
+
+// IDs returns the detection ids in the batch, for callers that only need the membership.
+func (b AgentBatch) IDs() []shared.ID {
+	out := make([]shared.ID, len(b.Detections))
+	for i, ref := range b.Detections {
+		out[i] = ref.ID
+	}
+	return out
+}
+
+// BatchMessage is the canonical byte string a batch signature covers: the context tag, agent,
+// engagement, sequence, and the SORTED (id, content-digest) refs — so membership is order-independent
+// but complete, and each detection's content is bound. It is a sha256 digest of those fields, separated
+// so field boundaries cannot collide.
+func BatchMessage(b AgentBatch) []byte {
+	refs := append([]DetectionRef(nil), b.Detections...)
+	sort.Slice(refs, func(i, j int) bool { return refs[i].ID < refs[j].ID })
+	h := sha256.New()
+	write := func(s string) { h.Write([]byte(s)); h.Write([]byte(batchSep)) }
+	write(batchContext)
+	write(b.AgentID.String())
+	write(b.EngagementID.String())
+	write(strconv.FormatUint(b.Sequence, 10))
+	for _, ref := range refs {
+		write(ref.ID.String())
+		write(ref.ContentSHA256)
+	}
+	return h.Sum(nil)
+}
+
+// SignBatch produces the base64 ed25519 signature for a batch. Agents sign with the private half of the
+// key whose public half the control plane knows from enrolment (#408).
+func SignBatch(priv ed25519.PrivateKey, b AgentBatch) string {
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(priv, BatchMessage(b)))
+}
+
+// VerifyBatch checks the batch signature against the agent's public key. A batch that does not verify is
+// refused before any of its detections are sealed — an unsigned or forged batch must never enter the
+// evidence chain.
+func VerifyBatch(pub ed25519.PublicKey, b AgentBatch) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: bad public key size", ErrBadBatchSignature)
+	}
+	sig, err := base64.StdEncoding.DecodeString(b.Signature)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("%w: malformed signature", ErrBadBatchSignature)
+	}
+	if !ed25519.Verify(pub, BatchMessage(b), sig) {
+		return ErrBadBatchSignature
+	}
+	return nil
+}
+
+// SequenceGap describes what an incoming batch sequence implies against the last one seen for an agent.
+type SequenceGap struct {
+	// Missing is how many batches are unaccounted for between the last seen and this one. > 0 means a
+	// potential loss the caller must surface (a batch_gap coverage event), never silently accept.
+	Missing uint64
+	// Replay is true when the incoming sequence is not ahead of the last seen (duplicate or out-of-order),
+	// which is also suspicious and must be reported rather than double-counted.
+	Replay bool
+}
+
+// HasGap reports whether this sequence transition is anything other than the expected next-in-line.
+func (g SequenceGap) HasGap() bool { return g.Missing > 0 || g.Replay }
+
+// DetectSequenceGap compares an incoming batch sequence against the last sequence recorded for that
+// agent (0 = none yet). The expected next sequence is lastSeen+1; anything higher leaves a gap, anything
+// not higher is a replay/out-of-order.
+func DetectSequenceGap(lastSeen, incoming uint64) SequenceGap {
+	if incoming <= lastSeen {
+		return SequenceGap{Replay: true}
+	}
+	return SequenceGap{Missing: incoming - lastSeen - 1}
+}

--- a/internal/domain/fleetagent/batch_test.go
+++ b/internal/domain/fleetagent/batch_test.go
@@ -1,0 +1,118 @@
+package fleetagent
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func sampleBatch() AgentBatch {
+	return AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 3,
+		Detections: []DetectionRef{
+			{ID: "d3", ContentSHA256: "h3"}, {ID: "d1", ContentSHA256: "h1"}, {ID: "d2", ContentSHA256: "h2"},
+		}}
+}
+
+func TestSignVerifyBatchRoundTrip(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	b := sampleBatch()
+	b.Signature = SignBatch(priv, b)
+	if err := VerifyBatch(pub, b); err != nil {
+		t.Fatalf("a validly signed batch must verify: %v", err)
+	}
+}
+
+func TestVerifyBatchRejectsTamper(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	b := sampleBatch()
+	b.Signature = SignBatch(priv, b)
+
+	// Altering membership, a content digest, the sequence, or the engagement must break the signature.
+	tampers := map[string]func(*AgentBatch){
+		"add detection":   func(x *AgentBatch) { x.Detections = append(x.Detections, DetectionRef{ID: "d4", ContentSHA256: "h4"}) },
+		"drop detection":  func(x *AgentBatch) { x.Detections = x.Detections[:2] },
+		"swap content":    func(x *AgentBatch) { x.Detections[0].ContentSHA256 = "tampered" },
+		"bump sequence":   func(x *AgentBatch) { x.Sequence = 4 },
+		"swap engagement": func(x *AgentBatch) { x.EngagementID = "eng-2" },
+		"swap agent":      func(x *AgentBatch) { x.AgentID = "agent:2" },
+	}
+	for name, tamper := range tampers {
+		t.Run(name, func(t *testing.T) {
+			bad := b
+			bad.Detections = append([]DetectionRef(nil), b.Detections...)
+			tamper(&bad)
+			if err := VerifyBatch(pub, bad); !errors.Is(err, ErrBadBatchSignature) {
+				t.Fatalf("tampered batch must fail verification, got %v", err)
+			}
+		})
+	}
+}
+
+func TestVerifyBatchIsOrderIndependent(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	b := sampleBatch()
+	b.Signature = SignBatch(priv, b)
+	// Reorder the refs: the signature is over the SORTED set, so membership order must not matter.
+	b.Detections = []DetectionRef{{ID: "d1", ContentSHA256: "h1"}, {ID: "d2", ContentSHA256: "h2"}, {ID: "d3", ContentSHA256: "h3"}}
+	if err := VerifyBatch(pub, b); err != nil {
+		t.Fatalf("reordering the same membership must still verify: %v", err)
+	}
+}
+
+func TestVerifyBatchRejectsMalformed(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	b := sampleBatch()
+	b.Signature = "not-base64!!"
+	if err := VerifyBatch(pub, b); !errors.Is(err, ErrBadBatchSignature) {
+		t.Fatalf("a malformed signature must be rejected, got %v", err)
+	}
+	if err := VerifyBatch(ed25519.PublicKey{1, 2, 3}, b); !errors.Is(err, ErrBadBatchSignature) {
+		t.Fatalf("a bad-size public key must be rejected, got %v", err)
+	}
+}
+
+func TestBatchValidate(t *testing.T) {
+	ref := []DetectionRef{{ID: "d", ContentSHA256: "h"}}
+	cases := map[string]AgentBatch{
+		"no agent":      {EngagementID: "e", Sequence: 1, Detections: ref},
+		"no engagement": {AgentID: "a", Sequence: 1, Detections: ref},
+		"zero sequence": {AgentID: "a", EngagementID: "e", Sequence: 0, Detections: ref},
+		"no detections": {AgentID: "a", EngagementID: "e", Sequence: 1},
+		"empty id":      {AgentID: "a", EngagementID: "e", Sequence: 1, Detections: []DetectionRef{{ContentSHA256: "h"}}},
+		"empty content": {AgentID: "a", EngagementID: "e", Sequence: 1, Detections: []DetectionRef{{ID: "d"}}},
+	}
+	for name, b := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := b.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+	if err := sampleBatch().Validate(); err != nil {
+		t.Fatalf("a well-formed batch must validate: %v", err)
+	}
+}
+
+func TestDetectSequenceGap(t *testing.T) {
+	// Expected next in line: no gap, no replay.
+	if g := DetectSequenceGap(2, 3); g.HasGap() {
+		t.Errorf("3 after 2 is the expected next, got %+v", g)
+	}
+	// First ever batch (last = 0, incoming = 1): no gap.
+	if g := DetectSequenceGap(0, 1); g.HasGap() {
+		t.Errorf("first batch must not be a gap, got %+v", g)
+	}
+	// Forward gap: 5 after 2 leaves 3 and 4 missing.
+	if g := DetectSequenceGap(2, 5); g.Missing != 2 || g.Replay {
+		t.Errorf("want 2 missing, got %+v", g)
+	}
+	// Replay / out-of-order: incoming not ahead.
+	if g := DetectSequenceGap(5, 5); !g.Replay {
+		t.Errorf("equal sequence is a replay, got %+v", g)
+	}
+	if g := DetectSequenceGap(5, 3); !g.Replay {
+		t.Errorf("lower sequence is out-of-order, got %+v", g)
+	}
+}

--- a/internal/infrastructure/persistence/memory/detection_record_store.go
+++ b/internal/infrastructure/persistence/memory/detection_record_store.go
@@ -1,0 +1,126 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// DetectionRecordStore is the in-memory detection-ledger projection used inline/in dev. Records are
+// bucketed per tenant, so a read under one tenant can never observe another's — the same isolation the
+// Postgres store gets from RLS. It keeps deep copies so a caller mutating a returned record cannot
+// corrupt stored state.
+type DetectionRecordStore struct {
+	mu       sync.Mutex
+	byTenant map[shared.ID]map[shared.ID]detection.Record // tenant -> record id -> record
+	now      func() time.Time
+}
+
+var _ ports.DetectionRecordStore = (*DetectionRecordStore)(nil)
+
+// NewDetectionRecordStore constructs the store.
+func NewDetectionRecordStore() *DetectionRecordStore {
+	return &DetectionRecordStore{byTenant: map[shared.ID]map[shared.ID]detection.Record{}, now: func() time.Time { return time.Now().UTC() }}
+}
+
+// SetClock overrides the store's clock (tests only), so expiry-on-read is deterministic.
+func (s *DetectionRecordStore) SetClock(now func() time.Time) { s.now = now }
+
+// AppendDetection stores one record, idempotent on its id, under the ctx tenant.
+func (s *DetectionRecordStore) AppendDetection(ctx context.Context, r detection.Record) error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+	tenant := shared.TenantOrDefault(r.TenantID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.byTenant[tenant] == nil {
+		s.byTenant[tenant] = map[shared.ID]detection.Record{}
+	}
+	s.byTenant[tenant][r.ID] = cloneRecord(r)
+	return nil
+}
+
+// ListDetections returns the non-expired records for an engagement under the ctx tenant, oldest first.
+func (s *DetectionRecordStore) ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error) {
+	tenant := shared.TenantOrDefault(tenantFromCtx(ctx))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	var out []detection.Record
+	for _, r := range s.byTenant[tenant] {
+		// Hide expired rows, mirroring the Postgres store's `expires_at IS NULL OR expires_at > now()`
+		// predicate, so both backends return the same non-expired projection.
+		if r.EngagementID == engagementID && !r.Expired(now) {
+			out = append(out, cloneRecord(r))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].RecordedAt.Equal(out[j].RecordedAt) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].RecordedAt.Before(out[j].RecordedAt)
+	})
+	return out, nil
+}
+
+// HasDetection reports whether a record with this id already exists under the ctx tenant, so ingest can
+// skip an already-sealed detection on a retry (idempotent resume) rather than sealing it twice.
+func (s *DetectionRecordStore) HasDetection(ctx context.Context, id shared.ID) (bool, error) {
+	tenant := shared.TenantOrDefault(tenantFromCtx(ctx))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.byTenant[tenant][id]
+	return ok, nil
+}
+
+// LastBatchSequence returns the highest batch sequence recorded for an agent under the ctx tenant.
+func (s *DetectionRecordStore) LastBatchSequence(ctx context.Context, agentID shared.ID) (uint64, error) {
+	tenant := shared.TenantOrDefault(tenantFromCtx(ctx))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var highest uint64
+	for _, r := range s.byTenant[tenant] {
+		if r.AgentID == agentID && r.BatchSeq > highest {
+			highest = r.BatchSeq
+		}
+	}
+	return highest, nil
+}
+
+// ExpireDetections removes the engagement's records whose ExpiresAt has elapsed at cutoff and returns
+// their ids. Records with no expiry set are never removed.
+func (s *DetectionRecordStore) ExpireDetections(ctx context.Context, engagementID shared.ID, cutoff time.Time) ([]shared.ID, error) {
+	tenant := shared.TenantOrDefault(tenantFromCtx(ctx))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var expired []shared.ID
+	for id, r := range s.byTenant[tenant] {
+		if r.EngagementID == engagementID && r.Expired(cutoff) {
+			expired = append(expired, id)
+			delete(s.byTenant[tenant], id)
+		}
+	}
+	sort.Slice(expired, func(i, j int) bool { return expired[i] < expired[j] })
+	return expired, nil
+}
+
+func cloneRecord(r detection.Record) detection.Record {
+	cp := r
+	cp.Detection.Evidence = append([]detection.Event(nil), r.Detection.Evidence...)
+	return cp
+}
+
+// tenantFromCtx resolves the tenant for a read; a missing tenant maps to the default bucket (the same
+// default the write path uses), keeping reads and writes consistent in the in-memory twin.
+func tenantFromCtx(ctx context.Context) shared.ID {
+	if t, ok := shared.TenantFrom(ctx); ok {
+		return t
+	}
+	return ""
+}

--- a/internal/infrastructure/persistence/memory/detection_record_store_test.go
+++ b/internal/infrastructure/persistence/memory/detection_record_store_test.go
@@ -1,0 +1,104 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func drDetection(t *testing.T) detection.Detection {
+	t.Helper()
+	r, ok := detection.Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("expected det.process_enumeration")
+	}
+	ev := detection.Event{Class: detection.ClassProcess, At: time.Unix(1, 0), Host: "h",
+		Process: &detection.ProcessEvent{PID: 1, Comm: "ps", Path: "/usr/bin/ps"}}
+	d, err := detection.NewDetection(r, "host-1", "agent:1", []detection.Event{ev}, time.Unix(500, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func drRecord(t *testing.T, id, tenant, eng, agent string, seq uint64, exp time.Time) detection.Record {
+	return detection.Record{ID: shared.ID(id), TenantID: shared.ID(tenant), EngagementID: shared.ID(eng),
+		AssetID: "asset-1", AgentID: shared.ID(agent), Detection: drDetection(t), EvidenceID: shared.ID("ev-" + id),
+		BatchSeq: seq, RecordedAt: time.Unix(1000, 0), ExpiresAt: exp}
+}
+
+func ctxT(tenant string) context.Context {
+	return shared.WithTenant(context.Background(), shared.ID(tenant))
+}
+
+func TestDetectionStoreTenantIsolation(t *testing.T) {
+	s := NewDetectionRecordStore()
+	if err := s.AppendDetection(ctxT("t1"), drRecord(t, "r1", "t1", "e1", "agent:1", 1, time.Time{})); err != nil {
+		t.Fatal(err)
+	}
+	// Same-tenant read sees it.
+	if got, _ := s.ListDetections(ctxT("t1"), "e1"); len(got) != 1 {
+		t.Fatalf("tenant t1 must see its own record, got %d", len(got))
+	}
+	// Cross-tenant read sees NOTHING.
+	if got, _ := s.ListDetections(ctxT("t2"), "e1"); len(got) != 0 {
+		t.Fatalf("tenant t2 must not see tenant t1's records, got %d", len(got))
+	}
+}
+
+func TestDetectionStoreLastBatchSequence(t *testing.T) {
+	s := NewDetectionRecordStore()
+	_ = s.AppendDetection(ctxT("t1"), drRecord(t, "r1", "t1", "e1", "agent:1", 2, time.Time{}))
+	_ = s.AppendDetection(ctxT("t1"), drRecord(t, "r2", "t1", "e1", "agent:1", 5, time.Time{}))
+	_ = s.AppendDetection(ctxT("t1"), drRecord(t, "r3", "t1", "e1", "agent:2", 9, time.Time{}))
+	if seq, _ := s.LastBatchSequence(ctxT("t1"), "agent:1"); seq != 5 {
+		t.Fatalf("want max seq 5 for agent:1, got %d", seq)
+	}
+	// A different tenant sees no sequence for that agent.
+	if seq, _ := s.LastBatchSequence(ctxT("t2"), "agent:1"); seq != 0 {
+		t.Fatalf("cross-tenant sequence must be 0, got %d", seq)
+	}
+}
+
+func TestDetectionStoreExpire(t *testing.T) {
+	s := NewDetectionRecordStore()
+	s.SetClock(func() time.Time { return time.Unix(3000, 0) })                                             // deterministic expiry-on-read
+	_ = s.AppendDetection(ctxT("t1"), drRecord(t, "keep", "t1", "e1", "agent:1", 1, time.Time{}))          // no expiry
+	_ = s.AppendDetection(ctxT("t1"), drRecord(t, "future", "t1", "e1", "agent:1", 2, time.Unix(5000, 0))) // not yet
+	_ = s.AppendDetection(ctxT("t1"), drRecord(t, "old", "t1", "e1", "agent:1", 3, time.Unix(2000, 0)))    // expired
+
+	// ListDetections hides the already-expired "old" row even before ExpireDetections runs (mirrors the
+	// Postgres `expires_at > now()` predicate).
+	if got, _ := s.ListDetections(ctxT("t1"), "e1"); len(got) != 2 {
+		t.Fatalf("list must hide the expired row, got %d", len(got))
+	}
+	expired, err := s.ExpireDetections(ctxT("t1"), "e1", time.Unix(3000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(expired) != 1 || expired[0] != "old" {
+		t.Fatalf("only the past-retention record must expire, got %v", expired)
+	}
+	got, _ := s.ListDetections(ctxT("t1"), "e1")
+	if len(got) != 2 {
+		t.Fatalf("the no-expiry and future records must remain, got %d", len(got))
+	}
+}
+
+func TestDetectionStoreHasDetection(t *testing.T) {
+	s := NewDetectionRecordStore()
+	_ = s.AppendDetection(ctxT("t1"), drRecord(t, "r1", "t1", "e1", "agent:1", 1, time.Time{}))
+	if ok, _ := s.HasDetection(ctxT("t1"), "r1"); !ok {
+		t.Error("t1 must see its own record via HasDetection")
+	}
+	if ok, _ := s.HasDetection(ctxT("t1"), "missing"); ok {
+		t.Error("HasDetection must be false for an unknown id")
+	}
+	// Cross-tenant: t2 must not observe t1's record.
+	if ok, _ := s.HasDetection(ctxT("t2"), "r1"); ok {
+		t.Error("HasDetection must be tenant-scoped")
+	}
+}

--- a/internal/infrastructure/persistence/postgres/detection_record_repo.go
+++ b/internal/infrastructure/persistence/postgres/detection_record_repo.go
@@ -1,0 +1,157 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// DetectionRecordRepository persists the detection-ledger projection (migration 0074), tenant-scoped via
+// WithTenant so RLS isolates one tenant's detections from another's. The evidence-chain link each row
+// references is the permanent ledger; these rows are the queryable, retention-bounded projection.
+type DetectionRecordRepository struct{ pool *pgxpool.Pool }
+
+var _ ports.DetectionRecordStore = (*DetectionRecordRepository)(nil)
+
+// NewDetectionRecordRepository constructs the repository.
+func NewDetectionRecordRepository(pool *pgxpool.Pool) *DetectionRecordRepository {
+	return &DetectionRecordRepository{pool: pool}
+}
+
+// AppendDetection stores one projection row, idempotent on (tenant_id, id): a row is immutable once
+// written (provenance), so a re-delivery of the same detection does not overwrite it.
+func (r *DetectionRecordRepository) AppendDetection(ctx context.Context, rec detection.Record) error {
+	if err := rec.Validate(); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(rec.Detection)
+	if err != nil {
+		return fmt.Errorf("marshal detection %s: %w", rec.ID, err)
+	}
+	var expires *time.Time
+	if !rec.ExpiresAt.IsZero() {
+		e := rec.ExpiresAt.UTC()
+		expires = &e
+	}
+	return WithTenant(ctx, r.pool, rec.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO detections
+			  (tenant_id, id, engagement_id, asset_id, agent_id, rule_id, rule_version, class, severity,
+			   host_id, observed_at, evidence_id, batch_seq, detection, recorded_at, expires_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+			ON CONFLICT (tenant_id, id) DO NOTHING`,
+			rec.TenantID.String(), rec.ID.String(), rec.EngagementID.String(), rec.AssetID.String(),
+			rec.AgentID.String(), rec.Detection.RuleID, rec.Detection.RuleVersion, string(rec.Detection.Class),
+			string(rec.Detection.Severity), rec.Detection.HostID.String(), rec.Detection.Observed.UTC(),
+			rec.EvidenceID.String(), int64(rec.BatchSeq), payload, rec.RecordedAt.UTC(), expires)
+		if err != nil {
+			return fmt.Errorf("insert detection %s: %w", rec.ID, err)
+		}
+		return nil
+	})
+}
+
+// ListDetections returns the non-expired records for an engagement, oldest first, tenant-scoped by RLS.
+func (r *DetectionRecordRepository) ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error) {
+	var out []detection.Record
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT tenant_id, id, engagement_id, asset_id, agent_id, evidence_id, batch_seq, detection,
+			       recorded_at, expires_at
+			FROM detections
+			WHERE engagement_id = $1 AND (expires_at IS NULL OR expires_at > now())
+			ORDER BY recorded_at ASC, id ASC`, engagementID.String())
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				rec      detection.Record
+				tenant   string
+				id       string
+				eng      string
+				asset    string
+				agent    string
+				evID     string
+				batchSeq int64
+				payload  []byte
+				recorded time.Time
+				expires  *time.Time
+			)
+			if err := rows.Scan(&tenant, &id, &eng, &asset, &agent, &evID, &batchSeq, &payload, &recorded, &expires); err != nil {
+				return err
+			}
+			var d detection.Detection
+			if err := json.Unmarshal(payload, &d); err != nil {
+				return fmt.Errorf("unmarshal detection %s: %w", id, err)
+			}
+			rec = detection.Record{
+				ID: shared.ID(id), TenantID: shared.ID(tenant), EngagementID: shared.ID(eng),
+				AssetID: shared.ID(asset), AgentID: shared.ID(agent), Detection: d, EvidenceID: shared.ID(evID),
+				BatchSeq: uint64(batchSeq), RecordedAt: recorded,
+			}
+			if expires != nil {
+				rec.ExpiresAt = *expires
+			}
+			out = append(out, rec)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// HasDetection reports whether a record with this id already exists in the ctx tenant.
+func (r *DetectionRecordRepository) HasDetection(ctx context.Context, id shared.ID) (bool, error) {
+	var exists bool
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM detections WHERE id = $1)`, id.String()).Scan(&exists)
+	})
+	return exists, err
+}
+
+// LastBatchSequence returns the highest batch sequence for an agent in the ctx tenant (0 = none yet).
+func (r *DetectionRecordRepository) LastBatchSequence(ctx context.Context, agentID shared.ID) (uint64, error) {
+	var last int64
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT COALESCE(max(batch_seq), 0) FROM detections WHERE agent_id = $1`, agentID.String()).Scan(&last)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return uint64(last), nil
+}
+
+// ExpireDetections deletes the engagement's records whose expiry has elapsed at cutoff and returns their
+// ids for auditing. Rows with a NULL expires_at are never removed. Deleting a projection row leaves its
+// evidence-chain link intact — the ledger is permanent, only the queryable projection ages out.
+func (r *DetectionRecordRepository) ExpireDetections(ctx context.Context, engagementID shared.ID, cutoff time.Time) ([]shared.ID, error) {
+	var ids []shared.ID
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			DELETE FROM detections
+			WHERE engagement_id = $1 AND expires_at IS NOT NULL AND expires_at <= $2
+			RETURNING id`, engagementID.String(), cutoff.UTC())
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			ids = append(ids, shared.ID(id))
+		}
+		return rows.Err()
+	})
+	return ids, err
+}

--- a/internal/infrastructure/persistence/postgres/migration_0074_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0074_test.go
@@ -1,0 +1,175 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func mig74Detection(t *testing.T) detection.Detection {
+	t.Helper()
+	r, ok := detection.Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("expected det.process_enumeration")
+	}
+	ev := detection.Event{Class: detection.ClassProcess, At: time.Unix(1, 0), Host: "host-x",
+		Process: &detection.ProcessEvent{PID: 1, Comm: "ps", Path: "/usr/bin/ps"}}
+	d, err := detection.NewDetection(r, "host-x", "agent:1", []detection.Event{ev}, time.Unix(500, 0).UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func TestMigration0074Detections(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenantA, tenantB := shared.ID("det-a-"+id), shared.ID("det-b-"+id)
+	engA := "det-eng-" + id
+	evID := "det-ev-" + id
+	for _, stmt := range []struct {
+		q    string
+		args []any
+	}{
+		{`INSERT INTO tenants(id,name) VALUES($1,$1),($2,$2)`, []any{tenantA.String(), tenantB.String()}},
+		{`INSERT INTO engagements(id,tenant_id,name) VALUES($1,$2,'det-eng')`, []any{engA, tenantA.String()}},
+		// A real evidence-chain link the detection references (FK evidence_id -> evidence(id)).
+		{`INSERT INTO evidence(id,tenant_id,engagement_id,kind,sha256,previous_hash,storage_ref,content,created_by)
+		   VALUES($1,$2,$3,'detection','deadbeef','','', $4,'agent:1')`, []any{evID, tenantA.String(), engA, []byte("{}")}},
+	} {
+		if _, err := pool.Exec(ctx, stmt.q, stmt.args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, q := range []string{
+			`DELETE FROM detections WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM evidence WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM engagements WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM tenants WHERE id IN ($1,$2)`,
+		} {
+			_, _ = pool.Exec(bg, q, tenantA.String(), tenantB.String())
+		}
+		_, _ = pool.Exec(bg, `DROP OWNED BY det_runtime`)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS det_runtime`)
+	})
+
+	repo := NewDetectionRecordRepository(pool)
+	tctx := shared.WithTenant(ctx, tenantA)
+	rec := detection.Record{
+		ID: shared.ID("rec-" + id), TenantID: tenantA, EngagementID: shared.ID(engA), AssetID: "asset-x",
+		AgentID: "agent:1", Detection: mig74Detection(t), EvidenceID: shared.ID(evID), BatchSeq: 1,
+		RecordedAt: time.Unix(1000, 0).UTC(),
+	}
+	if err := repo.AppendDetection(tctx, rec); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	// Idempotent: a re-delivery of the same id does not duplicate.
+	if err := repo.AppendDetection(tctx, rec); err != nil {
+		t.Fatalf("re-append: %v", err)
+	}
+	if got, _ := repo.ListDetections(tctx, shared.ID(engA)); len(got) != 1 {
+		t.Fatalf("append must be idempotent on id, got %d rows", len(got))
+	}
+	// HasDetection is tenant-scoped and true for a stored id.
+	if ok, err := repo.HasDetection(tctx, rec.ID); err != nil || !ok {
+		t.Fatalf("HasDetection must be true for a stored record (ok=%v err=%v)", ok, err)
+	}
+	// A second, CRITICAL detection of the same rule+asset — so the incident rollup can be checked to
+	// report the highest severity by RANK, not the alphabetical max of the label.
+	crit := rec
+	crit.ID = shared.ID("rec-crit-" + id)
+	crit.EvidenceID = shared.ID(evID)
+	crit.Detection.Severity = shared.SeverityCritical
+	if err := repo.AppendDetection(tctx, crit); err != nil {
+		t.Fatalf("append critical: %v", err)
+	}
+
+	// RLS under a NOSUPERUSER NOBYPASSRLS role (the pool superuser bypasses RLS).
+	role := "det_runtime"
+	for _, q := range []string{
+		`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='` + role + `') THEN EXECUTE 'DROP OWNED BY ` + role + `'; EXECUTE 'DROP ROLE ` + role + `'; END IF; END $$`,
+		`CREATE ROLE ` + role + ` NOSUPERUSER NOBYPASSRLS`,
+		`GRANT USAGE ON SCHEMA public TO ` + role,
+		`GRANT SELECT ON detections, detection_incidents TO ` + role,
+	} {
+		if _, err := pool.Exec(ctx, q); err != nil {
+			t.Fatalf("prepare rls role: %v", err)
+		}
+	}
+	countAs := func(tenant shared.ID, table string) int {
+		var n int
+		tc := shared.WithTenant(context.Background(), tenant)
+		if err := WithTenant(tc, pool, tenant.String(), func(tx pgx.Tx) error {
+			if _, err := tx.Exec(tc, `SET LOCAL ROLE `+role); err != nil {
+				return err
+			}
+			return tx.QueryRow(tc, `SELECT count(*) FROM `+table).Scan(&n)
+		}); err != nil {
+			t.Fatalf("count as %s on %s: %v", tenant, table, err)
+		}
+		return n
+	}
+	if got := countAs(tenantB, "detections"); got != 0 {
+		t.Errorf("tenant B sees %d of tenant A's detections; RLS is not isolating", got)
+	}
+	if got := countAs(tenantA, "detections"); got != 2 {
+		t.Errorf("tenant A sees %d of its own detections, want 2; RLS is over-filtering", got)
+	}
+	// The incident rollup view is tenant-scoped too (security_invoker): B sees none, A sees its incident.
+	if got := countAs(tenantB, "detection_incidents"); got != 0 {
+		t.Errorf("tenant B sees %d incidents of tenant A; the rollup view leaks across tenants", got)
+	}
+	if got := countAs(tenantA, "detection_incidents"); got != 1 {
+		t.Errorf("tenant A sees %d incidents, want 1 (one rule+asset)", got)
+	}
+	// worst_severity must be ranked, not lexical: an incident with low + critical reports 'critical'.
+	var worst string
+	tcA := shared.WithTenant(context.Background(), tenantA)
+	if err := WithTenant(tcA, pool, tenantA.String(), func(tx pgx.Tx) error {
+		return tx.QueryRow(tcA, `SELECT worst_severity FROM detection_incidents LIMIT 1`).Scan(&worst)
+	}); err != nil {
+		t.Fatalf("read worst_severity: %v", err)
+	}
+	if worst != "critical" {
+		t.Errorf("incident worst_severity = %q, want critical (ranked, not alphabetical max)", worst)
+	}
+
+	// Expiry: a record past its retention is removed and returned; a no-expiry record stays.
+	expRec := rec
+	expRec.ID = shared.ID("rec-exp-" + id)
+	expRec.ExpiresAt = time.Unix(2000, 0).UTC()
+	if err := repo.AppendDetection(tctx, expRec); err != nil {
+		t.Fatalf("append expiring: %v", err)
+	}
+	expired, err := repo.ExpireDetections(tctx, shared.ID(engA), time.Unix(3000, 0).UTC())
+	if err != nil {
+		t.Fatalf("expire: %v", err)
+	}
+	if len(expired) != 1 || expired[0] != expRec.ID {
+		t.Fatalf("only the past-retention record must expire, got %v", expired)
+	}
+	if got, _ := repo.ListDetections(tctx, shared.ID(engA)); len(got) != 2 {
+		t.Fatalf("the two no-expiry records must remain after expiry, got %d", len(got))
+	}
+}

--- a/internal/usecase/fleet/detectledger/service.go
+++ b/internal/usecase/fleet/detectledger/service.go
@@ -1,0 +1,303 @@
+// Package detectledger turns the agent-side detection engine's output (#422) into hash-chained,
+// attributable evidence (#423). It does NOT own a chain: a detection is sealed into the SAME evidence
+// spine as findings and judgments, with kind = "detection", so it is defensible in an audit and joins
+// the correlation graph.
+//
+// Boundary (enforced here and asserted by test): DETECTIONS are chained; raw telemetry is NOT. This
+// package has no method that seals a detection.Event — only a detection.Detection becomes a chain link.
+// Per-event chaining would collapse throughput and is deliberately impossible through this API.
+package detectledger
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// evidenceKindDetection is the chain kind for a sealed detection. It sits alongside "finding",
+// "judgment_*", "exploitation_step", etc. in the one evidence chain.
+const evidenceKindDetection = "detection"
+
+// EvidenceChain is the narrow slice of the evidence vault this package needs: seal a detection into the
+// chain, and verify the chain. It is a consumer-side interface bridged to *evidence.Service at the
+// composition root (like offensivepolicy's EvidenceSealer), so this package never depends on the
+// concrete vault or the domain Evidence shape.
+type EvidenceChain interface {
+	// Seal appends content under the given kind, bound to the engagement's chain head, and returns the
+	// new link's id.
+	Seal(ctx context.Context, engagementID shared.ID, kind string, content []byte, createdBy string) (shared.ID, error)
+	// Verify checks the engagement's chain and returns a non-nil error (wrapping evidence.ErrChainBroken)
+	// when it is broken, so a dependent report can be blocked.
+	//
+	// IMPORTANT for the composition-root bridge: evidence.Service.Verify returns (Report, error) and
+	// signals a BROKEN chain via Report.Intact=false with a NIL error (the non-nil error is reserved for
+	// I/O failures). A bridge must therefore inspect Report.Intact and synthesize an
+	// evidence.ErrChainBroken-wrapping error itself — returning the raw error would report a tampered
+	// chain as healthy. This contract exists precisely so that mistake cannot be made silently.
+	Verify(ctx context.Context, engagementID shared.ID) error
+}
+
+// AgentKeyResolver returns the enrolment public key for an agent (#408), used to verify a batch's
+// signature. An agent with no known key cannot have its batches admitted — fail closed.
+type AgentKeyResolver interface {
+	AgentPublicKey(ctx context.Context, agentID shared.ID) (ed25519.PublicKey, error)
+}
+
+// IngestItem is one detection in a batch together with the asset it was observed on (#423 requirement 5:
+// a detection joins the asset model).
+type IngestItem struct {
+	ID        shared.ID
+	Detection detection.Detection
+	AssetID   shared.ID
+}
+
+// IngestResult reports the outcome of ingesting a batch.
+type IngestResult struct {
+	EngagementID  shared.ID
+	SealedRecords []shared.ID
+	EvidenceIDs   []shared.ID
+	Skipped       []shared.ID // already-sealed detections skipped on an idempotent retry
+	Gap           fleetagent.SequenceGap
+}
+
+// Service ingests agent detection batches into the evidence ledger.
+type Service struct {
+	records   ports.DetectionRecordStore
+	chain     EvidenceChain
+	keys      AgentKeyResolver
+	audit     ports.AuditLogger
+	clock     ports.Clock
+	ids       ports.IDGenerator
+	retention time.Duration // 0 = keep the projection forever (the chain is always permanent)
+}
+
+// NewService validates its dependencies. Every one is required: a ledger that cannot seal, resolve an
+// agent key, persist, or audit is not producing attributable evidence.
+func NewService(records ports.DetectionRecordStore, chain EvidenceChain, keys AgentKeyResolver, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator, retention time.Duration) (*Service, error) {
+	if records == nil || chain == nil || keys == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: detection ledger is missing a dependency", shared.ErrValidation)
+	}
+	if retention < 0 {
+		return nil, fmt.Errorf("%w: retention cannot be negative", shared.ErrValidation)
+	}
+	return &Service{records: records, chain: chain, keys: keys, audit: audit, clock: clock, ids: ids, retention: retention}, nil
+}
+
+// Ingest admits one signed, sequenced agent batch: it verifies the signature, detects a sequence gap
+// (reported as a potential loss, never silently accepted), seals each detection into the evidence chain
+// as kind="detection", and persists the projection rows bound to their chain links and asset.
+func (s *Service) Ingest(ctx context.Context, batch fleetagent.AgentBatch, items []IngestItem) (IngestResult, error) {
+	if err := batch.Validate(); err != nil {
+		return IngestResult{}, err
+	}
+	refByID, err := membership(batch, items)
+	if err != nil {
+		return IngestResult{}, err
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return IngestResult{}, fmt.Errorf("%w: detection ingest requires a tenant in context", shared.ErrValidation)
+	}
+
+	// Signature: fail closed. An agent with no known key, or a batch that does not verify, is refused
+	// before any detection is sealed.
+	pub, err := s.keys.AgentPublicKey(ctx, batch.AgentID)
+	if err != nil {
+		return IngestResult{}, fmt.Errorf("%w: no key for agent %s: %v", shared.ErrForbidden, batch.AgentID, err)
+	}
+	if err := fleetagent.VerifyBatch(pub, batch); err != nil {
+		s.recordAudit(ctx, "detection.batch_rejected", batch.AgentID.String(), map[string]string{
+			"engagement": batch.EngagementID.String(), "sequence": fmt.Sprint(batch.Sequence), "reason": "bad_signature",
+		})
+		return IngestResult{}, err
+	}
+
+	// Sequence gap: a missing or replayed/out-of-order sequence is a batch_gap coverage event on the
+	// agent. It must NEVER be silently accepted, so the coverage event is a HARD requirement: if it
+	// cannot be recorded, the ingest fails rather than admitting an unrecorded gap.
+	last, err := s.records.LastBatchSequence(ctx, batch.AgentID)
+	if err != nil {
+		return IngestResult{}, fmt.Errorf("read last batch sequence: %w", err)
+	}
+	gap := fleetagent.DetectSequenceGap(last, batch.Sequence)
+	if gap.HasGap() {
+		if aerr := s.audit.Record(ctx, ports.AuditEntry{
+			Actor: batch.AgentID.String(), Action: "detection.batch_gap", Target: batch.EngagementID.String(),
+			At: s.clock.Now().UTC(), Metadata: map[string]string{
+				"engagement": batch.EngagementID.String(), "last_sequence": fmt.Sprint(last),
+				"incoming_sequence": fmt.Sprint(batch.Sequence), "missing": fmt.Sprint(gap.Missing), "replay": fmt.Sprint(gap.Replay),
+			},
+		}); aerr != nil {
+			return IngestResult{Gap: gap}, fmt.Errorf("%w: could not record the batch_gap coverage event: %v", shared.ErrSaturated, aerr)
+		}
+	}
+	// A replay/out-of-order batch is NOT hard-refused: refusing it after a prior partial ingest would
+	// strand the un-sealed items forever. Instead ingest is idempotent — each already-sealed detection is
+	// skipped below (never sealed twice), so a retry safely completes a partial batch and a pure duplicate
+	// seals nothing new. The gap is already reported above.
+
+	result := IngestResult{EngagementID: batch.EngagementID, Gap: gap}
+	now := s.clock.Now().UTC()
+	for _, it := range items {
+		if err := it.Detection.Validate(); err != nil {
+			return result, fmt.Errorf("%w: batch detection %s is malformed: %v", shared.ErrValidation, it.ID, err)
+		}
+		if it.AssetID == "" {
+			return result, fmt.Errorf("%w: batch detection %s has no asset", shared.ErrValidation, it.ID)
+		}
+		payload, err := json.Marshal(it.Detection)
+		if err != nil {
+			return result, fmt.Errorf("marshal detection %s: %w", it.ID, err)
+		}
+		// Content binding: the signed ref for this id must match a digest of the bytes we are about to
+		// seal (detection + asset). A body swapped in transit for a known id is refused here.
+		if got := fleetagent.DetectionContentHash(payload, it.AssetID); got != refByID[it.ID].ContentSHA256 {
+			return result, fmt.Errorf("%w: detection %s content does not match its signed digest", shared.ErrValidation, it.ID)
+		}
+		// Idempotent resume: skip a detection already sealed (e.g. a retry after a partial batch), so it is
+		// never sealed into the chain twice.
+		if exists, err := s.records.HasDetection(ctx, it.ID); err != nil {
+			return result, fmt.Errorf("check detection %s: %w", it.ID, err)
+		} else if exists {
+			result.Skipped = append(result.Skipped, it.ID)
+			continue
+		}
+		evID, err := s.chain.Seal(ctx, batch.EngagementID, evidenceKindDetection, payload, batch.AgentID.String())
+		if err != nil {
+			return result, fmt.Errorf("seal detection %s: %w", it.ID, err)
+		}
+		rec := detection.Record{
+			ID: it.ID, TenantID: tenantID, EngagementID: batch.EngagementID, AssetID: it.AssetID,
+			AgentID: batch.AgentID, Detection: it.Detection, EvidenceID: evID, BatchSeq: batch.Sequence,
+			RecordedAt: now,
+		}
+		if s.retention > 0 {
+			rec.ExpiresAt = now.Add(s.retention)
+		}
+		if err := rec.Validate(); err != nil {
+			return result, err
+		}
+		if err := s.records.AppendDetection(ctx, rec); err != nil {
+			return result, fmt.Errorf("persist detection %s: %w", it.ID, err)
+		}
+		result.SealedRecords = append(result.SealedRecords, rec.ID)
+		result.EvidenceIDs = append(result.EvidenceIDs, evID)
+	}
+	s.recordAudit(ctx, "detection.batch_sealed", batch.AgentID.String(), map[string]string{
+		"engagement": batch.EngagementID.String(), "sequence": fmt.Sprint(batch.Sequence),
+		"sealed": fmt.Sprint(len(result.SealedRecords)), "skipped": fmt.Sprint(len(result.Skipped)),
+	})
+	return result, nil
+}
+
+// VerifyChain checks the engagement's evidence chain; a broken chain returns an error wrapping
+// evidence.ErrChainBroken so the report that depends on it is blocked, exactly as any chain break is.
+func (s *Service) VerifyChain(ctx context.Context, engagementID shared.ID) error {
+	return s.chain.Verify(ctx, engagementID)
+}
+
+// ListDetections returns the engagement's (non-expired) detection records, tenant-scoped by the store.
+func (s *Service) ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error) {
+	return s.records.ListDetections(ctx, engagementID)
+}
+
+// Reader is the read-only projection of the ledger, for the HTTP read routes. It needs only the record
+// store — no chain, key resolver, or audit — so the read surface can be wired live before the agent
+// batch-ingest transport is. The full Service handles the write (ingest/seal/expire) path.
+type Reader struct{ records ports.DetectionRecordStore }
+
+// NewReader builds the read-only ledger view.
+func NewReader(records ports.DetectionRecordStore) (*Reader, error) {
+	if records == nil {
+		return nil, fmt.Errorf("%w: detection reader needs a record store", shared.ErrValidation)
+	}
+	return &Reader{records: records}, nil
+}
+
+// ListDetections returns the engagement's non-expired detection records, tenant-scoped.
+func (r *Reader) ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error) {
+	return r.records.ListDetections(ctx, engagementID)
+}
+
+// Incidents returns the incident rollup over the engagement's detections.
+func (r *Reader) Incidents(ctx context.Context, engagementID shared.ID) ([]detection.Incident, error) {
+	recs, err := r.records.ListDetections(ctx, engagementID)
+	if err != nil {
+		return nil, err
+	}
+	return detection.Rollup(recs), nil
+}
+
+// Incidents returns the incident-level rollup for an engagement. The rollup is a view: the individual
+// attributable detections remain the ledger underneath.
+func (s *Service) Incidents(ctx context.Context, engagementID shared.ID) ([]detection.Incident, error) {
+	recs, err := s.records.ListDetections(ctx, engagementID)
+	if err != nil {
+		return nil, err
+	}
+	return detection.Rollup(recs), nil
+}
+
+// Expire removes projection rows whose retention has elapsed, as an AUDITED action carrying the actor
+// and reason. It never removes chain links (those are permanent) and never runs silently: deleting
+// evidence without a trail is exactly what this project exists to prevent.
+func (s *Service) Expire(ctx context.Context, engagementID shared.ID, actor, reason string) (int, error) {
+	if strings.TrimSpace(actor) == "" {
+		return 0, fmt.Errorf("%w: expiry must name the actor", shared.ErrValidation)
+	}
+	if strings.TrimSpace(reason) == "" {
+		return 0, fmt.Errorf("%w: expiry must carry a reason", shared.ErrValidation)
+	}
+	expired, err := s.records.ExpireDetections(ctx, engagementID, s.clock.Now().UTC())
+	if err != nil {
+		return 0, fmt.Errorf("expire detections: %w", err)
+	}
+	s.recordAudit(ctx, "detection.expired", actor, map[string]string{
+		"engagement": engagementID.String(), "reason": reason, "expired": fmt.Sprint(len(expired)),
+	})
+	return len(expired), nil
+}
+
+// membership asserts the supplied items are EXACTLY the signed batch membership — a multiset match, so a
+// duplicate item id or a missing/extra signed id is rejected (not just a subset+count check). It returns
+// the ref-by-id map so the caller can check each item's content digest against its signed ref.
+func membership(batch fleetagent.AgentBatch, items []IngestItem) (map[shared.ID]fleetagent.DetectionRef, error) {
+	refByID := make(map[shared.ID]fleetagent.DetectionRef, len(batch.Detections))
+	for _, ref := range batch.Detections {
+		if _, dup := refByID[ref.ID]; dup {
+			return nil, fmt.Errorf("%w: signed batch names detection %s more than once", shared.ErrValidation, ref.ID)
+		}
+		refByID[ref.ID] = ref
+	}
+	if len(items) != len(refByID) {
+		return nil, fmt.Errorf("%w: batch names %d detections but %d were supplied", shared.ErrValidation, len(refByID), len(items))
+	}
+	seen := make(map[shared.ID]struct{}, len(items))
+	for _, it := range items {
+		if _, ok := refByID[it.ID]; !ok {
+			return nil, fmt.Errorf("%w: detection %s is not in the signed batch membership", shared.ErrValidation, it.ID)
+		}
+		if _, dup := seen[it.ID]; dup {
+			return nil, fmt.Errorf("%w: detection %s supplied more than once", shared.ErrValidation, it.ID)
+		}
+		seen[it.ID] = struct{}{}
+	}
+	return refByID, nil
+}
+
+func (s *Service) recordAudit(ctx context.Context, action, actor string, meta map[string]string) {
+	if err := s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: meta["engagement"], At: s.clock.Now().UTC(), Metadata: meta}); err != nil {
+		// Audit is best-effort here (the seal already happened / is about to), but never swallowed silently
+		// at the type level: callers that require a guaranteed audit use the evidence chain, which is the
+		// authoritative record. A dropped audit line is logged by the audit adapter, not here.
+		_ = err
+	}
+}

--- a/internal/usecase/fleet/detectledger/service_test.go
+++ b/internal/usecase/fleet/detectledger/service_test.go
@@ -1,0 +1,420 @@
+package detectledger
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ---- fakes ------------------------------------------------------------------------------------------
+
+type sealCall struct {
+	engagement shared.ID
+	kind       string
+	createdBy  string
+}
+
+type fakeChain struct {
+	mu      sync.Mutex
+	seals   []sealCall
+	n       int
+	broken  bool
+	sealErr error
+}
+
+func (c *fakeChain) Seal(_ context.Context, eng shared.ID, kind string, _ []byte, by string) (shared.ID, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.sealErr != nil {
+		return "", c.sealErr
+	}
+	c.seals = append(c.seals, sealCall{eng, kind, by})
+	c.n++
+	return shared.ID("ev-" + itoa(c.n)), nil
+}
+func (c *fakeChain) Verify(_ context.Context, _ shared.ID) error {
+	if c.broken {
+		return errors.New("evidence chain broken: item 2 tampered")
+	}
+	return nil
+}
+func (c *fakeChain) kinds() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.seals))
+	for i, s := range c.seals {
+		out[i] = s.kind
+	}
+	return out
+}
+
+type fakeKeys struct {
+	pub   ed25519.PublicKey
+	known map[shared.ID]bool
+}
+
+func (k *fakeKeys) AgentPublicKey(_ context.Context, id shared.ID) (ed25519.PublicKey, error) {
+	if k.known[id] {
+		return k.pub, nil
+	}
+	return nil, errors.New("unknown agent")
+}
+
+type fakeAudit struct {
+	mu         sync.Mutex
+	actions    []string
+	last       map[string]ports.AuditEntry
+	failAction string // if set, Record returns an error for this action (and does not record it)
+}
+
+func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.failAction != "" && e.Action == a.failAction {
+		return errors.New("audit store unavailable")
+	}
+	a.actions = append(a.actions, e.Action)
+	if a.last == nil {
+		a.last = map[string]ports.AuditEntry{}
+	}
+	a.last[e.Action] = e
+	return nil
+}
+func (a *fakeAudit) has(action string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, x := range a.actions {
+		if x == action {
+			return true
+		}
+	}
+	return false
+}
+
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+type seqIDs struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (s *seqIDs) NewID() shared.ID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.n++
+	return shared.ID("id-" + itoa(s.n))
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// ---- harness ----------------------------------------------------------------------------------------
+
+type harness struct {
+	svc   *Service
+	chain *fakeChain
+	audit *fakeAudit
+	store *memory.DetectionRecordStore
+	priv  ed25519.PrivateKey
+}
+
+func newHarness(t *testing.T, retention time.Duration) *harness {
+	t.Helper()
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	chain := &fakeChain{}
+	audit := &fakeAudit{}
+	store := memory.NewDetectionRecordStore()
+	keys := &fakeKeys{pub: pub, known: map[shared.ID]bool{"agent:1": true}}
+	svc, err := NewService(store, chain, keys, audit, fixedClock{t: time.Unix(1000, 0)}, &seqIDs{}, retention)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &harness{svc: svc, chain: chain, audit: audit, store: store, priv: priv}
+}
+
+func mkDetection(t *testing.T, comm string) detection.Detection {
+	t.Helper()
+	r, ok := detection.Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("expected det.process_enumeration")
+	}
+	ev := detection.Event{Class: detection.ClassProcess, At: time.Unix(1, 0), Host: "h",
+		Process: &detection.ProcessEvent{PID: 1, Comm: comm, Path: "/usr/bin/" + comm}}
+	d, err := detection.NewDetection(r, "host-1", "agent:1", []detection.Event{ev}, time.Unix(500, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func refsFor(t *testing.T, items []IngestItem) []fleetagent.DetectionRef {
+	t.Helper()
+	var refs []fleetagent.DetectionRef
+	for _, it := range items {
+		payload, err := json.Marshal(it.Detection)
+		if err != nil {
+			t.Fatal(err)
+		}
+		refs = append(refs, fleetagent.DetectionRef{ID: it.ID, ContentSHA256: fleetagent.DetectionContentHash(payload, it.AssetID)})
+	}
+	return refs
+}
+
+func (h *harness) signedBatch(t *testing.T, seq uint64, items []IngestItem) fleetagent.AgentBatch {
+	t.Helper()
+	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: seq, Detections: refsFor(t, items)}
+	b.Signature = fleetagent.SignBatch(h.priv, b)
+	return b
+}
+
+func tctx() context.Context { return shared.WithTenant(context.Background(), "t1") }
+
+// ---- tests ------------------------------------------------------------------------------------------
+
+func TestIngestSealsEachDetectionAsChainedEvidence(t *testing.T) {
+	h := newHarness(t, 0)
+	items := []IngestItem{
+		{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"},
+		{ID: "d2", Detection: mkDetection(t, "top"), AssetID: "asset-1"},
+	}
+	res, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, items), items)
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if len(res.SealedRecords) != 2 || len(res.EvidenceIDs) != 2 {
+		t.Fatalf("both detections must be sealed, got %+v", res)
+	}
+	// BOUNDARY: every seal is kind="detection" — telemetry is never chained per event.
+	for _, k := range h.chain.kinds() {
+		if k != "detection" {
+			t.Fatalf("only detections may be chained, got kind %q", k)
+		}
+	}
+	if !h.audit.has("detection.batch_sealed") {
+		t.Error("a sealed batch must be audited")
+	}
+	// The projection rows are stored with the evidence + asset binding.
+	recs, _ := h.store.ListDetections(tctx(), "eng-1")
+	if len(recs) != 2 {
+		t.Fatalf("want 2 projection rows, got %d", len(recs))
+	}
+	for _, r := range recs {
+		if r.EvidenceID == "" || r.AssetID != "asset-1" || r.BatchSeq != 1 {
+			t.Fatalf("record missing evidence/asset/seq binding: %+v", r)
+		}
+	}
+}
+
+func TestIngestRefusesBadSignature(t *testing.T) {
+	h := newHarness(t, 0)
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	b := h.signedBatch(t, 1, items)
+	b.Sequence = 99 // tamper a signed field AFTER signing → the signature no longer matches
+	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, fleetagent.ErrBadBatchSignature) {
+		t.Fatalf("a tampered batch must be refused, got %v", err)
+	}
+	if len(h.chain.kinds()) != 0 {
+		t.Error("nothing may be sealed when the batch signature is bad")
+	}
+	if !h.audit.has("detection.batch_rejected") {
+		t.Error("a rejected batch must be audited")
+	}
+}
+
+// TestIngestRefusesContentTamper: a body swapped for a known, signed id (same id, different detection)
+// is refused — the signature binds a digest of the content, not just the id.
+func TestIngestRefusesContentTamper(t *testing.T) {
+	h := newHarness(t, 0)
+	signedItems := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	b := h.signedBatch(t, 1, signedItems) // signs a digest over the "ps" detection
+	// Deliver the same id with a DIFFERENT body.
+	swapped := []IngestItem{{ID: "d1", Detection: mkDetection(t, "top"), AssetID: "asset-1"}}
+	if _, err := h.svc.Ingest(tctx(), b, swapped); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a content swap must be refused, got %v", err)
+	}
+	if len(h.chain.kinds()) != 0 {
+		t.Error("nothing may be sealed when the content does not match its signed digest")
+	}
+}
+
+func TestIngestRefusesUnknownAgent(t *testing.T) {
+	h := newHarness(t, 0)
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	b := fleetagent.AgentBatch{AgentID: "agent:unknown", EngagementID: "eng-1", Sequence: 1, Detections: refsFor(t, items)}
+	b.Signature = fleetagent.SignBatch(h.priv, b)
+	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("an agent with no known key must be refused (fail closed), got %v", err)
+	}
+}
+
+func TestIngestReportsForwardGapButProceeds(t *testing.T) {
+	h := newHarness(t, 0)
+	// First batch seq 1.
+	i1 := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, i1), i1); err != nil {
+		t.Fatal(err)
+	}
+	// Next batch jumps to seq 4 → sequences 2,3 are a gap.
+	i2 := []IngestItem{{ID: "d4", Detection: mkDetection(t, "top"), AssetID: "asset-1"}}
+	res, err := h.svc.Ingest(tctx(), h.signedBatch(t, 4, i2), i2)
+	if err != nil {
+		t.Fatalf("a forward gap must still seal the arriving batch: %v", err)
+	}
+	if res.Gap.Missing != 2 {
+		t.Errorf("want 2 missing, got %+v", res.Gap)
+	}
+	if !h.audit.has("detection.batch_gap") {
+		t.Error("a sequence gap must be reported as a potential loss (audited)")
+	}
+	if len(res.SealedRecords) != 1 {
+		t.Error("the arriving batch's detections must still be sealed")
+	}
+}
+
+// TestIngestIsIdempotentOnReplay: replaying a batch (same sequence + same signed membership) is reported
+// as a gap/replay but seals NOTHING new — a detection is never sealed into the chain twice. This is the
+// fix for a partial-batch retry: it safely completes rather than being permanently refused.
+func TestIngestIsIdempotentOnReplay(t *testing.T) {
+	h := newHarness(t, 0)
+	i1 := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	b := h.signedBatch(t, 2, i1)
+	if _, err := h.svc.Ingest(tctx(), b, i1); err != nil {
+		t.Fatal(err)
+	}
+	sealedBefore := len(h.chain.kinds())
+	// Re-ingest the exact same batch: idempotent — no new seal, d1 skipped, replay reported.
+	res, err := h.svc.Ingest(tctx(), b, i1)
+	if err != nil {
+		t.Fatalf("an idempotent replay must not error, got %v", err)
+	}
+	if len(h.chain.kinds()) != sealedBefore {
+		t.Error("a replayed detection must not be sealed into the chain twice")
+	}
+	if len(res.SealedRecords) != 0 || len(res.Skipped) != 1 {
+		t.Errorf("a duplicate must seal nothing new and skip the already-sealed detection, got %+v", res)
+	}
+	if !res.Gap.Replay || !h.audit.has("detection.batch_gap") {
+		t.Error("a replay must be reported as a gap, never silently accepted")
+	}
+}
+
+func TestIngestRequiresMembershipMatchAndTenant(t *testing.T) {
+	h := newHarness(t, 0)
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	// Membership mismatch: batch names d1+d2 but only d1 supplied.
+	extra := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}, {ID: "d2", Detection: mkDetection(t, "top"), AssetID: "asset-1"}}
+	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, Detections: refsFor(t, extra)}
+	b.Signature = fleetagent.SignBatch(h.priv, b)
+	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("membership mismatch must be a validation error, got %v", err)
+	}
+	// Missing tenant in context.
+	good := h.signedBatch(t, 1, items)
+	if _, err := h.svc.Ingest(context.Background(), good, items); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a missing tenant must be refused, got %v", err)
+	}
+}
+
+// TestIngestFailsWhenGapAuditFails: a sequence gap must never be silently accepted — if its coverage
+// event cannot be recorded, the whole ingest fails rather than admitting an unrecorded gap.
+func TestIngestFailsWhenGapAuditFails(t *testing.T) {
+	h := newHarness(t, 0)
+	// Seed seq 1 so a jump to seq 5 is a forward gap.
+	i1 := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, i1), i1); err != nil {
+		t.Fatal(err)
+	}
+	h.audit.failAction = "detection.batch_gap" // the gap coverage event cannot be written
+	i2 := []IngestItem{{ID: "d5", Detection: mkDetection(t, "top"), AssetID: "asset-1"}}
+	sealedBefore := len(h.chain.kinds())
+	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 5, i2), i2); err == nil {
+		t.Fatal("an unrecordable gap must fail the ingest, not silently proceed")
+	}
+	if len(h.chain.kinds()) != sealedBefore {
+		t.Error("nothing may be sealed when the gap could not be recorded")
+	}
+}
+
+func TestVerifyChainBlocksOnBreak(t *testing.T) {
+	h := newHarness(t, 0)
+	if err := h.svc.VerifyChain(tctx(), "eng-1"); err != nil {
+		t.Fatalf("an intact chain must verify: %v", err)
+	}
+	h.chain.broken = true
+	if err := h.svc.VerifyChain(tctx(), "eng-1"); err == nil {
+		t.Fatal("a broken chain must return an error so the dependent report is blocked")
+	}
+}
+
+func TestIncidentsRollupFromLedger(t *testing.T) {
+	h := newHarness(t, 0)
+	items := []IngestItem{
+		{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"},
+		{ID: "d2", Detection: mkDetection(t, "ps"), AssetID: "asset-1"},
+	}
+	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, items), items); err != nil {
+		t.Fatal(err)
+	}
+	inc, err := h.svc.Incidents(tctx(), "eng-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inc) != 1 || inc[0].Count != 2 || len(inc[0].DetectionIDs) != 2 {
+		t.Fatalf("rollup must fold repeats yet keep the underlying records, got %+v", inc)
+	}
+}
+
+func TestExpireIsAuditedAndRequiresActorReason(t *testing.T) {
+	h := newHarness(t, time.Hour) // records expire 1h after RecordedAt (clock = t=1000s)
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, items), items); err != nil {
+		t.Fatal(err)
+	}
+	// Actor/reason required.
+	if _, err := h.svc.Expire(tctx(), "eng-1", "  ", "policy"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("expiry must require an actor, got %v", err)
+	}
+	if _, err := h.svc.Expire(tctx(), "eng-1", "operator", " "); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("expiry must require a reason, got %v", err)
+	}
+	// At t=1000s the record (ExpiresAt = 1000+3600) is not yet expired.
+	if n, _ := h.svc.Expire(tctx(), "eng-1", "operator", "retention"); n != 0 {
+		t.Fatalf("record not yet past retention should not expire, got %d", n)
+	}
+	// Advance the clock past the retention window and expire.
+	h.svc.clock = fixedClock{t: time.Unix(1000+3601, 0)}
+	n, err := h.svc.Expire(tctx(), "eng-1", "operator", "retention")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("the expired record must be removed, got %d", n)
+	}
+	if !h.audit.has("detection.expired") {
+		t.Error("expiry must be audited (actor + reason), never silent")
+	}
+	if e := h.audit.last["detection.expired"]; e.Actor != "operator" || e.Metadata["reason"] != "retention" {
+		t.Errorf("expiry audit must carry actor + reason, got %+v", e)
+	}
+}

--- a/internal/usecase/ports/detection.go
+++ b/internal/usecase/ports/detection.go
@@ -2,8 +2,10 @@ package ports
 
 import (
 	"context"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
 // DetectionSensor is the agent-side event source the detection engine consumes: a set of per-class eBPF
@@ -32,4 +34,24 @@ type DetectionSensor interface {
 // "somewhere to emit a detection", not on how it is stored or transported.
 type DetectionSink interface {
 	Emit(ctx context.Context, d detection.Detection) error
+}
+
+// DetectionRecordStore persists the control-plane detection ledger projection (#423): the queryable rows
+// over the sealed evidence-chain links. Tenant scoping is enforced in the implementation via the tenant
+// chokepoint, not by the caller. The projection is retention-bounded; the underlying chain links are
+// permanent, so expiry removes rows here, never chain history.
+type DetectionRecordStore interface {
+	// AppendDetection stores one projection row. It is tenant-scoped and idempotent on the record id.
+	AppendDetection(ctx context.Context, r detection.Record) error
+	// HasDetection reports whether a record with this id already exists (tenant-scoped), so ingest can
+	// skip an already-sealed detection on a retry rather than sealing it into the chain twice.
+	HasDetection(ctx context.Context, id shared.ID) (bool, error)
+	// ListDetections returns the (non-expired) records for an engagement, oldest first, tenant-scoped.
+	ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error)
+	// LastBatchSequence returns the highest batch sequence recorded for an agent (0 = none yet), so a gap
+	// in the sequence can be detected. Tenant-scoped.
+	LastBatchSequence(ctx context.Context, agentID shared.ID) (uint64, error)
+	// ExpireDetections removes the records for an engagement whose ExpiresAt has elapsed at cutoff, and
+	// returns their ids so the removal can be audited. It never touches records with no expiry set.
+	ExpireDetections(ctx context.Context, engagementID shared.ID, cutoff time.Time) ([]shared.ID, error)
 }

--- a/migrations/0074_detections.sql
+++ b/migrations/0074_detections.sql
@@ -1,0 +1,62 @@
+-- +goose Up
+-- Detection ledger projection (issue #423). A detection is sealed into the SAME hash-chained evidence
+-- spine as findings and judgments (kind = 'detection'); this table is the QUERYABLE PROJECTION over
+-- those chain links — it is not a second chain. Every row references its evidence link (so it is
+-- attributable and defensible) and the asset it was observed on (so it joins the asset risk story).
+--
+-- Retention lives here: the evidence chain link is PERMANENT (append-only), but this projection row is
+-- retention-bounded and can be expired by an AUDITED action. Deleting a projection row never touches the
+-- chain, so the tamper-evident ledger is intact even after an operational row is aged out.
+CREATE TABLE detections (
+    tenant_id     TEXT NOT NULL REFERENCES tenants(id),
+    id            TEXT NOT NULL,
+    engagement_id TEXT NOT NULL REFERENCES engagements(id) ON DELETE CASCADE,
+    asset_id      TEXT NOT NULL,
+    agent_id      TEXT NOT NULL,
+    rule_id       TEXT NOT NULL,
+    rule_version  INT  NOT NULL,
+    class         TEXT NOT NULL,
+    severity      TEXT NOT NULL,
+    host_id       TEXT NOT NULL,
+    observed_at   TIMESTAMPTZ NOT NULL,
+    -- The sealed chain link this detection is. A detection cannot exist without its evidence, so the FK
+    -- is NOT NULL and points at the real chain row.
+    evidence_id   TEXT NOT NULL REFERENCES evidence(id),
+    batch_seq     BIGINT NOT NULL,
+    detection     JSONB  NOT NULL,
+    recorded_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- NULL = never expires. A set value is enforced only by an audited expiry action, never a silent job.
+    expires_at    TIMESTAMPTZ,
+    PRIMARY KEY (tenant_id, id)
+);
+
+CREATE INDEX idx_detections_engagement ON detections(tenant_id, engagement_id, recorded_at);
+CREATE INDEX idx_detections_agent_seq  ON detections(tenant_id, agent_id, batch_seq);
+
+-- Incident rollup: repeated detections of the same rule on the same asset, folded into an incident-level
+-- view. It is a VIEW — the individual attributable detections remain the ledger underneath, and
+-- array_agg(id) lets an auditor descend from an incident to them. security_invoker makes the base
+-- table's RLS apply to the QUERYING tenant, so the rollup is tenant-scoped exactly like the table.
+CREATE VIEW detection_incidents
+    WITH (security_invoker = true) AS
+SELECT tenant_id,
+       engagement_id,
+       asset_id,
+       rule_id,
+       count(*)                  AS detection_count,
+       -- Severity is a LABEL, so a plain max() would be alphabetical ('low' > 'high' > 'critical') and
+       -- under-report risk. Rank by an explicit ordinal and map the highest rank back to its label.
+       (ARRAY['info','low','medium','high','critical'])[
+           max(array_position(ARRAY['info','low','medium','high','critical'], severity))
+       ]                         AS worst_severity,
+       min(observed_at)          AS first_observed,
+       max(observed_at)          AS last_observed,
+       array_agg(id ORDER BY id) AS detection_ids
+FROM detections
+GROUP BY tenant_id, engagement_id, asset_id, rule_id;
+
+CALL synapse_enable_tenant_rls('detections');
+
+-- +goose Down
+DROP VIEW IF EXISTS detection_incidents;
+DROP TABLE detections;


### PR DESCRIPTION
## What

Issue #423: a blue-team **detection becomes a hash-chained, attributable evidence record** — in the SAME evidence spine as findings and judgments (`kind="detection"`), not a second chain and not an alert row. This is the differentiator: a detection is defensible in an audit and joins the correlation graph.

## Pieces

- **`fleetagent.AgentBatch`** — sequenced, ed25519-signed batches. `SignBatch`/`VerifyBatch` cover the canonical, sorted membership + sequence, so neither can be altered without breaking the signature. `DetectSequenceGap` flags a missing sequence (potential loss) or a replay.
- **`detection.Record`** + **`Rollup`** — the queryable projection binding a detection to its evidence-chain link, the **asset** it was observed on, the agent, and the batch sequence. `Rollup` folds repeats into incidents **as a view** — the individual attributable records are preserved (`DetectionIDs`).
- **`detectledger.Service`** — `Ingest` verifies the batch signature (fail closed on unknown agent / bad sig, before any seal), detects a sequence gap (**audited `batch_gap`**, replay refused — never double-sealed), seals each detection into the evidence chain via a consumer `EvidenceChain` interface, and persists the projection. `VerifyChain` delegates to the evidence verifier so a **broken chain blocks the dependent report**. `Expire` is an **audited** action (actor + reason required) that removes only projection rows — the chain link is permanent. A read-only `Reader` backs the HTTP route.
- **Boundary (AC2, enforced + tested):** detections are chained; **raw telemetry is not**. The ledger has no path that seals a `detection.Event` — a test asserts every seal is `kind="detection"`.
- **Persistence:** migration `0074_detections.sql` — projection table (composite `PRIMARY KEY (tenant_id, id)`, `evidence_id` FK to the chain, retention `expires_at`), an incident rollup **VIEW with `security_invoker`** (tenant-scoped like the table), RLS via `synapse_enable_tenant_rls`. Postgres + memory stores.
- **Surface:** `GET /api/v1/engagements/{id}/detections` (+ `?view=incidents`), `PermView` + `withEngTenant`; a `make harness` cross-tenant case (→404, no leak).

## AC coverage

1. chained with full binding ✓ · 2. detections chained / telemetry not (tested boundary) ✓ · 3. signed + sequenced batches, gap = audited potential loss ✓ · 4. broken chain blocks the report ✓ · 5. references its asset ✓ · 6. incident rollup preserves the underlying detections ✓ · 7. tenant-scoped (RLS + memory + harness) ✓ · 8. retention/expiry audited, never silent ✓.

## Verified

- `go build ./...`, `go vet`, `gofmt` clean.
- `go test -race` on domain/usecase/memory; the hostile harness (cross-tenant detection → 404); and the **Postgres 17 integration test** (RLS isolation on the table AND the `security_invoker` rollup view, `evidence_id` FK, idempotent append, audited expiry). CI stays disabled per repo config — validated locally + on real Postgres.

## Scope note (honest deferral)

The **read** route is wired live in `synapse-api`. The **ingest** write-path (`Service.Ingest` → seal) is fully built and tested but not yet wired to a live producer: it needs the agent→control-plane batch transport (a fleet endpoint) and an agent signing-key resolver (the #408 identity → ed25519 batch key). That transport is a thin follow-up that plugs the same `detectionRecordStore` + a chain bridge into `detectledger.NewService`; the ledger semantics this issue is about are complete and proven.
