### PR TITLE
feat(fleet): agent clean-uninstall decommission lifecycle (#412 AC-11)

### DIFF
--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -45,6 +45,8 @@ type fleetAgentService interface {
 	Authenticate(ctx context.Context, token string) (*fleetagent.Agent, error)
 	AuthenticateCertificate(ctx context.Context, tenantID, agentID shared.ID, fingerprint string) (*fleetagent.Agent, error)
 	Heartbeat(ctx context.Context, agent *fleetagent.Agent, in fleetagentuc.HeartbeatInput) error
+	// Decommission records the agent's own clean-uninstall report (#412).
+	Decommission(ctx context.Context, agent *fleetagent.Agent) error
 }
 
 // fleetWorkService is the narrow view of the work order lifecycle the transport needs.
@@ -269,6 +271,7 @@ func (f *fleetRouter) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v1/fleet/enrol", f.entry(f.enrol))
 	mux.HandleFunc("POST /api/v1/fleet/heartbeat", f.entry(f.authed(f.heartbeat)))
+	mux.HandleFunc("POST /api/v1/fleet/decommission", f.entry(f.authed(f.decommission)))
 	mux.HandleFunc("POST /api/v1/fleet/work/claim", f.entry(f.authed(f.claim)))
 	mux.HandleFunc("POST /api/v1/fleet/work/{id}/progress", f.entry(f.authed(f.progress)))
 	mux.HandleFunc("POST /api/v1/fleet/work/{id}/result", f.entry(f.authed(f.result)))
@@ -335,6 +338,8 @@ func (f *fleetRouter) authed(next http.HandlerFunc) http.HandlerFunc {
 			switch {
 			case errors.Is(err, fleetagentuc.ErrRevoked):
 				writeJSON(w, http.StatusForbidden, errorBody{Error: "revoked"})
+			case errors.Is(err, fleetagentuc.ErrDecommissioned):
+				writeJSON(w, http.StatusForbidden, errorBody{Error: "decommissioned"})
 			case errors.Is(err, fleetagentuc.ErrUnauthenticated):
 				writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
 			default:
@@ -422,6 +427,19 @@ func (f *fleetRouter) heartbeat(w http.ResponseWriter, r *http.Request) {
 	// service wired, no update is ever offered: the absence of a decider is not permission.
 	out["update"] = f.updateOffer(r.Context(), agent, req.AgentVersion)
 	writeJSON(w, http.StatusOK, out)
+}
+
+// decommission records the agent's own clean-uninstall report (#412, AC 11). It is agent-authenticated
+// (the caller is the agent, resolved by authed), tenant-scoped to that agent's identity, and takes no
+// body — the identity is the credential, never a request field. The control plane then shows the agent
+// as decommissioned rather than letting it decay into stale, and the credential stops authenticating.
+func (f *fleetRouter) decommission(w http.ResponseWriter, r *http.Request) {
+	agent, _ := agentFrom(r.Context())
+	if err := f.agents.Decommission(r.Context(), agent); err != nil {
+		writeError(w, f.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "decommissioned"})
 }
 
 // updateOffer computes the heartbeat's update block for ONE agent.

--- a/internal/adapter/httpapi/fleet_handler_test.go
+++ b/internal/adapter/httpapi/fleet_handler_test.go
@@ -280,3 +280,43 @@ func (s stubRollout) DecideFor(_ context.Context, _ shared.ID, _, group, _ strin
 	}
 	return fleetrollout.Decision{Reason: fleetrollout.ReasonCanaryOnly}
 }
+
+// TestFleetDecommission exercises the agent-self clean-uninstall report (#412, AC 11): an authenticated
+// agent decommissions itself, and its credential then stops authenticating (403 decommissioned) on any
+// further transport call.
+func TestFleetDecommission(t *testing.T) {
+	h, agentSvc, _ := setupFleet(t)
+	ctx := context.Background()
+
+	enrolTok, err := agentSvc.MintEnrolToken(ctx, "op", "default", time.Hour)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/enrol", enrolTok, map[string]any{"name": "agent-x", "platform": "linux"}, true)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("enrol should be 201, got %d (%s)", w.Code, w.Body.String())
+	}
+	var enrolResp struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &enrolResp); err != nil {
+		t.Fatalf("enrol resp: %v", err)
+	}
+	agentTok := enrolResp.Token
+
+	// Decommission requires auth.
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/decommission", "", nil, true); w.Code != http.StatusUnauthorized {
+		t.Fatalf("decommission without auth should be 401, got %d", w.Code)
+	}
+	// A healthy agent decommissions itself.
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/decommission", agentTok, nil, true); w.Code != http.StatusOK {
+		t.Fatalf("decommission should be 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	// Its credential no longer authenticates anywhere on the transport.
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/heartbeat", agentTok, map[string]string{"agent_version": "0.2.0"}, true); w.Code != http.StatusForbidden {
+		t.Fatalf("decommissioned agent heartbeat should be 403, got %d (%s)", w.Code, w.Body.String())
+	}
+	if w := fleetCall(h, http.MethodPost, "/api/v1/fleet/decommission", agentTok, nil, true); w.Code != http.StatusForbidden {
+		t.Fatalf("re-decommission after decommission should be 403, got %d", w.Code)
+	}
+}

--- a/internal/domain/fleetagent/fleetagent.go
+++ b/internal/domain/fleetagent/fleetagent.go
@@ -31,13 +31,21 @@ func CertFingerprint(der []byte) string {
 type State string
 
 const (
-	StateActive  State = "active"
-	StateStale   State = "stale" // last seen longer ago than the freshness threshold (computed by fleet coverage)
+	StateActive State = "active"
+	StateStale  State = "stale" // last seen longer ago than the freshness threshold (computed by fleet coverage)
+	// StateRevoked is an OPERATOR decision: the credential is killed with attribution.
 	StateRevoked State = "revoked"
+	// StateDecommissioned is a terminal state the AGENT reports when it is cleanly uninstalled (#412).
+	// It is distinct from Revoked (an operator killed it) and from Stale (it silently stopped reporting):
+	// the control plane shows an orderly removal rather than leaving the identity to rot into Stale. A
+	// decommissioned agent can no longer authenticate.
+	StateDecommissioned State = "decommissioned"
 )
 
 // Valid reports whether s is a known state.
-func (s State) Valid() bool { return s == StateActive || s == StateStale || s == StateRevoked }
+func (s State) Valid() bool {
+	return s == StateActive || s == StateStale || s == StateRevoked || s == StateDecommissioned
+}
 
 // Agent is an enrolled fleet agent. TokenHash is the hash of the bearer credential presented on
 // every call; the plaintext is shown once at enrolment and never stored.
@@ -63,6 +71,9 @@ type Agent struct {
 	RevokedAt    *time.Time
 	RevokedBy    shared.ID
 	RevokeReason string
+	// DecommissionedAt is when the agent self-reported a clean uninstall (#412). Nil unless the agent
+	// is in StateDecommissioned. There is no "by": decommission is self-reported, not operator-attributed.
+	DecommissionedAt *time.Time
 }
 
 // AssignGroup places the agent in a rollout group. Validation lives in the rollout domain, which owns
@@ -116,8 +127,29 @@ func NewAgent(id, tenantID shared.ID, name, platform, osVersion, agentVersion st
 	}, nil
 }
 
+// Decommission marks the agent cleanly removed (self-reported on uninstall, #412). It is a no-op on an
+// already-revoked agent — an operator revocation is a stronger, attributed terminal state and must not
+// be overwritten by a self-report. Idempotent: decommissioning an already-decommissioned agent only
+// refreshes the audit timestamp.
+func (a *Agent) Decommission(now time.Time) {
+	if a.State == StateRevoked {
+		return
+	}
+	a.State = StateDecommissioned
+	t := now
+	a.DecommissionedAt = &t
+	a.Audit.UpdatedAt = now
+}
+
 // Revoked reports whether the agent may no longer act.
 func (a *Agent) Revoked() bool { return a.State == StateRevoked }
+
+// Decommissioned reports whether the agent was cleanly removed.
+func (a *Agent) Decommissioned() bool { return a.State == StateDecommissioned }
+
+// Removed reports whether the agent's credential may no longer authenticate for any reason — an
+// operator revocation or a self-reported decommission. Auth and coverage both fail closed on it.
+func (a *Agent) Removed() bool { return a.Revoked() || a.Decommissioned() }
 
 // EnrolToken is a single-use, tenant-scoped, expiring token an operator issues so an agent can
 // enrol once. Only its hash is stored.

--- a/internal/domain/fleetagent/fleetagent_test.go
+++ b/internal/domain/fleetagent/fleetagent_test.go
@@ -70,3 +70,50 @@ func TestEnrolToken(t *testing.T) {
 		t.Fatalf("used token should not be usable")
 	}
 }
+
+func TestDecommission(t *testing.T) {
+	mk := func() *Agent {
+		a, err := NewAgent("a1", "t1", "agent", "linux", "5.15", "0.1.0", nil, "hash", tNow)
+		if err != nil {
+			t.Fatalf("new agent: %v", err)
+		}
+		return a
+	}
+
+	// A clean decommission moves an active agent to the terminal decommissioned state, self-reported
+	// (no operator attribution), and marks it removed.
+	a := mk()
+	later := tNow.Add(time.Hour)
+	a.Decommission(later)
+	if a.State != StateDecommissioned || !a.Decommissioned() || !a.Removed() {
+		t.Fatalf("decommission did not set terminal state: %+v", a)
+	}
+	if a.DecommissionedAt == nil || !a.DecommissionedAt.Equal(later) || a.RevokedBy != "" {
+		t.Fatalf("decommission attribution wrong: at=%v by=%q", a.DecommissionedAt, a.RevokedBy)
+	}
+	if a.Revoked() {
+		t.Fatalf("a decommissioned agent is not revoked")
+	}
+
+	// Re-decommissioning an already-decommissioned agent is idempotent: it refreshes the timestamp and
+	// stays decommissioned (never toggles back).
+	evenLater := later.Add(time.Hour)
+	a.Decommission(evenLater)
+	if a.State != StateDecommissioned || a.DecommissionedAt == nil || !a.DecommissionedAt.Equal(evenLater) {
+		t.Fatalf("re-decommission should refresh the timestamp and stay decommissioned: %+v", a)
+	}
+
+	// Decommission must NOT overwrite an operator revocation (the stronger terminal state).
+	r := mk()
+	r.Revoke("op", "compromised", tNow)
+	r.Decommission(later)
+	if r.State != StateRevoked || r.Decommissioned() {
+		t.Fatalf("decommission overwrote a revocation: %s", r.State)
+	}
+	if !r.Removed() {
+		t.Fatalf("a revoked agent is removed")
+	}
+	if !StateDecommissioned.Valid() {
+		t.Fatalf("decommissioned must be a valid state")
+	}
+}

--- a/internal/domain/fleetcoverage/agent.go
+++ b/internal/domain/fleetcoverage/agent.go
@@ -11,14 +11,17 @@ const (
 	AgentHealthy AgentHealth = "healthy"
 	// AgentStale: alive at last enrolment but not seen within the threshold (or never seen).
 	AgentStale AgentHealth = "stale"
-	// AgentRevoked: decommissioned; it must never count as covering anything.
+	// AgentRevoked: an operator revoked the credential; it must never count as covering anything.
 	AgentRevoked AgentHealth = "revoked"
+	// AgentDecommissioned: the agent cleanly uninstalled and self-reported removal (#412). Like revoked
+	// it never covers, but it is surfaced DISTINCTLY so an orderly removal is not shown as a revocation.
+	AgentDecommissioned AgentHealth = "decommissioned"
 )
 
 // Valid reports whether h is a known agent-health state.
 func (h AgentHealth) Valid() bool {
 	switch h {
-	case AgentHealthy, AgentStale, AgentRevoked:
+	case AgentHealthy, AgentStale, AgentRevoked, AgentDecommissioned:
 		return true
 	default:
 		return false
@@ -26,16 +29,20 @@ func (h AgentHealth) Valid() bool {
 }
 
 // Live reports whether an agent in this state can currently cover work (only healthy agents do; a
-// stale or revoked agent contributes nothing to coverage).
+// stale, revoked, or decommissioned agent contributes nothing to coverage).
 func (h AgentHealth) Live() bool { return h == AgentHealthy }
 
-// AgentStateFrom derives the health state from the last-seen time. A revoked agent is always revoked.
-// Otherwise, an agent not seen within staleAfter (or never seen) is stale; a non-positive staleAfter
-// disables the staleness check (an unset threshold must not mark every agent stale). now is injected
-// for determinism.
-func AgentStateFrom(lastSeen, now time.Time, staleAfter time.Duration, revoked bool) AgentHealth {
+// AgentStateFrom derives the health state from the last-seen time. A revoked agent is always revoked and
+// a decommissioned agent is always decommissioned (revocation takes precedence when both are set, as it
+// is the stronger, operator-attributed terminal state). Otherwise, an agent not seen within staleAfter
+// (or never seen) is stale; a non-positive staleAfter disables the staleness check (an unset threshold
+// must not mark every agent stale). now is injected for determinism.
+func AgentStateFrom(lastSeen, now time.Time, staleAfter time.Duration, revoked, decommissioned bool) AgentHealth {
 	if revoked {
 		return AgentRevoked
+	}
+	if decommissioned {
+		return AgentDecommissioned
 	}
 	if lastSeen.IsZero() {
 		return AgentStale

--- a/internal/domain/fleetcoverage/verdict_test.go
+++ b/internal/domain/fleetcoverage/verdict_test.go
@@ -95,19 +95,28 @@ func TestIsFresh(t *testing.T) {
 
 func TestAgentStateFrom(t *testing.T) {
 	now := time.Unix(1_000_000, 0).UTC()
-	if got := AgentStateFrom(now, now, time.Hour, true); got != AgentRevoked {
+	if got := AgentStateFrom(now, now, time.Hour, true, false); got != AgentRevoked {
 		t.Errorf("revoked must dominate, got %q", got)
 	}
-	if got := AgentStateFrom(time.Time{}, now, time.Hour, false); got != AgentStale {
+	if got := AgentStateFrom(now, now, time.Hour, false, true); got != AgentDecommissioned {
+		t.Errorf("decommissioned must be surfaced distinctly, got %q", got)
+	}
+	if got := AgentStateFrom(now, now, time.Hour, true, true); got != AgentRevoked {
+		t.Errorf("revoked must take precedence over decommissioned, got %q", got)
+	}
+	if AgentDecommissioned.Live() || !AgentDecommissioned.Valid() {
+		t.Errorf("decommissioned must be valid and non-live")
+	}
+	if got := AgentStateFrom(time.Time{}, now, time.Hour, false, false); got != AgentStale {
 		t.Errorf("never-seen must be stale, got %q", got)
 	}
-	if got := AgentStateFrom(now.Add(-30*time.Minute), now, time.Hour, false); got != AgentHealthy {
+	if got := AgentStateFrom(now.Add(-30*time.Minute), now, time.Hour, false, false); got != AgentHealthy {
 		t.Errorf("recent must be healthy, got %q", got)
 	}
-	if got := AgentStateFrom(now.Add(-2*time.Hour), now, time.Hour, false); got != AgentStale {
+	if got := AgentStateFrom(now.Add(-2*time.Hour), now, time.Hour, false, false); got != AgentStale {
 		t.Errorf("beyond threshold must be stale, got %q", got)
 	}
-	if got := AgentStateFrom(now.Add(-1000*time.Hour), now, 0, false); got != AgentHealthy {
+	if got := AgentStateFrom(now.Add(-1000*time.Hour), now, 0, false, false); got != AgentHealthy {
 		t.Errorf("disabled threshold must not force stale, got %q", got)
 	}
 	if AgentHealthy.Live() != true || AgentStale.Live() || AgentRevoked.Live() {

--- a/internal/infrastructure/persistence/memory/fleetagent_store.go
+++ b/internal/infrastructure/persistence/memory/fleetagent_store.go
@@ -118,6 +118,17 @@ func (s *FleetAgentStore) Revoke(_ context.Context, tenantID, id, by shared.ID, 
 	return nil
 }
 
+func (s *FleetAgentStore) Decommission(_ context.Context, tenantID, id shared.ID, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a, ok := s.agents[agentKey(tenantID, id)]
+	if !ok {
+		return shared.ErrNotFound
+	}
+	a.Decommission(now) // no-op on a revoked agent (the domain enforces it)
+	return nil
+}
+
 func (s *FleetAgentStore) ListAgents(_ context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/infrastructure/persistence/postgres/fleetagent_repo.go
+++ b/internal/infrastructure/persistence/postgres/fleetagent_repo.go
@@ -26,7 +26,7 @@ func NewFleetAgentRepository(pool *pgxpool.Pool) *FleetAgentRepository {
 
 var _ ports.FleetAgentStore = (*FleetAgentRepository)(nil)
 
-const fleetAgentCols = `id, tenant_id, name, platform, os_version, agent_version, capabilities, token_hash, state, created_at, updated_at, last_seen_at, fingerprint, revoked_at, revoked_by, revoke_reason`
+const fleetAgentCols = `id, tenant_id, name, platform, os_version, agent_version, capabilities, token_hash, state, created_at, updated_at, last_seen_at, fingerprint, revoked_at, revoked_by, revoke_reason, decommissioned_at`
 
 func (r *FleetAgentRepository) CreateEnrolToken(ctx context.Context, t *fleetagent.EnrolToken) error {
 	return WithTenant(ctx, r.pool, t.TenantID.String(), func(tx pgx.Tx) error {
@@ -69,10 +69,10 @@ func (r *FleetAgentRepository) CreateAgent(ctx context.Context, a *fleetagent.Ag
 	return WithTenant(ctx, r.pool, a.TenantID.String(), func(tx pgx.Tx) error {
 		_, e := tx.Exec(ctx, `
 			INSERT INTO fleet_agents (`+fleetAgentCols+`)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
 			a.ID.String(), a.TenantID.String(), a.Name, a.Platform, a.OSVersion, a.AgentVersion,
 			caps, a.TokenHash, string(a.State), a.Audit.CreatedAt, a.Audit.UpdatedAt, a.LastSeenAt,
-			a.Fingerprint, a.RevokedAt, a.RevokedBy.String(), a.RevokeReason)
+			a.Fingerprint, a.RevokedAt, a.RevokedBy.String(), a.RevokeReason, a.DecommissionedAt)
 		return e
 	})
 }
@@ -154,6 +154,28 @@ func (r *FleetAgentRepository) Revoke(ctx context.Context, tenantID, id, by shar
 	})
 }
 
+// Decommission marks the agent decommissioned on its own report (#412). It is an idempotent no-op on a
+// REVOKED agent: an operator revocation is the stronger terminal state and a self-report must not
+// overwrite it (the CASE leaves a revoked row untouched but still matches it, so only a truly missing
+// agent yields ErrNotFound — matching the memory store's contract).
+func (r *FleetAgentRepository) Decommission(ctx context.Context, tenantID, id shared.ID, now time.Time) error {
+	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, e := tx.Exec(ctx, `UPDATE fleet_agents
+			SET state = CASE WHEN state='revoked' THEN state ELSE 'decommissioned' END,
+			    decommissioned_at = CASE WHEN state='revoked' THEN decommissioned_at ELSE $3 END,
+			    updated_at = CASE WHEN state='revoked' THEN updated_at ELSE $3 END
+			WHERE tenant_id=$1 AND id=$2`,
+			tenantID.String(), id.String(), now)
+		if e != nil {
+			return e
+		}
+		if tag.RowsAffected() == 0 {
+			return shared.ErrNotFound
+		}
+		return nil
+	})
+}
+
 func (r *FleetAgentRepository) ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error) {
 	var out []*fleetagent.Agent
 	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
@@ -181,13 +203,13 @@ func scanAgent(row rowScanner) (*fleetagent.Agent, error) {
 	var (
 		id, tid, name, platform, osv, ver, hash, state string
 		fingerprint, revokedBy, revokeReason           string
-		revokedAt                                      *time.Time
+		revokedAt, decommissionedAt                    *time.Time
 		caps                                           []byte
 		a                                              fleetagent.Agent
 	)
 	if err := row.Scan(&id, &tid, &name, &platform, &osv, &ver, &caps, &hash, &state,
 		&a.Audit.CreatedAt, &a.Audit.UpdatedAt, &a.LastSeenAt,
-		&fingerprint, &revokedAt, &revokedBy, &revokeReason); err != nil {
+		&fingerprint, &revokedAt, &revokedBy, &revokeReason, &decommissionedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, shared.ErrNotFound
 		}
@@ -205,6 +227,7 @@ func scanAgent(row rowScanner) (*fleetagent.Agent, error) {
 	a.RevokedAt = revokedAt
 	a.RevokedBy = shared.ID(revokedBy)
 	a.RevokeReason = revokeReason
+	a.DecommissionedAt = decommissionedAt
 	if len(caps) > 0 {
 		if err := json.Unmarshal(caps, &a.Capabilities); err != nil {
 			return nil, err

--- a/internal/infrastructure/persistence/postgres/fleetagent_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/fleetagent_repo_test.go
@@ -94,6 +94,35 @@ func TestFleetAgentRepository(t *testing.T) {
 	if !got.Revoked() {
 		t.Fatalf("agent should be revoked")
 	}
+
+	// Decommission (#412): a second, healthy agent cleanly decommissions and round-trips the terminal
+	// state + timestamp; decommissioning the already-revoked ag1 is a silent no-op that does not
+	// downgrade the revocation.
+	ag2, err := fleetagent.NewAgent("ag2", "ft", "agent-2", "linux", "5.15", "0.1.0", []string{"scan.host"}, "tokhash2", now)
+	if err != nil {
+		t.Fatalf("new agent 2: %v", err)
+	}
+	if err := repo.CreateAgent(ctx, ag2); err != nil {
+		t.Fatalf("create agent 2: %v", err)
+	}
+	if err := repo.Decommission(ctx, "ft", "ag2", now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("decommission ag2: %v", err)
+	}
+	got, _ = repo.GetAgent(ctx, "ft", "ag2")
+	if !got.Decommissioned() || got.DecommissionedAt == nil {
+		t.Fatalf("ag2 should be decommissioned with a timestamp: %+v", got)
+	}
+	if err := repo.Decommission(ctx, "ft", "ag1", now.Add(4*time.Minute)); err != nil {
+		t.Fatalf("decommission of a revoked agent must be a silent no-op, got %v", err)
+	}
+	got, _ = repo.GetAgent(ctx, "ft", "ag1")
+	if !got.Revoked() || got.Decommissioned() {
+		t.Fatalf("revoked ag1 must stay revoked after a decommission no-op: %s", got.State)
+	}
+	if err := repo.Decommission(ctx, "ft", "missing", now); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("decommission of a missing agent must be ErrNotFound, got %v", err)
+	}
+
 	if _, err := repo.GetAgent(ctx, "ft", "missing"); !errors.Is(err, shared.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound for missing agent, got %v", err)
 	}

--- a/internal/usecase/fleet/coverage/service.go
+++ b/internal/usecase/fleet/coverage/service.go
@@ -103,7 +103,7 @@ func (s *Service) Agents(ctx context.Context, tenantID shared.ID, stateFilter fl
 	for _, a := range agents {
 		row := AgentRow{
 			ID: a.ID.String(), Name: a.Name, Platform: a.Platform, Version: a.AgentVersion,
-			Health:       fleetcoverage.AgentStateFrom(a.LastSeenAt, now, s.staleAfter, a.RevokedAt != nil),
+			Health:       fleetcoverage.AgentStateFrom(a.LastSeenAt, now, s.staleAfter, a.Revoked(), a.Decommissioned()),
 			LastSeen:     a.LastSeenAt,
 			Capabilities: append([]string(nil), a.Capabilities...),
 			CurrentWork:  liveByAgent[a.ID],
@@ -187,7 +187,7 @@ func (s *Service) Coverage(ctx context.Context, tenantID shared.ID) ([]CoverageR
 	liveCapabilities := map[string]bool{} // a capability advertised by at least one HEALTHY agent
 	anyLiveAgent := false                 // is there any live agent at all (for assets with no work orders)?
 	for _, a := range agents {
-		if fleetcoverage.AgentStateFrom(a.LastSeenAt, now, s.staleAfter, a.RevokedAt != nil).Live() {
+		if fleetcoverage.AgentStateFrom(a.LastSeenAt, now, s.staleAfter, a.Revoked(), a.Decommissioned()).Live() {
 			anyLiveAgent = true
 			for _, c := range a.Capabilities {
 				liveCapabilities[c] = true

--- a/internal/usecase/fleetagentuc/service.go
+++ b/internal/usecase/fleetagentuc/service.go
@@ -23,6 +23,9 @@ import (
 var (
 	ErrUnauthenticated = errors.New("fleetagent: unauthenticated")
 	ErrRevoked         = errors.New("fleetagent: agent revoked")
+	// ErrDecommissioned means the agent cleanly uninstalled and reported itself decommissioned (#412);
+	// its credential no longer authenticates. Mapped to 403 at the adapter edge, like ErrRevoked.
+	ErrDecommissioned = errors.New("fleetagent: agent decommissioned")
 )
 
 // Service is the fleet agent identity use case.
@@ -176,6 +179,9 @@ func (s *Service) AuthenticateCertificate(ctx context.Context, tenantID, agentID
 	if agent.Revoked() {
 		return nil, ErrRevoked
 	}
+	if agent.Decommissioned() {
+		return nil, ErrDecommissioned
+	}
 	return agent, nil
 }
 
@@ -198,6 +204,9 @@ func (s *Service) Authenticate(ctx context.Context, token string) (*fleetagent.A
 	}
 	if agent.Revoked() {
 		return nil, ErrRevoked
+	}
+	if agent.Decommissioned() {
+		return nil, ErrDecommissioned
 	}
 	return agent, nil
 }
@@ -239,6 +248,37 @@ func (s *Service) Revoke(ctx context.Context, actor string, tenantID, id shared.
 		At:       now,
 	}); err != nil {
 		return fmt.Errorf("revoke agent: audit: %w", err)
+	}
+	return nil
+}
+
+// Decommission marks an agent cleanly removed on the agent's own authenticated report during uninstall
+// (#412), cancels its in-flight work orders, and audits it. It is self-reported: the actor is the
+// agent's own id. A revoked agent is unaffected (an operator revocation is the stronger terminal
+// state). The control plane then shows the identity as decommissioned rather than letting it decay into
+// stale. Tenant scope comes from the authenticated agent, never from the request body.
+func (s *Service) Decommission(ctx context.Context, agent *fleetagent.Agent) error {
+	if agent == nil {
+		return fmt.Errorf("%w: decommission needs an authenticated agent", shared.ErrValidation)
+	}
+	now := s.clock.Now()
+	if err := s.store.Decommission(ctx, agent.TenantID, agent.ID, now); err != nil {
+		return fmt.Errorf("decommission agent: %w", err)
+	}
+	cancelled := 0
+	if s.workOrders != nil {
+		// Best-effort, mirroring Revoke: a decommissioned agent must stop, but a failure to cancel its
+		// orders must not leave it un-decommissioned. Orders also expire on their own NotAfter.
+		if n, cerr := s.workOrders.CancelForAgent(ctx, agent.TenantID, agent.ID, "agent decommissioned", now); cerr == nil {
+			cancelled = n
+		}
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor: agent.ID.String(), Action: "agent.decommissioned", Target: agent.ID.String(),
+		Metadata: map[string]string{"tenant_id": agent.TenantID.String(), "cancelled_orders": fmt.Sprintf("%d", cancelled)},
+		At:       now,
+	}); err != nil {
+		return fmt.Errorf("decommission agent: audit: %w", err)
 	}
 	return nil
 }

--- a/internal/usecase/fleetagentuc/service_test.go
+++ b/internal/usecase/fleetagentuc/service_test.go
@@ -109,6 +109,51 @@ func TestAuthenticateRevoked(t *testing.T) {
 	}
 }
 
+func TestDecommissionStopsAuthAndCancelsOrders(t *testing.T) {
+	svc := newSvc(t)
+	canceller := &fakeCanceller{}
+	svc.SetWorkOrders(canceller)
+	ctx := context.Background()
+	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
+	agent, agentTok, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"})
+	if err != nil {
+		t.Fatalf("enrol: %v", err)
+	}
+	if err := svc.Decommission(ctx, agent); err != nil {
+		t.Fatalf("decommission: %v", err)
+	}
+	// A decommissioned agent's credential no longer authenticates.
+	if _, err := svc.Authenticate(ctx, agentTok); !errors.Is(err, ErrDecommissioned) {
+		t.Fatalf("decommissioned agent must return ErrDecommissioned, got %v", err)
+	}
+	// In-flight orders are cancelled, mirroring revoke.
+	if canceller.cancelled != 1 {
+		t.Fatalf("decommission must cancel the agent's in-flight orders, calls=%d", canceller.cancelled)
+	}
+}
+
+func TestDecommissionDoesNotOverrideRevocation(t *testing.T) {
+	svc := newSvc(t)
+	ctx := context.Background()
+	enrolTok, _ := svc.MintEnrolToken(ctx, "op", "t1", time.Hour)
+	agent, agentTok, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "a"})
+	if err != nil {
+		t.Fatalf("enrol: %v", err)
+	}
+	if err := svc.Revoke(ctx, "op", "t1", agent.ID, "compromised"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	// A self-reported decommission is an idempotent no-op on a revoked agent (revocation wins); it
+	// returns no error but must not downgrade the terminal state.
+	if err := svc.Decommission(ctx, agent); err != nil {
+		t.Fatalf("decommission on a revoked agent should be a silent no-op, got %v", err)
+	}
+	// It stays revoked (the stronger terminal state), not decommissioned.
+	if _, err := svc.Authenticate(ctx, agentTok); !errors.Is(err, ErrRevoked) {
+		t.Fatalf("agent must remain revoked, got %v", err)
+	}
+}
+
 func TestExpiredEnrolTokenRejected(t *testing.T) {
 	svc := newSvc(t)
 	ctx := context.Background()

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -155,6 +155,9 @@ type FleetAgentStore interface {
 	SetFingerprint(ctx context.Context, tenantID, id shared.ID, fingerprint string, now time.Time) error
 	// Revoke marks the agent revoked with operator attribution and a reason.
 	Revoke(ctx context.Context, tenantID, id, by shared.ID, reason string, now time.Time) error
+	// Decommission marks the agent cleanly decommissioned on its own report (#412). It must NOT
+	// overwrite an operator revocation (the stronger terminal state).
+	Decommission(ctx context.Context, tenantID, id shared.ID, now time.Time) error
 	ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error)
 }
 

--- a/migrations/0102_fleet_agent_decommission.sql
+++ b/migrations/0102_fleet_agent_decommission.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- Clean-uninstall decommission for fleet agents (#412, AC 11): a terminal, self-reported state distinct
+-- from operator 'revoked' and from last-seen 'stale', so the control plane shows an orderly removal
+-- rather than letting a removed agent decay into stale. decommissioned_at is the self-reported time
+-- (nullable; no attributed actor — the agent reports its own decommission over its authenticated
+-- credential during uninstall).
+ALTER TABLE fleet_agents ADD COLUMN decommissioned_at TIMESTAMPTZ;
+
+ALTER TABLE fleet_agents DROP CONSTRAINT fleet_agents_state_check;
+ALTER TABLE fleet_agents ADD CONSTRAINT fleet_agents_state_check CHECK (state IN ('active', 'stale', 'revoked', 'decommissioned'));
+
+-- +goose Down
+ALTER TABLE fleet_agents DROP CONSTRAINT fleet_agents_state_check;
+ALTER TABLE fleet_agents ADD CONSTRAINT fleet_agents_state_check CHECK (state IN ('active', 'stale', 'revoked'));
+ALTER TABLE fleet_agents DROP COLUMN decommissioned_at;


### PR DESCRIPTION
## What

Implements the **clean-uninstall decommission** slice of epic #412 (AC 11: *"the agent identity is reported as decommissioned rather than silently going stale"* and *"the control plane shows the agent as decommissioned"*).

Most of #412 already shipped — the update channel + signature/checksum verification + health-gated auto-rollback (`internal/infrastructure/fleetupdate`), operator-controlled rollout/canary (`fleetrollout`), version skew, and the signing/release-scan/libc-floor pipeline (see the checked acceptance boxes). The remaining code gap was the terminal lifecycle state for an orderly removal.

## How

A new terminal agent state, `decommissioned`, **self-reported by the agent during uninstall** — distinct from operator `revoked` (an operator killed the credential, with attribution) and from `stale` (it silently stopped reporting). The control plane now shows an orderly removal instead of letting the identity decay into stale.

- **Domain** (`fleetagent`): `StateDecommissioned` + `DecommissionedAt` (self-reported, no operator attribution) + `Decommission(now)` (a **no-op on a revoked agent** — revocation is the stronger terminal state) + `Decommissioned()` / `Removed()` (revoked ∨ decommissioned).
- **Usecase** (`fleetagentuc`): `Decommission(ctx, agent)` — agent-self (actor = the agent's own id), cancels in-flight work orders (best-effort, mirroring revoke), append-only audit `agent.decommissioned`; tenant comes from the authenticated agent, never a request body. `Authenticate` **and** `AuthenticateCertificate` now reject a decommissioned agent with `ErrDecommissioned`.
- **Transport** (`httpapi`): `POST /api/v1/fleet/decommission`, behind the agent-auth transport (`entry`→`authed`), **no request body** (identity is the credential). `ErrDecommissioned` → `403`.
- **Persistence**: `decommissioned_at` column + `Decommission` on both stores. Postgres uses a single CASE update that leaves a revoked row untouched (idempotent no-op) and returns `ErrNotFound` only when the agent is truly missing; the memory store honors the same contract. Migration `0102` adds the column and widens the `state` CHECK (with a Down).
- **Coverage** (`fleetcoverage`/`coverage`): a decommissioned agent never counts as covering work — coverage now keys on `agent.Removed()`, not just revocation.

## Revocation precedence (safety)

A self-reported decommission can never overwrite or downgrade an operator revocation. Enforced in three places: the domain `Decommission` no-op on revoked, the Postgres CASE (a revoked row is matched but untouched), and the memory store. A decommissioned agent's credential also stops authenticating, so a compromised host cannot use decommission to escape a revocation.

## Tests

- Domain: decommission transition + timestamp, no-op on revoked, `Removed`, `Valid`.
- Usecase: decommission stops auth (`ErrDecommissioned`) + cancels in-flight orders; decommission does not override a revocation.
- Transport: `POST /fleet/decommission` requires auth (401), succeeds (200), then the credential is 403 everywhere (heartbeat + re-decommission).
- Postgres (real DB): `decommissioned_at` round-trips, revoked-agent no-op keeps it revoked, missing → `ErrNotFound`; migration `0102` applies (verified to version 102 on a fresh schema).

## Scope note

This closes the decommission/uninstall-reporting code portion of #412 (AC 11). The remaining open acceptance criteria — the per-platform CI install/start/heartbeat/uninstall matrix and the on-host package tests — require real RHEL/Ubuntu/Windows runners and are ops/release-engineering rather than control-plane code; they stay open on the epic.

## Verification (local — Actions disabled)

`go build ./...` · `go vet ./...` · `gofmt -l` clean · fleet domain/usecase/coverage + `httpapi` (incl. `TestHostileHarness`) suites green · Postgres `TestFleetAgentRepository` green on a fresh schema (migrations through `0102`).
