### PR TITLE
feat(ai-triage): curate reviewer feedback for evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The lasting difference is what sits around the finding:
 
 Grab a prebuilt binary from the [Releases page](https://github.com/KKloudTarus/synapse-ce/releases)
 (linux, macOS and Windows; amd64 and arm64) and verify it against `checksums.txt`. Each archive bundles
-all five commands.
+the packaged commands.
 
 ```bash
 # Example: linux/amd64
@@ -229,6 +229,7 @@ The exit code is 0 when no finding meets the threshold, non-zero otherwise.
 | `synapse-agent` | Fleet agent: host inventory and eBPF runtime detections |
 | `synapse-cluster-agent` | Fleet agent: Kubernetes workload/exposure/identity inventory |
 | `synapse-fptriage-eval` | Offline evaluation harness for AI false-positive triage |
+| `synapse-fptriage-curate` | Offline privacy- and label-reviewed feedback curation for AI false-positive evaluation |
 | `synapse-mcp` | Read-only, propose-only integration server, never executes |
 
 ## Architecture

--- a/cmd/synapse-fptriage-curate/main.go
+++ b/cmd/synapse-fptriage-curate/main.go
@@ -1,0 +1,153 @@
+// Command synapse-fptriage-curate converts explicitly reviewed AI-triage outcomes
+// into an offline evaluation dataset after privacy and label-quality approval.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+type reviewExport struct {
+	Reviews []aitriagereview.Review `json:"reviews"`
+}
+
+func main() {
+	reviewsPath := flag.String("reviews", "", "tenant-scoped AI-triage review-list JSON exported from the API")
+	manifestPath := flag.String("manifest", "", "offline feedback-curation manifest JSON")
+	outputPath := flag.String("output", "", "new private path for the curated evaluation dataset (required unless printing digests)")
+	printDigests := flag.Bool("print-review-digests", false, "print approval digests for the manifest without producing a dataset")
+	flag.Parse()
+
+	if err := run(*reviewsPath, *manifestPath, *outputPath, *printDigests, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "synapse-fptriage-curate: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(reviewsPath, manifestPath, outputPath string, printDigests bool, stdout io.Writer) error {
+	reviewsPath = strings.TrimSpace(reviewsPath)
+	manifestPath = strings.TrimSpace(manifestPath)
+	outputPath = strings.TrimSpace(outputPath)
+	if reviewsPath == "" || manifestPath == "" {
+		return fmt.Errorf("--reviews and --manifest are required")
+	}
+	if !printDigests && (outputPath == "" || outputPath == "-") {
+		return fmt.Errorf("--output must be a new private file path; curated source is never written to stdout")
+	}
+	if !printDigests && (sameFilePath(outputPath, reviewsPath) || sameFilePath(outputPath, manifestPath)) {
+		return fmt.Errorf("--output must differ from the review export and curation manifest")
+	}
+
+	var exported reviewExport
+	if err := readStrictJSON(reviewsPath, &exported); err != nil {
+		return fmt.Errorf("read review export: %w", err)
+	}
+	var manifest sca.AIEvaluationFeedbackManifest
+	if err := readStrictJSON(manifestPath, &manifest); err != nil {
+		return fmt.Errorf("read curation manifest: %w", err)
+	}
+
+	if printDigests {
+		digests, err := sca.AIEvaluationFeedbackReviewDigests(exported.Reviews, manifest)
+		if err != nil {
+			return err
+		}
+		return writeJSON(stdout, map[string]any{"review_digests": digests})
+	}
+
+	dataset, err := sca.CurateAIEvaluationFeedback(exported.Reviews, manifest)
+	if err != nil {
+		return err
+	}
+	return writePrivateJSONFile(outputPath, dataset)
+}
+
+// writePrivateJSONFile publishes a curated dataset without following or replacing
+// an existing path. The temporary file is created in the destination directory,
+// written with mode 0600, synced, closed, then hard-linked into place. os.Link is
+// an atomic create-only operation: an existing file, symlink, or directory causes
+// the publish to fail instead of being truncated or followed.
+func writePrivateJSONFile(path string, value any) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return fmt.Errorf("invalid curated dataset output path %q", path)
+	}
+	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create private curated dataset temporary file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	published := false
+	defer func() {
+		if !published {
+			_ = tmp.Close()
+		}
+		_ = os.Remove(tmpPath)
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		return fmt.Errorf("protect curated dataset temporary file: %w", err)
+	}
+	if err := writeJSON(tmp, value); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync curated dataset temporary file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close curated dataset temporary file: %w", err)
+	}
+	if err := os.Link(tmpPath, path); err != nil {
+		return fmt.Errorf("publish curated dataset without replacing an existing path: %w", err)
+	}
+	published = true
+	// Publication already succeeded. Temporary-link cleanup is best effort so a
+	// cleanup failure cannot be reported as a failed dataset materialization.
+	_ = os.Remove(tmpPath)
+	return nil
+}
+
+func sameFilePath(a, b string) bool {
+	aa, errA := filepath.Abs(a)
+	bb, errB := filepath.Abs(b)
+	if errA == nil && errB == nil {
+		a, b = aa, bb
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func readStrictJSON(path string, dst any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("trailing JSON content")
+	}
+	return nil
+}
+
+func writeJSON(w io.Writer, value any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(value); err != nil {
+		return fmt.Errorf("write curated feedback output: %w", err)
+	}
+	return nil
+}

--- a/cmd/synapse-fptriage-curate/main_test.go
+++ b/cmd/synapse-fptriage-curate/main_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+func curateReview() aitriagereview.Review {
+	decidedAt := time.Unix(200, 0).UTC()
+	return aitriagereview.Review{
+		ID: "r1", TenantID: "tenant-a", EngagementID: "e1", FindingID: "f1", EvidenceRef: "ev1",
+		DedupKey: "sast:key", Title: "SQL injection", Severity: shared.SeverityMedium, CWE: "CWE-89", Owner: "reviewer-a",
+		State: aitriagereview.StateAccepted, Verdict: "refuted", Driver: "sanitizer", Confidence: 91, SuspectedFP: true,
+		ProposerModel: "model-a", ProposerProvider: "openai", ProposerModelFamily: "model-a",
+		VerifierModel: "model-b", VerifierProvider: "anthropic", VerifierModelFamily: "model-b", IndependencePolicy: "provider",
+		PromptVersion: "fp-triage-v3", PolicyVersion: "fp-gate-v5", PolicyReason: "verified_consensus", Verified: true,
+		VerifierVerdict: "refuted", VerifierDriver: "sanitizer", VerifierConfidence: 90, ReviewRequired: true,
+		DecidedBy: "reviewer-a", DecisionRationale: "reviewed evidence", DecidedAt: &decidedAt,
+		CreatedAt: time.Unix(100, 0).UTC(), UpdatedAt: decidedAt, Version: 3,
+	}
+}
+
+func curateManifest(review aitriagereview.Review) sca.AIEvaluationFeedbackManifest {
+	return sca.AIEvaluationFeedbackManifest{
+		SchemaVersion:  sca.AIEvaluationFeedbackManifestSchema,
+		DatasetVersion: "feedback-v1", Provenance: "approved internal feedback", Curator: "curator-a",
+		Cases: []sca.AIEvaluationFeedbackCase{{
+			ReviewID: review.ID, Label: sca.AIEvaluationFalsePositive, Language: "go", Framework: "net/http", Kind: finding.KindSAST,
+			Title: "Curated SQL injection", File: "curated/example.go", Line: 4, Source: "package curated\n",
+		}},
+	}
+}
+
+func writeFixture(t *testing.T, path string, value any) {
+	t.Helper()
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func approveCurateManifest(t *testing.T, review aitriagereview.Review, manifest *sca.AIEvaluationFeedbackManifest) {
+	t.Helper()
+	digest, err := sca.AIEvaluationFeedbackReviewDigest(review, *manifest, manifest.Cases[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := review.DecidedAt.Add(time.Minute)
+	manifest.Cases[0].PrivacyReview = sca.AIEvaluationFeedbackApproval{
+		Reviewer: "privacy-a", Approved: true, Rationale: "approved context", ReviewedAt: at, ReviewedSHA256: digest,
+	}
+	manifest.Cases[0].LabelQualityReview = sca.AIEvaluationFeedbackApproval{
+		Reviewer: "label-a", Approved: true, Rationale: "label verified", ReviewedAt: at, ReviewedSHA256: digest,
+	}
+}
+
+func approvedCurateInputs(t *testing.T, dir string) (aitriagereview.Review, string, string) {
+	t.Helper()
+	review := curateReview()
+	manifest := curateManifest(review)
+	approveCurateManifest(t, review, &manifest)
+	reviewsPath := filepath.Join(dir, "reviews.json")
+	manifestPath := filepath.Join(dir, "manifest.json")
+	writeFixture(t, reviewsPath, reviewExport{Reviews: []aitriagereview.Review{review}})
+	writeFixture(t, manifestPath, manifest)
+	return review, reviewsPath, manifestPath
+}
+
+func TestRunPrintsDigestsThenProducesCuratedDataset(t *testing.T) {
+	dir := t.TempDir()
+	review := curateReview()
+	manifest := curateManifest(review)
+	reviewsPath := filepath.Join(dir, "reviews.json")
+	manifestPath := filepath.Join(dir, "manifest.json")
+	outputPath := filepath.Join(dir, "dataset.json")
+	writeFixture(t, reviewsPath, reviewExport{Reviews: []aitriagereview.Review{review}})
+	writeFixture(t, manifestPath, manifest)
+
+	var digestOut bytes.Buffer
+	if err := run(reviewsPath, manifestPath, "", true, &digestOut); err != nil {
+		t.Fatal(err)
+	}
+	var printed struct {
+		ReviewDigests []sca.AIEvaluationFeedbackDigest `json:"review_digests"`
+	}
+	if err := json.Unmarshal(digestOut.Bytes(), &printed); err != nil {
+		t.Fatal(err)
+	}
+	if len(printed.ReviewDigests) != 1 || printed.ReviewDigests[0].Case != 1 || printed.ReviewDigests[0].SHA256 == "" {
+		t.Fatalf("unexpected digest output: %s", digestOut.String())
+	}
+	if strings.Contains(digestOut.String(), review.ID.String()) || strings.Contains(digestOut.String(), review.TenantID.String()) || strings.Contains(digestOut.String(), "review_id") {
+		t.Fatalf("digest stdout leaked production review identity: %s", digestOut.String())
+	}
+
+	digest := printed.ReviewDigests[0].SHA256
+	at := review.DecidedAt.Add(time.Minute)
+	manifest.Cases[0].PrivacyReview = sca.AIEvaluationFeedbackApproval{
+		Reviewer: "privacy-a", Approved: true, Rationale: "approved context", ReviewedAt: at, ReviewedSHA256: digest,
+	}
+	manifest.Cases[0].LabelQualityReview = sca.AIEvaluationFeedbackApproval{
+		Reviewer: "label-a", Approved: true, Rationale: "label verified", ReviewedAt: at, ReviewedSHA256: digest,
+	}
+	writeFixture(t, manifestPath, manifest)
+
+	if err := run(reviewsPath, manifestPath, outputPath, false, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(outputPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("curated dataset mode = %o, want 600", got)
+		}
+	}
+	b, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataset, err := sca.LoadAIEvaluationDataset(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dataset.Cases) != 1 || dataset.Cases[0].Label != sca.AIEvaluationFalsePositive {
+		t.Fatalf("unexpected dataset: %+v", dataset)
+	}
+	if strings.Contains(string(b), review.ID.String()) || strings.Contains(string(b), review.EvidenceRef.String()) {
+		t.Fatalf("curated output leaked raw review linkage: %s", b)
+	}
+}
+
+func TestRunRefusesCuratedDatasetOnStdout(t *testing.T) {
+	dir := t.TempDir()
+	_, reviewsPath, manifestPath := approvedCurateInputs(t, dir)
+	var stdout bytes.Buffer
+	if err := run(reviewsPath, manifestPath, "-", false, &stdout); err == nil {
+		t.Fatal("curated production-derived source was allowed on stdout")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout received curated dataset bytes: %q", stdout.String())
+	}
+}
+
+func TestRunCuratedOutputIsCreateOnlyAndDoesNotFollowSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation commonly requires elevated Windows privileges")
+	}
+	dir := t.TempDir()
+	_, reviewsPath, manifestPath := approvedCurateInputs(t, dir)
+	victim := filepath.Join(dir, "victim.txt")
+	if err := os.WriteFile(victim, []byte("DO NOT TOUCH"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(dir, "dataset.json")
+	if err := os.Symlink(victim, outputPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(reviewsPath, manifestPath, outputPath, false, &bytes.Buffer{}); err == nil {
+		t.Fatal("curated output replaced or followed an existing symlink")
+	}
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "DO NOT TOUCH" {
+		t.Fatalf("output symlink overwrote victim: %q", got)
+	}
+	info, err := os.Lstat(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("failed publication unexpectedly replaced the output symlink")
+	}
+}
+
+func TestRunCuratedOutputDoesNotOverwriteExistingFileOrInputs(t *testing.T) {
+	dir := t.TempDir()
+	_, reviewsPath, manifestPath := approvedCurateInputs(t, dir)
+	existing := filepath.Join(dir, "existing.json")
+	if err := os.WriteFile(existing, []byte("DO NOT REPLACE"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(reviewsPath, manifestPath, existing, false, &bytes.Buffer{}); err == nil {
+		t.Fatal("curated output replaced an existing file")
+	}
+	got, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "DO NOT REPLACE" {
+		t.Fatalf("existing output was modified: %q", got)
+	}
+
+	for _, input := range []string{reviewsPath, manifestPath} {
+		before, err := os.ReadFile(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := run(reviewsPath, manifestPath, input, false, &bytes.Buffer{}); err == nil {
+			t.Fatalf("curated output was allowed to target input %q", input)
+		}
+		after, err := os.ReadFile(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(before, after) {
+			t.Fatalf("input %q was modified", input)
+		}
+	}
+}
+
+func TestRunRejectsUnknownManifestFields(t *testing.T) {
+	dir := t.TempDir()
+	review := curateReview()
+	reviewsPath := filepath.Join(dir, "reviews.json")
+	manifestPath := filepath.Join(dir, "manifest.json")
+	writeFixture(t, reviewsPath, reviewExport{Reviews: []aitriagereview.Review{review}})
+	if err := os.WriteFile(manifestPath, []byte(`{"schema_version":"synapse-ai-triage-feedback-curation-v1","unknown":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(reviewsPath, manifestPath, "", true, &bytes.Buffer{}); err == nil {
+		t.Fatal("unknown curation field was accepted")
+	}
+}

--- a/docs/guide/ai-triage-evaluation.md
+++ b/docs/guide/ai-triage-evaluation.md
@@ -5,6 +5,13 @@ an operator enables gate automation. Evaluation uses the same proposer, verifier
 threshold, human-review floors, and deterministic policy as a scan. The only policy difference is forced
 shadow mode: `would_gate_exempt` is measured, while `gate_exempt` must remain `false`.
 
+The repository includes two offline AI-triage data/evaluation commands:
+
+| Binary | Role |
+| --- | --- |
+| `synapse-fptriage-eval` | Run the versioned AI false-positive evaluation harness |
+| `synapse-fptriage-curate` | Curate human review outcomes into privacy- and label-reviewed evaluation data |
+
 ## Golden dataset
 
 The seed dataset is stored at
@@ -18,6 +25,121 @@ The seed dataset is stored at
 
 Dataset validation fails before any model call if review metadata, dimensions, context, or labels are
 missing. Do not copy production findings or source into the repository fixture.
+
+## Curate human reviewer feedback
+
+Human Accept/Reject outcomes can seed a separate evaluation dataset, but they never update production
+thresholds, prompts, models, or gate policy automatically. The feedback path is offline and pull-based:
+the existing review decision remains the source of truth, and an operator explicitly curates selected
+outcomes into an evaluation file.
+
+Export the tenant-scoped response from `GET /api/v1/ai-triage/reviews` to a local `reviews.json`. Keep this
+file outside the repository: it contains production review metadata. Prepare a local curation manifest
+using schema `synapse-ai-triage-feedback-curation-v1`. Each selected case identifies one decided review
+and supplies only the source/context intended for evaluation use:
+
+```json
+{
+  "schema_version": "synapse-ai-triage-feedback-curation-v1",
+  "dataset_version": "feedback-2026-08-12",
+  "provenance": "privacy-approved reviewer feedback batch",
+  "curator": "dataset-curator",
+  "cases": [
+    {
+      "review_id": "<review-id>",
+      "label": "false_positive",
+      "language": "go",
+      "framework": "net/http",
+      "kind": "sast",
+      "title": "Sanitized reproduction title",
+      "description": "Approved minimal reproduction",
+      "file": "curated/example.go",
+      "line": 7,
+      "source": "package curated\n",
+      "privacy_review": {
+        "reviewer": "privacy-reviewer",
+        "approved": true,
+        "rationale": "approved redacted context",
+        "reviewed_at": "2026-08-12T12:00:00Z",
+        "reviewed_sha256": "<digest>"
+      },
+      "label_quality_review": {
+        "reviewer": "label-auditor",
+        "approved": true,
+        "rationale": "label matches reviewed outcome",
+        "reviewed_at": "2026-08-12T12:05:00Z",
+        "reviewed_sha256": "<same-digest>"
+      }
+    }
+  ]
+}
+```
+
+Compute the exact digest reviewers must approve before filling the two `reviewed_sha256` fields:
+
+```bash
+go run ./cmd/synapse-fptriage-curate \
+  --reviews reviews.json \
+  --manifest feedback-curation.json \
+  --print-review-digests
+```
+
+The approval digest is fail-closed over the complete exported review snapshot, including tenant,
+engagement/finding identity, sealed evidence reference, decision actor/timestamps/version, model/provider,
+prompt, policy, finding metadata, and the decision rationale via the snapshot hash. It also binds the
+manifest header (`schema_version`, `dataset_version`, `provenance`, and `curator`) and the exact curated
+label, dimensions, title/description, file/line, adversarial flag, and source hash. Changing any of those
+values after approval invalidates both approvals.
+
+Privacy and label-quality approval are both mandatory and must be performed by distinct human reviewers.
+The label-quality reviewer must also differ from the original reviewer who made the Accept/Reject decision.
+Machine principals (`agent:`, `llm:`, `mcp:`, `system:`, `machine:`, `bot:`, and `service:` identities) are
+rejected using the same domain predicate that protects the human review lifecycle, and the original decision
+actor is revalidated as neither a machine principal nor the proposer/verifier model identity. The manifest is
+deliberately local: approval identities and rationale stay in the curation record and are not copied verbatim
+into the evaluation dataset. Reviewer names in this offline manifest are process provenance, not cryptographic
+identities; run curation only in a controlled workflow that authenticates and records the humans responsible
+for those approvals.
+
+An accepted AI false-positive recommendation may become `false_positive`; a rejected recommendation may
+become `true_positive`. A label-quality auditor may conservatively downgrade either outcome to
+`uncertain`, but cannot reverse it into the opposite label. Pending reviews, reviews without sealed
+evidence, impossible decision lifecycle metadata, contradictory labels, missing approvals, stale approval
+digests, changed manifest metadata, changed source, machine approvers, and machine/model decision actors all
+fail closed.
+
+After both approvals are recorded, materialize the evaluation dataset explicitly to a **new private file**:
+
+```bash
+go run ./cmd/synapse-fptriage-curate \
+  --reviews reviews.json \
+  --manifest feedback-curation.json \
+  --output curated-feedback.json
+```
+
+Dataset materialization intentionally refuses stdout because approved source may still be
+production-derived and terminal/CI logs are not a privacy boundary. The curator also refuses to replace
+an existing file, symlink, review export, or manifest. It writes and syncs a mode-`0600` temporary file in
+the destination directory and publishes it with an atomic create-only filesystem link, so an existing
+path is never followed or truncated. Once that link succeeds, publication is considered successful;
+cleanup of the temporary link is best effort and cannot turn a successfully published dataset into a
+reported materialization failure. Choose a fresh output path for each materialized dataset.
+
+The generated dataset uses opaque digest-derived case IDs and does not copy raw tenant IDs, review IDs,
+evidence references, decision rationale, or local provenance text into the evaluation file. It does
+contain the explicitly approved source/context, so treat it according to the approved data-handling
+policy and do not commit a production-derived dataset to the repository fixture by default. The dataset
+provenance includes a hash of the complete curation manifest so the evaluated file can be tied back to
+the reviewed local curation record.
+
+Use the resulting file only as an explicit evaluation input. Nothing in this workflow changes runtime
+behaviour:
+
+```bash
+go run ./cmd/synapse-fptriage-eval \
+  --dataset curated-feedback.json \
+  --output ai-triage-feedback-eval.json
+```
 
 ## Run an evaluation
 

--- a/internal/domain/aitriagereview/actor.go
+++ b/internal/domain/aitriagereview/actor.go
@@ -1,0 +1,25 @@
+package aitriagereview
+
+// IsMachineActor reports whether actor uses one of Synapse's reserved non-human
+// principal prefixes. Curation and other in-process consumers should use this
+// shared predicate instead of duplicating the denylist maintained by the review
+// domain.
+func IsMachineActor(actor string) bool {
+	return machineActor(actor)
+}
+
+// IsMachineOrModelActor reports whether actor is either a reserved machine
+// principal or the identity of one of the supplied models. It mirrors the
+// separation-of-duties check enforced by Review.Decide/Claim for consumers that
+// must revalidate a durable review snapshot fail closed.
+func IsMachineOrModelActor(actor string, models ...string) bool {
+	if machineActor(actor) {
+		return true
+	}
+	for _, model := range models {
+		if sameIdentity(actor, model) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/usecase/sca/fptriage_feedback.go
+++ b/internal/usecase/sca/fptriage_feedback.go
@@ -1,0 +1,387 @@
+package sca
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	AIEvaluationFeedbackManifestSchema = "synapse-ai-triage-feedback-curation-v1"
+	feedbackApprovalDigestSchema       = "synapse-ai-triage-feedback-approval-v1"
+	maxFeedbackSourceBytes             = 128 << 10
+	maxFeedbackReviewTextRunes         = 2000
+)
+
+// AIEvaluationFeedbackApproval is one human approval over the exact review outcome
+// and curated evaluation context. ReviewedSHA256 is produced by
+// AIEvaluationFeedbackReviewDigest and prevents approval reuse after edits.
+type AIEvaluationFeedbackApproval struct {
+	Reviewer       string    `json:"reviewer"`
+	Approved       bool      `json:"approved"`
+	Rationale      string    `json:"rationale"`
+	ReviewedAt     time.Time `json:"reviewed_at"`
+	ReviewedSHA256 string    `json:"reviewed_sha256"`
+}
+
+// AIEvaluationFeedbackCase selects one durable human review outcome and supplies
+// only the context explicitly approved for evaluation use. ReviewID never enters
+// the resulting dataset; the output case ID is an opaque digest-derived token.
+type AIEvaluationFeedbackCase struct {
+	ReviewID           shared.ID                    `json:"review_id"`
+	Label              AIEvaluationLabel            `json:"label"`
+	Language           string                       `json:"language"`
+	Framework          string                       `json:"framework"`
+	Kind               finding.Kind                 `json:"kind"`
+	Title              string                       `json:"title"`
+	Description        string                       `json:"description,omitempty"`
+	File               string                       `json:"file"`
+	Line               int                          `json:"line"`
+	Source             string                       `json:"source"`
+	Adversarial        bool                         `json:"adversarial,omitempty"`
+	PrivacyReview      AIEvaluationFeedbackApproval `json:"privacy_review"`
+	LabelQualityReview AIEvaluationFeedbackApproval `json:"label_quality_review"`
+}
+
+// AIEvaluationFeedbackManifest is an offline, operator-owned curation manifest.
+// It is deliberately separate from runtime triage policy and never changes model,
+// prompt, threshold, or gate settings.
+type AIEvaluationFeedbackManifest struct {
+	SchemaVersion  string                     `json:"schema_version"`
+	DatasetVersion string                     `json:"dataset_version"`
+	Provenance     string                     `json:"provenance"`
+	Curator        string                     `json:"curator"`
+	Cases          []AIEvaluationFeedbackCase `json:"cases"`
+}
+
+// AIEvaluationFeedbackDigest is safe to print for reviewers: Case maps the digest
+// to manifest order while ReviewID is retained only in-process and never serialized.
+type AIEvaluationFeedbackDigest struct {
+	Case     int       `json:"case"`
+	ReviewID shared.ID `json:"-"`
+	SHA256   string    `json:"sha256"`
+}
+
+// AIEvaluationFeedbackReviewDigests computes the exact digests that privacy and
+// label-quality reviewers must approve. It does not require approvals to exist yet.
+func AIEvaluationFeedbackReviewDigests(reviews []aitriagereview.Review, manifest AIEvaluationFeedbackManifest) ([]AIEvaluationFeedbackDigest, error) {
+	if err := validateFeedbackManifestHeader(manifest); err != nil {
+		return nil, err
+	}
+	byID, err := feedbackReviewIndex(reviews)
+	if err != nil {
+		return nil, err
+	}
+	if len(manifest.Cases) == 0 {
+		return nil, feedbackValidationf("AI feedback curation manifest has no cases")
+	}
+
+	seen := make(map[string]struct{}, len(manifest.Cases))
+	out := make([]AIEvaluationFeedbackDigest, 0, len(manifest.Cases))
+	for i, c := range manifest.Cases {
+		id := strings.TrimSpace(c.ReviewID.String())
+		if id == "" {
+			return nil, feedbackValidationf("AI feedback curation case %d has no review id", i+1)
+		}
+		if _, duplicate := seen[id]; duplicate {
+			return nil, feedbackValidationf("AI feedback curation contains a duplicate review id")
+		}
+		seen[id] = struct{}{}
+		review, ok := byID[id]
+		if !ok {
+			return nil, feedbackNotFoundf("AI feedback curation references an unknown review")
+		}
+		digest, err := AIEvaluationFeedbackReviewDigest(review, manifest, c)
+		if err != nil {
+			return nil, fmt.Errorf("AI feedback curation case %d: %w", i+1, err)
+		}
+		out = append(out, AIEvaluationFeedbackDigest{Case: i + 1, ReviewID: c.ReviewID, SHA256: digest})
+	}
+	return out, nil
+}
+
+// AIEvaluationFeedbackReviewDigest binds a human review decision to both the exact
+// review snapshot and the manifest header under which the curated context will be
+// used. Both approval steps must cite this digest.
+func AIEvaluationFeedbackReviewDigest(review aitriagereview.Review, manifest AIEvaluationFeedbackManifest, c AIEvaluationFeedbackCase) (string, error) {
+	caseDigest, err := feedbackReviewCaseDigest(review, c)
+	if err != nil {
+		return "", err
+	}
+	headerDigest, err := feedbackManifestHeaderDigest(manifest)
+	if err != nil {
+		return "", err
+	}
+	payload := struct {
+		Schema               string `json:"schema"`
+		ReviewCaseSHA256     string `json:"review_case_sha256"`
+		ManifestHeaderSHA256 string `json:"manifest_header_sha256"`
+	}{
+		Schema:               feedbackApprovalDigestSchema,
+		ReviewCaseSHA256:     caseDigest,
+		ManifestHeaderSHA256: headerDigest,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encode AI feedback approval digest: %w", err)
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:]), nil
+}
+
+// feedbackReviewCaseDigest is a stable opaque identity for one exact decided review
+// plus its curated non-approval fields. The complete JSON review snapshot is hashed
+// so future or currently-unused review metadata cannot be silently rebound after an
+// approval. Approval objects are intentionally excluded to avoid a circular digest.
+func feedbackReviewCaseDigest(review aitriagereview.Review, c AIEvaluationFeedbackCase) (string, error) {
+	if err := validateFeedbackReview(review); err != nil {
+		return "", err
+	}
+	if c.ReviewID != review.ID {
+		return "", feedbackValidationf("curation review id does not match review snapshot")
+	}
+	if !feedbackLabelMatchesDecision(review.State, c.Label) {
+		return "", feedbackValidationf("curated feedback label contradicts the human review outcome")
+	}
+	if c.Kind != finding.KindSAST && c.Kind != finding.KindMisconfig {
+		return "", feedbackValidationf("curated feedback kind %q is not AI-triage evaluable", c.Kind)
+	}
+	if strings.TrimSpace(c.Language) == "" || strings.TrimSpace(c.Framework) == "" ||
+		strings.TrimSpace(c.Title) == "" || strings.TrimSpace(c.File) == "" || c.Line < 1 || strings.TrimSpace(c.Source) == "" {
+		return "", feedbackValidationf("curated feedback requires language, framework, title, file, line, and source")
+	}
+	if len([]byte(c.Source)) > maxFeedbackSourceBytes {
+		return "", feedbackValidationf("curated feedback source exceeds %d bytes", maxFeedbackSourceBytes)
+	}
+
+	reviewBytes, err := json.Marshal(review)
+	if err != nil {
+		return "", fmt.Errorf("encode AI feedback review snapshot: %w", err)
+	}
+	reviewHash := sha256.Sum256(reviewBytes)
+	sourceHash := sha256.Sum256([]byte(c.Source))
+	payload := struct {
+		ReviewSnapshotHash string            `json:"review_snapshot_sha256"`
+		Label              AIEvaluationLabel `json:"label"`
+		Language           string            `json:"language"`
+		Framework          string            `json:"framework"`
+		Kind               finding.Kind      `json:"kind"`
+		Title              string            `json:"title"`
+		Description        string            `json:"description"`
+		File               string            `json:"file"`
+		Line               int               `json:"line"`
+		SourceHash         string            `json:"source_sha256"`
+		Adversarial        bool              `json:"adversarial"`
+	}{
+		ReviewSnapshotHash: hex.EncodeToString(reviewHash[:]),
+		Label:              c.Label,
+		Language:           strings.TrimSpace(c.Language),
+		Framework:          strings.TrimSpace(c.Framework),
+		Kind:               c.Kind,
+		Title:              strings.TrimSpace(c.Title),
+		Description:        strings.TrimSpace(c.Description),
+		File:               strings.TrimSpace(c.File),
+		Line:               c.Line,
+		SourceHash:         hex.EncodeToString(sourceHash[:]),
+		Adversarial:        c.Adversarial,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encode AI feedback review case digest: %w", err)
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:]), nil
+}
+
+func feedbackManifestHeaderDigest(manifest AIEvaluationFeedbackManifest) (string, error) {
+	if err := validateFeedbackManifestHeader(manifest); err != nil {
+		return "", err
+	}
+	header := struct {
+		SchemaVersion  string `json:"schema_version"`
+		DatasetVersion string `json:"dataset_version"`
+		Provenance     string `json:"provenance"`
+		Curator        string `json:"curator"`
+	}{
+		SchemaVersion:  manifest.SchemaVersion,
+		DatasetVersion: manifest.DatasetVersion,
+		Provenance:     manifest.Provenance,
+		Curator:        manifest.Curator,
+	}
+	b, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("encode AI feedback manifest header: %w", err)
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:]), nil
+}
+
+// CurateAIEvaluationFeedback converts only doubly-approved review outcomes into a
+// normal evaluation dataset. It has no runtime-policy side effects: callers receive
+// data and must explicitly pass that dataset to the existing evaluation command.
+func CurateAIEvaluationFeedback(reviews []aitriagereview.Review, manifest AIEvaluationFeedbackManifest) (AIEvaluationDataset, error) {
+	digests, err := AIEvaluationFeedbackReviewDigests(reviews, manifest)
+	if err != nil {
+		return AIEvaluationDataset{}, err
+	}
+	byID, err := feedbackReviewIndex(reviews)
+	if err != nil {
+		return AIEvaluationDataset{}, err
+	}
+
+	digestByID := make(map[string]string, len(digests))
+	for _, d := range digests {
+		digestByID[d.ReviewID.String()] = d.SHA256
+	}
+
+	cases := make([]AIEvaluationCase, 0, len(manifest.Cases))
+	for _, c := range manifest.Cases {
+		review := byID[c.ReviewID.String()]
+		digest := digestByID[c.ReviewID.String()]
+		if err := validateFeedbackApproval("privacy", c.PrivacyReview, digest, review, false); err != nil {
+			return AIEvaluationDataset{}, err
+		}
+		if err := validateFeedbackApproval("label-quality", c.LabelQualityReview, digest, review, true); err != nil {
+			return AIEvaluationDataset{}, err
+		}
+		if strings.EqualFold(strings.TrimSpace(c.PrivacyReview.Reviewer), strings.TrimSpace(c.LabelQualityReview.Reviewer)) {
+			return AIEvaluationDataset{}, feedbackValidationf("AI feedback privacy and label-quality reviewers must be distinct")
+		}
+		caseDigest, err := feedbackReviewCaseDigest(review, c)
+		if err != nil {
+			return AIEvaluationDataset{}, err
+		}
+		cases = append(cases, AIEvaluationCase{
+			ID: "review-feedback-" + caseDigest[:24], Label: c.Label,
+			Language: strings.TrimSpace(c.Language), Framework: strings.TrimSpace(c.Framework),
+			Adversarial: c.Adversarial, Kind: c.Kind, Severity: review.Severity, CWE: strings.TrimSpace(review.CWE),
+			Title: strings.TrimSpace(c.Title), Description: strings.TrimSpace(c.Description),
+			File: strings.TrimSpace(c.File), Line: c.Line, Source: c.Source,
+		})
+	}
+
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return AIEvaluationDataset{}, fmt.Errorf("encode AI feedback curation manifest: %w", err)
+	}
+	manifestHash := sha256.Sum256(manifestBytes)
+	dataset := AIEvaluationDataset{
+		SchemaVersion: "synapse-ai-triage-dataset-v1",
+		Version:       strings.TrimSpace(manifest.DatasetVersion),
+		Provenance:    "reviewer-feedback-curation; curated_feedback_sha256=" + hex.EncodeToString(manifestHash[:]),
+		Reviewer:      strings.TrimSpace(manifest.Curator),
+		Cases:         cases,
+	}
+	if err := dataset.Validate(); err != nil {
+		return AIEvaluationDataset{}, fmt.Errorf("curated AI feedback dataset: %w", err)
+	}
+	return dataset, nil
+}
+
+func validateFeedbackManifestHeader(manifest AIEvaluationFeedbackManifest) error {
+	if manifest.SchemaVersion != AIEvaluationFeedbackManifestSchema {
+		return feedbackValidationf("AI feedback curation manifest requires schema %q", AIEvaluationFeedbackManifestSchema)
+	}
+	if strings.TrimSpace(manifest.DatasetVersion) == "" || strings.TrimSpace(manifest.Provenance) == "" || strings.TrimSpace(manifest.Curator) == "" {
+		return feedbackValidationf("AI feedback curation manifest requires dataset version, provenance, and curator")
+	}
+	if len([]rune(strings.TrimSpace(manifest.Provenance))) > maxFeedbackReviewTextRunes {
+		return feedbackValidationf("AI feedback provenance exceeds %d characters", maxFeedbackReviewTextRunes)
+	}
+	return nil
+}
+
+func feedbackReviewIndex(reviews []aitriagereview.Review) (map[string]aitriagereview.Review, error) {
+	byID := make(map[string]aitriagereview.Review, len(reviews))
+	for i, review := range reviews {
+		id := strings.TrimSpace(review.ID.String())
+		if id == "" {
+			return nil, feedbackValidationf("AI feedback review export item %d has no id", i+1)
+		}
+		if _, duplicate := byID[id]; duplicate {
+			return nil, feedbackValidationf("AI feedback review export contains a duplicate review id")
+		}
+		byID[id] = review
+	}
+	return byID, nil
+}
+
+func validateFeedbackReview(review aitriagereview.Review) error {
+	if review.State != aitriagereview.StateAccepted && review.State != aitriagereview.StateRejected {
+		return feedbackValidationf("AI feedback review is not a decided accept/reject outcome")
+	}
+	if review.ID.IsZero() || review.TenantID.IsZero() || review.EngagementID.IsZero() || review.FindingID.IsZero() || review.EvidenceRef.IsZero() || review.DecidedAt == nil ||
+		strings.TrimSpace(review.DecidedBy) == "" || strings.TrimSpace(review.DecisionRationale) == "" {
+		return feedbackValidationf("AI feedback review lacks decision provenance or sealed evidence reference")
+	}
+	if aitriagereview.IsMachineOrModelActor(review.DecidedBy, review.ProposerModel, review.VerifierModel) {
+		return feedbackValidationf("AI feedback review decision must be attributed to a human reviewer")
+	}
+	if strings.TrimSpace(review.DedupKey) == "" || strings.TrimSpace(review.Title) == "" || !review.Severity.Valid() {
+		return feedbackValidationf("AI feedback review lacks a valid finding snapshot")
+	}
+	if review.CreatedAt.IsZero() || review.UpdatedAt.IsZero() || review.DecidedAt.IsZero() ||
+		review.DecidedAt.Before(review.CreatedAt) || !review.UpdatedAt.Equal(*review.DecidedAt) || review.Version < 3 {
+		return feedbackValidationf("AI feedback review has an impossible decision lifecycle")
+	}
+	if strings.TrimSpace(review.Owner) == "" || !strings.EqualFold(strings.TrimSpace(review.Owner), strings.TrimSpace(review.DecidedBy)) {
+		return feedbackValidationf("AI feedback review decision owner does not match deciding reviewer")
+	}
+	if review.GateExempt || !review.ReviewRequired {
+		return feedbackValidationf("AI feedback review is not a policy-held human-review outcome")
+	}
+	return nil
+}
+
+func feedbackLabelMatchesDecision(state aitriagereview.State, label AIEvaluationLabel) bool {
+	if label == AIEvaluationUncertain {
+		return true
+	}
+	switch state {
+	case aitriagereview.StateAccepted:
+		return label == AIEvaluationFalsePositive
+	case aitriagereview.StateRejected:
+		return label == AIEvaluationTruePositive
+	default:
+		return false
+	}
+}
+
+func validateFeedbackApproval(kind string, approval AIEvaluationFeedbackApproval, digest string, review aitriagereview.Review, requireIndependentReviewer bool) error {
+	if !approval.Approved {
+		return feedbackValidationf("AI feedback %s review is not approved", kind)
+	}
+	reviewer := strings.TrimSpace(approval.Reviewer)
+	rationale := strings.TrimSpace(approval.Rationale)
+	if reviewer == "" || approval.ReviewedAt.IsZero() || len([]rune(rationale)) < 3 || len([]rune(rationale)) > maxFeedbackReviewTextRunes {
+		return feedbackValidationf("AI feedback %s review requires reviewer, timestamp, and 3..%d character rationale", kind, maxFeedbackReviewTextRunes)
+	}
+	if aitriagereview.IsMachineOrModelActor(reviewer, review.ProposerModel, review.VerifierModel) {
+		return feedbackValidationf("AI feedback %s review must be performed by a human reviewer", kind)
+	}
+	if review.DecidedAt != nil && approval.ReviewedAt.Before(*review.DecidedAt) {
+		return feedbackValidationf("AI feedback %s review predates the human triage decision", kind)
+	}
+	if requireIndependentReviewer && strings.EqualFold(reviewer, strings.TrimSpace(review.DecidedBy)) {
+		return feedbackValidationf("AI feedback label-quality reviewer must differ from the original decision reviewer")
+	}
+	if approval.ReviewedSHA256 != digest {
+		return feedbackValidationf("AI feedback %s approval does not match current review/content digest", kind)
+	}
+	return nil
+}
+
+func feedbackValidationf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", shared.ErrValidation, fmt.Sprintf(format, args...))
+}
+
+func feedbackNotFoundf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", shared.ErrNotFound, fmt.Sprintf(format, args...))
+}

--- a/internal/usecase/sca/fptriage_feedback_sod_test.go
+++ b/internal/usecase/sca/fptriage_feedback_sod_test.go
@@ -1,0 +1,34 @@
+package sca
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAIEvaluationFeedbackRejectsBareModelIdentitiesAsApprovers(t *testing.T) {
+	review := feedbackReview(aitriagereview.StateAccepted)
+	base := feedbackManifest(feedbackCase(review, AIEvaluationFalsePositive))
+	approveFeedbackCase(t, review, &base, 0)
+
+	for _, actor := range []string{"model-a", "MODEL-B"} {
+		t.Run("privacy_"+actor, func(t *testing.T) {
+			manifest := base
+			manifest.Cases = append([]AIEvaluationFeedbackCase(nil), base.Cases...)
+			manifest.Cases[0].PrivacyReview.Reviewer = actor
+			if _, err := CurateAIEvaluationFeedback([]aitriagereview.Review{review}, manifest); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("model privacy reviewer %q must fail validation, got %v", actor, err)
+			}
+		})
+		t.Run("label_"+actor, func(t *testing.T) {
+			manifest := base
+			manifest.Cases = append([]AIEvaluationFeedbackCase(nil), base.Cases...)
+			manifest.Cases[0].LabelQualityReview.Reviewer = actor
+			if _, err := CurateAIEvaluationFeedback([]aitriagereview.Review{review}, manifest); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("model label-quality reviewer %q must fail validation, got %v", actor, err)
+			}
+		})
+	}
+}

--- a/internal/usecase/sca/fptriage_feedback_test.go
+++ b/internal/usecase/sca/fptriage_feedback_test.go
@@ -1,0 +1,287 @@
+package sca
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func feedbackReview(state aitriagereview.State) aitriagereview.Review {
+	decidedAt := time.Unix(200, 0).UTC()
+	return aitriagereview.Review{
+		ID: "review-prod-1", TenantID: "tenant-secret", EngagementID: "eng-secret", FindingID: "finding-prod-1",
+		DedupKey: "sast:private", Title: "production SQL injection", Severity: shared.SeverityMedium, CWE: "CWE-89",
+		Owner: "original-reviewer", State: state, Verdict: "refuted", Driver: "sanitizer", Confidence: 92, SuspectedFP: true,
+		ProposerModel: "model-a", ProposerProvider: "openai", ProposerModelFamily: "model-a",
+		VerifierModel: "model-b", VerifierProvider: "anthropic", VerifierModelFamily: "model-b", IndependencePolicy: "provider",
+		PromptVersion: "fp-triage-v3", Verified: true, VerifierVerdict: "refuted", VerifierDriver: "sanitizer", VerifierConfidence: 91,
+		PolicyVersion: "fp-gate-v5", PolicyReason: "verified_consensus", ReviewRequired: true,
+		EvidenceRef: "evidence-prod-1", DecidedBy: "original-reviewer", DecisionRationale: "contains production-only reasoning",
+		CreatedAt: time.Unix(100, 0).UTC(), UpdatedAt: decidedAt, DecidedAt: &decidedAt, Version: 3,
+	}
+}
+
+func feedbackCase(review aitriagereview.Review, label AIEvaluationLabel) AIEvaluationFeedbackCase {
+	return AIEvaluationFeedbackCase{
+		ReviewID: review.ID, Label: label, Language: "go", Framework: "net/http", Kind: finding.KindSAST,
+		Title: "Curated SQL injection example", Description: "Approved minimal reproduction",
+		File: "curated/sql_injection.go", Line: 7, Source: "package curated\nfunc handler() {}\n",
+	}
+}
+
+func approveFeedbackCase(t *testing.T, review aitriagereview.Review, manifest *AIEvaluationFeedbackManifest, caseIndex int) {
+	t.Helper()
+	c := &manifest.Cases[caseIndex]
+	digest, err := AIEvaluationFeedbackReviewDigest(review, *manifest, *c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := review.DecidedAt.Add(time.Minute)
+	c.PrivacyReview = AIEvaluationFeedbackApproval{
+		Reviewer: "privacy-reviewer", Approved: true, Rationale: "approved redacted context", ReviewedAt: at, ReviewedSHA256: digest,
+	}
+	c.LabelQualityReview = AIEvaluationFeedbackApproval{
+		Reviewer: "label-auditor", Approved: true, Rationale: "label matches reviewed outcome", ReviewedAt: at, ReviewedSHA256: digest,
+	}
+}
+
+func feedbackManifest(cases ...AIEvaluationFeedbackCase) AIEvaluationFeedbackManifest {
+	return AIEvaluationFeedbackManifest{
+		SchemaVersion:  AIEvaluationFeedbackManifestSchema,
+		DatasetVersion: "feedback-2026-08-12",
+		Provenance:     "privacy-approved reviewer feedback batch",
+		Curator:        "dataset-curator",
+		Cases:          cases,
+	}
+}
+
+func TestCurateAIEvaluationFeedbackProducesApprovedDatasetWithOpaqueProvenance(t *testing.T) {
+	review := feedbackReview(aitriagereview.StateAccepted)
+	manifest := feedbackManifest(feedbackCase(review, AIEvaluationFalsePositive))
+	approveFeedbackCase(t, review, &manifest, 0)
+
+	dataset, err := CurateAIEvaluationFeedback([]aitriagereview.Review{review}, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dataset.SchemaVersion != "synapse-ai-triage-dataset-v1" || dataset.Version != "feedback-2026-08-12" || dataset.Reviewer != "dataset-curator" {
+		t.Fatalf("unexpected dataset metadata: %+v", dataset)
+	}
+	if !strings.HasPrefix(dataset.Provenance, "reviewer-feedback-curation; curated_feedback_sha256=") {
+		t.Fatalf("dataset provenance is not bound to curation manifest: %q", dataset.Provenance)
+	}
+	if len(dataset.Cases) != 1 {
+		t.Fatalf("want one curated case, got %d", len(dataset.Cases))
+	}
+	got := dataset.Cases[0]
+	if !strings.HasPrefix(got.ID, "review-feedback-") || got.Label != AIEvaluationFalsePositive || got.Severity != shared.SeverityMedium || got.CWE != "CWE-89" {
+		t.Fatalf("unexpected curated case: %+v", got)
+	}
+
+	encoded, err := json.Marshal(dataset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range []string{review.ID.String(), review.EvidenceRef.String(), review.TenantID.String(), review.DecisionRationale, manifest.Provenance} {
+		if strings.Contains(string(encoded), secret) {
+			t.Fatalf("curated dataset leaked production/local curation provenance %q: %s", secret, encoded)
+		}
+	}
+}
+
+func TestCurateAIEvaluationFeedbackFailsClosedOnApprovalOrContentChanges(t *testing.T) {
+	review := feedbackReview(aitriagereview.StateAccepted)
+	base := feedbackManifest(feedbackCase(review, AIEvaluationFalsePositive))
+	approveFeedbackCase(t, review, &base, 0)
+
+	severityChanged := review
+	severityChanged.Severity = shared.SeverityLow
+	if _, err := CurateAIEvaluationFeedback([]aitriagereview.Review{severityChanged}, base); err == nil {
+		t.Fatal("review severity changed after approval without invalidating digest")
+	}
+
+	caseMutations := map[string]func(*AIEvaluationFeedbackCase){
+		"privacy not approved":        func(c *AIEvaluationFeedbackCase) { c.PrivacyReview.Approved = false },
+		"source changed after review": func(c *AIEvaluationFeedbackCase) { c.Source += "// changed\n" },
+		"label changed after review":  func(c *AIEvaluationFeedbackCase) { c.Label = AIEvaluationUncertain },
+		"label auditor is original reviewer": func(c *AIEvaluationFeedbackCase) {
+			c.LabelQualityReview.Reviewer = review.DecidedBy
+		},
+		"privacy and label auditor are same reviewer": func(c *AIEvaluationFeedbackCase) {
+			c.LabelQualityReview.Reviewer = c.PrivacyReview.Reviewer
+		},
+	}
+	for name, mutate := range caseMutations {
+		t.Run(name, func(t *testing.T) {
+			manifest := base
+			manifest.Cases = append([]AIEvaluationFeedbackCase(nil), base.Cases...)
+			mutate(&manifest.Cases[0])
+			if _, err := CurateAIEvaluationFeedback([]aitriagereview.Review{review}, manifest); err == nil {
+				t.Fatal("expected curation to fail closed")
+			}
+		})
+	}
+}
+
+func TestAIEvaluationFeedbackApprovalBindsManifestHeader(t *testing.T) {
+	review := feedbackReview(aitriagereview.StateAccepted)
+	base := feedbackManifest(feedbackCase(review, AIEvaluationFalsePositive))
+	approveFeedbackCase(t, review, &base, 0)
+
+	mutations := map[string]func(*AIEvaluationFeedbackManifest){
+		"dataset version": func(m *AIEvaluationFeedbackManifest) { m.DatasetVersion = "forged-version" },
+		"provenance":      func(m *AIEvaluationFeedbackManifest) { m.Provenance = "forged provenance after approval" },
+		"curator":         func(m *AIEvaluationFeedbackManifest) { m.Curator = "forged-curator" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			manifest := base
+			mutate(&manifest)
+			if _, err := CurateAIEvaluationFeedback([]aitriagereview.Review{review}, manifest); err == nil {
+				t.Fatal("manifest header changed after approval without invalidating digest")
+			}
+		})
+	}
+}
+
+func TestAIEvaluationFeedbackApprovalBindsCompleteReviewSnapshot(t *testing.T) {
+	review := feedbackReview(aitriagereview.StateAccepted)
+	base := feedbackManifest(feedbackCase(review, AIEvaluationFalsePositive))
+	approveFeedbackCase(t, review, &base, 0)
+
+	mutations := map[string]func(*aitriagereview.Review){
+		"tenant":         func(r *aitriagereview.Review) { r.TenantID = "different-tenant" },
+		"engagement":     func(r *aitriagereview.Review) { r.EngagementID = "different-engagement" },
+		"dedup key":      func(r *aitriagereview.Review) { r.DedupKey = "sast:forged" },
+		"policy version": func(r *aitriagereview.Review) { r.PolicyVersion = "fp-gate-forged" },
+		"proposer model": func(r *aitriagereview.Review) { r.ProposerModel = "forged-model" },
+		"verifier model": func(r *aitriagereview.Review) { r.VerifierModel = "forged-verifier" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			tampered := review
+			mutate(&tampered)
+			if _, err := CurateAIEvaluationFeedback([]aitriagereview.Review{tampered}, base); err == nil {
+				t.Fatal("review snapshot changed after approval without invalidating digest")
+			}
+		})
+	}
+}
+
+func TestAIEvaluationFeedbackLabelMustFollowHumanOutcome(t *testing.T) {
+	accepted := feedbackReview(aitriagereview.StateAccepted)
+	acceptedCase := feedbackCase(accepted, AIEvaluationTruePositive)
+	if _, err := AIEvaluationFeedbackReviewDigest(accepted, feedbackManifest(acceptedCase), acceptedCase); err == nil {
+		t.Fatal("accepted false-positive recommendation must not become a true-positive label")
+	}
+	rejected := feedbackReview(aitriagereview.StateRejected)
+	rejectedCase := feedbackCase(rejected, AIEvaluationFalsePositive)
+	if _, err := AIEvaluationFeedbackReviewDigest(rejected, feedbackManifest(rejectedCase), rejectedCase); err == nil {
+		t.Fatal("rejected false-positive recommendation must not become a false-positive label")
+	}
+	uncertainCase := feedbackCase(rejected, AIEvaluationUncertain)
+	if _, err := AIEvaluationFeedbackReviewDigest(rejected, feedbackManifest(uncertainCase), uncertainCase); err != nil {
+		t.Fatalf("label audit must be able to conservatively downgrade to uncertain: %v", err)
+	}
+}
+
+func TestAIEvaluationFeedbackRejectsPendingUnsealedOrImpossibleReviews(t *testing.T) {
+	tests := map[string]aitriagereview.Review{}
+	pending := feedbackReview(aitriagereview.StatePending)
+	tests["pending"] = pending
+	unsealed := feedbackReview(aitriagereview.StateAccepted)
+	unsealed.EvidenceRef = ""
+	tests["unsealed"] = unsealed
+	ownerless := feedbackReview(aitriagereview.StateAccepted)
+	ownerless.Owner = ""
+	tests["ownerless"] = ownerless
+	wrongOwner := feedbackReview(aitriagereview.StateAccepted)
+	wrongOwner.Owner = "somebody-else"
+	tests["owner mismatch"] = wrongOwner
+	badVersion := feedbackReview(aitriagereview.StateAccepted)
+	badVersion.Version = 2
+	tests["pre-decision version"] = badVersion
+	badTimestamp := feedbackReview(aitriagereview.StateAccepted)
+	badTimestamp.UpdatedAt = badTimestamp.UpdatedAt.Add(time.Second)
+	tests["decision timestamp mismatch"] = badTimestamp
+	missingTenant := feedbackReview(aitriagereview.StateAccepted)
+	missingTenant.TenantID = ""
+	tests["missing tenant"] = missingTenant
+
+	for name, review := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := feedbackCase(review, AIEvaluationUncertain)
+			if _, err := AIEvaluationFeedbackReviewDigest(review, feedbackManifest(c), c); err == nil {
+				t.Fatal("invalid review entered feedback curation")
+			}
+		})
+	}
+}
+
+func TestAIEvaluationFeedbackRejectsMachineApproversAndDecisionActors(t *testing.T) {
+	review := feedbackReview(aitriagereview.StateAccepted)
+	base := feedbackManifest(feedbackCase(review, AIEvaluationFalsePositive))
+	approveFeedbackCase(t, review, &base, 0)
+
+	machineActors := []string{
+		"agent:runner", "llm:model-a", "mcp:bot", "system:curator",
+		"machine:worker", "bot:triage", "service:reviewer", "  SYSTEM:CURATOR  ",
+	}
+	for _, actor := range machineActors {
+		t.Run("privacy_"+strings.TrimSpace(actor), func(t *testing.T) {
+			manifest := base
+			manifest.Cases = append([]AIEvaluationFeedbackCase(nil), base.Cases...)
+			manifest.Cases[0].PrivacyReview.Reviewer = actor
+			if _, err := CurateAIEvaluationFeedback([]aitriagereview.Review{review}, manifest); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("machine privacy reviewer %q must fail validation, got %v", actor, err)
+			}
+		})
+		t.Run("label_"+strings.TrimSpace(actor), func(t *testing.T) {
+			manifest := base
+			manifest.Cases = append([]AIEvaluationFeedbackCase(nil), base.Cases...)
+			manifest.Cases[0].LabelQualityReview.Reviewer = actor
+			if _, err := CurateAIEvaluationFeedback([]aitriagereview.Review{review}, manifest); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("machine label-quality reviewer %q must fail validation, got %v", actor, err)
+			}
+		})
+	}
+
+	for _, actor := range append(machineActors, "model-a", "MODEL-B") {
+		t.Run("decider_"+strings.TrimSpace(actor), func(t *testing.T) {
+			forged := review
+			forged.DecidedBy = actor
+			forged.Owner = actor
+			c := feedbackCase(forged, AIEvaluationFalsePositive)
+			if _, err := AIEvaluationFeedbackReviewDigest(forged, feedbackManifest(c), c); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("machine/model decision actor %q must fail validation, got %v", actor, err)
+			}
+		})
+	}
+}
+
+func TestAIEvaluationFeedbackErrorsUseDomainTaxonomyWithoutLeakingReviewIDs(t *testing.T) {
+	review := feedbackReview(aitriagereview.StateAccepted)
+	missing := feedbackCase(review, AIEvaluationFalsePositive)
+	missing.ReviewID = "review-super-secret-missing"
+	_, err := AIEvaluationFeedbackReviewDigests([]aitriagereview.Review{review}, feedbackManifest(missing))
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("unknown review must be classified not-found, got %v", err)
+	}
+	if strings.Contains(err.Error(), missing.ReviewID.String()) || strings.Contains(err.Error(), review.ID.String()) {
+		t.Fatalf("lookup error leaked raw review id: %v", err)
+	}
+
+	_, err = AIEvaluationFeedbackReviewDigests([]aitriagereview.Review{review, review}, feedbackManifest(feedbackCase(review, AIEvaluationFalsePositive)))
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("duplicate review export must be classified validation, got %v", err)
+	}
+	if strings.Contains(err.Error(), review.ID.String()) {
+		t.Fatalf("duplicate-id validation error leaked raw review id: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an offline, fail-closed reviewer-feedback curation flow for AI false-positive triage.

- Converts decided human Accept/Reject AI-triage reviews into explicit evaluation cases.
- Requires privacy and label-quality approval before reviewer feedback can be materialized as evaluation data.
- Binds approvals to the complete exported review snapshot, manifest metadata, curated dimensions, labels, and source hash.
- Maps human outcomes conservatively:
  - accepted AI false-positive recommendations may become `false_positive`;
  - rejected recommendations may become `true_positive`;
  - either may be downgraded to `uncertain`;
  - outcomes cannot be reversed into the contradictory label.
- Generates opaque digest-derived case IDs instead of copying raw review, tenant, or evidence identifiers into the dataset.
- Adds `synapse-fptriage-curate` for approval-digest generation and private dataset materialization.
- Keeps reviewer feedback strictly offline and evaluation-only; it does not automatically change thresholds, prompts, models, gate policy, or runtime behavior.
- Documents the curation workflow, privacy requirements, provenance contract, and reviewer trust boundary.

## Safety and privacy

The curation path is fail closed.

- Approval digests bind the complete review snapshot, including finding identity, tenant/engagement context, evidence reference, human decision metadata, model/provider identities, prompt/policy metadata, and rationale.
- Manifest schema/version/provenance/curator and the exact curated case content are also covered by the approval digest.
- Missing or stale approvals, modified review/source/manifest data, unsealed reviews, invalid lifecycle metadata, contradictory labels, or reviewer-role conflicts are rejected.
- Privacy and label-quality reviews must be performed by distinct reviewers.
- The label-quality reviewer must also differ from the human who made the original Accept/Reject decision.
- Production-derived curated source is never written to stdout.
- Dataset output is written through a private `0600` temporary file and published create-only, so existing files and symlinks are never followed or overwritten.
- Digest output uses opaque case ordinals and hashes rather than raw review IDs.

Reviewer identities in the offline manifest are process provenance rather than cryptographic authentication; the operating workflow remains responsible for authenticating and auditing human approvers.

## Runtime isolation

Reviewer feedback does not create an automatic production-feedback loop.

The change does not modify AI gate authorization, scan orchestration, runtime triage policy, model/prompt selection, thresholds, or the checked-in golden dataset. Curated feedback only becomes input when an operator explicitly materializes a reviewed dataset and passes it to the existing evaluation harness.

## Verification

- Reproduced five concrete integrity/privacy exploits against the pre-hardening implementation and added regression coverage for them.
- Focused reviewer-feedback and CLI tests.
- Race tests for changed packages.
- Runtime behavior seam guard.
- `go vet ./...`
- `go build ./...`
- `CGO_ENABLED=0 go build ./cmd/...`
- `go test -count=1 ./...`
- PostgreSQL 17 integration tests.
- golangci-lint v2.12.2 new-code check: 0 issues.
- Windows build, vet, and changed-package tests.
- 16/16 semantic audit mutations killed.

Closes #395