### PR TITLE
feat(sla): deterministic risk-based remediation SLA scoring (#80 Phase 0)

### DIFF
--- a/internal/domain/sla/config.go
+++ b/internal/domain/sla/config.go
@@ -1,0 +1,205 @@
+package sla
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Config is the versioned, fully-declarative scoring policy. Everything that determines a tier lives
+// here: the factor weights (each is the MAX points that factor can contribute), the score thresholds
+// that map a 0..100 score to a tier, the per-tier due-date ranges, and the override rules. Version is
+// recorded on every Result, so a stored decision can always be re-derived and explained. A persistence
+// layer (Phase 2) may supply a newer version; the built-in DefaultConfig is the floor.
+type Config struct {
+	Weights    Weights    `json:"weights"`
+	Thresholds Thresholds `json:"thresholds"`
+	DueRanges  DueRanges  `json:"due_ranges"`
+	Version    string     `json:"version"`
+}
+
+// Weights are the maximum point contributions of each factor. Severity + Exploitability + ThreatIntel +
+// Exposure + Criticality should sum to 100 so a maxed-out finding scores 100 before the (negative)
+// feasibility relief. FeasibilityRelief is the maximum urgency reduction for a hard-to-fix finding.
+type Weights struct {
+	Severity          float64 `json:"severity"`
+	Exploitability    float64 `json:"exploitability"`
+	ThreatIntel       float64 `json:"threat_intel"`
+	Exposure          float64 `json:"exposure"`
+	Criticality       float64 `json:"criticality"`
+	FeasibilityRelief float64 `json:"feasibility_relief"`
+}
+
+// Thresholds are the inclusive lower score bounds for each ladder tier, strictly descending
+// (Emergency highest). A score below Medium is Low.
+type Thresholds struct {
+	Emergency float64 `json:"emergency"`
+	Critical  float64 `json:"critical"`
+	High      float64 `json:"high"`
+	Medium    float64 `json:"medium"`
+}
+
+// DueRange is how long a tier has to mitigate (a compensating step) and to fully remediate.
+// MitigateWithin <= RemediateWithin.
+type DueRange struct {
+	MitigateWithin  time.Duration `json:"mitigate_within"`
+	RemediateWithin time.Duration `json:"remediate_within"`
+}
+
+// DueRanges is the per-tier due-date policy.
+type DueRanges struct {
+	Emergency DueRange `json:"emergency"`
+	Critical  DueRange `json:"critical"`
+	High      DueRange `json:"high"`
+	Medium    DueRange `json:"medium"`
+	Low       DueRange `json:"low"`
+	Exception DueRange `json:"exception"`
+}
+
+const day = 24 * time.Hour
+
+// DefaultConfig is the built-in policy. Weights sum to 100 (35 + 25 + 10 + 15 + 15); thresholds and due
+// ranges follow common risk-based-patching guidance (KEV/critical measured in days, low in months).
+// This is the reproducible floor when no stored config is active.
+func DefaultConfig() Config {
+	return Config{
+		Version: "sla-v1",
+		Weights: Weights{
+			Severity:          35,
+			Exploitability:    25,
+			ThreatIntel:       10,
+			Exposure:          15,
+			Criticality:       15,
+			FeasibilityRelief: 15,
+		},
+		Thresholds: Thresholds{
+			Emergency: 85,
+			Critical:  70,
+			High:      50,
+			Medium:    30,
+		},
+		DueRanges: DueRanges{
+			Emergency: DueRange{MitigateWithin: 1 * day, RemediateWithin: 7 * day},
+			Critical:  DueRange{MitigateWithin: 3 * day, RemediateWithin: 15 * day},
+			High:      DueRange{MitigateWithin: 7 * day, RemediateWithin: 30 * day},
+			Medium:    DueRange{MitigateWithin: 30 * day, RemediateWithin: 90 * day},
+			Low:       DueRange{MitigateWithin: 90 * day, RemediateWithin: 180 * day},
+			Exception: DueRange{MitigateWithin: 30 * day, RemediateWithin: 180 * day},
+		},
+	}
+}
+
+// Validate checks a Config is well-formed: a version is set, the positive factor weights are
+// non-negative, the score thresholds are strictly descending and positive, and every tier's due range
+// has mitigate <= remediate. Compute is robust to a malformed Config (the score is clamped), so Phase 0
+// does not call this on the built-in DefaultConfig; it exists so a Phase-2 persistence layer can reject
+// a stored/operator-supplied Config at the edge (returning shared.ErrValidation) rather than silently
+// scoring against a degenerate policy.
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.Version) == "" {
+		return fmt.Errorf("%w: sla config needs a version", shared.ErrValidation)
+	}
+	w := c.Weights
+	for name, v := range map[string]float64{
+		"severity": w.Severity, "exploitability": w.Exploitability, "threat_intel": w.ThreatIntel,
+		"exposure": w.Exposure, "criticality": w.Criticality, "feasibility_relief": w.FeasibilityRelief,
+	} {
+		if v < 0 {
+			return fmt.Errorf("%w: sla weight %q is negative", shared.ErrValidation, name)
+		}
+	}
+	th := c.Thresholds
+	if !(th.Emergency > th.Critical && th.Critical > th.High && th.High > th.Medium && th.Medium > 0) {
+		return fmt.Errorf("%w: sla thresholds must be strictly descending and positive", shared.ErrValidation)
+	}
+	for name, r := range map[string]DueRange{
+		"emergency": c.DueRanges.Emergency, "critical": c.DueRanges.Critical, "high": c.DueRanges.High,
+		"medium": c.DueRanges.Medium, "low": c.DueRanges.Low, "exception": c.DueRanges.Exception,
+	} {
+		if r.MitigateWithin < 0 || r.RemediateWithin < 0 || r.MitigateWithin > r.RemediateWithin {
+			return fmt.Errorf("%w: sla due range %q must have 0 <= mitigate <= remediate", shared.ErrValidation, name)
+		}
+	}
+	return nil
+}
+
+// severityWeight maps a severity band to a 0..1 multiplier of the Severity weight.
+func (Config) severityWeight(band shared.Severity) float64 {
+	switch band {
+	case shared.SeverityCritical:
+		return 1.0
+	case shared.SeverityHigh:
+		return 0.75
+	case shared.SeverityMedium:
+		return 0.5
+	case shared.SeverityLow:
+		return 0.25
+	default: // Info / unknown
+		return 0.0
+	}
+}
+
+func (c Config) dueRange(t Tier) DueRange {
+	switch t {
+	case TierEmergency:
+		return c.DueRanges.Emergency
+	case TierCritical:
+		return c.DueRanges.Critical
+	case TierHigh:
+		return c.DueRanges.High
+	case TierMedium:
+		return c.DueRanges.Medium
+	case TierLow:
+		return c.DueRanges.Low
+	case TierException:
+		return c.DueRanges.Exception
+	default:
+		return c.DueRanges.Low
+	}
+}
+
+// overrideRule is a deterministic escalation/routing rule. when decides if it fires for the inputs;
+// apply maps the current tier to the (equal-or-more-urgent, or Exception) tier. Rules never
+// de-escalate below the score-derived tier.
+type overrideRule struct {
+	name  string
+	when  func(Inputs) bool
+	apply func(Tier) Tier
+}
+
+// overrideRules is the fixed-order rule set for the built-in policy. Order is deterministic so the fired
+// list and final tier are reproducible.
+func (Config) overrideRules() []overrideRule {
+	return []overrideRule{
+		{
+			// Actively exploited in the wild is always an emergency, whatever the score said.
+			name:  "active_exploitation_is_emergency",
+			when:  func(in Inputs) bool { return in.ActiveExploitation },
+			apply: func(Tier) Tier { return TierEmergency },
+		},
+		{
+			// A known-exploited vulnerability on an internet-facing asset escalates one tier.
+			name:  "kev_external_escalates",
+			when:  func(in Inputs) bool { return in.KEV && in.Exposure == ExposureExternal },
+			apply: escalate,
+		},
+		{
+			// Nothing to patch to: route to a governed Exception (accept-risk with an expiry). This is
+			// deliberately NOT applied to a KEV (known-exploited) finding: Exception's due dates are
+			// longer than a Critical/High window, and relaxing the clock on a vulnerability being
+			// exploited in the wild is the wrong direction — a KEV no-patch keeps its score-derived
+			// urgency and is mitigated by a compensating control instead. The Emergency guard covers the
+			// active-exploitation and score-derived-emergency paths for the same reason.
+			name: "no_patch_routes_to_exception",
+			when: func(in Inputs) bool { return in.Feasibility == FeasibilityNoPatch && !in.KEV },
+			apply: func(t Tier) Tier {
+				if t == TierEmergency {
+					return t
+				}
+				return TierException
+			},
+		},
+	}
+}

--- a/internal/domain/sla/sla.go
+++ b/internal/domain/sla/sla.go
@@ -1,0 +1,317 @@
+// Package sla is the pure, deterministic domain for the risk-based remediation SLA (issue #80,
+// Phase 0). Given a finding's real risk context it assigns a remediation tier, a bounded 0..100
+// urgency score with an explainable breakdown, and concrete mitigate-by / remediate-by due dates.
+//
+// It stays inside the golden rules: pure Go (no I/O, no framework, no DB), the clock is injected, and
+// the output is fully determined by the inputs plus a VERSIONED Config — so a decision is reproducible
+// and every result records the config version that produced it. There is NO LLM in this path; ordering
+// by risk is not governance, and this package supplies the governance (due dates + tiering) on top of
+// the existing KEV -> EPSS -> CVSS ordering without changing it.
+package sla
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Tier is the remediation SLA tier. Emergency..Low form a severity ladder (Emergency most urgent);
+// Exception is off-ladder — it is only ever reached by an override rule (e.g. no patch is available),
+// never by the score, and it carries the longest due dates plus a required governance follow-up.
+type Tier string
+
+const (
+	TierEmergency Tier = "emergency"
+	TierCritical  Tier = "critical"
+	TierHigh      Tier = "high"
+	TierMedium    Tier = "medium"
+	TierLow       Tier = "low"
+	TierException Tier = "exception"
+)
+
+// ladder is the on-score ordering, most urgent first. rank(t) is the index; a lower rank is more
+// urgent. Exception is deliberately absent — it is not comparable on the score ladder.
+var ladder = []Tier{TierEmergency, TierCritical, TierHigh, TierMedium, TierLow}
+
+func rank(t Tier) int {
+	for i, l := range ladder {
+		if l == t {
+			return i
+		}
+	}
+	return len(ladder) // Exception / unknown sort last (least urgent on the ladder)
+}
+
+// moreUrgent reports whether a is strictly more urgent than b on the ladder.
+func moreUrgent(a, b Tier) bool { return rank(a) < rank(b) }
+
+// escalate returns the next-more-urgent ladder tier, saturating at Emergency. Exception is returned
+// unchanged (it is off-ladder).
+func escalate(t Tier) Tier {
+	if t == TierException {
+		return t
+	}
+	r := rank(t)
+	if r <= 0 {
+		return TierEmergency
+	}
+	if r >= len(ladder) {
+		return TierLow
+	}
+	return ladder[r-1]
+}
+
+// Exposure is how reachable the asset is from an untrusted network. Unknown is the neutral default so
+// the feature works before any asset model exists.
+type Exposure string
+
+const (
+	ExposureUnknown  Exposure = ""
+	ExposureInternal Exposure = "internal"
+	ExposureExternal Exposure = "external"
+)
+
+// Criticality is the business importance of the asset. Unknown is the neutral default.
+type Criticality string
+
+const (
+	CriticalityUnknown Criticality = ""
+	CriticalityLow     Criticality = "low"
+	CriticalityMedium  Criticality = "medium"
+	CriticalityHigh    Criticality = "high"
+)
+
+// Feasibility is how readily the finding can actually be remediated. PatchAvailable is neutral; the
+// others reduce urgency and NoPatch routes to the Exception tier (there is nothing to remediate to, so
+// the honest outcome is a governed acceptance, not an impossible due date).
+type Feasibility string
+
+const (
+	FeasibilityUnknown             Feasibility = ""
+	FeasibilityPatchAvailable      Feasibility = "patch_available"
+	FeasibilityChangeWindow        Feasibility = "change_window"
+	FeasibilityCompensatingControl Feasibility = "compensating_control"
+	FeasibilityNoPatch             Feasibility = "no_patch"
+)
+
+// EPSS bands. EPSS is a 0..1 probability; the score model uses coarse bands so a decision does not swing
+// on noise in the third decimal place.
+const (
+	epssHighBand   = 0.5
+	epssMediumBand = 0.1
+	epssLowBand    = 0.01
+)
+
+// Inputs is the risk context of one finding. Every field defaults to a neutral value, so a partial
+// context (common before an asset model is wired) yields a defensible, reproducible result rather than
+// an error.
+type Inputs struct {
+	Severity           shared.Severity
+	CVSSScore          float64 // 0..10 base score; when 0 the Severity label is used instead
+	KEV                bool    // CISA Known-Exploited
+	EPSS               float64 // 0..1 exploit-prediction probability
+	PublicPoC          bool
+	ActiveExploitation bool
+	Criticality        Criticality
+	Exposure           Exposure
+	Feasibility        Feasibility
+}
+
+// Breakdown is the explainable decomposition of the score: each factor's contribution, plus the names
+// of every override rule that fired. It exists so a tier can be justified to an auditor.
+type Breakdown struct {
+	Severity       float64  `json:"severity"`
+	Exploitability float64  `json:"exploitability"`
+	ThreatIntel    float64  `json:"threat_intel"`
+	Exposure       float64  `json:"exposure"`
+	Criticality    float64  `json:"criticality"`
+	Feasibility    float64  `json:"feasibility"` // an adjustment; may be negative
+	Overrides      []string `json:"overrides,omitempty"`
+}
+
+// Result is the computed SLA decision for one finding. Score is bounded 0..100; MitigateBy/RemediateBy
+// are absolute due dates (now + the tier's range); ConfigVersion records exactly which Config produced
+// it so the decision is reproducible and explainable later.
+type Result struct {
+	Tier          Tier      `json:"tier"`
+	Score         float64   `json:"score"`
+	Breakdown     Breakdown `json:"breakdown"`
+	MitigateBy    time.Time `json:"mitigate_by"`
+	RemediateBy   time.Time `json:"remediate_by"`
+	Reason        string    `json:"reason"`
+	ComputedAt    time.Time `json:"computed_at"`
+	ConfigVersion string    `json:"config_version"`
+}
+
+// Compute deterministically scores the inputs against the config and returns the tier, breakdown, and
+// due dates. It performs no I/O; the same inputs, config, and clock always produce the same Result.
+func Compute(in Inputs, cfg Config, now time.Time) Result {
+	now = now.UTC()
+	b := Breakdown{
+		Severity:       severityFactor(in, cfg),
+		Exploitability: exploitabilityFactor(in, cfg),
+		ThreatIntel:    threatIntelFactor(in, cfg),
+		Exposure:       exposureFactor(in, cfg),
+		Criticality:    criticalityFactor(in, cfg),
+		Feasibility:    feasibilityFactor(in, cfg),
+	}
+	score := clamp(b.Severity+b.Exploitability+b.ThreatIntel+b.Exposure+b.Criticality+b.Feasibility, 0, 100)
+
+	tier := tierForScore(score, cfg)
+	tier, b.Overrides = applyOverrides(tier, in, cfg)
+
+	due := cfg.dueRange(tier)
+	return Result{
+		Tier:          tier,
+		Score:         score,
+		Breakdown:     b,
+		MitigateBy:    now.Add(due.MitigateWithin),
+		RemediateBy:   now.Add(due.RemediateWithin),
+		Reason:        reasonFor(tier, b),
+		ComputedAt:    now,
+		ConfigVersion: cfg.Version,
+	}
+}
+
+func severityFactor(in Inputs, cfg Config) float64 {
+	band := in.severityBand()
+	return cfg.Weights.Severity * cfg.severityWeight(band)
+}
+
+// severityBand prefers the numeric CVSS base score (more precise) and falls back to the Severity label
+// when no score is present.
+func (in Inputs) severityBand() shared.Severity {
+	if in.CVSSScore > 0 {
+		return shared.SeverityFromScore(in.CVSSScore)
+	}
+	if in.Severity != "" {
+		return in.Severity
+	}
+	return shared.SeverityInfo
+}
+
+func exploitabilityFactor(in Inputs, cfg Config) float64 {
+	// KEV dominates: a known-exploited vulnerability is maximally exploitable regardless of EPSS.
+	if in.KEV {
+		return cfg.Weights.Exploitability
+	}
+	switch {
+	case in.EPSS >= epssHighBand:
+		return cfg.Weights.Exploitability
+	case in.EPSS >= epssMediumBand:
+		return cfg.Weights.Exploitability * 0.6
+	case in.EPSS >= epssLowBand:
+		return cfg.Weights.Exploitability * 0.3
+	default:
+		return 0
+	}
+}
+
+func threatIntelFactor(in Inputs, cfg Config) float64 {
+	f := 0.0
+	if in.ActiveExploitation {
+		f += cfg.Weights.ThreatIntel
+	} else if in.PublicPoC {
+		f += cfg.Weights.ThreatIntel * 0.5
+	}
+	return f
+}
+
+func exposureFactor(in Inputs, cfg Config) float64 {
+	switch in.Exposure {
+	case ExposureExternal:
+		return cfg.Weights.Exposure
+	case ExposureInternal:
+		return cfg.Weights.Exposure * 0.4
+	default: // Unknown -> neutral middle
+		return cfg.Weights.Exposure * 0.5
+	}
+}
+
+func criticalityFactor(in Inputs, cfg Config) float64 {
+	switch in.Criticality {
+	case CriticalityHigh:
+		return cfg.Weights.Criticality
+	case CriticalityMedium:
+		return cfg.Weights.Criticality * 0.6
+	case CriticalityLow:
+		return cfg.Weights.Criticality * 0.2
+	default: // Unknown -> neutral middle
+		return cfg.Weights.Criticality * 0.5
+	}
+}
+
+// feasibilityFactor is an ADJUSTMENT (<= 0): a finding you cannot readily fix is less urgent to chase
+// on the clock (NoPatch is instead routed to the Exception tier by an override). PatchAvailable and
+// Unknown are neutral.
+func feasibilityFactor(in Inputs, cfg Config) float64 {
+	switch in.Feasibility {
+	case FeasibilityCompensatingControl:
+		return -cfg.Weights.FeasibilityRelief
+	case FeasibilityChangeWindow:
+		return -cfg.Weights.FeasibilityRelief * 0.5
+	default:
+		return 0
+	}
+}
+
+func tierForScore(score float64, cfg Config) Tier {
+	// Descending thresholds; the first the score meets wins. Below the lowest threshold is Low.
+	switch {
+	case score >= cfg.Thresholds.Emergency:
+		return TierEmergency
+	case score >= cfg.Thresholds.Critical:
+		return TierCritical
+	case score >= cfg.Thresholds.High:
+		return TierHigh
+	case score >= cfg.Thresholds.Medium:
+		return TierMedium
+	default:
+		return TierLow
+	}
+}
+
+// applyOverrides applies the deterministic override rules to the score-derived tier. The escalate-or-
+// Exception invariant is ENFORCED here, not merely trusted to each rule: a rule's proposed tier is
+// accepted only if it is at least as urgent as the current tier, or is the governed Exception routing.
+// A rule that would DE-ESCALATE below the score-derived urgency is ignored (a security tool must never
+// silently relax a finding's urgency), even if a future or stored Config supplies such a rule. Only a
+// rule that actually changes the tier is recorded, so the breakdown/Reason never claims a rule drove
+// the tier when it was a no-op. Rules run in a fixed order for determinism.
+func applyOverrides(tier Tier, in Inputs, cfg Config) (Tier, []string) {
+	var fired []string
+	for _, rule := range cfg.overrideRules() {
+		if !rule.when(in) {
+			continue
+		}
+		next := rule.apply(tier)
+		// Accept only an escalation (equal-or-more-urgent) or the Exception routing; drop a de-escalation.
+		if next != TierException && moreUrgent(tier, next) {
+			continue
+		}
+		if next != tier {
+			tier = next
+			fired = append(fired, rule.name)
+		}
+	}
+	return tier, fired
+}
+
+func reasonFor(tier Tier, b Breakdown) string {
+	if len(b.Overrides) > 0 {
+		return fmt.Sprintf("tier %s (overrides: %s)", tier, strings.Join(b.Overrides, ", "))
+	}
+	return fmt.Sprintf("tier %s from score", tier)
+}
+
+func clamp(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/internal/domain/sla/sla_test.go
+++ b/internal/domain/sla/sla_test.go
@@ -1,0 +1,265 @@
+package sla
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var epoch = time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+
+func TestComputeTable(t *testing.T) {
+	cfg := DefaultConfig()
+	tests := []struct {
+		name     string
+		in       Inputs
+		wantTier Tier
+	}{
+		{
+			name:     "critical KEV external actively exploited is emergency",
+			in:       Inputs{CVSSScore: 9.8, KEV: true, EPSS: 0.9, ActiveExploitation: true, Exposure: ExposureExternal, Criticality: CriticalityHigh, Feasibility: FeasibilityPatchAvailable},
+			wantTier: TierEmergency,
+		},
+		{
+			// Risk-based, not CVSS-based: a high base score with no exploit signal, internal only, is
+			// Medium urgency — severity alone never drives the tier without corroborating risk.
+			name:     "high cvss, no exploit signal, internal is medium",
+			in:       Inputs{CVSSScore: 7.5, Exposure: ExposureInternal, Criticality: CriticalityMedium, Feasibility: FeasibilityPatchAvailable},
+			wantTier: TierMedium,
+		},
+		{
+			// Same base score, now with an EPSS signal and external exposure, reaches High.
+			name:     "high cvss with exploit signal and external exposure is high",
+			in:       Inputs{CVSSScore: 7.5, EPSS: 0.2, Exposure: ExposureExternal, Criticality: CriticalityMedium, Feasibility: FeasibilityPatchAvailable},
+			wantTier: TierHigh,
+		},
+		{
+			name:     "low severity unknown context",
+			in:       Inputs{CVSSScore: 2.0},
+			wantTier: TierLow,
+		},
+		{
+			name:     "no patch routes to exception",
+			in:       Inputs{CVSSScore: 6.0, Exposure: ExposureInternal, Feasibility: FeasibilityNoPatch},
+			wantTier: TierException,
+		},
+		{
+			name:     "no patch does not override an emergency",
+			in:       Inputs{CVSSScore: 9.9, KEV: true, ActiveExploitation: true, Feasibility: FeasibilityNoPatch},
+			wantTier: TierEmergency,
+		},
+		{
+			name:     "label fallback when no cvss score",
+			in:       Inputs{Severity: shared.SeverityCritical, EPSS: 0.6, Exposure: ExposureExternal, Criticality: CriticalityHigh},
+			wantTier: TierEmergency,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Compute(tc.in, cfg, epoch)
+			if got.Tier != tc.wantTier {
+				t.Fatalf("tier = %s (score %.1f, overrides %v), want %s", got.Tier, got.Score, got.Breakdown.Overrides, tc.wantTier)
+			}
+			if got.Score < 0 || got.Score > 100 {
+				t.Fatalf("score %.2f out of 0..100", got.Score)
+			}
+			if got.ConfigVersion != cfg.Version {
+				t.Fatalf("config version = %q, want %q", got.ConfigVersion, cfg.Version)
+			}
+			if !got.MitigateBy.After(epoch) || got.RemediateBy.Before(got.MitigateBy) {
+				t.Fatalf("due dates invalid: mitigate %v remediate %v", got.MitigateBy, got.RemediateBy)
+			}
+		})
+	}
+}
+
+func TestOverrideRulesFireAndAreRecorded(t *testing.T) {
+	cfg := DefaultConfig()
+
+	// KEV + external escalates one tier and records the rule.
+	base := Inputs{CVSSScore: 6.5, Exposure: ExposureInternal, Feasibility: FeasibilityPatchAvailable}
+	escalated := base
+	escalated.KEV = true
+	escalated.Exposure = ExposureExternal
+	b := Compute(base, cfg, epoch)
+	e := Compute(escalated, cfg, epoch)
+	if !moreUrgent(e.Tier, b.Tier) {
+		t.Fatalf("kev+external did not escalate: base %s escalated %s", b.Tier, e.Tier)
+	}
+	if !contains(e.Breakdown.Overrides, "kev_external_escalates") {
+		t.Fatalf("escalation not recorded: %v", e.Breakdown.Overrides)
+	}
+
+	// Active exploitation forces emergency and records the rule.
+	ae := Compute(Inputs{CVSSScore: 3.0, ActiveExploitation: true}, cfg, epoch)
+	if ae.Tier != TierEmergency || !contains(ae.Breakdown.Overrides, "active_exploitation_is_emergency") {
+		t.Fatalf("active exploitation not emergency: tier %s overrides %v", ae.Tier, ae.Breakdown.Overrides)
+	}
+}
+
+// Score stays in 0..100 and the ladder tier is monotonic in score when the override-relevant flags are
+// held constant (so no override fires): a higher score is never assigned a less-urgent tier.
+func TestScoreBoundedAndTierMonotonic(t *testing.T) {
+	cfg := DefaultConfig()
+	var prevScore float64 = -1
+	var prevTier Tier
+	first := true
+	// Sweep CVSS 0..10 and EPSS 0..1 with all override flags off and a fixed neutral context, in an
+	// order that produces non-decreasing score, then assert monotonic tier urgency.
+	for cvssStep := 0; cvssStep <= 20; cvssStep++ {
+		cvss := float64(cvssStep) * 0.5 // 0.0 .. 10.0
+		in := Inputs{
+			CVSSScore:   cvss,
+			EPSS:        cvss / 10.0, // rises with cvss, still no override flags
+			Exposure:    ExposureInternal,
+			Criticality: CriticalityMedium,
+			Feasibility: FeasibilityPatchAvailable,
+		}
+		got := Compute(in, cfg, epoch)
+		if got.Score < 0 || got.Score > 100 {
+			t.Fatalf("score %.2f out of range at cvss %.1f", got.Score, cvss)
+		}
+		if len(got.Breakdown.Overrides) != 0 {
+			t.Fatalf("no override should fire in this sweep, got %v at cvss %.1f", got.Breakdown.Overrides, cvss)
+		}
+		if !first {
+			if got.Score < prevScore {
+				t.Fatalf("score not monotonic: %.2f then %.2f", prevScore, got.Score)
+			}
+			// higher-or-equal score must be at least as urgent (rank not greater)
+			if rank(got.Tier) > rank(prevTier) {
+				t.Fatalf("tier not monotonic in score: score %.2f tier %s came after score %.2f tier %s", got.Score, got.Tier, prevScore, prevTier)
+			}
+		}
+		prevScore, prevTier, first = got.Score, got.Tier, false
+	}
+}
+
+// A KEV (known-exploited) finding with no patch must NOT be relaxed to the longer Exception window; it
+// keeps its score-derived urgency and is mitigated by a compensating control instead.
+func TestKEVNoPatchIsNotRelaxedToException(t *testing.T) {
+	cfg := DefaultConfig()
+	got := Compute(Inputs{CVSSScore: 8.0, KEV: true, Exposure: ExposureInternal, Feasibility: FeasibilityNoPatch}, cfg, epoch)
+	if got.Tier == TierException {
+		t.Fatalf("KEV no-patch was relaxed to Exception (longer window); want a ladder tier, got %s", got.Tier)
+	}
+	if contains(got.Breakdown.Overrides, "no_patch_routes_to_exception") {
+		t.Fatalf("no_patch routing fired for a KEV finding: %v", got.Breakdown.Overrides)
+	}
+}
+
+// applyOverrides must drop a de-escalating rule even if a (future/stored) Config supplies one — the
+// invariant is enforced, not trusted to the rule.
+func TestDeEscalatingOverrideIsDropped(t *testing.T) {
+	cfg := DefaultConfig()
+	// Score-derived tier for this input is Emergency (critical + KEV + external + high crit + active).
+	in := Inputs{CVSSScore: 9.8, KEV: true, EPSS: 0.9, ActiveExploitation: true, Exposure: ExposureExternal, Criticality: CriticalityHigh}
+	base := Compute(in, cfg, epoch)
+	if base.Tier != TierEmergency {
+		t.Fatalf("precondition: want Emergency base tier, got %s", base.Tier)
+	}
+	// The built-in rules never de-escalate; assert the guard directly at the unit level.
+	if got := func() Tier { tier, _ := applyOverrides(TierEmergency, Inputs{}, cfg); return tier }(); got != TierEmergency {
+		t.Fatalf("no-match overrides changed the tier: %s", got)
+	}
+	if next := escalate(TierLow); !moreUrgent(next, TierLow) {
+		t.Fatalf("escalate did not increase urgency: %s", next)
+	}
+}
+
+func TestThresholdBoundariesMapToTiers(t *testing.T) {
+	cfg := DefaultConfig()
+	tests := []struct {
+		score float64
+		want  Tier
+	}{
+		{cfg.Thresholds.Emergency, TierEmergency},
+		{cfg.Thresholds.Emergency - 0.1, TierCritical},
+		{cfg.Thresholds.Critical, TierCritical},
+		{cfg.Thresholds.Critical - 0.1, TierHigh},
+		{cfg.Thresholds.High, TierHigh},
+		{cfg.Thresholds.High - 0.1, TierMedium},
+		{cfg.Thresholds.Medium, TierMedium},
+		{cfg.Thresholds.Medium - 0.1, TierLow},
+		{0, TierLow},
+	}
+	for _, tc := range tests {
+		if got := tierForScore(tc.score, cfg); got != tc.want {
+			t.Errorf("tierForScore(%.1f) = %s, want %s", tc.score, got, tc.want)
+		}
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	if err := DefaultConfig().Validate(); err != nil {
+		t.Fatalf("DefaultConfig must validate: %v", err)
+	}
+	bad := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"no version", func(c *Config) { c.Version = "" }},
+		{"non-descending thresholds", func(c *Config) { c.Thresholds.Critical = c.Thresholds.Emergency + 1 }},
+		{"negative weight", func(c *Config) { c.Weights.Severity = -1 }},
+		{"mitigate after remediate", func(c *Config) { c.DueRanges.High.MitigateWithin = c.DueRanges.High.RemediateWithin + day }},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			tc.mutate(&cfg)
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("expected Validate to reject %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestComputeIsDeterministic(t *testing.T) {
+	cfg := DefaultConfig()
+	in := Inputs{CVSSScore: 8.1, KEV: true, EPSS: 0.4, PublicPoC: true, Exposure: ExposureExternal, Criticality: CriticalityHigh, Feasibility: FeasibilityChangeWindow}
+	first := Compute(in, cfg, epoch)
+	for i := 0; i < 10; i++ {
+		if got := Compute(in, cfg, epoch); !reflect.DeepEqual(got, first) {
+			t.Fatalf("Compute not deterministic on run %d: %+v vs %+v", i, first, got)
+		}
+	}
+}
+
+func TestDefaultConfigIsWellFormed(t *testing.T) {
+	cfg := DefaultConfig()
+	w := cfg.Weights
+	if sum := w.Severity + w.Exploitability + w.ThreatIntel + w.Exposure + w.Criticality; sum != 100 {
+		t.Fatalf("positive weights sum to %.1f, want 100", sum)
+	}
+	th := cfg.Thresholds
+	if !(th.Emergency > th.Critical && th.Critical > th.High && th.High > th.Medium && th.Medium > 0) {
+		t.Fatalf("thresholds not strictly descending/positive: %+v", th)
+	}
+	// Due ranges: mitigate <= remediate, and more-urgent tiers are not slower than less-urgent ones.
+	ranges := []struct {
+		t Tier
+		r DueRange
+	}{
+		{TierEmergency, cfg.DueRanges.Emergency}, {TierCritical, cfg.DueRanges.Critical},
+		{TierHigh, cfg.DueRanges.High}, {TierMedium, cfg.DueRanges.Medium}, {TierLow, cfg.DueRanges.Low},
+	}
+	for i, r := range ranges {
+		if r.r.MitigateWithin > r.r.RemediateWithin {
+			t.Fatalf("%s mitigate > remediate", r.t)
+		}
+		if i > 0 && r.r.RemediateWithin < ranges[i-1].r.RemediateWithin {
+			t.Fatalf("tier %s remediate window shorter than more-urgent %s", r.t, ranges[i-1].t)
+		}
+	}
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Implements **Phase 0** of epic #80 (risk-based remediation SLA and finding lifecycle): the pure, deterministic scoring domain that every later phase builds on. New package `internal/domain/sla`.

Findings are ordered by risk (KEV → EPSS → CVSS) today, but ordering is not governance — a finding has no tier and no due date. This adds the deterministic engine that turns a finding's risk context into a remediation **tier**, a bounded **0..100 urgency score** with an explainable **breakdown**, and concrete **mitigate-by / remediate-by** due dates.

## How (Phase 0 scope)

- `sla.Compute(Inputs, Config, now) Result` — a **pure** function: no I/O, the clock is injected, and the output is fully determined by the inputs plus a **versioned `Config`**. Every `Result` records the `ConfigVersion` that produced it, so a decision is reproducible and explainable later.
- **Score** is a bounded 0..100 weighted sum of factors — severity (CVSS band, falling back to the label), exploitability (KEV dominates, else EPSS bands), threat intel (active exploitation / public PoC), exposure, criticality — minus a feasibility relief for hard-to-fix findings. It is **risk-based, not CVSS-based**: severity alone never drives the tier without corroborating risk.
- **Tiers**: `emergency · critical · high · medium · low` form a score ladder; `exception` is off-ladder, reached only by an override (e.g. no patch is available → a governed accept-risk outcome, not an impossible due date).
- **Override rules** are deterministic and can only **escalate** urgency or route to `exception` — never de-escalate below the score-derived tier: active exploitation → emergency; KEV + internet exposure → escalate one tier; no-patch → exception (but never downgrades a genuine emergency). Every rule that fires is recorded in the breakdown.
- **Versioned `Config`** (`DefaultConfig()` = `sla-v1`): weights (sum to 100), descending thresholds, and per-tier due ranges. A Phase-2 persistence layer can supply a newer version; the default is the reproducible floor.
- Neutral defaults for unknown asset context (exposure/criticality), so the engine works before any asset model exists.

## Fail-safe hardening (from review)

- `applyOverrides` now **enforces** the escalate-or-Exception invariant structurally — a rule that would de-escalate a finding below its score-derived urgency is dropped, even if a future/stored `Config` supplies one (a security tool must never silently relax urgency).
- A **KEV** (known-exploited) no-patch finding is *not* routed to the longer Exception window — it keeps its score-derived urgency and is mitigated by a compensating control instead.
- Exported `Config.Validate()` (version set, non-negative weights, strictly-descending thresholds, mitigate ≤ remediate) so a Phase-2 persistence layer can reject a malformed stored config at the edge with `shared.ErrValidation`.
- Only overrides that actually change the tier are recorded, so the auditor-facing `Reason` never claims a no-op rule drove the tier.

## Tests

Table-driven tier cases · override-rule firing + recording · a **property test** that the score stays in 0..100 and the tier is monotonic in score (override flags held constant) · determinism across repeated runs · `DefaultConfig` well-formedness (weights sum to 100, strictly-descending thresholds, mitigate ≤ remediate, more-urgent tiers not slower).

## Scope note

This is Phase 0 (the foundation) of the epic; the acceptance criteria for later phases — wiring into the findings pipeline (Phase 1), versioned persistence + migration (Phase 2), the remediation lifecycle + accept-risk-with-expiry (Phase 3), and real asset risk context (Phase 4) — remain open and will land as follow-up PRs on this domain. Phase 0's own acceptance is met: `make build vet test` green, deterministic, and no imports outside stdlib + `internal/domain`.

## Verification (local — Actions disabled)

`go build ./...` · `go vet ./internal/domain/sla/...` · `gofmt -l` clean · `go test ./internal/domain/sla/...` green.
