### PR TITLE
docs: refresh README/features/config for the full platform + team roster

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -246,7 +246,10 @@ SYNAPSE_SANDBOX_ENABLED=false
 SYNAPSE_JUDGMENTS_ENABLED=true       # judgment lifecycle routes (verify/accept/list)
 SYNAPSE_SAST_ENABLED=true            # pattern-SAST in the scan pipeline
 SYNAPSE_REACHABILITY_ENABLED=true    # Tier-2 call-graph reachability proof (govulncheck; best-effort)
+SYNAPSE_JVM_REACHABILITY_ENABLED=true # JVM (Java/Kotlin) reachability
 # SYNAPSE_PYREACH_ENABLED=false      # Tier-1 Python import-reachability (dead-dependency → OpenVEX not_affected)
+# SYNAPSE_JSREACH_ENABLED=false      # JS/TS reachability (Tier-1 import-level)
+# SYNAPSE_JSREACH_TIER2_ENABLED=false # JS/TS symbol-level (Tier-2) reachability
 SYNAPSE_CROSSCHECK_ENABLED=true      # detection-source disagreement judgments
 SYNAPSE_SBOM_CROSSCHECK_ENABLED=true # dual-producer SBOM cross-check
 SYNAPSE_GOMODGRAPH_ENABLED=true      # transitive Go dep edges via `go mod graph`
@@ -256,6 +259,45 @@ SYNAPSE_GOMODGRAPH_ENABLED=true      # transitive Go dep edges via `go mod graph
 # SYNAPSE_TAINT_ENABLED=false          # taint CapSAST proposals – needs Judgments + the sandbox
 # SYNAPSE_TAINT_CALLGRAPH_BIN=synapse-callgraph
 # SYNAPSE_WRITEUP_DRAFTS_ENABLED=false # agent propose_writeup_draft tool – needs the agent
+
+# =============================================================================
+# Fleet & runtime (blue team) – distributed agents, coverage, eBPF detections
+# =============================================================================
+# All off by default; the fleet needs PostgreSQL + synapse-worker, and the agents
+# run on Linux hosts / Kubernetes. Agent-side detection classes are configured on
+# the agent process (synapse-agent), not here.
+# SYNAPSE_FLEET_ENABLED=false                      # fleet transport + agent-admin routes
+# SYNAPSE_FLEET_ASSETS_ENABLED=false               # fleet asset model + attack paths
+# SYNAPSE_FLEET_HOST_INGEST_ENABLED=false          # accept host-inventory from agents
+# SYNAPSE_FLEET_CLUSTER_INGEST_ENABLED=false       # accept Kubernetes inventory from cluster agents
+# SYNAPSE_FLEET_STALE_AFTER=10m                    # an agent older than this reads as stale (<=0 disables)
+# SYNAPSE_FLEET_COVERAGE_FRESHNESS_TARGET=24h      # coverage freshness SLO
+# SYNAPSE_FLEET_MIN_AGENT_VERSION=                 # reject agents below this version (empty = no floor)
+# Enrolment PKI + package signing (required to enrol/verify agents; never logged):
+# SYNAPSE_FLEET_CA_CERT=      SYNAPSE_FLEET_CA_KEY=      SYNAPSE_FLEET_CERT_TTL=
+# SYNAPSE_FLEET_SIGNER_KEY=   SYNAPSE_FLEET_CLIENT_CERT_HEADER=
+
+# =============================================================================
+# Leader election (horizontal scale) – fence scheduled work to one node
+# =============================================================================
+# Off by default (single-process). Enable when running more than one API/worker so
+# scheduled dispatch runs exactly once (fenced lease in Postgres).
+# SYNAPSE_LEADER_ENABLED=false
+# SYNAPSE_LEADER_RESOURCE=scheduler   # lease name
+# SYNAPSE_LEADER_TERM=15s             # lease term
+# SYNAPSE_LEADER_RENEW=5s             # renew interval
+
+# =============================================================================
+# DAST (authenticated crawling + first-party checks) – bounded, sandboxed
+# =============================================================================
+# Runs through the governed workflow (scope + HITL + kernel egress). Limits below
+# bound the crawler; the defaults are conservative.
+# SYNAPSE_DAST_RATE_PER_SEC=5
+# SYNAPSE_DAST_CONCURRENCY=4
+# SYNAPSE_DAST_MAX_DEPTH=8
+# SYNAPSE_DAST_MAX_PAGES=2000
+# SYNAPSE_DAST_MAX_WALL_CLOCK=30m
+# SYNAPSE_DAST_HELPER_BIN=synapse-dast-helper
 
 # =============================================================================
 # MCP server (synapse-mcp) – read + propose-only; never executes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,16 @@
 Thanks for your interest in improving Synapse! This document explains how to get set up and
 what we expect from contributions.
 
+## Maintainers & review
+
+Synapse is stewarded by its founding team. Pull requests are reviewed strictly against the
+architecture rules and safety invariants below; expect a maintainer to ask for changes until
+they hold.
+
+- **Founder:** [@nghiadaulau](https://github.com/nghiadaulau) · **Co-founder:** [@nnatuan03](https://github.com/nnatuan03)
+- **Lead maintainer:** [@pho-veteran](https://github.com/pho-veteran) — primary reviewer/merger
+- Engineers, designer, and AI-engineer contributors are credited in the [README](README.md#team--contributors).
+
 ## Getting started
 
 1. Fork the repository and create a feature branch off `main`.
@@ -47,8 +57,24 @@ Synapse is a security tool. Changes must preserve these:
 4. **Reports are templated from stored data** – deterministic, reproducible.
 5. **Evidence and audit logs are append-only** and hash-chained; a broken chain blocks the
    report.
+6. **Tenant-scoped tables carry `tenant_id` + Postgres RLS** (`synapse_enable_tenant_rls`) and are
+   reached through a `WithTenant` transaction; global reference data (e.g. `advisories`) is the
+   deliberate exception. Cross-tenant access must be rejected by the hostile harness.
 
 If a change would weaken any of these, please open an issue to discuss first.
+
+## Database migrations
+
+Migrations are numbered SQL files in `migrations/`, embedded and **auto-applied at startup via
+goose**. Two rules avoid the duplicate-version startup crash goose raises on collisions:
+
+- **Append a new numbered file — never edit or renumber a shipped migration.** Take the next
+  free number after the current maximum on `main` at PR time; if two PRs race for the same number,
+  the later one rebases and renumbers. goose keys on the leading integer, so a duplicate is a
+  hard startup panic, not a git merge conflict (the filenames differ), and a clean merge will not
+  catch it.
+- **Add a Postgres integration test** (`migration_00NN_test.go`) that calls `postgres.Migrate`,
+  so a broken or duplicate version is caught locally.
 
 ## Coding conventions
 
@@ -68,7 +94,9 @@ If a change would weaken any of these, please open an issue to discuss first.
 ## Pull requests
 
 - Keep PRs focused; describe the change and its rationale.
-- Include tests for new behavior.
+- Include tests for new behavior. Security- or execution-sensitive changes should also pass the
+  hostile harness (`TestHostileHarness` in `internal/adapter/httpapi/harness_test.go`); persistence
+  changes should include real-Postgres integration tests run with `SYNAPSE_TEST_DB_DSN` set.
 - Ensure `make build vet test typecheck` and `cd web && pnpm build` pass.
 - Use clear, conventional commit messages (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`).
 - For a user-visible change, add an entry under the `Unreleased` section of [`CHANGELOG.md`](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 ### Verify Everything. Trust Nothing.
 
-**A governed control plane for software composition analysis, recon, evidence, and reporting.**
+**A governed control plane for the whole security-assessment lifecycle — supply chain, code,
+cloud, offensive, and runtime defense.**
 
-Turn a fragmented, manual security process into a controlled, auditable workflow, with
-server-side scope enforcement, hardened tool execution, tamper-evident evidence, and
-deterministic reports.
+Turn a fragmented, manual security process into one controlled, auditable workflow: SCA, SAST,
+secret and IaC scanning, reachability, recon and governed exploitation, cloud posture, and a
+distributed blue-team agent fleet — all behind server-side scope enforcement, hardened tool
+execution, tamper-evident evidence, and deterministic reports.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-6d5bff)](LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8)](go.mod)
@@ -37,47 +39,84 @@ deterministic reports.
 
 - ✅ **Deterministic first.** Scanning, matching, and reporting are pure, reproducible Go. No model sits in the report path.
 - ✅ **Evidence you can trust.** Every artifact is hash-chained into a tamper-evident custody record. A broken chain blocks the report.
-- ✅ **One tool, four scanners.** SCA, first-party SAST, secret scanning, and IaC misconfig behind a single gate.
+- ✅ **One platform, every angle.** Supply chain, code, cloud, offensive, and runtime defense behind a single gate.
 - ✅ **Reachability aware.** A deterministic call graph decides whether a vulnerable symbol is actually reachable from your code.
-- ✅ **Detection independent.** Owns its SBOM parsers and advisory matching, and ingests OSV, GHSA, and CSAF.
+- ✅ **Detection independent.** Owns its SBOM parsers and advisory matching, and ingests OSV, GHSA, CSAF and OVAL.
+- ✅ **A detection is evidence, not an alert.** Runtime detections are attributable, hash-chained, and joined to the same asset, finding, and attack path the static pillars reason about.
 - ✅ **CI ready.** `synapse-cli` is a single static binary that gates a build and emits SARIF for code scanning.
 - ✅ **Safe by construction.** argv-only execution in a Linux sandbox, server-side scope and authorization before any tool runs, secrets never leave the server.
 
 ## What is Synapse
 
-Synapse runs the security-assessment lifecycle behind one governed control plane: software
-composition analysis, recon, evidence capture, findings, and reporting.
+Synapse runs the whole security-assessment lifecycle behind one governed control plane, across
+both point-in-time analysis (SCA, SAST, code quality, IaC) and runtime analysis (a distributed
+agent fleet, eBPF detections, response actions), over container and VM estates, with a single
+asset model, one authorization model, one hash-chained evidence chain, and one prioritized queue.
 
-It is deterministic-first. Scanning, matching, license classification, and reporting are
-pure, reproducible Go with nothing else in the path. Where automated analysis is offered it
-stays strictly bounded: a proposal is only ever proposed, a typed Go state machine validates
-and executes, scope and authorization are checked in the execution layer, secrets never leave
-the server, every artifact is hash-chained into a tamper-evident custody record, and a human
-approves anything intrusive.
+It is deterministic-first. Scanning, matching, license classification, scoring, and reporting are
+pure, reproducible Go with nothing else in the path. Where automated analysis is offered it stays
+strictly bounded: a proposal is only ever proposed, a typed Go state machine validates and
+executes, scope and authorization are checked in the execution layer, secrets never leave the
+server, every artifact is hash-chained into a tamper-evident custody record, and a human approves
+anything intrusive.
 
 ## Features
 
+**Software supply chain**
 - **SBOM generation** across many ecosystems (npm, PyPI, Maven, Gradle, Go, Cargo, RubyGems,
-  Composer, NuGet, Hex, Dart and more), with owned per-ecosystem lockfile parsers.
-- **Vulnerability detection** from a live advisory API and an offline database,
-  cross-correlated and de-duplicated, plus an owned advisory store that ingests OSV, GHSA and
-  CSAF feeds for detection independence.
-- **Risk-based prioritization**: findings are ordered by exploitability (known-exploited
-  catalog, then exploit-prediction score, then CVSS), never by raw CVSS alone.
-- **License compliance**: declared-license resolution, SPDX expression parsing, a curated
-  category and risk model, and coordinate recovery for shaded or metadata-less JARs.
-- **Reachability**: a deterministic call-graph engine decides whether a vulnerable symbol is
-  actually reachable from application code.
-- **Tamper-evident evidence**: every artifact is hash-chained. A broken chain blocks the
-  report. Audit and evidence logs are append-only.
-- **Hardened execution**: tools are shelled out via argv arrays inside a Linux sandbox with
-  egress scoping. Scope and the authorization window are enforced before any tool runs.
-- **RBAC and tenant isolation** through a single authorization chokepoint.
+  Composer, NuGet, Hex, Dart, pnpm, Poetry, yarn and more) with owned per-ecosystem lockfile parsers.
+- **Vulnerability detection** from a live advisory API and an offline database, cross-correlated
+  and de-duplicated, plus an owned advisory store that ingests OSV, GHSA, CSAF and OVAL for
+  detection independence.
+- **Risk-based prioritization** ordered by exploitability (CISA KEV, then EPSS, then CVSS), never
+  by raw CVSS alone.
+- **License compliance**: declared-license resolution, SPDX expression parsing, a curated category
+  and risk model, and coordinate recovery for shaded or metadata-less JARs.
+- **Reachability**: a deterministic call-graph engine (Go, plus JVM and JS/TS tiers) decides
+  whether a vulnerable symbol is actually reachable from application code.
+
+**Code & configuration**
+- **First-party SAST** with source-code rules across many languages, plus a taint engine over the
+  sandboxed call graph.
+- **Secret scanning** and **IaC misconfiguration** (Terraform, CloudFormation, ARM, Kubernetes,
+  Helm, Dockerfile, Compose).
+- **Code quality** rules, quality gates and profiles, and third-party **SARIF ingest** into the
+  same governance path.
+
+**Offensive**
+- **Recon** in a hardened sandbox, an **attack-path graph** over the asset inventory, **chained
+  exploitation with per-step proof**, and **adversary emulation** with expected-detection output —
+  all gated by a written offensive policy and a kill switch.
+- **DAST**: authenticated crawling and a first-party check corpus with sessions from the credential vault.
+
+**Runtime defense (blue team)**
+- A distributed **agent fleet** (host and Kubernetes cluster inventory, coverage/freshness,
+  signed packaging and updates) with certificate enrolment and fenced leadership.
+- An **eBPF detection engine**, **detections sealed as hash-chained evidence**, a **columnar
+  telemetry tier** with retention, **governed response actions** (same admission + evidence as
+  exploitation), and **purple-team coverage** measured from emulation-expected vs actually-fired.
+
+**Cloud posture (CSPM)**
+- Read-only **AWS, Azure and GCP** posture connectors behind a sandboxed helper, with vault-ref
+  credentials over an inherited FD, per-operation server-side authorization, and IaC-vs-live drift findings.
+
+**Governance & evidence**
+- **Tamper-evident evidence**: every artifact is hash-chained (RFC-3161 anchored); a broken chain
+  blocks the report. Audit and evidence logs are append-only.
+- **Hardened execution**: tools run via argv arrays inside a Linux sandbox with egress scoping;
+  scope and the authorization window are enforced before any tool runs.
+- **RBAC, tenant isolation (Postgres RLS), and separation of duties** through a single authorization chokepoint.
+- **The Judgment primitive**: every AI/analysis claim is propose → verify → confirm; gated
+  capabilities promote only on a distinct verifier's sealed verdict.
+
+**AI analysis (optional, bounded)**
+- **AI false-positive triage** grounded in deterministic evidence citations, with provider-independent
+  proposer/verifier separation of duties, budgets, circuit breakers, and observability.
+- The agent proposes; a distinct verifier or a human confirms. **No model ever sits in the report path.**
+
+**Standards & reports**
 - **Standards native**: CycloneDX and SPDX with PURL, SARIF, OpenVEX and CSAF, plus KEV and EPSS.
-- **Deterministic reports** templated from stored data, with a curated CWE to OWASP, PCI and
-  ISO compliance mapping.
-- **Bounded AI analysis** (optional): the agent proposes, a distinct verifier or a human
-  confirms. No model ever sits in the report path.
+- **Deterministic reports** templated from stored data, with a curated CWE → OWASP, PCI and ISO compliance mapping.
 
 See the full walkthrough with screenshots on the [documentation site](https://synapse.kkloudtarus.net/#screens).
 
@@ -95,9 +134,13 @@ The lasting difference is what sits around the finding:
 | SCA, license, IaC misconfig, secret scanning | Yes | Yes |
 | First-party SAST (source-code rules) | Yes | Usually no |
 | Reachability via a call graph | Yes | Rarely |
+| Offensive: attack paths, chained exploitation, emulation, DAST | Yes | No |
+| Runtime blue team: agent fleet, eBPF detections, response actions | Yes | No |
+| Detections sealed as hash-chained evidence, joined to the same asset | Yes | No |
+| Cloud posture (AWS/Azure/GCP), IaC-vs-live drift | Yes | Varies |
 | Hash-chained, tamper-evident evidence | Yes | No |
 | Server-side scope and authorization before a tool runs | Yes | No |
-| RBAC, tenant isolation, separation of duties | Yes | No |
+| RBAC, tenant isolation (RLS), separation of duties | Yes | No |
 | Deterministic, model-free report path | Yes | Varies |
 
 ## Quickstart
@@ -177,9 +220,15 @@ The exit code is 0 when no finding meets the threshold, non-zero otherwise.
 | Binary | Role |
 | --- | --- |
 | `synapse-api` | HTTP API server, the primary service |
-| `synapse-cli` | Run an SCA scan from the command line, CI-friendly |
-| `synapse-worker` | Durable job runner for recon and background jobs, lease-based |
-| `synapse-callgraph` | Sandboxed call-graph builder for reachability analysis |
+| `synapse-cli` | Run an SCA/SAST scan from the command line, CI-friendly (SARIF, `--fail-on`) |
+| `synapse-worker` | Durable job runner for recon and background jobs, lease-based, leader-gated |
+| `synapse-callgraph` | Sandboxed `go/ssa` call-graph builder for reachability and taint |
+| `synapse-ast` | Sandboxed tree-sitter AST helper for source-code analysis |
+| `synapse-cspm` | Sandboxed cloud-posture helper (AWS/Azure/GCP), read-only, FD-passed credentials |
+| `synapse-dast-helper` | Sandboxed DAST crawler/check helper |
+| `synapse-agent` | Fleet agent: host inventory and eBPF runtime detections |
+| `synapse-cluster-agent` | Fleet agent: Kubernetes workload/exposure/identity inventory |
+| `synapse-fptriage-eval` | Offline evaluation harness for AI false-positive triage |
 | `synapse-mcp` | Read-only, propose-only integration server, never executes |
 
 ## Architecture
@@ -208,30 +257,33 @@ See [`CHANGELOG.md`](CHANGELOG.md) for what has changed.
 
 Synapse is under active development. Near-term directions:
 
+- **Continuous vulnerability intelligence and risk management** ([epic #514](https://github.com/KKloudTarus/synapse-ce/issues/514)): keep the advisory corpus current, detect newly affected components without re-scanning, and recalculate risk when intelligence changes.
+- **Correlation**: one unified risk story per asset, and cross-pillar promotion rules through the judgment gate.
 - Broader ecosystem coverage: more owned lockfile parsers (Conda, R, Julia, Conan).
-- More first-party SAST rules, and additional languages.
-- More IaC checks across Terraform, Kubernetes, and CloudFormation.
+- More first-party SAST rules and reachability for more language ecosystems.
 - Richer SARIF output, including remediation in code-scanning alerts.
-- More curated, model-free compliance profiles.
-- Reachability for more language ecosystems.
-- More CI recipes and integration examples.
+- More curated, model-free compliance profiles, and more CI recipes and integration examples.
 
 Have a request? Open an issue or start a discussion. Issues tagged
 [`good first issue`](https://github.com/KKloudTarus/synapse-ce/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 and [`help wanted`](https://github.com/KKloudTarus/synapse-ce/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 are a good place to start.
 
-## Contributors
+## Team & contributors
 
-Synapse was built by its founding team.
+Synapse is built by its founding team and contributors.
 
-| | Contributor | Role |
+| | Member | Role |
 | --- | --- | --- |
-| <img src="https://github.com/nghiadaulau.png?size=80" width="46" height="46" alt="nghiadaulau"> | [**nghiadaulau**](https://github.com/nghiadaulau) | Engineer |
-| <img src="https://github.com/nnatuan03.png?size=80" width="46" height="46" alt="nnatuan03"> | [**nnatuan03**](https://github.com/nnatuan03) | Engineer |
-| <img src="https://github.com/lethanhsang188.png?size=80" width="46" height="46" alt="lethanhsang188"> | [**lethanhsang188**](https://github.com/lethanhsang188) | Engineer |
+| <img src="https://github.com/nghiadaulau.png?size=80" width="46" height="46" alt="nghiadaulau"> | [**nghiadaulau**](https://github.com/nghiadaulau) | Founder |
+| <img src="https://github.com/nnatuan03.png?size=80" width="46" height="46" alt="nnatuan03"> | [**nnatuan03**](https://github.com/nnatuan03) | Co-founder |
+| <img src="https://github.com/pho-veteran.png?size=80" width="46" height="46" alt="pho-veteran"> | [**pho-veteran**](https://github.com/pho-veteran) | Lead maintainer |
 | <img src="https://github.com/VietSory.png?size=80" width="46" height="46" alt="VietSory"> | [**VietSory**](https://github.com/VietSory) | Engineer |
+| <img src="https://github.com/lethanhsang188.png?size=80" width="46" height="46" alt="lethanhsang188"> | [**lethanhsang188**](https://github.com/lethanhsang188) | Engineer |
 | <img src="https://github.com/tuu-ngo.png?size=80" width="46" height="46" alt="tuu-ngo"> | [**tuu-ngo**](https://github.com/tuu-ngo) | Brand identity designer |
+| <img src="https://github.com/H1eu232.png?size=80" width="46" height="46" alt="H1eu232"> | [**H1eu232**](https://github.com/H1eu232) | AI engineer (contributor) |
+| <img src="https://github.com/XUanhoa04.png?size=80" width="46" height="46" alt="XUanhoa04"> | [**XUanhoa04**](https://github.com/XUanhoa04) | AI engineer (contributor) |
+| <img src="https://github.com/thx2an.png?size=80" width="46" height="46" alt="thx2an"> | [**thx2an**](https://github.com/thx2an) | AI engineer (contributor) |
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md), the
 [Code of Conduct](CODE_OF_CONDUCT.md), and report vulnerabilities per the

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -143,6 +143,42 @@ reports whether traversal was truncated; lowering a bound never produces a resul
 | `SYNAPSE_ATTACKPATH_MAX_PATHS` | `100` | Maximum retained paths per requested target or finding. Must be positive. |
 | `SYNAPSE_ATTACKPATH_WALLCLOCK` | `2s` | Wall-clock traversal budget. Must be positive. |
 
+## Reachability tiers (opt-in per language)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SYNAPSE_REACHABILITY_ENABLED` | `true` | Go Tier-2 call-graph reachability proof (best-effort). |
+| `SYNAPSE_JVM_REACHABILITY_ENABLED` | `true` | JVM (Java/Kotlin) reachability. |
+| `SYNAPSE_PYREACH_ENABLED` | `false` | Python Tier-1 import-reachability (a dead dependency becomes an OpenVEX `not_affected`). |
+| `SYNAPSE_JSREACH_ENABLED` | `false` | JS/TS Tier-1 import-level reachability. |
+| `SYNAPSE_JSREACH_TIER2_ENABLED` | `false` | JS/TS Tier-2 symbol-level reachability. |
+
+## Fleet, leader election, and DAST
+
+All off by default. The fleet needs PostgreSQL + `synapse-worker`; agents run on Linux hosts / Kubernetes. Enable leader election when running more than one API/worker so scheduled work fires once.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SYNAPSE_FLEET_ENABLED` | `false` | Fleet transport + agent-admin routes. |
+| `SYNAPSE_FLEET_ASSETS_ENABLED` | `false` | Fleet asset model + attack paths. |
+| `SYNAPSE_FLEET_HOST_INGEST_ENABLED` | `false` | Accept host-inventory from `synapse-agent`. |
+| `SYNAPSE_FLEET_CLUSTER_INGEST_ENABLED` | `false` | Accept Kubernetes inventory from `synapse-cluster-agent`. |
+| `SYNAPSE_FLEET_STALE_AFTER` | `10m` | An agent older than this reads as stale (`<=0` disables the staleness view). |
+| `SYNAPSE_FLEET_COVERAGE_FRESHNESS_TARGET` | `24h` | Coverage freshness SLO. |
+| `SYNAPSE_FLEET_MIN_AGENT_VERSION` | empty | Reject agents below this version (empty = no floor). |
+| `SYNAPSE_FLEET_CA_CERT` / `_CA_KEY` / `_CERT_TTL` | empty | Enrolment PKI for agent client certificates (never logged). |
+| `SYNAPSE_FLEET_SIGNER_KEY` | empty | Signing key for agent packages/updates (never logged). |
+| `SYNAPSE_LEADER_ENABLED` | `false` | Fence scheduled dispatch to one node via a Postgres lease. |
+| `SYNAPSE_LEADER_RESOURCE` | `scheduler` | Lease name. |
+| `SYNAPSE_LEADER_TERM` | `15s` | Lease term. |
+| `SYNAPSE_LEADER_RENEW` | `5s` | Renew interval. |
+| `SYNAPSE_DAST_RATE_PER_SEC` | `5` | DAST crawler request rate. |
+| `SYNAPSE_DAST_CONCURRENCY` | `4` | DAST crawler concurrency. |
+| `SYNAPSE_DAST_MAX_DEPTH` | `8` | Maximum crawl depth. |
+| `SYNAPSE_DAST_MAX_PAGES` | `2000` | Maximum pages crawled. |
+| `SYNAPSE_DAST_MAX_WALL_CLOCK` | `30m` | Maximum crawl wall-clock. |
+| `SYNAPSE_DAST_HELPER_BIN` | `synapse-dast-helper` | Sandboxed DAST helper binary. |
+
 ## Recon and execution sandbox (sandbox required in production)
 
 | Variable | Default | Description |

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -61,6 +61,54 @@ runs owned catalogers over it, so a shipped artifact is inventoried even without
 Every parser treats the image as untrusted input: reads are bounded, cancellable, and hardened
 against a hostile filesystem or a crafted package database.
 
+## First-party SAST and code quality
+
+Synapse ships its own source-code analysis, not just dependency scanning. First-party SAST rules
+run across many languages and feed a taint engine over the sandboxed `go/ssa` and tree-sitter call
+graphs; confirmed results emit `Kind=sast` findings. A SonarQube-style code-quality surface adds
+quality rules, quality gates and quality profiles, and hotspots. Third-party results enter the same
+governance path through **SARIF ingest**, so findings from other scanners are de-duplicated,
+prioritized, and reported alongside first-party ones.
+
+## Offensive testing (red team)
+
+Offensive capabilities are governed by a written offensive policy and a kill switch, and run only
+inside the hardened sandbox with server-side scope and authorization:
+
+- **Recon** enumerates a target's surface within the authorized scope.
+- An **attack-path graph** correlates the asset inventory into reachable exposure chains.
+- **Chained exploitation** advances step by step, each step producing its own proof; nothing
+  promotes without a distinct verifier's sealed verdict.
+- **Adversary emulation** runs benign technique variants that declare the detection each technique
+  should produce — the offensive half of the purple-team ledger.
+
+## Runtime defense (blue team)
+
+A distributed **agent fleet** extends Synapse from point-in-time analysis to runtime, over both host
+and Kubernetes estates:
+
+- **Agents** collect host inventory and Kubernetes workload/exposure/identity inventory, with
+  certificate enrolment, signed packaging and updates, per-asset coverage and freshness, and fenced
+  leadership so scheduled work runs once.
+- An **eBPF detection engine** observes process, file, network, and privilege events and evaluates a
+  first-party detection catalog. A detection is **evidence, not an alert**: it is attributable,
+  sealed into the same hash-chained evidence chain, and joined to the same asset and finding the
+  static pillars reason about.
+- A **columnar telemetry tier** retains raw events with a retention/cost model for retro-hunting.
+- **Governed response actions** (isolate host, quarantine file, stop process) run under the *same*
+  admission model as exploitation: server-side authorization, a human-approved sealed evidence
+  record, argv-only execution, a mandatory reversal, and a declared blast radius.
+- **Purple-team coverage** measures which techniques would actually be detected by joining
+  emulation-expected detections with what actually fired, and reports the gap as a first-class number.
+
+## Cloud posture (CSPM)
+
+Read-only posture connectors for **AWS, Azure, and GCP** run behind a sandboxed helper. Credentials
+are resolved by vault reference and passed to the helper out-of-band over an inherited file
+descriptor (never in argv, env, or logs), every cloud operation is authorized server-side against
+the engagement scope before it runs, and the connectors issue describe/list/get calls only. Findings
+include IaC-declared-vs-live-state drift.
+
 ## Governance: suppression, VEX, and compliance
 
 These share one rule that fits a chain-of-custody tool: acceptance is retain-and-mark, never


### PR DESCRIPTION
Brings the docs in line with what has shipped and records the current team.

- **README**: broaden the description to the full governed lifecycle; expand **Features** into pillars (supply chain, code & config, offensive, runtime blue-team fleet, CSPM, governance, bounded AI, standards); add runtime/cloud rows to the comparison; list **all 11 binaries**; roadmap now points at the continuous-vuln-intelligence epic (#514).
- **Team & contributors**: nghiadaulau (Founder), nnatuan03 (Co-founder), pho-veteran (Lead maintainer), VietSory + lethanhsang188 (Engineers), tuu-ngo (Brand identity designer), H1eu232/XUanhoa04/thx2an (AI engineers).
- **CONTRIBUTING**: Maintainers & review; a Database-migrations section (append-only numbering + migration integration test to avoid goose `duplicate version` startup crashes); the tenant/RLS invariant; harness/Postgres test expectations.
- **features.md**: add First-party SAST & code quality, Offensive (red team), Runtime defense (blue team), Cloud posture (CSPM) sections.
- **.env.example + configuration.md**: document Fleet, leader election, DAST, and JS/JVM reachability flag groups with defaults verified against `internal/platform/config/config.go`.

Docs-only; no code changed.