### PR TITLE
feat(sla): complete governed remediation lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -309,6 +309,15 @@ SYNAPSE_GOMODGRAPH_ENABLED=true      # transitive Go dep edges via `go mod graph
 # SYNAPSE_VULNERABILITY_TENANT_ALLOWLIST=       # tenant-a,tenant-b or *
 
 # =============================================================================
+# Risk-based remediation SLA governance – opt-in
+# =============================================================================
+# Creates versioned, reproducible remediation deadlines for persisted findings and reassesses them
+# when continuous vulnerability intelligence changes. Human lifecycle state and accepted-risk
+# decisions are never overwritten by scanner/AI refreshes. Reviewer permission is required for
+# lifecycle transitions; administrator permission is required to activate a tenant policy.
+# SYNAPSE_SLA_ENABLED=false
+
+# =============================================================================
 # DAST (authenticated crawling + first-party checks) – bounded, sandboxed
 # =============================================================================
 # Runs through the governed workflow (scope + HITL + kernel egress). Limits below

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ capabilities below are already shipped on `main`.
 
 ### Added
 
+- **Risk-based remediation SLA governance.** Adds opt-in, tenant/RLS-safe and versioned SLA policy,
+  immutable deterministic assessment history, mitigate/remediate deadlines in scan/API/UI output,
+  human-only open/mitigating/remediated/accepted-risk transitions with hard acceptance expiry, and
+  continuous vulnerability-intelligence reassessment that preserves human state. Replays cannot move
+  an original deadline, machine principals cannot accept risk, and remediated findings cannot be
+  silently reopened; re-exposure remains explicit review work.
+
 - **Adversarial invariance gate for AI-triage promotion.** Golden datasets can bind a clean control to
   semantically equivalent prompt-injection challenges. Evaluation reports emit source-free pair evidence,
   and the comparison/release boundary requires complete coverage plus zero proposer, verifier, consensus,

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1966,7 +1966,7 @@ components:
 
     SLAAssessment:
       type: object
-      required: [tenant_id, id, engagement_id, finding_id, inputs, result, input_hash, config_hash, assessed_at, created_at]
+      required: [tenant_id, id, engagement_id, finding_id, inputs, result, input_hash, config_hash, deadline_anchor_at, assessed_at, created_at]
       properties:
         tenant_id: {type: string}
         id: {type: string}
@@ -1978,6 +1978,7 @@ components:
         input_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
         config_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
         previous_assessment_id: {type: string}
+        deadline_anchor_at: {type: string, format: date-time}
         assessed_at: {type: string, format: date-time}
         created_at: {type: string, format: date-time}
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -40,6 +40,8 @@ tags:
   description: Tenant-scoped security operations summaries
 - name: vulnerability-intelligence
   description: Tenant-scoped vulnerability feeds, exposure correlation, risk transitions, and durable operations
+- name: remediation-sla
+  description: Risk-based remediation deadlines, immutable assessments, policy versions, and human-owned lifecycle governance
 
 paths:
   /healthz:
@@ -1593,6 +1595,142 @@ paths:
         '403': {$ref: '#/components/responses/Forbidden'}
         '404': {$ref: '#/components/responses/NotFound'}
 
+  /api/v1/sla/policies:
+    get:
+      tags: [remediation-sla]
+      operationId: listSLAPolicies
+      summary: List immutable SLA policy versions and the active version
+      description: Requires view permission. The built-in policy is installed on first use when no tenant policy exists.
+      responses:
+        '200':
+          description: Active policy and append-only tenant policy history
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/SLAPolicyList'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+    post:
+      tags: [remediation-sla]
+      operationId: activateSLAPolicy
+      summary: Validate, append, and activate an SLA policy version
+      description: Requires administer permission and a human principal. Existing assessments are never rewritten.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [config]
+              properties:
+                config: {$ref: '#/components/schemas/SLAConfig'}
+      responses:
+        '200': {description: Existing identical policy selected, content: {application/json: {schema: {$ref: '#/components/schemas/SLAPolicyActivation'}}}}
+        '201': {description: New immutable policy created and selected, content: {application/json: {schema: {$ref: '#/components/schemas/SLAPolicyActivation'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+
+  /api/v1/engagements/{id}/slas:
+    parameters: [{$ref: '#/components/parameters/EngagementId'}]
+    get:
+      tags: [remediation-sla, findings]
+      operationId: listEngagementSLAs
+      summary: List current remediation SLA views for an engagement
+      description: Time-sensitive overdue and acceptance-expiry fields are calculated at read time.
+      responses:
+        '200':
+          description: Current SLA views
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [slas]
+                properties:
+                  slas: {type: array, items: {$ref: '#/components/schemas/SLAView'}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
+  /api/v1/engagements/{id}/slas/{fid}:
+    parameters:
+    - $ref: '#/components/parameters/EngagementId'
+    - $ref: '#/components/parameters/FindingId'
+    get:
+      tags: [remediation-sla, findings]
+      operationId: getFindingSLA
+      summary: Get the current SLA assessment and remediation lifecycle for a finding
+      responses:
+        '200': {description: Current SLA view, content: {application/json: {schema: {$ref: '#/components/schemas/SLAView'}}}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
+  /api/v1/engagements/{id}/slas/{fid}/assessments:
+    parameters:
+    - $ref: '#/components/parameters/EngagementId'
+    - $ref: '#/components/parameters/FindingId'
+    get:
+      tags: [remediation-sla, findings]
+      operationId: listSLAAssessmentHistory
+      summary: List immutable SLA assessments for a finding
+      responses:
+        '200':
+          description: Oldest-to-newest assessment history
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [assessments]
+                properties:
+                  assessments: {type: array, items: {$ref: '#/components/schemas/SLAAssessment'}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
+  /api/v1/engagements/{id}/slas/{fid}/events:
+    parameters:
+    - $ref: '#/components/parameters/EngagementId'
+    - $ref: '#/components/parameters/FindingId'
+    get:
+      tags: [remediation-sla, findings]
+      operationId: listSLALifecycleEvents
+      summary: List append-only human remediation lifecycle events
+      responses:
+        '200':
+          description: Oldest-to-newest lifecycle audit history
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [events]
+                properties:
+                  events: {type: array, items: {$ref: '#/components/schemas/SLALifecycleEvent'}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
+  /api/v1/engagements/{id}/slas/{fid}/transition:
+    parameters:
+    - $ref: '#/components/parameters/EngagementId'
+    - $ref: '#/components/parameters/FindingId'
+    post:
+      tags: [remediation-sla, findings]
+      operationId: transitionFindingSLA
+      summary: Apply an optimistic-concurrency protected human remediation decision
+      description: Machine principals are rejected. Accepted risk requires a reason, compensating control, and future expiry; remediated is terminal.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/SLATransitionRequest'}
+      responses:
+        '200': {description: Updated current SLA view, content: {application/json: {schema: {$ref: '#/components/schemas/SLAView'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Lifecycle version changed since it was loaded, content: {application/json: {schema: {$ref: '#/components/schemas/Error'}}}}
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1605,6 +1743,11 @@ components:
       in: path
       required: true
       schema: {type: string}
+    FindingId:
+      name: fid
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
     BusinessAssetId:
       name: assetID
       in: path
@@ -1701,6 +1844,200 @@ components:
           schema: {$ref: "#/components/schemas/Error"}
 
   schemas:
+    SLATier:
+      type: string
+      enum: [emergency, critical, high, medium, low, exception]
+
+    SLARemediationStatus:
+      type: string
+      enum: [open, mitigating, remediated, accepted_risk]
+
+    SLAWeights:
+      type: object
+      required: [severity, exploitability, threat_intel, exposure, criticality, feasibility_relief]
+      properties:
+        severity: {type: number, minimum: 0}
+        exploitability: {type: number, minimum: 0}
+        threat_intel: {type: number, minimum: 0}
+        exposure: {type: number, minimum: 0}
+        criticality: {type: number, minimum: 0}
+        feasibility_relief: {type: number, minimum: 0}
+
+    SLAThresholds:
+      type: object
+      description: Inclusive lower score bounds; values must be strictly descending from emergency to medium.
+      required: [emergency, critical, high, medium]
+      properties:
+        emergency: {type: number, minimum: 0, maximum: 100}
+        critical: {type: number, minimum: 0, maximum: 100}
+        high: {type: number, minimum: 0, maximum: 100}
+        medium: {type: number, exclusiveMinimum: 0, maximum: 100}
+
+    SLADueRange:
+      type: object
+      description: Go duration values encoded as integer nanoseconds; mitigate_within must not exceed remediate_within.
+      required: [mitigate_within, remediate_within]
+      properties:
+        mitigate_within: {type: integer, format: int64, minimum: 0, example: 86400000000000}
+        remediate_within: {type: integer, format: int64, minimum: 0, example: 604800000000000}
+
+    SLADueRanges:
+      type: object
+      required: [emergency, critical, high, medium, low, exception]
+      properties:
+        emergency: {$ref: '#/components/schemas/SLADueRange'}
+        critical: {$ref: '#/components/schemas/SLADueRange'}
+        high: {$ref: '#/components/schemas/SLADueRange'}
+        medium: {$ref: '#/components/schemas/SLADueRange'}
+        low: {$ref: '#/components/schemas/SLADueRange'}
+        exception: {$ref: '#/components/schemas/SLADueRange'}
+
+    SLAConfig:
+      type: object
+      required: [weights, thresholds, due_ranges, version]
+      properties:
+        weights: {$ref: '#/components/schemas/SLAWeights'}
+        thresholds: {$ref: '#/components/schemas/SLAThresholds'}
+        due_ranges: {$ref: '#/components/schemas/SLADueRanges'}
+        version: {type: string, minLength: 1, example: sla-v2}
+
+    SLAPolicy:
+      type: object
+      required: [tenant_id, config, sha256, created_by, created_at]
+      properties:
+        tenant_id: {type: string}
+        config: {$ref: '#/components/schemas/SLAConfig'}
+        sha256: {type: string, pattern: '^[0-9a-f]{64}$'}
+        created_by: {type: string}
+        created_at: {type: string, format: date-time}
+
+    SLAPolicyList:
+      type: object
+      required: [active, policies]
+      properties:
+        active: {$ref: '#/components/schemas/SLAPolicy'}
+        policies: {type: array, items: {$ref: '#/components/schemas/SLAPolicy'}}
+
+    SLAPolicyActivation:
+      type: object
+      required: [policy, created]
+      properties:
+        policy: {$ref: '#/components/schemas/SLAPolicy'}
+        created: {type: boolean}
+
+    SLAInputs:
+      type: object
+      required: [severity, cvss_score, kev, epss, public_poc, active_exploitation]
+      properties:
+        severity: {type: string, enum: ['', info, low, medium, high, critical]}
+        cvss_score: {type: number, minimum: 0, maximum: 10}
+        kev: {type: boolean}
+        epss: {type: number, minimum: 0, maximum: 1}
+        public_poc: {type: boolean}
+        active_exploitation: {type: boolean}
+        criticality: {type: string, enum: ['', low, medium, high]}
+        exposure: {type: string, enum: ['', internal, external]}
+        feasibility: {type: string, enum: ['', patch_available, change_window, compensating_control, no_patch]}
+
+    SLABreakdown:
+      type: object
+      required: [severity, exploitability, threat_intel, exposure, criticality, feasibility]
+      properties:
+        severity: {type: number}
+        exploitability: {type: number}
+        threat_intel: {type: number}
+        exposure: {type: number}
+        criticality: {type: number}
+        feasibility: {type: number}
+        overrides: {type: array, items: {type: string}}
+
+    SLAResult:
+      type: object
+      required: [tier, score, breakdown, mitigate_by, remediate_by, reason, computed_at, config_version]
+      properties:
+        tier: {$ref: '#/components/schemas/SLATier'}
+        score: {type: number, minimum: 0, maximum: 100}
+        breakdown: {$ref: '#/components/schemas/SLABreakdown'}
+        mitigate_by: {type: string, format: date-time}
+        remediate_by: {type: string, format: date-time}
+        reason: {type: string}
+        computed_at: {type: string, format: date-time}
+        config_version: {type: string}
+
+    SLAAssessment:
+      type: object
+      required: [tenant_id, id, engagement_id, finding_id, inputs, result, input_hash, config_hash, assessed_at, created_at]
+      properties:
+        tenant_id: {type: string}
+        id: {type: string}
+        engagement_id: {type: string}
+        finding_id: {type: string}
+        source_risk_assessment_id: {type: string}
+        inputs: {$ref: '#/components/schemas/SLAInputs'}
+        result: {$ref: '#/components/schemas/SLAResult'}
+        input_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        config_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        previous_assessment_id: {type: string}
+        assessed_at: {type: string, format: date-time}
+        created_at: {type: string, format: date-time}
+
+    SLALifecycle:
+      type: object
+      required: [tenant_id, engagement_id, finding_id, assessment_id, status, version, updated_by, updated_at]
+      properties:
+        tenant_id: {type: string}
+        engagement_id: {type: string}
+        finding_id: {type: string}
+        assessment_id: {type: string}
+        status: {$ref: '#/components/schemas/SLARemediationStatus'}
+        version: {type: integer, minimum: 1}
+        reason: {type: string}
+        compensating_control: {type: string}
+        accepted_by: {type: string}
+        accepted_at: {type: string, format: date-time}
+        acceptance_expires_at: {type: string, format: date-time}
+        updated_by: {type: string}
+        updated_at: {type: string, format: date-time}
+
+    SLAView:
+      type: object
+      required: [assessment, lifecycle, effective_state, overdue, acceptance_expired]
+      properties:
+        assessment: {$ref: '#/components/schemas/SLAAssessment'}
+        lifecycle: {$ref: '#/components/schemas/SLALifecycle'}
+        effective_state: {$ref: '#/components/schemas/SLARemediationStatus'}
+        overdue: {type: boolean}
+        acceptance_expired: {type: boolean}
+
+    SLALifecycleEvent:
+      type: object
+      required: [tenant_id, id, engagement_id, finding_id, assessment_id, from, to, reason, actor, before_version, after_version, at]
+      properties:
+        tenant_id: {type: string}
+        id: {type: string}
+        engagement_id: {type: string}
+        finding_id: {type: string}
+        assessment_id: {type: string}
+        from: {$ref: '#/components/schemas/SLARemediationStatus'}
+        to: {$ref: '#/components/schemas/SLARemediationStatus'}
+        reason: {type: string}
+        compensating_control: {type: string}
+        acceptance_expires_at: {type: string, format: date-time}
+        actor: {type: string}
+        before_version: {type: integer, minimum: 1}
+        after_version: {type: integer, minimum: 2}
+        at: {type: string, format: date-time}
+
+    SLATransitionRequest:
+      type: object
+      required: [to, reason, version]
+      properties:
+        to: {$ref: '#/components/schemas/SLARemediationStatus'}
+        reason: {type: string, minLength: 1}
+        compensating_control: {type: string}
+        acceptance_expires_at: {type: string, format: date-time}
+        version: {type: integer, minimum: 1}
+
     VulnerabilityCursor:
       type: object
       required: [before_time, before_id]

--- a/api/openapi_sla_test.go
+++ b/api/openapi_sla_test.go
@@ -66,6 +66,10 @@ func TestSLAOpenAPIContract(t *testing.T) {
 	}
 
 	schemas := doc["components"].(map[string]any)["schemas"].(map[string]any)
+	assessment := schemas["SLAAssessment"].(map[string]any)
+	if !stringSet(assessment["required"].([]any))["deadline_anchor_at"] {
+		t.Error("SLAAssessment.deadline_anchor_at must be required")
+	}
 	request := schemas["SLATransitionRequest"].(map[string]any)
 	required := stringSet(request["required"].([]any))
 	for _, field := range []string{"to", "reason", "version"} {

--- a/api/openapi_sla_test.go
+++ b/api/openapi_sla_test.go
@@ -1,0 +1,97 @@
+package api_test
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestSLAOpenAPIContract protects the public surface of the feature. Router-only tests cannot detect
+// a renamed path, missing optimistic-concurrency field, or undocumented policy activation response.
+func TestSLAOpenAPIContract(t *testing.T) {
+	b, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	paths := doc["paths"].(map[string]any)
+	want := map[string]map[string]string{
+		"/api/v1/sla/policies": {
+			"get": "listSLAPolicies", "post": "activateSLAPolicy",
+		},
+		"/api/v1/engagements/{id}/slas": {
+			"get": "listEngagementSLAs",
+		},
+		"/api/v1/engagements/{id}/slas/{fid}": {
+			"get": "getFindingSLA",
+		},
+		"/api/v1/engagements/{id}/slas/{fid}/assessments": {
+			"get": "listSLAAssessmentHistory",
+		},
+		"/api/v1/engagements/{id}/slas/{fid}/events": {
+			"get": "listSLALifecycleEvents",
+		},
+		"/api/v1/engagements/{id}/slas/{fid}/transition": {
+			"post": "transitionFindingSLA",
+		},
+	}
+	for path, methods := range want {
+		route, ok := paths[path].(map[string]any)
+		if !ok {
+			t.Errorf("SLA route %s missing", path)
+			continue
+		}
+		for method, operationID := range methods {
+			op, ok := route[method].(map[string]any)
+			if !ok {
+				t.Errorf("SLA route %s missing %s", path, method)
+				continue
+			}
+			if got := op["operationId"]; got != operationID {
+				t.Errorf("%s %s operationId=%v, want %s", method, path, got, operationID)
+			}
+		}
+	}
+
+	transition := paths["/api/v1/engagements/{id}/slas/{fid}/transition"].(map[string]any)["post"].(map[string]any)
+	responses := transition["responses"].(map[string]any)
+	for _, status := range []string{"200", "400", "401", "403", "404", "409"} {
+		if _, ok := responses[status]; !ok {
+			t.Errorf("SLA transition response %s missing", status)
+		}
+	}
+
+	schemas := doc["components"].(map[string]any)["schemas"].(map[string]any)
+	request := schemas["SLATransitionRequest"].(map[string]any)
+	required := stringSet(request["required"].([]any))
+	for _, field := range []string{"to", "reason", "version"} {
+		if !required[field] {
+			t.Errorf("SLATransitionRequest.%s must be required", field)
+		}
+	}
+	status := schemas["SLARemediationStatus"].(map[string]any)
+	wantStatuses := []string{"open", "mitigating", "remediated", "accepted_risk"}
+	gotStatuses := status["enum"].([]any)
+	if len(gotStatuses) != len(wantStatuses) {
+		t.Fatalf("SLA status count=%d, want %d", len(gotStatuses), len(wantStatuses))
+	}
+	for i, wantStatus := range wantStatuses {
+		if gotStatuses[i] != wantStatus {
+			t.Errorf("SLA status[%d]=%v, want %s", i, gotStatuses[i], wantStatus)
+		}
+	}
+}
+
+func stringSet(values []any) map[string]bool {
+	result := make(map[string]bool, len(values))
+	for _, value := range values {
+		if text, ok := value.(string); ok {
+			result[text] = true
+		}
+	}
+	return result
+}

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -156,6 +156,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/sarifingest"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/sbomcrosscheckjudge"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/slauc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/srcreach"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/taintscan"
 	threatmodeluc "github.com/KKloudTarus/synapse-ce/internal/usecase/threatmodeluc"
@@ -287,6 +288,7 @@ func main() {
 	var vulnerabilityActions ports.VulnerabilityActionStore
 	var vulnerabilityReconcileRuns ports.VulnerabilityReconcileRunStore
 	var vulnerabilityTransactions ports.TenantTransactionRunner
+	var slaStore ports.SLAStore
 	var vulnerabilityWorker *worker.Worker
 	var reconRunLock ports.RunLocker              // recon run lease (Postgres only); row-lease, no pinned conn
 	var agentRunLock ports.RunLocker              // agent SESSION lock (advisory; cannot expire mid-LLM-loop)
@@ -439,6 +441,7 @@ func main() {
 		vulnerabilityActions = postgres.NewVulnerabilityActionStore(pool)
 		vulnerabilityReconcileRuns = postgres.NewVulnerabilityReconcileRunStore(pool, ids)
 		vulnerabilityTransactions = postgres.NewTenantTransactionRunner(pool)
+		slaStore = postgres.NewSLAStore(pool)
 		// Shared by recon AND the in-process SCA worker, so the base lease TTL must cover the
 		// longer of the two timeouts (the renewer extends it while live, but the base must not
 		// be shorter than a max-length scan). row-lease: no pinned conn.
@@ -514,6 +517,7 @@ func main() {
 		vulnerabilityAssessments = memory.NewVulnerabilityRiskAssessmentStore()
 		vulnerabilityActions = memory.NewVulnerabilityActionStore()
 		vulnerabilityReconcileRuns = memory.NewVulnerabilityReconcileRunStore(ids, clock, vulnerabilityQueue)
+		slaStore = memory.NewSLAStore()
 		agentSessionStore = memory.NewAgentSessionStore()
 		approvalStore = memory.NewApprovalStore()
 		planStore = memory.NewPlanStore()
@@ -744,6 +748,17 @@ func main() {
 		enry.New(), sbomGen,
 		detectionSources,
 		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil), licensemeta.NewPyPI("", nil)))
+	var slaService *slauc.Service
+	if cfg.SLAEnabled {
+		var slaErr error
+		slaService, slaErr = slauc.NewService(slaStore, clock, ids)
+		if slaErr != nil {
+			log.Error("sla governance service init failed", "err", slaErr)
+			os.Exit(1)
+		}
+		scaService.SetSLAAssessor(slaService)
+		log.Info("risk-based remediation SLA governance ENABLED")
+	}
 	scaService.SetImportedSBOMStore(importedSBOMStore)
 	// Record scanned image digests so the fleet cluster agent can correlate running images (#446).
 	scaService.SetScannedImageRecorder(scannedImageStore)
@@ -1135,6 +1150,9 @@ func main() {
 		os.Exit(1)
 	}
 	router := httpapi.NewRouter(log, auth, engService, scaService, aupService, findingsService, exportService, reportService, evidenceService, reconService, logBroker, transferService, auditService, vexService, usersService, credentialsService)
+	if slaService != nil {
+		router.SetSLA(slaService)
+	}
 	vulnerabilityRollout, err := vulnerabilityrollout.New(vulnerabilityrollout.Config{
 		ProviderSync: cfg.VulnerabilityProviderSyncEnabled, OccurrenceWrites: cfg.VulnerabilityOccurrenceWritesEnabled,
 		FindingProjection: cfg.VulnerabilityFindingProjectionEnabled, Actions: cfg.VulnerabilityActionsEnabled,
@@ -1179,6 +1197,9 @@ func main() {
 	}
 	vulnerabilityEvaluator.SetActionStore(vulnerabilityActions)
 	vulnerabilityEvaluator.SetRollout(vulnerabilityRollout)
+	if slaService != nil {
+		vulnerabilityEvaluator.SetSLAAssessor(slaService)
+	}
 	vulnerabilityActionService, err := vulnerabilityactionuc.NewService(vulnerabilityActions, auditLog, clock)
 	if err != nil {
 		log.Error("vulnerability action service init failed", "err", err)

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -81,6 +81,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fptriage"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/slauc"
 )
 
 func main() {
@@ -590,7 +591,10 @@ func runRating(args []string) error {
 			return fmt.Errorf("unknown or incomplete option %q", args[i])
 		}
 	}
-	ctx := context.Background()
+	// The standalone CLI is the single-tenant deployment boundary. Bind the same canonical tenant
+	// the API's in-memory mode uses so optional tenant-aware services (including SLA governance) do
+	// not need a weaker persistence contract just for dogfood scans.
+	ctx := shared.WithTenant(context.Background(), shared.DefaultTenant)
 
 	inv, err := codeinventory.New().Inventory(ctx, dir)
 	if err != nil {
@@ -1197,6 +1201,13 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 		detectionSources,
 		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil), licensemeta.NewPyPI("", nil)),
 	)
+	if cfg.SLAEnabled {
+		slaService, slaErr := slauc.NewService(memory.NewSLAStore(), clock, ids)
+		if slaErr != nil {
+			return fmt.Errorf("configure remediation SLA: %w", slaErr)
+		}
+		sca.SetSLAAssessor(slaService)
+	}
 	sca.SetProjectAnalysisCompletionTimeout(cfg.ProjectAnalysisCompletionTimeout)
 	sca.SetProjectComparisonSource(&gitdiff.ComparisonSource{})
 	sca.SetGateDecoder(qualityprofile.LoadGateBytes)
@@ -1623,6 +1634,20 @@ func printReport(target string, res *scauc.ScanResult) {
 		fmt.Printf("  reachability (JVM, coarse): %d referenced, %d unreferenced by app code\n", reach, unref)
 	}
 	fmt.Printf("  findings (promoted): %d\n", len(res.Findings))
+	if len(res.SLAs) > 0 {
+		overdue := 0
+		for _, item := range res.SLAs {
+			if item.Overdue {
+				overdue++
+			}
+			fmt.Printf("    SLA %-9s %-13s mitigate %s · remediate %s · %s\n",
+				item.Assessment.Result.Tier, item.EffectiveState,
+				item.Assessment.Result.MitigateBy.Format("2006-01-02"),
+				item.Assessment.Result.RemediateBy.Format("2006-01-02"), item.Assessment.FindingID)
+		}
+		fmt.Printf("  remediation SLA: %d assessed, %d overdue (policy %s)\n",
+			len(res.SLAs), overdue, res.SLAs[0].Assessment.Result.ConfigVersion)
+	}
 	if res.VulnsBelowThreshold > 0 {
 		fmt.Printf("  ! %d detected vulnerabilities are BELOW the '%s' severity floor and were NOT promoted "+
 			"(set SYNAPSE_FINDING_MIN_SEVERITY=info to promote every detected vuln)\n", res.VulnsBelowThreshold, res.MinSeverity)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -186,6 +186,7 @@ All off by default. The fleet needs PostgreSQL + `synapse-worker`; agents run on
 | `SYNAPSE_VULNERABILITY_NOTIFICATIONS_ENABLED` | `false` | Permit notification-outbox writes for allowlisted tenants. |
 | `SYNAPSE_VULNERABILITY_DRY_RUN_ENABLED` | `true` | Persist reconciliation diffs and counts without occurrence, finding, action, or notification mutations. |
 | `SYNAPSE_VULNERABILITY_TENANT_ALLOWLIST` | empty | Comma-separated tenant IDs allowed to use tenant-scoped gates and dry-run; `*` enables every tenant. Empty fails closed. |
+| `SYNAPSE_SLA_ENABLED` | `false` | Enable versioned risk-based remediation deadlines, immutable assessment history, human-only lifecycle transitions, and continuous-intelligence reassessment. See [Remediation SLA governance](sla-governance.md). |
 | `SYNAPSE_DAST_RATE_PER_SEC` | `5` | DAST crawler request rate. |
 | `SYNAPSE_DAST_CONCURRENCY` | `4` | DAST crawler concurrency. |
 | `SYNAPSE_DAST_MAX_DEPTH` | `8` | Maximum crawl depth. |

--- a/docs/guide/sla-governance.md
+++ b/docs/guide/sla-governance.md
@@ -156,6 +156,16 @@ Assessment writes serialize on the stable tenant/engagement/finding identity. Th
 first-write case where no row exists to lock and ensures concurrent material updates produce a
 single ordered history rather than sibling assessments with the same predecessor.
 
+The first assessment also fixes `deadline_anchor_at` for the complete finding chain. Later risk or
+policy assessments rebase their tier windows to that original anchor and retain the earlier of the
+old and newly calculated deadlines, so a rescan, de-escalation, or late emergency escalation cannot
+silently reset or extend the remediation clock. CVSS/EPSS movement within the same effective scoring
+band is retained as upstream risk provenance but does not create a duplicate SLA assessment.
+
+Policies, assessments, and lifecycle events are protected by PostgreSQL append-only triggers in
+addition to application conventions and RLS. In-place UPDATE, DELETE, and TRUNCATE operations are
+rejected; mutable active/current pointers and lifecycle state remain separate.
+
 ## Rollout guidance
 
 1. Apply migrations with the DDL owner and run the API with a non-superuser, non-`BYPASSRLS`

--- a/docs/guide/sla-governance.md
+++ b/docs/guide/sla-governance.md
@@ -162,9 +162,12 @@ old and newly calculated deadlines, so a rescan, de-escalation, or late emergenc
 silently reset or extend the remediation clock. CVSS/EPSS movement within the same effective scoring
 band is retained as upstream risk provenance but does not create a duplicate SLA assessment.
 
-Policies, assessments, and lifecycle events are protected by PostgreSQL append-only triggers in
-addition to application conventions and RLS. In-place UPDATE, DELETE, and TRUNCATE operations are
-rejected; mutable active/current pointers and lifecycle state remain separate.
+Policies reject in-place `UPDATE`, `DELETE`, and `TRUNCATE` through PostgreSQL triggers. Assessments
+and lifecycle events reject `UPDATE` and `TRUNCATE`, while their `DELETE` follows the repository's
+intentional finding/engagement/project cascade contract. This keeps retained history immutable
+without blocking project deletion or partially-materialized-import rollback. The assessment
+self-reference also cascades explicitly, so multi-hop chains tear down as one aggregate. Mutable
+active/current pointers and lifecycle state remain separate.
 
 ## Rollout guidance
 

--- a/docs/guide/sla-governance.md
+++ b/docs/guide/sla-governance.md
@@ -1,0 +1,172 @@
+# Remediation SLA governance
+
+Synapse can turn finding risk into a governed remediation clock. The feature builds on the pure,
+deterministic SLA scorer and adds the operational pieces needed to use its output safely:
+
+- tenant-owned, versioned policy;
+- immutable, reproducible assessments and history;
+- one current assessment pointer per finding;
+- a separate human-owned remediation lifecycle;
+- append-only transition evidence; and
+- reassessment when continuous vulnerability intelligence changes.
+
+It is off by default:
+
+```bash
+SYNAPSE_SLA_ENABLED=true
+```
+
+After enabling it, a new scan assesses every persisted finding. When continuous vulnerability
+intelligence projection is also enabled, a material change to CVSS, KEV, EPSS, public exploit,
+active exploitation, or fix availability creates a new SLA assessment. A new source risk-assessment
+ID with the same SLA-relevant facts is provenance-only and cannot move the existing deadline.
+
+## Safety model
+
+SLA scoring and remediation workflow are deliberately separate.
+
+The scorer owns machine-derived facts: score, tier, explanation, due dates, config version, input
+hash, and source assessment. The remediation lifecycle owns human decisions: open, mitigating,
+remediated, accepted risk, reason, compensating control, actor, and acceptance expiry.
+
+This boundary enforces several invariants:
+
+1. A scanner or intelligence refresh may advance the current assessment pointer but cannot change a
+   lifecycle status, reason, actor, accepted-risk expiry, or optimistic version.
+2. Replaying identical material input returns the original immutable assessment. Its deadlines do
+   not move forward just because another scan ran.
+3. A changed input or policy creates another assessment linked through `previous_assessment_id`.
+4. Accepted risk is effective only before its expiry. At and after expiry every read treats the
+   lifecycle as open, even if a scheduler did not run.
+5. Machine principal families (`agent:`, `llm:`, `mcp:`, `system:`, `machine:`, `bot:`, and
+   `service:`) cannot make a remediation decision.
+6. Remediated is terminal for automatic and ordinary manual transitions. New intelligence creates
+   reassessment and the existing re-exposure review action; it does not silently reopen the human
+   workflow.
+
+## Default policy
+
+The built-in `sla-v1` policy is installed for a tenant on first use. It scores a bounded `0..100`
+urgency from these factors:
+
+| Factor | Maximum points | Notes |
+| --- | ---: | --- |
+| Severity | 35 | Uses CVSS base score when available, otherwise the severity label. |
+| Exploitability | 25 | KEV is maximal; EPSS is mapped through stable bands. |
+| Threat intelligence | 10 | Active exploitation has full weight; public PoC has half. |
+| Exposure | 15 | Unknown is neutral rather than falsely safe. |
+| Asset criticality | 15 | Unknown is neutral rather than falsely safe. |
+| Feasibility relief | -15 | A bounded relief; it cannot make the score negative. |
+
+Deterministic overrides then apply:
+
+- active exploitation becomes emergency;
+- KEV on an externally exposed asset escalates one tier; and
+- a non-KEV vulnerability without a patch routes to the governed exception tier.
+
+Overrides may escalate urgency or route to exception. They cannot silently de-escalate a score.
+
+Default due windows are:
+
+| Tier | Mitigate within | Remediate within |
+| --- | ---: | ---: |
+| Emergency | 1 day | 7 days |
+| Critical | 3 days | 15 days |
+| High | 7 days | 30 days |
+| Medium | 30 days | 90 days |
+| Low | 90 days | 180 days |
+| Exception | 30 days | 180 days |
+
+The scanner currently maps only facts it owns. It does not infer asset criticality or network
+exposure from source reachability. Those inputs stay unknown/neutral unless a future governed asset
+binding supplies them. Continuous intelligence retains additional public-exploit and active-
+exploitation reason codes that are not present on a legacy finding row.
+
+## Web workflow
+
+Open an engagement and select **Remediation SLA**. The view shows:
+
+- overdue, emergency, accepted-risk, and remediated counts;
+- current tier and explainable score;
+- mitigate-by and remediate-by timestamps;
+- effective workflow state and optimistic version; and
+- the policy version that produced the assessment.
+
+A reviewer can transition a non-terminal finding. Every transition requires a reason. Accepted risk
+also requires a compensating control and an explicit future expiry. If another reviewer or a risk
+refresh changed the record, the request returns a conflict; reload and decide against the current
+version.
+
+## HTTP API
+
+Read operations require `view`; transitions require `review`; policy activation requires
+`administer`.
+
+```text
+GET  /api/v1/engagements/{engagement}/slas
+GET  /api/v1/engagements/{engagement}/slas/{finding}
+GET  /api/v1/engagements/{engagement}/slas/{finding}/assessments
+GET  /api/v1/engagements/{engagement}/slas/{finding}/events
+POST /api/v1/engagements/{engagement}/slas/{finding}/transition
+GET  /api/v1/sla/policies
+POST /api/v1/sla/policies
+```
+
+Example mitigation transition:
+
+```json
+{
+  "to": "mitigating",
+  "reason": "Emergency maintenance is approved",
+  "version": 1
+}
+```
+
+Example accepted-risk transition:
+
+```json
+{
+  "to": "accepted_risk",
+  "reason": "The supported vendor upgrade is scheduled",
+  "compensating_control": "WAF rule and network isolation",
+  "acceptance_expires_at": "2026-09-30T17:00:00Z",
+  "version": 2
+}
+```
+
+Policy activation takes the complete declarative `Config` object under `config`. Go durations are
+encoded as integer nanoseconds in this API version. The server validates the version, weights,
+strictly descending thresholds, every due range, and a SHA-256 digest before it can become active.
+An existing version cannot be rewritten with different content.
+
+## Persistence and tenant isolation
+
+Migration `0103_sla_governance.sql` creates six tables:
+
+- `sla_policies` and `sla_active_policies`;
+- `sla_assessments` and `sla_current_assessments`; and
+- `sla_lifecycles` and `sla_lifecycle_events`.
+
+Every table carries `tenant_id`, enables and forces PostgreSQL row-level security, and is accessed
+through a tenant-bound transaction. Composite foreign keys bind assessments to the exact
+tenant/engagement/finding. The in-memory adapter implements the same tenant checks for development
+and tests.
+
+Assessment writes serialize on the stable tenant/engagement/finding identity. This protects the
+first-write case where no row exists to lock and ensures concurrent material updates produce a
+single ordered history rather than sibling assessments with the same predecessor.
+
+## Rollout guidance
+
+1. Apply migrations with the DDL owner and run the API with a non-superuser, non-`BYPASSRLS`
+   runtime role.
+2. Enable SLA governance in a test tenant and run a scan.
+3. Inspect the Remediation SLA tab and confirm policy/due windows match your program.
+4. Exercise accepted-risk expiry and optimistic conflicts with reviewer accounts.
+5. If continuous intelligence is enabled, change an advisory signal and confirm the assessment
+   advances while human lifecycle state stays unchanged.
+6. Activate a tenant-specific policy only after review; existing assessments remain historical and
+   adopt the new version only when explicitly reassessed.
+
+Disabling `SYNAPSE_SLA_ENABLED` removes routes and stops new assessments. It does not delete policy,
+assessment, lifecycle, or event history, so rollback is non-destructive.

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -30,6 +30,7 @@ import (
 	reconuc "github.com/KKloudTarus/synapse-ce/internal/usecase/recon"
 	reportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/report"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/slauc"
 	transferuc "github.com/KKloudTarus/synapse-ce/internal/usecase/transfer"
 	usersuc "github.com/KKloudTarus/synapse-ce/internal/usecase/users"
 	vexuc "github.com/KKloudTarus/synapse-ce/internal/usecase/vex"
@@ -92,6 +93,7 @@ type Router struct {
 	vulnerabilityAudit     ports.AuditLogger
 	vulnerabilityRead      *vulnerabilityinteluc.Service
 	vulnerabilityActions   *vulnerabilityactionuc.Service
+	sla                    *slauc.Service
 }
 
 // findingVerifier is the narrow slice of the exploitation use-case the verify endpoint needs:
@@ -209,6 +211,9 @@ func (rt *Router) SetVulnerabilityActions(actions *vulnerabilityactionuc.Service
 	rt.vulnerabilityActions = actions
 }
 
+// SetSLA wires the opt-in risk-based remediation governance API.
+func (rt *Router) SetSLA(service *slauc.Service) { rt.sla = service }
+
 // NewRouter builds the HTTP router.
 func NewRouter(log *slog.Logger, auth *Authenticator, eng *enguc.Service, sca *scauc.Service, aup *aupuc.Service, findings *findingsuc.Service, export *exportuc.Service, report *reportuc.Service, evidence *evidenceuc.Service, recon *reconuc.Service, logs ports.LogStream, transfer *transferuc.Service, audit *audituc.Service, vex *vexuc.Service, users *usersuc.Service, credentials *credentialsuc.Service) *Router {
 	return &Router{log: log, auth: auth, eng: eng, sca: sca, aup: aup, findings: findings, export: export, report: report, evidence: evidence, recon: recon, logs: logs, transfer: transfer, audit: audit, vex: vex, users: users, credentials: credentials}
@@ -289,6 +294,15 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/ai-triage/reviews", rt.authz(userdom.PermView, rt.listAITriageReviews))
 		mux.HandleFunc("POST /api/v1/ai-triage/reviews/{rid}/claim", rt.authz(userdom.PermReview, rt.claimAITriageReview))
 		mux.HandleFunc("POST /api/v1/ai-triage/reviews/{rid}/decision", rt.authz(userdom.PermReview, rt.decideAITriageReview))
+	}
+	if rt.sla != nil {
+		mux.HandleFunc("GET /api/v1/sla/policies", rt.authz(userdom.PermView, rt.listSLAPolicies))
+		mux.HandleFunc("POST /api/v1/sla/policies", rt.authz(userdom.PermAdminister, rt.activateSLAPolicy))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/slas", rt.authz(userdom.PermView, rt.withEngTenant(rt.listEngagementSLAs)))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/slas/{fid}", rt.authz(userdom.PermView, rt.withEngTenant(rt.getFindingSLA)))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/slas/{fid}/assessments", rt.authz(userdom.PermView, rt.withEngTenant(rt.listSLAAssessments)))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/slas/{fid}/events", rt.authz(userdom.PermView, rt.withEngTenant(rt.listSLAEvents)))
+		mux.HandleFunc("POST /api/v1/engagements/{id}/slas/{fid}/transition", rt.authz(userdom.PermReview, rt.withEngTenant(rt.transitionFindingSLA)))
 	}
 	if rt.sca != nil {
 		mux.HandleFunc("GET /api/v1/ai-triage/observability", rt.authz(userdom.PermView, rt.getAITriageObservability))

--- a/internal/adapter/httpapi/sla_handler.go
+++ b/internal/adapter/httpapi/sla_handler.go
@@ -1,0 +1,121 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+)
+
+func (rt *Router) listEngagementSLAs(w http.ResponseWriter, r *http.Request) {
+	items, err := rt.sla.List(r.Context(), slaTenant(r), slaEngagement(r))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"slas": items})
+}
+
+func (rt *Router) getFindingSLA(w http.ResponseWriter, r *http.Request) {
+	item, err := rt.sla.Get(r.Context(), slaTenant(r), slaEngagement(r), slaFinding(r))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, item)
+}
+
+func (rt *Router) listSLAAssessments(w http.ResponseWriter, r *http.Request) {
+	items, err := rt.sla.AssessmentHistory(r.Context(), slaTenant(r), slaEngagement(r), slaFinding(r))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"assessments": items})
+}
+
+func (rt *Router) listSLAEvents(w http.ResponseWriter, r *http.Request) {
+	items, err := rt.sla.LifecycleEvents(r.Context(), slaTenant(r), slaEngagement(r), slaFinding(r))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": items})
+}
+
+func (rt *Router) transitionFindingSLA(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		To                  sla.RemediationStatus `json:"to"`
+		Reason              string                `json:"reason"`
+		CompensatingControl string                `json:"compensating_control"`
+		AcceptanceExpiresAt *time.Time            `json:"acceptance_expires_at"`
+		Version             int                   `json:"version"`
+	}
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16<<10))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	item, err := rt.sla.Transition(r.Context(), slaTenant(r), slaEngagement(r), slaFinding(r), sla.TransitionCommand{
+		To: body.To, Reason: body.Reason, CompensatingControl: body.CompensatingControl,
+		AcceptanceExpiresAt: body.AcceptanceExpiresAt, Actor: PrincipalFrom(r.Context()), ExpectedVersion: body.Version,
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, item)
+}
+
+func (rt *Router) listSLAPolicies(w http.ResponseWriter, r *http.Request) {
+	tenantID := slaTenant(r)
+	active, err := rt.sla.ActivePolicy(r.Context(), tenantID)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	items, err := rt.sla.Policies(r.Context(), tenantID)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"active": active, "policies": items})
+}
+
+func (rt *Router) activateSLAPolicy(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Config sla.Config `json:"config"`
+	}
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	policy, created, err := rt.sla.ActivatePolicy(r.Context(), slaTenant(r), body.Config, PrincipalFrom(r.Context()))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	writeJSON(w, status, map[string]any{"policy": policy, "created": created})
+}
+
+func slaTenant(r *http.Request) shared.ID {
+	return shared.ID(strings.TrimSpace(TenantFrom(r.Context())))
+}
+
+func slaEngagement(r *http.Request) shared.ID {
+	return shared.ID(strings.TrimSpace(r.PathValue("id")))
+}
+
+func slaFinding(r *http.Request) shared.ID {
+	return shared.ID(strings.TrimSpace(r.PathValue("fid")))
+}

--- a/internal/adapter/httpapi/sla_handler_test.go
+++ b/internal/adapter/httpapi/sla_handler_test.go
@@ -1,0 +1,187 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/slauc"
+)
+
+type slaHTTPClock struct{ now time.Time }
+
+func (c *slaHTTPClock) Now() time.Time { return c.now }
+
+type slaHTTPIDs struct{ n int }
+
+func (ids *slaHTTPIDs) NewID() shared.ID {
+	ids.n++
+	return shared.ID(fmt.Sprintf("http-event-%d", ids.n))
+}
+
+func newSLARouter(t *testing.T) (*Router, *slauc.Service) {
+	t.Helper()
+	service, err := slauc.NewService(memory.NewSLAStore(), &slaHTTPClock{now: time.Date(2026, 8, 15, 14, 0, 0, 0, time.UTC)}, &slaHTTPIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := &Router{log: discardLog()}
+	router.SetSLA(service)
+	ctx := slaHTTPContext("seed", "admin")
+	if _, err := service.Assess(ctx, sla.AssessmentInput{
+		TenantID: "tenant-a", EngagementID: "eng-1", FindingID: "finding-1",
+		Risk: sla.Inputs{Severity: shared.SeverityHigh, CVSSScore: 8.1, EPSS: 0.4, Feasibility: sla.FeasibilityPatchAvailable},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return router, service
+}
+
+func slaHTTPContext(id, role string) context.Context {
+	ctx := context.WithValue(context.Background(), principalKey, Principal{ID: id, Name: id, Role: role, TenantID: "tenant-a"})
+	return shared.WithTenant(ctx, "tenant-a")
+}
+
+func slaHTTPRequest(method, target, id, role string, body []byte) *http.Request {
+	req := httptest.NewRequest(method, target, bytes.NewReader(body)).WithContext(slaHTTPContext(id, role))
+	req.SetPathValue("id", "eng-1")
+	req.SetPathValue("fid", "finding-1")
+	return req
+}
+
+func TestSLAListGetHistoryAndEventsHandlers(t *testing.T) {
+	router, service := newSLARouter(t)
+
+	listRecorder := httptest.NewRecorder()
+	router.listEngagementSLAs(listRecorder, slaHTTPRequest(http.MethodGet, "/api/v1/engagements/eng-1/slas", "reader", "readonly", nil))
+	if listRecorder.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", listRecorder.Code, listRecorder.Body.String())
+	}
+	var listBody struct {
+		SLAs []sla.View `json:"slas"`
+	}
+	if err := json.Unmarshal(listRecorder.Body.Bytes(), &listBody); err != nil || len(listBody.SLAs) != 1 || listBody.SLAs[0].Assessment.FindingID != "finding-1" {
+		t.Fatalf("list body=%s err=%v", listRecorder.Body.String(), err)
+	}
+
+	getRecorder := httptest.NewRecorder()
+	router.getFindingSLA(getRecorder, slaHTTPRequest(http.MethodGet, "/api/v1/engagements/eng-1/slas/finding-1", "reader", "readonly", nil))
+	if getRecorder.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", getRecorder.Code, getRecorder.Body.String())
+	}
+
+	ctx := slaHTTPContext("reviewer", "reviewer")
+	if _, err := service.Transition(ctx, "tenant-a", "eng-1", "finding-1", sla.TransitionCommand{
+		To: sla.RemediationMitigating, Actor: "reviewer", Reason: "patch scheduled", ExpectedVersion: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	historyRecorder := httptest.NewRecorder()
+	router.listSLAAssessments(historyRecorder, slaHTTPRequest(http.MethodGet, "/history", "reader", "readonly", nil))
+	if historyRecorder.Code != http.StatusOK || !bytes.Contains(historyRecorder.Body.Bytes(), []byte(`"assessments"`)) {
+		t.Fatalf("history status=%d body=%s", historyRecorder.Code, historyRecorder.Body.String())
+	}
+	eventsRecorder := httptest.NewRecorder()
+	router.listSLAEvents(eventsRecorder, slaHTTPRequest(http.MethodGet, "/events", "reader", "readonly", nil))
+	if eventsRecorder.Code != http.StatusOK || !bytes.Contains(eventsRecorder.Body.Bytes(), []byte(`"patch scheduled"`)) {
+		t.Fatalf("events status=%d body=%s", eventsRecorder.Code, eventsRecorder.Body.String())
+	}
+}
+
+func TestSLATransitionHandlerRequiresReviewPermissionAndAttributesHuman(t *testing.T) {
+	router, _ := newSLARouter(t)
+	body := []byte(`{"to":"mitigating","reason":"maintenance approved","version":1}`)
+
+	memberRecorder := httptest.NewRecorder()
+	router.authz(userdom.PermReview, router.transitionFindingSLA)(memberRecorder,
+		slaHTTPRequest(http.MethodPost, "/transition", "member", "member", body))
+	if memberRecorder.Code != http.StatusForbidden {
+		t.Fatalf("member status=%d body=%s", memberRecorder.Code, memberRecorder.Body.String())
+	}
+
+	reviewerRecorder := httptest.NewRecorder()
+	router.authz(userdom.PermReview, router.transitionFindingSLA)(reviewerRecorder,
+		slaHTTPRequest(http.MethodPost, "/transition", "alice", "reviewer", body))
+	if reviewerRecorder.Code != http.StatusOK {
+		t.Fatalf("reviewer status=%d body=%s", reviewerRecorder.Code, reviewerRecorder.Body.String())
+	}
+	var updated sla.View
+	if err := json.Unmarshal(reviewerRecorder.Body.Bytes(), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Lifecycle.Status != sla.RemediationMitigating || updated.Lifecycle.UpdatedBy != "alice" || updated.Lifecycle.Version != 2 {
+		t.Fatalf("unexpected transition response: %+v", updated.Lifecycle)
+	}
+
+	staleRecorder := httptest.NewRecorder()
+	router.authz(userdom.PermReview, router.transitionFindingSLA)(staleRecorder,
+		slaHTTPRequest(http.MethodPost, "/transition", "alice", "reviewer", []byte(`{"to":"remediated","reason":"stale","version":1}`)))
+	if staleRecorder.Code != http.StatusConflict {
+		t.Fatalf("stale status=%d body=%s", staleRecorder.Code, staleRecorder.Body.String())
+	}
+}
+
+func TestSLAAcceptedRiskHandlerRequiresControlAndExpiry(t *testing.T) {
+	router, _ := newSLARouter(t)
+	invalid := []byte(`{"to":"accepted_risk","reason":"vendor exception","version":1}`)
+	recorder := httptest.NewRecorder()
+	router.transitionFindingSLA(recorder, slaHTTPRequest(http.MethodPost, "/transition", "alice", "reviewer", invalid))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("invalid acceptance status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	expiry := time.Date(2026, 9, 15, 14, 0, 0, 0, time.UTC)
+	valid, _ := json.Marshal(map[string]any{
+		"to": "accepted_risk", "reason": "vendor exception", "version": 1,
+		"compensating_control": "WAF plus isolation", "acceptance_expires_at": expiry,
+	})
+	recorder = httptest.NewRecorder()
+	router.transitionFindingSLA(recorder, slaHTTPRequest(http.MethodPost, "/transition", "alice", "reviewer", valid))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("valid acceptance status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestSLAPolicyHandlersAreAdminOnlyAndVersioned(t *testing.T) {
+	router, _ := newSLARouter(t)
+	listRecorder := httptest.NewRecorder()
+	router.listSLAPolicies(listRecorder, slaHTTPRequest(http.MethodGet, "/api/v1/sla/policies", "reader", "readonly", nil))
+	if listRecorder.Code != http.StatusOK || !bytes.Contains(listRecorder.Body.Bytes(), []byte(`"active"`)) {
+		t.Fatalf("policy list status=%d body=%s", listRecorder.Code, listRecorder.Body.String())
+	}
+
+	cfg := sla.DefaultConfig()
+	cfg.Version = "tenant-policy-2"
+	body, _ := json.Marshal(map[string]any{"config": cfg})
+	reviewerRecorder := httptest.NewRecorder()
+	router.authz(userdom.PermAdminister, router.activateSLAPolicy)(reviewerRecorder,
+		slaHTTPRequest(http.MethodPost, "/api/v1/sla/policies", "reviewer", "reviewer", body))
+	if reviewerRecorder.Code != http.StatusForbidden {
+		t.Fatalf("reviewer activated policy: status=%d", reviewerRecorder.Code)
+	}
+	adminRecorder := httptest.NewRecorder()
+	router.authz(userdom.PermAdminister, router.activateSLAPolicy)(adminRecorder,
+		slaHTTPRequest(http.MethodPost, "/api/v1/sla/policies", "admin", "admin", body))
+	if adminRecorder.Code != http.StatusCreated || !bytes.Contains(adminRecorder.Body.Bytes(), []byte(`"tenant-policy-2"`)) {
+		t.Fatalf("admin status=%d body=%s", adminRecorder.Code, adminRecorder.Body.String())
+	}
+}
+
+func TestSLAHandlersRejectUnknownJSONFields(t *testing.T) {
+	router, _ := newSLARouter(t)
+	recorder := httptest.NewRecorder()
+	router.transitionFindingSLA(recorder, slaHTTPRequest(http.MethodPost, "/transition", "alice", "reviewer",
+		[]byte(`{"to":"mitigating","reason":"x","version":1,"machine_override":true}`)))
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("unknown field status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/internal/domain/aitriagereview/actor.go
+++ b/internal/domain/aitriagereview/actor.go
@@ -1,11 +1,13 @@
 package aitriagereview
 
+import "github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+
 // IsMachineActor reports whether actor uses one of Synapse's reserved non-human
 // principal prefixes. Curation and other in-process consumers should use this
 // shared predicate instead of duplicating the denylist maintained by the review
 // domain.
 func IsMachineActor(actor string) bool {
-	return machineActor(actor)
+	return shared.IsMachineActor(actor)
 }
 
 // IsMachineOrModelActor reports whether actor is either a reserved machine

--- a/internal/domain/shared/principal.go
+++ b/internal/domain/shared/principal.go
@@ -1,0 +1,19 @@
+package shared
+
+import "strings"
+
+// IsMachineActor reports whether actor belongs to one of Synapse's reserved non-human principal
+// families. Human-only decisions use this shared predicate so a newly added machine namespace cannot
+// accidentally be denied in one governance workflow but accepted in another.
+func IsMachineActor(actor string) bool {
+	actor = strings.ToLower(strings.TrimSpace(actor))
+	if actor == "" {
+		return true
+	}
+	for _, prefix := range []string{"agent:", "llm:", "mcp:", "system:", "machine:", "bot:", "service:"} {
+		if strings.HasPrefix(actor, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/domain/shared/principal.go
+++ b/internal/domain/shared/principal.go
@@ -4,7 +4,9 @@ import "strings"
 
 // IsMachineActor reports whether actor belongs to one of Synapse's reserved non-human principal
 // families. Human-only decisions use this shared predicate so a newly added machine namespace cannot
-// accidentally be denied in one governance workflow but accepted in another.
+// accidentally be denied in one governance workflow but accepted in another. Empty or whitespace-only
+// identities deliberately return true: an absent authenticated actor must fail closed at authorization
+// boundaries. Existing AI-triage callers already validate non-empty actor text before this predicate.
 func IsMachineActor(actor string) bool {
 	actor = strings.ToLower(strings.TrimSpace(actor))
 	if actor == "" {

--- a/internal/domain/shared/principal_test.go
+++ b/internal/domain/shared/principal_test.go
@@ -1,0 +1,16 @@
+package shared
+
+import "testing"
+
+func TestIsMachineActor(t *testing.T) {
+	cases := map[string]bool{
+		"": true, "  ": true, "agent:scan": true, "LLM:GPT": true, "mcp:tool": true,
+		"system:worker": true, "machine:job": true, "bot:renovate": true, "service:sync": true,
+		"alice": false, "alice@example.com": false, "reviewer:alice": false, "human:system:operator": false,
+	}
+	for actor, want := range cases {
+		if got := IsMachineActor(actor); got != want {
+			t.Errorf("IsMachineActor(%q)=%v, want %v", actor, got, want)
+		}
+	}
+}

--- a/internal/domain/sla/assessment.go
+++ b/internal/domain/sla/assessment.go
@@ -1,0 +1,189 @@
+package sla
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// AssessmentInput binds the pure risk inputs to one tenant-owned finding and to the immutable risk
+// assessment that first supplied them, when present. SourceRiskAssessmentID is immutable provenance,
+// not a scoring input: ordinary scanner findings have none, and a later intelligence assessment with
+// identical SLA-relevant facts must not mint another deadline merely because its source ID changed.
+type AssessmentInput struct {
+	TenantID               shared.ID `json:"tenant_id"`
+	EngagementID           shared.ID `json:"engagement_id"`
+	FindingID              shared.ID `json:"finding_id"`
+	SourceRiskAssessmentID shared.ID `json:"source_risk_assessment_id,omitempty"`
+	Risk                   Inputs    `json:"risk"`
+}
+
+// Assessment is an immutable, reproducible SLA decision. A change to material risk input or policy
+// creates another assessment linked to PreviousAssessmentID. Replaying the same finding, policy, and
+// input hash resolves to the same deterministic ID and the store returns the original row, preserving
+// its original due dates instead of moving them forward on every rescan.
+type Assessment struct {
+	TenantID               shared.ID `json:"tenant_id"`
+	ID                     shared.ID `json:"id"`
+	EngagementID           shared.ID `json:"engagement_id"`
+	FindingID              shared.ID `json:"finding_id"`
+	SourceRiskAssessmentID shared.ID `json:"source_risk_assessment_id,omitempty"`
+	Inputs                 Inputs    `json:"inputs"`
+	Result                 Result    `json:"result"`
+	InputHash              string    `json:"input_hash"`
+	ConfigHash             string    `json:"config_hash"`
+	PreviousAssessmentID   shared.ID `json:"previous_assessment_id,omitempty"`
+	AssessedAt             time.Time `json:"assessed_at"`
+	CreatedAt              time.Time `json:"created_at"`
+}
+
+// AssessmentUpsertResult tells callers whether an immutable assessment was newly created or an
+// idempotent replay returned the existing row.
+type AssessmentUpsertResult struct {
+	Assessment Assessment `json:"assessment"`
+	Created    bool       `json:"created"`
+}
+
+// Policy is a tenant-owned immutable config version. Activating another policy changes only the
+// active pointer; existing assessments retain their exact config version and digest.
+type Policy struct {
+	TenantID  shared.ID `json:"tenant_id"`
+	Config    Config    `json:"config"`
+	SHA256    string    `json:"sha256"`
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// NewPolicy validates and canonicalizes a stored policy version.
+func NewPolicy(tenantID shared.ID, cfg Config, createdBy string, now time.Time) (Policy, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	createdBy = strings.TrimSpace(createdBy)
+	if tenantID.IsZero() || createdBy == "" || now.IsZero() {
+		return Policy{}, fmt.Errorf("%w: sla policy tenant, actor, and time are required", shared.ErrValidation)
+	}
+	if err := cfg.Validate(); err != nil {
+		return Policy{}, err
+	}
+	digest, err := ConfigDigest(cfg)
+	if err != nil {
+		return Policy{}, err
+	}
+	return Policy{TenantID: tenantID, Config: cfg, SHA256: digest, CreatedBy: createdBy, CreatedAt: now.UTC()}, nil
+}
+
+// Validate verifies durable policy provenance rather than trusting a stored digest.
+func (p Policy) Validate() error {
+	if p.TenantID.IsZero() || strings.TrimSpace(p.CreatedBy) == "" || p.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: sla policy provenance is incomplete", shared.ErrValidation)
+	}
+	if err := p.Config.Validate(); err != nil {
+		return err
+	}
+	digest, err := ConfigDigest(p.Config)
+	if err != nil {
+		return err
+	}
+	if digest != p.SHA256 {
+		return fmt.Errorf("%w: sla policy digest does not match config", shared.ErrValidation)
+	}
+	return nil
+}
+
+// ConfigDigest returns a stable SHA-256 over the declarative config.
+func ConfigDigest(cfg Config) (string, error) {
+	encoded, err := json.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("marshal sla config: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// Evaluate creates a candidate immutable assessment. Stores bind PreviousAssessmentID and preserve
+// the original candidate when the deterministic ID already exists.
+func Evaluate(input AssessmentInput, cfg Config, now time.Time) (Assessment, error) {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	if input.TenantID.IsZero() || input.EngagementID.IsZero() || input.FindingID.IsZero() || now.IsZero() {
+		return Assessment{}, fmt.Errorf("%w: sla assessment identity and time are required", shared.ErrValidation)
+	}
+	if err := input.Risk.Validate(); err != nil {
+		return Assessment{}, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return Assessment{}, err
+	}
+	inputHash, err := assessmentInputHash(input)
+	if err != nil {
+		return Assessment{}, err
+	}
+	configHash, err := ConfigDigest(cfg)
+	if err != nil {
+		return Assessment{}, err
+	}
+	now = now.UTC()
+	return Assessment{
+		TenantID: input.TenantID, ID: AssessmentID(input.TenantID, input.FindingID, cfg.Version, inputHash),
+		EngagementID: input.EngagementID, FindingID: input.FindingID,
+		SourceRiskAssessmentID: input.SourceRiskAssessmentID, Inputs: input.Risk,
+		Result: Compute(input.Risk, cfg, now), InputHash: inputHash, ConfigHash: configHash,
+		AssessedAt: now, CreatedAt: now,
+	}, nil
+}
+
+// AssessmentID is stable for a material input and policy version. Tenant and finding identity are
+// included so identical findings in different security boundaries never share an artifact identity.
+func AssessmentID(tenantID, findingID shared.ID, configVersion, inputHash string) shared.ID {
+	digest := sha256.Sum256([]byte(strings.Join([]string{
+		shared.TenantOrDefault(tenantID).String(), findingID.String(), strings.TrimSpace(configVersion), inputHash,
+	}, "\x00")))
+	return shared.ID(hex.EncodeToString(digest[:16]))
+}
+
+// Validate recomputes every binding used at the persistence and promotion boundaries.
+func (a Assessment) Validate() error {
+	if a.TenantID.IsZero() || a.ID.IsZero() || a.EngagementID.IsZero() || a.FindingID.IsZero() ||
+		a.AssessedAt.IsZero() || a.CreatedAt.IsZero() || len(a.InputHash) != 64 || len(a.ConfigHash) != 64 {
+		return fmt.Errorf("%w: sla assessment identity or provenance is incomplete", shared.ErrValidation)
+	}
+	if err := a.Inputs.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(a.Result.ConfigVersion) == "" || a.Result.ComputedAt.IsZero() ||
+		a.Result.MitigateBy.Before(a.Result.ComputedAt) || a.Result.RemediateBy.Before(a.Result.MitigateBy) {
+		return fmt.Errorf("%w: sla assessment result is invalid", shared.ErrValidation)
+	}
+	inputHash, err := assessmentInputHash(AssessmentInput{
+		TenantID: a.TenantID, EngagementID: a.EngagementID, FindingID: a.FindingID,
+		SourceRiskAssessmentID: a.SourceRiskAssessmentID, Risk: a.Inputs,
+	})
+	if err != nil {
+		return err
+	}
+	if inputHash != a.InputHash || AssessmentID(a.TenantID, a.FindingID, a.Result.ConfigVersion, inputHash) != a.ID {
+		return fmt.Errorf("%w: sla assessment identity does not match inputs", shared.ErrValidation)
+	}
+	return nil
+}
+
+func assessmentInputHash(input AssessmentInput) (string, error) {
+	payload := struct {
+		TenantID     string `json:"tenant_id"`
+		EngagementID string `json:"engagement_id"`
+		FindingID    string `json:"finding_id"`
+		Risk         Inputs `json:"risk"`
+	}{
+		TenantID: input.TenantID.String(), EngagementID: input.EngagementID.String(), FindingID: input.FindingID.String(),
+		Risk: input.Risk,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal sla assessment input: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}

--- a/internal/domain/sla/assessment.go
+++ b/internal/domain/sla/assessment.go
@@ -38,6 +38,7 @@ type Assessment struct {
 	InputHash              string    `json:"input_hash"`
 	ConfigHash             string    `json:"config_hash"`
 	PreviousAssessmentID   shared.ID `json:"previous_assessment_id,omitempty"`
+	DeadlineAnchorAt       time.Time `json:"deadline_anchor_at"`
 	AssessedAt             time.Time `json:"assessed_at"`
 	CreatedAt              time.Time `json:"created_at"`
 }
@@ -131,8 +132,53 @@ func Evaluate(input AssessmentInput, cfg Config, now time.Time) (Assessment, err
 		EngagementID: input.EngagementID, FindingID: input.FindingID,
 		SourceRiskAssessmentID: input.SourceRiskAssessmentID, Inputs: input.Risk,
 		Result: Compute(input.Risk, cfg, now), InputHash: inputHash, ConfigHash: configHash,
-		AssessedAt: now, CreatedAt: now,
+		DeadlineAnchorAt: now, AssessedAt: now, CreatedAt: now,
 	}, nil
+}
+
+// ContinueAssessment binds a new immutable assessment to the current chain without resetting its
+// clock. The new tier's due windows are rebased to the first assessment, and an already-promised
+// deadline is never moved later. Stores call this while holding their per-finding serialization lock,
+// so the anchor and deadline caps always come from the actual current predecessor.
+func ContinueAssessment(candidate, previous Assessment) (Assessment, error) {
+	if err := candidate.Validate(); err != nil {
+		return Assessment{}, err
+	}
+	if err := previous.Validate(); err != nil {
+		return Assessment{}, fmt.Errorf("validate previous sla assessment: %w", err)
+	}
+	if candidate.TenantID != previous.TenantID || candidate.EngagementID != previous.EngagementID ||
+		candidate.FindingID != previous.FindingID {
+		return Assessment{}, fmt.Errorf("%w: sla assessment predecessor belongs to another finding", shared.ErrValidation)
+	}
+	if !candidate.PreviousAssessmentID.IsZero() && candidate.PreviousAssessmentID != previous.ID {
+		return Assessment{}, fmt.Errorf("%w: sla assessment chain advanced", shared.ErrConflict)
+	}
+	if candidate.AssessedAt.Before(previous.AssessedAt) {
+		return Assessment{}, fmt.Errorf("%w: sla assessment cannot precede its current predecessor", shared.ErrConflict)
+	}
+
+	mitigateWindow := candidate.Result.MitigateBy.Sub(candidate.DeadlineAnchorAt)
+	remediateWindow := candidate.Result.RemediateBy.Sub(candidate.DeadlineAnchorAt)
+	candidate.PreviousAssessmentID = previous.ID
+	candidate.DeadlineAnchorAt = previous.DeadlineAnchorAt
+	candidate.Result.MitigateBy = earlierDeadline(
+		candidate.DeadlineAnchorAt.Add(mitigateWindow), previous.Result.MitigateBy,
+	)
+	candidate.Result.RemediateBy = earlierDeadline(
+		candidate.DeadlineAnchorAt.Add(remediateWindow), previous.Result.RemediateBy,
+	)
+	if err := candidate.Validate(); err != nil {
+		return Assessment{}, fmt.Errorf("validate continued sla assessment: %w", err)
+	}
+	return candidate, nil
+}
+
+func earlierDeadline(left, right time.Time) time.Time {
+	if left.Before(right) {
+		return left
+	}
+	return right
 }
 
 // AssessmentID is stable for a material input and policy version. Tenant and finding identity are
@@ -147,15 +193,20 @@ func AssessmentID(tenantID, findingID shared.ID, configVersion, inputHash string
 // Validate recomputes every binding used at the persistence and promotion boundaries.
 func (a Assessment) Validate() error {
 	if a.TenantID.IsZero() || a.ID.IsZero() || a.EngagementID.IsZero() || a.FindingID.IsZero() ||
-		a.AssessedAt.IsZero() || a.CreatedAt.IsZero() || len(a.InputHash) != 64 || len(a.ConfigHash) != 64 {
+		a.DeadlineAnchorAt.IsZero() || a.AssessedAt.IsZero() || a.CreatedAt.IsZero() ||
+		len(a.InputHash) != 64 || len(a.ConfigHash) != 64 {
 		return fmt.Errorf("%w: sla assessment identity or provenance is incomplete", shared.ErrValidation)
 	}
 	if err := a.Inputs.Validate(); err != nil {
 		return err
 	}
 	if strings.TrimSpace(a.Result.ConfigVersion) == "" || a.Result.ComputedAt.IsZero() ||
-		a.Result.MitigateBy.Before(a.Result.ComputedAt) || a.Result.RemediateBy.Before(a.Result.MitigateBy) {
+		!a.Result.ComputedAt.Equal(a.AssessedAt) || a.DeadlineAnchorAt.After(a.AssessedAt) ||
+		a.Result.MitigateBy.Before(a.DeadlineAnchorAt) || a.Result.RemediateBy.Before(a.Result.MitigateBy) {
 		return fmt.Errorf("%w: sla assessment result is invalid", shared.ErrValidation)
+	}
+	if a.PreviousAssessmentID.IsZero() && !a.DeadlineAnchorAt.Equal(a.AssessedAt) {
+		return fmt.Errorf("%w: first sla assessment must start its own deadline clock", shared.ErrValidation)
 	}
 	inputHash, err := assessmentInputHash(AssessmentInput{
 		TenantID: a.TenantID, EngagementID: a.EngagementID, FindingID: a.FindingID,
@@ -171,14 +222,38 @@ func (a Assessment) Validate() error {
 }
 
 func assessmentInputHash(input AssessmentInput) (string, error) {
+	// Hash only facts that can change the decision. Raw CVSS/EPSS movement inside one scoring band,
+	// an EPSS change hidden by KEV, and PublicPoC while active exploitation is already true are useful
+	// provenance but not new SLA decisions and therefore must not mint a fresh deadline artifact.
+	exploitabilityBand := "none"
+	switch {
+	case input.Risk.KEV:
+		exploitabilityBand = "kev"
+	case input.Risk.EPSS >= epssHighBand:
+		exploitabilityBand = "high"
+	case input.Risk.EPSS >= epssMediumBand:
+		exploitabilityBand = "medium"
+	case input.Risk.EPSS >= epssLowBand:
+		exploitabilityBand = "low"
+	}
 	payload := struct {
-		TenantID     string `json:"tenant_id"`
-		EngagementID string `json:"engagement_id"`
-		FindingID    string `json:"finding_id"`
-		Risk         Inputs `json:"risk"`
+		TenantID           string          `json:"tenant_id"`
+		EngagementID       string          `json:"engagement_id"`
+		FindingID          string          `json:"finding_id"`
+		SeverityBand       shared.Severity `json:"severity_band"`
+		ExploitabilityBand string          `json:"exploitability_band"`
+		KEV                bool            `json:"kev"`
+		PublicPoC          bool            `json:"public_poc"`
+		ActiveExploitation bool            `json:"active_exploitation"`
+		Criticality        Criticality     `json:"criticality"`
+		Exposure           Exposure        `json:"exposure"`
+		Feasibility        Feasibility     `json:"feasibility"`
 	}{
 		TenantID: input.TenantID.String(), EngagementID: input.EngagementID.String(), FindingID: input.FindingID.String(),
-		Risk: input.Risk,
+		SeverityBand: input.Risk.severityBand(), ExploitabilityBand: exploitabilityBand, KEV: input.Risk.KEV,
+		PublicPoC:          input.Risk.PublicPoC && !input.Risk.ActiveExploitation,
+		ActiveExploitation: input.Risk.ActiveExploitation, Criticality: input.Risk.Criticality,
+		Exposure: input.Risk.Exposure, Feasibility: input.Risk.Feasibility,
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/domain/sla/assessment_test.go
+++ b/internal/domain/sla/assessment_test.go
@@ -1,0 +1,194 @@
+package sla
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var assessmentEpoch = time.Date(2026, 8, 15, 9, 30, 0, 0, time.UTC)
+
+func validAssessmentInput() AssessmentInput {
+	return AssessmentInput{
+		TenantID: "tenant-a", EngagementID: "eng-1", FindingID: "finding-1", SourceRiskAssessmentID: "risk-1",
+		Risk: Inputs{
+			Severity: shared.SeverityCritical, CVSSScore: 9.8, KEV: true, EPSS: 0.91,
+			PublicPoC: true, Criticality: CriticalityHigh, Exposure: ExposureExternal,
+			Feasibility: FeasibilityPatchAvailable,
+		},
+	}
+}
+
+func mustAssessment(t *testing.T) Assessment {
+	t.Helper()
+	item, err := Evaluate(validAssessmentInput(), DefaultConfig(), assessmentEpoch)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	return item
+}
+
+func TestAssessmentEvaluateIsDeterministicAndBound(t *testing.T) {
+	first := mustAssessment(t)
+	second, err := Evaluate(validAssessmentInput(), DefaultConfig(), assessmentEpoch.Add(24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID != second.ID || first.InputHash != second.InputHash || first.ConfigHash != second.ConfigHash {
+		t.Fatalf("materially identical input changed identity: first=%+v second=%+v", first, second)
+	}
+	if first.AssessedAt == second.AssessedAt || first.Result.RemediateBy == second.Result.RemediateBy {
+		t.Fatal("candidate clocks should reflect the attempted assessment; the store preserves the original on replay")
+	}
+	if first.TenantID != "tenant-a" || first.EngagementID != "eng-1" || first.FindingID != "finding-1" || first.SourceRiskAssessmentID != "risk-1" {
+		t.Fatalf("ownership/provenance not retained: %+v", first)
+	}
+	if err := first.Validate(); err != nil {
+		t.Fatalf("valid assessment rejected: %v", err)
+	}
+}
+
+func TestAssessmentIdentityChangesOnlyForMaterialInputOrPolicy(t *testing.T) {
+	base := mustAssessment(t)
+	cases := []struct {
+		name  string
+		input AssessmentInput
+		cfg   Config
+	}{
+		{name: "finding", input: func() AssessmentInput { in := validAssessmentInput(); in.FindingID = "finding-2"; return in }(), cfg: DefaultConfig()},
+		{name: "tenant", input: func() AssessmentInput { in := validAssessmentInput(); in.TenantID = "tenant-b"; return in }(), cfg: DefaultConfig()},
+		{name: "risk", input: func() AssessmentInput { in := validAssessmentInput(); in.Risk.EPSS = 0.2; return in }(), cfg: DefaultConfig()},
+		{name: "policy", input: validAssessmentInput(), cfg: func() Config { cfg := DefaultConfig(); cfg.Version = "sla-v2"; return cfg }()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Evaluate(tc.input, tc.cfg, assessmentEpoch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.ID == base.ID {
+				t.Fatalf("material change %q retained assessment id %s", tc.name, got.ID)
+			}
+		})
+	}
+}
+
+func TestAssessmentIdentityIgnoresProvenanceOnlyRefresh(t *testing.T) {
+	first := validAssessmentInput()
+	second := validAssessmentInput()
+	second.SourceRiskAssessmentID = "risk-2"
+	left, err := Evaluate(first, DefaultConfig(), assessmentEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := Evaluate(second, DefaultConfig(), assessmentEpoch.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left.ID != right.ID || left.InputHash != right.InputHash {
+		t.Fatalf("provenance-only refresh changed SLA identity: first=%+v second=%+v", left, right)
+	}
+	if right.SourceRiskAssessmentID != "risk-2" {
+		t.Fatalf("candidate did not retain new source provenance: %+v", right)
+	}
+}
+
+func TestAssessmentInputValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		edit func(*AssessmentInput)
+	}{
+		{name: "engagement", edit: func(in *AssessmentInput) { in.EngagementID = "" }},
+		{name: "finding", edit: func(in *AssessmentInput) { in.FindingID = "" }},
+		{name: "time", edit: func(*AssessmentInput) {}},
+		{name: "severity", edit: func(in *AssessmentInput) { in.Risk.Severity = "urgent" }},
+		{name: "cvss negative", edit: func(in *AssessmentInput) { in.Risk.CVSSScore = -0.1 }},
+		{name: "cvss high", edit: func(in *AssessmentInput) { in.Risk.CVSSScore = 10.1 }},
+		{name: "epss negative", edit: func(in *AssessmentInput) { in.Risk.EPSS = -0.1 }},
+		{name: "epss high", edit: func(in *AssessmentInput) { in.Risk.EPSS = 1.1 }},
+		{name: "exposure", edit: func(in *AssessmentInput) { in.Risk.Exposure = "partner" }},
+		{name: "criticality", edit: func(in *AssessmentInput) { in.Risk.Criticality = "mission" }},
+		{name: "feasibility", edit: func(in *AssessmentInput) { in.Risk.Feasibility = "eventually" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := validAssessmentInput()
+			tc.edit(&input)
+			now := assessmentEpoch
+			if tc.name == "time" {
+				now = time.Time{}
+			}
+			if _, err := Evaluate(input, DefaultConfig(), now); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAssessmentValidateDetectsTampering(t *testing.T) {
+	cases := []struct {
+		name string
+		edit func(*Assessment)
+	}{
+		{name: "id", edit: func(a *Assessment) { a.ID = "forged" }},
+		{name: "input hash", edit: func(a *Assessment) { a.InputHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }},
+		{name: "config hash", edit: func(a *Assessment) { a.ConfigHash = "short" }},
+		{name: "computed at", edit: func(a *Assessment) { a.Result.ComputedAt = time.Time{} }},
+		{name: "mitigate before computed", edit: func(a *Assessment) { a.Result.MitigateBy = a.Result.ComputedAt.Add(-time.Second) }},
+		{name: "remediate before mitigate", edit: func(a *Assessment) { a.Result.RemediateBy = a.Result.MitigateBy.Add(-time.Second) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := mustAssessment(t)
+			tc.edit(&item)
+			if err := item.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPolicyDigestAndValidation(t *testing.T) {
+	policy, err := NewPolicy("tenant-a", DefaultConfig(), "alice", assessmentEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(policy.SHA256) != 64 || policy.CreatedAt.Location() != time.UTC {
+		t.Fatalf("unexpected canonical policy: %+v", policy)
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	copy := policy
+	copy.Config.Thresholds.High++
+	if err := copy.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("tampered config should fail digest validation, got %v", err)
+	}
+	copy = policy
+	copy.SHA256 = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	if err := copy.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("tampered digest should fail, got %v", err)
+	}
+}
+
+func TestNewPolicyRejectsInvalidProvenanceAndConfig(t *testing.T) {
+	cases := []struct {
+		name   string
+		actor  string
+		now    time.Time
+		config Config
+	}{
+		{name: "actor", now: assessmentEpoch, config: DefaultConfig()},
+		{name: "time", actor: "alice", config: DefaultConfig()},
+		{name: "config", actor: "alice", now: assessmentEpoch, config: Config{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewPolicy("tenant-a", tc.config, tc.actor, tc.now); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/domain/sla/assessment_test.go
+++ b/internal/domain/sla/assessment_test.go
@@ -59,7 +59,7 @@ func TestAssessmentIdentityChangesOnlyForMaterialInputOrPolicy(t *testing.T) {
 	}{
 		{name: "finding", input: func() AssessmentInput { in := validAssessmentInput(); in.FindingID = "finding-2"; return in }(), cfg: DefaultConfig()},
 		{name: "tenant", input: func() AssessmentInput { in := validAssessmentInput(); in.TenantID = "tenant-b"; return in }(), cfg: DefaultConfig()},
-		{name: "risk", input: func() AssessmentInput { in := validAssessmentInput(); in.Risk.EPSS = 0.2; return in }(), cfg: DefaultConfig()},
+		{name: "risk", input: func() AssessmentInput { in := validAssessmentInput(); in.Risk.KEV = false; return in }(), cfg: DefaultConfig()},
 		{name: "policy", input: validAssessmentInput(), cfg: func() Config { cfg := DefaultConfig(); cfg.Version = "sla-v2"; return cfg }()},
 	}
 	for _, tc := range cases {
@@ -92,6 +92,96 @@ func TestAssessmentIdentityIgnoresProvenanceOnlyRefresh(t *testing.T) {
 	}
 	if right.SourceRiskAssessmentID != "risk-2" {
 		t.Fatalf("candidate did not retain new source provenance: %+v", right)
+	}
+}
+
+func TestAssessmentIdentityIgnoresNonMaterialRiskDrift(t *testing.T) {
+	base := validAssessmentInput()
+	base.Risk.KEV = false
+	base.Risk.ActiveExploitation = false
+	base.Risk.CVSSScore = 9.1
+	base.Risk.EPSS = 0.61
+
+	cases := map[string]func(*AssessmentInput){
+		"cvss inside critical band": func(in *AssessmentInput) { in.Risk.CVSSScore = 9.9 },
+		"epss inside high band":     func(in *AssessmentInput) { in.Risk.EPSS = 0.99 },
+		"severity hidden by cvss":   func(in *AssessmentInput) { in.Risk.Severity = shared.SeverityLow },
+	}
+	first, err := Evaluate(base, DefaultConfig(), assessmentEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, edit := range cases {
+		t.Run(name, func(t *testing.T) {
+			changed := base
+			edit(&changed)
+			got, err := Evaluate(changed, DefaultConfig(), assessmentEpoch.Add(time.Hour))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.ID != first.ID || got.InputHash != first.InputHash {
+				t.Fatalf("non-material drift minted assessment: first=%s got=%s", first.ID, got.ID)
+			}
+		})
+	}
+
+	crossed := base
+	crossed.Risk.EPSS = 0.49
+	changed, err := Evaluate(crossed, DefaultConfig(), assessmentEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.ID == first.ID {
+		t.Fatal("crossing an EPSS scoring band must create a new material assessment")
+	}
+}
+
+func TestContinueAssessmentPreservesOriginalClockAndNeverExtendsDeadline(t *testing.T) {
+	cfg := DefaultConfig()
+	input := validAssessmentInput()
+	input.Risk = Inputs{Severity: shared.SeverityHigh, CVSSScore: 8.1, EPSS: 0.2, Feasibility: FeasibilityPatchAvailable}
+	first, err := Evaluate(input, cfg, assessmentEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Result.Tier != TierHigh {
+		t.Fatalf("test setup tier=%s, want high", first.Result.Tier)
+	}
+
+	input.Risk.ActiveExploitation = true
+	candidate, err := Evaluate(input, cfg, assessmentEpoch.Add(25*24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	continued, err := ContinueAssessment(candidate, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if continued.PreviousAssessmentID != first.ID || !continued.DeadlineAnchorAt.Equal(first.AssessedAt) {
+		t.Fatalf("assessment chain/anchor not retained: %+v", continued)
+	}
+	wantEmergencyDue := first.AssessedAt.Add(cfg.DueRanges.Emergency.RemediateWithin)
+	if !continued.Result.RemediateBy.Equal(wantEmergencyDue) {
+		t.Fatalf("late emergency deadline=%s, want original anchor + emergency range=%s", continued.Result.RemediateBy, wantEmergencyDue)
+	}
+	if !continued.Result.RemediateBy.Before(continued.Result.ComputedAt) {
+		t.Fatal("late escalation should remain observably overdue instead of resetting its clock")
+	}
+	if err := continued.Validate(); err != nil {
+		t.Fatalf("overdue continued assessment rejected: %v", err)
+	}
+
+	input.Risk = Inputs{Severity: shared.SeverityLow, CVSSScore: 2.0, Feasibility: FeasibilityPatchAvailable}
+	deescalated, err := Evaluate(input, cfg, assessmentEpoch.Add(26*24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deescalated, err = ContinueAssessment(deescalated, continued)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !deescalated.Result.RemediateBy.Equal(continued.Result.RemediateBy) {
+		t.Fatalf("de-escalation extended committed deadline: previous=%s got=%s", continued.Result.RemediateBy, deescalated.Result.RemediateBy)
 	}
 }
 
@@ -136,6 +226,7 @@ func TestAssessmentValidateDetectsTampering(t *testing.T) {
 		{name: "input hash", edit: func(a *Assessment) { a.InputHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }},
 		{name: "config hash", edit: func(a *Assessment) { a.ConfigHash = "short" }},
 		{name: "computed at", edit: func(a *Assessment) { a.Result.ComputedAt = time.Time{} }},
+		{name: "deadline anchor", edit: func(a *Assessment) { a.DeadlineAnchorAt = time.Time{} }},
 		{name: "mitigate before computed", edit: func(a *Assessment) { a.Result.MitigateBy = a.Result.ComputedAt.Add(-time.Second) }},
 		{name: "remediate before mitigate", edit: func(a *Assessment) { a.Result.RemediateBy = a.Result.MitigateBy.Add(-time.Second) }},
 	}

--- a/internal/domain/sla/lifecycle.go
+++ b/internal/domain/sla/lifecycle.go
@@ -1,0 +1,202 @@
+package sla
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// RemediationStatus is independent of finding validity/triage. A finding can remain confirmed while
+// its remediation moves open -> mitigating -> remediated, and accepting risk never relabels a real
+// vulnerability as a false positive.
+type RemediationStatus string
+
+const (
+	RemediationOpen         RemediationStatus = "open"
+	RemediationMitigating   RemediationStatus = "mitigating"
+	RemediationRemediated   RemediationStatus = "remediated"
+	RemediationAcceptedRisk RemediationStatus = "accepted_risk"
+)
+
+func (s RemediationStatus) Valid() bool {
+	return s == RemediationOpen || s == RemediationMitigating || s == RemediationRemediated || s == RemediationAcceptedRisk
+}
+
+// Lifecycle is the current human-owned remediation state. Machine risk refreshes may update the
+// current AssessmentID but must preserve every other field. Version protects transitions from lost
+// updates. Acceptance is effective only before AcceptanceExpiresAt.
+type Lifecycle struct {
+	TenantID            shared.ID         `json:"tenant_id"`
+	EngagementID        shared.ID         `json:"engagement_id"`
+	FindingID           shared.ID         `json:"finding_id"`
+	AssessmentID        shared.ID         `json:"assessment_id"`
+	Status              RemediationStatus `json:"status"`
+	Version             int               `json:"version"`
+	Reason              string            `json:"reason,omitempty"`
+	CompensatingControl string            `json:"compensating_control,omitempty"`
+	AcceptedBy          string            `json:"accepted_by,omitempty"`
+	AcceptedAt          *time.Time        `json:"accepted_at,omitempty"`
+	AcceptanceExpiresAt *time.Time        `json:"acceptance_expires_at,omitempty"`
+	UpdatedBy           string            `json:"updated_by"`
+	UpdatedAt           time.Time         `json:"updated_at"`
+}
+
+// NewLifecycle creates the default human workflow state alongside the first SLA assessment.
+func NewLifecycle(a Assessment, now time.Time) (Lifecycle, error) {
+	if err := a.Validate(); err != nil {
+		return Lifecycle{}, err
+	}
+	if now.IsZero() {
+		return Lifecycle{}, fmt.Errorf("%w: sla lifecycle time is required", shared.ErrValidation)
+	}
+	return Lifecycle{
+		TenantID: a.TenantID, EngagementID: a.EngagementID, FindingID: a.FindingID,
+		AssessmentID: a.ID, Status: RemediationOpen, Version: 1,
+		UpdatedBy: "system:sla", UpdatedAt: now.UTC(),
+	}, nil
+}
+
+func (s Lifecycle) Validate() error {
+	if s.TenantID.IsZero() || s.EngagementID.IsZero() || s.FindingID.IsZero() || s.AssessmentID.IsZero() ||
+		!s.Status.Valid() || s.Version < 1 || strings.TrimSpace(s.UpdatedBy) == "" || s.UpdatedAt.IsZero() {
+		return fmt.Errorf("%w: sla lifecycle is invalid", shared.ErrValidation)
+	}
+	if s.Status == RemediationAcceptedRisk {
+		if strings.TrimSpace(s.Reason) == "" || strings.TrimSpace(s.CompensatingControl) == "" ||
+			strings.TrimSpace(s.AcceptedBy) == "" || s.AcceptedAt == nil || s.AcceptanceExpiresAt == nil ||
+			!s.AcceptanceExpiresAt.After(*s.AcceptedAt) {
+			return fmt.Errorf("%w: accepted risk requires reason, control, human, and future expiry", shared.ErrValidation)
+		}
+	} else if s.AcceptedAt != nil || s.AcceptanceExpiresAt != nil || s.AcceptedBy != "" {
+		return fmt.Errorf("%w: non-accepted sla lifecycle carries acceptance metadata", shared.ErrValidation)
+	}
+	return nil
+}
+
+// EffectiveStatus makes expiry fail-safe without relying on a background scheduler. The durable
+// acceptance event stays auditable, while every read/gate treats an expired acceptance as open.
+func (s Lifecycle) EffectiveStatus(now time.Time) RemediationStatus {
+	if s.Status == RemediationAcceptedRisk && (s.AcceptanceExpiresAt == nil || !now.UTC().Before(s.AcceptanceExpiresAt.UTC())) {
+		return RemediationOpen
+	}
+	return s.Status
+}
+
+// TransitionCommand is a human remediation decision guarded by ExpectedVersion.
+type TransitionCommand struct {
+	To                  RemediationStatus `json:"to"`
+	Reason              string            `json:"reason"`
+	CompensatingControl string            `json:"compensating_control,omitempty"`
+	AcceptanceExpiresAt *time.Time        `json:"acceptance_expires_at,omitempty"`
+	Actor               string            `json:"actor"`
+	ExpectedVersion     int               `json:"expected_version"`
+}
+
+// LifecycleEvent is append-only evidence of one state transition.
+type LifecycleEvent struct {
+	TenantID            shared.ID         `json:"tenant_id"`
+	ID                  shared.ID         `json:"id"`
+	EngagementID        shared.ID         `json:"engagement_id"`
+	FindingID           shared.ID         `json:"finding_id"`
+	AssessmentID        shared.ID         `json:"assessment_id"`
+	From                RemediationStatus `json:"from"`
+	To                  RemediationStatus `json:"to"`
+	Reason              string            `json:"reason"`
+	CompensatingControl string            `json:"compensating_control,omitempty"`
+	AcceptanceExpiresAt *time.Time        `json:"acceptance_expires_at,omitempty"`
+	Actor               string            `json:"actor"`
+	BeforeVersion       int               `json:"before_version"`
+	AfterVersion        int               `json:"after_version"`
+	At                  time.Time         `json:"at"`
+}
+
+// ApplyTransition validates a human-only decision and returns the next state plus append-only event.
+// Remediated is terminal for manual transitions: a later intelligence re-exposure creates review work
+// through #540 but never silently reopens the finding.
+func ApplyTransition(current Lifecycle, eventID shared.ID, cmd TransitionCommand, now time.Time) (Lifecycle, LifecycleEvent, error) {
+	if err := current.Validate(); err != nil {
+		return Lifecycle{}, LifecycleEvent{}, err
+	}
+	cmd.Actor, cmd.Reason, cmd.CompensatingControl = strings.TrimSpace(cmd.Actor), strings.TrimSpace(cmd.Reason), strings.TrimSpace(cmd.CompensatingControl)
+	if eventID.IsZero() || now.IsZero() || !cmd.To.Valid() || cmd.Reason == "" || cmd.ExpectedVersion != current.Version {
+		if cmd.ExpectedVersion != current.Version {
+			return Lifecycle{}, LifecycleEvent{}, fmt.Errorf("sla lifecycle changed since it was loaded: %w", shared.ErrConflict)
+		}
+		return Lifecycle{}, LifecycleEvent{}, fmt.Errorf("%w: sla transition identity, state, reason, and time are required", shared.ErrValidation)
+	}
+	if shared.IsMachineActor(cmd.Actor) {
+		return Lifecycle{}, LifecycleEvent{}, fmt.Errorf("%w: sla remediation decisions require a human principal", shared.ErrValidation)
+	}
+	from := current.EffectiveStatus(now)
+	if from == RemediationRemediated && cmd.To != RemediationRemediated {
+		return Lifecycle{}, LifecycleEvent{}, fmt.Errorf("%w: remediated sla state cannot be silently reopened", shared.ErrValidation)
+	}
+	if from == cmd.To && !(current.Status == RemediationAcceptedRisk && from == RemediationOpen) {
+		return Lifecycle{}, LifecycleEvent{}, fmt.Errorf("%w: sla transition must change effective state", shared.ErrValidation)
+	}
+	if cmd.To == RemediationAcceptedRisk {
+		if cmd.CompensatingControl == "" || cmd.AcceptanceExpiresAt == nil || !cmd.AcceptanceExpiresAt.After(now.UTC()) {
+			return Lifecycle{}, LifecycleEvent{}, fmt.Errorf("%w: accepted risk requires a compensating control and future expiry", shared.ErrValidation)
+		}
+	}
+
+	next := current
+	next.Status, next.Version, next.Reason = cmd.To, current.Version+1, cmd.Reason
+	next.UpdatedBy, next.UpdatedAt = cmd.Actor, now.UTC()
+	next.CompensatingControl, next.AcceptedBy, next.AcceptedAt, next.AcceptanceExpiresAt = "", "", nil, nil
+	if cmd.To == RemediationAcceptedRisk {
+		at, expiry := now.UTC(), cmd.AcceptanceExpiresAt.UTC()
+		next.CompensatingControl, next.AcceptedBy = cmd.CompensatingControl, cmd.Actor
+		next.AcceptedAt, next.AcceptanceExpiresAt = &at, &expiry
+	}
+	if err := next.Validate(); err != nil {
+		return Lifecycle{}, LifecycleEvent{}, err
+	}
+	event := LifecycleEvent{
+		TenantID: current.TenantID, ID: eventID, EngagementID: current.EngagementID, FindingID: current.FindingID,
+		AssessmentID: current.AssessmentID, From: current.Status, To: cmd.To, Reason: cmd.Reason,
+		CompensatingControl: cmd.CompensatingControl, AcceptanceExpiresAt: next.AcceptanceExpiresAt,
+		Actor: cmd.Actor, BeforeVersion: current.Version, AfterVersion: next.Version, At: now.UTC(),
+	}
+	return next, event, nil
+}
+
+// View joins current immutable assessment and human lifecycle for API/CLI/report consumption.
+type View struct {
+	Assessment     Assessment        `json:"assessment"`
+	Lifecycle      Lifecycle         `json:"lifecycle"`
+	EffectiveState RemediationStatus `json:"effective_state"`
+	Overdue        bool              `json:"overdue"`
+	Expired        bool              `json:"acceptance_expired"`
+}
+
+// Current is the durable aggregate returned by SLA stores. Keeping the join explicit lets the
+// use-case calculate time-sensitive expiry/overdue fields at read time rather than persisting values
+// that become stale. It also gives adapters one shape for atomic current-assessment/lifecycle reads.
+type Current struct {
+	Assessment Assessment `json:"assessment"`
+	Lifecycle  Lifecycle  `json:"lifecycle"`
+}
+
+// View calculates the time-sensitive projection of a durable current record.
+func (c Current) View(now time.Time) (View, error) {
+	return NewView(c.Assessment, c.Lifecycle, now)
+}
+
+func NewView(a Assessment, state Lifecycle, now time.Time) (View, error) {
+	if err := a.Validate(); err != nil {
+		return View{}, err
+	}
+	if err := state.Validate(); err != nil {
+		return View{}, err
+	}
+	if a.TenantID != state.TenantID || a.EngagementID != state.EngagementID || a.FindingID != state.FindingID || state.AssessmentID != a.ID {
+		return View{}, fmt.Errorf("%w: sla assessment and lifecycle ownership differ", shared.ErrValidation)
+	}
+	effective := state.EffectiveStatus(now)
+	expired := state.Status == RemediationAcceptedRisk && effective == RemediationOpen
+	overdue := effective != RemediationRemediated && effective != RemediationAcceptedRisk && !now.UTC().Before(a.Result.RemediateBy.UTC())
+	return View{Assessment: a, Lifecycle: state, EffectiveState: effective, Overdue: overdue, Expired: expired}, nil
+}

--- a/internal/domain/sla/lifecycle_test.go
+++ b/internal/domain/sla/lifecycle_test.go
@@ -1,0 +1,171 @@
+package sla
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func mustLifecycle(t *testing.T) Lifecycle {
+	t.Helper()
+	state, err := NewLifecycle(mustAssessment(t), assessmentEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func transition(t *testing.T, state Lifecycle, id shared.ID, to RemediationStatus, actor, reason string, expiry *time.Time, now time.Time) (Lifecycle, LifecycleEvent) {
+	t.Helper()
+	next, event, err := ApplyTransition(state, id, TransitionCommand{
+		To: to, Actor: actor, Reason: reason, ExpectedVersion: state.Version,
+		CompensatingControl: "WAF plus network isolation", AcceptanceExpiresAt: expiry,
+	}, now)
+	if err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+	return next, event
+}
+
+func TestLifecycleOrdinaryTransitionsAreVersionedAndAudited(t *testing.T) {
+	open := mustLifecycle(t)
+	mitigating, first := transition(t, open, "event-1", RemediationMitigating, "alice", "rollout started", nil, assessmentEpoch.Add(time.Hour))
+	if mitigating.Version != 2 || mitigating.UpdatedBy != "alice" || mitigating.Status != RemediationMitigating {
+		t.Fatalf("unexpected mitigating state: %+v", mitigating)
+	}
+	if first.From != RemediationOpen || first.To != RemediationMitigating || first.BeforeVersion != 1 || first.AfterVersion != 2 {
+		t.Fatalf("unexpected event: %+v", first)
+	}
+	remediated, second := transition(t, mitigating, "event-2", RemediationRemediated, "bob", "fix deployed and verified", nil, assessmentEpoch.Add(2*time.Hour))
+	if remediated.Status != RemediationRemediated || remediated.Version != 3 || second.AssessmentID != open.AssessmentID {
+		t.Fatalf("unexpected terminal state/event: %+v %+v", remediated, second)
+	}
+}
+
+func TestAcceptedRiskRequiresHumanControlAndHardExpiry(t *testing.T) {
+	open := mustLifecycle(t)
+	expiry := assessmentEpoch.Add(30 * 24 * time.Hour)
+	accepted, event := transition(t, open, "event-accept", RemediationAcceptedRisk, "risk.owner@example.com", "upgrade blocked by vendor", &expiry, assessmentEpoch)
+	if accepted.AcceptedBy != "risk.owner@example.com" || accepted.AcceptedAt == nil || accepted.AcceptanceExpiresAt == nil {
+		t.Fatalf("acceptance provenance missing: %+v", accepted)
+	}
+	if event.AcceptanceExpiresAt == nil || event.CompensatingControl == "" {
+		t.Fatalf("event did not retain acceptance evidence: %+v", event)
+	}
+	if got := accepted.EffectiveStatus(expiry.Add(-time.Nanosecond)); got != RemediationAcceptedRisk {
+		t.Fatalf("before expiry status=%q", got)
+	}
+	if got := accepted.EffectiveStatus(expiry); got != RemediationOpen {
+		t.Fatalf("at expiry status=%q, want fail-safe open", got)
+	}
+	view, err := NewView(mustAssessment(t), accepted, expiry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Expired || view.EffectiveState != RemediationOpen {
+		t.Fatalf("expired projection not fail-safe: %+v", view)
+	}
+}
+
+func TestExpiredAcceptanceCanBeExplicitlyRearmedToOpen(t *testing.T) {
+	state := mustLifecycle(t)
+	expiry := assessmentEpoch.Add(time.Hour)
+	accepted, _ := transition(t, state, "accept", RemediationAcceptedRisk, "alice", "temporary exception", &expiry, assessmentEpoch)
+	next, event, err := ApplyTransition(accepted, "expire", TransitionCommand{
+		To: RemediationOpen, Actor: "alice", Reason: "exception expired", ExpectedVersion: accepted.Version,
+	}, expiry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.From != RemediationAcceptedRisk || next.Status != RemediationOpen || next.AcceptedAt != nil || next.AcceptanceExpiresAt != nil {
+		t.Fatalf("unexpected expiry transition: next=%+v event=%+v", next, event)
+	}
+}
+
+func TestLifecycleRejectsMachineActors(t *testing.T) {
+	for _, actor := range []string{"", "agent:scanner", "llm:model", "mcp:tool", "system:worker", "machine:job", "bot:renovate", "service:sync"} {
+		t.Run(actor, func(t *testing.T) {
+			_, _, err := ApplyTransition(mustLifecycle(t), "event", TransitionCommand{
+				To: RemediationMitigating, Reason: "attempt", Actor: actor, ExpectedVersion: 1,
+			}, assessmentEpoch)
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("machine actor %q should fail, got %v", actor, err)
+			}
+		})
+	}
+}
+
+func TestLifecycleRejectsStaleInvalidAndTerminalChanges(t *testing.T) {
+	base := mustLifecycle(t)
+	expiryPast := assessmentEpoch.Add(-time.Minute)
+	cases := []struct {
+		name string
+		cmd  TransitionCommand
+		want error
+	}{
+		{name: "stale", cmd: TransitionCommand{To: RemediationMitigating, Actor: "alice", Reason: "x", ExpectedVersion: 2}, want: shared.ErrConflict},
+		{name: "unknown", cmd: TransitionCommand{To: "paused", Actor: "alice", Reason: "x", ExpectedVersion: 1}, want: shared.ErrValidation},
+		{name: "same", cmd: TransitionCommand{To: RemediationOpen, Actor: "alice", Reason: "x", ExpectedVersion: 1}, want: shared.ErrValidation},
+		{name: "no reason", cmd: TransitionCommand{To: RemediationMitigating, Actor: "alice", ExpectedVersion: 1}, want: shared.ErrValidation},
+		{name: "accept no expiry", cmd: TransitionCommand{To: RemediationAcceptedRisk, Actor: "alice", Reason: "x", CompensatingControl: "WAF", ExpectedVersion: 1}, want: shared.ErrValidation},
+		{name: "accept no control", cmd: TransitionCommand{To: RemediationAcceptedRisk, Actor: "alice", Reason: "x", AcceptanceExpiresAt: ptrTime(assessmentEpoch.Add(time.Hour)), ExpectedVersion: 1}, want: shared.ErrValidation},
+		{name: "accept past", cmd: TransitionCommand{To: RemediationAcceptedRisk, Actor: "alice", Reason: "x", CompensatingControl: "WAF", AcceptanceExpiresAt: &expiryPast, ExpectedVersion: 1}, want: shared.ErrValidation},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := ApplyTransition(base, "event", tc.cmd, assessmentEpoch)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("want %v, got %v", tc.want, err)
+			}
+		})
+	}
+	remediated, _ := transition(t, base, "finish", RemediationRemediated, "alice", "fixed", nil, assessmentEpoch)
+	if _, _, err := ApplyTransition(remediated, "reopen", TransitionCommand{
+		To: RemediationOpen, Actor: "alice", Reason: "new intelligence", ExpectedVersion: remediated.Version,
+	}, assessmentEpoch.Add(time.Hour)); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("terminal remediation reopened: %v", err)
+	}
+}
+
+func TestLifecycleValidationRejectsMalformedAcceptance(t *testing.T) {
+	base := mustLifecycle(t)
+	cases := []struct {
+		name string
+		edit func(*Lifecycle)
+	}{
+		{name: "version", edit: func(s *Lifecycle) { s.Version = 0 }},
+		{name: "actor", edit: func(s *Lifecycle) { s.UpdatedBy = "" }},
+		{name: "unknown", edit: func(s *Lifecycle) { s.Status = "paused" }},
+		{name: "metadata on open", edit: func(s *Lifecycle) { s.AcceptedBy = "alice" }},
+		{name: "accepted incomplete", edit: func(s *Lifecycle) { s.Status = RemediationAcceptedRisk }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := base
+			tc.edit(&state)
+			if err := state.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestViewOwnershipAndOverdue(t *testing.T) {
+	assessment := mustAssessment(t)
+	state := mustLifecycle(t)
+	view, err := NewView(assessment, state, assessment.Result.RemediateBy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Overdue || view.Expired || view.EffectiveState != RemediationOpen {
+		t.Fatalf("unexpected overdue view: %+v", view)
+	}
+	state.FindingID = "other"
+	if _, err := NewView(assessment, state, assessmentEpoch); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-owned join should fail, got %v", err)
+	}
+}
+
+func ptrTime(value time.Time) *time.Time { return &value }

--- a/internal/domain/sla/sla.go
+++ b/internal/domain/sla/sla.go
@@ -108,15 +108,47 @@ const (
 // context (common before an asset model is wired) yields a defensible, reproducible result rather than
 // an error.
 type Inputs struct {
-	Severity           shared.Severity
-	CVSSScore          float64 // 0..10 base score; when 0 the Severity label is used instead
-	KEV                bool    // CISA Known-Exploited
-	EPSS               float64 // 0..1 exploit-prediction probability
-	PublicPoC          bool
-	ActiveExploitation bool
-	Criticality        Criticality
-	Exposure           Exposure
-	Feasibility        Feasibility
+	Severity           shared.Severity `json:"severity"`
+	CVSSScore          float64         `json:"cvss_score"` // 0..10 base score; when 0 the Severity label is used instead
+	KEV                bool            `json:"kev"`        // CISA Known-Exploited
+	EPSS               float64         `json:"epss"`       // 0..1 exploit-prediction probability
+	PublicPoC          bool            `json:"public_poc"`
+	ActiveExploitation bool            `json:"active_exploitation"`
+	Criticality        Criticality     `json:"criticality,omitempty"`
+	Exposure           Exposure        `json:"exposure,omitempty"`
+	Feasibility        Feasibility     `json:"feasibility,omitempty"`
+}
+
+// Validate rejects inputs that would make a persisted SLA assessment ambiguous or impossible to
+// reproduce. Unknown asset context remains valid and neutral, but numeric risk signals must remain in
+// their documented ranges and every closed vocabulary must be recognized.
+func (in Inputs) Validate() error {
+	if in.Severity != "" && !in.Severity.Valid() {
+		return fmt.Errorf("%w: sla severity %q is invalid", shared.ErrValidation, in.Severity)
+	}
+	if in.CVSSScore < 0 || in.CVSSScore > 10 {
+		return fmt.Errorf("%w: sla cvss score must be between 0 and 10", shared.ErrValidation)
+	}
+	if in.EPSS < 0 || in.EPSS > 1 {
+		return fmt.Errorf("%w: sla epss must be between 0 and 1", shared.ErrValidation)
+	}
+	if !validExposure(in.Exposure) || !validCriticality(in.Criticality) || !validFeasibility(in.Feasibility) {
+		return fmt.Errorf("%w: sla context contains an unknown closed-vocabulary value", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validExposure(v Exposure) bool {
+	return v == ExposureUnknown || v == ExposureInternal || v == ExposureExternal
+}
+
+func validCriticality(v Criticality) bool {
+	return v == CriticalityUnknown || v == CriticalityLow || v == CriticalityMedium || v == CriticalityHigh
+}
+
+func validFeasibility(v Feasibility) bool {
+	return v == FeasibilityUnknown || v == FeasibilityPatchAvailable || v == FeasibilityChangeWindow ||
+		v == FeasibilityCompensatingControl || v == FeasibilityNoPatch
 }
 
 // Breakdown is the explainable decomposition of the score: each factor's contribution, plus the names

--- a/internal/infrastructure/persistence/memory/sla_store.go
+++ b/internal/infrastructure/persistence/memory/sla_store.go
@@ -116,8 +116,12 @@ func (s *SLAStore) UpsertAssessment(ctx context.Context, assessment sla.Assessme
 	if existing, ok := s.assessments[idKey]; ok {
 		return sla.AssessmentUpsertResult{Assessment: cloneSLAAssessment(existing)}, nil
 	}
-	if previousID, ok := s.current[key]; ok && assessment.PreviousAssessmentID.IsZero() {
-		assessment.PreviousAssessmentID = previousID
+	if previousID, ok := s.current[key]; ok {
+		previous := s.assessments[slaAssessmentKey(tenantID, previousID)]
+		assessment, err = sla.ContinueAssessment(assessment, previous)
+		if err != nil {
+			return sla.AssessmentUpsertResult{}, err
+		}
 	}
 	s.assessments[idKey] = cloneSLAAssessment(assessment)
 	s.current[key] = assessment.ID

--- a/internal/infrastructure/persistence/memory/sla_store.go
+++ b/internal/infrastructure/persistence/memory/sla_store.go
@@ -1,0 +1,324 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// SLAStore is the development/test adapter for the complete SLA governance aggregate. It mirrors
+// the PostgreSQL adapter's tenant checks, idempotency, immutable history, optimistic transitions,
+// and preservation of human state during machine assessment refreshes.
+type SLAStore struct {
+	mu sync.RWMutex
+
+	policies     map[string]sla.Policy
+	activePolicy map[shared.ID]string
+	assessments  map[string]sla.Assessment
+	current      map[string]shared.ID
+	lifecycles   map[string]sla.Lifecycle
+	events       map[string][]sla.LifecycleEvent
+}
+
+func NewSLAStore() *SLAStore {
+	return &SLAStore{
+		policies: map[string]sla.Policy{}, activePolicy: map[shared.ID]string{},
+		assessments: map[string]sla.Assessment{}, current: map[string]shared.ID{},
+		lifecycles: map[string]sla.Lifecycle{}, events: map[string][]sla.LifecycleEvent{},
+	}
+}
+
+var _ ports.SLAStore = (*SLAStore)(nil)
+
+func (s *SLAStore) PutPolicy(ctx context.Context, policy sla.Policy, activate bool) (bool, error) {
+	tenantID, err := slaMemoryTenant(ctx, policy.TenantID)
+	if err != nil {
+		return false, err
+	}
+	policy.TenantID = tenantID
+	if err := policy.Validate(); err != nil {
+		return false, err
+	}
+	key := slaPolicyKey(tenantID, policy.Config.Version)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, exists := s.policies[key]
+	if exists && existing.SHA256 != policy.SHA256 {
+		return false, fmt.Errorf("%w: sla policy version already has different content", shared.ErrConflict)
+	}
+	if !exists {
+		s.policies[key] = cloneSLAPolicy(policy)
+	}
+	if activate {
+		s.activePolicy[tenantID] = policy.Config.Version
+	}
+	return !exists, nil
+}
+
+func (s *SLAStore) ActivePolicy(ctx context.Context, tenantID shared.ID) (sla.Policy, error) {
+	tenantID, err := slaMemoryTenant(ctx, tenantID)
+	if err != nil {
+		return sla.Policy{}, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	version, ok := s.activePolicy[tenantID]
+	if !ok {
+		return sla.Policy{}, shared.ErrNotFound
+	}
+	policy, ok := s.policies[slaPolicyKey(tenantID, version)]
+	if !ok {
+		return sla.Policy{}, shared.ErrNotFound
+	}
+	return cloneSLAPolicy(policy), nil
+}
+
+func (s *SLAStore) PolicyHistory(ctx context.Context, tenantID shared.ID) ([]sla.Policy, error) {
+	tenantID, err := slaMemoryTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	items := make([]sla.Policy, 0)
+	for _, policy := range s.policies {
+		if policy.TenantID == tenantID {
+			items = append(items, cloneSLAPolicy(policy))
+		}
+	}
+	s.mu.RUnlock()
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].Config.Version > items[j].Config.Version
+		}
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
+	return items, nil
+}
+
+func (s *SLAStore) UpsertAssessment(ctx context.Context, assessment sla.Assessment) (sla.AssessmentUpsertResult, error) {
+	tenantID, err := slaMemoryTenant(ctx, assessment.TenantID)
+	if err != nil {
+		return sla.AssessmentUpsertResult{}, err
+	}
+	assessment.TenantID = tenantID
+	if err := assessment.Validate(); err != nil {
+		return sla.AssessmentUpsertResult{}, err
+	}
+	key := slaFindingKey(tenantID, assessment.EngagementID, assessment.FindingID)
+	idKey := slaAssessmentKey(tenantID, assessment.ID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.assessments[idKey]; ok {
+		return sla.AssessmentUpsertResult{Assessment: cloneSLAAssessment(existing)}, nil
+	}
+	if previousID, ok := s.current[key]; ok && assessment.PreviousAssessmentID.IsZero() {
+		assessment.PreviousAssessmentID = previousID
+	}
+	s.assessments[idKey] = cloneSLAAssessment(assessment)
+	s.current[key] = assessment.ID
+	state, exists := s.lifecycles[key]
+	if !exists {
+		state, err = sla.NewLifecycle(assessment, assessment.AssessedAt)
+		if err != nil {
+			return sla.AssessmentUpsertResult{}, err
+		}
+	} else {
+		// Risk intelligence advances provenance only. Status, acceptance, human attribution,
+		// timestamps, and version are deliberately untouched.
+		state.AssessmentID = assessment.ID
+	}
+	s.lifecycles[key] = cloneSLALifecycle(state)
+	return sla.AssessmentUpsertResult{Assessment: cloneSLAAssessment(assessment), Created: true}, nil
+}
+
+func (s *SLAStore) Current(ctx context.Context, tenantID, engagementID, findingID shared.ID) (sla.Current, error) {
+	tenantID, err := slaMemoryTenant(ctx, tenantID)
+	if err != nil {
+		return sla.Current{}, err
+	}
+	key := slaFindingKey(tenantID, engagementID, findingID)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	assessmentID, ok := s.current[key]
+	if !ok {
+		return sla.Current{}, shared.ErrNotFound
+	}
+	assessment, assessmentOK := s.assessments[slaAssessmentKey(tenantID, assessmentID)]
+	state, stateOK := s.lifecycles[key]
+	if !assessmentOK || !stateOK {
+		return sla.Current{}, fmt.Errorf("sla current pointer is incomplete: %w", shared.ErrNotFound)
+	}
+	return sla.Current{Assessment: cloneSLAAssessment(assessment), Lifecycle: cloneSLALifecycle(state)}, nil
+}
+
+func (s *SLAStore) ListCurrent(ctx context.Context, tenantID, engagementID shared.ID) ([]sla.Current, error) {
+	tenantID, err := slaMemoryTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	items := make([]sla.Current, 0)
+	for key, assessmentID := range s.current {
+		assessment, ok := s.assessments[slaAssessmentKey(tenantID, assessmentID)]
+		if !ok || assessment.TenantID != tenantID || assessment.EngagementID != engagementID {
+			continue
+		}
+		state, ok := s.lifecycles[key]
+		if !ok {
+			continue
+		}
+		items = append(items, sla.Current{Assessment: cloneSLAAssessment(assessment), Lifecycle: cloneSLALifecycle(state)})
+	}
+	s.mu.RUnlock()
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Assessment.Result.RemediateBy.Equal(items[j].Assessment.Result.RemediateBy) {
+			return items[i].Assessment.FindingID < items[j].Assessment.FindingID
+		}
+		return items[i].Assessment.Result.RemediateBy.Before(items[j].Assessment.Result.RemediateBy)
+	})
+	return items, nil
+}
+
+func (s *SLAStore) AssessmentHistory(ctx context.Context, tenantID, engagementID, findingID shared.ID) ([]sla.Assessment, error) {
+	tenantID, err := slaMemoryTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	items := make([]sla.Assessment, 0)
+	for _, assessment := range s.assessments {
+		if assessment.TenantID == tenantID && assessment.EngagementID == engagementID && assessment.FindingID == findingID {
+			items = append(items, cloneSLAAssessment(assessment))
+		}
+	}
+	s.mu.RUnlock()
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].AssessedAt.Equal(items[j].AssessedAt) {
+			return items[i].ID > items[j].ID
+		}
+		return items[i].AssessedAt.After(items[j].AssessedAt)
+	})
+	return items, nil
+}
+
+func (s *SLAStore) SaveTransition(ctx context.Context, next sla.Lifecycle, event sla.LifecycleEvent) error {
+	tenantID, err := slaMemoryTenant(ctx, next.TenantID)
+	if err != nil {
+		return err
+	}
+	next.TenantID, event.TenantID = tenantID, tenantID
+	if err := next.Validate(); err != nil {
+		return err
+	}
+	if err := validateSLAEvent(next, event); err != nil {
+		return err
+	}
+	key := slaFindingKey(tenantID, next.EngagementID, next.FindingID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.lifecycles[key]
+	if !ok {
+		return shared.ErrNotFound
+	}
+	// A machine intelligence refresh deliberately leaves Version unchanged while advancing
+	// AssessmentID. Compare both: otherwise a human decision made from a stale risk view could race
+	// the refresh and move the lifecycle pointer back to the old assessment.
+	if current.Version != event.BeforeVersion || next.Version != current.Version+1 ||
+		current.AssessmentID != next.AssessmentID {
+		return fmt.Errorf("sla lifecycle changed: %w", shared.ErrConflict)
+	}
+	for _, existing := range s.events[key] {
+		if existing.ID == event.ID {
+			return fmt.Errorf("sla lifecycle event already exists: %w", shared.ErrConflict)
+		}
+	}
+	s.lifecycles[key] = cloneSLALifecycle(next)
+	s.events[key] = append(s.events[key], cloneSLAEvent(event))
+	return nil
+}
+
+func (s *SLAStore) LifecycleEvents(ctx context.Context, tenantID, engagementID, findingID shared.ID) ([]sla.LifecycleEvent, error) {
+	tenantID, err := slaMemoryTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	stored := s.events[slaFindingKey(tenantID, engagementID, findingID)]
+	items := make([]sla.LifecycleEvent, len(stored))
+	for i := range stored {
+		items[i] = cloneSLAEvent(stored[i])
+	}
+	s.mu.RUnlock()
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].At.Equal(items[j].At) {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].At.Before(items[j].At)
+	})
+	return items, nil
+}
+
+func slaMemoryTenant(ctx context.Context, requested shared.ID) (shared.ID, error) {
+	bound, err := requiredTenant(ctx)
+	if err != nil {
+		return "", err
+	}
+	requested = shared.TenantOrDefault(requested)
+	if requested != bound {
+		return "", fmt.Errorf("%w: sla tenant does not match context", shared.ErrValidation)
+	}
+	return bound, nil
+}
+
+func validateSLAEvent(next sla.Lifecycle, event sla.LifecycleEvent) error {
+	if event.ID.IsZero() || event.TenantID != next.TenantID || event.EngagementID != next.EngagementID ||
+		event.FindingID != next.FindingID || event.AssessmentID != next.AssessmentID || event.To != next.Status ||
+		event.AfterVersion != next.Version || event.BeforeVersion+1 != event.AfterVersion || event.At.IsZero() {
+		return fmt.Errorf("%w: sla lifecycle event does not match next state", shared.ErrValidation)
+	}
+	return nil
+}
+
+func slaPolicyKey(tenantID shared.ID, version string) string {
+	return tenantID.String() + "\x00" + version
+}
+
+func slaFindingKey(tenantID, engagementID, findingID shared.ID) string {
+	return tenantID.String() + "\x00" + engagementID.String() + "\x00" + findingID.String()
+}
+
+func slaAssessmentKey(tenantID, assessmentID shared.ID) string {
+	return tenantID.String() + "\x00" + assessmentID.String()
+}
+
+func cloneSLAPolicy(value sla.Policy) sla.Policy { return value }
+
+func cloneSLAAssessment(value sla.Assessment) sla.Assessment {
+	value.Result.Breakdown.Overrides = append([]string(nil), value.Result.Breakdown.Overrides...)
+	return value
+}
+
+func cloneSLALifecycle(value sla.Lifecycle) sla.Lifecycle {
+	if value.AcceptedAt != nil {
+		copied := *value.AcceptedAt
+		value.AcceptedAt = &copied
+	}
+	if value.AcceptanceExpiresAt != nil {
+		copied := *value.AcceptanceExpiresAt
+		value.AcceptanceExpiresAt = &copied
+	}
+	return value
+}
+
+func cloneSLAEvent(value sla.LifecycleEvent) sla.LifecycleEvent {
+	if value.AcceptanceExpiresAt != nil {
+		copied := *value.AcceptanceExpiresAt
+		value.AcceptanceExpiresAt = &copied
+	}
+	return value
+}

--- a/internal/infrastructure/persistence/memory/sla_store.go
+++ b/internal/infrastructure/persistence/memory/sla_store.go
@@ -117,7 +117,10 @@ func (s *SLAStore) UpsertAssessment(ctx context.Context, assessment sla.Assessme
 		return sla.AssessmentUpsertResult{Assessment: cloneSLAAssessment(existing)}, nil
 	}
 	if previousID, ok := s.current[key]; ok {
-		previous := s.assessments[slaAssessmentKey(tenantID, previousID)]
+		previous, exists := s.assessments[slaAssessmentKey(tenantID, previousID)]
+		if !exists {
+			return sla.AssessmentUpsertResult{}, fmt.Errorf("load current sla assessment: %w", shared.ErrNotFound)
+		}
 		assessment, err = sla.ContinueAssessment(assessment, previous)
 		if err != nil {
 			return sla.AssessmentUpsertResult{}, err

--- a/internal/infrastructure/persistence/memory/sla_store_test.go
+++ b/internal/infrastructure/persistence/memory/sla_store_test.go
@@ -134,6 +134,10 @@ func TestSLAStoreMaterialRefreshLinksHistoryAndPreservesHumanState(t *testing.T)
 	if err != nil || !upserted.Created || upserted.Assessment.PreviousAssessmentID != first.ID {
 		t.Fatalf("refresh=%+v err=%v", upserted, err)
 	}
+	if !upserted.Assessment.DeadlineAnchorAt.Equal(first.DeadlineAnchorAt) ||
+		upserted.Assessment.Result.RemediateBy.After(first.Result.RemediateBy) {
+		t.Fatalf("refresh reset or extended SLA clock: first=%+v refresh=%+v", first, upserted.Assessment)
+	}
 	current, err = store.Current(ctx, "tenant-a", "eng-1", "finding-1")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/infrastructure/persistence/memory/sla_store_test.go
+++ b/internal/infrastructure/persistence/memory/sla_store_test.go
@@ -154,6 +154,25 @@ func TestSLAStoreMaterialRefreshLinksHistoryAndPreservesHumanState(t *testing.T)
 	}
 }
 
+func TestSLAStoreMissingCurrentPredecessorReturnsNotFound(t *testing.T) {
+	store := NewSLAStore()
+	ctx := slaContext("tenant-a")
+	first := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.1, slaStoreEpoch)
+	if _, err := store.UpsertAssessment(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate an impossible corrupt adapter state: the current pointer survived but its immutable
+	// artifact did not. PostgreSQL reports ErrNotFound for the same condition, so memory must match.
+	store.mu.Lock()
+	delete(store.assessments, slaAssessmentKey("tenant-a", first.ID))
+	store.mu.Unlock()
+
+	refresh := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.9, slaStoreEpoch.Add(time.Hour))
+	if _, err := store.UpsertAssessment(ctx, refresh); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("missing current predecessor error=%v, want not found", err)
+	}
+}
+
 func TestSLAStoreTransitionIsAtomicAndOptimistic(t *testing.T) {
 	store := NewSLAStore()
 	ctx := slaContext("tenant-a")

--- a/internal/infrastructure/persistence/memory/sla_store_test.go
+++ b/internal/infrastructure/persistence/memory/sla_store_test.go
@@ -1,0 +1,286 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+)
+
+var slaStoreEpoch = time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC)
+
+func slaContext(tenant shared.ID) context.Context {
+	return shared.WithTenant(context.Background(), tenant)
+}
+
+func slaAssessmentFor(t *testing.T, tenant, engagement, finding shared.ID, epss float64, at time.Time) sla.Assessment {
+	t.Helper()
+	item, err := sla.Evaluate(sla.AssessmentInput{
+		TenantID: tenant, EngagementID: engagement, FindingID: finding,
+		Risk: sla.Inputs{Severity: shared.SeverityHigh, CVSSScore: 8.1, EPSS: epss, Feasibility: sla.FeasibilityPatchAvailable},
+	}, sla.DefaultConfig(), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return item
+}
+
+func slaPolicyFor(t *testing.T, tenant shared.ID, version, actor string, at time.Time) sla.Policy {
+	t.Helper()
+	cfg := sla.DefaultConfig()
+	cfg.Version = version
+	policy, err := sla.NewPolicy(tenant, cfg, actor, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return policy
+}
+
+func TestSLAStorePolicyActivationHistoryAndIdempotency(t *testing.T) {
+	store := NewSLAStore()
+	ctx := slaContext("tenant-a")
+	v1 := slaPolicyFor(t, "tenant-a", "sla-v1", "alice", slaStoreEpoch)
+	created, err := store.PutPolicy(ctx, v1, true)
+	if err != nil || !created {
+		t.Fatalf("put v1 created=%v err=%v", created, err)
+	}
+	created, err = store.PutPolicy(ctx, v1, true)
+	if err != nil || created {
+		t.Fatalf("replay v1 created=%v err=%v", created, err)
+	}
+	v2 := slaPolicyFor(t, "tenant-a", "sla-v2", "bob", slaStoreEpoch.Add(time.Hour))
+	if created, err = store.PutPolicy(ctx, v2, true); err != nil || !created {
+		t.Fatalf("put v2 created=%v err=%v", created, err)
+	}
+	active, err := store.ActivePolicy(ctx, "tenant-a")
+	if err != nil || active.Config.Version != "sla-v2" {
+		t.Fatalf("active=%+v err=%v", active, err)
+	}
+	history, err := store.PolicyHistory(ctx, "tenant-a")
+	if err != nil || len(history) != 2 || history[0].Config.Version != "sla-v2" || history[1].Config.Version != "sla-v1" {
+		t.Fatalf("history=%+v err=%v", history, err)
+	}
+}
+
+func TestSLAStorePolicyVersionCannotBeRewritten(t *testing.T) {
+	store := NewSLAStore()
+	ctx := slaContext("tenant-a")
+	policy := slaPolicyFor(t, "tenant-a", "policy-1", "alice", slaStoreEpoch)
+	if _, err := store.PutPolicy(ctx, policy, true); err != nil {
+		t.Fatal(err)
+	}
+	changed := sla.DefaultConfig()
+	changed.Version = "policy-1"
+	changed.Thresholds.High++
+	forged, err := sla.NewPolicy("tenant-a", changed, "bob", slaStoreEpoch.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.PutPolicy(ctx, forged, true); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("policy rewrite should conflict, got %v", err)
+	}
+}
+
+func TestSLAStoreAssessmentReplayPreservesOriginalDeadlines(t *testing.T) {
+	store := NewSLAStore()
+	ctx := slaContext("tenant-a")
+	first := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.4, slaStoreEpoch)
+	stored, err := store.UpsertAssessment(ctx, first)
+	if err != nil || !stored.Created {
+		t.Fatalf("first upsert=%+v err=%v", stored, err)
+	}
+	replay := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.4, slaStoreEpoch.Add(48*time.Hour))
+	if replay.ID != first.ID || replay.Result.RemediateBy == first.Result.RemediateBy {
+		t.Fatal("test setup does not represent same material input at a later clock")
+	}
+	stored, err = store.UpsertAssessment(ctx, replay)
+	if err != nil || stored.Created {
+		t.Fatalf("replay upsert=%+v err=%v", stored, err)
+	}
+	if !stored.Assessment.Result.RemediateBy.Equal(first.Result.RemediateBy) || !stored.Assessment.CreatedAt.Equal(first.CreatedAt) {
+		t.Fatalf("replay moved durable deadline: first=%+v replay=%+v", first, stored.Assessment)
+	}
+	current, err := store.Current(ctx, "tenant-a", "eng-1", "finding-1")
+	if err != nil || current.Lifecycle.Status != sla.RemediationOpen || current.Lifecycle.Version != 1 {
+		t.Fatalf("current=%+v err=%v", current, err)
+	}
+}
+
+func TestSLAStoreMaterialRefreshLinksHistoryAndPreservesHumanState(t *testing.T) {
+	store := NewSLAStore()
+	ctx := slaContext("tenant-a")
+	first := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.1, slaStoreEpoch)
+	if _, err := store.UpsertAssessment(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	current, _ := store.Current(ctx, "tenant-a", "eng-1", "finding-1")
+	expires := slaStoreEpoch.Add(30 * 24 * time.Hour)
+	nextState, event, err := sla.ApplyTransition(current.Lifecycle, "event-1", sla.TransitionCommand{
+		To: sla.RemediationAcceptedRisk, Actor: "alice", Reason: "vendor exception", ExpectedVersion: 1,
+		CompensatingControl: "WAF", AcceptanceExpiresAt: &expires,
+	}, slaStoreEpoch.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveTransition(ctx, nextState, event); err != nil {
+		t.Fatal(err)
+	}
+	refresh := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.9, slaStoreEpoch.Add(2*time.Hour))
+	upserted, err := store.UpsertAssessment(ctx, refresh)
+	if err != nil || !upserted.Created || upserted.Assessment.PreviousAssessmentID != first.ID {
+		t.Fatalf("refresh=%+v err=%v", upserted, err)
+	}
+	current, err = store.Current(ctx, "tenant-a", "eng-1", "finding-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := current.Lifecycle
+	if state.AssessmentID != refresh.ID || state.Status != sla.RemediationAcceptedRisk || state.Version != 2 ||
+		state.AcceptedBy != "alice" || state.AcceptanceExpiresAt == nil || !state.AcceptanceExpiresAt.Equal(expires) ||
+		state.UpdatedBy != "alice" {
+		t.Fatalf("machine refresh clobbered human state: %+v", state)
+	}
+	history, err := store.AssessmentHistory(ctx, "tenant-a", "eng-1", "finding-1")
+	if err != nil || len(history) != 2 || history[0].ID != refresh.ID || history[1].ID != first.ID {
+		t.Fatalf("history=%+v err=%v", history, err)
+	}
+}
+
+func TestSLAStoreTransitionIsAtomicAndOptimistic(t *testing.T) {
+	store := NewSLAStore()
+	ctx := slaContext("tenant-a")
+	assessment := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.1, slaStoreEpoch)
+	if _, err := store.UpsertAssessment(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	current, _ := store.Current(ctx, "tenant-a", "eng-1", "finding-1")
+	next, event, err := sla.ApplyTransition(current.Lifecycle, "event-1", sla.TransitionCommand{
+		To: sla.RemediationMitigating, Actor: "alice", Reason: "change scheduled", ExpectedVersion: 1,
+	}, slaStoreEpoch.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveTransition(ctx, next, event); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveTransition(ctx, next, event); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale replay should conflict, got %v", err)
+	}
+	events, err := store.LifecycleEvents(ctx, "tenant-a", "eng-1", "finding-1")
+	if err != nil || len(events) != 1 || events[0].ID != "event-1" {
+		t.Fatalf("events=%+v err=%v", events, err)
+	}
+	got, _ := store.Current(ctx, "tenant-a", "eng-1", "finding-1")
+	if got.Lifecycle.Version != 2 || got.Lifecycle.Status != sla.RemediationMitigating {
+		t.Fatalf("unexpected current state: %+v", got.Lifecycle)
+	}
+}
+
+func TestSLAStoreTransitionConflictsWithConcurrentRiskRefresh(t *testing.T) {
+	store := NewSLAStore()
+	ctx := slaContext("tenant-a")
+	first := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.1, slaStoreEpoch)
+	if _, err := store.UpsertAssessment(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	stale, _ := store.Current(ctx, "tenant-a", "eng-1", "finding-1")
+	next, event, err := sla.ApplyTransition(stale.Lifecycle, "event-stale-risk", sla.TransitionCommand{
+		To: sla.RemediationMitigating, Actor: "alice", Reason: "scheduled from old risk view", ExpectedVersion: 1,
+	}, slaStoreEpoch.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	refresh := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.95, slaStoreEpoch.Add(30*time.Minute))
+	if _, err := store.UpsertAssessment(ctx, refresh); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveTransition(ctx, next, event); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("transition from stale risk view should conflict, got %v", err)
+	}
+	current, err := store.Current(ctx, "tenant-a", "eng-1", "finding-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Assessment.ID != refresh.ID || current.Lifecycle.AssessmentID != refresh.ID ||
+		current.Lifecycle.Status != sla.RemediationOpen || current.Lifecycle.Version != 1 {
+		t.Fatalf("stale transition rolled back refreshed provenance: %+v", current)
+	}
+	events, err := store.LifecycleEvents(ctx, "tenant-a", "eng-1", "finding-1")
+	if err != nil || len(events) != 0 {
+		t.Fatalf("conflicting transition appended events=%+v err=%v", events, err)
+	}
+}
+
+func TestSLAStoreListOrdersByDueDateThenFinding(t *testing.T) {
+	store := NewSLAStore()
+	ctx := slaContext("tenant-a")
+	inputs := []struct {
+		id   shared.ID
+		epss float64
+	}{
+		{id: "finding-low", epss: 0},
+		{id: "finding-hot-b", epss: 0.9},
+		{id: "finding-hot-a", epss: 0.9},
+	}
+	for _, input := range inputs {
+		if _, err := store.UpsertAssessment(ctx, slaAssessmentFor(t, "tenant-a", "eng-1", input.id, input.epss, slaStoreEpoch)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	items, err := store.ListCurrent(ctx, "tenant-a", "eng-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, len(items))
+	for i := range items {
+		got[i] = items[i].Assessment.FindingID.String()
+	}
+	want := []string{"finding-hot-a", "finding-hot-b", "finding-low"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("order=%v, want %v", got, want)
+	}
+}
+
+func TestSLAStoreFailsClosedAcrossTenantBoundaries(t *testing.T) {
+	store := NewSLAStore()
+	ctxA := slaContext("tenant-a")
+	ctxB := slaContext("tenant-b")
+	assessment := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.2, slaStoreEpoch)
+	if _, err := store.UpsertAssessment(context.Background(), assessment); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant context should fail, got %v", err)
+	}
+	if _, err := store.UpsertAssessment(ctxB, assessment); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("mismatched tenant should fail, got %v", err)
+	}
+	if _, err := store.UpsertAssessment(ctxA, assessment); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Current(ctxB, "tenant-a", "eng-1", "finding-1"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant read should fail, got %v", err)
+	}
+	if _, err := store.Current(ctxB, "tenant-b", "eng-1", "finding-1"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("tenant B should see not found, got %v", err)
+	}
+}
+
+func TestSLAStoreReturnsDefensiveCopies(t *testing.T) {
+	store := NewSLAStore()
+	ctx := slaContext("tenant-a")
+	assessment := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.2, slaStoreEpoch)
+	assessment.Result.Breakdown.Overrides = []string{"one"}
+	// Recompute validation identity is unaffected because overrides are output. This deliberately
+	// exercises adapter cloning rather than the scorer.
+	if _, err := store.UpsertAssessment(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := store.Current(ctx, "tenant-a", "eng-1", "finding-1")
+	first.Assessment.Result.Breakdown.Overrides[0] = "mutated"
+	second, _ := store.Current(ctx, "tenant-a", "eng-1", "finding-1")
+	if second.Assessment.Result.Breakdown.Overrides[0] != "one" {
+		t.Fatal("caller mutated store-owned assessment slice")
+	}
+}

--- a/internal/infrastructure/persistence/memory/vulnerability_risk_assessment_store.go
+++ b/internal/infrastructure/persistence/memory/vulnerability_risk_assessment_store.go
@@ -45,6 +45,11 @@ func (s *VulnerabilityRiskAssessmentStore) Upsert(ctx context.Context, assessmen
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if existing, ok := s.byID[hashKey]; ok {
+		// An occurrence can return to a historically seen state (for example
+		// no_longer_detected -> detected). The immutable assessment is reused, but it must become
+		// current again; otherwise reads remain pinned to the retired state and re-exposure work is
+		// silently lost.
+		s.current[key] = existing.ID
 		return vulnerabilityrisk.Result{Assessment: cloneAssessment(existing)}, nil
 	}
 	if currentID, ok := s.current[key]; ok && assessment.PreviousAssessmentID.IsZero() {

--- a/internal/infrastructure/persistence/memory/vulnerability_risk_assessment_store_test.go
+++ b/internal/infrastructure/persistence/memory/vulnerability_risk_assessment_store_test.go
@@ -33,3 +33,49 @@ func TestVulnerabilityRiskAssessmentStoreIsAppendOnlyAndIdempotent(t *testing.T)
 		t.Fatalf("history=%+v err=%v", history, err)
 	}
 }
+
+func TestVulnerabilityRiskAssessmentStoreRepromotesHistoricalAssessment(t *testing.T) {
+	store := NewVulnerabilityRiskAssessmentStore()
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	input := vulnerabilityrisk.Input{
+		TenantID: "tenant-a", EngagementID: "eng-1", OccurrenceID: "occ-1", AdvisoryID: "CVE-1",
+		AdvisoryRevision: 1, ComponentFingerprint: "fp", Severity: shared.SeverityHigh,
+		CVSSScore: 8, EPSS: 0.5, Scope: "production", Reachability: "high", OccurrenceState: "detected",
+	}
+	detected, err := vulnerabilityrisk.Evaluate(input, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Upsert(ctx, detected); err != nil {
+		t.Fatal(err)
+	}
+	input.OccurrenceState = "no_longer_detected"
+	retired, err := vulnerabilityrisk.Evaluate(input, now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Upsert(ctx, retired); err != nil {
+		t.Fatal(err)
+	}
+	input.OccurrenceState = "detected"
+	reexposed, err := vulnerabilityrisk.Evaluate(input, now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reexposed.ID != detected.ID {
+		t.Fatalf("test setup did not replay historical assessment: first=%s replay=%s", detected.ID, reexposed.ID)
+	}
+	result, err := store.Upsert(ctx, reexposed)
+	if err != nil || result.Created {
+		t.Fatalf("historical replay=%+v err=%v", result, err)
+	}
+	current, err := store.Current(ctx, "tenant-a", "occ-1")
+	if err != nil || current.ID != detected.ID || current.OccurrenceState != "detected" {
+		t.Fatalf("historical assessment was not re-promoted: %+v err=%v", current, err)
+	}
+	history, err := store.History(ctx, "tenant-a", "occ-1")
+	if err != nil || len(history) != 2 {
+		t.Fatalf("re-promotion must not duplicate history: %+v err=%v", history, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/sla_store.go
+++ b/internal/infrastructure/persistence/postgres/sla_store.go
@@ -2,11 +2,14 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -130,8 +133,8 @@ func (s *SLAStore) UpsertAssessment(ctx context.Context, assessment sla.Assessme
 		// Serialize every candidate for one finding, including its first assessment. A row lock
 		// cannot protect the absent-pointer case, so use a transaction advisory lock on the stable
 		// tenant/engagement/finding identity.
-		lockKey := tenantID.String() + "\x00" + assessment.EngagementID.String() + "\x00" + assessment.FindingID.String()
-		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, lockKey); err != nil {
+		lockKey := slaFindingAdvisoryLockKey(tenantID, assessment.EngagementID, assessment.FindingID)
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, lockKey); err != nil {
 			return fmt.Errorf("lock sla finding: %w", err)
 		}
 		var existing sla.Assessment
@@ -151,8 +154,19 @@ func (s *SLAStore) UpsertAssessment(ctx context.Context, assessment sla.Assessme
 			assessment.PreviousAssessmentID = ""
 		} else if err != nil {
 			return fmt.Errorf("load current sla assessment pointer: %w", err)
-		} else if assessment.PreviousAssessmentID.IsZero() {
-			assessment.PreviousAssessmentID = shared.ID(previousID)
+		} else {
+			var previous sla.Assessment
+			found, err := loadSLAAssessment(ctx, tx, tenantID, shared.ID(previousID), &previous)
+			if err != nil {
+				return err
+			}
+			if !found {
+				return fmt.Errorf("load current sla assessment: %w", shared.ErrNotFound)
+			}
+			assessment, err = sla.ContinueAssessment(assessment, previous)
+			if err != nil {
+				return err
+			}
 		}
 		if err := insertSLAAssessment(ctx, tx, assessment); err != nil {
 			return err
@@ -287,6 +301,9 @@ func (s *SLAStore) SaveTransition(ctx context.Context, next sla.Lifecycle, event
 			event.EngagementID.String(), event.FindingID.String(), event.AssessmentID.String(), string(event.From),
 			string(event.To), event.Reason, event.CompensatingControl, event.AcceptanceExpiresAt, event.Actor,
 			event.BeforeVersion, event.AfterVersion, event.At); err != nil {
+			if postgresUniqueViolation(err) {
+				return fmt.Errorf("insert sla lifecycle event: %v: %w", err, shared.ErrConflict)
+			}
 			return fmt.Errorf("insert sla lifecycle event: %w", err)
 		}
 		return nil
@@ -323,7 +340,7 @@ func (s *SLAStore) LifecycleEvents(ctx context.Context, tenantID, engagementID, 
 }
 
 const slaAssessmentColumns = `tenant_id,id,engagement_id,finding_id,source_risk_assessment_id,inputs,result,
-	input_hash,config_hash,previous_assessment_id,assessed_at,created_at`
+	input_hash,config_hash,previous_assessment_id,deadline_anchor_at,assessed_at,created_at`
 
 const slaLifecycleColumns = `lifecycle.tenant_id,lifecycle.engagement_id,lifecycle.finding_id,lifecycle.assessment_id,
 	lifecycle.status,lifecycle.version,lifecycle.reason,lifecycle.compensating_control,lifecycle.accepted_by,
@@ -338,7 +355,8 @@ const currentSLAQuery = `SELECT ` + slaAssessmentPrefixedColumns + `,` + slaLife
 
 const slaAssessmentPrefixedColumns = `assessment.tenant_id,assessment.id,assessment.engagement_id,
 	assessment.finding_id,assessment.source_risk_assessment_id,assessment.inputs,assessment.result,
-	assessment.input_hash,assessment.config_hash,assessment.previous_assessment_id,assessment.assessed_at,assessment.created_at`
+	assessment.input_hash,assessment.config_hash,assessment.previous_assessment_id,assessment.deadline_anchor_at,
+	assessment.assessed_at,assessment.created_at`
 
 func slaPostgresTenant(ctx context.Context, requested shared.ID) (shared.ID, error) {
 	bound, ok := shared.TenantFrom(ctx)
@@ -380,7 +398,7 @@ func scanSLAAssessment(row interface{ Scan(...any) error }, item *sla.Assessment
 	var sourceID, previousID pgtype.Text
 	if err := row.Scan(&item.TenantID, &item.ID, &item.EngagementID, &item.FindingID,
 		&sourceID, &inputJSON, &resultJSON, &item.InputHash, &item.ConfigHash,
-		&previousID, &item.AssessedAt, &item.CreatedAt); err != nil {
+		&previousID, &item.DeadlineAnchorAt, &item.AssessedAt, &item.CreatedAt); err != nil {
 		return err
 	}
 	item.SourceRiskAssessmentID, item.PreviousAssessmentID = "", ""
@@ -420,7 +438,8 @@ func scanSLACurrent(row interface{ Scan(...any) error }, item *sla.Current) erro
 	if err := row.Scan(&item.Assessment.TenantID, &item.Assessment.ID, &item.Assessment.EngagementID,
 		&item.Assessment.FindingID, &sourceID, &inputJSON, &resultJSON,
 		&item.Assessment.InputHash, &item.Assessment.ConfigHash, &previousID,
-		&item.Assessment.AssessedAt, &item.Assessment.CreatedAt, &item.Lifecycle.TenantID,
+		&item.Assessment.DeadlineAnchorAt, &item.Assessment.AssessedAt, &item.Assessment.CreatedAt,
+		&item.Lifecycle.TenantID,
 		&item.Lifecycle.EngagementID, &item.Lifecycle.FindingID, &item.Lifecycle.AssessmentID,
 		&item.Lifecycle.Status, &item.Lifecycle.Version, &item.Lifecycle.Reason,
 		&item.Lifecycle.CompensatingControl, &item.Lifecycle.AcceptedBy, &item.Lifecycle.AcceptedAt,
@@ -457,11 +476,13 @@ func insertSLAAssessment(ctx context.Context, tx pgx.Tx, item sla.Assessment) er
 	}
 	_, err = tx.Exec(ctx, `INSERT INTO sla_assessments
 		(tenant_id,id,engagement_id,finding_id,source_risk_assessment_id,inputs,result,input_hash,
-		config_hash,config_version,tier,score,mitigate_by,remediate_by,previous_assessment_id,assessed_at,created_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`, item.TenantID.String(),
+		config_hash,config_version,tier,score,mitigate_by,remediate_by,previous_assessment_id,
+		deadline_anchor_at,assessed_at,created_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`, item.TenantID.String(),
 		item.ID.String(), item.EngagementID.String(), item.FindingID.String(), nullableSLAID(item.SourceRiskAssessmentID),
 		inputs, result, item.InputHash, item.ConfigHash, item.Result.ConfigVersion, string(item.Result.Tier), item.Result.Score,
-		item.Result.MitigateBy, item.Result.RemediateBy, nullableSLAID(item.PreviousAssessmentID), item.AssessedAt, item.CreatedAt)
+		item.Result.MitigateBy, item.Result.RemediateBy, nullableSLAID(item.PreviousAssessmentID), item.DeadlineAnchorAt,
+		item.AssessedAt, item.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("insert sla assessment: %w", err)
 	}
@@ -482,4 +503,14 @@ func nullableSLAID(value shared.ID) any {
 		return nil
 	}
 	return value.String()
+}
+
+func slaFindingAdvisoryLockKey(tenantID, engagementID, findingID shared.ID) int64 {
+	digest := sha256.Sum256([]byte(tenantID.String() + "\x00" + engagementID.String() + "\x00" + findingID.String()))
+	return int64(binary.BigEndian.Uint64(digest[:8]))
+}
+
+func postgresUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }

--- a/internal/infrastructure/persistence/postgres/sla_store.go
+++ b/internal/infrastructure/persistence/postgres/sla_store.go
@@ -301,10 +301,7 @@ func (s *SLAStore) SaveTransition(ctx context.Context, next sla.Lifecycle, event
 			event.EngagementID.String(), event.FindingID.String(), event.AssessmentID.String(), string(event.From),
 			string(event.To), event.Reason, event.CompensatingControl, event.AcceptanceExpiresAt, event.Actor,
 			event.BeforeVersion, event.AfterVersion, event.At); err != nil {
-			if postgresUniqueViolation(err) {
-				return fmt.Errorf("insert sla lifecycle event: %v: %w", err, shared.ErrConflict)
-			}
-			return fmt.Errorf("insert sla lifecycle event: %w", err)
+			return wrapPostgresSLAWriteError("insert sla lifecycle event", err)
 		}
 		return nil
 	})
@@ -513,4 +510,11 @@ func slaFindingAdvisoryLockKey(tenantID, engagementID, findingID shared.ID) int6
 func postgresUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+func wrapPostgresSLAWriteError(operation string, err error) error {
+	if postgresUniqueViolation(err) {
+		return fmt.Errorf("%s: %w: %w", operation, err, shared.ErrConflict)
+	}
+	return fmt.Errorf("%s: %w", operation, err)
 }

--- a/internal/infrastructure/persistence/postgres/sla_store.go
+++ b/internal/infrastructure/persistence/postgres/sla_store.go
@@ -1,0 +1,485 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// SLAStore is the PostgreSQL adapter for versioned SLA policy, immutable assessments, and the
+// human remediation lifecycle. Every operation is routed through WithTenant so RLS remains the
+// final isolation boundary even when an application-level predicate regresses.
+type SLAStore struct{ pool *pgxpool.Pool }
+
+func NewSLAStore(pool *pgxpool.Pool) *SLAStore { return &SLAStore{pool: pool} }
+
+var _ ports.SLAStore = (*SLAStore)(nil)
+
+func (s *SLAStore) PutPolicy(ctx context.Context, policy sla.Policy, activate bool) (bool, error) {
+	tenantID, err := slaPostgresTenant(ctx, policy.TenantID)
+	if err != nil {
+		return false, err
+	}
+	policy.TenantID = tenantID
+	if err := policy.Validate(); err != nil {
+		return false, err
+	}
+	encoded, err := json.Marshal(policy.Config)
+	if err != nil {
+		return false, fmt.Errorf("marshal sla policy: %w", err)
+	}
+	created := false
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `INSERT INTO sla_policies
+			(tenant_id,config_version,config,sha256,created_by,created_at)
+			VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (tenant_id,config_version) DO NOTHING`,
+			tenantID.String(), policy.Config.Version, encoded, policy.SHA256, policy.CreatedBy, policy.CreatedAt)
+		if err != nil {
+			return fmt.Errorf("insert sla policy: %w", err)
+		}
+		created = tag.RowsAffected() == 1
+		if !created {
+			var storedHash string
+			if err := tx.QueryRow(ctx, `SELECT sha256 FROM sla_policies WHERE tenant_id=$1 AND config_version=$2`,
+				tenantID.String(), policy.Config.Version).Scan(&storedHash); err != nil {
+				return fmt.Errorf("load existing sla policy: %w", err)
+			}
+			if storedHash != policy.SHA256 {
+				return fmt.Errorf("%w: sla policy version already has different content", shared.ErrConflict)
+			}
+		}
+		if activate {
+			if _, err := tx.Exec(ctx, `INSERT INTO sla_active_policies (tenant_id,config_version,activated_at)
+				VALUES ($1,$2,$3) ON CONFLICT (tenant_id) DO UPDATE
+				SET config_version=EXCLUDED.config_version,activated_at=EXCLUDED.activated_at`,
+				tenantID.String(), policy.Config.Version, policy.CreatedAt); err != nil {
+				return fmt.Errorf("activate sla policy: %w", err)
+			}
+		}
+		return nil
+	})
+	return created, err
+}
+
+func (s *SLAStore) ActivePolicy(ctx context.Context, tenantID shared.ID) (sla.Policy, error) {
+	tenantID, err := slaPostgresTenant(ctx, tenantID)
+	if err != nil {
+		return sla.Policy{}, err
+	}
+	var policy sla.Policy
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		return scanSLAPolicy(tx.QueryRow(ctx, `SELECT p.tenant_id,p.config,p.sha256,p.created_by,p.created_at
+			FROM sla_active_policies active JOIN sla_policies p
+			ON p.tenant_id=active.tenant_id AND p.config_version=active.config_version
+			WHERE active.tenant_id=$1`, tenantID.String()), &policy)
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return sla.Policy{}, shared.ErrNotFound
+	}
+	if err != nil {
+		return sla.Policy{}, fmt.Errorf("load active sla policy: %w", err)
+	}
+	return policy, nil
+}
+
+func (s *SLAStore) PolicyHistory(ctx context.Context, tenantID shared.ID) ([]sla.Policy, error) {
+	tenantID, err := slaPostgresTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]sla.Policy, 0)
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT tenant_id,config,sha256,created_by,created_at FROM sla_policies
+			WHERE tenant_id=$1 ORDER BY created_at DESC,config_version DESC`, tenantID.String())
+		if err != nil {
+			return fmt.Errorf("list sla policies: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var policy sla.Policy
+			if err := scanSLAPolicy(rows, &policy); err != nil {
+				return err
+			}
+			items = append(items, policy)
+		}
+		return rows.Err()
+	})
+	return items, err
+}
+
+func (s *SLAStore) UpsertAssessment(ctx context.Context, assessment sla.Assessment) (sla.AssessmentUpsertResult, error) {
+	tenantID, err := slaPostgresTenant(ctx, assessment.TenantID)
+	if err != nil {
+		return sla.AssessmentUpsertResult{}, err
+	}
+	assessment.TenantID = tenantID
+	if err := assessment.Validate(); err != nil {
+		return sla.AssessmentUpsertResult{}, err
+	}
+	result := sla.AssessmentUpsertResult{Assessment: assessment}
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		// Serialize every candidate for one finding, including its first assessment. A row lock
+		// cannot protect the absent-pointer case, so use a transaction advisory lock on the stable
+		// tenant/engagement/finding identity.
+		lockKey := tenantID.String() + "\x00" + assessment.EngagementID.String() + "\x00" + assessment.FindingID.String()
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, lockKey); err != nil {
+			return fmt.Errorf("lock sla finding: %w", err)
+		}
+		var existing sla.Assessment
+		found, err := loadSLAAssessment(ctx, tx, tenantID, assessment.ID, &existing)
+		if err != nil {
+			return err
+		}
+		if found {
+			result.Assessment = existing
+			return nil
+		}
+		var previousID string
+		err = tx.QueryRow(ctx, `SELECT assessment_id FROM sla_current_assessments
+			WHERE tenant_id=$1 AND engagement_id=$2 AND finding_id=$3`, tenantID.String(),
+			assessment.EngagementID.String(), assessment.FindingID.String()).Scan(&previousID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			assessment.PreviousAssessmentID = ""
+		} else if err != nil {
+			return fmt.Errorf("load current sla assessment pointer: %w", err)
+		} else if assessment.PreviousAssessmentID.IsZero() {
+			assessment.PreviousAssessmentID = shared.ID(previousID)
+		}
+		if err := insertSLAAssessment(ctx, tx, assessment); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO sla_current_assessments
+			(tenant_id,engagement_id,finding_id,assessment_id,updated_at) VALUES ($1,$2,$3,$4,$5)
+			ON CONFLICT (tenant_id,engagement_id,finding_id) DO UPDATE
+			SET assessment_id=EXCLUDED.assessment_id,updated_at=EXCLUDED.updated_at`, tenantID.String(),
+			assessment.EngagementID.String(), assessment.FindingID.String(), assessment.ID.String(), assessment.AssessedAt); err != nil {
+			return fmt.Errorf("update current sla assessment pointer: %w", err)
+		}
+		// ON CONFLICT changes only machine-owned provenance. It cannot clobber status, acceptance,
+		// attribution, timestamps, reason, or optimistic version.
+		if _, err := tx.Exec(ctx, `INSERT INTO sla_lifecycles
+			(tenant_id,engagement_id,finding_id,assessment_id,status,version,updated_by,updated_at)
+			VALUES ($1,$2,$3,$4,'open',1,'system:sla',$5)
+			ON CONFLICT (tenant_id,engagement_id,finding_id) DO UPDATE SET assessment_id=EXCLUDED.assessment_id`,
+			tenantID.String(), assessment.EngagementID.String(), assessment.FindingID.String(),
+			assessment.ID.String(), assessment.AssessedAt); err != nil {
+			return fmt.Errorf("initialize sla lifecycle: %w", err)
+		}
+		result.Assessment, result.Created = assessment, true
+		return nil
+	})
+	if err != nil {
+		return sla.AssessmentUpsertResult{}, err
+	}
+	return result, nil
+}
+
+func (s *SLAStore) Current(ctx context.Context, tenantID, engagementID, findingID shared.ID) (sla.Current, error) {
+	tenantID, err := slaPostgresTenant(ctx, tenantID)
+	if err != nil {
+		return sla.Current{}, err
+	}
+	var current sla.Current
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, currentSLAQuery+` WHERE pointer.tenant_id=$1 AND pointer.engagement_id=$2 AND pointer.finding_id=$3`,
+			tenantID.String(), engagementID.String(), findingID.String())
+		return scanSLACurrent(row, &current)
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return sla.Current{}, shared.ErrNotFound
+	}
+	if err != nil {
+		return sla.Current{}, fmt.Errorf("load current sla: %w", err)
+	}
+	return current, nil
+}
+
+func (s *SLAStore) ListCurrent(ctx context.Context, tenantID, engagementID shared.ID) ([]sla.Current, error) {
+	tenantID, err := slaPostgresTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]sla.Current, 0)
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, currentSLAQuery+` WHERE pointer.tenant_id=$1 AND pointer.engagement_id=$2
+			ORDER BY assessment.remediate_by,assessment.finding_id`, tenantID.String(), engagementID.String())
+		if err != nil {
+			return fmt.Errorf("list current sla: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var item sla.Current
+			if err := scanSLACurrent(rows, &item); err != nil {
+				return err
+			}
+			items = append(items, item)
+		}
+		return rows.Err()
+	})
+	return items, err
+}
+
+func (s *SLAStore) AssessmentHistory(ctx context.Context, tenantID, engagementID, findingID shared.ID) ([]sla.Assessment, error) {
+	tenantID, err := slaPostgresTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]sla.Assessment, 0)
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+slaAssessmentColumns+` FROM sla_assessments
+			WHERE tenant_id=$1 AND engagement_id=$2 AND finding_id=$3 ORDER BY assessed_at DESC,id DESC`,
+			tenantID.String(), engagementID.String(), findingID.String())
+		if err != nil {
+			return fmt.Errorf("list sla assessment history: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var item sla.Assessment
+			if err := scanSLAAssessment(rows, &item); err != nil {
+				return err
+			}
+			items = append(items, item)
+		}
+		return rows.Err()
+	})
+	return items, err
+}
+
+func (s *SLAStore) SaveTransition(ctx context.Context, next sla.Lifecycle, event sla.LifecycleEvent) error {
+	tenantID, err := slaPostgresTenant(ctx, next.TenantID)
+	if err != nil {
+		return err
+	}
+	next.TenantID, event.TenantID = tenantID, tenantID
+	if err := next.Validate(); err != nil {
+		return err
+	}
+	if err := validatePostgresSLAEvent(next, event); err != nil {
+		return err
+	}
+	return WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE sla_lifecycles SET
+			status=$1,version=$2,reason=$3,compensating_control=$4,accepted_by=$5,accepted_at=$6,
+			acceptance_expires_at=$7,updated_by=$8,updated_at=$9
+			WHERE tenant_id=$10 AND engagement_id=$11 AND finding_id=$12 AND assessment_id=$13 AND version=$14`,
+			string(next.Status), next.Version, next.Reason, next.CompensatingControl, next.AcceptedBy,
+			next.AcceptedAt, next.AcceptanceExpiresAt, next.UpdatedBy, next.UpdatedAt, tenantID.String(),
+			next.EngagementID.String(), next.FindingID.String(), next.AssessmentID.String(), event.BeforeVersion)
+		if err != nil {
+			return fmt.Errorf("update sla lifecycle: %w", err)
+		}
+		if tag.RowsAffected() != 1 {
+			return fmt.Errorf("sla lifecycle changed: %w", shared.ErrConflict)
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO sla_lifecycle_events
+			(tenant_id,id,engagement_id,finding_id,assessment_id,from_status,to_status,reason,
+			compensating_control,acceptance_expires_at,actor,before_version,after_version,occurred_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`, tenantID.String(), event.ID.String(),
+			event.EngagementID.String(), event.FindingID.String(), event.AssessmentID.String(), string(event.From),
+			string(event.To), event.Reason, event.CompensatingControl, event.AcceptanceExpiresAt, event.Actor,
+			event.BeforeVersion, event.AfterVersion, event.At); err != nil {
+			return fmt.Errorf("insert sla lifecycle event: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *SLAStore) LifecycleEvents(ctx context.Context, tenantID, engagementID, findingID shared.ID) ([]sla.LifecycleEvent, error) {
+	tenantID, err := slaPostgresTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]sla.LifecycleEvent, 0)
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT tenant_id,id,engagement_id,finding_id,assessment_id,from_status,to_status,
+			reason,compensating_control,acceptance_expires_at,actor,before_version,after_version,occurred_at
+			FROM sla_lifecycle_events WHERE tenant_id=$1 AND engagement_id=$2 AND finding_id=$3
+			ORDER BY occurred_at,id`, tenantID.String(), engagementID.String(), findingID.String())
+		if err != nil {
+			return fmt.Errorf("list sla lifecycle events: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var item sla.LifecycleEvent
+			if err := rows.Scan(&item.TenantID, &item.ID, &item.EngagementID, &item.FindingID, &item.AssessmentID,
+				&item.From, &item.To, &item.Reason, &item.CompensatingControl, &item.AcceptanceExpiresAt,
+				&item.Actor, &item.BeforeVersion, &item.AfterVersion, &item.At); err != nil {
+				return fmt.Errorf("scan sla lifecycle event: %w", err)
+			}
+			items = append(items, item)
+		}
+		return rows.Err()
+	})
+	return items, err
+}
+
+const slaAssessmentColumns = `tenant_id,id,engagement_id,finding_id,source_risk_assessment_id,inputs,result,
+	input_hash,config_hash,previous_assessment_id,assessed_at,created_at`
+
+const slaLifecycleColumns = `lifecycle.tenant_id,lifecycle.engagement_id,lifecycle.finding_id,lifecycle.assessment_id,
+	lifecycle.status,lifecycle.version,lifecycle.reason,lifecycle.compensating_control,lifecycle.accepted_by,
+	lifecycle.accepted_at,lifecycle.acceptance_expires_at,lifecycle.updated_by,lifecycle.updated_at`
+
+const currentSLAQuery = `SELECT ` + slaAssessmentPrefixedColumns + `,` + slaLifecycleColumns + `
+	FROM sla_current_assessments pointer
+	JOIN sla_assessments assessment ON assessment.tenant_id=pointer.tenant_id AND assessment.id=pointer.assessment_id
+	JOIN sla_lifecycles lifecycle ON lifecycle.tenant_id=pointer.tenant_id
+		AND lifecycle.engagement_id=pointer.engagement_id AND lifecycle.finding_id=pointer.finding_id
+		AND lifecycle.assessment_id=pointer.assessment_id`
+
+const slaAssessmentPrefixedColumns = `assessment.tenant_id,assessment.id,assessment.engagement_id,
+	assessment.finding_id,assessment.source_risk_assessment_id,assessment.inputs,assessment.result,
+	assessment.input_hash,assessment.config_hash,assessment.previous_assessment_id,assessment.assessed_at,assessment.created_at`
+
+func slaPostgresTenant(ctx context.Context, requested shared.ID) (shared.ID, error) {
+	bound, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return "", fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
+	bound, requested = shared.TenantOrDefault(bound), shared.TenantOrDefault(requested)
+	if bound != requested {
+		return "", fmt.Errorf("%w: sla tenant does not match context", shared.ErrValidation)
+	}
+	return bound, nil
+}
+
+func scanSLAPolicy(row interface{ Scan(...any) error }, policy *sla.Policy) error {
+	var encoded []byte
+	if err := row.Scan(&policy.TenantID, &encoded, &policy.SHA256, &policy.CreatedBy, &policy.CreatedAt); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(encoded, &policy.Config); err != nil {
+		return fmt.Errorf("decode sla policy: %w", err)
+	}
+	if err := policy.Validate(); err != nil {
+		return fmt.Errorf("validate stored sla policy: %w", err)
+	}
+	return nil
+}
+
+func loadSLAAssessment(ctx context.Context, tx pgx.Tx, tenantID, id shared.ID, item *sla.Assessment) (bool, error) {
+	err := scanSLAAssessment(tx.QueryRow(ctx, `SELECT `+slaAssessmentColumns+` FROM sla_assessments WHERE tenant_id=$1 AND id=$2`,
+		tenantID.String(), id.String()), item)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func scanSLAAssessment(row interface{ Scan(...any) error }, item *sla.Assessment) error {
+	var inputJSON, resultJSON []byte
+	var sourceID, previousID pgtype.Text
+	if err := row.Scan(&item.TenantID, &item.ID, &item.EngagementID, &item.FindingID,
+		&sourceID, &inputJSON, &resultJSON, &item.InputHash, &item.ConfigHash,
+		&previousID, &item.AssessedAt, &item.CreatedAt); err != nil {
+		return err
+	}
+	item.SourceRiskAssessmentID, item.PreviousAssessmentID = "", ""
+	if sourceID.Valid {
+		item.SourceRiskAssessmentID = shared.ID(sourceID.String)
+	}
+	if previousID.Valid {
+		item.PreviousAssessmentID = shared.ID(previousID.String)
+	}
+	if err := json.Unmarshal(inputJSON, &item.Inputs); err != nil {
+		return fmt.Errorf("decode sla assessment inputs: %w", err)
+	}
+	if err := json.Unmarshal(resultJSON, &item.Result); err != nil {
+		return fmt.Errorf("decode sla assessment result: %w", err)
+	}
+	if err := item.Validate(); err != nil {
+		return fmt.Errorf("validate stored sla assessment: %w", err)
+	}
+	return nil
+}
+
+func scanSLALifecycle(row interface{ Scan(...any) error }, item *sla.Lifecycle) error {
+	if err := row.Scan(&item.TenantID, &item.EngagementID, &item.FindingID, &item.AssessmentID,
+		&item.Status, &item.Version, &item.Reason, &item.CompensatingControl, &item.AcceptedBy,
+		&item.AcceptedAt, &item.AcceptanceExpiresAt, &item.UpdatedBy, &item.UpdatedAt); err != nil {
+		return err
+	}
+	if err := item.Validate(); err != nil {
+		return fmt.Errorf("validate stored sla lifecycle: %w", err)
+	}
+	return nil
+}
+
+func scanSLACurrent(row interface{ Scan(...any) error }, item *sla.Current) error {
+	var inputJSON, resultJSON []byte
+	var sourceID, previousID pgtype.Text
+	if err := row.Scan(&item.Assessment.TenantID, &item.Assessment.ID, &item.Assessment.EngagementID,
+		&item.Assessment.FindingID, &sourceID, &inputJSON, &resultJSON,
+		&item.Assessment.InputHash, &item.Assessment.ConfigHash, &previousID,
+		&item.Assessment.AssessedAt, &item.Assessment.CreatedAt, &item.Lifecycle.TenantID,
+		&item.Lifecycle.EngagementID, &item.Lifecycle.FindingID, &item.Lifecycle.AssessmentID,
+		&item.Lifecycle.Status, &item.Lifecycle.Version, &item.Lifecycle.Reason,
+		&item.Lifecycle.CompensatingControl, &item.Lifecycle.AcceptedBy, &item.Lifecycle.AcceptedAt,
+		&item.Lifecycle.AcceptanceExpiresAt, &item.Lifecycle.UpdatedBy, &item.Lifecycle.UpdatedAt); err != nil {
+		return err
+	}
+	item.Assessment.SourceRiskAssessmentID, item.Assessment.PreviousAssessmentID = "", ""
+	if sourceID.Valid {
+		item.Assessment.SourceRiskAssessmentID = shared.ID(sourceID.String)
+	}
+	if previousID.Valid {
+		item.Assessment.PreviousAssessmentID = shared.ID(previousID.String)
+	}
+	if err := json.Unmarshal(inputJSON, &item.Assessment.Inputs); err != nil {
+		return fmt.Errorf("decode sla current inputs: %w", err)
+	}
+	if err := json.Unmarshal(resultJSON, &item.Assessment.Result); err != nil {
+		return fmt.Errorf("decode sla current result: %w", err)
+	}
+	if _, err := item.View(item.Assessment.AssessedAt); err != nil {
+		return fmt.Errorf("validate stored sla current: %w", err)
+	}
+	return nil
+}
+
+func insertSLAAssessment(ctx context.Context, tx pgx.Tx, item sla.Assessment) error {
+	inputs, err := json.Marshal(item.Inputs)
+	if err != nil {
+		return fmt.Errorf("marshal sla assessment inputs: %w", err)
+	}
+	result, err := json.Marshal(item.Result)
+	if err != nil {
+		return fmt.Errorf("marshal sla assessment result: %w", err)
+	}
+	_, err = tx.Exec(ctx, `INSERT INTO sla_assessments
+		(tenant_id,id,engagement_id,finding_id,source_risk_assessment_id,inputs,result,input_hash,
+		config_hash,config_version,tier,score,mitigate_by,remediate_by,previous_assessment_id,assessed_at,created_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`, item.TenantID.String(),
+		item.ID.String(), item.EngagementID.String(), item.FindingID.String(), nullableSLAID(item.SourceRiskAssessmentID),
+		inputs, result, item.InputHash, item.ConfigHash, item.Result.ConfigVersion, string(item.Result.Tier), item.Result.Score,
+		item.Result.MitigateBy, item.Result.RemediateBy, nullableSLAID(item.PreviousAssessmentID), item.AssessedAt, item.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("insert sla assessment: %w", err)
+	}
+	return nil
+}
+
+func validatePostgresSLAEvent(next sla.Lifecycle, event sla.LifecycleEvent) error {
+	if event.ID.IsZero() || event.TenantID != next.TenantID || event.EngagementID != next.EngagementID ||
+		event.FindingID != next.FindingID || event.AssessmentID != next.AssessmentID || event.To != next.Status ||
+		event.AfterVersion != next.Version || event.BeforeVersion+1 != event.AfterVersion || event.At.IsZero() {
+		return fmt.Errorf("%w: sla lifecycle event does not match next state", shared.ErrValidation)
+	}
+	return nil
+}
+
+func nullableSLAID(value shared.ID) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value.String()
+}

--- a/internal/infrastructure/persistence/postgres/sla_store_test.go
+++ b/internal/infrastructure/persistence/postgres/sla_store_test.go
@@ -1,0 +1,136 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+)
+
+// TestPostgresSLAStore exercises the real migration, JSON codecs, nullable provenance, RLS-scoped
+// adapter calls, immutable history, and the no-human-clobber refresh invariant. It deliberately uses
+// an assessment without source/previous IDs first so nullable column scanning is covered.
+func TestPostgresSLAStore(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	base := context.Background()
+	if err := Migrate(base, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(base, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	prefix := "sla-" + randHex(t)
+	tenantID := shared.ID(prefix + "-tenant")
+	engagementID := shared.ID(prefix + "-engagement")
+	findingID := shared.ID(prefix + "-finding")
+	if _, err := pool.Exec(base, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tenantID.String()); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	if _, err := pool.Exec(base, `INSERT INTO engagements(id,tenant_id,name) VALUES($1,$2,$1)`, engagementID.String(), tenantID.String()); err != nil {
+		t.Fatalf("seed engagement: %v", err)
+	}
+	if _, err := pool.Exec(base, `INSERT INTO findings(id,tenant_id,engagement_id,title,dedup_key) VALUES($1,$2,$3,'SLA integration finding',$1)`, findingID.String(), tenantID.String(), engagementID.String()); err != nil {
+		t.Fatalf("seed finding: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(base, `DELETE FROM sla_lifecycle_events WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `DELETE FROM sla_lifecycles WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `DELETE FROM sla_current_assessments WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `UPDATE sla_assessments SET previous_assessment_id=NULL WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `DELETE FROM sla_assessments WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `DELETE FROM sla_active_policies WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `DELETE FROM sla_policies WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `DELETE FROM findings WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `DELETE FROM engagements WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `DELETE FROM tenants WHERE id=$1`, tenantID.String())
+	})
+
+	ctx := shared.WithTenant(base, tenantID)
+	store := NewSLAStore(pool)
+	now := time.Date(2026, 8, 15, 13, 0, 0, 0, time.UTC)
+	policy, err := sla.NewPolicy(tenantID, sla.DefaultConfig(), "integration-admin", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created, err := store.PutPolicy(ctx, policy, true); err != nil || !created {
+		t.Fatalf("put policy created=%v err=%v", created, err)
+	}
+	active, err := store.ActivePolicy(ctx, tenantID)
+	if err != nil || active.SHA256 != policy.SHA256 || active.Config.DueRanges.High != policy.Config.DueRanges.High {
+		t.Fatalf("active policy=%+v err=%v", active, err)
+	}
+
+	first, err := sla.Evaluate(sla.AssessmentInput{
+		TenantID: tenantID, EngagementID: engagementID, FindingID: findingID,
+		Risk: sla.Inputs{Severity: shared.SeverityHigh, CVSSScore: 8.1, EPSS: 0.2, Feasibility: sla.FeasibilityPatchAvailable},
+	}, policy.Config, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, err := store.UpsertAssessment(ctx, first)
+	if err != nil || !stored.Created || !stored.Assessment.PreviousAssessmentID.IsZero() {
+		t.Fatalf("first assessment=%+v err=%v", stored, err)
+	}
+	current, err := store.Current(ctx, tenantID, engagementID, findingID)
+	if err != nil || current.Assessment.ID != first.ID || current.Lifecycle.Version != 1 {
+		t.Fatalf("current=%+v err=%v", current, err)
+	}
+
+	expiry := now.Add(14 * 24 * time.Hour)
+	next, event, err := sla.ApplyTransition(current.Lifecycle, shared.ID(prefix+"-event"), sla.TransitionCommand{
+		To: sla.RemediationAcceptedRisk, Actor: "risk-owner", Reason: "vendor maintenance window",
+		CompensatingControl: "network isolation", AcceptanceExpiresAt: &expiry, ExpectedVersion: 1,
+	}, now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveTransition(ctx, next, event); err != nil {
+		t.Fatal(err)
+	}
+
+	refreshed, err := sla.Evaluate(sla.AssessmentInput{
+		TenantID: tenantID, EngagementID: engagementID, FindingID: findingID,
+		Risk: sla.Inputs{Severity: shared.SeverityCritical, CVSSScore: 9.8, EPSS: 0.95, ActiveExploitation: true, Feasibility: sla.FeasibilityPatchAvailable},
+	}, policy.Config, now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, err = store.UpsertAssessment(ctx, refreshed)
+	if err != nil || !stored.Created || stored.Assessment.PreviousAssessmentID != first.ID {
+		t.Fatalf("refreshed assessment=%+v err=%v", stored, err)
+	}
+	current, err = store.Current(ctx, tenantID, engagementID, findingID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Lifecycle.AssessmentID != refreshed.ID || current.Lifecycle.Status != sla.RemediationAcceptedRisk ||
+		current.Lifecycle.Version != 2 || current.Lifecycle.AcceptedBy != "risk-owner" ||
+		current.Lifecycle.AcceptanceExpiresAt == nil || !current.Lifecycle.AcceptanceExpiresAt.Equal(expiry) {
+		t.Fatalf("machine refresh clobbered human lifecycle: %+v", current.Lifecycle)
+	}
+	history, err := store.AssessmentHistory(ctx, tenantID, engagementID, findingID)
+	if err != nil || len(history) != 2 || history[0].ID != refreshed.ID || history[1].ID != first.ID {
+		t.Fatalf("history=%+v err=%v", history, err)
+	}
+	events, err := store.LifecycleEvents(ctx, tenantID, engagementID, findingID)
+	if err != nil || len(events) != 1 || events[0].ID != event.ID {
+		t.Fatalf("events=%+v err=%v", events, err)
+	}
+
+	if err := store.SaveTransition(ctx, next, event); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale transition should conflict, got %v", err)
+	}
+	otherCtx := shared.WithTenant(base, "other-tenant")
+	if _, err := store.Current(otherCtx, tenantID, engagementID, findingID); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant read should fail closed, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/sla_store_test.go
+++ b/internal/infrastructure/persistence/postgres/sla_store_test.go
@@ -10,9 +10,28 @@ import (
 
 	"github.com/jackc/pgx/v5/pgconn"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
 )
+
+type slaDeleteClock struct{ now time.Time }
+
+func (clock slaDeleteClock) Now() time.Time { return clock.now }
+
+type slaDeleteIDs struct{}
+
+func (slaDeleteIDs) NewID() shared.ID { return "unused-sla-delete-id" }
+
+type slaDeleteAudit struct{ entries []ports.AuditEntry }
+
+func (audit *slaDeleteAudit) Record(_ context.Context, entry ports.AuditEntry) error {
+	audit.entries = append(audit.entries, entry)
+	return nil
+}
 
 // TestPostgresSLAStore exercises the real migration, JSON codecs, nullable provenance, RLS-scoped
 // adapter calls, immutable history, and the no-human-clobber refresh invariant. It deliberately uses
@@ -33,39 +52,52 @@ func TestPostgresSLAStore(t *testing.T) {
 	defer pool.Close()
 	prefix := "sla-" + randHex(t)
 	tenantID := shared.ID(prefix + "-tenant")
+	projectID := shared.ID(prefix + "-project")
+	projectKey := prefix + "-project"
 	engagementID := shared.ID(prefix + "-engagement")
 	findingID := shared.ID(prefix + "-finding")
+	now := time.Date(2026, 8, 15, 13, 0, 0, 0, time.UTC)
+	ctx := shared.WithTenant(base, tenantID)
 	if _, err := pool.Exec(base, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tenantID.String()); err != nil {
 		t.Fatalf("seed tenant: %v", err)
 	}
-	if _, err := pool.Exec(base, `INSERT INTO engagements(id,tenant_id,name) VALUES($1,$2,$1)`, engagementID.String(), tenantID.String()); err != nil {
+	projectItem, err := project.New(projectID, tenantID, "SLA delete integration", projectKey,
+		project.SourceBinding{Kind: project.SourceLocal, Value: "."}, nil, "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectRepo := NewProjectRepository(pool)
+	if err := projectRepo.Create(ctx, projectItem); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	engagementItem, err := engagement.New(engagementID, tenantID, "SLA integration engagement", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engagementItem.ProjectID = projectID
+	engagementRepo := NewEngagementRepository(pool)
+	if err := engagementRepo.Create(ctx, engagementItem); err != nil {
 		t.Fatalf("seed engagement: %v", err)
 	}
 	if _, err := pool.Exec(base, `INSERT INTO findings(id,tenant_id,engagement_id,title,dedup_key) VALUES($1,$2,$3,'SLA integration finding',$1)`, findingID.String(), tenantID.String(), engagementID.String()); err != nil {
 		t.Fatalf("seed finding: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = pool.Exec(base, `ALTER TABLE sla_lifecycle_events DISABLE TRIGGER sla_lifecycle_events_append_only`)
-		_, _ = pool.Exec(base, `ALTER TABLE sla_assessments DISABLE TRIGGER sla_assessments_append_only`)
 		_, _ = pool.Exec(base, `ALTER TABLE sla_policies DISABLE TRIGGER sla_policies_append_only`)
 		_, _ = pool.Exec(base, `DELETE FROM sla_lifecycle_events WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM sla_lifecycles WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM sla_current_assessments WHERE tenant_id=$1`, tenantID.String())
-		_, _ = pool.Exec(base, `UPDATE sla_assessments SET previous_assessment_id=NULL WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM sla_assessments WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM sla_active_policies WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM sla_policies WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM findings WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM engagements WHERE tenant_id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `DELETE FROM projects WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM tenants WHERE id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `ALTER TABLE sla_policies ENABLE TRIGGER sla_policies_append_only`)
-		_, _ = pool.Exec(base, `ALTER TABLE sla_assessments ENABLE TRIGGER sla_assessments_append_only`)
-		_, _ = pool.Exec(base, `ALTER TABLE sla_lifecycle_events ENABLE TRIGGER sla_lifecycle_events_append_only`)
 	})
 
-	ctx := shared.WithTenant(base, tenantID)
 	store := NewSLAStore(pool)
-	now := time.Date(2026, 8, 15, 13, 0, 0, 0, time.UTC)
 	policy, err := sla.NewPolicy(tenantID, sla.DefaultConfig(), "integration-admin", now)
 	if err != nil {
 		t.Fatal(err)
@@ -138,6 +170,17 @@ func TestPostgresSLAStore(t *testing.T) {
 	if err != nil || len(events) != 1 || events[0].ID != event.ID {
 		t.Fatalf("events=%+v err=%v", events, err)
 	}
+	third, err := sla.Evaluate(sla.AssessmentInput{
+		TenantID: tenantID, EngagementID: engagementID, FindingID: findingID,
+		Risk: sla.Inputs{Severity: shared.SeverityMedium, CVSSScore: 5.5, EPSS: 0.04, PublicPoC: true, Feasibility: sla.FeasibilityChangeWindow},
+	}, policy.Config, now.Add(3*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, err = store.UpsertAssessment(ctx, third)
+	if err != nil || !stored.Created || stored.Assessment.PreviousAssessmentID != refreshed.ID {
+		t.Fatalf("third assessment did not extend the multi-hop chain: %+v err=%v", stored, err)
+	}
 
 	if err := store.SaveTransition(ctx, next, event); !errors.Is(err, shared.ErrConflict) {
 		t.Fatalf("stale transition should conflict, got %v", err)
@@ -149,7 +192,7 @@ func TestPostgresSLAStore(t *testing.T) {
 	}{
 		{name: "policy update", query: `UPDATE sla_policies SET created_by='tampered' WHERE tenant_id=$1`, args: []any{tenantID.String()}},
 		{name: "assessment update", query: `UPDATE sla_assessments SET score=0 WHERE tenant_id=$1`, args: []any{tenantID.String()}},
-		{name: "event delete", query: `DELETE FROM sla_lifecycle_events WHERE tenant_id=$1`, args: []any{tenantID.String()}},
+		{name: "event update", query: `UPDATE sla_lifecycle_events SET actor='tampered' WHERE tenant_id=$1`, args: []any{tenantID.String()}},
 	}
 	for _, mutation := range immutableMutations {
 		if _, err := pool.Exec(base, mutation.query, mutation.args...); err == nil || !strings.Contains(err.Error(), "append-only") {
@@ -159,6 +202,35 @@ func TestPostgresSLAStore(t *testing.T) {
 	otherCtx := shared.WithTenant(base, "other-tenant")
 	if _, err := store.Current(otherCtx, tenantID, engagementID, findingID); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("cross-tenant read should fail closed, got %v", err)
+	}
+
+	// projectuc.Delete first calls EngagementRepository.Delete, which cascades findings and their
+	// multi-hop SLA history, then removes the project. This is the production teardown path that the
+	// update-immutability triggers must not block.
+	audit := &slaDeleteAudit{}
+	projectService := projectuc.NewService(projectRepo, engagementRepo, slaDeleteClock{now: now}, slaDeleteIDs{}, audit, true)
+	if err := projectService.Delete(ctx, "integration-admin", tenantID, projectKey); err != nil {
+		t.Fatalf("delete SLA-assessed project: %v", err)
+	}
+	for _, check := range []struct {
+		name  string
+		query string
+	}{
+		{name: "assessments", query: `SELECT count(*) FROM sla_assessments WHERE tenant_id=$1`},
+		{name: "current assessments", query: `SELECT count(*) FROM sla_current_assessments WHERE tenant_id=$1`},
+		{name: "lifecycles", query: `SELECT count(*) FROM sla_lifecycles WHERE tenant_id=$1`},
+		{name: "lifecycle events", query: `SELECT count(*) FROM sla_lifecycle_events WHERE tenant_id=$1`},
+		{name: "findings", query: `SELECT count(*) FROM findings WHERE tenant_id=$1`},
+		{name: "engagements", query: `SELECT count(*) FROM engagements WHERE tenant_id=$1`},
+		{name: "projects", query: `SELECT count(*) FROM projects WHERE tenant_id=$1`},
+	} {
+		var count int
+		if err := pool.QueryRow(base, check.query, tenantID.String()).Scan(&count); err != nil || count != 0 {
+			t.Errorf("%s remaining after project teardown=%d err=%v", check.name, count, err)
+		}
+	}
+	if len(audit.entries) != 1 || audit.entries[0].Action != "project.delete" {
+		t.Fatalf("project teardown audit=%+v", audit.entries)
 	}
 }
 
@@ -174,8 +246,14 @@ func TestSLAFindingAdvisoryLockKeyIsStableAndScoped(t *testing.T) {
 }
 
 func TestPostgresUniqueViolationClassification(t *testing.T) {
-	if !postgresUniqueViolation(&pgconn.PgError{Code: "23505"}) {
+	pgErr := &pgconn.PgError{Code: "23505", ConstraintName: "sla_lifecycle_events_pkey"}
+	if !postgresUniqueViolation(pgErr) {
 		t.Fatal("unique_violation must be classified as a conflict")
+	}
+	wrapped := wrapPostgresSLAWriteError("insert sla lifecycle event", pgErr)
+	var recovered *pgconn.PgError
+	if !errors.Is(wrapped, shared.ErrConflict) || !errors.As(wrapped, &recovered) || recovered != pgErr {
+		t.Fatalf("wrapped unique violation lost conflict or PostgreSQL cause: %v", wrapped)
 	}
 	if postgresUniqueViolation(&pgconn.PgError{Code: "23503"}) || postgresUniqueViolation(errors.New("23505")) {
 		t.Fatal("non-unique PostgreSQL and untyped errors must not be classified as unique violations")

--- a/internal/infrastructure/persistence/postgres/sla_store_test.go
+++ b/internal/infrastructure/persistence/postgres/sla_store_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
@@ -42,6 +45,9 @@ func TestPostgresSLAStore(t *testing.T) {
 		t.Fatalf("seed finding: %v", err)
 	}
 	t.Cleanup(func() {
+		_, _ = pool.Exec(base, `ALTER TABLE sla_lifecycle_events DISABLE TRIGGER sla_lifecycle_events_append_only`)
+		_, _ = pool.Exec(base, `ALTER TABLE sla_assessments DISABLE TRIGGER sla_assessments_append_only`)
+		_, _ = pool.Exec(base, `ALTER TABLE sla_policies DISABLE TRIGGER sla_policies_append_only`)
 		_, _ = pool.Exec(base, `DELETE FROM sla_lifecycle_events WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM sla_lifecycles WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM sla_current_assessments WHERE tenant_id=$1`, tenantID.String())
@@ -52,6 +58,9 @@ func TestPostgresSLAStore(t *testing.T) {
 		_, _ = pool.Exec(base, `DELETE FROM findings WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM engagements WHERE tenant_id=$1`, tenantID.String())
 		_, _ = pool.Exec(base, `DELETE FROM tenants WHERE id=$1`, tenantID.String())
+		_, _ = pool.Exec(base, `ALTER TABLE sla_policies ENABLE TRIGGER sla_policies_append_only`)
+		_, _ = pool.Exec(base, `ALTER TABLE sla_assessments ENABLE TRIGGER sla_assessments_append_only`)
+		_, _ = pool.Exec(base, `ALTER TABLE sla_lifecycle_events ENABLE TRIGGER sla_lifecycle_events_append_only`)
 	})
 
 	ctx := shared.WithTenant(base, tenantID)
@@ -108,6 +117,10 @@ func TestPostgresSLAStore(t *testing.T) {
 	if err != nil || !stored.Created || stored.Assessment.PreviousAssessmentID != first.ID {
 		t.Fatalf("refreshed assessment=%+v err=%v", stored, err)
 	}
+	if !stored.Assessment.DeadlineAnchorAt.Equal(first.AssessedAt) ||
+		stored.Assessment.Result.RemediateBy.After(first.Result.RemediateBy) {
+		t.Fatalf("refreshed assessment reset or extended SLA clock: first=%+v refreshed=%+v", first, stored.Assessment)
+	}
 	current, err = store.Current(ctx, tenantID, engagementID, findingID)
 	if err != nil {
 		t.Fatal(err)
@@ -129,8 +142,42 @@ func TestPostgresSLAStore(t *testing.T) {
 	if err := store.SaveTransition(ctx, next, event); !errors.Is(err, shared.ErrConflict) {
 		t.Fatalf("stale transition should conflict, got %v", err)
 	}
+	immutableMutations := []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{name: "policy update", query: `UPDATE sla_policies SET created_by='tampered' WHERE tenant_id=$1`, args: []any{tenantID.String()}},
+		{name: "assessment update", query: `UPDATE sla_assessments SET score=0 WHERE tenant_id=$1`, args: []any{tenantID.String()}},
+		{name: "event delete", query: `DELETE FROM sla_lifecycle_events WHERE tenant_id=$1`, args: []any{tenantID.String()}},
+	}
+	for _, mutation := range immutableMutations {
+		if _, err := pool.Exec(base, mutation.query, mutation.args...); err == nil || !strings.Contains(err.Error(), "append-only") {
+			t.Errorf("%s must be rejected by append-only trigger, got %v", mutation.name, err)
+		}
+	}
 	otherCtx := shared.WithTenant(base, "other-tenant")
 	if _, err := store.Current(otherCtx, tenantID, engagementID, findingID); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("cross-tenant read should fail closed, got %v", err)
+	}
+}
+
+func TestSLAFindingAdvisoryLockKeyIsStableAndScoped(t *testing.T) {
+	first := slaFindingAdvisoryLockKey("tenant-a", "eng-1", "finding-1")
+	if first != slaFindingAdvisoryLockKey("tenant-a", "eng-1", "finding-1") {
+		t.Fatal("same SLA finding identity produced an unstable advisory lock key")
+	}
+	if first == slaFindingAdvisoryLockKey("tenant-a", "eng-1", "finding-2") ||
+		first == slaFindingAdvisoryLockKey("tenant-b", "eng-1", "finding-1") {
+		t.Fatal("distinct SLA finding identities produced the same test lock key")
+	}
+}
+
+func TestPostgresUniqueViolationClassification(t *testing.T) {
+	if !postgresUniqueViolation(&pgconn.PgError{Code: "23505"}) {
+		t.Fatal("unique_violation must be classified as a conflict")
+	}
+	if postgresUniqueViolation(&pgconn.PgError{Code: "23503"}) || postgresUniqueViolation(errors.New("23505")) {
+		t.Fatal("non-unique PostgreSQL and untyped errors must not be classified as unique violations")
 	}
 }

--- a/internal/infrastructure/persistence/postgres/vulnerability_risk_assessment_store.go
+++ b/internal/infrastructure/persistence/postgres/vulnerability_risk_assessment_store.go
@@ -48,6 +48,16 @@ func (s *VulnerabilityRiskAssessmentStore) Upsert(ctx context.Context, assessmen
 			return err
 		}
 		if exists {
+			// Re-promote a historical immutable assessment when an occurrence returns to a previously
+			// seen state. Re-exposure commonly maps to the original detected input hash; returning it
+			// without moving this pointer leaves current risk stuck at no_longer_detected.
+			if _, err := tx.Exec(ctx, `INSERT INTO vulnerability_current_risk_assessments
+				(tenant_id, occurrence_id, assessment_id, updated_at) VALUES ($1,$2,$3,$4)
+				ON CONFLICT (tenant_id, occurrence_id) DO UPDATE
+				SET assessment_id=EXCLUDED.assessment_id, updated_at=EXCLUDED.updated_at`, tenantID.String(),
+				assessment.OccurrenceID.String(), existing.ID.String(), assessment.AssessedAt); err != nil {
+				return fmt.Errorf("re-promote current risk assessment: %w", err)
+			}
 			result.Assessment = existing
 			return nil
 		}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -312,6 +312,9 @@ type Config struct {
 	VulnerabilityNotificationsEnabled     bool
 	VulnerabilityDryRunEnabled            bool
 	VulnerabilityTenantAllowlist          []string
+	// SLAEnabled turns on durable risk-based remediation deadlines, versioned tenant policy, and
+	// human lifecycle APIs. Default false until an operator explicitly opts into the new schema/path.
+	SLAEnabled bool
 	// SASTEnabled turns on the deterministic pattern-SAST analyzer in the scan pipeline; off by default.
 	SASTEnabled bool
 	// SecretScanEnabled turns on the deterministic secret scanner in the scan pipeline; off by default.
@@ -647,6 +650,7 @@ func Load() Config {
 		VulnerabilityNotificationsEnabled:     getbool("SYNAPSE_VULNERABILITY_NOTIFICATIONS_ENABLED", false),
 		VulnerabilityDryRunEnabled:            getbool("SYNAPSE_VULNERABILITY_DRY_RUN_ENABLED", true),
 		VulnerabilityTenantAllowlist:          splitList(getenv("SYNAPSE_VULNERABILITY_TENANT_ALLOWLIST", "")),
+		SLAEnabled:                            getbool("SYNAPSE_SLA_ENABLED", false),
 		GovulncheckBin:                        getenv("SYNAPSE_GOVULNCHECK_BIN", "govulncheck"),
 		GoModGraphEnabled:                     getbool("SYNAPSE_GOMODGRAPH_ENABLED", true),
 		GoBin:                                 getenv("SYNAPSE_GO_BIN", "go"),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -147,6 +147,21 @@ func TestLoadVulnerabilityRolloutDefaultsFailClosed(t *testing.T) {
 	}
 }
 
+func TestLoadSLAGovernanceIsExplicitOptIn(t *testing.T) {
+	t.Setenv("SYNAPSE_SLA_ENABLED", "")
+	if Load().SLAEnabled {
+		t.Fatal("SLA governance must remain disabled by default")
+	}
+	t.Setenv("SYNAPSE_SLA_ENABLED", "true")
+	if !Load().SLAEnabled {
+		t.Fatal("SYNAPSE_SLA_ENABLED=true did not enable SLA governance")
+	}
+	t.Setenv("SYNAPSE_SLA_ENABLED", "invalid")
+	if Load().SLAEnabled {
+		t.Fatal("invalid SLA feature flag must fail closed")
+	}
+}
+
 func TestLoadCSPMDefaultsAndBounds(t *testing.T) {
 	for _, key := range []string{"SYNAPSE_CSPM_ENABLED", "SYNAPSE_CSPM_PROVIDERS", "SYNAPSE_CSPM_RATE"} {
 		t.Setenv(key, "")

--- a/internal/usecase/ports/sla.go
+++ b/internal/usecase/ports/sla.go
@@ -1,0 +1,39 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+)
+
+// SLAStore is the tenant-isolated source of truth for remediation governance. Assessments and
+// policies are immutable; their current pointers may advance. SaveTransition is the only operation
+// allowed to modify human remediation state and must enforce event.BeforeVersion atomically.
+type SLAStore interface {
+	PutPolicy(ctx context.Context, policy sla.Policy, activate bool) (created bool, err error)
+	ActivePolicy(ctx context.Context, tenantID shared.ID) (sla.Policy, error)
+	PolicyHistory(ctx context.Context, tenantID shared.ID) ([]sla.Policy, error)
+
+	UpsertAssessment(ctx context.Context, assessment sla.Assessment) (sla.AssessmentUpsertResult, error)
+	Current(ctx context.Context, tenantID, engagementID, findingID shared.ID) (sla.Current, error)
+	ListCurrent(ctx context.Context, tenantID, engagementID shared.ID) ([]sla.Current, error)
+	AssessmentHistory(ctx context.Context, tenantID, engagementID, findingID shared.ID) ([]sla.Assessment, error)
+
+	SaveTransition(ctx context.Context, next sla.Lifecycle, event sla.LifecycleEvent) error
+	LifecycleEvents(ctx context.Context, tenantID, engagementID, findingID shared.ID) ([]sla.LifecycleEvent, error)
+}
+
+// SLAAssessor is the narrow integration boundary used by finding-producing pipelines. Keeping the
+// input in the domain means SCA and continuous intelligence do not depend on the concrete SLA
+// use-case, and deployments can leave the capability unwired while SYNAPSE_SLA_ENABLED is false.
+type SLAAssessor interface {
+	Assess(ctx context.Context, input sla.AssessmentInput) (sla.View, error)
+}
+
+// FindingSLAAssessor is the pipeline-facing convenience projection for finding producers that do not
+// own continuous-intelligence detail. The concrete service derives only signals present on the row.
+type FindingSLAAssessor interface {
+	AssessFinding(ctx context.Context, tenantID shared.ID, item finding.Finding) (sla.View, error)
+}

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -147,6 +147,7 @@ func buildFindings(engagementID shared.ID, res *ScanResult, now time.Time, minSe
 			CVSSVector:        v.CVSSVector,
 			KEV:               v.KEV,
 			RiskScore:         v.RiskScore(),
+			FixedVersion:      v.FixedVersion,
 			Sources:           v.Sources,
 			Confidence:        v.Confidence,
 			Class:             class,

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/codequality"
 	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
@@ -119,6 +120,7 @@ type Service struct {
 	comparisonSource ports.ProjectComparisonSource
 	log              *slog.Logger
 	gateDecoder      ports.GateDecoder
+	slaAssessor      ports.FindingSLAAssessor // optional; nil while SYNAPSE_SLA_ENABLED=false
 }
 
 // SetSeverityEnricher configures optional severity backfill (NVD CVSS) for vulnerabilities the
@@ -188,6 +190,10 @@ func (s *Service) logger() *slog.Logger {
 }
 
 func (s *Service) SetGateDecoder(decoder ports.GateDecoder) { s.gateDecoder = decoder }
+
+// SetSLAAssessor enables durable remediation SLA assessment at the finding persistence boundary.
+// When unset, scan behavior and output remain unchanged.
+func (s *Service) SetSLAAssessor(assessor ports.FindingSLAAssessor) { s.slaAssessor = assessor }
 
 // SetIgnoreUnfixed controls whether vulnerabilities with no available fix are promoted to
 // findings. true = suppress them (Trivy's --ignore-unfixed); they stay in the vuln inventory.
@@ -626,6 +632,9 @@ type ScanResult struct {
 	Licenses          []ports.LicenseFinding        `json:"licenses"`
 	ComponentLicenses []ComponentLicenseAudit       `json:"component_licenses"`
 	Findings          []finding.Finding             `json:"findings"`
+	// SLAs is populated only when SLA governance is enabled. Each entry joins immutable scoring
+	// provenance with the separately human-owned remediation lifecycle.
+	SLAs []sla.View `json:"slas,omitempty"`
 	// MinSeverity + VulnsBelowThreshold make the severity floor VISIBLE: every detected vuln is
 	// kept in Vulnerabilities, but only those at/above MinSeverity become promoted Findings.
 	// VulnsBelowThreshold counts the detected-but-not-promoted vulns so a raised floor can never
@@ -1945,6 +1954,9 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 		if err := s.findings.Upsert(ctx, result.Findings); err != nil {
 			return nil, fmt.Errorf("persist findings: %w", err)
 		}
+		if err := s.assessFindingSLAs(ctx, result); err != nil {
+			return nil, err
+		}
 		if err := s.reconcileVulnerabilities(ctx, engagementID, doc); err != nil {
 			return nil, err
 		}
@@ -1963,6 +1975,29 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 		}
 	}
 	return result, nil
+}
+
+// assessFindingSLAs runs after finding persistence (the PostgreSQL SLA schema has a composite
+// finding foreign key) and before continuous-intelligence reconciliation. The latter may immediately
+// replace a basic finding-only assessment with a richer one carrying PoC/exploitation provenance.
+func (s *Service) assessFindingSLAs(ctx context.Context, result *ScanResult) error {
+	if s.slaAssessor == nil || result == nil {
+		return nil
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("%w: tenant context is required for sla assessment", shared.ErrValidation)
+	}
+	views := make([]sla.View, 0, len(result.Findings))
+	for _, item := range result.Findings {
+		view, err := s.slaAssessor.AssessFinding(ctx, shared.TenantOrDefault(tenantID), item)
+		if err != nil {
+			return fmt.Errorf("assess finding %s sla: %w", item.ID, err)
+		}
+		views = append(views, view)
+	}
+	result.SLAs = views
+	return nil
 }
 
 // normalizedSourceTarget is the same canonical request identity authorized for a
@@ -2806,6 +2841,9 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	if s.findings != nil {
 		if err := s.findings.Upsert(ctx, result.Findings); err != nil {
 			return nil, fmt.Errorf("persist findings: %w", err)
+		}
+		if err := s.assessFindingSLAs(ctx, result); err != nil {
+			return nil, err
 		}
 		if err := s.reconcileVulnerabilities(ctx, engagementID, doc); err != nil {
 			return nil, err

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -1955,7 +1955,7 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 			return nil, fmt.Errorf("persist findings: %w", err)
 		}
 		if err := s.assessFindingSLAs(ctx, result); err != nil {
-			return nil, err
+			s.logger().Warn("assess SCA finding SLAs failed (best-effort)", "err", err)
 		}
 		if err := s.reconcileVulnerabilities(ctx, engagementID, doc); err != nil {
 			return nil, err
@@ -1977,9 +1977,11 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 	return result, nil
 }
 
-// assessFindingSLAs runs after finding persistence (the PostgreSQL SLA schema has a composite
-// finding foreign key) and before continuous-intelligence reconciliation. The latter may immediately
-// replace a basic finding-only assessment with a richer one carrying PoC/exploitation provenance.
+// assessFindingSLAs is an opt-in enrichment after finding persistence (the PostgreSQL SLA schema has
+// a composite finding foreign key). It retains every successful view and reports all failures to the
+// caller for logging; an unavailable governance dependency must never turn a committed scan into a
+// client-visible failure. Continuous-intelligence reconciliation may immediately replace a basic
+// finding-only assessment with a richer one carrying PoC/exploitation provenance.
 func (s *Service) assessFindingSLAs(ctx context.Context, result *ScanResult) error {
 	if s.slaAssessor == nil || result == nil {
 		return nil
@@ -1989,15 +1991,17 @@ func (s *Service) assessFindingSLAs(ctx context.Context, result *ScanResult) err
 		return fmt.Errorf("%w: tenant context is required for sla assessment", shared.ErrValidation)
 	}
 	views := make([]sla.View, 0, len(result.Findings))
+	var assessmentErrors []error
 	for _, item := range result.Findings {
 		view, err := s.slaAssessor.AssessFinding(ctx, shared.TenantOrDefault(tenantID), item)
 		if err != nil {
-			return fmt.Errorf("assess finding %s sla: %w", item.ID, err)
+			assessmentErrors = append(assessmentErrors, fmt.Errorf("assess finding %s sla: %w", item.ID, err))
+			continue
 		}
 		views = append(views, view)
 	}
 	result.SLAs = views
-	return nil
+	return errors.Join(assessmentErrors...)
 }
 
 // normalizedSourceTarget is the same canonical request identity authorized for a
@@ -2843,7 +2847,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 			return nil, fmt.Errorf("persist findings: %w", err)
 		}
 		if err := s.assessFindingSLAs(ctx, result); err != nil {
-			return nil, err
+			s.logger().Warn("assess SCA finding SLAs failed (best-effort)", "err", err)
 		}
 		if err := s.reconcileVulnerabilities(ctx, engagementID, doc); err != nil {
 			return nil, err

--- a/internal/usecase/sca/sla_integration_test.go
+++ b/internal/usecase/sca/sla_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,6 +22,15 @@ func (clock slaPipelineClock) Now() time.Time { return clock.at }
 type slaPipelineIDs struct{}
 
 func (slaPipelineIDs) NewID() shared.ID { return "sla-event" }
+
+type selectiveSLAAssessor struct{ fail shared.ID }
+
+func (assessor selectiveSLAAssessor) AssessFinding(_ context.Context, tenantID shared.ID, item finding.Finding) (sla.View, error) {
+	if item.ID == assessor.fail {
+		return sla.View{}, errors.New("governance unavailable")
+	}
+	return sla.View{Assessment: sla.Assessment{TenantID: tenantID, FindingID: item.ID}}, nil
+}
 
 func TestAssessFindingSLAsUsesPersistedFindingOrderAndTenant(t *testing.T) {
 	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
@@ -78,5 +88,20 @@ func TestAssessFindingSLAsFailsClosedWithoutTenantContext(t *testing.T) {
 	result := &ScanResult{Findings: []finding.Finding{{ID: "finding-1", EngagementID: "eng-1"}}}
 	if err := service.assessFindingSLAs(context.Background(), result); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("missing tenant error=%v, want validation", err)
+	}
+}
+
+func TestAssessFindingSLAsRetainsPartialEnrichment(t *testing.T) {
+	service := &Service{slaAssessor: selectiveSLAAssessor{fail: "finding-2"}}
+	result := &ScanResult{Findings: []finding.Finding{
+		{ID: "finding-1"}, {ID: "finding-2"}, {ID: "finding-3"},
+	}}
+	err := service.assessFindingSLAs(shared.WithTenant(context.Background(), "tenant-a"), result)
+	if err == nil || !strings.Contains(err.Error(), "finding-2") {
+		t.Fatalf("aggregate enrichment error=%v, want failed finding identity", err)
+	}
+	if len(result.SLAs) != 2 || result.SLAs[0].Assessment.FindingID != "finding-1" ||
+		result.SLAs[1].Assessment.FindingID != "finding-3" {
+		t.Fatalf("successful SLA enrichments were not retained in order: %+v", result.SLAs)
 	}
 }

--- a/internal/usecase/sca/sla_integration_test.go
+++ b/internal/usecase/sca/sla_integration_test.go
@@ -1,0 +1,82 @@
+package sca
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/slauc"
+)
+
+type slaPipelineClock struct{ at time.Time }
+
+func (clock slaPipelineClock) Now() time.Time { return clock.at }
+
+type slaPipelineIDs struct{}
+
+func (slaPipelineIDs) NewID() shared.ID { return "sla-event" }
+
+func TestAssessFindingSLAsUsesPersistedFindingOrderAndTenant(t *testing.T) {
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	store := memory.NewSLAStore()
+	governance, err := slauc.NewService(store, slaPipelineClock{at: now}, slaPipelineIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{slaAssessor: governance}
+	result := &ScanResult{Findings: []finding.Finding{
+		{
+			ID: "finding-critical", EngagementID: "eng-1", Kind: finding.KindSCA,
+			Severity: shared.SeverityCritical, DedupKey: "vuln:CVE-2026-1:pkg:1.0.0",
+			CVSSVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", KEV: true,
+			RiskScore: 8.82, FixedVersion: "1.0.1",
+		},
+		{
+			ID: "finding-unfixed", EngagementID: "eng-1", Kind: finding.KindSCA,
+			Severity: shared.SeverityMedium, DedupKey: "vuln:CVE-2026-2:pkg:2.0.0",
+		},
+	}}
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	if err := service.assessFindingSLAs(ctx, result); err != nil {
+		t.Fatal(err)
+	}
+	if len(result.SLAs) != 2 {
+		t.Fatalf("SLA count=%d, want 2", len(result.SLAs))
+	}
+	if result.SLAs[0].Assessment.FindingID != "finding-critical" || result.SLAs[1].Assessment.FindingID != "finding-unfixed" {
+		t.Fatalf("SLA order does not match persisted findings: %+v", result.SLAs)
+	}
+	if result.SLAs[0].Assessment.TenantID != "tenant-a" || math.Abs(result.SLAs[0].Assessment.Inputs.EPSS-0.9) > 1e-9 {
+		t.Fatalf("critical SLA lost tenant/risk input: %+v", result.SLAs[0].Assessment)
+	}
+	if result.SLAs[1].Assessment.Result.Tier != sla.TierException {
+		t.Fatalf("unfixed vulnerability tier=%s, want exception", result.SLAs[1].Assessment.Result.Tier)
+	}
+	for _, item := range result.SLAs {
+		current, err := store.Current(ctx, "tenant-a", "eng-1", item.Assessment.FindingID)
+		if err != nil {
+			t.Fatalf("current SLA %s: %v", item.Assessment.FindingID, err)
+		}
+		if current.Assessment.ID != item.Assessment.ID || current.Lifecycle.Status != sla.RemediationOpen {
+			t.Fatalf("scan result differs from durable current: %+v vs %+v", item, current)
+		}
+	}
+}
+
+func TestAssessFindingSLAsFailsClosedWithoutTenantContext(t *testing.T) {
+	governance, err := slauc.NewService(memory.NewSLAStore(), slaPipelineClock{at: time.Now().UTC()}, slaPipelineIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{slaAssessor: governance}
+	result := &ScanResult{Findings: []finding.Finding{{ID: "finding-1", EngagementID: "eng-1"}}}
+	if err := service.assessFindingSLAs(context.Background(), result); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant error=%v, want validation", err)
+	}
+}

--- a/internal/usecase/slauc/service.go
+++ b/internal/usecase/slauc/service.go
@@ -1,0 +1,260 @@
+// Package slauc coordinates tenant policy versions, immutable SLA assessments, and human-owned
+// remediation transitions. The scoring algorithm stays in domain/sla; this package owns clocks,
+// identifiers, persistence, and cross-domain input mapping.
+package slauc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityrisk"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const builtInPolicyActor = "system:sla-default"
+
+// Service is safe to share between scan, continuous-intelligence, HTTP, and CLI entry points. The
+// store owns transaction/concurrency semantics; all time and IDs enter through ports for replayable
+// tests.
+type Service struct {
+	store ports.SLAStore
+	clock ports.Clock
+	ids   ports.IDGenerator
+}
+
+func NewService(store ports.SLAStore, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if store == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: sla service dependencies are required", shared.ErrValidation)
+	}
+	return &Service{store: store, clock: clock, ids: ids}, nil
+}
+
+var _ ports.SLAAssessor = (*Service)(nil)
+var _ ports.FindingSLAAssessor = (*Service)(nil)
+
+// AssessFinding derives the reproducible subset of SLA inputs available on a finding row.
+func (s *Service) AssessFinding(ctx context.Context, tenantID shared.ID, item finding.Finding) (sla.View, error) {
+	return s.Assess(ctx, sla.AssessmentInput{
+		TenantID: tenantID, EngagementID: item.EngagementID, FindingID: item.ID,
+		SourceRiskAssessmentID: item.RiskAssessmentID, Risk: InputsFromFinding(item),
+	})
+}
+
+// Assess evaluates and promotes a current SLA assessment. An idempotent replay returns the existing
+// immutable artifact and does not move its deadlines. A materially changed input advances the current
+// pointer while the store preserves every human lifecycle field.
+func (s *Service) Assess(ctx context.Context, input sla.AssessmentInput) (sla.View, error) {
+	tenantID, err := tenantFor(ctx, input.TenantID)
+	if err != nil {
+		return sla.View{}, err
+	}
+	input.TenantID = tenantID
+	policy, err := s.ensureActivePolicy(ctx, tenantID)
+	if err != nil {
+		return sla.View{}, err
+	}
+	candidate, err := sla.Evaluate(input, policy.Config, s.clock.Now().UTC())
+	if err != nil {
+		return sla.View{}, err
+	}
+	if _, err := s.store.UpsertAssessment(ctx, candidate); err != nil {
+		return sla.View{}, fmt.Errorf("persist sla assessment: %w", err)
+	}
+	current, err := s.store.Current(ctx, tenantID, input.EngagementID, input.FindingID)
+	if err != nil {
+		return sla.View{}, fmt.Errorf("load current sla assessment: %w", err)
+	}
+	return current.View(s.clock.Now().UTC())
+}
+
+// Get returns the live overdue/acceptance-expiry projection for one finding.
+func (s *Service) Get(ctx context.Context, tenantID, engagementID, findingID shared.ID) (sla.View, error) {
+	tenantID, err := tenantFor(ctx, tenantID)
+	if err != nil {
+		return sla.View{}, err
+	}
+	current, err := s.store.Current(ctx, tenantID, engagementID, findingID)
+	if err != nil {
+		return sla.View{}, err
+	}
+	return current.View(s.clock.Now().UTC())
+}
+
+// List returns current SLA views in the deterministic order supplied by the store.
+func (s *Service) List(ctx context.Context, tenantID, engagementID shared.ID) ([]sla.View, error) {
+	tenantID, err := tenantFor(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	items, err := s.store.ListCurrent(ctx, tenantID, engagementID)
+	if err != nil {
+		return nil, err
+	}
+	views := make([]sla.View, 0, len(items))
+	now := s.clock.Now().UTC()
+	for _, item := range items {
+		view, err := item.View(now)
+		if err != nil {
+			return nil, fmt.Errorf("project stored sla current: %w", err)
+		}
+		views = append(views, view)
+	}
+	return views, nil
+}
+
+func (s *Service) AssessmentHistory(ctx context.Context, tenantID, engagementID, findingID shared.ID) ([]sla.Assessment, error) {
+	tenantID, err := tenantFor(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	return s.store.AssessmentHistory(ctx, tenantID, engagementID, findingID)
+}
+
+func (s *Service) LifecycleEvents(ctx context.Context, tenantID, engagementID, findingID shared.ID) ([]sla.LifecycleEvent, error) {
+	tenantID, err := tenantFor(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	return s.store.LifecycleEvents(ctx, tenantID, engagementID, findingID)
+}
+
+// Transition applies a human decision under optimistic concurrency and persists its audit event in
+// the same store transaction. AI/machine identities are rejected by the domain even if a caller
+// bypasses an HTTP permission check.
+func (s *Service) Transition(ctx context.Context, tenantID, engagementID, findingID shared.ID, cmd sla.TransitionCommand) (sla.View, error) {
+	tenantID, err := tenantFor(ctx, tenantID)
+	if err != nil {
+		return sla.View{}, err
+	}
+	current, err := s.store.Current(ctx, tenantID, engagementID, findingID)
+	if err != nil {
+		return sla.View{}, err
+	}
+	now := s.clock.Now().UTC()
+	next, event, err := sla.ApplyTransition(current.Lifecycle, s.ids.NewID(), cmd, now)
+	if err != nil {
+		return sla.View{}, err
+	}
+	if err := s.store.SaveTransition(ctx, next, event); err != nil {
+		return sla.View{}, fmt.Errorf("persist sla lifecycle transition: %w", err)
+	}
+	return sla.NewView(current.Assessment, next, now)
+}
+
+// ActivatePolicy appends a validated tenant policy and atomically selects it for future assessments.
+// Existing assessments are not rewritten; callers can explicitly reassess findings to adopt it.
+func (s *Service) ActivatePolicy(ctx context.Context, tenantID shared.ID, cfg sla.Config, actor string) (sla.Policy, bool, error) {
+	tenantID, err := tenantFor(ctx, tenantID)
+	if err != nil {
+		return sla.Policy{}, false, err
+	}
+	if shared.IsMachineActor(actor) {
+		return sla.Policy{}, false, fmt.Errorf("%w: activating an sla policy requires a human principal", shared.ErrValidation)
+	}
+	policy, err := sla.NewPolicy(tenantID, cfg, actor, s.clock.Now().UTC())
+	if err != nil {
+		return sla.Policy{}, false, err
+	}
+	created, err := s.store.PutPolicy(ctx, policy, true)
+	if err != nil {
+		return sla.Policy{}, false, err
+	}
+	active, err := s.store.ActivePolicy(ctx, tenantID)
+	return active, created, err
+}
+
+func (s *Service) Policies(ctx context.Context, tenantID shared.ID) ([]sla.Policy, error) {
+	tenantID, err := tenantFor(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	return s.store.PolicyHistory(ctx, tenantID)
+}
+
+// ActivePolicy returns the selected tenant policy, installing the built-in version on first use.
+func (s *Service) ActivePolicy(ctx context.Context, tenantID shared.ID) (sla.Policy, error) {
+	tenantID, err := tenantFor(ctx, tenantID)
+	if err != nil {
+		return sla.Policy{}, err
+	}
+	return s.ensureActivePolicy(ctx, tenantID)
+}
+
+func (s *Service) ensureActivePolicy(ctx context.Context, tenantID shared.ID) (sla.Policy, error) {
+	policy, err := s.store.ActivePolicy(ctx, tenantID)
+	if err == nil {
+		return policy, nil
+	}
+	if !errors.Is(err, shared.ErrNotFound) {
+		return sla.Policy{}, fmt.Errorf("load active sla policy: %w", err)
+	}
+	policy, err = sla.NewPolicy(tenantID, sla.DefaultConfig(), builtInPolicyActor, s.clock.Now().UTC())
+	if err != nil {
+		return sla.Policy{}, err
+	}
+	if _, err := s.store.PutPolicy(ctx, policy, true); err != nil {
+		return sla.Policy{}, fmt.Errorf("install default sla policy: %w", err)
+	}
+	return s.store.ActivePolicy(ctx, tenantID)
+}
+
+func tenantFor(ctx context.Context, requested shared.ID) (shared.ID, error) {
+	bound, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return "", fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
+	bound, requested = shared.TenantOrDefault(bound), shared.TenantOrDefault(requested)
+	if bound != requested {
+		return "", fmt.Errorf("%w: sla tenant does not match context", shared.ErrValidation)
+	}
+	return bound, nil
+}
+
+// InputsFromFinding maps durable finding facts into SLA risk signals without inventing asset
+// criticality or network exposure. RiskScore is EPSS*CVSS in the finding model, so EPSS can be
+// recovered when a valid CVSS vector is present. Unknown context remains neutral by domain design.
+func InputsFromFinding(item finding.Finding) sla.Inputs {
+	inputs := sla.Inputs{Severity: item.Severity, KEV: item.KEV}
+	if score, ok := shared.CVSSv3BaseScore(item.CVSSVector); ok {
+		inputs.CVSSScore = score
+		if score > 0 && item.RiskScore >= 0 {
+			inputs.EPSS = item.RiskScore / score
+			if inputs.EPSS > 1 {
+				inputs.EPSS = 1
+			}
+		}
+	}
+	if strings.TrimSpace(item.FixedVersion) != "" {
+		inputs.Feasibility = sla.FeasibilityPatchAvailable
+	} else if item.Kind == finding.KindSCA && strings.HasPrefix(strings.TrimSpace(item.DedupKey), "vuln:") {
+		inputs.Feasibility = sla.FeasibilityNoPatch
+	}
+	return inputs
+}
+
+// InputsFromRiskAssessment preserves continuous-intelligence signals that are not projected onto
+// the finding row (public PoC and active exploitation). Asset context is intentionally left unknown.
+func InputsFromRiskAssessment(item vulnerabilityrisk.Assessment) sla.Inputs {
+	inputs := sla.Inputs{
+		Severity: item.Severity, CVSSScore: item.CVSSScore, KEV: item.KEV, EPSS: item.EPSS,
+	}
+	for _, reason := range item.ReasonCodes {
+		switch strings.TrimSpace(reason) {
+		case "public_exploit":
+			inputs.PublicPoC = true
+		case "active_exploitation":
+			inputs.ActiveExploitation = true
+		}
+	}
+	if strings.TrimSpace(item.FixedVersion) != "" {
+		inputs.Feasibility = sla.FeasibilityPatchAvailable
+	} else {
+		inputs.Feasibility = sla.FeasibilityNoPatch
+	}
+	return inputs
+}

--- a/internal/usecase/slauc/service_test.go
+++ b/internal/usecase/slauc/service_test.go
@@ -169,7 +169,10 @@ func TestActivatePolicyIsHumanOnlyAndAffectsFutureAssessment(t *testing.T) {
 		second.Assessment.PreviousAssessmentID != first.Assessment.ID {
 		t.Fatalf("new policy did not version assessment: %+v", second.Assessment)
 	}
-	if got := second.Assessment.Result.RemediateBy.Sub(second.Assessment.AssessedAt); got != 10*24*time.Hour {
+	if !second.Assessment.DeadlineAnchorAt.Equal(first.Assessment.DeadlineAnchorAt) {
+		t.Fatalf("new policy reset deadline anchor: first=%s second=%s", first.Assessment.DeadlineAnchorAt, second.Assessment.DeadlineAnchorAt)
+	}
+	if got := second.Assessment.Result.RemediateBy.Sub(second.Assessment.DeadlineAnchorAt); got != 10*24*time.Hour {
 		t.Fatalf("new due policy not applied: %v", got)
 	}
 	if _, created, err := service.ActivatePolicy(ctx, "tenant-a", cfg, "security-admin@example.com"); err != nil || created {

--- a/internal/usecase/slauc/service_test.go
+++ b/internal/usecase/slauc/service_test.go
@@ -1,0 +1,271 @@
+package slauc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityrisk"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+type slaTestClock struct{ now time.Time }
+
+func (c *slaTestClock) Now() time.Time { return c.now }
+
+type slaTestIDs struct{ next int }
+
+func (ids *slaTestIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("event-%d", ids.next))
+}
+
+var serviceEpoch = time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+
+func newSLAService(t *testing.T) (*Service, *slaTestClock, *memory.SLAStore, context.Context) {
+	t.Helper()
+	clock := &slaTestClock{now: serviceEpoch}
+	store := memory.NewSLAStore()
+	service, err := NewService(store, clock, &slaTestIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	return service, clock, store, ctx
+}
+
+func assessRequest() sla.AssessmentInput {
+	return sla.AssessmentInput{
+		TenantID: "tenant-a", EngagementID: "eng-1", FindingID: "finding-1",
+		Risk: sla.Inputs{Severity: shared.SeverityHigh, CVSSScore: 8.1, EPSS: 0.4, Feasibility: sla.FeasibilityPatchAvailable},
+	}
+}
+
+func TestNewServiceRequiresDependencies(t *testing.T) {
+	store := memory.NewSLAStore()
+	clock := &slaTestClock{now: serviceEpoch}
+	ids := &slaTestIDs{}
+	cases := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "store", run: func() error { _, err := NewService(nil, clock, ids); return err }},
+		{name: "clock", run: func() error { _, err := NewService(store, nil, ids); return err }},
+		{name: "ids", run: func() error { _, err := NewService(store, clock, nil); return err }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAssessInstallsDefaultPolicyAndDoesNotMoveDeadlineOnReplay(t *testing.T) {
+	service, clock, _, ctx := newSLAService(t)
+	first, err := service.Assess(ctx, assessRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Assessment.Result.ConfigVersion != "sla-v1" || first.Lifecycle.Status != sla.RemediationOpen {
+		t.Fatalf("unexpected first view: %+v", first)
+	}
+	active, err := service.ActivePolicy(ctx, "tenant-a")
+	if err != nil || active.CreatedBy != builtInPolicyActor || active.Config.Version != "sla-v1" {
+		t.Fatalf("default policy=%+v err=%v", active, err)
+	}
+	clock.now = clock.now.Add(7 * 24 * time.Hour)
+	replayed, err := service.Assess(ctx, assessRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayed.Assessment.ID != first.Assessment.ID || !replayed.Assessment.Result.RemediateBy.Equal(first.Assessment.Result.RemediateBy) {
+		t.Fatalf("replay moved identity/deadline: first=%+v replay=%+v", first.Assessment, replayed.Assessment)
+	}
+	provenanceOnly := assessRequest()
+	provenanceOnly.SourceRiskAssessmentID = "risk-refresh-with-same-sla-facts"
+	clock.now = clock.now.Add(time.Hour)
+	refreshed, err := service.Assess(ctx, provenanceOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.Assessment.ID != first.Assessment.ID ||
+		!refreshed.Assessment.Result.RemediateBy.Equal(first.Assessment.Result.RemediateBy) {
+		t.Fatalf("provenance-only refresh moved SLA deadline: first=%+v refresh=%+v", first.Assessment, refreshed.Assessment)
+	}
+	policies, err := service.Policies(ctx, "tenant-a")
+	if err != nil || len(policies) != 1 {
+		t.Fatalf("policies=%+v err=%v", policies, err)
+	}
+}
+
+func TestAssessmentRefreshPreservesAcceptedRisk(t *testing.T) {
+	service, clock, _, ctx := newSLAService(t)
+	initial, err := service.Assess(ctx, assessRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expires := serviceEpoch.Add(30 * 24 * time.Hour)
+	accepted, err := service.Transition(ctx, "tenant-a", "eng-1", "finding-1", sla.TransitionCommand{
+		To: sla.RemediationAcceptedRisk, Actor: "alice", Reason: "vendor support window",
+		CompensatingControl: "WAF plus isolation", AcceptanceExpiresAt: &expires, ExpectedVersion: initial.Lifecycle.Version,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock.now = clock.now.Add(time.Hour)
+	request := assessRequest()
+	request.SourceRiskAssessmentID = "risk-new"
+	request.Risk.ActiveExploitation = true
+	refreshed, err := service.Assess(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.Assessment.ID == initial.Assessment.ID || refreshed.Assessment.PreviousAssessmentID != initial.Assessment.ID {
+		t.Fatalf("assessment history did not advance: %+v", refreshed.Assessment)
+	}
+	if refreshed.Lifecycle.Status != sla.RemediationAcceptedRisk || refreshed.Lifecycle.Version != accepted.Lifecycle.Version ||
+		refreshed.Lifecycle.AcceptedBy != "alice" || refreshed.Lifecycle.AssessmentID != refreshed.Assessment.ID {
+		t.Fatalf("risk refresh clobbered human state: %+v", refreshed.Lifecycle)
+	}
+	history, err := service.AssessmentHistory(ctx, "tenant-a", "eng-1", "finding-1")
+	if err != nil || len(history) != 2 {
+		t.Fatalf("history=%+v err=%v", history, err)
+	}
+	events, err := service.LifecycleEvents(ctx, "tenant-a", "eng-1", "finding-1")
+	if err != nil || len(events) != 1 || events[0].To != sla.RemediationAcceptedRisk {
+		t.Fatalf("events=%+v err=%v", events, err)
+	}
+}
+
+func TestActivatePolicyIsHumanOnlyAndAffectsFutureAssessment(t *testing.T) {
+	service, clock, _, ctx := newSLAService(t)
+	first, err := service.Assess(ctx, assessRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := sla.DefaultConfig()
+	cfg.Version = "tenant-policy-2"
+	cfg.DueRanges.High.RemediateWithin = 10 * 24 * time.Hour
+	if _, _, err := service.ActivatePolicy(ctx, "tenant-a", cfg, "system:policy-bot"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("machine policy activation should fail, got %v", err)
+	}
+	clock.now = clock.now.Add(time.Hour)
+	policy, created, err := service.ActivatePolicy(ctx, "tenant-a", cfg, "security-admin@example.com")
+	if err != nil || !created || policy.Config.Version != cfg.Version {
+		t.Fatalf("policy=%+v created=%v err=%v", policy, created, err)
+	}
+	second, err := service.Assess(ctx, assessRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Assessment.ID == first.Assessment.ID || second.Assessment.Result.ConfigVersion != cfg.Version ||
+		second.Assessment.PreviousAssessmentID != first.Assessment.ID {
+		t.Fatalf("new policy did not version assessment: %+v", second.Assessment)
+	}
+	if got := second.Assessment.Result.RemediateBy.Sub(second.Assessment.AssessedAt); got != 10*24*time.Hour {
+		t.Fatalf("new due policy not applied: %v", got)
+	}
+	if _, created, err := service.ActivatePolicy(ctx, "tenant-a", cfg, "security-admin@example.com"); err != nil || created {
+		t.Fatalf("policy replay created=%v err=%v", created, err)
+	}
+}
+
+func TestTransitionUsesOptimisticVersionAndHumanPrincipal(t *testing.T) {
+	service, _, _, ctx := newSLAService(t)
+	initial, err := service.Assess(ctx, assessRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := service.Transition(ctx, "tenant-a", "eng-1", "finding-1", sla.TransitionCommand{
+		To: sla.RemediationMitigating, Actor: "reviewer", Reason: "maintenance scheduled", ExpectedVersion: 1,
+	})
+	if err != nil || updated.Lifecycle.Version != 2 {
+		t.Fatalf("updated=%+v err=%v", updated, err)
+	}
+	if _, err := service.Transition(ctx, "tenant-a", "eng-1", "finding-1", sla.TransitionCommand{
+		To: sla.RemediationRemediated, Actor: "reviewer", Reason: "stale", ExpectedVersion: initial.Lifecycle.Version,
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale transition should conflict, got %v", err)
+	}
+	if _, err := service.Transition(ctx, "tenant-a", "eng-1", "finding-1", sla.TransitionCommand{
+		To: sla.RemediationRemediated, Actor: "agent:fixer", Reason: "automated", ExpectedVersion: 2,
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("machine transition should fail, got %v", err)
+	}
+}
+
+func TestListAndGetCalculateOverdueAtReadTime(t *testing.T) {
+	service, clock, _, ctx := newSLAService(t)
+	view, err := service.Assess(ctx, assessRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock.now = view.Assessment.Result.RemediateBy
+	got, err := service.Get(ctx, "tenant-a", "eng-1", "finding-1")
+	if err != nil || !got.Overdue {
+		t.Fatalf("get=%+v err=%v", got, err)
+	}
+	list, err := service.List(ctx, "tenant-a", "eng-1")
+	if err != nil || len(list) != 1 || !list[0].Overdue {
+		t.Fatalf("list=%+v err=%v", list, err)
+	}
+}
+
+func TestServiceTenantBoundaryFailsClosed(t *testing.T) {
+	service, _, _, ctx := newSLAService(t)
+	if _, err := service.Assess(context.Background(), assessRequest()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant should fail, got %v", err)
+	}
+	request := assessRequest()
+	request.TenantID = "tenant-b"
+	if _, err := service.Assess(ctx, request); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("mismatch should fail, got %v", err)
+	}
+	if _, err := service.Get(ctx, "tenant-b", "eng-1", "finding-1"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross tenant get should fail, got %v", err)
+	}
+}
+
+func TestInputsFromFindingUsesOnlyDurableSignals(t *testing.T) {
+	item := finding.Finding{
+		Severity: shared.SeverityHigh, CVSSVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+		KEV: true, RiskScore: 4.9, FixedVersion: "2.0.0", Kind: finding.KindSCA, DedupKey: "vuln:CVE-1:pkg:1",
+	}
+	inputs := InputsFromFinding(item)
+	if inputs.CVSSScore != 9.8 || inputs.EPSS < 0.49 || inputs.EPSS > 0.51 || !inputs.KEV || inputs.Feasibility != sla.FeasibilityPatchAvailable {
+		t.Fatalf("unexpected finding inputs: %+v", inputs)
+	}
+	if inputs.Exposure != sla.ExposureUnknown || inputs.Criticality != sla.CriticalityUnknown || inputs.PublicPoC || inputs.ActiveExploitation {
+		t.Fatalf("mapper invented unavailable context: %+v", inputs)
+	}
+	item.FixedVersion = ""
+	if got := InputsFromFinding(item).Feasibility; got != sla.FeasibilityNoPatch {
+		t.Fatalf("unfixed vulnerability feasibility=%q", got)
+	}
+	item.DedupKey = "license:GPL-3.0"
+	if got := InputsFromFinding(item).Feasibility; got != sla.FeasibilityUnknown {
+		t.Fatalf("license finding should not be treated as no-patch vulnerability: %q", got)
+	}
+}
+
+func TestInputsFromRiskAssessmentRetainsThreatIntelligence(t *testing.T) {
+	assessment := vulnerabilityrisk.Assessment{
+		Severity: shared.SeverityCritical, CVSSScore: 9.8, KEV: true, EPSS: 0.92,
+		FixedVersion: "3.1.4", ReasonCodes: []string{"public_exploit", "active_exploitation", "unrelated"},
+	}
+	inputs := InputsFromRiskAssessment(assessment)
+	if !inputs.PublicPoC || !inputs.ActiveExploitation || !inputs.KEV || inputs.EPSS != 0.92 || inputs.Feasibility != sla.FeasibilityPatchAvailable {
+		t.Fatalf("unexpected continuous-intelligence inputs: %+v", inputs)
+	}
+	assessment.FixedVersion = ""
+	if got := InputsFromRiskAssessment(assessment).Feasibility; got != sla.FeasibilityNoPatch {
+		t.Fatalf("no-fix assessment feasibility=%q", got)
+	}
+}

--- a/internal/usecase/vulnerabilityevaluation/service.go
+++ b/internal/usecase/vulnerabilityevaluation/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityoccurrence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityrisk"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/slauc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/vulnerabilityprojection"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/vulnerabilityrollout"
 )
@@ -101,7 +102,7 @@ func (s *Service) EvaluateOccurrence(ctx context.Context, upserted vulnerability
 	if s.slaAssessor != nil {
 		if _, err := s.slaAssessor.Assess(ctx, sla.AssessmentInput{
 			TenantID: occurrence.TenantID, EngagementID: occurrence.EngagementID, FindingID: projected.ID,
-			SourceRiskAssessmentID: stored.Assessment.ID, Risk: slaInputs(stored.Assessment),
+			SourceRiskAssessmentID: stored.Assessment.ID, Risk: slauc.InputsFromRiskAssessment(stored.Assessment),
 		}); err != nil {
 			return fmt.Errorf("reassess finding sla from vulnerability intelligence: %w", err)
 		}
@@ -126,26 +127,6 @@ func (s *Service) EvaluateOccurrence(ctx context.Context, upserted vulnerability
 		return fmt.Errorf("persist vulnerability risk change: %w", err)
 	}
 	return nil
-}
-
-func slaInputs(assessment vulnerabilityrisk.Assessment) sla.Inputs {
-	inputs := sla.Inputs{
-		Severity: assessment.Severity, CVSSScore: assessment.CVSSScore, KEV: assessment.KEV, EPSS: assessment.EPSS,
-	}
-	for _, reason := range assessment.ReasonCodes {
-		switch reason {
-		case "public_exploit":
-			inputs.PublicPoC = true
-		case "active_exploitation":
-			inputs.ActiveExploitation = true
-		}
-	}
-	if assessment.FixedVersion == "" {
-		inputs.Feasibility = sla.FeasibilityNoPatch
-	} else {
-		inputs.Feasibility = sla.FeasibilityPatchAvailable
-	}
-	return inputs
 }
 
 func boolValue(value *bool) bool {

--- a/internal/usecase/vulnerabilityevaluation/service.go
+++ b/internal/usecase/vulnerabilityevaluation/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/advisory"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityaction"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityoccurrence"
@@ -23,6 +24,7 @@ type Service struct {
 	actions     ports.VulnerabilityActionStore
 	clock       ports.Clock
 	rollout     *vulnerabilityrollout.Policy
+	slaAssessor ports.SLAAssessor
 }
 
 func NewService(advisories ports.AdvisoryMaterializer, assessments ports.VulnerabilityRiskAssessmentStore, projection *vulnerabilityprojection.Service, clock ports.Clock) (*Service, error) {
@@ -35,6 +37,11 @@ func NewService(advisories ports.AdvisoryMaterializer, assessments ports.Vulnera
 func (s *Service) SetActionStore(actions ports.VulnerabilityActionStore) {
 	s.actions = actions
 }
+
+// SetSLAAssessor wires SLA reassessment to the continuous-intelligence projection boundary. Nil
+// keeps the feature disabled. Machine refreshes advance only SLA assessment provenance; the SLA
+// store guarantees they cannot overwrite a human remediation/acceptance state.
+func (s *Service) SetSLAAssessor(assessor ports.SLAAssessor) { s.slaAssessor = assessor }
 
 func (s *Service) SetRollout(policy *vulnerabilityrollout.Policy) { s.rollout = policy }
 
@@ -91,7 +98,18 @@ func (s *Service) EvaluateOccurrence(ctx context.Context, upserted vulnerability
 	if err != nil {
 		return err
 	}
-	if s.actions == nil || !stored.Created || !s.rollout.Enabled(vulnerabilityrollout.Actions, occurrence.TenantID) {
+	if s.slaAssessor != nil {
+		if _, err := s.slaAssessor.Assess(ctx, sla.AssessmentInput{
+			TenantID: occurrence.TenantID, EngagementID: occurrence.EngagementID, FindingID: projected.ID,
+			SourceRiskAssessmentID: stored.Assessment.ID, Risk: slaInputs(stored.Assessment),
+		}); err != nil {
+			return fmt.Errorf("reassess finding sla from vulnerability intelligence: %w", err)
+		}
+	}
+	// A re-exposure can re-promote an existing immutable risk assessment, so Created is false even
+	// though the occurrence event is new and must create review/retest work. Only a pure assessment
+	// replay with no occurrence transition is safe to skip.
+	if s.actions == nil || (!stored.Created && upserted.Event == nil) || !s.rollout.Enabled(vulnerabilityrollout.Actions, occurrence.TenantID) {
 		return nil
 	}
 	change, err := vulnerabilityaction.Build(previous, stored.Assessment, upserted.Event, projected.ID, s.clock.Now().UTC())
@@ -108,6 +126,26 @@ func (s *Service) EvaluateOccurrence(ctx context.Context, upserted vulnerability
 		return fmt.Errorf("persist vulnerability risk change: %w", err)
 	}
 	return nil
+}
+
+func slaInputs(assessment vulnerabilityrisk.Assessment) sla.Inputs {
+	inputs := sla.Inputs{
+		Severity: assessment.Severity, CVSSScore: assessment.CVSSScore, KEV: assessment.KEV, EPSS: assessment.EPSS,
+	}
+	for _, reason := range assessment.ReasonCodes {
+		switch reason {
+		case "public_exploit":
+			inputs.PublicPoC = true
+		case "active_exploitation":
+			inputs.ActiveExploitation = true
+		}
+	}
+	if assessment.FixedVersion == "" {
+		inputs.Feasibility = sla.FeasibilityNoPatch
+	} else {
+		inputs.Feasibility = sla.FeasibilityPatchAvailable
+	}
+	return inputs
 }
 
 func boolValue(value *bool) bool {

--- a/internal/usecase/vulnerabilityevaluation/service_test.go
+++ b/internal/usecase/vulnerabilityevaluation/service_test.go
@@ -1,0 +1,300 @@
+package vulnerabilityevaluation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/advisory"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityaction"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityoccurrence"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/slauc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/vulnerabilityprojection"
+)
+
+type evaluationClock struct{ at time.Time }
+
+func (clock evaluationClock) Now() time.Time { return clock.at }
+
+type evaluationIDs struct{ next int }
+
+func (ids *evaluationIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("evaluation-event-%d", ids.next))
+}
+
+type recordingSLAAssessor struct {
+	inputs []sla.AssessmentInput
+	err    error
+}
+
+func (assessor *recordingSLAAssessor) Assess(_ context.Context, input sla.AssessmentInput) (sla.View, error) {
+	assessor.inputs = append(assessor.inputs, input)
+	return sla.View{}, assessor.err
+}
+
+func TestEvaluateOccurrenceReassessesSLAWithContinuousIntelligence(t *testing.T) {
+	now := time.Date(2026, 8, 15, 13, 0, 0, 0, time.UTC)
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	materializer := memory.NewAdvisoryMaterializer()
+	knownExploited, publicExploit, activeExploitation, epss := true, true, true, 0.91
+	materialized, err := materializer.Materialize(ctx, []advisory.ObservationRecord{{
+		Observation: advisory.Observation{
+			SourceType: "osv", SourceID: "osv", RecordID: "CVE-2026-8000", Status: advisory.StatusActive,
+			Advisory: advisory.Advisory{
+				ID: "CVE-2026-8000", Summary: "continuously enriched vulnerability",
+				CVSSVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", CVSSScore: 9.8,
+			},
+			KEV: &knownExploited, EPSS: &epss, PublicExploit: &publicExploit, ActiveExploitation: &activeExploitation,
+		},
+		ObservedAt: now,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := memory.NewFindingRepository()
+	projection, err := vulnerabilityprojection.NewService(findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService(materializer, memory.NewVulnerabilityRiskAssessmentStore(), projection, evaluationClock{at: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := &recordingSLAAssessor{}
+	service.SetSLAAssessor(recorder)
+	occurrence := vulnerabilityoccurrence.Occurrence{
+		TenantID: "tenant-a", ID: "occurrence-1", EngagementID: "eng-1", AdvisoryID: "CVE-2026-8000",
+		ComponentID: "component-1", SBOMID: "sbom-1", ComponentFingerprint: "pkg:golang/example.com/module@1.0.0",
+		Ecosystem: "Go", Package: "example.com/module", ComponentVersion: "1.0.0", FixedVersion: "1.1.0",
+		MatchMethod: vulnerabilityoccurrence.MatchMethodPackageRange, Confidence: vulnerabilityoccurrence.ConfidenceHigh,
+		MatchEvidence: []vulnerabilityoccurrence.MatchEvidence{{
+			Method: vulnerabilityoccurrence.MatchMethodPackageRange, Confidence: vulnerabilityoccurrence.ConfidenceHigh,
+			Criteria: "Go/example.com/module", FixedVersion: "1.1.0",
+		}},
+		AdvisoryRevision: materialized.Revision, Scope: "production", Reachability: "high",
+		State: vulnerabilityoccurrence.StateDetected, FirstDetectedAt: now, LastDetectedAt: now,
+		LastEvaluatedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := service.EvaluateOccurrence(ctx, vulnerabilityoccurrence.UpsertResult{Occurrence: occurrence, Created: true, Changed: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(recorder.inputs) != 1 {
+		t.Fatalf("SLA assessment calls=%d, want 1", len(recorder.inputs))
+	}
+	input := recorder.inputs[0]
+	if input.TenantID != "tenant-a" || input.EngagementID != "eng-1" || input.FindingID.IsZero() || input.SourceRiskAssessmentID.IsZero() {
+		t.Fatalf("SLA provenance is incomplete: %+v", input)
+	}
+	if !input.Risk.KEV || !input.Risk.PublicPoC || !input.Risk.ActiveExploitation || input.Risk.EPSS != epss || input.Risk.CVSSScore != 9.8 {
+		t.Fatalf("continuous intelligence signals were not preserved: %+v", input.Risk)
+	}
+	if input.Risk.Feasibility != sla.FeasibilityPatchAvailable {
+		t.Fatalf("feasibility=%s, want patch_available", input.Risk.Feasibility)
+	}
+	items, err := findings.ListByEngagement(ctx, "eng-1")
+	if err != nil || len(items) != 1 || items[0].ID != input.FindingID {
+		t.Fatalf("projected finding=%+v err=%v, SLA finding=%s", items, err, input.FindingID)
+	}
+	want := errors.New("SLA store unavailable")
+	recorder.err = want
+	if err := service.EvaluateOccurrence(ctx, vulnerabilityoccurrence.UpsertResult{Occurrence: occurrence}); !errors.Is(err, want) {
+		t.Fatalf("SLA reassessment error=%v, want wrapped %v", err, want)
+	}
+	if len(recorder.inputs) != 2 || recorder.inputs[1].FindingID != input.FindingID {
+		t.Fatalf("failed evaluator did not attempt the same finding provenance: %+v", recorder.inputs)
+	}
+}
+
+func TestContinuousLifecyclePreservesHumanSLAAndCreatesReexposureWork(t *testing.T) {
+	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
+	clock := &evaluationClock{at: now}
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	materializer := memory.NewAdvisoryMaterializer()
+	record := advisory.ObservationRecord{Observation: advisory.Observation{
+		SourceType: "osv", SourceID: "osv", RecordID: "CVE-2026-8100", Status: advisory.StatusActive,
+		Advisory: advisory.Advisory{
+			ID: "CVE-2026-8100", Summary: "risk changes over time",
+			CVSSVector: "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L", CVSSScore: 5.5,
+		},
+	}, ObservedAt: now}
+	firstRevision, err := materializer.Materialize(ctx, []advisory.ObservationRecord{record})
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := memory.NewFindingRepository()
+	projection, err := vulnerabilityprojection.NewService(findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	riskStore := memory.NewVulnerabilityRiskAssessmentStore()
+	service, err := NewService(materializer, riskStore, projection, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions := memory.NewVulnerabilityActionStore()
+	service.SetActionStore(actions)
+	slaStore := memory.NewSLAStore()
+	governance, err := slauc.NewService(slaStore, clock, &evaluationIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.SetSLAAssessor(governance)
+
+	occurrence := evaluationOccurrence(firstRevision.Revision, now)
+	if err := service.EvaluateOccurrence(ctx, vulnerabilityoccurrence.UpsertResult{
+		Occurrence: occurrence, Created: true, Changed: true,
+		Event: evaluationOccurrenceEvent("detected", vulnerabilityoccurrence.EventDetected,
+			vulnerabilityoccurrence.State(""), vulnerabilityoccurrence.StateDetected, occurrence, now),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	projected, err := findings.ListByEngagement(ctx, "eng-1")
+	if err != nil || len(projected) != 1 {
+		t.Fatalf("initial projection=%+v err=%v", projected, err)
+	}
+	findingID := projected[0].ID
+	initialSLA, err := governance.Get(ctx, "tenant-a", "eng-1", findingID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expires := now.Add(30 * 24 * time.Hour)
+	accepted, err := governance.Transition(ctx, "tenant-a", "eng-1", findingID, sla.TransitionCommand{
+		To: sla.RemediationAcceptedRisk, Actor: "risk-owner", Reason: "vendor maintenance window",
+		CompensatingControl: "network isolation", AcceptanceExpiresAt: &expires,
+		ExpectedVersion: initialSLA.Lifecycle.Version,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The provider escalates the same advisory to KEV with active exploitation. This must create a
+	// new SLA assessment, but it must not overwrite the human acceptance decision.
+	clock.at = now.Add(time.Hour)
+	trueValue, highEPSS := true, 0.97
+	record.Observation.Advisory.CVSSVector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+	record.Observation.Advisory.CVSSScore = 9.8
+	record.Observation.KEV, record.Observation.EPSS = &trueValue, &highEPSS
+	record.Observation.PublicExploit, record.Observation.ActiveExploitation = &trueValue, &trueValue
+	record.ObservedAt = clock.at
+	escalatedRevision, err := materializer.Materialize(ctx, []advisory.ObservationRecord{record})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrence.AdvisoryRevision = escalatedRevision.Revision
+	occurrence.LastEvaluatedAt, occurrence.UpdatedAt = clock.at, clock.at
+	if err := service.EvaluateOccurrence(ctx, vulnerabilityoccurrence.UpsertResult{
+		Occurrence: occurrence, Changed: true,
+		Event: evaluationOccurrenceEvent("escalated", vulnerabilityoccurrence.EventUpdated,
+			vulnerabilityoccurrence.StateDetected, vulnerabilityoccurrence.StateDetected, occurrence, clock.at),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	escalatedSLA, err := governance.Get(ctx, "tenant-a", "eng-1", findingID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if escalatedSLA.Assessment.ID == initialSLA.Assessment.ID ||
+		escalatedSLA.Assessment.PreviousAssessmentID != initialSLA.Assessment.ID ||
+		escalatedSLA.Assessment.Result.Tier != sla.TierEmergency {
+		t.Fatalf("risk escalation did not advance SLA assessment: %+v", escalatedSLA.Assessment)
+	}
+	if escalatedSLA.Lifecycle.Status != sla.RemediationAcceptedRisk ||
+		escalatedSLA.Lifecycle.AcceptedBy != "risk-owner" ||
+		escalatedSLA.Lifecycle.Version != accepted.Lifecycle.Version {
+		t.Fatalf("intelligence refresh clobbered accepted risk: %+v", escalatedSLA.Lifecycle)
+	}
+
+	clock.at = now.Add(2 * time.Hour)
+	remediated, err := governance.Transition(ctx, "tenant-a", "eng-1", findingID, sla.TransitionCommand{
+		To: sla.RemediationRemediated, Actor: "risk-owner", Reason: "upgrade deployed and verified",
+		ExpectedVersion: escalatedSLA.Lifecycle.Version,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Retirement creates retest work without auto-remediating. Re-exposure then reuses the prior
+	// detected risk assessment (Created=false), but still must re-promote it and create review work.
+	occurrence.State = vulnerabilityoccurrence.StateNoLongerDetected
+	occurrence.LastEvaluatedAt, occurrence.UpdatedAt = clock.at, clock.at
+	if err := service.EvaluateOccurrence(ctx, vulnerabilityoccurrence.UpsertResult{
+		Occurrence: occurrence, Changed: true,
+		Event: evaluationOccurrenceEvent("retired", vulnerabilityoccurrence.EventNoLongerDetected,
+			vulnerabilityoccurrence.StateDetected, vulnerabilityoccurrence.StateNoLongerDetected, occurrence, clock.at),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	clock.at = now.Add(3 * time.Hour)
+	occurrence.State = vulnerabilityoccurrence.StateDetected
+	occurrence.LastDetectedAt, occurrence.LastEvaluatedAt, occurrence.UpdatedAt = clock.at, clock.at, clock.at
+	if err := service.EvaluateOccurrence(ctx, vulnerabilityoccurrence.UpsertResult{
+		Occurrence: occurrence, Changed: true,
+		Event: evaluationOccurrenceEvent("reexposed", vulnerabilityoccurrence.EventReexposed,
+			vulnerabilityoccurrence.StateNoLongerDetected, vulnerabilityoccurrence.StateDetected, occurrence, clock.at),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	currentRisk, err := riskStore.Current(ctx, "tenant-a", occurrence.ID)
+	if err != nil || currentRisk.OccurrenceState != string(vulnerabilityoccurrence.StateDetected) {
+		t.Fatalf("re-exposed risk was not current: %+v err=%v", currentRisk, err)
+	}
+	currentSLA, err := governance.Get(ctx, "tenant-a", "eng-1", findingID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if currentSLA.Lifecycle.Status != sla.RemediationRemediated ||
+		currentSLA.Lifecycle.Version != remediated.Lifecycle.Version ||
+		currentSLA.Assessment.ID != escalatedSLA.Assessment.ID {
+		t.Fatalf("re-exposure silently reopened or rewrote terminal SLA: %+v", currentSLA)
+	}
+	page, err := actions.ListActions(ctx, vulnerabilityaction.ActionQuery{TenantID: "tenant-a", EngagementID: "eng-1", Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantActions := map[vulnerabilityaction.ActionType]bool{
+		vulnerabilityaction.ActionRetestRequired: false,
+		vulnerabilityaction.ActionReexposure:     false,
+	}
+	for _, item := range page.Items {
+		if _, ok := wantActions[item.Type]; ok {
+			wantActions[item.Type] = true
+		}
+	}
+	for actionType, found := range wantActions {
+		if !found {
+			t.Errorf("continuous lifecycle did not create %s action: %+v", actionType, page.Items)
+		}
+	}
+}
+
+func evaluationOccurrence(revision int64, now time.Time) vulnerabilityoccurrence.Occurrence {
+	return vulnerabilityoccurrence.Occurrence{
+		TenantID: "tenant-a", ID: "occurrence-lifecycle", EngagementID: "eng-1", AdvisoryID: "CVE-2026-8100",
+		ComponentID: "component-1", SBOMID: "sbom-1", ComponentFingerprint: "pkg:golang/example.com/lifecycle@1.0.0",
+		Ecosystem: "Go", Package: "example.com/lifecycle", ComponentVersion: "1.0.0", FixedVersion: "1.1.0",
+		MatchMethod: vulnerabilityoccurrence.MatchMethodPackageRange, Confidence: vulnerabilityoccurrence.ConfidenceHigh,
+		MatchEvidence: []vulnerabilityoccurrence.MatchEvidence{{
+			Method: vulnerabilityoccurrence.MatchMethodPackageRange, Confidence: vulnerabilityoccurrence.ConfidenceHigh,
+			Criteria: "Go/example.com/lifecycle", FixedVersion: "1.1.0",
+		}},
+		AdvisoryRevision: revision, Scope: "production", Reachability: "high", State: vulnerabilityoccurrence.StateDetected,
+		FirstDetectedAt: now, LastDetectedAt: now, LastEvaluatedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+}
+
+func evaluationOccurrenceEvent(id string, kind vulnerabilityoccurrence.EventType, from, to vulnerabilityoccurrence.State,
+	occurrence vulnerabilityoccurrence.Occurrence, at time.Time,
+) *vulnerabilityoccurrence.Event {
+	return &vulnerabilityoccurrence.Event{
+		TenantID: occurrence.TenantID, ID: shared.ID("occurrence-event-" + id), OccurrenceID: occurrence.ID,
+		EventType: kind, AdvisoryRevision: occurrence.AdvisoryRevision, FromState: from, ToState: to,
+		Details: json.RawMessage(`{}`), CreatedAt: at,
+	}
+}

--- a/migrations/0103_sla_governance.sql
+++ b/migrations/0103_sla_governance.sql
@@ -1,7 +1,9 @@
 -- +goose Up
 -- Risk-based remediation SLA governance (#80) and continuous-intelligence reassessment (#540).
--- Policies and assessments are append-only. Current pointers are separate so an audit can reproduce
--- every historical deadline. Human lifecycle state is isolated from machine-owned assessment refreshes.
+-- Policies are append-only. Assessment/event rows are immutable for the lifetime of their finding
+-- aggregate and cascade with an intentional finding/engagement/project teardown. Current pointers are
+-- separate so an audit can reproduce every retained deadline. Human lifecycle state is isolated from
+-- machine-owned assessment refreshes.
 
 CREATE TABLE sla_policies (
     tenant_id      TEXT NOT NULL REFERENCES tenants(id),
@@ -50,7 +52,7 @@ CREATE TABLE sla_assessments (
     FOREIGN KEY (tenant_id, source_risk_assessment_id)
         REFERENCES vulnerability_risk_assessments(tenant_id, id),
     FOREIGN KEY (tenant_id, engagement_id, finding_id, previous_assessment_id)
-        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id),
+        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id) ON DELETE CASCADE,
     CHECK (deadline_anchor_at <= assessed_at),
     CHECK (mitigate_by >= deadline_anchor_at),
     CHECK (remediate_by >= mitigate_by)
@@ -91,7 +93,7 @@ CREATE TABLE sla_lifecycles (
     FOREIGN KEY (tenant_id, engagement_id, finding_id)
         REFERENCES findings(tenant_id, engagement_id, id) ON DELETE CASCADE,
     FOREIGN KEY (tenant_id, engagement_id, finding_id, assessment_id)
-        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id),
+        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id) ON DELETE CASCADE,
     CHECK (
         (status = 'accepted_risk' AND btrim(reason) <> '' AND btrim(compensating_control) <> ''
             AND btrim(accepted_by) <> '' AND accepted_at IS NOT NULL
@@ -126,13 +128,15 @@ CREATE TABLE sla_lifecycle_events (
     FOREIGN KEY (tenant_id, engagement_id, finding_id)
         REFERENCES sla_lifecycles(tenant_id, engagement_id, finding_id) ON DELETE CASCADE,
     FOREIGN KEY (tenant_id, engagement_id, finding_id, assessment_id)
-        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id)
+        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id) ON DELETE CASCADE
 );
 CREATE INDEX idx_sla_lifecycle_events_history
     ON sla_lifecycle_events(tenant_id, engagement_id, finding_id, occurred_at, id);
 
--- The application never mutates these audit artifacts, but RLS alone still permits mutation by an
--- authorized tenant writer. Enforce the append-only contract at the database boundary as well.
+-- Policies outlive every governed finding and are fully append-only. Assessments and lifecycle
+-- events are update-immutable while their finding aggregate exists, but DELETE remains available
+-- for the repository's intentional finding/engagement/project ON DELETE CASCADE teardown. Combining
+-- an unconditional child DELETE trigger with those parent FKs would make production teardown fail.
 CREATE TRIGGER sla_policies_append_only
     BEFORE UPDATE OR DELETE ON sla_policies
     FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
@@ -141,14 +145,14 @@ CREATE TRIGGER sla_policies_no_truncate
     FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
 
 CREATE TRIGGER sla_assessments_append_only
-    BEFORE UPDATE OR DELETE ON sla_assessments
+    BEFORE UPDATE ON sla_assessments
     FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
 CREATE TRIGGER sla_assessments_no_truncate
     BEFORE TRUNCATE ON sla_assessments
     FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
 
 CREATE TRIGGER sla_lifecycle_events_append_only
-    BEFORE UPDATE OR DELETE ON sla_lifecycle_events
+    BEFORE UPDATE ON sla_lifecycle_events
     FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
 CREATE TRIGGER sla_lifecycle_events_no_truncate
     BEFORE TRUNCATE ON sla_lifecycle_events

--- a/migrations/0103_sla_governance.sql
+++ b/migrations/0103_sla_governance.sql
@@ -11,8 +11,7 @@ CREATE TABLE sla_policies (
     created_by     TEXT NOT NULL CHECK (btrim(created_by) <> ''),
     created_at     TIMESTAMPTZ NOT NULL,
     PRIMARY KEY (tenant_id, config_version),
-    UNIQUE (tenant_id, config_version, sha256),
-    UNIQUE (tenant_id, sha256)
+    UNIQUE (tenant_id, config_version, sha256)
 );
 
 CREATE TABLE sla_active_policies (
@@ -38,6 +37,7 @@ CREATE TABLE sla_assessments (
     mitigate_by               TIMESTAMPTZ NOT NULL,
     remediate_by              TIMESTAMPTZ NOT NULL,
     previous_assessment_id    TEXT,
+    deadline_anchor_at        TIMESTAMPTZ NOT NULL,
     assessed_at               TIMESTAMPTZ NOT NULL,
     created_at                TIMESTAMPTZ NOT NULL,
     PRIMARY KEY (tenant_id, id),
@@ -51,7 +51,8 @@ CREATE TABLE sla_assessments (
         REFERENCES vulnerability_risk_assessments(tenant_id, id),
     FOREIGN KEY (tenant_id, engagement_id, finding_id, previous_assessment_id)
         REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id),
-    CHECK (mitigate_by >= assessed_at),
+    CHECK (deadline_anchor_at <= assessed_at),
+    CHECK (mitigate_by >= deadline_anchor_at),
     CHECK (remediate_by >= mitigate_by)
 );
 CREATE INDEX idx_sla_assessments_history
@@ -129,6 +130,29 @@ CREATE TABLE sla_lifecycle_events (
 );
 CREATE INDEX idx_sla_lifecycle_events_history
     ON sla_lifecycle_events(tenant_id, engagement_id, finding_id, occurred_at, id);
+
+-- The application never mutates these audit artifacts, but RLS alone still permits mutation by an
+-- authorized tenant writer. Enforce the append-only contract at the database boundary as well.
+CREATE TRIGGER sla_policies_append_only
+    BEFORE UPDATE OR DELETE ON sla_policies
+    FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER sla_policies_no_truncate
+    BEFORE TRUNCATE ON sla_policies
+    FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CREATE TRIGGER sla_assessments_append_only
+    BEFORE UPDATE OR DELETE ON sla_assessments
+    FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER sla_assessments_no_truncate
+    BEFORE TRUNCATE ON sla_assessments
+    FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CREATE TRIGGER sla_lifecycle_events_append_only
+    BEFORE UPDATE OR DELETE ON sla_lifecycle_events
+    FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER sla_lifecycle_events_no_truncate
+    BEFORE TRUNCATE ON sla_lifecycle_events
+    FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
 
 CALL synapse_enable_tenant_rls('sla_policies');
 CALL synapse_enable_tenant_rls('sla_active_policies');

--- a/migrations/0103_sla_governance.sql
+++ b/migrations/0103_sla_governance.sql
@@ -1,0 +1,146 @@
+-- +goose Up
+-- Risk-based remediation SLA governance (#80) and continuous-intelligence reassessment (#540).
+-- Policies and assessments are append-only. Current pointers are separate so an audit can reproduce
+-- every historical deadline. Human lifecycle state is isolated from machine-owned assessment refreshes.
+
+CREATE TABLE sla_policies (
+    tenant_id      TEXT NOT NULL REFERENCES tenants(id),
+    config_version TEXT NOT NULL,
+    config         JSONB NOT NULL CHECK (jsonb_typeof(config) = 'object'),
+    sha256         TEXT NOT NULL CHECK (length(sha256) = 64),
+    created_by     TEXT NOT NULL CHECK (btrim(created_by) <> ''),
+    created_at     TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, config_version),
+    UNIQUE (tenant_id, config_version, sha256),
+    UNIQUE (tenant_id, sha256)
+);
+
+CREATE TABLE sla_active_policies (
+    tenant_id      TEXT PRIMARY KEY REFERENCES tenants(id),
+    config_version TEXT NOT NULL,
+    activated_at   TIMESTAMPTZ NOT NULL,
+    FOREIGN KEY (tenant_id, config_version) REFERENCES sla_policies(tenant_id, config_version)
+);
+
+CREATE TABLE sla_assessments (
+    tenant_id                 TEXT NOT NULL REFERENCES tenants(id),
+    id                        TEXT NOT NULL,
+    engagement_id             TEXT NOT NULL,
+    finding_id                TEXT NOT NULL,
+    source_risk_assessment_id TEXT,
+    inputs                    JSONB NOT NULL CHECK (jsonb_typeof(inputs) = 'object'),
+    result                    JSONB NOT NULL CHECK (jsonb_typeof(result) = 'object'),
+    input_hash                TEXT NOT NULL CHECK (length(input_hash) = 64),
+    config_hash               TEXT NOT NULL CHECK (length(config_hash) = 64),
+    config_version            TEXT NOT NULL,
+    tier                      TEXT NOT NULL CHECK (tier IN ('emergency','critical','high','medium','low','exception')),
+    score                     DOUBLE PRECISION NOT NULL CHECK (score >= 0 AND score <= 100),
+    mitigate_by               TIMESTAMPTZ NOT NULL,
+    remediate_by              TIMESTAMPTZ NOT NULL,
+    previous_assessment_id    TEXT,
+    assessed_at               TIMESTAMPTZ NOT NULL,
+    created_at                TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, id),
+    UNIQUE (tenant_id, engagement_id, finding_id, id),
+    UNIQUE (tenant_id, engagement_id, finding_id, config_version, input_hash),
+    FOREIGN KEY (tenant_id, engagement_id, finding_id)
+        REFERENCES findings(tenant_id, engagement_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (tenant_id, config_version, config_hash)
+        REFERENCES sla_policies(tenant_id, config_version, sha256),
+    FOREIGN KEY (tenant_id, source_risk_assessment_id)
+        REFERENCES vulnerability_risk_assessments(tenant_id, id),
+    FOREIGN KEY (tenant_id, engagement_id, finding_id, previous_assessment_id)
+        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id),
+    CHECK (mitigate_by >= assessed_at),
+    CHECK (remediate_by >= mitigate_by)
+);
+CREATE INDEX idx_sla_assessments_history
+    ON sla_assessments(tenant_id, engagement_id, finding_id, assessed_at DESC, id DESC);
+CREATE INDEX idx_sla_assessments_due
+    ON sla_assessments(tenant_id, engagement_id, remediate_by, finding_id);
+
+CREATE TABLE sla_current_assessments (
+    tenant_id     TEXT NOT NULL REFERENCES tenants(id),
+    engagement_id TEXT NOT NULL,
+    finding_id    TEXT NOT NULL,
+    assessment_id TEXT NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, engagement_id, finding_id),
+    FOREIGN KEY (tenant_id, engagement_id, finding_id)
+        REFERENCES findings(tenant_id, engagement_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (tenant_id, engagement_id, finding_id, assessment_id)
+        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id) ON DELETE CASCADE
+);
+
+CREATE TABLE sla_lifecycles (
+    tenant_id              TEXT NOT NULL REFERENCES tenants(id),
+    engagement_id          TEXT NOT NULL,
+    finding_id             TEXT NOT NULL,
+    assessment_id          TEXT NOT NULL,
+    status                 TEXT NOT NULL CHECK (status IN ('open','mitigating','remediated','accepted_risk')),
+    version                INT NOT NULL CHECK (version > 0),
+    reason                 TEXT NOT NULL DEFAULT '',
+    compensating_control   TEXT NOT NULL DEFAULT '',
+    accepted_by            TEXT NOT NULL DEFAULT '',
+    accepted_at            TIMESTAMPTZ,
+    acceptance_expires_at  TIMESTAMPTZ,
+    updated_by             TEXT NOT NULL CHECK (btrim(updated_by) <> ''),
+    updated_at             TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, engagement_id, finding_id),
+    FOREIGN KEY (tenant_id, engagement_id, finding_id)
+        REFERENCES findings(tenant_id, engagement_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (tenant_id, engagement_id, finding_id, assessment_id)
+        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id),
+    CHECK (
+        (status = 'accepted_risk' AND btrim(reason) <> '' AND btrim(compensating_control) <> ''
+            AND btrim(accepted_by) <> '' AND accepted_at IS NOT NULL
+            AND acceptance_expires_at IS NOT NULL AND acceptance_expires_at > accepted_at)
+        OR
+        (status <> 'accepted_risk' AND accepted_by = '' AND accepted_at IS NULL
+            AND acceptance_expires_at IS NULL)
+    )
+);
+CREATE INDEX idx_sla_lifecycles_state
+    ON sla_lifecycles(tenant_id, engagement_id, status, updated_at DESC);
+CREATE INDEX idx_sla_lifecycles_acceptance_expiry
+    ON sla_lifecycles(tenant_id, acceptance_expires_at)
+    WHERE status = 'accepted_risk';
+
+CREATE TABLE sla_lifecycle_events (
+    tenant_id              TEXT NOT NULL REFERENCES tenants(id),
+    id                     TEXT NOT NULL,
+    engagement_id          TEXT NOT NULL,
+    finding_id             TEXT NOT NULL,
+    assessment_id          TEXT NOT NULL,
+    from_status            TEXT NOT NULL CHECK (from_status IN ('open','mitigating','remediated','accepted_risk')),
+    to_status              TEXT NOT NULL CHECK (to_status IN ('open','mitigating','remediated','accepted_risk')),
+    reason                 TEXT NOT NULL CHECK (btrim(reason) <> ''),
+    compensating_control   TEXT NOT NULL DEFAULT '',
+    acceptance_expires_at  TIMESTAMPTZ,
+    actor                  TEXT NOT NULL CHECK (btrim(actor) <> ''),
+    before_version         INT NOT NULL CHECK (before_version > 0),
+    after_version          INT NOT NULL CHECK (after_version = before_version + 1),
+    occurred_at            TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, id),
+    FOREIGN KEY (tenant_id, engagement_id, finding_id)
+        REFERENCES sla_lifecycles(tenant_id, engagement_id, finding_id) ON DELETE CASCADE,
+    FOREIGN KEY (tenant_id, engagement_id, finding_id, assessment_id)
+        REFERENCES sla_assessments(tenant_id, engagement_id, finding_id, id)
+);
+CREATE INDEX idx_sla_lifecycle_events_history
+    ON sla_lifecycle_events(tenant_id, engagement_id, finding_id, occurred_at, id);
+
+CALL synapse_enable_tenant_rls('sla_policies');
+CALL synapse_enable_tenant_rls('sla_active_policies');
+CALL synapse_enable_tenant_rls('sla_assessments');
+CALL synapse_enable_tenant_rls('sla_current_assessments');
+CALL synapse_enable_tenant_rls('sla_lifecycles');
+CALL synapse_enable_tenant_rls('sla_lifecycle_events');
+
+-- +goose Down
+DROP TABLE IF EXISTS sla_lifecycle_events;
+DROP TABLE IF EXISTS sla_lifecycles;
+DROP TABLE IF EXISTS sla_current_assessments;
+DROP TABLE IF EXISTS sla_assessments;
+DROP TABLE IF EXISTS sla_active_policies;
+DROP TABLE IF EXISTS sla_policies;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
   - Code quality rules: code-quality-rules.md
   - Fleet agent packaging: fleet-agent-packaging.md
   - AI triage evaluation: ai-triage-evaluation.md
+  - Remediation SLA governance: sla-governance.md
   - Architecture: architecture.md
   - Deployment: deployment.md
   - Security model: security.md

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -31,6 +31,10 @@ import type {
   Judgment,
   ScanJob,
   ScanResult,
+  SLAAssessment,
+  SLAEvent,
+  SLATransitionInput,
+  SLAView,
   Severity,
   AuditEntry,
   AuditReport,
@@ -279,6 +283,107 @@ function mapFinding(r: any): Finding {
       id: c.ID ?? '',
       title: c.Title ?? '',
     })),
+  }
+}
+
+function mapSLAView(r: any): SLAView {
+  const assessment = r?.assessment ?? {}
+  const result = assessment.result ?? {}
+  const inputs = assessment.inputs ?? {}
+  const breakdown = result.breakdown ?? {}
+  const lifecycle = r?.lifecycle ?? {}
+  return {
+    assessment: {
+      tenantId: assessment.tenant_id ?? '',
+      id: assessment.id ?? '',
+      engagementId: assessment.engagement_id ?? '',
+      findingId: assessment.finding_id ?? '',
+      sourceRiskAssessmentId: assessment.source_risk_assessment_id ?? '',
+      inputs: {
+        severity: inputs.severity ?? 'unknown',
+        cvssScore: inputs.cvss_score ?? 0,
+        kev: inputs.kev ?? false,
+        epss: inputs.epss ?? 0,
+        publicPoC: inputs.public_poc ?? false,
+        activeExploitation: inputs.active_exploitation ?? false,
+        criticality: inputs.criticality ?? '',
+        exposure: inputs.exposure ?? '',
+        feasibility: inputs.feasibility ?? '',
+      },
+      result: {
+        tier: result.tier ?? 'low',
+        score: result.score ?? 0,
+        breakdown: {
+          severity: breakdown.severity ?? 0,
+          exploitability: breakdown.exploitability ?? 0,
+          threatIntel: breakdown.threat_intel ?? 0,
+          exposure: breakdown.exposure ?? 0,
+          criticality: breakdown.criticality ?? 0,
+          feasibility: breakdown.feasibility ?? 0,
+          overrides: breakdown.overrides ?? [],
+        },
+        mitigateBy: result.mitigate_by ?? '',
+        remediateBy: result.remediate_by ?? '',
+        reason: result.reason ?? '',
+        computedAt: result.computed_at ?? '',
+        configVersion: result.config_version ?? '',
+      },
+      inputHash: assessment.input_hash ?? '',
+      configHash: assessment.config_hash ?? '',
+      previousAssessmentId: assessment.previous_assessment_id ?? '',
+      assessedAt: assessment.assessed_at ?? '',
+      createdAt: assessment.created_at ?? '',
+    },
+    lifecycle: {
+      tenantId: lifecycle.tenant_id ?? '',
+      engagementId: lifecycle.engagement_id ?? '',
+      findingId: lifecycle.finding_id ?? '',
+      assessmentId: lifecycle.assessment_id ?? '',
+      status: lifecycle.status ?? 'open',
+      version: lifecycle.version ?? 1,
+      reason: lifecycle.reason ?? '',
+      compensatingControl: lifecycle.compensating_control ?? '',
+      acceptedBy: lifecycle.accepted_by ?? '',
+      acceptedAt: lifecycle.accepted_at ?? null,
+      acceptanceExpiresAt: lifecycle.acceptance_expires_at ?? null,
+      updatedBy: lifecycle.updated_by ?? '',
+      updatedAt: lifecycle.updated_at ?? '',
+    },
+    effectiveState: r?.effective_state ?? lifecycle.status ?? 'open',
+    overdue: r?.overdue ?? false,
+    acceptanceExpired: r?.acceptance_expired ?? false,
+  }
+}
+
+function mapSLAAssessment(r: any): SLAAssessment {
+  return mapSLAView({ assessment: r, lifecycle: {
+    tenant_id: r?.tenant_id,
+    engagement_id: r?.engagement_id,
+    finding_id: r?.finding_id,
+    assessment_id: r?.id,
+    status: 'open',
+    version: 1,
+    updated_by: 'history',
+    updated_at: r?.assessed_at,
+  } }).assessment
+}
+
+function mapSLAEvent(r: any): SLAEvent {
+  return {
+    tenantId: r?.tenant_id ?? '',
+    id: r?.id ?? '',
+    engagementId: r?.engagement_id ?? '',
+    findingId: r?.finding_id ?? '',
+    assessmentId: r?.assessment_id ?? '',
+    from: r?.from ?? 'open',
+    to: r?.to ?? 'open',
+    reason: r?.reason ?? '',
+    compensatingControl: r?.compensating_control ?? '',
+    acceptanceExpiresAt: r?.acceptance_expires_at ?? null,
+    actor: r?.actor ?? '',
+    beforeVersion: r?.before_version ?? 0,
+    afterVersion: r?.after_version ?? 0,
+    at: r?.at ?? '',
   }
 }
 
@@ -695,7 +800,8 @@ function mapScanResult(r: any): ScanResult {
       verdict: l.verdict ?? 'warn',
       components: l.components ?? [],
     })),
-    findings: (r.findings ?? []).map(mapFinding),
+	findings: (r.findings ?? []).map(mapFinding),
+	slas: (r.slas ?? []).map(mapSLAView),
     aiTriage: (r.ai_triage ?? []).map(mapAITriage),
     toolVersions: r.tool_versions ?? {},
     vulnDBSnapshot: r.vuln_db_snapshot ?? '',
@@ -1686,6 +1792,36 @@ export const api = {
 
   findings: async (engagementId: string): Promise<Finding[]> =>
     ((await req(`/engagements/${encodeURIComponent(engagementId)}/findings`)) ?? []).map(mapFinding),
+
+  slas: async (engagementId: string): Promise<SLAView[]> => {
+    const response = await req(`/engagements/${encodeURIComponent(engagementId)}/slas`)
+    return (response?.slas ?? []).map(mapSLAView)
+  },
+
+  findingSLA: async (engagementId: string, findingId: string): Promise<SLAView> =>
+    mapSLAView(await req(`/engagements/${encodeURIComponent(engagementId)}/slas/${encodeURIComponent(findingId)}`)),
+
+  transitionSLA: async (engagementId: string, findingId: string, input: SLATransitionInput): Promise<SLAView> =>
+    mapSLAView(await req(`/engagements/${encodeURIComponent(engagementId)}/slas/${encodeURIComponent(findingId)}/transition`, {
+      method: 'POST',
+      body: JSON.stringify({
+        to: input.to,
+        reason: input.reason,
+        compensating_control: input.compensatingControl ?? '',
+        acceptance_expires_at: input.acceptanceExpiresAt || null,
+        version: input.version,
+      }),
+    })),
+
+  slaAssessments: async (engagementId: string, findingId: string): Promise<SLAAssessment[]> => {
+    const response = await req(`/engagements/${encodeURIComponent(engagementId)}/slas/${encodeURIComponent(findingId)}/assessments`)
+    return (response?.assessments ?? []).map(mapSLAAssessment)
+  },
+
+  slaEvents: async (engagementId: string, findingId: string): Promise<SLAEvent[]> => {
+    const response = await req(`/engagements/${encodeURIComponent(engagementId)}/slas/${encodeURIComponent(findingId)}/events`)
+    return (response?.events ?? []).map(mapSLAEvent)
+  },
 
   updateFindingStatus: async (
     engagementId: string,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -331,6 +331,7 @@ function mapSLAView(r: any): SLAView {
       inputHash: assessment.input_hash ?? '',
       configHash: assessment.config_hash ?? '',
       previousAssessmentId: assessment.previous_assessment_id ?? '',
+      deadlineAnchorAt: assessment.deadline_anchor_at ?? '',
       assessedAt: assessment.assessed_at ?? '',
       createdAt: assessment.created_at ?? '',
     },

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -143,6 +143,7 @@ export interface SLAAssessment {
   inputHash: string
   configHash: string
   previousAssessmentId: string
+  deadlineAnchorAt: string
   assessedAt: string
   createdAt: string
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -96,6 +96,106 @@ export interface Finding {
   complianceControls: ComplianceControl[] // curated regulatory/standard controls the CWE maps to
 }
 
+export type SLATier = 'emergency' | 'critical' | 'high' | 'medium' | 'low' | 'exception'
+export type SLARemediationStatus = 'open' | 'mitigating' | 'remediated' | 'accepted_risk'
+
+export interface SLAInputs {
+  severity: Severity
+  cvssScore: number
+  kev: boolean
+  epss: number
+  publicPoC: boolean
+  activeExploitation: boolean
+  criticality: '' | 'low' | 'medium' | 'high'
+  exposure: '' | 'internal' | 'external'
+  feasibility: '' | 'patch_available' | 'change_window' | 'compensating_control' | 'no_patch'
+}
+
+export interface SLABreakdown {
+  severity: number
+  exploitability: number
+  threatIntel: number
+  exposure: number
+  criticality: number
+  feasibility: number
+  overrides: string[]
+}
+
+export interface SLAResult {
+  tier: SLATier
+  score: number
+  breakdown: SLABreakdown
+  mitigateBy: string
+  remediateBy: string
+  reason: string
+  computedAt: string
+  configVersion: string
+}
+
+export interface SLAAssessment {
+  tenantId: string
+  id: string
+  engagementId: string
+  findingId: string
+  sourceRiskAssessmentId: string
+  inputs: SLAInputs
+  result: SLAResult
+  inputHash: string
+  configHash: string
+  previousAssessmentId: string
+  assessedAt: string
+  createdAt: string
+}
+
+export interface SLALifecycle {
+  tenantId: string
+  engagementId: string
+  findingId: string
+  assessmentId: string
+  status: SLARemediationStatus
+  version: number
+  reason: string
+  compensatingControl: string
+  acceptedBy: string
+  acceptedAt: string | null
+  acceptanceExpiresAt: string | null
+  updatedBy: string
+  updatedAt: string
+}
+
+export interface SLAView {
+  assessment: SLAAssessment
+  lifecycle: SLALifecycle
+  effectiveState: SLARemediationStatus
+  overdue: boolean
+  acceptanceExpired: boolean
+}
+
+export interface SLAEvent {
+  tenantId: string
+  id: string
+  engagementId: string
+  findingId: string
+  assessmentId: string
+  from: SLARemediationStatus
+  to: SLARemediationStatus
+  reason: string
+  compensatingControl: string
+  acceptanceExpiresAt: string | null
+  actor: string
+  beforeVersion: number
+  afterVersion: number
+  at: string
+}
+
+export interface SLATransitionInput {
+  to: SLARemediationStatus
+  reason: string
+  compensatingControl?: string
+  acceptanceExpiresAt?: string
+  version: number
+}
+
 // ComplianceControl is one curated control a finding's CWE maps to: the framework, the
 // control/category id, and its title – e.g. { OWASP-2021, A03:2021, Injection }. Deterministic
 // reference data from the server's curated table (a lookup, not a model output).
@@ -308,6 +408,7 @@ export interface ScanResult {
   vulnerabilities: Vulnerability[]
   licenses: LicenseFinding[]
   findings: Finding[]
+  slas?: SLAView[]
   aiTriage?: AITriage[]
   toolVersions: Record<string, string>
   vulnDBSnapshot: string

--- a/web/src/pages/EngagementDetail.tsx
+++ b/web/src/pages/EngagementDetail.tsx
@@ -60,6 +60,7 @@ import { AITriageBadges } from '../components/AITriageBadges'
 import { AgentTab } from './AgentTab'
 import { ThreatModelTab } from './ThreatModelTab'
 import { CodeQualityTab } from './CodeQualityTab'
+import { SLATab } from './SLATab'
 import { api, ApiError, downloadBundle, downloadExport, downloadReport, downloadReportDoc, streamReconLogs, type ReportType } from '../lib/api'
 import {
   downloadStyledExcel,
@@ -99,7 +100,7 @@ import { StatusPill } from './Engagements'
 // Lazy-loaded so React Flow stays out of the initial bundle (only the Graph tab needs it).
 const DependencyGraphTab = lazy(() => import('./DependencyGraph').then((m) => ({ default: m.DependencyGraphTab })))
 
-type Tab = 'overview' | 'findings' | 'components' | 'vulns' | 'licenses' | 'graph' | 'quality' | 'threats' | 'recon' | 'agent' | 'reviews' | 'evidence' | 'settings'
+type Tab = 'overview' | 'findings' | 'sla' | 'components' | 'vulns' | 'licenses' | 'graph' | 'quality' | 'threats' | 'recon' | 'agent' | 'reviews' | 'evidence' | 'settings'
 
 function findingAnchor(id: string) {
   return `finding-${id}`
@@ -270,6 +271,7 @@ export function EngagementDetail() {
             onReload={reloadFindings}
           />
         )}
+        {tab === 'sla' && <SLATab engagementId={id} findings={findings} />}
         {tab === 'components' && <ComponentsTab scan={scan} />}
         {tab === 'vulns' && <VulnsTab scan={scan} />}
         {tab === 'graph' && (
@@ -1165,6 +1167,7 @@ function fmtDebugDuration(ms: number) {
 const TABS: { id: Tab; label: string; icon: typeof LayoutDashboard; countKey?: keyof TabCounts }[] = [
   { id: 'overview', label: 'Overview', icon: LayoutDashboard },
   { id: 'findings', label: 'Findings', icon: ShieldAlert, countKey: 'findings' },
+  { id: 'sla', label: 'Remediation SLA', icon: CalendarClock },
   { id: 'components', label: 'Packages', icon: Boxes, countKey: 'components' },
   { id: 'vulns', label: 'Vulnerabilities', icon: Bug, countKey: 'vulns' },
   { id: 'licenses', label: 'Licenses', icon: Scale, countKey: 'licenses' },

--- a/web/src/pages/SLATab.tsx
+++ b/web/src/pages/SLATab.tsx
@@ -1,0 +1,220 @@
+import { AlertTriangle, CalendarClock, CheckCircle2, Clock3, RefreshCw, ShieldCheck } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { api, ApiError } from '../lib/api'
+import type { Finding, SLARemediationStatus, SLAView } from '../lib/types'
+import { Button, Card, cn, EmptyState, ErrorState, Spinner } from '../components/ui'
+
+const STATUS_LABEL: Record<SLARemediationStatus, string> = {
+  open: 'Open',
+  mitigating: 'Mitigating',
+  remediated: 'Remediated',
+  accepted_risk: 'Accepted risk',
+}
+
+const TIER_STYLE: Record<string, string> = {
+  emergency: 'bg-critical/15 text-critical ring-critical/30',
+  critical: 'bg-critical/15 text-critical ring-critical/30',
+  high: 'bg-high/15 text-high ring-high/30',
+  medium: 'bg-medium/15 text-medium ring-medium/30',
+  low: 'bg-low/15 text-low ring-low/30',
+  exception: 'bg-muted text-mutedfg ring-borderstrong',
+}
+
+export function SLATab({ engagementId, findings }: { engagementId: string; findings: Finding[] | null }) {
+  const [items, setItems] = useState<SLAView[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [disabled, setDisabled] = useState(false)
+  const [selected, setSelected] = useState<SLAView | null>(null)
+
+  const load = useCallback(async () => {
+    setError(null)
+    try {
+      setItems(await api.slas(engagementId))
+      setDisabled(false)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setDisabled(true)
+        setItems([])
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to load remediation SLAs')
+        setItems([])
+      }
+    }
+  }, [engagementId])
+
+  useEffect(() => { void load() }, [load])
+
+  const findingByID = useMemo(() => new Map((findings ?? []).map((item) => [item.id, item])), [findings])
+  const stats = useMemo(() => {
+    const values = items ?? []
+    return {
+      overdue: values.filter((item) => item.overdue).length,
+      emergency: values.filter((item) => item.assessment.result.tier === 'emergency').length,
+      accepted: values.filter((item) => item.effectiveState === 'accepted_risk').length,
+      remediated: values.filter((item) => item.effectiveState === 'remediated').length,
+    }
+  }, [items])
+
+  if (items === null) return <Spinner label="Loading remediation SLAs…" />
+  if (error) return <ErrorState message={error} />
+  if (disabled) {
+    return <EmptyState icon={CalendarClock} title="Remediation SLA is not enabled" hint="Set SYNAPSE_SLA_ENABLED=true to create governed, versioned deadlines for findings." />
+  }
+  if (items.length === 0) {
+    return <EmptyState icon={CheckCircle2} title="No SLA assessments yet" hint="Run a scan after enabling SLA governance. Existing findings are unchanged until explicitly reassessed." />
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <Stat label="Overdue" value={stats.overdue} icon={AlertTriangle} tone={stats.overdue > 0 ? 'text-critical' : 'text-mutedfg'} />
+        <Stat label="Emergency" value={stats.emergency} icon={Clock3} tone={stats.emergency > 0 ? 'text-critical' : 'text-mutedfg'} />
+        <Stat label="Accepted risk" value={stats.accepted} icon={ShieldCheck} tone="text-medium" />
+        <Stat label="Remediated" value={stats.remediated} icon={CheckCircle2} tone="text-low" />
+      </div>
+
+      <Card
+        title="Risk-based remediation deadlines"
+        actions={<Button variant="secondary" onClick={() => void load()} className="px-3 py-1.5"><RefreshCw className="size-3.5" /> Refresh</Button>}
+        bodyClass="p-0"
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[980px] text-left text-sm">
+            <thead className="border-b border-border bg-elevated text-xs uppercase tracking-wide text-subtlefg">
+              <tr>
+                <th className="px-5 py-3">Finding</th>
+                <th className="px-4 py-3">Tier / score</th>
+                <th className="px-4 py-3">Mitigate by</th>
+                <th className="px-4 py-3">Remediate by</th>
+                <th className="px-4 py-3">Workflow</th>
+                <th className="px-4 py-3">Policy</th>
+                <th className="px-5 py-3 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {items.map((item) => {
+                const finding = findingByID.get(item.assessment.findingId)
+                return (
+                  <tr key={item.assessment.findingId} className={cn('hover:bg-elevated/60', item.overdue && 'bg-critical/5')}>
+                    <td className="max-w-sm px-5 py-4">
+                      <div className="truncate font-medium text-foreground">{finding?.title ?? item.assessment.findingId}</div>
+                      <div className="mt-1 font-mono text-[11px] text-subtlefg">{item.assessment.findingId}</div>
+                    </td>
+                    <td className="px-4 py-4">
+                      <span className={cn('inline-flex rounded-md px-2 py-0.5 text-xs font-semibold uppercase ring-1 ring-inset', TIER_STYLE[item.assessment.result.tier])}>
+                        {item.assessment.result.tier}
+                      </span>
+                      <span className="ml-2 font-mono tabular-nums text-mutedfg">{item.assessment.result.score.toFixed(1)}</span>
+                    </td>
+                    <Deadline value={item.assessment.result.mitigateBy} />
+                    <Deadline value={item.assessment.result.remediateBy} overdue={item.overdue} />
+                    <td className="px-4 py-4">
+                      <div className="font-medium text-foreground">{STATUS_LABEL[item.effectiveState]}</div>
+                      {item.acceptanceExpired && <div className="mt-1 text-xs font-semibold text-critical">Acceptance expired</div>}
+                      <div className="mt-1 font-mono text-[11px] text-subtlefg">v{item.lifecycle.version}</div>
+                    </td>
+                    <td className="px-4 py-4 font-mono text-xs text-mutedfg">{item.assessment.result.configVersion}</td>
+                    <td className="px-5 py-4 text-right">
+                      <Button variant="secondary" className="px-3 py-1.5" onClick={() => setSelected(item)} disabled={item.effectiveState === 'remediated'}>
+                        Transition
+                      </Button>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      {selected && (
+        <TransitionPanel
+          item={selected}
+          findingTitle={findingByID.get(selected.assessment.findingId)?.title ?? selected.assessment.findingId}
+          onClose={() => setSelected(null)}
+          onSaved={(updated) => {
+            setItems((current) => (current ?? []).map((item) => item.assessment.findingId === updated.assessment.findingId ? updated : item))
+            setSelected(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function Stat({ label, value, icon: Icon, tone }: { label: string; value: number; icon: typeof AlertTriangle; tone: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-subtlefg"><Icon className={cn('size-4', tone)} />{label}</div>
+      <div className={cn('mt-2 font-mono text-2xl font-semibold tabular-nums', tone)}>{value}</div>
+    </div>
+  )
+}
+
+function Deadline({ value, overdue = false }: { value: string; overdue?: boolean }) {
+  const date = value ? new Date(value) : null
+  return (
+    <td className={cn('px-4 py-4 font-mono text-xs tabular-nums', overdue ? 'font-semibold text-critical' : 'text-mutedfg')}>
+      {date && !Number.isNaN(date.getTime()) ? date.toLocaleString() : '—'}
+    </td>
+  )
+}
+
+function TransitionPanel({ item, findingTitle, onClose, onSaved }: { item: SLAView; findingTitle: string; onClose: () => void; onSaved: (item: SLAView) => void }) {
+  const [to, setTo] = useState<SLARemediationStatus>(item.effectiveState === 'open' ? 'mitigating' : 'remediated')
+  const [reason, setReason] = useState('')
+  const [control, setControl] = useState('')
+  const [expiry, setExpiry] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function save() {
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await api.transitionSLA(item.assessment.engagementId, item.assessment.findingId, {
+        to,
+        reason,
+        compensatingControl: control,
+        acceptanceExpiresAt: expiry ? new Date(expiry).toISOString() : undefined,
+        version: item.lifecycle.version,
+      })
+      onSaved(updated)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to transition remediation SLA')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card title={`Transition: ${findingTitle}`}>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <label className="text-sm text-mutedfg">New state
+          <select value={to} onChange={(event) => setTo(event.target.value as SLARemediationStatus)} className="mt-1 block w-full rounded-lg border border-border bg-elevated px-3 py-2 text-foreground">
+            <option value="open">Open</option>
+            <option value="mitigating">Mitigating</option>
+            <option value="remediated">Remediated</option>
+            <option value="accepted_risk">Accepted risk</option>
+          </select>
+        </label>
+        <label className="text-sm text-mutedfg">Reason
+          <input value={reason} onChange={(event) => setReason(event.target.value)} placeholder="Required audit rationale" className="mt-1 block w-full rounded-lg border border-border bg-elevated px-3 py-2 text-foreground" />
+        </label>
+        {to === 'accepted_risk' && <>
+          <label className="text-sm text-mutedfg">Compensating control
+            <input value={control} onChange={(event) => setControl(event.target.value)} placeholder="Required control" className="mt-1 block w-full rounded-lg border border-border bg-elevated px-3 py-2 text-foreground" />
+          </label>
+          <label className="text-sm text-mutedfg">Acceptance expires
+            <input type="datetime-local" value={expiry} onChange={(event) => setExpiry(event.target.value)} className="mt-1 block w-full rounded-lg border border-border bg-elevated px-3 py-2 text-foreground" />
+          </label>
+        </>}
+      </div>
+      {error && <div className="mt-4"><ErrorState message={error} /></div>}
+      <div className="mt-5 flex justify-end gap-2">
+        <Button variant="ghost" onClick={onClose}>Cancel</Button>
+        <Button loading={saving} onClick={() => void save()} disabled={!reason.trim() || (to === 'accepted_risk' && (!control.trim() || !expiry))}>Save transition</Button>
+      </div>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary

Completes the operational phases of risk-based remediation SLA governance and connects them to continuous vulnerability intelligence.

- adds immutable, deterministic SLA assessments with versioned tenant policy and deadlines that do not slide on replay or reassessment
- adds a separate human-owned remediation lifecycle (`open`, `mitigating`, `remediated`, `accepted_risk`) with optimistic concurrency, append-only events, compensating controls, and hard acceptance expiry
- wires scan/API/CLI/web output and continuous CVSS/KEV/EPSS/PoC/exploitation refresh through narrow ports while preserving human decisions
- adds tenant-safe memory/Postgres stores, migration `0103_sla_governance.sql`, RLS, composite ownership FKs, OpenAPI contracts, configuration, and operator documentation
- fixes historical risk-assessment re-promotion so `no_longer_detected -> detected` creates re-exposure review work even when the immutable assessment already exists

This is an opt-in capability (`SYNAPSE_SLA_ENABLED=false` by default) and adds 5,085 lines across domain, persistence, integration, API, UI, documentation, and tests.

## Governance guarantees

- policy versions are DB-enforced append-only; retained assessment artifacts and lifecycle events reject UPDATE/TRUNCATE while DELETE follows the intentional finding/engagement/project cascade; current pointers are separate
- the first assessment fixes `deadline_anchor_at` for its chain; reassessments rebase to it and keep the earlier old/new deadline, so escalation, de-escalation, policy changes, and rescans cannot reset or extend the clock
- identical SLA-relevant facts reuse the original assessment, including provenance-only refreshes and CVSS/EPSS drift inside the same effective scoring band
- material risk or policy changes link a new assessment through `previous_assessment_id`
- machine identities cannot transition remediation state or activate policy
- the shared machine-principal classifier treats empty/whitespace identities as machine (fail closed); existing AI-triage decision and drift callers already require non-empty actor text before classification
- intelligence refresh can advance assessment provenance but cannot overwrite lifecycle status, reason, actor, expiry, timestamps, or version
- a transition racing a risk refresh conflicts instead of rolling the assessment pointer backward
- accepted risk becomes effectively open exactly at expiry
- remediated remains terminal; re-exposure creates explicit review work without silently reopening it
- every read/write is tenant-bound and every SLA table has forced RLS

## Review follow-up (`09555f8`)

- replaces the NUL-containing PostgreSQL text advisory-lock input with a stable SHA-256-derived `int64` lock key
- anchors/caps reassessment deadlines and canonicalizes material-input fingerprints
- makes post-persistence SCA SLA enrichment best-effort while retaining successful partial enrichment
- removes duplicated vulnerability-risk-to-SLA mapping and uses `slauc.InputsFromRiskAssessment`
- adds UPDATE/DELETE/TRUNCATE guards for policies and UPDATE/TRUNCATE immutability guards for retained assessments and lifecycle events
- maps PostgreSQL lifecycle-event unique violations to `shared.ErrConflict` and removes the redundant policy uniqueness constraint
- adds regression coverage for late emergency escalation, de-escalation, non-material drift, advisory lock identity, append-only mutations, partial enrichment, and conflict classification

## Review follow-up round 2 (`fc4321d`)

- preserves intentional finding/engagement/project teardown by allowing assessment/event DELETE cascades while retaining UPDATE/TRUNCATE immutability
- adds explicit cascading ownership for multi-hop assessment chains plus lifecycle assessment references
- replaces trigger-bypassing test cleanup with a production `projectuc.Delete` integration test covering a three-assessment chain
- aligns the memory adapter's missing-predecessor error with PostgreSQL `ErrNotFound`
- preserves the underlying `pgconn.PgError` while also classifying lifecycle event uniqueness as `shared.ErrConflict`
## Surface area

- scanner `ScanResult.SLAs`, CLI JSON, and human CLI report
- policy/list/detail/history/event/transition HTTP APIs behind existing RBAC and engagement tenant chokepoints
- complete OpenAPI schemas and contract test
- engagement **Remediation SLA** tab with tier/deadline/overdue summaries and reviewed transitions
- default policy/operator rollout documentation

## Verification

- fresh PostgreSQL 18 cluster: migrations plus the complete `internal/infrastructure/persistence/postgres` package passed with `SYNAPSE_TEST_DB_DSN`
- targeted SLA/domain/memory/Postgres/SCA/vulnerability-evaluation/OpenAPI/use-case suites passed
- `go vet` on all changed Go packages passed
- `npm run typecheck` passed
- `npm test` — 39 files, 311 tests passed
- full `go test ./...` passed every package except the pre-existing race-sensitive `TestAdvisoryReconciliationPinsSnapshotRevision`; the same failure was reproduced on a clean `upstream/main` worktree

Closes #80
Closes #540