### PR TITLE
fix(httpapi,postgres): harden readiness concurrency and telemetry gap keying

### DIFF
--- a/internal/adapter/httpapi/readiness.go
+++ b/internal/adapter/httpapi/readiness.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -14,6 +15,7 @@ const defaultReadinessTimeout = 2 * time.Second
 type ReadinessCheck func(context.Context) error
 
 type readinessConfig struct {
+	mu      sync.RWMutex
 	checks  map[string]ReadinessCheck
 	timeout time.Duration
 }
@@ -25,7 +27,10 @@ type readinessResponse struct {
 
 // SetReadinessChecks replaces the dependency checks used by GET /readyz. It copies the map so
 // startup wiring cannot mutate the live probe configuration after the server begins serving.
+// Protected by write-lock against concurrent probe execution (race safety).
 func (rt *Router) SetReadinessChecks(checks map[string]ReadinessCheck) {
+	rt.readiness.mu.Lock()
+	defer rt.readiness.mu.Unlock()
 	rt.readiness.checks = make(map[string]ReadinessCheck, len(checks))
 	for name, check := range checks {
 		if name = strings.TrimSpace(name); name != "" && check != nil {
@@ -35,7 +40,14 @@ func (rt *Router) SetReadinessChecks(checks map[string]ReadinessCheck) {
 }
 
 func (rt *Router) ready(w http.ResponseWriter, r *http.Request) {
-	checks := rt.readiness.checks
+	rt.readiness.mu.RLock()
+	checks := make(map[string]ReadinessCheck, len(rt.readiness.checks))
+	for k, v := range rt.readiness.checks {
+		checks[k] = v
+	}
+	timeout := rt.readiness.timeout
+	rt.readiness.mu.RUnlock()
+
 	states := make(map[string]string, len(checks))
 	w.Header().Set("Cache-Control", "no-store")
 	if len(checks) == 0 {
@@ -43,7 +55,6 @@ func (rt *Router) ready(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	timeout := rt.readiness.timeout
 	if timeout <= 0 {
 		timeout = defaultReadinessTimeout
 	}

--- a/internal/adapter/httpapi/readiness_test.go
+++ b/internal/adapter/httpapi/readiness_test.go
@@ -160,4 +160,3 @@ func TestReadinessSetChecksConcurrentRace(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
-

--- a/internal/adapter/httpapi/readiness_test.go
+++ b/internal/adapter/httpapi/readiness_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -116,3 +117,47 @@ func TestHealthzRemainsConstantLivenessProbe(t *testing.T) {
 		t.Fatalf("liveness changed: code=%d called=%v body=%q", recorder.Code, called, recorder.Body.String())
 	}
 }
+
+func TestReadinessSetChecksConcurrentRace(t *testing.T) {
+	rt := &Router{}
+	rt.readiness.timeout = 50 * time.Millisecond
+	rt.SetReadinessChecks(map[string]ReadinessCheck{
+		"database": func(context.Context) error { return nil },
+	})
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Goroutine 1: concurrently query the readiness probe.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				recorder := httptest.NewRecorder()
+				rt.routes().ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+			}
+		}
+	}()
+
+	// Goroutine 2: concurrently update readiness checks (e.g., dynamic dependency lifecycle).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			rt.SetReadinessChecks(map[string]ReadinessCheck{
+				"database": func(context.Context) error { return nil },
+				"cache":    func(context.Context) error { return nil },
+			})
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	time.Sleep(120 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+

--- a/internal/infrastructure/persistence/postgres/telemetry_gaps_test.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_gaps_test.go
@@ -1,0 +1,88 @@
+package postgres
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestTelemetryGapsCalculation(t *testing.T) {
+	input := map[telemetryKey][]uint64{
+		{host: "host-1", class: detection.ClassProcess}: {1, 2, 5, 8, 8, 2}, // duplicates & out of order: 1, 2, 5, 8 -> gaps: 2..5 (missing 2), 5..8 (missing 2)
+		{host: "host-2", class: detection.ClassNetwork}: {10, 11, 12},       // contiguous -> no gaps
+		{host: "host-3", class: detection.ClassFile}:    {1, 4},              // gap: 1..4 (missing 2)
+	}
+
+	gaps := telemetryGaps(input)
+
+	// Verify all expected gaps are discovered
+	expected := []ports.TelemetrySequenceGap{
+		{HostID: "host-1", Class: detection.ClassProcess, Missing: 2, LastSeen: 2, Incoming: 5},
+		{HostID: "host-3", Class: detection.ClassFile, Missing: 2, LastSeen: 1, Incoming: 4},
+		{HostID: "host-1", Class: detection.ClassProcess, Missing: 2, LastSeen: 5, Incoming: 8},
+	}
+
+	// Gaps should be sorted by LastSeen
+	for i := 1; i < len(gaps); i++ {
+		if gaps[i].LastSeen < gaps[i-1].LastSeen {
+			t.Errorf("gaps not sorted by LastSeen: at %d got %d < %d", i, gaps[i].LastSeen, gaps[i-1].LastSeen)
+		}
+	}
+
+	// Check total gap count
+	if len(gaps) != len(expected) {
+		t.Fatalf("got %d gaps, want %d: %+v", len(gaps), len(expected), gaps)
+	}
+
+	// Check contiguous stream has no gap
+	for _, g := range gaps {
+		if g.HostID == "host-2" {
+			t.Errorf("host-2 has contiguous sequences, should have no gaps: %+v", g)
+		}
+	}
+}
+
+func TestDedupSorted(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []uint64
+		want []uint64
+	}{
+		{"empty", nil, nil},
+		{"single", []uint64{5}, []uint64{5}},
+		{"already sorted no dups", []uint64{1, 2, 3}, []uint64{1, 2, 3}},
+		{"duplicates and unordered", []uint64{4, 2, 4, 1, 2, 3}, []uint64{1, 2, 3, 4}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dedupSorted(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("dedupSorted(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTelemetryKeyDistinctClassSameHost(t *testing.T) {
+	// Distinct classes on the same host must be isolated in different map buckets
+	k1 := telemetryKey{host: shared.ID("host-a"), class: detection.ClassProcess}
+	k2 := telemetryKey{host: shared.ID("host-a"), class: detection.ClassNetwork}
+	if k1 == k2 {
+		t.Fatalf("keys with different classes on same host must not equal")
+	}
+
+	m := map[telemetryKey][]uint64{
+		k1: {1, 2, 3},
+		k2: {1, 4},
+	}
+	gaps := telemetryGaps(m)
+	if len(gaps) != 1 {
+		t.Fatalf("expected exactly 1 gap from k2, got %d: %+v", len(gaps), gaps)
+	}
+	if gaps[0].HostID != "host-a" || gaps[0].Class != detection.ClassNetwork || gaps[0].Missing != 2 {
+		t.Errorf("unexpected gap: %+v", gaps[0])
+	}
+}

--- a/internal/infrastructure/persistence/postgres/telemetry_gaps_test.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_gaps_test.go
@@ -13,7 +13,7 @@ func TestTelemetryGapsCalculation(t *testing.T) {
 	input := map[telemetryKey][]uint64{
 		{host: "host-1", class: detection.ClassProcess}: {1, 2, 5, 8, 8, 2}, // duplicates & out of order: 1, 2, 5, 8 -> gaps: 2..5 (missing 2), 5..8 (missing 2)
 		{host: "host-2", class: detection.ClassNetwork}: {10, 11, 12},       // contiguous -> no gaps
-		{host: "host-3", class: detection.ClassFile}:    {1, 4},              // gap: 1..4 (missing 2)
+		{host: "host-3", class: detection.ClassFile}:    {1, 4},             // gap: 1..4 (missing 2)
 	}
 
 	gaps := telemetryGaps(input)

--- a/internal/infrastructure/persistence/postgres/telemetry_repo.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_repo.go
@@ -135,7 +135,7 @@ func (r *TelemetryRepository) Query(ctx context.Context, q ports.HuntQuery) (por
 	}
 
 	res := ports.HuntResult{MaxSampleRate: 1}
-	seqsByHostClass := map[string][]uint64{}
+	seqsByHostClass := map[telemetryKey][]uint64{}
 	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
 		// 1. The (bounded) event rows.
 		rows, err := tx.Query(ctx, `SELECT event FROM telemetry_events WHERE `+where+` ORDER BY observed_at ASC LIMIT `+fmt.Sprint(rowCap), args...)
@@ -172,7 +172,8 @@ func (r *TelemetryRepository) Query(ctx context.Context, q ports.HuntQuery) (por
 			if err := seqRows.Scan(&host, &class, &seq); err != nil {
 				return err
 			}
-			seqsByHostClass[host+"\x00"+class] = append(seqsByHostClass[host+"\x00"+class], uint64(seq))
+			k := telemetryKey{host: shared.ID(host), class: detection.Class(class)}
+			seqsByHostClass[k] = append(seqsByHostClass[k], uint64(seq))
 		}
 		if err := seqRows.Err(); err != nil {
 			return err
@@ -283,15 +284,20 @@ func (r *TelemetryRepository) Footprint(ctx context.Context) (ports.TelemetryFoo
 	return fp, nil
 }
 
-func telemetryGaps(seqsByHostClass map[string][]uint64) []ports.TelemetrySequenceGap {
+// telemetryKey uniquely identifies a (host, class) stream for grouping sequences in hunt queries.
+type telemetryKey struct {
+	host  shared.ID
+	class detection.Class
+}
+
+func telemetryGaps(seqsByHostClass map[telemetryKey][]uint64) []ports.TelemetrySequenceGap {
 	var gaps []ports.TelemetrySequenceGap
 	for k, seqs := range seqsByHostClass {
 		uniq := dedupSorted(seqs)
-		host, class := splitTelemetryKey(k)
 		for i := 1; i < len(uniq); i++ {
 			if uniq[i] > uniq[i-1]+1 {
 				gaps = append(gaps, ports.TelemetrySequenceGap{
-					HostID: host, Class: class, Missing: uniq[i] - uniq[i-1] - 1, LastSeen: uniq[i-1], Incoming: uniq[i],
+					HostID: k.host, Class: k.class, Missing: uniq[i] - uniq[i-1] - 1, LastSeen: uniq[i-1], Incoming: uniq[i],
 				})
 			}
 		}
@@ -312,13 +318,4 @@ func dedupSorted(in []uint64) []uint64 {
 		}
 	}
 	return out
-}
-
-func splitTelemetryKey(k string) (shared.ID, detection.Class) {
-	for i := 0; i < len(k); i++ {
-		if k[i] == 0 {
-			return shared.ID(k[:i]), detection.Class(k[i+1:])
-		}
-	}
-	return shared.ID(k), ""
 }


### PR DESCRIPTION
### Summary

This PR introduces two clean, self-contained robustness improvements:

1. **`httpapi` Concurrency Safety**: Protects `Router.readiness.checks` map with a `sync.RWMutex`. `SetReadinessChecks` takes a write lock while `ready()` snapshots the configuration under a brief read lock before dispatching probe checks concurrently outside the critical section.
2. **`postgres/telemetry_repo` Typed Composite Key**: Replaces the string concatenation delimiter pattern (`host + "\x00" + class`) with a typed `telemetryKey` struct for grouping sequence streams during retro-hunt queries. This eliminates unnecessary per-row string allocations and removes `splitTelemetryKey`.

### Changes

- `internal/adapter/httpapi/readiness.go`: add `sync.RWMutex` to `readinessConfig`, guard `SetReadinessChecks` (write lock) and `ready()` (read lock snapshot).
- `internal/adapter/httpapi/readiness_test.go`: add `TestReadinessSetChecksConcurrentRace`.
- `internal/infrastructure/persistence/postgres/telemetry_repo.go`: define `telemetryKey struct`, update `Query` and `telemetryGaps` to use struct keys in map, remove `splitTelemetryKey`.
- `internal/infrastructure/persistence/postgres/telemetry_gaps_test.go`: add unit tests for `telemetryGaps`, `dedupSorted`, and multi-class key isolation.

### Verification

- Unit tests pass with `-count=1`
- Full repository build succeeds (`go build ./...`)
