### PR TITLE
feat(fleet): canonical telemetry envelope + normalizer (A1, #622)

### DIFF
--- a/internal/domain/telemetry/arch_test.go
+++ b/internal/domain/telemetry/arch_test.go
@@ -1,0 +1,65 @@
+package telemetry
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// TestArchNoDetectionObservationType enforces the A1 boundary (#622): the raw-telemetry domain owns its
+// OWN observation schema (TelemetryEvent + the per-class *Observation types) and must never reuse
+// detection.Event — the thin, single-timestamp shape built for rule matching — as the canonical
+// observation type. Reusing detection.Class (the four-value class enum) is allowed and intentional; the
+// forbidden thing is the detection OBSERVATION types.
+//
+// The check parses each source file and inspects real selector expressions (detection.X in CODE), so a
+// doc comment that merely MENTIONS "detection.Event" to explain the boundary does not trip it.
+func TestArchNoDetectionObservationType(t *testing.T) {
+	forbidden := map[string]bool{
+		"Event":          true,
+		"ProcessEvent":   true,
+		"NetworkEvent":   true,
+		"FileEvent":      true,
+		"PrivilegeEvent": true,
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		// Exclude test files from the boundary scan: the boundary is a property of the shipped package,
+		// and tests legitimately reference detection.ClassProcess etc.
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("arch test parsed no packages; the boundary is not actually being checked")
+	}
+
+	scannedFiles := 0
+	for _, pkg := range pkgs {
+		for name, file := range pkg.Files {
+			scannedFiles++
+			ast.Inspect(file, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				ident, ok := sel.X.(*ast.Ident)
+				if !ok || ident.Name != "detection" {
+					return true
+				}
+				if forbidden[sel.Sel.Name] {
+					t.Errorf("%s uses detection.%s in code — raw telemetry must not reuse the detection observation type (A1/D4 boundary)", name, sel.Sel.Name)
+				}
+				return true
+			})
+		}
+	}
+	if scannedFiles == 0 {
+		t.Fatal("arch test scanned no source files; the boundary is not actually being checked")
+	}
+}

--- a/internal/domain/telemetry/entityid.go
+++ b/internal/domain/telemetry/entityid.go
@@ -1,0 +1,71 @@
+package telemetry
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"io"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Stable entity identity for the raw-telemetry tier (A1, fixes D4). A raw PID is NOT an identity: the
+// kernel reuses a PID the moment a process dies, so two unrelated processes can share one PID within a
+// boot, and the same PID means different things across a reboot. These helpers derive a content-addressed
+// id that is stable for the life of one process and distinct across PID reuse and reboots.
+//
+// Every id is a domain-separated sha256 over a LENGTH-PREFIXED encoding of its parts (never a delimiter
+// join): a naive `a + sep + b` collides when a field can contain the separator (e.g. a path or a host id
+// with an embedded NUL), which is exactly the class of bug the columnar-key work removed. Length-prefixing
+// makes the encoding unambiguous regardless of field content.
+
+// hashFields returns the hex sha256 of a domain-separated, length-prefixed encoding of parts. The domain
+// string is written first (and length-prefixed) so an id computed for one purpose can never equal an id
+// for another purpose, even with identical parts.
+func hashFields(domain string, parts ...string) string {
+	h := sha256.New()
+	writeField(h, domain)
+	for _, p := range parts {
+		writeField(h, p)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func writeField(h io.Writer, s string) {
+	var lp [8]byte
+	binary.BigEndian.PutUint64(lp[:], uint64(len(s)))
+	_, _ = h.Write(lp[:])
+	_, _ = io.WriteString(h, s)
+}
+
+func uint64Str(v uint64) string {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], v)
+	return string(b[:])
+}
+
+// ProcessEntityID derives the stable identity of a process from the tuple that actually pins it:
+// (AssetID, BootID, PID, StartTimeNanos). StartTimeNanos is the kernel process start time — it is what
+// makes a reused PID a DISTINCT entity; BootID makes the same (pid, start) on a different boot distinct.
+// The id is prefixed "pe_" so it is self-describing in logs and evidence.
+func ProcessEntityID(assetID, bootID shared.ID, pid int, startTimeNanos uint64) shared.ID {
+	sum := hashFields("telemetry:process-entity:v1",
+		assetID.String(), bootID.String(), uint64Str(uint64(int64(pid))), uint64Str(startTimeNanos))
+	return shared.ID("pe_" + sum[:32])
+}
+
+// FileTargetID derives the identity of a file target from (path, device, inode, contentHash). Path alone
+// is not identity — it is rebindable (rename/symlink/bind-mount) — so device+inode pin the concrete
+// object and the optional contentHash pins its contents at observation time.
+func FileTargetID(path string, device, inode uint64, contentHash string) shared.ID {
+	sum := hashFields("telemetry:file-target:v1", path, uint64Str(device), uint64Str(inode), contentHash)
+	return shared.ID("ft_" + sum[:32])
+}
+
+// ContainerTargetID derives the identity of a container target from
+// (containerID, cgroupID, podUID, imageDigest). A bare container id or pod name is not durable identity
+// across a restart; the combination pins the concrete running instance.
+func ContainerTargetID(containerID string, cgroupID uint64, podUID, imageDigest string) shared.ID {
+	sum := hashFields("telemetry:container-target:v1", containerID, uint64Str(cgroupID), podUID, imageDigest)
+	return shared.ID("ct_" + sum[:32])
+}

--- a/internal/domain/telemetry/entityid_test.go
+++ b/internal/domain/telemetry/entityid_test.go
@@ -1,0 +1,94 @@
+package telemetry
+
+import "testing"
+
+func TestProcessEntityIDDeterministic(t *testing.T) {
+	a := ProcessEntityID("asset-1", "boot-1", 1234, 999)
+	b := ProcessEntityID("asset-1", "boot-1", 1234, 999)
+	if a != b {
+		t.Fatalf("same tuple must yield same id: %q != %q", a, b)
+	}
+	if a == "" || len(a) < 4 || a[:3] != "pe_" {
+		t.Fatalf("id must be non-empty and prefixed pe_: %q", a)
+	}
+}
+
+func TestProcessEntityIDPIDReuse(t *testing.T) {
+	// Same PID, DIFFERENT start time = a reused PID after the first process died => a DISTINCT entity.
+	first := ProcessEntityID("asset-1", "boot-1", 1234, 1000)
+	reused := ProcessEntityID("asset-1", "boot-1", 1234, 2000)
+	if first == reused {
+		t.Fatalf("PID reuse with a new start time must produce a distinct id: both %q", first)
+	}
+}
+
+func TestProcessEntityIDRebootDistinct(t *testing.T) {
+	// Same (pid, start) on a different boot => distinct entity (start time is only monotonic within a boot).
+	before := ProcessEntityID("asset-1", "boot-1", 1234, 1000)
+	afterReboot := ProcessEntityID("asset-1", "boot-2", 1234, 1000)
+	if before == afterReboot {
+		t.Fatalf("a reboot (new BootID) must produce a distinct id: both %q", before)
+	}
+}
+
+func TestProcessEntityIDAssetDistinct(t *testing.T) {
+	h1 := ProcessEntityID("asset-1", "boot-1", 1234, 1000)
+	h2 := ProcessEntityID("asset-2", "boot-1", 1234, 1000)
+	if h1 == h2 {
+		t.Fatalf("different assets must produce distinct ids: both %q", h1)
+	}
+}
+
+// TestProcessEntityIDNoDelimiterCollision proves the length-prefixed encoding is unambiguous: two
+// different field splittings that would collide under a naive `a + sep + b` join must NOT collide.
+func TestProcessEntityIDNoDelimiterCollision(t *testing.T) {
+	// asset "a" boot "bc" vs asset "ab" boot "c" — a delimiter join of the string fields could alias.
+	x := ProcessEntityID("a", "bc", 1, 1)
+	y := ProcessEntityID("ab", "c", 1, 1)
+	if x == y {
+		t.Fatalf("length-prefixing must prevent field-boundary collisions: both %q", x)
+	}
+}
+
+func TestFileTargetIDDistinctness(t *testing.T) {
+	// Same path, different inode (path rebound to a new object) => distinct target.
+	a := FileTargetID("/etc/shadow", 66, 100, "")
+	b := FileTargetID("/etc/shadow", 66, 200, "")
+	if a == b {
+		t.Fatalf("different inode must give a distinct file target id")
+	}
+	if a[:3] != "ft_" {
+		t.Fatalf("file target id must be prefixed ft_: %q", a)
+	}
+	// Content hash participates: same path+dev+inode, different content => distinct.
+	c := FileTargetID("/etc/shadow", 66, 100, "hashA")
+	d := FileTargetID("/etc/shadow", 66, 100, "hashB")
+	if c == d {
+		t.Fatalf("different content hash must give a distinct file target id")
+	}
+}
+
+func TestContainerTargetIDDistinctness(t *testing.T) {
+	a := ContainerTargetID("cid-1", 42, "pod-uid-1", "sha256:img")
+	b := ContainerTargetID("cid-1", 42, "pod-uid-1", "sha256:img")
+	if a != b {
+		t.Fatalf("same container tuple must be stable")
+	}
+	c := ContainerTargetID("cid-2", 42, "pod-uid-1", "sha256:img")
+	if a == c {
+		t.Fatalf("different container id must be distinct")
+	}
+	if a[:3] != "ct_" {
+		t.Fatalf("container target id must be prefixed ct_: %q", a)
+	}
+}
+
+// TestDistinctIDNamespaces confirms domain separation: the same raw parts hashed for different purposes
+// never collide across id kinds.
+func TestDistinctIDNamespaces(t *testing.T) {
+	p := ProcessEntityID("x", "y", 0, 0)
+	f := FileTargetID("x", 0, 0, "y")
+	if string(p)[3:] == string(f)[3:] {
+		t.Fatalf("process and file id hashes must be domain-separated")
+	}
+}

--- a/internal/domain/telemetry/envelope.go
+++ b/internal/domain/telemetry/envelope.go
@@ -1,0 +1,128 @@
+package telemetry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// SchemaVersion is the current canonical raw-telemetry schema version. It is stamped on every envelope so
+// the schema can evolve (A0.3, #608) without an agent-version coupling; SchemaMin..SchemaMax is the range
+// a reader accepts.
+const (
+	SchemaVersion = 1
+	SchemaMin     = 1
+	SchemaMax     = 1
+)
+
+// TelemetryEnvelope is the canonical unit of raw telemetry (A1, fixes D4): a class-typed observation plus
+// the identity, three distinct timestamps, sequencing, coverage/quality honesty, and host/K8s placement
+// that the whole data plane (A2 spool, A3 transport, A5 evidence, B/C detection) is built on. It is
+// telemetry's own type; it does not reuse detection.Event as the observation schema.
+//
+// The three timestamps are deliberately separate and mean different things:
+//   - OccurredAt  — when the event happened, from the KERNEL source clock (the truth).
+//   - ObservedAt  — when the agent collector decoded it (userspace).
+//   - ReceivedAt  — when the control plane ingested it (stamped at ingest, A3; zero on the agent).
+//
+// The old thin path stamped a single userspace time.Now() for all three, which is D4.
+type TelemetryEnvelope struct {
+	SchemaVersion int
+	EventID       shared.ID
+	// EventType is the stable dotted type name (e.g. "process.exec"); it must equal Event.EventType().
+	EventType string
+	// EventClass is the top-level class for coarse indexing; it must equal Event.Class.
+	EventClass     detection.Class
+	AgentID        shared.ID
+	AgentSessionID shared.ID
+	AssetID        shared.ID
+	BootID         shared.ID
+	StreamID       shared.ID
+	SensorID       string
+	SensorVersion  string
+	OccurredAt     time.Time
+	ObservedAt     time.Time
+	ReceivedAt     time.Time
+	// Sequence is the per-stream monotonic sequence number (within one incarnation/Epoch — see #594
+	// identity conventions; the incarnation is embedded in StreamID upstream).
+	Sequence        uint64
+	CoverageFlags   CoverageFlags
+	DataQuality     DataQuality
+	ResourceContext ResourceContext
+	// Event is the typed payload (the "TypedPayload" contract slot).
+	Event TelemetryEvent
+}
+
+// Validate enforces a well-formed envelope: an accepted schema version, the mandatory identity, a class
+// that matches its payload, and the timestamp ordering invariant. ReceivedAt is optional (zero on the
+// agent, stamped at ingest) but, when present, must not precede ObservedAt.
+func (e TelemetryEnvelope) Validate() error {
+	if e.SchemaVersion < SchemaMin || e.SchemaVersion > SchemaMax {
+		return fmt.Errorf("%w: telemetry envelope schema version %d outside [%d,%d]", shared.ErrValidation, e.SchemaVersion, SchemaMin, SchemaMax)
+	}
+	if e.EventID.IsZero() {
+		return fmt.Errorf("%w: telemetry envelope has no event id", shared.ErrValidation)
+	}
+	if e.AgentID.IsZero() {
+		return fmt.Errorf("%w: telemetry envelope has no agent id", shared.ErrValidation)
+	}
+	if e.AssetID.IsZero() {
+		return fmt.Errorf("%w: telemetry envelope has no asset id", shared.ErrValidation)
+	}
+	if e.EventClass != e.Event.Class {
+		return fmt.Errorf("%w: telemetry envelope class %q disagrees with payload class %q", shared.ErrValidation, e.EventClass, e.Event.Class)
+	}
+	if e.EventType != e.Event.EventType() {
+		return fmt.Errorf("%w: telemetry envelope type %q disagrees with payload type %q", shared.ErrValidation, e.EventType, e.Event.EventType())
+	}
+	if err := e.Event.Validate(); err != nil {
+		return err
+	}
+	if e.OccurredAt.IsZero() {
+		return fmt.Errorf("%w: telemetry envelope has no occurred-at timestamp", shared.ErrValidation)
+	}
+	if e.ObservedAt.IsZero() {
+		return fmt.Errorf("%w: telemetry envelope has no observed-at timestamp", shared.ErrValidation)
+	}
+	if e.OccurredAt.After(e.ObservedAt) {
+		return fmt.Errorf("%w: telemetry envelope occurred-at %s is after observed-at %s", shared.ErrValidation, e.OccurredAt, e.ObservedAt)
+	}
+	if !e.ReceivedAt.IsZero() && e.ObservedAt.After(e.ReceivedAt) {
+		return fmt.Errorf("%w: telemetry envelope observed-at %s is after received-at %s", shared.ErrValidation, e.ObservedAt, e.ReceivedAt)
+	}
+	return nil
+}
+
+// StampReceived sets ReceivedAt at ingest (A3), enforcing the ordering invariant against ObservedAt. It
+// is the ONLY sanctioned way to set the control-plane timestamp, so the ordering can never be violated by
+// a caller assigning the field directly and skipping the check.
+func (e *TelemetryEnvelope) StampReceived(t time.Time) error {
+	if t.IsZero() {
+		return fmt.Errorf("%w: received-at timestamp is zero", shared.ErrValidation)
+	}
+	if e.ObservedAt.After(t) {
+		return fmt.Errorf("%w: received-at %s precedes observed-at %s", shared.ErrValidation, t, e.ObservedAt)
+	}
+	e.ReceivedAt = t
+	return nil
+}
+
+// Clone returns a deep copy, so an envelope handed downstream (spool, batch, evidence) cannot be mutated
+// through the original's payload pointers.
+func (e TelemetryEnvelope) Clone() TelemetryEnvelope {
+	c := e
+	c.Event = e.Event.clone()
+	return c
+}
+
+// DeriveEventID computes a deterministic, collision-resistant event id from the per-stream coordinates
+// that uniquely place an event: (AssetID, BootID, StreamID, Sequence, Class, OccurredAt). Determinism
+// makes ingest idempotent (a re-delivered event derives the same id) and makes golden fixtures stable.
+func DeriveEventID(assetID, bootID, streamID shared.ID, sequence uint64, class detection.Class, occurredAtNanos int64) shared.ID {
+	sum := hashFields("telemetry:event-id:v1",
+		assetID.String(), bootID.String(), streamID.String(),
+		uint64Str(sequence), string(class), uint64Str(uint64(occurredAtNanos)))
+	return shared.ID("te_" + sum[:32])
+}

--- a/internal/domain/telemetry/envelope_test.go
+++ b/internal/domain/telemetry/envelope_test.go
@@ -1,0 +1,123 @@
+package telemetry
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func baseEnvelope() TelemetryEnvelope {
+	occurred := time.Unix(1000, 0).UTC()
+	observed := occurred.Add(2 * time.Millisecond)
+	ev := TelemetryEvent{Class: detection.ClassProcess, Process: &ProcessObservation{Kind: "exec", PID: 10, EntityID: "pe_x", Comm: "sh", Path: "/bin/sh"}}
+	return TelemetryEnvelope{
+		SchemaVersion: SchemaVersion,
+		EventID:       "te_x",
+		EventType:     ev.EventType(),
+		EventClass:    detection.ClassProcess,
+		AgentID:       "agent-1",
+		AssetID:       "asset-1",
+		BootID:        "boot-1",
+		StreamID:      "stream-1",
+		OccurredAt:    occurred,
+		ObservedAt:    observed,
+		Event:         ev,
+	}
+}
+
+func TestEnvelopeValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*TelemetryEnvelope)
+		wantErr bool
+	}{
+		{"valid", func(*TelemetryEnvelope) {}, false},
+		{"schema too low", func(e *TelemetryEnvelope) { e.SchemaVersion = SchemaMin - 1 }, true},
+		{"schema too high", func(e *TelemetryEnvelope) { e.SchemaVersion = SchemaMax + 1 }, true},
+		{"no event id", func(e *TelemetryEnvelope) { e.EventID = "" }, true},
+		{"no agent id", func(e *TelemetryEnvelope) { e.AgentID = "" }, true},
+		{"no asset id", func(e *TelemetryEnvelope) { e.AssetID = "" }, true},
+		{"class disagrees with payload", func(e *TelemetryEnvelope) { e.EventClass = detection.ClassNetwork }, true},
+		{"type disagrees with payload", func(e *TelemetryEnvelope) { e.EventType = "process.fork" }, true},
+		{"no occurred-at", func(e *TelemetryEnvelope) { e.OccurredAt = time.Time{} }, true},
+		{"no observed-at", func(e *TelemetryEnvelope) { e.ObservedAt = time.Time{} }, true},
+		{"occurred after observed", func(e *TelemetryEnvelope) { e.OccurredAt = e.ObservedAt.Add(time.Second) }, true},
+		{"observed after received", func(e *TelemetryEnvelope) { e.ReceivedAt = e.ObservedAt.Add(-time.Second) }, true},
+		{"received set and ordered", func(e *TelemetryEnvelope) { e.ReceivedAt = e.ObservedAt.Add(time.Second) }, false},
+		{"invalid payload", func(e *TelemetryEnvelope) { e.Event.Process.PID = 0 }, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := baseEnvelope()
+			tt.mutate(&e)
+			err := e.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() err=%v, wantErr=%t", err, tt.wantErr)
+			}
+			if err != nil && !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("error must wrap shared.ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEnvelopeTimestampOrdering(t *testing.T) {
+	e := baseEnvelope()
+	if err := e.StampReceived(e.ObservedAt.Add(5 * time.Millisecond)); err != nil {
+		t.Fatalf("stamp received: %v", err)
+	}
+	if !(e.OccurredAt.Before(e.ObservedAt) || e.OccurredAt.Equal(e.ObservedAt)) {
+		t.Fatalf("occurred must be <= observed")
+	}
+	if !(e.ObservedAt.Before(e.ReceivedAt) || e.ObservedAt.Equal(e.ReceivedAt)) {
+		t.Fatalf("observed must be <= received")
+	}
+	if err := e.Validate(); err != nil {
+		t.Fatalf("validate after stamp: %v", err)
+	}
+}
+
+func TestStampReceivedRejectsOutOfOrder(t *testing.T) {
+	e := baseEnvelope()
+	if err := e.StampReceived(e.ObservedAt.Add(-time.Nanosecond)); err == nil {
+		t.Fatalf("StampReceived must reject a time before observed-at")
+	}
+	if !e.ReceivedAt.IsZero() {
+		t.Fatalf("a rejected stamp must not mutate ReceivedAt")
+	}
+	if err := e.StampReceived(time.Time{}); err == nil {
+		t.Fatalf("StampReceived must reject a zero time")
+	}
+}
+
+func TestEnvelopeCloneIsDeep(t *testing.T) {
+	e := baseEnvelope()
+	e.Event.Process.Args = []string{"a"}
+	c := e.Clone()
+	c.Event.Process.Comm = "changed"
+	c.Event.Process.Args[0] = "MUTATED"
+	if e.Event.Process.Comm != "sh" || e.Event.Process.Args[0] != "a" {
+		t.Fatalf("Clone must deep-copy the payload; original was mutated")
+	}
+}
+
+func TestDeriveEventIDDeterministic(t *testing.T) {
+	a := DeriveEventID("asset-1", "boot-1", "stream-1", 7, detection.ClassProcess, 1234)
+	b := DeriveEventID("asset-1", "boot-1", "stream-1", 7, detection.ClassProcess, 1234)
+	if a != b {
+		t.Fatalf("same coordinates must derive the same event id")
+	}
+	if a[:3] != "te_" {
+		t.Fatalf("event id must be prefixed te_: %q", a)
+	}
+	// Any coordinate change => distinct id.
+	if a == DeriveEventID("asset-1", "boot-1", "stream-1", 8, detection.ClassProcess, 1234) {
+		t.Fatalf("a different sequence must derive a distinct id")
+	}
+	if a == DeriveEventID("asset-1", "boot-1", "stream-2", 7, detection.ClassProcess, 1234) {
+		t.Fatalf("a different stream must derive a distinct id")
+	}
+}

--- a/internal/domain/telemetry/event.go
+++ b/internal/domain/telemetry/event.go
@@ -1,0 +1,113 @@
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TelemetryEvent is the class-typed observation carried by a TelemetryEnvelope. It is telemetry's OWN
+// observation type — the whole point of A1 (fixing D4) is that raw telemetry stops reusing
+// detection.Event (a thin, single-timestamp shape built for rule matching) as the canonical schema.
+//
+// Exactly one payload is set — the one matching Class — mirroring the closed-set discipline of
+// detection.Event but over telemetry's richer payloads. Class reuses detection.Class as the shared,
+// four-value class vocabulary (process/network/file/privilege) so the whole data plane names classes the
+// same way; it is only the enum, never the detection observation type.
+type TelemetryEvent struct {
+	Class     detection.Class
+	Process   *ProcessObservation
+	Network   *NetworkObservation
+	File      *FileObservation
+	Privilege *PrivilegeObservation
+}
+
+// payloadClass reports which class actually carries a payload, and whether exactly one does.
+func (e TelemetryEvent) payloadClass() (detection.Class, bool) {
+	set := make([]detection.Class, 0, 1)
+	if e.Process != nil {
+		set = append(set, detection.ClassProcess)
+	}
+	if e.Network != nil {
+		set = append(set, detection.ClassNetwork)
+	}
+	if e.File != nil {
+		set = append(set, detection.ClassFile)
+	}
+	if e.Privilege != nil {
+		set = append(set, detection.ClassPrivilege)
+	}
+	if len(set) != 1 {
+		return "", false
+	}
+	return set[0], true
+}
+
+// Validate enforces a well-formed event: a known class carrying exactly its own, individually-valid
+// payload. A malformed event must never silently match or silently miss downstream.
+func (e TelemetryEvent) Validate() error {
+	if !e.Class.Valid() {
+		return fmt.Errorf("%w: telemetry event has an unknown class %q", shared.ErrValidation, e.Class)
+	}
+	pc, ok := e.payloadClass()
+	if !ok || pc != e.Class {
+		return fmt.Errorf("%w: telemetry event of class %s must carry exactly its own payload", shared.ErrValidation, e.Class)
+	}
+	switch e.Class {
+	case detection.ClassProcess:
+		return e.Process.Validate()
+	case detection.ClassNetwork:
+		return e.Network.Validate()
+	case detection.ClassFile:
+		return e.File.Validate()
+	case detection.ClassPrivilege:
+		return e.Privilege.Validate()
+	default:
+		return fmt.Errorf("%w: telemetry event of class %s has no validator", shared.ErrValidation, e.Class)
+	}
+}
+
+// EventType returns the stable dotted per-event-type name (e.g. "process.exec", "network.connect") used
+// for indexing and coarse routing. It is derived from the class and the payload's kind/op, so it never
+// drifts from the payload it names.
+func (e TelemetryEvent) EventType() string {
+	switch e.Class {
+	case detection.ClassProcess:
+		if e.Process != nil {
+			return "process." + e.Process.Kind
+		}
+	case detection.ClassNetwork:
+		if e.Network != nil {
+			return "network." + e.Network.Kind
+		}
+	case detection.ClassFile:
+		if e.File != nil {
+			return "file." + e.File.Op
+		}
+	case detection.ClassPrivilege:
+		if e.Privilege != nil {
+			return "privilege." + e.Privilege.Kind
+		}
+	}
+	return string(e.Class)
+}
+
+// clone returns a deep copy so a caller (or a sensor reusing event structs) cannot mutate an event after
+// it has been enveloped and, downstream, sealed as evidence.
+func (e TelemetryEvent) clone() TelemetryEvent {
+	c := TelemetryEvent{Class: e.Class}
+	if e.Process != nil {
+		c.Process = e.Process.clone()
+	}
+	if e.Network != nil {
+		c.Network = e.Network.clone()
+	}
+	if e.File != nil {
+		c.File = e.File.clone()
+	}
+	if e.Privilege != nil {
+		c.Privilege = e.Privilege.clone()
+	}
+	return c
+}

--- a/internal/domain/telemetry/event_test.go
+++ b/internal/domain/telemetry/event_test.go
@@ -1,0 +1,93 @@
+package telemetry
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func validProcess() *ProcessObservation {
+	return &ProcessObservation{Kind: "exec", PID: 10, EntityID: "pe_x", Comm: "sh", Path: "/bin/sh"}
+}
+func validNetwork() *NetworkObservation {
+	return &NetworkObservation{Kind: "connect", Proto: "tcp", Direction: "egress", RemoteAddr: "1.2.3.4", RemotePort: 443}
+}
+func validFile() *FileObservation {
+	return &FileObservation{Op: "open", Path: "/etc/shadow"}
+}
+func validPriv() *PrivilegeObservation {
+	return &PrivilegeObservation{Kind: "setuid", PID: 10, ToUID: 0}
+}
+
+func TestTelemetryEventValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		event   TelemetryEvent
+		wantErr bool
+	}{
+		{"valid process", TelemetryEvent{Class: detection.ClassProcess, Process: validProcess()}, false},
+		{"valid network", TelemetryEvent{Class: detection.ClassNetwork, Network: validNetwork()}, false},
+		{"valid file", TelemetryEvent{Class: detection.ClassFile, File: validFile()}, false},
+		{"valid privilege", TelemetryEvent{Class: detection.ClassPrivilege, Privilege: validPriv()}, false},
+		{"unknown class", TelemetryEvent{Class: "bogus", Process: validProcess()}, true},
+		{"no payload", TelemetryEvent{Class: detection.ClassProcess}, true},
+		{"two payloads", TelemetryEvent{Class: detection.ClassProcess, Process: validProcess(), Network: validNetwork()}, true},
+		{"payload mismatches class", TelemetryEvent{Class: detection.ClassProcess, Network: validNetwork()}, true},
+		{"process bad kind", TelemetryEvent{Class: detection.ClassProcess, Process: &ProcessObservation{Kind: "weird", PID: 1, EntityID: "pe_x", Comm: "x"}}, true},
+		{"process no pid", TelemetryEvent{Class: detection.ClassProcess, Process: &ProcessObservation{Kind: "exec", PID: 0, EntityID: "pe_x", Comm: "x"}}, true},
+		{"process no entity id", TelemetryEvent{Class: detection.ClassProcess, Process: &ProcessObservation{Kind: "exec", PID: 1, Comm: "x"}}, true},
+		{"process no comm/path", TelemetryEvent{Class: detection.ClassProcess, Process: &ProcessObservation{Kind: "exec", PID: 1, EntityID: "pe_x"}}, true},
+		{"network bad proto", TelemetryEvent{Class: detection.ClassNetwork, Network: &NetworkObservation{Kind: "connect", Proto: "sctp", Direction: "egress", RemoteAddr: "1.1.1.1", RemotePort: 1}}, true},
+		{"network bad direction", TelemetryEvent{Class: detection.ClassNetwork, Network: &NetworkObservation{Kind: "connect", Proto: "tcp", Direction: "sideways", RemoteAddr: "1.1.1.1", RemotePort: 1}}, true},
+		{"network no remote", TelemetryEvent{Class: detection.ClassNetwork, Network: &NetworkObservation{Kind: "connect", Proto: "tcp", Direction: "egress", RemotePort: 1}}, true},
+		{"network port out of range", TelemetryEvent{Class: detection.ClassNetwork, Network: &NetworkObservation{Kind: "connect", Proto: "tcp", Direction: "egress", RemoteAddr: "1.1.1.1", RemotePort: 70000}}, true},
+		{"file bad op", TelemetryEvent{Class: detection.ClassFile, File: &FileObservation{Op: "chmod", Path: "/x"}}, true},
+		{"file no path", TelemetryEvent{Class: detection.ClassFile, File: &FileObservation{Op: "open"}}, true},
+		{"priv bad kind", TelemetryEvent{Class: detection.ClassPrivilege, Privilege: &PrivilegeObservation{Kind: "sudo", PID: 1}}, true},
+		{"priv capset no cap", TelemetryEvent{Class: detection.ClassPrivilege, Privilege: &PrivilegeObservation{Kind: "capset", PID: 1}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.event.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() err=%v, wantErr=%t", err, tt.wantErr)
+			}
+			if err != nil && !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("error must wrap shared.ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestTelemetryEventEventType(t *testing.T) {
+	tests := []struct {
+		event TelemetryEvent
+		want  string
+	}{
+		{TelemetryEvent{Class: detection.ClassProcess, Process: &ProcessObservation{Kind: "exec"}}, "process.exec"},
+		{TelemetryEvent{Class: detection.ClassProcess, Process: &ProcessObservation{Kind: "fork"}}, "process.fork"},
+		{TelemetryEvent{Class: detection.ClassNetwork, Network: &NetworkObservation{Kind: "connect"}}, "network.connect"},
+		{TelemetryEvent{Class: detection.ClassFile, File: &FileObservation{Op: "write"}}, "file.write"},
+		{TelemetryEvent{Class: detection.ClassPrivilege, Privilege: &PrivilegeObservation{Kind: "capset"}}, "privilege.capset"},
+	}
+	for _, tt := range tests {
+		if got := tt.event.EventType(); got != tt.want {
+			t.Errorf("EventType() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestTelemetryEventCloneIsDeep(t *testing.T) {
+	orig := TelemetryEvent{Class: detection.ClassProcess, Process: &ProcessObservation{Kind: "exec", PID: 1, EntityID: "pe_x", Comm: "x", Args: []string{"a", "b"}}}
+	c := orig.clone()
+	c.Process.Args[0] = "MUTATED"
+	c.Process.Comm = "changed"
+	if orig.Process.Args[0] != "a" {
+		t.Fatalf("clone must not alias argv slice")
+	}
+	if orig.Process.Comm != "x" {
+		t.Fatalf("clone must not alias payload")
+	}
+}

--- a/internal/domain/telemetry/file.go
+++ b/internal/domain/telemetry/file.go
@@ -1,0 +1,52 @@
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// FileObservation is a raw sensitive-path file observation — telemetry's own type, distinct from
+// detection.FileEvent. It carries the fields that make a file TARGET a stable identity (device + inode +
+// optional content hash) rather than a bare, rebindable path, and it links to the acting process by
+// stable entity id. The operation is a real verb (open/write/rename), never the hardcoded "open" the thin
+// decode path used to stamp.
+type FileObservation struct {
+	// Op is "open", "write", or "rename".
+	Op   string
+	Path string
+	// Device / Inode pin the concrete filesystem object behind Path (which is rebindable). Zero is
+	// allowed when the sensor could not stat the target; TargetID then falls back to path+hash.
+	Device uint64
+	Inode  uint64
+	// ContentHash is an optional sha256 of the file's contents at observation time.
+	ContentHash   string
+	PathTruncated bool
+	PID           int
+	// ProcessEntityID links the access to its process; empty when it could not be correlated.
+	ProcessEntityID shared.ID
+	Comm            string
+}
+
+// Validate enforces a well-formed file observation.
+func (f FileObservation) Validate() error {
+	switch f.Op {
+	case "open", "write", "rename":
+	default:
+		return fmt.Errorf("%w: file observation has unknown op %q", shared.ErrValidation, f.Op)
+	}
+	if f.Path == "" {
+		return fmt.Errorf("%w: file observation has no path", shared.ErrValidation)
+	}
+	return nil
+}
+
+// TargetID returns the stable file-target identity for this observation.
+func (f FileObservation) TargetID() shared.ID {
+	return FileTargetID(f.Path, f.Device, f.Inode, f.ContentHash)
+}
+
+func (f FileObservation) clone() *FileObservation {
+	c := f
+	return &c
+}

--- a/internal/domain/telemetry/network.go
+++ b/internal/domain/telemetry/network.go
@@ -1,0 +1,63 @@
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// NetworkObservation is a raw connect/sendmsg observation carrying the full 5-tuple and direction —
+// telemetry's own type, distinct from detection.NetworkEvent. It links to the originating process by its
+// stable entity id, not a bare PID.
+type NetworkObservation struct {
+	// Kind is "connect" or "sendmsg".
+	Kind string
+	// Proto is "tcp" or "udp".
+	Proto string
+	// Direction is "egress" or "ingress".
+	Direction string
+	// The 5-tuple: local and remote endpoints (LocalAddr/LocalPort may be empty/0 when the sensor sees
+	// only the connect target).
+	LocalAddr  string
+	LocalPort  int
+	RemoteAddr string
+	RemotePort int
+	PID        int
+	// ProcessEntityID links the flow to its process; empty when the process could not be correlated.
+	ProcessEntityID shared.ID
+	Comm            string
+}
+
+// Validate enforces a well-formed network observation.
+func (n NetworkObservation) Validate() error {
+	switch n.Kind {
+	case "connect", "sendmsg":
+	default:
+		return fmt.Errorf("%w: network observation has unknown kind %q", shared.ErrValidation, n.Kind)
+	}
+	switch n.Proto {
+	case "tcp", "udp":
+	default:
+		return fmt.Errorf("%w: network observation has unknown proto %q", shared.ErrValidation, n.Proto)
+	}
+	switch n.Direction {
+	case "egress", "ingress":
+	default:
+		return fmt.Errorf("%w: network observation has unknown direction %q", shared.ErrValidation, n.Direction)
+	}
+	if n.RemoteAddr == "" {
+		return fmt.Errorf("%w: network observation has no remote address", shared.ErrValidation)
+	}
+	if n.RemotePort < 0 || n.RemotePort > 65535 {
+		return fmt.Errorf("%w: network observation has out-of-range remote port %d", shared.ErrValidation, n.RemotePort)
+	}
+	if n.LocalPort < 0 || n.LocalPort > 65535 {
+		return fmt.Errorf("%w: network observation has out-of-range local port %d", shared.ErrValidation, n.LocalPort)
+	}
+	return nil
+}
+
+func (n NetworkObservation) clone() *NetworkObservation {
+	c := n
+	return &c
+}

--- a/internal/domain/telemetry/privilege.go
+++ b/internal/domain/telemetry/privilege.go
@@ -1,0 +1,44 @@
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// PrivilegeObservation is a raw privilege/capability-change observation (setuid/setresuid/capset) —
+// telemetry's own type, distinct from detection.PrivilegeEvent. It links to the acting process by stable
+// entity id.
+type PrivilegeObservation struct {
+	// Kind is "setuid", "setresuid", or "capset".
+	Kind string
+	PID  int
+	// ProcessEntityID links the change to its process; empty when it could not be correlated.
+	ProcessEntityID shared.ID
+	Comm            string
+	FromUID         int
+	ToUID           int
+	// Cap is the capability gained, when Kind is capset (empty otherwise).
+	Cap string
+}
+
+// Validate enforces a well-formed privilege observation.
+func (p PrivilegeObservation) Validate() error {
+	switch p.Kind {
+	case "setuid", "setresuid", "capset":
+	default:
+		return fmt.Errorf("%w: privilege observation has unknown kind %q", shared.ErrValidation, p.Kind)
+	}
+	if p.PID <= 0 {
+		return fmt.Errorf("%w: privilege observation has non-positive pid %d", shared.ErrValidation, p.PID)
+	}
+	if p.Kind == "capset" && p.Cap == "" {
+		return fmt.Errorf("%w: capset privilege observation carries no capability", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (p PrivilegeObservation) clone() *PrivilegeObservation {
+	c := p
+	return &c
+}

--- a/internal/domain/telemetry/process.go
+++ b/internal/domain/telemetry/process.go
@@ -1,0 +1,60 @@
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ProcessObservation is a raw process exec/fork observation — telemetry's OWN type, distinct from
+// detection.ProcessEvent (which is the thin, single-timestamp shape the detection tier matches over). It
+// carries the fields D4 was missing: the parent pid, the kernel start time, and stable entity ids for
+// both the process and its parent, so a downstream reader can build a process tree without racing PID
+// reuse.
+type ProcessObservation struct {
+	// Kind is "exec" or "fork".
+	Kind string
+	PID  int
+	PPID int
+	// StartTimeNanos is the kernel process start time; it pins ProcessEntityID against PID reuse. Zero
+	// means the sensor could not read it (the normalizer records QualityMissingStartTime).
+	StartTimeNanos uint64
+	// EntityID / ParentEntityID are the stable ids the normalizer derives via ProcessEntityID. The domain
+	// keeps them on the observation so evidence sealed later cannot be re-derived differently.
+	EntityID       shared.ID
+	ParentEntityID shared.ID
+	Comm           string   // resolved short command name (basename of Path when available)
+	Path           string   // resolved executable path
+	Args           []string // bounded argv; ArgsTruncated reports when it is a prefix
+	ArgsTruncated  bool
+	// PathTruncated reports the executable path was cut by the sensor's path buffer (mirrors the honesty
+	// signal FileObservation carries; the same fact is also recorded as QualityTruncatedPath on the
+	// envelope).
+	PathTruncated bool
+	UID           int
+}
+
+// Validate enforces a well-formed process observation.
+func (p ProcessObservation) Validate() error {
+	switch p.Kind {
+	case "exec", "fork":
+	default:
+		return fmt.Errorf("%w: process observation has unknown kind %q", shared.ErrValidation, p.Kind)
+	}
+	if p.PID <= 0 {
+		return fmt.Errorf("%w: process observation has non-positive pid %d", shared.ErrValidation, p.PID)
+	}
+	if p.EntityID.IsZero() {
+		return fmt.Errorf("%w: process observation has no entity id", shared.ErrValidation)
+	}
+	if p.Comm == "" && p.Path == "" {
+		return fmt.Errorf("%w: process observation has neither comm nor path", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (p ProcessObservation) clone() *ProcessObservation {
+	c := p
+	c.Args = append([]string(nil), p.Args...)
+	return &c
+}

--- a/internal/domain/telemetry/quality.go
+++ b/internal/domain/telemetry/quality.go
@@ -1,0 +1,88 @@
+package telemetry
+
+import "strings"
+
+// Coverage and data-quality honesty for a single raw event (A1). These are the per-event twin of the
+// batch-level loss semantics in loss.go: they let a downstream reader tell a whole observation from one
+// that was capped or is missing a field, so a rule or a hunt never treats a truncated event as complete.
+
+// DataQuality is a bitset of per-event defects the normalizer discovered (a capped argv, a missing PPID,
+// no kernel timestamp, …). Zero means the event is fully-formed. It is deliberately additive: new defects
+// get a new bit without changing the wire meaning of the old ones.
+type DataQuality uint32
+
+const (
+	// QualityTruncatedArgv — the process argv was cut by the sensor's per-arg / arg-count cap; the args
+	// present are a prefix, not the whole command line.
+	QualityTruncatedArgv DataQuality = 1 << iota
+	// QualityTruncatedPath — an executable or file path was cut by the sensor's path buffer.
+	QualityTruncatedPath
+	// QualityMissingPPID — the parent pid was not recoverable, so ParentProcessEntityID is empty.
+	QualityMissingPPID
+	// QualityMissingStartTime — the kernel process start time was unavailable, so the ProcessEntityID is
+	// derived without it and is therefore weaker against PID reuse.
+	QualityMissingStartTime
+	// QualityMissingParentStartTime — the PARENT's kernel start time was unavailable, so a reliable
+	// ParentProcessEntityID could not be derived. The normalizer leaves ParentEntityID empty rather than
+	// synthesize a start=0 id that would silently fail to match the parent's real entity (and could alias
+	// the wrong process under parent-PID reuse — the D4 failure mode); this flag records the gap honestly.
+	QualityMissingParentStartTime
+	// QualityKernelTimestampUnavailable — OccurredAt could not be taken from the kernel event and fell
+	// back to the collector's ObservedAt; the two are equal for this event.
+	QualityKernelTimestampUnavailable
+)
+
+// Has reports whether flag f is set.
+func (q DataQuality) Has(f DataQuality) bool { return q&f != 0 }
+
+// With returns q with flag f set (value-style; DataQuality is a small immutable value).
+func (q DataQuality) With(f DataQuality) DataQuality { return q | f }
+
+// IsClean reports whether the event carries no quality defects.
+func (q DataQuality) IsClean() bool { return q == 0 }
+
+// String renders the set flags for logs/tests; "clean" when none are set.
+func (q DataQuality) String() string {
+	if q.IsClean() {
+		return "clean"
+	}
+	names := []struct {
+		f DataQuality
+		n string
+	}{
+		{QualityTruncatedArgv, "truncated_argv"},
+		{QualityTruncatedPath, "truncated_path"},
+		{QualityMissingPPID, "missing_ppid"},
+		{QualityMissingStartTime, "missing_start_time"},
+		{QualityMissingParentStartTime, "missing_parent_start_time"},
+		{QualityKernelTimestampUnavailable, "kernel_ts_unavailable"},
+	}
+	var set []string
+	for _, e := range names {
+		if q.Has(e.f) {
+			set = append(set, e.n)
+		}
+	}
+	return strings.Join(set, "|")
+}
+
+// CoverageFlags is a bitset describing the coverage posture of the sensor path this event came through —
+// distinct from DataQuality (which is about THIS event's fields). Zero means full, healthy coverage.
+type CoverageFlags uint32
+
+const (
+	// CoverageSensorDegraded — the emitting sensor was in a degraded state (e.g. partial attach) when this
+	// event was produced, so absence of sibling events is not proof of absence of activity.
+	CoverageSensorDegraded CoverageFlags = 1 << iota
+	// CoverageBackfilled — the event was recovered from a durable spool after a gap, not observed live.
+	CoverageBackfilled
+)
+
+// Has reports whether flag f is set.
+func (c CoverageFlags) Has(f CoverageFlags) bool { return c&f != 0 }
+
+// With returns c with flag f set.
+func (c CoverageFlags) With(f CoverageFlags) CoverageFlags { return c | f }
+
+// IsComplete reports whether the event came through a fully-covered, live sensor path.
+func (c CoverageFlags) IsComplete() bool { return c == 0 }

--- a/internal/domain/telemetry/quality_test.go
+++ b/internal/domain/telemetry/quality_test.go
@@ -1,0 +1,48 @@
+package telemetry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDataQualityFlags(t *testing.T) {
+	var q DataQuality
+	if !q.IsClean() {
+		t.Fatalf("zero value must be clean")
+	}
+	if q.String() != "clean" {
+		t.Fatalf("clean String() = %q", q.String())
+	}
+	q = q.With(QualityTruncatedArgv).With(QualityMissingPPID)
+	if !q.Has(QualityTruncatedArgv) || !q.Has(QualityMissingPPID) {
+		t.Fatalf("With must set both flags")
+	}
+	if q.Has(QualityTruncatedPath) {
+		t.Fatalf("must not report an unset flag")
+	}
+	if q.IsClean() {
+		t.Fatalf("a set quality must not be clean")
+	}
+	s := q.String()
+	if !strings.Contains(s, "truncated_argv") || !strings.Contains(s, "missing_ppid") {
+		t.Fatalf("String() = %q, must name the set flags", s)
+	}
+	// Flags are independent bits.
+	if QualityTruncatedArgv == QualityMissingPPID {
+		t.Fatalf("flags must be distinct bits")
+	}
+}
+
+func TestCoverageFlags(t *testing.T) {
+	var c CoverageFlags
+	if !c.IsComplete() {
+		t.Fatalf("zero value must be complete")
+	}
+	c = c.With(CoverageSensorDegraded)
+	if !c.Has(CoverageSensorDegraded) || c.IsComplete() {
+		t.Fatalf("degraded coverage must not be complete")
+	}
+	if c.Has(CoverageBackfilled) {
+		t.Fatalf("must not report an unset flag")
+	}
+}

--- a/internal/domain/telemetry/resourcecontext.go
+++ b/internal/domain/telemetry/resourcecontext.go
@@ -1,0 +1,52 @@
+package telemetry
+
+import "github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+
+// ResourceContext is the host/container/Kubernetes placement of an observed event. A1 owns this type and
+// reserves its FULL field set now — the node sensor + K8s topology work (X3, #632) and endpoint
+// visibility (B, #637) populate these fields on every envelope, so fixing the schema here keeps them
+// unblocked. A non-Kubernetes host leaves the cluster/pod/workload fields empty; that is a valid, complete
+// ResourceContext, not a defect.
+//
+// A pod NAME is intentionally absent: it is not stable identity (a pod is recreated under a new name).
+// Identity is carried by the immutable ids (PodUID, WorkloadUID, ContainerID, CgroupID, ImageDigest).
+type ResourceContext struct {
+	// Host is the host's stable name (== the AssetID's host, for a non-K8s or node-level view).
+	Host string
+	// ClusterID identifies the Kubernetes cluster; empty off-cluster.
+	ClusterID string
+	// NodeUID is the K8s Node object's UID (not its rename-able name).
+	NodeUID string
+	// Namespace is the K8s namespace.
+	Namespace string
+	// ServiceAccount is the workload's service account, the identity a policy binds to.
+	ServiceAccount string
+	// WorkloadUID is the owning controller's UID (Deployment/DaemonSet/…), stable across pod churn.
+	WorkloadUID string
+	// PodUID is the Pod object's UID — the durable pod identity (pod NAME is deliberately not carried).
+	PodUID string
+	// ContainerID is the container runtime id of the process's container.
+	ContainerID string
+	// CgroupID is the kernel cgroup id, the reliable in-kernel container correlator.
+	CgroupID uint64
+	// ImageDigest is the content-addressed image the container runs (immutable, unlike a tag).
+	ImageDigest string
+	// Runtime is the container runtime (containerd, cri-o, …); empty off-container.
+	Runtime string
+}
+
+// IsKubernetes reports whether this context carries Kubernetes placement. It is true when any durable K8s
+// identity is present; a bare host context returns false.
+func (rc ResourceContext) IsKubernetes() bool {
+	return rc.ClusterID != "" || rc.PodUID != "" || rc.WorkloadUID != "" || rc.Namespace != ""
+}
+
+// ContainerTargetID returns the stable container-target identity for this context, or empty when the
+// event is not container-scoped. It is a convenience over the package-level ContainerTargetID and returns
+// shared.ID for parity with the sibling id accessors (ProcessEntityID/FileObservation.TargetID).
+func (rc ResourceContext) ContainerTargetID() shared.ID {
+	if rc.ContainerID == "" && rc.CgroupID == 0 && rc.PodUID == "" && rc.ImageDigest == "" {
+		return ""
+	}
+	return ContainerTargetID(rc.ContainerID, rc.CgroupID, rc.PodUID, rc.ImageDigest)
+}

--- a/internal/domain/telemetry/resourcecontext_test.go
+++ b/internal/domain/telemetry/resourcecontext_test.go
@@ -1,0 +1,34 @@
+package telemetry
+
+import "testing"
+
+func TestResourceContextIsKubernetes(t *testing.T) {
+	if (ResourceContext{Host: "h1"}).IsKubernetes() {
+		t.Fatalf("a bare host context is not Kubernetes")
+	}
+	tests := []ResourceContext{
+		{PodUID: "p"},
+		{ClusterID: "c"},
+		{WorkloadUID: "w"},
+		{Namespace: "n"},
+	}
+	for i, rc := range tests {
+		if !rc.IsKubernetes() {
+			t.Errorf("case %d: any durable K8s id must mark the context Kubernetes", i)
+		}
+	}
+}
+
+func TestResourceContextContainerTargetID(t *testing.T) {
+	if (ResourceContext{Host: "h1"}).ContainerTargetID() != "" {
+		t.Fatalf("a non-container context has no container target id")
+	}
+	rc := ResourceContext{ContainerID: "cid", CgroupID: 7, PodUID: "pod", ImageDigest: "sha256:x"}
+	got := rc.ContainerTargetID()
+	if got == "" || got[:3] != "ct_" {
+		t.Fatalf("container context must yield a ct_ target id, got %q", got)
+	}
+	if got != ContainerTargetID("cid", 7, "pod", "sha256:x") {
+		t.Fatalf("method must match the package function")
+	}
+}

--- a/internal/usecase/fleet/normalize/normalizer.go
+++ b/internal/usecase/fleet/normalize/normalizer.go
@@ -1,0 +1,310 @@
+// Package normalize turns a decoded kernel event (the sensor's raw, pre-identity output) into the
+// canonical telemetry.TelemetryEnvelope the whole data plane consumes (A1, #622). It is PURE and
+// DETERMINISTIC: the same DecodedEvent always yields the same envelope, including its derived entity ids
+// and event id, so ingest is idempotent (A3) and golden fixtures are stable. It owns no I/O and no clock —
+// the collector stamps ObservedAt and resolves the kernel OccurredAt before calling Normalize; ReceivedAt
+// is stamped later at ingest via TelemetryEnvelope.StampReceived.
+package normalize
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+// DecodedEvent is the sensor decode output the normalizer consumes: the raw per-class fields plus the
+// identity, sequencing, timestamps, and placement the sensor already knows. Exactly one payload pointer
+// is set — the one matching Class. The eBPF decode side (internal/infrastructure/ebpf) builds this from a
+// kernel record; the normalizer never touches the kernel or the wire.
+type DecodedEvent struct {
+	Class detection.Class
+
+	AgentID        shared.ID
+	AgentSessionID shared.ID
+	AssetID        shared.ID
+	BootID         shared.ID
+	StreamID       shared.ID
+	SensorID       string
+	SensorVersion  string
+	Sequence       uint64
+
+	// OccurredAt is the KERNEL source time of the event; zero when the sensor could not read a kernel
+	// timestamp (the normalizer then falls back to ObservedAt and records the quality flag).
+	OccurredAt time.Time
+	// ObservedAt is when the collector decoded the event (userspace); it is required.
+	ObservedAt time.Time
+
+	Resource telemetry.ResourceContext
+	Coverage telemetry.CoverageFlags
+
+	Process   *DecodedProcess
+	Network   *DecodedNetwork
+	File      *DecodedFile
+	Privilege *DecodedPrivilege
+}
+
+// DecodedProcess carries the raw process fields including the parent pid and the kernel start times the
+// normalizer needs to derive stable entity ids (the fields D4 was missing).
+type DecodedProcess struct {
+	Kind                 string // "exec" | "fork"
+	PID                  int
+	PPID                 int
+	StartTimeNanos       uint64 // this process's kernel start time; 0 => unknown
+	ParentStartTimeNanos uint64 // the parent's kernel start time; 0 => unknown
+	Comm                 string
+	Path                 string
+	Args                 []string
+	ArgsTruncated        bool
+	PathTruncated        bool
+	UID                  int
+}
+
+// DecodedNetwork carries the raw flow fields. ProcStartTimeNanos (resolved by the sensor's process table)
+// lets the normalizer link the flow to a stable ProcessEntityID; 0 leaves the link empty (honest).
+type DecodedNetwork struct {
+	Kind               string // "connect" | "sendmsg"
+	Proto              string
+	Direction          string
+	LocalAddr          string
+	LocalPort          int
+	RemoteAddr         string
+	RemotePort         int
+	PID                int
+	ProcStartTimeNanos uint64
+	Comm               string
+}
+
+// DecodedFile carries the raw file fields plus device+inode for a stable target id.
+type DecodedFile struct {
+	Op                 string // "open" | "write" | "rename"
+	Path               string
+	Device             uint64
+	Inode              uint64
+	ContentHash        string
+	PathTruncated      bool
+	PID                int
+	ProcStartTimeNanos uint64
+	Comm               string
+}
+
+// DecodedPrivilege carries the raw privilege-change fields.
+type DecodedPrivilege struct {
+	Kind               string // "setuid" | "setresuid" | "capset"
+	PID                int
+	ProcStartTimeNanos uint64
+	Comm               string
+	FromUID            int
+	ToUID              int
+	Cap                string
+}
+
+// Normalizer maps DecodedEvent → telemetry.TelemetryEnvelope. It is stateless; a zero value is ready to
+// use. It is a type (not just a function) so a future caller can inject it behind an interface without a
+// signature change.
+type Normalizer struct{}
+
+// Normalize produces the canonical envelope for one decoded event, deriving stable entity ids, resolving
+// the source timestamp, recording coverage/quality honesty, and validating the result. It returns a
+// wrapped shared.ErrValidation for any malformed input so the caller maps it to a 4xx at the edge.
+func (Normalizer) Normalize(d DecodedEvent) (telemetry.TelemetryEnvelope, error) {
+	if d.ObservedAt.IsZero() {
+		return telemetry.TelemetryEnvelope{}, fmt.Errorf("%w: decoded event has no observed-at timestamp", shared.ErrValidation)
+	}
+	if err := exactlyOnePayload(d); err != nil {
+		return telemetry.TelemetryEnvelope{}, err
+	}
+
+	dq := telemetry.DataQuality(0)
+
+	// Resolve the source timestamp. A missing kernel ts, or one that is after the collector saw the event
+	// (clock-domain skew), falls back to ObservedAt so the OccurredAt<=ObservedAt invariant always holds,
+	// and is flagged so a reader knows the two are equal by fallback, not by coincidence.
+	occurred := d.OccurredAt
+	if occurred.IsZero() || occurred.After(d.ObservedAt) {
+		occurred = d.ObservedAt
+		dq = dq.With(telemetry.QualityKernelTimestampUnavailable)
+	}
+
+	event, dq, err := d.buildEvent(dq)
+	if err != nil {
+		return telemetry.TelemetryEnvelope{}, err
+	}
+
+	env := telemetry.TelemetryEnvelope{
+		SchemaVersion:   telemetry.SchemaVersion,
+		EventID:         telemetry.DeriveEventID(d.AssetID, d.BootID, d.StreamID, d.Sequence, d.Class, occurred.UnixNano()),
+		EventType:       event.EventType(),
+		EventClass:      d.Class,
+		AgentID:         d.AgentID,
+		AgentSessionID:  d.AgentSessionID,
+		AssetID:         d.AssetID,
+		BootID:          d.BootID,
+		StreamID:        d.StreamID,
+		SensorID:        d.SensorID,
+		SensorVersion:   d.SensorVersion,
+		OccurredAt:      occurred,
+		ObservedAt:      d.ObservedAt,
+		Sequence:        d.Sequence,
+		CoverageFlags:   d.Coverage,
+		DataQuality:     dq,
+		ResourceContext: d.Resource,
+		Event:           event,
+	}
+	if err := env.Validate(); err != nil {
+		return telemetry.TelemetryEnvelope{}, err
+	}
+	return env, nil
+}
+
+func exactlyOnePayload(d DecodedEvent) error {
+	n := 0
+	if d.Process != nil {
+		n++
+	}
+	if d.Network != nil {
+		n++
+	}
+	if d.File != nil {
+		n++
+	}
+	if d.Privilege != nil {
+		n++
+	}
+	if n != 1 {
+		return fmt.Errorf("%w: decoded event must carry exactly one payload, found %d", shared.ErrValidation, n)
+	}
+	return nil
+}
+
+func (d DecodedEvent) buildEvent(dq telemetry.DataQuality) (telemetry.TelemetryEvent, telemetry.DataQuality, error) {
+	switch d.Class {
+	case detection.ClassProcess:
+		if d.Process == nil {
+			return telemetry.TelemetryEvent{}, dq, mismatch(d.Class)
+		}
+		return d.buildProcess(dq)
+	case detection.ClassNetwork:
+		if d.Network == nil {
+			return telemetry.TelemetryEvent{}, dq, mismatch(d.Class)
+		}
+		return d.buildNetwork(dq)
+	case detection.ClassFile:
+		if d.File == nil {
+			return telemetry.TelemetryEvent{}, dq, mismatch(d.Class)
+		}
+		return d.buildFile(dq)
+	case detection.ClassPrivilege:
+		if d.Privilege == nil {
+			return telemetry.TelemetryEvent{}, dq, mismatch(d.Class)
+		}
+		return d.buildPrivilege(dq)
+	default:
+		return telemetry.TelemetryEvent{}, dq, fmt.Errorf("%w: decoded event has unknown class %q", shared.ErrValidation, d.Class)
+	}
+}
+
+func mismatch(c detection.Class) error {
+	return fmt.Errorf("%w: decoded event class %q has no matching payload", shared.ErrValidation, c)
+}
+
+func (d DecodedEvent) buildProcess(dq telemetry.DataQuality) (telemetry.TelemetryEvent, telemetry.DataQuality, error) {
+	p := d.Process
+	if p.StartTimeNanos == 0 {
+		dq = dq.With(telemetry.QualityMissingStartTime)
+	}
+	if p.ArgsTruncated {
+		dq = dq.With(telemetry.QualityTruncatedArgv)
+	}
+	if p.PathTruncated {
+		dq = dq.With(telemetry.QualityTruncatedPath)
+	}
+	obs := &telemetry.ProcessObservation{
+		Kind:           p.Kind,
+		PID:            p.PID,
+		PPID:           p.PPID,
+		StartTimeNanos: p.StartTimeNanos,
+		EntityID:       telemetry.ProcessEntityID(d.AssetID, d.BootID, p.PID, p.StartTimeNanos),
+		Comm:           p.Comm,
+		Path:           p.Path,
+		Args:           append([]string(nil), p.Args...),
+		ArgsTruncated:  p.ArgsTruncated,
+		PathTruncated:  p.PathTruncated,
+		UID:            p.UID,
+	}
+	// Derive the parent entity id ONLY when it can be trustworthy. A known parent pid with an unknown
+	// start time must NOT be synthesized as a start=0 id: it would silently fail to match the parent's
+	// real entity, and could alias the wrong process under parent-PID reuse — the D4 failure mode this
+	// change exists to prevent. Leave it empty and record the gap honestly, mirroring linkProcess.
+	switch {
+	case p.PPID <= 0:
+		dq = dq.With(telemetry.QualityMissingPPID)
+	case p.ParentStartTimeNanos == 0:
+		dq = dq.With(telemetry.QualityMissingParentStartTime)
+	default:
+		obs.ParentEntityID = telemetry.ProcessEntityID(d.AssetID, d.BootID, p.PPID, p.ParentStartTimeNanos)
+	}
+	return telemetry.TelemetryEvent{Class: detection.ClassProcess, Process: obs}, dq, nil
+}
+
+func (d DecodedEvent) buildNetwork(dq telemetry.DataQuality) (telemetry.TelemetryEvent, telemetry.DataQuality, error) {
+	n := d.Network
+	obs := &telemetry.NetworkObservation{
+		Kind:            n.Kind,
+		Proto:           n.Proto,
+		Direction:       n.Direction,
+		LocalAddr:       n.LocalAddr,
+		LocalPort:       n.LocalPort,
+		RemoteAddr:      n.RemoteAddr,
+		RemotePort:      n.RemotePort,
+		PID:             n.PID,
+		ProcessEntityID: d.linkProcess(n.PID, n.ProcStartTimeNanos),
+		Comm:            n.Comm,
+	}
+	return telemetry.TelemetryEvent{Class: detection.ClassNetwork, Network: obs}, dq, nil
+}
+
+func (d DecodedEvent) buildFile(dq telemetry.DataQuality) (telemetry.TelemetryEvent, telemetry.DataQuality, error) {
+	f := d.File
+	if f.PathTruncated {
+		dq = dq.With(telemetry.QualityTruncatedPath)
+	}
+	obs := &telemetry.FileObservation{
+		Op:              f.Op,
+		Path:            f.Path,
+		Device:          f.Device,
+		Inode:           f.Inode,
+		ContentHash:     f.ContentHash,
+		PathTruncated:   f.PathTruncated,
+		PID:             f.PID,
+		ProcessEntityID: d.linkProcess(f.PID, f.ProcStartTimeNanos),
+		Comm:            f.Comm,
+	}
+	return telemetry.TelemetryEvent{Class: detection.ClassFile, File: obs}, dq, nil
+}
+
+func (d DecodedEvent) buildPrivilege(dq telemetry.DataQuality) (telemetry.TelemetryEvent, telemetry.DataQuality, error) {
+	p := d.Privilege
+	obs := &telemetry.PrivilegeObservation{
+		Kind:            p.Kind,
+		PID:             p.PID,
+		ProcessEntityID: d.linkProcess(p.PID, p.ProcStartTimeNanos),
+		Comm:            p.Comm,
+		FromUID:         p.FromUID,
+		ToUID:           p.ToUID,
+		Cap:             p.Cap,
+	}
+	return telemetry.TelemetryEvent{Class: detection.ClassPrivilege, Privilege: obs}, dq, nil
+}
+
+// linkProcess derives the stable ProcessEntityID for a non-process event's originating process, or empty
+// when the sensor could not resolve the process's start time (correlation unavailable — honestly empty,
+// never a wrong-but-present id).
+func (d DecodedEvent) linkProcess(pid int, startTimeNanos uint64) shared.ID {
+	if pid <= 0 || startTimeNanos == 0 {
+		return ""
+	}
+	return telemetry.ProcessEntityID(d.AssetID, d.BootID, pid, startTimeNanos)
+}

--- a/internal/usecase/fleet/normalize/normalizer_test.go
+++ b/internal/usecase/fleet/normalize/normalizer_test.go
@@ -1,0 +1,293 @@
+package normalize
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+var (
+	occurred = time.Unix(1_700_000_000, 0).UTC()
+	observed = occurred.Add(3 * time.Millisecond)
+)
+
+func baseProcess() DecodedEvent {
+	return DecodedEvent{
+		Class:      detection.ClassProcess,
+		AgentID:    "agent-1",
+		AssetID:    "asset-1",
+		BootID:     "boot-1",
+		StreamID:   "stream-1",
+		Sequence:   42,
+		OccurredAt: occurred,
+		ObservedAt: observed,
+		Resource:   telemetry.ResourceContext{Host: "h1"},
+		Process: &DecodedProcess{
+			Kind: "exec", PID: 1234, PPID: 1000,
+			StartTimeNanos: 5555, ParentStartTimeNanos: 1111,
+			Comm: "curl", Path: "/usr/bin/curl", Args: []string{"curl", "http://x"}, UID: 0,
+		},
+	}
+}
+
+func TestNormalizeProcessGolden(t *testing.T) {
+	env, err := Normalizer{}.Normalize(baseProcess())
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if env.SchemaVersion != telemetry.SchemaVersion {
+		t.Errorf("schema version = %d", env.SchemaVersion)
+	}
+	if env.EventClass != detection.ClassProcess || env.EventType != "process.exec" {
+		t.Errorf("class/type = %s / %s", env.EventClass, env.EventType)
+	}
+	if !env.OccurredAt.Equal(occurred) || !env.ObservedAt.Equal(observed) {
+		t.Errorf("timestamps not carried through: occurred=%s observed=%s", env.OccurredAt, env.ObservedAt)
+	}
+	if !env.ReceivedAt.IsZero() {
+		t.Errorf("received-at must be zero on the agent side, got %s", env.ReceivedAt)
+	}
+	wantEntity := telemetry.ProcessEntityID("asset-1", "boot-1", 1234, 5555)
+	if env.Event.Process.EntityID != wantEntity {
+		t.Errorf("entity id = %q, want %q", env.Event.Process.EntityID, wantEntity)
+	}
+	wantParent := telemetry.ProcessEntityID("asset-1", "boot-1", 1000, 1111)
+	if env.Event.Process.ParentEntityID != wantParent {
+		t.Errorf("parent entity id = %q, want %q", env.Event.Process.ParentEntityID, wantParent)
+	}
+	wantEventID := telemetry.DeriveEventID("asset-1", "boot-1", "stream-1", 42, detection.ClassProcess, occurred.UnixNano())
+	if env.EventID != wantEventID {
+		t.Errorf("event id = %q, want %q", env.EventID, wantEventID)
+	}
+	if !env.DataQuality.IsClean() {
+		t.Errorf("clean process must have no quality flags, got %s", env.DataQuality)
+	}
+	if err := env.Validate(); err != nil {
+		t.Errorf("normalized envelope must validate: %v", err)
+	}
+}
+
+func TestNormalizeNetworkGolden(t *testing.T) {
+	d := DecodedEvent{
+		Class: detection.ClassNetwork, AgentID: "a", AssetID: "asset-1", BootID: "boot-1", StreamID: "s", Sequence: 1,
+		OccurredAt: occurred, ObservedAt: observed,
+		Network: &DecodedNetwork{Kind: "connect", Proto: "tcp", Direction: "egress", RemoteAddr: "9.9.9.9", RemotePort: 53, PID: 1234, ProcStartTimeNanos: 5555, Comm: "curl"},
+	}
+	env, err := Normalizer{}.Normalize(d)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if env.EventType != "network.connect" {
+		t.Errorf("event type = %q", env.EventType)
+	}
+	want := telemetry.ProcessEntityID("asset-1", "boot-1", 1234, 5555)
+	if env.Event.Network.ProcessEntityID != want {
+		t.Errorf("flow must link to the process entity id: got %q want %q", env.Event.Network.ProcessEntityID, want)
+	}
+	if err := env.Validate(); err != nil {
+		t.Errorf("validate: %v", err)
+	}
+}
+
+func TestNormalizeFileGolden(t *testing.T) {
+	d := DecodedEvent{
+		Class: detection.ClassFile, AgentID: "a", AssetID: "asset-1", BootID: "boot-1", StreamID: "s", Sequence: 1,
+		OccurredAt: occurred, ObservedAt: observed,
+		File: &DecodedFile{Op: "write", Path: "/etc/shadow", Device: 66, Inode: 128, PID: 1234, ProcStartTimeNanos: 5555, Comm: "vi"},
+	}
+	env, err := Normalizer{}.Normalize(d)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if env.EventType != "file.write" {
+		t.Errorf("event type = %q (must be a real op, never a hardcoded 'open')", env.EventType)
+	}
+	if got := env.Event.File.TargetID(); got != telemetry.FileTargetID("/etc/shadow", 66, 128, "") {
+		t.Errorf("file target id mismatch: %q", got)
+	}
+	if err := env.Validate(); err != nil {
+		t.Errorf("validate: %v", err)
+	}
+}
+
+func TestNormalizePrivilegeGolden(t *testing.T) {
+	d := DecodedEvent{
+		Class: detection.ClassPrivilege, AgentID: "a", AssetID: "asset-1", BootID: "boot-1", StreamID: "s", Sequence: 1,
+		OccurredAt: occurred, ObservedAt: observed,
+		Privilege: &DecodedPrivilege{Kind: "setuid", PID: 1234, ProcStartTimeNanos: 5555, FromUID: 1000, ToUID: 0, Comm: "sudo"},
+	}
+	env, err := Normalizer{}.Normalize(d)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if env.EventType != "privilege.setuid" {
+		t.Errorf("event type = %q", env.EventType)
+	}
+	if env.Event.Privilege.ToUID != 0 || env.Event.Privilege.FromUID != 1000 {
+		t.Errorf("uid transition not carried")
+	}
+	if err := env.Validate(); err != nil {
+		t.Errorf("validate: %v", err)
+	}
+}
+
+func TestNormalizeKernelTimestampFallback(t *testing.T) {
+	d := baseProcess()
+	d.OccurredAt = time.Time{} // sensor could not read a kernel timestamp
+	env, err := Normalizer{}.Normalize(d)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !env.OccurredAt.Equal(env.ObservedAt) {
+		t.Errorf("fallback must set occurred = observed, got %s vs %s", env.OccurredAt, env.ObservedAt)
+	}
+	if !env.DataQuality.Has(telemetry.QualityKernelTimestampUnavailable) {
+		t.Errorf("fallback must set the kernel-ts-unavailable flag, got %s", env.DataQuality)
+	}
+	if err := env.Validate(); err != nil {
+		t.Errorf("validate: %v", err)
+	}
+}
+
+func TestNormalizeClockSkewClamp(t *testing.T) {
+	d := baseProcess()
+	d.OccurredAt = observed.Add(time.Second) // kernel ts implausibly after decode: clock-domain skew
+	env, err := Normalizer{}.Normalize(d)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if env.OccurredAt.After(env.ObservedAt) {
+		t.Errorf("occurred must never be after observed after clamp")
+	}
+	if !env.DataQuality.Has(telemetry.QualityKernelTimestampUnavailable) {
+		t.Errorf("a clamped skewed ts must be flagged")
+	}
+}
+
+func TestNormalizeQualityFlags(t *testing.T) {
+	d := baseProcess()
+	d.Process.ArgsTruncated = true
+	d.Process.PathTruncated = true
+	d.Process.StartTimeNanos = 0 // unknown start time
+	d.Process.PPID = 0           // unknown parent
+	env, err := Normalizer{}.Normalize(d)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	for _, f := range []telemetry.DataQuality{
+		telemetry.QualityTruncatedArgv, telemetry.QualityTruncatedPath,
+		telemetry.QualityMissingStartTime, telemetry.QualityMissingPPID,
+	} {
+		if !env.DataQuality.Has(f) {
+			t.Errorf("expected quality flag %s to be set; got %s", f, env.DataQuality)
+		}
+	}
+	if !env.Event.Process.ParentEntityID.IsZero() {
+		t.Errorf("missing PPID must leave parent entity id empty")
+	}
+}
+
+func TestNormalizeParentStartTimeMissing(t *testing.T) {
+	// A KNOWN parent pid but an UNKNOWN parent start time must NOT synthesize a start=0 parent id (it
+	// would mis-match the parent's real entity and could alias under PID reuse — the D4 failure mode).
+	// The link is left empty and the gap is flagged.
+	d := baseProcess()
+	d.Process.PPID = 1000
+	d.Process.ParentStartTimeNanos = 0
+	env, err := Normalizer{}.Normalize(d)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !env.Event.Process.ParentEntityID.IsZero() {
+		t.Errorf("unknown parent start time must leave ParentEntityID empty, got %q", env.Event.Process.ParentEntityID)
+	}
+	if !env.DataQuality.Has(telemetry.QualityMissingParentStartTime) {
+		t.Errorf("must flag QualityMissingParentStartTime; got %s", env.DataQuality)
+	}
+	if env.DataQuality.Has(telemetry.QualityMissingPPID) {
+		t.Errorf("PPID is known, so QualityMissingPPID must NOT be set; got %s", env.DataQuality)
+	}
+	// A known parent pid WITH a start time still derives the parent id (the normal, trustworthy path).
+	d.Process.ParentStartTimeNanos = 4242
+	env2, _ := Normalizer{}.Normalize(d)
+	if env2.Event.Process.ParentEntityID != telemetry.ProcessEntityID("asset-1", "boot-1", 1000, 4242) {
+		t.Errorf("a known parent start time must derive the parent entity id")
+	}
+	if env2.DataQuality.Has(telemetry.QualityMissingParentStartTime) {
+		t.Errorf("a resolved parent must not carry the missing-parent-start flag")
+	}
+}
+
+func TestNormalizeDeterministic(t *testing.T) {
+	a, err := Normalizer{}.Normalize(baseProcess())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Normalizer{}.Normalize(baseProcess())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.EventID != b.EventID || a.Event.Process.EntityID != b.Event.Process.EntityID {
+		t.Fatalf("normalization must be deterministic: %q/%q vs %q/%q", a.EventID, a.Event.Process.EntityID, b.EventID, b.Event.Process.EntityID)
+	}
+}
+
+func TestNormalizePIDReuseDistinct(t *testing.T) {
+	first := baseProcess()
+	first.Process.StartTimeNanos = 1000
+	second := baseProcess()
+	second.Process.StartTimeNanos = 2000 // same PID, later start = a reused PID, distinct process
+	ea, _ := Normalizer{}.Normalize(first)
+	eb, _ := Normalizer{}.Normalize(second)
+	if ea.Event.Process.EntityID == eb.Event.Process.EntityID {
+		t.Fatalf("PID reuse with a new start time must produce distinct entity ids")
+	}
+}
+
+func TestNormalizeLinkProcessOptional(t *testing.T) {
+	d := DecodedEvent{
+		Class: detection.ClassNetwork, AgentID: "a", AssetID: "asset-1", BootID: "boot-1", StreamID: "s", Sequence: 1,
+		OccurredAt: occurred, ObservedAt: observed,
+		Network: &DecodedNetwork{Kind: "connect", Proto: "udp", Direction: "egress", RemoteAddr: "1.1.1.1", RemotePort: 53, PID: 1234, ProcStartTimeNanos: 0},
+	}
+	env, err := Normalizer{}.Normalize(d)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !env.Event.Network.ProcessEntityID.IsZero() {
+		t.Errorf("an unresolvable process start time must leave the link empty, not a wrong-but-present id")
+	}
+}
+
+func TestNormalizeErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*DecodedEvent)
+	}{
+		{"no observed-at", func(d *DecodedEvent) { d.ObservedAt = time.Time{} }},
+		{"no payload", func(d *DecodedEvent) { d.Process = nil }},
+		{"two payloads", func(d *DecodedEvent) {
+			d.Network = &DecodedNetwork{Kind: "connect", Proto: "tcp", Direction: "egress", RemoteAddr: "1.1.1.1", RemotePort: 1}
+		}},
+		{"class-payload mismatch", func(d *DecodedEvent) { d.Class = detection.ClassNetwork }},
+		{"unknown class", func(d *DecodedEvent) { d.Class = "bogus" }},
+		{"invalid payload (bad kind)", func(d *DecodedEvent) { d.Process.Kind = "weird" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := baseProcess()
+			tt.mutate(&d)
+			_, err := Normalizer{}.Normalize(d)
+			if err == nil {
+				t.Fatalf("expected an error")
+			}
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("error must wrap shared.ErrValidation, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements **A1 (#622)** — the canonical raw-telemetry schema the whole EDR data plane is built on, and a pure normalizer that produces it. **Fixes D4**: the agent reused `detection.Event` as the observation type and stamped a single userspace `time.Now()` at decode (thin, ambiguous events).

## What lands

**Domain `internal/domain/telemetry` (pure):**
- `TelemetryEnvelope` — all contract fields: schema version, identity (Agent/AgentSession/Asset/Boot/Stream/Sensor), the **three distinct, ordered timestamps** (OccurredAt kernel / ObservedAt collector / ReceivedAt control-plane), sequence, coverage/quality, `ResourceContext`, typed payload. `StampReceived` is the only sanctioned `ReceivedAt` setter and re-checks ordering.
- `TelemetryEvent` — telemetry's **own** observation type, distinct from `detection.Event` (reuses only `detection.Class`, the shared 4-value class enum). Typed per-class payloads (process/network/privilege/file), each with `Validate()`.
- **Stable entity identity** (not raw PID): `ProcessEntityID = hash(asset, boot, pid, start_time)`, `FileTargetID` (path+device+inode+contenthash), `ContainerTargetID`. Domain-separated sha256 over a **length-prefixed** encoding — field boundaries and purposes cannot collide.
- `ResourceContext` reserves the **full K8s field set** so X3 (#632) and B (#637) are unblocked at the schema.
- `DataQuality`/`CoverageFlags` — per-event honesty (truncated argv/path, missing PPID, missing start time, missing parent start time, kernel-ts-unavailable).

**Usecase `internal/usecase/fleet/normalize` (pure, deterministic):**
- `Normalizer` maps a decoded kernel event → `TelemetryEnvelope`: derives stable entity ids, resolves the kernel `OccurredAt` (falls back to `ObservedAt` + flags on missing/skewed), records quality/coverage, derives a **deterministic** `EventID` (idempotent ingest), and validates. It never fabricates a plausible-but-wrong process/parent link when a start time is unknown — it abstains (empty id) and flags the gap (the D4 discipline).

## Tests
- Entity-id determinism / **PID-reuse → distinct** / **reboot → distinct** / boundary-collision.
- Timestamp ordering + `StampReceived` rejection paths.
- Per-class `Validate()` table tests (malformed / wrong / multiple payloads).
- Golden decode fixtures per class (raw `DecodedEvent` → expected envelope).
- `DataQuality`/`CoverageFlags`/`ResourceContext` helpers.
- **AST-level arch test** forbidding reuse of the detection observation type (allows `detection.Class`).

`go build ./...`, `go vet`, `gofmt -l` clean; `-race` green; coverage **91.5%** (telemetry) / **94.3%** (normalize). CI is intentionally off; verified locally.

## Review
Dual-reviewed (go-arch + security subagents). go-arch: **PASS** (dependency rule + concurrency/correctness). security: clean after one applied fix — **F1**: `ParentEntityID` was derived even when the parent start time was unknown (D4-mode aliasing risk); now abstains + sets `QualityMissingParentStartTime`. Also applied go-arch's two consistency nits (`ContainerTargetID()` → `shared.ID`; `ProcessObservation.PathTruncated` parity).

## Scope / non-goals (per #622)
Schema + normalizer **only**. The eBPF C-side enrichment (emitting kernel ktime/PPID/start_time) and the live-agent cutover from `detection.Event` to `TelemetryEnvelope` are **Linux-validated wiring** done in the A2/A3 transport slices (eBPF objects can't be recompiled/verified off-Linux). **#622 stays open** for that tail, mirroring how the A0 issues carried their transport tails. No transport/WAL/batching (A2/A3); no detection matching over envelopes (B/C).

Part of #594.
