### PR TITLE
feat(purple): detection coverage from emulation expected vs actual (#426)

### DIFF
--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/importedfinding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	projectdom "github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/threatmodel"
@@ -133,6 +134,23 @@ func (harnessDetections) ListDetections(_ context.Context, engagementID shared.I
 }
 
 func (harnessDetections) Incidents(_ context.Context, _ shared.ID) ([]detection.Incident, error) {
+	return nil, nil
+}
+
+// harnessPurple is the #426 purple-coverage read side: it returns one tenant-A coverage record carrying a
+// marker technique, so the harness proves a cross-tenant read (blocked by withEngTenant → 404) never
+// reaches it, while a same-tenant read does.
+type harnessPurple struct{}
+
+func (harnessPurple) Trend(_ context.Context, engagementID shared.ID) ([]purplecoverage.Coverage, error) {
+	return []purplecoverage.Coverage{{
+		TenantID: "tenantA", EngagementID: engagementID, RunID: "run-A", AssetID: "asset-A",
+		TechniqueID: "emu.markerA", TaxonomyRef: "T-marker-A", Expected: "det.markerA",
+		Verdict: purplecoverage.VerdictGap, ComputedAt: time.Unix(1000, 0),
+	}}, nil
+}
+
+func (harnessPurple) WorkItems(_ context.Context, _, _ shared.ID) ([]purplecoverage.WorkItem, error) {
 	return nil, nil
 }
 
@@ -285,7 +303,8 @@ func TestHostileHarness(t *testing.T) {
 	rt.SetAttackPaths(attackSvc)              // real #419 service proves cross-tenant derived data isolation
 	rt.SetSARIFIngest(harnessSARIF{})         // register the #415 import route so the harness guards its operate/tenant gates
 	rt.SetImportedFindings(harnessImportedFindings{})
-	rt.SetDetectionReader(harnessDetections{}) // register the #423 detection-ledger read route
+	rt.SetDetectionReader(harnessDetections{})  // register the #423 detection-ledger read route
+	rt.SetPurpleCoverageReader(harnessPurple{}) // register the #426 purple-coverage read route
 	rt.SetFleetRolloutAdmin(harnessRollout{})
 	rt.EnableAgent(nil, nil, nil, nil, nil, 1, 8)
 	mux := rt.routes()
@@ -415,6 +434,11 @@ func TestHostileHarness(t *testing.T) {
 		{"readonly may read detections (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/detections", http.StatusOK},
 		{"cross-tenant detection read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/detections", http.StatusNotFound},
 		{"principal-less detection read is denied", "", "", false, http.MethodGet, "/api/v1/engagements/engA/detections", http.StatusForbidden},
+		// #426 purple coverage (PermView): readonly may read; cross-tenant is 404 before the handler; a
+		// principal-less read is denied.
+		{"readonly may read purple coverage", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/purple-coverage", http.StatusOK},
+		{"cross-tenant purple coverage → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/purple-coverage", http.StatusNotFound},
+		{"principal-less purple coverage read is denied", "", "", false, http.MethodGet, "/api/v1/engagements/engA/purple-coverage", http.StatusForbidden},
 		// Fleet coverage (#413, PermView): machine roles denied; readonly may read; cross-tenant agent
 		// detail is 404 (never an existence-revealing 403). The cross-tenant LIST emptiness (a 200 that
 		// leaks nothing) is asserted on the body just below the table.
@@ -445,6 +469,14 @@ func TestHostileHarness(t *testing.T) {
 	}
 	if code, body := send("consultant", "tenantB", http.MethodGet, "/api/v1/engagements/engA/detections", true); code != http.StatusNotFound || strings.Contains(body, "asset-A") {
 		t.Errorf("cross-tenant detection read must be 404 with no tenantA data (code=%d body=%s)", code, body)
+	}
+	// #426 purple coverage: tenantA sees its own coverage marker; a cross-tenant read returns NOTHING
+	// (404 via withEngTenant), so tenantA's marker can never leak.
+	if code, body := send("readonly", "tenantA", http.MethodGet, "/api/v1/engagements/engA/purple-coverage", true); code != http.StatusOK || !strings.Contains(body, "emu.markerA") {
+		t.Fatalf("tenantA must see its own purple coverage (code=%d body=%s)", code, body)
+	}
+	if code, body := send("consultant", "tenantB", http.MethodGet, "/api/v1/engagements/engA/purple-coverage", true); code != http.StatusNotFound || strings.Contains(body, "emu.markerA") {
+		t.Errorf("cross-tenant purple coverage read must be 404 with no tenantA data (code=%d body=%s)", code, body)
 	}
 
 	if code, body := send("readonly", "tenantB", http.MethodGet, "/api/v1/attack-paths", true); code != http.StatusOK || strings.Contains(body, "tenant-A-secret-marker") {

--- a/internal/adapter/httpapi/purple_handler.go
+++ b/internal/adapter/httpapi/purple_handler.go
@@ -1,0 +1,55 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// purpleCoverageReader is the narrow read side the HTTP layer needs for purple-team coverage (#426): an
+// engagement's coverage across runs (the trend) and the work items (one per gap) derived from it.
+// *purplecoverageuc.Service satisfies it. Reads are tenant-gated by withEngTenant + the store's RLS, so a
+// cross-tenant read returns nothing.
+type purpleCoverageReader interface {
+	Trend(ctx context.Context, engagementID shared.ID) ([]purplecoverage.Coverage, error)
+	WorkItems(ctx context.Context, engagementID, runID shared.ID) ([]purplecoverage.WorkItem, error)
+}
+
+// SetPurpleCoverageReader wires the purple-coverage read route (#426). Left unset, the route reports empty
+// coverage rather than 500 — the feature is simply not enabled.
+func (rt *Router) SetPurpleCoverageReader(r purpleCoverageReader) {
+	if r != nil {
+		rt.purpleCoverage = r
+	}
+}
+
+// listPurpleCoverage returns the engagement's coverage across runs (the trend), or — with ?run=<id> — the
+// work items (one per gap) for a single run. PermView + withEngTenant; a cross-tenant engagement is
+// already a 404 before this runs.
+func (rt *Router) listPurpleCoverage(w http.ResponseWriter, r *http.Request) {
+	engID := shared.ID(r.PathValue("id"))
+	if rt.purpleCoverage == nil {
+		// Not wired: an empty, honest answer (not a 500), consistent with the read being optional.
+		writeJSON(w, http.StatusOK, map[string]any{"coverage": []purplecoverage.Coverage{}})
+		return
+	}
+	if runID := r.URL.Query().Get("run"); runID != "" {
+		// The run is bound to the path engagement inside WorkItems, so a run id from another engagement in
+		// the same tenant resolves to no items rather than leaking that engagement's gaps.
+		items, err := rt.purpleCoverage.WorkItems(r.Context(), engID, shared.ID(runID))
+		if err != nil {
+			writeError(w, rt.log, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"work_items": items})
+		return
+	}
+	cov, err := rt.purpleCoverage.Trend(r.Context(), engID)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"coverage": cov})
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -71,6 +71,7 @@ type Router struct {
 	fleetRolloutAdmin fleetRolloutService   // optional; nil ⇒ the operator rollout routes are not served
 	offensiveHalt     offensiveKillSwitch   // optional; nil ⇒ the red-team halt route is not served
 	detections        detectionReader       // optional read side for the detection ledger (#423)
+	purpleCoverage    purpleCoverageReader  // optional read side for purple-team coverage (#426)
 	fleet             *fleetRouter          // optional; nil ⇒ agent transport plane is not served
 	fleetAdmin        fleetAdminService     // optional; nil ⇒ operator agent-admin routes not registered
 	qualityGates      qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
@@ -368,6 +369,7 @@ func (rt *Router) routes() *http.ServeMux {
 		// itself, rather than the governance claim being made by a method nothing calls.
 		mux.HandleFunc("GET /api/v1/engagements/{id}/imported-findings", rt.authz(userdom.PermView, rt.withEngTenant(rt.listImportedFindings)))
 		mux.HandleFunc("GET /api/v1/engagements/{id}/detections", rt.authz(userdom.PermView, rt.withEngTenant(rt.listDetections)))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/purple-coverage", rt.authz(userdom.PermView, rt.withEngTenant(rt.listPurpleCoverage)))
 	}
 	mux.HandleFunc("GET /api/v1/engagements/{id}/scan", rt.authz(userdom.PermView, rt.withEngTenant(rt.latestScan)))
 	mux.HandleFunc("GET /api/v1/engagements/{id}/scan-status", rt.authz(userdom.PermView, rt.withEngTenant(rt.scanStatus)))

--- a/internal/domain/purplecoverage/verdict.go
+++ b/internal/domain/purplecoverage/verdict.go
@@ -1,0 +1,196 @@
+// Package purplecoverage is the pure domain that closes the purple loop (issue #426): it joins the
+// detection each emulated technique EXPECTED (#421) with the detections that ACTUALLY fired (#422/#423)
+// and resolves a coverage verdict. Coverage is measured, not claimed — the intersection is coverage, the
+// difference is the gap, and the honest distinctions (unknown vs gap, bonus vs hidden) are enforced here.
+//
+// No I/O, no clock. The join and persistence live in internal/usecase/purplecoverage.
+package purplecoverage
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Verdict is the coverage outcome for one technique. The set is closed and resolved TOP-DOWN in this
+// order (issue #426): out_of_reach, unknown, covered, gap — so an emulation that never executed can
+// never be counted as a gap.
+type Verdict string
+
+const (
+	VerdictOutOfReach Verdict = "out_of_reach" // the platform cannot emulate this technique at all
+	VerdictUnknown    Verdict = "unknown"      // emulatable, but this run could not execute it (e.g. out of scope)
+	VerdictCovered    Verdict = "covered"      // executed AND the expected detection fired
+	VerdictGap        Verdict = "gap"          // executed, but the expected detection did NOT fire
+)
+
+// Valid reports whether v is a known verdict.
+func (v Verdict) Valid() bool {
+	switch v {
+	case VerdictOutOfReach, VerdictUnknown, VerdictCovered, VerdictGap:
+		return true
+	default:
+		return false
+	}
+}
+
+// Uncovered reports whether a verdict counts against coverage in a way a defender must act on: only a gap
+// is an actionable coverage hole. unknown and out_of_reach are honest non-measurements, not holes.
+func (v Verdict) Uncovered() bool { return v == VerdictGap }
+
+// Input is one technique's expected-vs-actual for a run. Emulatable=false means the platform cannot
+// emulate it (out_of_reach); Executed=false means it was emulatable but did not run this time (unknown).
+// Actual is the set of detection ids observed in the same window on the same asset.
+type Input struct {
+	TechniqueID string
+	TaxonomyRef string
+	Expected    string // the detection id the technique should produce
+	Emulatable  bool
+	Executed    bool
+	Actual      []string
+}
+
+// Resolve applies the top-down verdict order. Crucially, a non-executed technique is unknown, NEVER a
+// gap: you cannot measure detection of something that did not run, and collapsing the two would over- or
+// under-state coverage — both dishonest.
+func Resolve(in Input) Verdict {
+	switch {
+	case !in.Emulatable:
+		return VerdictOutOfReach
+	case !in.Executed:
+		return VerdictUnknown
+	case containsDetection(in.Actual, in.Expected):
+		return VerdictCovered
+	default:
+		return VerdictGap
+	}
+}
+
+// Coverage is one technique's resolved coverage for a run — the stored record, so coverage over time is a
+// trend and a regression is visible. It carries the public taxonomy reference so coverage is reported in
+// terms a customer and an auditor already understand.
+type Coverage struct {
+	TenantID     shared.ID
+	EngagementID shared.ID
+	RunID        shared.ID
+	AssetID      shared.ID
+	TechniqueID  string
+	TaxonomyRef  string
+	Expected     string
+	Actual       []string
+	Verdict      Verdict
+	ComputedAt   time.Time
+}
+
+// Validate enforces the invariants a stored coverage record must hold: a taxonomy reference (coverage is
+// expressed against the public taxonomy), a technique, and a valid verdict.
+func (c Coverage) Validate() error {
+	if c.TenantID == "" || c.RunID == "" || c.EngagementID == "" {
+		return fmt.Errorf("%w: coverage is missing tenant/run/engagement scope", shared.ErrValidation)
+	}
+	if c.TechniqueID == "" {
+		return fmt.Errorf("%w: coverage has no technique id", shared.ErrValidation)
+	}
+	if c.TaxonomyRef == "" {
+		return fmt.Errorf("%w: coverage for %s has no taxonomy reference — coverage must be expressed against the public taxonomy", shared.ErrValidation, c.TechniqueID)
+	}
+	if !c.Verdict.Valid() {
+		return fmt.Errorf("%w: coverage for %s has an invalid verdict %q", shared.ErrValidation, c.TechniqueID, c.Verdict)
+	}
+	return nil
+}
+
+// BonusDetections returns the actual detection ids that matched NO technique's expected detection — a
+// bonus detection or noise. They are reported SEPARATELY (never hidden, never counted as coverage), so a
+// hunt sees them for what they are.
+func BonusDetections(inputs []Input, allActual []string) []string {
+	expected := make(map[string]struct{}, len(inputs))
+	for _, in := range inputs {
+		if in.Expected != "" {
+			expected[in.Expected] = struct{}{}
+		}
+	}
+	seen := map[string]struct{}{}
+	var bonus []string
+	for _, a := range allActual {
+		if _, isExpected := expected[a]; isExpected {
+			continue
+		}
+		if _, dup := seen[a]; dup {
+			continue
+		}
+		seen[a] = struct{}{}
+		bonus = append(bonus, a)
+	}
+	sort.Strings(bonus)
+	return bonus
+}
+
+// Regression is a technique that went from covered to uncovered between two runs — a detection
+// regression, surfaced in the same spirit as the code regression suite.
+type Regression struct {
+	TechniqueID string
+	TaxonomyRef string
+	From        Verdict
+	To          Verdict
+}
+
+// Regressions compares an earlier run's coverage with a later run's and returns the covered->uncovered
+// transitions. A covered technique that becomes a gap (or unknown/out_of_reach) is a regression; the
+// reverse (a gap that becomes covered) is progress, not a regression.
+func Regressions(prev, curr []Coverage) []Regression {
+	was := make(map[string]Verdict, len(prev))
+	tax := make(map[string]string, len(prev))
+	for _, c := range prev {
+		was[c.TechniqueID] = c.Verdict
+		tax[c.TechniqueID] = c.TaxonomyRef
+	}
+	var out []Regression
+	for _, c := range curr {
+		if was[c.TechniqueID] == VerdictCovered && c.Verdict != VerdictCovered {
+			ref := c.TaxonomyRef
+			if ref == "" {
+				ref = tax[c.TechniqueID]
+			}
+			out = append(out, Regression{TechniqueID: c.TechniqueID, TaxonomyRef: ref, From: VerdictCovered, To: c.Verdict})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TechniqueID < out[j].TechniqueID })
+	return out
+}
+
+// WorkItem is the actionable item an uncovered technique produces: write or fix the missing detection.
+// It references the technique and the missing detection so a human can pick it up (the platform never
+// auto-writes the rule — that is deliberately out of scope).
+type WorkItem struct {
+	TechniqueID      string
+	TaxonomyRef      string
+	MissingDetection string
+}
+
+// WorkItems returns one work item per GAP (executed-but-undetected) technique. unknown/out_of_reach do
+// NOT produce work items: there is no detection to write for something that did not run or cannot run.
+func WorkItems(cov []Coverage) []WorkItem {
+	var out []WorkItem
+	for _, c := range cov {
+		if c.Verdict == VerdictGap {
+			out = append(out, WorkItem{TechniqueID: c.TechniqueID, TaxonomyRef: c.TaxonomyRef, MissingDetection: c.Expected})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TechniqueID < out[j].TechniqueID })
+	return out
+}
+
+func containsDetection(actual []string, expected string) bool {
+	if expected == "" {
+		return false
+	}
+	for _, a := range actual {
+		if a == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/domain/purplecoverage/verdict_test.go
+++ b/internal/domain/purplecoverage/verdict_test.go
@@ -1,0 +1,95 @@
+package purplecoverage
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TestResolveVerdictPerCase covers the four verdicts and the ambiguous pairs the resolution order must
+// disambiguate — most importantly that a non-executed technique is unknown, NEVER a gap.
+func TestResolveVerdictPerCase(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Input
+		want Verdict
+	}{
+		{"out of reach (not emulatable) wins over everything",
+			Input{Emulatable: false, Executed: false, Expected: "det.x"}, VerdictOutOfReach},
+		{"out of reach even if actual fired",
+			Input{Emulatable: false, Executed: true, Expected: "det.x", Actual: []string{"det.x"}}, VerdictOutOfReach},
+		{"emulatable but did not execute -> unknown, never gap",
+			Input{Emulatable: true, Executed: false, Expected: "det.x"}, VerdictUnknown},
+		{"executed and expected fired -> covered",
+			Input{Emulatable: true, Executed: true, Expected: "det.x", Actual: []string{"det.other", "det.x"}}, VerdictCovered},
+		{"executed but expected did NOT fire -> gap",
+			Input{Emulatable: true, Executed: true, Expected: "det.x", Actual: []string{"det.other"}}, VerdictGap},
+		{"executed, nothing fired -> gap",
+			Input{Emulatable: true, Executed: true, Expected: "det.x"}, VerdictGap},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Resolve(tt.in); got != tt.want {
+				t.Fatalf("Resolve = %s, want %s", got, tt.want)
+			}
+			if got := Resolve(tt.in); got == VerdictGap && !tt.in.Executed {
+				t.Fatal("a non-executed technique must never resolve to gap")
+			}
+		})
+	}
+}
+
+func TestBonusDetectionsReportedNotHidden(t *testing.T) {
+	inputs := []Input{
+		{TechniqueID: "emu.a", Expected: "det.a", Emulatable: true, Executed: true, Actual: []string{"det.a"}},
+		{TechniqueID: "emu.b", Expected: "det.b", Emulatable: true, Executed: true, Actual: []string{"det.b"}},
+	}
+	// det.surprise matched no expected → a bonus/noise detection, reported separately.
+	all := []string{"det.a", "det.b", "det.surprise", "det.surprise"}
+	bonus := BonusDetections(inputs, all)
+	if len(bonus) != 1 || bonus[0] != "det.surprise" {
+		t.Fatalf("an unexpected actual detection must be reported as bonus (deduped), got %v", bonus)
+	}
+}
+
+func TestRegressionsCoveredToUncovered(t *testing.T) {
+	prev := []Coverage{
+		{TechniqueID: "emu.a", TaxonomyRef: "T1", Verdict: VerdictCovered},
+		{TechniqueID: "emu.b", TaxonomyRef: "T2", Verdict: VerdictGap},
+	}
+	curr := []Coverage{
+		{TechniqueID: "emu.a", TaxonomyRef: "T1", Verdict: VerdictGap},     // regression: covered -> gap
+		{TechniqueID: "emu.b", TaxonomyRef: "T2", Verdict: VerdictCovered}, // progress: gap -> covered (NOT a regression)
+	}
+	regs := Regressions(prev, curr)
+	if len(regs) != 1 || regs[0].TechniqueID != "emu.a" || regs[0].From != VerdictCovered || regs[0].To != VerdictGap {
+		t.Fatalf("only the covered->uncovered transition is a regression, got %+v", regs)
+	}
+}
+
+func TestWorkItemsOnlyForGaps(t *testing.T) {
+	cov := []Coverage{
+		{TechniqueID: "emu.gap", TaxonomyRef: "T1", Expected: "det.gap", Verdict: VerdictGap},
+		{TechniqueID: "emu.cov", TaxonomyRef: "T2", Expected: "det.cov", Verdict: VerdictCovered},
+		{TechniqueID: "emu.unk", TaxonomyRef: "T3", Expected: "det.unk", Verdict: VerdictUnknown},
+		{TechniqueID: "emu.oor", TaxonomyRef: "T4", Expected: "det.oor", Verdict: VerdictOutOfReach},
+	}
+	items := WorkItems(cov)
+	if len(items) != 1 || items[0].TechniqueID != "emu.gap" || items[0].MissingDetection != "det.gap" {
+		t.Fatalf("a work item must be produced ONLY for a gap, referencing the missing detection, got %+v", items)
+	}
+}
+
+func TestCoverageValidateRequiresTaxonomy(t *testing.T) {
+	good := Coverage{TenantID: "t1", RunID: "r1", EngagementID: "eng-1", TechniqueID: "emu.a", TaxonomyRef: "T1", Verdict: VerdictCovered, ComputedAt: time.Unix(1, 0)}
+	if err := good.Validate(); err != nil {
+		t.Fatalf("a well-formed coverage must validate: %v", err)
+	}
+	bad := good
+	bad.TaxonomyRef = ""
+	if err := bad.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("coverage without a taxonomy reference must be rejected, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/purple_store.go
+++ b/internal/infrastructure/persistence/memory/purple_store.go
@@ -1,0 +1,108 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	pcdom "github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// PurpleStore is the in-memory purple-coverage store, tenant-bucketed so one tenant's coverage is never
+// visible to another. Coverage is keyed (run, technique) so a re-computation of the same run replaces its
+// records in place and coverage across runs forms a trend.
+type PurpleStore struct {
+	mu       sync.Mutex
+	byTenant map[shared.ID]map[coverageKey]pcdom.Coverage
+}
+
+type coverageKey struct {
+	run       shared.ID
+	technique string
+}
+
+var _ ports.PurpleCoverageStore = (*PurpleStore)(nil)
+
+// NewPurpleStore constructs the store.
+func NewPurpleStore() *PurpleStore {
+	return &PurpleStore{byTenant: map[shared.ID]map[coverageKey]pcdom.Coverage{}}
+}
+
+// SaveCoverage upserts a run's coverage records under the authenticated tenant. A record claiming a
+// different tenant is refused so a computation cannot write into another tenant's ledger.
+func (s *PurpleStore) SaveCoverage(ctx context.Context, records []pcdom.Coverage) error {
+	tenant, err := requirePurpleTenant(ctx)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.byTenant[tenant] == nil {
+		s.byTenant[tenant] = map[coverageKey]pcdom.Coverage{}
+	}
+	for _, r := range records {
+		if r.TenantID != "" && r.TenantID != tenant {
+			return fmt.Errorf("purple coverage: record tenant %q does not match context: %w", r.TenantID, shared.ErrForbidden)
+		}
+		if err := r.Validate(); err != nil {
+			return err
+		}
+		s.byTenant[tenant][coverageKey{run: r.RunID, technique: r.TechniqueID}] = r
+	}
+	return nil
+}
+
+// ListByRun returns one run's coverage records in the ctx tenant, ordered by technique.
+func (s *PurpleStore) ListByRun(ctx context.Context, runID shared.ID) ([]pcdom.Coverage, error) {
+	tenant, err := requirePurpleTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []pcdom.Coverage
+	for k, c := range s.byTenant[tenant] {
+		if k.run == runID {
+			out = append(out, c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TechniqueID < out[j].TechniqueID })
+	return out, nil
+}
+
+// ListByEngagement returns all coverage for an engagement in the ctx tenant, oldest first (by
+// ComputedAt, then run/technique) so a trend across runs is stable.
+func (s *PurpleStore) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]pcdom.Coverage, error) {
+	tenant, err := requirePurpleTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []pcdom.Coverage
+	for _, c := range s.byTenant[tenant] {
+		if c.EngagementID == engagementID {
+			out = append(out, c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].ComputedAt.Equal(out[j].ComputedAt) {
+			return out[i].ComputedAt.Before(out[j].ComputedAt)
+		}
+		if out[i].RunID != out[j].RunID {
+			return out[i].RunID < out[j].RunID
+		}
+		return out[i].TechniqueID < out[j].TechniqueID
+	})
+	return out, nil
+}
+
+func requirePurpleTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("purple coverage: no tenant in context: %w", shared.ErrValidation)
+}

--- a/internal/infrastructure/persistence/postgres/migration_0077_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0077_test.go
@@ -1,0 +1,127 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	pcdom "github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestMigration0077PurpleCoverage(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenantA, tenantB := shared.ID("pc-a-"+id), shared.ID("pc-b-"+id)
+	engA := "pc-eng-" + id
+	for _, stmt := range []struct {
+		q    string
+		args []any
+	}{
+		{`INSERT INTO tenants(id,name) VALUES($1,$1),($2,$2)`, []any{tenantA.String(), tenantB.String()}},
+		{`INSERT INTO engagements(id,tenant_id,name) VALUES($1,$2,'pc-eng')`, []any{engA, tenantA.String()}},
+	} {
+		if _, err := pool.Exec(ctx, stmt.q, stmt.args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM purple_coverage WHERE tenant_id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DELETE FROM engagements WHERE tenant_id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DROP OWNED BY pc_runtime`)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS pc_runtime`)
+	})
+
+	repo := NewPurpleRepository(pool)
+	tctx := shared.WithTenant(ctx, tenantA)
+	when := time.Unix(1700, 0).UTC()
+	cov := []pcdom.Coverage{
+		{TenantID: tenantA, RunID: shared.ID("run-1"), TechniqueID: "emu.a", EngagementID: shared.ID(engA),
+			AssetID: "asset-1", TaxonomyRef: "T1", Expected: "det.a", Actual: []string{"det.a"}, Verdict: pcdom.VerdictCovered, ComputedAt: when},
+		{TenantID: tenantA, RunID: shared.ID("run-1"), TechniqueID: "emu.b", EngagementID: shared.ID(engA),
+			AssetID: "asset-1", TaxonomyRef: "T2", Expected: "det.b", Actual: nil, Verdict: pcdom.VerdictGap, ComputedAt: when},
+	}
+	if err := repo.SaveCoverage(tctx, cov); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Round-trip preserves verdict + actual list.
+	got, err := repo.ListByRun(tctx, "run-1")
+	if err != nil || len(got) != 2 {
+		t.Fatalf("list by run = %d (%v), want 2", len(got), err)
+	}
+	if got[0].TechniqueID != "emu.a" || got[0].Verdict != pcdom.VerdictCovered || len(got[0].Actual) != 1 {
+		t.Fatalf("round-trip lost coverage detail: %+v", got[0])
+	}
+	// Trend by engagement returns the same rows.
+	if trend, err := repo.ListByEngagement(tctx, shared.ID(engA)); err != nil || len(trend) != 2 {
+		t.Fatalf("trend = %d (%v), want 2", len(trend), err)
+	}
+	// Re-computation of the same run+technique replaces in place (upsert, not duplicate).
+	cov[1].Verdict = pcdom.VerdictCovered
+	cov[1].Actual = []string{"det.b"}
+	if err := repo.SaveCoverage(tctx, cov); err != nil {
+		t.Fatalf("re-save: %v", err)
+	}
+	if got, _ := repo.ListByRun(tctx, "run-1"); len(got) != 2 || got[1].Verdict != pcdom.VerdictCovered {
+		t.Fatalf("upsert must replace in place, got %d rows, emu.b verdict %s", len(got), got[1].Verdict)
+	}
+
+	// RLS under a NOSUPERUSER role: tenant B must see none of tenant A's coverage.
+	role := "pc_runtime"
+	for _, q := range []string{
+		`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='` + role + `') THEN EXECUTE 'DROP OWNED BY ` + role + `'; EXECUTE 'DROP ROLE ` + role + `'; END IF; END $$`,
+		`CREATE ROLE ` + role + ` NOSUPERUSER NOBYPASSRLS`,
+		`GRANT USAGE ON SCHEMA public TO ` + role,
+		`GRANT SELECT ON purple_coverage TO ` + role,
+	} {
+		if _, err := pool.Exec(ctx, q); err != nil {
+			t.Fatalf("prepare rls role: %v", err)
+		}
+	}
+	countAs := func(tenant shared.ID) int {
+		var n int
+		tc := shared.WithTenant(context.Background(), tenant)
+		if err := WithTenant(tc, pool, tenant.String(), func(tx pgx.Tx) error {
+			if _, err := tx.Exec(tc, `SET LOCAL ROLE `+role); err != nil {
+				return err
+			}
+			return tx.QueryRow(tc, `SELECT count(*) FROM purple_coverage`).Scan(&n)
+		}); err != nil {
+			t.Fatalf("count as %s: %v", tenant, err)
+		}
+		return n
+	}
+	if got := countAs(tenantB); got != 0 {
+		t.Errorf("tenant B sees %d of tenant A's coverage; RLS is not isolating", got)
+	}
+	if got := countAs(tenantA); got != 2 {
+		t.Errorf("tenant A sees %d of its own coverage, want 2", got)
+	}
+
+	// The taxonomy CHECK: coverage with an empty taxonomy_ref is unstorable (coverage must be expressed
+	// against the public taxonomy).
+	_, ckErr := pool.Exec(ctx, `INSERT INTO purple_coverage
+		(tenant_id, run_id, technique_id, engagement_id, taxonomy_ref, verdict, computed_at)
+		VALUES ($1,'run-x','emu.x',$2,'','gap', now())`, tenantA.String(), engA)
+	if ckErr == nil {
+		t.Error("coverage with no taxonomy reference must fail the CHECK")
+	}
+}

--- a/internal/infrastructure/persistence/postgres/purple_repo.go
+++ b/internal/infrastructure/persistence/postgres/purple_repo.go
@@ -1,0 +1,129 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	pcdom "github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// PurpleRepository persists purple-team coverage (migration 0077), tenant-scoped via WithTenant/RLS so
+// one tenant's coverage is never visible to another.
+type PurpleRepository struct{ pool *pgxpool.Pool }
+
+var _ ports.PurpleCoverageStore = (*PurpleRepository)(nil)
+
+// NewPurpleRepository constructs the repository.
+func NewPurpleRepository(pool *pgxpool.Pool) *PurpleRepository {
+	return &PurpleRepository{pool: pool}
+}
+
+// SaveCoverage upserts a run's coverage under the authenticated tenant, keyed (run, technique), in one
+// transaction so a re-computation of a run is atomic.
+func (r *PurpleRepository) SaveCoverage(ctx context.Context, records []pcdom.Coverage) error {
+	// The written tenant is the AUTHENTICATED tenant on the context, never the record's self-declared
+	// TenantID: a record must not be able to write into another tenant's partition by claiming a
+	// different id. RLS WITH CHECK is the backstop, but this makes the store correct on its own (the
+	// same defense-in-depth the memory store applies), so a misconfigured/superuser role cannot silently
+	// write a foreign tenant_id.
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok || tenant == "" {
+		return fmt.Errorf("purple coverage: no tenant in context: %w", shared.ErrValidation)
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		for _, c := range records {
+			if c.TenantID != "" && c.TenantID != tenant {
+				return fmt.Errorf("purple coverage: record tenant %q does not match context: %w", c.TenantID, shared.ErrForbidden)
+			}
+			if err := c.Validate(); err != nil {
+				return err
+			}
+			actual, err := json.Marshal(c.Actual)
+			if err != nil {
+				return fmt.Errorf("marshal actual for %s: %w", c.TechniqueID, err)
+			}
+			_, err = tx.Exec(ctx, `
+				INSERT INTO purple_coverage
+				  (tenant_id, run_id, technique_id, engagement_id, asset_id, taxonomy_ref, expected, actual, verdict, computed_at)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+				ON CONFLICT (tenant_id, run_id, technique_id) DO UPDATE SET
+				  engagement_id = EXCLUDED.engagement_id, asset_id = EXCLUDED.asset_id,
+				  taxonomy_ref = EXCLUDED.taxonomy_ref, expected = EXCLUDED.expected,
+				  actual = EXCLUDED.actual, verdict = EXCLUDED.verdict, computed_at = EXCLUDED.computed_at`,
+				tenant.String(), c.RunID.String(), c.TechniqueID, c.EngagementID.String(),
+				c.AssetID.String(), c.TaxonomyRef, c.Expected, actual, string(c.Verdict), c.ComputedAt.UTC())
+			if err != nil {
+				return fmt.Errorf("upsert coverage %s/%s: %w", c.RunID, c.TechniqueID, err)
+			}
+		}
+		return nil
+	})
+}
+
+// ListByRun returns one run's coverage in the ctx tenant, ordered by technique.
+func (r *PurpleRepository) ListByRun(ctx context.Context, runID shared.ID) ([]pcdom.Coverage, error) {
+	return r.query(ctx, `
+		SELECT tenant_id, run_id, technique_id, engagement_id, asset_id, taxonomy_ref, expected, actual, verdict, computed_at
+		FROM purple_coverage WHERE run_id = $1 ORDER BY technique_id ASC`, runID.String())
+}
+
+// ListByEngagement returns all coverage for an engagement in the ctx tenant, oldest first, so a trend
+// across runs is queryable.
+func (r *PurpleRepository) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]pcdom.Coverage, error) {
+	return r.query(ctx, `
+		SELECT tenant_id, run_id, technique_id, engagement_id, asset_id, taxonomy_ref, expected, actual, verdict, computed_at
+		FROM purple_coverage WHERE engagement_id = $1 ORDER BY computed_at ASC, run_id ASC, technique_id ASC`, engagementID.String())
+}
+
+func (r *PurpleRepository) query(ctx context.Context, sql string, arg string) ([]pcdom.Coverage, error) {
+	var out []pcdom.Coverage
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, sql, arg)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			c, err := scanCoverage(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, c)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+func scanCoverage(row rowScanner) (pcdom.Coverage, error) {
+	var (
+		tenant, run, tech, eng, asset, tax, expected, verdict string
+		actual                                                []byte
+		c                                                     pcdom.Coverage
+	)
+	if err := row.Scan(&tenant, &run, &tech, &eng, &asset, &tax, &expected, &actual, &verdict, &c.ComputedAt); err != nil {
+		return pcdom.Coverage{}, err
+	}
+	var actualSlice []string
+	if len(actual) > 0 {
+		if err := json.Unmarshal(actual, &actualSlice); err != nil {
+			return pcdom.Coverage{}, fmt.Errorf("unmarshal actual: %w", err)
+		}
+	}
+	c.TenantID = shared.ID(tenant)
+	c.RunID = shared.ID(run)
+	c.TechniqueID = tech
+	c.EngagementID = shared.ID(eng)
+	c.AssetID = shared.ID(asset)
+	c.TaxonomyRef = tax
+	c.Expected = expected
+	c.Actual = actualSlice
+	c.Verdict = pcdom.Verdict(verdict)
+	return c, nil
+}

--- a/internal/usecase/ports/purplecoverage.go
+++ b/internal/usecase/ports/purplecoverage.go
@@ -1,0 +1,21 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// PurpleCoverageStore persists purple-team coverage records (#426): the per-technique verdict for an
+// emulation run, keyed by (run, technique) so coverage over time is a trend and a covered->uncovered
+// transition is a detectable regression. Tenant-scoped through the chokepoint.
+type PurpleCoverageStore interface {
+	// SaveCoverage upserts a run's coverage records (immutable per run+technique) under the ctx tenant.
+	SaveCoverage(ctx context.Context, records []purplecoverage.Coverage) error
+	// ListByRun returns one run's coverage records, tenant-scoped.
+	ListByRun(ctx context.Context, runID shared.ID) ([]purplecoverage.Coverage, error)
+	// ListByEngagement returns all coverage records for an engagement (across runs), oldest first, so a
+	// trend across runs is queryable. Tenant-scoped.
+	ListByEngagement(ctx context.Context, engagementID shared.ID) ([]purplecoverage.Coverage, error)
+}

--- a/internal/usecase/purplecoverage/arch_test.go
+++ b/internal/usecase/purplecoverage/arch_test.go
@@ -1,0 +1,37 @@
+package purplecoverage
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDomainDoesNotImportPortsOrPersistence asserts the dependency rule for the purple-coverage domain:
+// the pure domain (internal/domain/purplecoverage) must not reach outward to usecase ports or any
+// persistence package. The join/verdict logic stays pure; the I/O lives here in the usecase.
+func TestDomainDoesNotImportPortsOrPersistence(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "internal", "domain", "purplecoverage")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read domain dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(root, e.Name()), nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", e.Name(), err)
+		}
+		for _, imp := range f.Imports {
+			p := strings.Trim(imp.Path.Value, `"`)
+			if strings.Contains(p, "usecase/ports") || strings.Contains(p, "persistence") || strings.Contains(p, "usecase/") {
+				t.Errorf("%s imports %q — the purple-coverage domain must stay pure", e.Name(), p)
+			}
+		}
+	}
+}

--- a/internal/usecase/purplecoverage/service.go
+++ b/internal/usecase/purplecoverage/service.go
@@ -1,0 +1,236 @@
+// Package purplecoverage is the control plane that closes the purple loop (#426): it joins the offensive
+// half of the ledger (an emulation.Run's per-technique coverage records — what each technique executed and
+// EXPECTED to be detected, #421) with the defensive half (the detections that ACTUALLY fired on the same
+// asset in the run window, #422/#423) and resolves a per-technique coverage verdict through the pure
+// domain. Coverage is measured from the two independent halves, never claimed.
+//
+// The join and the verdict order (out_of_reach → unknown → covered → gap) live in the domain; this
+// package supplies the two halves, persists the result tenant-scoped, and audits the computation. It is
+// the same honest deferral as the rest of the blue-team pillar: the compute + store are real; the
+// scheduler that triggers a run and streams its window is wired at the composition root later.
+package purplecoverage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Service computes and serves purple coverage.
+type Service struct {
+	store      ports.PurpleCoverageStore
+	detections ports.DetectionRecordStore
+	audit      ports.AuditLogger
+	clock      ports.Clock
+}
+
+// NewService validates its dependencies. All are required: without the detection ledger there is no
+// defensive half to join against, and without the audit log a coverage computation would not be
+// attributable.
+func NewService(store ports.PurpleCoverageStore, detections ports.DetectionRecordStore, audit ports.AuditLogger, clock ports.Clock) (*Service, error) {
+	if store == nil || detections == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: purple-coverage service is missing a dependency", shared.ErrValidation)
+	}
+	return &Service{store: store, detections: detections, audit: audit, clock: clock}, nil
+}
+
+// Window is the observation window a run's detections are joined over. It is explicit because an
+// emulation.Run carries no timestamps: the caller (the scheduler that ran the emulation) owns when the
+// run started and ended, and only detections observed inside [From,To] on the run's asset can count as
+// coverage for that run. A detection outside the window is a different event, not this run's coverage.
+type Window struct {
+	From time.Time
+	To   time.Time
+}
+
+// bounded reports whether the window is fully specified. Compute REQUIRES a bounded window: an
+// unbounded window would join all-time detections for the engagement, so a detection from an unrelated
+// or earlier run could mark this run's technique covered — a false-covered, exactly what #426 exists to
+// prevent. A bounded window is the honest join key.
+func (w Window) bounded() bool {
+	return !w.From.IsZero() && !w.To.IsZero() && !w.To.Before(w.From)
+}
+
+func (w Window) contains(t time.Time) bool {
+	return !t.Before(w.From) && !t.After(w.To)
+}
+
+// Result is one computation's honest outcome: the stored per-technique coverage, the bonus detections
+// (fired but expected by no technique — reported, never hidden or counted as coverage), and the work
+// items (one per gap).
+type Result struct {
+	Coverage []purplecoverage.Coverage
+	Bonus    []string
+	Gaps     []purplecoverage.WorkItem
+}
+
+// Compute joins an emulation run with the detections that fired on its asset in the window, resolves a
+// verdict per technique, persists the coverage tenant-scoped, and audits the computation. The run's
+// tenant/engagement must match the authenticated tenant on the context (fail closed) so a run cannot be
+// scored into another tenant's ledger.
+//
+// Every technique in the run is emulatable by construction (it was in the catalogue and produced a
+// record); out_of_reach is a domain verdict reserved for techniques the platform cannot emulate, which a
+// run does not carry — so a run resolves only to covered/gap/unknown, and a non-executed technique is
+// unknown, never a gap.
+func (s *Service) Compute(ctx context.Context, run emulation.Run, window Window) (Result, error) {
+	if run.EngagementID == "" || run.ID == "" {
+		return Result{}, fmt.Errorf("%w: run is missing engagement/run scope", shared.ErrValidation)
+	}
+	// A run must name the asset it ran against: without it the join would count detections on ANY asset
+	// in the engagement toward every technique — a cross-asset false-covered. Fail closed.
+	if run.Target == "" {
+		return Result{}, fmt.Errorf("%w: run has no target asset; coverage cannot be attributed to an asset", shared.ErrValidation)
+	}
+	// A bounded window is mandatory (see Window.bounded): an all-time join is a false-covered risk.
+	if !window.bounded() {
+		return Result{}, fmt.Errorf("%w: coverage needs a bounded observation window (from <= to, both set)", shared.ErrValidation)
+	}
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return Result{}, fmt.Errorf("%w: purple coverage requires a tenant in context", shared.ErrValidation)
+	}
+	if run.TenantID != "" && run.TenantID != tenant {
+		return Result{}, fmt.Errorf("%w: run tenant %q does not match the authenticated tenant", shared.ErrForbidden, run.TenantID)
+	}
+
+	// Defensive half: the detections that actually fired for this engagement, filtered to the run's asset
+	// and window. The store is tenant-scoped, so this can only see the authenticated tenant's ledger.
+	records, err := s.detections.ListDetections(ctx, run.EngagementID)
+	if err != nil {
+		return Result{}, fmt.Errorf("load detections for %s: %w", run.EngagementID, err)
+	}
+	var actual []string
+	for _, r := range records {
+		if run.Target != "" && r.AssetID != run.Target {
+			continue
+		}
+		if !window.contains(r.Detection.Observed) {
+			continue
+		}
+		actual = append(actual, r.Detection.RuleID)
+	}
+
+	now := s.clock.Now().UTC()
+	inputs := make([]purplecoverage.Input, 0, len(run.Coverage))
+	coverage := make([]purplecoverage.Coverage, 0, len(run.Coverage))
+	for _, rec := range run.Coverage {
+		in := purplecoverage.Input{
+			TechniqueID: rec.TechniqueID,
+			TaxonomyRef: rec.TaxonomyRef,
+			Expected:    rec.Expected,
+			Emulatable:  true, // a run only carries techniques the platform emulated
+			Executed:    rec.Executed,
+			Actual:      actual,
+		}
+		inputs = append(inputs, in)
+		c := purplecoverage.Coverage{
+			TenantID:     tenant,
+			EngagementID: run.EngagementID,
+			RunID:        run.ID,
+			AssetID:      run.Target,
+			TechniqueID:  rec.TechniqueID,
+			TaxonomyRef:  rec.TaxonomyRef,
+			Expected:     rec.Expected,
+			Actual:       actual,
+			Verdict:      purplecoverage.Resolve(in),
+			ComputedAt:   now,
+		}
+		if err := c.Validate(); err != nil {
+			return Result{}, fmt.Errorf("coverage for %s: %w", rec.TechniqueID, err)
+		}
+		coverage = append(coverage, c)
+	}
+
+	res := Result{
+		Coverage: coverage,
+		Bonus:    purplecoverage.BonusDetections(inputs, actual),
+		Gaps:     purplecoverage.WorkItems(coverage),
+	}
+
+	// Audit BEFORE persisting: the invariant is that no coverage row exists without an attributing audit
+	// entry. If the audit write fails, nothing is stored, so a query can never surface an unattributable
+	// coverage record. (The reverse order would leave rows queryable via Trend/WorkItems the instant the
+	// audit failed.) The entry carries who/when and the honest headline numbers (gaps and bonus) so a
+	// coverage claim can always be traced back to the run it was measured from.
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor:  run.Actor,
+		Action: "purple.coverage_computed",
+		Target: run.EngagementID.String(),
+		At:     now,
+		Metadata: map[string]string{
+			"run":        run.ID.String(),
+			"asset":      run.Target.String(),
+			"techniques": fmt.Sprint(len(coverage)),
+			"gaps":       fmt.Sprint(len(res.Gaps)),
+			"bonus":      fmt.Sprint(len(res.Bonus)),
+		},
+	}); err != nil {
+		return Result{}, fmt.Errorf("coverage computed but could not be audited (run=%s): %w", run.ID, err)
+	}
+
+	if err := s.store.SaveCoverage(ctx, coverage); err != nil {
+		return Result{}, fmt.Errorf("save coverage for run %s: %w", run.ID, err)
+	}
+
+	return res, nil
+}
+
+// Trend returns an engagement's coverage across runs, oldest first, so a defender can see coverage
+// improve (or regress) over time. Tenant-scoped through the store.
+func (s *Service) Trend(ctx context.Context, engagementID shared.ID) ([]purplecoverage.Coverage, error) {
+	if engagementID == "" {
+		return nil, fmt.Errorf("%w: trend needs an engagement id", shared.ErrValidation)
+	}
+	cov, err := s.store.ListByEngagement(ctx, engagementID)
+	if err != nil {
+		return nil, fmt.Errorf("coverage trend for %s: %w", engagementID, err)
+	}
+	return cov, nil
+}
+
+// Regressions compares two runs' coverage and returns the techniques that went from covered to
+// uncovered — a detection regression. Both runs are loaded tenant-scoped.
+func (s *Service) Regressions(ctx context.Context, prevRun, currRun shared.ID) ([]purplecoverage.Regression, error) {
+	if prevRun == "" || currRun == "" {
+		return nil, fmt.Errorf("%w: regression needs two run ids", shared.ErrValidation)
+	}
+	prev, err := s.store.ListByRun(ctx, prevRun)
+	if err != nil {
+		return nil, fmt.Errorf("load prev run %s: %w", prevRun, err)
+	}
+	curr, err := s.store.ListByRun(ctx, currRun)
+	if err != nil {
+		return nil, fmt.Errorf("load curr run %s: %w", currRun, err)
+	}
+	return purplecoverage.Regressions(prev, curr), nil
+}
+
+// WorkItems returns one actionable item per gap in a run (the missing detection a human must write). It
+// reads the stored coverage so it reflects what was measured, not a recomputation.
+//
+// The run is bound to engagementID: ListByRun is only tenant-scoped, so a run id belonging to a
+// DIFFERENT engagement in the same tenant would otherwise be readable through an engagement the caller is
+// authorized for. Any record whose EngagementID does not match is dropped, so a mismatched run resolves
+// to no work items rather than leaking another engagement's gaps.
+func (s *Service) WorkItems(ctx context.Context, engagementID, runID shared.ID) ([]purplecoverage.WorkItem, error) {
+	if engagementID == "" || runID == "" {
+		return nil, fmt.Errorf("%w: work items need an engagement id and a run id", shared.ErrValidation)
+	}
+	cov, err := s.store.ListByRun(ctx, runID)
+	if err != nil {
+		return nil, fmt.Errorf("load run %s: %w", runID, err)
+	}
+	bound := cov[:0]
+	for _, c := range cov {
+		if c.EngagementID == engagementID {
+			bound = append(bound, c)
+		}
+	}
+	return purplecoverage.WorkItems(bound), nil
+}

--- a/internal/usecase/purplecoverage/service_test.go
+++ b/internal/usecase/purplecoverage/service_test.go
@@ -1,0 +1,236 @@
+package purplecoverage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	pcdom "github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+// fakeDetections is a detection ledger that returns canned records; the join filters them by asset+window.
+type fakeDetections struct{ records []detection.Record }
+
+func (f *fakeDetections) AppendDetection(context.Context, detection.Record) error { return nil }
+func (f *fakeDetections) HasDetection(context.Context, shared.ID) (bool, error)   { return false, nil }
+func (f *fakeDetections) ListDetections(context.Context, shared.ID) ([]detection.Record, error) {
+	return f.records, nil
+}
+func (f *fakeDetections) LastBatchSequence(context.Context, shared.ID) (uint64, error) { return 0, nil }
+func (f *fakeDetections) ExpireDetections(context.Context, shared.ID, time.Time) ([]shared.ID, error) {
+	return nil, nil
+}
+
+type fakeAudit struct {
+	entries []ports.AuditEntry
+	fail    bool
+}
+
+func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	if a.fail {
+		return errors.New("audit down")
+	}
+	a.entries = append(a.entries, e)
+	return nil
+}
+
+func tctx() context.Context { return shared.WithTenant(context.Background(), "t1") }
+
+func newSvc(t *testing.T, det *fakeDetections, audit *fakeAudit) (*Service, ports.PurpleCoverageStore) {
+	t.Helper()
+	store := memory.NewPurpleStore()
+	svc, err := NewService(store, det, audit, fixedClock{t: time.Unix(2000, 0)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc, store
+}
+
+func firedDetection(rule string, asset shared.ID, at time.Time) detection.Record {
+	return detection.Record{
+		AssetID:   asset,
+		Detection: detection.Detection{RuleID: rule, Observed: at},
+	}
+}
+
+// TestComputeResolvesCoveredGapUnknownFromTheTwoHalves is the core join: covered when the expected
+// detection fired in the window on the asset, gap when it did not, unknown when the technique did not run.
+func TestComputeResolvesCoveredGapUnknownFromTheTwoHalves(t *testing.T) {
+	window := time.Unix(1500, 0)
+	det := &fakeDetections{records: []detection.Record{
+		firedDetection("det.covered", "asset-1", window),     // expected by emu.covered → covered
+		firedDetection("det.surprise", "asset-1", window),    // matches no technique → bonus
+		firedDetection("det.covered", "asset-OTHER", window), // right rule, WRONG asset → must not count
+	}}
+	audit := &fakeAudit{}
+	svc, store := newSvc(t, det, audit)
+
+	run := emulation.Run{
+		ID: "run-1", TenantID: "t1", EngagementID: "eng-1", Target: "asset-1", Actor: "op@x",
+		Coverage: []emulation.CoverageRecord{
+			{TechniqueID: "emu.covered", TaxonomyRef: "T1", Executed: true, Expected: "det.covered"},
+			{TechniqueID: "emu.gap", TaxonomyRef: "T2", Executed: true, Expected: "det.gap"},
+			{TechniqueID: "emu.unknown", TaxonomyRef: "T3", Executed: false, Expected: "det.unknown"},
+		},
+	}
+
+	res, err := svc.Compute(tctx(), run, Window{From: time.Unix(1000, 0), To: time.Unix(2000, 0)})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	got := map[string]pcdom.Verdict{}
+	for _, c := range res.Coverage {
+		got[c.TechniqueID] = c.Verdict
+	}
+	if got["emu.covered"] != pcdom.VerdictCovered {
+		t.Errorf("emu.covered = %s, want covered", got["emu.covered"])
+	}
+	if got["emu.gap"] != pcdom.VerdictGap {
+		t.Errorf("emu.gap = %s, want gap", got["emu.gap"])
+	}
+	if got["emu.unknown"] != pcdom.VerdictUnknown {
+		t.Errorf("emu.unknown = %s, want unknown (never gap)", got["emu.unknown"])
+	}
+	if len(res.Bonus) != 1 || res.Bonus[0] != "det.surprise" {
+		t.Errorf("bonus = %v, want [det.surprise]", res.Bonus)
+	}
+	if len(res.Gaps) != 1 || res.Gaps[0].TechniqueID != "emu.gap" {
+		t.Errorf("gaps = %+v, want one for emu.gap", res.Gaps)
+	}
+	// Persisted, so a trend/regression query later sees it.
+	stored, err := store.ListByRun(tctx(), "run-1")
+	if err != nil || len(stored) != 3 {
+		t.Fatalf("stored coverage = %d (%v), want 3", len(stored), err)
+	}
+	if len(audit.entries) != 1 || audit.entries[0].Action != "purple.coverage_computed" {
+		t.Fatalf("computation must be audited exactly once, got %+v", audit.entries)
+	}
+}
+
+// TestComputeWindowExcludesDetectionsOutsideRange proves a detection observed outside the window does not
+// count as coverage — otherwise a later run's detection could paper over an earlier gap.
+func TestComputeWindowExcludesDetectionsOutsideRange(t *testing.T) {
+	det := &fakeDetections{records: []detection.Record{
+		firedDetection("det.a", "asset-1", time.Unix(9999, 0)), // outside [1000,2000]
+	}}
+	svc, _ := newSvc(t, det, &fakeAudit{})
+	run := emulation.Run{ID: "run-1", TenantID: "t1", EngagementID: "eng-1", Target: "asset-1",
+		Coverage: []emulation.CoverageRecord{{TechniqueID: "emu.a", TaxonomyRef: "T1", Executed: true, Expected: "det.a"}}}
+	res, err := svc.Compute(tctx(), run, Window{From: time.Unix(1000, 0), To: time.Unix(2000, 0)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Coverage[0].Verdict != pcdom.VerdictGap {
+		t.Fatalf("a detection outside the window must not close the gap, got %s", res.Coverage[0].Verdict)
+	}
+}
+
+func fullWindow() Window { return Window{From: time.Unix(1000, 0), To: time.Unix(2000, 0)} }
+
+// TestComputeRejectsForeignTenantRun fails closed if the run claims a tenant other than the authenticated
+// one — a run must not be scored into another tenant's ledger.
+func TestComputeRejectsForeignTenantRun(t *testing.T) {
+	svc, _ := newSvc(t, &fakeDetections{}, &fakeAudit{})
+	run := emulation.Run{ID: "run-1", TenantID: "t2", EngagementID: "eng-1", Target: "asset-1",
+		Coverage: []emulation.CoverageRecord{{TechniqueID: "emu.a", TaxonomyRef: "T1", Executed: true, Expected: "det.a"}}}
+	_, err := svc.Compute(tctx(), run, fullWindow())
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("cross-tenant run must be forbidden, got %v", err)
+	}
+}
+
+// TestComputeRequiresBoundedWindowAndTarget proves the false-covered guards fail closed: an unbounded
+// window or a run with no target asset is refused, so an all-time / cross-asset join can never happen.
+func TestComputeRequiresBoundedWindowAndTarget(t *testing.T) {
+	svc, _ := newSvc(t, &fakeDetections{}, &fakeAudit{})
+	base := emulation.Run{ID: "run-1", TenantID: "t1", EngagementID: "eng-1", Target: "asset-1",
+		Coverage: []emulation.CoverageRecord{{TechniqueID: "emu.a", TaxonomyRef: "T1", Executed: true, Expected: "det.a"}}}
+	if _, err := svc.Compute(tctx(), base, Window{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("an unbounded window must be refused, got %v", err)
+	}
+	if _, err := svc.Compute(tctx(), base, Window{From: time.Unix(2000, 0), To: time.Unix(1000, 0)}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a reversed window must be refused, got %v", err)
+	}
+	noTarget := base
+	noTarget.Target = ""
+	if _, err := svc.Compute(tctx(), noTarget, fullWindow()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a run with no target asset must be refused, got %v", err)
+	}
+}
+
+// TestComputeFailsWhenUnauditedAndStoresNothing proves an un-attributable coverage computation is not
+// presented as measured AND leaves no row behind: a failed audit fails the whole computation, and because
+// the audit is written before the save, nothing is persisted.
+func TestComputeFailsWhenUnauditedAndStoresNothing(t *testing.T) {
+	svc, store := newSvc(t, &fakeDetections{}, &fakeAudit{fail: true})
+	run := emulation.Run{ID: "run-1", TenantID: "t1", EngagementID: "eng-1", Target: "asset-1",
+		Coverage: []emulation.CoverageRecord{{TechniqueID: "emu.a", TaxonomyRef: "T1", Executed: true, Expected: "det.a"}}}
+	_, err := svc.Compute(tctx(), run, fullWindow())
+	if err == nil || !strings.Contains(err.Error(), "audited") {
+		t.Fatalf("a failed audit must fail the computation, got %v", err)
+	}
+	if stored, _ := store.ListByRun(tctx(), "run-1"); len(stored) != 0 {
+		t.Fatalf("no coverage row may exist when the audit failed, got %d", len(stored))
+	}
+}
+
+// TestWorkItemsBoundRunToEngagement proves a run id from another engagement in the same tenant resolves
+// to no work items — the within-tenant cross-engagement read is closed.
+func TestWorkItemsBoundRunToEngagement(t *testing.T) {
+	det := &fakeDetections{}
+	svc, _ := newSvc(t, det, &fakeAudit{})
+	run := emulation.Run{ID: "run-1", TenantID: "t1", EngagementID: "eng-1", Target: "asset-1",
+		Coverage: []emulation.CoverageRecord{{TechniqueID: "emu.gap", TaxonomyRef: "T1", Executed: true, Expected: "det.gap"}}}
+	if _, err := svc.Compute(tctx(), run, fullWindow()); err != nil {
+		t.Fatal(err)
+	}
+	// Correct engagement → one gap work item.
+	if items, err := svc.WorkItems(tctx(), "eng-1", "run-1"); err != nil || len(items) != 1 {
+		t.Fatalf("same-engagement work items = %d (%v), want 1", len(items), err)
+	}
+	// Different engagement, same tenant → the run's items must NOT leak.
+	if items, err := svc.WorkItems(tctx(), "eng-OTHER", "run-1"); err != nil || len(items) != 0 {
+		t.Fatalf("cross-engagement work items must be empty, got %d (%v)", len(items), err)
+	}
+}
+
+// TestRegressionsAcrossRuns proves a covered→gap transition between two runs is surfaced as a regression.
+func TestRegressionsAcrossRuns(t *testing.T) {
+	det := &fakeDetections{}
+	audit := &fakeAudit{}
+	svc, _ := newSvc(t, det, audit)
+
+	base := emulation.Run{ID: "run-1", TenantID: "t1", EngagementID: "eng-1", Target: "asset-1",
+		Coverage: []emulation.CoverageRecord{{TechniqueID: "emu.a", TaxonomyRef: "T1", Executed: true, Expected: "det.a"}}}
+	// Run 1: det.a fired → covered.
+	det.records = []detection.Record{firedDetection("det.a", "asset-1", time.Unix(1500, 0))}
+	if _, err := svc.Compute(tctx(), base, Window{From: time.Unix(1000, 0), To: time.Unix(2000, 0)}); err != nil {
+		t.Fatal(err)
+	}
+	// Run 2: same technique, det.a did NOT fire → gap (a detection regression).
+	run2 := base
+	run2.ID = "run-2"
+	det.records = nil
+	if _, err := svc.Compute(tctx(), run2, Window{From: time.Unix(1000, 0), To: time.Unix(2000, 0)}); err != nil {
+		t.Fatal(err)
+	}
+	regs, err := svc.Regressions(tctx(), "run-1", "run-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(regs) != 1 || regs[0].TechniqueID != "emu.a" || regs[0].To != pcdom.VerdictGap {
+		t.Fatalf("expected one covered->gap regression, got %+v", regs)
+	}
+}

--- a/migrations/0077_purple_coverage.sql
+++ b/migrations/0077_purple_coverage.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- Purple-team coverage ledger (issue #426). Each row is one emulated technique's resolved coverage for a
+-- run: the join of the offensive half (what the technique executed and EXPECTED to be detected, #421) with
+-- the defensive half (what actually fired, #422/#423). Keyed (run_id, technique_id) so a re-computation of
+-- a run replaces its rows in place and coverage across runs is a trend. Tenant-scoped and RLS-enforced.
+CREATE TABLE purple_coverage (
+    tenant_id         TEXT NOT NULL REFERENCES tenants(id),
+    run_id            TEXT NOT NULL,
+    technique_id      TEXT NOT NULL,
+    engagement_id     TEXT NOT NULL REFERENCES engagements(id) ON DELETE CASCADE,
+    asset_id          TEXT NOT NULL DEFAULT '',
+    -- The public taxonomy reference is NOT NULL and non-empty: coverage is expressed against a taxonomy a
+    -- customer and an auditor already understand, mirroring the domain's construction-time refusal.
+    taxonomy_ref      TEXT NOT NULL CHECK (taxonomy_ref <> ''),
+    expected          TEXT NOT NULL DEFAULT '',
+    actual            JSONB NOT NULL DEFAULT '[]'::jsonb,
+    -- The verdict set is closed. out_of_reach/unknown are honest non-measurements; only 'gap' is an
+    -- actionable coverage hole — so a non-executed technique can never be stored as a gap.
+    verdict           TEXT NOT NULL CHECK (verdict IN ('out_of_reach', 'unknown', 'covered', 'gap')),
+    computed_at       TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, technique_id)
+);
+
+CREATE INDEX idx_purple_coverage_engagement ON purple_coverage (tenant_id, engagement_id, computed_at);
+
+CALL synapse_enable_tenant_rls('purple_coverage');
+
+-- +goose Down
+DROP TABLE purple_coverage;


### PR DESCRIPTION
## What

Closes #426 — the last blue-team pillar of #405. Measures which techniques the platform would **actually** detect by joining the detection each emulated technique EXPECTED (#421) with the detections that ACTUALLY fired (#422/#423), and surfaces the gap as a first-class, stored number. Coverage is **measured, never claimed**.

## How

- **`domain/purplecoverage`** — pure verdict resolution, evaluated top-down: `out_of_reach → unknown → covered → gap`, so a technique that never executed can **never** be a gap. Plus `BonusDetections` (fired-but-unexpected — reported separately, never hidden or counted as coverage), `Regressions` (covered→uncovered), and `WorkItems` (one per gap, naming the missing detection).
- **`usecase/purplecoverage`** — `Compute` joins a run's `CoverageRecord`s (expected) with the detection ledger filtered by **asset + bounded window** (actual) → `Resolve` → persist; plus `Trend`/`Regressions`/`WorkItems`. Fail-closed:
  - requires a ctx tenant, a run **target asset**, and a **bounded window** (no all-time / cross-asset false-covered);
  - rejects a foreign-tenant run (`ErrForbidden`);
  - **audits before persisting**, so no unattributable coverage row can exist;
  - work items are **bound to the engagement**, so a run id from another same-tenant engagement leaks nothing.
- **Persistence** — `ports.PurpleCoverageStore` + memory and Postgres stores (migration `0077`: composite PK `(tenant_id, run_id, technique_id)`, `taxonomy_ref <> ''` + `verdict` CHECKs, RLS via `synapse_enable_tenant_rls`, engagement FK cascade). Both stores derive the written tenant from **ctx**, never a self-declared field.
- **HTTP** — `GET /api/v1/engagements/{id}/purple-coverage` (trend; `?run=<id>` → work items), `PermView` + `withEngTenant`.

## Acceptance criteria (all met)

- ✅ verdict per case + ambiguous pairs · ✅ `unknown` ≠ `gap` (test) · ✅ bonus reported separately · ✅ stored with the run + trend across runs queryable · ✅ covered→uncovered regression (test) · ✅ work item references technique + missing detection · ✅ cross-tenant read → 404 in `make harness` · ✅ coverage expressed against the public taxonomy (invariant test).

## Reviews

go-arch-reviewer (dependency rule clean) + security-auditor run; **every finding fixed** — cross-engagement work-item binding, audit-before-save, ctx-tenant authoritative in the Postgres store, mandatory bounded-window + target-asset guards, `EngagementID` invariant, error-wrapping idioms.

## Verification (local; CI disabled)

`go build ./...` (darwin + linux cross), `go vet ./...`, `gofmt` clean, `go test -race` on domain/usecase/memory, hostile harness (`TestHostileHarness`), and the real-Postgres RLS integration test (`TestMigration0077PurpleCoverage`, NOSUPERUSER role) — all green.

`Compute` is real; the scheduler that triggers a run and streams its window is wired at the composition root later (same honest deferral as #423/#424).
