### PR TITLE
feat(ai-triage): observability, budget, and resilience (P1.5)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1242,6 +1242,16 @@ paths:
         '401': {$ref: '#/components/responses/Unauthorized'}
         '403': {$ref: '#/components/responses/Forbidden'}
 
+  /api/v1/ai-triage/observability:
+    get:
+      tags: [ai-triage]
+      operationId: getAITriageObservability
+      summary: Aggregate tenant-scoped AI triage safety and cost metrics
+      responses:
+        '200': {description: Latest per-project AI triage metrics and baseline alerts, content: {application/json: {schema: {$ref: '#/components/schemas/AITriageDashboard'}}}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+
   /api/v1/redteam/halt:
     post:
       tags: [redteam]
@@ -1451,6 +1461,52 @@ components:
         updated_at: {type: string, format: date-time}
         decided_at: {type: [string, 'null'], format: date-time}
         version: {type: integer, minimum: 1}
+
+    AITriageMetricRow:
+      type: object
+      required: [value, request_count, average_latency_ms, timeout_count, parse_failure_count, provider_failure_count, circuit_open_count, total_tokens, estimated_cost_micro_usd, comparisons, disagreements, gate_exemptions, findings]
+      properties:
+        value: {type: string}
+        request_count: {type: integer, minimum: 0}
+        average_latency_ms: {type: integer, minimum: 0}
+        timeout_count: {type: integer, minimum: 0}
+        parse_failure_count: {type: integer, minimum: 0}
+        provider_failure_count: {type: integer, minimum: 0}
+        circuit_open_count: {type: integer, minimum: 0}
+        total_tokens: {type: integer, minimum: 0}
+        estimated_cost_micro_usd: {type: integer, minimum: 0}
+        comparisons: {type: integer, minimum: 0}
+        disagreements: {type: integer, minimum: 0}
+        gate_exemptions: {type: integer, minimum: 0}
+        findings: {type: integer, minimum: 0}
+    AITriageAlert:
+      type: object
+      required: [metric, observed_basis_points, baseline_basis_points, deviation_basis_points, sample_size, message]
+      properties:
+        metric: {type: string, enum: [disagreement_rate, exemption_rate, parse_failure_rate]}
+        observed_basis_points: {type: integer, minimum: 0, maximum: 10000}
+        baseline_basis_points: {type: integer, minimum: 0, maximum: 10000}
+        deviation_basis_points: {type: integer, minimum: 0, maximum: 10000}
+        sample_size: {type: integer, minimum: 0}
+        message: {type: string}
+    AITriageDashboardAlert:
+      type: object
+      required: [project_id, project_name, alert]
+      properties:
+        project_id: {type: string}
+        project_name: {type: string}
+        alert: {$ref: '#/components/schemas/AITriageAlert'}
+    AITriageDashboard:
+      type: object
+      required: [generated_at, totals, by_model, by_prompt_version, by_cwe, by_project, alerts]
+      properties:
+        generated_at: {type: string, format: date-time}
+        totals: {$ref: '#/components/schemas/AITriageMetricRow'}
+        by_model: {type: array, items: {$ref: '#/components/schemas/AITriageMetricRow'}}
+        by_prompt_version: {type: array, items: {$ref: '#/components/schemas/AITriageMetricRow'}}
+        by_cwe: {type: array, items: {$ref: '#/components/schemas/AITriageMetricRow'}}
+        by_project: {type: array, items: {$ref: '#/components/schemas/AITriageMetricRow'}}
+        alerts: {type: array, items: {$ref: '#/components/schemas/AITriageDashboardAlert'}}
     OffensiveHaltRequest:
       type: object
       required: [reason]

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -787,11 +787,21 @@ func main() {
 		scaService.SetFPTriageMode(cfg.FPTriageMode)
 		scaService.SetFPTriageMaxFindings(cfg.FPTriageMaxFindings)
 		scaService.SetFPTriageIndependence(cfg.FPTriageIndependence)
+		scaService.SetFPTriageAlertPolicy(cfg.FPTriageAlertMinSamples, cfg.FPTriageDisagreeBaseBPS,
+			cfg.FPTriageExemptBaseBPS, cfg.FPTriageParseFailBaseBPS, cfg.FPTriageAlertDeltaBPS)
 		if tllm, terr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.FPTriageModel, cfg.LLMTimeout); terr != nil {
 			log.Warn("AI false-positive triage DISABLED (LLM unavailable)", "err", terr)
 		} else {
 			coord := fptriage.NewWithIdentity(tllm, cfg.FPTriageProvider, cfg.FPTriageModel).
-				WithConcurrency(cfg.FPTriageConcurrency)
+				WithConcurrency(cfg.FPTriageConcurrency).
+				WithOperationalPolicy(ports.FPTriageOperationalPolicy{
+					MaxTokens: cfg.FPTriageMaxTokens, MaxCostMicroUSD: cfg.FPTriageMaxCostMicroUSD,
+					ProposerInputMicroUSDPerMillion:  cfg.FPTriageProposerInputRate,
+					ProposerOutputMicroUSDPerMillion: cfg.FPTriageProposerOutputRate,
+					VerifierInputMicroUSDPerMillion:  cfg.FPTriageVerifierInputRate,
+					VerifierOutputMicroUSDPerMillion: cfg.FPTriageVerifierOutputRate,
+					CircuitFailureThreshold:          cfg.FPTriageCircuitFailures, CircuitCooldown: cfg.FPTriageCircuitCooldown,
+				})
 			mode := "advisory-only (distinct verifier required for gate exemption)"
 			if strings.TrimSpace(cfg.VerifierModel) != "" {
 				if !agent.IndependentLLMs(cfg.FPTriageProvider, cfg.FPTriageModel, cfg.VerifierProvider, cfg.VerifierModel, cfg.FPTriageIndependence) {
@@ -820,7 +830,8 @@ func main() {
 			}
 			scaService.SetFPTriage(triager)
 			log.Info("AI false-positive triage ENABLED ("+mode+")", "model", cfg.FPTriageModel,
-				"triage_mode", cfg.FPTriageMode, "max_findings", cfg.FPTriageMaxFindings, "concurrency", cfg.FPTriageConcurrency)
+				"triage_mode", cfg.FPTriageMode, "max_findings", cfg.FPTriageMaxFindings, "max_tokens", cfg.FPTriageMaxTokens,
+				"max_cost_micro_usd", cfg.FPTriageMaxCostMicroUSD, "concurrency", cfg.FPTriageConcurrency)
 		}
 	}
 	if cfg.SuppressionEnabled {

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1352,11 +1352,21 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		sca.SetFPTriageMode(cfg.FPTriageMode)
 		sca.SetFPTriageMaxFindings(cfg.FPTriageMaxFindings)
 		sca.SetFPTriageIndependence(cfg.FPTriageIndependence)
+		sca.SetFPTriageAlertPolicy(cfg.FPTriageAlertMinSamples, cfg.FPTriageDisagreeBaseBPS,
+			cfg.FPTriageExemptBaseBPS, cfg.FPTriageParseFailBaseBPS, cfg.FPTriageAlertDeltaBPS)
 		if llm, lerr := openai.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.FPTriageModel, cfg.LLMTimeout); lerr != nil {
 			fmt.Fprintf(os.Stderr, "synapse-cli: AI false-positive triage disabled: %v\n", lerr)
 		} else {
 			coord := fptriage.NewWithIdentity(llm, cfg.FPTriageProvider, cfg.FPTriageModel).
-				WithConcurrency(cfg.FPTriageConcurrency)
+				WithConcurrency(cfg.FPTriageConcurrency).
+				WithOperationalPolicy(ports.FPTriageOperationalPolicy{
+					MaxTokens: cfg.FPTriageMaxTokens, MaxCostMicroUSD: cfg.FPTriageMaxCostMicroUSD,
+					ProposerInputMicroUSDPerMillion:  cfg.FPTriageProposerInputRate,
+					ProposerOutputMicroUSDPerMillion: cfg.FPTriageProposerOutputRate,
+					VerifierInputMicroUSDPerMillion:  cfg.FPTriageVerifierInputRate,
+					VerifierOutputMicroUSDPerMillion: cfg.FPTriageVerifierOutputRate,
+					CircuitFailureThreshold:          cfg.FPTriageCircuitFailures, CircuitCooldown: cfg.FPTriageCircuitCooldown,
+				})
 			if strings.TrimSpace(cfg.VerifierModel) != "" {
 				if !agent.IndependentLLMs(cfg.FPTriageProvider, cfg.FPTriageModel, cfg.VerifierProvider, cfg.VerifierModel, cfg.FPTriageIndependence) {
 					fmt.Fprintf(os.Stderr, "synapse-cli: verifier %q/%q does not satisfy %q independence from proposer %q/%q; AI triage remains advisory-only\n",

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -109,6 +109,13 @@ stays in the report, it is only held back from the `--fail-on` gate).
    every skipped finding remains reported and gating, and `ai_triage_budget` plus the CLI warning expose
    eligible, attempted, and skipped counts. Accepted ranges are `1..1000` findings and `1..32` concurrent
    assessments; zero, negative, malformed, and over-limit values restore the safe finite defaults.
+   A second reservation guard defaults to `SYNAPSE_FP_TRIAGE_MAX_TOKENS=1000000`. Optional micro-USD
+   pricing and `SYNAPSE_FP_TRIAGE_MAX_COST_MICRO_USD` add a strict cost ceiling. Reservations happen
+   before either model is contacted, so a finding that does not fit receives no partial verifier call
+   and remains gating. Repeated provider or invalid-output failures open a bounded circuit and keep the
+   remaining findings advisory-only until its cooldown probe succeeds. API deployments expose the
+   resulting request, latency, timeout, parse, token/cost, disagreement, exemption and alert views at
+   `/api/v1/ai-triage/observability`.
 
 ```bash
 export SYNAPSE_LLM_BASE_URL=http://localhost:8081/v1

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -91,6 +91,14 @@ Most of these ship ON by default (safe, best-effort). See [Features](features.md
 | `SYNAPSE_FP_TRIAGE_MODE` | `shadow` | `shadow` records `would_gate_exempt` but always keeps the finding gating. `enforce` permits the verified-consensus policy to set `gate_exempt`. Empty or unknown values fail closed to shadow. |
 | `SYNAPSE_FP_TRIAGE_MAX_FINDINGS` | `100` | Hard per-scan cap on eligible findings sent to AI triage (range `1..1000`). When capped, deterministic policy-impact/severity/risk ordering selects work; skipped findings remain reported and gating, and counts are exposed in `ai_triage_budget`. Invalid values restore the finite default. |
 | `SYNAPSE_FP_TRIAGE_CONCURRENCY` | `6` | Maximum simultaneous AI finding assessments (range `1..32`). A distinct verifier makes at most two provider calls per attempted finding. Invalid values restore the finite default. |
+| `SYNAPSE_FP_TRIAGE_MAX_TOKENS` | `1000000` | Conservative per-scan token reservation ceiling. Both proposer/verifier requests are reserved before a finding is scheduled; work that does not fit remains gating. |
+| `SYNAPSE_FP_TRIAGE_MAX_COST_MICRO_USD` | `0` | Optional per-scan cost ceiling in integer micro-USD (`0` disables cost enforcement). When enabled, all active role prices must be configured or triage fails closed without provider calls. |
+| `SYNAPSE_FP_TRIAGE_{PROPOSER,VERIFIER}_{INPUT,OUTPUT}_MICRO_USD_PER_MILLION` | `0` | Provider price in micro-USD per million tokens for deterministic cost reservation and observed-cost metrics. |
+| `SYNAPSE_FP_TRIAGE_CIRCUIT_FAILURES` | `5` | Consecutive provider/parse failures before that role's circuit opens (range `1..100`). An open circuit is advisory-only and cannot exempt findings. |
+| `SYNAPSE_FP_TRIAGE_CIRCUIT_COOLDOWN` | `1m` | Open-circuit cooldown before one half-open probe (maximum `24h`). |
+| `SYNAPSE_FP_TRIAGE_ALERT_MIN_SAMPLES` | `10` | Minimum per-scan samples before a safety-rate baseline alert is emitted. |
+| `SYNAPSE_FP_TRIAGE_{DISAGREEMENT,EXEMPTION,PARSE_FAILURE}_BASELINE_BPS` | `1500`, `1000`, `200` | Expected safety rates in basis points (`10000` = 100%). |
+| `SYNAPSE_FP_TRIAGE_ALERT_DEVIATION_BPS` | `1000` | Absolute deviation from a configured baseline that emits a persisted warning and structured alert metric. |
 | `SYNAPSE_LLM_PROVIDER` | `openai-compatible` | Explicit proposer-provider audit identity. It is not inferred from the URL because gateways may route multiple providers. |
 | `SYNAPSE_VERIFIER_BASE_URL` | `SYNAPSE_LLM_BASE_URL` | Independent OpenAI-compatible endpoint for the verifier. |
 | `SYNAPSE_VERIFIER_API_KEY` | `SYNAPSE_LLM_API_KEY` | Independent verifier credential; never logged. |

--- a/internal/adapter/httpapi/aitriage_observability_handler.go
+++ b/internal/adapter/httpapi/aitriage_observability_handler.go
@@ -1,0 +1,16 @@
+package httpapi
+
+import (
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func (rt *Router) getAITriageObservability(w http.ResponseWriter, r *http.Request) {
+	dashboard, err := rt.sca.AITriageObservability(r.Context(), shared.ID(TenantFrom(r.Context())))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, dashboard)
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -258,6 +258,9 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/ai-triage/reviews/{rid}/claim", rt.authz(userdom.PermReview, rt.claimAITriageReview))
 		mux.HandleFunc("POST /api/v1/ai-triage/reviews/{rid}/decision", rt.authz(userdom.PermReview, rt.decideAITriageReview))
 	}
+	if rt.sca != nil {
+		mux.HandleFunc("GET /api/v1/ai-triage/observability", rt.authz(userdom.PermView, rt.getAITriageObservability))
+	}
 	if rt.fleetAdmin != nil {
 		mux.HandleFunc("POST /api/v1/agents/enrolment-tokens", rt.authz(userdom.PermAdminister, rt.mintEnrolToken))
 		mux.HandleFunc("GET /api/v1/agents", rt.authz(userdom.PermView, rt.listFleetAgents))

--- a/internal/infrastructure/persistence/memory/engagement_repo.go
+++ b/internal/infrastructure/persistence/memory/engagement_repo.go
@@ -121,3 +121,16 @@ func (r *EngagementRepository) List(_ context.Context, tenantID shared.ID) ([]*e
 	}
 	return out, nil
 }
+
+func (r *EngagementRepository) ListProjectEngagements(_ context.Context, tenantID shared.ID) ([]*engagement.Engagement, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	out := make([]*engagement.Engagement, 0)
+	for _, e := range r.data {
+		if !e.ProjectID.IsZero() && e.TenantID == tenantID {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -216,6 +216,40 @@ func (r *EngagementRepository) List(ctx context.Context, tenantID shared.ID) (ou
 	return out, err
 }
 
+// ListProjectEngagements returns the tenant's hidden Project analysis contexts for operational
+// aggregation. Normal engagement lists remain unchanged and continue to hide these rows.
+func (r *EngagementRepository) ListProjectEngagements(ctx context.Context, tenantID shared.ID) (out []*engagement.Engagement, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE tenant_id=$1 AND project_id IS NOT NULL ORDER BY created_at DESC`, tenantID.String())
+		if err != nil {
+			return fmt.Errorf("list project engagements: %w", err)
+		}
+		for rows.Next() {
+			e, err := scanEngagement(rows)
+			if err != nil {
+				rows.Close()
+				return fmt.Errorf("scan project engagement: %w", err)
+			}
+			out = append(out, e)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("list project engagements: %w", err)
+		}
+		rows.Close()
+		for _, e := range out {
+			scope, err := loadScope(ctx, tx, e.ID)
+			if err != nil {
+				return err
+			}
+			e.Scope = scope
+		}
+		return nil
+	})
+	return out, err
+}
+
 func (r *EngagementRepository) get(ctx context.Context, tx pgx.Tx, predicate string, args ...any) (*engagement.Engagement, error) {
 	e, err := scanEngagement(tx.QueryRow(ctx, `SELECT `+engagementCols+` FROM engagements WHERE `+predicate, args...))
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -10,10 +10,14 @@ import (
 )
 
 const (
-	defaultFPTriageMaxFindings = 100
-	maxFPTriageMaxFindings     = 1000
-	defaultFPTriageConcurrency = 6
-	maxFPTriageConcurrency     = 32
+	defaultFPTriageMaxFindings     = 100
+	maxFPTriageMaxFindings         = 1000
+	defaultFPTriageConcurrency     = 6
+	maxFPTriageConcurrency         = 32
+	defaultFPTriageMaxTokens       = int64(1_000_000)
+	maxFPTriageMaxTokens           = int64(100_000_000)
+	defaultFPTriageCircuitFailures = 5
+	maxFPTriageCircuitFailures     = 100
 )
 
 // Config holds runtime configuration.
@@ -177,9 +181,22 @@ type Config struct {
 	FPTriageProvider string
 	// FPTriageMode is shadow|enforce. Shadow is the fail-closed default: decisions are persisted for
 	// evaluation but can never set gate_exempt. Enforce requires a deliberate operator choice.
-	FPTriageMode        string
-	FPTriageMaxFindings int
-	FPTriageConcurrency int
+	FPTriageMode               string
+	FPTriageMaxFindings        int
+	FPTriageConcurrency        int
+	FPTriageMaxTokens          int64
+	FPTriageMaxCostMicroUSD    int64
+	FPTriageProposerInputRate  int64
+	FPTriageProposerOutputRate int64
+	FPTriageVerifierInputRate  int64
+	FPTriageVerifierOutputRate int64
+	FPTriageCircuitFailures    int
+	FPTriageCircuitCooldown    time.Duration
+	FPTriageAlertMinSamples    int
+	FPTriageDisagreeBaseBPS    int
+	FPTriageExemptBaseBPS      int
+	FPTriageParseFailBaseBPS   int
+	FPTriageAlertDeltaBPS      int
 	// FPTriageIndependence is model_family (default) or provider. Provider mode additionally
 	// requires a different explicit provider identity; invalid values disable verifier authority.
 	FPTriageIndependence string
@@ -626,6 +643,19 @@ func Load() Config {
 		FPTriageMode:                 normalizeFPTriageMode(getenv("SYNAPSE_FP_TRIAGE_MODE", "shadow")),
 		FPTriageMaxFindings:          boundedPositive(getint("SYNAPSE_FP_TRIAGE_MAX_FINDINGS", defaultFPTriageMaxFindings), defaultFPTriageMaxFindings, maxFPTriageMaxFindings),
 		FPTriageConcurrency:          boundedPositive(getint("SYNAPSE_FP_TRIAGE_CONCURRENCY", defaultFPTriageConcurrency), defaultFPTriageConcurrency, maxFPTriageConcurrency),
+		FPTriageMaxTokens:            boundedPositive64(getint64("SYNAPSE_FP_TRIAGE_MAX_TOKENS", defaultFPTriageMaxTokens), defaultFPTriageMaxTokens, maxFPTriageMaxTokens),
+		FPTriageMaxCostMicroUSD:      boundedNonNegative64(getint64("SYNAPSE_FP_TRIAGE_MAX_COST_MICRO_USD", 0), 1_000_000_000_000),
+		FPTriageProposerInputRate:    boundedNonNegative64(getint64("SYNAPSE_FP_TRIAGE_PROPOSER_INPUT_MICRO_USD_PER_MILLION", 0), 1_000_000_000_000),
+		FPTriageProposerOutputRate:   boundedNonNegative64(getint64("SYNAPSE_FP_TRIAGE_PROPOSER_OUTPUT_MICRO_USD_PER_MILLION", 0), 1_000_000_000_000),
+		FPTriageVerifierInputRate:    boundedNonNegative64(getint64("SYNAPSE_FP_TRIAGE_VERIFIER_INPUT_MICRO_USD_PER_MILLION", 0), 1_000_000_000_000),
+		FPTriageVerifierOutputRate:   boundedNonNegative64(getint64("SYNAPSE_FP_TRIAGE_VERIFIER_OUTPUT_MICRO_USD_PER_MILLION", 0), 1_000_000_000_000),
+		FPTriageCircuitFailures:      boundedPositive(getint("SYNAPSE_FP_TRIAGE_CIRCUIT_FAILURES", defaultFPTriageCircuitFailures), defaultFPTriageCircuitFailures, maxFPTriageCircuitFailures),
+		FPTriageCircuitCooldown:      boundedPositiveDuration(getduration("SYNAPSE_FP_TRIAGE_CIRCUIT_COOLDOWN", time.Minute), time.Minute, 24*time.Hour),
+		FPTriageAlertMinSamples:      boundedPositive(getint("SYNAPSE_FP_TRIAGE_ALERT_MIN_SAMPLES", 10), 10, 10000),
+		FPTriageDisagreeBaseBPS:      boundedNonNegative(getint("SYNAPSE_FP_TRIAGE_DISAGREEMENT_BASELINE_BPS", 1500), 10000),
+		FPTriageExemptBaseBPS:        boundedNonNegative(getint("SYNAPSE_FP_TRIAGE_EXEMPTION_BASELINE_BPS", 1000), 10000),
+		FPTriageParseFailBaseBPS:     boundedNonNegative(getint("SYNAPSE_FP_TRIAGE_PARSE_FAILURE_BASELINE_BPS", 200), 10000),
+		FPTriageAlertDeltaBPS:        boundedNonNegative(getint("SYNAPSE_FP_TRIAGE_ALERT_DEVIATION_BPS", 1000), 10000),
 		FPTriageIndependence:         normalizeFPTriageIndependence(getenv("SYNAPSE_FP_TRIAGE_INDEPENDENCE", "model_family")),
 
 		AgentApprovalMode:    getenv("SYNAPSE_AGENT_APPROVAL_MODE", "manual"),
@@ -702,6 +732,27 @@ func normalizeFPTriageMode(s string) string {
 
 func boundedPositive(value, fallback, max int) int {
 	if value < 1 || value > max {
+		return fallback
+	}
+	return value
+}
+
+func boundedPositive64(value, fallback, max int64) int64 {
+	if value <= 0 || value > max {
+		return fallback
+	}
+	return value
+}
+
+func boundedNonNegative64(value, max int64) int64 {
+	if value < 0 || value > max {
+		return 0
+	}
+	return value
+}
+
+func boundedPositiveDuration(value, fallback, max time.Duration) time.Duration {
+	if value <= 0 || value > max {
 		return fallback
 	}
 	return value

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -225,6 +225,24 @@ func TestFPTriageBudgetDefaultsAndBounds(t *testing.T) {
 	}
 }
 
+func TestFPTriageOperationalBudgetAndCircuitConfig(t *testing.T) {
+	for _, key := range []string{"SYNAPSE_FP_TRIAGE_MAX_TOKENS", "SYNAPSE_FP_TRIAGE_MAX_COST_MICRO_USD", "SYNAPSE_FP_TRIAGE_CIRCUIT_FAILURES", "SYNAPSE_FP_TRIAGE_CIRCUIT_COOLDOWN"} {
+		t.Setenv(key, "")
+	}
+	cfg := Load()
+	if cfg.FPTriageMaxTokens != defaultFPTriageMaxTokens || cfg.FPTriageMaxCostMicroUSD != 0 || cfg.FPTriageCircuitFailures != defaultFPTriageCircuitFailures || cfg.FPTriageCircuitCooldown != time.Minute {
+		t.Fatalf("operational defaults = tokens:%d cost:%d failures:%d cooldown:%s", cfg.FPTriageMaxTokens, cfg.FPTriageMaxCostMicroUSD, cfg.FPTriageCircuitFailures, cfg.FPTriageCircuitCooldown)
+	}
+	t.Setenv("SYNAPSE_FP_TRIAGE_MAX_TOKENS", "25000")
+	t.Setenv("SYNAPSE_FP_TRIAGE_MAX_COST_MICRO_USD", "4000")
+	t.Setenv("SYNAPSE_FP_TRIAGE_CIRCUIT_FAILURES", "3")
+	t.Setenv("SYNAPSE_FP_TRIAGE_CIRCUIT_COOLDOWN", "30s")
+	cfg = Load()
+	if cfg.FPTriageMaxTokens != 25000 || cfg.FPTriageMaxCostMicroUSD != 4000 || cfg.FPTriageCircuitFailures != 3 || cfg.FPTriageCircuitCooldown != 30*time.Second {
+		t.Fatalf("operational config = tokens:%d cost:%d failures:%d cooldown:%s", cfg.FPTriageMaxTokens, cfg.FPTriageMaxCostMicroUSD, cfg.FPTriageCircuitFailures, cfg.FPTriageCircuitCooldown)
+	}
+}
+
 func TestFPTriageVerifierIdentityConfig(t *testing.T) {
 	for _, key := range []string{
 		"SYNAPSE_LLM_BASE_URL", "SYNAPSE_LLM_API_KEY", "SYNAPSE_LLM_PROVIDER", "SYNAPSE_FP_TRIAGE_PROVIDER",

--- a/internal/usecase/fptriage/coordinator.go
+++ b/internal/usecase/fptriage/coordinator.go
@@ -87,6 +87,9 @@ type Coordinator struct {
 	minConf            int // minimum confidence for a "refuted" to be actionable (default verdict.EvidenceThreshold)
 	radius             int // source context lines each side of the finding line
 	concurrency        int
+	operations         ports.FPTriageOperationalPolicy
+	proposerCircuit    *circuitBreaker
+	verifierCircuit    *circuitBreaker
 }
 
 // preparedFinding is one immutable model input. sourceSHA256 covers the complete file when the reader
@@ -116,7 +119,7 @@ func New(llm ports.LLM, model string) *Coordinator {
 
 // NewWithIdentity builds a Coordinator with explicit proposer provider/model audit identity.
 func NewWithIdentity(llm ports.LLM, provider, model string) *Coordinator {
-	return &Coordinator{
+	c := &Coordinator{
 		llm:                llm,
 		model:              strings.TrimSpace(model),
 		proposerProvider:   agent.CanonicalProviderID(provider),
@@ -125,6 +128,21 @@ func NewWithIdentity(llm ports.LLM, provider, model string) *Coordinator {
 		radius:             8,
 		concurrency:        defaultConcurrency,
 	}
+	c.WithOperationalPolicy(ports.FPTriageOperationalPolicy{})
+	return c
+}
+
+// WithOperationalPolicy configures per-run resource ceilings and provider circuit breaking. Invalid
+// values are replaced with finite fail-safe defaults; a zero cost ceiling leaves cost enforcement off.
+func (c *Coordinator) WithOperationalPolicy(policy ports.FPTriageOperationalPolicy) *Coordinator {
+	if c == nil {
+		return c
+	}
+	policy = normalizeOperationalPolicy(policy)
+	c.operations = policy
+	c.proposerCircuit = newCircuitBreaker(policy.CircuitFailureThreshold, policy.CircuitCooldown)
+	c.verifierCircuit = newCircuitBreaker(policy.CircuitFailureThreshold, policy.CircuitCooldown)
+	return c
 }
 
 // WithMinConfidence overrides the confidence bar a "refuted" verdict must clear (clamped to 1..100).
@@ -243,21 +261,60 @@ func (c *Coordinator) prepare(ctx context.Context, f finding.Finding, src Source
 }
 
 func (c *Coordinator) assessPrepared(ctx context.Context, candidates []preparedFinding) []Critique {
+	out, _ := c.assessPreparedObserved(ctx, candidates)
+	return out
+}
+
+func (c *Coordinator) assessPreparedObserved(ctx context.Context, candidates []preparedFinding) ([]Critique, ports.FPTriageTelemetry) {
 	out := make([]Critique, len(candidates))
 	if c == nil || c.llm == nil || len(candidates) == 0 {
-		return out
+		return out, ports.FPTriageTelemetry{}
 	}
+	budget := newRunBudget(c.operations)
+	type assessment struct {
+		candidate preparedFinding
+		proposer  ports.ChatRequest
+		verifier  ports.ChatRequest
+		admitted  bool
+	}
+	work := make([]assessment, len(candidates))
+	skipped := 0
+	for i, candidate := range candidates {
+		if !candidate.ready {
+			candidate = c.prepare(ctx, candidate.finding, candidate.reader)
+		}
+		proposer := c.proposerRequest(candidate.finding, candidate.snippet)
+		requests := []pricedRequest{{request: proposer, price: c.proposerPrice()}}
+		var verifier ports.ChatRequest
+		if c.verifier != nil {
+			verifier = c.verifierRequest(candidate.finding, candidate.snippet)
+			requests = append(requests, pricedRequest{request: verifier, price: c.verifierPrice()})
+		}
+		admitted := budget.reservePair(requests...)
+		work[i] = assessment{candidate: candidate, proposer: proposer, verifier: verifier, admitted: admitted}
+		if !admitted {
+			out[i] = Critique{FindingID: candidate.finding.ID.String(), DedupKey: candidate.finding.DedupKey, Err: errTriageBudgetExhausted}
+			skipped++
+		}
+	}
+	observer := newRunObserver(budget)
+	observer.telemetry.BudgetSkippedFindings = skipped
 	sem := make(chan struct{}, c.Concurrency())
 	var wg sync.WaitGroup
-	for i := range candidates {
+	for i := range work {
+		if !work[i].admitted {
+			continue
+		}
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
-			for j := i; j < len(candidates); j++ {
-				out[j] = Critique{FindingID: string(candidates[j].finding.ID), DedupKey: candidates[j].finding.DedupKey, Err: ctx.Err()}
+			for j := i; j < len(work); j++ {
+				if work[j].admitted {
+					out[j] = Critique{FindingID: work[j].candidate.finding.ID.String(), DedupKey: work[j].candidate.finding.DedupKey, Err: ctx.Err()}
+				}
 			}
 			wg.Wait()
-			return out
+			return out, observer.snapshot()
 		}
 		wg.Add(1)
 		go func(i int) {
@@ -268,56 +325,80 @@ func (c *Coordinator) assessPrepared(ctx context.Context, candidates []preparedF
 			defer func() {
 				if r := recover(); r != nil {
 					out[i] = Critique{
-						FindingID: string(candidates[i].finding.ID),
-						DedupKey:  candidates[i].finding.DedupKey,
+						FindingID: work[i].candidate.finding.ID.String(),
+						DedupKey:  work[i].candidate.finding.DedupKey,
 						Err:       fmt.Errorf("critique panicked: %v", r),
 					}
 				}
 			}()
-			candidate := candidates[i]
-			if !candidate.ready {
-				candidate = c.prepare(ctx, candidate.finding, candidate.reader)
-			}
-			out[i] = c.assessOne(ctx, candidate.finding, candidate.snippet)
+			out[i] = c.assessOneObserved(ctx, work[i].candidate.finding, work[i].proposer, work[i].verifier, observer)
 		}(i)
 	}
 	wg.Wait()
-	return out
+	telemetry := observer.snapshot()
+	for _, critique := range out {
+		if critique.Verifier != nil {
+			telemetry.Comparisons++
+			if disagreement(critique) {
+				telemetry.Disagreements++
+			}
+		}
+	}
+	return out, telemetry
 }
 
 func (c *Coordinator) assessOne(ctx context.Context, f finding.Finding, snippet string) Critique {
-	res := Critique{FindingID: string(f.ID), DedupKey: f.DedupKey}
-	if ctx.Err() != nil {
-		res.Err = ctx.Err()
-		return res
+	out, _ := c.assessPreparedObserved(ctx, []preparedFinding{{finding: f, snippet: snippet, ready: true}})
+	if len(out) == 0 {
+		return Critique{FindingID: f.ID.String(), DedupKey: f.DedupKey, Err: context.Canceled}
 	}
-	req := ports.ChatRequest{
+	return out[0]
+}
+
+func (c *Coordinator) proposerRequest(f finding.Finding, snippet string) ports.ChatRequest {
+	return ports.ChatRequest{
 		Model:          c.model,
-		Temperature:    ports.Temp(0), // greedy: the same finding must critique the same way twice
-		MaxTokens:      512,           // headroom if the model emits a short rationale field before the JSON object
+		Temperature:    ports.Temp(0),
+		MaxTokens:      512,
 		ResponseSchema: critiqueSchema,
 		Messages: []agent.Message{
 			{Role: "system", Content: systemPrompt},
 			{Role: "user", Content: userPrompt(f, snippet)},
 		},
 	}
+}
+
+func (c *Coordinator) verifierRequest(f finding.Finding, snippet string) ports.ChatRequest {
+	return ports.ChatRequest{
+		Model:          c.verifierModel,
+		Temperature:    ports.Temp(0),
+		MaxTokens:      512,
+		ResponseSchema: critiqueSchema,
+		Messages: []agent.Message{
+			{Role: "system", Content: verifierSystemPrompt},
+			{Role: "user", Content: verifierUserPrompt(f, snippet)},
+		},
+	}
+}
+
+func (c *Coordinator) assessOneObserved(ctx context.Context, f finding.Finding, proposerReq, verifierReq ports.ChatRequest, observer *runObserver) Critique {
+	res := Critique{FindingID: string(f.ID), DedupKey: f.DedupKey}
+	if ctx.Err() != nil {
+		res.Err = ctx.Err()
+		return res
+	}
 	// Run the verifier before the proposer result exists. Its request contains only the finding and source
 	// context, so neither invocation order nor prompt content can anchor it to the proposer's conclusion.
 	if c.verifier != nil {
 		res.VerifyAttempted = true
-		if v, verr := c.verify(ctx, f, snippet); verr == nil {
+		if v, verr := c.observeCall(ctx, c.verifier, c.verifierCircuit, verifierReq, "verifier", c.verifierProvider, f.ID.String(), f.DedupKey, c.verifierPrice(), observer); verr == nil {
 			res.Verifier = &v
 		}
 	}
 
-	resp, err := c.llm.Chat(ctx, req)
+	claim, err := c.observeCall(ctx, c.llm, c.proposerCircuit, proposerReq, "proposer", c.proposerProvider, f.ID.String(), f.DedupKey, c.proposerPrice(), observer)
 	if err != nil {
 		res.Err = fmt.Errorf("critique llm: %w", err)
-		return res
-	}
-	claim, err := parseCritique(resp.Content)
-	if err != nil {
-		res.Err = err
 		return res
 	}
 	res.Claim = claim

--- a/internal/usecase/fptriage/telemetry.go
+++ b/internal/usecase/fptriage/telemetry.go
@@ -1,0 +1,294 @@
+package fptriage
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	defaultMaxTriageTokens     int64 = 1_000_000
+	defaultCircuitFailures           = 5
+	defaultCircuitCooldown           = time.Minute
+	requestFramingTokenCeiling int64 = 4096
+)
+
+var (
+	errTriageBudgetExhausted = errors.New("AI triage request budget exhausted")
+	errTriageCircuitOpen     = errors.New("AI triage provider circuit open")
+)
+
+func normalizeOperationalPolicy(p ports.FPTriageOperationalPolicy) ports.FPTriageOperationalPolicy {
+	if p.MaxTokens <= 0 {
+		p.MaxTokens = defaultMaxTriageTokens
+	}
+	if p.MaxCostMicroUSD < 0 {
+		p.MaxCostMicroUSD = 0
+	}
+	if p.CircuitFailureThreshold < 1 {
+		p.CircuitFailureThreshold = defaultCircuitFailures
+	}
+	if p.CircuitCooldown <= 0 {
+		p.CircuitCooldown = defaultCircuitCooldown
+	}
+	return p
+}
+
+type requestPrice struct {
+	inputMicroUSDPerMillion  int64
+	outputMicroUSDPerMillion int64
+}
+
+type requestReservation struct {
+	tokens int64
+	cost   int64
+}
+
+type runBudget struct {
+	policy       ports.FPTriageOperationalPolicy
+	reserved     int64
+	reservedCost int64
+}
+
+func newRunBudget(policy ports.FPTriageOperationalPolicy) *runBudget {
+	return &runBudget{policy: normalizeOperationalPolicy(policy)}
+}
+
+// reservePair is called in deterministic candidate order before workers start. A verifier is never
+// contacted unless the same reservation also admits the proposer, avoiding partial consensus work.
+func (b *runBudget) reservePair(reqs ...pricedRequest) bool {
+	var reservation requestReservation
+	for _, req := range reqs {
+		r := reserveRequest(req.request, req.price)
+		reservation.tokens += r.tokens
+		reservation.cost += r.cost
+	}
+	if b.reserved+reservation.tokens > b.policy.MaxTokens {
+		return false
+	}
+	if b.policy.MaxCostMicroUSD > 0 {
+		for _, req := range reqs {
+			if req.price.inputMicroUSDPerMillion <= 0 || req.price.outputMicroUSDPerMillion <= 0 {
+				return false
+			}
+		}
+		if b.reservedCost+reservation.cost > b.policy.MaxCostMicroUSD {
+			return false
+		}
+	}
+	b.reserved += reservation.tokens
+	b.reservedCost += reservation.cost
+	return true
+}
+
+type pricedRequest struct {
+	request ports.ChatRequest
+	price   requestPrice
+}
+
+func reserveRequest(req ports.ChatRequest, price requestPrice) requestReservation {
+	input := requestFramingTokenCeiling + int64(len(req.ResponseSchema))
+	for _, message := range req.Messages {
+		input += int64(len(message.Role) + len(message.Content))
+	}
+	for _, tool := range req.Tools {
+		input += int64(len(tool.Name) + len(tool.Description) + len(tool.Parameters))
+	}
+	output := int64(req.MaxTokens)
+	if output < 0 {
+		output = 0
+	}
+	return requestReservation{
+		tokens: input + output,
+		cost:   microUSDCeiling(input, price.inputMicroUSDPerMillion) + microUSDCeiling(output, price.outputMicroUSDPerMillion),
+	}
+}
+
+func microUSDCeiling(tokens, rate int64) int64 {
+	if tokens <= 0 || rate <= 0 {
+		return 0
+	}
+	return (tokens*rate + 999_999) / 1_000_000
+}
+
+type runObserver struct {
+	mu        sync.Mutex
+	telemetry ports.FPTriageTelemetry
+}
+
+func newRunObserver(b *runBudget) *runObserver {
+	return &runObserver{telemetry: ports.FPTriageTelemetry{
+		MaxTokens:            b.policy.MaxTokens,
+		MaxCostMicroUSD:      b.policy.MaxCostMicroUSD,
+		ReservedTokens:       b.reserved,
+		ReservedCostMicroUSD: b.reservedCost,
+	}}
+}
+
+func (o *runObserver) record(metric ports.FPTriageCallMetric) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.telemetry.Calls = append(o.telemetry.Calls, metric)
+	switch metric.Outcome {
+	case "success":
+		o.telemetry.RequestCount++
+		o.telemetry.SuccessCount++
+	case "timeout":
+		o.telemetry.RequestCount++
+		o.telemetry.TimeoutCount++
+	case "parse_failure":
+		o.telemetry.RequestCount++
+		o.telemetry.ParseFailureCount++
+	case "provider_error":
+		o.telemetry.RequestCount++
+		o.telemetry.ProviderFailureCount++
+	case "circuit_open":
+		o.telemetry.CircuitOpenCount++
+	}
+	o.telemetry.UsedTokens += int64(metric.TotalTokens)
+	o.telemetry.EstimatedCostMicroUSD += metric.EstimatedCostMicroUSD
+}
+
+func (o *runObserver) snapshot() ports.FPTriageTelemetry {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	result := o.telemetry
+	result.Calls = append([]ports.FPTriageCallMetric(nil), result.Calls...)
+	sort.SliceStable(result.Calls, func(i, j int) bool {
+		if result.Calls[i].DedupKey != result.Calls[j].DedupKey {
+			return result.Calls[i].DedupKey < result.Calls[j].DedupKey
+		}
+		return result.Calls[i].Role < result.Calls[j].Role
+	})
+	return result
+}
+
+type circuitBreaker struct {
+	mu        sync.Mutex
+	threshold int
+	cooldown  time.Duration
+	failures  int
+	openedAt  time.Time
+	probe     bool
+	now       func() time.Time
+}
+
+func newCircuitBreaker(threshold int, cooldown time.Duration) *circuitBreaker {
+	if threshold < 1 {
+		threshold = defaultCircuitFailures
+	}
+	if cooldown <= 0 {
+		cooldown = defaultCircuitCooldown
+	}
+	return &circuitBreaker{threshold: threshold, cooldown: cooldown, now: time.Now}
+}
+
+func (b *circuitBreaker) allow() bool {
+	if b == nil {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.openedAt.IsZero() {
+		return true
+	}
+	if b.now().Sub(b.openedAt) < b.cooldown || b.probe {
+		return false
+	}
+	b.probe = true
+	return true
+}
+
+func (b *circuitBreaker) success() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.failures = 0
+	b.openedAt = time.Time{}
+	b.probe = false
+	b.mu.Unlock()
+}
+
+func (b *circuitBreaker) failure() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.failures++
+	b.probe = false
+	if b.failures >= b.threshold {
+		b.openedAt = b.now()
+	}
+	b.mu.Unlock()
+}
+
+func classifyCallError(ctx context.Context, err error) string {
+	if errors.Is(err, errTriageCircuitOpen) {
+		return "circuit_open"
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return "timeout"
+	}
+	return "provider_error"
+}
+
+func callMetric(role, provider, model, findingID, dedupKey string, started time.Time, resp ports.ChatResponse, outcome string, price requestPrice) ports.FPTriageCallMetric {
+	return ports.FPTriageCallMetric{
+		FindingID:             findingID,
+		DedupKey:              dedupKey,
+		Role:                  role,
+		Provider:              provider,
+		Model:                 model,
+		PromptVersion:         promptVersion,
+		Outcome:               outcome,
+		LatencyMillis:         time.Since(started).Milliseconds(),
+		PromptTokens:          resp.Usage.PromptTokens,
+		CompletionTokens:      resp.Usage.CompletionTokens,
+		TotalTokens:           resp.Usage.TotalTokens,
+		EstimatedCostMicroUSD: microUSDCeiling(int64(resp.Usage.PromptTokens), price.inputMicroUSDPerMillion) + microUSDCeiling(int64(resp.Usage.CompletionTokens), price.outputMicroUSDPerMillion),
+	}
+}
+
+func (c *Coordinator) proposerPrice() requestPrice {
+	return requestPrice{c.operations.ProposerInputMicroUSDPerMillion, c.operations.ProposerOutputMicroUSDPerMillion}
+}
+
+func (c *Coordinator) verifierPrice() requestPrice {
+	return requestPrice{c.operations.VerifierInputMicroUSDPerMillion, c.operations.VerifierOutputMicroUSDPerMillion}
+}
+
+func (c *Coordinator) observeCall(ctx context.Context, llm ports.LLM, breaker *circuitBreaker, req ports.ChatRequest, role, provider, findingID, dedupKey string, price requestPrice, observer *runObserver) (judgment.CritiqueClaim, error) {
+	started := time.Now()
+	if !breaker.allow() {
+		observer.record(callMetric(role, provider, req.Model, findingID, dedupKey, started, ports.ChatResponse{}, "circuit_open", price))
+		return judgment.CritiqueClaim{}, errTriageCircuitOpen
+	}
+	resp, err := llm.Chat(ctx, req)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			breaker.failure()
+		}
+		observer.record(callMetric(role, provider, req.Model, findingID, dedupKey, started, resp, classifyCallError(ctx, err), price))
+		return judgment.CritiqueClaim{}, err
+	}
+	claim, err := parseCritique(resp.Content)
+	if err != nil {
+		breaker.failure()
+		observer.record(callMetric(role, provider, req.Model, findingID, dedupKey, started, resp, "parse_failure", price))
+		return judgment.CritiqueClaim{}, err
+	}
+	breaker.success()
+	observer.record(callMetric(role, provider, req.Model, findingID, dedupKey, started, resp, "success", price))
+	return claim, nil
+}
+
+func disagreement(c Critique) bool {
+	return c.Verifier != nil && (c.Claim.Verdict != c.Verifier.Verdict || c.Claim.Confidence != c.Verifier.Confidence || !strings.EqualFold(c.Claim.Driver, c.Verifier.Driver))
+}

--- a/internal/usecase/fptriage/telemetry_test.go
+++ b/internal/usecase/fptriage/telemetry_test.go
@@ -1,0 +1,100 @@
+package fptriage
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type observedLLM struct {
+	mu      sync.Mutex
+	calls   int
+	content string
+	err     error
+	usage   agent.Usage
+}
+
+func (l *observedLLM) Chat(context.Context, ports.ChatRequest) (ports.ChatResponse, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.calls++
+	return ports.ChatResponse{Content: l.content, Usage: l.usage}, l.err
+}
+
+func (l *observedLLM) count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
+func TestObservedTriageEnforcesTokenBudgetBeforeProviderCall(t *testing.T) {
+	llm := &observedLLM{content: `{"verdict":"sound","driver":"attacker_controlled","confidence":90}`}
+	coord := New(llm, "model").WithOperationalPolicy(ports.FPTriageOperationalPolicy{MaxTokens: 1})
+	critiques, telemetry := coord.assessPreparedObserved(context.Background(), prepareCandidatesForTest(2))
+	if llm.count() != 0 || telemetry.RequestCount != 0 || telemetry.BudgetSkippedFindings != 2 {
+		t.Fatalf("calls=%d telemetry=%+v", llm.count(), telemetry)
+	}
+	for _, critique := range critiques {
+		if !errors.Is(critique.Err, errTriageBudgetExhausted) {
+			t.Fatalf("critique error = %v, want budget exhaustion", critique.Err)
+		}
+	}
+	if telemetry.ReservedTokens > telemetry.MaxTokens {
+		t.Fatalf("reserved tokens %d exceeded max %d", telemetry.ReservedTokens, telemetry.MaxTokens)
+	}
+}
+
+func TestObservedTriageFailsClosedWhenCostBudgetHasNoPricing(t *testing.T) {
+	llm := &observedLLM{content: `{"verdict":"sound","driver":"attacker_controlled","confidence":90}`}
+	coord := New(llm, "model").WithOperationalPolicy(ports.FPTriageOperationalPolicy{MaxTokens: 100_000, MaxCostMicroUSD: 100})
+	_, telemetry := coord.assessPreparedObserved(context.Background(), prepareCandidatesForTest(1))
+	if llm.count() != 0 || telemetry.BudgetSkippedFindings != 1 || telemetry.ReservedCostMicroUSD != 0 {
+		t.Fatalf("unpriced cost budget was not fail-closed: calls=%d telemetry=%+v", llm.count(), telemetry)
+	}
+}
+
+func TestObservedTriageRecordsUsageAndCostWithoutPromptContent(t *testing.T) {
+	llm := &observedLLM{
+		content: `{"verdict":"sound","driver":"attacker_controlled","confidence":90}`,
+		usage:   agent.Usage{PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120},
+	}
+	coord := New(llm, "model").WithOperationalPolicy(ports.FPTriageOperationalPolicy{
+		MaxTokens: 100_000, ProposerInputMicroUSDPerMillion: 1_000_000, ProposerOutputMicroUSDPerMillion: 2_000_000,
+	})
+	_, telemetry := coord.assessPreparedObserved(context.Background(), prepareCandidatesForTest(1))
+	if telemetry.RequestCount != 1 || telemetry.SuccessCount != 1 || telemetry.UsedTokens != 120 || telemetry.EstimatedCostMicroUSD != 140 {
+		t.Fatalf("telemetry = %+v", telemetry)
+	}
+	if len(telemetry.Calls) != 1 || telemetry.Calls[0].PromptTokens != 100 || telemetry.Calls[0].Outcome != "success" {
+		t.Fatalf("call metric = %+v", telemetry.Calls)
+	}
+}
+
+func TestProviderFailureOpensCircuitAndRemainingFindingStaysAdvisory(t *testing.T) {
+	llm := &observedLLM{err: errors.New("provider unavailable")}
+	coord := New(llm, "model").WithConcurrency(1).WithOperationalPolicy(ports.FPTriageOperationalPolicy{
+		MaxTokens: 100_000, CircuitFailureThreshold: 1, CircuitCooldown: time.Hour,
+	})
+	critiques, telemetry := coord.assessPreparedObserved(context.Background(), prepareCandidatesForTest(2))
+	if llm.count() != 1 || telemetry.ProviderFailureCount != 1 || telemetry.CircuitOpenCount != 1 {
+		t.Fatalf("circuit telemetry = %+v, calls=%d", telemetry, llm.count())
+	}
+	for _, critique := range critiques {
+		if critique.Err == nil || critique.VerifiedConsensus(1) {
+			t.Fatalf("outage critique gained authority: %+v", critique)
+		}
+	}
+}
+
+func prepareCandidatesForTest(count int) []preparedFinding {
+	out := make([]preparedFinding, count)
+	for i := range out {
+		out[i] = preparedFinding{finding: mkFinding(string(rune('a'+i)), "finding"), ready: true}
+	}
+	return out
+}

--- a/internal/usecase/fptriage/triager.go
+++ b/internal/usecase/fptriage/triager.go
@@ -27,6 +27,7 @@ type Triager struct {
 }
 
 var _ ports.FPTriager = (*Triager)(nil)
+var _ ports.ObservableFPTriager = (*Triager)(nil)
 
 // NewTriager wraps a Coordinator. readerFor returns the source reader rooted at a scan's workspace dir
 // (nil-safe: a nil factory means the coordinator critiques on metadata only).
@@ -52,15 +53,21 @@ func (t *Triager) WithCache(cache ports.FPTriageCache, policyVersion string) *Tr
 // Triage critiques each candidate and returns the advisory verdicts. A best-effort failure (Err set) is
 // dropped so that finding gates normally. Never mutates a finding.
 func (t *Triager) Triage(ctx context.Context, candidates []finding.Finding, workspaceDir string) []ports.AICritique {
+	return t.TriageObserved(ctx, candidates, workspaceDir).Critiques
+}
+
+// TriageObserved performs the same fail-safe triage while returning source-free operational metrics.
+func (t *Triager) TriageObserved(ctx context.Context, candidates []finding.Finding, workspaceDir string) ports.FPTriageObservedResult {
 	if t == nil || t.coord == nil || len(candidates) == 0 {
-		return nil
+		return ports.FPTriageObservedResult{}
 	}
 	var reader ports.SourceSnippetReader
 	if t.readerFor != nil {
 		reader = t.readerFor(workspaceDir)
 	}
 	if t.cache == nil {
-		return t.mapCritiques(t.coord.Assess(ctx, candidates, reader))
+		critiques, telemetry := t.coord.assessPreparedObserved(ctx, prepareCandidates(candidates, reader))
+		return ports.FPTriageObservedResult{Critiques: t.mapCritiques(critiques), Telemetry: telemetry}
 	}
 	prepared := make([]preparedFinding, len(candidates))
 	for i := range candidates {
@@ -72,6 +79,7 @@ func (t *Triager) Triage(ctx context.Context, candidates []finding.Finding, work
 	missIndexes := make([]int, 0, len(candidates))
 	keys := make([]ports.FPTriageCacheKey, len(candidates))
 	cacheable := make([]bool, len(candidates))
+	cacheHits := 0
 	for i := range prepared {
 		key, ok := t.cacheKey(ctx, prepared[i])
 		keys[i], cacheable[i] = key, ok
@@ -79,6 +87,7 @@ func (t *Triager) Triage(ctx context.Context, candidates []finding.Finding, work
 			if cached, hit, err := t.cache.Load(ctx, key); err == nil && hit {
 				if critique, valid := critiqueFromCache(prepared[i].finding, key, cached); valid {
 					crits[i] = critique
+					cacheHits++
 					continue
 				}
 			}
@@ -86,7 +95,10 @@ func (t *Triager) Triage(ctx context.Context, candidates []finding.Finding, work
 		misses = append(misses, prepared[i])
 		missIndexes = append(missIndexes, i)
 	}
-	assessed := t.coord.assessPrepared(ctx, misses)
+	assessed, telemetry := t.coord.assessPreparedObserved(ctx, misses)
+	if len(misses) == 0 {
+		telemetry = newRunObserver(newRunBudget(t.coord.operations)).snapshot()
+	}
 	for i, critique := range assessed {
 		idx := missIndexes[i]
 		crits[idx] = critique
@@ -97,7 +109,26 @@ func (t *Triager) Triage(ctx context.Context, candidates []finding.Finding, work
 		}
 	}
 
-	return t.mapCritiques(crits)
+	telemetry.CacheHits = cacheHits
+	telemetry.Comparisons = 0
+	telemetry.Disagreements = 0
+	for _, critique := range crits {
+		if critique.Verifier != nil {
+			telemetry.Comparisons++
+			if disagreement(critique) {
+				telemetry.Disagreements++
+			}
+		}
+	}
+	return ports.FPTriageObservedResult{Critiques: t.mapCritiques(crits), Telemetry: telemetry}
+}
+
+func prepareCandidates(candidates []finding.Finding, reader ports.SourceSnippetReader) []preparedFinding {
+	prepared := make([]preparedFinding, len(candidates))
+	for i := range candidates {
+		prepared[i] = preparedFinding{finding: candidates[i], reader: reader}
+	}
+	return prepared
 }
 
 func (t *Triager) mapCritiques(crits []Critique) []ports.AICritique {

--- a/internal/usecase/ports/fptriage.go
+++ b/internal/usecase/ports/fptriage.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"context"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -140,4 +141,69 @@ type FPTriageCache interface {
 // nil = no triage.
 type FPTriager interface {
 	Triage(ctx context.Context, candidates []finding.Finding, workspaceDir string) []AICritique
+}
+
+// FPTriageOperationalPolicy bounds one triage run and configures the shared provider circuit breaker.
+// Token reservations use a conservative upper bound before either model is contacted. Cost values are
+// integer micro-USD to keep policy arithmetic deterministic and free of floating-point rounding.
+type FPTriageOperationalPolicy struct {
+	MaxTokens                        int64
+	MaxCostMicroUSD                  int64
+	ProposerInputMicroUSDPerMillion  int64
+	ProposerOutputMicroUSDPerMillion int64
+	VerifierInputMicroUSDPerMillion  int64
+	VerifierOutputMicroUSDPerMillion int64
+	CircuitFailureThreshold          int
+	CircuitCooldown                  time.Duration
+}
+
+// FPTriageCallMetric is safe operational metadata for one provider request. It deliberately excludes
+// prompt text, source context, provider error bodies, and credentials.
+type FPTriageCallMetric struct {
+	FindingID             string `json:"finding_id"`
+	DedupKey              string `json:"dedup_key"`
+	Role                  string `json:"role"`
+	Provider              string `json:"provider"`
+	Model                 string `json:"model"`
+	PromptVersion         string `json:"prompt_version"`
+	Outcome               string `json:"outcome"`
+	LatencyMillis         int64  `json:"latency_ms"`
+	PromptTokens          int    `json:"prompt_tokens,omitempty"`
+	CompletionTokens      int    `json:"completion_tokens,omitempty"`
+	TotalTokens           int    `json:"total_tokens,omitempty"`
+	EstimatedCostMicroUSD int64  `json:"estimated_cost_micro_usd,omitempty"`
+}
+
+// FPTriageTelemetry is one scan's bounded, evidence-sealed operational summary. Reserved values are
+// authoritative for enforcing the budget; usage values are provider-reported observations.
+type FPTriageTelemetry struct {
+	Calls                 []FPTriageCallMetric `json:"calls,omitempty"`
+	RequestCount          int                  `json:"request_count"`
+	SuccessCount          int                  `json:"success_count"`
+	TimeoutCount          int                  `json:"timeout_count"`
+	ParseFailureCount     int                  `json:"parse_failure_count"`
+	ProviderFailureCount  int                  `json:"provider_failure_count"`
+	CircuitOpenCount      int                  `json:"circuit_open_count"`
+	CacheHits             int                  `json:"cache_hits"`
+	BudgetSkippedFindings int                  `json:"budget_skipped_findings"`
+	MaxTokens             int64                `json:"max_tokens"`
+	ReservedTokens        int64                `json:"reserved_tokens"`
+	UsedTokens            int64                `json:"used_tokens"`
+	MaxCostMicroUSD       int64                `json:"max_cost_micro_usd"`
+	ReservedCostMicroUSD  int64                `json:"reserved_cost_micro_usd"`
+	EstimatedCostMicroUSD int64                `json:"estimated_cost_micro_usd"`
+	Comparisons           int                  `json:"comparisons"`
+	Disagreements         int                  `json:"disagreements"`
+	GateExemptions        int                  `json:"gate_exemptions"`
+}
+
+// FPTriageObservedResult is supported as an optional extension so existing custom FPTriager
+// implementations remain source-compatible and continue to fail safe without telemetry.
+type FPTriageObservedResult struct {
+	Critiques []AICritique
+	Telemetry FPTriageTelemetry
+}
+
+type ObservableFPTriager interface {
+	TriageObserved(ctx context.Context, candidates []finding.Finding, workspaceDir string) FPTriageObservedResult
 }

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -307,6 +307,13 @@ type EngagementRepository interface {
 	Delete(ctx context.Context, id shared.ID) error
 }
 
+// ProjectEngagementLister is an optional read extension for tenant-wide operational dashboards.
+// Project analysis contexts are intentionally hidden from EngagementRepository.List, so callers that
+// need project metrics must opt into this tenant-scoped projection instead of weakening List semantics.
+type ProjectEngagementLister interface {
+	ListProjectEngagements(ctx context.Context, tenantID shared.ID) ([]*engagement.Engagement, error)
+}
+
 // JudgmentStore is the broad read/create repository for AI judgments. The
 // score/state MOVER is deliberately NOT here – it lives on the analysis use case's narrow Store
 // interface + the concrete repo, so a read-only consumer (e.g. the agent tool catalog) cannot move

--- a/internal/usecase/sca/fptriage_budget.go
+++ b/internal/usecase/sca/fptriage_budget.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 // AITriageBudget records bounded per-scan AI coverage. The cap is on findings, so a configured
@@ -59,8 +60,24 @@ func (s *Service) runFPTriage(ctx context.Context, result *ScanResult, workspace
 	if trace != nil {
 		tstep = trace.start(stageFindings, "ai-fp-triage", "fp-triager", "AI false-positive triage", counts)
 	}
-	result.AITriage = s.fpTriager.Triage(ctx, attempted, workspaceDir)
+	if observed, ok := s.fpTriager.(ports.ObservableFPTriager); ok {
+		observation := observed.TriageObserved(ctx, attempted, workspaceDir)
+		result.AITriage = observation.Critiques
+		result.AITriageTelemetry = &observation.Telemetry
+		if observation.Telemetry.BudgetSkippedFindings > 0 {
+			result.SourceWarnings = append(result.SourceWarnings, fmt.Sprintf(
+				"AI false-positive triage token/cost budget skipped %d attempted findings; they remain gating",
+				observation.Telemetry.BudgetSkippedFindings,
+			))
+		}
+	} else {
+		result.AITriage = s.fpTriager.Triage(ctx, attempted, workspaceDir)
+	}
 	applyAIGatePolicyWithIndependence(result, s.evidence != nil, s.fpTriageMode, s.fpTriageIndependence)
+	if result.AITriageTelemetry != nil {
+		result.AITriageTelemetry.GateExemptions = len(result.AIGateExemptKeys())
+		s.emitAITriageTelemetry(ctx, result)
+	}
 	if trace != nil {
 		trace.succeed(tstep, "AI false-positive triage", map[string]int{
 			"candidates":      len(candidates),

--- a/internal/usecase/sca/fptriage_dashboard.go
+++ b/internal/usecase/sca/fptriage_dashboard.go
@@ -1,0 +1,203 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AITriageMetricRow struct {
+	Value                 string `json:"value"`
+	RequestCount          int    `json:"request_count"`
+	AverageLatencyMillis  int64  `json:"average_latency_ms"`
+	TimeoutCount          int    `json:"timeout_count"`
+	ParseFailureCount     int    `json:"parse_failure_count"`
+	ProviderFailureCount  int    `json:"provider_failure_count"`
+	CircuitOpenCount      int    `json:"circuit_open_count"`
+	TotalTokens           int64  `json:"total_tokens"`
+	EstimatedCostMicroUSD int64  `json:"estimated_cost_micro_usd"`
+	Comparisons           int    `json:"comparisons"`
+	Disagreements         int    `json:"disagreements"`
+	GateExemptions        int    `json:"gate_exemptions"`
+	Findings              int    `json:"findings"`
+	latencyTotalMillis    int64
+}
+
+type AITriageDashboardAlert struct {
+	ProjectID   string        `json:"project_id"`
+	ProjectName string        `json:"project_name"`
+	Alert       AITriageAlert `json:"alert"`
+}
+
+type AITriageDashboard struct {
+	GeneratedAt time.Time                `json:"generated_at"`
+	Totals      AITriageMetricRow        `json:"totals"`
+	ByModel     []AITriageMetricRow      `json:"by_model"`
+	ByPrompt    []AITriageMetricRow      `json:"by_prompt_version"`
+	ByCWE       []AITriageMetricRow      `json:"by_cwe"`
+	ByProject   []AITriageMetricRow      `json:"by_project"`
+	Alerts      []AITriageDashboardAlert `json:"alerts"`
+}
+
+// AITriageObservability aggregates the latest evidence-sealed result for each tenant-visible project.
+// It never returns source, prompts, provider errors, or credentials.
+func (s *Service) AITriageObservability(ctx context.Context, tenantID shared.ID) (AITriageDashboard, error) {
+	dashboard := AITriageDashboard{GeneratedAt: time.Now().UTC()}
+	if s == nil || s.engagements == nil || s.results == nil {
+		return dashboard, fmt.Errorf("AI triage observability: %w", shared.ErrValidation)
+	}
+	engagements, err := s.engagements.List(ctx, tenantID)
+	if err != nil {
+		return dashboard, err
+	}
+	if projectLister, ok := s.engagements.(ports.ProjectEngagementLister); ok {
+		projects, listErr := projectLister.ListProjectEngagements(ctx, tenantID)
+		if listErr != nil {
+			return dashboard, listErr
+		}
+		engagements = append(engagements, projects...)
+	}
+	byModel := map[string]*AITriageMetricRow{}
+	byPrompt := map[string]*AITriageMetricRow{}
+	byCWE := map[string]*AITriageMetricRow{}
+	byProject := map[string]*AITriageMetricRow{}
+	for _, engagement := range engagements {
+		if engagement == nil {
+			continue
+		}
+		data, loadErr := s.results.LatestResult(ctx, engagement.ID)
+		if errors.Is(loadErr, shared.ErrNotFound) {
+			continue
+		}
+		if loadErr != nil {
+			return dashboard, loadErr
+		}
+		var result ScanResult
+		if err := json.Unmarshal(data, &result); err != nil {
+			return dashboard, fmt.Errorf("decode AI triage observability result: %w", err)
+		}
+		if result.AITriageTelemetry == nil {
+			continue
+		}
+		projectID := engagement.ProjectID
+		if projectID.IsZero() {
+			projectID = engagement.ID
+		}
+		projectValue := projectID.String() + " · " + strings.TrimSpace(engagement.Name)
+		findingsByKey := map[string]string{}
+		for _, item := range result.Findings {
+			cwe := strings.TrimSpace(item.CWE)
+			if cwe == "" {
+				cwe = "unclassified"
+			}
+			findingsByKey[strings.TrimSpace(item.DedupKey)] = cwe
+		}
+		for _, call := range result.AITriageTelemetry.Calls {
+			model := strings.TrimSpace(call.Provider + "/" + call.Model + " (" + call.Role + ")")
+			prompt := strings.TrimSpace(call.PromptVersion)
+			if prompt == "" {
+				prompt = "unknown"
+			}
+			cwe := findingsByKey[strings.TrimSpace(call.DedupKey)]
+			if cwe == "" {
+				cwe = "unclassified"
+			}
+			updateCallMetric(&dashboard.Totals, call)
+			updateCallMetric(metricRow(byModel, model), call)
+			updateCallMetric(metricRow(byPrompt, prompt), call)
+			updateCallMetric(metricRow(byCWE, cwe), call)
+			updateCallMetric(metricRow(byProject, projectValue), call)
+		}
+		for _, critique := range result.AITriage {
+			cwe := findingsByKey[strings.TrimSpace(critique.DedupKey)]
+			if cwe == "" {
+				cwe = "unclassified"
+			}
+			model := strings.TrimSpace(critique.ProposerProvider + "/" + critique.ProposerModel + " (proposer)")
+			prompt := strings.TrimSpace(critique.PromptVersion)
+			if prompt == "" {
+				prompt = "unknown"
+			}
+			rows := []*AITriageMetricRow{&dashboard.Totals, metricRow(byModel, model), metricRow(byPrompt, prompt), metricRow(byCWE, cwe), metricRow(byProject, projectValue)}
+			for _, row := range rows {
+				row.Findings++
+				if critique.VerifierModel != "" && critique.VerifierVerdict != "" {
+					row.Comparisons++
+					if !strings.EqualFold(critique.Verdict, critique.VerifierVerdict) || critique.Confidence != critique.VerifierConfidence || !strings.EqualFold(critique.Driver, critique.VerifierDriver) {
+						row.Disagreements++
+					}
+				}
+				if critique.GateExempt {
+					row.GateExemptions++
+				}
+			}
+		}
+		for _, alert := range result.AITriageAlerts {
+			dashboard.Alerts = append(dashboard.Alerts, AITriageDashboardAlert{ProjectID: projectID.String(), ProjectName: engagement.Name, Alert: alert})
+		}
+	}
+	finalizeMetricRow(&dashboard.Totals)
+	dashboard.Totals.Value = "all"
+	dashboard.ByModel = sortedMetricRows(byModel)
+	dashboard.ByPrompt = sortedMetricRows(byPrompt)
+	dashboard.ByCWE = sortedMetricRows(byCWE)
+	dashboard.ByProject = sortedMetricRows(byProject)
+	sort.SliceStable(dashboard.Alerts, func(i, j int) bool {
+		if dashboard.Alerts[i].ProjectID != dashboard.Alerts[j].ProjectID {
+			return dashboard.Alerts[i].ProjectID < dashboard.Alerts[j].ProjectID
+		}
+		return dashboard.Alerts[i].Alert.Metric < dashboard.Alerts[j].Alert.Metric
+	})
+	return dashboard, nil
+}
+
+func metricRow(rows map[string]*AITriageMetricRow, value string) *AITriageMetricRow {
+	if row := rows[value]; row != nil {
+		return row
+	}
+	row := &AITriageMetricRow{Value: value}
+	rows[value] = row
+	return row
+}
+
+func updateCallMetric(row *AITriageMetricRow, call ports.FPTriageCallMetric) {
+	if call.Outcome != "circuit_open" {
+		row.RequestCount++
+		row.latencyTotalMillis += call.LatencyMillis
+	}
+	switch call.Outcome {
+	case "timeout":
+		row.TimeoutCount++
+	case "parse_failure":
+		row.ParseFailureCount++
+	case "provider_error":
+		row.ProviderFailureCount++
+	case "circuit_open":
+		row.CircuitOpenCount++
+	}
+	row.TotalTokens += int64(call.TotalTokens)
+	row.EstimatedCostMicroUSD += call.EstimatedCostMicroUSD
+}
+
+func finalizeMetricRow(row *AITriageMetricRow) {
+	if row.RequestCount > 0 {
+		row.AverageLatencyMillis = row.latencyTotalMillis / int64(row.RequestCount)
+	}
+}
+
+func sortedMetricRows(rows map[string]*AITriageMetricRow) []AITriageMetricRow {
+	out := make([]AITriageMetricRow, 0, len(rows))
+	for _, row := range rows {
+		finalizeMetricRow(row)
+		out = append(out, *row)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Value < out[j].Value })
+	return out
+}

--- a/internal/usecase/sca/fptriage_observability.go
+++ b/internal/usecase/sca/fptriage_observability.go
@@ -1,0 +1,134 @@
+package sca
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const aiTriageMetricPrefix = "synapse_sca_ai_triage_"
+
+type AITriageAlert struct {
+	Metric               string `json:"metric"`
+	ObservedBasisPoints  int    `json:"observed_basis_points"`
+	BaselineBasisPoints  int    `json:"baseline_basis_points"`
+	DeviationBasisPoints int    `json:"deviation_basis_points"`
+	SampleSize           int    `json:"sample_size"`
+	Message              string `json:"message"`
+}
+
+type aiTriageAlertPolicy struct {
+	minSamples           int
+	disagreementBaseline int
+	exemptionBaseline    int
+	parseFailureBaseline int
+	deviation            int
+}
+
+func defaultAITriageAlertPolicy() aiTriageAlertPolicy {
+	return aiTriageAlertPolicy{minSamples: 10, disagreementBaseline: 1500, exemptionBaseline: 1000, parseFailureBaseline: 200, deviation: 1000}
+}
+
+// SetFPTriageAlertPolicy configures scan-local baseline deviation alerts. Rates are basis points
+// (10000 = 100%); invalid values restore conservative defaults.
+func (s *Service) SetFPTriageAlertPolicy(minSamples, disagreementBaseline, exemptionBaseline, parseFailureBaseline, deviation int) {
+	p := defaultAITriageAlertPolicy()
+	if minSamples > 0 && minSamples <= 10000 {
+		p.minSamples = minSamples
+	}
+	if validBasisPoints(disagreementBaseline) {
+		p.disagreementBaseline = disagreementBaseline
+	}
+	if validBasisPoints(exemptionBaseline) {
+		p.exemptionBaseline = exemptionBaseline
+	}
+	if validBasisPoints(parseFailureBaseline) {
+		p.parseFailureBaseline = parseFailureBaseline
+	}
+	if validBasisPoints(deviation) {
+		p.deviation = deviation
+	}
+	s.fpTriageAlerts = p
+}
+
+func validBasisPoints(value int) bool { return value >= 0 && value <= 10000 }
+
+func rateBasisPoints(numerator, denominator int) int {
+	if numerator <= 0 || denominator <= 0 {
+		return 0
+	}
+	return numerator * 10000 / denominator
+}
+
+func (s *Service) emitAITriageTelemetry(ctx context.Context, result *ScanResult) {
+	if s == nil || result == nil || result.AITriageTelemetry == nil {
+		return
+	}
+	t := result.AITriageTelemetry
+	result.AITriageAlerts = buildAITriageAlerts(t, len(result.AITriage), s.fpTriageAlerts)
+	for _, alert := range result.AITriageAlerts {
+		result.SourceWarnings = append(result.SourceWarnings, alert.Message)
+		s.logger().LogAttrs(context.WithoutCancel(ctx), slog.LevelWarn, "AI triage safety metric deviated from baseline",
+			slog.String("metric", aiTriageMetricPrefix+alert.Metric+"_alert"), slog.String("metric_kind", "alert"),
+			slog.Int("observed_basis_points", alert.ObservedBasisPoints), slog.Int("baseline_basis_points", alert.BaselineBasisPoints),
+			slog.Int("deviation_basis_points", alert.DeviationBasisPoints), slog.Int("sample_size", alert.SampleSize))
+	}
+
+	findingsByKey := make(map[string]finding.Finding, len(result.Findings))
+	for _, item := range result.Findings {
+		findingsByKey[strings.TrimSpace(item.DedupKey)] = item
+	}
+	for _, call := range t.Calls {
+		item := findingsByKey[strings.TrimSpace(call.DedupKey)]
+		s.logger().LogAttrs(context.WithoutCancel(ctx), slog.LevelInfo, "AI triage provider request observed",
+			slog.String("metric", aiTriageMetricPrefix+"requests_total"), slog.String("metric_kind", "counter"), slog.Int("metric_value", 1),
+			slog.String("role", call.Role), slog.String("provider", call.Provider), slog.String("model", call.Model),
+			slog.String("prompt_version", call.PromptVersion), slog.String("cwe", strings.TrimSpace(item.CWE)),
+			slog.String("engagement", item.EngagementID.String()),
+			slog.String("outcome", call.Outcome), slog.Int64("latency_ms", call.LatencyMillis),
+			slog.Int("total_tokens", call.TotalTokens), slog.Int64("estimated_cost_micro_usd", call.EstimatedCostMicroUSD))
+	}
+}
+
+func buildAITriageAlerts(t *ports.FPTriageTelemetry, critiqueCount int, policy aiTriageAlertPolicy) []AITriageAlert {
+	if t == nil {
+		return nil
+	}
+	if policy.minSamples == 0 {
+		policy = defaultAITriageAlertPolicy()
+	}
+	type candidate struct {
+		name               string
+		numerator, samples int
+		baseline           int
+	}
+	candidates := []candidate{
+		{name: "disagreement_rate", numerator: t.Disagreements, samples: t.Comparisons, baseline: policy.disagreementBaseline},
+		{name: "exemption_rate", numerator: t.GateExemptions, samples: critiqueCount, baseline: policy.exemptionBaseline},
+		{name: "parse_failure_rate", numerator: t.ParseFailureCount, samples: t.RequestCount, baseline: policy.parseFailureBaseline},
+	}
+	alerts := make([]AITriageAlert, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.samples < policy.minSamples {
+			continue
+		}
+		observed := rateBasisPoints(candidate.numerator, candidate.samples)
+		delta := observed - candidate.baseline
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta <= policy.deviation {
+			continue
+		}
+		alerts = append(alerts, AITriageAlert{
+			Metric: candidate.name, ObservedBasisPoints: observed, BaselineBasisPoints: candidate.baseline,
+			DeviationBasisPoints: delta, SampleSize: candidate.samples,
+			Message: fmt.Sprintf("AI triage %s is %.2f%% versus %.2f%% baseline across %d samples; review model health before trusting exemptions", strings.ReplaceAll(candidate.name, "_", " "), float64(observed)/100, float64(candidate.baseline)/100, candidate.samples),
+		})
+	}
+	return alerts
+}

--- a/internal/usecase/sca/fptriage_observability_test.go
+++ b/internal/usecase/sca/fptriage_observability_test.go
@@ -1,0 +1,68 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestBuildAITriageAlertsUsesConfiguredBaselineAndMinimumSamples(t *testing.T) {
+	telemetry := &ports.FPTriageTelemetry{RequestCount: 20, ParseFailureCount: 5, Comparisons: 20, Disagreements: 8, GateExemptions: 6}
+	policy := aiTriageAlertPolicy{minSamples: 10, disagreementBaseline: 1000, exemptionBaseline: 1000, parseFailureBaseline: 100, deviation: 500}
+	alerts := buildAITriageAlerts(telemetry, 20, policy)
+	if len(alerts) != 3 {
+		t.Fatalf("alerts = %+v, want all three safety rates", alerts)
+	}
+	if got := buildAITriageAlerts(telemetry, 20, aiTriageAlertPolicy{minSamples: 50, disagreementBaseline: 1000, exemptionBaseline: 1000, parseFailureBaseline: 100, deviation: 500}); len(got) != 0 {
+		t.Fatalf("small sample emitted alerts: %+v", got)
+	}
+}
+
+type dashboardEngagementRepo struct {
+	*fakeEngRepo
+	items []*engdom.Engagement
+}
+
+func (r dashboardEngagementRepo) List(context.Context, shared.ID) ([]*engdom.Engagement, error) {
+	return r.items, nil
+}
+
+func TestAITriageObservabilityGroupsLatestTenantResult(t *testing.T) {
+	engagement := &engdom.Engagement{ID: "e1", TenantID: shared.TenantOrDefault(""), Name: "checkout"}
+	result := ScanResult{
+		Findings: []finding.Finding{{DedupKey: "k1", CWE: "CWE-89"}},
+		AITriage: []ports.AICritique{{DedupKey: "k1", ProposerProvider: "provider", ProposerModel: "model", PromptVersion: "v1", GateExempt: true}},
+		AITriageTelemetry: &ports.FPTriageTelemetry{Calls: []ports.FPTriageCallMetric{{
+			DedupKey: "k1", Role: "proposer", Provider: "provider", Model: "model", PromptVersion: "v1", Outcome: "success",
+			LatencyMillis: 25, TotalTokens: 120, EstimatedCostMicroUSD: 50,
+		}}},
+		AITriageAlerts: []AITriageAlert{{Metric: "exemption_rate", Message: "alert"}},
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{
+		engagements: dashboardEngagementRepo{fakeEngRepo: &fakeEngRepo{}, items: []*engdom.Engagement{engagement}},
+		results:     staticScanResultStore{data: data},
+	}
+	dashboard, err := service.AITriageObservability(context.Background(), shared.TenantOrDefault(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dashboard.GeneratedAt.Before(time.Now().Add(-time.Minute)) || dashboard.Totals.RequestCount != 1 || dashboard.Totals.GateExemptions != 1 {
+		t.Fatalf("totals = %+v", dashboard.Totals)
+	}
+	if len(dashboard.ByModel) != 1 || len(dashboard.ByPrompt) != 1 || len(dashboard.ByCWE) != 1 || dashboard.ByCWE[0].Value != "CWE-89" || len(dashboard.ByProject) != 1 {
+		t.Fatalf("dashboard dimensions = model:%+v prompt:%+v cwe:%+v project:%+v", dashboard.ByModel, dashboard.ByPrompt, dashboard.ByCWE, dashboard.ByProject)
+	}
+	if len(dashboard.Alerts) != 1 || dashboard.Alerts[0].ProjectID != "e1" {
+		t.Fatalf("alerts = %+v", dashboard.Alerts)
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -80,6 +80,7 @@ type Service struct {
 	fpTriageMode                     aiTriageMode                          // shadow by default; enforce must be selected explicitly
 	aiReviews                        ports.AITriageReviewRecorder          // optional durable human-review queue sink
 	fpTriageIndependence             ports.AIIndependencePolicy            // deterministic verifier separation-of-duties requirement
+	fpTriageAlerts                   aiTriageAlertPolicy                   // scan-local safety metric baselines
 	osPkgCataloger                   ports.OSPackageCataloger              // optional owned OS-package cataloging (dpkg/apk) from an image rootfs
 	instCataloger                    ports.InstalledPackageCataloger       // optional owned installed-package cataloging (Go binaries, Python dist-info) from an image rootfs
 	artifactCataloger                ports.ArtifactCataloger               // optional owned standalone-artifact cataloging (.msi product identity) from the workspace dir
@@ -579,6 +580,7 @@ func NewService(
 		detector: d, sbomGen: s, sources: sources, riskEnricher: r, licScan: l, licEnricher: le,
 		fpTriageMaxFindings:  defaultFPTriageMaxFindings,
 		fpTriageIndependence: ports.AIIndependenceModelFamily,
+		fpTriageAlerts:       defaultAITriageAlertPolicy(),
 	}
 	// Build the shared execution guard from the service's own scope/clock/audit
 	// deps, so every scan is gated + audited through the one chokepoint recon will
@@ -684,6 +686,10 @@ type ScanResult struct {
 	// triager even when a provider error produced no critique; SkippedFindings never enter an LLM and
 	// remain gating. nil means AI triage did not run for any eligible finding.
 	AITriageBudget *AITriageBudget `json:"ai_triage_budget,omitempty"`
+	// AITriageTelemetry contains source-free request, latency, provider outcome, token, cost, consensus,
+	// and exemption observations for this scan. It is sealed with the policy decision.
+	AITriageTelemetry *ports.FPTriageTelemetry `json:"ai_triage_telemetry,omitempty"`
+	AITriageAlerts    []AITriageAlert          `json:"ai_triage_alerts,omitempty"`
 	// SourceCapture is analysis-owned source availability metadata. Content is held by
 	// ProjectSourceArtifactStore, never embedded in this scan result.
 	SourceCapture *projectanalysis.SourceCapture `json:"source_capture,omitempty"`
@@ -2939,6 +2945,11 @@ func mergeCachedAnnotations(current *ScanResult, previous ScanResult, preservePr
 	current.SuppressedFindings = mergeSuppressedFindings(current.SuppressedFindings, previous.SuppressedFindings, keys)
 	current.NeedsVerification = mergeNeedsVerification(current.NeedsVerification, previous.NeedsVerification, keys)
 	current.AITriage = mergeAITriage(current.AITriage, previous.AITriage, keys)
+	if current.AITriageTelemetry == nil {
+		current.AITriageTelemetry = previous.AITriageTelemetry
+		current.AITriageAlerts = append([]AITriageAlert(nil), previous.AITriageAlerts...)
+		current.AITriageBudget = previous.AITriageBudget
+	}
 	if preservePrevious {
 		current.SourceWarnings = mergeStrings(current.SourceWarnings, previous.SourceWarnings)
 		current.ExpiredSuppressions = mergeStrings(current.ExpiredSuppressions, previous.ExpiredSuppressions)
@@ -3384,16 +3395,18 @@ func isPinnedVersion(v string) bool {
 var credInErr = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@\s]+@`)
 
 type scanEvidencePayload struct {
-	SBOMSHA256       string                  `json:"sbom_sha256"`
-	Findings         []string                `json:"findings"`
-	Suppressed       []string                `json:"suppressed,omitempty"`
-	AITriagePolicy   string                  `json:"ai_triage_policy,omitempty"`
-	AITriage         []ports.AICritique      `json:"ai_triage,omitempty"`
-	AITriageFindings []scanEvidenceAIFinding `json:"ai_triage_findings,omitempty"`
-	AITriageBudget   *AITriageBudget         `json:"ai_triage_budget,omitempty"`
-	Manifest         ports.ScanManifest      `json:"manifest"`
-	SealedAt         string                  `json:"sealed_at"`
-	Actor            string                  `json:"actor"`
+	SBOMSHA256        string                   `json:"sbom_sha256"`
+	Findings          []string                 `json:"findings"`
+	Suppressed        []string                 `json:"suppressed,omitempty"`
+	AITriagePolicy    string                   `json:"ai_triage_policy,omitempty"`
+	AITriage          []ports.AICritique       `json:"ai_triage,omitempty"`
+	AITriageFindings  []scanEvidenceAIFinding  `json:"ai_triage_findings,omitempty"`
+	AITriageBudget    *AITriageBudget          `json:"ai_triage_budget,omitempty"`
+	AITriageTelemetry *ports.FPTriageTelemetry `json:"ai_triage_telemetry,omitempty"`
+	AITriageAlerts    []AITriageAlert          `json:"ai_triage_alerts,omitempty"`
+	Manifest          ports.ScanManifest       `json:"manifest"`
+	SealedAt          string                   `json:"sealed_at"`
+	Actor             string                   `json:"actor"`
 }
 
 // scanEvidenceAIFinding seals every input the gate policy reads. Sealing a dedup key alone would not
@@ -3487,16 +3500,18 @@ func scanEvidenceContent(actor string, now time.Time, result *ScanResult) ([]byt
 		policyVersion = aiTriagePolicyVersion
 	}
 	return json.Marshal(scanEvidencePayload{
-		SBOMSHA256:       result.Manifest.SBOMSHA256,
-		Findings:         keys,
-		Suppressed:       suppressed,
-		AITriagePolicy:   policyVersion,
-		AITriage:         aiTriage,
-		AITriageFindings: aiFindings,
-		AITriageBudget:   result.AITriageBudget,
-		Manifest:         result.Manifest,
-		SealedAt:         now.UTC().Format(time.RFC3339),
-		Actor:            actor,
+		SBOMSHA256:        result.Manifest.SBOMSHA256,
+		Findings:          keys,
+		Suppressed:        suppressed,
+		AITriagePolicy:    policyVersion,
+		AITriage:          aiTriage,
+		AITriageFindings:  aiFindings,
+		AITriageBudget:    result.AITriageBudget,
+		AITriageTelemetry: result.AITriageTelemetry,
+		AITriageAlerts:    result.AITriageAlerts,
+		Manifest:          result.Manifest,
+		SealedAt:          now.UTC().Format(time.RFC3339),
+		Actor:             actor,
 	})
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { MobileSidebar, Sidebar } from './components/Sidebar'
 import { Topbar } from './components/Topbar'
 import { Audit } from './pages/Audit'
 import { AITriageReviews } from './pages/AITriageReviews'
+import { AITriageObservability } from './pages/AITriageObservability'
 import { Connect } from './pages/Connect'
 import { EngagementDetail } from './pages/EngagementDetail'
 import { Engagements } from './pages/Engagements'
@@ -76,6 +77,7 @@ function Gate() {
         <Route path="rules/:key" element={<RuleDetail />} />
         <Route path="audit" element={<Audit />} />
         <Route path="ai-triage/reviews" element={<AITriageReviews />} />
+        <Route path="ai-triage/observability" element={<AITriageObservability />} />
         <Route path="team" element={<Team />} />
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Route>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   ChevronRight,
   FileText,
   Gauge,
+  Activity,
   LayoutDashboard,
   Library,
   Moon,
@@ -41,6 +42,7 @@ const NAV_GROUPS: Array<{
     items: [
       { icon: SquarePen, label: 'New Engagement', to: '/engagements?create=1', prefix: '/engagements', action: true },
       { icon: ShieldQuestion, label: 'AI review queue', to: '/ai-triage/reviews', prefix: '/ai-triage/reviews' },
+      { icon: Activity, label: 'AI observability', to: '/ai-triage/observability', prefix: '/ai-triage/observability' },
       { icon: Library, label: 'Rules', to: '/rules', prefix: '/rules' },
     ],
   },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,6 +3,8 @@ import type {
   AITriage,
   AITriageReview,
   AITriageReviewFilter,
+  AITriageObservability,
+  AITriageMetricRow,
   AgentReadiness,
   AgentPlan,
   AgentMessage,
@@ -768,6 +770,35 @@ function mapAITriageReview(r: any): AITriageReview {
   }
 }
 
+function mapAITriageMetricRow(r: any): AITriageMetricRow {
+  return {
+    value: r?.value ?? '', requestCount: r?.request_count ?? 0, averageLatencyMillis: r?.average_latency_ms ?? 0,
+    timeoutCount: r?.timeout_count ?? 0, parseFailureCount: r?.parse_failure_count ?? 0,
+    providerFailureCount: r?.provider_failure_count ?? 0, circuitOpenCount: r?.circuit_open_count ?? 0,
+    totalTokens: r?.total_tokens ?? 0, estimatedCostMicroUSD: r?.estimated_cost_micro_usd ?? 0,
+    comparisons: r?.comparisons ?? 0, disagreements: r?.disagreements ?? 0,
+    gateExemptions: r?.gate_exemptions ?? 0, findings: r?.findings ?? 0,
+  }
+}
+
+function mapAITriageObservability(r: any): AITriageObservability {
+  return {
+    generatedAt: r?.generated_at ?? '', totals: mapAITriageMetricRow(r?.totals),
+    byModel: (r?.by_model ?? []).map(mapAITriageMetricRow),
+    byPromptVersion: (r?.by_prompt_version ?? []).map(mapAITriageMetricRow),
+    byCWE: (r?.by_cwe ?? []).map(mapAITriageMetricRow),
+    byProject: (r?.by_project ?? []).map(mapAITriageMetricRow),
+    alerts: (r?.alerts ?? []).map((item: any) => ({
+      projectId: item?.project_id ?? '', projectName: item?.project_name ?? '',
+      alert: {
+        metric: item?.alert?.metric ?? '', observedBasisPoints: item?.alert?.observed_basis_points ?? 0,
+        baselineBasisPoints: item?.alert?.baseline_basis_points ?? 0, deviationBasisPoints: item?.alert?.deviation_basis_points ?? 0,
+        sampleSize: item?.alert?.sample_size ?? 0, message: item?.alert?.message ?? '',
+      },
+    })),
+  }
+}
+
 function mapImportedSBOMMetadata(r: any): ImportedSBOMMetadata {
   return {
     id: r.id ?? '',
@@ -1427,6 +1458,9 @@ export const api = {
     const r = await req(`/ai-triage/reviews${suffix}`)
     return (r?.reviews ?? []).map(mapAITriageReview)
   },
+
+  aiTriageObservability: async (): Promise<AITriageObservability> =>
+    mapAITriageObservability(await req('/ai-triage/observability')),
 
   decideAITriageReview: async (reviewId: string, decision: 'accept' | 'reject', rationale: string, version: number): Promise<AITriageReview> =>
     mapAITriageReview(await req(`/ai-triage/reviews/${encodeURIComponent(reviewId)}/decision`, {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -398,6 +398,41 @@ export interface AITriageReviewFilter {
   state?: AITriageReviewState
 }
 
+export interface AITriageMetricRow {
+  value: string
+  requestCount: number
+  averageLatencyMillis: number
+  timeoutCount: number
+  parseFailureCount: number
+  providerFailureCount: number
+  circuitOpenCount: number
+  totalTokens: number
+  estimatedCostMicroUSD: number
+  comparisons: number
+  disagreements: number
+  gateExemptions: number
+  findings: number
+}
+
+export interface AITriageAlert {
+  metric: string
+  observedBasisPoints: number
+  baselineBasisPoints: number
+  deviationBasisPoints: number
+  sampleSize: number
+  message: string
+}
+
+export interface AITriageObservability {
+  generatedAt: string
+  totals: AITriageMetricRow
+  byModel: AITriageMetricRow[]
+  byPromptVersion: AITriageMetricRow[]
+  byCWE: AITriageMetricRow[]
+  byProject: AITriageMetricRow[]
+  alerts: Array<{ projectId: string; projectName: string; alert: AITriageAlert }>
+}
+
 export type ScanMode = 'full' | 'vulnerabilities' | 'licenses'
 
 export interface ImportedSBOMMetadata {

--- a/web/src/pages/AITriageObservability.test.tsx
+++ b/web/src/pages/AITriageObservability.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../lib/api'
+import type { AITriageObservability as Observability } from '../lib/types'
+import { AITriageObservability } from './AITriageObservability'
+
+vi.mock('../lib/api', () => ({
+  ApiError: class ApiError extends Error { constructor(public status: number, message: string) { super(message) } },
+  api: { aiTriageObservability: vi.fn() },
+}))
+
+const row = {
+  value: 'all', requestCount: 4, averageLatencyMillis: 25, timeoutCount: 0, parseFailureCount: 1,
+  providerFailureCount: 0, circuitOpenCount: 0, totalTokens: 1200, estimatedCostMicroUSD: 2500,
+  comparisons: 2, disagreements: 1, gateExemptions: 1, findings: 4,
+}
+
+const dashboard: Observability = {
+  generatedAt: '2026-08-12T00:00:00Z', totals: row,
+  byModel: [{ ...row, value: 'provider/model (proposer)' }],
+  byPromptVersion: [{ ...row, value: 'fp-triage-v2' }],
+  byCWE: [{ ...row, value: 'CWE-89' }],
+  byProject: [{ ...row, value: 'p1 · Checkout' }],
+  alerts: [{ projectId: 'p1', projectName: 'Checkout', alert: { metric: 'parse_failure_rate', observedBasisPoints: 2500, baselineBasisPoints: 200, deviationBasisPoints: 2300, sampleSize: 4, message: 'Parse failures exceeded baseline' } }],
+}
+
+describe('AITriageObservability', () => {
+  beforeEach(() => { vi.resetAllMocks(); vi.mocked(api.aiTriageObservability).mockResolvedValue(dashboard) })
+
+  it('shows safety totals, all required dimensions, and persisted alerts', async () => {
+    render(<AITriageObservability />)
+    expect(await screen.findByText('AI triage observability')).toBeInTheDocument()
+    expect(screen.getByText('50.0%')).toBeInTheDocument()
+    expect(screen.getByText('provider/model (proposer)')).toBeInTheDocument()
+    expect(screen.getByText('fp-triage-v2')).toBeInTheDocument()
+    expect(screen.getByText('CWE-89')).toBeInTheDocument()
+    expect(screen.getByText('p1 · Checkout')).toBeInTheDocument()
+    expect(screen.getByText('Parse failures exceeded baseline')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/AITriageObservability.tsx
+++ b/web/src/pages/AITriageObservability.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+import { Activity, AlertTriangle, Coins, Gauge, RefreshCw } from 'lucide-react'
+import { Button, Card, EmptyState, ErrorState, Spinner } from '../components/ui'
+import { api, ApiError } from '../lib/api'
+import type { AITriageMetricRow, AITriageObservability as Observability } from '../lib/types'
+
+export function AITriageObservability() {
+  const [data, setData] = useState<Observability | null>(null)
+  const [error, setError] = useState('')
+  const [refresh, setRefresh] = useState(0)
+
+  useEffect(() => {
+    let active = true
+    setData(null); setError('')
+    api.aiTriageObservability()
+      .then((value) => { if (active) setData(value) })
+      .catch((e) => { if (active) setError(e instanceof ApiError ? e.message : 'Failed to load AI triage observability') })
+    return () => { active = false }
+  }, [refresh])
+
+  return <div className="space-y-5">
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div><h1 className="text-3xl font-bold tracking-tight">AI triage observability</h1><p className="mt-1 text-sm text-mutedfg">Evidence-sealed safety, reliability, token and cost signals from each project's latest scan.</p></div>
+      <Button variant="secondary" onClick={() => setRefresh((value) => value + 1)}><RefreshCw className="size-4" />Refresh</Button>
+    </div>
+    {error ? <ErrorState message={error} /> : data === null ? <Spinner label="Loading AI triage metrics…" /> : <Dashboard data={data} />}
+  </div>
+}
+
+function Dashboard({ data }: { data: Observability }) {
+  if (data.totals.requestCount === 0 && data.totals.findings === 0) return <EmptyState icon={Activity} title="No AI triage telemetry yet" hint="Metrics appear after an AI-triaged scan completes." />
+  const disagreementRate = rate(data.totals.disagreements, data.totals.comparisons)
+  const exemptionRate = rate(data.totals.gateExemptions, data.totals.findings)
+  return <>
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <Metric icon={Activity} label="Provider requests" value={data.totals.requestCount.toLocaleString()} hint={`${data.totals.averageLatencyMillis.toLocaleString()} ms average`} />
+      <Metric icon={Gauge} label="Disagreement rate" value={disagreementRate} hint={`${data.totals.comparisons} verified comparisons`} />
+      <Metric icon={AlertTriangle} label="Gate exemption rate" value={exemptionRate} hint={`${data.totals.gateExemptions} retained findings exempted`} />
+      <Metric icon={Coins} label="Estimated cost" value={formatCost(data.totals.estimatedCostMicroUSD)} hint={`${data.totals.totalTokens.toLocaleString()} tokens`} />
+    </div>
+    {data.alerts.length > 0 && <Card title="Safety alerts"><ul className="divide-y divide-border">{data.alerts.map((item, index) => <li className="px-6 py-4" key={`${item.projectId}-${item.alert.metric}-${index}`}><div className="flex gap-3"><AlertTriangle className="mt-0.5 size-4 shrink-0 text-high" /><div><div className="text-sm font-medium">{item.projectName || item.projectId}</div><p className="mt-1 text-sm text-mutedfg">{item.alert.message}</p></div></div></li>)}</ul></Card>}
+    <MetricTable title="By model" rows={data.byModel} />
+    <div className="grid gap-5 xl:grid-cols-2"><MetricTable title="By prompt version" rows={data.byPromptVersion} /><MetricTable title="By CWE" rows={data.byCWE} /></div>
+    <MetricTable title="By project" rows={data.byProject} />
+  </>
+}
+
+function Metric({ icon: Icon, label, value, hint }: { icon: typeof Activity; label: string; value: string; hint: string }) {
+  return <Card bodyClass="p-5"><div className="flex items-start justify-between"><div><div className="text-xs font-medium uppercase tracking-wide text-mutedfg">{label}</div><div className="mt-2 text-2xl font-bold tabular-nums">{value}</div><div className="mt-1 text-xs text-mutedfg">{hint}</div></div><Icon className="size-5 text-brand" /></div></Card>
+}
+
+function MetricTable({ title, rows }: { title: string; rows: AITriageMetricRow[] }) {
+  return <Card title={title} bodyClass="p-0"><div className="overflow-x-auto"><table className="w-full text-left text-sm"><thead className="border-b border-border bg-elevated/40 text-xs uppercase tracking-wide text-mutedfg"><tr><th className="px-5 py-3">Dimension</th><th className="px-3 py-3 text-right">Requests</th><th className="px-3 py-3 text-right">Latency</th><th className="px-3 py-3 text-right">Failures</th><th className="px-3 py-3 text-right">Tokens</th><th className="px-3 py-3 text-right">Cost</th><th className="px-5 py-3 text-right">Exemptions</th></tr></thead><tbody className="divide-y divide-border">{rows.map((row) => <tr key={row.value}><td className="max-w-xs truncate px-5 py-3 font-medium" title={row.value}>{row.value}</td><td className="px-3 py-3 text-right tabular-nums">{row.requestCount}</td><td className="px-3 py-3 text-right tabular-nums">{row.averageLatencyMillis} ms</td><td className="px-3 py-3 text-right tabular-nums">{row.timeoutCount + row.parseFailureCount + row.providerFailureCount + row.circuitOpenCount}</td><td className="px-3 py-3 text-right tabular-nums">{row.totalTokens.toLocaleString()}</td><td className="px-3 py-3 text-right tabular-nums">{formatCost(row.estimatedCostMicroUSD)}</td><td className="px-5 py-3 text-right tabular-nums">{row.gateExemptions}</td></tr>)}</tbody></table></div></Card>
+}
+
+function rate(numerator: number, denominator: number) { return denominator > 0 ? `${(numerator * 100 / denominator).toFixed(1)}%` : '—' }
+function formatCost(microUSD: number) { return `$${(microUSD / 1_000_000).toFixed(4)}` }


### PR DESCRIPTION
## Summary

- enforce conservative per-scan token reservations and optional micro-USD cost budgets before proposer/verifier calls
- add per-role circuit breakers with advisory-only fallback while preserving the OpenAI adapter's bounded transient retry behavior
- evidence-seal request, latency, timeout, parse/provider failure, token/cost, disagreement, cache, and exemption telemetry
- add configurable baseline alerts plus a tenant-scoped API/UI dashboard by model, prompt version, CWE, and project
- document the operational controls and extend OpenAPI

## Safety contract

- budget-exhausted findings receive no partial verifier call and remain gating
- missing pricing with an enabled cost budget fails closed without contacting the provider
- provider or parse failures cannot produce verified consensus or a gate exemption
- telemetry excludes prompt text, source snippets, provider error bodies, and credentials

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `go test -race ./internal/usecase/fptriage ./internal/usecase/sca`
- `pnpm test` (298 tests)
- `pnpm typecheck`
- `pnpm build`

Closes #392
Parent: #387