### PR TITLE
feat(correlation): gate cross-pillar promotions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ capabilities below are already shipped on `main`.
 
 - **AI-triage candidate promotion gate.** Strictly revalidates deterministic shadow reports, compares a candidate model/prompt with a baseline on the exact same reviewed dataset and policy, blocks new true-positive escapes plus overall or segment regressions, and emits stable CI evidence that still requires explicit human promotion approval.
 
+- **Judgment-gated cross-pillar promotion.** Correlates deterministic reachability, confident internet-facing attack paths, and active same-path runtime detections into tenant-scoped priority proposals. Distinct sealed verification applies one-level changes, uncertain inputs remain review-only, and signal loss restores the exact prior priority through an append-only, auditable lifecycle.
+
 - **AI-triage input drift evidence.** The tenant observability API and UI now expose deterministic,
   source-free language/CWE/project distributions. A new offline CLI compares them with a versioned,
   human-approved baseline using total-variation distance, writes stable CI evidence, and alerts on

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -140,6 +140,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
+	promotionuc "github.com/KKloudTarus/synapse-ce/internal/usecase/promotion"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/pyreach"
 	qualitygatesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/qualitygates"
 	qualityprofilesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/qualityprofiles"
@@ -176,6 +177,22 @@ func requireJudgmentsOrSkip(log *slog.Logger, hasJudgment bool, envKey, name str
 	}
 	log.Warn(name + " auto-skipped: SYNAPSE_JUDGMENTS_ENABLED is off (it mints judgments)")
 	return false
+}
+
+func migrationDSNForStartup(cfg config.Config) (string, error) {
+	migrationDSN := cfg.DBMigrationDSN
+	if migrationDSN == "" {
+		if cfg.IsProduction() {
+			return "", fmt.Errorf("SYNAPSE_DB_MIGRATION_DSN is required with SYNAPSE_DB_DSN outside development")
+		}
+		return cfg.DBDSN, nil
+	}
+	if cfg.IsProduction() {
+		if err := postgres.ValidateMigrationRoleSeparation(migrationDSN, cfg.DBDSN); err != nil {
+			return "", fmt.Errorf("validate migration and runtime database roles: %w", err)
+		}
+	}
+	return migrationDSN, nil
 }
 
 func main() {
@@ -226,6 +243,7 @@ func main() {
 	var importedSBOMStore ports.ImportedSBOMStore
 	var importedFindingStore ports.ImportedFindingStore // third-party (SARIF) findings under governance
 	var detectionRecordStore ports.DetectionRecordStore // #423 detection ledger projection
+	var promotionStore ports.PendingPromotionAuditStore
 	var scanJobStore ports.ScanJobStore
 	var scanRunStore ports.ScanRunStore
 	var projectAnalysisStore ports.ProjectAnalysisStore
@@ -240,7 +258,7 @@ func main() {
 	var threatModelStore ports.ThreatModelStore   // per-engagement architecture threat model (tenant-scoped)
 	var writeupDraftStore ports.WriteupDraftStore // AI-proposed, human-gated finding write-up drafts
 	var aupStore ports.AUPStore
-	var auditLog ports.AuditLogger
+	var auditLog ports.IdempotentAuditLogger
 	var timestampStore ports.TimestampStore
 	var credVault ports.CredentialVault
 	var reconQueue ports.JobQueue                 // durable queue for recon-via-worker (Postgres only)
@@ -290,9 +308,20 @@ func main() {
 		// until multi-replica horizontal scaling lands (P5).
 		startup, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
-		if err := postgres.Migrate(startup, cfg.DBDSN); err != nil {
+		migrationDSN, err := migrationDSNForStartup(cfg)
+		if err != nil {
+			log.Error("database migration configuration invalid", "err", err)
+			os.Exit(1)
+		}
+		if err := postgres.Migrate(startup, migrationDSN); err != nil {
 			log.Error("db migrate failed", "err", err)
 			os.Exit(1)
+		}
+		if migrationDSN != cfg.DBDSN {
+			if err := postgres.GrantRuntimePrivileges(startup, migrationDSN, cfg.DBDSN); err != nil {
+				log.Error("db runtime role grant failed", "err", err)
+				os.Exit(1)
+			}
 		}
 		pool, err := postgres.ConnectPool(startup, cfg.DBDSN, postgres.PoolConfig{
 			MaxConns: int32(cfg.DBMaxConns), MinConns: int32(cfg.DBMinConns),
@@ -331,6 +360,11 @@ func main() {
 		importedSBOMStore = postgres.NewImportedSBOMStore(pool)
 		importedFindingStore = postgres.NewImportedFindingRepository(pool)
 		detectionRecordStore = postgres.NewDetectionRecordRepository(pool)
+		promotionStore, err = postgres.NewPromotionStore(pool)
+		if err != nil {
+			log.Error("postgres promotion store init failed", "err", err)
+			os.Exit(1)
+		}
 		scanJobStore = postgres.NewScanJobStore(pool)
 		scanRunStore = postgres.NewScanRunStore(pool)
 		projectAnalysisStore = postgres.NewProjectAnalysisStore(pool)
@@ -398,6 +432,22 @@ func main() {
 		importedSBOMStore = memory.NewImportedSBOMStore()
 		importedFindingStore = memory.NewImportedFindingStore()
 		detectionRecordStore = memory.NewDetectionRecordStore()
+		memoryFindings, ok := findingRepo.(*memory.FindingRepository)
+		if !ok {
+			log.Error("memory finding repository type mismatch")
+			os.Exit(1)
+		}
+		memoryEngagements, ok := repo.(*memory.EngagementRepository)
+		if !ok {
+			log.Error("memory engagement repository type mismatch")
+			os.Exit(1)
+		}
+		var promotionErr error
+		promotionStore, promotionErr = memory.NewPromotionStore(memoryFindings, memoryEngagements)
+		if promotionErr != nil {
+			log.Error("memory promotion store init failed", "err", promotionErr)
+			os.Exit(1)
+		}
 		scanJobStore = memory.NewScanJobStore()
 		scanRunStore = memory.NewScanRunStore()
 		projectAnalysisStore = memory.NewProjectAnalysisStore()
@@ -1093,8 +1143,10 @@ func main() {
 	} else {
 		router.SetThreatModel(tmSvc)
 	}
-	var judgmentSvc *analysisuc.Service // shared by the HTTP verify/accept routes + the agent propose tool
-	if cfg.JudgmentsEnabled {           // AI judgment lifecycle (verify/accept/list); off by default
+	var judgmentSvc *analysisuc.Service                   // shared by the HTTP verify/accept routes + the agent propose tool
+	var promotionEval *promotionuc.Evaluator              // optional source-signal reevaluator; proposes only
+	var promotionRunner *promotionuc.ReconciliationRunner // server-only promotion recovery
+	if cfg.JudgmentsEnabled {                             // AI judgment lifecycle (verify/accept/list); off by default
 		svc, aerr := analysisuc.NewService(judgmentStore, evidenceService, auditLog, clock, ids)
 		if aerr != nil {
 			log.Error("analysis (judgment) service init failed", "err", aerr)
@@ -1104,6 +1156,48 @@ func main() {
 		judgmentSvc.SetThreatRecorder(findingsService) // a ratified threat auto-emits a Kind=threat finding
 		judgmentSvc.SetSASTRecorder(findingsService)   // a confirmed CapSAST (taint) judgment auto-emits a Kind=sast finding
 		judgmentSvc.SetDASTRecorder(findingsService)   // a RUNTIME-confirmed CapSAST judgment auto-emits a Kind=dast finding (via VerifyRuntime)
+		promotionRecorder, perr := promotionuc.NewConfirmedRecorder(evidenceService, promotionStore, findingRepo, repo, auditLog, clock)
+		if perr != nil {
+			log.Error("promotion recorder init failed", "err", perr)
+			os.Exit(1)
+		}
+		judgmentSvc.SetPromotionRecorder(promotionRecorder)
+		promotionReconciler, perr := promotionuc.NewReconciler(judgmentStore, promotionStore, promotionRecorder, auditLog, clock)
+		if perr != nil {
+			log.Error("promotion reconciler init failed", "err", perr)
+			os.Exit(1)
+		}
+		proposalAudit, ok := auditLog.(ports.IdempotentAuditLogger)
+		if !ok {
+			log.Error("promotion evaluator requires an idempotent audit logger")
+			os.Exit(1)
+		}
+		promotionEval, perr = promotionuc.NewEvaluator(judgmentSvc, findingRepo, judgmentStore, attackPathStore, assetStore, detectionRecordStore, repo, promotionStore, clock, proposalAudit)
+		if perr != nil {
+			log.Error("promotion evaluator init failed", "err", perr)
+			os.Exit(1)
+		}
+		promotionScopes, ok := repo.(ports.PromotionReconciliationScopeReader)
+		if !ok {
+			log.Error("promotion reconciliation scope reader is not configured")
+			os.Exit(1)
+		}
+		promotionRunner, perr = promotionuc.NewReconciliationRunner(promotionScopes, promotionEval, promotionReconciler, log)
+		if perr != nil {
+			log.Error("promotion reconciliation runner init failed", "err", perr)
+			os.Exit(1)
+		}
+		judgmentAuditStore, ok := judgmentStore.(ports.JudgmentAuditStore)
+		if !ok {
+			log.Error("judgment audit outbox is not configured")
+			os.Exit(1)
+		}
+		governanceReconciler, gerr := analysisuc.NewGovernanceReconciler(judgmentAuditStore, auditLog)
+		if gerr != nil {
+			log.Error("judgment governance reconciler init failed", "err", gerr)
+			os.Exit(1)
+		}
+		promotionRunner.SetGovernanceReconciler(governanceReconciler)
 		router.SetJudgments(judgmentSvc)
 		// Automated LLM judgment-verifier: when SYNAPSE_VERIFIER_MODEL names a model DIFFERENT from the
 		// agent's model, a distinct verifier independently scores each proposed gated judgment and seals a
@@ -1623,6 +1717,18 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	if promotionRunner != nil {
+		startupTimeout := cfg.PromotionReconcileInterval
+		if startupTimeout <= 0 {
+			startupTimeout = time.Minute
+		}
+		startupCtx, cancelPromotionStartup := context.WithTimeout(ctx, startupTimeout)
+		if err := promotionRunner.RunOnce(startupCtx); err != nil && startupCtx.Err() == nil {
+			log.Warn("promotion reconciliation startup run failed", "err", err)
+		}
+		cancelPromotionStartup()
+		go promotionRunner.RunPeriodic(ctx, cfg.PromotionReconcileInterval)
+	}
 	go approvalSvc.RunSweeper(ctx, cfg.ApprovalSweepInterval) // fail-closed HITL approval timeouts for agent + DAST
 
 	// AI agent orchestration. Off unless SYNAPSE_AGENT_ENABLED.

--- a/cmd/synapse-api/main_test.go
+++ b/cmd/synapse-api/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
+)
+
+func TestMigrationDSNForStartup(t *testing.T) {
+	devDSN := "postgres://synapse_app:runtime-secret@localhost/synapse?sslmode=disable"
+	ownerDSN := "postgres://synapse_owner:owner-secret@localhost/synapse?sslmode=disable"
+
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want string
+		fail bool
+	}{
+		{
+			name: "development falls back to runtime DSN",
+			cfg:  config.Config{Environment: "development", DBDSN: devDSN},
+			want: devDSN,
+		},
+		{
+			name: "production requires migration DSN",
+			cfg:  config.Config{Environment: "production", DBDSN: devDSN},
+			fail: true,
+		},
+		{
+			name: "production accepts distinct migration role",
+			cfg:  config.Config{Environment: "production", DBDSN: devDSN, DBMigrationDSN: ownerDSN},
+			want: ownerDSN,
+		},
+		{
+			name: "production rejects same migration role",
+			cfg:  config.Config{Environment: "production", DBDSN: devDSN, DBMigrationDSN: "postgres://synapse_app:owner-secret@localhost/synapse?application_name=migrate&sslmode=require"},
+			fail: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := migrationDSNForStartup(tt.cfg)
+			if (err != nil) != tt.fail {
+				t.Fatalf("migrationDSNForStartup() error = %v, fail %t", err, tt.fail)
+			}
+			if got != tt.want {
+				t.Fatalf("migrationDSNForStartup() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/docker-compose.full.yml
+++ b/deploy/docker-compose.full.yml
@@ -14,25 +14,47 @@
 # recon + the API-server Maven/Gradle resolvers require a Linux host with bubblewrap (+ CAP_NET_ADMIN for
 # egress scoping) and a privileged/user-ns container; that's a separate hardened deployment.
 #
-# Credentials below are LOCAL-DEV defaults, overridable via the shell / an .env file next to this compose
-# (DB_USER, DB_PASSWORD, BLOB_USER, BLOB_PASSWORD, SYNAPSE_API_TOKEN, …). Change them for anything but dev.
+# Credentials below use local-dev defaults where safe. Set DB_ADMIN_PASSWORD and DB_APP_PASSWORD
+# via the shell or an .env file next to this compose; the admin owns migrations and the API
+# connects as a non-superuser app role.
 
 services:
   postgres:
     image: postgres:17-alpine
     environment:
-      POSTGRES_USER: "${DB_USER:-synapse}"
-      POSTGRES_PASSWORD: "${DB_PASSWORD:-synapse}"
+      POSTGRES_USER: "${DB_ADMIN_USER:-synapse_admin}"
+      POSTGRES_PASSWORD: "${DB_ADMIN_PASSWORD:?DB_ADMIN_PASSWORD must be set (for example, in .env)}"
       POSTGRES_DB: "${DB_NAME:-synapse}"
     ports:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-synapse}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_ADMIN_USER:-synapse_admin}"]
       interval: 5s
       timeout: 5s
       retries: 10
+
+  postgres-init:
+    image: postgres:17-alpine
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: "${DB_ADMIN_PASSWORD:?DB_ADMIN_PASSWORD must be set (for example, in .env)}"
+      DB_APP_PASSWORD: "${DB_APP_PASSWORD:?DB_APP_PASSWORD must be set (for example, in .env)}"
+    entrypoint:
+      - sh
+      - -ec
+      - |
+        psql -h postgres -U "${DB_ADMIN_USER:-synapse_admin}" -d "${DB_NAME:-synapse}" -v ON_ERROR_STOP=1 \
+          -v app_role="${DB_APP_USER:-synapse_app}" <<'SQL'
+        \getenv app_password DB_APP_PASSWORD
+        SELECT format('CREATE ROLE %I LOGIN NOSUPERUSER NOBYPASSRLS PASSWORD %L', :'app_role', :'app_password')
+        WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'app_role')
+        \gexec
+        ALTER ROLE :"app_role" NOSUPERUSER NOBYPASSRLS;
+        SQL
 
   minio:
     image: minio/minio:latest
@@ -76,8 +98,8 @@ services:
     depends_on:
       project-source-artifacts-init:
         condition: service_completed_successfully
-      postgres:
-        condition: service_healthy
+      postgres-init:
+        condition: service_completed_successfully
       minio-init:
         condition: service_completed_successfully
     build:
@@ -104,9 +126,10 @@ services:
       SYNAPSE_SINGLE_TENANT: "true"
 
       # --- persistence + evidence blob store ---
-      # DSN scheme is a var so no literal "scheme://user:pass@" is committed (secret-scan clean). pgx
-      # accepts the assembled URL; override any part via the shell / an .env file.
-      SYNAPSE_DB_DSN: "${DB_SCHEME:-postgres}://${DB_USER:-synapse}:${DB_PASSWORD:-synapse}@${DB_HOST:-postgres}:5432/${DB_NAME:-synapse}?sslmode=disable"
+      # Supply complete DSNs so passwords containing URL-reserved characters remain valid.
+      # The API uses the runtime role; migrations use the distinct DDL-owner role.
+      SYNAPSE_DB_DSN: "${SYNAPSE_DB_DSN:?SYNAPSE_DB_DSN must be set (for example, in .env)}"
+      SYNAPSE_DB_MIGRATION_DSN: "${SYNAPSE_DB_MIGRATION_DSN:?SYNAPSE_DB_MIGRATION_DSN must be set (for example, in .env)}"
       SYNAPSE_BLOB_ENDPOINT: "minio:9000"
       SYNAPSE_BLOB_ACCESS_KEY: "${BLOB_USER:-synapse}"
       SYNAPSE_BLOB_SECRET_KEY: "${BLOB_PASSWORD:-synapse-secret}"

--- a/docs/architecture/promotion-rules.md
+++ b/docs/architecture/promotion-rules.md
@@ -1,0 +1,76 @@
+# Promotion Rules
+
+Promotion rules are deterministic, pure-domain policies that propose finding-priority changes
+based on cross-pillar signals. They never mutate state directly; a distinct verifier must
+confirm the proposal through the judgment gate.
+
+## Rule catalogue
+
+### promotion.escalate.runtime_reachable_exposed
+
+- **Inputs**: publishable reachable judgment, confident internet-exposure path, active detection on a path asset
+- **Effect**: escalate (one level toward P1)
+- **Confidence**: all inputs confirmed or observed
+- **Reversal**: signal loss proposes de-escalation
+
+### promotion.deescalate.deterministic_unreachable
+
+- **Inputs**: publishable deterministic not-reachable judgment
+- **Effect**: de-escalate (one level toward P5)
+- **Confidence**: deterministic proof
+- **Reversal**: a later reachable proof is reevaluated
+
+### promotion.deescalate.corroborating_signal_loss
+
+- **Inputs**: prior applied escalation plus lost or superseded corroborating input
+- **Effect**: de-escalate (restores the exact prior priority from the applied escalation event)
+- **Confidence**: deterministic signal loss
+- **Reversal**: restores the prior escalation's before priority
+
+### promotion.review.uncertain_corroboration
+
+- **Inputs**: plausible runtime corroboration with inferred path or unknown reachability
+- **Effect**: flag_for_review (no priority change)
+- **Confidence**: uncertain
+- **Reversal**: reevaluated when inputs become certain
+
+## Priority boundaries
+
+- Priorities are integers in the range 1..5 (P1 = highest, P5 = lowest).
+- Escalation moves exactly one level toward P1. P1 cannot escalate.
+- De-escalation moves toward P5. Normal de-escalation (deterministic unreachable) moves
+  exactly one level. Signal-loss reversal restores the exact `BeforePriority` recorded in the
+  prior escalation event, which may span multiple levels.
+- P5 cannot de-escalate.
+- `flag_for_review` never changes priority.
+
+## Uncertainty
+
+Any uncertainty token in a proposal forces the effect to `flag_for_review`. Confident
+escalation or de-escalation requires all inputs to be fully confirmed or observed. Known
+uncertainty tokens:
+
+- `inferred_edge`: the attack path contains inferred (not confirmed) edges.
+- `unknown_reachability`: the reachability judgment is not publishable or is `unknown`.
+
+## Input ordering
+
+Inputs are sorted by kind, then by ID, then by evidence ID. The sort is deterministic and
+produces stable fingerprints for idempotent reevaluation.
+
+## Fingerprint
+
+The fingerprint is a SHA-256 digest of the complete normalized input state: finding ID, rule
+key, sorted inputs, proposed effect, sorted uncertainty tokens, finding version, and
+before/after priority. Two evaluations with identical state produce the same fingerprint,
+enabling the service layer to skip unchanged proposals.
+
+## Evaluation precedence
+
+The `Evaluate` function returns at most one claim per snapshot, evaluated in this order:
+
+1. Deterministic unreachability (highest precedence when publishable and deterministic).
+2. Signal-loss reversal (when a prior escalation exists and its inputs are no longer active).
+3. Runtime reachable exposed (when all corroboration signals are present and confident).
+4. Uncertain corroboration (when signals are present but confidence is incomplete).
+5. No claim (when no rule matches).

--- a/internal/adapter/httpapi/evidence_handler_test.go
+++ b/internal/adapter/httpapi/evidence_handler_test.go
@@ -39,6 +39,17 @@ func (s *evStoreFake) Head(_ context.Context, id shared.ID) (string, error) {
 	return c[len(c)-1].Hash, nil
 }
 
+func (s *evStoreFake) LookupSealedForFinding(_ context.Context, engagementID, findingID shared.ID, kind string) (evdom.Evidence, bool, error) {
+	chain := s.items[engagementID]
+	for i := len(chain) - 1; i >= 0; i-- {
+		e := chain[i]
+		if e.FindingID == findingID && e.Kind == kind {
+			return e, true, nil
+		}
+	}
+	return evdom.Evidence{}, false, nil
+}
+
 type blobFake struct{ m map[string][]byte }
 
 func newBlobFake() *blobFake                                        { return &blobFake{m: map[string][]byte{}} }

--- a/internal/adapter/httpapi/finding_handler_test.go
+++ b/internal/adapter/httpapi/finding_handler_test.go
@@ -70,6 +70,13 @@ func (r *findRepoFake) SetAssignee(_ context.Context, eng, id shared.ID, a strin
 	r.byID[id] = f
 	return f, nil
 }
+func (r *findRepoFake) GetByEngagementAndID(_ context.Context, eng, id shared.ID) (finding.Finding, error) {
+	f, ok := r.byID[id]
+	if !ok || f.EngagementID != eng {
+		return finding.Finding{}, fmt.Errorf("finding %s: %w", id, shared.ErrNotFound)
+	}
+	return f, nil
+}
 
 type commentRepoFake struct{ added []finding.Comment }
 

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -25,14 +25,18 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/threatmodel"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/writeupdraft"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	attackpathuc "github.com/KKloudTarus/synapse-ce/internal/usecase/attackpath"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
 	dastverifieruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastverifier"
 	dastworkflowuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastworkflow"
 	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetrolloutuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
+	promotionuc "github.com/KKloudTarus/synapse-ce/internal/usecase/promotion"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/sarifingest"
 	usersuc "github.com/KKloudTarus/synapse-ce/internal/usecase/users"
@@ -41,7 +45,32 @@ import (
 // fakeJudgments is a no-op judgmentService for the harness – every judgment assertion below is a
 // DENY (403/404) rejected by authz/withEngTenant before any method runs, except the readonly LIST
 // allow which returns an empty set.
+func mustPromotionStore(t *testing.T, findings *memory.FindingRepository, engagements ports.EngagementOwnershipReader) ports.PendingPromotionAuditStore {
+	t.Helper()
+	store, err := memory.NewPromotionStore(findings, engagements)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
 type fakeJudgments struct{}
+
+type harnessAudit struct{ entries []ports.AuditEntry }
+
+func (a *harnessAudit) Record(ctx context.Context, e ports.AuditEntry) error {
+	return a.RecordOnce(ctx, e)
+}
+
+func (a *harnessAudit) RecordOnce(_ context.Context, e ports.AuditEntry) error {
+	for _, existing := range a.entries {
+		if e.Metadata["idempotency_key"] != "" && existing.Metadata["idempotency_key"] == e.Metadata["idempotency_key"] {
+			return nil
+		}
+	}
+	a.entries = append(a.entries, e)
+	return nil
+}
 
 func (fakeJudgments) List(context.Context, shared.ID) ([]judgment.Judgment, error) { return nil, nil }
 func (fakeJudgments) Verify(context.Context, string, shared.ID, shared.ID, int, string, int) (judgment.Judgment, error) {
@@ -225,6 +254,18 @@ func (fakeRules) Get(context.Context, rule.Key) (rule.Rule, error)        { retu
 // assertions are the denials.
 func TestHostileHarness(t *testing.T) {
 	engRepo := memory.NewEngagementRepository()
+	promotionFindings := memory.NewFindingRepository()
+	promotionJudgments := memory.NewJudgmentStore()
+	promotionEvents := mustPromotionStore(t, promotionFindings, engRepo)
+	audit := &harnessAudit{}
+	promotionEvidence, err := evidenceuc.NewService(memory.NewEvidenceStore(), nil, audit, fixedClock{t: time.Unix(1, 0)}, engIDs{})
+	if err != nil {
+		t.Fatalf("promotion evidence service: %v", err)
+	}
+	promotionAnalysis, err := analysisuc.NewService(promotionJudgments, promotionEvidence, audit, fixedClock{t: time.Unix(1, 0)}, engIDs{})
+	if err != nil {
+		t.Fatalf("promotion analysis service: %v", err)
+	}
 	if err := engRepo.Create(context.Background(), &engdom.Engagement{
 		ID: "engA", TenantID: "tenantA", Name: "A", Client: "A", Status: engdom.StatusActive,
 	}); err != nil {
@@ -234,6 +275,26 @@ func TestHostileHarness(t *testing.T) {
 		ID: "engB", TenantID: "tenantB", Name: "B", Client: "B", Status: engdom.StatusActive,
 	}); err != nil {
 		t.Fatalf("seed engagement B: %v", err)
+	}
+	promotionCtx := shared.WithTenant(context.Background(), "tenantA")
+	promotionFinding := finding.Finding{
+		ID: "promotion-finding-A", EngagementID: "engA", Title: "promotion marker", Kind: finding.KindSCA,
+		Priority: 3, Version: 1, DedupKey: "promotion-finding-A", Audit: shared.Audit{CreatedAt: time.Unix(1, 0), UpdatedAt: time.Unix(1, 0)},
+	}
+	if err := promotionFindings.Upsert(promotionCtx, []finding.Finding{promotionFinding}); err != nil {
+		t.Fatalf("seed promotion finding: %v", err)
+	}
+	promotionRecorder, err := promotionuc.NewConfirmedRecorder(promotionEvidence, promotionEvents, promotionFindings, engRepo, audit, fixedClock{t: time.Unix(1, 0)})
+	if err != nil {
+		t.Fatalf("promotion recorder: %v", err)
+	}
+	promotionAnalysis.SetPromotionRecorder(promotionRecorder)
+	if _, err := promotionAnalysis.Propose(promotionCtx, "system:promotion", "engA", judgment.CapPromotion, judgment.SubjectFinding, promotionFinding.ID, judgment.PromotionClaim{
+		FindingID: promotionFinding.ID, Rule: judgment.RuleRuntimeReachableExposed, Proposed: judgment.PromotionEscalate,
+		Inputs:      []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reachability-A"}},
+		Fingerprint: strings.Repeat("a", 64), FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+	}); err != nil {
+		t.Fatalf("seed promotion claim: %v", err)
 	}
 	attackAssets := memory.NewAssetStore()
 	attackBindings := memory.NewAttackPathStore()
@@ -292,7 +353,7 @@ func TestHostileHarness(t *testing.T) {
 	// PermReview approval-decide (needs a non-nil agent – nil deps are fine because every assertion
 	// below on these routes is a DENY that authz/withEngTenant reject before any handler runs).
 	rt.SetExploitation(&fakeVerifier{})
-	rt.SetJudgments(&fakeJudgments{}) // register the judgment sign-off routes so the harness guards their SoD gates
+	rt.SetJudgments(promotionAnalysis) // real judgment/promotion lifecycle for hostile verification coverage
 	rt.SetRuntimeVerifier(&fakeRuntimeVerifier{})
 	rt.SetDASTWorkflow(&fakeDASTWorkflow{})
 	rt.SetThreatModel(&fakeThreatModel{})     // register the threat-model ingest/read routes so the harness guards their gates
@@ -317,6 +378,50 @@ func TestHostileHarness(t *testing.T) {
 		rec := httptest.NewRecorder()
 		mux.ServeHTTP(rec, req)
 		return rec.Code, rec.Body.String()
+	}
+
+	verifyPromotion := func(role, tenant string) (int, string) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/engagements/engA/judgments/eng-1/verify", strings.NewReader(`{"score":75,"rationale":"hostile verification","version":1}`))
+		req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "p", Role: role, TenantID: tenant}))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec.Code, rec.Body.String()
+	}
+	assertPromotionUnchanged := func() {
+		current, err := promotionFindings.GetByEngagementAndID(promotionCtx, "engA", promotionFinding.ID)
+		if err != nil {
+			t.Fatalf("load promotion finding: %v", err)
+		}
+		if current.Priority != promotionFinding.Priority || current.Version != promotionFinding.Version {
+			t.Fatalf("hostile verification mutated promotion finding: priority/version=%d/%d, want %d/%d", current.Priority, current.Version, promotionFinding.Priority, promotionFinding.Version)
+		}
+		events, err := promotionEvents.ListByFinding(promotionCtx, "engA", promotionFinding.ID)
+		if err != nil {
+			t.Fatalf("list tenantA promotion events: %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("hostile verification created %d tenantA promotion events", len(events))
+		}
+	}
+	for _, role := range []string{"agent", "mcp"} {
+		if code, body := verifyPromotion(role, "tenantA"); code != http.StatusForbidden {
+			t.Errorf("machine role %q promotion verification = %d, body=%s, want 403", role, code, body)
+		}
+		assertPromotionUnchanged()
+	}
+	if code, body := verifyPromotion("reviewer", "tenantB"); code != http.StatusNotFound {
+		t.Errorf("tenantB reviewer promotion verification = %d, body=%s, want 404", code, body)
+	}
+	assertPromotionUnchanged()
+	if code, body := send("reviewer", "tenantB", http.MethodGet, "/api/v1/engagements/engA/judgments", true); code != http.StatusNotFound || strings.Contains(body, promotionFinding.ID.String()) {
+		t.Errorf("tenantB observed tenantA promotion lifecycle: code=%d body=%s", code, body)
+	}
+	tenantBEvents, err := promotionEvents.ListByFinding(shared.WithTenant(context.Background(), "tenantB"), "engA", promotionFinding.ID)
+	if err != nil {
+		t.Fatalf("list tenantB promotion events: %v", err)
+	}
+	if len(tenantBEvents) != 0 {
+		t.Fatalf("tenantB observed %d tenantA promotion events", len(tenantBEvents))
 	}
 
 	cases := []struct {

--- a/internal/domain/judgment/claim.go
+++ b/internal/domain/judgment/claim.go
@@ -18,6 +18,8 @@ import (
 // no LLM prose reaches a deliverable).
 var driverRE = regexp.MustCompile(`^[a-z][a-z0-9_]*((<=|>=|==|!=|<|>)[0-9]+(\.[0-9]+)?)?$`)
 var fingerprintRE = regexp.MustCompile(`^[a-z][a-z0-9_]{0,31}$|^[a-z][a-z0-9_]{0,15}_[a-f0-9]{64}$`)
+var promotionRuleKeyRE = regexp.MustCompile(`^promotion\.[a-z][a-z0-9_.]*$`)
+var promotionFingerprintRE = regexp.MustCompile(`^[a-f0-9]{64}$`)
 
 // These fields can be proposed by an LLM before a verifier reviews the claim. Keep their wire
 // representation bounded and token-shaped at the domain seam so model prose/control characters
@@ -26,6 +28,68 @@ var (
 	cweRE      = regexp.MustCompile(`^CWE-[0-9]{1,9}$`)
 	sastRuleRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/-]*$`)
 )
+
+// Stable promotion rule identifiers. These constants are the canonical source of truth; the
+// promotion catalog in internal/domain/promotion reuses them to avoid duplicated string
+// vocabularies across domain packages.
+const (
+	RuleRuntimeReachableExposed  = "promotion.escalate.runtime_reachable_exposed"
+	RuleDeterministicUnreachable = "promotion.deescalate.deterministic_unreachable"
+	RuleUncertainCorroboration   = "promotion.review.uncertain_corroboration"
+	RuleCorroboratingSignalLoss  = "promotion.deescalate.corroborating_signal_loss"
+)
+
+// ExpectedEffect returns the PromotionChange that the given rule is allowed to produce.
+// Unknown rules are rejected so claims cannot introduce new promotion behavior.
+func ExpectedEffect(rule string) (PromotionChange, bool) {
+	switch rule {
+	case RuleRuntimeReachableExposed:
+		return PromotionEscalate, true
+	case RuleDeterministicUnreachable, RuleCorroboratingSignalLoss:
+		return PromotionDeescalate, true
+	case RuleUncertainCorroboration:
+		return PromotionFlagForReview, true
+	default:
+		return "", false
+	}
+}
+
+// Reserved deterministic reachability proof identities. These are domain provenance
+// vocabulary; use cases may mint claims with them but cannot define new proof engines.
+const (
+	ProofActorCallgraphScan    = "system:callgraph-scan"
+	ProofActorCallgraphEngine  = "system:callgraph-engine"
+	ProofActorJSSymbolScan     = "system:jssymbol-scan"
+	ProofActorJSSymbolEngine   = "system:jssymbol-engine"
+	ProofActorJSImportScan     = "system:jsimport-scan"
+	ProofActorJSImportEngine   = "system:jsimport-engine"
+	ProofActorPyImportScan     = "system:pyimport-scan"
+	ProofActorPyImportEngine   = "system:pyimport-engine"
+	ProofActorRustImportScan   = "system:rustimport-scan"
+	ProofActorRustImportEngine = "system:rustimport-engine"
+	ProofActorPHPImportScan    = "system:phpimport-scan"
+	ProofActorPHPImportEngine  = "system:phpimport-engine"
+	ProofActorRubyImportScan   = "system:rubyimport-scan"
+	ProofActorRubyImportEngine = "system:rubyimport-engine"
+)
+
+// IsDeterministicReachabilityProof reports whether the distinct reserved identities
+// prove the supplied reachability tier. Unknown identities fail closed.
+func IsDeterministicReachabilityProof(tier ReachabilityTier, proposer, verifier string) bool {
+	switch tier {
+	case Tier2:
+		return (proposer == ProofActorCallgraphScan && verifier == ProofActorCallgraphEngine) ||
+			(proposer == ProofActorJSSymbolScan && verifier == ProofActorJSSymbolEngine)
+	case Tier1:
+		return (proposer == ProofActorJSImportScan && verifier == ProofActorJSImportEngine) ||
+			(proposer == ProofActorPyImportScan && verifier == ProofActorPyImportEngine) ||
+			(proposer == ProofActorRustImportScan && verifier == ProofActorRustImportEngine) ||
+			(proposer == ProofActorPHPImportScan && verifier == ProofActorPHPImportEngine) ||
+			(proposer == ProofActorRubyImportScan && verifier == ProofActorRubyImportEngine)
+	default:
+		return false
+	}
+}
 
 // maxClaimPathElems / maxClaimPathElemLen bound a reachability claim's call/dependency path so a
 // hostile or runaway proposer (agent or HTTP) cannot seal an unbounded path into the evidence ledger
@@ -358,13 +422,149 @@ func (c CorrelationClaim) Validate() error {
 	return nil
 }
 
+// PromotionChange is the closed set of finding-priority effects a cross-pillar rule may propose.
+type PromotionChange string
+
+const (
+	PromotionEscalate      PromotionChange = "escalate"
+	PromotionDeescalate    PromotionChange = "de_escalate"
+	PromotionFlagForReview PromotionChange = "flag_for_review"
+)
+
+func (c PromotionChange) Valid() bool {
+	return c == PromotionEscalate || c == PromotionDeescalate || c == PromotionFlagForReview
+}
+
+// PromotionInputKind identifies a typed record that supports or contradicts a promotion.
+type PromotionInputKind string
+
+const (
+	PromotionInputReachability PromotionInputKind = "reachability_judgment"
+	PromotionInputAttackPath   PromotionInputKind = "attack_path"
+	PromotionInputDetection    PromotionInputKind = "detection"
+	PromotionInputPrior        PromotionInputKind = "prior_promotion"
+)
+
+func (k PromotionInputKind) Valid() bool {
+	return k == PromotionInputReachability || k == PromotionInputAttackPath || k == PromotionInputDetection || k == PromotionInputPrior
+}
+
+// PromotionInput links a promotion to the exact record and, where available, its sealed evidence.
+type PromotionInput struct {
+	Kind       PromotionInputKind `json:"kind"`
+	ID         shared.ID          `json:"id"`
+	EvidenceID shared.ID          `json:"evidence_id,omitempty"`
+}
+
+// PromotionClaim proposes a deterministic priority change. It is inert until a distinct verifier's
+// sealed verdict clears the evidence bar. Uncertain inputs may only produce a review flag.
+type PromotionClaim struct {
+	FindingID      shared.ID        `json:"finding_id"`
+	Rule           string           `json:"rule"`
+	Inputs         []PromotionInput `json:"inputs"`
+	Proposed       PromotionChange  `json:"proposed"`
+	Uncertainty    []string         `json:"uncertainty,omitempty"`
+	Fingerprint    string           `json:"fingerprint"`
+	FindingVersion int              `json:"finding_version"`
+	BeforePriority int              `json:"before_priority"`
+	AfterPriority  int              `json:"after_priority"`
+}
+
+func (PromotionClaim) Capability() Capability { return CapPromotion }
+
+func (c PromotionClaim) Validate() error {
+	if c.FindingID.IsZero() {
+		return fmt.Errorf("%w: promotion finding id is required", shared.ErrValidation)
+	}
+	if len(c.Rule) > 128 || !promotionRuleKeyRE.MatchString(c.Rule) {
+		return fmt.Errorf("%w: promotion rule must be a stable promotion.* token", shared.ErrValidation)
+	}
+	expectEffect, ok := ExpectedEffect(c.Rule)
+	if !ok {
+		return fmt.Errorf("%w: unknown promotion rule %q", shared.ErrValidation, c.Rule)
+	}
+	if c.Proposed != expectEffect {
+		return fmt.Errorf("%w: promotion rule %q produces %s, got %s", shared.ErrValidation, c.Rule, expectEffect, c.Proposed)
+	}
+	if !promotionFingerprintRE.MatchString(c.Fingerprint) {
+		return fmt.Errorf("%w: promotion fingerprint must be a lowercase SHA-256 digest", shared.ErrValidation)
+	}
+	if !c.Proposed.Valid() {
+		return fmt.Errorf("%w: promotion change must be escalate|de_escalate|flag_for_review", shared.ErrValidation)
+	}
+	if c.FindingVersion < 1 || c.BeforePriority < 1 || c.BeforePriority > 5 || c.AfterPriority < 1 || c.AfterPriority > 5 {
+		return fmt.Errorf("%w: promotion requires a positive finding version and priorities in 1..5", shared.ErrValidation)
+	}
+	if len(c.Inputs) == 0 || len(c.Inputs) > 32 {
+		return fmt.Errorf("%w: promotion requires 1..32 inputs", shared.ErrValidation)
+	}
+	for i, in := range c.Inputs {
+		if !in.Kind.Valid() || in.ID.IsZero() {
+			return fmt.Errorf("%w: promotion input %d has invalid kind or id", shared.ErrValidation, i)
+		}
+		if i > 0 {
+			prev := c.Inputs[i-1]
+			if prev.Kind > in.Kind || prev.Kind == in.Kind && (prev.ID > in.ID || prev.ID == in.ID && prev.EvidenceID >= in.EvidenceID) {
+				return fmt.Errorf("%w: promotion inputs must be sorted and distinct", shared.ErrValidation)
+			}
+		}
+	}
+	if len(c.Uncertainty) > 8 {
+		return fmt.Errorf("%w: promotion has too many uncertainty tokens", shared.ErrValidation)
+	}
+	for i, token := range c.Uncertainty {
+		if len(token) > 64 || !driverRE.MatchString(token) || i > 0 && c.Uncertainty[i-1] >= token {
+			return fmt.Errorf("%w: promotion uncertainty must be sorted distinct tokens", shared.ErrValidation)
+		}
+	}
+	if len(c.Uncertainty) > 0 && c.Proposed != PromotionFlagForReview {
+		return fmt.Errorf("%w: uncertain promotion can only flag for review", shared.ErrValidation)
+	}
+	switch c.Proposed {
+	case PromotionEscalate:
+		// Escalation is always exactly one level toward P1.
+		if c.AfterPriority != c.BeforePriority-1 {
+			return fmt.Errorf("%w: escalation must move priority one level toward P1", shared.ErrValidation)
+		}
+	case PromotionDeescalate:
+		if c.AfterPriority <= c.BeforePriority || c.AfterPriority > 5 {
+			return fmt.Errorf("%w: de-escalation must move priority toward P5", shared.ErrValidation)
+		}
+		if c.Rule == RuleCorroboratingSignalLoss {
+			// Multi-level reversal: requires at least one prior_promotion input
+			// and must restore a strictly higher prior priority.
+			hasPrior := false
+			for _, in := range c.Inputs {
+				if in.Kind == PromotionInputPrior {
+					hasPrior = true
+					break
+				}
+			}
+			if !hasPrior {
+				return fmt.Errorf("%w: corroborating_signal_loss requires at least one prior_promotion input", shared.ErrValidation)
+			}
+			if c.AfterPriority <= c.BeforePriority {
+				return fmt.Errorf("%w: corroborating_signal_loss must restore a higher priority", shared.ErrValidation)
+			}
+		} else {
+			// Ordinary de-escalation: exactly one level.
+			if c.AfterPriority != c.BeforePriority+1 {
+				return fmt.Errorf("%w: ordinary de-escalation must move exactly one level toward P5", shared.ErrValidation)
+			}
+		}
+	case PromotionFlagForReview:
+		if c.AfterPriority != c.BeforePriority {
+			return fmt.Errorf("%w: review flag cannot change priority", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
 // VexJustificationClaim is a proposed OpenVEX justification for why a finding is NOT_AFFECTED – the
 // AI's STRUCTURED choice from the CLOSED OpenVEX justification set, never free prose. The finding it
 // applies to is the Judgment's SUBJECT (SubjectFinding), not part of the claim. Gated: a distinct human
 // verifier ratifies it before the export trusts it (it asserts "not affected" in a published deliverable);
-// the agent only proposes it at score 0. It COMPLEMENTS the deterministic reachability-tier justification
-// (which wins where a confirmed not_reachable proof exists); this carries the OTHER not_affected
-// reasons (component_not_present / cannot_be_controlled / inline_mitigations / code_not_present).
+// the agent only proposes it at score 0. It COMPLEMENTS the deterministic reachability-tier justification.
 type VexJustificationClaim struct {
 	Justification vex.OpenVexJustification `json:"justification"`
 }
@@ -462,6 +662,12 @@ func UnmarshalClaim(data []byte) (Claim, error) {
 			return nil, err
 		}
 		c = cc
+	case CapPromotion:
+		var pc PromotionClaim
+		if err := strictDecode(env.Claim, &pc); err != nil {
+			return nil, err
+		}
+		c = pc
 	case CapVexJustification:
 		var vc VexJustificationClaim
 		if err := strictDecode(env.Claim, &vc); err != nil {

--- a/internal/domain/judgment/claim_test.go
+++ b/internal/domain/judgment/claim_test.go
@@ -1,6 +1,7 @@
 package judgment
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -19,6 +20,7 @@ func TestClaimRoundTrip(t *testing.T) {
 		ThreatClaim{Category: InfoDisclosure, Asset: "pii"},
 		ThreatClaim{Category: Spoofing}, // asset optional
 		CorrelationClaim{Reporters: []string{"osv"}, Missing: []string{"advisory-store"}},
+		PromotionClaim{FindingID: "finding-1", Rule: RuleUncertainCorroboration, Inputs: []PromotionInput{{Kind: PromotionInputReachability, ID: "judgment-1"}}, Proposed: PromotionFlagForReview, Uncertainty: []string{"unknown_reachability"}, Fingerprint: strings.Repeat("a", 64), FindingVersion: 1, BeforePriority: 3, AfterPriority: 3},
 		VexJustificationClaim{Justification: vex.VulnerableCodeNotInExecutePath},
 	}
 	for _, c := range claims {
@@ -189,10 +191,10 @@ func TestCorrelationClaimValidate(t *testing.T) {
 		t.Errorf("a real disagreement should pass: %v", err)
 	}
 	if err := (CorrelationClaim{Reporters: []string{"osv"}}).Validate(); !errors.Is(err, shared.ErrValidation) {
-		t.Error("no missing source → not a disagreement → must be rejected")
+		t.Error("no missing source -> not a disagreement -> must be rejected")
 	}
 	if err := (CorrelationClaim{Missing: []string{"owned"}}).Validate(); !errors.Is(err, shared.ErrValidation) {
-		t.Error("no reporters → must be rejected")
+		t.Error("no reporters -> must be rejected")
 	}
 	if err := (CorrelationClaim{Reporters: []string{""}, Missing: []string{"owned"}}).Validate(); !errors.Is(err, shared.ErrValidation) {
 		t.Error("an empty source name must be rejected")
@@ -210,7 +212,7 @@ func TestReachabilitySupersedes(t *testing.T) {
 	if !rc(Tier1_5).Supersedes(rc(Tier0)) {
 		t.Error("Tier-1.5 must supersede Tier-0")
 	}
-	// same tier does NOT supersede (no churn) – even if the new verdict disagrees
+	// same tier does NOT supersede (no churn) - even if the new verdict disagrees
 	notReach := ReachabilityClaim{Reachable: NotReachable, Tier: Tier2, Confidence: 90}
 	if notReach.Supersedes(rc(Tier2)) {
 		t.Error("same tier must not supersede (stored verdict stands)")
@@ -236,7 +238,7 @@ func TestMarshalNilClaim(t *testing.T) {
 }
 
 func TestReachabilityTierRank(t *testing.T) {
-	// Strength ordering must be strictly increasing – supersession compares ranks.
+	// Strength ordering must be strictly increasing - supersession compares ranks.
 	if !(Tier0.Rank() < Tier1.Rank() && Tier1.Rank() < Tier1_5.Rank() && Tier1_5.Rank() < Tier2.Rank()) {
 		t.Fatalf("tier ranks must be strictly increasing: %d %d %d %d", Tier0.Rank(), Tier1.Rank(), Tier1_5.Rank(), Tier2.Rank())
 	}
@@ -277,5 +279,238 @@ func TestReachabilityClaimPathBounded(t *testing.T) {
 	// a normal path passes
 	if err := (ReachabilityClaim{Reachable: Reachable, Tier: Tier1, Path: []string{"root", "lodash"}, Confidence: 50}).Validate(); err != nil {
 		t.Fatalf("normal path should pass: %v", err)
+	}
+}
+
+// --- Promotion claim tests ---
+
+func TestPromotionClaimStrictRoundTrip(t *testing.T) {
+	orig := PromotionClaim{
+		FindingID:      "finding-abc",
+		Rule:           RuleRuntimeReachableExposed,
+		Inputs:         []PromotionInput{{Kind: PromotionInputAttackPath, ID: "ap1"}, {Kind: PromotionInputReachability, ID: "j1"}},
+		Proposed:       PromotionEscalate,
+		Fingerprint:    strings.Repeat("b", 64),
+		FindingVersion: 2,
+		BeforePriority: 3,
+		AfterPriority:  2,
+	}
+	data, err := MarshalClaim(orig)
+	if err != nil {
+		t.Fatalf("MarshalClaim: %v", err)
+	}
+	got, err := UnmarshalClaim(data)
+	if err != nil {
+		t.Fatalf("UnmarshalClaim: %v", err)
+	}
+	pc, ok := got.(PromotionClaim)
+	if !ok {
+		t.Fatalf("type = %T, want PromotionClaim", got)
+	}
+	if pc.FindingID != orig.FindingID {
+		t.Errorf("FindingID = %s, want %s", pc.FindingID, orig.FindingID)
+	}
+	if pc.Rule != orig.Rule {
+		t.Errorf("Rule = %s, want %s", pc.Rule, orig.Rule)
+	}
+	if pc.Proposed != orig.Proposed {
+		t.Errorf("Proposed = %s, want %s", pc.Proposed, orig.Proposed)
+	}
+	if pc.BeforePriority != orig.BeforePriority || pc.AfterPriority != orig.AfterPriority {
+		t.Errorf("priority: before=%d,after=%d want %d,%d", pc.BeforePriority, pc.AfterPriority, orig.BeforePriority, orig.AfterPriority)
+	}
+	if pc.Fingerprint != orig.Fingerprint {
+		t.Errorf("Fingerprint mismatch")
+	}
+}
+
+func TestPromotionClaimMalformed(t *testing.T) {
+	fp := strings.Repeat("a", 64)
+	cases := []struct {
+		name string
+		data string
+	}{
+		{"zero finding id", `{"capability":"promotion","claim":{"finding_id":"","rule":"` + RuleUncertainCorroboration + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"flag_for_review","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":3}}`},
+		{"bad rule prefix", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"bad.rule","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"flag_for_review","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":3}}`},
+		{"unknown rule (fail closed)", `{"capability":"promotion","claim":{"finding_id":"f1","rule":RuleUncertainCorroboration,"inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"flag_for_review","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":3}}`},
+		{"bad fingerprint", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleUncertainCorroboration + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"flag_for_review","fingerprint":"not_hex","finding_version":1,"before_priority":3,"after_priority":3}}`},
+		{"no inputs", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleUncertainCorroboration + `","inputs":[],"proposed":"flag_for_review","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":3}}`},
+		{"rule-effect mismatch: escalate rule with review", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleRuntimeReachableExposed + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"flag_for_review","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":3}}`},
+		{"rule-effect mismatch: review rule with escalate", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleUncertainCorroboration + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"escalate","uncertainty":["inferred_edge"],"fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":2}}`},
+		{"escalation wrong delta", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleRuntimeReachableExposed + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"escalate","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":1}}`},
+		{"review changes priority", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleUncertainCorroboration + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"flag_for_review","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":2}}`},
+		{"smuggled field", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleUncertainCorroboration + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"flag_for_review","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":3,"notes":"PROSE LEAK"}}`},
+		{"hostile: multi-level de-escalation with deterministic_unreachable rule", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleDeterministicUnreachable + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"de_escalate","fingerprint":"` + fp + `","finding_version":1,"before_priority":2,"after_priority":5}}`},
+		{"hostile: multi-level de-escalation without prior_promotion input", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleCorroboratingSignalLoss + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"de_escalate","fingerprint":"` + fp + `","finding_version":1,"before_priority":2,"after_priority":5}}`},
+		{"hostile: de-escalation no movement", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleDeterministicUnreachable + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"de_escalate","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":3}}`},
+		{"hostile: de-escalation toward P1", `{"capability":"promotion","claim":{"finding_id":"f1","rule":"` + RuleDeterministicUnreachable + `","inputs":[{"kind":"reachability_judgment","id":"j1"}],"proposed":"de_escalate","fingerprint":"` + fp + `","finding_version":1,"before_priority":3,"after_priority":2}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := UnmarshalClaim([]byte(tc.data)); err == nil {
+				t.Fatal("want error (fail-closed), got nil")
+			} else if !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPromotionClaimBoundaries(t *testing.T) {
+	fp := strings.Repeat("a", 64)
+	claim := func(rule string, p PromotionChange, before, after int, inputs ...PromotionInput) PromotionClaim {
+		if len(inputs) == 0 {
+			inputs = []PromotionInput{{Kind: PromotionInputReachability, ID: "j1"}}
+		}
+		return PromotionClaim{
+			FindingID: "f1", Rule: rule,
+			Inputs: inputs, Proposed: p, Fingerprint: fp,
+			FindingVersion: 1, BeforePriority: before, AfterPriority: after,
+		}
+	}
+
+	// Escalation: exactly one level toward P1.
+	esc := RuleRuntimeReachableExposed
+	if err := claim(esc, PromotionEscalate, 3, 2).Validate(); err != nil {
+		t.Errorf("escalate 3->2 should pass: %v", err)
+	}
+	if err := claim(esc, PromotionEscalate, 3, 1).Validate(); err == nil {
+		t.Error("escalate 3->1 (two levels) must fail")
+	}
+	if err := claim(esc, PromotionEscalate, 1, 0).Validate(); err == nil {
+		t.Error("escalate 1->0 must fail (out of range)")
+	}
+
+	// De-escalation: ordinary (deterministic_unreachable) must be exactly one level.
+	dea := RuleDeterministicUnreachable
+	if err := claim(dea, PromotionDeescalate, 3, 4).Validate(); err != nil {
+		t.Errorf("de-escalate 3->4 should pass: %v", err)
+	}
+	if err := claim(dea, PromotionDeescalate, 2, 5).Validate(); err == nil {
+		t.Error("ordinary de-escalate 2->5 (multi-level) must fail for deterministic_unreachable")
+	}
+	if err := claim(dea, PromotionDeescalate, 3, 3).Validate(); err == nil {
+		t.Error("de-escalate 3->3 (no movement) must fail")
+	}
+	if err := claim(dea, PromotionDeescalate, 3, 2).Validate(); err == nil {
+		t.Error("de-escalate toward P1 must fail")
+	}
+	if err := claim(dea, PromotionDeescalate, 3, 6).Validate(); err == nil {
+		t.Error("de-escalate past P5 must fail")
+	}
+
+	// De-escalation: multi-level reversal (corroborating_signal_loss) with prior_promotion input.
+	csl := RuleCorroboratingSignalLoss
+	priorInputs := []PromotionInput{
+		{Kind: PromotionInputPrior, ID: "evt-1"},
+		{Kind: PromotionInputReachability, ID: "j1"},
+	}
+	if err := claim(csl, PromotionDeescalate, 2, 5, priorInputs...).Validate(); err != nil {
+		t.Errorf("signal-loss reversal 2->5 with prior input should pass: %v", err)
+	}
+	if err := claim(csl, PromotionDeescalate, 2, 5).Validate(); err == nil {
+		t.Error("signal-loss reversal without prior_promotion input must fail")
+	}
+
+	// Review: same priority only.
+	rev := RuleUncertainCorroboration
+	if err := claim(rev, PromotionFlagForReview, 3, 3).Validate(); err != nil {
+		t.Errorf("review 3->3 should pass: %v", err)
+	}
+	if err := claim(rev, PromotionFlagForReview, 3, 4).Validate(); err == nil {
+		t.Error("review 3->4 must fail")
+	}
+}
+
+func TestPromotionClaimInputSorting(t *testing.T) {
+	fp := strings.Repeat("c", 64)
+	sorted := PromotionClaim{
+		FindingID: "f1", Rule: RuleUncertainCorroboration,
+		Inputs: []PromotionInput{
+			{Kind: PromotionInputAttackPath, ID: "ap-1"},
+			{Kind: PromotionInputDetection, ID: "det-1"},
+			{Kind: PromotionInputReachability, ID: "j1"},
+		},
+		Proposed: PromotionFlagForReview, Fingerprint: fp,
+		FindingVersion: 1, BeforePriority: 3, AfterPriority: 3,
+	}
+	if err := sorted.Validate(); err != nil {
+		t.Errorf("sorted inputs should pass: %v", err)
+	}
+	unsorted := PromotionClaim{
+		FindingID: "f1", Rule: RuleUncertainCorroboration,
+		Inputs: []PromotionInput{
+			{Kind: PromotionInputDetection, ID: "det-1"},
+			{Kind: PromotionInputAttackPath, ID: "ap-1"},
+		},
+		Proposed: PromotionFlagForReview, Fingerprint: fp,
+		FindingVersion: 1, BeforePriority: 3, AfterPriority: 3,
+	}
+	if err := unsorted.Validate(); err == nil {
+		t.Error("unsorted inputs must be rejected")
+	}
+	dup := PromotionClaim{
+		FindingID: "f1", Rule: RuleUncertainCorroboration,
+		Inputs: []PromotionInput{
+			{Kind: PromotionInputReachability, ID: "j1"},
+			{Kind: PromotionInputReachability, ID: "j1"},
+		},
+		Proposed: PromotionFlagForReview, Fingerprint: fp,
+		FindingVersion: 1, BeforePriority: 3, AfterPriority: 3,
+	}
+	if err := dup.Validate(); err == nil {
+		t.Error("duplicate inputs must be rejected")
+	}
+}
+
+func TestPromotionClaimUncertaintyTokens(t *testing.T) {
+	fp := strings.Repeat("d", 64)
+	base := PromotionClaim{
+		FindingID: "f1", Rule: RuleUncertainCorroboration,
+		Inputs:      []PromotionInput{{Kind: PromotionInputReachability, ID: "j1"}},
+		Fingerprint: fp, FindingVersion: 1, BeforePriority: 3, AfterPriority: 3,
+	}
+	sorted := base
+	sorted.Proposed = PromotionFlagForReview
+	sorted.Uncertainty = []string{"inferred_edge", "unknown_reachability"}
+	if err := sorted.Validate(); err != nil {
+		t.Errorf("sorted uncertainty + review should pass: %v", err)
+	}
+	unsorted := base
+	unsorted.Proposed = PromotionFlagForReview
+	unsorted.Uncertainty = []string{"unknown_reachability", "inferred_edge"}
+	if err := unsorted.Validate(); err == nil {
+		t.Error("unsorted uncertainty must be rejected")
+	}
+	escWithUncertainty := base
+	escWithUncertainty.Proposed = PromotionEscalate
+	escWithUncertainty.AfterPriority = 2
+	escWithUncertainty.Uncertainty = []string{"inferred_edge"}
+	if err := escWithUncertainty.Validate(); err == nil {
+		t.Error("uncertain escalation must be rejected")
+	}
+}
+
+func TestPromotionClaimJsonEnvelope(t *testing.T) {
+	pc := PromotionClaim{
+		FindingID: "f1", Rule: RuleUncertainCorroboration,
+		Inputs:   []PromotionInput{{Kind: PromotionInputReachability, ID: "j1"}},
+		Proposed: PromotionFlagForReview, Fingerprint: strings.Repeat("e", 64),
+		FindingVersion: 1, BeforePriority: 3, AfterPriority: 3,
+	}
+	data, err := MarshalClaim(pc)
+	if err != nil {
+		t.Fatalf("MarshalClaim: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	var cap string
+	if err := json.Unmarshal(raw["capability"], &cap); err != nil {
+		t.Fatalf("unmarshal capability: %v", err)
+	}
+	if cap != "promotion" {
+		t.Errorf("capability = %q, want %q", cap, "promotion")
 	}
 }

--- a/internal/domain/judgment/judgment.go
+++ b/internal/domain/judgment/judgment.go
@@ -28,25 +28,26 @@ const (
 	CapRiskNarrative    Capability = "risk_narrative"    // NOT gated (explains, doesn't prove)
 	CapThreat           Capability = "threat"            // gated (STRIDE threat over the model, human-ratified)
 	CapCorrelation      Capability = "correlation"       // NOT gated (a cross-check disagreement; human-acknowledged, never auto-resolved)
+	CapPromotion        Capability = "promotion"         // gated (cross-pillar priority change, distinct-verifier only)
 	CapVexJustification Capability = "vex_justification" // gated (AI-proposed OpenVEX not_affected justification, human-ratified)
 )
 
 // Valid reports whether c is a known capability.
 func (c Capability) Valid() bool {
 	switch c {
-	case CapReachability, CapSAST, CapDAST, CapCritique, CapRiskNarrative, CapThreat, CapCorrelation, CapVexJustification:
+	case CapReachability, CapSAST, CapDAST, CapCritique, CapRiskNarrative, CapThreat, CapCorrelation, CapPromotion, CapVexJustification:
 		return true
 	}
 	return false
 }
 
 // Gated reports whether a verdict gates this capability's publishability (R2). Adversarially-
-// refutable capabilities (reachability/sast/critique/threat/vex_justification) are gated: publishable only with a sealed
+// refutable capabilities (reachability/sast/critique/threat/promotion/vex_justification) are gated: publishable only with a sealed
 // verdict >= EvidenceThreshold. Descriptive ones (risk_narrative; correlation – a deterministic
 // cross-check disagreement) have no "refuted at 75" semantics; they are human-accepted, not score-gated.
 func (c Capability) Gated() bool {
 	switch c {
-	case CapReachability, CapSAST, CapDAST, CapCritique, CapThreat, CapVexJustification:
+	case CapReachability, CapSAST, CapDAST, CapCritique, CapThreat, CapPromotion, CapVexJustification:
 		return true
 	}
 	return false
@@ -102,9 +103,14 @@ type Judgment struct {
 	Claim         Claim
 	State         State
 	EvidenceScore int
-	ProposedBy    string
-	Version       int
-	Audit         shared.Audit
+	ProposedBy    string `json:"proposed_by"`
+	// VerifiedBy and VerdictRationale are sealed-verdict provenance. They are set
+	// only by ApplyVerdict for a distinct verifier; proposed and accepted
+	// judgments leave both empty.
+	VerifiedBy       string `json:"verified_by"`
+	VerdictRationale string `json:"verdict_rationale"`
+	Version          int
+	Audit            shared.Audit
 }
 
 // New builds a PROPOSED judgment at EvidenceScore 0 (the proposer can never set a score). It
@@ -161,6 +167,8 @@ func (j Judgment) ApplyVerdict(v verdict.Verdict, now time.Time) (Judgment, erro
 		return Judgment{}, fmt.Errorf("%w: the verifier (%s) may not be the proposer", shared.ErrValidation, v.Verifier)
 	}
 	j.EvidenceScore = v.Score
+	j.VerifiedBy = strings.TrimSpace(v.Verifier)
+	j.VerdictRationale = strings.TrimSpace(v.Rationale)
 	if verdict.MeetsBar(v.Score) {
 		j.State = StateConfirmed
 	} else {

--- a/internal/domain/judgment/judgment_test.go
+++ b/internal/domain/judgment/judgment_test.go
@@ -1,7 +1,9 @@
 package judgment
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,6 +62,28 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestVerdictProvenanceJSON(t *testing.T) {
+	j, err := New("j1", "e1", CapReachability, SubjectFinding, "f1", reach(), "agent:s1", t0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j, err = j.ApplyVerdict(verdict.Verdict{Verifier: "human:bob", Score: 80, Rationale: "holds"}, t0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(j)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["verified_by"] != "human:bob" || got["verdict_rationale"] != "holds" {
+		t.Fatalf("sealed provenance JSON: %s", data)
+	}
+}
+
 func TestApplyVerdict(t *testing.T) {
 	base, _ := New("j1", "e1", CapReachability, SubjectFinding, "f1", reach(), "agent:s1", t0)
 
@@ -70,6 +94,9 @@ func TestApplyVerdict(t *testing.T) {
 	if got.State != StateConfirmed || got.EvidenceScore != 80 || !got.Publishable() {
 		t.Fatalf("want confirmed/80/publishable, got %s/%d/%v", got.State, got.EvidenceScore, got.Publishable())
 	}
+	if got.VerifiedBy != "human:bob" || got.VerdictRationale != "holds" {
+		t.Fatalf("verdict provenance lost: %#v", got)
+	}
 
 	got, err = base.ApplyVerdict(verdict.Verdict{Verifier: "human:bob", Score: 40, Rationale: "weak"}, t0)
 	if err != nil {
@@ -77,6 +104,9 @@ func TestApplyVerdict(t *testing.T) {
 	}
 	if got.State != StateRefuted || got.Publishable() {
 		t.Fatalf("want refuted/not-publishable, got %s/%v", got.State, got.Publishable())
+	}
+	if got.VerifiedBy != "human:bob" || got.VerdictRationale != "weak" {
+		t.Fatalf("refuted verdict provenance lost: %#v", got)
 	}
 
 	if _, err := base.ApplyVerdict(verdict.Verdict{Verifier: "agent:s1", Score: 90, Rationale: "x"}, t0); !errors.Is(err, shared.ErrValidation) {
@@ -100,6 +130,9 @@ func TestAccept(t *testing.T) {
 	}
 	if got.State != StateConfirmed || !got.Publishable() {
 		t.Fatalf("want confirmed/publishable, got %s/%v", got.State, got.Publishable())
+	}
+	if got.VerifiedBy != "" || got.VerdictRationale != "" {
+		t.Fatalf("accept fabricated verdict provenance: %#v", got)
 	}
 
 	if _, err := ung.Accept("agent:s1", t0); !errors.Is(err, shared.ErrValidation) {
@@ -157,6 +190,7 @@ func TestCapabilityContractExhaustive(t *testing.T) {
 		{CapRiskNarrative, RiskNarrativeClaim{Drivers: []string{"kev"}, Priority: 3}, false},
 		{CapThreat, ThreatClaim{Category: Tampering}, true},
 		{CapCorrelation, CorrelationClaim{Reporters: []string{"osv"}, Missing: []string{"owned"}}, false},
+		{CapPromotion, PromotionClaim{FindingID: "finding", Rule: "promotion.review.uncertain_corroboration", Inputs: []PromotionInput{{Kind: PromotionInputReachability, ID: "judgment"}}, Proposed: PromotionFlagForReview, Uncertainty: []string{"unknown_reachability"}, Fingerprint: strings.Repeat("a", 64), FindingVersion: 1, BeforePriority: 3, AfterPriority: 3}, true},
 		{CapVexJustification, VexJustificationClaim{Justification: vex.VulnerableCodeNotPresent}, true},
 	}
 	for _, tc := range all {

--- a/internal/domain/offensivepolicy/policy_test.go
+++ b/internal/domain/offensivepolicy/policy_test.go
@@ -13,6 +13,8 @@ import (
 func mutate(t *testing.T, old, new string) error {
 	t.Helper()
 	raw := strings.ReplaceAll(string(embeddedPolicy), "\r\n", "\n")
+	old = strings.ReplaceAll(old, "\r\n", "\n")
+	new = strings.ReplaceAll(new, "\r\n", "\n")
 	if !strings.Contains(raw, old) {
 		t.Fatalf("fixture anchor not found in policy.yaml: %q", old)
 	}

--- a/internal/domain/promotion/doc_drift_test.go
+++ b/internal/domain/promotion/doc_drift_test.go
@@ -1,0 +1,84 @@
+package promotion
+
+import (
+	_ "embed"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+)
+
+//go:embed testdata/promotion-rules.md
+var rulesDoc string
+
+// TestDocDriftRuleKeysPresent verifies every rule key in the code catalogue is documented.
+// If a new rule is added to rules.go but not to promotion-rules.md, this test fails.
+func TestDocDriftRuleKeysPresent(t *testing.T) {
+	for _, r := range Rules() {
+		if !strings.Contains(rulesDoc, r.Key) {
+			t.Errorf("rule key %q is in the code catalogue but not in docs/architecture/promotion-rules.md", r.Key)
+		}
+	}
+}
+
+// TestDocDriftNoStaleRules verifies every rule key documented in promotion-rules.md exists
+// in the code catalogue. If a rule is removed from the code but the doc is not updated,
+// this test fails.
+func TestDocDriftNoStaleRules(t *testing.T) {
+	knownKeys := []string{
+		judgment.RuleRuntimeReachableExposed,
+		judgment.RuleDeterministicUnreachable,
+		judgment.RuleCorroboratingSignalLoss,
+		judgment.RuleUncertainCorroboration,
+	}
+	rules := Rules()
+	for _, key := range knownKeys {
+		found := false
+		for _, r := range rules {
+			if r.Key == key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("rule key %q is documented but not in the code catalogue", key)
+		}
+	}
+}
+
+// TestDocDriftEffectsMatch verifies the effect described in the doc for each rule matches
+// the code catalogue's effect.
+func TestDocDriftEffectsMatch(t *testing.T) {
+	effectCodes := map[string]judgment.PromotionChange{
+		judgment.RuleRuntimeReachableExposed:  judgment.PromotionEscalate,
+		judgment.RuleDeterministicUnreachable: judgment.PromotionDeescalate,
+		judgment.RuleCorroboratingSignalLoss:  judgment.PromotionDeescalate,
+		judgment.RuleUncertainCorroboration:   judgment.PromotionFlagForReview,
+	}
+	rules := Rules()
+	for _, r := range rules {
+		wantCode, ok := effectCodes[r.Key]
+		if !ok {
+			continue
+		}
+		if r.Effect != wantCode {
+			t.Errorf("rule %q: code effect = %s, want %s", r.Key, r.Effect, wantCode)
+		}
+	}
+}
+
+// TestDocDriftRuleCountMatches verifies the documented rule count matches the code catalogue
+// count. If a rule is added or removed, both the code and docs must be updated.
+func TestDocDriftRuleCountMatches(t *testing.T) {
+	rules := Rules()
+	// Count rule headers in the doc (lines starting with "### promotion.")
+	count := 0
+	for _, line := range strings.Split(rulesDoc, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "### promotion.") {
+			count++
+		}
+	}
+	if count != len(rules) {
+		t.Errorf("doc has %d rule headers, code has %d rules; they must match", count, len(rules))
+	}
+}

--- a/internal/domain/promotion/event.go
+++ b/internal/domain/promotion/event.go
@@ -1,0 +1,275 @@
+package promotion
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/verdict"
+)
+
+// PromotionEvent is the immutable record of an applied finding-priority change.
+// It captures the claim that was accepted, the exact before/after priority, and
+// the sealed version of the finding at the time of application so that the
+// lifecycle is fully reconstructable.
+//
+// Events are append-only and never mutated. Reversals produce a new event whose
+// AfterPriority restores the prior event's BeforePriority.
+// PromotionEvent is the immutable record of an applied finding-priority change.
+// It captures the claim that was accepted, the exact before/after priority, and
+// the sealed version of the finding at the time of application so that the
+// lifecycle is fully reconstructable.
+//
+// Events are append-only and never mutated. Reversals produce a new event whose
+// AfterPriority restores the prior event's BeforePriority.
+type PromotionEvent struct {
+	// ID is the stable event identity (used for prior-escalation references).
+	ID shared.ID
+
+	// EngagementID scopes the event to an engagement (tenant enforcement is at
+	// the context/store chokepoint via shared.WithTenant/shared.TenantFrom; the
+	// event itself carries only the engagement boundary).
+	EngagementID shared.ID
+
+	// JudgmentID identifies the judgment whose sealed verdict cleared the
+	// evidence bar for this promotion. Used for idempotency (tenant+judgment)
+	// so a single judgment cannot produce multiple events.
+	JudgmentID shared.ID
+
+	// FindingID and FindingVersion identify the exact finding snapshot this
+	// event applies to. The version is the finding's optimistic-concurrency
+	// token BEFORE the priority was moved.
+	FindingID      shared.ID
+	FindingVersion int
+
+	// AfterFindingVersion is the finding's optimistic-concurrency token AFTER
+	// the priority was moved. For mutating effects (escalate/de_escalate) this
+	// is FindingVersion+1; for flag_for_review this equals FindingVersion
+	// (no version bump).
+	AfterFindingVersion int
+
+	// Rule is the stable promotion.* policy key (e.g. promotion.escalate.runtime_reachable_exposed).
+	Rule string
+
+	// Effect reuses the judgment vocabulary: escalate, de_escalate, or
+	// flag_for_review. A domain-to-domain import of judgment.PromotionChange is
+	// the canonical path so claim and lifecycle can never drift.
+	Effect judgment.PromotionChange
+
+	// BeforePriority and AfterPriority record the exact priority movement.
+	// For flag_for_review, Before == After (no mutation, no version bump on
+	// the finding).
+	BeforePriority int
+	AfterPriority  int
+
+	// Inputs are the typed records that supported this decision. They are
+	// persisted verbatim from the validated claim. The constructor makes a
+	// defensive copy so the caller cannot mutate the stored slice.
+	Inputs []judgment.PromotionInput
+
+	// Fingerprint is the deterministic SHA-256 digest of the claim material.
+	// Combined with JudgmentID it makes Apply idempotent: a second call with
+	// the same judgment and fingerprint returns the existing event without
+	// side effects.
+	Fingerprint string
+
+	// VerdictScore is the sealed evidence score from the judgment that
+	// cleared the promotion gate. Zero when not available (e.g. deterministic
+	// unassisted rules).
+	VerdictScore int
+
+	// VerdictRationale is the sealed rationale from the judgment, if any.
+	// Stored as-is; never rendered into a report path.
+	VerdictRationale string
+
+	// EvidenceID is the sealed evidence artifact that attests this promotion.
+	// Empty when the promotion was produced by a deterministic rule that did
+	// not seal a separate evidence record.
+	EvidenceID shared.ID
+
+	// Verifier identifies the human or service identity whose sealed verdict
+	// cleared the evidence bar. Empty for deterministic unassisted rules.
+	Verifier string
+
+	// Uncertainty carries the sorted distinct tokens from the claim that
+	// describe why this promotion was flagged for review rather than applied
+	// deterministically. Empty for deterministic effects (escalate/de_escalate).
+	// Preserved from the validated PromotionClaim so that event replay can
+	// round-trip through claim validation without losing semantics.
+	Uncertainty []string
+
+	// AppliedBy is the actor (human or service identity) that applied this
+	// event. Empty means system/unknown.
+	AppliedBy string
+
+	// AppliedAt is the wall-clock time of application (append-only; never updated).
+	AppliedAt time.Time
+}
+
+// NewPromotionEvent validates inputs and builds an immutable event record.
+// The id and now parameters are supplied by the use case layer (deterministic,
+// testable). Returns shared.ErrValidation on any invariant violation.
+// NewPromotionEvent validates inputs and builds an immutable event record.
+// The id and now parameters are supplied by the use case layer (deterministic,
+// testable). Returns shared.ErrValidation on any invariant violation.
+//
+// Inputs are defensively copied on construction; the caller can safely reuse or
+// mutate the original slice after this call returns.
+//
+// For escalating/de-escalating effects the afterFindingVersion must be
+// findingVersion+1; for flag_for_review it must equal findingVersion.
+func NewPromotionEvent(
+	id, engagementID, judgmentID, findingID shared.ID,
+	findingVersion, afterFindingVersion int,
+	rule string,
+	effect judgment.PromotionChange,
+	beforePriority, afterPriority int,
+	inputs []judgment.PromotionInput,
+	fingerprint string,
+	verdictScore int,
+	verdictRationale string,
+	evidenceID shared.ID,
+	verifier string,
+	uncertainty []string,
+	appliedBy string,
+	now time.Time,
+) (PromotionEvent, error) {
+	if id.IsZero() {
+		return PromotionEvent{}, fmt.Errorf("%w: promotion event id is required", shared.ErrValidation)
+	}
+	if engagementID.IsZero() {
+		return PromotionEvent{}, fmt.Errorf("%w: promotion event engagement id is required", shared.ErrValidation)
+	}
+	if judgmentID.IsZero() {
+		return PromotionEvent{}, fmt.Errorf("%w: promotion event judgment id is required", shared.ErrValidation)
+	}
+	if findingID.IsZero() {
+		return PromotionEvent{}, fmt.Errorf("%w: promotion event finding id is required", shared.ErrValidation)
+	}
+
+	// Round-trip through PromotionClaim.Validate to reuse its canonical
+	// validation of fingerprint format (lowercase SHA-256), known rule/effect,
+	// input kinds/IDs/order/uniqueness/count, uncertainty semantics, and
+	// effect-specific priority constraints. This avoids duplicating validation
+	// logic and ensures the event is a faithful snapshot of a valid claim.
+	claim := judgment.PromotionClaim{
+		FindingID:      findingID,
+		Rule:           rule,
+		Inputs:         inputs,
+		Proposed:       effect,
+		Uncertainty:    uncertainty,
+		Fingerprint:    fingerprint,
+		FindingVersion: findingVersion,
+		BeforePriority: beforePriority,
+		AfterPriority:  afterPriority,
+	}
+	if err := claim.Validate(); err != nil {
+		return PromotionEvent{}, fmt.Errorf("promotion event claim validation: %w", err)
+	}
+
+	// AfterFindingVersion: mutating effects bump by 1; flag_for_review does not.
+	if effect == judgment.PromotionFlagForReview {
+		if afterFindingVersion != findingVersion {
+			return PromotionEvent{}, fmt.Errorf("%w: review flag must not bump finding version (got %d, want %d)", shared.ErrValidation, afterFindingVersion, findingVersion)
+		}
+	} else {
+		if afterFindingVersion != findingVersion+1 {
+			return PromotionEvent{}, fmt.Errorf("%w: mutating effect must bump finding version by 1 (got %d, want %d)", shared.ErrValidation, afterFindingVersion, findingVersion+1)
+		}
+	}
+
+	if verdictScore < verdict.EvidenceThreshold || verdictScore > 100 {
+		return PromotionEvent{}, fmt.Errorf("%w: promotion verdict score must be %d..100, got %d", shared.ErrValidation, verdict.EvidenceThreshold, verdictScore)
+	}
+	verifier = strings.TrimSpace(verifier)
+	if verifier == "" || len(verifier) > 256 {
+		return PromotionEvent{}, fmt.Errorf("%w: promotion verifier is required and must be at most 256 bytes", shared.ErrValidation)
+	}
+	verdictRationale = strings.TrimSpace(verdictRationale)
+	if verdictRationale == "" || len(verdictRationale) > verdict.MaxRationaleBytes {
+		return PromotionEvent{}, fmt.Errorf("%w: promotion verdict rationale is required and must be at most %d bytes", shared.ErrValidation, verdict.MaxRationaleBytes)
+	}
+	if evidenceID.IsZero() {
+		return PromotionEvent{}, fmt.Errorf("%w: promotion evidence id is required", shared.ErrValidation)
+	}
+	appliedBy = strings.TrimSpace(appliedBy)
+	if appliedBy == "" {
+		return PromotionEvent{}, fmt.Errorf("%w: promotion applied-by actor is required", shared.ErrValidation)
+	}
+
+	// Defensive-copy the inputs and uncertainty slices so the caller cannot
+	// mutate stored state.
+	inputsCopy := make([]judgment.PromotionInput, len(inputs))
+	copy(inputsCopy, inputs)
+
+	uncertaintyCopy := make([]string, len(uncertainty))
+	copy(uncertaintyCopy, uncertainty)
+
+	return PromotionEvent{
+		ID:                  id,
+		EngagementID:        engagementID,
+		JudgmentID:          judgmentID,
+		FindingID:           findingID,
+		FindingVersion:      findingVersion,
+		AfterFindingVersion: afterFindingVersion,
+		Rule:                rule,
+		Effect:              effect,
+		BeforePriority:      beforePriority,
+		AfterPriority:       afterPriority,
+		Inputs:              inputsCopy,
+		Fingerprint:         fingerprint,
+		VerdictScore:        verdictScore,
+		VerdictRationale:    verdictRationale,
+		EvidenceID:          evidenceID,
+		Verifier:            verifier,
+		Uncertainty:         uncertaintyCopy,
+		AppliedBy:           appliedBy,
+		AppliedAt:           now,
+	}, nil
+}
+
+// Equals reports whether two PromotionEvents are semantically identical on all
+// immutable provenance and semantic fields. Only generated fields that retries
+// legitimately regenerate (EventID and AppliedAt) are excluded. Verifier, VerdictScore,
+// VerdictRationale, and EvidenceID are sealed provenance from the judgment
+// that cleared the promotion gate — altering any of them means the replay
+// carries different provenance and must not be treated as idempotent.
+// Used for exact-replay detection in memory and postgres stores.
+func (a PromotionEvent) Equals(b PromotionEvent) bool {
+	if a.EngagementID != b.EngagementID ||
+		a.JudgmentID != b.JudgmentID ||
+		a.FindingID != b.FindingID ||
+		a.FindingVersion != b.FindingVersion ||
+		a.AfterFindingVersion != b.AfterFindingVersion ||
+		a.Rule != b.Rule ||
+		a.Effect != b.Effect ||
+		a.BeforePriority != b.BeforePriority ||
+		a.AfterPriority != b.AfterPriority ||
+		a.Fingerprint != b.Fingerprint ||
+		a.Verifier != b.Verifier ||
+		a.VerdictScore != b.VerdictScore ||
+		a.VerdictRationale != b.VerdictRationale ||
+		a.EvidenceID != b.EvidenceID ||
+		a.AppliedBy != b.AppliedBy {
+		return false
+	}
+	if len(a.Inputs) != len(b.Inputs) {
+		return false
+	}
+	for i := range a.Inputs {
+		if a.Inputs[i] != b.Inputs[i] {
+			return false
+		}
+	}
+	if len(a.Uncertainty) != len(b.Uncertainty) {
+		return false
+	}
+	for i := range a.Uncertainty {
+		if a.Uncertainty[i] != b.Uncertainty[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/domain/promotion/rules.go
+++ b/internal/domain/promotion/rules.go
@@ -1,0 +1,185 @@
+// Package promotion defines deterministic cross-pillar finding-priority rules.
+package promotion
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Rule is one stable, documented promotion policy.
+type Rule struct {
+	Key        string
+	Inputs     string
+	Effect     judgment.PromotionChange
+	Confidence string
+	Reversal   string
+}
+
+// Rules returns immutable, local catalogue values in key order.
+func Rules() []Rule {
+	catalogue := []struct {
+		key        string
+		inputs     string
+		confidence string
+		reversal   string
+	}{
+		{judgment.RuleCorroboratingSignalLoss, "prior applied escalation plus lost or superseded corroborating input", "deterministic signal loss", "restores the prior escalation's before priority"},
+		{judgment.RuleDeterministicUnreachable, "publishable deterministic not-reachable judgment", "deterministic proof", "a later reachable proof is reevaluated"},
+		{judgment.RuleRuntimeReachableExposed, "publishable reachable judgment, confident internet-exposure path, active detection on a path asset", "all inputs confirmed or observed", "signal loss proposes de-escalation"},
+		{judgment.RuleUncertainCorroboration, "plausible runtime corroboration with inferred path or unknown reachability", "uncertain", "reevaluated when inputs become certain"},
+	}
+	out := make([]Rule, 0, len(catalogue))
+	for _, entry := range catalogue {
+		effect, ok := judgment.ExpectedEffect(entry.key)
+		if !ok {
+			continue
+		}
+		out = append(out, Rule{Key: entry.key, Inputs: entry.inputs, Effect: effect, Confidence: entry.confidence, Reversal: entry.reversal})
+	}
+	return out
+}
+
+// Signal is a typed promotion input record.
+type Signal struct {
+	Kind       judgment.PromotionInputKind
+	ID         shared.ID
+	EvidenceID shared.ID
+}
+
+// PriorEscalation is the latest applied escalation that may need reversal.
+type PriorEscalation struct {
+	EventID        shared.ID
+	BeforePriority int
+	InputsActive   bool
+	// InputsMatch reports that the current deterministic escalation evidence
+	// exactly matches this applied escalation. Matching evidence is already
+	// reflected in priority and must not cascade another escalation.
+	InputsMatch bool
+	// DeescalationInputsMatch reports that the current deterministic
+	// unreachability evidence exactly matches the latest applied de-escalation.
+	// Matching evidence is already reflected in priority and must not cascade.
+	DeescalationInputsMatch bool
+}
+
+// Snapshot is the normalized, I/O-free input to the promotion rules.
+type Snapshot struct {
+	FindingID                 shared.ID
+	FindingVersion            int
+	Priority                  int
+	Reachability              judgment.ReachabilityState
+	ReachabilityPublishable   bool
+	ReachabilityDeterministic bool
+	ReachabilitySignal        Signal
+	AttackPathSignal          Signal
+	PathPresent               bool
+	PathConfident             bool
+	DetectionSignals          []Signal
+	PriorEscalation           *PriorEscalation
+}
+
+// Evaluate returns at most one deterministic promotion claim. Signal-loss reversal restores the
+// exact prior priority recorded in the applied escalation event rather than stepping one level.
+func Evaluate(s Snapshot) (*judgment.PromotionClaim, error) {
+	if s.FindingID.IsZero() || s.FindingVersion < 1 || s.Priority < 1 || s.Priority > 5 {
+		return nil, fmt.Errorf("%w: promotion snapshot has invalid finding state", shared.ErrValidation)
+	}
+	inputs := []Signal{s.ReachabilitySignal}
+	if s.ReachabilityPublishable && s.ReachabilityDeterministic && s.Reachability == judgment.NotReachable && s.Priority < 5 && (s.PriorEscalation == nil || !s.PriorEscalation.DeescalationInputsMatch) {
+		return claim(s, judgment.RuleDeterministicUnreachable, judgment.PromotionDeescalate, s.Priority+1, inputs, nil)
+	}
+	if s.PriorEscalation != nil && !s.PriorEscalation.InputsActive {
+		prior := s.PriorEscalation.BeforePriority
+		if prior > s.Priority && prior >= 1 && prior <= 5 {
+			inputs = append(inputs, Signal{Kind: judgment.PromotionInputPrior, ID: s.PriorEscalation.EventID})
+			return claim(s, judgment.RuleCorroboratingSignalLoss, judgment.PromotionDeescalate, prior, inputs, nil)
+		}
+	}
+	if len(s.DetectionSignals) == 0 || !s.PathPresent {
+		return nil, nil
+	}
+	inputs = append(inputs, s.AttackPathSignal)
+	inputs = append(inputs, s.DetectionSignals...)
+	if s.ReachabilityPublishable && s.Reachability == judgment.Reachable && s.PathConfident && s.Priority > 1 && (s.PriorEscalation == nil || !s.PriorEscalation.InputsMatch) {
+		return claim(s, judgment.RuleRuntimeReachableExposed, judgment.PromotionEscalate, s.Priority-1, inputs, nil)
+	}
+	uncertainty := make([]string, 0, 2)
+	if !s.PathConfident {
+		uncertainty = append(uncertainty, "inferred_edge")
+	}
+	if !s.ReachabilityPublishable || s.Reachability == judgment.ReachUnknown {
+		uncertainty = append(uncertainty, "unknown_reachability")
+	}
+	if len(uncertainty) == 0 {
+		return nil, nil
+	}
+	return claim(s, judgment.RuleUncertainCorroboration, judgment.PromotionFlagForReview, s.Priority, inputs, uncertainty)
+}
+
+func claim(s Snapshot, rule string, effect judgment.PromotionChange, after int, signals []Signal, uncertainty []string) (*judgment.PromotionClaim, error) {
+	inputs := make([]judgment.PromotionInput, 0, len(signals))
+	for _, signal := range signals {
+		if signal.ID.IsZero() {
+			continue
+		}
+		inputs = append(inputs, judgment.PromotionInput{
+			Kind:       signal.Kind,
+			ID:         signal.ID,
+			EvidenceID: signal.EvidenceID,
+		})
+	}
+	sort.Slice(inputs, func(i, j int) bool {
+		if inputs[i].Kind != inputs[j].Kind {
+			return inputs[i].Kind < inputs[j].Kind
+		}
+		if inputs[i].ID != inputs[j].ID {
+			return inputs[i].ID < inputs[j].ID
+		}
+		return inputs[i].EvidenceID < inputs[j].EvidenceID
+	})
+	sort.Strings(uncertainty)
+	material := struct {
+		FindingID      shared.ID                 `json:"finding_id"`
+		Rule           string                    `json:"rule"`
+		Inputs         []judgment.PromotionInput `json:"inputs"`
+		Proposed       judgment.PromotionChange  `json:"proposed"`
+		Uncertainty    []string                  `json:"uncertainty,omitempty"`
+		FindingVersion int                       `json:"finding_version"`
+		BeforePriority int                       `json:"before_priority"`
+		AfterPriority  int                       `json:"after_priority"`
+	}{
+		FindingID:      s.FindingID,
+		Rule:           rule,
+		Inputs:         inputs,
+		Proposed:       effect,
+		Uncertainty:    uncertainty,
+		FindingVersion: s.FindingVersion,
+		BeforePriority: s.Priority,
+		AfterPriority:  after,
+	}
+	data, err := json.Marshal(material)
+	if err != nil {
+		return nil, fmt.Errorf("marshal promotion fingerprint: %w", err)
+	}
+	digest := sha256.Sum256(data)
+	out := &judgment.PromotionClaim{
+		FindingID:      s.FindingID,
+		Rule:           rule,
+		Inputs:         inputs,
+		Proposed:       effect,
+		Uncertainty:    uncertainty,
+		Fingerprint:    hex.EncodeToString(digest[:]),
+		FindingVersion: s.FindingVersion,
+		BeforePriority: s.Priority,
+		AfterPriority:  after,
+	}
+	if err := out.Validate(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/domain/promotion/rules_test.go
+++ b/internal/domain/promotion/rules_test.go
@@ -1,0 +1,457 @@
+package promotion
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func baseSnapshot() Snapshot {
+	return Snapshot{
+		FindingID:      "finding-1",
+		FindingVersion: 1,
+		Priority:       3,
+		Reachability:   judgment.ReachUnknown,
+		ReachabilitySignal: Signal{
+			Kind: judgment.PromotionInputReachability,
+			ID:   "reach-j1",
+		},
+	}
+}
+
+func TestEvaluateDeterministicEscalation(t *testing.T) {
+	cases := []struct {
+		name     string
+		priority int
+		want     int
+	}{
+		{"P5 to P4", 5, 4},
+		{"P4 to P3", 4, 3},
+		{"P3 to P2", 3, 2},
+		{"P2 to P1", 2, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := baseSnapshot()
+			s.Priority = tc.priority
+			s.Reachability = judgment.Reachable
+			s.ReachabilityPublishable = true
+			s.PathPresent = true
+			s.PathConfident = true
+			s.AttackPathSignal = Signal{Kind: judgment.PromotionInputAttackPath, ID: "ap-1"}
+			s.DetectionSignals = []Signal{{Kind: judgment.PromotionInputDetection, ID: "det-1"}}
+			got, err := Evaluate(s)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if got == nil {
+				t.Fatal("expected a claim, got nil")
+			}
+			if got.Rule != judgment.RuleRuntimeReachableExposed {
+				t.Errorf("rule = %s, want %s", got.Rule, judgment.RuleRuntimeReachableExposed)
+			}
+			if got.Proposed != judgment.PromotionEscalate {
+				t.Errorf("proposed = %s, want escalate", got.Proposed)
+			}
+			if got.BeforePriority != tc.priority {
+				t.Errorf("before = %d, want %d", got.BeforePriority, tc.priority)
+			}
+			if got.AfterPriority != tc.want {
+				t.Errorf("after = %d, want %d", got.AfterPriority, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateDeterministicEscalationBoundary(t *testing.T) {
+	s := baseSnapshot()
+	s.Priority = 1
+	s.Reachability = judgment.Reachable
+	s.ReachabilityPublishable = true
+	s.PathPresent = true
+	s.PathConfident = true
+	s.AttackPathSignal = Signal{Kind: judgment.PromotionInputAttackPath, ID: "ap-1"}
+	s.DetectionSignals = []Signal{{Kind: judgment.PromotionInputDetection, ID: "det-1"}}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got != nil {
+		t.Errorf("P1 must not escalate; got after=%d", got.AfterPriority)
+	}
+}
+
+func TestEvaluateDeterministicUnreachability(t *testing.T) {
+	cases := []struct {
+		name     string
+		priority int
+		want     int
+	}{
+		{"P1 to P2", 1, 2},
+		{"P3 to P4", 3, 4},
+		{"P4 to P5", 4, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := baseSnapshot()
+			s.Priority = tc.priority
+			s.Reachability = judgment.NotReachable
+			s.ReachabilityPublishable = true
+			s.ReachabilityDeterministic = true
+			got, err := Evaluate(s)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if got == nil {
+				t.Fatal("expected a claim, got nil")
+			}
+			if got.Rule != judgment.RuleDeterministicUnreachable {
+				t.Errorf("rule = %s, want %s", got.Rule, judgment.RuleDeterministicUnreachable)
+			}
+			if got.Proposed != judgment.PromotionDeescalate {
+				t.Errorf("proposed = %s, want de_escalate", got.Proposed)
+			}
+			if got.AfterPriority != tc.want {
+				t.Errorf("after = %d, want %d", got.AfterPriority, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateSkipsRepeatedDeterministicDeescalationForMatchingSignal(t *testing.T) {
+	s := baseSnapshot()
+	s.Priority = 4
+	s.Reachability = judgment.NotReachable
+	s.ReachabilityPublishable = true
+	s.ReachabilityDeterministic = true
+	s.PriorEscalation = &PriorEscalation{DeescalationInputsMatch: true}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("matching deterministic signal must not cascade P4 to P5: %+v", got)
+	}
+}
+
+func TestEvaluateChangedDeterministicDeescalationSignalProposesAgain(t *testing.T) {
+	s := baseSnapshot()
+	s.Priority = 4
+	s.Reachability = judgment.NotReachable
+	s.ReachabilityPublishable = true
+	s.ReachabilityDeterministic = true
+	s.PriorEscalation = &PriorEscalation{DeescalationInputsMatch: false}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.AfterPriority != 5 {
+		t.Fatalf("changed deterministic signal must propose P4 to P5: %+v", got)
+	}
+}
+
+func TestEvaluateDeterministicUnreachabilityBoundary(t *testing.T) {
+	s := baseSnapshot()
+	s.Priority = 5
+	s.Reachability = judgment.NotReachable
+	s.ReachabilityPublishable = true
+	s.ReachabilityDeterministic = true
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got != nil {
+		t.Errorf("P5 must not de-escalate; got after=%d", got.AfterPriority)
+	}
+}
+
+func TestEvaluateExactReversal(t *testing.T) {
+	s := baseSnapshot()
+	s.Priority = 2
+	s.PriorEscalation = &PriorEscalation{
+		EventID:        "evt-1",
+		BeforePriority: 4,
+		InputsActive:   false,
+	}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a reversal claim, got nil")
+	}
+	if got.Rule != judgment.RuleCorroboratingSignalLoss {
+		t.Errorf("rule = %s, want %s", got.Rule, judgment.RuleCorroboratingSignalLoss)
+	}
+	if got.Proposed != judgment.PromotionDeescalate {
+		t.Errorf("proposed = %s, want de_escalate", got.Proposed)
+	}
+	if got.AfterPriority != 4 {
+		t.Errorf("after = %d, want 4 (exact prior priority)", got.AfterPriority)
+	}
+}
+
+func TestEvaluateExactReversalSkipsWhenPriorNotHigher(t *testing.T) {
+	s := baseSnapshot()
+	s.Priority = 3
+	s.PriorEscalation = &PriorEscalation{
+		EventID:        "evt-1",
+		BeforePriority: 3,
+		InputsActive:   false,
+	}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got != nil && got.Rule == judgment.RuleCorroboratingSignalLoss {
+		t.Errorf("reversal should not fire when prior=%d <= current=%d", 3, s.Priority)
+	}
+}
+
+func TestEvaluateReversalSkipsWhenInputsStillActive(t *testing.T) {
+	s := baseSnapshot()
+	s.Priority = 2
+	s.PriorEscalation = &PriorEscalation{
+		EventID:        "evt-1",
+		BeforePriority: 4,
+		InputsActive:   true,
+	}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got != nil && got.Rule == judgment.RuleCorroboratingSignalLoss {
+		t.Error("reversal must not fire when inputs are still active")
+	}
+}
+
+func TestEvaluateSkipsRepeatedEscalationForMatchingAppliedInputs(t *testing.T) {
+	s := baseSnapshot()
+	s.Priority = 2
+	s.Reachability = judgment.Reachable
+	s.ReachabilityPublishable = true
+	s.PathPresent = true
+	s.PathConfident = true
+	s.AttackPathSignal = Signal{Kind: judgment.PromotionInputAttackPath, ID: "ap-1"}
+	s.DetectionSignals = []Signal{{Kind: judgment.PromotionInputDetection, ID: "det-1", EvidenceID: "ev-1"}}
+	s.PriorEscalation = &PriorEscalation{EventID: "evt-1", BeforePriority: 3, InputsActive: true, InputsMatch: true}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("matching applied inputs must not cascade priority, got %+v", got)
+	}
+}
+
+func TestEvaluateEscalatesForChangedInputsAfterApplication(t *testing.T) {
+	s := baseSnapshot()
+	s.Priority = 2
+	s.Reachability = judgment.Reachable
+	s.ReachabilityPublishable = true
+	s.PathPresent = true
+	s.PathConfident = true
+	s.AttackPathSignal = Signal{Kind: judgment.PromotionInputAttackPath, ID: "ap-1"}
+	s.DetectionSignals = []Signal{{Kind: judgment.PromotionInputDetection, ID: "det-2", EvidenceID: "ev-2"}}
+	s.PriorEscalation = &PriorEscalation{EventID: "evt-1", BeforePriority: 3, InputsActive: true, InputsMatch: false}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got == nil || got.Proposed != judgment.PromotionEscalate || got.AfterPriority != 1 {
+		t.Fatalf("changed inputs must allow a distinct escalation, got %+v", got)
+	}
+}
+
+func TestEvaluateUncertainCorroboration(t *testing.T) {
+	cases := []struct {
+		name        string
+		confident   bool
+		publishable bool
+		reach       judgment.ReachabilityState
+		wantTokens  []string
+	}{
+		{
+			name:        "inferred path + unknown reachability",
+			confident:   false,
+			publishable: false,
+			reach:       judgment.ReachUnknown,
+			wantTokens:  []string{"inferred_edge", "unknown_reachability"},
+		},
+		{
+			name:        "inferred path only",
+			confident:   false,
+			publishable: true,
+			reach:       judgment.Reachable,
+			wantTokens:  []string{"inferred_edge"},
+		},
+		{
+			name:        "unknown reachability only",
+			confident:   true,
+			publishable: false,
+			reach:       judgment.ReachUnknown,
+			wantTokens:  []string{"unknown_reachability"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := baseSnapshot()
+			s.Reachability = tc.reach
+			s.ReachabilityPublishable = tc.publishable
+			s.PathPresent = true
+			s.PathConfident = tc.confident
+			s.AttackPathSignal = Signal{Kind: judgment.PromotionInputAttackPath, ID: "ap-1"}
+			s.DetectionSignals = []Signal{{Kind: judgment.PromotionInputDetection, ID: "det-1"}}
+			got, err := Evaluate(s)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if got == nil {
+				t.Fatal("expected a review claim, got nil")
+			}
+			if got.Rule != judgment.RuleUncertainCorroboration {
+				t.Errorf("rule = %s, want %s", got.Rule, judgment.RuleUncertainCorroboration)
+			}
+			if got.Proposed != judgment.PromotionFlagForReview {
+				t.Errorf("proposed = %s, want flag_for_review", got.Proposed)
+			}
+			if got.AfterPriority != s.Priority {
+				t.Errorf("review must not change priority: after=%d, want=%d", got.AfterPriority, s.Priority)
+			}
+			if len(got.Uncertainty) != len(tc.wantTokens) {
+				t.Fatalf("uncertainty tokens = %v, want %v", got.Uncertainty, tc.wantTokens)
+			}
+			for i, tok := range got.Uncertainty {
+				if tok != tc.wantTokens[i] {
+					t.Errorf("uncertainty[%d] = %s, want %s", i, tok, tc.wantTokens[i])
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluateNoDetectionReturnsNil(t *testing.T) {
+	s := baseSnapshot()
+	s.PathPresent = true
+	s.PathConfident = true
+	s.DetectionSignals = nil
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got != nil {
+		t.Error("no detections must return nil")
+	}
+}
+
+func TestEvaluateNoPathReturnsNil(t *testing.T) {
+	s := baseSnapshot()
+	s.PathPresent = false
+	s.DetectionSignals = []Signal{{Kind: judgment.PromotionInputDetection, ID: "det-1"}}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if got != nil {
+		t.Error("no path must return nil")
+	}
+}
+
+func TestEvaluateDeterminismIdempotentFingerprint(t *testing.T) {
+	s := baseSnapshot()
+	s.Reachability = judgment.Reachable
+	s.ReachabilityPublishable = true
+	s.PathPresent = true
+	s.PathConfident = true
+	s.AttackPathSignal = Signal{Kind: judgment.PromotionInputAttackPath, ID: "ap-1"}
+	s.DetectionSignals = []Signal{
+		{Kind: judgment.PromotionInputDetection, ID: "det-b"},
+		{Kind: judgment.PromotionInputDetection, ID: "det-a"},
+	}
+	first, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("first Evaluate: %v", err)
+	}
+	second, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("second Evaluate: %v", err)
+	}
+	if first.Fingerprint != second.Fingerprint {
+		t.Errorf("fingerprint not deterministic: %s != %s", first.Fingerprint, second.Fingerprint)
+	}
+}
+
+func TestEvaluateInputSorting(t *testing.T) {
+	s := baseSnapshot()
+	s.Reachability = judgment.Reachable
+	s.ReachabilityPublishable = true
+	s.PathPresent = true
+	s.PathConfident = true
+	s.AttackPathSignal = Signal{Kind: judgment.PromotionInputAttackPath, ID: "ap-z"}
+	s.DetectionSignals = []Signal{
+		{Kind: judgment.PromotionInputDetection, ID: "det-m"},
+		{Kind: judgment.PromotionInputDetection, ID: "det-a"},
+	}
+	got, err := Evaluate(s)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	for i := 1; i < len(got.Inputs); i++ {
+		prev, cur := got.Inputs[i-1], got.Inputs[i]
+		if prev.Kind > cur.Kind || (prev.Kind == cur.Kind && prev.ID >= cur.ID) {
+			t.Errorf("inputs not sorted at %d: %+v >= %+v", i-1, prev, cur)
+		}
+	}
+}
+
+func TestEvaluateInvalidSnapshot(t *testing.T) {
+	cases := []struct {
+		name string
+		snap Snapshot
+	}{
+		{"zero finding id", Snapshot{FindingID: "", FindingVersion: 1, Priority: 3}},
+		{"zero version", Snapshot{FindingID: "f1", FindingVersion: 0, Priority: 3}},
+		{"priority zero", Snapshot{FindingID: "f1", FindingVersion: 1, Priority: 0}},
+		{"priority too high", Snapshot{FindingID: "f1", FindingVersion: 1, Priority: 6}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Evaluate(tc.snap)
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Errorf("want ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRulesCatalogueDriftGuard(t *testing.T) {
+	rules := Rules()
+	if len(rules) == 0 {
+		t.Fatal("Rules() returned empty; the drift test would pass vacuously")
+	}
+	for i := 1; i < len(rules); i++ {
+		if rules[i-1].Key >= rules[i].Key {
+			t.Errorf("rules not sorted by key at %d: %s >= %s", i-1, rules[i-1].Key, rules[i].Key)
+		}
+	}
+	for _, r := range rules {
+		if !strings.HasPrefix(r.Key, "promotion.") {
+			t.Errorf("rule key %q missing promotion. prefix", r.Key)
+		}
+		if r.Inputs == "" {
+			t.Errorf("rule %q has empty inputs description", r.Key)
+		}
+		if !r.Effect.Valid() {
+			t.Errorf("rule %q has invalid effect %q", r.Key, r.Effect)
+		}
+	}
+	rules2 := Rules()
+	for i := range rules {
+		if rules[i].Key != rules2[i].Key {
+			t.Errorf("Rules() not deterministic at %d: %s vs %s", i, rules[i].Key, rules2[i].Key)
+		}
+	}
+}

--- a/internal/domain/promotion/testdata/promotion-rules.md
+++ b/internal/domain/promotion/testdata/promotion-rules.md
@@ -1,0 +1,76 @@
+# Promotion Rules
+
+Promotion rules are deterministic, pure-domain policies that propose finding-priority changes
+based on cross-pillar signals. They never mutate state directly; a distinct verifier must
+confirm the proposal through the judgment gate.
+
+## Rule catalogue
+
+### promotion.escalate.runtime_reachable_exposed
+
+- **Inputs**: publishable reachable judgment, confident internet-exposure path, active detection on a path asset
+- **Effect**: escalate (one level toward P1)
+- **Confidence**: all inputs confirmed or observed
+- **Reversal**: signal loss proposes de-escalation
+
+### promotion.deescalate.deterministic_unreachable
+
+- **Inputs**: publishable deterministic not-reachable judgment
+- **Effect**: de-escalate (one level toward P5)
+- **Confidence**: deterministic proof
+- **Reversal**: a later reachable proof is reevaluated
+
+### promotion.deescalate.corroborating_signal_loss
+
+- **Inputs**: prior applied escalation plus lost or superseded corroborating input
+- **Effect**: de-escalate (restores the exact prior priority from the applied escalation event)
+- **Confidence**: deterministic signal loss
+- **Reversal**: restores the prior escalation's before priority
+
+### promotion.review.uncertain_corroboration
+
+- **Inputs**: plausible runtime corroboration with inferred path or unknown reachability
+- **Effect**: flag_for_review (no priority change)
+- **Confidence**: uncertain
+- **Reversal**: reevaluated when inputs become certain
+
+## Priority boundaries
+
+- Priorities are integers in the range 1..5 (P1 = highest, P5 = lowest).
+- Escalation moves exactly one level toward P1. P1 cannot escalate.
+- De-escalation moves toward P5. Normal de-escalation (deterministic unreachable) moves
+  exactly one level. Signal-loss reversal restores the exact `BeforePriority` recorded in the
+  prior escalation event, which may span multiple levels.
+- P5 cannot de-escalate.
+- `flag_for_review` never changes priority.
+
+## Uncertainty
+
+Any uncertainty token in a proposal forces the effect to `flag_for_review`. Confident
+escalation or de-escalation requires all inputs to be fully confirmed or observed. Known
+uncertainty tokens:
+
+- `inferred_edge`: the attack path contains inferred (not confirmed) edges.
+- `unknown_reachability`: the reachability judgment is not publishable or is `unknown`.
+
+## Input ordering
+
+Inputs are sorted by kind, then by ID, then by evidence ID. The sort is deterministic and
+produces stable fingerprints for idempotent reevaluation.
+
+## Fingerprint
+
+The fingerprint is a SHA-256 digest of the complete normalized input state: finding ID, rule
+key, sorted inputs, proposed effect, sorted uncertainty tokens, finding version, and
+before/after priority. Two evaluations with identical state produce the same fingerprint,
+enabling the service layer to skip unchanged proposals.
+
+## Evaluation precedence
+
+The `Evaluate` function returns at most one claim per snapshot, evaluated in this order:
+
+1. Deterministic unreachability (highest precedence when publishable and deterministic).
+2. Signal-loss reversal (when a prior escalation exists and its inputs are no longer active).
+3. Runtime reachable exposed (when all corroboration signals are present and confident).
+4. Uncertain corroboration (when signals are present but confidence is incomplete).
+5. No claim (when no rule matches).

--- a/internal/domain/verdict/verdict.go
+++ b/internal/domain/verdict/verdict.go
@@ -16,6 +16,9 @@ import (
 // promoted/published. Shared by finding + judgment; do not fork it.
 const EvidenceThreshold = 75
 
+// MaxRationaleBytes bounds sealed verdict rationale payloads and promotion-event provenance.
+const MaxRationaleBytes = 4096
+
 // DeterministicProofScore is the fixed evidence score for a judgment confirmed by a DETERMINISTIC tool
 // proof (a call-graph reachability result), as opposed to a human verdict or an LLM claim.
 // It is well above EvidenceThreshold because a reproducible static call-path is strong evidence, but NOT
@@ -44,6 +47,9 @@ func (v Verdict) Validate() error {
 	}
 	if strings.TrimSpace(v.Rationale) == "" {
 		return fmt.Errorf("%w: verdict requires a rationale", shared.ErrValidation)
+	}
+	if len(v.Rationale) > MaxRationaleBytes {
+		return fmt.Errorf("%w: verdict rationale exceeds %d bytes", shared.ErrValidation, MaxRationaleBytes)
 	}
 	return nil
 }

--- a/internal/domain/verdict/verdict_test.go
+++ b/internal/domain/verdict/verdict_test.go
@@ -2,6 +2,7 @@ package verdict
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -20,6 +21,8 @@ func TestVerdictValidate(t *testing.T) {
 		{"score negative", Verdict{Verifier: "reviewer", Score: -1, Rationale: "x"}, false},
 		{"score over 100", Verdict{Verifier: "reviewer", Score: 101, Rationale: "x"}, false},
 		{"no rationale", Verdict{Verifier: "reviewer", Score: 80, Rationale: " "}, false},
+		{"rationale at byte limit", Verdict{Verifier: "reviewer", Score: 80, Rationale: strings.Repeat("a", MaxRationaleBytes)}, true},
+		{"rationale over byte limit", Verdict{Verifier: "reviewer", Score: 80, Rationale: strings.Repeat("a", MaxRationaleBytes+1)}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/infrastructure/persistence/file/audit_log.go
+++ b/internal/infrastructure/persistence/file/audit_log.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/audit"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -20,41 +21,56 @@ import (
 type AuditLog struct {
 	path string
 	mu   sync.Mutex
-	// head is the hash of the last appended record; "" before the first append.
-	// loaded becomes true once head has been recovered from the file tail so the
-	// chain survives a process restart.
-	head   string
+
+	// Loaded lazily under mu because construction must not fail if the audit path
+	// has not been created yet.
+	heads  map[string]string
 	loaded bool
 }
 
+// auditFileEntry keeps RecordOnce's tenant-scoped identity outside caller metadata.
+// Existing tenantless records decode with an empty TenantID for compatibility.
+type auditFileEntry struct {
+	ports.AuditEntry
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
 // NewAuditLog returns an append-only audit log writing JSONL to path.
-func NewAuditLog(path string) *AuditLog { return &AuditLog{path: path} }
+func NewAuditLog(path string) *AuditLog { return &AuditLog{path: path, heads: map[string]string{}} }
 
 var (
-	_ ports.AuditLogger = (*AuditLog)(nil)
-	_ ports.AuditReader = (*AuditLog)(nil)
+	_ ports.AuditLogger           = (*AuditLog)(nil)
+	_ ports.AuditReader           = (*AuditLog)(nil)
+	_ ports.IdempotentAuditLogger = (*AuditLog)(nil)
 )
 
-// readAll returns every entry oldest-first (file order), tolerating blank/partial
-// lines. Caller holds the mutex.
-func (a *AuditLog) readAll() ([]ports.AuditEntry, error) {
+// readAll returns every entry oldest-first (file order). Caller holds the mutex.
+// Every record must be a complete non-blank JSON line; accepting a valid suffix
+// after corruption would let Verify report an incomplete chain as intact.
+func (a *AuditLog) readAll() ([]auditFileEntry, error) {
 	data, err := os.ReadFile(a.path) // #nosec G304 -- operator config path
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []ports.AuditEntry{}, nil
+			return []auditFileEntry{}, nil
 		}
 		return nil, fmt.Errorf("audit read: %w", err)
 	}
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	out := make([]ports.AuditEntry, 0, len(lines))
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
+	if len(data) == 0 {
+		return []auditFileEntry{}, nil
+	}
+	if data[len(data)-1] != '\n' {
+		return nil, fmt.Errorf("audit record %d: incomplete final record", strings.Count(string(data), "\n")+1)
+	}
+
+	lines := strings.Split(string(data[:len(data)-1]), "\n")
+	out := make([]auditFileEntry, 0, len(lines))
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			return nil, fmt.Errorf("audit record %d: blank record", i+1)
 		}
-		var e ports.AuditEntry
+		var e auditFileEntry
 		if err := json.Unmarshal([]byte(line), &e); err != nil {
-			continue // tolerate a malformed/partial line
+			return nil, fmt.Errorf("audit decode record %d: %w", i+1, err)
 		}
 		out = append(out, e)
 	}
@@ -64,7 +80,11 @@ func (a *AuditLog) readAll() ([]ports.AuditEntry, error) {
 // List returns the most recent audit entries (newest first), capped at limit, by
 // reading the JSONL sink. Dev-scale only (the file is small); Postgres is used in
 // any real deployment.
-func (a *AuditLog) List(_ context.Context, limit int) ([]ports.AuditEntry, error) {
+func (a *AuditLog) List(ctx context.Context, limit int) ([]ports.AuditEntry, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
 	if limit <= 0 || limit > 1000 {
 		limit = 200
 	}
@@ -76,21 +96,33 @@ func (a *AuditLog) List(_ context.Context, limit int) ([]ports.AuditEntry, error
 	}
 	out := make([]ports.AuditEntry, 0, limit)
 	for i := len(all) - 1; i >= 0 && len(out) < limit; i-- {
-		out = append(out, all[i])
+		if all[i].TenantID == tenantID.String() {
+			out = append(out, all[i].AuditEntry)
+		}
 	}
 	return out, nil
 }
 
 // Verify re-derives the hash chain over the whole log (oldest-first) and reports
 // whether it is intact.
-func (a *AuditLog) Verify(_ context.Context) (audit.Report, error) {
+func (a *AuditLog) Verify(ctx context.Context) (audit.Report, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return audit.Report{}, fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	all, err := a.readAll()
 	if err != nil {
 		return audit.Report{}, err
 	}
-	return audit.Verify(toRecords(all)), nil
+	entries := make([]auditFileEntry, 0)
+	for _, entry := range all {
+		if entry.TenantID == tenantID.String() {
+			entries = append(entries, entry)
+		}
+	}
+	return audit.Verify(toRecords(entries)), nil
 }
 
 // loadHead recovers the chain head from the file tail once per process. Caller
@@ -103,22 +135,60 @@ func (a *AuditLog) loadHead() error {
 	if err != nil {
 		return err
 	}
-	if len(all) > 0 {
-		a.head = all[len(all)-1].Hash
+	for _, entry := range all {
+		if entry.TenantID != "" {
+			a.heads[entry.TenantID] = entry.Hash
+		}
 	}
 	a.loaded = true
 	return nil
 }
 
-// Record appends one audit entry, chaining it to the previous record. The file is
-// opened O_APPEND so existing records can never be overwritten in-process.
+// RecordOnce appends an idempotent audit entry, chaining it to the previous record.
+// It persists the context tenant with the key, while tenantless records remain global.
+func (a *AuditLog) RecordOnce(ctx context.Context, e ports.AuditEntry) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if key := e.Metadata["idempotency_key"]; key != "" {
+		all, err := a.readAll()
+		if err != nil {
+			return err
+		}
+		tenantID := ""
+		if tenant, ok := shared.TenantFrom(ctx); ok {
+			tenantID = tenant.String()
+		}
+		for _, existing := range all {
+			if existing.Action == e.Action && existing.Metadata["idempotency_key"] == key && existing.TenantID == tenantID {
+				return nil
+			}
+		}
+		return a.recordLocked(auditFileEntry{AuditEntry: e, TenantID: tenantID})
+	}
+	tenantID := ""
+	if tenant, ok := shared.TenantFrom(ctx); ok {
+		tenantID = tenant.String()
+	}
+	return a.recordLocked(auditFileEntry{AuditEntry: e, TenantID: tenantID})
+}
+
 func (a *AuditLog) Record(ctx context.Context, e ports.AuditEntry) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	tenantID := ""
+	if tenant, ok := shared.TenantFrom(ctx); ok {
+		tenantID = tenant.String()
+	}
+	return a.recordLocked(auditFileEntry{AuditEntry: e, TenantID: tenantID})
+}
 
+func (a *AuditLog) recordLocked(entry auditFileEntry) error {
 	if dir := filepath.Dir(a.path); dir != "" && dir != "." {
 		if err := os.MkdirAll(dir, 0o750); err != nil {
 			return fmt.Errorf("audit mkdir: %w", err)
@@ -127,10 +197,13 @@ func (a *AuditLog) Record(ctx context.Context, e ports.AuditEntry) error {
 	if err := a.loadHead(); err != nil {
 		return err
 	}
-	e.PreviousHash = a.head
-	e.Hash = audit.ComputeHash(a.head, e.Actor, e.Action, e.Target, e.Metadata, e.At)
+	e := entry.AuditEntry
+	previous := a.heads[entry.TenantID]
+	e.PreviousHash = previous
+	e.Hash = audit.ComputeHash(previous, e.Actor, e.Action, e.Target, e.Metadata, e.At)
+	entry.AuditEntry = e
 
-	b, err := json.Marshal(e)
+	b, err := json.Marshal(entry)
 	if err != nil {
 		return fmt.Errorf("audit encode: %w", err)
 	}
@@ -142,14 +215,15 @@ func (a *AuditLog) Record(ctx context.Context, e ports.AuditEntry) error {
 	if _, err := f.Write(append(b, '\n')); err != nil {
 		return fmt.Errorf("audit write: %w", err)
 	}
-	a.head = e.Hash
+	a.heads[entry.TenantID] = e.Hash
 	return nil
 }
 
 // toRecords maps oldest-first audit entries to chain records for verification.
-func toRecords(entries []ports.AuditEntry) []audit.Record {
+func toRecords(entries []auditFileEntry) []audit.Record {
 	recs := make([]audit.Record, len(entries))
-	for i, e := range entries {
+	for i, entry := range entries {
+		e := entry.AuditEntry
 		recs[i] = audit.Record{
 			Actor: e.Actor, Action: e.Action, Target: e.Target,
 			Metadata: e.Metadata, At: e.At, Hash: e.Hash, PreviousHash: e.PreviousHash,

--- a/internal/infrastructure/persistence/file/audit_log_test.go
+++ b/internal/infrastructure/persistence/file/audit_log_test.go
@@ -2,12 +2,14 @@ package file
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -37,7 +39,7 @@ func TestAuditLogAppends(t *testing.T) {
 
 func TestAuditLogChainsAndVerifies(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.jsonl")
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
 
 	// First process: write two entries.
 	a := NewAuditLog(path)
@@ -73,7 +75,7 @@ func TestAuditLogChainsAndVerifies(t *testing.T) {
 
 func TestAuditLogVerifyDetectsTampering(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.jsonl")
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
 	a := NewAuditLog(path)
 	for _, act := range []string{"a", "b", "c"} {
 		if err := a.Record(ctx, ports.AuditEntry{Actor: "operator", Action: act, Target: "t", At: time.Unix(0, 0).UTC()}); err != nil {
@@ -95,5 +97,148 @@ func TestAuditLogVerifyDetectsTampering(t *testing.T) {
 	}
 	if rep.Intact {
 		t.Fatalf("tampering must be detected, report = %+v", rep)
+	}
+}
+
+func TestAuditLogRejectsMalformedRecords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	a := NewAuditLog(path)
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		if err := a.Record(ctx, ports.AuditEntry{Actor: "operator", Action: "a", Target: "t", At: time.Unix(int64(i), 0).UTC()}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstEnd := strings.IndexByte(string(raw), '\n') + 1
+	for _, tc := range []struct {
+		name string
+		data []byte
+	}{
+		{"malformed middle", append(append(append([]byte(nil), raw[:firstEnd]...), []byte("{bad json}\n")...), raw[firstEnd:]...)},
+		{"blank record", append(append(append([]byte(nil), raw[:firstEnd]...), '\n'), raw[firstEnd:]...)},
+		{"torn final", append(append([]byte(nil), raw...), []byte("{\"actor\":\"partial\"")...)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(path, tc.data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			broken := NewAuditLog(path)
+			if _, err := broken.Verify(ctx); err == nil {
+				t.Fatal("Verify accepted corrupt audit log")
+			}
+			if _, err := broken.List(ctx, 10); err == nil {
+				t.Fatal("List accepted corrupt audit log")
+			}
+			if err := broken.RecordOnce(ctx, ports.AuditEntry{Actor: "operator", Action: "a", Target: "t", Metadata: map[string]string{"idempotency_key": "retry"}, At: time.Unix(2, 0).UTC()}); err == nil {
+				t.Fatal("RecordOnce wrote through corrupt audit log")
+			}
+		})
+	}
+}
+
+func TestAuditLogRecordOnceScopesIdempotencyByTenant(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	log := NewAuditLog(path)
+	ctx := context.Background()
+	entry := ports.AuditEntry{
+		Actor:    "operator",
+		Action:   "promotion.apply",
+		Target:   "finding-1",
+		Metadata: map[string]string{"idempotency_key": "retry"},
+		At:       time.Unix(0, 0).UTC(),
+	}
+
+	for _, tenantCtx := range []context.Context{
+		shared.WithTenant(ctx, "tenant-a"),
+		shared.WithTenant(ctx, "tenant-a"),
+		shared.WithTenant(ctx, "tenant-b"),
+		ctx,
+		ctx,
+	} {
+		if err := log.RecordOnce(tenantCtx, entry); err != nil {
+			t.Fatalf("RecordOnce: %v", err)
+		}
+	}
+	if _, ok := entry.Metadata["tenant_id"]; ok {
+		t.Fatal("RecordOnce mutated caller metadata")
+	}
+
+	entries, err := log.List(shared.WithTenant(ctx, "tenant-a"), 10)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("tenant-a idempotent audit entries = %d, want 1", len(entries))
+	}
+	for _, e := range entries {
+		if _, ok := e.Metadata["tenant_id"]; ok {
+			t.Fatal("tenant identity leaked into audit metadata")
+		}
+	}
+	if report, err := log.Verify(shared.WithTenant(ctx, "tenant-a")); err != nil || !report.Intact {
+		t.Fatalf("Verify = %+v, %v", report, err)
+	}
+}
+
+func TestAuditLogTenantEndpointsIsolateV2Chains(t *testing.T) {
+	log := NewAuditLog(filepath.Join(t.TempDir(), "audit.jsonl"))
+	base := context.Background()
+	a := shared.WithTenant(base, "tenant-a")
+	b := shared.WithTenant(base, "tenant-b")
+	if err := log.Record(a, ports.AuditEntry{Actor: "a", Action: "a1", Target: "t", At: time.Unix(1, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := log.Record(b, ports.AuditEntry{Actor: "b", Action: "b1", Target: "t", At: time.Unix(2, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := log.Record(a, ports.AuditEntry{Actor: "a", Action: "a2", Target: "t", At: time.Unix(3, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := log.List(a, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].Action != "a2" || got[1].Action != "a1" {
+		t.Fatalf("tenant A entries = %#v", got)
+	}
+	if rep, err := log.Verify(a); err != nil || !rep.Intact || rep.Verified != 2 {
+		t.Fatalf("tenant A verify = %+v, %v", rep, err)
+	}
+	got, err = log.List(b, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Action != "b1" {
+		t.Fatalf("tenant B entries = %#v", got)
+	}
+	if _, err := log.List(base, 10); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant List error = %v", err)
+	}
+	if _, err := log.Verify(base); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant Verify error = %v", err)
+	}
+}
+
+func TestAuditLogTenantEndpointsHideLegacyEntries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	legacy := NewAuditLog(path)
+	if err := legacy.Record(context.Background(), ports.AuditEntry{Actor: "legacy", Action: "old", Target: "t", At: time.Unix(1, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+	log := NewAuditLog(path)
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	got, err := log.List(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("tenant endpoint exposed legacy entries: %#v", got)
+	}
+	if rep, err := log.Verify(ctx); err != nil || !rep.Intact || rep.Verified != 0 {
+		t.Fatalf("tenant verify legacy chain = %+v, %v", rep, err)
 	}
 }

--- a/internal/infrastructure/persistence/memory/engagement_repo.go
+++ b/internal/infrastructure/persistence/memory/engagement_repo.go
@@ -24,6 +24,7 @@ func NewEngagementRepository() *EngagementRepository {
 
 // Compile-time assertion that we satisfy the port.
 var _ ports.EngagementRepository = (*EngagementRepository)(nil)
+var _ ports.PromotionReconciliationScopeReader = (*EngagementRepository)(nil)
 
 func (r *EngagementRepository) Create(_ context.Context, e *engagement.Engagement) error {
 	r.mu.Lock()
@@ -107,6 +108,27 @@ func (r *EngagementRepository) Delete(_ context.Context, id shared.ID) error {
 	defer r.mu.Unlock()
 	delete(r.data, id)
 	return nil
+}
+
+// ListPromotionReconciliationScopes returns every non-project engagement for
+// process-local recovery. It is only wired by the API composition root.
+func (r *EngagementRepository) ListPromotionReconciliationScopes(ctx context.Context) ([]ports.PromotionReconciliationScope, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]ports.PromotionReconciliationScope, 0, len(r.data))
+	for _, e := range r.data {
+		if !e.ProjectID.IsZero() {
+			continue
+		}
+		out = append(out, ports.PromotionReconciliationScope{
+			TenantID:     shared.TenantOrDefault(e.TenantID),
+			EngagementID: e.ID,
+		})
+	}
+	return out, nil
 }
 
 func (r *EngagementRepository) List(_ context.Context, tenantID shared.ID) ([]*engagement.Engagement, error) {

--- a/internal/infrastructure/persistence/memory/evidence_repo.go
+++ b/internal/infrastructure/persistence/memory/evidence_repo.go
@@ -12,24 +12,33 @@ import (
 
 // EvidenceStore is an in-memory append-only evidence ledger.
 type EvidenceStore struct {
-	mu    sync.RWMutex
-	items map[shared.ID][]evidence.Evidence // by engagement, in append order
+	mu          sync.RWMutex
+	items       map[shared.ID][]evidence.Evidence // by engagement, in append order
+	engagements map[shared.ID]shared.ID           // engagement -> tenant; first append establishes ownership
 }
 
 // NewEvidenceStore returns an empty in-memory evidence store.
 func NewEvidenceStore() *EvidenceStore {
-	return &EvidenceStore{items: map[shared.ID][]evidence.Evidence{}}
+	return &EvidenceStore{
+		items:       map[shared.ID][]evidence.Evidence{},
+		engagements: map[shared.ID]shared.ID{},
+	}
 }
 
+// sameEvidence compares the complete sealed record, including chain metadata.
 var _ ports.EvidenceStore = (*EvidenceStore)(nil)
 
-func (s *EvidenceStore) Append(_ context.Context, items []evidence.Evidence) error {
+func (s *EvidenceStore) Append(ctx context.Context, items []evidence.Evidence) error {
+	tenantID, scoped := shared.TenantFrom(ctx)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Fork guard: one child per parent. Validate the WHOLE batch before mutating –
-	// against existing links AND earlier items in the same batch – so a mid-batch conflict
-	// leaves nothing appended (atomic, mirroring the Postgres transaction + unique index).
+	// Validate the whole batch before mutating. Reserved-ID replay is resolved
+	// by the evidence service before append; this store preserves legacy ID
+	// generator compatibility for ordinary, non-reserved evidence links.
 	for i, e := range items {
+		if owner, exists := s.engagements[e.EngagementID]; exists && scoped && owner != tenantID {
+			return fmt.Errorf("evidence engagement %s: %w", e.EngagementID, shared.ErrNotFound)
+		}
 		for _, existing := range s.items[e.EngagementID] {
 			if existing.PreviousHash == e.PreviousHash {
 				return fmt.Errorf("evidence chain: parent already linked: %w", shared.ErrConflict)
@@ -43,25 +52,54 @@ func (s *EvidenceStore) Append(_ context.Context, items []evidence.Evidence) err
 	}
 	for _, e := range items {
 		s.items[e.EngagementID] = append(s.items[e.EngagementID], e)
+		if scoped {
+			s.engagements[e.EngagementID] = tenantID
+		}
 	}
 	return nil
 }
 
-func (s *EvidenceStore) ListByEngagement(_ context.Context, engagementID shared.ID) ([]evidence.Evidence, error) {
+func (s *EvidenceStore) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]evidence.Evidence, error) {
+	tenantID, scoped := shared.TenantFrom(ctx)
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	if owner, exists := s.engagements[engagementID]; exists && scoped && owner != tenantID {
+		return nil, fmt.Errorf("evidence engagement %s: %w", engagementID, shared.ErrNotFound)
+	}
 	src := s.items[engagementID]
 	out := make([]evidence.Evidence, len(src))
 	copy(out, src)
 	return out, nil
 }
 
-func (s *EvidenceStore) Head(_ context.Context, engagementID shared.ID) (string, error) {
+func (s *EvidenceStore) Head(ctx context.Context, engagementID shared.ID) (string, error) {
+	tenantID, scoped := shared.TenantFrom(ctx)
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	if owner, exists := s.engagements[engagementID]; exists && scoped && owner != tenantID {
+		return "", fmt.Errorf("evidence engagement %s: %w", engagementID, shared.ErrNotFound)
+	}
 	chain := s.items[engagementID]
 	if len(chain) == 0 {
 		return "", nil
 	}
 	return chain[len(chain)-1].Hash, nil
+}
+
+// LookupSealedForFinding returns the most recent sealed evidence link of the
+// given kind for the specified finding, or (zero, false, nil) if none exists.
+// Used for crash-recoverable evidence reservation in the promotion recorder.
+func (s *EvidenceStore) LookupSealedForFinding(_ context.Context, engagementID, findingID shared.ID, kind string) (evidence.Evidence, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	chain := s.items[engagementID]
+	// Scan backward to find the most recent matching link.
+	for i := len(chain) - 1; i >= 0; i-- {
+		e := chain[i]
+		if e.FindingID == findingID && e.Kind == kind {
+			out := e // defensive copy
+			return out, true, nil
+		}
+	}
+	return evidence.Evidence{}, false, nil
 }

--- a/internal/infrastructure/persistence/memory/finding_repo.go
+++ b/internal/infrastructure/persistence/memory/finding_repo.go
@@ -77,8 +77,9 @@ func (r *FindingRepository) Upsert(_ context.Context, findings []finding.Finding
 			f.Status = existing.Status // preserve triage
 			f.Assignee = existing.Assignee
 			f.Audit.CreatedAt = existing.Audit.CreatedAt
-			f.Version = existing.Version             // version is a triage token; re-scans preserve it
+			f.Version = existing.Version + 1         // re-scan is a concurrent change; bump version (mirrors postgres)
 			f.EvidenceScore = existing.EvidenceScore // moves only via SetEvidenceScore; a re-upsert never changes it – mirrors the postgres ON CONFLICT set
+			f.Priority = existing.Priority           // preserve promoted priority; PromotionStore.Apply is the only path that moves it
 		} else if f.Version <= 0 {
 			f.Version = 1
 		}
@@ -125,6 +126,18 @@ func (r *FindingRepository) SetAssignee(_ context.Context, engagementID, finding
 	return finding.Finding{}, fmt.Errorf("finding %s: %w", findingID, shared.ErrNotFound)
 }
 
+// GetByEngagementAndID loads a single finding by engagement and finding ID.
+func (r *FindingRepository) GetByEngagementAndID(_ context.Context, engagementID, findingID shared.ID) (finding.Finding, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, f := range r.data[engagementID] {
+		if f.ID == findingID {
+			return f, nil
+		}
+	}
+	return finding.Finding{}, fmt.Errorf("finding %s in engagement %s: %w", findingID, engagementID, shared.ErrNotFound)
+}
+
 // SetEvidenceScore sets a finding's evidence score with the same optimistic-concurrency
 // guard as UpdateStatus (the adversarial-verdict path). Returns
 // shared.ErrConflict on a version mismatch, shared.ErrNotFound if absent.
@@ -137,6 +150,28 @@ func (r *FindingRepository) SetEvidenceScore(_ context.Context, engagementID, fi
 				return finding.Finding{}, fmt.Errorf("finding %s changed since you loaded it: %w", findingID, shared.ErrConflict)
 			}
 			f.EvidenceScore = score
+			f.Version++
+			r.data[engagementID][key] = f
+			return f, nil
+		}
+	}
+	return finding.Finding{}, fmt.Errorf("finding %s: %w", findingID, shared.ErrNotFound)
+}
+
+// setPriorityInternal sets a finding's priority and increments its version. It
+// is package-private: only PromotionStore.Apply calls it after its own lock
+// acquisition and priority/version verification. The caller MUST hold
+// PromotionStore.mu; this method acquires FindingRepository.mu (lock ordering:
+// PromotionStore.mu before FindingRepository.mu).
+func (r *FindingRepository) setPriorityInternal(engagementID, findingID shared.ID, priority, expectedVersion int) (finding.Finding, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for key, f := range r.data[engagementID] {
+		if f.ID == findingID {
+			if f.Version != expectedVersion {
+				return finding.Finding{}, fmt.Errorf("finding %s changed since you loaded it: %w", findingID, shared.ErrConflict)
+			}
+			f.Priority = priority
 			f.Version++
 			r.data[engagementID][key] = f
 			return f, nil

--- a/internal/infrastructure/persistence/memory/judgment_store.go
+++ b/internal/infrastructure/persistence/memory/judgment_store.go
@@ -15,16 +15,26 @@ import (
 // (expectedVersion → shared.ErrConflict on mismatch), the same discipline as the finding repo's
 // SetEvidenceScore. The score mover is deliberately not exposed on a broad read port.
 type JudgmentStore struct {
-	mu    sync.Mutex
-	byEng map[shared.ID][]judgment.Judgment
+	mu           sync.Mutex
+	byEng        map[shared.ID][]judgment.Judgment
+	pendingAudit map[judgmentAuditKey]ports.PendingJudgmentAudit
+}
+
+type judgmentAuditKey struct {
+	kind       ports.JudgmentAuditKind
+	judgmentID shared.ID
+	version    int
 }
 
 // NewJudgmentStore returns an empty in-memory judgment store.
 func NewJudgmentStore() *JudgmentStore {
-	return &JudgmentStore{byEng: map[shared.ID][]judgment.Judgment{}}
+	return &JudgmentStore{byEng: map[shared.ID][]judgment.Judgment{}, pendingAudit: map[judgmentAuditKey]ports.PendingJudgmentAudit{}}
 }
 
-var _ ports.JudgmentStore = (*JudgmentStore)(nil)
+var (
+	_ ports.JudgmentStore      = (*JudgmentStore)(nil)
+	_ ports.JudgmentAuditStore = (*JudgmentStore)(nil)
+)
 
 // Save inserts or replaces a judgment within its engagement (idempotent by id).
 func (s *JudgmentStore) Save(_ context.Context, j judgment.Judgment) error {
@@ -66,6 +76,15 @@ func (s *JudgmentStore) ListBySubject(_ context.Context, engagementID, subjectID
 // SetScoreState moves a judgment's score + state under optimistic concurrency. A version mismatch
 // returns shared.ErrConflict (lost-update guard); an unknown id returns shared.ErrNotFound.
 func (s *JudgmentStore) SetScoreState(_ context.Context, engagementID, id shared.ID, score int, state judgment.State, expectedVersion int) (judgment.Judgment, error) {
+	return s.setScoreState(engagementID, id, score, state, "", "", false, expectedVersion)
+}
+
+// SetVerdictState persists a verdict's sealed verifier and rationale with its score transition.
+func (s *JudgmentStore) SetVerdictState(_ context.Context, engagementID, id shared.ID, score int, state judgment.State, verifiedBy, verdictRationale string, expectedVersion int) (judgment.Judgment, error) {
+	return s.setScoreState(engagementID, id, score, state, verifiedBy, verdictRationale, true, expectedVersion)
+}
+
+func (s *JudgmentStore) setScoreState(engagementID, id shared.ID, score int, state judgment.State, verifiedBy, verdictRationale string, setVerdictProvenance bool, expectedVersion int) (judgment.Judgment, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	list := s.byEng[engagementID]
@@ -76,9 +95,90 @@ func (s *JudgmentStore) SetScoreState(_ context.Context, engagementID, id shared
 			}
 			list[i].EvidenceScore = score
 			list[i].State = state
+			if setVerdictProvenance {
+				list[i].VerifiedBy = verifiedBy
+				list[i].VerdictRationale = verdictRationale
+			}
 			list[i].Version++
+			s.byEng[engagementID] = list
 			return list[i], nil
 		}
 	}
 	return judgment.Judgment{}, fmt.Errorf("judgment %s: %w", id, shared.ErrNotFound)
+}
+
+// SaveWithProposalAudit inserts a proposal and its immutable pending audit payload
+// under one lock. Exact replays do not duplicate either record.
+func (s *JudgmentStore) SaveWithProposalAudit(ctx context.Context, j judgment.Judgment, entry ports.AuditEntry) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list := s.byEng[j.EngagementID]
+	for _, existing := range list {
+		if existing.ID == j.ID {
+			return nil
+		}
+	}
+	s.byEng[j.EngagementID] = append(list, j)
+	key := judgmentAuditKey{kind: ports.JudgmentProposalAudit, judgmentID: j.ID, version: j.Version}
+	s.pendingAudit[key] = ports.PendingJudgmentAudit{Kind: ports.JudgmentProposalAudit, JudgmentID: j.ID, Version: j.Version, EngagementID: j.EngagementID, Entry: entry}
+	return nil
+}
+
+// SetVerdictStateWithAudit persists a sealed verdict and its immutable pending audit
+// payload together, so a crash can only leave a recoverable pending delivery.
+func (s *JudgmentStore) SetVerdictStateWithAudit(ctx context.Context, engagementID, id shared.ID, score int, state judgment.State, verifiedBy, rationale string, expectedVersion int, entry ports.AuditEntry) (judgment.Judgment, error) {
+	if err := ctx.Err(); err != nil {
+		return judgment.Judgment{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list := s.byEng[engagementID]
+	for i := range list {
+		if list[i].ID != id {
+			continue
+		}
+		if list[i].Version != expectedVersion {
+			return judgment.Judgment{}, fmt.Errorf("%w: judgment %s version %d != expected %d", shared.ErrConflict, id, list[i].Version, expectedVersion)
+		}
+		list[i].EvidenceScore, list[i].State = score, state
+		list[i].VerifiedBy, list[i].VerdictRationale = verifiedBy, rationale
+		list[i].Version++
+		s.byEng[engagementID] = list
+		key := judgmentAuditKey{kind: ports.JudgmentVerdictAudit, judgmentID: id, version: list[i].Version}
+		s.pendingAudit[key] = ports.PendingJudgmentAudit{Kind: ports.JudgmentVerdictAudit, JudgmentID: id, Version: list[i].Version, EngagementID: engagementID, Entry: entry}
+		return list[i], nil
+	}
+	return judgment.Judgment{}, fmt.Errorf("judgment %s: %w", id, shared.ErrNotFound)
+}
+
+func (s *JudgmentStore) ListPendingJudgmentAudits(ctx context.Context, engagementID shared.ID) ([]ports.PendingJudgmentAudit, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ports.PendingJudgmentAudit, 0)
+	for _, pending := range s.pendingAudit {
+		if pending.EngagementID == engagementID {
+			out = append(out, pending)
+		}
+	}
+	return out, nil
+}
+
+func (s *JudgmentStore) AcknowledgeJudgmentAudit(ctx context.Context, kind ports.JudgmentAuditKind, judgmentID shared.ID, version int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := judgmentAuditKey{kind: kind, judgmentID: judgmentID, version: version}
+	if _, ok := s.pendingAudit[key]; !ok {
+		return nil
+	}
+	delete(s.pendingAudit, key)
+	return nil
 }

--- a/internal/infrastructure/persistence/memory/judgment_store_test.go
+++ b/internal/infrastructure/persistence/memory/judgment_store_test.go
@@ -33,15 +33,29 @@ func TestJudgmentStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if upd.EvidenceScore != 80 || upd.State != judgment.StateConfirmed || upd.Version != 2 {
+	if upd.EvidenceScore != 80 || upd.State != judgment.StateConfirmed || upd.Version != 2 || upd.VerifiedBy != "" || upd.VerdictRationale != "" {
 		t.Fatalf("SetScoreState: %+v", upd)
 	}
+	provenance, err := st.SetVerdictState(ctx, "e1", "j1", 91, judgment.StateConfirmed, "human:verifier", "reproduced", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provenance.VerifiedBy != "human:verifier" || provenance.VerdictRationale != "reproduced" || provenance.EvidenceScore != 91 || provenance.Version != 3 {
+		t.Fatalf("SetVerdictState lost provenance: %#v", provenance)
+	}
+	accepted, err := st.SetScoreState(ctx, "e1", "j1", 91, judgment.StateConfirmed, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accepted.VerifiedBy != "human:verifier" || accepted.VerdictRationale != "reproduced" || accepted.Version != 4 {
+		t.Fatalf("SetScoreState cleared sealed provenance: %#v", accepted)
+	}
 	// stale expectedVersion → conflict (lost-update guard)
-	if _, err := st.SetScoreState(ctx, "e1", "j1", 90, judgment.StateRefuted, 1); !errors.Is(err, shared.ErrConflict) {
+	if _, err := st.SetScoreState(ctx, "e1", "j1", 90, judgment.StateRefuted, 3); !errors.Is(err, shared.ErrConflict) {
 		t.Fatalf("stale version: want ErrConflict, got %v", err)
 	}
 	// unknown id → not found
-	if _, err := st.SetScoreState(ctx, "e1", "nope", 1, judgment.StateConfirmed, 2); !errors.Is(err, shared.ErrNotFound) {
+	if _, err := st.SetScoreState(ctx, "e1", "nope", 1, judgment.StateConfirmed, 4); !errors.Is(err, shared.ErrNotFound) {
 		t.Fatalf("unknown id: want ErrNotFound, got %v", err)
 	}
 
@@ -55,7 +69,7 @@ func TestJudgmentStore(t *testing.T) {
 		t.Fatal(err)
 	}
 	again, _ := st.ListByEngagement(ctx, "e1")
-	if again[0].EvidenceScore != 80 || again[0].State != judgment.StateConfirmed || again[0].Version != 2 {
+	if again[0].EvidenceScore != 91 || again[0].State != judgment.StateConfirmed || again[0].Version != 4 || again[0].VerifiedBy != "human:verifier" || again[0].VerdictRationale != "reproduced" {
 		t.Fatalf("re-Save clobbered an existing row: %+v", again[0])
 	}
 }

--- a/internal/infrastructure/persistence/memory/promotion_store.go
+++ b/internal/infrastructure/persistence/memory/promotion_store.go
@@ -1,0 +1,516 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/promotion"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// PromotionStore is the in-memory promotion event store (dev/tests). It
+// coordinates event persistence with finding-CAS (priority + version) under a
+// single lock so that Apply is atomic:
+//
+//  1. Tenant-ownership verification via EngagementOwnershipReader.
+//  2. Judgment-level idempotency check (dedup by tenant+judgmentID).
+//  3. Fingerprint-level idempotency check (dedup by tenant+fingerprint).
+//  4. CAS binding: command metadata must match finding state.
+//  5. Reversal validation for corroborating_signal_loss rule.
+//  6. EventID uniqueness check (reject collision before any mutation).
+//  7. Finding CAS via FindingRepository.setPriorityInternal (for escalate/de_escalate).
+//  8. Event append.
+//
+// Lock ordering: PromotionStore.mu is always acquired BEFORE
+// FindingRepository.mu (via setPriorityInternal). FindingRepository.mu is never
+// acquired while PromotionStore.mu is held by any other path, so deadlock
+// is impossible.
+//
+// Tenant scoping: the store reads the tenant from context (shared.TenantFrom)
+// and scopes all reads and writes by tenant, matching the postgres adapter's
+// RLS behavior. Cross-tenant access returns shared.ErrNotFound.
+type judgmentStoreKey struct {
+	tenantID   shared.ID
+	judgmentID shared.ID
+}
+
+type fingerprintStoreKey struct {
+	tenantID    shared.ID
+	fingerprint string
+}
+
+type findingStoreKey struct {
+	tenantID     shared.ID
+	engagementID shared.ID
+	findingID    shared.ID
+}
+
+type eventStoreKey struct {
+	tenantID shared.ID
+	eventID  shared.ID
+}
+
+type PromotionStore struct {
+	mu                sync.Mutex
+	byJudgment        map[judgmentStoreKey]promotion.PromotionEvent
+	byFinger          map[fingerprintStoreKey]promotion.PromotionEvent
+	byFinding         map[findingStoreKey][]promotion.PromotionEvent
+	byID              map[eventStoreKey]promotion.PromotionEvent
+	pendingAudit      map[eventStoreKey]bool
+	pendingAuditOrder map[shared.ID][]shared.ID // tenant -> event IDs in append order
+	findingRepo       *FindingRepository
+	engagementReader  ports.EngagementOwnershipReader
+}
+
+// NewPromotionStore returns an empty in-memory promotion store. The
+// findingRepo must be the SAME instance used by the service layer so that
+// CAS operates on the same data. The engagementReader verifies that the
+// engagement belongs to the context tenant before any mutation.
+func NewPromotionStore(findingRepo *FindingRepository, engagementReader ports.EngagementOwnershipReader) (*PromotionStore, error) {
+	if findingRepo == nil || engagementReader == nil {
+		return nil, fmt.Errorf("%w: promotion store is missing a dependency", shared.ErrValidation)
+	}
+	return &PromotionStore{
+		byJudgment:        map[judgmentStoreKey]promotion.PromotionEvent{},
+		byFinger:          map[fingerprintStoreKey]promotion.PromotionEvent{},
+		byFinding:         map[findingStoreKey][]promotion.PromotionEvent{},
+		byID:              map[eventStoreKey]promotion.PromotionEvent{},
+		pendingAudit:      map[eventStoreKey]bool{},
+		pendingAuditOrder: map[shared.ID][]shared.ID{},
+		findingRepo:       findingRepo,
+		engagementReader:  engagementReader,
+	}, nil
+}
+
+var (
+	_ ports.PromotionStore             = (*PromotionStore)(nil)
+	_ ports.PromotionAuditTracker      = (*PromotionStore)(nil)
+	_ ports.PendingPromotionAuditStore = (*PromotionStore)(nil)
+)
+
+// judgmentKey builds the tenant-scoped idempotency key for a judgment.
+func judgmentKey(tenantID, judgmentID shared.ID) judgmentStoreKey {
+	return judgmentStoreKey{tenantID: tenantID, judgmentID: judgmentID}
+}
+
+// fingerprintKey builds the tenant-scoped idempotency key for a fingerprint.
+func fingerprintKey(tenantID shared.ID, fp string) fingerprintStoreKey {
+	return fingerprintStoreKey{tenantID: tenantID, fingerprint: fp}
+}
+
+// storeFindingKey builds the tenant+engagement+finding scoped key for a
+// finding's event list. Engagement is included so that ListByFinding and
+// LatestByFinding can scope results to a specific engagement.
+func storeFindingKey(tenantID, engagementID, findingID shared.ID) findingStoreKey {
+	return findingStoreKey{tenantID: tenantID, engagementID: engagementID, findingID: findingID}
+}
+
+// eventIDKey builds the tenant-scoped key for looking up an event by ID.
+func eventIDKey(tenantID, eventID shared.ID) eventStoreKey {
+	return eventStoreKey{tenantID: tenantID, eventID: eventID}
+}
+
+// Apply constructs a PromotionEvent from the command, persists it, and
+// atomically moves the finding's priority. Returns the existing event on
+// exact replay (same judgmentID), or shared.ErrConflict on semantic conflicts
+// (matching fingerprint with different judgment, or CAS mismatch).
+func (s *PromotionStore) Apply(ctx context.Context, engagementID, findingID shared.ID, cmd ports.PromotionCommand) (finding.Finding, error) {
+	if err := ctx.Err(); err != nil {
+		return finding.Finding{}, err
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return finding.Finding{}, fmt.Errorf("%w: tenant context is required for promotion store", shared.ErrValidation)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// 0. Verify engagement belongs to the context tenant. This is the
+	// trust-boundary chokepoint: the postgres adapter handles this via RLS,
+	// but the in-memory store must explicitly check tenant ownership.
+	if _, err := s.engagementReader.GetByIDInTenant(ctx, tenantID, engagementID); err != nil {
+		return finding.Finding{}, fmt.Errorf("apply promotion: engagement %s: %w", engagementID, err)
+	}
+
+	// 1. Judgment-level idempotency: if this exact judgment was already
+	// applied, verify exact replay consistency (all immutable semantic fields
+	// must match) and return the existing finding state.
+	jKey := judgmentKey(tenantID, cmd.JudgmentID)
+	if existing, ok := s.byJudgment[jKey]; ok {
+		replayEvt := promotion.PromotionEvent{
+			EngagementID:        engagementID,
+			JudgmentID:          cmd.JudgmentID,
+			FindingID:           findingID,
+			FindingVersion:      cmd.FindingVersion,
+			AfterFindingVersion: cmd.FindingVersion, // placeholder; Equals checks this
+			Rule:                cmd.Rule,
+			Effect:              cmd.Effect,
+			BeforePriority:      cmd.BeforePriority,
+			AfterPriority:       cmd.AfterPriority,
+			Inputs:              cmd.Inputs,
+			Fingerprint:         cmd.Fingerprint,
+			Uncertainty:         cmd.Uncertainty,
+			VerdictScore:        cmd.VerdictScore,
+			VerdictRationale:    cmd.VerdictRationale,
+			EvidenceID:          cmd.EvidenceID,
+			Verifier:            cmd.Verifier,
+			AppliedBy:           cmd.AppliedBy,
+		}
+		// Compute afterFindingVersion for comparison.
+		if cmd.Effect != judgment.PromotionFlagForReview {
+			replayEvt.AfterFindingVersion = cmd.FindingVersion + 1
+		}
+		if !existing.Equals(replayEvt) {
+			return finding.Finding{}, fmt.Errorf("%w: judgment %s replay differs from stored event", shared.ErrConflict, cmd.JudgmentID)
+		}
+		f, err := s.findingRepo.getFinding(engagementID, findingID)
+		if err != nil {
+			return finding.Finding{}, fmt.Errorf("apply promotion idempotent: %w", err)
+		}
+		return f, nil
+	}
+
+	// 2. Fingerprint-level idempotency: if this fingerprint already exists
+	// under a different judgment, that is a semantic conflict.
+	fKey := fingerprintKey(tenantID, cmd.Fingerprint)
+	if existing, ok := s.byFinger[fKey]; ok {
+		if existing.JudgmentID != cmd.JudgmentID {
+			return finding.Finding{}, fmt.Errorf("%w: fingerprint %s already applied by judgment %s (not %s)", shared.ErrConflict, cmd.Fingerprint, existing.JudgmentID, cmd.JudgmentID)
+		}
+		// Judgment matches: this is a replay through a different code path.
+		f, err := s.findingRepo.getFinding(engagementID, findingID)
+		if err != nil {
+			return finding.Finding{}, fmt.Errorf("apply promotion idempotent: %w", err)
+		}
+		return f, nil
+	}
+
+	// 3. Verify the finding exists and belongs to the engagement.
+	f, err := s.findingRepo.getFinding(engagementID, findingID)
+	if err != nil {
+		return finding.Finding{}, fmt.Errorf("apply promotion: %w", err)
+	}
+	if f.EngagementID != engagementID {
+		return finding.Finding{}, fmt.Errorf("%w: finding %s does not belong to engagement %s", shared.ErrNotFound, findingID, engagementID)
+	}
+
+	// 4. CAS: verify expected priority and expected version BEFORE any mutation.
+	if f.Version != cmd.ExpectedVersion {
+		return finding.Finding{}, fmt.Errorf("finding %s changed since you loaded it: %w", findingID, shared.ErrConflict)
+	}
+	if f.Priority != cmd.ExpectedPriority {
+		return finding.Finding{}, fmt.Errorf("finding %s priority changed since you loaded it: %w", findingID, shared.ErrConflict)
+	}
+
+	// 4b. Bind command metadata to CAS: the event's FindingVersion must
+	// equal ExpectedVersion and BeforePriority must equal ExpectedPriority.
+	// This prevents a caller from forging stale or inconsistent metadata.
+	if cmd.FindingVersion != cmd.ExpectedVersion {
+		return finding.Finding{}, fmt.Errorf("%w: command FindingVersion %d != ExpectedVersion %d", shared.ErrValidation, cmd.FindingVersion, cmd.ExpectedVersion)
+	}
+	if cmd.BeforePriority != cmd.ExpectedPriority {
+		return finding.Finding{}, fmt.Errorf("%w: command BeforePriority %d != ExpectedPriority %d", shared.ErrValidation, cmd.BeforePriority, cmd.ExpectedPriority)
+	}
+
+	// 5. For corroborating_signal_loss, validate the exact reversal: the
+	// prior event must exist, belong to the same tenant/engagement/finding,
+	// be an applied escalation, and the requested AfterPriority must equal
+	// the prior event's BeforePriority.
+	if cmd.Rule == judgment.RuleCorroboratingSignalLoss {
+		if err := s.validateExactReversal(tenantID, engagementID, findingID, cmd); err != nil {
+			return finding.Finding{}, err
+		}
+	}
+
+	// 6. Construct and validate the event.
+	afterFindingVersion := cmd.FindingVersion
+	if cmd.Effect != judgment.PromotionFlagForReview {
+		afterFindingVersion = cmd.FindingVersion + 1
+	}
+
+	evt, err := promotion.NewPromotionEvent(
+		cmd.EventID,
+		engagementID,
+		cmd.JudgmentID,
+		findingID,
+		cmd.FindingVersion,
+		afterFindingVersion,
+		cmd.Rule,
+		cmd.Effect,
+		cmd.BeforePriority,
+		cmd.AfterPriority,
+		cmd.Inputs,
+		cmd.Fingerprint,
+		cmd.VerdictScore,
+		cmd.VerdictRationale,
+		cmd.EvidenceID,
+		cmd.Verifier,
+		cmd.Uncertainty,
+		cmd.AppliedBy,
+		time.Now().UTC(),
+	)
+	if err != nil {
+		return finding.Finding{}, fmt.Errorf("construct promotion event: %w", err)
+	}
+
+	// 7. Cross-check: the constructed event's judgment must match the command.
+	if evt.JudgmentID != cmd.JudgmentID {
+		return finding.Finding{}, fmt.Errorf("%w: event judgment mismatch", shared.ErrConflict)
+	}
+
+	// 8. EventID uniqueness: a tenant-scoped EventID collision with a
+	// different (non-semantically-equal) event must be rejected before
+	// any finding mutation or event append. An exact semantic replay
+	// with a regenerated EventID is allowed (the judgment-idempotency
+	// check at step 1 would normally catch this, but a caller that
+	// regenerates EventID needs this guard).
+	ek := eventIDKey(tenantID, evt.ID)
+	if existing, ok := s.byID[ek]; ok {
+		if !existing.Equals(evt) {
+			return finding.Finding{}, fmt.Errorf("%w: event ID %s already exists with different content", shared.ErrConflict, evt.ID)
+		}
+		// Exact semantic replay with a regenerated EventID: allow.
+		f, err := s.findingRepo.getFinding(engagementID, findingID)
+		if err != nil {
+			return finding.Finding{}, fmt.Errorf("apply promotion eventID replay: %w", err)
+		}
+		return f, nil
+	}
+
+	// Cancellation after validation must not commit a partial finding/event transition.
+	if err := ctx.Err(); err != nil {
+		return finding.Finding{}, err
+	}
+
+	// 9. For mutating effects, move the finding's priority atomically.
+	if evt.Effect != judgment.PromotionFlagForReview {
+		f, err = s.findingRepo.setPriorityInternal(engagementID, findingID, evt.AfterPriority, cmd.ExpectedVersion)
+		if err != nil {
+			return finding.Finding{}, fmt.Errorf("apply promotion CAS: %w", err)
+		}
+	}
+
+	// 10. Persist the event (append-only) and indexes.
+	s.byJudgment[jKey] = evt
+	s.byFinger[fKey] = evt
+	fk := storeFindingKey(tenantID, engagementID, findingID)
+	s.byFinding[fk] = append(s.byFinding[fk], evt)
+	s.byID[ek] = evt
+	s.pendingAudit[ek] = true
+	s.pendingAuditOrder[tenantID] = append(s.pendingAuditOrder[tenantID], evt.ID)
+
+	return f, nil
+}
+
+// validateExactReversal verifies that a corroborating_signal_loss command
+// references a valid prior escalation event that is the latest mutating
+// promotion in the finding's lineage. The prior event must:
+//   - be referenced by exactly one prior_promotion input
+//   - exist in the store under the same tenant
+//   - belong to the same engagement and finding
+//   - be an applied escalation
+//   - have a BeforePriority that equals the requested AfterPriority
+//   - be the latest mutating event for this finding (no later events after it)
+//   - its AfterPriority and AfterFindingVersion must match the command's
+//     BeforePriority and FindingVersion (lineage continuity)
+func (s *PromotionStore) validateExactReversal(tenantID, engagementID, findingID shared.ID, cmd ports.PromotionCommand) error {
+	var priorEventID shared.ID
+	priorCount := 0
+	for _, in := range cmd.Inputs {
+		if in.Kind == judgment.PromotionInputPrior {
+			priorEventID = in.ID
+			priorCount++
+		}
+	}
+	if priorCount == 0 {
+		return fmt.Errorf("%w: corroborating_signal_loss requires a prior_promotion input", shared.ErrValidation)
+	}
+	if priorCount > 1 {
+		return fmt.Errorf("%w: corroborating_signal_loss requires exactly one prior_promotion input, got %d", shared.ErrValidation, priorCount)
+	}
+	if priorEventID.IsZero() {
+		return fmt.Errorf("%w: prior_promotion input has empty event ID", shared.ErrValidation)
+	}
+
+	fk := storeFindingKey(tenantID, engagementID, findingID)
+	events := s.byFinding[fk]
+	stack := make([]promotion.PromotionEvent, 0, len(events))
+	for _, event := range events {
+		switch event.Effect {
+		case judgment.PromotionEscalate:
+			stack = append(stack, event)
+		case judgment.PromotionDeescalate:
+			if event.Rule != judgment.RuleCorroboratingSignalLoss {
+				continue
+			}
+			for _, input := range event.Inputs {
+				if input.Kind != judgment.PromotionInputPrior {
+					continue
+				}
+				for i := len(stack) - 1; i >= 0; i-- {
+					if stack[i].ID == input.ID {
+						stack = stack[:i]
+						break
+					}
+				}
+			}
+		}
+	}
+	if _, ok := s.byID[eventIDKey(tenantID, priorEventID)]; !ok {
+		return fmt.Errorf("%w: prior promotion event %s not found", shared.ErrNotFound, priorEventID)
+	}
+	if len(stack) == 0 || stack[len(stack)-1].ID != priorEventID {
+		return fmt.Errorf("%w: prior event %s is not the latest unresolved escalation", shared.ErrConflict, priorEventID)
+	}
+	prior := stack[len(stack)-1]
+	if cmd.AfterPriority != prior.BeforePriority {
+		return fmt.Errorf("%w: reversal target priority %d != prior event %s before-priority %d", shared.ErrConflict, cmd.AfterPriority, priorEventID, prior.BeforePriority)
+	}
+	if cmd.BeforePriority != prior.AfterPriority {
+		return fmt.Errorf("%w: command before-priority %d != prior event %s after-priority %d", shared.ErrConflict, cmd.BeforePriority, priorEventID, prior.AfterPriority)
+	}
+	return nil
+}
+
+// ListByFinding returns all promotion events for a finding, oldest first.
+// The returned slice and each event's Inputs are defensive copies; callers
+// may modify them safely. Results are scoped to the given engagement.
+func (s *PromotionStore) ListByFinding(ctx context.Context, engagementID, findingID shared.ID) ([]promotion.PromotionEvent, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: tenant context is required for promotion store", shared.ErrValidation)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fk := storeFindingKey(tenantID, engagementID, findingID)
+	events := s.byFinding[fk]
+	return deepCopyEvents(events), nil
+}
+
+// LatestByFinding returns the most recent promotion event for a finding,
+// or (zero, false) if none exist. The returned event is a defensive copy.
+// Results are scoped to the given engagement.
+func (s *PromotionStore) LatestByFinding(ctx context.Context, engagementID, findingID shared.ID) (promotion.PromotionEvent, bool, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return promotion.PromotionEvent{}, false, fmt.Errorf("%w: tenant context is required for promotion store", shared.ErrValidation)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fk := storeFindingKey(tenantID, engagementID, findingID)
+	events := s.byFinding[fk]
+	if len(events) == 0 {
+		return promotion.PromotionEvent{}, false, nil
+	}
+	latest := deepCopyEvent(events[len(events)-1])
+	return latest, true, nil
+}
+
+// FindByJudgment returns an event scoped to its tenant, engagement, and finding.
+func (s *PromotionStore) FindByJudgment(ctx context.Context, engagementID, findingID, judgmentID shared.ID) (promotion.PromotionEvent, bool, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return promotion.PromotionEvent{}, false, fmt.Errorf("%w: tenant context is required for promotion store", shared.ErrValidation)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	evt, ok := s.byJudgment[judgmentKey(tenantID, judgmentID)]
+	if !ok || evt.EngagementID != engagementID || evt.FindingID != findingID {
+		return promotion.PromotionEvent{}, false, nil
+	}
+	return deepCopyEvent(evt), true, nil
+}
+
+// ListPendingAudits returns applied promotion events whose required audit has
+// not been durably acknowledged. Results are oldest first.
+func (s *PromotionStore) ListPendingAudits(ctx context.Context, engagementID shared.ID) ([]promotion.PromotionEvent, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: tenant context is required for promotion store", shared.ErrValidation)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]promotion.PromotionEvent, 0)
+	for _, eventID := range s.pendingAuditOrder[tenantID] {
+		key := eventIDKey(tenantID, eventID)
+		if !s.pendingAudit[key] {
+			continue
+		}
+		evt := s.byID[key]
+		if evt.EngagementID == engagementID {
+			out = append(out, deepCopyEvent(evt))
+		}
+	}
+	return out, nil
+}
+
+// MarkAuditComplete durably acknowledges an applied event's audit record.
+func (s *PromotionStore) MarkAuditComplete(ctx context.Context, eventID shared.ID) error {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("%w: tenant context is required for promotion store", shared.ErrValidation)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := eventIDKey(tenantID, eventID)
+	if _, ok := s.byID[key]; !ok {
+		return fmt.Errorf("promotion event %s: %w", eventID, shared.ErrNotFound)
+	}
+	delete(s.pendingAudit, key)
+	return nil
+}
+
+// getFinding is an internal helper that retrieves a finding by engagement+ID.
+// The caller MUST hold PromotionStore.mu (FindingRepository's read lock is
+// acquired here).
+func (r *FindingRepository) getFinding(engagementID, findingID shared.ID) (finding.Finding, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	byKey := r.data[engagementID]
+	for _, f := range byKey {
+		if f.ID == findingID {
+			return f, nil
+		}
+	}
+	return finding.Finding{}, fmt.Errorf("finding %s: %w", findingID, shared.ErrNotFound)
+}
+
+// deepCopyEvents returns a defensive copy of the events slice, with each
+// event's Inputs independently copied.
+func deepCopyEvents(events []promotion.PromotionEvent) []promotion.PromotionEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]promotion.PromotionEvent, len(events))
+	for i, e := range events {
+		out[i] = deepCopyEvent(e)
+	}
+	return out
+}
+
+// deepCopyEvent returns a defensive copy of a single event, including its
+// Inputs and Uncertainty slices.
+func deepCopyEvent(e promotion.PromotionEvent) promotion.PromotionEvent {
+	cp := e
+	if len(e.Inputs) > 0 {
+		cp.Inputs = make([]judgment.PromotionInput, len(e.Inputs))
+		copy(cp.Inputs, e.Inputs)
+	}
+	if len(e.Uncertainty) > 0 {
+		cp.Uncertainty = make([]string, len(e.Uncertainty))
+		copy(cp.Uncertainty, e.Uncertainty)
+	}
+	return cp
+}

--- a/internal/infrastructure/persistence/memory/promotion_store_test.go
+++ b/internal/infrastructure/persistence/memory/promotion_store_test.go
@@ -1,0 +1,2342 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/promotion"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	analysis "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
+	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	promotionuc "github.com/KKloudTarus/synapse-ce/internal/usecase/promotion"
+)
+
+// mockEngagementReader is a test double for ports.EngagementOwnershipReader.
+// It maps (tenantID, engagementID) -> bool and returns ErrNotFound for
+// unknown pairs.
+func mustPromotionStore(t *testing.T, findingRepo *FindingRepository, engagementReader ports.EngagementOwnershipReader) *PromotionStore {
+	t.Helper()
+	store, err := NewPromotionStore(findingRepo, engagementReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+type mockEngagementReader struct {
+	// allowed maps "tenantID:engagementID" -> true.
+	allowed map[string]bool
+}
+
+func newMockEngagementReader() *mockEngagementReader {
+	return &mockEngagementReader{allowed: map[string]bool{}}
+}
+
+func (m *mockEngagementReader) allow(tenantID, engagementID shared.ID) {
+	m.allowed[string(tenantID)+":"+string(engagementID)] = true
+}
+
+func (m *mockEngagementReader) GetByIDInTenant(_ context.Context, tenantID, id shared.ID) (*engagement.Engagement, error) {
+	if m.allowed[string(tenantID)+":"+string(id)] {
+		return &engagement.Engagement{ID: id, TenantID: tenantID}, nil
+	}
+	return nil, fmt.Errorf("engagement %s in tenant %s: %w", id, tenantID, shared.ErrNotFound)
+}
+
+var _ ports.EngagementOwnershipReader = (*mockEngagementReader)(nil)
+
+// seedFinding inserts a finding with the given priority into the memory finding
+// repo at version 1, then optionally bumps the version through the repository
+// API to simulate prior concurrent edits. Returns the stored finding state.
+func seedFinding(t *testing.T, repo *FindingRepository, engagementID, findingID shared.ID, priority, wantVersion int) finding.Finding {
+	t.Helper()
+	f := finding.Finding{
+		ID:           findingID,
+		EngagementID: engagementID,
+		Title:        "test finding",
+		Severity:     shared.SeverityHigh,
+		Status:       finding.StatusConfirmed,
+		Kind:         finding.KindSCA,
+		Priority:     priority,
+		// Version=0 so Upsert always sets it to 1 for a fresh insert.
+		DedupKey: "test:" + findingID.String(),
+		Audit:    shared.Audit{CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	}
+	if err := repo.Upsert(context.Background(), []finding.Finding{f}); err != nil {
+		t.Fatalf("seed finding: %v", err)
+	}
+	// Bump to the desired version through a public, versioned repository update.
+	for v := 1; v < wantVersion; v++ {
+		if _, err := repo.SetEvidenceScore(context.Background(), engagementID, findingID, 0, v); err != nil {
+			t.Fatalf("bump version from %d to %d: %v", v, v+1, err)
+		}
+	}
+	out, err := repo.getFinding(engagementID, findingID)
+	if err != nil {
+		t.Fatalf("get seeded finding: %v", err)
+	}
+	return out
+}
+
+// sampleCmd builds a valid PromotionCommand for testing.
+func sampleCmd(effect judgment.PromotionChange, before, after int) ports.PromotionCommand {
+	return ports.PromotionCommand{
+		EventID:        "evt-1",
+		JudgmentID:     "j1",
+		FindingVersion: 1,
+		Rule:           judgment.RuleRuntimeReachableExposed,
+		Effect:         effect,
+		BeforePriority: before,
+		AfterPriority:  after,
+		Inputs: []judgment.PromotionInput{
+			{Kind: judgment.PromotionInputReachability, ID: "j1"},
+		},
+		Fingerprint:      strings.Repeat("a", 64),
+		VerdictScore:     75,
+		VerdictRationale: "verified",
+		EvidenceID:       "evidence-1",
+		Verifier:         "human:verifier",
+		AppliedBy:        "tester",
+	}
+}
+
+// tenantCtx returns a context with the default test tenant.
+func tenantCtx() context.Context {
+	return shared.WithTenant(context.Background(), "test-tenant")
+}
+
+// defaultReader returns a mockEngagementReader that allows common test
+// engagement-tenant pairs.
+func defaultReader() *mockEngagementReader {
+	r := newMockEngagementReader()
+	r.allow("test-tenant", "eng-1")
+	r.allow("test-tenant", "eng-2")
+	r.allow("tenant-a", "eng-a")
+	r.allow("tenant-b", "eng-b")
+	return r
+}
+
+func TestPromotionStoreTypedKeysResistColonCollisions(t *testing.T) {
+	fingerprint := strings.Repeat("a", 64)
+	judgmentA, judgmentB := judgmentKey("tenant:a", "judgment"), judgmentKey("tenant", "a:judgment")
+	fingerA, fingerB := fingerprintKey("tenant:a", fingerprint), fingerprintKey("tenant", "a:"+fingerprint)
+	findingA, findingB := storeFindingKey("tenant:a", "engagement", "finding"), storeFindingKey("tenant", "a:engagement", "finding")
+	eventA, eventB := eventIDKey("tenant:a", "event"), eventIDKey("tenant", "a:event")
+
+	if judgmentA == judgmentB || fingerA == fingerB || findingA == findingB || eventA == eventB {
+		t.Fatal("typed promotion-store keys must retain colon-containing field boundaries")
+	}
+	pending := map[eventStoreKey]bool{eventA: true, eventB: true}
+	if len(pending) != 2 {
+		t.Fatalf("pending audit keys collided: %#v", pending)
+	}
+}
+
+func TestPromotionStoreApplyEscalation(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+
+	got, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if err != nil {
+		t.Fatalf("Apply escalation: %v", err)
+	}
+	if got.Priority != 2 {
+		t.Errorf("priority = %d, want 2", got.Priority)
+	}
+	if got.Version != 2 {
+		t.Errorf("version = %d, want 2 (bumped)", got.Version)
+	}
+	// Event persisted.
+	events, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 1 || events[0].Effect != judgment.PromotionEscalate {
+		t.Fatalf("events: %+v", events)
+	}
+	if events[0].JudgmentID != "j1" {
+		t.Errorf("event JudgmentID = %s, want j1", events[0].JudgmentID)
+	}
+	if events[0].VerdictScore != 75 {
+		t.Errorf("event VerdictScore = %d, want 75", events[0].VerdictScore)
+	}
+}
+
+func TestPromotionStoreApplyDeescalation(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 2, 1)
+	cmd := sampleCmd(judgment.PromotionDeescalate, 2, 3)
+	cmd.Rule = judgment.RuleDeterministicUnreachable
+	cmd.ExpectedPriority = 2
+	cmd.ExpectedVersion = f.Version
+
+	got, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if err != nil {
+		t.Fatalf("Apply de-escalation: %v", err)
+	}
+	if got.Priority != 3 {
+		t.Errorf("priority = %d, want 3", got.Priority)
+	}
+	if got.Version != 2 {
+		t.Errorf("version = %d, want 2 (bumped)", got.Version)
+	}
+}
+
+func TestPromotionStoreApplyExactReversal(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// First, seed a finding at P4, version 1 and escalate it to P3.
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+	escCmd := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	escCmd.ExpectedPriority = 4
+	escCmd.ExpectedVersion = f.Version
+	escCmd.EventID = "prior-evt"
+	if _, err := store.Apply(ctx, "eng-1", "f1", escCmd); err != nil {
+		t.Fatalf("setup escalation: %v", err)
+	}
+
+	// Now apply exact reversal: corroborating_signal_loss references
+	// "prior-evt" and restores P4 (the prior event's BeforePriority).
+	revCmd := sampleCmd(judgment.PromotionDeescalate, 3, 4)
+	revCmd.Rule = judgment.RuleCorroboratingSignalLoss
+	revCmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputPrior, ID: "prior-evt"},
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+	}
+	revCmd.JudgmentID = "j-rev"
+	revCmd.Fingerprint = strings.Repeat("d", 64)
+	revCmd.EventID = "evt-rev"
+	revCmd.FindingVersion = 2
+	revCmd.ExpectedPriority = 3
+	revCmd.ExpectedVersion = 2
+
+	got, err := store.Apply(ctx, "eng-1", "f1", revCmd)
+	if err != nil {
+		t.Fatalf("Apply exact reversal: %v", err)
+	}
+	if got.Priority != 4 {
+		t.Errorf("priority = %d, want 4 (exact reversal)", got.Priority)
+	}
+	if got.Version != 3 {
+		t.Errorf("version = %d, want 3 (bumped)", got.Version)
+	}
+}
+
+func TestPromotionStoreStackedReversalsAreLIFO(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	store := mustPromotionStore(t, findingRepo, defaultReader())
+	ctx := tenantCtx()
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+	apply := func(cmd ports.PromotionCommand) {
+		t.Helper()
+		if _, err := store.Apply(ctx, "eng-1", "f1", cmd); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	a.EventID, a.JudgmentID, a.ExpectedPriority, a.ExpectedVersion = "event-a", "judgment-a", f.Priority, f.Version
+	apply(a)
+	b := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	b.EventID, b.JudgmentID, b.Fingerprint, b.FindingVersion, b.ExpectedPriority, b.ExpectedVersion = "event-b", "judgment-b", strings.Repeat("b", 64), 2, 3, 2
+	apply(b)
+	reverse := func(eventID, judgmentID, fingerprint string, before, after, version int) ports.PromotionCommand {
+		cmd := sampleCmd(judgment.PromotionDeescalate, before, after)
+		cmd.EventID, cmd.JudgmentID, cmd.Fingerprint = shared.ID(eventID+"-reverse"), shared.ID(judgmentID), fingerprint
+		cmd.Rule = judgment.RuleCorroboratingSignalLoss
+		cmd.Inputs = []judgment.PromotionInput{{Kind: judgment.PromotionInputPrior, ID: shared.ID(eventID)}, {Kind: judgment.PromotionInputReachability, ID: "j1"}}
+		cmd.FindingVersion, cmd.ExpectedPriority, cmd.ExpectedVersion = version, before, version
+		return cmd
+	}
+	apply(reverse("event-b", "judgment-b-reverse", strings.Repeat("c", 64), 2, 3, 3))
+	got, err := findingRepo.GetByEngagementAndID(ctx, "eng-1", "f1")
+	if err != nil || got.Priority != 3 {
+		t.Fatalf("first LIFO reversal finding = %#v, %v", got, err)
+	}
+	apply(reverse("event-a", "judgment-a-reverse", strings.Repeat("d", 64), 3, 4, 4))
+	got, err = findingRepo.GetByEngagementAndID(ctx, "eng-1", "f1")
+	if err != nil || got.Priority != 4 {
+		t.Fatalf("second LIFO reversal finding = %#v, %v", got, err)
+	}
+	if _, err := store.Apply(ctx, "eng-1", "f1", reverse("event-a", "judgment-a-reverse", strings.Repeat("d", 64), 3, 4, 4)); err != nil {
+		t.Fatalf("unchanged reverse replay: %v", err)
+	}
+	events, err := store.ListByFinding(ctx, "eng-1", "f1")
+	if err != nil || len(events) != 4 {
+		t.Fatalf("events after unchanged reevaluation = %#v, %v", events, err)
+	}
+}
+
+func TestPromotionStoreApplyFlagForReview(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionFlagForReview, 3, 3)
+	cmd.Rule = judgment.RuleUncertainCorroboration
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+
+	got, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if err != nil {
+		t.Fatalf("Apply review: %v", err)
+	}
+	// Review must NOT mutate the finding.
+	if got.Priority != 3 {
+		t.Errorf("priority = %d, want 3 (unchanged)", got.Priority)
+	}
+	if got.Version != 1 {
+		t.Errorf("version = %d, want 1 (no bump for review)", got.Version)
+	}
+	// Event persisted.
+	events, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 1 || events[0].Effect != judgment.PromotionFlagForReview {
+		t.Fatalf("events: %+v", events)
+	}
+}
+
+func TestPromotionStoreApplyCASVersionMismatch(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	// Bump the finding version externally through the repository API.
+	if _, err := findingRepo.SetEvidenceScore(context.Background(), "eng-1", "f1", 0, 1); err != nil {
+		t.Fatalf("bump finding version: %v", err)
+	}
+
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = 1 // stale
+
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict, got %v", err)
+	}
+	// No event should be persisted on CAS failure.
+	events, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 0 {
+		t.Fatalf("events on CAS failure: %+v", events)
+	}
+}
+
+func TestPromotionStoreApplyCASPriorityMismatchReview(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	seedFinding(t, findingRepo, "eng-1", "f1", 2, 1)
+
+	cmd := sampleCmd(judgment.PromotionFlagForReview, 3, 3)
+	cmd.Rule = judgment.RuleUncertainCorroboration
+	cmd.ExpectedPriority = 3 // stale -- finding is P2
+	cmd.ExpectedVersion = 1
+
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict, got %v", err)
+	}
+	// No event should be persisted on priority mismatch.
+	events, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 0 {
+		t.Fatalf("events on priority mismatch: %+v", events)
+	}
+}
+
+func TestPromotionStoreApplyCASPriorityMismatchEscalation(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	seedFinding(t, findingRepo, "eng-1", "f1", 2, 1)
+
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3 // stale -- finding is P2
+	cmd.ExpectedVersion = 1
+
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict, got %v", err)
+	}
+	// No event should be persisted on priority mismatch.
+	events, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 0 {
+		t.Fatalf("events on priority mismatch: %+v", events)
+	}
+}
+
+func TestPromotionStoreApplyJudgmentIdempotent(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+
+	// First apply succeeds and moves priority.
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	// Second apply with same judgmentID is idempotent (no error, no
+	// duplicate event, no double mutation).
+	got, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if err != nil {
+		t.Fatalf("idempotent re-apply: %v", err)
+	}
+	if got.Priority != 2 {
+		t.Errorf("priority after idempotent re-apply = %d, want 2", got.Priority)
+	}
+	// Only one event.
+	events, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 1 {
+		t.Fatalf("events after idempotent re-apply: %d, want 1", len(events))
+	}
+}
+
+func TestPromotionStoreApplyJudgmentFingerprintConflict(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+
+	// First apply succeeds.
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	// Same fingerprint but different judgmentID is a semantic conflict.
+	cmd2 := cmd
+	cmd2.JudgmentID = "j2"
+	_, err = store.Apply(ctx, "eng-1", "f1", cmd2)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict for fingerprint conflict, got %v", err)
+	}
+}
+
+func TestPromotionStoreApplyFindingNotFound(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = 1
+
+	_, err := store.Apply(ctx, "eng-1", "nonexistent", cmd)
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestPromotionStoreApplyMissingTenantContext(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := context.Background() // no tenant
+
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("want ErrValidation for missing tenant, got %v", err)
+	}
+}
+
+func TestPromotionStoreApplyCrossTenantEngagementRejection(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+
+	// Engage under tenant-a but the engagement belongs to tenant-b.
+	ctxA := shared.WithTenant(context.Background(), "tenant-a")
+	seedFinding(t, findingRepo, "eng-a", "f1", 3, 1)
+
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = 1
+
+	// Try to apply with tenant-a's context against eng-b (owned by tenant-b).
+	_, err := store.Apply(ctxA, "eng-b", "f1", cmd)
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("want ErrNotFound for cross-tenant engagement, got %v", err)
+	}
+}
+
+func TestPromotionStoreApplyCASBindingVersionMismatch(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+	cmd.FindingVersion = 5 // does not match ExpectedVersion
+
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("want ErrValidation for FindingVersion != ExpectedVersion, got %v", err)
+	}
+}
+
+func TestPromotionStoreApplyCASBindingPriorityMismatch(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+	cmd.BeforePriority = 2 // does not match ExpectedPriority
+
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("want ErrValidation for BeforePriority != ExpectedPriority, got %v", err)
+	}
+}
+
+func TestPromotionStoreReversalMissingPriorInput(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionDeescalate, 3, 4)
+	cmd.Rule = judgment.RuleCorroboratingSignalLoss
+	cmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+		// No prior_promotion input.
+	}
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("want ErrValidation for missing prior input, got %v", err)
+	}
+}
+
+func TestPromotionStoreReversalMissingPriorEvent(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionDeescalate, 3, 4)
+	cmd.Rule = judgment.RuleCorroboratingSignalLoss
+	cmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+		{Kind: judgment.PromotionInputPrior, ID: "nonexistent-prior"},
+	}
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("want ErrNotFound for missing prior event, got %v", err)
+	}
+}
+
+func TestPromotionStoreReversalWrongFinding(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Seed two findings in the same engagement.
+	seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+	f2 := seedFinding(t, findingRepo, "eng-1", "f2", 3, 1)
+
+	// Escalate f1 from P4 to P3 (creates prior event).
+	escCmd := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	escCmd.ExpectedPriority = 4
+	escCmd.ExpectedVersion = 1
+	escCmd.EventID = "prior-evt-f1"
+	if _, err := store.Apply(ctx, "eng-1", "f1", escCmd); err != nil {
+		t.Fatalf("setup escalation: %v", err)
+	}
+
+	// Try to use prior-evt-f1 (on f1) to reverse f2: wrong finding.
+	revCmd := sampleCmd(judgment.PromotionDeescalate, 3, 4)
+	revCmd.Rule = judgment.RuleCorroboratingSignalLoss
+	revCmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+		{Kind: judgment.PromotionInputPrior, ID: "prior-evt-f1"},
+	}
+	revCmd.JudgmentID = "j-rev"
+	revCmd.Fingerprint = strings.Repeat("d", 64)
+	revCmd.ExpectedPriority = 3
+	revCmd.ExpectedVersion = f2.Version
+
+	_, err := store.Apply(ctx, "eng-1", "f2", revCmd)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict for wrong finding, got %v", err)
+	}
+}
+
+func TestPromotionStoreReversalNonEscalation(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Seed a finding and apply a flag_for_review (not an escalation).
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	reviewCmd := sampleCmd(judgment.PromotionFlagForReview, 3, 3)
+	reviewCmd.Rule = judgment.RuleUncertainCorroboration
+	reviewCmd.ExpectedPriority = 3
+	reviewCmd.ExpectedVersion = f.Version
+	reviewCmd.EventID = "review-evt"
+	if _, err := store.Apply(ctx, "eng-1", "f1", reviewCmd); err != nil {
+		t.Fatalf("setup review: %v", err)
+	}
+
+	// Try to use review-evt as prior for reversal: not an escalation.
+	revCmd := sampleCmd(judgment.PromotionDeescalate, 3, 3)
+	revCmd.Rule = judgment.RuleCorroboratingSignalLoss
+	revCmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+		{Kind: judgment.PromotionInputPrior, ID: "review-evt"},
+	}
+	revCmd.JudgmentID = "j-rev"
+	revCmd.Fingerprint = strings.Repeat("d", 64)
+	revCmd.ExpectedPriority = 3
+	revCmd.ExpectedVersion = 1
+
+	_, err := store.Apply(ctx, "eng-1", "f1", revCmd)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict for non-escalation prior, got %v", err)
+	}
+}
+
+func TestPromotionStoreReversalIncorrectTarget(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Escalate from P4 to P3 (prior event: BeforePriority=4).
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+	escCmd := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	escCmd.ExpectedPriority = 4
+	escCmd.ExpectedVersion = f.Version
+	escCmd.EventID = "prior-evt"
+	if _, err := store.Apply(ctx, "eng-1", "f1", escCmd); err != nil {
+		t.Fatalf("setup escalation: %v", err)
+	}
+
+	// Try to reverse to P5 (wrong target: prior BeforePriority was P4).
+	revCmd := sampleCmd(judgment.PromotionDeescalate, 3, 5)
+	revCmd.Rule = judgment.RuleCorroboratingSignalLoss
+	revCmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputPrior, ID: "prior-evt"},
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+	}
+	revCmd.JudgmentID = "j-rev"
+	revCmd.Fingerprint = strings.Repeat("d", 64)
+	revCmd.FindingVersion = 2
+	revCmd.ExpectedPriority = 3
+	revCmd.ExpectedVersion = 2
+
+	_, err := store.Apply(ctx, "eng-1", "f1", revCmd)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict for incorrect target priority, got %v", err)
+	}
+}
+
+func TestPromotionStoreReversalWrongTenant(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+
+	tenantA := shared.WithTenant(context.Background(), "tenant-a")
+	tenantB := shared.WithTenant(context.Background(), "tenant-b")
+
+	// Escalate under tenant-a.
+	seedFinding(t, findingRepo, "eng-a", "f1", 4, 1)
+	escCmd := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	escCmd.ExpectedPriority = 4
+	escCmd.ExpectedVersion = 1
+	escCmd.EventID = "prior-evt-a"
+	if _, err := store.Apply(tenantA, "eng-a", "f1", escCmd); err != nil {
+		t.Fatalf("setup escalation: %v", err)
+	}
+
+	// Try to reference tenant-a's prior event under tenant-b context.
+	seedFinding(t, findingRepo, "eng-b", "f1", 3, 1)
+	revCmd := sampleCmd(judgment.PromotionDeescalate, 3, 4)
+	revCmd.Rule = judgment.RuleCorroboratingSignalLoss
+	revCmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+		{Kind: judgment.PromotionInputPrior, ID: "prior-evt-a"},
+	}
+	revCmd.JudgmentID = "j-rev"
+	revCmd.Fingerprint = strings.Repeat("d", 64)
+	revCmd.ExpectedPriority = 3
+	revCmd.ExpectedVersion = 1
+
+	_, err := store.Apply(tenantB, "eng-b", "f1", revCmd)
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("want ErrNotFound for cross-tenant prior event, got %v", err)
+	}
+}
+
+func TestPromotionStoreHostileFalseHistory(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Hostile test: caller tries to forge a FindingVersion that doesn't match
+	// ExpectedVersion to trick the store into accepting stale data.
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+
+	// Attempt 1: FindingVersion claims v5 but finding is at v1.
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+	cmd.FindingVersion = 5 // forged
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("hostile version: want ErrValidation, got %v", err)
+	}
+
+	// Attempt 2: BeforePriority claims P1 but finding is at P3.
+	cmd2 := sampleCmd(judgment.PromotionEscalate, 1, 2)
+	cmd2.ExpectedPriority = 3
+	cmd2.ExpectedVersion = f.Version
+	cmd2.FindingVersion = f.Version
+	cmd2.BeforePriority = 1 // forged
+	_, err = store.Apply(ctx, "eng-1", "f1", cmd2)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("hostile priority: want ErrValidation, got %v", err)
+	}
+
+	// Verify no events were persisted.
+	events, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 0 {
+		t.Fatalf("hostile test: %d events persisted (should be 0)", len(events))
+	}
+}
+
+func TestPromotionStoreLatestByFinding(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// No events yet.
+	_, ok, err := store.LatestByFinding(ctx, "eng-1", "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("expected no latest event for unknown finding")
+	}
+
+	// Seed and apply two events.
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+	cmd1 := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	cmd1.ExpectedPriority = 4
+	cmd1.ExpectedVersion = f.Version
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd1); err != nil {
+		t.Fatal(err)
+	}
+	cmd2 := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd2.EventID = "evt-2"
+	cmd2.JudgmentID = "j2"
+	cmd2.Fingerprint = strings.Repeat("b", 64)
+	cmd2.FindingVersion = 2
+	cmd2.ExpectedPriority = 3
+	cmd2.ExpectedVersion = 2
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd2); err != nil {
+		t.Fatal(err)
+	}
+
+	latest, ok, err := store.LatestByFinding(ctx, "eng-1", "f1")
+	if err != nil || !ok {
+		t.Fatalf("LatestByFinding: ok=%v err=%v", ok, err)
+	}
+	if latest.ID != "evt-2" {
+		t.Errorf("latest ID = %s, want evt-2", latest.ID)
+	}
+	if latest.AfterPriority != 2 {
+		t.Errorf("latest AfterPriority = %d, want 2", latest.AfterPriority)
+	}
+}
+
+func TestPromotionStoreListByFinding(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Empty list for unknown finding.
+	events, err := store.ListByFinding(ctx, "eng-1", "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected empty, got %d events", len(events))
+	}
+
+	// Apply two events.
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+	cmd1 := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	cmd1.ExpectedPriority = 4
+	cmd1.ExpectedVersion = f.Version
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd1); err != nil {
+		t.Fatal(err)
+	}
+	cmd2 := sampleCmd(judgment.PromotionFlagForReview, 3, 3)
+	cmd2.EventID = "evt-2"
+	cmd2.JudgmentID = "j2"
+	cmd2.Fingerprint = strings.Repeat("b", 64)
+	cmd2.Rule = judgment.RuleUncertainCorroboration
+	cmd2.FindingVersion = 2
+	cmd2.ExpectedPriority = 3
+	cmd2.ExpectedVersion = 2
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd2); err != nil {
+		t.Fatal(err)
+	}
+
+	events, _ = store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].ID != "evt-1" || events[1].ID != "evt-2" {
+		t.Errorf("events not in order: %s, %s", events[0].ID, events[1].ID)
+	}
+}
+
+func TestPromotionStoreImmutableLifecycle(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = f.Version
+
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	// The stored event should be identical to what we put in (immutable).
+	events, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	stored := events[0]
+	if stored.Effect != judgment.PromotionEscalate {
+		t.Errorf("Effect = %s, want escalate", stored.Effect)
+	}
+	if stored.BeforePriority != 3 || stored.AfterPriority != 2 {
+		t.Errorf("priority: before=%d after=%d, want 3->2", stored.BeforePriority, stored.AfterPriority)
+	}
+	if stored.JudgmentID != "j1" {
+		t.Errorf("JudgmentID = %s, want j1", stored.JudgmentID)
+	}
+	if stored.AfterFindingVersion != 2 {
+		t.Errorf("AfterFindingVersion = %d, want 2", stored.AfterFindingVersion)
+	}
+}
+
+func TestPromotionStoreVersionBump(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Apply two escalations in sequence. Each should bump the version.
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+
+	cmd1 := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	cmd1.ExpectedPriority = 4
+	cmd1.ExpectedVersion = f.Version
+	got1, err := store.Apply(ctx, "eng-1", "f1", cmd1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got1.Version != 2 {
+		t.Errorf("version after first escalation = %d, want 2", got1.Version)
+	}
+
+	cmd2 := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd2.EventID = "evt-2"
+	cmd2.JudgmentID = "j2"
+	cmd2.Fingerprint = strings.Repeat("b", 64)
+	cmd2.FindingVersion = got1.Version
+	cmd2.ExpectedPriority = 3
+	cmd2.ExpectedVersion = got1.Version
+	got2, err := store.Apply(ctx, "eng-1", "f1", cmd2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2.Version != 3 {
+		t.Errorf("version after second escalation = %d, want 3", got2.Version)
+	}
+	if got2.Priority != 2 {
+		t.Errorf("priority after second escalation = %d, want 2", got2.Priority)
+	}
+}
+
+func TestPromotionStoreReviewDoesNotBumpVersion(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+
+	// Apply three review flags in sequence. Version must never change.
+	for i := 0; i < 3; i++ {
+		cmd := sampleCmd(judgment.PromotionFlagForReview, 3, 3)
+		cmd.EventID = shared.ID("evt-" + string(rune('a'+i)))
+		cmd.JudgmentID = shared.ID("judg-" + string(rune('a'+i)))
+		cmd.Fingerprint = strings.Repeat(string(rune('a'+i)), 64)
+		cmd.Rule = judgment.RuleUncertainCorroboration
+		cmd.ExpectedPriority = 3
+		cmd.ExpectedVersion = 1
+		got, err := store.Apply(ctx, "eng-1", "f1", cmd)
+		if err != nil {
+			t.Fatalf("review %d: %v", i, err)
+		}
+		if got.Version != 1 {
+			t.Errorf("review %d: version = %d, want 1 (no bump)", i, got.Version)
+		}
+		if got.Priority != 3 {
+			t.Errorf("review %d: priority = %d, want 3 (no change)", i, got.Priority)
+		}
+	}
+	_ = f
+}
+
+func TestPromotionEventValidation(t *testing.T) {
+	now := time.Now()
+	valid := func() promotion.PromotionEvent {
+		evt, _ := promotion.NewPromotionEvent(
+			"evt-1", "eng-1", "j1", "f1", 1, 2,
+			judgment.RuleRuntimeReachableExposed,
+			judgment.PromotionEscalate, 3, 2,
+			[]judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "j1"}},
+			strings.Repeat("a", 64),
+			75, "rationale", "ev-1", "verifier",
+			nil, "tester", now,
+		)
+		return evt
+	}
+
+	// Valid construction.
+	evt := valid()
+	if evt.ID != "evt-1" {
+		t.Errorf("ID = %s, want evt-1", evt.ID)
+	}
+	if evt.JudgmentID != "j1" {
+		t.Errorf("JudgmentID = %s, want j1", evt.JudgmentID)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*promotion.PromotionEvent)
+	}{
+		{"zero id", func(e *promotion.PromotionEvent) { e.ID = "" }},
+		{"zero engagement", func(e *promotion.PromotionEvent) { e.EngagementID = "" }},
+		{"zero judgment", func(e *promotion.PromotionEvent) { e.JudgmentID = "" }},
+		{"zero finding", func(e *promotion.PromotionEvent) { e.FindingID = "" }},
+		{"zero version", func(e *promotion.PromotionEvent) { e.FindingVersion = 0 }},
+		{"invalid effect", func(e *promotion.PromotionEvent) { e.Effect = "bogus" }},
+		{"before priority zero", func(e *promotion.PromotionEvent) { e.BeforePriority = 0 }},
+		{"after priority too high", func(e *promotion.PromotionEvent) { e.AfterPriority = 6 }},
+		{"no inputs", func(e *promotion.PromotionEvent) { e.Inputs = nil }},
+		{"no fingerprint", func(e *promotion.PromotionEvent) { e.Fingerprint = "" }},
+		{"escalation wrong delta", func(e *promotion.PromotionEvent) { e.AfterPriority = 1 }}, // 3->1 is two levels
+		{"de-escalation toward P1", func(e *promotion.PromotionEvent) {
+			e.Effect = judgment.PromotionDeescalate
+			e.BeforePriority = 3
+			e.AfterPriority = 2
+		}},
+		{"review changes priority", func(e *promotion.PromotionEvent) {
+			e.Effect = judgment.PromotionFlagForReview
+			e.BeforePriority = 3
+			e.AfterPriority = 4
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := valid()
+			tc.mutate(&e)
+			_, err := promotion.NewPromotionEvent(
+				e.ID, e.EngagementID, e.JudgmentID, e.FindingID,
+				e.FindingVersion, e.AfterFindingVersion,
+				e.Rule, e.Effect, e.BeforePriority, e.AfterPriority,
+				e.Inputs, e.Fingerprint,
+				e.VerdictScore, e.VerdictRationale, e.EvidenceID, e.Verifier,
+				nil, e.AppliedBy, e.AppliedAt,
+			)
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Errorf("want ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPromotionEventRejectsMissingAppliedProvenance(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name       string
+		score      int
+		rationale  string
+		evidenceID shared.ID
+		verifier   string
+		appliedBy  string
+	}{
+		{"score below threshold", 74, "verified", "ev-1", "human:verifier", "system:promotion"},
+		{"score over maximum", 101, "verified", "ev-1", "human:verifier", "system:promotion"},
+		{"missing rationale", 75, "", "ev-1", "human:verifier", "system:promotion"},
+		{"missing evidence", 75, "verified", "", "human:verifier", "system:promotion"},
+		{"missing verifier", 75, "verified", "ev-1", "", "system:promotion"},
+		{"missing actor", 75, "verified", "ev-1", "human:verifier", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := promotion.NewPromotionEvent(
+				"evt-1", "eng-1", "j1", "f1", 1, 2,
+				judgment.RuleRuntimeReachableExposed, judgment.PromotionEscalate, 3, 2,
+				[]judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "j1"}},
+				strings.Repeat("a", 64), tc.score, tc.rationale, tc.evidenceID, tc.verifier, nil, tc.appliedBy, now,
+			)
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("NewPromotionEvent error = %v, want ErrValidation", err)
+			}
+		})
+	}
+}
+
+func TestPromotionStoreDefensiveCopies(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	inputs := []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+	}
+	cmd := ports.PromotionCommand{
+		ExpectedPriority: 3,
+		ExpectedVersion:  f.Version,
+		EventID:          "evt-1",
+		JudgmentID:       "j1",
+		FindingVersion:   1,
+		Rule:             judgment.RuleRuntimeReachableExposed,
+		Effect:           judgment.PromotionEscalate,
+		BeforePriority:   3,
+		AfterPriority:    2,
+		Inputs:           inputs,
+		Fingerprint:      strings.Repeat("a", 64),
+		VerdictScore:     75,
+		VerdictRationale: "verified",
+		EvidenceID:       "evidence-1",
+		Verifier:         "human:verifier",
+		AppliedBy:        "tester",
+	}
+
+	_, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mutate the caller's inputs after Apply returns.
+	inputs[0].ID = "mutated"
+
+	// The stored event must be unaffected.
+	events, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Inputs[0].ID == "mutated" {
+		t.Error("stored event's Inputs were mutated by the caller (defensive copy failed)")
+	}
+
+	// Mutating the returned list must not affect the store.
+	events[0].ID = "mutated-evt"
+	events2, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if events2[0].ID == "mutated-evt" {
+		t.Error("ListByFinding returned a mutable reference to the store's internal data")
+	}
+}
+
+func TestPromotionEventAfterFindingVersionValidation(t *testing.T) {
+	now := time.Now()
+	base := func() promotion.PromotionEvent {
+		evt, _ := promotion.NewPromotionEvent(
+			"evt-1", "eng-1", "j1", "f1", 1, 2,
+			judgment.RuleRuntimeReachableExposed,
+			judgment.PromotionEscalate, 3, 2,
+			[]judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "j1"}},
+			strings.Repeat("a", 64),
+			75, "verified", "ev-1", "human:verifier",
+			nil, "tester", now,
+		)
+		return evt
+	}
+	_ = base
+
+	// Escalation: afterVersion must be findingVersion+1.
+	t.Run("escalation version must be +1", func(t *testing.T) {
+		_, err := promotion.NewPromotionEvent(
+			"evt-1", "eng-1", "j1", "f1", 1, 3, // should be 2
+			judgment.RuleRuntimeReachableExposed,
+			judgment.PromotionEscalate, 3, 2,
+			[]judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "j1"}},
+			strings.Repeat("a", 64), 75, "", "", "", nil, "tester", now,
+		)
+		if !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("want ErrValidation, got %v", err)
+		}
+	})
+
+	// Review: afterVersion must equal findingVersion.
+	t.Run("review version must equal findingVersion", func(t *testing.T) {
+		_, err := promotion.NewPromotionEvent(
+			"evt-1", "eng-1", "j1", "f1", 1, 2, // should be 1
+			judgment.RuleUncertainCorroboration,
+			judgment.PromotionFlagForReview, 3, 3,
+			[]judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "j1"}},
+			strings.Repeat("b", 64), 0, "", "", "", nil, "tester", now,
+		)
+		if !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("want ErrValidation, got %v", err)
+		}
+	})
+}
+
+func TestPromotionEventRuleEffectCoherence(t *testing.T) {
+	now := time.Now()
+
+	// Rule produces de_escalate, but effect is escalate.
+	_, err := promotion.NewPromotionEvent(
+		"evt-1", "eng-1", "j1", "f1", 1, 2,
+		judgment.RuleDeterministicUnreachable,
+		judgment.PromotionEscalate, 3, 2,
+		[]judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "j1"}},
+		strings.Repeat("a", 64), 0, "", "", "", nil, "tester", now,
+	)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("rule/effect mismatch: want ErrValidation, got %v", err)
+	}
+
+	// Unknown rule key.
+	_, err = promotion.NewPromotionEvent(
+		"evt-1", "eng-1", "j1", "f1", 1, 2,
+		"promotion.unknown.rule",
+		judgment.PromotionEscalate, 3, 2,
+		[]judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "j1"}},
+		strings.Repeat("a", 64), 0, "", "", "", nil, "tester", now,
+	)
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("unknown rule: want ErrValidation, got %v", err)
+	}
+}
+
+func TestPromotionStoreCrossTenantIsolation(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+
+	tenantA := shared.WithTenant(context.Background(), "tenant-a")
+	tenantB := shared.WithTenant(context.Background(), "tenant-b")
+
+	// Seed separate findings per tenant (different engagements).
+	seedFinding(t, findingRepo, "eng-a", "f1", 3, 1)
+	seedFinding(t, findingRepo, "eng-b", "f1", 3, 1)
+
+	// Apply under tenant A.
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = 1
+	_, err := store.Apply(tenantA, "eng-a", "f1", cmd)
+	if err != nil {
+		t.Fatalf("apply under tenant A: %v", err)
+	}
+
+	// Tenant B must not see tenant A's events.
+	events, err := store.ListByFinding(tenantB, "eng-b", "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 {
+		t.Errorf("tenant B saw %d events from tenant A", len(events))
+	}
+
+	// Tenant B should be able to apply its own event.
+	cmd2 := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd2.JudgmentID = "j2"
+	cmd2.Fingerprint = strings.Repeat("b", 64)
+	cmd2.ExpectedPriority = 3
+	cmd2.ExpectedVersion = 1
+	_, err = store.Apply(tenantB, "eng-b", "f1", cmd2)
+	if err != nil {
+		t.Fatalf("apply under tenant B: %v", err)
+	}
+
+	// Each tenant sees exactly 1 event.
+	eventsA, _ := store.ListByFinding(tenantA, "eng-a", "f1")
+	eventsB, _ := store.ListByFinding(tenantB, "eng-b", "f1")
+	if len(eventsA) != 1 || len(eventsB) != 1 {
+		t.Errorf("tenant A events: %d, tenant B events: %d, want 1 each", len(eventsA), len(eventsB))
+	}
+}
+
+// --- New tests for Task #9 fixes ---
+
+func TestPromotionEventEquals(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	base := promotion.PromotionEvent{
+		ID: "evt-1", EngagementID: "eng-1", JudgmentID: "j1", FindingID: "f1",
+		FindingVersion: 1, AfterFindingVersion: 2,
+		Rule: judgment.RuleRuntimeReachableExposed, Effect: judgment.PromotionEscalate,
+		BeforePriority: 3, AfterPriority: 2,
+		Inputs:      []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "in1"}},
+		Fingerprint: strings.Repeat("a", 64),
+		Uncertainty: nil,
+		AppliedAt:   now,
+	}
+	if !base.Equals(base) {
+		t.Error("event should equal itself")
+	}
+	other := base
+	other.EngagementID = "eng-2"
+	if base.Equals(other) {
+		t.Error("should differ on engagementID")
+	}
+	other = base
+	other.Rule = "other.rule"
+	if base.Equals(other) {
+		t.Error("should differ on rule")
+	}
+	other = base
+	other.Fingerprint = strings.Repeat("b", 64)
+	if base.Equals(other) {
+		t.Error("should differ on fingerprint")
+	}
+	other = base
+	other.Inputs = []judgment.PromotionInput{{Kind: judgment.PromotionInputAttackPath, ID: "x"}}
+	if base.Equals(other) {
+		t.Error("should differ on inputs")
+	}
+	other = base
+	other.Uncertainty = []string{"token"}
+	if base.Equals(other) {
+		t.Error("should differ on uncertainty")
+	}
+	other = base
+	other.AppliedAt = now.Add(time.Hour)
+	if !base.Equals(other) {
+		t.Error("AppliedAt is generated; should still be equal")
+	}
+	// Verifier, VerdictScore, VerdictRationale, EvidenceID are sealed
+	// provenance from the judgment — altering them means different provenance.
+	other = base
+	other.VerdictScore = 999
+	if base.Equals(other) {
+		t.Error("should differ on VerdictScore (sealed provenance)")
+	}
+	other = base
+	other.Verifier = "attacker"
+	if base.Equals(other) {
+		t.Error("should differ on Verifier (sealed provenance)")
+	}
+	other = base
+	other.VerdictRationale = "tampered"
+	if base.Equals(other) {
+		t.Error("should differ on VerdictRationale (sealed provenance)")
+	}
+	other = base
+	other.EvidenceID = "ev-other"
+	if base.Equals(other) {
+		t.Error("should differ on EvidenceID (sealed provenance)")
+	}
+	other = base
+	other.ID = "evt-other"
+	if !base.Equals(other) {
+		t.Error("EventID is regenerated; should still be equal")
+	}
+	other = base
+	other.AppliedBy = "other-actor"
+	if base.Equals(other) {
+		t.Error("should differ on AppliedBy")
+	}
+}
+
+func TestPromotionEventUncertaintyPreserved(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	unc := []string{"inferred_path", "unknown_reachability"}
+	evt, err := promotion.NewPromotionEvent(
+		"evt-unc", "eng-1", "j1", "f1", 1, 1,
+		judgment.RuleUncertainCorroboration,
+		judgment.PromotionFlagForReview, 3, 3,
+		[]judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "in1"}},
+		strings.Repeat("a", 64),
+		75, "verified", "ev-1", "human:verifier",
+		unc, "tester", now,
+	)
+	if err != nil {
+		t.Fatalf("NewPromotionEvent: %v", err)
+	}
+	if len(evt.Uncertainty) != 2 {
+		t.Fatalf("uncertainty length = %d, want 2", len(evt.Uncertainty))
+	}
+	unc[0] = "mutated"
+	if evt.Uncertainty[0] == "mutated" {
+		t.Error("uncertainty should be a defensive copy")
+	}
+}
+
+func TestPromotionEventClaimValidationEnforced(t *testing.T) {
+	now := time.Now()
+	_, err := promotion.NewPromotionEvent(
+		"evt-1", "eng-1", "j1", "f1", 1, 2,
+		judgment.RuleRuntimeReachableExposed,
+		judgment.PromotionEscalate, 3, 2,
+		[]judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "in1"}},
+		strings.Repeat("z", 64), 0, "", "", "",
+		nil, "tester", now,
+	)
+	if err == nil {
+		t.Error("want validation error for invalid fingerprint format")
+	}
+	_, err = promotion.NewPromotionEvent(
+		"evt-1", "eng-1", "j1", "f1", 1, 2,
+		judgment.RuleRuntimeReachableExposed,
+		judgment.PromotionEscalate, 3, 2,
+		[]judgment.PromotionInput{
+			{Kind: judgment.PromotionInputReachability, ID: "b"},
+			{Kind: judgment.PromotionInputAttackPath, ID: "a"},
+		},
+		strings.Repeat("a", 64), 0, "", "", "",
+		nil, "tester", now,
+	)
+	if err == nil {
+		t.Error("want validation error for unsorted inputs")
+	}
+}
+
+func TestPromotionStoreExactReplayConflictOnAlteredFields(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+	seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = 1
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	altered := cmd
+	altered.Rule = "promotion.altered.rule"
+	altered.Effect = judgment.PromotionDeescalate
+	altered.AfterPriority = 4
+	if _, err := store.Apply(ctx, "eng-1", "f1", altered); !errors.Is(err, shared.ErrConflict) {
+		t.Errorf("want ErrConflict for altered replay, got %v", err)
+	}
+}
+
+func TestPromotionStoreReplayConflictOnAlteredProvenance(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+	seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = 1
+	cmd.VerdictScore = 80
+	cmd.VerdictRationale = "reachability confirmed"
+	cmd.EvidenceID = "ev-1"
+	cmd.Verifier = "verifier-a"
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*ports.PromotionCommand)
+	}{
+		{"altered VerdictScore", func(c *ports.PromotionCommand) { c.VerdictScore = 999 }},
+		{"altered Verifier", func(c *ports.PromotionCommand) { c.Verifier = "attacker" }},
+		{"altered VerdictRationale", func(c *ports.PromotionCommand) { c.VerdictRationale = "tampered" }},
+		{"altered EvidenceID", func(c *ports.PromotionCommand) { c.EvidenceID = "ev-other" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			altered := cmd
+			tc.mutate(&altered)
+			_, err := store.Apply(ctx, "eng-1", "f1", altered)
+			if !errors.Is(err, shared.ErrConflict) {
+				t.Errorf("want ErrConflict for %s, got %v", tc.name, err)
+			}
+		})
+	}
+
+	// Exact replay (same provenance) should still be idempotent.
+	got, err := store.Apply(ctx, "eng-1", "f1", cmd)
+	if err != nil {
+		t.Fatalf("exact replay: %v", err)
+	}
+	if got.Priority != 2 {
+		t.Errorf("replay priority = %d, want 2", got.Priority)
+	}
+}
+
+func TestPromotionStoreReplayConflictsOnAppliedBy(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	store := mustPromotionStore(t, findingRepo, defaultReader())
+	ctx := tenantCtx()
+	seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority, cmd.ExpectedVersion = 3, 1
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd); err != nil {
+		t.Fatal(err)
+	}
+	altered := cmd
+	altered.AppliedBy = "human:other"
+	if _, err := store.Apply(ctx, "eng-1", "f1", altered); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("altered applied-by error = %v, want ErrConflict", err)
+	}
+}
+
+func TestPromotionStoreReversalLineageContinuity(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+	seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+	esc1 := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	esc1.ExpectedPriority = 4
+	esc1.ExpectedVersion = 1
+	esc1.EventID = "evt-esc1"
+	esc1.FindingVersion = 1
+	if _, err := store.Apply(ctx, "eng-1", "f1", esc1); err != nil {
+		t.Fatalf("escalation 1: %v", err)
+	}
+	esc2 := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	esc2.ExpectedPriority = 3
+	esc2.ExpectedVersion = 2
+	esc2.EventID = "evt-esc2"
+	esc2.JudgmentID = "j2"
+	esc2.FindingVersion = 2
+	esc2.Fingerprint = strings.Repeat("b", 64)
+	if _, err := store.Apply(ctx, "eng-1", "f1", esc2); err != nil {
+		t.Fatalf("escalation 2: %v", err)
+	}
+	revCmd := sampleCmd(judgment.PromotionDeescalate, 2, 4)
+	revCmd.Rule = judgment.RuleCorroboratingSignalLoss
+	revCmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputPrior, ID: "evt-esc1"},
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+	}
+	revCmd.JudgmentID = "j-rev"
+	revCmd.EventID = "evt-rev"
+	revCmd.FindingVersion = 3
+	revCmd.ExpectedPriority = 2
+	revCmd.ExpectedVersion = 3
+	revCmd.BeforePriority = 2
+	revCmd.Fingerprint = strings.Repeat("e", 64)
+	if _, err := store.Apply(ctx, "eng-1", "f1", revCmd); !errors.Is(err, shared.ErrConflict) {
+		t.Errorf("want ErrConflict for reversing non-latest event, got %v", err)
+	}
+	revCmd2 := sampleCmd(judgment.PromotionDeescalate, 2, 3)
+	revCmd2.Rule = judgment.RuleCorroboratingSignalLoss
+	revCmd2.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputPrior, ID: "evt-esc2"},
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+	}
+	revCmd2.JudgmentID = "j-rev2"
+	revCmd2.EventID = "evt-rev2"
+	revCmd2.FindingVersion = 3
+	revCmd2.ExpectedPriority = 2
+	revCmd2.ExpectedVersion = 3
+	revCmd2.BeforePriority = 2
+	revCmd2.Fingerprint = strings.Repeat("c", 64)
+	got, err := store.Apply(ctx, "eng-1", "f1", revCmd2)
+	if err != nil {
+		t.Fatalf("reverse latest escalation: %v", err)
+	}
+	if got.Priority != 3 {
+		t.Errorf("priority = %d, want 3", got.Priority)
+	}
+}
+
+func TestPromotionStoreListByFindingEngagementScope(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+	seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	seedFinding(t, findingRepo, "eng-2", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority = 3
+	cmd.ExpectedVersion = 1
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd); err != nil {
+		t.Fatalf("apply to eng-1: %v", err)
+	}
+	events1, _ := store.ListByFinding(ctx, "eng-1", "f1")
+	if len(events1) != 1 {
+		t.Errorf("eng-1 events: %d, want 1", len(events1))
+	}
+	events2, _ := store.ListByFinding(ctx, "eng-2", "f1")
+	if len(events2) != 0 {
+		t.Errorf("eng-2 events: %d, want 0", len(events2))
+	}
+	_, ok1, _ := store.LatestByFinding(ctx, "eng-1", "f1")
+	if !ok1 {
+		t.Error("eng-1 latest should exist")
+	}
+	_, ok2, _ := store.LatestByFinding(ctx, "eng-2", "f1")
+	if ok2 {
+		t.Error("eng-2 latest should not exist")
+	}
+}
+
+func TestPromotionStoreStaleCASAfterReupsert(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Seed finding at P3, version 1.
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	if f.Version != 1 {
+		t.Fatalf("seed version = %d, want 1", f.Version)
+	}
+
+	// Apply escalation P3->P2 with j1. Finding becomes version 2.
+	cmd1 := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd1.ExpectedPriority = 3
+	cmd1.ExpectedVersion = 1
+	cmd1.VerdictScore = 80
+	cmd1.VerdictRationale = "verified"
+	cmd1.EvidenceID = "evidence-1"
+	cmd1.Verifier = "v1"
+	got1, err := store.Apply(ctx, "eng-1", "f1", cmd1)
+	if err != nil {
+		t.Fatalf("first escalation: %v", err)
+	}
+	if got1.Version != 2 {
+		t.Fatalf("version after escalation = %d, want 2", got1.Version)
+	}
+
+	// Re-upsert the finding (simulates a re-scan). Version bumps to 3,
+	// promoted priority (2) is preserved.
+	fRescan := finding.Finding{
+		ID: "f1", EngagementID: "eng-1", Title: "test finding",
+		Severity: shared.SeverityHigh, Status: finding.StatusConfirmed,
+		Kind: finding.KindSCA, Priority: 2,
+		DedupKey: "test:f1",
+		Audit:    shared.Audit{CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	}
+	if err := findingRepo.Upsert(ctx, []finding.Finding{fRescan}); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	fAfter, err := findingRepo.getFinding("eng-1", "f1")
+	if err != nil {
+		t.Fatalf("get finding after re-upsert: %v", err)
+	}
+	if fAfter.Version != 3 {
+		t.Fatalf("version after re-upsert = %d, want 3", fAfter.Version)
+	}
+	if fAfter.Priority != 2 {
+		t.Fatalf("priority after re-upsert = %d, want 2 (preserved)", fAfter.Priority)
+	}
+
+	// Now try to apply j2 escalation P2->P1 with ExpectedVersion=2 (stale).
+	// Should fail CAS because stored version is now 3.
+	cmd2 := sampleCmd(judgment.PromotionEscalate, 2, 1)
+	cmd2.JudgmentID = "j2"
+	cmd2.EventID = "evt-stale"
+	cmd2.Fingerprint = strings.Repeat("b", 64)
+	cmd2.ExpectedPriority = 2
+	cmd2.ExpectedVersion = 2 // stale: actual is 3
+	cmd2.VerdictScore = 90
+	cmd2.Verifier = "v2"
+	_, err = store.Apply(ctx, "eng-1", "f1", cmd2)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict for stale CAS after re-upsert, got %v", err)
+	}
+
+	// Exact replay of j1 should still succeed (idempotent path).
+	replay, err := store.Apply(ctx, "eng-1", "f1", cmd1)
+	if err != nil {
+		t.Fatalf("j1 idempotent replay after re-upsert: %v", err)
+	}
+	if replay.Priority != 2 {
+		t.Errorf("replay priority = %d, want 2", replay.Priority)
+	}
+}
+
+func TestPromotionStoreEventIDCollisionConflict(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Seed two findings in the same engagement.
+	seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	seedFinding(t, findingRepo, "eng-1", "f2", 3, 1)
+
+	// Apply escalation to f1 with EventID "evt-shared".
+	cmd1 := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd1.ExpectedPriority = 3
+	cmd1.ExpectedVersion = 1
+	cmd1.EventID = "evt-shared"
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd1); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	// Try to apply a DIFFERENT event to f2 with the same EventID.
+	// Must return ErrConflict before any mutation.
+	cmd2 := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd2.JudgmentID = "j2"
+	cmd2.EventID = "evt-shared" // collision
+	cmd2.Fingerprint = strings.Repeat("b", 64)
+	cmd2.ExpectedPriority = 3
+	cmd2.ExpectedVersion = 1
+	_, err := store.Apply(ctx, "eng-1", "f2", cmd2)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict for EventID collision, got %v", err)
+	}
+
+	// f2 must not have been mutated: no event persisted, priority and
+	// version must be unchanged from the seeded state.
+	events2, _ := store.ListByFinding(ctx, "eng-1", "f2")
+	if len(events2) != 0 {
+		t.Errorf("f2 events after collision: %d, want 0", len(events2))
+	}
+	f2After, err := findingRepo.getFinding("eng-1", "f2")
+	if err != nil {
+		t.Fatalf("get f2 after collision: %v", err)
+	}
+	if f2After.Priority != 3 {
+		t.Errorf("f2 priority after collision = %d, want 3 (unchanged)", f2After.Priority)
+	}
+	if f2After.Version != 1 {
+		t.Errorf("f2 version after collision = %d, want 1 (unchanged)", f2After.Version)
+	}
+
+	// f1 must also be unaffected by the collision attempt.
+	f1After, err := findingRepo.getFinding("eng-1", "f1")
+	if err != nil {
+		t.Fatalf("get f1 after collision: %v", err)
+	}
+	if f1After.Priority != 2 {
+		t.Errorf("f1 priority after collision = %d, want 2", f1After.Priority)
+	}
+	if f1After.Version != 2 {
+		t.Errorf("f1 version after collision = %d, want 2", f1After.Version)
+	}
+
+	// Exact semantic replay with same EventID should succeed (idempotent).
+	replay, err := store.Apply(ctx, "eng-1", "f1", cmd1)
+	if err != nil {
+		t.Fatalf("exact replay with same EventID: %v", err)
+	}
+	if replay.Priority != 2 {
+		t.Errorf("replay priority = %d, want 2", replay.Priority)
+	}
+}
+
+func TestPromotionStoreReversalAfterFlagForReview(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Seed finding at P4, version 1.
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+
+	// 1. Escalate P4->P3. Finding becomes version 2.
+	escCmd := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	escCmd.ExpectedPriority = 4
+	escCmd.ExpectedVersion = f.Version
+	escCmd.EventID = "prior-evt"
+	if _, err := store.Apply(ctx, "eng-1", "f1", escCmd); err != nil {
+		t.Fatalf("escalation: %v", err)
+	}
+
+	// 2. flag_for_review (non-mutating). Version stays 2.
+	reviewCmd := sampleCmd(judgment.PromotionFlagForReview, 3, 3)
+	reviewCmd.Rule = judgment.RuleUncertainCorroboration
+	reviewCmd.JudgmentID = "j-review"
+	reviewCmd.EventID = "review-evt"
+	reviewCmd.Fingerprint = strings.Repeat("b", 64)
+	reviewCmd.FindingVersion = 2
+	reviewCmd.ExpectedPriority = 3
+	reviewCmd.ExpectedVersion = 2
+	if _, err := store.Apply(ctx, "eng-1", "f1", reviewCmd); err != nil {
+		t.Fatalf("flag_for_review: %v", err)
+	}
+
+	// 3. Exact reversal should succeed even though a flag_for_review event
+	// was inserted between the escalation and the reversal. flag_for_review
+	// is non-mutating and does not block the reversal lineage.
+	revCmd := sampleCmd(judgment.PromotionDeescalate, 3, 4)
+	revCmd.Rule = judgment.RuleCorroboratingSignalLoss
+	revCmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputPrior, ID: "prior-evt"},
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+	}
+	revCmd.JudgmentID = "j-rev"
+	revCmd.EventID = "evt-rev"
+	revCmd.Fingerprint = strings.Repeat("c", 64)
+	revCmd.FindingVersion = 2
+	revCmd.ExpectedPriority = 3
+	revCmd.ExpectedVersion = 2
+	got, err := store.Apply(ctx, "eng-1", "f1", revCmd)
+	if err != nil {
+		t.Fatalf("reversal after review: %v", err)
+	}
+	if got.Priority != 4 {
+		t.Errorf("priority = %d, want 4 (exact reversal)", got.Priority)
+	}
+	if got.Version != 3 {
+		t.Errorf("version = %d, want 3 (bumped)", got.Version)
+	}
+}
+
+func TestPromotionStoreReversalBlockedByLaterEscalation(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+
+	// Seed finding at P4, version 1.
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 4, 1)
+
+	// 1. Escalation A: P4->P3.
+	escA := sampleCmd(judgment.PromotionEscalate, 4, 3)
+	escA.ExpectedPriority = 4
+	escA.ExpectedVersion = f.Version
+	escA.EventID = "evt-escA"
+	if _, err := store.Apply(ctx, "eng-1", "f1", escA); err != nil {
+		t.Fatalf("escalation A: %v", err)
+	}
+
+	// 2. Escalation B: P3->P2.
+	escB := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	escB.JudgmentID = "j2"
+	escB.EventID = "evt-escB"
+	escB.Fingerprint = strings.Repeat("b", 64)
+	escB.FindingVersion = 2
+	escB.ExpectedPriority = 3
+	escB.ExpectedVersion = 2
+	if _, err := store.Apply(ctx, "eng-1", "f1", escB); err != nil {
+		t.Fatalf("escalation B: %v", err)
+	}
+
+	// 3. Try to reverse escalation A. Must fail because escalation B
+	// is a later MUTATING event.
+	revCmd := sampleCmd(judgment.PromotionDeescalate, 2, 4)
+	revCmd.Rule = judgment.RuleCorroboratingSignalLoss
+	revCmd.Inputs = []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputPrior, ID: "evt-escA"},
+		{Kind: judgment.PromotionInputReachability, ID: "j1"},
+	}
+	revCmd.JudgmentID = "j-rev"
+	revCmd.EventID = "evt-rev"
+	revCmd.Fingerprint = strings.Repeat("c", 64)
+	revCmd.FindingVersion = 3
+	revCmd.ExpectedPriority = 2
+	revCmd.ExpectedVersion = 3
+	_, err := store.Apply(ctx, "eng-1", "f1", revCmd)
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("want ErrConflict for reversing non-latest mutating event, got %v", err)
+	}
+}
+
+func TestPromotionStorePendingAuditRecovery(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	ctx := tenantCtx()
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority, cmd.ExpectedVersion = f.Priority, f.Version
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListPendingAudits(ctx, "eng-1")
+	if err != nil || len(pending) != 1 || pending[0].ID != cmd.EventID {
+		t.Fatalf("pending audits = %#v, %v", pending, err)
+	}
+	if err := store.MarkAuditComplete(ctx, cmd.EventID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkAuditComplete(ctx, cmd.EventID); err != nil {
+		t.Fatalf("idempotent acknowledgement: %v", err)
+	}
+	pending, err = store.ListPendingAudits(ctx, "eng-1")
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending audits after acknowledgement = %#v, %v", pending, err)
+	}
+}
+
+func TestPromotionStorePendingAuditsIsolateSameEventIDAcrossTenants(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	reader := defaultReader()
+	store := mustPromotionStore(t, findingRepo, reader)
+	tenantA := shared.WithTenant(context.Background(), "tenant-a")
+	tenantB := shared.WithTenant(context.Background(), "tenant-b")
+	seedFinding(t, findingRepo, "eng-a", "finding-a", 3, 1)
+	seedFinding(t, findingRepo, "eng-b", "finding-b", 3, 1)
+
+	for _, tc := range []struct {
+		ctx                   context.Context
+		engagement, finding   shared.ID
+		judgment, fingerprint shared.ID
+	}{
+		{tenantA, "eng-a", "finding-a", "judgment-a", shared.ID(strings.Repeat("a", 64))},
+		{tenantB, "eng-b", "finding-b", "judgment-b", shared.ID(strings.Repeat("b", 64))},
+	} {
+		cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+		cmd.EventID = "shared-event-id"
+		cmd.JudgmentID = tc.judgment
+		cmd.Fingerprint = string(tc.fingerprint)
+		cmd.ExpectedPriority, cmd.ExpectedVersion = 3, 1
+		if _, err := store.Apply(tc.ctx, tc.engagement, tc.finding, cmd); err != nil {
+			t.Fatalf("apply %s: %v", tc.engagement, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		ctx                 context.Context
+		engagement, finding shared.ID
+	}{
+		{tenantA, "eng-a", "finding-a"},
+		{tenantB, "eng-b", "finding-b"},
+	} {
+		pending, err := store.ListPendingAudits(tc.ctx, tc.engagement)
+		if err != nil || len(pending) != 1 || pending[0].ID != "shared-event-id" || pending[0].FindingID != tc.finding {
+			t.Fatalf("pending audits for %s = %#v, %v", tc.engagement, pending, err)
+		}
+	}
+
+	if err := store.MarkAuditComplete(tenantA, "shared-event-id"); err != nil {
+		t.Fatalf("acknowledge tenant A: %v", err)
+	}
+	pendingA, err := store.ListPendingAudits(tenantA, "eng-a")
+	if err != nil || len(pendingA) != 0 {
+		t.Fatalf("tenant A pending audits = %#v, %v", pendingA, err)
+	}
+	pendingB, err := store.ListPendingAudits(tenantB, "eng-b")
+	if err != nil || len(pendingB) != 1 || pendingB[0].FindingID != "finding-b" {
+		t.Fatalf("tenant B pending audits = %#v, %v", pendingB, err)
+	}
+}
+
+type promotionIntegrationClock struct{ t time.Time }
+
+func (c *promotionIntegrationClock) Now() time.Time { return c.t }
+
+type promotionIntegrationIDs struct{ next int }
+
+func (g *promotionIntegrationIDs) NewID() shared.ID {
+	g.next++
+	return shared.ID(fmt.Sprintf("integration-id-%d", g.next))
+}
+
+type promotionIntegrationAudit struct {
+	entries []ports.AuditEntry
+	fail    int
+	seen    map[string]struct{}
+}
+
+func (a *promotionIntegrationAudit) Record(_ context.Context, entry ports.AuditEntry) error {
+	a.entries = append(a.entries, entry)
+	return nil
+}
+
+func (a *promotionIntegrationAudit) RecordOnce(ctx context.Context, entry ports.AuditEntry) error {
+	if a.fail > 0 {
+		a.fail--
+		return errors.New("audit unavailable")
+	}
+	if a.seen == nil {
+		a.seen = make(map[string]struct{})
+	}
+	key := entry.Action + ":" + entry.Metadata["idempotency_key"]
+	if _, ok := a.seen[key]; ok {
+		return nil
+	}
+	a.seen[key] = struct{}{}
+	return a.Record(ctx, entry)
+}
+
+func TestPromotionIntegrationRecoversAudit(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-1")
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	engagements := NewEngagementRepository()
+	eng, err := engagement.New("eng-1", "tenant-1", "promotion recovery", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, eng); err != nil {
+		t.Fatal(err)
+	}
+	findings := NewFindingRepository()
+	f := integrationFinding(eng.ID, now)
+	if err := findings.Upsert(ctx, []finding.Finding{f}); err != nil {
+		t.Fatal(err)
+	}
+	promotions := mustPromotionStore(t, findings, engagements)
+	audit := &promotionIntegrationAudit{fail: 1}
+	evidenceStore := NewEvidenceStore()
+	clock := &promotionIntegrationClock{t: now}
+	evidenceService, err := evidenceuc.NewService(evidenceStore, nil, audit, clock, &promotionIntegrationIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder, err := promotionuc.NewConfirmedRecorder(evidenceService, promotions, findings, engagements, audit, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := integrationRecoveryJudgment()
+	if err := recorder.RecordConfirmed(ctx, j); err == nil {
+		t.Fatal("first audit failure must be returned")
+	}
+	integrationAssertPriority(t, findings, ctx, j.EngagementID, j.SubjectID, 2, 2)
+	if err := recorder.RecordConfirmed(ctx, j); err != nil {
+		t.Fatalf("retry audit: %v", err)
+	}
+	events, err := promotions.ListByFinding(ctx, j.EngagementID, j.SubjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("lifecycle events = %d, want 1", len(events))
+	}
+	links, err := evidenceStore.ListByEngagement(ctx, j.EngagementID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 || len(audit.entries) != 1 {
+		t.Fatalf("recovery = links %d audits %d, want 1/1", len(links), len(audit.entries))
+	}
+}
+
+func TestPromotionIntegrationLifecycleReevaluatesAndRestoresPriority(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-1")
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := &promotionIntegrationClock{t: now}
+	ids := &promotionIntegrationIDs{}
+	engagements := NewEngagementRepository()
+	eng, err := engagement.New("eng-1", "tenant-1", "promotion lifecycle", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, eng); err != nil {
+		t.Fatal(err)
+	}
+	findings := NewFindingRepository()
+	initial := integrationFinding(eng.ID, now)
+	initial.ID, initial.DedupKey = "finding-1", "finding-1"
+	if err := findings.Upsert(ctx, []finding.Finding{initial}); err != nil {
+		t.Fatal(err)
+	}
+	assets := NewAssetStore()
+	exposure, err := asset.New("exposure-1", "tenant-1", asset.KindExposure, "internet", "Internet", nil, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := asset.New("asset-1", "tenant-1", asset.KindHost, "host-1", "Host", nil, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assets.UpsertAsset(ctx, exposure); err != nil {
+		t.Fatal(err)
+	}
+	if err := assets.UpsertAsset(ctx, target); err != nil {
+		t.Fatal(err)
+	}
+	edge, err := asset.NewEdge("tenant-1", exposure.ID, target.ID, asset.EdgeReaches, "edge-1", asset.EdgeObserved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assets.UpsertEdge(ctx, edge); err != nil {
+		t.Fatal(err)
+	}
+	bindings := NewAttackPathStore()
+	if err := bindings.ReplaceBindings(ctx, "tenant-1", eng.ID, "scanner-1", []attackpath.Binding{{TenantID: "tenant-1", EngagementID: eng.ID, AssetID: target.ID, FindingID: initial.ID, TargetKind: attackpath.TargetCanonical, Producer: "scanner-1", Provenance: "binding-1", Confidence: asset.EdgeObserved}}); err != nil {
+		t.Fatal(err)
+	}
+	detections := NewDetectionRecordStore()
+	detections.SetClock(clock.Now)
+	detectionRule, ok := detection.Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("missing detection rule fixture")
+	}
+	detected, err := detection.NewDetection(detectionRule, "host-1", "agent-1", []detection.Event{{Class: detection.ClassProcess, At: now, Host: "host-1", Process: &detection.ProcessEvent{PID: 1, Comm: "ps", Path: "/usr/bin/ps"}}}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := detections.AppendDetection(ctx, detection.Record{ID: "detection-1", TenantID: "tenant-1", EngagementID: eng.ID, AssetID: target.ID, AgentID: "agent-1", Detection: detected, EvidenceID: "detection-evidence-1", BatchSeq: 1, RecordedAt: now, ExpiresAt: now.Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	audit := &promotionIntegrationAudit{}
+	evidenceStore := NewEvidenceStore()
+	evidenceService, err := evidenceuc.NewService(evidenceStore, nil, audit, clock, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	judgments := NewJudgmentStore()
+	analysisService, err := analysis.NewService(judgments, evidenceService, audit, clock, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	promotions := mustPromotionStore(t, findings, engagements)
+	recorder, err := promotionuc.NewConfirmedRecorder(evidenceService, promotions, findings, engagements, audit, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysisService.SetPromotionRecorder(recorder)
+	evaluator, err := promotionuc.NewEvaluator(analysisService, findings, judgments, bindings, assets, detections, engagements, promotions, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reachability, err := analysisService.Propose(ctx, "system:jsimport-scan", eng.ID, judgment.CapReachability, judgment.SubjectFinding, initial.ID, judgment.ReachabilityClaim{Reachable: judgment.Reachable, Tier: judgment.Tier1})
+	if err != nil {
+		t.Fatalf("propose reachability: %v", err)
+	}
+	if _, err := analysisService.Verify(ctx, "system:jsimport-engine", eng.ID, reachability.ID, 90, "first-party import proof", reachability.Version); err != nil {
+		t.Fatalf("confirm reachability: %v", err)
+	}
+	if proposed, err := evaluator.Evaluate(ctx, eng.ID); err != nil || proposed != 1 {
+		t.Fatalf("escalation reevaluation = (%d, %v), want (1, nil)", proposed, err)
+	}
+	escalation := integrationLatestPromotionJudgment(t, integrationListJudgments(t, analysisService, ctx, eng.ID))
+	if proposed, err := evaluator.Evaluate(ctx, eng.ID); err != nil || proposed != 0 {
+		t.Fatalf("unchanged reevaluation = (%d, %v), want (0, nil)", proposed, err)
+	}
+	if _, err := analysisService.Verify(ctx, "human:reviewer", eng.ID, escalation.ID, 75, "confirmed escalation", escalation.Version); err != nil {
+		t.Fatalf("confirm escalation: %v", err)
+	}
+	integrationAssertPriority(t, findings, ctx, eng.ID, initial.ID, 2, 2)
+	clock.t = now.Add(2 * time.Hour)
+	if proposed, err := evaluator.Evaluate(ctx, eng.ID); err != nil || proposed != 1 {
+		t.Fatalf("signal-loss reevaluation = (%d, %v), want (1, nil)", proposed, err)
+	}
+	reversal := integrationLatestPromotionJudgment(t, integrationListJudgments(t, analysisService, ctx, eng.ID))
+	if reversal.ID == escalation.ID {
+		t.Fatal("signal loss must propose a distinct reversal judgment")
+	}
+	if _, err := analysisService.Verify(ctx, "human:reviewer", eng.ID, reversal.ID, 75, "confirmed reversal", reversal.Version); err != nil {
+		t.Fatalf("confirm reversal: %v", err)
+	}
+	integrationAssertPriority(t, findings, ctx, eng.ID, initial.ID, initial.Priority, 3)
+	if proposed, err := evaluator.Evaluate(ctx, eng.ID); err != nil || proposed != 0 {
+		t.Fatalf("reversal retry = (%d, %v), want (0, nil)", proposed, err)
+	}
+	confirmed := integrationLatestPromotionJudgment(t, integrationListJudgments(t, analysisService, ctx, eng.ID))
+	if _, err := analysisService.Verify(ctx, "human:reviewer", eng.ID, reversal.ID, 75, "confirmed reversal", confirmed.Version); err != nil {
+		t.Fatalf("confirmed reversal retry: %v", err)
+	}
+	integrationAssertPriority(t, findings, ctx, eng.ID, initial.ID, initial.Priority, 3)
+	events, err := promotions.ListByFinding(ctx, eng.ID, initial.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 || events[1].AfterPriority != initial.Priority {
+		t.Fatalf("events = %#v, want one escalation and exact-priority reversal", events)
+	}
+	links, err := evidenceStore.ListByEngagement(ctx, eng.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 8 || integrationAuditCount(audit.entries, "promotion.applied") != 2 {
+		t.Fatalf("lifecycle idempotency = links %d audits %d, want 8/2", len(links), integrationAuditCount(audit.entries, "promotion.applied"))
+	}
+}
+
+func TestPromotionIntegrationRecoveryRejectsAlteredProvenance(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-1")
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	engagements := NewEngagementRepository()
+	eng, err := engagement.New("eng-1", "tenant-1", "promotion recovery", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, eng); err != nil {
+		t.Fatal(err)
+	}
+	findings := NewFindingRepository()
+	if err := findings.Upsert(ctx, []finding.Finding{integrationFinding(eng.ID, now)}); err != nil {
+		t.Fatal(err)
+	}
+	promotions := mustPromotionStore(t, findings, engagements)
+	audit := &promotionIntegrationAudit{fail: 1}
+	clock := &promotionIntegrationClock{t: now}
+	evidenceService, err := evidenceuc.NewService(NewEvidenceStore(), nil, audit, clock, &promotionIntegrationIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder, err := promotionuc.NewConfirmedRecorder(evidenceService, promotions, findings, engagements, audit, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := integrationRecoveryJudgment()
+	if err := recorder.RecordConfirmed(ctx, j); err == nil {
+		t.Fatal("first audit failure must be returned")
+	}
+	for _, altered := range []judgment.Judgment{
+		func() judgment.Judgment { replay := j; replay.VerdictRationale = "altered provenance"; return replay }(),
+		func() judgment.Judgment {
+			replay := j
+			replay.Claim = judgment.PromotionClaim{FindingID: "find-1", Rule: judgment.RuleRuntimeReachableExposed, Inputs: []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: "altered-input"}}, Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2, Fingerprint: strings.Repeat("1", 64)}
+			return replay
+		}(),
+	} {
+		if err := recorder.RecordConfirmed(ctx, altered); !errors.Is(err, shared.ErrConflict) {
+			t.Fatalf("altered recovery = %v, want ErrConflict", err)
+		}
+	}
+	events, err := promotions.ListByFinding(ctx, j.EngagementID, j.SubjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || len(audit.entries) != 0 {
+		t.Fatalf("altered recovery changed state: events=%d audits=%d", len(events), len(audit.entries))
+	}
+}
+
+func TestPromotionIntegrationReconcilerAppliesConfirmedPromotionIdempotently(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-1")
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	engagements := NewEngagementRepository()
+	eng, err := engagement.New("eng-1", "tenant-1", "promotion reconciliation", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, eng); err != nil {
+		t.Fatal(err)
+	}
+	findings := NewFindingRepository()
+	f := integrationFinding(eng.ID, now)
+	if err := findings.Upsert(ctx, []finding.Finding{f}); err != nil {
+		t.Fatal(err)
+	}
+	judgments := NewJudgmentStore()
+	j := integrationRecoveryJudgment()
+	if err := judgments.Save(ctx, j); err != nil {
+		t.Fatal(err)
+	}
+	promotions := mustPromotionStore(t, findings, engagements)
+	audit := &promotionIntegrationAudit{}
+	clock := &promotionIntegrationClock{t: now}
+	evidenceService, err := evidenceuc.NewService(NewEvidenceStore(), nil, audit, clock, &promotionIntegrationIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder, err := promotionuc.NewConfirmedRecorder(evidenceService, promotions, findings, engagements, audit, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reconciler, err := promotionuc.NewReconciler(judgments, promotions, recorder, audit, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reconciler.Reconcile(ctx, eng.ID); err != nil {
+		t.Fatalf("reconcile confirmed promotion: %v", err)
+	}
+	integrationAssertPriority(t, findings, ctx, eng.ID, f.ID, 2, 2)
+	if integrationAuditCount(audit.entries, "promotion.applied") != 1 {
+		t.Fatalf("promotion audit records = %d, want 1", integrationAuditCount(audit.entries, "promotion.applied"))
+	}
+	if err := reconciler.Reconcile(ctx, eng.ID); err != nil {
+		t.Fatalf("idempotent reconciliation: %v", err)
+	}
+	events, err := promotions.ListByFinding(ctx, eng.ID, f.ID)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("reconciliation duplicated lifecycle event: (%d, %v)", len(events), err)
+	}
+}
+
+func TestPromotionIntegrationReconcilerRecoversAppliedAudit(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-1")
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	engagements := NewEngagementRepository()
+	eng, err := engagement.New("eng-1", "tenant-1", "promotion audit reconciliation", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, eng); err != nil {
+		t.Fatal(err)
+	}
+	findings := NewFindingRepository()
+	f := integrationFinding(eng.ID, now)
+	if err := findings.Upsert(ctx, []finding.Finding{f}); err != nil {
+		t.Fatal(err)
+	}
+	judgments := NewJudgmentStore()
+	j := integrationRecoveryJudgment()
+	if err := judgments.Save(ctx, j); err != nil {
+		t.Fatal(err)
+	}
+	promotions := mustPromotionStore(t, findings, engagements)
+	audit := &promotionIntegrationAudit{fail: 1}
+	clock := &promotionIntegrationClock{t: now}
+	evidenceService, err := evidenceuc.NewService(NewEvidenceStore(), nil, audit, clock, &promotionIntegrationIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder, err := promotionuc.NewConfirmedRecorder(evidenceService, promotions, findings, engagements, audit, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := recorder.RecordConfirmed(ctx, j); err == nil {
+		t.Fatal("applied promotion with failed audit must return an error")
+	}
+	integrationAssertPriority(t, findings, ctx, eng.ID, f.ID, 2, 2)
+	pending, err := promotions.ListPendingAudits(ctx, eng.ID)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending promotion audits = %#v, %v", pending, err)
+	}
+	reconciler, err := promotionuc.NewReconciler(judgments, promotions, recorder, audit, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reconciler.Reconcile(ctx, eng.ID); err != nil {
+		t.Fatalf("recover applied promotion audit: %v", err)
+	}
+	pending, err = promotions.ListPendingAudits(ctx, eng.ID)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending promotion audits after recovery = %#v, %v", pending, err)
+	}
+	if integrationAuditCount(audit.entries, "promotion.applied") != 1 {
+		t.Fatalf("promotion audit records = %d, want one recovered idempotent record", integrationAuditCount(audit.entries, "promotion.applied"))
+	}
+	events, err := promotions.ListByFinding(ctx, eng.ID, f.ID)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("audit reconciliation duplicated lifecycle event: (%d, %v)", len(events), err)
+	}
+}
+
+func integrationFinding(engagementID shared.ID, now time.Time) finding.Finding {
+	return finding.Finding{ID: "find-1", EngagementID: engagementID, Title: "reachable finding", Kind: finding.KindSCA, Priority: 3, Version: 1, DedupKey: "find-1", Audit: shared.Audit{CreatedAt: now, UpdatedAt: now}}
+}
+
+func integrationRecoveryJudgment() judgment.Judgment {
+	return judgment.Judgment{
+		ID: "recovery-judgment", EngagementID: "eng-1", Capability: judgment.CapPromotion, SubjectKind: judgment.SubjectFinding, SubjectID: "find-1",
+		State: judgment.StateConfirmed, EvidenceScore: 75, ProposedBy: "agent:proposer", VerifiedBy: "human:verifier", VerdictRationale: "confirmed",
+		Claim: judgment.PromotionClaim{FindingID: "find-1", Rule: judgment.RuleRuntimeReachableExposed, Inputs: []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: "det-1"}}, Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2, Fingerprint: strings.Repeat("1", 64)},
+	}
+}
+
+func integrationListJudgments(t *testing.T, service *analysis.Service, ctx context.Context, engagementID shared.ID) []judgment.Judgment {
+	t.Helper()
+	judgments, err := service.List(ctx, engagementID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return judgments
+}
+
+func integrationLatestPromotionJudgment(t *testing.T, judgments []judgment.Judgment) judgment.Judgment {
+	t.Helper()
+	for i := len(judgments) - 1; i >= 0; i-- {
+		if judgments[i].Capability == judgment.CapPromotion {
+			return judgments[i]
+		}
+	}
+	t.Fatal("missing promotion judgment")
+	return judgment.Judgment{}
+}
+
+func integrationAssertPriority(t *testing.T, findings ports.FindingRepository, ctx context.Context, engagementID, findingID shared.ID, priority, version int) {
+	t.Helper()
+	got, err := findings.GetByEngagementAndID(ctx, engagementID, findingID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Priority != priority || got.Version != version {
+		t.Fatalf("finding = priority %d version %d, want %d/%d", got.Priority, got.Version, priority, version)
+	}
+}
+
+func integrationAuditCount(entries []ports.AuditEntry, action string) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.Action == action {
+			count++
+		}
+	}
+	return count
+}
+
+func TestPromotionStoreApplyCanceledDoesNotMutate(t *testing.T) {
+	findingRepo := NewFindingRepository()
+	store := mustPromotionStore(t, findingRepo, defaultReader())
+	f := seedFinding(t, findingRepo, "eng-1", "f1", 3, 1)
+	cmd := sampleCmd(judgment.PromotionEscalate, 3, 2)
+	cmd.ExpectedPriority, cmd.ExpectedVersion = f.Priority, f.Version
+	ctx, cancel := context.WithCancel(tenantCtx())
+	cancel()
+	if _, err := store.Apply(ctx, "eng-1", "f1", cmd); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Apply canceled error = %v", err)
+	}
+	got, err := findingRepo.GetByEngagementAndID(tenantCtx(), "eng-1", "f1")
+	if err != nil || got.Priority != 3 || got.Version != 1 {
+		t.Fatalf("canceled Apply mutated finding: %#v, %v", got, err)
+	}
+	events, err := store.ListByFinding(tenantCtx(), "eng-1", "f1")
+	if err != nil || len(events) != 0 {
+		t.Fatalf("canceled Apply appended events: %#v, %v", events, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/aup_audit.go
+++ b/internal/infrastructure/persistence/postgres/aup_audit.go
@@ -58,8 +58,9 @@ type AuditLog struct{ pool *pgxpool.Pool }
 func NewAuditLog(pool *pgxpool.Pool) *AuditLog { return &AuditLog{pool: pool} }
 
 var (
-	_ ports.AuditLogger = (*AuditLog)(nil)
-	_ ports.AuditReader = (*AuditLog)(nil)
+	_ ports.AuditLogger           = (*AuditLog)(nil)
+	_ ports.AuditReader           = (*AuditLog)(nil)
+	_ ports.IdempotentAuditLogger = (*AuditLog)(nil)
 )
 
 // auditChainLock is a fixed key for the transaction-scoped advisory lock that
@@ -95,35 +96,86 @@ func scanEntries(rows pgx.Rows) ([]ports.AuditEntry, error) {
 	return out, rows.Err()
 }
 
-// List returns the most recent audit entries (newest first), capped at limit.
-func (l *AuditLog) List(ctx context.Context, limit int) ([]ports.AuditEntry, error) {
+// List returns the calling tenant's most recent audit entries (newest first), capped at limit.
+func (l *AuditLog) List(ctx context.Context, limit int) (out []ports.AuditEntry, err error) {
 	if limit <= 0 || limit > 1000 {
 		limit = 200
 	}
-	rows, err := l.pool.Query(ctx,
-		`SELECT actor, action, target, metadata, created_at, hash, previous_hash
-		   FROM audit_log ORDER BY id DESC LIMIT $1`, limit)
-	if err != nil {
-		return nil, fmt.Errorf("list audit: %w", err)
-	}
-	return scanEntries(rows)
+	err = WithContextTenant(ctx, l.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			`SELECT actor, action, target, metadata, created_at, hash, previous_hash
+			   FROM audit_log ORDER BY id DESC LIMIT $1`, limit)
+		if err != nil {
+			return fmt.Errorf("list audit: %w", err)
+		}
+		out, err = scanEntries(rows)
+		return err
+	})
+	return out, err
 }
 
-// Verify re-derives the hash chain over the entire log (oldest-first, id order) and
-// reports whether it is intact. It is an explicit integrity check, so
-// it reads every row rather than a capped window.
+// Verify examines only the calling tenant's rows. The historical audit chain is
+// global, so omitted links make a tenant-only result unavailable rather than falsely
+// claiming a complete integrity check. Server maintenance code may use VerifyGlobal.
 func (l *AuditLog) Verify(ctx context.Context) (audit.Report, error) {
-	rows, err := l.pool.Query(ctx,
+	entries, err := l.tenantEntries(ctx)
+	if err != nil {
+		return audit.Report{}, err
+	}
+	report := audit.Verify(toRecords(entries))
+	firstHashedPrevious := ""
+	for _, entry := range entries {
+		if entry.Hash != "" {
+			firstHashedPrevious = entry.PreviousHash
+			break
+		}
+	}
+	if firstHashedPrevious != "" || !report.Intact {
+		return audit.Report{
+			Unchained: report.Unchained,
+			Error:     "tenant-scoped audit verification is unavailable for the global hash chain; use server-only VerifyGlobal",
+		}, nil
+	}
+	return report, nil
+}
+
+// VerifyGlobal re-derives the complete, globally linked audit chain. It deliberately
+// bypasses tenant visibility and must only be called by server-side maintenance code,
+// never by a tenant HTTP endpoint.
+func (l *AuditLog) VerifyGlobal(ctx context.Context) (audit.Report, error) {
+	tx, err := l.pool.Begin(ctx)
+	if err != nil {
+		return audit.Report{}, fmt.Errorf("global audit verify: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.audit_global_read', 'on', true)"); err != nil {
+		return audit.Report{}, fmt.Errorf("global audit verify: enable read: %w", err)
+	}
+	rows, err := tx.Query(ctx,
 		`SELECT actor, action, target, metadata, created_at, hash, previous_hash
 		   FROM audit_log ORDER BY id ASC`)
 	if err != nil {
-		return audit.Report{}, fmt.Errorf("verify audit: %w", err)
+		return audit.Report{}, fmt.Errorf("global audit verify: query: %w", err)
 	}
 	entries, err := scanEntries(rows)
 	if err != nil {
 		return audit.Report{}, err
 	}
 	return audit.Verify(toRecords(entries)), nil
+}
+
+func (l *AuditLog) tenantEntries(ctx context.Context) (out []ports.AuditEntry, err error) {
+	err = WithContextTenant(ctx, l.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			`SELECT actor, action, target, metadata, created_at, hash, previous_hash
+			   FROM audit_log ORDER BY id ASC`)
+		if err != nil {
+			return fmt.Errorf("verify audit: %w", err)
+		}
+		out, err = scanEntries(rows)
+		return err
+	})
+	return out, err
 }
 
 // Record appends an immutable audit entry (INSERT only – never update or delete), chaining it
@@ -133,6 +185,27 @@ func (l *AuditLog) Verify(ctx context.Context) (audit.Report, error) {
 // concurrent append yields a 23505 unique violation – Record then re-reads the advanced head
 // and re-chains (bounded), parity with the evidence store, rather than surfacing an opaque
 // error. On the normal locked path the conflict is unreachable and the loop runs once.
+// RecordOnce implements ports.IdempotentAuditLogger. Entries with a deterministic
+// metadata idempotency_key are recovered without adding a second chain link.
+func (l *AuditLog) RecordOnce(ctx context.Context, e ports.AuditEntry) error {
+	if e.Metadata["idempotency_key"] == "" {
+		return l.Record(ctx, e)
+	}
+	const maxAttempts = 8
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		err := l.recordOnce(ctx, e)
+		if err == nil {
+			return nil
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			continue
+		}
+		return err
+	}
+	return fmt.Errorf("append idempotent audit entry: %w after %d attempts", shared.ErrConflict, maxAttempts)
+}
+
 func (l *AuditLog) Record(ctx context.Context, e ports.AuditEntry) error {
 	const maxAttempts = 8
 	for attempt := 0; attempt < maxAttempts; attempt++ {
@@ -152,12 +225,26 @@ func (l *AuditLog) Record(ctx context.Context, e ports.AuditEntry) error {
 // recordOnce performs one locked read-head → chain → insert attempt. A 23505 unique violation
 // propagates (wrapped) so Record can retry.
 func (l *AuditLog) recordOnce(ctx context.Context, e ports.AuditEntry) error {
+	tenantID, tenantBound := shared.TenantFrom(ctx)
 	tx, err := l.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("audit tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
-	if err := appendAudit(ctx, tx, e); err != nil {
+	if tenantBound {
+		if _, err := tx.Exec(ctx, "SELECT set_config('app.current_tenant', $1, true)", tenantID.String()); err != nil {
+			return fmt.Errorf("audit tx: set tenant: %w", err)
+		}
+	}
+	var rlsEnforced bool
+	if err := tx.QueryRow(ctx, "SELECT row_security_active('audit_log'::regclass)").Scan(&rlsEnforced); err != nil {
+		return fmt.Errorf("audit tx: inspect RLS: %w", err)
+	}
+	if tenantBound && rlsEnforced {
+		if err := appendTenantAudit(ctx, tx, tenantID.String(), e); err != nil {
+			return err
+		}
+	} else if err := appendAudit(ctx, tx, e); err != nil {
 		return err
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -185,13 +272,47 @@ func appendAudit(ctx context.Context, tx pgx.Tx, e ports.AuditEntry) error {
 		prevHash = *prev
 	}
 	hash := audit.ComputeHash(prevHash, e.Actor, e.Action, e.Target, e.Metadata, e.At)
-	// tenant_id '' = default tenant, matching the other writers. Audit reads are gated to the
-	// review capability since the log is global; populating this row's tenant_id from the
-	// authenticated context + per-tenant audit scoping is a remaining row-level follow-up.
 	if _, err := tx.Exec(ctx,
 		`INSERT INTO audit_log (tenant_id, actor, action, target, metadata, created_at, hash, previous_hash)
 		 VALUES ('', $1, $2, $3, $4, $5, $6, $7)`,
 		e.Actor, e.Action, e.Target, string(meta), e.At, hash, prevHash); err != nil {
+		return fmt.Errorf("insert audit: %w", err)
+	}
+	return nil
+}
+
+func appendTenantAudit(ctx context.Context, tx pgx.Tx, tenantID string, e ports.AuditEntry) error {
+	meta, err := json.Marshal(e.Metadata)
+	if err != nil {
+		return fmt.Errorf("marshal audit metadata: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, int64(auditChainLock)); err != nil {
+		return fmt.Errorf("audit lock: %w", err)
+	}
+	if key := e.Metadata["idempotency_key"]; key != "" {
+		var exists bool
+		if err := tx.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM audit_log WHERE tenant_id = $1 AND action = $2 AND idempotency_key = $3)`, tenantID, e.Action, key).Scan(&exists); err != nil {
+			return fmt.Errorf("check idempotent audit record: %w", err)
+		}
+		if exists {
+			return nil
+		}
+	}
+	var prev *string
+	if err := tx.QueryRow(ctx,
+		`SELECT hash FROM audit_log WHERE tenant_id = $1 AND hash_version = 2 AND hash IS NOT NULL ORDER BY id DESC LIMIT 1`, tenantID).Scan(&prev); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("audit head: %w", err)
+	}
+	prevHash := ""
+	if prev != nil {
+		prevHash = *prev
+	}
+	hash := audit.ComputeHash(prevHash, e.Actor, e.Action, e.Target, e.Metadata, e.At)
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO audit_log (tenant_id, actor, action, target, metadata, idempotency_key, hash_version, created_at, hash, previous_hash)
+		 VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), 2, $7, $8, $9)`,
+		tenantID, e.Actor, e.Action, e.Target, string(meta), e.Metadata["idempotency_key"], e.At, hash, prevHash); err != nil {
 		return fmt.Errorf("insert audit: %w", err) // 23505 propagates for Record's retry
 	}
 	return nil

--- a/internal/infrastructure/persistence/postgres/aup_audit_test.go
+++ b/internal/infrastructure/persistence/postgres/aup_audit_test.go
@@ -3,13 +3,40 @@ package postgres
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/KKloudTarus/synapse-ce/internal/domain/aup"
-	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	aupuc "github.com/KKloudTarus/synapse-ce/internal/usecase/aup"
 )
+
+type aupTestClock struct{ now time.Time }
+
+func (c aupTestClock) Now() time.Time { return c.now }
+
+func runtimeAUPPool(ctx context.Context, adminPool *pgxpool.Pool, dsn, role string) (*pgxpool.Pool, error) {
+	for _, statement := range []string{
+		"CREATE ROLE " + role + " LOGIN PASSWORD 'test-password' NOSUPERUSER NOBYPASSRLS",
+		"GRANT USAGE ON SCHEMA public TO " + role,
+		"GRANT SELECT, INSERT ON audit_log TO " + role,
+		"GRANT USAGE, SELECT ON SEQUENCE audit_log_id_seq TO " + role,
+	} {
+		if _, err := adminPool.Exec(ctx, statement); err != nil {
+			return nil, err
+		}
+	}
+	runtimeConfig, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	runtimeConfig.ConnConfig.User = role
+	runtimeConfig.ConnConfig.Password = "test-password"
+	runtimeConfig.MaxConns = 1
+	return pgxpool.NewWithConfig(ctx, runtimeConfig)
+}
 
 func TestAUPStoreAndAuditLog(t *testing.T) {
 	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
@@ -24,7 +51,7 @@ func TestAUPStoreAndAuditLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer pool.Close()
+	t.Cleanup(pool.Close)
 
 	// --- AUP acceptance ---
 	ver := "test-" + randHex(t)
@@ -52,25 +79,41 @@ func TestAUPStoreAndAuditLog(t *testing.T) {
 		t.Errorf("want 1 acceptance row (idempotent), got %d", n)
 	}
 
-	// --- append-only audit ---
-	// audit_log is DB-enforced append-only (migration 0033: UPDATE/DELETE/TRUNCATE raise), so
-	// there is no cleanup – the test uses a unique action per run (randHex) and filters reads by
-	// it, so accumulated rows from prior runs are harmless.
-	action := "test.action-" + randHex(t)
-	log := NewAuditLog(pool)
+	// --- AUP acceptance audit under a NOSUPERUSER, NOBYPASSRLS runtime role ---
+	role := "aup_runtime_" + randHex(t)
+	runtimePool, err := runtimeAUPPool(ctx, pool, dsn, role)
+	if err != nil {
+		t.Fatalf("runtime role setup: %v", err)
+	}
+	defer runtimePool.Close()
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), "DROP ROLE "+role) })
 
-	if err := log.Record(ctx, ports.AuditEntry{
-		Actor: "operator", Action: action, Target: "engagement-1",
-		Metadata: map[string]string{"kind": "local"}, At: time.Now().UTC(),
-	}); err != nil {
-		t.Fatalf("Record: %v", err)
+	tenantID := shared.ID("tenant-aup-" + randHex(t))
+	tenantCtx := shared.WithTenant(ctx, tenantID)
+	version := "aup-" + randHex(t)
+	svc := aupuc.NewService(NewAUPStore(pool), NewAuditLog(runtimePool), aupTestClock{now: time.Now().UTC()}, version)
+	if err := svc.Accept(tenantCtx, "operator", version); err != nil {
+		t.Fatalf("runtime role AUP acceptance: %v", err)
 	}
-	var actor, target, meta string
-	if err := pool.QueryRow(ctx,
-		"SELECT actor, target, metadata::text FROM audit_log WHERE action=$1", action).Scan(&actor, &target, &meta); err != nil {
-		t.Fatalf("read audit: %v", err)
+	var storedTenant string
+	var hashVersion int
+	if err := pool.QueryRow(ctx, "SELECT tenant_id, hash_version FROM audit_log WHERE action='aup.accept' AND target=$1", "aup:"+version).Scan(&storedTenant, &hashVersion); err != nil {
+		t.Fatalf("read tenant-bound AUP audit row: %v", err)
 	}
-	if actor != "operator" || target != "engagement-1" || !strings.Contains(meta, "local") {
-		t.Errorf("audit entry = actor=%s target=%s meta=%s", actor, target, meta)
+	if storedTenant != tenantID.String() || hashVersion != 2 {
+		t.Fatalf("audit row tenant/version = %q/%d, want %q/2", storedTenant, hashVersion, tenantID)
 	}
+	// Migration rollback tests share this database. Remove this test's v2 chain
+	// row after exercising the runtime path because migration 0085 correctly
+	// refuses to roll back while any v2 history exists.
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(), "SET session_replication_role = replica"); err != nil {
+			t.Errorf("disable audit append-only trigger: %v", err)
+			return
+		}
+		defer func() { _, _ = pool.Exec(context.Background(), "SET session_replication_role = origin") }()
+		if _, err := pool.Exec(context.Background(), "DELETE FROM audit_log WHERE action='aup.accept' AND target=$1", "aup:"+version); err != nil {
+			t.Errorf("remove test audit row: %v", err)
+		}
+	})
 }

--- a/internal/infrastructure/persistence/postgres/db.go
+++ b/internal/infrastructure/persistence/postgres/db.go
@@ -167,3 +167,61 @@ func Migrate(ctx context.Context, dsn string) error {
 	}
 	return nil
 }
+
+// ValidateMigrationRoleSeparation ensures migrations cannot run as the runtime role.
+func ValidateMigrationRoleSeparation(migrationDSN, runtimeDSN string) error {
+	migrationConfig, err := pgxpool.ParseConfig(migrationDSN)
+	if err != nil {
+		return fmt.Errorf("parse migration dsn: %w", err)
+	}
+	if migrationConfig.ConnConfig.User == "" {
+		return fmt.Errorf("migration dsn has no user")
+	}
+	runtimeConfig, err := pgxpool.ParseConfig(runtimeDSN)
+	if err != nil {
+		return fmt.Errorf("parse runtime dsn: %w", err)
+	}
+	if runtimeConfig.ConnConfig.User == "" {
+		return fmt.Errorf("runtime dsn has no user")
+	}
+	if migrationConfig.ConnConfig.User == runtimeConfig.ConnConfig.User {
+		return fmt.Errorf("migration and runtime DSNs must use distinct database users")
+	}
+	return nil
+}
+
+func quoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
+// GrantRuntimePrivileges grants the runtime role the DML privileges required by the
+// application after migrations have completed under the separate owner credential.
+func GrantRuntimePrivileges(ctx context.Context, adminDSN, runtimeDSN string) error {
+	runtimeConfig, err := pgxpool.ParseConfig(runtimeDSN)
+	if err != nil {
+		return fmt.Errorf("parse runtime dsn: %w", err)
+	}
+	role := runtimeConfig.ConnConfig.User
+	if role == "" {
+		return fmt.Errorf("runtime dsn has no user")
+	}
+	adminDB, err := sql.Open("pgx", dsnForMigrate(adminDSN))
+	if err != nil {
+		return fmt.Errorf("open admin dsn: %w", err)
+	}
+	defer func() { _ = adminDB.Close() }()
+
+	quotedRole := `"` + strings.ReplaceAll(role, `"`, `""`) + `"`
+	for _, statement := range []string{
+		"REVOKE CREATE ON SCHEMA public FROM " + quotedRole,
+		"REVOKE CREATE ON DATABASE " + quoteIdentifier(runtimeConfig.ConnConfig.Database) + " FROM " + quotedRole,
+		"GRANT USAGE ON SCHEMA public TO " + quotedRole,
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO " + quotedRole,
+		"GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO " + quotedRole,
+	} {
+		if _, err := adminDB.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("grant runtime privileges: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/db_pool_test.go
+++ b/internal/infrastructure/persistence/postgres/db_pool_test.go
@@ -76,3 +76,44 @@ func TestDSNForMigrate_KeywordForm(t *testing.T) {
 		t.Fatalf("keyword-form non-pool fields must be preserved, got %q", got)
 	}
 }
+
+func TestValidateMigrationRoleSeparation(t *testing.T) {
+	tests := []struct {
+		name         string
+		migrationDSN string
+		runtimeDSN   string
+		wantErr      bool
+	}{
+		{
+			name:         "identical DSNs",
+			migrationDSN: "postgres://synapse_app:secret@localhost/synapse?sslmode=disable",
+			runtimeDSN:   "postgres://synapse_app:secret@localhost/synapse?sslmode=disable",
+			wantErr:      true,
+		},
+		{
+			name:         "same role with different credentials and options",
+			migrationDSN: "postgres://synapse_app:owner-secret@localhost/synapse?sslmode=require&application_name=migrate",
+			runtimeDSN:   "postgres://synapse_app:runtime-secret@localhost/synapse?application_name=api&sslmode=disable",
+			wantErr:      true,
+		},
+		{
+			name:         "distinct roles",
+			migrationDSN: "postgres://synapse_owner:owner-secret@localhost/synapse?sslmode=disable",
+			runtimeDSN:   "postgres://synapse_app:runtime-secret@localhost/synapse?sslmode=disable",
+		},
+		{
+			name:         "malformed migration DSN",
+			migrationDSN: "::not a dsn::",
+			runtimeDSN:   "postgres://synapse_app:runtime-secret@localhost/synapse?sslmode=disable",
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMigrationRoleSeparation(tt.migrationDSN, tt.runtimeDSN)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateMigrationRoleSeparation() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -27,6 +27,7 @@ func NewEngagementRepository(pool *pgxpool.Pool) *EngagementRepository {
 }
 
 var _ ports.EngagementRepository = (*EngagementRepository)(nil)
+var _ ports.PromotionReconciliationScopeReader = (*EngagementRepository)(nil)
 
 // Create inserts the engagement and its scope targets in one transaction.
 func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagement) error {
@@ -180,6 +181,50 @@ func (r *EngagementRepository) GetByProjectID(ctx context.Context, tenantID, pro
 		return err
 	})
 	return out, err
+}
+
+// ListPromotionReconciliationScopes returns every non-project tenant and engagement
+// pair for process-local recovery. Each engagement query remains RLS-scoped.
+func (r *EngagementRepository) ListPromotionReconciliationScopes(ctx context.Context) ([]ports.PromotionReconciliationScope, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenants, err := r.pool.Query(ctx, `SELECT id FROM tenants ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list promotion reconciliation tenants: %w", err)
+	}
+	defer tenants.Close()
+	var out []ports.PromotionReconciliationScope
+	for tenants.Next() {
+		var tenantID shared.ID
+		if err := tenants.Scan(&tenantID); err != nil {
+			return nil, fmt.Errorf("scan promotion reconciliation tenant: %w", err)
+		}
+		if err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+			rows, err := tx.Query(ctx, `SELECT id FROM engagements WHERE project_id IS NULL ORDER BY id`)
+			if err != nil {
+				return fmt.Errorf("list promotion reconciliation engagements: %w", err)
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var engagementID shared.ID
+				if err := rows.Scan(&engagementID); err != nil {
+					return fmt.Errorf("scan promotion reconciliation engagement: %w", err)
+				}
+				out = append(out, ports.PromotionReconciliationScope{TenantID: tenantID, EngagementID: engagementID})
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("list promotion reconciliation engagements: %w", err)
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	if err := tenants.Err(); err != nil {
+		return nil, fmt.Errorf("list promotion reconciliation tenants: %w", err)
+	}
+	return out, nil
 }
 
 // List returns the tenant's engagements, each with its scope loaded (consistent

--- a/internal/infrastructure/persistence/postgres/evidence_repo.go
+++ b/internal/infrastructure/persistence/postgres/evidence_repo.go
@@ -41,9 +41,6 @@ func (r *EvidenceStore) Append(ctx context.Context, items []evidence.Evidence) e
 				`INSERT INTO evidence (id, tenant_id, finding_id, engagement_id, kind, sha256, previous_hash, storage_ref, content, created_by, created_at)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 				e.ID.String(), tenantID.String(), findingID, e.EngagementID.String(), e.Kind, e.Hash, e.PreviousHash, e.StorageRef, e.Content, e.CreatedBy, e.CreatedAt); err != nil {
-				// Fork guard: the unique(engagement, previous_hash) index rejects a
-				// second child for the same parent – surface as ErrConflict so the caller
-				// re-reads the advanced head + re-chains (keeps the chain strictly linear).
 				var pgErr *pgconn.PgError
 				if errors.As(err, &pgErr) && pgErr.Code == "23505" {
 					return fmt.Errorf("evidence chain: parent already linked: %w", shared.ErrConflict)
@@ -98,4 +95,26 @@ func (r *EvidenceStore) Head(ctx context.Context, engagementID shared.ID) (strin
 		return "", fmt.Errorf("head evidence: %w", err)
 	}
 	return head, nil
+}
+
+// LookupSealedForFinding returns the most recent sealed evidence link of the
+// given kind for the specified finding, or (zero, false, nil) if none exists.
+func (r *EvidenceStore) LookupSealedForFinding(ctx context.Context, engagementID, findingID shared.ID, kind string) (evidence.Evidence, bool, error) {
+	var out evidence.Evidence
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT id, engagement_id, finding_id, kind, storage_ref, sha256, previous_hash, created_by, created_at
+			 FROM evidence
+			 WHERE engagement_id=$1 AND finding_id=$2 AND kind=$3
+			 ORDER BY seq DESC LIMIT 1`,
+			engagementID.String(), findingID.String(), kind,
+		).Scan(&out.ID, &out.EngagementID, &out.FindingID, &out.Kind, &out.StorageRef, &out.Hash, &out.PreviousHash, &out.CreatedBy, &out.CreatedAt)
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return evidence.Evidence{}, false, nil
+	}
+	if err != nil {
+		return evidence.Evidence{}, false, fmt.Errorf("lookup sealed evidence: %w", err)
+	}
+	return out, true, nil
 }

--- a/internal/infrastructure/persistence/postgres/finding_repo.go
+++ b/internal/infrastructure/persistence/postgres/finding_repo.go
@@ -83,9 +83,10 @@ func (r *FindingRepository) Upsert(ctx context.Context, findings []finding.Findi
 			 DO UPDATE SET title = EXCLUDED.title, description = EXCLUDED.description,
 			               severity = EXCLUDED.severity, cvss_vector = EXCLUDED.cvss_vector, kev = EXCLUDED.kev, risk_score = EXCLUDED.risk_score,
 			               sources = EXCLUDED.sources, confidence = EXCLUDED.confidence, class = EXCLUDED.class,
-			               scope = EXCLUDED.scope, reachability = EXCLUDED.reachability, impact = EXCLUDED.impact, priority = EXCLUDED.priority,
+			               scope = EXCLUDED.scope, reachability = EXCLUDED.reachability, impact = EXCLUDED.impact,
 			               kind = EXCLUDED.kind, class_reachability = EXCLUDED.class_reachability,
-			               rule_key = EXCLUDED.rule_key, updated_at = EXCLUDED.updated_at`,
+			               rule_key = EXCLUDED.rule_key, updated_at = EXCLUDED.updated_at,
+			               version = findings.version + 1`,
 				f.ID.String(), tenantID.String(), f.EngagementID.String(), f.Title, f.Description, string(f.Severity),
 				f.CVSSVector, f.CWE, string(f.Status), f.EvidenceScore, f.DedupKey,
 				f.KEV, f.RiskScore, f.Audit.CreatedAt, f.Audit.UpdatedAt, strings.Join(f.Sources, ","), f.Confidence, classOrDefault(f.Class),
@@ -208,6 +209,28 @@ func (r *FindingRepository) ListPublishableByEngagement(ctx context.Context, eng
 		return nil, err
 	}
 	return finding.Publishable(all), nil
+}
+
+// GetByEngagementAndID loads a single finding by engagement and finding ID.
+// Returns shared.ErrNotFound if no such finding exists in the engagement.
+func (r *FindingRepository) GetByEngagementAndID(ctx context.Context, engagementID, findingID shared.ID) (finding.Finding, error) {
+	var f finding.Finding
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`SELECT `+findingCols+` FROM findings WHERE engagement_id=$1 AND id=$2`,
+			engagementID.String(), findingID.String(),
+		)
+		var scanErr error
+		f, scanErr = scanFinding(row)
+		return scanErr
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return finding.Finding{}, fmt.Errorf("finding %s in engagement %s: %w", findingID, engagementID, shared.ErrNotFound)
+	}
+	if err != nil {
+		return finding.Finding{}, fmt.Errorf("get finding: %w", err)
+	}
+	return f, nil
 }
 
 // scanFinding scans a findingCols row (pgx.Row or pgx.Rows) into a Finding.

--- a/internal/infrastructure/persistence/postgres/judgment_repo.go
+++ b/internal/infrastructure/persistence/postgres/judgment_repo.go
@@ -2,8 +2,11 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -14,9 +17,12 @@ import (
 )
 
 // judgmentCols is the SELECT/RETURNING projection scanned by scanJudgment.
-const judgmentCols = `id, engagement_id, capability, subject_kind, subject_id, claim, state, evidence_score, proposed_by, version, created_at, updated_at`
+const judgmentCols = `id, engagement_id, capability, subject_kind, subject_id, claim, state, evidence_score, proposed_by, verified_by, verdict_rationale, version, created_at, updated_at`
 
 // JudgmentRepository persists AI judgments to PostgreSQL, engagement-scoped.
+// All operations route through WithContextTenant so tenant isolation is enforced
+// at the database level. Save validates that the engagement belongs to the
+// context tenant before writing.
 type JudgmentRepository struct{ pool *pgxpool.Pool }
 
 // NewJudgmentRepository returns a repository backed by the given pool.
@@ -24,51 +30,83 @@ func NewJudgmentRepository(pool *pgxpool.Pool) *JudgmentRepository {
 	return &JudgmentRepository{pool: pool}
 }
 
-var _ ports.JudgmentStore = (*JudgmentRepository)(nil)
+var (
+	_ ports.JudgmentStore      = (*JudgmentRepository)(nil)
+	_ ports.JudgmentAuditStore = (*JudgmentRepository)(nil)
+)
 
 // Save inserts a proposed judgment (idempotent by id; never clobbers an existing row – score/state
 // move only via SetScoreState). The typed claim is stored as its fail-closed discriminated
-// envelope (JSONB).
+// envelope (JSONB). The tenant_id is resolved from context, and the engagement is validated
+// to belong to that tenant before the insert.
 func (r *JudgmentRepository) Save(ctx context.Context, j judgment.Judgment) error {
 	claimJSON, err := judgment.MarshalClaim(j.Claim)
 	if err != nil {
 		return fmt.Errorf("marshal judgment claim: %w", err)
 	}
-	// tenant_id '' = the seeded default tenant (mirrors findings); reads are tenant-isolated via the
-	// engagement gate, and the column is present so the P5/E22 row-scoping sweep covers it.
-	if _, err := r.pool.Exec(ctx,
-		`INSERT INTO judgments (id, tenant_id, engagement_id, capability, subject_kind, subject_id, claim, state, evidence_score, proposed_by, version, created_at, updated_at)
-		 VALUES ($1, '', $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-		 ON CONFLICT (id) DO NOTHING`,
-		j.ID.String(), j.EngagementID.String(), string(j.Capability), string(j.SubjectKind), j.SubjectID.String(),
-		claimJSON, string(j.State), j.EvidenceScore, j.ProposedBy, versionOrDefault(j.Version), j.Audit.CreatedAt, j.Audit.UpdatedAt); err != nil {
-		return fmt.Errorf("save judgment: %w", err)
-	}
-	return nil
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		// Validate the engagement belongs to this tenant.
+		tenantID, _ := shared.TenantFrom(ctx)
+		var belongs bool
+		if err := tx.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM engagements WHERE id = $1 AND COALESCE(NULLIF(tenant_id, ''), 'default') = $2)`,
+			j.EngagementID.String(), tenantID.String()).Scan(&belongs); err != nil {
+			return fmt.Errorf("validate engagement tenant: %w", err)
+		}
+		if !belongs {
+			return fmt.Errorf("%w: engagement %s does not belong to tenant %s", shared.ErrNotFound, j.EngagementID, tenantID)
+		}
+
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO judgments (id, tenant_id, engagement_id, capability, subject_kind, subject_id, claim, state, evidence_score, proposed_by, verified_by, verdict_rationale, version, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+			 ON CONFLICT (id) DO NOTHING`,
+			j.ID.String(), tenantID.String(), j.EngagementID.String(),
+			string(j.Capability), string(j.SubjectKind), j.SubjectID.String(),
+			claimJSON, string(j.State), j.EvidenceScore, j.ProposedBy, j.VerifiedBy, j.VerdictRationale,
+			versionOrDefault(j.Version), j.Audit.CreatedAt, j.Audit.UpdatedAt); err != nil {
+			return fmt.Errorf("save judgment: %w", err)
+		}
+		return nil
+	})
 }
 
 // ListByEngagement returns the engagement's judgments, oldest first (deterministic order).
+// RLS scopes the query to the context tenant.
 func (r *JudgmentRepository) ListByEngagement(ctx context.Context, engagementID shared.ID) ([]judgment.Judgment, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT `+judgmentCols+` FROM judgments WHERE engagement_id=$1 ORDER BY created_at ASC, id COLLATE "C" ASC`,
-		engagementID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list judgments: %w", err)
-	}
-	defer rows.Close()
-	return scanJudgments(rows)
+	var out []judgment.Judgment
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, qErr := tx.Query(ctx,
+			`SELECT `+judgmentCols+` FROM judgments WHERE engagement_id=$1 ORDER BY created_at ASC, id COLLATE "C" ASC`,
+			engagementID.String())
+		if qErr != nil {
+			return fmt.Errorf("list judgments: %w", qErr)
+		}
+		defer rows.Close()
+		var scanErr error
+		out, scanErr = scanJudgments(rows)
+		return scanErr
+	})
+	return out, err
 }
 
 // ListBySubject returns the engagement's judgments about a given subject id, oldest first.
+// RLS scopes the query to the context tenant.
 func (r *JudgmentRepository) ListBySubject(ctx context.Context, engagementID, subjectID shared.ID) ([]judgment.Judgment, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT `+judgmentCols+` FROM judgments WHERE engagement_id=$1 AND subject_id=$2 ORDER BY created_at ASC, id COLLATE "C" ASC`,
-		engagementID.String(), subjectID.String())
-	if err != nil {
-		return nil, fmt.Errorf("list judgments by subject: %w", err)
-	}
-	defer rows.Close()
-	return scanJudgments(rows)
+	var out []judgment.Judgment
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, qErr := tx.Query(ctx,
+			`SELECT `+judgmentCols+` FROM judgments WHERE engagement_id=$1 AND subject_id=$2 ORDER BY created_at ASC, id COLLATE "C" ASC`,
+			engagementID.String(), subjectID.String())
+		if qErr != nil {
+			return fmt.Errorf("list judgments by subject: %w", qErr)
+		}
+		defer rows.Close()
+		var scanErr error
+		out, scanErr = scanJudgments(rows)
+		return scanErr
+	})
+	return out, err
 }
 
 // SetScoreState moves a judgment's evidence score + state under optimistic concurrency (the
@@ -76,24 +114,44 @@ func (r *JudgmentRepository) ListBySubject(ctx context.Context, engagementID, su
 // then version is bumped. This is the ONLY path that moves a stored judgment's score/state, and
 // it is deliberately off the broad ports.JudgmentStore interface (a read-only consumer cannot
 // reach it). On a miss it distinguishes ErrConflict (exists, version moved) from ErrNotFound.
+// RLS scopes the operation to the context tenant.
 func (r *JudgmentRepository) SetScoreState(ctx context.Context, engagementID, id shared.ID, score int, state judgment.State, expectedVersion int) (judgment.Judgment, error) {
-	j, err := scanJudgment(r.pool.QueryRow(ctx,
-		`UPDATE judgments SET evidence_score=$1, state=$2, version=version+1, updated_at=now()
-		 WHERE id=$3 AND engagement_id=$4 AND version=$5
-		 RETURNING `+judgmentCols,
-		score, string(state), id.String(), engagementID.String(), expectedVersion))
-	if errors.Is(err, pgx.ErrNoRows) {
-		return judgment.Judgment{}, r.classifyJudgmentMiss(ctx, engagementID, id)
-	}
-	if err != nil {
-		return judgment.Judgment{}, fmt.Errorf("set judgment score/state: %w", err)
-	}
-	return j, nil
+	return r.setScoreState(ctx, engagementID, id, score, state, "", "", false, expectedVersion)
 }
 
-func (r *JudgmentRepository) classifyJudgmentMiss(ctx context.Context, engagementID, id shared.ID) error {
+// SetVerdictState persists a verdict's sealed verifier and rationale with its score transition.
+func (r *JudgmentRepository) SetVerdictState(ctx context.Context, engagementID, id shared.ID, score int, state judgment.State, verifiedBy, verdictRationale string, expectedVersion int) (judgment.Judgment, error) {
+	return r.setScoreState(ctx, engagementID, id, score, state, verifiedBy, verdictRationale, true, expectedVersion)
+}
+
+func (r *JudgmentRepository) setScoreState(ctx context.Context, engagementID, id shared.ID, score int, state judgment.State, verifiedBy, verdictRationale string, setVerdictProvenance bool, expectedVersion int) (out judgment.Judgment, err error) {
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		var scanErr error
+		query := `UPDATE judgments SET evidence_score=$1, state=$2, version=version+1, updated_at=now()`
+		args := []any{score, string(state)}
+		if setVerdictProvenance {
+			query = `UPDATE judgments SET evidence_score=$1, state=$2, verified_by=$3, verdict_rationale=$4, version=version+1, updated_at=now()`
+			args = append(args, verifiedBy, verdictRationale)
+		}
+		query += ` WHERE id=$` + strconv.Itoa(len(args)+1) + ` AND engagement_id=$` + strconv.Itoa(len(args)+2) + ` AND version=$` + strconv.Itoa(len(args)+3) + ` RETURNING ` + judgmentCols
+		args = append(args, id.String(), engagementID.String(), expectedVersion)
+		out, scanErr = scanJudgment(tx.QueryRow(ctx, query, args...))
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			return classifyJudgmentMiss(ctx, tx, engagementID, id)
+		}
+		if scanErr != nil {
+			return fmt.Errorf("set judgment score/state: %w", scanErr)
+		}
+		return nil
+	})
+	return out, err
+}
+
+// classifyJudgmentMiss distinguishes ErrConflict (the judgment exists but its version moved)
+// from ErrNotFound. Runs inside the caller's transaction.
+func classifyJudgmentMiss(ctx context.Context, tx pgx.Tx, engagementID, id shared.ID) error {
 	var exists bool
-	if err := r.pool.QueryRow(ctx,
+	if err := tx.QueryRow(ctx,
 		`SELECT EXISTS(SELECT 1 FROM judgments WHERE id=$1 AND engagement_id=$2)`,
 		id.String(), engagementID.String()).Scan(&exists); err != nil {
 		return fmt.Errorf("classify judgment miss: %w", err)
@@ -125,7 +183,7 @@ func scanJudgment(row rowScanner) (judgment.Judgment, error) {
 		claimJSON                       []byte
 	)
 	if err := row.Scan(&id, &eid, &capStr, &sk, &sid, &claimJSON, &state,
-		&j.EvidenceScore, &j.ProposedBy, &j.Version, &j.Audit.CreatedAt, &j.Audit.UpdatedAt); err != nil {
+		&j.EvidenceScore, &j.ProposedBy, &j.VerifiedBy, &j.VerdictRationale, &j.Version, &j.Audit.CreatedAt, &j.Audit.UpdatedAt); err != nil {
 		return judgment.Judgment{}, err
 	}
 	claim, err := judgment.UnmarshalClaim(claimJSON)
@@ -145,4 +203,109 @@ func scanJudgment(row rowScanner) (judgment.Judgment, error) {
 		return judgment.Judgment{}, fmt.Errorf("%w: judgment %s has invalid stored enums (capability=%q state=%q subject_kind=%q)", shared.ErrValidation, j.ID, j.Capability, j.State, j.SubjectKind)
 	}
 	return j, nil
+}
+
+// SaveWithProposalAudit persists a proposal with its immutable pending audit entry.
+func (r *JudgmentRepository) SaveWithProposalAudit(ctx context.Context, j judgment.Judgment, entry ports.AuditEntry) error {
+	claimJSON, err := judgment.MarshalClaim(j.Claim)
+	if err != nil {
+		return fmt.Errorf("marshal judgment claim: %w", err)
+	}
+	metadata, err := json.Marshal(entry.Metadata)
+	if err != nil {
+		return fmt.Errorf("marshal proposal audit metadata: %w", err)
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		tenantID, _ := shared.TenantFrom(ctx)
+		var belongs bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM engagements WHERE id = $1 AND COALESCE(NULLIF(tenant_id, ''), 'default') = $2)`, j.EngagementID.String(), tenantID.String()).Scan(&belongs); err != nil {
+			return fmt.Errorf("validate engagement tenant: %w", err)
+		}
+		if !belongs {
+			return fmt.Errorf("%w: engagement %s does not belong to tenant %s", shared.ErrNotFound, j.EngagementID, tenantID)
+		}
+		result, err := tx.Exec(ctx, `INSERT INTO judgments (id, tenant_id, engagement_id, capability, subject_kind, subject_id, claim, state, evidence_score, proposed_by, verified_by, verdict_rationale, version, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) ON CONFLICT (id) DO NOTHING`, j.ID.String(), tenantID.String(), j.EngagementID.String(), string(j.Capability), string(j.SubjectKind), j.SubjectID.String(), claimJSON, string(j.State), j.EvidenceScore, j.ProposedBy, j.VerifiedBy, j.VerdictRationale, versionOrDefault(j.Version), j.Audit.CreatedAt, j.Audit.UpdatedAt)
+		if err != nil {
+			return fmt.Errorf("save judgment: %w", err)
+		}
+		if result.RowsAffected() == 0 {
+			return nil
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO judgment_proposal_audit_status (tenant_id, judgment_id, engagement_id, actor, action, target, metadata, occurred_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`, tenantID.String(), j.ID.String(), j.EngagementID.String(), entry.Actor, entry.Action, entry.Target, metadata, entry.At); err != nil {
+			return fmt.Errorf("insert judgment proposal audit status: %w", err)
+		}
+		return nil
+	})
+}
+
+// SetVerdictStateWithAudit commits the verdict and immutable pending audit entry atomically.
+func (r *JudgmentRepository) SetVerdictStateWithAudit(ctx context.Context, engagementID, id shared.ID, score int, state judgment.State, verifiedBy, rationale string, expectedVersion int, entry ports.AuditEntry) (out judgment.Judgment, err error) {
+	metadata, err := json.Marshal(entry.Metadata)
+	if err != nil {
+		return out, fmt.Errorf("marshal verdict audit metadata: %w", err)
+	}
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		out, err = scanJudgment(tx.QueryRow(ctx, `UPDATE judgments SET evidence_score=$1, state=$2, verified_by=$3, verdict_rationale=$4, version=version+1, updated_at=now() WHERE id=$5 AND engagement_id=$6 AND version=$7 RETURNING `+judgmentCols, score, string(state), verifiedBy, rationale, id.String(), engagementID.String(), expectedVersion))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return classifyJudgmentMiss(ctx, tx, engagementID, id)
+		}
+		if err != nil {
+			return fmt.Errorf("set judgment verdict state: %w", err)
+		}
+		tenantID, _ := shared.TenantFrom(ctx)
+		if _, err := tx.Exec(ctx, `INSERT INTO judgment_verdict_audit_status (tenant_id, judgment_id, version, engagement_id, actor, action, target, metadata, occurred_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`, tenantID.String(), id.String(), out.Version, engagementID.String(), entry.Actor, entry.Action, entry.Target, metadata, entry.At); err != nil {
+			return fmt.Errorf("insert judgment verdict audit status: %w", err)
+		}
+		return nil
+	})
+	return out, err
+}
+
+func (r *JudgmentRepository) ListPendingJudgmentAudits(ctx context.Context, engagementID shared.ID) (out []ports.PendingJudgmentAudit, err error) {
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT 'proposal', judgment_id, 1, engagement_id, actor, action, target, metadata, occurred_at FROM judgment_proposal_audit_status WHERE engagement_id=$1 AND completed_at IS NULL UNION ALL SELECT 'verdict', judgment_id, version, engagement_id, actor, action, target, metadata, occurred_at FROM judgment_verdict_audit_status WHERE engagement_id=$1 AND completed_at IS NULL ORDER BY 1,3,2`, engagementID.String())
+		if err != nil {
+			return fmt.Errorf("list pending judgment audits: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var kind, jid, eid, actor, action, target string
+			var version int
+			var metadata []byte
+			var at time.Time
+			if err := rows.Scan(&kind, &jid, &version, &eid, &actor, &action, &target, &metadata, &at); err != nil {
+				return fmt.Errorf("scan pending judgment audit: %w", err)
+			}
+			entry := ports.AuditEntry{Actor: actor, Action: action, Target: target, At: at}
+			if err := json.Unmarshal(metadata, &entry.Metadata); err != nil {
+				return fmt.Errorf("decode pending judgment audit metadata: %w", err)
+			}
+			out = append(out, ports.PendingJudgmentAudit{Kind: ports.JudgmentAuditKind(kind), JudgmentID: shared.ID(jid), Version: version, EngagementID: shared.ID(eid), Entry: entry})
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+func (r *JudgmentRepository) AcknowledgeJudgmentAudit(ctx context.Context, kind ports.JudgmentAuditKind, judgmentID shared.ID, version int) error {
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		var query string
+		var args []any
+		switch kind {
+		case ports.JudgmentProposalAudit:
+			query, args = `UPDATE judgment_proposal_audit_status SET completed_at=COALESCE(completed_at,now()) WHERE judgment_id=$1`, []any{judgmentID.String()}
+		case ports.JudgmentVerdictAudit:
+			query, args = `UPDATE judgment_verdict_audit_status SET completed_at=COALESCE(completed_at,now()) WHERE judgment_id=$1 AND version=$2`, []any{judgmentID.String(), version}
+		default:
+			return fmt.Errorf("%w: unknown judgment audit kind %q", shared.ErrValidation, kind)
+		}
+		result, err := tx.Exec(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("acknowledge judgment audit: %w", err)
+		}
+		if result.RowsAffected() == 0 {
+			return fmt.Errorf("judgment audit %s/%d: %w", judgmentID, version, shared.ErrNotFound)
+		}
+		return nil
+	})
 }

--- a/internal/infrastructure/persistence/postgres/judgment_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/judgment_repo_test.go
@@ -18,7 +18,7 @@ func TestJudgmentRepository(t *testing.T) {
 	if dsn == "" {
 		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
 	}
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), shared.DefaultTenant)
 	if err := Migrate(ctx, dsn); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -58,8 +58,8 @@ func TestJudgmentRepository(t *testing.T) {
 	if err != nil || len(list) != 1 || list[0].ID != jid {
 		t.Fatalf("ListByEngagement: %+v err=%v", list, err)
 	}
-	if list[0].State != judgment.StateProposed || list[0].EvidenceScore != 0 {
-		t.Fatalf("want proposed/0, got %s/%d", list[0].State, list[0].EvidenceScore)
+	if list[0].State != judgment.StateProposed || list[0].EvidenceScore != 0 || list[0].VerifiedBy != "" || list[0].VerdictRationale != "" {
+		t.Fatalf("want proposed/0/empty provenance, got %#v", list[0])
 	}
 	if rc, ok := list[0].Claim.(judgment.ReachabilityClaim); !ok || rc.Tier != "tier-1.5" {
 		t.Fatalf("claim did not round-trip typed: %#v", list[0].Claim)
@@ -68,20 +68,34 @@ func TestJudgmentRepository(t *testing.T) {
 		t.Fatalf("ListBySubject: %+v", bySub)
 	}
 
-	// score/state move under optimistic concurrency
+	// Score/state updates for acceptance must not invent or clear verdict provenance.
 	upd, err := repo.SetScoreState(ctx, eid, jid, 80, judgment.StateConfirmed, 1)
 	if err != nil {
 		t.Fatalf("SetScoreState: %v", err)
 	}
-	if upd.EvidenceScore != 80 || upd.State != judgment.StateConfirmed || upd.Version != 2 {
+	if upd.EvidenceScore != 80 || upd.State != judgment.StateConfirmed || upd.Version != 2 || upd.VerifiedBy != "" || upd.VerdictRationale != "" {
 		t.Fatalf("SetScoreState result: %+v", upd)
 	}
+
+	// A verdict transition round-trips its sealed provenance through storage.
+	verdictState, err := repo.SetVerdictState(ctx, eid, jid, 90, judgment.StateConfirmed, "human:verifier", "reproduced", 2)
+	if err != nil {
+		t.Fatalf("SetVerdictState: %v", err)
+	}
+	if verdictState.EvidenceScore != 90 || verdictState.Version != 3 || verdictState.VerifiedBy != "human:verifier" || verdictState.VerdictRationale != "reproduced" {
+		t.Fatalf("SetVerdictState result: %+v", verdictState)
+	}
+	list, err = repo.ListByEngagement(ctx, eid)
+	if err != nil || len(list) != 1 || list[0].VerifiedBy != "human:verifier" || list[0].VerdictRationale != "reproduced" {
+		t.Fatalf("verdict provenance did not round-trip: %+v err=%v", list, err)
+	}
+
 	// stale version → conflict (lost-update guard)
-	if _, err := repo.SetScoreState(ctx, eid, jid, 90, judgment.StateRefuted, 1); !errors.Is(err, shared.ErrConflict) {
+	if _, err := repo.SetScoreState(ctx, eid, jid, 90, judgment.StateRefuted, 2); !errors.Is(err, shared.ErrConflict) {
 		t.Fatalf("stale version: want ErrConflict, got %v", err)
 	}
 	// unknown id → not found
-	if _, err := repo.SetScoreState(ctx, eid, shared.ID("nope"), 1, judgment.StateConfirmed, 1); !errors.Is(err, shared.ErrNotFound) {
+	if _, err := repo.SetScoreState(ctx, eid, shared.ID("nope"), 1, judgment.StateConfirmed, 3); !errors.Is(err, shared.ErrNotFound) {
 		t.Fatalf("unknown id: want ErrNotFound, got %v", err)
 	}
 
@@ -89,7 +103,7 @@ func TestJudgmentRepository(t *testing.T) {
 	// must be rejected on read, never hydrated. (Last assertion – it poisons ListByEngagement.)
 	if _, err := pool.Exec(ctx,
 		`INSERT INTO judgments (id, tenant_id, engagement_id, capability, subject_kind, subject_id, claim, state, version, created_at, updated_at)
-		 VALUES ($1,'',$2,'reachability','finding','f1','{"capability":"reachability","claim":{"reachable":"unknown","tier":"tier-0","confidence":0}}','GARBAGE',1,now(),now())`,
+		 VALUES ($1,'default',$2,'reachability','finding','f1','{"capability":"reachability","claim":{"reachable":"unknown","tier":"tier-0","confidence":0}}','GARBAGE',1,now(),now())`,
 		"jbad-"+randHex(t), eid.String()); err != nil {
 		t.Fatalf("insert corrupted row: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/migration_0081_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0081_test.go
@@ -66,14 +66,40 @@ func TestMigration0081MakesIndependenceConstraintFailClosed(t *testing.T) {
 	}
 
 	assertUp(constraint())
-	// Exercise exactly this migration so the regression stays isolated from any
-	// neighboring migrations that may land while this branch is under review.
+	// Migration 0085 intentionally refuses a rollback after a tenant v2 audit
+	// entry exists. Isolate this historical migration test from prior live-DSN
+	// test data before rolling through 0085 to reach 0081.
+	cleanupConn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("migration cleanup connection: %v", err)
+	}
+	if _, err := cleanupConn.ExecContext(context.Background(), "SET session_replication_role = replica"); err != nil {
+		cleanupConn.Close()
+		t.Fatalf("disable audit append-only trigger: %v", err)
+	}
+	if _, err := cleanupConn.ExecContext(context.Background(), "DELETE FROM audit_log WHERE hash_version = 2"); err != nil {
+		_, _ = cleanupConn.ExecContext(context.Background(), "SET session_replication_role = origin")
+		cleanupConn.Close()
+		t.Fatalf("clear v2 audit rows: %v", err)
+	}
+	if _, err := cleanupConn.ExecContext(context.Background(), "SET session_replication_role = origin"); err != nil {
+		cleanupConn.Close()
+		t.Fatalf("restore audit append-only trigger: %v", err)
+	}
+	cleanupConn.Close()
+
+	// DownTo(80) makes 0081 the current migration, so the following Down
+	// applies exactly 0081 rather than only the latest migration. Reapply all
+	// migrations afterwards to restore this shared test database to version 88.
+	if err := goose.DownTo(db, ".", 80); err != nil {
+		t.Fatalf("down to 0080: %v", err)
+	}
 	if err := goose.Down(db, "."); err != nil {
 		t.Fatalf("down 0081: %v", err)
 	}
 	assertDown(constraint())
 	if err := goose.Up(db, "."); err != nil {
-		t.Fatalf("up 0081: %v", err)
+		t.Fatalf("restore to 0088: %v", err)
 	}
 	assertUp(constraint())
 

--- a/internal/infrastructure/persistence/postgres/migration_0088_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0088_test.go
@@ -1,0 +1,52 @@
+package postgres
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+func deleteV2AuditRowsForMigrationRollback(t *testing.T, db *sql.DB) {
+	t.Helper()
+	var exists bool
+	if err := db.QueryRow(`SELECT EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_schema = current_schema() AND table_name = 'audit_log' AND column_name = 'hash_version'
+	)`).Scan(&exists); err != nil {
+		t.Fatalf("check audit migration state: %v", err)
+	}
+	if !exists {
+		return
+	}
+	if _, err := db.Exec(`SET session_replication_role = replica`); err != nil {
+		t.Fatalf("disable audit append-only trigger for intentional historical rollback: %v", err)
+	}
+	defer func() {
+		if _, err := db.Exec(`SET session_replication_role = origin`); err != nil {
+			t.Errorf("restore audit append-only trigger: %v", err)
+		}
+	}()
+	if _, err := db.Exec(`DELETE FROM audit_log WHERE hash_version = 2`); err != nil {
+		t.Fatalf("clear v2 audit rows before intentional historical rollback: %v", err)
+	}
+}
+
+func TestMigration0088ProposalAndPromotionAuditStatusAreImmutable(t *testing.T) {
+	migration, err := migrations.FS.ReadFile("0088_judgment_proposal_audit_and_promotion_hardening.sql")
+	if err != nil {
+		t.Fatalf("read migration 0088: %v", err)
+	}
+	text := string(migration)
+	for _, required := range []string{
+		"judgment_proposal_audit_status", "finding_promotion_audit_status", "FOR SELECT", "FOR INSERT", "FOR UPDATE", "BEFORE UPDATE OR DELETE", "BEFORE TRUNCATE",
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("migration 0088 lacks %q", required)
+		}
+	}
+	if strings.Contains(text, "FOR ALL") || strings.Contains(text, "FOR DELETE") {
+		t.Fatal("migration 0088 permits broad or delete RLS policy")
+	}
+}

--- a/internal/infrastructure/persistence/postgres/promotion_store.go
+++ b/internal/infrastructure/persistence/postgres/promotion_store.go
@@ -1,0 +1,552 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/promotion"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// fpeCols is the SELECT/RETURNING projection scanned by scanPromotionEvent.
+const fpeCols = `id, engagement_id, judgment_id, finding_id, finding_version, after_finding_version,
+    rule, effect, before_priority, after_priority, inputs, fingerprint,
+    verdict_score, verdict_rationale, evidence_id, verifier,
+    uncertainty, applied_by, applied_at`
+
+// PromotionStore persists promotion lifecycle events to PostgreSQL.
+// Every operation runs inside a single RLS-scoped transaction via
+// WithContextTenant so tenant isolation is enforced at the database level.
+//
+// Apply atomically:
+//  1. Acquires sorted advisory transaction locks on (judgment, fingerprint)
+//     to serialize concurrent idempotency checks (prevents deadlocks).
+//  2. Checks judgment-level idempotency (tenant+judgmentID).
+//  3. Checks fingerprint-level idempotency (tenant+fingerprint).
+//  4. Locks the finding FOR UPDATE, verifies CAS (priority + version).
+//  5. Binds command metadata to CAS state.
+//  6. Validates exact reversal for corroborating_signal_loss.
+//  7. Constructs and validates the PromotionEvent.
+//  8. Mutates the finding (priority + version) for escalating/de-escalating effects.
+//  9. Appends the event to the append-only table.
+type PromotionStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPromotionStore returns a repository backed by the given pool.
+func NewPromotionStore(pool *pgxpool.Pool) (*PromotionStore, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("%w: promotion store requires a database pool", shared.ErrValidation)
+	}
+	return &PromotionStore{pool: pool}, nil
+}
+
+var (
+	_ ports.PromotionStore             = (*PromotionStore)(nil)
+	_ ports.PromotionAuditTracker      = (*PromotionStore)(nil)
+	_ ports.PendingPromotionAuditStore = (*PromotionStore)(nil)
+)
+
+// sortedLockKeys returns two hashtext-based int32 keys in sorted order so that
+// concurrent transactions always acquire advisory locks in the same order,
+// preventing deadlocks. The "fpe:" namespace separates promotion locks from
+// other advisory lock users.
+func sortedLockKeys(judgmentID, fingerprint string) (int32, int32) {
+	// Use the first 4 bytes of the string as a simple hash for advisory locks.
+	// This doesn't need to be cryptographic; it just needs to be deterministic
+	// and reasonably distributed. We use hashtext() in SQL instead.
+	// For Go-side sorting, we compare the raw strings.
+	a := "fpe:j:" + judgmentID
+	b := "fpe:f:" + fingerprint
+	if a > b {
+		return hashStr(b), hashStr(a)
+	}
+	return hashStr(a), hashStr(b)
+}
+
+// hashStr produces a deterministic int32 from a string for advisory lock keys.
+// Mirrors PostgreSQL's hashtext() behavior closely enough for lock keying.
+func hashStr(s string) int32 {
+	var h int32
+	for _, c := range s {
+		h = h*31 + int32(c)
+	}
+	return h
+}
+
+// Apply constructs a PromotionEvent from the command, persists it, and
+// atomically moves the finding's priority. Returns the existing event on
+// exact replay (same judgmentID), or shared.ErrConflict on semantic conflicts.
+func (r *PromotionStore) Apply(ctx context.Context, engagementID, findingID shared.ID, cmd ports.PromotionCommand) (out finding.Finding, err error) {
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		// 1. Acquire TWO independent namespaced advisory transaction locks:
+		// one for the judgment key and one for the fingerprint key. Sorting
+		// by the key values ensures deterministic acquisition order to
+		// prevent deadlocks. We use the single-argument pg_advisory_xact_lock
+		// form (one lock per call) so each key is an independent lock.
+		k1, k2 := sortedLockKeys(cmd.JudgmentID.String(), cmd.Fingerprint)
+		if _, lockErr := tx.Exec(ctx,
+			`SELECT pg_advisory_xact_lock($1)`, k1); lockErr != nil {
+			return fmt.Errorf("acquire promotion advisory lock (judgment): %w", lockErr)
+		}
+		if _, lockErr := tx.Exec(ctx,
+			`SELECT pg_advisory_xact_lock($1)`, k2); lockErr != nil {
+			return fmt.Errorf("acquire promotion advisory lock (fingerprint): %w", lockErr)
+		}
+
+		// 2. Judgment-level idempotency: if this exact judgment was already
+		// applied, verify exact replay (all immutable semantic fields must
+		// match) and return the existing finding state.
+		jRow := tx.QueryRow(ctx,
+			`SELECT `+fpeCols+` FROM finding_promotion_events WHERE judgment_id = $1`,
+			cmd.JudgmentID.String())
+		existingEvt, jErr := scanPromotionEvent(jRow)
+		if jErr == nil {
+			// Defense-in-depth: verify the stored event's engagement matches
+			// the requested engagement. The composite FK
+			// (tenant_id, engagement_id, judgment_id) enforces this at the
+			// database level; this code-level check makes the intent explicit.
+			if existingEvt.EngagementID != engagementID {
+				return fmt.Errorf("%w: judgment %s belongs to engagement %s, not %s", shared.ErrConflict, cmd.JudgmentID, existingEvt.EngagementID, engagementID)
+			}
+			// Build the expected replay event for comparison.
+			afterFV := cmd.FindingVersion
+			if cmd.Effect != judgment.PromotionFlagForReview {
+				afterFV = cmd.FindingVersion + 1
+			}
+			replayEvt := promotion.PromotionEvent{
+				EngagementID:        engagementID,
+				JudgmentID:          cmd.JudgmentID,
+				FindingID:           findingID,
+				FindingVersion:      cmd.FindingVersion,
+				AfterFindingVersion: afterFV,
+				Rule:                cmd.Rule,
+				Effect:              cmd.Effect,
+				BeforePriority:      cmd.BeforePriority,
+				AfterPriority:       cmd.AfterPriority,
+				Inputs:              cmd.Inputs,
+				Fingerprint:         cmd.Fingerprint,
+				Uncertainty:         cmd.Uncertainty,
+				VerdictScore:        cmd.VerdictScore,
+				VerdictRationale:    cmd.VerdictRationale,
+				EvidenceID:          cmd.EvidenceID,
+				Verifier:            cmd.Verifier,
+				AppliedBy:           cmd.AppliedBy,
+			}
+			if !existingEvt.Equals(replayEvt) {
+				return fmt.Errorf("%w: judgment %s replay differs from stored event", shared.ErrConflict, cmd.JudgmentID)
+			}
+			var scanErr error
+			out, scanErr = scanFindingFromTx(ctx, tx, engagementID, findingID)
+			return scanErr
+		}
+		if !errors.Is(jErr, pgx.ErrNoRows) {
+			return fmt.Errorf("check judgment idempotency: %w", jErr)
+		}
+
+		// 3. Fingerprint-level idempotency: if this fingerprint already exists
+		// under a different judgment, that is a semantic conflict.
+		var fpJudgment string
+		fpErr := tx.QueryRow(ctx,
+			`SELECT judgment_id FROM finding_promotion_events WHERE fingerprint = $1`,
+			cmd.Fingerprint).Scan(&fpJudgment)
+		if fpErr == nil {
+			if fpJudgment != cmd.JudgmentID.String() {
+				return fmt.Errorf("%w: fingerprint %s already applied by judgment %s (not %s)", shared.ErrConflict, cmd.Fingerprint, fpJudgment, cmd.JudgmentID)
+			}
+			// Judgment matches: replay through a different code path.
+			var scanErr error
+			out, scanErr = scanFindingFromTx(ctx, tx, engagementID, findingID)
+			return scanErr
+		}
+		if !errors.Is(fpErr, pgx.ErrNoRows) {
+			return fmt.Errorf("check fingerprint idempotency: %w", fpErr)
+		}
+
+		// 4. Lock the finding FOR UPDATE and verify CAS (priority + version).
+		var (
+			fPriority int
+			fVersion  int
+		)
+		fErr := tx.QueryRow(ctx,
+			`SELECT priority, version
+			 FROM findings WHERE id = $1 AND engagement_id = $2
+			 FOR UPDATE`,
+			findingID.String(), engagementID.String(),
+		).Scan(&fPriority, &fVersion)
+		if errors.Is(fErr, pgx.ErrNoRows) {
+			return fmt.Errorf("finding %s: %w", findingID, shared.ErrNotFound)
+		}
+		if fErr != nil {
+			return fmt.Errorf("lock finding for promotion: %w", fErr)
+		}
+		if fVersion != cmd.ExpectedVersion {
+			return fmt.Errorf("finding %s changed since you loaded it: %w", findingID, shared.ErrConflict)
+		}
+		if fPriority != cmd.ExpectedPriority {
+			return fmt.Errorf("finding %s priority changed since you loaded it: %w", findingID, shared.ErrConflict)
+		}
+
+		// 5. Bind command metadata to CAS: the event's FindingVersion must
+		// equal ExpectedVersion and BeforePriority must equal ExpectedPriority.
+		if cmd.FindingVersion != cmd.ExpectedVersion {
+			return fmt.Errorf("%w: command FindingVersion %d != ExpectedVersion %d", shared.ErrValidation, cmd.FindingVersion, cmd.ExpectedVersion)
+		}
+		if cmd.BeforePriority != cmd.ExpectedPriority {
+			return fmt.Errorf("%w: command BeforePriority %d != ExpectedPriority %d", shared.ErrValidation, cmd.BeforePriority, cmd.ExpectedPriority)
+		}
+
+		// 6. For corroborating_signal_loss, validate the exact reversal.
+		if cmd.Rule == judgment.RuleCorroboratingSignalLoss {
+			if vErr := r.validateExactReversalTx(ctx, tx, engagementID, findingID, cmd); vErr != nil {
+				return vErr
+			}
+		}
+
+		// 7. Construct and validate the event BEFORE any mutation.
+		afterFindingVersion := cmd.FindingVersion
+		if cmd.Effect != judgment.PromotionFlagForReview {
+			afterFindingVersion = cmd.FindingVersion + 1
+		}
+
+		evt, err := promotion.NewPromotionEvent(
+			cmd.EventID,
+			engagementID,
+			cmd.JudgmentID,
+			findingID,
+			cmd.FindingVersion,
+			afterFindingVersion,
+			cmd.Rule,
+			cmd.Effect,
+			cmd.BeforePriority,
+			cmd.AfterPriority,
+			cmd.Inputs,
+			cmd.Fingerprint,
+			cmd.VerdictScore,
+			cmd.VerdictRationale,
+			cmd.EvidenceID,
+			cmd.Verifier,
+			cmd.Uncertainty,
+			cmd.AppliedBy,
+			time.Now().UTC(),
+		)
+		if err != nil {
+			return fmt.Errorf("construct promotion event: %w", err)
+		}
+
+		// 8. For mutating effects, bump the finding's priority + version.
+		if evt.Effect != judgment.PromotionFlagForReview {
+			_, err := tx.Exec(ctx,
+				`UPDATE findings SET priority = $1, version = version + 1, updated_at = now()
+				 WHERE id = $2 AND engagement_id = $3 AND version = $4`,
+				evt.AfterPriority, findingID.String(), engagementID.String(), cmd.ExpectedVersion)
+			if err != nil {
+				return fmt.Errorf("update finding priority: %w", err)
+			}
+		}
+
+		// 9. Append the event to the append-only table.
+		inputsJSON, err := json.Marshal(evt.Inputs)
+		if err != nil {
+			return fmt.Errorf("marshal promotion inputs: %w", err)
+		}
+		uncertaintyJSON, err := json.Marshal(evt.Uncertainty)
+		if err != nil {
+			return fmt.Errorf("marshal promotion uncertainty: %w", err)
+		}
+		tenantID, _ := shared.TenantFrom(ctx)
+
+		_, err = tx.Exec(ctx,
+			`INSERT INTO finding_promotion_events
+			 (id, tenant_id, engagement_id, judgment_id, finding_id,
+			  finding_version, after_finding_version,
+			  rule, effect, before_priority, after_priority,
+			  inputs, fingerprint,
+			  verdict_score, verdict_rationale, evidence_id, verifier,
+			  uncertainty, applied_by, applied_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)`,
+			evt.ID.String(), tenantID.String(), evt.EngagementID.String(),
+			evt.JudgmentID.String(), evt.FindingID.String(),
+			evt.FindingVersion, evt.AfterFindingVersion,
+			evt.Rule, string(evt.Effect), evt.BeforePriority, evt.AfterPriority,
+			inputsJSON, evt.Fingerprint,
+			evt.VerdictScore, evt.VerdictRationale,
+			evt.EvidenceID.String(), evt.Verifier,
+			uncertaintyJSON, evt.AppliedBy, evt.AppliedAt,
+		)
+		if err != nil {
+			return fmt.Errorf("insert promotion event: %w", err)
+		}
+		if _, err = tx.Exec(ctx,
+			`INSERT INTO finding_promotion_audit_status (tenant_id, event_id) VALUES ($1, $2)`,
+			tenantID.String(), evt.ID.String()); err != nil {
+			return fmt.Errorf("insert promotion audit status: %w", err)
+		}
+
+		// Re-read the finding post-mutation to return its final state.
+		out, err = scanFindingFromTx(ctx, tx, engagementID, findingID)
+		return err
+	})
+	return out, err
+}
+
+// validateExactReversalTx verifies that a corroborating_signal_loss command
+// references a valid prior escalation event that is the latest mutating
+// promotion in the finding's lineage. The prior event must:
+//   - be referenced by exactly one prior_promotion input
+//   - exist in the store under the same engagement and finding
+//   - be an applied escalation
+//   - have a BeforePriority that equals the requested AfterPriority
+//   - be the latest event for this finding (no later events after it)
+//   - its AfterPriority and AfterFindingVersion must match the command's
+//     BeforePriority and FindingVersion (lineage continuity)
+func (r *PromotionStore) validateExactReversalTx(ctx context.Context, tx pgx.Tx, engagementID, findingID shared.ID, cmd ports.PromotionCommand) error {
+	var priorEventID shared.ID
+	priorCount := 0
+	for _, in := range cmd.Inputs {
+		if in.Kind == judgment.PromotionInputPrior {
+			priorEventID = in.ID
+			priorCount++
+		}
+	}
+	if priorCount == 0 {
+		return fmt.Errorf("%w: corroborating_signal_loss requires a prior_promotion input", shared.ErrValidation)
+	}
+	if priorCount > 1 {
+		return fmt.Errorf("%w: corroborating_signal_loss requires exactly one prior_promotion input, got %d", shared.ErrValidation, priorCount)
+	}
+	if priorEventID.IsZero() {
+		return fmt.Errorf("%w: prior_promotion input has empty event ID", shared.ErrValidation)
+	}
+	rows, err := tx.Query(ctx, `SELECT `+fpeCols+` FROM finding_promotion_events
+		WHERE engagement_id=$1 AND finding_id=$2 ORDER BY applied_at ASC, id COLLATE "C" ASC`, engagementID.String(), findingID.String())
+	if err != nil {
+		return fmt.Errorf("list promotion lineage: %w", err)
+	}
+	defer rows.Close()
+	stack := make([]promotion.PromotionEvent, 0)
+	found := false
+	for rows.Next() {
+		event, err := scanPromotionEvent(rows)
+		if err != nil {
+			return fmt.Errorf("scan promotion lineage: %w", err)
+		}
+		if event.ID == priorEventID {
+			found = true
+		}
+		switch event.Effect {
+		case judgment.PromotionEscalate:
+			stack = append(stack, event)
+		case judgment.PromotionDeescalate:
+			if event.Rule != judgment.RuleCorroboratingSignalLoss {
+				continue
+			}
+			for _, input := range event.Inputs {
+				if input.Kind != judgment.PromotionInputPrior {
+					continue
+				}
+				for i := len(stack) - 1; i >= 0; i-- {
+					if stack[i].ID == input.ID {
+						stack = stack[:i]
+						break
+					}
+				}
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("list promotion lineage: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("%w: prior promotion event %s not found for engagement %s finding %s", shared.ErrNotFound, priorEventID, engagementID, findingID)
+	}
+	if len(stack) == 0 || stack[len(stack)-1].ID != priorEventID {
+		return fmt.Errorf("%w: prior event %s is not the latest unresolved escalation", shared.ErrConflict, priorEventID)
+	}
+	prior := stack[len(stack)-1]
+	if cmd.AfterPriority != prior.BeforePriority {
+		return fmt.Errorf("%w: reversal target priority %d != prior event %s before-priority %d", shared.ErrConflict, cmd.AfterPriority, priorEventID, prior.BeforePriority)
+	}
+	if cmd.BeforePriority != prior.AfterPriority {
+		return fmt.Errorf("%w: command before-priority %d != prior event %s after-priority %d", shared.ErrConflict, cmd.BeforePriority, priorEventID, prior.AfterPriority)
+	}
+	return nil
+}
+
+// ListByFinding returns all promotion events for a finding, oldest first.
+func (r *PromotionStore) ListByFinding(ctx context.Context, engagementID, findingID shared.ID) (out []promotion.PromotionEvent, err error) {
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, qErr := tx.Query(ctx,
+			`SELECT `+fpeCols+`
+			 FROM finding_promotion_events
+			 WHERE engagement_id = $1 AND finding_id = $2
+			 ORDER BY applied_at ASC, id COLLATE "C" ASC`,
+			engagementID.String(), findingID.String())
+		if qErr != nil {
+			return fmt.Errorf("list promotion events: %w", qErr)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			evt, scanErr := scanPromotionEvent(rows)
+			if scanErr != nil {
+				return fmt.Errorf("scan promotion event: %w", scanErr)
+			}
+			out = append(out, evt)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// LatestByFinding returns the most recent promotion event for a finding,
+// or (zero, false) if none exist.
+func (r *PromotionStore) LatestByFinding(ctx context.Context, engagementID, findingID shared.ID) (evt promotion.PromotionEvent, ok bool, err error) {
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`SELECT `+fpeCols+`
+			 FROM finding_promotion_events
+			 WHERE engagement_id = $1 AND finding_id = $2
+			 ORDER BY applied_at DESC, id DESC
+			 LIMIT 1`,
+			engagementID.String(), findingID.String())
+		scanEvt, scanErr := scanPromotionEvent(row)
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			ok = false
+			return nil
+		}
+		if scanErr != nil {
+			return fmt.Errorf("scan latest promotion event: %w", scanErr)
+		}
+		evt = scanEvt
+		ok = true
+		return nil
+	})
+	return evt, ok, err
+}
+
+// FindByJudgment returns an event scoped to its tenant, engagement, and finding.
+func (r *PromotionStore) FindByJudgment(ctx context.Context, engagementID, findingID, judgmentID shared.ID) (evt promotion.PromotionEvent, ok bool, err error) {
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`SELECT `+fpeCols+`
+			 FROM finding_promotion_events
+			 WHERE engagement_id = $1 AND finding_id = $2 AND judgment_id = $3`,
+			engagementID.String(), findingID.String(), judgmentID.String())
+		scanEvt, scanErr := scanPromotionEvent(row)
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			return nil
+		}
+		if scanErr != nil {
+			return fmt.Errorf("scan promotion event by judgment: %w", scanErr)
+		}
+		evt, ok = scanEvt, true
+		return nil
+	})
+	return evt, ok, err
+}
+
+// ListPendingAudits returns applied events whose required audit record has not
+// been acknowledged. The status row is created atomically with each event.
+func (r *PromotionStore) ListPendingAudits(ctx context.Context, engagementID shared.ID) (out []promotion.PromotionEvent, err error) {
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, qErr := tx.Query(ctx,
+			`SELECT `+fpeCols+`
+			 FROM finding_promotion_events e
+			 JOIN finding_promotion_audit_status s ON s.tenant_id = e.tenant_id AND s.event_id = e.id
+			 WHERE e.engagement_id = $1 AND s.completed_at IS NULL
+			 ORDER BY e.applied_at ASC, e.id COLLATE "C" ASC`, engagementID.String())
+		if qErr != nil {
+			return fmt.Errorf("list pending promotion audits: %w", qErr)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			evt, scanErr := scanPromotionEvent(rows)
+			if scanErr != nil {
+				return fmt.Errorf("scan pending promotion audit: %w", scanErr)
+			}
+			out = append(out, evt)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// MarkAuditComplete acknowledges an event's required audit record. Repeating
+// the acknowledgement is idempotent.
+func (r *PromotionStore) MarkAuditComplete(ctx context.Context, eventID shared.ID) error {
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		result, err := tx.Exec(ctx,
+			`UPDATE finding_promotion_audit_status SET completed_at = COALESCE(completed_at, now()) WHERE event_id = $1`,
+			eventID.String())
+		if err != nil {
+			return fmt.Errorf("mark promotion audit complete: %w", err)
+		}
+		if result.RowsAffected() == 0 {
+			return fmt.Errorf("promotion event %s: %w", eventID, shared.ErrNotFound)
+		}
+		return nil
+	})
+}
+
+// scanFindingFromTx reads a finding within an existing transaction (no new
+// transaction, no separate RLS scope). Used by Apply to re-read the finding
+// after mutation.
+func scanFindingFromTx(ctx context.Context, tx pgx.Tx, engagementID, findingID shared.ID) (finding.Finding, error) {
+	return scanFinding(tx.QueryRow(ctx,
+		`SELECT `+findingCols+` FROM findings WHERE id = $1 AND engagement_id = $2`,
+		findingID.String(), engagementID.String()))
+}
+
+// scanPromotionEvent scans a finding_promotion_events row into a
+// PromotionEvent. Accepts pgx.Row or pgx.Rows via the rowScanner interface.
+func scanPromotionEvent(row rowScanner) (promotion.PromotionEvent, error) {
+	var (
+		evt                                               promotion.PromotionEvent
+		id, eid, jid, fid, rule, effect, fingerprint      string
+		verdictRationale, evidenceID, verifier, appliedBy string
+		inputsJSON, uncertaintyJSON                       []byte
+	)
+	if err := row.Scan(
+		&id, &eid, &jid, &fid,
+		&evt.FindingVersion, &evt.AfterFindingVersion,
+		&rule, &effect, &evt.BeforePriority, &evt.AfterPriority,
+		&inputsJSON, &fingerprint,
+		&evt.VerdictScore, &verdictRationale, &evidenceID, &verifier,
+		&uncertaintyJSON, &appliedBy, &evt.AppliedAt,
+	); err != nil {
+		return promotion.PromotionEvent{}, err
+	}
+	evt.ID = shared.ID(id)
+	evt.EngagementID = shared.ID(eid)
+	evt.JudgmentID = shared.ID(jid)
+	evt.FindingID = shared.ID(fid)
+	evt.Rule = rule
+	evt.Effect = judgment.PromotionChange(effect)
+	evt.Fingerprint = fingerprint
+	evt.VerdictRationale = verdictRationale
+	evt.EvidenceID = shared.ID(evidenceID)
+	evt.Verifier = verifier
+	evt.AppliedBy = appliedBy
+
+	if len(inputsJSON) > 0 {
+		if err := json.Unmarshal(inputsJSON, &evt.Inputs); err != nil {
+			return promotion.PromotionEvent{}, fmt.Errorf("unmarshal promotion inputs: %w", err)
+		}
+	}
+	if len(uncertaintyJSON) > 0 {
+		if err := json.Unmarshal(uncertaintyJSON, &evt.Uncertainty); err != nil {
+			return promotion.PromotionEvent{}, fmt.Errorf("unmarshal promotion uncertainty: %w", err)
+		}
+	}
+
+	return evt, nil
+}

--- a/internal/infrastructure/persistence/postgres/promotion_store_test.go
+++ b/internal/infrastructure/persistence/postgres/promotion_store_test.go
@@ -1,0 +1,757 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func mustPromotionStore(t *testing.T, pool *pgxpool.Pool) *PromotionStore {
+	t.Helper()
+	store, err := NewPromotionStore(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func TestPromotionStore(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	ctx = shared.WithTenant(ctx, "default")
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	// Create engagement fixture.
+	eid := shared.ID("promo-eng-" + randHex(t))
+	e, err := engagement.New(eid, "", "promotion-test", "", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewEngagementRepository(pool).Create(ctx, e); err != nil {
+		t.Fatalf("create engagement: %v", err)
+	}
+	t.Cleanup(func() {
+		// finding_promotion_events cascade-deletes via engagement FK.
+		_, _ = pool.Exec(ctx, "DELETE FROM judgments WHERE engagement_id=$1", eid.String())
+		_, _ = pool.Exec(ctx, "DELETE FROM findings WHERE engagement_id=$1", eid.String())
+		_, _ = pool.Exec(ctx, "DELETE FROM engagements WHERE id=$1", eid.String())
+	})
+
+	fRepo := NewFindingRepository(pool)
+	jRepo := NewJudgmentRepository(pool)
+	pStore := mustPromotionStore(t, pool)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Seed a finding at P3, version 1.
+	fid := shared.ID("promo-f-" + randHex(t))
+	f := finding.Finding{
+		ID: fid, EngagementID: eid, Title: "CVE-2025-0001 in x@1",
+		Severity: shared.SeverityHigh, Status: finding.StatusConfirmed,
+		Kind: finding.KindSCA, Priority: 3,
+		DedupKey: "vuln:CVE-2025-0001:x:1",
+		Audit:    shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+	if err := fRepo.Upsert(ctx, []finding.Finding{f}); err != nil {
+		t.Fatalf("seed finding: %v", err)
+	}
+
+	// Seed a judgment for the finding.
+	jid := shared.ID("promo-j-" + randHex(t))
+	j := judgment.Judgment{
+		ID: jid, EngagementID: eid,
+		Capability:  judgment.CapPromotion,
+		SubjectKind: judgment.SubjectFinding,
+		SubjectID:   fid,
+		Claim: &judgment.PromotionClaim{
+			FindingID:      fid,
+			Rule:           judgment.RuleRuntimeReachableExposed,
+			Inputs:         []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reach-1"}},
+			Proposed:       judgment.PromotionEscalate,
+			Fingerprint:    strings.Repeat("a", 64),
+			FindingVersion: 1,
+			BeforePriority: 3,
+			AfterPriority:  2,
+		},
+		State: judgment.StateConfirmed,
+		Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+	if err := jRepo.Save(ctx, j); err != nil {
+		t.Fatalf("seed judgment: %v", err)
+	}
+
+	t.Run("apply escalation", func(t *testing.T) {
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 3,
+			ExpectedVersion:  1,
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       jid,
+			FindingVersion:   1,
+			Rule:             judgment.RuleRuntimeReachableExposed,
+			Effect:           judgment.PromotionEscalate,
+			BeforePriority:   3,
+			AfterPriority:    2,
+			Inputs: []judgment.PromotionInput{
+				{Kind: judgment.PromotionInputReachability, ID: "reach-1"},
+			},
+			Fingerprint:      strings.Repeat("a", 64),
+			VerdictScore:     80,
+			AppliedBy:        "tester",
+			VerdictRationale: "verified",
+			EvidenceID:       "evidence-1",
+			Verifier:         "human:verifier",
+		}
+		got, err := pStore.Apply(ctx, eid, fid, cmd)
+		if err != nil {
+			t.Fatalf("Apply escalation: %v", err)
+		}
+		if got.Priority != 2 {
+			t.Errorf("priority = %d, want 2", got.Priority)
+		}
+		if got.Version != 2 {
+			t.Errorf("version = %d, want 2 (bumped)", got.Version)
+		}
+	})
+
+	t.Run("pending audit status", func(t *testing.T) {
+		pending, err := pStore.ListPendingAudits(ctx, eid)
+		if err != nil {
+			t.Fatalf("list pending promotion audits: %v", err)
+		}
+		if len(pending) != 1 || pending[0].JudgmentID != jid {
+			t.Fatalf("pending promotion audits = %#v, want event for %s", pending, jid)
+		}
+		if err := pStore.MarkAuditComplete(ctx, pending[0].ID); err != nil {
+			t.Fatalf("mark promotion audit complete: %v", err)
+		}
+		if err := pStore.MarkAuditComplete(ctx, pending[0].ID); err != nil {
+			t.Fatalf("idempotent promotion audit completion: %v", err)
+		}
+		pending, err = pStore.ListPendingAudits(ctx, eid)
+		if err != nil || len(pending) != 0 {
+			t.Fatalf("pending promotion audits after completion = %#v, %v", pending, err)
+		}
+	})
+
+	t.Run("apply escalation idempotent", func(t *testing.T) {
+		// Idempotent replay: same judgment, same fingerprint. The replay path
+		// returns early at judgment-level idempotency before CAS binding.
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 2,
+			ExpectedVersion:  2,
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       jid, // same judgment
+			FindingVersion:   1,
+			Rule:             judgment.RuleRuntimeReachableExposed,
+			Effect:           judgment.PromotionEscalate,
+			BeforePriority:   3,
+			AfterPriority:    2,
+			Inputs: []judgment.PromotionInput{
+				{Kind: judgment.PromotionInputReachability, ID: "reach-1"},
+			},
+			Fingerprint:      strings.Repeat("a", 64), // same fingerprint
+			VerdictScore:     80,
+			AppliedBy:        "tester",
+			VerdictRationale: "verified",
+			EvidenceID:       "evidence-1",
+			Verifier:         "human:verifier",
+		}
+		got, err := pStore.Apply(ctx, eid, fid, cmd)
+		if err != nil {
+			t.Fatalf("idempotent re-apply: %v", err)
+		}
+		if got.Priority != 2 {
+			t.Errorf("priority = %d, want 2 (unchanged)", got.Priority)
+		}
+	})
+
+	t.Run("replay target mismatch", func(t *testing.T) {
+		// Same judgment but try to apply against a different finding: should
+		// fail because the replay detects the engagement/finding mismatch.
+		fid2 := shared.ID("promo-f2-" + randHex(t))
+		f2 := finding.Finding{
+			ID: fid2, EngagementID: eid, Title: "other finding",
+			Severity: shared.SeverityMedium, Status: finding.StatusConfirmed,
+			Kind: finding.KindSCA, Priority: 3,
+			DedupKey: "vuln:other:x:1",
+			Audit:    shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}
+		if err := fRepo.Upsert(ctx, []finding.Finding{f2}); err != nil {
+			t.Fatalf("seed finding 2: %v", err)
+		}
+
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 3,
+			ExpectedVersion:  1,
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       jid, // same judgment as the escalation
+			FindingVersion:   1,
+			Rule:             judgment.RuleRuntimeReachableExposed,
+			Effect:           judgment.PromotionEscalate,
+			BeforePriority:   3,
+			AfterPriority:    2,
+			Inputs: []judgment.PromotionInput{
+				{Kind: judgment.PromotionInputReachability, ID: "reach-1"},
+			},
+			Fingerprint:      strings.Repeat("a", 64),
+			AppliedBy:        "tester",
+			VerdictRationale: "verified",
+			EvidenceID:       "evidence-1",
+			Verifier:         "human:verifier",
+		}
+		_, err := pStore.Apply(ctx, eid, fid2, cmd)
+		if !errors.Is(err, shared.ErrConflict) {
+			t.Fatalf("want ErrConflict for replay target mismatch, got %v", err)
+		}
+	})
+
+	t.Run("fingerprint conflict with different judgment", func(t *testing.T) {
+		jid2 := shared.ID("promo-j2-" + randHex(t))
+		j2 := judgment.Judgment{
+			ID: jid2, EngagementID: eid,
+			Capability:  judgment.CapPromotion,
+			SubjectKind: judgment.SubjectFinding,
+			SubjectID:   fid,
+			Claim: &judgment.PromotionClaim{
+				FindingID:      fid,
+				Rule:           judgment.RuleRuntimeReachableExposed,
+				Inputs:         []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reach-2"}},
+				Proposed:       judgment.PromotionEscalate,
+				Fingerprint:    strings.Repeat("b", 64),
+				FindingVersion: 1,
+				BeforePriority: 3,
+				AfterPriority:  2,
+			},
+			State: judgment.StateConfirmed,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}
+		if err := jRepo.Save(ctx, j2); err != nil {
+			t.Fatalf("seed judgment 2: %v", err)
+		}
+
+		// Same fingerprint as first apply but different judgment -> conflict.
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 2,
+			ExpectedVersion:  2,
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       jid2,
+			FindingVersion:   2,
+			Rule:             judgment.RuleRuntimeReachableExposed,
+			Effect:           judgment.PromotionEscalate,
+			BeforePriority:   2,
+			AfterPriority:    1,
+			Inputs: []judgment.PromotionInput{
+				{Kind: judgment.PromotionInputReachability, ID: "reach-2"},
+			},
+			Fingerprint:      strings.Repeat("a", 64), // same as first
+			AppliedBy:        "tester",
+			VerdictRationale: "verified",
+			EvidenceID:       "evidence-1",
+			Verifier:         "human:verifier",
+		}
+		_, err := pStore.Apply(ctx, eid, fid, cmd)
+		if !errors.Is(err, shared.ErrConflict) {
+			t.Fatalf("want ErrConflict for fingerprint conflict, got %v", err)
+		}
+	})
+
+	t.Run("CAS version mismatch", func(t *testing.T) {
+		jid3 := shared.ID("promo-j3-" + randHex(t))
+		j3 := judgment.Judgment{
+			ID: jid3, EngagementID: eid,
+			Capability:  judgment.CapPromotion,
+			SubjectKind: judgment.SubjectFinding,
+			SubjectID:   fid,
+			Claim: &judgment.PromotionClaim{
+				FindingID:      fid,
+				Rule:           judgment.RuleDeterministicUnreachable,
+				Inputs:         []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reach-3"}},
+				Proposed:       judgment.PromotionDeescalate,
+				Fingerprint:    strings.Repeat("c", 64),
+				FindingVersion: 1,
+				BeforePriority: 3,
+				AfterPriority:  4,
+			},
+			State: judgment.StateConfirmed,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}
+		if err := jRepo.Save(ctx, j3); err != nil {
+			t.Fatalf("seed judgment 3: %v", err)
+		}
+
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 2,
+			ExpectedVersion:  1, // stale: actual is 2
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       jid3,
+			FindingVersion:   1,
+			Rule:             judgment.RuleDeterministicUnreachable,
+			Effect:           judgment.PromotionDeescalate,
+			BeforePriority:   2,
+			AfterPriority:    3,
+			Inputs: []judgment.PromotionInput{
+				{Kind: judgment.PromotionInputReachability, ID: "reach-3"},
+			},
+			Fingerprint:      strings.Repeat("c", 64),
+			AppliedBy:        "tester",
+			VerdictRationale: "verified",
+			EvidenceID:       "evidence-1",
+			Verifier:         "human:verifier",
+		}
+		_, err := pStore.Apply(ctx, eid, fid, cmd)
+		if !errors.Is(err, shared.ErrConflict) {
+			t.Fatalf("want ErrConflict for CAS mismatch, got %v", err)
+		}
+	})
+
+	t.Run("CAS binding FindingVersion mismatch", func(t *testing.T) {
+		jid4 := shared.ID("promo-j4-" + randHex(t))
+		j4 := judgment.Judgment{
+			ID: jid4, EngagementID: eid,
+			Capability:  judgment.CapPromotion,
+			SubjectKind: judgment.SubjectFinding,
+			SubjectID:   fid,
+			Claim: &judgment.PromotionClaim{
+				FindingID:      fid,
+				Rule:           judgment.RuleDeterministicUnreachable,
+				Inputs:         []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reach-4"}},
+				Proposed:       judgment.PromotionDeescalate,
+				Fingerprint:    strings.Repeat("d", 64),
+				FindingVersion: 1,
+				BeforePriority: 2,
+				AfterPriority:  3,
+			},
+			State: judgment.StateConfirmed,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}
+		if err := jRepo.Save(ctx, j4); err != nil {
+			t.Fatalf("seed judgment 4: %v", err)
+		}
+
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 2,
+			ExpectedVersion:  2,
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       jid4,
+			FindingVersion:   5, // does not match ExpectedVersion=2
+			Rule:             judgment.RuleDeterministicUnreachable,
+			Effect:           judgment.PromotionDeescalate,
+			BeforePriority:   2,
+			AfterPriority:    3,
+			Inputs: []judgment.PromotionInput{
+				{Kind: judgment.PromotionInputReachability, ID: "reach-4"},
+			},
+			Fingerprint:      strings.Repeat("d", 64),
+			AppliedBy:        "tester",
+			VerdictRationale: "verified",
+			EvidenceID:       "evidence-1",
+			Verifier:         "human:verifier",
+		}
+		_, err := pStore.Apply(ctx, eid, fid, cmd)
+		if !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("want ErrValidation for FindingVersion mismatch, got %v", err)
+		}
+	})
+
+	t.Run("CAS binding BeforePriority mismatch", func(t *testing.T) {
+		jid5 := shared.ID("promo-j5-" + randHex(t))
+		j5 := judgment.Judgment{
+			ID: jid5, EngagementID: eid,
+			Capability:  judgment.CapPromotion,
+			SubjectKind: judgment.SubjectFinding,
+			SubjectID:   fid,
+			Claim: &judgment.PromotionClaim{
+				FindingID:      fid,
+				Rule:           judgment.RuleDeterministicUnreachable,
+				Inputs:         []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reach-5"}},
+				Proposed:       judgment.PromotionDeescalate,
+				Fingerprint:    strings.Repeat("e", 64),
+				FindingVersion: 1,
+				BeforePriority: 2,
+				AfterPriority:  3,
+			},
+			State: judgment.StateConfirmed,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}
+		if err := jRepo.Save(ctx, j5); err != nil {
+			t.Fatalf("seed judgment 5: %v", err)
+		}
+
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 2,
+			ExpectedVersion:  2,
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       jid5,
+			FindingVersion:   2,
+			Rule:             judgment.RuleDeterministicUnreachable,
+			Effect:           judgment.PromotionDeescalate,
+			BeforePriority:   1, // does not match ExpectedPriority=2
+			AfterPriority:    3,
+			Inputs: []judgment.PromotionInput{
+				{Kind: judgment.PromotionInputReachability, ID: "reach-5"},
+			},
+			Fingerprint:      strings.Repeat("e", 64),
+			AppliedBy:        "tester",
+			VerdictRationale: "verified",
+			EvidenceID:       "evidence-1",
+			Verifier:         "human:verifier",
+		}
+		_, err := pStore.Apply(ctx, eid, fid, cmd)
+		if !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("want ErrValidation for BeforePriority mismatch, got %v", err)
+		}
+	})
+
+	t.Run("reversal missing prior input", func(t *testing.T) {
+		jid6 := shared.ID("promo-j6-" + randHex(t))
+		j6 := judgment.Judgment{
+			ID: jid6, EngagementID: eid,
+			Capability:  judgment.CapPromotion,
+			SubjectKind: judgment.SubjectFinding,
+			SubjectID:   fid,
+			Claim: &judgment.PromotionClaim{
+				FindingID:      fid,
+				Rule:           judgment.RuleCorroboratingSignalLoss,
+				Inputs:         []judgment.PromotionInput{{Kind: judgment.PromotionInputPrior, ID: "prior-for-claim"}, {Kind: judgment.PromotionInputReachability, ID: "reach-6"}},
+				Proposed:       judgment.PromotionDeescalate,
+				Fingerprint:    strings.Repeat("6", 64),
+				FindingVersion: 1,
+				BeforePriority: 2,
+				AfterPriority:  3,
+			},
+			State: judgment.StateConfirmed,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}
+		if err := jRepo.Save(ctx, j6); err != nil {
+			t.Fatalf("seed judgment 6: %v", err)
+		}
+
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 2,
+			ExpectedVersion:  2,
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       jid6,
+			FindingVersion:   2,
+			Rule:             judgment.RuleCorroboratingSignalLoss,
+			Effect:           judgment.PromotionDeescalate,
+			BeforePriority:   2,
+			AfterPriority:    3,
+			Inputs: []judgment.PromotionInput{
+				{Kind: judgment.PromotionInputReachability, ID: "reach-6"},
+				// No prior_promotion input.
+			},
+			Fingerprint:      strings.Repeat("6", 64),
+			AppliedBy:        "tester",
+			VerdictRationale: "verified",
+			EvidenceID:       "evidence-1",
+			Verifier:         "human:verifier",
+		}
+		_, err := pStore.Apply(ctx, eid, fid, cmd)
+		if !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("want ErrValidation for missing prior input, got %v", err)
+		}
+	})
+
+	t.Run("reversal missing prior event", func(t *testing.T) {
+		jid7 := shared.ID("promo-j7-" + randHex(t))
+		j7 := judgment.Judgment{
+			ID: jid7, EngagementID: eid,
+			Capability:  judgment.CapPromotion,
+			SubjectKind: judgment.SubjectFinding,
+			SubjectID:   fid,
+			Claim: &judgment.PromotionClaim{
+				FindingID:      fid,
+				Rule:           judgment.RuleCorroboratingSignalLoss,
+				Inputs:         []judgment.PromotionInput{{Kind: judgment.PromotionInputPrior, ID: "nonexistent-event"}, {Kind: judgment.PromotionInputReachability, ID: "reach-7"}},
+				Proposed:       judgment.PromotionDeescalate,
+				Fingerprint:    strings.Repeat("7", 64),
+				FindingVersion: 1,
+				BeforePriority: 2,
+				AfterPriority:  3,
+			},
+			State: judgment.StateConfirmed,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}
+		if err := jRepo.Save(ctx, j7); err != nil {
+			t.Fatalf("seed judgment 7: %v", err)
+		}
+
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 2,
+			ExpectedVersion:  2,
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       jid7,
+			FindingVersion:   2,
+			Rule:             judgment.RuleCorroboratingSignalLoss,
+			Effect:           judgment.PromotionDeescalate,
+			BeforePriority:   2,
+			AfterPriority:    3,
+			Inputs: []judgment.PromotionInput{
+				{Kind: judgment.PromotionInputReachability, ID: "reach-7"},
+				{Kind: judgment.PromotionInputPrior, ID: "nonexistent-event"},
+			},
+			Fingerprint:      strings.Repeat("7", 64),
+			AppliedBy:        "tester",
+			VerdictRationale: "verified",
+			EvidenceID:       "evidence-1",
+			Verifier:         "human:verifier",
+		}
+		_, err := pStore.Apply(ctx, eid, fid, cmd)
+		if !errors.Is(err, shared.ErrNotFound) {
+			t.Fatalf("want ErrNotFound for missing prior event, got %v", err)
+		}
+	})
+
+	t.Run("list and latest", func(t *testing.T) {
+		events, err := pStore.ListByFinding(ctx, eid, fid)
+		if err != nil {
+			t.Fatalf("ListByFinding: %v", err)
+		}
+		if len(events) < 1 {
+			t.Fatalf("expected at least 1 event, got %d", len(events))
+		}
+		if events[0].JudgmentID != jid {
+			t.Errorf("event JudgmentID = %s, want %s", events[0].JudgmentID, jid)
+		}
+		if events[0].VerdictScore != 80 {
+			t.Errorf("event VerdictScore = %d, want 80", events[0].VerdictScore)
+		}
+
+		latest, ok, err := pStore.LatestByFinding(ctx, eid, fid)
+		if err != nil || !ok {
+			t.Fatalf("LatestByFinding: ok=%v err=%v", ok, err)
+		}
+		if latest.ID != events[len(events)-1].ID {
+			t.Errorf("latest ID = %s, want %s", latest.ID, events[len(events)-1].ID)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		cmd := ports.PromotionCommand{
+			ExpectedPriority: 3,
+			ExpectedVersion:  1,
+			EventID:          shared.ID("evt-" + randHex(t)),
+			JudgmentID:       shared.ID("nonexistent-j"),
+			FindingVersion:   1,
+			Rule:             judgment.RuleRuntimeReachableExposed,
+			Effect:           judgment.PromotionEscalate,
+			BeforePriority:   3,
+			AfterPriority:    2,
+			Inputs:           []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "j1"}},
+			Fingerprint:      strings.Repeat("f", 64),
+		}
+		_, err := pStore.Apply(ctx, eid, shared.ID("nonexistent-f"), cmd)
+		if !errors.Is(err, shared.ErrNotFound) {
+			t.Fatalf("want ErrNotFound, got %v", err)
+		}
+	})
+}
+
+// TestPromotionStoreAuditStatusLifecycle verifies that Apply creates the pending
+// audit status in its transaction, and acknowledgement removes it from recovery.
+func TestPromotionStoreAuditStatusLifecycle(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := shared.WithTenant(context.Background(), "default")
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	eid := shared.ID("promo-audit-eng-" + randHex(t))
+	e, err := engagement.New(eid, "", "promotion audit status", "", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewEngagementRepository(pool).Create(ctx, e); err != nil {
+		t.Fatalf("create engagement: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM findings WHERE engagement_id=$1", eid.String())
+		_, _ = pool.Exec(ctx, "DELETE FROM engagements WHERE id=$1", eid.String())
+	})
+
+	fid := shared.ID("promo-audit-f-" + randHex(t))
+	now := time.Now().UTC()
+	jid := shared.ID("promo-audit-j-" + randHex(t))
+	if err := NewFindingRepository(pool).Upsert(ctx, []finding.Finding{{
+		ID: fid, EngagementID: eid, Title: "promotion audit finding",
+		Severity: shared.SeverityHigh, Status: finding.StatusConfirmed,
+		Kind: finding.KindSCA, Priority: 3, DedupKey: "promotion-audit:" + fid.String(),
+		Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}}); err != nil {
+		t.Fatalf("seed finding: %v", err)
+	}
+
+	store := mustPromotionStore(t, pool)
+	cmd := ports.PromotionCommand{
+		ExpectedPriority: 3, ExpectedVersion: 1,
+		EventID: shared.ID("promo-audit-evt-" + randHex(t)), JudgmentID: jid,
+		FindingVersion: 1, Rule: judgment.RuleRuntimeReachableExposed, Effect: judgment.PromotionEscalate,
+		BeforePriority: 3, AfterPriority: 2,
+		Inputs:      []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reach-1"}},
+		Fingerprint: strings.Repeat("2", 64), VerdictScore: 80, VerdictRationale: "verified",
+		EvidenceID: "evidence-1", Verifier: "human:verifier", AppliedBy: "tester",
+	}
+	if err := NewJudgmentRepository(pool).Save(ctx, judgment.Judgment{
+		ID: jid, EngagementID: eid, Capability: judgment.CapPromotion,
+		SubjectKind: judgment.SubjectFinding, SubjectID: fid,
+		Claim: &judgment.PromotionClaim{
+			FindingID: fid, Rule: judgment.RuleRuntimeReachableExposed,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reach-1"}},
+			Proposed: judgment.PromotionEscalate, Fingerprint: cmd.Fingerprint,
+			FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+		},
+		State: judgment.StateConfirmed, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}); err != nil {
+		t.Fatalf("seed judgment: %v", err)
+	}
+	if _, err := store.Apply(ctx, eid, fid, cmd); err != nil {
+		t.Fatalf("apply promotion: %v", err)
+	}
+	pending, err := store.ListPendingAudits(ctx, eid)
+	if err != nil || len(pending) != 1 || pending[0].ID != cmd.EventID {
+		t.Fatalf("pending audits = %#v, %v", pending, err)
+	}
+	if err := store.MarkAuditComplete(ctx, cmd.EventID); err != nil {
+		t.Fatalf("acknowledge audit: %v", err)
+	}
+	pending, err = store.ListPendingAudits(ctx, eid)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending audits after acknowledgement = %#v, %v", pending, err)
+	}
+}
+
+func TestPromotionStoreFindByJudgmentUsesRLSTenant(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := shared.WithTenant(context.Background(), "default")
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	eid := shared.ID("promo-find-eng-" + randHex(t))
+	e, err := engagement.New(eid, "", "promotion find", "", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewEngagementRepository(pool).Create(ctx, e); err != nil {
+		t.Fatalf("create engagement: %v", err)
+	}
+	fid := shared.ID("promo-find-f-" + randHex(t))
+	now := time.Now().UTC()
+	if err := NewFindingRepository(pool).Upsert(ctx, []finding.Finding{{
+		ID: fid, EngagementID: eid, Title: "promotion find finding",
+		Severity: shared.SeverityHigh, Status: finding.StatusConfirmed,
+		Kind: finding.KindSCA, Priority: 3, DedupKey: "promotion-find:" + fid.String(),
+		Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}}); err != nil {
+		t.Fatalf("seed finding: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM findings WHERE engagement_id=$1", eid.String())
+		_, _ = pool.Exec(ctx, "DELETE FROM engagements WHERE id=$1", eid.String())
+	})
+
+	store := mustPromotionStore(t, pool)
+	jid := shared.ID("promo-find-j-" + randHex(t))
+	cmd := ports.PromotionCommand{
+		ExpectedPriority: 3, ExpectedVersion: 1,
+		EventID: shared.ID("promo-find-evt-" + randHex(t)), JudgmentID: jid,
+		FindingVersion: 1, Rule: judgment.RuleRuntimeReachableExposed, Effect: judgment.PromotionEscalate,
+		BeforePriority: 3, AfterPriority: 2,
+		Inputs:      []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reach-1"}},
+		Fingerprint: strings.Repeat("3", 64), VerdictScore: 80, VerdictRationale: "verified",
+		EvidenceID: "evidence-1", Verifier: "human:verifier", AppliedBy: "tester",
+	}
+	if err := NewJudgmentRepository(pool).Save(ctx, judgment.Judgment{
+		ID: jid, EngagementID: eid, Capability: judgment.CapPromotion,
+		SubjectKind: judgment.SubjectFinding, SubjectID: fid,
+		Claim: &judgment.PromotionClaim{
+			FindingID: fid, Rule: judgment.RuleRuntimeReachableExposed,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputReachability, ID: "reach-1"}},
+			Proposed: judgment.PromotionEscalate, Fingerprint: cmd.Fingerprint,
+			FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+		},
+		State: judgment.StateConfirmed, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}); err != nil {
+		t.Fatalf("seed judgment: %v", err)
+	}
+	if _, err := store.Apply(ctx, eid, fid, cmd); err != nil {
+		t.Fatalf("apply promotion: %v", err)
+	}
+
+	if _, ok, err := store.FindByJudgment(ctx, eid, fid, jid); err != nil || !ok {
+		t.Fatalf("same-tenant recovery lookup = ok:%t err:%v", ok, err)
+	}
+	otherTenantID := shared.ID("promo-find-tenant-b-" + randHex(t))
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1, $1)`, otherTenantID.String()); err != nil {
+		t.Fatalf("seed tenant B: %v", err)
+	}
+	role := "promo_find_rls_" + randHex(t)
+	for _, query := range []string{
+		`CREATE ROLE ` + role + ` NOSUPERUSER NOBYPASSRLS`,
+		`GRANT USAGE ON SCHEMA public TO ` + role,
+		`GRANT SELECT ON finding_promotion_events TO ` + role,
+	} {
+		if _, err := pool.Exec(ctx, query); err != nil {
+			t.Fatalf("create RLS test role: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DROP OWNED BY `+role)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS `+role)
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id=$1`, otherTenantID.String())
+	})
+	otherCtx := shared.WithTenant(context.Background(), otherTenantID)
+	if err := WithContextTenant(otherCtx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(otherCtx, `SET LOCAL ROLE `+role); err != nil {
+			return err
+		}
+		var visible int
+		if err := tx.QueryRow(otherCtx, `SELECT COUNT(*) FROM finding_promotion_events WHERE judgment_id = $1`, jid.String()).Scan(&visible); err != nil {
+			return err
+		}
+		if visible != 0 {
+			t.Fatalf("tenant B sees %d tenant A promotion events", visible)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("cross-tenant RLS lookup: %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/tenant.go
+++ b/internal/infrastructure/persistence/postgres/tenant.go
@@ -75,10 +75,12 @@ func WithContextTenant(ctx context.Context, pool *pgxpool.Pool, fn func(pgx.Tx) 
 // so that path can enforce it at startup, while single-tenant deployments that connect as a
 // superuser and use no RLS-protected table are not forced to change their role.
 func CheckRLSRuntimeRole(ctx context.Context, pool *pgxpool.Pool) error {
-	var super, bypass bool
-	err := pool.QueryRow(ctx,
-		`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`,
-	).Scan(&super, &bypass)
+	var super, bypass, databaseCreate, schemaCreate, ownsRLSTable bool
+	err := pool.QueryRow(ctx, `SELECT r.rolsuper, r.rolbypassrls,
+		has_database_privilege(current_user, current_database(), 'CREATE'),
+		has_schema_privilege(current_user, 'public', 'CREATE'),
+		EXISTS (SELECT 1 FROM pg_class c WHERE c.relkind IN ('r','p') AND c.relrowsecurity AND c.relowner = r.oid)
+		FROM pg_roles r WHERE r.rolname = current_user`).Scan(&super, &bypass, &databaseCreate, &schemaCreate, &ownsRLSTable)
 	if err != nil {
 		return fmt.Errorf("rls: inspect runtime role: %w", err)
 	}
@@ -87,6 +89,10 @@ func CheckRLSRuntimeRole(ctx context.Context, pool *pgxpool.Pool) error {
 		return fmt.Errorf("rls: runtime DB role %w: role is SUPERUSER, which bypasses row level security", errRLSRoleBypasses)
 	case bypass:
 		return fmt.Errorf("rls: runtime DB role %w: role has BYPASSRLS, which bypasses row level security", errRLSRoleBypasses)
+	case ownsRLSTable:
+		return fmt.Errorf("rls: runtime DB role %w: role owns an RLS table", errRLSRoleBypasses)
+	case schemaCreate || databaseCreate:
+		return fmt.Errorf("rls: runtime DB role %w: role has schema or database DDL authority", errRLSRoleBypasses)
 	default:
 		return nil
 	}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	AuditFile string
 	// DBDSN, when set, enables PostgreSQL persistence; empty = in-memory (dev).
 	DBDSN string
+	// DBMigrationDSN, when set, is used only for schema migrations and runtime-role grants.
+	// It must be a DDL owner credential; DBDSN remains the least-privilege application credential.
+	DBMigrationDSN string
 	// SyftBin is the Syft executable used for SBOM generation (shell-out).
 	SyftBin string
 	// SBOMProducer selects the SBOM-generation producer: "syft" (default – the pinned
@@ -219,12 +222,14 @@ type Config struct {
 	// Postgres); else the API runs them inline-bounded. Concurrency/QueueDepth bound admission
 	// (backpressure → 503). ApprovalSweepInterval drives the prod timeout sweeper. MaxParallel
 	// caps in-flight plan nodes (P5). ReconConcurrency sizes the agent's dedicated recon pool.
-	AgentViaWorker        bool
-	AgentConcurrency      int
-	AgentQueueDepth       int
-	AgentMaxParallel      int
-	AgentReconConcurrency int
-	ApprovalSweepInterval time.Duration
+	// PromotionReconcileInterval schedules server-only recovery of confirmed promotions and audits.
+	AgentViaWorker             bool
+	AgentConcurrency           int
+	AgentQueueDepth            int
+	AgentMaxParallel           int
+	AgentReconConcurrency      int
+	ApprovalSweepInterval      time.Duration
+	PromotionReconcileInterval time.Duration
 
 	// JudgmentsEnabled turns on the AI judgment lifecycle HTTP routes; off by default.
 	JudgmentsEnabled bool
@@ -497,6 +502,7 @@ func Load() Config {
 		AUPFile:                          getenv("SYNAPSE_AUP_FILE", "data/aup-accepted.json"),
 		AuditFile:                        getenv("SYNAPSE_AUDIT_FILE", "data/audit.jsonl"),
 		DBDSN:                            getenv("SYNAPSE_DB_DSN", ""),
+		DBMigrationDSN:                   getenv("SYNAPSE_DB_MIGRATION_DSN", ""),
 		SyftBin:                          getenv("SYNAPSE_SYFT_BIN", "syft"),
 		SBOMProducer:                     getenv("SYNAPSE_SBOM_PRODUCER", "syft"),
 		GrypeBin:                         getenv("SYNAPSE_GRYPE_BIN", "grype"),
@@ -664,18 +670,19 @@ func Load() Config {
 		AgentTokenBudget:     getint("SYNAPSE_AGENT_TOKEN_BUDGET", 0),
 		AgentMaxDuration:     getduration("SYNAPSE_AGENT_MAX_DURATION", 10*time.Minute),
 
-		DBMaxConns:            getint("SYNAPSE_DB_MAX_CONNS", 32),
-		DBMinConns:            getint("SYNAPSE_DB_MIN_CONNS", 0),
-		DBMaxConnLifetime:     getduration("SYNAPSE_DB_MAX_CONN_LIFETIME", time.Hour),
-		DBMaxConnIdleTime:     getduration("SYNAPSE_DB_MAX_CONN_IDLE", 30*time.Minute),
-		AgentViaWorker:        getbool("SYNAPSE_AGENT_VIA_WORKER", false),
-		AgentConcurrency:      getint("SYNAPSE_AGENT_CONCURRENCY", 8),
-		AgentQueueDepth:       getint("SYNAPSE_AGENT_QUEUE_DEPTH", 256),
-		AgentMaxParallel:      getint("SYNAPSE_AGENT_MAX_PARALLEL", 1), // serial by default; operators raise it to parallelize
-		AgentReconConcurrency: getint("SYNAPSE_AGENT_RECON_CONCURRENCY", 3),
-		ApprovalSweepInterval: getduration("SYNAPSE_APPROVAL_SWEEP_INTERVAL", time.Minute),
-		VerifierBaseURL:       getenv("SYNAPSE_VERIFIER_BASE_URL", getenv("SYNAPSE_LLM_BASE_URL", "http://localhost:20128/v1")),
-		VerifierAPIKey:        getenv("SYNAPSE_VERIFIER_API_KEY", getenv("SYNAPSE_LLM_API_KEY", "")),
+		DBMaxConns:                 getint("SYNAPSE_DB_MAX_CONNS", 32),
+		DBMinConns:                 getint("SYNAPSE_DB_MIN_CONNS", 0),
+		DBMaxConnLifetime:          getduration("SYNAPSE_DB_MAX_CONN_LIFETIME", time.Hour),
+		DBMaxConnIdleTime:          getduration("SYNAPSE_DB_MAX_CONN_IDLE", 30*time.Minute),
+		AgentViaWorker:             getbool("SYNAPSE_AGENT_VIA_WORKER", false),
+		AgentConcurrency:           getint("SYNAPSE_AGENT_CONCURRENCY", 8),
+		AgentQueueDepth:            getint("SYNAPSE_AGENT_QUEUE_DEPTH", 256),
+		AgentMaxParallel:           getint("SYNAPSE_AGENT_MAX_PARALLEL", 1), // serial by default; operators raise it to parallelize
+		AgentReconConcurrency:      getint("SYNAPSE_AGENT_RECON_CONCURRENCY", 3),
+		ApprovalSweepInterval:      getduration("SYNAPSE_APPROVAL_SWEEP_INTERVAL", time.Minute),
+		PromotionReconcileInterval: getduration("SYNAPSE_PROMOTION_RECONCILE_INTERVAL", time.Minute),
+		VerifierBaseURL:            getenv("SYNAPSE_VERIFIER_BASE_URL", getenv("SYNAPSE_LLM_BASE_URL", "http://localhost:20128/v1")),
+		VerifierAPIKey:             getenv("SYNAPSE_VERIFIER_API_KEY", getenv("SYNAPSE_LLM_API_KEY", "")),
 		VerifierProvider: normalizeProvider(getenv("SYNAPSE_VERIFIER_PROVIDER",
 			getenv("SYNAPSE_FP_TRIAGE_PROVIDER", getenv("SYNAPSE_LLM_PROVIDER", "openai-compatible")))),
 		VerifierModel: getenv("SYNAPSE_VERIFIER_MODEL", getenv("SYNAPSE_LLM_MODEL", "")),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -352,3 +352,11 @@ func TestLoadDASTCeilingsFailClosed(t *testing.T) {
 		t.Fatalf("DAST ceilings did not fail closed: %+v", config)
 	}
 }
+
+func TestLoadDatabaseMigrationDSN(t *testing.T) {
+	t.Setenv("SYNAPSE_DB_DSN", "postgres://app@example/app")
+	t.Setenv("SYNAPSE_DB_MIGRATION_DSN", "postgres://owner@example/app")
+	if got := Load().DBMigrationDSN; got != "postgres://owner@example/app" {
+		t.Fatalf("migration DSN = %q", got)
+	}
+}

--- a/internal/usecase/analysis/service.go
+++ b/internal/usecase/analysis/service.go
@@ -31,8 +31,8 @@ const (
 // (SetScoreState) lives here (and on the concrete repo) – NOT on a broad ports interface – so a
 // read-only consumer (the agent tool catalog) cannot move a score. Concrete repos satisfy it.
 type Store interface {
-	Save(ctx context.Context, j judgment.Judgment) error
-	ListByEngagement(ctx context.Context, engagementID shared.ID) ([]judgment.Judgment, error)
+	ports.JudgmentStore
+	ports.JudgmentAuditStore
 	SetScoreState(ctx context.Context, engagementID, id shared.ID, score int, state judgment.State, expectedVersion int) (judgment.Judgment, error)
 }
 
@@ -45,7 +45,7 @@ type evidenceSealer interface {
 type Service struct {
 	store    Store
 	evidence evidenceSealer
-	audit    ports.AuditLogger
+	audit    ports.IdempotentAuditLogger
 	clock    ports.Clock
 	ids      ports.IDGenerator
 	// threatRecorder (optional) promotes a CONFIRMED threat judgment to a Kind=threat finding,
@@ -57,12 +57,13 @@ type Service struct {
 	// dastRecorder (optional) promotes a CONFIRMED CapSAST judgment to a Kind=dast finding when the
 	// confirming verdict came from a RUNTIME probe (via VerifyRuntime) rather than a static/LLM verdict,
 	// best-effort. Injected from the composition root – never reachable by the agent.
-	dastRecorder ports.ConfirmedDASTRecorder
+	dastRecorder      ports.ConfirmedDASTRecorder
+	promotionRecorder ports.ConfirmedPromotionRecorder
 }
 
 // NewService validates dependencies (all required; the sealer is mandatory because a verdict that
 // cannot be sealed must never move a score).
-func NewService(store Store, ev evidenceSealer, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+func NewService(store Store, ev evidenceSealer, audit ports.IdempotentAuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
 	if store == nil || ev == nil || audit == nil || clock == nil || ids == nil {
 		return nil, fmt.Errorf("%w: analysis service is missing a dependency", shared.ErrValidation)
 	}
@@ -120,15 +121,16 @@ func (s *Service) Propose(ctx context.Context, proposer string, engagementID sha
 	if _, err := s.evidence.Seal(ctx, engagementID, ProposedEvidenceKind, payload, j.ProposedBy); err != nil {
 		return judgment.Judgment{}, fmt.Errorf("seal judgment proposal: %w", err)
 	}
-	if err := s.store.Save(ctx, j); err != nil {
-		return judgment.Judgment{}, fmt.Errorf("persist judgment: %w", err)
-	}
-	if err := s.audit.Record(ctx, ports.AuditEntry{
+	entry := ports.AuditEntry{
 		Actor: proposer, Action: "judgment.proposed", Target: j.ID.String(),
-		Metadata: map[string]string{"engagement": engagementID.String(), "capability": string(j.Capability), "subject": string(j.SubjectKind) + ":" + j.SubjectID.String()},
+		Metadata: map[string]string{"idempotency_key": "judgment.proposed:" + j.ID.String(), "engagement": engagementID.String(), "capability": string(j.Capability), "subject": string(j.SubjectKind) + ":" + j.SubjectID.String()},
 		At:       s.clock.Now(),
-	}); err != nil {
-		return judgment.Judgment{}, fmt.Errorf("audit judgment proposal: %w", err)
+	}
+	if err := s.store.SaveWithProposalAudit(ctx, j, entry); err != nil {
+		return judgment.Judgment{}, fmt.Errorf("persist judgment proposal: %w", err)
+	}
+	if err := s.deliverAudit(ctx, ports.PendingJudgmentAudit{Kind: ports.JudgmentProposalAudit, JudgmentID: j.ID, Version: j.Version, EngagementID: engagementID, Entry: entry}); err != nil {
+		return judgment.Judgment{}, err
 	}
 	return j, nil
 }
@@ -159,9 +161,18 @@ func (s *Service) verify(ctx context.Context, verifier string, engagementID, jud
 	if err != nil {
 		return judgment.Judgment{}, err
 	}
-	if cur.Publishable() && (cur.Capability == judgment.CapThreat || cur.Capability == judgment.CapSAST || cur.Capability == judgment.CapDAST) {
+	if cur.Publishable() && (cur.Capability == judgment.CapThreat || cur.Capability == judgment.CapSAST || cur.Capability == judgment.CapDAST || cur.Capability == judgment.CapPromotion) {
 		if cur.Version != expectedVersion {
 			return judgment.Judgment{}, shared.ErrConflict
+		}
+		if cur.Capability == judgment.CapPromotion {
+			if err := s.deliverPendingForJudgment(ctx, engagementID, judgmentID); err != nil {
+				return judgment.Judgment{}, err
+			}
+			if err := s.recordPromotion(ctx, cur); err != nil {
+				return judgment.Judgment{}, err
+			}
+			return cur, nil
 		}
 		s.emitFinding(ctx, verifier, cur, runtimeProof)
 		return cur, nil
@@ -179,19 +190,26 @@ func (s *Service) verify(ctx context.Context, verifier string, engagementID, jud
 	if _, err := s.evidence.Seal(ctx, engagementID, VerdictEvidenceKind, payload, verifier); err != nil {
 		return judgment.Judgment{}, fmt.Errorf("seal judgment verdict: %w", err)
 	}
-	saved, err := s.store.SetScoreState(ctx, engagementID, judgmentID, updated.EvidenceScore, updated.State, expectedVersion)
+	entry := ports.AuditEntry{
+		Actor: verifier, Action: "judgment.verdict", Target: judgmentID.String(),
+		Metadata: map[string]string{"idempotency_key": "judgment.verdict:" + judgmentID.String() + ":" + strconv.Itoa(expectedVersion+1), "engagement": engagementID.String(), "score": strconv.Itoa(v.Score), "state": string(updated.State), "publishable": strconv.FormatBool(updated.Publishable())},
+		At:       s.clock.Now(),
+	}
+	saved, err := s.store.SetVerdictStateWithAudit(ctx, engagementID, judgmentID, updated.EvidenceScore, updated.State, updated.VerifiedBy, updated.VerdictRationale, expectedVersion, entry)
 	if err != nil {
 		return judgment.Judgment{}, fmt.Errorf("apply judgment verdict: %w", err)
 	}
-	if err := s.audit.Record(ctx, ports.AuditEntry{
-		Actor: verifier, Action: "judgment.verdict", Target: judgmentID.String(),
-		Metadata: map[string]string{"engagement": engagementID.String(), "score": strconv.Itoa(v.Score), "state": string(saved.State), "publishable": strconv.FormatBool(saved.Publishable())},
-		At:       s.clock.Now(),
-	}); err != nil {
-		return judgment.Judgment{}, fmt.Errorf("audit judgment verdict: %w", err)
+	if err := s.deliverAudit(ctx, ports.PendingJudgmentAudit{Kind: ports.JudgmentVerdictAudit, JudgmentID: judgmentID, Version: saved.Version, EngagementID: engagementID, Entry: entry}); err != nil {
+		return judgment.Judgment{}, err
 	}
 	if saved.Publishable() {
-		s.emitFinding(ctx, verifier, saved, runtimeProof)
+		if saved.Capability == judgment.CapPromotion {
+			if err := s.recordPromotion(ctx, saved); err != nil {
+				return judgment.Judgment{}, err
+			}
+		} else {
+			s.emitFinding(ctx, verifier, saved, runtimeProof)
+		}
 	}
 	return saved, nil
 }
@@ -229,6 +247,39 @@ func (s *Service) recordProjectionFailure(ctx context.Context, verifier, kind st
 	})
 }
 
+func (s *Service) deliverAudit(ctx context.Context, pending ports.PendingJudgmentAudit) error {
+	if err := s.audit.RecordOnce(ctx, pending.Entry); err != nil {
+		return fmt.Errorf("deliver judgment %s audit: %w", pending.Kind, err)
+	}
+	if err := s.store.AcknowledgeJudgmentAudit(ctx, pending.Kind, pending.JudgmentID, pending.Version); err != nil {
+		return fmt.Errorf("acknowledge judgment %s audit: %w", pending.Kind, err)
+	}
+	return nil
+}
+
+func (s *Service) deliverPendingForJudgment(ctx context.Context, engagementID, judgmentID shared.ID) error {
+	pending, err := s.store.ListPendingJudgmentAudits(ctx, engagementID)
+	if err != nil {
+		return fmt.Errorf("list pending judgment audits: %w", err)
+	}
+	for _, item := range pending {
+		if item.JudgmentID == judgmentID && item.Kind == ports.JudgmentVerdictAudit {
+			return s.deliverAudit(ctx, item)
+		}
+	}
+	return nil
+}
+
+func (s *Service) recordPromotion(ctx context.Context, j judgment.Judgment) error {
+	if s.promotionRecorder == nil {
+		return fmt.Errorf("%w: promotion recorder is not configured", shared.ErrValidation)
+	}
+	if err := s.promotionRecorder.RecordConfirmed(ctx, j); err != nil {
+		return fmt.Errorf("record confirmed promotion: %w", err)
+	}
+	return nil
+}
+
 // SetThreatRecorder wires the optional confirmed-threat → finding promoter. nil ⇒ no finding is
 // emitted on confirm. Composition-root only.
 func (s *Service) SetThreatRecorder(r ports.ConfirmedThreatRecorder) { s.threatRecorder = r }
@@ -241,6 +292,8 @@ func (s *Service) SetSASTRecorder(r ports.ConfirmedSASTRecorder) { s.sastRecorde
 // the VerifyRuntime path. nil ⇒ a runtime confirmation still confirms the judgment but emits no DAST
 // finding. Composition-root only.
 func (s *Service) SetDASTRecorder(r ports.ConfirmedDASTRecorder) { s.dastRecorder = r }
+
+func (s *Service) SetPromotionRecorder(r ports.ConfirmedPromotionRecorder) { s.promotionRecorder = r }
 
 // Accept confirms an UNGATED judgment by human acceptance (no score; there is nothing to refute at
 // 75). It seals the acceptance FIRST, then transitions state under optimistic concurrency. The
@@ -295,4 +348,39 @@ func (s *Service) load(ctx context.Context, engagementID, id shared.ID) (judgmen
 		}
 	}
 	return judgment.Judgment{}, fmt.Errorf("judgment %s: %w", id, shared.ErrNotFound)
+}
+
+// GovernanceReconciler retries immutable judgment audit outboxes. It has no
+// transition authority; it can only deliver already-committed payloads.
+type GovernanceReconciler struct {
+	store ports.JudgmentAuditStore
+	audit ports.IdempotentAuditLogger
+}
+
+func NewGovernanceReconciler(store ports.JudgmentAuditStore, audit ports.IdempotentAuditLogger) (*GovernanceReconciler, error) {
+	if store == nil || audit == nil {
+		return nil, fmt.Errorf("%w: judgment governance reconciler is missing a dependency", shared.ErrValidation)
+	}
+	return &GovernanceReconciler{store: store, audit: audit}, nil
+}
+
+var _ ports.GovernanceReconciler = (*GovernanceReconciler)(nil)
+
+func (r *GovernanceReconciler) Reconcile(ctx context.Context, engagementID shared.ID) error {
+	pending, err := r.store.ListPendingJudgmentAudits(ctx, engagementID)
+	if err != nil {
+		return fmt.Errorf("list pending judgment audits: %w", err)
+	}
+	for _, item := range pending {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := r.audit.RecordOnce(ctx, item.Entry); err != nil {
+			return fmt.Errorf("deliver judgment %s audit: %w", item.Kind, err)
+		}
+		if err := r.store.AcknowledgeJudgmentAudit(ctx, item.Kind, item.JudgmentID, item.Version); err != nil {
+			return fmt.Errorf("acknowledge judgment %s audit: %w", item.Kind, err)
+		}
+	}
+	return nil
 }

--- a/internal/usecase/analysis/service_test.go
+++ b/internal/usecase/analysis/service_test.go
@@ -15,7 +15,10 @@ import (
 
 // --- in-package fakes (no infra import from a use-case test) ---
 
-type fakeStore struct{ saved []judgment.Judgment }
+type fakeStore struct {
+	saved   []judgment.Judgment
+	pending []ports.PendingJudgmentAudit
+}
 
 func (f *fakeStore) Save(_ context.Context, j judgment.Judgment) error {
 	for i := range f.saved {
@@ -36,6 +39,15 @@ func (f *fakeStore) ListByEngagement(_ context.Context, eng shared.ID) ([]judgme
 	}
 	return out, nil
 }
+func (f *fakeStore) ListBySubject(_ context.Context, eng, subject shared.ID) ([]judgment.Judgment, error) {
+	var out []judgment.Judgment
+	for _, j := range f.saved {
+		if j.EngagementID == eng && j.SubjectID == subject {
+			out = append(out, j)
+		}
+	}
+	return out, nil
+}
 func (f *fakeStore) SetScoreState(_ context.Context, _, id shared.ID, score int, state judgment.State, expectedVersion int) (judgment.Judgment, error) {
 	for i := range f.saved {
 		if f.saved[i].ID == id {
@@ -49,6 +61,56 @@ func (f *fakeStore) SetScoreState(_ context.Context, _, id shared.ID, score int,
 		}
 	}
 	return judgment.Judgment{}, shared.ErrNotFound
+}
+func (f *fakeStore) SetVerdictState(_ context.Context, _, id shared.ID, score int, state judgment.State, verifiedBy, verdictRationale string, expectedVersion int) (judgment.Judgment, error) {
+	for i := range f.saved {
+		if f.saved[i].ID == id {
+			if f.saved[i].Version != expectedVersion {
+				return judgment.Judgment{}, shared.ErrConflict
+			}
+			f.saved[i].EvidenceScore = score
+			f.saved[i].State = state
+			f.saved[i].VerifiedBy = verifiedBy
+			f.saved[i].VerdictRationale = verdictRationale
+			f.saved[i].Version++
+			return f.saved[i], nil
+		}
+	}
+	return judgment.Judgment{}, shared.ErrNotFound
+}
+
+func (f *fakeStore) SaveWithProposalAudit(_ context.Context, j judgment.Judgment, entry ports.AuditEntry) error {
+	if err := f.Save(context.Background(), j); err != nil {
+		return err
+	}
+	f.pending = append(f.pending, ports.PendingJudgmentAudit{Kind: ports.JudgmentProposalAudit, JudgmentID: j.ID, Version: j.Version, EngagementID: j.EngagementID, Entry: entry})
+	return nil
+}
+func (f *fakeStore) SetVerdictStateWithAudit(_ context.Context, eng, id shared.ID, score int, state judgment.State, by, rationale string, expectedVersion int, entry ports.AuditEntry) (judgment.Judgment, error) {
+	j, err := f.SetVerdictState(context.Background(), eng, id, score, state, by, rationale, expectedVersion)
+	if err != nil {
+		return judgment.Judgment{}, err
+	}
+	f.pending = append(f.pending, ports.PendingJudgmentAudit{Kind: ports.JudgmentVerdictAudit, JudgmentID: id, Version: j.Version, EngagementID: eng, Entry: entry})
+	return j, nil
+}
+func (f *fakeStore) ListPendingJudgmentAudits(_ context.Context, eng shared.ID) ([]ports.PendingJudgmentAudit, error) {
+	var out []ports.PendingJudgmentAudit
+	for _, p := range f.pending {
+		if p.EngagementID == eng {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+func (f *fakeStore) AcknowledgeJudgmentAudit(_ context.Context, kind ports.JudgmentAuditKind, id shared.ID, version int) error {
+	for i, p := range f.pending {
+		if p.Kind == kind && p.JudgmentID == id && p.Version == version {
+			f.pending = append(f.pending[:i], f.pending[i+1:]...)
+			return nil
+		}
+	}
+	return nil
 }
 
 type fakeSealer struct {
@@ -64,10 +126,44 @@ func (f *fakeSealer) Seal(_ context.Context, _ shared.ID, kind string, _ []byte,
 	return evidence.Evidence{}, nil
 }
 
-type fakeAudit struct{ actions []string }
+type fakeAudit struct {
+	actions []string
+	fail    bool
+	once    int
+}
 
 func (f *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
 	f.actions = append(f.actions, e.Action)
+	return nil
+}
+func (f *fakeAudit) RecordOnce(ctx context.Context, e ports.AuditEntry) error {
+	f.once++
+	if f.fail {
+		return errors.New("audit unavailable")
+	}
+	return f.Record(ctx, e)
+}
+
+type fakePromotionRecorder struct {
+	attempts int
+	calls    []judgment.Judgment
+	err      error
+	check    func(j judgment.Judgment) error
+}
+
+func (f *fakePromotionRecorder) RecordConfirmed(_ context.Context, j judgment.Judgment) error {
+	f.attempts++
+	if f.check != nil {
+		if err := f.check(j); err != nil {
+			return err
+		}
+	}
+	if f.err != nil {
+		err := f.err
+		f.err = nil
+		return err
+	}
+	f.calls = append(f.calls, j)
 	return nil
 }
 
@@ -93,6 +189,23 @@ func reach() judgment.Claim {
 }
 func narr() judgment.Claim {
 	return judgment.RiskNarrativeClaim{Drivers: []string{"kev"}, Priority: 1}
+}
+
+func promo() judgment.Claim {
+	return judgment.PromotionClaim{
+		FindingID: "f1",
+		Rule:      judgment.RuleRuntimeReachableExposed,
+		Inputs: []judgment.PromotionInput{
+			{Kind: judgment.PromotionInputAttackPath, ID: "path1"},
+			{Kind: judgment.PromotionInputDetection, ID: "det1"},
+			{Kind: judgment.PromotionInputReachability, ID: "reach1"},
+		},
+		Proposed:       judgment.PromotionEscalate,
+		Fingerprint:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		FindingVersion: 1,
+		BeforePriority: 3,
+		AfterPriority:  2,
+	}
 }
 
 func TestProposeRecordsAtScoreZero(t *testing.T) {
@@ -131,6 +244,9 @@ func TestVerifyConfirmsSealFirst(t *testing.T) {
 	}
 	if got.State != judgment.StateConfirmed || got.EvidenceScore != 80 || !got.Publishable() {
 		t.Fatalf("want confirmed/80/publishable, got %s/%d/%v", got.State, got.EvidenceScore, got.Publishable())
+	}
+	if got.VerifiedBy != "human:bob" || got.VerdictRationale != "holds" || store.saved[0].VerifiedBy != "human:bob" || store.saved[0].VerdictRationale != "holds" {
+		t.Fatalf("sealed verdict provenance was not persisted: got=%#v stored=%#v", got, store.saved[0])
 	}
 	// seal order: proposed BEFORE verdict
 	if len(sealer.kinds) != 2 || sealer.kinds[0] != ProposedEvidenceKind || sealer.kinds[1] != VerdictEvidenceKind {
@@ -174,6 +290,21 @@ func TestVerifyRejectsSelfConfirmAndUngated(t *testing.T) {
 	}
 }
 
+func TestAcceptUngatedDoesNotSetVerdictProvenance(t *testing.T) {
+	svc, store, _, _ := newSvc()
+	jn, err := svc.Propose(context.Background(), "agent:s1", "e1", judgment.CapRiskNarrative, judgment.SubjectFinding, "f1", narr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := svc.Accept(context.Background(), "human:bob", "e1", jn.ID, jn.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.VerifiedBy != "" || got.VerdictRationale != "" || store.saved[0].VerifiedBy != "" || store.saved[0].VerdictRationale != "" {
+		t.Fatalf("accept fabricated verdict provenance: got=%#v stored=%#v", got, store.saved[0])
+	}
+}
+
 func TestAcceptUngated(t *testing.T) {
 	svc, _, _, audit := newSvc()
 	jn, _ := svc.Propose(context.Background(), "agent:s1", "e1", judgment.CapRiskNarrative, judgment.SubjectFinding, "f1", narr())
@@ -200,5 +331,124 @@ func TestVerifyConflict(t *testing.T) {
 	// wrong expectedVersion → conflict (seal still happens; orphan acceptable by design)
 	if _, err := svc.Verify(context.Background(), "human:bob", "e1", j.ID, 80, "holds", j.Version+1); !errors.Is(err, shared.ErrConflict) {
 		t.Fatalf("want ErrConflict, got %v", err)
+	}
+}
+
+func TestVerifyPromotionRecordsAfterSealedVerdict(t *testing.T) {
+	svc, store, sealer, audit := newSvc()
+	rec := &fakePromotionRecorder{check: func(j judgment.Judgment) error {
+		if j.State != judgment.StateConfirmed || !j.Publishable() || j.VerifiedBy != "human:bob" || j.VerdictRationale != "holds" {
+			return fmt.Errorf("recorder saw unsealed judgment: %#v", j)
+		}
+		if store.saved[0].State != judgment.StateConfirmed || store.saved[0].VerifiedBy != "human:bob" || store.saved[0].VerdictRationale != "holds" {
+			return fmt.Errorf("recorder ran before verdict persistence: %#v", store.saved[0])
+		}
+		if len(sealer.kinds) != 2 || sealer.kinds[0] != ProposedEvidenceKind || sealer.kinds[1] != VerdictEvidenceKind {
+			return fmt.Errorf("recorder ran before verdict seal: %v", sealer.kinds)
+		}
+		if audit.actions[len(audit.actions)-1] != "judgment.verdict" {
+			return fmt.Errorf("recorder ran before verdict audit: %v", audit.actions)
+		}
+		return nil
+	}}
+	svc.SetPromotionRecorder(rec)
+	j, err := svc.Propose(context.Background(), "agent:s1", "e1", judgment.CapPromotion, judgment.SubjectFinding, "f1", promo())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := svc.Verify(context.Background(), "human:bob", "e1", j.ID, 75, "holds", j.Version)
+	if err != nil {
+		t.Fatalf("Verify promotion: %v", err)
+	}
+	if got.Capability != judgment.CapPromotion || got.State != judgment.StateConfirmed {
+		t.Fatalf("promotion verdict not confirmed: %#v", got)
+	}
+	if rec.attempts != 1 || len(rec.calls) != 1 {
+		t.Fatalf("promotion recorder calls = attempts %d stored %d", rec.attempts, len(rec.calls))
+	}
+}
+
+func TestVerifyPromotionReturnsRecorderErrorAndRetriesConfirmed(t *testing.T) {
+	svc, store, _, _ := newSvc()
+	rec := &fakePromotionRecorder{err: errors.New("apply promotion down")}
+	svc.SetPromotionRecorder(rec)
+	j, err := svc.Propose(context.Background(), "agent:s1", "e1", judgment.CapPromotion, judgment.SubjectFinding, "f1", promo())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Verify(context.Background(), "human:bob", "e1", j.ID, 75, "holds", j.Version); err == nil {
+		t.Fatal("promotion recorder failure must be returned")
+	}
+	if store.saved[0].State != judgment.StateConfirmed || store.saved[0].Version != 2 {
+		t.Fatalf("judgment not persisted for retry: %#v", store.saved[0])
+	}
+	got, err := svc.Verify(context.Background(), "human:bob", "e1", j.ID, 75, "holds", store.saved[0].Version)
+	if err != nil {
+		t.Fatalf("retry confirmed promotion: %v", err)
+	}
+	if got.Version != store.saved[0].Version || rec.attempts != 2 || len(rec.calls) != 1 {
+		t.Fatalf("retry state wrong: got version %d store version %d attempts %d calls %d", got.Version, store.saved[0].Version, rec.attempts, len(rec.calls))
+	}
+}
+
+func TestVerifyPromotionRejectsMissingRecorder(t *testing.T) {
+	svc, store, _, _ := newSvc()
+	j, err := svc.Propose(context.Background(), "agent:s1", "e1", judgment.CapPromotion, judgment.SubjectFinding, "f1", promo())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Verify(context.Background(), "human:bob", "e1", j.ID, 75, "holds", j.Version); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing promotion recorder: want ErrValidation, got %v", err)
+	}
+	if store.saved[0].State != judgment.StateConfirmed {
+		t.Fatalf("verdict should remain retryable after projection config error: %#v", store.saved[0])
+	}
+}
+
+func TestGovernanceReconcilerDeliversPendingAuditOnce(t *testing.T) {
+	store, sealer, audit := &fakeStore{}, &fakeSealer{}, &fakeAudit{fail: true}
+	svc, err := NewService(store, sealer, audit, fakeClock{}, &fakeIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Propose(context.Background(), "agent:s1", "e1", judgment.CapReachability, judgment.SubjectFinding, "f1", reach()); err == nil {
+		t.Fatal("proposal must surface failed durable audit delivery")
+	}
+	if len(store.pending) != 1 {
+		t.Fatalf("pending audits = %d, want 1", len(store.pending))
+	}
+	audit.fail = false
+	reconciler, err := NewGovernanceReconciler(store, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reconciler.Reconcile(context.Background(), "e1"); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.pending) != 0 || audit.once != 2 {
+		t.Fatalf("reconciliation pending=%d attempts=%d", len(store.pending), audit.once)
+	}
+}
+
+func TestPromotionWaitsForDurableVerdictAudit(t *testing.T) {
+	svc, store, _, audit := newSvc()
+	audit.fail = true
+	recorder := &fakePromotionRecorder{}
+	svc.SetPromotionRecorder(recorder)
+	j, err := svc.Propose(context.Background(), "agent:s1", "e1", judgment.CapPromotion, judgment.SubjectFinding, "f1", promo())
+	if err == nil {
+		t.Fatal("proposal audit must fail")
+	}
+	audit.fail = false
+	if err := svc.deliverPendingForJudgment(context.Background(), "e1", j.ID); err != nil {
+		t.Fatal(err)
+	}
+	j = store.saved[0]
+	audit.fail = true
+	if _, err := svc.Verify(context.Background(), "human:bob", "e1", j.ID, 75, "holds", j.Version); err == nil {
+		t.Fatal("verdict audit must fail")
+	}
+	if recorder.attempts != 0 {
+		t.Fatalf("promotion applied before durable verdict audit: %d", recorder.attempts)
 	}
 }

--- a/internal/usecase/evidence/service.go
+++ b/internal/usecase/evidence/service.go
@@ -113,6 +113,128 @@ func (s *Service) Seal(ctx context.Context, engagementID shared.ID, kind string,
 	return s.sealRef(ctx, engagementID, kind, content, "", createdBy)
 }
 
+// SealForFinding appends one sealed link bound to the chain head with a
+// FindingID link. Used by the promotion service to seal finding-linked
+// promotion application evidence.
+func (s *Service) SealForFinding(ctx context.Context, engagementID, findingID shared.ID, kind string, content []byte, createdBy string) (evdom.Evidence, error) {
+	return s.sealRefForFinding(ctx, engagementID, findingID, kind, content, "", createdBy)
+}
+
+// LookupSealedForFinding returns the most recent sealed evidence link of the
+// given kind for the specified finding, or (zero, false, nil) if none exists.
+// Delegates to the underlying store.
+// LookupSealedByID returns a sealed evidence link by stable ID.
+func (s *Service) LookupSealedByID(ctx context.Context, engagementID, evidenceID shared.ID) (evdom.Evidence, bool, error) {
+	items, err := s.store.ListByEngagement(ctx, engagementID)
+	if err != nil {
+		return evdom.Evidence{}, false, fmt.Errorf("list evidence: %w", err)
+	}
+	for _, item := range items {
+		if item.ID == evidenceID {
+			return item, true, nil
+		}
+	}
+	return evdom.Evidence{}, false, nil
+}
+
+// appendReserved appends a deterministic reserved evidence ID exactly once.
+// A retry compares the existing complete payload before accepting it; a
+// conflicting reuse fails closed without adding another chain link.
+func (s *Service) appendReserved(ctx context.Context, link evdom.Evidence) (evdom.Evidence, error) {
+	if existing, found, err := s.LookupSealedByID(ctx, link.EngagementID, link.ID); err != nil {
+		return evdom.Evidence{}, err
+	} else if found {
+		if existing.FindingID == link.FindingID && existing.Kind == link.Kind && string(existing.Content) == string(link.Content) && existing.StorageRef == link.StorageRef && existing.CreatedBy == link.CreatedBy {
+			return existing, nil
+		}
+		return evdom.Evidence{}, fmt.Errorf("evidence id %s conflicts: %w", link.ID, shared.ErrConflict)
+	}
+	if err := s.store.Append(ctx, []evdom.Evidence{link}); err != nil {
+		if errors.Is(err, shared.ErrConflict) {
+			if existing, found, lookupErr := s.LookupSealedByID(ctx, link.EngagementID, link.ID); lookupErr == nil && found {
+				if existing.FindingID == link.FindingID && existing.Kind == link.Kind && string(existing.Content) == string(link.Content) && existing.StorageRef == link.StorageRef && existing.CreatedBy == link.CreatedBy {
+					return existing, nil
+				}
+				return evdom.Evidence{}, fmt.Errorf("evidence id %s conflicts: %w", link.ID, shared.ErrConflict)
+			}
+		}
+		return evdom.Evidence{}, fmt.Errorf("append evidence: %w", err)
+	}
+	s.anchorSealedHead(ctx, link.EngagementID, link.Hash)
+	return link, nil
+}
+
+// SealForFindingWithID appends a finding-linked evidence link with its caller-
+// reserved stable ID. It is used only by crash-recoverable application flows.
+func (s *Service) SealForFindingWithID(ctx context.Context, evidenceID, engagementID, findingID shared.ID, kind string, content []byte, storageRef, createdBy string) (evdom.Evidence, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return evdom.Evidence{}, err
+		}
+		if existing, found, err := s.LookupSealedByID(ctx, engagementID, evidenceID); err != nil {
+			return evdom.Evidence{}, err
+		} else if found {
+			if existing.FindingID == findingID && existing.Kind == kind && string(existing.Content) == string(content) && existing.StorageRef == storageRef && existing.CreatedBy == createdBy {
+				return existing, nil
+			}
+			return evdom.Evidence{}, fmt.Errorf("evidence id %s conflicts: %w", evidenceID, shared.ErrConflict)
+		}
+		prev, err := s.store.Head(ctx, engagementID)
+		if err != nil {
+			return evdom.Evidence{}, fmt.Errorf("evidence head: %w", err)
+		}
+		link := evdom.Evidence{ID: evidenceID, EngagementID: engagementID, FindingID: findingID, Kind: kind, Content: content, StorageRef: storageRef, PreviousHash: prev, CreatedBy: createdBy, CreatedAt: s.clock.Now()}.Seal()
+		ev, err := s.appendReserved(ctx, link)
+		if err == nil {
+			return ev, nil
+		}
+		if !errors.Is(err, shared.ErrConflict) {
+			return evdom.Evidence{}, err
+		}
+		select {
+		case <-ctx.Done():
+			return evdom.Evidence{}, ctx.Err()
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+func (s *Service) sealRefForFinding(ctx context.Context, engagementID, findingID shared.ID, kind string, content []byte, storageRef, createdBy string) (evdom.Evidence, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return evdom.Evidence{}, err
+		}
+		prev, err := s.store.Head(ctx, engagementID)
+		if err != nil {
+			return evdom.Evidence{}, fmt.Errorf("evidence head: %w", err)
+		}
+		link := evdom.Evidence{
+			ID:           s.ids.NewID(),
+			EngagementID: engagementID,
+			FindingID:    findingID,
+			Kind:         kind,
+			Content:      content,
+			StorageRef:   storageRef,
+			PreviousHash: prev,
+			CreatedBy:    createdBy,
+			CreatedAt:    s.clock.Now(),
+		}.Seal()
+		err = s.store.Append(ctx, []evdom.Evidence{link})
+		if err == nil {
+			s.anchorSealedHead(ctx, engagementID, link.Hash)
+			return link, nil
+		}
+		if !errors.Is(err, shared.ErrConflict) {
+			return evdom.Evidence{}, fmt.Errorf("append evidence: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return evdom.Evidence{}, ctx.Err()
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
 func (s *Service) sealRef(ctx context.Context, engagementID shared.ID, kind string, content []byte, storageRef, createdBy string) (evdom.Evidence, error) {
 	// Concurrency-safe append: two writers (e.g. the API + the worker) sealing to
 	// the same engagement chain can both read the same head and FORK it. The store enforces

--- a/internal/usecase/evidence/service_test.go
+++ b/internal/usecase/evidence/service_test.go
@@ -12,8 +12,6 @@ import (
 
 	evdom "github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
-	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
-	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -41,6 +39,69 @@ func (s *memStore) Head(_ context.Context, id shared.ID) (string, error) {
 		return "", nil
 	}
 	return c[len(c)-1].Hash, nil
+}
+
+func (s *memStore) LookupSealedForFinding(_ context.Context, engagementID, findingID shared.ID, kind string) (evdom.Evidence, bool, error) {
+	chain := s.items[engagementID]
+	for i := len(chain) - 1; i >= 0; i-- {
+		e := chain[i]
+		if e.FindingID == findingID && e.Kind == kind {
+			return e, true, nil
+		}
+	}
+	return evdom.Evidence{}, false, nil
+}
+
+type concurrentEvidenceStore struct {
+	mu      sync.Mutex
+	items   map[shared.ID][]evdom.Evidence
+	tenants map[shared.ID]shared.ID
+}
+
+func newConcurrentEvidenceStore() *concurrentEvidenceStore {
+	return &concurrentEvidenceStore{items: map[shared.ID][]evdom.Evidence{}, tenants: map[shared.ID]shared.ID{}}
+}
+func (s *concurrentEvidenceStore) Append(ctx context.Context, items []evdom.Evidence) error {
+	tenant, _ := shared.TenantFrom(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range items {
+		if existing, ok := s.tenants[e.EngagementID]; ok && existing != tenant {
+			return shared.ErrNotFound
+		}
+		if list := s.items[e.EngagementID]; len(list) > 0 && e.PreviousHash != list[len(list)-1].Hash {
+			return shared.ErrConflict
+		}
+		s.tenants[e.EngagementID] = tenant
+		s.items[e.EngagementID] = append(s.items[e.EngagementID], e)
+	}
+	return nil
+}
+func (s *concurrentEvidenceStore) ListByEngagement(ctx context.Context, id shared.ID) ([]evdom.Evidence, error) {
+	tenant, _ := shared.TenantFrom(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.tenants[id]; ok && existing != tenant {
+		return nil, shared.ErrNotFound
+	}
+	return append([]evdom.Evidence(nil), s.items[id]...), nil
+}
+func (s *concurrentEvidenceStore) Head(ctx context.Context, id shared.ID) (string, error) {
+	items, err := s.ListByEngagement(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if len(items) == 0 {
+		return "", nil
+	}
+	return items[len(items)-1].Hash, nil
+}
+
+type randomTestIDs struct{ n int64 }
+
+func (g *randomTestIDs) NewID() shared.ID {
+	g.n++
+	return shared.ID("test-" + strconv.FormatInt(g.n, 10))
 }
 
 type memBlobs struct{ m map[string][]byte }
@@ -386,8 +447,8 @@ func TestVerifyNoAnchorWithoutTimestamper(t *testing.T) {
 // chain concurrently must never fork it – the store's one-child-per-parent guard +
 // re-chain-on-conflict keeps the chain strictly linear and intact.
 func TestSealConcurrentStaysLinear(t *testing.T) {
-	store := memory.NewEvidenceStore()
-	svc, err := NewService(store, nil, &capAudit{}, fixedClock{t: time.Unix(0, 0).UTC()}, idgen.RandomID{})
+	store := newConcurrentEvidenceStore()
+	svc, err := NewService(store, nil, &capAudit{}, fixedClock{t: time.Unix(0, 0).UTC()}, &randomTestIDs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -419,5 +480,122 @@ func TestSealConcurrentStaysLinear(t *testing.T) {
 		if chain[j].PreviousHash != chain[j-1].Hash {
 			t.Fatalf("chain FORKED at link %d: previous_hash=%s, want %s", j, chain[j].PreviousHash, chain[j-1].Hash)
 		}
+	}
+}
+
+func TestSealRejectsCrossTenantAppendWithoutChangingChain(t *testing.T) {
+	store := newConcurrentEvidenceStore()
+	svc, err := NewService(store, nil, &capAudit{}, fixedClock{t: time.Unix(0, 0).UTC()}, &randomTestIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner := shared.WithTenant(context.Background(), "tenant-owner")
+	other := shared.WithTenant(context.Background(), "tenant-other")
+	if _, err := svc.Seal(owner, "eng-tenant", "scan", []byte("owner"), "operator"); err != nil {
+		t.Fatalf("owner seal: %v", err)
+	}
+	before, err := store.ListByEngagement(owner, "eng-tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := store.Head(owner, "eng-tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Seal(other, "eng-tenant", "scan", []byte("other"), "operator"); err == nil {
+		t.Fatal("cross-tenant append unexpectedly succeeded")
+	}
+	after, err := store.ListByEngagement(owner, "eng-tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterHead, err := store.Head(owner, "eng-tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) || afterHead != head {
+		t.Fatalf("cross-tenant append changed chain: before=%d/%s after=%d/%s", len(before), head, len(after), afterHead)
+	}
+}
+
+func TestSealForFindingWithIDReplaysExactlyAndRejectsConflicts(t *testing.T) {
+	store := newConcurrentEvidenceStore()
+	svc, err := NewService(store, nil, &capAudit{}, fixedClock{t: time.Unix(0, 0).UTC()}, &randomTestIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := shared.WithTenant(context.Background(), "tenant-evidence")
+	const n = 64
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = svc.SealForFindingWithID(ctx, "reserved-evidence", "eng-evidence", "finding-evidence", "promotion_application", []byte("sealed"), "", "system:promotion")
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("exact replay %d: %v", i, err)
+		}
+	}
+	items, err := store.ListByEngagement(ctx, "eng-evidence")
+	if err != nil || len(items) != 1 {
+		t.Fatalf("reserved replay links=%d err=%v, want one", len(items), err)
+	}
+	if _, err := svc.SealForFindingWithID(ctx, "reserved-evidence", "eng-evidence", "finding-evidence", "promotion_application", []byte("altered"), "", "system:promotion"); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("altered payload = %v, want conflict", err)
+	}
+	if _, err := svc.SealForFindingWithID(ctx, "reserved-evidence", "eng-evidence", "other-finding", "promotion_application", []byte("sealed"), "", "system:promotion"); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("altered finding = %v, want conflict", err)
+	}
+	if _, err := svc.SealForFindingWithID(shared.WithTenant(context.Background(), "other-tenant"), "reserved-evidence", "eng-evidence", "finding-evidence", "promotion_application", []byte("sealed"), "", "system:promotion"); err == nil {
+		t.Fatal("cross-tenant replay unexpectedly succeeded")
+	}
+}
+
+func TestSealForFindingWithIDHighContentionStaysLinear(t *testing.T) {
+	store := newConcurrentEvidenceStore()
+	svc, err := NewService(store, nil, &capAudit{}, fixedClock{t: time.Unix(0, 0).UTC()}, &randomTestIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(shared.WithTenant(context.Background(), "tenant-evidence"), 10*time.Second)
+	defer cancel()
+	const writers = 64
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := shared.ID("reserved-" + strconv.Itoa(i))
+			_, errs[i] = svc.SealForFindingWithID(ctx, id, "eng-evidence", "finding-evidence", "promotion_application", []byte(strconv.Itoa(i)), "", "system:promotion")
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("writer %d: %v", i, err)
+		}
+	}
+	items, err := store.ListByEngagement(ctx, "eng-evidence")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != writers {
+		t.Fatalf("links = %d, want %d", len(items), writers)
+	}
+	ids := make(map[shared.ID]struct{}, len(items))
+	for _, item := range items {
+		if _, exists := ids[item.ID]; exists {
+			t.Fatalf("duplicate evidence ID %s", item.ID)
+		}
+		ids[item.ID] = struct{}{}
+	}
+	if err := evdom.VerifyChain(items); err != nil {
+		t.Fatalf("chain invalid: %v", err)
 	}
 }

--- a/internal/usecase/findings/service_test.go
+++ b/internal/usecase/findings/service_test.go
@@ -59,6 +59,9 @@ func (f *fakeRepo) SetAssignee(_ context.Context, _, _ shared.ID, a string, ver 
 	f.called, f.assignee, f.gotVer = true, a, ver
 	return f.ret, f.err
 }
+func (f *fakeRepo) GetByEngagementAndID(_ context.Context, _, _ shared.ID) (finding.Finding, error) {
+	return f.ret, f.err
+}
 
 type fakeComments struct {
 	added []finding.Comment

--- a/internal/usecase/llmverifier/coordinator.go
+++ b/internal/usecase/llmverifier/coordinator.go
@@ -100,7 +100,7 @@ func (c *Coordinator) AutoVerify(ctx context.Context, engagementID shared.ID, tr
 		if ctx.Err() != nil {
 			break
 		}
-		if j.State != judgment.StateProposed || !j.Capability.Gated() {
+		if j.State != judgment.StateProposed || !j.Capability.Gated() || j.Capability == judgment.CapPromotion {
 			continue
 		}
 		// Never confirm a claim this verifier proposed (the analysis gate enforces this too; skipping

--- a/internal/usecase/llmverifier/coordinator_test.go
+++ b/internal/usecase/llmverifier/coordinator_test.go
@@ -82,6 +82,19 @@ func TestAutoVerifyConfirmsAndRefutes(t *testing.T) {
 	}
 }
 
+func TestAutoVerifySkipsPromotion(t *testing.T) {
+	ver := &fakeVerifier{}
+	c := New(fakeLLM{content: `{"score":99,"rationale":"promotion looks good"}`}, "cx/proposer", "cx/verifier", ver,
+		fakeLister{js: []judgment.Judgment{{ID: "p1", Capability: judgment.CapPromotion, State: judgment.StateProposed, ProposedBy: "agent:x"}}})
+	res, err := c.AutoVerify(context.Background(), "eng", "human:tester")
+	if err != nil {
+		t.Fatalf("AutoVerify: %v", err)
+	}
+	if res != (Result{}) || len(ver.calls) != 0 {
+		t.Fatalf("promotion must not be LLM verified: result=%+v calls=%+v", res, ver.calls)
+	}
+}
+
 func TestAutoVerifyLowScoreRefutes(t *testing.T) {
 	c := New(fakeLLM{content: `{"score":40,"rationale":"finding looks real"}`}, "cx/proposer", "cx/verifier", &fakeVerifier{},
 		fakeLister{js: []judgment.Judgment{critique("1", "agent:x", judgment.StateProposed)}})

--- a/internal/usecase/llmverifier/live_test.go
+++ b/internal/usecase/llmverifier/live_test.go
@@ -24,7 +24,8 @@ func (noopSealer) Seal(_ context.Context, _ shared.ID, kind string, _ []byte, _ 
 
 type noopAudit struct{}
 
-func (noopAudit) Record(_ context.Context, _ ports.AuditEntry) error { return nil }
+func (noopAudit) Record(_ context.Context, _ ports.AuditEntry) error     { return nil }
+func (noopAudit) RecordOnce(_ context.Context, _ ports.AuditEntry) error { return nil }
 
 type sysClock struct{}
 

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -25,6 +25,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/projectanalysis"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/promotion"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualityprofile"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
@@ -307,11 +308,14 @@ type EngagementRepository interface {
 	Delete(ctx context.Context, id shared.ID) error
 }
 
-// ProjectEngagementLister is an optional read extension for tenant-wide operational dashboards.
-// Project analysis contexts are intentionally hidden from EngagementRepository.List, so callers that
-// need project metrics must opt into this tenant-scoped projection instead of weakening List semantics.
-type ProjectEngagementLister interface {
-	ListProjectEngagements(ctx context.Context, tenantID shared.ID) ([]*engagement.Engagement, error)
+// EngagementOwnershipReader is a narrow interface for verifying that an
+// engagement belongs to a given tenant. Used by the in-memory PromotionStore
+// to enforce tenant-ownership before mutation (the postgres adapter handles
+// this via RLS). EngagementRepository satisfies this interface.
+type EngagementOwnershipReader interface {
+	// GetByIDInTenant loads an engagement by id scoped to tenantID.
+	// Returns ErrNotFound if the engagement does not exist in that tenant.
+	GetByIDInTenant(ctx context.Context, tenantID, id shared.ID) (*engagement.Engagement, error)
 }
 
 // JudgmentStore is the broad read/create repository for AI judgments. The
@@ -319,6 +323,45 @@ type ProjectEngagementLister interface {
 // interface + the concrete repo, so a read-only consumer (e.g. the agent tool catalog) cannot move
 // a judgment's score. Reads are engagement-scoped (tenant-isolated via the
 // engagement gate).
+// ProjectEngagementLister is an optional read extension for tenant-wide operational dashboards.
+type ProjectEngagementLister interface {
+	ListProjectEngagements(ctx context.Context, tenantID shared.ID) ([]*engagement.Engagement, error)
+}
+
+// GovernanceReconciler repairs durable governance side effects for one engagement.
+type GovernanceReconciler interface {
+	Reconcile(ctx context.Context, engagementID shared.ID) error
+}
+
+// JudgmentAuditKind identifies the immutable lifecycle transition whose audit record
+// is awaiting durable delivery.
+type JudgmentAuditKind string
+
+const (
+	JudgmentProposalAudit JudgmentAuditKind = "proposal"
+	JudgmentVerdictAudit  JudgmentAuditKind = "verdict"
+)
+
+// PendingJudgmentAudit is an immutable audit payload committed with its judgment
+// mutation. Version identifies a verdict transition; proposals use the inserted
+// judgment version.
+type PendingJudgmentAudit struct {
+	Kind         JudgmentAuditKind
+	JudgmentID   shared.ID
+	Version      int
+	EngagementID shared.ID
+	Entry        AuditEntry
+}
+
+// JudgmentAuditStore keeps judgment persistence and governance-audit outbox state
+// atomic. It is intentionally separate from the broad JudgmentStore read/create port.
+type JudgmentAuditStore interface {
+	SaveWithProposalAudit(ctx context.Context, j judgment.Judgment, entry AuditEntry) error
+	SetVerdictStateWithAudit(ctx context.Context, engagementID, id shared.ID, score int, state judgment.State, verifiedBy, rationale string, expectedVersion int, entry AuditEntry) (judgment.Judgment, error)
+	ListPendingJudgmentAudits(ctx context.Context, engagementID shared.ID) ([]PendingJudgmentAudit, error)
+	AcknowledgeJudgmentAudit(ctx context.Context, kind JudgmentAuditKind, judgmentID shared.ID, version int) error
+}
+
 type JudgmentStore interface {
 	// Save persists a proposed judgment (idempotent by id; never moves an existing row's score).
 	Save(ctx context.Context, j judgment.Judgment) error
@@ -367,6 +410,9 @@ type EngagementTenantResolver interface {
 type FindingRepository interface {
 	Upsert(ctx context.Context, findings []finding.Finding) error
 	ListByEngagement(ctx context.Context, engagementID shared.ID) ([]finding.Finding, error)
+	// GetByEngagementAndID loads a single finding by engagement and finding ID.
+	// Returns shared.ErrNotFound if no such finding exists in the engagement.
+	GetByEngagementAndID(ctx context.Context, engagementID, findingID shared.ID) (finding.Finding, error)
 	// ListPublishableByEngagement returns ONLY the findings that may appear in a
 	// customer-facing deliverable – the evidence gate applied via
 	// finding.Publishable/CanPromote. Every client-facing reader (report PDF/HTML/DOCX,
@@ -397,6 +443,108 @@ type CommentRepository interface {
 type RetestRepository interface {
 	Add(ctx context.Context, r finding.Retest) error
 	ListByEngagementFinding(ctx context.Context, engagementID, findingID shared.ID) ([]finding.Retest, error)
+}
+
+// PromotionCommand bundles every input the store needs to atomically construct,
+// validate, and persist a PromotionEvent plus the matching finding mutation.
+// The store derives AfterFindingVersion from FindingVersion and Effect, and
+// constructs the event from the remaining fields. Tenant is always derived
+// from context (shared.WithTenant / shared.TenantFrom), never from the
+// command, so an untrusted caller cannot forge cross-tenant writes.
+//
+// Idempotency: a command whose JudgmentID matches an existing event returns
+// the existing event (exact replay). A command whose Fingerprint matches but
+// whose JudgmentID differs is a semantic conflict (shared.ErrConflict).
+type PromotionCommand struct {
+	// CAS (compare-and-swap) fields: the store verifies the finding's current
+	// priority and version match before applying any mutation. A mismatch
+	// returns shared.ErrConflict (lost-update guard).
+	ExpectedPriority int
+	ExpectedVersion  int
+
+	// Event construction fields – these become immutable event metadata.
+	EventID        shared.ID
+	JudgmentID     shared.ID
+	FindingVersion int // the finding version BEFORE this promotion (≥1)
+	Rule           string
+	Effect         judgment.PromotionChange
+	BeforePriority int
+	AfterPriority  int
+	Inputs         []judgment.PromotionInput
+	Fingerprint    string
+
+	// Verdict metadata from the sealed judgment (if available).
+	VerdictScore     int
+	VerdictRationale string
+	EvidenceID       shared.ID
+	Verifier         string
+
+	// Uncertainty carries the sorted distinct tokens from the claim that
+	// describe why this promotion was flagged for review. Empty for
+	// deterministic effects. Preserved so that event construction can
+	// round-trip through PromotionClaim.Validate without losing semantics.
+	Uncertainty []string
+
+	// AppliedBy is the actor (human or service identity) that requests this
+	// promotion. Empty means system/unknown.
+	AppliedBy string
+}
+
+// PromotionStore persists promotion lifecycle events (the immutable record of
+// applied finding-priority changes). Apply is the single mutation surface:
+//   - Constructs and validates a PromotionEvent from the command, then
+//     atomically persists the finding mutation + event in one transaction.
+//   - Idempotent by (tenant, judgmentID): re-applying the same judgment
+//     returns the existing event without side effects. A matching fingerprint
+//     with a different judgmentID is a semantic conflict.
+//   - Validates that the finding's current priority matches
+//     command.ExpectedPriority and its version matches command.ExpectedVersion
+//     (CAS) before any mutation.
+//   - For escalate/de_escalate, bumps the finding's version and moves its
+//     priority atomically.
+//   - For flag_for_review, records the event without mutating the finding
+//     (no version bump, no priority change).
+//
+// Returns shared.ErrConflict on a CAS or idempotency mismatch,
+// shared.ErrNotFound if the finding or engagement does not exist.
+type PromotionEvaluator interface {
+	Evaluate(ctx context.Context, engagementID shared.ID) (int, error)
+}
+
+// PromotionReconciler restores promotion lifecycle work after a process failure.
+// It is intentionally separate from PromotionEvaluator: evaluators propose only.
+type PromotionReconciler interface {
+	Reconcile(ctx context.Context, engagementID shared.ID) error
+}
+
+type PromotionReconciliationScopeReader interface {
+	ListPromotionReconciliationScopes(ctx context.Context) ([]PromotionReconciliationScope, error)
+}
+
+type PromotionReconciliationScope struct {
+	TenantID     shared.ID
+	EngagementID shared.ID
+}
+
+type PromotionStore interface {
+	Apply(ctx context.Context, engagementID, findingID shared.ID, cmd PromotionCommand) (finding.Finding, error)
+	ListByFinding(ctx context.Context, engagementID, findingID shared.ID) ([]promotion.PromotionEvent, error)
+	LatestByFinding(ctx context.Context, engagementID, findingID shared.ID) (promotion.PromotionEvent, bool, error)
+	FindByJudgment(ctx context.Context, engagementID, findingID, judgmentID shared.ID) (promotion.PromotionEvent, bool, error)
+}
+
+// PromotionAuditTracker is the recovery-only audit-status authority. Proposal
+// evaluation and read paths do not receive it.
+type PromotionAuditTracker interface {
+	ListPendingAudits(ctx context.Context, engagementID shared.ID) ([]promotion.PromotionEvent, error)
+	MarkAuditComplete(ctx context.Context, eventID shared.ID) error
+}
+
+// PendingPromotionAuditStore combines lifecycle storage with audit-status
+// tracking for the confirmed recorder, which needs both capabilities.
+type PendingPromotionAuditStore interface {
+	PromotionStore
+	PromotionAuditTracker
 }
 
 // Provenance is the static tool/library version context captured at startup for
@@ -652,6 +800,14 @@ type AuditEntry struct {
 // tamper-evident; callers leave those fields zero.
 type AuditLogger interface {
 	Record(ctx context.Context, e AuditEntry) error
+}
+
+// IdempotentAuditLogger records an entry at most once when Metadata contains a
+// deterministic idempotency_key. Durable audit implementations use the key to
+// recover from a committed write whose acknowledgement was lost.
+type IdempotentAuditLogger interface {
+	AuditLogger
+	RecordOnce(ctx context.Context, e AuditEntry) error
 }
 
 // AuditReader reads the append-only audit log for the audit-trail UI. List
@@ -1186,6 +1342,11 @@ type ConfirmedSASTRecorder interface {
 // and it is never agent-reachable (the agent proposes; a distinct verifier confirms).
 type ConfirmedDASTRecorder interface {
 	RecordConfirmedDAST(ctx context.Context, verifier string, j judgment.Judgment) error
+}
+
+// ConfirmedPromotionRecorder applies a promotion only after the existing judgment gate seals a distinct verdict.
+type ConfirmedPromotionRecorder interface {
+	RecordConfirmed(ctx context.Context, j judgment.Judgment) error
 }
 
 // FindingWriteupApplier applies an accepted, human-signed-off write-up draft to its finding: it sets

--- a/internal/usecase/promotion/runner.go
+++ b/internal/usecase/promotion/runner.go
@@ -1,0 +1,89 @@
+package promotion
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ReconciliationRunner invokes a reconciler for every discovered tenant-bound engagement.
+type ReconciliationRunner struct {
+	scopes     ports.PromotionReconciliationScopeReader
+	evaluator  ports.PromotionEvaluator
+	reconciler ports.PromotionReconciler
+	governance ports.GovernanceReconciler
+	log        *slog.Logger
+}
+
+func NewReconciliationRunner(scopes ports.PromotionReconciliationScopeReader, evaluator ports.PromotionEvaluator, reconciler ports.PromotionReconciler, log *slog.Logger) (*ReconciliationRunner, error) {
+	if scopes == nil || evaluator == nil || reconciler == nil || log == nil {
+		return nil, fmt.Errorf("%w: promotion reconciliation runner is missing a dependency", shared.ErrValidation)
+	}
+	return &ReconciliationRunner{scopes: scopes, evaluator: evaluator, reconciler: reconciler, log: log}, nil
+}
+
+// SetGovernanceReconciler adds server-only durable governance recovery without
+// granting the evaluator or any read path mutation authority.
+func (r *ReconciliationRunner) SetGovernanceReconciler(governance ports.GovernanceReconciler) {
+	r.governance = governance
+}
+
+// RunOnce reconciles every scope. Per-scope failures are logged and do not block
+// other tenants; scope discovery and cancellation failures are returned.
+func (r *ReconciliationRunner) RunOnce(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	scopes, err := r.scopes.ListPromotionReconciliationScopes(ctx)
+	if err != nil {
+		return fmt.Errorf("list promotion reconciliation scopes: %w", err)
+	}
+	for _, scope := range scopes {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if scope.TenantID.IsZero() || scope.EngagementID.IsZero() {
+			r.log.Error("promotion reconciliation scope is invalid", "tenant", scope.TenantID, "engagement", scope.EngagementID)
+			continue
+		}
+		scopeCtx := shared.WithTenant(ctx, scope.TenantID)
+		// A confirmed promotion can only be applied after its verdict audit outbox is
+		// delivered. Do this recovery first and skip the mutating reconciler on failure.
+		if r.governance != nil {
+			if err := r.governance.Reconcile(scopeCtx, scope.EngagementID); err != nil {
+				r.log.Error("governance reconciliation failed", "tenant", scope.TenantID, "engagement", scope.EngagementID, "err", err)
+				continue
+			}
+		}
+		if _, err := r.evaluator.Evaluate(scopeCtx, scope.EngagementID); err != nil {
+			r.log.Error("promotion evaluation failed", "tenant", scope.TenantID, "engagement", scope.EngagementID, "err", err)
+		}
+		if err := r.reconciler.Reconcile(scopeCtx, scope.EngagementID); err != nil {
+			r.log.Error("promotion reconciliation failed", "tenant", scope.TenantID, "engagement", scope.EngagementID, "err", err)
+		}
+	}
+	return nil
+}
+
+// RunPeriodic reconciles at interval until ctx is cancelled.
+func (r *ReconciliationRunner) RunPeriodic(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := r.RunOnce(ctx); err != nil && ctx.Err() == nil {
+				r.log.Error("promotion reconciliation run failed", "err", err)
+			}
+		}
+	}
+}

--- a/internal/usecase/promotion/runner_test.go
+++ b/internal/usecase/promotion/runner_test.go
@@ -1,0 +1,118 @@
+package promotion
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type reconciliationScopeReaderStub struct {
+	scopes []ports.PromotionReconciliationScope
+	err    error
+}
+
+func (s reconciliationScopeReaderStub) ListPromotionReconciliationScopes(context.Context) ([]ports.PromotionReconciliationScope, error) {
+	return s.scopes, s.err
+}
+
+type reconciliationStub struct {
+	calls  []ports.PromotionReconciliationScope
+	fail   shared.ID
+	cancel context.CancelFunc
+}
+
+type evaluationStub struct {
+	calls []ports.PromotionReconciliationScope
+}
+
+func (e *evaluationStub) Evaluate(ctx context.Context, engagementID shared.ID) (int, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return 0, errors.New("missing tenant context")
+	}
+	e.calls = append(e.calls, ports.PromotionReconciliationScope{TenantID: tenantID, EngagementID: engagementID})
+	return 0, nil
+}
+
+var _ ports.PromotionEvaluator = (*evaluationStub)(nil)
+
+func (r *reconciliationStub) Reconcile(ctx context.Context, engagementID shared.ID) error {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return errors.New("missing tenant context")
+	}
+	r.calls = append(r.calls, ports.PromotionReconciliationScope{TenantID: tenantID, EngagementID: engagementID})
+	if r.cancel != nil {
+		r.cancel()
+	}
+	if engagementID == r.fail {
+		return errors.New("reconcile failure")
+	}
+	return nil
+}
+
+func newReconciliationRunner(t *testing.T, scopes ports.PromotionReconciliationScopeReader, evaluator ports.PromotionEvaluator, reconciler ports.PromotionReconciler) *ReconciliationRunner {
+	t.Helper()
+	runner, err := NewReconciliationRunner(scopes, evaluator, reconciler, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runner
+}
+
+func TestReconciliationRunnerBindsEveryScopeTenant(t *testing.T) {
+	reconciler := &reconciliationStub{}
+	evaluator := &evaluationStub{}
+	runner := newReconciliationRunner(t, reconciliationScopeReaderStub{scopes: []ports.PromotionReconciliationScope{
+		{TenantID: "tenant-a", EngagementID: "eng-a"},
+		{TenantID: "tenant-b", EngagementID: "eng-b"},
+	}}, evaluator, reconciler)
+	if err := runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	want := []ports.PromotionReconciliationScope{{TenantID: "tenant-a", EngagementID: "eng-a"}, {TenantID: "tenant-b", EngagementID: "eng-b"}}
+	if len(reconciler.calls) != len(want) {
+		t.Fatalf("reconciliation calls = %#v, want %#v", reconciler.calls, want)
+	}
+	for i := range want {
+		if evaluator.calls[i] != want[i] || reconciler.calls[i] != want[i] {
+			t.Fatalf("scope %d evaluated=%#v reconciled=%#v, want %#v", i, evaluator.calls[i], reconciler.calls[i], want[i])
+		}
+	}
+}
+
+func TestReconciliationRunnerContinuesAfterScopeFailure(t *testing.T) {
+	reconciler := &reconciliationStub{fail: "eng-a"}
+	evaluator := &evaluationStub{}
+	runner := newReconciliationRunner(t, reconciliationScopeReaderStub{scopes: []ports.PromotionReconciliationScope{
+		{TenantID: "tenant-a", EngagementID: "eng-a"},
+		{TenantID: "tenant-b", EngagementID: "eng-b"},
+	}}, evaluator, reconciler)
+	if err := runner.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(reconciler.calls) != 2 || reconciler.calls[1].EngagementID != "eng-b" {
+		t.Fatalf("calls after failed scope = %#v, want both scopes", reconciler.calls)
+	}
+}
+
+func TestReconciliationRunnerHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reconciler := &reconciliationStub{cancel: cancel}
+	evaluator := &evaluationStub{}
+	runner := newReconciliationRunner(t, reconciliationScopeReaderStub{scopes: []ports.PromotionReconciliationScope{
+		{TenantID: "tenant-a", EngagementID: "eng-a"},
+		{TenantID: "tenant-b", EngagementID: "eng-b"},
+	}}, evaluator, reconciler)
+	if err := runner.RunOnce(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunOnce error = %v, want context.Canceled", err)
+	}
+	if len(reconciler.calls) != 1 {
+		t.Fatalf("calls after cancellation = %#v, want first scope only", reconciler.calls)
+	}
+}

--- a/internal/usecase/promotion/service.go
+++ b/internal/usecase/promotion/service.go
@@ -1,0 +1,1153 @@
+// Package promotion implements the use-case layer for deterministic finding-priority
+// promotion. It contains two narrow authorities:
+//
+//   - [Evaluator]: loads findings, attack-path graph, detections, and reachability
+//     judgments, builds [promotion.Snapshot] values, calls the pure [promotion.Evaluate]
+//     function, and proposes typed [judgment.PromotionClaim] judgments. Its local reader
+//     interfaces expose no finding, judgment, or promotion mutation.
+//
+//   - [ConfirmedRecorder]: receives an already publishable confirmed
+//     [judgment.Judgment] with CapPromotion, seals a finding-linked evidence
+//     payload, and atomically applies the promotion through [ports.PromotionStore].
+//
+// Neither authority imports model/pillar/MCP code. Inputs are sourced, sorted, and
+// tenant-bound; the caller never provides a tenant ID.
+package promotion
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/promotion"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/verdict"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+
+	evdom "github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
+)
+
+// proposer is the narrow judgment-lifecycle slice the evaluator needs.
+// It has NO Verify, Accept, or List methods; the evaluator can only propose.
+type proposer interface {
+	Propose(ctx context.Context, proposer string, engagementID shared.ID, capability judgment.Capability, subjectKind judgment.SubjectKind, subjectID shared.ID, claim judgment.Claim) (judgment.Judgment, error)
+}
+
+type findingReader interface {
+	ListByEngagement(context.Context, shared.ID) ([]finding.Finding, error)
+}
+
+type confirmedFindingReader interface {
+	GetByEngagementAndID(context.Context, shared.ID, shared.ID) (finding.Finding, error)
+}
+
+type confirmedPromotionStore interface {
+	Apply(context.Context, shared.ID, shared.ID, ports.PromotionCommand) (finding.Finding, error)
+	FindByJudgment(context.Context, shared.ID, shared.ID, shared.ID) (promotion.PromotionEvent, bool, error)
+	MarkAuditComplete(context.Context, shared.ID) error
+}
+
+type judgmentReader interface {
+	ListByEngagement(context.Context, shared.ID) ([]judgment.Judgment, error)
+}
+
+type attackPathReader interface {
+	ListBindings(context.Context, shared.ID) ([]attackpath.Binding, error)
+}
+
+type assetReader interface {
+	ListAssets(context.Context, shared.ID) ([]*asset.Asset, error)
+	ListEdges(context.Context, shared.ID) ([]*asset.Edge, error)
+}
+
+type detectionReader interface {
+	ListDetections(context.Context, shared.ID) ([]detection.Record, error)
+}
+
+type engagementReader interface {
+	GetByIDInTenant(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error)
+}
+
+type promotionEventReader interface {
+	ListByFinding(context.Context, shared.ID, shared.ID) ([]promotion.PromotionEvent, error)
+}
+
+type clock interface {
+	Now() time.Time
+}
+
+type proposalAuditRecorder interface {
+	RecordOnce(context.Context, ports.AuditEntry) error
+}
+
+type confirmedAuditRecorder interface {
+	RecordOnce(context.Context, ports.AuditEntry) error
+}
+
+// proposerActor is the reserved, non-agent identity that proposes promotion claims.
+const proposerActor = "system:promotion"
+
+// PromotionEvidenceKind is the evidence-chain kind for sealed promotion applications.
+const PromotionEvidenceKind = "promotion_application"
+
+// ---------------------------------------------------------------------------
+// Evaluator
+// ---------------------------------------------------------------------------
+
+// Evaluator loads deterministic inputs and proposes promotion claims. It holds no
+// finding, judgment, or promotion mutation authority.
+type Evaluator struct {
+	proposer   proposer
+	findings   findingReader
+	judgments  judgmentReader
+	bindings   attackPathReader
+	assets     assetReader
+	detections detectionReader
+	engagement engagementReader
+	promotions promotionEventReader
+	clock      clock
+	audit      proposalAuditRecorder
+}
+
+// NewEvaluator validates dependencies and returns an Evaluator.
+func NewEvaluator(
+	p proposer,
+	findings findingReader,
+	judgments judgmentReader,
+	bindings attackPathReader,
+	assets assetReader,
+	detections detectionReader,
+	engagement engagementReader,
+	promotions promotionEventReader,
+	clock clock,
+	audit proposalAuditRecorder,
+) (*Evaluator, error) {
+	if p == nil || findings == nil || judgments == nil || bindings == nil ||
+		assets == nil || detections == nil || engagement == nil || promotions == nil ||
+		clock == nil || audit == nil {
+		return nil, fmt.Errorf("%w: promotion evaluator is missing a dependency", shared.ErrValidation)
+	}
+	return &Evaluator{
+		proposer: p, findings: findings, judgments: judgments, bindings: bindings,
+		assets: assets, detections: detections, engagement: engagement,
+		promotions: promotions, clock: clock, audit: audit,
+	}, nil
+}
+
+// Evaluate loads all promotion-relevant signals for the engagement, evaluates
+// the deterministic promotion rules for every finding, and proposes new
+// [judgment.PromotionClaim] judgments through the narrow proposer. It requires
+// tenant context and validates engagement ownership through the chokepoint.
+//
+// Stable ordering: findings are sorted by ID; duplicate fingerprints are
+// skipped; existing proposals with unchanged fingerprints are not re-proposed.
+// Evaluate never verifies or mutates a finding.
+func (e *Evaluator) Evaluate(ctx context.Context, engagementID shared.ID) (int, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return 0, fmt.Errorf("%w: promotion evaluation requires tenant context", shared.ErrValidation)
+	}
+	if engagementID.IsZero() {
+		return 0, fmt.Errorf("%w: engagement id is required", shared.ErrValidation)
+	}
+	if _, err := e.engagement.GetByIDInTenant(ctx, tenantID, engagementID); err != nil {
+		return 0, fmt.Errorf("validate engagement ownership: %w", err)
+	}
+	findings, err := e.findings.ListByEngagement(ctx, engagementID)
+	if err != nil {
+		return 0, fmt.Errorf("list findings: %w", err)
+	}
+	sort.Slice(findings, func(i, j int) bool { return findings[i].ID < findings[j].ID })
+	judgments, err := e.judgments.ListByEngagement(ctx, engagementID)
+	if err != nil {
+		return 0, fmt.Errorf("list judgments: %w", err)
+	}
+	reachabilityByFinding := indexReachability(judgments)
+	existingProposals := indexPromotionProposals(judgments)
+	allBindings, err := e.bindings.ListBindings(ctx, tenantID)
+	if err != nil {
+		return 0, fmt.Errorf("list attack-path bindings: %w", err)
+	}
+	findingSet := make(map[shared.ID]struct{}, len(findings))
+	for _, f := range findings {
+		findingSet[f.ID] = struct{}{}
+	}
+	bindings := make([]attackpath.Binding, 0, len(allBindings))
+	for _, b := range allBindings {
+		if b.EngagementID == engagementID {
+			if _, ok := findingSet[b.FindingID]; ok {
+				bindings = append(bindings, b)
+			}
+		}
+	}
+	assetsList, err := e.assets.ListAssets(ctx, tenantID)
+	if err != nil {
+		return 0, fmt.Errorf("list assets: %w", err)
+	}
+	edgePtrs, err := e.assets.ListEdges(ctx, tenantID)
+	if err != nil {
+		return 0, fmt.Errorf("list edges: %w", err)
+	}
+	edges := make([]asset.Edge, len(edgePtrs))
+	for i, ep := range edgePtrs {
+		edges[i] = *ep
+	}
+	graph, err := buildGraph(tenantID, assetsList, edges, bindings, findings, reachabilityByFinding)
+	if err != nil {
+		return 0, fmt.Errorf("build attack-path graph: %w", err)
+	}
+	detRecords, err := e.detections.ListDetections(ctx, engagementID)
+	if err != nil {
+		return 0, fmt.Errorf("list detections: %w", err)
+	}
+	activeDetections := filterActive(detRecords, e.clock.Now())
+	latestEvents, err := e.loadLatestEvents(ctx, engagementID, findings, graph, activeDetections, reachabilityByFinding)
+	if err != nil {
+		return 0, fmt.Errorf("load latest promotion events: %w", err)
+	}
+
+	proposed := 0
+	for _, f := range findings {
+		snap, err := e.buildSnapshot(ctx, f, graph, activeDetections, reachabilityByFinding, latestEvents)
+		if err != nil {
+			return proposed, fmt.Errorf("build promotion snapshot for finding %s: %w", f.ID, err)
+		}
+		claim, err := promotion.Evaluate(snap)
+		if err != nil {
+			return proposed, fmt.Errorf("evaluate finding %s: %w", f.ID, err)
+		}
+		if claim == nil {
+			continue
+		}
+		if _, ok := existingProposals[f.ID][claim.Fingerprint]; ok {
+			if err := e.recordProposalAudit(ctx, engagementID, f.ID, claim); err != nil {
+				return proposed, err
+			}
+			continue
+		}
+		if _, err := e.proposer.Propose(ctx, proposerActor, engagementID, judgment.CapPromotion, judgment.SubjectFinding, f.ID, claim); err != nil {
+			return proposed, fmt.Errorf("propose promotion for finding %s: %w", f.ID, err)
+		}
+		if err := e.recordProposalAudit(ctx, engagementID, f.ID, claim); err != nil {
+			return proposed, err
+		}
+		proposed++
+	}
+	return proposed, nil
+}
+
+// recordProposalAudit appends the audit record only after proposal persistence.
+// The deterministic key lets retries recover a proposal whose audit write failed.
+func (e *Evaluator) recordProposalAudit(ctx context.Context, engagementID, findingID shared.ID, claim *judgment.PromotionClaim) error {
+	if err := e.audit.RecordOnce(ctx, ports.AuditEntry{
+		Actor:  proposerActor,
+		Action: "promotion.proposed",
+		Target: findingID.String(),
+		Metadata: map[string]string{
+			"idempotency_key": "promotion.proposed:" + engagementID.String() + ":" + findingID.String() + ":" + claim.Fingerprint,
+			"engagement":      engagementID.String(),
+			"finding":         findingID.String(),
+			"rule":            claim.Rule,
+			"effect":          string(claim.Proposed),
+			"fingerprint":     claim.Fingerprint,
+		},
+		At: e.clock.Now(),
+	}); err != nil {
+		return fmt.Errorf("audit promotion proposal for %s: %w", findingID, err)
+	}
+	return nil
+}
+
+// buildSnapshot constructs a [promotion.Snapshot] for a finding by correlating
+// the attack-path graph, active detections, reachability judgments, and prior
+// promotion events.
+func (e *Evaluator) buildSnapshot(
+	ctx context.Context,
+	f finding.Finding,
+	graph *attackpath.Graph,
+	activeDetections []detection.Record,
+	reachability map[shared.ID]reachInfo,
+	latestEvents map[shared.ID]promotion.PriorEscalation,
+) (promotion.Snapshot, error) {
+	snap := promotion.Snapshot{
+		FindingID:      f.ID,
+		FindingVersion: f.Version,
+		Priority:       f.Priority,
+	}
+
+	// Reachability signal from judgments.
+	if ri, ok := reachability[f.ID]; ok {
+		snap.Reachability = ri.state
+		snap.ReachabilityPublishable = ri.publishable
+		snap.ReachabilityDeterministic = ri.deterministic
+		snap.ReachabilitySignal = promotion.Signal{
+			Kind: judgment.PromotionInputReachability,
+			ID:   ri.judgmentID,
+		}
+	}
+
+	// Attack-path signal: evaluate each path independently so that
+	// confidence, attack-path provenance, and detection match come from
+	// THE SAME path. Do not union assets across paths then use first
+	// path's confidence (that contaminates evaluation).
+	if graph != nil {
+		result, err := graph.Traverse(ctx,
+			attackpath.Query{Finding: f.ID},
+			attackpath.Limits{MaxLength: 32, MaxPaths: 100},
+		)
+		if err != nil {
+			return promotion.Snapshot{}, fmt.Errorf("traverse attack paths for finding %s: %w", f.ID, err)
+		}
+		if len(result.Paths) > 0 {
+			type pathEval struct {
+				path      attackpath.Path
+				dets      []detection.Record
+				confident bool
+			}
+			pevals := make([]pathEval, 0, len(result.Paths))
+			for _, p := range result.Paths {
+				pe := pathEval{path: p, confident: p.Confident}
+				pathAssets := make(map[shared.ID]struct{})
+				for _, n := range p.Nodes {
+					if n.Asset != nil {
+						pathAssets[n.Asset.Asset.ID] = struct{}{}
+					}
+				}
+				for _, d := range activeDetections {
+					if _, on := pathAssets[d.AssetID]; on {
+						pe.dets = append(pe.dets, d)
+					}
+				}
+				pevals = append(pevals, pe)
+			}
+
+			// Stable deterministic selection: confident paths with detections
+			// first, then uncertain paths with detections, then paths without
+			// detections. This keeps confidence/provenance/detection together.
+			sort.Slice(pevals, func(i, j int) bool {
+				rank := func(p pathEval) int {
+					if len(p.dets) == 0 {
+						return 2
+					}
+					if p.confident {
+						return 0
+					}
+					return 1
+				}
+				if ri, rj := rank(pevals[i]), rank(pevals[j]); ri != rj {
+					return ri < rj
+				}
+				return pevals[i].path.ID < pevals[j].path.ID
+			})
+
+			best := pevals[0]
+			snap.PathPresent = true
+			snap.PathConfident = best.confident
+			snap.AttackPathSignal = promotion.Signal{
+				Kind: judgment.PromotionInputAttackPath,
+				ID:   shared.ID(best.path.ID),
+			}
+			snap.DetectionSignals = make([]promotion.Signal, 0, len(best.dets))
+			for _, d := range best.dets {
+				snap.DetectionSignals = append(snap.DetectionSignals, promotion.Signal{
+					Kind:       judgment.PromotionInputDetection,
+					ID:         d.ID,
+					EvidenceID: d.EvidenceID,
+				})
+			}
+		}
+	}
+
+	// Prior escalation for reversal detection.
+	if prior, ok := latestEvents[f.ID]; ok {
+		snap.PriorEscalation = &prior
+	}
+
+	return snap, nil
+}
+
+// loadLatestEvents returns the latest active (non-flag_for_review) promotion
+// event for each finding that has one. Signal-loss reversal compares prior
+// escalation inputs against the CURRENT active detections so that expired,
+// removed, or superseded detections correctly set InputsActive=false.
+func (e *Evaluator) loadLatestEvents(
+	ctx context.Context,
+	engagementID shared.ID,
+	findings []finding.Finding,
+	graph *attackpath.Graph,
+	activeDetections []detection.Record,
+	reachability map[shared.ID]reachInfo,
+) (map[shared.ID]promotion.PriorEscalation, error) {
+	out := make(map[shared.ID]promotion.PriorEscalation, len(findings))
+	for _, f := range findings {
+		events, err := e.promotions.ListByFinding(ctx, engagementID, f.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list promotions for finding %s: %w", f.ID, err)
+		}
+		// Events are oldest-first. Reconstruct unresolved escalations as a stack:
+		// an exact corroborating-signal-loss reversal pops only its referenced event.
+		var stack []promotion.PromotionEvent
+		var latestDeescalation *promotion.PromotionEvent
+		for _, evt := range events {
+			if evt.Effect == judgment.PromotionFlagForReview {
+				continue
+			}
+			switch evt.Effect {
+			case judgment.PromotionEscalate:
+				stack = append(stack, evt)
+				latestDeescalation = nil
+			case judgment.PromotionDeescalate:
+				if evt.Rule == judgment.RuleCorroboratingSignalLoss {
+					for _, input := range evt.Inputs {
+						if input.Kind != judgment.PromotionInputPrior {
+							continue
+						}
+						for i := len(stack) - 1; i >= 0; i-- {
+							if stack[i].ID == input.ID {
+								stack = stack[:i]
+								break
+							}
+						}
+					}
+				} else {
+					copy := evt
+					latestDeescalation = &copy
+				}
+			}
+		}
+		if len(stack) > 0 {
+			evt := stack[len(stack)-1]
+			inputsActive, err := inputsStillActive(ctx, evt, f.ID, graph, activeDetections, reachability)
+			if err != nil {
+				return nil, fmt.Errorf("check active escalation inputs for finding %s: %w", f.ID, err)
+			}
+			inputsMatch, err := escalationInputsMatch(ctx, evt, f.ID, graph, activeDetections, reachability)
+			if err != nil {
+				return nil, fmt.Errorf("check matching escalation inputs for finding %s: %w", f.ID, err)
+			}
+			out[f.ID] = promotion.PriorEscalation{EventID: evt.ID, BeforePriority: evt.BeforePriority, InputsActive: inputsActive, InputsMatch: inputsMatch}
+		} else if latestDeescalation != nil {
+			out[f.ID] = promotion.PriorEscalation{DeescalationInputsMatch: deescalationInputsMatch(*latestDeescalation, f.ID, reachability)}
+		}
+	}
+	return out, nil
+}
+
+// inputsStillActive reports whether the detection inputs that drove a prior
+// escalation are still present in the current active detection set. A detection
+// that was expired, removed, or superseded means InputsActive=false. The caller
+// passes the evaluator clock's active detections (already filtered by filterActive).
+func inputsStillActive(ctx context.Context, evt promotion.PromotionEvent, findingID shared.ID, graph *attackpath.Graph, activeDetections []detection.Record, reachability map[shared.ID]reachInfo) (bool, error) {
+	var pathID shared.ID
+	var reachabilityID shared.ID
+	detectionInputs := make(map[shared.ID]struct{})
+	for _, in := range evt.Inputs {
+		switch in.Kind {
+		case judgment.PromotionInputAttackPath:
+			if pathID != "" {
+				return false, nil
+			}
+			pathID = in.ID
+		case judgment.PromotionInputReachability:
+			if reachabilityID != "" {
+				return false, nil
+			}
+			reachabilityID = in.ID
+		case judgment.PromotionInputDetection:
+			detectionInputs[in.ID] = struct{}{}
+		}
+	}
+	if pathID == "" || reachabilityID == "" || len(detectionInputs) == 0 || graph == nil {
+		return false, nil
+	}
+	ri, ok := reachability[findingID]
+	if !ok || !ri.publishable || ri.state != judgment.Reachable || ri.judgmentID != reachabilityID {
+		return false, nil
+	}
+	result, err := graph.Traverse(ctx, attackpath.Query{Finding: findingID}, attackpath.Limits{MaxLength: 32, MaxPaths: 100})
+	if err != nil {
+		return false, err
+	}
+	active := make(map[shared.ID]detection.Record, len(activeDetections))
+	for _, d := range activeDetections {
+		active[d.ID] = d
+	}
+	for _, path := range result.Paths {
+		if shared.ID(path.ID) != pathID || !path.Confident {
+			continue
+		}
+		assets := make(map[shared.ID]struct{})
+		for _, node := range path.Nodes {
+			if node.Asset != nil {
+				assets[node.Asset.Asset.ID] = struct{}{}
+			}
+		}
+		for id := range detectionInputs {
+			d, ok := active[id]
+			if !ok {
+				return false, nil
+			}
+			if _, onPath := assets[d.AssetID]; !onPath {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// escalationInputsMatch reports whether an active escalation has exactly the
+// same reachability judgment, confident path, and detection evidence as the
+// current snapshot. It gates repeat escalation only; inputsStillActive remains
+// deliberately weaker so loss of any original signal still triggers reversal.
+func escalationInputsMatch(ctx context.Context, evt promotion.PromotionEvent, findingID shared.ID, graph *attackpath.Graph, activeDetections []detection.Record, reachability map[shared.ID]reachInfo) (bool, error) {
+	var pathID, reachabilityID shared.ID
+	detectionInputs := make(map[shared.ID]shared.ID)
+	for _, in := range evt.Inputs {
+		switch in.Kind {
+		case judgment.PromotionInputAttackPath:
+			if !pathID.IsZero() {
+				return false, nil
+			}
+			pathID = in.ID
+		case judgment.PromotionInputReachability:
+			if !reachabilityID.IsZero() {
+				return false, nil
+			}
+			reachabilityID = in.ID
+		case judgment.PromotionInputDetection:
+			if _, exists := detectionInputs[in.ID]; exists {
+				return false, nil
+			}
+			detectionInputs[in.ID] = in.EvidenceID
+		}
+	}
+	if pathID.IsZero() || reachabilityID.IsZero() || len(detectionInputs) == 0 || graph == nil {
+		return false, nil
+	}
+	ri, ok := reachability[findingID]
+	if !ok || !ri.publishable || ri.state != judgment.Reachable || ri.judgmentID != reachabilityID {
+		return false, nil
+	}
+	result, err := graph.Traverse(ctx, attackpath.Query{Finding: findingID}, attackpath.Limits{MaxLength: 32, MaxPaths: 100})
+	if err != nil {
+		return false, err
+	}
+	for _, path := range result.Paths {
+		if shared.ID(path.ID) != pathID || !path.Confident {
+			continue
+		}
+		assets := make(map[shared.ID]struct{})
+		for _, node := range path.Nodes {
+			if node.Asset != nil {
+				assets[node.Asset.Asset.ID] = struct{}{}
+			}
+		}
+		current := make(map[shared.ID]shared.ID)
+		for _, detection := range activeDetections {
+			if _, onPath := assets[detection.AssetID]; onPath {
+				current[detection.ID] = detection.EvidenceID
+			}
+		}
+		if len(current) != len(detectionInputs) {
+			return false, nil
+		}
+		for id, evidenceID := range detectionInputs {
+			if current[id] != evidenceID {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// deescalationInputsMatch reports whether a deterministic unreachability event
+// was applied from the same reachability judgment as the current snapshot.
+func deescalationInputsMatch(evt promotion.PromotionEvent, findingID shared.ID, reachability map[shared.ID]reachInfo) bool {
+	if evt.Rule != judgment.RuleDeterministicUnreachable {
+		return false
+	}
+	var reachabilityID shared.ID
+	for _, input := range evt.Inputs {
+		if input.Kind != judgment.PromotionInputReachability || !reachabilityID.IsZero() {
+			return false
+		}
+		reachabilityID = input.ID
+	}
+	ri, ok := reachability[findingID]
+	return ok && ri.publishable && ri.deterministic && ri.state == judgment.NotReachable && ri.judgmentID == reachabilityID
+}
+
+// ---------------------------------------------------------------------------
+// ConfirmedRecorder
+// ---------------------------------------------------------------------------
+
+// evidenceSealer extends the basic seal with a finding-linked variant and a
+// lookup method for crash-recoverable evidence reservation.
+type evidenceSealer interface {
+	SealForFindingWithID(ctx context.Context, evidenceID, engagementID, findingID shared.ID, kind string, content []byte, storageRef, createdBy string) (evdom.Evidence, error)
+	LookupSealedByID(ctx context.Context, engagementID, evidenceID shared.ID) (evdom.Evidence, bool, error)
+}
+
+// ConfirmedRecorder receives an already publishable confirmed
+// [judgment.Judgment] with CapPromotion, loads the finding for CAS fields,
+// validates subject/engagement consistency, seals a finding-linked evidence
+// payload (crash-recoverable), and atomically applies the promotion through
+// [ports.PromotionStore]. It cannot propose or verify.
+type ConfirmedRecorder struct {
+	evidence   evidenceSealer
+	promotions confirmedPromotionStore
+	findings   confirmedFindingReader
+	engagement engagementReader
+	audit      confirmedAuditRecorder
+	clock      ports.Clock
+}
+
+// NewConfirmedRecorder validates dependencies and returns a ConfirmedRecorder.
+func NewConfirmedRecorder(
+	evidence evidenceSealer,
+	promotions confirmedPromotionStore,
+	findings confirmedFindingReader,
+	engagement engagementReader,
+	audit confirmedAuditRecorder,
+	clock ports.Clock,
+) (*ConfirmedRecorder, error) {
+	if evidence == nil || promotions == nil || findings == nil || engagement == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: promotion recorder is missing a dependency", shared.ErrValidation)
+	}
+	return &ConfirmedRecorder{
+		evidence: evidence, promotions: promotions, findings: findings, engagement: engagement,
+		audit: audit, clock: clock,
+	}, nil
+}
+
+// RecordConfirmed applies a confirmed promotion judgment. The judgment must:
+//   - be CapPromotion
+//   - be Publishable (confirmed + meets evidence bar)
+//   - have evidence score >= verdict.EvidenceThreshold
+//   - have SubjectKind == SubjectFinding and SubjectID == claim.FindingID
+//   - belong to the same engagement as the finding
+//   - contain a valid PromotionClaim
+//
+// On success the method loads the finding for CAS fields, seals a
+// finding-linked evidence payload (crash-recoverable via LookupSealedForFinding),
+// then atomically applies the promotion through the store. For flag_for_review
+// effects, lifecycle evidence is recorded without priority/version mutation.
+// Retries with the same judgment + fingerprint are idempotent.
+//
+// Audit reliability: the mutation and audit are ordered so that we never
+// return success without a required audit. If audit fails AFTER the store
+// mutation succeeded, we return the audit error (lifecycle/evidence are
+// canonical and the caller can retry the audit). Deterministic event and
+// evidence IDs ensure retry is recoverable.
+func (r *ConfirmedRecorder) RecordConfirmed(ctx context.Context, j judgment.Judgment) error {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("%w: promotion recording requires tenant context", shared.ErrValidation)
+	}
+	if _, err := r.engagement.GetByIDInTenant(ctx, tenantID, j.EngagementID); err != nil {
+		return fmt.Errorf("validate engagement ownership: %w", err)
+	}
+
+	// Validate the judgment meets all gate requirements.
+	if j.Capability != judgment.CapPromotion {
+		return fmt.Errorf("%w: expected CapPromotion, got %s", shared.ErrValidation, j.Capability)
+	}
+	if !j.Publishable() {
+		return fmt.Errorf("%w: judgment is not publishable", shared.ErrValidation)
+	}
+	if !j.MeetsEvidenceBar() {
+		return fmt.Errorf("%w: evidence score %d does not meet threshold", shared.ErrValidation, j.EvidenceScore)
+	}
+
+	// Extract and validate the PromotionClaim.
+	pc, err := extractPromotionClaim(j)
+	if err != nil {
+		return fmt.Errorf("extract promotion claim: %w", err)
+	}
+
+	// (5) Subject/engagement validation: the judgment must target the same
+	// finding and engagement as the claim.
+	if j.SubjectKind != judgment.SubjectFinding {
+		return fmt.Errorf("%w: expected SubjectFinding, got %s", shared.ErrValidation, j.SubjectKind)
+	}
+	if j.SubjectID != pc.FindingID {
+		return fmt.Errorf("%w: judgment subject %s != claim finding %s", shared.ErrValidation, j.SubjectID, pc.FindingID)
+	}
+	if j.EngagementID.IsZero() {
+		return fmt.Errorf("%w: judgment engagement id is required", shared.ErrValidation)
+	}
+
+	if j.VerifiedBy == "" || j.VerdictRationale == "" || j.VerifiedBy == j.ProposedBy {
+		return fmt.Errorf("%w: publishable promotion needs a distinct verifier and rationale", shared.ErrValidation)
+	}
+
+	// Recover an applied lifecycle event before testing the finding's pre-application
+	// state. A failed audit leaves the finding at the event's post-application state.
+	evidenceID := deriveStableEvidenceID(tenantID, j.ID, pc.Fingerprint)
+	expected, err := expectedPromotionEvent(j, pc, evidenceID)
+	if err != nil {
+		return fmt.Errorf("construct expected promotion event: %w", err)
+	}
+	existing, found, err := r.promotions.FindByJudgment(ctx, j.EngagementID, pc.FindingID, j.ID)
+	if err != nil {
+		return fmt.Errorf("find applied promotion: %w", err)
+	}
+	if found {
+		if existing.ID != expected.ID || !existing.Equals(expected) {
+			return fmt.Errorf("%w: judgment %s replay differs from stored event", shared.ErrConflict, j.ID)
+		}
+		return r.recordAudit(ctx, existing)
+	}
+
+	// Load the finding for CAS fields. The store requires ExpectedPriority and
+	// ExpectedVersion to match before applying any mutation.
+	f, err := r.findings.GetByEngagementAndID(ctx, j.EngagementID, pc.FindingID)
+	if err != nil {
+		return fmt.Errorf("load finding for CAS: %w", err)
+	}
+	if f.Version != pc.FindingVersion || f.Priority != pc.BeforePriority {
+		return fmt.Errorf("%w: finding state changed since promotion claim", shared.ErrConflict)
+	}
+
+	// Evidence sealing must be crash-recoverable. Reserve a stable
+	// evidence ID from the tenant + judgment + fingerprint. If we crashed
+	// between seal and apply, retry finds THIS exact reserved link rather
+	// than another promotion link for the same finding.
+	evContent, err := marshalPromotionEvidence(pc, j)
+	if err != nil {
+		return fmt.Errorf("marshal promotion evidence: %w", err)
+	}
+	var ev evdom.Evidence
+	if existing, found, err := r.evidence.LookupSealedByID(ctx, j.EngagementID, evidenceID); err != nil {
+		return fmt.Errorf("lookup sealed evidence: %w", err)
+	} else if found {
+		if existing.FindingID != pc.FindingID || existing.Kind != PromotionEvidenceKind || string(existing.Content) != string(evContent) {
+			return fmt.Errorf("%w: reserved evidence %s conflicts with promotion payload", shared.ErrConflict, evidenceID)
+		}
+		ev = existing
+	} else {
+		ev, err = r.evidence.SealForFindingWithID(ctx, evidenceID, j.EngagementID, pc.FindingID,
+			PromotionEvidenceKind, evContent, "", proposerActor)
+		if err != nil {
+			return fmt.Errorf("seal promotion evidence: %w", err)
+		}
+	}
+
+	cmd := ports.PromotionCommand{
+		EventID:        deriveStableEventID(j.EngagementID, j.ID),
+		JudgmentID:     j.ID,
+		FindingVersion: pc.FindingVersion,
+		// (1) CAS fields from the actual finding state.
+		ExpectedPriority: f.Priority,
+		ExpectedVersion:  f.Version,
+		Rule:             pc.Rule,
+		Effect:           pc.Proposed,
+		BeforePriority:   pc.BeforePriority,
+		AfterPriority:    pc.AfterPriority,
+		Inputs:           pc.Inputs,
+		Fingerprint:      pc.Fingerprint,
+		// (6) Verdict provenance from the judgment.
+		VerdictScore:     j.EvidenceScore,
+		VerdictRationale: j.VerdictRationale,
+		EvidenceID:       ev.ID,
+		Verifier:         j.VerifiedBy,
+		Uncertainty:      pc.Uncertainty,
+		AppliedBy:        proposerActor,
+	}
+
+	// For flag_for_review, before == after (no priority mutation).
+	if pc.Proposed == judgment.PromotionFlagForReview {
+		cmd.AfterPriority = cmd.BeforePriority
+	}
+
+	// Atomically apply: CAS update finding priority/version + append lifecycle event.
+	// The evidence and lifecycle records are canonical. If audit fails after
+	// this succeeds, return the audit error so callers retry; the exact-replay
+	// branch above retries the audit rather than claiming success.
+	if _, err = r.promotions.Apply(ctx, j.EngagementID, pc.FindingID, cmd); err != nil {
+		return fmt.Errorf("apply promotion: %w", err)
+	}
+	stored, found, err := r.promotions.FindByJudgment(ctx, j.EngagementID, pc.FindingID, j.ID)
+	if err != nil {
+		return fmt.Errorf("load applied promotion: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("apply promotion: stored event missing: %w", shared.ErrNotFound)
+	}
+	return r.recordAudit(ctx, stored)
+}
+
+// expectedPromotionEvent reconstructs every immutable lifecycle field from the
+// confirmed judgment and claim. AppliedAt is intentionally excluded by Equals.
+func expectedPromotionEvent(j judgment.Judgment, pc judgment.PromotionClaim, evidenceID shared.ID) (promotion.PromotionEvent, error) {
+	afterVersion := pc.FindingVersion
+	if pc.Proposed != judgment.PromotionFlagForReview {
+		afterVersion++
+	}
+	afterPriority := pc.AfterPriority
+	if pc.Proposed == judgment.PromotionFlagForReview {
+		afterPriority = pc.BeforePriority
+	}
+	return promotion.NewPromotionEvent(
+		deriveStableEventID(j.EngagementID, j.ID),
+		j.EngagementID,
+		j.ID,
+		pc.FindingID,
+		pc.FindingVersion,
+		afterVersion,
+		pc.Rule,
+		pc.Proposed,
+		pc.BeforePriority,
+		afterPriority,
+		pc.Inputs,
+		pc.Fingerprint,
+		j.EvidenceScore,
+		j.VerdictRationale,
+		evidenceID,
+		j.VerifiedBy,
+		pc.Uncertainty,
+		proposerActor,
+		time.Time{},
+	)
+}
+
+// recordAudit records and durably acknowledges the required audit entry after
+// the canonical lifecycle event exists.
+func (r *ConfirmedRecorder) recordAudit(ctx context.Context, evt promotion.PromotionEvent) error {
+	if err := recordPromotionAudit(ctx, r.audit, r.clock, evt); err != nil {
+		return err
+	}
+	if err := r.promotions.MarkAuditComplete(ctx, evt.ID); err != nil {
+		return fmt.Errorf("mark promotion audit complete: %w", err)
+	}
+	return nil
+}
+
+// Reconciler is the distinct recovery authority for confirmed promotions. It
+// applies already-confirmed judgments and retries only outstanding audits; it
+// has no proposal or verdict authority.
+type Reconciler struct {
+	judgments judgmentReader
+	audits    ports.PromotionAuditTracker
+	recorder  ports.ConfirmedPromotionRecorder
+	audit     ports.IdempotentAuditLogger
+	clock     ports.Clock
+}
+
+// NewReconciler creates the durable promotion recovery authority.
+func NewReconciler(judgments judgmentReader, audits ports.PromotionAuditTracker, recorder ports.ConfirmedPromotionRecorder, audit ports.IdempotentAuditLogger, clock ports.Clock) (*Reconciler, error) {
+	if judgments == nil || audits == nil || recorder == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: promotion reconciler is missing a dependency", shared.ErrValidation)
+	}
+	return &Reconciler{judgments: judgments, audits: audits, recorder: recorder, audit: audit, clock: clock}, nil
+}
+
+var _ ports.PromotionReconciler = (*Reconciler)(nil)
+
+// Reconcile recovers confirmed CapPromotion judgments that have no event, then
+// retries every event whose audit completion was not durably acknowledged.
+func (r *Reconciler) Reconcile(ctx context.Context, engagementID shared.ID) error {
+	judgments, err := r.judgments.ListByEngagement(ctx, engagementID)
+	if err != nil {
+		return fmt.Errorf("list judgments for promotion reconciliation: %w", err)
+	}
+	var errs []error
+	for _, j := range judgments {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(append(errs, err)...)
+		}
+		if j.Capability != judgment.CapPromotion || !j.Publishable() {
+			continue
+		}
+		if err := r.recorder.RecordConfirmed(ctx, j); err != nil {
+			if ctx.Err() != nil {
+				return errors.Join(append(errs, ctx.Err())...)
+			}
+			errs = append(errs, fmt.Errorf("recover confirmed promotion %s: %w", j.ID, err))
+		}
+	}
+	pending, err := r.audits.ListPendingAudits(ctx, engagementID)
+	if err != nil {
+		return errors.Join(append(errs, fmt.Errorf("list pending promotion audits: %w", err))...)
+	}
+	for _, evt := range pending {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(append(errs, err)...)
+		}
+		if err := recordPromotionAudit(ctx, r.audit, r.clock, evt); err != nil {
+			if ctx.Err() != nil {
+				return errors.Join(append(errs, ctx.Err())...)
+			}
+			errs = append(errs, fmt.Errorf("recover promotion audit %s: %w", evt.ID, err))
+			continue
+		}
+		if err := r.audits.MarkAuditComplete(ctx, evt.ID); err != nil {
+			if ctx.Err() != nil {
+				return errors.Join(append(errs, ctx.Err())...)
+			}
+			errs = append(errs, fmt.Errorf("mark recovered promotion audit complete %s: %w", evt.ID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func recordPromotionAudit(ctx context.Context, audit confirmedAuditRecorder, clock ports.Clock, evt promotion.PromotionEvent) error {
+	at := evt.AppliedAt
+	if at.IsZero() {
+		at = clock.Now()
+	}
+	if err := audit.RecordOnce(ctx, ports.AuditEntry{
+		Actor: proposerActor, Action: "promotion.applied", Target: evt.FindingID.String(),
+		Metadata: map[string]string{
+			"idempotency_key": evt.ID.String(), "engagement": evt.EngagementID.String(), "finding": evt.FindingID.String(),
+			"judgment": evt.JudgmentID.String(), "rule": evt.Rule, "effect": string(evt.Effect),
+			"fingerprint": evt.Fingerprint, "evidence": evt.EvidenceID.String(),
+		},
+		At: at,
+	}); err != nil {
+		return fmt.Errorf("audit promotion application: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// reachInfo holds reachability state derived from judgments.
+type reachInfo struct {
+	judgmentID    shared.ID
+	state         judgment.ReachabilityState
+	tier          judgment.ReachabilityTier
+	publishable   bool
+	deterministic bool
+	evidenceScore int
+	version       int
+	updatedAt     time.Time
+}
+
+// deriveStableEventID produces a deterministic event ID from the engagement
+// and judgment IDs so that retries always produce the same ID. This makes
+// the promotion store's EventID uniqueness guard a crash-recovery mechanism:
+// if the recorder applied the event but crashed before returning, the retry
+// produces the same EventID and the store returns the existing event.
+func deriveStableEventID(engagementID, judgmentID shared.ID) shared.ID {
+	h := sha256.Sum256([]byte("promotion:event:" + string(engagementID) + ":" + string(judgmentID)))
+	return shared.ID(hex.EncodeToString(h[:16]))
+}
+
+func deriveStableEvidenceID(tenantID, judgmentID shared.ID, fingerprint string) shared.ID {
+	h := sha256.Sum256([]byte("promotion:evidence:" + string(tenantID) + ":" + string(judgmentID) + ":" + fingerprint))
+	return shared.ID(hex.EncodeToString(h[:16]))
+}
+
+// indexReachability indexes the current publishable finding-scoped reachability
+// judgment. Stronger tiers supersede weaker ones; within a tier, later judgment
+// chronology wins so a contradictory later proof replaces the earlier state.
+func indexReachability(judgments []judgment.Judgment) map[shared.ID]reachInfo {
+	out := make(map[shared.ID]reachInfo)
+	for _, j := range judgments {
+		if j.Capability != judgment.CapReachability || j.SubjectKind != judgment.SubjectFinding || !j.Publishable() {
+			continue
+		}
+		rc, ok := j.Claim.(judgment.ReachabilityClaim)
+		if !ok {
+			continue
+		}
+		existing, exists := out[j.SubjectID]
+		if exists && !reachabilitySupersedes(j, rc, existing) {
+			continue
+		}
+		out[j.SubjectID] = reachInfo{
+			judgmentID:    j.ID,
+			state:         rc.Reachable,
+			tier:          rc.Tier,
+			publishable:   true,
+			deterministic: j.EvidenceScore >= verdict.DeterministicProofScore && judgment.IsDeterministicReachabilityProof(rc.Tier, j.ProposedBy, j.VerifiedBy),
+			evidenceScore: j.EvidenceScore,
+			version:       j.Version,
+			updatedAt:     j.Audit.UpdatedAt,
+		}
+	}
+	return out
+}
+
+func reachabilitySupersedes(j judgment.Judgment, rc judgment.ReachabilityClaim, existing reachInfo) bool {
+	if rc.Tier.Rank() != existing.tier.Rank() {
+		return rc.Tier.Rank() > existing.tier.Rank()
+	}
+	if j.Audit.UpdatedAt != existing.updatedAt {
+		return j.Audit.UpdatedAt.After(existing.updatedAt)
+	}
+	if j.Version != existing.version {
+		return j.Version > existing.version
+	}
+	return j.ID > existing.judgmentID
+}
+
+// indexPromotionProposals indexes the latest promotion proposal claim per
+// finding for idempotency. Only CapPromotion judgments in proposed/confirmed
+// state are considered.
+func indexPromotionProposals(judgments []judgment.Judgment) map[shared.ID]map[string]struct{} {
+	out := make(map[shared.ID]map[string]struct{})
+	for _, j := range judgments {
+		if j.Capability != judgment.CapPromotion {
+			continue
+		}
+		var pc judgment.PromotionClaim
+		switch claim := j.Claim.(type) {
+		case judgment.PromotionClaim:
+			pc = claim
+		case *judgment.PromotionClaim:
+			if claim == nil {
+				continue
+			}
+			pc = *claim
+		default:
+			continue
+		}
+		if out[pc.FindingID] == nil {
+			out[pc.FindingID] = make(map[string]struct{})
+		}
+		out[pc.FindingID][pc.Fingerprint] = struct{}{}
+	}
+	return out
+}
+
+// filterActive returns only detections that are active at now. Expiry is
+// evaluated against the evaluator clock, never RecordedAt, so an old record
+// that has since expired cannot keep a promotion escalated.
+func filterActive(records []detection.Record, now time.Time) []detection.Record {
+	out := make([]detection.Record, 0, len(records))
+	for _, r := range records {
+		if r.ExpiresAt.IsZero() || r.ExpiresAt.After(now) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// buildGraph constructs an [attackpath.Graph] from raw assets, edges, bindings,
+// and findings. Returns nil (without error) if the graph has no assets.
+func buildGraph(
+	tenantID shared.ID,
+	assetsList []*asset.Asset,
+	edges []asset.Edge,
+	bindings []attackpath.Binding,
+	findings []finding.Finding,
+	reachability map[shared.ID]reachInfo,
+) (*attackpath.Graph, error) {
+	if len(assetsList) == 0 {
+		return nil, nil
+	}
+	domAssets := make([]asset.Asset, len(assetsList))
+	for i, a := range assetsList {
+		domAssets[i] = *a
+	}
+	findingInputs := make([]attackpath.FindingInput, len(findings))
+	for i, f := range findings {
+		fi := attackpath.FindingInput{
+			Target:  attackpath.FindingTarget{ID: f.ID, Kind: attackpath.TargetCanonical},
+			Finding: f,
+		}
+		if ri, ok := reachability[f.ID]; ok && ri.publishable {
+			fi.Reachability = ri.state
+			fi.Confirmed = true
+			fi.Tier = ri.tier
+			fi.Provenance = ri.judgmentID
+		}
+		findingInputs[i] = fi
+	}
+	// Filter bindings to this tenant.
+	tenantBindings := make([]attackpath.Binding, 0, len(bindings))
+	for _, b := range bindings {
+		if b.TenantID == tenantID {
+			tenantBindings = append(tenantBindings, b)
+		}
+	}
+	g, err := attackpath.NewGraph(attackpath.Input{
+		TenantID: tenantID,
+		Assets:   domAssets,
+		Edges:    edges,
+		Bindings: tenantBindings,
+		Findings: findingInputs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("new graph: %w", err)
+	}
+	return g, nil
+}
+
+// extractPromotionClaim unmarshals the claim from a judgment as a PromotionClaim.
+func extractPromotionClaim(j judgment.Judgment) (judgment.PromotionClaim, error) {
+	switch pc := j.Claim.(type) {
+	case judgment.PromotionClaim:
+		if err := pc.Validate(); err != nil {
+			return judgment.PromotionClaim{}, fmt.Errorf("invalid promotion claim: %w", err)
+		}
+		return pc, nil
+	case *judgment.PromotionClaim:
+		if pc == nil {
+			return judgment.PromotionClaim{}, fmt.Errorf("%w: nil promotion claim", shared.ErrValidation)
+		}
+		if err := pc.Validate(); err != nil {
+			return judgment.PromotionClaim{}, fmt.Errorf("invalid promotion claim: %w", err)
+		}
+		return *pc, nil
+	default:
+		return judgment.PromotionClaim{}, fmt.Errorf("%w: judgment claim is not a PromotionClaim", shared.ErrValidation)
+	}
+}
+
+// marshalPromotionEvidence creates the canonical evidence payload for a
+// promotion application. The payload is deterministic and includes the
+// claim, verdict metadata, and judgment identity.
+func marshalPromotionEvidence(pc judgment.PromotionClaim, j judgment.Judgment) ([]byte, error) {
+	payload := struct {
+		JudgmentID       string                    `json:"judgment_id"`
+		EngagementID     string                    `json:"engagement_id"`
+		FindingID        string                    `json:"finding_id"`
+		Rule             string                    `json:"rule"`
+		Effect           judgment.PromotionChange  `json:"effect"`
+		Fingerprint      string                    `json:"fingerprint"`
+		FindingVersion   int                       `json:"finding_version"`
+		BeforePriority   int                       `json:"before_priority"`
+		AfterPriority    int                       `json:"after_priority"`
+		Inputs           []judgment.PromotionInput `json:"inputs"`
+		VerdictScore     int                       `json:"verdict_score"`
+		VerifiedBy       string                    `json:"verified_by"`
+		VerdictRationale string                    `json:"verdict_rationale"`
+	}{
+		JudgmentID:       j.ID.String(),
+		EngagementID:     j.EngagementID.String(),
+		FindingID:        pc.FindingID.String(),
+		Rule:             pc.Rule,
+		Effect:           pc.Proposed,
+		Fingerprint:      pc.Fingerprint,
+		FindingVersion:   pc.FindingVersion,
+		BeforePriority:   pc.BeforePriority,
+		AfterPriority:    pc.AfterPriority,
+		Inputs:           pc.Inputs,
+		VerdictScore:     j.EvidenceScore,
+		VerifiedBy:       j.VerifiedBy,
+		VerdictRationale: j.VerdictRationale,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal promotion evidence: %w", err)
+	}
+	return data, nil
+}

--- a/internal/usecase/promotion/service_test.go
+++ b/internal/usecase/promotion/service_test.go
@@ -1,0 +1,1532 @@
+package promotion
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/promotion"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers / fakes
+// ---------------------------------------------------------------------------
+
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time { return c.t }
+
+type fakeIDGen struct{ id shared.ID }
+
+func (g *fakeIDGen) NewID() shared.ID { return g.id }
+
+type fakeAudit struct {
+	entries []ports.AuditEntry
+	fail    int
+	seen    map[string]struct{}
+}
+
+func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.entries = append(a.entries, e)
+	return nil
+}
+
+func (a *fakeAudit) RecordOnce(ctx context.Context, e ports.AuditEntry) error {
+	if a.fail > 0 {
+		a.fail--
+		return errors.New("audit unavailable")
+	}
+	if a.seen == nil {
+		a.seen = make(map[string]struct{})
+	}
+	key := e.Action + ":" + e.Metadata["idempotency_key"]
+	if _, ok := a.seen[key]; ok {
+		return nil
+	}
+	a.seen[key] = struct{}{}
+	return a.Record(ctx, e)
+}
+
+type fakeProposer struct {
+	proposed []judgment.Judgment
+	existing []judgment.Judgment
+}
+
+func (p *fakeProposer) Propose(_ context.Context, proposer string, engagementID shared.ID, cap judgment.Capability, sk judgment.SubjectKind, sid shared.ID, claim judgment.Claim) (judgment.Judgment, error) {
+	j := judgment.Judgment{
+		ID:           shared.ID("j-" + sid.String()),
+		EngagementID: engagementID,
+		Capability:   cap,
+		SubjectKind:  sk,
+		SubjectID:    sid,
+		Claim:        claim,
+		State:        judgment.StateProposed,
+		ProposedBy:   proposer,
+	}
+	p.proposed = append(p.proposed, j)
+	return j, nil
+}
+
+type fakeFindingRepo struct {
+	findings []finding.Finding
+}
+
+func (r *fakeFindingRepo) Upsert(_ context.Context, _ []finding.Finding) error { return nil }
+func (r *fakeFindingRepo) ListByEngagement(_ context.Context, _ shared.ID) ([]finding.Finding, error) {
+	return r.findings, nil
+}
+func (r *fakeFindingRepo) ListPublishableByEngagement(_ context.Context, _ shared.ID) ([]finding.Finding, error) {
+	return r.findings, nil
+}
+func (r *fakeFindingRepo) UpdateStatus(_ context.Context, _, _ shared.ID, _ finding.Status, _ int) (finding.Finding, error) {
+	return finding.Finding{}, nil
+}
+func (r *fakeFindingRepo) SetAssignee(_ context.Context, _, _ shared.ID, _ string, _ int) (finding.Finding, error) {
+	return finding.Finding{}, nil
+}
+func (r *fakeFindingRepo) GetByEngagementAndID(_ context.Context, engagementID, findingID shared.ID) (finding.Finding, error) {
+	for _, f := range r.findings {
+		if f.ID == findingID && f.EngagementID == engagementID {
+			return f, nil
+		}
+	}
+	return finding.Finding{}, shared.ErrNotFound
+}
+
+type fakeJudgmentStore struct {
+	judgments []judgment.Judgment
+}
+
+func (s *fakeJudgmentStore) Save(_ context.Context, _ judgment.Judgment) error { return nil }
+func (s *fakeJudgmentStore) ListByEngagement(_ context.Context, _ shared.ID) ([]judgment.Judgment, error) {
+	return s.judgments, nil
+}
+func (s *fakeJudgmentStore) ListBySubject(_ context.Context, _, _ shared.ID) ([]judgment.Judgment, error) {
+	return nil, nil
+}
+
+type fakeAttackPathStore struct {
+	bindings []attackpath.Binding
+}
+
+func (s *fakeAttackPathStore) ReplaceBindings(_ context.Context, _, _, _ shared.ID, _ []attackpath.Binding) error {
+	return nil
+}
+func (s *fakeAttackPathStore) ListBindings(_ context.Context, _ shared.ID) ([]attackpath.Binding, error) {
+	return s.bindings, nil
+}
+
+type fakeAssetRepo struct {
+	assets []*asset.Asset
+	edges  []*asset.Edge
+}
+
+func (r *fakeAssetRepo) UpsertAsset(_ context.Context, _ *asset.Asset) error { return nil }
+func (r *fakeAssetRepo) GetAssetByKey(_ context.Context, _ shared.ID, _ asset.Kind, _ string) (*asset.Asset, error) {
+	return nil, nil
+}
+func (r *fakeAssetRepo) ListAssets(_ context.Context, _ shared.ID) ([]*asset.Asset, error) {
+	return r.assets, nil
+}
+func (r *fakeAssetRepo) UpsertEdge(_ context.Context, _ *asset.Edge) error { return nil }
+func (r *fakeAssetRepo) ListEdges(_ context.Context, _ shared.ID) ([]*asset.Edge, error) {
+	return r.edges, nil
+}
+
+type fakeDetectionStore struct {
+	records []detection.Record
+}
+
+func (s *fakeDetectionStore) AppendDetection(_ context.Context, _ detection.Record) error { return nil }
+func (s *fakeDetectionStore) HasDetection(_ context.Context, _ shared.ID) (bool, error) {
+	return false, nil
+}
+func (s *fakeDetectionStore) ListDetections(_ context.Context, _ shared.ID) ([]detection.Record, error) {
+	return s.records, nil
+}
+func (s *fakeDetectionStore) LastBatchSequence(_ context.Context, _ shared.ID) (uint64, error) {
+	return 0, nil
+}
+func (s *fakeDetectionStore) ExpireDetections(_ context.Context, _ shared.ID, _ time.Time) ([]shared.ID, error) {
+	return nil, nil
+}
+
+type fakeEngagementReader struct {
+	eng *engagementStub
+}
+
+type engagementStub struct {
+	id       shared.ID
+	tenantID shared.ID
+}
+
+func (r *fakeEngagementReader) GetByIDInTenant(_ context.Context, tenantID, id shared.ID) (*engagementStub, error) {
+	if r.eng == nil || r.eng.id != id || r.eng.tenantID != tenantID {
+		return nil, shared.ErrNotFound
+	}
+	return r.eng, nil
+}
+
+// Adapt to the ports.EngagementOwnershipReader interface which returns
+// *engagement.Engagement. We need a minimal stub.
+// The ports.EngagementOwnershipReader returns (*engagement.Engagement, error).
+// Let's use a real adapter.
+
+type fakePromotionStore struct {
+	events  map[shared.ID][]promotion.PromotionEvent
+	latest  map[shared.ID]promotion.PromotionEvent
+	applied []ports.PromotionCommand
+	byEvent map[shared.ID]ports.PromotionCommand
+}
+
+func (s *fakePromotionStore) Apply(_ context.Context, _, _ shared.ID, cmd ports.PromotionCommand) (finding.Finding, error) {
+	if s.byEvent == nil {
+		s.byEvent = make(map[shared.ID]ports.PromotionCommand)
+	}
+	if _, ok := s.byEvent[cmd.EventID]; ok {
+		return finding.Finding{}, nil
+	}
+	s.byEvent[cmd.EventID] = cmd
+	s.applied = append(s.applied, cmd)
+	return finding.Finding{}, nil
+}
+func (s *fakePromotionStore) ListByFinding(_ context.Context, _, fid shared.ID) ([]promotion.PromotionEvent, error) {
+	if events, ok := s.events[fid]; ok {
+		return append([]promotion.PromotionEvent(nil), events...), nil
+	}
+	if evt, ok := s.latest[fid]; ok {
+		return []promotion.PromotionEvent{evt}, nil
+	}
+	return nil, nil
+}
+func (s *fakePromotionStore) LatestByFinding(_ context.Context, _, fid shared.ID) (promotion.PromotionEvent, bool, error) {
+	if evt, ok := s.latest[fid]; ok {
+		return evt, true, nil
+	}
+	return promotion.PromotionEvent{}, false, nil
+}
+
+func (s *fakePromotionStore) FindByJudgment(_ context.Context, engagementID, findingID, judgmentID shared.ID) (promotion.PromotionEvent, bool, error) {
+	for eventID, cmd := range s.byEvent {
+		if cmd.JudgmentID == judgmentID {
+			afterVersion := cmd.FindingVersion
+			if cmd.Effect != judgment.PromotionFlagForReview {
+				afterVersion++
+			}
+			return promotion.PromotionEvent{
+				ID: eventID, EngagementID: engagementID, JudgmentID: judgmentID, FindingID: findingID, FindingVersion: cmd.FindingVersion, AfterFindingVersion: afterVersion,
+				Rule: cmd.Rule, Effect: cmd.Effect, BeforePriority: cmd.BeforePriority, AfterPriority: cmd.AfterPriority,
+				Inputs: cmd.Inputs, Fingerprint: cmd.Fingerprint, VerdictScore: cmd.VerdictScore,
+				VerdictRationale: cmd.VerdictRationale, EvidenceID: cmd.EvidenceID, Verifier: cmd.Verifier,
+				Uncertainty: cmd.Uncertainty, AppliedBy: cmd.AppliedBy,
+			}, true, nil
+		}
+	}
+	return promotion.PromotionEvent{}, false, nil
+}
+func (s *fakePromotionStore) ListPendingAudits(_ context.Context, _ shared.ID) ([]promotion.PromotionEvent, error) {
+	return nil, nil
+}
+func (s *fakePromotionStore) MarkAuditComplete(_ context.Context, _ shared.ID) error { return nil }
+
+type fakeEvidenceSealer struct {
+	evidence.Evidence
+	err          error
+	sealed       *evidence.Evidence // pre-sealed evidence for crash recovery
+	sealCalled   int
+	contentMatch bool // whether LookupSealedForFinding content matches
+}
+
+func (s *fakeEvidenceSealer) Seal(_ context.Context, _ shared.ID, _ string, _ []byte, _ string) (evidence.Evidence, error) {
+	return s.Evidence, s.err
+}
+func (s *fakeEvidenceSealer) SealForFinding(_ context.Context, _, _ shared.ID, _ string, _ []byte, _ string) (evidence.Evidence, error) {
+	s.sealCalled++
+	return s.Evidence, s.err
+}
+func (s *fakeEvidenceSealer) LookupSealedForFinding(_ context.Context, _, _ shared.ID, _ string) (evidence.Evidence, bool, error) {
+	if s.sealed != nil {
+		ev := *s.sealed
+		if s.contentMatch {
+			return ev, true, nil
+		}
+		ev.Content = []byte("different")
+		return ev, true, nil
+	}
+	return evidence.Evidence{}, false, nil
+}
+func (s *fakeEvidenceSealer) LookupSealedByID(_ context.Context, _ shared.ID, evidenceID shared.ID) (evidence.Evidence, bool, error) {
+	if s.sealed != nil && s.sealed.ID == evidenceID {
+		return *s.sealed, true, nil
+	}
+	return evidence.Evidence{}, false, nil
+}
+func (s *fakeEvidenceSealer) SealForFindingWithID(_ context.Context, evidenceID, _, _ shared.ID, _ string, content []byte, _ string, _ string) (evidence.Evidence, error) {
+	s.sealCalled++
+	s.Content = append([]byte(nil), content...)
+	ev := s.Evidence
+	ev.ID, ev.Content = evidenceID, s.Content
+	return ev, s.err
+}
+
+// ---------------------------------------------------------------------------
+// Helper to build a minimal engagement for the ownership reader.
+// ---------------------------------------------------------------------------
+
+// We need to import the engagement domain for the ownership reader.
+// The ports.EngagementOwnershipReader returns *engagement.Engagement.
+// We wrap the fake to satisfy the interface.
+
+type fakeEngagementOwnershipReader struct {
+	eng *engdom.Engagement
+}
+
+func (r *fakeEngagementOwnershipReader) GetByIDInTenant(_ context.Context, tenantID, id shared.ID) (*engdom.Engagement, error) {
+	if r.eng == nil || r.eng.ID != id || r.eng.TenantID != tenantID {
+		return nil, shared.ErrNotFound
+	}
+	return r.eng, nil
+}
+
+// ---------------------------------------------------------------------------
+// Test fakes for Evaluator dependencies
+// ---------------------------------------------------------------------------
+
+func testTenantID() shared.ID     { return shared.ID("tenant-1") }
+func testEngagementID() shared.ID { return shared.ID("eng-1") }
+func testFindingID() shared.ID    { return shared.ID("find-1") }
+func testAssetID() shared.ID      { return shared.ID("asset-1") }
+func testExposureID() shared.ID   { return shared.ID("exposure-1") }
+func testDetectionID() shared.ID  { return shared.ID("det-1") }
+func testEvidenceID() shared.ID   { return shared.ID("ev-1") }
+
+func baseFinding() finding.Finding {
+	return finding.Finding{
+		ID:           testFindingID(),
+		EngagementID: testEngagementID(),
+		Title:        "Test Finding",
+		Priority:     3,
+		Version:      1,
+		Kind:         finding.KindSCA,
+		DedupKey:     "dedup-1",
+	}
+}
+
+func baseEngagement() *engdom.Engagement {
+	return &engdom.Engagement{
+		ID:       testEngagementID(),
+		TenantID: testTenantID(),
+	}
+}
+
+func baseEvaluator(t *testing.T) (*Evaluator, *fakeProposer, *fakeAudit) {
+	t.Helper()
+	p := &fakeProposer{}
+	audit := &fakeAudit{}
+	ev := &Evaluator{
+		proposer:   p,
+		findings:   &fakeFindingRepo{findings: []finding.Finding{baseFinding()}},
+		judgments:  &fakeJudgmentStore{},
+		bindings:   &fakeAttackPathStore{},
+		assets:     &fakeAssetRepo{},
+		detections: &fakeDetectionStore{},
+		engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()},
+		promotions: &fakePromotionStore{},
+		clock:      &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+		audit:      audit,
+	}
+	return ev, p, audit
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Evaluator
+// ---------------------------------------------------------------------------
+
+func TestEvaluatorRequiresTenantContext(t *testing.T) {
+	ev, _, _ := baseEvaluator(t)
+	_, err := ev.Evaluate(context.Background(), testEngagementID())
+	if err == nil {
+		t.Fatal("expected error without tenant context")
+	}
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestEvaluatorRequiresEngagementID(t *testing.T) {
+	ev, _, _ := baseEvaluator(t)
+	ctx := shared.WithTenant(context.Background(), testTenantID())
+	_, err := ev.Evaluate(ctx, shared.ID(""))
+	if err == nil {
+		t.Fatal("expected error with zero engagement ID")
+	}
+}
+
+func TestEvaluatorRejectsCrossTenantAccess(t *testing.T) {
+	ev, _, _ := baseEvaluator(t)
+	ctx := shared.WithTenant(context.Background(), shared.ID("other-tenant"))
+	_, err := ev.Evaluate(ctx, testEngagementID())
+	if err == nil {
+		t.Fatal("expected error for cross-tenant access")
+	}
+}
+
+func TestEvaluatorNoDetectionReturnsNoProposal(t *testing.T) {
+	ev, p, _ := baseEvaluator(t)
+	ctx := shared.WithTenant(context.Background(), testTenantID())
+	n, err := ev.Evaluate(ctx, testEngagementID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 proposals without detection+path, got %d", n)
+	}
+	if len(p.proposed) != 0 {
+		t.Fatalf("expected 0 proposed judgments, got %d", len(p.proposed))
+	}
+}
+
+func TestEvaluatorEscalationWithDetectionOnExposurePath(t *testing.T) {
+	tid := testTenantID()
+	eid := testEngagementID()
+	fid := testFindingID()
+	aid := testAssetID()
+	expID := testExposureID()
+	detID := testDetectionID()
+	evID := testEvidenceID()
+
+	// Build a finding at priority 3 (escalation moves to 2).
+	f := baseFinding()
+	f.Priority = 3
+
+	// A publishable Reachable judgment so the domain Evaluate sees Reachable.
+	reachJudgment := judgment.Judgment{
+		ID:           shared.ID("reach-j-1"),
+		EngagementID: eid,
+		Capability:   judgment.CapReachability,
+		SubjectKind:  judgment.SubjectFinding,
+		SubjectID:    fid,
+		Claim: judgment.ReachabilityClaim{
+			Reachable: judgment.Reachable,
+			Tier:      judgment.Tier0,
+		},
+		State:         judgment.StateConfirmed,
+		EvidenceScore: 90,
+		ProposedBy:    "agent:reacher",
+	}
+
+	// Build assets: an exposure root and a connected asset.
+	exposureAsset := &asset.Asset{ID: expID, TenantID: tid, Kind: asset.KindExposure, Key: "exp-1", Name: "Internet"}
+	targetAsset := &asset.Asset{ID: aid, TenantID: tid, Kind: asset.KindHost, Key: "host-1", Name: "Host"}
+	edges := []*asset.Edge{{TenantID: tid, From: expID, To: aid, Kind: asset.EdgeReaches, Provenance: shared.ID("prov-1"), Confidence: asset.EdgeObserved}}
+
+	// Binding: finding bound to the target asset.
+	bindings := []attackpath.Binding{{
+		TenantID: tid, EngagementID: eid, AssetID: aid, FindingID: fid,
+		TargetKind: attackpath.TargetCanonical, Producer: shared.ID("prod-1"),
+		Provenance: shared.ID("prov-1"), Confidence: asset.EdgeObserved,
+	}}
+
+	// Active detection on the target asset.
+	det := detection.Record{
+		ID:           detID,
+		TenantID:     tid,
+		EngagementID: eid,
+		AssetID:      aid,
+		EvidenceID:   evID,
+		RecordedAt:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	p := &fakeProposer{}
+	audit := &fakeAudit{}
+	ev := &Evaluator{
+		proposer:   p,
+		findings:   &fakeFindingRepo{findings: []finding.Finding{f}},
+		judgments:  &fakeJudgmentStore{judgments: []judgment.Judgment{reachJudgment}},
+		bindings:   &fakeAttackPathStore{bindings: bindings},
+		assets:     &fakeAssetRepo{assets: []*asset.Asset{exposureAsset, targetAsset}, edges: edges},
+		detections: &fakeDetectionStore{records: []detection.Record{det}},
+		engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()},
+		promotions: &fakePromotionStore{},
+		clock:      &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+		audit:      audit,
+	}
+
+	ctx := shared.WithTenant(context.Background(), tid)
+	n, err := ev.Evaluate(ctx, eid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 proposal, got %d", n)
+	}
+	if len(p.proposed) != 1 {
+		t.Fatalf("expected 1 proposed judgment, got %d", len(p.proposed))
+	}
+	j := p.proposed[0]
+	if j.Capability != judgment.CapPromotion {
+		t.Fatalf("expected CapPromotion, got %s", j.Capability)
+	}
+	pc, ok := j.Claim.(*judgment.PromotionClaim)
+	if !ok {
+		t.Fatal("expected *PromotionClaim")
+	}
+	if pc.Rule != judgment.RuleRuntimeReachableExposed {
+		t.Fatalf("expected rule %s, got %s", judgment.RuleRuntimeReachableExposed, pc.Rule)
+	}
+	if pc.Proposed != judgment.PromotionEscalate {
+		t.Fatalf("expected escalate, got %s", pc.Proposed)
+	}
+	if pc.BeforePriority != 3 || pc.AfterPriority != 2 {
+		t.Fatalf("expected priority 3->2, got %d->%d", pc.BeforePriority, pc.AfterPriority)
+	}
+	// Audit should have recorded the proposal.
+	if len(audit.entries) != 1 || audit.entries[0].Action != "promotion.proposed" {
+		t.Fatalf("expected 1 audit entry for promotion.proposed, got %d", len(audit.entries))
+	}
+}
+
+func TestEvaluatorDeterministicUnreachabilityDeescalation(t *testing.T) {
+	tid := testTenantID()
+	eid := testEngagementID()
+	fid := testFindingID()
+
+	f := baseFinding()
+	f.Priority = 2
+
+	// A publishable NotReachable judgment from a system reachproof identity
+	// with score >= DeterministicProofScore. This is the only combination
+	// that triggers deterministic de-escalation (not just Tier0).
+	reachJudgment := judgment.Judgment{
+		ID:           shared.ID("reach-j-1"),
+		EngagementID: eid,
+		Capability:   judgment.CapReachability,
+		SubjectKind:  judgment.SubjectFinding,
+		SubjectID:    fid,
+		Claim: judgment.ReachabilityClaim{
+			Reachable: judgment.NotReachable,
+			Tier:      judgment.Tier2,
+		},
+		State:         judgment.StateConfirmed,
+		EvidenceScore: 90,
+		ProposedBy:    "system:callgraph-scan", VerifiedBy: "system:callgraph-engine", VerdictRationale: "confirmed",
+	}
+
+	p := &fakeProposer{}
+	audit := &fakeAudit{}
+	ev := &Evaluator{
+		proposer:   p,
+		findings:   &fakeFindingRepo{findings: []finding.Finding{f}},
+		judgments:  &fakeJudgmentStore{judgments: []judgment.Judgment{reachJudgment}},
+		bindings:   &fakeAttackPathStore{},
+		assets:     &fakeAssetRepo{},
+		detections: &fakeDetectionStore{},
+		engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()},
+		promotions: &fakePromotionStore{},
+		clock:      &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+		audit:      audit,
+	}
+
+	ctx := shared.WithTenant(context.Background(), tid)
+	n, err := ev.Evaluate(ctx, eid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 proposal, got %d", n)
+	}
+	pc := p.proposed[0].Claim.(*judgment.PromotionClaim)
+	if pc.Rule != judgment.RuleDeterministicUnreachable {
+		t.Fatalf("expected rule %s, got %s", judgment.RuleDeterministicUnreachable, pc.Rule)
+	}
+	if pc.Proposed != judgment.PromotionDeescalate {
+		t.Fatalf("expected de_escalate, got %s", pc.Proposed)
+	}
+	if pc.BeforePriority != 2 || pc.AfterPriority != 3 {
+		t.Fatalf("expected priority 2->3, got %d->%d", pc.BeforePriority, pc.AfterPriority)
+	}
+}
+
+func TestEvaluatorInferredPathFlagForReview(t *testing.T) {
+	tid := testTenantID()
+	eid := testEngagementID()
+	fid := testFindingID()
+	aid := testAssetID()
+	expID := testExposureID()
+	detID := testDetectionID()
+
+	f := baseFinding()
+	f.Priority = 3
+
+	// Assets with an inferred (not observed) edge.
+	exposureAsset := &asset.Asset{ID: expID, TenantID: tid, Kind: asset.KindExposure, Key: "exp-1", Name: "Internet"}
+	targetAsset := &asset.Asset{ID: aid, TenantID: tid, Kind: asset.KindHost, Key: "host-1", Name: "Host"}
+	edges := []*asset.Edge{{TenantID: tid, From: expID, To: aid, Kind: asset.EdgeReaches, Provenance: shared.ID("prov-1"), Confidence: asset.EdgeInferred}}
+
+	bindings := []attackpath.Binding{{
+		TenantID: tid, EngagementID: eid, AssetID: aid, FindingID: fid,
+		TargetKind: attackpath.TargetCanonical, Producer: shared.ID("prod-1"),
+		Provenance: shared.ID("prov-1"), Confidence: asset.EdgeInferred,
+	}}
+
+	det := detection.Record{
+		ID: detID, TenantID: tid, EngagementID: eid, AssetID: aid,
+		RecordedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	p := &fakeProposer{}
+	ev := &Evaluator{
+		proposer:   p,
+		findings:   &fakeFindingRepo{findings: []finding.Finding{f}},
+		judgments:  &fakeJudgmentStore{},
+		bindings:   &fakeAttackPathStore{bindings: bindings},
+		assets:     &fakeAssetRepo{assets: []*asset.Asset{exposureAsset, targetAsset}, edges: edges},
+		detections: &fakeDetectionStore{records: []detection.Record{det}},
+		engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()},
+		promotions: &fakePromotionStore{},
+		clock:      &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+		audit:      &fakeAudit{},
+	}
+
+	ctx := shared.WithTenant(context.Background(), tid)
+	n, err := ev.Evaluate(ctx, eid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 proposal for inferred path, got %d", n)
+	}
+	pc := p.proposed[0].Claim.(*judgment.PromotionClaim)
+	if pc.Rule != judgment.RuleUncertainCorroboration {
+		t.Fatalf("expected rule %s, got %s", judgment.RuleUncertainCorroboration, pc.Rule)
+	}
+	if pc.Proposed != judgment.PromotionFlagForReview {
+		t.Fatalf("expected flag_for_review, got %s", pc.Proposed)
+	}
+	if len(pc.Uncertainty) == 0 {
+		t.Fatal("expected uncertainty tokens for inferred path")
+	}
+}
+
+func TestEvaluatorUnrelatedDetectionRejected(t *testing.T) {
+	tid := testTenantID()
+	eid := testEngagementID()
+	aid := testAssetID()
+	expID := testExposureID()
+
+	// Finding bound to asset A, but detection is on asset B (not on any path).
+	f := baseFinding()
+	f.Priority = 3
+
+	exposureAsset := &asset.Asset{ID: expID, TenantID: tid, Kind: asset.KindExposure, Key: "exp-1", Name: "Internet"}
+	targetAsset := &asset.Asset{ID: aid, TenantID: tid, Kind: asset.KindHost, Key: "host-1", Name: "Host"}
+	otherAsset := &asset.Asset{ID: shared.ID("other-asset"), TenantID: tid, Kind: asset.KindHost, Key: "host-2", Name: "Other"}
+	edges := []*asset.Edge{{TenantID: tid, From: expID, To: aid, Kind: asset.EdgeReaches, Provenance: shared.ID("prov-1"), Confidence: asset.EdgeObserved}}
+
+	bindings := []attackpath.Binding{{
+		TenantID: tid, EngagementID: eid, AssetID: aid, FindingID: testFindingID(),
+		TargetKind: attackpath.TargetCanonical, Producer: shared.ID("prod-1"),
+		Provenance: shared.ID("prov-1"), Confidence: asset.EdgeObserved,
+	}}
+
+	// Detection on otherAsset (not on the path to the finding).
+	det := detection.Record{
+		ID: shared.ID("det-other"), TenantID: tid, EngagementID: eid,
+		AssetID:    shared.ID("other-asset"),
+		RecordedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	p := &fakeProposer{}
+	ev := &Evaluator{
+		proposer:   p,
+		findings:   &fakeFindingRepo{findings: []finding.Finding{f}},
+		judgments:  &fakeJudgmentStore{},
+		bindings:   &fakeAttackPathStore{bindings: bindings},
+		assets:     &fakeAssetRepo{assets: []*asset.Asset{exposureAsset, targetAsset, otherAsset}, edges: edges},
+		detections: &fakeDetectionStore{records: []detection.Record{det}},
+		engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()},
+		promotions: &fakePromotionStore{},
+		clock:      &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+		audit:      &fakeAudit{},
+	}
+
+	ctx := shared.WithTenant(context.Background(), tid)
+	n, err := ev.Evaluate(ctx, eid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 proposals for unrelated detection, got %d", n)
+	}
+}
+
+func TestEvaluatorIdempotentSkipUnchangedFingerprint(t *testing.T) {
+	tid := testTenantID()
+	eid := testEngagementID()
+	fid := testFindingID()
+	aid := testAssetID()
+	expID := testExposureID()
+	detID := testDetectionID()
+
+	f := baseFinding()
+	f.Priority = 3
+
+	exposureAsset := &asset.Asset{ID: expID, TenantID: tid, Kind: asset.KindExposure, Key: "exp-1", Name: "Internet"}
+	targetAsset := &asset.Asset{ID: aid, TenantID: tid, Kind: asset.KindHost, Key: "host-1", Name: "Host"}
+	edges := []*asset.Edge{{TenantID: tid, From: expID, To: aid, Kind: asset.EdgeReaches, Provenance: shared.ID("prov-1"), Confidence: asset.EdgeObserved}}
+	bindings := []attackpath.Binding{{
+		TenantID: tid, EngagementID: eid, AssetID: aid, FindingID: fid,
+		TargetKind: attackpath.TargetCanonical, Producer: shared.ID("prod-1"),
+		Provenance: shared.ID("prov-1"), Confidence: asset.EdgeObserved,
+	}}
+	det := detection.Record{
+		ID: detID, TenantID: tid, EngagementID: eid, AssetID: aid,
+		RecordedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	// Pre-compute the expected fingerprint by running evaluate once.
+	p1 := &fakeProposer{}
+	ev1 := &Evaluator{
+		proposer: p1, findings: &fakeFindingRepo{findings: []finding.Finding{f}},
+		judgments: &fakeJudgmentStore{}, bindings: &fakeAttackPathStore{bindings: bindings},
+		assets:     &fakeAssetRepo{assets: []*asset.Asset{exposureAsset, targetAsset}, edges: edges},
+		detections: &fakeDetectionStore{records: []detection.Record{det}},
+		engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()},
+		promotions: &fakePromotionStore{}, clock: &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)}, audit: &fakeAudit{},
+	}
+	ctx := shared.WithTenant(context.Background(), tid)
+	n, err := ev1.Evaluate(ctx, eid)
+	if err != nil || n != 1 {
+		t.Fatalf("first evaluate: n=%d err=%v", n, err)
+	}
+	fp := p1.proposed[0].Claim.(*judgment.PromotionClaim).Fingerprint
+
+	// Second evaluate with existing proposal having same fingerprint -> skip.
+	existingJ := judgment.Judgment{
+		ID: shared.ID("existing-j"), EngagementID: eid, Capability: judgment.CapPromotion,
+		SubjectKind: judgment.SubjectFinding, SubjectID: fid,
+		Claim: judgment.PromotionClaim{FindingID: fid, Fingerprint: fp, Rule: judgment.RuleRuntimeReachableExposed,
+			Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+			Inputs: []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: detID}}},
+		State: judgment.StateProposed,
+	}
+	p2 := &fakeProposer{existing: []judgment.Judgment{existingJ}}
+	ev2 := &Evaluator{
+		proposer: p2, findings: &fakeFindingRepo{findings: []finding.Finding{f}},
+		judgments:  &fakeJudgmentStore{judgments: []judgment.Judgment{existingJ}},
+		bindings:   &fakeAttackPathStore{bindings: bindings},
+		assets:     &fakeAssetRepo{assets: []*asset.Asset{exposureAsset, targetAsset}, edges: edges},
+		detections: &fakeDetectionStore{records: []detection.Record{det}},
+		engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()},
+		promotions: &fakePromotionStore{}, clock: &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+		audit: &fakeAudit{},
+	}
+	n2, err := ev2.Evaluate(ctx, eid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n2 != 0 {
+		t.Fatalf("expected 0 proposals (unchanged fingerprint), got %d", n2)
+	}
+	if len(p2.proposed) != 0 {
+		t.Fatalf("expected 0 proposed (skip unchanged), got %d", len(p2.proposed))
+	}
+}
+
+func TestIndexPromotionProposalsTracksEveryFingerprint(t *testing.T) {
+	claims := []judgment.Judgment{
+		{Capability: judgment.CapPromotion, Claim: judgment.PromotionClaim{FindingID: "finding", Fingerprint: "refuted"}, State: judgment.StateRefuted},
+		{Capability: judgment.CapPromotion, Claim: judgment.PromotionClaim{FindingID: "finding", Fingerprint: "changed"}, State: judgment.StateProposed},
+	}
+	got := indexPromotionProposals(claims)["finding"]
+	if len(got) != 2 {
+		t.Fatalf("fingerprints = %#v, want refuted and changed", got)
+	}
+	if _, ok := got["refuted"]; !ok {
+		t.Fatal("unchanged refuted fingerprint was not evaluated")
+	}
+	if _, ok := got["changed"]; !ok {
+		t.Fatal("changed fingerprint was not retained as eligible comparison state")
+	}
+}
+
+func TestEvaluatorRetriesProposalAuditWithoutDuplicateProposal(t *testing.T) {
+	tid, eid := testTenantID(), testEngagementID()
+	fid, aid, expID, detID := testFindingID(), testAssetID(), testExposureID(), testDetectionID()
+	f := baseFinding()
+	exposure := &asset.Asset{ID: expID, TenantID: tid, Kind: asset.KindExposure, Key: "exp", Name: "Internet"}
+	target := &asset.Asset{ID: aid, TenantID: tid, Kind: asset.KindHost, Key: "host", Name: "Host"}
+	bindings := []attackpath.Binding{{TenantID: tid, EngagementID: eid, AssetID: aid, FindingID: fid, TargetKind: attackpath.TargetCanonical, Producer: "producer", Provenance: "provenance", Confidence: asset.EdgeObserved}}
+	dets := []detection.Record{{ID: detID, TenantID: tid, EngagementID: eid, AssetID: aid, RecordedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)}}
+	clock := &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)}
+	audit := &fakeAudit{fail: 1}
+	newEvaluator := func(p *fakeProposer, judgments []judgment.Judgment) *Evaluator {
+		return &Evaluator{
+			proposer: p, findings: &fakeFindingRepo{findings: []finding.Finding{f}}, judgments: &fakeJudgmentStore{judgments: judgments},
+			bindings: &fakeAttackPathStore{bindings: bindings}, assets: &fakeAssetRepo{assets: []*asset.Asset{exposure, target}, edges: []*asset.Edge{{TenantID: tid, From: expID, To: aid, Kind: asset.EdgeReaches, Provenance: "provenance", Confidence: asset.EdgeObserved}}},
+			detections: &fakeDetectionStore{records: dets}, engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()}, promotions: &fakePromotionStore{}, clock: clock, audit: audit,
+		}
+	}
+	ctx := shared.WithTenant(context.Background(), tid)
+	firstProposer := &fakeProposer{}
+	if _, err := newEvaluator(firstProposer, nil).Evaluate(ctx, eid); err == nil {
+		t.Fatal("first audit failure must be returned")
+	}
+	if len(firstProposer.proposed) != 1 || len(audit.entries) != 0 {
+		t.Fatalf("proposal must persist before failed audit: proposals=%d audits=%d", len(firstProposer.proposed), len(audit.entries))
+	}
+	retryProposer := &fakeProposer{}
+	if n, err := newEvaluator(retryProposer, firstProposer.proposed).Evaluate(ctx, eid); err != nil || n != 0 {
+		t.Fatalf("retry = (%d, %v), want (0, nil)", n, err)
+	}
+	if len(retryProposer.proposed) != 0 || len(audit.entries) != 1 {
+		t.Fatalf("retry duplicated proposal/audit: proposals=%d audits=%d", len(retryProposer.proposed), len(audit.entries))
+	}
+	if _, err := newEvaluator(retryProposer, firstProposer.proposed).Evaluate(ctx, eid); err != nil {
+		t.Fatalf("exact retry: %v", err)
+	}
+	if len(audit.entries) != 1 {
+		t.Fatalf("exact retry duplicated audit: %d", len(audit.entries))
+	}
+}
+
+func TestEvaluatorProposesStackedSignalLossReversalsLIFO(t *testing.T) {
+	fid := testFindingID()
+	first := promotion.PromotionEvent{ID: "escalation-a", FindingID: fid, Effect: judgment.PromotionEscalate, BeforePriority: 4, AfterPriority: 3, AfterFindingVersion: 2}
+	second := promotion.PromotionEvent{ID: "escalation-b", FindingID: fid, Effect: judgment.PromotionEscalate, BeforePriority: 3, AfterPriority: 2, AfterFindingVersion: 3}
+	store := &fakePromotionStore{events: map[shared.ID][]promotion.PromotionEvent{fid: {first, second}}}
+	newEvaluator := func(priority, version int, events []promotion.PromotionEvent) (*Evaluator, *fakeProposer) {
+		store.events[fid] = events
+		f := baseFinding()
+		f.Priority, f.Version = priority, version
+		proposer := &fakeProposer{}
+		return &Evaluator{
+			proposer: proposer, findings: &fakeFindingRepo{findings: []finding.Finding{f}}, judgments: &fakeJudgmentStore{},
+			bindings: &fakeAttackPathStore{}, assets: &fakeAssetRepo{}, detections: &fakeDetectionStore{},
+			engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()}, promotions: store,
+			clock: &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)}, audit: &fakeAudit{},
+		}, proposer
+	}
+	ctx := shared.WithTenant(context.Background(), testTenantID())
+	evaluator, proposer := newEvaluator(2, 3, []promotion.PromotionEvent{first, second})
+	if n, err := evaluator.Evaluate(ctx, testEngagementID()); err != nil || n != 1 {
+		t.Fatalf("first signal-loss evaluation = (%d, %v)", n, err)
+	}
+	claim := proposer.proposed[0].Claim.(*judgment.PromotionClaim)
+	if claim.Rule != judgment.RuleCorroboratingSignalLoss || claim.BeforePriority != 2 || claim.AfterPriority != 3 || claim.Inputs[0].ID != second.ID {
+		t.Fatalf("first reversal claim = %#v, want reversal of %s", claim, second.ID)
+	}
+	reversalB := promotion.PromotionEvent{ID: "reversal-b", FindingID: fid, Effect: judgment.PromotionDeescalate, Rule: judgment.RuleCorroboratingSignalLoss, Inputs: claim.Inputs}
+	evaluator, proposer = newEvaluator(3, 4, []promotion.PromotionEvent{first, second, reversalB})
+	if n, err := evaluator.Evaluate(ctx, testEngagementID()); err != nil || n != 1 {
+		t.Fatalf("second signal-loss evaluation = (%d, %v)", n, err)
+	}
+	claim = proposer.proposed[0].Claim.(*judgment.PromotionClaim)
+	if claim.BeforePriority != 3 || claim.AfterPriority != 4 || claim.Inputs[0].ID != first.ID {
+		t.Fatalf("second reversal claim = %#v, want reversal of %s", claim, first.ID)
+	}
+	evaluator, proposer = newEvaluator(4, 5, append(store.events[fid], promotion.PromotionEvent{ID: "reversal-a", FindingID: fid, Effect: judgment.PromotionDeescalate, Rule: judgment.RuleCorroboratingSignalLoss, Inputs: claim.Inputs}))
+	if n, err := evaluator.Evaluate(ctx, testEngagementID()); err != nil || n != 0 || len(proposer.proposed) != 0 {
+		t.Fatalf("unchanged reevaluation = (%d, %v), proposals=%#v", n, err, proposer.proposed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: ConfirmedRecorder
+// ---------------------------------------------------------------------------
+
+func TestRecorderRejectsNonPromotionCapability(t *testing.T) {
+	r, err := NewConfirmedRecorder(&fakeEvidenceSealer{}, &fakePromotionStore{}, &fakeFindingRepo{findings: []finding.Finding{baseFinding()}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, &fakeAudit{}, &fakeClock{t: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := judgment.Judgment{Capability: judgment.CapSAST, State: judgment.StateConfirmed, EvidenceScore: 90}
+	err = r.RecordConfirmed(shared.WithTenant(context.Background(), testTenantID()), j)
+	if err == nil {
+		t.Fatal("expected error for non-CapPromotion")
+	}
+}
+
+func TestRecorderRejectsNotPublishable(t *testing.T) {
+	r, err := NewConfirmedRecorder(&fakeEvidenceSealer{}, &fakePromotionStore{}, &fakeFindingRepo{findings: []finding.Finding{baseFinding()}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, &fakeAudit{}, &fakeClock{t: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// StateProposed is not publishable.
+	j := judgment.Judgment{Capability: judgment.CapPromotion, State: judgment.StateProposed, EvidenceScore: 90}
+	err = r.RecordConfirmed(shared.WithTenant(context.Background(), testTenantID()), j)
+	if err == nil {
+		t.Fatal("expected error for not publishable")
+	}
+}
+
+func TestRecorderRejectsLowEvidenceScore(t *testing.T) {
+	r, err := NewConfirmedRecorder(&fakeEvidenceSealer{}, &fakePromotionStore{}, &fakeFindingRepo{findings: []finding.Finding{baseFinding()}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, &fakeAudit{}, &fakeClock{t: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := judgment.Judgment{
+		ID: shared.ID("j-1"), EngagementID: testEngagementID(),
+		Capability: judgment.CapPromotion, State: judgment.StateConfirmed,
+		EvidenceScore: 74, Claim: judgment.PromotionClaim{
+			FindingID: testFindingID(), Rule: judgment.RuleRuntimeReachableExposed,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: testDetectionID()}},
+			Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+		},
+	}
+	err = r.RecordConfirmed(shared.WithTenant(context.Background(), testTenantID()), j)
+	if err == nil {
+		t.Fatal("expected error for score < threshold")
+	}
+}
+
+func TestRecorderRejectsMissingVerdictProvenance(t *testing.T) {
+	fid := testFindingID()
+	r, err := NewConfirmedRecorder(&fakeEvidenceSealer{}, &fakePromotionStore{}, &fakeFindingRepo{findings: []finding.Finding{baseFinding()}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, &fakeAudit{}, &fakeClock{t: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := judgment.Judgment{
+		ID: "j-missing-provenance", EngagementID: testEngagementID(), Capability: judgment.CapPromotion,
+		SubjectKind: judgment.SubjectFinding, SubjectID: fid, State: judgment.StateConfirmed,
+		EvidenceScore: 75, ProposedBy: "agent:proposer",
+		Claim: judgment.PromotionClaim{
+			FindingID: fid, Rule: judgment.RuleRuntimeReachableExposed,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: testDetectionID()}},
+			Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+			Fingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
+	}
+	for _, tc := range []struct {
+		name string
+		j    judgment.Judgment
+	}{
+		{"missing verifier", base},
+		{"missing rationale", func() judgment.Judgment { j := base; j.VerifiedBy = "human:verifier"; return j }()},
+		{"self verifier", func() judgment.Judgment {
+			j := base
+			j.VerifiedBy, j.VerdictRationale = "agent:proposer", "confirmed"
+			return j
+		}()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := r.RecordConfirmed(shared.WithTenant(context.Background(), testTenantID()), tc.j); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("RecordConfirmed: want ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRecorderScoreMeetsThresholdApplies(t *testing.T) {
+	fid := testFindingID()
+	ps := &fakePromotionStore{}
+	es := &fakeEvidenceSealer{Evidence: evidence.Evidence{ID: testEvidenceID()}}
+	audit := &fakeAudit{}
+	r, err := NewConfirmedRecorder(es, ps, &fakeFindingRepo{findings: []finding.Finding{baseFinding()}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, audit, &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := judgment.Judgment{
+		ID: shared.ID("j-1"), EngagementID: testEngagementID(),
+		Capability: judgment.CapPromotion, SubjectKind: judgment.SubjectFinding, SubjectID: fid,
+		State:         judgment.StateConfirmed,
+		EvidenceScore: 75, ProposedBy: "agent:proposer", VerifiedBy: "human:verifier", VerdictRationale: "confirmed",
+		Claim: judgment.PromotionClaim{
+			FindingID: fid, Rule: judgment.RuleRuntimeReachableExposed,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: testDetectionID()}},
+			Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+			Fingerprint: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		},
+	}
+	err = r.RecordConfirmed(shared.WithTenant(context.Background(), testTenantID()), j)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ps.applied) != 1 {
+		t.Fatalf("expected 1 applied command, got %d", len(ps.applied))
+	}
+	if ps.applied[0].JudgmentID != j.ID {
+		t.Fatalf("applied command judgment mismatch")
+	}
+	if ps.applied[0].EvidenceID.IsZero() {
+		t.Fatalf("expected evidence ID to be set")
+	}
+	if ps.applied[0].VerdictScore != 75 {
+		t.Fatalf("expected sealed verdict score 75, got %d", ps.applied[0].VerdictScore)
+	}
+	if len(audit.entries) != 1 || audit.entries[0].Action != "promotion.applied" {
+		t.Fatalf("expected audit entry for promotion.applied")
+	}
+}
+
+func TestRecorderRejectsStaleFindingBeforeEvidenceSeal(t *testing.T) {
+	f := baseFinding()
+	f.Version = 2
+	evidence := &fakeEvidenceSealer{Evidence: evidence.Evidence{ID: testEvidenceID()}}
+	r, err := NewConfirmedRecorder(evidence, &fakePromotionStore{}, &fakeFindingRepo{findings: []finding.Finding{f}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, &fakeAudit{}, &fakeClock{t: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := judgment.Judgment{
+		ID: "j-stale", EngagementID: testEngagementID(), Capability: judgment.CapPromotion, SubjectKind: judgment.SubjectFinding, SubjectID: testFindingID(),
+		State: judgment.StateConfirmed, EvidenceScore: 75, ProposedBy: "agent:proposer", VerifiedBy: "human:verifier", VerdictRationale: "verified",
+		Claim: judgment.PromotionClaim{FindingID: testFindingID(), Rule: judgment.RuleRuntimeReachableExposed, Inputs: []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: testDetectionID()}}, Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2, Fingerprint: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"},
+	}
+	if err := r.RecordConfirmed(shared.WithTenant(context.Background(), testTenantID()), j); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("RecordConfirmed error = %v, want ErrConflict", err)
+	}
+	if evidence.sealCalled != 0 {
+		t.Fatalf("sealed stale promotion evidence %d times", evidence.sealCalled)
+	}
+}
+
+func TestRecorderCarriesVerdictProvenanceToEvidenceAndEvent(t *testing.T) {
+	fid := testFindingID()
+	ps := &fakePromotionStore{}
+	es := &fakeEvidenceSealer{Evidence: evidence.Evidence{ID: testEvidenceID()}}
+	r, err := NewConfirmedRecorder(es, ps, &fakeFindingRepo{findings: []finding.Finding{baseFinding()}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, &fakeAudit{}, &fakeClock{t: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := judgment.Judgment{
+		ID: "j-provenance", EngagementID: testEngagementID(), Capability: judgment.CapPromotion,
+		SubjectKind: judgment.SubjectFinding, SubjectID: fid, State: judgment.StateConfirmed,
+		EvidenceScore: 91, ProposedBy: "agent:proposer", VerifiedBy: "human:verifier", VerdictRationale: "reproduced",
+		Claim: judgment.PromotionClaim{
+			FindingID: fid, Rule: judgment.RuleRuntimeReachableExposed,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: testDetectionID()}},
+			Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+			Fingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
+	}
+	if err := r.RecordConfirmed(shared.WithTenant(context.Background(), testTenantID()), j); err != nil {
+		t.Fatal(err)
+	}
+	if len(ps.applied) != 1 || ps.applied[0].VerdictScore != 91 || ps.applied[0].Verifier != "human:verifier" || ps.applied[0].VerdictRationale != "reproduced" {
+		t.Fatalf("event provenance not preserved: %#v", ps.applied)
+	}
+	if string(es.Content) == "" || !strings.Contains(string(es.Content), `"verdict_score":91`) || !strings.Contains(string(es.Content), `"verified_by":"human:verifier"`) || !strings.Contains(string(es.Content), `"verdict_rationale":"reproduced"`) {
+		t.Fatalf("evidence provenance not preserved: %s", es.Content)
+	}
+}
+
+func TestRecorderIdempotentExactReplay(t *testing.T) {
+	fid := testFindingID()
+	jid := shared.ID("j-1")
+	fp := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	ps := &fakePromotionStore{
+		latest: map[shared.ID]promotion.PromotionEvent{
+			fid: {JudgmentID: jid, Fingerprint: fp},
+		},
+	}
+	es := &fakeEvidenceSealer{Evidence: evidence.Evidence{ID: testEvidenceID()}}
+	r, err := NewConfirmedRecorder(es, ps, &fakeFindingRepo{findings: []finding.Finding{baseFinding()}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, &fakeAudit{}, &fakeClock{t: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := judgment.Judgment{
+		ID: jid, EngagementID: testEngagementID(),
+		Capability: judgment.CapPromotion, SubjectKind: judgment.SubjectFinding, SubjectID: fid,
+		State:         judgment.StateConfirmed,
+		EvidenceScore: 75, ProposedBy: "agent:proposer", VerifiedBy: "human:verifier", VerdictRationale: "confirmed",
+		Claim: judgment.PromotionClaim{
+			FindingID: fid, Rule: judgment.RuleRuntimeReachableExposed,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: testDetectionID()}},
+			Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+			Fingerprint: fp,
+		},
+	}
+	err = r.RecordConfirmed(shared.WithTenant(context.Background(), testTenantID()), j)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Exact replay must reach the lifecycle store, which validates complete semantics.
+	if len(ps.applied) != 1 {
+		t.Fatalf("expected 1 applied replay, got %d", len(ps.applied))
+	}
+}
+
+func TestRecorderRetriesAuditWithoutRepeatingLifecycle(t *testing.T) {
+	fid := testFindingID()
+	ps := &fakePromotionStore{}
+	es := &fakeEvidenceSealer{Evidence: evidence.Evidence{ID: testEvidenceID()}}
+	audit := &fakeAudit{fail: 1}
+	r, err := NewConfirmedRecorder(es, ps, &fakeFindingRepo{findings: []finding.Finding{baseFinding()}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, audit, &fakeClock{t: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := judgment.Judgment{
+		ID: "j-audit-retry", EngagementID: testEngagementID(), Capability: judgment.CapPromotion,
+		SubjectKind: judgment.SubjectFinding, SubjectID: fid, State: judgment.StateConfirmed,
+		EvidenceScore: 75, ProposedBy: "agent:proposer", VerifiedBy: "human:verifier", VerdictRationale: "confirmed",
+		Claim: judgment.PromotionClaim{
+			FindingID: fid, Rule: judgment.RuleRuntimeReachableExposed,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: testDetectionID()}},
+			Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+			Fingerprint: "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+		},
+	}
+	ctx := shared.WithTenant(context.Background(), testTenantID())
+	if err := r.RecordConfirmed(ctx, j); err == nil {
+		t.Fatal("first audit failure must be returned")
+	}
+	if len(ps.applied) != 1 || es.sealCalled != 1 {
+		t.Fatalf("failed audit must retain one lifecycle application and evidence seal, got applications=%d seals=%d", len(ps.applied), es.sealCalled)
+	}
+	if err := r.RecordConfirmed(ctx, j); err != nil {
+		t.Fatalf("retry audit: %v", err)
+	}
+	if len(ps.applied) != 1 || es.sealCalled != 1 {
+		t.Fatalf("retry must not repeat lifecycle application or evidence seal, got applications=%d seals=%d", len(ps.applied), es.sealCalled)
+	}
+	if len(audit.entries) != 1 || audit.entries[0].Metadata["idempotency_key"] == "" {
+		t.Fatalf("retry must create one idempotent audit record: %#v", audit.entries)
+	}
+	if err := r.RecordConfirmed(ctx, j); err != nil {
+		t.Fatalf("successful replay: %v", err)
+	}
+	if len(audit.entries) != 1 || len(ps.applied) != 1 {
+		t.Fatalf("successful replay duplicated audit or lifecycle: audits=%d applications=%d", len(audit.entries), len(ps.applied))
+	}
+}
+
+func TestRecorderRetriesPersistedPromotionAuditPayloadAfterAcknowledgementFailure(t *testing.T) {
+	fid := testFindingID()
+	appliedAt := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	event := promotion.PromotionEvent{
+		ID: "event-audit-retry", EngagementID: testEngagementID(), JudgmentID: "judgment-audit-retry", FindingID: fid,
+		Rule: judgment.RuleRuntimeReachableExposed, Effect: judgment.PromotionEscalate, Fingerprint: strings.Repeat("a", 64), EvidenceID: testEvidenceID(), AppliedAt: appliedAt,
+	}
+	promotions := &reconciliationAudits{pending: []promotion.PromotionEvent{event}, failMark: 1}
+	audit := &fakeAudit{}
+	reconciler, err := NewReconciler(&fakeJudgmentStore{}, promotions, &reconciliationRecorder{}, audit, &fakeClock{t: appliedAt.Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := shared.WithTenant(context.Background(), testTenantID())
+	if err := reconciler.Reconcile(ctx, testEngagementID()); err == nil {
+		t.Fatal("acknowledgement failure must be returned")
+	}
+	if len(audit.entries) != 1 || !audit.entries[0].At.Equal(appliedAt) {
+		t.Fatalf("first audit = %#v, want persisted AppliedAt %s", audit.entries, appliedAt)
+	}
+	if len(promotions.pending) != 1 || len(promotions.marked) != 1 {
+		t.Fatalf("pending audit cleared after failed acknowledgement: pending=%#v marked=%#v", promotions.pending, promotions.marked)
+	}
+	if err := reconciler.Reconcile(ctx, testEngagementID()); err != nil {
+		t.Fatalf("retry reconciliation: %v", err)
+	}
+	if len(audit.entries) != 1 || len(promotions.pending) != 0 || len(promotions.marked) != 2 {
+		t.Fatalf("retry duplicated audit or left status pending: audits=%#v pending=%#v marked=%#v", audit.entries, promotions.pending, promotions.marked)
+	}
+}
+
+func latestPromotionJudgment(t *testing.T, judgments []judgment.Judgment) judgment.Judgment {
+	t.Helper()
+	for i := len(judgments) - 1; i >= 0; i-- {
+		if judgments[i].Capability == judgment.CapPromotion {
+			return judgments[i]
+		}
+	}
+	t.Fatal("missing promotion judgment")
+	return judgment.Judgment{}
+}
+
+func assertPriority(t *testing.T, findings ports.FindingRepository, ctx context.Context, engagementID, findingID shared.ID, priority, version int) {
+	t.Helper()
+	got, err := findings.GetByEngagementAndID(ctx, engagementID, findingID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Priority != priority || got.Version != version {
+		t.Fatalf("finding = priority %d version %d, want %d/%d", got.Priority, got.Version, priority, version)
+	}
+}
+
+func countAudit(entries []ports.AuditEntry, action string) int {
+	n := 0
+	for _, entry := range entries {
+		if entry.Action == action {
+			n++
+		}
+	}
+	return n
+}
+
+func recoveryJudgment() judgment.Judgment {
+	return judgment.Judgment{
+		ID: "recovery-judgment", EngagementID: testEngagementID(),
+		Capability: judgment.CapPromotion, SubjectKind: judgment.SubjectFinding, SubjectID: testFindingID(),
+		State: judgment.StateConfirmed, EvidenceScore: 75, ProposedBy: "agent:proposer", VerifiedBy: "human:verifier", VerdictRationale: "confirmed",
+		Claim: judgment.PromotionClaim{
+			FindingID: testFindingID(), Rule: judgment.RuleRuntimeReachableExposed,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: testDetectionID()}},
+			Proposed: judgment.PromotionEscalate, FindingVersion: 1, BeforePriority: 3, AfterPriority: 2,
+			Fingerprint: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		},
+	}
+}
+
+func TestRecorderFlagForReviewNoPriorityBump(t *testing.T) {
+	fid := testFindingID()
+	ps := &fakePromotionStore{}
+	es := &fakeEvidenceSealer{Evidence: evidence.Evidence{ID: testEvidenceID()}}
+	audit := &fakeAudit{}
+	r, err := NewConfirmedRecorder(es, ps, &fakeFindingRepo{findings: []finding.Finding{baseFinding()}}, &fakeEngagementOwnershipReader{eng: baseEngagement()}, audit, &fakeClock{t: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := judgment.Judgment{
+		ID: shared.ID("j-review"), EngagementID: testEngagementID(),
+		Capability: judgment.CapPromotion, SubjectKind: judgment.SubjectFinding, SubjectID: fid,
+		State:         judgment.StateConfirmed,
+		EvidenceScore: 75, ProposedBy: "agent:proposer", VerifiedBy: "human:verifier", VerdictRationale: "confirmed",
+		Claim: judgment.PromotionClaim{
+			FindingID: fid, Rule: judgment.RuleUncertainCorroboration,
+			Inputs:   []judgment.PromotionInput{{Kind: judgment.PromotionInputDetection, ID: testDetectionID()}},
+			Proposed: judgment.PromotionFlagForReview, FindingVersion: 1,
+			BeforePriority: 3, AfterPriority: 3,
+			Uncertainty: []string{"inferred_edge"}, Fingerprint: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+		},
+	}
+	err = r.RecordConfirmed(shared.WithTenant(context.Background(), testTenantID()), j)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ps.applied) != 1 {
+		t.Fatalf("expected 1 applied, got %d", len(ps.applied))
+	}
+	cmd := ps.applied[0]
+	if cmd.BeforePriority != 3 || cmd.AfterPriority != 3 {
+		t.Fatalf("expected no priority change for review, got %d->%d", cmd.BeforePriority, cmd.AfterPriority)
+	}
+	if cmd.Effect != judgment.PromotionFlagForReview {
+		t.Fatalf("expected flag_for_review, got %s", cmd.Effect)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Architecture: Evaluator cannot Verify/Accept
+// ---------------------------------------------------------------------------
+
+// Compile-time check that the proposer interface does NOT include Verify or Accept.
+// This is enforced by the narrow interface definition, but we verify it explicitly.
+func TestEvaluatorCannotVerify(t *testing.T) {
+	// The evaluator proposal authority excludes verification, acceptance, and reads.
+	// It cannot confirm a promotion or use proposal listing as state.
+	type proposerCheck interface {
+		Propose(context.Context, string, shared.ID, judgment.Capability, judgment.SubjectKind, shared.ID, judgment.Claim) (judgment.Judgment, error)
+	}
+	var _ proposerCheck = (proposer)(nil)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Constructor validation
+// ---------------------------------------------------------------------------
+
+func TestNewEvaluatorRejectsNilDependencies(t *testing.T) {
+	full := func() (*fakeProposer, *fakeFindingRepo, *fakeJudgmentStore, *fakeAttackPathStore, *fakeAssetRepo, *fakeDetectionStore, *fakeEngagementOwnershipReader, *fakePromotionStore, *fakeClock, *fakeAudit) {
+		return &fakeProposer{}, &fakeFindingRepo{}, &fakeJudgmentStore{},
+			&fakeAttackPathStore{}, &fakeAssetRepo{}, &fakeDetectionStore{},
+			&fakeEngagementOwnershipReader{}, &fakePromotionStore{}, &fakeClock{}, &fakeAudit{}
+	}
+	cases := []struct {
+		name string
+		new  func(*fakeProposer, *fakeFindingRepo, *fakeJudgmentStore, *fakeAttackPathStore, *fakeAssetRepo, *fakeDetectionStore, *fakeEngagementOwnershipReader, *fakePromotionStore, *fakeClock, *fakeAudit) (*Evaluator, error)
+	}{
+		{"nil_proposer", func(_ *fakeProposer, fr *fakeFindingRepo, jr *fakeJudgmentStore, ap *fakeAttackPathStore, ar *fakeAssetRepo, dr *fakeDetectionStore, er *fakeEngagementOwnershipReader, ps *fakePromotionStore, cl *fakeClock, au *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(nil, fr, jr, ap, ar, dr, er, ps, cl, au)
+		}},
+		{"nil_findings", func(p *fakeProposer, _ *fakeFindingRepo, jr *fakeJudgmentStore, ap *fakeAttackPathStore, ar *fakeAssetRepo, dr *fakeDetectionStore, er *fakeEngagementOwnershipReader, ps *fakePromotionStore, cl *fakeClock, au *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(p, nil, jr, ap, ar, dr, er, ps, cl, au)
+		}},
+		{"nil_judgments", func(p *fakeProposer, fr *fakeFindingRepo, _ *fakeJudgmentStore, ap *fakeAttackPathStore, ar *fakeAssetRepo, dr *fakeDetectionStore, er *fakeEngagementOwnershipReader, ps *fakePromotionStore, cl *fakeClock, au *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(p, fr, nil, ap, ar, dr, er, ps, cl, au)
+		}},
+		{"nil_bindings", func(p *fakeProposer, fr *fakeFindingRepo, jr *fakeJudgmentStore, _ *fakeAttackPathStore, ar *fakeAssetRepo, dr *fakeDetectionStore, er *fakeEngagementOwnershipReader, ps *fakePromotionStore, cl *fakeClock, au *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(p, fr, jr, nil, ar, dr, er, ps, cl, au)
+		}},
+		{"nil_assets", func(p *fakeProposer, fr *fakeFindingRepo, jr *fakeJudgmentStore, ap *fakeAttackPathStore, _ *fakeAssetRepo, dr *fakeDetectionStore, er *fakeEngagementOwnershipReader, ps *fakePromotionStore, cl *fakeClock, au *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(p, fr, jr, ap, nil, dr, er, ps, cl, au)
+		}},
+		{"nil_detections", func(p *fakeProposer, fr *fakeFindingRepo, jr *fakeJudgmentStore, ap *fakeAttackPathStore, ar *fakeAssetRepo, _ *fakeDetectionStore, er *fakeEngagementOwnershipReader, ps *fakePromotionStore, cl *fakeClock, au *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(p, fr, jr, ap, ar, nil, er, ps, cl, au)
+		}},
+		{"nil_engagement", func(p *fakeProposer, fr *fakeFindingRepo, jr *fakeJudgmentStore, ap *fakeAttackPathStore, ar *fakeAssetRepo, dr *fakeDetectionStore, _ *fakeEngagementOwnershipReader, ps *fakePromotionStore, cl *fakeClock, au *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(p, fr, jr, ap, ar, dr, nil, ps, cl, au)
+		}},
+		{"nil_promotions", func(p *fakeProposer, fr *fakeFindingRepo, jr *fakeJudgmentStore, ap *fakeAttackPathStore, ar *fakeAssetRepo, dr *fakeDetectionStore, er *fakeEngagementOwnershipReader, _ *fakePromotionStore, cl *fakeClock, au *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(p, fr, jr, ap, ar, dr, er, nil, cl, au)
+		}},
+		{"nil_clock", func(p *fakeProposer, fr *fakeFindingRepo, jr *fakeJudgmentStore, ap *fakeAttackPathStore, ar *fakeAssetRepo, dr *fakeDetectionStore, er *fakeEngagementOwnershipReader, ps *fakePromotionStore, _ *fakeClock, au *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(p, fr, jr, ap, ar, dr, er, ps, nil, au)
+		}},
+		{"nil_audit", func(p *fakeProposer, fr *fakeFindingRepo, jr *fakeJudgmentStore, ap *fakeAttackPathStore, ar *fakeAssetRepo, dr *fakeDetectionStore, er *fakeEngagementOwnershipReader, ps *fakePromotionStore, cl *fakeClock, _ *fakeAudit) (*Evaluator, error) {
+			return NewEvaluator(p, fr, jr, ap, ar, dr, er, ps, cl, nil)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, fr, jr, ap, ar, dr, er, ps, cl, au := full()
+			if _, err := tc.new(p, fr, jr, ap, ar, dr, er, ps, cl, au); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestNewConfirmedRecorderRejectsNilDependencies(t *testing.T) {
+	full := func() (*fakeEvidenceSealer, *fakePromotionStore, *fakeFindingRepo, *fakeAudit, *fakeClock) {
+		return &fakeEvidenceSealer{}, &fakePromotionStore{}, &fakeFindingRepo{}, &fakeAudit{}, &fakeClock{}
+	}
+	t.Run("nil_evidence", func(t *testing.T) {
+		_, ps, fr, au, cl := full()
+		_, err := NewConfirmedRecorder(nil, ps, fr, &fakeEngagementOwnershipReader{eng: baseEngagement()}, au, cl)
+		if err == nil {
+			t.Error("expected error")
+		}
+	})
+	t.Run("nil_promotions", func(t *testing.T) {
+		es, _, fr, au, cl := full()
+		_, err := NewConfirmedRecorder(es, nil, fr, &fakeEngagementOwnershipReader{eng: baseEngagement()}, au, cl)
+		if err == nil {
+			t.Error("expected error")
+		}
+	})
+	t.Run("nil_findings", func(t *testing.T) {
+		es, ps, _, au, cl := full()
+		_, err := NewConfirmedRecorder(es, ps, nil, &fakeEngagementOwnershipReader{eng: baseEngagement()}, au, cl)
+		if err == nil {
+			t.Error("expected error")
+		}
+	})
+	t.Run("nil_audit", func(t *testing.T) {
+		es, ps, fr, _, cl := full()
+		_, err := NewConfirmedRecorder(es, ps, fr, &fakeEngagementOwnershipReader{eng: baseEngagement()}, nil, cl)
+		if err == nil {
+			t.Error("expected error")
+		}
+	})
+	t.Run("nil_clock", func(t *testing.T) {
+		es, ps, fr, au, _ := full()
+		_, err := NewConfirmedRecorder(es, ps, fr, &fakeEngagementOwnershipReader{eng: baseEngagement()}, au, nil)
+		if err == nil {
+			t.Error("expected error")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Stable ordering
+// ---------------------------------------------------------------------------
+
+func TestEvaluatorStableFindingOrder(t *testing.T) {
+	// Create findings in reverse order; evaluate should process them sorted by ID.
+	f1 := finding.Finding{ID: shared.ID("find-z"), EngagementID: testEngagementID(), Priority: 3, Version: 1, Kind: finding.KindSCA, DedupKey: "z"}
+	f2 := finding.Finding{ID: shared.ID("find-a"), EngagementID: testEngagementID(), Priority: 3, Version: 1, Kind: finding.KindSCA, DedupKey: "a"}
+
+	p := &fakeProposer{}
+	ev := &Evaluator{
+		proposer: p, findings: &fakeFindingRepo{findings: []finding.Finding{f1, f2}},
+		judgments: &fakeJudgmentStore{}, bindings: &fakeAttackPathStore{},
+		assets: &fakeAssetRepo{}, detections: &fakeDetectionStore{},
+		engagement: &fakeEngagementOwnershipReader{eng: baseEngagement()},
+		promotions: &fakePromotionStore{}, clock: &fakeClock{t: time.Now()},
+		audit: &fakeAudit{},
+	}
+	ctx := shared.WithTenant(context.Background(), testTenantID())
+	_, err := ev.Evaluate(ctx, testEngagementID())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No proposals expected (no detections), but verify no error with sorted input.
+	_ = p
+}
+
+// ---------------------------------------------------------------------------
+// Tests: FilterActive
+// ---------------------------------------------------------------------------
+
+func TestFilterActiveExpired(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	records := []detection.Record{
+		{ID: shared.ID("active"), RecordedAt: now},
+		{ID: shared.ID("no-expiry"), RecordedAt: now},
+		{ID: shared.ID("expired"), RecordedAt: now, ExpiresAt: now.Add(-time.Hour)},
+	}
+	active := filterActive(records, now)
+	if len(active) != 2 {
+		t.Fatalf("expected 2 active, got %d", len(active))
+	}
+}
+
+// Ensure the imports are used.
+var _ = promotion.Snapshot{}
+var _ = judgment.PromotionClaim{}
+var _ = attackpath.Binding{}
+var _ = detection.Record{}
+var _ = evidence.Evidence{}
+var _ = asset.KindExposure
+var _ = engdom.Engagement{}
+
+type reconciliationRecorder struct {
+	failed shared.ID
+	called []shared.ID
+}
+
+func (r *reconciliationRecorder) RecordConfirmed(_ context.Context, j judgment.Judgment) error {
+	r.called = append(r.called, j.ID)
+	if j.ID == r.failed {
+		return errors.New("record failed")
+	}
+	return nil
+}
+
+type reconciliationAudits struct {
+	pending  []promotion.PromotionEvent
+	marked   []shared.ID
+	failMark int
+}
+
+func (a *reconciliationAudits) ListPendingAudits(_ context.Context, _ shared.ID) ([]promotion.PromotionEvent, error) {
+	return a.pending, nil
+}
+
+func (a *reconciliationAudits) MarkAuditComplete(_ context.Context, id shared.ID) error {
+	a.marked = append(a.marked, id)
+	if a.failMark > 0 {
+		a.failMark--
+		return errors.New("acknowledgement unavailable")
+	}
+	for i, event := range a.pending {
+		if event.ID == id {
+			a.pending = append(a.pending[:i], a.pending[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func TestReconcilerContinuesFailuresAndDrainsPendingAudits(t *testing.T) {
+	first, second := recoveryJudgment(), recoveryJudgment()
+	first.ID, second.ID = "failed", "succeeds"
+	recorder := &reconciliationRecorder{failed: first.ID}
+	audits := &reconciliationAudits{pending: []promotion.PromotionEvent{{ID: "audit-1", FindingID: testFindingID()}, {ID: "audit-2", FindingID: testFindingID()}}}
+	reconciler, err := NewReconciler(&fakeJudgmentStore{judgments: []judgment.Judgment{first, second}}, audits, recorder, &fakeAudit{}, &fakeClock{t: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = reconciler.Reconcile(shared.WithTenant(context.Background(), testTenantID()), testEngagementID())
+	if err == nil || !strings.Contains(err.Error(), "recover confirmed promotion failed") {
+		t.Fatalf("Reconcile error = %v, want joined failed promotion error", err)
+	}
+	if len(recorder.called) != 2 || recorder.called[1] != second.ID {
+		t.Fatalf("recovered judgments = %#v, want both", recorder.called)
+	}
+	if len(audits.marked) != 2 {
+		t.Fatalf("completed audits = %#v, want both pending audits drained", audits.marked)
+	}
+}
+
+type conflictAudit struct{}
+
+func (conflictAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+func (conflictAudit) RecordOnce(context.Context, ports.AuditEntry) error { return shared.ErrConflict }
+
+func TestReconcilerLeavesPendingAuditAfterRecordOnceConflict(t *testing.T) {
+	audits := &reconciliationAudits{pending: []promotion.PromotionEvent{{ID: "audit-1", FindingID: testFindingID()}}}
+	reconciler, err := NewReconciler(&fakeJudgmentStore{}, audits, &reconciliationRecorder{}, conflictAudit{}, &fakeClock{t: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = reconciler.Reconcile(shared.WithTenant(context.Background(), testTenantID()), testEngagementID())
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("Reconcile error = %v, want ErrConflict", err)
+	}
+	if len(audits.marked) != 0 {
+		t.Fatalf("completed audits = %#v, want none after RecordOnce conflict", audits.marked)
+	}
+}
+
+func TestReconcilerStopsPromptlyOnContextCancellation(t *testing.T) {
+	recorder := &reconciliationRecorder{}
+	audits := &reconciliationAudits{}
+	reconciler, err := NewReconciler(&fakeJudgmentStore{judgments: []judgment.Judgment{recoveryJudgment()}}, audits, recorder, &fakeAudit{}, &fakeClock{t: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(shared.WithTenant(context.Background(), testTenantID()))
+	cancel()
+	if err := reconciler.Reconcile(ctx, testEngagementID()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Reconcile error = %v, want context.Canceled", err)
+	}
+	if len(recorder.called) != 0 {
+		t.Fatalf("recovered canceled judgment: %#v", recorder.called)
+	}
+}
+
+func promotionTraversalFixture(t *testing.T) (*attackpath.Graph, promotion.PromotionEvent, map[shared.ID]reachInfo) {
+	t.Helper()
+	tenantID, engagementID, findingID := testTenantID(), testEngagementID(), testFindingID()
+	exposureID, assetID := testExposureID(), testAssetID()
+	graph, err := attackpath.NewGraph(attackpath.Input{
+		TenantID: tenantID,
+		Assets: []asset.Asset{
+			{ID: exposureID, TenantID: tenantID, Kind: asset.KindExposure, Key: "exposure", Name: "Exposure"},
+			{ID: assetID, TenantID: tenantID, Kind: asset.KindHost, Key: "asset", Name: "Asset"},
+		},
+		Edges:    []asset.Edge{{TenantID: tenantID, From: exposureID, To: assetID, Kind: asset.EdgeReaches, Provenance: "edge", Confidence: asset.EdgeObserved}},
+		Bindings: []attackpath.Binding{{TenantID: tenantID, EngagementID: engagementID, AssetID: assetID, FindingID: findingID, TargetKind: attackpath.TargetCanonical, Producer: "producer", Provenance: "binding", Confidence: asset.EdgeObserved}},
+		Findings: []attackpath.FindingInput{{Target: attackpath.FindingTarget{ID: findingID, Kind: attackpath.TargetCanonical}, Finding: baseFinding()}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return graph, promotion.PromotionEvent{ID: "event", FindingID: findingID, Effect: judgment.PromotionEscalate, Inputs: []judgment.PromotionInput{
+		{Kind: judgment.PromotionInputAttackPath, ID: "path"},
+		{Kind: judgment.PromotionInputReachability, ID: "reach"},
+		{Kind: judgment.PromotionInputDetection, ID: testDetectionID()},
+	}}, map[shared.ID]reachInfo{findingID: {judgmentID: "reach", state: judgment.Reachable, publishable: true}}
+}
+
+func TestPromotionTraversalCancellationPropagates(t *testing.T) {
+	graph, event, reachability := promotionTraversalFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := (&Evaluator{}).buildSnapshot(ctx, baseFinding(), graph, nil, reachability, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("buildSnapshot error = %v, want context.Canceled", err)
+	}
+	if _, err := inputsStillActive(ctx, event, testFindingID(), graph, nil, reachability); !errors.Is(err, context.Canceled) {
+		t.Fatalf("inputsStillActive error = %v, want context.Canceled", err)
+	}
+	if _, err := escalationInputsMatch(ctx, event, testFindingID(), graph, nil, reachability); !errors.Is(err, context.Canceled) {
+		t.Fatalf("escalationInputsMatch error = %v, want context.Canceled", err)
+	}
+
+	ev, _, _ := baseEvaluator(t)
+	ev.assets = &fakeAssetRepo{assets: []*asset.Asset{
+		{ID: testExposureID(), TenantID: testTenantID(), Kind: asset.KindExposure, Key: "exposure", Name: "Exposure"},
+		{ID: testAssetID(), TenantID: testTenantID(), Kind: asset.KindHost, Key: "asset", Name: "Asset"},
+	}, edges: []*asset.Edge{{TenantID: testTenantID(), From: testExposureID(), To: testAssetID(), Kind: asset.EdgeReaches, Provenance: "edge", Confidence: asset.EdgeObserved}}}
+	ev.bindings = &fakeAttackPathStore{bindings: []attackpath.Binding{{TenantID: testTenantID(), EngagementID: testEngagementID(), AssetID: testAssetID(), FindingID: testFindingID(), TargetKind: attackpath.TargetCanonical, Producer: "producer", Provenance: "binding", Confidence: asset.EdgeObserved}}}
+	ev.judgments = &fakeJudgmentStore{judgments: []judgment.Judgment{{ID: "reach", EngagementID: testEngagementID(), Capability: judgment.CapReachability, SubjectKind: judgment.SubjectFinding, SubjectID: testFindingID(), Claim: judgment.ReachabilityClaim{Reachable: judgment.Reachable, Tier: judgment.Tier0}, State: judgment.StateConfirmed, EvidenceScore: 90, ProposedBy: "agent"}}}
+	ev.promotions = &fakePromotionStore{latest: map[shared.ID]promotion.PromotionEvent{testFindingID(): event}}
+	ctx = shared.WithTenant(ctx, testTenantID())
+	if _, err := ev.Evaluate(ctx, testEngagementID()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Evaluate error = %v, want context.Canceled", err)
+	}
+}

--- a/internal/usecase/pyreach/e2e_test.go
+++ b/internal/usecase/pyreach/e2e_test.go
@@ -29,7 +29,8 @@ func (sealer) Seal(context.Context, shared.ID, string, []byte, string) (evidence
 
 type auditor struct{}
 
-func (auditor) Record(context.Context, ports.AuditEntry) error { return nil }
+func (auditor) Record(context.Context, ports.AuditEntry) error     { return nil }
+func (auditor) RecordOnce(context.Context, ports.AuditEntry) error { return nil }
 
 type clock struct{}
 

--- a/internal/usecase/reachproof/coordinator.go
+++ b/internal/usecase/reachproof/coordinator.go
@@ -66,21 +66,21 @@ func actorsFor(tier judgment.ReachabilityTier, language Language) (proposer, ver
 		// named the wrong one would make a module-graph proof indistinguishable from an interprocedural
 		// one in the report and in the audit trail.
 		if language == LanguageJavaScript {
-			return "system:jssymbol-scan", "system:jssymbol-engine", "tier-2 javascript affected-export proof"
+			return judgment.ProofActorJSSymbolScan, judgment.ProofActorJSSymbolEngine, "tier-2 javascript affected-export proof"
 		}
-		return "system:callgraph-scan", "system:callgraph-engine", "tier-2 call-graph proof"
+		return judgment.ProofActorCallgraphScan, judgment.ProofActorCallgraphEngine, "tier-2 call-graph proof"
 	}
 	switch language {
 	case LanguageJavaScript:
-		return "system:jsimport-scan", "system:jsimport-engine", "tier-1 javascript import-reachability proof"
+		return judgment.ProofActorJSImportScan, judgment.ProofActorJSImportEngine, "tier-1 javascript import-reachability proof"
 	case LanguageRust:
-		return "system:rustimport-scan", "system:rustimport-engine", "tier-1 rust import-reachability proof"
+		return judgment.ProofActorRustImportScan, judgment.ProofActorRustImportEngine, "tier-1 rust import-reachability proof"
 	case LanguagePHP:
-		return "system:phpimport-scan", "system:phpimport-engine", "tier-1 php import-reachability proof"
+		return judgment.ProofActorPHPImportScan, judgment.ProofActorPHPImportEngine, "tier-1 php import-reachability proof"
 	case LanguageRuby:
-		return "system:rubyimport-scan", "system:rubyimport-engine", "tier-1 ruby import-reachability proof"
+		return judgment.ProofActorRubyImportScan, judgment.ProofActorRubyImportEngine, "tier-1 ruby import-reachability proof"
 	default:
-		return "system:pyimport-scan", "system:pyimport-engine", "tier-1 import-reachability proof"
+		return judgment.ProofActorPyImportScan, judgment.ProofActorPyImportEngine, "tier-1 import-reachability proof"
 	}
 }
 

--- a/internal/usecase/sca/fptriage_evidence_test.go
+++ b/internal/usecase/sca/fptriage_evidence_test.go
@@ -73,6 +73,17 @@ func (s *aiEvidenceScriptStore) ListByEngagement(_ context.Context, engagementID
 	return out, nil
 }
 
+func (s *aiEvidenceScriptStore) LookupSealedForFinding(_ context.Context, engagementID, findingID shared.ID, kind string) (evdom.Evidence, bool, error) {
+	chain := s.items[engagementID]
+	for i := len(chain) - 1; i >= 0; i-- {
+		e := chain[i]
+		if e.FindingID == findingID && e.Kind == kind {
+			return e, true, nil
+		}
+	}
+	return evdom.Evidence{}, false, nil
+}
+
 type aiEvidenceTestClock struct{ now time.Time }
 
 func (c aiEvidenceTestClock) Now() time.Time { return c.now }

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -1442,6 +1442,15 @@ func (f *fakeEvidence) Head(_ context.Context, _ shared.ID) (string, error) {
 	}
 	return f.items[len(f.items)-1].Hash, nil
 }
+func (f *fakeEvidence) LookupSealedForFinding(_ context.Context, engagementID, findingID shared.ID, kind string) (evidence.Evidence, bool, error) {
+	for i := len(f.items) - 1; i >= 0; i-- {
+		e := f.items[i]
+		if e.EngagementID == engagementID && e.FindingID == findingID && e.Kind == kind {
+			return e, true, nil
+		}
+	}
+	return evidence.Evidence{}, false, nil
+}
 
 type truncatedSecretScanner struct{}
 

--- a/internal/usecase/taintscan/coordinator_test.go
+++ b/internal/usecase/taintscan/coordinator_test.go
@@ -59,6 +59,9 @@ func (f *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
 	f.entries = append(f.entries, e)
 	return nil
 }
+func (f *fakeAudit) RecordOnce(ctx context.Context, e ports.AuditEntry) error {
+	return f.Record(ctx, e)
+}
 
 type fixedClock struct{}
 

--- a/migrations/0082_finding_promotions.sql
+++ b/migrations/0082_finding_promotions.sql
@@ -1,0 +1,207 @@
+-- +goose Up
+-- Phase B1 (Task #9): promotion lifecycle persistence — the append-only record of
+-- applied finding-priority changes plus the atomic CAS store that moves a finding's
+-- priority and version in the same transaction as the event append.
+--
+-- 1) Backfill judgments.tenant_id from their engagement's tenant. Strict: fail
+--    if engagement tenant is empty/missing or if an existing non-empty judgment
+--    tenant conflicts with its engagement tenant. No fallback/default ownership.
+--    Temporarily lifts FORCE RLS on engagements (restored atomically).
+-- 2) Enable forced tenant RLS on judgments (previously unprotected since 0037).
+-- 3) Add composite UNIQUE(tenant_id, id) on judgments so composite FKs from
+--    finding_promotion_events can reference tenant-scoped parent keys.
+-- 4) finding_promotion_events: append-only, RLS-protected, composite
+--    tenant-scoped idempotency, complete metadata, RESTRICT FKs.
+-- 5) Remove standalone SetPriority from the finding mutation surface.
+
+-- 1. Backfill judgments.tenant_id from engagements. Strict: fail if any
+--    judgment has no resolvable engagement or the engagement tenant is empty.
+--    Fail if an existing non-empty judgment tenant conflicts with engagement.
+--
+--    Migrations run as the table owner. engagements already has FORCE RLS
+--    (migration 0057/0066), so the backfill JOIN would see zero engagement
+--    rows when app.current_tenant is unset. Temporarily lift FORCE on
+--    engagements for this transaction; RLS remains ENABLED (non-owner roles
+--    are still governed). Restore FORCE at the end of the same DO block so
+--    any failure rolls back the entire goose transaction, restoring FORCE
+--    automatically.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    -- Lift FORCE so the migration-owner role can read all engagements.
+    EXECUTE 'ALTER TABLE engagements NO FORCE ROW LEVEL SECURITY';
+
+    -- Strict backfill: fail if any judgment is orphaned or has a tenant
+    -- conflict with its engagement.
+    PERFORM 1 FROM (
+        SELECT j.id
+          FROM judgments j
+     LEFT JOIN engagements e ON j.engagement_id = e.id
+         WHERE e.id IS NULL
+            OR e.tenant_id IS NULL
+            OR e.tenant_id = ''
+         LIMIT 1
+    ) bad;
+    IF FOUND THEN
+        RAISE EXCEPTION 'judgments tenant backfill: some judgments have no resolvable engagement or engagement has empty tenant';
+    END IF;
+
+    PERFORM 1 FROM (
+        SELECT j.id
+          FROM judgments j
+          JOIN engagements e ON j.engagement_id = e.id
+         WHERE j.tenant_id IS NOT NULL
+           AND j.tenant_id != ''
+           AND j.tenant_id != e.tenant_id
+         LIMIT 1
+    ) bad;
+    IF FOUND THEN
+        RAISE EXCEPTION 'judgments tenant backfill: some judgments have tenant_id conflicting with engagement tenant';
+    END IF;
+
+    UPDATE judgments j
+       SET tenant_id = e.tenant_id
+      FROM engagements e
+     WHERE j.engagement_id = e.id
+       AND (j.tenant_id IS NULL OR j.tenant_id = '');
+
+    -- Restore FORCE RLS on engagements before this transaction commits.
+    EXECUTE 'ALTER TABLE engagements FORCE ROW LEVEL SECURITY';
+END $$;
+-- +goose StatementEnd
+
+-- 2. Enable forced tenant RLS on judgments (was unprotected since migration 0037).
+CALL synapse_enable_tenant_rls('judgments');
+
+-- 3. Add composite UNIQUE constraints on judgments so composite FKs from
+--    finding_promotion_events can reference tenant-scoped parent keys.
+--    judgments_tenant_id_unique supports the tenant-scoped (tenant_id, id)
+--    FK path. judgments_tenant_engagement_id_unique adds engagement-level
+--    ownership binding so the judgment FK also constrains engagement_id,
+--    preventing a promotion from referencing a judgment that belongs to a
+--    different engagement within the same tenant.
+--    engagements already has engagements_tenant_id_unique from migration 0066.
+--    findings already has findings_tenant_engagement_id_unique from migration 0066.
+ALTER TABLE judgments ADD CONSTRAINT judgments_tenant_id_unique UNIQUE (tenant_id, id);
+ALTER TABLE judgments ADD CONSTRAINT judgments_tenant_engagement_id_unique UNIQUE (tenant_id, engagement_id, id);
+
+-- 4. The promotion events table. Append-only, tenant-scoped, complete metadata.
+CREATE TABLE finding_promotion_events (
+    id                     TEXT PRIMARY KEY,
+    tenant_id              TEXT NOT NULL,
+    engagement_id          TEXT NOT NULL,
+    judgment_id            TEXT NOT NULL,
+    finding_id             TEXT NOT NULL,
+    finding_version        INTEGER NOT NULL,
+    after_finding_version  INTEGER NOT NULL,
+    rule                   TEXT NOT NULL,
+    effect                 TEXT NOT NULL,
+    before_priority        INTEGER NOT NULL,
+    after_priority         INTEGER NOT NULL,
+    inputs                 JSONB NOT NULL,
+    fingerprint            TEXT NOT NULL,
+    verdict_score          INTEGER NOT NULL DEFAULT 0,
+    verdict_rationale      TEXT NOT NULL DEFAULT '',
+    evidence_id            TEXT NOT NULL DEFAULT '',
+    verifier               TEXT NOT NULL DEFAULT '',
+    uncertainty            JSONB NOT NULL DEFAULT '[]',
+    applied_by             TEXT NOT NULL DEFAULT '',
+    applied_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Composite foreign keys using tenant-scoped parent unique constraints.
+-- RESTRICT (not CASCADE): promotion history is append-only — deleting a parent
+-- row that has promotion history must be explicitly blocked, not silently
+-- cascade-destroyed. This follows the repository's append-only evidence/audit
+-- precedent.
+ALTER TABLE finding_promotion_events
+    ADD CONSTRAINT fpe_engagement_fk
+        FOREIGN KEY (tenant_id, engagement_id)
+        REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fpe_finding_fk
+        FOREIGN KEY (tenant_id, engagement_id, finding_id)
+        REFERENCES findings(tenant_id, engagement_id, id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fpe_judgment_fk
+        FOREIGN KEY (tenant_id, engagement_id, judgment_id)
+        REFERENCES judgments(tenant_id, engagement_id, id) ON DELETE RESTRICT;
+
+-- Tenant FK: enforce that the tenant exists.
+ALTER TABLE finding_promotion_events
+    ADD CONSTRAINT fpe_tenant_fk
+        FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+
+-- Priority range constraints.
+ALTER TABLE finding_promotion_events
+    ADD CONSTRAINT fpe_finding_version_positive CHECK (finding_version >= 1),
+    ADD CONSTRAINT fpe_after_version_positive CHECK (after_finding_version >= finding_version),
+    ADD CONSTRAINT fpe_before_priority_range CHECK (before_priority >= 1 AND before_priority <= 5),
+    ADD CONSTRAINT fpe_after_priority_range CHECK (after_priority >= 1 AND after_priority <= 5);
+
+-- Composite tenant+judgment idempotency: a single judgment cannot produce
+-- multiple promotion events under the same tenant.
+CREATE UNIQUE INDEX fpe_judgment_uniq
+    ON finding_promotion_events (tenant_id, judgment_id);
+
+-- Composite tenant+fingerprint idempotency: the same claim digest cannot
+-- appear twice under the same tenant.
+CREATE UNIQUE INDEX fpe_fingerprint_uniq
+    ON finding_promotion_events (tenant_id, fingerprint);
+
+-- Query indexes for the ListByFinding / LatestByFinding read paths.
+-- Includes engagement_id for tenant+engagement+finding scoping.
+CREATE INDEX fpe_finding_idx
+    ON finding_promotion_events (tenant_id, engagement_id, finding_id, applied_at, id);
+
+CREATE INDEX fpe_engagement_idx
+    ON finding_promotion_events (tenant_id, engagement_id);
+
+-- RLS: tenant isolation at the database level.
+CALL synapse_enable_tenant_rls('finding_promotion_events');
+
+-- Append-only enforcement: block UPDATE / DELETE / TRUNCATE.
+CREATE TRIGGER fpe_append_only
+    BEFORE UPDATE OR DELETE ON finding_promotion_events
+    FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+
+CREATE TRIGGER fpe_no_truncate
+    BEFORE TRUNCATE ON finding_promotion_events
+    FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+-- +goose Down
+-- Reverse 0082 additions in dependency order.
+
+-- 1. Remove triggers from finding_promotion_events.
+DROP TRIGGER IF EXISTS fpe_no_truncate ON finding_promotion_events;
+DROP TRIGGER IF EXISTS fpe_append_only ON finding_promotion_events;
+
+-- 2. Remove indexes.
+DROP INDEX IF EXISTS fpe_engagement_idx;
+DROP INDEX IF EXISTS fpe_finding_idx;
+DROP INDEX IF EXISTS fpe_fingerprint_uniq;
+DROP INDEX IF EXISTS fpe_judgment_uniq;
+
+-- 3. Remove constraints added by 0082 (FKs and check constraints).
+ALTER TABLE finding_promotion_events DROP CONSTRAINT IF EXISTS fpe_tenant_fk;
+ALTER TABLE finding_promotion_events DROP CONSTRAINT IF EXISTS fpe_judgment_fk;
+ALTER TABLE finding_promotion_events DROP CONSTRAINT IF EXISTS fpe_finding_fk;
+ALTER TABLE finding_promotion_events DROP CONSTRAINT IF EXISTS fpe_engagement_fk;
+ALTER TABLE finding_promotion_events DROP CONSTRAINT IF EXISTS fpe_finding_version_positive;
+ALTER TABLE finding_promotion_events DROP CONSTRAINT IF EXISTS fpe_after_version_positive;
+ALTER TABLE finding_promotion_events DROP CONSTRAINT IF EXISTS fpe_before_priority_range;
+ALTER TABLE finding_promotion_events DROP CONSTRAINT IF EXISTS fpe_after_priority_range;
+
+-- 4. Drop the table.
+DROP TABLE IF EXISTS finding_promotion_events;
+
+-- 5. Remove the judgments composite unique constraints added by 0082.
+--    Drop engagement-scoped first (depends on tenant-scoped for the parent side
+--    of the FK, though we already dropped fpe_judgment_fk above).
+ALTER TABLE judgments DROP CONSTRAINT IF EXISTS judgments_tenant_engagement_id_unique;
+ALTER TABLE judgments DROP CONSTRAINT IF EXISTS judgments_tenant_id_unique;
+
+-- 6. Remove the judgments RLS policy and forced RLS added by 0082.
+--    synapse_enable_tenant_rls creates a policy named "<table>_tenant_isolation".
+--    We must drop the policy before disabling RLS, then un-FORCE it.
+DROP POLICY IF EXISTS judgments_tenant_isolation ON judgments;
+ALTER TABLE judgments NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE judgments DISABLE ROW LEVEL SECURITY;

--- a/migrations/0083_judgment_verdict_provenance.sql
+++ b/migrations/0083_judgment_verdict_provenance.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Persist sealed verifier provenance with each judgment score transition.
+ALTER TABLE judgments
+    ADD COLUMN verified_by TEXT NOT NULL DEFAULT '',
+    ADD COLUMN verdict_rationale TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE judgments
+    DROP COLUMN IF EXISTS verdict_rationale,
+    DROP COLUMN IF EXISTS verified_by;

--- a/migrations/0084_finding_promotion_audit_status.sql
+++ b/migrations/0084_finding_promotion_audit_status.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- Tracks delivery of the required, idempotent audit record separately from the
+-- append-only lifecycle event. The row is inserted in the same transaction as
+-- the finding mutation and event; completion is retried after crashes.
+ALTER TABLE finding_promotion_events
+    ADD CONSTRAINT fpe_tenant_id_unique UNIQUE (tenant_id, id);
+
+CREATE TABLE finding_promotion_audit_status (
+    tenant_id    TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
+    completed_at TIMESTAMPTZ,
+    PRIMARY KEY (tenant_id, event_id),
+    CONSTRAINT fpas_event_fk FOREIGN KEY (tenant_id, event_id)
+        REFERENCES finding_promotion_events(tenant_id, id) ON DELETE RESTRICT,
+    CONSTRAINT fpas_tenant_fk FOREIGN KEY (tenant_id)
+        REFERENCES tenants(id)
+);
+
+INSERT INTO finding_promotion_audit_status (tenant_id, event_id)
+    SELECT tenant_id, id FROM finding_promotion_events;
+
+CREATE INDEX fpas_pending_idx
+    ON finding_promotion_audit_status (tenant_id, event_id)
+    WHERE completed_at IS NULL;
+
+CALL synapse_enable_tenant_rls('finding_promotion_audit_status');
+
+-- +goose Down
+DROP INDEX IF EXISTS fpas_pending_idx;
+ALTER TABLE finding_promotion_audit_status DROP CONSTRAINT IF EXISTS fpas_tenant_fk;
+ALTER TABLE finding_promotion_audit_status DROP CONSTRAINT IF EXISTS fpas_event_fk;
+DROP TABLE IF EXISTS finding_promotion_audit_status;
+ALTER TABLE finding_promotion_events DROP CONSTRAINT IF EXISTS fpe_tenant_id_unique;

--- a/migrations/0085_audit_log_tenant_idempotency.sql
+++ b/migrations/0085_audit_log_tenant_idempotency.sql
@@ -1,0 +1,54 @@
+-- +goose Up
+-- Legacy rows retain the global v1 chain (hash_version = 1). New v2 rows bind
+-- tenant_id into the canonical hash and form an independent chain per tenant.
+ALTER TABLE audit_log
+    ADD COLUMN idempotency_key TEXT,
+    ADD COLUMN hash_version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE audit_log
+    ADD CONSTRAINT audit_log_hash_version_check CHECK (hash_version IN (1, 2));
+
+CREATE UNIQUE INDEX audit_log_tenant_action_idempotency_key_uniq
+    ON audit_log (tenant_id, action, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+-- The v1 chain has one global parent per hash. V2 chains have one parent per
+-- tenant; retaining the old global index would reject every second tenant root.
+DROP INDEX audit_chain_link_uniq;
+CREATE UNIQUE INDEX audit_chain_link_v1_uniq
+    ON audit_log (previous_hash)
+    WHERE previous_hash IS NOT NULL AND hash_version = 1;
+CREATE UNIQUE INDEX audit_chain_link_v2_uniq
+    ON audit_log (tenant_id, previous_hash)
+    WHERE previous_hash IS NOT NULL AND hash_version = 2;
+
+CREATE INDEX audit_log_tenant_chain_head_idx
+    ON audit_log (tenant_id, hash_version, id DESC)
+    WHERE hash IS NOT NULL;
+
+-- +goose Down
+-- V2 chains are tenant-local. The v1 fork guard is global, so any v2 history
+-- can make the original constraint invalid. Refuse rollback rather than leave
+-- a mixed schema or silently weaken the fork guarantee.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM audit_log
+        WHERE hash_version = 2
+    ) THEN
+        RAISE EXCEPTION 'cannot roll back audit_log tenant chains after tenant genesis rows exist';
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+DROP INDEX IF EXISTS audit_log_tenant_chain_head_idx;
+DROP INDEX IF EXISTS audit_chain_link_v2_uniq;
+DROP INDEX IF EXISTS audit_chain_link_v1_uniq;
+CREATE UNIQUE INDEX audit_chain_link_uniq ON audit_log (previous_hash) WHERE previous_hash IS NOT NULL;
+DROP INDEX IF EXISTS audit_log_tenant_action_idempotency_key_uniq;
+ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_hash_version_check;
+ALTER TABLE audit_log DROP COLUMN IF EXISTS hash_version;
+ALTER TABLE audit_log DROP COLUMN IF EXISTS idempotency_key;

--- a/migrations/0086_audit_log_tenant_rls.sql
+++ b/migrations/0086_audit_log_tenant_rls.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- New v2 rows are tenant-local chains. Legacy v1 rows remain platform-global and
+-- are intentionally invisible to tenant reviewers; verify them with an offline
+-- maintenance connection that has BYPASSRLS rather than this application role.
+ALTER TABLE audit_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_log FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY audit_log_tenant_isolation ON audit_log
+    USING (hash_version = 2 AND tenant_id = synapse_current_tenant())
+    WITH CHECK (hash_version = 2 AND tenant_id = synapse_current_tenant());
+
+-- +goose Down
+DROP POLICY IF EXISTS audit_log_tenant_isolation ON audit_log;
+ALTER TABLE audit_log NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE audit_log DISABLE ROW LEVEL SECURITY;

--- a/migrations/0087_judgment_verdict_audit_status.sql
+++ b/migrations/0087_judgment_verdict_audit_status.sql
@@ -1,0 +1,93 @@
+-- +goose Up
+-- The verdict transition and this outbox row commit together. The payload is the
+-- exact idempotent audit entry to replay after an audit sink failure or crash.
+CREATE TABLE judgment_verdict_audit_status (
+    tenant_id     TEXT NOT NULL,
+    judgment_id   TEXT NOT NULL,
+    version       INTEGER NOT NULL,
+    engagement_id TEXT NOT NULL,
+    actor         TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    target        TEXT NOT NULL,
+    metadata      JSONB NOT NULL,
+    occurred_at   TIMESTAMPTZ NOT NULL,
+    completed_at  TIMESTAMPTZ,
+    PRIMARY KEY (tenant_id, judgment_id, version),
+    CONSTRAINT jvas_version_positive CHECK (version >= 1),
+    CONSTRAINT jvas_judgment_fk FOREIGN KEY (tenant_id, engagement_id, judgment_id)
+        REFERENCES judgments(tenant_id, engagement_id, id) ON DELETE RESTRICT,
+    CONSTRAINT jvas_tenant_fk FOREIGN KEY (tenant_id)
+        REFERENCES tenants(id) ON DELETE RESTRICT
+);
+
+CREATE INDEX jvas_pending_engagement_idx
+    ON judgment_verdict_audit_status (tenant_id, engagement_id, judgment_id, version)
+    WHERE completed_at IS NULL;
+
+CALL synapse_enable_tenant_rls('judgment_verdict_audit_status');
+
+-- The generic RLS policy also permits UPDATE and DELETE. This outbox is immutable
+-- except for one monotonic delivery acknowledgement, so use command-specific
+-- policies and a trigger that remains effective for table owners.
+DROP POLICY judgment_verdict_audit_status_tenant_isolation ON judgment_verdict_audit_status;
+CREATE POLICY judgment_verdict_audit_status_tenant_select ON judgment_verdict_audit_status
+    FOR SELECT USING (tenant_id = synapse_current_tenant());
+CREATE POLICY judgment_verdict_audit_status_tenant_insert ON judgment_verdict_audit_status
+    FOR INSERT WITH CHECK (tenant_id = synapse_current_tenant());
+CREATE POLICY judgment_verdict_audit_status_tenant_update ON judgment_verdict_audit_status
+    FOR UPDATE USING (tenant_id = synapse_current_tenant())
+    WITH CHECK (tenant_id = synapse_current_tenant());
+
+-- +goose StatementBegin
+CREATE FUNCTION judgment_verdict_audit_status_immutable() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'judgment_verdict_audit_status is append-only';
+    END IF;
+    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+        OR NEW.judgment_id IS DISTINCT FROM OLD.judgment_id
+        OR NEW.version IS DISTINCT FROM OLD.version
+        OR NEW.engagement_id IS DISTINCT FROM OLD.engagement_id
+        OR NEW.actor IS DISTINCT FROM OLD.actor
+        OR NEW.action IS DISTINCT FROM OLD.action
+        OR NEW.target IS DISTINCT FROM OLD.target
+        OR NEW.metadata IS DISTINCT FROM OLD.metadata
+        OR NEW.occurred_at IS DISTINCT FROM OLD.occurred_at
+        OR (OLD.completed_at IS NOT NULL AND NEW.completed_at IS DISTINCT FROM OLD.completed_at) THEN
+        RAISE EXCEPTION 'judgment_verdict_audit_status immutable fields cannot change';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE TRIGGER judgment_verdict_audit_status_immutable_trigger
+    BEFORE UPDATE OR DELETE ON judgment_verdict_audit_status
+    FOR EACH ROW EXECUTE FUNCTION judgment_verdict_audit_status_immutable();
+
+-- +goose StatementBegin
+CREATE FUNCTION judgment_verdict_audit_status_no_truncate() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE EXCEPTION 'judgment_verdict_audit_status is append-only';
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE TRIGGER judgment_verdict_audit_status_no_truncate_trigger
+    BEFORE TRUNCATE ON judgment_verdict_audit_status
+    FOR EACH STATEMENT EXECUTE FUNCTION judgment_verdict_audit_status_no_truncate();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS judgment_verdict_audit_status_no_truncate_trigger ON judgment_verdict_audit_status;
+DROP FUNCTION IF EXISTS judgment_verdict_audit_status_no_truncate();
+DROP TRIGGER IF EXISTS judgment_verdict_audit_status_immutable_trigger ON judgment_verdict_audit_status;
+DROP FUNCTION IF EXISTS judgment_verdict_audit_status_immutable();
+DROP POLICY IF EXISTS judgment_verdict_audit_status_tenant_update ON judgment_verdict_audit_status;
+DROP POLICY IF EXISTS judgment_verdict_audit_status_tenant_insert ON judgment_verdict_audit_status;
+DROP POLICY IF EXISTS judgment_verdict_audit_status_tenant_select ON judgment_verdict_audit_status;
+DROP INDEX IF EXISTS jvas_pending_engagement_idx;
+DROP TABLE IF EXISTS judgment_verdict_audit_status;

--- a/migrations/0088_judgment_proposal_audit_and_promotion_hardening.sql
+++ b/migrations/0088_judgment_proposal_audit_and_promotion_hardening.sql
@@ -1,0 +1,70 @@
+-- +goose Up
+CREATE TABLE judgment_proposal_audit_status (
+    tenant_id TEXT NOT NULL, judgment_id TEXT NOT NULL, engagement_id TEXT NOT NULL,
+    actor TEXT NOT NULL, action TEXT NOT NULL, target TEXT NOT NULL, metadata JSONB NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL, completed_at TIMESTAMPTZ,
+    PRIMARY KEY (tenant_id, judgment_id),
+    CONSTRAINT jpas_judgment_fk FOREIGN KEY (tenant_id, engagement_id, judgment_id)
+        REFERENCES judgments(tenant_id, engagement_id, id) ON DELETE RESTRICT,
+    CONSTRAINT jpas_tenant_fk FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE RESTRICT
+);
+CREATE INDEX jpas_pending_engagement_idx ON judgment_proposal_audit_status (tenant_id, engagement_id, judgment_id) WHERE completed_at IS NULL;
+CALL synapse_enable_tenant_rls('judgment_proposal_audit_status');
+DROP POLICY judgment_proposal_audit_status_tenant_isolation ON judgment_proposal_audit_status;
+CREATE POLICY judgment_proposal_audit_status_tenant_select ON judgment_proposal_audit_status FOR SELECT USING (tenant_id = synapse_current_tenant());
+CREATE POLICY judgment_proposal_audit_status_tenant_insert ON judgment_proposal_audit_status FOR INSERT WITH CHECK (tenant_id = synapse_current_tenant());
+CREATE POLICY judgment_proposal_audit_status_tenant_update ON judgment_proposal_audit_status FOR UPDATE USING (tenant_id = synapse_current_tenant()) WITH CHECK (tenant_id = synapse_current_tenant());
+-- +goose StatementBegin
+CREATE FUNCTION judgment_proposal_audit_status_immutable() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'DELETE' OR NEW.tenant_id IS DISTINCT FROM OLD.tenant_id OR NEW.judgment_id IS DISTINCT FROM OLD.judgment_id OR NEW.engagement_id IS DISTINCT FROM OLD.engagement_id OR NEW.actor IS DISTINCT FROM OLD.actor OR NEW.action IS DISTINCT FROM OLD.action OR NEW.target IS DISTINCT FROM OLD.target OR NEW.metadata IS DISTINCT FROM OLD.metadata OR NEW.occurred_at IS DISTINCT FROM OLD.occurred_at OR (OLD.completed_at IS NOT NULL AND NEW.completed_at IS DISTINCT FROM OLD.completed_at) THEN
+        RAISE EXCEPTION 'judgment_proposal_audit_status immutable fields cannot change';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+CREATE TRIGGER judgment_proposal_audit_status_immutable_trigger BEFORE UPDATE OR DELETE ON judgment_proposal_audit_status FOR EACH ROW EXECUTE FUNCTION judgment_proposal_audit_status_immutable();
+-- +goose StatementBegin
+CREATE FUNCTION judgment_proposal_audit_status_no_truncate() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'judgment_proposal_audit_status is append-only'; END; $$;
+-- +goose StatementEnd
+CREATE TRIGGER judgment_proposal_audit_status_no_truncate_trigger BEFORE TRUNCATE ON judgment_proposal_audit_status FOR EACH STATEMENT EXECUTE FUNCTION judgment_proposal_audit_status_no_truncate();
+
+DROP POLICY finding_promotion_audit_status_tenant_isolation ON finding_promotion_audit_status;
+CREATE POLICY finding_promotion_audit_status_tenant_select ON finding_promotion_audit_status FOR SELECT USING (tenant_id = synapse_current_tenant());
+CREATE POLICY finding_promotion_audit_status_tenant_insert ON finding_promotion_audit_status FOR INSERT WITH CHECK (tenant_id = synapse_current_tenant());
+CREATE POLICY finding_promotion_audit_status_tenant_update ON finding_promotion_audit_status FOR UPDATE USING (tenant_id = synapse_current_tenant()) WITH CHECK (tenant_id = synapse_current_tenant());
+-- +goose StatementBegin
+CREATE FUNCTION finding_promotion_audit_status_immutable() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'DELETE' OR NEW.tenant_id IS DISTINCT FROM OLD.tenant_id OR NEW.event_id IS DISTINCT FROM OLD.event_id OR (OLD.completed_at IS NOT NULL AND NEW.completed_at IS DISTINCT FROM OLD.completed_at) THEN
+        RAISE EXCEPTION 'finding_promotion_audit_status immutable fields cannot change';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+CREATE TRIGGER finding_promotion_audit_status_immutable_trigger BEFORE UPDATE OR DELETE ON finding_promotion_audit_status FOR EACH ROW EXECUTE FUNCTION finding_promotion_audit_status_immutable();
+-- +goose StatementBegin
+CREATE FUNCTION finding_promotion_audit_status_no_truncate() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'finding_promotion_audit_status is append-only'; END; $$;
+-- +goose StatementEnd
+CREATE TRIGGER finding_promotion_audit_status_no_truncate_trigger BEFORE TRUNCATE ON finding_promotion_audit_status FOR EACH STATEMENT EXECUTE FUNCTION finding_promotion_audit_status_no_truncate();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS finding_promotion_audit_status_no_truncate_trigger ON finding_promotion_audit_status;
+DROP FUNCTION IF EXISTS finding_promotion_audit_status_no_truncate();
+DROP TRIGGER IF EXISTS finding_promotion_audit_status_immutable_trigger ON finding_promotion_audit_status;
+DROP FUNCTION IF EXISTS finding_promotion_audit_status_immutable();
+DROP POLICY IF EXISTS finding_promotion_audit_status_tenant_update ON finding_promotion_audit_status;
+DROP POLICY IF EXISTS finding_promotion_audit_status_tenant_insert ON finding_promotion_audit_status;
+DROP POLICY IF EXISTS finding_promotion_audit_status_tenant_select ON finding_promotion_audit_status;
+CALL synapse_enable_tenant_rls('finding_promotion_audit_status');
+DROP TRIGGER IF EXISTS judgment_proposal_audit_status_no_truncate_trigger ON judgment_proposal_audit_status;
+DROP FUNCTION IF EXISTS judgment_proposal_audit_status_no_truncate();
+DROP TRIGGER IF EXISTS judgment_proposal_audit_status_immutable_trigger ON judgment_proposal_audit_status;
+DROP FUNCTION IF EXISTS judgment_proposal_audit_status_immutable();
+DROP POLICY IF EXISTS judgment_proposal_audit_status_tenant_update ON judgment_proposal_audit_status;
+DROP POLICY IF EXISTS judgment_proposal_audit_status_tenant_insert ON judgment_proposal_audit_status;
+DROP POLICY IF EXISTS judgment_proposal_audit_status_tenant_select ON judgment_proposal_audit_status;
+DROP INDEX IF EXISTS jpas_pending_engagement_idx;
+DROP TABLE IF EXISTS judgment_proposal_audit_status;


### PR DESCRIPTION
## Summary

Implements deterministic cross-pillar finding promotion through the existing judgment gate. Corroborating reachability, confident internet exposure, and active same-path runtime detection can propose one-level escalation; deterministic unreachability can propose de-escalation; uncertain inputs remain review-only. Promotions require a distinct sealed verifier verdict at the evidence threshold and reverse to the exact prior priority when their support disappears.

Closes #428

## Changes

- Add typed promotion claims, deterministic rule evaluation, stable fingerprints, exact reversal lineage, and code/documentation drift tests.
- Persist append-only tenant-scoped promotion lifecycle events, evidence, before/after priorities, verdict provenance, and durable proposal/verdict/promotion audit outboxes in memory and PostgreSQL.
- Apply confirmed promotions only after sealed verdict evidence and idempotent governance-audit delivery; agents, MCP, pillars, human `Accept`, and the automated LLM verifier remain unable to confirm or apply promotions.
- Add startup/periodic tenant-scoped reconciliation for pending promotions and governance audits, including crash and lost-ack recovery.
- Add migrations `0082`–`0088` for promotion lifecycle, verdict provenance, tenant-local audit chains/RLS, and append-only outbox hardening.
- Separate PostgreSQL migration/admin and runtime roles; production requires a migration DSN and rejects runtime roles with RLS bypass, RLS-table ownership, or DDL authority.
- Add hostile cross-tenant HTTP coverage, memory/PostgreSQL parity tests, cancellation tests, exact replay tests, and full-stack Compose role setup.

## Verification

- [x] `make build vet test typecheck`
- [x] `make harness`
- [x] `make web-build`
- [x] `SYNAPSE_TEST_DB_DSN=... go test -count=1 ./...` against PostgreSQL 17
- [x] `SYNAPSE_TEST_DB_DSN=... go test -count=1 ./internal/infrastructure/persistence/postgres` against the same database
- [x] `git diff --check`
- [x] Fresh full-stack Compose smoke: PostgreSQL and MinIO healthy; API healthy; API/web/proxied health and authenticated AUP returned 200; migration version 88; runtime role `NOSUPERUSER NOBYPASSRLS`; API logs contained no error/fatal/panic entries

## Checklist

- [x] `make build vet test typecheck` passes
- [x] `cd web && pnpm build` passes (if the dashboard changed)
- [x] Documentation updated if needed
