### PR TITLE
ci(release): owned SBOM engine + dispatchable scan gate

### DIFF
--- a/.github/workflows/release-scan-gate.yml
+++ b/.github/workflows/release-scan-gate.yml
@@ -4,13 +4,20 @@ name: Release Scan Gate
 # scanner binary is missing, errors, or reports a finding above the floor, the job fails. No step in
 # the release path may swallow a non-zero exit (asserted by the lint step below).
 #
-# STATUS: authored to the #412 spec. GitHub Actions is currently disabled for this repository, so this
-# workflow does not run yet; it is the gate that activates when Actions is enabled. Its logic is
-# deliberately fail-closed so a dormant/misconfigured scanner can never masquerade as "0 findings".
+# Its logic is deliberately fail-closed so a dormant/misconfigured scanner can never masquerade as
+# "0 findings". It runs on a published release; workflow_dispatch(tag) also lets it be run on demand for
+# an existing tag (e.g. a release published by goreleaser's GITHUB_TOKEN, which does not itself emit the
+# release:published event that would otherwise trigger this gate).
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to scan (e.g. v0.1.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -47,17 +54,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          tag="${{ github.event.release.tag_name || inputs.tag }}"
+          test -n "${tag}"
           mkdir -p ./release-artifacts
-          gh release download "${{ github.event.release.tag_name }}" --dir ./release-artifacts
+          gh release download "${tag}" --dir ./release-artifacts
 
       - name: Scan every artifact and the image, fail on findings at/above the floor
         # Each invocation must propagate its exit; `set -e` + no swallowing. --fail-on high makes the
-        # scanner exit non-zero on a High/Critical finding, which fails the job.
+        # scanner exit non-zero on a High/Critical finding, which fails the job. SYNAPSE_SBOM_PRODUCER=
+        # ownsbom uses the first-party SBOM engine so no external syft binary is required on the runner.
+        env:
+          SYNAPSE_SBOM_PRODUCER: ownsbom
         run: |
           set -euo pipefail
           shopt -s nullglob
           scanned=0
           for art in ./release-artifacts/*; do
+            case "${art}" in
+            *.sig | *.asc | *.sha256 | *checksums.txt | *SHA256SUMS) continue ;;
+            esac
             echo "scanning ${art}"
             ./dist/synapse-cli scan --fail-on high "${art}"
             scanned=$((scanned + 1))

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -141,15 +141,20 @@ jobs:
 
       # Requirement 5: the SBOM is produced by this project's OWN engine, which makes every release a
       # dogfooding run. A scanner that cannot describe our own artifact has no business describing a
-      # customer's.
+      # customer's. SYNAPSE_SBOM_PRODUCER=ownsbom selects the first-party engine so no external syft
+      # binary is required on the runner (using syft here would contradict "our OWN engine" anyway).
       - name: Build the scanner and emit an SBOM per artifact
+        env:
+          SYNAPSE_SBOM_PRODUCER: ownsbom
         run: |
           set -euo pipefail
           go build -o ./dist/synapse-cli ./cmd/synapse-cli
           test -x ./dist/synapse-cli
           for art in ./artifacts/*; do
             case "${art}" in
-            *.sig | *.asc | *.sha256 | *.sbom.json | *.intoto.jsonl) continue ;;
+            # Skip signatures, checksums, and already-emitted derived files — an SBOM of a checksum
+            # manifest is meaningless and only package artifacts describe a bill of materials.
+            *.sig | *.asc | *.sha256 | *.sbom.json | *.intoto.jsonl | *checksums.txt | *SHA256SUMS) continue ;;
             esac
             # `scan <path> --sbom` renders CycloneDX to stdout through the SAME renderer the engagement
             # export uses, so a release SBOM cannot drift from the one customers get.


### PR DESCRIPTION
Fixes surfaced by running the release pipeline for v0.1.8 (these workflows were authored while Actions was off, never executed):

- **release-sign**: `scan --sbom` defaulted to `SYNAPSE_SBOM_PRODUCER=syft` → failed `syft: executable file not found`. Set `SYNAPSE_SBOM_PRODUCER=ownsbom` (the first-party engine the workflow's own comment says it uses) + skip checksum manifests in the SBOM loop.
- **release-scan-gate**: add `workflow_dispatch(tag)` + tag fallback so the fail-closed release scan can run on demand for an existing tag (a goreleaser/`GITHUB_TOKEN` release doesn't emit `release:published`, so the gate couldn't otherwise run for it); also `ownsbom` + skip checksums.

Unblocks signing/SBOM/attest + the fail-closed scan for v0.1.8. YAML validated; exit-swallow lint clean.