### PR TITLE
feat(agent): add durable priority telemetry spool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -304,6 +304,8 @@ SYNAPSE_GOMODGRAPH_ENABLED=true      # transitive Go dep edges via `go mod graph
 # SYNAPSE_FLEET_URL=https://synapse.example.com
 # SYNAPSE_FLEET_ENROL_TOKEN_FILE=/run/secrets/synapse-enrol-token
 # SYNAPSE_AGENT_STATE_DIR=/var/lib/synapse-agent
+# SYNAPSE_TELEMETRY_SPOOL_BYTES=536870912             # P0-P3 durable WAL quota (512 MiB)
+# SYNAPSE_AGENT_METRICS_ADDR=127.0.0.1:9465           # optional, unauthenticated private scrape listener
 
 # =============================================================================
 # Leader election (horizontal scale) – fence scheduled work to one node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Crash-recoverable priority telemetry spool for the host agent.** Normalized eBPF events and
+  confirmed detections now enter checksummed, per-priority WAL segments before downstream use. The
+  spool resumes sequence incarnations after restart, commits exact-epoch ACKs, evicts only P3 under
+  quota pressure, persists queryable gap evidence before any loss, repairs torn/corrupt frames, and
+  exports bounded-cardinality depth, oldest-age, eviction, corruption, and fsync metrics. P0–P2 apply
+  backpressure instead of silently shedding; A3 will consume the exposed peek/ACK and retry contract.
+
 - **Authority-surface precondition on AI-triage promotion.** Evaluation reports record
   `gate_reachable_pairs`, and the promotion boundary requires at least one counterfactual pair the
   deterministic policy could actually exempt (`--minimum-gate-reachable-counterfactual-pairs`,

--- a/cmd/synapse-agent/detect.go
+++ b/cmd/synapse-agent/detect.go
@@ -5,15 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/adapter/agentspool"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
-	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/detectsink"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/ebpf"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
 	detectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detect"
@@ -56,31 +55,49 @@ func (r *runner) startDetection(ctx context.Context, cred fleetclient.Credential
 		log.Print("detection: enrolled credential has no canonical agent id; detection engine disabled")
 		return
 	}
-	sinkPath := filepath.Join(r.cfg.stateDir, "detections.jsonl")
-	sink, err := detectsink.New(sinkPath)
+	durable, identity, err := r.openTelemetrySpool(ctx, cred)
 	if err != nil {
-		log.Printf("detection: %v; detection engine disabled", err)
+		log.Printf("detection: open durable telemetry spool: %v; detection engine disabled", err)
 		return
 	}
-	sensor := ebpf.NewSensor(host, agent, classes)
+	rawSensor := ebpf.NewSensor(host, agent, classes)
+	sensor, err := agentspool.NewDurableSensor(rawSensor, durable, identity)
+	if err != nil {
+		log.Printf("detection: wire durable telemetry sensor: %v; detection engine disabled", err)
+		_ = durable.Close()
+		return
+	}
+	sink, err := agentspool.NewDetectionSink(durable)
+	if err != nil {
+		log.Printf("detection: wire durable detection sink: %v; detection engine disabled", err)
+		_ = durable.Close()
+		return
+	}
 	eng, err := detectuc.NewEngine(sensor, sink, host, agent, detectuc.Options{
 		Classes:       classes,
 		CPUCeilingPct: r.cfg.detectCeiling,
 	})
 	if err != nil {
 		log.Printf("detection: %v; detection engine disabled", err)
-		_ = sink.Close()
+		_ = durable.Close()
 		return
 	}
+	if err := r.startSpoolMetrics(ctx, durable); err != nil {
+		log.Printf("detection: agent metrics listener unavailable: %v", err)
+	}
 
-	log.Printf("detection engine starting: classes=%s ceiling=%.0f%% sink=%s", r.cfg.detectClasses, r.cfg.detectCeiling, sinkPath)
+	log.Printf("detection engine starting: classes=%s ceiling=%.0f%% durable_spool=%s", r.cfg.detectClasses, r.cfg.detectCeiling, r.telemetrySpoolDir())
 	// One-shot coverage report shortly after start, so the operator can see which classes actually came
 	// up on this host and which are gaps — never silently assume a class is observing.
 	go func() {
 		select {
 		case <-ctx.Done():
 		case <-time.After(3 * time.Second):
-			log.Printf("detection coverage: %s", formatCoverage(eng.Coverage()))
+			coverage := eng.Coverage()
+			log.Printf("detection coverage: %s", formatCoverage(coverage))
+			if err := agentspool.RecordCoverage(ctx, durable, coverage, time.Now().UTC()); err != nil {
+				log.Printf("detection: persist coverage/sensor state: %v", err)
+			}
 		}
 	}()
 	go func() {
@@ -88,7 +105,9 @@ func (r *runner) startDetection(ctx context.Context, cred fleetclient.Credential
 		if err != nil && !errors.Is(err, context.Canceled) {
 			log.Printf("detection engine stopped: %v", err)
 		}
-		_ = sink.Close()
+		if closeErr := durable.Close(); closeErr != nil {
+			log.Printf("detection: close durable spool: %v", closeErr)
+		}
 	}()
 }
 

--- a/cmd/synapse-agent/detect.go
+++ b/cmd/synapse-agent/detect.go
@@ -82,29 +82,38 @@ func (r *runner) startDetection(ctx context.Context, cred fleetclient.Credential
 		_ = durable.Close()
 		return
 	}
-	if err := r.startSpoolMetrics(ctx, durable); err != nil {
+	runCtx, cancelRun := context.WithCancel(ctx)
+	if err := r.startSpoolMetrics(runCtx, durable); err != nil {
 		log.Printf("detection: agent metrics listener unavailable: %v", err)
 	}
 
 	log.Printf("detection engine starting: classes=%s ceiling=%.0f%% durable_spool=%s", r.cfg.detectClasses, r.cfg.detectCeiling, r.telemetrySpoolDir())
 	// One-shot coverage report shortly after start, so the operator can see which classes actually came
 	// up on this host and which are gaps — never silently assume a class is observing.
+	coverageDone := make(chan struct{})
 	go func() {
+		defer close(coverageDone)
+		timer := time.NewTimer(3 * time.Second)
+		defer timer.Stop()
 		select {
-		case <-ctx.Done():
-		case <-time.After(3 * time.Second):
+		case <-runCtx.Done():
+		case <-timer.C:
 			coverage := eng.Coverage()
 			log.Printf("detection coverage: %s", formatCoverage(coverage))
-			if err := agentspool.RecordCoverage(ctx, durable, coverage, time.Now().UTC()); err != nil {
+			if err := agentspool.RecordCoverage(runCtx, durable, coverage, time.Now().UTC()); err != nil && !errors.Is(err, context.Canceled) {
 				log.Printf("detection: persist coverage/sensor state: %v", err)
 			}
 		}
 	}()
 	go func() {
-		err := eng.Run(ctx)
+		err := eng.Run(runCtx)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			log.Printf("detection engine stopped: %v", err)
 		}
+		cancelRun()
+		// A timer that fired concurrently may still be persisting coverage. Wait
+		// for it before closing the shared spool so no operation races Close.
+		<-coverageDone
 		if closeErr := durable.Close(); closeErr != nil {
 			log.Printf("detection: close durable spool: %v", closeErr)
 		}

--- a/cmd/synapse-agent/main.go
+++ b/cmd/synapse-agent/main.go
@@ -22,6 +22,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -67,6 +68,8 @@ type config struct {
 	once          bool
 	detectClasses string  // SYNAPSE_DETECT_CLASSES; empty = detection engine off
 	detectCeiling float64 // SYNAPSE_DETECT_CPU_CEIL_PCT; 0 = no load shedding
+	spoolBytes    int64   // durable telemetry WAL quota
+	metricsAddr   string  // optional private agent metrics listener
 }
 
 func main() {
@@ -120,6 +123,8 @@ func parseConfig() config {
 	flag.BoolVar(&cfg.once, "once", false, "run a single cycle then exit")
 	flag.StringVar(&cfg.detectClasses, "detect-classes", os.Getenv("SYNAPSE_DETECT_CLASSES"), "comma-separated eBPF detection classes to run (process,network,file,privilege); empty = detection engine off (#422, Linux+root only)")
 	flag.Float64Var(&cfg.detectCeiling, "detect-ceiling", parseCeiling(os.Getenv("SYNAPSE_DETECT_CPU_CEIL_PCT")), "CPU ceiling percent for the detection engine; over it, classes are shed in a defined order (0 = no shedding)")
+	flag.Int64Var(&cfg.spoolBytes, "telemetry-spool-bytes", parsePositiveBytes(os.Getenv("SYNAPSE_TELEMETRY_SPOOL_BYTES"), 512<<20), "maximum bytes retained by the priority telemetry WAL")
+	flag.StringVar(&cfg.metricsAddr, "agent-metrics-addr", os.Getenv("SYNAPSE_AGENT_METRICS_ADDR"), "optional address for private agent Prometheus metrics (for example 127.0.0.1:9465)")
 	flag.Parse()
 	if cfg.enrolToken == "" {
 		// An absent token file is NOT fatal: it is the normal state after enrolment, once the
@@ -297,6 +302,18 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func parsePositiveBytes(value string, def int64) int64 {
+	if value == "" {
+		return def
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || parsed <= 0 {
+		log.Printf("ignoring invalid telemetry spool byte count (want a positive integer)")
+		return def
+	}
+	return parsed
 }
 
 func defaultStateDir() string {

--- a/cmd/synapse-agent/telemetry_spool.go
+++ b/cmd/synapse-agent/telemetry_spool.go
@@ -52,11 +52,15 @@ func (r *runner) openTelemetrySpool(ctx context.Context, cred fleetclient.Creden
 	if cfg.MaxBytes < 1<<20 {
 		return nil, agentspool.SensorIdentity{}, fmt.Errorf("telemetry spool quota must be at least 1048576 bytes, got %d", cfg.MaxBytes)
 	}
-	if cfg.SegmentBytes > cfg.MaxBytes {
-		cfg.SegmentBytes = cfg.MaxBytes
+	// Reserve the same bounded share normalizeConfig will assign to loss
+	// evidence, so WAL sizing cannot consume the gap journal's capacity.
+	cfg.MaxGapBytes = spool.RecommendedGapBytes(cfg.MaxBytes)
+	walBytes := cfg.MaxBytes - cfg.MaxGapBytes
+	if cfg.SegmentBytes > walBytes {
+		cfg.SegmentBytes = walBytes
 	}
-	if cfg.MaxRecordBytes > cfg.SegmentBytes {
-		cfg.MaxRecordBytes = cfg.SegmentBytes
+	if cfg.MaxRecordBytes > cfg.SegmentBytes-spool.FrameOverheadBudget {
+		cfg.MaxRecordBytes = cfg.SegmentBytes - spool.FrameOverheadBudget
 	}
 	durable, err := spool.Open(cfg)
 	if err != nil {

--- a/cmd/synapse-agent/telemetry_spool.go
+++ b/cmd/synapse-agent/telemetry_spool.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/KKloudTarus/synapse-ce/internal/adapter/agentspool"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/spool"
+)
+
+const (
+	agentSensorID      = "synapse-ebpf"
+	agentSensorVersion = "1"
+)
+
+func (r *runner) telemetrySpoolDir() string {
+	return filepath.Join(r.cfg.stateDir, "telemetry-spool")
+}
+
+func (r *runner) openTelemetrySpool(ctx context.Context, cred fleetclient.Credential) (*spool.Spool, agentspool.SensorIdentity, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, agentspool.SensorIdentity{}, err
+	}
+	agentID := shared.ID(strings.TrimSpace(cred.AgentID))
+	if agentID.IsZero() {
+		return nil, agentspool.SensorIdentity{}, errors.New("enrolled credential has no canonical agent id")
+	}
+	bootID, err := currentBootID()
+	if err != nil {
+		return nil, agentspool.SensorIdentity{}, err
+	}
+	cfg := spool.DefaultConfig()
+	cfg.Dir = r.telemetrySpoolDir()
+	cfg.Session = fleetagent.SessionID(agentID)
+	cfg.Boot = fleetagent.BootID(bootID)
+	cfg.MaxBytes = r.cfg.spoolBytes
+	if cfg.MaxBytes < 1<<20 {
+		return nil, agentspool.SensorIdentity{}, fmt.Errorf("telemetry spool quota must be at least 1048576 bytes, got %d", cfg.MaxBytes)
+	}
+	if cfg.SegmentBytes > cfg.MaxBytes {
+		cfg.SegmentBytes = cfg.MaxBytes
+	}
+	if cfg.MaxRecordBytes > cfg.SegmentBytes {
+		cfg.MaxRecordBytes = cfg.SegmentBytes
+	}
+	durable, err := spool.Open(cfg)
+	if err != nil {
+		return nil, agentspool.SensorIdentity{}, err
+	}
+	identity := agentspool.SensorIdentity{
+		AgentID: agentID, AssetID: agentID, AgentSession: agentID,
+		BootID: bootID, SensorID: agentSensorID, SensorVersion: agentSensorVersion,
+	}
+	return durable, identity, nil
+}
+
+// currentBootID uses the Linux kernel boot UUID. eBPF detection is Linux-only,
+// so refusing to fabricate an incarnation on another platform is safer than a
+// stable installation id which would misclassify post-reboot sequence resets.
+func currentBootID() (shared.ID, error) {
+	if runtime.GOOS != "linux" {
+		return "", fmt.Errorf("kernel boot identity is unavailable on %s", runtime.GOOS)
+	}
+	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return "", fmt.Errorf("read kernel boot id: %w", err)
+	}
+	id := shared.ID(strings.TrimSpace(string(data)))
+	if id.IsZero() {
+		return "", errors.New("kernel boot id is empty")
+	}
+	return id, nil
+}
+
+func (r *runner) startSpoolMetrics(ctx context.Context, durable *spool.Spool) error {
+	address := strings.TrimSpace(r.cfg.metricsAddr)
+	if address == "" {
+		return nil
+	}
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return err
+	}
+	registry := prometheus.NewPedanticRegistry()
+	registry.MustRegister(spool.NewCollector(durable))
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("metrics listener stopped: %v", err)
+		}
+	}()
+	return nil
+}

--- a/cmd/synapse-agent/telemetry_spool_test.go
+++ b/cmd/synapse-agent/telemetry_spool_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
+)
+
+func TestParsePositiveBytes(t *testing.T) {
+	for _, tt := range []struct {
+		input string
+		def   int64
+		want  int64
+	}{
+		{"", 99, 99},
+		{"1048576", 99, 1048576},
+		{"0", 99, 99},
+		{"-1", 99, 99},
+		{"not-a-number", 99, 99},
+	} {
+		if got := parsePositiveBytes(tt.input, tt.def); got != tt.want {
+			t.Errorf("parsePositiveBytes(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCurrentBootIDIsHonestAboutPlatform(t *testing.T) {
+	id, err := currentBootID()
+	if runtime.GOOS == "linux" {
+		if err != nil || id.IsZero() {
+			t.Fatalf("Linux boot id = %q, %v", id, err)
+		}
+		return
+	}
+	if err == nil || !id.IsZero() {
+		t.Fatalf("unsupported platform fabricated boot id %q, %v", id, err)
+	}
+}
+
+func TestOpenTelemetrySpoolUsesCanonicalIdentity(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("live telemetry spool is paired with the Linux-only eBPF sensor")
+	}
+	r := &runner{cfg: config{stateDir: t.TempDir(), spoolBytes: 1 << 20}}
+	durable, identity, err := r.openTelemetrySpool(context.Background(), fleetclient.Credential{AgentID: " agent-1 "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer durable.Close()
+	if identity.AgentID != "agent-1" || identity.AssetID != identity.AgentID || identity.AgentSession != identity.AgentID || identity.BootID.IsZero() {
+		t.Fatalf("identity = %#v", identity)
+	}
+}
+
+func TestOpenTelemetrySpoolRejectsMissingAgentIdentity(t *testing.T) {
+	r := &runner{cfg: config{stateDir: t.TempDir(), spoolBytes: 1 << 20}}
+	if durable, _, err := r.openTelemetrySpool(context.Background(), fleetclient.Credential{}); err == nil {
+		_ = durable.Close()
+		t.Fatal("missing canonical agent id accepted")
+	}
+}

--- a/docs/architecture/agent-telemetry-spool.md
+++ b/docs/architecture/agent-telemetry-spool.md
@@ -1,0 +1,144 @@
+# Agent telemetry WAL invariants
+
+The host agent's telemetry spool is the durability boundary between observing a security event and a
+future transport accepting it. This note records the invariants reviewers and future A3 changes must
+preserve. The implementation lives in `internal/infrastructure/spool`; the inward-facing contract is
+`ports.TelemetrySpool`.
+
+## Delivery claim
+
+Synapse does not claim exactly-once delivery. The contract is:
+
+> at-least-once delivery + idempotent ingest + a durable agent spool + a monotonic sequence per stream
+> incarnation + highest-contiguous ACK + explicit durable gaps.
+
+Once `Enqueue` succeeds, its coordinate must have one of three observable outcomes:
+
+1. it remains readable from the WAL;
+2. the exact priority/epoch/sequence was durably ACKed; or
+3. durable gap evidence covers the coordinate.
+
+An enqueue which fails is not part of that accepted set. Quota failures still append an
+unknown-coordinate gap because the sensor did observe something the WAL could not accept. That gap
+makes coverage incomplete without inventing a sequence which was never committed.
+
+## Priority and pressure
+
+The queue is physically segmented and logically ordered per priority. `Peek` always visits P0, P1, P2,
+then P3, while preserving epoch/sequence order inside each lane.
+
+- P0: response verification, coverage, and sensor health.
+- P1: confirmed detections.
+- P2: privilege changes and critical-file events.
+- P3: background process and network telemetry.
+
+P0–P2 carry `MustNotShed=true` and use `SyncAlways`. If the quota cannot be recovered by deleting P3,
+the append returns `ports.ErrTelemetrySpoolSaturated` after syncing a `quota_backpressure` gap. The
+producer retries and therefore applies pressure toward the source.
+
+P3 is the only eviction lane. Before removing a P3 segment, the spool appends and fsyncs exact inclusive
+sequence ranges to `gaps.log`. If the gap write or fsync fails, the segment is not deleted. If higher
+priorities consume the entire quota, a new P3 observation is refused after an unknown-coordinate
+`quota_eviction` gap is committed; the sensor may shed it and marks class coverage degraded.
+
+The quota counts WAL segment bytes, not state/gap journal bytes. This reservation is intentional: a full
+data allocation must not make the evidence of loss impossible to write. Operators must still monitor
+gap-journal growth.
+
+## Frame format
+
+Each WAL frame has a fixed 48-byte little-endian header followed by JSON metadata and the producer's raw
+payload bytes. Payloads are not base64 encoded. Version one contains:
+
+| Offset | Size | Field |
+| ---: | ---: | --- |
+| 0 | 4 | magic `SYNW` |
+| 4 | 2 | format version |
+| 6 | 2 | header length |
+| 8 | 4 | body length |
+| 12 | 4 | CRC32C |
+| 16 | 1 | priority |
+| 17 | 1 | record kind |
+| 18 | 2 | flags (`MustNotShed`) |
+| 20 | 8 | epoch |
+| 28 | 8 | sequence |
+| 36 | 8 | observed-at Unix nanoseconds |
+| 44 | 4 | metadata length |
+
+The CRC32C covers the complete header with the checksum slot zeroed plus metadata and payload. Header
+coordinates are therefore protected as strongly as the body. Configured record/segment bounds are
+checked before allocating recovery buffers, preventing a corrupted length field from becoming an
+unbounded allocation.
+
+Metadata contains the event id/class, content type, session id, boot id, enqueue time, and schema
+version. It is separately validated after checksum verification. `Peek` rereads payloads by offset
+instead of retaining them in memory, so memory usage scales with record count/index size rather than
+queued payload bytes.
+
+## State and incarnation recovery
+
+`state.json` and `state.backup.json` are generation-numbered snapshots installed by synced temporary
+file plus atomic replace. State records the current session, boot, epoch, assigned-through coordinate per
+priority, and ACK watermarks keyed by priority+epoch.
+
+On a normal process restart with the same enrollment identity and Linux kernel boot UUID, recovery keeps
+the epoch and continues the sequence. A different session or boot advances the epoch and resets each
+lane to sequence one. If both state copies are missing or invalid while WAL data exists, recovery derives
+the maximum epoch present, starts at the next epoch, and commits a `state_recovery` gap for every lane.
+It never reuses an incarnation observed on disk.
+
+For batched P3 sync, the assigned-through state is forced before `Enqueue` returns. A crash can therefore
+lose kernel-buffered WAL tail bytes but cannot erase knowledge of their coordinates. Startup compares
+the highest recovered/ACKed/gapped coordinate with assigned-through and commits the missing suffix as an
+`unsynced_tail` gap. P0–P2 sync the segment before committing assigned state.
+
+## Corruption and repair
+
+Startup scans segment files in canonical filename order. It validates the fixed header, length bounds,
+CRC, metadata, record contract, and filename priority/epoch. A valid header with a bad body produces an
+exact `corrupt_frame` gap. Damage before a trustworthy coordinate produces an unknown-coordinate gap.
+A partial final header/body produces `torn_write` evidence.
+
+After damage the scanner searches for the next valid magic/header and can retain later frames in the
+same segment. Valid unacknowledged frames are rewritten to a synced repair file and atomically installed,
+so the next restart does not report the same corruption again. A corrupt gap journal is different: loss
+evidence is the authority which permits deletion, so checksum corruption there fails open rather than
+silently discarding it. Only an incomplete unsynced tail is safely truncated.
+
+## ACK and deletion order
+
+An ACK always names priority, epoch, and highest contiguous sequence. ACKs ahead of anything assigned are
+rejected. Regressive/equal ACKs are idempotent. The state snapshot containing the new ACK is synced before
+record references are removed or segment files are deleted. Consequently, a crash can retain an already
+ACKed segment (harmless resend/compaction on restart), but cannot delete a segment whose ACK was not
+durably committed.
+
+A3 must not reinterpret `Peek` as a destructive dequeue. It should batch returned records, deliver them
+with their `StreamPosition`, then call `Ack` only after the control plane returns a durable
+highest-contiguous ACK for that exact lane and epoch.
+
+## Retry and metrics
+
+`RetryPolicy` provides capped exponential full jitter. HTTP 429 honors a bounded `Retry-After`; 408 and
+5xx retry; other 4xx are permanent; network failures use the same jitter schedule. A3 owns the actual
+request loop but should consume this policy so a server outage cannot synchronize a fleet-wide retry
+storm.
+
+The Prometheus collector owns no global registry and uses only the bounded `priority` label. It reports
+depth/bytes, oldest-unacked age, current sequence/ACK, durable gaps, evictions, corruption recovery, and
+fsync count/duration. Collection errors become invalid metrics rather than stale healthy-looking values.
+
+## Test obligations
+
+Changes to the WAL or A3 integration must retain:
+
+- restart membership/order and sequence continuation;
+- epoch advance on boot/session change;
+- ACK-before-delete ordering and idempotent ACK behavior;
+- P3-only eviction with gap-before-delete;
+- never-shed saturation/backpressure evidence;
+- middle-frame corruption resynchronization and stable repair;
+- torn/unsynced tail gap coverage;
+- exclusive directory locking;
+- concurrent unique sequence assignment and `go test -race` cleanliness;
+- the property invariant that every successful enqueue remains readable or gap-covered unless ACKed.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -368,6 +368,8 @@ The following variables are read by `synapse-agent` and `synapse-cluster-agent`,
 | `SYNAPSE_AGENT_NAME` | hostname | Human-readable agent display name. |
 | `SYNAPSE_DETECT_CLASSES` | empty | Comma-separated eBPF classes: `process`, `network`, `file`, `privilege`. Empty disables the engine; Linux root/capabilities are required. |
 | `SYNAPSE_DETECT_CPU_CEIL_PCT` | `0` | CPU ceiling for deterministic class shedding; zero disables shedding. |
+| `SYNAPSE_TELEMETRY_SPOOL_BYTES` | `536870912` | Maximum bytes of checksummed telemetry WAL segments (minimum 1 MiB). P3 is evicted first with durable gap evidence; P0–P2 backpressure instead of shedding. |
+| `SYNAPSE_AGENT_METRICS_ADDR` | empty | Optional private Prometheus listener for agent spool metrics. It has no authentication; bind to loopback or a protected scrape network. |
 | `SYNAPSE_CLUSTER` | empty (required) | Stable cluster identity attached to every Kubernetes asset. |
 | `SYNAPSE_CLUSTER_NAMESPACES` | empty | Comma-separated namespace scope; empty means all authorized namespaces. |
 | `SYNAPSE_CLUSTER_RESYNC` | `5m` | Interval between Kubernetes inventory collections. |

--- a/docs/guide/fleet-blue-team.md
+++ b/docs/guide/fleet-blue-team.md
@@ -85,7 +85,8 @@ GET  /api/v1/fleet/agents/{id}
 ```
 
 Configure a host agent with `SYNAPSE_AGENT_ROOT` (filesystem root to inventory), `SYNAPSE_AGENT_NAME`, and
-`SYNAPSE_AGENT_STATE_DIR`. Protect the state directory: it holds the agent credential and offline buffer.
+`SYNAPSE_AGENT_STATE_DIR`. Protect the state directory: it holds the agent credential and offline buffer,
+including the telemetry WAL under `telemetry-spool/`.
 
 The cluster agent requires `SYNAPSE_CLUSTER` as a stable identity keyed into every asset, and accepts
 `SYNAPSE_CLUSTER_NAMESPACES` to narrow scope and `SYNAPSE_CLUSTER_RESYNC` (default `5m`) to set the
@@ -105,6 +106,40 @@ per engagement:
 ```
 GET /api/v1/engagements/{id}/detections
 ```
+
+### Durable telemetry spool
+
+Before the detection engine evaluates an eBPF event, the agent normalizes it to the canonical telemetry
+envelope and appends it to a checksummed priority WAL. Confirmed detections enter the same spool at P1.
+The four lanes drain in P0 → P3 order:
+
+| Priority | Signals | Disk-pressure behavior |
+| --- | --- | --- |
+| P0 | response verification, coverage, sensor state | never shed; producer backpressure plus a durable gap record |
+| P1 | confirmed detections | never shed; producer backpressure plus a durable gap record |
+| P2 | privilege changes and critical-file telemetry | never shed; producer backpressure plus a durable gap record |
+| P3 | background process and network telemetry | oldest P3 segment evicted first, only after its exact sequence gap is fsynced |
+
+`SYNAPSE_TELEMETRY_SPOOL_BYTES` sets the WAL-segment quota (default 512 MiB). The small state and gap
+journals are outside that quota so a full data allocation cannot prevent the agent recording why data
+was not retained. A restart reads both state generations, validates CRC32C frames, removes ACKed bytes,
+repairs corrupt/torn segments, and continues the current `(priority, epoch, sequence)` coordinate. A
+kernel reboot changes the Linux boot UUID, advances the epoch, and safely restarts sequence at one.
+
+The WAL is the A2 durability boundary; wire batching and server ACK exchange belong to A3. Until that
+transport is enabled, P3 rotates within the configured quota while never-shed lanes can eventually
+backpressure. Operators should therefore size the quota for the expected disconnected interval.
+
+Set `SYNAPSE_AGENT_METRICS_ADDR=127.0.0.1:9465` to expose `/metrics`. This listener is deliberately off
+by default and has no authentication. Exported series have bounded labels (priority only):
+
+- `synapse_agent_spool_records` and `synapse_agent_spool_record_bytes`
+- `synapse_agent_spool_oldest_unacked_age_seconds`
+- `synapse_agent_spool_next_sequence` and `synapse_agent_spool_highest_acked_sequence`
+- `synapse_agent_spool_gap_records` and `synapse_agent_spool_gap_bytes`
+- `synapse_agent_spool_evicted_records_total`
+- `synapse_agent_spool_corruption_events_total`
+- `synapse_agent_spool_fsync_total` and `synapse_agent_spool_fsync_duration_seconds_total`
 
 ## Coverage
 
@@ -158,14 +193,15 @@ For packaging, service integration, and uninstall contracts, see
 
 ## Telemetry
 
-Raw telemetry is deliberately isolated behind its own persistence port (`ports.TelemetryStore`) so the
-finding, judgment, and evidence paths never wait on a high-volume store. The architectural boundary is in
-place, and an architecture test asserts the columnar store never leaks into a domain package.
+Raw telemetry is deliberately isolated behind persistence ports so the finding, judgment, and evidence
+paths never wait on a high-volume store. `ports.TelemetrySpool` is the agent-side WAL boundary;
+`ports.TelemetryStore` is the control-plane columnar boundary. Architecture tests keep both concrete
+stores out of domain packages.
 
 The retention, sampling, and ingest-budget behavior described in the
 [telemetry store ADR](repository/telemetry-store-adr.md) is the accepted design, but the operator
-configuration for it is **not wired yet**: there are currently no telemetry environment variables to set.
-Detections themselves are persisted and hash-chained today and do not depend on this tier.
+configuration for the control-plane tier is **not wired yet**. Agent-side durability and its quota are
+wired as described above; A3 still owns transmission from that WAL to the existing columnar ingest.
 
 ## Purple coverage
 

--- a/internal/adapter/agentspool/detection_sink.go
+++ b/internal/adapter/agentspool/detection_sink.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
@@ -48,12 +47,8 @@ func (s *DetectionSink) Emit(ctx context.Context, value detection.Detection) err
 		if _, err = s.spool.Enqueue(ctx, item); !errors.Is(err, ports.ErrTelemetrySpoolSaturated) {
 			return err
 		}
-		timer := time.NewTimer(250 * time.Millisecond)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		case <-timer.C:
+		if err := waitForSpoolCapacity(ctx); err != nil {
+			return err
 		}
 	}
 }

--- a/internal/adapter/agentspool/detection_sink.go
+++ b/internal/adapter/agentspool/detection_sink.go
@@ -1,0 +1,61 @@
+package agentspool
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const detectionContentType = "application/vnd.synapse.detection+json;version=1"
+
+// DetectionSink persists confirmed detections in P1. Its deterministic event
+// id is derived from the canonical JSON, making an engine retry idempotent.
+type DetectionSink struct{ spool ports.TelemetrySpool }
+
+func NewDetectionSink(durable ports.TelemetrySpool) (*DetectionSink, error) {
+	if durable == nil {
+		return nil, fmt.Errorf("%w: detection spool is required", shared.ErrValidation)
+	}
+	return &DetectionSink{spool: durable}, nil
+}
+
+func (s *DetectionSink) Emit(ctx context.Context, value detection.Detection) error {
+	if err := value.Validate(); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("encode detection for spool: %w", err)
+	}
+	digest := sha256.Sum256(payload)
+	id := shared.ID("det_" + hex.EncodeToString(digest[:16]))
+	item := ports.SpoolItem{
+		Kind: ports.SpoolRecordDetection, Priority: fleetagent.PriorityP1,
+		EventID: id, EventClass: value.Class, ContentType: detectionContentType,
+		Payload: payload, ObservedAt: value.Observed.UTC(), MustNotShed: true,
+		SchemaVersion: 1,
+	}
+	for {
+		if _, err = s.spool.Enqueue(ctx, item); !errors.Is(err, ports.ErrTelemetrySpoolSaturated) {
+			return err
+		}
+		timer := time.NewTimer(250 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+var _ ports.DetectionSink = (*DetectionSink)(nil)

--- a/internal/adapter/agentspool/detection_sink_test.go
+++ b/internal/adapter/agentspool/detection_sink_test.go
@@ -1,0 +1,81 @@
+package agentspool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestDetectionSinkPersistsP1AndDeterministicID(t *testing.T) {
+	durable := &captureSpool{}
+	sink, err := NewDetectionSink(durable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value := validDetection()
+	if err := sink.Emit(context.Background(), value); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Emit(context.Background(), value); err != nil {
+		t.Fatal(err)
+	}
+	items := durable.snapshot()
+	if len(items) != 2 {
+		t.Fatalf("items = %d", len(items))
+	}
+	if items[0].Priority != fleetagent.PriorityP1 || !items[0].MustNotShed || items[0].EventID.IsZero() {
+		t.Fatalf("classification = %#v", items[0])
+	}
+	if items[0].EventID != items[1].EventID {
+		t.Fatalf("same detection derived different ids: %s / %s", items[0].EventID, items[1].EventID)
+	}
+	var decoded detection.Detection
+	if err := json.Unmarshal(items[0].Payload, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if err := decoded.Validate(); err != nil {
+		t.Fatalf("spooled detection invalid: %v", err)
+	}
+}
+
+func TestDetectionSinkRejectsInvalidValueAndDependency(t *testing.T) {
+	if _, err := NewDetectionSink(nil); err == nil {
+		t.Fatal("nil spool accepted")
+	}
+	sink, _ := NewDetectionSink(&captureSpool{})
+	if err := sink.Emit(context.Background(), detection.Detection{}); err == nil {
+		t.Fatal("invalid detection accepted")
+	}
+}
+
+func TestDetectionSinkBackpressuresUntilP1IsAccepted(t *testing.T) {
+	durable := &captureSpool{errors: []error{ports.ErrTelemetrySpoolSaturated, nil}}
+	sink, _ := NewDetectionSink(durable)
+	if err := sink.Emit(context.Background(), validDetection()); err != nil {
+		t.Fatal(err)
+	}
+	if durable.calls != 2 || len(durable.snapshot()) != 1 {
+		t.Fatalf("calls=%d accepted=%d", durable.calls, len(durable.snapshot()))
+	}
+
+	failed := &captureSpool{errors: []error{errors.New("disk failed")}}
+	sink, _ = NewDetectionSink(failed)
+	if err := sink.Emit(context.Background(), validDetection()); err == nil {
+		t.Fatal("non-saturation disk error swallowed")
+	}
+}
+
+func validDetection() detection.Detection {
+	event := processEvent()
+	return detection.Detection{
+		RuleID: "proc.curl", RuleVersion: 1, Class: detection.ClassProcess,
+		Severity: shared.SeverityHigh, HostID: "asset-1", AgentID: "agent-1",
+		Evidence: []detection.Event{event}, ObservedCount: 1, Observed: adapterNow,
+	}
+}

--- a/internal/adapter/agentspool/health.go
+++ b/internal/adapter/agentspool/health.go
@@ -1,0 +1,86 @@
+package agentspool
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const healthContentType = "application/vnd.synapse.sensor-health+json;version=1"
+
+// CoverageSnapshot is the agent-side P0 representation consumed by A3/A6. It
+// deliberately wraps the existing coverage domain records instead of defining
+// a second competing coverage state machine.
+type CoverageSnapshot struct {
+	SchemaVersion int                       `json:"schema_version"`
+	ObservedAt    time.Time                 `json:"observed_at"`
+	Classes       []detection.ClassCoverage `json:"classes"`
+}
+
+// RecordCoverage persists both an aggregate coverage window and one sensor
+// state record per class. All records are P0 and never shed: absence of health
+// evidence must never make an unobserved host appear clean.
+func RecordCoverage(ctx context.Context, durable ports.TelemetrySpool, coverage []detection.ClassCoverage, observedAt time.Time) error {
+	if durable == nil {
+		return fmt.Errorf("%w: coverage spool is required", shared.ErrValidation)
+	}
+	if observedAt.IsZero() {
+		return fmt.Errorf("%w: coverage observation time is required", shared.ErrValidation)
+	}
+	copyOfCoverage := append([]detection.ClassCoverage(nil), coverage...)
+	for index := range copyOfCoverage {
+		if err := copyOfCoverage[index].Validate(); err != nil {
+			return fmt.Errorf("coverage[%d]: %w", index, err)
+		}
+	}
+	snapshot := CoverageSnapshot{SchemaVersion: 1, ObservedAt: observedAt.UTC(), Classes: copyOfCoverage}
+	if err := enqueueHealth(ctx, durable, ports.SpoolRecordCoverage, snapshot, observedAt); err != nil {
+		return err
+	}
+	for _, state := range copyOfCoverage {
+		record := struct {
+			SchemaVersion int                     `json:"schema_version"`
+			ObservedAt    time.Time               `json:"observed_at"`
+			State         detection.ClassCoverage `json:"state"`
+		}{SchemaVersion: 1, ObservedAt: observedAt.UTC(), State: state}
+		if err := enqueueHealth(ctx, durable, ports.SpoolRecordSensorState, record, observedAt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func enqueueHealth(ctx context.Context, durable ports.TelemetrySpool, kind ports.SpoolRecordKind, value any, observedAt time.Time) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", kind, err)
+	}
+	digest := sha256.Sum256(append([]byte(string(kind)+"\x00"), payload...))
+	item := ports.SpoolItem{
+		Kind: kind, Priority: fleetagent.PriorityP0,
+		EventID:     shared.ID("health_" + hex.EncodeToString(digest[:16])),
+		ContentType: healthContentType, Payload: payload, ObservedAt: observedAt.UTC(),
+		MustNotShed: true, SchemaVersion: 1,
+	}
+	for {
+		if _, err = durable.Enqueue(ctx, item); !errors.Is(err, ports.ErrTelemetrySpoolSaturated) {
+			return err
+		}
+		timer := time.NewTimer(250 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}

--- a/internal/adapter/agentspool/health.go
+++ b/internal/adapter/agentspool/health.go
@@ -75,12 +75,8 @@ func enqueueHealth(ctx context.Context, durable ports.TelemetrySpool, kind ports
 		if _, err = durable.Enqueue(ctx, item); !errors.Is(err, ports.ErrTelemetrySpoolSaturated) {
 			return err
 		}
-		timer := time.NewTimer(250 * time.Millisecond)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		case <-timer.C:
+		if err := waitForSpoolCapacity(ctx); err != nil {
+			return err
 		}
 	}
 }

--- a/internal/adapter/agentspool/health_test.go
+++ b/internal/adapter/agentspool/health_test.go
@@ -1,0 +1,67 @@
+package agentspool
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestRecordCoveragePersistsAggregateAndPerClassP0(t *testing.T) {
+	durable := &captureSpool{}
+	coverage := []detection.ClassCoverage{
+		{Class: detection.ClassProcess, HostID: "host-1", AgentID: "agent-1", State: detection.StateActive, Since: adapterNow.Add(-time.Minute)},
+		{Class: detection.ClassFile, HostID: "host-1", AgentID: "agent-1", State: detection.StateFailed, Reason: "attach refused", Since: adapterNow.Add(-time.Minute)},
+	}
+	if err := RecordCoverage(context.Background(), durable, coverage, adapterNow); err != nil {
+		t.Fatal(err)
+	}
+	items := durable.snapshot()
+	if len(items) != 3 {
+		t.Fatalf("items = %d, want aggregate + 2 states", len(items))
+	}
+	for index, item := range items {
+		if item.Priority != fleetagent.PriorityP0 || !item.MustNotShed || item.EventID.IsZero() {
+			t.Errorf("item[%d] classification = %#v", index, item)
+		}
+	}
+	if items[0].Kind != ports.SpoolRecordCoverage || items[1].Kind != ports.SpoolRecordSensorState || items[2].Kind != ports.SpoolRecordSensorState {
+		t.Fatalf("kinds = %s, %s, %s", items[0].Kind, items[1].Kind, items[2].Kind)
+	}
+	var snapshot CoverageSnapshot
+	if err := json.Unmarshal(items[0].Payload, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.SchemaVersion != 1 || len(snapshot.Classes) != 2 || !snapshot.ObservedAt.Equal(adapterNow) {
+		t.Fatalf("snapshot = %#v", snapshot)
+	}
+}
+
+func TestRecordCoverageIsDeterministicAndValidates(t *testing.T) {
+	durable := &captureSpool{}
+	coverage := []detection.ClassCoverage{{Class: detection.ClassNetwork, HostID: "host", State: detection.StateActive}}
+	if err := RecordCoverage(context.Background(), durable, coverage, adapterNow); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordCoverage(context.Background(), durable, coverage, adapterNow); err != nil {
+		t.Fatal(err)
+	}
+	items := durable.snapshot()
+	if items[0].EventID != items[2].EventID || items[1].EventID != items[3].EventID {
+		t.Fatal("identical health snapshots did not derive stable ids")
+	}
+	if err := RecordCoverage(context.Background(), durable, coverage, time.Time{}); err == nil {
+		t.Fatal("zero timestamp accepted")
+	}
+	invalid := []detection.ClassCoverage{{Class: "future", HostID: "host", State: detection.StateActive}}
+	if err := RecordCoverage(context.Background(), durable, invalid, adapterNow); err == nil {
+		t.Fatal("invalid coverage accepted")
+	}
+	if err := RecordCoverage(context.Background(), nil, coverage, adapterNow); err == nil {
+		t.Fatal("nil spool accepted")
+	}
+}

--- a/internal/adapter/agentspool/retry.go
+++ b/internal/adapter/agentspool/retry.go
@@ -1,0 +1,28 @@
+package agentspool
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+)
+
+const (
+	minSaturationRetryDelay = 200 * time.Millisecond
+	maxSaturationRetryDelay = 300 * time.Millisecond
+)
+
+func saturationRetryDelay() time.Duration {
+	window := maxSaturationRetryDelay - minSaturationRetryDelay
+	return minSaturationRetryDelay + time.Duration(rand.Int64N(int64(window)+1))
+}
+
+func waitForSpoolCapacity(ctx context.Context) error {
+	timer := time.NewTimer(saturationRetryDelay())
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/adapter/agentspool/sensor.go
+++ b/internal/adapter/agentspool/sensor.go
@@ -175,13 +175,9 @@ func (s *DurableSensor) persist(ctx context.Context, event detection.Event) bool
 		// A non-sheddable class applies real backpressure. The spool has already
 		// persisted a quota-backpressure gap; retry until A3 ACKs free space or
 		// shutdown cancels the observation.
-		timer := time.NewTimer(250 * time.Millisecond)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
+		if err := waitForSpoolCapacity(ctx); err != nil {
 			s.recordFailure(event.Class)
 			return false
-		case <-timer.C:
 		}
 	}
 }
@@ -242,7 +238,7 @@ func (s *DurableSensor) Coverage() []detection.ClassCoverage {
 	}
 	s.mu.Unlock()
 	for index := range coverage {
-		if failures[coverage[index].Class] == 0 {
+		if failures[coverage[index].Class] == 0 || coverage[index].State != detection.StateActive {
 			continue
 		}
 		coverage[index].State = detection.StateDegraded

--- a/internal/adapter/agentspool/sensor.go
+++ b/internal/adapter/agentspool/sensor.go
@@ -1,0 +1,280 @@
+// Package agentspool adapts the existing detection sensor and sink contracts to
+// the canonical telemetry normalizer and the durable agent spool. It contains
+// orchestration only: normalization remains a pure use case and persistence is
+// owned by infrastructure/spool.
+package agentspool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/normalize"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const telemetryContentType = "application/vnd.synapse.telemetry-envelope+json;version=1"
+
+// SensorIdentity contains the stable attribution needed to turn the legacy
+// detection sensor's decoded event into A1's canonical envelope.
+type SensorIdentity struct {
+	AgentID       shared.ID
+	AssetID       shared.ID
+	AgentSession  shared.ID
+	BootID        shared.ID
+	SensorID      string
+	SensorVersion string
+}
+
+func (i SensorIdentity) validate() error {
+	if i.AgentID.IsZero() || i.AssetID.IsZero() || i.AgentSession.IsZero() || i.BootID.IsZero() {
+		return fmt.Errorf("%w: telemetry sensor identity is incomplete", shared.ErrValidation)
+	}
+	if i.SensorID == "" || i.SensorVersion == "" {
+		return fmt.Errorf("%w: telemetry sensor id/version is required", shared.ErrValidation)
+	}
+	return nil
+}
+
+// DurableSensor tees every decoded event through Normalize and the WAL before
+// exposing it to the detection engine. This ordering means a confirmed
+// detection never references a raw event which was silently discarded first.
+type DurableSensor struct {
+	source   ports.DetectionSensor
+	spool    ports.TelemetrySpool
+	identity SensorIdentity
+	now      func() time.Time
+	runID    string
+
+	mu       sync.Mutex
+	started  bool
+	events   chan detection.Event
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	failures map[detection.Class]uint64
+	sequence map[detection.Class]uint64
+}
+
+// NewDurableSensor validates dependencies and returns a sensor wrapper. A
+// zero-buffer output intentionally propagates pressure back to the kernel
+// reader rather than growing an unbounded second queue in memory.
+func NewDurableSensor(source ports.DetectionSensor, durable ports.TelemetrySpool, identity SensorIdentity) (*DurableSensor, error) {
+	if source == nil || durable == nil {
+		return nil, fmt.Errorf("%w: durable sensor needs a source and spool", shared.ErrValidation)
+	}
+	if err := identity.validate(); err != nil {
+		return nil, err
+	}
+	return &DurableSensor{
+		source: source, spool: durable, identity: identity, now: time.Now,
+		runID:  uuid.NewString(),
+		events: make(chan detection.Event), failures: make(map[detection.Class]uint64),
+		sequence: make(map[detection.Class]uint64),
+	}, nil
+}
+
+func (s *DurableSensor) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return fmt.Errorf("%w: durable sensor already started", shared.ErrValidation)
+	}
+	s.started = true
+	runCtx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.mu.Unlock()
+	if err := s.source.Start(runCtx); err != nil {
+		cancel()
+		return err
+	}
+	s.wg.Add(1)
+	go s.pump(runCtx)
+	return nil
+}
+
+func (s *DurableSensor) Events() <-chan detection.Event { return s.events }
+
+func (s *DurableSensor) pump(ctx context.Context) {
+	defer s.wg.Done()
+	defer close(s.events)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-s.source.Events():
+			if !ok {
+				return
+			}
+			if !s.persist(ctx, event) {
+				return
+			}
+			select {
+			case s.events <- event:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (s *DurableSensor) persist(ctx context.Context, event detection.Event) bool {
+	s.mu.Lock()
+	s.sequence[event.Class]++
+	sequence := s.sequence[event.Class]
+	s.mu.Unlock()
+
+	decoded, err := s.decoded(event, sequence)
+	if err != nil {
+		s.recordFailure(event.Class)
+		return true // detection can still evaluate; coverage reports raw loss
+	}
+	envelope, err := (normalize.Normalizer{}).Normalize(decoded)
+	if err != nil {
+		s.recordFailure(event.Class)
+		return true
+	}
+	payload, err := json.Marshal(envelope)
+	if err != nil {
+		s.recordFailure(event.Class)
+		return true
+	}
+	priority, err := fleetagent.TelemetryPriority(event.Class)
+	if err != nil {
+		s.recordFailure(event.Class)
+		return true
+	}
+	item := ports.SpoolItem{
+		Kind: ports.SpoolRecordTelemetry, Priority: priority, EventID: envelope.EventID,
+		EventClass: event.Class, ContentType: telemetryContentType, Payload: payload,
+		ObservedAt: envelope.ObservedAt, MustNotShed: telemetry.MustNotShed(event.Class),
+		SchemaVersion: envelope.SchemaVersion,
+	}
+	for {
+		if _, err := s.spool.Enqueue(ctx, item); err == nil {
+			return true
+		} else if !errors.Is(err, ports.ErrTelemetrySpoolSaturated) {
+			s.recordFailure(event.Class)
+			return true
+		}
+		if priority == fleetagent.PriorityP3 {
+			// P3 is explicitly sheddable. The spool persisted an unknown-coordinate
+			// quota gap before returning saturation, so continue observation and
+			// report degraded coverage instead of head-of-line blocking P0..P2.
+			s.recordFailure(event.Class)
+			return true
+		}
+		// A non-sheddable class applies real backpressure. The spool has already
+		// persisted a quota-backpressure gap; retry until A3 ACKs free space or
+		// shutdown cancels the observation.
+		timer := time.NewTimer(250 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			s.recordFailure(event.Class)
+			return false
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *DurableSensor) decoded(event detection.Event, sequence uint64) (normalize.DecodedEvent, error) {
+	if err := event.Validate(); err != nil {
+		return normalize.DecodedEvent{}, err
+	}
+	observed := s.now().UTC()
+	d := normalize.DecodedEvent{
+		Class: event.Class, AgentID: s.identity.AgentID, AgentSessionID: s.identity.AgentSession,
+		AssetID: s.identity.AssetID, BootID: s.identity.BootID,
+		StreamID: shared.ID(fmt.Sprintf("%s:%s:%s:%s", s.identity.SensorID, s.identity.BootID, s.runID, event.Class)),
+		SensorID: s.identity.SensorID, SensorVersion: s.identity.SensorVersion,
+		// The legacy sensor's Event.At is a userspace decode timestamp, not a
+		// kernel-source timestamp. Leave OccurredAt zero so A1's normalizer
+		// honestly applies its fallback and quality flag instead of relabeling it.
+		Sequence: sequence, ObservedAt: observed,
+	}
+	switch event.Class {
+	case detection.ClassProcess:
+		d.Process = &normalize.DecodedProcess{
+			Kind: "exec", PID: event.Process.PID, PPID: event.Process.PPID,
+			Comm: event.Process.Comm, Path: event.Process.Path,
+			Args: append([]string(nil), event.Process.Args...), UID: event.Process.UID,
+		}
+	case detection.ClassNetwork:
+		d.Network = &normalize.DecodedNetwork{
+			Kind: "connect", Proto: event.Network.Proto, Direction: event.Network.Direction,
+			RemoteAddr: event.Network.RemoteAddr, RemotePort: event.Network.RemotePort,
+			PID: event.Network.PID, Comm: event.Network.Comm,
+		}
+	case detection.ClassFile:
+		d.File = &normalize.DecodedFile{
+			Op: event.File.Op, Path: event.File.Path, PID: event.File.PID, Comm: event.File.Comm,
+		}
+	case detection.ClassPrivilege:
+		d.Privilege = &normalize.DecodedPrivilege{
+			Kind: event.Privilege.Kind, PID: event.Privilege.PID, Comm: event.Privilege.Comm,
+			FromUID: event.Privilege.FromUID, ToUID: event.Privilege.ToUID, Cap: event.Privilege.Cap,
+		}
+	}
+	return d, nil
+}
+
+func (s *DurableSensor) recordFailure(class detection.Class) {
+	s.mu.Lock()
+	s.failures[class]++
+	s.mu.Unlock()
+}
+
+func (s *DurableSensor) Coverage() []detection.ClassCoverage {
+	coverage := append([]detection.ClassCoverage(nil), s.source.Coverage()...)
+	s.mu.Lock()
+	failures := make(map[detection.Class]uint64, len(s.failures))
+	for class, count := range s.failures {
+		failures[class] = count
+	}
+	s.mu.Unlock()
+	for index := range coverage {
+		if failures[coverage[index].Class] == 0 {
+			continue
+		}
+		coverage[index].State = detection.StateDegraded
+		coverage[index].Reason = fmt.Sprintf("durable telemetry spool rejected %d event(s)", failures[coverage[index].Class])
+	}
+	return coverage
+}
+
+func (s *DurableSensor) Dropped() map[detection.Class]uint64 {
+	sourceDropped := s.source.Dropped()
+	dropped := make(map[detection.Class]uint64, len(sourceDropped))
+	for class, count := range sourceDropped {
+		dropped[class] = count
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for class, count := range s.failures {
+		dropped[class] += count
+	}
+	return dropped
+}
+
+func (s *DurableSensor) Close() error {
+	s.mu.Lock()
+	cancel := s.cancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	err := s.source.Close()
+	s.wg.Wait()
+	return err
+}
+
+var _ ports.DetectionSensor = (*DurableSensor)(nil)

--- a/internal/adapter/agentspool/sensor_test.go
+++ b/internal/adapter/agentspool/sensor_test.go
@@ -1,0 +1,320 @@
+package agentspool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var adapterNow = time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+func TestDurableSensorNormalizesAndPersistsBeforeForwarding(t *testing.T) {
+	source := newFakeSensor()
+	durable := &captureSpool{}
+	wrapper := mustSensor(t, source, durable)
+	wrapper.now = func() time.Time { return adapterNow }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := wrapper.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	event := processEvent()
+	source.events <- event
+	select {
+	case got := <-wrapper.Events():
+		if got.Process.Path != event.Process.Path {
+			t.Fatalf("forwarded event = %#v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("event was not forwarded")
+	}
+	items := durable.snapshot()
+	if len(items) != 1 {
+		t.Fatalf("spooled items = %d", len(items))
+	}
+	item := items[0]
+	if item.Kind != ports.SpoolRecordTelemetry || item.Priority != fleetagent.PriorityP3 || item.MustNotShed {
+		t.Fatalf("spool classification = %#v", item)
+	}
+	var envelope telemetry.TelemetryEnvelope
+	if err := json.Unmarshal(item.Payload, &envelope); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if err := envelope.Validate(); err != nil {
+		t.Fatalf("canonical envelope invalid: %v", err)
+	}
+	if envelope.EventClass != detection.ClassProcess || envelope.Sequence != 1 || envelope.AgentID != "agent-1" || envelope.BootID != "boot-1" {
+		t.Fatalf("envelope attribution = %#v", envelope)
+	}
+	if envelope.Event.Process.StartTimeNanos != 0 || !envelope.DataQuality.Has(telemetry.QualityMissingStartTime) {
+		t.Fatalf("legacy sensor limitations were not represented honestly: %#v", envelope.Event.Process)
+	}
+	if !envelope.DataQuality.Has(telemetry.QualityKernelTimestampUnavailable) || !envelope.OccurredAt.Equal(envelope.ObservedAt) {
+		t.Fatalf("userspace-only timestamp was presented as kernel truth: quality=%s occurred=%s observed=%s",
+			envelope.DataQuality, envelope.OccurredAt, envelope.ObservedAt)
+	}
+	cancel()
+	if err := wrapper.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDurableSensorClassifiesCriticalTelemetryP2NeverShed(t *testing.T) {
+	for _, event := range []detection.Event{fileEvent(), privilegeEvent()} {
+		t.Run(string(event.Class), func(t *testing.T) {
+			source := newFakeSensor()
+			durable := &captureSpool{}
+			wrapper := mustSensor(t, source, durable)
+			wrapper.now = func() time.Time { return adapterNow }
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := wrapper.Start(ctx); err != nil {
+				t.Fatal(err)
+			}
+			source.events <- event
+			select {
+			case <-wrapper.Events():
+			case <-time.After(time.Second):
+				t.Fatal("event not forwarded")
+			}
+			item := durable.snapshot()[0]
+			if item.Priority != fleetagent.PriorityP2 || !item.MustNotShed {
+				t.Fatalf("critical item = %#v", item)
+			}
+			cancel()
+			_ = wrapper.Close()
+		})
+	}
+}
+
+func TestDurableSensorUsesIndependentPerClassSequences(t *testing.T) {
+	source := newFakeSensor()
+	durable := &captureSpool{}
+	wrapper := mustSensor(t, source, durable)
+	wrapper.now = func() time.Time { return adapterNow }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := wrapper.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range []detection.Event{processEvent(), fileEvent(), processEvent(), fileEvent()} {
+		source.events <- event
+		<-wrapper.Events()
+	}
+	items := durable.snapshot()
+	want := []uint64{1, 1, 2, 2}
+	for index, item := range items {
+		var envelope telemetry.TelemetryEnvelope
+		if err := json.Unmarshal(item.Payload, &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if envelope.Sequence != want[index] {
+			t.Errorf("item %d sequence = %d, want %d", index, envelope.Sequence, want[index])
+		}
+	}
+	cancel()
+	_ = wrapper.Close()
+}
+
+func TestDurableSensorRetriesSaturationInsteadOfDropping(t *testing.T) {
+	source := newFakeSensor()
+	durable := &captureSpool{errors: []error{ports.ErrTelemetrySpoolSaturated, nil}}
+	wrapper := mustSensor(t, source, durable)
+	wrapper.now = func() time.Time { return adapterNow }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := wrapper.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	source.events <- fileEvent()
+	select {
+	case <-wrapper.Events():
+	case <-time.After(time.Second):
+		t.Fatal("saturated event was not retried")
+	}
+	if durable.calls != 2 {
+		t.Fatalf("enqueue calls = %d, want 2", durable.calls)
+	}
+	if wrapper.Dropped()[detection.ClassFile] != 0 {
+		t.Fatal("successfully retried event counted as dropped")
+	}
+	cancel()
+	_ = wrapper.Close()
+}
+
+func TestDurableSensorShedsP3SaturationWithoutHeadOfLineBlocking(t *testing.T) {
+	source := newFakeSensor()
+	durable := &captureSpool{errors: []error{ports.ErrTelemetrySpoolSaturated}}
+	wrapper := mustSensor(t, source, durable)
+	wrapper.now = func() time.Time { return adapterNow }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := wrapper.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	source.events <- processEvent()
+	select {
+	case <-wrapper.Events():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("sheddable P3 saturation blocked the sensor")
+	}
+	if durable.calls != 1 || wrapper.Dropped()[detection.ClassProcess] != 1 {
+		t.Fatalf("calls=%d dropped=%v", durable.calls, wrapper.Dropped())
+	}
+	cancel()
+	_ = wrapper.Close()
+}
+
+func TestDurableSensorFailureDegradesCoverage(t *testing.T) {
+	source := newFakeSensor()
+	durable := &captureSpool{errors: []error{errors.New("disk I/O failed")}}
+	wrapper := mustSensor(t, source, durable)
+	wrapper.now = func() time.Time { return adapterNow }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := wrapper.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	source.events <- processEvent()
+	select {
+	case <-wrapper.Events():
+	case <-time.After(time.Second):
+		t.Fatal("detection path should continue after recorded telemetry failure")
+	}
+	coverage := wrapper.Coverage()
+	if len(coverage) != 1 || coverage[0].State != detection.StateDegraded || coverage[0].Reason == "" {
+		t.Fatalf("coverage = %#v", coverage)
+	}
+	if wrapper.Dropped()[detection.ClassProcess] != 1 {
+		t.Fatalf("dropped = %#v", wrapper.Dropped())
+	}
+	cancel()
+	_ = wrapper.Close()
+}
+
+func TestDurableSensorRejectsBadDependenciesAndDoubleStart(t *testing.T) {
+	identity := testIdentity()
+	if _, err := NewDurableSensor(nil, &captureSpool{}, identity); err == nil {
+		t.Fatal("nil source accepted")
+	}
+	if _, err := NewDurableSensor(newFakeSensor(), nil, identity); err == nil {
+		t.Fatal("nil spool accepted")
+	}
+	identity.BootID = ""
+	if _, err := NewDurableSensor(newFakeSensor(), &captureSpool{}, identity); err == nil {
+		t.Fatal("incomplete identity accepted")
+	}
+	wrapper := mustSensor(t, newFakeSensor(), &captureSpool{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := wrapper.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := wrapper.Start(ctx); err == nil {
+		t.Fatal("double Start accepted")
+	}
+	cancel()
+	_ = wrapper.Close()
+}
+
+func mustSensor(t *testing.T, source ports.DetectionSensor, durable ports.TelemetrySpool) *DurableSensor {
+	t.Helper()
+	sensor, err := NewDurableSensor(source, durable, testIdentity())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sensor
+}
+
+func testIdentity() SensorIdentity {
+	return SensorIdentity{
+		AgentID: "agent-1", AssetID: "asset-1", AgentSession: "session-1", BootID: "boot-1",
+		SensorID: "ebpf", SensorVersion: "1",
+	}
+}
+
+func processEvent() detection.Event {
+	return detection.Event{
+		Class: detection.ClassProcess, At: adapterNow.Add(-time.Millisecond), Host: "asset-1",
+		Process: &detection.ProcessEvent{PID: 10, PPID: 1, Comm: "curl", Path: "/usr/bin/curl", Args: []string{"curl", "https://example.test"}, UID: 1000},
+	}
+}
+
+func fileEvent() detection.Event {
+	return detection.Event{
+		Class: detection.ClassFile, At: adapterNow.Add(-time.Millisecond), Host: "asset-1",
+		File: &detection.FileEvent{Op: "write", Path: "/etc/shadow", PID: 10, Comm: "vi"},
+	}
+}
+
+func privilegeEvent() detection.Event {
+	return detection.Event{
+		Class: detection.ClassPrivilege, At: adapterNow.Add(-time.Millisecond), Host: "asset-1",
+		Privilege: &detection.PrivilegeEvent{Kind: "setuid", PID: 10, Comm: "sudo", FromUID: 1000, ToUID: 0},
+	}
+}
+
+type fakeSensor struct {
+	events chan detection.Event
+	once   sync.Once
+}
+
+func newFakeSensor() *fakeSensor                     { return &fakeSensor{events: make(chan detection.Event)} }
+func (f *fakeSensor) Start(context.Context) error    { return nil }
+func (f *fakeSensor) Events() <-chan detection.Event { return f.events }
+func (f *fakeSensor) Coverage() []detection.ClassCoverage {
+	return []detection.ClassCoverage{{Class: detection.ClassProcess, HostID: "asset-1", AgentID: "agent-1", State: detection.StateActive, Since: adapterNow}}
+}
+func (f *fakeSensor) Dropped() map[detection.Class]uint64 { return nil }
+func (f *fakeSensor) Close() error {
+	f.once.Do(func() { close(f.events) })
+	return nil
+}
+
+type captureSpool struct {
+	mu     sync.Mutex
+	items  []ports.SpoolItem
+	errors []error
+	calls  int
+}
+
+func (c *captureSpool) Enqueue(_ context.Context, item ports.SpoolItem) (fleetagent.StreamPosition, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	if len(c.errors) > 0 {
+		err := c.errors[0]
+		c.errors = c.errors[1:]
+		if err != nil {
+			return fleetagent.StreamPosition{}, err
+		}
+	}
+	item.Payload = append([]byte(nil), item.Payload...)
+	c.items = append(c.items, item)
+	return fleetagent.StreamPosition{Priority: item.Priority, Epoch: 1, Sequence: uint64(len(c.items)), Session: "s", Boot: "b"}, nil
+}
+func (c *captureSpool) snapshot() []ports.SpoolItem {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]ports.SpoolItem(nil), c.items...)
+}
+func (c *captureSpool) Peek(context.Context, ports.PeekSpoolRequest) ([]ports.SpoolRecord, error) {
+	return nil, nil
+}
+func (c *captureSpool) Ack(context.Context, ports.SpoolACK) (ports.SpoolACKResult, error) {
+	return ports.SpoolACKResult{}, nil
+}
+func (c *captureSpool) Flush(context.Context) error                    { return nil }
+func (c *captureSpool) Gaps(context.Context) ([]ports.SpoolGap, error) { return nil, nil }
+func (c *captureSpool) Stats(context.Context) (ports.SpoolStats, error) {
+	return ports.SpoolStats{}, nil
+}
+func (c *captureSpool) Close() error { return nil }

--- a/internal/adapter/agentspool/sensor_test.go
+++ b/internal/adapter/agentspool/sensor_test.go
@@ -200,6 +200,48 @@ func TestDurableSensorFailureDegradesCoverage(t *testing.T) {
 	_ = wrapper.Close()
 }
 
+func TestDurableSensorFailureDoesNotMaskFailedCoverage(t *testing.T) {
+	source := newFakeSensor()
+	source.coverage = []detection.ClassCoverage{{
+		Class: detection.ClassProcess, HostID: "asset-1", AgentID: "agent-1",
+		State: detection.StateFailed, Reason: "probe attach failed", Since: adapterNow,
+	}}
+	durable := &captureSpool{errors: []error{errors.New("disk I/O failed")}}
+	wrapper := mustSensor(t, source, durable)
+	wrapper.now = func() time.Time { return adapterNow }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := wrapper.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	source.events <- processEvent()
+	select {
+	case <-wrapper.Events():
+	case <-time.After(time.Second):
+		t.Fatal("detection path should continue after recorded telemetry failure")
+	}
+	coverage := wrapper.Coverage()
+	if len(coverage) != 1 || coverage[0].State != detection.StateFailed || coverage[0].Reason != "probe attach failed" {
+		t.Fatalf("failed source coverage was masked: %#v", coverage)
+	}
+	cancel()
+	_ = wrapper.Close()
+}
+
+func TestSaturationRetryDelayIsJitteredWithinBounds(t *testing.T) {
+	seen := make(map[time.Duration]struct{})
+	for range 100 {
+		delay := saturationRetryDelay()
+		if delay < minSaturationRetryDelay || delay > maxSaturationRetryDelay {
+			t.Fatalf("retry delay %s outside [%s, %s]", delay, minSaturationRetryDelay, maxSaturationRetryDelay)
+		}
+		seen[delay] = struct{}{}
+	}
+	if len(seen) == 1 {
+		t.Fatal("retry delay remained fixed")
+	}
+}
+
 func TestDurableSensorRejectsBadDependenciesAndDoubleStart(t *testing.T) {
 	identity := testIdentity()
 	if _, err := NewDurableSensor(nil, &captureSpool{}, identity); err == nil {
@@ -263,14 +305,18 @@ func privilegeEvent() detection.Event {
 }
 
 type fakeSensor struct {
-	events chan detection.Event
-	once   sync.Once
+	events   chan detection.Event
+	coverage []detection.ClassCoverage
+	once     sync.Once
 }
 
 func newFakeSensor() *fakeSensor                     { return &fakeSensor{events: make(chan detection.Event)} }
 func (f *fakeSensor) Start(context.Context) error    { return nil }
 func (f *fakeSensor) Events() <-chan detection.Event { return f.events }
 func (f *fakeSensor) Coverage() []detection.ClassCoverage {
+	if f.coverage != nil {
+		return append([]detection.ClassCoverage(nil), f.coverage...)
+	}
 	return []detection.ClassCoverage{{Class: detection.ClassProcess, HostID: "asset-1", AgentID: "agent-1", State: detection.StateActive, Since: adapterNow}}
 }
 func (f *fakeSensor) Dropped() map[detection.Class]uint64 { return nil }

--- a/internal/domain/fleetagent/delivery.go
+++ b/internal/domain/fleetagent/delivery.go
@@ -6,7 +6,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
 )
 
 // Delivery contract (#609, A0.4). The agent ships security signals to the control plane under an explicit,
@@ -54,6 +56,19 @@ func (p DeliveryPriority) String() string {
 	default:
 		return "P?"
 	}
+}
+
+// TelemetryPriority assigns canonical raw telemetry to the A2 priority ladder. Privilege transitions and
+// sensitive-file observations are never-shed P2; high-volume process/network observations are evictable
+// P3. P0 and P1 are reserved for coverage/verification and confirmed detections respectively.
+func TelemetryPriority(class detection.Class) (DeliveryPriority, error) {
+	if !class.Valid() {
+		return PriorityP3, fmt.Errorf("%w: unknown telemetry class %q", shared.ErrValidation, class)
+	}
+	if telemetry.MustNotShed(class) {
+		return PriorityP2, nil
+	}
+	return PriorityP3, nil
 }
 
 // SessionID identifies one agent run/enrolment session; BootID identifies one host boot. Both are opaque

--- a/internal/domain/fleetagent/telemetry_priority_test.go
+++ b/internal/domain/fleetagent/telemetry_priority_test.go
@@ -1,0 +1,30 @@
+package fleetagent
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestTelemetryPriorityContract(t *testing.T) {
+	tests := []struct {
+		class detection.Class
+		want  DeliveryPriority
+	}{
+		{detection.ClassProcess, PriorityP3},
+		{detection.ClassNetwork, PriorityP3},
+		{detection.ClassFile, PriorityP2},
+		{detection.ClassPrivilege, PriorityP2},
+	}
+	for _, tt := range tests {
+		got, err := TelemetryPriority(tt.class)
+		if err != nil || got != tt.want {
+			t.Errorf("TelemetryPriority(%s) = %s, %v; want %s", tt.class, got, err, tt.want)
+		}
+	}
+	if _, err := TelemetryPriority("future"); err == nil || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unknown class error = %v", err)
+	}
+}

--- a/internal/infrastructure/spool/config.go
+++ b/internal/infrastructure/spool/config.go
@@ -10,12 +10,19 @@ import (
 
 const (
 	defaultMaxBytes       = int64(512 << 20)
+	defaultMaxGapBytes    = int64(8 << 20)
 	defaultSegmentBytes   = int64(8 << 20)
 	defaultMaxRecordBytes = int64(4 << 20)
 	defaultPeekRecords    = 256
 	defaultPeekBytes      = int64(2 << 20)
 	defaultBatchInterval  = time.Second
 	defaultBatchBytes     = int64(256 << 10)
+	// FrameOverheadBudget bounds the header plus encoded record metadata. It is
+	// exported so composition roots that shrink a spool can also shrink the
+	// payload limit without creating a record that can never fit.
+	FrameOverheadBudget   = int64(512)
+	maxFrameMetadataBytes = FrameOverheadBudget - frameHeaderSize
+	minimumGapReserve     = 8 * FrameOverheadBudget
 )
 
 // SyncPolicy controls when an accepted record is forced to stable storage.
@@ -31,10 +38,16 @@ const (
 
 // Config is the bounded resource and durability policy for one spool.
 type Config struct {
-	Dir            string
-	Session        fleetagent.SessionID
-	Boot           fleetagent.BootID
-	MaxBytes       int64
+	// Dir must be service-owned and non-world-writable. Open tightens it to
+	// 0700 and refuses symlink paths before reading spool contents.
+	Dir      string
+	Session  fleetagent.SessionID
+	Boot     fleetagent.BootID
+	MaxBytes int64
+	// MaxGapBytes is reserved inside MaxBytes for durable loss evidence and its
+	// atomic compaction scratch file. Zero selects a size-derived default; WAL
+	// records cannot consume this reserve.
+	MaxGapBytes    int64
 	SegmentBytes   int64
 	MaxRecordBytes int64
 	PeekRecords    int
@@ -81,6 +94,11 @@ func normalizeConfig(in Config) (Config, error) {
 	if in.MaxBytes != 0 {
 		cfg.MaxBytes = in.MaxBytes
 	}
+	if in.MaxGapBytes != 0 {
+		cfg.MaxGapBytes = in.MaxGapBytes
+	} else {
+		cfg.MaxGapBytes = RecommendedGapBytes(cfg.MaxBytes)
+	}
 	if in.SegmentBytes != 0 {
 		cfg.SegmentBytes = in.SegmentBytes
 	}
@@ -115,14 +133,21 @@ func normalizeConfig(in Config) (Config, error) {
 	if cfg.Session == "" || cfg.Boot == "" {
 		return Config{}, fmt.Errorf("%w: spool session and boot ids are required", shared.ErrValidation)
 	}
-	if cfg.MaxBytes <= 0 || cfg.SegmentBytes <= 0 || cfg.MaxRecordBytes <= 0 {
+	if cfg.MaxBytes <= 0 || cfg.MaxGapBytes <= 0 || cfg.SegmentBytes <= 0 || cfg.MaxRecordBytes <= 0 {
 		return Config{}, fmt.Errorf("%w: spool byte limits must be positive", shared.ErrValidation)
 	}
-	if cfg.SegmentBytes > cfg.MaxBytes {
-		return Config{}, fmt.Errorf("%w: segment limit cannot exceed spool quota", shared.ErrValidation)
+	if cfg.MaxGapBytes >= cfg.MaxBytes {
+		return Config{}, fmt.Errorf("%w: gap journal budget must be smaller than spool quota", shared.ErrValidation)
 	}
-	if cfg.MaxRecordBytes > cfg.SegmentBytes {
-		return Config{}, fmt.Errorf("%w: record limit cannot exceed segment limit", shared.ErrValidation)
+	if cfg.MaxGapBytes < minimumGapReserve {
+		return Config{}, fmt.Errorf("%w: gap journal budget is too small for bounded atomic compaction", shared.ErrValidation)
+	}
+	walBytes := cfg.MaxBytes - cfg.MaxGapBytes
+	if cfg.SegmentBytes > walBytes {
+		return Config{}, fmt.Errorf("%w: segment limit cannot exceed WAL quota after gap reserve", shared.ErrValidation)
+	}
+	if cfg.MaxRecordBytes > cfg.SegmentBytes-FrameOverheadBudget {
+		return Config{}, fmt.Errorf("%w: record limit plus frame overhead cannot exceed segment limit", shared.ErrValidation)
 	}
 	if cfg.PeekRecords < 1 || cfg.PeekBytes < 1 {
 		return Config{}, fmt.Errorf("%w: peek limits must be positive", shared.ErrValidation)
@@ -140,4 +165,17 @@ func normalizeConfig(in Config) (Config, error) {
 		}
 	}
 	return cfg, nil
+}
+
+// RecommendedGapBytes returns the bounded loss-evidence reserve used when
+// MaxGapBytes is zero. The reserve includes room for an atomic rewrite copy.
+func RecommendedGapBytes(maxBytes int64) int64 {
+	budget := maxBytes / 64
+	if budget > defaultMaxGapBytes {
+		budget = defaultMaxGapBytes
+	}
+	if budget < minimumGapReserve {
+		budget = minimumGapReserve
+	}
+	return budget
 }

--- a/internal/infrastructure/spool/config.go
+++ b/internal/infrastructure/spool/config.go
@@ -1,0 +1,143 @@
+package spool
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	defaultMaxBytes       = int64(512 << 20)
+	defaultSegmentBytes   = int64(8 << 20)
+	defaultMaxRecordBytes = int64(4 << 20)
+	defaultPeekRecords    = 256
+	defaultPeekBytes      = int64(2 << 20)
+	defaultBatchInterval  = time.Second
+	defaultBatchBytes     = int64(256 << 10)
+)
+
+// SyncPolicy controls when an accepted record is forced to stable storage.
+// Always is the default for the non-sheddable P0..P2 lanes. Batch is intended
+// only for P3: sequence reservations make a crash-visible gap explicit even
+// when the operating system loses the last accepted, not-yet-synced frames.
+type SyncPolicy string
+
+const (
+	SyncAlways SyncPolicy = "always"
+	SyncBatch  SyncPolicy = "batch"
+)
+
+// Config is the bounded resource and durability policy for one spool.
+type Config struct {
+	Dir            string
+	Session        fleetagent.SessionID
+	Boot           fleetagent.BootID
+	MaxBytes       int64
+	SegmentBytes   int64
+	MaxRecordBytes int64
+	PeekRecords    int
+	PeekBytes      int64
+	BatchInterval  time.Duration
+	BatchBytes     int64
+	Sync           map[fleetagent.DeliveryPriority]SyncPolicy
+	Now            func() time.Time
+}
+
+// DefaultConfig returns conservative production defaults. It deliberately
+// leaves identity and directory unset so a caller cannot accidentally open a
+// spool whose incarnation cannot be attributed.
+func DefaultConfig() Config {
+	return Config{
+		MaxBytes:       defaultMaxBytes,
+		SegmentBytes:   defaultSegmentBytes,
+		MaxRecordBytes: defaultMaxRecordBytes,
+		PeekRecords:    defaultPeekRecords,
+		PeekBytes:      defaultPeekBytes,
+		BatchInterval:  defaultBatchInterval,
+		BatchBytes:     defaultBatchBytes,
+		Sync: map[fleetagent.DeliveryPriority]SyncPolicy{
+			fleetagent.PriorityP0: SyncAlways,
+			fleetagent.PriorityP1: SyncAlways,
+			fleetagent.PriorityP2: SyncAlways,
+			fleetagent.PriorityP3: SyncBatch,
+		},
+		Now: time.Now,
+	}
+}
+
+func normalizeConfig(in Config) (Config, error) {
+	cfg := DefaultConfig()
+	if in.Dir != "" {
+		cfg.Dir = in.Dir
+	}
+	if in.Session != "" {
+		cfg.Session = in.Session
+	}
+	if in.Boot != "" {
+		cfg.Boot = in.Boot
+	}
+	if in.MaxBytes != 0 {
+		cfg.MaxBytes = in.MaxBytes
+	}
+	if in.SegmentBytes != 0 {
+		cfg.SegmentBytes = in.SegmentBytes
+	}
+	if in.MaxRecordBytes != 0 {
+		cfg.MaxRecordBytes = in.MaxRecordBytes
+	}
+	if in.PeekRecords != 0 {
+		cfg.PeekRecords = in.PeekRecords
+	}
+	if in.PeekBytes != 0 {
+		cfg.PeekBytes = in.PeekBytes
+	}
+	if in.BatchInterval != 0 {
+		cfg.BatchInterval = in.BatchInterval
+	}
+	if in.BatchBytes != 0 {
+		cfg.BatchBytes = in.BatchBytes
+	}
+	if in.Now != nil {
+		cfg.Now = in.Now
+	}
+	if in.Sync != nil {
+		cfg.Sync = make(map[fleetagent.DeliveryPriority]SyncPolicy, 4)
+		for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+			cfg.Sync[priority] = in.Sync[priority]
+		}
+	}
+
+	if cfg.Dir == "" {
+		return Config{}, fmt.Errorf("%w: spool directory is required", shared.ErrValidation)
+	}
+	if cfg.Session == "" || cfg.Boot == "" {
+		return Config{}, fmt.Errorf("%w: spool session and boot ids are required", shared.ErrValidation)
+	}
+	if cfg.MaxBytes <= 0 || cfg.SegmentBytes <= 0 || cfg.MaxRecordBytes <= 0 {
+		return Config{}, fmt.Errorf("%w: spool byte limits must be positive", shared.ErrValidation)
+	}
+	if cfg.SegmentBytes > cfg.MaxBytes {
+		return Config{}, fmt.Errorf("%w: segment limit cannot exceed spool quota", shared.ErrValidation)
+	}
+	if cfg.MaxRecordBytes > cfg.SegmentBytes {
+		return Config{}, fmt.Errorf("%w: record limit cannot exceed segment limit", shared.ErrValidation)
+	}
+	if cfg.PeekRecords < 1 || cfg.PeekBytes < 1 {
+		return Config{}, fmt.Errorf("%w: peek limits must be positive", shared.ErrValidation)
+	}
+	if cfg.BatchInterval <= 0 || cfg.BatchBytes <= 0 {
+		return Config{}, fmt.Errorf("%w: batch sync limits must be positive", shared.ErrValidation)
+	}
+	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+		policy := cfg.Sync[priority]
+		if policy != SyncAlways && policy != SyncBatch {
+			return Config{}, fmt.Errorf("%w: priority %s has invalid sync policy %q", shared.ErrValidation, priority, policy)
+		}
+		if priority != fleetagent.PriorityP3 && policy != SyncAlways {
+			return Config{}, fmt.Errorf("%w: non-sheddable priority %s must use always sync", shared.ErrValidation, priority)
+		}
+	}
+	return cfg, nil
+}

--- a/internal/infrastructure/spool/config_test.go
+++ b/internal/infrastructure/spool/config_test.go
@@ -10,7 +10,14 @@ import (
 )
 
 func TestDefaultConfigUsesNeverShedDurability(t *testing.T) {
-	cfg := DefaultConfig()
+	input := DefaultConfig()
+	input.Dir = t.TempDir()
+	input.Session = "s"
+	input.Boot = "b"
+	cfg, err := normalizeConfig(input)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP2; priority++ {
 		if cfg.Sync[priority] != SyncAlways {
 			t.Errorf("%s sync = %q, want always", priority, cfg.Sync[priority])
@@ -19,8 +26,8 @@ func TestDefaultConfigUsesNeverShedDurability(t *testing.T) {
 	if cfg.Sync[fleetagent.PriorityP3] != SyncBatch {
 		t.Errorf("P3 sync = %q, want batch", cfg.Sync[fleetagent.PriorityP3])
 	}
-	if cfg.MaxRecordBytes > cfg.SegmentBytes || cfg.SegmentBytes > cfg.MaxBytes {
-		t.Fatalf("invalid default size hierarchy: record=%d segment=%d quota=%d", cfg.MaxRecordBytes, cfg.SegmentBytes, cfg.MaxBytes)
+	if cfg.MaxGapBytes <= 0 || cfg.MaxRecordBytes+FrameOverheadBudget > cfg.SegmentBytes || cfg.SegmentBytes > cfg.MaxBytes-cfg.MaxGapBytes {
+		t.Fatalf("invalid default size hierarchy: record=%d segment=%d gaps=%d quota=%d", cfg.MaxRecordBytes, cfg.SegmentBytes, cfg.MaxGapBytes, cfg.MaxBytes)
 	}
 }
 
@@ -34,8 +41,10 @@ func TestNormalizeConfigRejectsUnsafePolicies(t *testing.T) {
 		{"missing session", func(c *Config) { c.Session = "" }},
 		{"missing boot", func(c *Config) { c.Boot = "" }},
 		{"negative quota", func(c *Config) { c.MaxBytes = -1 }},
+		{"gap budget over quota", func(c *Config) { c.MaxGapBytes = c.MaxBytes }},
+		{"gap budget too small", func(c *Config) { c.MaxGapBytes = minimumGapReserve - 1 }},
 		{"segment over quota", func(c *Config) { c.SegmentBytes = c.MaxBytes + 1 }},
-		{"record over segment", func(c *Config) { c.MaxRecordBytes = c.SegmentBytes + 1 }},
+		{"record plus overhead over segment", func(c *Config) { c.MaxRecordBytes = c.SegmentBytes - FrameOverheadBudget + 1 }},
 		{"negative peek count", func(c *Config) { c.PeekRecords = -1 }},
 		{"negative peek bytes", func(c *Config) { c.PeekBytes = -1 }},
 		{"negative batch interval", func(c *Config) { c.BatchInterval = -time.Second }},

--- a/internal/infrastructure/spool/config_test.go
+++ b/internal/infrastructure/spool/config_test.go
@@ -1,0 +1,76 @@
+package spool
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestDefaultConfigUsesNeverShedDurability(t *testing.T) {
+	cfg := DefaultConfig()
+	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP2; priority++ {
+		if cfg.Sync[priority] != SyncAlways {
+			t.Errorf("%s sync = %q, want always", priority, cfg.Sync[priority])
+		}
+	}
+	if cfg.Sync[fleetagent.PriorityP3] != SyncBatch {
+		t.Errorf("P3 sync = %q, want batch", cfg.Sync[fleetagent.PriorityP3])
+	}
+	if cfg.MaxRecordBytes > cfg.SegmentBytes || cfg.SegmentBytes > cfg.MaxBytes {
+		t.Fatalf("invalid default size hierarchy: record=%d segment=%d quota=%d", cfg.MaxRecordBytes, cfg.SegmentBytes, cfg.MaxBytes)
+	}
+}
+
+func TestNormalizeConfigRejectsUnsafePolicies(t *testing.T) {
+	base := testConfig(t)
+	tests := []struct {
+		name string
+		edit func(*Config)
+	}{
+		{"missing directory", func(c *Config) { c.Dir = "" }},
+		{"missing session", func(c *Config) { c.Session = "" }},
+		{"missing boot", func(c *Config) { c.Boot = "" }},
+		{"negative quota", func(c *Config) { c.MaxBytes = -1 }},
+		{"segment over quota", func(c *Config) { c.SegmentBytes = c.MaxBytes + 1 }},
+		{"record over segment", func(c *Config) { c.MaxRecordBytes = c.SegmentBytes + 1 }},
+		{"negative peek count", func(c *Config) { c.PeekRecords = -1 }},
+		{"negative peek bytes", func(c *Config) { c.PeekBytes = -1 }},
+		{"negative batch interval", func(c *Config) { c.BatchInterval = -time.Second }},
+		{"P0 batching", func(c *Config) { c.Sync[fleetagent.PriorityP0] = SyncBatch }},
+		{"P2 batching", func(c *Config) { c.Sync[fleetagent.PriorityP2] = SyncBatch }},
+		{"unknown policy", func(c *Config) { c.Sync[fleetagent.PriorityP3] = "sometimes" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			cfg.Sync = clonePolicies(base.Sync)
+			tt.edit(&cfg)
+			_, err := normalizeConfig(cfg)
+			if err == nil || !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("normalize error = %v, want validation error", err)
+			}
+		})
+	}
+}
+
+func TestNormalizeConfigFillsOptionalDefaults(t *testing.T) {
+	cfg, err := normalizeConfig(Config{Dir: t.TempDir(), Session: "s", Boot: "b"})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	defaults := DefaultConfig()
+	if cfg.MaxBytes != defaults.MaxBytes || cfg.PeekRecords != defaults.PeekRecords || cfg.Now == nil {
+		t.Fatalf("defaults not applied: %#v", cfg)
+	}
+}
+
+func clonePolicies(in map[fleetagent.DeliveryPriority]SyncPolicy) map[fleetagent.DeliveryPriority]SyncPolicy {
+	out := make(map[fleetagent.DeliveryPriority]SyncPolicy, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/infrastructure/spool/errors.go
+++ b/internal/infrastructure/spool/errors.go
@@ -13,6 +13,9 @@ var (
 	ErrSaturated = ports.ErrTelemetrySpoolSaturated
 	// ErrClosed means the spool no longer accepts or serves operations.
 	ErrClosed = errors.New("telemetry spool closed")
+	// ErrFailed means a durability operation had an ambiguous outcome. The
+	// spool fails stop until it is closed and recovered from disk.
+	ErrFailed = errors.New("telemetry spool durability failure")
 	// ErrLocked means another process already owns the spool directory.
 	ErrLocked = errors.New("telemetry spool already open")
 	// ErrACKAhead means an ACK claims a sequence which this spool has never assigned.

--- a/internal/infrastructure/spool/errors.go
+++ b/internal/infrastructure/spool/errors.go
@@ -1,0 +1,35 @@
+package spool
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var (
+	// ErrSaturated means the quota could not be satisfied without deleting a
+	// non-sheddable P0..P2 record. Producers should apply backpressure.
+	ErrSaturated = ports.ErrTelemetrySpoolSaturated
+	// ErrClosed means the spool no longer accepts or serves operations.
+	ErrClosed = errors.New("telemetry spool closed")
+	// ErrLocked means another process already owns the spool directory.
+	ErrLocked = errors.New("telemetry spool already open")
+	// ErrACKAhead means an ACK claims a sequence which this spool has never assigned.
+	ErrACKAhead = errors.New("telemetry spool ACK is ahead of assigned sequence")
+	// ErrStaleACK means an ACK addresses an incarnation which this spool cannot own.
+	ErrStaleACK = errors.New("telemetry spool ACK addresses a stale incarnation")
+)
+
+// SaturatedError includes safe capacity information without leaking host paths.
+type SaturatedError struct {
+	UsedBytes     int64
+	MaxBytes      int64
+	RequiredBytes int64
+}
+
+func (e *SaturatedError) Error() string {
+	return fmt.Sprintf("%v: used=%d max=%d required=%d", ErrSaturated, e.UsedBytes, e.MaxBytes, e.RequiredBytes)
+}
+
+func (e *SaturatedError) Unwrap() error { return ErrSaturated }

--- a/internal/infrastructure/spool/errors.go
+++ b/internal/infrastructure/spool/errors.go
@@ -16,6 +16,10 @@ var (
 	// ErrFailed means a durability operation had an ambiguous outcome. The
 	// spool fails stop until it is closed and recovered from disk.
 	ErrFailed = errors.New("telemetry spool durability failure")
+	// ErrGapJournalFull means loss evidence cannot be retained within its
+	// reserved share of the spool quota. The spool fails stop rather than erase
+	// evidence or grow beyond its configured disk bound.
+	ErrGapJournalFull = errors.New("telemetry spool gap journal full")
 	// ErrLocked means another process already owns the spool directory.
 	ErrLocked = errors.New("telemetry spool already open")
 	// ErrACKAhead means an ACK claims a sequence which this spool has never assigned.

--- a/internal/infrastructure/spool/frame.go
+++ b/internal/infrastructure/spool/frame.go
@@ -96,6 +96,9 @@ func encodeFrame(item ports.SpoolItem, position fleetagent.StreamPosition, enque
 	if err != nil {
 		return nil, fmt.Errorf("encode WAL metadata: %w", err)
 	}
+	if len(meta) > int(maxFrameMetadataBytes) {
+		return nil, fmt.Errorf("%w: encoded WAL metadata is %d bytes, maximum is %d", shared.ErrValidation, len(meta), maxFrameMetadataBytes)
+	}
 	bodySize := len(meta) + len(item.Payload)
 	if bodySize > int(^uint32(0)) {
 		return nil, errors.New("encode WAL frame: body exceeds format limit")

--- a/internal/infrastructure/spool/frame.go
+++ b/internal/infrastructure/spool/frame.go
@@ -1,0 +1,218 @@
+package spool
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	frameMagic      uint32 = 0x53594e57 // SYNW
+	frameVersion    uint16 = 1
+	frameHeaderSize        = 48
+	frameFlagNoShed uint16 = 1 << 0
+)
+
+var castagnoli = crc32.MakeTable(crc32.Castagnoli)
+
+type frameHeader struct {
+	Magic      uint32
+	Version    uint16
+	HeaderSize uint16
+	BodySize   uint32
+	Checksum   uint32
+	Priority   uint8
+	Kind       uint8
+	Flags      uint16
+	Epoch      uint64
+	Sequence   uint64
+	ObservedNS int64
+	MetaSize   uint32
+}
+
+type recordMeta struct {
+	EventID       shared.ID            `json:"event_id"`
+	EventClass    detection.Class      `json:"event_class,omitempty"`
+	ContentType   string               `json:"content_type"`
+	Session       fleetagent.SessionID `json:"session"`
+	Boot          fleetagent.BootID    `json:"boot"`
+	EnqueuedAt    time.Time            `json:"enqueued_at"`
+	SchemaVersion int                  `json:"schema_version"`
+}
+
+func recordKindCode(kind ports.SpoolRecordKind) (uint8, bool) {
+	switch kind {
+	case ports.SpoolRecordTelemetry:
+		return 1, true
+	case ports.SpoolRecordDetection:
+		return 2, true
+	case ports.SpoolRecordCoverage:
+		return 3, true
+	case ports.SpoolRecordSensorState:
+		return 4, true
+	case ports.SpoolRecordResponseVerification:
+		return 5, true
+	default:
+		return 0, false
+	}
+}
+
+func recordKindFromCode(code uint8) (ports.SpoolRecordKind, bool) {
+	switch code {
+	case 1:
+		return ports.SpoolRecordTelemetry, true
+	case 2:
+		return ports.SpoolRecordDetection, true
+	case 3:
+		return ports.SpoolRecordCoverage, true
+	case 4:
+		return ports.SpoolRecordSensorState, true
+	case 5:
+		return ports.SpoolRecordResponseVerification, true
+	default:
+		return "", false
+	}
+}
+
+func encodeFrame(item ports.SpoolItem, position fleetagent.StreamPosition, enqueuedAt time.Time) ([]byte, error) {
+	kind, ok := recordKindCode(item.Kind)
+	if !ok {
+		return nil, fmt.Errorf("encode WAL frame: unknown kind %q", item.Kind)
+	}
+	meta, err := json.Marshal(recordMeta{
+		EventID: item.EventID, EventClass: item.EventClass, ContentType: item.ContentType,
+		Session: position.Session, Boot: position.Boot, EnqueuedAt: enqueuedAt.UTC(),
+		SchemaVersion: item.SchemaVersion,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode WAL metadata: %w", err)
+	}
+	bodySize := len(meta) + len(item.Payload)
+	if bodySize > int(^uint32(0)) {
+		return nil, errors.New("encode WAL frame: body exceeds format limit")
+	}
+	flags := uint16(0)
+	if item.MustNotShed {
+		flags |= frameFlagNoShed
+	}
+	header := frameHeader{
+		Magic: frameMagic, Version: frameVersion, HeaderSize: frameHeaderSize,
+		BodySize: uint32(bodySize), Priority: uint8(position.Priority), Kind: kind,
+		Flags: flags, Epoch: position.Epoch, Sequence: position.Sequence,
+		ObservedNS: item.ObservedAt.UTC().UnixNano(), MetaSize: uint32(len(meta)),
+	}
+	frame := make([]byte, frameHeaderSize+bodySize)
+	marshalHeader(frame[:frameHeaderSize], header)
+	copy(frame[frameHeaderSize:], meta)
+	copy(frame[frameHeaderSize+len(meta):], item.Payload)
+	header.Checksum = checksumFrame(frame)
+	marshalHeader(frame[:frameHeaderSize], header)
+	return frame, nil
+}
+
+func decodeFrame(frame []byte) (ports.SpoolRecord, frameHeader, error) {
+	if len(frame) < frameHeaderSize {
+		return ports.SpoolRecord{}, frameHeader{}, io.ErrUnexpectedEOF
+	}
+	header := unmarshalHeader(frame[:frameHeaderSize])
+	if err := validateHeader(header); err != nil {
+		return ports.SpoolRecord{}, header, err
+	}
+	want := frameHeaderSize + int(header.BodySize)
+	if len(frame) != want {
+		return ports.SpoolRecord{}, header, fmt.Errorf("WAL frame length %d, want %d: %w", len(frame), want, io.ErrUnexpectedEOF)
+	}
+	if checksumFrame(frame) != header.Checksum {
+		return ports.SpoolRecord{}, header, errors.New("WAL frame checksum mismatch")
+	}
+	if header.MetaSize > header.BodySize {
+		return ports.SpoolRecord{}, header, errors.New("WAL metadata exceeds frame body")
+	}
+	var meta recordMeta
+	if err := json.Unmarshal(frame[frameHeaderSize:frameHeaderSize+int(header.MetaSize)], &meta); err != nil {
+		return ports.SpoolRecord{}, header, fmt.Errorf("decode WAL metadata: %w", err)
+	}
+	kind, ok := recordKindFromCode(header.Kind)
+	if !ok {
+		return ports.SpoolRecord{}, header, fmt.Errorf("unknown WAL record kind %d", header.Kind)
+	}
+	record := ports.SpoolRecord{
+		Kind: kind,
+		Position: fleetagent.StreamPosition{
+			Priority: fleetagent.DeliveryPriority(header.Priority), Epoch: header.Epoch,
+			Sequence: header.Sequence, Session: meta.Session, Boot: meta.Boot,
+		},
+		EventID: meta.EventID, EventClass: meta.EventClass, ContentType: meta.ContentType,
+		Payload:    append([]byte(nil), frame[frameHeaderSize+int(header.MetaSize):]...),
+		ObservedAt: time.Unix(0, header.ObservedNS).UTC(), EnqueuedAt: meta.EnqueuedAt.UTC(),
+		MustNotShed: header.Flags&frameFlagNoShed != 0, SchemaVersion: meta.SchemaVersion,
+	}
+	if err := record.Validate(); err != nil {
+		return ports.SpoolRecord{}, header, fmt.Errorf("validate WAL record: %w", err)
+	}
+	return record, header, nil
+}
+
+func validateHeader(h frameHeader) error {
+	if h.Magic != frameMagic {
+		return errors.New("WAL frame magic mismatch")
+	}
+	if h.Version != frameVersion || h.HeaderSize != frameHeaderSize {
+		return fmt.Errorf("unsupported WAL frame version/header %d/%d", h.Version, h.HeaderSize)
+	}
+	if !fleetagent.DeliveryPriority(h.Priority).Valid() {
+		return fmt.Errorf("invalid WAL priority %d", h.Priority)
+	}
+	if _, ok := recordKindFromCode(h.Kind); !ok {
+		return fmt.Errorf("invalid WAL kind %d", h.Kind)
+	}
+	if h.Epoch == 0 || h.Sequence == 0 {
+		return errors.New("invalid zero WAL coordinate")
+	}
+	if h.BodySize == 0 || h.MetaSize == 0 || h.MetaSize > h.BodySize {
+		return errors.New("invalid WAL body or metadata size")
+	}
+	return nil
+}
+
+func marshalHeader(dst []byte, h frameHeader) {
+	binary.LittleEndian.PutUint32(dst[0:4], h.Magic)
+	binary.LittleEndian.PutUint16(dst[4:6], h.Version)
+	binary.LittleEndian.PutUint16(dst[6:8], h.HeaderSize)
+	binary.LittleEndian.PutUint32(dst[8:12], h.BodySize)
+	binary.LittleEndian.PutUint32(dst[12:16], h.Checksum)
+	dst[16], dst[17] = h.Priority, h.Kind
+	binary.LittleEndian.PutUint16(dst[18:20], h.Flags)
+	binary.LittleEndian.PutUint64(dst[20:28], h.Epoch)
+	binary.LittleEndian.PutUint64(dst[28:36], h.Sequence)
+	binary.LittleEndian.PutUint64(dst[36:44], uint64(h.ObservedNS))
+	binary.LittleEndian.PutUint32(dst[44:48], h.MetaSize)
+}
+
+func unmarshalHeader(src []byte) frameHeader {
+	return frameHeader{
+		Magic: binary.LittleEndian.Uint32(src[0:4]), Version: binary.LittleEndian.Uint16(src[4:6]),
+		HeaderSize: binary.LittleEndian.Uint16(src[6:8]), BodySize: binary.LittleEndian.Uint32(src[8:12]),
+		Checksum: binary.LittleEndian.Uint32(src[12:16]), Priority: src[16], Kind: src[17],
+		Flags: binary.LittleEndian.Uint16(src[18:20]), Epoch: binary.LittleEndian.Uint64(src[20:28]),
+		Sequence: binary.LittleEndian.Uint64(src[28:36]), ObservedNS: int64(binary.LittleEndian.Uint64(src[36:44])),
+		MetaSize: binary.LittleEndian.Uint32(src[44:48]),
+	}
+}
+
+func checksumFrame(frame []byte) uint32 {
+	hasher := crc32.New(castagnoli)
+	_, _ = hasher.Write(frame[:12])
+	_, _ = hasher.Write([]byte{0, 0, 0, 0})
+	_, _ = hasher.Write(frame[16:])
+	return hasher.Sum32()
+}

--- a/internal/infrastructure/spool/frame_test.go
+++ b/internal/infrastructure/spool/frame_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -99,6 +101,15 @@ func TestDecodeFrameRejectsTruncationAndFormatBombs(t *testing.T) {
 	binary.LittleEndian.PutUint32(bad[44:48], binary.LittleEndian.Uint32(bad[8:12])+1)
 	if _, _, err := decodeFrame(bad); err == nil {
 		t.Fatal("metadata larger than body accepted")
+	}
+}
+
+func TestEncodeFrameRejectsMetadataOutsideReservedOverhead(t *testing.T) {
+	item := testItem(fleetagent.PriorityP3, "bounded-meta", 32)
+	item.ContentType = strings.Repeat("x", int(maxFrameMetadataBytes))
+	position := fleetagent.StreamPosition{Priority: fleetagent.PriorityP3, Epoch: 1, Sequence: 1, Session: "s", Boot: "b"}
+	if _, err := encodeFrame(item, position, testNow); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("oversized metadata error = %v, want validation error", err)
 	}
 }
 

--- a/internal/infrastructure/spool/frame_test.go
+++ b/internal/infrastructure/spool/frame_test.go
@@ -1,0 +1,134 @@
+package spool
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestFrameRoundTripEveryRecordKind(t *testing.T) {
+	kinds := []ports.SpoolRecordKind{
+		ports.SpoolRecordTelemetry, ports.SpoolRecordDetection, ports.SpoolRecordCoverage,
+		ports.SpoolRecordSensorState, ports.SpoolRecordResponseVerification,
+	}
+	for _, kind := range kinds {
+		t.Run(string(kind), func(t *testing.T) {
+			priority := fleetagent.PriorityP0
+			if kind == ports.SpoolRecordTelemetry {
+				priority = fleetagent.PriorityP3
+			} else if kind == ports.SpoolRecordDetection {
+				priority = fleetagent.PriorityP1
+			}
+			item := testItem(priority, "event-1", 32)
+			item.Kind = kind
+			if kind != ports.SpoolRecordTelemetry {
+				item.EventClass = ""
+			}
+			position := fleetagent.StreamPosition{Priority: priority, Epoch: 7, Sequence: 99, Session: "session", Boot: "boot"}
+			frame, err := encodeFrame(item, position, testNow)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			record, header, err := decodeFrame(frame)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if header.Checksum == 0 || header.BodySize == 0 || header.MetaSize == 0 {
+				t.Fatalf("incomplete header: %#v", header)
+			}
+			if record.Kind != kind || record.Position != position || record.EventID != item.EventID || !bytes.Equal(record.Payload, item.Payload) {
+				t.Fatalf("round trip mismatch: %#v", record)
+			}
+			item.Payload[0] ^= 0xff
+			if bytes.Equal(record.Payload, item.Payload) {
+				t.Fatal("decoded payload aliases caller memory")
+			}
+		})
+	}
+}
+
+func TestFrameChecksumCoversHeaderAndPayload(t *testing.T) {
+	item := testItem(fleetagent.PriorityP2, "checksum", 128)
+	position := fleetagent.StreamPosition{Priority: fleetagent.PriorityP2, Epoch: 2, Sequence: 3, Session: "s", Boot: "b"}
+	frame, err := encodeFrame(item, position, testNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutations := []struct {
+		name   string
+		offset int
+	}{
+		{"coordinate", 28},
+		{"timestamp", 36},
+		{"metadata", frameHeaderSize + 2},
+		{"payload", len(frame) - 1},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			corrupt := append([]byte(nil), frame...)
+			corrupt[mutation.offset] ^= 0x40
+			if _, _, err := decodeFrame(corrupt); err == nil {
+				t.Fatal("corrupt frame decoded successfully")
+			}
+		})
+	}
+}
+
+func TestDecodeFrameRejectsTruncationAndFormatBombs(t *testing.T) {
+	item := testItem(fleetagent.PriorityP3, "bounded", 32)
+	position := fleetagent.StreamPosition{Priority: fleetagent.PriorityP3, Epoch: 1, Sequence: 1, Session: "s", Boot: "b"}
+	frame, err := encodeFrame(item, position, testNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, size := range []int{0, 1, frameHeaderSize - 1, frameHeaderSize, len(frame) - 1} {
+		_, _, err := decodeFrame(frame[:size])
+		if err == nil {
+			t.Errorf("truncated size %d decoded", size)
+		}
+		if size < frameHeaderSize && !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Errorf("size %d error = %v, want unexpected EOF", size, err)
+		}
+	}
+	bad := append([]byte(nil), frame...)
+	binary.LittleEndian.PutUint32(bad[44:48], binary.LittleEndian.Uint32(bad[8:12])+1)
+	if _, _, err := decodeFrame(bad); err == nil {
+		t.Fatal("metadata larger than body accepted")
+	}
+}
+
+func TestRecordKindCodesAreStableAndBijective(t *testing.T) {
+	for code := uint8(1); code <= 5; code++ {
+		kind, ok := recordKindFromCode(code)
+		if !ok {
+			t.Fatalf("code %d missing", code)
+		}
+		back, ok := recordKindCode(kind)
+		if !ok || back != code {
+			t.Fatalf("code %d -> %q -> %d", code, kind, back)
+		}
+	}
+	if _, ok := recordKindFromCode(0); ok {
+		t.Fatal("zero kind code accepted")
+	}
+	if _, ok := recordKindCode("future"); ok {
+		t.Fatal("unknown kind accepted")
+	}
+}
+
+func FuzzDecodeFrameNeverPanics(f *testing.F) {
+	item := testItem(fleetagent.PriorityP3, "fuzz", 64)
+	position := fleetagent.StreamPosition{Priority: fleetagent.PriorityP3, Epoch: 1, Sequence: 1, Session: "s", Boot: "b"}
+	valid, _ := encodeFrame(item, position, testNow)
+	f.Add(valid)
+	f.Add([]byte{})
+	f.Add([]byte("SYNW"))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _, _ = decodeFrame(data)
+	})
+}

--- a/internal/infrastructure/spool/gaps.go
+++ b/internal/infrastructure/spool/gaps.go
@@ -1,0 +1,140 @@
+package spool
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	gapMagic      uint32 = 0x53594750 // SYGP
+	gapHeaderSize        = 12
+	maxGapBody           = 64 << 10
+)
+
+func openGapJournal(dir string) (*os.File, []ports.SpoolGap, int64, error) {
+	path := filepath.Join(dir, "gaps.log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("open gap journal: %w", err)
+	}
+	if err := securePath(path, 0o600); err != nil {
+		_ = f.Close()
+		return nil, nil, 0, fmt.Errorf("secure gap journal: %w", err)
+	}
+	gaps, validBytes, err := readGapJournal(f)
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, 0, err
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, 0, err
+	}
+	if stat.Size() != validBytes {
+		if err := f.Truncate(validBytes); err != nil {
+			_ = f.Close()
+			return nil, nil, 0, fmt.Errorf("truncate torn gap journal: %w", err)
+		}
+		if err := f.Sync(); err != nil {
+			_ = f.Close()
+			return nil, nil, 0, fmt.Errorf("sync repaired gap journal: %w", err)
+		}
+	}
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		_ = f.Close()
+		return nil, nil, 0, err
+	}
+	return f, gaps, validBytes, nil
+}
+
+func readGapJournal(f *os.File) ([]ports.SpoolGap, int64, error) {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, 0, err
+	}
+	var gaps []ports.SpoolGap
+	var offset int64
+	header := make([]byte, gapHeaderSize)
+	for {
+		n, err := io.ReadFull(f, header)
+		if errors.Is(err, io.EOF) {
+			return gaps, offset, nil
+		}
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return gaps, offset, nil // a crash before Sync: safe to truncate
+		}
+		if err != nil {
+			return nil, offset, fmt.Errorf("read gap journal header: %w", err)
+		}
+		if n != gapHeaderSize || binary.LittleEndian.Uint32(header[0:4]) != gapMagic {
+			return nil, offset, fmt.Errorf("gap journal corruption at offset %d", offset)
+		}
+		length := binary.LittleEndian.Uint32(header[4:8])
+		checksum := binary.LittleEndian.Uint32(header[8:12])
+		if length == 0 || length > maxGapBody {
+			return nil, offset, fmt.Errorf("invalid gap record length %d at offset %d", length, offset)
+		}
+		body := make([]byte, length)
+		if _, err := io.ReadFull(f, body); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return gaps, offset, nil
+			}
+			return nil, offset, fmt.Errorf("read gap journal body: %w", err)
+		}
+		if crc32.Checksum(body, castagnoli) != checksum {
+			return nil, offset, fmt.Errorf("gap journal checksum mismatch at offset %d", offset)
+		}
+		var gap ports.SpoolGap
+		if err := json.Unmarshal(body, &gap); err != nil {
+			return nil, offset, fmt.Errorf("decode gap at offset %d: %w", offset, err)
+		}
+		if err := gap.Validate(); err != nil {
+			return nil, offset, fmt.Errorf("validate gap at offset %d: %w", offset, err)
+		}
+		gaps = append(gaps, gap)
+		offset += int64(gapHeaderSize) + int64(length)
+	}
+}
+
+func (s *Spool) appendGapLocked(gap ports.SpoolGap) error {
+	if err := gap.Validate(); err != nil {
+		return err
+	}
+	body, err := json.Marshal(gap)
+	if err != nil {
+		return fmt.Errorf("encode spool gap: %w", err)
+	}
+	if len(body) > maxGapBody {
+		return errors.New("encoded spool gap exceeds journal format limit")
+	}
+	frame := make([]byte, gapHeaderSize+len(body))
+	binary.LittleEndian.PutUint32(frame[0:4], gapMagic)
+	binary.LittleEndian.PutUint32(frame[4:8], uint32(len(body)))
+	binary.LittleEndian.PutUint32(frame[8:12], crc32.Checksum(body, castagnoli))
+	copy(frame[gapHeaderSize:], body)
+	written, writeErr := s.gapFile.Write(frame)
+	if writeErr != nil || written != len(frame) {
+		if writeErr == nil {
+			writeErr = io.ErrShortWrite
+		}
+		truncateErr := s.gapFile.Truncate(s.gapBytes)
+		_, seekErr := s.gapFile.Seek(0, io.SeekEnd)
+		return errors.Join(fmt.Errorf("append spool gap: %w", writeErr), truncateErr, seekErr)
+	}
+	started := s.cfg.Now()
+	if err := s.gapFile.Sync(); err != nil {
+		return fmt.Errorf("sync spool gap: %w", err)
+	}
+	s.observeSyncLocked(started)
+	s.gaps = append(s.gaps, gap)
+	s.gapBytes += int64(len(frame))
+	return nil
+}

--- a/internal/infrastructure/spool/gaps.go
+++ b/internal/infrastructure/spool/gaps.go
@@ -1,6 +1,7 @@
 package spool
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -10,13 +11,15 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 const (
-	gapMagic      uint32 = 0x53594750 // SYGP
-	gapHeaderSize        = 12
-	maxGapBody           = 64 << 10
+	gapMagic         uint32 = 0x53594750 // SYGP
+	gapHeaderSize           = 12
+	maxGapBody              = 64 << 10
+	gapCoalesceBatch        = 256
 )
 
 func openGapJournal(dir string) (*os.File, []ports.SpoolGap, int64, error) {
@@ -108,18 +111,24 @@ func (s *Spool) appendGapLocked(gap ports.SpoolGap) error {
 	if err := gap.Validate(); err != nil {
 		return err
 	}
-	body, err := json.Marshal(gap)
+	if len(s.gaps) > 0 && mergeGap(&s.gaps[len(s.gaps)-1], gap) {
+		s.gapDirty = true
+		return s.flushGapJournalLocked()
+	}
+	frame, err := encodeGapFrame(gap)
 	if err != nil {
-		return fmt.Errorf("encode spool gap: %w", err)
+		return err
 	}
-	if len(body) > maxGapBody {
-		return errors.New("encoded spool gap exceeds journal format limit")
+	if s.gapBytes+int64(len(frame)) > s.gapJournalLimitLocked() {
+		s.gaps = compactGaps(s.gaps)
+		s.gapDirty = true
+		if err := s.flushGapJournalLocked(); err != nil {
+			return err
+		}
 	}
-	frame := make([]byte, gapHeaderSize+len(body))
-	binary.LittleEndian.PutUint32(frame[0:4], gapMagic)
-	binary.LittleEndian.PutUint32(frame[4:8], uint32(len(body)))
-	binary.LittleEndian.PutUint32(frame[8:12], crc32.Checksum(body, castagnoli))
-	copy(frame[gapHeaderSize:], body)
+	if s.gapBytes+int64(len(frame)) > s.gapJournalLimitLocked() {
+		return s.failLocked(fmt.Errorf("%w: used=%d max=%d required=%d", ErrGapJournalFull, s.gapBytes, s.gapJournalLimitLocked(), len(frame)))
+	}
 	written, writeErr := s.gapFile.Write(frame)
 	if writeErr != nil || written != len(frame) {
 		if writeErr == nil {
@@ -127,14 +136,188 @@ func (s *Spool) appendGapLocked(gap ports.SpoolGap) error {
 		}
 		truncateErr := s.gapFile.Truncate(s.gapBytes)
 		_, seekErr := s.gapFile.Seek(0, io.SeekEnd)
-		return errors.Join(fmt.Errorf("append spool gap: %w", writeErr), truncateErr, seekErr)
+		appendErr := errors.Join(fmt.Errorf("append spool gap: %w", writeErr), truncateErr, seekErr)
+		return s.failLocked(appendErr)
 	}
 	started := s.cfg.Now()
-	if err := s.gapFile.Sync(); err != nil {
-		return fmt.Errorf("sync spool gap: %w", err)
+	if err := s.syncFile(s.gapFile); err != nil {
+		return s.failLocked(fmt.Errorf("sync spool gap: %w", err))
 	}
 	s.observeSyncLocked(started)
 	s.gaps = append(s.gaps, gap)
 	s.gapBytes += int64(len(frame))
+	s.lastGapSync = s.cfg.Now().UTC()
 	return nil
+}
+
+func (s *Spool) recordP3LossLocked(reason ports.SpoolGapReason) error {
+	for index := len(s.gaps) - 1; index >= 0; index-- {
+		gap := &s.gaps[index]
+		if gap.Priority != fleetagent.PriorityP3 || gap.Epoch != s.state.CurrentEpoch ||
+			gap.Reason != reason || gap.KnownSequence {
+			continue
+		}
+		if gap.Count == ^uint64(0) {
+			return s.failLocked(errors.New("P3 coalesced gap count overflow"))
+		}
+		gap.Count++
+		s.gapDirty = true
+		s.gapPending++
+		now := s.cfg.Now().UTC()
+		if s.gapPending >= gapCoalesceBatch || (!s.lastGapSync.IsZero() && now.Sub(s.lastGapSync) >= s.cfg.BatchInterval) {
+			return s.flushGapJournalLocked()
+		}
+		return nil
+	}
+	return s.appendUnknownGapLocked(fleetagent.PriorityP3, s.state.CurrentEpoch, reason)
+}
+
+func encodeGapFrame(gap ports.SpoolGap) ([]byte, error) {
+	body, err := json.Marshal(gap)
+	if err != nil {
+		return nil, fmt.Errorf("encode spool gap: %w", err)
+	}
+	if len(body) > maxGapBody {
+		return nil, errors.New("encoded spool gap exceeds journal format limit")
+	}
+	frame := make([]byte, gapHeaderSize+len(body))
+	binary.LittleEndian.PutUint32(frame[0:4], gapMagic)
+	binary.LittleEndian.PutUint32(frame[4:8], uint32(len(body)))
+	binary.LittleEndian.PutUint32(frame[8:12], crc32.Checksum(body, castagnoli))
+	copy(frame[gapHeaderSize:], body)
+	return frame, nil
+}
+
+func (s *Spool) flushGapJournalLocked() error {
+	if !s.gapDirty {
+		return nil
+	}
+	if s.gapFile == nil {
+		return s.failLocked(errors.New("gap journal is unavailable"))
+	}
+	started := s.cfg.Now()
+	var snapshot bytes.Buffer
+	for _, gap := range s.gaps {
+		frame, err := encodeGapFrame(gap)
+		if err != nil {
+			return err
+		}
+		if _, err := snapshot.Write(frame); err != nil {
+			return err
+		}
+	}
+	if int64(snapshot.Len()) > s.gapJournalLimitLocked() {
+		return s.failLocked(fmt.Errorf("%w: compacted=%d max=%d", ErrGapJournalFull, snapshot.Len(), s.gapJournalLimitLocked()))
+	}
+	path := filepath.Join(s.cfg.Dir, "gaps.log")
+	tmp := path + ".tmp"
+	if err := writeExclusiveSyncedFile(tmp, snapshot.Bytes(), 0o600); err != nil {
+		return s.failLocked(fmt.Errorf("write compacted gap journal: %w", err))
+	}
+	if err := s.gapFile.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return s.failLocked(fmt.Errorf("close old gap journal: %w", err))
+	}
+	s.gapFile = nil
+	if err := replaceFile(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		_ = s.reopenGapJournalLocked(path)
+		return s.failLocked(fmt.Errorf("install compacted gap journal: %w", err))
+	}
+	if err := syncDirectory(s.cfg.Dir); err != nil {
+		_ = s.reopenGapJournalLocked(path)
+		return s.failLocked(fmt.Errorf("sync compacted gap journal: %w", err))
+	}
+	if err := s.reopenGapJournalLocked(path); err != nil {
+		return s.failLocked(err)
+	}
+	s.gapBytes = int64(snapshot.Len())
+	s.gapDirty = false
+	s.gapPending = 0
+	s.lastGapSync = s.cfg.Now().UTC()
+	s.observeSyncLocked(started)
+	return nil
+}
+
+func (s *Spool) gapJournalLimitLocked() int64 { return s.cfg.MaxGapBytes / 2 }
+
+func (s *Spool) reopenGapJournalLocked(path string) error {
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("reopen gap journal: %w", err)
+	}
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("seek reopened gap journal: %w", err)
+	}
+	s.gapFile = f
+	return nil
+}
+
+func writeExclusiveSyncedFile(path string, data []byte, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if errors.Is(err, os.ErrExist) {
+		if removeErr := os.Remove(path); removeErr != nil {
+			return removeErr
+		}
+		f, err = os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	}
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	return f.Close()
+}
+
+func compactGaps(in []ports.SpoolGap) []ports.SpoolGap {
+	out := make([]ports.SpoolGap, 0, len(in))
+	for _, gap := range in {
+		merged := false
+		for index := len(out) - 1; index >= 0; index-- {
+			if mergeGap(&out[index], gap) {
+				merged = true
+				break
+			}
+		}
+		if !merged {
+			out = append(out, gap)
+		}
+	}
+	return out
+}
+
+func mergeGap(current *ports.SpoolGap, next ports.SpoolGap) bool {
+	if current.Priority != next.Priority || current.Epoch != next.Epoch || current.Reason != next.Reason || current.KnownSequence != next.KnownSequence {
+		return false
+	}
+	if !current.KnownSequence {
+		if ^uint64(0)-current.Count < next.Count {
+			return false
+		}
+		current.Count += next.Count
+		return true
+	}
+	if next.FromSequence > current.ToSequence && (current.ToSequence == ^uint64(0) || next.FromSequence != current.ToSequence+1) {
+		return false
+	}
+	if current.FromSequence > next.ToSequence && (next.ToSequence == ^uint64(0) || current.FromSequence != next.ToSequence+1) {
+		return false
+	}
+	if next.FromSequence < current.FromSequence {
+		current.FromSequence = next.FromSequence
+	}
+	if next.ToSequence > current.ToSequence {
+		current.ToSequence = next.ToSequence
+	}
+	current.Count = current.ToSequence - current.FromSequence + 1
+	return true
 }

--- a/internal/infrastructure/spool/lock_unix.go
+++ b/internal/infrastructure/spool/lock_unix.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package spool
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func acquireDirectoryLock(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, ErrLocked
+		}
+		return nil, err
+	}
+	return f, nil
+}
+
+func releaseDirectoryLock(f *os.File) error {
+	unlockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	closeErr := f.Close()
+	return errors.Join(unlockErr, closeErr)
+}
+
+func replaceFilePlatform(from, to string) error { return os.Rename(from, to) }
+
+func syncDirectory(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}

--- a/internal/infrastructure/spool/lock_windows.go
+++ b/internal/infrastructure/spool/lock_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package spool
+
+import (
+	"errors"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func acquireDirectoryLock(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	var overlapped windows.Overlapped
+	err = windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped)
+	if err != nil {
+		_ = f.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			return nil, ErrLocked
+		}
+		return nil, err
+	}
+	return f, nil
+}
+
+func releaseDirectoryLock(f *os.File) error {
+	var overlapped windows.Overlapped
+	unlockErr := windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &overlapped)
+	closeErr := f.Close()
+	return errors.Join(unlockErr, closeErr)
+}
+
+func replaceFilePlatform(from, to string) error {
+	fromPtr, err := syscall.UTF16PtrFromString(from)
+	if err != nil {
+		return err
+	}
+	toPtr, err := syscall.UTF16PtrFromString(to)
+	if err != nil {
+		return err
+	}
+	if err := windows.MoveFileEx(fromPtr, toPtr, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Windows does not expose a portable directory-fsync primitive. MoveFileEx
+// with WRITE_THROUGH above supplies the required rename durability.
+func syncDirectory(string) error { return nil }

--- a/internal/infrastructure/spool/metrics.go
+++ b/internal/infrastructure/spool/metrics.go
@@ -1,0 +1,91 @@
+package spool
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Collector exports spool health without registering globals. The agent
+// composition root may register it on a private registry/listener.
+type Collector struct {
+	spool ports.TelemetrySpool
+	now   func() time.Time
+
+	depth       *prometheus.Desc
+	bytes       *prometheus.Desc
+	oldestAge   *prometheus.Desc
+	nextSeq     *prometheus.Desc
+	highestACK  *prometheus.Desc
+	gaps        *prometheus.Desc
+	gapBytes    *prometheus.Desc
+	evicted     *prometheus.Desc
+	corruptions *prometheus.Desc
+	fsyncs      *prometheus.Desc
+	fsyncTime   *prometheus.Desc
+}
+
+// NewCollector constructs an unregistered collector. A nil spool is rejected
+// at collection time as an invalid metric rather than panicking a process.
+func NewCollector(source ports.TelemetrySpool) *Collector {
+	labels := []string{"priority"}
+	return &Collector{
+		spool: source, now: time.Now,
+		depth:       prometheus.NewDesc("synapse_agent_spool_records", "Unacknowledged WAL records by delivery priority.", labels, nil),
+		bytes:       prometheus.NewDesc("synapse_agent_spool_record_bytes", "Logical unacknowledged WAL bytes by delivery priority.", labels, nil),
+		oldestAge:   prometheus.NewDesc("synapse_agent_spool_oldest_unacked_age_seconds", "Age of the oldest unacknowledged record by delivery priority.", labels, nil),
+		nextSeq:     prometheus.NewDesc("synapse_agent_spool_next_sequence", "Next sequence assigned in the current incarnation by delivery priority.", labels, nil),
+		highestACK:  prometheus.NewDesc("synapse_agent_spool_highest_acked_sequence", "Highest contiguous ACK in the current incarnation by delivery priority.", labels, nil),
+		gaps:        prometheus.NewDesc("synapse_agent_spool_gap_records", "Durable loss-evidence records retained locally.", nil, nil),
+		gapBytes:    prometheus.NewDesc("synapse_agent_spool_gap_bytes", "Bytes occupied by the durable gap journal.", nil, nil),
+		evicted:     prometheus.NewDesc("synapse_agent_spool_evicted_records_total", "P3 WAL records evicted after durable gap evidence was committed.", nil, nil),
+		corruptions: prometheus.NewDesc("synapse_agent_spool_corruption_events_total", "Corrupt or torn WAL intervals recovered in this process.", nil, nil),
+		fsyncs:      prometheus.NewDesc("synapse_agent_spool_fsync_total", "Successful WAL and gap fsync operations in this process.", nil, nil),
+		fsyncTime:   prometheus.NewDesc("synapse_agent_spool_fsync_duration_seconds_total", "Cumulative WAL and gap fsync latency in this process.", nil, nil),
+	}
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	for _, desc := range []*prometheus.Desc{c.depth, c.bytes, c.oldestAge, c.nextSeq, c.highestACK, c.gaps, c.gapBytes, c.evicted, c.corruptions, c.fsyncs, c.fsyncTime} {
+		ch <- desc
+	}
+}
+
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	if c.spool == nil {
+		ch <- prometheus.NewInvalidMetric(c.depth, context.Canceled)
+		return
+	}
+	stats, err := c.spool.Stats(context.Background())
+	if err != nil {
+		ch <- prometheus.NewInvalidMetric(c.depth, err)
+		return
+	}
+	now := c.now()
+	for _, lane := range stats.Priorities {
+		priority := lane.Priority.String()
+		age := float64(0)
+		if !lane.OldestUnacked.IsZero() {
+			age = now.Sub(lane.OldestUnacked).Seconds()
+			if age < 0 {
+				age = 0
+			}
+		}
+		ch <- prometheus.MustNewConstMetric(c.depth, prometheus.GaugeValue, float64(lane.Records), priority)
+		ch <- prometheus.MustNewConstMetric(c.bytes, prometheus.GaugeValue, float64(lane.Bytes), priority)
+		ch <- prometheus.MustNewConstMetric(c.oldestAge, prometheus.GaugeValue, age, priority)
+		ch <- prometheus.MustNewConstMetric(c.nextSeq, prometheus.GaugeValue, float64(lane.NextSequence), priority)
+		ch <- prometheus.MustNewConstMetric(c.highestACK, prometheus.GaugeValue, float64(lane.HighestACKed), priority)
+	}
+	ch <- prometheus.MustNewConstMetric(c.gaps, prometheus.GaugeValue, float64(stats.GapRecords))
+	ch <- prometheus.MustNewConstMetric(c.gapBytes, prometheus.GaugeValue, float64(stats.GapBytes))
+	ch <- prometheus.MustNewConstMetric(c.evicted, prometheus.CounterValue, float64(stats.EvictedRecords))
+	ch <- prometheus.MustNewConstMetric(c.corruptions, prometheus.CounterValue, float64(stats.CorruptionEvents))
+	ch <- prometheus.MustNewConstMetric(c.fsyncs, prometheus.CounterValue, float64(stats.FsyncCount))
+	ch <- prometheus.MustNewConstMetric(c.fsyncTime, prometheus.CounterValue, stats.FsyncTotal.Seconds())
+}
+
+var _ prometheus.Collector = (*Collector)(nil)

--- a/internal/infrastructure/spool/metrics_test.go
+++ b/internal/infrastructure/spool/metrics_test.go
@@ -1,0 +1,82 @@
+package spool
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestCollectorExportsDepthSequenceAndOldestAge(t *testing.T) {
+	s := mustOpen(t, testConfig(t))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP1, "det", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "raw", 32))
+	collector := NewCollector(s)
+	collector.now = func() time.Time { return testNow.Add(12 * time.Second) }
+	registry := prometheus.NewPedanticRegistry()
+	if err := registry.Register(collector); err != nil {
+		t.Fatal(err)
+	}
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metrics) == 0 {
+		t.Fatal("collector exported no metrics")
+	}
+	want := `
+# HELP synapse_agent_spool_oldest_unacked_age_seconds Age of the oldest unacknowledged record by delivery priority.
+# TYPE synapse_agent_spool_oldest_unacked_age_seconds gauge
+synapse_agent_spool_oldest_unacked_age_seconds{priority="P0"} 0
+synapse_agent_spool_oldest_unacked_age_seconds{priority="P1"} 12
+synapse_agent_spool_oldest_unacked_age_seconds{priority="P2"} 0
+synapse_agent_spool_oldest_unacked_age_seconds{priority="P3"} 12
+# HELP synapse_agent_spool_records Unacknowledged WAL records by delivery priority.
+# TYPE synapse_agent_spool_records gauge
+synapse_agent_spool_records{priority="P0"} 0
+synapse_agent_spool_records{priority="P1"} 1
+synapse_agent_spool_records{priority="P2"} 0
+synapse_agent_spool_records{priority="P3"} 1
+`
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(want),
+		"synapse_agent_spool_oldest_unacked_age_seconds", "synapse_agent_spool_records"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCollectorReturnsInvalidMetricWhenSourceFails(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	if err := registry.Register(NewCollector(failingStatsSpool{})); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.Gather(); err == nil {
+		t.Fatal("stats failure did not make scrape fail")
+	}
+}
+
+type failingStatsSpool struct{}
+
+func (failingStatsSpool) Enqueue(context.Context, ports.SpoolItem) (fleetagent.StreamPosition, error) {
+	return fleetagent.StreamPosition{}, errors.New("not implemented")
+}
+func (failingStatsSpool) Peek(context.Context, ports.PeekSpoolRequest) ([]ports.SpoolRecord, error) {
+	return nil, errors.New("not implemented")
+}
+func (failingStatsSpool) Ack(context.Context, ports.SpoolACK) (ports.SpoolACKResult, error) {
+	return ports.SpoolACKResult{}, errors.New("not implemented")
+}
+func (failingStatsSpool) Flush(context.Context) error { return errors.New("not implemented") }
+func (failingStatsSpool) Gaps(context.Context) ([]ports.SpoolGap, error) {
+	return nil, errors.New("not implemented")
+}
+func (failingStatsSpool) Stats(context.Context) (ports.SpoolStats, error) {
+	return ports.SpoolStats{}, errors.New("disk unavailable")
+}
+func (failingStatsSpool) Close() error { return nil }

--- a/internal/infrastructure/spool/permissions.go
+++ b/internal/infrastructure/spool/permissions.go
@@ -1,0 +1,27 @@
+package spool
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// securePath tightens pre-existing spool paths as well as newly-created ones.
+// Windows FileMode does not model ACLs, so Unix-bit verification is not claimed
+// there; the package/service-owned state-directory ACL is authoritative.
+func securePath(path string, mode os.FileMode) error {
+	if err := os.Chmod(path, mode); err != nil {
+		return err
+	}
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm() != mode.Perm() {
+		return fmt.Errorf("%s mode is %o, want %o", path, info.Mode().Perm(), mode.Perm())
+	}
+	return nil
+}

--- a/internal/infrastructure/spool/permissions.go
+++ b/internal/infrastructure/spool/permissions.go
@@ -10,15 +10,25 @@ import (
 // Windows FileMode does not model ACLs, so Unix-bit verification is not claimed
 // there; the package/service-owned state-directory ACL is authoritative.
 func securePath(path string, mode os.FileMode) error {
+	before, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if before.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refuse symlink spool path %s", path)
+	}
 	if err := os.Chmod(path, mode); err != nil {
 		return err
 	}
 	if runtime.GOOS == "windows" {
 		return nil
 	}
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refuse symlink spool path %s", path)
 	}
 	if info.Mode().Perm() != mode.Perm() {
 		return fmt.Errorf("%s mode is %o, want %o", path, info.Mode().Perm(), mode.Perm())

--- a/internal/infrastructure/spool/quota.go
+++ b/internal/infrastructure/spool/quota.go
@@ -1,0 +1,155 @@
+package spool
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func (s *Spool) ensureCapacityLocked(required int64, incoming fleetagent.DeliveryPriority, eventID shared.ID) error {
+	if required > s.cfg.MaxBytes {
+		return s.saturatedLocked(required, incoming, eventID)
+	}
+	if _, err := s.removeEmptySegmentsLocked(); err != nil {
+		return err
+	}
+	if s.totalBytes+required <= s.cfg.MaxBytes {
+		s.lastRejected[incoming] = ""
+		return nil
+	}
+	segments := append([]*segment(nil), s.segments...)
+	sort.SliceStable(segments, func(i, j int) bool {
+		if segments[i].epoch != segments[j].epoch {
+			return segments[i].epoch < segments[j].epoch
+		}
+		return segments[i].start < segments[j].start
+	})
+	for _, seg := range segments {
+		if seg.priority != fleetagent.PriorityP3 || seg.live == 0 {
+			continue
+		}
+		refs := s.segmentRefsLocked(seg)
+		if err := s.recordEvictionGapsLocked(refs); err != nil {
+			return fmt.Errorf("persist P3 eviction evidence: %w", err)
+		}
+		s.evictedRecords += uint64(len(refs))
+		if err := s.deleteSegmentLocked(seg); err != nil {
+			return err
+		}
+		if s.totalBytes+required <= s.cfg.MaxBytes {
+			s.lastRejected[incoming] = ""
+			return nil
+		}
+	}
+	return s.saturatedLocked(required, incoming, eventID)
+}
+
+func (s *Spool) saturatedLocked(required int64, incoming fleetagent.DeliveryPriority, eventID shared.ID) error {
+	reason := ports.SpoolGapQuotaBackpressure
+	if incoming == fleetagent.PriorityP3 {
+		reason = ports.SpoolGapQuotaEviction
+	}
+	if s.lastRejected[incoming] != eventID {
+		if err := s.appendUnknownGapLocked(incoming, s.state.CurrentEpoch, reason); err != nil {
+			return fmt.Errorf("record quota saturation evidence: %w", err)
+		}
+		s.lastRejected[incoming] = eventID
+	}
+	return &SaturatedError{UsedBytes: s.totalBytes, MaxBytes: s.cfg.MaxBytes, RequiredBytes: required}
+}
+
+func (s *Spool) recordEvictionGapsLocked(refs []*recordRef) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].header.Epoch != refs[j].header.Epoch {
+			return refs[i].header.Epoch < refs[j].header.Epoch
+		}
+		return refs[i].header.Sequence < refs[j].header.Sequence
+	})
+	start := refs[0].header.Sequence
+	end := start
+	epoch := refs[0].header.Epoch
+	flush := func() error {
+		return s.appendKnownGapLocked(fleetagent.PriorityP3, epoch, start, end, ports.SpoolGapQuotaEviction)
+	}
+	for _, ref := range refs[1:] {
+		if ref.header.Epoch == epoch && ref.header.Sequence == end+1 {
+			end = ref.header.Sequence
+			continue
+		}
+		if err := flush(); err != nil {
+			return err
+		}
+		epoch, start, end = ref.header.Epoch, ref.header.Sequence, ref.header.Sequence
+	}
+	return flush()
+}
+
+func (s *Spool) segmentRefsLocked(target *segment) []*recordRef {
+	var result []*recordRef
+	for _, ref := range s.records[target.priority] {
+		if ref.segment == target {
+			result = append(result, ref)
+		}
+	}
+	return result
+}
+
+func (s *Spool) deleteSegmentLocked(target *segment) error {
+	if writer := s.writers[target.priority]; writer == target {
+		if err := s.syncSegmentLocked(target); err != nil {
+			return err
+		}
+		if target.file != nil {
+			if err := target.file.Close(); err != nil {
+				return err
+			}
+			target.file = nil
+		}
+		s.writers[target.priority] = nil
+	}
+	keptRefs := s.records[target.priority][:0]
+	for _, ref := range s.records[target.priority] {
+		if ref.segment != target {
+			keptRefs = append(keptRefs, ref)
+		}
+	}
+	s.records[target.priority] = keptRefs
+	keptSegments := s.segments[:0]
+	for _, seg := range s.segments {
+		if seg != target {
+			keptSegments = append(keptSegments, seg)
+		}
+	}
+	s.segments = keptSegments
+	if err := os.Remove(target.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("delete WAL segment: %w", err)
+	}
+	s.totalBytes -= target.size
+	if s.totalBytes < 0 {
+		s.totalBytes = 0
+	}
+	return syncDirectory(s.cfg.Dir)
+}
+
+func (s *Spool) removeEmptySegmentsLocked() (int64, error) {
+	var reclaimed int64
+	for _, seg := range append([]*segment(nil), s.segments...) {
+		if seg.live != 0 {
+			continue
+		}
+		size := seg.size
+		if err := s.deleteSegmentLocked(seg); err != nil {
+			return reclaimed, err
+		}
+		reclaimed += size
+	}
+	return reclaimed, nil
+}

--- a/internal/infrastructure/spool/quota.go
+++ b/internal/infrastructure/spool/quota.go
@@ -11,15 +11,15 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-func (s *Spool) ensureCapacityLocked(required int64, incoming fleetagent.DeliveryPriority, eventID shared.ID) error {
-	if required > s.cfg.MaxBytes {
-		return s.saturatedLocked(required, incoming, eventID)
+func (s *Spool) ensureCapacityLocked(required int64, incoming fleetagent.DeliveryPriority) error {
+	if required > s.cfg.SegmentBytes || required > s.walMaxBytesLocked() {
+		return fmt.Errorf("%w: encoded WAL frame is %d bytes, maximum permanent capacity is %d",
+			shared.ErrValidation, required, min(s.cfg.SegmentBytes, s.walMaxBytesLocked()))
 	}
 	if _, err := s.removeEmptySegmentsLocked(); err != nil {
 		return err
 	}
-	if s.totalBytes+required <= s.cfg.MaxBytes {
-		s.lastRejected[incoming] = ""
+	if s.totalBytes+required <= s.walMaxBytesLocked() {
 		return nil
 	}
 	segments := append([]*segment(nil), s.segments...)
@@ -41,27 +41,28 @@ func (s *Spool) ensureCapacityLocked(required int64, incoming fleetagent.Deliver
 		if err := s.deleteSegmentLocked(seg); err != nil {
 			return err
 		}
-		if s.totalBytes+required <= s.cfg.MaxBytes {
-			s.lastRejected[incoming] = ""
+		if s.totalBytes+required <= s.walMaxBytesLocked() {
 			return nil
 		}
 	}
-	return s.saturatedLocked(required, incoming, eventID)
+	return s.saturatedLocked(required, incoming)
 }
 
-func (s *Spool) saturatedLocked(required int64, incoming fleetagent.DeliveryPriority, eventID shared.ID) error {
-	reason := ports.SpoolGapQuotaBackpressure
+func (s *Spool) saturatedLocked(required int64, incoming fleetagent.DeliveryPriority) error {
+	// P0..P2 apply backpressure and retain the item at the producer, so no loss
+	// gap exists yet. P3 is explicitly shed by its adapter and needs one durable,
+	// coalesced record for the ongoing saturation interval.
 	if incoming == fleetagent.PriorityP3 {
-		reason = ports.SpoolGapQuotaEviction
-	}
-	if s.lastRejected[incoming] != eventID {
-		if err := s.appendUnknownGapLocked(incoming, s.state.CurrentEpoch, reason); err != nil {
+		if err := s.recordP3LossLocked(ports.SpoolGapQuotaEviction); err != nil {
 			return fmt.Errorf("record quota saturation evidence: %w", err)
 		}
-		s.lastRejected[incoming] = eventID
 	}
-	return &SaturatedError{UsedBytes: s.totalBytes, MaxBytes: s.cfg.MaxBytes, RequiredBytes: required}
+	return &SaturatedError{UsedBytes: s.usedBytesLocked(), MaxBytes: s.cfg.MaxBytes, RequiredBytes: required}
 }
+
+func (s *Spool) walMaxBytesLocked() int64 { return s.cfg.MaxBytes - s.cfg.MaxGapBytes }
+
+func (s *Spool) usedBytesLocked() int64 { return s.totalBytes + s.gapBytes }
 
 func (s *Spool) recordEvictionGapsLocked(refs []*recordRef) error {
 	if len(refs) == 0 {

--- a/internal/infrastructure/spool/quota_test.go
+++ b/internal/infrastructure/spool/quota_test.go
@@ -1,0 +1,240 @@
+package spool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func quotaConfig(t *testing.T) Config {
+	cfg := testConfig(t)
+	cfg.MaxBytes = 1100
+	cfg.SegmentBytes = 600
+	cfg.MaxRecordBytes = 300
+	cfg.Sync[fleetagent.PriorityP3] = SyncAlways
+	return cfg
+}
+
+func TestQuotaEvictsP3BeforeNeverShedLanes(t *testing.T) {
+	cfg := quotaConfig(t)
+	s := mustOpen(t, cfg)
+	p3a := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "background-a", 220))
+	p3b := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "background-b", 220))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "critical-a", 220))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "critical-b", 220))
+
+	records := mustPeek(t, s)
+	ids := map[string]bool{}
+	for _, record := range records {
+		ids[record.EventID.String()] = true
+	}
+	if !ids["critical-a"] || !ids["critical-b"] {
+		t.Fatalf("never-shed records evicted: %v", ids)
+	}
+	if ids["background-a"] && ids["background-b"] {
+		t.Fatalf("quota did not evict P3: %v", ids)
+	}
+	gaps, _ := s.Gaps(context.Background())
+	if !ids["background-a"] {
+		assertKnownGap(t, gaps, ports.SpoolGapQuotaEviction, p3a.Epoch, p3a.Sequence, p3a.Sequence)
+	}
+	if !ids["background-b"] {
+		assertKnownGap(t, gaps, ports.SpoolGapQuotaEviction, p3b.Epoch, p3b.Sequence, p3b.Sequence)
+	}
+	stats, _ := s.Stats(context.Background())
+	if stats.TotalBytes > cfg.MaxBytes || stats.EvictedRecords == 0 {
+		t.Fatalf("quota stats = %#v", stats)
+	}
+}
+
+func TestNeverShedSaturationBackpressuresAndPersistsGap(t *testing.T) {
+	cfg := quotaConfig(t)
+	s := mustOpen(t, cfg)
+	for n := 0; ; n++ {
+		_, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP2, fmt.Sprintf("critical-%d", n), 220))
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, ErrSaturated) {
+			t.Fatalf("enqueue error = %v", err)
+		}
+		var detail *SaturatedError
+		if !errors.As(err, &detail) || detail.MaxBytes != cfg.MaxBytes || detail.RequiredBytes == 0 {
+			t.Fatalf("saturation detail = %#v", detail)
+		}
+		break
+	}
+	gaps, err := s.Gaps(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, gap := range gaps {
+		if gap.Priority == fleetagent.PriorityP2 && gap.Reason == ports.SpoolGapQuotaBackpressure && !gap.KnownSequence {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no durable P2 backpressure gap: %#v", gaps)
+	}
+}
+
+func TestRepeatedBackpressureForSameEventDoesNotFloodGapJournal(t *testing.T) {
+	cfg := quotaConfig(t)
+	s := mustOpen(t, cfg)
+	for n := 0; ; n++ {
+		_, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP2, fmt.Sprintf("fill-%d", n), 220))
+		if errors.Is(err, ErrSaturated) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	item := testItem(fleetagent.PriorityP2, "same-retry", 220)
+	before := len(mustGaps(t, s))
+	for attempt := 0; attempt < 5; attempt++ {
+		if _, err := s.Enqueue(context.Background(), item); !errors.Is(err, ErrSaturated) {
+			t.Fatalf("attempt %d error = %v", attempt, err)
+		}
+	}
+	after := len(mustGaps(t, s))
+	if after != before+1 {
+		t.Fatalf("same-event retry added %d gaps, want 1", after-before)
+	}
+}
+
+func TestP3SaturationNeverDeletesHigherPriority(t *testing.T) {
+	cfg := quotaConfig(t)
+	cfg.MaxBytes = 1500
+	s := mustOpen(t, cfg)
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP0, "health", 220))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP1, "detection", 220))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "critical", 220))
+	for n := 0; n < 10; n++ {
+		_, _ = s.Enqueue(context.Background(), testItem(fleetagent.PriorityP3, fmt.Sprintf("raw-%d", n), 220))
+	}
+	ids := map[string]bool{}
+	for _, record := range mustPeek(t, s) {
+		ids[record.EventID.String()] = true
+	}
+	for _, id := range []string{"health", "detection", "critical"} {
+		if !ids[id] {
+			t.Fatalf("%s was shed while accepting P3: %v", id, ids)
+		}
+	}
+}
+
+func TestEvictionEvidenceSurvivesRestart(t *testing.T) {
+	cfg := quotaConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	positions := make(map[string]fleetagent.StreamPosition)
+	for n := 0; n < 8; n++ {
+		id := fmt.Sprintf("raw-%d", n)
+		position, enqueueErr := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP3, id, 220))
+		if enqueueErr == nil {
+			positions[id] = position
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Close()
+	present := make(map[uint64]bool)
+	for _, record := range mustPeek(t, recovered) {
+		present[record.Position.Sequence] = true
+	}
+	covered := make(map[uint64]bool)
+	for _, gap := range mustGaps(t, recovered) {
+		if gap.Priority != fleetagent.PriorityP3 || !gap.KnownSequence {
+			continue
+		}
+		for sequence := gap.FromSequence; sequence <= gap.ToSequence; sequence++ {
+			covered[sequence] = true
+		}
+	}
+	for id, position := range positions {
+		if !present[position.Sequence] && !covered[position.Sequence] {
+			t.Errorf("accepted %s at sequence %d is neither recoverable nor a durable gap", id, position.Sequence)
+		}
+	}
+}
+
+// This deterministic property exercise crosses rotations, P3 evictions,
+// never-shed backpressure, and restart. The invariant is the delivery contract:
+// every successful enqueue is still readable or is covered by durable gap evidence.
+func TestPropertyNoAcceptedRecordSilentlyDisappears(t *testing.T) {
+	cfg := quotaConfig(t)
+	cfg.MaxBytes = 5000
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type accepted struct {
+		id       string
+		position fleetagent.StreamPosition
+	}
+	var all []accepted
+	for n := 0; n < 120; n++ {
+		priority := fleetagent.PriorityP3
+		if n%11 == 0 {
+			priority = fleetagent.PriorityP2
+		}
+		id := fmt.Sprintf("event-%03d", n)
+		position, enqueueErr := s.Enqueue(context.Background(), testItem(priority, id, 180+(n%5)*9))
+		if enqueueErr == nil {
+			all = append(all, accepted{id, position})
+			continue
+		}
+		if !errors.Is(enqueueErr, ErrSaturated) {
+			t.Fatalf("enqueue %d: %v", n, enqueueErr)
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	present := make(map[string]bool)
+	for _, record := range mustPeek(t, s) {
+		present[fmt.Sprintf("%d:%d:%d", record.Position.Priority, record.Position.Epoch, record.Position.Sequence)] = true
+	}
+	gapped := make(map[string]bool)
+	for _, gap := range mustGaps(t, s) {
+		if !gap.KnownSequence {
+			continue
+		}
+		for sequence := gap.FromSequence; sequence <= gap.ToSequence; sequence++ {
+			gapped[fmt.Sprintf("%d:%d:%d", gap.Priority, gap.Epoch, sequence)] = true
+		}
+	}
+	for _, event := range all {
+		key := fmt.Sprintf("%d:%d:%d", event.position.Priority, event.position.Epoch, event.position.Sequence)
+		if !present[key] && !gapped[key] {
+			t.Errorf("accepted event %s (%s) silently disappeared", event.id, key)
+		}
+	}
+}
+
+func mustGaps(t *testing.T, s *Spool) []ports.SpoolGap {
+	t.Helper()
+	gaps, err := s.Gaps(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return gaps
+}

--- a/internal/infrastructure/spool/quota_test.go
+++ b/internal/infrastructure/spool/quota_test.go
@@ -7,14 +7,16 @@ import (
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 func quotaConfig(t *testing.T) Config {
 	cfg := testConfig(t)
-	cfg.MaxBytes = 1100
-	cfg.SegmentBytes = 600
-	cfg.MaxRecordBytes = 300
+	cfg.MaxBytes = 6 << 10
+	cfg.MaxGapBytes = 4 << 10
+	cfg.SegmentBytes = 1200
+	cfg.MaxRecordBytes = 600
 	cfg.Sync[fleetagent.PriorityP3] = SyncAlways
 	return cfg
 }
@@ -22,10 +24,10 @@ func quotaConfig(t *testing.T) Config {
 func TestQuotaEvictsP3BeforeNeverShedLanes(t *testing.T) {
 	cfg := quotaConfig(t)
 	s := mustOpen(t, cfg)
-	p3a := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "background-a", 220))
-	p3b := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "background-b", 220))
-	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "critical-a", 220))
-	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "critical-b", 220))
+	p3a := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "background-a", 500))
+	p3b := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "background-b", 500))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "critical-a", 500))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "critical-b", 500))
 
 	records := mustPeek(t, s)
 	ids := map[string]bool{}
@@ -40,10 +42,10 @@ func TestQuotaEvictsP3BeforeNeverShedLanes(t *testing.T) {
 	}
 	gaps, _ := s.Gaps(context.Background())
 	if !ids["background-a"] {
-		assertKnownGap(t, gaps, ports.SpoolGapQuotaEviction, p3a.Epoch, p3a.Sequence, p3a.Sequence)
+		assertGapCovers(t, gaps, ports.SpoolGapQuotaEviction, p3a.Epoch, p3a.Sequence)
 	}
 	if !ids["background-b"] {
-		assertKnownGap(t, gaps, ports.SpoolGapQuotaEviction, p3b.Epoch, p3b.Sequence, p3b.Sequence)
+		assertGapCovers(t, gaps, ports.SpoolGapQuotaEviction, p3b.Epoch, p3b.Sequence)
 	}
 	stats, _ := s.Stats(context.Background())
 	if stats.TotalBytes > cfg.MaxBytes || stats.EvictedRecords == 0 {
@@ -51,7 +53,7 @@ func TestQuotaEvictsP3BeforeNeverShedLanes(t *testing.T) {
 	}
 }
 
-func TestNeverShedSaturationBackpressuresAndPersistsGap(t *testing.T) {
+func TestNeverShedSaturationBackpressuresWithoutClaimingLoss(t *testing.T) {
 	cfg := quotaConfig(t)
 	s := mustOpen(t, cfg)
 	for n := 0; ; n++ {
@@ -72,18 +74,14 @@ func TestNeverShedSaturationBackpressuresAndPersistsGap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	found := false
 	for _, gap := range gaps {
 		if gap.Priority == fleetagent.PriorityP2 && gap.Reason == ports.SpoolGapQuotaBackpressure && !gap.KnownSequence {
-			found = true
+			t.Fatalf("backpressured item was falsely reported lost: %#v", gap)
 		}
-	}
-	if !found {
-		t.Fatalf("no durable P2 backpressure gap: %#v", gaps)
 	}
 }
 
-func TestRepeatedBackpressureForSameEventDoesNotFloodGapJournal(t *testing.T) {
+func TestRepeatedBackpressureDoesNotCreateLossGaps(t *testing.T) {
 	cfg := quotaConfig(t)
 	s := mustOpen(t, cfg)
 	for n := 0; ; n++ {
@@ -103,14 +101,78 @@ func TestRepeatedBackpressureForSameEventDoesNotFloodGapJournal(t *testing.T) {
 		}
 	}
 	after := len(mustGaps(t, s))
-	if after != before+1 {
-		t.Fatalf("same-event retry added %d gaps, want 1", after-before)
+	if after != before {
+		t.Fatalf("retryable backpressure added %d false loss gaps", after-before)
+	}
+}
+
+func TestFrameLargerThanPermanentCapacityIsNotRetryable(t *testing.T) {
+	s := mustOpen(t, quotaConfig(t))
+	s.mu.Lock()
+	err := s.ensureCapacityLocked(s.walMaxBytesLocked()+1, fleetagent.PriorityP2)
+	s.mu.Unlock()
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("oversized frame error = %v, want validation error", err)
+	}
+	if errors.Is(err, ErrSaturated) {
+		t.Fatalf("oversized frame was classified as retryable saturation: %v", err)
+	}
+}
+
+func TestDistinctP3SaturationCoalescesWithinGapBudget(t *testing.T) {
+	cfg := quotaConfig(t)
+	s := mustOpen(t, cfg)
+	for n := 0; ; n++ {
+		_, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP2, fmt.Sprintf("fill-%d", n), 500))
+		if errors.Is(err, ErrSaturated) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	before, err := s.Stats(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	const dropped = 1000
+	for n := 0; n < dropped; n++ {
+		_, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP3, fmt.Sprintf("raw-drop-%d", n), 600))
+		if !errors.Is(err, ErrSaturated) {
+			t.Fatalf("drop %d error = %v", n, err)
+		}
+	}
+	gaps := mustGaps(t, s)
+	if len(gaps) != 1 || gaps[0].Priority != fleetagent.PriorityP3 || gaps[0].KnownSequence || gaps[0].Count != dropped {
+		t.Fatalf("coalesced gaps = %#v", gaps)
+	}
+	stats, err := s.Stats(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.TotalBytes > cfg.MaxBytes || stats.GapBytes > cfg.MaxGapBytes/2 {
+		t.Fatalf("bounded stats = %#v, quota=%d gap_budget=%d", stats, cfg.MaxBytes, cfg.MaxGapBytes)
+	}
+	if delta := stats.FsyncCount - before.FsyncCount; delta > 5 {
+		t.Fatalf("P3 saturation caused %d fsyncs for %d drops", delta, dropped)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Close()
+	recoveredGaps := mustGaps(t, recovered)
+	if len(recoveredGaps) != 1 || recoveredGaps[0].Count != dropped {
+		t.Fatalf("recovered coalesced gaps = %#v", recoveredGaps)
 	}
 }
 
 func TestP3SaturationNeverDeletesHigherPriority(t *testing.T) {
 	cfg := quotaConfig(t)
-	cfg.MaxBytes = 1500
+	cfg.MaxBytes = 8 << 10
 	s := mustOpen(t, cfg)
 	mustEnqueue(t, s, testItem(fleetagent.PriorityP0, "health", 220))
 	mustEnqueue(t, s, testItem(fleetagent.PriorityP1, "detection", 220))
@@ -176,7 +238,7 @@ func TestEvictionEvidenceSurvivesRestart(t *testing.T) {
 // every successful enqueue is still readable or is covered by durable gap evidence.
 func TestPropertyNoAcceptedRecordSilentlyDisappears(t *testing.T) {
 	cfg := quotaConfig(t)
-	cfg.MaxBytes = 5000
+	cfg.MaxBytes = 7 << 10
 	s, err := Open(cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -237,4 +299,14 @@ func mustGaps(t *testing.T, s *Spool) []ports.SpoolGap {
 		t.Fatal(err)
 	}
 	return gaps
+}
+
+func assertGapCovers(t *testing.T, gaps []ports.SpoolGap, reason ports.SpoolGapReason, epoch, sequence uint64) {
+	t.Helper()
+	for _, gap := range gaps {
+		if gap.Reason == reason && gap.KnownSequence && gap.Epoch == epoch && gap.FromSequence <= sequence && gap.ToSequence >= sequence {
+			return
+		}
+	}
+	t.Fatalf("missing %s gap covering %d:%d in %#v", reason, epoch, sequence, gaps)
 }

--- a/internal/infrastructure/spool/recovery.go
+++ b/internal/infrastructure/spool/recovery.go
@@ -118,11 +118,24 @@ func (s *Spool) recoverSegmentsLocked() (uint64, error) {
 }
 
 func (s *Spool) scanSegmentLocked(path string, expectedPriority fleetagent.DeliveryPriority, expectedEpoch uint64) ([]recoveredFrame, bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, false, fmt.Errorf("stat WAL segment: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, false, fmt.Errorf("refuse symlink WAL segment %s", filepath.Base(path))
+	}
+	// Older versions allowed metadata headroom outside SegmentBytes. Keep that
+	// bounded compatibility window, but inspect the file size before ReadFile so
+	// a hostile sparse/large segment cannot force an unbounded allocation.
+	maxSegmentRead := s.cfg.SegmentBytes + (256 << 10) + frameHeaderSize
+	if info.Size() > maxSegmentRead {
+		return nil, false, fmt.Errorf("WAL segment exceeds recovery bound: size=%d bound=%d", info.Size(), maxSegmentRead)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, false, fmt.Errorf("read WAL segment: %w", err)
 	}
-	maxSegmentRead := s.cfg.SegmentBytes + s.cfg.MaxRecordBytes + (512 << 10)
 	if int64(len(data)) > maxSegmentRead {
 		return nil, false, fmt.Errorf("WAL segment exceeds recovery bound: size=%d bound=%d", len(data), maxSegmentRead)
 	}
@@ -145,7 +158,7 @@ func (s *Spool) scanSegmentLocked(path string, expectedPriority fleetagent.Deliv
 		headerTrusted := header.Magic == frameMagic && header.Version == frameVersion &&
 			header.HeaderSize == frameHeaderSize && header.Epoch == expectedEpoch &&
 			fleetagent.DeliveryPriority(header.Priority) == expectedPriority && header.Sequence > 0
-		if err := validateHeader(header); err != nil || !headerTrusted || int64(header.BodySize) > s.cfg.MaxRecordBytes+(256<<10) {
+		if err := validateHeader(header); err != nil || !headerTrusted || int64(header.BodySize) > s.cfg.MaxRecordBytes+maxFrameMetadataBytes {
 			if headerTrusted {
 				if gapErr := s.appendKnownGapLocked(expectedPriority, expectedEpoch, header.Sequence, header.Sequence, ports.SpoolGapCorruptFrame); gapErr != nil {
 					return nil, damaged, gapErr

--- a/internal/infrastructure/spool/recovery.go
+++ b/internal/infrastructure/spool/recovery.go
@@ -1,0 +1,257 @@
+package spool
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type recoveredFrame struct {
+	bytes    []byte
+	header   frameHeader
+	observed int64
+}
+
+func (s *Spool) recoverSegmentsLocked() (uint64, error) {
+	entries, err := os.ReadDir(s.cfg.Dir)
+	if err != nil {
+		return 0, fmt.Errorf("list spool directory: %w", err)
+	}
+	type candidate struct {
+		name     string
+		priority fleetagent.DeliveryPriority
+		epoch    uint64
+		start    uint64
+	}
+	var candidates []candidate
+	var maxEpoch uint64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		priority, epoch, start, ok := parseSegmentName(entry.Name())
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, candidate{entry.Name(), priority, epoch, start})
+		if epoch > maxEpoch {
+			maxEpoch = epoch
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].priority != candidates[j].priority {
+			return candidates[i].priority < candidates[j].priority
+		}
+		if candidates[i].epoch != candidates[j].epoch {
+			return candidates[i].epoch < candidates[j].epoch
+		}
+		return candidates[i].start < candidates[j].start
+	})
+
+	seen := make(map[string]struct{})
+	for _, candidate := range candidates {
+		path := filepath.Join(s.cfg.Dir, candidate.name)
+		if err := securePath(path, 0o600); err != nil {
+			return 0, fmt.Errorf("secure WAL segment: %w", err)
+		}
+		frames, damaged, err := s.scanSegmentLocked(path, candidate.priority, candidate.epoch)
+		if err != nil {
+			return 0, err
+		}
+		kept := frames[:0]
+		for _, frame := range frames {
+			key := fmt.Sprintf("%d:%d:%d", frame.header.Priority, frame.header.Epoch, frame.header.Sequence)
+			if _, duplicate := seen[key]; duplicate {
+				return 0, fmt.Errorf("duplicate WAL coordinate %s across segments", key)
+			}
+			seen[key] = struct{}{}
+			acked := s.state.ACK[ackKey(candidate.priority, candidate.epoch)]
+			if frame.header.Sequence <= acked {
+				damaged = true // compact already-ACKed bytes during startup
+				continue
+			}
+			kept = append(kept, frame)
+		}
+		frames = kept
+		if len(frames) == 0 {
+			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return 0, fmt.Errorf("remove empty WAL segment: %w", err)
+			}
+			continue
+		}
+		if damaged {
+			if err := rewriteRecoveredSegment(path, frames); err != nil {
+				return 0, err
+			}
+		}
+		seg := &segment{
+			priority: candidate.priority, epoch: candidate.epoch, start: frames[0].header.Sequence,
+			path: path,
+		}
+		var offset int64
+		for _, frame := range frames {
+			length := int64(len(frame.bytes))
+			seg.live++
+			s.records[candidate.priority] = append(s.records[candidate.priority], &recordRef{
+				segment: seg, offset: offset, length: length, header: frame.header,
+				observed: unixNanoUTC(frame.observed),
+			})
+			offset += length
+		}
+		seg.size = offset
+		s.totalBytes += offset
+		s.segments = append(s.segments, seg)
+	}
+	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+		sortRecords(s.records[priority])
+	}
+	if err := syncDirectory(s.cfg.Dir); err != nil {
+		return 0, fmt.Errorf("sync recovered spool directory: %w", err)
+	}
+	return maxEpoch, nil
+}
+
+func (s *Spool) scanSegmentLocked(path string, expectedPriority fleetagent.DeliveryPriority, expectedEpoch uint64) ([]recoveredFrame, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false, fmt.Errorf("read WAL segment: %w", err)
+	}
+	maxSegmentRead := s.cfg.SegmentBytes + s.cfg.MaxRecordBytes + (512 << 10)
+	if int64(len(data)) > maxSegmentRead {
+		return nil, false, fmt.Errorf("WAL segment exceeds recovery bound: size=%d bound=%d", len(data), maxSegmentRead)
+	}
+	if len(data) == 0 {
+		return nil, true, nil
+	}
+	var frames []recoveredFrame
+	damaged := false
+	for offset := 0; offset < len(data); {
+		remaining := len(data) - offset
+		if remaining < frameHeaderSize {
+			if err := s.appendUnknownGapLocked(expectedPriority, expectedEpoch, ports.SpoolGapTornWrite); err != nil {
+				return nil, damaged, err
+			}
+			s.corruptionEvents++
+			damaged = true
+			break
+		}
+		header := unmarshalHeader(data[offset : offset+frameHeaderSize])
+		headerTrusted := header.Magic == frameMagic && header.Version == frameVersion &&
+			header.HeaderSize == frameHeaderSize && header.Epoch == expectedEpoch &&
+			fleetagent.DeliveryPriority(header.Priority) == expectedPriority && header.Sequence > 0
+		if err := validateHeader(header); err != nil || !headerTrusted || int64(header.BodySize) > s.cfg.MaxRecordBytes+(256<<10) {
+			if headerTrusted {
+				if gapErr := s.appendKnownGapLocked(expectedPriority, expectedEpoch, header.Sequence, header.Sequence, ports.SpoolGapCorruptFrame); gapErr != nil {
+					return nil, damaged, gapErr
+				}
+			} else if gapErr := s.appendUnknownGapLocked(expectedPriority, expectedEpoch, ports.SpoolGapCorruptFrame); gapErr != nil {
+				return nil, damaged, gapErr
+			}
+			s.corruptionEvents++
+			damaged = true
+			next := nextMagic(data, offset+1)
+			if next < 0 {
+				break
+			}
+			offset = next
+			continue
+		}
+		length := frameHeaderSize + int(header.BodySize)
+		if length > remaining {
+			if err := s.appendKnownGapLocked(expectedPriority, expectedEpoch, header.Sequence, header.Sequence, ports.SpoolGapTornWrite); err != nil {
+				return nil, damaged, err
+			}
+			s.corruptionEvents++
+			damaged = true
+			break
+		}
+		frameBytes := append([]byte(nil), data[offset:offset+length]...)
+		record, decodedHeader, err := decodeFrame(frameBytes)
+		if err != nil || decodedHeader.Priority != header.Priority || record.Position.Epoch != expectedEpoch {
+			if gapErr := s.appendKnownGapLocked(expectedPriority, expectedEpoch, header.Sequence, header.Sequence, ports.SpoolGapCorruptFrame); gapErr != nil {
+				return nil, damaged, gapErr
+			}
+			s.corruptionEvents++
+			damaged = true
+			next := nextMagic(data, offset+1)
+			if next < 0 {
+				break
+			}
+			offset = next
+			continue
+		}
+		frames = append(frames, recoveredFrame{bytes: frameBytes, header: header, observed: header.ObservedNS})
+		offset += length
+	}
+	return frames, damaged, nil
+}
+
+func rewriteRecoveredSegment(path string, frames []recoveredFrame) error {
+	tmp := path + ".repair"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if errors.Is(err, os.ErrExist) {
+		if removeErr := os.Remove(tmp); removeErr != nil {
+			return fmt.Errorf("remove abandoned WAL repair: %w", removeErr)
+		}
+		f, err = os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	}
+	if err != nil {
+		return fmt.Errorf("create repaired WAL segment: %w", err)
+	}
+	for _, frame := range frames {
+		if _, err := f.Write(frame.bytes); err != nil {
+			_ = f.Close()
+			_ = os.Remove(tmp)
+			return fmt.Errorf("write repaired WAL segment: %w", err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("sync repaired WAL segment: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := replaceFile(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("install repaired WAL segment: %w", err)
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+func (s *Spool) reconcileAssignedTailLocked() error {
+	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+		assigned := s.state.AssignedThrough[priority]
+		covered := s.state.ACK[ackKey(priority, s.state.CurrentEpoch)]
+		for _, ref := range s.records[priority] {
+			if ref.header.Epoch == s.state.CurrentEpoch && ref.header.Sequence > covered {
+				covered = ref.header.Sequence
+			}
+		}
+		for _, gap := range s.gaps {
+			if gap.Priority == priority && gap.Epoch == s.state.CurrentEpoch && gap.KnownSequence && gap.ToSequence > covered {
+				covered = gap.ToSequence
+			}
+		}
+		if covered > assigned {
+			s.state.AssignedThrough[priority] = covered
+			continue
+		}
+		if assigned > covered {
+			if err := s.appendKnownGapLocked(priority, s.state.CurrentEpoch, covered+1, assigned, ports.SpoolGapUnsyncedTail); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func unixNanoUTC(value int64) time.Time { return time.Unix(0, value).UTC() }

--- a/internal/infrastructure/spool/recovery_test.go
+++ b/internal/infrastructure/spool/recovery_test.go
@@ -1,0 +1,312 @@
+package spool
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestRecoverySkipsCorruptMiddleFrameAndKeepsFollowingFrame(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Sync[fleetagent.PriorityP3] = SyncAlways
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "first", 80))
+	second := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "corrupt", 80))
+	third := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "third", 80))
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := onlySegment(t, cfg.Dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstLength := frameHeaderSize + int(binary.LittleEndian.Uint32(data[8:12]))
+	secondLength := frameHeaderSize + int(binary.LittleEndian.Uint32(data[firstLength+8:firstLength+12]))
+	data[firstLength+secondLength-1] ^= 0x80
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	requireIDs(t, mustPeek(t, recovered), "first", "third")
+	gaps, err := recovered.Gaps(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertKnownGap(t, gaps, ports.SpoolGapCorruptFrame, second.Epoch, second.Sequence, second.Sequence)
+	stats, _ := recovered.Stats(context.Background())
+	if stats.CorruptionEvents != 1 {
+		t.Errorf("corruptions = %d", stats.CorruptionEvents)
+	}
+	if err := recovered.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Recovery rewrites the segment. A second restart must neither rediscover
+	// the same corruption nor duplicate its durable gap record.
+	again, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer again.Close()
+	requireIDs(t, mustPeek(t, again), "first", "third")
+	againGaps, _ := again.Gaps(context.Background())
+	if len(againGaps) != len(gaps) {
+		t.Fatalf("repair was not stable: gaps %d -> %d", len(gaps), len(againGaps))
+	}
+	if first.Sequence != 1 || third.Sequence != 3 {
+		t.Fatal("test coordinates unexpected")
+	}
+}
+
+func TestRecoveryReportsTornFrameAndContinuesSequence(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Sync[fleetagent.PriorityP3] = SyncAlways
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "complete", 80))
+	torn := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "torn", 256))
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := onlySegment(t, cfg.Dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data[:len(data)-17], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Close()
+	requireIDs(t, mustPeek(t, recovered), "complete")
+	gaps, _ := recovered.Gaps(context.Background())
+	assertKnownGap(t, gaps, ports.SpoolGapTornWrite, torn.Epoch, torn.Sequence, torn.Sequence)
+	next := mustEnqueue(t, recovered, testItem(fleetagent.PriorityP3, "after", 32))
+	if next.Epoch != first.Epoch || next.Sequence != torn.Sequence+1 {
+		t.Fatalf("sequence reused after torn accepted frame: %#v", next)
+	}
+}
+
+func TestBatchTailLossBecomesExactUnsyncedGap(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "durable-after-close", 64))
+	second := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "simulate-lost", 64))
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := onlySegment(t, cfg.Dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstLength := frameHeaderSize + int(binary.LittleEndian.Uint32(data[8:12]))
+	if err := os.WriteFile(path, data[:firstLength], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Close()
+	requireIDs(t, mustPeek(t, recovered), "durable-after-close")
+	gaps, _ := recovered.Gaps(context.Background())
+	assertKnownGap(t, gaps, ports.SpoolGapUnsyncedTail, second.Epoch, second.Sequence, second.Sequence)
+	next := mustEnqueue(t, recovered, testItem(fleetagent.PriorityP3, "next", 32))
+	if next.Sequence != second.Sequence+1 || first.Sequence != 1 {
+		t.Fatalf("lost accepted coordinate reused: next=%#v", next)
+	}
+}
+
+func TestStatePrimaryCorruptionFallsBackToBackup(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "one", 32))
+	second := mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "two", 32))
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.Dir, "state.json"), []byte("{not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("backup recovery: %v", err)
+	}
+	defer recovered.Close()
+	next := mustEnqueue(t, recovered, testItem(fleetagent.PriorityP2, "three", 32))
+	if next.Epoch != first.Epoch || next.Sequence != second.Sequence+1 {
+		t.Fatalf("backup state reused coordinate: %#v", next)
+	}
+}
+
+func TestBothStateCopiesLostStartsNewIncarnationAndReportsRecovery(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "old", 32))
+	// Force a backup generation to exist.
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "old-2", 32))
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"state.json", "state.backup.json"} {
+		if err := os.WriteFile(filepath.Join(cfg.Dir, name), []byte("corrupt"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	recovered, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Close()
+	fresh := mustEnqueue(t, recovered, testItem(fleetagent.PriorityP3, "fresh", 32))
+	if fresh.Epoch <= old.Epoch || fresh.Sequence != 1 {
+		t.Fatalf("state loss did not start new incarnation: old=%#v new=%#v", old, fresh)
+	}
+	gaps, _ := recovered.Gaps(context.Background())
+	count := 0
+	for _, gap := range gaps {
+		if gap.Reason == ports.SpoolGapStateRecovery && !gap.KnownSequence {
+			count++
+		}
+	}
+	if count != 4 {
+		t.Fatalf("state recovery gaps = %d, want one per priority", count)
+	}
+}
+
+func TestStateLossUsesGapJournalEpochWhenNoSegmentsRemain(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.appendUnknownGapLocked(fleetagent.PriorityP3, 7, ports.SpoolGapStateRecovery); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.Dir, "state.json"), []byte("corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(filepath.Join(cfg.Dir, "state.backup.json"))
+	recovered, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Close()
+	position := mustEnqueue(t, recovered, testItem(fleetagent.PriorityP3, "fresh", 32))
+	if position.Epoch != 8 || position.Sequence != 1 {
+		t.Fatalf("position after state loss = %#v, want epoch 8 sequence 1", position)
+	}
+}
+
+func TestGapJournalTornTailIsSafelyTruncated(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.appendUnknownGapLocked(fleetagent.PriorityP0, 1, ports.SpoolGapStateRecovery); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cfg.Dir, "gaps.log")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.Write([]byte{1, 2, 3, 4, 5})
+	_ = f.Close()
+	recovered, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Close()
+	gaps, _ := recovered.Gaps(context.Background())
+	if len(gaps) != 1 {
+		t.Fatalf("gaps = %d", len(gaps))
+	}
+}
+
+func TestGapJournalChecksumCorruptionFailsClosed(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.appendUnknownGapLocked(fleetagent.PriorityP0, 1, ports.SpoolGapStateRecovery); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cfg.Dir, "gaps.log")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[len(data)-1] ^= 0xff
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if recovered, err := Open(cfg); err == nil {
+		_ = recovered.Close()
+		t.Fatal("corrupt loss evidence was silently accepted")
+	}
+}
+
+func onlySegment(t *testing.T, dir string) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.wal"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("segments = %v, want one", matches)
+	}
+	return matches[0]
+}
+
+func assertKnownGap(t *testing.T, gaps []ports.SpoolGap, reason ports.SpoolGapReason, epoch, from, to uint64) {
+	t.Helper()
+	for _, gap := range gaps {
+		if gap.Reason == reason && gap.KnownSequence && gap.Epoch == epoch && gap.FromSequence == from && gap.ToSequence == to {
+			return
+		}
+	}
+	t.Fatalf("missing %s gap %d:%d..%d in %#v", reason, epoch, from, to, gaps)
+}

--- a/internal/infrastructure/spool/retry.go
+++ b/internal/infrastructure/spool/retry.go
@@ -1,0 +1,142 @@
+package spool
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// RetryReason is a stable label for transport metrics and logs. The A3 wire
+// client consumes this policy; A2 owns it because retry timing determines how
+// quickly the durable spool grows while a control plane is unavailable.
+type RetryReason string
+
+const (
+	RetryNone          RetryReason = "none"
+	RetryRateLimited   RetryReason = "rate_limited"
+	RetryServerFailure RetryReason = "server_failure"
+	RetryTimeout       RetryReason = "request_timeout"
+	RetryNetwork       RetryReason = "network_failure"
+	RetryPermanent     RetryReason = "permanent_failure"
+)
+
+// RetryDecision tells a future transport whether and when to retry a batch.
+type RetryDecision struct {
+	Retry  bool
+	Delay  time.Duration
+	Reason RetryReason
+}
+
+// RetryPolicy implements capped exponential backoff with full jitter. Random
+// is injectable for deterministic tests; values outside [0,1] are clamped.
+type RetryPolicy struct {
+	Base   time.Duration
+	Max    time.Duration
+	Random func() float64
+}
+
+// DefaultRetryPolicy is intentionally moderate: retries begin quickly, while
+// the cap prevents a long outage from creating synchronized request storms.
+func DefaultRetryPolicy() RetryPolicy {
+	return RetryPolicy{Base: 500 * time.Millisecond, Max: 30 * time.Second, Random: rand.Float64}
+}
+
+func (p RetryPolicy) validate() error {
+	if p.Base <= 0 || p.Max <= 0 || p.Base > p.Max {
+		return fmt.Errorf("%w: retry base/max must be positive and base <= max", shared.ErrValidation)
+	}
+	if p.Random == nil {
+		return fmt.Errorf("%w: retry random source is required", shared.ErrValidation)
+	}
+	return nil
+}
+
+// Delay returns full-jitter exponential backoff for a zero-based attempt.
+func (p RetryPolicy) Delay(attempt uint) (time.Duration, error) {
+	if err := p.validate(); err != nil {
+		return 0, err
+	}
+	exponent := attempt
+	if exponent > 62 {
+		exponent = 62
+	}
+	capDelay := float64(p.Base) * math.Pow(2, float64(exponent))
+	if capDelay > float64(p.Max) || math.IsInf(capDelay, 1) {
+		capDelay = float64(p.Max)
+	}
+	random := p.Random()
+	if math.IsNaN(random) {
+		return 0, fmt.Errorf("%w: retry random source returned NaN", shared.ErrValidation)
+	}
+	if random < 0 {
+		random = 0
+	}
+	if random > 1 {
+		random = 1
+	}
+	return time.Duration(random * capDelay), nil
+}
+
+// ClassifyHTTP applies the A2 retry contract. 429 and Retry-After take
+// precedence; 408 and 5xx retry with jitter; other 4xx are permanent. A valid
+// Retry-After delta/date is capped to Max to keep configuration authoritative.
+func (p RetryPolicy) ClassifyHTTP(status int, retryAfter string, now time.Time, attempt uint) (RetryDecision, error) {
+	if err := p.validate(); err != nil {
+		return RetryDecision{}, err
+	}
+	if status >= 200 && status < 300 {
+		return RetryDecision{Reason: RetryNone}, nil
+	}
+	reason := RetryPermanent
+	retry := false
+	switch {
+	case status == http.StatusTooManyRequests:
+		reason, retry = RetryRateLimited, true
+	case status == http.StatusRequestTimeout:
+		reason, retry = RetryTimeout, true
+	case status >= 500 && status <= 599:
+		reason, retry = RetryServerFailure, true
+	}
+	if !retry {
+		return RetryDecision{Reason: reason}, nil
+	}
+	if delay, ok := parseRetryAfter(retryAfter, now); ok {
+		if delay > p.Max {
+			delay = p.Max
+		}
+		return RetryDecision{Retry: true, Delay: delay, Reason: reason}, nil
+	}
+	delay, err := p.Delay(attempt)
+	return RetryDecision{Retry: true, Delay: delay, Reason: reason}, err
+}
+
+// NetworkFailure applies backoff to a transport error which has no HTTP response.
+func (p RetryPolicy) NetworkFailure(attempt uint) (RetryDecision, error) {
+	delay, err := p.Delay(attempt)
+	return RetryDecision{Retry: true, Delay: delay, Reason: RetryNetwork}, err
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.ParseUint(value, 10, 31); err == nil {
+		return time.Duration(seconds) * time.Second, true
+	}
+	date, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	delay := date.Sub(now)
+	if delay < 0 {
+		delay = 0
+	}
+	return delay, true
+}

--- a/internal/infrastructure/spool/retry_test.go
+++ b/internal/infrastructure/spool/retry_test.go
@@ -1,0 +1,116 @@
+package spool
+
+import (
+	"math"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRetryDelayUsesCappedFullJitter(t *testing.T) {
+	policy := RetryPolicy{Base: time.Second, Max: 10 * time.Second, Random: func() float64 { return 0.5 }}
+	tests := []struct {
+		attempt uint
+		want    time.Duration
+	}{
+		{0, 500 * time.Millisecond},
+		{1, time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 5 * time.Second},
+		{63, 5 * time.Second},
+	}
+	for _, tt := range tests {
+		got, err := policy.Delay(tt.attempt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tt.want {
+			t.Errorf("attempt %d delay = %s, want %s", tt.attempt, got, tt.want)
+		}
+	}
+}
+
+func TestRetryDelayClampsRandomSource(t *testing.T) {
+	low := RetryPolicy{Base: time.Second, Max: time.Second, Random: func() float64 { return -7 }}
+	if got, _ := low.Delay(0); got != 0 {
+		t.Errorf("negative random delay = %s", got)
+	}
+	high := RetryPolicy{Base: time.Second, Max: time.Second, Random: func() float64 { return 9 }}
+	if got, _ := high.Delay(0); got != time.Second {
+		t.Errorf("over-one random delay = %s", got)
+	}
+	nan := RetryPolicy{Base: time.Second, Max: time.Second, Random: func() float64 { return math.NaN() }}
+	if _, err := nan.Delay(0); err == nil {
+		t.Fatal("NaN random source accepted")
+	}
+}
+
+func TestRetryPolicyRejectsInvalidConfiguration(t *testing.T) {
+	for _, policy := range []RetryPolicy{
+		{},
+		{Base: 2 * time.Second, Max: time.Second, Random: func() float64 { return 0 }},
+		{Base: time.Second, Max: time.Second},
+	} {
+		if _, err := policy.Delay(0); err == nil {
+			t.Errorf("invalid policy accepted: %#v", policy)
+		}
+	}
+}
+
+func TestClassifyHTTPRetryContract(t *testing.T) {
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	policy := RetryPolicy{Base: time.Second, Max: 20 * time.Second, Random: func() float64 { return 0.25 }}
+	tests := []struct {
+		name       string
+		status     int
+		retryAfter string
+		retry      bool
+		delay      time.Duration
+		reason     RetryReason
+	}{
+		{"success", http.StatusNoContent, "", false, 0, RetryNone},
+		{"bad request", http.StatusBadRequest, "", false, 0, RetryPermanent},
+		{"unauthorized", http.StatusUnauthorized, "", false, 0, RetryPermanent},
+		{"timeout", http.StatusRequestTimeout, "", true, 250 * time.Millisecond, RetryTimeout},
+		{"rate delta", http.StatusTooManyRequests, "7", true, 7 * time.Second, RetryRateLimited},
+		{"rate date", http.StatusTooManyRequests, now.Add(9 * time.Second).Format(http.TimeFormat), true, 9 * time.Second, RetryRateLimited},
+		{"rate cap", http.StatusTooManyRequests, "999", true, 20 * time.Second, RetryRateLimited},
+		{"server", http.StatusServiceUnavailable, "", true, 250 * time.Millisecond, RetryServerFailure},
+		{"invalid retry after", http.StatusBadGateway, "tomorrow", true, 250 * time.Millisecond, RetryServerFailure},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := policy.ClassifyHTTP(tt.status, tt.retryAfter, now, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Retry != tt.retry || decision.Delay != tt.delay || decision.Reason != tt.reason {
+				t.Fatalf("decision = %#v, want retry=%v delay=%s reason=%s", decision, tt.retry, tt.delay, tt.reason)
+			}
+		})
+	}
+}
+
+func TestRetryAfterPastDateRetriesImmediately(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	policy := RetryPolicy{Base: time.Second, Max: time.Minute, Random: func() float64 { return 1 }}
+	decision, err := policy.ClassifyHTTP(http.StatusTooManyRequests, now.Add(-time.Hour).Format(http.TimeFormat), now, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decision.Retry || decision.Delay != 0 {
+		t.Fatalf("past Retry-After = %#v", decision)
+	}
+}
+
+func TestNetworkFailureUsesSameBackoff(t *testing.T) {
+	policy := RetryPolicy{Base: 2 * time.Second, Max: 10 * time.Second, Random: func() float64 { return 0.5 }}
+	decision, err := policy.NetworkFailure(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decision.Retry || decision.Reason != RetryNetwork || decision.Delay != 4*time.Second {
+		t.Fatalf("network decision = %#v", decision)
+	}
+}

--- a/internal/infrastructure/spool/spool.go
+++ b/internal/infrastructure/spool/spool.go
@@ -1,0 +1,609 @@
+package spool
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type recordRef struct {
+	segment  *segment
+	offset   int64
+	length   int64
+	header   frameHeader
+	observed time.Time
+}
+
+type segment struct {
+	priority fleetagent.DeliveryPriority
+	epoch    uint64
+	start    uint64
+	path     string
+	size     int64
+	file     *os.File
+	live     int
+}
+
+// Spool is a priority-aware, crash-recoverable implementation of ports.TelemetrySpool.
+// All mutable state is guarded by mu, including file offsets: callers may safely
+// enqueue, peek, ACK, and scrape metrics concurrently.
+type Spool struct {
+	mu      sync.Mutex
+	cfg     Config
+	lock    *os.File
+	gapFile *os.File
+	state   diskState
+	closed  bool
+
+	records  [4][]*recordRef
+	segments []*segment
+	writers  [4]*segment
+	gaps     []ports.SpoolGap
+
+	totalBytes   int64
+	gapBytes     int64
+	batchBytes   [4]int64
+	lastSync     [4]time.Time
+	lastRejected [4]shared.ID
+
+	evictedRecords   uint64
+	corruptionEvents uint64
+	fsyncCount       uint64
+	fsyncTotal       time.Duration
+}
+
+// Open exclusively opens or creates a spool and repairs recoverable torn or
+// corrupt WAL frames before returning. The lock is held until Close.
+func Open(input Config) (*Spool, error) {
+	cfg, err := normalizeConfig(input)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(cfg.Dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create spool directory: %w", err)
+	}
+	if err := securePath(cfg.Dir, 0o700); err != nil {
+		return nil, fmt.Errorf("secure spool directory: %w", err)
+	}
+	lock, err := acquireDirectoryLock(filepath.Join(cfg.Dir, ".lock"))
+	if err != nil {
+		return nil, fmt.Errorf("lock spool directory: %w", err)
+	}
+	s := &Spool{cfg: cfg, lock: lock}
+	fail := func(openErr error) (*Spool, error) {
+		if s.gapFile != nil {
+			_ = s.gapFile.Close()
+		}
+		_ = releaseDirectoryLock(lock)
+		return nil, openErr
+	}
+
+	s.gapFile, s.gaps, s.gapBytes, err = openGapJournal(cfg.Dir)
+	if err != nil {
+		return fail(err)
+	}
+	state, found, stateErr := loadState(cfg.Dir)
+	if stateErr != nil {
+		// WAL records are still recoverable when both state copies are damaged.
+		// Recovery starts a fresh incarnation and records that degraded fact.
+		found = false
+	}
+	s.state = state
+	maxEpoch, err := s.recoverSegmentsLocked()
+	if err != nil {
+		return fail(err)
+	}
+	for _, gap := range s.gaps {
+		if gap.Epoch > maxEpoch {
+			maxEpoch = gap.Epoch
+		}
+	}
+	if !found {
+		epoch := maxEpoch + 1
+		s.state = newDiskState(cfg.Session, cfg.Boot, epoch)
+		if stateErr != nil || maxEpoch > 0 {
+			for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+				if err := s.appendUnknownGapLocked(priority, epoch, ports.SpoolGapStateRecovery); err != nil {
+					return fail(err)
+				}
+			}
+		}
+	} else if s.state.Session != cfg.Session || s.state.Boot != cfg.Boot {
+		s.state.Session = cfg.Session
+		s.state.Boot = cfg.Boot
+		s.state.CurrentEpoch++
+		s.state.AssignedThrough = [4]uint64{}
+	}
+	if s.state.CurrentEpoch < maxEpoch {
+		// This is possible when recovery used a valid backup which predates a WAL
+		// frame. Never reuse an incarnation observed on disk.
+		s.state.CurrentEpoch = maxEpoch + 1
+		s.state.AssignedThrough = [4]uint64{}
+	}
+	if err := s.reconcileAssignedTailLocked(); err != nil {
+		return fail(err)
+	}
+	if err := s.persistStateLocked(); err != nil {
+		return fail(err)
+	}
+	return s, nil
+}
+
+// Enqueue durably assigns and appends an item. Returning nil guarantees that a
+// later restart can recover the record or an explicit sequence gap.
+func (s *Spool) Enqueue(ctx context.Context, item ports.SpoolItem) (fleetagent.StreamPosition, error) {
+	if err := ctx.Err(); err != nil {
+		return fleetagent.StreamPosition{}, err
+	}
+	if err := item.Validate(); err != nil {
+		return fleetagent.StreamPosition{}, err
+	}
+	if int64(len(item.Payload)) > s.cfg.MaxRecordBytes {
+		return fleetagent.StreamPosition{}, fmt.Errorf("%w: payload is %d bytes, maximum is %d", shared.ErrValidation, len(item.Payload), s.cfg.MaxRecordBytes)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureOpenLocked(); err != nil {
+		return fleetagent.StreamPosition{}, err
+	}
+	priority := item.Priority
+	position := fleetagent.StreamPosition{
+		Priority: priority, Epoch: s.state.CurrentEpoch,
+		Sequence: s.state.AssignedThrough[priority] + 1,
+		Session:  s.state.Session, Boot: s.state.Boot,
+	}
+	now := s.cfg.Now().UTC()
+	frame, err := encodeFrame(item, position, now)
+	if err != nil {
+		return fleetagent.StreamPosition{}, err
+	}
+	if int64(len(frame)) > s.cfg.MaxRecordBytes+frameHeaderSize+(256<<10) {
+		return fleetagent.StreamPosition{}, fmt.Errorf("%w: encoded frame metadata exceeds safety budget", shared.ErrValidation)
+	}
+	if err := s.ensureCapacityLocked(int64(len(frame)), priority, item.EventID); err != nil {
+		return fleetagent.StreamPosition{}, err
+	}
+	seg, err := s.writerLocked(priority, position.Epoch, position.Sequence, int64(len(frame)))
+	if err != nil {
+		return fleetagent.StreamPosition{}, err
+	}
+	offset := seg.size
+	written, writeErr := seg.file.Write(frame)
+	if writeErr != nil || written != len(frame) {
+		if writeErr == nil {
+			writeErr = io.ErrShortWrite
+		}
+		rollbackErr := rollbackAppend(seg.file, offset)
+		gapReason := ports.SpoolGapQuotaBackpressure
+		if priority == fleetagent.PriorityP3 {
+			gapReason = ports.SpoolGapQuotaEviction
+		}
+		gapErr := s.appendUnknownGapLocked(priority, position.Epoch, gapReason)
+		appendErr := fmt.Errorf("append %s WAL frame: %w", priority, writeErr)
+		if errors.Is(writeErr, syscall.ENOSPC) {
+			appendErr = errors.Join(&SaturatedError{
+				UsedBytes: s.totalBytes, MaxBytes: s.cfg.MaxBytes, RequiredBytes: int64(len(frame)),
+			}, appendErr)
+		}
+		return fleetagent.StreamPosition{}, errors.Join(appendErr, rollbackErr, gapErr)
+	}
+	seg.size += int64(len(frame))
+	seg.live++
+	s.totalBytes += int64(len(frame))
+	ref := &recordRef{segment: seg, offset: offset, length: int64(len(frame)), header: unmarshalHeader(frame[:frameHeaderSize]), observed: item.ObservedAt.UTC()}
+	s.records[priority] = append(s.records[priority], ref)
+	s.state.AssignedThrough[priority] = position.Sequence
+
+	policy := s.cfg.Sync[priority]
+	if policy == SyncAlways {
+		if err := s.syncSegmentLocked(seg); err != nil {
+			return fleetagent.StreamPosition{}, err
+		}
+	} else {
+		s.batchBytes[priority] += int64(len(frame))
+		if s.lastSync[priority].IsZero() {
+			s.lastSync[priority] = now
+		}
+	}
+	// State is forced before success even for batch mode. If the WAL tail is
+	// lost, AssignedThrough is the exact upper bound used to emit a gap.
+	if err := s.persistStateLocked(); err != nil {
+		return fleetagent.StreamPosition{}, fmt.Errorf("commit assigned sequence: %w", err)
+	}
+	if policy == SyncBatch && (s.batchBytes[priority] >= s.cfg.BatchBytes || now.Sub(s.lastSync[priority]) >= s.cfg.BatchInterval) {
+		if err := s.syncSegmentLocked(seg); err != nil {
+			return fleetagent.StreamPosition{}, err
+		}
+		s.batchBytes[priority] = 0
+		s.lastSync[priority] = now
+	}
+	return position, nil
+}
+
+// Peek returns records in strict priority order and sequence order within a
+// lane. It does not mutate delivery state; records remain until ACKed.
+func (s *Spool) Peek(ctx context.Context, req ports.PeekSpoolRequest) ([]ports.SpoolRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureOpenLocked(); err != nil {
+		return nil, err
+	}
+	maxRecords := req.MaxRecords
+	if maxRecords == 0 {
+		maxRecords = s.cfg.PeekRecords
+	}
+	maxBytes := req.MaxBytes
+	if maxBytes == 0 {
+		maxBytes = s.cfg.PeekBytes
+	}
+	if maxRecords < 0 || maxBytes < 0 {
+		return nil, fmt.Errorf("%w: negative peek limit", shared.ErrValidation)
+	}
+	result := make([]ports.SpoolRecord, 0, min(maxRecords, 64))
+	var bytesRead int64
+	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+		for _, ref := range s.records[priority] {
+			if len(result) >= maxRecords {
+				return result, nil
+			}
+			record, err := readRecordRef(ref)
+			if err != nil {
+				return nil, err
+			}
+			payloadBytes := int64(len(record.Payload))
+			if len(result) > 0 && bytesRead+payloadBytes > maxBytes {
+				return result, nil
+			}
+			result = append(result, record)
+			bytesRead += payloadBytes
+		}
+	}
+	return result, nil
+}
+
+// Ack commits a highest-contiguous ACK and reclaims fully acknowledged segments.
+func (s *Spool) Ack(ctx context.Context, ack ports.SpoolACK) (ports.SpoolACKResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SpoolACKResult{}, err
+	}
+	if err := ack.Validate(); err != nil {
+		return ports.SpoolACKResult{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureOpenLocked(); err != nil {
+		return ports.SpoolACKResult{}, err
+	}
+	if ack.Epoch > s.state.CurrentEpoch {
+		return ports.SpoolACKResult{}, ErrACKAhead
+	}
+	assigned := s.highestAssignedLocked(ack.Priority, ack.Epoch)
+	if assigned == 0 && ack.Epoch < s.state.CurrentEpoch {
+		return ports.SpoolACKResult{}, ErrStaleACK
+	}
+	if ack.Through > assigned {
+		return ports.SpoolACKResult{}, fmt.Errorf("%w: through=%d assigned=%d", ErrACKAhead, ack.Through, assigned)
+	}
+	key := ackKey(ack.Priority, ack.Epoch)
+	previous := s.state.ACK[key]
+	if ack.Through <= previous {
+		reclaimed, err := s.removeEmptySegmentsLocked()
+		return ports.SpoolACKResult{HighestACKed: previous, ReclaimedBytes: reclaimed}, err
+	}
+	s.state.ACK[key] = ack.Through
+	if err := s.persistStateLocked(); err != nil {
+		s.state.ACK[key] = previous
+		return ports.SpoolACKResult{}, fmt.Errorf("commit spool ACK: %w", err)
+	}
+
+	result := ports.SpoolACKResult{HighestACKed: ack.Through}
+	refs := s.records[ack.Priority]
+	kept := refs[:0]
+	for _, ref := range refs {
+		if ref.header.Epoch == ack.Epoch && ref.header.Sequence <= ack.Through {
+			result.RemovedRecords++
+			ref.segment.live--
+			continue
+		}
+		kept = append(kept, ref)
+	}
+	s.records[ack.Priority] = kept
+	reclaimed, err := s.removeEmptySegmentsLocked()
+	result.ReclaimedBytes = reclaimed
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// Flush synchronizes all active segments. It is safe to call repeatedly.
+func (s *Spool) Flush(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureOpenLocked(); err != nil {
+		return err
+	}
+	return s.flushLocked()
+}
+
+func (s *Spool) flushLocked() error {
+	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+		if writer := s.writers[priority]; writer != nil {
+			if err := s.syncSegmentLocked(writer); err != nil {
+				return err
+			}
+			s.batchBytes[priority] = 0
+			s.lastSync[priority] = s.cfg.Now().UTC()
+		}
+	}
+	return nil
+}
+
+func (s *Spool) Gaps(ctx context.Context) ([]ports.SpoolGap, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureOpenLocked(); err != nil {
+		return nil, err
+	}
+	return append([]ports.SpoolGap(nil), s.gaps...), nil
+}
+
+func (s *Spool) Stats(ctx context.Context) (ports.SpoolStats, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SpoolStats{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureOpenLocked(); err != nil {
+		return ports.SpoolStats{}, err
+	}
+	stats := ports.SpoolStats{
+		TotalBytes: s.totalBytes, GapRecords: int64(len(s.gaps)), GapBytes: s.gapBytes,
+		EvictedRecords: s.evictedRecords, CorruptionEvents: s.corruptionEvents,
+		FsyncCount: s.fsyncCount, FsyncTotal: s.fsyncTotal,
+		Priorities: make([]ports.SpoolPriorityStats, 0, 4),
+	}
+	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+		refs := s.records[priority]
+		lane := ports.SpoolPriorityStats{
+			Priority: priority, Records: int64(len(refs)), CurrentEpoch: s.state.CurrentEpoch,
+			NextSequence: s.state.AssignedThrough[priority] + 1,
+			HighestACKed: s.state.ACK[ackKey(priority, s.state.CurrentEpoch)],
+		}
+		for _, ref := range refs {
+			lane.Bytes += ref.length
+		}
+		if len(refs) > 0 {
+			lane.OldestUnacked = refs[0].observed
+		}
+		stats.TotalRecords += lane.Records
+		stats.Priorities = append(stats.Priorities, lane)
+	}
+	return stats, nil
+}
+
+// Close flushes data, closes descriptors, and releases directory ownership.
+func (s *Spool) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	var errs []error
+	if err := s.flushLocked(); err != nil {
+		errs = append(errs, err)
+	}
+	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+		if writer := s.writers[priority]; writer != nil && writer.file != nil {
+			if err := writer.file.Close(); err != nil {
+				errs = append(errs, err)
+			}
+			writer.file = nil
+		}
+	}
+	if s.gapFile != nil {
+		if err := s.gapFile.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if s.lock != nil {
+		if err := releaseDirectoryLock(s.lock); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	s.closed = true
+	return errors.Join(errs...)
+}
+
+func (s *Spool) ensureOpenLocked() error {
+	if s.closed {
+		return ErrClosed
+	}
+	return nil
+}
+
+func (s *Spool) writerLocked(priority fleetagent.DeliveryPriority, epoch, sequence uint64, frameBytes int64) (*segment, error) {
+	current := s.writers[priority]
+	if current != nil && (current.epoch != epoch || (current.size > 0 && current.size+frameBytes > s.cfg.SegmentBytes)) {
+		if err := s.syncSegmentLocked(current); err != nil {
+			return nil, err
+		}
+		if err := current.file.Close(); err != nil {
+			return nil, err
+		}
+		current.file = nil
+		s.writers[priority] = nil
+		current = nil
+	}
+	if current != nil {
+		return current, nil
+	}
+	name := segmentName(priority, epoch, sequence)
+	path := filepath.Join(s.cfg.Dir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create WAL segment: %w", err)
+	}
+	if err := syncDirectory(s.cfg.Dir); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("sync new WAL segment: %w", err)
+	}
+	current = &segment{priority: priority, epoch: epoch, start: sequence, path: path, file: f}
+	s.segments = append(s.segments, current)
+	s.writers[priority] = current
+	return current, nil
+}
+
+func (s *Spool) syncSegmentLocked(seg *segment) error {
+	if seg == nil || seg.file == nil {
+		return nil
+	}
+	started := s.cfg.Now()
+	if err := seg.file.Sync(); err != nil {
+		return fmt.Errorf("sync %s WAL segment: %w", seg.priority, err)
+	}
+	s.observeSyncLocked(started)
+	return nil
+}
+
+func (s *Spool) observeSyncLocked(started time.Time) {
+	s.fsyncCount++
+	duration := s.cfg.Now().Sub(started)
+	if duration > 0 {
+		s.fsyncTotal += duration
+	}
+}
+
+func (s *Spool) persistStateLocked() error {
+	started := s.cfg.Now()
+	if err := persistState(s.cfg.Dir, &s.state); err != nil {
+		return err
+	}
+	s.observeSyncLocked(started)
+	return nil
+}
+
+func readRecordRef(ref *recordRef) (ports.SpoolRecord, error) {
+	f, err := os.Open(ref.segment.path)
+	if err != nil {
+		return ports.SpoolRecord{}, fmt.Errorf("open WAL record: %w", err)
+	}
+	defer f.Close()
+	frame := make([]byte, ref.length)
+	if _, err := f.ReadAt(frame, ref.offset); err != nil {
+		return ports.SpoolRecord{}, fmt.Errorf("read WAL record: %w", err)
+	}
+	record, _, err := decodeFrame(frame)
+	if err != nil {
+		return ports.SpoolRecord{}, fmt.Errorf("decode WAL record after recovery: %w", err)
+	}
+	return record, nil
+}
+
+func rollbackAppend(file *os.File, offset int64) error {
+	if err := file.Truncate(offset); err != nil {
+		return fmt.Errorf("truncate failed WAL append: %w", err)
+	}
+	if _, err := file.Seek(0, io.SeekEnd); err != nil {
+		return fmt.Errorf("seek repaired WAL append: %w", err)
+	}
+	return nil
+}
+
+func (s *Spool) highestAssignedLocked(priority fleetagent.DeliveryPriority, epoch uint64) uint64 {
+	high := s.state.ACK[ackKey(priority, epoch)]
+	if epoch == s.state.CurrentEpoch && s.state.AssignedThrough[priority] > high {
+		high = s.state.AssignedThrough[priority]
+	}
+	for _, ref := range s.records[priority] {
+		if ref.header.Epoch == epoch && ref.header.Sequence > high {
+			high = ref.header.Sequence
+		}
+	}
+	for _, gap := range s.gaps {
+		if gap.Priority == priority && gap.Epoch == epoch && gap.KnownSequence && gap.ToSequence > high {
+			high = gap.ToSequence
+		}
+	}
+	return high
+}
+
+func (s *Spool) appendUnknownGapLocked(priority fleetagent.DeliveryPriority, epoch uint64, reason ports.SpoolGapReason) error {
+	return s.appendGapLocked(ports.SpoolGap{
+		ID: shared.ID(uuid.NewString()), Priority: priority, Epoch: epoch,
+		KnownSequence: false, Reason: reason, Count: 1, OccurredAt: s.cfg.Now().UTC(),
+	})
+}
+
+func (s *Spool) appendKnownGapLocked(priority fleetagent.DeliveryPriority, epoch, from, to uint64, reason ports.SpoolGapReason) error {
+	if from == 0 || to < from {
+		return fmt.Errorf("invalid internal gap range %d..%d", from, to)
+	}
+	return s.appendGapLocked(ports.SpoolGap{
+		ID: shared.ID(uuid.NewString()), Priority: priority, Epoch: epoch,
+		FromSequence: from, ToSequence: to, KnownSequence: true, Reason: reason,
+		Count: to - from + 1, OccurredAt: s.cfg.Now().UTC(),
+	})
+}
+
+func segmentName(priority fleetagent.DeliveryPriority, epoch, start uint64) string {
+	return fmt.Sprintf("p%d-e%020d-s%020d.wal", priority, epoch, start)
+}
+
+func parseSegmentName(name string) (fleetagent.DeliveryPriority, uint64, uint64, bool) {
+	var p int
+	var epoch, start uint64
+	if _, err := fmt.Sscanf(name, "p%d-e%d-s%d.wal", &p, &epoch, &start); err != nil {
+		return 0, 0, 0, false
+	}
+	priority := fleetagent.DeliveryPriority(p)
+	if !priority.Valid() || epoch == 0 || start == 0 || name != segmentName(priority, epoch, start) {
+		return 0, 0, 0, false
+	}
+	return priority, epoch, start, true
+}
+
+func nextMagic(data []byte, from int) int {
+	needle := []byte{byte(frameMagic & 0xff), byte((frameMagic >> 8) & 0xff), byte((frameMagic >> 16) & 0xff), byte((frameMagic >> 24) & 0xff)}
+	index := bytes.Index(data[from:], needle)
+	if index < 0 {
+		return -1
+	}
+	return from + index
+}
+
+func sortRecords(refs []*recordRef) {
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].header.Epoch != refs[j].header.Epoch {
+			return refs[i].header.Epoch < refs[j].header.Epoch
+		}
+		return refs[i].header.Sequence < refs[j].header.Sequence
+	})
+}
+
+var _ ports.TelemetrySpool = (*Spool)(nil)

--- a/internal/infrastructure/spool/spool.go
+++ b/internal/infrastructure/spool/spool.go
@@ -48,6 +48,10 @@ type Spool struct {
 	gapFile *os.File
 	state   diskState
 	closed  bool
+	failed  error
+
+	syncFile     func(*os.File) error
+	persistState func(string, *diskState) error
 
 	records  [4][]*recordRef
 	segments []*segment
@@ -83,7 +87,11 @@ func Open(input Config) (*Spool, error) {
 	if err != nil {
 		return nil, fmt.Errorf("lock spool directory: %w", err)
 	}
-	s := &Spool{cfg: cfg, lock: lock}
+	s := &Spool{
+		cfg: cfg, lock: lock,
+		syncFile:     func(file *os.File) error { return file.Sync() },
+		persistState: persistState,
+	}
 	fail := func(openErr error) (*Spool, error) {
 		if s.gapFile != nil {
 			_ = s.gapFile.Close()
@@ -443,7 +451,17 @@ func (s *Spool) ensureOpenLocked() error {
 	if s.closed {
 		return ErrClosed
 	}
+	if s.failed != nil {
+		return errors.Join(ErrFailed, s.failed)
+	}
 	return nil
+}
+
+func (s *Spool) failLocked(err error) error {
+	if s.failed == nil {
+		s.failed = err
+	}
+	return errors.Join(ErrFailed, err)
 }
 
 func (s *Spool) writerLocked(priority fleetagent.DeliveryPriority, epoch, sequence uint64, frameBytes int64) (*segment, error) {
@@ -484,8 +502,8 @@ func (s *Spool) syncSegmentLocked(seg *segment) error {
 		return nil
 	}
 	started := s.cfg.Now()
-	if err := seg.file.Sync(); err != nil {
-		return fmt.Errorf("sync %s WAL segment: %w", seg.priority, err)
+	if err := s.syncFile(seg.file); err != nil {
+		return s.failLocked(fmt.Errorf("sync %s WAL segment: %w", seg.priority, err))
 	}
 	s.observeSyncLocked(started)
 	return nil
@@ -501,8 +519,8 @@ func (s *Spool) observeSyncLocked(started time.Time) {
 
 func (s *Spool) persistStateLocked() error {
 	started := s.cfg.Now()
-	if err := persistState(s.cfg.Dir, &s.state); err != nil {
-		return err
+	if err := s.persistState(s.cfg.Dir, &s.state); err != nil {
+		return s.failLocked(err)
 	}
 	s.observeSyncLocked(started)
 	return nil

--- a/internal/infrastructure/spool/spool.go
+++ b/internal/infrastructure/spool/spool.go
@@ -58,11 +58,13 @@ type Spool struct {
 	writers  [4]*segment
 	gaps     []ports.SpoolGap
 
-	totalBytes   int64
-	gapBytes     int64
-	batchBytes   [4]int64
-	lastSync     [4]time.Time
-	lastRejected [4]shared.ID
+	totalBytes  int64
+	gapBytes    int64
+	batchBytes  [4]int64
+	lastSync    [4]time.Time
+	gapDirty    bool
+	gapPending  uint64
+	lastGapSync time.Time
 
 	evictedRecords   uint64
 	corruptionEvents uint64
@@ -103,6 +105,14 @@ func Open(input Config) (*Spool, error) {
 	s.gapFile, s.gaps, s.gapBytes, err = openGapJournal(cfg.Dir)
 	if err != nil {
 		return fail(err)
+	}
+	s.lastGapSync = cfg.Now().UTC()
+	if s.gapBytes > s.gapJournalLimitLocked() {
+		s.gaps = compactGaps(s.gaps)
+		s.gapDirty = true
+		if err := s.flushGapJournalLocked(); err != nil {
+			return fail(err)
+		}
 	}
 	state, found, stateErr := loadState(cfg.Dir)
 	if stateErr != nil {
@@ -180,10 +190,10 @@ func (s *Spool) Enqueue(ctx context.Context, item ports.SpoolItem) (fleetagent.S
 	if err != nil {
 		return fleetagent.StreamPosition{}, err
 	}
-	if int64(len(frame)) > s.cfg.MaxRecordBytes+frameHeaderSize+(256<<10) {
-		return fleetagent.StreamPosition{}, fmt.Errorf("%w: encoded frame metadata exceeds safety budget", shared.ErrValidation)
+	if int64(len(frame)) > s.cfg.MaxRecordBytes+FrameOverheadBudget {
+		return fleetagent.StreamPosition{}, fmt.Errorf("%w: encoded WAL frame exceeds record plus metadata budget", shared.ErrValidation)
 	}
-	if err := s.ensureCapacityLocked(int64(len(frame)), priority, item.EventID); err != nil {
+	if err := s.ensureCapacityLocked(int64(len(frame)), priority); err != nil {
 		return fleetagent.StreamPosition{}, err
 	}
 	seg, err := s.writerLocked(priority, position.Epoch, position.Sequence, int64(len(frame)))
@@ -197,18 +207,24 @@ func (s *Spool) Enqueue(ctx context.Context, item ports.SpoolItem) (fleetagent.S
 			writeErr = io.ErrShortWrite
 		}
 		rollbackErr := rollbackAppend(seg.file, offset)
-		gapReason := ports.SpoolGapQuotaBackpressure
-		if priority == fleetagent.PriorityP3 {
-			gapReason = ports.SpoolGapQuotaEviction
-		}
-		gapErr := s.appendUnknownGapLocked(priority, position.Epoch, gapReason)
 		appendErr := fmt.Errorf("append %s WAL frame: %w", priority, writeErr)
 		if errors.Is(writeErr, syscall.ENOSPC) {
-			appendErr = errors.Join(&SaturatedError{
-				UsedBytes: s.totalBytes, MaxBytes: s.cfg.MaxBytes, RequiredBytes: int64(len(frame)),
+			if rollbackErr != nil {
+				return fleetagent.StreamPosition{}, s.failLocked(errors.Join(appendErr, rollbackErr))
+			}
+			if priority == fleetagent.PriorityP3 {
+				if gapErr := s.recordP3LossLocked(ports.SpoolGapIOFailure); gapErr != nil {
+					return fleetagent.StreamPosition{}, errors.Join(appendErr, gapErr)
+				}
+			}
+			return fleetagent.StreamPosition{}, errors.Join(&SaturatedError{
+				UsedBytes: s.usedBytesLocked(), MaxBytes: s.cfg.MaxBytes, RequiredBytes: int64(len(frame)),
 			}, appendErr)
 		}
-		return fleetagent.StreamPosition{}, errors.Join(appendErr, rollbackErr, gapErr)
+		if rollbackErr != nil {
+			return fleetagent.StreamPosition{}, s.failLocked(errors.Join(appendErr, rollbackErr))
+		}
+		return fleetagent.StreamPosition{}, appendErr
 	}
 	seg.size += int64(len(frame))
 	seg.live++
@@ -365,7 +381,7 @@ func (s *Spool) flushLocked() error {
 			s.lastSync[priority] = s.cfg.Now().UTC()
 		}
 	}
-	return nil
+	return s.flushGapJournalLocked()
 }
 
 func (s *Spool) Gaps(ctx context.Context) ([]ports.SpoolGap, error) {
@@ -390,7 +406,7 @@ func (s *Spool) Stats(ctx context.Context) (ports.SpoolStats, error) {
 		return ports.SpoolStats{}, err
 	}
 	stats := ports.SpoolStats{
-		TotalBytes: s.totalBytes, GapRecords: int64(len(s.gaps)), GapBytes: s.gapBytes,
+		TotalBytes: s.usedBytesLocked(), GapRecords: int64(len(s.gaps)), GapBytes: s.gapBytes,
 		EvictedRecords: s.evictedRecords, CorruptionEvents: s.corruptionEvents,
 		FsyncCount: s.fsyncCount, FsyncTotal: s.fsyncTotal,
 		Priorities: make([]ports.SpoolPriorityStats, 0, 4),

--- a/internal/infrastructure/spool/spool_test.go
+++ b/internal/infrastructure/spool/spool_test.go
@@ -1,0 +1,363 @@
+package spool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestSpoolPriorityDrainAndLaneOrdering(t *testing.T) {
+	s := mustOpen(t, testConfig(t))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "p3-first", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "p2-first", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP0, "p0", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "p3-second", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP1, "p1", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "p2-second", 32))
+
+	records := mustPeek(t, s)
+	requireIDs(t, records, "p0", "p1", "p2-first", "p2-second", "p3-first", "p3-second")
+	for i := 1; i < len(records); i++ {
+		if records[i-1].Position.Priority == records[i].Position.Priority && records[i-1].Position.Sequence >= records[i].Position.Sequence {
+			t.Fatalf("lane order is not increasing: %#v then %#v", records[i-1].Position, records[i].Position)
+		}
+	}
+}
+
+func TestPeekBoundsAndAlwaysMakesProgress(t *testing.T) {
+	s := mustOpen(t, testConfig(t))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "large", 4096))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "small", 16))
+
+	records, err := s.Peek(context.Background(), ports.PeekSpoolRequest{MaxRecords: 1, MaxBytes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].EventID != "large" {
+		t.Fatalf("oversize head must make progress, got %v", recordIDs(records))
+	}
+	if _, err := s.Peek(context.Background(), ports.PeekSpoolRequest{MaxRecords: -1}); !errors.Is(err, context.Canceled) && err == nil {
+		t.Fatal("negative limit accepted")
+	}
+}
+
+func TestACKIsContiguousScopedAndIdempotent(t *testing.T) {
+	s := mustOpen(t, testConfig(t))
+	p1 := mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "one", 32))
+	p2 := mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "two", 32))
+	p3 := mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "three", 32))
+
+	result, err := s.Ack(context.Background(), ports.SpoolACK{Priority: fleetagent.PriorityP2, Epoch: p2.Epoch, Through: p2.Sequence})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RemovedRecords != 2 || result.HighestACKed != p2.Sequence {
+		t.Fatalf("ACK result = %#v", result)
+	}
+	requireIDs(t, mustPeek(t, s), "three")
+
+	again, err := s.Ack(context.Background(), ports.SpoolACK{Priority: fleetagent.PriorityP2, Epoch: p1.Epoch, Through: p1.Sequence})
+	if err != nil || again.RemovedRecords != 0 || again.HighestACKed != p2.Sequence {
+		t.Fatalf("idempotent/regressive ACK = %#v, %v", again, err)
+	}
+	if _, err := s.Ack(context.Background(), ports.SpoolACK{Priority: fleetagent.PriorityP2, Epoch: p3.Epoch, Through: p3.Sequence + 1}); !errors.Is(err, ErrACKAhead) {
+		t.Fatalf("ahead ACK error = %v", err)
+	}
+	if _, err := s.Ack(context.Background(), ports.SpoolACK{Priority: fleetagent.PriorityP3, Epoch: p3.Epoch, Through: 1}); !errors.Is(err, ErrACKAhead) {
+		t.Fatalf("cross-lane ACK error = %v", err)
+	}
+}
+
+func TestResumeAfterRestartPreservesMembershipAndSequence(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "one", 64))
+	second := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "two", 64))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP1, "detection", 64))
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	requireIDs(t, mustPeek(t, reopened), "detection", "one", "two")
+	third := mustEnqueue(t, reopened, testItem(fleetagent.PriorityP3, "three", 64))
+	if first.Epoch != second.Epoch || third.Epoch != second.Epoch || third.Sequence != second.Sequence+1 {
+		t.Fatalf("positions did not resume: first=%#v second=%#v third=%#v", first, second, third)
+	}
+}
+
+func TestBootChangeAdvancesEpochAndResetsSequence(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "before-reboot", 32))
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Boot = "boot-2"
+	reopened, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	fresh := mustEnqueue(t, reopened, testItem(fleetagent.PriorityP3, "after-reboot", 32))
+	if fresh.Epoch != old.Epoch+1 || fresh.Sequence != 1 || fresh.Boot != "boot-2" {
+		t.Fatalf("reboot position = %#v, old = %#v", fresh, old)
+	}
+	requireIDs(t, mustPeek(t, reopened), "before-reboot", "after-reboot")
+}
+
+func TestSessionChangeAdvancesEpoch(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "old-session", 32))
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Session = "session-2"
+	reopened, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	fresh := mustEnqueue(t, reopened, testItem(fleetagent.PriorityP2, "new-session", 32))
+	if fresh.Epoch != old.Epoch+1 || fresh.Sequence != 1 || fresh.Session != "session-2" {
+		t.Fatalf("new session position = %#v, old = %#v", fresh, old)
+	}
+}
+
+func TestACKSurvivesRestartAndReclaimsSegment(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.SegmentBytes = 512
+	cfg.MaxRecordBytes = 256
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "one", 128))
+	second := mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "two", 128))
+	before, _ := s.Stats(context.Background())
+	if _, err := s.Ack(context.Background(), ports.SpoolACK{Priority: fleetagent.PriorityP3, Epoch: first.Epoch, Through: first.Sequence}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	requireIDs(t, mustPeek(t, reopened), "two")
+	stats, _ := reopened.Stats(context.Background())
+	if stats.TotalBytes >= before.TotalBytes {
+		t.Errorf("ACKed segment was not compacted: before=%d after=%d", before.TotalBytes, stats.TotalBytes)
+	}
+	if stats.Priorities[fleetagent.PriorityP3].HighestACKed != first.Sequence || second.Sequence != first.Sequence+1 {
+		t.Fatalf("ACK/sequence state not restored: %#v", stats.Priorities[fleetagent.PriorityP3])
+	}
+}
+
+func TestDirectoryHasExclusiveProcessOwnership(t *testing.T) {
+	cfg := testConfig(t)
+	first, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Open(cfg)
+	if second != nil {
+		_ = second.Close()
+		t.Fatal("second open unexpectedly succeeded")
+	}
+	if !errors.Is(err, ErrLocked) {
+		t.Fatalf("second open error = %v, want ErrLocked", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	third, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("lock not released by Close: %v", err)
+	}
+	_ = third.Close()
+}
+
+func TestConcurrentProducersAssignUniqueMonotonicCoordinates(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Sync[fleetagent.PriorityP3] = SyncAlways
+	s := mustOpen(t, cfg)
+	const producers = 6
+	const perProducer = 20
+	positions := make(chan fleetagent.StreamPosition, producers*perProducer)
+	errs := make(chan error, producers)
+	var wg sync.WaitGroup
+	for producer := 0; producer < producers; producer++ {
+		producer := producer
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := 0; n < perProducer; n++ {
+				id := fmt.Sprintf("producer-%d-%d", producer, n)
+				position, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP3, id, 16))
+				if err != nil {
+					errs <- err
+					return
+				}
+				positions <- position
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	close(positions)
+	for err := range errs {
+		t.Fatalf("concurrent enqueue: %v", err)
+	}
+	var sequences []int
+	for position := range positions {
+		sequences = append(sequences, int(position.Sequence))
+	}
+	sort.Ints(sequences)
+	if len(sequences) != producers*perProducer {
+		t.Fatalf("positions = %d", len(sequences))
+	}
+	for index, sequence := range sequences {
+		if sequence != index+1 {
+			t.Fatalf("sequence[%d] = %d", index, sequence)
+		}
+	}
+	if len(mustPeek(t, s)) != producers*perProducer {
+		t.Fatalf("records missing after concurrent enqueue")
+	}
+}
+
+func TestClosedAndCancelledOperations(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	if _, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP3, "x", 1)); !errors.Is(err, ErrClosed) {
+		t.Errorf("enqueue after close = %v", err)
+	}
+	if _, err := s.Peek(context.Background(), ports.PeekSpoolRequest{}); !errors.Is(err, ErrClosed) {
+		t.Errorf("peek after close = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := s.Flush(ctx); !errors.Is(err, context.Canceled) {
+		t.Errorf("cancelled flush = %v", err)
+	}
+}
+
+func TestSpoolFilesAreOwnerOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows ACLs are not represented by os.FileMode permission bits")
+	}
+	cfg := testConfig(t)
+	s := mustOpen(t, cfg)
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP2, "secret-signal", 32))
+	entries, err := os.ReadDir(cfg.Dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			t.Errorf("%s permissions = %o, expose group/world bits", filepath.Base(entry.Name()), info.Mode().Perm())
+		}
+	}
+}
+
+func TestStatsDescribeAllLanes(t *testing.T) {
+	s := mustOpen(t, testConfig(t))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP1, "det", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "raw", 32))
+	stats, err := s.Stats(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats.Priorities) != 4 || stats.TotalRecords != 2 || stats.TotalBytes <= 0 || stats.FsyncCount == 0 {
+		t.Fatalf("stats = %#v", stats)
+	}
+	if stats.Priorities[1].Records != 1 || stats.Priorities[3].Records != 1 {
+		t.Fatalf("lane stats = %#v", stats.Priorities)
+	}
+	if !stats.Priorities[1].OldestUnacked.Equal(testNow) {
+		t.Errorf("oldest = %s", stats.Priorities[1].OldestUnacked)
+	}
+}
+
+func TestSegmentNamesRoundTripAndRejectAliases(t *testing.T) {
+	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+		name := segmentName(priority, 123, 456)
+		gotPriority, epoch, start, ok := parseSegmentName(name)
+		if !ok || gotPriority != priority || epoch != 123 || start != 456 {
+			t.Fatalf("parse %q = %s/%d/%d/%v", name, gotPriority, epoch, start, ok)
+		}
+	}
+	for _, invalid := range []string{"p3-e1-s1.wal", "p4-e00000000000000000001-s00000000000000000001.wal", "p0-e00000000000000000000-s00000000000000000001.wal", "gaps.log", "../p0.wal"} {
+		if _, _, _, ok := parseSegmentName(invalid); ok {
+			t.Errorf("accepted non-canonical segment name %q", invalid)
+		}
+	}
+}
+
+func TestRollbackAppendRestoresOffsetForNextWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "append.wal")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if _, err := file.Write([]byte("goodpartial")); err != nil {
+		t.Fatal(err)
+	}
+	if err := rollbackAppend(file, 4); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write([]byte("next")); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "goodnext" {
+		t.Fatalf("repaired contents = %q", data)
+	}
+}

--- a/internal/infrastructure/spool/spool_test.go
+++ b/internal/infrastructure/spool/spool_test.go
@@ -361,3 +361,64 @@ func TestRollbackAppendRestoresOffsetForNextWrite(t *testing.T) {
 		t.Fatalf("repaired contents = %q", data)
 	}
 }
+
+func TestSyncFailurePoisonsSpoolUntilRecovery(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Sync[fleetagent.PriorityP3] = SyncAlways
+	s := mustOpen(t, cfg)
+	originalSync := s.syncFile
+	s.syncFile = func(*os.File) error { return errors.New("injected sync failure") }
+
+	if _, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP3, "ambiguous", 32)); !errors.Is(err, ErrFailed) {
+		t.Fatalf("enqueue after sync failure = %v, want ErrFailed", err)
+	}
+	if _, err := s.Peek(context.Background(), ports.PeekSpoolRequest{}); !errors.Is(err, ErrFailed) {
+		t.Fatalf("peek after sync failure = %v, want ErrFailed", err)
+	}
+	if _, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP3, "must-not-reuse", 32)); !errors.Is(err, ErrFailed) {
+		t.Fatalf("enqueue after sync failure = %v, want ErrFailed", err)
+	}
+
+	// Close still owns cleanup after fail-stop. A successful final flush makes
+	// the ambiguous frame recoverable without ever reusing its coordinate.
+	s.syncFile = originalSync
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened := mustOpen(t, cfg)
+	defer reopened.Close()
+	requireIDs(t, mustPeek(t, reopened), "ambiguous")
+	next := mustEnqueue(t, reopened, testItem(fleetagent.PriorityP3, "next", 32))
+	if next.Sequence != 2 {
+		t.Fatalf("sequence after recovery = %d, want 2", next.Sequence)
+	}
+}
+
+func TestStateCommitFailurePoisonsSpoolUntilRecovery(t *testing.T) {
+	cfg := testConfig(t)
+	s := mustOpen(t, cfg)
+	originalPersist := s.persistState
+	s.persistState = func(string, *diskState) error { return errors.New("injected state failure") }
+
+	if _, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP2, "ambiguous", 32)); !errors.Is(err, ErrFailed) {
+		t.Fatalf("enqueue after state commit failure = %v, want ErrFailed", err)
+	}
+	if _, err := s.Stats(context.Background()); !errors.Is(err, ErrFailed) {
+		t.Fatalf("stats after state failure = %v, want ErrFailed", err)
+	}
+	if _, err := s.Enqueue(context.Background(), testItem(fleetagent.PriorityP2, "must-not-reuse", 32)); !errors.Is(err, ErrFailed) {
+		t.Fatalf("enqueue after state failure = %v, want ErrFailed", err)
+	}
+
+	s.persistState = originalPersist
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened := mustOpen(t, cfg)
+	defer reopened.Close()
+	requireIDs(t, mustPeek(t, reopened), "ambiguous")
+	next := mustEnqueue(t, reopened, testItem(fleetagent.PriorityP2, "next", 32))
+	if next.Sequence != 2 {
+		t.Fatalf("sequence after recovery = %d, want 2", next.Sequence)
+	}
+}

--- a/internal/infrastructure/spool/spool_test.go
+++ b/internal/infrastructure/spool/spool_test.go
@@ -149,7 +149,7 @@ func TestSessionChangeAdvancesEpoch(t *testing.T) {
 
 func TestACKSurvivesRestartAndReclaimsSegment(t *testing.T) {
 	cfg := testConfig(t)
-	cfg.SegmentBytes = 512
+	cfg.SegmentBytes = 1024
 	cfg.MaxRecordBytes = 256
 	s, err := Open(cfg)
 	if err != nil {
@@ -300,6 +300,24 @@ func TestSpoolFilesAreOwnerOnly(t *testing.T) {
 		if info.Mode().Perm()&0o077 != 0 {
 			t.Errorf("%s permissions = %o, expose group/world bits", filepath.Base(entry.Name()), info.Mode().Perm())
 		}
+	}
+}
+
+func TestSecurePathRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on some Windows hosts")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "p3-e00000000000000000001-s00000000000000000001.wal")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := securePath(link, 0o600); err == nil {
+		t.Fatal("symlink spool path accepted")
 	}
 }
 

--- a/internal/infrastructure/spool/state.go
+++ b/internal/infrastructure/spool/state.go
@@ -1,0 +1,168 @@
+package spool
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+)
+
+const stateVersion = 1
+
+type diskState struct {
+	Version         int                  `json:"version"`
+	Generation      uint64               `json:"generation"`
+	Session         fleetagent.SessionID `json:"session"`
+	Boot            fleetagent.BootID    `json:"boot"`
+	CurrentEpoch    uint64               `json:"current_epoch"`
+	AssignedThrough [4]uint64            `json:"assigned_through"`
+	ACK             map[string]uint64    `json:"ack"`
+}
+
+func newDiskState(session fleetagent.SessionID, boot fleetagent.BootID, epoch uint64) diskState {
+	return diskState{
+		Version: stateVersion, Session: session, Boot: boot, CurrentEpoch: epoch,
+		ACK: make(map[string]uint64),
+	}
+}
+
+func (s diskState) validate() error {
+	if s.Version != stateVersion {
+		return fmt.Errorf("unsupported spool state version %d", s.Version)
+	}
+	if s.Session == "" || s.Boot == "" || s.CurrentEpoch == 0 {
+		return errors.New("spool state has an invalid identity or epoch")
+	}
+	for key := range s.ACK {
+		if _, _, err := parseACKKey(key); err != nil {
+			return fmt.Errorf("spool state has invalid ACK key: %w", err)
+		}
+	}
+	return nil
+}
+
+func ackKey(priority fleetagent.DeliveryPriority, epoch uint64) string {
+	return strconv.Itoa(int(priority)) + ":" + strconv.FormatUint(epoch, 10)
+}
+
+func parseACKKey(key string) (fleetagent.DeliveryPriority, uint64, error) {
+	var p int
+	var epoch uint64
+	if _, err := fmt.Sscanf(key, "%d:%d", &p, &epoch); err != nil {
+		return 0, 0, err
+	}
+	priority := fleetagent.DeliveryPriority(p)
+	if !priority.Valid() || epoch == 0 || key != ackKey(priority, epoch) {
+		return 0, 0, fmt.Errorf("malformed coordinate %q", key)
+	}
+	return priority, epoch, nil
+}
+
+func loadState(dir string) (diskState, bool, error) {
+	primary, primaryErr := readStateFile(filepath.Join(dir, "state.json"))
+	backup, backupErr := readStateFile(filepath.Join(dir, "state.backup.json"))
+
+	switch {
+	case primaryErr == nil && backupErr == nil:
+		if backup.Generation > primary.Generation {
+			return backup, true, nil
+		}
+		return primary, true, nil
+	case primaryErr == nil:
+		return primary, true, nil
+	case backupErr == nil:
+		return backup, true, nil
+	case errors.Is(primaryErr, os.ErrNotExist) && errors.Is(backupErr, os.ErrNotExist):
+		return diskState{}, false, nil
+	default:
+		return diskState{}, false, fmt.Errorf("read spool state (primary: %v; backup: %v)", primaryErr, backupErr)
+	}
+}
+
+func readStateFile(path string) (diskState, error) {
+	if err := securePath(path, 0o600); err != nil {
+		return diskState{}, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return diskState{}, err
+	}
+	defer f.Close()
+	limited := io.LimitReader(f, 1<<20)
+	decoder := json.NewDecoder(limited)
+	decoder.DisallowUnknownFields()
+	var state diskState
+	if err := decoder.Decode(&state); err != nil {
+		return diskState{}, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return diskState{}, errors.New("spool state contains multiple JSON values")
+		}
+		return diskState{}, fmt.Errorf("spool state has trailing data: %w", err)
+	}
+	if err := state.validate(); err != nil {
+		return diskState{}, err
+	}
+	return state, nil
+}
+
+func persistState(dir string, state *diskState) error {
+	state.Generation++
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		state.Generation--
+		return fmt.Errorf("encode spool state: %w", err)
+	}
+	data = append(data, '\n')
+	tmp := filepath.Join(dir, ".state.json.tmp")
+	if err := writeSyncedFile(tmp, data, 0o600); err != nil {
+		state.Generation--
+		return err
+	}
+	primary := filepath.Join(dir, "state.json")
+	backup := filepath.Join(dir, "state.backup.json")
+	if err := replaceFile(primary, backup); err != nil && !errors.Is(err, os.ErrNotExist) {
+		state.Generation--
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rotate spool state: %w", err)
+	}
+	if err := replaceFile(tmp, primary); err != nil {
+		state.Generation--
+		return fmt.Errorf("install spool state: %w", err)
+	}
+	if err := syncDirectory(dir); err != nil {
+		return fmt.Errorf("sync spool state directory: %w", err)
+	}
+	return nil
+}
+
+func writeSyncedFile(path string, data []byte, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	if err := securePath(path, mode); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// replaceFile has its platform-specific implementation because Windows does
+// not let os.Rename replace an existing destination.
+func replaceFile(from, to string) error { return replaceFilePlatform(from, to) }

--- a/internal/infrastructure/spool/test_helpers_test.go
+++ b/internal/infrastructure/spool/test_helpers_test.go
@@ -1,0 +1,106 @@
+package spool
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var testNow = time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+func testConfig(t *testing.T) Config {
+	t.Helper()
+	return Config{
+		Dir: t.TempDir(), Session: "session-1", Boot: "boot-1",
+		MaxBytes: 4 << 20, SegmentBytes: 64 << 10, MaxRecordBytes: 32 << 10,
+		PeekRecords: 128, PeekBytes: 1 << 20,
+		BatchInterval: time.Hour, BatchBytes: 1 << 20,
+		Sync: map[fleetagent.DeliveryPriority]SyncPolicy{
+			fleetagent.PriorityP0: SyncAlways,
+			fleetagent.PriorityP1: SyncAlways,
+			fleetagent.PriorityP2: SyncAlways,
+			fleetagent.PriorityP3: SyncBatch,
+		},
+		Now: func() time.Time { return testNow },
+	}
+}
+
+func testItem(priority fleetagent.DeliveryPriority, id string, size int) ports.SpoolItem {
+	class := detection.ClassProcess
+	mustNotShed := false
+	if priority == fleetagent.PriorityP2 {
+		class = detection.ClassFile
+		mustNotShed = true
+	}
+	if priority < fleetagent.PriorityP2 {
+		class = ""
+		mustNotShed = true
+	}
+	kind := ports.SpoolRecordTelemetry
+	if priority == fleetagent.PriorityP1 {
+		kind = ports.SpoolRecordDetection
+	}
+	if priority == fleetagent.PriorityP0 {
+		kind = ports.SpoolRecordSensorState
+	}
+	return ports.SpoolItem{
+		Kind: kind, Priority: priority, EventID: shared.ID(id), EventClass: class,
+		ContentType: "application/json", Payload: bytes.Repeat([]byte(id+"|"), max(1, size/max(1, len(id)+1))),
+		ObservedAt: testNow, MustNotShed: mustNotShed, SchemaVersion: 1,
+	}
+}
+
+func mustOpen(t *testing.T, cfg Config) *Spool {
+	t.Helper()
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("open spool: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Errorf("close spool: %v", err)
+		}
+	})
+	return s
+}
+
+func mustEnqueue(t *testing.T, s *Spool, item ports.SpoolItem) fleetagent.StreamPosition {
+	t.Helper()
+	position, err := s.Enqueue(context.Background(), item)
+	if err != nil {
+		t.Fatalf("enqueue %s: %v", item.EventID, err)
+	}
+	return position
+}
+
+func mustPeek(t *testing.T, s *Spool) []ports.SpoolRecord {
+	t.Helper()
+	records, err := s.Peek(context.Background(), ports.PeekSpoolRequest{MaxRecords: 10_000, MaxBytes: 64 << 20})
+	if err != nil {
+		t.Fatalf("peek: %v", err)
+	}
+	return records
+}
+
+func recordIDs(records []ports.SpoolRecord) []string {
+	result := make([]string, len(records))
+	for i := range records {
+		result[i] = records[i].EventID.String()
+	}
+	return result
+}
+
+func requireIDs(t *testing.T, records []ports.SpoolRecord, want ...string) {
+	t.Helper()
+	got := recordIDs(records)
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("record ids = %v, want %v", got, want)
+	}
+}

--- a/internal/usecase/ports/telemetry_spool.go
+++ b/internal/usecase/ports/telemetry_spool.go
@@ -1,0 +1,270 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+// ErrTelemetrySpoolSaturated is the transport-neutral backpressure signal a
+// producer may match without importing a concrete filesystem implementation.
+var ErrTelemetrySpoolSaturated = errors.New("telemetry spool saturated")
+
+// SpoolRecordKind identifies the durable lane payload without coupling the WAL to a future wire format.
+// Telemetry is produced by A1's canonical normalizer; the other kinds reserve the priority lanes A2 owns
+// so detection, coverage, sensor-health, and response verification never need a second competing spool.
+type SpoolRecordKind string
+
+const (
+	SpoolRecordTelemetry            SpoolRecordKind = "telemetry"
+	SpoolRecordDetection            SpoolRecordKind = "detection"
+	SpoolRecordCoverage             SpoolRecordKind = "coverage"
+	SpoolRecordSensorState          SpoolRecordKind = "sensor_state"
+	SpoolRecordResponseVerification SpoolRecordKind = "response_verification"
+)
+
+// Valid reports whether k is one of the version-one spool record kinds.
+func (k SpoolRecordKind) Valid() bool {
+	switch k {
+	case SpoolRecordTelemetry, SpoolRecordDetection, SpoolRecordCoverage,
+		SpoolRecordSensorState, SpoolRecordResponseVerification:
+		return true
+	default:
+		return false
+	}
+}
+
+// SpoolItem is an immutable security signal submitted to the durable agent WAL. Payload is the canonical
+// uncompressed representation owned by the producer. A2 preserves these exact bytes; A3 may batch and
+// compress them for transport without changing the durable commitment input.
+type SpoolItem struct {
+	Kind          SpoolRecordKind
+	Priority      fleetagent.DeliveryPriority
+	EventID       shared.ID
+	EventClass    detection.Class
+	ContentType   string
+	Payload       []byte
+	ObservedAt    time.Time
+	MustNotShed   bool
+	SchemaVersion int
+}
+
+// Validate enforces bounded-at-the-port semantics that do not depend on a concrete disk implementation.
+// Concrete size limits are Config-owned because operators choose the record and quota budgets.
+func (i SpoolItem) Validate() error {
+	if !i.Kind.Valid() {
+		return fmt.Errorf("%w: unknown spool record kind %q", shared.ErrValidation, i.Kind)
+	}
+	if !i.Priority.Valid() {
+		return fmt.Errorf("%w: unknown spool priority %d", shared.ErrValidation, int(i.Priority))
+	}
+	if i.EventID.IsZero() {
+		return fmt.Errorf("%w: spool item has no event id", shared.ErrValidation)
+	}
+	if i.ContentType == "" {
+		return fmt.Errorf("%w: spool item has no content type", shared.ErrValidation)
+	}
+	if len(i.Payload) == 0 {
+		return fmt.Errorf("%w: spool item has an empty payload", shared.ErrValidation)
+	}
+	if i.ObservedAt.IsZero() {
+		return fmt.Errorf("%w: spool item has no observed-at timestamp", shared.ErrValidation)
+	}
+	if i.SchemaVersion <= 0 {
+		return fmt.Errorf("%w: spool item schema version must be positive", shared.ErrValidation)
+	}
+	if i.Kind == SpoolRecordTelemetry && !i.EventClass.Valid() {
+		return fmt.Errorf("%w: telemetry spool item has invalid class %q", shared.ErrValidation, i.EventClass)
+	}
+	if i.Kind == SpoolRecordTelemetry && i.MustNotShed != telemetry.MustNotShed(i.EventClass) {
+		return fmt.Errorf("%w: telemetry class %s must-not-shed=%t, got %t", shared.ErrValidation,
+			i.EventClass, telemetry.MustNotShed(i.EventClass), i.MustNotShed)
+	}
+	// The priority contract makes P0..P2 non-sheddable. P3 is the only eviction lane; allowing a caller
+	// to mark a higher-priority item sheddable would turn a producer bug into silent security-data loss.
+	if i.Priority != fleetagent.PriorityP3 && !i.MustNotShed {
+		return fmt.Errorf("%w: %s spool item must be marked must-not-shed", shared.ErrValidation, i.Priority)
+	}
+	if i.MustNotShed && i.Priority == fleetagent.PriorityP3 {
+		return fmt.Errorf("%w: must-not-shed item cannot use the evictable P3 lane", shared.ErrValidation)
+	}
+	return nil
+}
+
+// SpoolRecord is one recovered, ordered WAL entry. The position is assigned durably by the spool; the
+// payload is copied on both ingress and egress so callers cannot mutate queued data through shared memory.
+type SpoolRecord struct {
+	Kind          SpoolRecordKind
+	Position      fleetagent.StreamPosition
+	EventID       shared.ID
+	EventClass    detection.Class
+	ContentType   string
+	Payload       []byte
+	ObservedAt    time.Time
+	EnqueuedAt    time.Time
+	MustNotShed   bool
+	SchemaVersion int
+}
+
+// Validate checks both the delivery coordinate and the record metadata recovered from disk.
+func (r SpoolRecord) Validate() error {
+	if err := r.Position.Validate(); err != nil {
+		return err
+	}
+	return SpoolItem{
+		Kind: r.Kind, Priority: r.Position.Priority, EventID: r.EventID, EventClass: r.EventClass,
+		ContentType: r.ContentType, Payload: r.Payload, ObservedAt: r.ObservedAt,
+		MustNotShed: r.MustNotShed, SchemaVersion: r.SchemaVersion,
+	}.Validate()
+}
+
+// PeekSpoolRequest bounds one priority-ordered read. Zero MaxRecords/MaxBytes asks the implementation to
+// use its safe defaults; a single record may exceed MaxBytes so callers can always make forward progress.
+type PeekSpoolRequest struct {
+	MaxRecords int
+	MaxBytes   int64
+}
+
+// SpoolACK is the highest contiguous record sequence the control plane durably accepted for one priority
+// incarnation. Epoch is mandatory: an ACK from before a reboot must never delete a new incarnation's data.
+type SpoolACK struct {
+	Priority fleetagent.DeliveryPriority
+	Epoch    uint64
+	Through  uint64
+}
+
+// Validate rejects ambiguous or malformed ACK coordinates.
+func (a SpoolACK) Validate() error {
+	if !a.Priority.Valid() {
+		return fmt.Errorf("%w: unknown ACK priority %d", shared.ErrValidation, int(a.Priority))
+	}
+	if a.Epoch == 0 || a.Through == 0 {
+		return fmt.Errorf("%w: ACK epoch and through sequence must be positive", shared.ErrValidation)
+	}
+	return nil
+}
+
+// SpoolACKResult reports the local effect of an idempotent ACK.
+type SpoolACKResult struct {
+	RemovedRecords int
+	ReclaimedBytes int64
+	HighestACKed   uint64
+}
+
+// SpoolGapReason is why a sequence or physical WAL interval cannot be delivered. These labels are stable
+// telemetry for A3/A6; Detail is deliberately not part of the contract because filesystem errors may
+// contain sensitive host paths.
+type SpoolGapReason string
+
+const (
+	SpoolGapQuotaEviction SpoolGapReason = "quota_eviction"
+	// SpoolGapQuotaBackpressure records that a non-sheddable producer reached
+	// the disk ceiling and was forced to stop/retry instead of silently dropping.
+	SpoolGapQuotaBackpressure SpoolGapReason = "quota_backpressure"
+	SpoolGapCorruptFrame      SpoolGapReason = "corrupt_frame"
+	SpoolGapTornWrite         SpoolGapReason = "torn_write"
+	SpoolGapUnsyncedTail      SpoolGapReason = "unsynced_tail"
+	SpoolGapStateRecovery     SpoolGapReason = "state_recovery"
+)
+
+// Valid reports whether r is a defined durable gap reason.
+func (r SpoolGapReason) Valid() bool {
+	switch r {
+	case SpoolGapQuotaEviction, SpoolGapQuotaBackpressure, SpoolGapCorruptFrame, SpoolGapTornWrite,
+		SpoolGapUnsyncedTail, SpoolGapStateRecovery:
+		return true
+	default:
+		return false
+	}
+}
+
+// SpoolGap is the agent-side, durable loss object. KnownSequence=false is reserved for damage so early in
+// a frame that even its coordinate could not be trusted; it remains queryable and makes coverage
+// incomplete without fabricating a sequence. A3 maps these records to the server's persisted gap model.
+type SpoolGap struct {
+	ID            shared.ID
+	Priority      fleetagent.DeliveryPriority
+	Epoch         uint64
+	FromSequence  uint64
+	ToSequence    uint64
+	KnownSequence bool
+	Reason        SpoolGapReason
+	Count         uint64
+	OccurredAt    time.Time
+}
+
+// Validate checks an honest gap: exact ranges when known, explicit unknown coordinates otherwise.
+func (g SpoolGap) Validate() error {
+	if g.ID.IsZero() {
+		return fmt.Errorf("%w: spool gap has no id", shared.ErrValidation)
+	}
+	if !g.Priority.Valid() {
+		return fmt.Errorf("%w: spool gap has invalid priority %d", shared.ErrValidation, int(g.Priority))
+	}
+	if !g.Reason.Valid() {
+		return fmt.Errorf("%w: spool gap has invalid reason %q", shared.ErrValidation, g.Reason)
+	}
+	if g.Epoch == 0 {
+		return fmt.Errorf("%w: spool gap has no epoch", shared.ErrValidation)
+	}
+	if g.OccurredAt.IsZero() {
+		return fmt.Errorf("%w: spool gap has no timestamp", shared.ErrValidation)
+	}
+	if g.Count == 0 {
+		return fmt.Errorf("%w: spool gap count must be positive", shared.ErrValidation)
+	}
+	if g.KnownSequence {
+		if g.FromSequence == 0 || g.ToSequence < g.FromSequence {
+			return fmt.Errorf("%w: spool gap has invalid sequence range %d..%d", shared.ErrValidation, g.FromSequence, g.ToSequence)
+		}
+		if want := g.ToSequence - g.FromSequence + 1; g.Count != want {
+			return fmt.Errorf("%w: spool gap count %d disagrees with range size %d", shared.ErrValidation, g.Count, want)
+		}
+	} else if g.FromSequence != 0 || g.ToSequence != 0 {
+		return fmt.Errorf("%w: unknown-coordinate spool gap cannot claim a sequence range", shared.ErrValidation)
+	}
+	return nil
+}
+
+// SpoolPriorityStats is a stable snapshot for one delivery lane.
+type SpoolPriorityStats struct {
+	Priority      fleetagent.DeliveryPriority
+	Records       int64
+	Bytes         int64
+	OldestUnacked time.Time
+	CurrentEpoch  uint64
+	NextSequence  uint64
+	HighestACKed  uint64
+}
+
+// SpoolStats is both an operator query and the source for the agent Prometheus collector.
+type SpoolStats struct {
+	Priorities       []SpoolPriorityStats
+	TotalRecords     int64
+	TotalBytes       int64
+	GapRecords       int64
+	GapBytes         int64
+	EvictedRecords   uint64
+	CorruptionEvents uint64
+	FsyncCount       uint64
+	FsyncTotal       time.Duration
+}
+
+// TelemetrySpool is the durable agent-side handoff between observation and transport. Implementations
+// must be safe for concurrent producers, preserve priority order, and make every accepted item either
+// readable until ACKed or represented by a durable SpoolGap.
+type TelemetrySpool interface {
+	Enqueue(ctx context.Context, item SpoolItem) (fleetagent.StreamPosition, error)
+	Peek(ctx context.Context, req PeekSpoolRequest) ([]SpoolRecord, error)
+	Ack(ctx context.Context, ack SpoolACK) (SpoolACKResult, error)
+	Flush(ctx context.Context) error
+	Gaps(ctx context.Context) ([]SpoolGap, error)
+	Stats(ctx context.Context) (SpoolStats, error)
+	Close() error
+}

--- a/internal/usecase/ports/telemetry_spool.go
+++ b/internal/usecase/ports/telemetry_spool.go
@@ -169,6 +169,7 @@ const (
 	SpoolGapQuotaBackpressure SpoolGapReason = "quota_backpressure"
 	SpoolGapCorruptFrame      SpoolGapReason = "corrupt_frame"
 	SpoolGapTornWrite         SpoolGapReason = "torn_write"
+	SpoolGapIOFailure         SpoolGapReason = "io_failure"
 	SpoolGapUnsyncedTail      SpoolGapReason = "unsynced_tail"
 	SpoolGapStateRecovery     SpoolGapReason = "state_recovery"
 )
@@ -177,7 +178,7 @@ const (
 func (r SpoolGapReason) Valid() bool {
 	switch r {
 	case SpoolGapQuotaEviction, SpoolGapQuotaBackpressure, SpoolGapCorruptFrame, SpoolGapTornWrite,
-		SpoolGapUnsyncedTail, SpoolGapStateRecovery:
+		SpoolGapIOFailure, SpoolGapUnsyncedTail, SpoolGapStateRecovery:
 		return true
 	default:
 		return false
@@ -245,8 +246,10 @@ type SpoolPriorityStats struct {
 
 // SpoolStats is both an operator query and the source for the agent Prometheus collector.
 type SpoolStats struct {
-	Priorities       []SpoolPriorityStats
-	TotalRecords     int64
+	Priorities   []SpoolPriorityStats
+	TotalRecords int64
+	// TotalBytes includes WAL records and GapBytes; GapBytes is exposed
+	// separately as the loss-evidence subset of the bounded spool quota.
 	TotalBytes       int64
 	GapRecords       int64
 	GapBytes         int64

--- a/internal/usecase/ports/telemetry_spool_test.go
+++ b/internal/usecase/ports/telemetry_spool_test.go
@@ -1,0 +1,97 @@
+package ports
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var spoolTestTime = time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+func validSpoolItem() SpoolItem {
+	return SpoolItem{
+		Kind: SpoolRecordTelemetry, Priority: fleetagent.PriorityP3, EventID: "event-1",
+		EventClass: detection.ClassProcess, ContentType: "application/json", Payload: []byte("{}"),
+		ObservedAt: spoolTestTime, SchemaVersion: 1,
+	}
+}
+
+func TestSpoolItemValidation(t *testing.T) {
+	if err := validSpoolItem().Validate(); err != nil {
+		t.Fatalf("valid item: %v", err)
+	}
+	tests := []struct {
+		name string
+		edit func(*SpoolItem)
+	}{
+		{"kind", func(i *SpoolItem) { i.Kind = "future" }},
+		{"priority", func(i *SpoolItem) { i.Priority = 9 }},
+		{"event id", func(i *SpoolItem) { i.EventID = "" }},
+		{"class", func(i *SpoolItem) { i.EventClass = "future" }},
+		{"content type", func(i *SpoolItem) { i.ContentType = "" }},
+		{"payload", func(i *SpoolItem) { i.Payload = nil }},
+		{"observed", func(i *SpoolItem) { i.ObservedAt = time.Time{} }},
+		{"schema", func(i *SpoolItem) { i.SchemaVersion = 0 }},
+		{"P2 shed", func(i *SpoolItem) {
+			i.Priority = fleetagent.PriorityP2
+			i.EventClass = detection.ClassFile
+			i.MustNotShed = false
+		}},
+		{"P3 no-shed", func(i *SpoolItem) { i.MustNotShed = true }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := validSpoolItem()
+			tt.edit(&item)
+			if err := item.Validate(); err == nil || !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestSpoolGapValidation(t *testing.T) {
+	gap := SpoolGap{
+		ID: "gap-1", Priority: fleetagent.PriorityP3, Epoch: 2,
+		FromSequence: 4, ToSequence: 6, KnownSequence: true,
+		Reason: SpoolGapQuotaEviction, Count: 3, OccurredAt: spoolTestTime,
+	}
+	if err := gap.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	bad := gap
+	bad.Count = 2
+	if err := bad.Validate(); err == nil {
+		t.Fatal("range/count mismatch accepted")
+	}
+	unknown := gap
+	unknown.KnownSequence = false
+	unknown.FromSequence, unknown.ToSequence, unknown.Count = 0, 0, 1
+	unknown.Reason = SpoolGapQuotaBackpressure
+	if err := unknown.Validate(); err != nil {
+		t.Fatalf("valid unknown gap: %v", err)
+	}
+	unknown.FromSequence = 1
+	if err := unknown.Validate(); err == nil {
+		t.Fatal("unknown gap claimed a sequence")
+	}
+}
+
+func TestSpoolACKValidation(t *testing.T) {
+	if err := (SpoolACK{Priority: fleetagent.PriorityP1, Epoch: 2, Through: 9}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+	for _, ack := range []SpoolACK{
+		{Priority: 7, Epoch: 1, Through: 1},
+		{Priority: fleetagent.PriorityP1, Epoch: 0, Through: 1},
+		{Priority: fleetagent.PriorityP1, Epoch: 1, Through: 0},
+	} {
+		if err := ack.Validate(); err == nil {
+			t.Errorf("invalid ACK accepted: %#v", ack)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #623.

Implements the A2 priority durable agent WAL and wires it into the live host-agent detection path. Raw eBPF observations are normalized to the canonical A1 telemetry envelope and committed before rule evaluation; confirmed detections, coverage snapshots, and per-class sensor state enter the same WAL at their contracted priorities.

This preserves the delivery claim from #609: at-least-once delivery, incarnation-aware monotonic positions, highest-contiguous exact-epoch ACKs, and explicit durable gaps. It does not claim exactly-once delivery.

## Changes

- Add ports.TelemetrySpool with immutable enqueue/read records, exact priority+epoch ACKs, stats, and queryable loss evidence.
- Add checksummed per-priority segment files with a fixed bounded frame format, payload CRC32C, exclusive process locking, owner-only Unix modes, bounded recovery allocation, and atomic dual-generation state.
- Resume sequence after process restart; advance Epoch on boot/enrolment change or state loss; never reuse an incarnation already present in WAL or gap history.
- Detect torn/hand-corrupted frames, resynchronize to later valid frames, commit exact or explicitly unknown gaps, and atomically rewrite repaired segments so corruption is not rediscovered every restart.
- Enforce a logical disk quota by deleting P3 segments only after exact eviction gaps are fsynced. P0-P2 return the shared saturation/backpressure error and record a durable quota-backpressure gap; repeated retries of the same event do not flood the gap journal.
- Roll partial WAL and gap-journal writes back to their last known-good offsets. ENOSPC becomes observable backpressure rather than a malformed tail.
- Persist ACK state before deleting bytes; reject ahead/stale-incarnation ACKs and keep equal/regressive ACKs idempotent.
- Add configurable P3 batch sync, mandatory always-sync for P0-P2, flush/close semantics, and fsync metrics.
- Add capped exponential full-jitter retry policy for network errors, 408, 429 with bounded Retry-After, and 5xx; other 4xx are permanent.
- Add a private Prometheus collector/listener with bounded priority-only labels for depth, bytes, oldest-unacked age, sequence/ACK, gaps, eviction, corruption, and fsync latency.
- Replace the host agent detection file sink with the durable P1 sink and add a sensor adapter which commits normalized raw telemetry before forwarding it to rule evaluation. Legacy userspace-only event timestamps are flagged as kernel-timestamp-unavailable rather than presented as kernel truth.
- Persist aggregate coverage and per-class sensor-state snapshots as never-shed P0 records.
- Document the on-disk format, crash ordering, recovery invariants, quota behavior, A3 handoff, settings, and metrics.

## Safety invariants covered by tests

- enqueue -> close/restart -> exact membership and lane ordering survive; sequence continues
- boot/session change -> Epoch increments and Sequence restarts at 1
- accepted record -> readable, ACKed, or covered by durable gap evidence
- P3 is evicted first; P0-P2 are never deleted under pressure
- gap fsync precedes P3 deletion; ACK persistence precedes segment deletion
- a corrupt middle frame is skipped while later frames remain readable
- a torn or unsynced tail becomes exact loss evidence without coordinate reuse
- both corrupt state generations recover into a new non-reused incarnation
- concurrent producers receive unique monotonically increasing coordinates
- one process owns a spool directory at a time on Unix and Windows
- retry classification, jitter bounds, metric values, and deterministic record IDs

## Non-goals

A3 still owns wire batching, signing, HTTP delivery, server ACK exchange, and mapping local gaps into the control-plane persisted gap model. This PR exposes Peek, Ack, Gaps, and RetryPolicy for that work; it does not add a competing transport.

## Validation

- [x] go build ./cmd/...
- [x] go vet ./...
- [x] go test ./... -count=1
- [x] pnpm run typecheck in web
- [x] Linux amd64 cross-compilation for spool, agentspool adapter, and synapse-agent
- [x] focused frame fuzz run: 209,662 executions, no crash
- [x] tests added for restart, corruption, torn writes, quota/backpressure, property invariant, concurrency, metrics, retry, agent wiring, and platform locks
- [x] documentation/configuration drift guards pass
- [x] no dashboard changes; web build/screenshots not applicable
- [x] no new HTTP routes or OpenAPI changes

The local Windows Go toolchain has no C compiler, so the race-enabled run is left to the repository Linux CI job; the concurrency suite itself passes locally and the Linux targets compile.