### PR TITLE
feat(fleetagent): telemetry/detection delivery contract (A0.4)

### DIFF
--- a/internal/domain/fleetagent/batch.go
+++ b/internal/domain/fleetagent/batch.go
@@ -155,6 +155,10 @@ func (g SequenceGap) HasGap() bool { return g.Missing > 0 || g.Replay }
 // DetectSequenceGap compares an incoming batch sequence against the last sequence recorded for that
 // agent (0 = none yet). The expected next sequence is lastSeen+1; anything higher leaves a gap, anything
 // not higher is a replay/out-of-order.
+//
+// This is the single-counter predecessor of the delivery contract (#609): it cannot tell a legitimate
+// reboot reset-to-1 apart from a replay. It is superseded by ClassifyDelivery (delivery.go), which is
+// incarnation-aware; A3 adopts ClassifyDelivery once the wire envelope carries a StreamPosition.
 func DetectSequenceGap(lastSeen, incoming uint64) SequenceGap {
 	if incoming <= lastSeen {
 		return SequenceGap{Replay: true}

--- a/internal/domain/fleetagent/delivery.go
+++ b/internal/domain/fleetagent/delivery.go
@@ -1,0 +1,304 @@
+package fleetagent
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Delivery contract (#609, A0.4). The agent ships security signals to the control plane under an explicit,
+// modest guarantee — NOT exactly-once:
+//
+//	at-least-once delivery + idempotent ingest + a durable agent spool + a monotonic sequence per
+//	(stream, incarnation) + a highest-contiguous ACK + explicit, queryable gaps.
+//
+// This file is the CONTRACT: the identity, ordering, de-duplication, and gap primitives both sides agree
+// on. The agent-side write-ahead spool (fsync/eviction/backoff/resume) is A2; the ingest+ACK transport is
+// A3. Both consume these types, so the safety properties are defined and tested here, once, independent of
+// any wire format or disk layout.
+
+// DeliveryPriority is the spool/delivery priority class of a signal. The agent's durable spool drains by
+// class so the signals that matter most for a live engagement survive back-pressure and disk pressure
+// first. The ladder is the contract; assigning a concrete signal to a class is the producer's job (A2).
+type DeliveryPriority int
+
+const (
+	// PriorityP0 — response-verification results, coverage/honesty, and sensor-health. Losing these would
+	// make the platform lie about what it did or saw, so they drain first and are evicted last.
+	PriorityP0 DeliveryPriority = iota
+	// PriorityP1 — confirmed detections.
+	PriorityP1
+	// PriorityP2 — privilege changes and critical-file events.
+	PriorityP2
+	// PriorityP3 — background process/network telemetry (the highest-volume, most-sheddable stream).
+	PriorityP3
+)
+
+// Valid reports whether p is one of the defined priority classes.
+func (p DeliveryPriority) Valid() bool { return p >= PriorityP0 && p <= PriorityP3 }
+
+// String renders the priority as its stable wire label (P0..P3).
+func (p DeliveryPriority) String() string {
+	switch p {
+	case PriorityP0:
+		return "P0"
+	case PriorityP1:
+		return "P1"
+	case PriorityP2:
+		return "P2"
+	case PriorityP3:
+		return "P3"
+	default:
+		return "P?"
+	}
+}
+
+// SessionID identifies one agent run/enrolment session; BootID identifies one host boot. Both are opaque
+// (typically random) — they are recorded for attribution and to detect corruption, but ordering is decided
+// by the Epoch, because random ids cannot be compared. A reinstall changes the Session; a reboot changes
+// the Boot; either resets the per-stream Sequence, and the agent signals that reset by advancing Epoch.
+type SessionID string
+type BootID string
+
+// StreamPosition is where an agent is in one priority stream. Sequence is monotonic within an INCARNATION
+// (Epoch); on a reboot/reinstall/spool-loss the agent starts a new incarnation — Epoch increments and
+// Sequence restarts at 1. Carrying a monotonic Epoch (not just the opaque Session/Boot) is what lets the
+// control plane tell a legitimate reset-to-1 apart from a replay of an old sequence: a higher Epoch is a
+// new incarnation, never a replay.
+type StreamPosition struct {
+	Priority DeliveryPriority
+	Epoch    uint64 // incarnation counter; increments on every Sequence reset (reboot/reinstall/spool-loss)
+	Sequence uint64 // monotonic within (Priority, Epoch); restarts at 1 when Epoch increments
+	Session  SessionID
+	Boot     BootID
+}
+
+// Validate checks a position is well-formed: a real priority, an incarnation and sequence that both start
+// at 1, and non-empty session/boot ids (so every accepted signal is attributable to a concrete run+boot).
+func (p StreamPosition) Validate() error {
+	if !p.Priority.Valid() {
+		return fmt.Errorf("%w: unknown delivery priority %d", shared.ErrValidation, int(p.Priority))
+	}
+	if p.Epoch == 0 {
+		return fmt.Errorf("%w: stream epoch must be >= 1 (0 is reserved for 'no incarnation yet')", shared.ErrValidation)
+	}
+	if p.Sequence == 0 {
+		return fmt.Errorf("%w: stream sequence must be >= 1 (0 is reserved for 'no batch yet')", shared.ErrValidation)
+	}
+	if p.Session == "" {
+		return fmt.Errorf("%w: stream position has no session id", shared.ErrValidation)
+	}
+	if p.Boot == "" {
+		return fmt.Errorf("%w: stream position has no boot id", shared.ErrValidation)
+	}
+	return nil
+}
+
+// DeliveryClass is how an incoming position relates to the last one accepted for the same stream.
+type DeliveryClass string
+
+const (
+	// DeliveryOK — exactly the expected next sequence within the current incarnation.
+	DeliveryOK DeliveryClass = "ok"
+	// DeliveryForwardGap — ahead of the expected next in the current incarnation: one or more sequences are
+	// unaccounted for (a potential loss the caller MUST surface as an explicit gap, never silently accept).
+	DeliveryForwardGap DeliveryClass = "forward_gap"
+	// DeliveryReplay — the incoming batch sequence is not ahead of the high-water within the current
+	// incarnation. This covers BOTH a true duplicate AND a genuine late arrival that fills an earlier gap,
+	// because ClassifyDelivery only knows the scalar high-water, not which sequences were actually received.
+	// It therefore MUST NOT be treated as "discard the payload": the authority for "already have this
+	// signal" is AckLedger.Observe / DeliveryKey (see below), and a below-high-water sequence is frequently
+	// a real gap-fill that closes an outstanding gap. Equating !IsProgress() with drop would silently lose
+	// exactly the signal the contract exists to preserve.
+	DeliveryReplay DeliveryClass = "replay"
+	// DeliveryNewIncarnation — a higher Epoch: a legitimate reboot/reinstall reset, NOT a replay even though
+	// the Sequence dropped back toward 1. If the new incarnation's first sequence is > 1, Missing says how
+	// many were lost across the restart.
+	DeliveryNewIncarnation DeliveryClass = "new_incarnation"
+	// DeliveryStaleIncarnation — a lower Epoch than the one already accepted: an old incarnation resurfacing
+	// (a delayed/duplicated batch from before a restart). Treated as a replay-class event, never accepted as
+	// forward progress.
+	DeliveryStaleIncarnation DeliveryClass = "stale_incarnation"
+)
+
+// DeliveryOutcome is the classification plus, when relevant, how many sequences are unaccounted for.
+type DeliveryOutcome struct {
+	Class   DeliveryClass
+	Missing uint64
+}
+
+// HasGap reports whether the outcome implies one or more sequences are missing.
+func (o DeliveryOutcome) HasGap() bool { return o.Missing > 0 }
+
+// IsProgress reports whether the incoming batch advances the high-water of its incarnation. OK,
+// ForwardGap, and NewIncarnation are progress; Replay and StaleIncarnation are not.
+//
+// IsProgress is a classification of ORDERING, not a persistence decision. A caller must NOT read
+// !IsProgress() as "drop this batch": a Replay may be a genuine gap-fill below the high-water. Decide
+// idempotent persistence per event via DeliveryKey (dedup) and AckLedger.Observe (which returns true for a
+// first-seen sequence — including a gap-fill — and false only for a true duplicate). Use IsProgress only to
+// drive high-water/gap bookkeeping.
+func (o DeliveryOutcome) IsProgress() bool {
+	switch o.Class {
+	case DeliveryOK, DeliveryForwardGap, DeliveryNewIncarnation:
+		return true
+	default:
+		return false
+	}
+}
+
+// ClassifyDelivery compares the last accepted position for a stream against an incoming one and says how
+// they relate — the core of session-aware gap/replay/reset detection. Both positions are assumed to be the
+// SAME priority stream (the caller partitions by priority). A zero-value `last` means nothing has been
+// accepted yet, so the first incarnation is reported as NewIncarnation.
+//
+// Ordering is by Epoch first (incarnations), then Sequence within an incarnation — never by the opaque
+// Session/Boot ids, which cannot be ordered. This is precisely what keeps a reboot's reset-to-1 from being
+// mistaken for a replay: the reboot advanced Epoch, so it sorts AFTER the previous incarnation.
+//
+// The caller MUST have Validate()d `incoming` first (Epoch >= 1, Sequence >= 1); a zero-Epoch incoming
+// against a zero-value last would otherwise fall through to the same-incarnation branch and read as a
+// Replay. `last` is the last ACCEPTED position (its zero value means "nothing yet").
+func ClassifyDelivery(last, incoming StreamPosition) DeliveryOutcome {
+	switch {
+	case incoming.Epoch > last.Epoch:
+		// A new incarnation (or the very first). Its first sequence should be 1; anything higher means
+		// batches were lost across the restart before this one reached us.
+		var missing uint64
+		if incoming.Sequence > 1 {
+			missing = incoming.Sequence - 1
+		}
+		return DeliveryOutcome{Class: DeliveryNewIncarnation, Missing: missing}
+	case incoming.Epoch < last.Epoch:
+		return DeliveryOutcome{Class: DeliveryStaleIncarnation}
+	default: // same incarnation
+		if incoming.Sequence <= last.Sequence {
+			return DeliveryOutcome{Class: DeliveryReplay}
+		}
+		missing := incoming.Sequence - last.Sequence - 1
+		if missing > 0 {
+			return DeliveryOutcome{Class: DeliveryForwardGap, Missing: missing}
+		}
+		return DeliveryOutcome{Class: DeliveryOK}
+	}
+}
+
+// DeliveryKey is the idempotency key for one event within a batch: a resend of the same
+// (agent, incarnation, stream, sequence, event index) is the SAME key, so the server's ingest can treat it
+// as a no-op instead of storing a duplicate. It deliberately keys on Epoch too, so the same (stream,
+// sequence, index) in a NEW incarnation is a distinct key (a legitimately different event after a reset),
+// never collapsed into the pre-restart one.
+//
+// Fields are LENGTH-PREFIXED, not separator-joined: the agent id is a free-form string that could itself
+// contain any separator byte, and a forged boundary in an idempotency key would let one event's ingest
+// suppress a different event (a silent-loss vector). Length prefixing makes the decoding unambiguous
+// regardless of field contents.
+func DeliveryKey(agent shared.ID, pos StreamPosition, eventIndex int) string {
+	var b strings.Builder
+	write := func(s string) {
+		b.WriteString(strconv.Itoa(len(s)))
+		b.WriteByte(':')
+		b.WriteString(s)
+	}
+	write(agent.String())
+	write(strconv.Itoa(int(pos.Priority))) // the raw discriminant, not String() (which maps every invalid value to "P?")
+	write(strconv.FormatUint(pos.Epoch, 10))
+	write(strconv.FormatUint(pos.Sequence, 10))
+	write(strconv.Itoa(eventIndex))
+	return b.String()
+}
+
+// SeqRange is an inclusive range of sequence numbers, used to report gaps compactly.
+type SeqRange struct {
+	From uint64 // inclusive
+	To   uint64 // inclusive
+}
+
+// AckLedger tracks, for ONE stream incarnation, which sequences have been received, and derives the
+// highest-contiguous ACK and the explicit gaps below it. The ACK a stream reports is the highest sequence
+// S such that every sequence in 1..S has been received — so an ACK can never skip a hole, and any sequence
+// received out of order above a hole is remembered but does NOT advance the ACK until the hole fills. The
+// gaps are the still-missing sequences below the highest one received, i.e. the explicit, queryable
+// "we know these are outstanding" set. A zero-value AckLedger is ready to use.
+//
+// NOT safe for concurrent use: it is a per-stream, per-caller accumulator — synchronize externally (or
+// use one ledger per goroutine) rather than sharing an instance across goroutines.
+type AckLedger struct {
+	contiguous uint64          // highest S with all of 1..S received (0 = none yet)
+	pending    map[uint64]bool // received sequences strictly beyond the contiguous run (out-of-order)
+}
+
+// NewAckLedger returns an empty ledger.
+func NewAckLedger() *AckLedger { return &AckLedger{} }
+
+// Observe records that sequence seq has been received. It returns true if this is the first time seq is
+// seen — INCLUDING a late arrival that fills an earlier gap below the high-water — and false if seq is a
+// true duplicate (idempotent no-op) or invalid (0). This boolean is the authoritative "new vs already-have"
+// signal the ingest path should gate persistence on (together with DeliveryKey), NOT ClassifyDelivery's
+// progress flag. Receiving the sequence just above the contiguous run extends it, absorbing any previously
+// out-of-order sequences that are now contiguous.
+//
+// The caller should bound an implausible forward jump BEFORE Observe (e.g. reject a batch whose
+// ForwardGap.Missing is absurd): the pending set holds one entry per out-of-order sequence, so an
+// untrusted agent that streams a huge spread of sparse sequences grows memory in proportion to what it
+// sent. That back-pressure/quota is A2/A3's job; Observe itself does no per-call unbounded work.
+func (l *AckLedger) Observe(seq uint64) bool {
+	if seq == 0 || seq <= l.contiguous {
+		return false // 0 is not a valid sequence; anything within the contiguous run is a duplicate
+	}
+	if l.pending[seq] {
+		return false // already recorded out-of-order
+	}
+	if seq == l.contiguous+1 {
+		l.contiguous++
+		for l.pending[l.contiguous+1] {
+			delete(l.pending, l.contiguous+1)
+			l.contiguous++
+		}
+		return true
+	}
+	if l.pending == nil {
+		l.pending = map[uint64]bool{}
+	}
+	l.pending[seq] = true
+	return true
+}
+
+// HighestContiguous returns the ACK: the highest sequence with no hole beneath it (0 = nothing yet).
+func (l *AckLedger) HighestContiguous() uint64 { return l.contiguous }
+
+// Gaps returns the still-missing sequence ranges below the highest sequence received, oldest first. An
+// empty result means everything received so far is contiguous (nothing outstanding). These are the
+// explicit gaps the contract requires be surfaced rather than silently tolerated.
+func (l *AckLedger) Gaps() []SeqRange {
+	if len(l.pending) == 0 {
+		return nil
+	}
+	// Iterate the RECEIVED (pending) sequences, not the numeric range: cost is O(n log n) in the number of
+	// out-of-order sequences held, never proportional to the largest sequence number an (untrusted) agent
+	// sends. Every pending key is > contiguous+1 (contiguous absorbs contiguous+1 on arrival), so the hole
+	// between one landmark and the next is a gap. The contiguous high-water is the first landmark.
+	seqs := make([]uint64, 0, len(l.pending))
+	for s := range l.pending {
+		seqs = append(seqs, s)
+	}
+	sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
+	var gaps []SeqRange
+	prev := l.contiguous // everything <= contiguous is present
+	for _, s := range seqs {
+		if s > prev+1 {
+			gaps = append(gaps, SeqRange{From: prev + 1, To: s - 1})
+		}
+		prev = s
+	}
+	return gaps
+}
+
+// SortSeqRanges orders ranges by their start, so callers comparing/persisting gap sets get a canonical
+// order. (Gaps already returns ranges in order; this is for callers that merge ranges from many streams.)
+func SortSeqRanges(rs []SeqRange) {
+	sort.Slice(rs, func(i, j int) bool { return rs[i].From < rs[j].From })
+}

--- a/internal/domain/fleetagent/delivery_test.go
+++ b/internal/domain/fleetagent/delivery_test.go
@@ -1,0 +1,178 @@
+package fleetagent
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func pos(pr DeliveryPriority, epoch, seq uint64) StreamPosition {
+	return StreamPosition{Priority: pr, Epoch: epoch, Sequence: seq, Session: "sess-1", Boot: "boot-1"}
+}
+
+func TestDeliveryPriority(t *testing.T) {
+	for _, p := range []DeliveryPriority{PriorityP0, PriorityP1, PriorityP2, PriorityP3} {
+		if !p.Valid() {
+			t.Errorf("%d must be valid", p)
+		}
+	}
+	if (DeliveryPriority(4)).Valid() || (DeliveryPriority(-1)).Valid() {
+		t.Error("out-of-range priorities must be invalid")
+	}
+	if PriorityP0.String() != "P0" || PriorityP3.String() != "P3" {
+		t.Error("priority labels must be P0..P3")
+	}
+}
+
+func TestStreamPositionValidate(t *testing.T) {
+	if err := pos(PriorityP1, 1, 1).Validate(); err != nil {
+		t.Fatalf("a well-formed position must validate: %v", err)
+	}
+	bad := map[string]StreamPosition{
+		"bad priority": {Priority: 9, Epoch: 1, Sequence: 1, Session: "s", Boot: "b"},
+		"zero epoch":   {Priority: PriorityP1, Epoch: 0, Sequence: 1, Session: "s", Boot: "b"},
+		"zero seq":     {Priority: PriorityP1, Epoch: 1, Sequence: 0, Session: "s", Boot: "b"},
+		"no session":   {Priority: PriorityP1, Epoch: 1, Sequence: 1, Boot: "b"},
+		"no boot":      {Priority: PriorityP1, Epoch: 1, Sequence: 1, Session: "s"},
+	}
+	for name, p := range bad {
+		t.Run(name, func(t *testing.T) {
+			if err := p.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestClassifyDelivery(t *testing.T) {
+	cases := []struct {
+		name           string
+		last, incoming StreamPosition
+		wantClass      DeliveryClass
+		wantMissing    uint64
+	}{
+		{"first ever", StreamPosition{}, pos(PriorityP1, 1, 1), DeliveryNewIncarnation, 0},
+		{"expected next", pos(PriorityP1, 1, 4), pos(PriorityP1, 1, 5), DeliveryOK, 0},
+		{"forward gap", pos(PriorityP1, 1, 4), pos(PriorityP1, 1, 7), DeliveryForwardGap, 2},
+		{"replay equal", pos(PriorityP1, 1, 5), pos(PriorityP1, 1, 5), DeliveryReplay, 0},
+		{"replay lower", pos(PriorityP1, 1, 5), pos(PriorityP1, 1, 3), DeliveryReplay, 0},
+		// The headline acceptance: a reboot resets Sequence to 1 but advances Epoch — NOT a replay.
+		{"reboot reset to 1", pos(PriorityP1, 1, 9), pos(PriorityP1, 2, 1), DeliveryNewIncarnation, 0},
+		{"reboot with loss", pos(PriorityP1, 1, 9), pos(PriorityP1, 2, 3), DeliveryNewIncarnation, 2},
+		{"stale incarnation", pos(PriorityP1, 3, 2), pos(PriorityP1, 2, 8), DeliveryStaleIncarnation, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ClassifyDelivery(c.last, c.incoming)
+			if got.Class != c.wantClass || got.Missing != c.wantMissing {
+				t.Fatalf("got %+v, want class %s missing %d", got, c.wantClass, c.wantMissing)
+			}
+			// Progress/loss helpers stay consistent with the class.
+			if (got.Missing > 0) != got.HasGap() {
+				t.Errorf("HasGap must track Missing>0")
+			}
+			wantProgress := c.wantClass == DeliveryOK || c.wantClass == DeliveryForwardGap || c.wantClass == DeliveryNewIncarnation
+			if got.IsProgress() != wantProgress {
+				t.Errorf("IsProgress=%v, want %v for %s", got.IsProgress(), wantProgress, c.wantClass)
+			}
+		})
+	}
+}
+
+func TestDeliveryKeyIdentity(t *testing.T) {
+	base := pos(PriorityP1, 1, 5)
+	k := DeliveryKey("agent:1", base, 2)
+	// A resend of the SAME (agent, incarnation, stream, sequence, index) is the same idempotency key.
+	if k != DeliveryKey("agent:1", base, 2) {
+		t.Fatal("the same event must produce the same key")
+	}
+	// Every distinguishing field changes the key — especially the epoch, so the same (seq,index) in a new
+	// incarnation is a DISTINCT event, never collapsed into the pre-restart one.
+	newEpoch := base
+	newEpoch.Epoch = 2
+	for name, other := range map[string]string{
+		"agent":    DeliveryKey("agent:2", base, 2),
+		"epoch":    DeliveryKey("agent:1", newEpoch, 2),
+		"index":    DeliveryKey("agent:1", base, 3),
+		"priority": DeliveryKey("agent:1", pos(PriorityP2, 1, 5), 2),
+	} {
+		if other == k {
+			t.Errorf("%s must change the delivery key", name)
+		}
+	}
+}
+
+func TestDeliveryKeyResistsBoundaryForgery(t *testing.T) {
+	// Length-prefixing means a free-form agent id — even one crammed with delimiter-ish bytes — cannot
+	// shift field boundaries to alias a different (agent, position, index) tuple.
+	a := DeliveryKey(shared.ID("a\x1e1:2:3"), pos(PriorityP1, 1, 5), 2)
+	b := DeliveryKey(shared.ID("a"), pos(PriorityP1, 1, 5), 2)
+	if a == b {
+		t.Fatal("a crafted agent id must not alias a different agent's key")
+	}
+	// Distinct priorities must never collapse to one key (they must not both render to a display fallback).
+	if DeliveryKey("agent:1", pos(PriorityP2, 1, 5), 0) == DeliveryKey("agent:1", pos(PriorityP3, 1, 5), 0) {
+		t.Fatal("distinct priorities must produce distinct keys")
+	}
+}
+
+func TestAckLedgerContiguousAndDuplicates(t *testing.T) {
+	l := NewAckLedger()
+	if l.HighestContiguous() != 0 {
+		t.Fatal("empty ledger ACKs 0")
+	}
+	for _, s := range []uint64{1, 2, 3} {
+		if !l.Observe(s) {
+			t.Fatalf("first sight of %d must record", s)
+		}
+	}
+	if l.HighestContiguous() != 3 {
+		t.Fatalf("contiguous 1..3 must ACK 3, got %d", l.HighestContiguous())
+	}
+	// Duplicates and 0 are idempotent no-ops.
+	if l.Observe(2) || l.Observe(0) {
+		t.Error("a duplicate or zero sequence must be a no-op")
+	}
+	if len(l.Gaps()) != 0 {
+		t.Errorf("a fully contiguous run has no gaps, got %+v", l.Gaps())
+	}
+}
+
+func TestAckLedgerOutOfOrderAndGaps(t *testing.T) {
+	l := NewAckLedger()
+	// Receive 1, then 4 and 6 out of order: ACK stays at 1, gaps are {2-3, 5}.
+	l.Observe(1)
+	l.Observe(4)
+	l.Observe(6)
+	if l.HighestContiguous() != 1 {
+		t.Fatalf("a hole above 1 must keep the ACK at 1, got %d", l.HighestContiguous())
+	}
+	got := l.Gaps()
+	want := []SeqRange{{From: 2, To: 3}, {From: 5, To: 5}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("gaps = %+v, want %+v", got, want)
+	}
+	// A re-observe of an out-of-order sequence already held is a duplicate (false); a genuine fill below
+	// the high-water is first-seen (true) — this is why the ingest path gates on Observe, not IsProgress.
+	if l.Observe(4) {
+		t.Error("re-observing a pending sequence must be a duplicate (false)")
+	}
+	if !l.Observe(3) {
+		t.Error("a first-seen gap-fill below the high-water must return true, not be dropped as a replay")
+	}
+	// Fill 2: the ACK jumps to 4 (absorbing the now-contiguous 3,4), leaving only the {5} gap.
+	l.Observe(2)
+	if l.HighestContiguous() != 4 {
+		t.Fatalf("filling 2,3 must advance the ACK to 4, got %d", l.HighestContiguous())
+	}
+	if got := l.Gaps(); !reflect.DeepEqual(got, []SeqRange{{From: 5, To: 5}}) {
+		t.Fatalf("after filling 2,3 the only gap is {5}, got %+v", got)
+	}
+	// Fill 5: 6 is absorbed, everything contiguous, no gaps.
+	l.Observe(5)
+	if l.HighestContiguous() != 6 || len(l.Gaps()) != 0 {
+		t.Fatalf("filling 5 must ACK 6 with no gaps, got ack=%d gaps=%+v", l.HighestContiguous(), l.Gaps())
+	}
+}


### PR DESCRIPTION
## What & why

Phase A0.4 of the security-data-plane → EDR epic (#594). Defines the telemetry/detection **delivery contract** so no security signal is silently lost and replays are safe. The guarantee is explicit and modest — **not** exactly-once:

> at-least-once delivery + idempotent ingest + a durable agent spool + a monotonic sequence per (stream, incarnation) + a highest-contiguous ACK + explicit, queryable gaps.

This lands the contract as **pure-domain primitives** both sides agree on. Per the issue's own dependency note, the agent write-ahead spool (**A2**) and the ingest/ACK transport (**A3**) consume these, so the safety properties are defined and exhaustively tested here once, independent of any wire format or disk layout.

## Changes (`internal/domain/fleetagent/delivery.go`)

- **`DeliveryPriority` (P0..P3)** — the spool/delivery ladder (P0 response-verification/coverage/sensor-health · P1 detections · P2 privilege/critical-file · P3 background process/network), so the most important signals drain and survive back-pressure first.
- **`StreamPosition{Priority, Epoch, Sequence, Session, Boot}`** — Sequence is monotonic within an **incarnation** (`Epoch`); a reboot/reinstall/spool-loss starts a new incarnation (`Epoch++`, `Sequence` back to 1). Carrying a monotonic Epoch — not just the opaque Session/Boot ids — is what lets a legitimate reset-to-1 be told apart from a replay.
- **`ClassifyDelivery`** — session-aware `ok` / `forward_gap` / `replay` / `new_incarnation` / `stale_incarnation`, ordered by Epoch then Sequence. A reboot's reset-to-1 is a new incarnation, never a replay; a forward gap reports how many sequences are missing; loss across a restart is counted.
- **`AckLedger`** — highest-contiguous ACK (never skips a hole) + the explicit, still-open gap ranges below the highest sequence received, so a missing batch is queryable, not silently tolerated. `Observe` is idempotent and is the authoritative "new vs already-have" signal (returns `true` for a genuine gap-fill, `false` only for a true duplicate).
- **`DeliveryKey(agent, position, eventIndex)`** — the idempotency key a resend collapses onto; keyed on the Epoch too (so the same `(sequence, index)` in a new incarnation is a distinct event), length-prefixed so a free-form agent id can't forge field boundaries, and keyed on the raw priority discriminant (no display-fallback collisions).

## Tests

Priority validity/labels; `StreamPosition.Validate`; the full `ClassifyDelivery` table incl. the headline **reboot-reset-to-1-is-not-a-replay** and reboot-with-loss; `DeliveryKey` identity, epoch/priority distinctness, and **boundary-forgery resistance**; `AckLedger` contiguous ACK, out-of-order + coalesced gaps, gap-fill-returns-true vs duplicate-returns-false. Full suite green (247 packages). go-arch + security reviews both clean.

## Reviewer-driven changes applied in this PR

- `AckLedger.Gaps()` rewritten to iterate the **received (pending) set** (O(n log n)), not the numeric range — removes a CPU-exhaustion vector from an untrusted agent sending a huge sparse sequence (both reviewers flagged).
- `DeliveryKey` length-prefixes fields and keys on the integer priority discriminant, closing two idempotency-key collision (silent-loss) vectors.
- Documented that idempotent persistence is decided by `Observe`/`DeliveryKey`, **never** by `ClassifyDelivery.IsProgress()` (a `Replay` may be a genuine gap-fill), so no A3 caller can equate `!IsProgress()` with "drop".
- `DetectSequenceGap` marked as the single-counter predecessor superseded by `ClassifyDelivery`; `AckLedger` documented not-concurrency-safe; `ClassifyDelivery` precondition (validated `incoming`) documented.

## Scope / follow-up

Deferred by the issue's dependency note: the agent **write-ahead spool** implementation — fsync/eviction/quota/backoff+jitter/resume/disk-full/429-5xx policy + agent metrics — is **A2**; folding `StreamPosition` into the wire envelope and the idempotent-ingest + highest-contiguous-ACK + persisted-gap **endpoint** is **A3** (which also retires `DetectSequenceGap` in `detectledger` for `ClassifyDelivery`).

**#609 stays open** after this merge — it tracks the A2/A3 work.

Part of #594.
