### PR TITLE
fix(fleet-agent): tag detections with the canonical AgentID, not the display name

### DIFF
--- a/cmd/synapse-agent/detect.go
+++ b/cmd/synapse-agent/detect.go
@@ -15,14 +15,33 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/detectsink"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/ebpf"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
 	detectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detect"
 )
+
+// detectionIdentity derives the canonical (host, agent) identity the detection engine tags its events
+// and detections with, from the ENROLLED credential — never from the mutable display name (cfg.name).
+//
+// This is the D1 fix (#606): the server issues a canonical AgentID at enrolment and resolves the asset
+// binding from it, so renaming an agent must not forge a new data-plane identity, two hosts sharing a
+// display name must not collide, and signing-key lookup by enrolled AgentID must not miss. The agent
+// runs one detection sensor for its own host, so that single canonical AgentID is the identity for both
+// the host and agent tags here; the control plane remains authoritative and binds the asset on ingest.
+// Returns ok=false when the credential carries no AgentID, so detection fails closed rather than
+// starting under an empty or attacker-influenced identity.
+func detectionIdentity(cred fleetclient.Credential) (host, agent shared.ID, ok bool) {
+	id := shared.ID(strings.TrimSpace(cred.AgentID))
+	if id == "" {
+		return "", "", false
+	}
+	return id, id, true
+}
 
 // startDetection launches the agent-side detection engine (#422) in the background when configured. It
 // is strictly best-effort and isolated from the inventory loop: on a host where the eBPF sensor cannot
 // run (non-Linux, no root, missing kernel features) it logs the reason and returns, leaving the agent's
 // normal work untouched. Detection is OFF unless -detect-classes / SYNAPSE_DETECT_CLASSES is set.
-func (r *runner) startDetection(ctx context.Context) {
+func (r *runner) startDetection(ctx context.Context, cred fleetclient.Credential) {
 	classes, err := parseDetectClasses(r.cfg.detectClasses)
 	if err != nil {
 		log.Printf("detection: %v; detection engine disabled", err)
@@ -32,8 +51,11 @@ func (r *runner) startDetection(ctx context.Context) {
 		return // off by default
 	}
 
-	host := shared.ID(r.cfg.name)
-	agent := shared.ID("agent:" + r.cfg.name)
+	host, agent, ok := detectionIdentity(cred)
+	if !ok {
+		log.Print("detection: enrolled credential has no canonical agent id; detection engine disabled")
+		return
+	}
 	sinkPath := filepath.Join(r.cfg.stateDir, "detections.jsonl")
 	sink, err := detectsink.New(sinkPath)
 	if err != nil {

--- a/cmd/synapse-agent/detect_test.go
+++ b/cmd/synapse-agent/detect_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
 )
 
 func TestParseDetectClasses(t *testing.T) {
@@ -45,5 +47,35 @@ func TestFormatCoverageShowsGapsWithReason(t *testing.T) {
 	}
 	if !strings.Contains(s, "file=failed(load failed)") {
 		t.Errorf("gap must show its reason: %q", s)
+	}
+}
+
+// TestDetectionIdentityUsesCanonicalAgentID proves the D1 fix (#606): the detection engine's identity
+// is the server-issued canonical AgentID from the enrolled credential, NOT the mutable display name.
+func TestDetectionIdentityUsesCanonicalAgentID(t *testing.T) {
+	cred := fleetclient.Credential{AgentID: "agt_01HCANONICAL", Token: "secret"}
+	host, agent, ok := detectionIdentity(cred)
+	if !ok {
+		t.Fatalf("expected ok for a credential with an agent id")
+	}
+	if agent != shared.ID("agt_01HCANONICAL") {
+		t.Errorf("agent identity = %q, want the canonical AgentID", agent)
+	}
+	if host != shared.ID("agt_01HCANONICAL") {
+		t.Errorf("host identity = %q, want the canonical AgentID", host)
+	}
+	// The identity must not be derived from the old display-name form.
+	if strings.HasPrefix(string(agent), "agent:") {
+		t.Errorf("agent identity %q still uses the display-name form", agent)
+	}
+}
+
+// TestDetectionIdentityFailsClosedWithoutAgentID proves detection does not start under an empty or
+// whitespace-only identity — no fallback to a display name.
+func TestDetectionIdentityFailsClosedWithoutAgentID(t *testing.T) {
+	for _, id := range []string{"", "   ", "\t"} {
+		if _, _, ok := detectionIdentity(fleetclient.Credential{AgentID: id}); ok {
+			t.Errorf("expected fail-closed (ok=false) for AgentID %q", id)
+		}
 	}
 }

--- a/cmd/synapse-agent/main.go
+++ b/cmd/synapse-agent/main.go
@@ -148,7 +148,9 @@ func (r *runner) run(ctx context.Context) error {
 	}
 	// Agent-side detection engine (#422): a continuous background observer, separate from the
 	// per-work-order inventory cycle below. Best-effort — it never blocks or fails the inventory loop.
-	r.startDetection(ctx)
+	// It is given the enrolled credential so its events carry the canonical AgentID, not the display
+	// name (D1 fix, #606).
+	r.startDetection(ctx, cred)
 	for {
 		if err := r.cycle(ctx, cred); err != nil {
 			if errors.Is(err, context.Canceled) {


### PR DESCRIPTION
## What

Fix defect **D1** (agent-side) from epic #594 / issue #606: the eBPF detection engine tagged its events and detections with an identity derived from the **mutable display name** instead of the **server-issued canonical AgentID**.

Before:
```go
host  := shared.ID(r.cfg.name)              // display name
agent := shared.ID("agent:" + r.cfg.name)   // display name
...
r.startDetection(ctx)                        // credential never passed in
```

After: identity comes from the enrolled credential's canonical `AgentID`, via a pure, testable helper; `startDetection` receives the credential; and it **fails closed** (detection disabled) when no canonical AgentID is present.

## Why (the risk)

With identity taken from `cfg.name`, detections and their **hash-chained evidence** could be mis-attributed:
- renaming an agent (changing `-name` / `SYNAPSE_AGENT_NAME`) forged a **new** data-plane identity;
- two hosts sharing a display name **collided**;
- a signing-key lookup keyed by the enrolled AgentID could **miss**.

The display name is still sent at enrolment/heartbeat — but only for **reconciliation**, never as security identity (unchanged).

## Scope

This is the **agent-side** half of #606. The server-side ingest verification ("reject a batch whose `AgentID`/`HostID` ≠ the authenticated agent") is intentionally **deferred to A3/A4**, when a telemetry/detection ingest endpoint actually exists to enforce it — there is no live ingest path to harden yet. So #606 stays open; this PR closes the identity-forgery vector at the source.

## Tests

- `TestDetectionIdentityUsesCanonicalAgentID` — identity == the canonical enrolled AgentID for both host and agent tags, and is **not** the old `agent:`-prefixed display-name form.
- `TestDetectionIdentityFailsClosedWithoutAgentID` — empty / whitespace-only AgentID → `ok=false` (detection disabled), no display-name fallback.

## Verification (local)

- `go build ./...` · `go vet ./cmd/synapse-agent/...` — clean
- `go test -count=1 ./cmd/synapse-agent/...` — pass
- `golangci-lint run ./cmd/synapse-agent/...` — 0 issues
- `gofmt -l` — clean
- Reviewed for clean-architecture + security (agent-side identity forgery vector closed; no secret logged; fail-closed).

Refs #606 · part of #594.
