### PR TITLE
fix: gate migrations and production sandbox startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,9 @@ SYNAPSE_DB_DSN=postgres://localhost:5432/synapse?sslmode=disable
 # Optional owner-level DSN used only for embedded migrations; keeps the runtime
 # identity least-privileged. Empty falls back to SYNAPSE_DB_DSN.
 # SYNAPSE_DB_MIGRATION_DSN=
+# Set false in production: synapse-migrate owns migrations. API exposes /readyz;
+# worker and MCP refuse startup until migrations are current.
+SYNAPSE_DB_AUTO_MIGRATE=true
 
 # =============================================================================
 # Evidence blob store – MinIO / S3 (empty endpoint ⇒ in-memory dev store)
@@ -175,8 +178,8 @@ SYNAPSE_SCAN_CACHE_ENABLED=true
 # =============================================================================
 # Recon & execution sandbox  (sandbox is REQUIRED in production)
 # =============================================================================
-# Run tool execution + acquisition in the bubblewrap sandbox. If set but
-# bubblewrap is unavailable, startup FAILS CLOSED (never runs unsandboxed).
+# Run tool execution + acquisition in the bubblewrap sandbox. Production requires
+# this to be true; if bubblewrap is unavailable, startup FAILS CLOSED.
 SYNAPSE_SANDBOX_ENABLED=false
 # Per-run cgroup limits (bytes / pid count).
 # SYNAPSE_SANDBOX_MEM_MAX=536870912    # 512 MiB

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,10 @@ goose**. Two rules avoid the duplicate-version startup crash goose raises on col
   the later one rebases and renumbers. goose keys on the leading integer, so a duplicate is a
   hard startup panic, not a git merge conflict (the filenames differ), and a clean merge will not
   catch it.
+- **Use backward-compatible, phased schema changes.** Production rollouts migrate first, then
+  deploy application binaries. During that overlap an older API may serve only a database whose
+  additional migration versions are applied and strictly newer than its embedded maximum; it must
+  not depend on columns or constraints removed by the migration.
 - **Add a Postgres integration test** (`migration_00NN_test.go`) that calls `postgres.Migrate`,
   so a broken or duplicate version is caught locally.
 

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -220,22 +220,6 @@ func metricsAddrIsLoopback(addr string) bool {
 	return ip.IsLoopback()
 }
 
-func migrationDSNForStartup(cfg config.Config) (string, error) {
-	migrationDSN := cfg.DBMigrationDSN
-	if migrationDSN == "" {
-		if cfg.IsProduction() {
-			return "", fmt.Errorf("SYNAPSE_DB_MIGRATION_DSN is required with SYNAPSE_DB_DSN outside development")
-		}
-		return cfg.DBDSN, nil
-	}
-	if cfg.IsProduction() {
-		if err := postgres.ValidateMigrationRoleSeparation(migrationDSN, cfg.DBDSN); err != nil {
-			return "", fmt.Errorf("validate migration and runtime database roles: %w", err)
-		}
-	}
-	return migrationDSN, nil
-}
-
 func main() {
 	cfg := config.Load()
 	if cfg.CSPMEnabled && !cfg.FleetAssetsEnabled {
@@ -248,6 +232,14 @@ func main() {
 	}
 	log := logging.New(cfg.LogLevel)
 	log.Info("starting synapse-api", "env", cfg.Environment, "single_tenant", cfg.SingleTenant)
+	if err := cfg.ValidateSandboxPosture(); err != nil {
+		log.Error("sandbox posture invalid", "err", err)
+		os.Exit(1)
+	}
+	if err := cfg.ValidateMigrationPosture(); err != nil {
+		log.Error("database migration posture invalid", "err", err)
+		os.Exit(1)
+	}
 
 	// Fail closed: no anonymous access. The token is never logged.
 	if cfg.APIToken == "" {
@@ -358,25 +350,25 @@ func main() {
 	}()
 
 	if cfg.DBDSN != "" {
-		// Bounded so a migration that blocks can't hang boot forever. NOTE: no
-		// advisory lock yet – run a single instance (or a one-shot migrate job)
-		// until multi-replica horizontal scaling lands (P5).
+		// Bounded so a contended migration lock cannot hang boot forever.
 		startup, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
-		migrationDSN, err := migrationDSNForStartup(cfg)
-		if err != nil {
-			log.Error("database migration configuration invalid", "err", err)
-			os.Exit(1)
-		}
-		if err := postgres.Migrate(startup, migrationDSN); err != nil {
-			log.Error("db migrate failed", "err", err)
-			os.Exit(1)
-		}
-		if migrationDSN != cfg.DBDSN {
-			if err := postgres.GrantRuntimePrivileges(startup, migrationDSN, cfg.DBDSN); err != nil {
-				log.Error("db runtime role grant failed", "err", err)
+		if cfg.DBAutoMigrate {
+			migrationDSN := cfg.MigrationDSN()
+			migrationStarted := time.Now()
+			if err := postgres.MigrateLocked(startup, migrationDSN); err != nil {
+				log.Error("db migrate failed", "err", err)
 				os.Exit(1)
 			}
+			log.Info("db migrations complete", "duration", time.Since(migrationStarted))
+			if migrationDSN != cfg.DBDSN {
+				if err := postgres.GrantRuntimePrivileges(startup, migrationDSN, cfg.DBDSN); err != nil {
+					log.Error("db runtime role grant failed", "err", err)
+					os.Exit(1)
+				}
+			}
+		} else {
+			log.Info("db auto-migration disabled; readiness requires current migrations")
 		}
 		pool, err := postgres.ConnectPool(startup, cfg.DBDSN, postgres.PoolConfig{
 			MaxConns: int32(cfg.DBMaxConns), MinConns: int32(cfg.DBMinConns),
@@ -738,10 +730,6 @@ func main() {
 		} else {
 			log.Info("acquisition (git/image) runs sandboxed (host-net; kernel egress scoping unavailable here)")
 		}
-	} else if cfg.IsProduction() {
-		// Production must not ship with zero containment (re-audit: the flag defaults off).
-		log.Error("SYNAPSE_SANDBOX_ENABLED is required in production (tool execution + acquisition containment); set it and install bubblewrap")
-		os.Exit(1)
 	} else {
 		log.Warn("SANDBOX DISABLED (SYNAPSE_SANDBOX_ENABLED is off) – syft/grype/git/crane run UNSANDBOXED with NO seccomp/rootfs/egress/cgroup containment; dev only, never production")
 	}

--- a/cmd/synapse-api/main_test.go
+++ b/cmd/synapse-api/main_test.go
@@ -2,53 +2,7 @@ package main
 
 import (
 	"testing"
-
-	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
 )
-
-func TestMigrationDSNForStartup(t *testing.T) {
-	devDSN := "postgres://synapse_app:runtime-secret@localhost/synapse?sslmode=disable"
-	ownerDSN := "postgres://synapse_owner:owner-secret@localhost/synapse?sslmode=disable"
-
-	tests := []struct {
-		name string
-		cfg  config.Config
-		want string
-		fail bool
-	}{
-		{
-			name: "development falls back to runtime DSN",
-			cfg:  config.Config{Environment: "development", DBDSN: devDSN},
-			want: devDSN,
-		},
-		{
-			name: "production requires migration DSN",
-			cfg:  config.Config{Environment: "production", DBDSN: devDSN},
-			fail: true,
-		},
-		{
-			name: "production accepts distinct migration role",
-			cfg:  config.Config{Environment: "production", DBDSN: devDSN, DBMigrationDSN: ownerDSN},
-			want: ownerDSN,
-		},
-		{
-			name: "production rejects same migration role",
-			cfg:  config.Config{Environment: "production", DBDSN: devDSN, DBMigrationDSN: "postgres://synapse_app:owner-secret@localhost/synapse?application_name=migrate&sslmode=require"},
-			fail: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := migrationDSNForStartup(tt.cfg)
-			if (err != nil) != tt.fail {
-				t.Fatalf("migrationDSNForStartup() error = %v, fail %t", err, tt.fail)
-			}
-			if got != tt.want {
-				t.Fatalf("migrationDSNForStartup() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestMetricsAddrIsLoopback(t *testing.T) {
 	tests := []struct {

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1089,7 +1089,7 @@ func runScan() {
 
 // syncAdvisories ingests a local OSV advisory dump into the owned advisory store. It requires a
 // Postgres DSN: the owned store is durable reference data, so ingesting into an ephemeral in-memory store
-// would do nothing. Migrations are applied first (the advisories tables may not exist yet), then a DirFeed
+// would do nothing. The database must already be migrated by synapse-migrate, then a DirFeed
 // over the dump directory streams every parseable advisory into the store via the narrow AdvisoryWriter.
 func syncAdvisories(args []string) error {
 	if len(args) < 1 {
@@ -1128,14 +1128,14 @@ func syncAdvisories(args []string) error {
 		src = args[0]
 	}
 	ctx := context.Background()
-	if err := postgres.Migrate(ctx, cfg.DBDSN); err != nil {
-		return fmt.Errorf("apply migrations: %w", err)
-	}
 	pool, err := postgres.Connect(ctx, cfg.DBDSN)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
 	}
 	defer pool.Close()
+	if err := postgres.CheckMigrationsReady(ctx, pool); err != nil {
+		return fmt.Errorf("database migrations are not current; run synapse-migrate: %w", err)
+	}
 	ingest, err := advisoryingest.NewService(feed, postgres.NewAdvisoryRepository(pool))
 	if err != nil {
 		return err

--- a/cmd/synapse-mcp/main.go
+++ b/cmd/synapse-mcp/main.go
@@ -42,6 +42,10 @@ func main() {
 		log.Error("synapse-mcp requires SYNAPSE_MCP_ENGAGEMENT_ID (the engagement it is scoped to)")
 		os.Exit(1)
 	}
+	if err := cfg.ValidateMigrationPosture(); err != nil {
+		log.Error("database migration posture invalid", "err", err)
+		os.Exit(1)
+	}
 
 	clock := idgen.SystemClock{}
 	ids := idgen.RandomID{}
@@ -54,9 +58,15 @@ func main() {
 	if cfg.DBDSN != "" {
 		startup, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
-		if err := postgres.Migrate(startup, cfg.DBDSN); err != nil {
-			log.Error("db migrate failed", "err", err)
-			os.Exit(1)
+		if cfg.DBAutoMigrate {
+			migrationStarted := time.Now()
+			if err := postgres.MigrateLocked(startup, cfg.MigrationDSN()); err != nil {
+				log.Error("db migrate failed", "err", err)
+				os.Exit(1)
+			}
+			log.Info("db migrations complete", "duration", time.Since(migrationStarted))
+		} else {
+			log.Info("db auto-migration disabled; readiness requires current migrations")
 		}
 		pool, err := postgres.Connect(startup, cfg.DBDSN)
 		if err != nil {
@@ -64,6 +74,12 @@ func main() {
 			os.Exit(1)
 		}
 		defer pool.Close()
+		if !cfg.DBAutoMigrate {
+			if err := postgres.CheckMigrationsReady(startup, pool); err != nil {
+				log.Error("database migrations are not current", "err", err)
+				os.Exit(1)
+			}
+		}
 		lockConn, ok, lerr := postgres.AcquireSingletonLock(startup, pool, "mcp")
 		if lerr != nil {
 			log.Error("mcp single-instance lock check failed", "err", lerr)

--- a/cmd/synapse-migrate/main.go
+++ b/cmd/synapse-migrate/main.go
@@ -1,0 +1,49 @@
+// Command synapse-migrate applies the embedded PostgreSQL migration set once.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
+)
+
+func main() {
+	cfg := config.Load()
+	log := logging.New(cfg.LogLevel)
+	if cfg.DBDSN == "" {
+		log.Error("synapse-migrate requires SYNAPSE_DB_DSN")
+		os.Exit(1)
+	}
+
+	migrationDSN := cfg.MigrationDSN()
+	if cfg.IsProduction() {
+		if cfg.DBMigrationDSN == "" {
+			log.Error("SYNAPSE_DB_MIGRATION_DSN is required with SYNAPSE_DB_DSN outside development")
+			os.Exit(1)
+		}
+		if err := postgres.ValidateMigrationRoleSeparation(migrationDSN, cfg.DBDSN); err != nil {
+			log.Error("database migration configuration invalid", "err", fmt.Errorf("validate migration and runtime database roles: %w", err))
+			os.Exit(1)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	started := time.Now()
+	if err := postgres.MigrateLocked(ctx, migrationDSN); err != nil {
+		log.Error("db migrate failed", "err", err)
+		os.Exit(1)
+	}
+	if migrationDSN != cfg.DBDSN {
+		if err := postgres.GrantRuntimePrivileges(ctx, migrationDSN, cfg.DBDSN); err != nil {
+			log.Error("db runtime role grant failed", "err", err)
+			os.Exit(1)
+		}
+	}
+	log.Info("db migrations complete", "duration", time.Since(started))
+}

--- a/cmd/synapse-worker/main.go
+++ b/cmd/synapse-worker/main.go
@@ -70,6 +70,14 @@ func main() {
 	cfg := config.Load()
 	log := logging.New(cfg.LogLevel)
 	log.Info("starting synapse-worker", "env", cfg.Environment)
+	if err := cfg.ValidateSandboxPosture(); err != nil {
+		log.Error("sandbox posture invalid", "err", err)
+		os.Exit(1)
+	}
+	if err := cfg.ValidateMigrationPosture(); err != nil {
+		log.Error("database migration posture invalid", "err", err)
+		os.Exit(1)
+	}
 
 	// The worker shares the API's Postgres (the queue + the recon/evidence repos), so a DSN
 	// is required – an in-memory queue is not shared across processes.
@@ -82,9 +90,15 @@ func main() {
 
 	startup, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	if err := postgres.Migrate(startup, cfg.DBDSN); err != nil {
-		log.Error("db migrate failed", "err", err)
-		os.Exit(1)
+	if cfg.DBAutoMigrate {
+		migrationStarted := time.Now()
+		if err := postgres.MigrateLocked(startup, cfg.MigrationDSN()); err != nil {
+			log.Error("db migrate failed", "err", err)
+			os.Exit(1)
+		}
+		log.Info("db migrations complete", "duration", time.Since(migrationStarted))
+	} else {
+		log.Info("db auto-migration disabled; readiness requires current migrations")
 	}
 	pool, err := postgres.ConnectPool(startup, cfg.DBDSN, postgres.PoolConfig{
 		MaxConns: int32(cfg.DBMaxConns), MinConns: int32(cfg.DBMinConns),
@@ -95,6 +109,12 @@ func main() {
 		os.Exit(1)
 	}
 	defer pool.Close()
+	if !cfg.DBAutoMigrate {
+		if err := postgres.CheckMigrationsReady(startup, pool); err != nil {
+			log.Error("database migrations are not current", "err", err)
+			os.Exit(1)
+		}
+	}
 	if err := postgres.CheckRLSRuntimeRole(startup, pool); err != nil {
 		log.Error("the worker DB role cannot enforce row level security – refusing to serve", "err", err)
 		os.Exit(1)

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -102,4 +102,11 @@ numbered SQL files embedded in the binary. Development services apply them autom
 uses the dedicated `synapse-migrate` command with the owner credential before API, worker, and MCP
 start with their runtime credential. A shipped migration is never edited. A new numbered file is appended.
 
+Production rollouts are migrate-first and migrations must be backward-compatible and phased: apply the
+schema expansion before deploying binaries that use it, and defer destructive changes until every older
+binary is gone. The API remains live but reports stale schema through `/readyz`; workers and the MCP
+server refuse startup on stale schema because they have no readiness endpoint to withdraw. Readiness
+accepts only an applied database migration newer than the binary's embedded maximum, which permits
+that migrate-first overlap while rejecting a missing, down, or divergent required migration.
+
 Next: [Deployment](deployment.md)

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -98,7 +98,8 @@ its own claim. No model ever sits in the report path.
 ## Persistence and migrations
 
 Persistence is PostgreSQL when a DSN is set, and an in-memory store otherwise. Migrations are
-numbered SQL files, embedded in the binary, and applied automatically at startup. There is no
-separate migrate step. A shipped migration is never edited. A new numbered file is appended.
+numbered SQL files embedded in the binary. Development services apply them automatically; production
+uses the dedicated `synapse-migrate` command with the owner credential before API, worker, and MCP
+start with their runtime credential. A shipped migration is never edited. A new numbered file is appended.
 
 Next: [Deployment](deployment.md)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -67,7 +67,9 @@ The metrics listener has no authentication of its own. Keep `SYNAPSE_METRICS_ADD
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `SYNAPSE_DB_DSN` | (in-memory) | PostgreSQL connection URL. Empty runs an in-memory dev store, so nothing is durable. |
+| `SYNAPSE_DB_DSN` | (in-memory) | Runtime PostgreSQL connection URL. Empty runs an in-memory dev store, so nothing is durable. |
+| `SYNAPSE_DB_MIGRATION_DSN` | `SYNAPSE_DB_DSN` in development | Optional owner-level PostgreSQL DSN used only by `synapse-migrate`, separating migration authority from the least-privileged runtime DSN. In production it must use a database user distinct from the runtime DSN. |
+| `SYNAPSE_DB_AUTO_MIGRATE` | `true` in development | Long-running services apply embedded migrations only in development. Production requires `false`; run `synapse-migrate` first. API exposes stale-schema status through `/readyz`; worker and MCP refuse startup until the schema is current. |
 | `SYNAPSE_DB_MAX_CONNS` | `32` | pgx pool maximum connections. |
 | `SYNAPSE_DB_MIN_CONNS` | `0` | pgx pool minimum connections. |
 | `SYNAPSE_DB_MAX_CONN_LIFETIME` | `1h` | Connection lifetime. |
@@ -237,7 +239,7 @@ All off by default. The fleet needs PostgreSQL + `synapse-worker`; agents run on
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `SYNAPSE_SANDBOX_ENABLED` | `false` | Run tool execution and acquisition in the bubblewrap sandbox. If set but bubblewrap is missing, startup fails closed. |
+| `SYNAPSE_SANDBOX_ENABLED` | `false` | Run tool execution and acquisition in the bubblewrap sandbox. Production requires `true`; if bubblewrap is missing, startup fails closed. |
 | `SYNAPSE_SANDBOX_MEM_MAX` | `536870912` | Per-run memory limit in bytes. |
 | `SYNAPSE_SANDBOX_PIDS_MAX` | `256` | Per-run pid limit. |
 | `SYNAPSE_TOOL_HASHES` | (TOFU) | Authoritative sha256 pins. The sandbox refuses a binary whose hash does not match. |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -69,7 +69,7 @@ The metrics listener has no authentication of its own. Keep `SYNAPSE_METRICS_ADD
 | --- | --- | --- |
 | `SYNAPSE_DB_DSN` | (in-memory) | Runtime PostgreSQL connection URL. Empty runs an in-memory dev store, so nothing is durable. |
 | `SYNAPSE_DB_MIGRATION_DSN` | `SYNAPSE_DB_DSN` in development | Optional owner-level PostgreSQL DSN used only by `synapse-migrate`, separating migration authority from the least-privileged runtime DSN. In production it must use a database user distinct from the runtime DSN. |
-| `SYNAPSE_DB_AUTO_MIGRATE` | `true` in development | Long-running services apply embedded migrations only in development. Production requires `false`; run `synapse-migrate` first. API exposes stale-schema status through `/readyz`; worker and MCP refuse startup until the schema is current. |
+| `SYNAPSE_DB_AUTO_MIGRATE` | `true` in development | Long-running services apply embedded migrations only in development. Production requires `false`; run `synapse-migrate` first. Use backward-compatible, phased, migrate-first changes: the API accepts only an applied forward migration strictly above its embedded maximum and exposes a stale or divergent schema through `/readyz`; worker and MCP refuse startup until the schema is current because they have no readiness endpoint. |
 | `SYNAPSE_DB_MAX_CONNS` | `32` | pgx pool maximum connections. |
 | `SYNAPSE_DB_MIN_CONNS` | `0` | pgx pool minimum connections. |
 | `SYNAPSE_DB_MAX_CONN_LIFETIME` | `1h` | Connection lifetime. |

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -109,6 +109,20 @@ Recommended hardening:
 
 `GET /healthz` and `GET /readyz` are unauthenticated by design. Every other API route requires the bearer token.
 
+## Migration rollout
+
+In production, set `SYNAPSE_DB_AUTO_MIGRATE=false` and run `synapse-migrate` with the owner
+credential before deploying API, worker, or MCP binaries. Design migrations as backward-compatible,
+phased changes: expand first, deploy consumers second, then remove obsolete schema only after all
+older consumers are gone. This migrate-first sequence permits an older API to remain serving a
+forward schema only when every additional database migration is applied and has a version strictly
+above that binary's embedded maximum. Missing, down, or divergent required migrations remain
+unready.
+
+The distinction is intentional: an API with a stale schema stays running but reports `503` from
+`/readyz`, allowing the orchestrator to remove it from traffic. `synapse-worker` and `synapse-mcp`
+have no equivalent HTTP readiness endpoint, so they refuse startup until migrations are ready.
+
 ## Metrics and access logging
 
 `SYNAPSE_METRICS_ENABLED` (default `false`) exposes Prometheus metrics — HTTP RED

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -43,8 +43,8 @@ intentionally public so probes work without a credential.
 
 A blank `SYNAPSE_DB_DSN` runs the development persistence: in-memory stores plus a few local files such as
 `data/audit.jsonl`. It is not durable and not suitable for real work, but it is not purely ephemeral
-either. Set a DSN for PostgreSQL. Database migrations are embedded and applied automatically at startup, so
-there is no separate migrate step.
+either. Set a DSN for PostgreSQL. Development applies embedded migrations automatically. Production runs
+`synapse-migrate` with `SYNAPSE_DB_MIGRATION_DSN` before starting services with `SYNAPSE_DB_AUTO_MIGRATE=false`.
 
 ## 2. Log in
 

--- a/internal/infrastructure/persistence/postgres/db.go
+++ b/internal/infrastructure/persistence/postgres/db.go
@@ -8,8 +8,9 @@ import (
 	"database/sql"
 	"fmt"
 	"hash/fnv"
-	"math"
+	"io/fs"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -273,22 +274,57 @@ type migrationState struct {
 }
 
 func embeddedMigrationVersions() ([]int64, error) {
-	goose.SetBaseFS(migrations.FS)
-	embedded, err := goose.CollectMigrations(".", 0, math.MaxInt64)
+	return migrationVersions(migrations.FS)
+}
+
+func migrationVersions(source fs.FS) ([]int64, error) {
+	entries, err := fs.ReadDir(source, ".")
 	if err != nil {
-		return nil, fmt.Errorf("collect embedded migrations: %w", err)
+		return nil, fmt.Errorf("read embedded migrations: %w", err)
 	}
-	versions := make([]int64, 0, len(embedded))
-	for _, migration := range embedded {
-		versions = append(versions, migration.Version)
+
+	versions := make([]int64, 0, len(entries))
+	seen := make(map[int64]string, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		prefix, _, ok := strings.Cut(entry.Name(), "_")
+		if !ok {
+			return nil, fmt.Errorf("embedded migration %q has an invalid filename", entry.Name())
+		}
+		version, err := goose.NumericComponent(entry.Name())
+		if err != nil || version <= 0 {
+			return nil, fmt.Errorf("embedded migration %q has invalid version %q", entry.Name(), prefix)
+		}
+		if previous, duplicate := seen[version]; duplicate {
+			return nil, fmt.Errorf("embedded migrations %q and %q use duplicate version %d", previous, entry.Name(), version)
+		}
+		seen[version] = entry.Name()
+		versions = append(versions, version)
 	}
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no embedded SQL migrations found")
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
 	return versions, nil
 }
 
 func compareMigrationStates(expected []int64, actual []migrationState) error {
+	if len(expected) == 0 {
+		return fmt.Errorf("migration readiness: no embedded migrations expected")
+	}
+
 	want := make(map[int64]struct{}, len(expected))
+	latestExpected := expected[0]
 	for _, version := range expected {
+		if _, duplicate := want[version]; duplicate {
+			return fmt.Errorf("migration readiness: duplicate embedded migration %d", version)
+		}
 		want[version] = struct{}{}
+		if version > latestExpected {
+			latestExpected = version
+		}
 	}
 	got := make(map[int64]bool, len(actual))
 	for _, state := range actual {
@@ -306,9 +342,15 @@ func compareMigrationStates(expected []int64, actual []migrationState) error {
 			return fmt.Errorf("migration readiness: embedded migration %d is not applied", version)
 		}
 	}
-	for version := range got {
-		if _, ok := want[version]; !ok {
-			return fmt.Errorf("migration readiness: database contains unexpected migration %d", version)
+	for version, applied := range got {
+		if _, ok := want[version]; ok {
+			continue
+		}
+		if version <= latestExpected {
+			return fmt.Errorf("migration readiness: database contains divergent migration %d", version)
+		}
+		if !applied {
+			return fmt.Errorf("migration readiness: newer migration %d is not applied", version)
 		}
 	}
 	return nil

--- a/internal/infrastructure/persistence/postgres/db.go
+++ b/internal/infrastructure/persistence/postgres/db.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 	"hash/fnv"
+	"math"
 	"net/url"
 	"strings"
 	"time"
@@ -98,6 +99,12 @@ func singletonLockKey(role string) int64 {
 	return int64(h.Sum64())
 }
 
+func migrationLockKey() int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte("synapse:migration"))
+	return int64(h.Sum64())
+}
+
 // AcquireSingletonLock takes a session-level advisory lock (keyed by role) on a DEDICATED
 // connection the caller holds for the whole process lifetime – releasing it drops the
 // lock. A second instance OF THE SAME ROLE gets ok=false so it can fail fast (the repos
@@ -158,7 +165,36 @@ func Migrate(ctx context.Context, dsn string) error {
 		return fmt.Errorf("migrate open: %w", err)
 	}
 	defer func() { _ = db.Close() }()
+	return migrate(ctx, db)
+}
 
+// MigrateLocked applies the embedded migration set while holding a database-wide advisory lock.
+// The lock and goose share the pool's sole connection, so the session lock is held for the
+// complete migration run. Acquisition blocks until the caller's context expires.
+func MigrateLocked(ctx context.Context, dsn string) error {
+	db, err := sql.Open("pgx", dsnForMigrate(dsn))
+	if err != nil {
+		return fmt.Errorf("migrate open: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	if _, err := db.ExecContext(ctx, "SELECT pg_advisory_lock($1)", migrationLockKey()); err != nil {
+		return fmt.Errorf("acquire migration advisory lock: %w", err)
+	}
+	defer func() {
+		// A network failure during cleanup must not turn a bounded migration startup
+		// into an unbounded shutdown hang. Closing the sole connection also releases
+		// the session lock if this best-effort unlock cannot complete.
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, _ = db.ExecContext(releaseCtx, "SELECT pg_advisory_unlock($1)", migrationLockKey())
+	}()
+	return migrate(ctx, db)
+}
+
+func migrate(ctx context.Context, db *sql.DB) error {
 	goose.SetBaseFS(migrations.FS)
 	if err := goose.SetDialect("postgres"); err != nil {
 		return fmt.Errorf("migrate dialect: %w", err)
@@ -195,33 +231,85 @@ func CheckMigrationsReady(ctx context.Context, pool *pgxpool.Pool) error {
 	return checkMigrationsReady(ctx, pool)
 }
 
-func checkMigrationsReady(ctx context.Context, queryer readinessQueryer) error {
-	entries, err := migrations.FS.ReadDir(".")
-	if err != nil {
-		return fmt.Errorf("read embedded migrations: %w", err)
-	}
-	expected := 0
-	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".sql") {
-			expected++
-		}
-	}
+type migrationReadinessQueryer interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+}
 
-	var applied int
-	err = queryer.QueryRow(ctx, `
-		SELECT count(*)
+func checkMigrationsReady(ctx context.Context, queryer migrationReadinessQueryer) error {
+	expected, err := embeddedMigrationVersions()
+	if err != nil {
+		return err
+	}
+	rows, err := queryer.Query(ctx, `SELECT version_id, is_applied
 		FROM (
 			SELECT DISTINCT ON (version_id) version_id, is_applied
 			FROM goose_db_version
 			WHERE version_id > 0
 			ORDER BY version_id, id DESC
 		) AS latest
-		WHERE is_applied`).Scan(&applied)
+		ORDER BY version_id`)
 	if err != nil {
-		return fmt.Errorf("migration readiness: %w", err)
+		return fmt.Errorf("migration readiness query: %w", err)
 	}
-	if applied != expected {
-		return fmt.Errorf("migration readiness: %d of %d embedded migrations applied", applied, expected)
+	defer rows.Close()
+
+	actual := make([]migrationState, 0, len(expected))
+	for rows.Next() {
+		var state migrationState
+		if err := rows.Scan(&state.version, &state.applied); err != nil {
+			return fmt.Errorf("migration readiness scan: %w", err)
+		}
+		actual = append(actual, state)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("migration readiness rows: %w", err)
+	}
+	return compareMigrationStates(expected, actual)
+}
+
+type migrationState struct {
+	version int64
+	applied bool
+}
+
+func embeddedMigrationVersions() ([]int64, error) {
+	goose.SetBaseFS(migrations.FS)
+	embedded, err := goose.CollectMigrations(".", 0, math.MaxInt64)
+	if err != nil {
+		return nil, fmt.Errorf("collect embedded migrations: %w", err)
+	}
+	versions := make([]int64, 0, len(embedded))
+	for _, migration := range embedded {
+		versions = append(versions, migration.Version)
+	}
+	return versions, nil
+}
+
+func compareMigrationStates(expected []int64, actual []migrationState) error {
+	want := make(map[int64]struct{}, len(expected))
+	for _, version := range expected {
+		want[version] = struct{}{}
+	}
+	got := make(map[int64]bool, len(actual))
+	for _, state := range actual {
+		if _, duplicate := got[state.version]; duplicate {
+			return fmt.Errorf("migration readiness: duplicate latest state for version %d", state.version)
+		}
+		got[state.version] = state.applied
+	}
+	for _, version := range expected {
+		applied, ok := got[version]
+		if !ok {
+			return fmt.Errorf("migration readiness: embedded migration %d is missing", version)
+		}
+		if !applied {
+			return fmt.Errorf("migration readiness: embedded migration %d is not applied", version)
+		}
+	}
+	for version := range got {
+		if _, ok := want[version]; !ok {
+			return fmt.Errorf("migration readiness: database contains unexpected migration %d", version)
+		}
 	}
 	return nil
 }

--- a/internal/infrastructure/persistence/postgres/db_pool_test.go
+++ b/internal/infrastructure/persistence/postgres/db_pool_test.go
@@ -1,8 +1,13 @@
 package postgres
 
 import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // credential-free DSN (parses without connecting; no secret).
@@ -75,6 +80,114 @@ func TestDSNForMigrate_KeywordForm(t *testing.T) {
 	if !strings.Contains(got, "host=localhost") || !strings.Contains(got, "sslmode=disable") {
 		t.Fatalf("keyword-form non-pool fields must be preserved, got %q", got)
 	}
+}
+
+func TestMigrationLockKeyIsDedicated(t *testing.T) {
+	migrationKey := migrationLockKey()
+	for _, role := range []string{"api", "worker", "mcp"} {
+		if migrationKey == singletonLockKey(role) {
+			t.Fatalf("migration lock key must differ from %s singleton lock key", role)
+		}
+	}
+}
+
+func TestMigrateLockedWaitsForMigrationLock(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	holder, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Release()
+	if _, err := holder.Exec(ctx, "SELECT pg_advisory_lock($1)", migrationLockKey()); err != nil {
+		t.Fatal(err)
+	}
+	locked := true
+	defer func() {
+		if !locked {
+			return
+		}
+		releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer releaseCancel()
+		_, _ = holder.Exec(releaseCtx, "SELECT pg_advisory_unlock($1)", migrationLockKey())
+	}()
+
+	contenderName := fmt.Sprintf("synapse-migration-test-%d", time.Now().UnixNano())
+	contenderDSN, err := dsnWithApplicationName(dsn, contenderName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contenderCtx, contenderCancel := context.WithCancel(ctx)
+	defer contenderCancel()
+	done := make(chan error, 1)
+	go func() { done <- MigrateLocked(contenderCtx, contenderDSN) }()
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer waitCancel()
+	for {
+		var waiting bool
+		err := holder.QueryRow(waitCtx, `
+SELECT EXISTS (
+	SELECT 1
+	FROM pg_stat_activity AS activity
+	JOIN pg_locks AS lock ON lock.pid = activity.pid
+	WHERE activity.application_name = $1
+		AND lock.locktype = 'advisory'
+		AND NOT lock.granted
+		AND lock.database = activity.datid
+		AND lock.objsubid = 1
+		AND ((lock.classid::bigint << 32) | lock.objid::bigint) = $2
+)`, contenderName, migrationLockKey()).Scan(&waiting)
+		if err != nil {
+			t.Fatalf("inspect contender advisory lock request: %v", err)
+		}
+		if waiting {
+			break
+		}
+
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf("contender did not request the migration advisory lock: %v", waitCtx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	if _, err := holder.Exec(ctx, "SELECT pg_advisory_unlock($1)", migrationLockKey()); err != nil {
+		t.Fatal(err)
+	}
+	locked = false
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("MigrateLocked did not complete after migration lock release: %v", ctx.Err())
+	}
+}
+
+func dsnWithApplicationName(dsn, applicationName string) (string, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parse test database dsn to set application_name: %w", err)
+	}
+	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
+		return dsn + " application_name=" + applicationName, nil
+	}
+	q := u.Query()
+	q.Set("application_name", applicationName)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 func TestValidateMigrationRoleSeparation(t *testing.T) {

--- a/internal/infrastructure/persistence/postgres/db_readiness_test.go
+++ b/internal/infrastructure/persistence/postgres/db_readiness_test.go
@@ -5,6 +5,30 @@ import (
 	"testing"
 )
 
+func TestCompareMigrationStates(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected []int64
+		actual   []migrationState
+		wantErr  bool
+	}{
+		{name: "all embedded migrations applied", expected: []int64{1, 2}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: true}}},
+		{name: "missing embedded migration", expected: []int64{1, 2}, actual: []migrationState{{version: 1, applied: true}}, wantErr: true},
+		{name: "latest state down", expected: []int64{1, 2}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: false}}, wantErr: true},
+		{name: "unexpected applied migration", expected: []int64{1}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: true}}, wantErr: true},
+		{name: "unexpected down migration", expected: []int64{1}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: false}}, wantErr: true},
+		{name: "duplicate latest state", expected: []int64{1}, actual: []migrationState{{version: 1, applied: true}, {version: 1, applied: true}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := compareMigrationStates(tt.expected, tt.actual)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("compareMigrationStates() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestPostgresReadinessChecks(t *testing.T) {
 	dsn := testDSN(t)
 	ctx := context.Background()

--- a/internal/infrastructure/persistence/postgres/db_readiness_test.go
+++ b/internal/infrastructure/persistence/postgres/db_readiness_test.go
@@ -2,7 +2,11 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+	"reflect"
+	"sync"
 	"testing"
+	"testing/fstest"
 )
 
 func TestCompareMigrationStates(t *testing.T) {
@@ -12,12 +16,17 @@ func TestCompareMigrationStates(t *testing.T) {
 		actual   []migrationState
 		wantErr  bool
 	}{
-		{name: "all embedded migrations applied", expected: []int64{1, 2}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: true}}},
-		{name: "missing embedded migration", expected: []int64{1, 2}, actual: []migrationState{{version: 1, applied: true}}, wantErr: true},
-		{name: "latest state down", expected: []int64{1, 2}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: false}}, wantErr: true},
-		{name: "unexpected applied migration", expected: []int64{1}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: true}}, wantErr: true},
-		{name: "unexpected down migration", expected: []int64{1}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: false}}, wantErr: true},
+		{name: "all embedded migrations applied", expected: []int64{1, 3}, actual: []migrationState{{version: 1, applied: true}, {version: 3, applied: true}}},
+		{name: "newer applied migration", expected: []int64{1, 3}, actual: []migrationState{{version: 1, applied: true}, {version: 3, applied: true}, {version: 4, applied: true}}},
+		{name: "multiple newer applied migrations", expected: []int64{1, 3}, actual: []migrationState{{version: 1, applied: true}, {version: 3, applied: true}, {version: 4, applied: true}, {version: 5, applied: true}}},
+		{name: "missing embedded migration", expected: []int64{1, 3}, actual: []migrationState{{version: 1, applied: true}}, wantErr: true},
+		{name: "latest state down", expected: []int64{1, 3}, actual: []migrationState{{version: 1, applied: true}, {version: 3, applied: false}}, wantErr: true},
+		{name: "divergent applied migration", expected: []int64{1, 3}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: true}, {version: 3, applied: true}}, wantErr: true},
+		{name: "divergent down migration", expected: []int64{1, 3}, actual: []migrationState{{version: 1, applied: true}, {version: 2, applied: false}, {version: 3, applied: true}}, wantErr: true},
+		{name: "newer down migration", expected: []int64{1, 3}, actual: []migrationState{{version: 1, applied: true}, {version: 3, applied: true}, {version: 4, applied: false}}, wantErr: true},
 		{name: "duplicate latest state", expected: []int64{1}, actual: []migrationState{{version: 1, applied: true}, {version: 1, applied: true}}, wantErr: true},
+		{name: "duplicate embedded version", expected: []int64{1, 1}, actual: []migrationState{{version: 1, applied: true}}, wantErr: true},
+		{name: "empty expected migrations", actual: nil, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -26,6 +35,80 @@ func TestCompareMigrationStates(t *testing.T) {
 				t.Fatalf("compareMigrationStates() error = %v, wantErr %t", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestMigrationVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   fstest.MapFS
+		want    []int64
+		wantErr bool
+	}{
+		{
+			name: "sorted SQL versions",
+			files: fstest.MapFS{
+				"0010_tenth.sql":  {},
+				"0002_second.sql": {},
+				"README.md":       {},
+			},
+			want: []int64{2, 10},
+		},
+		{name: "missing separator", files: fstest.MapFS{"0001.sql": {}}, wantErr: true},
+		{name: "empty description follows Goose", files: fstest.MapFS{"0001_.sql": {}}, want: []int64{1}},
+		{name: "non-numeric version", files: fstest.MapFS{"next_change.sql": {}}, wantErr: true},
+		{name: "non-positive version", files: fstest.MapFS{"0000_init.sql": {}}, wantErr: true},
+		{
+			name: "duplicate version",
+			files: fstest.MapFS{
+				"0001_first.sql":  {},
+				"1_duplicate.sql": {},
+			},
+			wantErr: true,
+		},
+		{name: "no SQL migrations", files: fstest.MapFS{"README.md": {}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := migrationVersions(tt.files)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("migrationVersions() error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("migrationVersions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEmbeddedMigrationVersionsConcurrent(t *testing.T) {
+	want, err := embeddedMigrationVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const callers = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, callers)
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := embeddedMigrationVersions()
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !reflect.DeepEqual(got, want) {
+				errs <- fmt.Errorf("embeddedMigrationVersions() = %v, want %v", got, want)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
 	}
 }
 
@@ -47,22 +130,44 @@ func TestPostgresReadinessChecks(t *testing.T) {
 		t.Fatalf("all embedded migrations should be ready: %v", err)
 	}
 
-	// Goose retains migration history. Add an uncommitted latest "down" record and run the check
-	// through the same transaction to prove it considers latest state rather than any historical up.
+	// A migrate-first rollout may leave a newer, applied migration while an older
+	// API binary is still serving. A later down record for that version is not ready.
 	tx, err := pool.Begin(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
 	var latest int64
 	if err := tx.QueryRow(ctx, `SELECT max(version_id) FROM goose_db_version WHERE is_applied`).Scan(&latest); err != nil {
+		t.Fatal(err)
+	}
+	newer := latest + 1
+	if _, err := tx.Exec(ctx, `INSERT INTO goose_db_version(version_id, is_applied) VALUES($1, true)`, newer); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkMigrationsReady(ctx, tx); err != nil {
+		t.Fatalf("a newer applied migration should be ready: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO goose_db_version(version_id, is_applied) VALUES($1, false)`, newer); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkMigrationsReady(ctx, tx); err == nil {
+		t.Fatal("a newer down record must make migrations not ready")
+	}
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Goose retains migration history. A latest down record for an embedded
+	// migration remains not ready even when its historical up record exists.
+	tx, err = pool.Begin(ctx)
+	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := tx.Exec(ctx, `INSERT INTO goose_db_version(version_id, is_applied) VALUES($1, false)`, latest); err != nil {
 		t.Fatal(err)
 	}
 	if err := checkMigrationsReady(ctx, tx); err == nil {
-		t.Fatal("a latest down record must make migrations not ready")
+		t.Fatal("a required migration down record must make migrations not ready")
 	}
 	if err := tx.Rollback(ctx); err != nil {
 		t.Fatal(err)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -48,6 +49,9 @@ type Config struct {
 	// DBMigrationDSN, when set, is used only for schema migrations and runtime-role grants.
 	// It must be a DDL owner credential; DBDSN remains the least-privilege application credential.
 	DBMigrationDSN string
+	// DBAutoMigrate controls embedded migrations for long-running services. A dedicated
+	// synapse-migrate job may own migrations while services rely on readiness instead.
+	DBAutoMigrate bool
 	// SyftBin is the Syft executable used for SBOM generation (shell-out).
 	SyftBin string
 	// SBOMProducer selects the SBOM-generation producer: "syft" (default – the pinned
@@ -536,6 +540,7 @@ func Load() Config {
 		AuditFile:                        getenv("SYNAPSE_AUDIT_FILE", "data/audit.jsonl"),
 		DBDSN:                            getenv("SYNAPSE_DB_DSN", ""),
 		DBMigrationDSN:                   getenv("SYNAPSE_DB_MIGRATION_DSN", ""),
+		DBAutoMigrate:                    getbool("SYNAPSE_DB_AUTO_MIGRATE", true),
 		SyftBin:                          getenv("SYNAPSE_SYFT_BIN", "syft"),
 		SBOMProducer:                     getenv("SYNAPSE_SBOM_PRODUCER", "syft"),
 		GrypeBin:                         getenv("SYNAPSE_GRYPE_BIN", "grype"),
@@ -851,6 +856,32 @@ func (c Config) IsProduction() bool {
 	default: // production, prod, staging, or any unrecognized/misspelled value → fail closed
 		return true
 	}
+}
+
+// ValidateSandboxPosture rejects a production configuration that would execute tools without containment.
+func (c Config) ValidateSandboxPosture() error {
+	if c.IsProduction() && !c.SandboxEnabled {
+		return errors.New("SYNAPSE_SANDBOX_ENABLED is required in production")
+	}
+	return nil
+}
+
+// ValidateMigrationPosture keeps DDL credentials out of long-running production services.
+// Production migrations are owned by the dedicated synapse-migrate command.
+func (c Config) ValidateMigrationPosture() error {
+	if c.IsProduction() && c.DBAutoMigrate {
+		return errors.New("SYNAPSE_DB_AUTO_MIGRATE=false is required in production; run synapse-migrate before starting services")
+	}
+	return nil
+}
+
+// MigrationDSN returns the DDL credential when configured, falling back to the runtime
+// credential only for development convenience.
+func (c Config) MigrationDSN() string {
+	if c.DBMigrationDSN != "" {
+		return c.DBMigrationDSN
+	}
+	return c.DBDSN
 }
 
 func getenv(key, def string) string {

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -29,6 +29,78 @@ func TestIsProductionFailsClosed(t *testing.T) {
 	}
 }
 
+func TestValidateSandboxPosture(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{name: "production sandbox disabled", cfg: Config{Environment: "production"}, want: true},
+		{name: "unknown environment sandbox disabled", cfg: Config{Environment: "typo-env"}, want: true},
+		{name: "production sandbox enabled", cfg: Config{Environment: "production", SandboxEnabled: true}},
+		{name: "development sandbox disabled", cfg: Config{Environment: "development"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Config(tt.cfg).ValidateSandboxPosture() != nil; got != tt.want {
+				t.Fatalf("ValidateSandboxPosture() error = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateMigrationPosture(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{name: "production auto-migrate enabled", cfg: Config{Environment: "production", DBAutoMigrate: true}, want: true},
+		{name: "unknown environment auto-migrate enabled", cfg: Config{Environment: "typo-env", DBAutoMigrate: true}, want: true},
+		{name: "production auto-migrate disabled", cfg: Config{Environment: "production"}},
+		{name: "development auto-migrate enabled", cfg: Config{Environment: "development", DBAutoMigrate: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.ValidateMigrationPosture() != nil; got != tt.want {
+				t.Fatalf("ValidateMigrationPosture() error = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigrationDSN(t *testing.T) {
+	cfg := Config{DBDSN: "runtime"}
+	if got := cfg.MigrationDSN(); got != "runtime" {
+		t.Fatalf("MigrationDSN() = %q, want runtime", got)
+	}
+	cfg.DBMigrationDSN = "owner"
+	if got := cfg.MigrationDSN(); got != "owner" {
+		t.Fatalf("MigrationDSN() = %q, want owner", got)
+	}
+}
+
+func TestLoadDBAutoMigrate(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "default", want: true},
+		{name: "enabled", value: "true", want: true},
+		{name: "disabled", value: "false"},
+		{name: "invalid uses default", value: "not-a-bool", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SYNAPSE_DB_AUTO_MIGRATE", tt.value)
+			if got := Load().DBAutoMigrate; got != tt.want {
+				t.Fatalf("DBAutoMigrate = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestLoadNormalizesEnvironment confirms Load canonicalizes the env so logs + any reader
 // see one form.
 func TestLoadNormalizesEnvironment(t *testing.T) {


### PR DESCRIPTION
## Summary

Make database migrations a gated, single-owner startup operation and fail closed when production sandboxing is disabled. This closes #588 and implements the code/startup portion of #591; deployment manifests and Linux isolation evidence remain tracked by #590 and #591.

## Changes

- Add the one-shot `synapse-migrate` command for production migrations using a dedicated blocking PostgreSQL advisory lock.
- Require production long-running services to set `SYNAPSE_DB_AUTO_MIGRATE=false`, keeping owner/DDL credentials out of API, worker, MCP, and advisory-sync startup paths.
- Validate the exact latest state of every embedded Goose migration; API exposes stale state through `/readyz`, while worker and MCP refuse startup.
- Require production API and worker startup to enable sandboxing, preserving fail-closed behavior when bubblewrap is unavailable.
- Document migration ownership, runtime-role separation, readiness behavior, and production sandbox requirements.
- Add unit and PostgreSQL integration coverage for migration-state validation, role separation, and lock contention.

## Checklist

- [x] `make build vet test typecheck` passes
- [x] `cd web && pnpm build` passes (if the dashboard changed)
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants (argv exec, server-side scope enforcement, secrets
      out of logs, deterministic reports, append-only evidence) – see CONTRIBUTING.md

### Documentation

Drift guards run in `make test`, so these usually fail loudly rather than silently. Confirm anyway:

- [x] New or changed `SYNAPSE_*` variables are in `docs/guide/configuration.md`, and
      security-relevant ones state the risk of a careless value
- [x] New or changed CLI flags, subcommands, and exit codes are in `docs/guide/cli.md` (N/A: the new composition-root command is documented in the architecture, configuration, and quickstart guides; no existing CLI subcommand or exit code changed)
- [x] New HTTP routes are described in `api/openapi.yaml` (do not grow
      `api/testdata/openapi-coverage-debt.txt`) (N/A: no HTTP routes changed)
- [x] New guides are in `mkdocs.yml` nav, so the site actually publishes them (N/A: no new guide added)
- [x] Claims match shipped behavior: no unbuilt artifact, unimplemented setting, or
      ingest-only format described as an export
- [x] Screenshots retaken if the documented UI changed, with no tokens, keys, or real
      customer data captured (N/A: no UI or screenshots changed)

### Validation

- `make build vet test typecheck`
- `cd web && pnpm build`
- Fresh PostgreSQL 17 integration run: all 106 migrations applied successfully.
- `TestMigrateLockedWaitsForMigrationLock`: verified the contender waits in `pg_locks` and completes only after lock release.
- `TestPostgresReadinessChecks`: verified exact migration readiness and rejection of a latest `down` state.
- Architecture and security reviews completed, followed by one remediation batch and focused confirmation.
