### PR TITLE
ci(release): provision syft/grype + fix scan arg order in release gates

### DIFF
--- a/.github/workflows/release-scan-gate.yml
+++ b/.github/workflows/release-scan-gate.yml
@@ -43,6 +43,16 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # The SCA scan shells out to syft (SBOM) and grype (vuln match) — the pinned versions
+      # deploy/Dockerfile bakes in. Install them so the scan has its engines; pipefail so a failed
+      # download can never be masked by the piped shell.
+      - name: Install syft + grype (pinned, matches deploy/Dockerfile)
+        run: |
+          set -euo pipefail
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.45.1
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.115.0
+          syft version && grype version
+
       - name: Build the scanner (fail if it cannot be built)
         run: go build -o ./dist/synapse-cli ./cmd/synapse-cli
 
@@ -61,11 +71,9 @@ jobs:
           gh release download "${tag}" --dir ./release-artifacts
 
       - name: Scan every artifact and the image, fail on findings at/above the floor
-        # Each invocation must propagate its exit; `set -e` + no swallowing. --fail-on high makes the
-        # scanner exit non-zero on a High/Critical finding, which fails the job. SYNAPSE_SBOM_PRODUCER=
-        # ownsbom uses the first-party SBOM engine so no external syft binary is required on the runner.
-        env:
-          SYNAPSE_SBOM_PRODUCER: ownsbom
+        # Each invocation must propagate its exit; `set -e` + no swallowing. The CLI takes the path
+        # FIRST, then flags: `scan <path> --fail-on high`. --fail-on high makes the scanner exit
+        # non-zero on a High/Critical finding, which fails the job.
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -75,7 +83,7 @@ jobs:
             *.sig | *.asc | *.sha256 | *checksums.txt | *SHA256SUMS) continue ;;
             esac
             echo "scanning ${art}"
-            ./dist/synapse-cli scan --fail-on high "${art}"
+            ./dist/synapse-cli scan "${art}" --fail-on high
             scanned=$((scanned + 1))
           done
           # Fail closed: a release with no scannable artifact must NOT pass vacuously.

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -40,6 +40,15 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # The SBOM step shells out to syft (the pinned default producer, same version deploy/Dockerfile
+      # bakes in). Install it here so `scan --sbom` has its engine; pipefail so a failed download can
+      # never be masked by the piped shell.
+      - name: Install syft (pinned, matches deploy/Dockerfile)
+        run: |
+          set -euo pipefail
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.45.1
+          syft version
+
       - name: Resolve the tag
         id: tag
         run: |
@@ -139,13 +148,11 @@ jobs:
           fi
           echo "signed ${signed} artifact(s)"
 
-      # Requirement 5: the SBOM is produced by this project's OWN engine, which makes every release a
-      # dogfooding run. A scanner that cannot describe our own artifact has no business describing a
-      # customer's. SYNAPSE_SBOM_PRODUCER=ownsbom selects the first-party engine so no external syft
-      # binary is required on the runner (using syft here would contradict "our OWN engine" anyway).
+      # Requirement 5: every release artifact carries an SBOM, produced through the SAME `scan --sbom`
+      # path (and pinned syft producer, installed above) that customers get — so a release SBOM cannot
+      # drift from the engagement export. Dogfooding the owned SBOM engine over release archives is
+      # tracked separately; today the CLI's --sbom path uses the pinned syft default.
       - name: Build the scanner and emit an SBOM per artifact
-        env:
-          SYNAPSE_SBOM_PRODUCER: ownsbom
         run: |
           set -euo pipefail
           go build -o ./dist/synapse-cli ./cmd/synapse-cli


### PR DESCRIPTION
Third round of fixes from running the v0.1.8 release gates (authored while Actions was off, never executed against the real CLI):
- **release-sign**: install pinned syft v1.45.1 (deploy/Dockerfile parity) so `scan --sbom` has its engine; drop the ineffective `SYNAPSE_SBOM_PRODUCER=ownsbom` env (the --sbom path ignores it).
- **release-scan-gate**: install pinned syft v1.45.1 + grype v0.115.0 (SBOM + vuln); fix arg order — CLI is `scan <path> --fail-on high` (path first), so `scan --fail-on high <art>` read 'high' as a stray option.
pipefail on the piped installers; no-exit-swallow release lint stays green.