### PR TITLE
Redesign engagements queue and creation flow

### DIFF
--- a/web/src/App.rules.test.tsx
+++ b/web/src/App.rules.test.tsx
@@ -151,16 +151,16 @@ describe('App Routing - Rules', () => {
     expect(document.documentElement.dataset.theme).toBe('light')
   })
 
-  it('shows only New Engagement for the Engagement workspace', () => {
+  it('links to the Engagements queue from the primary navigation', () => {
     render(
       <MemoryRouter initialEntries={['/assets']}>
         <Sidebar />
       </MemoryRouter>
     )
 
-    const newEngagement = screen.getByRole('link', { name: 'New Engagement' })
-    expect(newEngagement.getAttribute('href')).toBe('/engagements?create=1')
-    expect(screen.queryByRole('link', { name: 'Engagements' })).not.toBeInTheDocument()
+    const engagements = screen.getByRole('link', { name: 'Engagements' })
+    expect(engagements.getAttribute('href')).toBe('/engagements')
+    expect(screen.queryByRole('link', { name: 'New Engagement' })).not.toBeInTheDocument()
   })
 
   it('opens mobile navigation and navigates to Rules', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,7 +8,7 @@ import { AITriageReviews } from './pages/AITriageReviews'
 import { AITriageObservability } from './pages/AITriageObservability'
 import { Connect } from './pages/Connect'
 import { EngagementDetail } from './pages/EngagementDetail'
-import { Engagements } from './pages/Engagements'
+import { Engagements, NewEngagement } from './pages/Engagements'
 import { Team } from './pages/Team'
 import Rules from './pages/Rules'
 import RuleDetail from './pages/RuleDetail'
@@ -48,6 +48,7 @@ function Gate() {
         <Route index element={<Navigate to="/dashboard" replace />} />
         <Route path="dashboard" element={<Dashboard />} />
         <Route path="engagements" element={<Engagements />} />
+        <Route path="engagements/new" element={<NewEngagement />} />
         <Route path="engagements/:id" element={<EngagementDetail />} />
         <Route path="assets" element={<Assets />} />
         <Route path="assets/:key" element={<AssetDetail />}>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -15,7 +15,7 @@ import {
   Settings,
   ShieldQuestion,
   ShieldAlert,
-  SquarePen,
+  Target,
   Sun,
   Users,
   X,
@@ -41,7 +41,7 @@ const NAV_GROUPS: Array<{
   {
     label: 'Assess risk',
     items: [
-      { icon: SquarePen, label: 'New Engagement', to: '/engagements?create=1', prefix: '/engagements', action: true },
+      { icon: Target, label: 'Engagements', to: '/engagements', prefix: '/engagements' },
       { icon: ShieldQuestion, label: 'AI review queue', to: '/ai-triage/reviews', prefix: '/ai-triage/reviews' },
       { icon: Activity, label: 'AI observability', to: '/ai-triage/observability', prefix: '/ai-triage/observability' },
       { icon: ShieldAlert, label: 'Vulnerability intelligence', to: '/vulnerability-intelligence', prefix: '/vulnerability-intelligence' },

--- a/web/src/pages/AssetDetail.tsx
+++ b/web/src/pages/AssetDetail.tsx
@@ -156,7 +156,7 @@ export function AssetDetail() {
 }
 
 function newEngagementPath(assetId: string) {
-  return `/engagements?${new URLSearchParams({ create: '1', assetId }).toString()}`
+  return `/engagements/new?${new URLSearchParams({ assetId }).toString()}`
 }
 
 function ProfileItem({ icon: Icon, label, value }: { icon: LucideIcon; label: string; value: string }) {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -119,7 +119,7 @@ export function Dashboard() {
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <QuickLink to="/engagements?create=1" label="New Engagement" icon={Target} />
+            <QuickLink to="/engagements/new" label="New Engagement" icon={Target} />
             <QuickLink to="/assets" label="Asset inventory" icon={Boxes} />
             <QuickLink to="/code-quality" label="Code security" icon={Gauge} />
           </div>

--- a/web/src/pages/Engagements.test.tsx
+++ b/web/src/pages/Engagements.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { api } from '../lib/api'
-import { Engagements } from './Engagements'
+import { Engagements, NewEngagement } from './Engagements'
 
 vi.mock('../lib/api', () => ({
   api: {
@@ -38,10 +38,19 @@ describe('Engagements', () => {
     })
   })
 
-  it('opens creation and preselects the Asset from query parameters', async () => {
-    render(<MemoryRouter initialEntries={['/engagements?create=1&assetId=a1']}><Engagements /></MemoryRouter>)
+  it('keeps the Engagements page focused on the assessment queue', async () => {
+    render(<MemoryRouter initialEntries={['/engagements']}><Engagements /></MemoryRouter>)
+
+    expect(screen.getByRole('heading', { name: 'Engagements' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Engagement details' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'New Engagement' })).toHaveAttribute('href', '/engagements/new')
+  })
+
+  it('renders creation separately and preselects the Asset from query parameters', async () => {
+    render(<MemoryRouter initialEntries={['/engagements/new?assetId=a1']}><NewEngagement /></MemoryRouter>)
 
     expect(screen.getByRole('heading', { name: 'New Engagement' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Engagement details' })).toBeInTheDocument()
     expect((await screen.findAllByText('Mobile Banking (mobile)')).length).toBeGreaterThan(0)
     await waitFor(() => expect(api.listBusinessAssets).toHaveBeenCalledWith('limit=200'))
   })

--- a/web/src/pages/Engagements.tsx
+++ b/web/src/pages/Engagements.tsx
@@ -1,6 +1,6 @@
-import { Activity, Boxes, Briefcase, CheckCircle2, Plus, Target, Trash2, Upload, X } from 'lucide-react'
+import { Activity, Boxes, Briefcase, CheckCircle2, Plus, Target, Trash2, Upload } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom'
 import { Button, Card, cn, EmptyState, ErrorState, Field, Input, Pill, Select, Spinner } from '../components/ui'
 import { kindLabel } from '../lib/format'
 import { api } from '../lib/api'
@@ -9,12 +9,10 @@ import type { BusinessAsset, Engagement, ScopeTarget } from '../lib/types'
 const KINDS = ['repo', 'domain', 'host', 'url', 'image', 'cidr']
 
 export function Engagements() {
-  const [searchParams, setSearchParams] = useSearchParams()
-  const requestedAssetId = searchParams.get('assetId') ?? ''
+  const [searchParams] = useSearchParams()
   const [list, setList] = useState<Engagement[] | null>(null)
   const [assetNames, setAssetNames] = useState<Record<string, string>>({})
   const [error, setError] = useState<string | null>(null)
-  const [creating, setCreating] = useState(() => searchParams.get('create') === '1')
   const [importing, setImporting] = useState(false)
   const [importErr, setImportErr] = useState<string | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
@@ -33,11 +31,6 @@ export function Engagements() {
   }
 
   useEffect(load, [])
-
-  function closeCreate() {
-    setCreating(false)
-    if (searchParams.has('create') || searchParams.has('assetId')) setSearchParams({}, { replace: true })
-  }
 
   async function onImportFile(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0]
@@ -60,6 +53,11 @@ export function Engagements() {
   const completedCount = engagements.filter((engagement) => engagement.status.toLowerCase() === 'completed').length
   const unassignedCount = engagements.filter((engagement) => !engagement.businessAssetId).length
 
+  if (searchParams.get('create') === '1') {
+    const assetId = searchParams.get('assetId')
+    return <Navigate replace to={assetId ? `/engagements/new?${new URLSearchParams({ assetId }).toString()}` : '/engagements/new'} />
+  }
+
   return (
     <div className="mx-auto max-w-[1480px] animate-fade-in">
       <header className="mb-6 flex flex-wrap items-end justify-between gap-4">
@@ -75,25 +73,13 @@ export function Engagements() {
           <Button variant="secondary" loading={importing} onClick={() => fileRef.current?.click()}>
             <Upload className="size-4" />Import bundle
           </Button>
-          <Button variant="brand" onClick={() => creating ? closeCreate() : setCreating(true)}>
-            {creating ? <><X className="size-4" />Cancel</> : <><Plus className="size-4" />New Engagement</>}
-          </Button>
+          <Link to="/engagements/new" className="btn-primary inline-flex items-center justify-center gap-2 rounded-lg px-3.5 py-2 text-sm font-semibold text-brandfg transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg">
+            <Plus className="size-4" />New Engagement
+          </Link>
         </div>
       </header>
 
       {importErr && <div className="mb-6"><ErrorState message={importErr} /></div>}
-
-      {creating && (
-        <div className="mb-6">
-          <CreateForm
-            initialAssetId={requestedAssetId}
-            onCreated={() => {
-              closeCreate()
-              load()
-            }}
-          />
-        </div>
-      )}
 
       <div className="mb-6 grid grid-cols-2 gap-3 lg:grid-cols-4">
         <EngagementStat icon={Target} label="Total" value={list ? engagements.length : '—'} />
@@ -104,12 +90,12 @@ export function Engagements() {
 
       {error && <ErrorState message={error} />}
       {!list && !error && <Spinner label="Loading engagements…" />}
-      {list && list.length === 0 && !creating && (
+      {list && list.length === 0 && (
         <EmptyState
           icon={Target}
           title="No engagements yet"
           hint="Create one to define an authorized testing scope and connect the assessment to an Asset."
-          action={<Button variant="brand" onClick={() => setCreating(true)}><Plus className="size-4" />New Engagement</Button>}
+          action={<Link to="/engagements/new" className="btn-primary inline-flex items-center justify-center gap-2 rounded-lg px-3.5 py-2 text-sm font-semibold text-brandfg transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"><Plus className="size-4" />New Engagement</Link>}
         />
       )}
       {list && list.length > 0 && (
@@ -119,6 +105,27 @@ export function Engagements() {
           ))}
         </Card>
       )}
+    </div>
+  )
+}
+
+export function NewEngagement() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const initialAssetId = searchParams.get('assetId') ?? ''
+
+  return (
+    <div className="mx-auto max-w-[1480px] animate-fade-in">
+      <header className="mb-6 flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-branddim">Assessment operations</p>
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">New Engagement</h1>
+          <p className="mt-2 max-w-3xl text-sm text-mutedfg sm:text-base">Define an authorized assessment scope and connect it to a business Asset.</p>
+        </div>
+        <Link to="/engagements" className="inline-flex items-center justify-center rounded-lg border border-border bg-elevated px-3.5 py-2 text-sm font-semibold text-foreground transition hover:border-borderstrong hover:bg-raised focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg">Cancel</Link>
+      </header>
+
+      <CreateForm initialAssetId={initialAssetId} onCreated={() => navigate('/engagements')} />
     </div>
   )
 }
@@ -252,7 +259,7 @@ function CreateForm({ initialAssetId, onCreated }: { initialAssetId?: string; on
   }
 
   return (
-    <Card title="New Engagement" className="animate-fade-in border-brand/25">
+    <Card title="Engagement details" className="border-brand/25">
       <form onSubmit={submit} className="space-y-5">
         <div>
           <div className="mb-3 flex items-center gap-2 text-sm font-semibold"><span className="flex size-6 items-center justify-center rounded-full bg-brand text-xs text-brandfg">1</span>Assessment context</div>


### PR DESCRIPTION
## Summary
- keep `/engagements` focused on the assessment queue
- move the creation form to `/engagements/new`
- update navigation, dashboard, and Asset shortcuts to the new route
- redirect legacy `?create=1` links to the dedicated creation route

## Validation
- `npm test` — 39 files, 311 tests passed
- `npm run typecheck`
- `npm run build`