### PR TITLE
feat(telemetry): version the wire schema independently of the agent (A0.3)

### DIFF
--- a/internal/domain/telemetryschema/schema.go
+++ b/internal/domain/telemetryschema/schema.go
@@ -1,0 +1,46 @@
+// Package telemetryschema owns the wire-format version of telemetry events and batches (A0.3, epic #594).
+//
+// The schema version is versioned INDEPENDENTLY of the agent binary version: a fleet of mixed agent
+// builds may all ship the same schema, and one agent build may emit an evolving schema across releases.
+// Ingest keys on THIS version, never on the agent version — so the wire contract can evolve without a
+// lockstep fleet upgrade, and upgrading the agent binary does not silently change how its data is read.
+//
+// Compatibility rules:
+//   - Current is the schema this build emits.
+//   - [MinSupported, MaxSupported] is the range a reader accepts. Within the range a reader tolerates
+//     additive fields (a newer minor schema stays readable by an older reader; unknown fields are ignored).
+//   - A version outside the range — or an unset/non-positive version — is REJECTED explicitly by the
+//     ingest gate, never parsed under a guessed shape. The range widens (MaxSupported bumps) only when a
+//     new schema version is actually defined; today only v1 exists.
+package telemetryschema
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	// Current is the telemetry schema version this build emits. Bump it when the wire shape changes; it
+	// is deliberately NOT derived from the agent binary version.
+	Current = 1
+	// MinSupported and MaxSupported bound the versions the ingest reader accepts, inclusive.
+	MinSupported = 1
+	MaxSupported = 1
+)
+
+// Supported reports whether v is within the accepted [MinSupported, MaxSupported] range.
+func Supported(v int) bool { return v >= MinSupported && v <= MaxSupported }
+
+// Validate returns nil when v is an accepted schema version, and a wrapped shared.ErrValidation otherwise
+// so the ingest gate fails closed: a batch that declares no version (0), an impossible version (< 0), or
+// a version outside the supported range is rejected rather than parsed under a guessed shape.
+func Validate(v int) error {
+	if v < MinSupported {
+		return fmt.Errorf("%w: telemetry schema version must be >= %d (0/unset is not allowed), got %d", shared.ErrValidation, MinSupported, v)
+	}
+	if v > MaxSupported {
+		return fmt.Errorf("%w: telemetry schema version %d is newer than this reader supports (max %d); upgrade the control plane", shared.ErrValidation, v, MaxSupported)
+	}
+	return nil
+}

--- a/internal/domain/telemetryschema/schema_test.go
+++ b/internal/domain/telemetryschema/schema_test.go
@@ -1,0 +1,57 @@
+package telemetryschema
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestRangeIsCoherent(t *testing.T) {
+	if MinSupported > MaxSupported {
+		t.Fatalf("MinSupported (%d) must be <= MaxSupported (%d)", MinSupported, MaxSupported)
+	}
+	if !Supported(Current) {
+		t.Fatalf("Current (%d) must be within the supported range [%d,%d]", Current, MinSupported, MaxSupported)
+	}
+}
+
+func TestSupported(t *testing.T) {
+	cases := []struct {
+		v    int
+		want bool
+	}{
+		{MinSupported - 1, false}, // unset/old
+		{0, false},
+		{-1, false},
+		{MinSupported, true},
+		{Current, true},
+		{MaxSupported, true},
+		{MaxSupported + 1, false}, // newer than the reader
+	}
+	for _, c := range cases {
+		if got := Supported(c.v); got != c.want {
+			t.Errorf("Supported(%d) = %v, want %v", c.v, got, c.want)
+		}
+	}
+}
+
+func TestValidate(t *testing.T) {
+	// Accepted: every version inside the range.
+	for v := MinSupported; v <= MaxSupported; v++ {
+		if err := Validate(v); err != nil {
+			t.Errorf("Validate(%d) = %v, want nil (in range)", v, err)
+		}
+	}
+	// Rejected, fail-closed with ErrValidation: unset (0), impossible (< 0), and newer-than-reader.
+	for _, v := range []int{0, -1, MinSupported - 1, MaxSupported + 1} {
+		err := Validate(v)
+		if err == nil {
+			t.Errorf("Validate(%d) = nil, want rejection", v)
+			continue
+		}
+		if !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("Validate(%d) error = %v, want wrapped shared.ErrValidation", v, err)
+		}
+	}
+}

--- a/internal/usecase/fleet/telemetry/service.go
+++ b/internal/usecase/fleet/telemetry/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetryschema"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -62,6 +63,12 @@ func (s *Service) Ingest(ctx context.Context, batch ports.TelemetryBatch) (Inges
 	}
 	if batch.SampleRate < 1 {
 		return IngestReport{}, fmt.Errorf("%w: telemetry sample rate must be >= 1 (1 = full fidelity)", shared.ErrValidation)
+	}
+	// The wire schema version is declared per batch and validated against the range THIS reader supports
+	// (telemetryschema), independent of the agent version. An unset or out-of-range version is rejected
+	// fail-closed rather than parsed under a guessed shape.
+	if err := telemetryschema.Validate(batch.SchemaVersion); err != nil {
+		return IngestReport{}, err
 	}
 	// The write tenant is the AUTHENTICATED tenant on the context, never a self-declared field on the
 	// wire batch: an agent must not be able to write into another tenant's partition by claiming a

--- a/internal/usecase/fleet/telemetry/service_test.go
+++ b/internal/usecase/fleet/telemetry/service_test.go
@@ -2,12 +2,14 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetryschema"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -58,7 +60,7 @@ func tctx() context.Context { return shared.WithTenant(context.Background(), "t1
 
 func batch(seq uint64, sampleRate int, evs ...detection.Event) ports.TelemetryBatch {
 	return ports.TelemetryBatch{TenantID: "t1", HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1",
-		Class: detection.ClassProcess, Sequence: seq, SampleRate: sampleRate, Events: evs}
+		SchemaVersion: telemetryschema.Current, Class: detection.ClassProcess, Sequence: seq, SampleRate: sampleRate, Events: evs}
 }
 
 func TestIngestBudgetOverflowReportsGap(t *testing.T) {
@@ -126,7 +128,7 @@ func TestRetentionTiersAndAuditedExpiry(t *testing.T) {
 	warmEvs := []detection.Event{procEventAt("a", now.Add(-90*time.Minute)), procEventAt("b", now.Add(-90*time.Minute))}
 	oldEv := procEventAt("old", now.Add(-3*time.Hour))
 	_, _ = svc.Ingest(tctx(), batch(1, 1, hotEv))
-	_, _ = svc.Ingest(tctx(), ports.TelemetryBatch{TenantID: "t1", HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1", Class: detection.ClassProcess, Sequence: 2, SampleRate: 1, Events: warmEvs})
+	_, _ = svc.Ingest(tctx(), ports.TelemetryBatch{TenantID: "t1", HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1", SchemaVersion: telemetryschema.Current, Class: detection.ClassProcess, Sequence: 2, SampleRate: 1, Events: warmEvs})
 	_, _ = svc.Ingest(tctx(), batch(3, 1, oldEv))
 
 	rep, err := svc.Sweep(tctx())
@@ -208,7 +210,7 @@ func TestRetroHuntLatencyOnSeededVolume(t *testing.T) {
 			}
 			evs[j] = procEventAt(comm, base.Add(time.Duration(i)*time.Second))
 		}
-		if _, err := svc.Ingest(tctx(), ports.TelemetryBatch{TenantID: "t1", HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1", Class: detection.ClassProcess, Sequence: uint64(i + 1), SampleRate: 1, Events: evs}); err != nil {
+		if _, err := svc.Ingest(tctx(), ports.TelemetryBatch{TenantID: "t1", HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1", SchemaVersion: telemetryschema.Current, Class: detection.ClassProcess, Sequence: uint64(i + 1), SampleRate: 1, Events: evs}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -224,5 +226,27 @@ func TestRetroHuntLatencyOnSeededVolume(t *testing.T) {
 	}
 	if elapsed > 5*time.Second {
 		t.Errorf("retro-hunt latency %s exceeds the 5s bound on %d events (memory tier)", elapsed, batches*per)
+	}
+}
+
+func TestIngestValidatesSchemaVersion(t *testing.T) {
+	svc, _, _ := newSvc(t, 100, 7*24*time.Hour, 30*24*time.Hour)
+	ev := procEventAt("ps", time.Unix(1_000_000, 0))
+
+	// Accepted: the schema version this build emits. Acceptance keys on the batch's declared schema
+	// version, never on any agent-binary version (there is no agent-version field on the batch) — proving
+	// the schema/agent decoupling structurally.
+	if _, err := svc.Ingest(tctx(), batch(1, 1, ev)); err != nil {
+		t.Fatalf("Current schema version (%d) must be accepted: %v", telemetryschema.Current, err)
+	}
+
+	// Rejected fail-closed with ErrValidation: an unset (0) version and a version newer than this reader
+	// supports — never parsed under a guessed shape.
+	for _, v := range []int{0, telemetryschema.MaxSupported + 1} {
+		b := batch(2, 1, ev)
+		b.SchemaVersion = v
+		if _, err := svc.Ingest(tctx(), b); !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("schema version %d must be rejected with ErrValidation, got %v", v, err)
+		}
 	}
 }

--- a/internal/usecase/ports/telemetry.go
+++ b/internal/usecase/ports/telemetry.go
@@ -39,8 +39,12 @@ type TelemetryBatch struct {
 	HostID   shared.ID
 	AssetID  shared.ID
 	AgentID  shared.ID
-	Class    detection.Class
-	Sequence uint64
+	// SchemaVersion is the wire-format version of the events in this batch (see domain/telemetryschema).
+	// It is versioned INDEPENDENTLY of the agent binary version; ingest validates it and rejects an unset
+	// or out-of-range version rather than parsing under a guessed shape.
+	SchemaVersion int
+	Class         detection.Class
+	Sequence      uint64
 	// SampleRate records how the batch was sampled: 1 = full fidelity; N>1 = one event kept per N observed
 	// (recorded WITH the data so a hunt knows it is looking at a sample, never a complete window).
 	SampleRate int


### PR DESCRIPTION
## What

Part of **#594** Phase **A0.3** (#608): version the telemetry **wire schema independently of the agent binary version**, and gate ingest on it fail-closed.

- New `internal/domain/telemetryschema` — `Current` version + an inclusive `[MinSupported, MaxSupported]` range the reader accepts, with `Supported(v)` / `Validate(v)` (wraps `shared.ErrValidation`). Documented compatibility rules (additive-within-range; out-of-range or unset is rejected, never parsed under a guessed shape; range widens only when a new version is defined — today only v1 exists).
- `ports.TelemetryBatch` gains a `SchemaVersion int` field (a plain scalar — no new import).
- `telemetry.Service.Ingest` validates it **before any store write**, fail-closed.

## Why

The schema version must be decoupled from the agent version so the wire contract can evolve without a lockstep fleet upgrade, and so upgrading an agent binary never silently changes how its data is read. Ingest keys on the batch's declared version, not the agent version.

## Verification (all green locally; Actions off)

- `go build ./...` + `CGO_ENABLED=0 go build ./cmd/...` · `go vet` · `golangci-lint v2.12.2` — **0 issues**
- `go test ./internal/domain/telemetryschema/... ./internal/usecase/fleet/telemetry/...` — pass (incl. the `#424` domain-purity arch test, still green)
- Postgres telemetry/migration tests pass with a live DB (the store path is unaffected — `repo.Ingest` maps explicit columns and does not reference the new field)
- **Reviews:** go-arch **CLEAN** (dependency rule PASS, idioms clean, tests non-vacuous), security **CLEAN** (fail-closed gate holds; no weakening of the existing tenant/identity/sequence checks; no bypass; structural agent/schema decoupling; `ErrValidation` → 400)

## Scope / follow-ups (kept out on purpose)

- **Persisting** the schema version in the columnar store (a small migration + INSERT column) lands with **A3** when the agent transport actually writes versioned batches — the deliverable here is the versioning **contract + the ingest gate**.
- The "two schema versions ingest from the same build" acceptance is fully exercised once a **v2** schema is defined; today the range mechanism is proven (accept in-range, reject below-min and above-max).

Part of #608 (kept open for the two follow-ups above).
