### PR TITLE
fix(binregistry): execute verified resolved path

### DIFF
--- a/internal/infrastructure/sandbox/binintegrity_integration_test.go
+++ b/internal/infrastructure/sandbox/binintegrity_integration_test.go
@@ -54,3 +54,36 @@ func TestBinaryIntegrityRefusesTamper(t *testing.T) {
 	}
 	t.Logf("F5 OK: replaced binary refused before exec (%v)", err)
 }
+
+// TestBinaryIntegrityExecutesResolvedSymlinkTarget proves the path returned by the registry is the
+// one passed to bubblewrap and exec. Re-resolving the input symlink downstream would reopen the
+// target-swap window that verification is intended to close.
+func TestBinaryIntegrityExecutesResolvedSymlinkTarget(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not installed")
+	}
+	sb, err := sandbox.NewRunner(20*time.Second, 8<<20, 1<<30, 256)
+	if err != nil {
+		t.Skipf("sandbox unavailable: %v", err)
+	}
+	sb.SetBinaryRegistry(binregistry.New(nil, true))
+
+	dir := t.TempDir()
+	link := filepath.Join(dir, "verified-sh")
+	if err := os.Symlink("/bin/sh", link); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := sb.Run(context.Background(), ports.ToolSpec{
+		Name: link, Args: []string{"-c", `printf %s "$0"`}, Workdir: dir,
+	})
+	if err != nil {
+		t.Fatalf("run symlinked tool: %v", err)
+	}
+	if got := string(result.Stdout); got != resolved {
+		t.Fatalf("executed argv[0] = %q, want verified resolved path %q", got, resolved)
+	}
+}

--- a/internal/infrastructure/sandbox/runner.go
+++ b/internal/infrastructure/sandbox/runner.go
@@ -210,19 +210,21 @@ func (r *Runner) Run(ctx context.Context, spec ports.ToolSpec) (ports.ToolResult
 		return ports.ToolResult{}, fmt.Errorf("%w: build seccomp filter: %v", shared.ErrValidation, serr)
 	}
 	defer func() { _ = seccompF.Close() }()
-	// Settle the exec path BEFORE verification, so the path that is verified is the path that is
-	// bound and executed (closing the verify-path != exec-path gap). An absolute name is kept as
-	// given - that is the operator-configured helper the bind below exists for. The host PATH counts
-	// as an authority for a bare name only when that name will also be integrity-verified.
+	// Settle PATH lookup before verification. An absolute name is kept as given; the registry below
+	// then resolves any symlinks and returns the exact path it hashed. The host PATH counts as an
+	// authority for a bare name only when that name will also be integrity-verified.
 	hostPATHIsAuthority := r.binreg != nil
 	spec.Name = resolveToolPath(spec.Name, hostPATHIsAuthority)
-	// F5: verify the tool binary's integrity before it runs. The resolved on-disk binary
-	// must match its pin (operator hash and/or trust-on-first-use); a replaced binary is
-	// refused. Defends the "compromised tool binary" threat the audit named.
+	// F5: verify the tool binary's integrity before it runs, then bind and execute the returned
+	// symlink-resolved path. This prevents a symlink swap from selecting a different target after
+	// verification. It does not eliminate the residual window in which that target's contents could
+	// be replaced between hashing and exec; fully closing that requires an fd-based execution path.
 	if r.binreg != nil {
-		if verr := r.binreg.Verify(spec.Name); verr != nil {
+		verifiedPath, verr := r.binreg.Verify(spec.Name)
+		if verr != nil {
 			return ports.ToolResult{}, fmt.Errorf("%w: %v", shared.ErrValidation, verr)
 		}
+		spec.Name = verifiedPath
 	}
 	// F3: a per-run cgroup v2 with hard memory.max + pids.max so a memory/fork bomb is
 	// contained on EVERY path (egress and isolated), independent of systemd-run. The tool
@@ -474,7 +476,8 @@ func (r *Runner) bwrapArgs(spec ports.ToolSpec, sharedNet bool, hostsFile string
 	// "bwrap: execvp ...: No such file or directory". Bind the single resolved FILE read-only, never
 	// its directory, so nothing else in that tree becomes visible. Only an absolute path is bound,
 	// and resolveToolPath keeps the host PATH from making a bare name absolute unless it is also
-	// integrity-verified - so what gets bound is operator authority, not an inherited PATH entry.
+	// integrity-verified. When the registry is enabled, spec.Name is also the symlink-resolved path
+	// it hashed, so a later symlink retarget cannot change this bind or the exec path.
 	if bin := strings.TrimSpace(spec.Name); strings.HasPrefix(bin, "/") && !underCuratedRoot(bin) {
 		args = append(args, "--ro-bind-try", bin, bin)
 	}

--- a/internal/platform/binregistry/registry.go
+++ b/internal/platform/binregistry/registry.go
@@ -41,12 +41,20 @@ func New(expected map[string]string, tofu bool) *Registry {
 }
 
 // Verify hashes the binary at path (symlinks resolved), checks it against its pin, and returns
-// the resolved path. Callers must execute the returned path rather than resolving the input again.
-// Returns ErrIntegrity on a mismatch; records a TOFU pin on first sight when enabled.
+// the resolved path. The returned path is always absolute, so callers can bind and execute it
+// verbatim rather than resolving the input again. Returns ErrIntegrity on a mismatch; records a
+// TOFU pin on first sight when enabled.
 func (r *Registry) Verify(path string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		return "", fmt.Errorf("%w: cannot resolve %q: %v", ErrIntegrity, path, err)
+	}
+	// EvalSymlinks preserves relative-ness: a bare name that host PATH resolution left unresolved
+	// would resolve against the process CWD and come back relative, and the sandbox binds/execs only
+	// absolute paths - so bwrap would re-resolve the bare name against its own PATH and run a file
+	// this never hashed. Refuse a non-absolute result so the verify==exec invariant is total.
+	if !filepath.IsAbs(resolved) {
+		return "", fmt.Errorf("%w: resolved path %q is not absolute", ErrIntegrity, resolved)
 	}
 	sum, err := hashFile(resolved)
 	if err != nil {

--- a/internal/platform/binregistry/registry.go
+++ b/internal/platform/binregistry/registry.go
@@ -40,33 +40,43 @@ func New(expected map[string]string, tofu bool) *Registry {
 	return &Registry{expected: cp, seen: map[string]string{}, tofu: tofu}
 }
 
-// Verify hashes the binary at path (symlinks resolved) and checks it against its pin.
+// Verify hashes the binary at path (symlinks resolved), checks it against its pin, and returns
+// the resolved path. Callers must execute the returned path rather than resolving the input again.
 // Returns ErrIntegrity on a mismatch; records a TOFU pin on first sight when enabled.
-func (r *Registry) Verify(path string) error {
+func (r *Registry) Verify(path string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return fmt.Errorf("%w: cannot resolve %q: %v", ErrIntegrity, path, err)
+		return "", fmt.Errorf("%w: cannot resolve %q: %v", ErrIntegrity, path, err)
 	}
 	sum, err := hashFile(resolved)
 	if err != nil {
-		return fmt.Errorf("%w: cannot hash %q: %v", ErrIntegrity, resolved, err)
+		return "", fmt.Errorf("%w: cannot hash %q: %v", ErrIntegrity, resolved, err)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// Authoritative pin keyed by resolved path or by basename (so config can pin "naabu").
 	if want, ok := r.expected[resolved]; ok {
-		return matchOrErr(resolved, want, sum)
+		if err := matchOrErr(resolved, want, sum); err != nil {
+			return "", err
+		}
+		return resolved, nil
 	}
 	if want, ok := r.expected[filepath.Base(resolved)]; ok {
-		return matchOrErr(resolved, want, sum)
+		if err := matchOrErr(resolved, want, sum); err != nil {
+			return "", err
+		}
+		return resolved, nil
 	}
 	if r.tofu {
 		if first, ok := r.seen[resolved]; ok {
-			return matchOrErr(resolved, first, sum)
+			if err := matchOrErr(resolved, first, sum); err != nil {
+				return "", err
+			}
+			return resolved, nil
 		}
 		r.seen[resolved] = sum // pin on first use
 	}
-	return nil
+	return resolved, nil
 }
 
 func matchOrErr(path, want, got string) error {

--- a/internal/platform/binregistry/registry_test.go
+++ b/internal/platform/binregistry/registry_test.go
@@ -75,3 +75,21 @@ func TestVerifyReturnsResolvedPath(t *testing.T) {
 		t.Fatalf("Verify(%q) returned %q, want resolved target %q", link, resolved, want)
 	}
 }
+
+// TestVerifyRejectsNonAbsoluteResolvedPath proves the verify==exec invariant is total: a bare name
+// that host PATH resolution left unresolved resolves against CWD and comes back relative, which the
+// sandbox cannot bind - so Verify must refuse it rather than return a path bwrap would re-resolve.
+func TestVerifyRejectsNonAbsoluteResolvedPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tool"), []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir) // so EvalSymlinks("tool") resolves relative to this dir and stays relative
+	resolved, err := New(nil, true).Verify("tool")
+	if !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("a non-absolute resolved path must be refused, got %v", err)
+	}
+	if resolved != "" {
+		t.Fatalf("a refused verification must not return a path, got %q", resolved)
+	}
+}

--- a/internal/platform/binregistry/registry_test.go
+++ b/internal/platform/binregistry/registry_test.go
@@ -14,17 +14,17 @@ func TestTOFUPinsThenDetectsTamper(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := New(nil, true)
-	if err := r.Verify(bin); err != nil {
+	if _, err := r.Verify(bin); err != nil {
 		t.Fatalf("first Verify (TOFU pin) should succeed: %v", err)
 	}
-	if err := r.Verify(bin); err != nil {
+	if _, err := r.Verify(bin); err != nil {
 		t.Fatalf("unchanged binary should still verify: %v", err)
 	}
 	// Replace the binary – a later run must be refused.
 	if err := os.WriteFile(bin, []byte("TAMPERED"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Verify(bin); !errors.Is(err, ErrIntegrity) {
+	if _, err := r.Verify(bin); !errors.Is(err, ErrIntegrity) {
 		t.Fatalf("a replaced binary must fail integrity, got %v", err)
 	}
 }
@@ -34,8 +34,12 @@ func TestExpectedHashMismatchRefused(t *testing.T) {
 	bin := filepath.Join(dir, "tool")
 	_ = os.WriteFile(bin, []byte("x"), 0o755)
 	r := New(map[string]string{"tool": "deadbeef"}, false) // wrong pin
-	if err := r.Verify(bin); !errors.Is(err, ErrIntegrity) {
+	resolved, err := r.Verify(bin)
+	if !errors.Is(err, ErrIntegrity) {
 		t.Fatalf("a binary not matching its authoritative pin must be refused, got %v", err)
+	}
+	if resolved != "" {
+		t.Fatalf("a failed verification must not return an executable path, got %q", resolved)
 	}
 }
 
@@ -43,7 +47,31 @@ func TestNoPinNoTOFUAllows(t *testing.T) {
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "tool")
 	_ = os.WriteFile(bin, []byte("x"), 0o755)
-	if err := New(nil, false).Verify(bin); err != nil {
+	if _, err := New(nil, false).Verify(bin); err != nil {
 		t.Fatalf("with no pin and tofu off, verification is a no-op: %v", err)
+	}
+}
+
+func TestVerifyReturnsResolvedPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "tool-v1")
+	link := filepath.Join(dir, "tool")
+	if err := os.WriteFile(target, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	resolved, err := New(nil, false).Verify(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != want || resolved == link {
+		t.Fatalf("Verify(%q) returned %q, want resolved target %q", link, resolved, want)
 	}
 }


### PR DESCRIPTION
## Summary

- make `binregistry.Registry.Verify` return the symlink-resolved path only after successful integrity verification
- replace the sandbox tool path with that verified result before building bubblewrap bind and exec arguments
- document the exact guarantee and the remaining in-place-content replacement window
- add registry and Linux sandbox regressions proving a symlinked tool executes via the verified resolved path

## Security impact

Previously, verification hashed the target of a symlink but discarded that resolved path. A retarget between verification and bubblewrap could therefore select a different file for bind/exec. The sandbox now carries the verified path forward, so later symlink retargeting cannot change the selected target.

This deliberately does not claim to close the remaining hash-to-exec window for replacing the resolved target's contents; that requires a future fd-based execution design.

## Verification

- `go test ./internal/platform/binregistry ./internal/infrastructure/sandbox -count=1`
- `go test ./internal/infrastructure/tools/syft ./internal/infrastructure/tools/grype ./internal/infrastructure/recon -count=1`
- `go vet ./internal/platform/binregistry ./internal/infrastructure/sandbox`
- Linux/amd64 sandbox test binary cross-compiles successfully with `CGO_ENABLED=0`
- `git diff --check`
- `go test ./... -count=1`: every code package passed; the unchanged `docs` package reports four publication-mirror drift failures already present at `upstream/main` (`24693b2`)

Closes #580