### PR TITLE
feat(ai-triage): govern model promotion and rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **Versioned AI-triage release governance.** Recomputes passing candidate comparisons at the approval boundary and records promotions or rollbacks in a create-only, hash-chained ledger. Every decision requires distinct PM and Security approvals bound to the current ledger head; no release artifact mutates runtime model, prompt, threshold, or gate configuration automatically.
+
 - **AI-triage candidate promotion gate.** Strictly revalidates deterministic shadow reports, compares a candidate model/prompt with a baseline on the exact same reviewed dataset and policy, blocks new true-positive escapes plus overall or segment regressions, and emits stable CI evidence that still requires explicit human promotion approval.
 
 - **Judgment-gated cross-pillar promotion.** Correlates deterministic reachability, confident internet-facing attack paths, and active same-path runtime detections into tenant-scoped priority proposals. Distinct sealed verification applies one-level changes, uncertain inputs remain review-only, and signal loss restores the exact prior priority through an append-only, auditable lifecycle.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install tools dev build run test harness vet lint format typecheck tidy ai-triage-eval ai-triage-compare ai-triage-drift \
+.PHONY: help install tools dev build run test harness vet lint format typecheck tidy ai-triage-eval ai-triage-compare ai-triage-release ai-triage-drift \
         docker-build docker-up docker-down clean web-dev web-build smoke
 
 GO ?= go
@@ -8,6 +8,9 @@ AI_EVAL_OUTPUT ?= ai-triage-eval.json
 AI_EVAL_BASELINE ?= ai-triage-baseline.json
 AI_EVAL_CANDIDATE ?= ai-triage-candidate.json
 AI_EVAL_COMPARISON ?= ai-triage-comparison.json
+AI_RELEASE_MANIFEST ?= ai-triage-release-manifest.json
+AI_RELEASE_LEDGER ?=
+AI_RELEASE_OUTPUT ?= ai-triage-release-ledger.json
 AI_DRIFT_BASELINE ?= ai-triage-drift-baseline.json
 AI_DRIFT_OBSERVED ?= ai-triage-observability.json
 AI_DRIFT_OUTPUT ?= ai-triage-drift-report.json
@@ -58,6 +61,9 @@ ai-triage-eval: ## Evaluate FP triage against the versioned golden dataset (requ
 
 ai-triage-compare: ## Compare candidate and baseline AI-triage shadow reports for promotion review
 	$(GO) run ./cmd/synapse-fptriage-compare --baseline $(AI_EVAL_BASELINE) --candidate $(AI_EVAL_CANDIDATE) --output $(AI_EVAL_COMPARISON)
+
+ai-triage-release: ## Append a PM/Security-approved AI-triage promotion to a new release ledger
+	$(GO) run ./cmd/synapse-fptriage-release --manifest $(AI_RELEASE_MANIFEST) $(if $(AI_RELEASE_LEDGER),--ledger $(AI_RELEASE_LEDGER),) --comparison $(AI_EVAL_COMPARISON) --baseline $(AI_EVAL_BASELINE) --candidate $(AI_EVAL_CANDIDATE) --output $(AI_RELEASE_OUTPUT)
 
 ai-triage-drift: ## Compare AI triage input distribution with a human-approved baseline
 	$(GO) run ./cmd/synapse-fptriage-drift --baseline $(AI_DRIFT_BASELINE) --observed $(AI_DRIFT_OBSERVED) --output $(AI_DRIFT_OUTPUT)

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ The exit code is 0 when no finding meets the threshold, non-zero otherwise.
 | `synapse-cluster-agent` | Fleet agent: Kubernetes workload/exposure/identity inventory |
 | `synapse-fptriage-eval` | Offline evaluation harness for AI false-positive triage |
 | `synapse-fptriage-compare` | Deterministic candidate-vs-baseline gate for AI model/prompt promotion review |
+| `synapse-fptriage-release` | Versioned PM/Security-approved promotion and rollback ledger for AI triage |
 | `synapse-fptriage-curate` | Offline privacy- and label-reviewed feedback curation for AI false-positive evaluation |
 | `synapse-fptriage-drift` | Offline language/CWE/project distribution drift evidence for AI triage |
 | `synapse-mcp` | Read-only, propose-only integration server, never executes |

--- a/cmd/synapse-fptriage-release/main.go
+++ b/cmd/synapse-fptriage-release/main.go
@@ -164,14 +164,26 @@ func writeReleaseJSON(w io.Writer, value any) error {
 }
 
 func sameReleasePath(a, b string) bool {
-	aa, errA := filepath.Abs(a)
-	bb, errB := filepath.Abs(b)
-	if errA == nil && errB == nil {
-		a, b = aa, bb
-	}
-	a, b = filepath.Clean(a), filepath.Clean(b)
+	a, b = canonicalReleasePath(a), canonicalReleasePath(b)
 	if runtime.GOOS == "windows" {
 		return strings.EqualFold(a, b)
 	}
 	return a == b
+}
+
+func canonicalReleasePath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	abs = filepath.Clean(abs)
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return filepath.Clean(resolved)
+	}
+	// The output normally does not exist yet. Resolve its parent so a symlinked directory
+	// cannot alias an input artifact and bypass the explicit overwrite guard.
+	if parent, err := filepath.EvalSymlinks(filepath.Dir(abs)); err == nil {
+		return filepath.Join(parent, filepath.Base(abs))
+	}
+	return abs
 }

--- a/cmd/synapse-fptriage-release/main.go
+++ b/cmd/synapse-fptriage-release/main.go
@@ -1,0 +1,177 @@
+// Command synapse-fptriage-release creates an immutable, versioned ledger of independently
+// approved AI-triage promotions and rollbacks. It never changes runtime configuration.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+func main() {
+	manifestPath := flag.String("manifest", "", "versioned PM/Security release manifest JSON")
+	ledgerPath := flag.String("ledger", "", "existing release ledger JSON (required for rollback; optional for first promotion)")
+	comparisonPath := flag.String("comparison", "", "passing candidate comparison JSON (promotion only)")
+	baselinePath := flag.String("baseline", "", "baseline evaluation-v2 report (promotion only)")
+	candidatePath := flag.String("candidate", "", "candidate evaluation-v2 report (promotion only)")
+	outputPath := flag.String("output", "", "new path for the append-only release ledger")
+	printDigest := flag.Bool("print-review-digest", false, "print the digest PM/Security must approve without writing a ledger")
+	flag.Parse()
+
+	if err := run(*manifestPath, *ledgerPath, *comparisonPath, *baselinePath, *candidatePath, *outputPath, *printDigest, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "synapse-fptriage-release: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(manifestPath, ledgerPath, comparisonPath, baselinePath, candidatePath, outputPath string, printDigest bool, stdout io.Writer) error {
+	manifestPath, ledgerPath, comparisonPath = strings.TrimSpace(manifestPath), strings.TrimSpace(ledgerPath), strings.TrimSpace(comparisonPath)
+	baselinePath, candidatePath, outputPath = strings.TrimSpace(baselinePath), strings.TrimSpace(candidatePath), strings.TrimSpace(outputPath)
+	if manifestPath == "" {
+		return fmt.Errorf("--manifest is required")
+	}
+	manifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read release manifest: %w", err)
+	}
+	manifest, err := sca.LoadAIEvaluationReleaseManifest(manifestBytes)
+	if err != nil {
+		return err
+	}
+
+	var ledger sca.AIEvaluationReleaseLedger
+	if ledgerPath != "" {
+		ledgerBytes, err := os.ReadFile(ledgerPath)
+		if err != nil {
+			return fmt.Errorf("read release ledger: %w", err)
+		}
+		ledger, err = sca.LoadAIEvaluationReleaseLedger(ledgerBytes)
+		if err != nil {
+			return err
+		}
+	}
+
+	var evidence *sca.AIEvaluationPromotionEvidence
+	if manifest.Action == sca.AIEvaluationReleasePromote {
+		if comparisonPath == "" || baselinePath == "" || candidatePath == "" {
+			return fmt.Errorf("promotion requires --comparison, --baseline, and --candidate")
+		}
+		loaded, err := loadPromotionEvidence(comparisonPath, baselinePath, candidatePath)
+		if err != nil {
+			return err
+		}
+		evidence = &loaded
+	} else {
+		if ledgerPath == "" {
+			return fmt.Errorf("rollback requires --ledger")
+		}
+		if comparisonPath != "" || baselinePath != "" || candidatePath != "" {
+			return fmt.Errorf("rollback must not supply promotion comparison or evaluation reports")
+		}
+	}
+
+	if printDigest {
+		digest, err := sca.AIEvaluationReleaseReviewDigest(ledger, evidence, manifest)
+		if err != nil {
+			return err
+		}
+		return writeReleaseJSON(stdout, map[string]string{"version": manifest.Version, "action": manifest.Action, "reviewed_sha256": digest})
+	}
+	if outputPath == "" || outputPath == "-" {
+		return fmt.Errorf("--output must be a new ledger file path")
+	}
+	for _, input := range []string{manifestPath, ledgerPath, comparisonPath, baselinePath, candidatePath} {
+		if input != "" && sameReleasePath(outputPath, input) {
+			return fmt.Errorf("--output must not overwrite an input artifact")
+		}
+	}
+	updated, err := sca.ApplyAIEvaluationRelease(ledger, evidence, manifest)
+	if err != nil {
+		return err
+	}
+	return writeReleaseLedger(outputPath, updated)
+}
+
+func loadPromotionEvidence(comparisonPath, baselinePath, candidatePath string) (sca.AIEvaluationPromotionEvidence, error) {
+	comparisonBytes, err := os.ReadFile(comparisonPath)
+	if err != nil {
+		return sca.AIEvaluationPromotionEvidence{}, fmt.Errorf("read comparison: %w", err)
+	}
+	comparison, err := sca.LoadAIEvaluationComparison(comparisonBytes)
+	if err != nil {
+		return sca.AIEvaluationPromotionEvidence{}, err
+	}
+	baselineBytes, err := os.ReadFile(baselinePath)
+	if err != nil {
+		return sca.AIEvaluationPromotionEvidence{}, fmt.Errorf("read baseline report: %w", err)
+	}
+	baseline, err := sca.LoadAIEvaluationReport(baselineBytes)
+	if err != nil {
+		return sca.AIEvaluationPromotionEvidence{}, fmt.Errorf("baseline report: %w", err)
+	}
+	candidateBytes, err := os.ReadFile(candidatePath)
+	if err != nil {
+		return sca.AIEvaluationPromotionEvidence{}, fmt.Errorf("read candidate report: %w", err)
+	}
+	candidate, err := sca.LoadAIEvaluationReport(candidateBytes)
+	if err != nil {
+		return sca.AIEvaluationPromotionEvidence{}, fmt.Errorf("candidate report: %w", err)
+	}
+	evidence := sca.AIEvaluationPromotionEvidence{BaselineReport: baseline, CandidateReport: candidate, Comparison: comparison}
+	if err := evidence.Validate(); err != nil {
+		return sca.AIEvaluationPromotionEvidence{}, err
+	}
+	return evidence, nil
+}
+
+func writeReleaseLedger(path string, ledger sca.AIEvaluationReleaseLedger) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create release ledger: %w", err)
+	}
+	if err := writeReleaseJSON(file, ledger); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("sync release ledger: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("close release ledger: %w", err)
+	}
+	return nil
+}
+
+func writeReleaseJSON(w io.Writer, value any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("write release artifact: %w", err)
+	}
+	return nil
+}
+
+func sameReleasePath(a, b string) bool {
+	aa, errA := filepath.Abs(a)
+	bb, errB := filepath.Abs(b)
+	if errA == nil && errB == nil {
+		a, b = aa, bb
+	}
+	a, b = filepath.Clean(a), filepath.Clean(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}

--- a/cmd/synapse-fptriage-release/main_test.go
+++ b/cmd/synapse-fptriage-release/main_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+type releaseFixtureTriager struct{ run sca.AIEvaluationRun }
+
+func (t releaseFixtureTriager) Triage(_ context.Context, candidates []finding.Finding, _ string) []ports.AICritique {
+	out := make([]ports.AICritique, 0, len(candidates))
+	for _, candidate := range candidates {
+		falsePositive := candidate.DedupKey == "ai-eval:fp"
+		critique := ports.AICritique{DedupKey: candidate.DedupKey,
+			ProposerProvider: agent.CanonicalProviderID(t.run.ProposerProvider), ProposerModel: t.run.ProposerModel,
+			ProposerModelFamily: agent.CanonicalModelID(t.run.ProposerModel),
+			VerifierProvider:    agent.CanonicalProviderID(t.run.VerifierProvider), VerifierModel: t.run.VerifierModel,
+			VerifierModelFamily: agent.CanonicalModelID(t.run.VerifierModel), IndependencePolicy: t.run.IndependencePolicy,
+			PromptVersion: t.run.PromptVersion}
+		if falsePositive {
+			critique.Verdict, critique.Driver, critique.Confidence = "refuted", "constant_or_literal", 95
+			critique.SuspectedFP, critique.Verified = true, true
+			critique.VerifierVerdict, critique.VerifierDriver, critique.VerifierConfidence = "refuted", "constant_or_literal", 94
+		} else {
+			critique.Verdict, critique.Driver, critique.Confidence = "sound", "attacker_controlled", 96
+			critique.VerifierVerdict, critique.VerifierDriver, critique.VerifierConfidence = "sound", "attacker_controlled", 93
+		}
+		out = append(out, critique)
+	}
+	return out
+}
+
+func TestRunCreatesPromotionAndRollbackLedger(t *testing.T) {
+	dir := t.TempDir()
+	baseline := releaseFixtureReport(t, "prompt-v1")
+	candidate := releaseFixtureReport(t, "prompt-v2")
+	comparison, err := sca.CompareAIEvaluationReports(baseline, candidate, sca.DefaultAIEvaluationPromotionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	baselinePath := writeReleaseFixture(t, dir, "baseline.json", baseline)
+	candidatePath := writeReleaseFixture(t, dir, "candidate.json", candidate)
+	comparisonPath := writeReleaseFixture(t, dir, "comparison.json", comparison)
+
+	promotion := sca.AIEvaluationReleaseManifest{SchemaVersion: sca.AIEvaluationReleaseManifestSchema,
+		Version: "release-canary", Action: sca.AIEvaluationReleasePromote, Provenance: "security/change-42", ComparisonID: comparison.ComparisonID}
+	promotionPath := writeReleaseFixture(t, dir, "promotion.json", promotion)
+	var digestOutput bytes.Buffer
+	if err := run(promotionPath, "", comparisonPath, baselinePath, candidatePath, "", true, &digestOutput); err != nil {
+		t.Fatalf("print promotion digest: %v", err)
+	}
+	digest := releaseDigest(t, digestOutput.Bytes())
+	promotion.Approvals = releaseApprovals(digest)
+	promotionPath = writeReleaseFixture(t, dir, "promotion-approved.json", promotion)
+	ledgerPath := filepath.Join(dir, "ledger-v1.json")
+	if err := run(promotionPath, "", comparisonPath, baselinePath, candidatePath, ledgerPath, false, &bytes.Buffer{}); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	ledger := loadReleaseLedger(t, ledgerPath)
+	if len(ledger.Decisions) != 1 || ledger.Decisions[0].ActiveRun.PromptVersion != "prompt-v2" {
+		t.Fatalf("promotion ledger = %+v", ledger)
+	}
+
+	rollback := sca.AIEvaluationReleaseManifest{SchemaVersion: sca.AIEvaluationReleaseManifestSchema,
+		Version: "release-rollback", Action: sca.AIEvaluationReleaseRollback, Provenance: "incident/42", RollbackTo: "initial"}
+	rollbackPath := writeReleaseFixture(t, dir, "rollback.json", rollback)
+	digestOutput.Reset()
+	if err := run(rollbackPath, ledgerPath, "", "", "", "", true, &digestOutput); err != nil {
+		t.Fatalf("print rollback digest: %v", err)
+	}
+	rollback.Approvals = releaseApprovals(releaseDigest(t, digestOutput.Bytes()))
+	rollbackPath = writeReleaseFixture(t, dir, "rollback-approved.json", rollback)
+	rolledBackPath := filepath.Join(dir, "ledger-v2.json")
+	if err := run(rollbackPath, ledgerPath, "", "", "", rolledBackPath, false, &bytes.Buffer{}); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	rolledBack := loadReleaseLedger(t, rolledBackPath)
+	if len(rolledBack.Decisions) != 2 || rolledBack.Decisions[1].ActiveRun.PromptVersion != "prompt-v1" {
+		t.Fatalf("rollback ledger = %+v", rolledBack)
+	}
+}
+
+func TestRunDoesNotOverwriteReleaseEvidence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ledger.json")
+	if err := os.WriteFile(path, []byte("approved evidence"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeReleaseLedger(path, sca.AIEvaluationReleaseLedger{}); err == nil {
+		t.Fatal("existing release evidence was overwritten")
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != "approved evidence" {
+		t.Fatalf("existing evidence changed to %q", data)
+	}
+}
+
+func releaseFixtureReport(t *testing.T, prompt string) sca.AIEvaluationReport {
+	t.Helper()
+	dataset := sca.AIEvaluationDataset{SchemaVersion: "synapse-ai-triage-dataset-v1", Version: "fixture-v1",
+		Provenance: "synthetic:test", Reviewer: "security-reviewer", Cases: []sca.AIEvaluationCase{
+			{ID: "fp", Label: sca.AIEvaluationFalsePositive, Language: "go", Framework: "stdlib", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-89", Title: "constant query", File: "fixture/fp.go", Line: 1, Source: "const query = `SELECT 1`"},
+			{ID: "tp", Label: sca.AIEvaluationTruePositive, Language: "go", Framework: "stdlib", Kind: finding.KindSAST, Severity: shared.SeverityMedium, CWE: "CWE-22", Title: "unsafe path", File: "fixture/tp.go", Line: 1, Source: "func read(p string) { os.ReadFile(p) }"},
+		}}
+	run := sca.AIEvaluationRun{ProposerProvider: "provider-a", ProposerModel: "model-a", VerifierProvider: "provider-b",
+		VerifierModel: "model-b", IndependencePolicy: ports.AIIndependenceProvider, PromptVersion: prompt, PolicyVersion: sca.EvaluationPolicyVersion()}
+	report, err := sca.EvaluateFPTriage(context.Background(), dataset, run, releaseFixtureTriager{run: run})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return report
+}
+
+func writeReleaseFixture(t *testing.T, dir, name string, value any) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func releaseDigest(t *testing.T, data []byte) string {
+	t.Helper()
+	var output map[string]string
+	if err := json.Unmarshal(data, &output); err != nil {
+		t.Fatal(err)
+	}
+	return output["reviewed_sha256"]
+}
+
+func releaseApprovals(digest string) []sca.AIEvaluationReleaseApproval {
+	now := time.Date(2026, 8, 14, 8, 0, 0, 0, time.UTC)
+	return []sca.AIEvaluationReleaseApproval{
+		{Role: "pm", Reviewer: "pm@example.com", Approved: true, Rationale: "Product rollout approved", ReviewedAt: now, ReviewedSHA256: digest},
+		{Role: "security", Reviewer: "security@example.com", Approved: true, Rationale: "Security evidence approved", ReviewedAt: now.Add(time.Minute), ReviewedSHA256: digest},
+	}
+}
+
+func loadReleaseLedger(t *testing.T, path string) sca.AIEvaluationReleaseLedger {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger, err := sca.LoadAIEvaluationReleaseLedger(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ledger
+}

--- a/cmd/synapse-fptriage-release/main_test.go
+++ b/cmd/synapse-fptriage-release/main_test.go
@@ -105,6 +105,25 @@ func TestRunDoesNotOverwriteReleaseEvidence(t *testing.T) {
 	}
 }
 
+func TestSameReleasePathResolvesSymlinkAliases(t *testing.T) {
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "evidence")
+	if err := os.Mkdir(realDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	input := filepath.Join(realDir, "ledger.json")
+	if err := os.WriteFile(input, []byte("approved evidence"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(dir, "evidence-alias")
+	if err := os.Symlink(realDir, alias); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+	if !sameReleasePath(filepath.Join(alias, "ledger.json"), input) {
+		t.Fatal("symlink alias was not recognized as the same release path")
+	}
+}
+
 func releaseFixtureReport(t *testing.T, prompt string) sca.AIEvaluationReport {
 	t.Helper()
 	dataset := sca.AIEvaluationDataset{SchemaVersion: "synapse-ai-triage-dataset-v1", Version: "fixture-v1",

--- a/docs/guide/ai-triage-evaluation.md
+++ b/docs/guide/ai-triage-evaluation.md
@@ -5,12 +5,13 @@ an operator enables gate automation. Evaluation uses the same proposer, verifier
 threshold, human-review floors, and deterministic policy as a scan. The only policy difference is forced
 shadow mode: `would_gate_exempt` is measured, while `gate_exempt` must remain `false`.
 
-The repository includes three offline AI-triage data/evaluation commands:
+The repository includes five offline AI-triage data/evaluation commands:
 
 | Binary | Role |
 | --- | --- |
 | `synapse-fptriage-eval` | Run the versioned AI false-positive evaluation harness |
 | `synapse-fptriage-compare` | Compare a candidate shadow report with an approved baseline before promotion review |
+| `synapse-fptriage-release` | Record independently approved, versioned promotions and rollbacks |
 | `synapse-fptriage-curate` | Curate human review outcomes into privacy- and label-reviewed evaluation data |
 | `synapse-fptriage-drift` | Compare production input distribution with a human-approved baseline |
 
@@ -242,6 +243,65 @@ evidence and still inspect `status`. The output is create-only: choose a fresh p
 parent is resolved before creation, and the final component cannot overwrite an existing file, symlink,
 or either input. A clean comparison has status `review_required`, never `promoted`: PM/Security approval,
 versioned rollout configuration, canary monitoring, and rollback remain explicit human-controlled steps.
+
+## Approve a promotion or rollback
+
+`synapse-fptriage-release` closes the governance step after a clean comparison. It recomputes the
+comparison from both shadow reports at the release boundary, then appends an immutable decision to a
+hash-chained release ledger. The command never edits runtime configuration, selects a model, changes a
+prompt or threshold, or grants a finding gate exemption.
+
+Start with a manifest that binds the exact comparison but leaves `approvals` empty:
+
+```json
+{
+  "schema_version": "synapse-ai-triage-release-manifest-v1",
+  "version": "ai-triage-2026-08-canary",
+  "action": "promote",
+  "provenance": "change/security-42",
+  "comparison_id": "<comparison_id>",
+  "approvals": []
+}
+```
+
+Print the digest over that manifest, the three evaluation artifacts, and the current ledger head:
+
+```bash
+go run ./cmd/synapse-fptriage-release \
+  --manifest ai-triage-release-manifest.json \
+  --comparison ai-triage-comparison.json \
+  --baseline ai-triage-baseline.json \
+  --candidate ai-triage-candidate.json \
+  --print-review-digest
+```
+
+One PM and one Security reviewer must independently add approvals in canonical order. They must be
+distinct human identities; model names and reserved machine principals are rejected. Each approval
+contains `role`, `reviewer`, `approved: true`, a rationale, a UTC `reviewed_at`, and the exact
+`reviewed_sha256` printed above. After approval, create the first ledger:
+
+```bash
+go run ./cmd/synapse-fptriage-release \
+  --manifest ai-triage-release-approved.json \
+  --comparison ai-triage-comparison.json \
+  --baseline ai-triage-baseline.json \
+  --candidate ai-triage-candidate.json \
+  --output ai-triage-release-ledger-v1.json
+```
+
+Every later decision reads the previous ledger and writes a new file; output is create-only and cannot
+overwrite any input artifact. Versions are unique, decision IDs form a hash chain, and the approval
+digest includes the previous head so a decision cannot be replayed after another release lands.
+
+Rollback uses the same two-person process. Set `action` to `rollback`, omit `comparison_id`, and set
+`rollback_to` to `initial` or an earlier `decision_id`. Run first with `--ledger <current-ledger>` and
+`--print-review-digest`, add both approvals, then run again with a fresh `--output`. Rollback can only
+select a configuration already present in the validated ledger and is rejected if that configuration
+is already active. Comparison/evaluation inputs are forbidden on rollback.
+
+The approved ledger is governance evidence, not deployment authority. Apply its active run identity
+through the normal reviewed deployment configuration, start in shadow/canary mode, retain all reports
+and comparison inputs, and use the distribution-drift workflow below for monitoring.
 
 ## Detect production distribution drift
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -167,6 +167,24 @@ another approved decision targeting `initial` or a previous decision. The comman
 file for every event and never changes live AI-triage or gate configuration. See
 [AI triage evaluation](ai-triage-evaluation.md#approve-a-promotion-or-rollback).
 
+```bash
+# First print the exact digest PM and Security must approve.
+go run ./cmd/synapse-fptriage-release \
+  --manifest ai-triage-release.json \
+  --comparison ai-triage-comparison.json \
+  --baseline ai-triage-baseline.json \
+  --candidate ai-triage-candidate.json \
+  --print-review-digest
+
+# After both approvals are added to the manifest, create a new ledger artifact.
+go run ./cmd/synapse-fptriage-release \
+  --manifest ai-triage-release-approved.json \
+  --comparison ai-triage-comparison.json \
+  --baseline ai-triage-baseline.json \
+  --candidate ai-triage-candidate.json \
+  --output ai-triage-release-ledger.json
+```
+
 The AI critique reads the target's own source into the prompt, so an **untrusted PR** can still try prompt
 injection through comments or strings. Distinct consensus and the human-review floor bound the risk, and
 the finding always remains in SARIF/JSON, but treat AI triage as advisory for untrusted contributor code.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -161,6 +161,12 @@ go run ./cmd/synapse-fptriage-compare \
 The command exits non-zero on a quality regression but writes the deterministic comparison evidence
 first. A passing result is still `review_required`; it never changes runtime AI configuration.
 
+After that result, use `synapse-fptriage-release` to bind the baseline, candidate, comparison, unique
+release version, and independent PM/Security approvals into a hash-chained ledger. Rollback appends
+another approved decision targeting `initial` or a previous decision. The command writes a new ledger
+file for every event and never changes live AI-triage or gate configuration. See
+[AI triage evaluation](ai-triage-evaluation.md#approve-a-promotion-or-rollback).
+
 The AI critique reads the target's own source into the prompt, so an **untrusted PR** can still try prompt
 injection through comments or strings. Distinct consensus and the human-review floor bound the risk, and
 the finding always remains in SARIF/JSON, but treat AI triage as advisory for untrusted contributor code.

--- a/internal/usecase/sca/fptriage_release.go
+++ b/internal/usecase/sca/fptriage_release.go
@@ -1,0 +1,505 @@
+package sca
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+)
+
+const (
+	AIEvaluationReleaseManifestSchema = "synapse-ai-triage-release-manifest-v1"
+	aiEvaluationReleaseLedgerSchema   = "synapse-ai-triage-release-ledger-v1"
+	aiEvaluationReleaseApprovalSchema = "synapse-ai-triage-release-approval-v1"
+	AIEvaluationReleasePromote        = "promote"
+	AIEvaluationReleaseRollback       = "rollback"
+)
+
+var releaseVersionPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+// AIEvaluationReleaseApproval records one independent human approval over the exact release
+// manifest, comparison, and current ledger head. PM and Security must approve separately.
+type AIEvaluationReleaseApproval struct {
+	Role           string    `json:"role"`
+	Reviewer       string    `json:"reviewer"`
+	Approved       bool      `json:"approved"`
+	Rationale      string    `json:"rationale"`
+	ReviewedAt     time.Time `json:"reviewed_at"`
+	ReviewedSHA256 string    `json:"reviewed_sha256"`
+}
+
+// AIEvaluationReleaseManifest is operator-owned approval input. A promotion binds a passing
+// comparison; a rollback binds an earlier approved decision (or the initial baseline).
+type AIEvaluationReleaseManifest struct {
+	SchemaVersion string                        `json:"schema_version"`
+	Version       string                        `json:"version"`
+	Action        string                        `json:"action"`
+	Provenance    string                        `json:"provenance"`
+	ComparisonID  string                        `json:"comparison_id,omitempty"`
+	RollbackTo    string                        `json:"rollback_to,omitempty"`
+	Approvals     []AIEvaluationReleaseApproval `json:"approvals"`
+}
+
+// AIEvaluationReleaseDecision is an append-only, versioned governance event. It has no runtime
+// authority: operators apply the approved configuration through their normal deployment controls.
+type AIEvaluationReleaseDecision struct {
+	DecisionID            string                        `json:"decision_id"`
+	Sequence              int                           `json:"sequence"`
+	Version               string                        `json:"version"`
+	Action                string                        `json:"action"`
+	Status                string                        `json:"status"`
+	Provenance            string                        `json:"provenance"`
+	PreviousDecisionID    string                        `json:"previous_decision_id,omitempty"`
+	ComparisonID          string                        `json:"comparison_id,omitempty"`
+	RollbackTo            string                        `json:"rollback_to,omitempty"`
+	BaselineEvaluationRun *AIEvaluationRun              `json:"baseline_evaluation_run,omitempty"`
+	BaselineEvaluationID  string                        `json:"baseline_evaluation_run_id,omitempty"`
+	PreviousActiveRunID   string                        `json:"previous_active_run_id"`
+	ActiveRun             AIEvaluationRun               `json:"active_run"`
+	ActiveRunID           string                        `json:"active_run_id"`
+	ApprovalDigest        string                        `json:"approval_digest"`
+	Approvals             []AIEvaluationReleaseApproval `json:"approvals"`
+}
+
+// AIEvaluationReleaseLedger is a deterministic hash-chained promotion/rollback history.
+type AIEvaluationReleaseLedger struct {
+	SchemaVersion  string                        `json:"schema_version"`
+	InitialRun     AIEvaluationRun               `json:"initial_run"`
+	InitialRunID   string                        `json:"initial_run_id"`
+	HeadDecisionID string                        `json:"head_decision_id"`
+	Decisions      []AIEvaluationReleaseDecision `json:"decisions"`
+}
+
+// AIEvaluationPromotionEvidence keeps both shadow reports beside their comparison so the release
+// boundary can recompute every metric and invariant instead of trusting a stored status or digest.
+type AIEvaluationPromotionEvidence struct {
+	BaselineReport  AIEvaluationReport     `json:"baseline_report"`
+	CandidateReport AIEvaluationReport     `json:"candidate_report"`
+	Comparison      AIEvaluationComparison `json:"comparison"`
+}
+
+func (e AIEvaluationPromotionEvidence) Validate() error {
+	if err := e.Comparison.Validate(); err != nil {
+		return err
+	}
+	recomputed, err := CompareAIEvaluationReports(e.BaselineReport, e.CandidateReport, e.Comparison.Policy)
+	if err != nil {
+		return fmt.Errorf("recompute AI evaluation comparison: %w", err)
+	}
+	if !reflect.DeepEqual(recomputed, e.Comparison) {
+		return fmt.Errorf("AI evaluation comparison does not match its baseline and candidate reports")
+	}
+	return nil
+}
+
+// LoadAIEvaluationComparison strictly decodes and validates comparison identity and status.
+func LoadAIEvaluationComparison(data []byte) (AIEvaluationComparison, error) {
+	var comparison AIEvaluationComparison
+	if err := decodeReleaseJSON(data, &comparison); err != nil {
+		return comparison, fmt.Errorf("decode AI evaluation comparison: %w", err)
+	}
+	if err := comparison.Validate(); err != nil {
+		return comparison, err
+	}
+	return comparison, nil
+}
+
+// Validate rechecks the deterministic comparison identity and promotion-review invariants.
+func (c AIEvaluationComparison) Validate() error {
+	if c.SchemaVersion != aiEvaluationComparisonSchema || !validEvaluationSHA256(c.ComparisonID) ||
+		c.ComparisonID != evaluationComparisonID(c) {
+		return fmt.Errorf("AI evaluation comparison has an invalid schema or canonical identity")
+	}
+	if c.Status != "review_required" || !c.ApprovalRequired || len(c.Failures) != 0 {
+		return fmt.Errorf("AI evaluation comparison is not eligible for human promotion approval")
+	}
+	if strings.TrimSpace(c.DatasetVersion) == "" || !validEvaluationSHA256(c.DatasetSHA256) ||
+		strings.TrimSpace(c.Provenance) == "" || strings.TrimSpace(c.Reviewer) == "" ||
+		!validEvaluationSHA256(c.BaselineRunID) || !validEvaluationSHA256(c.CandidateRunID) {
+		return fmt.Errorf("AI evaluation comparison has incomplete evidence identity")
+	}
+	if err := validateReleaseRun(c.BaselineRun); err != nil {
+		return fmt.Errorf("AI evaluation comparison baseline: %w", err)
+	}
+	if err := validateReleaseRun(c.CandidateRun); err != nil {
+		return fmt.Errorf("AI evaluation comparison candidate: %w", err)
+	}
+	if sameEvaluationConfiguration(c.BaselineRun, c.CandidateRun) {
+		return fmt.Errorf("AI evaluation comparison does not change the evaluated configuration")
+	}
+	return nil
+}
+
+func LoadAIEvaluationReleaseManifest(data []byte) (AIEvaluationReleaseManifest, error) {
+	var manifest AIEvaluationReleaseManifest
+	if err := decodeReleaseJSON(data, &manifest); err != nil {
+		return manifest, fmt.Errorf("decode AI evaluation release manifest: %w", err)
+	}
+	if err := validateReleaseManifestHeader(manifest); err != nil {
+		return manifest, err
+	}
+	return manifest, nil
+}
+
+func LoadAIEvaluationReleaseLedger(data []byte) (AIEvaluationReleaseLedger, error) {
+	var ledger AIEvaluationReleaseLedger
+	if err := decodeReleaseJSON(data, &ledger); err != nil {
+		return ledger, fmt.Errorf("decode AI evaluation release ledger: %w", err)
+	}
+	if err := ledger.Validate(); err != nil {
+		return ledger, err
+	}
+	return ledger, nil
+}
+
+// AIEvaluationReleaseReviewDigest returns the exact digest PM and Security approve. It binds the
+// current ledger head, so an approval cannot be replayed after another release decision lands.
+func AIEvaluationReleaseReviewDigest(ledger AIEvaluationReleaseLedger, evidence *AIEvaluationPromotionEvidence, manifest AIEvaluationReleaseManifest) (string, error) {
+	if err := validateReleaseManifestHeader(manifest); err != nil {
+		return "", err
+	}
+	if len(ledger.Decisions) != 0 || ledger.SchemaVersion != "" {
+		if err := ledger.Validate(); err != nil {
+			return "", err
+		}
+	}
+	for _, decision := range ledger.Decisions {
+		if strings.EqualFold(decision.Version, manifest.Version) {
+			return "", fmt.Errorf("AI evaluation release version %q already exists", manifest.Version)
+		}
+	}
+	var targetRun AIEvaluationRun
+	var targetRunID string
+	if manifest.Action == AIEvaluationReleasePromote {
+		if evidence == nil {
+			return "", fmt.Errorf("AI evaluation promotion requires a passing comparison")
+		}
+		if err := evidence.Validate(); err != nil {
+			return "", err
+		}
+		comparison := evidence.Comparison
+		if manifest.ComparisonID != comparison.ComparisonID {
+			return "", fmt.Errorf("AI evaluation release manifest comparison_id does not match the reviewed comparison")
+		}
+		if manifest.RollbackTo != "" {
+			return "", fmt.Errorf("AI evaluation promotion must not set rollback_to")
+		}
+		if len(ledger.Decisions) != 0 && !sameEvaluationConfiguration(currentReleaseRun(ledger), comparison.BaselineRun) {
+			return "", fmt.Errorf("AI evaluation promotion baseline does not match the active approved configuration")
+		}
+		targetRun, targetRunID = comparison.CandidateRun, comparison.CandidateRunID
+	} else {
+		if evidence != nil || manifest.ComparisonID != "" {
+			return "", fmt.Errorf("AI evaluation rollback must not carry a promotion comparison")
+		}
+		if len(ledger.Decisions) == 0 {
+			return "", fmt.Errorf("AI evaluation rollback requires an existing release ledger")
+		}
+		var err error
+		targetRun, targetRunID, err = rollbackReleaseTarget(ledger, manifest.RollbackTo)
+		if err != nil {
+			return "", err
+		}
+		if sameEvaluationConfiguration(currentReleaseRun(ledger), targetRun) {
+			return "", fmt.Errorf("AI evaluation rollback target is already active")
+		}
+	}
+
+	payload := struct {
+		Schema       string          `json:"schema"`
+		LedgerHead   string          `json:"ledger_head"`
+		Version      string          `json:"version"`
+		Action       string          `json:"action"`
+		Provenance   string          `json:"provenance"`
+		ComparisonID string          `json:"comparison_id,omitempty"`
+		RollbackTo   string          `json:"rollback_to,omitempty"`
+		TargetRun    AIEvaluationRun `json:"target_run"`
+		TargetRunID  string          `json:"target_run_id"`
+	}{aiEvaluationReleaseApprovalSchema, ledger.HeadDecisionID, manifest.Version, manifest.Action,
+		manifest.Provenance, manifest.ComparisonID, manifest.RollbackTo, targetRun, targetRunID}
+	b, _ := json.Marshal(payload)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// ApplyAIEvaluationRelease appends an approved promotion or rollback. It does not mutate runtime
+// configuration, model clients, prompts, thresholds, findings, or gate state.
+func ApplyAIEvaluationRelease(ledger AIEvaluationReleaseLedger, evidence *AIEvaluationPromotionEvidence, manifest AIEvaluationReleaseManifest) (AIEvaluationReleaseLedger, error) {
+	digest, err := AIEvaluationReleaseReviewDigest(ledger, evidence, manifest)
+	if err != nil {
+		return AIEvaluationReleaseLedger{}, err
+	}
+	if err := validateReleaseApprovals(manifest.Approvals, digest, releaseModelIdentities(ledger, evidence)); err != nil {
+		return AIEvaluationReleaseLedger{}, err
+	}
+	for _, decision := range ledger.Decisions {
+		if strings.EqualFold(decision.Version, manifest.Version) {
+			return AIEvaluationReleaseLedger{}, fmt.Errorf("AI evaluation release version %q already exists", manifest.Version)
+		}
+	}
+
+	if ledger.SchemaVersion == "" {
+		if evidence == nil || manifest.Action != AIEvaluationReleasePromote {
+			return AIEvaluationReleaseLedger{}, fmt.Errorf("AI evaluation release ledger must start with a promotion")
+		}
+		comparison := evidence.Comparison
+		ledger = AIEvaluationReleaseLedger{SchemaVersion: aiEvaluationReleaseLedgerSchema,
+			InitialRun: comparison.BaselineRun, InitialRunID: comparison.BaselineRunID,
+			Decisions: []AIEvaluationReleaseDecision{}}
+	}
+	var comparison *AIEvaluationComparison
+	if evidence != nil {
+		comparison = &evidence.Comparison
+	}
+	previousRun, previousRunID := currentReleaseRun(ledger), currentReleaseRunID(ledger)
+	decision := AIEvaluationReleaseDecision{
+		Sequence: len(ledger.Decisions) + 1, Version: manifest.Version, Action: manifest.Action,
+		Status: "approved", Provenance: manifest.Provenance, PreviousDecisionID: ledger.HeadDecisionID,
+		ComparisonID: manifest.ComparisonID, RollbackTo: manifest.RollbackTo,
+		PreviousActiveRunID: previousRunID, ApprovalDigest: digest,
+		Approvals: append([]AIEvaluationReleaseApproval(nil), manifest.Approvals...),
+	}
+	if manifest.Action == AIEvaluationReleasePromote {
+		baseline := comparison.BaselineRun
+		decision.BaselineEvaluationRun, decision.BaselineEvaluationID = &baseline, comparison.BaselineRunID
+		decision.ActiveRun, decision.ActiveRunID = comparison.CandidateRun, comparison.CandidateRunID
+	} else {
+		decision.ActiveRun, decision.ActiveRunID, err = rollbackReleaseTarget(ledger, manifest.RollbackTo)
+		if err != nil {
+			return AIEvaluationReleaseLedger{}, err
+		}
+	}
+	if sameEvaluationConfiguration(previousRun, decision.ActiveRun) {
+		return AIEvaluationReleaseLedger{}, fmt.Errorf("AI evaluation release decision would not change the active configuration")
+	}
+	decision.DecisionID = releaseDecisionID(decision)
+	ledger.Decisions = append(ledger.Decisions, decision)
+	ledger.HeadDecisionID = decision.DecisionID
+	if err := ledger.Validate(); err != nil {
+		return AIEvaluationReleaseLedger{}, err
+	}
+	return ledger, nil
+}
+
+func (l AIEvaluationReleaseLedger) Validate() error {
+	if l.SchemaVersion != aiEvaluationReleaseLedgerSchema || len(l.Decisions) == 0 ||
+		!validEvaluationSHA256(l.InitialRunID) || strings.TrimSpace(l.HeadDecisionID) == "" {
+		return fmt.Errorf("AI evaluation release ledger has an incomplete header")
+	}
+	if err := validateReleaseRun(l.InitialRun); err != nil {
+		return fmt.Errorf("AI evaluation release initial run: %w", err)
+	}
+	versions := map[string]struct{}{}
+	previousDecisionID, activeRun, activeRunID := "", l.InitialRun, l.InitialRunID
+	for i, decision := range l.Decisions {
+		if decision.Sequence != i+1 || decision.PreviousDecisionID != previousDecisionID ||
+			decision.PreviousActiveRunID != activeRunID || decision.Status != "approved" ||
+			!releaseVersionPattern.MatchString(decision.Version) || strings.TrimSpace(decision.Provenance) == "" ||
+			decision.DecisionID != releaseDecisionID(decision) || !validEvaluationSHA256(decision.ActiveRunID) {
+			return fmt.Errorf("AI evaluation release decision %d has invalid version, chain, status, or identity", i+1)
+		}
+		key := strings.ToLower(decision.Version)
+		if _, duplicate := versions[key]; duplicate {
+			return fmt.Errorf("AI evaluation release version %q is duplicated", decision.Version)
+		}
+		versions[key] = struct{}{}
+		if err := validateReleaseRun(decision.ActiveRun); err != nil {
+			return fmt.Errorf("AI evaluation release decision %d active run: %w", i+1, err)
+		}
+		if sameEvaluationConfiguration(activeRun, decision.ActiveRun) {
+			return fmt.Errorf("AI evaluation release decision %d does not change configuration", i+1)
+		}
+		if decision.Action == AIEvaluationReleasePromote {
+			if !validEvaluationSHA256(decision.ComparisonID) || decision.RollbackTo != "" ||
+				!validEvaluationSHA256(decision.BaselineEvaluationID) || decision.BaselineEvaluationRun == nil ||
+				!validEvaluationSHA256(decision.ActiveRunID) ||
+				!sameEvaluationConfiguration(activeRun, *decision.BaselineEvaluationRun) {
+				return fmt.Errorf("AI evaluation promotion decision %d has invalid comparison or baseline", i+1)
+			}
+			if err := validateReleaseRun(*decision.BaselineEvaluationRun); err != nil {
+				return fmt.Errorf("AI evaluation promotion decision %d baseline: %w", i+1, err)
+			}
+			if i == 0 && (decision.BaselineEvaluationID != activeRunID ||
+				!reflect.DeepEqual(*decision.BaselineEvaluationRun, activeRun)) {
+				return fmt.Errorf("AI evaluation first promotion does not bind the ledger's initial baseline")
+			}
+		} else if decision.Action == AIEvaluationReleaseRollback {
+			if decision.ComparisonID != "" || strings.TrimSpace(decision.RollbackTo) == "" ||
+				decision.BaselineEvaluationID != "" || decision.BaselineEvaluationRun != nil {
+				return fmt.Errorf("AI evaluation rollback decision %d has invalid target metadata", i+1)
+			}
+			targetRun, targetRunID, err := rollbackReleaseTarget(AIEvaluationReleaseLedger{
+				SchemaVersion: l.SchemaVersion, InitialRun: l.InitialRun, InitialRunID: l.InitialRunID,
+				HeadDecisionID: previousDecisionID, Decisions: l.Decisions[:i],
+			}, decision.RollbackTo)
+			if err != nil || targetRunID != decision.ActiveRunID || !reflect.DeepEqual(targetRun, decision.ActiveRun) {
+				return fmt.Errorf("AI evaluation rollback decision %d does not match its approved target", i+1)
+			}
+		} else {
+			return fmt.Errorf("AI evaluation release decision %d has invalid action", i+1)
+		}
+		if decision.ApprovalDigest != releaseDecisionApprovalDigest(decision) {
+			return fmt.Errorf("AI evaluation release decision %d approval digest is invalid", i+1)
+		}
+		models := []string{activeRun.ProposerModel, activeRun.VerifierModel, decision.ActiveRun.ProposerModel, decision.ActiveRun.VerifierModel}
+		if err := validateReleaseApprovals(decision.Approvals, decision.ApprovalDigest, models); err != nil {
+			return fmt.Errorf("AI evaluation release decision %d: %w", i+1, err)
+		}
+		previousDecisionID, activeRun, activeRunID = decision.DecisionID, decision.ActiveRun, decision.ActiveRunID
+	}
+	if l.HeadDecisionID != previousDecisionID {
+		return fmt.Errorf("AI evaluation release ledger head does not match the decision chain")
+	}
+	return nil
+}
+
+func validateReleaseManifestHeader(manifest AIEvaluationReleaseManifest) error {
+	if manifest.SchemaVersion != AIEvaluationReleaseManifestSchema || !releaseVersionPattern.MatchString(manifest.Version) ||
+		strings.TrimSpace(manifest.Provenance) == "" || manifest.Provenance != strings.TrimSpace(manifest.Provenance) ||
+		len([]rune(manifest.Provenance)) > 2000 {
+		return fmt.Errorf("AI evaluation release manifest requires canonical schema, version, and provenance")
+	}
+	if manifest.Action != AIEvaluationReleasePromote && manifest.Action != AIEvaluationReleaseRollback {
+		return fmt.Errorf("AI evaluation release action must be promote or rollback")
+	}
+	if manifest.Action == AIEvaluationReleasePromote {
+		if !validEvaluationSHA256(manifest.ComparisonID) || manifest.RollbackTo != "" {
+			return fmt.Errorf("AI evaluation promotion requires comparison_id and no rollback target")
+		}
+	} else if manifest.ComparisonID != "" || strings.TrimSpace(manifest.RollbackTo) == "" {
+		return fmt.Errorf("AI evaluation rollback requires rollback_to and no comparison_id")
+	}
+	return nil
+}
+
+func validateReleaseApprovals(approvals []AIEvaluationReleaseApproval, digest string, models []string) error {
+	if len(approvals) != 2 {
+		return fmt.Errorf("AI evaluation release requires exactly one PM and one Security approval")
+	}
+	roles, reviewers := map[string]struct{}{}, map[string]struct{}{}
+	for _, approval := range approvals {
+		role := strings.ToLower(strings.TrimSpace(approval.Role))
+		reviewer := strings.TrimSpace(approval.Reviewer)
+		_, offset := approval.ReviewedAt.Zone()
+		if (role != "pm" && role != "security") || approval.Role != role || reviewer == "" || approval.Reviewer != reviewer ||
+			!approval.Approved || len([]rune(strings.TrimSpace(approval.Rationale))) < 3 ||
+			len([]rune(approval.Rationale)) > 2000 || approval.Rationale != strings.TrimSpace(approval.Rationale) ||
+			approval.ReviewedAt.IsZero() || offset != 0 || approval.ReviewedSHA256 != digest ||
+			aitriagereview.IsMachineOrModelActor(reviewer, models...) {
+			return fmt.Errorf("AI evaluation release contains an invalid or non-human approval")
+		}
+		if _, exists := roles[role]; exists {
+			return fmt.Errorf("AI evaluation release approval role %q is duplicated", role)
+		}
+		roles[role] = struct{}{}
+		identity := strings.ToLower(reviewer)
+		if _, exists := reviewers[identity]; exists {
+			return fmt.Errorf("AI evaluation release approvals require distinct humans")
+		}
+		reviewers[identity] = struct{}{}
+	}
+	if approvals[0].Role != "pm" || approvals[1].Role != "security" {
+		return fmt.Errorf("AI evaluation release approvals must be ordered pm then security")
+	}
+	return nil
+}
+
+func validateReleaseRun(run AIEvaluationRun) error {
+	if run.ProposerProvider == "" || run.ProposerProvider != agent.CanonicalProviderID(run.ProposerProvider) ||
+		strings.TrimSpace(run.ProposerModel) == "" || run.ProposerModel != strings.TrimSpace(run.ProposerModel) ||
+		run.VerifierProvider == "" || run.VerifierProvider != agent.CanonicalProviderID(run.VerifierProvider) ||
+		strings.TrimSpace(run.VerifierModel) == "" || run.VerifierModel != strings.TrimSpace(run.VerifierModel) ||
+		strings.TrimSpace(run.PromptVersion) == "" || run.PromptVersion != strings.TrimSpace(run.PromptVersion) ||
+		strings.TrimSpace(run.PolicyVersion) == "" || run.PolicyVersion != strings.TrimSpace(run.PolicyVersion) ||
+		!agent.IndependentLLMs(run.ProposerProvider, run.ProposerModel, run.VerifierProvider, run.VerifierModel, string(run.IndependencePolicy)) {
+		return fmt.Errorf("run identity is incomplete or non-independent")
+	}
+	return nil
+}
+
+func currentReleaseRun(ledger AIEvaluationReleaseLedger) AIEvaluationRun {
+	if len(ledger.Decisions) == 0 {
+		return ledger.InitialRun
+	}
+	return ledger.Decisions[len(ledger.Decisions)-1].ActiveRun
+}
+
+func currentReleaseRunID(ledger AIEvaluationReleaseLedger) string {
+	if len(ledger.Decisions) == 0 {
+		return ledger.InitialRunID
+	}
+	return ledger.Decisions[len(ledger.Decisions)-1].ActiveRunID
+}
+
+func rollbackReleaseTarget(ledger AIEvaluationReleaseLedger, target string) (AIEvaluationRun, string, error) {
+	if target == "initial" {
+		return ledger.InitialRun, ledger.InitialRunID, nil
+	}
+	for _, decision := range ledger.Decisions {
+		if decision.DecisionID == target {
+			return decision.ActiveRun, decision.ActiveRunID, nil
+		}
+	}
+	return AIEvaluationRun{}, "", fmt.Errorf("AI evaluation rollback target %q is not in the approved release ledger", target)
+}
+
+func releaseModelIdentities(ledger AIEvaluationReleaseLedger, evidence *AIEvaluationPromotionEvidence) []string {
+	models := []string{}
+	if ledger.SchemaVersion != "" {
+		run := currentReleaseRun(ledger)
+		models = append(models, run.ProposerModel, run.VerifierModel)
+	}
+	if evidence != nil {
+		comparison := evidence.Comparison
+		models = append(models, comparison.BaselineRun.ProposerModel, comparison.BaselineRun.VerifierModel,
+			comparison.CandidateRun.ProposerModel, comparison.CandidateRun.VerifierModel)
+	}
+	return models
+}
+
+func releaseDecisionApprovalDigest(decision AIEvaluationReleaseDecision) string {
+	payload := struct {
+		Schema       string          `json:"schema"`
+		LedgerHead   string          `json:"ledger_head"`
+		Version      string          `json:"version"`
+		Action       string          `json:"action"`
+		Provenance   string          `json:"provenance"`
+		ComparisonID string          `json:"comparison_id,omitempty"`
+		RollbackTo   string          `json:"rollback_to,omitempty"`
+		TargetRun    AIEvaluationRun `json:"target_run"`
+		TargetRunID  string          `json:"target_run_id"`
+	}{aiEvaluationReleaseApprovalSchema, decision.PreviousDecisionID, decision.Version, decision.Action,
+		decision.Provenance, decision.ComparisonID, decision.RollbackTo, decision.ActiveRun, decision.ActiveRunID}
+	b, _ := json.Marshal(payload)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func releaseDecisionID(decision AIEvaluationReleaseDecision) string {
+	copyDecision := decision
+	copyDecision.DecisionID = ""
+	b, _ := json.Marshal(copyDecision)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func decodeReleaseJSON(data []byte, dst any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("trailing JSON content")
+	}
+	return nil
+}

--- a/internal/usecase/sca/fptriage_release.go
+++ b/internal/usecase/sca/fptriage_release.go
@@ -63,6 +63,7 @@ type AIEvaluationReleaseDecision struct {
 	RollbackTo            string                        `json:"rollback_to,omitempty"`
 	BaselineEvaluationRun *AIEvaluationRun              `json:"baseline_evaluation_run,omitempty"`
 	BaselineEvaluationID  string                        `json:"baseline_evaluation_run_id,omitempty"`
+	PromotionPolicy       *AIEvaluationPromotionPolicy  `json:"promotion_policy,omitempty"`
 	PreviousActiveRunID   string                        `json:"previous_active_run_id"`
 	ActiveRun             AIEvaluationRun               `json:"active_run"`
 	ActiveRunID           string                        `json:"active_run_id"`
@@ -88,6 +89,9 @@ type AIEvaluationPromotionEvidence struct {
 }
 
 func (e AIEvaluationPromotionEvidence) Validate() error {
+	if err := validateReleasePromotionPolicy(e.Comparison.Policy); err != nil {
+		return err
+	}
 	if err := e.Comparison.Validate(); err != nil {
 		return err
 	}
@@ -193,8 +197,9 @@ func AIEvaluationReleaseReviewDigest(ledger AIEvaluationReleaseLedger, evidence 
 		if manifest.RollbackTo != "" {
 			return "", fmt.Errorf("AI evaluation promotion must not set rollback_to")
 		}
-		if len(ledger.Decisions) != 0 && !sameEvaluationConfiguration(currentReleaseRun(ledger), comparison.BaselineRun) {
-			return "", fmt.Errorf("AI evaluation promotion baseline does not match the active approved configuration")
+		if len(ledger.Decisions) != 0 && (comparison.BaselineRunID != currentReleaseRunID(ledger) ||
+			!reflect.DeepEqual(currentReleaseRun(ledger), comparison.BaselineRun)) {
+			return "", fmt.Errorf("AI evaluation promotion baseline does not match the exact active approved run")
 		}
 		targetRun, targetRunID = comparison.CandidateRun, comparison.CandidateRunID
 	} else {
@@ -226,7 +231,10 @@ func AIEvaluationReleaseReviewDigest(ledger AIEvaluationReleaseLedger, evidence 
 		TargetRunID  string          `json:"target_run_id"`
 	}{aiEvaluationReleaseApprovalSchema, ledger.HeadDecisionID, manifest.Version, manifest.Action,
 		manifest.Provenance, manifest.ComparisonID, manifest.RollbackTo, targetRun, targetRunID}
-	b, _ := json.Marshal(payload)
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal AI evaluation release approval digest: %w", err)
+	}
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:]), nil
 }
@@ -238,7 +246,7 @@ func ApplyAIEvaluationRelease(ledger AIEvaluationReleaseLedger, evidence *AIEval
 	if err != nil {
 		return AIEvaluationReleaseLedger{}, err
 	}
-	if err := validateReleaseApprovals(manifest.Approvals, digest, releaseModelIdentities(ledger, evidence)); err != nil {
+	if err := validateReleaseApprovals(manifest.Approvals, digest, releaseModelIdentities(ledger, evidence, manifest)); err != nil {
 		return AIEvaluationReleaseLedger{}, err
 	}
 	for _, decision := range ledger.Decisions {
@@ -271,6 +279,8 @@ func ApplyAIEvaluationRelease(ledger AIEvaluationReleaseLedger, evidence *AIEval
 	if manifest.Action == AIEvaluationReleasePromote {
 		baseline := comparison.BaselineRun
 		decision.BaselineEvaluationRun, decision.BaselineEvaluationID = &baseline, comparison.BaselineRunID
+		policy := comparison.Policy
+		decision.PromotionPolicy = &policy
 		decision.ActiveRun, decision.ActiveRunID = comparison.CandidateRun, comparison.CandidateRunID
 	} else {
 		decision.ActiveRun, decision.ActiveRunID, err = rollbackReleaseTarget(ledger, manifest.RollbackTo)
@@ -281,7 +291,10 @@ func ApplyAIEvaluationRelease(ledger AIEvaluationReleaseLedger, evidence *AIEval
 	if sameEvaluationConfiguration(previousRun, decision.ActiveRun) {
 		return AIEvaluationReleaseLedger{}, fmt.Errorf("AI evaluation release decision would not change the active configuration")
 	}
-	decision.DecisionID = releaseDecisionID(decision)
+	decision.DecisionID, err = releaseDecisionID(decision)
+	if err != nil {
+		return AIEvaluationReleaseLedger{}, err
+	}
 	ledger.Decisions = append(ledger.Decisions, decision)
 	ledger.HeadDecisionID = decision.DecisionID
 	if err := ledger.Validate(); err != nil {
@@ -301,10 +314,14 @@ func (l AIEvaluationReleaseLedger) Validate() error {
 	versions := map[string]struct{}{}
 	previousDecisionID, activeRun, activeRunID := "", l.InitialRun, l.InitialRunID
 	for i, decision := range l.Decisions {
+		expectedDecisionID, err := releaseDecisionID(decision)
+		if err != nil {
+			return fmt.Errorf("AI evaluation release decision %d identity: %w", i+1, err)
+		}
 		if decision.Sequence != i+1 || decision.PreviousDecisionID != previousDecisionID ||
 			decision.PreviousActiveRunID != activeRunID || decision.Status != "approved" ||
 			!releaseVersionPattern.MatchString(decision.Version) || strings.TrimSpace(decision.Provenance) == "" ||
-			decision.DecisionID != releaseDecisionID(decision) || !validEvaluationSHA256(decision.ActiveRunID) {
+			decision.DecisionID != expectedDecisionID || !validEvaluationSHA256(decision.ActiveRunID) {
 			return fmt.Errorf("AI evaluation release decision %d has invalid version, chain, status, or identity", i+1)
 		}
 		key := strings.ToLower(decision.Version)
@@ -321,20 +338,23 @@ func (l AIEvaluationReleaseLedger) Validate() error {
 		if decision.Action == AIEvaluationReleasePromote {
 			if !validEvaluationSHA256(decision.ComparisonID) || decision.RollbackTo != "" ||
 				!validEvaluationSHA256(decision.BaselineEvaluationID) || decision.BaselineEvaluationRun == nil ||
-				!validEvaluationSHA256(decision.ActiveRunID) ||
+				!validEvaluationSHA256(decision.ActiveRunID) || decision.PromotionPolicy == nil ||
 				!sameEvaluationConfiguration(activeRun, *decision.BaselineEvaluationRun) {
 				return fmt.Errorf("AI evaluation promotion decision %d has invalid comparison or baseline", i+1)
 			}
 			if err := validateReleaseRun(*decision.BaselineEvaluationRun); err != nil {
 				return fmt.Errorf("AI evaluation promotion decision %d baseline: %w", i+1, err)
 			}
-			if i == 0 && (decision.BaselineEvaluationID != activeRunID ||
-				!reflect.DeepEqual(*decision.BaselineEvaluationRun, activeRun)) {
-				return fmt.Errorf("AI evaluation first promotion does not bind the ledger's initial baseline")
+			if err := validateReleasePromotionPolicy(*decision.PromotionPolicy); err != nil {
+				return fmt.Errorf("AI evaluation promotion decision %d policy: %w", i+1, err)
+			}
+			if decision.BaselineEvaluationID != activeRunID ||
+				!reflect.DeepEqual(*decision.BaselineEvaluationRun, activeRun) {
+				return fmt.Errorf("AI evaluation promotion decision %d does not bind the exact previous active run", i+1)
 			}
 		} else if decision.Action == AIEvaluationReleaseRollback {
 			if decision.ComparisonID != "" || strings.TrimSpace(decision.RollbackTo) == "" ||
-				decision.BaselineEvaluationID != "" || decision.BaselineEvaluationRun != nil {
+				decision.BaselineEvaluationID != "" || decision.BaselineEvaluationRun != nil || decision.PromotionPolicy != nil {
 				return fmt.Errorf("AI evaluation rollback decision %d has invalid target metadata", i+1)
 			}
 			targetRun, targetRunID, err := rollbackReleaseTarget(AIEvaluationReleaseLedger{
@@ -347,7 +367,11 @@ func (l AIEvaluationReleaseLedger) Validate() error {
 		} else {
 			return fmt.Errorf("AI evaluation release decision %d has invalid action", i+1)
 		}
-		if decision.ApprovalDigest != releaseDecisionApprovalDigest(decision) {
+		expectedApprovalDigest, err := releaseDecisionApprovalDigest(decision)
+		if err != nil {
+			return fmt.Errorf("AI evaluation release decision %d approval digest: %w", i+1, err)
+		}
+		if decision.ApprovalDigest != expectedApprovalDigest {
 			return fmt.Errorf("AI evaluation release decision %d approval digest is invalid", i+1)
 		}
 		models := []string{activeRun.ProposerModel, activeRun.VerifierModel, decision.ActiveRun.ProposerModel, decision.ActiveRun.VerifierModel}
@@ -377,6 +401,25 @@ func validateReleaseManifestHeader(manifest AIEvaluationReleaseManifest) error {
 		}
 	} else if manifest.ComparisonID != "" || strings.TrimSpace(manifest.RollbackTo) == "" {
 		return fmt.Errorf("AI evaluation rollback requires rollback_to and no comparison_id")
+	}
+	return nil
+}
+
+// validateReleasePromotionPolicy pins release authority to a conservative policy floor. Comparison
+// tooling may evaluate exploratory thresholds, but a release cannot weaken the built-in defaults.
+func validateReleasePromotionPolicy(policy AIEvaluationPromotionPolicy) error {
+	if err := policy.Validate(); err != nil {
+		return err
+	}
+	floor := DefaultAIEvaluationPromotionPolicy()
+	if policy.MinimumPrecisionBasisPoints < floor.MinimumPrecisionBasisPoints ||
+		policy.MaximumFalseNegativeEscapeRateBasisPoints > floor.MaximumFalseNegativeEscapeRateBasisPoints ||
+		policy.MaximumPrecisionDropBasisPoints > floor.MaximumPrecisionDropBasisPoints ||
+		policy.MaximumRecallDropBasisPoints > floor.MaximumRecallDropBasisPoints ||
+		policy.MaximumCoverageDropBasisPoints > floor.MaximumCoverageDropBasisPoints ||
+		policy.MaximumVerifierCoverageDropBasisPoints > floor.MaximumVerifierCoverageDropBasisPoints ||
+		policy.MaximumDisagreementIncreaseBasisPoints > floor.MaximumDisagreementIncreaseBasisPoints {
+		return fmt.Errorf("AI evaluation release promotion policy is weaker than the built-in safety floor")
 	}
 	return nil
 }
@@ -452,7 +495,7 @@ func rollbackReleaseTarget(ledger AIEvaluationReleaseLedger, target string) (AIE
 	return AIEvaluationRun{}, "", fmt.Errorf("AI evaluation rollback target %q is not in the approved release ledger", target)
 }
 
-func releaseModelIdentities(ledger AIEvaluationReleaseLedger, evidence *AIEvaluationPromotionEvidence) []string {
+func releaseModelIdentities(ledger AIEvaluationReleaseLedger, evidence *AIEvaluationPromotionEvidence, manifest AIEvaluationReleaseManifest) []string {
 	models := []string{}
 	if ledger.SchemaVersion != "" {
 		run := currentReleaseRun(ledger)
@@ -463,10 +506,15 @@ func releaseModelIdentities(ledger AIEvaluationReleaseLedger, evidence *AIEvalua
 		models = append(models, comparison.BaselineRun.ProposerModel, comparison.BaselineRun.VerifierModel,
 			comparison.CandidateRun.ProposerModel, comparison.CandidateRun.VerifierModel)
 	}
+	if manifest.Action == AIEvaluationReleaseRollback && ledger.SchemaVersion != "" {
+		if target, _, err := rollbackReleaseTarget(ledger, manifest.RollbackTo); err == nil {
+			models = append(models, target.ProposerModel, target.VerifierModel)
+		}
+	}
 	return models
 }
 
-func releaseDecisionApprovalDigest(decision AIEvaluationReleaseDecision) string {
+func releaseDecisionApprovalDigest(decision AIEvaluationReleaseDecision) (string, error) {
 	payload := struct {
 		Schema       string          `json:"schema"`
 		LedgerHead   string          `json:"ledger_head"`
@@ -479,17 +527,23 @@ func releaseDecisionApprovalDigest(decision AIEvaluationReleaseDecision) string 
 		TargetRunID  string          `json:"target_run_id"`
 	}{aiEvaluationReleaseApprovalSchema, decision.PreviousDecisionID, decision.Version, decision.Action,
 		decision.Provenance, decision.ComparisonID, decision.RollbackTo, decision.ActiveRun, decision.ActiveRunID}
-	b, _ := json.Marshal(payload)
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal AI evaluation release approval digest: %w", err)
+	}
 	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:]), nil
 }
 
-func releaseDecisionID(decision AIEvaluationReleaseDecision) string {
+func releaseDecisionID(decision AIEvaluationReleaseDecision) (string, error) {
 	copyDecision := decision
 	copyDecision.DecisionID = ""
-	b, _ := json.Marshal(copyDecision)
+	b, err := json.Marshal(copyDecision)
+	if err != nil {
+		return "", fmt.Errorf("marshal AI evaluation release decision identity: %w", err)
+	}
 	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func decodeReleaseJSON(data []byte, dst any) error {

--- a/internal/usecase/sca/fptriage_release_test.go
+++ b/internal/usecase/sca/fptriage_release_test.go
@@ -131,6 +131,122 @@ func TestAIEvaluationReleaseApprovalCannotReplayAfterLedgerHeadChanges(t *testin
 	}
 }
 
+func TestAIEvaluationReleaseRejectsFreshBaselineForSameActiveConfiguration(t *testing.T) {
+	firstEvidence := releaseTestEvidenceFor(t, "prompt-v1", "prompt-v2")
+	first := releaseTestManifest("release-one", AIEvaluationReleasePromote, firstEvidence.Comparison.ComparisonID, "")
+	first.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &firstEvidence, first)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &firstEvidence, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This is the same prompt/model configuration as the active run, but it is a freshly
+	// evaluated artifact with different canonical evidence. It must not replace the exact
+	// active run as the next promotion's baseline.
+	freshBaseline := promotionTestReport("prompt-v2", func(results []AIEvaluationResult) {
+		results[0].Critique.Confidence--
+	})
+	if freshBaseline.RunID == currentReleaseRunID(ledger) {
+		t.Fatal("test setup did not create a distinct baseline run")
+	}
+	candidate := promotionTestReport("prompt-v3", nil)
+	comparison, err := CompareAIEvaluationReports(freshBaseline, candidate, DefaultAIEvaluationPromotionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := AIEvaluationPromotionEvidence{BaselineReport: freshBaseline, CandidateReport: candidate, Comparison: comparison}
+	manifest := releaseTestManifest("release-two", AIEvaluationReleasePromote, comparison.ComparisonID, "")
+	if _, err := AIEvaluationReleaseReviewDigest(ledger, &evidence, manifest); err == nil {
+		t.Fatal("fresh same-configuration baseline replaced the exact active approved run")
+	}
+
+	validEvidence := releaseTestEvidenceFor(t, "prompt-v2", "prompt-v3")
+	validManifest := releaseTestManifest("release-two-valid", AIEvaluationReleasePromote, validEvidence.Comparison.ComparisonID, "")
+	validManifest.Approvals = releaseTestApprovals(t, ledger, &validEvidence, validManifest)
+	validLedger, err := ApplyAIEvaluationRelease(ledger, &validEvidence, validManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validLedger.Decisions[1].BaselineEvaluationID = freshBaseline.RunID
+	validLedger.Decisions[1].DecisionID, err = releaseDecisionID(validLedger.Decisions[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	validLedger.HeadDecisionID = validLedger.Decisions[1].DecisionID
+	if err := validLedger.Validate(); err == nil {
+		t.Fatal("ledger validation accepted a rehashed promotion with a substituted baseline run id")
+	}
+}
+
+func TestAIEvaluationReleaseEnforcesPromotionPolicyFloor(t *testing.T) {
+	baseline := promotionTestReport("prompt-v1", nil)
+	candidate := promotionTestReport("prompt-v2", nil)
+	weak := DefaultAIEvaluationPromotionPolicy()
+	weak.MinimumPrecisionBasisPoints = 0
+	comparison, err := CompareAIEvaluationReports(baseline, candidate, weak)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := AIEvaluationPromotionEvidence{BaselineReport: baseline, CandidateReport: candidate, Comparison: comparison}
+	manifest := releaseTestManifest("release-weak", AIEvaluationReleasePromote, comparison.ComparisonID, "")
+	if _, err := AIEvaluationReleaseReviewDigest(AIEvaluationReleaseLedger{}, &evidence, manifest); err == nil {
+		t.Fatal("self-declared policy below the release safety floor was accepted")
+	}
+
+	validEvidence := releaseTestEvidence(t)
+	validManifest := releaseTestManifest("release-valid", AIEvaluationReleasePromote, validEvidence.Comparison.ComparisonID, "")
+	validManifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &validEvidence, validManifest)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &validEvidence, validManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger.Decisions[0].PromotionPolicy.MinimumPrecisionBasisPoints = 0
+	ledger.Decisions[0].DecisionID, err = releaseDecisionID(ledger.Decisions[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger.HeadDecisionID = ledger.Decisions[0].DecisionID
+	if err := ledger.Validate(); err == nil {
+		t.Fatal("ledger validation accepted a rehashed policy below the release safety floor")
+	}
+
+	strict := DefaultAIEvaluationPromotionPolicy()
+	strict.MinimumPrecisionBasisPoints = 9600
+	comparison, err = CompareAIEvaluationReports(baseline, candidate, strict)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence = AIEvaluationPromotionEvidence{BaselineReport: baseline, CandidateReport: candidate, Comparison: comparison}
+	manifest = releaseTestManifest("release-strict", AIEvaluationReleasePromote, comparison.ComparisonID, "")
+	if _, err := AIEvaluationReleaseReviewDigest(AIEvaluationReleaseLedger{}, &evidence, manifest); err != nil {
+		t.Fatalf("stricter release policy was rejected: %v", err)
+	}
+}
+
+func TestAIEvaluationRollbackSeparationOfDutiesIncludesTargetModels(t *testing.T) {
+	target := candidateRun("prompt-v1")
+	target.ProposerModel = "rollback-target-model"
+	current := candidateRun("prompt-v2")
+	ledger := AIEvaluationReleaseLedger{
+		SchemaVersion: aiEvaluationReleaseLedgerSchema,
+		InitialRun:    target,
+		InitialRunID:  strings.Repeat("a", 64),
+		Decisions: []AIEvaluationReleaseDecision{{
+			ActiveRun: current, ActiveRunID: strings.Repeat("b", 64),
+		}},
+	}
+	manifest := releaseTestManifest("rollback-target", AIEvaluationReleaseRollback, "", "initial")
+	digest := strings.Repeat("c", 64)
+	now := time.Date(2026, 8, 14, 8, 0, 0, 0, time.UTC)
+	approvals := []AIEvaluationReleaseApproval{
+		{Role: "pm", Reviewer: target.ProposerModel, Approved: true, Rationale: "Product approval", ReviewedAt: now, ReviewedSHA256: digest},
+		{Role: "security", Reviewer: "security@example.com", Approved: true, Rationale: "Security approval", ReviewedAt: now.Add(time.Minute), ReviewedSHA256: digest},
+	}
+	if err := validateReleaseApprovals(approvals, digest, releaseModelIdentities(ledger, nil, manifest)); err == nil {
+		t.Fatal("rollback target model was accepted as a human approver")
+	}
+}
+
 func TestAIEvaluationReleaseRecomputesComparisonFromReports(t *testing.T) {
 	evidence := releaseTestEvidence(t)
 	evidence.BaselineReport.Run.PromptVersion = "tampered"

--- a/internal/usecase/sca/fptriage_release_test.go
+++ b/internal/usecase/sca/fptriage_release_test.go
@@ -1,0 +1,173 @@
+package sca
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAIEvaluationReleasePromotionAndRollbackAreVersionedAndChained(t *testing.T) {
+	evidence := releaseTestEvidence(t)
+	comparison := evidence.Comparison
+	manifest := releaseTestManifest("release-2026-08-canary", AIEvaluationReleasePromote, comparison.ComparisonID, "")
+	manifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &evidence, manifest)
+
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ledger.Decisions) != 1 || ledger.Decisions[0].Status != "approved" ||
+		ledger.Decisions[0].ActiveRun.PromptVersion != "prompt-v2" || ledger.HeadDecisionID == "" {
+		t.Fatalf("promotion ledger = %+v", ledger)
+	}
+
+	rollback := releaseTestManifest("release-2026-08-rollback", AIEvaluationReleaseRollback, "", "initial")
+	rollback.Approvals = releaseTestApprovals(t, ledger, nil, rollback)
+	ledger, err = ApplyAIEvaluationRelease(ledger, nil, rollback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ledger.Decisions) != 2 || ledger.Decisions[1].PreviousDecisionID != ledger.Decisions[0].DecisionID ||
+		ledger.Decisions[1].ActiveRun.PromptVersion != "prompt-v1" {
+		t.Fatalf("rollback ledger = %+v", ledger)
+	}
+	b, _ := json.Marshal(ledger)
+	loaded, err := LoadAIEvaluationReleaseLedger(b)
+	if err != nil || loaded.HeadDecisionID != ledger.HeadDecisionID {
+		t.Fatalf("load ledger = %+v err=%v", loaded, err)
+	}
+}
+
+func TestAIEvaluationReleaseRejectsMachineDuplicateAndReplayedApprovals(t *testing.T) {
+	evidence := releaseTestEvidence(t)
+	comparison := evidence.Comparison
+	manifest := releaseTestManifest("release-canary", AIEvaluationReleasePromote, comparison.ComparisonID, "")
+	manifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &evidence, manifest)
+
+	tests := map[string]func(*AIEvaluationReleaseManifest){
+		"same human":      func(m *AIEvaluationReleaseManifest) { m.Approvals[1].Reviewer = m.Approvals[0].Reviewer },
+		"model actor":     func(m *AIEvaluationReleaseManifest) { m.Approvals[0].Reviewer = comparison.CandidateRun.ProposerModel },
+		"machine actor":   func(m *AIEvaluationReleaseManifest) { m.Approvals[0].Reviewer = "bot:release" },
+		"replayed digest": func(m *AIEvaluationReleaseManifest) { m.Provenance = "security/change-43" },
+		"role order":      func(m *AIEvaluationReleaseManifest) { m.Approvals[0], m.Approvals[1] = m.Approvals[1], m.Approvals[0] },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			changed := manifest
+			changed.Approvals = append([]AIEvaluationReleaseApproval(nil), manifest.Approvals...)
+			mutate(&changed)
+			if _, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, changed); err == nil {
+				t.Fatal("unsafe release approval was accepted")
+			}
+		})
+	}
+}
+
+func TestAIEvaluationReleaseRejectsBlockedComparisonAndTamperedLedger(t *testing.T) {
+	evidence := releaseTestEvidence(t)
+	comparison := evidence.Comparison
+	blocked := comparison
+	blocked.Status = "blocked"
+	blocked.ApprovalRequired = false
+	blocked.ComparisonID = evaluationComparisonID(blocked)
+	manifest := releaseTestManifest("release-canary", AIEvaluationReleasePromote, blocked.ComparisonID, "")
+	blockedEvidence := evidence
+	blockedEvidence.Comparison = blocked
+	if _, err := AIEvaluationReleaseReviewDigest(AIEvaluationReleaseLedger{}, &blockedEvidence, manifest); err == nil {
+		t.Fatal("blocked comparison reached approval")
+	}
+
+	manifest = releaseTestManifest("release-canary", AIEvaluationReleasePromote, comparison.ComparisonID, "")
+	manifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &evidence, manifest)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger.Decisions[0].ActiveRun.PromptVersion = "tampered"
+	if err := ledger.Validate(); err == nil {
+		t.Fatal("tampered ledger passed validation")
+	}
+}
+
+func TestAIEvaluationReleaseRejectsUnknownAndCurrentRollbackTargets(t *testing.T) {
+	evidence := releaseTestEvidence(t)
+	comparison := evidence.Comparison
+	manifest := releaseTestManifest("release-canary", AIEvaluationReleasePromote, comparison.ComparisonID, "")
+	manifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &evidence, manifest)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, target := range []string{strings.Repeat("a", 64), ledger.HeadDecisionID} {
+		rollback := releaseTestManifest("rollback-"+target[:4], AIEvaluationReleaseRollback, "", target)
+		if _, err := AIEvaluationReleaseReviewDigest(ledger, nil, rollback); err == nil {
+			t.Fatalf("rollback target %q was accepted", target)
+		}
+	}
+}
+
+func TestAIEvaluationReleaseApprovalCannotReplayAfterLedgerHeadChanges(t *testing.T) {
+	firstEvidence := releaseTestEvidenceFor(t, "prompt-v1", "prompt-v2")
+	first := releaseTestManifest("release-one", AIEvaluationReleasePromote, firstEvidence.Comparison.ComparisonID, "")
+	first.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &firstEvidence, first)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &firstEvidence, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rollback := releaseTestManifest("rollback-one", AIEvaluationReleaseRollback, "", "initial")
+	rollback.Approvals = releaseTestApprovals(t, ledger, nil, rollback)
+
+	secondEvidence := releaseTestEvidenceFor(t, "prompt-v2", "prompt-v3")
+	second := releaseTestManifest("release-two", AIEvaluationReleasePromote, secondEvidence.Comparison.ComparisonID, "")
+	second.Approvals = releaseTestApprovals(t, ledger, &secondEvidence, second)
+	ledger, err = ApplyAIEvaluationRelease(ledger, &secondEvidence, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyAIEvaluationRelease(ledger, nil, rollback); err == nil {
+		t.Fatal("approval from an older ledger head was replayed")
+	}
+}
+
+func TestAIEvaluationReleaseRecomputesComparisonFromReports(t *testing.T) {
+	evidence := releaseTestEvidence(t)
+	evidence.BaselineReport.Run.PromptVersion = "tampered"
+	manifest := releaseTestManifest("release-canary", AIEvaluationReleasePromote, evidence.Comparison.ComparisonID, "")
+	if _, err := AIEvaluationReleaseReviewDigest(AIEvaluationReleaseLedger{}, &evidence, manifest); err == nil {
+		t.Fatal("comparison was trusted after its baseline report changed")
+	}
+}
+
+func releaseTestEvidence(t *testing.T) AIEvaluationPromotionEvidence {
+	return releaseTestEvidenceFor(t, "prompt-v1", "prompt-v2")
+}
+
+func releaseTestEvidenceFor(t *testing.T, baselinePrompt, candidatePrompt string) AIEvaluationPromotionEvidence {
+	t.Helper()
+	baseline, candidate := promotionTestReport(baselinePrompt, nil), promotionTestReport(candidatePrompt, nil)
+	comparison, err := CompareAIEvaluationReports(baseline, candidate, DefaultAIEvaluationPromotionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return AIEvaluationPromotionEvidence{BaselineReport: baseline, CandidateReport: candidate, Comparison: comparison}
+}
+
+func releaseTestManifest(version, action, comparisonID, rollbackTo string) AIEvaluationReleaseManifest {
+	return AIEvaluationReleaseManifest{SchemaVersion: AIEvaluationReleaseManifestSchema, Version: version,
+		Action: action, Provenance: "security/change-42", ComparisonID: comparisonID, RollbackTo: rollbackTo}
+}
+
+func releaseTestApprovals(t *testing.T, ledger AIEvaluationReleaseLedger, evidence *AIEvaluationPromotionEvidence, manifest AIEvaluationReleaseManifest) []AIEvaluationReleaseApproval {
+	t.Helper()
+	digest, err := AIEvaluationReleaseReviewDigest(ledger, evidence, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 14, 8, 0, 0, 0, time.UTC)
+	return []AIEvaluationReleaseApproval{
+		{Role: "pm", Reviewer: "pm@example.com", Approved: true, Rationale: "Product rollout approved", ReviewedAt: now, ReviewedSHA256: digest},
+		{Role: "security", Reviewer: "security@example.com", Approved: true, Rationale: "Security evidence approved", ReviewedAt: now.Add(time.Minute), ReviewedSHA256: digest},
+	}
+}


### PR DESCRIPTION
## Summary

Completes the remaining governance slice of P2.4 after #554 and #555:

- add synapse-fptriage-release for independently approved model/prompt promotions and rollbacks
- recompute the candidate comparison from the complete baseline and candidate shadow reports at the release boundary
- require distinct PM and Security human approvals bound to the exact manifest and current ledger head
- record unique release versions in a create-only, hash-chained ledger
- restrict rollback targets to the initial baseline or an earlier approved decision
- document the promotion, approval, canary deployment, monitoring, and rollback workflow

## Safety contract

- release artifacts have no runtime authority and never mutate models, prompts, thresholds, findings, or gate configuration
- stored comparison status and IDs are not trusted without full report recomputation
- reserved machine principals and proposer/verifier model identities cannot approve a release
- approvals cannot be replayed after the ledger head changes
- existing evidence files and input artifacts are never overwritten

## Verification

- go test ./...
- go vet ./...
- go build ./...
- go test -race ./internal/usecase/sca ./cmd/synapse-fptriage-release
- git diff --check

Closes #396