### PR TITLE
chore(lint): fix all golangci-lint issues to unblock CI

### DIFF
--- a/cmd/synapse-agent/detect.go
+++ b/cmd/synapse-agent/detect.go
@@ -101,7 +101,9 @@ func parseCeiling(s string) float64 {
 	}
 	v, err := strconv.ParseFloat(s, 64)
 	if err != nil || v < 0 {
-		log.Printf("detection: ignoring invalid SYNAPSE_DETECT_CPU_CEIL_PCT %q", s)
+		// The raw value is operator-controlled (an environment variable), so it is deliberately kept
+		// out of the log line to prevent log injection.
+		log.Print("detection: ignoring invalid SYNAPSE_DETECT_CPU_CEIL_PCT (want a non-negative number)")
 		return 0
 	}
 	return v

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1375,12 +1375,7 @@ func main() {
 			log.Error("promotion reconciler init failed", "err", perr)
 			os.Exit(1)
 		}
-		proposalAudit, ok := auditLog.(ports.IdempotentAuditLogger)
-		if !ok {
-			log.Error("promotion evaluator requires an idempotent audit logger")
-			os.Exit(1)
-		}
-		promotionEval, perr = promotionuc.NewEvaluator(judgmentSvc, findingRepo, judgmentStore, attackPathStore, assetStore, detectionRecordStore, repo, promotionStore, clock, proposalAudit)
+		promotionEval, perr = promotionuc.NewEvaluator(judgmentSvc, findingRepo, judgmentStore, attackPathStore, assetStore, detectionRecordStore, repo, promotionStore, clock, auditLog)
 		if perr != nil {
 			log.Error("promotion evaluator init failed", "err", perr)
 			os.Exit(1)

--- a/cmd/synapse-cspm/main.go
+++ b/cmd/synapse-cspm/main.go
@@ -63,7 +63,7 @@ func main() {
 	if credentialFile == nil {
 		fail("credential descriptor unavailable")
 	}
-	defer credentialFile.Close()
+	defer func() { _ = credentialFile.Close() }()
 	secret, err := io.ReadAll(io.LimitReader(credentialFile, 1<<20))
 	if err != nil || len(secret) == 0 {
 		fail("credential unavailable")

--- a/internal/domain/sbom/identity.go
+++ b/internal/domain/sbom/identity.go
@@ -129,14 +129,6 @@ func ComponentFingerprint(identity ComponentIdentity, purl string) string {
 	return hex.EncodeToString(digest[:])
 }
 
-func urlDecode(value string) string {
-	decoded, err := url.PathUnescape(value)
-	if err != nil {
-		return value
-	}
-	return decoded
-}
-
 func distroEcosystem(typ, purl string) string {
 	qualifiers := ""
 	if i := strings.IndexByte(purl, '?'); i >= 0 {

--- a/internal/domain/sla/assessment_test.go
+++ b/internal/domain/sla/assessment_test.go
@@ -39,7 +39,7 @@ func TestAssessmentEvaluateIsDeterministicAndBound(t *testing.T) {
 	if first.ID != second.ID || first.InputHash != second.InputHash || first.ConfigHash != second.ConfigHash {
 		t.Fatalf("materially identical input changed identity: first=%+v second=%+v", first, second)
 	}
-	if first.AssessedAt == second.AssessedAt || first.Result.RemediateBy == second.Result.RemediateBy {
+	if first.AssessedAt.Equal(second.AssessedAt) || first.Result.RemediateBy.Equal(second.Result.RemediateBy) {
 		t.Fatal("candidate clocks should reflect the attempted assessment; the store preserves the original on replay")
 	}
 	if first.TenantID != "tenant-a" || first.EngagementID != "eng-1" || first.FindingID != "finding-1" || first.SourceRiskAssessmentID != "risk-1" {

--- a/internal/infrastructure/cloud/gcp/connector.go
+++ b/internal/infrastructure/cloud/gcp/connector.go
@@ -551,18 +551,22 @@ func (c *Connector) buckets(ctx context.Context, service *storage.Service, proje
 			} else {
 				policy, policyErr := service.Buckets.GetIamPolicy(bucket.Name).Context(ctx).OptionsRequestedPolicyVersion(3).Do()
 				if policyErr != nil {
+					// A public ACL entity already establishes the posture definitively; only
+					// downgrade to unknown (and drop policyKnown) when the ACL was inconclusive.
 					if public != cloudposture.StateEnabled {
 						public = cloudposture.StateUnknown
+						policyKnown = false
 					}
-					policyKnown = false
 					*gaps = append(*gaps, coverage(bucket.Name, "storage", errorCode(policyErr), "bucket IAM policy unavailable"))
 				} else if policyHasPublicMember(policy) {
 					public, policyKnown = cloudposture.StateEnabled, true
 				} else if policyHasConditionalBinding(policy) {
+					// A public ACL entity already establishes the posture definitively; a
+					// conditional binding only leaves it unknown when the ACL was inconclusive.
 					if public != cloudposture.StateEnabled {
 						public = cloudposture.StateUnknown
+						policyKnown = false
 					}
-					policyKnown = false
 					*gaps = append(*gaps, coverage(bucket.Name, "storage", "conditional_policy", "conditional bucket policy cannot be resolved safely"))
 				} else {
 					policyKnown = true

--- a/internal/infrastructure/persistence/memory/advisory_materializer.go
+++ b/internal/infrastructure/persistence/memory/advisory_materializer.go
@@ -44,6 +44,10 @@ type AdvisoryMaterializer struct {
 	aliases      map[string]string
 	revisions    map[string][]advisoryRevision
 	evaluated    map[shared.ID]map[string]evaluationCheckpoint
+	// now stamps each revision's createdAt. It defaults to the wall clock; tests inject a controlled
+	// clock so revision-pinning is deterministic regardless of the host clock resolution (Windows'
+	// ~15ms tick otherwise lets two closely-spaced Materialize calls share a createdAt).
+	now func() time.Time
 }
 
 func NewAdvisoryMaterializer() *AdvisoryMaterializer {
@@ -54,7 +58,18 @@ func NewAdvisoryMaterializer() *AdvisoryMaterializer {
 		aliases:      map[string]string{},
 		revisions:    map[string][]advisoryRevision{},
 		evaluated:    map[shared.ID]map[string]evaluationCheckpoint{},
+		now:          func() time.Time { return time.Now().UTC() },
 	}
+}
+
+// WithClock overrides the revision-createdAt clock (tests only). A nil clock is ignored.
+func (m *AdvisoryMaterializer) WithClock(now func() time.Time) *AdvisoryMaterializer {
+	if now != nil {
+		m.mu.Lock()
+		m.now = now
+		m.mu.Unlock()
+	}
+	return m
 }
 
 var _ ports.AdvisoryMaterializer = (*AdvisoryMaterializer)(nil)
@@ -175,7 +190,7 @@ func (m *AdvisoryMaterializer) materializeLocked(tenantID shared.ID, records []a
 	for _, id := range append([]string{canonical.Advisory.ID}, canonical.Advisory.Aliases...) {
 		m.aliases[id] = canonical.Advisory.ID
 	}
-	m.revisions[canonical.Advisory.ID] = append(m.revisions[canonical.Advisory.ID], advisoryRevision{canonical: canonical, hash: hash, fields: append([]advisory.ChangedField(nil), result.ChangedFields...), syncRuns: observationSyncRuns(tenantID, normalized), createdAt: time.Now().UTC()})
+	m.revisions[canonical.Advisory.ID] = append(m.revisions[canonical.Advisory.ID], advisoryRevision{canonical: canonical, hash: hash, fields: append([]advisory.ChangedField(nil), result.ChangedFields...), syncRuns: observationSyncRuns(tenantID, normalized), createdAt: m.now()})
 	result.Revision = int64(len(m.revisions[canonical.Advisory.ID]))
 	result.CreatedRevision = true
 	return result, nil
@@ -210,6 +225,7 @@ func (m *AdvisoryMaterializer) clone() *AdvisoryMaterializer {
 			clone.evaluated[tenantID][advisoryID] = checkpoint
 		}
 	}
+	clone.now = m.now
 	return clone
 }
 

--- a/internal/infrastructure/persistence/memory/component_inventory_store.go
+++ b/internal/infrastructure/persistence/memory/component_inventory_store.go
@@ -18,9 +18,7 @@ type ComponentInventoryStore struct {
 
 func NewComponentInventoryStore(records ...sbom.ComponentRecord) *ComponentInventoryStore {
 	store := &ComponentInventoryStore{}
-	for _, record := range records {
-		store.items = append(store.items, record)
-	}
+	store.items = append(store.items, records...)
 	return store
 }
 

--- a/internal/infrastructure/persistence/memory/sla_store_test.go
+++ b/internal/infrastructure/persistence/memory/sla_store_test.go
@@ -94,7 +94,7 @@ func TestSLAStoreAssessmentReplayPreservesOriginalDeadlines(t *testing.T) {
 		t.Fatalf("first upsert=%+v err=%v", stored, err)
 	}
 	replay := slaAssessmentFor(t, "tenant-a", "eng-1", "finding-1", 0.4, slaStoreEpoch.Add(48*time.Hour))
-	if replay.ID != first.ID || replay.Result.RemediateBy == first.Result.RemediateBy {
+	if replay.ID != first.ID || replay.Result.RemediateBy.Equal(first.Result.RemediateBy) {
 		t.Fatal("test setup does not represent same material input at a later clock")
 	}
 	stored, err = store.UpsertAssessment(ctx, replay)

--- a/internal/infrastructure/persistence/postgres/sla_store.go
+++ b/internal/infrastructure/persistence/postgres/sla_store.go
@@ -417,18 +417,6 @@ func scanSLAAssessment(row interface{ Scan(...any) error }, item *sla.Assessment
 	return nil
 }
 
-func scanSLALifecycle(row interface{ Scan(...any) error }, item *sla.Lifecycle) error {
-	if err := row.Scan(&item.TenantID, &item.EngagementID, &item.FindingID, &item.AssessmentID,
-		&item.Status, &item.Version, &item.Reason, &item.CompensatingControl, &item.AcceptedBy,
-		&item.AcceptedAt, &item.AcceptanceExpiresAt, &item.UpdatedBy, &item.UpdatedAt); err != nil {
-		return err
-	}
-	if err := item.Validate(); err != nil {
-		return fmt.Errorf("validate stored sla lifecycle: %w", err)
-	}
-	return nil
-}
-
 func scanSLACurrent(row interface{ Scan(...any) error }, item *sla.Current) error {
 	var inputJSON, resultJSON []byte
 	var sourceID, previousID pgtype.Text

--- a/internal/infrastructure/persistence/postgres/sync_run_store.go
+++ b/internal/infrastructure/persistence/postgres/sync_run_store.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -626,11 +625,6 @@ func trimSyncErrors(samples []string) []string {
 		out = vulnerabilitysync.AddErrorSample(out, sample)
 	}
 	return out
-}
-
-func isUniqueConstraint(err error) bool {
-	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }
 
 func WithGlobalRead(ctx context.Context, pool *pgxpool.Pool, fn func(pgx.Tx) error) error {

--- a/internal/infrastructure/persistence/postgres/telemetry_repo.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_repo.go
@@ -250,10 +250,3 @@ func splitTelemetryKey(k string) (shared.ID, detection.Class) {
 	}
 	return shared.ID(k), ""
 }
-
-func nullableTime(t time.Time) interface{} {
-	if t.IsZero() {
-		return nil
-	}
-	return t.UTC()
-}

--- a/internal/infrastructure/persistence/postgres/vulnerability_action_store.go
+++ b/internal/infrastructure/persistence/postgres/vulnerability_action_store.go
@@ -405,7 +405,6 @@ func (s *VulnerabilityActionStore) updateOutbox(ctx context.Context, tenantID, e
 
 const vulnerabilityActionColumns = `tenant_id,id,engagement_id,occurrence_id,finding_id,transition_id,action_type,status,title,reason_codes,acknowledged_by,acknowledged_at,resolved_by,resolved_at,created_at,updated_at`
 const vulnerabilityTransitionColumns = `tenant_id,id,engagement_id,occurrence_id,advisory_id,transition_type,before_assessment_id,after_assessment_id,before_occurrence_state,after_occurrence_state,reason_codes,created_at`
-const vulnerabilityOutboxColumns = `tenant_id,id,action_id,idempotency_key,event_type,payload,state,attempts,available_at,locked_until,last_error,delivered_at,created_at,updated_at`
 const outboxReturningColumns = `o.tenant_id,o.id,o.action_id,o.idempotency_key,o.event_type,o.payload,o.state,o.attempts,o.available_at,o.locked_until,o.last_error,o.delivered_at,o.created_at,o.updated_at`
 
 type vulnerabilityActionScanner interface{ Scan(...any) error }

--- a/internal/infrastructure/tools/ownadvisory/remotefeed.go
+++ b/internal/infrastructure/tools/ownadvisory/remotefeed.go
@@ -74,7 +74,7 @@ func (f *RemoteFeed) Test(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("remote feed test request: %w", err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("remote feed test returned HTTP %d", response.StatusCode)
 	}

--- a/internal/infrastructure/tools/vulnerabilityprovider/http.go
+++ b/internal/infrastructure/tools/vulnerabilityprovider/http.go
@@ -104,7 +104,7 @@ func testEndpoint(ctx context.Context, httpClient *http.Client, endpoint string,
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("provider returned HTTP %d", response.StatusCode)
 	}

--- a/internal/usecase/fleet/detect/engine_test.go
+++ b/internal/usecase/fleet/detect/engine_test.go
@@ -301,10 +301,7 @@ func TestEngineRunLoopProcessesThenStops(t *testing.T) {
 	sensor.events <- procEvent("ps", "-ef")
 	// Give the loop a moment, then close the stream to end Run.
 	deadline := time.After(2 * time.Second)
-	for {
-		if len(sink.detections()) > 0 {
-			break
-		}
+	for len(sink.detections()) == 0 {
 		select {
 		case <-deadline:
 			t.Fatal("Run did not process the event")

--- a/internal/usecase/fptriage/coordinator.go
+++ b/internal/usecase/fptriage/coordinator.go
@@ -375,14 +375,6 @@ func (c *Coordinator) assessPreparedObserved(ctx context.Context, candidates []p
 	return out, telemetry
 }
 
-func (c *Coordinator) assessOne(ctx context.Context, f finding.Finding, snippet string) Critique {
-	out, _ := c.assessPreparedObserved(ctx, []preparedFinding{{finding: f, snippet: snippet, ready: true}})
-	if len(out) == 0 {
-		return Critique{FindingID: f.ID.String(), DedupKey: f.DedupKey, Err: context.Canceled}
-	}
-	return out[0]
-}
-
 func promptVersionFor(p preparedFinding) string {
 	if p.evidenceRequired {
 		return evidencePromptVersion
@@ -442,28 +434,6 @@ func (c *Coordinator) assessOneObserved(ctx context.Context, p preparedFinding, 
 	}
 	res.Claim = claim
 	return res
-}
-
-// verify runs the distinct verifier over only the finding and source context. Returns its independent
-// CritiqueClaim, or an error if the verifier is unreachable or its reply fails validation.
-func (c *Coordinator) verify(ctx context.Context, f finding.Finding, snippet string) (judgment.CritiqueClaim, error) {
-	if ctx.Err() != nil {
-		return judgment.CritiqueClaim{}, ctx.Err()
-	}
-	resp, err := c.verifier.Chat(ctx, ports.ChatRequest{
-		Model:          c.verifierModel,
-		Temperature:    ports.Temp(0), // greedy: consensus is only meaningful if the verifier is reproducible
-		MaxTokens:      512,
-		ResponseSchema: critiqueSchema,
-		Messages: []agent.Message{
-			{Role: "system", Content: verifierSystemPrompt},
-			{Role: "user", Content: verifierUserPrompt(f, snippet)},
-		},
-	})
-	if err != nil {
-		return judgment.CritiqueClaim{}, fmt.Errorf("verify llm: %w", err)
-	}
-	return parseCritique(resp.Content)
 }
 
 // parseCritique decodes the model's reply into a CritiqueClaim and validates it against the domain's

--- a/internal/usecase/fptriage/triager.go
+++ b/internal/usecase/fptriage/triager.go
@@ -143,14 +143,6 @@ func (t *Triager) triageObserved(ctx context.Context, candidates []finding.Findi
 	return ports.FPTriageObservedResult{Critiques: t.mapCritiques(crits), Telemetry: telemetry}
 }
 
-func prepareCandidates(candidates []finding.Finding, reader ports.SourceSnippetReader) []preparedFinding {
-	prepared := make([]preparedFinding, len(candidates))
-	for i := range candidates {
-		prepared[i] = preparedFinding{finding: candidates[i], reader: reader}
-	}
-	return prepared
-}
-
 func (t *Triager) mapCritiques(crits []Critique) []ports.AICritique {
 	out := make([]ports.AICritique, 0, len(crits))
 	for _, c := range crits {

--- a/internal/usecase/ports/vulnerabilitysync.go
+++ b/internal/usecase/ports/vulnerabilitysync.go
@@ -2,7 +2,6 @@ package ports
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/advisory"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilitysource"
@@ -79,8 +78,4 @@ func PermanentProviderError(err error) error {
 		return nil
 	}
 	return &ProviderError{Retryable: false, Err: err}
-}
-
-func providerTypeError(source vulnerabilitysource.Source) error {
-	return fmt.Errorf("no vulnerability provider registered for adapter %q", source.AdapterType)
 }

--- a/internal/usecase/sca/fptriage_promotion.go
+++ b/internal/usecase/sca/fptriage_promotion.go
@@ -592,10 +592,6 @@ func baselineResult(results []AIEvaluationResult, caseID string) AIEvaluationRes
 	return AIEvaluationResult{}
 }
 
-func verifierCoverage(metrics AIEvaluationMetrics) float64 {
-	return ratio(metrics.VerifierComparisons, metrics.Total)
-}
-
 func belowBasisPointMinimum(numerator, denominator, minimum int) bool {
 	return scaledRate(numerator, denominator).Cmp(big.NewRat(int64(minimum), 1)) < 0
 }

--- a/internal/usecase/vulnerabilityinteluc/service.go
+++ b/internal/usecase/vulnerabilityinteluc/service.go
@@ -294,33 +294,34 @@ func (s *Service) enrichAdvisories(ctx context.Context, tenantID shared.ID, item
 		return err
 	}
 	for index := range items {
-		advisoryID := items[index].Canonical.Advisory.ID
+		item := &items[index]
+		advisoryID := item.Canonical.Advisory.ID
 		occurrence := occurrences[advisoryID]
-		items[index].ActiveAffectedCount = occurrence.ActiveAffectedCount
-		items[index].AffectedAssetCount = occurrence.AffectedAssetCount
-		items[index].AffectedComponentCount = occurrence.AffectedComponentCount
-		items[index].DetectionStates = occurrence.DetectionStates
-		items[index].LastEvaluation = occurrence.LastEvaluation
+		item.ActiveAffectedCount = occurrence.ActiveAffectedCount
+		item.AffectedAssetCount = occurrence.AffectedAssetCount
+		item.AffectedComponentCount = occurrence.AffectedComponentCount
+		item.DetectionStates = occurrence.DetectionStates
+		item.LastEvaluation = occurrence.LastEvaluation
 		risk, ok := risks[advisoryID]
 		if ok {
-			items[index].RiskPriority = risk.Priority
-			items[index].PreviousRiskPriority = risk.PreviousPriority
-			items[index].RiskTrend = risk.Trend
-			items[index].RiskScore = risk.Score
-			items[index].RiskScoreChange = risk.ScoreChange
+			item.RiskPriority = risk.Priority
+			item.PreviousRiskPriority = risk.PreviousPriority
+			item.RiskTrend = risk.Trend
+			item.RiskScore = risk.Score
+			item.RiskScoreChange = risk.ScoreChange
 		} else {
-			items[index].RiskTrend = vulnerabilityintel.RiskTrendNone
+			item.RiskTrend = vulnerabilityintel.RiskTrendNone
 		}
-		items[index].ActionStates = actions[advisoryID].States
+		item.ActionStates = actions[advisoryID].States
 		if filters.AffectedAsset != "" {
 			if occurrence.MatchesAffectedAsset {
-				items[index].AffectedAssetCount = max(items[index].AffectedAssetCount, 1)
+				item.AffectedAssetCount = max(item.AffectedAssetCount, 1)
 			} else {
-				items[index].AffectedAssetCount = 0
+				item.AffectedAssetCount = 0
 			}
 		}
-		if len(filters.DetectionStates) > 0 && occurrence.MatchesDetectionState && len(items[index].DetectionStates) == 0 {
-			items[index].DetectionStates = append([]vulnerabilityoccurrence.State(nil), filters.DetectionStates...)
+		if len(filters.DetectionStates) > 0 && occurrence.MatchesDetectionState && len(item.DetectionStates) == 0 {
+			item.DetectionStates = append([]vulnerabilityoccurrence.State(nil), filters.DetectionStates...)
 		}
 	}
 	return nil

--- a/internal/usecase/vulnerabilityreconciliation/service_test.go
+++ b/internal/usecase/vulnerabilityreconciliation/service_test.go
@@ -143,12 +143,17 @@ func TestAdvisoryReconciliationPinsSnapshotRevision(t *testing.T) {
 	if err := engagements.Create(ctx, item); err != nil {
 		t.Fatal(err)
 	}
-	materializer := memory.NewAdvisoryMaterializer()
+	// Deterministic revision clock so the run's SnapshotAt sits strictly between revision 1 and
+	// revision 2's createdAt on every platform. Windows' ~15ms clock resolution otherwise lets the
+	// run start and revision-2 materialization share a tick, leaking revision 2 into the pinned
+	// snapshot (flaky TestAdvisoryReconciliationPinsSnapshotRevision).
+	revClock := base
+	materializer := memory.NewAdvisoryMaterializer().WithClock(func() time.Time { return revClock })
 	first := advisory.Advisory{ID: "CVE-2026-9001", Summary: "revision one", Affected: []advisory.AffectedPackage{{Ecosystem: "Go", Package: "example.com/pkg", Versions: []string{"1.0.0"}}}}
 	if _, err := materializer.Materialize(context.Background(), []advisory.ObservationRecord{{Observation: advisory.Observation{SourceType: "osv", SourceID: "source", RecordID: first.ID, Status: advisory.StatusActive, Advisory: first}, ObservedAt: base}}); err != nil {
 		t.Fatal(err)
 	}
-	clock := testClock{now: time.Now().UTC()}
+	clock := testClock{now: base.Add(time.Minute)}
 	ids := &sequenceIDs{}
 	inventory := memory.NewComponentInventoryStore(componentRecord("eng-1", "component-1", base))
 	occurrences := memory.NewVulnerabilityOccurrenceStore()
@@ -161,6 +166,7 @@ func TestAdvisoryReconciliationPinsSnapshotRevision(t *testing.T) {
 	}
 	second := first
 	second.Summary = "revision two"
+	revClock = base.Add(2 * time.Minute) // revision 2 is created strictly after the run's SnapshotAt
 	if _, err := materializer.Materialize(context.Background(), []advisory.ObservationRecord{{Observation: advisory.Observation{SourceType: "osv", SourceID: "source", RecordID: second.ID, Status: advisory.StatusActive, Advisory: second}, ObservedAt: base.Add(time.Minute)}}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What
Fix all **23 golangci-lint v2.12.2** findings so CI's **Lint (Go)** job passes. Actions was disabled while the recent PRs (#560–#567) merged, so lint drift accumulated on `main`; this restores a clean `golangci-lint run`.

## Changes
- **unused (10)** — deleted dead funcs/const + now-unused imports.
- **errcheck (3)** — deferred `Close` guarded with `defer func() { _ = x.Close() }()`.
- **staticcheck (5)** — S1040 redundant assertion removed, QF1009 `time.Equal` ×2, S1011 `append(...)`, QF1006 loop-condition lift.
- **ineffassign (1)** — gcp connector no longer erases a known-public ACL verdict when the IAM policy is unreachable (a real bug the ineffectual assignment masked).
- **gosec (4)** — G706: keep the operator-controlled env value out of the log line; G602 ×3: restructure `enrichAdvisories` to a per-iteration pointer so the range index is provably in-bounds.

## Verification (local)
`golangci-lint run` → **0 issues** · `go build ./...` · `go vet ./...` · `gofmt -l` clean · `go test ./...` green · real-Postgres suite green.

## Note
The pre-existing `internal/infrastructure/dastengine` tests remain intermittently flaky (timing/IPC in the in-process auth-pipe harness — `-race` clean, no production bug). Untouched here; tracked as a separate follow-up.
