### PR TITLE
feat(httpapi): add dependency readiness probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@
 # REQUIRED before the server will start
 # =============================================================================
 # Bootstrap-admin bearer token – the API exits if this is empty. Operational API
-# routes require it; GET /healthz is intentionally public. Generate: openssl rand -hex 32
+# routes require it; GET /healthz and GET /readyz are intentionally public. Generate: openssl rand -hex 32
 SYNAPSE_API_TOKEN=
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ make install                       # Go modules + web deps
 make tools                         # syft + grype into ./bin
 export PATH="$PWD/bin:$PATH"
 
-export SYNAPSE_API_TOKEN="$(openssl rand -hex 32)"   # required for operational API routes; /healthz is public
+export SYNAPSE_API_TOKEN="$(openssl rand -hex 32)"   # required for operational API routes; /healthz and /readyz are public
 make dev                           # API on :8080, dashboard on :5173
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,7 @@ operator is responsible for holding written permission.
 Hardening highlights operators should preserve:
 
 - Always set `SYNAPSE_API_TOKEN`; operational API routes require authentication. The intentionally
-  public `GET /healthz` endpoint exposes only service health.
+  public `GET /healthz` and `GET /readyz` endpoints expose only liveness and named dependency pass/fail state.
 - Run the execution sandbox and live recon on a Linux host; they **fail closed** without
   the required kernel features rather than running unsandboxed.
 - Keep secrets in the credential vault; never place them in logs or source.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7,7 +7,7 @@ info:
     Authorized security testing only: every scan is gated by an engagement's
     scope and authorization window, enforced server-side.
 
-    Auth: all endpoints except `/healthz` require a bearer token
+    Auth: all endpoints except `/healthz` and `/readyz` require a bearer token
     (`Authorization: Bearer <SYNAPSE_API_TOKEN>`). After authentication, every
     endpoint except the AUP endpoints also requires that the current Acceptable
     Use Policy has been accepted, else `403`.
@@ -59,6 +59,24 @@ paths:
                 properties:
                   status: {type: string, example: ok}
                   service: {type: string, example: synapse-api}
+
+  /readyz:
+    get:
+      tags: [health]
+      summary: Dependency readiness probe
+      description: Checks PostgreSQL, embedded migration state, and the object store when configured.
+      security: []
+      responses:
+        "200":
+          description: Every configured dependency is ready
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/Readiness"}
+        "503":
+          description: One or more configured dependencies failed or timed out
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/Readiness"}
 
   /api/v1/aup:
     get:
@@ -1844,6 +1862,19 @@ components:
           schema: {$ref: "#/components/schemas/Error"}
 
   schemas:
+    Readiness:
+      type: object
+      required: [status, checks]
+      properties:
+        status:
+          type: string
+          enum: [ready, not_ready]
+        checks:
+          type: object
+          additionalProperties:
+            type: string
+            enum: [ok, failed]
+
     SLATier:
       type: string
       enum: [emergency, critical, high, medium, low, exception]

--- a/api/openapi_coverage_test.go
+++ b/api/openapi_coverage_test.go
@@ -75,9 +75,9 @@ func TestOpenAPIHasNoDeadOperations(t *testing.T) {
 	sort.Strings(described)
 
 	for _, op := range described {
-		// /healthz lives outside /api/v1 and is registered separately; it is verified by the
+		// Health probes live outside /api/v1 and are registered separately; they are verified by the
 		// public-endpoint assertions in openapi_test.go rather than here.
-		if strings.HasSuffix(op, " /healthz") {
+		if strings.HasSuffix(op, " /healthz") || strings.HasSuffix(op, " /readyz") {
 			continue
 		}
 		if !registered[op] {

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -296,6 +296,7 @@ func main() {
 	var approvalStore ports.ApprovalStore         // durable HITL approval queue
 	var planStore ports.PlanStore                 // agent execution-plan DAG
 	var decisionStore ports.DecisionStore         // structured decision log
+	readinessChecks := map[string]httpapi.ReadinessCheck{}
 
 	// Credential vault cipher: a configured master key gives durable
 	// encryption; an empty key yields an ephemeral one (dev only – stored secrets won't
@@ -360,6 +361,12 @@ func main() {
 			os.Exit(1)
 		}
 		defer pool.Close()
+		readinessChecks["database"] = func(ctx context.Context) error {
+			return postgres.CheckDatabaseReady(ctx, pool)
+		}
+		readinessChecks["migrations"] = func(ctx context.Context) error {
+			return postgres.CheckMigrationsReady(ctx, pool)
+		}
 		// Single-instance guard: until horizontal scaling the repos
 		// ignore tenant_id and there is no leader election, so two writers would race. A
 		// session advisory lock makes the assumption explicit + enforced – a second
@@ -603,6 +610,7 @@ func main() {
 			os.Exit(1)
 		}
 		blobStore = bs
+		readinessChecks["object_store"] = bs.CheckReady
 		log.Info("blob store: minio/s3", "bucket", cfg.BlobBucket)
 	} else {
 		blobStore = blob.NewMemory()
@@ -1150,6 +1158,7 @@ func main() {
 		os.Exit(1)
 	}
 	router := httpapi.NewRouter(log, auth, engService, scaService, aupService, findingsService, exportService, reportService, evidenceService, reconService, logBroker, transferService, auditService, vexService, usersService, credentialsService)
+	router.SetReadinessChecks(readinessChecks)
 	if slaService != nil {
 		router.SetSLA(slaService)
 	}

--- a/deploy/docker-compose.full.yml
+++ b/deploy/docker-compose.full.yml
@@ -1,7 +1,8 @@
 # Full Synapse stack: API server + Postgres + MinIO (+ bucket init), all env wired.
 #
 #   docker compose -f deploy/docker-compose.full.yml up -d --build
-#   curl localhost:8080/healthz
+#   curl localhost:8080/healthz   # liveness
+#   curl localhost:8080/readyz    # dependency readiness
 #   # authenticated call:
 #   curl -H "Authorization: Bearer $SYNAPSE_API_TOKEN" localhost:8080/api/...
 #
@@ -113,7 +114,7 @@ services:
       - project-source-artifacts:/home/synapse/project-source-artifacts
       # - ../:/scan:ro            # uncomment to `synapse-cli scan /scan` this repo
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS localhost:8080/healthz || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS localhost:8080/readyz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -14,7 +14,7 @@ Conventions: an empty value means unset, so the built-in default applies. Boolea
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `SYNAPSE_API_TOKEN` | (none) | Bootstrap-admin bearer token. The API exits if empty. Operational routes require it; `GET /healthz` is intentionally public. Generate with `openssl rand -hex 32`. |
+| `SYNAPSE_API_TOKEN` | (none) | Bootstrap-admin bearer token. The API exits if empty. Operational routes require it; liveness `GET /healthz` and readiness `GET /readyz` are intentionally public. Generate with `openssl rand -hex 32`. |
 
 ## Core and server
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -107,14 +107,29 @@ Recommended hardening:
 - Terminate TLS at your load balancer or reverse proxy in front of the API.
 - Back up the database and the evidence object store together; a report depends on both.
 
-`GET /healthz` is unauthenticated by design. Every other API route requires the bearer token.
+`GET /healthz` and `GET /readyz` are unauthenticated by design. Every other API route requires the bearer token.
 
-## Health check
+## Liveness and readiness probes
 
-The API exposes an unauthenticated `GET /healthz` for liveness and readiness probes.
+`GET /healthz` is a constant liveness probe: `200` means the process and HTTP listener are alive. It
+does not inspect dependencies. `GET /readyz` runs the configured PostgreSQL, migration, and evidence
+object-store checks concurrently with a short timeout. It returns `200` only when every check passes,
+or `503` with per-check pass/fail states; dependency errors and credentials are never exposed.
+
+In in-memory development mode no external checks are configured, so readiness follows process health.
+The full Compose stack uses `/readyz` for its service health condition. Kubernetes should keep the two
+signals separate:
 
 ```bash
 curl -s http://localhost:8080/healthz
+curl -s http://localhost:8080/readyz
+```
+
+```yaml
+livenessProbe:
+  httpGet: {path: /healthz, port: 8080}
+readinessProbe:
+  httpGet: {path: /readyz, port: 8080}
 ```
 
 Next: [Security model](security.md)

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -38,8 +38,8 @@ make dev                                             # API on :8080, dashboard o
 ```
 
 `SYNAPSE_API_TOKEN` is the only required development setting. The server refuses to start without it.
-Operational API routes require it; `GET /healthz` is intentionally public so probes work without a
-credential.
+Operational API routes require it; liveness `GET /healthz` and dependency readiness `GET /readyz` are
+intentionally public so probes work without a credential.
 
 A blank `SYNAPSE_DB_DSN` runs the development persistence: in-memory stores plus a few local files such as
 `data/audit.jsonl`. It is not durable and not suitable for real work, but it is not purely ephemeral

--- a/internal/adapter/httpapi/auth_test.go
+++ b/internal/adapter/httpapi/auth_test.go
@@ -45,7 +45,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		}
 		return Principal{}, false
 	})
-	public := map[string]bool{"/healthz": true}
+	public := map[string]bool{"/healthz": true, "/readyz": true}
 
 	var nextCalled bool
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -62,6 +62,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		wantNext bool
 	}{
 		{"public needs no token", "/healthz", "", http.StatusOK, true},
+		{"readiness needs no token", "/readyz", "", http.StatusOK, true},
 		{"protected missing token", "/api/v1/engagements", "", http.StatusUnauthorized, false},
 		{"protected wrong token", "/api/v1/engagements", "Bearer nope", http.StatusUnauthorized, false},
 		{"protected wrong scheme", "/api/v1/engagements", "Basic secret", http.StatusUnauthorized, false},

--- a/internal/adapter/httpapi/middleware_test.go
+++ b/internal/adapter/httpapi/middleware_test.go
@@ -33,7 +33,7 @@ func TestNormalizePathRejectsNonCanonical(t *testing.T) {
 		}
 	}
 
-	good := []string{"/healthz", "/api/v1/engagements", "/api/v1/aup", "/api/v1/aup/accept", "/"}
+	good := []string{"/healthz", "/readyz", "/api/v1/engagements", "/api/v1/aup", "/api/v1/aup/accept", "/"}
 	for _, p := range good {
 		called = false
 		rec := httptest.NewRecorder()

--- a/internal/adapter/httpapi/readiness.go
+++ b/internal/adapter/httpapi/readiness.go
@@ -1,0 +1,94 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultReadinessTimeout = 2 * time.Second
+
+// ReadinessCheck verifies one dependency required to serve production traffic.
+// The endpoint exposes only the check name and pass/fail state, never the returned error.
+type ReadinessCheck func(context.Context) error
+
+type readinessConfig struct {
+	checks  map[string]ReadinessCheck
+	timeout time.Duration
+}
+
+type readinessResponse struct {
+	Status string            `json:"status"`
+	Checks map[string]string `json:"checks"`
+}
+
+// SetReadinessChecks replaces the dependency checks used by GET /readyz. It copies the map so
+// startup wiring cannot mutate the live probe configuration after the server begins serving.
+func (rt *Router) SetReadinessChecks(checks map[string]ReadinessCheck) {
+	rt.readiness.checks = make(map[string]ReadinessCheck, len(checks))
+	for name, check := range checks {
+		if name = strings.TrimSpace(name); name != "" && check != nil {
+			rt.readiness.checks[name] = check
+		}
+	}
+}
+
+func (rt *Router) ready(w http.ResponseWriter, r *http.Request) {
+	checks := rt.readiness.checks
+	states := make(map[string]string, len(checks))
+	w.Header().Set("Cache-Control", "no-store")
+	if len(checks) == 0 {
+		writeJSON(w, http.StatusOK, readinessResponse{Status: "ready", Checks: states})
+		return
+	}
+
+	timeout := rt.readiness.timeout
+	if timeout <= 0 {
+		timeout = defaultReadinessTimeout
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	type result struct {
+		name string
+		err  error
+	}
+	results := make(chan result, len(checks))
+	pending := make(map[string]struct{}, len(checks))
+	for name, check := range checks {
+		pending[name] = struct{}{}
+		go func() {
+			results <- result{name: name, err: check(ctx)}
+		}()
+	}
+
+	isReady := true
+	for len(pending) > 0 {
+		select {
+		case result := <-results:
+			if _, ok := pending[result.name]; !ok {
+				continue
+			}
+			delete(pending, result.name)
+			if result.err != nil {
+				states[result.name] = "failed"
+				isReady = false
+			} else {
+				states[result.name] = "ok"
+			}
+		case <-ctx.Done():
+			for name := range pending {
+				states[name] = "failed"
+			}
+			isReady = false
+			pending = nil
+		}
+	}
+
+	if !isReady {
+		writeJSON(w, http.StatusServiceUnavailable, readinessResponse{Status: "not_ready", Checks: states})
+		return
+	}
+	writeJSON(w, http.StatusOK, readinessResponse{Status: "ready", Checks: states})
+}

--- a/internal/adapter/httpapi/readiness_test.go
+++ b/internal/adapter/httpapi/readiness_test.go
@@ -1,0 +1,118 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReadinessEndpointReportsDependencyStateWithoutDetails(t *testing.T) {
+	tests := []struct {
+		name       string
+		checks     map[string]ReadinessCheck
+		wantCode   int
+		wantStatus string
+		wantChecks map[string]string
+	}{
+		{
+			name:       "no external dependencies",
+			wantCode:   http.StatusOK,
+			wantStatus: "ready",
+			wantChecks: map[string]string{},
+		},
+		{
+			name: "ready", wantCode: http.StatusOK, wantStatus: "ready",
+			checks: map[string]ReadinessCheck{
+				"database":     func(context.Context) error { return nil },
+				"migrations":   func(context.Context) error { return nil },
+				"object_store": func(context.Context) error { return nil },
+			},
+			wantChecks: map[string]string{"database": "ok", "migrations": "ok", "object_store": "ok"},
+		},
+		{
+			name: "database down", wantCode: http.StatusServiceUnavailable, wantStatus: "not_ready",
+			checks: map[string]ReadinessCheck{
+				"database":   func(context.Context) error { return errors.New("dial postgres://secret@db") },
+				"migrations": func(context.Context) error { return nil },
+			},
+			wantChecks: map[string]string{"database": "failed", "migrations": "ok"},
+		},
+		{
+			name: "migrations incomplete", wantCode: http.StatusServiceUnavailable, wantStatus: "not_ready",
+			checks: map[string]ReadinessCheck{
+				"database":   func(context.Context) error { return nil },
+				"migrations": func(context.Context) error { return errors.New("102 of 103 applied") },
+			},
+			wantChecks: map[string]string{"database": "ok", "migrations": "failed"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &Router{}
+			rt.SetReadinessChecks(tc.checks)
+			recorder := httptest.NewRecorder()
+			rt.routes().ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+			if recorder.Code != tc.wantCode {
+				t.Fatalf("status code=%d, want %d; body=%s", recorder.Code, tc.wantCode, recorder.Body.String())
+			}
+			var response readinessResponse
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			if response.Status != tc.wantStatus {
+				t.Errorf("status=%q, want %q", response.Status, tc.wantStatus)
+			}
+			if !reflect.DeepEqual(response.Checks, tc.wantChecks) {
+				t.Errorf("checks=%v, want %v", response.Checks, tc.wantChecks)
+			}
+			if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+				t.Errorf("Cache-Control=%q, want no-store", got)
+			}
+			if strings.Contains(recorder.Body.String(), "secret") || strings.Contains(recorder.Body.String(), "102") {
+				t.Fatalf("readiness response leaked dependency details: %s", recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestReadinessTimesOutAndRemainsPublic(t *testing.T) {
+	rt := &Router{auth: NewAuthenticator(func(context.Context, string) (Principal, bool) {
+		t.Fatal("public readiness probe attempted authentication")
+		return Principal{}, false
+	})}
+	rt.readiness.timeout = 10 * time.Millisecond
+	rt.SetReadinessChecks(map[string]ReadinessCheck{
+		"database": func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	recorder := httptest.NewRecorder()
+	rt.Handler().ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if recorder.Code != http.StatusServiceUnavailable || !strings.Contains(recorder.Body.String(), `"database":"failed"`) {
+		t.Fatalf("timed-out readiness response code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestHealthzRemainsConstantLivenessProbe(t *testing.T) {
+	called := false
+	rt := &Router{}
+	rt.SetReadinessChecks(map[string]ReadinessCheck{
+		"database": func(context.Context) error {
+			called = true
+			return errors.New("down")
+		},
+	})
+	recorder := httptest.NewRecorder()
+	rt.routes().ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if recorder.Code != http.StatusOK || called || recorder.Body.String() != "{\"service\":\"synapse-api\",\"status\":\"ok\"}\n" {
+		t.Fatalf("liveness changed: code=%d called=%v body=%q", recorder.Code, called, recorder.Body.String())
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -94,6 +94,7 @@ type Router struct {
 	vulnerabilityRead      *vulnerabilityinteluc.Service
 	vulnerabilityActions   *vulnerabilityactionuc.Service
 	sla                    *slauc.Service
+	readiness              readinessConfig
 }
 
 // findingVerifier is the narrow slice of the exploitation use-case the verify endpoint needs:
@@ -266,8 +267,9 @@ func (rt *Router) routes() *http.ServeMux {
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "service": "synapse-api"})
 	})
+	mux.HandleFunc("GET /readyz", rt.ready)
 	// Identity/consent routes carry NO role gate (a brand-new principal must reach them): /aup,
-	// /aup/accept, /me, and public /healthz. EVERY other route below is registered through
+	// /aup/accept, /me, and public probes. EVERY other route below is registered through
 	// authz(perm, …) – the single RBAC chokepoint, so no handler decides its own role
 	// check. Engagement child routes compose authz OUTSIDE withEngTenant: the role 403 is decided
 	// first and cheaply (without revealing whether a cross-tenant engagement exists); a role-allowed
@@ -584,10 +586,11 @@ func (rt *Router) routes() *http.ServeMux {
 // raw-vs-cleaned path mismatch).
 func (rt *Router) Handler() http.Handler {
 	// Public: no auth and no AUP gate.
-	public := map[string]bool{"/healthz": true}
+	public := map[string]bool{"/healthz": true, "/readyz": true}
 	// Authenticated but exempt from the AUP gate (so the operator can read + accept).
 	aupExempt := map[string]bool{
 		"/healthz":           true,
+		"/readyz":            true,
 		"/api/v1/aup":        true,
 		"/api/v1/aup/accept": true,
 		"/api/v1/me":         true,

--- a/internal/infrastructure/blob/minio.go
+++ b/internal/infrastructure/blob/minio.go
@@ -88,3 +88,16 @@ func (m *MinIO) Get(ctx context.Context, key string) ([]byte, error) {
 	}
 	return data, nil
 }
+
+// CheckReady verifies that the configured evidence bucket remains reachable. It performs no object
+// reads or writes and is safe to call from the unauthenticated readiness endpoint.
+func (m *MinIO) CheckReady(ctx context.Context) error {
+	exists, err := m.client.BucketExists(ctx, m.bucket)
+	if err != nil {
+		return fmt.Errorf("minio bucket readiness: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("minio bucket readiness: bucket is missing")
+	}
+	return nil
+}

--- a/internal/infrastructure/blob/minio_test.go
+++ b/internal/infrastructure/blob/minio_test.go
@@ -1,0 +1,57 @@
+package blob
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func TestMinIOCheckReadyUsesBucketProbe(t *testing.T) {
+	headStatus := http.StatusOK
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/evidence/" {
+			t.Errorf("unexpected readiness request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-east-1</LocationConstraint>`))
+		case http.MethodHead:
+			w.WriteHeader(headStatus)
+		default:
+			t.Errorf("unexpected readiness request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	client, err := minio.New(strings.TrimPrefix(server.URL, "http://"), &minio.Options{
+		Creds: credentials.NewStaticV4("access", "secret", ""),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &MinIO{client: client, bucket: "evidence"}
+	if err := store.CheckReady(context.Background()); err != nil {
+		t.Fatalf("reachable bucket should be ready: %v", err)
+	}
+
+	headStatus = http.StatusNotFound
+	if err := store.CheckReady(context.Background()); err == nil {
+		t.Fatal("missing bucket must not be ready")
+	}
+
+	server.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	if err := store.CheckReady(ctx); err == nil {
+		t.Fatal("unreachable object store must not be ready")
+	}
+}

--- a/internal/infrastructure/persistence/postgres/db.go
+++ b/internal/infrastructure/persistence/postgres/db.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // registers the "pgx" database/sql driver for goose
 	"github.com/pressly/goose/v3"
@@ -164,6 +165,63 @@ func Migrate(ctx context.Context, dsn string) error {
 	}
 	if err := goose.UpContext(ctx, db, "."); err != nil {
 		return fmt.Errorf("migrate up: %w", err)
+	}
+	return nil
+}
+
+// CheckDatabaseReady verifies the runtime pool can execute a trivial query.
+func CheckDatabaseReady(ctx context.Context, pool *pgxpool.Pool) error {
+	return checkDatabaseReady(ctx, pool)
+}
+
+type readinessQueryer interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+func checkDatabaseReady(ctx context.Context, queryer readinessQueryer) error {
+	var one int
+	if err := queryer.QueryRow(ctx, "SELECT 1").Scan(&one); err != nil {
+		return fmt.Errorf("database readiness: %w", err)
+	}
+	if one != 1 {
+		return fmt.Errorf("database readiness returned %d", one)
+	}
+	return nil
+}
+
+// CheckMigrationsReady verifies the latest state of every embedded migration is applied. Goose
+// retains down records, so the query considers only the newest row for each migration version.
+func CheckMigrationsReady(ctx context.Context, pool *pgxpool.Pool) error {
+	return checkMigrationsReady(ctx, pool)
+}
+
+func checkMigrationsReady(ctx context.Context, queryer readinessQueryer) error {
+	entries, err := migrations.FS.ReadDir(".")
+	if err != nil {
+		return fmt.Errorf("read embedded migrations: %w", err)
+	}
+	expected := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".sql") {
+			expected++
+		}
+	}
+
+	var applied int
+	err = queryer.QueryRow(ctx, `
+		SELECT count(*)
+		FROM (
+			SELECT DISTINCT ON (version_id) version_id, is_applied
+			FROM goose_db_version
+			WHERE version_id > 0
+			ORDER BY version_id, id DESC
+		) AS latest
+		WHERE is_applied`).Scan(&applied)
+	if err != nil {
+		return fmt.Errorf("migration readiness: %w", err)
+	}
+	if applied != expected {
+		return fmt.Errorf("migration readiness: %d of %d embedded migrations applied", applied, expected)
 	}
 	return nil
 }

--- a/internal/infrastructure/persistence/postgres/db_readiness_test.go
+++ b/internal/infrastructure/persistence/postgres/db_readiness_test.go
@@ -1,0 +1,51 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPostgresReadinessChecks(t *testing.T) {
+	dsn := testDSN(t)
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CheckDatabaseReady(ctx, pool); err != nil {
+		t.Fatalf("migrated database should be reachable: %v", err)
+	}
+	if err := CheckMigrationsReady(ctx, pool); err != nil {
+		t.Fatalf("all embedded migrations should be ready: %v", err)
+	}
+
+	// Goose retains migration history. Add an uncommitted latest "down" record and run the check
+	// through the same transaction to prove it considers latest state rather than any historical up.
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var latest int64
+	if err := tx.QueryRow(ctx, `SELECT max(version_id) FROM goose_db_version WHERE is_applied`).Scan(&latest); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO goose_db_version(version_id, is_applied) VALUES($1, false)`, latest); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkMigrationsReady(ctx, tx); err == nil {
+		t.Fatal("a latest down record must make migrations not ready")
+	}
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	pool.Close()
+	if err := CheckDatabaseReady(ctx, pool); err == nil {
+		t.Fatal("a closed database pool must not be ready")
+	}
+}


### PR DESCRIPTION
## Summary

- add a public `GET /readyz` endpoint with concurrent, bounded checks for PostgreSQL connectivity, embedded migration state, and the configured evidence bucket
- preserve `GET /healthz` as constant liveness and return only named `ok`/`failed` states without dependency error details
- wire the full Compose healthcheck to readiness and document separate Compose/Kubernetes liveness and readiness probes
- cover ready, database-down, migration-incomplete, timeout, unauthenticated access, missing/unreachable bucket, and real PostgreSQL behavior

## Why

The existing `/healthz` response is intentionally constant, so orchestrators cannot distinguish a live process from an API that cannot serve traffic. This gives Compose, Kubernetes, and load balancers a dependency-aware signal without changing liveness semantics.

## Verification

- `go test ./internal/adapter/httpapi ./internal/infrastructure/blob ./internal/infrastructure/persistence/postgres ./cmd/synapse-api ./api -count=1`
- `SYNAPSE_TEST_DB_DSN=... go test ./internal/infrastructure/persistence/postgres -run TestPostgresReadinessChecks -count=1 -v` (PostgreSQL 18)
- `go vet ./internal/adapter/httpapi ./internal/infrastructure/blob ./internal/infrastructure/persistence/postgres ./cmd/synapse-api ./api`
- `docker compose -f deploy/docker-compose.full.yml config --no-interpolate --quiet`
- `go test ./... -count=1` passes all code packages; the existing Windows-only docs mirror drift check still reports four unchanged repository mirrors

Closes #585