### PR TITLE
feat(ai-triage): detect input distribution drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **AI-triage input drift evidence.** The tenant observability API and UI now expose deterministic,
+  source-free language/CWE/project distributions. A new offline CLI compares them with a versioned,
+  human-approved baseline using total-variation distance, writes stable CI evidence, and alerts on
+  excessive drift or insufficient samples without gaining model-promotion or quality-gate authority.
+
 - **Evidence-cited AI false-positive triage.** Supplies bounded deterministic source/sink, data-flow, sanitizer, call-path, route/framework, and reachability metadata to the AI triage proposer/verifier before model calls. Model claims must cite current server-generated evidence-token IDs; unknown, missing, driver-incompatible, or finding-mismatched receipts fail closed. Gate authorization now uses `fp-gate-v5` and requires that closed receipt in addition to the existing severity/CWE/evidence safety floors.
 
 - **Safe AI-triage caching.** Tenant-bound API scans reuse typed proposer/verifier claims only when

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: help install tools dev build run test harness vet lint format typecheck tidy ai-triage-eval \
+.PHONY: help install tools dev build run test harness vet lint format typecheck tidy ai-triage-eval ai-triage-drift \
         docker-build docker-up docker-down clean web-dev web-build smoke
 
 GO ?= go
 IMAGE ?= synapse-api:dev
 AI_EVAL_DATASET ?= internal/usecase/sca/testdata/fptriage-golden-v1.json
 AI_EVAL_OUTPUT ?= ai-triage-eval.json
+AI_DRIFT_BASELINE ?= ai-triage-drift-baseline.json
+AI_DRIFT_OBSERVED ?= ai-triage-observability.json
+AI_DRIFT_OUTPUT ?= ai-triage-drift-report.json
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
@@ -49,6 +52,9 @@ tidy: ## Tidy go.mod / go.sum
 
 ai-triage-eval: ## Evaluate FP triage against the versioned golden dataset (requires two model IDs)
 	$(GO) run ./cmd/synapse-fptriage-eval --dataset $(AI_EVAL_DATASET) --output $(AI_EVAL_OUTPUT)
+
+ai-triage-drift: ## Compare AI triage input distribution with a human-approved baseline
+	$(GO) run ./cmd/synapse-fptriage-drift --baseline $(AI_DRIFT_BASELINE) --observed $(AI_DRIFT_OBSERVED) --output $(AI_DRIFT_OUTPUT)
 
 docker-build: ## Build the API container image
 	docker build -t $(IMAGE) -f deploy/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ The exit code is 0 when no finding meets the threshold, non-zero otherwise.
 | `synapse-cluster-agent` | Fleet agent: Kubernetes workload/exposure/identity inventory |
 | `synapse-fptriage-eval` | Offline evaluation harness for AI false-positive triage |
 | `synapse-fptriage-curate` | Offline privacy- and label-reviewed feedback curation for AI false-positive evaluation |
+| `synapse-fptriage-drift` | Offline language/CWE/project distribution drift evidence for AI triage |
 | `synapse-mcp` | Read-only, propose-only integration server, never executes |
 
 ## Architecture

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1246,9 +1246,9 @@ paths:
     get:
       tags: [ai-triage]
       operationId: getAITriageObservability
-      summary: Aggregate tenant-scoped AI triage safety and cost metrics
+      summary: Aggregate tenant-scoped AI triage safety, cost, and input-distribution metrics
       responses:
-        '200': {description: Latest per-project AI triage metrics and baseline alerts, content: {application/json: {schema: {$ref: '#/components/schemas/AITriageDashboard'}}}}
+        '200': {description: Latest per-project AI triage metrics, baseline alerts, and drift-ready distribution snapshot, content: {application/json: {schema: {$ref: '#/components/schemas/AITriageDashboard'}}}}
         '401': {$ref: '#/components/responses/Unauthorized'}
         '403': {$ref: '#/components/responses/Forbidden'}
 
@@ -1496,9 +1496,25 @@ components:
         project_id: {type: string}
         project_name: {type: string}
         alert: {$ref: '#/components/schemas/AITriageAlert'}
+    AITriageDistributionSnapshot:
+      type: object
+      description: Source-free distribution snapshot; every populated dimension sums to 10000 basis points.
+      required: [schema_version, sample_size, language_basis_points, cwe_basis_points, project_basis_points]
+      properties:
+        schema_version: {type: string, const: synapse-ai-triage-distribution-v1}
+        sample_size: {type: integer, minimum: 0}
+        language_basis_points:
+          type: object
+          additionalProperties: {type: integer, minimum: 1, maximum: 10000}
+        cwe_basis_points:
+          type: object
+          additionalProperties: {type: integer, minimum: 1, maximum: 10000}
+        project_basis_points:
+          type: object
+          additionalProperties: {type: integer, minimum: 1, maximum: 10000}
     AITriageDashboard:
       type: object
-      required: [generated_at, totals, by_model, by_prompt_version, by_cwe, by_project, alerts]
+      required: [generated_at, totals, by_model, by_prompt_version, by_cwe, by_project, distribution, alerts]
       properties:
         generated_at: {type: string, format: date-time}
         totals: {$ref: '#/components/schemas/AITriageMetricRow'}
@@ -1506,6 +1522,7 @@ components:
         by_prompt_version: {type: array, items: {$ref: '#/components/schemas/AITriageMetricRow'}}
         by_cwe: {type: array, items: {$ref: '#/components/schemas/AITriageMetricRow'}}
         by_project: {type: array, items: {$ref: '#/components/schemas/AITriageMetricRow'}}
+        distribution: {$ref: '#/components/schemas/AITriageDistributionSnapshot'}
         alerts: {type: array, items: {$ref: '#/components/schemas/AITriageDashboardAlert'}}
     OffensiveHaltRequest:
       type: object

--- a/cmd/synapse-fptriage-drift/main.go
+++ b/cmd/synapse-fptriage-drift/main.go
@@ -1,0 +1,131 @@
+// Command synapse-fptriage-drift compares a saved AI-triage observability
+// distribution with a versioned, human-approved baseline. It only emits drift
+// evidence; it never changes runtime model, prompt, or quality-gate behavior.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+var errDriftAlert = errors.New("AI triage distribution requires review")
+
+func main() {
+	baselinePath := flag.String("baseline", "", "versioned human-approved drift baseline JSON")
+	observedPath := flag.String("observed", "", "saved AI triage observability response or distribution snapshot")
+	outputPath := flag.String("output", "-", "drift report path, or - for stdout")
+	failOnAlert := flag.Bool("fail-on-alert", true, "exit non-zero after writing a drift or insufficient-sample report")
+	flag.Parse()
+
+	if err := run(*baselinePath, *observedPath, *outputPath, *failOnAlert); err != nil {
+		fmt.Fprintf(os.Stderr, "synapse-fptriage-drift: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(baselinePath, observedPath, outputPath string, failOnAlert bool) error {
+	if strings.TrimSpace(baselinePath) == "" || strings.TrimSpace(observedPath) == "" {
+		return fmt.Errorf("--baseline and --observed are required")
+	}
+	if err := validateOutputPath(outputPath, baselinePath, observedPath); err != nil {
+		return err
+	}
+	baselineData, err := os.ReadFile(baselinePath)
+	if err != nil {
+		return fmt.Errorf("read drift baseline: %w", err)
+	}
+	baseline, err := sca.LoadAITriageDriftBaseline(baselineData)
+	if err != nil {
+		return fmt.Errorf("load drift baseline: %w", err)
+	}
+	observedData, err := os.ReadFile(observedPath)
+	if err != nil {
+		return fmt.Errorf("read observed distribution: %w", err)
+	}
+	observed, err := sca.LoadAITriageDistributionSnapshot(observedData)
+	if err != nil {
+		return fmt.Errorf("load observed distribution: %w", err)
+	}
+	report, err := sca.DetectAITriageDistributionDrift(baseline, observed)
+	if err != nil {
+		return err
+	}
+	if err := writeReport(outputPath, report); err != nil {
+		return err
+	}
+	if report.Status != "stable" && failOnAlert {
+		return fmt.Errorf("%w (%s; report %s)", errDriftAlert, report.Status, report.ReportID)
+	}
+	return nil
+}
+
+func validateOutputPath(outputPath string, inputPaths ...string) error {
+	if outputPath == "-" {
+		return nil
+	}
+	outputAbs, err := filepath.Abs(outputPath)
+	if err != nil {
+		return fmt.Errorf("resolve drift output path: %w", err)
+	}
+	if info, statErr := os.Lstat(outputAbs); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("drift output must not be a symlink")
+	}
+	outputInfo, outputStatErr := os.Stat(outputAbs)
+	for _, inputPath := range inputPaths {
+		inputAbs, err := filepath.Abs(inputPath)
+		if err != nil {
+			return fmt.Errorf("resolve drift input path: %w", err)
+		}
+		sameName := outputAbs == inputAbs
+		if runtime.GOOS == "windows" {
+			sameName = strings.EqualFold(outputAbs, inputAbs)
+		}
+		if sameName {
+			return fmt.Errorf("drift output must not overwrite an input")
+		}
+		if outputStatErr == nil {
+			if inputInfo, statErr := os.Stat(inputAbs); statErr == nil && os.SameFile(outputInfo, inputInfo) {
+				return fmt.Errorf("drift output must not alias an input")
+			}
+		}
+	}
+	return nil
+}
+
+func writeReport(outputPath string, report sca.AITriageDriftReport) error {
+	var (
+		out *os.File
+		err error
+	)
+	if outputPath == "-" {
+		out = os.Stdout
+	} else {
+		out, err = os.Create(outputPath)
+		if err != nil {
+			return fmt.Errorf("create drift report: %w", err)
+		}
+	}
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(report); err != nil {
+		if out != os.Stdout {
+			_ = out.Close()
+		}
+		return fmt.Errorf("write drift report: %w", err)
+	}
+	if out != os.Stdout {
+		if err := out.Close(); err != nil {
+			return fmt.Errorf("close drift report (it may be incomplete): %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/synapse-fptriage-drift/main_test.go
+++ b/cmd/synapse-fptriage-drift/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+func TestRunWritesAlertReportBeforeReturningFailure(t *testing.T) {
+	directory := t.TempDir()
+	baselinePath := filepath.Join(directory, "baseline.json")
+	observedPath := filepath.Join(directory, "observed.json")
+	outputPath := filepath.Join(directory, "report.json")
+	writeTestJSON(t, baselinePath, testBaseline())
+	writeTestJSON(t, observedPath, map[string]any{
+		"generated_at": "2026-08-13T00:00:00Z",
+		"distribution": testDistribution(100, map[string]int{"go": 2000, "typescript": 8000}),
+	})
+
+	err := run(baselinePath, observedPath, outputPath, true)
+	if !errors.Is(err, errDriftAlert) {
+		t.Fatalf("run() error = %v", err)
+	}
+	data, readErr := os.ReadFile(outputPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	var report sca.AITriageDriftReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Status != "drift_detected" || report.ReportID == "" || len(report.Alerts) != 1 {
+		t.Fatalf("report = %+v", report)
+	}
+	if err := run(baselinePath, observedPath, outputPath, false); err != nil {
+		t.Fatalf("run(fail-on-alert=false) error = %v", err)
+	}
+}
+
+func TestRunRejectsOutputThatOverwritesInput(t *testing.T) {
+	directory := t.TempDir()
+	baselinePath := filepath.Join(directory, "baseline.json")
+	observedPath := filepath.Join(directory, "observed.json")
+	writeTestJSON(t, baselinePath, testBaseline())
+	writeTestJSON(t, observedPath, testDistribution(100, map[string]int{"go": 6000, "typescript": 4000}))
+
+	if err := run(baselinePath, observedPath, observedPath, false); err == nil {
+		t.Fatal("run() accepted an output path that overwrites observed input")
+	}
+}
+
+func testBaseline() map[string]any {
+	return map[string]any{
+		"schema_version": "synapse-ai-triage-drift-baseline-v1",
+		"version":        "production-2026-08", "provenance": "security/review-42", "approved_by": "security@example.com",
+		"minimum_samples": 50, "maximum_total_variation_basis_points": 1000,
+		"distribution": testDistribution(100, map[string]int{"go": 6000, "typescript": 4000}),
+	}
+}
+
+func testDistribution(sampleSize int, languages map[string]int) map[string]any {
+	return map[string]any{
+		"schema_version": "synapse-ai-triage-distribution-v1", "sample_size": sampleSize,
+		"language_basis_points": languages,
+		"cwe_basis_points":      map[string]int{"CWE-79": 10_000},
+		"project_basis_points":  map[string]int{"project-a": 10_000},
+	}
+}
+
+func writeTestJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/guide/ai-triage-evaluation.md
+++ b/docs/guide/ai-triage-evaluation.md
@@ -5,12 +5,13 @@ an operator enables gate automation. Evaluation uses the same proposer, verifier
 threshold, human-review floors, and deterministic policy as a scan. The only policy difference is forced
 shadow mode: `would_gate_exempt` is measured, while `gate_exempt` must remain `false`.
 
-The repository includes two offline AI-triage data/evaluation commands:
+The repository includes three offline AI-triage data/evaluation commands:
 
 | Binary | Role |
 | --- | --- |
 | `synapse-fptriage-eval` | Run the versioned AI false-positive evaluation harness |
 | `synapse-fptriage-curate` | Curate human review outcomes into privacy- and label-reviewed evaluation data |
+| `synapse-fptriage-drift` | Compare production input distribution with a human-approved baseline |
 
 ## Golden dataset
 
@@ -194,3 +195,59 @@ cannot produce `gate_exempt`.
 
 The report is evidence for PM/Security threshold approval; it does not approve a model automatically.
 Keep `SYNAPSE_FP_TRIAGE_MODE=shadow` until the threshold and dataset are approved for canary rollout.
+
+## Detect production distribution drift
+
+The tenant-scoped observability response includes a source-free `distribution` snapshot. It counts the
+latest stored scan for each visible project and normalizes language, CWE, and project shares to exactly
+10,000 basis points. Language byte percentages are weighted by the number of AI-triaged findings in that
+scan; missing language and CWE metadata are explicit as `unknown` and `unclassified` rather than silently
+dropped.
+
+Save a current response without committing it to the repository:
+
+```bash
+curl -H "Authorization: Bearer $SYNAPSE_TOKEN" \
+  "$SYNAPSE_API_URL/api/v1/ai-triage/observability" \
+  > ai-triage-observability.json
+```
+
+Create a reviewed baseline by copying a trusted snapshot into this versioned envelope. The approver must
+be a human identity; reserved machine principals fail validation.
+
+```json
+{
+  "schema_version": "synapse-ai-triage-drift-baseline-v1",
+  "version": "production-2026-08",
+  "provenance": "security/review-42",
+  "approved_by": "security@example.com",
+  "minimum_samples": 50,
+  "maximum_total_variation_basis_points": 1000,
+  "distribution": {
+    "schema_version": "synapse-ai-triage-distribution-v1",
+    "sample_size": 100,
+    "language_basis_points": {"go": 6000, "typescript": 4000},
+    "cwe_basis_points": {"CWE-79": 10000},
+    "project_basis_points": {"project-a": 10000}
+  }
+}
+```
+
+Run the deterministic comparison in CI:
+
+```bash
+go run ./cmd/synapse-fptriage-drift \
+  --baseline ai-triage-drift-baseline.json \
+  --observed ai-triage-observability.json \
+  --output ai-triage-drift-report.json
+```
+
+For each dimension, drift is total-variation distance: half the sum of absolute basis-point changes over
+the union of baseline and observed categories. This catches a newly dominant language, CWE, or project as
+well as shifts among existing categories. The default CLI behavior writes the complete deterministic
+report and then exits non-zero for `drift_detected` or `insufficient_samples`; use
+`--fail-on-alert=false` for report-only monitoring. The approved threshold is read only from the baseline,
+not from a CLI override. A drift report requests review but has no authority to promote a model, change a
+prompt, suppress a finding, or alter a quality gate. `approved_by` is process provenance, not a
+cryptographic identity; create and run approved baselines only in a workflow that authenticates and
+audits the responsible reviewer.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -115,7 +115,19 @@ stays in the report, it is only held back from the `--fail-on` gate).
    and remains gating. Repeated provider or invalid-output failures open a bounded circuit and keep the
    remaining findings advisory-only until its cooldown probe succeeds. API deployments expose the
    resulting request, latency, timeout, parse, token/cost, disagreement, exemption and alert views at
-   `/api/v1/ai-triage/observability`.
+   `/api/v1/ai-triage/observability`. The same response carries normalized language/CWE/project
+   distributions for offline drift checks:
+
+```bash
+go run ./cmd/synapse-fptriage-drift \
+  --baseline ai-triage-drift-baseline.json \
+  --observed ai-triage-observability.json \
+  --output ai-triage-drift-report.json
+```
+
+The baseline owns its human approval, minimum sample size, and maximum total-variation distance. The
+command writes deterministic evidence before returning a non-zero drift alert; it never changes runtime
+gate behavior. See [AI triage evaluation](ai-triage-evaluation.md#detect-production-distribution-drift).
 
 ```bash
 export SYNAPSE_LLM_BASE_URL=http://localhost:8081/v1

--- a/internal/usecase/sca/fptriage_dashboard.go
+++ b/internal/usecase/sca/fptriage_dashboard.go
@@ -37,19 +37,28 @@ type AITriageDashboardAlert struct {
 }
 
 type AITriageDashboard struct {
-	GeneratedAt time.Time                `json:"generated_at"`
-	Totals      AITriageMetricRow        `json:"totals"`
-	ByModel     []AITriageMetricRow      `json:"by_model"`
-	ByPrompt    []AITriageMetricRow      `json:"by_prompt_version"`
-	ByCWE       []AITriageMetricRow      `json:"by_cwe"`
-	ByProject   []AITriageMetricRow      `json:"by_project"`
-	Alerts      []AITriageDashboardAlert `json:"alerts"`
+	GeneratedAt  time.Time                    `json:"generated_at"`
+	Totals       AITriageMetricRow            `json:"totals"`
+	ByModel      []AITriageMetricRow          `json:"by_model"`
+	ByPrompt     []AITriageMetricRow          `json:"by_prompt_version"`
+	ByCWE        []AITriageMetricRow          `json:"by_cwe"`
+	ByProject    []AITriageMetricRow          `json:"by_project"`
+	Distribution AITriageDistributionSnapshot `json:"distribution"`
+	Alerts       []AITriageDashboardAlert     `json:"alerts"`
 }
 
 // AITriageObservability aggregates the latest evidence-sealed result for each tenant-visible project.
 // It never returns source, prompts, provider errors, or credentials.
 func (s *Service) AITriageObservability(ctx context.Context, tenantID shared.ID) (AITriageDashboard, error) {
-	dashboard := AITriageDashboard{GeneratedAt: time.Now().UTC()}
+	dashboard := AITriageDashboard{
+		GeneratedAt: time.Now().UTC(),
+		Distribution: AITriageDistributionSnapshot{
+			SchemaVersion: aiTriageDistributionSchemaVersion,
+			Language:      map[string]int{},
+			CWE:           map[string]int{},
+			Project:       map[string]int{},
+		},
+	}
 	if s == nil || s.engagements == nil || s.results == nil {
 		return dashboard, fmt.Errorf("AI triage observability: %w", shared.ErrValidation)
 	}
@@ -68,6 +77,10 @@ func (s *Service) AITriageObservability(ctx context.Context, tenantID shared.ID)
 	byPrompt := map[string]*AITriageMetricRow{}
 	byCWE := map[string]*AITriageMetricRow{}
 	byProject := map[string]*AITriageMetricRow{}
+	languageWeights := map[string]float64{}
+	cweWeights := map[string]float64{}
+	projectWeights := map[string]float64{}
+	distributionSamples := 0
 	for _, engagement := range engagements {
 		if engagement == nil {
 			continue
@@ -83,9 +96,6 @@ func (s *Service) AITriageObservability(ctx context.Context, tenantID shared.ID)
 		if err := json.Unmarshal(data, &result); err != nil {
 			return dashboard, fmt.Errorf("decode AI triage observability result: %w", err)
 		}
-		if result.AITriageTelemetry == nil {
-			continue
-		}
 		projectID := engagement.ProjectID
 		if projectID.IsZero() {
 			projectID = engagement.ID
@@ -99,7 +109,11 @@ func (s *Service) AITriageObservability(ctx context.Context, tenantID shared.ID)
 			}
 			findingsByKey[strings.TrimSpace(item.DedupKey)] = cwe
 		}
-		for _, call := range result.AITriageTelemetry.Calls {
+		var calls []ports.FPTriageCallMetric
+		if result.AITriageTelemetry != nil {
+			calls = result.AITriageTelemetry.Calls
+		}
+		for _, call := range calls {
 			model := strings.TrimSpace(call.Provider + "/" + call.Model + " (" + call.Role + ")")
 			prompt := strings.TrimSpace(call.PromptVersion)
 			if prompt == "" {
@@ -120,6 +134,8 @@ func (s *Service) AITriageObservability(ctx context.Context, tenantID shared.ID)
 			if cwe == "" {
 				cwe = "unclassified"
 			}
+			cweWeights[canonicalDistributionCWE(cwe)]++
+			projectWeights[projectID.String()]++
 			model := strings.TrimSpace(critique.ProposerProvider + "/" + critique.ProposerModel + " (proposer)")
 			prompt := strings.TrimSpace(critique.PromptVersion)
 			if prompt == "" {
@@ -139,6 +155,8 @@ func (s *Service) AITriageObservability(ctx context.Context, tenantID shared.ID)
 				}
 			}
 		}
+		distributionSamples += len(result.AITriage)
+		addLanguageDistributionWeights(languageWeights, result.Languages, len(result.AITriage))
 		for _, alert := range result.AITriageAlerts {
 			dashboard.Alerts = append(dashboard.Alerts, AITriageDashboardAlert{ProjectID: projectID.String(), ProjectName: engagement.Name, Alert: alert})
 		}
@@ -149,6 +167,7 @@ func (s *Service) AITriageObservability(ctx context.Context, tenantID shared.ID)
 	dashboard.ByPrompt = sortedMetricRows(byPrompt)
 	dashboard.ByCWE = sortedMetricRows(byCWE)
 	dashboard.ByProject = sortedMetricRows(byProject)
+	dashboard.Distribution = newAITriageDistributionSnapshot(distributionSamples, languageWeights, cweWeights, projectWeights)
 	sort.SliceStable(dashboard.Alerts, func(i, j int) bool {
 		if dashboard.Alerts[i].ProjectID != dashboard.Alerts[j].ProjectID {
 			return dashboard.Alerts[i].ProjectID < dashboard.Alerts[j].ProjectID

--- a/internal/usecase/sca/fptriage_distribution.go
+++ b/internal/usecase/sca/fptriage_distribution.go
@@ -1,0 +1,115 @@
+package sca
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const aiTriageDistributionSchemaVersion = "synapse-ai-triage-distribution-v1"
+
+// AITriageDistributionSnapshot is a deterministic, source-free view of
+// the population evaluated by AI triage. Every populated dimension sums to
+// 10,000 basis points so snapshots can be compared across scan volumes.
+type AITriageDistributionSnapshot struct {
+	SchemaVersion string         `json:"schema_version"`
+	SampleSize    int            `json:"sample_size"`
+	Language      map[string]int `json:"language_basis_points"`
+	CWE           map[string]int `json:"cwe_basis_points"`
+	Project       map[string]int `json:"project_basis_points"`
+}
+
+func newAITriageDistributionSnapshot(sampleSize int, language, cwe, project map[string]float64) AITriageDistributionSnapshot {
+	return AITriageDistributionSnapshot{
+		SchemaVersion: aiTriageDistributionSchemaVersion,
+		SampleSize:    sampleSize,
+		Language:      normalizeDistributionWeights(language),
+		CWE:           normalizeDistributionWeights(cwe),
+		Project:       normalizeDistributionWeights(project),
+	}
+}
+
+func addLanguageDistributionWeights(weights map[string]float64, languages []ports.DetectedLanguage, sampleSize int) {
+	if sampleSize <= 0 {
+		return
+	}
+	valid := make(map[string]float64, len(languages))
+	total := 0.0
+	for _, language := range languages {
+		name := strings.ToLower(strings.TrimSpace(language.Name))
+		if name == "" || language.Percent <= 0 || math.IsNaN(language.Percent) || math.IsInf(language.Percent, 0) {
+			continue
+		}
+		valid[name] += language.Percent
+		total += language.Percent
+	}
+	if total == 0 {
+		weights["unknown"] += float64(sampleSize)
+		return
+	}
+	for name, percent := range valid {
+		weights[name] += float64(sampleSize) * percent / total
+	}
+}
+
+func canonicalDistributionCWE(value string) string {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	if value == "" || value == "UNCLASSIFIED" {
+		return "unclassified"
+	}
+	return value
+}
+
+func normalizeDistributionWeights(weights map[string]float64) map[string]int {
+	type share struct {
+		key       string
+		basis     int
+		remainder float64
+	}
+	keys := make([]string, 0, len(weights))
+	for key := range weights {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	total := 0.0
+	for _, key := range keys {
+		weight := weights[key]
+		if weight > 0 && !math.IsNaN(weight) && !math.IsInf(weight, 0) {
+			total += weight
+		}
+	}
+	if total == 0 {
+		return map[string]int{}
+	}
+
+	shares := make([]share, 0, len(weights))
+	allocated := 0
+	for _, key := range keys {
+		weight := weights[key]
+		if weight <= 0 || math.IsNaN(weight) || math.IsInf(weight, 0) {
+			continue
+		}
+		exact := weight * 10_000 / total
+		basis := int(math.Floor(exact))
+		shares = append(shares, share{key: key, basis: basis, remainder: exact - float64(basis)})
+		allocated += basis
+	}
+	sort.Slice(shares, func(i, j int) bool {
+		if shares[i].remainder != shares[j].remainder {
+			return shares[i].remainder > shares[j].remainder
+		}
+		return shares[i].key < shares[j].key
+	})
+	for i := 0; i < 10_000-allocated; i++ {
+		shares[i%len(shares)].basis++
+	}
+	result := make(map[string]int, len(shares))
+	for _, item := range shares {
+		if item.basis > 0 {
+			result[item.key] = item.basis
+		}
+	}
+	return result
+}

--- a/internal/usecase/sca/fptriage_drift.go
+++ b/internal/usecase/sca/fptriage_drift.go
@@ -1,0 +1,261 @@
+package sca
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+)
+
+const (
+	aiTriageDriftBaselineSchema = "synapse-ai-triage-drift-baseline-v1"
+	aiTriageDriftReportSchema   = "synapse-ai-triage-drift-report-v1"
+	maxDistributionEntries      = 10_000
+)
+
+// AITriageDriftBaseline is a versioned, human-approved reference population.
+// It carries policy as data so CI cannot silently substitute a threshold.
+type AITriageDriftBaseline struct {
+	SchemaVersion                    string                       `json:"schema_version"`
+	Version                          string                       `json:"version"`
+	Provenance                       string                       `json:"provenance"`
+	ApprovedBy                       string                       `json:"approved_by"`
+	MinimumSamples                   int                          `json:"minimum_samples"`
+	MaximumTotalVariationBasisPoints int                          `json:"maximum_total_variation_basis_points"`
+	Distribution                     AITriageDistributionSnapshot `json:"distribution"`
+}
+
+type AITriageDriftAlert struct {
+	Dimension                 string `json:"dimension"`
+	TotalVariationBasisPoints int    `json:"total_variation_basis_points"`
+	ThresholdBasisPoints      int    `json:"threshold_basis_points"`
+	SampleSize                int    `json:"sample_size"`
+	Message                   string `json:"message"`
+}
+
+// AITriageDriftReport is deterministic CI evidence. It reports population
+// change only; it cannot promote a model, change a prompt, or exempt a finding.
+type AITriageDriftReport struct {
+	SchemaVersion                    string                       `json:"schema_version"`
+	ReportID                         string                       `json:"report_id"`
+	Status                           string                       `json:"status"`
+	ReviewRequired                   bool                         `json:"review_required"`
+	BaselineVersion                  string                       `json:"baseline_version"`
+	BaselineProvenance               string                       `json:"baseline_provenance"`
+	BaselineApprovedBy               string                       `json:"baseline_approved_by"`
+	MinimumSamples                   int                          `json:"minimum_samples"`
+	MaximumTotalVariationBasisPoints int                          `json:"maximum_total_variation_basis_points"`
+	Baseline                         AITriageDistributionSnapshot `json:"baseline"`
+	Observed                         AITriageDistributionSnapshot `json:"observed"`
+	Alerts                           []AITriageDriftAlert         `json:"alerts"`
+}
+
+func LoadAITriageDriftBaseline(data []byte) (AITriageDriftBaseline, error) {
+	var baseline AITriageDriftBaseline
+	if err := decodeStrictJSON(data, &baseline); err != nil {
+		return baseline, fmt.Errorf("decode AI triage drift baseline: %w", err)
+	}
+	if err := baseline.Validate(); err != nil {
+		return baseline, err
+	}
+	return baseline, nil
+}
+
+// LoadAITriageDistributionSnapshot accepts either a snapshot or the saved JSON
+// response from GET /api/v1/ai-triage/observability.
+func LoadAITriageDistributionSnapshot(data []byte) (AITriageDistributionSnapshot, error) {
+	var envelope map[string]json.RawMessage
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&envelope); err != nil {
+		return AITriageDistributionSnapshot{}, fmt.Errorf("decode AI triage distribution: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return AITriageDistributionSnapshot{}, fmt.Errorf("decode AI triage distribution: %w", err)
+	}
+	payload := data
+	if distribution, ok := envelope["distribution"]; ok {
+		for _, field := range []string{"schema_version", "sample_size", "language_basis_points", "cwe_basis_points", "project_basis_points"} {
+			if _, ambiguous := envelope[field]; ambiguous {
+				return AITriageDistributionSnapshot{}, fmt.Errorf("decode AI triage distribution: ambiguous snapshot envelope")
+			}
+		}
+		payload = distribution
+	}
+	var snapshot AITriageDistributionSnapshot
+	if err := decodeStrictJSON(payload, &snapshot); err != nil {
+		return snapshot, fmt.Errorf("decode AI triage distribution: %w", err)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return snapshot, err
+	}
+	return snapshot, nil
+}
+
+func (b AITriageDriftBaseline) Validate() error {
+	if b.SchemaVersion != aiTriageDriftBaselineSchema {
+		return fmt.Errorf("AI triage drift baseline requires schema %q", aiTriageDriftBaselineSchema)
+	}
+	for _, field := range []struct{ name, value string }{
+		{"version", b.Version}, {"provenance", b.Provenance}, {"approved_by", b.ApprovedBy},
+	} {
+		if strings.TrimSpace(field.value) == "" || field.value != strings.TrimSpace(field.value) {
+			return fmt.Errorf("AI triage drift baseline %s must be non-empty canonical text", field.name)
+		}
+	}
+	if aitriagereview.IsMachineActor(b.ApprovedBy) {
+		return fmt.Errorf("AI triage drift baseline must be approved by a human actor")
+	}
+	if b.MinimumSamples < 1 || b.MinimumSamples > 1_000_000_000 {
+		return fmt.Errorf("AI triage drift baseline minimum_samples must be between 1 and 1000000000")
+	}
+	if b.MaximumTotalVariationBasisPoints < 0 || b.MaximumTotalVariationBasisPoints > 10_000 {
+		return fmt.Errorf("AI triage drift baseline maximum total variation must be between 0 and 10000 basis points")
+	}
+	if err := b.Distribution.Validate(); err != nil {
+		return fmt.Errorf("AI triage drift baseline distribution: %w", err)
+	}
+	if b.Distribution.SampleSize < b.MinimumSamples {
+		return fmt.Errorf("AI triage drift baseline distribution has %d samples, below minimum %d", b.Distribution.SampleSize, b.MinimumSamples)
+	}
+	return nil
+}
+
+func (s AITriageDistributionSnapshot) Validate() error {
+	if s.SchemaVersion != aiTriageDistributionSchemaVersion {
+		return fmt.Errorf("AI triage distribution requires schema %q", aiTriageDistributionSchemaVersion)
+	}
+	if s.SampleSize < 0 || s.SampleSize > 1_000_000_000 {
+		return fmt.Errorf("AI triage distribution sample_size must be between 0 and 1000000000")
+	}
+	dimensions := []struct {
+		name   string
+		values map[string]int
+		valid  func(string) bool
+	}{
+		{"language", s.Language, func(value string) bool {
+			return value != "" && value == strings.TrimSpace(value) && value == strings.ToLower(value)
+		}},
+		{"cwe", s.CWE, func(value string) bool { return value == canonicalDistributionCWE(value) }},
+		{"project", s.Project, func(value string) bool { return value != "" && value == strings.TrimSpace(value) }},
+	}
+	for _, dimension := range dimensions {
+		if s.SampleSize == 0 {
+			if len(dimension.values) != 0 {
+				return fmt.Errorf("AI triage distribution %s must be empty when sample_size is zero", dimension.name)
+			}
+			continue
+		}
+		if len(dimension.values) == 0 || len(dimension.values) > maxDistributionEntries {
+			return fmt.Errorf("AI triage distribution %s must contain between 1 and %d entries", dimension.name, maxDistributionEntries)
+		}
+		total := 0
+		for key, value := range dimension.values {
+			if !dimension.valid(key) || value <= 0 || value > 10_000 {
+				return fmt.Errorf("AI triage distribution %s entry %q is not canonical positive basis points", dimension.name, key)
+			}
+			total += value
+		}
+		if total != 10_000 {
+			return fmt.Errorf("AI triage distribution %s sums to %d basis points, want 10000", dimension.name, total)
+		}
+	}
+	return nil
+}
+
+func DetectAITriageDistributionDrift(baseline AITriageDriftBaseline, observed AITriageDistributionSnapshot) (AITriageDriftReport, error) {
+	if err := baseline.Validate(); err != nil {
+		return AITriageDriftReport{}, err
+	}
+	if err := observed.Validate(); err != nil {
+		return AITriageDriftReport{}, err
+	}
+	report := AITriageDriftReport{
+		SchemaVersion: aiTriageDriftReportSchema, Status: "stable",
+		BaselineVersion: baseline.Version, BaselineProvenance: baseline.Provenance, BaselineApprovedBy: baseline.ApprovedBy,
+		MinimumSamples: baseline.MinimumSamples, MaximumTotalVariationBasisPoints: baseline.MaximumTotalVariationBasisPoints,
+		Baseline: baseline.Distribution, Observed: observed, Alerts: []AITriageDriftAlert{},
+	}
+	if observed.SampleSize < baseline.MinimumSamples {
+		report.Status = "insufficient_samples"
+		report.ReviewRequired = true
+		report.Alerts = append(report.Alerts, AITriageDriftAlert{
+			Dimension: "all", ThresholdBasisPoints: baseline.MaximumTotalVariationBasisPoints, SampleSize: observed.SampleSize,
+			Message: fmt.Sprintf("observed sample size %d is below the approved minimum %d", observed.SampleSize, baseline.MinimumSamples),
+		})
+	} else {
+		dimensions := []struct {
+			name               string
+			baseline, observed map[string]int
+		}{
+			{"language", baseline.Distribution.Language, observed.Language},
+			{"cwe", baseline.Distribution.CWE, observed.CWE},
+			{"project", baseline.Distribution.Project, observed.Project},
+		}
+		for _, dimension := range dimensions {
+			distance := totalVariationBasisPoints(dimension.baseline, dimension.observed)
+			if distance > baseline.MaximumTotalVariationBasisPoints {
+				report.Alerts = append(report.Alerts, AITriageDriftAlert{
+					Dimension: dimension.name, TotalVariationBasisPoints: distance,
+					ThresholdBasisPoints: baseline.MaximumTotalVariationBasisPoints, SampleSize: observed.SampleSize,
+					Message: fmt.Sprintf("%s distribution drift is %d basis points, above the approved maximum %d", dimension.name, distance, baseline.MaximumTotalVariationBasisPoints),
+				})
+			}
+		}
+		if len(report.Alerts) > 0 {
+			report.Status = "drift_detected"
+			report.ReviewRequired = true
+		}
+	}
+	report.ReportID = aiTriageDriftReportID(report)
+	return report, nil
+}
+
+func totalVariationBasisPoints(baseline, observed map[string]int) int {
+	keys := make(map[string]struct{}, len(baseline)+len(observed))
+	for key := range baseline {
+		keys[key] = struct{}{}
+	}
+	for key := range observed {
+		keys[key] = struct{}{}
+	}
+	difference := 0
+	for key := range keys {
+		delta := baseline[key] - observed[key]
+		if delta < 0 {
+			delta = -delta
+		}
+		difference += delta
+	}
+	return difference / 2
+}
+
+func aiTriageDriftReportID(report AITriageDriftReport) string {
+	report.ReportID = ""
+	data, _ := json.Marshal(report)
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}
+
+func decodeStrictJSON(data []byte, value any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(value); err != nil {
+		return err
+	}
+	return requireJSONEOF(decoder)
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("trailing JSON content")
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/usecase/sca/fptriage_drift_test.go
+++ b/internal/usecase/sca/fptriage_drift_test.go
@@ -1,0 +1,130 @@
+package sca
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDetectAITriageDistributionDriftReportsExactDistances(t *testing.T) {
+	baseline := validDriftBaseline()
+	observed := distributionSnapshot(80,
+		map[string]int{"go": 3000, "typescript": 7000},
+		map[string]int{"CWE-79": 8000, "CWE-89": 2000},
+		map[string]int{"project-a": 10_000},
+	)
+	report, err := DetectAITriageDistributionDrift(baseline, observed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Status != "drift_detected" || !report.ReviewRequired || len(report.Alerts) != 2 {
+		t.Fatalf("report = %+v", report)
+	}
+	if report.Alerts[0].Dimension != "language" || report.Alerts[0].TotalVariationBasisPoints != 3000 ||
+		report.Alerts[1].Dimension != "cwe" || report.Alerts[1].TotalVariationBasisPoints != 2000 {
+		t.Fatalf("alerts = %+v", report.Alerts)
+	}
+	again, err := DetectAITriageDistributionDrift(baseline, observed)
+	if err != nil || report.ReportID == "" || report.ReportID != again.ReportID {
+		t.Fatalf("report IDs = %q and %q, err %v", report.ReportID, again.ReportID, err)
+	}
+}
+
+func TestDetectAITriageDistributionDriftHandlesStableAndSmallSamples(t *testing.T) {
+	baseline := validDriftBaseline()
+	baseline.MaximumTotalVariationBasisPoints = 3000
+	observed := distributionSnapshot(50,
+		map[string]int{"go": 3000, "typescript": 7000},
+		map[string]int{"CWE-79": 10_000},
+		map[string]int{"project-a": 10_000},
+	)
+	report, err := DetectAITriageDistributionDrift(baseline, observed)
+	if err != nil || report.Status != "stable" || report.ReviewRequired || len(report.Alerts) != 0 {
+		t.Fatalf("stable report = %+v, err %v", report, err)
+	}
+
+	observed.SampleSize = 49
+	report, err = DetectAITriageDistributionDrift(baseline, observed)
+	if err != nil || report.Status != "insufficient_samples" || len(report.Alerts) != 1 || report.Alerts[0].Dimension != "all" {
+		t.Fatalf("small-sample report = %+v, err %v", report, err)
+	}
+}
+
+func TestAITriageDriftBaselineValidationFailsClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*AITriageDriftBaseline)
+		want   string
+	}{
+		{"machine approver", func(b *AITriageDriftBaseline) { b.ApprovedBy = "bot:baseline" }, "human actor"},
+		{"insufficient baseline", func(b *AITriageDriftBaseline) { b.MinimumSamples = 101 }, "below minimum"},
+		{"invalid total", func(b *AITriageDriftBaseline) { b.Distribution.Language["go"] = 5999 }, "sums to"},
+		{"noncanonical cwe", func(b *AITriageDriftBaseline) { b.Distribution.CWE = map[string]int{"cwe-79": 10_000} }, "not canonical"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			baseline := validDriftBaseline()
+			test.mutate(&baseline)
+			if err := baseline.Validate(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestAITriageDriftLoadersRejectAmbiguousJSON(t *testing.T) {
+	baseline := validDriftBaseline()
+	data, err := json.Marshal(baseline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadAITriageDriftBaseline(append(data, []byte(` {}`)...)); err == nil {
+		t.Fatal("baseline loader accepted trailing JSON")
+	}
+	withUnknown := append(data[:len(data)-1], []byte(`,"unexpected":true}`)...)
+	if _, err := LoadAITriageDriftBaseline(withUnknown); err == nil {
+		t.Fatal("baseline loader accepted an unknown field")
+	}
+
+	snapshotData, err := json.Marshal(map[string]any{
+		"generated_at": "2026-08-13T00:00:00Z",
+		"distribution": baseline.Distribution,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadAITriageDistributionSnapshot(snapshotData)
+	if err != nil || loaded.SampleSize != baseline.Distribution.SampleSize {
+		t.Fatalf("load dashboard snapshot = %+v, %v", loaded, err)
+	}
+	ambiguousData, err := json.Marshal(map[string]any{
+		"schema_version": "synapse-ai-triage-distribution-v1",
+		"distribution":   baseline.Distribution,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadAITriageDistributionSnapshot(ambiguousData); err == nil {
+		t.Fatal("snapshot loader accepted ambiguous direct and envelope fields")
+	}
+}
+
+func validDriftBaseline() AITriageDriftBaseline {
+	return AITriageDriftBaseline{
+		SchemaVersion: aiTriageDriftBaselineSchema,
+		Version:       "production-2026-08", Provenance: "security/review-42", ApprovedBy: "security@example.com",
+		MinimumSamples: 50, MaximumTotalVariationBasisPoints: 1000,
+		Distribution: distributionSnapshot(100,
+			map[string]int{"go": 6000, "typescript": 4000},
+			map[string]int{"CWE-79": 10_000},
+			map[string]int{"project-a": 10_000},
+		),
+	}
+}
+
+func distributionSnapshot(sampleSize int, language, cwe, project map[string]int) AITriageDistributionSnapshot {
+	return AITriageDistributionSnapshot{
+		SchemaVersion: aiTriageDistributionSchemaVersion, SampleSize: sampleSize,
+		Language: language, CWE: cwe, Project: project,
+	}
+}

--- a/internal/usecase/sca/fptriage_observability_test.go
+++ b/internal/usecase/sca/fptriage_observability_test.go
@@ -36,8 +36,9 @@ func (r dashboardEngagementRepo) List(context.Context, shared.ID) ([]*engdom.Eng
 func TestAITriageObservabilityGroupsLatestTenantResult(t *testing.T) {
 	engagement := &engdom.Engagement{ID: "e1", TenantID: shared.TenantOrDefault(""), Name: "checkout"}
 	result := ScanResult{
-		Findings: []finding.Finding{{DedupKey: "k1", CWE: "CWE-89"}},
-		AITriage: []ports.AICritique{{DedupKey: "k1", ProposerProvider: "provider", ProposerModel: "model", PromptVersion: "v1", GateExempt: true}},
+		Languages: []ports.DetectedLanguage{{Name: "Go", Percent: 75}, {Name: "TypeScript", Percent: 25}},
+		Findings:  []finding.Finding{{DedupKey: "k1", CWE: "CWE-89"}},
+		AITriage:  []ports.AICritique{{DedupKey: "k1", ProposerProvider: "provider", ProposerModel: "model", PromptVersion: "v1", GateExempt: true}},
 		AITriageTelemetry: &ports.FPTriageTelemetry{Calls: []ports.FPTriageCallMetric{{
 			DedupKey: "k1", Role: "proposer", Provider: "provider", Model: "model", PromptVersion: "v1", Outcome: "success",
 			LatencyMillis: 25, TotalTokens: 120, EstimatedCostMicroUSD: 50,
@@ -64,5 +65,51 @@ func TestAITriageObservabilityGroupsLatestTenantResult(t *testing.T) {
 	}
 	if len(dashboard.Alerts) != 1 || dashboard.Alerts[0].ProjectID != "e1" {
 		t.Fatalf("alerts = %+v", dashboard.Alerts)
+	}
+	if dashboard.Distribution.SchemaVersion != aiTriageDistributionSchemaVersion || dashboard.Distribution.SampleSize != 1 ||
+		dashboard.Distribution.Language["go"] != 7500 || dashboard.Distribution.Language["typescript"] != 2500 ||
+		dashboard.Distribution.CWE["CWE-89"] != 10_000 || dashboard.Distribution.Project["e1"] != 10_000 {
+		t.Fatalf("distribution = %+v", dashboard.Distribution)
+	}
+}
+
+func TestAITriageDistributionNormalizesDeterministically(t *testing.T) {
+	got := normalizeDistributionWeights(map[string]float64{"c": 1, "a": 1, "b": 1})
+	if got["a"] != 3334 || got["b"] != 3333 || got["c"] != 3333 {
+		t.Fatalf("normalized tie = %+v", got)
+	}
+	languages := map[string]float64{}
+	addLanguageDistributionWeights(languages, nil, 3)
+	if got := normalizeDistributionWeights(languages); got["unknown"] != 10_000 {
+		t.Fatalf("missing languages = %+v", got)
+	}
+	weighted := map[string]float64{}
+	addLanguageDistributionWeights(weighted, []ports.DetectedLanguage{{Name: "Go", Percent: 100}}, 3)
+	addLanguageDistributionWeights(weighted, []ports.DetectedLanguage{{Name: "TypeScript", Percent: 100}}, 1)
+	if got := normalizeDistributionWeights(weighted); got["go"] != 7500 || got["typescript"] != 2500 {
+		t.Fatalf("sample-weighted languages = %+v", got)
+	}
+}
+
+func TestAITriageObservabilityIncludesDistributionWithoutLegacyTelemetry(t *testing.T) {
+	engagement := &engdom.Engagement{ID: "e-without-telemetry", TenantID: shared.TenantOrDefault("")}
+	data, err := json.Marshal(ScanResult{
+		Findings: []finding.Finding{{DedupKey: "k1"}},
+		AITriage: []ports.AICritique{{DedupKey: "k1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{
+		engagements: dashboardEngagementRepo{fakeEngRepo: &fakeEngRepo{}, items: []*engdom.Engagement{engagement}},
+		results:     staticScanResultStore{data: data},
+	}
+	dashboard, err := service.AITriageObservability(context.Background(), shared.TenantOrDefault(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dashboard.Distribution.SampleSize != 1 || dashboard.Distribution.Language["unknown"] != 10_000 ||
+		dashboard.Distribution.CWE["unclassified"] != 10_000 || dashboard.Distribution.Project["e-without-telemetry"] != 10_000 {
+		t.Fatalf("distribution = %+v", dashboard.Distribution)
 	}
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -788,6 +788,13 @@ function mapAITriageObservability(r: any): AITriageObservability {
     byPromptVersion: (r?.by_prompt_version ?? []).map(mapAITriageMetricRow),
     byCWE: (r?.by_cwe ?? []).map(mapAITriageMetricRow),
     byProject: (r?.by_project ?? []).map(mapAITriageMetricRow),
+    distribution: {
+      schemaVersion: r?.distribution?.schema_version ?? 'synapse-ai-triage-distribution-v1',
+      sampleSize: r?.distribution?.sample_size ?? 0,
+      languageBasisPoints: r?.distribution?.language_basis_points ?? {},
+      cweBasisPoints: r?.distribution?.cwe_basis_points ?? {},
+      projectBasisPoints: r?.distribution?.project_basis_points ?? {},
+    },
     alerts: (r?.alerts ?? []).map((item: any) => ({
       projectId: item?.project_id ?? '', projectName: item?.project_name ?? '',
       alert: {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -423,6 +423,14 @@ export interface AITriageAlert {
   message: string
 }
 
+export interface AITriageDistributionSnapshot {
+  schemaVersion: string
+  sampleSize: number
+  languageBasisPoints: Record<string, number>
+  cweBasisPoints: Record<string, number>
+  projectBasisPoints: Record<string, number>
+}
+
 export interface AITriageObservability {
   generatedAt: string
   totals: AITriageMetricRow
@@ -430,6 +438,7 @@ export interface AITriageObservability {
   byPromptVersion: AITriageMetricRow[]
   byCWE: AITriageMetricRow[]
   byProject: AITriageMetricRow[]
+  distribution: AITriageDistributionSnapshot
   alerts: Array<{ projectId: string; projectName: string; alert: AITriageAlert }>
 }
 

--- a/web/src/pages/AITriageObservability.test.tsx
+++ b/web/src/pages/AITriageObservability.test.tsx
@@ -21,6 +21,11 @@ const dashboard: Observability = {
   byPromptVersion: [{ ...row, value: 'fp-triage-v2' }],
   byCWE: [{ ...row, value: 'CWE-89' }],
   byProject: [{ ...row, value: 'p1 · Checkout' }],
+  distribution: {
+    schemaVersion: 'synapse-ai-triage-distribution-v1', sampleSize: 4,
+    languageBasisPoints: { go: 7500, typescript: 2500 },
+    cweBasisPoints: { 'CWE-89': 10000 }, projectBasisPoints: { p1: 10000 },
+  },
   alerts: [{ projectId: 'p1', projectName: 'Checkout', alert: { metric: 'parse_failure_rate', observedBasisPoints: 2500, baselineBasisPoints: 200, deviationBasisPoints: 2300, sampleSize: 4, message: 'Parse failures exceeded baseline' } }],
 }
 
@@ -33,8 +38,10 @@ describe('AITriageObservability', () => {
     expect(screen.getByText('50.0%')).toBeInTheDocument()
     expect(screen.getByText('provider/model (proposer)')).toBeInTheDocument()
     expect(screen.getByText('fp-triage-v2')).toBeInTheDocument()
-    expect(screen.getByText('CWE-89')).toBeInTheDocument()
+    expect(screen.getAllByText('CWE-89')).toHaveLength(2)
     expect(screen.getByText('p1 · Checkout')).toBeInTheDocument()
     expect(screen.getByText('Parse failures exceeded baseline')).toBeInTheDocument()
+    expect(screen.getByText('Drift input distribution')).toBeInTheDocument()
+    expect(screen.getByText('75.00%')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/AITriageObservability.tsx
+++ b/web/src/pages/AITriageObservability.tsx
@@ -39,6 +39,14 @@ function Dashboard({ data }: { data: Observability }) {
       <Metric icon={Coins} label="Estimated cost" value={formatCost(data.totals.estimatedCostMicroUSD)} hint={`${data.totals.totalTokens.toLocaleString()} tokens`} />
     </div>
     {data.alerts.length > 0 && <Card title="Safety alerts"><ul className="divide-y divide-border">{data.alerts.map((item, index) => <li className="px-6 py-4" key={`${item.projectId}-${item.alert.metric}-${index}`}><div className="flex gap-3"><AlertTriangle className="mt-0.5 size-4 shrink-0 text-high" /><div><div className="text-sm font-medium">{item.projectName || item.projectId}</div><p className="mt-1 text-sm text-mutedfg">{item.alert.message}</p></div></div></li>)}</ul></Card>}
+    <Card title="Drift input distribution" bodyClass="p-0">
+      <div className="border-b border-border px-6 py-3 text-xs text-mutedfg">Normalized from {data.distribution.sampleSize.toLocaleString()} AI-triaged findings; export this snapshot for deterministic drift checks.</div>
+      <div className="grid divide-y divide-border lg:grid-cols-3 lg:divide-x lg:divide-y-0">
+        <DistributionList title="Language" values={data.distribution.languageBasisPoints} />
+        <DistributionList title="CWE" values={data.distribution.cweBasisPoints} />
+        <DistributionList title="Project" values={data.distribution.projectBasisPoints} />
+      </div>
+    </Card>
     <MetricTable title="By model" rows={data.byModel} />
     <div className="grid gap-5 xl:grid-cols-2"><MetricTable title="By prompt version" rows={data.byPromptVersion} /><MetricTable title="By CWE" rows={data.byCWE} /></div>
     <MetricTable title="By project" rows={data.byProject} />
@@ -51,6 +59,11 @@ function Metric({ icon: Icon, label, value, hint }: { icon: typeof Activity; lab
 
 function MetricTable({ title, rows }: { title: string; rows: AITriageMetricRow[] }) {
   return <Card title={title} bodyClass="p-0"><div className="overflow-x-auto"><table className="w-full text-left text-sm"><thead className="border-b border-border bg-elevated/40 text-xs uppercase tracking-wide text-mutedfg"><tr><th className="px-5 py-3">Dimension</th><th className="px-3 py-3 text-right">Requests</th><th className="px-3 py-3 text-right">Latency</th><th className="px-3 py-3 text-right">Failures</th><th className="px-3 py-3 text-right">Tokens</th><th className="px-3 py-3 text-right">Cost</th><th className="px-5 py-3 text-right">Exemptions</th></tr></thead><tbody className="divide-y divide-border">{rows.map((row) => <tr key={row.value}><td className="max-w-xs truncate px-5 py-3 font-medium" title={row.value}>{row.value}</td><td className="px-3 py-3 text-right tabular-nums">{row.requestCount}</td><td className="px-3 py-3 text-right tabular-nums">{row.averageLatencyMillis} ms</td><td className="px-3 py-3 text-right tabular-nums">{row.timeoutCount + row.parseFailureCount + row.providerFailureCount + row.circuitOpenCount}</td><td className="px-3 py-3 text-right tabular-nums">{row.totalTokens.toLocaleString()}</td><td className="px-3 py-3 text-right tabular-nums">{formatCost(row.estimatedCostMicroUSD)}</td><td className="px-5 py-3 text-right tabular-nums">{row.gateExemptions}</td></tr>)}</tbody></table></div></Card>
+}
+
+function DistributionList({ title, values }: { title: string; values: Record<string, number> }) {
+  const rows = Object.entries(values).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).slice(0, 8)
+  return <section className="p-5"><h3 className="text-xs font-semibold uppercase tracking-wide text-mutedfg">{title}</h3><ul className="mt-3 space-y-2">{rows.map(([value, basisPoints]) => <li className="flex items-center justify-between gap-3 text-sm" key={value}><span className="truncate font-medium" title={value}>{value}</span><span className="tabular-nums text-mutedfg">{(basisPoints / 100).toFixed(2)}%</span></li>)}</ul></section>
 }
 
 function rate(numerator: number, denominator: number) { return denominator > 0 ? `${(numerator * 100 / denominator).toFixed(1)}%` : '—' }


### PR DESCRIPTION
## Summary

- add a deterministic AI-triage population snapshot to tenant observability, normalized to 10,000 basis points by language, CWE, and project
- add `synapse-fptriage-drift` to compare a saved observability response with a versioned, human-approved baseline using total-variation distance
- surface the drift input distribution in the observability UI and document the API/CLI workflow

## Safety and behavior

- uses only the latest evidence-sealed result for each tenant-visible project and exports no source or prompt content
- treats missing language/CWE metadata explicitly as `unknown` / `unclassified`
- strictly validates baseline schema, canonical distributions, exact basis-point totals, minimum samples, and human approval provenance; reserved machine actors fail closed
- produces deterministic report IDs and writes the report before returning a non-zero drift or insufficient-sample alert
- has no authority to promote a model, change a prompt, suppress a finding, or alter the quality gate

This complements #554 while remaining independently mergeable: #554 covers candidate-vs-baseline promotion evidence, while this PR covers the language/CWE/project drift acceptance criterion.

## Verification

- `go test ./...`
- `go vet ./...`
- `go build ./cmd/...`
- `pnpm test` (298 tests)
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`

Advances #396