### PR TITLE
feat: add Prometheus metrics and access logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,16 @@ SYNAPSE_HTTP_ADDR=:8080
 SYNAPSE_ENV=development
 SYNAPSE_LOG_LEVEL=info
 SYNAPSE_SINGLE_TENANT=true
+# Prometheus /metrics on a SEPARATE, uninstrumented, non-bearer-protected listener.
+# Off by default; when enabled the listener stays loopback-only unless you widen it –
+# do not expose it beyond a private scrape network. See docs/guide/configuration.md
+# for the metric names and the label/privacy policy.
+SYNAPSE_METRICS_ENABLED=false
+SYNAPSE_METRICS_ADDR=127.0.0.1:9090
+# One structured "http access" log event per request (method, matched route, status,
+# latency, request id, and the resolved principal id when authenticated). Never logs
+# raw paths, queries, headers, bodies, or secrets. On by default.
+SYNAPSE_ACCESS_LOG_ENABLED=true
 # Acceptable-Use Policy version operators must accept on first run.
 SYNAPSE_AUP_VERSION=1.0
 # File-backed paths used only in in-memory mode (no SYNAPSE_DB_DSN).

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -13,6 +13,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -194,6 +195,29 @@ func requireJudgmentsOrSkip(log *slog.Logger, hasJudgment bool, envKey, name str
 	}
 	log.Warn(name + " auto-skipped: SYNAPSE_JUDGMENTS_ENABLED is off (it mints judgments)")
 	return false
+}
+
+// metricsAddrIsLoopback reports whether addr binds only to a loopback interface. The
+// metrics listener is intentionally unauthenticated, so a non-loopback bind exposes
+// aggregate operational metrics to anything that can reach it; callers use this to
+// decide whether to warn. It fails loud (returns false, i.e. "warn") on anything it
+// cannot confidently classify as loopback-only.
+func metricsAddrIsLoopback(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "" {
+		return false // empty host binds all interfaces
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
 }
 
 func migrationDSNForStartup(cfg config.Config) (string, error) {
@@ -1177,6 +1201,9 @@ func main() {
 		metrics = observability.New(queueReader)
 		httpObserver = metrics
 		scaService.SetObserver(metrics)
+		if !metricsAddrIsLoopback(cfg.MetricsAddr) {
+			log.Warn("metrics listener is bound to a non-loopback address; it is unauthenticated and exposes aggregate operational metrics to anything that can reach it", "addr", cfg.MetricsAddr)
+		}
 	}
 	router.SetObservability(cfg.AccessLogEnabled, httpObserver)
 	vulnerabilityRollout, err := vulnerabilityrollout.New(vulnerabilityrollout.Config{

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -13,6 +13,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/adapter/httpapi"
+	"github.com/KKloudTarus/synapse-ce/internal/adapter/observability"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	ap "github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/cloudposture"
@@ -1162,6 +1164,21 @@ func main() {
 	if slaService != nil {
 		router.SetSLA(slaService)
 	}
+	// Metrics stay off by default and, when enabled, are exposed only on the separate
+	// loopback-by-default listener (never bearer-protected, never instrumented itself).
+	var metrics *observability.Collectors
+	var httpObserver httpapi.HTTPObserver // kept as a nil INTERFACE unless metrics is built
+	if cfg.MetricsEnabled {
+		queueReader, ok := vulnerabilityQueue.(ports.AggregateJobQueueStatsReader)
+		if !ok {
+			log.Error("metrics enabled but the configured job queue does not support aggregate stats")
+			os.Exit(1)
+		}
+		metrics = observability.New(queueReader)
+		httpObserver = metrics
+		scaService.SetObserver(metrics)
+	}
+	router.SetObservability(cfg.AccessLogEnabled, httpObserver)
 	vulnerabilityRollout, err := vulnerabilityrollout.New(vulnerabilityrollout.Config{
 		ProviderSync: cfg.VulnerabilityProviderSyncEnabled, OccurrenceWrites: cfg.VulnerabilityOccurrenceWritesEnabled,
 		FindingProjection: cfg.VulnerabilityFindingProjectionEnabled, Actions: cfg.VulnerabilityActionsEnabled,
@@ -2128,7 +2145,11 @@ func main() {
 		)
 	}
 
-	if err := httpserver.Run(ctx, cfg.HTTPAddr, router.Handler(), log); err != nil {
+	var metricsHandler http.Handler
+	if metrics != nil {
+		metricsHandler = metrics.Handler()
+	}
+	if err := httpserver.RunPair(ctx, cfg.HTTPAddr, router.Handler(), cfg.MetricsAddr, metricsHandler, log); err != nil {
 		log.Error("server error", "err", err)
 		os.Exit(1)
 	}

--- a/cmd/synapse-api/main_test.go
+++ b/cmd/synapse-api/main_test.go
@@ -49,3 +49,26 @@ func TestMigrationDSNForStartup(t *testing.T) {
 		})
 	}
 }
+
+func TestMetricsAddrIsLoopback(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		{name: "ipv4 loopback", addr: "127.0.0.1:9090", want: true},
+		{name: "ipv6 loopback", addr: "[::1]:9090", want: true},
+		{name: "localhost hostname", addr: "localhost:9090", want: true},
+		{name: "empty host binds all interfaces", addr: ":9090", want: false},
+		{name: "explicit all interfaces", addr: "0.0.0.0:9090", want: false},
+		{name: "routable ip", addr: "10.0.0.5:9090", want: false},
+		{name: "malformed address", addr: "not-a-valid-addr", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := metricsAddrIsLoopback(tt.addr); got != tt.want {
+				t.Fatalf("metricsAddrIsLoopback(%q) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/docs_publication_test.go
+++ b/docs/docs_publication_test.go
@@ -169,7 +169,7 @@ func TestPublishedMirrorsMatchCanonicalSources(t *testing.T) {
 
 		notice := "> Canonical source: [`" + canonical + "`](https://github.com/KKloudTarus/synapse-ce/blob/main/" + canonical + "). Do not edit this published mirror directly.\n\n"
 		want := notice + string(canonicalBody)
-		if string(mirrorBody) != want {
+		if strings.ReplaceAll(string(mirrorBody), "\r\n", "\n") != strings.ReplaceAll(want, "\r\n", "\n") {
 			t.Errorf("%s has drifted from %s; regenerate the mirror as its canonical-source notice plus the complete canonical file", mirror, canonical)
 		}
 	}

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -46,6 +46,7 @@ Metric names and label cardinality:
 | `synapse_job_queue_queued` | gauge | none | Aggregate queued durable jobs, across every tenant. Present only when the configured job queue supports aggregate stats (Postgres and in-memory both do). |
 | `synapse_job_queue_in_flight` | gauge | none | Aggregate claimed/in-flight durable jobs, across every tenant. |
 | `synapse_job_queue_oldest_active_age_seconds` | gauge | none | Age of the oldest still-queued-or-claimed job (`ports.JobStats.OldestActiveAt`), `0` when the queue is empty. |
+| `synapse_job_queue_scrape_errors_total` | counter | none | Failed attempts to read aggregate durable job queue stats for a scrape. The three `synapse_job_queue_*` gauges above are omitted from that scrape (never a stale or bogus value) when this increments. |
 | `synapse_sca_scan_duration_seconds` | histogram | `outcome` | Completed synchronous or asynchronous SCA execution duration. For an async scan, measured from worker execution start, not from `StartScan`/enqueue time. Queue failures, dead letters, stale sweeps, and blocked gates do not record a duration. |
 | `synapse_sca_scan_outcomes_total` | counter | `outcome` | Terminal SCA outcomes: `success`, `failed`, or `blocked`. Queue failures, dead letters, and stale sweeps count as `failed` without a duration. `blocked` is recorded only for an execution-gate denial reached after a genuine scan attempt — never for a pre-gate validation failure. |
 
@@ -60,7 +61,7 @@ scrape_configs:
       - targets: ["127.0.0.1:9090"]
 ```
 
-The metrics listener has no authentication of its own. Keep `SYNAPSE_METRICS_ADDR` on loopback or a private network reachable only by your scrape infrastructure; do not put it behind the same reverse-proxy path as the bearer-protected API, and do not widen it to a public interface.
+The metrics listener has no authentication of its own. Keep `SYNAPSE_METRICS_ADDR` on loopback or a private network reachable only by your scrape infrastructure; do not put it behind the same reverse-proxy path as the bearer-protected API, and do not widen it to a public interface. Startup logs a WARN if `SYNAPSE_METRICS_ENABLED` is set and `SYNAPSE_METRICS_ADDR` does not resolve to a loopback address.
 
 ## Persistence
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -29,6 +29,39 @@ Conventions: an empty value means unset, so the built-in default applies. Boolea
 | `SYNAPSE_AUDIT_FILE` | `data/audit.jsonl` | File-backed path, in-memory mode only. |
 | `SYNAPSE_MEASURE_CURSOR_SECRET` | Ephemeral in development; required in production | HMAC key for signing Measures pagination cursors; minimum 32 bytes |
 
+## Observability
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SYNAPSE_METRICS_ENABLED` | `false` | Expose Prometheus metrics on a SEPARATE listener (`SYNAPSE_METRICS_ADDR`). Off by default; the listener is never bearer-protected and is never itself instrumented. |
+| `SYNAPSE_METRICS_ADDR` | `127.0.0.1:9090` | Metrics listener address. Loopback-only by default; widen it only onto a private scrape network, never a public interface. |
+| `SYNAPSE_ACCESS_LOG_ENABLED` | `true` | Emit one structured `http access` log event per request (method, matched route, status, latency, request id, and — once authenticated — the resolved principal id). Never logs raw paths, query strings, headers, bodies, tenant ids, remote addresses, user agents, or secrets. |
+
+Metric names and label cardinality:
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `synapse_http_requests_total` | counter | `method`, `route`, `status_class` | Total HTTP requests. `route` is the matched `net/http` `ServeMux` pattern (e.g. `GET /api/v1/engagements/{id}`), never the raw path — path *values* collapse into one bounded label. An unmatched request reports `route="unmatched"`. `status_class` is `2xx`/`3xx`/`4xx`/`5xx`. |
+| `synapse_http_request_duration_seconds` | histogram | `method`, `route`, `status_class` | Request handling latency. |
+| `synapse_job_queue_queued` | gauge | none | Aggregate queued durable jobs, across every tenant. Present only when the configured job queue supports aggregate stats (Postgres and in-memory both do). |
+| `synapse_job_queue_in_flight` | gauge | none | Aggregate claimed/in-flight durable jobs, across every tenant. |
+| `synapse_job_queue_oldest_active_age_seconds` | gauge | none | Age of the oldest still-queued-or-claimed job (`ports.JobStats.OldestActiveAt`), `0` when the queue is empty. |
+| `synapse_sca_scan_duration_seconds` | histogram | `outcome` | Completed synchronous or asynchronous SCA execution duration. For an async scan, measured from worker execution start, not from `StartScan`/enqueue time. Queue failures, dead letters, stale sweeps, and blocked gates do not record a duration. |
+| `synapse_sca_scan_outcomes_total` | counter | `outcome` | Terminal SCA outcomes: `success`, `failed`, or `blocked`. Queue failures, dead letters, and stale sweeps count as `failed` without a duration. `blocked` is recorded only for an execution-gate denial reached after a genuine scan attempt — never for a pre-gate validation failure. |
+
+No metric or access-log field ever carries a tenant id, engagement id, target, raw path, or free-form error text — the label sets above are exhaustive and deliberately bounded (unlike, for example, embedding a full URL path) to avoid unbounded label cardinality on the collector.
+
+Example Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: synapse-api
+    static_configs:
+      - targets: ["127.0.0.1:9090"]
+```
+
+The metrics listener has no authentication of its own. Keep `SYNAPSE_METRICS_ADDR` on loopback or a private network reachable only by your scrape infrastructure; do not put it behind the same reverse-proxy path as the bearer-protected API, and do not widen it to a public interface.
+
 ## Persistence
 
 | Variable | Default | Description |

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -109,6 +109,22 @@ Recommended hardening:
 
 `GET /healthz` and `GET /readyz` are unauthenticated by design. Every other API route requires the bearer token.
 
+## Metrics and access logging
+
+`SYNAPSE_METRICS_ENABLED` (default `false`) exposes Prometheus metrics — HTTP RED
+(rate/errors/duration), aggregate durable-job queue depth, and SCA scan outcomes — on a
+SEPARATE listener bound by `SYNAPSE_METRICS_ADDR` (default `127.0.0.1:9090`). That
+listener is intentionally uninstrumented and never bearer-protected: keep it loopback-only
+or on a private scrape network, and never put it behind the same public path as the API.
+See [Configuration](configuration.md#observability) for metric names and the label/privacy
+policy.
+
+`SYNAPSE_ACCESS_LOG_ENABLED` (default `true`) emits one structured `http access` log event
+per request with only bounded, non-sensitive fields (method, matched route, status,
+latency, request id, and — once authenticated — the resolved principal id). It never logs
+raw paths, query strings, headers, bodies, tenant ids, remote addresses, user agents, or
+secrets.
+
 ## Liveness and readiness probes
 
 `GET /healthz` is a constant liveness probe: `200` means the process and HTTP listener are alive. It

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/minio/minio-go/v7 v7.2.1
 	github.com/phpdave11/gofpdf v1.4.3
 	github.com/pressly/goose/v3 v3.27.3
+	github.com/prometheus/client_golang v1.23.2
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/ulikunitz/xz v0.5.16
 	golang.org/x/net v0.58.0
@@ -59,6 +60,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.5.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.6 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/boombuler/barcode v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
@@ -108,6 +110,9 @@ require (
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.66.1 // indirect
+	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/rs/xid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.45.6 h1:JvExZWabChDM0qJAirQYGfOYo0nd
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.6/go.mod h1:XZcaQkV2cItp6yEkrwljyaPOf22RuX7T43jxap/FOmM=
 github.com/aws/smithy-go v1.27.8 h1:FR0dxZfIlV7Z8eh2iHfIofdunw382XsDV3Mxt9nUvRY=
 github.com/aws/smithy-go v1.27.8/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.1.0 h1:ChaYjBR63fr4LFyGn8E8nt7dBSt3MiU3zMOZqFvVkHo=
 github.com/boombuler/barcode v1.1.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -230,6 +232,14 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pressly/goose/v3 v3.27.3 h1:pIglVHjw99r4e/hDHHwbl9vfOsDMqUokfkXo6+n/RxA=
 github.com/pressly/goose/v3 v3.27.3/go.mod h1:Dag+xpV6o20HR2LFY1j0q6MDwc3f7vPUFDA77R+0yGY=
+github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
+github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
+github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
+github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
+github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9ZoGs=
+github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
+github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
+github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
@@ -284,6 +294,8 @@ go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRk
 go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=

--- a/internal/adapter/httpapi/auth.go
+++ b/internal/adapter/httpapi/auth.go
@@ -87,6 +87,9 @@ func (a *Authenticator) Middleware(publicPaths map[string]bool, next http.Handle
 		principal.TenantID = shared.TenantOrDefault(shared.ID(principal.TenantID)).String()
 		ctx := context.WithValue(r.Context(), principalKey, principal)
 		ctx = shared.WithTenant(ctx, shared.ID(principal.TenantID))
+		if observation := requestObservationFrom(ctx); observation != nil {
+			observation.setPrincipal(principal.ID)
+		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -405,6 +405,9 @@ func (f *fleetRouter) authed(next http.HandlerFunc) http.HandlerFunc {
 		// claim, result, and inventory writes fail the audit insert with
 		// "new row violates row-level security policy for table audit_log".
 		ctx = shared.WithTenant(ctx, agent.TenantID)
+		if observation := requestObservationFrom(ctx); observation != nil {
+			observation.setPrincipal(agent.ID.String())
+		}
 		next(w, r.WithContext(ctx))
 	}
 }

--- a/internal/adapter/httpapi/observability.go
+++ b/internal/adapter/httpapi/observability.go
@@ -1,0 +1,187 @@
+package httpapi
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const unmatchedRoute = "unmatched"
+
+type requestIDKey struct{}
+type requestLoggerKey struct{}
+type requestObservationKey struct{}
+
+// HTTPObserver receives bounded HTTP request measurements. It deliberately has
+// no Prometheus dependency so the HTTP adapter remains transport-neutral.
+type HTTPObserver interface {
+	ObserveHTTPRequest(method, route, statusClass string, duration time.Duration)
+}
+
+// RequestIDFrom returns the server-generated request correlation ID.
+func RequestIDFrom(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(requestIDKey{}).(string)
+	return id, ok && id != ""
+}
+
+// LoggerFrom returns the request-scoped logger, which includes the request ID.
+// It returns false for contexts not created by Instrument.
+func LoggerFrom(ctx context.Context) (*slog.Logger, bool) {
+	log, ok := ctx.Value(requestLoggerKey{}).(*slog.Logger)
+	return log, ok && log != nil
+}
+
+type requestObservation struct {
+	mu          sync.RWMutex
+	principalID string
+}
+
+func requestObservationFrom(ctx context.Context) *requestObservation {
+	state, _ := ctx.Value(requestObservationKey{}).(*requestObservation)
+	return state
+}
+
+func (o *requestObservation) setPrincipal(id string) {
+	if o == nil || id == "" {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.principalID = id
+}
+
+func (o *requestObservation) principal() string {
+	if o == nil {
+		return ""
+	}
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.principalID
+}
+
+type responseRecorder struct {
+	http.ResponseWriter
+	log    *slog.Logger
+	status int
+}
+
+type requestLoggerResponseWriter interface {
+	requestLogger() *slog.Logger
+}
+
+func (w *responseRecorder) requestLogger() *slog.Logger { return w.log }
+
+func (w *responseRecorder) WriteHeader(status int) {
+	if w.status == 0 {
+		w.status = status
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *responseRecorder) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// Unwrap lets http.ResponseController reach the original writer without a
+// buffer, preserving streaming behavior through this observability wrapper.
+func (w *responseRecorder) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+type flushingResponseRecorder struct{ *responseRecorder }
+
+func (w *flushingResponseRecorder) Flush() {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	w.ResponseWriter.(http.Flusher).Flush()
+}
+
+// normalizeMethod bounds method cardinality in metrics and access logs.
+func normalizeMethod(method string) string {
+	switch method {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodHead, http.MethodOptions:
+		return method
+	default:
+		return "OTHER"
+	}
+}
+
+// Instrument wraps the complete normalized API handler exactly once. It avoids
+// recording unbounded request data and emits a single access event after every
+// request when enabled.
+func Instrument(next http.Handler, log *slog.Logger, accessLogEnabled bool, observer HTTPObserver) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started := time.Now()
+		requestID := uuid.NewString()
+		requestLog := log
+		if requestLog != nil {
+			requestLog = requestLog.With("request_id", requestID)
+		}
+		state := &requestObservation{}
+		ctx := context.WithValue(r.Context(), requestIDKey{}, requestID)
+		if requestLog != nil {
+			ctx = context.WithValue(ctx, requestLoggerKey{}, requestLog)
+		}
+		ctx = context.WithValue(ctx, requestObservationKey{}, state)
+		r = r.WithContext(ctx)
+		w.Header().Set("X-Request-ID", requestID)
+		recorder := &responseRecorder{ResponseWriter: w, log: requestLog}
+		var observedWriter http.ResponseWriter = recorder
+		if _, ok := w.(http.Flusher); ok {
+			observedWriter = &flushingResponseRecorder{responseRecorder: recorder}
+		}
+
+		finalize := func() {
+			status := recorder.status
+			if status == 0 {
+				status = http.StatusOK
+			}
+			route := r.Pattern
+			if route == "" {
+				route = unmatchedRoute
+			}
+			method := normalizeMethod(r.Method)
+			duration := time.Since(started)
+			statusClass := string([]byte{byte('0' + status/100), 'x', 'x'})
+			if observer != nil {
+				observer.ObserveHTTPRequest(method, route, statusClass, duration)
+			}
+			if accessLogEnabled && requestLog != nil {
+				attrs := []any{
+					"method", method,
+					"route", route,
+					"status", status,
+					"duration_ms", duration.Milliseconds(),
+				}
+				if principalID := state.principal(); principalID != "" {
+					attrs = append(attrs, "principal_id", principalID)
+				}
+				requestLog.Info("http access", attrs...)
+			}
+		}
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				// A response may already have started, but the observation must still
+				// classify the failed handler as a 500 before propagating its panic.
+				if recorder.status == 0 {
+					recorder.WriteHeader(http.StatusInternalServerError)
+				} else {
+					recorder.status = http.StatusInternalServerError
+				}
+				if requestLog != nil {
+					requestLog.Error("http handler panic")
+				}
+				finalize()
+				panic(recovered)
+			}
+			finalize()
+		}()
+		next.ServeHTTP(observedWriter, r)
+	})
+}

--- a/internal/adapter/httpapi/observability_test.go
+++ b/internal/adapter/httpapi/observability_test.go
@@ -1,0 +1,378 @@
+package httpapi
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recordedObservation struct {
+	method, route, statusClass string
+	duration                   time.Duration
+}
+
+type fakeHTTPObserver struct {
+	mu    sync.Mutex
+	calls []recordedObservation
+}
+
+func (f *fakeHTTPObserver) ObserveHTTPRequest(method, route, statusClass string, duration time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, recordedObservation{method: method, route: route, statusClass: statusClass, duration: duration})
+}
+
+func (f *fakeHTTPObserver) snapshot() []recordedObservation {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]recordedObservation(nil), f.calls...)
+}
+
+// TestInstrumentGeneratesRequestID covers request-ID correlation: Instrument must mint
+// one ID, expose it via X-Request-ID and RequestIDFrom, and every request gets exactly one.
+func TestInstrumentGeneratesRequestID(t *testing.T) {
+	var gotID string
+	var ok bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotID, ok = RequestIDFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	h := Instrument(next, discardLog(), false, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	if !ok || gotID == "" {
+		t.Fatal("request ID must be set in the request context")
+	}
+	if rec.Header().Get("X-Request-ID") != gotID {
+		t.Errorf("X-Request-ID header = %q, want %q", rec.Header().Get("X-Request-ID"), gotID)
+	}
+}
+
+// TestInstrumentDefaultStatusIsOK covers a handler that never calls WriteHeader: the
+// default response status recorded and observed must be 200, matching net/http semantics.
+func TestInstrumentDefaultStatusIsOK(t *testing.T) {
+	observer := &fakeHTTPObserver{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok")) // no explicit WriteHeader
+	})
+	h := Instrument(next, discardLog(), false, observer)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	h.ServeHTTP(rec, req)
+
+	if len(observer.snapshot()) != 1 {
+		t.Fatalf("want exactly 1 observation, got %d", len(observer.snapshot()))
+	}
+	if observer.snapshot()[0].statusClass != "2xx" {
+		t.Errorf("statusClass = %q, want 2xx (default status 200)", observer.snapshot()[0].statusClass)
+	}
+}
+
+// TestInstrumentExplicitStatus covers an explicit WriteHeader call, and that the
+// route label falls back to "unmatched" when r.Pattern is unset (no ServeMux match).
+func TestInstrumentExplicitStatus(t *testing.T) {
+	observer := &fakeHTTPObserver{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	h := Instrument(next, discardLog(), false, observer)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/missing", nil))
+
+	if len(observer.snapshot()) != 1 {
+		t.Fatalf("want exactly 1 observation, got %d", len(observer.snapshot()))
+	}
+	got := observer.snapshot()[0]
+	if got.statusClass != "4xx" {
+		t.Errorf("statusClass = %q, want 4xx", got.statusClass)
+	}
+	if got.route != unmatchedRoute {
+		t.Errorf("route = %q, want %q for a request with no matched ServeMux pattern", got.route, unmatchedRoute)
+	}
+}
+
+// TestInstrumentRoutePatternCardinality covers bounded route labels: the matched
+// ServeMux pattern (a fixed template, never the raw path) is used for the route label,
+// so distinct path VALUES on the same route collapse to one bounded label.
+func TestInstrumentRoutePatternCardinality(t *testing.T) {
+	observer := &fakeHTTPObserver{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/engagements/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := Instrument(mux, discardLog(), false, observer)
+
+	for _, id := range []string{"e1", "e2", "e3"} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/engagements/"+id, nil))
+	}
+	if len(observer.snapshot()) != 3 {
+		t.Fatalf("want 3 observations, got %d", len(observer.snapshot()))
+	}
+	for _, c := range observer.snapshot() {
+		if c.route != "GET /api/v1/engagements/{id}" {
+			t.Errorf("route = %q, want the matched pattern (not the raw path)", c.route)
+		}
+	}
+}
+
+// TestInstrumentAccessLogEmitsExactlyOnceWhenEnabled covers the single-access-event
+// contract: enabled → exactly one Info "http access" record per request with the
+// documented safe fields; disabled → zero.
+func TestInstrumentAccessLogEmitsExactlyOnceWhenEnabled(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	var buf strings.Builder
+	log := newCapturingLogger(&buf)
+	h := Instrument(next, log, true, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/engagements", nil))
+
+	out := buf.String()
+	if strings.Count(out, "http access") != 1 {
+		t.Fatalf("want exactly 1 access-log event, got log: %s", out)
+	}
+	for _, field := range []string{"request_id=", "method=GET", "status=200"} {
+		if !strings.Contains(out, field) {
+			t.Errorf("access log missing field %q: %s", field, out)
+		}
+	}
+}
+
+func TestInstrumentAccessLogDisabledEmitsNothing(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	var buf strings.Builder
+	log := newCapturingLogger(&buf)
+	h := Instrument(next, log, false, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/engagements", nil))
+	if buf.Len() != 0 {
+		t.Errorf("access logging disabled must emit nothing, got: %s", buf.String())
+	}
+}
+
+// TestInstrumentSensitiveFieldsAbsent covers the privacy contract: the access-log
+// event must never contain the raw path, query string, or a value the handler wrote
+// to the response body, even though the request carried them.
+func TestInstrumentSensitiveFieldsAbsent(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("super-secret-body-content"))
+	})
+	var buf strings.Builder
+	log := newCapturingLogger(&buf)
+	h := Instrument(next, log, true, nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/engagements?token=super-secret-query&tenant=acme", nil)
+	req.Header.Set("Authorization", "Bearer super-secret-bearer-token")
+	req.Header.Set("User-Agent", "sensitive-agent-string")
+	h.ServeHTTP(rec, req)
+
+	out := buf.String()
+	for _, secret := range []string{"super-secret-query", "super-secret-bearer-token", "sensitive-agent-string", "super-secret-body-content", "?token="} {
+		if strings.Contains(out, secret) {
+			t.Errorf("access log leaked sensitive content %q: %s", secret, out)
+		}
+	}
+}
+
+// TestInstrumentPrincipalPropagation covers principal attribution: setPrincipal (as
+// called by the real auth middleware) must surface in the access log only when the
+// principal actually resolves; an unauthenticated request logs no principal_id field.
+func TestInstrumentPrincipalPropagation(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if observation := requestObservationFrom(r.Context()); observation != nil {
+			observation.setPrincipal("user-123")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	var buf strings.Builder
+	log := newCapturingLogger(&buf)
+	h := Instrument(next, log, true, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	if !strings.Contains(buf.String(), "principal_id=user-123") {
+		t.Errorf("access log missing resolved principal_id: %s", buf.String())
+	}
+
+	buf.Reset()
+	anon := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusUnauthorized) })
+	h2 := Instrument(anon, log, true, nil)
+	rec2 := httptest.NewRecorder()
+	h2.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if strings.Contains(buf.String(), "principal_id") {
+		t.Errorf("unauthenticated request must not log principal_id: %s", buf.String())
+	}
+}
+
+// flushRecorder is a ResponseWriter double implementing http.Flusher, so the test can
+// confirm Instrument's wrapper preserves streaming instead of buffering.
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushed int
+}
+
+func (f *flushRecorder) Flush() { f.flushed++ }
+
+// TestInstrumentPreservesFlusher covers streaming preservation: the wrapper must
+// expose http.Flusher (via Unwrap for http.ResponseController, and directly) so a
+// streaming handler's Flush() calls still reach the underlying writer.
+func TestInstrumentPreservesFlusher(t *testing.T) {
+	under := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+	var sawFlusher bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		rc := http.NewResponseController(w)
+		if err := rc.Flush(); err == nil {
+			sawFlusher = true
+		}
+	})
+	h := Instrument(next, discardLog(), false, nil)
+	h.ServeHTTP(under, httptest.NewRequest(http.MethodGet, "/stream", nil))
+
+	if !sawFlusher {
+		t.Error("http.ResponseController(w).Flush() must succeed through the observability wrapper")
+	}
+	if under.flushed == 0 {
+		t.Error("Flush must reach the underlying ResponseWriter, not be buffered")
+	}
+}
+
+// newCapturingLogger returns a slog.Logger that writes to buf using the text handler,
+// so key=value substrings are stable for the assertions above.
+func newCapturingLogger(buf *strings.Builder) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, nil))
+}
+
+func TestInstrumentBoundsArbitraryMethod(t *testing.T) {
+	observer := &fakeHTTPObserver{}
+	h := Instrument(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }), discardLog(), false, observer)
+	req := httptest.NewRequest("BREW", "/x", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	calls := observer.snapshot()
+	if len(calls) != 1 || calls[0].method != "OTHER" {
+		t.Fatalf("observations = %+v, want one OTHER method", calls)
+	}
+}
+
+func TestInstrumentPanicObservesOneServerErrorAndRepans(t *testing.T) {
+	observer := &fakeHTTPObserver{}
+	h := Instrument(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		panic("boom")
+	}), discardLog(), false, observer)
+	defer func() {
+		if recover() != "boom" {
+			t.Fatal("panic must be preserved")
+		}
+		calls := observer.snapshot()
+		if len(calls) != 1 || calls[0].statusClass != "5xx" {
+			t.Fatalf("observations = %+v, want one 5xx", calls)
+		}
+	}()
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", nil))
+}
+
+type plainRecorder struct{ header http.Header }
+
+func (w *plainRecorder) Header() http.Header         { return w.header }
+func (w *plainRecorder) Write(b []byte) (int, error) { return len(b), nil }
+func (w *plainRecorder) WriteHeader(int)             {}
+
+type responseWriterWrapper struct{ http.ResponseWriter }
+
+func (w responseWriterWrapper) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+func TestInstrumentDoesNotExposeUnsupportedFlusher(t *testing.T) {
+	under := &plainRecorder{header: make(http.Header)}
+	h := Instrument(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, ok := w.(http.Flusher); ok {
+			t.Error("wrapper must not expose Flusher when the underlying writer does not")
+		}
+		if err := http.NewResponseController(w).Flush(); err == nil {
+			t.Error("Flush must be unsupported when the underlying writer does not support it")
+		}
+	}), discardLog(), false, nil)
+	h.ServeHTTP(under, httptest.NewRequest(http.MethodGet, "/", nil))
+}
+
+func TestInstrumentCorrelatesUnexpectedErrorAndAccessLogs(t *testing.T) {
+	var buf strings.Builder
+	log := newCapturingLogger(&buf)
+	h := Instrument(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeError(responseWriterWrapper{responseWriterWrapper{w}}, log, errors.New("database unavailable"))
+	}), log, true, nil)
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/secret?token=not-logged", nil))
+	output := buf.String()
+	var requestIDs []string
+	for _, field := range strings.Fields(output) {
+		if requestID, ok := strings.CutPrefix(field, "request_id="); ok {
+			requestIDs = append(requestIDs, requestID)
+		}
+	}
+	if len(requestIDs) != 2 || requestIDs[0] != requestIDs[1] {
+		t.Fatalf("unexpected/access logs must share one request ID through response-writer wrappers: %s", output)
+	}
+	if strings.Contains(output, "token") || strings.Contains(output, "/secret") {
+		t.Fatalf("logs contain sensitive request data: %s", output)
+	}
+}
+
+func TestInstrumentPreservesRoutePatternsAcrossRejectedAndFleetRequests(t *testing.T) {
+	humanRoutes := http.NewServeMux()
+	humanRoutes.HandleFunc("GET /protected", func(http.ResponseWriter, *http.Request) {})
+	humanRoutes.HandleFunc("GET /wild/{id}", func(http.ResponseWriter, *http.Request) {})
+	human := annotateRoutePattern(humanRoutes, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Forbidden") != "" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	top := http.NewServeMux()
+	top.HandleFunc("POST /api/v1/fleet/agents/{id}/heartbeat", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	top.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Pattern = ""
+		human.ServeHTTP(w, r)
+	}))
+	observer := &fakeHTTPObserver{}
+	h := Instrument(top, discardLog(), false, observer)
+	for _, test := range []struct {
+		name, method, path, route string
+		forbidden                 bool
+	}{
+		{name: "unauthorized known", method: http.MethodGet, path: "/protected", route: "GET /protected"},
+		{name: "forbidden known", method: http.MethodGet, path: "/protected", route: "GET /protected", forbidden: true},
+		{name: "wildcard", method: http.MethodGet, path: "/wild/e-123", route: "GET /wild/{id}"},
+		{name: "method mismatch", method: http.MethodPost, path: "/protected", route: unmatchedRoute},
+		{name: "unmatched", method: http.MethodGet, path: "/missing", route: unmatchedRoute},
+		{name: "fleet", method: http.MethodPost, path: "/api/v1/fleet/agents/a-123/heartbeat", route: "POST /api/v1/fleet/agents/{id}/heartbeat"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(test.method, test.path, nil)
+			if test.forbidden {
+				req.Header.Set("X-Forbidden", "1")
+			}
+			h.ServeHTTP(httptest.NewRecorder(), req)
+		})
+	}
+	calls := observer.snapshot()
+	if len(calls) != 6 {
+		t.Fatalf("observations = %d, want 6", len(calls))
+	}
+	for i, want := range []string{"GET /protected", "GET /protected", "GET /wild/{id}", unmatchedRoute, unmatchedRoute, "POST /api/v1/fleet/agents/{id}/heartbeat"} {
+		if calls[i].route != want {
+			t.Errorf("observation %d route = %q, want %q", i, calls[i].route, want)
+		}
+	}
+}

--- a/internal/adapter/httpapi/response.go
+++ b/internal/adapter/httpapi/response.go
@@ -19,6 +19,22 @@ type errorBody struct {
 	Error string `json:"error"`
 }
 
+func requestLogger(w http.ResponseWriter, fallback *slog.Logger) *slog.Logger {
+	for w != nil {
+		if carrier, ok := w.(requestLoggerResponseWriter); ok {
+			if log := carrier.requestLogger(); log != nil {
+				return log
+			}
+		}
+		unwrapper, ok := w.(interface{ Unwrap() http.ResponseWriter })
+		if !ok {
+			break
+		}
+		w = unwrapper.Unwrap()
+	}
+	return fallback
+}
+
 // writeError maps domain sentinel errors to HTTP status codes.
 func writeError(w http.ResponseWriter, log *slog.Logger, err error) {
 	switch {
@@ -38,7 +54,7 @@ func writeError(w http.ResponseWriter, log *slog.Logger, err error) {
 		}
 		writeJSON(w, http.StatusServiceUnavailable, errorBody{Error: err.Error()})
 	default:
-		log.Error("request failed", "err", err)
+		requestLogger(w, log).Error("request failed", "err", err)
 		writeJSON(w, http.StatusInternalServerError, errorBody{Error: "internal error"})
 	}
 }

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -44,6 +44,8 @@ import (
 // Router wires HTTP routes to use case services.
 type Router struct {
 	log                    *slog.Logger
+	accessLogEnabled       bool
+	httpObserver           HTTPObserver
 	auth                   *Authenticator
 	eng                    *enguc.Service
 	sca                    *scauc.Service
@@ -214,6 +216,13 @@ func (rt *Router) SetVulnerabilityActions(actions *vulnerabilityactionuc.Service
 
 // SetSLA wires the opt-in risk-based remediation governance API.
 func (rt *Router) SetSLA(service *slauc.Service) { rt.sla = service }
+
+// SetObservability installs the optional bounded HTTP observer and access-log policy.
+// A nil observer disables metrics feed but access logging (if enabled) still runs.
+func (rt *Router) SetObservability(accessLogEnabled bool, observer HTTPObserver) {
+	rt.accessLogEnabled = accessLogEnabled
+	rt.httpObserver = observer
+}
 
 // NewRouter builds the HTTP router.
 func NewRouter(log *slog.Logger, auth *Authenticator, eng *enguc.Service, sca *scauc.Service, aup *aupuc.Service, findings *findingsuc.Service, export *exportuc.Service, report *reportuc.Service, evidence *evidenceuc.Service, recon *reconuc.Service, logs ports.LogStream, transfer *transferuc.Service, audit *audituc.Service, vex *vexuc.Service, users *usersuc.Service, credentials *credentialsuc.Service) *Router {
@@ -595,25 +604,37 @@ func (rt *Router) Handler() http.Handler {
 		"/api/v1/aup/accept": true,
 		"/api/v1/me":         true,
 	}
-	human := rt.auth.Middleware(public, rt.requireAUP(aupExempt, rt.routes()))
+	routes := rt.routes()
+	human := rt.auth.Middleware(public, rt.requireAUP(aupExempt, routes))
+	// Attach a method-aware route pattern before auth/AUP can reject a known human
+	// route. ServeMux returns an empty pattern for unknown paths and method mismatches.
+	human = annotateRoutePattern(routes, human)
+	var complete http.Handler
 	if rt.fleet == nil {
-		return normalizePath(human)
+		complete = normalizePath(human)
+	} else {
+		// The untrusted agent transport is a separate auth plane. Mount its exact
+		// subtrees so operator routes under /api/v1/fleet remain on the human chain.
+		top := http.NewServeMux()
+		agentPlane := rt.fleet.handler()
+		for _, mount := range fleetAgentPlaneMounts() {
+			top.Handle(mount, agentPlane)
+		}
+		top.Handle("/", human)
+		complete = normalizePath(top)
 	}
-	// The untrusted agent transport is a SEPARATE auth plane: it must not pass through the human
-	// bearer-token authenticator or the AUP gate. Mount it on the EXACT agent-plane subtrees rather
-	// than the whole /api/v1/fleet/ prefix. A prefix mount also swallows the OPERATOR routes that
-	// live under /api/v1/fleet (coverage + agent health), which the agent mux does not serve, so
-	// every one of them answered 404 instead of reaching the human chain. The mounts are derived
-	// from fleetAgentPlaneRoutes, the same declaration fleetRouter.handler() registers, so the two
-	// planes cannot drift apart. normalizePath wraps the whole top mux once, so both planes are
-	// normalized without double-wrapping.
-	top := http.NewServeMux()
-	agentPlane := rt.fleet.handler()
-	for _, mount := range fleetAgentPlaneMounts() {
-		top.Handle(mount, agentPlane)
-	}
-	top.Handle("/", human)
-	return normalizePath(top)
+	// Instrument wraps the entire normalized human+fleet handler exactly once.
+	return Instrument(complete, rt.log, rt.accessLogEnabled, rt.httpObserver)
+}
+
+func annotateRoutePattern(mux *http.ServeMux, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, pattern := mux.Handler(r)
+		if pattern != "" && pattern != "/" {
+			r.Pattern = pattern
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // normalizePath rejects non-canonical request paths (e.g. `/a//b`, `/a/../b`,

--- a/internal/adapter/observability/prometheus.go
+++ b/internal/adapter/observability/prometheus.go
@@ -1,0 +1,125 @@
+// Package observability adapts Synapse's bounded telemetry seams to Prometheus.
+package observability
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const queueStatsTimeout = time.Second
+
+// Collectors owns a private Prometheus registry. It contains no global
+// collectors, so only Synapse's documented metrics are exposed by /metrics.
+type Collectors struct {
+	registry     *prometheus.Registry
+	httpRequests *prometheus.CounterVec
+	httpDuration *prometheus.HistogramVec
+	scaDuration  *prometheus.HistogramVec
+	scaOutcomes  *prometheus.CounterVec
+	queueReader  ports.AggregateJobQueueStatsReader
+	now          func() time.Time
+}
+
+// New constructs the bounded Prometheus collectors used by the API metrics listener.
+func New(queueReader ports.AggregateJobQueueStatsReader) *Collectors {
+	c := &Collectors{
+		registry:    prometheus.NewRegistry(),
+		queueReader: queueReader,
+		now:         time.Now,
+		httpRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "http", Name: "requests_total",
+			Help: "Total HTTP requests handled by the API.",
+		}, []string{"method", "route", "status_class"}),
+		httpDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "synapse", Subsystem: "http", Name: "request_duration_seconds",
+			Help: "HTTP request handling duration in seconds.",
+		}, []string{"method", "route", "status_class"}),
+		scaDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "synapse", Subsystem: "sca", Name: "scan_duration_seconds",
+			Help: "Completed SCA scan execution duration.",
+		}, []string{"outcome"}),
+		scaOutcomes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "sca", Name: "scan_outcomes_total",
+			Help: "Terminal SCA scan outcomes.",
+		}, []string{"outcome"}),
+	}
+	c.registry.MustRegister(c.httpRequests, c.httpDuration, c.scaDuration, c.scaOutcomes)
+	if queueReader != nil {
+		queue := newQueueCollector(queueReader, c.now)
+		c.registry.MustRegister(queue)
+	}
+	return c
+}
+
+type queueCollector struct {
+	reader          ports.AggregateJobQueueStatsReader
+	now             func() time.Time
+	queued          *prometheus.Desc
+	inFlight        *prometheus.Desc
+	oldestActiveAge *prometheus.Desc
+}
+
+func (c *queueCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.queued
+	ch <- c.inFlight
+	ch <- c.oldestActiveAge
+}
+
+func (c *queueCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), queueStatsTimeout)
+	defer cancel()
+	stats, err := c.reader.AggregateJobQueueStats(ctx)
+	if err != nil {
+		return
+	}
+	age := 0.0
+	if stats.OldestActiveAt != nil {
+		age = c.now().Sub(*stats.OldestActiveAt).Seconds()
+		if age < 0 {
+			age = 0
+		}
+	}
+	ch <- prometheus.MustNewConstMetric(c.queued, prometheus.GaugeValue, float64(stats.Queued))
+	ch <- prometheus.MustNewConstMetric(c.inFlight, prometheus.GaugeValue, float64(stats.Claimed))
+	ch <- prometheus.MustNewConstMetric(c.oldestActiveAge, prometheus.GaugeValue, age)
+}
+
+func newQueueCollector(reader ports.AggregateJobQueueStatsReader, now func() time.Time) *queueCollector {
+	return &queueCollector{
+		reader:          reader,
+		now:             now,
+		queued:          prometheus.NewDesc("synapse_job_queue_queued", "Aggregate queued durable jobs.", nil, nil),
+		inFlight:        prometheus.NewDesc("synapse_job_queue_in_flight", "Aggregate claimed durable jobs.", nil, nil),
+		oldestActiveAge: prometheus.NewDesc("synapse_job_queue_oldest_active_age_seconds", "Age of the oldest queued or claimed durable job.", nil, nil),
+	}
+}
+
+// ObserveHTTPRequest records a bounded HTTP request outcome.
+func (c *Collectors) ObserveHTTPRequest(method, route, statusClass string, duration time.Duration) {
+	c.httpRequests.WithLabelValues(method, route, statusClass).Inc()
+	c.httpDuration.WithLabelValues(method, route, statusClass).Observe(duration.Seconds())
+}
+
+// ObserveSCAOutcome records one terminal SCA outcome without an execution duration.
+func (c *Collectors) ObserveSCAOutcome(outcome string) {
+	c.scaOutcomes.WithLabelValues(outcome).Inc()
+}
+
+// ObserveSCAScan records one completed SCA execution outcome and its duration.
+func (c *Collectors) ObserveSCAScan(duration time.Duration, outcome string) {
+	c.scaDuration.WithLabelValues(outcome).Observe(duration.Seconds())
+	c.ObserveSCAOutcome(outcome)
+}
+
+// Handler returns the private-registry Prometheus metrics endpoint.
+func (c *Collectors) Handler() http.Handler {
+	return promhttp.HandlerFor(c.registry, promhttp.HandlerOpts{})
+}
+
+var _ ports.SCAObserver = (*Collectors)(nil)

--- a/internal/adapter/observability/prometheus.go
+++ b/internal/adapter/observability/prometheus.go
@@ -63,12 +63,14 @@ type queueCollector struct {
 	queued          *prometheus.Desc
 	inFlight        *prometheus.Desc
 	oldestActiveAge *prometheus.Desc
+	scrapeErrors    prometheus.Counter
 }
 
 func (c *queueCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.queued
 	ch <- c.inFlight
 	ch <- c.oldestActiveAge
+	ch <- c.scrapeErrors.Desc()
 }
 
 func (c *queueCollector) Collect(ch chan<- prometheus.Metric) {
@@ -76,6 +78,11 @@ func (c *queueCollector) Collect(ch chan<- prometheus.Metric) {
 	defer cancel()
 	stats, err := c.reader.AggregateJobQueueStats(ctx)
 	if err != nil {
+		// Do not emit bogus/stale gauge values for queued/in_flight/oldest_active_age; the
+		// scrape-error counter makes the failure itself observable instead of the gauges
+		// silently vanishing from the scrape exactly when queue health matters.
+		c.scrapeErrors.Inc()
+		ch <- c.scrapeErrors
 		return
 	}
 	age := 0.0
@@ -88,6 +95,7 @@ func (c *queueCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.queued, prometheus.GaugeValue, float64(stats.Queued))
 	ch <- prometheus.MustNewConstMetric(c.inFlight, prometheus.GaugeValue, float64(stats.Claimed))
 	ch <- prometheus.MustNewConstMetric(c.oldestActiveAge, prometheus.GaugeValue, age)
+	ch <- c.scrapeErrors
 }
 
 func newQueueCollector(reader ports.AggregateJobQueueStatsReader, now func() time.Time) *queueCollector {
@@ -97,6 +105,10 @@ func newQueueCollector(reader ports.AggregateJobQueueStatsReader, now func() tim
 		queued:          prometheus.NewDesc("synapse_job_queue_queued", "Aggregate queued durable jobs.", nil, nil),
 		inFlight:        prometheus.NewDesc("synapse_job_queue_in_flight", "Aggregate claimed durable jobs.", nil, nil),
 		oldestActiveAge: prometheus.NewDesc("synapse_job_queue_oldest_active_age_seconds", "Age of the oldest queued or claimed durable job.", nil, nil),
+		scrapeErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "job_queue", Name: "scrape_errors_total",
+			Help: "Failed attempts to read aggregate durable job queue stats for this scrape.",
+		}),
 	}
 }
 

--- a/internal/adapter/observability/prometheus_test.go
+++ b/internal/adapter/observability/prometheus_test.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -103,5 +104,27 @@ func TestCollectorsQueueGaugesAbsentWithoutReader(t *testing.T) {
 	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	if strings.Contains(rec.Body.String(), "synapse_job_queue_") {
 		t.Error("no queue gauge should be registered without an AggregateJobQueueStatsReader")
+	}
+}
+
+// TestCollectorsQueueScrapeErrorSurfacesFailure covers that a failed
+// AggregateJobQueueStats read does not silently drop the queue gauges: the three
+// gauges must be absent from that scrape (no bogus/stale values), and the failure
+// itself must be observable via the scrape-error counter.
+func TestCollectorsQueueScrapeErrorSurfacesFailure(t *testing.T) {
+	reader := &fakeQueueReader{err: errors.New("queue stats unavailable")}
+	c := New(reader)
+
+	rec := httptest.NewRecorder()
+	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rec.Body.String()
+
+	for _, absent := range []string{"synapse_job_queue_queued", "synapse_job_queue_in_flight", "synapse_job_queue_oldest_active_age_seconds"} {
+		if strings.Contains(body, absent) {
+			t.Errorf("gauge %q must be absent on a failed scrape, got: %s", absent, body)
+		}
+	}
+	if !strings.Contains(body, "synapse_job_queue_scrape_errors_total 1") {
+		t.Errorf("scrape-error counter missing/incorrect: %s", body)
 	}
 }

--- a/internal/adapter/observability/prometheus_test.go
+++ b/internal/adapter/observability/prometheus_test.go
@@ -1,0 +1,107 @@
+package observability
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeQueueReader struct {
+	stats    ports.JobStats
+	err      error
+	calls    int
+	deadline time.Time
+}
+
+func (f *fakeQueueReader) AggregateJobQueueStats(ctx context.Context, _ ...string) (ports.JobStats, error) {
+	f.calls++
+	f.deadline, _ = ctx.Deadline()
+	return f.stats, f.err
+}
+
+// TestCollectorsExposesHTTPMetrics covers the private-registry contract: recorded HTTP
+// requests must be scrapable via the returned Handler with the documented label set
+// (method, route, status_class) and nothing else attached to the private registry.
+func TestCollectorsExposesHTTPMetrics(t *testing.T) {
+	c := New(nil)
+	c.ObserveHTTPRequest("GET", "GET /api/v1/engagements/{id}", "2xx", 25*time.Millisecond)
+
+	got := testutil.ToFloat64(c.httpRequests.WithLabelValues("GET", "GET /api/v1/engagements/{id}", "2xx"))
+	if got != 1 {
+		t.Errorf("synapse_http_requests_total = %v, want 1", got)
+	}
+}
+
+// TestCollectorsScrapeOutput covers that the handler actually serves the registered
+// series in the Prometheus text exposition format expected by a scrape target.
+func TestCollectorsScrapeOutput(t *testing.T) {
+	c := New(nil)
+	c.ObserveHTTPRequest("GET", "GET /healthz", "2xx", time.Millisecond)
+	c.ObserveSCAScan(time.Second, "success")
+
+	rec := httptest.NewRecorder()
+	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"synapse_http_requests_total",
+		"synapse_http_request_duration_seconds",
+		"synapse_sca_scan_duration_seconds",
+		"synapse_sca_scan_outcomes_total",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("scrape output missing metric %q", want)
+		}
+	}
+}
+
+// TestCollectorsQueueGaugesReflectAggregateStats covers the aggregate queue gauges:
+// they must reflect the reader's totals and report no tenant label anywhere.
+func TestCollectorsQueueGaugesReflectAggregateStats(t *testing.T) {
+	oldest := time.Now().Add(-90 * time.Second)
+	reader := &fakeQueueReader{stats: ports.JobStats{Queued: 3, Claimed: 2, OldestActiveAt: &oldest}}
+	c := New(reader)
+	c.now = func() time.Time { return oldest.Add(90 * time.Second) }
+
+	rec := httptest.NewRecorder()
+	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "synapse_job_queue_queued 3") {
+		t.Errorf("queued gauge missing/incorrect: %s", body)
+	}
+	if !strings.Contains(body, "synapse_job_queue_in_flight 2") {
+		t.Errorf("in_flight gauge missing/incorrect: %s", body)
+	}
+	if !strings.Contains(body, "synapse_job_queue_oldest_active_age_seconds 90") {
+		t.Errorf("oldest_active_age_seconds gauge missing/incorrect: %s", body)
+	}
+	if strings.Contains(body, "tenant") {
+		t.Errorf("aggregate queue metrics must never carry a tenant label: %s", body)
+	}
+	if reader.calls != 1 {
+		t.Errorf("aggregate stats calls = %d, want 1 per scrape", reader.calls)
+	}
+	if reader.deadline.IsZero() || time.Until(reader.deadline) > queueStatsTimeout {
+		t.Errorf("queue collector must provide a bounded deadline, got %v", reader.deadline)
+	}
+}
+
+// TestCollectorsQueueGaugesAbsentWithoutReader covers that a nil reader (metrics
+// enabled without an aggregate-capable queue implementation) registers no queue gauges
+// rather than panicking or exposing a stale/zero series that misleads an operator.
+func TestCollectorsQueueGaugesAbsentWithoutReader(t *testing.T) {
+	c := New(nil)
+	rec := httptest.NewRecorder()
+	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if strings.Contains(rec.Body.String(), "synapse_job_queue_") {
+		t.Error("no queue gauge should be registered without an AggregateJobQueueStatsReader")
+	}
+}

--- a/internal/infrastructure/persistence/memory/jobqueue.go
+++ b/internal/infrastructure/persistence/memory/jobqueue.go
@@ -43,6 +43,7 @@ func NewJobQueue(ids ports.IDGenerator, now func() time.Time) *JobQueue {
 
 var _ ports.JobQueue = (*JobQueue)(nil)
 var _ ports.JobStatusReader = (*JobQueue)(nil)
+var _ ports.AggregateJobQueueStatsReader = (*JobQueue)(nil)
 
 func (q *JobQueue) Enqueue(ctx context.Context, kind string, payload []byte) (string, error) {
 	if kind == "" {
@@ -202,4 +203,10 @@ func (q *JobQueue) Fail(_ context.Context, id string, retryIn time.Duration) err
 	j.claimedUntil = time.Time{}
 	j.availableAt = q.now().Add(retryIn)
 	return nil
+}
+
+// AggregateJobQueueStats aggregates every in-memory job without tenant scoping. It is
+// intended solely for the operator metrics collector and never returns tenant labels.
+func (q *JobQueue) AggregateJobQueueStats(ctx context.Context, kinds ...string) (ports.JobStats, error) {
+	return q.Stats(ctx, kinds...)
 }

--- a/internal/infrastructure/persistence/memory/jobqueue_test.go
+++ b/internal/infrastructure/persistence/memory/jobqueue_test.go
@@ -169,3 +169,26 @@ func TestJobQueueClaimByKind(t *testing.T) {
 		t.Fatalf("a recon worker must claim the recon job, got %+v", j3)
 	}
 }
+
+// TestJobQueueAggregateJobQueueStatsAggregatesAllTenants covers the metrics seam: unlike
+// Stats (tenant-scoped by JobStatus's own tenant check), AggregateJobQueueStats must sum
+// every job across every tenant, since the in-memory adapter has no per-tenant isolation
+// boundary to preserve for a single-process operator collector.
+func TestJobQueueAggregateJobQueueStatsAggregatesAllTenants(t *testing.T) {
+	clk := &movableClock{t: time.Unix(1000, 0).UTC()}
+	q := NewJobQueue(&seqIDs{}, clk.now)
+	ctxA := shared.WithTenant(context.Background(), "tenant-a")
+	ctxB := shared.WithTenant(context.Background(), "tenant-b")
+
+	_, _ = q.Enqueue(ctxA, "sca", nil)
+	_, _ = q.Enqueue(ctxB, "sca", nil)
+	_, _ = q.Claim(ctxA, time.Minute, "sca")
+
+	stats, err := q.AggregateJobQueueStats(context.Background(), "sca")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Queued != 1 || stats.Claimed != 1 {
+		t.Fatalf("aggregate stats = %+v, want 1 queued + 1 claimed across both tenants", stats)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/jobqueue.go
+++ b/internal/infrastructure/persistence/postgres/jobqueue.go
@@ -25,6 +25,7 @@ func NewJobQueue(pool *pgxpool.Pool, ids ports.IDGenerator) *JobQueue {
 
 var _ ports.JobQueue = (*JobQueue)(nil)
 var _ ports.JobStatusReader = (*JobQueue)(nil)
+var _ ports.AggregateJobQueueStatsReader = (*JobQueue)(nil)
 
 func (q *JobQueue) Enqueue(ctx context.Context, kind string, payload []byte) (string, error) {
 	if kind == "" {
@@ -168,4 +169,46 @@ func (q *JobQueue) JobStatus(ctx context.Context, id string) (status ports.JobSt
 		return nil
 	})
 	return status, err
+}
+
+// AggregateJobQueueStats aggregates each tenant's RLS-scoped queue statistics for the
+// operator metrics collector. The tenant enumeration mirrors Claim so the forced-RLS
+// per-tenant transaction remains the only way any job row is read; no tenant label is
+// ever attached to the aggregated totals.
+func (q *JobQueue) AggregateJobQueueStats(ctx context.Context, kinds ...string) (ports.JobStats, error) {
+	rows, err := q.pool.Query(ctx, `SELECT id FROM tenants ORDER BY id`)
+	if err != nil {
+		return ports.JobStats{}, fmt.Errorf("list queue tenants: %w", err)
+	}
+	var tenantIDs []shared.ID
+	for rows.Next() {
+		var tenantID shared.ID
+		if err := rows.Scan(&tenantID); err != nil {
+			rows.Close()
+			return ports.JobStats{}, fmt.Errorf("scan queue tenant: %w", err)
+		}
+		tenantIDs = append(tenantIDs, tenantID)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return ports.JobStats{}, fmt.Errorf("list queue tenants: %w", err)
+	}
+	rows.Close()
+
+	var total ports.JobStats
+	for _, tenantID := range tenantIDs {
+		stats, err := q.Stats(shared.WithTenant(ctx, tenantID), kinds...)
+		if err != nil {
+			return ports.JobStats{}, fmt.Errorf("queue stats for tenant: %w", err)
+		}
+		total.Queued += stats.Queued
+		total.Claimed += stats.Claimed
+		total.Failed += stats.Failed
+		total.Done += stats.Done
+		if stats.OldestActiveAt != nil && (total.OldestActiveAt == nil || stats.OldestActiveAt.Before(*total.OldestActiveAt)) {
+			at := *stats.OldestActiveAt
+			total.OldestActiveAt = &at
+		}
+	}
+	return total, nil
 }

--- a/internal/infrastructure/persistence/postgres/jobqueue_test.go
+++ b/internal/infrastructure/persistence/postgres/jobqueue_test.go
@@ -109,3 +109,30 @@ func TestPostgresJobQueueClaimByKind(t *testing.T) {
 		t.Fatalf("a recon worker must claim the recon job, got %+v", j3)
 	}
 }
+
+// TestPostgresJobQueueAggregateJobQueueStatsAcrossTenants covers the operator metrics
+// seam: AggregateJobQueueStats must sum every tenant's RLS-scoped Stats (mirroring
+// Claim's per-tenant transaction loop), never a privileged cross-tenant query, and must
+// never require or expose a tenant label on the result. Gated on SYNAPSE_TEST_DB_DSN.
+func TestPostgresJobQueueAggregateJobQueueStatsAcrossTenants(t *testing.T) {
+	q, ctx := setupJobQueue(t)
+	tenantA := shared.DefaultTenant
+	_, _ = q.Enqueue(ctx, "sca", []byte("a"))
+
+	otherTenant := shared.ID("other-tenant")
+	if _, err := q.pool.Exec(ctx, `INSERT INTO tenants (id) VALUES ($1) ON CONFLICT DO NOTHING`, otherTenant.String()); err != nil {
+		t.Fatalf("seed second tenant: %v", err)
+	}
+	ctxB := shared.WithTenant(context.Background(), otherTenant)
+	if _, err := q.Enqueue(ctxB, "sca", []byte("b")); err != nil {
+		t.Fatalf("enqueue tenant b: %v", err)
+	}
+
+	stats, err := q.AggregateJobQueueStats(context.Background(), "sca")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Queued != 2 {
+		t.Fatalf("aggregate queued = %d, want 2 (across tenant %s and %s)", stats.Queued, tenantA, otherTenant)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -22,10 +22,18 @@ const (
 
 // Config holds runtime configuration.
 type Config struct {
-	HTTPAddr     string
-	Environment  string
-	LogLevel     string
-	SingleTenant bool
+	HTTPAddr string
+	// MetricsEnabled turns on the Prometheus /metrics endpoint on a SEPARATE,
+	// uninstrumented, non-bearer-protected listener. Off by default.
+	MetricsEnabled bool
+	// MetricsAddr is the loopback-by-default listen address for the metrics endpoint.
+	MetricsAddr string
+	// AccessLogEnabled turns on the single structured access-log event per HTTP
+	// request (method, matched route, status, latency, request id). On by default.
+	AccessLogEnabled bool
+	Environment      string
+	LogLevel         string
+	SingleTenant     bool
 
 	// APIToken protects all API + UI routes; required (no anonymous access).
 	APIToken string
@@ -516,6 +524,9 @@ func Load() Config {
 	}
 	return Config{
 		HTTPAddr:                         getenv("SYNAPSE_HTTP_ADDR", ":8080"),
+		MetricsEnabled:                   getbool("SYNAPSE_METRICS_ENABLED", false),
+		MetricsAddr:                      getenv("SYNAPSE_METRICS_ADDR", "127.0.0.1:9090"),
+		AccessLogEnabled:                 getbool("SYNAPSE_ACCESS_LOG_ENABLED", true),
 		Environment:                      normalizeEnv(getenv("SYNAPSE_ENV", "development")),
 		LogLevel:                         getenv("SYNAPSE_LOG_LEVEL", "info"),
 		SingleTenant:                     getbool("SYNAPSE_SINGLE_TENANT", true),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -446,3 +446,36 @@ func TestLoadDatabaseMigrationDSN(t *testing.T) {
 		t.Fatalf("migration DSN = %q", got)
 	}
 }
+
+// TestLoadObservabilityDefaults pins the opt-in-metrics / on-by-default-access-log
+// posture: metrics stay off and loopback-bound until explicitly enabled, while
+// access logging is on by default so a fresh deployment gets request correlation
+// without operator action.
+func TestLoadObservabilityDefaults(t *testing.T) {
+	config := Load()
+	if config.MetricsEnabled {
+		t.Error("SYNAPSE_METRICS_ENABLED must default to false (opt-in)")
+	}
+	if config.MetricsAddr != "127.0.0.1:9090" {
+		t.Errorf("MetricsAddr default = %q, want 127.0.0.1:9090 (loopback-only)", config.MetricsAddr)
+	}
+	if !config.AccessLogEnabled {
+		t.Error("SYNAPSE_ACCESS_LOG_ENABLED must default to true")
+	}
+}
+
+func TestLoadObservabilityFromEnv(t *testing.T) {
+	t.Setenv("SYNAPSE_METRICS_ENABLED", "true")
+	t.Setenv("SYNAPSE_METRICS_ADDR", "0.0.0.0:9999")
+	t.Setenv("SYNAPSE_ACCESS_LOG_ENABLED", "false")
+	config := Load()
+	if !config.MetricsEnabled {
+		t.Error("SYNAPSE_METRICS_ENABLED=true must enable metrics")
+	}
+	if config.MetricsAddr != "0.0.0.0:9999" {
+		t.Errorf("MetricsAddr = %q, want 0.0.0.0:9999", config.MetricsAddr)
+	}
+	if config.AccessLogEnabled {
+		t.Error("SYNAPSE_ACCESS_LOG_ENABLED=false must disable access logging")
+	}
+}

--- a/internal/platform/httpserver/server.go
+++ b/internal/platform/httpserver/server.go
@@ -4,6 +4,7 @@ package httpserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -12,27 +13,51 @@ import (
 // Run starts the HTTP server and blocks until ctx is cancelled, then shuts down
 // gracefully within a 10s timeout.
 func Run(ctx context.Context, addr string, handler http.Handler, log *slog.Logger) error {
-	srv := &http.Server{
-		Addr:              addr,
-		Handler:           handler,
-		ReadHeaderTimeout: 10 * time.Second,
+	return RunPair(ctx, addr, handler, "", nil, log)
+}
+
+// RunPair serves the API and an optional metrics listener under one coordinated
+// lifecycle: either listener's failure cancels the shared context so the other
+// listener is joined via the same graceful shutdown, instead of leaking a goroutine.
+// metricsHandler nil means no metrics listener is started at all.
+func RunPair(ctx context.Context, apiAddr string, apiHandler http.Handler, metricsAddr string, metricsHandler http.Handler, log *slog.Logger) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	type namedServer struct {
+		name string
+		srv  *http.Server
+	}
+	servers := []namedServer{{name: "http server", srv: &http.Server{Addr: apiAddr, Handler: apiHandler, ReadHeaderTimeout: 10 * time.Second}}}
+	if metricsHandler != nil {
+		servers = append(servers, namedServer{name: "metrics server", srv: &http.Server{Addr: metricsAddr, Handler: metricsHandler, ReadHeaderTimeout: 10 * time.Second}})
 	}
 
-	errCh := make(chan error, 1)
-	go func() {
-		log.Info("http server listening", "addr", addr)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- err
-		}
-	}()
+	errCh := make(chan error, len(servers))
+	for _, ns := range servers {
+		ns := ns
+		go func() {
+			log.Info(ns.name+" listening", "addr", ns.srv.Addr)
+			if err := ns.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errCh <- fmt.Errorf("%s: %w", ns.name, err)
+			}
+		}()
+	}
 
+	var runErr error
 	select {
-	case err := <-errCh:
-		return err
+	case runErr = <-errCh:
+		cancel() // a listener failed: cancel so the sibling joins shutdown too
 	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		log.Info("http server shutting down")
-		return srv.Shutdown(shutdownCtx)
 	}
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	for _, ns := range servers {
+		log.Info(ns.name + " shutting down")
+		if err := ns.srv.Shutdown(shutdownCtx); err != nil && runErr == nil {
+			runErr = fmt.Errorf("%s shutdown: %w", ns.name, err)
+		}
+	}
+	return runErr
 }

--- a/internal/platform/httpserver/server_test.go
+++ b/internal/platform/httpserver/server_test.go
@@ -1,0 +1,144 @@
+package httpserver
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// freePort asks the OS for an unused loopback port so tests never collide on a fixed
+// address.
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := l.Addr().String()
+	l.Close()
+	return addr
+}
+
+// TestRunPairServesBothListeners covers the coordinated dual-listener lifecycle: with a
+// non-nil metrics handler, RunPair must actually serve BOTH the API and the metrics
+// endpoint, and both must shut down cleanly when ctx is cancelled.
+func TestRunPairServesBothListeners(t *testing.T) {
+	apiAddr := freePort(t)
+	metricsAddr := freePort(t)
+
+	apiHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	metricsHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("# metrics\n"))
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- RunPair(ctx, apiAddr, apiHandler, metricsAddr, metricsHandler, discardLog()) }()
+
+	waitForListener(t, apiAddr)
+	waitForListener(t, metricsAddr)
+
+	if resp, err := http.Get("http://" + apiAddr + "/"); err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("api listener not serving: err=%v resp=%v", err, resp)
+	}
+	resp, err := http.Get("http://" + metricsAddr + "/metrics")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("metrics listener not serving: err=%v resp=%v", err, resp)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("RunPair returned an error on graceful shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunPair did not return after context cancellation")
+	}
+}
+
+// TestRunPairMetricsFailureCancelsAPI covers coordinated failure: if the metrics
+// listener cannot bind (e.g. address in use), RunPair must cancel the shared context so
+// the API listener is also gracefully joined, rather than leaking a goroutine serving
+// forever with no supervisor.
+func TestRunPairMetricsFailureCancelsAPI(t *testing.T) {
+	apiAddr := freePort(t)
+	blocked, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve blocking port: %v", err)
+	}
+	defer blocked.Close()
+	takenAddr := blocked.Addr().String()
+
+	apiHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	metricsHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunPair(context.Background(), apiAddr, apiHandler, takenAddr, metricsHandler, discardLog())
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("want a bind error from the metrics listener, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunPair did not return after the metrics listener failed to bind")
+	}
+
+	// The API listener must not still be reachable after the coordinated shutdown.
+	time.Sleep(100 * time.Millisecond)
+	if conn, err := net.DialTimeout("tcp", apiAddr, 200*time.Millisecond); err == nil {
+		conn.Close()
+		t.Error("api listener should have been shut down when the metrics listener failed")
+	}
+}
+
+// TestRunNoMetricsListener covers the metrics-disabled default: Run (metricsHandler
+// nil via RunPair) must serve only the API listener and never attempt to bind a
+// metrics address.
+func TestRunNoMetricsListener(t *testing.T) {
+	apiAddr := freePort(t)
+	apiHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- Run(ctx, apiAddr, apiHandler, discardLog()) }()
+
+	waitForListener(t, apiAddr)
+	if resp, err := http.Get("http://" + apiAddr + "/"); err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("api listener not serving: err=%v resp=%v", err, resp)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run returned an error on graceful shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+func waitForListener(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("listener at %s did not come up in time", addr)
+}

--- a/internal/usecase/ports/jobqueue.go
+++ b/internal/usecase/ports/jobqueue.go
@@ -35,6 +35,20 @@ type JobStatusReader interface {
 	JobStatus(ctx context.Context, id string) (JobStatus, error)
 }
 
+// AggregateJobQueueStatsReader reads queue totals across all tenants for
+// operator-only telemetry. Implementations retain tenant isolation internally
+// (mirroring Claim's per-tenant RLS scoping) and never expose tenant labels.
+type AggregateJobQueueStatsReader interface {
+	AggregateJobQueueStats(ctx context.Context, kinds ...string) (JobStats, error)
+}
+
+// SCAObserver receives terminal SCA outcomes. Durations are recorded only for
+// completed synchronous or asynchronous scan execution, not queue/gate failures.
+type SCAObserver interface {
+	ObserveSCAOutcome(outcome string)
+	ObserveSCAScan(duration time.Duration, outcome string)
+}
+
 // JobQueue is a durable, at-least-once work queue with a visibility timeout.
 // It replaces the in-process jobs.Pool (which loses queued work on restart and
 // cannot reach a separate worker process). Claim hands a job to exactly one worker for

--- a/internal/usecase/sca/observability_test.go
+++ b/internal/usecase/sca/observability_test.go
@@ -1,0 +1,298 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type recordedSCAOutcome struct {
+	duration time.Duration
+	outcome  string
+}
+
+type fakeSCAObserver struct {
+	mu    sync.Mutex
+	calls []recordedSCAOutcome
+}
+
+type terminalSaveFailingJobStore struct {
+	*fakeJobStore
+	err error
+}
+
+func (s terminalSaveFailingJobStore) Save(ctx context.Context, job ports.ScanJob) error {
+	if job.Status == ports.ScanSucceeded || job.Status == ports.ScanFailed {
+		return s.err
+	}
+	return s.fakeJobStore.Save(ctx, job)
+}
+
+func (f *fakeSCAObserver) ObserveSCAOutcome(outcome string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, recordedSCAOutcome{outcome: outcome})
+}
+
+func (f *fakeSCAObserver) ObserveSCAScan(duration time.Duration, outcome string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, recordedSCAOutcome{duration: duration, outcome: outcome})
+}
+
+func (f *fakeSCAObserver) snapshot() []recordedSCAOutcome {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]recordedSCAOutcome(nil), f.calls...)
+}
+
+// TestScanObservesSuccessOutcome covers the synchronous path: a completed in-scope scan
+// records exactly one terminal "success" outcome.
+func TestScanObservesSuccessOutcome(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	acq := &fakeAcquirer{dir: "/tmp/ws"}
+	svc := newSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, acq, &fakeAudit{}, &fakeDetector{})
+	observer := &fakeSCAObserver{}
+	svc.SetObserver(observer)
+
+	if _, err := svc.Scan(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"}); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(observer.snapshot()) != 1 || observer.snapshot()[0].outcome != "success" {
+		t.Fatalf("observed calls = %+v, want exactly one success", observer.snapshot())
+	}
+}
+
+// TestScanObservesBlockedOnlyAfterGateForbidden covers that "blocked" is recorded ONLY
+// for an execution-gate denial (shared.ErrForbidden) reached after a genuine scan
+// attempt (past option normalization / SBOM-import loading) — never for a validation
+// failure, which is not a scan attempt.
+func TestScanObservesBlockedOnlyAfterGateForbidden(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "allowed")}
+	acq := &fakeAcquirer{dir: "/tmp/ws"}
+	svc := newSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, acq, &fakeAudit{}, &fakeDetector{})
+	observer := &fakeSCAObserver{}
+	svc.SetObserver(observer)
+
+	_, err := svc.Scan(context.Background(), "operator", "e1", ports.AcquireRequest{Value: "not-allowed"})
+	if !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("want ErrForbidden, got %v", err)
+	}
+	if len(observer.snapshot()) != 1 || observer.snapshot()[0].outcome != "blocked" {
+		t.Fatalf("observed calls = %+v, want exactly one blocked", observer.snapshot())
+	}
+}
+
+// TestScanValidationFailureNotObserved covers that a validation error (invalid scan
+// options, never reaching the execution gate) is not a scan attempt and must not emit
+// any terminal outcome — success, failed, or blocked.
+func TestScanValidationFailureNotObserved(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	svc := newSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{})
+	observer := &fakeSCAObserver{}
+	svc.SetObserver(observer)
+
+	if _, err := svc.ScanWithOptions(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: "not-a-real-mode"}); err == nil {
+		t.Fatal("want a validation error for an invalid scan mode")
+	}
+	if len(observer.snapshot()) != 0 {
+		t.Fatalf("a pre-gate validation failure must not be observed, got %+v", observer.snapshot())
+	}
+}
+
+// TestStartScanAsyncObservesSuccessAtExecution covers the async path: the async
+// duration is measured from EXECUTION (runScanJob's start), not from the original
+// StartScan/enqueue call, and the terminal outcome fires exactly once on completion.
+func TestStartScanAsyncObservesSuccessAtExecution(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	acq := &fakeAcquirer{dir: "/tmp/ws"}
+	jobs := newFakeJobStore()
+	svc := newAsyncSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, acq, &fakeAudit{}, &fakeDetector{}, jobs, fakeIDs{})
+	observer := &fakeSCAObserver{}
+	svc.SetObserver(observer)
+
+	job, err := svc.StartScan(shared.WithTenant(context.Background(), shared.DefaultTenant), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"})
+	if err != nil {
+		t.Fatalf("StartScan: %v", err)
+	}
+
+	var final ports.ScanJob
+	for i := 0; i < 400; i++ {
+		j, err := svc.LatestJob(context.Background(), "e1")
+		if err != nil {
+			t.Fatalf("LatestJob: %v", err)
+		}
+		final = j
+		if j.Status != ports.ScanRunning {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if final.Status != ports.ScanSucceeded {
+		t.Fatalf("final status = %q, want succeeded", final.Status)
+	}
+	if job.ID != final.ID {
+		t.Fatalf("job id mismatch: started %q, final %q", job.ID, final.ID)
+	}
+	if len(observer.snapshot()) != 1 || observer.snapshot()[0].outcome != "success" {
+		t.Fatalf("observed calls = %+v, want exactly one success", observer.snapshot())
+	}
+	if observer.snapshot()[0].duration < 0 {
+		t.Errorf("duration must not be negative, got %v", observer.snapshot()[0].duration)
+	}
+}
+
+// TestRunScanJobIdempotentSkipDoesNotDoubleObserve covers the idempotency guard:
+// runScanJob's terminal-state skip for an already-finished redelivery must not emit a
+// second terminal observation for the same job.
+func TestRunScanJobIdempotentSkipDoesNotDoubleObserve(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	jobs := newFakeJobStore()
+	svc := newAsyncSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{}, jobs, fakeIDs{})
+	observer := &fakeSCAObserver{}
+	svc.SetObserver(observer)
+
+	job := ports.ScanJob{ID: "job-1", EngagementID: "e1", Status: ports.ScanRunning, StartedAt: time.Unix(0, 0).UTC()}
+	if err := jobs.CreateRunning(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	ctx := shared.WithTenant(context.Background(), shared.DefaultTenant)
+
+	// First delivery runs the pipeline and finishes it (terminal).
+	svc.runScanJob(ctx, "operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull}, job)
+	if len(observer.snapshot()) != 1 {
+		t.Fatalf("first delivery: observed %d calls, want 1", len(observer.snapshot()))
+	}
+
+	// A redelivery of the SAME already-terminal job must be skipped by the idempotency
+	// guard (latest.ID == job.ID && terminal) and must NOT emit a second observation.
+	svc.runScanJob(ctx, "operator", "e1", time.Unix(0, 0).UTC(), ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeFull}, job)
+	if len(observer.snapshot()) != 1 {
+		t.Fatalf("redelivery of a terminal job must not double-observe, got %d calls", len(observer.snapshot()))
+	}
+}
+
+// TestRunScanJobReturnsTerminalSaveFailureWithoutObservation covers durable queue
+// retry behavior: the public worker entry point returns a final ScanJob save failure
+// and does not record a terminal outcome whose persistence was unsuccessful.
+func TestRunScanJobReturnsTerminalSaveFailureWithoutObservation(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	terminalSaveErr := errors.New("terminal scan job save unavailable")
+	jobs := newFakeJobStore()
+	svc := newAsyncSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{}, terminalSaveFailingJobStore{fakeJobStore: jobs, err: terminalSaveErr}, fakeIDs{})
+	observer := &fakeSCAObserver{}
+	svc.SetObserver(observer)
+
+	job := ports.ScanJob{ID: "job-1", EngagementID: "e1", Status: ports.ScanRunning, StartedAt: time.Unix(0, 0).UTC()}
+	if err := jobs.CreateRunning(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(scaJobPayload{
+		Actor: "operator", TenantID: strPtr(shared.DefaultTenant.String()), EngagementID: "e1",
+		Now: time.Unix(0, 0).UTC(), Req: ports.AcquireRequest{Kind: "local", Value: "myrepo"}, Options: ScanOptions{Mode: ScanModeFull}, Job: job,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = svc.RunScanJob(shared.WithTenant(context.Background(), shared.DefaultTenant), payload)
+	if !errors.Is(err, terminalSaveErr) {
+		t.Fatalf("RunScanJob error = %v, want terminal save error %v", err, terminalSaveErr)
+	}
+	if calls := observer.snapshot(); len(calls) != 0 {
+		t.Fatalf("terminal save failure must not observe an outcome or duration, got %+v", calls)
+	}
+	stored, err := jobs.LatestForEngagement(context.Background(), "e1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != ports.ScanRunning || stored.FinishedAt != nil {
+		t.Fatalf("terminal save failure must leave no terminal job state, got %+v", stored)
+	}
+}
+
+// TestFailStrandedScanJobObservesFailedOnce covers the dead-letter finalization path:
+// exactly one "failed" outcome for a job that never reached a terminal state, and no
+// observation at all when the job is already terminal (avoiding a double count with
+// whatever delivery already finished it).
+func TestFailStrandedScanJobObservesFailedOnce(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	jobs := newFakeJobStore()
+	svc := newAsyncSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{}, jobs, fakeIDs{})
+	observer := &fakeSCAObserver{}
+	svc.SetObserver(observer)
+
+	job := ports.ScanJob{ID: "job-1", EngagementID: "e1", Status: ports.ScanRunning, StartedAt: time.Unix(0, 0).UTC()}
+	if err := jobs.CreateRunning(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(scaJobPayload{
+		Actor: "operator", TenantID: strPtr(shared.DefaultTenant.String()), EngagementID: "e1",
+		Now: time.Unix(0, 0).UTC(), Req: ports.AcquireRequest{Kind: "local", Value: "myrepo"}, Options: ScanOptions{Mode: ScanModeFull}, Job: job,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := shared.WithTenant(context.Background(), shared.DefaultTenant)
+
+	if err := svc.FailStrandedScanJob(ctx, payload, errors.New("dead-lettered")); err != nil {
+		t.Fatalf("FailStrandedScanJob: %v", err)
+	}
+	if len(observer.snapshot()) != 1 || observer.snapshot()[0].outcome != "failed" {
+		t.Fatalf("observed calls = %+v, want exactly one failed", observer.snapshot())
+	}
+
+	// Calling it again on the now-terminal job must be a no-op (already terminal guard)
+	// and must not double-observe.
+	if err := svc.FailStrandedScanJob(ctx, payload, errors.New("dead-lettered again")); err != nil {
+		t.Fatalf("FailStrandedScanJob (idempotent): %v", err)
+	}
+	if len(observer.snapshot()) != 1 {
+		t.Fatalf("dead-lettering an already-terminal job must not double-observe, got %d calls", len(observer.snapshot()))
+	}
+}
+
+// TestStartScanEnqueueFailureObservesFailedOnce covers the enqueue-terminal-failure
+// path: when the durable queue rejects Enqueue, the job never reaches execution, and
+// this dead end must record exactly one "failed" outcome (not "blocked", not silence).
+func TestStartScanEnqueueFailureObservesFailedOnce(t *testing.T) {
+	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
+	jobs := newFakeJobStore()
+	svc := newAsyncSvc(repo, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{}, jobs, fakeIDs{})
+	observer := &fakeSCAObserver{}
+	svc.SetObserver(observer)
+	svc.SetQueue(&failingEnqueueQueue{})
+
+	_, err := svc.StartScan(shared.WithTenant(context.Background(), shared.DefaultTenant), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"})
+	if err == nil {
+		t.Fatal("want an enqueue error")
+	}
+	if len(observer.snapshot()) != 1 || observer.snapshot()[0].outcome != "failed" {
+		t.Fatalf("observed calls = %+v, want exactly one failed", observer.snapshot())
+	}
+}
+
+type failingEnqueueQueue struct{}
+
+func (failingEnqueueQueue) Enqueue(context.Context, string, []byte) (string, error) {
+	return "", errors.New("queue unavailable")
+}
+func (failingEnqueueQueue) Claim(context.Context, time.Duration, ...string) (*ports.QueuedJob, error) {
+	return nil, nil
+}
+func (failingEnqueueQueue) Heartbeat(context.Context, string, time.Duration) error { return nil }
+func (failingEnqueueQueue) Complete(context.Context, string) error                 { return nil }
+func (failingEnqueueQueue) Fail(context.Context, string, time.Duration) error      { return nil }
+func (failingEnqueueQueue) Deadletter(context.Context, string) error               { return nil }
+func (failingEnqueueQueue) Depth(context.Context, ...string) (int, error)          { return 0, nil }
+func (failingEnqueueQueue) Stats(context.Context, ...string) (ports.JobStats, error) {
+	return ports.JobStats{}, nil
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/usecase/sca/observability_test.go
+++ b/internal/usecase/sca/observability_test.go
@@ -178,10 +178,15 @@ func TestRunScanJobIdempotentSkipDoesNotDoubleObserve(t *testing.T) {
 	}
 }
 
-// TestRunScanJobReturnsTerminalSaveFailureWithoutObservation covers durable queue
-// retry behavior: the public worker entry point returns a final ScanJob save failure
-// and does not record a terminal outcome whose persistence was unsuccessful.
-func TestRunScanJobReturnsTerminalSaveFailureWithoutObservation(t *testing.T) {
+// TestRunScanJobDoesNotRedeliverOnTerminalSaveFailure covers a double-seal hazard: if
+// the terminal ScanJob Save fails, the scan already executed but the job is left
+// stranded at Status=Running (not terminal). Returning that Save error would make the
+// durable queue redeliver the job; runScanJob's idempotency guard only skips a
+// redelivery when the latest job is already terminal, so redelivery here would re-run
+// the pipeline and seal a DUPLICATE "scan" evidence link plus a phantom ScanRun row.
+// RunScanJob must therefore return nil (no redelivery) and must not observe any
+// terminal outcome — SweepStaleScans alone finalizes the stranded job and counts it.
+func TestRunScanJobDoesNotRedeliverOnTerminalSaveFailure(t *testing.T) {
 	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
 	terminalSaveErr := errors.New("terminal scan job save unavailable")
 	jobs := newFakeJobStore()
@@ -202,8 +207,8 @@ func TestRunScanJobReturnsTerminalSaveFailureWithoutObservation(t *testing.T) {
 	}
 
 	err = svc.RunScanJob(shared.WithTenant(context.Background(), shared.DefaultTenant), payload)
-	if !errors.Is(err, terminalSaveErr) {
-		t.Fatalf("RunScanJob error = %v, want terminal save error %v", err, terminalSaveErr)
+	if err != nil {
+		t.Fatalf("RunScanJob error = %v, want nil so the durable queue does not redeliver", err)
 	}
 	if calls := observer.snapshot(); len(calls) != 0 {
 		t.Fatalf("terminal save failure must not observe an outcome or duration, got %+v", calls)
@@ -213,7 +218,7 @@ func TestRunScanJobReturnsTerminalSaveFailureWithoutObservation(t *testing.T) {
 		t.Fatal(err)
 	}
 	if stored.Status != ports.ScanRunning || stored.FinishedAt != nil {
-		t.Fatalf("terminal save failure must leave no terminal job state, got %+v", stored)
+		t.Fatalf("terminal save failure must leave the job stranded (running, not terminal) for SweepStaleScans, got %+v", stored)
 	}
 }
 

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -1349,7 +1349,7 @@ func (s *Service) ScanWithOptions(ctx context.Context, actor string, engagementI
 	} else if ok {
 		now, err := s.gateImportedSBOMAndAudit(ctx, actor, engagementID, imported, opts)
 		if err != nil {
-			s.observeGateOutcome(started, err)
+			s.observeGateOutcome(err)
 			return nil, err
 		}
 		result, err := s.runImportedSBOMPipeline(ctx, actor, engagementID, now, imported, doc, opts, func(string, int, []ports.ScanDebugEvent) {})
@@ -1358,7 +1358,7 @@ func (s *Service) ScanWithOptions(ctx context.Context, actor string, engagementI
 	}
 	now, err := s.gateAndAudit(ctx, actor, engagementID, req, opts)
 	if err != nil {
-		s.observeGateOutcome(started, err)
+		s.observeGateOutcome(err)
 		return nil, err
 	}
 	result, err := s.runPipeline(ctx, actor, engagementID, now, req, opts, func(string, int, []ports.ScanDebugEvent) {})
@@ -1383,7 +1383,6 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 		return ports.ScanJob{}, err
 	}
 	req = normalizeLocalTarget(req)
-	started := s.clock.Now()
 	var imported importedsbom.Record
 	var importedDoc *sbom.SBOM
 	var useImported bool
@@ -1397,7 +1396,7 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 		now, err = s.gateAndAudit(ctx, actor, engagementID, req, opts)
 	}
 	if err != nil {
-		s.observeGateOutcome(started, err)
+		s.observeGateOutcome(err)
 		return ports.ScanJob{}, err
 	}
 	target := req.Value
@@ -1498,7 +1497,7 @@ func (s *Service) observeOutcome(outcome string) {
 // (shared.ErrForbidden) reached AFTER a genuine scan attempt (past option
 // normalization and SBOM-import loading). A validation failure (malformed
 // options, unconfigured guard) is not a scan attempt and is never observed here.
-func (s *Service) observeGateOutcome(started time.Time, err error) {
+func (s *Service) observeGateOutcome(err error) {
 	if errors.Is(err, shared.ErrForbidden) {
 		s.observeOutcome("blocked")
 	}
@@ -1835,7 +1834,16 @@ func (s *Service) runScanJob(ctx context.Context, actor string, engagementID sha
 		// Detached from ctx so the record still lands when the completion timeout above has fired.
 		// (ScanJobStore.Save is not tenant-scoped; the tenant matters at the recorder call, not here.)
 		if saveErr := s.jobs.Save(context.WithoutCancel(ctx), job); saveErr != nil {
-			return saveErr
+			// Do NOT return saveErr here: the durable queue treats a non-nil error as
+			// redeliverable, but the scan already executed. The job is left stranded at
+			// Status=Running (not terminal), so runScanJob's idempotency guard above would
+			// NOT skip a redelivery – it would re-run the pipeline and seal a DUPLICATE "scan"
+			// evidence link plus a phantom ScanRun row, violating the append-only evidence
+			// chain. SweepStaleScans is the single component that finalizes a stranded running
+			// job, so it alone counts the eventual "failed" outcome; observing here too would
+			// double-count. Log and swallow instead.
+			s.logger().Error("terminal scan job save failed; job left stranded for SweepStaleScans to finalize", "job_id", job.ID, "err", saveErr)
+			return nil
 		}
 	}
 	s.observeSyncTerminal(execStarted, err)

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -53,8 +53,9 @@ type Service struct {
 	runs                             ports.ScanRunStore
 	evidence                         *evidenceuc.Service
 	ids                              ports.IDGenerator
-	jobQueue                         ports.JobQueue  // optional; when set, StartScan defers to the durable queue
-	runLock                          ports.RunLocker // optional; guards single active execution per scan job
+	jobQueue                         ports.JobQueue    // optional; when set, StartScan defers to the durable queue
+	runLock                          ports.RunLocker   // optional; guards single active execution per scan job
+	observer                         ports.SCAObserver // optional; observes terminal scan outcomes for metrics
 	prov                             ports.Provenance
 	clock                            ports.Clock
 	audit                            ports.AuditLogger
@@ -1342,20 +1343,27 @@ func (s *Service) ScanWithOptions(ctx context.Context, actor string, engagementI
 		ctx, cancel = context.WithTimeout(ctx, s.timeout)
 		defer cancel()
 	}
+	started := s.clock.Now()
 	if imported, doc, ok, err := s.loadImportedSBOM(ctx, engagementID, opts); err != nil {
 		return nil, err
 	} else if ok {
 		now, err := s.gateImportedSBOMAndAudit(ctx, actor, engagementID, imported, opts)
 		if err != nil {
+			s.observeGateOutcome(started, err)
 			return nil, err
 		}
-		return s.runImportedSBOMPipeline(ctx, actor, engagementID, now, imported, doc, opts, func(string, int, []ports.ScanDebugEvent) {})
+		result, err := s.runImportedSBOMPipeline(ctx, actor, engagementID, now, imported, doc, opts, func(string, int, []ports.ScanDebugEvent) {})
+		s.observeSyncTerminal(started, err)
+		return result, err
 	}
 	now, err := s.gateAndAudit(ctx, actor, engagementID, req, opts)
 	if err != nil {
+		s.observeGateOutcome(started, err)
 		return nil, err
 	}
-	return s.runPipeline(ctx, actor, engagementID, now, req, opts, func(string, int, []ports.ScanDebugEvent) {})
+	result, err := s.runPipeline(ctx, actor, engagementID, now, req, opts, func(string, int, []ports.ScanDebugEvent) {})
+	s.observeSyncTerminal(started, err)
+	return result, err
 }
 
 // StartScan gates + audits the scan, then runs the pipeline ASYNCHRONOUSLY
@@ -1375,6 +1383,7 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 		return ports.ScanJob{}, err
 	}
 	req = normalizeLocalTarget(req)
+	started := s.clock.Now()
 	var imported importedsbom.Record
 	var importedDoc *sbom.SBOM
 	var useImported bool
@@ -1388,6 +1397,7 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 		now, err = s.gateAndAudit(ctx, actor, engagementID, req, opts)
 	}
 	if err != nil {
+		s.observeGateOutcome(started, err)
 		return ports.ScanJob{}, err
 	}
 	target := req.Value
@@ -1429,6 +1439,9 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 			fin := s.clock.Now()
 			job.Status, job.Stage, job.Error, job.FinishedAt = ports.ScanFailed, "enqueue", truncateErr(err), &fin
 			_ = s.jobs.Save(context.WithoutCancel(ctx), job)
+			// Terminal: the job never reaches execution, so it dead-ends here rather than
+			// double-counting when a worker later (never) runs it.
+			s.observeOutcome("failed")
 			return ports.ScanJob{}, fmt.Errorf("enqueue scan job: %w", err)
 		}
 		return job, nil
@@ -1463,6 +1476,44 @@ func (s *Service) SetQueue(q ports.JobQueue) { s.jobQueue = q }
 // at-least-once queue redelivery.
 func (s *Service) SetRunLock(l ports.RunLocker) { s.runLock = l }
 
+// SetObserver installs an optional terminal SCA execution observer (duration +
+// success/failed/blocked outcome). Nil disables observation.
+func (s *Service) SetObserver(observer ports.SCAObserver) { s.observer = observer }
+
+// observeTerminal records one terminal SCA execution outcome with its duration when
+// an observer is configured; a no-op otherwise.
+func (s *Service) observeTerminal(started time.Time, outcome string) {
+	if s.observer != nil {
+		s.observer.ObserveSCAScan(s.clock.Now().Sub(started), outcome)
+	}
+}
+
+func (s *Service) observeOutcome(outcome string) {
+	if s.observer != nil {
+		s.observer.ObserveSCAOutcome(outcome)
+	}
+}
+
+// observeGateOutcome records "blocked" only for an execution-gate denial
+// (shared.ErrForbidden) reached AFTER a genuine scan attempt (past option
+// normalization and SBOM-import loading). A validation failure (malformed
+// options, unconfigured guard) is not a scan attempt and is never observed here.
+func (s *Service) observeGateOutcome(started time.Time, err error) {
+	if errors.Is(err, shared.ErrForbidden) {
+		s.observeOutcome("blocked")
+	}
+}
+
+// observeSyncTerminal records the synchronous pipeline's terminal outcome
+// (success/failed) after the execution gate has already passed.
+func (s *Service) observeSyncTerminal(started time.Time, err error) {
+	if err != nil {
+		s.observeTerminal(started, "failed")
+		return
+	}
+	s.observeTerminal(started, "success")
+}
+
 // RunScanJob runs an SCA scan claimed from the durable queue (the worker handler calls
 // this). A malformed payload is a hard error (dead-letters); pipeline failures are
 // recorded on the ScanJob (not a job error), so the job completes.
@@ -1492,8 +1543,7 @@ func (s *Service) RunScanJob(ctx context.Context, payload []byte) error {
 	if err != nil {
 		return err
 	}
-	s.runScanJob(ctx, p.Actor, shared.ID(p.EngagementID), p.Now, p.Req, opts, p.Job)
-	return nil
+	return s.runScanJob(ctx, p.Actor, shared.ID(p.EngagementID), p.Now, p.Req, opts, p.Job)
 }
 
 // FailStrandedScanJob marks the scan job behind a DEAD-LETTERED sca job failed if it has not
@@ -1542,7 +1592,14 @@ func (s *Service) FailStrandedScanJob(ctx context.Context, payload []byte, cause
 	fin := s.clock.Now()
 	job.FinishedAt, job.Progress = &fin, 100
 	job.Status, job.Stage, job.Error = ports.ScanFailed, "dead-letter", truncateErr(cause)
-	return s.jobs.Save(ctx, job)
+	if err := s.jobs.Save(ctx, job); err != nil {
+		return err
+	}
+	// This is the ONE place dead-letter finalization observes a terminal outcome; the
+	// terminal guard above (already-terminal jobs return early) keeps it from double-
+	// counting a scan runScanJob already finished.
+	s.observeOutcome("failed")
+	return nil
 }
 
 // SweepStaleScans reclaims scan jobs a crashed worker left `running` past staleFor WITHOUT a
@@ -1573,8 +1630,12 @@ func (s *Service) SweepStaleScans(ctx context.Context, staleFor time.Duration) (
 		fin := s.clock.Now()
 		job.FinishedAt, job.Progress = &fin, 100
 		job.Status, job.Stage, job.Error = ports.ScanFailed, "swept", "scan stranded running past staleFor with no live owner – reclaimed by sweeper"
-		_ = s.jobs.Save(ctx, job)
+		if err := s.jobs.Save(ctx, job); err != nil {
+			release()
+			return n, fmt.Errorf("save swept scan job %s: %w", job.ID, err)
+		}
 		release()
+		s.observeOutcome("failed")
 		n++
 	}
 	return n, nil
@@ -1709,7 +1770,7 @@ func looksLikePath(v string) bool {
 
 // runScanJob runs the pipeline on a detached background context (the request that
 // started the scan has returned), advancing + finishing the job.
-func (s *Service) runScanJob(ctx context.Context, actor string, engagementID shared.ID, now time.Time, req ports.AcquireRequest, opts ScanOptions, job ports.ScanJob) {
+func (s *Service) runScanJob(ctx context.Context, actor string, engagementID shared.ID, now time.Time, req ports.AcquireRequest, opts ScanOptions, job ports.ScanJob) error {
 	// Idempotency (audit): the durable queue is at-least-once, so a redelivery can
 	// re-invoke a scan a prior delivery already finished. Re-running is read-only (findings
 	// dedup by advisory+component+version) but would seal a DUPLICATE "scan" evidence link
@@ -1719,12 +1780,15 @@ func (s *Service) runScanJob(ctx context.Context, actor string, engagementID sha
 	if s.jobs != nil {
 		if latest, err := s.jobs.LatestForEngagement(ctx, engagementID); err == nil &&
 			latest.ID == job.ID && (latest.Status == ports.ScanSucceeded || latest.Status == ports.ScanFailed) {
-			return
+			return nil
 		}
 	}
 	if opts.ProjectAnalysis {
 		opts.ProjectAnalysisID = job.ID
 	}
+	// Async duration is measured from EXECUTION (this claim/delivery), not from the
+	// original enqueue time (job.StartedAt) – the queue wait is not scan work.
+	execStarted := s.clock.Now()
 	if s.timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, s.timeout)
@@ -1770,8 +1834,12 @@ func (s *Service) runScanJob(ctx context.Context, actor string, engagementID sha
 	if s.jobs != nil {
 		// Detached from ctx so the record still lands when the completion timeout above has fired.
 		// (ScanJobStore.Save is not tenant-scoped; the tenant matters at the recorder call, not here.)
-		_ = s.jobs.Save(context.WithoutCancel(ctx), job)
+		if saveErr := s.jobs.Save(context.WithoutCancel(ctx), job); saveErr != nil {
+			return saveErr
+		}
 	}
+	s.observeSyncTerminal(execStarted, err)
+	return nil
 }
 
 // runPipeline is the read-only tool chain (acquire -> detect -> SBOM -> vulns ->


### PR DESCRIPTION
## Summary

- add an opt-in, separate Prometheus metrics listener with HTTP RED, aggregate durable-job queue, and SCA scan metrics
- add structured HTTP access logging with server-generated request IDs, bounded route/method fields, principal correlation, and streaming-safe response recording
- coordinate API and metrics listener shutdown and make publication mirror drift checks line-ending-neutral on Windows

## Security and privacy

- metrics use a private registry and bounded labels; no tenant, target, raw path, query, headers, body, or error text is exported
- PostgreSQL queue aggregates preserve forced tenant RLS and expose no tenant labels
- the unauthenticated metrics listener is disabled by default and bound to `127.0.0.1:9090` by default; deployment docs require loopback or a private scrape network
- access logs never record bearer tokens or request bodies

## Verification

- `go build ./...`
- `go vet ./...`
- `make test`
- focused race tests for HTTP observability, Prometheus collectors, and SCA lifecycle
- `make typecheck`
- `cd web && pnpm build`
- runtime smoke test of API, `/metrics`, request IDs, and token non-disclosure
- Go architecture and security reviews with focused confirmation passes

Closes #584
Closes #586