### PR TITLE
Reorganize sidebar around security workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ capabilities below are already shipped on `main`.
 
 ### Changed
 
+- **Workflow-oriented sidebar navigation.** Reorganizes shipped dashboard capabilities around security operations, exposure management, engineering, runtime, and governance; separates engagement creation from the active navigation state; and removes unavailable placeholder destinations.
+
 - **Breaking Asset API consolidation.** Removed `POST|GET /api/v1/assets/services`, `asset.BusinessService`, and the unused `member_of` fleet edge. Business-level Asset reads and writes now use `/api/v1/appsec/assets`; technical/fleet `/api/v1/assets` remains unchanged. Existing business-service rows retain their IDs and owners and receive stable keys during migration.
 
 ### Fixed

--- a/web/src/App.rules.test.tsx
+++ b/web/src/App.rules.test.tsx
@@ -151,16 +151,33 @@ describe('App Routing - Rules', () => {
     expect(document.documentElement.dataset.theme).toBe('light')
   })
 
-  it('links to the Engagements queue from the primary navigation', () => {
+  it('separates the create action from the active Engagements destination', () => {
     render(
-      <MemoryRouter initialEntries={['/assets']}>
+      <MemoryRouter initialEntries={['/engagements/new']}>
         <Sidebar />
       </MemoryRouter>
     )
 
-    const engagements = screen.getByRole('link', { name: 'Engagements' })
-    expect(engagements.getAttribute('href')).toBe('/engagements')
-    expect(screen.queryByRole('link', { name: 'New Engagement' })).not.toBeInTheDocument()
+    const newEngagement = screen.getByRole('link', { name: 'New Engagement' })
+    expect(newEngagement.getAttribute('href')).toBe('/engagements/new')
+    expect(newEngagement).not.toHaveAttribute('aria-current')
+    expect(screen.getByRole('link', { name: 'Engagements' })).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('groups shipped capabilities by operator workflow without placeholder navigation', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Sidebar />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Security operations' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Exposure management' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Security engineering' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Runtime security' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Governance' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Review queue' })).toHaveAttribute('href', '/ai-triage/reviews')
+    expect(screen.queryByText('Coming soon')).not.toBeInTheDocument()
   })
 
   it('opens mobile navigation and navigates to Rules', async () => {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -170,7 +170,7 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
       <nav className="flex-1 overflow-y-auto px-3 py-4" aria-label="Primary navigation">
         <div className="space-y-1">{renderItems([DASHBOARD])}</div>
         {NAV_GROUPS.map((group) => (
-          <section key={group.label} aria-label={group.label} className="mt-4">
+          <section key={group.label} className="mt-4">
             <h2 className={cn('mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-[0.16em] text-navsubtle', collapsed && 'sr-only')}>
               {group.label}
             </h2>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,73 +1,76 @@
 import {
+  Activity,
   Boxes,
-  ChevronDown,
   ChevronLeft,
   ChevronRight,
-  FileText,
   Gauge,
-  Activity,
   LayoutDashboard,
   Library,
   Moon,
-  Radar,
+  Plus,
   ScrollText,
   Server,
-  Settings,
-  ShieldQuestion,
   ShieldAlert,
-  Target,
+  ShieldQuestion,
   Sun,
+  Target,
   Users,
   X,
   type LucideIcon,
 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import { NavLink, useLocation } from 'react-router-dom'
+import { Link, NavLink } from 'react-router-dom'
 import logo from '../assets/logo.png'
 import { cn } from './ui'
 
+type NavItem = {
+  icon: LucideIcon
+  label: string
+  to: string
+  end?: boolean
+}
+
+const DASHBOARD: NavItem = { icon: LayoutDashboard, label: 'Dashboard', to: '/dashboard', end: true }
+
 const NAV_GROUPS: Array<{
   label: string
-  items: Array<{ icon: LucideIcon; label: string; to: string; prefix?: string; action?: boolean }>
+  items: NavItem[]
 }> = [
   {
-    label: 'Command center',
-    items: [{ icon: LayoutDashboard, label: 'Dashboard', to: '/dashboard' }],
-  },
-  {
-    label: 'Scope & inventory',
-    items: [{ icon: Boxes, label: 'Assets', to: '/assets', prefix: '/assets' }],
-  },
-  {
-    label: 'Assess risk',
+    label: 'Security operations',
     items: [
-      { icon: Target, label: 'Engagements', to: '/engagements', prefix: '/engagements' },
-      { icon: ShieldQuestion, label: 'AI review queue', to: '/ai-triage/reviews', prefix: '/ai-triage/reviews' },
-      { icon: Activity, label: 'AI observability', to: '/ai-triage/observability', prefix: '/ai-triage/observability' },
-      { icon: ShieldAlert, label: 'Vulnerability intelligence', to: '/vulnerability-intelligence', prefix: '/vulnerability-intelligence' },
-      { icon: Library, label: 'Rules', to: '/rules', prefix: '/rules' },
+      { icon: Target, label: 'Engagements', to: '/engagements' },
+      { icon: ShieldQuestion, label: 'Review queue', to: '/ai-triage/reviews' },
+    ],
+  },
+  {
+    label: 'Exposure management',
+    items: [
+      { icon: Boxes, label: 'Assets', to: '/assets' },
+      { icon: ShieldAlert, label: 'Vulnerability intelligence', to: '/vulnerability-intelligence' },
     ],
   },
   {
     label: 'Security engineering',
     items: [
-      { icon: Gauge, label: 'Code Quality', to: '/code-quality', prefix: '/code-quality' },
-      { icon: Server, label: 'Fleet', to: '/fleet', prefix: '/fleet' },
+      { icon: Gauge, label: 'Code Quality', to: '/code-quality' },
+      { icon: Library, label: 'Rules', to: '/rules' },
     ],
   },
   {
-    label: 'Govern & evidence',
+    label: 'Runtime security',
+    items: [
+      { icon: Server, label: 'Fleet', to: '/fleet' },
+      { icon: Activity, label: 'Automation observability', to: '/ai-triage/observability' },
+    ],
+  },
+  {
+    label: 'Governance',
     items: [
       { icon: ScrollText, label: 'Audit log', to: '/audit' },
       { icon: Users, label: 'Team', to: '/team' },
     ],
   },
-]
-
-const SOON: { icon: LucideIcon; label: string }[] = [
-  { icon: Radar, label: 'Recon' },
-  { icon: FileText, label: 'Reports' },
-  { icon: Settings, label: 'Settings' },
 ]
 
 type Theme = 'light' | 'dark'
@@ -91,7 +94,6 @@ function currentTheme(): Theme {
 }
 
 function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; onNavigate?: () => void }) {
-  const location = useLocation()
   const [theme, setTheme] = useState<Theme>(currentTheme)
 
   useEffect(() => {
@@ -111,32 +113,32 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
     setTheme(next)
   }
 
-  function renderItems(items: (typeof NAV_GROUPS)[number]['items']) {
-    return items.map(({ icon: Icon, label, to, prefix, action }) => {
-      const active = prefix ? location.pathname.startsWith(prefix) : location.pathname === to
-      return (
-        <NavLink
-          key={to}
-          to={to}
-          title={collapsed ? label : undefined}
-          aria-label={collapsed ? label : undefined}
-          onClick={onNavigate}
-          className={cn(
-            'relative flex min-h-10 items-center rounded-lg text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/70',
-            collapsed ? 'justify-center px-2' : 'gap-3 px-3',
-            active
-              ? 'bg-navactive font-semibold text-white'
-              : action
-                ? 'border border-brand/30 bg-brand/10 font-semibold text-navfg hover:bg-brand/20'
-                : 'text-navmuted hover:bg-navhover hover:text-navfg',
-          )}
-        >
-          <Icon className={cn('size-[18px] shrink-0', action && !active && 'text-branddim')} aria-hidden="true" />
-          <span className={collapsed ? 'sr-only' : undefined}>{label}</span>
-          {active && <span className="absolute inset-y-2 left-0 w-0.5 rounded-r-full bg-brand" />}
-        </NavLink>
-      )
-    })
+  function renderItems(items: NavItem[]) {
+    return items.map(({ icon: Icon, label, to, end }) => (
+      <NavLink
+        key={to}
+        to={to}
+        end={end}
+        title={collapsed ? label : undefined}
+        aria-label={collapsed ? label : undefined}
+        onClick={onNavigate}
+        className={({ isActive }) => cn(
+          'relative flex min-h-10 items-center rounded-lg text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/70',
+          collapsed ? 'justify-center px-2' : 'gap-3 px-3',
+          isActive
+            ? 'bg-navactive font-semibold text-white'
+            : 'text-navmuted hover:bg-navhover hover:text-navfg',
+        )}
+      >
+        {({ isActive }) => (
+          <>
+            <Icon className="size-[18px] shrink-0" aria-hidden="true" />
+            <span className={collapsed ? 'sr-only' : undefined}>{label}</span>
+            {isActive && <span className="absolute inset-y-2 left-0 w-0.5 rounded-r-full bg-brand" />}
+          </>
+        )}
+      </NavLink>
+    ))
   }
 
   return (
@@ -149,39 +151,32 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
         </div>
       </div>
 
-      <nav className="flex-1 overflow-y-auto px-3 py-4" aria-label="Primary navigation">
-        {NAV_GROUPS.map((group, index) => collapsed ? (
-          <div key={group.label} className={cn('space-y-1', index > 0 && 'mt-3')}>{renderItems(group.items)}</div>
-        ) : (
-          <details key={group.label} open className={cn('group', index > 0 && 'mt-4')}>
-            <summary className="mb-1.5 flex cursor-pointer list-none items-center justify-between rounded-md px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-navsubtle transition-colors hover:text-navmuted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/70 [&::-webkit-details-marker]:hidden">
-              {group.label}
-              <ChevronDown className="size-3.5 transition-transform group-open:rotate-180" />
-            </summary>
-            <div className="space-y-1">{renderItems(group.items)}</div>
-          </details>
-        ))}
+      <div className="border-b border-navborder p-3">
+        <Link
+          to="/engagements/new"
+          title={collapsed ? 'New Engagement' : undefined}
+          aria-label={collapsed ? 'New Engagement' : undefined}
+          onClick={onNavigate}
+          className={cn(
+            'btn-primary flex min-h-10 items-center justify-center rounded-lg text-sm font-semibold text-brandfg transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/70 focus-visible:ring-offset-2 focus-visible:ring-offset-nav',
+            collapsed ? 'px-2' : 'gap-2 px-3',
+          )}
+        >
+          <Plus className="size-[18px] shrink-0" aria-hidden="true" />
+          <span className={collapsed ? 'sr-only' : undefined}>New Engagement</span>
+        </Link>
+      </div>
 
-        <div className="mt-5">
-          <div className={cn('mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-[0.16em] text-navsubtle', collapsed && 'sr-only')}>
-            Coming soon
-          </div>
-          <div className="space-y-1">
-            {SOON.map(({ icon: Icon, label }) => (
-              <span
-                key={label}
-                title={collapsed ? `${label} · Coming soon` : 'Coming soon'}
-                className={cn(
-                  'flex min-h-10 cursor-not-allowed items-center rounded-lg text-sm text-navsubtle/60',
-                  collapsed ? 'justify-center px-2' : 'gap-3 px-3',
-                )}
-              >
-                <Icon className="size-[18px] shrink-0" aria-hidden="true" />
-                <span className={collapsed ? 'sr-only' : undefined}>{label}</span>
-              </span>
-            ))}
-          </div>
-        </div>
+      <nav className="flex-1 overflow-y-auto px-3 py-4" aria-label="Primary navigation">
+        <div className="space-y-1">{renderItems([DASHBOARD])}</div>
+        {NAV_GROUPS.map((group) => (
+          <section key={group.label} aria-label={group.label} className="mt-4">
+            <h2 className={cn('mb-1.5 px-3 text-[10px] font-semibold uppercase tracking-[0.16em] text-navsubtle', collapsed && 'sr-only')}>
+              {group.label}
+            </h2>
+            <div className="space-y-1">{renderItems(group.items)}</div>
+          </section>
+        ))}
       </nav>
 
       <div className="border-t border-navborder p-3">

--- a/web/src/pages/Engagements.test.tsx
+++ b/web/src/pages/Engagements.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Sidebar } from '../components/Sidebar'
 import { api } from '../lib/api'
 import { Engagements, NewEngagement } from './Engagements'
 
@@ -53,5 +54,22 @@ describe('Engagements', () => {
     expect(screen.getByRole('heading', { name: 'Engagement details' })).toBeInTheDocument()
     expect((await screen.findAllByText('Mobile Banking (mobile)')).length).toBeGreaterThan(0)
     await waitFor(() => expect(api.listBusinessAssets).toHaveBeenCalledWith('limit=200'))
+  })
+
+  it('navigates to the dedicated creation route from the sidebar', async () => {
+    render(
+      <MemoryRouter initialEntries={['/engagements']}>
+        <Sidebar />
+        <Routes>
+          <Route path="/engagements" element={<Engagements />} />
+          <Route path="/engagements/new" element={<NewEngagement />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await screen.findByText('No engagements yet')
+    const newEngagementLinks = screen.getAllByRole('link', { name: 'New Engagement' })
+    fireEvent.click(newEngagementLinks[0])
+    expect(await screen.findByRole('heading', { name: 'New Engagement' })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Reorganizes the dashboard sidebar around operator workflows from the unified control-plane roadmap and vulnerability-intelligence workspace.

## Changes

- separates `New Engagement` into a persistent CTA while keeping `Engagements` as the active destination
- groups shipped routes into security operations, exposure management, engineering, runtime, and governance
- removes unavailable `Coming soon` placeholders from primary navigation
- uses React Router `NavLink` state instead of manual pathname matching
- keeps the engagement create form synchronized when the CTA changes query parameters on an already-mounted route
- adds regression coverage and an Unreleased changelog entry

Context: #405, #519

## Validation

- [x] `make build vet test typecheck`
- [x] `cd web && pnpm test` (39 files, 312 tests)
- [x] `cd web && pnpm build`
- [x] Tests added/updated for new behavior
- [x] Preserves existing safety invariants
- [x] Documentation updated via `CHANGELOG.md`

Authenticated browser QA was blocked by the local API session rejecting its stored token; the app shell rendered without a framework error overlay, and component interaction coverage validates the sidebar CTA and active states.
