### PR TITLE
feat(blueteam): governed, reversible, audited response actions (#425)

### DIFF
--- a/internal/domain/response/action.go
+++ b/internal/domain/response/action.go
@@ -1,0 +1,155 @@
+// Package response is the pure domain for governed defensive response actions (issue #425): contain,
+// isolate, quarantine. It adds NO new trust model — it reuses the one that governs exploitation:
+// server-side admission, an argv-only sandbox, an append-only audit, approval-as-evidence, and a
+// decision a model can propose but never make. This package defines the actions and their MANDATORY
+// reversals; admission, approval and execution live in internal/usecase/response.
+//
+// Every action is REVERSIBLE by construction: an Action with no declared reversal cannot be built, and a
+// catalogue drift test fails CI if a Kind is ever added without one. Every action is argv-only — no
+// shell, ever, including the reversal.
+package response
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Kind is a response action type. The first cut is deliberately small, high-confidence, and each maps to
+// an agent capability with a clean reversal (#425 requirement 5).
+type Kind string
+
+const (
+	KindIsolateHost    Kind = "isolate_host"    // network-isolate a host; reversal restores connectivity
+	KindQuarantineFile Kind = "quarantine_file" // move a file to quarantine; reversal restores it
+	KindStopProcess    Kind = "stop_process"    // stop a process; reversal is documented as best-effort restart
+)
+
+// ReversalKind is the response Kind that undoes a given action. Keeping the reversal typed (a Kind, not a
+// free string) means a reversal is itself a first-class, admittable, auditable action.
+type ReversalKind string
+
+const (
+	ReversalRestoreHost    ReversalKind = "restore_host"
+	ReversalRestoreFile    ReversalKind = "restore_file"
+	ReversalRestartProcess ReversalKind = "restart_process"
+)
+
+// ReversalSpec declares how an action is undone. It is REQUIRED on every action: Description states the
+// intent for the operator/audit, and Argv is the argv-only reversal command (no shell). An empty spec is
+// refused at construction, and the catalogue drift test fails CI if a Kind lacks one.
+type ReversalSpec struct {
+	Kind        ReversalKind `json:"kind"`
+	Description string       `json:"description"`
+	Argv        []string     `json:"argv"`
+}
+
+func (r ReversalSpec) valid() bool {
+	return r.Kind != "" && r.Description != "" && len(r.Argv) > 0 && !containsShell(r.Argv)
+}
+
+// Action is one governed response. It is state-changing by nature, declares its blast radius (enforced
+// at execution), and carries its mandatory reversal. Argv is the exact argv-only command.
+type Action struct {
+	ID          shared.ID
+	Kind        Kind
+	Target      shared.ID // the asset the action affects
+	BlastRadius offensivepolicy.Radius
+	Argv        []string // argv-only; no shell
+	Reversal    ReversalSpec
+}
+
+// Validate fails CLOSED: a missing reversal, empty argv, a shell metacharacter, an unknown kind, or an
+// invalid radius each make the action unimplementable. Reversibility is mandatory, so an action without
+// a valid reversal is refused here (not at runtime).
+func (a Action) Validate() error {
+	if a.ID == "" {
+		return fmt.Errorf("%w: response action has no id", shared.ErrValidation)
+	}
+	if !a.Kind.valid() {
+		return fmt.Errorf("%w: unknown response kind %q", shared.ErrValidation, a.Kind)
+	}
+	if a.Target == "" {
+		return fmt.Errorf("%w: response action %s has no target", shared.ErrValidation, a.ID)
+	}
+	if !a.BlastRadius.Valid() {
+		return fmt.Errorf("%w: response action %s has an invalid blast radius %q", shared.ErrValidation, a.ID, a.BlastRadius)
+	}
+	if len(a.Argv) == 0 || containsShell(a.Argv) {
+		return fmt.Errorf("%w: response action %s must be argv-only with no shell", shared.ErrValidation, a.ID)
+	}
+	if !a.Reversal.valid() {
+		return fmt.Errorf("%w: response action %s has no valid reversal — reversibility is mandatory", shared.ErrValidation, a.ID)
+	}
+	// The reversal for this kind must be the catalogued one, so an action cannot declare a bogus reversal.
+	if want := catalogue[a.Kind].Reversal.Kind; a.Reversal.Kind != want {
+		return fmt.Errorf("%w: response %s reversal must be %q, got %q", shared.ErrValidation, a.Kind, want, a.Reversal.Kind)
+	}
+	return nil
+}
+
+func (k Kind) valid() bool {
+	_, ok := catalogue[k]
+	return ok
+}
+
+// Spec is the catalogued contract for a Kind: its blast radius and the required reversal kind. It is the
+// single source of truth the drift test guards.
+type Spec struct {
+	Kind     Kind
+	Radius   offensivepolicy.Radius
+	Reversal ReversalSpec
+}
+
+// catalogue maps each response Kind to its contract. EVERY entry carries a reversal; the drift test
+// (action_test.go) fails CI if any Kind is added without one — the "an action with no reversal fails a
+// CI check, not a runtime check" requirement.
+var catalogue = map[Kind]Spec{
+	KindIsolateHost: {
+		Kind: KindIsolateHost, Radius: offensivepolicy.RadiusStateChanging,
+		Reversal: ReversalSpec{Kind: ReversalRestoreHost, Description: "restore host network connectivity", Argv: []string{"synapse-agent-response", "restore-host"}},
+	},
+	KindQuarantineFile: {
+		Kind: KindQuarantineFile, Radius: offensivepolicy.RadiusStateChanging,
+		Reversal: ReversalSpec{Kind: ReversalRestoreFile, Description: "restore the quarantined file to its path", Argv: []string{"synapse-agent-response", "restore-file"}},
+	},
+	KindStopProcess: {
+		Kind: KindStopProcess, Radius: offensivepolicy.RadiusStateChanging,
+		Reversal: ReversalSpec{Kind: ReversalRestartProcess, Description: "restart the stopped process (best-effort)", Argv: []string{"synapse-agent-response", "restart-process"}},
+	},
+}
+
+// Catalogue returns the response contracts in a deterministic order.
+func Catalogue() []Spec {
+	kinds := make([]Kind, 0, len(catalogue))
+	for k := range catalogue {
+		kinds = append(kinds, k)
+	}
+	sort.Slice(kinds, func(i, j int) bool { return kinds[i] < kinds[j] })
+	out := make([]Spec, 0, len(kinds))
+	for _, k := range kinds {
+		out = append(out, catalogue[k])
+	}
+	return out
+}
+
+// SpecFor returns the catalogued contract for a kind.
+func SpecFor(k Kind) (Spec, bool) { s, ok := catalogue[k]; return s, ok }
+
+// containsShell reports whether any argv token carries a shell metacharacter — a coarse guard so a
+// caller cannot smuggle a shell fragment into an "argv-only" command.
+func containsShell(argv []string) bool {
+	const meta = "|&;<>()$`\\\"'\n\t*?[]{}"
+	for _, tok := range argv {
+		for _, r := range tok {
+			for _, m := range meta {
+				if r == m {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/domain/response/action_test.go
+++ b/internal/domain/response/action_test.go
@@ -1,0 +1,70 @@
+package response
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TestCatalogueEveryKindHasAReversal is the CI/drift check the #425 "an action with no reversal fails a
+// CI check, not a runtime check" requirement rests on: every catalogued Kind must carry a valid reversal.
+func TestCatalogueEveryKindHasAReversal(t *testing.T) {
+	specs := Catalogue()
+	if len(specs) == 0 {
+		t.Fatal("empty catalogue; the drift test would pass vacuously")
+	}
+	for _, s := range specs {
+		if !s.Reversal.valid() {
+			t.Errorf("response kind %s has no valid reversal — reversibility is mandatory", s.Kind)
+		}
+		if !s.Radius.Valid() {
+			t.Errorf("response kind %s has an invalid blast radius %q", s.Kind, s.Radius)
+		}
+	}
+}
+
+func validAction() Action {
+	sp := catalogue[KindIsolateHost]
+	return Action{ID: "act-1", Kind: KindIsolateHost, Target: "host-1", BlastRadius: sp.Radius,
+		Argv: []string{"synapse-agent-response", "isolate-host", "host-1"}, Reversal: sp.Reversal}
+}
+
+func TestActionValidateFailsClosed(t *testing.T) {
+	if err := validAction().Validate(); err != nil {
+		t.Fatalf("a well-formed action must validate: %v", err)
+	}
+	cases := map[string]func(*Action){
+		"no id":             func(a *Action) { a.ID = "" },
+		"unknown kind":      func(a *Action) { a.Kind = "nuke_from_orbit" },
+		"no target":         func(a *Action) { a.Target = "" },
+		"bad radius":        func(a *Action) { a.BlastRadius = "galactic" },
+		"no argv":           func(a *Action) { a.Argv = nil },
+		"shell in argv":     func(a *Action) { a.Argv = []string{"sh", "-c", "rm -rf / && echo pwned"} },
+		"no reversal":       func(a *Action) { a.Reversal = ReversalSpec{} },
+		"shell in reversal": func(a *Action) { a.Reversal.Argv = []string{"sh", "-c", "restore; echo x"} },
+		"wrong reversal":    func(a *Action) { a.Reversal.Kind = ReversalRestartProcess },
+	}
+	for name, mut := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := validAction()
+			mut(&a)
+			if err := a.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestReversalIsAlwaysStateChangingSafe(t *testing.T) {
+	// Sanity: the shipped reversals are argv-only and non-empty.
+	for _, s := range Catalogue() {
+		if containsShell(s.Reversal.Argv) {
+			t.Errorf("reversal for %s contains a shell metacharacter", s.Kind)
+		}
+		if s.Radius != offensivepolicy.RadiusStateChanging {
+			t.Errorf("response %s should be state-changing", s.Kind)
+		}
+	}
+}

--- a/internal/domain/response/record.go
+++ b/internal/domain/response/record.go
@@ -1,0 +1,42 @@
+package response
+
+import (
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// State is the lifecycle of a response action.
+type State string
+
+const (
+	StatePending   State = "pending"   // admitted-but-awaiting approval (the kill switch can cancel it)
+	StateApplied   State = "applied"   // executed
+	StateReverted  State = "reverted"  // its reversal was applied
+	StateCancelled State = "cancelled" // halted by the kill switch before applying
+	StateViolation State = "violation" // halted: actual effect exceeded the declared blast radius
+)
+
+// Valid reports whether s is a known state.
+func (s State) Valid() bool {
+	switch s {
+	case StatePending, StateApplied, StateReverted, StateCancelled, StateViolation:
+		return true
+	default:
+		return false
+	}
+}
+
+// Record is the persisted state of a response action, including the approval that authorized it (sealed
+// into the evidence chain by the admission gate).
+type Record struct {
+	ID                 shared.ID
+	TenantID           shared.ID
+	EngagementID       shared.ID
+	Action             Action
+	State              State
+	ApprovedBy         string
+	ApprovalEvidenceID shared.ID
+	AppliedAt          time.Time
+	UpdatedAt          time.Time
+}

--- a/internal/infrastructure/persistence/memory/response_store.go
+++ b/internal/infrastructure/persistence/memory/response_store.go
@@ -1,0 +1,80 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	rdom "github.com/KKloudTarus/synapse-ce/internal/domain/response"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ResponseStore is the in-memory response-action store, tenant-bucketed so one tenant's actions are
+// never visible to another. It backs idempotency, the kill-switch halt set, and the audit trail.
+type ResponseStore struct {
+	mu       sync.Mutex
+	byTenant map[shared.ID]map[shared.ID]rdom.Record // tenant -> action id -> record
+}
+
+var _ ports.ResponseStore = (*ResponseStore)(nil)
+
+// NewResponseStore constructs the store.
+func NewResponseStore() *ResponseStore {
+	return &ResponseStore{byTenant: map[shared.ID]map[shared.ID]rdom.Record{}}
+}
+
+// Get returns the record for an id in the ctx tenant.
+func (s *ResponseStore) Get(ctx context.Context, id shared.ID) (rdom.Record, bool, error) {
+	tenant, err := requireResponseTenant(ctx)
+	if err != nil {
+		return rdom.Record{}, false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.byTenant[tenant][id]
+	return r, ok, nil
+}
+
+// Put upserts a record under the authenticated tenant; a record claiming a different tenant is refused.
+func (s *ResponseStore) Put(ctx context.Context, r rdom.Record) error {
+	tenant, err := requireResponseTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if r.TenantID != "" && r.TenantID != tenant {
+		return shared.ErrForbidden
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.byTenant[tenant] == nil {
+		s.byTenant[tenant] = map[shared.ID]rdom.Record{}
+	}
+	s.byTenant[tenant][r.ID] = r
+	return nil
+}
+
+// ListByState returns the ctx tenant's records in the given state, deterministically ordered by id.
+func (s *ResponseStore) ListByState(ctx context.Context, state rdom.State) ([]rdom.Record, error) {
+	tenant, err := requireResponseTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []rdom.Record
+	for _, r := range s.byTenant[tenant] {
+		if r.State == state {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+func requireResponseTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", shared.ErrValidation
+}

--- a/internal/infrastructure/persistence/postgres/migration_0076_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0076_test.go
@@ -1,0 +1,124 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	rdom "github.com/KKloudTarus/synapse-ce/internal/domain/response"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestMigration0076ResponseActions(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenantA, tenantB := shared.ID("rsp-a-"+id), shared.ID("rsp-b-"+id)
+	engA := "rsp-eng-" + id
+	for _, stmt := range []struct {
+		q    string
+		args []any
+	}{
+		{`INSERT INTO tenants(id,name) VALUES($1,$1),($2,$2)`, []any{tenantA.String(), tenantB.String()}},
+		{`INSERT INTO engagements(id,tenant_id,name) VALUES($1,$2,'rsp-eng')`, []any{engA, tenantA.String()}},
+	} {
+		if _, err := pool.Exec(ctx, stmt.q, stmt.args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM response_actions WHERE tenant_id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DELETE FROM engagements WHERE tenant_id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DROP OWNED BY rsp_runtime`)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS rsp_runtime`)
+	})
+
+	repo := NewResponseRepository(pool)
+	tctx := shared.WithTenant(ctx, tenantA)
+	sp, _ := rdom.SpecFor(rdom.KindIsolateHost)
+	rec := rdom.Record{
+		ID: shared.ID("rec-" + id), TenantID: tenantA, EngagementID: shared.ID(engA),
+		Action: rdom.Action{ID: shared.ID("rec-" + id), Kind: rdom.KindIsolateHost, Target: "host-1",
+			BlastRadius: offensivepolicy.RadiusStateChanging, Argv: []string{"synapse-agent-response", "isolate-host", "host-1"}, Reversal: sp.Reversal},
+		State: rdom.StatePending, ApprovedBy: "alice", UpdatedAt: time.Unix(1000, 0).UTC(),
+	}
+	if err := repo.Put(tctx, rec); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	// Get round-trips the action incl. its reversal.
+	got, found, err := repo.Get(tctx, rec.ID)
+	if err != nil || !found {
+		t.Fatalf("get: found=%v err=%v", found, err)
+	}
+	if got.Action.Reversal.Kind != rdom.ReversalRestoreHost || len(got.Action.Argv) != 3 {
+		t.Fatalf("round-trip lost action detail: %+v", got.Action)
+	}
+	// State transition upsert.
+	rec.State = rdom.StateApplied
+	rec.AppliedAt = time.Unix(1001, 0).UTC()
+	if err := repo.Put(tctx, rec); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if applied, _ := repo.ListByState(tctx, rdom.StateApplied); len(applied) != 1 {
+		t.Fatalf("want 1 applied record, got %d", len(applied))
+	}
+
+	// RLS under a NOSUPERUSER role.
+	role := "rsp_runtime"
+	for _, q := range []string{
+		`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='` + role + `') THEN EXECUTE 'DROP OWNED BY ` + role + `'; EXECUTE 'DROP ROLE ` + role + `'; END IF; END $$`,
+		`CREATE ROLE ` + role + ` NOSUPERUSER NOBYPASSRLS`,
+		`GRANT USAGE ON SCHEMA public TO ` + role,
+		`GRANT SELECT ON response_actions TO ` + role,
+	} {
+		if _, err := pool.Exec(ctx, q); err != nil {
+			t.Fatalf("prepare rls role: %v", err)
+		}
+	}
+	countAs := func(tenant shared.ID) int {
+		var n int
+		tc := shared.WithTenant(context.Background(), tenant)
+		if err := WithTenant(tc, pool, tenant.String(), func(tx pgx.Tx) error {
+			if _, err := tx.Exec(tc, `SET LOCAL ROLE `+role); err != nil {
+				return err
+			}
+			return tx.QueryRow(tc, `SELECT count(*) FROM response_actions`).Scan(&n)
+		}); err != nil {
+			t.Fatalf("count as %s: %v", tenant, err)
+		}
+		return n
+	}
+	if got := countAs(tenantB); got != 0 {
+		t.Errorf("tenant B sees %d of tenant A's response actions; RLS is not isolating", got)
+	}
+	if got := countAs(tenantA); got != 1 {
+		t.Errorf("tenant A sees %d of its own actions, want 1", got)
+	}
+
+	// The reversal CHECK: a row whose reversal JSON lacks a kind is unstorable.
+	_, ckErr := pool.Exec(ctx, `INSERT INTO response_actions
+		(tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state)
+		VALUES ($1,'bad',$2,'isolate_host','host-1','state_changing','[]'::jsonb,'{}'::jsonb,'pending')`,
+		tenantA.String(), engA)
+	if ckErr == nil {
+		t.Error("a reversal with no kind must fail the CHECK (reversibility is mandatory)")
+	}
+}

--- a/internal/infrastructure/persistence/postgres/response_repo.go
+++ b/internal/infrastructure/persistence/postgres/response_repo.go
@@ -1,0 +1,148 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	rdom "github.com/KKloudTarus/synapse-ce/internal/domain/response"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ResponseRepository persists governed response actions (migration 0076), tenant-scoped via
+// WithTenant/RLS so one tenant's actions are never visible to another.
+type ResponseRepository struct{ pool *pgxpool.Pool }
+
+var _ ports.ResponseStore = (*ResponseRepository)(nil)
+
+// NewResponseRepository constructs the repository.
+func NewResponseRepository(pool *pgxpool.Pool) *ResponseRepository {
+	return &ResponseRepository{pool: pool}
+}
+
+// Put upserts a response record under the authenticated tenant.
+func (r *ResponseRepository) Put(ctx context.Context, rec rdom.Record) error {
+	argv, err := json.Marshal(rec.Action.Argv)
+	if err != nil {
+		return fmt.Errorf("marshal argv: %w", err)
+	}
+	reversal, err := json.Marshal(rec.Action.Reversal)
+	if err != nil {
+		return fmt.Errorf("marshal reversal: %w", err)
+	}
+	var applied *time.Time
+	if !rec.AppliedAt.IsZero() {
+		a := rec.AppliedAt.UTC()
+		applied = &a
+	}
+	var evID *string
+	if rec.ApprovalEvidenceID != "" {
+		e := rec.ApprovalEvidenceID.String()
+		evID = &e
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO response_actions
+			  (tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state, approved_by, approval_evidence_id, applied_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+			ON CONFLICT (tenant_id, id) DO UPDATE SET
+			  state = EXCLUDED.state, approved_by = EXCLUDED.approved_by,
+			  approval_evidence_id = EXCLUDED.approval_evidence_id, applied_at = EXCLUDED.applied_at,
+			  updated_at = EXCLUDED.updated_at`,
+			rec.TenantID.String(), rec.ID.String(), rec.EngagementID.String(), string(rec.Action.Kind),
+			rec.Action.Target.String(), string(rec.Action.BlastRadius), argv, reversal, string(rec.State),
+			rec.ApprovedBy, evID, applied, rec.UpdatedAt.UTC())
+		if err != nil {
+			return fmt.Errorf("upsert response action %s: %w", rec.ID, err)
+		}
+		return nil
+	})
+}
+
+// Get returns the record for an id in the ctx tenant.
+func (r *ResponseRepository) Get(ctx context.Context, id shared.ID) (rdom.Record, bool, error) {
+	var rec rdom.Record
+	found := false
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			SELECT tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state, approved_by, approval_evidence_id, applied_at
+			FROM response_actions WHERE id = $1`, id.String())
+		var scanned rdom.Record
+		if err := scanResponse(row, &scanned); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return err
+		}
+		rec = scanned
+		found = true
+		return nil
+	})
+	return rec, found, err
+}
+
+// ListByState returns the ctx tenant's records in a state, deterministically ordered by id.
+func (r *ResponseRepository) ListByState(ctx context.Context, state rdom.State) ([]rdom.Record, error) {
+	var out []rdom.Record
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state, approved_by, approval_evidence_id, applied_at
+			FROM response_actions WHERE state = $1 ORDER BY id ASC`, string(state))
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var rec rdom.Record
+			if err := scanResponse(rows, &rec); err != nil {
+				return err
+			}
+			out = append(out, rec)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+func scanResponse(row rowScanner, rec *rdom.Record) error {
+	var (
+		tenant, id, eng, kind, targetStr, radius, state, approvedBy string
+		argv, reversal                                              []byte
+		evID                                                        *string
+		applied                                                     *time.Time
+	)
+	if err := row.Scan(&tenant, &id, &eng, &kind, &targetStr, &radius, &argv, &reversal, &state, &approvedBy, &evID, &applied); err != nil {
+		return err
+	}
+	var argvSlice []string
+	if err := json.Unmarshal(argv, &argvSlice); err != nil {
+		return fmt.Errorf("unmarshal argv: %w", err)
+	}
+	var rev rdom.ReversalSpec
+	if err := json.Unmarshal(reversal, &rev); err != nil {
+		return fmt.Errorf("unmarshal reversal: %w", err)
+	}
+	rec.ID = shared.ID(id)
+	rec.TenantID = shared.ID(tenant)
+	rec.EngagementID = shared.ID(eng)
+	rec.State = rdom.State(state)
+	rec.ApprovedBy = approvedBy
+	if evID != nil {
+		rec.ApprovalEvidenceID = shared.ID(*evID)
+	}
+	if applied != nil {
+		rec.AppliedAt = *applied
+	}
+	rec.Action = rdom.Action{
+		ID: shared.ID(id), Kind: rdom.Kind(kind), Target: shared.ID(targetStr),
+		BlastRadius: offensivepolicy.Radius(radius), Argv: argvSlice, Reversal: rev,
+	}
+	return nil
+}

--- a/internal/usecase/offensivepolicy/killswitch.go
+++ b/internal/usecase/offensivepolicy/killswitch.go
@@ -50,6 +50,13 @@ type ChainHalter interface {
 	HaltChains(ctx context.Context, tenantID shared.ID, actor, reason string) (ChainHaltSummary, error)
 }
 
+// ResponseHalter halts pending/in-flight DEFENSIVE response actions for a tenant (#425): the kill switch
+// stops response actions exactly as it stops offensive work — a defensive action that changes a
+// production system must be as haltable as an offensive one. Optional; nil means no response layer.
+type ResponseHalter interface {
+	HaltResponses(ctx context.Context, tenantID shared.ID, actor, reason string) (int, error)
+}
+
 // HaltResult is what the operator gets back. It reports partial failure honestly: a halt that cancelled
 // nine of ten orders is not a clean halt, and saying so is the difference between an operator escalating
 // and an operator believing the estate is safe.
@@ -67,6 +74,10 @@ type HaltResult struct {
 	// ChainHaltError is set when the chain layer could not be driven at all (not a per-chain failure,
 	// which lands in Chains.Failed). It is a failure to halt and must not read like success.
 	ChainHaltError string
+	// ResponsesHalted counts the pending/in-flight defensive response actions this halt cancelled;
+	// ResponseHaltError is set when that layer could not be driven at all.
+	ResponsesHalted   int
+	ResponseHaltError string
 	// EstateStopNote states, in the response, what the bound does not cover. An operator reading only
 	// this field must not conclude the estate has stopped.
 	EstateStopNote string
@@ -75,7 +86,7 @@ type HaltResult struct {
 // Halted reports whether every in-flight offensive order AND every running chain was cancelled. A halt
 // that stopped every work order but left a chain running is not a clean halt.
 func (r HaltResult) Halted() bool {
-	return len(r.Failed) == 0 && r.Chains.clean() && r.ChainHaltError == ""
+	return len(r.Failed) == 0 && r.Chains.clean() && r.ChainHaltError == "" && r.ResponseHaltError == ""
 }
 
 // KillSwitch halts all in-flight offensive work for a tenant.
@@ -85,6 +96,7 @@ type KillSwitch struct {
 	isOffensive func(*workorder.WorkOrder) bool
 	now         func() time.Time
 	chains      ChainHalter
+	responses   ResponseHalter
 }
 
 // SetChainHalter wires the in-process chain registry so a halt also stops exploitation chains executing
@@ -94,6 +106,14 @@ type KillSwitch struct {
 func (k *KillSwitch) SetChainHalter(ch ChainHalter) {
 	if k != nil {
 		k.chains = ch
+	}
+}
+
+// SetResponseHalter wires the defensive-response layer so a halt also cancels pending/in-flight response
+// actions. Optional: left unset, the kill switch covers offensive work + chains alone.
+func (k *KillSwitch) SetResponseHalter(rh ResponseHalter) {
+	if k != nil {
+		k.responses = rh
 	}
 }
 
@@ -155,6 +175,14 @@ func (k *KillSwitch) Halt(ctx context.Context, tenantID shared.ID, actor, reason
 			result.ChainHaltError = cerr.Error()
 		}
 	}
+	// And the defensive-response layer: pending/in-flight response actions are halted like offensive work.
+	if k.responses != nil {
+		n, rerr := k.responses.HaltResponses(ctx, tenantID, actor, reason)
+		result.ResponsesHalted = n
+		if rerr != nil {
+			result.ResponseHaltError = rerr.Error()
+		}
+	}
 
 	orders, err := k.orders.ListByTenant(ctx, tenantID)
 	if err != nil {
@@ -205,6 +233,10 @@ func (k *KillSwitch) Halt(ctx context.Context, tenantID shared.ID, actor, reason
 			return result, fmt.Errorf("%w: halt failed for %d work order(s) and could not drive chain halt: %s",
 				shared.ErrSaturated, len(result.Failed), result.ChainHaltError)
 		}
+		if result.ResponseHaltError != "" {
+			return result, fmt.Errorf("%w: halt failed for %d work order(s) and could not drive response halt: %s",
+				shared.ErrSaturated, len(result.Failed), result.ResponseHaltError)
+		}
 		return result, fmt.Errorf("%w: halt failed for %d work order(s) and %d chain(s)",
 			shared.ErrSaturated, len(result.Failed), len(result.Chains.Failed))
 	}
@@ -233,18 +265,22 @@ func (k *KillSwitch) retryOnce(ctx context.Context, tenantID, id shared.ID, reas
 
 func (k *KillSwitch) recordAudit(ctx context.Context, actor, reason string, tenantID shared.ID, result *HaltResult, note string) {
 	meta := map[string]string{
-		"tenant":          tenantID.String(),
-		"reason":          reason,
-		"cancelled":       fmt.Sprint(len(result.Cancelled)),
-		"failed":          fmt.Sprint(len(result.Failed)),
-		"chains_halted":   fmt.Sprint(len(result.Chains.Halted)),
-		"chains_failed":   fmt.Sprint(len(result.Chains.Failed)),
-		"duration_ms":     fmt.Sprint(result.Duration.Milliseconds()),
-		"within_bound":    fmt.Sprint(result.WithinBound),
-		"stated_bound_ms": fmt.Sprint(HaltBound.Milliseconds()),
+		"tenant":           tenantID.String(),
+		"reason":           reason,
+		"cancelled":        fmt.Sprint(len(result.Cancelled)),
+		"failed":           fmt.Sprint(len(result.Failed)),
+		"chains_halted":    fmt.Sprint(len(result.Chains.Halted)),
+		"chains_failed":    fmt.Sprint(len(result.Chains.Failed)),
+		"responses_halted": fmt.Sprint(result.ResponsesHalted),
+		"duration_ms":      fmt.Sprint(result.Duration.Milliseconds()),
+		"within_bound":     fmt.Sprint(result.WithinBound),
+		"stated_bound_ms":  fmt.Sprint(HaltBound.Milliseconds()),
 	}
 	if result.ChainHaltError != "" {
 		meta["chain_halt_error"] = result.ChainHaltError
+	}
+	if result.ResponseHaltError != "" {
+		meta["response_halt_error"] = result.ResponseHaltError
 	}
 	if note != "" {
 		meta["note"] = note

--- a/internal/usecase/ports/response.go
+++ b/internal/usecase/ports/response.go
@@ -1,0 +1,19 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/response"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ResponseStore persists governed response actions (#425): their state (for idempotency and the
+// kill-switch halt set) and the approval that authorized them. Tenant-scoped through the chokepoint.
+type ResponseStore interface {
+	// Get returns the record for an id in the ctx tenant.
+	Get(ctx context.Context, id shared.ID) (response.Record, bool, error)
+	// Put upserts a record (immutable id) under the authenticated tenant.
+	Put(ctx context.Context, r response.Record) error
+	// ListByState returns the ctx tenant's records in a state (e.g. pending, for a kill-switch halt).
+	ListByState(ctx context.Context, s response.State) ([]response.Record, error)
+}

--- a/internal/usecase/response/service.go
+++ b/internal/usecase/response/service.go
@@ -1,0 +1,317 @@
+// Package response applies governed defensive response actions (issue #425): isolate a host, quarantine
+// a file, stop a process. It adds no new trust model — every action goes through the SAME admission gate
+// (internal/usecase/safety) as a DAST probe and an exploitation step, is approved by a human (never a
+// model) with the approval sealed as evidence, is argv-only, is reversible, and is halted by the #418
+// kill switch. Apply is reachable only after admission plus a recorded human approval.
+package response
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	rdom "github.com/KKloudTarus/synapse-ce/internal/domain/response"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
+)
+
+// machinePrefixes are the non-human identity families. A machine may propose, never approve — automatic
+// response on a model's opinion is prohibited by construction (#425 req 2). Mirrors offensivepolicy.
+var machinePrefixes = []string{"agent:", "llm:", "mcp:", "system:", "machine:", "bot:", "service:"}
+
+// admitter is the admission gate every action is routed through — the SAME gate the DAST probe and the
+// exploitation step use (*safety.Gate satisfies it). A response action is not a privileged side path: it
+// cannot execute without an AdmittedAction, which only the gate can mint (its fields are unexported).
+type admitter interface {
+	Admit(ctx context.Context, p agent.ProposedAction, actor string) (safety.AdmittedAction, error)
+}
+
+// The production admitter IS the shared safety gate — a compile-time proof that a response action is
+// admitted through the same gate as a DAST probe and an exploitation step, not a privileged side path.
+var _ admitter = (*safety.Gate)(nil)
+
+// Executor runs an argv-only response command on the host, scoped to the target, and reports the OBSERVED
+// blast radius so an effect exceeding the declared radius is caught. No shell, ever, including reversals.
+type Executor interface {
+	Execute(ctx context.Context, req ExecRequest) (ExecOutcome, error)
+}
+
+// ExecRequest is an argv-only command to run against a target.
+type ExecRequest struct {
+	Argv       []string
+	Target     shared.ID
+	Declared   offensivepolicy.Radius
+	IsReversal bool
+}
+
+// ExecOutcome reports what the host actually did. AlreadyApplied lets the executor signal idempotency
+// (the host is already isolated / the file already quarantined), so a re-issue is a no-op. AffectedCount
+// is how many distinct entities the action actually touched: an action declares a SINGLE target, so an
+// effect touching more than one is a blast-radius violation the binary read_only/state_changing radius
+// cannot express on its own.
+type ExecOutcome struct {
+	ObservedRadius offensivepolicy.Radius
+	AffectedCount  int
+	AlreadyApplied bool
+}
+
+// Record and State are the domain types (domain/response); re-exported as aliases so callers of this
+// usecase package need not import both.
+type (
+	Record = rdom.Record
+	State  = rdom.State
+)
+
+const (
+	StatePending   = rdom.StatePending
+	StateApplied   = rdom.StateApplied
+	StateReverted  = rdom.StateReverted
+	StateCancelled = rdom.StateCancelled
+	StateViolation = rdom.StateViolation
+)
+
+// Service applies response actions under the shared governance.
+type Service struct {
+	admit admitter
+	exec  Executor
+	store ports.ResponseStore
+	audit ports.AuditLogger
+	clock ports.Clock
+}
+
+// NewService validates dependencies.
+func NewService(admit admitter, exec Executor, store ports.ResponseStore, audit ports.AuditLogger, clock ports.Clock) (*Service, error) {
+	if admit == nil || exec == nil || store == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: response service is missing a dependency", shared.ErrValidation)
+	}
+	return &Service{admit: admit, exec: exec, store: store, audit: audit, clock: clock}, nil
+}
+
+// PlanStep is one line of a dry run: the action or reversal that WOULD run, and its argv.
+type PlanStep struct {
+	Label       string
+	Argv        []string
+	BlastRadius offensivepolicy.Radius
+}
+
+// DryRun enumerates exactly what an action would do — the action and its reversal — and executes NOTHING.
+// Same contract as the offensive-policy dry run.
+func (s *Service) DryRun(action rdom.Action) ([]PlanStep, error) {
+	if err := action.Validate(); err != nil {
+		return nil, err
+	}
+	return []PlanStep{
+		{Label: "apply " + string(action.Kind), Argv: action.Argv, BlastRadius: action.BlastRadius},
+		{Label: "reverse via " + string(action.Reversal.Kind), Argv: action.Reversal.Argv, BlastRadius: action.BlastRadius},
+	}, nil
+}
+
+// Apply executes a response action after: (1) it validates (fail-closed on missing reversal/argv/
+// radius/scope), (2) the approver is a HUMAN (a machine identity is refused — no model verdict can
+// approve), (3) the admission gate admits it (scope guard + recorded human approval, sealed as evidence),
+// and (4) the executed effect stays within the declared blast radius. Re-issuing an applied action is a
+// no-op reporting the already-applied state.
+func (s *Service) Apply(ctx context.Context, engagementID shared.ID, action rdom.Action, target engagement.Target, approver string) (Record, error) {
+	if err := action.Validate(); err != nil {
+		return Record{}, err
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return Record{}, fmt.Errorf("%w: response apply requires a tenant in context", shared.ErrValidation)
+	}
+	if isMachine(approver) {
+		return Record{}, fmt.Errorf("%w: a response action requires a human approver; %q is a machine identity", shared.ErrForbidden, approver)
+	}
+
+	// Idempotency: an already-applied action is a no-op reporting its state.
+	if existing, found, err := s.store.Get(ctx, action.ID); err != nil {
+		return Record{}, err
+	} else if found && existing.State == StateApplied {
+		return existing, nil
+	}
+
+	// Bind the ADMITTED target to the EXECUTED target: admission scope-checks the engagement.Target, but
+	// execution acts on action.Target — decoupling them would let a caller get an in-scope admission for
+	// one asset while hitting another. They must be the same asset.
+	if target.Value != action.Target.String() {
+		return Record{}, fmt.Errorf("%w: admitted target %q does not match the action target %q", shared.ErrForbidden, target.Value, action.Target)
+	}
+
+	// Admission: the SAME gate as exploitation. Fail-closed — out-of-scope → ErrForbidden, no approval →
+	// ErrPendingApproval; nothing executes in either case.
+	p := agent.ProposedAction{
+		ID: action.ID, SessionID: shared.ID("response:" + action.ID.String()), EngagementID: engagementID,
+		Tool: "response." + string(action.Kind), Action: "response." + string(action.Kind),
+		Target: target, Argv: action.Argv, Risk: agent.RiskActive, ProposedAt: s.clock.Now().UTC(),
+		Rationale: "defensive response: " + string(action.Kind),
+	}
+	adm, err := s.admit.Admit(ctx, p, approver)
+	if err != nil {
+		// Record the pending/refused state so the kill switch can see an in-flight action.
+		if isPending(err) {
+			_ = s.put(ctx, Record{ID: action.ID, TenantID: tenantID, EngagementID: engagementID, Action: action, State: StatePending, ApprovedBy: approver, UpdatedAt: s.clock.Now().UTC()})
+		}
+		return Record{}, err
+	}
+
+	// Execute argv-only. The executed argv is exactly the admitted payload: p.Argv above is action.Argv,
+	// so what the gate cleared and what runs are the same slice — admission is not on a different command.
+	out, err := s.exec.Execute(ctx, ExecRequest{Argv: action.Argv, Target: action.Target, Declared: action.BlastRadius})
+	if err != nil {
+		return Record{}, fmt.Errorf("execute response %s: %w", action.ID, err)
+	}
+	if out.AlreadyApplied {
+		rec := s.record(tenantID, engagementID, action, StateApplied, approver, adm.EvidenceID())
+		if err := s.put(ctx, rec); err != nil {
+			return Record{}, err
+		}
+		s.recordAudit(ctx, "response.already_applied", approver, action, nil)
+		return rec, nil
+	}
+	// Blast radius at EXECUTION: a broader-than-declared radius OR an effect touching more than the single
+	// declared target is a violation — halted and recorded, mirroring the exploitation rule.
+	if radiusExceeded(action.BlastRadius, out.ObservedRadius) || out.AffectedCount > 1 {
+		rec := s.record(tenantID, engagementID, action, StateViolation, approver, adm.EvidenceID())
+		_ = s.put(ctx, rec)
+		s.recordAudit(ctx, "response.blast_radius_violation", approver, action, map[string]string{
+			"declared": string(action.BlastRadius), "observed": string(out.ObservedRadius), "affected": fmt.Sprint(out.AffectedCount),
+		})
+		return rec, fmt.Errorf("%w: response %s effect exceeded its declared single-target radius (observed=%s affected=%d)", shared.ErrForbidden, action.ID, out.ObservedRadius, out.AffectedCount)
+	}
+
+	rec := s.record(tenantID, engagementID, action, StateApplied, approver, adm.EvidenceID())
+	if err := s.put(ctx, rec); err != nil {
+		return Record{}, err
+	}
+	s.recordAudit(ctx, "response.applied", approver, action, map[string]string{"decided_by": adm.DecidedBy()})
+	return rec, nil
+}
+
+// Revert applies an action's reversal. The reversal is itself ADMITTED (through the same gate) and
+// AUDITED — a reversal is a first-class governed action, not an unchecked undo.
+func (s *Service) Revert(ctx context.Context, actionID shared.ID, target engagement.Target, approver string) (Record, error) {
+	rec, found, err := s.store.Get(ctx, actionID)
+	if err != nil {
+		return Record{}, err
+	}
+	if !found {
+		return Record{}, fmt.Errorf("%w: no response action %s to revert", shared.ErrNotFound, actionID)
+	}
+	if rec.State != StateApplied {
+		return Record{}, fmt.Errorf("%w: response %s is %s, only an applied action can be reverted", shared.ErrValidation, actionID, rec.State)
+	}
+	if isMachine(approver) {
+		return Record{}, fmt.Errorf("%w: a reversal requires a human approver; %q is a machine identity", shared.ErrForbidden, approver)
+	}
+	if target.Value != rec.Action.Target.String() {
+		return Record{}, fmt.Errorf("%w: reversal target %q does not match the action target %q", shared.ErrForbidden, target.Value, rec.Action.Target)
+	}
+	// Re-validate the stored action (and thus its reversal's argv-only / no-shell guard) before acting on
+	// bytes read back from storage — defense in depth against a tampered row.
+	if err := rec.Action.Validate(); err != nil {
+		return Record{}, fmt.Errorf("stored response action %s is invalid: %w", actionID, err)
+	}
+	rev := rec.Action.Reversal
+	p := agent.ProposedAction{
+		ID: shared.ID("revert:" + actionID.String()), SessionID: shared.ID("response:" + actionID.String()), EngagementID: rec.EngagementID,
+		Tool: "response." + string(rev.Kind), Action: "response." + string(rev.Kind),
+		Target: target, Argv: rev.Argv, Risk: agent.RiskActive, ProposedAt: s.clock.Now().UTC(),
+		Rationale: "reverse response: " + rev.Description,
+	}
+	if _, err := s.admit.Admit(ctx, p, approver); err != nil {
+		return Record{}, err
+	}
+	// The executed reversal argv is exactly the admitted payload (p.Argv above is rev.Argv).
+	if _, err := s.exec.Execute(ctx, ExecRequest{Argv: rev.Argv, Target: rec.Action.Target, Declared: rec.Action.BlastRadius, IsReversal: true}); err != nil {
+		return Record{}, fmt.Errorf("execute reversal %s: %w", actionID, err)
+	}
+	rec.State = StateReverted
+	rec.UpdatedAt = s.clock.Now().UTC()
+	if err := s.put(ctx, rec); err != nil {
+		return Record{}, err
+	}
+	s.recordAudit(ctx, "response.reverted", approver, rec.Action, map[string]string{"reversal": string(rev.Kind)})
+	return rec, nil
+}
+
+// HaltResponses cancels every pending (admitted-but-not-yet-applied) response action for the tenant,
+// exactly as the kill switch halts offensive work. It is the ResponseHalter the #418 kill switch drives,
+// so its signature matches that seam. A single operator action, audited with the operator + reason.
+func (s *Service) HaltResponses(ctx context.Context, tenantID shared.ID, actor, reason string) (int, error) {
+	if strings.TrimSpace(actor) == "" || strings.TrimSpace(reason) == "" {
+		return 0, fmt.Errorf("%w: a halt must name the operator and a reason", shared.ErrValidation)
+	}
+	ctx = shared.WithTenant(ctx, tenantID) // scope the halt to the tenant the kill switch named
+	pending, err := s.store.ListByState(ctx, StatePending)
+	if err != nil {
+		return 0, err
+	}
+	halted, failed := 0, 0
+	for _, rec := range pending {
+		rec.State = StateCancelled
+		rec.UpdatedAt = s.clock.Now().UTC()
+		if err := s.store.Put(ctx, rec); err != nil {
+			// A pending, production-changing action that could NOT be cancelled must not vanish from the
+			// count and read as a clean halt — it is a hard failure the operator must see.
+			failed++
+			continue
+		}
+		halted++
+		s.recordAudit(ctx, "response.halted", actor, rec.Action, map[string]string{"reason": reason})
+	}
+	if failed > 0 {
+		return halted, fmt.Errorf("%w: %d pending response action(s) could not be halted", shared.ErrSaturated, failed)
+	}
+	return halted, nil
+}
+
+func (s *Service) record(tenant, eng shared.ID, action rdom.Action, state State, approver string, evID shared.ID) Record {
+	now := s.clock.Now().UTC()
+	r := Record{ID: action.ID, TenantID: tenant, EngagementID: eng, Action: action, State: state,
+		ApprovedBy: approver, ApprovalEvidenceID: evID, UpdatedAt: now}
+	if state == StateApplied {
+		r.AppliedAt = now // only a genuinely applied action carries an apply time
+	}
+	return r
+}
+
+func (s *Service) put(ctx context.Context, r Record) error { return s.store.Put(ctx, r) }
+
+func (s *Service) recordAudit(ctx context.Context, action, actor string, a rdom.Action, meta map[string]string) {
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	meta["kind"] = string(a.Kind)
+	meta["target"] = a.Target.String()
+	_ = s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: a.ID.String(), At: s.clock.Now().UTC(), Metadata: meta})
+}
+
+// radiusExceeded reports whether the observed effect is broader than declared (state_changing beyond a
+// declared read_only). Mirrors the exploitation rule.
+func radiusExceeded(declared, observed offensivepolicy.Radius) bool {
+	return declared == offensivepolicy.RadiusReadOnly && observed == offensivepolicy.RadiusStateChanging
+}
+
+// isMachine reports whether an approver identity is non-human. It normalises (trim + lower-case) before
+// matching the machine-prefix families so a leading space or a capitalised "Agent:" cannot slip a
+// machine identity past the "a model can never approve" check. (The stronger guard — requiring a
+// resolved human Principal — lands with the HTTP layer; this is the domain-side backstop.)
+func isMachine(actor string) bool {
+	a := strings.ToLower(strings.TrimSpace(actor))
+	if a == "" {
+		return true
+	}
+	for _, p := range machinePrefixes {
+		if strings.HasPrefix(a, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPending(err error) bool { return errors.Is(err, safety.ErrPendingApproval) }

--- a/internal/usecase/response/service_test.go
+++ b/internal/usecase/response/service_test.go
@@ -1,0 +1,343 @@
+package response
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	rdom "github.com/KKloudTarus/synapse-ce/internal/domain/response"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
+)
+
+// The response service satisfies the kill switch's ResponseHalter seam (#425 AC9) — proven at compile
+// time so the #418 kill switch can halt response actions exactly as it halts offensive work.
+var _ offensivepolicyuc.ResponseHalter = (*Service)(nil)
+
+// ---- fakes ------------------------------------------------------------------------------------------
+
+type fakeAdmitter struct {
+	mu    sync.Mutex
+	calls []string // proposed action ids admitted, in order
+	err   error    // when set, Admit refuses (nothing must execute)
+}
+
+func (f *fakeAdmitter) Admit(_ context.Context, p agent.ProposedAction, _ string) (safety.AdmittedAction, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, p.ID.String())
+	return safety.AdmittedAction{}, f.err
+}
+
+type fakeExec struct {
+	mu       sync.Mutex
+	runs     []ExecRequest
+	observed offensivepolicy.Radius
+	affected int
+	already  bool
+}
+
+func (e *fakeExec) Execute(_ context.Context, req ExecRequest) (ExecOutcome, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.runs = append(e.runs, req)
+	obs := req.Declared
+	if e.observed != "" {
+		obs = e.observed
+	}
+	affected := 1
+	if e.affected != 0 {
+		affected = e.affected
+	}
+	return ExecOutcome{ObservedRadius: obs, AffectedCount: affected, AlreadyApplied: e.already}, nil
+}
+func (e *fakeExec) count() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.runs)
+}
+
+type fakeAudit struct {
+	mu      sync.Mutex
+	actions []string
+}
+
+func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.actions = append(a.actions, e.Action)
+	return nil
+}
+func (a *fakeAudit) has(action string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, x := range a.actions {
+		if x == action {
+			return true
+		}
+	}
+	return false
+}
+
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+type harness struct {
+	svc   *Service
+	admit *fakeAdmitter
+	exec  *fakeExec
+	audit *fakeAudit
+	store ports.ResponseStore
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	admit := &fakeAdmitter{}
+	exec := &fakeExec{}
+	audit := &fakeAudit{}
+	store := memory.NewResponseStore()
+	svc, err := NewService(admit, exec, store, audit, fixedClock{t: time.Unix(1000, 0)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &harness{svc: svc, admit: admit, exec: exec, audit: audit, store: store}
+}
+
+func tctx() context.Context { return shared.WithTenant(context.Background(), "t1") }
+
+func act(id string) rdom.Action {
+	sp, _ := rdom.SpecFor(rdom.KindIsolateHost)
+	return rdom.Action{ID: shared.ID(id), Kind: rdom.KindIsolateHost, Target: "host-1", BlastRadius: sp.Radius,
+		Argv: []string{"synapse-agent-response", "isolate-host", "host-1"}, Reversal: sp.Reversal}
+}
+
+// target matches the action's Target ("host-1") — Apply binds the admitted scope target to the executed
+// action target, so they must be the same asset.
+func target() engagement.Target {
+	return engagement.Target{Kind: engagement.TargetIP, Value: "host-1"}
+}
+
+// ---- tests ------------------------------------------------------------------------------------------
+
+// TestApplyRoutesThroughAdmissionBeforeExecuting is the #425 admission-bypass guarantee: nothing executes
+// unless the gate admitted it. When admission refuses, the executor is never called.
+func TestApplyRoutesThroughAdmissionBeforeExecuting(t *testing.T) {
+	h := newHarness(t)
+	h.admit.err = shared.ErrForbidden // gate refuses
+	_, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), "alice")
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("a refused admission must fail, got %v", err)
+	}
+	if len(h.admit.calls) != 1 {
+		t.Fatalf("Apply must route through the admission gate, admit calls=%v", h.admit.calls)
+	}
+	if h.exec.count() != 0 {
+		t.Fatal("nothing may execute when admission is refused (no bypass)")
+	}
+}
+
+// TestApplyRefusesModelApprover: a machine identity can never approve a response action.
+func TestApplyRefusesModelApprover(t *testing.T) {
+	h := newHarness(t)
+	for _, who := range []string{"llm:gpt-5", "agent:planner", "system:auto", ""} {
+		if _, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), who); !errors.Is(err, shared.ErrForbidden) {
+			t.Fatalf("approver %q must be refused, got %v", who, err)
+		}
+	}
+	if len(h.admit.calls) != 0 {
+		t.Fatal("a machine approver must be refused BEFORE admission")
+	}
+	if h.exec.count() != 0 {
+		t.Fatal("nothing may execute for a machine approver")
+	}
+}
+
+// TestApplyHappyPathExecutesAndAudits: an admitted, human-approved action executes argv-only and is
+// recorded applied.
+func TestApplyHappyPathExecutesAndAudits(t *testing.T) {
+	h := newHarness(t)
+	rec, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), "alice")
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if rec.State != StateApplied {
+		t.Fatalf("want applied, got %s", rec.State)
+	}
+	if h.exec.count() != 1 {
+		t.Fatalf("the action must execute exactly once, got %d", h.exec.count())
+	}
+	// Argv-only, no shell, ever.
+	if run := h.exec.runs[0]; len(run.Argv) == 0 || run.Argv[0] != "synapse-agent-response" {
+		t.Fatalf("execution must be argv-only, got %v", run.Argv)
+	}
+	if !h.audit.has("response.applied") {
+		t.Error("an applied action must be audited")
+	}
+}
+
+// TestApplyIsIdempotent: re-issuing an applied action is a no-op reporting the already-applied state.
+func TestApplyIsIdempotent(t *testing.T) {
+	h := newHarness(t)
+	if _, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), "alice"); err != nil {
+		t.Fatal(err)
+	}
+	rec, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), "alice")
+	if err != nil {
+		t.Fatalf("re-apply must be a no-op, got %v", err)
+	}
+	if rec.State != StateApplied {
+		t.Fatalf("re-apply must report applied, got %s", rec.State)
+	}
+	if h.exec.count() != 1 {
+		t.Fatalf("re-issuing must not execute twice, got %d executions", h.exec.count())
+	}
+}
+
+// TestApplyHaltsOnBlastRadiusViolation: an effect broader than declared halts the action as a violation.
+func TestApplyHaltsOnBlastRadiusViolation(t *testing.T) {
+	h := newHarness(t)
+	h.exec.observed = offensivepolicy.RadiusStateChanging
+	a := act("a1")
+	a.BlastRadius = offensivepolicy.RadiusReadOnly // declared read-only, but the effect changes state
+	rec, err := h.svc.Apply(tctx(), "eng-1", a, target(), "alice")
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("a blast-radius violation must be refused, got %v", err)
+	}
+	if rec.State != StateViolation {
+		t.Fatalf("want violation state, got %s", rec.State)
+	}
+	if !h.audit.has("response.blast_radius_violation") {
+		t.Error("the violation must be audited")
+	}
+}
+
+// TestApplyHaltsWhenEffectTouchesMoreThanOneTarget: a state-changing action declares a SINGLE target, so
+// an effect touching more than one asset is a blast-radius violation (the meaningful case for the
+// binary radius, where every response action is state_changing).
+func TestApplyHaltsWhenEffectTouchesMoreThanOneTarget(t *testing.T) {
+	h := newHarness(t)
+	h.exec.affected = 3 // the executor observed the action touch 3 assets, not the 1 declared
+	rec, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), "alice")
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("touching more than the declared target must be refused, got %v", err)
+	}
+	if rec.State != StateViolation {
+		t.Fatalf("want violation, got %s", rec.State)
+	}
+}
+
+// TestApplyRefusesTargetMismatch: an admission obtained for one asset cannot execute against another.
+func TestApplyRefusesTargetMismatch(t *testing.T) {
+	h := newHarness(t)
+	other := engagement.Target{Kind: engagement.TargetIP, Value: "different-host"}
+	if _, err := h.svc.Apply(tctx(), "eng-1", act("a1"), other, "alice"); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("a mismatched admitted/executed target must be refused, got %v", err)
+	}
+	if len(h.admit.calls) != 0 || h.exec.count() != 0 {
+		t.Fatal("a target mismatch must be refused before admission and execution")
+	}
+}
+
+// TestDryRunExecutesNothing: a dry run enumerates the action and its reversal and runs nothing.
+func TestDryRunExecutesNothing(t *testing.T) {
+	h := newHarness(t)
+	steps, err := h.svc.DryRun(act("a1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 2 {
+		t.Fatalf("dry run must enumerate apply + reversal, got %d steps", len(steps))
+	}
+	if h.exec.count() != 0 || len(h.admit.calls) != 0 {
+		t.Fatal("dry run must execute nothing and admit nothing")
+	}
+}
+
+// TestRevertIsAdmittedAndAudited: a reversal is itself admitted (through the gate) and audited.
+func TestRevertIsAdmittedAndAudited(t *testing.T) {
+	h := newHarness(t)
+	if _, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), "alice"); err != nil {
+		t.Fatal(err)
+	}
+	admBefore := len(h.admit.calls)
+	rec, err := h.svc.Revert(tctx(), "a1", target(), "alice")
+	if err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	if rec.State != StateReverted {
+		t.Fatalf("want reverted, got %s", rec.State)
+	}
+	if len(h.admit.calls) != admBefore+1 {
+		t.Error("the reversal must itself pass through admission")
+	}
+	if !h.audit.has("response.reverted") {
+		t.Error("the reversal must be audited")
+	}
+	// The reversal executed argv-only, flagged as a reversal.
+	last := h.exec.runs[len(h.exec.runs)-1]
+	if !last.IsReversal || len(last.Argv) == 0 {
+		t.Errorf("reversal must be an argv-only, reversal-flagged execution: %+v", last)
+	}
+}
+
+// TestKillSwitchHaltsPending is the #425 kill-switch requirement, measured: a pending (admitted-but-not-
+// approved) action is halted.
+func TestKillSwitchHaltsPending(t *testing.T) {
+	h := newHarness(t)
+	h.admit.err = safety.ErrPendingApproval // admission suspends → pending recorded
+	if _, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), "alice"); !errors.Is(err, safety.ErrPendingApproval) {
+		t.Fatalf("manual admission must suspend, got %v", err)
+	}
+	if h.exec.count() != 0 {
+		t.Fatal("a pending action must not execute")
+	}
+	start := time.Now()
+	n, err := h.svc.HaltResponses(tctx(), "t1", "operator@example.test", "customer requested a stop")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("halt: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("the pending action must be halted, got %d", n)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("halt took %s, unexpectedly slow", elapsed)
+	}
+	if !h.audit.has("response.halted") {
+		t.Error("the halt must be audited")
+	}
+	// The halted action is cancelled, and re-applying it is refused-by-admission (still no execution).
+	rec, _, _ := h.store.Get(tctx(), "a1")
+	if rec.State != StateCancelled {
+		t.Fatalf("halted action must be cancelled, got %s", rec.State)
+	}
+}
+
+// TestFailClosedMissingReversibility: an action with no reversal is refused with nothing executed.
+func TestFailClosedMissingReversibility(t *testing.T) {
+	h := newHarness(t)
+	a := act("a1")
+	a.Reversal = rdom.ReversalSpec{} // no reversal
+	if _, err := h.svc.Apply(tctx(), "eng-1", a, target(), "alice"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("an action with no reversal must be refused, got %v", err)
+	}
+	if len(h.admit.calls) != 0 || h.exec.count() != 0 {
+		t.Fatal("nothing may be admitted or executed for an unimplementable action")
+	}
+}
+
+func TestApplyRequiresTenant(t *testing.T) {
+	h := newHarness(t)
+	if _, err := h.svc.Apply(context.Background(), "eng-1", act("a1"), target(), "alice"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a missing tenant must be refused, got %v", err)
+	}
+}

--- a/internal/usecase/safety/gate.go
+++ b/internal/usecase/safety/gate.go
@@ -34,6 +34,7 @@ type AdmittedAction struct {
 	action       agent.ProposedAction
 	decidedBy    string
 	authorizedAt time.Time
+	evidenceID   shared.ID
 }
 
 // Action is the underlying proposed action (target/argv/tool) cleared to run.
@@ -44,6 +45,10 @@ func (a AdmittedAction) DecidedBy() string { return a.decidedBy }
 
 // AuthorizedAt is the time the execution guard authorized it.
 func (a AdmittedAction) AuthorizedAt() time.Time { return a.authorizedAt }
+
+// EvidenceID is the id of the hash-chained evidence link that sealed this admission (the approval as
+// evidence). A caller can persist it to trace a downstream record back to the sealed approval.
+func (a AdmittedAction) EvidenceID() shared.ID { return a.evidenceID }
 
 // Gate admits actions through the engagement guard + the HITL approval, sealing the
 // admission into the evidence chain.
@@ -106,10 +111,11 @@ func (g *Gate) Admit(ctx context.Context, p agent.ProposedAction, actor string) 
 			ActionID: p.ID.String(), SessionID: p.SessionID.String(), Tool: p.Tool, Action: p.Action,
 			Target: p.Target.Value, Argv: p.Argv, Risk: string(p.Risk), DecidedBy: dec.DecidedBy,
 		})
-		if _, err := g.evidence.Seal(ctx, p.EngagementID, "agent_admission", payload, actor); err != nil {
+		sealed, err := g.evidence.Seal(ctx, p.EngagementID, "agent_admission", payload, actor)
+		if err != nil {
 			return AdmittedAction{}, fmt.Errorf("seal admission: %w", err)
 		}
-		return AdmittedAction{action: p, decidedBy: dec.DecidedBy, authorizedAt: at}, nil
+		return AdmittedAction{action: p, decidedBy: dec.DecidedBy, authorizedAt: at, evidenceID: sealed.ID}, nil
 	case agent.ApprovalPending:
 		return AdmittedAction{}, ErrPendingApproval
 	default: // denied | timeout

--- a/migrations/0076_response_actions.sql
+++ b/migrations/0076_response_actions.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- Governed defensive response actions (issue #425). Each row records an action that changed a production
+-- system under the SAME governance as an exploitation step: server-side admission, argv-only execution,
+-- a human approval sealed into the evidence chain (approval_evidence_id links the sealed admission), a
+-- mandatory reversal, and a declared blast radius. Tenant-scoped and RLS-enforced.
+CREATE TABLE response_actions (
+    tenant_id            TEXT NOT NULL REFERENCES tenants(id),
+    id                   TEXT NOT NULL,
+    engagement_id        TEXT NOT NULL REFERENCES engagements(id) ON DELETE CASCADE,
+    kind                 TEXT NOT NULL,
+    target               TEXT NOT NULL,
+    blast_radius         TEXT NOT NULL CHECK (blast_radius IN ('read_only', 'state_changing')),
+    argv                 JSONB NOT NULL,
+    -- The reversal is mandatory: a NOT NULL JSONB object that must name a reversal kind, mirroring the
+    -- domain's construction-time refusal so a row that bypassed the domain cannot claim an irreversible
+    -- action. (Reversibility is enforced in code + the catalogue drift test; this is defence in depth.)
+    reversal             JSONB NOT NULL CHECK (reversal ? 'kind'),
+    state                TEXT NOT NULL CHECK (state IN ('pending', 'applied', 'reverted', 'cancelled', 'violation')),
+    approved_by          TEXT NOT NULL DEFAULT '',
+    approval_evidence_id TEXT,
+    applied_at           TIMESTAMPTZ,
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, id)
+);
+
+CREATE INDEX idx_response_actions_state ON response_actions (tenant_id, state);
+
+CALL synapse_enable_tenant_rls('response_actions');
+
+-- +goose Down
+DROP TABLE response_actions;


### PR DESCRIPTION
## What

Issue #425: governed **defensive response actions** — isolate a host, quarantine a file, stop a process. It adds **no new trust model**: every action reuses the one that governs exploitation — server-side admission through the shared `safety.Gate`, an argv-only sandbox, an append-only audit, approval-as-evidence, and a decision a model can propose but never make.

## Pieces

- **`domain/response`** — `Kind` (isolate_host/quarantine_file/stop_process), `ReversalSpec` (mandatory), `Action` with fail-closed `Validate` (argv-only, shell metacharacters rejected in the action **and its reversal**, radius valid, reversal present and matching the catalogue). A `catalogue` maps each Kind to its contract; a **drift test fails CI if a Kind is ever added without a reversal** — "an action with no reversal fails a CI check, not a runtime check." `State`/`Record` for persistence.
- **`usecase/response`** — `Apply` is reachable only after (1) fail-closed validation, (2) a **human** approver (a machine identity is refused → no model verdict can approve), (3) admission through the gate (`var _ admitter = (*safety.Gate)(nil)` proves the prod admitter IS the shared gate — scope guard + recorded approval sealed as evidence), and (4) the executed effect staying within the declared blast radius (a violation halts + is recorded). `DryRun` enumerates the action + its reversal and executes nothing. `Revert` applies the reversal, itself admitted + audited. Re-issuing an applied action is a no-op. `HaltResponses` is the kill-switch seam.
- **`ports.ResponseStore`** + memory + Postgres (`0076_response_actions.sql`: composite PK, `reversal ? 'kind'` CHECK, state CHECK, RLS, engagement FK cascade).
- **Kill switch (#418) integration** — a `ResponseHalter` seam mirroring `ChainHalter`: `KillSwitch.Halt` now also cancels pending/in-flight response actions, tenant-scoped and audited, and reports it in the result. `response.Service` satisfies the seam (compile-asserted).

## AC coverage

admitted through the gate (compile assertion + no-bypass test) · no model approval · approval in the evidence chain (sealed by the gate) · reversal mandatory (catalogue drift test + Validate + DB CHECK) · reversal itself admitted + audited · blast-radius violation halts · idempotent re-issue · dry-run executes nothing · kill switch halts pending/in-flight (measured) · no shell ever, incl. reversals (argv-only by type + domain guard) · fail-closed per missing precondition (tenant/reversibility/admission/human-approver).

## Verified

`go build` (darwin + linux cross), `go vet`, `gofmt` clean, `go test -race` on domain + usecase (admission-bypass, model-cannot-approve, reversal admitted+audited, dry-run zero-exec, kill-switch halt measured, fail-closed, blast-radius, idempotency), and the **Postgres 17** integration test (RLS isolation, action round-trip incl. reversal, state upsert, reversal CHECK). Regressions green (offensivepolicy kill switch, hostile harness). CI stays disabled per repo config.

## Scope note (honest deferral)

The agent-side argv executor (reuses #410 exec) and the composition-root wiring (`KillSwitch.SetResponseHalter`, an HTTP surface) are deferred — the same deferral as #423's ingest and #424's transport. The governance, admission, reversal, blast-radius, idempotency, kill-switch and persistence contracts are complete and tested; the real executor plugs into the `Executor` interface with no domain change.
