### PR TITLE
fix(detectledger): idempotent detection seal + engagement-scoped projection key (A0.5)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1609,6 +1609,12 @@ func main() {
 		// evidence chain) plugs the same detectionRecordStore into detectledger.NewService once the
 		// agent→control-plane batch transport + agent signing-key resolver land; the read surface is live
 		// now so a detection is queryable and tenant-scoped through the same chokepoint.
+		// A0.5 (#610) PREREQUISITE — before wiring detectledger.NewService here, the EvidenceChain passed
+		// to it MUST implement SealOnce as a truly key-idempotent seal, keyed on (engagement, detection id)
+		// and atomic with the chain append (e.g. an ON CONFLICT (engagement_id, idempotency_key) DO NOTHING
+		// insert that returns the existing link). A keyless Seal, or a non-atomic check-then-append, reopens
+		// D3 (a seal-then-crash retry appends a duplicate permanent link). evidence.Service.SealOnce is the
+		// A4 deliverable that provides this; do not bridge NewService onto plain Seal.
 		if detectionReader, drerr := detectledger.NewReader(detectionRecordStore); drerr != nil {
 			log.Error("detection ledger reader init failed", "err", drerr)
 			os.Exit(1)

--- a/internal/infrastructure/persistence/memory/detection_record_store.go
+++ b/internal/infrastructure/persistence/memory/detection_record_store.go
@@ -11,13 +11,19 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
+// recKey identifies a projection row by (engagement, detection id) — the SAME namespace the per-engagement
+// seal uses. Keying on this (not the id alone) is what lets the same detection id in two engagements be two
+// distinct rows instead of one silently overwriting the other, mirroring the Postgres PRIMARY KEY
+// (tenant_id, engagement_id, id).
+type recKey struct{ eng, id shared.ID }
+
 // DetectionRecordStore is the in-memory detection-ledger projection used inline/in dev. Records are
 // bucketed per tenant, so a read under one tenant can never observe another's — the same isolation the
-// Postgres store gets from RLS. It keeps deep copies so a caller mutating a returned record cannot
-// corrupt stored state.
+// Postgres store gets from RLS. Within a tenant, a row is keyed by (engagement, id) to match the Postgres
+// uniqueness key. It keeps deep copies so a caller mutating a returned record cannot corrupt stored state.
 type DetectionRecordStore struct {
 	mu       sync.Mutex
-	byTenant map[shared.ID]map[shared.ID]detection.Record // tenant -> record id -> record
+	byTenant map[shared.ID]map[recKey]detection.Record // tenant -> (engagement, record id) -> record
 	now      func() time.Time
 }
 
@@ -25,13 +31,13 @@ var _ ports.DetectionRecordStore = (*DetectionRecordStore)(nil)
 
 // NewDetectionRecordStore constructs the store.
 func NewDetectionRecordStore() *DetectionRecordStore {
-	return &DetectionRecordStore{byTenant: map[shared.ID]map[shared.ID]detection.Record{}, now: func() time.Time { return time.Now().UTC() }}
+	return &DetectionRecordStore{byTenant: map[shared.ID]map[recKey]detection.Record{}, now: func() time.Time { return time.Now().UTC() }}
 }
 
 // SetClock overrides the store's clock (tests only), so expiry-on-read is deterministic.
 func (s *DetectionRecordStore) SetClock(now func() time.Time) { s.now = now }
 
-// AppendDetection stores one record, idempotent on its id, under the ctx tenant.
+// AppendDetection stores one record, idempotent on (engagement, id), bucketed by the record's TenantID.
 func (s *DetectionRecordStore) AppendDetection(ctx context.Context, r detection.Record) error {
 	if err := r.Validate(); err != nil {
 		return err
@@ -40,9 +46,16 @@ func (s *DetectionRecordStore) AppendDetection(ctx context.Context, r detection.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.byTenant[tenant] == nil {
-		s.byTenant[tenant] = map[shared.ID]detection.Record{}
+		s.byTenant[tenant] = map[recKey]detection.Record{}
 	}
-	s.byTenant[tenant][r.ID] = cloneRecord(r)
+	// Idempotent on (engagement, id), matching the Postgres ON CONFLICT (tenant_id, engagement_id, id):
+	// a re-delivery of the same detection in the same engagement is a no-op, while the same id in a
+	// DIFFERENT engagement is a distinct row and must not overwrite the first.
+	k := recKey{eng: r.EngagementID, id: r.ID}
+	if _, exists := s.byTenant[tenant][k]; exists {
+		return nil
+	}
+	s.byTenant[tenant][k] = cloneRecord(r)
 	return nil
 }
 
@@ -69,13 +82,13 @@ func (s *DetectionRecordStore) ListDetections(ctx context.Context, engagementID 
 	return out, nil
 }
 
-// HasDetection reports whether a record with this id already exists under the ctx tenant, so ingest can
+// HasDetection reports whether a record with this id already exists in the given engagement under the ctx tenant, so ingest can
 // skip an already-sealed detection on a retry (idempotent resume) rather than sealing it twice.
-func (s *DetectionRecordStore) HasDetection(ctx context.Context, id shared.ID) (bool, error) {
+func (s *DetectionRecordStore) HasDetection(ctx context.Context, engagementID, id shared.ID) (bool, error) {
 	tenant := shared.TenantOrDefault(tenantFromCtx(ctx))
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_, ok := s.byTenant[tenant][id]
+	_, ok := s.byTenant[tenant][recKey{eng: engagementID, id: id}]
 	return ok, nil
 }
 
@@ -100,10 +113,10 @@ func (s *DetectionRecordStore) ExpireDetections(ctx context.Context, engagementI
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var expired []shared.ID
-	for id, r := range s.byTenant[tenant] {
+	for k, r := range s.byTenant[tenant] {
 		if r.EngagementID == engagementID && r.Expired(cutoff) {
-			expired = append(expired, id)
-			delete(s.byTenant[tenant], id)
+			expired = append(expired, r.ID)
+			delete(s.byTenant[tenant], k)
 		}
 	}
 	sort.Slice(expired, func(i, j int) bool { return expired[i] < expired[j] })

--- a/internal/infrastructure/persistence/memory/detection_record_store_test.go
+++ b/internal/infrastructure/persistence/memory/detection_record_store_test.go
@@ -49,6 +49,36 @@ func TestDetectionStoreTenantIsolation(t *testing.T) {
 	}
 }
 
+func TestDetectionStoreEngagementScopedKey(t *testing.T) {
+	s := NewDetectionRecordStore()
+	// The SAME detection id under two engagements of one tenant: two distinct rows, not an overwrite
+	// (matches the Postgres (tenant_id, engagement_id, id) key). drRecord binds EvidenceID to "ev-"+id, so
+	// both would collide on id alone.
+	a := drRecord(t, "dupe", "t1", "e1", "agent:1", 1, time.Time{})
+	a.EvidenceID = "ev-a"
+	b := drRecord(t, "dupe", "t1", "e2", "agent:1", 1, time.Time{})
+	b.EvidenceID = "ev-b"
+	if err := s.AppendDetection(ctxT("t1"), a); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendDetection(ctxT("t1"), b); err != nil {
+		t.Fatal(err)
+	}
+	// A re-delivery in e1 is idempotent (first-writer-wins, like ON CONFLICT DO NOTHING): the immutable
+	// row is kept, a swapped-evidence replay does NOT overwrite it.
+	replay := a
+	replay.EvidenceID = "ev-tampered"
+	if err := s.AppendDetection(ctxT("t1"), replay); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := s.ListDetections(ctxT("t1"), "e1"); len(got) != 1 || got[0].EvidenceID != "ev-a" {
+		t.Fatalf("e1 must keep its own immutable row bound to ev-a, got %+v", got)
+	}
+	if got, _ := s.ListDetections(ctxT("t1"), "e2"); len(got) != 1 || got[0].EvidenceID != "ev-b" {
+		t.Fatalf("e2 must retain its distinct row bound to ev-b, got %+v", got)
+	}
+}
+
 func TestDetectionStoreLastBatchSequence(t *testing.T) {
 	s := NewDetectionRecordStore()
 	_ = s.AppendDetection(ctxT("t1"), drRecord(t, "r1", "t1", "e1", "agent:1", 2, time.Time{}))
@@ -91,14 +121,19 @@ func TestDetectionStoreExpire(t *testing.T) {
 func TestDetectionStoreHasDetection(t *testing.T) {
 	s := NewDetectionRecordStore()
 	_ = s.AppendDetection(ctxT("t1"), drRecord(t, "r1", "t1", "e1", "agent:1", 1, time.Time{}))
-	if ok, _ := s.HasDetection(ctxT("t1"), "r1"); !ok {
+	if ok, _ := s.HasDetection(ctxT("t1"), "e1", "r1"); !ok {
 		t.Error("t1 must see its own record via HasDetection")
 	}
-	if ok, _ := s.HasDetection(ctxT("t1"), "missing"); ok {
+	if ok, _ := s.HasDetection(ctxT("t1"), "e1", "missing"); ok {
 		t.Error("HasDetection must be false for an unknown id")
 	}
+	// Engagement-scoped: the same id in a DIFFERENT engagement is a distinct detection, not a match —
+	// so a tenant-wide skip cannot silently drop it (the D3 cross-engagement loss vector).
+	if ok, _ := s.HasDetection(ctxT("t1"), "e2", "r1"); ok {
+		t.Error("HasDetection must be engagement-scoped")
+	}
 	// Cross-tenant: t2 must not observe t1's record.
-	if ok, _ := s.HasDetection(ctxT("t2"), "r1"); ok {
+	if ok, _ := s.HasDetection(ctxT("t2"), "e1", "r1"); ok {
 		t.Error("HasDetection must be tenant-scoped")
 	}
 }

--- a/internal/infrastructure/persistence/postgres/detection_record_repo.go
+++ b/internal/infrastructure/persistence/postgres/detection_record_repo.go
@@ -26,8 +26,9 @@ func NewDetectionRecordRepository(pool *pgxpool.Pool) *DetectionRecordRepository
 	return &DetectionRecordRepository{pool: pool}
 }
 
-// AppendDetection stores one projection row, idempotent on (tenant_id, id): a row is immutable once
-// written (provenance), so a re-delivery of the same detection does not overwrite it.
+// AppendDetection stores one projection row, idempotent on (tenant_id, engagement_id, id): a row is
+// immutable once written (provenance), so a re-delivery of the same detection in the same engagement does
+// not overwrite it, while the same id in a DIFFERENT engagement is a distinct row (not dropped).
 func (r *DetectionRecordRepository) AppendDetection(ctx context.Context, rec detection.Record) error {
 	if err := rec.Validate(); err != nil {
 		return err
@@ -47,7 +48,7 @@ func (r *DetectionRecordRepository) AppendDetection(ctx context.Context, rec det
 			  (tenant_id, id, engagement_id, asset_id, agent_id, rule_id, rule_version, class, severity,
 			   host_id, observed_at, evidence_id, batch_seq, detection, recorded_at, expires_at)
 			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
-			ON CONFLICT (tenant_id, id) DO NOTHING`,
+			ON CONFLICT (tenant_id, engagement_id, id) DO NOTHING`,
 			rec.TenantID.String(), rec.ID.String(), rec.EngagementID.String(), rec.AssetID.String(),
 			rec.AgentID.String(), rec.Detection.RuleID, rec.Detection.RuleVersion, string(rec.Detection.Class),
 			string(rec.Detection.Severity), rec.Detection.HostID.String(), rec.Detection.Observed.UTC(),
@@ -109,11 +110,11 @@ func (r *DetectionRecordRepository) ListDetections(ctx context.Context, engageme
 	return out, err
 }
 
-// HasDetection reports whether a record with this id already exists in the ctx tenant.
-func (r *DetectionRecordRepository) HasDetection(ctx context.Context, id shared.ID) (bool, error) {
+// HasDetection reports whether a record with this id already exists in the given engagement (ctx tenant).
+func (r *DetectionRecordRepository) HasDetection(ctx context.Context, engagementID, id shared.ID) (bool, error) {
 	var exists bool
 	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM detections WHERE id = $1)`, id.String()).Scan(&exists)
+		return tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM detections WHERE engagement_id = $1 AND id = $2)`, engagementID.String(), id.String()).Scan(&exists)
 	})
 	return exists, err
 }

--- a/internal/infrastructure/persistence/postgres/migration_0074_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0074_test.go
@@ -91,9 +91,14 @@ func TestMigration0074Detections(t *testing.T) {
 	if got, _ := repo.ListDetections(tctx, shared.ID(engA)); len(got) != 1 {
 		t.Fatalf("append must be idempotent on id, got %d rows", len(got))
 	}
-	// HasDetection is tenant-scoped and true for a stored id.
-	if ok, err := repo.HasDetection(tctx, rec.ID); err != nil || !ok {
+	// HasDetection is engagement-scoped (tenant-scoped by ctx) and true for a stored id.
+	if ok, err := repo.HasDetection(tctx, rec.EngagementID, rec.ID); err != nil || !ok {
 		t.Fatalf("HasDetection must be true for a stored record (ok=%v err=%v)", ok, err)
+	}
+	// The same id under a DIFFERENT engagement must NOT match — a tenant-wide skip would silently drop
+	// a distinct detection that happens to share the id (the D3 cross-engagement loss vector).
+	if ok, err := repo.HasDetection(tctx, shared.ID("eng-other"), rec.ID); err != nil || ok {
+		t.Fatalf("HasDetection must be engagement-scoped (ok=%v err=%v)", ok, err)
 	}
 	// A second, CRITICAL detection of the same rule+asset — so the incident rollup can be checked to
 	// report the highest severity by RANK, not the alphabetical max of the label.
@@ -171,5 +176,89 @@ func TestMigration0074Detections(t *testing.T) {
 	}
 	if got, _ := repo.ListDetections(tctx, shared.ID(engA)); len(got) != 2 {
 		t.Fatalf("the two no-expiry records must remain after expiry, got %d", len(got))
+	}
+}
+
+// TestDetectionRecordEngagementScopedKey proves the (tenant_id, engagement_id, id) uniqueness key
+// (migration 0104): the SAME detection id delivered under two engagements of one tenant is TWO distinct
+// rows, each bound to its own evidence link. Under the original (tenant_id, id) key the second engagement's
+// row was silently dropped by ON CONFLICT DO NOTHING — the D3 cross-engagement loss vector.
+func TestDetectionRecordEngagementScopedKey(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenant := shared.ID("detk-" + id)
+	engA, engB := "detk-engA-"+id, "detk-engB-"+id
+	evA, evB := "detk-evA-"+id, "detk-evB-"+id
+	for _, stmt := range []struct {
+		q    string
+		args []any
+	}{
+		{`INSERT INTO tenants(id,name) VALUES($1,$1)`, []any{tenant.String()}},
+		{`INSERT INTO engagements(id,tenant_id,name) VALUES($1,$3,'detk-a'),($2,$3,'detk-b')`, []any{engA, engB, tenant.String()}},
+		{`INSERT INTO evidence(id,tenant_id,engagement_id,kind,sha256,previous_hash,storage_ref,content,created_by)
+		   VALUES($1,$3,$5,'detection','deadbeef','','', $7,'agent:1'),($2,$4,$6,'detection','feedface','','', $7,'agent:1')`,
+			[]any{evA, evB, tenant.String(), tenant.String(), engA, engB, []byte("{}")}},
+	} {
+		if _, err := pool.Exec(ctx, stmt.q, stmt.args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, q := range []string{
+			`DELETE FROM detections WHERE tenant_id = $1`,
+			`DELETE FROM evidence WHERE tenant_id = $1`,
+			`DELETE FROM engagements WHERE tenant_id = $1`,
+			`DELETE FROM tenants WHERE id = $1`,
+		} {
+			_, _ = pool.Exec(bg, q, tenant.String())
+		}
+	})
+
+	repo := NewDetectionRecordRepository(pool)
+	tctx := shared.WithTenant(ctx, tenant)
+	base := detection.Record{
+		ID: shared.ID("dupe-" + id), TenantID: tenant, AssetID: "asset-x", AgentID: "agent:1",
+		Detection: mig74Detection(t), BatchSeq: 1, RecordedAt: time.Unix(1000, 0).UTC(),
+	}
+	recA := base
+	recA.EngagementID, recA.EvidenceID = shared.ID(engA), shared.ID(evA)
+	recB := base
+	recB.EngagementID, recB.EvidenceID = shared.ID(engB), shared.ID(evB)
+	if err := repo.AppendDetection(tctx, recA); err != nil {
+		t.Fatalf("append engA: %v", err)
+	}
+	if err := repo.AppendDetection(tctx, recB); err != nil {
+		t.Fatalf("append engB (same id): %v", err)
+	}
+	// Idempotent within each engagement: a re-delivery is a no-op, not a duplicate.
+	if err := repo.AppendDetection(tctx, recA); err != nil {
+		t.Fatalf("re-append engA: %v", err)
+	}
+
+	if got, _ := repo.ListDetections(tctx, shared.ID(engA)); len(got) != 1 || got[0].EvidenceID != shared.ID(evA) {
+		t.Fatalf("engA must retain its own row bound to %q, got %+v", evA, got)
+	}
+	if got, _ := repo.ListDetections(tctx, shared.ID(engB)); len(got) != 1 || got[0].EvidenceID != shared.ID(evB) {
+		t.Fatalf("engB must retain its own row bound to %q, got %+v", evB, got)
+	}
+	if okA, _ := repo.HasDetection(tctx, shared.ID(engA), base.ID); !okA {
+		t.Error("HasDetection(engA) must be true")
+	}
+	if okB, _ := repo.HasDetection(tctx, shared.ID(engB), base.ID); !okB {
+		t.Error("HasDetection(engB) must be true")
 	}
 }

--- a/internal/usecase/fleet/detectledger/service.go
+++ b/internal/usecase/fleet/detectledger/service.go
@@ -31,9 +31,16 @@ const evidenceKindDetection = "detection"
 // composition root (like offensivepolicy's EvidenceSealer), so this package never depends on the
 // concrete vault or the domain Evidence shape.
 type EvidenceChain interface {
-	// Seal appends content under the given kind, bound to the engagement's chain head, and returns the
-	// new link's id.
-	Seal(ctx context.Context, engagementID shared.ID, kind string, content []byte, createdBy string) (shared.ID, error)
+	// SealOnce appends content under the given kind, bound to the engagement's chain head, and returns
+	// the new link's id. It is IDEMPOTENT on idempotencyKey (the detection id): if a link was already
+	// sealed for (engagementID, idempotencyKey) it returns that existing link's id and appends NOTHING.
+	//
+	// This is what closes D3 (#610): sealing a detection into the permanent chain and writing its
+	// projection row are two stores with no shared transaction, so a projection write that fails AFTER a
+	// successful seal would, on retry, seal a SECOND chain link for the same detection. Keying the seal on
+	// the detection id makes the retry return the first link instead — a detection can never be sealed
+	// into the chain twice.
+	SealOnce(ctx context.Context, engagementID shared.ID, kind string, idempotencyKey string, content []byte, createdBy string) (shared.ID, error)
 	// Verify checks the engagement's chain and returns a non-nil error (wrapping evidence.ErrChainBroken)
 	// when it is broken, so a dependent report can be blocked.
 	//
@@ -162,15 +169,19 @@ func (s *Service) Ingest(ctx context.Context, batch fleetagent.AgentBatch, items
 		if got := fleetagent.DetectionContentHash(payload, it.AssetID); got != refByID[it.ID].ContentSHA256 {
 			return result, fmt.Errorf("%w: detection %s content does not match its signed digest", shared.ErrValidation, it.ID)
 		}
-		// Idempotent resume: skip a detection already sealed (e.g. a retry after a partial batch), so it is
-		// never sealed into the chain twice.
-		if exists, err := s.records.HasDetection(ctx, it.ID); err != nil {
+		// Fast-path idempotent resume: skip a detection whose projection row already exists FOR THIS
+		// engagement (a retry after a fully-completed item). The skip is engagement-scoped to match the
+		// per-engagement seal below — a tenant-wide skip would silently drop the same id in another
+		// engagement. The AUTHORITATIVE no-double-seal guarantee is SealOnce, keyed on (engagement,
+		// detection id) — so a retry after a seal-then-append crash (no projection row, so HasDetection
+		// is false here) still cannot seal a second chain link.
+		if exists, err := s.records.HasDetection(ctx, batch.EngagementID, it.ID); err != nil {
 			return result, fmt.Errorf("check detection %s: %w", it.ID, err)
 		} else if exists {
 			result.Skipped = append(result.Skipped, it.ID)
 			continue
 		}
-		evID, err := s.chain.Seal(ctx, batch.EngagementID, evidenceKindDetection, payload, batch.AgentID.String())
+		evID, err := s.chain.SealOnce(ctx, batch.EngagementID, evidenceKindDetection, it.ID.String(), payload, batch.AgentID.String())
 		if err != nil {
 			return result, fmt.Errorf("seal detection %s: %w", it.ID, err)
 		}

--- a/internal/usecase/fleet/detectledger/service_test.go
+++ b/internal/usecase/fleet/detectledger/service_test.go
@@ -22,25 +22,50 @@ type sealCall struct {
 	engagement shared.ID
 	kind       string
 	createdBy  string
+	key        string
 }
 
 type fakeChain struct {
 	mu      sync.Mutex
-	seals   []sealCall
+	seals   []sealCall           // one entry per link ACTUALLY appended; an idempotent replay adds none
+	byKey   map[string]shared.ID // (engagement, idempotency key) -> the id of the link sealed for it
 	n       int
 	broken  bool
 	sealErr error
 }
 
-func (c *fakeChain) Seal(_ context.Context, eng shared.ID, kind string, _ []byte, by string) (shared.ID, error) {
+// sealKey namespaces the idempotency key by engagement, mirroring the real chain: the key is unique only
+// WITHIN an engagement, so the same detection id in two engagements seals two distinct links.
+func sealKey(eng shared.ID, key string) string { return string(eng) + "\x00" + key }
+
+// SealOnce models the real chain's idempotency contract: a repeated (engagement, key) returns the existing
+// link and appends NOTHING new, so a test can prove a detection is sealed into the chain at most once.
+func (c *fakeChain) SealOnce(_ context.Context, eng shared.ID, kind, key string, _ []byte, by string) (shared.ID, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.sealErr != nil {
 		return "", c.sealErr
 	}
-	c.seals = append(c.seals, sealCall{eng, kind, by})
+	if c.byKey == nil {
+		c.byKey = map[string]shared.ID{}
+	}
+	k := sealKey(eng, key)
+	if id, ok := c.byKey[k]; ok {
+		return id, nil // idempotent: same (engagement, key) -> same link, nothing appended
+	}
 	c.n++
-	return shared.ID("ev-" + itoa(c.n)), nil
+	id := shared.ID("ev-" + itoa(c.n))
+	c.byKey[k] = id
+	c.seals = append(c.seals, sealCall{eng, kind, by, key})
+	return id, nil
+}
+
+// idFor returns the link id sealed for (engagement, key), read under the same lock that guards byKey, so a
+// test can inspect it without racing a concurrent SealOnce.
+func (c *fakeChain) idFor(eng shared.ID, key string) shared.ID {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.byKey[sealKey(eng, key)]
 }
 func (c *fakeChain) Verify(_ context.Context, _ shared.ID) error {
 	if c.broken {
@@ -127,6 +152,25 @@ func itoa(n int) string {
 		n /= 10
 	}
 	return string(b)
+}
+
+// failingRecords wraps a real record store and fails the next N AppendDetection calls, to simulate a
+// projection-write failure AFTER the seal has succeeded — the exact D3 crash window.
+type failingRecords struct {
+	ports.DetectionRecordStore
+	mu         sync.Mutex
+	failAppend int
+}
+
+func (f *failingRecords) AppendDetection(ctx context.Context, r detection.Record) error {
+	f.mu.Lock()
+	if f.failAppend > 0 {
+		f.failAppend--
+		f.mu.Unlock()
+		return errors.New("projection store unavailable")
+	}
+	f.mu.Unlock()
+	return f.DetectionRecordStore.AppendDetection(ctx, r)
 }
 
 // ---- harness ----------------------------------------------------------------------------------------
@@ -416,5 +460,102 @@ func TestExpireIsAuditedAndRequiresActorReason(t *testing.T) {
 	}
 	if e := h.audit.last["detection.expired"]; e.Actor != "operator" || e.Metadata["reason"] != "retention" {
 		t.Errorf("expiry audit must carry actor + reason, got %+v", e)
+	}
+}
+
+// TestIngestNeverDoubleSealsAfterProjectionFailure proves the D3 fix (#610): sealing a detection into
+// the permanent chain and writing its projection row are two stores with no shared transaction. If the
+// projection write fails AFTER a successful seal, a retry finds no row (HasDetection is false) and, with
+// a naive Seal, would append a SECOND chain link for the same detection. Because SealOnce is keyed on the
+// detection id, the retry returns the first link instead — the detection is sealed exactly once.
+func TestIngestNeverDoubleSealsAfterProjectionFailure(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	chain := &fakeChain{}
+	audit := &fakeAudit{}
+	records := &failingRecords{DetectionRecordStore: memory.NewDetectionRecordStore(), failAppend: 1}
+	keys := &fakeKeys{pub: pub, known: map[shared.ID]bool{"agent:1": true}}
+	svc, err := NewService(records, chain, keys, audit, fixedClock{t: time.Unix(1000, 0)}, &seqIDs{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, Detections: refsFor(t, items)}
+	b.Signature = fleetagent.SignBatch(priv, b)
+
+	// First ingest: the seal succeeds, then the injected projection-write failure surfaces.
+	if _, err := svc.Ingest(tctx(), b, items); err == nil {
+		t.Fatal("expected the injected projection-write failure to surface")
+	}
+	if got := len(chain.kinds()); got != 1 {
+		t.Fatalf("the detection must have been sealed exactly once before the crash, got %d", got)
+	}
+	if recs, _ := records.ListDetections(tctx(), "eng-1"); len(recs) != 0 {
+		t.Fatalf("the projection write failed, so no row should exist yet, got %d", len(recs))
+	}
+
+	// Retry the SAME batch. The row is still missing (HasDetection is false), so a naive Seal would run
+	// again — SealOnce must return the first link instead.
+	res, err := svc.Ingest(tctx(), b, items)
+	if err != nil {
+		t.Fatalf("the retry must complete the projection, got %v", err)
+	}
+	if got := len(chain.kinds()); got != 1 {
+		t.Fatalf("D3: a detection must never be sealed into the chain twice, got %d links", got)
+	}
+	if len(res.SealedRecords) != 1 {
+		t.Fatalf("the retry must complete the previously-unwritten projection row, got %+v", res)
+	}
+	recs, _ := records.ListDetections(tctx(), "eng-1")
+	sealed := chain.idFor("eng-1", "d1")
+	if len(recs) != 1 || recs[0].EvidenceID != sealed {
+		t.Fatalf("the row must bind to the single sealed link %q, got %+v", sealed, recs)
+	}
+}
+
+// TestIngestSealsSameDetectionIDInDistinctEngagements proves the seal namespace is per-engagement: the
+// same detection id delivered under two different engagements is two distinct detections and must each be
+// sealed — the engagement-scoped HasDetection skip must NOT suppress the second (the D3 cross-engagement
+// loss/suppression vector). Both links are sealed and both projection rows are written.
+func TestIngestSealsSameDetectionIDInDistinctEngagements(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	chain := &fakeChain{}
+	audit := &fakeAudit{}
+	records := memory.NewDetectionRecordStore()
+	keys := &fakeKeys{pub: pub, known: map[shared.ID]bool{"agent:1": true}}
+	svc, err := NewService(records, chain, keys, audit, fixedClock{t: time.Unix(1000, 0)}, &seqIDs{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	for _, eng := range []shared.ID{"eng-1", "eng-2"} {
+		b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: eng, Sequence: 1, Detections: refsFor(t, items)}
+		b.Signature = fleetagent.SignBatch(priv, b)
+		res, err := svc.Ingest(tctx(), b, items)
+		if err != nil {
+			t.Fatalf("ingest into %s: %v", eng, err)
+		}
+		if len(res.SealedRecords) != 1 || len(res.Skipped) != 0 {
+			t.Fatalf("%s: the detection must be sealed, not skipped, got %+v", eng, res)
+		}
+	}
+	if got := len(chain.kinds()); got != 2 {
+		t.Fatalf("the same id in two engagements must seal two distinct links, got %d", got)
+	}
+	l1, l2 := chain.idFor("eng-1", "d1"), chain.idFor("eng-2", "d1")
+	if l1 == "" || l2 == "" || l1 == l2 {
+		t.Fatalf("each engagement must get its own link, got %q and %q", l1, l2)
+	}
+	// The projection must hold BOTH rows — one per engagement — each bound to its own sealed link. A
+	// projection keyed on (tenant, id) alone would drop one of these silently; the (tenant, engagement,
+	// id) key keeps them distinct. Assert per engagement so this test actually verifies the claim.
+	r1, _ := records.ListDetections(tctx(), "eng-1")
+	if len(r1) != 1 || r1[0].ID != "d1" || r1[0].EvidenceID != l1 {
+		t.Fatalf("eng-1 must retain its own row bound to link %q, got %+v", l1, r1)
+	}
+	r2, _ := records.ListDetections(tctx(), "eng-2")
+	if len(r2) != 1 || r2[0].ID != "d1" || r2[0].EvidenceID != l2 {
+		t.Fatalf("eng-2 must retain its own row bound to link %q, got %+v", l2, r2)
 	}
 }

--- a/internal/usecase/ports/detection.go
+++ b/internal/usecase/ports/detection.go
@@ -41,11 +41,16 @@ type DetectionSink interface {
 // chokepoint, not by the caller. The projection is retention-bounded; the underlying chain links are
 // permanent, so expiry removes rows here, never chain history.
 type DetectionRecordStore interface {
-	// AppendDetection stores one projection row. It is tenant-scoped and idempotent on the record id.
+	// AppendDetection stores one projection row. It is tenant-scoped and idempotent on (engagement, id):
+	// a re-delivery in the same engagement is a no-op, while the same id in a different engagement is a
+	// distinct row (never overwritten), matching the per-engagement seal namespace.
 	AppendDetection(ctx context.Context, r detection.Record) error
-	// HasDetection reports whether a record with this id already exists (tenant-scoped), so ingest can
-	// skip an already-sealed detection on a retry rather than sealing it into the chain twice.
-	HasDetection(ctx context.Context, id shared.ID) (bool, error)
+	// HasDetection reports whether a record with this id already exists in the given engagement
+	// (tenant-scoped by ctx), so ingest can skip an already-sealed detection on a retry rather than
+	// sealing it into the chain twice. It is scoped to the engagement to MATCH the per-engagement seal:
+	// the same detection id in a DIFFERENT engagement is a distinct detection and must not be skipped
+	// (a tenant-wide skip would silently drop it — a cross-engagement loss/suppression vector).
+	HasDetection(ctx context.Context, engagementID, id shared.ID) (bool, error)
 	// ListDetections returns the (non-expired) records for an engagement, oldest first, tenant-scoped.
 	ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error)
 	// LastBatchSequence returns the highest batch sequence recorded for an agent (0 = none yet), so a gap

--- a/internal/usecase/promotion/service_test.go
+++ b/internal/usecase/promotion/service_test.go
@@ -149,7 +149,7 @@ type fakeDetectionStore struct {
 }
 
 func (s *fakeDetectionStore) AppendDetection(_ context.Context, _ detection.Record) error { return nil }
-func (s *fakeDetectionStore) HasDetection(_ context.Context, _ shared.ID) (bool, error) {
+func (s *fakeDetectionStore) HasDetection(_ context.Context, _, _ shared.ID) (bool, error) {
 	return false, nil
 }
 func (s *fakeDetectionStore) ListDetections(_ context.Context, _ shared.ID) ([]detection.Record, error) {

--- a/internal/usecase/purplecoverage/service_test.go
+++ b/internal/usecase/purplecoverage/service_test.go
@@ -23,7 +23,9 @@ func (c fixedClock) Now() time.Time { return c.t }
 type fakeDetections struct{ records []detection.Record }
 
 func (f *fakeDetections) AppendDetection(context.Context, detection.Record) error { return nil }
-func (f *fakeDetections) HasDetection(context.Context, shared.ID) (bool, error)   { return false, nil }
+func (f *fakeDetections) HasDetection(context.Context, shared.ID, shared.ID) (bool, error) {
+	return false, nil
+}
 func (f *fakeDetections) ListDetections(context.Context, shared.ID) ([]detection.Record, error) {
 	return f.records, nil
 }

--- a/migrations/0104_detections_engagement_pk.sql
+++ b/migrations/0104_detections_engagement_pk.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- A0.5 (#610): the detection ledger seals each detection into the evidence chain idempotently per
+-- (engagement, detection id) — see detectledger.SealOnce. The projection's uniqueness key must match that
+-- namespace, or the two idempotency scopes disagree: with the original PRIMARY KEY (tenant_id, id), the
+-- SAME detection id delivered under two different engagements seals two distinct (correct) chain links but
+-- collides here on the second engagement's row — ON CONFLICT (tenant_id, id) DO NOTHING silently drops it,
+-- orphaning a chain link and leaving HasDetection(eng-2, id) false forever (the retry never converges).
+-- Widen the key to (tenant_id, engagement_id, id) so a distinct-engagement detection is a distinct row.
+-- Safe as a plain PK swap: the ingest write path is not wired yet (only the read surface is), so the table
+-- is empty in every deployment; no row can violate the widened key.
+ALTER TABLE detections DROP CONSTRAINT detections_pkey;
+ALTER TABLE detections ADD PRIMARY KEY (tenant_id, engagement_id, id);
+
+-- +goose Down
+ALTER TABLE detections DROP CONSTRAINT detections_pkey;
+ALTER TABLE detections ADD PRIMARY KEY (tenant_id, id);


### PR DESCRIPTION
## What & why

Phase A0.5 of the security-data-plane → EDR epic (#594). Fixes defect **D3 — a detection must be sealed into the permanent hash-chained evidence spine exactly once**, even across a seal-then-projection-write crash and retry.

Sealing a detection into the evidence chain and writing its projection row are two stores with no shared transaction. If the projection write failed *after* a successful seal, a retry found no row (`HasDetection` false) and, under a naive `Seal`, appended a **second** chain link for the same detection — duplicate permanent evidence.

## Changes

- **Idempotent seal.** The `EvidenceChain` interface used by `detectledger` now exposes `SealOnce(engagement, kind, idempotencyKey, content, createdBy)`; `Ingest` passes the detection id as the key, so a retry returns the first link instead of appending a new one. `HasDetection` remains a fast-path skip; `SealOnce` is the authoritative no-double-seal guarantee.
- **Projection key aligned to the seal namespace.** The skip and the store were previously scoped differently — `HasDetection` and the projection keyed on `(tenant, id)`, the seal on `(engagement, id)`. The same detection id in two engagements then sealed two distinct chain links but collided on the projection: Postgres `ON CONFLICT (tenant, id) DO NOTHING` dropped the second row (orphaning a chain link, and the retry never converged); the memory twin overwrote the first (last-writer-wins). This widens the projection uniqueness to `(tenant, engagement, id)`:
  - new migration **0104** swaps the `detections` PK (safe — the ingest write path is unwired, so the table is empty in every deployment);
  - Postgres `ON CONFLICT (tenant_id, engagement_id, id) DO NOTHING`;
  - the memory store re-keys on `(engagement, id)` and becomes **first-writer-wins / immutable** to mirror Postgres (this also fixes a pre-existing twin divergence);
  - `HasDetection` is engagement-scoped in both stores.

## Tests

- A detection is sealed **exactly once** across a projection-write failure and retry (fault injection).
- The same id in two engagements yields **two distinct rows**, each bound to its own evidence link — proven at both the memory and Postgres store level.
- A replay with swapped evidence **cannot mutate** a sealed projection row (immutability).

Full suite green (247 packages, incl. Postgres integration; migration 0104 applies clean). go-arch + security reviews both clean.

## Scope / follow-up

Deliberately does **not** wire the write path. `detectledger.NewService` (the sole `SealOnce` caller) stays unwired; only the read surface is composed. The concrete `evidence.Service.SealOnce` — which must be **atomic** and idempotent on `(engagement_id, idempotency_key)` — lands with the composition-root bridge at **A4**. A wiring anchor note in `cmd/synapse-api/main.go` records this prerequisite so the writer is never bridged onto plain `Seal`.

**#610 stays open** after this merge — it tracks the remaining A4 wiring.

Part of #594.
