### PR TITLE
ci(release-sign): correct the attest-build-provenance pinned SHA

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -173,7 +173,7 @@ jobs:
         run: ./scripts/release/verify-artifacts-signed.sh ./artifacts
 
       - name: Provenance attestation
-        uses: actions/attest-build-provenance@92c22c5d770a3f8010cf6c11c8c2b3e4d7bc4d8d # v3.0.0
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: "./artifacts/*"
 


### PR DESCRIPTION
release-sign failed at 'Set up job' (Unable to resolve action) because `actions/attest-build-provenance` was pinned to `92c22c5d…` (# v3.0.0), a SHA that does not exist. v3.0.0 resolves to `977bb373ede98d70efdf65b84cb5f73e068dcc2a`; pin that. Verified via `gh api repos/actions/attest-build-provenance/git/ref/tags/v3.0.0`. Unblocks signing + attestation of the v0.1.8 release.