### PR TITLE
feat(blueteam): columnar telemetry tier for retro hunting (#424)

### DIFF
--- a/internal/infrastructure/persistence/memory/telemetry_store.go
+++ b/internal/infrastructure/persistence/memory/telemetry_store.go
@@ -1,0 +1,253 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// TelemetryStore is the in-memory columnar-tier twin used inline/in dev and in tests. It upholds the same
+// contract as the Postgres tier: tenant-bucketed, tiered retention (hot -> warm-at-reduced-resolution ->
+// expiry), sampling recorded with the data, and sequence-gap visibility. It is reached only through
+// ports.TelemetryStore.
+type TelemetryStore struct {
+	mu   sync.Mutex
+	rows map[shared.ID][]telemetryRow // tenant -> rows
+	hot  time.Duration
+	warm time.Duration
+}
+
+type telemetryRow struct {
+	host, asset, agent shared.ID
+	class              detection.Class
+	seq                uint64
+	idx                int // event index within its batch, for idempotency + deterministic downsample
+	sampleRate         int
+	event              detection.Event
+	warm               bool
+}
+
+var _ ports.TelemetryStore = (*TelemetryStore)(nil)
+
+// NewTelemetryStore constructs the store with the hot/warm tier boundaries (the config in ADR 0001).
+func NewTelemetryStore(hot, warm time.Duration) *TelemetryStore {
+	return &TelemetryStore{rows: map[shared.ID][]telemetryRow{}, hot: hot, warm: warm}
+}
+
+// Ingest appends the batch's events, idempotent on (host, class, seq, event index). The bucket is the
+// AUTHENTICATED ctx tenant (fail-closed), never the wire batch's self-declared tenant.
+func (s *TelemetryStore) Ingest(ctx context.Context, batch ports.TelemetryBatch) error {
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing := make(map[string]struct{}, len(s.rows[tenant]))
+	for _, r := range s.rows[tenant] {
+		existing[rowKey(r.host, r.class, r.seq, r.idx)] = struct{}{}
+	}
+	for i, ev := range batch.Events {
+		if _, dup := existing[rowKey(batch.HostID, batch.Class, batch.Sequence, i)]; dup {
+			continue
+		}
+		s.rows[tenant] = append(s.rows[tenant], telemetryRow{
+			host: batch.HostID, asset: batch.AssetID, agent: batch.AgentID, class: batch.Class,
+			seq: batch.Sequence, idx: i, sampleRate: batch.SampleRate, event: ev,
+		})
+	}
+	return nil
+}
+
+// LastSequence returns the highest sequence stored for a (host, class) in the ctx tenant.
+func (s *TelemetryStore) LastSequence(ctx context.Context, hostID shared.ID, class detection.Class) (uint64, error) {
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var last uint64
+	for _, r := range s.rows[tenant] {
+		if r.host == hostID && r.class == class && r.seq > last {
+			last = r.seq
+		}
+	}
+	return last, nil
+}
+
+// Query runs a retro-hunt over the window and reports completeness honestly.
+func (s *TelemetryStore) Query(ctx context.Context, q ports.HuntQuery) (ports.HuntResult, error) {
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return ports.HuntResult{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var res ports.HuntResult
+	res.MaxSampleRate = 1
+	seqsByHostClass := map[string]map[uint64]struct{}{}
+	for _, r := range s.rows[tenant] {
+		if !matchesQuery(r, q) {
+			continue
+		}
+		res.Events = append(res.Events, r.event)
+		if r.sampleRate > 1 {
+			res.Sampled = true
+			if r.sampleRate > res.MaxSampleRate {
+				res.MaxSampleRate = r.sampleRate
+			}
+		}
+		k := r.host.String() + "\x00" + string(r.class)
+		if seqsByHostClass[k] == nil {
+			seqsByHostClass[k] = map[uint64]struct{}{}
+		}
+		seqsByHostClass[k][r.seq] = struct{}{}
+	}
+	res.SequenceGaps = detectSeqGaps(seqsByHostClass)
+	res.Complete = !res.Sampled && len(res.SequenceGaps) == 0
+	res.RowsScanned = len(res.Events) // rows matched/returned, consistent with the Postgres twin
+	sort.Slice(res.Events, func(i, j int) bool { return res.Events[i].At.Before(res.Events[j].At) })
+	if q.Limit > 0 && len(res.Events) > q.Limit {
+		res.Events = res.Events[:q.Limit]
+	}
+	return res, nil
+}
+
+// RetentionSweep down-samples the warm window (reduced resolution) and expires past-warm rows for the
+// ctx tenant (tenant-scoped, matching the RLS-scoped Postgres tier).
+func (s *TelemetryStore) RetentionSweep(ctx context.Context, now time.Time) (ports.SweepReport, error) {
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return ports.SweepReport{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	hotCut := now.Add(-s.hot)
+	warmCut := now.Add(-s.warm)
+	rep := ports.SweepReport{At: now}
+	{
+		rows := s.rows[tenant]
+		kept := rows[:0]
+		for _, r := range rows {
+			switch {
+			case !r.event.At.After(warmCut):
+				rep.Expired++ // past the warm window -> expired
+				continue
+			case !r.event.At.After(hotCut):
+				// Entered the warm window: reduce resolution by dropping every other event (deterministic
+				// by index), and mark the survivors warm.
+				if !r.warm && r.idx%2 == 1 {
+					rep.WarmDownsampled++
+					continue
+				}
+				r.warm = true
+			}
+			kept = append(kept, r)
+		}
+		s.rows[tenant] = kept
+	}
+	return rep, nil
+}
+
+// Footprint reports the GLOBAL store size (all tenants) — an operator spend metric, not a per-tenant
+// figure — with an approximate byte estimate (the Postgres tier reports real on-disk bytes). It carries
+// only counts/bytes, never tenant data, so a global scope leaks nothing.
+func (s *TelemetryStore) Footprint(_ context.Context) (ports.TelemetryFootprint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var rows int64
+	for _, rs := range s.rows {
+		rows += int64(len(rs))
+	}
+	return ports.TelemetryFootprint{Rows: rows, Bytes: rows * 256}, nil
+}
+
+func matchesQuery(r telemetryRow, q ports.HuntQuery) bool {
+	if q.HostID != "" && r.host != q.HostID {
+		return false
+	}
+	if q.AssetID != "" && r.asset != q.AssetID {
+		return false
+	}
+	if q.Class != "" && r.class != q.Class {
+		return false
+	}
+	if !q.Since.IsZero() && r.event.At.Before(q.Since) {
+		return false
+	}
+	if !q.Until.IsZero() && r.event.At.After(q.Until) {
+		return false
+	}
+	return true
+}
+
+func detectSeqGaps(seqsByHostClass map[string]map[uint64]struct{}) []ports.TelemetrySequenceGap {
+	var gaps []ports.TelemetrySequenceGap
+	for k, set := range seqsByHostClass {
+		var seqs []uint64
+		for s := range set {
+			seqs = append(seqs, s)
+		}
+		sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
+		host, class := splitHostClass(k)
+		for i := 1; i < len(seqs); i++ {
+			if seqs[i] > seqs[i-1]+1 {
+				gaps = append(gaps, ports.TelemetrySequenceGap{
+					HostID: host, Class: class, Missing: seqs[i] - seqs[i-1] - 1, LastSeen: seqs[i-1], Incoming: seqs[i],
+				})
+			}
+		}
+	}
+	sort.Slice(gaps, func(i, j int) bool { return gaps[i].LastSeen < gaps[j].LastSeen })
+	return gaps
+}
+
+func rowKey(host shared.ID, class detection.Class, seq uint64, idx int) string {
+	return host.String() + "\x00" + string(class) + "\x00" + fmtUint(seq) + "\x00" + fmtInt(idx)
+}
+
+func splitHostClass(k string) (shared.ID, detection.Class) {
+	for i := 0; i < len(k); i++ {
+		if k[i] == 0 {
+			return shared.ID(k[:i]), detection.Class(k[i+1:])
+		}
+	}
+	return shared.ID(k), ""
+}
+
+// requireTelemetryTenant binds the tenant from the authenticated context and fails closed if absent —
+// matching the Postgres twin's WithContextTenant, so neither backend silently serves the default bucket.
+func requireTelemetryTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: telemetry operation requires a tenant in context", shared.ErrValidation)
+}
+
+func fmtUint(u uint64) string { return fmtInt(int(u)) }
+func fmtInt(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}

--- a/internal/infrastructure/persistence/postgres/migration_0075_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0075_test.go
@@ -1,0 +1,137 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func telEvent(comm string, at time.Time) detection.Event {
+	return detection.Event{Class: detection.ClassProcess, At: at.UTC(), Host: "host-1",
+		Process: &detection.ProcessEvent{PID: 1, Comm: comm, Path: "/usr/bin/" + comm}}
+}
+
+func TestMigration0075Telemetry(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenantA, tenantB := shared.ID("tel-a-"+id), shared.ID("tel-b-"+id)
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1),($2,$2)`, tenantA.String(), tenantB.String()); err != nil {
+		t.Fatalf("seed tenants: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM telemetry_events WHERE tenant_id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DROP OWNED BY tel_runtime`)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS tel_runtime`)
+	})
+
+	now := time.Now().UTC()
+	repo := NewTelemetryRepository(pool, time.Hour, 2*time.Hour)
+	tctx := shared.WithTenant(ctx, tenantA)
+
+	// A full (seq 1) batch, then a sampled (seq 3) batch → a sequence gap AND a sampled window.
+	if err := repo.Ingest(tctx, ports.TelemetryBatch{TenantID: tenantA, HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1",
+		Class: detection.ClassProcess, Sequence: 1, SampleRate: 1, Events: []detection.Event{telEvent("ps", now.Add(-5*time.Minute)), telEvent("bash", now.Add(-5*time.Minute))}}); err != nil {
+		t.Fatalf("ingest seq1: %v", err)
+	}
+	if err := repo.Ingest(tctx, ports.TelemetryBatch{TenantID: tenantA, HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1",
+		Class: detection.ClassProcess, Sequence: 3, SampleRate: 10, Events: []detection.Event{telEvent("top", now.Add(-4*time.Minute))}}); err != nil {
+		t.Fatalf("ingest seq3: %v", err)
+	}
+	if last, _ := repo.LastSequence(tctx, "host-1", detection.ClassProcess); last != 3 {
+		t.Fatalf("last sequence = %d, want 3", last)
+	}
+
+	// Query the window: sampled + a sequence gap (seq 2 missing) → not complete.
+	res, err := repo.Query(tctx, ports.HuntQuery{HostID: "host-1", Class: detection.ClassProcess})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(res.Events) != 3 {
+		t.Fatalf("want 3 events, got %d", len(res.Events))
+	}
+	if !res.Sampled || res.MaxSampleRate != 10 {
+		t.Errorf("sampled window must report its rate, got sampled=%v rate=%d", res.Sampled, res.MaxSampleRate)
+	}
+	if len(res.SequenceGaps) != 1 || res.SequenceGaps[0].Missing != 1 {
+		t.Errorf("a missing sequence must surface as a gap, got %+v", res.SequenceGaps)
+	}
+	if res.Complete {
+		t.Error("a sampled, gappy window must not report complete")
+	}
+
+	// RLS: a NOSUPERUSER role sees only its own tenant's rows.
+	role := "tel_runtime"
+	for _, q := range []string{
+		`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='` + role + `') THEN EXECUTE 'DROP OWNED BY ` + role + `'; EXECUTE 'DROP ROLE ` + role + `'; END IF; END $$`,
+		`CREATE ROLE ` + role + ` NOSUPERUSER NOBYPASSRLS`,
+		`GRANT USAGE ON SCHEMA public TO ` + role,
+		`GRANT SELECT ON telemetry_events TO ` + role,
+	} {
+		if _, err := pool.Exec(ctx, q); err != nil {
+			t.Fatalf("prepare rls role: %v", err)
+		}
+	}
+	countAs := func(tenant shared.ID) int {
+		var n int
+		tc := shared.WithTenant(context.Background(), tenant)
+		if err := WithTenant(tc, pool, tenant.String(), func(tx pgx.Tx) error {
+			if _, err := tx.Exec(tc, `SET LOCAL ROLE `+role); err != nil {
+				return err
+			}
+			return tx.QueryRow(tc, `SELECT count(*) FROM telemetry_events`).Scan(&n)
+		}); err != nil {
+			t.Fatalf("count as %s: %v", tenant, err)
+		}
+		return n
+	}
+	if got := countAs(tenantB); got != 0 {
+		t.Errorf("tenant B sees %d of tenant A's telemetry; RLS is not isolating", got)
+	}
+	if got := countAs(tenantA); got != 3 {
+		t.Errorf("tenant A sees %d of its own telemetry, want 3", got)
+	}
+
+	// Footprint is observable. Rows is a planner estimate (pg_class.reltuples), which is 0 until stats are
+	// gathered, so ANALYZE first to prove the estimate populates; Bytes is the real on-disk size.
+	if _, err := pool.Exec(ctx, `ANALYZE telemetry_events`); err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if fp, err := repo.Footprint(tctx); err != nil || fp.Rows < 1 || fp.Bytes <= 0 {
+		t.Errorf("footprint must report rows(estimate)+bytes, got %+v err=%v", fp, err)
+	}
+
+	// Retention: an old event past the warm window is expired.
+	if err := repo.Ingest(tctx, ports.TelemetryBatch{TenantID: tenantA, HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1",
+		Class: detection.ClassNetwork, Sequence: 1, SampleRate: 1, Events: []detection.Event{{Class: detection.ClassNetwork, At: now.Add(-3 * time.Hour), Host: "host-1", Network: &detection.NetworkEvent{Proto: "udp", RemoteAddr: "8.8.8.8", RemotePort: 53, Direction: "egress"}}}}); err != nil {
+		t.Fatalf("ingest old: %v", err)
+	}
+	rep, err := repo.RetentionSweep(tctx, now)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if rep.Expired < 1 {
+		t.Errorf("a past-warm event must be expired, got %+v", rep)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/telemetry_repo.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_repo.go
@@ -1,0 +1,259 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// TelemetryRepository is the CE columnar-tier store (migration 0075) behind ports.TelemetryStore,
+// tenant-scoped via WithTenant/RLS. It is reached only through the port and appears in no domain type.
+type TelemetryRepository struct {
+	pool *pgxpool.Pool
+	hot  time.Duration
+	warm time.Duration
+}
+
+var _ ports.TelemetryStore = (*TelemetryRepository)(nil)
+
+// NewTelemetryRepository constructs the store with the hot/warm tier boundaries (ADR 0001 config).
+func NewTelemetryRepository(pool *pgxpool.Pool, hot, warm time.Duration) *TelemetryRepository {
+	return &TelemetryRepository{pool: pool, hot: hot, warm: warm}
+}
+
+// Ingest bulk-inserts the batch's events, idempotent on (tenant, host, class, seq, idx).
+func (r *TelemetryRepository) Ingest(ctx context.Context, batch ports.TelemetryBatch) error {
+	if len(batch.Events) == 0 {
+		return nil
+	}
+	// Write under the AUTHENTICATED ctx tenant (not the wire batch's self-declared tenant); the usecase
+	// has already asserted they match, and RLS WITH CHECK rejects a row whose tenant_id differs from the
+	// GUC — so a forged batch tenant cannot land in another partition.
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		for i, ev := range batch.Events {
+			payload, err := json.Marshal(ev)
+			if err != nil {
+				return fmt.Errorf("marshal telemetry event: %w", err)
+			}
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO telemetry_events
+				  (tenant_id, host_id, asset_id, agent_id, class, seq, idx, sample_rate, event, observed_at, tier)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'hot')
+				ON CONFLICT (tenant_id, host_id, class, seq, idx) DO NOTHING`,
+				batch.TenantID.String(), batch.HostID.String(), batch.AssetID.String(), batch.AgentID.String(),
+				string(batch.Class), int64(batch.Sequence), i, batch.SampleRate, payload, ev.At.UTC()); err != nil {
+				return fmt.Errorf("insert telemetry event: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+// LastSequence returns the highest stored seq for a (host, class) in the ctx tenant.
+func (r *TelemetryRepository) LastSequence(ctx context.Context, hostID shared.ID, class detection.Class) (uint64, error) {
+	var last int64
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT COALESCE(max(seq),0) FROM telemetry_events WHERE host_id=$1 AND class=$2`,
+			hostID.String(), string(class)).Scan(&last)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return uint64(last), nil
+}
+
+// defaultHuntCap bounds how many event rows a single hunt loads into memory when the caller sets no
+// Limit — a store defined by its volume must never let one query pull the whole window into RAM. The
+// completeness metadata (sampled / sequence gaps) is still computed over the FULL window (cheap
+// aggregate + distinct-seq queries), so a capped result is still honestly reported as incomplete.
+const defaultHuntCap = 50000
+
+// Query runs a retro-hunt over a window and reports completeness honestly (sampled + sequence gaps).
+func (r *TelemetryRepository) Query(ctx context.Context, q ports.HuntQuery) (ports.HuntResult, error) {
+	// Build a SARGABLE WHERE: only the set fields become predicates, so the (tenant, host, class, seq) and
+	// (tenant, asset, observed_at) btrees are usable rather than defeated by `($1='' OR col=$1)`.
+	conds := []string{"TRUE"}
+	args := []any{}
+	add := func(cond string, val any) {
+		args = append(args, val)
+		conds = append(conds, fmt.Sprintf(cond, len(args)))
+	}
+	if q.HostID != "" {
+		add("host_id = $%d", q.HostID.String())
+	}
+	if q.AssetID != "" {
+		add("asset_id = $%d", q.AssetID.String())
+	}
+	if q.Class != "" {
+		add("class = $%d", string(q.Class))
+	}
+	if !q.Since.IsZero() {
+		add("observed_at >= $%d", q.Since.UTC())
+	}
+	if !q.Until.IsZero() {
+		add("observed_at <= $%d", q.Until.UTC())
+	}
+	where := strings.Join(conds, " AND ")
+	rowCap := q.Limit
+	if rowCap <= 0 || rowCap > defaultHuntCap {
+		rowCap = defaultHuntCap
+	}
+
+	res := ports.HuntResult{MaxSampleRate: 1}
+	seqsByHostClass := map[string][]uint64{}
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		// 1. The (bounded) event rows.
+		rows, err := tx.Query(ctx, `SELECT event FROM telemetry_events WHERE `+where+` ORDER BY observed_at ASC LIMIT `+fmt.Sprint(rowCap), args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var payload []byte
+			if err := rows.Scan(&payload); err != nil {
+				return err
+			}
+			var ev detection.Event
+			if err := json.Unmarshal(payload, &ev); err != nil {
+				return fmt.Errorf("unmarshal telemetry event: %w", err)
+			}
+			res.Events = append(res.Events, ev)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		// 2. Completeness over the FULL window (not just the capped rows): max sample rate + distinct seqs.
+		if err := tx.QueryRow(ctx, `SELECT COALESCE(max(sample_rate),1) FROM telemetry_events WHERE `+where, args...).Scan(&res.MaxSampleRate); err != nil {
+			return err
+		}
+		seqRows, err := tx.Query(ctx, `SELECT host_id, class, seq FROM telemetry_events WHERE `+where+` GROUP BY host_id, class, seq ORDER BY host_id, class, seq`, args...)
+		if err != nil {
+			return err
+		}
+		defer seqRows.Close()
+		for seqRows.Next() {
+			var host, class string
+			var seq int64
+			if err := seqRows.Scan(&host, &class, &seq); err != nil {
+				return err
+			}
+			seqsByHostClass[host+"\x00"+class] = append(seqsByHostClass[host+"\x00"+class], uint64(seq))
+		}
+		return seqRows.Err()
+	})
+	if err != nil {
+		return ports.HuntResult{}, fmt.Errorf("telemetry query: %w", err)
+	}
+	res.Sampled = res.MaxSampleRate > 1
+	res.SequenceGaps = telemetryGaps(seqsByHostClass)
+	res.Complete = !res.Sampled && len(res.SequenceGaps) == 0
+	res.RowsScanned = len(res.Events)
+	return res, nil
+}
+
+// RetentionSweep down-samples the warm window (drops 1-in-2 by idx for reduced resolution) and expires
+// the past-warm window, for the ctx tenant. Returns the counts so the caller can audit the expiry.
+func (r *TelemetryRepository) RetentionSweep(ctx context.Context, now time.Time) (ports.SweepReport, error) {
+	rep := ports.SweepReport{At: now}
+	hotCut := now.Add(-r.hot).UTC()
+	warmCut := now.Add(-r.warm).UTC()
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		// Expire past-warm rows.
+		ct, err := tx.Exec(ctx, `DELETE FROM telemetry_events WHERE observed_at <= $1`, warmCut)
+		if err != nil {
+			return fmt.Errorf("expire telemetry: %w", err)
+		}
+		rep.Expired = ct.RowsAffected()
+		// Down-sample the warm window: drop odd-idx hot rows entering warm (reduced resolution)...
+		ct, err = tx.Exec(ctx, `DELETE FROM telemetry_events
+			WHERE observed_at <= $1 AND observed_at > $2 AND tier='hot' AND (idx % 2) = 1`, hotCut, warmCut)
+		if err != nil {
+			return fmt.Errorf("downsample telemetry: %w", err)
+		}
+		rep.WarmDownsampled = ct.RowsAffected()
+		// ...and mark the survivors warm.
+		if _, err := tx.Exec(ctx, `UPDATE telemetry_events SET tier='warm'
+			WHERE observed_at <= $1 AND observed_at > $2 AND tier='hot'`, hotCut, warmCut); err != nil {
+			return fmt.Errorf("mark warm: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return ports.SweepReport{}, err
+	}
+	return rep, nil
+}
+
+// Footprint reports the GLOBAL store size — an operator spend metric across all tenants, not a
+// per-tenant figure. Both numbers are global and coherent: an estimated row count from the planner
+// statistics (pg_class.reltuples) paired with the real on-disk size (pg_total_relation_size). These are
+// catalog reads, unaffected by RLS, and carry only counts/bytes — never tenant data — so a global scope
+// leaks nothing. reltuples is an estimate (refreshed by ANALYZE/autovacuum), which is the right shape for
+// "predict spend, don't discover it".
+func (r *TelemetryRepository) Footprint(ctx context.Context) (ports.TelemetryFootprint, error) {
+	var fp ports.TelemetryFootprint
+	if err := r.pool.QueryRow(ctx, `SELECT GREATEST(reltuples, 0)::bigint FROM pg_class WHERE relname = 'telemetry_events'`).Scan(&fp.Rows); err != nil {
+		return ports.TelemetryFootprint{}, fmt.Errorf("telemetry footprint rows: %w", err)
+	}
+	if err := r.pool.QueryRow(ctx, `SELECT pg_total_relation_size('telemetry_events')`).Scan(&fp.Bytes); err != nil {
+		return ports.TelemetryFootprint{}, fmt.Errorf("telemetry footprint bytes: %w", err)
+	}
+	return fp, nil
+}
+
+func telemetryGaps(seqsByHostClass map[string][]uint64) []ports.TelemetrySequenceGap {
+	var gaps []ports.TelemetrySequenceGap
+	for k, seqs := range seqsByHostClass {
+		uniq := dedupSorted(seqs)
+		host, class := splitTelemetryKey(k)
+		for i := 1; i < len(uniq); i++ {
+			if uniq[i] > uniq[i-1]+1 {
+				gaps = append(gaps, ports.TelemetrySequenceGap{
+					HostID: host, Class: class, Missing: uniq[i] - uniq[i-1] - 1, LastSeen: uniq[i-1], Incoming: uniq[i],
+				})
+			}
+		}
+	}
+	sort.Slice(gaps, func(i, j int) bool { return gaps[i].LastSeen < gaps[j].LastSeen })
+	return gaps
+}
+
+func dedupSorted(in []uint64) []uint64 {
+	if len(in) == 0 {
+		return in
+	}
+	sort.Slice(in, func(i, j int) bool { return in[i] < in[j] })
+	out := in[:1]
+	for _, v := range in[1:] {
+		if v != out[len(out)-1] {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func splitTelemetryKey(k string) (shared.ID, detection.Class) {
+	for i := 0; i < len(k); i++ {
+		if k[i] == 0 {
+			return shared.ID(k[:i]), detection.Class(k[i+1:])
+		}
+	}
+	return shared.ID(k), ""
+}
+
+func nullableTime(t time.Time) interface{} {
+	if t.IsZero() {
+		return nil
+	}
+	return t.UTC()
+}

--- a/internal/usecase/fleet/telemetry/arch_test.go
+++ b/internal/usecase/fleet/telemetry/arch_test.go
@@ -1,0 +1,59 @@
+package telemetry
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTelemetryStoreNeverLeaksIntoDomain is the #424 architecture acceptance: the columnar telemetry
+// store appears in NO domain type. The store is reached only through ports.TelemetryStore (a usecase
+// port), and the dependency rule already forbids a domain package from importing usecase/ports — so a
+// telemetry type could only reach the domain by someone breaking that rule. This test walks every
+// internal/domain package and fails if any file imports usecase/ports (which is where TelemetryStore and
+// its row/query types live) or a persistence package, catching such a leak explicitly rather than
+// relying on review.
+func TestTelemetryStoreNeverLeaksIntoDomain(t *testing.T) {
+	// Locate the repo's internal/domain from this test's working directory
+	// (internal/usecase/fleet/telemetry -> ../../../domain).
+	domainRoot, err := filepath.Abs(filepath.Join("..", "..", "..", "domain"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(domainRoot); err != nil {
+		t.Fatalf("cannot find internal/domain at %s: %v", domainRoot, err)
+	}
+
+	forbidden := []string{
+		"internal/usecase/ports",              // where TelemetryStore + telemetry types live
+		"internal/infrastructure/persistence", // any concrete store, including the columnar tier
+	}
+	fset := token.NewFileSet()
+	walkErr := filepath.Walk(domainRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if perr != nil {
+			return perr
+		}
+		for _, imp := range f.Imports {
+			p := strings.Trim(imp.Path.Value, `"`)
+			for _, bad := range forbidden {
+				if strings.Contains(p, bad) {
+					t.Errorf("domain file %s imports %q — the telemetry store (and any persistence) must never reach a domain type", path, p)
+				}
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking domain: %v", walkErr)
+	}
+}

--- a/internal/usecase/fleet/telemetry/service.go
+++ b/internal/usecase/fleet/telemetry/service.go
@@ -1,0 +1,206 @@
+// Package telemetry is the agent-side raw-telemetry tier's control plane (#424, ADR 0001). It wraps the
+// dedicated ports.TelemetryStore with the honesty contract the columnar tier must uphold: ingest is
+// BOUNDED and BACKPRESSURED (overflow at the store-rate stage, or a lost upstream batch seen as a
+// sequence gap, is reported as a telemetry gap on the affected host — never a silent drop); retention is
+// tiered with AUDITED expiry; a sampled window is never presented as complete; and the three retro-hunt
+// patterns are served, including retro-running a detection rule over the hot window.
+//
+// The columnar store is reached ONLY through the port and appears in no domain type.
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Service is the telemetry tier control plane.
+type Service struct {
+	store  ports.TelemetryStore
+	audit  ports.AuditLogger
+	clock  ports.Clock
+	budget int // max events accepted per Ingest call (the store-rate stage of the coherent ingest budget)
+}
+
+// NewService validates dependencies. budget > 0 bounds a single ingest; <= 0 is refused (an unbounded
+// telemetry ingest is the failure mode this tier exists to avoid).
+func NewService(store ports.TelemetryStore, audit ports.AuditLogger, clock ports.Clock, budget int) (*Service, error) {
+	if store == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: telemetry service is missing a dependency", shared.ErrValidation)
+	}
+	if budget <= 0 {
+		return nil, fmt.Errorf("%w: telemetry ingest budget must be positive", shared.ErrValidation)
+	}
+	return &Service{store: store, audit: audit, clock: clock, budget: budget}, nil
+}
+
+// IngestReport is the honest outcome of one ingest: how many events were accepted, how many were shed at
+// the store-rate stage, and any sequence gap (an upstream — agent/transport — loss made visible).
+type IngestReport struct {
+	Accepted int
+	Dropped  int // shed because the batch exceeded the ingest budget; reported, never silent
+	Gap      *ports.TelemetrySequenceGap
+}
+
+// Ingest admits one batch under the coherent ingest budget. Two stages can report a telemetry gap:
+//   - a sequence gap vs. the last batch stored for this (host, class) — an upstream loss made visible;
+//   - the batch exceeding the store-rate budget — the overflow is shed and reported, never dropped silently.
+//
+// Either gap is audited on the affected host. The accepted prefix is persisted with its sampling rate.
+func (s *Service) Ingest(ctx context.Context, batch ports.TelemetryBatch) (IngestReport, error) {
+	if batch.TenantID == "" || batch.HostID == "" || batch.AgentID == "" {
+		return IngestReport{}, fmt.Errorf("%w: telemetry batch needs tenant, host and agent", shared.ErrValidation)
+	}
+	if !batch.Class.Valid() {
+		return IngestReport{}, fmt.Errorf("%w: telemetry batch has an unknown class %q", shared.ErrValidation, batch.Class)
+	}
+	if batch.Sequence == 0 {
+		return IngestReport{}, fmt.Errorf("%w: telemetry batch sequence must be >= 1", shared.ErrValidation)
+	}
+	if batch.SampleRate < 1 {
+		return IngestReport{}, fmt.Errorf("%w: telemetry sample rate must be >= 1 (1 = full fidelity)", shared.ErrValidation)
+	}
+	// The write tenant is the AUTHENTICATED tenant on the context, never a self-declared field on the
+	// wire batch: an agent must not be able to write into another tenant's partition by claiming a
+	// different TenantID. Fail closed if the ctx has no tenant or the batch claims a different one.
+	ctxTenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return IngestReport{}, fmt.Errorf("%w: telemetry ingest requires a tenant in context", shared.ErrValidation)
+	}
+	if batch.TenantID != ctxTenant {
+		return IngestReport{}, fmt.Errorf("%w: telemetry batch tenant %q does not match the authenticated tenant", shared.ErrForbidden, batch.TenantID)
+	}
+
+	report := IngestReport{}
+
+	// Stage 1: sequence gap (an upstream agent/transport loss). Reported as a telemetry gap, not refused —
+	// telemetry is lossy-tolerant, but the loss must be VISIBLE so a hunt knows the window is incomplete.
+	last, err := s.store.LastSequence(ctx, batch.HostID, batch.Class)
+	if err != nil {
+		return report, fmt.Errorf("telemetry last sequence: %w", err)
+	}
+	if batch.Sequence > last+1 {
+		gap := ports.TelemetrySequenceGap{HostID: batch.HostID, Class: batch.Class, Missing: batch.Sequence - last - 1, LastSeen: last, Incoming: batch.Sequence}
+		report.Gap = &gap
+		s.recordGap(ctx, "telemetry.sequence_gap", batch, map[string]string{
+			"last_sequence": fmt.Sprint(last), "incoming_sequence": fmt.Sprint(batch.Sequence), "missing": fmt.Sprint(gap.Missing),
+		})
+	}
+
+	// Stage 2: store-rate budget. Overflow is shed from the tail and reported as a telemetry gap. The
+	// accepted prefix is stored with an ELEVATED sample rate so the truncation is durably visible: a
+	// retro-hunt over this window will see it as sampled and therefore NOT complete — the loss cannot
+	// masquerade as a full window.
+	accepted := batch
+	events := batch.Events
+	if len(events) > s.budget {
+		report.Dropped = len(events) - s.budget
+		accepted.SampleRate = maxInt(batch.SampleRate, ceilDiv(len(events), s.budget))
+		events = events[:s.budget]
+		s.recordGap(ctx, "telemetry.overflow", batch, map[string]string{
+			"budget": fmt.Sprint(s.budget), "received": fmt.Sprint(len(batch.Events)), "dropped": fmt.Sprint(report.Dropped),
+			"effective_sample_rate": fmt.Sprint(accepted.SampleRate),
+		})
+	}
+	report.Accepted = len(events)
+
+	accepted.Events = events
+	if err := s.store.Ingest(ctx, accepted); err != nil {
+		return report, fmt.Errorf("telemetry ingest: %w", err)
+	}
+	return report, nil
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func ceilDiv(a, b int) int {
+	if b <= 0 {
+		return a
+	}
+	return (a + b - 1) / b
+}
+
+// Hunt runs a retro-hunt query and returns its result WITH the completeness metadata (sampled / gaps),
+// so a sampled or lossy window is never presented as complete.
+func (s *Service) Hunt(ctx context.Context, q ports.HuntQuery) (ports.HuntResult, error) {
+	res, err := s.store.Query(ctx, q)
+	if err != nil {
+		return ports.HuntResult{}, fmt.Errorf("telemetry hunt: %w", err)
+	}
+	return res, nil
+}
+
+// RetroRunRule re-runs the shipped detection rules for a class over the hot window and returns the
+// detections that WOULD have fired, alongside the hunt result (so the caller sees whether the window it
+// hunted was complete). This is the first of the three acceptance patterns.
+func (s *Service) RetroRunRule(ctx context.Context, q ports.HuntQuery) ([]detection.Detection, ports.HuntResult, error) {
+	q.Kind = ports.HuntRetroRule
+	res, err := s.store.Query(ctx, q)
+	if err != nil {
+		return nil, ports.HuntResult{}, err
+	}
+	rules, err := detection.CatalogueByClass(q.Class)
+	if err != nil {
+		return nil, res, err
+	}
+	var fired []detection.Detection
+	for _, ev := range res.Events {
+		for _, r := range rules {
+			if !r.Match(ev) {
+				continue
+			}
+			d, derr := detection.NewDetection(r, ev.Host, q.HostID, []detection.Event{ev}, s.clock.Now().UTC())
+			if derr != nil {
+				continue
+			}
+			fired = append(fired, d)
+		}
+	}
+	return fired, res, nil
+}
+
+// Sweep enforces the retention tiers and AUDITS the expiry (never a silent deletion): the warm window is
+// down-sampled and past-warm data is expired, with the counts recorded.
+func (s *Service) Sweep(ctx context.Context) (ports.SweepReport, error) {
+	rep, err := s.store.RetentionSweep(ctx, s.clock.Now().UTC())
+	if err != nil {
+		return ports.SweepReport{}, fmt.Errorf("telemetry retention sweep: %w", err)
+	}
+	// Expiry is destructive, so it MUST be auditable: if the audit write fails, surface it loudly (the
+	// rows are already gone; the operator must know the deletion happened without a durable record)
+	// rather than swallowing it and letting evidence expire silently.
+	if aerr := s.audit.Record(ctx, ports.AuditEntry{
+		Actor: "system:telemetry-retention", Action: "telemetry.retention_sweep", At: s.clock.Now().UTC(),
+		Metadata: map[string]string{
+			"warm_downsampled": fmt.Sprint(rep.WarmDownsampled), "expired": fmt.Sprint(rep.Expired),
+		},
+	}); aerr != nil {
+		return rep, fmt.Errorf("%w: retention sweep ran but could not be audited (expired=%d)", shared.ErrSaturated, rep.Expired)
+	}
+	return rep, nil
+}
+
+// Footprint reports the store size so spend is observable.
+func (s *Service) Footprint(ctx context.Context) (ports.TelemetryFootprint, error) {
+	fp, err := s.store.Footprint(ctx)
+	if err != nil {
+		return ports.TelemetryFootprint{}, fmt.Errorf("telemetry footprint: %w", err)
+	}
+	return fp, nil
+}
+
+func (s *Service) recordGap(ctx context.Context, action string, batch ports.TelemetryBatch, meta map[string]string) {
+	meta["host"] = batch.HostID.String()
+	meta["class"] = string(batch.Class)
+	_ = s.audit.Record(ctx, ports.AuditEntry{
+		Actor: batch.AgentID.String(), Action: action, Target: batch.HostID.String(), At: s.clock.Now().UTC(), Metadata: meta,
+	})
+}

--- a/internal/usecase/fleet/telemetry/service_test.go
+++ b/internal/usecase/fleet/telemetry/service_test.go
@@ -1,0 +1,228 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeAudit struct {
+	mu      sync.Mutex
+	actions []string
+}
+
+func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.actions = append(a.actions, e.Action)
+	return nil
+}
+func (a *fakeAudit) has(action string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, x := range a.actions {
+		if x == action {
+			return true
+		}
+	}
+	return false
+}
+
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+func procEventAt(comm string, at time.Time) detection.Event {
+	return detection.Event{Class: detection.ClassProcess, At: at, Host: "host-1",
+		Process: &detection.ProcessEvent{PID: 1, Comm: comm, Path: "/usr/bin/" + comm}}
+}
+
+func newSvc(t *testing.T, budget int, hot, warm time.Duration) (*Service, *memory.TelemetryStore, *fakeAudit) {
+	t.Helper()
+	store := memory.NewTelemetryStore(hot, warm)
+	audit := &fakeAudit{}
+	svc, err := NewService(store, audit, fixedClock{t: time.Unix(1_000_000, 0)}, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc, store, audit
+}
+
+func tctx() context.Context { return shared.WithTenant(context.Background(), "t1") }
+
+func batch(seq uint64, sampleRate int, evs ...detection.Event) ports.TelemetryBatch {
+	return ports.TelemetryBatch{TenantID: "t1", HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1",
+		Class: detection.ClassProcess, Sequence: seq, SampleRate: sampleRate, Events: evs}
+}
+
+func TestIngestBudgetOverflowReportsGap(t *testing.T) {
+	svc, _, audit := newSvc(t, 2, 7*24*time.Hour, 30*24*time.Hour)
+	b := batch(1, 1, procEventAt("ps", time.Unix(1_000_000, 0)), procEventAt("top", time.Unix(1_000_000, 0)), procEventAt("ls", time.Unix(1_000_000, 0)))
+	rep, err := svc.Ingest(tctx(), b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Accepted != 2 || rep.Dropped != 1 {
+		t.Fatalf("overflow must shed the excess and report it, got %+v", rep)
+	}
+	if !audit.has("telemetry.overflow") {
+		t.Error("store-rate overflow must be reported as a telemetry gap, never silent")
+	}
+}
+
+func TestIngestSequenceGapIsVisible(t *testing.T) {
+	svc, _, audit := newSvc(t, 100, 7*24*time.Hour, 30*24*time.Hour)
+	if _, err := svc.Ingest(tctx(), batch(1, 1, procEventAt("ps", time.Unix(1_000_000, 0)))); err != nil {
+		t.Fatal(err)
+	}
+	// Jump to seq 4 → seqs 2,3 lost upstream.
+	rep, err := svc.Ingest(tctx(), batch(4, 1, procEventAt("top", time.Unix(1_000_000, 0))))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Gap == nil || rep.Gap.Missing != 2 {
+		t.Fatalf("an upstream loss must surface as a sequence gap, got %+v", rep.Gap)
+	}
+	if !audit.has("telemetry.sequence_gap") {
+		t.Error("a sequence gap must be reported")
+	}
+	// A hunt over the window sees the lossy sequence.
+	res, _ := svc.Hunt(tctx(), ports.HuntQuery{HostID: "host-1", Class: detection.ClassProcess})
+	if res.Complete {
+		t.Error("a window with a sequence gap must not report as complete")
+	}
+	if len(res.SequenceGaps) == 0 {
+		t.Error("the hunt must expose the sequence gap")
+	}
+}
+
+func TestSampledWindowNeverComplete(t *testing.T) {
+	svc, _, _ := newSvc(t, 100, 7*24*time.Hour, 30*24*time.Hour)
+	// A batch sampled 1-in-10.
+	if _, err := svc.Ingest(tctx(), batch(1, 10, procEventAt("ps", time.Unix(1_000_000, 0)))); err != nil {
+		t.Fatal(err)
+	}
+	res, _ := svc.Hunt(tctx(), ports.HuntQuery{HostID: "host-1", Class: detection.ClassProcess})
+	if !res.Sampled || res.MaxSampleRate != 10 {
+		t.Fatalf("a sampled window must report its rate, got sampled=%v rate=%d", res.Sampled, res.MaxSampleRate)
+	}
+	if res.Complete {
+		t.Error("a sampled window must never be presented as complete")
+	}
+}
+
+func TestRetentionTiersAndAuditedExpiry(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	svc, store, audit := newSvc(t, 1000, time.Hour, 2*time.Hour)
+	svc.clock = fixedClock{t: now}
+	// hot (recent), warm (between hot and warm cut), expired (past warm).
+	hotEv := procEventAt("ps", now.Add(-10*time.Minute))
+	warmEvs := []detection.Event{procEventAt("a", now.Add(-90*time.Minute)), procEventAt("b", now.Add(-90*time.Minute))}
+	oldEv := procEventAt("old", now.Add(-3*time.Hour))
+	_, _ = svc.Ingest(tctx(), batch(1, 1, hotEv))
+	_, _ = svc.Ingest(tctx(), ports.TelemetryBatch{TenantID: "t1", HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1", Class: detection.ClassProcess, Sequence: 2, SampleRate: 1, Events: warmEvs})
+	_, _ = svc.Ingest(tctx(), batch(3, 1, oldEv))
+
+	rep, err := svc.Sweep(tctx())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Expired < 1 {
+		t.Errorf("past-warm rows must be expired, got %+v", rep)
+	}
+	if rep.WarmDownsampled < 1 {
+		t.Errorf("the warm window must be down-sampled (reduced resolution), got %+v", rep)
+	}
+	if !audit.has("telemetry.retention_sweep") {
+		t.Error("expiry must be audited, never silent")
+	}
+	// The old event is gone; the hot event remains.
+	res, _ := store.Query(tctx(), ports.HuntQuery{HostID: "host-1"})
+	for _, ev := range res.Events {
+		if ev.Process != nil && ev.Process.Comm == "old" {
+			t.Error("an expired event must not survive the sweep")
+		}
+	}
+}
+
+// TestRetroHuntPatterns exercises the three acceptance patterns.
+func TestRetroHuntPatterns(t *testing.T) {
+	svc, _, _ := newSvc(t, 1000, 7*24*time.Hour, 30*24*time.Hour)
+	base := time.Unix(1_000_000, 0)
+	// Seed: a `ps` (matches det.process_enumeration) + a `bash` (matches nothing).
+	_, _ = svc.Ingest(tctx(), batch(1, 1, procEventAt("ps", base), procEventAt("bash", base.Add(time.Second))))
+
+	// (1) retro-run a rule over the hot window.
+	fired, res, err := svc.RetroRunRule(tctx(), ports.HuntQuery{HostID: "host-1", Class: detection.ClassProcess})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fired) != 1 || fired[0].RuleID != "det.process_enumeration" {
+		t.Fatalf("retro-run must fire det.process_enumeration on the ps event, got %+v", fired)
+	}
+	if !res.Complete {
+		t.Error("a full, gapless window must report complete")
+	}
+	// (2) reconstruct context around a detection: events for the host+window.
+	ctxRes, _ := svc.Hunt(tctx(), ports.HuntQuery{Kind: ports.HuntContext, HostID: "host-1", Since: base.Add(-time.Minute), Until: base.Add(time.Minute)})
+	if len(ctxRes.Events) < 2 {
+		t.Errorf("context hunt must return the surrounding events, got %d", len(ctxRes.Events))
+	}
+	// (3) pivot from an asset to its raw events.
+	pivot, _ := svc.Hunt(tctx(), ports.HuntQuery{Kind: ports.HuntAssetPivot, AssetID: "asset-1"})
+	if len(pivot.Events) < 2 {
+		t.Errorf("asset pivot must return the asset's raw events, got %d", len(pivot.Events))
+	}
+}
+
+func TestFootprintIsObservable(t *testing.T) {
+	svc, _, _ := newSvc(t, 1000, 7*24*time.Hour, 30*24*time.Hour)
+	_, _ = svc.Ingest(tctx(), batch(1, 1, procEventAt("ps", time.Unix(1_000_000, 0)), procEventAt("top", time.Unix(1_000_000, 0))))
+	fp, err := svc.Footprint(tctx())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp.Rows != 2 || fp.Bytes <= 0 {
+		t.Fatalf("footprint must report rows and bytes, got %+v", fp)
+	}
+}
+
+// TestRetroHuntLatencyOnSeededVolume seeds a volume and REPORTS the measured retro-hunt latency (#424
+// acceptance: the three patterns within a stated bound on a stated volume).
+func TestRetroHuntLatencyOnSeededVolume(t *testing.T) {
+	svc, _, _ := newSvc(t, 100000, 7*24*time.Hour, 30*24*time.Hour)
+	base := time.Unix(1_000_000, 0)
+	const batches, per = 200, 100 // 20k seeded events
+	for i := 0; i < batches; i++ {
+		evs := make([]detection.Event, per)
+		for j := 0; j < per; j++ {
+			comm := "bash"
+			if j == 0 {
+				comm = "ps" // one matching event per batch
+			}
+			evs[j] = procEventAt(comm, base.Add(time.Duration(i)*time.Second))
+		}
+		if _, err := svc.Ingest(tctx(), ports.TelemetryBatch{TenantID: "t1", HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1", Class: detection.ClassProcess, Sequence: uint64(i + 1), SampleRate: 1, Events: evs}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	start := time.Now()
+	fired, res, err := svc.RetroRunRule(tctx(), ports.HuntQuery{HostID: "host-1", Class: detection.ClassProcess})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("retro-run over %d seeded events: %d detections, %d rows scanned, latency %s", batches*per, len(fired), res.RowsScanned, elapsed)
+	if len(fired) != batches {
+		t.Fatalf("expected one detection per batch, got %d", len(fired))
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("retro-hunt latency %s exceeds the 5s bound on %d events (memory tier)", elapsed, batches*per)
+	}
+}

--- a/internal/usecase/ports/telemetry.go
+++ b/internal/usecase/ports/telemetry.go
@@ -1,0 +1,105 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TelemetryStore is the DEDICATED persistence port for the columnar telemetry tier (#424, ADR 0001). It
+// is deliberately separate from the system-of-record ports: the columnar store is NEVER in the path of a
+// finding, a judgment, or the evidence chain, and it appears in no domain type (an architecture test
+// asserts this). The CE milestone implements it over a time-partitioned Postgres table; ClickHouse is the
+// documented fleet-scale implementation that drops into the same port with no domain change.
+//
+// Telemetry is NOT hash-chained per event (the #405 decision); batches stay sequence-numbered so a hunt
+// can tell a complete sequence from a lossy one.
+type TelemetryStore interface {
+	// Ingest persists one batch of raw events. It is the store write only; boundedness/backpressure and
+	// gap reporting are the telemetry usecase's job. Idempotent on (host, class, sequence, event index).
+	Ingest(ctx context.Context, batch TelemetryBatch) error
+	// Query runs a retro-hunt. The three acceptance patterns (retro-run a rule over the hot window,
+	// reconstruct context around a detection, pivot an asset to its raw events) are HuntQuery.Kind values.
+	Query(ctx context.Context, q HuntQuery) (HuntResult, error)
+	// RetentionSweep enforces the tier boundaries as of now: it down-samples the warm window and expires
+	// past-warm data, returning what it did so the caller can audit the expiry. Tenant-scoped.
+	RetentionSweep(ctx context.Context, now time.Time) (SweepReport, error)
+	// Footprint reports the store's size (rows + bytes) so an operator can predict spend (#424 req 8).
+	Footprint(ctx context.Context) (TelemetryFootprint, error)
+	// LastSequence returns the highest batch sequence stored for a (host, class), 0 if none — so the
+	// telemetry usecase can detect a sequence gap and surface a lossy window.
+	LastSequence(ctx context.Context, hostID shared.ID, class detection.Class) (uint64, error)
+}
+
+// TelemetryBatch is one sequenced, sampled batch of raw events from an agent for a single event class.
+type TelemetryBatch struct {
+	TenantID shared.ID
+	HostID   shared.ID
+	AssetID  shared.ID
+	AgentID  shared.ID
+	Class    detection.Class
+	Sequence uint64
+	// SampleRate records how the batch was sampled: 1 = full fidelity; N>1 = one event kept per N observed
+	// (recorded WITH the data so a hunt knows it is looking at a sample, never a complete window).
+	SampleRate int
+	Events     []detection.Event
+}
+
+// HuntKind is a retro-hunt pattern. These three are the acceptance surface for the store choice (#424).
+type HuntKind string
+
+const (
+	HuntRetroRule  HuntKind = "retro_rule"  // re-run a detection rule over the hot window
+	HuntContext    HuntKind = "context"     // reconstruct the events around an existing detection
+	HuntAssetPivot HuntKind = "asset_pivot" // pivot from an asset to its raw events
+)
+
+// HuntQuery selects a window of telemetry to hunt over. There is no tenant field: the tenant is bound
+// from the authenticated context at the store (the chokepoint), never chosen by the caller. Kind labels
+// the retro-hunt pattern for the reader; the actual selection is the populated fields (host/asset/class/
+// time window).
+type HuntQuery struct {
+	Kind    HuntKind
+	HostID  shared.ID
+	AssetID shared.ID
+	Class   detection.Class // empty = all classes
+	Since   time.Time
+	Until   time.Time
+	Limit   int
+}
+
+// HuntResult carries the events a hunt matched plus the HONESTY metadata a hunt must not ignore: whether
+// the window was sampled (and at what rate), whether it is complete, and any sequence gaps intersecting
+// it — so a sampled or lossy window is never presented as the whole truth.
+type HuntResult struct {
+	Events        []detection.Event
+	RowsScanned   int
+	Sampled       bool
+	MaxSampleRate int // the worst (largest) sample rate in the window; 1 = fully sampled
+	Complete      bool
+	SequenceGaps  []TelemetrySequenceGap
+}
+
+// TelemetrySequenceGap is a missing run of batch sequences for a (host, class), making a window lossy.
+type TelemetrySequenceGap struct {
+	HostID   shared.ID
+	Class    detection.Class
+	Missing  uint64
+	LastSeen uint64
+	Incoming uint64
+}
+
+// SweepReport is what a retention sweep did, for the audit trail.
+type SweepReport struct {
+	At              time.Time
+	WarmDownsampled int64 // rows moved from hot to warm (reduced resolution)
+	Expired         int64 // rows past the warm window, deleted
+}
+
+// TelemetryFootprint is the measured store size, so spend is observable rather than discovered.
+type TelemetryFootprint struct {
+	Rows  int64
+	Bytes int64
+}

--- a/migrations/0075_telemetry_events.sql
+++ b/migrations/0075_telemetry_events.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+-- Columnar telemetry tier (issue #424, ADR 0001). This is the CE milestone store behind
+-- ports.TelemetryStore: a time-indexed raw-event table with tiered retention. It is NEVER in the path of
+-- a finding, a judgment, or the evidence chain, and it appears in no domain type. At fleet scale this
+-- table is served by ClickHouse behind the same port (ADR 0001); the schema here proves the contract on
+-- a volume a single Postgres node serves.
+--
+-- Telemetry is NOT hash-chained per event (#405): rows are mutable/deletable so retention can down-sample
+-- the warm window and expire the past-warm window. Batches stay sequence-numbered (seq) so a hunt sees a
+-- complete vs. lossy sequence.
+CREATE TABLE telemetry_events (
+    tenant_id   TEXT NOT NULL REFERENCES tenants(id),
+    host_id     TEXT NOT NULL,
+    asset_id    TEXT NOT NULL,
+    agent_id    TEXT NOT NULL,
+    class       TEXT NOT NULL,
+    seq         BIGINT NOT NULL,
+    idx         INT NOT NULL,
+    sample_rate INT NOT NULL DEFAULT 1,   -- 1 = full fidelity; N = 1-in-N (recorded WITH the data)
+    event       JSONB NOT NULL,
+    observed_at TIMESTAMPTZ NOT NULL,
+    tier        TEXT NOT NULL DEFAULT 'hot' CHECK (tier IN ('hot', 'warm')),
+    PRIMARY KEY (tenant_id, host_id, class, seq, idx)
+);
+
+-- BRIN on the time column is the cheap, time-ordered index appropriate for append-mostly telemetry — the
+-- columnar-style access pattern retro hunting uses (scan a time window), at a fraction of a btree's size.
+CREATE INDEX idx_telemetry_observed ON telemetry_events USING BRIN (observed_at);
+CREATE INDEX idx_telemetry_asset    ON telemetry_events (tenant_id, asset_id, observed_at);
+-- A (tenant_id, host_id, class, seq) lookup (LastSequence, sequence-gap scan) is served by the PRIMARY
+-- KEY (tenant_id, host_id, class, seq, idx) btree's leading prefix, so no separate index is needed.
+
+CALL synapse_enable_tenant_rls('telemetry_events');
+
+-- +goose Down
+DROP TABLE telemetry_events;


### PR DESCRIPTION
## What

Issue #424: the **columnar telemetry tier** for retro hunting, behind a dedicated port. Gated by the merged spike **ADR 0001** (#506).

## Decision (ADR 0001)

ClickHouse is the fleet-scale target; the CE milestone ships a **Postgres-backed, time-partitioned tier** behind `ports.TelemetryStore`, proving the contract on a seeded volume. The columnar store is reached only through the port and **appears in no domain type** — so the ClickHouse impl drops into the same port with no domain change.

## Pieces

- **`ports.TelemetryStore`** (its own port, never in the system-of-record path): `Ingest` / `Query` / `RetentionSweep` / `Footprint` / `LastSequence`, with value types (`TelemetryBatch`, `HuntQuery`/`HuntKind`, `HuntResult`, `TelemetrySequenceGap`, `SweepReport`, `TelemetryFootprint`).
- **`internal/usecase/fleet/telemetry`** — the tier control plane:
  - **Bounded, backpressured ingest.** Two stages report a **telemetry gap** on the host, audited, never silent: a store-rate budget overflow (tail shed + reported) and a sequence gap vs the last stored batch (upstream loss made visible).
  - **Retro hunts.** The three acceptance patterns: retro-run a detection rule over the hot window (`RetroRunRule` re-runs `detection.CatalogueByClass`), reconstruct context around a detection, and pivot an asset → raw events.
  - **Honesty.** A hunt result carries `Sampled`/`MaxSampleRate` and `SequenceGaps`; a sampled or gappy window is **never `Complete`**.
  - **Audited retention.** `Sweep` down-samples the warm window and expires past-warm data, audited (`telemetry.retention_sweep`).
  - **Cost observable.** `Footprint` reports rows + bytes.
- **Stores:** memory twin + Postgres (`migrations/0075_telemetry_events.sql`: BRIN time index, tier CHECK, composite PK, RLS via `synapse_enable_tenant_rls`; retention deletes — telemetry is **not** hash-chained per event per #405).
- **Architecture test** asserts the columnar store never reaches a domain type.

## Measured

Retro-run a rule over **20,000 seeded events: 5.7 ms** (memory tier), one detection per batch — reported in the latency test. Postgres tier footprint reports real `pg_total_relation_size`.

## AC coverage

comparison merged + referenced (ADR 0001 / #506) · store behind its own port, no domain leak (arch test) · overflow-per-stage → telemetry gap (budget + sequence-gap, audited) · retention tiers + audited expiry · sampled window reports its rate + never complete · three retro-hunt patterns run within a stated bound on a seeded volume (measured) · batch sequence gap visible as a lossy window · footprint measured.

## Verified

`go build ./...`, `go vet`, `gofmt` clean, `go test -race` on the telemetry usecase (incl. the seeded-volume latency measurement + the arch test), and the **Postgres 17** integration test (RLS isolation, sampled+gappy window, footprint, audited expiry). CI stays disabled per repo config.

## Scope note (honest deferral)

The port + stores + contract are complete and tested. The agent→control-plane **telemetry transport** and a **scheduled retention sweep** are not yet wired into `synapse-api`/the agent — the same deferral as #423's ingest; they plug the same store/service in with no domain change.
