### PR TITLE
fix(telemetry): honest loss accounting — Sampled != Truncated != Dropped (A0.6, D2)

### DIFF
--- a/internal/domain/telemetry/loss.go
+++ b/internal/domain/telemetry/loss.go
@@ -1,0 +1,91 @@
+// Package telemetry is the pure domain for the raw-telemetry tier's HONESTY semantics (#611, A0.4/A0.6):
+// how a batch's fidelity is classified so coverage/confidence never lie. It owns no I/O and no store — the
+// columnar tier lives behind ports.TelemetryStore — only the vocabulary both sides reason about.
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// LossDisposition names WHY a stored window is less than the full truth. The whole point of A0.6 (fixing
+// D2) is that these are DISTINCT and never collapsed into a single "sample rate": keeping a prefix and
+// calling it a sample hides that the tail — where a late malicious sequence lives — was dropped.
+type LossDisposition string
+
+const (
+	// Complete — nothing was lost; the window is the full truth for what the agent shipped.
+	Complete LossDisposition = "complete"
+	// Sampled — an INTENTIONAL policy kept one event per N observed, under a named algorithm. A sample is
+	// representative by construction; it is not a truncation.
+	Sampled LossDisposition = "sampled"
+	// Truncated — a batch was cut by a hard limit (e.g. the ingest budget). Unlike a sample, a truncation
+	// is NOT representative — it keeps a prefix and drops a contiguous tail — so it must be recorded as its
+	// own thing with a reason, never as an elevated sample rate.
+	Truncated LossDisposition = "truncated"
+	// Dropped — events were observed and then lost under pressure or failure (never stored at all). This is
+	// the most severe: the window is missing signal that was seen but could not be kept.
+	Dropped LossDisposition = "dropped"
+)
+
+// Valid reports whether d is a known disposition.
+func (d LossDisposition) Valid() bool {
+	switch d {
+	case Complete, Sampled, Truncated, Dropped:
+		return true
+	default:
+		return false
+	}
+}
+
+// Lossy reports whether the disposition means the window is less than complete — i.e. a hunt over it must
+// NOT be presented as the whole truth. Everything but Complete is lossy (a Sample included: a sampled
+// window is representative but still not every event).
+func (d LossDisposition) Lossy() bool { return d != Complete }
+
+// MustNotShed reports whether a telemetry class carries signal that must NEVER be sampled or truncated
+// (the hard "never-sample" list of #611 applied to the raw-telemetry classes): losing part of it would
+// corrupt a security decision, so an over-budget batch of such a class is refused (back-pressured) rather
+// than stored as a lossy prefix. Privilege transitions and sensitive-file activity qualify; high-volume
+// process/network background telemetry is sheddable.
+//
+// The broader never-sample list (confirmed detections, response-verification, sensor-state, coverage
+// gaps, key/config tampering, agent stop/update/decommission) rides the evidence/detection path, not this
+// lossy columnar tier, so it is enforced there — here we gate the two raw classes that are never-shed.
+func MustNotShed(c detection.Class) bool {
+	switch c {
+	case detection.ClassPrivilege, detection.ClassFile:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateLossCounts checks the honest-accounting invariant shared by every loss record: the counts add
+// up (kept + dropped == observed) and are non-negative, and each disposition carries what it needs — a
+// Truncated/Dropped record must actually report a drop, a Complete record must report none. It keeps the
+// count arithmetic in one place so the ports/store records and any future producer agree.
+func ValidateLossCounts(d LossDisposition, observed, kept, dropped int) error {
+	if !d.Valid() {
+		return fmt.Errorf("%w: unknown loss disposition %q", shared.ErrValidation, d)
+	}
+	if observed < 0 || kept < 0 || dropped < 0 {
+		return fmt.Errorf("%w: loss counts cannot be negative (observed=%d kept=%d dropped=%d)", shared.ErrValidation, observed, kept, dropped)
+	}
+	if kept+dropped != observed {
+		return fmt.Errorf("%w: loss counts must add up: kept(%d)+dropped(%d) != observed(%d)", shared.ErrValidation, kept, dropped, observed)
+	}
+	switch d {
+	case Complete:
+		if dropped != 0 {
+			return fmt.Errorf("%w: a Complete window cannot report a drop (dropped=%d)", shared.ErrValidation, dropped)
+		}
+	case Truncated, Dropped:
+		if dropped == 0 {
+			return fmt.Errorf("%w: a %s loss must report at least one dropped event", shared.ErrValidation, d)
+		}
+	}
+	return nil
+}

--- a/internal/domain/telemetry/loss_test.go
+++ b/internal/domain/telemetry/loss_test.go
@@ -1,0 +1,75 @@
+package telemetry
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestLossDisposition(t *testing.T) {
+	for _, d := range []LossDisposition{Complete, Sampled, Truncated, Dropped} {
+		if !d.Valid() {
+			t.Errorf("%q must be valid", d)
+		}
+	}
+	if LossDisposition("nope").Valid() {
+		t.Error("an unknown disposition must be invalid")
+	}
+	// Only Complete is non-lossy.
+	if Complete.Lossy() {
+		t.Error("Complete must not be lossy")
+	}
+	for _, d := range []LossDisposition{Sampled, Truncated, Dropped} {
+		if !d.Lossy() {
+			t.Errorf("%q must be lossy", d)
+		}
+	}
+}
+
+func TestMustNotShed(t *testing.T) {
+	// Privilege + sensitive-file are never-shed; process/network are sheddable background.
+	if !MustNotShed(detection.ClassPrivilege) || !MustNotShed(detection.ClassFile) {
+		t.Error("privilege and file classes must be never-shed")
+	}
+	if MustNotShed(detection.ClassProcess) || MustNotShed(detection.ClassNetwork) {
+		t.Error("process and network are sheddable background telemetry")
+	}
+}
+
+func TestValidateLossCounts(t *testing.T) {
+	ok := []struct {
+		d                       LossDisposition
+		observed, kept, dropped int
+	}{
+		{Complete, 5, 5, 0},
+		{Sampled, 10, 1, 9},
+		{Truncated, 10, 4, 6},
+		{Dropped, 7, 0, 7},
+	}
+	for _, c := range ok {
+		if err := ValidateLossCounts(c.d, c.observed, c.kept, c.dropped); err != nil {
+			t.Errorf("%+v must validate, got %v", c, err)
+		}
+	}
+	bad := []struct {
+		name                    string
+		d                       LossDisposition
+		observed, kept, dropped int
+	}{
+		{"bad disposition", "nope", 5, 5, 0},
+		{"negative", Truncated, 5, -1, 6},
+		{"counts do not add up", Truncated, 10, 4, 5},
+		{"complete with a drop", Complete, 5, 4, 1},
+		{"truncated with no drop", Truncated, 5, 5, 0},
+		{"dropped with no drop", Dropped, 5, 5, 0},
+	}
+	for _, c := range bad {
+		t.Run(c.name, func(t *testing.T) {
+			if err := ValidateLossCounts(c.d, c.observed, c.kept, c.dropped); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want validation error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/persistence/memory/telemetry_store.go
+++ b/internal/infrastructure/persistence/memory/telemetry_store.go
@@ -17,10 +17,11 @@ import (
 // expiry), sampling recorded with the data, and sequence-gap visibility. It is reached only through
 // ports.TelemetryStore.
 type TelemetryStore struct {
-	mu   sync.Mutex
-	rows map[shared.ID][]telemetryRow // tenant -> rows
-	hot  time.Duration
-	warm time.Duration
+	mu     sync.Mutex
+	rows   map[shared.ID][]telemetryRow        // tenant -> rows
+	losses map[shared.ID][]ports.TelemetryLoss // tenant -> first-class loss records (A0.6)
+	hot    time.Duration
+	warm   time.Duration
 }
 
 type telemetryRow struct {
@@ -37,7 +38,28 @@ var _ ports.TelemetryStore = (*TelemetryStore)(nil)
 
 // NewTelemetryStore constructs the store with the hot/warm tier boundaries (the config in ADR 0001).
 func NewTelemetryStore(hot, warm time.Duration) *TelemetryStore {
-	return &TelemetryStore{rows: map[shared.ID][]telemetryRow{}, hot: hot, warm: warm}
+	return &TelemetryStore{rows: map[shared.ID][]telemetryRow{}, losses: map[shared.ID][]ports.TelemetryLoss{}, hot: hot, warm: warm}
+}
+
+// RecordLoss persists a Truncated/Dropped loss record for the ctx tenant, idempotent on
+// (host, class, seq, disposition) so a re-ingest of the same over-budget batch records one loss.
+func (s *TelemetryStore) RecordLoss(ctx context.Context, loss ports.TelemetryLoss) error {
+	if err := loss.Validate(); err != nil {
+		return err
+	}
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, l := range s.losses[tenant] {
+		if l.HostID == loss.HostID && l.Class == loss.Class && l.Sequence == loss.Sequence && l.Disposition == loss.Disposition {
+			return nil // idempotent
+		}
+	}
+	s.losses[tenant] = append(s.losses[tenant], loss)
+	return nil
 }
 
 // Ingest appends the batch's events, idempotent on (host, class, seq, event index). The bucket is the
@@ -112,7 +134,15 @@ func (s *TelemetryStore) Query(ctx context.Context, q ports.HuntQuery) (ports.Hu
 		seqsByHostClass[k][r.seq] = struct{}{}
 	}
 	res.SequenceGaps = detectSeqGaps(seqsByHostClass)
-	res.Complete = !res.Sampled && len(res.SequenceGaps) == 0
+	// First-class losses intersecting the window (by host/asset/class/time, like the events). Any loss
+	// makes the window incomplete — including on an asset pivot, since losses carry an AssetID.
+	for _, l := range s.losses[tenant] {
+		if matchesLossQuery(l, q) {
+			res.Losses = append(res.Losses, l)
+		}
+	}
+	sort.Slice(res.Losses, func(i, j int) bool { return res.Losses[i].FromAt.Before(res.Losses[j].FromAt) })
+	res.Complete = !res.Sampled && len(res.SequenceGaps) == 0 && len(res.Losses) == 0
 	res.RowsScanned = len(res.Events) // rows matched/returned, consistent with the Postgres twin
 	sort.Slice(res.Events, func(i, j int) bool { return res.Events[i].At.Before(res.Events[j].At) })
 	if q.Limit > 0 && len(res.Events) > q.Limit {
@@ -184,6 +214,30 @@ func matchesQuery(r telemetryRow, q ports.HuntQuery) bool {
 		return false
 	}
 	if !q.Until.IsZero() && r.event.At.After(q.Until) {
+		return false
+	}
+	return true
+}
+
+// matchesLossQuery windows a loss record by the hunt's host/asset/class/time — the SAME dimensions the
+// events matcher uses, so an asset-pivot hunt surfaces losses (a truncated/dropped window is never
+// presented as complete on an asset pivot). Losses carry an AssetID for exactly this reason.
+func matchesLossQuery(l ports.TelemetryLoss, q ports.HuntQuery) bool {
+	if q.HostID != "" && l.HostID != q.HostID {
+		return false
+	}
+	if q.AssetID != "" && l.AssetID != q.AssetID {
+		return false
+	}
+	if q.Class != "" && l.Class != q.Class {
+		return false
+	}
+	// Overlap, not point containment: the loss surfaces if its dropped-event span [FromAt, ToAt] intersects
+	// the hunt window — so a window starting INSIDE the span still sees the loss.
+	if !q.Since.IsZero() && l.ToAt.Before(q.Since) {
+		return false
+	}
+	if !q.Until.IsZero() && l.FromAt.After(q.Until) {
 		return false
 	}
 	return true

--- a/internal/infrastructure/persistence/postgres/telemetry_losses_test.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_losses_test.go
@@ -1,0 +1,108 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestTelemetryLosses(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenant := shared.ID("tloss-" + id)
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tenant.String()); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM telemetry_losses WHERE tenant_id=$1`, tenant.String())
+		_, _ = pool.Exec(bg, `DELETE FROM telemetry_events WHERE tenant_id=$1`, tenant.String())
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id=$1`, tenant.String())
+	})
+
+	now := time.Now().UTC()
+	repo := NewTelemetryRepository(pool, time.Hour, 2*time.Hour)
+	tctx := shared.WithTenant(ctx, tenant)
+
+	// A stored full batch, plus a Truncated and a Dropped loss on the same host/class.
+	if err := repo.Ingest(tctx, ports.TelemetryBatch{TenantID: tenant, HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1",
+		Class: detection.ClassProcess, Sequence: 1, SampleRate: 1, Events: []detection.Event{telEvent("ps", now.Add(-5*time.Minute))}}); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	trunc := ports.TelemetryLoss{HostID: "host-1", AssetID: "asset-1", Class: detection.ClassProcess, Sequence: 2, Disposition: telemetry.Truncated,
+		ObservedCount: 10, KeptCount: 4, DroppedCount: 6, Reason: "ingest budget exceeded", FromAt: now.Add(-4 * time.Minute), ToAt: now.Add(-2 * time.Minute)}
+	if err := repo.RecordLoss(tctx, trunc); err != nil {
+		t.Fatalf("record truncation: %v", err)
+	}
+	// Idempotent on (host, class, seq, disposition).
+	if err := repo.RecordLoss(tctx, trunc); err != nil {
+		t.Fatalf("re-record truncation: %v", err)
+	}
+	if err := repo.RecordLoss(tctx, ports.TelemetryLoss{HostID: "host-1", AssetID: "asset-1", Class: detection.ClassProcess, Sequence: 3, Disposition: telemetry.Dropped,
+		ObservedCount: 5, KeptCount: 0, DroppedCount: 5, Reason: "over budget on a never-shed class", FromAt: now.Add(-3 * time.Minute), ToAt: now.Add(-1 * time.Minute)}); err != nil {
+		t.Fatalf("record drop: %v", err)
+	}
+	// An inconsistent loss is refused (counts do not add up).
+	if err := repo.RecordLoss(tctx, ports.TelemetryLoss{HostID: "host-1", AssetID: "asset-1", Class: detection.ClassProcess, Sequence: 4, Disposition: telemetry.Truncated,
+		ObservedCount: 10, KeptCount: 4, DroppedCount: 5, Reason: "bad", FromAt: now, ToAt: now}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("an inconsistent loss must be refused, got %v", err)
+	}
+
+	// The hunt surfaces both losses and reports the window incomplete (never complete despite a full batch).
+	res, err := repo.Query(tctx, ports.HuntQuery{HostID: "host-1", Class: detection.ClassProcess})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(res.Losses) != 2 {
+		t.Fatalf("both losses must surface (idempotent record kept one truncation), got %+v", res.Losses)
+	}
+	if res.Complete {
+		t.Error("a window with losses must never report complete")
+	}
+	// A different class in the same window has no losses.
+	if r2, _ := repo.Query(tctx, ports.HuntQuery{HostID: "host-1", Class: detection.ClassNetwork}); len(r2.Losses) != 0 {
+		t.Errorf("losses must be class-scoped, got %+v", r2.Losses)
+	}
+	// An asset-pivot hunt (only AssetID set) must ALSO surface the losses — otherwise a truncated/dropped
+	// window reads complete on that acceptance pattern (the D2 hole this closes).
+	ap, err := repo.Query(tctx, ports.HuntQuery{AssetID: "asset-1", Class: detection.ClassProcess})
+	if err != nil {
+		t.Fatalf("asset-pivot query: %v", err)
+	}
+	if len(ap.Losses) != 2 || ap.Complete {
+		t.Fatalf("an asset-pivot hunt must surface losses and never be complete, got losses=%+v complete=%v", ap.Losses, ap.Complete)
+	}
+	// Time-window OVERLAP: a hunt whose Since lands INSIDE the truncation span [now-4m, now-2m] must still
+	// surface it (a point anchor at the earliest dropped event would miss this) → never reads complete.
+	inside, err := repo.Query(tctx, ports.HuntQuery{HostID: "host-1", Class: detection.ClassProcess, Since: now.Add(-3 * time.Minute), Until: now})
+	if err != nil {
+		t.Fatalf("windowed query: %v", err)
+	}
+	if len(inside.Losses) == 0 || inside.Complete {
+		t.Fatalf("a hunt window overlapping a dropped span must surface the loss and not be complete, got losses=%+v complete=%v", inside.Losses, inside.Complete)
+	}
+	// A window entirely AFTER both spans (starts at now, spans end by now-1m) sees no loss.
+	if after, _ := repo.Query(tctx, ports.HuntQuery{HostID: "host-1", Class: detection.ClassProcess, Since: now.Add(time.Minute)}); len(after.Losses) != 0 {
+		t.Errorf("a window after all dropped spans must see no loss, got %+v", after.Losses)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/telemetry_repo.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_repo.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -70,6 +71,30 @@ func (r *TelemetryRepository) LastSequence(ctx context.Context, hostID shared.ID
 		return 0, err
 	}
 	return uint64(last), nil
+}
+
+// RecordLoss persists a Truncated/Dropped loss record for the ctx tenant, idempotent on
+// (host, class, seq, disposition) via the primary key, so a re-ingest records one loss.
+func (r *TelemetryRepository) RecordLoss(ctx context.Context, loss ports.TelemetryLoss) error {
+	if err := loss.Validate(); err != nil {
+		return err
+	}
+	if _, ok := shared.TenantFrom(ctx); !ok {
+		return fmt.Errorf("%w: telemetry loss requires a tenant in context", shared.ErrValidation)
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		tenant, _ := shared.TenantFrom(ctx)
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO telemetry_losses
+			  (tenant_id, host_id, asset_id, class, seq, disposition, observed_count, kept_count, dropped_count, reason, from_at, to_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+			ON CONFLICT (tenant_id, host_id, class, seq, disposition) DO NOTHING`,
+			tenant.String(), loss.HostID.String(), loss.AssetID.String(), string(loss.Class), int64(loss.Sequence), string(loss.Disposition),
+			loss.ObservedCount, loss.KeptCount, loss.DroppedCount, loss.Reason, loss.FromAt.UTC(), loss.ToAt.UTC()); err != nil {
+			return fmt.Errorf("insert telemetry loss: %w", err)
+		}
+		return nil
+	})
 }
 
 // defaultHuntCap bounds how many event rows a single hunt loads into memory when the caller sets no
@@ -149,14 +174,61 @@ func (r *TelemetryRepository) Query(ctx context.Context, q ports.HuntQuery) (por
 			}
 			seqsByHostClass[host+"\x00"+class] = append(seqsByHostClass[host+"\x00"+class], uint64(seq))
 		}
-		return seqRows.Err()
+		if err := seqRows.Err(); err != nil {
+			return err
+		}
+		// 3. First-class losses intersecting the window, windowed by the SAME host/asset/class/time
+		// dimensions as the events — so an asset-pivot hunt surfaces losses and a truncated/dropped window
+		// is never presented as complete on an asset pivot (losses carry an asset_id for this).
+		lossConds := []string{"TRUE"}
+		lossArgs := []any{}
+		laddc := func(cond string, val any) {
+			lossArgs = append(lossArgs, val)
+			lossConds = append(lossConds, fmt.Sprintf(cond, len(lossArgs)))
+		}
+		if q.HostID != "" {
+			laddc("host_id = $%d", q.HostID.String())
+		}
+		if q.AssetID != "" {
+			laddc("asset_id = $%d", q.AssetID.String())
+		}
+		if q.Class != "" {
+			laddc("class = $%d", string(q.Class))
+		}
+		// Overlap, not point containment: to_at >= since AND from_at <= until.
+		if !q.Since.IsZero() {
+			laddc("to_at >= $%d", q.Since.UTC())
+		}
+		if !q.Until.IsZero() {
+			laddc("from_at <= $%d", q.Until.UTC())
+		}
+		lossRows, err := tx.Query(ctx, `
+			SELECT host_id, asset_id, class, seq, disposition, observed_count, kept_count, dropped_count, reason, from_at, to_at
+			FROM telemetry_losses WHERE `+strings.Join(lossConds, " AND ")+` ORDER BY from_at ASC`, lossArgs...)
+		if err != nil {
+			return err
+		}
+		defer lossRows.Close()
+		for lossRows.Next() {
+			var (
+				l                        ports.TelemetryLoss
+				host, asset, class, disp string
+				seq                      int64
+			)
+			if err := lossRows.Scan(&host, &asset, &class, &seq, &disp, &l.ObservedCount, &l.KeptCount, &l.DroppedCount, &l.Reason, &l.FromAt, &l.ToAt); err != nil {
+				return err
+			}
+			l.HostID, l.AssetID, l.Class, l.Sequence, l.Disposition = shared.ID(host), shared.ID(asset), detection.Class(class), uint64(seq), telemetry.LossDisposition(disp)
+			res.Losses = append(res.Losses, l)
+		}
+		return lossRows.Err()
 	})
 	if err != nil {
 		return ports.HuntResult{}, fmt.Errorf("telemetry query: %w", err)
 	}
 	res.Sampled = res.MaxSampleRate > 1
 	res.SequenceGaps = telemetryGaps(seqsByHostClass)
-	res.Complete = !res.Sampled && len(res.SequenceGaps) == 0
+	res.Complete = !res.Sampled && len(res.SequenceGaps) == 0 && len(res.Losses) == 0
 	res.RowsScanned = len(res.Events)
 	return res, nil
 }

--- a/internal/usecase/fleet/telemetry/service.go
+++ b/internal/usecase/fleet/telemetry/service.go
@@ -11,9 +11,11 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetryschema"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -39,11 +41,15 @@ func NewService(store ports.TelemetryStore, audit ports.AuditLogger, clock ports
 }
 
 // IngestReport is the honest outcome of one ingest: how many events were accepted, how many were shed at
-// the store-rate stage, and any sequence gap (an upstream — agent/transport — loss made visible).
+// the store-rate stage, the loss disposition of the batch, and any sequence gap (an upstream —
+// agent/transport — loss made visible). Disposition names the store-stage outcome honestly (A0.6): a
+// truncation is Truncated, a refused never-shed overflow is Dropped, an agent-sampled batch is Sampled —
+// never a truncation relabelled as a sample (D2).
 type IngestReport struct {
-	Accepted int
-	Dropped  int // shed because the batch exceeded the ingest budget; reported, never silent
-	Gap      *ports.TelemetrySequenceGap
+	Accepted    int
+	Dropped     int // shed because the batch exceeded the ingest budget; reported, never silent
+	Disposition telemetry.LossDisposition
+	Gap         *ports.TelemetrySequenceGap
 }
 
 // Ingest admits one batch under the coherent ingest budget. Two stages can report a telemetry gap:
@@ -52,8 +58,8 @@ type IngestReport struct {
 //
 // Either gap is audited on the affected host. The accepted prefix is persisted with its sampling rate.
 func (s *Service) Ingest(ctx context.Context, batch ports.TelemetryBatch) (IngestReport, error) {
-	if batch.TenantID == "" || batch.HostID == "" || batch.AgentID == "" {
-		return IngestReport{}, fmt.Errorf("%w: telemetry batch needs tenant, host and agent", shared.ErrValidation)
+	if batch.TenantID == "" || batch.HostID == "" || batch.AgentID == "" || batch.AssetID == "" {
+		return IngestReport{}, fmt.Errorf("%w: telemetry batch needs tenant, host, agent and asset", shared.ErrValidation)
 	}
 	if !batch.Class.Valid() {
 		return IngestReport{}, fmt.Errorf("%w: telemetry batch has an unknown class %q", shared.ErrValidation, batch.Class)
@@ -92,25 +98,82 @@ func (s *Service) Ingest(ctx context.Context, batch ports.TelemetryBatch) (Inges
 	if batch.Sequence > last+1 {
 		gap := ports.TelemetrySequenceGap{HostID: batch.HostID, Class: batch.Class, Missing: batch.Sequence - last - 1, LastSeen: last, Incoming: batch.Sequence}
 		report.Gap = &gap
-		s.recordGap(ctx, "telemetry.sequence_gap", batch, map[string]string{
+		// HARD: a gap coverage event that cannot be audited fails the ingest rather than admitting an
+		// unrecorded gap (recordGap no longer swallows the audit-write error — the D2 companion bug).
+		if err := s.recordGap(ctx, "telemetry.sequence_gap", batch, map[string]string{
 			"last_sequence": fmt.Sprint(last), "incoming_sequence": fmt.Sprint(batch.Sequence), "missing": fmt.Sprint(gap.Missing),
-		})
+		}); err != nil {
+			return report, err
+		}
 	}
 
-	// Stage 2: store-rate budget. Overflow is shed from the tail and reported as a telemetry gap. The
-	// accepted prefix is stored with an ELEVATED sample rate so the truncation is durably visible: a
-	// retro-hunt over this window will see it as sampled and therefore NOT complete — the loss cannot
-	// masquerade as a full window.
+	// Stage 2: store-rate budget — HONEST loss accounting (A0.6, fixes D2). An over-budget batch is NEVER
+	// relabelled as an elevated sample rate. A never-shed class (privilege / sensitive-file) is not
+	// truncated at all: it is refused (back-pressured) and recorded as Dropped, so a security-critical
+	// signal is never silently cut. A sheddable class keeps its prefix but the drop is recorded as a
+	// first-class Truncated loss with a reason — so a hunt sees the window as incomplete from stored data,
+	// not from a lie in the sample rate.
 	accepted := batch
 	events := batch.Events
+	report.Disposition = telemetry.Complete
+	if batch.SampleRate > 1 {
+		report.Disposition = telemetry.Sampled // the agent already sampled; this rides SampleRate on the rows
+	}
+	// If a sampled batch also overflows, the branches below overwrite Disposition with Truncated/Dropped
+	// (the more actionable outcome). The single-valued report cannot express both; agent-side sampling
+	// stays independently visible via SampleRate on the stored rows (HuntResult.Sampled).
 	if len(events) > s.budget {
-		report.Dropped = len(events) - s.budget
-		accepted.SampleRate = maxInt(batch.SampleRate, ceilDiv(len(events), s.budget))
-		events = events[:s.budget]
-		s.recordGap(ctx, "telemetry.overflow", batch, map[string]string{
-			"budget": fmt.Sprint(s.budget), "received": fmt.Sprint(len(batch.Events)), "dropped": fmt.Sprint(report.Dropped),
-			"effective_sample_rate": fmt.Sprint(accepted.SampleRate),
-		})
+		observed, kept := len(events), s.budget
+		dropped := observed - kept
+
+		if telemetry.MustNotShed(batch.Class) {
+			// Never-shed: refuse the WHOLE batch (nothing stored) and record the loss as Dropped, so the
+			// agent re-sends within budget rather than a security-critical class being silently truncated.
+			// The whole batch is refused, so the honest drop count is `observed`, not just the tail.
+			report.Disposition = telemetry.Dropped
+			report.Accepted = 0
+			report.Dropped = observed
+			dropFrom, dropTo := s.lossSpan(batch.Events)
+			if err := s.store.RecordLoss(ctx, ports.TelemetryLoss{
+				HostID: batch.HostID, AssetID: batch.AssetID, Class: batch.Class, Sequence: batch.Sequence, Disposition: telemetry.Dropped,
+				ObservedCount: observed, KeptCount: 0, DroppedCount: observed, Reason: "over budget on a never-shed class",
+				FromAt: dropFrom, ToAt: dropTo,
+			}); err != nil {
+				return report, fmt.Errorf("record telemetry drop: %w", err)
+			}
+			// Audit the drop (the domain's most-severe disposition) — hard, like the overflow audit: a
+			// security-critical class being refused must leave an actor-attributed trail or the ingest fails.
+			if err := s.recordGap(ctx, "telemetry.drop", batch, map[string]string{
+				"budget": fmt.Sprint(s.budget), "received": fmt.Sprint(observed), "dropped": fmt.Sprint(observed),
+				"disposition": string(telemetry.Dropped),
+			}); err != nil {
+				return report, err
+			}
+			return report, fmt.Errorf("%w: telemetry batch for never-shed class %q exceeds the ingest budget (%d > %d); refused whole rather than truncating a security-critical class",
+				shared.ErrSaturated, batch.Class, observed, s.budget)
+		}
+
+		// Sheddable: keep the prefix, record the truncation as a first-class loss BEFORE storing — a
+		// truncated window whose loss could not be recorded must not be stored (fail closed). The loss is
+		// anchored to the DROPPED tail's earliest event time so a time-bounded hunt over it surfaces it.
+		droppedTail := batch.Events[kept:]
+		events = events[:kept]
+		report.Dropped = dropped
+		report.Disposition = telemetry.Truncated
+		dropFrom, dropTo := s.lossSpan(droppedTail)
+		if err := s.store.RecordLoss(ctx, ports.TelemetryLoss{
+			HostID: batch.HostID, AssetID: batch.AssetID, Class: batch.Class, Sequence: batch.Sequence, Disposition: telemetry.Truncated,
+			ObservedCount: observed, KeptCount: kept, DroppedCount: dropped, Reason: "ingest budget exceeded",
+			FromAt: dropFrom, ToAt: dropTo,
+		}); err != nil {
+			return report, fmt.Errorf("record telemetry truncation: %w", err)
+		}
+		if err := s.recordGap(ctx, "telemetry.overflow", batch, map[string]string{
+			"budget": fmt.Sprint(s.budget), "received": fmt.Sprint(observed), "dropped": fmt.Sprint(dropped),
+			"disposition": string(telemetry.Truncated),
+		}); err != nil {
+			return report, err
+		}
 	}
 	report.Accepted = len(events)
 
@@ -119,20 +182,6 @@ func (s *Service) Ingest(ctx context.Context, batch ports.TelemetryBatch) (Inges
 		return report, fmt.Errorf("telemetry ingest: %w", err)
 	}
 	return report, nil
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func ceilDiv(a, b int) int {
-	if b <= 0 {
-		return a
-	}
-	return (a + b - 1) / b
 }
 
 // Hunt runs a retro-hunt query and returns its result WITH the completeness metadata (sampled / gaps),
@@ -204,10 +253,41 @@ func (s *Service) Footprint(ctx context.Context) (ports.TelemetryFootprint, erro
 	return fp, nil
 }
 
-func (s *Service) recordGap(ctx context.Context, action string, batch ports.TelemetryBatch, meta map[string]string) {
+// lossSpan computes the observed-time SPAN [from, to] of the dropped events, so the loss is windowed by
+// OVERLAP (a hunt overlapping any part of the span surfaces it, not just one whose window starts at the
+// earliest dropped event). Events with no time are ignored; if none carry a time, both bounds fall back to
+// the clock so the loss still anchors somewhere real rather than the zero time.
+func (s *Service) lossSpan(events []detection.Event) (from, to time.Time) {
+	for _, e := range events {
+		if e.At.IsZero() {
+			continue
+		}
+		at := e.At.UTC()
+		if from.IsZero() || at.Before(from) {
+			from = at
+		}
+		if to.IsZero() || at.After(to) {
+			to = at
+		}
+	}
+	if from.IsZero() {
+		now := s.clock.Now().UTC()
+		return now, now
+	}
+	return from, to
+}
+
+// recordGap audits a telemetry coverage event. It NO LONGER swallows the audit-write error (the D2
+// companion bug): a coverage/loss event that cannot be durably recorded fails the ingest, so a gap is
+// never admitted without a trail. The first-class loss record (RecordLoss) is the queryable object; this
+// audit line is the human-facing trail alongside it.
+func (s *Service) recordGap(ctx context.Context, action string, batch ports.TelemetryBatch, meta map[string]string) error {
 	meta["host"] = batch.HostID.String()
 	meta["class"] = string(batch.Class)
-	_ = s.audit.Record(ctx, ports.AuditEntry{
+	if err := s.audit.Record(ctx, ports.AuditEntry{
 		Actor: batch.AgentID.String(), Action: action, Target: batch.HostID.String(), At: s.clock.Now().UTC(), Metadata: meta,
-	})
+	}); err != nil {
+		return fmt.Errorf("%w: telemetry %s coverage event could not be audited", shared.ErrSaturated, action)
+	}
+	return nil
 }

--- a/internal/usecase/fleet/telemetry/service_test.go
+++ b/internal/usecase/fleet/telemetry/service_test.go
@@ -9,19 +9,24 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetryschema"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 type fakeAudit struct {
-	mu      sync.Mutex
-	actions []string
+	mu         sync.Mutex
+	actions    []string
+	failAction string // if set, Record returns an error for this action (and does not record it)
 }
 
 func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.failAction != "" && e.Action == a.failAction {
+		return errors.New("audit sink unavailable")
+	}
 	a.actions = append(a.actions, e.Action)
 	return nil
 }
@@ -63,18 +68,85 @@ func batch(seq uint64, sampleRate int, evs ...detection.Event) ports.TelemetryBa
 		SchemaVersion: telemetryschema.Current, Class: detection.ClassProcess, Sequence: seq, SampleRate: sampleRate, Events: evs}
 }
 
-func TestIngestBudgetOverflowReportsGap(t *testing.T) {
+func TestIngestBudgetOverflowIsTruncatedNotSampled(t *testing.T) {
+	// D2: a sheddable-class overflow keeps the prefix but is recorded as a first-class Truncated loss —
+	// NOT relabelled as an elevated sample rate. A hunt sees the window incomplete via the loss, while the
+	// stored sample rate stays truthful (1 = full fidelity for the events that WERE kept).
 	svc, _, audit := newSvc(t, 2, 7*24*time.Hour, 30*24*time.Hour)
-	b := batch(1, 1, procEventAt("ps", time.Unix(1_000_000, 0)), procEventAt("top", time.Unix(1_000_000, 0)), procEventAt("ls", time.Unix(1_000_000, 0)))
+	at := time.Unix(1_000_000, 0)
+	b := batch(1, 1, procEventAt("ps", at), procEventAt("top", at), procEventAt("ls", at))
 	rep, err := svc.Ingest(tctx(), b)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if rep.Accepted != 2 || rep.Dropped != 1 {
-		t.Fatalf("overflow must shed the excess and report it, got %+v", rep)
+		t.Fatalf("overflow must keep the budget prefix and report the drop, got %+v", rep)
+	}
+	if rep.Disposition != telemetry.Truncated {
+		t.Fatalf("overflow of a sheddable class must be Truncated, got %q", rep.Disposition)
 	}
 	if !audit.has("telemetry.overflow") {
-		t.Error("store-rate overflow must be reported as a telemetry gap, never silent")
+		t.Error("store-rate overflow must be reported, never silent")
+	}
+	res, _ := svc.Hunt(tctx(), ports.HuntQuery{HostID: "host-1", Class: detection.ClassProcess})
+	// The D2 fix: the truncation surfaces as a first-class loss, NOT as a fake elevated sample rate.
+	if res.Sampled || res.MaxSampleRate != 1 {
+		t.Errorf("truncation must NOT masquerade as sampling, got sampled=%v rate=%d", res.Sampled, res.MaxSampleRate)
+	}
+	if res.Complete {
+		t.Error("a truncated window must never be presented as complete")
+	}
+	if len(res.Losses) != 1 || res.Losses[0].Disposition != telemetry.Truncated || res.Losses[0].DroppedCount != 1 {
+		t.Fatalf("the hunt must expose the truncation as a first-class loss, got %+v", res.Losses)
+	}
+}
+
+func TestIngestNeverShedClassRefusesOverflow(t *testing.T) {
+	// A never-shed class (privilege) that exceeds the budget is refused WHOLE (back-pressure) and recorded
+	// as Dropped — never truncated into a lossy prefix that hides a security-critical event.
+	svc, _, audit := newSvc(t, 2, 7*24*time.Hour, 30*24*time.Hour)
+	at := time.Unix(1_000_000, 0)
+	priv := func(comm string) detection.Event {
+		return detection.Event{Class: detection.ClassPrivilege, At: at, Host: "host-1",
+			Process: &detection.ProcessEvent{PID: 1, Comm: comm, Path: "/usr/bin/" + comm}}
+	}
+	b := ports.TelemetryBatch{TenantID: "t1", HostID: "host-1", AssetID: "asset-1", AgentID: "agent:1",
+		SchemaVersion: telemetryschema.Current, Class: detection.ClassPrivilege, Sequence: 1, SampleRate: 1,
+		Events: []detection.Event{priv("su"), priv("sudo"), priv("setuid")}}
+	rep, err := svc.Ingest(tctx(), b)
+	if !errors.Is(err, shared.ErrSaturated) {
+		t.Fatalf("a never-shed overflow must be refused with ErrSaturated, got %v", err)
+	}
+	if rep.Disposition != telemetry.Dropped || rep.Accepted != 0 || rep.Dropped != 3 {
+		t.Fatalf("a refused never-shed batch must be Dropped with 0 accepted and the WHOLE batch dropped, got %+v", rep)
+	}
+	if !audit.has("telemetry.drop") {
+		t.Error("a refused never-shed drop (the most severe loss) must be audited")
+	}
+	// Nothing was stored (refused whole), but the loss is queryable so the drop is never silent.
+	res, _ := svc.Hunt(tctx(), ports.HuntQuery{HostID: "host-1", Class: detection.ClassPrivilege})
+	if len(res.Events) != 0 {
+		t.Errorf("no event of a refused never-shed batch may be stored, got %d", len(res.Events))
+	}
+	if len(res.Losses) != 1 || res.Losses[0].Disposition != telemetry.Dropped {
+		t.Fatalf("the drop must be a queryable first-class loss, got %+v", res.Losses)
+	}
+	// The loss must ALSO surface on an asset-pivot hunt (HuntAssetPivot) — otherwise a dropped window
+	// reads complete on exactly that acceptance pattern.
+	if ap, _ := svc.Hunt(tctx(), ports.HuntQuery{AssetID: "asset-1", Class: detection.ClassPrivilege}); len(ap.Losses) != 1 || ap.Complete {
+		t.Fatalf("an asset-pivot hunt must surface the drop and never be complete, got losses=%+v complete=%v", ap.Losses, ap.Complete)
+	}
+}
+
+func TestIngestFailsWhenGapAuditFails(t *testing.T) {
+	// The recordGap audit is a HARD requirement now (D2 companion bug): if the overflow coverage event
+	// cannot be audited, the whole ingest fails rather than admitting an unrecorded loss.
+	svc, _, audit := newSvc(t, 2, 7*24*time.Hour, 30*24*time.Hour)
+	audit.failAction = "telemetry.overflow"
+	at := time.Unix(1_000_000, 0)
+	b := batch(1, 1, procEventAt("ps", at), procEventAt("top", at), procEventAt("ls", at))
+	if _, err := svc.Ingest(tctx(), b); !errors.Is(err, shared.ErrSaturated) {
+		t.Fatalf("an unauditable overflow must fail the ingest, got %v", err)
 	}
 }
 

--- a/internal/usecase/ports/telemetry.go
+++ b/internal/usecase/ports/telemetry.go
@@ -2,10 +2,12 @@ package ports
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
 )
 
 // TelemetryStore is the DEDICATED persistence port for the columnar telemetry tier (#424, ADR 0001). It
@@ -31,6 +33,62 @@ type TelemetryStore interface {
 	// LastSequence returns the highest batch sequence stored for a (host, class), 0 if none — so the
 	// telemetry usecase can detect a sequence gap and surface a lossy window.
 	LastSequence(ctx context.Context, hostID shared.ID, class detection.Class) (uint64, error)
+	// RecordLoss persists a first-class loss record (a Truncated or Dropped batch), so a hunt over the
+	// window learns the window is incomplete from stored data — not from a best-effort audit line, and
+	// never by a truncation masquerading as an elevated sample rate (D2). Idempotent on
+	// (host, class, sequence, disposition): a re-ingest of the same over-budget batch records one loss.
+	RecordLoss(ctx context.Context, loss TelemetryLoss) error
+}
+
+// TelemetryLoss is a first-class, persisted record that a batch was cut (Truncated) or observed-then-lost
+// (Dropped) at the store-rate stage. Agent-side SAMPLING is not a TelemetryLoss — it rides SampleRate on
+// the stored rows (surfaced as HuntResult.Sampled); this type captures the losses D2 used to hide.
+type TelemetryLoss struct {
+	HostID        shared.ID
+	AssetID       shared.ID // the asset the batch was observed on, so an asset-pivot hunt windows the loss
+	Class         detection.Class
+	Sequence      uint64
+	Disposition   telemetry.LossDisposition // Truncated or Dropped
+	ObservedCount int
+	KeptCount     int
+	DroppedCount  int
+	Reason        string
+	// FromAt..ToAt is the observed-time SPAN of the dropped events (not ingest wall-clock), so a
+	// time-bounded hunt that overlaps ANY part of the dropped span surfaces the loss — a point anchor
+	// would miss a hunt whose window starts inside the span. Windowing is by overlap: ToAt >= Since AND
+	// FromAt <= Until.
+	FromAt time.Time
+	ToAt   time.Time
+}
+
+// Validate checks a loss record is well-formed and honest: a real (host, class, sequence), a lossy
+// disposition that actually reports a drop, counts that add up, and a reason.
+func (l TelemetryLoss) Validate() error {
+	if l.HostID == "" {
+		return fmt.Errorf("%w: telemetry loss has no host", shared.ErrValidation)
+	}
+	if l.AssetID == "" {
+		return fmt.Errorf("%w: telemetry loss has no asset", shared.ErrValidation)
+	}
+	if !l.Class.Valid() {
+		return fmt.Errorf("%w: telemetry loss has an unknown class %q", shared.ErrValidation, l.Class)
+	}
+	if l.Sequence == 0 {
+		return fmt.Errorf("%w: telemetry loss sequence must be >= 1", shared.ErrValidation)
+	}
+	if l.Disposition != telemetry.Truncated && l.Disposition != telemetry.Dropped {
+		return fmt.Errorf("%w: telemetry loss disposition must be truncated or dropped, got %q", shared.ErrValidation, l.Disposition)
+	}
+	if err := telemetry.ValidateLossCounts(l.Disposition, l.ObservedCount, l.KeptCount, l.DroppedCount); err != nil {
+		return err
+	}
+	if l.Reason == "" {
+		return fmt.Errorf("%w: telemetry loss must carry a reason", shared.ErrValidation)
+	}
+	if l.FromAt.IsZero() || l.ToAt.IsZero() || l.ToAt.Before(l.FromAt) {
+		return fmt.Errorf("%w: telemetry loss must carry a valid observed-time span (from <= to)", shared.ErrValidation)
+	}
+	return nil
 }
 
 // TelemetryBatch is one sequenced, sampled batch of raw events from an agent for a single event class.
@@ -84,6 +142,9 @@ type HuntResult struct {
 	MaxSampleRate int // the worst (largest) sample rate in the window; 1 = fully sampled
 	Complete      bool
 	SequenceGaps  []TelemetrySequenceGap
+	// Losses are the first-class Truncated/Dropped records intersecting the window (A0.6). A window with
+	// any loss is never Complete, so a truncated/dropped batch can never be presented as the whole truth.
+	Losses []TelemetryLoss
 }
 
 // TelemetrySequenceGap is a missing run of batch sequences for a (host, class), making a window lossy.

--- a/migrations/0106_telemetry_losses.sql
+++ b/migrations/0106_telemetry_losses.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+-- First-class telemetry loss records (#611, A0.6 — fixes D2). When the store-rate stage cuts a batch, the
+-- loss is persisted HERE as its own row — Truncated (a prefix kept, tail dropped) or Dropped (observed
+-- then lost) — instead of being smuggled into an elevated sample_rate on telemetry_events. A retro-hunt
+-- reads the loss records intersecting its window and reports the window as incomplete, so a truncation can
+-- never masquerade as a complete window (the D2 bug). Agent-side SAMPLING is not recorded here — it stays
+-- on telemetry_events.sample_rate.
+--
+-- Like telemetry_events these rows are mutable/expirable (retention), NOT hash-chained: they are honesty
+-- metadata for the lossy tier, never evidence. Idempotent on (tenant, host, class, seq, disposition) so a
+-- re-ingest of the same over-budget batch records one loss.
+CREATE TABLE telemetry_losses (
+    tenant_id      TEXT NOT NULL REFERENCES tenants(id),
+    host_id        TEXT NOT NULL,
+    asset_id       TEXT NOT NULL,   -- so an asset-pivot hunt windows the loss like it windows events
+    class          TEXT NOT NULL,
+    seq            BIGINT NOT NULL,
+    disposition    TEXT NOT NULL CHECK (disposition IN ('truncated', 'dropped')),
+    observed_count INT NOT NULL,
+    kept_count     INT NOT NULL,
+    dropped_count  INT NOT NULL,
+    reason         TEXT NOT NULL,
+    -- The observed-time SPAN of the dropped events. A hunt overlapping any part of the span surfaces the
+    -- loss (window by overlap: to_at >= since AND from_at <= until) — a single point would miss a hunt
+    -- whose window starts inside the span.
+    from_at        TIMESTAMPTZ NOT NULL,
+    to_at          TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, host_id, class, seq, disposition),
+    CONSTRAINT telemetry_losses_counts_check CHECK (kept_count + dropped_count = observed_count AND dropped_count > 0),
+    CONSTRAINT telemetry_losses_span_check CHECK (from_at <= to_at)
+);
+
+-- Hunts window losses by the span (BRIN on from_at, append-mostly) and pivot host/class or asset.
+CREATE INDEX idx_telemetry_losses_from  ON telemetry_losses USING BRIN (from_at);
+CREATE INDEX idx_telemetry_losses_host  ON telemetry_losses (tenant_id, host_id, class, from_at);
+CREATE INDEX idx_telemetry_losses_asset ON telemetry_losses (tenant_id, asset_id, from_at);
+
+CALL synapse_enable_tenant_rls('telemetry_losses');
+
+-- +goose Down
+DROP TABLE telemetry_losses;


### PR DESCRIPTION
## What & why

Phase A0.6 of the security-data-plane → EDR epic (#594). Fixes defect **D2**: on a store-rate overflow the telemetry tier kept the batch **prefix** and recorded it as an elevated `SampleRate` —

```
accepted.SampleRate = maxInt(batch.SampleRate, ceilDiv(len(events), s.budget))
events = events[:s.budget]   // tail truncation, relabelled as a sample
```

Keeping the prefix drops the tail — where a late malicious sequence lives — and calls it a sample, so a hunt could not tell a representative sample from a blind truncation. `recordGap` also swallowed its audit-write error, so a coverage event could vanish silently.

## Changes — Sampled ≠ Truncated ≠ Dropped

- **`domain/telemetry`**: `LossDisposition` (Complete / Sampled / Truncated / Dropped) + `Lossy()`, `MustNotShed(class)` (the never-shed classes on the raw tier — privilege transitions and sensitive-file activity), and `ValidateLossCounts` (kept + dropped == observed).
- **First-class persisted loss** (`ports.TelemetryLoss` + migration **0106** `telemetry_losses`): carries the honest counts, the `AssetID`, and the dropped-event observed-time **span** `FromAt..ToAt`. Threaded through **both** store twins and surfaced in `HuntResult.Losses`; a window with any loss is never `Complete`. Losses are windowed by the SAME host / asset / class / time-overlap dimensions as events — so a **host, asset-pivot, or all-scoped** hunt all surface the loss (closing a review-found blind spot where an asset-pivot hunt read a truncated window as complete). Overlap windowing (`to_at >= since AND from_at <= until`) means a hunt whose window starts *inside* a dropped span still sees the loss.
- **`telemetry.Service.Ingest`**:
  - sheddable-class overflow → keep the prefix, record a **Truncated** loss over the dropped-tail span; the stored `SampleRate` stays truthful (no fake elevation).
  - **never-shed** class over budget → **refused whole** (`ErrSaturated`, nothing stored) and recorded as **Dropped**, so a security-critical class is never silently cut — the agent re-sends within budget.
  - `recordGap` propagates its audit error; the sequence-gap, overflow, and the new never-shed **drop** audits are all hard coverage requirements (an unauditable loss fails the ingest).
  - `IngestReport.Disposition` reports the honest outcome; `AssetID` is now required at ingest.

## Tests

Domain vocabulary + count invariant; the D2 regression (overflow is Truncated, **not** an elevated SampleRate, and the hunt sees the window incomplete via a first-class loss); never-shed refuse-whole (ErrSaturated, nothing stored, Dropped loss, drop audited, `report.Dropped == observed`); the hard-audit requirement; and the loss surfacing on **host, asset-pivot, and time-overlap** hunts (memory via the service, Postgres `TestTelemetryLosses`). Full serialized suite green (248 packages, pristine DB); migration 0106 applies clean. go-arch + security reviews both clean (two rounds; the asset-pivot HIGH and the point-anchor MEDIUM found in review are fixed by the AssetID + `FromAt/ToAt` span).

## Scope / follow-up

This PR is the **loss-semantics half** of #611. The **source-side privacy** half — field classification (allow / redact / hash / drop), no environment variables collected by default, bounded argv/path length, secret-pattern redaction at the source, and ensuring batch commitments retain no PII after telemetry deletion — is the remaining scope and is **not** in this PR.

**#611 stays open** after this merge — it tracks the privacy half.

Part of #594.
