### PR TITLE
feat(fleetagent): first-class agent signing-key lifecycle (A0.2)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1615,6 +1615,13 @@ func main() {
 		// insert that returns the existing link). A keyless Seal, or a non-atomic check-then-append, reopens
 		// D3 (a seal-then-crash retry appends a duplicate permanent link). evidence.Service.SealOnce is the
 		// A4 deliverable that provides this; do not bridge NewService onto plain Seal.
+		// A0.2 (#607) — the detectledger.AgentKeyResolver that NewService needs is satisfied by the agent
+		// signing-key registry (ports.AgentSigningKeyStore → postgres.NewAgentSigningKeyRepository /
+		// memory.NewAgentSigningKeyStore): its Resolve(agentID, keyID) returns the AgentSigningKey the batch
+		// names, and VerifyBatchWithKey gates purpose+window+revocation fail-closed. The store is the durable
+		// backing; still deferred to A4 is the agent-plane registration endpoint (an agent posts its ed25519
+		// signing public key + a ProveKeyPossession proof, bound to its canonical AgentID) plus the operator
+		// rotate/revoke routes — none can be wired until the agent→control-plane transport exists.
 		if detectionReader, drerr := detectledger.NewReader(detectionRecordStore); drerr != nil {
 			log.Error("detection ledger reader init failed", "err", drerr)
 			os.Exit(1)

--- a/internal/domain/fleetagent/batch.go
+++ b/internal/domain/fleetagent/batch.go
@@ -41,6 +41,7 @@ type AgentBatch struct {
 	AgentID      shared.ID
 	EngagementID shared.ID
 	Sequence     uint64
+	KeyID        string // the AgentSigningKey this batch is signed with; resolved + verified server-side
 	Signature    string // base64 ed25519 over BatchMessage
 	Detections   []DetectionRef
 }
@@ -68,6 +69,9 @@ func (b AgentBatch) Validate() error {
 	if b.Sequence == 0 {
 		return fmt.Errorf("%w: batch sequence must be >= 1 (0 is reserved for 'no batch yet')", shared.ErrValidation)
 	}
+	if b.KeyID == "" {
+		return fmt.Errorf("%w: batch has no signing key id", shared.ErrValidation)
+	}
 	if len(b.Detections) == 0 {
 		return fmt.Errorf("%w: batch carries no detections", shared.ErrValidation)
 	}
@@ -92,9 +96,9 @@ func (b AgentBatch) IDs() []shared.ID {
 }
 
 // BatchMessage is the canonical byte string a batch signature covers: the context tag, agent,
-// engagement, sequence, and the SORTED (id, content-digest) refs — so membership is order-independent
-// but complete, and each detection's content is bound. It is a sha256 digest of those fields, separated
-// so field boundaries cannot collide.
+// engagement, sequence, signing-key id, and the SORTED (id, content-digest) refs — so membership is
+// order-independent but complete, each detection's content is bound, and the named signing key cannot be
+// swapped. It is a sha256 digest of those fields, separated so field boundaries cannot collide.
 func BatchMessage(b AgentBatch) []byte {
 	refs := append([]DetectionRef(nil), b.Detections...)
 	sort.Slice(refs, func(i, j int) bool { return refs[i].ID < refs[j].ID })
@@ -104,6 +108,7 @@ func BatchMessage(b AgentBatch) []byte {
 	write(b.AgentID.String())
 	write(b.EngagementID.String())
 	write(strconv.FormatUint(b.Sequence, 10))
+	write(b.KeyID) // bind the signing-key id into the signature: the envelope KeyID cannot be swapped
 	for _, ref := range refs {
 		write(ref.ID.String())
 		write(ref.ContentSHA256)

--- a/internal/domain/fleetagent/batch_test.go
+++ b/internal/domain/fleetagent/batch_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func sampleBatch() AgentBatch {
-	return AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 3,
+	return AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 3, KeyID: "kid-1",
 		Detections: []DetectionRef{
 			{ID: "d3", ContentSHA256: "h3"}, {ID: "d1", ContentSHA256: "h1"}, {ID: "d2", ContentSHA256: "h2"},
 		}}
@@ -37,6 +37,7 @@ func TestVerifyBatchRejectsTamper(t *testing.T) {
 		"bump sequence":   func(x *AgentBatch) { x.Sequence = 4 },
 		"swap engagement": func(x *AgentBatch) { x.EngagementID = "eng-2" },
 		"swap agent":      func(x *AgentBatch) { x.AgentID = "agent:2" },
+		"swap key id":     func(x *AgentBatch) { x.KeyID = "kid-2" },
 	}
 	for name, tamper := range tampers {
 		t.Run(name, func(t *testing.T) {
@@ -78,10 +79,11 @@ func TestBatchValidate(t *testing.T) {
 	cases := map[string]AgentBatch{
 		"no agent":      {EngagementID: "e", Sequence: 1, Detections: ref},
 		"no engagement": {AgentID: "a", Sequence: 1, Detections: ref},
-		"zero sequence": {AgentID: "a", EngagementID: "e", Sequence: 0, Detections: ref},
-		"no detections": {AgentID: "a", EngagementID: "e", Sequence: 1},
-		"empty id":      {AgentID: "a", EngagementID: "e", Sequence: 1, Detections: []DetectionRef{{ContentSHA256: "h"}}},
-		"empty content": {AgentID: "a", EngagementID: "e", Sequence: 1, Detections: []DetectionRef{{ID: "d"}}},
+		"zero sequence": {AgentID: "a", EngagementID: "e", Sequence: 0, KeyID: "k", Detections: ref},
+		"no key id":     {AgentID: "a", EngagementID: "e", Sequence: 1, Detections: ref},
+		"no detections": {AgentID: "a", EngagementID: "e", Sequence: 1, KeyID: "k"},
+		"empty id":      {AgentID: "a", EngagementID: "e", Sequence: 1, KeyID: "k", Detections: []DetectionRef{{ContentSHA256: "h"}}},
+		"empty content": {AgentID: "a", EngagementID: "e", Sequence: 1, KeyID: "k", Detections: []DetectionRef{{ID: "d"}}},
 	}
 	for name, b := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/domain/fleetagent/signingkey.go
+++ b/internal/domain/fleetagent/signingkey.go
@@ -1,0 +1,281 @@
+package fleetagent
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// A content-signing key is separate from the agent's TLS/enrolment cert key: it signs the CONTENT an
+// agent ships (telemetry / detection / response), so a payload is attributable to a canonical agent
+// identity over the key's lifetime even as the transport cert rotates independently (#607, A0.2).
+//
+// Three invariants make a signing key trustworthy:
+//   - the KeyID is the fingerprint of the public key, so a KeyID cannot name a different key than the one
+//     it was minted from (see NewSigningKey / evidence.KeyFingerprint);
+//   - the key is bound to a canonical AgentID (#606, A0.1) and to ONE purpose, so a detection-batch key
+//     can never verify a telemetry batch (domain separation);
+//   - it carries a validity window plus revocation, so a rotated-out or compromised key fails closed.
+
+// SigningPurpose is the single content stream a key may sign. A key is minted for exactly one purpose so
+// a signature over one stream can never be replayed as another (domain separation).
+type SigningPurpose string
+
+const (
+	PurposeTelemetryBatch SigningPurpose = "telemetry-batch"
+	PurposeDetectionBatch SigningPurpose = "detection-batch"
+	PurposeResponseResult SigningPurpose = "response-result"
+)
+
+// Valid reports whether p is one of the known purposes.
+func (p SigningPurpose) Valid() bool {
+	switch p {
+	case PurposeTelemetryBatch, PurposeDetectionBatch, PurposeResponseResult:
+		return true
+	default:
+		return false
+	}
+}
+
+// SigningAlgorithm is the only content-signing algorithm A0.2 supports. It is a named constant (not a
+// free string) so an unknown algorithm is rejected at construction rather than silently trusted.
+const SigningAlgorithm = "ed25519"
+
+// keyBindingContext domain-separates the proof-of-possession signature an agent produces when it
+// registers a key, so that proof can never be replayed as a batch signature or an attestation.
+const keyBindingContext = "synapse-agent-key-binding:v1"
+
+// KeyStatus is a signing key's lifecycle state AT A GIVEN TIME. It is derived (never stored) from the
+// window + revocation, so the same stored key reads Pending, Active, Expired, or Revoked as time moves.
+type KeyStatus string
+
+const (
+	KeyPending KeyStatus = "pending" // now < NotBefore
+	KeyActive  KeyStatus = "active"  // usable
+	KeyExpired KeyStatus = "expired" // now >= NotAfter
+	KeyRevoked KeyStatus = "revoked" // now >= RevokedAt
+)
+
+// AgentSigningKey is a first-class content-signing key with a lifecycle. It is minted by NewSigningKey so
+// the KeyID↔PublicKey invariant always holds; a zero-value struct is not a valid key.
+type AgentSigningKey struct {
+	KeyID      string            // evidence.KeyFingerprint(PublicKey); a key names itself, tamper-evident
+	AgentID    shared.ID         // the canonical enrolled agent this key is bound to (#606)
+	Algorithm  string            // SigningAlgorithm
+	Purpose    SigningPurpose    // the one content stream this key may sign
+	PublicKey  ed25519.PublicKey // raw 32-byte ed25519 public key
+	NotBefore  time.Time         // key is not usable before this instant
+	NotAfter   time.Time         // key is not usable at/after this instant (bounded — supports rotation)
+	RevokedAt  time.Time         // zero = not revoked; a set value fails the key closed from that instant
+	ReplacedBy string            // KeyID of the successor minted to rotate this key out; "" if none
+}
+
+// NewSigningKey mints a signing key from a public key and a validity window, deriving the KeyID from the
+// key itself so KeyID and PublicKey can never disagree. It validates the algorithm, purpose, key size,
+// and that the window is a real bounded interval (NotBefore < NotAfter) — an unbounded key defeats
+// rotation and anti-rollback. Revocation and ReplacedBy are set later, through the lifecycle, not here.
+func NewSigningKey(agentID shared.ID, purpose SigningPurpose, pub ed25519.PublicKey, notBefore, notAfter time.Time) (AgentSigningKey, error) {
+	if agentID == "" {
+		return AgentSigningKey{}, fmt.Errorf("%w: signing key must be bound to a canonical agent id", shared.ErrValidation)
+	}
+	if !purpose.Valid() {
+		return AgentSigningKey{}, fmt.Errorf("%w: unknown signing purpose %q", shared.ErrValidation, purpose)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return AgentSigningKey{}, fmt.Errorf("%w: signing public key must be %d bytes, got %d", shared.ErrValidation, ed25519.PublicKeySize, len(pub))
+	}
+	if notBefore.IsZero() || notAfter.IsZero() {
+		return AgentSigningKey{}, fmt.Errorf("%w: signing key must carry a validity window", shared.ErrValidation)
+	}
+	if !notBefore.Before(notAfter) {
+		return AgentSigningKey{}, fmt.Errorf("%w: signing key NotBefore must precede NotAfter", shared.ErrValidation)
+	}
+	cp := append(ed25519.PublicKey(nil), pub...) // defensive copy: caller's slice can't mutate the key
+	return AgentSigningKey{
+		KeyID:     evidence.KeyFingerprint(cp),
+		AgentID:   agentID,
+		Algorithm: SigningAlgorithm,
+		Purpose:   purpose,
+		PublicKey: cp,
+		NotBefore: notBefore.UTC(),
+		NotAfter:  notAfter.UTC(),
+	}, nil
+}
+
+// Validate checks a stored key is internally consistent — the same invariants NewSigningKey enforces,
+// re-asserted after a round-trip through storage so a corrupted or hand-built row is rejected, plus the
+// KeyID↔PublicKey binding (a row whose KeyID does not fingerprint its stored key is refused).
+func (k AgentSigningKey) Validate() error {
+	if k.AgentID == "" {
+		return fmt.Errorf("%w: signing key has no agent id", shared.ErrValidation)
+	}
+	if k.Algorithm != SigningAlgorithm {
+		return fmt.Errorf("%w: unsupported signing algorithm %q", shared.ErrValidation, k.Algorithm)
+	}
+	if !k.Purpose.Valid() {
+		return fmt.Errorf("%w: unknown signing purpose %q", shared.ErrValidation, k.Purpose)
+	}
+	if len(k.PublicKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: signing public key must be %d bytes", shared.ErrValidation, ed25519.PublicKeySize)
+	}
+	if k.KeyID == "" || k.KeyID != evidence.KeyFingerprint(k.PublicKey) {
+		return fmt.Errorf("%w: signing key id does not match its public key", shared.ErrValidation)
+	}
+	if k.NotBefore.IsZero() || k.NotAfter.IsZero() || !k.NotBefore.Before(k.NotAfter) {
+		return fmt.Errorf("%w: signing key has an invalid validity window", shared.ErrValidation)
+	}
+	if !k.RevokedAt.IsZero() && k.RevokedAt.Before(k.NotBefore) {
+		return fmt.Errorf("%w: signing key cannot be revoked before it is valid", shared.ErrValidation)
+	}
+	return nil
+}
+
+// SameIdentity reports whether o is the same registration as k by its IMMUTABLE fields only — key id,
+// agent, purpose, algorithm, public key, and window — NOT its lifecycle state (RevokedAt/ReplacedBy). A
+// store uses it to make Register idempotent (a duplicate is a no-op) while refusing an attempt to
+// re-point an existing KeyID at different attributes (anti-rollback → conflict).
+func (k AgentSigningKey) SameIdentity(o AgentSigningKey) bool {
+	return k.KeyID == o.KeyID &&
+		k.AgentID == o.AgentID &&
+		k.Purpose == o.Purpose &&
+		k.Algorithm == o.Algorithm &&
+		k.NotBefore.Equal(o.NotBefore) &&
+		k.NotAfter.Equal(o.NotAfter) &&
+		bytes.Equal(k.PublicKey, o.PublicKey)
+}
+
+// StatusAt derives the lifecycle state at now. Revocation takes precedence over the window: a key revoked
+// while still inside its window is Revoked, not Active, from RevokedAt onward.
+func (k AgentSigningKey) StatusAt(now time.Time) KeyStatus {
+	if !k.RevokedAt.IsZero() && !now.Before(k.RevokedAt) {
+		return KeyRevoked
+	}
+	if now.Before(k.NotBefore) {
+		return KeyPending
+	}
+	if !now.Before(k.NotAfter) {
+		return KeyExpired
+	}
+	return KeyActive
+}
+
+// UsableAt fails closed: it returns nil ONLY when the key is Active at now, and otherwise a validation
+// error naming why (pending / expired / revoked). Verification paths gate on this before trusting a
+// signature, so a rotated-out or revoked key can never admit a payload.
+func (k AgentSigningKey) UsableAt(now time.Time) error {
+	switch k.StatusAt(now) {
+	case KeyActive:
+		return nil
+	case KeyPending:
+		return fmt.Errorf("%w: signing key %s is not yet valid", shared.ErrForbidden, k.KeyID)
+	case KeyExpired:
+		return fmt.Errorf("%w: signing key %s has expired", shared.ErrForbidden, k.KeyID)
+	case KeyRevoked:
+		return fmt.Errorf("%w: signing key %s is revoked", shared.ErrForbidden, k.KeyID)
+	default:
+		return fmt.Errorf("%w: signing key %s is not usable", shared.ErrForbidden, k.KeyID)
+	}
+}
+
+// KeyBindingMessage is the canonical proof-of-possession challenge an agent signs when it registers a
+// key: the context tag plus every field that binds the key to its identity — agent, key id, purpose,
+// algorithm, and window. Signing it with the key's private half proves possession AND commits to the
+// binding, so the server cannot be tricked into registering a public key its holder did not intend for
+// this agent/purpose. Field boundaries are separated so they cannot collide.
+func KeyBindingMessage(k AgentSigningKey) []byte {
+	fields := []string{
+		keyBindingContext,
+		k.AgentID.String(),
+		k.KeyID,
+		string(k.Purpose),
+		k.Algorithm,
+		strconvUnix(k.NotBefore),
+		strconvUnix(k.NotAfter),
+	}
+	return hashFields(fields)
+}
+
+// ProveKeyPossession produces the base64 proof an agent presents at registration: an ed25519 signature
+// over KeyBindingMessage with the key's PRIVATE half. The public half is what gets registered.
+func ProveKeyPossession(priv ed25519.PrivateKey, k AgentSigningKey) string {
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(priv, KeyBindingMessage(k)))
+}
+
+// VerifyKeyPossession checks a registration proof fail-closed: the key must be internally valid (which
+// re-asserts KeyID == fingerprint(PublicKey)), and the proof must be a well-formed ed25519 signature over
+// the binding message BY THE KEY'S OWN PUBLIC HALF. A holder who does not possess the private key, or who
+// signed a different binding, cannot register the key.
+func VerifyKeyPossession(k AgentSigningKey, proofB64 string) error {
+	if err := k.Validate(); err != nil {
+		return err
+	}
+	sig, err := base64.StdEncoding.DecodeString(proofB64)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("%w: malformed key-possession proof", shared.ErrValidation)
+	}
+	if !ed25519.Verify(k.PublicKey, KeyBindingMessage(k), sig) {
+		return fmt.Errorf("%w: key-possession proof does not verify for this key", shared.ErrValidation)
+	}
+	return nil
+}
+
+// VerifyBatchWithKey is the server-side gate that admits a signed batch under the keyed lifecycle. It
+// fails closed on every mismatch, in order: wrong purpose (a key for another stream), a key not bound to
+// the batch's agent, an envelope naming a different KeyID than the resolved key, a key that is not usable
+// at now (pending/expired/revoked), and finally a bad signature. Only a key that passes all of these
+// verifies the batch, so no rotated-out, cross-purpose, or misattributed key can admit a detection.
+func VerifyBatchWithKey(k AgentSigningKey, wantPurpose SigningPurpose, now time.Time, b AgentBatch) error {
+	if k.Purpose != wantPurpose {
+		return fmt.Errorf("%w: signing key %s is for %q, not %q", shared.ErrForbidden, k.KeyID, k.Purpose, wantPurpose)
+	}
+	if k.AgentID != b.AgentID {
+		return fmt.Errorf("%w: signing key %s is bound to agent %s, not %s", shared.ErrForbidden, k.KeyID, k.AgentID, b.AgentID)
+	}
+	if b.KeyID != k.KeyID {
+		return fmt.Errorf("%w: batch names key %s but was verified against %s", ErrBadBatchSignature, b.KeyID, k.KeyID)
+	}
+	if err := k.UsableAt(now); err != nil {
+		return err
+	}
+	return VerifyBatch(k.PublicKey, b)
+}
+
+// ActiveKeyFor selects the key to sign with at now among a ring for one purpose: the Active key with the
+// latest NotBefore (so during a rotation OVERLAP the newest usable key is chosen while the older one
+// still verifies inbound traffic). It returns false if no key is currently usable for that purpose.
+func ActiveKeyFor(ring []AgentSigningKey, purpose SigningPurpose, now time.Time) (AgentSigningKey, bool) {
+	usable := make([]AgentSigningKey, 0, len(ring))
+	for _, k := range ring {
+		if k.Purpose == purpose && k.UsableAt(now) == nil {
+			usable = append(usable, k)
+		}
+	}
+	if len(usable) == 0 {
+		return AgentSigningKey{}, false
+	}
+	sort.Slice(usable, func(i, j int) bool { return usable[i].NotBefore.After(usable[j].NotBefore) })
+	return usable[0], true
+}
+
+// strconvUnix renders an instant as whole-second Unix time. Whole seconds (not nanos) keep the binding
+// message reproducible across a Postgres round-trip, whose timestamptz truncates below microseconds.
+func strconvUnix(t time.Time) string { return strconv.FormatInt(t.UTC().Unix(), 10) }
+
+// hashFields digests a canonical, separator-delimited field list, so distinct field layouts cannot
+// collide into the same message. It mirrors BatchMessage's construction (same separator).
+func hashFields(fields []string) []byte {
+	h := sha256.New()
+	for _, f := range fields {
+		h.Write([]byte(f))
+		h.Write([]byte(batchSep))
+	}
+	return h.Sum(nil)
+}

--- a/internal/domain/fleetagent/signingkey_test.go
+++ b/internal/domain/fleetagent/signingkey_test.go
@@ -1,0 +1,221 @@
+package fleetagent
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func mkKey(t *testing.T, agent shared.ID, purpose SigningPurpose, nb, na time.Time) (AgentSigningKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	k, err := NewSigningKey(agent, purpose, pub, nb, na)
+	if err != nil {
+		t.Fatalf("NewSigningKey: %v", err)
+	}
+	return k, priv
+}
+
+func TestNewSigningKeyDerivesKeyIDAndValidates(t *testing.T) {
+	nb := time.Unix(1000, 0)
+	na := nb.Add(time.Hour)
+	pub, _, _ := ed25519.GenerateKey(nil)
+	k, err := NewSigningKey("agent:1", PurposeDetectionBatch, pub, nb, na)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.KeyID != evidence.KeyFingerprint(pub) {
+		t.Errorf("KeyID must be the fingerprint of the public key")
+	}
+	if k.Algorithm != SigningAlgorithm {
+		t.Errorf("algorithm must default to %q", SigningAlgorithm)
+	}
+	if err := k.Validate(); err != nil {
+		t.Errorf("a freshly minted key must validate: %v", err)
+	}
+}
+
+func TestNewSigningKeyRejectsBadInput(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	nb := time.Unix(1000, 0)
+	na := nb.Add(time.Hour)
+	cases := map[string]func() (AgentSigningKey, error){
+		"empty agent": func() (AgentSigningKey, error) { return NewSigningKey("", PurposeDetectionBatch, pub, nb, na) },
+		"bad purpose": func() (AgentSigningKey, error) { return NewSigningKey("a", "no-such", pub, nb, na) },
+		"short key": func() (AgentSigningKey, error) {
+			return NewSigningKey("a", PurposeDetectionBatch, ed25519.PublicKey{1, 2, 3}, nb, na)
+		},
+		"zero window": func() (AgentSigningKey, error) {
+			return NewSigningKey("a", PurposeDetectionBatch, pub, time.Time{}, na)
+		},
+		"inverted window": func() (AgentSigningKey, error) {
+			return NewSigningKey("a", PurposeDetectionBatch, pub, na, nb)
+		},
+	}
+	for name, fn := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := fn(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSigningKeyValidateRejectsCorruptRow(t *testing.T) {
+	base, _ := mkKey(t, "agent:1", PurposeDetectionBatch, time.Unix(1000, 0), time.Unix(5000, 0))
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+	mutate := map[string]func(*AgentSigningKey){
+		"keyid does not match key": func(k *AgentSigningKey) { k.PublicKey = otherPub },
+		"bad algorithm":            func(k *AgentSigningKey) { k.Algorithm = "rsa" },
+		"unknown purpose":          func(k *AgentSigningKey) { k.Purpose = "nope" },
+		"revoked before valid":     func(k *AgentSigningKey) { k.RevokedAt = k.NotBefore.Add(-time.Second) },
+	}
+	for name, m := range mutate {
+		t.Run(name, func(t *testing.T) {
+			k := base
+			m(&k)
+			if err := k.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSigningKeyStatusAndUsability(t *testing.T) {
+	nb := time.Unix(1000, 0)
+	na := time.Unix(2000, 0)
+	k, _ := mkKey(t, "agent:1", PurposeDetectionBatch, nb, na)
+
+	if got := k.StatusAt(nb.Add(-time.Second)); got != KeyPending {
+		t.Errorf("before NotBefore = pending, got %s", got)
+	}
+	if got := k.StatusAt(nb.Add(time.Second)); got != KeyActive {
+		t.Errorf("inside window = active, got %s", got)
+	}
+	if got := k.StatusAt(na); got != KeyExpired {
+		t.Errorf("at NotAfter = expired, got %s", got)
+	}
+	if err := k.UsableAt(nb.Add(time.Second)); err != nil {
+		t.Errorf("active key must be usable: %v", err)
+	}
+	for _, at := range []time.Time{nb.Add(-time.Second), na} {
+		if err := k.UsableAt(at); !errors.Is(err, shared.ErrForbidden) {
+			t.Errorf("a non-active key must fail closed at %v, got %v", at, err)
+		}
+	}
+
+	// Revocation takes precedence over the window: revoked mid-window reads Revoked from RevokedAt on.
+	revoked := k
+	revoked.RevokedAt = time.Unix(1500, 0)
+	if got := revoked.StatusAt(time.Unix(1400, 0)); got != KeyActive {
+		t.Errorf("before revocation, still active, got %s", got)
+	}
+	if got := revoked.StatusAt(time.Unix(1500, 0)); got != KeyRevoked {
+		t.Errorf("at revocation = revoked, got %s", got)
+	}
+	if err := revoked.UsableAt(time.Unix(1600, 0)); !errors.Is(err, shared.ErrForbidden) {
+		t.Errorf("a revoked key must fail closed, got %v", err)
+	}
+}
+
+func TestKeyPossessionProofRoundTrip(t *testing.T) {
+	k, priv := mkKey(t, "agent:1", PurposeDetectionBatch, time.Unix(1000, 0), time.Unix(5000, 0))
+	proof := ProveKeyPossession(priv, k)
+	if err := VerifyKeyPossession(k, proof); err != nil {
+		t.Fatalf("a genuine possession proof must verify: %v", err)
+	}
+
+	// A proof made with a DIFFERENT private key must not verify (no possession).
+	_, otherPriv, _ := ed25519.GenerateKey(nil)
+	if err := VerifyKeyPossession(k, ProveKeyPossession(otherPriv, k)); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("a proof from a different key must be rejected, got %v", err)
+	}
+
+	// A binding tampered AFTER the proof (different agent / purpose) must not verify: the proof commits
+	// to the exact binding, so re-pointing the key at another agent breaks it.
+	reagent := k
+	reagent.AgentID = "agent:2"
+	if err := VerifyKeyPossession(reagent, proof); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("a proof must not verify against a re-bound agent, got %v", err)
+	}
+
+	// A malformed proof is rejected.
+	if err := VerifyKeyPossession(k, "not-base64!!"); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("a malformed proof must be rejected, got %v", err)
+	}
+}
+
+func TestVerifyBatchWithKeyGate(t *testing.T) {
+	now := time.Unix(1500, 0)
+	k, priv := mkKey(t, "agent:1", PurposeDetectionBatch, time.Unix(1000, 0), time.Unix(2000, 0))
+	b := AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, KeyID: k.KeyID,
+		Detections: []DetectionRef{{ID: "d1", ContentSHA256: "h1"}}}
+	b.Signature = SignBatch(priv, b)
+
+	if err := VerifyBatchWithKey(k, PurposeDetectionBatch, now, b); err != nil {
+		t.Fatalf("a well-formed batch under an active, bound, matching key must verify: %v", err)
+	}
+
+	// Wrong purpose: a telemetry key must not verify a detection batch.
+	wrongPurpose := k
+	wrongPurpose.Purpose = PurposeTelemetryBatch
+	if err := VerifyBatchWithKey(wrongPurpose, PurposeDetectionBatch, now, b); !errors.Is(err, shared.ErrForbidden) {
+		t.Errorf("cross-purpose key must fail closed, got %v", err)
+	}
+
+	// Key bound to a different agent.
+	wrongAgent := k
+	wrongAgent.AgentID = "agent:2"
+	if err := VerifyBatchWithKey(wrongAgent, PurposeDetectionBatch, now, b); !errors.Is(err, shared.ErrForbidden) {
+		t.Errorf("key bound to another agent must fail closed, got %v", err)
+	}
+
+	// Envelope names a different KeyID than the resolved key.
+	mismatch := b
+	mismatch.KeyID = "some-other-kid"
+	mismatch.Signature = SignBatch(priv, mismatch)
+	if err := VerifyBatchWithKey(k, PurposeDetectionBatch, now, mismatch); !errors.Is(err, ErrBadBatchSignature) {
+		t.Errorf("a KeyID mismatch must be refused, got %v", err)
+	}
+
+	// Outside the validity window (expired at now).
+	if err := VerifyBatchWithKey(k, PurposeDetectionBatch, time.Unix(3000, 0), b); !errors.Is(err, shared.ErrForbidden) {
+		t.Errorf("an expired key must fail closed, got %v", err)
+	}
+
+	// Tampered payload: the signature no longer verifies.
+	tampered := b
+	tampered.Sequence = 2
+	if err := VerifyBatchWithKey(k, PurposeDetectionBatch, now, tampered); !errors.Is(err, ErrBadBatchSignature) {
+		t.Errorf("a tampered batch must fail the signature check, got %v", err)
+	}
+}
+
+func TestActiveKeyForPrefersNewestDuringOverlap(t *testing.T) {
+	now := time.Unix(1500, 0)
+	old, _ := mkKey(t, "agent:1", PurposeDetectionBatch, time.Unix(1000, 0), time.Unix(2000, 0))
+	newer, _ := mkKey(t, "agent:1", PurposeDetectionBatch, time.Unix(1400, 0), time.Unix(2400, 0)) // overlaps old
+	telem, _ := mkKey(t, "agent:1", PurposeTelemetryBatch, time.Unix(1000, 0), time.Unix(2000, 0))
+	expired, _ := mkKey(t, "agent:1", PurposeDetectionBatch, time.Unix(100, 0), time.Unix(200, 0))
+
+	ring := []AgentSigningKey{old, telem, expired, newer}
+	got, ok := ActiveKeyFor(ring, PurposeDetectionBatch, now)
+	if !ok {
+		t.Fatal("an active detection key must be found during overlap")
+	}
+	if got.KeyID != newer.KeyID {
+		t.Errorf("overlap must select the newest-NotBefore active key")
+	}
+
+	// No usable key of that purpose → not found.
+	if _, ok := ActiveKeyFor([]AgentSigningKey{expired, telem}, PurposeDetectionBatch, now); ok {
+		t.Error("no usable detection key must report not-found")
+	}
+}

--- a/internal/infrastructure/persistence/memory/agent_signing_key_store.go
+++ b/internal/infrastructure/persistence/memory/agent_signing_key_store.go
@@ -1,0 +1,132 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// skKey identifies a signing key by (agent, key id) within a tenant bucket — a KeyID is unique per agent
+// (it fingerprints the agent's public key), and the pair is what the verify path resolves by.
+type skKey struct {
+	agent shared.ID
+	keyID string
+}
+
+// AgentSigningKeyStore is the in-memory agent-signing-key registry used inline/in dev. Keys are bucketed
+// per tenant, so a read under one tenant can never observe another's — the same isolation the Postgres
+// store gets from RLS. It keeps deep copies so a caller mutating a returned key cannot corrupt stored
+// state, and enforces the same immutability + monotonic-revocation invariants as the Postgres store.
+type AgentSigningKeyStore struct {
+	mu       sync.Mutex
+	byTenant map[shared.ID]map[skKey]fleetagent.AgentSigningKey
+}
+
+var _ ports.AgentSigningKeyStore = (*AgentSigningKeyStore)(nil)
+
+// NewAgentSigningKeyStore constructs the store.
+func NewAgentSigningKeyStore() *AgentSigningKeyStore {
+	return &AgentSigningKeyStore{byTenant: map[shared.ID]map[skKey]fleetagent.AgentSigningKey{}}
+}
+
+// Register stores a signing key, idempotent on its identity and anti-rollback on its KeyID. Like the
+// Postgres store it does NOT verify proof-of-possession — see the port contract; the caller must have
+// called fleetagent.VerifyKeyPossession first.
+func (s *AgentSigningKeyStore) Register(ctx context.Context, key fleetagent.AgentSigningKey) error {
+	if err := key.Validate(); err != nil {
+		return err
+	}
+	// Fail closed on a missing tenant, matching the authoritative Postgres store (a security registry
+	// must never silently bucket a key under a default tenant).
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("%w: signing-key registration requires a tenant in context", shared.ErrValidation)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.byTenant[tenant] == nil {
+		s.byTenant[tenant] = map[skKey]fleetagent.AgentSigningKey{}
+	}
+	k := skKey{agent: key.AgentID, keyID: key.KeyID}
+	if existing, ok := s.byTenant[tenant][k]; ok {
+		// A KeyID (a public-key fingerprint) can never be re-pointed at a different key/agent/purpose/
+		// window. An identical re-registration is a no-op (at-least-once safe); anything else conflicts.
+		if !existing.SameIdentity(key) {
+			return fmt.Errorf("%w: signing key %s already registered with different attributes", shared.ErrConflict, key.KeyID)
+		}
+		return nil
+	}
+	s.byTenant[tenant][k] = cloneSigningKey(key)
+	return nil
+}
+
+// ResolveSigningKey returns the (agent, keyID) key under the ctx tenant, or ErrNotFound.
+func (s *AgentSigningKeyStore) ResolveSigningKey(ctx context.Context, agentID shared.ID, keyID string) (fleetagent.AgentSigningKey, error) {
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("%w: signing-key resolution requires a tenant in context", shared.ErrValidation)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key, found := s.byTenant[tenant][skKey{agent: agentID, keyID: keyID}]
+	if !found {
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("%w: signing key %s for agent %s", shared.ErrNotFound, keyID, agentID)
+	}
+	return cloneSigningKey(key), nil
+}
+
+// ListByAgent returns every key for an agent under the ctx tenant, newest NotBefore first.
+func (s *AgentSigningKeyStore) ListByAgent(ctx context.Context, agentID shared.ID) ([]fleetagent.AgentSigningKey, error) {
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: listing signing keys requires a tenant in context", shared.ErrValidation)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []fleetagent.AgentSigningKey
+	for k, key := range s.byTenant[tenant] {
+		if k.agent == agentID {
+			out = append(out, cloneSigningKey(key))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].NotBefore.Equal(out[j].NotBefore) {
+			return out[i].KeyID < out[j].KeyID
+		}
+		return out[i].NotBefore.After(out[j].NotBefore)
+	})
+	return out, nil
+}
+
+// Revoke marks a key revoked at `at`, monotonic: an already-revoked key keeps its first RevokedAt.
+func (s *AgentSigningKeyStore) Revoke(ctx context.Context, agentID shared.ID, keyID string, at time.Time) error {
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("%w: revoking a signing key requires a tenant in context", shared.ErrValidation)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := skKey{agent: agentID, keyID: keyID}
+	key, found := s.byTenant[tenant][k]
+	if !found {
+		return fmt.Errorf("%w: signing key %s for agent %s", shared.ErrNotFound, keyID, agentID)
+	}
+	if !key.RevokedAt.IsZero() {
+		return nil // already revoked — revocation is monotonic, never moved
+	}
+	key.RevokedAt = at.UTC()
+	s.byTenant[tenant][k] = key
+	return nil
+}
+
+func cloneSigningKey(k fleetagent.AgentSigningKey) fleetagent.AgentSigningKey {
+	cp := k
+	cp.PublicKey = append([]byte(nil), k.PublicKey...)
+	return cp
+}

--- a/internal/infrastructure/persistence/memory/agent_signing_key_store_test.go
+++ b/internal/infrastructure/persistence/memory/agent_signing_key_store_test.go
@@ -1,0 +1,117 @@
+package memory
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func mkSK(t *testing.T, agent shared.ID, nb, na time.Time) fleetagent.AgentSigningKey {
+	t.Helper()
+	pub, _, _ := ed25519.GenerateKey(nil)
+	k, err := fleetagent.NewSigningKey(agent, fleetagent.PurposeDetectionBatch, pub, nb, na)
+	if err != nil {
+		t.Fatalf("NewSigningKey: %v", err)
+	}
+	return k
+}
+
+func TestSigningKeyStoreRegisterResolve(t *testing.T) {
+	s := NewAgentSigningKeyStore()
+	k := mkSK(t, "agent:1", time.Unix(1000, 0), time.Unix(2000, 0))
+	if err := s.Register(ctxT("t1"), k); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	got, err := s.ResolveSigningKey(ctxT("t1"), "agent:1", k.KeyID)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.KeyID != k.KeyID || !got.PublicKey.Equal(k.PublicKey) {
+		t.Errorf("resolved key does not match the registered one")
+	}
+	// Unknown key + cross-tenant both fail closed with ErrNotFound.
+	if _, err := s.ResolveSigningKey(ctxT("t1"), "agent:1", "nope"); !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("unknown key must be ErrNotFound, got %v", err)
+	}
+	if _, err := s.ResolveSigningKey(ctxT("t2"), "agent:1", k.KeyID); !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("cross-tenant resolve must be ErrNotFound, got %v", err)
+	}
+}
+
+func TestSigningKeyStoreFailsClosedWithoutTenant(t *testing.T) {
+	s := NewAgentSigningKeyStore()
+	k := mkSK(t, "agent:1", time.Unix(1000, 0), time.Unix(2000, 0))
+	// A tenant-less context must be refused, not silently bucketed under a default tenant — this store
+	// is a security registry and mirrors the fail-closed Postgres behavior.
+	if err := s.Register(context.Background(), k); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("Register without a tenant must fail closed, got %v", err)
+	}
+	if _, err := s.ResolveSigningKey(context.Background(), "agent:1", k.KeyID); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("Resolve without a tenant must fail closed, got %v", err)
+	}
+	if _, err := s.ListByAgent(context.Background(), "agent:1"); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("ListByAgent without a tenant must fail closed, got %v", err)
+	}
+	if err := s.Revoke(context.Background(), "agent:1", k.KeyID, time.Unix(1500, 0)); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("Revoke without a tenant must fail closed, got %v", err)
+	}
+}
+
+func TestSigningKeyStoreRegisterIdempotentAndConflict(t *testing.T) {
+	s := NewAgentSigningKeyStore()
+	k := mkSK(t, "agent:1", time.Unix(1000, 0), time.Unix(2000, 0))
+	if err := s.Register(ctxT("t1"), k); err != nil {
+		t.Fatal(err)
+	}
+	// Identical re-registration is a no-op (at-least-once safe).
+	if err := s.Register(ctxT("t1"), k); err != nil {
+		t.Errorf("identical re-register must be a no-op, got %v", err)
+	}
+	if keys, _ := s.ListByAgent(ctxT("t1"), "agent:1"); len(keys) != 1 {
+		t.Fatalf("a duplicate register must not create a second row, got %d", len(keys))
+	}
+	// A DIFFERENT registration under the same KeyID (same public key, different window) is refused —
+	// a KeyID can never be re-pointed (anti-rollback).
+	rebind := k
+	rebind.NotAfter = time.Unix(9999, 0)
+	if err := s.Register(ctxT("t1"), rebind); !errors.Is(err, shared.ErrConflict) {
+		t.Errorf("re-pointing a KeyID must conflict, got %v", err)
+	}
+}
+
+func TestSigningKeyStoreListAndRevoke(t *testing.T) {
+	s := NewAgentSigningKeyStore()
+	older := mkSK(t, "agent:1", time.Unix(1000, 0), time.Unix(2000, 0))
+	newer := mkSK(t, "agent:1", time.Unix(1500, 0), time.Unix(2500, 0))
+	other := mkSK(t, "agent:2", time.Unix(1000, 0), time.Unix(2000, 0))
+	for _, k := range []fleetagent.AgentSigningKey{older, newer, other} {
+		if err := s.Register(ctxT("t1"), k); err != nil {
+			t.Fatal(err)
+		}
+	}
+	list, _ := s.ListByAgent(ctxT("t1"), "agent:1")
+	if len(list) != 2 || list[0].KeyID != newer.KeyID {
+		t.Fatalf("ListByAgent must return this agent's keys newest-first, got %+v", list)
+	}
+
+	// Revoke is monotonic: a second revoke at a later time keeps the first RevokedAt.
+	if err := s.Revoke(ctxT("t1"), "agent:1", older.KeyID, time.Unix(1800, 0)); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if err := s.Revoke(ctxT("t1"), "agent:1", older.KeyID, time.Unix(1900, 0)); err != nil {
+		t.Fatalf("second revoke: %v", err)
+	}
+	got, _ := s.ResolveSigningKey(ctxT("t1"), "agent:1", older.KeyID)
+	if !got.RevokedAt.Equal(time.Unix(1800, 0).UTC()) {
+		t.Errorf("revocation must be monotonic (kept first time), got %v", got.RevokedAt)
+	}
+	// Revoking an unknown key is ErrNotFound.
+	if err := s.Revoke(ctxT("t1"), "agent:1", "nope", time.Unix(1800, 0)); !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("revoking an unknown key must be ErrNotFound, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/agent_signing_key_repo.go
+++ b/internal/infrastructure/persistence/postgres/agent_signing_key_repo.go
@@ -1,0 +1,185 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// AgentSigningKeyRepository is the Postgres-backed agent content-signing key registry (#607, A0.2). Every
+// method runs through WithContextTenant so Row Level Security (migration 0105 via the 0057 procedure)
+// isolates one tenant's keys from another's. A key's public half and window are immutable once written;
+// revocation is monotonic. The primary key (tenant_id, agent_id, key_id) makes registration idempotent
+// on identity and blocks re-pointing a KeyID at another key (anti-rollback).
+type AgentSigningKeyRepository struct{ pool *pgxpool.Pool }
+
+var _ ports.AgentSigningKeyStore = (*AgentSigningKeyRepository)(nil)
+
+// NewAgentSigningKeyRepository constructs the repository.
+func NewAgentSigningKeyRepository(pool *pgxpool.Pool) *AgentSigningKeyRepository {
+	return &AgentSigningKeyRepository{pool: pool}
+}
+
+const agentSigningKeyCols = `agent_id, key_id, algorithm, purpose, public_key, not_before, not_after, revoked_at, replaced_by`
+
+// Register stores a signing key, idempotent on identity and anti-rollback on KeyID.
+func (r *AgentSigningKeyRepository) Register(ctx context.Context, key fleetagent.AgentSigningKey) error {
+	if err := key.Validate(); err != nil {
+		return err
+	}
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("%w: signing-key registration requires a tenant in context", shared.ErrValidation)
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `
+			INSERT INTO agent_signing_keys
+			  (tenant_id, agent_id, key_id, algorithm, purpose, public_key, not_before, not_after, revoked_at, replaced_by)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+			ON CONFLICT (tenant_id, agent_id, key_id) DO NOTHING`,
+			tenant.String(), key.AgentID.String(), key.KeyID, key.Algorithm, string(key.Purpose),
+			[]byte(key.PublicKey), key.NotBefore.UTC(), key.NotAfter.UTC(), nullableTime(key.RevokedAt), key.ReplacedBy)
+		if err != nil {
+			return fmt.Errorf("insert signing key %s: %w", key.KeyID, err)
+		}
+		if ct.RowsAffected() == 1 {
+			return nil // freshly inserted
+		}
+		// Conflict on (tenant, agent, key_id): a row already exists. An identical re-registration is a
+		// no-op (at-least-once safe); a differing one is refused (a KeyID cannot be re-pointed).
+		existing, err := scanSigningKey(tx.QueryRow(ctx, `
+			SELECT `+agentSigningKeyCols+` FROM agent_signing_keys
+			WHERE agent_id = $1 AND key_id = $2`, key.AgentID.String(), key.KeyID))
+		if err != nil {
+			return err
+		}
+		if existing.SameIdentity(key) {
+			return nil
+		}
+		return fmt.Errorf("%w: signing key %s already registered with different attributes", shared.ErrConflict, key.KeyID)
+	})
+}
+
+// ResolveSigningKey returns the (agent, keyID) key under the ctx tenant, or shared.ErrNotFound.
+func (r *AgentSigningKeyRepository) ResolveSigningKey(ctx context.Context, agentID shared.ID, keyID string) (fleetagent.AgentSigningKey, error) {
+	var out fleetagent.AgentSigningKey
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		k, e := scanSigningKey(tx.QueryRow(ctx, `
+			SELECT `+agentSigningKeyCols+` FROM agent_signing_keys
+			WHERE agent_id = $1 AND key_id = $2`, agentID.String(), keyID))
+		if errors.Is(e, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: signing key %s for agent %s", shared.ErrNotFound, keyID, agentID)
+		}
+		if e != nil {
+			return e
+		}
+		out = k
+		return nil
+	})
+	return out, err
+}
+
+// ListByAgent returns every key for an agent under the ctx tenant, newest NotBefore first.
+func (r *AgentSigningKeyRepository) ListByAgent(ctx context.Context, agentID shared.ID) ([]fleetagent.AgentSigningKey, error) {
+	var out []fleetagent.AgentSigningKey
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT `+agentSigningKeyCols+` FROM agent_signing_keys
+			WHERE agent_id = $1
+			ORDER BY not_before DESC, key_id ASC`, agentID.String())
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			k, e := scanSigningKey(rows)
+			if e != nil {
+				return e
+			}
+			out = append(out, k)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+// Revoke marks (agentID, keyID) revoked at `at`, monotonic (an already-revoked key keeps its first
+// RevokedAt), tenant-scoped. shared.ErrNotFound if the key is unknown.
+func (r *AgentSigningKeyRepository) Revoke(ctx context.Context, agentID shared.ID, keyID string, at time.Time) error {
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		ct, err := tx.Exec(ctx, `
+			UPDATE agent_signing_keys SET revoked_at = $3
+			WHERE agent_id = $1 AND key_id = $2 AND revoked_at IS NULL`,
+			agentID.String(), keyID, at.UTC())
+		if err != nil {
+			return fmt.Errorf("revoke signing key %s: %w", keyID, err)
+		}
+		if ct.RowsAffected() == 1 {
+			return nil // revoked now
+		}
+		// No row updated: either the key does not exist, or it is already revoked (monotonic no-op).
+		var exists bool
+		if err := tx.QueryRow(ctx, `
+			SELECT EXISTS(SELECT 1 FROM agent_signing_keys WHERE agent_id = $1 AND key_id = $2)`,
+			agentID.String(), keyID).Scan(&exists); err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("%w: signing key %s for agent %s", shared.ErrNotFound, keyID, agentID)
+		}
+		return nil
+	})
+}
+
+// scanSigningKey materializes one row into a domain key and re-validates it, so a corrupted row is
+// refused rather than trusted. rowScanner is satisfied by both pgx.Row and pgx.Rows.
+func scanSigningKey(row rowScanner) (fleetagent.AgentSigningKey, error) {
+	var (
+		agentID   string
+		keyID     string
+		algorithm string
+		purpose   string
+		pub       []byte
+		notBefore time.Time
+		notAfter  time.Time
+		revokedAt *time.Time
+		replaced  string
+	)
+	if err := row.Scan(&agentID, &keyID, &algorithm, &purpose, &pub, &notBefore, &notAfter, &revokedAt, &replaced); err != nil {
+		return fleetagent.AgentSigningKey{}, err
+	}
+	k := fleetagent.AgentSigningKey{
+		KeyID:      keyID,
+		AgentID:    shared.ID(agentID),
+		Algorithm:  algorithm,
+		Purpose:    fleetagent.SigningPurpose(purpose),
+		PublicKey:  append([]byte(nil), pub...),
+		NotBefore:  notBefore.UTC(),
+		NotAfter:   notAfter.UTC(),
+		ReplacedBy: replaced,
+	}
+	if revokedAt != nil {
+		k.RevokedAt = revokedAt.UTC()
+	}
+	if err := k.Validate(); err != nil {
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("stored signing key %s is corrupt: %w", keyID, err)
+	}
+	return k, nil
+}
+
+// nullableTime maps a zero time to a SQL NULL so revoked_at is NULL for an un-revoked key.
+func nullableTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	u := t.UTC()
+	return &u
+}

--- a/internal/infrastructure/persistence/postgres/agent_signing_key_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/agent_signing_key_repo_test.go
@@ -1,0 +1,135 @@
+package postgres
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func skTestKey(t *testing.T, agent shared.ID, nb, na time.Time) fleetagent.AgentSigningKey {
+	t.Helper()
+	pub, _, _ := ed25519.GenerateKey(nil)
+	k, err := fleetagent.NewSigningKey(agent, fleetagent.PurposeDetectionBatch, pub, nb, na)
+	if err != nil {
+		t.Fatalf("NewSigningKey: %v", err)
+	}
+	return k
+}
+
+func TestAgentSigningKeyRepo(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenantA, tenantB := shared.ID("sk-a-"+id), shared.ID("sk-b-"+id)
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1),($2,$2)`, tenantA.String(), tenantB.String()); err != nil {
+		t.Fatalf("seed tenants: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM agent_signing_keys WHERE tenant_id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id IN ($1,$2)`, tenantA.String(), tenantB.String())
+		_, _ = pool.Exec(bg, `DROP OWNED BY sk_runtime`)
+		_, _ = pool.Exec(bg, `DROP ROLE IF EXISTS sk_runtime`)
+	})
+
+	repo := NewAgentSigningKeyRepository(pool)
+	tctxA := shared.WithTenant(ctx, tenantA)
+
+	older := skTestKey(t, "agent:1", time.Unix(1000, 0), time.Unix(2000, 0))
+	newer := skTestKey(t, "agent:1", time.Unix(1500, 0), time.Unix(2500, 0))
+	if err := repo.Register(tctxA, older); err != nil {
+		t.Fatalf("register older: %v", err)
+	}
+	if err := repo.Register(tctxA, newer); err != nil {
+		t.Fatalf("register newer: %v", err)
+	}
+	// Idempotent on identity; anti-rollback on a re-pointed KeyID.
+	if err := repo.Register(tctxA, older); err != nil {
+		t.Errorf("identical re-register must be a no-op, got %v", err)
+	}
+	rebind := older
+	rebind.NotAfter = time.Unix(9999, 0)
+	if err := repo.Register(tctxA, rebind); !errors.Is(err, shared.ErrConflict) {
+		t.Errorf("re-pointing a KeyID must conflict, got %v", err)
+	}
+
+	got, err := repo.ResolveSigningKey(tctxA, "agent:1", older.KeyID)
+	if err != nil || got.KeyID != older.KeyID || !got.PublicKey.Equal(older.PublicKey) {
+		t.Fatalf("resolve older: got %+v err %v", got, err)
+	}
+	if _, err := repo.ResolveSigningKey(tctxA, "agent:1", "nope"); !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("unknown key must be ErrNotFound, got %v", err)
+	}
+	list, _ := repo.ListByAgent(tctxA, "agent:1")
+	if len(list) != 2 || list[0].KeyID != newer.KeyID {
+		t.Fatalf("ListByAgent must return newest-first, got %+v", list)
+	}
+
+	// Revoke is monotonic.
+	if err := repo.Revoke(tctxA, "agent:1", older.KeyID, time.Unix(1800, 0)); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if err := repo.Revoke(tctxA, "agent:1", older.KeyID, time.Unix(1900, 0)); err != nil {
+		t.Fatalf("second revoke: %v", err)
+	}
+	got, _ = repo.ResolveSigningKey(tctxA, "agent:1", older.KeyID)
+	if !got.RevokedAt.Equal(time.Unix(1800, 0).UTC()) {
+		t.Errorf("revocation must be monotonic, got %v", got.RevokedAt)
+	}
+	if err := repo.Revoke(tctxA, "agent:1", "nope", time.Unix(1800, 0)); !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("revoking an unknown key must be ErrNotFound, got %v", err)
+	}
+
+	// RLS isolation under a NOSUPERUSER NOBYPASSRLS role (the pool superuser bypasses RLS): tenant B must
+	// not observe tenant A's keys. tenant B has none of its own, so it must count zero.
+	role := "sk_runtime"
+	for _, q := range []string{
+		`DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname='` + role + `') THEN EXECUTE 'DROP OWNED BY ` + role + `'; EXECUTE 'DROP ROLE ` + role + `'; END IF; END $$`,
+		`CREATE ROLE ` + role + ` NOSUPERUSER NOBYPASSRLS`,
+		`GRANT USAGE ON SCHEMA public TO ` + role,
+		`GRANT SELECT ON agent_signing_keys TO ` + role,
+	} {
+		if _, err := pool.Exec(ctx, q); err != nil {
+			t.Fatalf("prepare rls role: %v", err)
+		}
+	}
+	countAs := func(tenant shared.ID) int {
+		var n int
+		tc := shared.WithTenant(context.Background(), tenant)
+		if err := WithTenant(tc, pool, tenant.String(), func(tx pgx.Tx) error {
+			if _, err := tx.Exec(tc, `SET LOCAL ROLE `+role); err != nil {
+				return err
+			}
+			return tx.QueryRow(tc, `SELECT count(*) FROM agent_signing_keys`).Scan(&n)
+		}); err != nil {
+			t.Fatalf("count as %s: %v", tenant, err)
+		}
+		return n
+	}
+	if got := countAs(tenantB); got != 0 {
+		t.Errorf("tenant B sees %d of tenant A's signing keys; RLS is not isolating", got)
+	}
+	if got := countAs(tenantA); got != 2 {
+		t.Errorf("tenant A sees %d of its own keys, want 2; RLS is over-filtering", got)
+	}
+}

--- a/internal/usecase/fleet/detectledger/service.go
+++ b/internal/usecase/fleet/detectledger/service.go
@@ -10,7 +10,6 @@ package detectledger
 
 import (
 	"context"
-	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -52,10 +51,12 @@ type EvidenceChain interface {
 	Verify(ctx context.Context, engagementID shared.ID) error
 }
 
-// AgentKeyResolver returns the enrolment public key for an agent (#408), used to verify a batch's
-// signature. An agent with no known key cannot have its batches admitted — fail closed.
+// AgentKeyResolver resolves the content-signing key an incoming batch names (#607, A0.2). The batch
+// carries a KeyID; the resolver returns the AgentSigningKey bound to (agentID, keyID), and Ingest gates
+// on purpose + validity window + revocation + agent binding via VerifyBatchWithKey before trusting the
+// signature. An unknown key resolves to an error and the batch is refused — fail closed.
 type AgentKeyResolver interface {
-	AgentPublicKey(ctx context.Context, agentID shared.ID) (ed25519.PublicKey, error)
+	ResolveSigningKey(ctx context.Context, agentID shared.ID, keyID string) (fleetagent.AgentSigningKey, error)
 }
 
 // IngestItem is one detection in a batch together with the asset it was observed on (#423 requirement 5:
@@ -114,15 +115,22 @@ func (s *Service) Ingest(ctx context.Context, batch fleetagent.AgentBatch, items
 		return IngestResult{}, fmt.Errorf("%w: detection ingest requires a tenant in context", shared.ErrValidation)
 	}
 
-	// Signature: fail closed. An agent with no known key, or a batch that does not verify, is refused
-	// before any detection is sealed.
-	pub, err := s.keys.AgentPublicKey(ctx, batch.AgentID)
+	// Signature: fail closed under the keyed lifecycle (#607). Resolve the signing key the batch names by
+	// KeyID; an unknown key admits nothing. VerifyBatchWithKey then refuses — before any detection is
+	// sealed — a key of the wrong purpose, a key bound to another agent, an envelope naming a different
+	// key, a pending/expired/revoked key, or a bad signature.
+	key, err := s.keys.ResolveSigningKey(ctx, batch.AgentID, batch.KeyID)
 	if err != nil {
-		return IngestResult{}, fmt.Errorf("%w: no key for agent %s: %v", shared.ErrForbidden, batch.AgentID, err)
-	}
-	if err := fleetagent.VerifyBatch(pub, batch); err != nil {
 		s.recordAudit(ctx, "detection.batch_rejected", batch.AgentID.String(), map[string]string{
-			"engagement": batch.EngagementID.String(), "sequence": fmt.Sprint(batch.Sequence), "reason": "bad_signature",
+			"engagement": batch.EngagementID.String(), "sequence": fmt.Sprint(batch.Sequence),
+			"key_id": batch.KeyID, "reason": "unknown_key",
+		})
+		return IngestResult{}, fmt.Errorf("%w: no signing key %s for agent %s: %v", shared.ErrForbidden, batch.KeyID, batch.AgentID, err)
+	}
+	if err := fleetagent.VerifyBatchWithKey(key, fleetagent.PurposeDetectionBatch, s.clock.Now().UTC(), batch); err != nil {
+		s.recordAudit(ctx, "detection.batch_rejected", batch.AgentID.String(), map[string]string{
+			"engagement": batch.EngagementID.String(), "sequence": fmt.Sprint(batch.Sequence),
+			"key_id": batch.KeyID, "reason": "unverified",
 		})
 		return IngestResult{}, err
 	}

--- a/internal/usecase/fleet/detectledger/service_test.go
+++ b/internal/usecase/fleet/detectledger/service_test.go
@@ -84,15 +84,17 @@ func (c *fakeChain) kinds() []string {
 }
 
 type fakeKeys struct {
-	pub   ed25519.PublicKey
-	known map[shared.ID]bool
+	byAgent map[shared.ID]fleetagent.AgentSigningKey
 }
 
-func (k *fakeKeys) AgentPublicKey(_ context.Context, id shared.ID) (ed25519.PublicKey, error) {
-	if k.known[id] {
-		return k.pub, nil
+// ResolveSigningKey returns the key bound to (agentID, keyID), fail-closed: an unknown agent or a KeyID
+// that does not match the agent's registered key resolves to an error, so the batch is refused.
+func (k *fakeKeys) ResolveSigningKey(_ context.Context, agentID shared.ID, keyID string) (fleetagent.AgentSigningKey, error) {
+	key, ok := k.byAgent[agentID]
+	if !ok || key.KeyID != keyID {
+		return fleetagent.AgentSigningKey{}, errors.New("unknown signing key")
 	}
-	return nil, errors.New("unknown agent")
+	return key, nil
 }
 
 type fakeAudit struct {
@@ -181,6 +183,18 @@ type harness struct {
 	audit *fakeAudit
 	store *memory.DetectionRecordStore
 	priv  ed25519.PrivateKey
+	key   fleetagent.AgentSigningKey
+}
+
+// mkSigningKey mints a detection-batch signing key bound to agent whose validity window comfortably
+// contains the harness clock (Unix 1000), so a well-formed batch verifies under the keyed lifecycle.
+func mkSigningKey(t *testing.T, agent shared.ID, pub ed25519.PublicKey) fleetagent.AgentSigningKey {
+	t.Helper()
+	key, err := fleetagent.NewSigningKey(agent, fleetagent.PurposeDetectionBatch, pub, time.Unix(1, 0), time.Unix(1<<31, 0))
+	if err != nil {
+		t.Fatalf("NewSigningKey: %v", err)
+	}
+	return key
 }
 
 func newHarness(t *testing.T, retention time.Duration) *harness {
@@ -189,12 +203,13 @@ func newHarness(t *testing.T, retention time.Duration) *harness {
 	chain := &fakeChain{}
 	audit := &fakeAudit{}
 	store := memory.NewDetectionRecordStore()
-	keys := &fakeKeys{pub: pub, known: map[shared.ID]bool{"agent:1": true}}
+	key := mkSigningKey(t, "agent:1", pub)
+	keys := &fakeKeys{byAgent: map[shared.ID]fleetagent.AgentSigningKey{"agent:1": key}}
 	svc, err := NewService(store, chain, keys, audit, fixedClock{t: time.Unix(1000, 0)}, &seqIDs{}, retention)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return &harness{svc: svc, chain: chain, audit: audit, store: store, priv: priv}
+	return &harness{svc: svc, chain: chain, audit: audit, store: store, priv: priv, key: key}
 }
 
 func mkDetection(t *testing.T, comm string) detection.Detection {
@@ -227,7 +242,7 @@ func refsFor(t *testing.T, items []IngestItem) []fleetagent.DetectionRef {
 
 func (h *harness) signedBatch(t *testing.T, seq uint64, items []IngestItem) fleetagent.AgentBatch {
 	t.Helper()
-	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: seq, Detections: refsFor(t, items)}
+	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: seq, KeyID: h.key.KeyID, Detections: refsFor(t, items)}
 	b.Signature = fleetagent.SignBatch(h.priv, b)
 	return b
 }
@@ -305,7 +320,7 @@ func TestIngestRefusesContentTamper(t *testing.T) {
 func TestIngestRefusesUnknownAgent(t *testing.T) {
 	h := newHarness(t, 0)
 	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
-	b := fleetagent.AgentBatch{AgentID: "agent:unknown", EngagementID: "eng-1", Sequence: 1, Detections: refsFor(t, items)}
+	b := fleetagent.AgentBatch{AgentID: "agent:unknown", EngagementID: "eng-1", Sequence: 1, KeyID: h.key.KeyID, Detections: refsFor(t, items)}
 	b.Signature = fleetagent.SignBatch(h.priv, b)
 	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrForbidden) {
 		t.Fatalf("an agent with no known key must be refused (fail closed), got %v", err)
@@ -368,7 +383,7 @@ func TestIngestRequiresMembershipMatchAndTenant(t *testing.T) {
 	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
 	// Membership mismatch: batch names d1+d2 but only d1 supplied.
 	extra := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}, {ID: "d2", Detection: mkDetection(t, "top"), AssetID: "asset-1"}}
-	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, Detections: refsFor(t, extra)}
+	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, KeyID: h.key.KeyID, Detections: refsFor(t, extra)}
 	b.Signature = fleetagent.SignBatch(h.priv, b)
 	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("membership mismatch must be a validation error, got %v", err)
@@ -473,14 +488,15 @@ func TestIngestNeverDoubleSealsAfterProjectionFailure(t *testing.T) {
 	chain := &fakeChain{}
 	audit := &fakeAudit{}
 	records := &failingRecords{DetectionRecordStore: memory.NewDetectionRecordStore(), failAppend: 1}
-	keys := &fakeKeys{pub: pub, known: map[shared.ID]bool{"agent:1": true}}
+	key := mkSigningKey(t, "agent:1", pub)
+	keys := &fakeKeys{byAgent: map[shared.ID]fleetagent.AgentSigningKey{"agent:1": key}}
 	svc, err := NewService(records, chain, keys, audit, fixedClock{t: time.Unix(1000, 0)}, &seqIDs{}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
-	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, Detections: refsFor(t, items)}
+	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, KeyID: key.KeyID, Detections: refsFor(t, items)}
 	b.Signature = fleetagent.SignBatch(priv, b)
 
 	// First ingest: the seal succeeds, then the injected projection-write failure surfaces.
@@ -522,7 +538,8 @@ func TestIngestSealsSameDetectionIDInDistinctEngagements(t *testing.T) {
 	chain := &fakeChain{}
 	audit := &fakeAudit{}
 	records := memory.NewDetectionRecordStore()
-	keys := &fakeKeys{pub: pub, known: map[shared.ID]bool{"agent:1": true}}
+	key := mkSigningKey(t, "agent:1", pub)
+	keys := &fakeKeys{byAgent: map[shared.ID]fleetagent.AgentSigningKey{"agent:1": key}}
 	svc, err := NewService(records, chain, keys, audit, fixedClock{t: time.Unix(1000, 0)}, &seqIDs{}, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -530,7 +547,7 @@ func TestIngestSealsSameDetectionIDInDistinctEngagements(t *testing.T) {
 
 	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
 	for _, eng := range []shared.ID{"eng-1", "eng-2"} {
-		b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: eng, Sequence: 1, Detections: refsFor(t, items)}
+		b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: eng, Sequence: 1, KeyID: key.KeyID, Detections: refsFor(t, items)}
 		b.Signature = fleetagent.SignBatch(priv, b)
 		res, err := svc.Ingest(tctx(), b, items)
 		if err != nil {
@@ -557,5 +574,51 @@ func TestIngestSealsSameDetectionIDInDistinctEngagements(t *testing.T) {
 	r2, _ := records.ListDetections(tctx(), "eng-2")
 	if len(r2) != 1 || r2[0].ID != "d1" || r2[0].EvidenceID != l2 {
 		t.Fatalf("eng-2 must retain its own row bound to link %q, got %+v", l2, r2)
+	}
+}
+
+// TestIngestRefusesUnknownKeyID: the agent is known but the batch names a KeyID the resolver cannot
+// resolve — fail closed (ErrForbidden), nothing sealed, and the rejection is audited.
+func TestIngestRefusesUnknownKeyID(t *testing.T) {
+	h := newHarness(t, 0)
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, KeyID: "kid-does-not-exist", Detections: refsFor(t, items)}
+	b.Signature = fleetagent.SignBatch(h.priv, b)
+	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("an unresolvable KeyID must be refused (fail closed), got %v", err)
+	}
+	if len(h.chain.kinds()) != 0 {
+		t.Fatal("nothing may be sealed when the key does not resolve")
+	}
+	if !h.audit.has("detection.batch_rejected") {
+		t.Error("an unknown-key rejection must be audited")
+	}
+}
+
+// TestIngestRefusesRevokedKey: the batch is validly signed by a key that resolves, but the key is revoked
+// at ingest time — VerifyBatchWithKey fails closed, so the batch is refused and nothing is sealed.
+func TestIngestRefusesRevokedKey(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	chain := &fakeChain{}
+	audit := &fakeAudit{}
+	store := memory.NewDetectionRecordStore()
+	key := mkSigningKey(t, "agent:1", pub)
+	key.RevokedAt = time.Unix(500, 0) // revoked before the harness clock (Unix 1000)
+	keys := &fakeKeys{byAgent: map[shared.ID]fleetagent.AgentSigningKey{"agent:1": key}}
+	svc, err := NewService(store, chain, keys, audit, fixedClock{t: time.Unix(1000, 0)}, &seqIDs{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, KeyID: key.KeyID, Detections: refsFor(t, items)}
+	b.Signature = fleetagent.SignBatch(priv, b)
+	if _, err := svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("a revoked key must fail closed, got %v", err)
+	}
+	if len(chain.kinds()) != 0 {
+		t.Fatal("nothing may be sealed under a revoked key")
+	}
+	if !audit.has("detection.batch_rejected") {
+		t.Error("a revoked-key rejection must be audited")
 	}
 }

--- a/internal/usecase/ports/agent_signing_key.go
+++ b/internal/usecase/ports/agent_signing_key.go
@@ -1,0 +1,45 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// AgentSigningKeyStore persists the agent content-signing key lifecycle (#607, A0.2): the public halves
+// of the keys an agent uses to sign telemetry/detection/response payloads, with their validity windows
+// and revocation. Tenant scoping is enforced in the implementation from the context tenant (the same
+// chokepoint the other fleet stores use), never by the caller.
+//
+// The store is the durable backing for the verify path: given the KeyID an incoming envelope names, the
+// control plane resolves the bound public key and decides — fail-closed — whether it may admit the
+// payload. Registration and revocation are append-only in spirit: a key's public half and window are
+// immutable once written (provenance), and revocation is monotonic (anti-rollback).
+type AgentSigningKeyStore interface {
+	// Register stores a newly registered signing key under the context tenant. It is idempotent on the
+	// KeyID: re-registering the identical key (same agent, purpose, public key, window) is a no-op, so an
+	// at-least-once registration transport cannot create duplicates. A KeyID that already exists bound to
+	// a DIFFERENT key/agent/purpose/window is refused with shared.ErrConflict — a KeyID (a public-key
+	// fingerprint) can never be re-pointed at another key (anti-rollback).
+	//
+	// CONTRACT: Register only checks the key is internally valid; it does NOT verify proof-of-possession.
+	// The caller (the A4 agent-plane registration handler) MUST first call
+	// fleetagent.VerifyKeyPossession(key, proof) so an agent cannot register a public key whose private
+	// half it does not hold, or bind a key to an agent/purpose it did not commit to. Persisting a key
+	// without that check would let an unverified public key later admit signed payloads — fail open.
+	Register(ctx context.Context, key fleetagent.AgentSigningKey) error
+	// ResolveSigningKey returns the key with keyID that is bound to agentID, under the context tenant. It
+	// returns shared.ErrNotFound when no such key exists — the verify path treats that as fail-closed (an
+	// unknown key admits nothing). The name matches the detectledger consumer interface so a store value
+	// satisfies it directly.
+	ResolveSigningKey(ctx context.Context, agentID shared.ID, keyID string) (fleetagent.AgentSigningKey, error)
+	// ListByAgent returns every signing key (any lifecycle state) for an agent, newest NotBefore first,
+	// under the context tenant — for rotation/audit views and for selecting the active signer.
+	ListByAgent(ctx context.Context, agentID shared.ID) ([]fleetagent.AgentSigningKey, error)
+	// Revoke marks the (agentID, keyID) key revoked as of `at`, under the context tenant. It is monotonic:
+	// once revoked, a later call never moves RevokedAt (a revocation cannot be walked back or forward —
+	// anti-rollback). It returns shared.ErrNotFound when the key is unknown.
+	Revoke(ctx context.Context, agentID shared.ID, keyID string, at time.Time) error
+}

--- a/migrations/0105_agent_signing_keys.sql
+++ b/migrations/0105_agent_signing_keys.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- Agent content-signing key registry (#607, A0.2). The public halves of the ed25519 keys an agent uses
+-- to sign the CONTENT it ships (telemetry / detection / response), separate from the TLS/enrolment cert
+-- key. The control plane resolves a key by the KeyID an incoming envelope names and decides — fail-closed
+-- — whether it may admit the payload, so this table is the trust root for attributable agent content.
+--
+-- Invariants enforced here:
+--   * key_id = fingerprint(public_key), and a row is immutable once written (provenance) — a KeyID can
+--     never be re-pointed at a different key (anti-rollback);
+--   * exactly one purpose per key (domain separation), CHECK-constrained;
+--   * a bounded validity window (not_before < not_after), so rotation and expiry are meaningful;
+--   * revocation is a monotonic, nullable timestamp — set once, never walked back.
+-- Tenant isolation is by RLS (the 0057 procedure), identical to the other fleet tables.
+CREATE TABLE agent_signing_keys (
+    tenant_id   TEXT NOT NULL REFERENCES tenants(id),
+    agent_id    TEXT NOT NULL,
+    key_id      TEXT NOT NULL,
+    algorithm   TEXT NOT NULL,
+    purpose     TEXT NOT NULL,
+    public_key  BYTEA NOT NULL,
+    not_before  TIMESTAMPTZ NOT NULL,
+    not_after   TIMESTAMPTZ NOT NULL,
+    revoked_at  TIMESTAMPTZ,
+    replaced_by TEXT NOT NULL DEFAULT '',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, agent_id, key_id),
+    CONSTRAINT agent_signing_keys_algorithm_check CHECK (algorithm = 'ed25519'),
+    CONSTRAINT agent_signing_keys_purpose_check CHECK (purpose IN ('telemetry-batch', 'detection-batch', 'response-result')),
+    CONSTRAINT agent_signing_keys_window_check CHECK (not_before < not_after)
+);
+
+CALL synapse_enable_tenant_rls('agent_signing_keys');
+
+-- +goose Down
+DROP TABLE agent_signing_keys;


### PR DESCRIPTION
## What & why

Phase A0.2 of the security-data-plane → EDR epic (#594). Enrollment issues a P-256 TLS cert + bearer credential, but the detection-batch protocol verifies an **Ed25519** signature the control plane can only check if it knows the agent's **content-signing key** — and there was no such key: no registry, no key id, no lifecycle, and `detectledger.AgentKeyResolver` had no production implementer. This adds a first-class content-signing key, separate from the TLS/cert key, so telemetry/detection/response payloads are attributable to a canonical agent identity over time.

## Changes

- **Domain** (`internal/domain/fleetagent/signingkey.go`): `AgentSigningKey{KeyID, AgentID, Algorithm, Purpose, PublicKey, NotBefore, NotAfter, RevokedAt, ReplacedBy}`.
  - `KeyID` **is** the public-key fingerprint (`evidence.KeyFingerprint`), so a KeyID can never name a key it wasn't minted from; `Validate()` re-asserts this on every storage round-trip.
  - `StatusAt`/`UsableAt` derive pending/active/expired/revoked and **fail closed** (revocation takes precedence over the window).
  - `ProveKeyPossession`/`VerifyKeyPossession` — proof-of-possession over a domain-separated binding message (context tag + agent + key id + purpose + algorithm + window), so a registrant must hold the private half and commits to the exact binding.
  - `VerifyBatchWithKey` — the server gate: wrong purpose → wrong agent → envelope KeyID mismatch → non-usable key → bad signature, each fails closed in order.
  - `ActiveKeyFor` — selects the newest usable key so **rotation with overlap** works.
- **Envelope** (`batch.go`): `AgentBatch` carries a `KeyID`, bound into `BatchMessage` so the named key cannot be swapped independently of the signature.
- **Persistence**: `ports.AgentSigningKeyStore` + memory and Postgres implementations (migration **0105**, PK `(tenant_id, agent_id, key_id)`, RLS-isolated). `Register` is **idempotent on identity** and **anti-rollback on the KeyID** (a KeyID can't be re-pointed → `ErrConflict`); revocation is **monotonic**. Both stores fail closed on a missing tenant.
- **detectledger**: `AgentKeyResolver` now resolves the `AgentSigningKey` by `(agentID, KeyID)` and `Ingest` verifies via `VerifyBatchWithKey`, so a rotated-out, cross-purpose, or misattributed key can never admit a detection; every rejection is audited.

## Tests

Domain lifecycle (mint/validate/status/usability, PoP round-trip incl. wrong-key + re-bound-agent + malformed, the full `VerifyBatchWithKey` gate, rotation-overlap selection); envelope KeyID binding + tamper; memory + Postgres stores (register idempotent/anti-rollback, monotonic revoke, tenant isolation under a `NOBYPASSRLS` role, fail-closed-without-tenant); detectledger Ingest fail-closed on unknown/revoked key with audit. Full suite green (247 packages, incl. Postgres integration; migration 0105 applies clean). go-arch + security reviews both clean.

## Reviewer-driven changes applied in this PR

- Renamed the port method to `ResolveSigningKey` so a store value **directly satisfies** the detectledger consumer interface (no A4 shim).
- Hard doc contract on `Register`: the A4 registration handler **MUST** call `VerifyKeyPossession` first.
- Memory store made fail-closed on a missing tenant, matching the authoritative Postgres store.

## Scope / follow-up

Deliberately does **not** wire the write path. `detectledger.NewService` (the `AgentKeyResolver` consumer) stays unwired; only the read surface is composed. Deferred to **A4** (needs the agent→control-plane transport): the agent-plane **key-registration endpoint** (agent posts its signing public key + a `ProveKeyPossession` proof bound to its canonical `AgentID`) and the operator **rotate/revoke** routes. A wiring anchor note in `cmd/synapse-api/main.go` records the prerequisite (resolver = the new store; registration must verify possession).

**#607 stays open** after this merge — it tracks the remaining A4 endpoint/handshake work.

Part of #594.
