### PR TITLE
feat(fleet): add asset-scoped desired reconciliation foundation

### DIFF
--- a/internal/domain/fleetdesired/desired.go
+++ b/internal/domain/fleetdesired/desired.go
@@ -1,0 +1,139 @@
+// Package fleetdesired defines control-plane-owned fleet intent for canonical technical assets.
+//
+// Desired state is deliberately separate from fleetagent.Agent.Capabilities. Capabilities are an
+// OBSERVATION reported by an untrusted agent; desired capabilities are an operator decision. Folding
+// the two together would let an agent erase a missing sensor by ceasing to advertise it. The durable
+// subject is the canonical host/cluster AssetID, not an enrolment-scoped AgentID, so replacing or
+// re-enrolling an agent does not orphan the policy it is expected to satisfy.
+package fleetdesired
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	MaxCapabilities     = 64
+	MaxCapabilityInputs = 256
+	MaxCapabilityLen    = 128
+)
+
+// State is the operator-owned desired capability set for one canonical host/cluster AssetID.
+// PolicyID identifies one policy lifecycle and never changes during updates; clearing and recreating
+// the policy mints a new PolicyID. Version starts at 1 within that lifecycle and increments once per
+// semantic replacement. The pair prevents both lost updates and delete/recreate ABA races.
+type State struct {
+	TenantID     shared.ID
+	AssetID      shared.ID
+	PolicyID     shared.ID
+	Capabilities []string
+	UpdatedBy    shared.ID
+	Version      int64
+	Audit        shared.Audit
+}
+
+type GapReason string
+
+const (
+	GapAgentMissing        GapReason = "agent_missing"
+	GapAgentStale          GapReason = "agent_stale"
+	GapAgentRevoked        GapReason = "agent_revoked"
+	GapAgentDecommissioned GapReason = "agent_decommissioned"
+	GapCapabilityMissing   GapReason = "capability_missing"
+)
+
+func (r GapReason) Valid() bool {
+	switch r {
+	case GapAgentMissing, GapAgentStale, GapAgentRevoked, GapAgentDecommissioned, GapCapabilityMissing:
+		return true
+	default:
+		return false
+	}
+}
+
+func SupportedAssetKind(kind asset.Kind) bool {
+	return kind == asset.KindHost || kind == asset.KindCluster
+}
+
+// NormalizeCapabilities returns the canonical persistence/comparison representation: trimmed,
+// de-duplicated, sorted, and bounded. Empty raw slots are ignored; an empty canonical result is handled
+// by the mutation API (which requires an explicit Clear rather than persisting a meaningless empty row).
+func NormalizeCapabilities(in []string) ([]string, error) {
+	if len(in) > MaxCapabilityInputs {
+		return nil, fmt.Errorf("%w: desired state received %d capability inputs, over the %d input bound",
+			shared.ErrValidation, len(in), MaxCapabilityInputs)
+	}
+	seen := make(map[string]struct{}, min(len(in), MaxCapabilities))
+	out := make([]string, 0, min(len(in), MaxCapabilities))
+	for _, raw := range in {
+		capability := strings.TrimSpace(raw)
+		if capability == "" {
+			continue
+		}
+		if !utf8.ValidString(capability) {
+			return nil, fmt.Errorf("%w: capability %q is not valid UTF-8", shared.ErrValidation, capability)
+		}
+		if len(capability) > MaxCapabilityLen {
+			return nil, fmt.Errorf("%w: capability %q is longer than %d bytes", shared.ErrValidation, capability, MaxCapabilityLen)
+		}
+		if strings.IndexFunc(capability, unicode.IsControl) >= 0 {
+			return nil, fmt.Errorf("%w: capability %q contains a control character", shared.ErrValidation, capability)
+		}
+		if _, exists := seen[capability]; exists {
+			continue
+		}
+		if len(out) == MaxCapabilities {
+			return nil, fmt.Errorf("%w: desired state names more than %d distinct capabilities", shared.ErrValidation, MaxCapabilities)
+		}
+		seen[capability] = struct{}{}
+		out = append(out, capability)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s State) Validate() error {
+	if s.TenantID.IsZero() {
+		return fmt.Errorf("%w: desired state needs a tenant", shared.ErrValidation)
+	}
+	if s.AssetID.IsZero() {
+		return fmt.Errorf("%w: desired state needs a canonical asset", shared.ErrValidation)
+	}
+	if s.PolicyID.IsZero() {
+		return fmt.Errorf("%w: desired state needs a policy id", shared.ErrValidation)
+	}
+	if strings.TrimSpace(s.UpdatedBy.String()) == "" {
+		return fmt.Errorf("%w: desired state change needs an actor", shared.ErrValidation)
+	}
+	if s.Version < 1 {
+		return fmt.Errorf("%w: desired state version must be at least 1", shared.ErrValidation)
+	}
+	if s.Audit.CreatedAt.IsZero() || s.Audit.UpdatedAt.IsZero() {
+		return fmt.Errorf("%w: desired state needs audit timestamps", shared.ErrValidation)
+	}
+	if s.Audit.UpdatedAt.Before(s.Audit.CreatedAt) {
+		return fmt.Errorf("%w: desired state updated_at precedes created_at", shared.ErrValidation)
+	}
+	canonical, err := NormalizeCapabilities(s.Capabilities)
+	if err != nil {
+		return err
+	}
+	if len(canonical) == 0 {
+		return fmt.Errorf("%w: desired state must contain at least one capability; clear the intent instead", shared.ErrValidation)
+	}
+	if len(canonical) != len(s.Capabilities) {
+		return fmt.Errorf("%w: desired capabilities must be canonical (trimmed, unique, sorted)", shared.ErrValidation)
+	}
+	for i := range canonical {
+		if canonical[i] != s.Capabilities[i] {
+			return fmt.Errorf("%w: desired capabilities must be canonical (trimmed, unique, sorted)", shared.ErrValidation)
+		}
+	}
+	return nil
+}

--- a/internal/domain/fleetdesired/desired.go
+++ b/internal/domain/fleetdesired/desired.go
@@ -38,6 +38,8 @@ type State struct {
 	Audit        shared.Audit
 }
 
+// GapReason names why a desired capability is not covered by a healthy bound agent. It is a closed set
+// so a consumer can reason over every uncovered case rather than an open-ended string.
 type GapReason string
 
 const (
@@ -48,6 +50,7 @@ const (
 	GapCapabilityMissing   GapReason = "capability_missing"
 )
 
+// Valid reports whether r is a known gap reason.
 func (r GapReason) Valid() bool {
 	switch r {
 	case GapAgentMissing, GapAgentStale, GapAgentRevoked, GapAgentDecommissioned, GapCapabilityMissing:
@@ -57,6 +60,8 @@ func (r GapReason) Valid() bool {
 	}
 }
 
+// SupportedAssetKind reports whether desired capabilities may target an asset of this kind. Only the
+// canonical host and cluster kinds carry a fleet agent that can satisfy a desired capability.
 func SupportedAssetKind(kind asset.Kind) bool {
 	return kind == asset.KindHost || kind == asset.KindCluster
 }

--- a/internal/domain/fleetdesired/desired_test.go
+++ b/internal/domain/fleetdesired/desired_test.go
@@ -1,0 +1,110 @@
+package fleetdesired
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestNormalizeCapabilitiesCanonical(t *testing.T) {
+	got, err := NormalizeCapabilities([]string{" telemetry.process ", "inventory.host", "telemetry.process", ""})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"inventory.host", "telemetry.process"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestNormalizeCapabilitiesBoundsRawAndCanonicalIndependently(t *testing.T) {
+	duplicates := make([]string, MaxCapabilities+1)
+	for i := range duplicates {
+		duplicates[i] = "process"
+	}
+	got, err := NormalizeCapabilities(duplicates)
+	if err != nil || len(got) != 1 || got[0] != "process" {
+		t.Fatalf("benign duplicates should canonicalize: got=%v err=%v", got, err)
+	}
+
+	tooManyDistinct := make([]string, MaxCapabilities+1)
+	for i := range tooManyDistinct {
+		tooManyDistinct[i] = fmt.Sprintf("cap.%03d", i)
+	}
+	if _, err := NormalizeCapabilities(tooManyDistinct); err == nil {
+		t.Fatal("expected distinct capability-count validation error")
+	}
+
+	tooManyInputs := make([]string, MaxCapabilityInputs+1)
+	for i := range tooManyInputs {
+		tooManyInputs[i] = "process"
+	}
+	if _, err := NormalizeCapabilities(tooManyInputs); err == nil {
+		t.Fatal("expected raw input-count validation error")
+	}
+	if _, err := NormalizeCapabilities([]string{strings.Repeat("x", MaxCapabilityLen+1)}); err == nil {
+		t.Fatal("expected capability-length validation error")
+	}
+	if _, err := NormalizeCapabilities([]string{"sensor\nexec"}); err == nil {
+		t.Fatal("expected control-character validation error")
+	}
+	if _, err := NormalizeCapabilities([]string{string([]byte{0xff})}); err == nil {
+		t.Fatal("expected invalid UTF-8 capability validation error")
+	}
+}
+
+func TestSupportedAssetKind(t *testing.T) {
+	if !SupportedAssetKind(asset.KindHost) || !SupportedAssetKind(asset.KindCluster) {
+		t.Fatal("host and cluster must be supported desired-state subjects")
+	}
+	for _, kind := range []asset.Kind{asset.KindWorkload, asset.KindImage, asset.KindNamespace} {
+		if SupportedAssetKind(kind) {
+			t.Fatalf("unexpected desired-state subject kind accepted: %q", kind)
+		}
+	}
+}
+
+func validState(now time.Time) State {
+	return State{
+		TenantID: "tenant-1", AssetID: "asset-1", PolicyID: "policy-1", UpdatedBy: "operator-1", Version: 1,
+		Capabilities: []string{"a", "z"}, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+}
+
+func TestStateValidateRequiresCanonicalNonEmptyVersionedPolicy(t *testing.T) {
+	now := time.Date(2026, 8, 19, 1, 2, 3, 0, time.UTC)
+	state := validState(now)
+	if err := state.Validate(); err != nil {
+		t.Fatalf("valid state rejected: %v", err)
+	}
+
+	state = validState(now)
+	state.PolicyID = ""
+	if err := state.Validate(); err == nil {
+		t.Fatal("expected empty policy id to be rejected")
+	}
+	state = validState(now)
+	state.UpdatedBy = "   "
+	if err := state.Validate(); err == nil {
+		t.Fatal("expected blank actor to be rejected")
+	}
+	state = validState(now)
+	state.Capabilities = []string{"z", "a"}
+	if err := state.Validate(); err == nil {
+		t.Fatal("expected non-canonical ordering to be rejected")
+	}
+	state = validState(now)
+	state.Capabilities = nil
+	if err := state.Validate(); err == nil {
+		t.Fatal("expected empty policy to be rejected")
+	}
+	state = validState(now)
+	state.Version = 0
+	if err := state.Validate(); err == nil {
+		t.Fatal("expected non-positive version to be rejected")
+	}
+}

--- a/internal/infrastructure/persistence/memory/asset_lookup.go
+++ b/internal/infrastructure/persistence/memory/asset_lookup.go
@@ -1,0 +1,46 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// GetAssetByID returns one canonical technical asset by server-issued ID. It is intentionally a
+// narrow extension used by desired-state admission; the broad AssetRepository contract remains keyed
+// by natural identity for normal observation/upsert flows. Invalid identifiers are validation errors;
+// a valid but absent/cross-tenant asset is reported as ErrNotFound. The memory AssetStore is keyed by
+// natural identity rather than ID, so duplicate canonical IDs are detected across the whole store and
+// fail closed to mirror PostgreSQL's global fleet_assets primary-key invariant.
+func (s *AssetStore) GetAssetByID(_ context.Context, tenantID, id shared.ID) (*asset.Asset, error) {
+	if tenantID.IsZero() || id.IsZero() {
+		return nil, fmt.Errorf("%w: asset id lookup needs tenant and id", shared.ErrValidation)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var (
+		found   *asset.Asset
+		matches int
+	)
+	for _, a := range s.assets {
+		if a.ID != id {
+			continue
+		}
+		matches++
+		if matches > 1 {
+			return nil, fmt.Errorf("%w: duplicate canonical asset id %s in memory asset store",
+				shared.ErrValidation, id)
+		}
+		if a.TenantID == tenantID {
+			cp := *a
+			cp.Attributes = cloneMap(a.Attributes)
+			found = &cp
+		}
+	}
+	if found == nil {
+		return nil, shared.ErrNotFound
+	}
+	return found, nil
+}

--- a/internal/infrastructure/persistence/memory/asset_lookup_test.go
+++ b/internal/infrastructure/persistence/memory/asset_lookup_test.go
@@ -1,0 +1,99 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAssetStoreGetAssetByIDTenantIsolationAndCopy(t *testing.T) {
+	ctx := context.Background()
+	store := NewAssetStore()
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	a, err := asset.New("asset-a", "tenant-a", asset.KindHost, "machine-id/a", "host-a", map[string]string{"k": "v"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertAsset(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetAssetByID(ctx, "tenant-a", "asset-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "asset-a" || got.TenantID != "tenant-a" || got.Kind != asset.KindHost {
+		t.Fatalf("unexpected asset: %+v", got)
+	}
+	got.Attributes["k"] = "mutated"
+	again, err := store.GetAssetByID(ctx, "tenant-a", "asset-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Attributes["k"] != "v" {
+		t.Fatalf("caller mutated stored attributes: %+v", again.Attributes)
+	}
+	if _, err := store.GetAssetByID(ctx, "tenant-b", "asset-a"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant lookup=%v, want ErrNotFound", err)
+	}
+	for _, tc := range []struct {
+		tenant shared.ID
+		id     shared.ID
+	}{
+		{id: "asset-a"},
+		{tenant: "tenant-a"},
+	} {
+		if _, err := store.GetAssetByID(ctx, tc.tenant, tc.id); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("invalid lookup tenant=%q id=%q error=%v, want ErrValidation", tc.tenant, tc.id, err)
+		}
+	}
+}
+
+func TestAssetStoreGetAssetByIDRejectsDuplicateCanonicalID(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+
+	t.Run("within tenant", func(t *testing.T) {
+		store := NewAssetStore()
+		for _, key := range []string{"machine-id/a", "machine-id/b"} {
+			a, err := asset.New("asset-duplicate", "tenant-a", asset.KindHost, key, key, nil, now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.UpsertAsset(ctx, a); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := store.GetAssetByID(ctx, "tenant-a", "asset-duplicate"); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("duplicate canonical id lookup=%v, want ErrValidation", err)
+		}
+	})
+
+	t.Run("across tenants", func(t *testing.T) {
+		store := NewAssetStore()
+		for _, tc := range []struct {
+			tenant shared.ID
+			key    string
+		}{
+			{tenant: "tenant-a", key: "machine-id/a"},
+			{tenant: "tenant-b", key: "machine-id/b"},
+		} {
+			a, err := asset.New("asset-global-duplicate", tc.tenant, asset.KindHost, tc.key, tc.key, nil, now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.UpsertAsset(ctx, a); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, tenant := range []shared.ID{"tenant-a", "tenant-b"} {
+			if _, err := store.GetAssetByID(ctx, tenant, "asset-global-duplicate"); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("global duplicate lookup tenant=%s error=%v, want ErrValidation", tenant, err)
+			}
+		}
+	})
+}

--- a/internal/infrastructure/persistence/memory/fleetdesired_store.go
+++ b/internal/infrastructure/persistence/memory/fleetdesired_store.go
@@ -1,0 +1,135 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fleetDesiredStoreKey struct {
+	tenantID shared.ID
+	assetID  shared.ID
+}
+
+// FleetDesiredStore is the in-memory desired-state store used by development and focused tests.
+type FleetDesiredStore struct {
+	mu     sync.RWMutex
+	states map[fleetDesiredStoreKey]fleetdesired.State
+}
+
+var _ ports.FleetDesiredStore = (*FleetDesiredStore)(nil)
+
+func NewFleetDesiredStore() *FleetDesiredStore {
+	return &FleetDesiredStore{states: make(map[fleetDesiredStoreKey]fleetdesired.State)}
+}
+
+func cloneDesired(state fleetdesired.State) fleetdesired.State {
+	state.Capabilities = append([]string(nil), state.Capabilities...)
+	return state
+}
+
+func (s *FleetDesiredStore) Get(_ context.Context, tenantID, assetID shared.ID) (*fleetdesired.State, error) {
+	if tenantID.IsZero() || assetID.IsZero() {
+		return nil, fmt.Errorf("%w: desired-state lookup needs tenant and asset", shared.ErrValidation)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	state, ok := s.states[fleetDesiredStoreKey{tenantID: tenantID, assetID: assetID}]
+	if !ok {
+		return nil, fmt.Errorf("desired state for asset %s: %w", assetID, shared.ErrNotFound)
+	}
+	state = cloneDesired(state)
+	return &state, nil
+}
+
+// Put applies a lifecycle-aware CAS. A new PolicyID may only create an absent row at version 1;
+// updates must retain the stored PolicyID and advance version by exactly one. PolicyID is unique
+// within a tenant so a lifecycle identifier can never alias another asset's policy.
+func (s *FleetDesiredStore) Put(_ context.Context, state *fleetdesired.State) error {
+	if state == nil {
+		return fmt.Errorf("%w: nil fleet desired state", shared.ErrValidation)
+	}
+	if err := state.Validate(); err != nil {
+		return err
+	}
+	stored := cloneDesired(*state)
+	key := fleetDesiredStoreKey{tenantID: state.TenantID, assetID: state.AssetID}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, exists := s.states[key]
+	if !exists {
+		if stored.Version != 1 {
+			return fmt.Errorf("%w: desired state for asset %s is absent; create requires version 1", shared.ErrConflict, state.AssetID)
+		}
+		for existingKey, existing := range s.states {
+			if existingKey.tenantID == stored.TenantID && existing.PolicyID == stored.PolicyID {
+				return fmt.Errorf("%w: desired policy id %s already belongs to asset %s in tenant %s",
+					shared.ErrConflict, stored.PolicyID, existing.AssetID, stored.TenantID)
+			}
+		}
+		s.states[key] = stored
+		return nil
+	}
+	if stored.PolicyID != current.PolicyID {
+		return fmt.Errorf("%w: desired policy lifecycle changed from %s to %s for asset %s",
+			shared.ErrConflict, current.PolicyID, stored.PolicyID, state.AssetID)
+	}
+	if current.Version == 1<<63-1 {
+		return fmt.Errorf("%w: desired state version exhausted for asset %s", shared.ErrConflict, state.AssetID)
+	}
+	if stored.Version != current.Version+1 {
+		return fmt.Errorf("%w: desired state version %d does not follow stored version %d for asset %s",
+			shared.ErrConflict, stored.Version, current.Version, state.AssetID)
+	}
+	stored.Audit.CreatedAt = current.Audit.CreatedAt
+	if err := stored.Validate(); err != nil {
+		return err
+	}
+	s.states[key] = stored
+	return nil
+}
+
+// Delete clears only the lifecycle/version the caller observed. Absence is idempotent; either a newer
+// version or a delete/recreate lifecycle returns ErrConflict and remains untouched.
+func (s *FleetDesiredStore) Delete(_ context.Context, tenantID, assetID, expectedPolicyID shared.ID, expectedVersion int64) error {
+	if tenantID.IsZero() || assetID.IsZero() || expectedPolicyID.IsZero() || expectedVersion < 1 {
+		return fmt.Errorf("%w: desired-state delete needs tenant, asset, policy id and positive expected version", shared.ErrValidation)
+	}
+	key := fleetDesiredStoreKey{tenantID: tenantID, assetID: assetID}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, exists := s.states[key]
+	if !exists {
+		return nil
+	}
+	if current.PolicyID != expectedPolicyID || current.Version != expectedVersion {
+		return fmt.Errorf("%w: desired policy changed after %s@%d for asset %s",
+			shared.ErrConflict, expectedPolicyID, expectedVersion, assetID)
+	}
+	delete(s.states, key)
+	return nil
+}
+
+func (s *FleetDesiredStore) List(_ context.Context, tenantID shared.ID) ([]*fleetdesired.State, error) {
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: desired-state list needs a tenant", shared.ErrValidation)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*fleetdesired.State, 0)
+	for _, state := range s.states {
+		if state.TenantID != tenantID {
+			continue
+		}
+		copy := cloneDesired(state)
+		out = append(out, &copy)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].AssetID < out[j].AssetID })
+	return out, nil
+}

--- a/internal/infrastructure/persistence/memory/fleetdesired_store_policyid_test.go
+++ b/internal/infrastructure/persistence/memory/fleetdesired_store_policyid_test.go
@@ -1,0 +1,192 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestFleetDesiredStoreRejectsDuplicatePolicyIDWithinTenant(t *testing.T) {
+	ctx := context.Background()
+	store := NewFleetDesiredStore()
+	now := time.Date(2026, 8, 19, 4, 0, 0, 0, time.UTC)
+	first := desiredStoreState("tenant", "asset-a", "policy-shared", []string{"process"}, 1, now)
+	second := desiredStoreState("tenant", "asset-b", "policy-shared", []string{"network"}, 1, now)
+	if err := store.Put(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(ctx, second); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate PolicyID error=%v, want ErrConflict", err)
+	}
+	if _, err := store.Get(ctx, "tenant", "asset-b"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("conflicting policy was stored: %v", err)
+	}
+	got, err := store.Get(ctx, "tenant", "asset-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PolicyID != "policy-shared" || got.Capabilities[0] != "process" {
+		t.Fatalf("existing policy changed after conflict: %+v", got)
+	}
+
+	// Policy IDs are tenant-scoped: the same opaque identifier in another tenant does not collide.
+	otherTenant := desiredStoreState("other", "asset-x", "policy-shared", []string{"file"}, 1, now)
+	if err := store.Put(ctx, otherTenant); err != nil {
+		t.Fatalf("cross-tenant PolicyID reuse unexpectedly conflicted: %v", err)
+	}
+}
+
+func TestFleetDesiredStoreDeleteRecreateRejectsStaleLifecycleDelete(t *testing.T) {
+	ctx := context.Background()
+	store := NewFleetDesiredStore()
+	now := time.Date(2026, 8, 19, 5, 0, 0, 0, time.UTC)
+	old := desiredStoreState("tenant", "asset", "policy-old", []string{"process"}, 1, now)
+	if err := store.Put(ctx, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(ctx, "tenant", "asset", "policy-old", 1); err != nil {
+		t.Fatal(err)
+	}
+	fresh := desiredStoreState("tenant", "asset", "policy-new", []string{"network"}, 1, now.Add(time.Minute))
+	if err := store.Put(ctx, fresh); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(ctx, "tenant", "asset", "policy-old", 1); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale lifecycle delete error=%v, want ErrConflict", err)
+	}
+	got, err := store.Get(ctx, "tenant", "asset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PolicyID != "policy-new" || got.Version != 1 || got.Capabilities[0] != "network" {
+		t.Fatalf("stale delete removed or changed recreated lifecycle: %+v", got)
+	}
+}
+
+func TestFleetDesiredStoreConcurrentCASAllowsExactlyOneWinner(t *testing.T) {
+	ctx := context.Background()
+	store := NewFleetDesiredStore()
+	now := time.Date(2026, 8, 19, 6, 0, 0, 0, time.UTC)
+
+	createResults := make(chan error, 2)
+	startCreate := make(chan struct{})
+	for _, state := range []*fleetdesired.State{
+		desiredStoreState("tenant", "asset", "policy-a", []string{"process"}, 1, now),
+		desiredStoreState("tenant", "asset", "policy-b", []string{"network"}, 1, now),
+	} {
+		state := state
+		go func() {
+			<-startCreate
+			createResults <- store.Put(ctx, state)
+		}()
+	}
+	close(startCreate)
+	assertOneCASWinner(t, createResults)
+
+	current, err := store.Get(ctx, "tenant", "asset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Version != 1 || current.PolicyID.IsZero() {
+		t.Fatalf("concurrent create stored invalid winner: %+v", current)
+	}
+
+	updateResults := make(chan error, 2)
+	startUpdate := make(chan struct{})
+	for _, caps := range [][]string{{"file"}, {"privilege"}} {
+		state := desiredStoreState("tenant", "asset", current.PolicyID.String(), caps, 2, now.Add(time.Minute))
+		state.Audit.CreatedAt = now
+		go func(state *fleetdesired.State) {
+			<-startUpdate
+			updateResults <- store.Put(ctx, state)
+		}(state)
+	}
+	close(startUpdate)
+	assertOneCASWinner(t, updateResults)
+
+	current, err = store.Get(ctx, "tenant", "asset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Version != 2 || current.PolicyID.IsZero() || len(current.Capabilities) != 1 {
+		t.Fatalf("concurrent update stored invalid winner: %+v", current)
+	}
+}
+
+func TestFleetDesiredStoreConcurrentUpdateAndClearAllowsExactlyOneWinner(t *testing.T) {
+	ctx := context.Background()
+	store := NewFleetDesiredStore()
+	now := time.Date(2026, 8, 19, 7, 0, 0, 0, time.UTC)
+	base := desiredStoreState("tenant", "asset", "policy-race", []string{"process"}, 1, now)
+	if err := store.Put(ctx, base); err != nil {
+		t.Fatal(err)
+	}
+	update := desiredStoreState("tenant", "asset", "policy-race", []string{"network"}, 2, now.Add(time.Minute))
+	update.Audit.CreatedAt = now
+
+	type result struct {
+		op  string
+		err error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	go func() {
+		<-start
+		results <- result{op: "update", err: store.Put(ctx, update)}
+	}()
+	go func() {
+		<-start
+		results <- result{op: "clear", err: store.Delete(ctx, "tenant", "asset", "policy-race", 1)}
+	}()
+	close(start)
+	first, second := <-results, <-results
+	outcomes := map[string]error{first.op: first.err, second.op: second.err}
+	wins, conflicts := 0, 0
+	for _, result := range []result{first, second} {
+		switch {
+		case result.err == nil:
+			wins++
+		case errors.Is(result.err, shared.ErrConflict):
+			conflicts++
+		default:
+			t.Fatalf("%s returned unexpected error: %v", result.op, result.err)
+		}
+	}
+	if wins != 1 || conflicts != 1 {
+		t.Fatalf("update/clear race wins=%d conflicts=%d, want one each: %+v", wins, conflicts, outcomes)
+	}
+	got, err := store.Get(ctx, "tenant", "asset")
+	if outcomes["update"] == nil {
+		if err != nil || got.Version != 2 || len(got.Capabilities) != 1 || got.Capabilities[0] != "network" {
+			t.Fatalf("winning update not preserved: got=%+v err=%v outcomes=%+v", got, err, outcomes)
+		}
+		return
+	}
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("winning clear left policy behind: got=%+v err=%v outcomes=%+v", got, err, outcomes)
+	}
+}
+
+func assertOneCASWinner(t *testing.T, results <-chan error) {
+	t.Helper()
+	successes := 0
+	conflicts := 0
+	for i := 0; i < 2; i++ {
+		err := <-results
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, shared.ErrConflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected CAS result: %v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("CAS results successes=%d conflicts=%d, want exactly one of each", successes, conflicts)
+	}
+}

--- a/internal/infrastructure/persistence/memory/fleetdesired_store_test.go
+++ b/internal/infrastructure/persistence/memory/fleetdesired_store_test.go
@@ -1,0 +1,142 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func desiredStoreState(tenant, assetID, policyID string, caps []string, version int64, now time.Time) *fleetdesired.State {
+	return &fleetdesired.State{
+		TenantID: shared.ID(tenant), AssetID: shared.ID(assetID), PolicyID: shared.ID(policyID), Capabilities: caps,
+		UpdatedBy: "operator", Version: version, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+}
+
+func TestFleetDesiredStoreTenantIsolationCopiesOrderingAndDelete(t *testing.T) {
+	ctx := context.Background()
+	store := NewFleetDesiredStore()
+	now := time.Date(2026, 8, 19, 1, 2, 3, 0, time.UTC)
+	for _, state := range []*fleetdesired.State{
+		desiredStoreState("tenant-a", "asset-b", "policy-b", []string{"b"}, 1, now),
+		desiredStoreState("tenant-a", "asset-a", "policy-a", []string{"a"}, 1, now),
+		desiredStoreState("tenant-b", "asset-x", "policy-x", []string{"x"}, 1, now),
+	} {
+		if err := store.Put(ctx, state); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rows, err := store.List(ctx, "tenant-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 || rows[0].AssetID != "asset-a" || rows[1].AssetID != "asset-b" {
+		t.Fatalf("unexpected deterministic tenant list: %#v", rows)
+	}
+	rows[0].Capabilities[0] = "mutated"
+	got, err := store.Get(ctx, "tenant-a", "asset-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Capabilities[0] != "a" {
+		t.Fatalf("caller mutated stored slice: %v", got.Capabilities)
+	}
+	if _, err := store.Get(ctx, "tenant-a", "asset-x"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant lookup = %v, want ErrNotFound", err)
+	}
+	if err := store.Delete(ctx, "tenant-a", "asset-a", "policy-a", 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(ctx, "tenant-a", "asset-a", "policy-a", 1); err != nil {
+		t.Fatalf("idempotent delete failed: %v", err)
+	}
+	if _, err := store.Get(ctx, "tenant-a", "asset-a"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("deleted policy lookup=%v, want ErrNotFound", err)
+	}
+}
+
+func TestFleetDesiredStoreUsesStructuredKeyNotDelimiterComposition(t *testing.T) {
+	ctx := context.Background()
+	store := NewFleetDesiredStore()
+	now := time.Date(2026, 8, 19, 1, 2, 3, 0, time.UTC)
+	first := desiredStoreState("a\x00b", "c", "policy-first", []string{"first"}, 1, now)
+	second := desiredStoreState("a", "b\x00c", "policy-second", []string{"second"}, 1, now)
+	if err := store.Put(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(ctx, second); err != nil {
+		t.Fatal(err)
+	}
+	gotFirst, err := store.Get(ctx, first.TenantID, first.AssetID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotSecond, err := store.Get(ctx, second.TenantID, second.AssetID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotFirst.Capabilities[0] != "first" || gotSecond.Capabilities[0] != "second" {
+		t.Fatalf("structured keys collided: first=%+v second=%+v", gotFirst, gotSecond)
+	}
+}
+
+func TestFleetDesiredStorePreservedCreatedAtCannotBreakTimeOrder(t *testing.T) {
+	ctx := context.Background()
+	store := NewFleetDesiredStore()
+	created := time.Date(2026, 8, 19, 2, 0, 0, 0, time.UTC)
+	initial := desiredStoreState("tenant", "asset", "policy", []string{"process"}, 1, created)
+	if err := store.Put(ctx, initial); err != nil {
+		t.Fatal(err)
+	}
+	older := created.Add(-time.Minute)
+	update := desiredStoreState("tenant", "asset", "policy", []string{"network"}, 2, older)
+	if err := store.Put(ctx, update); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("Put error=%v, want validation error", err)
+	}
+	got, err := store.Get(ctx, "tenant", "asset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != 1 || len(got.Capabilities) != 1 || got.Capabilities[0] != "process" {
+		t.Fatalf("invalid update changed stored state: %+v", got)
+	}
+}
+
+func TestFleetDesiredStoreCASRejectsStaleWritersAndDeletes(t *testing.T) {
+	ctx := context.Background()
+	store := NewFleetDesiredStore()
+	now := time.Date(2026, 8, 19, 3, 0, 0, 0, time.UTC)
+	v1 := desiredStoreState("tenant", "asset", "policy", []string{"process"}, 1, now)
+	if err := store.Put(ctx, v1); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(ctx, desiredStoreState("tenant", "asset", "policy", []string{"network"}, 1, now)); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate create error=%v, want ErrConflict", err)
+	}
+
+	v2 := desiredStoreState("tenant", "asset", "policy", []string{"network"}, 2, now.Add(time.Minute))
+	v2.Audit.CreatedAt = now
+	if err := store.Put(ctx, v2); err != nil {
+		t.Fatal(err)
+	}
+	stale := desiredStoreState("tenant", "asset", "policy", []string{"file"}, 2, now.Add(2*time.Minute))
+	stale.Audit.CreatedAt = now
+	if err := store.Put(ctx, stale); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale update error=%v, want ErrConflict", err)
+	}
+	if err := store.Delete(ctx, "tenant", "asset", "policy", 1); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale delete error=%v, want ErrConflict", err)
+	}
+	got, err := store.Get(ctx, "tenant", "asset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != 2 || got.PolicyID != "policy" || len(got.Capabilities) != 1 || got.Capabilities[0] != "network" {
+		t.Fatalf("stale operation changed newer policy: %+v", got)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/asset_lookup.go
+++ b/internal/infrastructure/persistence/postgres/asset_lookup.go
@@ -1,0 +1,40 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// GetAssetByID returns one canonical technical asset by server-issued ID under tenant RLS. It is a
+// narrow extension for control-plane policy admission; normal asset observation remains keyed by the
+// natural (tenant, kind, key) identity. Cross-tenant and missing ids both resolve to ErrNotFound so a
+// caller cannot distinguish another tenant's asset from an absent one.
+func (r *AssetRepository) GetAssetByID(ctx context.Context, tenantID, id shared.ID) (*asset.Asset, error) {
+	if tenantID.IsZero() || id.IsZero() {
+		return nil, fmt.Errorf("%w: asset id lookup needs tenant and id", shared.ErrValidation)
+	}
+	var out *asset.Asset
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var scanErr error
+		out, scanErr = scanAsset(tx.QueryRow(ctx,
+			`SELECT `+assetCols+` FROM fleet_assets WHERE tenant_id=$1 AND id=$2`,
+			tenantID.String(), id.String()))
+		return scanErr
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("asset %s: %w", id, shared.ErrNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("asset id lookup: %w", err)
+	}
+	if out == nil || out.TenantID != tenantID || out.ID != id {
+		return nil, fmt.Errorf("%w: asset id lookup returned inconsistent identity", shared.ErrValidation)
+	}
+	return out, nil
+}

--- a/internal/infrastructure/persistence/postgres/fleetdesired_repo.go
+++ b/internal/infrastructure/persistence/postgres/fleetdesired_repo.go
@@ -1,0 +1,190 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const fleetDesiredCols = `tenant_id, asset_id, policy_id, capabilities, updated_by, version, created_at, updated_at`
+
+type FleetDesiredRepository struct{ pool *pgxpool.Pool }
+
+func NewFleetDesiredRepository(pool *pgxpool.Pool) *FleetDesiredRepository {
+	return &FleetDesiredRepository{pool: pool}
+}
+
+var _ ports.FleetDesiredStore = (*FleetDesiredRepository)(nil)
+
+func (r *FleetDesiredRepository) Get(ctx context.Context, tenantID, assetID shared.ID) (*fleetdesired.State, error) {
+	if tenantID.IsZero() || assetID.IsZero() {
+		return nil, fmt.Errorf("%w: desired-state lookup needs tenant and asset", shared.ErrValidation)
+	}
+	var state *fleetdesired.State
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var scanErr error
+		state, scanErr = scanFleetDesired(tx.QueryRow(ctx,
+			`SELECT `+fleetDesiredCols+` FROM fleet_desired_state WHERE tenant_id=$1 AND asset_id=$2`,
+			tenantID.String(), assetID.String()))
+		return scanErr
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("desired state for asset %s: %w", assetID, shared.ErrNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get fleet desired state: %w", err)
+	}
+	if state.TenantID != tenantID || state.AssetID != assetID {
+		return nil, fmt.Errorf("%w: desired-state query returned identity %s/%s, want %s/%s",
+			shared.ErrValidation, state.TenantID, state.AssetID, tenantID, assetID)
+	}
+	return state, nil
+}
+
+// Put applies lifecycle-aware CAS. Version 1 inserts a new PolicyID only when the asset has no current
+// policy. Later versions must retain the same PolicyID and advance exactly one version.
+func (r *FleetDesiredRepository) Put(ctx context.Context, state *fleetdesired.State) error {
+	if state == nil {
+		return fmt.Errorf("%w: nil fleet desired state", shared.ErrValidation)
+	}
+	if err := state.Validate(); err != nil {
+		return err
+	}
+	err := WithTenant(ctx, r.pool, state.TenantID.String(), func(tx pgx.Tx) error {
+		if state.Version == 1 {
+			var insertedVersion int64
+			err := tx.QueryRow(ctx, `
+				INSERT INTO fleet_desired_state (`+fleetDesiredCols+`)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+				ON CONFLICT (tenant_id, asset_id) DO NOTHING
+				RETURNING version`,
+				state.TenantID.String(), state.AssetID.String(), state.PolicyID.String(), state.Capabilities,
+				state.UpdatedBy.String(), state.Version, state.Audit.CreatedAt, state.Audit.UpdatedAt).Scan(&insertedVersion)
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("%w: desired state for asset %s already exists", shared.ErrConflict, state.AssetID)
+			}
+			if err != nil {
+				var pgErr *pgconn.PgError
+				if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+					return fmt.Errorf("%w: desired policy id %s already exists in tenant %s",
+						shared.ErrConflict, state.PolicyID, state.TenantID)
+				}
+			}
+			return err
+		}
+
+		tag, err := tx.Exec(ctx, `
+			UPDATE fleet_desired_state
+			SET capabilities=$4, updated_by=$5, version=$6, updated_at=$7
+			WHERE tenant_id=$1 AND asset_id=$2 AND policy_id=$3 AND version=$8`,
+			state.TenantID.String(), state.AssetID.String(), state.PolicyID.String(), state.Capabilities,
+			state.UpdatedBy.String(), state.Version, state.Audit.UpdatedAt, state.Version-1)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23514" && pgErr.ConstraintName == "fleet_desired_state_time_order" {
+				return fmt.Errorf("%w: desired state updated_at precedes stored created_at for asset %s",
+					shared.ErrValidation, state.AssetID)
+			}
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			return fmt.Errorf("%w: desired policy %s for asset %s no longer has version %d",
+				shared.ErrConflict, state.PolicyID, state.AssetID, state.Version-1)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("store fleet desired state: %w", err)
+	}
+	return nil
+}
+
+func (r *FleetDesiredRepository) Delete(ctx context.Context, tenantID, assetID, expectedPolicyID shared.ID, expectedVersion int64) error {
+	if tenantID.IsZero() || assetID.IsZero() || expectedPolicyID.IsZero() || expectedVersion < 1 {
+		return fmt.Errorf("%w: desired-state delete needs tenant, asset, policy id and positive expected version", shared.ErrValidation)
+	}
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`DELETE FROM fleet_desired_state WHERE tenant_id=$1 AND asset_id=$2 AND policy_id=$3 AND version=$4`,
+			tenantID.String(), assetID.String(), expectedPolicyID.String(), expectedVersion)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() == 1 {
+			return nil
+		}
+		var exists bool
+		if err := tx.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM fleet_desired_state WHERE tenant_id=$1 AND asset_id=$2)`,
+			tenantID.String(), assetID.String()).Scan(&exists); err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("%w: desired policy for asset %s changed after %s@%d",
+				shared.ErrConflict, assetID, expectedPolicyID, expectedVersion)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("delete fleet desired state: %w", err)
+	}
+	return nil
+}
+
+func (r *FleetDesiredRepository) List(ctx context.Context, tenantID shared.ID) ([]*fleetdesired.State, error) {
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: desired-state list needs a tenant", shared.ErrValidation)
+	}
+	out := make([]*fleetdesired.State, 0)
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, queryErr := tx.Query(ctx,
+			`SELECT `+fleetDesiredCols+` FROM fleet_desired_state WHERE tenant_id=$1 ORDER BY asset_id`, tenantID.String())
+		if queryErr != nil {
+			return queryErr
+		}
+		defer rows.Close()
+		for rows.Next() {
+			state, scanErr := scanFleetDesired(rows)
+			if scanErr != nil {
+				return scanErr
+			}
+			if state.TenantID != tenantID {
+				return fmt.Errorf("%w: desired-state list returned tenant %s, want %s",
+					shared.ErrValidation, state.TenantID, tenantID)
+			}
+			out = append(out, state)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list fleet desired states: %w", err)
+	}
+	return out, nil
+}
+
+func scanFleetDesired(row rowScanner) (*fleetdesired.State, error) {
+	var (
+		state                                fleetdesired.State
+		tenant, assetID, policyID, updatedBy string
+	)
+	if err := row.Scan(&tenant, &assetID, &policyID, &state.Capabilities, &updatedBy, &state.Version,
+		&state.Audit.CreatedAt, &state.Audit.UpdatedAt); err != nil {
+		return nil, err
+	}
+	state.TenantID = shared.ID(tenant)
+	state.AssetID = shared.ID(assetID)
+	state.PolicyID = shared.ID(policyID)
+	state.UpdatedBy = shared.ID(updatedBy)
+	if err := state.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid stored fleet desired state: %w", err)
+	}
+	return &state, nil
+}

--- a/internal/infrastructure/persistence/postgres/fleetdesired_repo.go
+++ b/internal/infrastructure/persistence/postgres/fleetdesired_repo.go
@@ -73,9 +73,19 @@ func (r *FleetDesiredRepository) Put(ctx context.Context, state *fleetdesired.St
 			}
 			if err != nil {
 				var pgErr *pgconn.PgError
-				if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-					return fmt.Errorf("%w: desired policy id %s already exists in tenant %s",
-						shared.ErrConflict, state.PolicyID, state.TenantID)
+				if errors.As(err, &pgErr) {
+					switch pgErr.Code {
+					case "23505":
+						return fmt.Errorf("%w: desired policy id %s already exists in tenant %s",
+							shared.ErrConflict, state.PolicyID, state.TenantID)
+					case "23503":
+						// Admission verifies the canonical subject before Put. A foreign-key failure here
+						// therefore means that the tenant/asset precondition disappeared before the write
+						// committed (or a lower-level caller supplied a stale subject). Surface that as an
+						// optimistic conflict rather than leaking a PostgreSQL implementation error.
+						return fmt.Errorf("%w: desired-state subject %s/%s no longer exists",
+							shared.ErrConflict, state.TenantID, state.AssetID)
+					}
 				}
 			}
 			return err

--- a/internal/infrastructure/persistence/postgres/fleetdesired_repo_concurrency_test.go
+++ b/internal/infrastructure/persistence/postgres/fleetdesired_repo_concurrency_test.go
@@ -1,0 +1,202 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestFleetDesiredRepositoryConcurrentCASAllowsExactlyOneWinner(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	const tenant = "fd-concurrent-cas"
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$1) ON CONFLICT (id) DO NOTHING`, tenant); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = WithTenant(bg, pool, tenant, func(tx pgx.Tx) error {
+			if _, err := tx.Exec(bg, `DELETE FROM fleet_desired_state WHERE tenant_id=$1`, tenant); err != nil {
+				return err
+			}
+			_, err := tx.Exec(bg, `DELETE FROM fleet_assets WHERE tenant_id=$1 AND id LIKE 'fd-concurrent-%'`, tenant)
+			return err
+		})
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id=$1`, tenant)
+	})
+
+	now := time.Date(2026, 8, 19, 6, 0, 0, 0, time.UTC)
+	assets := NewAssetRepository(pool)
+	for _, id := range []shared.ID{"fd-concurrent-create", "fd-concurrent-update", "fd-concurrent-clear"} {
+		a, err := asset.New(id, tenant, asset.KindHost, "key/"+id.String(), id.String(), nil, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := assets.UpsertAsset(ctx, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	repo := NewFleetDesiredRepository(pool)
+	runPutRace := func(t *testing.T, left, right *fleetdesired.State) {
+		t.Helper()
+		start := make(chan struct{})
+		results := make(chan error, 2)
+		for _, candidate := range []*fleetdesired.State{left, right} {
+			candidate := candidate
+			go func() {
+				<-start
+				results <- repo.Put(context.Background(), candidate)
+			}()
+		}
+		close(start)
+		errA, errB := <-results, <-results
+		wins := 0
+		conflicts := 0
+		for _, err := range []error{errA, errB} {
+			switch {
+			case err == nil:
+				wins++
+			case errors.Is(err, shared.ErrConflict):
+				conflicts++
+			default:
+				t.Fatalf("concurrent CAS returned unexpected error: %v", err)
+			}
+		}
+		if wins != 1 || conflicts != 1 {
+			t.Fatalf("concurrent CAS wins=%d conflicts=%d, want exactly one of each; errors=(%v, %v)", wins, conflicts, errA, errB)
+		}
+	}
+
+	t.Run("create", func(t *testing.T) {
+		runPutRace(t,
+			&fleetdesired.State{
+				TenantID: tenant, AssetID: "fd-concurrent-create", PolicyID: "policy-create-a",
+				Capabilities: []string{"process"}, UpdatedBy: "operator-a", Version: 1,
+				Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+			},
+			&fleetdesired.State{
+				TenantID: tenant, AssetID: "fd-concurrent-create", PolicyID: "policy-create-b",
+				Capabilities: []string{"network"}, UpdatedBy: "operator-b", Version: 1,
+				Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+			},
+		)
+		got, err := repo.Get(ctx, tenant, "fd-concurrent-create")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Version != 1 || (got.PolicyID != "policy-create-a" && got.PolicyID != "policy-create-b") {
+			t.Fatalf("unexpected concurrent-create winner: %+v", got)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		base := &fleetdesired.State{
+			TenantID: tenant, AssetID: "fd-concurrent-update", PolicyID: "policy-update",
+			Capabilities: []string{"process"}, UpdatedBy: "operator", Version: 1,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}
+		if err := repo.Put(ctx, base); err != nil {
+			t.Fatal(err)
+		}
+		at := now.Add(time.Minute)
+		runPutRace(t,
+			&fleetdesired.State{
+				TenantID: tenant, AssetID: "fd-concurrent-update", PolicyID: "policy-update",
+				Capabilities: []string{"file"}, UpdatedBy: "operator-a", Version: 2,
+				Audit: shared.Audit{CreatedAt: now, UpdatedAt: at},
+			},
+			&fleetdesired.State{
+				TenantID: tenant, AssetID: "fd-concurrent-update", PolicyID: "policy-update",
+				Capabilities: []string{"network"}, UpdatedBy: "operator-b", Version: 2,
+				Audit: shared.Audit{CreatedAt: now, UpdatedAt: at},
+			},
+		)
+		got, err := repo.Get(ctx, tenant, "fd-concurrent-update")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Version != 2 || got.PolicyID != "policy-update" || len(got.Capabilities) != 1 ||
+			(got.Capabilities[0] != "file" && got.Capabilities[0] != "network") {
+			t.Fatalf("unexpected concurrent-update winner: %+v", got)
+		}
+	})
+
+	t.Run("update versus clear", func(t *testing.T) {
+		base := &fleetdesired.State{
+			TenantID: tenant, AssetID: "fd-concurrent-clear", PolicyID: "policy-clear-race",
+			Capabilities: []string{"process"}, UpdatedBy: "operator", Version: 1,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}
+		if err := repo.Put(ctx, base); err != nil {
+			t.Fatal(err)
+		}
+		update := &fleetdesired.State{
+			TenantID: tenant, AssetID: "fd-concurrent-clear", PolicyID: "policy-clear-race",
+			Capabilities: []string{"network"}, UpdatedBy: "operator-update", Version: 2,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now.Add(time.Minute)},
+		}
+		type result struct {
+			op  string
+			err error
+		}
+		start := make(chan struct{})
+		results := make(chan result, 2)
+		go func() {
+			<-start
+			results <- result{op: "update", err: repo.Put(context.Background(), update)}
+		}()
+		go func() {
+			<-start
+			results <- result{op: "clear", err: repo.Delete(context.Background(), tenant, "fd-concurrent-clear", "policy-clear-race", 1)}
+		}()
+		close(start)
+		first, second := <-results, <-results
+		outcomes := map[string]error{first.op: first.err, second.op: second.err}
+		wins := 0
+		conflicts := 0
+		for _, result := range []result{first, second} {
+			switch {
+			case result.err == nil:
+				wins++
+			case errors.Is(result.err, shared.ErrConflict):
+				conflicts++
+			default:
+				t.Fatalf("%s returned unexpected error: %v", result.op, result.err)
+			}
+		}
+		if wins != 1 || conflicts != 1 {
+			t.Fatalf("update/clear race wins=%d conflicts=%d, want one each: %+v", wins, conflicts, outcomes)
+		}
+		got, err := repo.Get(ctx, tenant, "fd-concurrent-clear")
+		if outcomes["update"] == nil {
+			if err != nil || got.Version != 2 || got.Capabilities[0] != "network" {
+				t.Fatalf("winning update not preserved: got=%+v err=%v outcomes=%+v", got, err, outcomes)
+			}
+			return
+		}
+		if !errors.Is(err, shared.ErrNotFound) {
+			t.Fatalf("winning clear left policy behind: got=%+v err=%v outcomes=%+v", got, err, outcomes)
+		}
+	})
+}

--- a/internal/infrastructure/persistence/postgres/fleetdesired_repo_fk_test.go
+++ b/internal/infrastructure/persistence/postgres/fleetdesired_repo_fk_test.go
@@ -1,0 +1,46 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestFleetDesiredRepositoryMapsMissingSubjectToConflict(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	const tenant = "fd-missing-subject"
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`, tenant, tenant); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tenants WHERE id=$1`, tenant)
+	})
+
+	now := time.Now().UTC().Truncate(time.Second)
+	err = NewFleetDesiredRepository(pool).Put(ctx, &fleetdesired.State{
+		TenantID: tenant, AssetID: "asset-that-disappeared", PolicyID: "policy-missing-subject",
+		Capabilities: []string{"process"}, UpdatedBy: "operator", Version: 1,
+		Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	})
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("missing desired-state subject error=%v, want ErrConflict", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/fleetdesired_repo_policyid_test.go
+++ b/internal/infrastructure/persistence/postgres/fleetdesired_repo_policyid_test.go
@@ -1,0 +1,161 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestFleetDesiredRepositoryRejectsDuplicatePolicyIDWithinTenant(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	const tenant = "fd-policy-id"
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$1) ON CONFLICT (id) DO NOTHING`, tenant); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = WithTenant(bg, pool, tenant, func(tx pgx.Tx) error {
+			if _, err := tx.Exec(bg, `DELETE FROM fleet_desired_state WHERE tenant_id=$1`, tenant); err != nil {
+				return err
+			}
+			_, err := tx.Exec(bg, `DELETE FROM fleet_assets WHERE tenant_id=$1 AND id LIKE 'fd-policy-asset-%'`, tenant)
+			return err
+		})
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id=$1`, tenant)
+	})
+
+	now := time.Date(2026, 8, 19, 4, 0, 0, 0, time.UTC)
+	assets := NewAssetRepository(pool)
+	for _, id := range []shared.ID{"fd-policy-asset-a", "fd-policy-asset-b"} {
+		a, err := asset.New(id, tenant, asset.KindHost, "key/"+id.String(), id.String(), nil, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := assets.UpsertAsset(ctx, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	repo := NewFleetDesiredRepository(pool)
+	first := &fleetdesired.State{
+		TenantID: tenant, AssetID: "fd-policy-asset-a", PolicyID: "policy-shared",
+		Capabilities: []string{"process"}, UpdatedBy: "operator", Version: 1,
+		Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+	second := &fleetdesired.State{
+		TenantID: tenant, AssetID: "fd-policy-asset-b", PolicyID: "policy-shared",
+		Capabilities: []string{"network"}, UpdatedBy: "operator", Version: 1,
+		Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+	if err := repo.Put(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Put(ctx, second); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate PolicyID error=%v, want ErrConflict", err)
+	}
+	if _, err := repo.Get(ctx, tenant, "fd-policy-asset-b"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("conflicting policy persisted: %v", err)
+	}
+	got, err := repo.Get(ctx, tenant, "fd-policy-asset-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PolicyID != "policy-shared" || got.Capabilities[0] != "process" {
+		t.Fatalf("existing policy changed after duplicate PolicyID conflict: %+v", got)
+	}
+}
+
+func TestFleetDesiredRepositoryDeleteRecreateRejectsStaleLifecycleDelete(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	const (
+		tenant  = "fd-policy-aba"
+		assetID = "fd-policy-asset-aba"
+	)
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$1) ON CONFLICT (id) DO NOTHING`, tenant); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_ = WithTenant(bg, pool, tenant, func(tx pgx.Tx) error {
+			if _, err := tx.Exec(bg, `DELETE FROM fleet_desired_state WHERE tenant_id=$1`, tenant); err != nil {
+				return err
+			}
+			_, err := tx.Exec(bg, `DELETE FROM fleet_assets WHERE tenant_id=$1 AND id=$2`, tenant, assetID)
+			return err
+		})
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id=$1`, tenant)
+	})
+
+	now := time.Date(2026, 8, 19, 5, 0, 0, 0, time.UTC)
+	assets := NewAssetRepository(pool)
+	a, err := asset.New(assetID, tenant, asset.KindHost, "key/"+assetID, assetID, nil, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assets.UpsertAsset(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewFleetDesiredRepository(pool)
+	old := &fleetdesired.State{
+		TenantID: tenant, AssetID: assetID, PolicyID: "policy-old", Capabilities: []string{"process"},
+		UpdatedBy: "operator", Version: 1, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+	if err := repo.Put(ctx, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Delete(ctx, tenant, assetID, "policy-old", 1); err != nil {
+		t.Fatal(err)
+	}
+	fresh := &fleetdesired.State{
+		TenantID: tenant, AssetID: assetID, PolicyID: "policy-new", Capabilities: []string{"network"},
+		UpdatedBy: "operator", Version: 1, Audit: shared.Audit{CreatedAt: now.Add(time.Minute), UpdatedAt: now.Add(time.Minute)},
+	}
+	if err := repo.Put(ctx, fresh); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Delete(ctx, tenant, assetID, "policy-old", 1); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale lifecycle delete error=%v, want ErrConflict", err)
+	}
+	got, err := repo.Get(ctx, tenant, assetID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PolicyID != "policy-new" || got.Version != 1 || len(got.Capabilities) != 1 || got.Capabilities[0] != "network" {
+		t.Fatalf("stale lifecycle delete changed recreated policy: %+v", got)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/fleetdesired_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/fleetdesired_repo_test.go
@@ -1,0 +1,228 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestFleetDesiredRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	for _, tenant := range []string{"fd-a", "fd-b"} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`, tenant, tenant); err != nil {
+			t.Fatalf("seed tenant %s: %v", tenant, err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, tenant := range []string{"fd-a", "fd-b"} {
+			_ = WithTenant(bg, pool, tenant, func(tx pgx.Tx) error {
+				if _, err := tx.Exec(bg, `DELETE FROM fleet_desired_state WHERE tenant_id=$1`, tenant); err != nil {
+					return err
+				}
+				_, err := tx.Exec(bg, `DELETE FROM fleet_assets WHERE tenant_id=$1 AND id LIKE 'fd-asset-%'`, tenant)
+				return err
+			})
+		}
+		_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id IN ('fd-a','fd-b')`)
+	})
+
+	var forced bool
+	if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE relname='fleet_desired_state'`).Scan(&forced); err != nil {
+		t.Fatalf("read desired-state RLS flag: %v", err)
+	}
+	if !forced {
+		t.Fatal("FORCE RLS not set on fleet_desired_state")
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	assetRepo := NewAssetRepository(pool)
+	createAsset := func(tenant, id string, kind asset.Kind) {
+		t.Helper()
+		a, err := asset.New(shared.ID(id), shared.ID(tenant), kind, "key/"+id, id, nil, now)
+		if err != nil {
+			t.Fatalf("new asset %s: %v", id, err)
+		}
+		if err := assetRepo.UpsertAsset(ctx, a); err != nil {
+			t.Fatalf("create asset %s: %v", id, err)
+		}
+	}
+	createAsset("fd-a", "fd-asset-a", asset.KindHost)
+	createAsset("fd-a", "fd-asset-c", asset.KindHost)
+	createAsset("fd-b", "fd-asset-b", asset.KindCluster)
+
+	gotAsset, err := assetRepo.GetAssetByID(ctx, "fd-a", "fd-asset-a")
+	if err != nil || gotAsset.ID != "fd-asset-a" || gotAsset.Kind != asset.KindHost {
+		t.Fatalf("asset id lookup mismatch: asset=%+v err=%v", gotAsset, err)
+	}
+	if _, err := assetRepo.GetAssetByID(ctx, "fd-b", "fd-asset-a"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant asset id lookup=%v, want ErrNotFound", err)
+	}
+
+	repo := NewFleetDesiredRepository(pool)
+	state := &fleetdesired.State{
+		TenantID: "fd-a", AssetID: "fd-asset-a", PolicyID: "policy-a", Capabilities: []string{"inventory.host", "telemetry.process"},
+		UpdatedBy: "operator-a", Version: 1, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+	if err := repo.Put(ctx, state); err != nil {
+		t.Fatalf("put desired state: %v", err)
+	}
+
+	got, err := repo.Get(ctx, "fd-a", "fd-asset-a")
+	if err != nil {
+		t.Fatalf("get desired state: %v", err)
+	}
+	if got.PolicyID != "policy-a" || got.Version != 1 || len(got.Capabilities) != 2 || got.Capabilities[0] != "inventory.host" || got.Capabilities[1] != "telemetry.process" {
+		t.Fatalf("desired state did not round-trip: %+v", got)
+	}
+	if got.UpdatedBy != "operator-a" || !got.Audit.CreatedAt.Equal(now) {
+		t.Fatalf("desired attribution/audit did not round-trip: %+v", got)
+	}
+
+	updatedAt := now.Add(time.Minute)
+	update := &fleetdesired.State{
+		TenantID: "fd-a", AssetID: "fd-asset-a", PolicyID: "policy-a", Capabilities: []string{"telemetry.network"},
+		UpdatedBy: "operator-b", Version: 2,
+		// The repository owns creation history and preserves the original value on conflict.
+		Audit: shared.Audit{CreatedAt: now.Add(-time.Hour), UpdatedAt: updatedAt},
+	}
+	if err := repo.Put(ctx, update); err != nil {
+		t.Fatalf("update desired state: %v", err)
+	}
+	got, err = repo.Get(ctx, "fd-a", "fd-asset-a")
+	if err != nil {
+		t.Fatalf("get updated desired state: %v", err)
+	}
+	if got.PolicyID != "policy-a" || got.Version != 2 || !got.Audit.CreatedAt.Equal(now) || !got.Audit.UpdatedAt.Equal(updatedAt) || got.UpdatedBy != "operator-b" || len(got.Capabilities) != 1 || got.Capabilities[0] != "telemetry.network" {
+		t.Fatalf("upsert history/mutable state mismatch: %+v", got)
+	}
+
+	// The caller may not forge an earlier CreatedAt to make an UpdatedAt that predates the persisted
+	// lifecycle appear valid. PostgreSQL must expose the same ErrValidation contract as the memory store.
+	backdated := &fleetdesired.State{
+		TenantID: "fd-a", AssetID: "fd-asset-a", PolicyID: "policy-a", Capabilities: []string{"telemetry.file"},
+		UpdatedBy: "operator-c", Version: 3,
+		Audit: shared.Audit{CreatedAt: now.Add(-2 * time.Hour), UpdatedAt: now.Add(-time.Minute)},
+	}
+	if err := repo.Put(ctx, backdated); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("backdated desired update=%v, want ErrValidation", err)
+	}
+	got, err = repo.Get(ctx, "fd-a", "fd-asset-a")
+	if err != nil || got.Version != 2 || got.Capabilities[0] != "telemetry.network" || !got.Audit.UpdatedAt.Equal(updatedAt) {
+		t.Fatalf("backdated update changed stored policy: got=%+v err=%v", got, err)
+	}
+
+	// Replaying another version 2 after version 2 is already current is a stale concurrent writer.
+	stale := &fleetdesired.State{
+		TenantID: "fd-a", AssetID: "fd-asset-a", PolicyID: "policy-a", Capabilities: []string{"telemetry.file"},
+		UpdatedBy: "stale-operator", Version: 2,
+		Audit: shared.Audit{CreatedAt: now, UpdatedAt: updatedAt.Add(time.Minute)},
+	}
+	if err := repo.Put(ctx, stale); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale desired update=%v, want ErrConflict", err)
+	}
+	if err := repo.Delete(ctx, "fd-a", "fd-asset-a", "policy-a", 1); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale desired delete=%v, want ErrConflict", err)
+	}
+	got, err = repo.Get(ctx, "fd-a", "fd-asset-a")
+	if err != nil || got.PolicyID != "policy-a" || got.Version != 2 || got.Capabilities[0] != "telemetry.network" {
+		t.Fatalf("stale operation changed version 2 state: got=%+v err=%v", got, err)
+	}
+
+	if _, err := repo.Get(ctx, "fd-b", "fd-asset-a"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant desired lookup=%v, want ErrNotFound", err)
+	}
+	rows, err := repo.List(ctx, "fd-a")
+	if err != nil || len(rows) != 1 || rows[0].AssetID != "fd-asset-a" || rows[0].PolicyID != "policy-a" || rows[0].Version != 2 {
+		t.Fatalf("tenant desired list mismatch: rows=%+v err=%v", rows, err)
+	}
+
+	// Prove the RLS policy itself with a real NOSUPERUSER/NOBYPASSRLS role when CI connects as postgres.
+	activateRLSRole := fleetDesiredRLSRole(t, ctx, pool)
+	var visible int
+	if err := WithTenant(ctx, pool, "fd-b", func(tx pgx.Tx) error {
+		if err := activateRLSRole(ctx, tx); err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx, `SELECT count(*) FROM fleet_desired_state WHERE tenant_id='fd-a'`).Scan(&visible)
+	}); err != nil {
+		t.Fatalf("direct cross-tenant RLS read: %v", err)
+	}
+	if visible != 0 {
+		t.Fatalf("RLS leaked %d fd-a desired rows to fd-b", visible)
+	}
+	var crossTenantUpdated int64
+	if err := WithTenant(ctx, pool, "fd-b", func(tx pgx.Tx) error {
+		if err := activateRLSRole(ctx, tx); err != nil {
+			return err
+		}
+		tag, err := tx.Exec(ctx, `UPDATE fleet_desired_state SET updated_by='intruder' WHERE tenant_id='fd-a' AND asset_id='fd-asset-a'`)
+		if err == nil {
+			crossTenantUpdated = tag.RowsAffected()
+		}
+		return err
+	}); err != nil {
+		t.Fatalf("direct cross-tenant RLS update: %v", err)
+	}
+	if crossTenantUpdated != 0 {
+		t.Fatalf("RLS permitted %d cross-tenant updates", crossTenantUpdated)
+	}
+
+	// The FK independently rejects a desired row whose canonical technical asset does not exist.
+	missingAsset := &fleetdesired.State{
+		TenantID: "fd-a", AssetID: "fd-asset-missing", PolicyID: "policy-missing", Capabilities: []string{"process"},
+		UpdatedBy: "operator", Version: 1, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+	if err := repo.Put(ctx, missingAsset); err == nil {
+		t.Fatal("desired state for a missing canonical asset unexpectedly persisted")
+	}
+
+	// Bypass the repository validator and prove the SQL CHECK rejects a non-canonical capability array.
+	var invalidInserted int64
+	if err := WithTenant(ctx, pool, "fd-a", func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `
+			INSERT INTO fleet_desired_state
+			  (tenant_id,asset_id,policy_id,capabilities,updated_by,version,created_at,updated_at)
+			VALUES ('fd-a','fd-asset-c','policy-direct-invalid',ARRAY['z','a'],'operator',1,now(),now())`)
+		if err == nil {
+			invalidInserted = tag.RowsAffected()
+		}
+		return err
+	}); err == nil {
+		t.Fatal("unsorted capability array unexpectedly bypassed database canonicality CHECK")
+	}
+	if invalidInserted != 0 {
+		t.Fatalf("invalid direct insert affected %d rows", invalidInserted)
+	}
+
+	if err := repo.Delete(ctx, "fd-a", "fd-asset-a", "policy-a", 2); err != nil {
+		t.Fatalf("delete desired state: %v", err)
+	}
+	if err := repo.Delete(ctx, "fd-a", "fd-asset-a", "policy-a", 2); err != nil {
+		t.Fatalf("idempotent delete desired state: %v", err)
+	}
+	if _, err := repo.Get(ctx, "fd-a", "fd-asset-a"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("deleted desired state lookup=%v, want ErrNotFound", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/migration_0107_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0107_test.go
@@ -1,0 +1,99 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+func TestMigration0107FleetDesiredState(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := Migrate(context.Background(), dsn); err != nil {
+			t.Errorf("restore migrations: %v", err)
+		}
+	})
+
+	db, err := goose.OpenDBWithDriver("pgx", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	goose.SetBaseFS(migrations.FS)
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatal(err)
+	}
+	if err := goose.DownTo(db, ".", 106); err != nil {
+		t.Fatalf("down to 0106: %v", err)
+	}
+	if err := goose.UpTo(db, ".", 107); err != nil {
+		t.Fatalf("up 0107: %v", err)
+	}
+
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+
+	var table, validator, rlsEnabled, rlsForced, assetFK, canonicalCheck, policyIDColumn, policyUnique, versionColumn, versionCheck, actorCheck bool
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			to_regclass('fleet_desired_state') IS NOT NULL,
+			to_regprocedure('synapse_fleet_desired_capabilities_valid(text[])') IS NOT NULL,
+			COALESCE((SELECT relrowsecurity FROM pg_class WHERE oid=to_regclass('fleet_desired_state')), false),
+			COALESCE((SELECT relforcerowsecurity FROM pg_class WHERE oid=to_regclass('fleet_desired_state')), false),
+			EXISTS (
+				SELECT 1 FROM pg_constraint
+				WHERE conrelid=to_regclass('fleet_desired_state')
+				  AND contype='f' AND confrelid=to_regclass('fleet_assets')
+			),
+			EXISTS (
+				SELECT 1 FROM pg_constraint
+				WHERE conrelid=to_regclass('fleet_desired_state')
+				  AND conname='fleet_desired_state_capabilities_canonical' AND contype='c'
+			),
+			EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema='public' AND table_name='fleet_desired_state'
+				  AND column_name='policy_id' AND data_type='text' AND is_nullable='NO'
+			),
+			EXISTS (
+				SELECT 1 FROM pg_constraint
+				WHERE conrelid=to_regclass('fleet_desired_state') AND contype='u'
+				  AND pg_get_constraintdef(oid) = 'UNIQUE (tenant_id, policy_id)'
+			),
+			EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema='public' AND table_name='fleet_desired_state'
+				  AND column_name='version' AND data_type='bigint' AND is_nullable='NO'
+			),
+			EXISTS (
+				SELECT 1 FROM pg_constraint
+				WHERE conrelid=to_regclass('fleet_desired_state') AND contype='c'
+				  AND pg_get_constraintdef(oid) LIKE '%version >= 1%'
+			),
+			EXISTS (
+				SELECT 1 FROM pg_constraint
+				WHERE conrelid=to_regclass('fleet_desired_state') AND contype='c'
+				  AND pg_get_constraintdef(oid) LIKE '%btrim(updated_by)%'
+			)
+	`).Scan(&table, &validator, &rlsEnabled, &rlsForced, &assetFK, &canonicalCheck, &policyIDColumn, &policyUnique, &versionColumn, &versionCheck, &actorCheck); err != nil {
+		t.Fatalf("inspect migration 0107: %v", err)
+	}
+	if !table || !validator || !rlsEnabled || !rlsForced || !assetFK || !canonicalCheck || !policyIDColumn || !policyUnique || !versionColumn || !versionCheck || !actorCheck {
+		t.Fatalf("0107 objects incomplete: table=%v validator=%v rls=%v force=%v asset_fk=%v canonical_check=%v policy_id=%v policy_unique=%v version_column=%v version_check=%v actor_check=%v",
+			table, validator, rlsEnabled, rlsForced, assetFK, canonicalCheck, policyIDColumn, policyUnique, versionColumn, versionCheck, actorCheck)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/rls_test_role_test.go
+++ b/internal/infrastructure/persistence/postgres/rls_test_role_test.go
@@ -1,0 +1,61 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const fleetDesiredRLSTestRole = "synapse_fd_rls_test"
+
+// fleetDesiredRLSRole returns a transaction hook that switches to a real non-superuser,
+// non-BYPASSRLS role when the integration DSN itself bypasses RLS (as the standard CI postgres admin
+// user does). If the DSN already uses a normal role the hook is a no-op. This makes policy tests prove
+// RLS behavior rather than merely exercise WHERE predicates under a privileged session.
+func fleetDesiredRLSRole(t *testing.T, ctx context.Context, pool *pgxpool.Pool) func(context.Context, pgx.Tx) error {
+	t.Helper()
+	var superuser, bypass bool
+	if err := pool.QueryRow(ctx, `
+		SELECT rolsuper, rolbypassrls
+		FROM pg_roles
+		WHERE rolname = current_user
+	`).Scan(&superuser, &bypass); err != nil {
+		t.Fatalf("inspect postgres test role: %v", err)
+	}
+	if !superuser && !bypass {
+		return func(context.Context, pgx.Tx) error { return nil }
+	}
+	if !superuser {
+		// A BYPASSRLS non-superuser cannot reliably create the isolated role needed to test itself.
+		// Treat that DSN as an invalid integration-test configuration rather than claiming RLS passed.
+		t.Fatalf("postgres integration role has BYPASSRLS without superuser; cannot prove tenant RLS safely")
+	}
+
+	cleanup := func(cleanCtx context.Context) {
+		_, _ = pool.Exec(cleanCtx, `DROP OWNED BY `+fleetDesiredRLSTestRole)
+		_, _ = pool.Exec(cleanCtx, `DROP ROLE IF EXISTS `+fleetDesiredRLSTestRole)
+	}
+	cleanup(ctx)
+	if _, err := pool.Exec(ctx, `CREATE ROLE `+fleetDesiredRLSTestRole+` NOLOGIN NOSUPERUSER NOBYPASSRLS`); err != nil {
+		t.Fatalf("create non-bypass RLS test role: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `GRANT USAGE ON SCHEMA public TO `+fleetDesiredRLSTestRole); err != nil {
+		cleanup(ctx)
+		t.Fatalf("grant schema usage to RLS test role: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `GRANT SELECT, UPDATE ON fleet_desired_state TO `+fleetDesiredRLSTestRole); err != nil {
+		cleanup(ctx)
+		t.Fatalf("grant desired-state access to RLS test role: %v", err)
+	}
+	t.Cleanup(func() { cleanup(context.Background()) })
+
+	return func(execCtx context.Context, tx pgx.Tx) error {
+		if _, err := tx.Exec(execCtx, `SET LOCAL ROLE `+fleetDesiredRLSTestRole); err != nil {
+			return fmt.Errorf("activate non-bypass RLS test role: %w", err)
+		}
+		return nil
+	}
+}

--- a/internal/usecase/fleet/desired/audit_context_external_test.go
+++ b/internal/usecase/fleet/desired/audit_context_external_test.go
@@ -1,0 +1,51 @@
+package fleetdesired_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	desireduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type tenantCapturingAudit struct {
+	tenants []shared.ID
+}
+
+func (a *tenantCapturingAudit) Record(ctx context.Context, _ ports.AuditEntry) error {
+	tenantID, _ := shared.TenantFrom(ctx)
+	a.tenants = append(a.tenants, tenantID)
+	return nil
+}
+
+func TestDesiredMutationBindsAuditToPolicyTenant(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "wrong-tenant")
+	now := time.Date(2026, 8, 20, 1, 0, 0, 0, time.UTC)
+	store := memory.NewFleetDesiredStore()
+	audit := &tenantCapturingAudit{}
+	svc := newTestService(t, store,
+		&testAssets{rows: map[shared.ID]*asset.Asset{"asset-1": technicalAsset("asset-1", asset.KindHost)}},
+		&testBindings{}, &testAgents{}, audit, &testClock{now: now}, time.Minute)
+
+	if _, err := svc.SetDesiredCapabilities(ctx, desireduc.SetInput{
+		TenantID: "tenant-1", AssetID: "asset-1", Actor: "operator", Capabilities: []string{"process"},
+	}); err != nil {
+		t.Fatalf("set desired capabilities: %v", err)
+	}
+	if len(audit.tenants) != 1 || audit.tenants[0] != "tenant-1" {
+		t.Fatalf("set audit tenant=%v, want [tenant-1]", audit.tenants)
+	}
+
+	if err := svc.ClearDesiredCapabilities(context.Background(), desireduc.ClearInput{
+		TenantID: "tenant-1", AssetID: "asset-1", Actor: "operator",
+	}); err != nil {
+		t.Fatalf("clear desired capabilities: %v", err)
+	}
+	if len(audit.tenants) != 2 || audit.tenants[1] != "tenant-1" {
+		t.Fatalf("clear audit tenants=%v, want both tenant-1", audit.tenants)
+	}
+}

--- a/internal/usecase/fleet/desired/empty_reconcile_external_test.go
+++ b/internal/usecase/fleet/desired/empty_reconcile_external_test.go
@@ -1,0 +1,61 @@
+package fleetdesired_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	desireduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
+)
+
+type noAssetRead struct{ calls int }
+
+func (r *noAssetRead) GetAssetByID(context.Context, shared.ID, shared.ID) (*asset.Asset, error) {
+	r.calls++
+	return nil, errors.New("unexpected asset read")
+}
+
+type noBindingRead struct{ calls int }
+
+func (r *noBindingRead) ListCurrentBindings(context.Context, shared.ID) ([]desireduc.CurrentBinding, error) {
+	r.calls++
+	return nil, errors.New("unexpected binding read")
+}
+
+type noObservedRead struct{ calls int }
+
+func (r *noObservedRead) ListAgents(context.Context, shared.ID) ([]*fleetagent.Agent, error) {
+	r.calls++
+	return nil, errors.New("unexpected agent read")
+}
+
+type noClockRead struct{ calls int }
+
+func (c *noClockRead) Now() time.Time { c.calls++; return time.Now() }
+
+func TestReconcileNoDesiredPolicyDoesNotReadOtherFleetState(t *testing.T) {
+	assets := &noAssetRead{}
+	bindings := &noBindingRead{}
+	agents := &noObservedRead{}
+	clock := &noClockRead{}
+	ids := &testIDGenerator{}
+	svc, err := desireduc.NewService(reconcileDesiredStore{rows: nil}, assets, bindings, agents, reconcileAudit{}, clock, ids, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := svc.Reconcile(context.Background(), "tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 || rows == nil {
+		t.Fatalf("rows=%#v, want non-nil empty projection", rows)
+	}
+	if assets.calls != 0 || bindings.calls != 0 || agents.calls != 0 || clock.calls != 0 || ids.calls != 0 {
+		t.Fatalf("empty policy performed unnecessary reads: assets=%d bindings=%d agents=%d clock=%d ids=%d",
+			assets.calls, bindings.calls, agents.calls, clock.calls, ids.calls)
+	}
+}

--- a/internal/usecase/fleet/desired/newservice_guard_test.go
+++ b/internal/usecase/fleet/desired/newservice_guard_test.go
@@ -1,0 +1,69 @@
+package fleetdesired_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	desireduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Self-contained minimal fakes so this guard test does not couple to the other test files' helpers.
+type guardAssets struct{}
+
+func (guardAssets) GetAssetByID(context.Context, shared.ID, shared.ID) (*asset.Asset, error) {
+	return nil, shared.ErrNotFound
+}
+
+type guardBindings struct{}
+
+func (guardBindings) ListCurrentBindings(context.Context, shared.ID) ([]desireduc.CurrentBinding, error) {
+	return nil, nil
+}
+
+type guardAgents struct{}
+
+func (guardAgents) ListAgents(context.Context, shared.ID) ([]*fleetagent.Agent, error) {
+	return nil, nil
+}
+
+type guardAudit struct{}
+
+func (guardAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+type guardClock struct{}
+
+func (guardClock) Now() time.Time { return time.Unix(0, 0).UTC() }
+
+type guardIDs struct{}
+
+func (guardIDs) NewID() shared.ID { return "id" }
+
+func newGuardService(stale time.Duration) (*desireduc.Service, error) {
+	return desireduc.NewService(
+		memory.NewFleetDesiredStore(), guardAssets{}, guardBindings{}, guardAgents{},
+		guardAudit{}, guardClock{}, guardIDs{}, stale,
+	)
+}
+
+// TestNewServiceRejectsNonPositiveStaleAfter locks in the fail-closed guard: a non-positive stale window
+// would make fleetcoverage.AgentStateFrom treat a long-idle agent as "never stale" (Healthy/covered) — a
+// coverage fail-open the constructor must refuse.
+func TestNewServiceRejectsNonPositiveStaleAfter(t *testing.T) {
+	for _, stale := range []time.Duration{0, -time.Second, -time.Hour} {
+		if _, err := newGuardService(stale); err == nil {
+			t.Errorf("NewService(staleAfter=%s) must fail closed", stale)
+		} else if !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("NewService(staleAfter=%s) error must wrap ErrValidation, got %v", stale, err)
+		}
+	}
+	if _, err := newGuardService(time.Minute); err != nil {
+		t.Fatalf("a positive stale window must construct: %v", err)
+	}
+}

--- a/internal/usecase/fleet/desired/reconcile_invariants_external_test.go
+++ b/internal/usecase/fleet/desired/reconcile_invariants_external_test.go
@@ -1,0 +1,244 @@
+package fleetdesired_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	desireddom "github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	desireduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type reconcileClock struct{ now time.Time }
+
+func (c reconcileClock) Now() time.Time { return c.now }
+
+type reconcileAudit struct{}
+
+func (reconcileAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+type reconcileDesiredStore struct{ rows []*desireddom.State }
+
+func (s reconcileDesiredStore) Get(context.Context, shared.ID, shared.ID) (*desireddom.State, error) {
+	return nil, shared.ErrNotFound
+}
+func (s reconcileDesiredStore) Put(context.Context, *desireddom.State) error { return nil }
+func (s reconcileDesiredStore) Delete(context.Context, shared.ID, shared.ID, shared.ID, int64) error {
+	return nil
+}
+func (s reconcileDesiredStore) List(context.Context, shared.ID) ([]*desireddom.State, error) {
+	return s.rows, nil
+}
+
+type reconcileAssets struct{ calls int }
+
+func (r *reconcileAssets) GetAssetByID(context.Context, shared.ID, shared.ID) (*asset.Asset, error) {
+	r.calls++
+	return nil, errors.New("reconciliation must not read asset catalog")
+}
+
+type reconcileBindings struct{ rows []desireduc.CurrentBinding }
+
+func (s reconcileBindings) ListCurrentBindings(context.Context, shared.ID) ([]desireduc.CurrentBinding, error) {
+	return s.rows, nil
+}
+
+type reconcileAgentReader struct{ rows []*fleetagent.Agent }
+
+func (s reconcileAgentReader) ListAgents(context.Context, shared.ID) ([]*fleetagent.Agent, error) {
+	return s.rows, nil
+}
+
+func desiredFixture(id string, caps []string, now time.Time) *desireddom.State {
+	return &desireddom.State{
+		TenantID: "tenant", AssetID: shared.ID(id), PolicyID: shared.ID("policy-" + id), Capabilities: caps,
+		UpdatedBy: "operator", Version: 1, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+}
+
+func bindingFixture(assetID, agentID string) desireduc.CurrentBinding {
+	return desireduc.CurrentBinding{TenantID: "tenant", AssetID: shared.ID(assetID), AgentID: shared.ID(agentID)}
+}
+
+func agentFixture(id string, caps []string, lastSeen time.Time) *fleetagent.Agent {
+	return &fleetagent.Agent{
+		ID: shared.ID(id), TenantID: "tenant", Capabilities: caps,
+		LastSeenAt: lastSeen, State: fleetagent.StateActive,
+	}
+}
+
+func reconcileService(t testing.TB, desired []*desireddom.State, bindings []desireduc.CurrentBinding, agents []*fleetagent.Agent, now time.Time) *desireduc.Service {
+	t.Helper()
+	svc, err := desireduc.NewService(
+		reconcileDesiredStore{rows: desired}, &reconcileAssets{}, reconcileBindings{rows: bindings},
+		reconcileAgentReader{rows: agents}, reconcileAudit{}, reconcileClock{now}, &testIDGenerator{}, 5*time.Minute,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func TestReconcileCanonicalizesObservedCapabilitiesAndDoesNotMutateDesiredOrder(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	z := desiredFixture("z-asset", []string{"process"}, now)
+	a := desiredFixture("a-asset", []string{"network", "process"}, now)
+	desired := []*desireddom.State{z, a}
+	bindings := []desireduc.CurrentBinding{bindingFixture("a-asset", "agent-a")}
+	agents := []*fleetagent.Agent{agentFixture("agent-a", []string{" process ", "network", "irrelevant"}, now)}
+	svc := reconcileService(t, desired, bindings, agents, now)
+
+	rows, err := svc.Reconcile(context.Background(), "tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"a-asset/policy-a-asset/agent-a/network/true/",
+		"a-asset/policy-a-asset/agent-a/process/true/",
+		"z-asset/policy-z-asset//process/false/agent_missing",
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("got %d rows: %#v", len(rows), rows)
+	}
+	for i, row := range rows {
+		got := fmt.Sprintf("%s/%s/%s/%s/%t/%s", row.AssetID, row.PolicyID, row.AgentID, row.Capability, row.Covered, row.GapReason)
+		if got != want[i] {
+			t.Fatalf("row[%d]=%q want %q", i, got, want[i])
+		}
+	}
+	if desired[0] != z || desired[1] != a {
+		t.Fatal("reconciliation mutated the store-owned desired slice")
+	}
+}
+
+func TestReconcileAllowsMultipleAgentsForOneAssetAndChoosesDeterministicWitness(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	desired := []*desireddom.State{desiredFixture("cluster", []string{"process"}, now)}
+	// Deliberately reverse the binding and observed-agent order. agent-b covers process; agent-a is
+	// healthy but does not. Reverse uniqueness AssetID -> AgentID is not part of the binding contract.
+	bindings := []desireduc.CurrentBinding{
+		bindingFixture("cluster", "agent-b"),
+		bindingFixture("cluster", "agent-a"),
+	}
+	agents := []*fleetagent.Agent{
+		agentFixture("agent-b", []string{"process"}, now),
+		agentFixture("agent-a", []string{"network"}, now),
+	}
+	svc := reconcileService(t, desired, bindings, agents, now)
+	rows, err := svc.Reconcile(context.Background(), "tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || !rows[0].Covered || rows[0].AgentID != "agent-b" || rows[0].GapReason != "" {
+		t.Fatalf("multi-agent covered result=%+v", rows)
+	}
+
+	// If no healthy bound agent advertises the capability, choose the lexicographically first healthy
+	// witness and return one asset-level capability gap rather than inventing a reverse-unique binding.
+	agents[0].Capabilities = []string{"file"}
+	rows, err = svc.Reconcile(context.Background(), "tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Covered || rows[0].AgentID != "agent-a" || rows[0].GapReason != desireddom.GapCapabilityMissing {
+		t.Fatalf("multi-agent uncovered result=%+v", rows)
+	}
+}
+
+func TestReconcileFailsClosedOnMalformedSnapshots(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	valid := desiredFixture("asset", []string{"process"}, now)
+	validBinding := bindingFixture("asset", "agent")
+	cases := []struct {
+		name     string
+		desired  []*desireddom.State
+		bindings []desireduc.CurrentBinding
+		agents   []*fleetagent.Agent
+	}{
+		{name: "nil desired", desired: []*desireddom.State{nil}},
+		{name: "cross-tenant desired", desired: []*desireddom.State{{
+			TenantID: "other", AssetID: "asset", PolicyID: "policy-asset", Capabilities: []string{"process"}, UpdatedBy: "operator", Version: 1,
+			Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}}},
+		{name: "duplicate desired", desired: []*desireddom.State{valid, valid}},
+		{name: "empty binding identity", desired: []*desireddom.State{valid}, bindings: []desireduc.CurrentBinding{{TenantID: "tenant", AssetID: "asset"}}},
+		{name: "cross-tenant binding", desired: []*desireddom.State{valid}, bindings: []desireduc.CurrentBinding{{TenantID: "other", AssetID: "asset", AgentID: "agent"}}},
+		{name: "duplicate agent-asset binding", desired: []*desireddom.State{valid}, bindings: []desireduc.CurrentBinding{validBinding, validBinding}},
+		{name: "agent bound to two assets", desired: []*desireddom.State{valid}, bindings: []desireduc.CurrentBinding{
+			validBinding, bindingFixture("other-asset", "agent"),
+		}},
+		{name: "nil observed", desired: []*desireddom.State{valid}, bindings: []desireduc.CurrentBinding{validBinding}, agents: []*fleetagent.Agent{nil}},
+		{name: "cross-tenant observed", desired: []*desireddom.State{valid}, bindings: []desireduc.CurrentBinding{validBinding}, agents: []*fleetagent.Agent{{
+			ID: "agent", TenantID: "other", LastSeenAt: now, State: fleetagent.StateActive,
+		}}},
+		{name: "invalid observed lifecycle", desired: []*desireddom.State{valid}, bindings: []desireduc.CurrentBinding{validBinding}, agents: []*fleetagent.Agent{{
+			ID: "agent", TenantID: "tenant", LastSeenAt: now, State: fleetagent.State("corrupt"),
+		}}},
+		{name: "duplicate observed", desired: []*desireddom.State{valid}, bindings: []desireduc.CurrentBinding{validBinding}, agents: []*fleetagent.Agent{
+			agentFixture("agent", nil, now), agentFixture("agent", nil, now),
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := reconcileService(t, tc.desired, tc.bindings, tc.agents, now)
+			_, err := svc.Reconcile(context.Background(), "tenant")
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("Reconcile error=%v, want validation error", err)
+			}
+		})
+	}
+}
+
+func BenchmarkReconcileTenThousandAssets(b *testing.B) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	caps := []string{"file", "network", "privilege", "process"}
+	desired := make([]*desireddom.State, 0, 10_000)
+	bindings := make([]desireduc.CurrentBinding, 0, 10_000)
+	agents := make([]*fleetagent.Agent, 0, 10_000)
+	for i := 0; i < 10_000; i++ {
+		assetID := fmt.Sprintf("asset-%05d", i)
+		agentID := fmt.Sprintf("agent-%05d", i)
+		desired = append(desired, desiredFixture(assetID, caps, now))
+		bindings = append(bindings, bindingFixture(assetID, agentID))
+		agents = append(agents, agentFixture(agentID, caps, now))
+	}
+	svc := reconcileService(b, desired, bindings, agents, now)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rows, err := svc.Reconcile(context.Background(), "tenant")
+		if err != nil || len(rows) != 40_000 {
+			b.Fatalf("rows=%d err=%v", len(rows), err)
+		}
+	}
+}
+
+func BenchmarkGapsHealthyTenThousandAssets(b *testing.B) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	caps := []string{"file", "network", "privilege", "process"}
+	desired := make([]*desireddom.State, 0, 10_000)
+	bindings := make([]desireduc.CurrentBinding, 0, 10_000)
+	agents := make([]*fleetagent.Agent, 0, 10_000)
+	for i := 0; i < 10_000; i++ {
+		assetID := fmt.Sprintf("asset-%05d", i)
+		agentID := fmt.Sprintf("agent-%05d", i)
+		desired = append(desired, desiredFixture(assetID, caps, now))
+		bindings = append(bindings, bindingFixture(assetID, agentID))
+		agents = append(agents, agentFixture(agentID, caps, now))
+	}
+	svc := reconcileService(b, desired, bindings, agents, now)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rows, err := svc.Gaps(context.Background(), "tenant")
+		if err != nil || len(rows) != 0 {
+			b.Fatalf("rows=%d err=%v", len(rows), err)
+		}
+	}
+}

--- a/internal/usecase/fleet/desired/service.go
+++ b/internal/usecase/fleet/desired/service.go
@@ -57,6 +57,13 @@ func NewService(store ports.FleetDesiredStore, assets AssetReader, bindings Bind
 	if store == nil || assets == nil || bindings == nil || agents == nil || audit == nil || clock == nil || ids == nil {
 		return nil, fmt.Errorf("%w: fleet desired-state service needs store, asset reader, binding reader, agent reader, audit log, clock and id generator", shared.ErrValidation)
 	}
+	// Fail closed on the coverage window: fleetcoverage.AgentStateFrom treats a non-positive staleAfter as
+	// "never stale", which would report a long-idle agent as Healthy/covered — the exact fail-open a
+	// coverage-honesty tool must refuse. Require a positive window at construction rather than trust the
+	// composition root to pass one.
+	if staleAfter <= 0 {
+		return nil, fmt.Errorf("%w: fleet desired-state service needs a positive stale-after window, got %s", shared.ErrValidation, staleAfter)
+	}
 	return &Service{store: store, assets: assets, bindings: bindings, agents: agents, audit: audit, clock: clock, ids: ids, staleAfter: staleAfter}, nil
 }
 
@@ -197,9 +204,9 @@ func (s *Service) Get(ctx context.Context, tenantID, assetID shared.ID) (*desire
 }
 
 type ReconciliationRow struct {
-	AssetID       string                    `json:"asset_id"`
-	PolicyID      string                    `json:"policy_id"`
-	PolicyVersion int64                     `json:"policy_version"`
+	AssetID       string `json:"asset_id"`
+	PolicyID      string `json:"policy_id"`
+	PolicyVersion int64  `json:"policy_version"`
 	// AgentID is the deterministic witness that satisfied the capability, or the best available
 	// representative when the capability is uncovered. Asset coverage does not imply reverse-unique
 	// AssetID -> AgentID binding.

--- a/internal/usecase/fleet/desired/service.go
+++ b/internal/usecase/fleet/desired/service.go
@@ -1,0 +1,492 @@
+// Package fleetdesired reconciles operator-owned desired capabilities for canonical host/cluster
+// assets against the latest server-authoritative agent bindings and observed fleet-agent state.
+// Reconciliation is read-only: polling fleet health must not create database churn.
+package fleetdesired
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetcoverage"
+	desireddom "github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssetReader interface {
+	GetAssetByID(ctx context.Context, tenantID, assetID shared.ID) (*asset.Asset, error)
+}
+
+// CurrentBinding is the read projection of one server-authoritative agent -> asset binding. The
+// reverse relation is intentionally not constrained here: more than one current agent may serve the
+// same canonical asset (for example, distinct cluster components). One AgentID, however, may not be
+// current for two assets at once.
+type CurrentBinding struct {
+	TenantID shared.ID
+	AssetID  shared.ID
+	AgentID  shared.ID
+}
+
+type BindingReader interface {
+	ListCurrentBindings(ctx context.Context, tenantID shared.ID) ([]CurrentBinding, error)
+}
+
+type AgentReader interface {
+	ListAgents(ctx context.Context, tenantID shared.ID) ([]*fleetagent.Agent, error)
+}
+
+type Service struct {
+	store      ports.FleetDesiredStore
+	assets     AssetReader
+	bindings   BindingReader
+	agents     AgentReader
+	audit      ports.AuditLogger
+	clock      ports.Clock
+	ids        ports.IDGenerator
+	staleAfter time.Duration
+}
+
+func NewService(store ports.FleetDesiredStore, assets AssetReader, bindings BindingReader, agents AgentReader, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator, staleAfter time.Duration) (*Service, error) {
+	if store == nil || assets == nil || bindings == nil || agents == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: fleet desired-state service needs store, asset reader, binding reader, agent reader, audit log, clock and id generator", shared.ErrValidation)
+	}
+	return &Service{store: store, assets: assets, bindings: bindings, agents: agents, audit: audit, clock: clock, ids: ids, staleAfter: staleAfter}, nil
+}
+
+type SetInput struct {
+	TenantID     shared.ID
+	AssetID      shared.ID
+	Capabilities []string
+	Actor        shared.ID
+}
+
+type ClearInput struct {
+	TenantID shared.ID
+	AssetID  shared.ID
+	Actor    shared.ID
+}
+
+// SetDesiredCapabilities replaces one host/cluster asset's desired capability set. PolicyID is stable
+// within one lifecycle; a clear followed by recreation receives a new ID. Store CAS on
+// (PolicyID,Version) prevents both concurrent lost updates and delete/recreate ABA races.
+func (s *Service) SetDesiredCapabilities(ctx context.Context, in SetInput) (*desireddom.State, error) {
+	if in.TenantID.IsZero() || in.AssetID.IsZero() || strings.TrimSpace(in.Actor.String()) == "" {
+		return nil, fmt.Errorf("%w: desired-state change needs tenant, canonical asset and actor", shared.ErrValidation)
+	}
+	caps, err := desireddom.NormalizeCapabilities(in.Capabilities)
+	if err != nil {
+		return nil, err
+	}
+	if len(caps) == 0 {
+		return nil, fmt.Errorf("%w: desired capability set is empty; use ClearDesiredCapabilities", shared.ErrValidation)
+	}
+
+	var current *desireddom.State
+	if got, getErr := s.store.Get(ctx, in.TenantID, in.AssetID); getErr == nil {
+		if err := validateStoredState(got, in.TenantID, in.AssetID); err != nil {
+			return nil, err
+		}
+		current = got
+		if slices.Equal(current.Capabilities, caps) {
+			return current, nil
+		}
+	} else if !errors.Is(getErr, shared.ErrNotFound) {
+		return nil, fmt.Errorf("read current desired state: %w", getErr)
+	}
+
+	version := int64(1)
+	policyID := shared.ID("")
+	if current != nil {
+		if current.Version == 1<<63-1 {
+			return nil, fmt.Errorf("%w: desired state version exhausted for asset %s", shared.ErrConflict, in.AssetID)
+		}
+		version = current.Version + 1
+		policyID = current.PolicyID
+	}
+
+	// Every semantic change re-validates the canonical subject. Clear remains available as the recovery
+	// path if the asset registry is damaged or the observation disappeared.
+	subject, err := s.assets.GetAssetByID(ctx, in.TenantID, in.AssetID)
+	if err != nil {
+		return nil, fmt.Errorf("load desired-state asset: %w", err)
+	}
+	if subject == nil {
+		return nil, fmt.Errorf("%w: asset reader returned nil for asset %s", shared.ErrValidation, in.AssetID)
+	}
+	if subject.TenantID != in.TenantID || subject.ID != in.AssetID {
+		return nil, fmt.Errorf("%w: asset reader returned identity %s/%s, want %s/%s",
+			shared.ErrValidation, subject.TenantID, subject.ID, in.TenantID, in.AssetID)
+	}
+	if !desireddom.SupportedAssetKind(subject.Kind) {
+		return nil, fmt.Errorf("%w: desired state may target only host/cluster assets, got %s kind %q",
+			shared.ErrValidation, subject.ID, subject.Kind)
+	}
+
+	if current == nil {
+		policyID = s.ids.NewID()
+		if policyID.IsZero() {
+			return nil, fmt.Errorf("%w: id generator returned an empty desired policy id", shared.ErrValidation)
+		}
+	}
+
+	now := s.clock.Now().UTC()
+	createdAt := now
+	if current != nil {
+		createdAt = current.Audit.CreatedAt
+	}
+	state := &desireddom.State{
+		TenantID: in.TenantID, AssetID: in.AssetID, PolicyID: policyID,
+		Capabilities: caps, UpdatedBy: in.Actor, Version: version,
+		Audit: shared.Audit{CreatedAt: createdAt, UpdatedAt: now},
+	}
+	if err := state.Validate(); err != nil {
+		return nil, err
+	}
+	if err := s.store.Put(ctx, state); err != nil {
+		return nil, fmt.Errorf("store desired state: %w", err)
+	}
+	s.record(ctx, state, in.Actor, "fleet.desired_capabilities.set", map[string]string{
+		"capabilities": strings.Join(caps, ","),
+	}, now)
+	return state, nil
+}
+
+func (s *Service) ClearDesiredCapabilities(ctx context.Context, in ClearInput) error {
+	if in.TenantID.IsZero() || in.AssetID.IsZero() || strings.TrimSpace(in.Actor.String()) == "" {
+		return fmt.Errorf("%w: desired-state clear needs tenant, canonical asset and actor", shared.ErrValidation)
+	}
+	current, err := s.store.Get(ctx, in.TenantID, in.AssetID)
+	if errors.Is(err, shared.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read desired state before clear: %w", err)
+	}
+	if err := validateStoredState(current, in.TenantID, in.AssetID); err != nil {
+		return err
+	}
+	if err := s.store.Delete(ctx, in.TenantID, in.AssetID, current.PolicyID, current.Version); err != nil {
+		return fmt.Errorf("clear desired state: %w", err)
+	}
+	now := s.clock.Now().UTC()
+	s.record(ctx, current, in.Actor, "fleet.desired_capabilities.clear", map[string]string{
+		"previous_capabilities": strings.Join(current.Capabilities, ","),
+	}, now)
+	return nil
+}
+
+func (s *Service) Get(ctx context.Context, tenantID, assetID shared.ID) (*desireddom.State, error) {
+	if tenantID.IsZero() || assetID.IsZero() {
+		return nil, fmt.Errorf("%w: desired-state lookup needs tenant and asset", shared.ErrValidation)
+	}
+	state, err := s.store.Get(ctx, tenantID, assetID)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateStoredState(state, tenantID, assetID); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+type ReconciliationRow struct {
+	AssetID       string                    `json:"asset_id"`
+	PolicyID      string                    `json:"policy_id"`
+	PolicyVersion int64                     `json:"policy_version"`
+	// AgentID is the deterministic witness that satisfied the capability, or the best available
+	// representative when the capability is uncovered. Asset coverage does not imply reverse-unique
+	// AssetID -> AgentID binding.
+	AgentID    string                    `json:"agent_id,omitempty"`
+	Capability string                    `json:"capability"`
+	Health     fleetcoverage.AgentHealth `json:"agent_health,omitempty"`
+	Covered    bool                      `json:"covered"`
+	GapReason  desireddom.GapReason      `json:"gap_reason,omitempty"`
+	Detail     string                    `json:"detail,omitempty"`
+	LastSeen   time.Time                 `json:"last_seen,omitempty"`
+}
+
+type observedAgent struct {
+	agent  *fleetagent.Agent
+	health fleetcoverage.AgentHealth
+	caps   map[string]struct{}
+}
+
+type bindingEvaluation struct {
+	binding  CurrentBinding
+	observed observedAgent
+	hasAgent bool
+	covered  bool
+	reason   desireddom.GapReason
+	detail   string
+	rank     int
+}
+
+func (s *Service) Reconcile(ctx context.Context, tenantID shared.ID) ([]ReconciliationRow, error) {
+	return s.reconcile(ctx, tenantID, false)
+}
+
+func (s *Service) Gaps(ctx context.Context, tenantID shared.ID) ([]ReconciliationRow, error) {
+	return s.reconcile(ctx, tenantID, true)
+}
+
+func (s *Service) reconcile(ctx context.Context, tenantID shared.ID, gapsOnly bool) ([]ReconciliationRow, error) {
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: desired-state reconciliation needs a tenant", shared.ErrValidation)
+	}
+	states, err := s.store.List(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list desired states: %w", err)
+	}
+	if len(states) == 0 {
+		return []ReconciliationRow{}, nil
+	}
+
+	ordered := append([]*desireddom.State(nil), states...)
+	desiredIDs := make(map[shared.ID]struct{}, len(ordered))
+	rowCount := 0
+	for i, desired := range ordered {
+		if desired == nil {
+			return nil, fmt.Errorf("%w: desired-state snapshot contains nil row at index %d", shared.ErrValidation, i)
+		}
+		if err := desired.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid desired-state snapshot for asset %s: %w", desired.AssetID, err)
+		}
+		if desired.TenantID != tenantID {
+			return nil, fmt.Errorf("%w: desired-state snapshot for asset %s belongs to tenant %s, want %s",
+				shared.ErrValidation, desired.AssetID, desired.TenantID, tenantID)
+		}
+		if _, duplicate := desiredIDs[desired.AssetID]; duplicate {
+			return nil, fmt.Errorf("%w: duplicate desired-state row for asset %s", shared.ErrValidation, desired.AssetID)
+		}
+		desiredIDs[desired.AssetID] = struct{}{}
+		rowCount += len(desired.Capabilities)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].AssetID < ordered[j].AssetID })
+
+	bindings, err := s.bindings.ListCurrentBindings(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list current agent bindings: %w", err)
+	}
+	bindingsByAsset := make(map[shared.ID][]CurrentBinding, min(len(bindings), len(ordered)))
+	assetByAgent := make(map[shared.ID]shared.ID, len(bindings))
+	for i, binding := range bindings {
+		if binding.TenantID.IsZero() || binding.AssetID.IsZero() || binding.AgentID.IsZero() {
+			return nil, fmt.Errorf("%w: binding snapshot contains empty identity at index %d", shared.ErrValidation, i)
+		}
+		if binding.TenantID != tenantID {
+			return nil, fmt.Errorf("%w: binding %s/%s belongs to tenant %s, want %s",
+				shared.ErrValidation, binding.AssetID, binding.AgentID, binding.TenantID, tenantID)
+		}
+		if other, duplicate := assetByAgent[binding.AgentID]; duplicate {
+			if other == binding.AssetID {
+				return nil, fmt.Errorf("%w: duplicate current binding for agent %s and asset %s",
+					shared.ErrValidation, binding.AgentID, binding.AssetID)
+			}
+			return nil, fmt.Errorf("%w: current agent %s is bound to both assets %s and %s",
+				shared.ErrValidation, binding.AgentID, other, binding.AssetID)
+		}
+		assetByAgent[binding.AgentID] = binding.AssetID
+		if _, wanted := desiredIDs[binding.AssetID]; wanted {
+			bindingsByAsset[binding.AssetID] = append(bindingsByAsset[binding.AssetID], binding)
+		}
+	}
+	for assetID := range bindingsByAsset {
+		if len(bindingsByAsset[assetID]) > 1 {
+			sort.Slice(bindingsByAsset[assetID], func(i, j int) bool {
+				return bindingsByAsset[assetID][i].AgentID < bindingsByAsset[assetID][j].AgentID
+			})
+		}
+	}
+
+	wantedByAgent := make(map[shared.ID]map[string]struct{}, len(bindings))
+	for _, desired := range ordered {
+		wanted := make(map[string]struct{}, len(desired.Capabilities))
+		for _, capability := range desired.Capabilities {
+			wanted[capability] = struct{}{}
+		}
+		for _, binding := range bindingsByAsset[desired.AssetID] {
+			wantedByAgent[binding.AgentID] = wanted
+		}
+	}
+
+	byID := make(map[shared.ID]observedAgent, len(wantedByAgent))
+	if len(wantedByAgent) > 0 {
+		agents, err := s.agents.ListAgents(ctx, tenantID)
+		if err != nil {
+			return nil, fmt.Errorf("list fleet agents: %w", err)
+		}
+		now := s.clock.Now().UTC()
+		seenAgents := make(map[shared.ID]struct{}, len(agents))
+		for i, agent := range agents {
+			if agent == nil {
+				return nil, fmt.Errorf("%w: observed-agent snapshot contains nil row at index %d", shared.ErrValidation, i)
+			}
+			if agent.ID.IsZero() {
+				return nil, fmt.Errorf("%w: observed-agent snapshot contains an empty agent id at index %d", shared.ErrValidation, i)
+			}
+			if agent.TenantID != tenantID {
+				return nil, fmt.Errorf("%w: observed agent %s belongs to tenant %s, want %s",
+					shared.ErrValidation, agent.ID, agent.TenantID, tenantID)
+			}
+			if !agent.State.Valid() {
+				return nil, fmt.Errorf("%w: observed agent %s has invalid lifecycle state %q",
+					shared.ErrValidation, agent.ID, agent.State)
+			}
+			if _, duplicate := seenAgents[agent.ID]; duplicate {
+				return nil, fmt.Errorf("%w: duplicate observed-agent row for agent %s", shared.ErrValidation, agent.ID)
+			}
+			seenAgents[agent.ID] = struct{}{}
+			wanted, relevant := wantedByAgent[agent.ID]
+			if !relevant {
+				continue
+			}
+			caps := make(map[string]struct{}, len(wanted))
+			for _, raw := range agent.Capabilities {
+				capability := strings.TrimSpace(raw)
+				if _, keep := wanted[capability]; keep {
+					caps[capability] = struct{}{}
+				}
+			}
+			byID[agent.ID] = observedAgent{
+				agent:  agent,
+				health: fleetcoverage.AgentStateFrom(agent.LastSeenAt, now, s.staleAfter, agent.Revoked(), agent.Decommissioned()),
+				caps:   caps,
+			}
+		}
+	}
+
+	outCap := rowCount
+	if gapsOnly {
+		outCap = 0
+	}
+	rows := make([]ReconciliationRow, 0, outCap)
+	for _, desired := range ordered {
+		assetBindings := bindingsByAsset[desired.AssetID]
+		for _, capability := range desired.Capabilities {
+			row := ReconciliationRow{
+				AssetID: desired.AssetID.String(), PolicyID: desired.PolicyID.String(), PolicyVersion: desired.Version,
+				Capability: capability,
+			}
+			if len(assetBindings) == 0 {
+				row.GapReason = desireddom.GapAgentMissing
+				row.Detail = "no current agent is bound to this desired asset"
+				rows = append(rows, row)
+				continue
+			}
+			evaluation, err := selectBindingForCapability(assetBindings, byID, capability)
+			if err != nil {
+				return nil, err
+			}
+			row.AgentID = evaluation.binding.AgentID.String()
+			row.Covered = evaluation.covered
+			row.GapReason = evaluation.reason
+			row.Detail = evaluation.detail
+			if evaluation.hasAgent {
+				row.LastSeen = evaluation.observed.agent.LastSeenAt
+				row.Health = evaluation.observed.health
+			}
+			if gapsOnly && row.Covered {
+				continue
+			}
+			rows = append(rows, row)
+		}
+	}
+	return rows, nil
+}
+
+// selectBindingForCapability implements presence semantics for one desired asset capability. Any
+// healthy bound agent advertising the capability satisfies it. If none does, the deterministic
+// representative is the most informative available state: healthy-but-missing capability, stale,
+// missing registry row, revoked, then decommissioned; AgentID order breaks ties. Required replica/node
+// cardinality is a separate topology policy and is deliberately not invented by this foundation.
+func selectBindingForCapability(bindings []CurrentBinding, byID map[shared.ID]observedAgent, capability string) (bindingEvaluation, error) {
+	var best bindingEvaluation
+	for _, binding := range bindings {
+		obs, exists := byID[binding.AgentID]
+		if !exists {
+			candidate := bindingEvaluation{
+				binding: binding, reason: desireddom.GapAgentMissing, rank: 3,
+				detail: "a current binding names an agent with no observed registry row",
+			}
+			if best.rank == 0 || candidate.rank < best.rank {
+				best = candidate
+			}
+			continue
+		}
+
+		candidate := bindingEvaluation{binding: binding, observed: obs, hasAgent: true}
+		switch obs.health {
+		case fleetcoverage.AgentHealthy:
+			if _, advertised := obs.caps[capability]; advertised {
+				candidate.covered = true
+				return candidate, nil
+			}
+			candidate.reason = desireddom.GapCapabilityMissing
+			candidate.detail = "no healthy bound agent advertises the desired capability"
+			candidate.rank = 1
+		case fleetcoverage.AgentStale:
+			candidate.reason = desireddom.GapAgentStale
+			candidate.detail = "no healthy bound agent provides this capability; the selected bound agent heartbeat is stale"
+			candidate.rank = 2
+		case fleetcoverage.AgentRevoked:
+			candidate.reason = desireddom.GapAgentRevoked
+			candidate.detail = "no healthy bound agent provides this capability; the selected bound agent was revoked"
+			candidate.rank = 4
+		case fleetcoverage.AgentDecommissioned:
+			candidate.reason = desireddom.GapAgentDecommissioned
+			candidate.detail = "no healthy bound agent provides this capability; the selected bound agent was decommissioned"
+			candidate.rank = 5
+		default:
+			return bindingEvaluation{}, fmt.Errorf("%w: derived invalid agent health %q for agent %s",
+				shared.ErrValidation, obs.health, binding.AgentID)
+		}
+		if best.rank == 0 || candidate.rank < best.rank {
+			best = candidate
+		}
+	}
+	if best.rank == 0 {
+		return bindingEvaluation{}, fmt.Errorf("%w: desired asset binding set is unexpectedly empty", shared.ErrValidation)
+	}
+	return best, nil
+}
+
+func validateStoredState(state *desireddom.State, tenantID, assetID shared.ID) error {
+	if state == nil {
+		return fmt.Errorf("%w: desired-state store returned a nil row", shared.ErrValidation)
+	}
+	if err := state.Validate(); err != nil {
+		return fmt.Errorf("invalid current desired state: %w", err)
+	}
+	if state.TenantID != tenantID || state.AssetID != assetID {
+		return fmt.Errorf("%w: desired-state store returned identity %s/%s, want %s/%s",
+			shared.ErrValidation, state.TenantID, state.AssetID, tenantID, assetID)
+	}
+	return nil
+}
+
+// record is intentionally best-effort after a durable mutation. A separate audit sink cannot be made
+// atomic with policy persistence here; rolling policy back after an audit failure would create a worse
+// split-brain. The audit implementation is responsible for surfacing its delivery failures.
+func (s *Service) record(ctx context.Context, state *desireddom.State, actor shared.ID, action string, extra map[string]string, at time.Time) {
+	metadata := map[string]string{
+		"tenant_id":      state.TenantID.String(),
+		"asset_id":       state.AssetID.String(),
+		"policy_id":      state.PolicyID.String(),
+		"policy_version": fmt.Sprintf("%d", state.Version),
+	}
+	for k, v := range extra {
+		if v != "" {
+			metadata[k] = v
+		}
+	}
+	_ = s.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor.String(), Action: action, Target: state.AssetID.String(), Metadata: metadata, At: at,
+	})
+}

--- a/internal/usecase/fleet/desired/service.go
+++ b/internal/usecase/fleet/desired/service.go
@@ -486,6 +486,10 @@ func (s *Service) record(ctx context.Context, state *desireddom.State, actor sha
 			metadata[k] = v
 		}
 	}
+	// Audit persistence is tenant-context driven under RLS. Bind the durable policy tenant here rather
+	// than trusting caller context so a missing or mismatched context cannot drop or misattribute the
+	// audit entry after the desired-state mutation has already committed.
+	ctx = shared.WithTenant(ctx, state.TenantID)
 	_ = s.audit.Record(ctx, ports.AuditEntry{
 		Actor: actor.String(), Action: action, Target: state.AssetID.String(), Metadata: metadata, At: at,
 	})

--- a/internal/usecase/fleet/desired/service_test.go
+++ b/internal/usecase/fleet/desired/service_test.go
@@ -1,0 +1,293 @@
+package fleetdesired_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	desireddom "github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	desireduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type testClock struct {
+	now   time.Time
+	calls int
+}
+
+func (c *testClock) Now() time.Time { c.calls++; return c.now }
+
+type testAudit struct{ entries []ports.AuditEntry }
+
+func (a *testAudit) Record(_ context.Context, entry ports.AuditEntry) error {
+	a.entries = append(a.entries, entry)
+	return nil
+}
+
+type testAssets struct {
+	rows  map[shared.ID]*asset.Asset
+	calls int
+}
+
+func (r *testAssets) GetAssetByID(_ context.Context, tenantID, assetID shared.ID) (*asset.Asset, error) {
+	r.calls++
+	a, ok := r.rows[assetID]
+	if !ok || a.TenantID != tenantID {
+		return nil, shared.ErrNotFound
+	}
+	cp := *a
+	return &cp, nil
+}
+
+type testBindings struct {
+	rows  []desireduc.CurrentBinding
+	calls int
+	err   error
+}
+
+func (r *testBindings) ListCurrentBindings(context.Context, shared.ID) ([]desireduc.CurrentBinding, error) {
+	r.calls++
+	return append([]desireduc.CurrentBinding(nil), r.rows...), r.err
+}
+
+type testAgents struct {
+	rows  []*fleetagent.Agent
+	calls int
+	err   error
+}
+
+func (r *testAgents) ListAgents(context.Context, shared.ID) ([]*fleetagent.Agent, error) {
+	r.calls++
+	return append([]*fleetagent.Agent(nil), r.rows...), r.err
+}
+
+func technicalAsset(id string, kind asset.Kind) *asset.Asset {
+	return &asset.Asset{ID: shared.ID(id), TenantID: "tenant-1", Kind: kind, Key: id, Name: id}
+}
+
+func observedAgent(id string, caps []string, at time.Time, state fleetagent.State) *fleetagent.Agent {
+	return &fleetagent.Agent{
+		ID: shared.ID(id), TenantID: "tenant-1", Capabilities: caps, LastSeenAt: at, State: state,
+	}
+}
+
+func newTestService(t *testing.T, store ports.FleetDesiredStore, assets desireduc.AssetReader, bindings desireduc.BindingReader, agents desireduc.AgentReader, audit ports.AuditLogger, clock ports.Clock, stale time.Duration) *desireduc.Service {
+	t.Helper()
+	svc, err := desireduc.NewService(store, assets, bindings, agents, audit, clock, &testIDGenerator{}, stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func TestSetDesiredCapabilitiesNormalizesAuditsPreservesCreatedAtAndIncrementsVersion(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 19, 1, 0, 0, 0, time.UTC)
+	clock := &testClock{now: now}
+	assets := &testAssets{rows: map[shared.ID]*asset.Asset{"asset-1": technicalAsset("asset-1", asset.KindHost)}}
+	store := memory.NewFleetDesiredStore()
+	audit := &testAudit{}
+	svc := newTestService(t, store, assets, &testBindings{}, &testAgents{}, audit, clock, 5*time.Minute)
+
+	first, err := svc.SetDesiredCapabilities(ctx, desireduc.SetInput{
+		TenantID: "tenant-1", AssetID: "asset-1", Actor: "operator-1",
+		Capabilities: []string{" telemetry.process ", "inventory.host", "telemetry.process"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.PolicyID.IsZero() || first.Version != 1 || len(first.Capabilities) != 2 || first.Capabilities[0] != "inventory.host" || first.Capabilities[1] != "telemetry.process" {
+		t.Fatalf("state not canonical/versioned: %+v", first)
+	}
+	clock.now = now.Add(time.Minute)
+	second, err := svc.SetDesiredCapabilities(ctx, desireduc.SetInput{
+		TenantID: "tenant-1", AssetID: "asset-1", Actor: "operator-2", Capabilities: []string{"telemetry.network"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Version != 2 || second.PolicyID != first.PolicyID {
+		t.Fatalf("second lifecycle=%s@%d want %s@2", second.PolicyID, second.Version, first.PolicyID)
+	}
+	if !second.Audit.CreatedAt.Equal(first.Audit.CreatedAt) || !second.Audit.UpdatedAt.Equal(clock.now) {
+		t.Fatalf("audit timestamps not preserved/moved: first=%v second=%v", first.Audit, second.Audit)
+	}
+	if len(audit.entries) != 2 || audit.entries[1].Action != "fleet.desired_capabilities.set" || audit.entries[1].Actor != "operator-2" || audit.entries[1].Metadata["policy_version"] != "2" || audit.entries[1].Metadata["policy_id"] != first.PolicyID.String() {
+		t.Fatalf("unexpected audit entries: %#v", audit.entries)
+	}
+	if assets.calls != 2 {
+		t.Fatalf("changed writes should validate canonical asset each time; calls=%d", assets.calls)
+	}
+}
+
+func TestSetDesiredCapabilitiesRequiresExistingSupportedCanonicalAsset(t *testing.T) {
+	ctx := context.Background()
+	clock := &testClock{now: time.Now().UTC()}
+	store := memory.NewFleetDesiredStore()
+	assets := &testAssets{rows: map[shared.ID]*asset.Asset{
+		"workload": technicalAsset("workload", asset.KindWorkload),
+	}}
+	svc := newTestService(t, store, assets, &testBindings{}, &testAgents{}, &testAudit{}, clock, time.Minute)
+
+	for _, tc := range []struct {
+		name    string
+		assetID shared.ID
+	}{
+		{name: "missing", assetID: "missing"},
+		{name: "unsupported kind", assetID: "workload"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.SetDesiredCapabilities(ctx, desireduc.SetInput{
+				TenantID: "tenant-1", AssetID: tc.assetID, Actor: "operator", Capabilities: []string{"process"},
+			})
+			if err == nil {
+				t.Fatal("expected mutation rejection")
+			}
+			if _, getErr := store.Get(ctx, "tenant-1", tc.assetID); !errors.Is(getErr, shared.ErrNotFound) {
+				t.Fatalf("rejected mutation wrote desired state: %v", getErr)
+			}
+		})
+	}
+	if _, err := svc.SetDesiredCapabilities(ctx, desireduc.SetInput{
+		TenantID: "tenant-1", AssetID: "workload", Actor: "operator", Capabilities: nil,
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("empty Set error=%v, want validation", err)
+	}
+}
+
+func TestClearDesiredCapabilitiesIsExplicitAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 19, 1, 0, 0, 0, time.UTC)
+	store := memory.NewFleetDesiredStore()
+	if err := store.Put(ctx, &desireddom.State{
+		TenantID: "tenant-1", AssetID: "asset-1", PolicyID: "policy-clear", Capabilities: []string{"process"}, UpdatedBy: "operator", Version: 1,
+		Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assets := &testAssets{rows: map[shared.ID]*asset.Asset{}}
+	audit := &testAudit{}
+	clock := &testClock{now: now.Add(time.Minute)}
+	svc := newTestService(t, store, assets, &testBindings{}, &testAgents{}, audit, clock, time.Minute)
+
+	if err := svc.ClearDesiredCapabilities(ctx, desireduc.ClearInput{TenantID: "tenant-1", AssetID: "asset-1", Actor: "operator-2"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Get(ctx, "tenant-1", "asset-1"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cleared policy still exists: %v", err)
+	}
+	if assets.calls != 0 || len(audit.entries) != 1 || clock.calls != 1 || audit.entries[0].Metadata["policy_version"] != "1" || audit.entries[0].Metadata["policy_id"] != "policy-clear" {
+		t.Fatalf("clear side effects: asset_reads=%d audits=%#v clock=%d", assets.calls, audit.entries, clock.calls)
+	}
+	if err := svc.ClearDesiredCapabilities(ctx, desireduc.ClearInput{TenantID: "tenant-1", AssetID: "asset-1", Actor: "operator-2"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(audit.entries) != 1 || clock.calls != 1 {
+		t.Fatalf("idempotent absent clear caused side effects: audits=%d clock=%d", len(audit.entries), clock.calls)
+	}
+}
+
+func TestReenrolledReplacementAgentSatisfiesExistingAssetPolicy(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 19, 2, 0, 0, 0, time.UTC)
+	store := memory.NewFleetDesiredStore()
+	if err := store.Put(ctx, &desireddom.State{
+		TenantID: "tenant-1", AssetID: "host-asset", PolicyID: "policy-host", Capabilities: []string{"network", "process"}, UpdatedBy: "operator", Version: 1,
+		Audit: shared.Audit{CreatedAt: now.Add(-time.Hour), UpdatedAt: now.Add(-time.Hour)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	bindings := &testBindings{rows: []desireduc.CurrentBinding{{TenantID: "tenant-1", AssetID: "host-asset", AgentID: "agent-new"}}}
+	agents := &testAgents{rows: []*fleetagent.Agent{observedAgent("agent-new", []string{"process", "network"}, now, fleetagent.StateActive)}}
+	svc := newTestService(t, store, &testAssets{rows: map[shared.ID]*asset.Asset{}}, bindings, agents, &testAudit{}, &testClock{now: now}, 5*time.Minute)
+
+	rows, err := svc.Reconcile(ctx, "tenant-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 || !rows[0].Covered || !rows[1].Covered || rows[0].AgentID != "agent-new" || rows[1].AgentID != "agent-new" || rows[0].PolicyID != "policy-host" || rows[1].PolicyID != "policy-host" {
+		t.Fatalf("replacement agent did not satisfy existing asset policy: %#v", rows)
+	}
+}
+
+func TestReconcileSurfacesHealthCapabilityAndBindingGaps(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 19, 2, 0, 0, 0, time.UTC)
+	store := memory.NewFleetDesiredStore()
+	put := func(assetID string, caps ...string) {
+		t.Helper()
+		if err := store.Put(ctx, &desireddom.State{
+			TenantID: "tenant-1", AssetID: shared.ID(assetID), PolicyID: shared.ID("policy-" + assetID), Capabilities: caps,
+			UpdatedBy: "operator", Version: 1, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	put("asset-healthy", "file", "network", "process")
+	put("asset-stale", "process")
+	put("asset-revoked", "process")
+	put("asset-decommissioned", "process")
+	put("asset-unbound", "process")
+	put("asset-agent-row-missing", "process")
+
+	bindings := &testBindings{rows: []desireduc.CurrentBinding{
+		{TenantID: "tenant-1", AssetID: "asset-healthy", AgentID: "agent-healthy"},
+		{TenantID: "tenant-1", AssetID: "asset-stale", AgentID: "agent-stale"},
+		{TenantID: "tenant-1", AssetID: "asset-revoked", AgentID: "agent-revoked"},
+		{TenantID: "tenant-1", AssetID: "asset-decommissioned", AgentID: "agent-decommissioned"},
+		{TenantID: "tenant-1", AssetID: "asset-agent-row-missing", AgentID: "agent-missing"},
+	}}
+	agents := &testAgents{rows: []*fleetagent.Agent{
+		observedAgent("agent-healthy", []string{" network ", "process"}, now, fleetagent.StateActive),
+		observedAgent("agent-stale", []string{"process"}, now.Add(-10*time.Minute), fleetagent.StateActive),
+		observedAgent("agent-revoked", []string{"process"}, now, fleetagent.StateRevoked),
+		observedAgent("agent-decommissioned", []string{"process"}, now, fleetagent.StateDecommissioned),
+	}}
+	svc := newTestService(t, store, &testAssets{rows: map[shared.ID]*asset.Asset{}}, bindings, agents, &testAudit{}, &testClock{now: now}, 5*time.Minute)
+
+	rows, err := svc.Reconcile(ctx, "tenant-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantGaps := map[string]desireddom.GapReason{
+		"asset-healthy/file":              desireddom.GapCapabilityMissing,
+		"asset-stale/process":             desireddom.GapAgentStale,
+		"asset-revoked/process":           desireddom.GapAgentRevoked,
+		"asset-decommissioned/process":    desireddom.GapAgentDecommissioned,
+		"asset-unbound/process":           desireddom.GapAgentMissing,
+		"asset-agent-row-missing/process": desireddom.GapAgentMissing,
+	}
+	covered := 0
+	for _, row := range rows {
+		key := row.AssetID + "/" + row.Capability
+		if row.PolicyID == "" || row.PolicyVersion != 1 {
+			t.Fatalf("row %s lost desired policy identity: %+v", key, row)
+		}
+		if row.Covered {
+			covered++
+			if row.GapReason != "" {
+				t.Fatalf("covered row %s carries gap %q", key, row.GapReason)
+			}
+			continue
+		}
+		want, ok := wantGaps[key]
+		if !ok || row.GapReason != want {
+			t.Fatalf("row %s gap=%q want=%q known=%v", key, row.GapReason, want, ok)
+		}
+	}
+	if covered != 2 {
+		t.Fatalf("covered=%d want 2; rows=%#v", covered, rows)
+	}
+	gaps, err := svc.Gaps(ctx, "tenant-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gaps) != len(wantGaps) {
+		t.Fatalf("gaps=%d want %d: %#v", len(gaps), len(wantGaps), gaps)
+	}
+}

--- a/internal/usecase/fleet/desired/set_invariants_external_test.go
+++ b/internal/usecase/fleet/desired/set_invariants_external_test.go
@@ -1,0 +1,263 @@
+package fleetdesired_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	desireddom "github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	desireduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type setInvariantStore struct {
+	current              *desireddom.State
+	getErr               error
+	puts                 int
+	deletes              int
+	deleteExpectedPolicy shared.ID
+	deleteExpected       int64
+	written              *desireddom.State
+}
+
+func (s *setInvariantStore) Get(context.Context, shared.ID, shared.ID) (*desireddom.State, error) {
+	return s.current, s.getErr
+}
+func (s *setInvariantStore) Put(_ context.Context, state *desireddom.State) error {
+	s.puts++
+	s.written = state
+	s.current = state
+	s.getErr = nil
+	return nil
+}
+func (s *setInvariantStore) Delete(_ context.Context, _ shared.ID, _ shared.ID, expectedPolicyID shared.ID, expectedVersion int64) error {
+	s.deletes++
+	s.deleteExpectedPolicy = expectedPolicyID
+	s.deleteExpected = expectedVersion
+	s.current = nil
+	s.getErr = shared.ErrNotFound
+	return nil
+}
+func (*setInvariantStore) List(context.Context, shared.ID) ([]*desireddom.State, error) { return nil, nil }
+
+type setInvariantAssetReader struct {
+	asset *asset.Asset
+	err   error
+	calls int
+}
+
+func (r *setInvariantAssetReader) GetAssetByID(context.Context, shared.ID, shared.ID) (*asset.Asset, error) {
+	r.calls++
+	return r.asset, r.err
+}
+
+type setInvariantBindings struct{ calls int }
+
+func (r *setInvariantBindings) ListCurrentBindings(context.Context, shared.ID) ([]desireduc.CurrentBinding, error) {
+	r.calls++
+	return nil, nil
+}
+
+type setInvariantAgents struct{ calls int }
+
+func (r *setInvariantAgents) ListAgents(context.Context, shared.ID) ([]*fleetagent.Agent, error) {
+	r.calls++
+	return nil, nil
+}
+
+type setInvariantAudit struct{ records int }
+
+func (a *setInvariantAudit) Record(context.Context, ports.AuditEntry) error {
+	a.records++
+	return nil
+}
+
+type setInvariantClock struct {
+	now   time.Time
+	calls int
+}
+
+func (c *setInvariantClock) Now() time.Time {
+	c.calls++
+	return c.now
+}
+
+func setInvariantState(now time.Time) *desireddom.State {
+	return &desireddom.State{
+		TenantID: "tenant", AssetID: "asset", PolicyID: "policy-current", Capabilities: []string{"network", "process"},
+		UpdatedBy: "operator", Version: 1, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+}
+
+func setInvariantService(t *testing.T, store *setInvariantStore, assets *setInvariantAssetReader, audit *setInvariantAudit, clock *setInvariantClock, ids *testIDGenerator) *desireduc.Service {
+	t.Helper()
+	svc, err := desireduc.NewService(store, assets, &setInvariantBindings{}, &setInvariantAgents{}, audit, clock, ids, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func TestDesiredMutationRejectsBlankActorBeforeSideEffects(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name string
+		run  func(*desireduc.Service) error
+	}{
+		{name: "set", run: func(svc *desireduc.Service) error {
+			_, err := svc.SetDesiredCapabilities(context.Background(), desireduc.SetInput{
+				TenantID: "tenant", AssetID: "asset", Actor: "   ", Capabilities: []string{"process"},
+			})
+			return err
+		}},
+		{name: "clear", run: func(svc *desireduc.Service) error {
+			return svc.ClearDesiredCapabilities(context.Background(), desireduc.ClearInput{
+				TenantID: "tenant", AssetID: "asset", Actor: "   ",
+			})
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &setInvariantStore{current: setInvariantState(now)}
+			assets := &setInvariantAssetReader{}
+			audit := &setInvariantAudit{}
+			clock := &setInvariantClock{now: now}
+			ids := &testIDGenerator{}
+			svc := setInvariantService(t, store, assets, audit, clock, ids)
+			if err := tc.run(svc); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("error=%v, want validation", err)
+			}
+			if store.puts != 0 || store.deletes != 0 || assets.calls != 0 || audit.records != 0 || clock.calls != 0 || ids.calls != 0 {
+				t.Fatalf("blank actor caused side effects: puts=%d deletes=%d asset_reads=%d audit=%d clock=%d ids=%d",
+					store.puts, store.deletes, assets.calls, audit.records, clock.calls, ids.calls)
+			}
+		})
+	}
+}
+
+func TestSetDesiredCapabilitiesIdenticalReapplyIsSideEffectFree(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	current := setInvariantState(now)
+	store := &setInvariantStore{current: current}
+	assets := &setInvariantAssetReader{err: errors.New("identical reapply must not read asset")}
+	audit := &setInvariantAudit{}
+	clock := &setInvariantClock{now: now.Add(time.Hour)}
+	ids := &testIDGenerator{}
+	svc := setInvariantService(t, store, assets, audit, clock, ids)
+
+	got, err := svc.SetDesiredCapabilities(context.Background(), desireduc.SetInput{
+		TenantID: "tenant", AssetID: "asset", Actor: "another-operator",
+		Capabilities: []string{" process ", "network", "process"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.puts != 0 || store.deletes != 0 || assets.calls != 0 || audit.records != 0 || clock.calls != 0 || ids.calls != 0 {
+		t.Fatalf("identical reapply caused side effects: puts=%d deletes=%d asset_reads=%d audit=%d clock=%d ids=%d",
+			store.puts, store.deletes, assets.calls, audit.records, clock.calls, ids.calls)
+	}
+	if got != current || got.PolicyID != "policy-current" || got.Version != 1 || !got.Audit.UpdatedAt.Equal(now) {
+		t.Fatalf("identical reapply did not return unchanged state: %+v", got)
+	}
+}
+
+func TestSetDesiredCapabilitiesFailsClosedOnMalformedAssetReaderResult(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name  string
+		asset *asset.Asset
+	}{
+		{name: "nil", asset: nil},
+		{name: "wrong tenant", asset: &asset.Asset{ID: "asset", TenantID: "other", Kind: asset.KindHost}},
+		{name: "wrong asset", asset: &asset.Asset{ID: "other", TenantID: "tenant", Kind: asset.KindHost}},
+		{name: "unsupported kind", asset: &asset.Asset{ID: "asset", TenantID: "tenant", Kind: asset.KindWorkload}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &setInvariantStore{getErr: shared.ErrNotFound}
+			assets := &setInvariantAssetReader{asset: tc.asset}
+			audit := &setInvariantAudit{}
+			clock := &setInvariantClock{now: now}
+			ids := &testIDGenerator{}
+			svc := setInvariantService(t, store, assets, audit, clock, ids)
+			_, err := svc.SetDesiredCapabilities(context.Background(), desireduc.SetInput{
+				TenantID: "tenant", AssetID: "asset", Actor: "operator", Capabilities: []string{"process"},
+			})
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("error=%v, want validation", err)
+			}
+			if store.puts != 0 || audit.records != 0 || clock.calls != 0 || ids.calls != 0 {
+				t.Fatalf("malformed asset result caused side effects: puts=%d audit=%d clock=%d ids=%d", store.puts, audit.records, clock.calls, ids.calls)
+			}
+		})
+	}
+}
+
+func TestSetDesiredCapabilitiesAllowsPolicyBeforeAgentBindingExists(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	store := &setInvariantStore{getErr: shared.ErrNotFound}
+	assets := &setInvariantAssetReader{asset: &asset.Asset{ID: "asset", TenantID: "tenant", Kind: asset.KindHost}}
+	audit := &setInvariantAudit{}
+	clock := &setInvariantClock{now: now}
+	bindings := &setInvariantBindings{}
+	agents := &setInvariantAgents{}
+	ids := &testIDGenerator{}
+	svc, err := desireduc.NewService(store, assets, bindings, agents, audit, clock, ids, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := svc.SetDesiredCapabilities(context.Background(), desireduc.SetInput{
+		TenantID: "tenant", AssetID: "asset", Actor: "operator", Capabilities: []string{"process"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AssetID != "asset" || got.PolicyID.IsZero() || got.Version != 1 || store.puts != 1 || store.written.Version != 1 ||
+		bindings.calls != 0 || agents.calls != 0 || audit.records != 1 || clock.calls != 1 || ids.calls != 1 {
+		t.Fatalf("pre-binding desired write mismatch: got=%+v written=%+v puts=%d bindings=%d agents=%d audit=%d clock=%d ids=%d",
+			got, store.written, store.puts, bindings.calls, agents.calls, audit.records, clock.calls, ids.calls)
+	}
+}
+
+func TestSetDesiredCapabilitiesIncrementsCurrentVersionExactlyOnce(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	current := setInvariantState(now)
+	current.Version = 41
+	store := &setInvariantStore{current: current}
+	assets := &setInvariantAssetReader{asset: &asset.Asset{ID: "asset", TenantID: "tenant", Kind: asset.KindHost}}
+	ids := &testIDGenerator{}
+	svc := setInvariantService(t, store, assets, &setInvariantAudit{}, &setInvariantClock{now: now.Add(time.Minute)}, ids)
+	got, err := svc.SetDesiredCapabilities(context.Background(), desireduc.SetInput{
+		TenantID: "tenant", AssetID: "asset", Actor: "operator", Capabilities: []string{"file"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != 42 || store.written.Version != 42 || got.PolicyID != current.PolicyID || ids.calls != 0 {
+		t.Fatalf("semantic update got=%+v written=%+v ids=%d; want version 42 with preserved policy id and no new id", got, store.written, ids.calls)
+	}
+}
+
+func TestClearDesiredCapabilitiesDoesNotDependOnAssetOrAgentExistence(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	store := &setInvariantStore{current: setInvariantState(now)}
+	assets := &setInvariantAssetReader{err: errors.New("clear must not read asset")}
+	audit := &setInvariantAudit{}
+	clock := &setInvariantClock{now: now.Add(time.Hour)}
+	ids := &testIDGenerator{}
+	svc := setInvariantService(t, store, assets, audit, clock, ids)
+
+	if err := svc.ClearDesiredCapabilities(context.Background(), desireduc.ClearInput{
+		TenantID: "tenant", AssetID: "asset", Actor: "operator",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if assets.calls != 0 || store.deletes != 1 || store.deleteExpectedPolicy != "policy-current" || store.deleteExpected != 1 ||
+		audit.records != 1 || clock.calls != 1 || ids.calls != 0 {
+		t.Fatalf("clear side effects mismatch: asset_reads=%d deletes=%d policy=%s expected=%d audit=%d clock=%d ids=%d",
+			assets.calls, store.deletes, store.deleteExpectedPolicy, store.deleteExpected, audit.records, clock.calls, ids.calls)
+	}
+}

--- a/internal/usecase/fleet/desired/set_invariants_external_test.go
+++ b/internal/usecase/fleet/desired/set_invariants_external_test.go
@@ -42,7 +42,9 @@ func (s *setInvariantStore) Delete(_ context.Context, _ shared.ID, _ shared.ID, 
 	s.getErr = shared.ErrNotFound
 	return nil
 }
-func (*setInvariantStore) List(context.Context, shared.ID) ([]*desireddom.State, error) { return nil, nil }
+func (*setInvariantStore) List(context.Context, shared.ID) ([]*desireddom.State, error) {
+	return nil, nil
+}
 
 type setInvariantAssetReader struct {
 	asset *asset.Asset

--- a/internal/usecase/fleet/desired/test_helpers_test.go
+++ b/internal/usecase/fleet/desired/test_helpers_test.go
@@ -1,0 +1,16 @@
+package fleetdesired_test
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type testIDGenerator struct {
+	calls int
+}
+
+func (g *testIDGenerator) NewID() shared.ID {
+	g.calls++
+	return shared.ID(fmt.Sprintf("policy-%d", g.calls))
+}

--- a/internal/usecase/ports/fleetdesired.go
+++ b/internal/usecase/ports/fleetdesired.go
@@ -1,0 +1,21 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// FleetDesiredStore persists control-plane-owned desired capability sets for canonical host/cluster
+// assets. Implementations are tenant-scoped; List is deterministically ordered by AssetID.
+//
+// Put is CAS by (PolicyID,Version): version 1 requires absence; later versions require the same
+// PolicyID and stored version N-1. Delete requires the lifecycle PolicyID plus expectedVersion. This
+// prevents both lost updates and the delete/recreate ABA race. An empty policy is represented by absence.
+type FleetDesiredStore interface {
+	Get(ctx context.Context, tenantID, assetID shared.ID) (*fleetdesired.State, error)
+	Put(ctx context.Context, state *fleetdesired.State) error
+	Delete(ctx context.Context, tenantID, assetID, expectedPolicyID shared.ID, expectedVersion int64) error
+	List(ctx context.Context, tenantID shared.ID) ([]*fleetdesired.State, error)
+}

--- a/migrations/0107_fleet_desired_state.sql
+++ b/migrations/0107_fleet_desired_state.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+-- Durable desired-vs-observed fleet intent (#633).
+--
+-- `fleet_agents.capabilities` is agent-reported observation and must never double as policy. Durable
+-- intent is attached to the canonical host/cluster technical AssetID instead of the enrolment-scoped
+-- AgentID: reinstalling or replacing an agent must not orphan the policy for the host/cluster it serves.
+-- Asset kind remains authoritative in fleet_assets and is intentionally not duplicated here. The
+-- mutation use case admits only host/cluster assets; the FK keeps every durable subject canonical.
+
+CREATE FUNCTION synapse_fleet_desired_capabilities_valid(caps TEXT[])
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+    SELECT
+        array_ndims(caps) = 1
+        AND cardinality(caps) BETWEEN 1 AND 64
+        AND NOT EXISTS (
+            SELECT 1
+            FROM unnest(caps) AS c
+            WHERE c IS NULL
+               OR btrim(c) = ''
+               OR c <> btrim(c)
+               OR octet_length(c) > 128
+               OR c ~ '[[:cntrl:]]'
+        )
+        AND cardinality(caps) = (SELECT count(DISTINCT c) FROM unnest(caps) AS c)
+        AND caps = ARRAY(SELECT c FROM unnest(caps) AS c ORDER BY c COLLATE "C")
+$$;
+
+CREATE TABLE fleet_desired_state (
+    tenant_id    TEXT NOT NULL REFERENCES tenants(id),
+    asset_id     TEXT NOT NULL CHECK (asset_id <> ''),
+    policy_id    TEXT NOT NULL CHECK (policy_id <> ''),
+    capabilities TEXT[] NOT NULL,
+    updated_by   TEXT NOT NULL CHECK (btrim(updated_by) <> ''),
+    version      BIGINT NOT NULL CHECK (version >= 1),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, asset_id),
+    UNIQUE (tenant_id, policy_id),
+    FOREIGN KEY (tenant_id, asset_id) REFERENCES fleet_assets(tenant_id, id),
+    CONSTRAINT fleet_desired_state_capabilities_canonical CHECK (synapse_fleet_desired_capabilities_valid(capabilities)),
+    CONSTRAINT fleet_desired_state_time_order CHECK (updated_at >= created_at)
+);
+
+CALL synapse_enable_tenant_rls('fleet_desired_state');
+
+-- +goose Down
+DROP TABLE fleet_desired_state;
+DROP FUNCTION synapse_fleet_desired_capabilities_valid(TEXT[]);


### PR DESCRIPTION
## Summary

Adds the AssetID-scoped desired-state reconciliation foundation for #633.

Desired fleet capabilities are persisted independently from agent-observed
capabilities and reconciled through the server-authoritative agent -> asset
binding contract.

Policies follow the canonical host/cluster `AssetID` rather than an
enrolment-scoped `AgentID`, so agent reinstall or re-enrolment does not orphan
the desired intent for the underlying asset.

## What changed

- Add a canonical desired fleet policy domain and memory/PostgreSQL stores.
- Add migration `0107_fleet_desired_state.sql` with tenant RLS and DB-level
  canonical capability constraints.
- Add lifecycle-aware `PolicyID + Version` CAS to prevent lost updates and
  clear/recreate ABA races.
- Make clearing desired intent an explicit operation rather than persisting an
  empty policy.
- Add desired-vs-observed reconciliation under
  `internal/usecase/fleet/desired`.
- Emit explicit gaps for:
  - missing agents;
  - stale agents;
  - revoked agents;
  - decommissioned agents;
  - missing capabilities.
- Support multiple current agents serving the same canonical asset. A desired
  capability is covered when any healthy bound agent advertises it.
- Keep the reverse binding assumption intentionally loose: one asset may have
  multiple agents, while one `AgentID` cannot resolve to multiple canonical
  assets.
- Add narrow canonical AssetID readers without expanding the broad asset
  repository port.
- Add migration, RLS, lifecycle, concurrency, ABA, malformed-snapshot,
  replacement-agent, multi-agent and reconciliation regression coverage.

## Desired-state semantics

`fleet_agents.capabilities` remains observed state only.

The desired policy is stored separately and is keyed by canonical `AssetID`.
This prevents a missing, compromised, reinstalled, or re-enrolled agent from
silently erasing the operator's expected coverage.

Desired capability sets are canonicalized and bounded:

- whitespace trimmed;
- duplicates removed;
- deterministic ordering;
- valid UTF-8 only;
- control characters rejected;
- bounded raw input and stored cardinality;
- bounded capability length;
- empty persisted policies rejected.

An identical declarative re-apply is a true no-op: it performs no asset lookup,
ID generation, clock read, persistence write, or audit churn.

## Reconciliation

The reconciler consumes:

1. desired state by canonical asset;
2. the server-authoritative current agent -> asset binding projection;
3. observed fleet-agent state.

For each desired capability, coverage is satisfied when at least one healthy
bound agent currently advertises it.

This allows a replacement/re-enrolled agent to satisfy an existing asset policy
as soon as the authoritative binding points the new agent at the same
`AssetID`, without rewriting desired state.

Malformed, cross-tenant, or internally contradictory snapshots fail closed.

## Concurrency and persistence safety

Desired mutations use `PolicyID + Version` lifecycle-aware CAS.

Coverage includes real competing operations for both memory and PostgreSQL:

- concurrent create -> exactly one version-1 policy wins;
- concurrent updates from the same version -> exactly one wins;
- update racing clear -> exactly one operation wins;
- clear -> recreate mints a new `PolicyID`, preventing stale-delete ABA;
- duplicate `PolicyID` within a tenant conflicts consistently.

PostgreSQL persistence also includes:

- tenant RLS with `FORCE ROW LEVEL SECURITY`;
- canonical asset foreign-key integrity;
- tenant-scoped unique policy IDs;
- DB-level capability canonicalization checks;
- timestamp/version invariants.

The RLS integration test switches to a real
`NOSUPERUSER NOBYPASSRLS` role when the test DSN uses an administrative
PostgreSQL account, so it tests the policy itself rather than relying on
repository query predicates.

## Validation

The final branch is a single commit on the current upstream base.

The final squashed commit contains the exact same Git tree as the fully
hardened pre-squash head, so squashing changed history only.

Feature-specific validation includes:

- Linux Go build: pass
- Linux Go vet: pass
- Windows Go build/vet/test: pass
- frontend test/typecheck/build: pass
- Agent Package Matrix: pass
- fleet desired domain tests: pass
- memory persistence tests: pass
- `internal/usecase/fleet/desired` tests: pass
- PostgreSQL 17 migration `0107`: pass
- PostgreSQL desired repository tests: pass
- RLS tests with a real non-bypass role: pass
- CAS/ABA/concurrency tests: pass
- 10k-asset reconciliation/gap benchmarks exercised during hardening

The repository-wide Linux test job still encounters an existing unrelated
JobQueue fixture that inserts a tenant without the now-required `name`.

`golangci-lint` likewise reports an existing unrelated SA4023 in
`internal/usecase/sca/service.go`.

Neither file is modified by this PR, and no #633-specific failure appears in
those jobs.

## Deliberate boundary

This is a foundation slice of #633, not full completion of the cross-cutting
workstream.

It intentionally does not implement `AssetBinding` or derive canonical identity
from hostname/work-order heuristics. The reconciler consumes the
server-authoritative binding contract instead of creating a competing identity
model.

Final operator HTTP/query wiring should be composed once the authoritative
binding adapter exists.

This PR also intentionally leaves:

- VM RPM/DEB install/update lifecycle to the corresponding deployment work;
- Kubernetes DaemonSet/topology semantics to #632;
- signed fleet-update mechanics to #631;
- final shared `CoverageWindow` materialization/integration to the appropriate
  coverage path.

Refs #633