### PR TITLE
ci(release-sign): stop uploading SHA256SUMS.sig twice

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -194,7 +194,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          # SHA256SUMS.sig is already matched by ./artifacts/*.sig; listing it again uploaded the same
+          # asset twice in one invocation, and --clobber only replaces PRE-existing assets (not a
+          # same-command duplicate), so the second upload 422'd "already exists". Let the *.sig glob
+          # cover it; only SHA256SUMS (no extension) needs an explicit entry.
           gh release upload "${{ steps.tag.outputs.tag }}" \
-            ./artifacts/*.sig ./artifacts/*.sbom.json ./artifacts/SHA256SUMS ./artifacts/SHA256SUMS.sig \
+            ./artifacts/*.sig ./artifacts/*.sbom.json ./artifacts/SHA256SUMS \
             --clobber
           echo "release ${{ steps.tag.outputs.tag }} is signed and attested"


### PR DESCRIPTION
Final release-sign blocker: the upload listed both `./artifacts/*.sig` (matches SHA256SUMS.sig) and `./artifacts/SHA256SUMS.sig` explicitly → the same asset uploaded twice in one `gh release upload`; `--clobber` replaces pre-existing assets but not a same-invocation dup → `HTTP 422: ReleaseAsset.name already exists`. Drop the redundant explicit entry (the *.sig glob covers it). release-scan-gate already passes for v0.1.8; this unblocks signing/attest.