### PR TITLE
feat(ai-triage): gate candidate promotion against baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **AI-triage candidate promotion gate.** Strictly revalidates deterministic shadow reports, compares a candidate model/prompt with a baseline on the exact same reviewed dataset and policy, blocks new true-positive escapes plus overall or segment regressions, and emits stable CI evidence that still requires explicit human promotion approval.
+
 - **Evidence-cited AI false-positive triage.** Supplies bounded deterministic source/sink, data-flow, sanitizer, call-path, route/framework, and reachability metadata to the AI triage proposer/verifier before model calls. Model claims must cite current server-generated evidence-token IDs; unknown, missing, driver-incompatible, or finding-mismatched receipts fail closed. Gate authorization now uses `fp-gate-v5` and requires that closed receipt in addition to the existing severity/CWE/evidence safety floors.
 
 - **Safe AI-triage caching.** Tenant-bound API scans reuse typed proposer/verifier claims only when

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: help install tools dev build run test harness vet lint format typecheck tidy ai-triage-eval \
+.PHONY: help install tools dev build run test harness vet lint format typecheck tidy ai-triage-eval ai-triage-compare \
         docker-build docker-up docker-down clean web-dev web-build smoke
 
 GO ?= go
 IMAGE ?= synapse-api:dev
 AI_EVAL_DATASET ?= internal/usecase/sca/testdata/fptriage-golden-v1.json
 AI_EVAL_OUTPUT ?= ai-triage-eval.json
+AI_EVAL_BASELINE ?= ai-triage-baseline.json
+AI_EVAL_CANDIDATE ?= ai-triage-candidate.json
+AI_EVAL_COMPARISON ?= ai-triage-comparison.json
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
@@ -49,6 +52,9 @@ tidy: ## Tidy go.mod / go.sum
 
 ai-triage-eval: ## Evaluate FP triage against the versioned golden dataset (requires two model IDs)
 	$(GO) run ./cmd/synapse-fptriage-eval --dataset $(AI_EVAL_DATASET) --output $(AI_EVAL_OUTPUT)
+
+ai-triage-compare: ## Compare candidate and baseline AI-triage shadow reports for promotion review
+	$(GO) run ./cmd/synapse-fptriage-compare --baseline $(AI_EVAL_BASELINE) --candidate $(AI_EVAL_CANDIDATE) --output $(AI_EVAL_COMPARISON)
 
 docker-build: ## Build the API container image
 	docker build -t $(IMAGE) -f deploy/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The exit code is 0 when no finding meets the threshold, non-zero otherwise.
 | `synapse-agent` | Fleet agent: host inventory and eBPF runtime detections |
 | `synapse-cluster-agent` | Fleet agent: Kubernetes workload/exposure/identity inventory |
 | `synapse-fptriage-eval` | Offline evaluation harness for AI false-positive triage |
+| `synapse-fptriage-compare` | Deterministic candidate-vs-baseline gate for AI model/prompt promotion review |
 | `synapse-fptriage-curate` | Offline privacy- and label-reviewed feedback curation for AI false-positive evaluation |
 | `synapse-mcp` | Read-only, propose-only integration server, never executes |
 

--- a/cmd/synapse-fptriage-compare/main.go
+++ b/cmd/synapse-fptriage-compare/main.go
@@ -1,0 +1,147 @@
+// Command synapse-fptriage-compare validates and compares two deterministic AI false-positive triage
+// shadow reports. It emits promotion-review evidence but never changes a runtime model or prompt.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+var errPromotionBlocked = errors.New("candidate is blocked from promotion review")
+
+func main() {
+	defaults := sca.DefaultAIEvaluationPromotionPolicy()
+	baselinePath := flag.String("baseline", "", "baseline synapse-ai-triage-evaluation-v2 report")
+	candidatePath := flag.String("candidate", "", "candidate synapse-ai-triage-evaluation-v2 report")
+	outputPath := flag.String("output", "-", "comparison report path, or - for stdout")
+	failOnBlocked := flag.Bool("fail-on-blocked", true, "exit non-zero after writing a blocked comparison")
+	minimumPrecision := flag.Int("minimum-precision-bps", defaults.MinimumPrecisionBasisPoints, "minimum candidate precision in basis points")
+	maximumEscape := flag.Int("maximum-fn-escape-bps", defaults.MaximumFalseNegativeEscapeRateBasisPoints, "maximum candidate false-negative escape rate in basis points")
+	maximumPrecisionDrop := flag.Int("maximum-precision-drop-bps", defaults.MaximumPrecisionDropBasisPoints, "maximum precision drop versus baseline in basis points")
+	maximumRecallDrop := flag.Int("maximum-recall-drop-bps", defaults.MaximumRecallDropBasisPoints, "maximum recall drop versus baseline in basis points")
+	maximumCoverageDrop := flag.Int("maximum-coverage-drop-bps", defaults.MaximumCoverageDropBasisPoints, "maximum coverage drop versus baseline in basis points")
+	maximumVerifierCoverageDrop := flag.Int("maximum-verifier-coverage-drop-bps", defaults.MaximumVerifierCoverageDropBasisPoints, "maximum verifier-comparison coverage drop versus baseline in basis points")
+	maximumDisagreementIncrease := flag.Int("maximum-disagreement-increase-bps", defaults.MaximumDisagreementIncreaseBasisPoints, "maximum disagreement-rate increase versus baseline in basis points")
+	flag.Parse()
+
+	policy := sca.AIEvaluationPromotionPolicy{
+		MinimumPrecisionBasisPoints:               *minimumPrecision,
+		MaximumFalseNegativeEscapeRateBasisPoints: *maximumEscape,
+		MaximumPrecisionDropBasisPoints:           *maximumPrecisionDrop,
+		MaximumRecallDropBasisPoints:              *maximumRecallDrop,
+		MaximumCoverageDropBasisPoints:            *maximumCoverageDrop,
+		MaximumVerifierCoverageDropBasisPoints:    *maximumVerifierCoverageDrop,
+		MaximumDisagreementIncreaseBasisPoints:    *maximumDisagreementIncrease,
+	}
+	if err := run(*baselinePath, *candidatePath, *outputPath, policy, *failOnBlocked); err != nil {
+		fmt.Fprintf(os.Stderr, "synapse-fptriage-compare: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(baselinePath, candidatePath, outputPath string, policy sca.AIEvaluationPromotionPolicy, failOnBlocked bool) error {
+	if baselinePath == "" || candidatePath == "" {
+		return fmt.Errorf("--baseline and --candidate are required")
+	}
+	if err := validateOutputPath(outputPath, baselinePath, candidatePath); err != nil {
+		return err
+	}
+	baselineData, err := os.ReadFile(baselinePath)
+	if err != nil {
+		return fmt.Errorf("read baseline report: %w", err)
+	}
+	baseline, err := sca.LoadAIEvaluationReport(baselineData)
+	if err != nil {
+		return fmt.Errorf("load baseline report: %w", err)
+	}
+	candidateData, err := os.ReadFile(candidatePath)
+	if err != nil {
+		return fmt.Errorf("read candidate report: %w", err)
+	}
+	candidate, err := sca.LoadAIEvaluationReport(candidateData)
+	if err != nil {
+		return fmt.Errorf("load candidate report: %w", err)
+	}
+	comparison, err := sca.CompareAIEvaluationReports(baseline, candidate, policy)
+	if err != nil {
+		return err
+	}
+	if err := writeComparison(outputPath, comparison); err != nil {
+		return err
+	}
+	if comparison.Status == "blocked" && failOnBlocked {
+		return fmt.Errorf("%w (%d failure(s); comparison %s)", errPromotionBlocked, len(comparison.Failures), comparison.ComparisonID)
+	}
+	return nil
+}
+
+func validateOutputPath(outputPath string, inputPaths ...string) error {
+	if outputPath == "-" {
+		return nil
+	}
+	outputAbs, err := filepath.Abs(outputPath)
+	if err != nil {
+		return fmt.Errorf("resolve comparison output path: %w", err)
+	}
+	if info, statErr := os.Lstat(outputAbs); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("comparison output must not be a symlink")
+	}
+	outputInfo, outputStatErr := os.Stat(outputAbs)
+	for _, inputPath := range inputPaths {
+		inputAbs, err := filepath.Abs(inputPath)
+		if err != nil {
+			return fmt.Errorf("resolve evaluation input path: %w", err)
+		}
+		sameName := outputAbs == inputAbs
+		if runtime.GOOS == "windows" {
+			sameName = strings.EqualFold(outputAbs, inputAbs)
+		}
+		if sameName {
+			return fmt.Errorf("comparison output must not overwrite an evaluation input")
+		}
+		if outputStatErr == nil {
+			if inputInfo, statErr := os.Stat(inputAbs); statErr == nil && os.SameFile(outputInfo, inputInfo) {
+				return fmt.Errorf("comparison output must not alias an evaluation input")
+			}
+		}
+	}
+	return nil
+}
+
+func writeComparison(outputPath string, comparison sca.AIEvaluationComparison) error {
+	var (
+		out *os.File
+		err error
+	)
+	if outputPath == "-" {
+		out = os.Stdout
+	} else {
+		out, err = os.Create(outputPath)
+		if err != nil {
+			return fmt.Errorf("create comparison report: %w", err)
+		}
+	}
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(comparison); err != nil {
+		if out != os.Stdout {
+			_ = out.Close()
+		}
+		return fmt.Errorf("write comparison report: %w", err)
+	}
+	if out != os.Stdout {
+		if err := out.Close(); err != nil {
+			return fmt.Errorf("close comparison report (it may be incomplete): %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/synapse-fptriage-compare/main_test.go
+++ b/cmd/synapse-fptriage-compare/main_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+type comparisonFixtureTriager struct {
+	run          sca.AIEvaluationRun
+	escapeTPCase bool
+}
+
+func (t comparisonFixtureTriager) Triage(_ context.Context, candidates []finding.Finding, _ string) []ports.AICritique {
+	out := make([]ports.AICritique, 0, len(candidates))
+	for _, candidate := range candidates {
+		refuted := candidate.DedupKey == "ai-eval:fp" || (t.escapeTPCase && candidate.DedupKey == "ai-eval:tp")
+		critique := ports.AICritique{
+			DedupKey:         candidate.DedupKey,
+			ProposerProvider: agent.CanonicalProviderID(t.run.ProposerProvider), ProposerModel: t.run.ProposerModel,
+			ProposerModelFamily: agent.CanonicalModelID(t.run.ProposerModel),
+			VerifierProvider:    agent.CanonicalProviderID(t.run.VerifierProvider), VerifierModel: t.run.VerifierModel,
+			VerifierModelFamily: agent.CanonicalModelID(t.run.VerifierModel),
+			IndependencePolicy:  t.run.IndependencePolicy, PromptVersion: t.run.PromptVersion,
+		}
+		if refuted {
+			critique.Verdict, critique.Driver, critique.Confidence = "refuted", "constant_or_literal", 95
+			critique.SuspectedFP, critique.Verified = true, true
+			critique.VerifierVerdict, critique.VerifierDriver, critique.VerifierConfidence = "refuted", "constant_or_literal", 94
+		} else {
+			critique.Verdict, critique.Driver, critique.Confidence = "sound", "attacker_controlled", 96
+			critique.VerifierVerdict, critique.VerifierDriver, critique.VerifierConfidence = "sound", "attacker_controlled", 93
+		}
+		out = append(out, critique)
+	}
+	return out
+}
+
+func TestRunWritesReviewRequiredComparison(t *testing.T) {
+	baseline := comparisonFixtureReport(t, "prompt-v1", false)
+	candidate := comparisonFixtureReport(t, "prompt-v2", false)
+	baselinePath := writeFixtureReport(t, "baseline.json", baseline)
+	candidatePath := writeFixtureReport(t, "candidate.json", candidate)
+	outputPath := filepath.Join(t.TempDir(), "comparison.json")
+
+	if err := run(baselinePath, candidatePath, outputPath, sca.DefaultAIEvaluationPromotionPolicy(), true); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var comparison sca.AIEvaluationComparison
+	if err := json.Unmarshal(data, &comparison); err != nil {
+		t.Fatal(err)
+	}
+	if comparison.Status != "review_required" || !comparison.ApprovalRequired || comparison.ComparisonID == "" {
+		t.Fatalf("comparison = %+v", comparison)
+	}
+}
+
+func TestRunWritesBlockedEvidenceBeforeFailingCI(t *testing.T) {
+	baseline := comparisonFixtureReport(t, "prompt-v1", false)
+	candidate := comparisonFixtureReport(t, "prompt-v2", true)
+	baselinePath := writeFixtureReport(t, "baseline.json", baseline)
+	candidatePath := writeFixtureReport(t, "candidate.json", candidate)
+	outputPath := filepath.Join(t.TempDir(), "comparison.json")
+
+	err := run(baselinePath, candidatePath, outputPath, sca.DefaultAIEvaluationPromotionPolicy(), true)
+	if !errors.Is(err, errPromotionBlocked) {
+		t.Fatalf("blocked candidate error = %v", err)
+	}
+	data, readErr := os.ReadFile(outputPath)
+	if readErr != nil {
+		t.Fatalf("blocked comparison evidence was not written: %v", readErr)
+	}
+	var comparison sca.AIEvaluationComparison
+	if err := json.Unmarshal(data, &comparison); err != nil || comparison.Status != "blocked" || len(comparison.Failures) == 0 {
+		t.Fatalf("blocked comparison = %+v err=%v", comparison, err)
+	}
+}
+
+func TestRunNeverOverwritesInputEvidence(t *testing.T) {
+	baseline := comparisonFixtureReport(t, "prompt-v1", false)
+	candidate := comparisonFixtureReport(t, "prompt-v2", false)
+	baselinePath := writeFixtureReport(t, "baseline.json", baseline)
+	candidatePath := writeFixtureReport(t, "candidate.json", candidate)
+	before, err := os.ReadFile(baselinePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := run(baselinePath, candidatePath, baselinePath, sca.DefaultAIEvaluationPromotionPolicy(), true); err == nil {
+		t.Fatal("comparison output must not overwrite the approved baseline")
+	}
+	after, err := os.ReadFile(baselinePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("baseline changed after rejected output alias")
+	}
+}
+
+func comparisonFixtureReport(t *testing.T, prompt string, escapeTP bool) sca.AIEvaluationReport {
+	t.Helper()
+	dataset := sca.AIEvaluationDataset{
+		SchemaVersion: "synapse-ai-triage-dataset-v1", Version: "fixture-v1",
+		Provenance: "synthetic:test", Reviewer: "security-reviewer",
+		Cases: []sca.AIEvaluationCase{
+			{ID: "fp", Label: sca.AIEvaluationFalsePositive, Language: "go", Framework: "stdlib", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-89", Title: "constant query", File: "fixture/fp.go", Line: 1, Source: "package fixture\nconst query = `SELECT 1`\n"},
+			{ID: "tp", Label: sca.AIEvaluationTruePositive, Language: "go", Framework: "stdlib", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-22", Title: "unsafe path", File: "fixture/tp.go", Line: 1, Source: "package fixture\nfunc read(p string) { os.ReadFile(p) }\n"},
+		},
+	}
+	run := sca.AIEvaluationRun{
+		ProposerProvider: "provider-a", ProposerModel: "model-a",
+		VerifierProvider: "provider-b", VerifierModel: "model-b",
+		IndependencePolicy: ports.AIIndependenceProvider,
+		PromptVersion:      prompt, PolicyVersion: sca.EvaluationPolicyVersion(),
+	}
+	report, err := sca.EvaluateFPTriage(context.Background(), dataset, run, comparisonFixtureTriager{run: run, escapeTPCase: escapeTP})
+	if err != nil {
+		t.Fatalf("EvaluateFPTriage: %v", err)
+	}
+	return report
+}
+
+func writeFixtureReport(t *testing.T, name string, report sca.AIEvaluationReport) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/docs/guide/ai-triage-evaluation.md
+++ b/docs/guide/ai-triage-evaluation.md
@@ -5,11 +5,12 @@ an operator enables gate automation. Evaluation uses the same proposer, verifier
 threshold, human-review floors, and deterministic policy as a scan. The only policy difference is forced
 shadow mode: `would_gate_exempt` is measured, while `gate_exempt` must remain `false`.
 
-The repository includes two offline AI-triage data/evaluation commands:
+The repository includes three offline AI-triage data/evaluation commands:
 
 | Binary | Role |
 | --- | --- |
 | `synapse-fptriage-eval` | Run the versioned AI false-positive evaluation harness |
+| `synapse-fptriage-compare` | Compare a candidate shadow report with an approved baseline before promotion review |
 | `synapse-fptriage-curate` | Curate human review outcomes into privacy- and label-reviewed evaluation data |
 
 ## Golden dataset
@@ -194,3 +195,47 @@ cannot produce `gate_exempt`.
 
 The report is evidence for PM/Security threshold approval; it does not approve a model automatically.
 Keep `SYNAPSE_FP_TRIAGE_MODE=shadow` until the threshold and dataset are approved for canary rollout.
+
+## Compare a promotion candidate with the baseline
+
+Run the baseline and candidate through `synapse-fptriage-eval` separately, using the exact same reviewed
+dataset and deterministic gate policy. Change only the provider/model identities or prompt version being
+evaluated. Then create the comparison artifact:
+
+```bash
+go run ./cmd/synapse-fptriage-compare \
+  --baseline ai-triage-baseline.json \
+  --candidate ai-triage-candidate.json \
+  --output ai-triage-comparison.json
+```
+
+The comparator strictly decodes both reports and recomputes their metrics, breakdowns, shadow invariant,
+model/provider identity, and canonical `run_id`. It rejects reports from different dataset content,
+provenance, reviewer, gate-policy version, or independence policy. Re-spelled aliases of the same
+provider/model configuration are not treated as a new candidate.
+
+The default policy requires at least 95% candidate precision, zero false-negative escape rate, and no
+precision, recall, coverage, or verifier-disagreement regression overall or within any language, kind,
+CWE, severity, or framework segment. Verifier-comparison coverage may not drop, preventing a candidate
+from appearing healthier merely because its verifier stopped returning decisions. Thresholds are integer
+basis points and can be supplied explicitly for an approved program policy:
+
+```bash
+go run ./cmd/synapse-fptriage-compare \
+  --baseline ai-triage-baseline.json \
+  --candidate ai-triage-candidate.json \
+  --minimum-precision-bps 9500 \
+  --maximum-fn-escape-bps 0 \
+  --maximum-precision-drop-bps 0 \
+  --maximum-recall-drop-bps 0 \
+  --maximum-coverage-drop-bps 0 \
+  --maximum-verifier-coverage-drop-bps 0 \
+  --maximum-disagreement-increase-bps 0 \
+  --output ai-triage-comparison.json
+```
+
+A blocked comparison is written before the command exits non-zero, so CI retains the exact failure
+rules and case-level behavior changes. Use `--fail-on-blocked=false` only when collecting exploratory
+shadow evidence. The output path may not overwrite/alias either input or resolve through a symlink. A
+clean comparison has status `review_required`, never `promoted`: PM/Security approval, versioned rollout
+configuration, canary monitoring, and rollback remain explicit human-controlled steps.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -136,6 +136,19 @@ SYNAPSE_FP_TRIAGE_MODEL=<proposer> SYNAPSE_VERIFIER_MODEL=<verifier> \
 The evaluator always invokes the server policy in shadow mode. A report containing `gate_exempt=true` is
 rejected, so an evaluation run can never authorize a production quality gate.
 
+Before reviewing a new model or prompt for promotion, compare its shadow report with the approved
+baseline on the same dataset and policy:
+
+```bash
+go run ./cmd/synapse-fptriage-compare \
+  --baseline ai-triage-baseline.json \
+  --candidate ai-triage-candidate.json \
+  --output ai-triage-comparison.json
+```
+
+The command exits non-zero on a quality regression but writes the deterministic comparison evidence
+first. A passing result is still `review_required`; it never changes runtime AI configuration.
+
 The AI critique reads the target's own source into the prompt, so an **untrusted PR** can still try prompt
 injection through comments or strings. Distinct consensus and the human-review floor bound the risk, and
 the finding always remains in SARIF/JSON, but treat AI triage as advisory for untrusted contributor code.

--- a/internal/usecase/sca/fptriage_evaluation.go
+++ b/internal/usecase/sca/fptriage_evaluation.go
@@ -22,6 +22,9 @@ import (
 type AIEvaluationLabel string
 
 const (
+	aiEvaluationDatasetSchema = "synapse-ai-triage-dataset-v1"
+	aiEvaluationReportSchema  = "synapse-ai-triage-evaluation-v2"
+
 	AIEvaluationTruePositive  AIEvaluationLabel = "true_positive"
 	AIEvaluationFalsePositive AIEvaluationLabel = "false_positive"
 	AIEvaluationUncertain     AIEvaluationLabel = "uncertain"
@@ -121,7 +124,7 @@ type AIEvaluationReport struct {
 
 // Validate rejects incomplete or ambiguously labelled datasets before any model call is made.
 func (d AIEvaluationDataset) Validate() error {
-	if d.SchemaVersion != "synapse-ai-triage-dataset-v1" || strings.TrimSpace(d.Version) == "" ||
+	if d.SchemaVersion != aiEvaluationDatasetSchema || strings.TrimSpace(d.Version) == "" ||
 		strings.TrimSpace(d.Provenance) == "" || strings.TrimSpace(d.Reviewer) == "" {
 		return fmt.Errorf("AI evaluation dataset requires the v1 schema, version, provenance, and reviewer")
 	}
@@ -264,7 +267,7 @@ func EvaluateFPTriage(ctx context.Context, dataset AIEvaluationDataset, run AIEv
 	}
 
 	report := AIEvaluationReport{
-		SchemaVersion: "synapse-ai-triage-evaluation-v2", DatasetVersion: dataset.Version,
+		SchemaVersion: aiEvaluationReportSchema, DatasetVersion: dataset.Version,
 		DatasetSHA256: evaluationDatasetDigest(dataset),
 		Provenance:    dataset.Provenance, Reviewer: dataset.Reviewer, Run: run,
 		Breakdowns: map[string]map[string]AIEvaluationMetrics{},
@@ -368,6 +371,7 @@ func evaluationRunID(report AIEvaluationReport) string {
 	copyReport := report
 	copyReport.RunID = ""
 	// Keep results canonical even if a future caller constructs a report manually.
+	copyReport.Results = append([]AIEvaluationResult(nil), report.Results...)
 	sort.SliceStable(copyReport.Results, func(i, j int) bool { return copyReport.Results[i].CaseID < copyReport.Results[j].CaseID })
 	b, _ := json.Marshal(copyReport)
 	sum := sha256.Sum256(b)

--- a/internal/usecase/sca/fptriage_evaluation_test.go
+++ b/internal/usecase/sca/fptriage_evaluation_test.go
@@ -93,6 +93,9 @@ func TestEvaluateFPTriageGoldenDataset(t *testing.T) {
 	if report.RunID == "" || report.DatasetSHA256 == "" || report.DatasetVersion != dataset.Version || report.Run != run {
 		t.Fatalf("versioned run metadata missing: %+v", report)
 	}
+	if err := report.Validate(); err != nil {
+		t.Fatalf("generated report must pass promotion-boundary validation: %v", err)
+	}
 	m := report.Metrics
 	if m.Total != 8 || m.Covered != 8 || m.HumanFalsePositives != 2 || m.HumanTruePositives != 4 ||
 		m.ConsensusFalsePositives != 3 || m.CorrectFalsePositives != 2 || m.TruePositiveEscapes != 1 ||

--- a/internal/usecase/sca/fptriage_promotion.go
+++ b/internal/usecase/sca/fptriage_promotion.go
@@ -1,0 +1,476 @@
+package sca
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+)
+
+const aiEvaluationComparisonSchema = "synapse-ai-triage-comparison-v1"
+
+// AIEvaluationPromotionPolicy is an operator-approved, deterministic quality gate for comparing a
+// candidate shadow run with a baseline run. Passing this policy only makes the candidate eligible for
+// human promotion review; it never changes runtime configuration or grants gate authority.
+type AIEvaluationPromotionPolicy struct {
+	MinimumPrecisionBasisPoints               int `json:"minimum_precision_basis_points"`
+	MaximumFalseNegativeEscapeRateBasisPoints int `json:"maximum_false_negative_escape_rate_basis_points"`
+	MaximumPrecisionDropBasisPoints           int `json:"maximum_precision_drop_basis_points"`
+	MaximumRecallDropBasisPoints              int `json:"maximum_recall_drop_basis_points"`
+	MaximumCoverageDropBasisPoints            int `json:"maximum_coverage_drop_basis_points"`
+	MaximumVerifierCoverageDropBasisPoints    int `json:"maximum_verifier_coverage_drop_basis_points"`
+	MaximumDisagreementIncreaseBasisPoints    int `json:"maximum_disagreement_increase_basis_points"`
+}
+
+// DefaultAIEvaluationPromotionPolicy returns the conservative proposed threshold from the AI-triage
+// epic: at least 95% precision, zero true-positive escapes, and no regression versus the baseline.
+// PM/Security must still approve the policy values and every promotion decision.
+func DefaultAIEvaluationPromotionPolicy() AIEvaluationPromotionPolicy {
+	return AIEvaluationPromotionPolicy{MinimumPrecisionBasisPoints: 9500}
+}
+
+// Validate rejects ambiguous or impossible basis-point thresholds.
+func (p AIEvaluationPromotionPolicy) Validate() error {
+	values := []struct {
+		name  string
+		value int
+	}{
+		{"minimum precision", p.MinimumPrecisionBasisPoints},
+		{"maximum false-negative escape rate", p.MaximumFalseNegativeEscapeRateBasisPoints},
+		{"maximum precision drop", p.MaximumPrecisionDropBasisPoints},
+		{"maximum recall drop", p.MaximumRecallDropBasisPoints},
+		{"maximum coverage drop", p.MaximumCoverageDropBasisPoints},
+		{"maximum verifier coverage drop", p.MaximumVerifierCoverageDropBasisPoints},
+		{"maximum disagreement increase", p.MaximumDisagreementIncreaseBasisPoints},
+	}
+	for _, item := range values {
+		if item.value < 0 || item.value > 10_000 {
+			return fmt.Errorf("AI evaluation promotion policy %s must be between 0 and 10000 basis points", item.name)
+		}
+	}
+	return nil
+}
+
+// AIEvaluationMetricComparison records exact counters plus integer basis-point deltas. Integer deltas
+// avoid float-tolerance ambiguity in CI and promotion approval records.
+type AIEvaluationMetricComparison struct {
+	Baseline                            AIEvaluationMetrics `json:"baseline"`
+	Candidate                           AIEvaluationMetrics `json:"candidate"`
+	PrecisionDeltaBasisPoints           int                 `json:"precision_delta_basis_points"`
+	RecallDeltaBasisPoints              int                 `json:"recall_delta_basis_points"`
+	FalseNegativeEscapeDeltaBasisPoints int                 `json:"false_negative_escape_delta_basis_points"`
+	DisagreementDeltaBasisPoints        int                 `json:"disagreement_delta_basis_points"`
+	CoverageDeltaBasisPoints            int                 `json:"coverage_delta_basis_points"`
+	VerifierCoverageDeltaBasisPoints    int                 `json:"verifier_coverage_delta_basis_points"`
+}
+
+// AIEvaluationCaseOutcome is the source-free typed behavior exposed for one changed golden case.
+type AIEvaluationCaseOutcome struct {
+	Covered                bool   `json:"covered"`
+	ConsensusFalsePositive bool   `json:"consensus_false_positive"`
+	WouldGateExempt        bool   `json:"would_gate_exempt"`
+	Verdict                string `json:"verdict,omitempty"`
+	Driver                 string `json:"driver,omitempty"`
+	Confidence             int    `json:"confidence,omitempty"`
+	VerifierVerdict        string `json:"verifier_verdict,omitempty"`
+	VerifierDriver         string `json:"verifier_driver,omitempty"`
+	VerifierConfidence     int    `json:"verifier_confidence,omitempty"`
+}
+
+// AIEvaluationCaseChange makes model behavior changes reviewable without copying source or prompt text
+// into the comparison artifact.
+type AIEvaluationCaseChange struct {
+	CaseID    string                  `json:"case_id"`
+	Label     AIEvaluationLabel       `json:"label"`
+	Language  string                  `json:"language"`
+	CWE       string                  `json:"cwe"`
+	Baseline  AIEvaluationCaseOutcome `json:"baseline"`
+	Candidate AIEvaluationCaseOutcome `json:"candidate"`
+}
+
+// AIEvaluationPromotionFailure is a stable machine-readable reason a candidate cannot proceed to
+// human promotion review. Scope is "overall", "case", or a report breakdown dimension.
+type AIEvaluationPromotionFailure struct {
+	Rule                 string `json:"rule"`
+	Scope                string `json:"scope"`
+	Segment              string `json:"segment,omitempty"`
+	CaseID               string `json:"case_id,omitempty"`
+	BaselineBasisPoints  int    `json:"baseline_basis_points"`
+	CandidateBasisPoints int    `json:"candidate_basis_points"`
+	LimitBasisPoints     int    `json:"limit_basis_points"`
+}
+
+// AIEvaluationComparison is deterministic CI evidence for a candidate-vs-baseline decision. A clean
+// comparison has status review_required: automatic promotion is deliberately not represented.
+type AIEvaluationComparison struct {
+	SchemaVersion    string                                             `json:"schema_version"`
+	ComparisonID     string                                             `json:"comparison_id"`
+	Status           string                                             `json:"status"`
+	ApprovalRequired bool                                               `json:"approval_required"`
+	DatasetVersion   string                                             `json:"dataset_version"`
+	DatasetSHA256    string                                             `json:"dataset_sha256"`
+	Provenance       string                                             `json:"provenance"`
+	Reviewer         string                                             `json:"reviewer"`
+	BaselineRunID    string                                             `json:"baseline_run_id"`
+	CandidateRunID   string                                             `json:"candidate_run_id"`
+	BaselineRun      AIEvaluationRun                                    `json:"baseline_run"`
+	CandidateRun     AIEvaluationRun                                    `json:"candidate_run"`
+	Policy           AIEvaluationPromotionPolicy                        `json:"policy"`
+	Metrics          AIEvaluationMetricComparison                       `json:"metrics"`
+	Breakdowns       map[string]map[string]AIEvaluationMetricComparison `json:"breakdowns"`
+	CaseChanges      []AIEvaluationCaseChange                           `json:"case_changes"`
+	Failures         []AIEvaluationPromotionFailure                     `json:"failures"`
+}
+
+// LoadAIEvaluationReport strictly decodes and revalidates a report before it is used for a promotion
+// decision. Metrics, breakdowns, shadow invariants, model identity, and run ID are all recomputed.
+func LoadAIEvaluationReport(data []byte) (AIEvaluationReport, error) {
+	var report AIEvaluationReport
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&report); err != nil {
+		return report, fmt.Errorf("decode AI evaluation report: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return report, fmt.Errorf("decode AI evaluation report: trailing JSON content")
+	}
+	if err := report.Validate(); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// Validate checks that an evaluation report is internally consistent and remains a shadow-only
+// artifact. It is intentionally strict because the comparison can become promotion evidence.
+func (r AIEvaluationReport) Validate() error {
+	if r.SchemaVersion != aiEvaluationReportSchema || strings.TrimSpace(r.RunID) == "" ||
+		strings.TrimSpace(r.DatasetVersion) == "" || r.DatasetVersion != strings.TrimSpace(r.DatasetVersion) ||
+		!validEvaluationSHA256(r.DatasetSHA256) || strings.TrimSpace(r.Provenance) == "" ||
+		r.Provenance != strings.TrimSpace(r.Provenance) || strings.TrimSpace(r.Reviewer) == "" ||
+		r.Reviewer != strings.TrimSpace(r.Reviewer) || len(r.Results) == 0 {
+		return fmt.Errorf("AI evaluation report requires the v2 schema, run/dataset identity, provenance, reviewer, and results")
+	}
+	if r.Run.ProposerProvider == "" || r.Run.ProposerProvider != agent.CanonicalProviderID(r.Run.ProposerProvider) ||
+		strings.TrimSpace(r.Run.ProposerModel) == "" || r.Run.ProposerModel != strings.TrimSpace(r.Run.ProposerModel) ||
+		r.Run.VerifierProvider == "" || r.Run.VerifierProvider != agent.CanonicalProviderID(r.Run.VerifierProvider) ||
+		strings.TrimSpace(r.Run.VerifierModel) == "" || r.Run.VerifierModel != strings.TrimSpace(r.Run.VerifierModel) ||
+		strings.TrimSpace(r.Run.PromptVersion) == "" || r.Run.PromptVersion != strings.TrimSpace(r.Run.PromptVersion) ||
+		strings.TrimSpace(r.Run.PolicyVersion) == "" || r.Run.PolicyVersion != strings.TrimSpace(r.Run.PolicyVersion) ||
+		!agent.IndependentLLMs(r.Run.ProposerProvider, r.Run.ProposerModel, r.Run.VerifierProvider, r.Run.VerifierModel, string(r.Run.IndependencePolicy)) {
+		return fmt.Errorf("AI evaluation report has an incomplete or non-independent run identity")
+	}
+	seen := make(map[string]struct{}, len(r.Results))
+	for i, result := range r.Results {
+		caseID := strings.TrimSpace(result.CaseID)
+		if caseID == "" || caseID != result.CaseID {
+			return fmt.Errorf("AI evaluation report result %d has an invalid case id", i)
+		}
+		if _, exists := seen[caseID]; exists {
+			return fmt.Errorf("AI evaluation report case %q is duplicated", caseID)
+		}
+		seen[caseID] = struct{}{}
+		if result.Label != AIEvaluationTruePositive && result.Label != AIEvaluationFalsePositive && result.Label != AIEvaluationUncertain {
+			return fmt.Errorf("AI evaluation report case %q has invalid label %q", caseID, result.Label)
+		}
+		if (result.Kind != finding.KindSAST && result.Kind != finding.KindMisconfig) || !result.Severity.Valid() ||
+			strings.TrimSpace(result.Language) == "" || strings.TrimSpace(result.Framework) == "" {
+			return fmt.Errorf("AI evaluation report case %q has incomplete dimensions", caseID)
+		}
+		if result.GateExempt || result.Critique.GateExempt {
+			return fmt.Errorf("AI evaluation report case %q is not shadow-only", caseID)
+		}
+		if !result.Covered {
+			if result.ConsensusFalsePositive || result.WouldGateExempt || strings.TrimSpace(result.Critique.DedupKey) != "" {
+				return fmt.Errorf("AI evaluation report uncovered case %q contains a model decision", caseID)
+			}
+			continue
+		}
+		critique := result.Critique
+		if critique.DedupKey != "ai-eval:"+caseID || !critique.Shadow ||
+			!agent.SameModel(critique.ProposerModel, r.Run.ProposerModel) ||
+			!agent.SameModel(critique.VerifierModel, r.Run.VerifierModel) ||
+			critique.ProposerProvider != agent.CanonicalProviderID(r.Run.ProposerProvider) ||
+			critique.VerifierProvider != agent.CanonicalProviderID(r.Run.VerifierProvider) ||
+			critique.ProposerModelFamily != agent.CanonicalModelID(r.Run.ProposerModel) ||
+			critique.VerifierModelFamily != agent.CanonicalModelID(r.Run.VerifierModel) ||
+			critique.IndependencePolicy != r.Run.IndependencePolicy || critique.PromptVersion != r.Run.PromptVersion ||
+			critique.PolicyVersion != r.Run.PolicyVersion || result.ConsensusFalsePositive != hasVerifiedConsensus(critique) ||
+			result.WouldGateExempt != critique.WouldGateExempt {
+			return fmt.Errorf("AI evaluation report case %q has inconsistent model or policy metadata", caseID)
+		}
+	}
+	if want := evaluationMetrics(r.Results); !reflect.DeepEqual(r.Metrics, want) {
+		return fmt.Errorf("AI evaluation report aggregate metrics do not match its results")
+	}
+	if want := evaluationBreakdowns(r.Results); !reflect.DeepEqual(r.Breakdowns, want) {
+		return fmt.Errorf("AI evaluation report breakdowns do not match its results")
+	}
+	if want := evaluationRunID(r); r.RunID != want {
+		return fmt.Errorf("AI evaluation report run id does not match its canonical content")
+	}
+	return nil
+}
+
+// CompareAIEvaluationReports compares a candidate against the exact same golden corpus and policy.
+// It rejects apples-to-oranges inputs and returns a deterministic blocked/review_required artifact.
+func CompareAIEvaluationReports(baseline, candidate AIEvaluationReport, policy AIEvaluationPromotionPolicy) (AIEvaluationComparison, error) {
+	if err := policy.Validate(); err != nil {
+		return AIEvaluationComparison{}, err
+	}
+	if err := baseline.Validate(); err != nil {
+		return AIEvaluationComparison{}, fmt.Errorf("baseline: %w", err)
+	}
+	if err := candidate.Validate(); err != nil {
+		return AIEvaluationComparison{}, fmt.Errorf("candidate: %w", err)
+	}
+	if baseline.DatasetVersion != candidate.DatasetVersion || baseline.DatasetSHA256 != candidate.DatasetSHA256 ||
+		baseline.Provenance != candidate.Provenance || baseline.Reviewer != candidate.Reviewer {
+		return AIEvaluationComparison{}, fmt.Errorf("AI evaluation comparison requires the exact same reviewed dataset")
+	}
+	if baseline.Run.PolicyVersion != candidate.Run.PolicyVersion || baseline.Run.IndependencePolicy != candidate.Run.IndependencePolicy {
+		return AIEvaluationComparison{}, fmt.Errorf("AI evaluation comparison requires the same gate policy and independence policy")
+	}
+	if sameEvaluationConfiguration(baseline.Run, candidate.Run) {
+		return AIEvaluationComparison{}, fmt.Errorf("AI evaluation candidate must change a provider, model family, or prompt version")
+	}
+
+	baselineCases := make(map[string]AIEvaluationResult, len(baseline.Results))
+	for _, result := range baseline.Results {
+		baselineCases[result.CaseID] = result
+	}
+	for _, result := range candidate.Results {
+		before, ok := baselineCases[result.CaseID]
+		if !ok || !sameEvaluationCase(before, result) {
+			return AIEvaluationComparison{}, fmt.Errorf("AI evaluation candidate case %q does not match the baseline corpus", result.CaseID)
+		}
+		delete(baselineCases, result.CaseID)
+	}
+	if len(baselineCases) != 0 {
+		return AIEvaluationComparison{}, fmt.Errorf("AI evaluation candidate is missing baseline cases")
+	}
+
+	comparison := AIEvaluationComparison{
+		SchemaVersion: aiEvaluationComparisonSchema, Status: "review_required", ApprovalRequired: true,
+		DatasetVersion: baseline.DatasetVersion, DatasetSHA256: baseline.DatasetSHA256,
+		Provenance: baseline.Provenance, Reviewer: baseline.Reviewer,
+		BaselineRunID: baseline.RunID, CandidateRunID: candidate.RunID,
+		BaselineRun: baseline.Run, CandidateRun: candidate.Run, Policy: policy,
+		Metrics:     metricComparison(baseline.Metrics, candidate.Metrics),
+		Breakdowns:  make(map[string]map[string]AIEvaluationMetricComparison, len(baseline.Breakdowns)),
+		CaseChanges: []AIEvaluationCaseChange{}, Failures: []AIEvaluationPromotionFailure{},
+	}
+	comparison.Failures = appendOverallPromotionFailures(comparison.Failures, comparison.Metrics, policy)
+
+	dimensions := sortedKeys(baseline.Breakdowns)
+	for _, dimension := range dimensions {
+		baselineSegments := baseline.Breakdowns[dimension]
+		candidateSegments, ok := candidate.Breakdowns[dimension]
+		if !ok || len(candidateSegments) != len(baselineSegments) {
+			return AIEvaluationComparison{}, fmt.Errorf("AI evaluation candidate breakdown %q does not match the baseline", dimension)
+		}
+		comparison.Breakdowns[dimension] = make(map[string]AIEvaluationMetricComparison, len(baselineSegments))
+		for _, segment := range sortedKeys(baselineSegments) {
+			candidateMetrics, exists := candidateSegments[segment]
+			if !exists {
+				return AIEvaluationComparison{}, fmt.Errorf("AI evaluation candidate breakdown %q/%q is missing", dimension, segment)
+			}
+			metrics := metricComparison(baselineSegments[segment], candidateMetrics)
+			comparison.Breakdowns[dimension][segment] = metrics
+			comparison.Failures = appendRegressionFailures(comparison.Failures, dimension, segment, metrics, policy)
+		}
+	}
+
+	candidateByID := make(map[string]AIEvaluationResult, len(candidate.Results))
+	for _, result := range candidate.Results {
+		candidateByID[result.CaseID] = result
+	}
+	baselineIDs := make([]string, 0, len(baseline.Results))
+	for _, result := range baseline.Results {
+		baselineIDs = append(baselineIDs, result.CaseID)
+	}
+	sort.Strings(baselineIDs)
+	for _, caseID := range baselineIDs {
+		before, after := baselineResult(baseline.Results, caseID), candidateByID[caseID]
+		beforeOutcome, afterOutcome := evaluationCaseOutcome(before), evaluationCaseOutcome(after)
+		if beforeOutcome != afterOutcome {
+			comparison.CaseChanges = append(comparison.CaseChanges, AIEvaluationCaseChange{
+				CaseID: caseID, Label: before.Label, Language: before.Language, CWE: before.CWE,
+				Baseline: beforeOutcome, Candidate: afterOutcome,
+			})
+		}
+		if after.Label == AIEvaluationTruePositive && after.WouldGateExempt && !before.WouldGateExempt {
+			comparison.Failures = append(comparison.Failures, AIEvaluationPromotionFailure{
+				Rule: "new_true_positive_escape", Scope: "case", CaseID: caseID,
+				BaselineBasisPoints:  boolBasisPoints(before.WouldGateExempt),
+				CandidateBasisPoints: boolBasisPoints(after.WouldGateExempt), LimitBasisPoints: 0,
+			})
+		}
+	}
+	if len(comparison.Failures) != 0 {
+		comparison.Status = "blocked"
+	}
+	comparison.ComparisonID = evaluationComparisonID(comparison)
+	return comparison, nil
+}
+
+func appendOverallPromotionFailures(failures []AIEvaluationPromotionFailure, metrics AIEvaluationMetricComparison, policy AIEvaluationPromotionPolicy) []AIEvaluationPromotionFailure {
+	candidatePrecision := ratioToBasisPoints(metrics.Candidate.Precision)
+	if belowBasisPointMinimum(metrics.Candidate.CorrectFalsePositives, metrics.Candidate.ConsensusFalsePositives, policy.MinimumPrecisionBasisPoints) {
+		failures = append(failures, AIEvaluationPromotionFailure{Rule: "minimum_precision", Scope: "overall", BaselineBasisPoints: ratioToBasisPoints(metrics.Baseline.Precision), CandidateBasisPoints: candidatePrecision, LimitBasisPoints: policy.MinimumPrecisionBasisPoints})
+	}
+	candidateEscape := ratioToBasisPoints(metrics.Candidate.FalseNegativeEscapeRate)
+	if aboveBasisPointMaximum(metrics.Candidate.TruePositiveEscapes, metrics.Candidate.HumanTruePositives, policy.MaximumFalseNegativeEscapeRateBasisPoints) {
+		failures = append(failures, AIEvaluationPromotionFailure{Rule: "maximum_false_negative_escape_rate", Scope: "overall", BaselineBasisPoints: ratioToBasisPoints(metrics.Baseline.FalseNegativeEscapeRate), CandidateBasisPoints: candidateEscape, LimitBasisPoints: policy.MaximumFalseNegativeEscapeRateBasisPoints})
+	}
+	return appendRegressionFailures(failures, "overall", "", metrics, policy)
+}
+
+func appendRegressionFailures(failures []AIEvaluationPromotionFailure, scope, segment string, metrics AIEvaluationMetricComparison, policy AIEvaluationPromotionPolicy) []AIEvaluationPromotionFailure {
+	tests := []struct {
+		rule      string
+		baseline  int
+		candidate int
+		limit     int
+		regressed bool
+	}{
+		{"precision_regression", ratioToBasisPoints(metrics.Baseline.Precision), ratioToBasisPoints(metrics.Candidate.Precision), policy.MaximumPrecisionDropBasisPoints, basisPointDropExceeds(metrics.Baseline.CorrectFalsePositives, metrics.Baseline.ConsensusFalsePositives, metrics.Candidate.CorrectFalsePositives, metrics.Candidate.ConsensusFalsePositives, policy.MaximumPrecisionDropBasisPoints)},
+		{"recall_regression", ratioToBasisPoints(metrics.Baseline.Recall), ratioToBasisPoints(metrics.Candidate.Recall), policy.MaximumRecallDropBasisPoints, basisPointDropExceeds(metrics.Baseline.CorrectFalsePositives, metrics.Baseline.HumanFalsePositives, metrics.Candidate.CorrectFalsePositives, metrics.Candidate.HumanFalsePositives, policy.MaximumRecallDropBasisPoints)},
+		{"coverage_regression", ratioToBasisPoints(metrics.Baseline.Coverage), ratioToBasisPoints(metrics.Candidate.Coverage), policy.MaximumCoverageDropBasisPoints, basisPointDropExceeds(metrics.Baseline.Covered, metrics.Baseline.Total, metrics.Candidate.Covered, metrics.Candidate.Total, policy.MaximumCoverageDropBasisPoints)},
+		{"verifier_coverage_regression", verifierCoverageBasisPoints(metrics.Baseline), verifierCoverageBasisPoints(metrics.Candidate), policy.MaximumVerifierCoverageDropBasisPoints, basisPointDropExceeds(metrics.Baseline.VerifierComparisons, metrics.Baseline.Total, metrics.Candidate.VerifierComparisons, metrics.Candidate.Total, policy.MaximumVerifierCoverageDropBasisPoints)},
+		{"disagreement_regression", ratioToBasisPoints(metrics.Baseline.DisagreementRate), ratioToBasisPoints(metrics.Candidate.DisagreementRate), policy.MaximumDisagreementIncreaseBasisPoints, basisPointIncreaseExceeds(metrics.Baseline.VerifierDisagreements, metrics.Baseline.VerifierComparisons, metrics.Candidate.VerifierDisagreements, metrics.Candidate.VerifierComparisons, policy.MaximumDisagreementIncreaseBasisPoints)},
+	}
+	for _, test := range tests {
+		if test.regressed {
+			failures = append(failures, AIEvaluationPromotionFailure{Rule: test.rule, Scope: scope, Segment: segment, BaselineBasisPoints: test.baseline, CandidateBasisPoints: test.candidate, LimitBasisPoints: test.limit})
+		}
+	}
+	return failures
+}
+
+func metricComparison(baseline, candidate AIEvaluationMetrics) AIEvaluationMetricComparison {
+	return AIEvaluationMetricComparison{
+		Baseline: baseline, Candidate: candidate,
+		PrecisionDeltaBasisPoints:           ratioToBasisPoints(candidate.Precision) - ratioToBasisPoints(baseline.Precision),
+		RecallDeltaBasisPoints:              ratioToBasisPoints(candidate.Recall) - ratioToBasisPoints(baseline.Recall),
+		FalseNegativeEscapeDeltaBasisPoints: ratioToBasisPoints(candidate.FalseNegativeEscapeRate) - ratioToBasisPoints(baseline.FalseNegativeEscapeRate),
+		DisagreementDeltaBasisPoints:        ratioToBasisPoints(candidate.DisagreementRate) - ratioToBasisPoints(baseline.DisagreementRate),
+		CoverageDeltaBasisPoints:            ratioToBasisPoints(candidate.Coverage) - ratioToBasisPoints(baseline.Coverage),
+		VerifierCoverageDeltaBasisPoints:    verifierCoverageBasisPoints(candidate) - verifierCoverageBasisPoints(baseline),
+	}
+}
+
+func sameEvaluationConfiguration(a, b AIEvaluationRun) bool {
+	return agent.CanonicalProviderID(a.ProposerProvider) == agent.CanonicalProviderID(b.ProposerProvider) &&
+		agent.SameModel(a.ProposerModel, b.ProposerModel) &&
+		agent.CanonicalProviderID(a.VerifierProvider) == agent.CanonicalProviderID(b.VerifierProvider) &&
+		agent.SameModel(a.VerifierModel, b.VerifierModel) && a.PromptVersion == b.PromptVersion
+}
+
+func sameEvaluationCase(a, b AIEvaluationResult) bool {
+	return a.CaseID == b.CaseID && a.Label == b.Label && a.Language == b.Language &&
+		a.Framework == b.Framework && a.Kind == b.Kind && a.Severity == b.Severity &&
+		a.CWE == b.CWE && a.Adversarial == b.Adversarial
+}
+
+func evaluationCaseOutcome(result AIEvaluationResult) AIEvaluationCaseOutcome {
+	return AIEvaluationCaseOutcome{
+		Covered: result.Covered, ConsensusFalsePositive: result.ConsensusFalsePositive, WouldGateExempt: result.WouldGateExempt,
+		Verdict: result.Critique.Verdict, Driver: result.Critique.Driver, Confidence: result.Critique.Confidence,
+		VerifierVerdict: result.Critique.VerifierVerdict, VerifierDriver: result.Critique.VerifierDriver,
+		VerifierConfidence: result.Critique.VerifierConfidence,
+	}
+}
+
+func baselineResult(results []AIEvaluationResult, caseID string) AIEvaluationResult {
+	for _, result := range results {
+		if result.CaseID == caseID {
+			return result
+		}
+	}
+	return AIEvaluationResult{}
+}
+
+func ratioToBasisPoints(rate float64) int {
+	return int(math.Round(rate * 10_000))
+}
+
+func verifierCoverageBasisPoints(metrics AIEvaluationMetrics) int {
+	return ratioToBasisPoints(verifierCoverage(metrics))
+}
+
+func verifierCoverage(metrics AIEvaluationMetrics) float64 {
+	return ratio(metrics.VerifierComparisons, metrics.Total)
+}
+
+func belowBasisPointMinimum(numerator, denominator, minimum int) bool {
+	return scaledRate(numerator, denominator).Cmp(big.NewRat(int64(minimum), 1)) < 0
+}
+
+func aboveBasisPointMaximum(numerator, denominator, maximum int) bool {
+	return scaledRate(numerator, denominator).Cmp(big.NewRat(int64(maximum), 1)) > 0
+}
+
+func basisPointDropExceeds(baselineNumerator, baselineDenominator, candidateNumerator, candidateDenominator, maximum int) bool {
+	delta := new(big.Rat).Sub(exactRate(baselineNumerator, baselineDenominator), exactRate(candidateNumerator, candidateDenominator))
+	delta.Mul(delta, big.NewRat(10_000, 1))
+	return delta.Cmp(big.NewRat(int64(maximum), 1)) > 0
+}
+
+func basisPointIncreaseExceeds(baselineNumerator, baselineDenominator, candidateNumerator, candidateDenominator, maximum int) bool {
+	delta := new(big.Rat).Sub(exactRate(candidateNumerator, candidateDenominator), exactRate(baselineNumerator, baselineDenominator))
+	delta.Mul(delta, big.NewRat(10_000, 1))
+	return delta.Cmp(big.NewRat(int64(maximum), 1)) > 0
+}
+
+func scaledRate(numerator, denominator int) *big.Rat {
+	return new(big.Rat).Mul(exactRate(numerator, denominator), big.NewRat(10_000, 1))
+}
+
+func exactRate(numerator, denominator int) *big.Rat {
+	if denominator <= 0 {
+		return new(big.Rat)
+	}
+	return new(big.Rat).SetFrac64(int64(numerator), int64(denominator))
+}
+
+func boolBasisPoints(value bool) int {
+	if value {
+		return 10_000
+	}
+	return 0
+}
+
+func validEvaluationSHA256(value string) bool {
+	if len(value) != sha256.Size*2 || strings.ToLower(value) != value {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func evaluationComparisonID(comparison AIEvaluationComparison) string {
+	copyComparison := comparison
+	copyComparison.ComparisonID = ""
+	b, _ := json.Marshal(copyComparison)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/usecase/sca/fptriage_promotion_test.go
+++ b/internal/usecase/sca/fptriage_promotion_test.go
@@ -1,0 +1,294 @@
+package sca
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestCompareAIEvaluationReportsPassesOnlyToHumanReview(t *testing.T) {
+	baseline := promotionTestReport("prompt-v1", nil)
+	candidate := promotionTestReport("prompt-v2", nil)
+
+	comparison, err := CompareAIEvaluationReports(baseline, candidate, DefaultAIEvaluationPromotionPolicy())
+	if err != nil {
+		t.Fatalf("CompareAIEvaluationReports: %v", err)
+	}
+	if comparison.Status != "review_required" || !comparison.ApprovalRequired || len(comparison.Failures) != 0 {
+		t.Fatalf("a passing comparison must still require human approval: %+v", comparison)
+	}
+	if comparison.ComparisonID == "" || comparison.BaselineRunID != baseline.RunID || comparison.CandidateRunID != candidate.RunID {
+		t.Fatalf("comparison identity is incomplete: %+v", comparison)
+	}
+	if len(comparison.CaseChanges) != 0 || comparison.Metrics.PrecisionDeltaBasisPoints != 0 {
+		t.Fatalf("identical decisions should have no behavioral changes: %+v", comparison)
+	}
+
+	again, err := CompareAIEvaluationReports(baseline, candidate, DefaultAIEvaluationPromotionPolicy())
+	if err != nil {
+		t.Fatalf("repeat comparison: %v", err)
+	}
+	if !reflect.DeepEqual(comparison, again) {
+		t.Fatal("same reports and policy must produce byte-stable comparison evidence")
+	}
+}
+
+func TestCompareAIEvaluationReportsBlocksNewTruePositiveEscapeAndSegmentRegressions(t *testing.T) {
+	baseline := promotionTestReport("prompt-v1", nil)
+	candidate := promotionTestReport("prompt-v2", func(results []AIEvaluationResult) {
+		for i := range results {
+			if results[i].CaseID == "tp-go-path" {
+				results[i].Critique = promotionTestCritique(candidateRun("prompt-v2"), results[i].CaseID, true, true)
+				results[i].ConsensusFalsePositive = true
+				results[i].WouldGateExempt = true
+			}
+		}
+	})
+
+	comparison, err := CompareAIEvaluationReports(baseline, candidate, DefaultAIEvaluationPromotionPolicy())
+	if err != nil {
+		t.Fatalf("CompareAIEvaluationReports: %v", err)
+	}
+	if comparison.Status != "blocked" || !comparison.ApprovalRequired {
+		t.Fatalf("unsafe candidate status = %q approval_required=%v", comparison.Status, comparison.ApprovalRequired)
+	}
+	for _, want := range []struct {
+		rule, scope, segment, caseID string
+	}{
+		{"minimum_precision", "overall", "", ""},
+		{"maximum_false_negative_escape_rate", "overall", "", ""},
+		{"precision_regression", "language", "go", ""},
+		{"new_true_positive_escape", "case", "", "tp-go-path"},
+	} {
+		if !hasPromotionFailure(comparison.Failures, want.rule, want.scope, want.segment, want.caseID) {
+			t.Errorf("missing failure %+v in %+v", want, comparison.Failures)
+		}
+	}
+	if len(comparison.CaseChanges) != 1 || comparison.CaseChanges[0].CaseID != "tp-go-path" ||
+		!comparison.CaseChanges[0].Candidate.WouldGateExempt {
+		t.Fatalf("case-level behavioral change missing: %+v", comparison.CaseChanges)
+	}
+}
+
+func TestCompareAIEvaluationReportsRejectsApplesToOrangesInputs(t *testing.T) {
+	baseline := promotionTestReport("prompt-v1", nil)
+	tests := map[string]func(*AIEvaluationReport){
+		"different dataset": func(candidate *AIEvaluationReport) { candidate.DatasetSHA256 = strings.Repeat("b", 64) },
+		"different policy":  func(candidate *AIEvaluationReport) { candidate.Run.PolicyVersion = "other-policy" },
+		"changed label":     func(candidate *AIEvaluationReport) { candidate.Results[0].Label = AIEvaluationTruePositive },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidate := promotionTestReport("prompt-v2", nil)
+			mutate(&candidate)
+			// Keep the report internally consistent so the comparison boundary itself rejects the mismatch.
+			candidate.Metrics = evaluationMetrics(candidate.Results)
+			candidate.Breakdowns = evaluationBreakdowns(candidate.Results)
+			candidate.RunID = evaluationRunID(candidate)
+			if _, err := CompareAIEvaluationReports(baseline, candidate, DefaultAIEvaluationPromotionPolicy()); err == nil {
+				t.Fatal("incompatible reports must be rejected")
+			}
+		})
+	}
+
+	candidate := promotionTestReport("prompt-v1", nil)
+	candidate.Run.ProposerProvider = " PROVIDER-A "
+	candidate.Run.ProposerModel = "router/MODEL-A"
+	for i := range candidate.Results {
+		candidate.Results[i].Critique.ProposerProvider = "provider-a"
+		candidate.Results[i].Critique.ProposerModel = "router/MODEL-A"
+		candidate.Results[i].Critique.ProposerModelFamily = "model-a"
+	}
+	candidate.RunID = evaluationRunID(candidate)
+	if _, err := CompareAIEvaluationReports(baseline, candidate, DefaultAIEvaluationPromotionPolicy()); err == nil {
+		t.Fatal("aliases of the same provider/model configuration are not a promotion candidate")
+	}
+}
+
+func TestCompareAIEvaluationReportsBlocksLostVerifierCoverage(t *testing.T) {
+	baseline := promotionTestReport("prompt-v1", nil)
+	candidate := promotionTestReport("prompt-v2", func(results []AIEvaluationResult) {
+		for i := range results {
+			if results[i].CaseID == "tp-go-path" {
+				results[i].Critique.VerifierVerdict = ""
+				results[i].Critique.VerifierDriver = ""
+				results[i].Critique.VerifierConfidence = 0
+			}
+		}
+	})
+
+	comparison, err := CompareAIEvaluationReports(baseline, candidate, DefaultAIEvaluationPromotionPolicy())
+	if err != nil {
+		t.Fatalf("CompareAIEvaluationReports: %v", err)
+	}
+	if comparison.Status != "blocked" || !hasPromotionFailure(comparison.Failures, "verifier_coverage_regression", "overall", "", "") {
+		t.Fatalf("lost verifier response must block promotion review: %+v", comparison.Failures)
+	}
+	if len(comparison.CaseChanges) != 1 || comparison.CaseChanges[0].Candidate.VerifierVerdict != "" {
+		t.Fatalf("lost verifier response must remain visible by case: %+v", comparison.CaseChanges)
+	}
+}
+
+func TestAIEvaluationReportValidateRejectsTamperingAndGateAuthority(t *testing.T) {
+	valid := promotionTestReport("prompt-v1", nil)
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid report: %v", err)
+	}
+	tests := map[string]func(*AIEvaluationReport){
+		"metrics":        func(report *AIEvaluationReport) { report.Metrics.Precision = 0 },
+		"breakdowns":     func(report *AIEvaluationReport) { delete(report.Breakdowns, "cwe") },
+		"run id":         func(report *AIEvaluationReport) { report.RunID = strings.Repeat("0", 64) },
+		"gate authority": func(report *AIEvaluationReport) { report.Results[0].GateExempt = true },
+		"model metadata": func(report *AIEvaluationReport) { report.Results[0].Critique.ProposerModel = "other" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			report := promotionTestReport("prompt-v1", nil)
+			mutate(&report)
+			if err := report.Validate(); err == nil {
+				t.Fatal("tampered report must be rejected")
+			}
+		})
+	}
+}
+
+func TestLoadAIEvaluationReportIsStrict(t *testing.T) {
+	report := promotionTestReport("prompt-v1", nil)
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadAIEvaluationReport(data)
+	if err != nil || loaded.RunID != report.RunID {
+		t.Fatalf("LoadAIEvaluationReport: run=%q err=%v", loaded.RunID, err)
+	}
+	unknown := bytes.Replace(data, []byte(`{"schema_version":`), []byte(`{"unexpected":true,"schema_version":`), 1)
+	if _, err := LoadAIEvaluationReport(unknown); err == nil {
+		t.Fatal("unknown report fields must be rejected")
+	}
+	if _, err := LoadAIEvaluationReport(append(data, []byte(` {}`)...)); err == nil {
+		t.Fatal("trailing JSON must be rejected")
+	}
+}
+
+func TestAIEvaluationPromotionPolicyRejectsInvalidBasisPoints(t *testing.T) {
+	policy := DefaultAIEvaluationPromotionPolicy()
+	policy.MaximumRecallDropBasisPoints = 10_001
+	if err := policy.Validate(); err == nil {
+		t.Fatal("out-of-range promotion threshold must be rejected")
+	}
+}
+
+func TestPromotionThresholdsDoNotRoundUnsafeRatesIntoCompliance(t *testing.T) {
+	if !belowBasisPointMinimum(18_999, 20_000, 9500) {
+		t.Fatal("precision below 95% must not round up into compliance")
+	}
+	if belowBasisPointMinimum(19, 20, 9500) {
+		t.Fatal("precision exactly at 95% must pass")
+	}
+	if !aboveBasisPointMaximum(1, 100_000, 0) {
+		t.Fatal("a non-zero escape rate must not round down to zero")
+	}
+	if !basisPointDropExceeds(100_000, 100_000, 99_999, 100_000, 0) {
+		t.Fatal("a sub-basis-point regression must fail a zero-regression policy")
+	}
+	if !basisPointIncreaseExceeds(0, 100_000, 1, 100_000, 0) {
+		t.Fatal("a sub-basis-point disagreement increase must fail a zero-regression policy")
+	}
+}
+
+func TestEvaluationRunIDDoesNotReorderCallerResults(t *testing.T) {
+	report := promotionTestReport("prompt-v1", nil)
+	report.Results[0], report.Results[len(report.Results)-1] = report.Results[len(report.Results)-1], report.Results[0]
+	before := make([]string, 0, len(report.Results))
+	for _, result := range report.Results {
+		before = append(before, result.CaseID)
+	}
+	_ = evaluationRunID(report)
+	for i, result := range report.Results {
+		if result.CaseID != before[i] {
+			t.Fatalf("evaluationRunID reordered caller results: before=%v after=%v", before, report.Results)
+		}
+	}
+}
+
+func promotionTestReport(prompt string, mutate func([]AIEvaluationResult)) AIEvaluationReport {
+	run := candidateRun(prompt)
+	definitions := []struct {
+		id, label, language, cwe string
+		falsePositive            bool
+	}{
+		{"fp-go-constant", "false_positive", "go", "CWE-89", true},
+		{"fp-python-sanitized", "false_positive", "python", "CWE-79", true},
+		{"tp-go-path", "true_positive", "go", "CWE-22", false},
+		{"tp-python-template", "true_positive", "python", "CWE-78", false},
+	}
+	results := make([]AIEvaluationResult, 0, len(definitions))
+	for _, definition := range definitions {
+		critique := promotionTestCritique(run, definition.id, definition.falsePositive, definition.falsePositive)
+		results = append(results, AIEvaluationResult{
+			CaseID: definition.id, Label: AIEvaluationLabel(definition.label), Language: definition.language,
+			Framework: "standard-library", Kind: finding.KindSAST, Severity: shared.SeverityMedium,
+			CWE: definition.cwe, Covered: true, ConsensusFalsePositive: definition.falsePositive,
+			WouldGateExempt: definition.falsePositive, Critique: critique,
+		})
+	}
+	if mutate != nil {
+		mutate(results)
+	}
+	report := AIEvaluationReport{
+		SchemaVersion: aiEvaluationReportSchema, DatasetVersion: "golden-v1",
+		DatasetSHA256: strings.Repeat("a", 64), Provenance: "synthetic:test", Reviewer: "security-reviewer",
+		Run: run, Results: results,
+	}
+	report.Metrics = evaluationMetrics(report.Results)
+	report.Breakdowns = evaluationBreakdowns(report.Results)
+	report.RunID = evaluationRunID(report)
+	return report
+}
+
+func candidateRun(prompt string) AIEvaluationRun {
+	return AIEvaluationRun{
+		ProposerProvider: "provider-a", ProposerModel: "model-a",
+		VerifierProvider: "provider-b", VerifierModel: "model-b",
+		IndependencePolicy: ports.AIIndependenceProvider,
+		PromptVersion:      prompt, PolicyVersion: "policy-v1",
+	}
+}
+
+func promotionTestCritique(run AIEvaluationRun, caseID string, falsePositive, wouldExempt bool) ports.AICritique {
+	critique := ports.AICritique{
+		DedupKey:         "ai-eval:" + caseID,
+		ProposerProvider: agent.CanonicalProviderID(run.ProposerProvider), ProposerModel: run.ProposerModel,
+		ProposerModelFamily: agent.CanonicalModelID(run.ProposerModel),
+		VerifierProvider:    agent.CanonicalProviderID(run.VerifierProvider), VerifierModel: run.VerifierModel,
+		VerifierModelFamily: agent.CanonicalModelID(run.VerifierModel),
+		IndependencePolicy:  run.IndependencePolicy, PromptVersion: run.PromptVersion, PolicyVersion: run.PolicyVersion,
+		Shadow: true, WouldGateExempt: wouldExempt,
+	}
+	if falsePositive {
+		critique.Verdict, critique.Driver, critique.Confidence = "refuted", "constant_or_literal", 95
+		critique.SuspectedFP, critique.Verified = true, true
+		critique.VerifierVerdict, critique.VerifierDriver, critique.VerifierConfidence = "refuted", "constant_or_literal", 94
+		return critique
+	}
+	critique.Verdict, critique.Driver, critique.Confidence = "sound", "attacker_controlled", 96
+	critique.VerifierVerdict, critique.VerifierDriver, critique.VerifierConfidence = "sound", "attacker_controlled", 93
+	return critique
+}
+
+func hasPromotionFailure(failures []AIEvaluationPromotionFailure, rule, scope, segment, caseID string) bool {
+	for _, failure := range failures {
+		if failure.Rule == rule && failure.Scope == scope && failure.Segment == segment && failure.CaseID == caseID {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds a deterministic, fail-closed candidate-vs-baseline gate for AI false-positive triage model/prompt promotion.

- Strictly decodes evaluation-v2 reports and recomputes aggregate metrics, segment breakdowns, shadow invariants, canonical model/provider identity, and `run_id` before comparison.
- Requires the exact same reviewed dataset, provenance, reviewer, gate-policy version, and independence policy; aliases of the same provider/model configuration are not accepted as a new candidate.
- Applies exact rational thresholds (no floating-point rounding at safety boundaries) for minimum precision, maximum false-negative escape rate, and allowed regression.
- Detects regressions overall and by language, kind, CWE, severity, and framework.
- Tracks verifier-comparison coverage separately so a verifier outage cannot make disagreement metrics look healthier.
- Emits source-free case behavior changes and stable machine-readable failure rules.
- Adds `synapse-fptriage-compare` plus a Make target and operator documentation.

## Safety contract

- Both inputs must remain shadow-only; any `gate_exempt=true` report is rejected.
- A passing comparison is `review_required` with `approval_required=true`; there is no automatic promotion or runtime configuration mutation.
- The comparison artifact contains typed outcomes and case IDs, not source snippets or prompts.
- Blocked evidence is written before the CLI exits non-zero for CI retention.
- The output cannot overwrite/alias either evaluation input or resolve through a symlink.
- The default proposed policy requires >=95% precision, zero true-positive escape rate, and zero regression; PM/Security approval is still required.

## Scope

This implements the candidate-vs-baseline promotion-gate slice of #396. Production distribution-drift alerts plus versioned rollout/rollback approval remain tracked by that issue, so this PR intentionally does not close it.

## Verification

- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./cmd/...`
- focused Go tests and vet repeated after the final exact-threshold/filesystem hardening
- `pnpm test` (38 files, 298 tests)
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`

Race tests were not available in the local Windows toolchain because `CGO_ENABLED=0`; the standard, focused, full-repository, vet, and build checks above are green.

Advances #396