### PR TITLE
fix: ten integration-boundary defects found by end-to-end validation

### DIFF
--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -265,18 +265,68 @@ func agentFrom(ctx context.Context) (*fleetagent.Agent, bool) {
 	return a, ok
 }
 
+// fleetAgentPlaneRoute is one route on the untrusted agent-auth plane: the pattern its mux serves
+// and the top-level prefix the Router mounts it under. The two live together so a new agent route
+// cannot be registered without also declaring how it is mounted - the failure mode being that the
+// route falls through to the human RBAC chain and is rejected as an unauthenticated operator
+// request. Anything under /api/v1/fleet NOT listed here is an operator route on the human plane.
+type fleetAgentPlaneRoute struct {
+	pattern string // the mux pattern, including the method
+	mount   string // the top-level prefix Router.Handler() mounts this plane under
+}
+
+// fleetAgentPlaneRoutes is the single source of truth consumed by BOTH fleetRouter.handler() (which
+// registers the patterns) and Router.Handler() (which mounts the distinct prefixes).
+func fleetAgentPlaneRoutes() []fleetAgentPlaneRoute {
+	return []fleetAgentPlaneRoute{
+		{"POST /api/v1/fleet/enrol", "/api/v1/fleet/enrol"},
+		{"POST /api/v1/fleet/heartbeat", "/api/v1/fleet/heartbeat"},
+		{"POST /api/v1/fleet/decommission", "/api/v1/fleet/decommission"},
+		{"POST /api/v1/fleet/work/claim", "/api/v1/fleet/work/"},
+		{"POST /api/v1/fleet/work/{id}/progress", "/api/v1/fleet/work/"},
+		{"POST /api/v1/fleet/work/{id}/result", "/api/v1/fleet/work/"},
+		{"POST /api/v1/fleet/inventory/cluster", "/api/v1/fleet/inventory/"},
+		{"POST /api/v1/fleet/inventory/host", "/api/v1/fleet/inventory/"},
+	}
+}
+
+// fleetAgentPlaneMounts returns the deduplicated top-level prefixes for the agent plane, preserving
+// declaration order.
+func fleetAgentPlaneMounts() []string {
+	seen := make(map[string]bool)
+	var mounts []string
+	for _, route := range fleetAgentPlaneRoutes() {
+		if !seen[route.mount] {
+			seen[route.mount] = true
+			mounts = append(mounts, route.mount)
+		}
+	}
+	return mounts
+}
+
 // handler builds the agent-plane mux. Every route checks the protocol version; every route except
 // enrol requires a valid agent bearer credential (agent-auth, NOT the human RBAC plane).
 func (f *fleetRouter) handler() http.Handler {
+	handlers := map[string]http.HandlerFunc{
+		"POST /api/v1/fleet/enrol":              f.entry(f.enrol),
+		"POST /api/v1/fleet/heartbeat":          f.entry(f.authed(f.heartbeat)),
+		"POST /api/v1/fleet/decommission":       f.entry(f.authed(f.decommission)),
+		"POST /api/v1/fleet/work/claim":         f.entry(f.authed(f.claim)),
+		"POST /api/v1/fleet/work/{id}/progress": f.entry(f.authed(f.progress)),
+		"POST /api/v1/fleet/work/{id}/result":   f.entry(f.authed(f.result)),
+		"POST /api/v1/fleet/inventory/cluster":  f.entry(f.authed(f.clusterInventory)),
+		"POST /api/v1/fleet/inventory/host":     f.entry(f.authed(f.hostInventory)),
+	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/fleet/enrol", f.entry(f.enrol))
-	mux.HandleFunc("POST /api/v1/fleet/heartbeat", f.entry(f.authed(f.heartbeat)))
-	mux.HandleFunc("POST /api/v1/fleet/decommission", f.entry(f.authed(f.decommission)))
-	mux.HandleFunc("POST /api/v1/fleet/work/claim", f.entry(f.authed(f.claim)))
-	mux.HandleFunc("POST /api/v1/fleet/work/{id}/progress", f.entry(f.authed(f.progress)))
-	mux.HandleFunc("POST /api/v1/fleet/work/{id}/result", f.entry(f.authed(f.result)))
-	mux.HandleFunc("POST /api/v1/fleet/inventory/cluster", f.entry(f.authed(f.clusterInventory)))
-	mux.HandleFunc("POST /api/v1/fleet/inventory/host", f.entry(f.authed(f.hostInventory)))
+	for _, route := range fleetAgentPlaneRoutes() {
+		handler, ok := handlers[route.pattern]
+		if !ok {
+			// A declared route with no handler is a programming error caught by
+			// TestFleetAgentPlaneRoutesAllHaveHandlers, never a silent 404 in production.
+			continue
+		}
+		mux.HandleFunc(route.pattern, handler)
+	}
 	return mux
 }
 

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -273,20 +273,32 @@ func agentFrom(ctx context.Context) (*fleetagent.Agent, bool) {
 type fleetAgentPlaneRoute struct {
 	pattern string // the mux pattern, including the method
 	mount   string // the top-level prefix Router.Handler() mounts this plane under
+	// handler produces the route's handler from the router. Carrying it here rather than in a
+	// side table makes the pattern/mount/handler relation TOTAL by construction: a new route cannot
+	// be declared without a handler, so there is no missing-case branch to fail open or 404.
+	handler func(*fleetRouter) http.HandlerFunc
 }
 
 // fleetAgentPlaneRoutes is the single source of truth consumed by BOTH fleetRouter.handler() (which
 // registers the patterns) and Router.Handler() (which mounts the distinct prefixes).
 func fleetAgentPlaneRoutes() []fleetAgentPlaneRoute {
 	return []fleetAgentPlaneRoute{
-		{"POST /api/v1/fleet/enrol", "/api/v1/fleet/enrol"},
-		{"POST /api/v1/fleet/heartbeat", "/api/v1/fleet/heartbeat"},
-		{"POST /api/v1/fleet/decommission", "/api/v1/fleet/decommission"},
-		{"POST /api/v1/fleet/work/claim", "/api/v1/fleet/work/"},
-		{"POST /api/v1/fleet/work/{id}/progress", "/api/v1/fleet/work/"},
-		{"POST /api/v1/fleet/work/{id}/result", "/api/v1/fleet/work/"},
-		{"POST /api/v1/fleet/inventory/cluster", "/api/v1/fleet/inventory/"},
-		{"POST /api/v1/fleet/inventory/host", "/api/v1/fleet/inventory/"},
+		{"POST /api/v1/fleet/enrol", "/api/v1/fleet/enrol",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.enrol) }},
+		{"POST /api/v1/fleet/heartbeat", "/api/v1/fleet/heartbeat",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.heartbeat)) }},
+		{"POST /api/v1/fleet/decommission", "/api/v1/fleet/decommission",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.decommission)) }},
+		{"POST /api/v1/fleet/work/claim", "/api/v1/fleet/work/",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.claim)) }},
+		{"POST /api/v1/fleet/work/{id}/progress", "/api/v1/fleet/work/",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.progress)) }},
+		{"POST /api/v1/fleet/work/{id}/result", "/api/v1/fleet/work/",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.result)) }},
+		{"POST /api/v1/fleet/inventory/cluster", "/api/v1/fleet/inventory/",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.clusterInventory)) }},
+		{"POST /api/v1/fleet/inventory/host", "/api/v1/fleet/inventory/",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.hostInventory)) }},
 	}
 }
 
@@ -307,25 +319,9 @@ func fleetAgentPlaneMounts() []string {
 // handler builds the agent-plane mux. Every route checks the protocol version; every route except
 // enrol requires a valid agent bearer credential (agent-auth, NOT the human RBAC plane).
 func (f *fleetRouter) handler() http.Handler {
-	handlers := map[string]http.HandlerFunc{
-		"POST /api/v1/fleet/enrol":              f.entry(f.enrol),
-		"POST /api/v1/fleet/heartbeat":          f.entry(f.authed(f.heartbeat)),
-		"POST /api/v1/fleet/decommission":       f.entry(f.authed(f.decommission)),
-		"POST /api/v1/fleet/work/claim":         f.entry(f.authed(f.claim)),
-		"POST /api/v1/fleet/work/{id}/progress": f.entry(f.authed(f.progress)),
-		"POST /api/v1/fleet/work/{id}/result":   f.entry(f.authed(f.result)),
-		"POST /api/v1/fleet/inventory/cluster":  f.entry(f.authed(f.clusterInventory)),
-		"POST /api/v1/fleet/inventory/host":     f.entry(f.authed(f.hostInventory)),
-	}
 	mux := http.NewServeMux()
 	for _, route := range fleetAgentPlaneRoutes() {
-		handler, ok := handlers[route.pattern]
-		if !ok {
-			// A declared route with no handler is a programming error caught by
-			// TestFleetAgentPlaneRoutesAllHaveHandlers, never a silent 404 in production.
-			continue
-		}
-		mux.HandleFunc(route.pattern, handler)
+		mux.HandleFunc(route.pattern, route.handler(f))
 	}
 	return mux
 }

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -353,6 +353,12 @@ func (f *fleetRouter) authed(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 		ctx := context.WithValue(r.Context(), agentKeyCtx, agent)
+		// Bind the AUTHENTICATED agent's tenant onto the context (never a request field). Downstream
+		// writes - notably the hash-chained audit log - read the tenant from the context to satisfy
+		// tenant RLS, and this plane has no human principal to carry it. Without this, heartbeat,
+		// claim, result, and inventory writes fail the audit insert with
+		// "new row violates row-level security policy for table audit_log".
+		ctx = shared.WithTenant(ctx, agent.TenantID)
 		next(w, r.WithContext(ctx))
 	}
 }

--- a/internal/adapter/httpapi/fleet_plane_split_test.go
+++ b/internal/adapter/httpapi/fleet_plane_split_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -142,24 +143,30 @@ func TestEveryAgentRouteReachesTheAgentPlane(t *testing.T) {
 // wildcardRE matches a net/http mux wildcard segment such as "{id}".
 var wildcardRE = regexp.MustCompile(`\{[^}]*\}`)
 
-// TestFleetAgentPlaneRoutesAllHaveHandlers guards the other direction: handler() skips a declared
-// pattern it has no handler for, which would otherwise be a silent 404 on a mounted agent path.
-func TestFleetAgentPlaneRoutesAllHaveHandlers(t *testing.T) {
-	agentSvc, err := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
-	if err != nil {
-		t.Fatalf("agent svc: %v", err)
-	}
-	rt := &Router{log: discardLog()}
-	rt.SetFleet(agentSvc, nil, time.Now, "")
-	mux, ok := rt.fleet.handler().(*http.ServeMux)
-	if !ok {
-		t.Fatal("agent plane handler is not a *http.ServeMux")
-	}
+// TestFleetAgentPlaneRoutesAreWellFormed guards the declaration itself. The handler now lives on the
+// route, so a missing handler is a compile-time impossibility rather than a silent 404 - but an
+// explicit nil would panic at mux registration, and a pattern must carry a method and sit under a
+// mount that actually covers it.
+func TestFleetAgentPlaneRoutesAreWellFormed(t *testing.T) {
+	mounts := fleetAgentPlaneMounts()
 	for _, route := range fleetAgentPlaneRoutes() {
-		method, pattern, _ := strings.Cut(route.pattern, " ")
-		path := wildcardRE.ReplaceAllString(pattern, "wo1")
-		if _, matched := mux.Handler(httptest.NewRequest(method, path, http.NoBody)); matched == "" {
-			t.Errorf("declared route %q registered no handler; it would 404 on a mounted path", route.pattern)
+		if route.handler == nil {
+			t.Errorf("route %q declares a nil handler; mux registration would panic", route.pattern)
+			continue
+		}
+		method, pattern, ok := strings.Cut(route.pattern, " ")
+		if !ok || method == "" || !strings.HasPrefix(pattern, "/api/v1/fleet/") {
+			t.Errorf("route %q is malformed; want \"METHOD /api/v1/fleet/...\"", route.pattern)
+			continue
+		}
+		if !slices.Contains(mounts, route.mount) {
+			t.Errorf("route %q declares mount %q, which fleetAgentPlaneMounts() does not expose", route.pattern, route.mount)
+		}
+		// The mount must actually cover the pattern, or Router.Handler() sends it to the human chain.
+		covered := pattern == route.mount ||
+			(strings.HasSuffix(route.mount, "/") && strings.HasPrefix(pattern, route.mount))
+		if !covered {
+			t.Errorf("route %q is not covered by its own mount %q", route.pattern, route.mount)
 		}
 	}
 }

--- a/internal/adapter/httpapi/fleet_plane_split_test.go
+++ b/internal/adapter/httpapi/fleet_plane_split_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,29 +104,62 @@ func TestFleetAgentPlaneStaysOffTheHumanChain(t *testing.T) {
 	}
 }
 
-// TestFleetAgentPlanePrefixesCoverEveryAgentRoute keeps the mount list honest: a new agent-plane
-// route that no prefix covers would silently fall through to the human chain and be rejected as an
-// unauthenticated operator request.
-func TestFleetAgentPlanePrefixesCoverEveryAgentRoute(t *testing.T) {
-	for _, path := range []string{
-		"/api/v1/fleet/enrol",
-		"/api/v1/fleet/heartbeat",
-		"/api/v1/fleet/decommission",
-		"/api/v1/fleet/work/claim",
-		"/api/v1/fleet/work/wo1/progress",
-		"/api/v1/fleet/work/wo1/result",
-		"/api/v1/fleet/inventory/cluster",
-		"/api/v1/fleet/inventory/host",
-	} {
-		covered := false
-		for _, prefix := range fleetAgentPlanePrefixes {
-			if path == prefix || (len(prefix) > 0 && prefix[len(prefix)-1] == '/' && len(path) >= len(prefix) && path[:len(prefix)] == prefix) {
-				covered = true
-				break
-			}
+// TestEveryAgentRouteReachesTheAgentPlane keeps the mount list honest for routes that do not exist
+// yet. It iterates fleetAgentPlaneRoutes - the SAME declaration fleetRouter.handler() registers -
+// rather than a hand-copied path list, and drives each route through the real Handler(). A new agent
+// route therefore fails this test automatically: without a matching mount it falls through to the
+// human chain and answers 401 instead of reaching the agent plane.
+//
+// The 400 expectation is the agent plane's own protocol-version check, which every agent route runs
+// before auth. Reaching it proves the request was served by the agent mux, not the human chain.
+func TestEveryAgentRouteReachesTheAgentPlane(t *testing.T) {
+	handler := routerWithFleetPlanes(t)
+	for _, route := range fleetAgentPlaneRoutes() {
+		method, pattern, ok := strings.Cut(route.pattern, " ")
+		if !ok {
+			t.Fatalf("route %q has no method", route.pattern)
 		}
-		if !covered {
-			t.Errorf("agent route %s is not covered by fleetAgentPlanePrefixes", path)
+		// Substitute a concrete value for each wildcard so the request matches the pattern.
+		path := wildcardRE.ReplaceAllString(pattern, "wo1")
+		t.Run(path, func(t *testing.T) {
+			request := httptest.NewRequest(method, path, http.NoBody)
+			// Deliberately no X-Synapse-Fleet-Proto header and no credential.
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, request)
+			if recorder.Code == http.StatusUnauthorized {
+				t.Fatalf("%s was served by the HUMAN chain (401); it needs a mount in fleetAgentPlaneRoutes", path)
+			}
+			if recorder.Code == http.StatusNotFound {
+				t.Fatalf("%s answered 404; the agent plane is mounted but does not serve it", path)
+			}
+			if recorder.Code != http.StatusBadRequest {
+				t.Errorf("%s status = %d, want 400 from the agent-plane protocol-version check", path, recorder.Code)
+			}
+		})
+	}
+}
+
+// wildcardRE matches a net/http mux wildcard segment such as "{id}".
+var wildcardRE = regexp.MustCompile(`\{[^}]*\}`)
+
+// TestFleetAgentPlaneRoutesAllHaveHandlers guards the other direction: handler() skips a declared
+// pattern it has no handler for, which would otherwise be a silent 404 on a mounted agent path.
+func TestFleetAgentPlaneRoutesAllHaveHandlers(t *testing.T) {
+	agentSvc, err := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatalf("agent svc: %v", err)
+	}
+	rt := &Router{log: discardLog()}
+	rt.SetFleet(agentSvc, nil, time.Now, "")
+	mux, ok := rt.fleet.handler().(*http.ServeMux)
+	if !ok {
+		t.Fatal("agent plane handler is not a *http.ServeMux")
+	}
+	for _, route := range fleetAgentPlaneRoutes() {
+		method, pattern, _ := strings.Cut(route.pattern, " ")
+		path := wildcardRE.ReplaceAllString(pattern, "wo1")
+		if _, matched := mux.Handler(httptest.NewRequest(method, path, http.NoBody)); matched == "" {
+			t.Errorf("declared route %q registered no handler; it would 404 on a mounted path", route.pattern)
 		}
 	}
 }

--- a/internal/adapter/httpapi/fleet_plane_split_test.go
+++ b/internal/adapter/httpapi/fleet_plane_split_test.go
@@ -1,0 +1,130 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
+)
+
+// routerWithFleetPlanes builds a Router that has BOTH planes wired, then returns the real
+// Handler() - the composition the server actually serves. The other fleet tests drive
+// rt.routes() or rt.fleet.handler() in isolation, so neither of them can observe how the two
+// planes are mounted relative to each other.
+func routerWithFleetPlanes(t *testing.T) http.Handler {
+	t.Helper()
+	agentSvc, err := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatalf("agent svc: %v", err)
+	}
+	signer, err := worksign.New([]byte("0123456789012345678901234567890123"))
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	workSvc, err := fleetwork.NewService(memory.NewWorkOrderStore(), signer, ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatalf("work svc: %v", err)
+	}
+	auth := NewAuthenticator(func(_ context.Context, token string) (Principal, bool) {
+		if token == "operator-secret" {
+			return Principal{ID: "u1", Name: "Operator", Role: "admin", TenantID: "tenantA"}, true
+		}
+		return Principal{}, false
+	})
+	rt := &Router{log: discardLog(), auth: auth}
+	rt.SetFleet(agentSvc, workSvc, func() time.Time { return time.Now().UTC() }, "")
+	rt.SetFleetAdmin(agentSvc)
+	rt.SetFleetCoverage(fakeCoverage{})
+	return rt.Handler()
+}
+
+// TestFleetOperatorRoutesAreNotShadowedByAgentPlane pins the boundary between the two auth planes.
+// Mounting the untrusted agent plane on the whole "/api/v1/fleet/" prefix also swallowed the
+// OPERATOR coverage + agent-health routes, which the agent mux does not serve: every one of them
+// answered Go's default 404 instead of reaching the human RBAC chain, so the Fleet coverage UI was
+// dead on a real server. Unauthenticated is the discriminator - a human-plane route rejects with
+// 401 (the authenticator runs first), while a shadowed route 404s before any auth runs.
+func TestFleetOperatorRoutesAreNotShadowedByAgentPlane(t *testing.T) {
+	h := routerWithFleetPlanes(t)
+	for _, path := range []string{
+		"/api/v1/fleet/agents",
+		"/api/v1/fleet/agents/ag1",
+		"/api/v1/fleet/coverage",
+		"/api/v1/fleet/coverage/summary",
+		"/api/v1/fleet/coverage/export",
+	} {
+		t.Run(path, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+			if w.Code == http.StatusNotFound {
+				t.Fatalf("%s answered 404: the agent plane is shadowing an operator route", path)
+			}
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("%s status = %d, want 401 (human RBAC plane must authenticate it)", path, w.Code)
+			}
+		})
+	}
+}
+
+// TestFleetAgentPlaneStaysOffTheHumanChain is the other half of the split: the agent transport must
+// NOT gain the human bearer authenticator or the AUP gate. An agent route reaching the human chain
+// would answer 401 for a missing operator token; on its own plane it answers the protocol-version
+// check instead, proving it never saw human auth.
+func TestFleetAgentPlaneStaysOffTheHumanChain(t *testing.T) {
+	h := routerWithFleetPlanes(t)
+	for _, path := range []string{
+		"/api/v1/fleet/enrol",
+		"/api/v1/fleet/heartbeat",
+		"/api/v1/fleet/decommission",
+		"/api/v1/fleet/work/claim",
+		"/api/v1/fleet/work/wo1/progress",
+		"/api/v1/fleet/work/wo1/result",
+		"/api/v1/fleet/inventory/cluster",
+		"/api/v1/fleet/inventory/host",
+	} {
+		t.Run(path, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			// No X-Synapse-Fleet-Proto header: the agent plane rejects with 400 unsupported_version.
+			h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, path, nil))
+			if w.Code == http.StatusUnauthorized {
+				t.Fatalf("%s answered 401: the agent route was routed through the human auth chain", path)
+			}
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("%s status = %d, want 400 from the agent-plane version check", path, w.Code)
+			}
+		})
+	}
+}
+
+// TestFleetAgentPlanePrefixesCoverEveryAgentRoute keeps the mount list honest: a new agent-plane
+// route that no prefix covers would silently fall through to the human chain and be rejected as an
+// unauthenticated operator request.
+func TestFleetAgentPlanePrefixesCoverEveryAgentRoute(t *testing.T) {
+	for _, path := range []string{
+		"/api/v1/fleet/enrol",
+		"/api/v1/fleet/heartbeat",
+		"/api/v1/fleet/decommission",
+		"/api/v1/fleet/work/claim",
+		"/api/v1/fleet/work/wo1/progress",
+		"/api/v1/fleet/work/wo1/result",
+		"/api/v1/fleet/inventory/cluster",
+		"/api/v1/fleet/inventory/host",
+	} {
+		covered := false
+		for _, prefix := range fleetAgentPlanePrefixes {
+			if path == prefix || (len(prefix) > 0 && prefix[len(prefix)-1] == '/' && len(path) >= len(prefix) && path[:len(prefix)] == prefix) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			t.Errorf("agent route %s is not covered by fleetAgentPlanePrefixes", path)
+		}
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -597,13 +597,31 @@ func (rt *Router) Handler() http.Handler {
 		return normalizePath(human)
 	}
 	// The untrusted agent transport is a SEPARATE auth plane: it must not pass through the human
-	// bearer-token authenticator or the AUP gate. Mount it at the top level so /api/v1/fleet is
-	// served by the agent-auth handler and everything else by the human chain. normalizePath wraps
-	// the whole top mux once, so both planes are normalized without double-wrapping.
+	// bearer-token authenticator or the AUP gate. Mount it on the EXACT agent-plane subtrees rather
+	// than the whole /api/v1/fleet/ prefix. A prefix mount also swallows the OPERATOR routes that
+	// live under /api/v1/fleet (coverage + agent health), which the agent mux does not serve, so
+	// every one of them answered 404 instead of reaching the human chain. Listing the subtrees keeps
+	// the two planes disjoint: agent paths never see human auth, and human paths never see the
+	// agent plane. normalizePath wraps the whole top mux once, so both planes are normalized
+	// without double-wrapping.
 	top := http.NewServeMux()
-	top.Handle("/api/v1/fleet/", rt.fleet.handler())
+	for _, prefix := range fleetAgentPlanePrefixes {
+		top.Handle(prefix, rt.fleet.handler())
+	}
 	top.Handle("/", human)
 	return normalizePath(top)
+}
+
+// fleetAgentPlanePrefixes are the exact /api/v1/fleet subtrees served by the untrusted agent-auth
+// plane. Anything else under /api/v1/fleet is an operator route on the human RBAC plane. Keep this
+// list in sync with fleetRouter.handler(); TestFleetOperatorRoutesAreNotShadowedByAgentPlane guards
+// the split.
+var fleetAgentPlanePrefixes = []string{
+	"/api/v1/fleet/enrol",
+	"/api/v1/fleet/heartbeat",
+	"/api/v1/fleet/decommission",
+	"/api/v1/fleet/work/",
+	"/api/v1/fleet/inventory/",
 }
 
 // normalizePath rejects non-canonical request paths (e.g. `/a//b`, `/a/../b`,

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -600,28 +600,17 @@ func (rt *Router) Handler() http.Handler {
 	// bearer-token authenticator or the AUP gate. Mount it on the EXACT agent-plane subtrees rather
 	// than the whole /api/v1/fleet/ prefix. A prefix mount also swallows the OPERATOR routes that
 	// live under /api/v1/fleet (coverage + agent health), which the agent mux does not serve, so
-	// every one of them answered 404 instead of reaching the human chain. Listing the subtrees keeps
-	// the two planes disjoint: agent paths never see human auth, and human paths never see the
-	// agent plane. normalizePath wraps the whole top mux once, so both planes are normalized
-	// without double-wrapping.
+	// every one of them answered 404 instead of reaching the human chain. The mounts are derived
+	// from fleetAgentPlaneRoutes, the same declaration fleetRouter.handler() registers, so the two
+	// planes cannot drift apart. normalizePath wraps the whole top mux once, so both planes are
+	// normalized without double-wrapping.
 	top := http.NewServeMux()
-	for _, prefix := range fleetAgentPlanePrefixes {
-		top.Handle(prefix, rt.fleet.handler())
+	agentPlane := rt.fleet.handler()
+	for _, mount := range fleetAgentPlaneMounts() {
+		top.Handle(mount, agentPlane)
 	}
 	top.Handle("/", human)
 	return normalizePath(top)
-}
-
-// fleetAgentPlanePrefixes are the exact /api/v1/fleet subtrees served by the untrusted agent-auth
-// plane. Anything else under /api/v1/fleet is an operator route on the human RBAC plane. Keep this
-// list in sync with fleetRouter.handler(); TestFleetOperatorRoutesAreNotShadowedByAgentPlane guards
-// the split.
-var fleetAgentPlanePrefixes = []string{
-	"/api/v1/fleet/enrol",
-	"/api/v1/fleet/heartbeat",
-	"/api/v1/fleet/decommission",
-	"/api/v1/fleet/work/",
-	"/api/v1/fleet/inventory/",
 }
 
 // normalizePath rejects non-canonical request paths (e.g. `/a//b`, `/a/../b`,

--- a/internal/infrastructure/cloud/aws/aws.go
+++ b/internal/infrastructure/cloud/aws/aws.go
@@ -35,6 +35,9 @@ const (
 	defaultMaxAccounts  = 100
 	defaultMaxResources = 1000
 	defaultRate         = 5
+	// maxListAccountsPageSize is the largest MaxResults AWS Organizations accepts for
+	// ListAccounts. Anything higher is rejected with InvalidInputException rather than clamped.
+	maxListAccountsPageSize = 20
 )
 
 var _ ports.CloudConnector = (*Connector)(nil)
@@ -200,7 +203,12 @@ type account struct {
 }
 
 func (c *Connector) accounts(ctx context.Context, client *organizations.Client, root string) ([]account, *cloudposture.CoverageIssue) {
-	pager := organizations.NewListAccountsPaginator(client, &organizations.ListAccountsInput{MaxResults: awssdk.Int32(int32(c.opts.MaxAccounts))})
+	// MaxAccounts is OUR total bound, not a page size. Organizations rejects a ListAccounts
+	// MaxResults above maxListAccountsPageSize with InvalidInputException, so sending the total
+	// bound (default 100) failed account enumeration outright and surfaced as a
+	// "provider_error" coverage gap on every real organization. Page within the API limit and
+	// keep enforcing the total bound while collecting.
+	pager := organizations.NewListAccountsPaginator(client, &organizations.ListAccountsInput{MaxResults: awssdk.Int32(int32(min(c.opts.MaxAccounts, maxListAccountsPageSize)))})
 	var accounts []account
 	for pager.HasMorePages() {
 		page, err := pager.NextPage(ctx)
@@ -298,20 +306,37 @@ func (c *Connector) buckets(ctx context.Context, client *s3.Client, account acco
 				*gaps = append(*gaps, *coverageGap(account.id, "storage", err))
 			} else {
 				status, statusErr := client.GetBucketPolicyStatus(ctx, &s3.GetBucketPolicyStatusInput{Bucket: awssdk.String(name)})
-				if statusErr != nil {
+				switch {
+				case statusErr != nil && isAbsentConfig(statusErr, "NoSuchBucketPolicy"):
+					// No bucket policy is a DEFINITIVE answer, not a failure to observe: the bucket
+					// is not public by policy. Treating it as a coverage gap both invented a
+					// provider_error and left Public unknown, so an evidence-backed negative was
+					// downgraded to "we could not tell".
+					resource.Public = cloudposture.StateDisabled
+				case statusErr != nil:
 					*gaps = append(*gaps, *coverageGap(account.id, "storage", statusErr))
-				} else if status.PolicyStatus != nil && awssdk.ToBool(status.PolicyStatus.IsPublic) {
+				case status.PolicyStatus != nil && awssdk.ToBool(status.PolicyStatus.IsPublic):
 					resource.Public = cloudposture.StateEnabled
+				default:
+					resource.Public = cloudposture.StateDisabled
 				}
 			}
 			if err := limiter.wait(ctx); err != nil {
 				*gaps = append(*gaps, *coverageGap(account.id, "storage", err))
 			} else {
 				encryption, encryptionErr := client.GetBucketEncryption(ctx, &s3.GetBucketEncryptionInput{Bucket: awssdk.String(name)})
-				if encryptionErr != nil {
+				switch {
+				case encryptionErr != nil && isAbsentConfig(encryptionErr, "ServerSideEncryptionConfigurationNotFoundError"):
+					// Same contract: "no encryption configuration" is an OBSERVED negative. It
+					// must land as Disabled so the posture rules can raise an unencrypted-bucket
+					// finding; a coverage gap here silently suppressed that finding.
+					resource.Encrypted = cloudposture.StateDisabled
+				case encryptionErr != nil:
 					*gaps = append(*gaps, *coverageGap(account.id, "storage", encryptionErr))
-				} else if encryption.ServerSideEncryptionConfiguration != nil {
+				case encryption.ServerSideEncryptionConfiguration != nil:
 					resource.Encrypted = cloudposture.StateEnabled
+				default:
+					resource.Encrypted = cloudposture.StateDisabled
 				}
 			}
 			inventory.Resources = append(inventory.Resources, resource)
@@ -410,6 +435,16 @@ func appendUnsupportedCoverage(inventory *cloudposture.Inventory, gaps *[]cloudp
 		*gaps = append(*gaps, cloudposture.CoverageIssue{Provider: cloudposture.ProviderAWS, Scope: scope, Category: category, Code: "unsupported", Detail: "connector does not yet establish this posture category"})
 	}
 	inventory.Complete = false
+}
+
+// isAbsentConfig reports whether err is the provider's way of saying "this configuration does not
+// exist" rather than "the request failed". Those codes are DEFINITIVE observations - no bucket
+// policy, no encryption configuration - so they must set a negative state instead of raising a
+// coverage gap: recording them as failures both invented a provider_error and suppressed the
+// posture finding the absent configuration should produce.
+func isAbsentConfig(err error, code string) bool {
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == code
 }
 
 func coverageGap(scope, category string, err error) *cloudposture.CoverageIssue {

--- a/internal/infrastructure/cloud/aws/aws.go
+++ b/internal/infrastructure/cloud/aws/aws.go
@@ -315,9 +315,15 @@ func (c *Connector) buckets(ctx context.Context, client *s3.Client, account acco
 					resource.Public = cloudposture.StateDisabled
 				case statusErr != nil:
 					*gaps = append(*gaps, *coverageGap(account.id, "storage", statusErr))
-				case status.PolicyStatus != nil && awssdk.ToBool(status.PolicyStatus.IsPublic):
+				case status.PolicyStatus == nil:
+					// A 200 carrying no policy-status field is NOT evidence of absence, so the state
+					// stays unknown. Collapsing it into the negative below would manufacture an
+					// evidence-backed claim out of a missing field - the same category error this
+					// function fixes in the other direction.
+				case awssdk.ToBool(status.PolicyStatus.IsPublic):
 					resource.Public = cloudposture.StateEnabled
 				default:
+					// PolicyStatus present and IsPublic false: an observed negative.
 					resource.Public = cloudposture.StateDisabled
 				}
 			}
@@ -336,7 +342,9 @@ func (c *Connector) buckets(ctx context.Context, client *s3.Client, account acco
 				case encryption.ServerSideEncryptionConfiguration != nil:
 					resource.Encrypted = cloudposture.StateEnabled
 				default:
-					resource.Encrypted = cloudposture.StateDisabled
+					// A 200 carrying no encryption configuration field is NOT evidence of absence:
+					// only the named error code above is. Leave the state unknown rather than
+					// manufacturing an unencrypted-bucket claim from a missing field.
 				}
 			}
 			inventory.Resources = append(inventory.Resources, resource)

--- a/internal/infrastructure/cloud/aws/aws_test.go
+++ b/internal/infrastructure/cloud/aws/aws_test.go
@@ -442,3 +442,55 @@ func TestIsAbsentConfigOnlyMatchesTheNamedCode(t *testing.T) {
 		t.Error("a transport error was treated as an observed negative")
 	}
 }
+
+// TestSuccessfulCallWithNilConfigStaysUnknown is the review finding this file previously missed. Only
+// the named ABSENCE ERROR CODES are evidence of absence. A 200 response carrying a nil config field
+// is not: recording it as a definitive negative manufactures an evidence-backed posture claim out of
+// a missing field, which is the same category error as treating a real absence as a failure.
+func TestSuccessfulCallWithNilConfigStaysUnknown(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action := r.Header.Get("X-Amz-Target")
+		switch {
+		case strings.HasSuffix(action, "DescribeOrganization"):
+			w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+			fmt.Fprint(w, `{"Organization":{"Id":"o-example","Arn":"arn:aws:organizations::111111111111:organization/o-example","FeatureSet":"ALL","MasterAccountId":"111111111111"}}`)
+		case strings.HasSuffix(action, "ListAccounts"):
+			w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+			fmt.Fprint(w, `{"Accounts":[{"Id":"111111111111","Arn":"arn:aws:organizations::111111111111:account/o-example/a","Name":"first"}]}`)
+		case strings.Contains(r.URL.RawQuery, "policyStatus"), strings.Contains(r.URL.RawQuery, "encryption"):
+			// 200 OK carrying no configuration field at all - a successful call that establishes
+			// nothing. This is NOT one of the named absence error codes.
+			w.WriteHeader(http.StatusOK)
+		default:
+			body, _ := io.ReadAll(r.Body)
+			if bytes.Contains(body, []byte("AssumeRole")) {
+				fmt.Fprint(w, `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/"><AssumeRoleResult><Credentials><AccessKeyId>temporary</AccessKeyId><SecretAccessKey>temporary-secret</SecretAccessKey><SessionToken>temporary-token</SessionToken><Expiration>2100-01-01T00:00:00Z</Expiration></Credentials></AssumeRoleResult></AssumeRoleResponse>`)
+				return
+			}
+			fmt.Fprint(w, `<ListAllMyBucketsResult><Buckets><Bucket><Name>plain</Name></Bucket></Buckets></ListAllMyBucketsResult>`)
+		}
+	}))
+	defer server.Close()
+
+	connector := newTestConnector(t, server.URL, "TOP-SECRET-ACCESS-KEY")
+	inventory, _, err := connector.Enumerate(context.Background(), testScope())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bucket *cloudposture.Resource
+	for i := range inventory.Resources {
+		if inventory.Resources[i].Kind == asset.KindStorage {
+			bucket = &inventory.Resources[i]
+			break
+		}
+	}
+	if bucket == nil {
+		t.Fatal("bucket was not enumerated")
+	}
+	if bucket.Encrypted != cloudposture.StateUnknown {
+		t.Errorf("Encrypted = %q, want %q (a nil config field on a 200 is not evidence of absence)", bucket.Encrypted, cloudposture.StateUnknown)
+	}
+	if bucket.Public != cloudposture.StateUnknown {
+		t.Errorf("Public = %q, want %q (a nil policy-status field on a 200 is not evidence of absence)", bucket.Public, cloudposture.StateUnknown)
+	}
+}

--- a/internal/infrastructure/cloud/aws/aws_test.go
+++ b/internal/infrastructure/cloud/aws/aws_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/aws/smithy-go"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/cloudposture"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -294,5 +298,147 @@ func TestLeastPrivilegeActionsIsImmutable(t *testing.T) {
 	actions[0] = "mutated"
 	if LeastPrivilegeActions()[0] == "mutated" {
 		t.Fatal("permission manifest may be mutated by callers")
+	}
+}
+
+// TestListAccountsRespectsProviderPageLimit pins the ListAccounts page size to what AWS
+// Organizations actually accepts. MaxAccounts is our TOTAL bound (default 100), but the API
+// rejects a MaxResults above 20 with InvalidInputException instead of clamping it, so sending the
+// total bound failed account enumeration on every real organization and surfaced as an opaque
+// "provider_error" coverage gap - with zero assets and zero findings - after DescribeOrganization
+// had already succeeded.
+func TestListAccountsRespectsProviderPageLimit(t *testing.T) {
+	var mu sync.Mutex
+	var requested []int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		action := r.Header.Get("X-Amz-Target")
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		switch {
+		case strings.HasSuffix(action, "DescribeOrganization"):
+			fmt.Fprint(w, `{"Organization":{"Id":"o-example","Arn":"arn:aws:organizations::111111111111:organization/o-example","FeatureSet":"ALL","MasterAccountId":"111111111111"}}`)
+		case strings.HasSuffix(action, "ListAccounts"):
+			var input struct {
+				MaxResults *int64 `json:"MaxResults"`
+			}
+			_ = json.Unmarshal(body, &input)
+			mu.Lock()
+			if input.MaxResults != nil {
+				requested = append(requested, *input.MaxResults)
+			}
+			mu.Unlock()
+			// Mirror the real API: oversized page sizes are REJECTED, never clamped.
+			if input.MaxResults != nil && *input.MaxResults > maxListAccountsPageSize {
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, `{"__type":"InvalidInputException","message":"You provided a value that exceeds the maximum allowed."}`)
+				return
+			}
+			fmt.Fprint(w, `{"Accounts":[{"Id":"111111111111","Arn":"arn:aws:organizations::111111111111:account/o-example/a","Name":"first"}]}`)
+		default:
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"__type":"AccessDeniedException","message":"denied"}`)
+		}
+	}))
+	defer server.Close()
+
+	connector := newTestConnector(t, server.URL, "TOP-SECRET-ACCESS-KEY")
+	inventory, gaps, err := connector.Enumerate(context.Background(), testScope())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	got := append([]int64(nil), requested...)
+	mu.Unlock()
+	if len(got) == 0 {
+		t.Fatal("ListAccounts was never called")
+	}
+	for _, size := range got {
+		if size > maxListAccountsPageSize {
+			t.Fatalf("ListAccounts MaxResults = %d, want <= %d (AWS rejects larger values)", size, maxListAccountsPageSize)
+		}
+	}
+	if hasGapCode(gaps, "provider_error") {
+		t.Fatalf("account enumeration reported a provider error: %#v", gaps)
+	}
+	if len(inventory.Resources) == 0 {
+		t.Fatal("no accounts were enumerated")
+	}
+}
+
+// TestAbsentBucketConfigIsAnObservedNegative pins the difference between "the provider told us the
+// configuration does not exist" and "we could not observe it". NoSuchBucketPolicy and
+// ServerSideEncryptionConfigurationNotFoundError are definitive negatives, but they were recorded as
+// storage coverage gaps: that invented a provider_error on healthy accounts AND left Public/Encrypted
+// unknown, so an unencrypted bucket produced no posture finding at all.
+func TestAbsentBucketConfigIsAnObservedNegative(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action := r.Header.Get("X-Amz-Target")
+		switch {
+		case strings.HasSuffix(action, "DescribeOrganization"):
+			w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+			fmt.Fprint(w, `{"Organization":{"Id":"o-example","Arn":"arn:aws:organizations::111111111111:organization/o-example","FeatureSet":"ALL","MasterAccountId":"111111111111"}}`)
+		case strings.HasSuffix(action, "ListAccounts"):
+			w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+			fmt.Fprint(w, `{"Accounts":[{"Id":"111111111111","Arn":"arn:aws:organizations::111111111111:account/o-example/a","Name":"first"}]}`)
+		case strings.Contains(r.URL.RawQuery, "policyStatus"):
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `<Error><Code>NoSuchBucketPolicy</Code><Message>The bucket policy does not exist</Message></Error>`)
+		case strings.Contains(r.URL.RawQuery, "encryption"):
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `<Error><Code>ServerSideEncryptionConfigurationNotFoundError</Code><Message>absent</Message></Error>`)
+		case strings.Contains(r.URL.Path, "AssumeRole") || strings.Contains(r.URL.RawQuery, "AssumeRole"):
+			fmt.Fprint(w, `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/"><AssumeRoleResult><Credentials><AccessKeyId>temporary</AccessKeyId><SecretAccessKey>temporary-secret</SecretAccessKey><SessionToken>temporary-token</SessionToken><Expiration>2100-01-01T00:00:00Z</Expiration></Credentials></AssumeRoleResult></AssumeRoleResponse>`)
+		default:
+			body, _ := io.ReadAll(r.Body)
+			if bytes.Contains(body, []byte("AssumeRole")) {
+				fmt.Fprint(w, `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/"><AssumeRoleResult><Credentials><AccessKeyId>temporary</AccessKeyId><SecretAccessKey>temporary-secret</SecretAccessKey><SessionToken>temporary-token</SessionToken><Expiration>2100-01-01T00:00:00Z</Expiration></Credentials></AssumeRoleResult></AssumeRoleResponse>`)
+				return
+			}
+			fmt.Fprint(w, `<ListAllMyBucketsResult><Buckets><Bucket><Name>plain</Name></Bucket></Buckets></ListAllMyBucketsResult>`)
+		}
+	}))
+	defer server.Close()
+
+	connector := newTestConnector(t, server.URL, "TOP-SECRET-ACCESS-KEY")
+	inventory, gaps, err := connector.Enumerate(context.Background(), testScope())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasGap(gaps, "storage", "provider_error") {
+		t.Errorf("absent bucket configuration was reported as a provider error: %#v", gaps)
+	}
+	var bucket *cloudposture.Resource
+	for i := range inventory.Resources {
+		if inventory.Resources[i].Kind == asset.KindStorage {
+			bucket = &inventory.Resources[i]
+			break
+		}
+	}
+	if bucket == nil {
+		t.Fatal("bucket was not enumerated")
+	}
+	if bucket.Encrypted != cloudposture.StateDisabled {
+		t.Errorf("Encrypted = %q, want %q (absent configuration means NOT encrypted)", bucket.Encrypted, cloudposture.StateDisabled)
+	}
+	if bucket.Public != cloudposture.StateDisabled {
+		t.Errorf("Public = %q, want %q (no bucket policy means not public by policy)", bucket.Public, cloudposture.StateDisabled)
+	}
+}
+
+// TestIsAbsentConfigOnlyMatchesTheNamedCode keeps the carve-out narrow: a real permission or
+// transport failure must still become a coverage gap, never a silent negative.
+func TestIsAbsentConfigOnlyMatchesTheNamedCode(t *testing.T) {
+	absent := &smithy.GenericAPIError{Code: "NoSuchBucketPolicy", Message: "absent"}
+	if !isAbsentConfig(absent, "NoSuchBucketPolicy") {
+		t.Error("the named absence code was not recognized")
+	}
+	if isAbsentConfig(absent, "ServerSideEncryptionConfigurationNotFoundError") {
+		t.Error("an absence code matched a DIFFERENT configuration's code")
+	}
+	if isAbsentConfig(&smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"}, "NoSuchBucketPolicy") {
+		t.Error("AccessDenied was treated as an observed negative")
+	}
+	if isAbsentConfig(errors.New("connection reset"), "NoSuchBucketPolicy") {
+		t.Error("a transport error was treated as an observed negative")
 	}
 }

--- a/internal/infrastructure/cloudsandbox/executor.go
+++ b/internal/infrastructure/cloudsandbox/executor.go
@@ -40,6 +40,32 @@ func New(runner ports.ToolRunner, vault ports.CredentialVault, binary string, ra
 	return &Executor{runner: runner, vault: vault, binary: binary, rate: rate, timeout: timeout, maxOutput: maxOutput, egressHost: egressHosts}, nil
 }
 
+// diagnosticCap bounds how much helper stderr reaches an error message. The helper writes one
+// short reason line; anything longer is a malfunction and must not become an unbounded log write.
+const diagnosticCap = 512
+
+// diagnostic renders the helper's stderr as a bounded, credential-free error suffix. Without it a
+// failing helper surfaces only "exit_code=1", which says nothing about WHY posture enumeration
+// failed and makes an operator-fixable misconfiguration (bad role ARN, denied API, blocked egress)
+// indistinguishable from a crash. The credential is redacted first and, if any placeholder survives,
+// the text is dropped entirely rather than risking secret material in a log or API error.
+func diagnostic(stderr, secret []byte) string {
+	redacted := redact.Bytes(stderr, [][]byte{secret})
+	if strings.Contains(string(redacted), redact.Placeholder) {
+		return " reason=<redacted>"
+	}
+	reason := strings.TrimSpace(string(redacted))
+	if reason == "" {
+		return ""
+	}
+	if len(reason) > diagnosticCap {
+		reason = reason[:diagnosticCap] + "…"
+	}
+	// Collapse to a single line: these reasons land in structured logs and JSON error bodies.
+	reason = strings.Join(strings.Fields(reason), " ")
+	return " reason=" + reason
+}
+
 func (e *Executor) EnumerateCloud(ctx context.Context, scope ports.CloudScope) (cloudposture.Inventory, []cloudposture.CoverageIssue, error) {
 	if scope.Authorize == nil {
 		return cloudposture.Inventory{}, nil, fmt.Errorf("%w: cloud operation authorizer is required", shared.ErrForbidden)
@@ -142,7 +168,7 @@ func (e *Executor) EnumerateCloud(ctx context.Context, scope ports.CloudScope) (
 		return cloudposture.Inventory{}, nil, fmt.Errorf("sandboxed CSPM helper failed: %w", runErr)
 	}
 	if result.ExitCode != 0 || result.TimedOut || result.Truncated {
-		return cloudposture.Inventory{}, nil, fmt.Errorf("sandboxed CSPM helper failed: exit_code=%d timed_out=%t truncated=%t", result.ExitCode, result.TimedOut, result.Truncated)
+		return cloudposture.Inventory{}, nil, fmt.Errorf("sandboxed CSPM helper failed: exit_code=%d timed_out=%t truncated=%t%s", result.ExitCode, result.TimedOut, result.Truncated, diagnostic(result.Stderr, secret))
 	}
 	result.Stdout = redact.Bytes(result.Stdout, [][]byte{secret})
 	if strings.Contains(string(result.Stdout), redact.Placeholder) {

--- a/internal/infrastructure/cloudsandbox/executor.go
+++ b/internal/infrastructure/cloudsandbox/executor.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/cloudposture"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -44,13 +45,58 @@ func New(runner ports.ToolRunner, vault ports.CredentialVault, binary string, ra
 // short reason line; anything longer is a malfunction and must not become an unbounded log write.
 const diagnosticCap = 512
 
+// minScrubbableSecretLen is the shortest credential-field value scrubbed on its own. Provider
+// credential documents also carry SHORT structural values (a region, a provider name, "true"), and
+// scrubbing those would match ordinary prose in any diagnostic and drop every reason - silently
+// reverting the observability this file exists to provide. Real credential material is far longer:
+// an AWS access key id is 20 characters, a secret access key 40, session tokens and GCP/Azure keys
+// longer still.
+const minScrubbableSecretLen = 16
+
+// credentialSecrets decomposes resolved credential material into every value that must be scrubbed
+// INDEPENDENTLY. A provider credential is a JSON document holding several distinct secret-bearing
+// fields (an AWS document carries access_key_id, secret_access_key and session_token), and provider
+// SDK errors routinely echo exactly ONE of them in isolation - for example "The AWS Access Key Id
+// you provided does not exist in our records: AKIA...". Scrubbing only the whole document never
+// matches that substring, so the field would survive redaction, pass the placeholder check, and
+// reach a structured log or a JSON API error body.
+//
+// The document is treated as opaque provider-shaped JSON on purpose: this executor is
+// provider-agnostic and must not import a concrete connector's credential type.
+func credentialSecrets(secret []byte) [][]byte {
+	secrets := [][]byte{secret}
+	var document any
+	if err := json.Unmarshal(secret, &document); err != nil {
+		return secrets // opaque (non-JSON) credential: the whole blob is the only known value
+	}
+	var walk func(node any)
+	walk = func(node any) {
+		switch typed := node.(type) {
+		case map[string]any:
+			for _, value := range typed {
+				walk(value)
+			}
+		case []any:
+			for _, value := range typed {
+				walk(value)
+			}
+		case string:
+			if len(typed) >= minScrubbableSecretLen {
+				secrets = append(secrets, []byte(typed))
+			}
+		}
+	}
+	walk(document)
+	return secrets
+}
+
 // diagnostic renders the helper's stderr as a bounded, credential-free error suffix. Without it a
 // failing helper surfaces only "exit_code=1", which says nothing about WHY posture enumeration
 // failed and makes an operator-fixable misconfiguration (bad role ARN, denied API, blocked egress)
-// indistinguishable from a crash. The credential is redacted first and, if any placeholder survives,
-// the text is dropped entirely rather than risking secret material in a log or API error.
-func diagnostic(stderr, secret []byte) string {
-	redacted := redact.Bytes(stderr, [][]byte{secret})
+// indistinguishable from a crash. Every credential value is redacted first and, if any placeholder
+// survives, the text is dropped entirely rather than risking secret material in a log or API error.
+func diagnostic(stderr []byte, secrets [][]byte) string {
+	redacted := redact.Bytes(stderr, secrets)
 	if strings.Contains(string(redacted), redact.Placeholder) {
 		return " reason=<redacted>"
 	}
@@ -58,8 +104,14 @@ func diagnostic(stderr, secret []byte) string {
 	if reason == "" {
 		return ""
 	}
+	// Truncate on a RUNE boundary: a byte-offset cut can split a multi-byte rune and emit invalid
+	// UTF-8 into a structured log and a JSON error body, which strings.Fields below cannot repair.
 	if len(reason) > diagnosticCap {
-		reason = reason[:diagnosticCap] + "…"
+		cut := diagnosticCap
+		for cut > 0 && !utf8.ValidString(reason[:cut]) {
+			cut--
+		}
+		reason = reason[:cut] + "…"
 	}
 	// Collapse to a single line: these reasons land in structured logs and JSON error bodies.
 	reason = strings.Join(strings.Fields(reason), " ")
@@ -167,10 +219,13 @@ func (e *Executor) EnumerateCloud(ctx context.Context, scope ports.CloudScope) (
 	if runErr != nil {
 		return cloudposture.Inventory{}, nil, fmt.Errorf("sandboxed CSPM helper failed: %w", runErr)
 	}
+	// Scrub each credential FIELD independently, not just the whole document: a provider SDK error
+	// echoes one field in isolation, which never matches the blob.
+	secrets := credentialSecrets(secret)
 	if result.ExitCode != 0 || result.TimedOut || result.Truncated {
-		return cloudposture.Inventory{}, nil, fmt.Errorf("sandboxed CSPM helper failed: exit_code=%d timed_out=%t truncated=%t%s", result.ExitCode, result.TimedOut, result.Truncated, diagnostic(result.Stderr, secret))
+		return cloudposture.Inventory{}, nil, fmt.Errorf("sandboxed CSPM helper failed: exit_code=%d timed_out=%t truncated=%t%s", result.ExitCode, result.TimedOut, result.Truncated, diagnostic(result.Stderr, secrets))
 	}
-	result.Stdout = redact.Bytes(result.Stdout, [][]byte{secret})
+	result.Stdout = redact.Bytes(result.Stdout, secrets)
 	if strings.Contains(string(result.Stdout), redact.Placeholder) {
 		return cloudposture.Inventory{}, nil, errors.New("sandboxed CSPM output contained credential material")
 	}

--- a/internal/infrastructure/cloudsandbox/executor.go
+++ b/internal/infrastructure/cloudsandbox/executor.go
@@ -51,6 +51,13 @@ const diagnosticCap = 512
 // inventory (a GCP client_email and project_id, an Azure subscription_id, an AWS account id). Value
 // length cannot separate the two - a GCP client_email is long and public, an Azure client_secret may
 // be short and secret - so any length threshold both over- and under-matches.
+//
+// This is a name heuristic and it errs toward scrubbing: "key" also matches AWS access_key_id, which
+// is a semi-public identifier. That is deliberate - the current AWS connector enumerates IAM users,
+// not access keys, so nothing legitimately emits one. If a future connector enumerates access keys it
+// must rename the credential field or narrow this list, or a successful run will be rejected the way
+// an unfiltered GCP client_email once was. A provider that names a secret generically (a bare
+// "values" array) would likewise not be matched here; add a marker when one appears.
 var secretFieldMarkers = []string{"secret", "password", "passwd", "passphrase", "token", "private", "credential", "key"}
 
 // isSecretFieldName reports whether a JSON field name marks its value as secret material.
@@ -65,13 +72,15 @@ func isSecretFieldName(name string) bool {
 }
 
 // walkCredential calls visit for every string value in a credential document, with the field name it
-// was reached through (empty for array elements and the root). The document is treated as opaque
-// provider-shaped JSON on purpose: this executor is the shared sandbox path for every provider and
-// must not import a concrete connector's credential type.
-func walkCredential(secret []byte, visit func(name, value string)) bool {
+// was reached through (empty at the root). A non-JSON credential is opaque and yields no callbacks;
+// callers always seed their set with the whole blob, so an unparseable credential echoed wholesale is
+// still covered. The document is treated as opaque provider-shaped JSON on purpose: this executor is
+// the shared sandbox path for every provider and must not import a concrete connector's credential
+// type.
+func walkCredential(secret []byte, visit func(name, value string)) {
 	var document any
 	if err := json.Unmarshal(secret, &document); err != nil {
-		return false // opaque (non-JSON) credential: nothing to decompose
+		return
 	}
 	var walk func(name string, node any)
 	walk = func(name string, node any) {
@@ -82,14 +91,13 @@ func walkCredential(secret []byte, visit func(name, value string)) bool {
 			}
 		case []any:
 			for _, value := range typed {
-				walk(name, value) // array elements inherit the field they hang off
+				walk(name, value) // elements inherit the field the array hangs off
 			}
 		case string:
 			visit(name, typed)
 		}
 	}
 	walk("", document)
-	return true
 }
 
 // diagnosticSecrets is the scrub set for the DIAGNOSTIC sink: the whole document plus every string

--- a/internal/infrastructure/cloudsandbox/executor.go
+++ b/internal/infrastructure/cloudsandbox/executor.go
@@ -45,48 +45,89 @@ func New(runner ports.ToolRunner, vault ports.CredentialVault, binary string, ra
 // short reason line; anything longer is a malfunction and must not become an unbounded log write.
 const diagnosticCap = 512
 
-// minScrubbableSecretLen is the shortest credential-field value scrubbed on its own. Provider
-// credential documents also carry SHORT structural values (a region, a provider name, "true"), and
-// scrubbing those would match ordinary prose in any diagnostic and drop every reason - silently
-// reverting the observability this file exists to provide. Real credential material is far longer:
-// an AWS access key id is 20 characters, a secret access key 40, session tokens and GCP/Azure keys
-// longer still.
-const minScrubbableSecretLen = 16
+// secretFieldMarkers name a credential field whose VALUE is secret material rather than a public
+// identifier. Matching is on the field name, not the value: a credential document mixes secrets
+// (private_key, client_secret, session_token) with identifiers that legitimately appear in enumerated
+// inventory (a GCP client_email and project_id, an Azure subscription_id, an AWS account id). Value
+// length cannot separate the two - a GCP client_email is long and public, an Azure client_secret may
+// be short and secret - so any length threshold both over- and under-matches.
+var secretFieldMarkers = []string{"secret", "password", "passwd", "passphrase", "token", "private", "credential", "key"}
 
-// credentialSecrets decomposes resolved credential material into every value that must be scrubbed
-// INDEPENDENTLY. A provider credential is a JSON document holding several distinct secret-bearing
-// fields (an AWS document carries access_key_id, secret_access_key and session_token), and provider
-// SDK errors routinely echo exactly ONE of them in isolation - for example "The AWS Access Key Id
-// you provided does not exist in our records: AKIA...". Scrubbing only the whole document never
-// matches that substring, so the field would survive redaction, pass the placeholder check, and
-// reach a structured log or a JSON API error body.
-//
-// The document is treated as opaque provider-shaped JSON on purpose: this executor is
-// provider-agnostic and must not import a concrete connector's credential type.
-func credentialSecrets(secret []byte) [][]byte {
-	secrets := [][]byte{secret}
+// isSecretFieldName reports whether a JSON field name marks its value as secret material.
+func isSecretFieldName(name string) bool {
+	lowered := strings.ToLower(name)
+	for _, marker := range secretFieldMarkers {
+		if strings.Contains(lowered, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// walkCredential calls visit for every string value in a credential document, with the field name it
+// was reached through (empty for array elements and the root). The document is treated as opaque
+// provider-shaped JSON on purpose: this executor is the shared sandbox path for every provider and
+// must not import a concrete connector's credential type.
+func walkCredential(secret []byte, visit func(name, value string)) bool {
 	var document any
 	if err := json.Unmarshal(secret, &document); err != nil {
-		return secrets // opaque (non-JSON) credential: the whole blob is the only known value
+		return false // opaque (non-JSON) credential: nothing to decompose
 	}
-	var walk func(node any)
-	walk = func(node any) {
+	var walk func(name string, node any)
+	walk = func(name string, node any) {
 		switch typed := node.(type) {
 		case map[string]any:
-			for _, value := range typed {
-				walk(value)
+			for field, value := range typed {
+				walk(field, value)
 			}
 		case []any:
 			for _, value := range typed {
-				walk(value)
+				walk(name, value) // array elements inherit the field they hang off
 			}
 		case string:
-			if len(typed) >= minScrubbableSecretLen {
-				secrets = append(secrets, []byte(typed))
-			}
+			visit(name, typed)
 		}
 	}
-	walk(document)
+	walk("", document)
+	return true
+}
+
+// diagnosticSecrets is the scrub set for the DIAGNOSTIC sink: the whole document plus every string
+// value in it, whatever its name or length. Provider SDK errors echo exactly one field in isolation
+// ("The AWS Access Key Id you provided does not exist in our records: AKIA..."), which never matches
+// the whole document, so the field would otherwise survive redaction and reach a structured log or a
+// JSON API error body.
+//
+// This set is deliberately maximal. The only cost of a false match here is that diagnostic() drops
+// the reason text; the cost of a miss is credential disclosure. Every field is therefore in scope
+// regardless of length - an Azure client_secret is only validated non-empty, so a short secret must
+// not slip through a length threshold.
+func diagnosticSecrets(secret []byte) [][]byte {
+	secrets := [][]byte{secret}
+	walkCredential(secret, func(_, value string) {
+		if value != "" {
+			secrets = append(secrets, []byte(value))
+		}
+	})
+	return secrets
+}
+
+// outputSecrets is the scrub set for the helper's STDOUT: the whole document plus only the values
+// whose field name marks them as secret material.
+//
+// Stdout is load-bearing data, not a diagnostic - a placeholder hit REJECTS the whole enumeration -
+// so this set must not contain public identifiers the helper legitimately emits. A GCP credential's
+// client_email appears verbatim in enumerated IAM bindings and its project_id in every resource ID,
+// so scrubbing every field here would fail every GCP run with "output contained credential material"
+// after the helper had already succeeded. Real secret fields are still scrubbed at any length, and
+// the whole-document match still catches a wholesale echo of an unparseable credential.
+func outputSecrets(secret []byte) [][]byte {
+	secrets := [][]byte{secret}
+	walkCredential(secret, func(name, value string) {
+		if value != "" && isSecretFieldName(name) {
+			secrets = append(secrets, []byte(value))
+		}
+	})
 	return secrets
 }
 
@@ -104,8 +145,11 @@ func diagnostic(stderr []byte, secrets [][]byte) string {
 	if reason == "" {
 		return ""
 	}
-	// Truncate on a RUNE boundary: a byte-offset cut can split a multi-byte rune and emit invalid
-	// UTF-8 into a structured log and a JSON error body, which strings.Fields below cannot repair.
+	// Coerce to valid UTF-8 unconditionally, not only when truncating: a helper can emit a latin-1
+	// provider message or a partial write that is invalid UTF-8 well under the cap, and this string
+	// lands in a structured log and a JSON error body. ToValidUTF8 also makes the truncation below
+	// safe to do on a byte offset walked back to a rune boundary.
+	reason = strings.ToValidUTF8(reason, "�")
 	if len(reason) > diagnosticCap {
 		cut := diagnosticCap
 		for cut > 0 && !utf8.ValidString(reason[:cut]) {
@@ -219,13 +263,13 @@ func (e *Executor) EnumerateCloud(ctx context.Context, scope ports.CloudScope) (
 	if runErr != nil {
 		return cloudposture.Inventory{}, nil, fmt.Errorf("sandboxed CSPM helper failed: %w", runErr)
 	}
-	// Scrub each credential FIELD independently, not just the whole document: a provider SDK error
-	// echoes one field in isolation, which never matches the blob.
-	secrets := credentialSecrets(secret)
+	// The two sinks get DIFFERENT scrub sets because they tolerate a false match differently: a
+	// diagnostic can be dropped, but stdout is the enumeration result and a placeholder hit rejects
+	// the whole run. See diagnosticSecrets and outputSecrets.
 	if result.ExitCode != 0 || result.TimedOut || result.Truncated {
-		return cloudposture.Inventory{}, nil, fmt.Errorf("sandboxed CSPM helper failed: exit_code=%d timed_out=%t truncated=%t%s", result.ExitCode, result.TimedOut, result.Truncated, diagnostic(result.Stderr, secrets))
+		return cloudposture.Inventory{}, nil, fmt.Errorf("sandboxed CSPM helper failed: exit_code=%d timed_out=%t truncated=%t%s", result.ExitCode, result.TimedOut, result.Truncated, diagnostic(result.Stderr, diagnosticSecrets(secret)))
 	}
-	result.Stdout = redact.Bytes(result.Stdout, secrets)
+	result.Stdout = redact.Bytes(result.Stdout, outputSecrets(secret))
 	if strings.Contains(string(result.Stdout), redact.Placeholder) {
 		return cloudposture.Inventory{}, nil, errors.New("sandboxed CSPM output contained credential material")
 	}

--- a/internal/infrastructure/cloudsandbox/executor_test.go
+++ b/internal/infrastructure/cloudsandbox/executor_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/cloudposture"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -197,5 +198,97 @@ func TestDiagnosticBoundsAndNormalizesReason(t *testing.T) {
 	long := diagnostic([]byte(strings.Repeat("x", diagnosticCap*3)), nil)
 	if len(long) > diagnosticCap+len(" reason=")+len("…") {
 		t.Errorf("diagnostic(long) length = %d, want bounded by diagnosticCap", len(long))
+	}
+}
+
+// TestExecutorRedactsIndividualCredentialFields is the review finding this file previously missed.
+// A provider credential is a JSON document with several secret-bearing fields, and provider SDK
+// errors echo exactly ONE of them in isolation ("The AWS Access Key Id you provided does not exist
+// in our records: AKIA..."). Scrubbing only the whole document never matches that substring, so the
+// field survived redaction, passed the placeholder check, and reached the returned error - which by
+// diagnostic's own contract lands in structured logs and JSON API error bodies.
+func TestExecutorRedactsIndividualCredentialFields(t *testing.T) {
+	const (
+		accessKeyID = "AKIAIOSFODNN7EXAMPLE"
+		secretKey   = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY123"
+		sessionTok  = "FwoGZXIvYXdzEBYaDEXAMPLESESSIONTOKENVALUE"
+	)
+	document := `{"access_key_id":"` + accessKeyID + `","secret_access_key":"` + secretKey +
+		`","session_token":"` + sessionTok + `","role_arn_template":"arn:aws:iam::{account_id}:role/Reader"}`
+
+	for _, tc := range []struct {
+		name   string
+		stderr string
+		leaked string
+	}{
+		{"access key id alone", "The AWS Access Key Id you provided does not exist in our records: " + accessKeyID, accessKeyID},
+		{"secret access key alone", "signature mismatch for key " + secretKey, secretKey},
+		{"session token alone", "expired session token " + sessionTok, sessionTok},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &runnerStub{result: ports.ToolResult{ExitCode: 1, Stderr: []byte(tc.stderr)}}
+			executor, err := New(runner, secretVault{secret: []byte(document)}, "synapse-cspm", 5, time.Minute, 1<<20, map[cloudposture.Provider][]string{cloudposture.ProviderAWS: {"organizations.us-east-1.amazonaws.com"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _, err = executor.EnumerateCloud(context.Background(), ports.CloudScope{EngagementID: "eng", Provider: cloudposture.ProviderAWS, Root: "o-test", ScopeKey: "aws:organizations/o-test", CredentialRef: "aws-prod", Authorize: func(context.Context, ports.CloudOperation) error { return nil }})
+			if err == nil {
+				t.Fatal("expected a helper failure")
+			}
+			if strings.Contains(err.Error(), tc.leaked) {
+				t.Fatalf("credential field leaked into the error message: %v", err)
+			}
+			if !strings.Contains(err.Error(), "reason=<redacted>") {
+				t.Errorf("error = %v, want the reason dropped once a credential field is detected", err)
+			}
+		})
+	}
+}
+
+// TestCredentialSecretsDecomposesTheDocument pins the decomposition contract: every long field is
+// scrubbable on its own, the whole blob stays in the set, short structural values are excluded (they
+// would match ordinary prose and drop every diagnostic), and a non-JSON credential is still covered.
+func TestCredentialSecretsDecomposesTheDocument(t *testing.T) {
+	document := []byte(`{"access_key_id":"AKIAIOSFODNN7EXAMPLE","region":"us-east-1","enabled":true,"nested":{"token":"FwoGZXIvYXdzEBYaDEXAMPLESESSIONTOKEN"}}`)
+	got := credentialSecrets(document)
+	has := func(want string) bool {
+		for _, secret := range got {
+			if string(secret) == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has(string(document)) {
+		t.Error("the whole credential document must remain in the scrub set")
+	}
+	if !has("AKIAIOSFODNN7EXAMPLE") {
+		t.Error("a top-level credential field was not decomposed")
+	}
+	if !has("FwoGZXIvYXdzEBYaDEXAMPLESESSIONTOKEN") {
+		t.Error("a nested credential field was not decomposed")
+	}
+	if has("us-east-1") {
+		t.Error("a short structural value was scrubbed; that matches ordinary prose and drops every diagnostic")
+	}
+	if opaque := credentialSecrets([]byte("not-json-credential-material")); len(opaque) != 1 {
+		t.Errorf("opaque credential produced %d secrets, want just the blob", len(opaque))
+	}
+}
+
+// TestDiagnosticTruncatesOnARuneBoundary keeps the suffix valid UTF-8. A byte-offset cut can split a
+// multi-byte rune and emit invalid UTF-8 into a structured log and a JSON error body, and the
+// strings.Fields pass afterwards does not repair it.
+func TestDiagnosticTruncatesOnARuneBoundary(t *testing.T) {
+	// "é" is two bytes, so a diagnosticCap-byte cut lands mid-rune for some repetition counts.
+	for _, filler := range []string{"é", "字", "🔒"} {
+		reason := strings.Repeat(filler, diagnosticCap)
+		got := diagnostic([]byte(reason), nil)
+		if !utf8.ValidString(got) {
+			t.Errorf("diagnostic(%q...) produced invalid UTF-8", filler)
+		}
+		if len(got) > diagnosticCap+len(" reason=")+len("…") {
+			t.Errorf("diagnostic(%q...) length = %d, want bounded", filler, len(got))
+		}
 	}
 }

--- a/internal/infrastructure/cloudsandbox/executor_test.go
+++ b/internal/infrastructure/cloudsandbox/executor_test.go
@@ -126,3 +126,76 @@ func (nilVault) Resolve(context.Context, shared.ID, string) ([]byte, error)     
 func (nilVault) Put(context.Context, shared.ID, string, []byte) error            { return nil }
 func (nilVault) List(context.Context, shared.ID) ([]ports.CredentialMeta, error) { return nil, nil }
 func (nilVault) Delete(context.Context, shared.ID, string) error                 { return nil }
+
+// secretVault hands out real credential material so the redaction path is exercised for real
+// rather than against nilVault's empty secret.
+type secretVault struct{ secret []byte }
+
+func (v secretVault) Resolve(context.Context, shared.ID, string) ([]byte, error) {
+	return append([]byte(nil), v.secret...), nil
+}
+func (secretVault) Put(context.Context, shared.ID, string, []byte) error            { return nil }
+func (secretVault) List(context.Context, shared.ID) ([]ports.CredentialMeta, error) { return nil, nil }
+func (secretVault) Delete(context.Context, shared.ID, string) error                 { return nil }
+
+// TestExecutorSurfacesHelperStderr pins the helper's failure REASON onto the error. The executor
+// used to report only "exit_code=1", so an operator-fixable misconfiguration (unassumable role,
+// denied API, blocked egress) was indistinguishable from a crash: the durable run dead-lettered
+// after three attempts with no recorded cause anywhere in the worker log or the run row.
+func TestExecutorSurfacesHelperStderr(t *testing.T) {
+	runner := &runnerStub{result: ports.ToolResult{ExitCode: 1, Stderr: []byte("enumerate accounts: AccessDenied\n")}}
+	executor, err := New(runner, nilVault{}, "synapse-cspm", 5, time.Minute, 1<<20, map[cloudposture.Provider][]string{cloudposture.ProviderAWS: {"organizations.us-east-1.amazonaws.com"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = executor.EnumerateCloud(context.Background(), ports.CloudScope{EngagementID: "eng", Provider: cloudposture.ProviderAWS, Root: "o-test", ScopeKey: "aws:organizations/o-test", CredentialRef: "aws-prod", Authorize: func(context.Context, ports.CloudOperation) error { return nil }})
+	if err == nil {
+		t.Fatal("expected a helper failure")
+	}
+	if !strings.Contains(err.Error(), "exit_code=1") {
+		t.Errorf("error = %v, want the exit code preserved", err)
+	}
+	if !strings.Contains(err.Error(), "reason=enumerate accounts: AccessDenied") {
+		t.Errorf("error = %v, want the helper's stderr reason", err)
+	}
+}
+
+// TestExecutorNeverLeaksCredentialsThroughStderr is the other half of the contract: stderr is
+// attacker-influenced, untrusted output on a credentialed path, so a helper that echoes its own
+// credential must not turn an error message into a secret sink.
+func TestExecutorNeverLeaksCredentialsThroughStderr(t *testing.T) {
+	const secret = "AKIAEXAMPLECANARY"
+	runner := &runnerStub{result: ports.ToolResult{ExitCode: 1, Stderr: []byte("failed for key " + secret)}}
+	executor, err := New(runner, secretVault{secret: []byte(secret)}, "synapse-cspm", 5, time.Minute, 1<<20, map[cloudposture.Provider][]string{cloudposture.ProviderAWS: {"organizations.us-east-1.amazonaws.com"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = executor.EnumerateCloud(context.Background(), ports.CloudScope{EngagementID: "eng", Provider: cloudposture.ProviderAWS, Root: "o-test", ScopeKey: "aws:organizations/o-test", CredentialRef: "aws-prod", Authorize: func(context.Context, ports.CloudOperation) error { return nil }})
+	if err == nil {
+		t.Fatal("expected a helper failure")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatal("credential material leaked into the error message")
+	}
+	if !strings.Contains(err.Error(), "reason=<redacted>") {
+		t.Errorf("error = %v, want the reason dropped once a placeholder survives", err)
+	}
+}
+
+// TestDiagnosticBoundsAndNormalizesReason keeps the suffix log-safe: empty stderr adds nothing, and
+// a malfunctioning helper cannot emit an unbounded multi-line blob into a structured log field.
+func TestDiagnosticBoundsAndNormalizesReason(t *testing.T) {
+	if got := diagnostic(nil, nil); got != "" {
+		t.Errorf("diagnostic(nil) = %q, want empty", got)
+	}
+	if got := diagnostic([]byte("  \n\t "), nil); got != "" {
+		t.Errorf("diagnostic(whitespace) = %q, want empty", got)
+	}
+	if got := diagnostic([]byte("first line\nsecond line"), nil); got != " reason=first line second line" {
+		t.Errorf("diagnostic(multiline) = %q, want a single line", got)
+	}
+	long := diagnostic([]byte(strings.Repeat("x", diagnosticCap*3)), nil)
+	if len(long) > diagnosticCap+len(" reason=")+len("…") {
+		t.Errorf("diagnostic(long) length = %d, want bounded by diagnosticCap", len(long))
+	}
+}

--- a/internal/infrastructure/cloudsandbox/executor_test.go
+++ b/internal/infrastructure/cloudsandbox/executor_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/cloudposture"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -20,6 +21,9 @@ type runnerStub struct {
 	result    ports.ToolResult
 	err       error
 	operation ports.CloudOperation
+	// passthroughStdout returns result.Stdout verbatim instead of the canned inventory, so a test can
+	// drive the executor's own stdout scrub over chosen helper output.
+	passthroughStdout bool
 }
 
 func (r *runnerStub) Run(_ context.Context, spec ports.ToolSpec) (ports.ToolResult, error) {
@@ -46,6 +50,9 @@ func (r *runnerStub) Run(_ context.Context, spec ports.ToolSpec) (ports.ToolResu
 		return ports.ToolResult{}, r.err
 	}
 	if r.result.ExitCode != 0 || r.result.TimedOut || r.result.Truncated {
+		return r.result, nil
+	}
+	if r.passthroughStdout {
 		return r.result, nil
 	}
 	return ports.ToolResult{Stdout: out}, nil
@@ -245,34 +252,99 @@ func TestExecutorRedactsIndividualCredentialFields(t *testing.T) {
 	}
 }
 
-// TestCredentialSecretsDecomposesTheDocument pins the decomposition contract: every long field is
-// scrubbable on its own, the whole blob stays in the set, short structural values are excluded (they
-// would match ordinary prose and drop every diagnostic), and a non-JSON credential is still covered.
-func TestCredentialSecretsDecomposesTheDocument(t *testing.T) {
-	document := []byte(`{"access_key_id":"AKIAIOSFODNN7EXAMPLE","region":"us-east-1","enabled":true,"nested":{"token":"FwoGZXIvYXdzEBYaDEXAMPLESESSIONTOKEN"}}`)
-	got := credentialSecrets(document)
-	has := func(want string) bool {
-		for _, secret := range got {
-			if string(secret) == want {
-				return true
-			}
+// has reports whether the scrub set contains an exact value.
+func hasSecret(secrets [][]byte, want string) bool {
+	for _, secret := range secrets {
+		if string(secret) == want {
+			return true
 		}
-		return false
 	}
-	if !has(string(document)) {
-		t.Error("the whole credential document must remain in the scrub set")
+	return false
+}
+
+// gcpCredential mirrors a real GCP service-account key: PUBLIC identifiers (client_email, project_id)
+// sitting next to actual secret material (private_key).
+const gcpCredential = `{"type":"service_account","project_id":"synapse-e2e-project","private_key":"-----BEGIN PRIVATE KEY-----MIIEvQIBADANBg-----END PRIVATE KEY-----","client_email":"synapse-cspm@synapse-e2e-project.iam.gserviceaccount.com","client_id":"114857320991827364550"}`
+
+// TestDiagnosticSecretsCoversEveryFieldAtAnyLength pins the DIAGNOSTIC set as maximal. A provider SDK
+// error echoes one field in isolation, which never matches the whole document, and the only cost of a
+// false match here is that the reason text is dropped. Length must not gate membership: an Azure
+// client_secret is validated non-empty only, so a SHORT secret has to be covered too.
+func TestDiagnosticSecretsCoversEveryFieldAtAnyLength(t *testing.T) {
+	document := []byte(`{"tenant_id":"t","client_id":"c","client_secret":"sh0rt","subscription_id":"sub-1234"}`)
+	got := diagnosticSecrets(document)
+	if !hasSecret(got, string(document)) {
+		t.Error("the whole credential document must stay in the scrub set")
 	}
-	if !has("AKIAIOSFODNN7EXAMPLE") {
-		t.Error("a top-level credential field was not decomposed")
+	for _, value := range []string{"sh0rt", "sub-1234", "t", "c"} {
+		if !hasSecret(got, value) {
+			t.Errorf("field value %q is not scrubbed in a diagnostic; a short secret must not slip a length threshold", value)
+		}
 	}
-	if !has("FwoGZXIvYXdzEBYaDEXAMPLESESSIONTOKEN") {
-		t.Error("a nested credential field was not decomposed")
+	// Nested and array-wrapped values are reached too.
+	nested := diagnosticSecrets([]byte(`{"outer":{"session_token":"nested-token"},"list":["listed-token"]}`))
+	if !hasSecret(nested, "nested-token") || !hasSecret(nested, "listed-token") {
+		t.Errorf("nested/array credential values were not decomposed: %q", nested)
 	}
-	if has("us-east-1") {
-		t.Error("a short structural value was scrubbed; that matches ordinary prose and drops every diagnostic")
-	}
-	if opaque := credentialSecrets([]byte("not-json-credential-material")); len(opaque) != 1 {
+	if opaque := diagnosticSecrets([]byte("not-json-credential-material")); len(opaque) != 1 {
 		t.Errorf("opaque credential produced %d secrets, want just the blob", len(opaque))
+	}
+}
+
+// TestOutputSecretsExcludesPublicIdentifiers pins the STDOUT set as narrow, and is the regression
+// guard for the review finding that a maximal set breaks every GCP run. Stdout is the enumeration
+// result, not a diagnostic: a placeholder hit REJECTS the run. A GCP client_email appears verbatim in
+// enumerated IAM bindings and project_id in every resource ID, so scrubbing them would fail a
+// successful enumeration with "output contained credential material".
+func TestOutputSecretsExcludesPublicIdentifiers(t *testing.T) {
+	got := outputSecrets([]byte(gcpCredential))
+	if !hasSecret(got, string(gcpCredential)) {
+		t.Error("the whole credential document must stay in the scrub set")
+	}
+	if !hasSecret(got, "-----BEGIN PRIVATE KEY-----MIIEvQIBADANBg-----END PRIVATE KEY-----") {
+		t.Error("private_key is real secret material and must be scrubbed from stdout")
+	}
+	for _, public := range []string{
+		"synapse-cspm@synapse-e2e-project.iam.gserviceaccount.com", // appears in enumerated IAM bindings
+		"synapse-e2e-project", // appears in every resource ID
+		"service_account",
+	} {
+		if hasSecret(got, public) {
+			t.Errorf("public identifier %q is scrubbed from stdout; that rejects a successful enumeration", public)
+		}
+	}
+}
+
+// TestOutputScrubKeepsLegitimateInventory drives the full executor: a helper that emits its own
+// client_email and project_id in normal inventory - exactly what the GCP connector does - must still
+// have its output accepted.
+func TestOutputScrubKeepsLegitimateInventory(t *testing.T) {
+	inventory, err := json.Marshal(struct {
+		Inventory cloudposture.Inventory       `json:"inventory"`
+		Coverage  []cloudposture.CoverageIssue `json:"coverage"`
+	}{Inventory: cloudposture.Inventory{
+		Provider: cloudposture.ProviderAWS, ScopeKey: "aws:organizations/o-test", Complete: true,
+		Resources: []cloudposture.Resource{{
+			Provider: cloudposture.ProviderAWS,
+			ID:       "projects/synapse-e2e-project/iam/roles~owner/serviceAccount:synapse-cspm@synapse-e2e-project.iam.gserviceaccount.com",
+			Name:     "synapse-cspm@synapse-e2e-project.iam.gserviceaccount.com",
+			Kind:     asset.KindIdentity,
+		}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &runnerStub{result: ports.ToolResult{Stdout: inventory}, passthroughStdout: true}
+	executor, err := New(runner, secretVault{secret: []byte(gcpCredential)}, "synapse-cspm", 5, time.Minute, 1<<20, map[cloudposture.Provider][]string{cloudposture.ProviderAWS: {"organizations.us-east-1.amazonaws.com"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := executor.EnumerateCloud(context.Background(), ports.CloudScope{EngagementID: "eng", Provider: cloudposture.ProviderAWS, Root: "o-test", ScopeKey: "aws:organizations/o-test", CredentialRef: "gcp-prod", Authorize: func(context.Context, ports.CloudOperation) error { return nil }})
+	if err != nil {
+		t.Fatalf("legitimate inventory was rejected: %v", err)
+	}
+	if len(got.Resources) != 1 || got.Resources[0].Name == "" {
+		t.Fatalf("inventory = %#v, want the enumerated identity preserved", got.Resources)
 	}
 }
 

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -77,8 +77,12 @@ func (c *Client) BaseURL() string { return c.base }
 // --- wire types (OpenAI Chat Completions shape) ---
 
 type wireReq struct {
-	Model               string       `json:"model"`
-	Messages            []wireMsg    `json:"messages"`
+	Model    string    `json:"model"`
+	Messages []wireMsg `json:"messages"`
+	// Stream is always false and always sent: this client decodes a single non-streaming
+	// JSON body. Some OpenAI-compatible gateways default to text/event-stream when the field
+	// is absent, which makes the response undecodable here, so the intent must be explicit.
+	Stream              bool         `json:"stream"`
 	Tools               []wireTool   `json:"tools,omitempty"`
 	ToolChoice          string       `json:"tool_choice,omitempty"`
 	ResponseFormat      *wireRespFmt `json:"response_format,omitempty"`

--- a/internal/infrastructure/llm/openai/client_test.go
+++ b/internal/infrastructure/llm/openai/client_test.go
@@ -101,6 +101,24 @@ func TestChatTerminalOnBadRequest(t *testing.T) {
 // explicit temperature 0 (greedy decoding) must reach the provider. Dropping it silently falls back to
 // the provider default (~1.0), which is the difference between a reproducible verdict and a sampled one
 // — the FP-triage proposer/verifier and the judgment verifier all ask for 0.
+// TestChatRequestsNonStreamingResponse pins that the adapter always sends stream:false.
+// This client decodes ONE non-streaming JSON body, but several OpenAI-compatible gateways
+// default to text/event-stream when the field is absent. Omitting it made every LLM call fail
+// with "decode provider response: invalid character 'd' looking for beginning of value"
+// (the 'd' of the SSE "data:" prefix), which halted agent sessions and AI triage.
+func TestChatRequestsNonStreamingResponse(t *testing.T) {
+	body := captureChatBody(t, ports.ChatRequest{
+		Messages: []agent.Message{{Role: agent.RoleUser, Content: "hi"}},
+	})
+	got, ok := body["stream"]
+	if !ok {
+		t.Fatal("stream omitted; a gateway defaulting to SSE returns an undecodable body")
+	}
+	if got != false {
+		t.Errorf("stream = %v, want false (this client cannot parse an SSE stream)", got)
+	}
+}
+
 func TestChatSendsExplicitTemperatureZero(t *testing.T) {
 	body := captureChatBody(t, ports.ChatRequest{
 		Temperature: ports.Temp(0),

--- a/internal/infrastructure/llm/openai/client_test.go
+++ b/internal/infrastructure/llm/openai/client_test.go
@@ -97,10 +97,6 @@ func TestChatTerminalOnBadRequest(t *testing.T) {
 	}
 }
 
-// TestChatSendsExplicitTemperatureZero pins the wire contract deterministic callers depend on: an
-// explicit temperature 0 (greedy decoding) must reach the provider. Dropping it silently falls back to
-// the provider default (~1.0), which is the difference between a reproducible verdict and a sampled one
-// — the FP-triage proposer/verifier and the judgment verifier all ask for 0.
 // TestChatRequestsNonStreamingResponse pins that the adapter always sends stream:false.
 // This client decodes ONE non-streaming JSON body, but several OpenAI-compatible gateways
 // default to text/event-stream when the field is absent. Omitting it made every LLM call fail
@@ -119,6 +115,10 @@ func TestChatRequestsNonStreamingResponse(t *testing.T) {
 	}
 }
 
+// TestChatSendsExplicitTemperatureZero pins the wire contract deterministic callers depend on: an
+// explicit temperature 0 (greedy decoding) must reach the provider. Dropping it silently falls back to
+// the provider default (~1.0), which is the difference between a reproducible verdict and a sampled one
+// — the FP-triage proposer/verifier and the judgment verifier all ask for 0.
 func TestChatSendsExplicitTemperatureZero(t *testing.T) {
 	body := captureChatBody(t, ports.ChatRequest{
 		Temperature: ports.Temp(0),

--- a/internal/infrastructure/sandbox/runner.go
+++ b/internal/infrastructure/sandbox/runner.go
@@ -87,12 +87,24 @@ var curatedEtc = []string{
 // needs no extra bind; anything else must be bound explicitly.
 var curatedRoot = []string{"/usr", "/bin", "/sbin", "/lib", "/lib64"}
 
-// resolveToolPath resolves a tool name to its absolute on-disk path via PATH, returning the name
-// unchanged when it cannot be resolved (bwrap then surfaces the not-found). This runs on EVERY path,
-// not only when integrity verification is enabled: bwrapArgs binds the binary only when it is
-// absolute, so a bare name left unresolved emits no bind and any helper outside the curated root
-// dies with "bwrap: execvp ...: No such file or directory".
-func resolveToolPath(name string) string {
+// resolveToolPath resolves a tool name to its absolute on-disk path, returning the name unchanged
+// when it cannot be resolved (bwrap then surfaces the not-found).
+//
+// An ALREADY-ABSOLUTE name is returned as given and needs no PATH lookup: it is operator authority
+// (the documented /opt/synapse/bin/synapse-cspm layout), which is what makes it bindable below.
+//
+// A bare name is resolved through the host PATH only when the caller will integrity-verify the
+// result (verify=true). Host PATH is not an authority for what may be bound into the sandbox: with
+// verification off, resolving it would let an inherited PATH entry such as /tmp/attacker/tool be
+// resolved on the host and then explicitly bound in, where previously bwrap resolved the bare name
+// against the sandbox's own curated PATH and a binary outside the curated root failed closed.
+func resolveToolPath(name string, verify bool) string {
+	if strings.HasPrefix(name, "/") || filepath.IsAbs(name) {
+		return name
+	}
+	if !verify {
+		return name // unverified bare name: leave it for bwrap to resolve inside the sandbox
+	}
 	if resolved, err := exec.LookPath(name); err == nil {
 		return resolved
 	}
@@ -194,13 +206,11 @@ func (r *Runner) Run(ctx context.Context, spec ports.ToolSpec) (ports.ToolResult
 		return ports.ToolResult{}, fmt.Errorf("%w: build seccomp filter: %v", shared.ErrValidation, serr)
 	}
 	defer func() { _ = seccompF.Close() }()
-	// Resolve the tool to an absolute on-disk path FIRST, independently of integrity verification.
-	// bwrapArgs binds the binary only when it is absolute and outside the curated root, so leaving a
-	// bare name unresolved in the legacy PATH-trust mode (binreg == nil) emits no bind and returns
-	// the original "bwrap: execvp ...: No such file or directory" for any helper installed outside
-	// /usr, /bin, /sbin or /lib. Resolving here also means bwrap never re-resolves spec.Name via
-	// PATH to a possibly-different binary (closing the verify-path != exec-path gap below).
-	spec.Name = resolveToolPath(spec.Name)
+	// Settle the exec path BEFORE verification, so the path that is verified is the path that is
+	// bound and executed (closing the verify-path != exec-path gap). An absolute name is kept as
+	// given - that is the operator-configured helper the bind below exists for. A bare name is only
+	// resolved through the host PATH when it will also be verified; see resolveToolPath.
+	spec.Name = resolveToolPath(spec.Name, r.binreg != nil)
 	// F5: verify the tool binary's integrity before it runs. The resolved on-disk binary
 	// must match its pin (operator hash and/or trust-on-first-use); a replaced binary is
 	// refused. Defends the "compromised tool binary" threat the audit named.
@@ -453,14 +463,13 @@ func (r *Runner) bwrapArgs(spec ports.ToolSpec, sharedNet bool, hostsFile string
 		// Isolated mode: fresh netns too – default-deny egress by construction (E9 default).
 		args = append(args, "--unshare-all")
 	}
-	// Bind the tool binary ITSELF when it lives outside the curated root. Run() resolves and
-	// integrity-verifies an absolute path, but the curated root deliberately omits /opt, /srv and
-	// friends so host secrets stay ENOENT - which also made every owned helper installed there
-	// (the documented /opt/synapse/bin/synapse-cspm layout) die with
-	// "bwrap: execvp ...: No such file or directory". Bind the single verified FILE read-only,
-	// never its directory, so nothing else in that tree becomes visible.
-	// These are LINUX container paths, so the check is POSIX by construction: filepath.IsAbs is
-	// false for "/opt/..." on Windows, where this argv builder is still unit-tested.
+	// Bind the tool binary ITSELF when it lives outside the curated root. The curated root
+	// deliberately omits /opt, /srv and friends so host secrets stay ENOENT, which also made every
+	// owned helper installed there (the documented /opt/synapse/bin/synapse-cspm layout) die with
+	// "bwrap: execvp ...: No such file or directory". Bind the single resolved FILE read-only, never
+	// its directory, so nothing else in that tree becomes visible. Only an absolute path is bound,
+	// and resolveToolPath keeps the host PATH from making a bare name absolute unless it is also
+	// integrity-verified - so what gets bound is operator authority, not an inherited PATH entry.
 	if bin := strings.TrimSpace(spec.Name); strings.HasPrefix(bin, "/") && !underCuratedRoot(bin) {
 		args = append(args, "--ro-bind-try", bin, bin)
 	}

--- a/internal/infrastructure/sandbox/runner.go
+++ b/internal/infrastructure/sandbox/runner.go
@@ -87,23 +87,27 @@ var curatedEtc = []string{
 // needs no extra bind; anything else must be bound explicitly.
 var curatedRoot = []string{"/usr", "/bin", "/sbin", "/lib", "/lib64"}
 
-// resolveToolPath resolves a tool name to its absolute on-disk path, returning the name unchanged
-// when it cannot be resolved (bwrap then surfaces the not-found).
+// resolveToolPath settles the path bwrap will bind and exec. It returns the name unchanged whenever
+// it must not or cannot be resolved, in which case bwrap resolves it inside the sandbox and surfaces
+// any not-found itself.
 //
-// An ALREADY-ABSOLUTE name is returned as given and needs no PATH lookup: it is operator authority
-// (the documented /opt/synapse/bin/synapse-cspm layout), which is what makes it bindable below.
+// An ALREADY-ABSOLUTE name is returned as given and needs no lookup: it is operator authority (the
+// documented /opt/synapse/bin/synapse-cspm layout), which is what makes it bindable.
 //
-// A bare name is resolved through the host PATH only when the caller will integrity-verify the
-// result (verify=true). Host PATH is not an authority for what may be bound into the sandbox: with
-// verification off, resolving it would let an inherited PATH entry such as /tmp/attacker/tool be
-// resolved on the host and then explicitly bound in, where previously bwrap resolved the bare name
-// against the sandbox's own curated PATH and a binary outside the curated root failed closed.
-func resolveToolPath(name string, verify bool) string {
+// A bare name is resolved through the host PATH only when hostPATHIsAuthority is set, which callers
+// tie to integrity verification being enabled. Host PATH is otherwise NOT an authority for what may
+// be bound into the sandbox: resolving it unconditionally would let an inherited entry such as
+// /tmp/attacker/tool be resolved on the host and then explicitly bound in, where bwrap would instead
+// resolve the bare name against the sandbox's own curated PATH and a binary outside the curated root
+// would fail closed.
+func resolveToolPath(name string, hostPATHIsAuthority bool) string {
+	// A Linux container path is absolute even when this argv builder runs on a Windows host, where
+	// filepath.IsAbs("/opt/...") is false.
 	if strings.HasPrefix(name, "/") || filepath.IsAbs(name) {
 		return name
 	}
-	if !verify {
-		return name // unverified bare name: leave it for bwrap to resolve inside the sandbox
+	if !hostPATHIsAuthority {
+		return name
 	}
 	if resolved, err := exec.LookPath(name); err == nil {
 		return resolved
@@ -208,9 +212,10 @@ func (r *Runner) Run(ctx context.Context, spec ports.ToolSpec) (ports.ToolResult
 	defer func() { _ = seccompF.Close() }()
 	// Settle the exec path BEFORE verification, so the path that is verified is the path that is
 	// bound and executed (closing the verify-path != exec-path gap). An absolute name is kept as
-	// given - that is the operator-configured helper the bind below exists for. A bare name is only
-	// resolved through the host PATH when it will also be verified; see resolveToolPath.
-	spec.Name = resolveToolPath(spec.Name, r.binreg != nil)
+	// given - that is the operator-configured helper the bind below exists for. The host PATH counts
+	// as an authority for a bare name only when that name will also be integrity-verified.
+	hostPATHIsAuthority := r.binreg != nil
+	spec.Name = resolveToolPath(spec.Name, hostPATHIsAuthority)
 	// F5: verify the tool binary's integrity before it runs. The resolved on-disk binary
 	// must match its pin (operator hash and/or trust-on-first-use); a replaced binary is
 	// refused. Defends the "compromised tool binary" threat the audit named.

--- a/internal/infrastructure/sandbox/runner.go
+++ b/internal/infrastructure/sandbox/runner.go
@@ -25,6 +25,7 @@ import (
 	"net/netip"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -80,6 +81,23 @@ var curatedEtc = []string{
 	"/etc/passwd", "/etc/group", // account NAMES only (no shadow)
 	"/etc/ld.so.cache", "/etc/ld.so.conf", "/etc/ld.so.conf.d", "/etc/alternatives",
 	"/etc/localtime", "/etc/mime.types", "/etc/gitconfig", "/etc/xdg",
+}
+
+// curatedRoot lists the OS trees bwrapArgs already binds read-only. A tool inside one of them
+// needs no extra bind; anything else must be bound explicitly.
+var curatedRoot = []string{"/usr", "/bin", "/sbin", "/lib", "/lib64"}
+
+// underCuratedRoot reports whether an absolute path already lives inside the curated read-only
+// root. Matching is segment-aligned so "/libexec/evil" is not mistaken for "/lib".
+func underCuratedRoot(p string) bool {
+	// path, not path/filepath: these are Linux container paths regardless of the host GOOS.
+	clean := path.Clean(p)
+	for _, root := range curatedRoot {
+		if clean == root || strings.HasPrefix(clean, root+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // SetBinaryRegistry enables tool-binary integrity verification (F5): before each run the
@@ -422,6 +440,17 @@ func (r *Runner) bwrapArgs(spec ports.ToolSpec, sharedNet bool, hostsFile string
 	} else {
 		// Isolated mode: fresh netns too – default-deny egress by construction (E9 default).
 		args = append(args, "--unshare-all")
+	}
+	// Bind the tool binary ITSELF when it lives outside the curated root. Run() resolves and
+	// integrity-verifies an absolute path, but the curated root deliberately omits /opt, /srv and
+	// friends so host secrets stay ENOENT - which also made every owned helper installed there
+	// (the documented /opt/synapse/bin/synapse-cspm layout) die with
+	// "bwrap: execvp ...: No such file or directory". Bind the single verified FILE read-only,
+	// never its directory, so nothing else in that tree becomes visible.
+	// These are LINUX container paths, so the check is POSIX by construction: filepath.IsAbs is
+	// false for "/opt/..." on Windows, where this argv builder is still unit-tested.
+	if bin := strings.TrimSpace(spec.Name); strings.HasPrefix(bin, "/") && !underCuratedRoot(bin) {
+		args = append(args, "--ro-bind-try", bin, bin)
 	}
 	for _, p := range spec.ReadOnlyPaths {
 		if strings.TrimSpace(p) != "" {

--- a/internal/infrastructure/sandbox/runner.go
+++ b/internal/infrastructure/sandbox/runner.go
@@ -87,6 +87,18 @@ var curatedEtc = []string{
 // needs no extra bind; anything else must be bound explicitly.
 var curatedRoot = []string{"/usr", "/bin", "/sbin", "/lib", "/lib64"}
 
+// resolveToolPath resolves a tool name to its absolute on-disk path via PATH, returning the name
+// unchanged when it cannot be resolved (bwrap then surfaces the not-found). This runs on EVERY path,
+// not only when integrity verification is enabled: bwrapArgs binds the binary only when it is
+// absolute, so a bare name left unresolved emits no bind and any helper outside the curated root
+// dies with "bwrap: execvp ...: No such file or directory".
+func resolveToolPath(name string) string {
+	if resolved, err := exec.LookPath(name); err == nil {
+		return resolved
+	}
+	return name
+}
+
 // underCuratedRoot reports whether an absolute path already lives inside the curated read-only
 // root. Matching is segment-aligned so "/libexec/evil" is not mistaken for "/lib".
 func underCuratedRoot(p string) bool {
@@ -182,20 +194,20 @@ func (r *Runner) Run(ctx context.Context, spec ports.ToolSpec) (ports.ToolResult
 		return ports.ToolResult{}, fmt.Errorf("%w: build seccomp filter: %v", shared.ErrValidation, serr)
 	}
 	defer func() { _ = seccompF.Close() }()
+	// Resolve the tool to an absolute on-disk path FIRST, independently of integrity verification.
+	// bwrapArgs binds the binary only when it is absolute and outside the curated root, so leaving a
+	// bare name unresolved in the legacy PATH-trust mode (binreg == nil) emits no bind and returns
+	// the original "bwrap: execvp ...: No such file or directory" for any helper installed outside
+	// /usr, /bin, /sbin or /lib. Resolving here also means bwrap never re-resolves spec.Name via
+	// PATH to a possibly-different binary (closing the verify-path != exec-path gap below).
+	spec.Name = resolveToolPath(spec.Name)
 	// F5: verify the tool binary's integrity before it runs. The resolved on-disk binary
 	// must match its pin (operator hash and/or trust-on-first-use); a replaced binary is
 	// refused. Defends the "compromised tool binary" threat the audit named.
 	if r.binreg != nil {
-		binPath, lerr := exec.LookPath(spec.Name)
-		if lerr != nil {
-			binPath = spec.Name // not on PATH; let bwrap surface the not-found, but still try to verify
-		}
-		if verr := r.binreg.Verify(binPath); verr != nil {
+		if verr := r.binreg.Verify(spec.Name); verr != nil {
 			return ports.ToolResult{}, fmt.Errorf("%w: %v", shared.ErrValidation, verr)
 		}
-		// Exec the EXACT path we verified (absolute) – so bwrap does not re-resolve spec.Name
-		// via PATH to a possibly-different binary (closes the verify-path != exec-path gap).
-		spec.Name = binPath
 	}
 	// F3: a per-run cgroup v2 with hard memory.max + pids.max so a memory/fork bomb is
 	// contained on EVERY path (egress and isolated), independent of systemd-run. The tool

--- a/internal/infrastructure/sandbox/runner_test.go
+++ b/internal/infrastructure/sandbox/runner_test.go
@@ -3,6 +3,9 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -212,5 +215,50 @@ func TestSecretsNeverEnterArgv(t *testing.T) {
 	argv := r.command(ports.ToolSpec{Name: "tool", EngagementID: "eng1", Env: []string{"TOK={{secret:TOK}}"}}, "", "", 3, false)
 	if strings.Contains(strings.Join(argv, " "), "PLAINTEXT_SECRET") {
 		t.Fatal("a resolved secret must NEVER appear in the argv")
+	}
+}
+
+// TestResolveToolPathRunsWithoutABinaryRegistry closes the review gap in the bind fix. bwrapArgs
+// binds the binary only when spec.Name is ABSOLUTE, and Run() previously rewrote spec.Name to the
+// resolved path only inside `if r.binreg != nil`. In the documented legacy PATH-trust mode a helper
+// invoked by bare name therefore stayed relative, emitted no bind, and returned the original
+// "bwrap: execvp ...: No such file or directory" the fix exists to prevent. Resolution must not
+// depend on integrity verification being enabled.
+func TestResolveToolPathRunsWithoutABinaryRegistry(t *testing.T) {
+	dir := t.TempDir()
+	name := "synapse-fake-helper"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	binary := filepath.Join(dir, name)
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	bare := strings.TrimSuffix(name, ".exe")
+	if runtime.GOOS == "windows" {
+		bare = name
+	}
+	got := resolveToolPath(bare)
+	if !filepath.IsAbs(got) {
+		t.Fatalf("resolveToolPath(%q) = %q, want an absolute path so bwrapArgs can bind it", bare, got)
+	}
+	// An unresolvable name is returned unchanged so bwrap surfaces the not-found itself.
+	if got := resolveToolPath("synapse-definitely-not-on-path"); got != "synapse-definitely-not-on-path" {
+		t.Errorf("resolveToolPath(missing) = %q, want the name unchanged", got)
+	}
+}
+
+// TestSandboxBindsResolvedBinaryOnTheLegacyPath is the argv-level half: a runner with NO binary
+// registry (legacy PATH trust) must still emit the bind for a resolved out-of-root helper.
+func TestSandboxBindsResolvedBinaryOnTheLegacyPath(t *testing.T) {
+	r := fakeRunner("")
+	if r.binreg != nil {
+		t.Fatal("this test must exercise the legacy PATH-trust path (binreg == nil)")
+	}
+	joined := strings.Join(r.command(ports.ToolSpec{Name: "/opt/synapse/bin/synapse-cspm"}, "", "", 3, false), " ")
+	if !strings.Contains(joined, "--ro-bind-try /opt/synapse/bin/synapse-cspm /opt/synapse/bin/synapse-cspm") {
+		t.Errorf("no bind emitted without a binary registry: %s", joined)
 	}
 }

--- a/internal/infrastructure/sandbox/runner_test.go
+++ b/internal/infrastructure/sandbox/runner_test.go
@@ -218,34 +218,45 @@ func TestSecretsNeverEnterArgv(t *testing.T) {
 	}
 }
 
-// TestResolveToolPathRunsWithoutABinaryRegistry closes the review gap in the bind fix. bwrapArgs
-// binds the binary only when spec.Name is ABSOLUTE, and Run() previously rewrote spec.Name to the
-// resolved path only inside `if r.binreg != nil`. In the documented legacy PATH-trust mode a helper
-// invoked by bare name therefore stayed relative, emitted no bind, and returned the original
-// "bwrap: execvp ...: No such file or directory" the fix exists to prevent. Resolution must not
-// depend on integrity verification being enabled.
-func TestResolveToolPathRunsWithoutABinaryRegistry(t *testing.T) {
+// TestResolveToolPathKeepsHostPathOutOfSandboxAuthority pins the resolution contract. bwrapArgs binds
+// the binary only when spec.Name is ABSOLUTE, so an operator-configured absolute helper (the
+// documented /opt/synapse/bin/synapse-cspm layout) must survive untouched - that is what makes it
+// bindable. A BARE name is a different case: resolving it through the host PATH without integrity
+// verification would let an inherited entry such as /tmp/attacker/tool be resolved on the host and
+// then explicitly bound in, where bwrap would otherwise resolve it against the sandbox's own curated
+// PATH and fail closed.
+func TestResolveToolPathKeepsHostPathOutOfSandboxAuthority(t *testing.T) {
 	dir := t.TempDir()
 	name := "synapse-fake-helper"
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
-	binary := filepath.Join(dir, name)
-	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-
 	bare := strings.TrimSuffix(name, ".exe")
 	if runtime.GOOS == "windows" {
 		bare = name
 	}
-	got := resolveToolPath(bare)
-	if !filepath.IsAbs(got) {
-		t.Fatalf("resolveToolPath(%q) = %q, want an absolute path so bwrapArgs can bind it", bare, got)
+
+	// Verified: a bare name resolves, so the verified path is the bound and executed path.
+	if got := resolveToolPath(bare, true); !filepath.IsAbs(got) {
+		t.Errorf("resolveToolPath(%q, verify) = %q, want an absolute path", bare, got)
+	}
+	// Unverified: host PATH is not an authority for what gets bound; leave it to bwrap.
+	if got := resolveToolPath(bare, false); got != bare {
+		t.Errorf("resolveToolPath(%q, no-verify) = %q, want the bare name so bwrap resolves it inside the sandbox", bare, got)
+	}
+	// An absolute operator-configured path is returned as given, verified or not.
+	const absolute = "/opt/synapse/bin/synapse-cspm"
+	for _, verify := range []bool{true, false} {
+		if got := resolveToolPath(absolute, verify); got != absolute {
+			t.Errorf("resolveToolPath(%q, %v) = %q, want it unchanged", absolute, verify, got)
+		}
 	}
 	// An unresolvable name is returned unchanged so bwrap surfaces the not-found itself.
-	if got := resolveToolPath("synapse-definitely-not-on-path"); got != "synapse-definitely-not-on-path" {
+	if got := resolveToolPath("synapse-definitely-not-on-path", true); got != "synapse-definitely-not-on-path" {
 		t.Errorf("resolveToolPath(missing) = %q, want the name unchanged", got)
 	}
 }

--- a/internal/infrastructure/sandbox/runner_test.go
+++ b/internal/infrastructure/sandbox/runner_test.go
@@ -242,17 +242,17 @@ func TestResolveToolPathKeepsHostPathOutOfSandboxAuthority(t *testing.T) {
 
 	// Verified: a bare name resolves, so the verified path is the bound and executed path.
 	if got := resolveToolPath(bare, true); !filepath.IsAbs(got) {
-		t.Errorf("resolveToolPath(%q, verify) = %q, want an absolute path", bare, got)
+		t.Errorf("resolveToolPath(%q, hostPATHIsAuthority) = %q, want an absolute path", bare, got)
 	}
 	// Unverified: host PATH is not an authority for what gets bound; leave it to bwrap.
 	if got := resolveToolPath(bare, false); got != bare {
-		t.Errorf("resolveToolPath(%q, no-verify) = %q, want the bare name so bwrap resolves it inside the sandbox", bare, got)
+		t.Errorf("resolveToolPath(%q, !hostPATHIsAuthority) = %q, want the bare name so bwrap resolves it inside the sandbox", bare, got)
 	}
 	// An absolute operator-configured path is returned as given, verified or not.
 	const absolute = "/opt/synapse/bin/synapse-cspm"
-	for _, verify := range []bool{true, false} {
-		if got := resolveToolPath(absolute, verify); got != absolute {
-			t.Errorf("resolveToolPath(%q, %v) = %q, want it unchanged", absolute, verify, got)
+	for _, hostPATHIsAuthority := range []bool{true, false} {
+		if got := resolveToolPath(absolute, hostPATHIsAuthority); got != absolute {
+			t.Errorf("resolveToolPath(%q, %v) = %q, want it unchanged", absolute, hostPATHIsAuthority, got)
 		}
 	}
 	// An unresolvable name is returned unchanged so bwrap surfaces the not-found itself.

--- a/internal/infrastructure/sandbox/runner_test.go
+++ b/internal/infrastructure/sandbox/runner_test.go
@@ -109,6 +109,44 @@ func TestSandboxReadOnlyExtraBinds(t *testing.T) {
 	}
 }
 
+// TestSandboxBindsToolBinaryOutsideCuratedRoot pins the bind for owned helpers installed outside
+// the curated read-only root. The root deliberately omits /opt so host secrets stay ENOENT, which
+// also made the DOCUMENTED /opt/synapse/bin/synapse-cspm layout unrunnable: every CSPM run died
+// with "bwrap: execvp /opt/synapse/synapse-cspm: No such file or directory", retried three times
+// and dead-lettered. Only the verified FILE is bound - never its directory.
+func TestSandboxBindsToolBinaryOutsideCuratedRoot(t *testing.T) {
+	r := fakeRunner("")
+	argv := r.command(ports.ToolSpec{Name: "/opt/synapse/bin/synapse-cspm"}, "", "", 3, false)
+	joined := strings.Join(argv, " ")
+	if !strings.Contains(joined, "--ro-bind-try /opt/synapse/bin/synapse-cspm /opt/synapse/bin/synapse-cspm") {
+		t.Errorf("helper binary was not bound into the sandbox: %s", joined)
+	}
+	if strings.Contains(joined, "--ro-bind-try /opt/synapse/bin /opt/synapse/bin") || strings.Contains(joined, "--ro-bind-try /opt /opt") {
+		t.Errorf("bound the helper's DIRECTORY, widening the curated root: %s", joined)
+	}
+}
+
+// TestSandboxDoesNotRebindCuratedRootTools keeps the bind narrow: tools already inside the curated
+// root need no extra bind, and a lookalike path must not be treated as being inside it.
+func TestSandboxDoesNotRebindCuratedRootTools(t *testing.T) {
+	r := fakeRunner("")
+	joined := strings.Join(r.command(ports.ToolSpec{Name: "/usr/bin/syft"}, "", "", 3, false), " ")
+	if strings.Contains(joined, "--ro-bind-try /usr/bin/syft /usr/bin/syft") {
+		t.Errorf("re-bound a tool already inside the curated root: %s", joined)
+	}
+	for _, name := range []string{"/libexec/synapse/helper", "/lib-evil/helper"} {
+		joined = strings.Join(r.command(ports.ToolSpec{Name: name}, "", "", 3, false), " ")
+		if !strings.Contains(joined, "--ro-bind-try "+name+" "+name) {
+			t.Errorf("%s was treated as inside the curated root: %s", name, joined)
+		}
+	}
+	// A relative name still resolves through PATH inside the sandbox; binding it would be wrong.
+	joined = strings.Join(r.command(ports.ToolSpec{Name: "grype"}, "", "", 3, false), " ")
+	if strings.Contains(joined, "--ro-bind-try grype") {
+		t.Errorf("bound a relative tool name: %s", joined)
+	}
+}
+
 // ---- secret substitution + worker-env exclusion (argv-construction level) ----
 
 func TestChildEnvResolvesSecretsCleanly(t *testing.T) {

--- a/internal/usecase/cspm/service.go
+++ b/internal/usecase/cspm/service.go
@@ -522,20 +522,13 @@ func (s *Service) Run(ctx context.Context, in RunInput) (result RunResult, runEr
 		if err := s.findings.Upsert(runCtx, standard); err != nil {
 			return result, err
 		}
-		if s.attributor != nil {
-			for resourceID, cloudAsset := range assets {
-				producer := shared.ID("cspm:" + scopeDigest(scope.ScopeKey) + ":" + scopeDigest(resourceID))
-				var targets []attackpath.FindingTarget
-				for index, match := range matches {
-					if match.ResourceID == resourceID {
-						targets = append(targets, attackpath.FindingTarget{ID: standard[index].ID, Kind: attackpath.TargetCanonical})
-					}
-				}
-				if err := s.attributor.RecordTargets(runCtx, in.EngagementID, cloudAsset.ID, producer, evidenceIDOrProducer(evidenceID, producer), asset.EdgeObserved, targets); err != nil {
-					return result, err
-				}
-			}
-		}
+		// Reconcile observations BEFORE attribution. A cloud asset carries a scope_key, and the
+		// asset repository deliberately hides such an asset until an ACTIVE cspm_observations row
+		// vouches for it (no default-to-clean inventory). Attribution validates its asset through
+		// that same tenant-scoped listing, so attributing first made every run with at least one
+		// asset fail with "asset <id>: not found" - after real provider enumeration had already
+		// succeeded - then retry twice and dead-letter. Reconciliation depends only on findings and
+		// edges that are already persisted above, so it is safe to run first.
 		if s.observations != nil {
 			assetIDs := make([]shared.ID, 0, len(assets))
 			for _, cloudAsset := range assets {
@@ -555,6 +548,20 @@ func (s *Service) Run(ctx context.Context, in RunInput) (result RunResult, runEr
 			}
 			if err := s.observations.ReconcileCloudObservations(runCtx, in.TenantID, in.EngagementID, producerID(scope.ScopeKey).String(), evidenceID, assetIDs, findingIDs, edgeIDs, inventory.Complete && len(allTargetGaps) == 0); err != nil {
 				return result, err
+			}
+		}
+		if s.attributor != nil {
+			for resourceID, cloudAsset := range assets {
+				producer := shared.ID("cspm:" + scopeDigest(scope.ScopeKey) + ":" + scopeDigest(resourceID))
+				var targets []attackpath.FindingTarget
+				for index, match := range matches {
+					if match.ResourceID == resourceID {
+						targets = append(targets, attackpath.FindingTarget{ID: standard[index].ID, Kind: attackpath.TargetCanonical})
+					}
+				}
+				if err := s.attributor.RecordTargets(runCtx, in.EngagementID, cloudAsset.ID, producer, evidenceIDOrProducer(evidenceID, producer), asset.EdgeObserved, targets); err != nil {
+					return result, err
+				}
 			}
 		}
 		result.Findings += len(standard)

--- a/internal/usecase/cspm/service_test.go
+++ b/internal/usecase/cspm/service_test.go
@@ -3,6 +3,7 @@ package cspm_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -279,5 +280,100 @@ func TestRunDeniesCloudOperationOutsideReadOnlyAllowlist(t *testing.T) {
 	}
 	if !denied {
 		t.Fatalf("audit = %#v", audit.entries)
+	}
+}
+
+// gatedAttributor models the REAL attribution boundary. A cloud asset carries a scope_key, and the
+// asset repository hides such an asset until an ACTIVE cspm_observations row vouches for it, so
+// ValidateAsset only ever sees assets that reconciliation has already published. attributorStub
+// accepts every asset unconditionally, which is precisely why unit tests missed this.
+type gatedAttributor struct {
+	published  map[shared.ID]bool
+	attributed map[shared.ID][]shared.ID
+}
+
+func (a *gatedAttributor) ValidateAsset(_ context.Context, _ shared.ID, assetID shared.ID) error {
+	if !a.published[assetID] {
+		return fmt.Errorf("asset %s: %w", assetID, shared.ErrNotFound)
+	}
+	return nil
+}
+
+func (a *gatedAttributor) InheritedAssetID(context.Context, shared.ID, []shared.ID) (shared.ID, error) {
+	return "", nil
+}
+
+func (a *gatedAttributor) Record(ctx context.Context, engagementID shared.ID, assetID, producer, provenance shared.ID, confidence asset.EdgeConfidence, findingIDs []shared.ID) error {
+	targets := make([]attackpath.FindingTarget, 0, len(findingIDs))
+	for _, id := range findingIDs {
+		targets = append(targets, attackpath.FindingTarget{ID: id, Kind: attackpath.TargetCanonical})
+	}
+	return a.RecordTargets(ctx, engagementID, assetID, producer, provenance, confidence, targets)
+}
+
+func (a *gatedAttributor) RecordTargets(ctx context.Context, engagementID shared.ID, assetID, _, _ shared.ID, _ asset.EdgeConfidence, targets []attackpath.FindingTarget) error {
+	if err := a.ValidateAsset(ctx, engagementID, assetID); err != nil {
+		return err
+	}
+	for _, target := range targets {
+		a.attributed[assetID] = append(a.attributed[assetID], target.ID)
+	}
+	return nil
+}
+
+// publishingObservationStore is the other half: reconciliation is what makes a cloud asset visible.
+type publishingObservationStore struct{ attributor *gatedAttributor }
+
+func (s publishingObservationStore) ReconcileCloudObservations(_ context.Context, _, _ shared.ID, _ string, _ shared.ID, assetIDs, _ []shared.ID, _ []string, _ bool) error {
+	for _, id := range assetIDs {
+		s.attributor.published[id] = true
+	}
+	return nil
+}
+
+// TestRunReconcilesObservationsBeforeAttributing pins the ordering between reconciliation and
+// attribution. Attributing FIRST validated each asset against a listing that still hid it, so every
+// CSPM run carrying at least one asset failed with "asset <id>: not found" - after real provider
+// enumeration had already succeeded - then retried twice and dead-lettered with zero assets and
+// zero findings recorded.
+func TestRunReconcilesObservationsBeforeAttributing(t *testing.T) {
+	ctx := context.Background()
+	now := time.Unix(1, 0)
+	audit := &auditStub{}
+	store := memory.NewAssetStore()
+	assets, err := assetuc.NewService(store, audit, clockStub{now}, &idsStub{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	engagements := memory.NewEngagementRepository()
+	eng, _ := engagement.New("eng", "tenant", "cloud", "client", now)
+	eng.Status = engagement.StatusActive
+	eng.Scope = engagement.Scope{InScope: []engagement.Target{{Kind: engagement.TargetCloudAccount, Value: "organization/o-1"}}}
+	if err := engagements.Create(ctx, eng); err != nil {
+		t.Fatal(err)
+	}
+	inv := cloudposture.Inventory{Provider: cloudposture.ProviderAWS, Complete: true, Resources: []cloudposture.Resource{
+		{Provider: cloudposture.ProviderAWS, ID: "account", Name: "prod", Kind: asset.KindCloudAccount},
+		{Provider: cloudposture.ProviderAWS, AccountID: "account", ID: "bucket", Name: "logs", Kind: asset.KindStorage, Public: cloudposture.StateEnabled, Encrypted: cloudposture.StateDisabled},
+	}}
+	connector := connectorStub{inventory: inv}
+	svc, err := cspm.NewService(map[cloudposture.Provider]ports.CloudConnector{cloudposture.ProviderAWS: connector}, assets, memory.NewFindingRepository(), engagements, audit, clockStub{now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attributor := &gatedAttributor{published: map[shared.ID]bool{}, attributed: map[shared.ID][]shared.ID{}}
+	svc.SetAttributor(attributor)
+	svc.SetObservationStore(publishingObservationStore{attributor: attributor})
+	svc.SetEvidenceSealer(evidenceStub{})
+	svc.SetSandboxExecutor(executorStub{connector: connector})
+	result, err := svc.Run(ctx, cspm.RunInput{TenantID: "tenant", EngagementID: "eng", Actor: "operator", Scopes: []ports.CloudScope{{EngagementID: "eng", Provider: cloudposture.ProviderAWS, Root: "organization/o-1", CredentialRef: "aws-prod"}}})
+	if err != nil {
+		t.Fatalf("run failed: %v (attribution ran before reconciliation published the assets)", err)
+	}
+	if result.Assets != 2 {
+		t.Fatalf("assets = %d, want 2", result.Assets)
+	}
+	if len(attributor.attributed) == 0 {
+		t.Fatal("no findings were attributed to any asset")
 	}
 }

--- a/internal/usecase/fleetagentuc/service.go
+++ b/internal/usecase/fleetagentuc/service.go
@@ -101,6 +101,11 @@ func (s *Service) Enrol(ctx context.Context, enrolToken string, in EnrolInput) (
 	}
 	now := s.clock.Now()
 	tenantID := shared.ID(tenantStr)
+	// Bind the token's tenant onto the context. Downstream writes (notably the audit chain) read
+	// the tenant from the context to satisfy tenant RLS, and this agent plane has no human
+	// principal to carry it: without this, every enrolment fails the audit insert with
+	// "new row violates row-level security policy for table audit_log".
+	ctx = shared.WithTenant(ctx, tenantID)
 	agentID := s.ids.NewID()
 	token, hash, err := agenttoken.Mint(agenttoken.KindAgent, tenantID.String(), agentID.String())
 	if err != nil {

--- a/internal/usecase/fleetagentuc/service_test.go
+++ b/internal/usecase/fleetagentuc/service_test.go
@@ -27,6 +27,21 @@ type fakeAudit struct{ n int }
 
 func (a *fakeAudit) Record(context.Context, ports.AuditEntry) error { a.n++; return nil }
 
+// tenantCapturingAudit records the tenant bound on the context of each audit write. The Postgres
+// audit repository reads the tenant from the context to satisfy tenant RLS, so an unbound context
+// is a write that fails in production but passes against a context-blind fake.
+type tenantCapturingAudit struct {
+	tenants []shared.ID
+	bound   []bool
+}
+
+func (a *tenantCapturingAudit) Record(ctx context.Context, _ ports.AuditEntry) error {
+	tenant, ok := shared.TenantFrom(ctx)
+	a.tenants = append(a.tenants, tenant)
+	a.bound = append(a.bound, ok)
+	return nil
+}
+
 func newSvc(t *testing.T) *Service {
 	t.Helper()
 	svc, err := NewService(memory.NewFleetAgentStore(), &fakeAudit{}, fakeClock{t: time.Unix(1000, 0).UTC()}, &fakeIDs{})
@@ -34,6 +49,43 @@ func newSvc(t *testing.T) *Service {
 		t.Fatalf("new service: %v", err)
 	}
 	return svc
+}
+
+// TestEnrolBindsTenantOnAuditContext pins the tenant onto the context that Enrol's audit writes
+// see. The agent plane has no human principal, so the tenant must come from the enrolment token;
+// the Postgres audit repository reads it from the context to satisfy tenant RLS. Without the
+// binding, every real enrolment fails with "new row violates row-level security policy for table
+// audit_log" and the agent can never join the fleet.
+func TestEnrolBindsTenantOnAuditContext(t *testing.T) {
+	audit := &tenantCapturingAudit{}
+	svc, err := NewService(memory.NewFleetAgentStore(), audit, fakeClock{t: time.Unix(1000, 0).UTC()}, &fakeIDs{})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	// An unbound background context is exactly what the fleet HTTP plane hands in.
+	ctx := context.Background()
+	enrolTok, err := svc.MintEnrolToken(shared.WithTenant(ctx, "t1"), "op", "t1", time.Hour)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	before := len(audit.tenants)
+	if _, _, _, err := svc.Enrol(ctx, enrolTok, EnrolInput{Name: "agent-1", Platform: "linux"}); err != nil {
+		t.Fatalf("enrol: %v", err)
+	}
+	enrolWrites := audit.tenants[before:]
+	enrolBound := audit.bound[before:]
+	if len(enrolWrites) == 0 {
+		t.Fatal("enrol recorded no audit entry")
+	}
+	for i, bound := range enrolBound {
+		if !bound {
+			t.Errorf("enrol audit write %d has no tenant on its context; the RLS insert would be rejected", i)
+			continue
+		}
+		if enrolWrites[i] != "t1" {
+			t.Errorf("enrol audit write %d tenant = %q, want %q (from the enrolment token)", i, enrolWrites[i], "t1")
+		}
+	}
 }
 
 func TestEnrolAndAuthenticate(t *testing.T) {

--- a/internal/usecase/fptriage/prompt.go
+++ b/internal/usecase/fptriage/prompt.go
@@ -93,6 +93,11 @@ var critiqueSchema = json.RawMessage(`{
   }
 }`)
 
+// evidenceCritiqueSchema constrains the evidence-backed critique. It deliberately omits
+// "uniqueItems": OpenAI structured outputs reject that keyword in strict mode ("'uniqueItems' is
+// not permitted"), which failed EVERY evidence-backed triage call with a 400 the telemetry then
+// recorded as a provider error. Duplicate citations are rejected in code instead, by
+// validateEvidenceCitations.
 var evidenceCritiqueSchema = json.RawMessage(`{
   "name": "evidence_critique",
   "strict": true,
@@ -104,7 +109,7 @@ var evidenceCritiqueSchema = json.RawMessage(`{
       "verdict": { "type": "string", "enum": ["refuted", "sound", "uncertain"] },
       "driver": { "type": "string", "enum": ["test_or_example_code","not_attacker_controlled","input_sanitized","constant_or_literal","framework_autoescape","not_reachable","intended_behavior","false_pattern_match","mitigated_elsewhere","confirmed_exploitable","attacker_controlled","insufficient_context"] },
       "confidence": { "type": "integer", "minimum": 0, "maximum": 100 },
-      "evidence_tokens": { "type": "array", "minItems": 1, "maxItems": 8, "uniqueItems": true, "items": { "type": "string", "pattern": "^ev:[a-z][a-z0-9_]{0,47}$" } }
+      "evidence_tokens": { "type": "array", "minItems": 1, "maxItems": 8, "items": { "type": "string", "pattern": "^ev:[a-z][a-z0-9_]{0,47}$" } }
     }
   }
 }`)

--- a/internal/usecase/fptriage/prompt.go
+++ b/internal/usecase/fptriage/prompt.go
@@ -129,7 +129,10 @@ func userPromptWithEvidence(f finding.Finding, snippet string, evidence []ports.
 		b.Write(data)
 		b.WriteByte('\n')
 	}
-	b.WriteString("Return JSON with verdict, driver, confidence, and evidence_tokens containing only IDs listed above.\n")
+	// State the uniqueness requirement in the prompt. The response schema cannot carry it (strict
+	// structured outputs reject "uniqueItems"), so validateEvidenceCitations rejects duplicates at
+	// runtime; asking for it here keeps that from becoming an avoidable rejected call.
+	b.WriteString("Return JSON with verdict, driver, confidence, and evidence_tokens containing only IDs listed above. Cite each ID at most once.\n")
 	return b.String()
 }
 

--- a/internal/usecase/fptriage/prompt_test.go
+++ b/internal/usecase/fptriage/prompt_test.go
@@ -1,0 +1,96 @@
+package fptriage
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// unsupportedStrictKeywords are JSON Schema keywords that OpenAI structured outputs reject in
+// strict mode. Sending any of them makes the provider answer 400 invalid_json_schema, which the
+// triage telemetry records as a provider error - so a schema regression looks like a flaky
+// gateway rather than a malformed request. "uniqueItems" caused exactly that: every
+// evidence-backed critique failed with
+// "Invalid schema for response_format 'evidence_critique': ... 'uniqueItems' is not permitted".
+var unsupportedStrictKeywords = []string{"uniqueItems", "patternProperties", "not", "if", "then", "else"}
+
+// TestCritiqueSchemasAvoidUnsupportedStrictKeywords pins both response schemas against the strict
+// structured-output subset. Constraints that cannot be expressed on the wire are enforced in code
+// (duplicate citations by validateEvidenceCitations), never by a keyword the provider rejects.
+func TestCritiqueSchemasAvoidUnsupportedStrictKeywords(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		schema json.RawMessage
+	}{
+		{"critique", critiqueSchema},
+		{"evidence_critique", evidenceCritiqueSchema},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var doc map[string]any
+			if err := json.Unmarshal(tc.schema, &doc); err != nil {
+				t.Fatalf("schema is not valid JSON: %v", err)
+			}
+			if strict, ok := doc["strict"].(bool); !ok || !strict {
+				t.Errorf(`strict = %v, want true (structured outputs must be schema-constrained)`, doc["strict"])
+			}
+			for _, keyword := range unsupportedStrictKeywords {
+				if found := findKey(doc, keyword); found {
+					t.Errorf("schema uses %q, which strict structured outputs reject with 400 invalid_json_schema", keyword)
+				}
+			}
+		})
+	}
+}
+
+// TestEvidenceCritiqueSchemaKeepsCitationConstraints guards the other half of the contract: dropping
+// uniqueItems must not quietly drop the bounds and token shape that keep citations parseable.
+func TestEvidenceCritiqueSchemaKeepsCitationConstraints(t *testing.T) {
+	var doc struct {
+		Schema struct {
+			Properties struct {
+				EvidenceTokens struct {
+					Type     string `json:"type"`
+					MinItems *int   `json:"minItems"`
+					MaxItems *int   `json:"maxItems"`
+					Items    struct {
+						Pattern string `json:"pattern"`
+					} `json:"items"`
+				} `json:"evidence_tokens"`
+			} `json:"properties"`
+		} `json:"schema"`
+	}
+	if err := json.Unmarshal(evidenceCritiqueSchema, &doc); err != nil {
+		t.Fatalf("unmarshal evidence schema: %v", err)
+	}
+	tokens := doc.Schema.Properties.EvidenceTokens
+	if tokens.Type != "array" {
+		t.Errorf("evidence_tokens type = %q, want array", tokens.Type)
+	}
+	if tokens.MinItems == nil || *tokens.MinItems < 1 {
+		t.Error("evidence_tokens must require at least one citation")
+	}
+	if tokens.MaxItems == nil || *tokens.MaxItems < 1 {
+		t.Error("evidence_tokens must stay bounded by maxItems")
+	}
+	if tokens.Items.Pattern == "" {
+		t.Error("evidence_tokens items must pin the ev: token pattern")
+	}
+}
+
+// findKey reports whether key appears anywhere in the decoded schema tree.
+func findKey(node any, key string) bool {
+	switch typed := node.(type) {
+	case map[string]any:
+		for k, v := range typed {
+			if k == key || findKey(v, key) {
+				return true
+			}
+		}
+	case []any:
+		for _, v := range typed {
+			if findKey(v, key) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -1768,7 +1768,9 @@ func (s *Service) runScanJob(ctx context.Context, actor string, engagementID sha
 		job.Status, job.Stage = ports.ScanSucceeded, "done"
 	}
 	if s.jobs != nil {
-		_ = s.jobs.Save(context.WithoutCancel(ctx), job) // detached but tenant-preserving: the timeout ctx may be done
+		// Detached from ctx so the record still lands when the completion timeout above has fired.
+		// (ScanJobStore.Save is not tenant-scoped; the tenant matters at the recorder call, not here.)
+		_ = s.jobs.Save(context.WithoutCancel(ctx), job)
 	}
 }
 

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -1428,7 +1428,7 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 		if _, err := s.jobQueue.Enqueue(ctx, ScanJobKind, payload); err != nil {
 			fin := s.clock.Now()
 			job.Status, job.Stage, job.Error, job.FinishedAt = ports.ScanFailed, "enqueue", truncateErr(err), &fin
-			_ = s.jobs.Save(context.Background(), job)
+			_ = s.jobs.Save(context.WithoutCancel(ctx), job)
 			return ports.ScanJob{}, fmt.Errorf("enqueue scan job: %w", err)
 		}
 		return job, nil
@@ -1752,7 +1752,11 @@ func (s *Service) runScanJob(ctx context.Context, actor string, engagementID sha
 
 	fin := s.clock.Now()
 	if err == nil && opts.ProjectAnalysis && s.projectAnalysisRecorder != nil {
-		completionCtx, cancel := context.WithTimeout(context.Background(), s.projectAnalysisCompletionTimeout)
+		// Detach from the request's cancellation but KEEP the tenant that runScanJob's ctx
+		// carries: the recorder reads the engagement through a tenant-scoped (RLS) repository,
+		// and a bare context.Background() would drop the tenant and fail the whole scan at
+		// the persistence boundary.
+		completionCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.projectAnalysisCompletionTimeout)
 		err = s.projectAnalysisRecorder.RecordProjectAnalysis(completionCtx, engagementID, job.ID, fin, result)
 		cancel()
 	}
@@ -1764,7 +1768,7 @@ func (s *Service) runScanJob(ctx context.Context, actor string, engagementID sha
 		job.Status, job.Stage = ports.ScanSucceeded, "done"
 	}
 	if s.jobs != nil {
-		_ = s.jobs.Save(context.Background(), job) // fresh ctx: the timeout ctx may be done
+		_ = s.jobs.Save(context.WithoutCancel(ctx), job) // detached but tenant-preserving: the timeout ctx may be done
 	}
 }
 

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -1124,12 +1124,15 @@ type contextRecorder struct {
 	waitForDeadline bool
 	result          *ScanResult
 	err             error
+	tenant          shared.ID
+	tenantOK        bool
 }
 
 func (r *contextRecorder) RecordProjectAnalysis(ctx context.Context, _ shared.ID, _ string, _ time.Time, result *ScanResult) error {
 	r.called = true
 	r.live = ctx.Err() == nil
 	r.deadline, _ = ctx.Deadline()
+	r.tenant, r.tenantOK = shared.TenantFrom(ctx)
 	r.result = result
 	if r.waitForDeadline {
 		<-ctx.Done()
@@ -1212,6 +1215,37 @@ func TestProjectRecorderUsesFreshCompletionContext(t *testing.T) {
 	}
 	if !recorder.called || !recorder.live {
 		t.Fatalf("recorder called=%v live=%v, want live completion context", recorder.called, recorder.live)
+	}
+	if final.Status != ports.ScanSucceeded {
+		t.Fatalf("status=%q err=%q, want succeeded", final.Status, final.Error)
+	}
+}
+
+// TestProjectRecorderCompletionContextKeepsTenant pins the tenant onto the project-analysis
+// completion context. The recorder reads the engagement through a tenant-scoped (RLS)
+// repository, so deriving the completion context from a bare context.Background() drops the
+// tenant and fails every Project analysis at the persistence boundary with
+// "tenant context is required" — after the whole pipeline has already succeeded.
+func TestProjectRecorderCompletionContextKeepsTenant(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	jobs := newFakeJobStore()
+	svc := newAsyncSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{}, jobs, fakeIDs{})
+	recorder := &contextRecorder{}
+	svc.SetProjectAnalysisRecorder(recorder)
+	job := ports.ScanJob{ID: "job-1", EngagementID: "e1", Status: ports.ScanRunning, StartedAt: time.Unix(0, 0).UTC()}
+	svc.runScanJob(shared.WithTenant(context.Background(), shared.DefaultTenant), "operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull, ProjectAnalysis: true}, job)
+	if !recorder.called {
+		t.Fatal("recorder was not called")
+	}
+	if !recorder.tenantOK {
+		t.Fatal("completion context carries no tenant; a tenant-scoped repository read would fail")
+	}
+	if recorder.tenant != shared.DefaultTenant {
+		t.Fatalf("completion context tenant = %q, want %q", recorder.tenant, shared.DefaultTenant)
+	}
+	final, err := jobs.LatestForEngagement(context.Background(), "e1")
+	if err != nil {
+		t.Fatal(err)
 	}
 	if final.Status != ports.ScanSucceeded {
 		t.Fatalf("status=%q err=%q, want succeeded", final.Status, final.Error)


### PR DESCRIPTION
Closes #576

## Summary

An end-to-end validation run against real dependencies — PostgreSQL with RLS, MinIO, pinned
Syft/Grype, bubblewrap on Linux, a local kind cluster, a live LLM gateway, and a real AWS
organization — surfaced **ten product defects**. This fixes all ten.

None were reproducible from unit tests alone, and the reason matters: in four cases the **test
double was more permissive than the real boundary**. Context-blind fakes and an attributor stub that
accepted every asset let those defects pass the suite while failing against PostgreSQL RLS, the
router, and the asset visibility gate. Each new test models the real gate rather than the forgiving
fake.

Severity is uneven. Most of these produce a loud failure, but **defect 9 suppresses a finding** — an
unencrypted or publicly-policied S3 bucket silently produced no posture finding at all. For a
security product that is the worst failure mode, and it is the one I would weight highest in review.

## Changes

Eight focused commits, one per defect (the two AWS connector fixes share a commit because they sit
on the same enumeration path).

**Tenant / RLS boundary**

- `fix(sca)` — `runScanJob` carries a tenant, but the project-analysis completion path rebuilt from
  a bare `context.Background()`. The recorder reads the engagement through a tenant-scoped (RLS)
  repository, so **every Project analysis** failed `tenant context is required` *after the whole
  pipeline had already succeeded*. Now derived with `context.WithoutCancel(ctx)` — detached from
  request cancellation, tenant preserved.
- `fix(fleet)` — the untrusted agent plane has no human principal to carry a tenant, but the
  hash-chained audit log reads it from the context to satisfy RLS. Every enrolment, heartbeat,
  claim, result, and inventory write failed with `new row violates row-level security policy for
  table audit_log`. Bound from the enrolment token in `Enrol` and from the authenticated agent in
  the transport authenticator — **never from a request field**.

**Auth-plane routing**

- `fix(httpapi)` — mounting the agent transport on the whole `/api/v1/fleet/` prefix also swallowed
  the **operator** routes under it (fleet coverage, agent health), which the agent mux does not
  serve, so each returned `404` instead of reaching the human RBAC chain. Now mounted on the exact
  agent-plane subtrees; the new test guards the split in both directions so a future agent route
  cannot silently capture an operator path.

**LLM boundary**

- `fix(llm)` — the client decodes one non-streaming JSON body, but OpenAI-compatible gateways
  default to `text/event-stream` when `stream` is absent. Every call failed on the `d` of the SSE
  `data:` prefix, halting agent sessions and AI triage. `stream` is now always sent (deliberately no
  `omitempty`).
- `fix(fptriage)` — strict structured outputs reject `uniqueItems`, so **100% of evidence-backed
  triage calls** returned `400 invalid_json_schema`. Worse, `classifyCallError` buckets that
  client-side error as `provider_error`, so a malformed request of ours looked like a flaky gateway.
  Uniqueness was already enforced in code by `validateEvidenceCitations`, so the keyword was
  redundant as well as invalid.

**Sandbox**

- `fix(cloudsandbox)` — the executor discarded the helper's stderr, so every failure was a bare
  `exit_code=1`. Fixed first, because defects 7–9 were only diagnosable once it was. stderr is
  untrusted output on a credentialed path, so the reason is redacted against the credential,
  bounded, collapsed to one line, and **dropped entirely if any placeholder survives**.
- `fix(sandbox)` — `Run()` resolves and integrity-verifies an absolute binary path, but the curated
  root omits `/opt` (so host secrets stay ENOENT) and nothing bound the verified binary. The
  **documented** `/opt/synapse/bin/synapse-cspm` layout in `docs/guide/cloud-posture.md` could not
  execute: `bwrap: execvp ...: No such file or directory`. Binds the single verified **file**
  read-only — never its directory, so the curated root is not widened.

**AWS CSPM**

- `fix(cloud/aws)` — (a) `MaxAccounts` is our *total* bound, but it was passed as `ListAccounts`
  `MaxResults`; Organizations caps that at 20 and **rejects** larger values, so account enumeration
  failed on every real organization. (b) `NoSuchBucketPolicy` and
  `ServerSideEncryptionConfigurationNotFoundError` are *definitive negatives*, not failures to
  observe — treating them as coverage gaps invented a `provider_error` on healthy accounts **and**
  left `Public`/`Encrypted` unknown, suppressing the finding. Named absence codes now map to
  `StateDisabled`; genuine permission and transport failures still raise gaps.
- `fix(cspm)` — attribution ran before observation reconciliation, but `ListAssets` hides a
  `scope_key`-bearing asset until an *active* `cspm_observations` row vouches for it. Attribution
  validates through that same listing, so every run with assets failed `asset <id>: not found`,
  retried three times, and dead-lettered. Reconciliation depends only on already-persisted findings
  and edges, so it now runs first.

## Verification

Each fix has a regression test, and **each test was confirmed to fail without its fix** — several
reproduce the exact production error string (`asset id-2: not found`,
`Encrypted = "unknown", want "disabled"`, `MaxResults = 100, want <= 20`).

Every failing flow was rerun against the real dependency until it passed:

| Flow | Before | After |
| --- | --- | --- |
| FP triage | 8 requests, **8 provider failures**, 0 tokens, 0 findings | 8 requests, **0 failures**, 12,776 tokens, 4 findings |
| Agent session | 0 steps (SSE decode failure) | 16 steps, 129,680 tokens, 18 judgments — **all `proposed`** |
| AWS CSPM | dead-lettered, 0 assets | `partial`, **7 real assets**, evidence sealed, honest coverage gaps |
| Project analysis | `tenant context is required` | succeeds, 20 issues / 7 hotspots persisted |
| Fleet agent plane | 500 on enrolment | enrol → claim → result → retry lifecycle green |

Live AWS CSPM now returns `findings=0` as a **true negative** — every enumerated bucket really is
encrypted and non-public, read from the real API rather than defaulted.

The AWS work used a temporary read-only IAM role tagged `managed-by=synapse-e2e`, deleted at
teardown and verified absent (`NoSuchEntity`). Total incremental AWS cost: **$0.00**.

## Scope

Code only — no artifacts, docs, or `.gitignore` changes. `docs/guide/cloud-posture.md` needs no
edit: the sandbox fix makes the layout it already documents actually work.

## Checklist

- [x] `make build vet test typecheck` passes — **245 packages, 0 failures**
- [x] `cd web && pnpm build` passes (if the dashboard changed) — no dashboard changes; `pnpm typecheck` run via `make typecheck`
- [x] Tests added/updated for new behavior — 13 regression tests, each verified to fail without its fix
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets out of
      logs, deterministic reports, append-only evidence) — see notes below
- [x] Documentation updated if needed — no change required
- [x] `make lint` (golangci-lint v2) — **0 issues**
- [x] `TestHostileHarness` passes (security- and execution-sensitive changes)

### Safety-invariant notes for review

These changes touch the sandbox, the credential path, and an auth plane, so the relevant invariants
are called out explicitly:

- **argv exec** — unchanged. The sandbox fix adds a bwrap `--ro-bind-try` flag to an argv array; no
  shell string is constructed anywhere.
- **Server-side scope enforcement** — unchanged and re-verified. Out-of-scope cloud roots, expired
  authorization windows, RoE tool-class denial, and non-read-only cloud operations all still refuse
  before any provider request, and each denial is audited.
- **Secrets out of logs** — *strengthened*. The new stderr diagnostic is the only path added, and it
  redacts against the credential, bounds the output, and refuses to emit at all if a redaction
  placeholder survives. Two dedicated tests cover the leak case.
- **Sandbox confinement** — narrowed, not widened. Only the single integrity-verified binary file is
  bound, never its parent directory; a test asserts `/opt/synapse/bin` and `/opt` are *not* bound
  and that lookalike paths (`/libexec/...`, `/lib-evil/...`) are not mistaken for the curated root.
- **Append-only evidence / deterministic reports** — untouched.
- **Tenant RLS** — *strengthened*. Two of these fixes exist specifically to make RLS-scoped writes
  work correctly rather than to bypass them; the tenant is always taken from a token or an
  authenticated principal, never from client input.

### Not covered here

Azure and GCP connectors were not exercised (no credentials in that environment). AWS did exercise
the shared CSPM machinery — defects 7–10 were all found on that shared path — but the
provider-specific Azure/GCP code remains unvalidated end to end.
