### PR TITLE
feat(correlation): unified per-asset risk story (#427)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -150,6 +150,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachproof"
 	reconuc "github.com/KKloudTarus/synapse-ce/internal/usecase/recon"
 	reportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/report"
+	riskstoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/riskstoryuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/sarifingest"
@@ -1597,6 +1598,17 @@ func main() {
 			os.Exit(1)
 		} else {
 			router.SetDetectionReader(detectionReader)
+		}
+		// #427 unified per-asset risk story. A read-model assembler that correlates the records ALREADY
+		// produced by the pillars above (assets/edges, findings, attack-path bindings, reachability
+		// judgments, and the detection ledger) into one deterministic, tenant-scoped story per asset. It
+		// creates no data and persists no table; staleness uses the same freshness target as fleet
+		// coverage (#413). No LLM is in this path (asserted by an arch test).
+		if riskStorySvc, rserr := riskstoryuc.NewService(assetStore, findingRepo, attackPathStore, judgmentStore, detectionRecordStore, cfg.FleetCoverageFreshnessTarget, clock.Now); rserr != nil {
+			log.Error("risk story assembler init failed", "err", rserr)
+			os.Exit(1)
+		} else {
+			router.SetRiskStoryReader(riskStorySvc)
 		}
 		// The ingest writes an append-only audit entry asserting that N external results entered an
 		// engagement. Without Postgres those rows live only in this process, so the banner says so

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -544,6 +544,13 @@ func TestHostileHarness(t *testing.T) {
 		{"readonly may read purple coverage", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/purple-coverage", http.StatusOK},
 		{"cross-tenant purple coverage → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/purple-coverage", http.StatusNotFound},
 		{"principal-less purple coverage read is denied", "", "", false, http.MethodGet, "/api/v1/engagements/engA/purple-coverage", http.StatusForbidden},
+		// #427 unified per-asset risk story (PermView): readonly may read; a cross-tenant read is 404 at
+		// the withEngTenant chokepoint before any correlation runs; a principal-less read is denied. Both
+		// the list route and the single-asset route are gated, so the story never crosses a tenant.
+		{"readonly may read risk stories", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/risk-stories", http.StatusOK},
+		{"cross-tenant risk story list → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/risk-stories", http.StatusNotFound},
+		{"principal-less risk story read is denied", "", "", false, http.MethodGet, "/api/v1/engagements/engA/risk-stories", http.StatusForbidden},
+		{"cross-tenant single risk story → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/risk-stories/asset-A", http.StatusNotFound},
 		// Fleet coverage (#413, PermView): machine roles denied; readonly may read; cross-tenant agent
 		// detail is 404 (never an existence-revealing 403). The cross-tenant LIST emptiness (a 200 that
 		// leaks nothing) is asserted on the body just below the table.

--- a/internal/adapter/httpapi/riskstory_handler.go
+++ b/internal/adapter/httpapi/riskstory_handler.go
@@ -1,0 +1,89 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskstory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// riskStoryReader is the narrow read side the HTTP layer needs for the unified per-asset risk story
+// (#427): the engagement's assembled stories and a single asset's story. *riskstoryuc.Service satisfies
+// it. Reads are tenant-gated by withEngTenant + the underlying stores' tenant scoping, and the
+// assembler additionally derives the tenant from ctx and fails closed, so a cross-tenant read returns
+// nothing.
+type riskStoryReader interface {
+	StoriesForEngagement(ctx context.Context, engagementID shared.ID) ([]riskstory.Story, error)
+	StoryForAsset(ctx context.Context, engagementID, assetID shared.ID) (riskstory.Story, error)
+}
+
+// SetRiskStoryReader wires the risk-story read routes (#427). Left unset, the routes report an empty
+// result rather than 500 — the correlation view is simply not enabled.
+func (rt *Router) SetRiskStoryReader(r riskStoryReader) {
+	if r != nil {
+		rt.riskStories = r
+	}
+}
+
+// listRiskStories returns one assembled risk story per asset in the engagement (ordered by asset id).
+// With ?view=export it returns each story alongside its flattened, deduplicated evidence references, so
+// an auditor/report consumer can trace every element to a backing record. PermView + withEngTenant; a
+// cross-tenant engagement is already a 404 before this runs.
+func (rt *Router) listRiskStories(w http.ResponseWriter, r *http.Request) {
+	engID := shared.ID(r.PathValue("id"))
+	if rt.riskStories == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"stories": []riskstory.Story{}})
+		return
+	}
+	stories, err := rt.riskStories.StoriesForEngagement(r.Context(), engID)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if r.URL.Query().Get("view") == "export" {
+		writeJSON(w, http.StatusOK, map[string]any{"exports": exportStories(stories)})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"stories": stories})
+}
+
+// getRiskStory returns the single risk story for one asset in the engagement. With ?view=export it also
+// carries the flattened evidence references. A 404 is returned when the asset has no correlated signal.
+func (rt *Router) getRiskStory(w http.ResponseWriter, r *http.Request) {
+	engID := shared.ID(r.PathValue("id"))
+	assetID := shared.ID(r.PathValue("assetID"))
+	if rt.riskStories == nil {
+		writeError(w, rt.log, shared.ErrNotFound)
+		return
+	}
+	story, err := rt.riskStories.StoryForAsset(r.Context(), engID, assetID)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if r.URL.Query().Get("view") == "export" {
+		writeJSON(w, http.StatusOK, exportStory(story))
+		return
+	}
+	writeJSON(w, http.StatusOK, story)
+}
+
+// riskStoryExport is the auditor/report representation: the story plus its full, deduplicated evidence
+// reference set, so the narrative is always traceable to its backing records.
+type riskStoryExport struct {
+	Story    riskstory.Story        `json:"story"`
+	Evidence []riskstory.Provenance `json:"evidence"`
+}
+
+func exportStory(s riskstory.Story) riskStoryExport {
+	return riskStoryExport{Story: s, Evidence: s.EvidenceRefs()}
+}
+
+func exportStories(stories []riskstory.Story) []riskStoryExport {
+	out := make([]riskStoryExport, 0, len(stories))
+	for _, s := range stories {
+		out = append(out, exportStory(s))
+	}
+	return out
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -78,6 +78,7 @@ type Router struct {
 	fleetRolloutAdmin      fleetRolloutService   // optional; nil ⇒ the operator rollout routes are not served
 	offensiveHalt          offensiveKillSwitch   // optional; nil ⇒ the red-team halt route is not served
 	detections             detectionReader       // optional read side for the detection ledger (#423)
+	riskStories            riskStoryReader       // optional read side for the unified per-asset risk story (#427)
 	purpleCoverage         purpleCoverageReader  // optional read side for purple-team coverage (#426)
 	fleet                  *fleetRouter          // optional; nil ⇒ agent transport plane is not served
 	fleetAdmin             fleetAdminService     // optional; nil ⇒ operator agent-admin routes not registered
@@ -405,6 +406,8 @@ func (rt *Router) routes() *http.ServeMux {
 		// itself, rather than the governance claim being made by a method nothing calls.
 		mux.HandleFunc("GET /api/v1/engagements/{id}/imported-findings", rt.authz(userdom.PermView, rt.withEngTenant(rt.listImportedFindings)))
 		mux.HandleFunc("GET /api/v1/engagements/{id}/detections", rt.authz(userdom.PermView, rt.withEngTenant(rt.listDetections)))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/risk-stories", rt.authz(userdom.PermView, rt.withEngTenant(rt.listRiskStories)))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/risk-stories/{assetID}", rt.authz(userdom.PermView, rt.withEngTenant(rt.getRiskStory)))
 		mux.HandleFunc("GET /api/v1/engagements/{id}/purple-coverage", rt.authz(userdom.PermView, rt.withEngTenant(rt.listPurpleCoverage)))
 	}
 	mux.HandleFunc("GET /api/v1/engagements/{id}/scan", rt.authz(userdom.PermView, rt.withEngTenant(rt.latestScan)))

--- a/internal/domain/riskstory/story.go
+++ b/internal/domain/riskstory/story.go
@@ -1,0 +1,399 @@
+// Package riskstory is the pure, deterministic domain for the unified per-asset risk story (issue
+// #427): one narrative per asset assembled from records already produced by the other pillars — the
+// asset inventory (#431), the findings of every engine + their reachability verdicts, the attack-path
+// graph (#419), runtime detections (#423), and the continuous vulnerability occurrences/assessments
+// (#514). It CREATES no data and owns no table; it only correlates and orders existing records.
+//
+// Two honesty invariants are enforced here, not left to the caller:
+//   - Every element references the backing record that produced it (Provenance). An element with no
+//     provenance fails Validate — the story is never allowed to show something it cannot trace to
+//     evidence.
+//   - Uncertainty is carried, never flattened. Unknown reachability, an inferred edge, a sampled
+//     telemetry window, and staleness travel as Qualifiers on the relevant element.
+//
+// Assembly is deterministic: the same records produce the same story in the same order, so a story can
+// be diffed over time. There is NO LLM in this package (an arch test asserts it); prose narration stays
+// in the human-gated writeupdraft path, outside the report.
+package riskstory
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Provenance is the backing record an element is derived from. Every element carries one; the story is
+// navigable to its evidence through it.
+type Provenance struct {
+	Kind string    `json:"kind"` // one of the ProvKind* constants
+	ID   shared.ID `json:"id"`
+}
+
+// Backing-record kinds. A Provenance with any other kind, or an empty ID, fails validation.
+const (
+	ProvAsset        = "asset"
+	ProvAssetEdge    = "asset_edge"
+	ProvFinding      = "finding"
+	ProvReachability = "reachability"
+	ProvAttackPath   = "attack_path"
+	ProvDetection    = "detection"
+	ProvOccurrence   = "occurrence"
+	ProvAssessment   = "assessment"
+)
+
+// Qualifier constants — the closed set of uncertainty markers carried from inputs. They are surfaced so
+// an uncertain input is never presented as certain.
+const (
+	QualReachabilityUnknown = "reachability_unknown" // a reachability verdict of "unknown"
+	QualInferredEdge        = "inferred_edge"        // an exposure/attack-path edge with inferred (not observed) confidence
+	QualSampledWindow       = "sampled_telemetry_window"
+	QualStale               = "stale" // last-observed older than the freshness target (see Fresh)
+)
+
+func validProvKind(k string) bool {
+	switch k {
+	case ProvAsset, ProvAssetEdge, ProvFinding, ProvReachability, ProvAttackPath, ProvDetection, ProvOccurrence, ProvAssessment:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p Provenance) valid() bool { return validProvKind(p.Kind) && p.ID != "" }
+
+// AssetFacts is the identity header of the story: what the asset IS.
+type AssetFacts struct {
+	Kind       string     `json:"kind"`
+	Key        string     `json:"key"`
+	Name       string     `json:"name"`
+	Provenance Provenance `json:"provenance"` // the asset record itself (ProvAsset)
+}
+
+// ExposureElement is one way the asset is exposed (an exposure edge/asset). Confidence carries the
+// observed-vs-inferred distinction; an inferred edge is qualified.
+type ExposureElement struct {
+	Description string     `json:"description"`
+	Confidence  string     `json:"confidence"` // "observed" | "inferred"
+	Provenance  Provenance `json:"provenance"` // ProvAssetEdge (or ProvAsset for an exposure asset)
+	Qualifiers  []string   `json:"qualifiers,omitempty"`
+}
+
+// FindingElement is one finding attributed to the asset, enriched with its reachability verdict and its
+// corroboration signals (on an attack path, seen under attack at runtime). Evidence carries the extra
+// backing records (the reachability judgment, the attack-path binding, the vulnerability occurrence and
+// its immutable assessment) so the element is fully traceable.
+type FindingElement struct {
+	FindingID    shared.ID `json:"finding_id"`
+	Title        string    `json:"title"`
+	Severity     string    `json:"severity"`
+	Priority     int       `json:"priority"` // the existing 1..5 RiskPriority (1 = act now); 0 = unset
+	RiskScore    float64   `json:"risk_score"`
+	KEV          bool      `json:"kev"`
+	Reachability string    `json:"reachability"` // "reachable"|"not_reachable"|"unknown"|""
+
+	// Corroboration signals. Corroboration lists the ones that are true, and RankReason explains why the
+	// element ranks where it does. These RAISE the ordering over an equal-priority finding without them;
+	// they do NOT mutate Priority (the promotion gate #428 owns priority mutation).
+	Reachable       bool     `json:"reachable"`
+	OnAttackPath    bool     `json:"on_attack_path"`
+	SeenUnderAttack bool     `json:"seen_under_attack"`
+	Corroboration   []string `json:"corroboration,omitempty"`
+	RankReason      string   `json:"rank_reason,omitempty"`
+
+	LastObserved time.Time    `json:"last_observed"`
+	Stale        bool         `json:"stale"`
+	Provenance   Provenance   `json:"provenance"` // ProvFinding
+	Evidence     []Provenance `json:"evidence,omitempty"`
+	Qualifiers   []string     `json:"qualifiers,omitempty"`
+}
+
+// corroborationCount is the number of corroborating signals; more signals raise the ordering.
+func (f FindingElement) corroborationCount() int {
+	n := 0
+	for _, b := range []bool{f.Reachable, f.OnAttackPath, f.SeenUnderAttack} {
+		if b {
+			n++
+		}
+	}
+	return n
+}
+
+// PathElement is an attack path the asset sits on. An inferred path is qualified.
+type PathElement struct {
+	Summary    string     `json:"summary"`
+	Confidence string     `json:"confidence"` // "observed" | "inferred"
+	Provenance Provenance `json:"provenance"` // ProvAttackPath
+	Qualifiers []string   `json:"qualifiers,omitempty"`
+}
+
+// DetectionElement is a runtime detection observed on the asset.
+type DetectionElement struct {
+	RuleID     string     `json:"rule_id"`
+	Severity   string     `json:"severity"`
+	Observed   time.Time  `json:"observed"`
+	Stale      bool       `json:"stale"`
+	Provenance Provenance `json:"provenance"` // ProvDetection
+	Qualifiers []string   `json:"qualifiers,omitempty"`
+}
+
+// Story is the assembled per-asset narrative. Score is the asset's worst (numerically lowest) finding
+// priority — the existing model, surfaced; corroboration raises the ORDER of findings within the story,
+// shown per element, rather than replacing the score.
+type Story struct {
+	AssetID     shared.ID          `json:"asset_id"`
+	TenantID    shared.ID          `json:"tenant_id"`
+	Identity    AssetFacts         `json:"identity"`
+	Exposure    []ExposureElement  `json:"exposure"`
+	Findings    []FindingElement   `json:"findings"`
+	Paths       []PathElement      `json:"paths"`
+	Detections  []DetectionElement `json:"detections"`
+	Score       int                `json:"score"`
+	Qualifiers  []string           `json:"qualifiers,omitempty"`
+	GeneratedAt time.Time          `json:"generated_at"`
+}
+
+// Inputs is the correlated, per-asset raw material the use case hands to Assemble. Assemble owns the
+// deterministic ordering, corroboration ranking, story-level rollup, and validation.
+type Inputs struct {
+	AssetID     shared.ID
+	TenantID    shared.ID
+	Identity    AssetFacts
+	Exposure    []ExposureElement
+	Findings    []FindingElement
+	Paths       []PathElement
+	Detections  []DetectionElement
+	GeneratedAt time.Time
+}
+
+// Assemble deterministically orders and validates the correlated inputs into a Story. It computes the
+// per-finding corroboration ordering + RankReason, the asset-level Score, and the story-level Qualifier
+// rollup. It returns shared.ErrValidation if any element lacks a backing record.
+func Assemble(in Inputs) (Story, error) {
+	s := Story{
+		AssetID: in.AssetID, TenantID: in.TenantID, Identity: in.Identity,
+		Exposure:    append([]ExposureElement(nil), in.Exposure...),
+		Findings:    append([]FindingElement(nil), in.Findings...),
+		Paths:       append([]PathElement(nil), in.Paths...),
+		Detections:  append([]DetectionElement(nil), in.Detections...),
+		GeneratedAt: in.GeneratedAt.UTC(),
+	}
+
+	// Corroboration reason per finding (deterministic order of reasons). A fresh slice is assigned rather
+	// than reusing any caller-provided backing array, keeping Assemble free of input aliasing.
+	for i := range s.Findings {
+		f := &s.Findings[i]
+		var reasons []string
+		if f.Reachable {
+			reasons = append(reasons, "reachable")
+		}
+		if f.OnAttackPath {
+			reasons = append(reasons, "on_attack_path")
+		}
+		if f.SeenUnderAttack {
+			reasons = append(reasons, "seen_under_attack")
+		}
+		f.Corroboration = reasons
+		if len(reasons) == 0 {
+			f.RankReason = "base priority; no corroborating signals"
+		} else {
+			f.RankReason = "raised by corroboration: " + strings.Join(reasons, " + ")
+		}
+	}
+
+	// Deterministic ordering. Findings: by effective priority (existing model), then more corroboration
+	// first, then higher RiskScore, then id — so an equal-priority finding WITH corroboration outranks
+	// one without, and the order is stable/diffable.
+	sort.SliceStable(s.Findings, func(a, b int) bool {
+		fa, fb := s.Findings[a], s.Findings[b]
+		pa, pb := effectivePriority(fa.Priority), effectivePriority(fb.Priority)
+		if pa != pb {
+			return pa < pb
+		}
+		if ca, cb := fa.corroborationCount(), fb.corroborationCount(); ca != cb {
+			return ca > cb
+		}
+		if fa.RiskScore != fb.RiskScore {
+			return fa.RiskScore > fb.RiskScore
+		}
+		return fa.FindingID < fb.FindingID
+	})
+	sort.SliceStable(s.Exposure, func(a, b int) bool {
+		return s.Exposure[a].Provenance.ID < s.Exposure[b].Provenance.ID
+	})
+	sort.SliceStable(s.Paths, func(a, b int) bool {
+		return s.Paths[a].Provenance.ID < s.Paths[b].Provenance.ID
+	})
+	sort.SliceStable(s.Detections, func(a, b int) bool {
+		da, db := s.Detections[a], s.Detections[b]
+		if da.RuleID != db.RuleID {
+			return da.RuleID < db.RuleID
+		}
+		if !da.Observed.Equal(db.Observed) {
+			return da.Observed.Before(db.Observed)
+		}
+		return da.Provenance.ID < db.Provenance.ID
+	})
+
+	s.Score = assetScore(s.Findings)
+	s.Qualifiers = rollupQualifiers(s)
+
+	if err := s.Validate(); err != nil {
+		return Story{}, err
+	}
+	return s, nil
+}
+
+// effectivePriority maps an unset priority (0) to the lowest bucket so it sorts last, keeping the
+// existing 1..5 model intact.
+func effectivePriority(p int) int {
+	if p < 1 {
+		return 6
+	}
+	return p
+}
+
+// assetScore is the asset's worst (numerically lowest) finding priority, or 0 when the asset has no
+// findings. This is the existing model surfaced at the asset level; corroboration is shown per finding.
+func assetScore(fs []FindingElement) int {
+	best := 0
+	for _, f := range fs {
+		p := effectivePriority(f.Priority)
+		if p > 5 {
+			continue
+		}
+		if best == 0 || p < best {
+			best = p
+		}
+	}
+	return best
+}
+
+// rollupQualifiers gathers the distinct element-level qualifiers to the story level, in deterministic
+// order, so a reader sees at a glance that the story carries uncertainty.
+func rollupQualifiers(s Story) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(qs []string) {
+		for _, q := range qs {
+			if _, dup := seen[q]; dup {
+				continue
+			}
+			seen[q] = struct{}{}
+			out = append(out, q)
+		}
+	}
+	for _, e := range s.Exposure {
+		add(e.Qualifiers)
+	}
+	for _, f := range s.Findings {
+		add(f.Qualifiers)
+	}
+	for _, p := range s.Paths {
+		add(p.Qualifiers)
+	}
+	for _, d := range s.Detections {
+		add(d.Qualifiers)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Validate enforces the honesty invariants: the story has an asset, its identity references the asset
+// record, and every element references a valid backing record (kind + non-empty id). Findings' extra
+// evidence refs must also be valid.
+func (s Story) Validate() error {
+	if s.AssetID == "" || s.TenantID == "" {
+		return fmt.Errorf("%w: risk story is missing asset/tenant scope", shared.ErrValidation)
+	}
+	if s.Identity.Provenance.Kind != ProvAsset || s.Identity.Provenance.ID == "" {
+		return fmt.Errorf("%w: risk story identity must reference the asset record", shared.ErrValidation)
+	}
+	for i, e := range s.Exposure {
+		if !e.Provenance.valid() {
+			return fmt.Errorf("%w: exposure element %d has no backing record", shared.ErrValidation, i)
+		}
+	}
+	for i, f := range s.Findings {
+		if f.FindingID == "" || f.Provenance.Kind != ProvFinding || f.Provenance.ID == "" {
+			return fmt.Errorf("%w: finding element %d has no backing finding record", shared.ErrValidation, i)
+		}
+		for j, ev := range f.Evidence {
+			if !ev.valid() {
+				return fmt.Errorf("%w: finding element %d evidence %d has no backing record", shared.ErrValidation, i, j)
+			}
+		}
+	}
+	for i, p := range s.Paths {
+		if !p.Provenance.valid() {
+			return fmt.Errorf("%w: path element %d has no backing record", shared.ErrValidation, i)
+		}
+	}
+	for i, d := range s.Detections {
+		if !d.Provenance.valid() {
+			return fmt.Errorf("%w: detection element %d has no backing record", shared.ErrValidation, i)
+		}
+	}
+	return nil
+}
+
+// EvidenceRefs returns every backing record the story references — identity, exposures, findings and
+// their evidence, paths and detections — deduplicated and deterministically ordered. This is the
+// auditor/report export: a risk narrative a customer cannot trace back to evidence is not usable in
+// this project's report path, so the export always carries the full provenance set.
+func (s Story) EvidenceRefs() []Provenance {
+	seen := map[Provenance]struct{}{}
+	var out []Provenance
+	add := func(p Provenance) {
+		if p.ID == "" {
+			return
+		}
+		if _, dup := seen[p]; dup {
+			return
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	add(s.Identity.Provenance)
+	for _, e := range s.Exposure {
+		add(e.Provenance)
+	}
+	for _, f := range s.Findings {
+		add(f.Provenance)
+		for _, ev := range f.Evidence {
+			add(ev)
+		}
+	}
+	for _, p := range s.Paths {
+		add(p.Provenance)
+	}
+	for _, d := range s.Detections {
+		add(d.Provenance)
+	}
+	sort.Slice(out, func(a, b int) bool {
+		if out[a].Kind != out[b].Kind {
+			return out[a].Kind < out[b].Kind
+		}
+		return out[a].ID < out[b].ID
+	})
+	return out
+}
+
+// Fresh mirrors the fleet-coverage freshness rule (#413): a zero last-observed time is never fresh; a
+// non-positive target means "no freshness requirement" (fresh once observed); otherwise fresh iff the
+// gap is within the target. Callers mark an element Stale when it is not fresh.
+func Fresh(lastObserved, now time.Time, target time.Duration) bool {
+	if lastObserved.IsZero() {
+		return false
+	}
+	if target <= 0 {
+		return true
+	}
+	gap := now.Sub(lastObserved)
+	if gap < 0 {
+		gap = -gap
+	}
+	return gap <= target
+}

--- a/internal/domain/riskstory/story_test.go
+++ b/internal/domain/riskstory/story_test.go
@@ -1,0 +1,258 @@
+package riskstory
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func baseInputs() Inputs {
+	return Inputs{
+		AssetID:  "asset-1",
+		TenantID: "tenant-1",
+		Identity: AssetFacts{Kind: "exposure", Key: "svc/api", Name: "api", Provenance: Provenance{Kind: ProvAsset, ID: "asset-1"}},
+		Findings: []FindingElement{
+			{FindingID: "f-1", Title: "sqli", Severity: "high", Priority: 2, RiskScore: 8.1, Provenance: Provenance{Kind: ProvFinding, ID: "f-1"}},
+		},
+		GeneratedAt: time.Date(2026, 8, 14, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestAssembleRejectsElementWithoutBackingRecord(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Inputs)
+	}{
+		{"missing asset scope", func(in *Inputs) { in.AssetID = "" }},
+		{"identity not asset-backed", func(in *Inputs) { in.Identity.Provenance = Provenance{} }},
+		{"finding no provenance", func(in *Inputs) { in.Findings[0].Provenance = Provenance{} }},
+		{"finding bad provenance kind", func(in *Inputs) { in.Findings[0].Provenance = Provenance{Kind: "guess", ID: "f-1"} }},
+		{"finding evidence no id", func(in *Inputs) {
+			in.Findings[0].Evidence = []Provenance{{Kind: ProvReachability, ID: ""}}
+		}},
+		{"exposure no provenance", func(in *Inputs) {
+			in.Exposure = []ExposureElement{{Description: "public", Confidence: "observed"}}
+		}},
+		{"path no provenance", func(in *Inputs) {
+			in.Paths = []PathElement{{Summary: "ingress→db", Confidence: "inferred"}}
+		}},
+		{"detection no provenance", func(in *Inputs) {
+			in.Detections = []DetectionElement{{RuleID: "r1", Severity: "high"}}
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in := baseInputs()
+			tc.mutate(&in)
+			if _, err := Assemble(in); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAssembleValidStoryPasses(t *testing.T) {
+	s, err := Assemble(baseInputs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Score != 2 {
+		t.Fatalf("score = %d, want 2 (worst finding priority)", s.Score)
+	}
+	if s.GeneratedAt.Location() != time.UTC {
+		t.Fatalf("GeneratedAt not normalized to UTC")
+	}
+}
+
+// Each uncertainty class must survive assembly on its element and roll up to the story.
+func TestUncertaintyCarriedPerClass(t *testing.T) {
+	tests := []struct {
+		name string
+		in   func() Inputs
+		qual string
+	}{
+		{"reachability unknown", func() Inputs {
+			in := baseInputs()
+			in.Findings[0].Reachability = "unknown"
+			in.Findings[0].Qualifiers = []string{QualReachabilityUnknown}
+			return in
+		}, QualReachabilityUnknown},
+		{"inferred edge", func() Inputs {
+			in := baseInputs()
+			in.Exposure = []ExposureElement{{Description: "guessed", Confidence: "inferred", Provenance: Provenance{Kind: ProvAssetEdge, ID: "e-1"}, Qualifiers: []string{QualInferredEdge}}}
+			return in
+		}, QualInferredEdge},
+		{"sampled telemetry window", func() Inputs {
+			in := baseInputs()
+			in.Detections = []DetectionElement{{RuleID: "r1", Severity: "high", Observed: time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC), Provenance: Provenance{Kind: ProvDetection, ID: "d-1"}, Qualifiers: []string{QualSampledWindow}}}
+			return in
+		}, QualSampledWindow},
+		{"stale", func() Inputs {
+			in := baseInputs()
+			in.Findings[0].Stale = true
+			in.Findings[0].Qualifiers = []string{QualStale}
+			return in
+		}, QualStale},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := Assemble(tc.in())
+			if err != nil {
+				t.Fatalf("assemble: %v", err)
+			}
+			if !contains(s.Qualifiers, tc.qual) {
+				t.Fatalf("story qualifiers %v missing %q", s.Qualifiers, tc.qual)
+			}
+		})
+	}
+}
+
+// Equal-priority findings: the one with more corroborating signals must rank first, and RankReason
+// must explain why — priority itself is never mutated.
+func TestCorroborationRaisesOrderingNotPriority(t *testing.T) {
+	in := baseInputs()
+	in.Findings = []FindingElement{
+		{FindingID: "plain", Priority: 3, RiskScore: 5, Provenance: Provenance{Kind: ProvFinding, ID: "plain"}},
+		{FindingID: "corrob", Priority: 3, RiskScore: 5, Reachable: true, OnAttackPath: true, SeenUnderAttack: true, Provenance: Provenance{Kind: ProvFinding, ID: "corrob"}},
+	}
+	s, err := Assemble(in)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	if s.Findings[0].FindingID != "corrob" {
+		t.Fatalf("corroborated finding did not rank first: order=%v", ids(s.Findings))
+	}
+	if s.Findings[0].Priority != 3 || s.Findings[1].Priority != 3 {
+		t.Fatalf("priority mutated by corroboration: %d,%d", s.Findings[0].Priority, s.Findings[1].Priority)
+	}
+	if s.Findings[0].RankReason == "" || s.Findings[1].RankReason == "" {
+		t.Fatalf("rank reason missing")
+	}
+	if want := "raised by corroboration: reachable + on_attack_path + seen_under_attack"; s.Findings[0].RankReason != want {
+		t.Fatalf("rank reason = %q, want %q", s.Findings[0].RankReason, want)
+	}
+}
+
+// Lower priority number always outranks corroboration on a higher number — corroboration only breaks
+// ties within the same priority.
+func TestPriorityDominatesCorroboration(t *testing.T) {
+	in := baseInputs()
+	in.Findings = []FindingElement{
+		{FindingID: "p4-corrob", Priority: 4, Reachable: true, OnAttackPath: true, SeenUnderAttack: true, Provenance: Provenance{Kind: ProvFinding, ID: "p4-corrob"}},
+		{FindingID: "p1-plain", Priority: 1, Provenance: Provenance{Kind: ProvFinding, ID: "p1-plain"}},
+	}
+	s, err := Assemble(in)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	if s.Findings[0].FindingID != "p1-plain" {
+		t.Fatalf("priority-1 finding did not rank first: %v", ids(s.Findings))
+	}
+	if s.Score != 1 {
+		t.Fatalf("score = %d, want 1", s.Score)
+	}
+}
+
+func TestAssemblyIsDeterministic(t *testing.T) {
+	build := func() Story {
+		in := baseInputs()
+		in.Findings = []FindingElement{
+			{FindingID: "b", Priority: 2, RiskScore: 3, Provenance: Provenance{Kind: ProvFinding, ID: "b"}},
+			{FindingID: "a", Priority: 2, RiskScore: 3, Provenance: Provenance{Kind: ProvFinding, ID: "a"}},
+			{FindingID: "c", Priority: 1, RiskScore: 9, Provenance: Provenance{Kind: ProvFinding, ID: "c"}},
+		}
+		in.Exposure = []ExposureElement{
+			{Description: "y", Confidence: "observed", Provenance: Provenance{Kind: ProvAssetEdge, ID: "e-y"}},
+			{Description: "x", Confidence: "observed", Provenance: Provenance{Kind: ProvAssetEdge, ID: "e-x"}},
+		}
+		s, err := Assemble(in)
+		if err != nil {
+			t.Fatalf("assemble: %v", err)
+		}
+		return s
+	}
+	first := build()
+	for i := 0; i < 8; i++ {
+		if got := build(); !reflect.DeepEqual(first, got) {
+			t.Fatalf("assembly not deterministic on run %d", i)
+		}
+	}
+	// Tie on (priority, corroboration, riskScore) breaks by id ascending.
+	if ids(first.Findings)[0] != "c" || ids(first.Findings)[1] != "a" || ids(first.Findings)[2] != "b" {
+		t.Fatalf("tie-break order wrong: %v", ids(first.Findings))
+	}
+}
+
+func TestFresh(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		last   time.Time
+		target time.Duration
+		want   bool
+	}{
+		{"zero never fresh", time.Time{}, time.Hour, false},
+		{"no target is fresh once observed", now.Add(-1000 * time.Hour), 0, true},
+		{"within target", now.Add(-30 * time.Minute), time.Hour, true},
+		{"beyond target", now.Add(-2 * time.Hour), time.Hour, false},
+		{"exactly at target", now.Add(-time.Hour), time.Hour, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Fresh(tc.last, now, tc.target); got != tc.want {
+				t.Fatalf("Fresh = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvidenceRefsCarriesEveryBackingRecord(t *testing.T) {
+	in := baseInputs()
+	in.Findings[0].Evidence = []Provenance{
+		{Kind: ProvReachability, ID: "reach-1"},
+		{Kind: ProvOccurrence, ID: "occ-1"},
+		{Kind: ProvReachability, ID: "reach-1"}, // dup, must collapse
+	}
+	in.Exposure = []ExposureElement{{Description: "x", Confidence: "observed", Provenance: Provenance{Kind: ProvAssetEdge, ID: "e-1"}}}
+	in.Detections = []DetectionElement{{RuleID: "r", Severity: "high", Provenance: Provenance{Kind: ProvDetection, ID: "d-1"}}}
+	s, err := Assemble(in)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	refs := s.EvidenceRefs()
+	want := []Provenance{
+		{Kind: ProvAsset, ID: "asset-1"},
+		{Kind: ProvAssetEdge, ID: "e-1"},
+		{Kind: ProvDetection, ID: "d-1"},
+		{Kind: ProvFinding, ID: "f-1"},
+		{Kind: ProvOccurrence, ID: "occ-1"},
+		{Kind: ProvReachability, ID: "reach-1"},
+	}
+	if !reflect.DeepEqual(refs, want) {
+		t.Fatalf("evidence refs = %+v, want %+v", refs, want)
+	}
+	// Deterministic across repeated calls.
+	if !reflect.DeepEqual(refs, s.EvidenceRefs()) {
+		t.Fatalf("EvidenceRefs not deterministic")
+	}
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+func ids(fs []FindingElement) []string {
+	out := make([]string, len(fs))
+	for i, f := range fs {
+		out[i] = string(f.FindingID)
+	}
+	return out
+}

--- a/internal/usecase/riskstoryuc/arch_test.go
+++ b/internal/usecase/riskstoryuc/arch_test.go
@@ -1,0 +1,101 @@
+package riskstoryuc
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestRiskStoryAssemblyHasNoLLM is the #427 architecture assertion: the risk story is assembled
+// DETERMINISTICALLY from stored records, with no LLM anywhere in the assembly path (prose narration
+// stays in the human-gated writeupdraft path, outside the report). It fails if any non-test source file
+// in this package imports an agent/LLM package or references an LLM port type, so nobody can quietly
+// wire a model into the deterministic assembler.
+func TestRiskStoryAssemblyHasNoLLM(t *testing.T) {
+	const mod = "github.com/KKloudTarus/synapse-ce"
+	forbiddenImport := []string{
+		mod + "/internal/domain/agent",
+		mod + "/internal/usecase/agent",
+		mod + "/internal/usecase/agenttools",
+		mod + "/internal/usecase/safety",
+		mod + "/internal/usecase/approval",
+		mod + "/internal/usecase/exploitation",
+		mod + "/internal/usecase/analysis",
+		mod + "/internal/infrastructure/llm",
+	}
+	// ports.LLM / ChatRequest / ChatResponse are LLM types living in the (otherwise allowed) ports
+	// package; flag them by selector so importing ports for a read store is fine.
+	forbiddenSelector := map[string]bool{"LLM": true, "ChatRequest": true, "ChatResponse": true}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	scanned := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		scanned++
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, imp := range file.Imports {
+			p := strings.Trim(imp.Path.Value, `"`)
+			for _, bad := range forbiddenImport {
+				if p == bad || strings.HasPrefix(p, bad+"/") {
+					t.Errorf("%s imports forbidden package %q – no LLM/agent in the risk-story assembly path", name, p)
+				}
+			}
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if x, ok := sel.X.(*ast.Ident); ok && x.Name == "ports" && forbiddenSelector[sel.Sel.Name] {
+				t.Errorf("%s references ports.%s – the risk-story assembly path must not touch an LLM type", name, sel.Sel.Name)
+			}
+			return true
+		})
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no risk-story source files – test wiring is wrong")
+	}
+}
+
+// TestRiskStoryAssemblyHasNoLLMTransitive is defense-in-depth over the direct-import scan: it asserts
+// the package's FULL transitive import graph reaches no LLM implementation or agent-orchestration
+// package, catching a model wired in two hops away. Best-effort: skips if the go toolchain is
+// unavailable, so the always-on direct scan remains the floor.
+func TestRiskStoryAssemblyHasNoLLMTransitive(t *testing.T) {
+	out, err := exec.Command("go", "list", "-deps", "-f", "{{.ImportPath}}", ".").CombinedOutput()
+	if err != nil {
+		t.Skipf("go toolchain unavailable for the transitive check (%v); the direct-import scan still applies", err)
+	}
+	const mod = "github.com/KKloudTarus/synapse-ce"
+	forbidden := []string{
+		mod + "/internal/infrastructure/llm",
+		mod + "/internal/usecase/agent",
+		mod + "/internal/usecase/agenttools",
+		mod + "/internal/usecase/safety",
+		mod + "/internal/usecase/approval",
+		mod + "/internal/usecase/exploitation",
+		mod + "/internal/usecase/analysis",
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		dep := strings.TrimSpace(line)
+		for _, bad := range forbidden {
+			if dep == bad || strings.HasPrefix(dep, bad+"/") {
+				t.Errorf("risk-story assembly transitively imports forbidden package %q – no LLM/agent in the assembly path", dep)
+			}
+		}
+	}
+}

--- a/internal/usecase/riskstoryuc/service.go
+++ b/internal/usecase/riskstoryuc/service.go
@@ -1,0 +1,454 @@
+// Package riskstoryuc is the read-model assembler for the unified per-asset risk story (issue #427). It
+// correlates records ALREADY produced by the other pillars — the asset inventory (#431), the findings of
+// every engine, the reachability verdicts (judgments), the attack-path graph (#419), the runtime
+// detections (#423), and the continuous vulnerability occurrences/assessments (#514) — into one story per
+// asset. It creates no data and persists no new table; every element it emits references the backing
+// record it came from, and the pure domain (internal/domain/riskstory) enforces that honesty invariant
+// and the deterministic ordering. There is NO LLM in this path.
+package riskstoryuc
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskstory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// The reader interfaces are the NARROW read surface this assembler needs — consumer-defined so the
+// service is testable with small fakes and depends only on "somewhere to read X", not on the concrete
+// stores. The composition root wires the tenant-scoped repositories (which satisfy the broader ports)
+// into these. Every read is tenant-scoped by the implementation via the existing chokepoint.
+type (
+	// AssetReader lists the tenant's assets and their typed edges.
+	AssetReader interface {
+		ListAssets(ctx context.Context, tenantID shared.ID) ([]*asset.Asset, error)
+		ListEdges(ctx context.Context, tenantID shared.ID) ([]*asset.Edge, error)
+	}
+	// FindingReader lists an engagement's findings (internal processing surface; the story is not the
+	// report path, so ListByEngagement is correct here).
+	FindingReader interface {
+		ListByEngagement(ctx context.Context, engagementID shared.ID) ([]finding.Finding, error)
+	}
+	// BindingReader lists the tenant's producer-owned asset↔finding attributions (#419). Attribution is
+	// explicit; the assembler never derives an asset from finding prose.
+	BindingReader interface {
+		ListBindings(ctx context.Context, tenantID shared.ID) ([]attackpath.Binding, error)
+	}
+	// JudgmentReader lists an engagement's judgments; the assembler reads only confirmed reachability
+	// verdicts from them.
+	JudgmentReader interface {
+		ListByEngagement(ctx context.Context, engagementID shared.ID) ([]judgment.Judgment, error)
+	}
+	// DetectionReader lists an engagement's runtime detection ledger rows (#423).
+	DetectionReader interface {
+		ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error)
+	}
+)
+
+// Service assembles risk stories. StaleAfter is the freshness target an element is measured against
+// (consistent with the fleet-coverage rules, #413); a non-positive target means "no freshness
+// requirement". now is injected so assembly is testable and deterministic.
+type Service struct {
+	assets     AssetReader
+	findings   FindingReader
+	bindings   BindingReader
+	judgments  JudgmentReader
+	detections DetectionReader
+	staleAfter time.Duration
+	now        func() time.Time
+}
+
+// NewService validates dependencies and returns the assembler. A nil clock defaults to time.Now.
+func NewService(assets AssetReader, findings FindingReader, bindings BindingReader, judgments JudgmentReader, detections DetectionReader, staleAfter time.Duration, now func() time.Time) (*Service, error) {
+	if assets == nil || findings == nil || bindings == nil || judgments == nil || detections == nil {
+		return nil, fmt.Errorf("%w: risk story read dependencies are required", shared.ErrValidation)
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &Service{assets: assets, findings: findings, bindings: bindings, judgments: judgments, detections: detections, staleAfter: staleAfter, now: now}, nil
+}
+
+// StoriesForEngagement assembles one story per asset that has at least one correlated signal in the
+// engagement (a bound finding, a runtime detection, an exposure, or an attack-path edge). Stories are
+// returned ordered by asset id for a diffable result. The tenant is derived from ctx and never crossed.
+func (s *Service) StoriesForEngagement(ctx context.Context, engagementID shared.ID) ([]riskstory.Story, error) {
+	tenantID, err := tenantIDFrom(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if engagementID.IsZero() {
+		return nil, fmt.Errorf("%w: engagement id is required", shared.ErrValidation)
+	}
+
+	c, err := s.load(ctx, tenantID, engagementID)
+	if err != nil {
+		return nil, err
+	}
+
+	stories := make([]riskstory.Story, 0, len(c.assets))
+	for _, a := range c.assets {
+		if a == nil {
+			continue
+		}
+		story, ok, err := s.assembleAsset(tenantID, a, c)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			stories = append(stories, story)
+		}
+	}
+	// Order by asset id so repeated runs over the same records produce the same slice.
+	sortStoriesByAsset(stories)
+	return stories, nil
+}
+
+// StoryForAsset assembles the single story for one asset, or shared.ErrNotFound when the asset has no
+// correlated signal in the engagement.
+func (s *Service) StoryForAsset(ctx context.Context, engagementID, assetID shared.ID) (riskstory.Story, error) {
+	tenantID, err := tenantIDFrom(ctx)
+	if err != nil {
+		return riskstory.Story{}, err
+	}
+	if engagementID.IsZero() || assetID.IsZero() {
+		return riskstory.Story{}, fmt.Errorf("%w: engagement id and asset id are required", shared.ErrValidation)
+	}
+	c, err := s.load(ctx, tenantID, engagementID)
+	if err != nil {
+		return riskstory.Story{}, err
+	}
+	a, ok := c.assetByID[assetID]
+	if !ok {
+		return riskstory.Story{}, fmt.Errorf("%w: asset %s", shared.ErrNotFound, assetID)
+	}
+	story, has, err := s.assembleAsset(tenantID, a, c)
+	if err != nil {
+		return riskstory.Story{}, err
+	}
+	if !has {
+		return riskstory.Story{}, fmt.Errorf("%w: no risk story for asset %s", shared.ErrNotFound, assetID)
+	}
+	return story, nil
+}
+
+// correlated is the per-engagement working set, loaded once and indexed by asset identity.
+type correlated struct {
+	assets      []*asset.Asset
+	assetByID   map[shared.ID]*asset.Asset
+	findingByID map[shared.ID]finding.Finding
+	reachBySubj map[shared.ID]reachVerdict // confirmed reachability verdict per finding
+	bindByAsset map[shared.ID][]attackpath.Binding
+	detsByAsset map[shared.ID][]detection.Record
+	exposeTo    map[shared.ID][]*asset.Edge // exposure edges pointing at the asset
+	reachEdges  map[shared.ID][]*asset.Edge // reachability edges touching the asset
+}
+
+type reachVerdict struct {
+	claim      judgment.ReachabilityClaim // the full claim, so Supersedes compares the real proof tier
+	judgmentID shared.ID
+}
+
+func (s *Service) load(ctx context.Context, tenantID, engagementID shared.ID) (*correlated, error) {
+	assets, err := s.assets.ListAssets(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list assets: %w", err)
+	}
+	edges, err := s.assets.ListEdges(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list edges: %w", err)
+	}
+	findings, err := s.findings.ListByEngagement(ctx, engagementID)
+	if err != nil {
+		return nil, fmt.Errorf("list findings: %w", err)
+	}
+	bindings, err := s.bindings.ListBindings(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list bindings: %w", err)
+	}
+	judgments, err := s.judgments.ListByEngagement(ctx, engagementID)
+	if err != nil {
+		return nil, fmt.Errorf("list judgments: %w", err)
+	}
+	dets, err := s.detections.ListDetections(ctx, engagementID)
+	if err != nil {
+		return nil, fmt.Errorf("list detections: %w", err)
+	}
+
+	c := &correlated{
+		assets:      assets,
+		assetByID:   make(map[shared.ID]*asset.Asset, len(assets)),
+		findingByID: make(map[shared.ID]finding.Finding, len(findings)),
+		reachBySubj: map[shared.ID]reachVerdict{},
+		bindByAsset: map[shared.ID][]attackpath.Binding{},
+		detsByAsset: map[shared.ID][]detection.Record{},
+		exposeTo:    map[shared.ID][]*asset.Edge{},
+		reachEdges:  map[shared.ID][]*asset.Edge{},
+	}
+	for _, a := range assets {
+		if a != nil {
+			c.assetByID[a.ID] = a
+		}
+	}
+	for _, f := range findings {
+		c.findingByID[f.ID] = f
+	}
+	// Only this engagement's bindings, and only for findings we actually loaded (tenant + engagement
+	// scoped both ways).
+	for _, b := range bindings {
+		if b.EngagementID != engagementID {
+			continue
+		}
+		if _, ok := c.findingByID[b.FindingID]; !ok {
+			continue
+		}
+		c.bindByAsset[b.AssetID] = append(c.bindByAsset[b.AssetID], b)
+	}
+	for _, d := range dets {
+		if d.AssetID.IsZero() {
+			continue
+		}
+		c.detsByAsset[d.AssetID] = append(c.detsByAsset[d.AssetID], d)
+	}
+	for _, e := range edges {
+		if e == nil {
+			continue
+		}
+		switch e.Kind {
+		case asset.EdgeExposes:
+			c.exposeTo[e.To] = append(c.exposeTo[e.To], e)
+		case asset.EdgeReaches:
+			// A reachability edge is a path element on both endpoints. A self-edge (From==To) touches one
+			// asset once, not twice.
+			c.reachEdges[e.From] = append(c.reachEdges[e.From], e)
+			if e.To != e.From {
+				c.reachEdges[e.To] = append(c.reachEdges[e.To], e)
+			}
+		}
+	}
+	// Reachability verdicts: only CONFIRMED reachability judgments. A STRICTLY stronger proof tier wins
+	// (Supersedes on the full typed claim, per ADR-0024 — a deterministic Tier-2 call-graph result
+	// overrides a weaker LLM tier); equal-or-lower tiers leave the stored verdict standing, so the first
+	// confirmed verdict at the strongest tier wins over the store's deterministic ordering.
+	for _, j := range judgments {
+		if j.Capability != judgment.CapReachability || j.State != judgment.StateConfirmed {
+			continue
+		}
+		rc, ok := j.Claim.(judgment.ReachabilityClaim)
+		if !ok {
+			continue
+		}
+		cur, seen := c.reachBySubj[j.SubjectID]
+		if !seen || rc.Supersedes(cur.claim) {
+			c.reachBySubj[j.SubjectID] = reachVerdict{claim: rc, judgmentID: j.ID}
+		}
+	}
+	return c, nil
+}
+
+// assembleAsset builds the Inputs for one asset and hands them to the pure domain assembler. It returns
+// ok=false when the asset has no correlated signal at all (so it is not surfaced as an empty story).
+// tenantID is the authenticated principal's tenant; an asset whose own tenant disagrees is skipped as a
+// defensive guard against a mis-scoped store (the reads are already tenant-scoped).
+func (s *Service) assembleAsset(tenantID shared.ID, a *asset.Asset, c *correlated) (riskstory.Story, bool, error) {
+	if a.TenantID != tenantID {
+		return riskstory.Story{}, false, nil
+	}
+	now := s.now().UTC()
+
+	// Asset-level runtime signal: the finding's asset has been seen under active attack when it carries a
+	// FRESH runtime detection. This corroborates every finding on the asset (the asset is under attack),
+	// without over-claiming that a specific CVE was exploited — the detections also appear as their own
+	// traceable elements.
+	seenUnderAttack := s.assetUnderActiveAttack(a, c, now)
+
+	exposure := s.exposureElements(a, c)
+	findings := s.findingElements(a, c, now, seenUnderAttack)
+	paths := s.pathElements(a, c)
+	detections := s.detectionElements(a, c, now)
+
+	if len(exposure) == 0 && len(findings) == 0 && len(paths) == 0 && len(detections) == 0 {
+		return riskstory.Story{}, false, nil
+	}
+
+	story, err := riskstory.Assemble(riskstory.Inputs{
+		AssetID:  a.ID,
+		TenantID: tenantID,
+		Identity: riskstory.AssetFacts{
+			Kind:       string(a.Kind),
+			Key:        a.Key,
+			Name:       a.Name,
+			Provenance: riskstory.Provenance{Kind: riskstory.ProvAsset, ID: a.ID},
+		},
+		Exposure:    exposure,
+		Findings:    findings,
+		Paths:       paths,
+		Detections:  detections,
+		GeneratedAt: now,
+	})
+	if err != nil {
+		return riskstory.Story{}, false, fmt.Errorf("assemble story for asset %s: %w", a.ID, err)
+	}
+	return story, true, nil
+}
+
+func (s *Service) exposureElements(a *asset.Asset, c *correlated) []riskstory.ExposureElement {
+	var out []riskstory.ExposureElement
+	for _, e := range c.exposeTo[a.ID] {
+		el := riskstory.ExposureElement{
+			Description: fmt.Sprintf("exposed by %s", e.From),
+			Confidence:  string(e.Confidence),
+			Provenance:  riskstory.Provenance{Kind: riskstory.ProvAssetEdge, ID: e.Provenance},
+		}
+		if e.Confidence == asset.EdgeInferred {
+			el.Qualifiers = append(el.Qualifiers, riskstory.QualInferredEdge)
+		}
+		out = append(out, el)
+	}
+	return out
+}
+
+func (s *Service) findingElements(a *asset.Asset, c *correlated, now time.Time, seenUnderAttack bool) []riskstory.FindingElement {
+	var out []riskstory.FindingElement
+	for _, b := range c.bindByAsset[a.ID] {
+		f, ok := c.findingByID[b.FindingID]
+		if !ok {
+			continue
+		}
+		el := riskstory.FindingElement{
+			FindingID:  f.ID,
+			Title:      f.Title,
+			Severity:   string(f.Severity),
+			Priority:   f.Priority,
+			RiskScore:  f.RiskScore,
+			KEV:        f.KEV,
+			Provenance: riskstory.Provenance{Kind: riskstory.ProvFinding, ID: f.ID},
+			// A finding attributed via an attack-path binding IS on an attack path. An inferred binding
+			// is carried as an inferred-edge qualifier rather than silently upgraded to certainty.
+			OnAttackPath: true,
+			// Asset-level runtime corroboration: the finding's asset carries a fresh detection.
+			SeenUnderAttack: seenUnderAttack,
+		}
+		if b.Confidence == asset.EdgeInferred {
+			el.Qualifiers = append(el.Qualifiers, riskstory.QualInferredEdge)
+		}
+		if b.Provenance != "" {
+			el.Evidence = append(el.Evidence, riskstory.Provenance{Kind: riskstory.ProvAttackPath, ID: b.Provenance})
+		}
+
+		// Reachability verdict (a strictly stronger proof tier supersedes; here we only read a confirmed
+		// verdict). Unknown is carried as a qualifier, never flattened to reachable/not-reachable.
+		if v, has := c.reachBySubj[f.ID]; has {
+			el.Reachability = string(v.claim.Reachable)
+			el.Reachable = v.claim.Reachable == judgment.Reachable
+			if v.claim.Reachable == judgment.ReachUnknown {
+				el.Qualifiers = append(el.Qualifiers, riskstory.QualReachabilityUnknown)
+			}
+			if v.judgmentID != "" {
+				el.Evidence = append(el.Evidence, riskstory.Provenance{Kind: riskstory.ProvReachability, ID: v.judgmentID})
+			}
+		} else if f.Reachability != "" {
+			// Fall back to the finding's own recorded reachability label when no judgment is present.
+			el.Reachability = f.Reachability
+			el.Reachable = f.Reachability == string(judgment.Reachable)
+			if f.Reachability == string(judgment.ReachUnknown) {
+				el.Qualifiers = append(el.Qualifiers, riskstory.QualReachabilityUnknown)
+			}
+		}
+
+		// The continuous vulnerability occurrence + immutable assessment (#514) are backing records for
+		// the finding's vulnerability state; reference them so the story is navigable to that evidence.
+		if !f.OccurrenceID.IsZero() {
+			el.Evidence = append(el.Evidence, riskstory.Provenance{Kind: riskstory.ProvOccurrence, ID: f.OccurrenceID})
+		}
+		if !f.RiskAssessmentID.IsZero() {
+			el.Evidence = append(el.Evidence, riskstory.Provenance{Kind: riskstory.ProvAssessment, ID: f.RiskAssessmentID})
+		}
+
+		el.LastObserved = findingObservedAt(f)
+		if !riskstory.Fresh(el.LastObserved, now, s.staleAfter) {
+			el.Stale = true
+			el.Qualifiers = append(el.Qualifiers, riskstory.QualStale)
+		}
+		out = append(out, el)
+	}
+	return out
+}
+
+func (s *Service) pathElements(a *asset.Asset, c *correlated) []riskstory.PathElement {
+	var out []riskstory.PathElement
+	for _, e := range c.reachEdges[a.ID] {
+		el := riskstory.PathElement{
+			Summary:    fmt.Sprintf("%s reaches %s", e.From, e.To),
+			Confidence: string(e.Confidence),
+			Provenance: riskstory.Provenance{Kind: riskstory.ProvAttackPath, ID: e.Provenance},
+		}
+		if e.Confidence == asset.EdgeInferred {
+			el.Qualifiers = append(el.Qualifiers, riskstory.QualInferredEdge)
+		}
+		out = append(out, el)
+	}
+	return out
+}
+
+func (s *Service) detectionElements(a *asset.Asset, c *correlated, now time.Time) []riskstory.DetectionElement {
+	var out []riskstory.DetectionElement
+	for _, d := range c.detsByAsset[a.ID] {
+		el := riskstory.DetectionElement{
+			RuleID:     d.Detection.RuleID,
+			Severity:   string(d.Detection.Severity),
+			Observed:   d.Detection.Observed,
+			Provenance: riskstory.Provenance{Kind: riskstory.ProvDetection, ID: d.ID},
+		}
+		if !riskstory.Fresh(d.Detection.Observed, now, s.staleAfter) {
+			el.Stale = true
+			el.Qualifiers = append(el.Qualifiers, riskstory.QualStale)
+		}
+		out = append(out, el)
+	}
+	return out
+}
+
+// assetUnderActiveAttack reports whether the asset carries at least one FRESH runtime detection — the
+// honest, asset-level "seen under attack" signal. A stale detection is a past event, not current
+// attack, so it does not corroborate.
+func (s *Service) assetUnderActiveAttack(a *asset.Asset, c *correlated, now time.Time) bool {
+	for _, d := range c.detsByAsset[a.ID] {
+		if riskstory.Fresh(d.Detection.Observed, now, s.staleAfter) {
+			return true
+		}
+	}
+	return false
+}
+
+// findingObservedAt is when the finding's risk state was last evaluated, falling back to its last audit
+// update so a stale finding is measurable even before the first re-evaluation.
+func findingObservedAt(f finding.Finding) time.Time {
+	if f.EvaluatedAt != nil && !f.EvaluatedAt.IsZero() {
+		return *f.EvaluatedAt
+	}
+	if !f.Audit.UpdatedAt.IsZero() {
+		return f.Audit.UpdatedAt
+	}
+	return f.Audit.CreatedAt
+}
+
+func sortStoriesByAsset(stories []riskstory.Story) {
+	sort.Slice(stories, func(i, j int) bool { return stories[i].AssetID < stories[j].AssetID })
+}
+
+func tenantIDFrom(ctx context.Context) (shared.ID, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok || tenantID.IsZero() {
+		return "", fmt.Errorf("%w: tenant is required in context", shared.ErrValidation)
+	}
+	return tenantID, nil
+}

--- a/internal/usecase/riskstoryuc/service_test.go
+++ b/internal/usecase/riskstoryuc/service_test.go
@@ -1,0 +1,364 @@
+package riskstoryuc
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskstory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	tenantA = shared.ID("tenant-a")
+	engID   = shared.ID("eng-1")
+)
+
+// ---- fakes (narrow reader interfaces) ----
+
+type fakeAssets struct {
+	assets map[shared.ID][]*asset.Asset
+	edges  map[shared.ID][]*asset.Edge
+}
+
+func (f *fakeAssets) ListAssets(_ context.Context, t shared.ID) ([]*asset.Asset, error) {
+	return f.assets[t], nil
+}
+func (f *fakeAssets) ListEdges(_ context.Context, t shared.ID) ([]*asset.Edge, error) {
+	return f.edges[t], nil
+}
+
+type fakeFindings struct {
+	byEng map[shared.ID][]finding.Finding
+}
+
+func (f *fakeFindings) ListByEngagement(_ context.Context, e shared.ID) ([]finding.Finding, error) {
+	return f.byEng[e], nil
+}
+
+type fakeBindings struct {
+	byTenant map[shared.ID][]attackpath.Binding
+}
+
+func (f *fakeBindings) ListBindings(_ context.Context, t shared.ID) ([]attackpath.Binding, error) {
+	return f.byTenant[t], nil
+}
+
+type fakeJudgments struct {
+	byEng map[shared.ID][]judgment.Judgment
+}
+
+func (f *fakeJudgments) ListByEngagement(_ context.Context, e shared.ID) ([]judgment.Judgment, error) {
+	return f.byEng[e], nil
+}
+
+type fakeDetections struct {
+	byEng map[shared.ID][]detection.Record
+}
+
+func (f *fakeDetections) ListDetections(_ context.Context, e shared.ID) ([]detection.Record, error) {
+	return f.byEng[e], nil
+}
+
+func fixedNow() time.Time { return time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC) }
+
+// fixture builds a tenant with one workload asset that has: an observed exposure edge, a reachable
+// KEV finding bound to it (with a confirmed reachability judgment + occurrence/assessment refs), a
+// reachability edge, and a runtime detection.
+func fixture() (*fakeAssets, *fakeFindings, *fakeBindings, *fakeJudgments, *fakeDetections) {
+	evalAt := fixedNow().Add(-10 * time.Minute)
+	web := &asset.Asset{ID: "web", TenantID: tenantA, Kind: asset.KindWorkload, Key: "svc/web", Name: "web"}
+	assets := &fakeAssets{
+		assets: map[shared.ID][]*asset.Asset{tenantA: {web}},
+		edges: map[shared.ID][]*asset.Edge{tenantA: {
+			{TenantID: tenantA, From: "exposure", To: "web", Kind: asset.EdgeExposes, Provenance: "obs-expose", Confidence: asset.EdgeObserved},
+			{TenantID: tenantA, From: "web", To: "db", Kind: asset.EdgeReaches, Provenance: "obs-reach", Confidence: asset.EdgeObserved},
+		}},
+	}
+	findings := &fakeFindings{byEng: map[shared.ID][]finding.Finding{engID: {
+		{
+			ID: "F-1", EngagementID: engID, Title: "log4shell", Severity: shared.SeverityCritical,
+			Priority: 1, RiskScore: 9.5, KEV: true, OccurrenceID: "occ-1", RiskAssessmentID: "assess-1",
+			EvaluatedAt: &evalAt,
+		},
+	}}}
+	bindings := &fakeBindings{byTenant: map[shared.ID][]attackpath.Binding{tenantA: {
+		{TenantID: tenantA, EngagementID: engID, AssetID: "web", FindingID: "F-1", Producer: "bind", Provenance: "bind-1", Confidence: asset.EdgeObserved},
+	}}}
+	judgments := &fakeJudgments{byEng: map[shared.ID][]judgment.Judgment{engID: {
+		{ID: "j-1", EngagementID: engID, Capability: judgment.CapReachability, SubjectID: "F-1", State: judgment.StateConfirmed, Claim: judgment.ReachabilityClaim{Reachable: judgment.Reachable, Tier: judgment.Tier2}},
+	}}}
+	dets := &fakeDetections{byEng: map[shared.ID][]detection.Record{engID: {
+		{ID: "det-1", TenantID: tenantA, EngagementID: engID, AssetID: "web", Detection: detection.Detection{RuleID: "probe", Severity: "high", Observed: fixedNow().Add(-5 * time.Minute)}},
+	}}}
+	return assets, findings, bindings, judgments, dets
+}
+
+func newFixtureService(t *testing.T, staleAfter time.Duration) *Service {
+	t.Helper()
+	a, f, b, j, d := fixture()
+	svc, err := NewService(a, f, b, j, d, staleAfter, fixedNow)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc
+}
+
+func ctxTenant(t shared.ID) context.Context {
+	return shared.WithTenant(context.Background(), t)
+}
+
+func TestStoryForAssetFixtureExpectation(t *testing.T) {
+	svc := newFixtureService(t, time.Hour)
+	story, err := svc.StoryForAsset(ctxTenant(tenantA), engID, "web")
+	if err != nil {
+		t.Fatalf("StoryForAsset: %v", err)
+	}
+
+	if story.AssetID != "web" || story.TenantID != tenantA {
+		t.Fatalf("scope wrong: %+v", story)
+	}
+	if story.Identity.Provenance != (riskstory.Provenance{Kind: riskstory.ProvAsset, ID: "web"}) {
+		t.Fatalf("identity provenance wrong: %+v", story.Identity.Provenance)
+	}
+	if len(story.Exposure) != 1 || story.Exposure[0].Provenance.ID != "obs-expose" {
+		t.Fatalf("exposure wrong: %+v", story.Exposure)
+	}
+	if len(story.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(story.Findings))
+	}
+	fe := story.Findings[0]
+	if fe.FindingID != "F-1" || fe.Priority != 1 || !fe.KEV {
+		t.Fatalf("finding facts wrong: %+v", fe)
+	}
+	if !fe.Reachable || fe.Reachability != string(judgment.Reachable) || !fe.OnAttackPath {
+		t.Fatalf("corroboration wrong: %+v", fe)
+	}
+	if fe.Stale {
+		t.Fatalf("finding should be fresh (evaluated 10m ago, target 1h)")
+	}
+	// Evidence must carry the attack-path binding, the reachability judgment, the occurrence and the
+	// assessment — the story is navigable to every backing record.
+	wantEvidence := map[string]shared.ID{
+		riskstory.ProvAttackPath:   "bind-1",
+		riskstory.ProvReachability: "j-1",
+		riskstory.ProvOccurrence:   "occ-1",
+		riskstory.ProvAssessment:   "assess-1",
+	}
+	got := map[string]shared.ID{}
+	for _, ev := range fe.Evidence {
+		got[ev.Kind] = ev.ID
+	}
+	if !reflect.DeepEqual(got, wantEvidence) {
+		t.Fatalf("evidence refs wrong: got %+v want %+v", got, wantEvidence)
+	}
+	if len(story.Paths) != 1 || story.Paths[0].Provenance.ID != "obs-reach" {
+		t.Fatalf("paths wrong: %+v", story.Paths)
+	}
+	if len(story.Detections) != 1 || story.Detections[0].Provenance.ID != "det-1" {
+		t.Fatalf("detections wrong: %+v", story.Detections)
+	}
+	if story.Score != 1 {
+		t.Fatalf("score = %d, want 1", story.Score)
+	}
+	if story.GeneratedAt != fixedNow() {
+		t.Fatalf("generatedAt = %v, want %v", story.GeneratedAt, fixedNow())
+	}
+}
+
+func TestStoriesForEngagementDeterministic(t *testing.T) {
+	svc := newFixtureService(t, time.Hour)
+	first, err := svc.StoriesForEngagement(ctxTenant(tenantA), engID)
+	if err != nil {
+		t.Fatalf("StoriesForEngagement: %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("want 1 story, got %d", len(first))
+	}
+	for i := 0; i < 6; i++ {
+		got, err := svc.StoriesForEngagement(ctxTenant(tenantA), engID)
+		if err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+		if !reflect.DeepEqual(first, got) {
+			t.Fatalf("assembly not deterministic on run %d", i)
+		}
+	}
+}
+
+func TestTenantFailClosedAndIsolation(t *testing.T) {
+	svc := newFixtureService(t, time.Hour)
+	// No tenant in context → fail closed.
+	if _, err := svc.StoriesForEngagement(context.Background(), engID); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("want ErrValidation without tenant, got %v", err)
+	}
+	// A different tenant sees no assets → no stories, never the other tenant's records.
+	stories, err := svc.StoriesForEngagement(ctxTenant("tenant-b"), engID)
+	if err != nil {
+		t.Fatalf("other tenant: %v", err)
+	}
+	if len(stories) != 0 {
+		t.Fatalf("tenant-b should see no stories, got %d", len(stories))
+	}
+}
+
+func TestUncertaintyPerClassAtAssembly(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*fakeBindings, *fakeJudgments, *fakeAssets, *fakeDetections)
+		staleAf time.Duration
+		wantQ   string
+	}{
+		{
+			name: "reachability unknown",
+			mutate: func(_ *fakeBindings, j *fakeJudgments, _ *fakeAssets, _ *fakeDetections) {
+				j.byEng[engID][0].Claim = judgment.ReachabilityClaim{Reachable: judgment.ReachUnknown}
+			},
+			staleAf: time.Hour,
+			wantQ:   riskstory.QualReachabilityUnknown,
+		},
+		{
+			name: "inferred binding edge",
+			mutate: func(b *fakeBindings, _ *fakeJudgments, _ *fakeAssets, _ *fakeDetections) {
+				b.byTenant[tenantA][0].Confidence = asset.EdgeInferred
+			},
+			staleAf: time.Hour,
+			wantQ:   riskstory.QualInferredEdge,
+		},
+		{
+			name:    "stale finding",
+			mutate:  func(_ *fakeBindings, _ *fakeJudgments, _ *fakeAssets, _ *fakeDetections) {},
+			staleAf: time.Minute, // evaluated 10m ago > 1m target → stale
+			wantQ:   riskstory.QualStale,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a, f, b, j, d := fixture()
+			tc.mutate(b, j, a, d)
+			svc, err := NewService(a, f, b, j, d, tc.staleAf, fixedNow)
+			if err != nil {
+				t.Fatalf("NewService: %v", err)
+			}
+			story, err := svc.StoryForAsset(ctxTenant(tenantA), engID, "web")
+			if err != nil {
+				t.Fatalf("StoryForAsset: %v", err)
+			}
+			found := false
+			for _, q := range story.Qualifiers {
+				if q == tc.wantQ {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("qualifier %q not carried; story qualifiers=%v", tc.wantQ, story.Qualifiers)
+			}
+		})
+	}
+}
+
+func TestBindingFromOtherEngagementExcluded(t *testing.T) {
+	a, f, b, j, d := fixture()
+	// Re-point the binding at a different engagement → the finding is no longer attributed here.
+	b.byTenant[tenantA][0].EngagementID = "eng-other"
+	svc, err := NewService(a, f, b, j, d, time.Hour, fixedNow)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	story, err := svc.StoryForAsset(ctxTenant(tenantA), engID, "web")
+	if err != nil {
+		t.Fatalf("StoryForAsset: %v", err)
+	}
+	if len(story.Findings) != 0 {
+		t.Fatalf("binding from another engagement must not attribute a finding: %+v", story.Findings)
+	}
+}
+
+// A strictly stronger reachability proof tier must win regardless of the order judgments arrive in —
+// a later Tier-1 "unknown" must never override a Tier-2 "reachable" deterministic proof (ADR-0024).
+func TestReachabilityStrongestTierWinsOrderIndependent(t *testing.T) {
+	strong := judgment.Judgment{ID: "j-strong", EngagementID: engID, Capability: judgment.CapReachability, SubjectID: "F-1", State: judgment.StateConfirmed, Claim: judgment.ReachabilityClaim{Reachable: judgment.Reachable, Tier: judgment.Tier2}}
+	weak := judgment.Judgment{ID: "j-weak", EngagementID: engID, Capability: judgment.CapReachability, SubjectID: "F-1", State: judgment.StateConfirmed, Claim: judgment.ReachabilityClaim{Reachable: judgment.ReachUnknown, Tier: judgment.Tier1}}
+
+	for i, order := range [][]judgment.Judgment{{strong, weak}, {weak, strong}} {
+		a, f, b, j, d := fixture()
+		j.byEng[engID] = order
+		svc, err := NewService(a, f, b, j, d, time.Hour, fixedNow)
+		if err != nil {
+			t.Fatalf("NewService: %v", err)
+		}
+		story, err := svc.StoryForAsset(ctxTenant(tenantA), engID, "web")
+		if err != nil {
+			t.Fatalf("StoryForAsset: %v", err)
+		}
+		fe := story.Findings[0]
+		if fe.Reachability != string(judgment.Reachable) || !fe.Reachable {
+			t.Fatalf("Tier-2 proof did not win (order case %d): reachability=%q reachable=%v", i, fe.Reachability, fe.Reachable)
+		}
+		// The winning judgment's id is the cited reachability evidence.
+		if !hasEvidence(fe, riskstory.ProvReachability, "j-strong") {
+			t.Fatalf("expected j-strong cited as reachability evidence, got %+v", fe.Evidence)
+		}
+	}
+}
+
+func TestSeenUnderAttackTracksFreshDetection(t *testing.T) {
+	// Fresh detection (5m ago) with a 1h target → seen under attack, corroboration reason present.
+	svc := newFixtureService(t, time.Hour)
+	story, err := svc.StoryForAsset(ctxTenant(tenantA), engID, "web")
+	if err != nil {
+		t.Fatalf("StoryForAsset: %v", err)
+	}
+	fe := story.Findings[0]
+	if !fe.SeenUnderAttack {
+		t.Fatalf("finding should be seen-under-attack (fresh detection on asset)")
+	}
+	if !containsStr(fe.Corroboration, "seen_under_attack") {
+		t.Fatalf("corroboration missing seen_under_attack: %v", fe.Corroboration)
+	}
+
+	// A stale detection (5m ago) with a 1m target → NOT current attack.
+	a, f, b, j, d := fixture()
+	svc2, err := NewService(a, f, b, j, d, time.Minute, fixedNow)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	story2, err := svc2.StoryForAsset(ctxTenant(tenantA), engID, "web")
+	if err != nil {
+		t.Fatalf("StoryForAsset: %v", err)
+	}
+	if story2.Findings[0].SeenUnderAttack {
+		t.Fatalf("stale detection must not corroborate seen-under-attack")
+	}
+}
+
+func hasEvidence(fe riskstory.FindingElement, kind string, id shared.ID) bool {
+	for _, ev := range fe.Evidence {
+		if ev.Kind == kind && ev.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStr(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNewServiceRejectsNilDeps(t *testing.T) {
+	if _, err := NewService(nil, nil, nil, nil, nil, time.Hour, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("want ErrValidation, got %v", err)
+	}
+}


### PR DESCRIPTION
## What

Closes #427 — the unified **per-asset risk story**, the last correlation piece of Phase 6 (#405). It assembles every signal about an asset into one narrative: what it is, what it exposes, what depends on it, what is wrong with it, whether the wrong thing is *reachable*, whether it is *on an attack path*, and whether it has been *seen under attack* — correlating the records the other pillars already produce (asset inventory #431, findings + reachability verdicts, attack-path bindings #419, runtime detections #423, and the continuous vulnerability occurrences/assessments #514).

It **creates no data and persists no new table** — it is a deterministic read model over existing records.

## How

- **`internal/domain/riskstory/story.go`** — the pure, deterministic domain: `Story` + element types, each carrying a `Provenance` backing reference. `Assemble()` orders deterministically, computes per-finding corroboration ranking + `RankReason`, rolls up qualifiers, and `Validate()`s that every element references a backing record. `Fresh()` mirrors the fleet-coverage freshness rule (#413). `EvidenceRefs()` is the auditor/report export — the full, deduped provenance set.
- **`internal/usecase/riskstoryuc/service.go`** — the read-model assembler. Consumer-defined narrow reader interfaces (asset/finding/binding/judgment/detection), tenant derived from ctx and **fail-closed**, correlation by asset identity (findings attributed only through explicit attack-path bindings scoped to *this* engagement — never derived from prose). Stories ordered by asset id.
- **`internal/adapter/httpapi/riskstory_handler.go`** — `GET /engagements/{id}/risk-stories` and `…/{assetID}`, plus `?view=export` carrying evidence references. Behind `authz(PermView)` + the `withEngTenant` tenant chokepoint.
- **`cmd/synapse-api/main.go`** — composition-root wiring.

## Honesty invariants (issue requirements)

1. Every element references a backing record; one with no provenance **fails validation**.
2. Uncertainty is **carried, never flattened** — unknown reachability, inferred edge, sampled telemetry window, staleness → `Qualifiers`.
3. Prioritisation uses the existing KEV→EPSS→CVSS model and is **raised by corroboration, not replaced** — corroboration changes *ordering* and shows the reason; it never mutates `Priority` (the #428 promotion gate owns that).
4. Freshness is part of the story; a stale element is marked stale.
5. Tenant-scoped through the existing chokepoint; the story never crosses a tenant boundary.
6. Deterministic assembly — same records → same story, same order.
7. Exportable carrying evidence references.
8. **No LLM in the assembly path** — asserted by `arch_test.go` (direct + transitive import scan).

## Tests

- Domain: validation rejects missing provenance; one test per uncertainty class; corroboration raises ordering without mutating priority; priority dominates corroboration across buckets; determinism across runs; `Fresh` table; `EvidenceRefs` committed expectation + determinism.
- Usecase: committed fixture-asset expectation (all elements + evidence refs); determinism; tenant fail-closed + cross-tenant isolation; per-class uncertainty at assembly; binding-from-other-engagement excluded; nil-dep rejection; **no-LLM arch assertion** (direct + transitive).
- Adapter: `TestHostileHarness` rows added for both routes (readonly 200 · cross-tenant 404 · principal-less 403).

## Verification (local — CI disabled)

`go build ./...` · `go vet ./...` · `gofmt -l` clean · domain/usecase/adapter unit suites green · `TestHostileHarness` green.
