### PR TITLE
feat: complete EPIC 583 production readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,19 @@
 # routes require it; GET /healthz and GET /readyz are intentionally public. Generate: openssl rand -hex 32
 SYNAPSE_API_TOKEN=
 
+# Optional browser OIDC BFF. Discovery is pinned to this HTTPS issuer; identities must already
+# be linked in the fixed tenant. Provider tokens and claims are neither persisted nor logged.
+# SYNAPSE_OIDC_ENABLED=false
+# SYNAPSE_OIDC_ISSUER=https://issuer.example
+# SYNAPSE_OIDC_CLIENT_ID=
+# SYNAPSE_OIDC_CLIENT_SECRET=
+# SYNAPSE_OIDC_REDIRECT_URL=https://synapse.example/api/auth/oidc/callback
+# SYNAPSE_OIDC_FRONTEND_URL=https://synapse.example/
+# SYNAPSE_OIDC_TENANT_ID=default
+# SYNAPSE_OIDC_GROUP_ROLE_MAPPING=synapse-admins=admin,synapse-reviewers=reviewer
+# SYNAPSE_OIDC_TRANSACTION_TTL=10m
+# SYNAPSE_OIDC_SESSION_TTL=8h
+
 # =============================================================================
 # Core / server
 # =============================================================================

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -22,6 +22,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/KKloudTarus/synapse-ce/internal/adapter/httpapi"
 	"github.com/KKloudTarus/synapse-ce/internal/adapter/observability"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
@@ -43,6 +45,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetca"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/llm/openai"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/logstream"
+	oidcadapter "github.com/KKloudTarus/synapse-ce/internal/infrastructure/oidc"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/file"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
@@ -138,6 +141,8 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetrolloutuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fptriage"
+	identitybff "github.com/KKloudTarus/synapse-ce/internal/usecase/identitybff"
+	identityuc "github.com/KKloudTarus/synapse-ce/internal/usecase/identityuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/jsreach"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/leaderuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/llmverifier"
@@ -240,6 +245,10 @@ func main() {
 		log.Error("database migration posture invalid", "err", err)
 		os.Exit(1)
 	}
+	if err := cfg.ValidateOIDCPosture(); err != nil {
+		log.Error("OIDC posture invalid", "err", err)
+		os.Exit(1)
+	}
 
 	// Fail closed: no anonymous access. The token is never logged.
 	if cfg.APIToken == "" {
@@ -252,6 +261,7 @@ func main() {
 	acquirer := acquire.New().WithMaxWorkspaceBytes(cfg.MaxWorkspaceBytes).WithImageRootFS(cfg.ImageRootFSEnabled).WithComparisonDepth(cfg.ProjectGitComparisonDepth)
 
 	// Persistence: PostgreSQL when configured, else file + in-memory (dev).
+	var databasePool *pgxpool.Pool
 	var repo ports.EngagementRepository
 	var projectRepo ports.ProjectRepository
 	var assetStore ports.AssetRepository
@@ -269,6 +279,7 @@ func main() {
 	var commentRepo ports.CommentRepository
 	var retestRepo ports.RetestRepository
 	var userRepo ports.UserRepository
+	var identityStore ports.IdentityStore
 	var auditReader ports.AuditReader
 	var scanRepo ports.ScanRepository
 	var scanResultStore ports.ScanResultStore
@@ -379,27 +390,13 @@ func main() {
 			os.Exit(1)
 		}
 		defer pool.Close()
+		databasePool = pool
 		readinessChecks["database"] = func(ctx context.Context) error {
 			return postgres.CheckDatabaseReady(ctx, pool)
 		}
 		readinessChecks["migrations"] = func(ctx context.Context) error {
 			return postgres.CheckMigrationsReady(ctx, pool)
 		}
-		// Single-instance guard: until horizontal scaling the repos
-		// ignore tenant_id and there is no leader election, so two writers would race. A
-		// session advisory lock makes the assumption explicit + enforced – a second
-		// instance fails fast instead of silently corrupting state.
-		lockConn, ok, lerr := postgres.AcquireSingletonLock(startup, pool, "api")
-		if lerr != nil {
-			log.Error("single-instance lock check failed", "err", lerr)
-			os.Exit(1)
-		}
-		if !ok {
-			log.Error("another synapse-api instance holds the single-instance lock – this build runs ONE instance (stop the other first); horizontal scaling is P5")
-			os.Exit(1)
-		}
-		defer lockConn.Release()
-		log.Info("acquired single-instance advisory lock")
 		repo = postgres.NewEngagementRepository(pool)
 		projectRepo = postgres.NewProjectRepository(pool)
 		findingRepo = postgres.NewFindingRepository(pool)
@@ -407,6 +404,11 @@ func main() {
 		commentRepo = postgres.NewCommentRepository(pool)
 		retestRepo = postgres.NewRetestRepository(pool)
 		userRepo = postgres.NewUserRepository(pool)
+		identityStore, err = postgres.NewIdentityStore(pool)
+		if err != nil {
+			log.Error("postgres OIDC identity store init failed", "err", err)
+			os.Exit(1)
+		}
 		scanRepo = postgres.NewScanRepository(pool)
 		vulnerabilityInventory = postgres.NewComponentInventoryStore(pool)
 		scanResultStore = postgres.NewScanResultStore(pool)
@@ -491,6 +493,12 @@ func main() {
 		commentRepo = memory.NewCommentRepository()
 		retestRepo = memory.NewRetestRepository()
 		userRepo = memory.NewUserRepository()
+		var identityStoreErr error
+		identityStore, identityStoreErr = memory.NewIdentityStore(userRepo)
+		if identityStoreErr != nil {
+			log.Error("memory OIDC identity store init failed", "err", identityStoreErr)
+			os.Exit(1)
+		}
 		memoryInventory := memory.NewComponentInventoryStore()
 		scanRepo = memory.NewScanRepository(memoryInventory)
 		vulnerabilityInventory = memoryInventory
@@ -1172,6 +1180,52 @@ func main() {
 		os.Exit(1)
 	}
 	router := httpapi.NewRouter(log, auth, engService, scaService, aupService, findingsService, exportService, reportService, evidenceService, reconService, logBroker, transferService, auditService, vexService, usersService, credentialsService)
+	if cfg.OIDCEnabled {
+		provider, oidcErr := oidcadapter.New(context.Background(), oidcadapter.Config{
+			Issuer: cfg.OIDCIssuer, ClientID: cfg.OIDCClientID, ClientSecret: cfg.OIDCClientSecret,
+			RedirectURL: cfg.OIDCRedirectURL, GroupRoleMapping: cfg.OIDCGroupRoleMapping,
+		})
+		if oidcErr != nil {
+			log.Error("OIDC provider initialization failed", "err", oidcErr)
+			os.Exit(1)
+		}
+		identityService, oidcErr := identityuc.NewService(identityStore, oidcadapter.NewSecretProtector(vaultCipher), clock, ids)
+		if oidcErr != nil {
+			log.Error("OIDC identity service initialization failed", "err", oidcErr)
+			os.Exit(1)
+		}
+		oidcService, oidcErr := identitybff.NewService(provider, identityService, identityStore, userRepo, clock, ids, identitybff.Config{
+			TenantID: shared.ID(cfg.OIDCTenantID), TransactionTTL: cfg.OIDCTransactionTTL, SessionTTL: cfg.OIDCSessionTTL,
+		})
+		if oidcErr != nil {
+			log.Error("OIDC BFF initialization failed", "err", oidcErr)
+			os.Exit(1)
+		}
+		httpOIDCService, oidcErr := httpapi.NewOIDCService(
+			func(ctx context.Context) (httpapi.OIDCAuthorization, error) {
+				result, err := oidcService.Begin(ctx)
+				return httpapi.OIDCAuthorization{URL: result.URL, Nonce: result.Nonce}, err
+			},
+			func(ctx context.Context, state, code, nonce string) (httpapi.OIDCSession, error) {
+				result, err := oidcService.Complete(ctx, state, code, nonce)
+				return httpapi.OIDCSession{Token: result.Token, CSRFToken: result.CSRFToken, Principal: httpapi.OIDCPrincipal{ID: result.Principal.ID, Name: result.Principal.Name, Role: result.Principal.Role, TenantID: result.Principal.TenantID}}, err
+			},
+			func(ctx context.Context, token string) (httpapi.OIDCSession, error) {
+				result, err := oidcService.Discover(ctx, token)
+				return httpapi.OIDCSession{Token: result.Token, CSRFToken: result.CSRFToken, Principal: httpapi.OIDCPrincipal{ID: result.Principal.ID, Name: result.Principal.Name, Role: result.Principal.Role, TenantID: result.Principal.TenantID}}, err
+			},
+			func(ctx context.Context, token, csrf string, unsafe bool) (httpapi.OIDCPrincipal, error) {
+				result, err := oidcService.Authenticate(ctx, token, csrf, unsafe)
+				return httpapi.OIDCPrincipal{ID: result.ID, Name: result.Name, Role: result.Role, TenantID: result.TenantID}, err
+			},
+			oidcService.Logout,
+		)
+		if oidcErr != nil {
+			log.Error("OIDC HTTP service initialization failed", "err", oidcErr)
+			os.Exit(1)
+		}
+		router.SetOIDC(httpOIDCService, cfg.OIDCFrontendURL)
+	}
 	router.SetReadinessChecks(readinessChecks)
 	if slaService != nil {
 		router.SetSLA(slaService)
@@ -1186,7 +1240,7 @@ func main() {
 			log.Error("metrics enabled but the configured job queue does not support aggregate stats")
 			os.Exit(1)
 		}
-		metrics = observability.New(queueReader)
+		metrics = observability.New(queueReader, postgres.NewPoolStatsSource(databasePool))
 		httpObserver = metrics
 		scaService.SetObserver(metrics)
 		if !metricsAddrIsLoopback(cfg.MetricsAddr) {

--- a/cmd/synapse-bench/main.go
+++ b/cmd/synapse-bench/main.go
@@ -1,0 +1,69 @@
+// Command synapse-bench reduces supplied benchmark fixture observations into a deterministic report.
+// It does not execute workloads, provision infrastructure, or contact external services.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/benchmark"
+)
+
+func main() {
+	inputPath := flag.String("input", "", "versioned benchmark input JSON")
+	outputPath := flag.String("output", "", "output benchmark report JSON (default: stdout)")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "synapse-bench: positional arguments are not supported")
+		os.Exit(1)
+	}
+	if err := run(*inputPath, *outputPath, os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "synapse-bench:", err)
+		os.Exit(1)
+	}
+}
+
+func run(inputPath, outputPath string, stdin io.Reader, stdout io.Writer) error {
+	inputReader := stdin
+	var inputFile *os.File
+	if inputPath != "" {
+		file, err := os.Open(inputPath)
+		if err != nil {
+			return fmt.Errorf("open benchmark input: %w", err)
+		}
+		inputFile = file
+		defer func() { _ = inputFile.Close() }()
+		inputReader = inputFile
+	}
+	input, err := benchmark.DecodeInput(inputReader)
+	if err != nil {
+		return err
+	}
+	report, err := benchmark.Evaluate(input)
+	if err != nil {
+		return fmt.Errorf("evaluate benchmark input: %w", err)
+	}
+
+	outputWriter := stdout
+	var outputFile *os.File
+	if outputPath != "" && outputPath != "-" {
+		file, err := os.Create(outputPath)
+		if err != nil {
+			return fmt.Errorf("create benchmark output: %w", err)
+		}
+		outputFile = file
+		defer func() { _ = outputFile.Close() }()
+		outputWriter = outputFile
+	}
+	if err := benchmark.EncodeReport(outputWriter, report); err != nil {
+		return err
+	}
+	if outputFile != nil {
+		if err := outputFile.Sync(); err != nil {
+			return fmt.Errorf("sync benchmark output: %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/synapse-bench/main_test.go
+++ b/cmd/synapse-bench/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/benchmark"
+)
+
+func TestRunWritesDeterministicJSON(t *testing.T) {
+	input := `{"schema_version":"synapse-benchmark-input-v1","metadata":{"environment":"fixture","environment_digest":"env","release":"release","release_digest":"rel","data_digest":"data"},"window":{"duration_milliseconds":1000},"requests":[{"duration_milliseconds":10,"succeeded":true}],"queue":{"delay_milliseconds":[2],"recovery_milliseconds":[3]},"pool":{"acquisition_milliseconds":[4],"saturation_events":0},"evidence":{"database_before_bytes":1,"database_after_bytes":2,"object_before_bytes":3,"object_after_bytes":5},"migration":{"duration_milliseconds":6},"api_failovers":[],"correctness":[]}`
+	var stdout bytes.Buffer
+	if err := run("", "", strings.NewReader(input), &stdout); err != nil {
+		t.Fatal(err)
+	}
+	var report benchmark.Report
+	if err := jsonUnmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.SchemaVersion != benchmark.OutputSchemaVersion || report.Throughput.RequestsPerSecond != 1 || report.Requests.Failures != 0 {
+		t.Fatalf("report = %+v", report)
+	}
+}
+
+func TestRunReturnsErrorForInvalidInput(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run("", "", strings.NewReader(`{"schema_version":"wrong"}`), &stdout)
+	if err == nil || !strings.Contains(err.Error(), "evaluate benchmark input") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCLIExitsNonZeroForInvalidInput(t *testing.T) {
+	command := exec.Command("go", "run", ".")
+	command.Stdin = strings.NewReader(`{"schema_version":"wrong"}`)
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	if err := command.Run(); err == nil {
+		t.Fatal("CLI succeeded with invalid input")
+	}
+	if !strings.Contains(stderr.String(), "synapse-bench:") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func jsonUnmarshal(data []byte, value any) error {
+	return json.Unmarshal(data, value)
+}

--- a/cmd/synapse-fptriage-blind/main.go
+++ b/cmd/synapse-fptriage-blind/main.go
@@ -1,0 +1,292 @@
+// Command synapse-fptriage-blind manages offline blinded human review packets for an existing shadow
+// evaluation report. It never invokes an LLM or changes a quality-gate decision.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+func main() {
+	mode := flag.String("mode", "", "export, import, or join")
+	datasetPath := flag.String("dataset", "", "locked evaluation dataset JSON (export and join)")
+	reportPath := flag.String("report", "", "locked shadow evaluation report JSON")
+	packetPath := flag.String("packet", "", "blind packet JSON (import and join)")
+	submissionPath := flag.String("submission", "", "reviewer decision submission JSON (import) or authenticated receipt JSON (join)")
+	reviewer := flag.String("reviewer", "", "trusted-boundary human reviewer identity (import only; never read from submission JSON)")
+	humanReviewersPath := flag.String("human-reviewers", "", "private operator-owned allowlist file, one human reviewer identity per line")
+	authKeyPath := flag.String("auth-key-file", "", "private operator HMAC key file, at least 32 bytes")
+	seed := flag.String("seed", "", "private reproducibility seed (export only)")
+	outputPath := flag.String("output", "", "new output artifact path")
+	flag.Parse()
+
+	if err := run(*mode, *datasetPath, *reportPath, *packetPath, *submissionPath, *seed, *reviewer, *humanReviewersPath, *authKeyPath, *outputPath); err != nil {
+		fmt.Fprintf(os.Stderr, "synapse-fptriage-blind: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(mode, datasetPath, reportPath, packetPath, submissionPath, seed, reviewer, humanReviewersPath, authKeyPath, outputPath string) error {
+	mode = strings.TrimSpace(mode)
+	if mode != "export" && mode != "import" && mode != "join" {
+		return fmt.Errorf("--mode must be export, import, or join")
+	}
+	outputPath = strings.TrimSpace(outputPath)
+	if outputPath == "" || outputPath == "-" {
+		return fmt.Errorf("--output must be a new private file path")
+	}
+	if _, err := os.Lstat(outputPath); err == nil || !os.IsNotExist(err) {
+		return fmt.Errorf("--output must be a new private file path")
+	}
+	authenticator, err := loadAuthenticator(authKeyPath)
+	if err != nil {
+		return err
+	}
+	allowedHumanReviewers, err := loadHumanReviewers(humanReviewersPath)
+	if err != nil {
+		return err
+	}
+	var value any
+	switch mode {
+	case "export":
+		dataset, report, err := loadDatasetAndReport(datasetPath, reportPath)
+		if err != nil {
+			return err
+		}
+		packet, err := sca.ExportBlindFPTriagePacket(dataset, report, seed, authenticator)
+		if err != nil {
+			return err
+		}
+		value = packet
+	case "import":
+		packet, err := loadPacket(packetPath)
+		if err != nil {
+			return err
+		}
+		report, err := loadReport(reportPath)
+		if err != nil {
+			return err
+		}
+		submission, err := loadSubmission(submissionPath)
+		if err != nil {
+			return err
+		}
+		imported, err := sca.ImportBlindFPTriageSubmission(packet, submission, reviewer, allowedHumanReviewers, report.Run.ProposerModel, report.Run.VerifierModel, authenticator)
+		if err != nil {
+			return err
+		}
+		value = imported
+	case "join":
+		dataset, report, err := loadDatasetAndReport(datasetPath, reportPath)
+		if err != nil {
+			return err
+		}
+		packet, err := loadPacket(packetPath)
+		if err != nil {
+			return err
+		}
+		submission, err := loadImportedSubmission(submissionPath)
+		if err != nil {
+			return err
+		}
+		joined, err := sca.JoinBlindFPTriageSubmission(dataset, report, packet, submission, allowedHumanReviewers, authenticator)
+		if err != nil {
+			return err
+		}
+		value = joined
+	default:
+		return fmt.Errorf("--mode must be export, import, or join")
+	}
+	return writePrivateJSON(outputPath, value)
+}
+
+func loadDatasetAndReport(datasetPath, reportPath string) (sca.AIEvaluationDataset, sca.AIEvaluationReport, error) {
+	if strings.TrimSpace(datasetPath) == "" || strings.TrimSpace(reportPath) == "" {
+		return sca.AIEvaluationDataset{}, sca.AIEvaluationReport{}, fmt.Errorf("--dataset and --report are required")
+	}
+	datasetBytes, err := os.ReadFile(datasetPath)
+	if err != nil {
+		return sca.AIEvaluationDataset{}, sca.AIEvaluationReport{}, fmt.Errorf("read dataset: %w", err)
+	}
+	dataset, err := sca.LoadAIEvaluationDataset(datasetBytes)
+	if err != nil {
+		return sca.AIEvaluationDataset{}, sca.AIEvaluationReport{}, err
+	}
+	report, err := loadReport(reportPath)
+	if err != nil {
+		return sca.AIEvaluationDataset{}, sca.AIEvaluationReport{}, err
+	}
+	return dataset, report, nil
+}
+
+func loadReport(path string) (sca.AIEvaluationReport, error) {
+	if strings.TrimSpace(path) == "" {
+		return sca.AIEvaluationReport{}, fmt.Errorf("--report is required")
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return sca.AIEvaluationReport{}, fmt.Errorf("read evaluation report: %w", err)
+	}
+	report, err := sca.LoadAIEvaluationReport(b)
+	if err != nil {
+		return sca.AIEvaluationReport{}, fmt.Errorf("load evaluation report: %w", err)
+	}
+	return report, nil
+}
+
+func loadPacket(path string) (sca.BlindFPTriagePacket, error) {
+	if strings.TrimSpace(path) == "" {
+		return sca.BlindFPTriagePacket{}, fmt.Errorf("--packet is required")
+	}
+	var packet sca.BlindFPTriagePacket
+	if err := readStrictJSON(path, &packet); err != nil {
+		return packet, fmt.Errorf("read blind packet: %w", err)
+	}
+	return packet, nil
+}
+
+func loadSubmission(path string) (sca.BlindFPTriageSubmission, error) {
+	if strings.TrimSpace(path) == "" {
+		return sca.BlindFPTriageSubmission{}, fmt.Errorf("--submission is required")
+	}
+	var submission sca.BlindFPTriageSubmission
+	if err := readStrictJSON(path, &submission); err != nil {
+		return submission, fmt.Errorf("read blind submission: %w", err)
+	}
+	return submission, nil
+}
+
+func loadImportedSubmission(path string) (sca.BlindFPTriageImportedSubmission, error) {
+	if strings.TrimSpace(path) == "" {
+		return sca.BlindFPTriageImportedSubmission{}, fmt.Errorf("--submission is required")
+	}
+	var submission sca.BlindFPTriageImportedSubmission
+	if err := readStrictJSON(path, &submission); err != nil {
+		return submission, fmt.Errorf("read authenticated blind submission: %w", err)
+	}
+	return submission, nil
+}
+
+func loadAuthenticator(path string) (sca.BlindFPTriageAuthenticator, error) {
+	if strings.TrimSpace(path) == "" {
+		return sca.BlindFPTriageAuthenticator{}, fmt.Errorf("--auth-key-file is required")
+	}
+	if err := requirePrivateFile(path); err != nil {
+		return sca.BlindFPTriageAuthenticator{}, fmt.Errorf("blind authentication key: %w", err)
+	}
+	key, err := os.ReadFile(path)
+	if err != nil {
+		return sca.BlindFPTriageAuthenticator{}, fmt.Errorf("read blind authentication key: %w", err)
+	}
+	return sca.NewBlindFPTriageAuthenticator(bytes.TrimSpace(key))
+}
+
+func loadHumanReviewers(path string) ([]string, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("--human-reviewers is required")
+	}
+	if err := requirePrivateFile(path); err != nil {
+		return nil, fmt.Errorf("human reviewer allowlist: %w", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read human reviewer allowlist: %w", err)
+	}
+	var reviewers []string
+	for _, line := range bytes.Split(b, []byte{10}) {
+		if identity := strings.TrimSpace(string(line)); identity != "" && !strings.HasPrefix(identity, "#") {
+			reviewers = append(reviewers, identity)
+		}
+	}
+	if len(reviewers) == 0 {
+		return nil, fmt.Errorf("human reviewer allowlist is empty")
+	}
+	return reviewers, nil
+}
+
+func readStrictJSON(path string, dst any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("trailing JSON content")
+	}
+	return nil
+}
+
+// requirePrivateFile rejects operator secrets and allowlists that another local account could
+// read or substitute: symlinks, non-regular files, and group- or world-accessible modes. Windows
+// is refused because this command cannot verify a current-user-only ACL.
+func requirePrivateFile(path string) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("private input files are not supported on Windows: current-user-only ACL verification is unavailable in this command")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat private input: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("private input must be a regular file, not a symlink or special file")
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("private input must not grant group or other access")
+	}
+	return nil
+}
+
+func writePrivateJSON(path string, value any) error {
+	if filepath.Base(path) == "." {
+		return fmt.Errorf("invalid output path")
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(path))
+	if err != nil {
+		return fmt.Errorf("private output parent must be a pre-existing directory: %w", err)
+	}
+	info, err := os.Stat(parent)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("private output parent must be a pre-existing directory")
+	}
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("private output is disabled on Windows: current-user-only ACL establishment and verification are unavailable in this command; use a platform with verifiable private permissions")
+	}
+	if info.Mode().Perm()&0o007 != 0 {
+		return fmt.Errorf("private output parent must not grant group or other access")
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create blind workflow output: %w", err)
+	}
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("write blind workflow output: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("sync blind workflow output: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("close blind workflow output: %w", err)
+	}
+	return nil
+}

--- a/cmd/synapse-fptriage-blind/main_test.go
+++ b/cmd/synapse-fptriage-blind/main_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsInvalidModeBeforeWriting(t *testing.T) {
+	err := run("invalid", "", "", "", "", "", "", "", "", filepath.Join(t.TempDir(), "output.json"))
+	if err == nil || !strings.Contains(err.Error(), "--mode must be export, import, or join") {
+		t.Fatalf("run() error = %v", err)
+	}
+}
+
+func TestRunRequiresNewOutputPath(t *testing.T) {
+	if err := run("export", "", "", "", "", "", "", "", "", ""); err == nil || !strings.Contains(err.Error(), "--output") {
+		t.Fatalf("run() error = %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "existing.json")
+	if err := os.WriteFile(path, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := run("export", "", "", "", "", "", "", "", "", path); err == nil || !strings.Contains(err.Error(), "new private file") {
+		t.Fatalf("run() error = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "keep" {
+		t.Fatalf("existing output was modified: %q", data)
+	}
+}
+
+func TestReadStrictJSONRejectsUnknownAndTrailingContent(t *testing.T) {
+	dir := t.TempDir()
+	for _, tt := range []struct {
+		name string
+		data string
+	}{
+		{name: "unknown", data: `{"reviewers":["human"],"unexpected":true}`},
+		{name: "trailing", data: `{"reviewers":["human"]}{}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, tt.name+".json")
+			if err := os.WriteFile(path, []byte(tt.data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var value struct {
+				Reviewers []string `json:"reviewers"`
+			}
+			if err := readStrictJSON(path, &value); err == nil {
+				t.Fatal("invalid JSON was accepted")
+			}
+		})
+	}
+}
+
+func TestWritePrivateJSONFailsClosedOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific fail-closed behavior")
+	}
+	path := filepath.Join(t.TempDir(), "output.json")
+	err := writePrivateJSON(path, map[string]bool{"ok": true})
+	if err == nil || !strings.Contains(err.Error(), "disabled on Windows") {
+		t.Fatalf("writePrivateJSON() error = %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("output was created despite fail-closed behavior: %v", err)
+	}
+}
+
+func TestWritePrivateJSONCreatesExclusivePrivateFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the command intentionally fails closed on Windows")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "output.json")
+	if err := writePrivateJSON(path, map[string]string{"status": "ok"}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("output permissions = %o, want 600", info.Mode().Perm())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["status"] != "ok" {
+		t.Fatalf("output = %v", decoded)
+	}
+	if err := writePrivateJSON(path, decoded); err == nil {
+		t.Fatal("existing output was overwritten")
+	}
+}

--- a/cmd/synapse-verify-restore/main.go
+++ b/cmd/synapse-verify-restore/main.go
@@ -1,0 +1,277 @@
+// Command synapse-verify-restore verifies a restored PostgreSQL database and
+// evidence bucket without changing either system.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/restoreverify"
+)
+
+const (
+	defaultTimeout = 2 * time.Minute
+	maxPoolConns   = int32(2)
+)
+
+var errIntegrity = errors.New("restore verification found integrity failures")
+
+type settings struct {
+	dbDSN         string
+	blobEndpoint  string
+	blobAccessKey string
+	blobSecretKey string
+	blobBucket    string
+	blobUseSSL    bool
+	timeout       time.Duration
+	expectedState *ports.RestoreExpectedState
+}
+
+type verifier interface {
+	Verify(context.Context) (restoreverify.Result, error)
+}
+
+type buildVerifier func(context.Context, settings) (verifier, func(), error)
+
+func main() {
+	manifestPath := flag.String("expected-state", "", "path to expected restore state manifest")
+	flag.Parse()
+	cfg, err := loadSettings(os.Getenv)
+	path := strings.TrimSpace(*manifestPath)
+	if path == "" {
+		path = strings.TrimSpace(os.Getenv("SYNAPSE_RESTORE_VERIFY_EXPECTED_STATE"))
+	}
+	if err == nil && path != "" {
+		cfg.expectedState, err = loadExpectedState(path)
+	}
+	if err != nil {
+		writeError(err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	if err := run(ctx, cfg, newVerifier, os.Stdout); err != nil {
+		writeError(err)
+		os.Exit(1)
+	}
+}
+
+func loadSettings(getenv func(string) string) (settings, error) {
+	cfg := settings{
+		dbDSN:         strings.TrimSpace(getenv("SYNAPSE_DB_DSN")),
+		blobEndpoint:  strings.TrimSpace(getenv("SYNAPSE_BLOB_ENDPOINT")),
+		blobAccessKey: strings.TrimSpace(getenv("SYNAPSE_BLOB_ACCESS_KEY")),
+		blobSecretKey: strings.TrimSpace(getenv("SYNAPSE_BLOB_SECRET_KEY")),
+		blobBucket:    strings.TrimSpace(getenv("SYNAPSE_BLOB_BUCKET")),
+	}
+	if cfg.dbDSN == "" {
+		return settings{}, errors.New("SYNAPSE_DB_DSN is required")
+	}
+	if cfg.blobEndpoint == "" || cfg.blobAccessKey == "" || cfg.blobSecretKey == "" || cfg.blobBucket == "" {
+		return settings{}, errors.New("SYNAPSE_BLOB_ENDPOINT, SYNAPSE_BLOB_ACCESS_KEY, SYNAPSE_BLOB_SECRET_KEY, and SYNAPSE_BLOB_BUCKET are required")
+	}
+
+	useSSL, err := parseBool(getenv("SYNAPSE_BLOB_USE_SSL"))
+	if err != nil {
+		return settings{}, errors.New("SYNAPSE_BLOB_USE_SSL must be a boolean")
+	}
+	cfg.blobUseSSL = useSSL
+
+	cfg.timeout = defaultTimeout
+	if raw := strings.TrimSpace(getenv("SYNAPSE_RESTORE_VERIFY_TIMEOUT")); raw != "" {
+		cfg.timeout, err = time.ParseDuration(raw)
+		if err != nil || cfg.timeout <= 0 {
+			return settings{}, errors.New("SYNAPSE_RESTORE_VERIFY_TIMEOUT must be a positive duration")
+		}
+	}
+	return cfg, nil
+}
+
+func parseBool(value string) (bool, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false, nil
+	}
+	switch strings.ToLower(value) {
+	case "1", "t", "true", "y", "yes", "on":
+		return true, nil
+	case "0", "f", "false", "n", "no", "off":
+		return false, nil
+	default:
+		return false, errors.New("invalid boolean")
+	}
+}
+
+func run(parent context.Context, cfg settings, build buildVerifier, stdout io.Writer) error {
+	if build == nil {
+		return errors.New("initialize restore verification")
+	}
+	if cfg.timeout <= 0 {
+		cfg.timeout = defaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(parent, cfg.timeout)
+	defer cancel()
+
+	svc, cleanup, err := build(ctx, cfg)
+	if err != nil {
+		return errors.New("initialize restore verification")
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if svc == nil {
+		return errors.New("initialize restore verification")
+	}
+
+	result, err := svc.Verify(ctx)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return errors.New("restore verification timed out")
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return errors.New("restore verification canceled")
+		}
+		return errors.New("restore verification failed")
+	}
+	if err := writeJSON(stdout, result); err != nil {
+		return err
+	}
+	if !result.Intact {
+		return errIntegrity
+	}
+	return nil
+}
+
+func newVerifier(ctx context.Context, cfg settings) (verifier, func(), error) {
+	poolCfg, err := pgxpool.ParseConfig(cfg.dbDSN)
+	if err != nil {
+		return nil, nil, errors.New("parse PostgreSQL configuration")
+	}
+	poolCfg.MaxConns = maxPoolConns
+	poolCfg.MinConns = 0
+	poolCfg.ConnConfig.RuntimeParams["default_transaction_read_only"] = "on"
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return nil, nil, errors.New("connect PostgreSQL")
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, nil, errors.New("connect PostgreSQL")
+	}
+
+	blobs, err := blob.NewReadOnlyMinIO(ctx, blob.Config{
+		Endpoint: cfg.blobEndpoint, AccessKey: cfg.blobAccessKey, SecretKey: cfg.blobSecretKey,
+		Bucket: cfg.blobBucket, UseSSL: cfg.blobUseSSL,
+	})
+	if err != nil {
+		pool.Close()
+		return nil, nil, errors.New("connect evidence blob store")
+	}
+
+	// The restore reader fails closed unless the database identity may read every
+	// tenant's chain, so a normal least-privilege runtime role cannot verify a restore.
+	evidenceStore, err := postgres.NewReadOnlyEvidenceStore(ctx, pool)
+	if err != nil {
+		pool.Close()
+		return nil, nil, errors.New("restore verification requires a recovery database identity")
+	}
+	auditLog := postgres.NewAuditLog(pool)
+	args := []ports.RestoreExpectedState{}
+	if cfg.expectedState != nil {
+		args = append(args, *cfg.expectedState)
+	}
+	svc, err := restoreverify.NewService(evidenceStore, blobs, auditLog, auditLog, args...)
+	if err != nil {
+		pool.Close()
+		return nil, nil, errors.New("initialize restore verification")
+	}
+	return svc, pool.Close, nil
+}
+
+func writeJSON(w io.Writer, value any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(value); err != nil {
+		return fmt.Errorf("write restore verification report: %w", err)
+	}
+	return nil
+}
+
+func writeError(err error) {
+	_, _ = fmt.Fprintf(os.Stderr, "synapse-verify-restore: %s\n", err)
+}
+
+// loadExpectedState parses an independently captured, content-free expected-state manifest.
+func loadExpectedState(path string) (*ports.RestoreExpectedState, error) {
+	path = strings.TrimSpace(path)
+	if path == "" || filepath.Clean(path) == "." {
+		return nil, errors.New("expected state manifest path is required")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.New("read expected state manifest")
+	}
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	var state ports.RestoreExpectedState
+	if err := dec.Decode(&state); err != nil {
+		return nil, errors.New("parse expected state manifest")
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); err != io.EOF {
+		return nil, errors.New("parse expected state manifest")
+	}
+	if state.AuditHead != "" && !isSHA256(state.AuditHead) {
+		return nil, errors.New("invalid expected state manifest")
+	}
+	seenChains := map[string]struct{}{}
+	for _, chain := range state.EvidenceChains {
+		if chain.EngagementID.IsZero() || chain.Count < 0 || (chain.Count == 0 && chain.Head != "") || (chain.Count > 0 && !isSHA256(chain.Head)) {
+			return nil, errors.New("invalid expected state manifest")
+		}
+		if _, ok := seenChains[chain.EngagementID.String()]; ok {
+			return nil, errors.New("invalid expected state manifest")
+		}
+		seenChains[chain.EngagementID.String()] = struct{}{}
+	}
+	seenVersions := map[int64]struct{}{}
+	for _, version := range state.MigrationVersions {
+		if version <= 0 {
+			return nil, errors.New("invalid expected state manifest")
+		}
+		if _, ok := seenVersions[version]; ok {
+			return nil, errors.New("invalid expected state manifest")
+		}
+		seenVersions[version] = struct{}{}
+	}
+	return &state, nil
+}
+
+func isSHA256(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		if !(r >= '0' && r <= '9') && !(r >= 'a' && r <= 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/synapse-verify-restore/main_test.go
+++ b/cmd/synapse-verify-restore/main_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/restoreverify"
+)
+
+type verifierStub struct {
+	result restoreverify.Result
+	err    error
+	ctx    context.Context
+}
+
+func (s *verifierStub) Verify(ctx context.Context) (restoreverify.Result, error) {
+	s.ctx = ctx
+	return s.result, s.err
+}
+
+func TestLoadSettingsRequiresExternalServicesWithoutLeakingValues(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{"database", map[string]string{}, "SYNAPSE_DB_DSN is required"},
+		{"blob", map[string]string{"SYNAPSE_DB_DSN": "postgres://user:secret@host/database"}, "SYNAPSE_BLOB_ENDPOINT"},
+		{"boolean", validEnv("SYNAPSE_BLOB_USE_SSL", "not-bool"), "SYNAPSE_BLOB_USE_SSL must be a boolean"},
+		{"timeout", validEnv("SYNAPSE_RESTORE_VERIFY_TIMEOUT", "zero"), "SYNAPSE_RESTORE_VERIFY_TIMEOUT must be a positive duration"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadSettings(func(key string) string { return tt.env[key] })
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("loadSettings() error = %v, want %q", err, tt.want)
+			}
+			if strings.Contains(err.Error(), "secret") {
+				t.Fatalf("loadSettings() leaked a credential: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunWritesIndentedReportAndFailsForNonIntactResult(t *testing.T) {
+	stub := &verifierStub{result: restoreverify.Result{Intact: false}}
+	closed := false
+	var out bytes.Buffer
+	err := run(context.Background(), settings{timeout: time.Second}, func(context.Context, settings) (verifier, func(), error) {
+		return stub, func() { closed = true }, nil
+	}, &out)
+	if !errors.Is(err, errIntegrity) {
+		t.Fatalf("run() error = %v, want integrity error", err)
+	}
+	if !closed {
+		t.Fatal("run() did not close dependencies")
+	}
+	if got, want := out.String(), "{\n  \"intact\": false,"; !strings.HasPrefix(got, want) {
+		t.Fatalf("run() output = %q, want indented JSON starting %q", got, want)
+	}
+}
+
+func TestRunReturnsGenericExecutionErrorWithoutWritingReport(t *testing.T) {
+	var out bytes.Buffer
+	err := run(context.Background(), settings{timeout: time.Second}, func(context.Context, settings) (verifier, func(), error) {
+		return &verifierStub{err: errors.New("connection failed for postgres://user:secret@host/database")}, nil, nil
+	}, &out)
+	if err == nil || err.Error() != "restore verification failed" {
+		t.Fatalf("run() error = %v, want generic execution error", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("run() wrote report on execution failure: %q", out.String())
+	}
+}
+
+func TestRunHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var out bytes.Buffer
+	err := run(ctx, settings{timeout: time.Second}, func(context.Context, settings) (verifier, func(), error) {
+		return &verifierStub{err: context.Canceled}, nil, nil
+	}, &out)
+	if err == nil || err.Error() != "restore verification canceled" {
+		t.Fatalf("run() error = %v, want cancellation error", err)
+	}
+}
+
+func validEnv(key, value string) map[string]string {
+	return map[string]string{
+		"SYNAPSE_DB_DSN":          "postgres://user:secret@host/database",
+		"SYNAPSE_BLOB_ENDPOINT":   "minio.example.test:9000",
+		"SYNAPSE_BLOB_ACCESS_KEY": "access-key",
+		"SYNAPSE_BLOB_SECRET_KEY": "secret-key",
+		"SYNAPSE_BLOB_BUCKET":     "evidence",
+		key:                       value,
+	}
+}
+
+func TestLoadExpectedStateStrictAndDoesNotExposeInput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	valid := `{"audit_head":"","evidence_chains":[{"engagement_id":"eng","head":"","count":0}],"migration_versions":[7]}`
+	if err := os.WriteFile(path, []byte(valid), 0600); err != nil {
+		t.Fatal(err)
+	}
+	state, err := loadExpectedState(path)
+	if err != nil || state == nil || len(state.EvidenceChains) != 1 {
+		t.Fatalf("loadExpectedState() = %#v, %v", state, err)
+	}
+	if err := os.WriteFile(path, []byte(`{"audit_head":"SECRET","extra":true}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadExpectedState(path); err == nil || strings.Contains(err.Error(), "SECRET") {
+		t.Fatalf("strict parse error leaked input: %v", err)
+	}
+	if _, err := loadExpectedState(filepath.Join(dir, "missing-secret.json")); err == nil || strings.Contains(err.Error(), "missing-secret") {
+		t.Fatalf("read error leaked path: %v", err)
+	}
+}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,38 +1,46 @@
-# Multi-stage, multi-TARGET build for Synapse.
+# Multi-stage image build for Synapse.
 #
-#   --target api  (DEFAULT) → lean distroless image: the API server + CLI + syft + grype.
-#                             SCA (SBOM + OSV/Grype vulns + licenses) works; the JVM-from-source
-#                             resolvers + git acquisition do NOT (no jdk/mvn/gradle/git in distroless).
-#   --target full           → batteries-included (Debian + JDK 17 + Maven + Gradle + git): every SCA
-#                             feature works, incl. Maven/Gradle transitive resolution and JVM
-#                             reachability, and git-clone acquisition. Used by docker-compose.full.yml.
+# Targets retained for local development:
+#   --target api   minimal distroless API image
+#   --target full  Debian development image with JVM dependency resolvers
+# Production:
+#   --target production  non-root API/worker/migrate image with sandbox helpers and tools
 #
-# NOTE on the sandbox: heavy/untrusted tool execution (E9) is confined by bubblewrap, which needs a Linux
-# host + user namespaces (and, for egress scoping E12, CAP_NET_ADMIN). A plain container cannot run it, so
-# these images default to SANDBOX-OFF (dev). On the API server the Maven/Gradle resolvers are fail-closed
-# without the sandbox (they run untrusted build logic) → use `synapse-cli scan` (trusted-local, unsandboxed)
-# for full JVM SCA from a container, or deploy on a bubblewrap-capable Linux host to enable the API path.
+# The production target is Linux/amd64 because Synapse's seccomp filter is built for
+# linux/amd64. Its Kubernetes workload must also permit unprivileged user namespaces
+# for bubblewrap; it does not require privileged mode, SYS_ADMIN, or added capabilities.
 
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.6-alpine AS build
 WORKDIR /src
-# Copy module files first for better layer caching.
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -o /out/synapse-api ./cmd/synapse-api \
-    && CGO_ENABLED=0 go build -trimpath -o /out/synapse-dast-helper ./cmd/synapse-dast-helper
-# synapse-cli is bundled too so the image doubles as a cross-platform scanner
-# (`docker run … synapse-cli scan /scan`) – the SCA path runs identically on any host
-# that runs Linux containers (Windows/macOS via Docker Desktop, Linux natively).
-RUN CGO_ENABLED=0 go build -trimpath -o /out/synapse-cli ./cmd/synapse-cli \
+    && CGO_ENABLED=0 go build -trimpath -o /out/synapse-worker ./cmd/synapse-worker \
+    && CGO_ENABLED=0 go build -trimpath -o /out/synapse-migrate ./cmd/synapse-migrate \
+    && CGO_ENABLED=0 go build -trimpath -o /out/synapse-dast-helper ./cmd/synapse-dast-helper \
+    && CGO_ENABLED=0 go build -trimpath -o /out/synapse-callgraph ./cmd/synapse-callgraph \
+    && CGO_ENABLED=0 go build -trimpath -o /out/synapse-cspm ./cmd/synapse-cspm \
+    && CGO_ENABLED=0 go build -trimpath -o /out/synapse-cli ./cmd/synapse-cli \
+    && CGO_ENABLED=0 go build -trimpath -o /out/synapse-verify-restore ./cmd/synapse-verify-restore \
     && mkdir -p /out/project-uploads /out/project-source-artifacts
 
-# Pinned SCA tool binaries, shelled out at runtime.
+# The tree-sitter helper is CGO-linked, so build it against Debian glibc for the
+# Debian production runtime rather than copying an Alpine/musl-linked executable.
+FROM golang:1.26.6-trixie AS ast-build
+WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=1 go build -trimpath -o /out/synapse-ast ./cmd/synapse-ast
+
+# Pinned SCA tools are copied as standalone binaries.
 FROM anchore/syft:v1.45.1 AS syft
 FROM anchore/grype:v0.115.0 AS grype
 
 # ---------------------------------------------------------------------------
-# target: full – batteries-included SCA platform (JVM toolchain + git).
+# target: full – batteries-included local-development SCA image.
 # ---------------------------------------------------------------------------
 FROM debian:bookworm-slim AS full
 ARG GRADLE_VERSION=8.10.2
@@ -43,7 +51,6 @@ RUN apt-get update \
     && unzip -q /tmp/gradle.zip -d /opt \
     && ln -s "/opt/gradle-${GRADLE_VERSION}/bin/gradle" /usr/local/bin/gradle \
     && rm -f /tmp/gradle.zip \
-    # arch-independent JAVA_HOME: resolve wherever `java` actually points (amd64/arm64 differ).
     && ln -s "$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")" /opt/java-home \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -r -u 10001 -m -d /home/synapse synapse \
@@ -63,13 +70,10 @@ ENV SYNAPSE_SYFT_BIN=/usr/local/bin/syft \
     JAVA_HOME=/opt/java-home
 EXPOSE 8080
 USER synapse:synapse
-# tini reaps the child processes mvn/gradle/syft spawn.
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/synapse-api"]
 
 # ---------------------------------------------------------------------------
-# target: api (DEFAULT – last stage) – minimal, non-root, distroless.
-# distroless/static has no git/jdk/mvn/gradle; the `local` kind + SBOM generation
-# + OSV/Grype vulns + licenses work here. `make docker-build` builds this stage.
+# target: api – minimal local-development API image (the historical default).
 # ---------------------------------------------------------------------------
 FROM gcr.io/distroless/static-debian12:nonroot AS api
 COPY --from=build /out/synapse-api /synapse-api
@@ -79,12 +83,55 @@ COPY --from=syft /syft /usr/local/bin/syft
 COPY --from=grype /grype /usr/local/bin/grype
 COPY --from=build --chown=nonroot:nonroot /out/project-uploads /project-uploads
 COPY --from=build --chown=nonroot:nonroot /out/project-source-artifacts /project-source-artifacts
-ENV SYNAPSE_SYFT_BIN=/usr/local/bin/syft
-ENV SYNAPSE_GRYPE_BIN=/usr/local/bin/grype
-ENV SYNAPSE_PROJECT_UPLOAD_DIR=/project-uploads
-ENV SYNAPSE_PROJECT_SOURCE_ARTIFACT_DIR=/project-source-artifacts
+ENV SYNAPSE_SYFT_BIN=/usr/local/bin/syft \
+    SYNAPSE_GRYPE_BIN=/usr/local/bin/grype \
+    SYNAPSE_PROJECT_UPLOAD_DIR=/project-uploads \
+    SYNAPSE_PROJECT_SOURCE_ARTIFACT_DIR=/project-source-artifacts
 EXPOSE 8080
 USER nonroot:nonroot
-# Default to the API server; override for a one-off scan, e.g.:
-#   docker run --rm -v "$PWD:/scan:ro" <image> /synapse-cli scan /scan --mode licenses
 ENTRYPOINT ["/synapse-api"]
+
+# ---------------------------------------------------------------------------
+# target: production – hardened control-plane runtime.
+#
+# Debian supplies bwrap. Synapse creates its seccomp BPF program itself, so no
+# libseccomp runtime is needed. The OCI/Kubernetes runtime must enable
+# unprivileged user namespaces for bwrap; no privileged container or SYS_ADMIN
+# capability is used or required.
+# ---------------------------------------------------------------------------
+FROM debian:trixie-slim AS production
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+         bubblewrap ca-certificates git tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10001 synapse \
+    && useradd --uid 10001 --gid 10001 --create-home --home-dir /home/synapse --shell /usr/sbin/nologin synapse \
+    && install -d -o synapse -g synapse -m 0750 \
+         /var/lib/synapse/project-uploads \
+         /var/lib/synapse/project-source-artifacts \
+         /var/lib/synapse/cache
+COPY --from=build /out/synapse-api /opt/synapse/synapse-api
+COPY --from=build /out/synapse-worker /opt/synapse/synapse-worker
+COPY --from=build /out/synapse-migrate /opt/synapse/synapse-migrate
+COPY --from=build /out/synapse-dast-helper /opt/synapse/synapse-dast-helper
+COPY --from=build /out/synapse-callgraph /opt/synapse/synapse-callgraph
+COPY --from=build /out/synapse-cspm /opt/synapse/synapse-cspm
+COPY --from=ast-build /out/synapse-ast /opt/synapse/synapse-ast
+COPY --from=build /out/synapse-cli /opt/synapse/synapse-cli
+COPY --from=build /out/synapse-verify-restore /opt/synapse/synapse-verify-restore
+COPY --from=syft /syft /opt/synapse/syft
+COPY --from=grype /grype /opt/synapse/grype
+RUN chown -R synapse:synapse /opt/synapse
+ENV PATH=/opt/synapse:/usr/bin:/bin \
+    HOME=/home/synapse \
+    SYNAPSE_SYFT_BIN=/opt/synapse/syft \
+    SYNAPSE_GRYPE_BIN=/opt/synapse/grype \
+    SYNAPSE_DAST_HELPER_BIN=/opt/synapse/synapse-dast-helper \
+    SYNAPSE_CSPM_HELPER_BIN=/opt/synapse/synapse-cspm \
+    SYNAPSE_TAINT_CALLGRAPH_BIN=/opt/synapse/synapse-callgraph \
+    SYNAPSE_PROJECT_UPLOAD_DIR=/var/lib/synapse/project-uploads \
+    SYNAPSE_PROJECT_SOURCE_ARTIFACT_DIR=/var/lib/synapse/project-source-artifacts
+WORKDIR /home/synapse
+EXPOSE 8080
+USER synapse:synapse
+ENTRYPOINT ["/usr/bin/tini", "--", "/opt/synapse/synapse-api"]

--- a/deploy/Dockerfile.web
+++ b/deploy/Dockerfile.web
@@ -1,38 +1,31 @@
-# Synapse web – Vite dev server. Used by docker-compose.full.yml as the `web` service.
-#
-# Vite proxies /api and /healthz to the `synapse-api` compose service on :8080,
-# so the SPA on :5173 talks to the same backend the CLI would.
-#
-# Build: docker compose -f deploy/docker-compose.full.yml up -d --build web
+# Synapse web dashboard images.
+# `dev` preserves the Compose hot-reload target. `production` is a non-root static server;
+# Kubernetes ingress routes /api, /healthz, and /readyz directly to synapse-api.
 
-FROM node:22-alpine
+FROM node:22-alpine AS build
 WORKDIR /app
-
-# pnpm via corepack (ships with Node 22).
 RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
-
-# Copy lockfile + manifest first for layer caching.
 COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
-
-# pnpm 11 reads build-script approval from pnpm-workspace.yaml (`allowBuilds`),
-# not from package.json or .npmrc. The project file approves esbuild's
-# postinstall; without it, pnpm exits with ERR_PNPM_IGNORED_BUILDS.
 RUN pnpm install --frozen-lockfile --config.trustLockfile=true
-
-# The rest of the source – bind-mount in dev for hot reload (see compose).
 COPY web/ .
+RUN pnpm build
 
-# Drop to the image's built-in non-root `node` user (uid 1000) instead of running the dev server as
-# root. Own /app so pnpm/Vite can write their caches (node_modules/.vite) under the unprivileged user.
+FROM node:22-alpine AS dev
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
+COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile --config.trustLockfile=true
+COPY web/ .
 RUN chown -R node:node /app
 USER node
-
-# Vite dev server. --host 0.0.0.0 so it's reachable from the host.
-# VITE_API_PROXY_TARGET is the in-network API URL (compose DNS resolves the service name).
-ENV CI=true
-ENV NPM_CONFIG_TRUST_LOCKFILE=true
-ENV VITE_API_PROXY_TARGET=http://synapse-api:8080
+ENV CI=true \
+    NPM_CONFIG_TRUST_LOCKFILE=true \
+    VITE_API_PROXY_TARGET=http://synapse-api:8080
 EXPOSE 5173
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
     CMD wget -qO- http://127.0.0.1:5173/ >/dev/null 2>&1 || exit 1
 CMD ["pnpm", "dev", "--host", "0.0.0.0", "--port", "5173"]
+
+FROM nginxinc/nginx-unprivileged:1.29-alpine AS production
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 8080

--- a/deploy/aws/staging/.gitignore
+++ b/deploy/aws/staging/.gitignore
@@ -1,0 +1,8 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+*.tfvars
+*.tfvars.json
+backend.hcl
+plan.tfplan

--- a/deploy/aws/staging/.terraform.lock.hcl
+++ b/deploy/aws/staging/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.61.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:/LR+WmjQr+mio3oxmUz0utvuk1USC0qa42+Y3dBoE44=",
+    "zh:216566f0fbc506e107d3a961c87d88aed052ec2b4ced13388394d3cff30425ac",
+    "zh:4700ad141d0ad96465ac35a3900f2ff7c91a1e5528428ac687c8b5825c0be718",
+    "zh:6b79d2fa6550fc51e2fac04f1066c5cc96e957e7634ad86d2250240e637db205",
+    "zh:76f6227bf2bcd7422cf29d9868d8b517c8220ec3edd4e7c8434b867a71c03334",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7be5814cf94a8e3869ec9fa7f5182223a11373a4510ce68b9bab431f9b83746",
+    "zh:b65392e24506fe99f8df7bd2b5d3940d7a234b64b79a890f1aabe2be91a827e5",
+    "zh:b68a5092203cf5a9d1a5f01f9f2e96fded3eb7cacfd49ae851c50b87bc610fe9",
+    "zh:b8fedfa62bac16592519e1bae0c82dd7cd1544b0637543d72e3597e46ad7db32",
+    "zh:bba8a35212c07e68b6c881aa011c4b26a284e42b971059579aca9ffb63a8faef",
+    "zh:bbd0391e3e2f21c8930872829df7cf7f4e35f84c4d6d7b7619a94f8078fe6f3d",
+    "zh:c9c921e8e466281c04cada8d336ec1ce978128ee153e9df7b451847fbea49d18",
+    "zh:c9cb0be3097f4392b977fa254d28efd0909d008f572e74a41ead6c0d84c0daaa",
+    "zh:cc7aeb23fa3775816e391d4668a9865f787993f9f8d6f5b7a9f7e4effdffb3cb",
+    "zh:e59e487220cec8999bbd120ba8f97b5e04b010fb9149e47d4c9032961614d7c7",
+    "zh:fa19a7571a99397120f2f2bdcf33bbcc2f39091b9b0c879cd7e5f9ebb1966c40",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:7QWrBlzkkFAFyDl9UsfC0tdfNFquFx03miHwZcta33Q=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/deploy/aws/staging/Makefile
+++ b/deploy/aws/staging/Makefile
@@ -1,0 +1,13 @@
+SHELL := /usr/bin/env bash
+
+.PHONY: fmt validate test
+
+fmt:
+	terraform fmt -recursive
+
+validate:
+	terraform init -backend=false -input=false
+	terraform validate
+
+test:
+	./scripts/test.sh

--- a/deploy/aws/staging/README.md
+++ b/deploy/aws/staging/README.md
@@ -1,0 +1,15 @@
+# Terraform state handling
+
+This configuration declares a partial S3 backend. Bootstrap a dedicated, encrypted Terraform-state bucket and DynamoDB lock table outside this disposable stack, with restricted access for the deployment identity only. Do not use the evidence bucket, local state, a personal bucket, or a bucket created by this configuration for state.
+
+Copy `backend.hcl.example` to an ignored `backend.hcl`, replace only the placeholders with governed backend resource names, and initialize with the wrapper:
+
+```bash
+./scripts/status.sh --backend-config backend.hcl --var-file staging.tfvars
+```
+
+Use an ignored `staging.tfvars` file for non-secret deployment inputs. Never put AWS credentials, database credentials, Cognito client secrets, account IDs, or the generated `backend.hcl` in version control. Authenticate AWS through the approved workload identity or AWS credential chain instead.
+
+The remote state reveals infrastructure metadata and can contain provider-managed sensitive values. Enable S3 versioning, SSE-KMS, public-access blocks, access logging, least-privilege bucket policies, DynamoDB point-in-time recovery, and a recovery process in the separately managed state backend. Limit state reads to Terraform operators; application workloads must not receive state access.
+
+The wrappers initialize the configured remote backend but never create a backend. `provision.sh` refuses to apply without an explicit confirmation. `teardown.sh` also refuses to destroy until the supplied `expires_at` has passed and a second explicit confirmation is supplied.

--- a/deploy/aws/staging/backend.hcl.example
+++ b/deploy/aws/staging/backend.hcl.example
@@ -1,0 +1,8 @@
+# Create this bucket, the DynamoDB lock table, and its KMS policy in a separately governed
+# state-bootstrap account or stack. Do not use the disposable environment's bucket for state.
+bucket         = "REPLACE-WITH-DEDICATED-TERRAFORM-STATE-BUCKET"
+key            = "synapse/staging/terraform.tfstate"
+region         = "us-east-1"
+dynamodb_table = "REPLACE-WITH-TERRAFORM-LOCK-TABLE"
+encrypt        = true
+# Optional: kms_key_id = "arn:aws:kms:us-east-1:...:key/..."

--- a/deploy/aws/staging/iam-eks.tf
+++ b/deploy/aws/staging/iam-eks.tf
@@ -1,0 +1,193 @@
+data "aws_iam_policy_document" "eks_cluster_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "eks_cluster" {
+  name               = "${local.prefix}-eks-cluster"
+  assume_role_policy = data.aws_iam_policy_document.eks_cluster_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster" {
+  role       = aws_iam_role.eks_cluster.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+data "aws_iam_policy_document" "eks_nodes_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "eks_nodes" {
+  name               = "${local.prefix}-eks-nodes"
+  assume_role_policy = data.aws_iam_policy_document.eks_nodes_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "node_worker" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_cni" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_ecr" {
+  role       = aws_iam_role.eks_nodes.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
+}
+
+resource "aws_eks_cluster" "staging" {
+  name     = "${local.prefix}-eks"
+  role_arn = aws_iam_role.eks_cluster.arn
+  version  = var.cluster_version
+
+  access_config {
+    authentication_mode = "API"
+  }
+
+  vpc_config {
+    endpoint_private_access = true
+    endpoint_public_access  = false
+    security_group_ids      = [aws_security_group.cluster.id]
+    subnet_ids              = [for subnet in aws_subnet.private : subnet.id]
+  }
+
+  enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+
+  depends_on = [aws_iam_role_policy_attachment.eks_cluster]
+  tags       = merge(local.tags, { Name = "${local.prefix}-eks" })
+}
+
+data "tls_certificate" "eks_oidc" {
+  url = aws_eks_cluster.staging.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "eks" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.eks_oidc.certificates[0].sha1_fingerprint]
+  url             = aws_eks_cluster.staging.identity[0].oidc[0].issuer
+  tags            = local.tags
+}
+
+resource "aws_launch_template" "eks_nodes" {
+  name_prefix            = "${local.prefix}-nodes-"
+  update_default_version = true
+  vpc_security_group_ids = [aws_security_group.nodes.id]
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
+    http_put_response_hop_limit = 2
+    http_tokens                 = "required"
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags          = merge(local.tags, { Name = "${local.prefix}-node" })
+  }
+
+  tags = local.tags
+}
+
+resource "aws_eks_node_group" "linux" {
+  cluster_name    = aws_eks_cluster.staging.name
+  node_group_name = "linux"
+  node_role_arn   = aws_iam_role.eks_nodes.arn
+  subnet_ids      = [for subnet in aws_subnet.private : subnet.id]
+  instance_types  = var.node_instance_types
+  ami_type        = "AL2023_x86_64_STANDARD"
+  capacity_type   = "ON_DEMAND"
+
+  launch_template {
+    id      = aws_launch_template.eks_nodes.id
+    version = aws_launch_template.eks_nodes.latest_version
+  }
+
+  scaling_config {
+    desired_size = var.node_desired_size
+    min_size     = var.node_min_size
+    max_size     = var.node_max_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_worker,
+    aws_iam_role_policy_attachment.node_cni,
+    aws_iam_role_policy_attachment.node_ecr,
+  ]
+
+  tags = merge(local.tags, { Name = "${local.prefix}-linux" })
+}
+
+data "aws_iam_policy_document" "app_irsa_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.eks.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_eks_cluster.staging.identity[0].oidc[0].issuer, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_eks_cluster.staging.identity[0].oidc[0].issuer, "https://", "")}:sub"
+      values   = ["system:serviceaccount:${var.app_namespace}:${var.app_service_account_name}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "app_irsa" {
+  name               = "${local.prefix}-app-irsa"
+  assume_role_policy = data.aws_iam_policy_document.app_irsa_assume.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "app_irsa" {
+  statement {
+    sid       = "ApplicationListEvidence"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.evidence.arn]
+  }
+
+  statement {
+    sid       = "ApplicationEvidenceObjects"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:AbortMultipartUpload"]
+    resources = ["${aws_s3_bucket.evidence.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "app_irsa" {
+  name   = "${local.prefix}-app-runtime"
+  role   = aws_iam_role.app_irsa.id
+  policy = data.aws_iam_policy_document.app_irsa.json
+}

--- a/deploy/aws/staging/locals.tf
+++ b/deploy/aws/staging/locals.tf
@@ -1,0 +1,18 @@
+locals {
+  prefix = "${var.name}-staging"
+
+  tags = merge(var.additional_tags, {
+    Name        = local.prefix
+    application = "synapse"
+    environment = "staging"
+    managed-by  = "terraform"
+    owner       = var.owner
+    cost-center = var.cost_center
+    expires-at  = var.expires_at
+    epic        = "583"
+    disposable  = "true"
+  })
+
+  private_subnet_cidrs = [for index in range(length(var.availability_zones)) : cidrsubnet(var.vpc_cidr, 4, index)]
+  public_subnet_cidrs  = [for index in range(length(var.availability_zones)) : cidrsubnet(var.vpc_cidr, 4, index + 8)]
+}

--- a/deploy/aws/staging/main.tf
+++ b/deploy/aws/staging/main.tf
@@ -1,0 +1,174 @@
+data "aws_partition" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "selected" {
+  state = "available"
+}
+
+resource "aws_kms_key" "staging" {
+  description             = "Encryption key for ${local.prefix} data services"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = merge(local.tags, { Name = "${local.prefix}-data" })
+}
+
+resource "aws_kms_alias" "staging" {
+  name          = "alias/${local.prefix}-data"
+  target_key_id = aws_kms_key.staging.key_id
+}
+
+resource "aws_vpc" "staging" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.tags, { Name = "${local.prefix}-vpc" })
+}
+
+resource "aws_internet_gateway" "staging" {
+  vpc_id = aws_vpc.staging.id
+
+  tags = merge(local.tags, { Name = "${local.prefix}-igw" })
+}
+
+resource "aws_subnet" "public" {
+  for_each = toset(var.availability_zones)
+
+  vpc_id                  = aws_vpc.staging.id
+  availability_zone       = each.value
+  cidr_block              = local.public_subnet_cidrs[index(var.availability_zones, each.value)]
+  map_public_ip_on_launch = false
+
+  tags = merge(local.tags, {
+    Name                     = "${local.prefix}-public-${each.value}"
+    "kubernetes.io/role/elb" = "1"
+  })
+}
+
+resource "aws_subnet" "private" {
+  for_each = toset(var.availability_zones)
+
+  vpc_id            = aws_vpc.staging.id
+  availability_zone = each.value
+  cidr_block        = local.private_subnet_cidrs[index(var.availability_zones, each.value)]
+
+  tags = merge(local.tags, {
+    Name                              = "${local.prefix}-private-${each.value}"
+    "kubernetes.io/role/internal-elb" = "1"
+  })
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+  tags   = merge(local.tags, { Name = "${local.prefix}-nat" })
+}
+
+resource "aws_nat_gateway" "staging" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[var.availability_zones[0]].id
+
+  depends_on = [aws_internet_gateway.staging]
+  tags       = merge(local.tags, { Name = "${local.prefix}-nat" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.staging.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.staging.id
+  }
+
+  tags = merge(local.tags, { Name = "${local.prefix}-public" })
+}
+
+resource "aws_route_table_association" "public" {
+  for_each       = aws_subnet.public
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.staging.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.staging.id
+  }
+
+  tags = merge(local.tags, { Name = "${local.prefix}-private" })
+}
+
+resource "aws_route_table_association" "private" {
+  for_each       = aws_subnet.private
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_security_group" "cluster" {
+  name        = "${local.prefix}-eks-control-plane"
+  description = "Restricts EKS control-plane access to managed nodes"
+  vpc_id      = aws_vpc.staging.id
+
+  tags = merge(local.tags, { Name = "${local.prefix}-eks-control-plane" })
+}
+
+resource "aws_security_group" "nodes" {
+  name        = "${local.prefix}-eks-nodes"
+  description = "Restricts managed EKS Linux node traffic"
+  vpc_id      = aws_vpc.staging.id
+
+  egress {
+    description = "Allow nodes to reach AWS APIs and package registries through NAT"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, { Name = "${local.prefix}-eks-nodes" })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "cluster_from_nodes" {
+  security_group_id            = aws_security_group.cluster.id
+  referenced_security_group_id = aws_security_group.nodes.id
+  from_port                    = 443
+  ip_protocol                  = "tcp"
+  to_port                      = 443
+  description                  = "Kubelet and pod traffic to private EKS API"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nodes_from_cluster" {
+  security_group_id            = aws_security_group.nodes.id
+  referenced_security_group_id = aws_security_group.cluster.id
+  from_port                    = 1025
+  ip_protocol                  = "tcp"
+  to_port                      = 65535
+  description                  = "Control plane to kubelet and webhook ports"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nodes_self" {
+  security_group_id            = aws_security_group.nodes.id
+  referenced_security_group_id = aws_security_group.nodes.id
+  ip_protocol                  = "-1"
+  description                  = "Node-to-node and pod overlay traffic"
+}
+
+resource "aws_security_group" "database" {
+  name        = "${local.prefix}-postgres"
+  description = "Restricts PostgreSQL to EKS nodes only"
+  vpc_id      = aws_vpc.staging.id
+
+  tags = merge(local.tags, { Name = "${local.prefix}-postgres" })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "postgres_from_nodes" {
+  security_group_id            = aws_security_group.database.id
+  referenced_security_group_id = aws_security_group.nodes.id
+  from_port                    = 5432
+  ip_protocol                  = "tcp"
+  to_port                      = 5432
+  description                  = "PostgreSQL from application pods on EKS nodes"
+}

--- a/deploy/aws/staging/outputs.tf
+++ b/deploy/aws/staging/outputs.tf
@@ -1,0 +1,55 @@
+output "eks_cluster_name" {
+  description = "EKS cluster name."
+  value       = aws_eks_cluster.staging.name
+}
+
+output "eks_cluster_endpoint" {
+  description = "Private EKS API endpoint; reachable only from within the VPC."
+  value       = aws_eks_cluster.staging.endpoint
+}
+
+output "ecr_repository_url" {
+  description = "Private ECR repository URL for staging images."
+  value       = aws_ecr_repository.app.repository_url
+}
+
+output "evidence_bucket_name" {
+  description = "Private, versioned, KMS-encrypted S3 evidence bucket name."
+  value       = aws_s3_bucket.evidence.id
+}
+
+output "database_endpoint" {
+  description = "Private PostgreSQL host and port."
+  value       = aws_db_instance.postgres.endpoint
+}
+
+output "database_master_secret_arn" {
+  description = "Secrets Manager ARN for the RDS-managed credentials; grant only the workload role access."
+  value       = aws_db_instance.postgres.master_user_secret[0].secret_arn
+  sensitive   = true
+}
+
+output "app_irsa_role_arn" {
+  description = "IRSA role limited to the application service account, evidence bucket, and database secret."
+  value       = aws_iam_role.app_irsa.arn
+}
+
+output "cognito_user_pool_id" {
+  description = "Cognito user-pool identifier."
+  value       = aws_cognito_user_pool.staging.id
+}
+
+output "cognito_client_id" {
+  description = "Cognito OAuth client ID. The generated client secret is intentionally not output."
+  value       = aws_cognito_user_pool_client.staging.id
+}
+
+output "cognito_issuer_url" {
+  description = "OIDC issuer URL for token validation."
+  value       = "https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.staging.id}"
+}
+
+output "cognito_hosted_ui_domain" {
+  description = "Hosted-UI domain endpoint."
+  value       = "https://${aws_cognito_user_pool_domain.staging.domain}.auth.${var.aws_region}.amazoncognito.com"
+}

--- a/deploy/aws/staging/scripts/provision.sh
+++ b/deploy/aws/staging/scripts/provision.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+cd -- "$root"
+
+usage() { printf '%s\n' 'Usage: provision.sh --backend-config FILE --var-file FILE --confirm-apply'; }
+backend_config=''
+var_file=''
+confirmed=false
+while (($#)); do
+  case "$1" in
+    --backend-config) backend_config=${2:?missing backend config path}; shift 2 ;;
+    --var-file) var_file=${2:?missing variable file path}; shift 2 ;;
+    --confirm-apply) confirmed=true; shift ;;
+    *) usage >&2; exit 64 ;;
+  esac
+done
+[[ -n "$backend_config" && -f "$backend_config" && -n "$var_file" && -f "$var_file" && "$confirmed" == true ]] || { usage >&2; exit 64; }
+
+terraform init -input=false -backend-config="$backend_config"
+terraform plan -input=false -var-file="$var_file" -out=plan.tfplan
+terraform apply -input=false plan.tfplan
+rm -f -- plan.tfplan

--- a/deploy/aws/staging/scripts/status.sh
+++ b/deploy/aws/staging/scripts/status.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+cd -- "$root"
+
+usage() { printf '%s\n' 'Usage: status.sh --backend-config FILE --var-file FILE'; }
+backend_config=''
+var_file=''
+while (($#)); do
+  case "$1" in
+    --backend-config) backend_config=${2:?missing backend config path}; shift 2 ;;
+    --var-file) var_file=${2:?missing variable file path}; shift 2 ;;
+    *) usage >&2; exit 64 ;;
+  esac
+done
+[[ -n "$backend_config" && -f "$backend_config" && -n "$var_file" && -f "$var_file" ]] || { usage >&2; exit 64; }
+
+terraform init -input=false -backend-config="$backend_config"
+set +e
+terraform plan -input=false -detailed-exitcode -var-file="$var_file"
+status=$?
+set -e
+case "$status" in
+  0) printf '%s\n' 'Infrastructure matches configuration.' ;;
+  2) printf '%s\n' 'Infrastructure drift or pending configuration changes detected.' ;;
+  *) exit "$status" ;;
+esac

--- a/deploy/aws/staging/scripts/teardown.sh
+++ b/deploy/aws/staging/scripts/teardown.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+cd -- "$root"
+
+usage() { printf '%s\n' 'Usage: teardown.sh --backend-config FILE --var-file FILE --confirm-destroy'; }
+backend_config=''
+var_file=''
+confirmed=false
+while (($#)); do
+  case "$1" in
+    --backend-config) backend_config=${2:?missing backend config path}; shift 2 ;;
+    --var-file) var_file=${2:?missing variable file path}; shift 2 ;;
+    --confirm-destroy) confirmed=true; shift ;;
+    *) usage >&2; exit 64 ;;
+  esac
+done
+[[ -n "$backend_config" && -f "$backend_config" && -n "$var_file" && -f "$var_file" && "$confirmed" == true ]] || { usage >&2; exit 64; }
+
+expires_at=$(perl -ne 'if (/^\s*expires_at\s*=\s*"([^"]+)"\s*$/) { print $1; exit }' -- "$var_file")
+[[ -n "$expires_at" ]] || { printf '%s\n' 'expires_at must be set in the supplied variable file.' >&2; exit 64; }
+python3 - "$expires_at" <<'PY'
+from datetime import datetime, timezone
+import sys
+try:
+    expiry = datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+except ValueError:
+    raise SystemExit("expires_at is not a valid RFC3339 timestamp")
+if expiry.tzinfo is None or expiry > datetime.now(timezone.utc):
+    raise SystemExit("refusing teardown: expires_at has not passed")
+PY
+
+terraform init -input=false -backend-config="$backend_config"
+terraform plan -input=false -destroy -var-file="$var_file" -out=destroy.tfplan
+terraform apply -input=false destroy.tfplan
+rm -f -- destroy.tfplan

--- a/deploy/aws/staging/scripts/test.sh
+++ b/deploy/aws/staging/scripts/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+cd -- "$root"
+
+command -v terraform >/dev/null 2>&1 || { printf '%s\n' 'terraform is required' >&2; exit 127; }
+terraform fmt -check -recursive
+terraform init -backend=false -input=false
+terraform validate
+./tests/static.sh

--- a/deploy/aws/staging/services.tf
+++ b/deploy/aws/staging/services.tf
@@ -1,0 +1,230 @@
+resource "aws_ecr_repository" "app" {
+  name                 = "${local.prefix}/synapse"
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.staging.arn
+  }
+
+  tags = merge(local.tags, { Name = "${local.prefix}-synapse" })
+}
+
+resource "aws_ecr_lifecycle_policy" "app" {
+  repository = aws_ecr_repository.app.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Retain only the ten newest staging images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 10
+      }
+      action = { type = "expire" }
+    }]
+  })
+}
+
+resource "aws_s3_bucket" "evidence" {
+  bucket_prefix = "${local.prefix}-evidence-"
+  force_destroy = true
+
+  tags = merge(local.tags, { Name = "${local.prefix}-evidence" })
+}
+
+resource "aws_s3_bucket_public_access_block" "evidence" {
+  bucket                  = aws_s3_bucket.evidence.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "evidence" {
+  bucket = aws_s3_bucket.evidence.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "evidence" {
+  bucket = aws_s3_bucket.evidence.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "evidence" {
+  bucket = aws_s3_bucket.evidence.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.staging.arn
+      sse_algorithm     = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "evidence" {
+  bucket = aws_s3_bucket.evidence.id
+
+  rule {
+    id     = "expire-disposable-evidence"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
+resource "aws_db_subnet_group" "postgres" {
+  name       = "${local.prefix}-postgres"
+  subnet_ids = [for subnet in aws_subnet.private : subnet.id]
+
+  tags = merge(local.tags, { Name = "${local.prefix}-postgres" })
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier                      = "${local.prefix}-postgres"
+  allocated_storage               = 50
+  max_allocated_storage           = 100
+  storage_type                    = "gp3"
+  storage_encrypted               = true
+  kms_key_id                      = aws_kms_key.staging.arn
+  engine                          = "postgres"
+  instance_class                  = var.db_instance_class
+  db_name                         = var.db_name
+  username                        = "synapse_admin"
+  manage_master_user_password     = true
+  master_user_secret_kms_key_id   = aws_kms_key.staging.arn
+  port                            = 5432
+  multi_az                        = true
+  publicly_accessible             = false
+  db_subnet_group_name            = aws_db_subnet_group.postgres.name
+  vpc_security_group_ids          = [aws_security_group.database.id]
+  backup_retention_period         = 7
+  backup_window                   = "03:00-03:30"
+  maintenance_window              = "sun:04:00-sun:04:30"
+  auto_minor_version_upgrade      = true
+  deletion_protection             = false
+  skip_final_snapshot             = true
+  copy_tags_to_snapshot           = true
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
+  performance_insights_enabled    = true
+  performance_insights_kms_key_id = aws_kms_key.staging.arn
+  monitoring_interval             = 0
+  apply_immediately               = false
+
+  tags = merge(local.tags, { Name = "${local.prefix}-postgres" })
+}
+
+resource "aws_cognito_user_pool" "staging" {
+  name                     = "${local.prefix}-users"
+  auto_verified_attributes = ["email"]
+  username_attributes      = ["email"]
+  mfa_configuration        = "OPTIONAL"
+
+  password_policy {
+    minimum_length                   = 14
+    require_lowercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    require_uppercase                = true
+    temporary_password_validity_days = 3
+  }
+
+  software_token_mfa_configuration {
+    enabled = true
+  }
+
+  user_pool_add_ons {
+    advanced_security_mode = "ENFORCED"
+  }
+
+  schema {
+    attribute_data_type = "String"
+    name                = "email"
+    required            = true
+    mutable             = false
+
+    string_attribute_constraints {
+      min_length = 5
+      max_length = 320
+    }
+  }
+
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+  }
+
+  tags = merge(local.tags, { Name = "${local.prefix}-users" })
+}
+
+resource "aws_cognito_user_pool_domain" "staging" {
+  domain       = var.cognito_domain_prefix
+  user_pool_id = aws_cognito_user_pool.staging.id
+}
+
+resource "aws_cognito_user_pool_client" "staging" {
+  name                                 = "${local.prefix}-web"
+  user_pool_id                         = aws_cognito_user_pool.staging.id
+  generate_secret                      = true
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_scopes                 = ["email", "openid", "profile"]
+  callback_urls                        = var.cognito_callback_urls
+  logout_urls                          = var.cognito_logout_urls
+  supported_identity_providers         = ["COGNITO"]
+  prevent_user_existence_errors        = "ENABLED"
+  enable_token_revocation              = true
+  access_token_validity                = 1
+  id_token_validity                    = 1
+  refresh_token_validity               = 1
+  token_validity_units {
+    access_token  = "hours"
+    id_token      = "hours"
+    refresh_token = "days"
+  }
+}
+
+resource "aws_cognito_user_group" "administrators" {
+  name         = "administrators"
+  user_pool_id = aws_cognito_user_pool.staging.id
+  description  = "Staging environment administrators"
+  precedence   = 1
+}
+
+resource "aws_cognito_user_group" "analysts" {
+  name         = "analysts"
+  user_pool_id = aws_cognito_user_pool.staging.id
+  description  = "Staging environment assessment analysts"
+  precedence   = 10
+}
+
+resource "aws_cognito_user_group" "readers" {
+  name         = "readers"
+  user_pool_id = aws_cognito_user_pool.staging.id
+  description  = "Staging environment read-only users"
+  precedence   = 20
+}

--- a/deploy/aws/staging/tests/static.sh
+++ b/deploy/aws/staging/tests/static.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+cd -- "$root"
+
+fail() {
+  printf 'static check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+# Detect credential-like literals without inspecting ignored operator variable files.
+if perl -ne 'exit 1 if /AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|(?i:aws_secret_access_key)\s*=\s*"[^"]/' -- ./*.tf; then :; else
+  fail "AWS credential-like literal found in Terraform source"
+fi
+
+if perl -ne 'exit 1 if /^\s*(?:password|master_password)\s*=\s*"/' -- ./*.tf; then :; else
+  fail "hard-coded password found in Terraform source"
+fi
+
+if perl -0777 -ne 'while (/output\s+"[^"]*(?:secret|password)[^"]*"\s*\{(.*?)\}/sg) { exit 1 unless $1 =~ /sensitive\s*=\s*true/ } exit 0' -- outputs.tf; then :; else
+  fail "secret or password outputs must be explicitly sensitive"
+fi
+
+for required in 'manage_master_user_password\s*=\s*true' 'storage_encrypted\s*=\s*true' 'publicly_accessible\s*=\s*false' 'endpoint_public_access\s*=\s*false' 'enable_key_rotation\s*=\s*true' 'block_public_policy\s*=\s*true' 'status\s*=\s*"Enabled"'; do
+  perl -0777 -ne "BEGIN { \$found = 0 } \$found = 1 if /$required/; END { exit !\$found }" -- ./*.tf || fail "missing required security control: $required"
+done
+
+printf '%s\n' 'static security checks passed'

--- a/deploy/aws/staging/variables.tf
+++ b/deploy/aws/staging/variables.tf
@@ -1,0 +1,210 @@
+variable "aws_region" {
+  description = "AWS region. This disposable staging stack is intentionally limited to us-east-1."
+  type        = string
+  default     = "us-east-1"
+
+  validation {
+    condition     = var.aws_region == "us-east-1"
+    error_message = "aws_region must be us-east-1 for this staging automation."
+  }
+}
+
+variable "name" {
+  description = "Short lowercase identifier used in all resource names."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{2,24}$", var.name))
+    error_message = "name must be 3-25 lowercase letters, digits, or hyphens and start with a letter."
+  }
+}
+
+variable "owner" {
+  description = "Individual or team responsible for the disposable environment."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.owner)) > 0 && length(var.owner) <= 128
+    error_message = "owner must be a non-empty value of at most 128 characters."
+  }
+}
+
+variable "cost_center" {
+  description = "Billing allocation tag value."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.cost_center)) > 0 && length(var.cost_center) <= 128
+    error_message = "cost_center must be a non-empty value of at most 128 characters."
+  }
+}
+
+variable "expires_at" {
+  description = "RFC3339 UTC expiry for this disposable environment; teardown refuses before this time."
+  type        = string
+
+  validation {
+    condition     = can(formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", var.expires_at)) && endswith(var.expires_at, "Z")
+    error_message = "expires_at must be an RFC3339 UTC timestamp, for example 2026-09-01T00:00:00Z."
+  }
+}
+
+variable "additional_tags" {
+  description = "Optional non-reserved tags. Reserved lifecycle and ownership tags cannot be overridden."
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for key, value in var.additional_tags :
+      !contains(["Name", "application", "environment", "managed-by", "owner", "cost-center", "expires-at"], key) && length(trimspace(value)) > 0
+    ])
+    error_message = "additional_tags may not override reserved tags and values must be non-empty."
+  }
+}
+
+variable "availability_zones" {
+  description = "Exactly three available us-east-1 Availability Zones for EKS and RDS high availability."
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+
+  validation {
+    condition     = length(var.availability_zones) == 3 && length(distinct(var.availability_zones)) == 3 && alltrue([for az in var.availability_zones : startswith(az, "us-east-1")])
+    error_message = "availability_zones must contain three distinct us-east-1 Availability Zones."
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR range assigned to the staging VPC."
+  type        = string
+  default     = "10.83.0.0/16"
+
+  validation {
+    condition     = can(cidrnetmask(var.vpc_cidr))
+    error_message = "vpc_cidr must be a valid IPv4 CIDR."
+  }
+}
+
+variable "cluster_version" {
+  description = "Supported EKS Kubernetes version approved for the staging environment."
+  type        = string
+  default     = "1.35"
+
+  validation {
+    condition     = can(regex("^[0-9]+\\.[0-9]+$", var.cluster_version))
+    error_message = "cluster_version must use a major.minor Kubernetes version."
+  }
+}
+
+variable "node_instance_types" {
+  description = "Managed Linux worker node instance types."
+  type        = list(string)
+  default     = ["t3.large"]
+
+  validation {
+    condition     = length(var.node_instance_types) > 0
+    error_message = "At least one node instance type is required."
+  }
+}
+
+variable "node_desired_size" {
+  description = "Desired managed worker node count."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.node_desired_size >= 1 && var.node_desired_size <= 6
+    error_message = "node_desired_size must be between 1 and 6."
+  }
+}
+
+variable "node_min_size" {
+  description = "Minimum managed worker node count."
+  type        = number
+  default     = 1
+}
+
+variable "node_max_size" {
+  description = "Maximum managed worker node count."
+  type        = number
+  default     = 4
+
+  validation {
+    condition     = var.node_max_size >= var.node_min_size && var.node_max_size <= 6 && var.node_desired_size >= var.node_min_size && var.node_desired_size <= var.node_max_size
+    error_message = "Require 1 <= node_min_size <= node_desired_size <= node_max_size <= 6."
+  }
+}
+
+variable "db_instance_class" {
+  description = "RDS PostgreSQL instance class for staging."
+  type        = string
+  default     = "db.t4g.medium"
+
+  validation {
+    condition     = startswith(var.db_instance_class, "db.")
+    error_message = "db_instance_class must be an RDS DB instance class."
+  }
+}
+
+variable "db_name" {
+  description = "Initial PostgreSQL database name."
+  type        = string
+  default     = "synapse"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9_]{0,62}$", var.db_name))
+    error_message = "db_name must start with a lowercase letter and contain only lowercase letters, digits, or underscores."
+  }
+}
+
+variable "app_service_account_name" {
+  description = "Kubernetes service-account name eligible for the application IRSA role."
+  type        = string
+  default     = "synapse-api"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", var.app_service_account_name))
+    error_message = "app_service_account_name must be a valid DNS-label Kubernetes name."
+  }
+}
+
+variable "app_namespace" {
+  description = "Kubernetes namespace eligible for the application IRSA role."
+  type        = string
+  default     = "synapse"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", var.app_namespace))
+    error_message = "app_namespace must be a valid DNS-label Kubernetes namespace."
+  }
+}
+
+variable "cognito_domain_prefix" {
+  description = "Globally unique Cognito hosted-UI domain prefix; it must not include a domain suffix."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{2,62}$", var.cognito_domain_prefix))
+    error_message = "cognito_domain_prefix must be 3-63 lowercase letters, digits, or hyphens and start with a letter."
+  }
+}
+
+variable "cognito_callback_urls" {
+  description = "HTTPS application callback URLs registered with Cognito."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.cognito_callback_urls) > 0 && alltrue([for url in var.cognito_callback_urls : startswith(url, "https://")])
+    error_message = "cognito_callback_urls must contain one or more HTTPS URLs."
+  }
+}
+
+variable "cognito_logout_urls" {
+  description = "HTTPS application logout URLs registered with Cognito."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.cognito_logout_urls) > 0 && alltrue([for url in var.cognito_logout_urls : startswith(url, "https://")])
+    error_message = "cognito_logout_urls must contain one or more HTTPS URLs."
+  }
+}

--- a/deploy/aws/staging/versions.tf
+++ b/deploy/aws/staging/versions.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  # Bootstrap this backend separately; see README.md. Do not store state locally.
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.tags
+  }
+}

--- a/deploy/helm/synapse/Chart.yaml
+++ b/deploy/helm/synapse/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: synapse
+description: Production Helm chart for the Synapse governed security-assessment control plane.
+type: application
+version: 0.1.0
+appVersion: "0.0.0"
+kubeVersion: ">=1.29.0-0"

--- a/deploy/helm/synapse/README.md
+++ b/deploy/helm/synapse/README.md
@@ -1,0 +1,34 @@
+# Synapse Helm chart
+
+This chart deploys the production control plane: at least two API replicas, one lease-locked worker, a static web dashboard, and a pre-install/pre-upgrade migration Job. It expects external PostgreSQL and S3-compatible object storage.
+
+## Prerequisites
+
+- Kubernetes 1.29 or later, Helm 4, and an ingress controller.
+- A Linux amd64 node runtime that permits unprivileged user namespaces. Bubblewrap is installed in the production image and Synapse supplies its own default-deny seccomp BPF filter. The chart does not request privileged mode, `SYS_ADMIN`, host networking, or host mounts.
+- Pre-created, split Secrets named by `existingSecrets` and a pre-created TLS Secret named by `ingress.tls.secretName`. The chart never renders Secret data.
+- Digest-qualified production images. Tags are rejected by `values.schema.json`.
+
+## Install
+
+Copy the production test values as a starting point, replace only references and non-secret endpoints, and use your secret-management controller for the referenced Secrets:
+
+```bash
+helm upgrade --install synapse deploy/helm/synapse \
+  --namespace synapse --create-namespace \
+  --values deploy/helm/synapse/tests/production-values.yaml
+```
+
+The migration hook uses the separate owner DSN Secret. API and worker set `SYNAPSE_DB_AUTO_MIGRATE=false`; the application verifies migration readiness before serving work. The API exposes aggregate Prometheus metrics on a dedicated ClusterIP port. That listener is unauthenticated by design, never appears on the public ingress, and its NetworkPolicy accepts traffic only from `api.metrics.monitoringNamespace`.
+
+## Validation
+
+```bash
+helm lint --strict deploy/helm/synapse -f deploy/helm/synapse/tests/production-values.yaml
+helm template synapse deploy/helm/synapse -f deploy/helm/synapse/tests/production-values.yaml --kube-version 1.29.0
+(cd deploy/helm/synapse && sh testdata/render_test.sh)
+```
+
+NetworkPolicy starts with namespace-wide default deny, allows ingress only from the configured ingress-controller namespace, permits DNS plus TLS/PostgreSQL egress, and grants HTTP/S recon egress only to the worker. Configure an FQDN-aware CNI or egress gateway with managed PostgreSQL/S3 and authorized-target allowlists before production use.
+
+The disposable EKS rehearsal proved the chart's HA, migration, TLS, private-service, and fail-closed startup paths. Its standard managed-node runtime denied the nested unprivileged namespaces required by bubblewrap, so positive sandbox execution remains a deployment prerequisite: validate the target AMI/runtime and run a sandboxed worker job before relying on the chart for production workloads.

--- a/deploy/helm/synapse/templates/NOTES.txt
+++ b/deploy/helm/synapse/templates/NOTES.txt
@@ -1,0 +1,7 @@
+Synapse requires pre-existing split Secrets; this chart deliberately never creates Secret data.
+
+The migration hook runs before install and upgrade. API and worker are configured with
+SYNAPSE_DB_AUTO_MIGRATE=false and wait for the migration schema state.
+
+Production image references are digest-only. Before deployment, validate that every worker
+node supports unprivileged user namespaces for bubblewrap. The chart is not yet proven on EKS.

--- a/deploy/helm/synapse/templates/_helpers.tpl
+++ b/deploy/helm/synapse/templates/_helpers.tpl
@@ -1,0 +1,111 @@
+{{- define "synapse.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "synapse.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (include "synapse.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "synapse.labels" -}}
+app.kubernetes.io/name: {{ include "synapse.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{- define "synapse.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "synapse.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "synapse.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "synapse.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- required "serviceAccount.name is required when serviceAccount.create is false" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "synapse.image" -}}
+{{- printf "%s@%s" .repository .digest }}
+{{- end }}
+
+{{- define "synapse.podSecurityContext" -}}
+{{- toYaml .Values.podSecurityContext }}
+{{- end }}
+
+{{- define "synapse.containerSecurityContext" -}}
+{{- toYaml .Values.containerSecurityContext }}
+{{- end }}
+
+{{- define "synapse.topologySpreadConstraints" -}}
+{{- $root := index . 0 -}}
+{{- $component := index . 1 -}}
+{{- range $constraint := $root.Values.topologySpreadConstraints }}
+- maxSkew: {{ $constraint.maxSkew }}
+  topologyKey: {{ $constraint.topologyKey }}
+  whenUnsatisfiable: {{ $constraint.whenUnsatisfiable }}
+  labelSelector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" $root | nindent 6 }}
+      app.kubernetes.io/component: {{ $component }}
+{{- end }}
+{{- end }}
+
+{{- define "synapse.runtimeEnv" -}}
+- name: SYNAPSE_ENV
+  value: production
+- name: SYNAPSE_DB_AUTO_MIGRATE
+  value: "false"
+- name: SYNAPSE_SANDBOX_ENABLED
+  value: "true"
+- name: SYNAPSE_BLOB_ENDPOINT
+  value: {{ required "objectStore.endpoint is required" .Values.objectStore.endpoint | quote }}
+- name: SYNAPSE_BLOB_BUCKET
+  value: {{ required "objectStore.bucket is required" .Values.objectStore.bucket | quote }}
+- name: SYNAPSE_BLOB_USE_SSL
+  value: {{ .Values.objectStore.useSSL | quote }}
+- name: SYNAPSE_API_TOKEN
+  valueFrom: {secretKeyRef: {name: {{ required "existingSecrets.apiToken.name is required" .Values.existingSecrets.apiToken.name }}, key: {{ required "existingSecrets.apiToken.key is required" .Values.existingSecrets.apiToken.key }}}}
+- name: SYNAPSE_DB_DSN
+  valueFrom: {secretKeyRef: {name: {{ required "existingSecrets.database.runtime.name is required" .Values.existingSecrets.database.runtime.name }}, key: {{ required "existingSecrets.database.runtime.key is required" .Values.existingSecrets.database.runtime.key }}}}
+- name: SYNAPSE_DB_MIGRATION_DSN
+  valueFrom: {secretKeyRef: {name: {{ required "existingSecrets.database.migration.name is required" .Values.existingSecrets.database.migration.name }}, key: {{ required "existingSecrets.database.migration.key is required" .Values.existingSecrets.database.migration.key }}}}
+- name: SYNAPSE_BLOB_ACCESS_KEY
+  valueFrom: {secretKeyRef: {name: {{ required "existingSecrets.objectStore.accessKey.name is required" .Values.existingSecrets.objectStore.accessKey.name }}, key: {{ required "existingSecrets.objectStore.accessKey.key is required" .Values.existingSecrets.objectStore.accessKey.key }}}}
+- name: SYNAPSE_BLOB_SECRET_KEY
+  valueFrom: {secretKeyRef: {name: {{ required "existingSecrets.objectStore.secretKey.name is required" .Values.existingSecrets.objectStore.secretKey.name }}, key: {{ required "existingSecrets.objectStore.secretKey.key is required" .Values.existingSecrets.objectStore.secretKey.key }}}}
+- name: SYNAPSE_VAULT_MASTER_KEY
+  valueFrom: {secretKeyRef: {name: {{ required "existingSecrets.cryptography.vaultMasterKey.name is required" .Values.existingSecrets.cryptography.vaultMasterKey.name }}, key: {{ required "existingSecrets.cryptography.vaultMasterKey.key is required" .Values.existingSecrets.cryptography.vaultMasterKey.key }}}}
+- name: SYNAPSE_EVIDENCE_SIGNING_SEED
+  valueFrom: {secretKeyRef: {name: {{ required "existingSecrets.cryptography.evidenceSigningSeed.name is required" .Values.existingSecrets.cryptography.evidenceSigningSeed.name }}, key: {{ required "existingSecrets.cryptography.evidenceSigningSeed.key is required" .Values.existingSecrets.cryptography.evidenceSigningSeed.key }}}}
+- name: SYNAPSE_MEASURE_CURSOR_SECRET
+  valueFrom: {secretKeyRef: {name: {{ required "existingSecrets.cryptography.measureCursorSecret.name is required" .Values.existingSecrets.cryptography.measureCursorSecret.name }}, key: {{ required "existingSecrets.cryptography.measureCursorSecret.key is required" .Values.existingSecrets.cryptography.measureCursorSecret.key }}}}
+{{- if .Values.oidc.enabled }}
+- name: SYNAPSE_OIDC_ENABLED
+  value: "true"
+- name: SYNAPSE_OIDC_ISSUER
+  value: {{ required "oidc.issuer is required when oidc.enabled" .Values.oidc.issuer | quote }}
+- name: SYNAPSE_OIDC_CLIENT_ID
+  value: {{ required "oidc.clientID is required when oidc.enabled" .Values.oidc.clientID | quote }}
+- name: SYNAPSE_OIDC_REDIRECT_URL
+  value: {{ required "oidc.redirectURL is required when oidc.enabled" .Values.oidc.redirectURL | quote }}
+- name: SYNAPSE_OIDC_FRONTEND_URL
+  value: {{ required "oidc.frontendURL is required when oidc.enabled" .Values.oidc.frontendURL | quote }}
+- name: SYNAPSE_OIDC_TENANT_ID
+  value: {{ required "oidc.tenantID is required when oidc.enabled" .Values.oidc.tenantID | quote }}
+- name: SYNAPSE_OIDC_GROUP_ROLE_MAPPING
+  value: {{ required "oidc.groupRoleMapping must map at least one provider group to a role" (join "," .Values.oidc.groupRoleMapping) | quote }}
+- name: SYNAPSE_OIDC_TRANSACTION_TTL
+  value: {{ .Values.oidc.transactionTTL | quote }}
+- name: SYNAPSE_OIDC_SESSION_TTL
+  value: {{ .Values.oidc.sessionTTL | quote }}
+- name: SYNAPSE_OIDC_CLIENT_SECRET
+  valueFrom: {secretKeyRef: {name: {{ required "existingSecrets.oidc.clientSecret.name is required when oidc.enabled" .Values.existingSecrets.oidc.clientSecret.name }}, key: {{ required "existingSecrets.oidc.clientSecret.key is required when oidc.enabled" .Values.existingSecrets.oidc.clientSecret.key }}}}
+{{- end }}
+{{- end }}

--- a/deploy/helm/synapse/templates/api.yaml
+++ b/deploy/helm/synapse/templates/api.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "synapse.fullname" . }}-api
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "synapse.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      hostUsers: {{ .Values.sandbox.hostUsers }}
+      serviceAccountName: {{ include "synapse.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- include "synapse.podSecurityContext" . | nindent 8 }}
+      topologySpreadConstraints:
+        {{- include "synapse.topologySpreadConstraints" (list . "api") | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      containers:
+        - name: api
+          image: {{ include "synapse.image" .Values.image | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- include "synapse.containerSecurityContext" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+            {{- if .Values.api.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.api.metrics.port }}
+            {{- end }}
+          env:
+            {{- include "synapse.runtimeEnv" . | nindent 12 }}
+            - name: SYNAPSE_HTTP_ADDR
+              value: ":8080"
+            - name: SYNAPSE_METRICS_ENABLED
+              value: {{ .Values.api.metrics.enabled | quote }}
+            {{- if .Values.api.metrics.enabled }}
+            - name: SYNAPSE_METRICS_ADDR
+              value: {{ printf "0.0.0.0:%d" (.Values.api.metrics.port | int) | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          livenessProbe:
+            httpGet: {path: /healthz, port: http}
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: {path: /readyz, port: http}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - {name: synapse-data, mountPath: /var/lib/synapse}
+            - {name: tmp, mountPath: /tmp}
+            - {name: database-ca, mountPath: /etc/synapse/database-ca, readOnly: true}
+      volumes:
+        - name: synapse-data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: database-ca
+          secret:
+            secretName: {{ required "externalDatabase.caBundle.secretName is required" .Values.externalDatabase.caBundle.secretName }}
+            items:
+              - key: {{ required "externalDatabase.caBundle.key is required" .Values.externalDatabase.caBundle.key }}
+                path: ca.crt

--- a/deploy/helm/synapse/templates/ingress.yaml
+++ b/deploy/helm/synapse/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "synapse.fullname" . }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  tls:
+    - hosts: [{{ required "ingress.host is required" .Values.ingress.host | quote }}]
+      secretName: {{ required "ingress.tls.secretName must name an existing TLS Secret" .Values.ingress.tls.secretName }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend: {service: {name: {{ include "synapse.fullname" . }}-api, port: {name: http}}}
+          - path: /healthz
+            pathType: Exact
+            backend: {service: {name: {{ include "synapse.fullname" . }}-api, port: {name: http}}}
+          - path: /readyz
+            pathType: Exact
+            backend: {service: {name: {{ include "synapse.fullname" . }}-api, port: {name: http}}}
+          - path: /
+            pathType: Prefix
+            backend: {service: {name: {{ include "synapse.fullname" . }}-web, port: {name: http}}}
+{{- end }}

--- a/deploy/helm/synapse/templates/migration.yaml
+++ b/deploy/helm/synapse/templates/migration.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "synapse.fullname" . }}-migrate
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        {{- include "synapse.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      hostUsers: {{ .Values.sandbox.hostUsers }}
+      restartPolicy: Never
+      serviceAccountName: {{ include "synapse.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- include "synapse.podSecurityContext" . | nindent 8 }}
+      containers:
+        - name: migrate
+          image: {{ include "synapse.image" .Values.image | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/opt/synapse/synapse-migrate"]
+          securityContext:
+            {{- include "synapse.containerSecurityContext" . | nindent 12 }}
+          env:
+            {{- include "synapse.runtimeEnv" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+          volumeMounts:
+            - {name: database-ca, mountPath: /etc/synapse/database-ca, readOnly: true}
+      volumes:
+        - name: database-ca
+          secret:
+            secretName: {{ required "externalDatabase.caBundle.secretName is required" .Values.externalDatabase.caBundle.secretName }}
+            items:
+              - key: {{ required "externalDatabase.caBundle.key is required" .Values.externalDatabase.caBundle.key }}
+                path: ca.crt

--- a/deploy/helm/synapse/templates/networkpolicy.yaml
+++ b/deploy/helm/synapse/templates/networkpolicy.yaml
@@ -1,0 +1,114 @@
+# Namespace-wide default deny. The following policies admit only the required control-plane paths.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "synapse.fullname" . }}-default-deny
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "synapse.fullname" . }}-ingress
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" . | nindent 6 }}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressControllerNamespace | quote }}
+      ports: [{protocol: TCP, port: 8080}]
+{{- if .Values.api.metrics.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "synapse.fullname" . }}-metrics
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.api.metrics.monitoringNamespace | quote }}
+      ports: [{protocol: TCP, port: {{ .Values.api.metrics.port }}}]
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "synapse.fullname" . }}-runtime-egress
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" . | nindent 6 }}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports: [{protocol: UDP, port: 53}, {protocol: TCP, port: 53}]
+    {{- $db := .Values.networkPolicy.runtimeEgress.database }}
+    {{- $objectStore := .Values.networkPolicy.runtimeEgress.objectStore }}
+    {{- $oidcRanges := .Values.networkPolicy.runtimeEgress.oidc }}
+    {{- if not $db }}
+      {{- fail "networkPolicy.runtimeEgress.database must list the PostgreSQL CIDR(s); an unrestricted egress rule is not accepted in production" }}
+    {{- end }}
+    {{- if not $objectStore }}
+      {{- fail "networkPolicy.runtimeEgress.objectStore must list the object-store CIDR(s); an unrestricted egress rule is not accepted in production" }}
+    {{- end }}
+    # Each destination is an explicit CIDR. There is deliberately no ports-only rule, so a
+    # compromised pod cannot reach an arbitrary host even on an allowed port.
+    - to:
+        {{- range $db }}
+        - ipBlock: {cidr: {{ . | quote }}}
+        {{- end }}
+      ports: [{protocol: TCP, port: 5432}]
+    - to:
+        {{- range $objectStore }}
+        - ipBlock: {cidr: {{ . | quote }}}
+        {{- end }}
+      ports: [{protocol: TCP, port: 443}]
+    {{- if $oidcRanges }}
+    - to:
+        {{- range $oidcRanges }}
+        - ipBlock: {cidr: {{ . | quote }}}
+        {{- end }}
+      ports: [{protocol: TCP, port: 443}]
+    {{- end }}
+{{- if .Values.networkPolicy.allowInternetEgress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "synapse.fullname" . }}-worker-recon-egress
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  policyTypes: [Egress]
+  egress:
+    # Only worker pods may reach authorized external recon/acquisition targets. Application
+    # scope/authorization and the in-process sandbox gate every execution.
+    - ports: [{protocol: TCP, port: 80}, {protocol: TCP, port: 443}]
+{{- end }}

--- a/deploy/helm/synapse/templates/pdb.yaml
+++ b/deploy/helm/synapse/templates/pdb.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "synapse.fullname" . }}-api
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "synapse.fullname" . }}-web
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web

--- a/deploy/helm/synapse/templates/service.yaml
+++ b/deploy/helm/synapse/templates/service.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "synapse.fullname" . }}-api
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "synapse.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+    {{- if .Values.api.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.api.metrics.port }}
+      targetPort: metrics
+    {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "synapse.fullname" . }}-web
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "synapse.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/deploy/helm/synapse/templates/serviceaccount.yaml
+++ b/deploy/helm/synapse/templates/serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "synapse.serviceAccountName" . }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+  annotations:
+    # The migration Job is a pre-install/pre-upgrade hook, and hooks run before normal
+    # resources. Without this the Job cannot be scheduled at all: the API server refuses pod
+    # creation for a service account that does not exist yet. A lower weight than the Job
+    # (-10) guarantees the identity is applied first. It is deliberately not deleted after the
+    # hook succeeds, because the long-lived Deployments run under this same service account.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/deploy/helm/synapse/templates/web.yaml
+++ b/deploy/helm/synapse/templates/web.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "synapse.fullname" . }}-web
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "synapse.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      hostUsers: {{ .Values.sandbox.hostUsers }}
+      serviceAccountName: {{ include "synapse.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- include "synapse.podSecurityContext" . | nindent 8 }}
+      topologySpreadConstraints:
+        {{- include "synapse.topologySpreadConstraints" (list . "web") | nindent 8 }}
+      containers:
+        - name: web
+          image: {{ include "synapse.image" .Values.web.image | quote }}
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          securityContext:
+            {{- include "synapse.containerSecurityContext" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+          livenessProbe:
+            httpGet: {path: /, port: http}
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet: {path: /, port: http}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          volumeMounts:
+            # nginx-unprivileged writes PID and temporary client/proxy state under /tmp.
+            - {name: tmp, mountPath: /tmp}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/deploy/helm/synapse/templates/worker.yaml
+++ b/deploy/helm/synapse/templates/worker.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "synapse.fullname" . }}-worker
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  # A singleton worker holds a PostgreSQL process lock. With one replica, zero surge and one
+  # unavailable stops the old pod before starting its replacement, without an overlap window.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "synapse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "synapse.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      hostUsers: {{ .Values.sandbox.hostUsers }}
+      serviceAccountName: {{ include "synapse.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- include "synapse.podSecurityContext" . | nindent 8 }}
+      topologySpreadConstraints:
+        {{- include "synapse.topologySpreadConstraints" (list . "worker") | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      containers:
+        - name: worker
+          image: {{ include "synapse.image" .Values.image | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/opt/synapse/synapse-worker"]
+          securityContext:
+            {{- include "synapse.containerSecurityContext" . | nindent 12 }}
+          env:
+            {{- include "synapse.runtimeEnv" . | nindent 12 }}
+            - name: SYNAPSE_LEADER_ENABLED
+              value: "true"
+            - name: SYNAPSE_METRICS_ENABLED
+              value: "false"
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          startupProbe:
+            # argv only: no shell is used anywhere in the execution path. bwrap --version
+            # confirms the sandbox helper is present and executable before work is claimed.
+            exec: {command: ["/usr/bin/bwrap", "--version"]}
+            periodSeconds: 10
+            failureThreshold: 18
+          volumeMounts:
+            - {name: synapse-data, mountPath: /var/lib/synapse}
+            - {name: tmp, mountPath: /tmp}
+            - {name: database-ca, mountPath: /etc/synapse/database-ca, readOnly: true}
+      volumes:
+        - name: synapse-data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: database-ca
+          secret:
+            secretName: {{ required "externalDatabase.caBundle.secretName is required" .Values.externalDatabase.caBundle.secretName }}
+            items:
+              - key: {{ required "externalDatabase.caBundle.key is required" .Values.externalDatabase.caBundle.key }}
+                path: ca.crt

--- a/deploy/helm/synapse/testdata/render_test.sh
+++ b/deploy/helm/synapse/testdata/render_test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env sh
+set -eu
+chart_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+values="$chart_dir/tests/production-values.yaml"
+out=$(mktemp)
+trap 'rm -f "$out"' EXIT
+
+helm lint --strict "$chart_dir" -f "$values"
+helm template synapse "$chart_dir" -f "$values" --kube-version 1.29.0 >"$out"
+
+# Production policy: only digest-qualified images, no privileged containers/capability additions,
+# a private metrics listener, and migrations as an ordered Helm hook.
+! grep -E 'image: .+:(latest|[[:alnum:]._-]+)$' "$out"
+grep -q 'helm.sh/hook": pre-install,pre-upgrade' "$out"
+# The migration hook runs before normal resources, so its service account must be a hook with a
+# lower weight. Otherwise the Job is never scheduled: the API server refuses pod creation for a
+# service account that does not exist yet.
+hook_weight_for_kind() {
+  # Print the hook-weight of the pre-install/pre-upgrade hook whose kind is $1.
+  awk -v want="$1" '
+    /^---$/ { kind=""; hook=0; weight="" ; next }
+    /^kind:[[:space:]]*/ { k=$0; sub(/^kind:[[:space:]]*/, "", k); kind=k }
+    /"helm\.sh\/hook":[[:space:]]*pre-install,pre-upgrade/ { hook=1 }
+    /"helm\.sh\/hook-weight":/ {
+      # Split on the quote character so the dash in "hook-weight" cannot leak into the value.
+      n=split($0, parts, "\""); if (n >= 4) { weight=parts[4] }
+    }
+    { if (kind == want && hook == 1 && weight != "") { print weight; exit } }
+  ' "$2"
+}
+sa_weight=$(hook_weight_for_kind ServiceAccount "$out")
+job_weight=$(hook_weight_for_kind Job "$out")
+if [ -z "$sa_weight" ]; then
+  printf '%s\n' 'ServiceAccount must be a pre-install/pre-upgrade hook so the migration Job can be scheduled' >&2
+  exit 1
+fi
+if [ -z "$job_weight" ]; then
+  printf '%s\n' 'migration Job must be a pre-install/pre-upgrade hook' >&2
+  exit 1
+fi
+if [ "$sa_weight" -ge "$job_weight" ]; then
+  printf '%s\n' "ServiceAccount hook-weight ($sa_weight) must be lower than the migration Job's ($job_weight)" >&2
+  exit 1
+fi
+grep -q 'SYNAPSE_DB_AUTO_MIGRATE' "$out"
+grep -q 'value: "false"' "$out"
+grep -q 'SYNAPSE_SANDBOX_ENABLED' "$out"
+grep -q 'value: "true"' "$out"
+# The pod user-namespace posture is explicit on every workload. Regardless of this setting, the
+# application performs a live bwrap namespace/mount/seccomp startup probe and fails closed.
+if [ "$(grep -c 'hostUsers: true' "$out")" -ne 4 ]; then
+  printf '%s\n' 'expected explicit hostUsers posture on API, worker, web, and migration workloads' >&2
+  exit 1
+fi
+! grep -E 'privileged: true|SYS_ADMIN' "$out"
+# Metrics use a dedicated API listener and ClusterIP port, never the public ingress. The aggregate
+# collectors have fixed low-cardinality labels and the runtime NetworkPolicy keeps this unauthenticated
+# endpoint private to explicitly allowed monitoring clients.
+grep -q 'name: SYNAPSE_METRICS_ENABLED' "$out"
+grep -q 'name: SYNAPSE_METRICS_ADDR' "$out"
+grep -q 'name: metrics' "$out"
+grep -q 'containerPort: 9090' "$out"
+grep -q 'kubernetes.io/metadata.name: "monitoring"' "$out"
+! awk '/^kind: Ingress$/{ingress=1} /^---$/{ingress=0} ingress && /9090|metrics/{found=1} END{exit found ? 0 : 1}' "$out"
+grep -q 'kind: NetworkPolicy' "$out"
+# Immutable image and explicitly scoped egress: no writable root filesystem, no shell in any
+# probe, and every runtime egress rule carries a destination rather than only a port.
+! grep -q 'readOnlyRootFilesystem: false' "$out"
+! grep -qE '"/bin/sh"|/bin/sh -c' "$out"
+grep -q 'ipBlock' "$out"
+# Both long-lived workloads and the migration hook receive the operator-supplied database trust
+# anchor read-only. DSNs use sslmode=verify-full and point sslrootcert at this mounted path.
+if [ "$(grep -c 'mountPath: /tmp' "$out")" -ne 3 ]; then
+  printf '%s\n' 'expected an explicit writable /tmp emptyDir on API, worker, and web workloads' >&2
+  exit 1
+fi
+if [ "$(grep -c 'mountPath: /etc/synapse/database-ca' "$out")" -ne 3 ]; then
+  printf '%s\n' 'expected the database CA bundle on API, worker, and migration workloads' >&2
+  exit 1
+fi
+if [ "$(grep -c 'secretName: synapse-database-ca' "$out")" -ne 3 ]; then
+  printf '%s\n' 'expected all database CA volumes to reference the configured external Secret' >&2
+  exit 1
+fi
+if helm template synapse "$chart_dir" -f "$values" --set networkPolicy.runtimeEgress.database=null >/dev/null 2>&1; then
+  printf '%s\n' 'expected unrestricted runtime egress to be refused' >&2
+  exit 1
+fi
+grep -q 'kind: PodDisruptionBudget' "$out"
+# Every spread rule must select its own workload component; a null/empty selector matches no pods on
+# current Kubernetes and silently defeats the intended HA topology.
+for component in api worker web; do
+  grep -q "app.kubernetes.io/component: $component" "$out"
+done
+! grep -q 'labelSelector: {}' "$out"
+grep -q 'kind: Ingress' "$out"
+# The worker enforces a process-wide singleton lock. Its update must allow no surge, so Kubernetes
+# stops the old singleton before creating the replacement instead of overlapping two lock holders.
+worker_strategy=$(awk '
+  /^---$/ { worker=0; next }
+  /app\.kubernetes\.io\/component: worker/ { worker=1 }
+  worker && /maxSurge:|maxUnavailable:/ { print }
+' "$out")
+case "$worker_strategy" in
+  *"maxSurge: 0"*) ;;
+  *) printf '%s\n' 'the singleton worker must roll out with maxSurge: 0' >&2; exit 1 ;;
+esac
+case "$worker_strategy" in
+  *"maxUnavailable: 1"*) ;;
+  *) printf '%s\n' 'the singleton worker must allow one unavailable replica so the old pod stops first' >&2; exit 1 ;;
+esac
+
+if helm lint "$chart_dir" -f "$chart_dir/tests/invalid-tag-values.yaml" >/dev/null 2>&1; then
+  printf '%s\n' 'expected tag-only image values to fail schema validation' >&2
+  exit 1
+fi

--- a/deploy/helm/synapse/tests/chart_test.go
+++ b/deploy/helm/synapse/tests/chart_test.go
@@ -1,0 +1,23 @@
+package tests
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestProductionChartRendersWithRequiredSecurityPosture(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the shell chart test is covered by Helm CI on Linux")
+	}
+	chartDir, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("sh", filepath.Join(chartDir, "testdata", "render_test.sh"))
+	cmd.Dir = chartDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("chart render test failed: %v\n%s", err, output)
+	}
+}

--- a/deploy/helm/synapse/tests/invalid-tag-values.yaml
+++ b/deploy/helm/synapse/tests/invalid-tag-values.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: registry.example.invalid/synapse
+  digest: latest

--- a/deploy/helm/synapse/tests/production-values.yaml
+++ b/deploy/helm/synapse/tests/production-values.yaml
@@ -1,0 +1,22 @@
+image:
+  repository: registry.example.invalid/synapse
+  digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+web:
+  image:
+    repository: registry.example.invalid/synapse-web
+    digest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+objectStore:
+  endpoint: s3.example.internal:443
+  bucket: synapse-evidence
+  useSSL: true
+ingress:
+  host: synapse.test.example
+  tls:
+    secretName: synapse-test-tls
+networkPolicy:
+  ingressControllerNamespace: ingress-nginx
+  allowInternetEgress: false
+  runtimeEgress:
+    database: ["10.64.16.0/20"]
+    objectStore: ["10.64.32.0/20"]
+    oidc: ["10.64.48.0/20"]

--- a/deploy/helm/synapse/values.schema.json
+++ b/deploy/helm/synapse/values.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Synapse production chart values",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["image", "api", "worker", "web", "migration", "existingSecrets", "objectStore", "sandbox", "ingress"],
+  "properties": {
+    "nameOverride": {"type": "string"},
+    "fullnameOverride": {"type": "string"},
+    "image": {"$ref": "#/definitions/image"},
+    "web": {"type": "object", "additionalProperties": false, "required": ["replicaCount", "image", "resources"], "properties": {"replicaCount": {"type": "integer", "minimum": 2}, "image": {"$ref": "#/definitions/image"}, "resources": {"$ref": "#/definitions/resources"}}},
+    "api": {"type": "object", "additionalProperties": false, "required": ["replicaCount", "metrics", "resources"], "properties": {"replicaCount": {"type": "integer", "minimum": 2}, "metrics": {"type": "object", "additionalProperties": false, "required": ["enabled", "port", "monitoringNamespace"], "properties": {"enabled": {"type": "boolean"}, "port": {"type": "integer", "minimum": 1024, "maximum": 65535}, "monitoringNamespace": {"type": "string", "minLength": 1}}}, "resources": {"$ref": "#/definitions/resources"}}},
+    "worker": {"type": "object", "additionalProperties": false, "required": ["replicaCount", "resources"], "properties": {"replicaCount": {"const": 1}, "resources": {"$ref": "#/definitions/resources"}}},
+    "migration": {"type": "object", "additionalProperties": false, "required": ["resources"], "properties": {"resources": {"$ref": "#/definitions/resources"}}},
+    "serviceAccount": {"type": "object", "additionalProperties": false, "required": ["create", "name"], "properties": {"create": {"type": "boolean"}, "name": {"type": "string"}, "annotations": {"type": "object", "additionalProperties": {"type": "string"}}}},
+    "podSecurityContext": {"type": "object"},
+    "containerSecurityContext": {"type": "object"},
+    "existingSecrets": {"type": "object", "additionalProperties": false, "required": ["apiToken", "database", "objectStore", "cryptography"], "properties": {"apiToken": {"$ref": "#/definitions/secretRef"}, "database": {"type": "object", "additionalProperties": false, "required": ["runtime", "migration"], "properties": {"runtime": {"$ref": "#/definitions/secretRef"}, "migration": {"$ref": "#/definitions/secretRef"}}}, "objectStore": {"type": "object", "additionalProperties": false, "required": ["accessKey", "secretKey"], "properties": {"accessKey": {"$ref": "#/definitions/secretRef"}, "secretKey": {"$ref": "#/definitions/secretRef"}}}, "cryptography": {"type": "object", "additionalProperties": false, "required": ["vaultMasterKey", "evidenceSigningSeed", "measureCursorSecret"], "properties": {"vaultMasterKey": {"$ref": "#/definitions/secretRef"}, "evidenceSigningSeed": {"$ref": "#/definitions/secretRef"}, "measureCursorSecret": {"$ref": "#/definitions/secretRef"}}}, "oidc": {"type": "object", "additionalProperties": false, "required": ["clientSecret"], "properties": {"clientSecret": {"$ref": "#/definitions/secretRef"}}}}},
+    "externalDatabase": {"type": "object", "additionalProperties": false, "required": ["sslMode", "caBundle"], "properties": {"sslMode": {"const": "verify-full"}, "caBundle": {"type": "object", "additionalProperties": false, "required": ["secretName", "key"], "properties": {"secretName": {"type": "string", "minLength": 1}, "key": {"type": "string", "minLength": 1}}}}},
+    "oidc": {"type": "object", "additionalProperties": false, "required": ["enabled"], "properties": {"enabled": {"type": "boolean"}, "issuer": {"type": "string"}, "clientID": {"type": "string"}, "redirectURL": {"type": "string"}, "frontendURL": {"type": "string"}, "tenantID": {"type": "string"}, "groupRoleMapping": {"type": "array", "items": {"type": "string", "pattern": "^[^=]+=(admin|consultant|reviewer|readonly|member)$"}}, "transactionTTL": {"type": "string"}, "sessionTTL": {"type": "string"}}},
+    "objectStore": {"type": "object", "additionalProperties": false, "required": ["endpoint", "bucket", "useSSL"], "properties": {"endpoint": {"type": "string", "minLength": 1}, "bucket": {"type": "string", "minLength": 1}, "useSSL": {"const": true}}},
+    "sandbox": {"type": "object", "additionalProperties": false, "required": ["enabled", "hostUsers", "userNamespacesRequired"], "properties": {"enabled": {"const": true}, "hostUsers": {"type": "boolean"}, "userNamespacesRequired": {"const": true}}},
+    "ingress": {"type": "object", "additionalProperties": false, "required": ["enabled", "className", "host", "tls"], "properties": {"enabled": {"const": true}, "className": {"type": "string"}, "host": {"type": "string", "minLength": 1}, "tls": {"type": "object", "additionalProperties": false, "required": ["secretName"], "properties": {"secretName": {"type": "string", "minLength": 1}}}}},
+    "networkPolicy": {"type": "object", "additionalProperties": false, "required": ["ingressControllerNamespace", "allowInternetEgress", "runtimeEgress"], "properties": {"ingressControllerNamespace": {"type": "string", "minLength": 1}, "allowInternetEgress": {"type": "boolean"}, "runtimeEgress": {"type": "object", "additionalProperties": false, "required": ["database", "objectStore", "oidc"], "properties": {"database": {"$ref": "#/definitions/cidrList"}, "objectStore": {"$ref": "#/definitions/cidrList"}, "oidc": {"$ref": "#/definitions/cidrList"}}}}},
+    "topologySpreadConstraints": {"type": "array", "minItems": 1},
+    "nodeSelector": {"type": "object"},
+    "tolerations": {"type": "array"},
+    "affinity": {"type": "object"}
+  },
+  "definitions": {
+    "image": {"type": "object", "additionalProperties": false, "required": ["repository", "digest", "pullPolicy"], "properties": {"repository": {"type": "string", "minLength": 1}, "digest": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"}, "pullPolicy": {"enum": ["Always", "IfNotPresent", "Never"]}}},
+    "secretRef": {"type": "object", "additionalProperties": false, "required": ["name", "key"], "properties": {"name": {"type": "string", "minLength": 1}, "key": {"type": "string", "minLength": 1}}},
+    "cidrList": {"type": "array", "items": {"type": "string", "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/([0-9]|[12][0-9]|3[0-2])$"}},
+    "resources": {"type": "object", "additionalProperties": false, "required": ["requests", "limits"], "properties": {"requests": {"type": "object", "minProperties": 2, "required": ["cpu", "memory"]}, "limits": {"type": "object", "minProperties": 2, "required": ["cpu", "memory"]}}}
+  }
+}

--- a/deploy/helm/synapse/values.yaml
+++ b/deploy/helm/synapse/values.yaml
@@ -1,0 +1,149 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/kkloudtarus/synapse
+  digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+  pullPolicy: IfNotPresent
+
+web:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/kkloudtarus/synapse-web
+    digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+    pullPolicy: IfNotPresent
+  resources:
+    requests: {cpu: 100m, memory: 128Mi}
+    limits: {cpu: 500m, memory: 256Mi}
+
+api:
+  replicaCount: 2
+  metrics:
+    # Dedicated, unauthenticated listener. It remains private behind this ClusterIP Service and
+    # the chart's default-deny NetworkPolicy; never expose this port through the public ingress.
+    enabled: true
+    port: 9090
+    monitoringNamespace: monitoring
+  resources:
+    requests: {cpu: 500m, memory: 1Gi}
+    limits: {cpu: "2", memory: 2Gi}
+
+worker:
+  # The worker holds a singleton PostgreSQL lock. Keep this at one until worker sharding exists.
+  replicaCount: 1
+  resources:
+    requests: {cpu: 500m, memory: 1Gi}
+    limits: {cpu: "2", memory: 2Gi}
+
+migration:
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: 500m, memory: 512Mi}
+
+serviceAccount:
+  create: true
+  name: ""
+  # Workload-identity annotations, e.g. eks.amazonaws.com/role-arn for IRSA. No credential
+  # material belongs here, only a role reference.
+  annotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  seccompProfile: {type: RuntimeDefault}
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  # Writable paths are supplied as explicit emptyDir mounts (/tmp, /var/lib/synapse), so the
+  # image itself stays immutable and pinned tool binaries cannot be replaced at runtime.
+  readOnlyRootFilesystem: true
+  capabilities: {drop: ["ALL"]}
+
+# Every secret reference is pre-existing and split by purpose. The chart never creates or
+# renders Secret data. Use external-secrets, CSI, or equivalent to supply these objects.
+existingSecrets:
+  apiToken: {name: synapse-api-token, key: api-token}
+  database:
+    runtime: {name: synapse-db-runtime, key: dsn}
+    migration: {name: synapse-db-migration, key: dsn}
+  objectStore:
+    accessKey: {name: synapse-s3-access, key: access-key}
+    secretKey: {name: synapse-s3-secret, key: secret-key}
+  cryptography:
+    vaultMasterKey: {name: synapse-vault-key, key: key}
+    evidenceSigningSeed: {name: synapse-evidence-signing, key: seed}
+    measureCursorSecret: {name: synapse-cursor-secret, key: secret}
+  # Referenced only when oidc.enabled is true; the value is never rendered by the chart.
+  oidc:
+    clientSecret: {name: synapse-oidc-client, key: client-secret}
+
+externalDatabase:
+  # Runtime and migration DSNs are supplied only by existingSecrets.database. Each DSN must use
+  # sslmode=verify-full and point sslrootcert at the mounted file below.
+  sslMode: verify-full
+  caBundle:
+    secretName: synapse-database-ca
+    key: ca.crt
+
+# Browser OIDC BFF. Disabled by default; bearer API tokens are unaffected either way. The client
+# secret is never rendered here, only referenced from a pre-existing Secret.
+oidc:
+  enabled: false
+  issuer: ""
+  clientID: ""
+  redirectURL: ""
+  frontendURL: ""
+  # The tenant is fixed by the operator and never read from a token claim.
+  tenantID: ""
+  # Allowlist entries map one provider group to one Synapse role, e.g. "administrators=admin".
+  groupRoleMapping: []
+  transactionTTL: 10m
+  sessionTTL: 8h
+
+objectStore:
+  endpoint: s3.example.internal:443
+  bucket: synapse-evidence
+  useSSL: true
+
+sandbox:
+  enabled: true
+  # Set false to place pods in a Kubernetes-managed user namespace. This does not replace the
+  # live bubblewrap startup self-check: the node/runtime must still allow nested namespaces.
+  hostUsers: true
+  # Nodes must permit unprivileged user namespaces for bubblewrap. Do not grant SYS_ADMIN.
+  userNamespacesRequired: true
+
+ingress:
+  enabled: true
+  className: ""
+  host: synapse.example.com
+  tls:
+    secretName: synapse-tls
+
+networkPolicy:
+  ingressControllerNamespace: ingress-nginx
+  # Runtime egress is restricted to these explicit destinations. A CIDR-based NetworkPolicy
+  # cannot express FQDNs, so each dependency must be named as the CIDR it actually resolves to
+  # (for example the RDS subnet range and the S3/OIDC endpoint prefix list ranges).
+  runtimeEgress:
+    database: []
+    objectStore: []
+    oidc: []
+  # Recon and governed acquisition reach authorized external targets from worker pods only.
+  # Leave false unless a cluster-level allowlist (FQDN-aware CNI or egress gateway) is in
+  # place; engagement scope and the sandbox gate execution, not this policy.
+  allowInternetEgress: false
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    # Rewritten by each workload template to its own component labels. Keeping a selector here
+    # would accidentally couple the API, worker, and web scheduling domains.
+    labelSelector: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/deploy/operations/recovery/backup.sh
+++ b/deploy/operations/recovery/backup.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Create a paired, quiesced PostgreSQL and object-store backup. Dry-run by default.
+
+set -euo pipefail
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  backup.sh --backup-dir ABSOLUTE_PATH --pg-dsn-env NAME --object-source MC_SOURCE \
+    --quiesced-confirmation BACKUP-QUIESCED [--execute]
+
+The caller must first quiesce every Synapse writer. Without --execute this command
+only validates its arguments and prints the planned operations.
+USAGE
+}
+
+backup_dir=""
+pg_dsn_env=""
+object_source=""
+quiesced_confirmation=""
+execute=false
+
+while (($#)); do
+  case "$1" in
+    --backup-dir) backup_dir="${2:-}"; shift 2 ;;
+    --pg-dsn-env) pg_dsn_env="${2:-}"; shift 2 ;;
+    --object-source) object_source="${2:-}"; shift 2 ;;
+    --quiesced-confirmation) quiesced_confirmation="${2:-}"; shift 2 ;;
+    --execute) execute=true; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+
+require_value "--backup-dir" "$backup_dir"
+require_absolute_path "--backup-dir" "$backup_dir"
+require_value "--pg-dsn-env" "$pg_dsn_env"
+require_environment_name "$pg_dsn_env"
+require_value "--object-source" "$object_source"
+require_safe_operand "--object-source" "$object_source"
+[[ ! -e "$backup_dir" ]] || fail "backup directory already exists: $backup_dir"
+
+if ! "$execute"; then
+  printf '%s\n' "dry run: would create a paired backup at $backup_dir"
+  printf '%s\n' 'dry run: would run pg_dump in custom archive format and mc mirror without --remove or --overwrite'
+  printf '%s\n' 'dry run: add --execute and --quiesced-confirmation BACKUP-QUIESCED after stopping all writers'
+  exit 0
+fi
+
+[[ "$quiesced_confirmation" == "BACKUP-QUIESCED" ]] || fail "--quiesced-confirmation must be BACKUP-QUIESCED"
+require_command pg_dump
+require_command mc
+require_command sha256sum
+
+parent_dir="$(dirname -- "$backup_dir")"
+[[ -d "$parent_dir" ]] || fail "backup parent directory does not exist: $parent_dir"
+umask 077
+mkdir -- "$backup_dir"
+mkdir -- "$backup_dir/objects"
+
+pg_dump --dbname="${!pg_dsn_env}" --format=custom --file="$backup_dir/database.dump"
+mc mirror "$object_source" "$backup_dir/objects"
+
+{
+  printf 'backup-format=postgres-custom-plus-object-mirror\n'
+  printf 'created-at-utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  pg_dump --version
+  mc --version | sed -n '1p'
+} >"$backup_dir/BACKUP-METADATA.txt"
+
+(
+  cd -- "$backup_dir"
+  {
+    sha256sum -b database.dump
+    LC_ALL=C find objects -type f -print0 | LC_ALL=C sort -z | xargs -r -0 sha256sum -b --
+  } >MANIFEST.sha256
+  sha256sum --check --strict MANIFEST.sha256
+)
+
+printf '%s\n' "backup complete: $backup_dir"
+printf '%s\n' 'record the immutable backup location and MANIFEST.sha256 with the change evidence'

--- a/deploy/operations/recovery/forward-upgrade.sh
+++ b/deploy/operations/recovery/forward-upgrade.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Verify a v0.1.8 baseline artifact and apply current embedded forward migrations. Dry-run by default.
+
+set -euo pipefail
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  forward-upgrade.sh --backup-dir ABSOLUTE_PATH     --baseline-migrator ABSOLUTE_PATH --baseline-expected-sha256 SHA256     --current-migrator ABSOLUTE_PATH --current-expected-sha256 SHA256     --runtime-pg-dsn-env NAME --migration-pg-dsn-env NAME     --quiesced-confirmation UPGRADE-QUIESCED     --baseline-confirmation BASELINE-V0.1.8-VERIFIED     --forward-upgrade-confirmation UPGRADE-FROM-V0.1.8-TO-CURRENT [--execute]
+
+The baseline migrator is verified only to attest the v0.1.8 state represented by this paired backup. The current migrator is the only binary this wrapper runs. It runs no down migration and does not deploy, stop, or delete any service.
+USAGE
+}
+
+backup_dir=""
+baseline_migrator=""
+baseline_expected_sha256=""
+current_migrator=""
+current_expected_sha256=""
+runtime_pg_dsn_env=""
+migration_pg_dsn_env=""
+quiesced_confirmation=""
+baseline_confirmation=""
+forward_upgrade_confirmation=""
+execute=false
+
+while (($#)); do
+  case "$1" in
+    --backup-dir) backup_dir="${2:-}"; shift 2 ;;
+    --baseline-migrator) baseline_migrator="${2:-}"; shift 2 ;;
+    --baseline-expected-sha256) baseline_expected_sha256="${2:-}"; shift 2 ;;
+    --current-migrator) current_migrator="${2:-}"; shift 2 ;;
+    --current-expected-sha256) current_expected_sha256="${2:-}"; shift 2 ;;
+    --runtime-pg-dsn-env) runtime_pg_dsn_env="${2:-}"; shift 2 ;;
+    --migration-pg-dsn-env) migration_pg_dsn_env="${2:-}"; shift 2 ;;
+    --quiesced-confirmation) quiesced_confirmation="${2:-}"; shift 2 ;;
+    --baseline-confirmation) baseline_confirmation="${2:-}"; shift 2 ;;
+    --forward-upgrade-confirmation) forward_upgrade_confirmation="${2:-}"; shift 2 ;;
+    --execute) execute=true; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+
+require_value "--backup-dir" "$backup_dir"
+require_absolute_path "--backup-dir" "$backup_dir"
+require_value "--baseline-migrator" "$baseline_migrator"
+require_absolute_path "--baseline-migrator" "$baseline_migrator"
+require_value "--baseline-expected-sha256" "$baseline_expected_sha256"
+[[ "$baseline_expected_sha256" =~ ^[[:xdigit:]]{64}$ ]] || fail "--baseline-expected-sha256 must be a SHA-256 digest"
+require_value "--current-migrator" "$current_migrator"
+require_absolute_path "--current-migrator" "$current_migrator"
+require_value "--current-expected-sha256" "$current_expected_sha256"
+[[ "$current_expected_sha256" =~ ^[[:xdigit:]]{64}$ ]] || fail "--current-expected-sha256 must be a SHA-256 digest"
+require_value "--runtime-pg-dsn-env" "$runtime_pg_dsn_env"
+require_environment_name "$runtime_pg_dsn_env"
+require_value "--migration-pg-dsn-env" "$migration_pg_dsn_env"
+require_environment_name "$migration_pg_dsn_env"
+
+if ! "$execute"; then
+  printf '%s\n' "dry run: would verify separate v0.1.8 baseline and current migrator digests, the paired baseline backup, and run only the current migrator at $current_migrator"
+  printf '%s\n' 'dry run: would execute only synapse-migrate; it does not run down migrations or deploy services'
+  printf '%s\n' 'dry run: add --execute and all explicit confirmations after quiescing writers'
+  exit 0
+fi
+
+[[ "$quiesced_confirmation" == "UPGRADE-QUIESCED" ]] || fail "--quiesced-confirmation must be UPGRADE-QUIESCED"
+[[ "$baseline_confirmation" == "BASELINE-V0.1.8-VERIFIED" ]] || fail "--baseline-confirmation must be BASELINE-V0.1.8-VERIFIED"
+[[ "$forward_upgrade_confirmation" == "UPGRADE-FROM-V0.1.8-TO-CURRENT" ]] || fail "--forward-upgrade-confirmation must be UPGRADE-FROM-V0.1.8-TO-CURRENT"
+[[ -x "$baseline_migrator" ]] || fail "baseline migrator is not executable: $baseline_migrator"
+[[ -x "$current_migrator" ]] || fail "current migrator is not executable: $current_migrator"
+require_command sha256sum
+verify_manifest "$backup_dir"
+verify_artifact_sha256() {
+  local label="$1" artifact="$2" expected_sha256="$3" actual_sha256
+  actual_sha256="$(sha256sum -- "$artifact")"
+  actual_sha256="${actual_sha256%% *}"
+  [[ "${actual_sha256,,}" == "${expected_sha256,,}" ]] || fail "$label SHA-256 does not match its approved artifact"
+}
+verify_artifact_sha256 'v0.1.8 baseline migrator' "$baseline_migrator" "$baseline_expected_sha256"
+verify_artifact_sha256 'current migrator' "$current_migrator" "$current_expected_sha256"
+
+# SYNAPSE_ENV must be production. The migrator only requires a distinct migration DSN and
+# validates migration/runtime role separation under a production posture; omitting it defaults
+# to development and silently disables the gate this wrapper exists to enforce.
+SYNAPSE_ENV=production \
+SYNAPSE_DB_DSN="${!runtime_pg_dsn_env}" \
+SYNAPSE_DB_MIGRATION_DSN="${!migration_pg_dsn_env}" \
+SYNAPSE_DB_AUTO_MIGRATE=false \
+"$current_migrator"
+
+printf '%s\n' 'current forward migrations complete: deploy only the separately verified current services, then run readiness checks'

--- a/deploy/operations/recovery/lib.sh
+++ b/deploy/operations/recovery/lib.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Shared guardrails for the EPIC #587 operational wrappers. Source only.
+
+set -euo pipefail
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command is unavailable: $1"
+}
+
+require_absolute_path() {
+  [[ "$2" == /* ]] || fail "$1 must be an absolute path"
+}
+
+require_value() {
+  [[ -n "$2" ]] || fail "$1 is required"
+}
+
+require_safe_operand() {
+  [[ "$2" != -* ]] || fail "$1 must not begin with a dash"
+}
+
+require_environment_name() {
+  [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || fail "invalid environment-variable name: $1"
+  [[ -n "${!1:-}" ]] || fail "environment variable $1 is unset or empty"
+}
+
+verify_manifest() {
+  local backup_dir="$1"
+  require_absolute_path "backup directory" "$backup_dir"
+  [[ -d "$backup_dir" ]] || fail "backup directory does not exist: $backup_dir"
+  [[ -f "$backup_dir/database.dump" ]] || fail "database.dump is missing from backup directory"
+  [[ -d "$backup_dir/objects" ]] || fail "objects directory is missing from backup directory"
+  [[ -f "$backup_dir/MANIFEST.sha256" ]] || fail "MANIFEST.sha256 is missing from backup directory"
+  (
+    cd -- "$backup_dir"
+    sha256sum --check --strict MANIFEST.sha256
+  )
+}

--- a/deploy/operations/recovery/restore.sh
+++ b/deploy/operations/recovery/restore.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Restore a verified paired backup to a fresh isolated target. Dry-run by default.
+
+set -euo pipefail
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  restore.sh --backup-dir ABSOLUTE_PATH --target-pg-dsn-env NAME --object-target MC_TARGET \
+    --verifier ABSOLUTE_PATH --expected-state ABSOLUTE_PATH \
+    --fresh-target-confirmation RESTORE-TO-FRESH-ISOLATED-TARGET [--execute]
+
+The target database must already exist, be isolated from production, and have no
+user tables. The target object-store location must already exist and be empty.
+
+A restore is only reported successful when synapse-verify-restore confirms the
+evidence chains, object identities, global audit chain, and migration state against
+the independently captured expected-state manifest.
+USAGE
+}
+
+backup_dir=""
+target_pg_dsn_env=""
+object_target=""
+verifier=""
+expected_state=""
+fresh_target_confirmation=""
+execute=false
+
+while (($#)); do
+  case "$1" in
+    --backup-dir) backup_dir="${2:-}"; shift 2 ;;
+    --target-pg-dsn-env) target_pg_dsn_env="${2:-}"; shift 2 ;;
+    --object-target) object_target="${2:-}"; shift 2 ;;
+    --verifier) verifier="${2:-}"; shift 2 ;;
+    --expected-state) expected_state="${2:-}"; shift 2 ;;
+    --fresh-target-confirmation) fresh_target_confirmation="${2:-}"; shift 2 ;;
+    --execute) execute=true; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+
+require_value "--backup-dir" "$backup_dir"
+require_absolute_path "--backup-dir" "$backup_dir"
+require_value "--target-pg-dsn-env" "$target_pg_dsn_env"
+require_environment_name "$target_pg_dsn_env"
+require_value "--object-target" "$object_target"
+require_safe_operand "--object-target" "$object_target"
+require_value "--verifier" "$verifier"
+require_absolute_path "--verifier" "$verifier"
+require_value "--expected-state" "$expected_state"
+require_absolute_path "--expected-state" "$expected_state"
+
+if ! "$execute"; then
+  printf '%s\n' "dry run: would verify $backup_dir/MANIFEST.sha256"
+  printf '%s\n' 'dry run: would restore only into a fresh isolated database and empty object-store target'
+  printf '%s\n' 'dry run: no --clean, object deletion, or overwrite option will be used'
+  printf '%s\n' "dry run: would then require synapse-verify-restore at $verifier to pass against --expected-state $expected_state"
+  exit 0
+fi
+
+[[ "$fresh_target_confirmation" == "RESTORE-TO-FRESH-ISOLATED-TARGET" ]] || fail "--fresh-target-confirmation must be RESTORE-TO-FRESH-ISOLATED-TARGET"
+require_command sha256sum
+require_command psql
+require_command pg_restore
+require_command mc
+verify_manifest "$backup_dir"
+
+user_table_count="$(psql --dbname="${!target_pg_dsn_env}" --tuples-only --no-align --quiet --command="SELECT count(*) FROM information_schema.tables WHERE table_schema NOT IN ('pg_catalog', 'information_schema') AND table_type = 'BASE TABLE';")"
+[[ "$user_table_count" == "0" ]] || fail "target database is not fresh: it has $user_table_count user table(s)"
+object_listing="$(mc ls "$object_target")"
+[[ -z "${object_listing//[[:space:]]/}" ]] || fail 'target object-store location is not empty'
+
+[[ -x "$verifier" ]] || fail "restore verifier is not executable: $verifier"
+[[ -f "$expected_state" ]] || fail "expected-state manifest does not exist: $expected_state"
+
+pg_restore --dbname="${!target_pg_dsn_env}" --exit-on-error --single-transaction --no-owner --no-privileges "$backup_dir/database.dump"
+mc mirror "$backup_dir/objects" "$object_target"
+
+# Matching files are not a restored system. Evidence chains, content-addressed object
+# identities, the global audit chain, and migration state must all verify against an
+# independently captured expected state before this reports success.
+SYNAPSE_DB_DSN="${!target_pg_dsn_env}" \
+"$verifier" --expected-state "$expected_state" \
+  || fail 'restore verification failed: the restored copy is not usable and must not be promoted'
+
+printf '%s\n' 'restore complete and verified: validate the isolated application with its own non-production configuration'

--- a/deploy/operations/recovery/tests.sh
+++ b/deploy/operations/recovery/tests.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Static and dry-run checks for the conservative operational wrappers.
+
+set -euo pipefail
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1" text="$2"
+  local content
+  content="$(<"$file")"
+  [[ "$content" == *"$text"* ]] || fail "$file must contain: $text"
+}
+
+assert_not_contains() {
+  local file="$1" text="$2"
+  local content
+  content="$(<"$file")"
+  [[ "$content" != *"$text"* ]] || fail "$file must not contain: $text"
+}
+
+for script in lib.sh backup.sh restore.sh forward-upgrade.sh; do
+  bash -n "$SCRIPT_DIR/$script"
+done
+
+backup_dry_run="$(SYNAPSE_TEST_DSN=placeholder "$SCRIPT_DIR/backup.sh" --backup-dir /tmp/synapse-backup-static-test --pg-dsn-env SYNAPSE_TEST_DSN --object-source test-alias/test-bucket)"
+[[ "$backup_dry_run" == *'dry run:'* ]] || fail 'backup default must be a dry run'
+restore_dry_run="$(SYNAPSE_TEST_DSN=placeholder "$SCRIPT_DIR/restore.sh" --backup-dir /tmp/synapse-backup-static-test --target-pg-dsn-env SYNAPSE_TEST_DSN --object-target test-alias/test-bucket --verifier /tmp/synapse-verify-restore --expected-state /tmp/synapse-expected-state.json)"
+[[ "$restore_dry_run" == *'synapse-verify-restore'* ]] || fail 'restore dry run must state that verification is required'
+[[ "$restore_dry_run" == *'dry run:'* ]] || fail 'restore default must be a dry run'
+upgrade_dry_run="$(SYNAPSE_TEST_DSN=placeholder "$SCRIPT_DIR/forward-upgrade.sh" --backup-dir /tmp/synapse-backup-static-test --baseline-migrator /tmp/synapse-migrate-v0.1.8 --baseline-expected-sha256 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --current-migrator /tmp/synapse-migrate-current --current-expected-sha256 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --runtime-pg-dsn-env SYNAPSE_TEST_DSN --migration-pg-dsn-env SYNAPSE_TEST_DSN)"
+[[ "$upgrade_dry_run" == *'dry run:'* ]] || fail 'upgrade default must be a dry run'
+
+for script in backup.sh restore.sh forward-upgrade.sh; do
+  assert_contains "$SCRIPT_DIR/$script" '--execute'
+done
+assert_contains "$SCRIPT_DIR/backup.sh" 'BACKUP-QUIESCED'
+assert_contains "$SCRIPT_DIR/restore.sh" 'RESTORE-TO-FRESH-ISOLATED-TARGET'
+assert_contains "$SCRIPT_DIR/forward-upgrade.sh" 'UPGRADE-QUIESCED'
+assert_contains "$SCRIPT_DIR/forward-upgrade.sh" 'BASELINE-V0.1.8-VERIFIED'
+assert_contains "$SCRIPT_DIR/forward-upgrade.sh" 'UPGRADE-FROM-V0.1.8-TO-CURRENT'
+assert_contains "$SCRIPT_DIR/forward-upgrade.sh" 'verify_artifact_sha256'
+assert_contains "$SCRIPT_DIR/forward-upgrade.sh" 'SYNAPSE_ENV=production'
+assert_contains "$SCRIPT_DIR/restore.sh" 'synapse-verify-restore'
+assert_contains "$SCRIPT_DIR/restore.sh" '--expected-state'
+assert_contains "$SCRIPT_DIR/forward-upgrade.sh" '"$current_migrator"'
+assert_not_contains "$SCRIPT_DIR/forward-upgrade.sh" 'UPGRADE-TO-0.1.8'
+assert_contains "$SCRIPT_DIR/lib.sh" 'sha256sum --check --strict MANIFEST.sha256'
+assert_not_contains "$SCRIPT_DIR/backup.sh" 'mc mirror --remove'
+assert_not_contains "$SCRIPT_DIR/backup.sh" 'mc mirror --overwrite'
+assert_not_contains "$SCRIPT_DIR/restore.sh" 'mc mirror --remove'
+assert_not_contains "$SCRIPT_DIR/restore.sh" 'mc mirror --overwrite'
+assert_not_contains "$SCRIPT_DIR/restore.sh" 'pg_restore --clean'
+assert_not_contains "$SCRIPT_DIR/restore.sh" 'pg_restore --create'
+assert_not_contains "$SCRIPT_DIR/forward-upgrade.sh" ' --down'
+
+printf '%s\n' 'operational script static tests passed'

--- a/docs/adr/0005-production-helm-eks-topology.md
+++ b/docs/adr/0005-production-helm-eks-topology.md
@@ -1,0 +1,43 @@
+# ADR 0005 — Production Helm and EKS topology
+
+**Status:** Accepted · **Date:** 2026-08-20 · **Deciders:** Issue #590
+
+## Context
+
+The Compose stack is explicitly a local-development profile. Production needs independently scalable
+control-plane services, private durable data, TLS at the public edge, and an upgrade order that never
+lets a workload use an unprepared database. The production sandbox is a Linux fail-closed boundary, not
+a best-effort container setting. See [Deployment](../guide/deployment.md) and [ADR 0004](0004-cspm-helper-authorization.md).
+
+## Decision
+
+The production reference deployment is a Helm release on Amazon EKS:
+
+- Run `synapse-api` as a Deployment with at least two replicas behind a TLS-terminating Ingress/load
+  balancer. Use readiness probes to remove a replica from service; do not use a single API replica as
+  the availability plan.
+- Run `synapse-worker` as its own scalable Deployment. It shares the API's durable database and object
+  store but is not co-located with the API tier.
+- Use externally operated PostgreSQL and S3-compatible object storage. They are private dependencies,
+  not Helm-managed StatefulSets; workload identities receive the minimum database and bucket access
+  required.
+- Set `SYNAPSE_DB_AUTO_MIGRATE=false`. A one-at-a-time Helm pre-install/pre-upgrade migration Job uses
+  the owner migration identity. The release waits for that Job, and API and worker rollout is gated on
+  its successful completion. A failed Job blocks the release rather than starting workloads on an
+  unknown schema.
+- Terminate and enforce TLS before public API traffic reaches the API Pods. Keep database, object-store,
+  metrics, and worker endpoints off the public ingress.
+- Schedule execution-capable Pods only onto approved Linux nodes that provide bubblewrap and the kernel
+  features required by the configured sandbox. Enable `SYNAPSE_SANDBOX_ENABLED=true`, pin helper hashes,
+  and preserve Synapse's startup refusal when those prerequisites are absent. A Pod that cannot provide
+  the sandbox must not fall back to unsandboxed execution.
+
+## Consequences
+
+- Helm values and the platform runbook must model API and worker capacity separately, including a
+  minimum of two ready APIs.
+- Database migration credentials are isolated from runtime credentials, and migration failure is an
+  explicit deployment failure.
+- EKS node images, admission policy, and sandbox prerequisite checks become release dependencies.
+- Backup, restore, and rollback follow [ADR 0007](0007-paired-backup-and-forward-only-upgrades.md), not
+  a Helm database downgrade.

--- a/docs/adr/0006-oidc-bff-trust-model.md
+++ b/docs/adr/0006-oidc-bff-trust-model.md
@@ -1,0 +1,39 @@
+# ADR 0006 — OIDC BFF trust model
+
+**Status:** Accepted · **Date:** 2026-08-20 · **Deciders:** Issue #592
+
+## Context
+
+Browser sign-in needs OIDC without turning browser-held tokens or tenant-provided claims into an
+application trust boundary. Synapse already authorizes actions through its existing roles and supports
+bearer authentication for machine clients. The BFF must remain safe when API replicas scale horizontally.
+
+## Decision
+
+Browser OIDC uses a backend-for-frontend (BFF) model:
+
+- The BFF performs the authorization-code flow and keeps provider tokens server-side. It accepts an
+  identity only when the configured issuer and subject both exactly match an approved identity record.
+  Matching issuer alone, matching a mutable display claim, wildcard subjects, and email-domain matching
+  are not authorization.
+- Each deployment has one fixed Synapse tenant for browser sessions. The BFF does not choose a tenant
+  from an OIDC claim, request parameter, host header, or client-side state.
+- A matched identity maps only to an explicitly allowlisted existing role: `admin`, `consultant`,
+  `reviewer`, or `read-only`. Unknown, missing, or newly asserted provider roles deny sign-in; the BFF
+  never creates roles or expands privileges from provider claims.
+- The browser receives only an opaque, high-entropy session identifier in a `Secure`, `HttpOnly` cookie.
+  Session identity, expiry, revocation state, and role live in a shared durable session store so any API
+  replica can validate or revoke the session. No bearer or OIDC token is exposed to browser JavaScript.
+- The BFF validates OIDC state and nonce, uses redirect URI allowlisting, and requires a session-bound
+  CSRF token for every browser-authenticated state-changing request. CSRF validation is independent of
+  cookie `SameSite` behavior.
+- Existing `Authorization: Bearer` machine authentication remains unchanged. It does not become an OIDC
+  browser fallback and retains its current principal and authorization semantics.
+
+## Consequences
+
+- Identity and role allowlists require explicit operator administration and audit records.
+- OIDC discovery or claim changes cannot silently widen tenant or role access.
+- Session storage, key rotation, expiry, logout, and replica-safe revocation are production dependencies.
+- Browser and machine access are distinct paths through the same authorization chokepoint described in
+  [Security model](../guide/security.md).

--- a/docs/adr/0007-paired-backup-and-forward-only-upgrades.md
+++ b/docs/adr/0007-paired-backup-and-forward-only-upgrades.md
@@ -1,0 +1,37 @@
+# ADR 0007 — Paired backup and forward-only upgrades
+
+**Status:** Accepted · **Date:** 2026-08-20 · **Deciders:** Issue #587
+
+## Context
+
+A report is recoverable only when its PostgreSQL records and evidence objects describe the same point in
+time. An independent database snapshot and object-store backup can restore a chain that references absent
+or newer blobs. Likewise, a schema downgrade after an attempted release can lose or reinterpret durable
+records. See [Deployment](../guide/deployment.md) and [Operations drill evidence](../guide/operations-drill-evidence.md).
+
+## Decision
+
+Production backup and upgrade operations use these policies:
+
+- Take a paired, quiesced backup. Drain or stop API and worker writers, wait for in-flight durable work to
+  reach a recorded terminal state, then capture the PostgreSQL backup and the evidence-object inventory or
+  versioned snapshot from the same quiesced window. Record the UTC window, database backup identifier,
+  object-store version/snapshot identifier, application release, migration version, and manifest hashes.
+- Restore drills restore the pair together into an isolated environment and verify the evidence and audit
+  chains before declaring success. Each drill produces the versioned operations-drill envelope defined in
+  [`operations-drill-evidence-v1.schema.json`](../guide/schemas/operations-drill-evidence-v1.schema.json); raw drill
+  material remains outside version control.
+- Database migration is forward-only. Before a production upgrade, create and validate a paired backup
+  copy. If the release must be abandoned, roll back only by restoring that copy and deploying the known-good
+  release against it. Do not run down migrations, point an older binary at a forward-migrated production
+  database, or treat a Helm rollback as a data rollback.
+
+## Consequences
+
+- Backup automation needs coordinated API/worker quiescing, immutable object versioning or an equivalent
+  inventory snapshot, and retention for both halves of the pair.
+- Recovery time includes restoring and validating both durable stores; a successful database-only restore
+  is not a recovery success.
+- Releases require an approved recovery point and enough isolated capacity to test rollback on a copy.
+- The migration Job in [ADR 0005](0005-production-helm-eks-topology.md) can move schemas forward but
+  cannot provide a downgrade path.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -35,10 +35,12 @@ architectural boundaries that keep execution auditable.
 | --- | --- |
 | [Configuration](configuration.md) | Environment variables, defaults, dependencies, and production requirements |
 | [Deployment](deployment.md) | Containers, services, agents, Linux-only capabilities, and production checks |
+| [Backup, restore, and upgrade recovery](backup-restore-upgrade.md) | Quiesced paired backups, restore verification, active-write characterization, and safe upgrades |
 | [CLI](cli.md) | Scanning, code-quality gates, advisory maintenance, imports, and exit contracts |
 | [MCP integration](mcp-integration.md) | Read/propose-only tool access scoped to one engagement |
 | [Fleet agent packaging](fleet-agent-packaging.md) | Package, identity, rollout, upgrade, and uninstall contracts |
 | [AI triage evaluation](ai-triage-evaluation.md) | Offline datasets, comparison gates, promotion, rollback, and drift detection |
+| [Operations drill evidence](operations-drill-evidence.md) | Versioned, redacted evidence for backup, restore, and rollback-on-copy drills |
 | [Code quality rule authoring](code-quality-rules.md) | Clean-room rule packs, schemas, references, and golden coverage |
 
 ## Architecture and policy

--- a/docs/guide/backup-restore-upgrade.md
+++ b/docs/guide/backup-restore-upgrade.md
@@ -1,0 +1,146 @@
+# Backup, restore, and v0.1.8-to-current upgrade runbook
+
+This runbook starts from a deliberately seeded and running v0.1.8 baseline, preserves a paired backup of that baseline, and performs a gated forward upgrade to the current branch. It is an operator procedure for the paired PostgreSQL database and evidence object store. It intentionally does not cover an active-write backup. Synapse reports rely on rows and evidence objects together; a database snapshot taken before or after its matching object state can be incomplete even when each individual command succeeds.
+
+The wrappers in `deploy/operations/recovery/` are deliberately conservative:
+
+- They perform a dry run unless `--execute` is passed.
+- They require a literal confirmation token for a quiesced backup, fresh isolated restore, or forward upgrade.
+- They accept connection strings only through the *name* of an already exported environment variable. Do not put a DSN, password, access key, account identifier, or other credential on a command line, in shell history, or in a ticket.
+- They do not use object deletion, object overwrite, `pg_restore --clean`, or `pg_restore --create`.
+- They never run down migrations, destroy a source database, delete a source bucket, or stop services. Quiescing and lifecycle changes remain deliberate operator actions outside the wrappers.
+
+Run commands from the repository root with a Bash implementation that provides `sha256sum`, `pg_dump`, `pg_restore`, `psql`, and the MinIO `mc` client. Use a PostgreSQL client compatible with the server version. `mc` is used because its default mirror behavior does not delete target-only objects; the wrappers also omit `--remove` and `--overwrite`.
+
+## Safety model and supported consistency boundary
+
+The supported backup consistency boundary is **fully quiesced writes**. Before collecting data, stop or drain every writer that can change Synapse state, including API instances, workers, migrations, scheduled jobs, import jobs, and any automation calling the API. Confirm that no writer remains and retain the change record that authorizes the outage. The wrapper requires `BACKUP-QUIESCED`, but the token is an acknowledgement, not a technical proof.
+
+An **active-write backup is unsupported** by this runbook. `pg_dump` creates a transactionally consistent database archive, but it cannot make a separately copied object store point-in-time consistent with that archive. Do not claim that a backup taken while writers are active is recoverable as a paired Synapse state. If an active-write recovery objective is required, design and validate a provider-native coordinated snapshot, write fencing, and an application-specific reconciliation procedure before using it in production.
+
+Keep the backup directory on storage distinct from the system being protected and limit access to approved operators. The wrappers set `umask 077`, but filesystem and object-store retention, encryption, immutability, and access controls are still operator responsibilities.
+
+## 1. Establish the v0.1.8 baseline
+
+Obtain approved v0.1.8 release artifacts and separately approved current-branch artifacts. Independently record and verify the SHA-256 digest of each v0.1.8 and current migrator and service artifact that will run. Do not reuse a digest between releases or artifacts. Create an isolated database with separate owner-level migration and runtime credentials. Run the verified v0.1.8 migrator against the empty database with automatic migration disabled, then start only verified v0.1.8 service artifacts. Confirm readiness and a representative evidence/report path before declaring the environment the baseline.
+
+## 2. Create a quiesced paired baseline backup
+
+1. Select a new, empty, absolute backup directory on protected storage. Its parent must already exist. A failed attempt can leave a partial directory; do not treat it as a backup and do not overwrite it.
+2. Export the database DSN in the operator's environment. The following uses a placeholder name only; it does not show a credential.
+3. Configure an authenticated `mc` alias outside these commands. Pass the source bucket or prefix as an `mc` source reference.
+4. Quiesce all writers and record the authorization and start time.
+5. First inspect the dry run, then execute with the exact confirmation token.
+
+```bash
+export SYNAPSE_BASELINE_DB_DSN='set-this-outside-command-history'
+
+deploy/operations/recovery/backup.sh \
+  --backup-dir /secure/backups/synapse/v0.1.8-baseline-YYYYMMDDTHHMMSSZ \
+  --pg-dsn-env SYNAPSE_BASELINE_DB_DSN \
+  --object-source baseline-evidence-alias/synapse-evidence
+
+# Only after all v0.1.8 baseline writers are quiesced:
+deploy/operations/recovery/backup.sh \
+  --backup-dir /secure/backups/synapse/v0.1.8-baseline-YYYYMMDDTHHMMSSZ \
+  --pg-dsn-env SYNAPSE_BASELINE_DB_DSN \
+  --object-source baseline-evidence-alias/synapse-evidence \
+  --quiesced-confirmation BACKUP-QUIESCED \
+  --execute
+```
+
+The backup contains:
+
+- `database.dump`: a PostgreSQL custom-format archive from `pg_dump`.
+- `objects/`: evidence objects copied with `mc mirror`, without deletion or overwrite options.
+- `BACKUP-METADATA.txt`: format, timestamp, and client version evidence.
+- `MANIFEST.sha256`: SHA-256 hashes for `database.dump` and every copied object.
+
+A manifest matches only the files captured in that backup directory. Record the immutable backup location, manifest, quiesce authorization, source database/object-store identifiers in the protected change record, and the wrapper output. Do not place protected identifiers or credentials in this guide or source control. Resume writers only after the backup operation and its evidence capture have completed.
+
+## 3. Restore to a fresh isolated environment
+
+Restore is a recovery rehearsal or investigation step, not an in-place repair procedure. Create a separate non-production environment with network isolation, distinct credentials, and an application configuration that cannot contact production. Create the destination database and empty destination object-store bucket or prefix before running the wrapper.
+
+The restore wrapper verifies `MANIFEST.sha256` before it writes anything, rejects a database containing user tables, and rejects a non-empty object target. It restores with `pg_restore --single-transaction --exit-on-error --no-owner --no-privileges`; it neither cleans nor creates a database. It mirrors objects without deletion or overwrite options. If an object appears in the target during execution, stop and investigate rather than retrying over it.
+
+```bash
+export SYNAPSE_RESTORE_DB_DSN='set-this-outside-command-history'
+
+deploy/operations/recovery/restore.sh \
+  --backup-dir /secure/backups/synapse/v0.1.8-baseline-YYYYMMDDTHHMMSSZ \
+  --target-pg-dsn-env SYNAPSE_RESTORE_DB_DSN \
+  --object-target isolated-baseline-evidence-alias/synapse-evidence-restore
+
+# Only for the new, isolated, empty targets:
+deploy/operations/recovery/restore.sh \
+  --backup-dir /secure/backups/synapse/v0.1.8-baseline-YYYYMMDDTHHMMSSZ \
+  --target-pg-dsn-env SYNAPSE_RESTORE_DB_DSN \
+  --object-target isolated-baseline-evidence-alias/synapse-evidence-restore \
+  --fresh-target-confirmation RESTORE-TO-FRESH-ISOLATED-TARGET \
+  --execute
+```
+
+After a successful restore, start Synapse only with isolated non-production configuration. Validate a baseline rehearsal with separately digest-verified v0.1.8 compatibility artifacts, application readiness, and a representative evidence/report path. Capture the manifest-verification output, database restore output, object-copy output, readiness result, and validation results as recovery evidence. Do not point restored services at production endpoints or credentials.
+
+## 4. Forward upgrade from v0.1.8 to current
+
+Use the current branch's verified synapse-migrate binary, not the v0.1.8 migrator. The wrapper verifies the paired baseline backup manifest and separately verifies the v0.1.8 baseline and current migrator digests. The baseline binary is verified as provenance evidence only; the wrapper executes only the current migrator with SYNAPSE_DB_AUTO_MIGRATE=false, applying current embedded forward migrations only.
+
+1. Confirm the seeded, running v0.1.8 baseline and its verified artifacts are recorded.
+2. Preserve the quiesced paired baseline backup using the preceding procedure.
+3. Quiesce writers again for the upgrade window.
+4. Dry-run and compare the baseline backup, both binary paths, matching digests, and environment-variable names with the change plan.
+5. Execute with all literal confirmations.
+6. Deploy only separately digest-verified current service artifacts with automatic migration disabled, then run readiness checks.
+
+Example dry run and execution use separately verified baseline and current migrators:
+
+```bash
+export SYNAPSE_RUNTIME_DB_DSN='set-this-outside-command-history'
+export SYNAPSE_MIGRATION_DB_DSN='set-this-outside-command-history'
+
+deploy/operations/recovery/forward-upgrade.sh \
+  --backup-dir /secure/backups/synapse/v0.1.8-baseline-YYYYMMDDTHHMMSSZ \
+  --baseline-migrator /approved-artifacts/v0.1.8/synapse-migrate \
+  --baseline-expected-sha256 APPROVED_V0.1.8_MIGRATOR_64_CHARACTER_SHA256 \
+  --current-migrator /approved-artifacts/current/synapse-migrate \
+  --current-expected-sha256 APPROVED_CURRENT_MIGRATOR_64_CHARACTER_SHA256 \
+  --runtime-pg-dsn-env SYNAPSE_RUNTIME_DB_DSN \
+  --migration-pg-dsn-env SYNAPSE_MIGRATION_DB_DSN
+
+# Only after writers are quiesced, the baseline is verified, and the change is approved:
+deploy/operations/recovery/forward-upgrade.sh \
+  --backup-dir /secure/backups/synapse/v0.1.8-baseline-YYYYMMDDTHHMMSSZ \
+  --baseline-migrator /approved-artifacts/v0.1.8/synapse-migrate \
+  --baseline-expected-sha256 APPROVED_V0.1.8_MIGRATOR_64_CHARACTER_SHA256 \
+  --current-migrator /approved-artifacts/current/synapse-migrate \
+  --current-expected-sha256 APPROVED_CURRENT_MIGRATOR_64_CHARACTER_SHA256 \
+  --runtime-pg-dsn-env SYNAPSE_RUNTIME_DB_DSN \
+  --migration-pg-dsn-env SYNAPSE_MIGRATION_DB_DSN \
+  --quiesced-confirmation UPGRADE-QUIESCED \
+  --baseline-confirmation BASELINE-V0.1.8-VERIFIED \
+  --forward-upgrade-confirmation UPGRADE-FROM-V0.1.8-TO-CURRENT \
+  --execute
+```
+
+Do not run a down migration. Do not remove migration records, edit migration files, or attempt to make a newer database appear older. The deployed current service configuration must keep SYNAPSE_DB_AUTO_MIGRATE=false; production migration authority belongs to the separate owner-level migration credential.
+
+## 5. Rollback rehearsal and recovery
+
+There is no in-place rollback. Test rollback only by restoring the pre-upgrade paired v0.1.8 baseline backup to a fresh isolated copy. Validate that copy with separately digest-verified v0.1.8 compatibility artifacts or as a pre-upgrade restore under an approved recovery plan. Never restore over the upgraded production database or production evidence bucket, and never use down migrations as a rollback mechanism.
+
+Before any cutover decision, preserve the upgraded state as separate evidence, identify the data-loss window, and obtain incident/change authorization. The restored copy can establish recoverability and support investigation; it is not authorization to destroy, overwrite, or replace a production source.
+
+## Operational evidence checklist
+
+For each baseline seed, backup, restore rehearsal, forward upgrade, or rollback decision, retain access-controlled evidence outside the source tree:
+
+- change/incident authorization and operators involved;
+- baseline v0.1.8 seed/readiness record and separately approved baseline artifact digests;
+- separately approved current migrator and service-artifact digests;
+- writer-quiescence record and start/end times;
+- backup directory location and `MANIFEST.sha256` result;
+- dry-run and execution output with secrets redacted;
+- isolated restore validation and readiness results; and
+- explicit confirmation that no down migration, source destruction, or in-place restore occurred.

--- a/docs/guide/capacity-slos.md
+++ b/docs/guide/capacity-slos.md
@@ -1,0 +1,94 @@
+# Capacity and service objectives
+
+[Documentation home](README.md) · Related: [Deployment](deployment.md) ·
+[Backup, restore, and upgrade](backup-restore-upgrade.md)
+
+Service objectives are activated only after a representative, repeatable benchmark covers the
+intended workload. A configured replica or connection limit is not evidence of capacity.
+
+## Reproducible benchmark input
+
+`synapse-bench` reduces a versioned observation set into deterministic JSON. It does not generate
+load or invent missing measurements:
+
+```bash
+synapse-bench -input benchmark-input.json -output benchmark-report.json
+sha256sum benchmark-input.json benchmark-report.json
+```
+
+Record the environment, release, image, fixture, and tool digests with each run. Include request,
+queue, pool, evidence-growth, migration, failover, and correctness observations when that scenario
+actually measures them. Leave an unmeasured observation set empty or zero rather than relabeling a
+configured limit as a measurement. A run is invalid if correctness reports a lost or duplicate job,
+cross-tenant result, result-digest drift, broken evidence chain, or missing object.
+
+## Current measured envelope
+
+The disposable AWS rehearsal used two API replicas on two EKS nodes, two web replicas, and one
+lease-locked worker. One hundred sequential, fresh-TLS `/readyz` requests were sent through the
+TLS ingress with certificate-chain and hostname verification enabled. The exact input and report
+are locally retained and SHA-256 sidecars bind each artifact.
+
+| Observation | Result |
+| --- | ---: |
+| Successful requests | 100 / 100 |
+| Request latency p50 | 732 ms |
+| Request latency p95 | 784 ms |
+| Request latency p99 | 948 ms |
+| Observed maximum | 1,546 ms |
+| API pod-deletion drill | 90 / 90 one-second probes succeeded |
+| Replacement pod | ready on the other node |
+
+This narrow result proves only low-rate readiness and API-replica failover. Every request opened a
+new TLS connection, so it is not an application-handler latency baseline. It did not measure scan
+throughput, queue saturation, PostgreSQL acquisition wait, evidence growth, or migration duration
+under production-like data. Those objectives therefore remain explicitly unactivated.
+
+## Provisional objectives for the measured path
+
+For the same topology and low-rate `/readyz` probe only:
+
+- **Availability:** 99.9% successful requests over a rolling 30-day window.
+- **Latency:** 95% complete within 1 second over five-minute windows.
+- **Failover continuity:** deleting one API pod produces no failed one-second service probes.
+
+The 1-second latency threshold is above the measured 784 ms p95 but below the observed 1,546 ms
+maximum; it is a starting objective, not a general API promise. The 99.9% objective permits a
+30-day error budget of 43 minutes 49 seconds. Alert on fast and slow error-budget burn rather than
+on a single failed request.
+
+Prometheus queries (exclude health checks when deriving user-API objectives):
+
+```promql
+# Five-minute successful-request ratio
+sum(rate(synapse_http_requests_total{route!~"/healthz|/readyz",status_class!="5xx"}[5m]))
+/
+sum(rate(synapse_http_requests_total{route!~"/healthz|/readyz"}[5m]))
+
+# Five-minute p95 request duration
+histogram_quantile(
+  0.95,
+  sum by (le) (rate(synapse_http_request_duration_seconds_bucket{route!~"/healthz|/readyz"}[5m]))
+)
+
+# PostgreSQL pool utilization
+sum(synapse_postgres_pool_connections{state="acquired"})
+/
+sum(synapse_postgres_pool_connections{state="max"})
+
+# Pool-empty wait rate
+sum(rate(synapse_postgres_pool_empty_acquire_wait_seconds[5m]))
+```
+
+## Alert starting points
+
+- Page when the user-API 5xx ratio exceeds 1.4% for one hour or 0.6% for six hours; these are
+  approximate 14.4× and 6× burn rates for a 99.9% objective.
+- Ticket when p95 user-API latency exceeds the activated route-specific threshold for 30 minutes.
+- Warn when pool utilization exceeds 80% for 15 minutes or empty-acquire wait keeps increasing;
+  page only when it coincides with errors or latency burn.
+- Page when fewer than two API replicas are ready for 10 minutes.
+
+Do not activate scan-completion, queue-delay, migration-duration, or evidence-growth objectives
+until a representative fixture and concurrency ladder have measured them. Repeat a scenario after
+any node shape, replica count, PostgreSQL pool budget, tool digest, or major release change.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -15,6 +15,13 @@ Conventions: an empty value means unset, so the built-in default applies. Boolea
 | Variable | Default | Description |
 | --- | --- | --- |
 | `SYNAPSE_API_TOKEN` | (none) | Bootstrap-admin bearer token. The API exits if empty. Operational routes require it; liveness `GET /healthz` and readiness `GET /readyz` are intentionally public. Generate with `openssl rand -hex 32`. |
+| `SYNAPSE_OIDC_ENABLED` | `false` | Enable the browser OIDC BFF. Requires the fixed HTTPS issuer, client credentials, callback URL, fixed frontend URL, fixed tenant, and allowlisted group-to-role mapping below. |
+| `SYNAPSE_OIDC_ISSUER` | (none) | Absolute HTTPS issuer used for pinned discovery and ID-token validation. |
+| `SYNAPSE_OIDC_CLIENT_ID`, `SYNAPSE_OIDC_CLIENT_SECRET`, `SYNAPSE_OIDC_REDIRECT_URL` | (none) | OAuth client settings. The callback must be the exact registered `https://<api-host>/api/auth/oidc/callback` URL. Never log the secret. |
+| `SYNAPSE_OIDC_FRONTEND_URL` | (none) | Fixed absolute HTTPS dashboard URL for a successful callback redirect. Query strings, fragments, and credentials are rejected; request parameters never control this destination. |
+| `SYNAPSE_OIDC_TENANT_ID` | (none) | The one fixed Synapse tenant accepted by this BFF instance. |
+| `SYNAPSE_OIDC_GROUP_ROLE_MAPPING` | (none) | Comma-separated exact `provider-group=role` entries. Roles may only be `admin`, `consultant`, `reviewer`, or `readonly`; unmapped, duplicate, and multi-role group claims are rejected. |
+| `SYNAPSE_OIDC_TRANSACTION_TTL`, `SYNAPSE_OIDC_SESSION_TTL` | `10m`, `8h` | Maximum authorization-transaction and opaque browser-session lifetimes. |
 
 ## Core and server
 
@@ -84,6 +91,18 @@ The metrics listener has no authentication of its own. Keep `SYNAPSE_METRICS_ADD
 | `SYNAPSE_BLOB_SECRET_KEY` | `synapse-secret` | Secret key. |
 | `SYNAPSE_BLOB_BUCKET` | `synapse-evidence` | Bucket for evidence artifacts. |
 | `SYNAPSE_BLOB_USE_SSL` | `false` | Set true for https endpoints. |
+
+## Restore verification (synapse-verify-restore)
+
+`synapse-verify-restore` is a read-only recovery tool. It reuses `SYNAPSE_DB_DSN` and the evidence
+blob-store settings above, and requires a database identity permitted to read every tenant's
+evidence chain; a least-privilege runtime role fails closed rather than reporting an empty restore
+as intact.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SYNAPSE_RESTORE_VERIFY_TIMEOUT` | `2m` | Maximum duration for one restore-verification run before it fails. |
+| `SYNAPSE_RESTORE_VERIFY_EXPECTED_STATE` | (none) | Path to an independently captured expected-state manifest (audit head, per-engagement evidence heads and counts, expected applied migration versions). Equivalent to `--expected-state`. Without it a run reports `completeness: incomplete_no_expected_state`, because an emptied database cannot be distinguished from an intact one. |
 
 ## Custody, signing, and anchoring (required in production)
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -78,6 +78,42 @@ docker build -t synapse:full --target full -f deploy/Dockerfile .
 The build is cgo-free, so the distroless image works with a pure-Go SQLite driver and no
 system libraries.
 
+## Production Helm and EKS topology
+
+The production reference topology is a Helm release on Amazon EKS; the Compose profile remains for local
+development. Run at least two ready `synapse-api` replicas behind a TLS-terminating ingress and operate
+`synapse-worker` as a separate scalable tier. PostgreSQL and S3-compatible evidence storage are private,
+externally operated dependencies rather than Helm-managed StatefulSets.
+
+Set `SYNAPSE_DB_AUTO_MIGRATE=false`. A single Helm pre-install/pre-upgrade migration Job must use the
+owner migration identity, complete successfully before API or worker rollout, and cause the release to
+fail when it does not. Execution-capable Pods require approved Linux nodes with bubblewrap and the kernel
+features required by the sandbox; `SYNAPSE_SANDBOX_ENABLED=true` remains fail-closed. See
+[ADR 0005](https://github.com/KKloudTarus/synapse-ce/blob/main/docs/adr/0005-production-helm-eks-topology.md).
+
+Back up PostgreSQL and the evidence object store as a quiesced pair, and restore them as a pair in an
+isolated drill. Schema migration is forward-only: recover an abandoned release by restoring a validated
+pre-upgrade copy and deploying the known-good release, never with down migrations. See
+[ADR 0007](https://github.com/KKloudTarus/synapse-ce/blob/main/docs/adr/0007-paired-backup-and-forward-only-upgrades.md) and
+[Operations drill evidence](operations-drill-evidence.md).
+
+## Kubernetes with Helm
+
+The production chart is at [`deploy/helm/synapse`](https://github.com/KKloudTarus/synapse-ce/blob/main/deploy/helm/synapse/README.md). It runs at least two API replicas, one lease-locked worker, a web deployment, and a pre-install/pre-upgrade migration hook. It uses external PostgreSQL and S3-compatible storage only; it never creates Secret data. Supply the separate runtime database, migration database, object-store, API-token, and cryptographic Secret references through your secret-management controller.
+
+The chart requires digest-qualified API and web images, an existing TLS Secret, `SYNAPSE_SANDBOX_ENABLED=true`, and `SYNAPSE_DB_AUTO_MIGRATE=false`. The production image is non-root and bundles bubblewrap plus Synapse's helpers and tools; the target Linux amd64 runtime must permit unprivileged user namespaces. It does not request privileged mode or `SYS_ADMIN`. The chart starts default-deny and allows only explicit ingress and egress paths; configure FQDN-aware CNI or egress-gateway allowlists for managed PostgreSQL, object storage, and authorized recon targets.
+
+Run static validation before installation:
+
+```bash
+helm lint --strict deploy/helm/synapse -f deploy/helm/synapse/tests/production-values.yaml
+helm template synapse deploy/helm/synapse -f deploy/helm/synapse/tests/production-values.yaml --kube-version 1.29.0
+(cd deploy/helm/synapse && sh testdata/render_test.sh)
+```
+
+Real EKS deployment proof remains pending. Before relying on this chart in EKS, validate that the selected node AMI and runtime allow bubblewrap's unprivileged-user-namespace path, then execute a sandboxed worker job in that cluster.
+
+
 ## Production checklist
 
 Required, by variable name. Any `SYNAPSE_ENV` value other than `development`, `dev`, `local`, `test`, or

--- a/docs/guide/operations-drill-evidence.md
+++ b/docs/guide/operations-drill-evidence.md
@@ -1,0 +1,61 @@
+# Operations drill evidence
+
+[Documentation home](README.md) · Related: [Deployment](deployment.md) ·
+[ADR 0007](https://github.com/KKloudTarus/synapse-ce/blob/main/docs/adr/0007-paired-backup-and-forward-only-upgrades.md)
+
+This guide records a backup, restore, or rollback-on-copy drill without committing operational output,
+credentials, topology, or customer data. The committed record is a redacted summary envelope, not the
+drill's raw evidence.
+
+## Envelope contract
+
+Use [`operations-drill-evidence-v1.schema.json`](schemas/operations-drill-evidence-v1.schema.json). Its fixed
+`schema_version` is `1.0`; a breaking change requires a new schema file and version, not an edit to the
+meaning of this one.
+
+Every envelope must include:
+
+- an `OPS-DRILL-` prefixed `drill_id`, unique `run_id`, environment, and the runbook identifier,
+  revision, and SHA-256;
+- UTC start and completion timestamps plus an explicit execution-complete flag;
+- every assertion's stable ID, whether it is required, its status, and a sanitized summary;
+- a derived result and its matching deterministic rule; and
+- at least one artifact manifest entry containing its stable ID, SHA-256, byte length, media type,
+  redacted summary, and named sanitization reviewer.
+
+The envelope contains no raw artifact path, database DSN, bucket name, access token, signed URL, IP
+address, hostname, tenant identifier, account number, email address, or unredacted command output.
+
+## Raw artifacts and committed summaries
+
+Keep raw local artifacts in the approved restricted drill location. Examples include database backup
+identifiers, object-store inventories, restore logs, command transcripts, and chain-verification output.
+They may be retained under the applicable access and retention policy, but must be excluded from Git and
+from review attachments unless a separately approved secure channel is used.
+
+Before writing the committed envelope, calculate each raw artifact's SHA-256 and byte length. The hash
+identifies the exact reviewed input without publishing its contents. Then replace the raw content with a
+short factual `redacted_summary`: describe the check, whether it succeeded, and the relevant count or
+version only when that value is safe to publish. A named reviewer records either `redacted` or
+`no-sensitive-content-confirmed`. Sanitization is not optional because a hash is safe while surrounding
+metadata and prose may not be.
+
+## Deterministic result semantics
+
+Set `result` from the recorded fields, never from a narrative judgement:
+
+1. If `execution.complete` is `false`, the result is `inconclusive` with rule
+   `execution-incomplete`.
+2. Otherwise, if any required assertion is `failed`, the result is `failed` with rule
+   `complete-and-a-required-assertion-failed`.
+3. Otherwise, if every required assertion is `passed`, the result is `passed` with rule
+   `complete-and-all-required-assertions-passed`.
+
+A required `not-run` assertion therefore makes execution incomplete. Optional assertions may explain
+follow-up work but never turn a completed passing required set into a failure. The schema enforces the
+allowed result/rule combinations and the required-assertion conditions for passed and failed records.
+
+A drill is successful only when the paired PostgreSQL and object-store copy restores in isolation and
+the evidence and audit chains verify. A database-only restore, a raw-artifact hash without the raw
+artifact, or a release rollback that uses down migrations is not a successful drill. See
+[ADR 0007](https://github.com/KKloudTarus/synapse-ce/blob/main/docs/adr/0007-paired-backup-and-forward-only-upgrades.md).

--- a/docs/guide/schemas/operations-drill-evidence-v1.schema.json
+++ b/docs/guide/schemas/operations-drill-evidence-v1.schema.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://synapse.kkloudtarus.net/schemas/operations-drill-evidence-envelope/v1.json",
+  "title": "Operations drill evidence envelope",
+  "description": "Versioned, redacted summary of a paired backup, restore, or rollback-on-copy drill.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "drill_id",
+    "run_id",
+    "runbook",
+    "environment",
+    "execution",
+    "assertions",
+    "result",
+    "artifacts"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0"
+    },
+    "drill_id": {
+      "type": "string",
+      "pattern": "^OPS-DRILL-[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "runbook": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identifier", "revision", "sha256"],
+      "properties": {
+        "identifier": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "revision": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "environment": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["started_at", "completed_at", "complete"],
+      "properties": {
+        "started_at": { "type": "string", "format": "date-time" },
+        "completed_at": { "type": "string", "format": "date-time" },
+        "complete": { "type": "boolean" }
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "required", "status", "summary"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+          },
+          "required": { "type": "boolean" },
+          "status": { "enum": ["passed", "failed", "not-run"] },
+          "summary": { "type": "string", "minLength": 1, "maxLength": 4000 }
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "rule"],
+      "properties": {
+        "status": { "enum": ["passed", "failed", "inconclusive"] },
+        "rule": {
+          "enum": [
+            "complete-and-all-required-assertions-passed",
+            "complete-and-a-required-assertion-failed",
+            "execution-incomplete"
+          ]
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "sha256", "bytes", "media_type", "redacted_summary", "sanitization"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+          },
+          "sha256": { "$ref": "#/$defs/sha256" },
+          "bytes": { "type": "integer", "minimum": 0 },
+          "media_type": { "type": "string", "minLength": 1, "maxLength": 255 },
+          "redacted_summary": { "type": "string", "minLength": 1, "maxLength": 4000 },
+          "sanitization": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["status", "reviewed_by"],
+            "properties": {
+              "status": { "enum": ["redacted", "no-sensitive-content-confirmed"] },
+              "reviewed_by": { "type": "string", "minLength": 1, "maxLength": 256 }
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "result": { "properties": { "status": { "const": "passed" } } } } },
+      "then": {
+        "properties": {
+          "execution": { "properties": { "complete": { "const": true } } },
+          "result": { "properties": { "rule": { "const": "complete-and-all-required-assertions-passed" } } },
+          "assertions": {
+            "not": {
+              "contains": {
+                "properties": {
+                  "required": { "const": true },
+                  "status": { "enum": ["failed", "not-run"] }
+                },
+                "required": ["required", "status"]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "result": { "properties": { "status": { "const": "failed" } } } } },
+      "then": {
+        "properties": {
+          "execution": { "properties": { "complete": { "const": true } } },
+          "result": { "properties": { "rule": { "const": "complete-and-a-required-assertion-failed" } } },
+          "assertions": {
+            "contains": {
+              "properties": {
+                "required": { "const": true },
+                "status": { "const": "failed" }
+              },
+              "required": ["required", "status"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "result": { "properties": { "status": { "const": "inconclusive" } } } } },
+      "then": {
+        "properties": {
+          "execution": { "properties": { "complete": { "const": false } } },
+          "result": { "properties": { "rule": { "const": "execution-incomplete" } } }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -39,6 +39,15 @@ admin, consultant, reviewer, and read-only. Separation of duties means a machine
 never verify or accept its own claim. Tenant isolation is enforced at the service layer, so a
 caller cannot read another tenant's engagement even if a route wrapper is bypassed.
 
+## Browser OIDC access
+
+Browser OIDC uses a backend-for-frontend model. The server accepts an identity only for an exact approved
+issuer and subject pair, assigns it to the deployment's fixed tenant, and maps it only to the existing
+allowlisted roles: `admin`, `consultant`, `reviewer`, and `read-only`. It stores the authenticated browser
+state in an opaque, replica-safe server-side session and requires a session-bound CSRF token for every
+state-changing request. Existing bearer-token machine authentication is unchanged. See
+[ADR 0006](https://github.com/KKloudTarus/synapse-ce/blob/main/docs/adr/0006-oidc-bff-trust-model.md).
+
 ## Authorization is your responsibility
 
 Synapse validates scope data but cannot verify legal authorization. The operator is responsible

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KKloudTarus/synapse-ce
 
-go 1.26.4
+go 1.26.6
 
 require (
 	cloud.google.com/go/auth v0.23.1
@@ -64,6 +64,7 @@ require (
 	github.com/boombuler/barcode v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -72,6 +73,7 @@ require (
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-enry/go-oniguruma v1.2.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -132,7 +134,7 @@ require (
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/image v0.43.0 // indirect
 	golang.org/x/mod v0.39.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KKloudTarus/synapse-ce
 
-go 1.26.6
+go 1.26.4
 
 require (
 	cloud.google.com/go/auth v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/cilium/ebpf v0.22.0 h1:v2ktp0roffpMOj2MMf3idtCQZOsAoC4BJbAJN+ke2bY=
 github.com/cilium/ebpf v0.22.0/go.mod h1:CDzZbe2hC5JjlDC+CY3KFCzlYwN4gbxppYM+Z10bQt4=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
+github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -98,6 +100,8 @@ github.com/go-enry/go-enry/v2 v2.9.6 h1:np63eOtMV56zfYDHnFVgpEVOk8fr2kmylcMnAZUD
 github.com/go-enry/go-enry/v2 v2.9.6/go.mod h1:9yrj4ES1YrbNb1Wb7/PWYr2bpaCXUGRt0uafN0ISyG8=
 github.com/go-enry/go-oniguruma v1.2.1 h1:k8aAMuJfMrqm/56SG2lV9Cfti6tC4x8673aHCcBk+eo=
 github.com/go-enry/go-oniguruma v1.2.1/go.mod h1:bWDhYP+S6xZQgiRL7wlTScFYBe023B6ilRZbCAD5Hf4=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
 github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/adapter/httpapi/auth.go
+++ b/internal/adapter/httpapi/auth.go
@@ -57,9 +57,18 @@ type Resolver func(ctx context.Context, token string) (Principal, bool)
 
 // Authenticator validates the bearer token on each request via the Resolver and
 // stamps the resolved principal into the request context for attribution.
+// SessionResolver validates an opaque browser session. CSRF is passed only for cookie authentication.
+type SessionResolver interface {
+	Authenticate(ctx context.Context, token, csrfToken string, unsafe bool) (Principal, error)
+}
+
 type Authenticator struct {
 	resolve Resolver
+	session SessionResolver
 }
+
+// SetSessionResolver enables the OIDC BFF cookie session fallback while retaining bearer authentication.
+func (a *Authenticator) SetSessionResolver(resolve SessionResolver) { a.session = resolve }
 
 // NewAuthenticator builds an authenticator from a token resolver.
 func NewAuthenticator(resolve Resolver) *Authenticator {
@@ -74,15 +83,28 @@ func (a *Authenticator) Middleware(publicPaths map[string]bool, next http.Handle
 			next.ServeHTTP(w, r)
 			return
 		}
-		token, ok := bearerToken(r)
-		if !ok {
-			unauthorized(w)
-			return
-		}
-		principal, ok := a.resolve(r.Context(), token)
-		if !ok {
-			unauthorized(w)
-			return
+		var principal Principal
+		if token, ok := bearerToken(r); ok {
+			// Bearer credentials retain their existing API semantics, including no CSRF requirement.
+			var authenticated bool
+			principal, authenticated = a.resolve(r.Context(), token)
+			if !authenticated {
+				unauthorized(w)
+				return
+			}
+		} else {
+			cookie, err := r.Cookie(sessionCookieName)
+			if err != nil || cookie.Value == "" || a.session == nil {
+				unauthorized(w)
+				return
+			}
+			unsafe := r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions
+			var sessionErr error
+			principal, sessionErr = a.session.Authenticate(r.Context(), cookie.Value, r.Header.Get("X-CSRF-Token"), unsafe)
+			if sessionErr != nil {
+				unauthorized(w)
+				return
+			}
 		}
 		principal.TenantID = shared.TenantOrDefault(shared.ID(principal.TenantID)).String()
 		ctx := context.WithValue(r.Context(), principalKey, principal)

--- a/internal/adapter/httpapi/auth_paths_test.go
+++ b/internal/adapter/httpapi/auth_paths_test.go
@@ -1,0 +1,35 @@
+package httpapi
+
+import "testing"
+
+// A public path skips authentication but NOT the AUP gate. An unauthenticated visitor has no
+// principal that could have accepted the policy, so a public path missing from the AUP exemption
+// set answers 403 forever – which silently makes browser login unreachable.
+func TestPublicPathsAreAUPExempt(t *testing.T) {
+	exempt := aupExemptPaths()
+	for path := range publicPaths() {
+		if !exempt[path] {
+			t.Errorf("public path %q is not AUP-exempt; it would always answer 403", path)
+		}
+	}
+}
+
+func TestBrowserLoginPathsAreReachableUnauthenticated(t *testing.T) {
+	public, exempt := publicPaths(), aupExemptPaths()
+	// The login redirect, the provider callback, and session discovery are all reached before a
+	// session exists. Logout requires a session, so it is authenticated but still AUP-exempt.
+	for _, path := range []string{"/api/auth/oidc/login", "/api/auth/oidc/callback", "/api/auth/session"} {
+		if !public[path] {
+			t.Errorf("%q must be public: the browser reaches it before any session exists", path)
+		}
+		if !exempt[path] {
+			t.Errorf("%q must be AUP-exempt", path)
+		}
+	}
+	if public["/api/auth/logout"] {
+		t.Error("/api/auth/logout must require authentication")
+	}
+	if !exempt["/api/auth/logout"] {
+		t.Error("/api/auth/logout must be AUP-exempt so an operator can always sign out")
+	}
+}

--- a/internal/adapter/httpapi/oidc_handler.go
+++ b/internal/adapter/httpapi/oidc_handler.go
@@ -1,0 +1,162 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+)
+
+const (
+	sessionCookieName = "__Host-synapse_session"
+	nonceCookieName   = "__Host-synapse_oidc_nonce"
+)
+
+// OIDCService is the narrow HTTP boundary for the OIDC BFF use-case.
+type OIDCAuthorization struct{ URL, Nonce string }
+type OIDCSession struct {
+	Token, CSRFToken string
+	Principal        OIDCPrincipal
+}
+type OIDCPrincipal struct{ ID, Name, Role, TenantID string }
+
+type OIDCService interface {
+	Begin(context.Context) (OIDCAuthorization, error)
+	Complete(context.Context, string, string, string) (OIDCSession, error)
+	Discover(context.Context, string) (OIDCSession, error)
+	Authenticate(context.Context, string, string, bool) (OIDCPrincipal, error)
+	Logout(context.Context, string) error
+}
+
+type oidcSessionResolver struct{ service OIDCService }
+
+func (r oidcSessionResolver) Authenticate(ctx context.Context, token, csrf string, unsafe bool) (Principal, error) {
+	p, err := r.service.Authenticate(ctx, token, csrf, unsafe)
+	if err != nil {
+		return Principal{}, err
+	}
+	return Principal(p), nil
+}
+
+// SetOIDC installs the browser OIDC BFF and its fixed, validated frontend destination.
+func (rt *Router) SetOIDC(service OIDCService, frontendURL string) {
+	rt.oidc = service
+	rt.oidcFrontendURL = frontendURL
+	if rt.auth != nil {
+		rt.auth.SetSessionResolver(oidcSessionResolver{service: service})
+	}
+}
+
+func (rt *Router) oidcLogin(w http.ResponseWriter, r *http.Request) {
+	authorization, err := rt.oidc.Begin(r.Context())
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	setNonceCookie(w, authorization.Nonce)
+	http.Redirect(w, r, authorization.URL, http.StatusFound)
+}
+
+func (rt *Router) oidcCallback(w http.ResponseWriter, r *http.Request) {
+	state, code := r.URL.Query().Get("state"), r.URL.Query().Get("code")
+	nonce, err := r.Cookie(nonceCookieName)
+	if state == "" || code == "" || err != nil || nonce.Value == "" {
+		clearNonceCookie(w)
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "OIDC callback requires state, code, and nonce"})
+		return
+	}
+	clearNonceCookie(w)
+	session, err := rt.oidc.Complete(r.Context(), state, code, nonce.Value)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	setSessionCookie(w, session.Token)
+	// The configured destination, rather than a request parameter, prevents open redirects.
+	http.Redirect(w, r, rt.oidcFrontendURL, http.StatusFound)
+}
+
+// oidcSession discovers a browser session without disclosing its opaque token, provider claims,
+// or provider credentials. A successful discovery rotates the opaque cookie and CSRF token.
+func (rt *Router) oidcSession(w http.ResponseWriter, r *http.Request) {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err != nil || cookie.Value == "" || rt.oidc == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"authenticated": false})
+		return
+	}
+	session, err := rt.oidc.Discover(r.Context(), cookie.Value)
+	if err != nil {
+		clearSessionCookie(w)
+		writeJSON(w, http.StatusOK, map[string]any{"authenticated": false})
+		return
+	}
+	setSessionCookie(w, session.Token)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"authenticated": true,
+		"principal": map[string]string{
+			"id":        session.Principal.ID,
+			"name":      session.Principal.Name,
+			"role":      session.Principal.Role,
+			"tenant_id": session.Principal.TenantID,
+		},
+		"csrf_token": session.CSRFToken,
+	})
+}
+
+func (rt *Router) oidcLogout(w http.ResponseWriter, r *http.Request) {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err == nil && cookie.Value != "" {
+		if err := rt.oidc.Logout(r.Context(), cookie.Value); err != nil && !errors.Is(err, context.Canceled) {
+			writeError(w, rt.log, err)
+			return
+		}
+	}
+	clearSessionCookie(w)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func setSessionCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{Name: sessionCookieName, Value: token, Path: "/", Secure: true, HttpOnly: true, SameSite: http.SameSiteLaxMode})
+}
+
+func clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{Name: sessionCookieName, Value: "", Path: "/", Secure: true, HttpOnly: true, SameSite: http.SameSiteLaxMode, MaxAge: -1})
+}
+
+func setNonceCookie(w http.ResponseWriter, nonce string) {
+	// The __Host- prefix forbids Domain and requires Path=/, preventing a sibling path or
+	// subdomain from planting the nonce consumed by the callback.
+	http.SetCookie(w, &http.Cookie{Name: nonceCookieName, Value: nonce, Path: "/", Secure: true, HttpOnly: true, SameSite: http.SameSiteLaxMode, MaxAge: int((10 * time.Minute).Seconds())})
+}
+
+func clearNonceCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{Name: nonceCookieName, Value: "", Path: "/", Secure: true, HttpOnly: true, SameSite: http.SameSiteLaxMode, MaxAge: -1})
+}
+
+type oidcServiceFuncs struct {
+	begin        func(context.Context) (OIDCAuthorization, error)
+	complete     func(context.Context, string, string, string) (OIDCSession, error)
+	discover     func(context.Context, string) (OIDCSession, error)
+	authenticate func(context.Context, string, string, bool) (OIDCPrincipal, error)
+	logout       func(context.Context, string) error
+}
+
+func NewOIDCService(begin func(context.Context) (OIDCAuthorization, error), complete func(context.Context, string, string, string) (OIDCSession, error), discover func(context.Context, string) (OIDCSession, error), authenticate func(context.Context, string, string, bool) (OIDCPrincipal, error), logout func(context.Context, string) error) (OIDCService, error) {
+	if begin == nil || complete == nil || discover == nil || authenticate == nil || logout == nil {
+		return nil, errors.New("OIDC HTTP service requires all operations")
+	}
+	return oidcServiceFuncs{begin: begin, complete: complete, discover: discover, authenticate: authenticate, logout: logout}, nil
+}
+func (s oidcServiceFuncs) Begin(ctx context.Context) (OIDCAuthorization, error) { return s.begin(ctx) }
+func (s oidcServiceFuncs) Complete(ctx context.Context, state, code, nonce string) (OIDCSession, error) {
+	return s.complete(ctx, state, code, nonce)
+}
+func (s oidcServiceFuncs) Discover(ctx context.Context, token string) (OIDCSession, error) {
+	return s.discover(ctx, token)
+}
+func (s oidcServiceFuncs) Authenticate(ctx context.Context, token, csrf string, unsafe bool) (OIDCPrincipal, error) {
+	return s.authenticate(ctx, token, csrf, unsafe)
+}
+func (s oidcServiceFuncs) Logout(ctx context.Context, token string) error {
+	return s.logout(ctx, token)
+}

--- a/internal/adapter/httpapi/oidc_handler_test.go
+++ b/internal/adapter/httpapi/oidc_handler_test.go
@@ -1,0 +1,143 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type cookieSessionResolver struct{ principal Principal }
+
+func (s cookieSessionResolver) Authenticate(_ context.Context, token, csrf string, unsafe bool) (Principal, error) {
+	if token != "opaque" || unsafe && csrf != "csrf" {
+		return Principal{}, errors.New("denied")
+	}
+	return s.principal, nil
+}
+
+func TestNewOIDCServiceRejectsNilOperations(t *testing.T) {
+	validBegin := func(context.Context) (OIDCAuthorization, error) { return OIDCAuthorization{}, nil }
+	validComplete := func(context.Context, string, string, string) (OIDCSession, error) { return OIDCSession{}, nil }
+	validDiscover := func(context.Context, string) (OIDCSession, error) { return OIDCSession{}, nil }
+	validAuthenticate := func(context.Context, string, string, bool) (OIDCPrincipal, error) { return OIDCPrincipal{}, nil }
+	validLogout := func(context.Context, string) error { return nil }
+	if service, err := NewOIDCService(validBegin, validComplete, validDiscover, validAuthenticate, validLogout); err != nil || service == nil {
+		t.Fatalf("valid service = %v, %v", service, err)
+	}
+	if _, err := NewOIDCService(nil, validComplete, validDiscover, validAuthenticate, validLogout); err == nil {
+		t.Fatal("nil operation was accepted")
+	}
+}
+
+func TestOIDCCookieFlags(t *testing.T) {
+	rec := httptest.NewRecorder()
+	setSessionCookie(rec, "opaque")
+	cookie := rec.Result().Cookies()[0]
+	if cookie.Name != sessionCookieName || !cookie.Secure || !cookie.HttpOnly || cookie.Path != "/" || cookie.SameSite != http.SameSiteLaxMode || strings.Contains(rec.Header().Get("Set-Cookie"), "Domain=") {
+		t.Fatalf("unsafe session cookie: %q", rec.Header().Get("Set-Cookie"))
+	}
+
+	rec = httptest.NewRecorder()
+	setNonceCookie(rec, "nonce")
+	nonce := rec.Result().Cookies()[0]
+	if nonce.Name != nonceCookieName || nonce.Path != "/" || !nonce.Secure || !nonce.HttpOnly || nonce.SameSite != http.SameSiteLaxMode || strings.Contains(rec.Header().Get("Set-Cookie"), "Domain=") {
+		t.Fatalf("unsafe nonce cookie: %q", rec.Header().Get("Set-Cookie"))
+	}
+}
+
+type oidcTestService struct {
+	discover func(context.Context, string) (OIDCSession, error)
+	complete func(context.Context, string, string, string) (OIDCSession, error)
+}
+
+func (s oidcTestService) Begin(context.Context) (OIDCAuthorization, error) {
+	return OIDCAuthorization{}, errors.New("not implemented")
+}
+func (s oidcTestService) Complete(ctx context.Context, state, code, nonce string) (OIDCSession, error) {
+	return s.complete(ctx, state, code, nonce)
+}
+func (s oidcTestService) Discover(ctx context.Context, token string) (OIDCSession, error) {
+	return s.discover(ctx, token)
+}
+func (s oidcTestService) Authenticate(context.Context, string, string, bool) (OIDCPrincipal, error) {
+	return OIDCPrincipal{}, errors.New("not implemented")
+}
+func (s oidcTestService) Logout(context.Context, string) error { return nil }
+
+func TestOIDCSessionDiscoveryDoesNotExposeOpaqueToken(t *testing.T) {
+	rt := &Router{oidc: oidcTestService{discover: func(_ context.Context, token string) (OIDCSession, error) {
+		if token != "old-token" {
+			t.Fatalf("token = %q", token)
+		}
+		return OIDCSession{Token: "new-token", CSRFToken: "csrf", Principal: OIDCPrincipal{ID: "u1", Name: "User", Role: "admin", TenantID: "tenant"}}, nil
+	}}}
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/session", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "old-token"})
+	rec := httptest.NewRecorder()
+	rt.oidcSession(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "\"authenticated\":true") || !strings.Contains(body, "\"csrf_token\":\"csrf\"") || strings.Contains(body, "old-token") || strings.Contains(body, "new-token") {
+		t.Fatalf("unexpected session response: %s", body)
+	}
+	if cookie := rec.Result().Cookies()[0]; cookie.Value != "new-token" || !cookie.HttpOnly {
+		t.Fatalf("session cookie = %#v", cookie)
+	}
+}
+
+func TestOIDCCallbackRedirectsToConfiguredFrontendOnly(t *testing.T) {
+	rt := &Router{oidcFrontendURL: "https://synapse.example/", oidc: oidcTestService{complete: func(_ context.Context, state, code, nonce string) (OIDCSession, error) {
+		if state != "state" || code != "code" || nonce != "nonce" {
+			t.Fatalf("unexpected callback values")
+		}
+		return OIDCSession{Token: "opaque"}, nil
+	}}}
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=state&code=code&next=https://attacker.example", nil)
+	req.AddCookie(&http.Cookie{Name: nonceCookieName, Value: "nonce"})
+	rec := httptest.NewRecorder()
+	rt.oidcCallback(rec, req)
+
+	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "https://synapse.example/" {
+		t.Fatalf("callback redirect = %d %q", rec.Code, rec.Header().Get("Location"))
+	}
+}
+
+func TestCookieCSRFAndBearerUnchanged(t *testing.T) {
+	resolver := cookieSessionResolver{principal: Principal{ID: "u1", Role: "admin", TenantID: "tenant"}}
+	auth := NewAuthenticator(func(_ context.Context, token string) (Principal, bool) {
+		return Principal{ID: "bearer", Role: "admin"}, token == "api"
+	})
+	auth.SetSessionResolver(resolver)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+	h := auth.Middleware(map[string]bool{}, next)
+	for _, tc := range []struct {
+		name, method, authz, cookie, csrf string
+		want                              int
+	}{
+		{"unsafe cookie lacks csrf", http.MethodPost, "", "opaque", "", http.StatusUnauthorized},
+		{"unsafe cookie csrf", http.MethodPost, "", "opaque", "csrf", http.StatusNoContent},
+		{"bearer ignores csrf", http.MethodPost, "Bearer api", "opaque", "", http.StatusNoContent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/api/v1/x", nil)
+			if tc.authz != "" {
+				req.Header.Set("Authorization", tc.authz)
+			}
+			if tc.cookie != "" {
+				req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: tc.cookie})
+			}
+			req.Header.Set("X-CSRF-Token", tc.csrf)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -47,6 +47,8 @@ type Router struct {
 	accessLogEnabled       bool
 	httpObserver           HTTPObserver
 	auth                   *Authenticator
+	oidc                   OIDCService
+	oidcFrontendURL        string
 	eng                    *enguc.Service
 	sca                    *scauc.Service
 	aup                    *aupuc.Service
@@ -277,6 +279,12 @@ func (rt *Router) routes() *http.ServeMux {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "service": "synapse-api"})
 	})
 	mux.HandleFunc("GET /readyz", rt.ready)
+	if rt.oidc != nil {
+		mux.HandleFunc("GET /api/auth/oidc/login", rt.oidcLogin)
+		mux.HandleFunc("GET /api/auth/oidc/callback", rt.oidcCallback)
+		mux.HandleFunc("GET /api/auth/session", rt.oidcSession)
+		mux.HandleFunc("POST /api/auth/logout", rt.oidcLogout)
+	}
 	// Identity/consent routes carry NO role gate (a brand-new principal must reach them): /aup,
 	// /aup/accept, /me, and public probes. EVERY other route below is registered through
 	// authz(perm, …) – the single RBAC chokepoint, so no handler decides its own role
@@ -593,17 +601,34 @@ func (rt *Router) routes() *http.ServeMux {
 // authz(perm, …) – not a path-set. Normalizing first ensures the public/AUP-exempt path-sets
 // (matched on the request path) see exactly the path the ServeMux will route on (closes the
 // raw-vs-cleaned path mismatch).
-func (rt *Router) Handler() http.Handler {
-	// Public: no auth and no AUP gate.
-	public := map[string]bool{"/healthz": true, "/readyz": true}
-	// Authenticated but exempt from the AUP gate (so the operator can read + accept).
-	aupExempt := map[string]bool{
-		"/healthz":           true,
-		"/readyz":            true,
+// publicPaths carry no authentication and no AUP gate.
+func publicPaths() map[string]bool {
+	return map[string]bool{
+		"/healthz": true, "/readyz": true,
+		"/api/auth/oidc/login": true, "/api/auth/oidc/callback": true, "/api/auth/session": true,
+	}
+}
+
+// aupExemptPaths are reachable without an accepted acceptable-use policy, so the operator can
+// read and accept it. Every entry in publicPaths must also appear here: skipping authentication
+// still leaves the AUP gate in the chain, and an unauthenticated visitor has no principal that
+// could ever have accepted the policy, so omitting a public path makes it permanently 403.
+func aupExemptPaths() map[string]bool {
+	exempt := map[string]bool{
 		"/api/v1/aup":        true,
 		"/api/v1/aup/accept": true,
 		"/api/v1/me":         true,
+		"/api/auth/logout":   true,
 	}
+	for path := range publicPaths() {
+		exempt[path] = true
+	}
+	return exempt
+}
+
+func (rt *Router) Handler() http.Handler {
+	public := publicPaths()
+	aupExempt := aupExemptPaths()
 	routes := rt.routes()
 	human := rt.auth.Middleware(public, rt.requireAUP(aupExempt, routes))
 	// Attach a method-aware route pattern before auth/AUP can reject a known human

--- a/internal/adapter/observability/prometheus.go
+++ b/internal/adapter/observability/prometheus.go
@@ -27,7 +27,8 @@ type Collectors struct {
 }
 
 // New constructs the bounded Prometheus collectors used by the API metrics listener.
-func New(queueReader ports.AggregateJobQueueStatsReader) *Collectors {
+// The optional pool reader supplies aggregate pool metrics without connection or tenant labels.
+func New(queueReader ports.AggregateJobQueueStatsReader, pool ports.PoolStatsReader) *Collectors {
 	c := &Collectors{
 		registry:    prometheus.NewRegistry(),
 		queueReader: queueReader,
@@ -53,6 +54,9 @@ func New(queueReader ports.AggregateJobQueueStatsReader) *Collectors {
 	if queueReader != nil {
 		queue := newQueueCollector(queueReader, c.now)
 		c.registry.MustRegister(queue)
+	}
+	if pool != nil {
+		c.registry.MustRegister(newPGXPoolCollector(pool))
 	}
 	return c
 }
@@ -111,6 +115,70 @@ func newQueueCollector(reader ports.AggregateJobQueueStatsReader, now func() tim
 		}),
 	}
 }
+
+type pgxPoolCollector struct {
+	pool             ports.PoolStatsReader
+	connections      *prometheus.Desc
+	acquires         *prometheus.Desc
+	newConnections   *prometheus.Desc
+	destroyed        *prometheus.Desc
+	acquireDuration  *prometheus.Desc
+	emptyAcquireWait *prometheus.Desc
+}
+
+func newPGXPoolCollector(pool ports.PoolStatsReader) *pgxPoolCollector {
+	return &pgxPoolCollector{
+		pool:             pool,
+		connections:      prometheus.NewDesc("synapse_postgres_pool_connections", "PostgreSQL pool connections by fixed state.", []string{"state"}, nil),
+		acquires:         prometheus.NewDesc("synapse_postgres_pool_acquires_total", "PostgreSQL pool acquire attempts by fixed outcome.", []string{"outcome"}, nil),
+		newConnections:   prometheus.NewDesc("synapse_postgres_pool_new_connections_total", "PostgreSQL pool connections created.", nil, nil),
+		destroyed:        prometheus.NewDesc("synapse_postgres_pool_connections_destroyed_total", "PostgreSQL pool connections destroyed by fixed reason.", []string{"reason"}, nil),
+		acquireDuration:  prometheus.NewDesc("synapse_postgres_pool_acquire_duration_seconds", "Cumulative PostgreSQL pool connection acquisition duration.", nil, nil),
+		emptyAcquireWait: prometheus.NewDesc("synapse_postgres_pool_empty_acquire_wait_seconds", "Cumulative wait time when PostgreSQL pool acquisition found no idle connection.", nil, nil),
+	}
+}
+
+func (c *pgxPoolCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.connections
+	ch <- c.acquires
+	ch <- c.newConnections
+	ch <- c.destroyed
+	ch <- c.acquireDuration
+	ch <- c.emptyAcquireWait
+}
+
+func (c *pgxPoolCollector) Collect(ch chan<- prometheus.Metric) {
+	stats := c.pool.PoolStats()
+	for _, metric := range []struct {
+		state string
+		value int32
+	}{
+		{"acquired", stats.AcquiredConns},
+		{"constructing", stats.ConstructingConns},
+		{"idle", stats.IdleConns},
+		{"max", stats.MaxConns},
+		{"total", stats.TotalConns},
+	} {
+		ch <- prometheus.MustNewConstMetric(c.connections, prometheus.GaugeValue, float64(metric.value), metric.state)
+	}
+	for _, metric := range []struct {
+		outcome string
+		value   int64
+	}{
+		{"acquired", stats.AcquireCount},
+		{"canceled", stats.CanceledAcquireCount},
+		{"empty", stats.EmptyAcquireCount},
+	} {
+		ch <- prometheus.MustNewConstMetric(c.acquires, prometheus.CounterValue, float64(metric.value), metric.outcome)
+	}
+	ch <- prometheus.MustNewConstMetric(c.newConnections, prometheus.CounterValue, float64(stats.NewConnsCount))
+	ch <- prometheus.MustNewConstMetric(c.destroyed, prometheus.CounterValue, float64(stats.MaxIdleDestroyCount), "max_idle")
+	ch <- prometheus.MustNewConstMetric(c.destroyed, prometheus.CounterValue, float64(stats.MaxLifetimeDestroy), "max_lifetime")
+	ch <- prometheus.MustNewConstMetric(c.acquireDuration, prometheus.CounterValue, stats.AcquireDuration.Seconds())
+	ch <- prometheus.MustNewConstMetric(c.emptyAcquireWait, prometheus.CounterValue, stats.EmptyAcquireWaitTime.Seconds())
+}
+
+var _ prometheus.Collector = (*pgxPoolCollector)(nil)
 
 // ObserveHTTPRequest records a bounded HTTP request outcome.
 func (c *Collectors) ObserveHTTPRequest(method, route, statusClass string, duration time.Duration) {

--- a/internal/adapter/observability/prometheus_test.go
+++ b/internal/adapter/observability/prometheus_test.go
@@ -31,7 +31,7 @@ func (f *fakeQueueReader) AggregateJobQueueStats(ctx context.Context, _ ...strin
 // requests must be scrapable via the returned Handler with the documented label set
 // (method, route, status_class) and nothing else attached to the private registry.
 func TestCollectorsExposesHTTPMetrics(t *testing.T) {
-	c := New(nil)
+	c := New(nil, nil)
 	c.ObserveHTTPRequest("GET", "GET /api/v1/engagements/{id}", "2xx", 25*time.Millisecond)
 
 	got := testutil.ToFloat64(c.httpRequests.WithLabelValues("GET", "GET /api/v1/engagements/{id}", "2xx"))
@@ -43,7 +43,7 @@ func TestCollectorsExposesHTTPMetrics(t *testing.T) {
 // TestCollectorsScrapeOutput covers that the handler actually serves the registered
 // series in the Prometheus text exposition format expected by a scrape target.
 func TestCollectorsScrapeOutput(t *testing.T) {
-	c := New(nil)
+	c := New(nil, nil)
 	c.ObserveHTTPRequest("GET", "GET /healthz", "2xx", time.Millisecond)
 	c.ObserveSCAScan(time.Second, "success")
 
@@ -68,7 +68,7 @@ func TestCollectorsScrapeOutput(t *testing.T) {
 func TestCollectorsQueueGaugesReflectAggregateStats(t *testing.T) {
 	oldest := time.Now().Add(-90 * time.Second)
 	reader := &fakeQueueReader{stats: ports.JobStats{Queued: 3, Claimed: 2, OldestActiveAt: &oldest}}
-	c := New(reader)
+	c := New(reader, nil)
 	c.now = func() time.Time { return oldest.Add(90 * time.Second) }
 
 	rec := httptest.NewRecorder()
@@ -99,7 +99,7 @@ func TestCollectorsQueueGaugesReflectAggregateStats(t *testing.T) {
 // enabled without an aggregate-capable queue implementation) registers no queue gauges
 // rather than panicking or exposing a stale/zero series that misleads an operator.
 func TestCollectorsQueueGaugesAbsentWithoutReader(t *testing.T) {
-	c := New(nil)
+	c := New(nil, nil)
 	rec := httptest.NewRecorder()
 	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	if strings.Contains(rec.Body.String(), "synapse_job_queue_") {
@@ -113,7 +113,7 @@ func TestCollectorsQueueGaugesAbsentWithoutReader(t *testing.T) {
 // itself must be observable via the scrape-error counter.
 func TestCollectorsQueueScrapeErrorSurfacesFailure(t *testing.T) {
 	reader := &fakeQueueReader{err: errors.New("queue stats unavailable")}
-	c := New(reader)
+	c := New(reader, nil)
 
 	rec := httptest.NewRecorder()
 	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
@@ -126,5 +126,44 @@ func TestCollectorsQueueScrapeErrorSurfacesFailure(t *testing.T) {
 	}
 	if !strings.Contains(body, "synapse_job_queue_scrape_errors_total 1") {
 		t.Errorf("scrape-error counter missing/incorrect: %s", body)
+	}
+}
+
+func TestCollectorsPoolMetricsAbsentWithoutPool(t *testing.T) {
+	c := New(nil, nil)
+	rec := httptest.NewRecorder()
+	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if strings.Contains(rec.Body.String(), "synapse_postgres_pool_") {
+		t.Error("no PostgreSQL pool metric should be registered without a pool")
+	}
+}
+
+// stubPoolStats stands in for the database pool so this adapter test needs no driver.
+type stubPoolStats struct{ stats ports.PoolStats }
+
+func (s stubPoolStats) PoolStats() ports.PoolStats { return s.stats }
+
+func TestCollectorsExposeBoundedPoolMetrics(t *testing.T) {
+	c := New(nil, stubPoolStats{stats: ports.PoolStats{MaxConns: 7}})
+	rec := httptest.NewRecorder()
+	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"synapse_postgres_pool_connections{state=\"max\"} 7",
+		"synapse_postgres_pool_acquires_total",
+		"synapse_postgres_pool_new_connections_total",
+		"synapse_postgres_pool_connections_destroyed_total",
+		"synapse_postgres_pool_acquire_duration_seconds",
+		"synapse_postgres_pool_empty_acquire_wait_seconds",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("pool scrape output missing metric %q: %s", want, body)
+		}
+	}
+	for _, forbidden := range []string{"tenant", "host", "database", "user", "secret", "127.0.0.1", "synapse"} {
+		if forbidden != "synapse" && strings.Contains(body, forbidden) {
+			t.Errorf("pool metrics must not expose sensitive label or value %q: %s", forbidden, body)
+		}
 	}
 }

--- a/internal/domain/identity/identity.go
+++ b/internal/domain/identity/identity.go
@@ -75,6 +75,12 @@ func (t AuthorizationTransaction) Usable(now time.Time) bool {
 	return t.ConsumedAt == nil && t.ExpiresAt.After(now)
 }
 
+// MaxSessionAge is the absolute lifetime of a browser session, independent of the sliding per-poll
+// TTL. Rotation refreshes the sliding expiry but never extends OriginAt, so an actively-polled (or
+// stolen-then-kept-alive) session cannot outlive this cap — past it the operator must re-authenticate
+// through the OIDC provider.
+const MaxSessionAge = 12 * time.Hour
+
 // Session is an opaque browser session. Only token hashes are persisted; no provider credentials
 // or raw session/CSRF tokens are retained.
 type Session struct {
@@ -84,10 +90,13 @@ type Session struct {
 	TokenHash     string
 	CSRFTokenHash string
 	Metadata      map[string]string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
-	ExpiresAt     time.Time
-	RevokedAt     *time.Time
+	// OriginAt is the immutable time the session lineage began at login. It is carried unchanged across
+	// every rotation so the absolute-age cap (MaxSessionAge) is measured from first authentication.
+	OriginAt  time.Time
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ExpiresAt time.Time
+	RevokedAt *time.Time
 }
 
 // NewSession constructs an opaque session record with bounded, non-secret metadata.
@@ -105,12 +114,23 @@ func NewSession(id, tenantID, userID shared.ID, tokenHash, csrfTokenHash string,
 	if err != nil {
 		return Session{}, err
 	}
-	return Session{ID: id, TenantID: tenantID, UserID: userID, TokenHash: tokenHash, CSRFTokenHash: csrfTokenHash, Metadata: metadata, CreatedAt: now.UTC(), UpdatedAt: now.UTC(), ExpiresAt: expiresAt.UTC()}, nil
+	return Session{ID: id, TenantID: tenantID, UserID: userID, TokenHash: tokenHash, CSRFTokenHash: csrfTokenHash, Metadata: metadata, OriginAt: now.UTC(), CreatedAt: now.UTC(), UpdatedAt: now.UTC(), ExpiresAt: expiresAt.UTC()}, nil
 }
 
 // Active reports whether a session remains unrevoked and unexpired.
 func (s Session) Active(now time.Time) bool {
 	return s.RevokedAt == nil && s.ExpiresAt.After(now)
+}
+
+// BeyondMaxAge reports whether the session has passed its absolute lifetime cap measured from
+// OriginAt. A session that has must not be rotated — the browser is forced back through OIDC. A zero
+// OriginAt is treated as beyond the cap (fail closed): a session lineage with no recorded origin
+// cannot prove it is within the absolute window.
+func (s Session) BeyondMaxAge(now time.Time) bool {
+	if s.OriginAt.IsZero() {
+		return true
+	}
+	return !now.Before(s.OriginAt.Add(MaxSessionAge))
 }
 
 // Revoke records the terminal revocation timestamp. It is intentionally idempotent on the entity;

--- a/internal/domain/identity/identity.go
+++ b/internal/domain/identity/identity.go
@@ -1,0 +1,161 @@
+// Package identity defines persisted OIDC identities, authorization transactions, and sessions.
+package identity
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	maxMetadataEntries  = 16
+	maxMetadataKeyLen   = 64
+	maxMetadataValueLen = 256
+)
+
+// ExternalIdentity links an immutable provider subject to one tenant-scoped user. Provider tokens
+// are deliberately not part of this model.
+type ExternalIdentity struct {
+	ID        shared.ID
+	TenantID  shared.ID
+	UserID    shared.ID
+	Issuer    string
+	Subject   string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// NewExternalIdentity constructs an identity whose issuer/subject tuple is globally unique in the
+// store. The user relationship is additionally enforced by the persistence adapter.
+func NewExternalIdentity(id, tenantID, userID shared.ID, issuer, subject string, now time.Time) (ExternalIdentity, error) {
+	issuer, subject = strings.TrimSpace(issuer), strings.TrimSpace(subject)
+	if id.IsZero() || tenantID.IsZero() || userID.IsZero() {
+		return ExternalIdentity{}, fmt.Errorf("%w: identity id, tenant id, and user id are required", shared.ErrValidation)
+	}
+	if issuer == "" || subject == "" {
+		return ExternalIdentity{}, fmt.Errorf("%w: issuer and subject are required", shared.ErrValidation)
+	}
+	return ExternalIdentity{ID: id, TenantID: tenantID, UserID: userID, Issuer: issuer, Subject: subject, CreatedAt: now.UTC(), UpdatedAt: now.UTC()}, nil
+}
+
+// AuthorizationTransaction is a short-lived, single-use OIDC login transaction. StateHash and
+// NonceHash are one-way hashes. PKCEVerifierCiphertext must be encrypted before it reaches this
+// model because the verifier must later be recovered for the token exchange.
+type AuthorizationTransaction struct {
+	ID                     shared.ID
+	TenantID               shared.ID
+	StateHash              string
+	NonceHash              string
+	PKCEVerifierCiphertext string
+	CreatedAt              time.Time
+	ExpiresAt              time.Time
+	ConsumedAt             *time.Time
+}
+
+// NewAuthorizationTransaction validates a transaction after state and nonce were hashed and the
+// PKCE verifier was encrypted by the caller.
+func NewAuthorizationTransaction(id, tenantID shared.ID, stateHash, nonceHash, pkceVerifierCiphertext string, expiresAt, now time.Time) (AuthorizationTransaction, error) {
+	stateHash, nonceHash = strings.TrimSpace(stateHash), strings.TrimSpace(nonceHash)
+	if id.IsZero() || tenantID.IsZero() {
+		return AuthorizationTransaction{}, fmt.Errorf("%w: authorization transaction id and tenant id are required", shared.ErrValidation)
+	}
+	if stateHash == "" || nonceHash == "" || strings.TrimSpace(pkceVerifierCiphertext) == "" {
+		return AuthorizationTransaction{}, fmt.Errorf("%w: state hash, nonce hash, and PKCE verifier ciphertext are required", shared.ErrValidation)
+	}
+	if !expiresAt.After(now) {
+		return AuthorizationTransaction{}, fmt.Errorf("%w: authorization transaction expiry must be in the future", shared.ErrValidation)
+	}
+	return AuthorizationTransaction{ID: id, TenantID: tenantID, StateHash: stateHash, NonceHash: nonceHash, PKCEVerifierCiphertext: pkceVerifierCiphertext, CreatedAt: now.UTC(), ExpiresAt: expiresAt.UTC()}, nil
+}
+
+// Usable reports whether the transaction has neither been consumed nor expired.
+func (t AuthorizationTransaction) Usable(now time.Time) bool {
+	return t.ConsumedAt == nil && t.ExpiresAt.After(now)
+}
+
+// Session is an opaque browser session. Only token hashes are persisted; no provider credentials
+// or raw session/CSRF tokens are retained.
+type Session struct {
+	ID            shared.ID
+	TenantID      shared.ID
+	UserID        shared.ID
+	TokenHash     string
+	CSRFTokenHash string
+	Metadata      map[string]string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	ExpiresAt     time.Time
+	RevokedAt     *time.Time
+}
+
+// NewSession constructs an opaque session record with bounded, non-secret metadata.
+func NewSession(id, tenantID, userID shared.ID, tokenHash, csrfTokenHash string, metadata map[string]string, expiresAt, now time.Time) (Session, error) {
+	if id.IsZero() || tenantID.IsZero() || userID.IsZero() {
+		return Session{}, fmt.Errorf("%w: session id, tenant id, and user id are required", shared.ErrValidation)
+	}
+	if strings.TrimSpace(tokenHash) == "" || strings.TrimSpace(csrfTokenHash) == "" {
+		return Session{}, fmt.Errorf("%w: session and CSRF token hashes are required", shared.ErrValidation)
+	}
+	if !expiresAt.After(now) {
+		return Session{}, fmt.Errorf("%w: session expiry must be in the future", shared.ErrValidation)
+	}
+	metadata, err := validMetadata(metadata)
+	if err != nil {
+		return Session{}, err
+	}
+	return Session{ID: id, TenantID: tenantID, UserID: userID, TokenHash: tokenHash, CSRFTokenHash: csrfTokenHash, Metadata: metadata, CreatedAt: now.UTC(), UpdatedAt: now.UTC(), ExpiresAt: expiresAt.UTC()}, nil
+}
+
+// Active reports whether a session remains unrevoked and unexpired.
+func (s Session) Active(now time.Time) bool {
+	return s.RevokedAt == nil && s.ExpiresAt.After(now)
+}
+
+// Revoke records the terminal revocation timestamp. It is intentionally idempotent on the entity;
+// the store detects a concurrent duplicate revoke where callers need that distinction.
+func (s *Session) Revoke(now time.Time) {
+	if s.RevokedAt != nil {
+		return
+	}
+	at := now.UTC()
+	s.RevokedAt = &at
+	s.UpdatedAt = at
+}
+
+func validMetadata(in map[string]string) (map[string]string, error) {
+	if len(in) > maxMetadataEntries {
+		return nil, fmt.Errorf("%w: session metadata exceeds %d entries", shared.ErrValidation, maxMetadataEntries)
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+		if key == "" || len(key) > maxMetadataKeyLen || len(value) > maxMetadataValueLen {
+			return nil, fmt.Errorf("%w: invalid session metadata", shared.ErrValidation)
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+// CopySession returns a defensive copy of a session and its mutable metadata.
+func CopySession(s Session) Session {
+	s.Metadata = copyMetadata(s.Metadata)
+	if s.RevokedAt != nil {
+		at := *s.RevokedAt
+		s.RevokedAt = &at
+	}
+	return s
+}
+
+func copyMetadata(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/domain/identity/identity_test.go
+++ b/internal/domain/identity/identity_test.go
@@ -1,0 +1,54 @@
+package identity
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAuthorizationTransactionUsable(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	transaction, err := NewAuthorizationTransaction("tx", "tenant", "state-hash", "nonce-hash", "encrypted-verifier", now.Add(time.Minute), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !transaction.Usable(now) {
+		t.Fatal("fresh authorization transaction must be usable")
+	}
+	transaction.ConsumedAt = &now
+	if transaction.Usable(now) {
+		t.Fatal("consumed authorization transaction must not be usable")
+	}
+	if _, err := NewAuthorizationTransaction("tx", "tenant", "state", "nonce", "ciphertext", now, now); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("expiry at creation must be invalid, got %v", err)
+	}
+}
+
+func TestSessionLifecycleAndMetadata(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	session, err := NewSession("session", "tenant", "user", "token-hash", "csrf-hash", map[string]string{"ip": "127.0.0.1"}, now.Add(time.Hour), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !session.Active(now) {
+		t.Fatal("new session must be active")
+	}
+	session.Revoke(now.Add(time.Second))
+	if session.Active(now.Add(time.Second)) || session.RevokedAt == nil {
+		t.Fatalf("revoked session must be inactive: %+v", session)
+	}
+	copy := CopySession(session)
+	copy.Metadata["ip"] = "changed"
+	if session.Metadata["ip"] != "127.0.0.1" {
+		t.Fatal("copy must not share mutable metadata")
+	}
+}
+
+func TestExternalIdentityRequiresTenantScopedUser(t *testing.T) {
+	_, err := NewExternalIdentity("identity", "", "user", "https://issuer", "subject", time.Now())
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("empty tenant must be rejected, got %v", err)
+	}
+}

--- a/internal/infrastructure/blob/memory.go
+++ b/internal/infrastructure/blob/memory.go
@@ -2,6 +2,9 @@ package blob
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"sync"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -19,6 +22,7 @@ type Memory struct {
 func NewMemory() *Memory { return &Memory{m: map[string][]byte{}} }
 
 var _ ports.BlobStore = (*Memory)(nil)
+var _ ports.RestoreBlobReader = (*Memory)(nil)
 
 func (s *Memory) Put(_ context.Context, key string, data []byte) error {
 	cp := make([]byte, len(data))
@@ -39,4 +43,32 @@ func (s *Memory) Get(_ context.Context, key string) ([]byte, error) {
 	cp := make([]byte, len(d))
 	copy(cp, d)
 	return cp, nil
+}
+
+// Verify streams the stored bytes into SHA-256 and compares them with expected.
+// It deliberately derives the digest from data rather than trusting the key.
+func (s *Memory) Verify(_ context.Context, key, expected string) error {
+	s.mu.RLock()
+	d, ok := s.m[key]
+	if !ok {
+		s.mu.RUnlock()
+		return shared.ErrNotFound
+	}
+	actual := sha256.Sum256(d)
+	s.mu.RUnlock()
+	if hex.EncodeToString(actual[:]) != expected {
+		return fmt.Errorf("artifact checksum does not match expected SHA-256")
+	}
+	return nil
+}
+
+// Stat reports the digest derived from the stored bytes. It exists for read-only
+// restore verification; callers must compare SHA256 with their expected digest.
+func (s *Memory) Stat(ctx context.Context, key string) (ObjectMetadata, error) {
+	data, err := s.Get(ctx, key)
+	if err != nil {
+		return ObjectMetadata{}, err
+	}
+	sum := sha256.Sum256(data)
+	return ObjectMetadata{SHA256: hex.EncodeToString(sum[:])}, nil
 }

--- a/internal/infrastructure/blob/memory_test.go
+++ b/internal/infrastructure/blob/memory_test.go
@@ -2,6 +2,8 @@ package blob
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"testing"
 
@@ -31,5 +33,32 @@ func TestMemoryRoundTrip(t *testing.T) {
 	again, _ := s.Get(ctx, "k1")
 	if string(again) != string(data) {
 		t.Errorf("store mutated via returned slice: %q", again)
+	}
+}
+
+func TestMemoryStatAndVerifyHashStoredBytes(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemory()
+	good := []byte("original artifact")
+	sum := sha256.Sum256(good)
+	key := hex.EncodeToString(sum[:])
+	if err := store.Put(ctx, key, good); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	// Simulate storage corruption beneath an otherwise valid content-address key.
+	store.mu.Lock()
+	store.m[key] = []byte("corrupted artifact")
+	store.mu.Unlock()
+
+	metadata, err := store.Stat(ctx, key)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if metadata.SHA256 == key {
+		t.Fatal("stat must derive checksum from corrupted stored bytes, not trust key")
+	}
+	if err := store.Verify(ctx, key, key); err == nil {
+		t.Fatal("verification must reject bytes corrupted under a valid content-address key")
 	}
 }

--- a/internal/infrastructure/blob/minio.go
+++ b/internal/infrastructure/blob/minio.go
@@ -7,6 +7,8 @@ package blob
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 
@@ -26,6 +28,17 @@ type Config struct {
 	UseSSL    bool
 }
 
+// ObjectMetadata is integrity metadata derived from an object. SHA256 is never
+// inferred from an object key or trusted solely from object metadata.
+type ObjectMetadata = ports.ObjectMetadata
+
+// ReadOnlyMinIO exposes only restore-verification operations. It intentionally
+// has no Put method so a restore caller cannot obtain write capability.
+type ReadOnlyMinIO struct {
+	client *minio.Client
+	bucket string
+}
+
 // MinIO is an S3-compatible content-addressed BlobStore.
 type MinIO struct {
 	client *minio.Client
@@ -33,18 +46,13 @@ type MinIO struct {
 }
 
 var _ ports.BlobStore = (*MinIO)(nil)
+var _ ports.RestoreBlobReader = (*ReadOnlyMinIO)(nil)
 
 // NewMinIO connects to the object store and ensures the bucket exists.
 func NewMinIO(ctx context.Context, cfg Config) (*MinIO, error) {
-	if cfg.Endpoint == "" || cfg.Bucket == "" {
-		return nil, fmt.Errorf("%w: blob store requires endpoint and bucket", shared.ErrValidation)
-	}
-	client, err := minio.New(cfg.Endpoint, &minio.Options{
-		Creds:  credentials.NewStaticV4(cfg.AccessKey, cfg.SecretKey, ""),
-		Secure: cfg.UseSSL,
-	})
+	client, err := newClient(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("minio client: %w", err)
+		return nil, err
 	}
 	exists, err := client.BucketExists(ctx, cfg.Bucket)
 	if err != nil {
@@ -56,6 +64,38 @@ func NewMinIO(ctx context.Context, cfg Config) (*MinIO, error) {
 		}
 	}
 	return &MinIO{client: client, bucket: cfg.Bucket}, nil
+}
+
+// NewReadOnlyMinIO connects to an existing object store without creating or
+// modifying the bucket. Its result is capability-constrained to read-only
+// verification methods for future restore ports.
+func NewReadOnlyMinIO(ctx context.Context, cfg Config) (*ReadOnlyMinIO, error) {
+	client, err := newClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	exists, err := client.BucketExists(ctx, cfg.Bucket)
+	if err != nil {
+		return nil, fmt.Errorf("minio bucket check: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("minio bucket check: bucket is missing")
+	}
+	return &ReadOnlyMinIO{client: client, bucket: cfg.Bucket}, nil
+}
+
+func newClient(cfg Config) (*minio.Client, error) {
+	if cfg.Endpoint == "" || cfg.Bucket == "" {
+		return nil, fmt.Errorf("%w: blob store requires endpoint and bucket", shared.ErrValidation)
+	}
+	client, err := minio.New(cfg.Endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(cfg.AccessKey, cfg.SecretKey, ""),
+		Secure: cfg.UseSSL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("minio client: %w", err)
+	}
+	return client, nil
 }
 
 // Put stores data under the content-addressed key. Idempotent: re-putting the same
@@ -71,22 +111,68 @@ func (m *MinIO) Put(ctx context.Context, key string, data []byte) error {
 
 // Get returns the bytes stored under key (shared.ErrNotFound if absent).
 func (m *MinIO) Get(ctx context.Context, key string) ([]byte, error) {
-	obj, err := m.client.GetObject(ctx, m.bucket, key, minio.GetObjectOptions{})
+	return get(m.client, ctx, m.bucket, key)
+}
+
+// Stat reads and hashes the object so metadata-less legacy objects are verified
+// securely. Object contents never appear in errors or logs.
+func (m *ReadOnlyMinIO) Stat(ctx context.Context, key string) (ObjectMetadata, error) {
+	return stat(m.client, ctx, m.bucket, key)
+}
+
+// Verify hashes object content and compares it to expected without exposing the
+// object's bytes to the restore caller.
+func (m *ReadOnlyMinIO) Verify(ctx context.Context, key, expected string) error {
+	return verify(m.client, ctx, m.bucket, key, expected)
+}
+
+func get(client *minio.Client, ctx context.Context, bucket, key string) ([]byte, error) {
+	obj, err := client.GetObject(ctx, bucket, key, minio.GetObjectOptions{})
 	if err != nil {
-		if minio.ToErrorResponse(err).Code == "NoSuchKey" {
-			return nil, shared.ErrNotFound
-		}
-		return nil, fmt.Errorf("get artifact: %w", err)
+		return nil, minioGetError("get artifact", err)
 	}
 	defer func() { _ = obj.Close() }()
 	data, err := io.ReadAll(obj)
 	if err != nil {
-		if minio.ToErrorResponse(err).Code == "NoSuchKey" {
-			return nil, shared.ErrNotFound
-		}
-		return nil, fmt.Errorf("read artifact: %w", err)
+		return nil, minioGetError("read artifact", err)
 	}
 	return data, nil
+}
+
+func stat(client *minio.Client, ctx context.Context, bucket, key string) (ObjectMetadata, error) {
+	obj, err := client.GetObject(ctx, bucket, key, minio.GetObjectOptions{})
+	if err != nil {
+		return ObjectMetadata{}, minioGetError("get artifact", err)
+	}
+	defer func() { _ = obj.Close() }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, obj); err != nil {
+		return ObjectMetadata{}, minioGetError("verify artifact", err)
+	}
+	return ObjectMetadata{SHA256: hex.EncodeToString(hash.Sum(nil))}, nil
+}
+
+func verify(client *minio.Client, ctx context.Context, bucket, key, expected string) error {
+	obj, err := client.GetObject(ctx, bucket, key, minio.GetObjectOptions{})
+	if err != nil {
+		return minioGetError("get artifact", err)
+	}
+	defer func() { _ = obj.Close() }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, obj); err != nil {
+		return minioGetError("verify artifact", err)
+	}
+	if hex.EncodeToString(hash.Sum(nil)) != expected {
+		return fmt.Errorf("artifact checksum does not match expected SHA-256")
+	}
+	return nil
+}
+
+func minioGetError(operation string, err error) error {
+	if minio.ToErrorResponse(err).Code == "NoSuchKey" {
+		return shared.ErrNotFound
+	}
+	return fmt.Errorf("%s: %w", operation, err)
 }
 
 // CheckReady verifies that the configured evidence bucket remains reachable. It performs no object

--- a/internal/infrastructure/blob/minio_test.go
+++ b/internal/infrastructure/blob/minio_test.go
@@ -2,6 +2,8 @@ package blob
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -53,5 +55,86 @@ func TestMinIOCheckReadyUsesBucketProbe(t *testing.T) {
 	defer cancel()
 	if err := store.CheckReady(ctx); err == nil {
 		t.Fatal("unreachable object store must not be ready")
+	}
+}
+
+func TestReadOnlyMinIOStatsLegacyObjectByStreamingBytes(t *testing.T) {
+	data := []byte("legacy object without checksum metadata")
+	sum := sha256.Sum256(data)
+	want := hex.EncodeToString(sum[:])
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/evidence/":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-east-1</LocationConstraint>`))
+		case r.Method == http.MethodHead && r.URL.Path == "/evidence/":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/evidence/"+want:
+			w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+			_, _ = w.Write(data)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	store, err := NewReadOnlyMinIO(context.Background(), Config{
+		Endpoint: strings.TrimPrefix(server.URL, "http://"), AccessKey: "access", SecretKey: "secret", Bucket: "evidence",
+	})
+	if err != nil {
+		t.Fatalf("new read-only store: %v", err)
+	}
+	metadata, err := store.Stat(context.Background(), want)
+	if err != nil {
+		t.Fatalf("stat legacy object: %v", err)
+	}
+	if metadata.SHA256 != want {
+		t.Fatalf("stat digest = %s, want %s", metadata.SHA256, want)
+	}
+	if err := store.Verify(context.Background(), want, want); err != nil {
+		t.Fatalf("verify legacy object: %v", err)
+	}
+}
+
+func TestReadOnlyMinIORejectsKeyWhoseBytesDoNotMatch(t *testing.T) {
+	key := strings.Repeat("a", 64)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/evidence/":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-east-1</LocationConstraint>`))
+		case r.Method == http.MethodHead && r.URL.Path == "/evidence/":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/evidence/"+key:
+			w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+			_, _ = w.Write([]byte("corrupted object bytes"))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	store, err := NewReadOnlyMinIO(context.Background(), Config{
+		Endpoint: strings.TrimPrefix(server.URL, "http://"), AccessKey: "access", SecretKey: "secret", Bucket: "evidence",
+	})
+	if err != nil {
+		t.Fatalf("new read-only store: %v", err)
+	}
+	if err := store.Verify(context.Background(), key, key); err == nil {
+		t.Fatal("verification must not trust the content-address key")
+	}
+}
+
+func TestReadOnlyMinIODoesNotExposePut(t *testing.T) {
+	var _ interface {
+		Stat(context.Context, string) (ObjectMetadata, error)
+		Verify(context.Context, string, string) error
+	} = (*ReadOnlyMinIO)(nil)
+	if _, exposesPut := any((*ReadOnlyMinIO)(nil)).(interface {
+		Put(context.Context, string, []byte) error
+	}); exposesPut {
+		t.Fatal("read-only MinIO must not expose Put")
 	}
 }

--- a/internal/infrastructure/oidc/protector.go
+++ b/internal/infrastructure/oidc/protector.go
@@ -4,10 +4,13 @@ import (
 	"context"
 
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/vault"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 // SecretProtector adapts the authenticated vault cipher for short-lived PKCE verifier storage.
 type SecretProtector struct{ cipher *vault.Cipher }
+
+var _ ports.IdentitySecretProtector = (*SecretProtector)(nil)
 
 func NewSecretProtector(cipher *vault.Cipher) *SecretProtector {
 	return &SecretProtector{cipher: cipher}

--- a/internal/infrastructure/oidc/protector.go
+++ b/internal/infrastructure/oidc/protector.go
@@ -1,0 +1,28 @@
+package oidc
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/vault"
+)
+
+// SecretProtector adapts the authenticated vault cipher for short-lived PKCE verifier storage.
+type SecretProtector struct{ cipher *vault.Cipher }
+
+func NewSecretProtector(cipher *vault.Cipher) *SecretProtector {
+	return &SecretProtector{cipher: cipher}
+}
+
+func (p *SecretProtector) Seal(ctx context.Context, plaintext, aad []byte) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return p.cipher.Seal(plaintext, aad)
+}
+
+func (p *SecretProtector) Open(ctx context.Context, ciphertext string, aad []byte) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return p.cipher.Open(ciphertext, aad)
+}

--- a/internal/infrastructure/oidc/provider.go
+++ b/internal/infrastructure/oidc/provider.go
@@ -1,0 +1,192 @@
+// Package oidc provides the OpenID Connect protocol boundary for Synapse's browser BFF.
+package oidc
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	coreoidc "github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Config is the fixed, operator-supplied OIDC relying-party configuration.
+var _ ports.OIDCProvider = (*Provider)(nil)
+
+type Config struct {
+	Issuer           string
+	ClientID         string
+	ClientSecret     string
+	RedirectURL      string
+	GroupRoleMapping []string
+}
+
+// Provider executes the authorization-code OIDC protocol. It neither persists nor logs tokens.
+type Provider struct {
+	issuer   string
+	verifier *coreoidc.IDTokenVerifier
+	oauth    oauth2.Config
+	roles    map[string]user.Role
+}
+
+// New discovers a fixed HTTPS issuer and builds its verifier and OAuth client.
+func New(ctx context.Context, cfg Config) (*Provider, error) {
+	issuer, err := httpsIssuer(cfg.Issuer)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(cfg.ClientID) == "" || strings.TrimSpace(cfg.ClientSecret) == "" || strings.TrimSpace(cfg.RedirectURL) == "" {
+		return nil, fmt.Errorf("OIDC client id, client secret, and redirect URL are required")
+	}
+	roles, err := parseGroupRoleMapping(cfg.GroupRoleMapping)
+	if err != nil {
+		return nil, err
+	}
+	provider, err := coreoidc.NewProvider(ctx, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("discover OIDC issuer: %w", err)
+	}
+	return &Provider{
+		issuer:   issuer,
+		verifier: provider.Verifier(&coreoidc.Config{ClientID: cfg.ClientID}),
+		oauth: oauth2.Config{
+			ClientID: cfg.ClientID, ClientSecret: cfg.ClientSecret, RedirectURL: cfg.RedirectURL,
+			Endpoint: provider.Endpoint(), Scopes: []string{coreoidc.ScopeOpenID, "profile", "groups"},
+		},
+		roles: roles,
+	}, nil
+}
+
+// GenerateVerifier mints a PKCE code verifier with the OAuth2 library's own generator, keeping
+// that dependency inside the protocol adapter.
+func (p *Provider) GenerateVerifier() string { return oauth2.GenerateVerifier() }
+
+// AuthorizationURL returns the authorization-code redirect with state, nonce, and PKCE S256.
+func (p *Provider) AuthorizationURL(state, nonce, verifier string) (string, error) {
+	if strings.TrimSpace(state) == "" || strings.TrimSpace(nonce) == "" || strings.TrimSpace(verifier) == "" {
+		return "", fmt.Errorf("OIDC state, nonce, and PKCE verifier are required")
+	}
+	return p.oauth.AuthCodeURL(state,
+		coreoidc.Nonce(nonce),
+		oauth2.S256ChallengeOption(verifier),
+	), nil
+}
+
+// ExchangeAndVerify exchanges one authorization code and validates the resulting ID token.
+func (p *Provider) ExchangeAndVerify(ctx context.Context, code, verifier, nonce string) (ports.OIDCIdentity, error) {
+	if strings.TrimSpace(code) == "" || strings.TrimSpace(verifier) == "" || strings.TrimSpace(nonce) == "" {
+		return ports.OIDCIdentity{}, fmt.Errorf("OIDC code, verifier, and nonce are required")
+	}
+	token, err := p.oauth.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		return ports.OIDCIdentity{}, fmt.Errorf("exchange OIDC authorization code: %w", err)
+	}
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok || rawIDToken == "" {
+		return ports.OIDCIdentity{}, fmt.Errorf("OIDC token response has no ID token")
+	}
+	idToken, err := p.verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return ports.OIDCIdentity{}, fmt.Errorf("verify OIDC ID token: %w", err)
+	}
+	var claims struct {
+		Nonce  string          `json:"nonce"`
+		AtHash string          `json:"at_hash"`
+		Groups json.RawMessage `json:"groups"`
+	}
+	if err := idToken.Claims(&claims); err != nil {
+		return ports.OIDCIdentity{}, fmt.Errorf("decode OIDC ID token claims: %w", err)
+	}
+	if claims.Nonce == "" || subtle.ConstantTimeCompare([]byte(claims.Nonce), []byte(nonce)) != 1 {
+		return ports.OIDCIdentity{}, fmt.Errorf("OIDC nonce mismatch")
+	}
+	if claims.AtHash != "" {
+		if err := idToken.VerifyAccessToken(token.AccessToken); err != nil {
+			return ports.OIDCIdentity{}, fmt.Errorf("verify OIDC access-token hash: %w", err)
+		}
+	}
+	role, err := p.roleForGroups(claims.Groups)
+	if err != nil {
+		return ports.OIDCIdentity{}, err
+	}
+	if idToken.Issuer != p.issuer || strings.TrimSpace(idToken.Subject) == "" {
+		return ports.OIDCIdentity{}, fmt.Errorf("OIDC issuer or subject is invalid")
+	}
+	return ports.OIDCIdentity{Issuer: idToken.Issuer, Subject: idToken.Subject, Role: role}, nil
+}
+
+func (p *Provider) roleForGroups(raw json.RawMessage) (user.Role, error) {
+	var groups []string
+	if len(raw) == 0 || string(raw) == "null" || json.Unmarshal(raw, &groups) != nil || len(groups) == 0 {
+		return "", fmt.Errorf("OIDC groups claim is required")
+	}
+	roles := make(map[user.Role]struct{})
+	seen := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		group = strings.TrimSpace(group)
+		if group == "" {
+			return "", fmt.Errorf("OIDC groups claim is invalid")
+		}
+		if _, duplicate := seen[group]; duplicate {
+			return "", fmt.Errorf("OIDC groups claim is ambiguous")
+		}
+		seen[group] = struct{}{}
+		role, ok := p.roles[group]
+		if !ok {
+			return "", fmt.Errorf("OIDC group is not allowlisted")
+		}
+		roles[role] = struct{}{}
+	}
+	if len(roles) != 1 {
+		return "", fmt.Errorf("OIDC groups map to ambiguous roles")
+	}
+	for role := range roles {
+		return role, nil
+	}
+	return "", fmt.Errorf("OIDC groups claim is required")
+}
+
+func httpsIssuer(value string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || u.Scheme != "https" || u.Host == "" || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("OIDC issuer must be an absolute HTTPS URL without query or fragment")
+	}
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+func parseGroupRoleMapping(values []string) (map[string]user.Role, error) {
+	if len(values) == 0 {
+		return nil, fmt.Errorf("OIDC group-role mapping is required")
+	}
+	roles := make(map[string]user.Role, len(values))
+	for _, value := range values {
+		group, roleText, ok := strings.Cut(value, "=")
+		group, roleText = strings.TrimSpace(group), strings.TrimSpace(roleText)
+		role := user.Role(roleText)
+		if !ok || group == "" || !role.Valid() || role == user.RoleMember {
+			return nil, fmt.Errorf("OIDC group-role mapping is invalid")
+		}
+		if _, exists := roles[group]; exists {
+			return nil, fmt.Errorf("OIDC group-role mapping has duplicate group")
+		}
+		roles[group] = role
+	}
+	return roles, nil
+}
+
+// GroupRoleMappings returns normalized mappings for validation and test inspection.
+func (p *Provider) GroupRoleMappings() []string {
+	result := make([]string, 0, len(p.roles))
+	for group, role := range p.roles {
+		result = append(result, group+"="+string(role))
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/infrastructure/oidc/provider_test.go
+++ b/internal/infrastructure/oidc/provider_test.go
@@ -1,0 +1,58 @@
+package oidc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/user"
+)
+
+func TestHTTPSIssuer(t *testing.T) {
+	for _, input := range []string{"http://issuer.example", "https://", "https://issuer.example/?x=1", "https://issuer.example/#x"} {
+		if _, err := httpsIssuer(input); err == nil {
+			t.Errorf("httpsIssuer(%q) succeeded", input)
+		}
+	}
+	got, err := httpsIssuer("https://issuer.example/")
+	if err != nil || got != "https://issuer.example" {
+		t.Fatalf("httpsIssuer() = %q, %v", got, err)
+	}
+}
+
+func TestGroupRoleMappingRejectsMissingUnknownAndAmbiguousGroups(t *testing.T) {
+	roles, err := parseGroupRoleMapping([]string{"synapse-admins=admin", "synapse-readers=readonly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := &Provider{roles: roles}
+	cases := []struct {
+		name   string
+		groups any
+		want   user.Role
+		ok     bool
+	}{
+		{name: "one allowed group", groups: []string{"synapse-admins"}, want: user.RoleAdmin, ok: true},
+		{name: "missing groups", groups: []string{}, ok: false},
+		{name: "unknown group", groups: []string{"synapse-admins", "other"}, ok: false},
+		{name: "ambiguous roles", groups: []string{"synapse-admins", "synapse-readers"}, ok: false},
+		{name: "duplicate group", groups: []string{"synapse-admins", "synapse-admins"}, ok: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.groups)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := provider.roleForGroups(raw)
+			if (err == nil) != tc.ok || got != tc.want {
+				t.Fatalf("roleForGroups() = %q, %v; want %q, success=%v", got, err, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestGroupRoleMappingRejectsMemberAlias(t *testing.T) {
+	if _, err := parseGroupRoleMapping([]string{"synapse-members=member"}); err == nil {
+		t.Fatal("member alias must not be configured for OIDC")
+	}
+}

--- a/internal/infrastructure/persistence/memory/identity_store.go
+++ b/internal/infrastructure/persistence/memory/identity_store.go
@@ -1,0 +1,194 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/identity"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// IdentityStore is a race-safe in-memory ports.IdentityStore for development and tests.
+type IdentityStore struct {
+	mu               sync.RWMutex
+	users            ports.UserRepository
+	identitiesByKey  map[string]identity.ExternalIdentity
+	transactions     map[string]identity.AuthorizationTransaction
+	sessionsByID     map[shared.ID]identity.Session
+	sessionIDsByHash map[string]shared.ID
+}
+
+// NewIdentityStore returns an empty store linked to the supplied user repository.
+func NewIdentityStore(users ports.UserRepository) (*IdentityStore, error) {
+	if users == nil {
+		return nil, fmt.Errorf("%w: identity store requires user repository", shared.ErrValidation)
+	}
+	return &IdentityStore{
+		users: users, identitiesByKey: make(map[string]identity.ExternalIdentity),
+		transactions: make(map[string]identity.AuthorizationTransaction), sessionsByID: make(map[shared.ID]identity.Session), sessionIDsByHash: make(map[string]shared.ID),
+	}, nil
+}
+
+var _ ports.IdentityStore = (*IdentityStore)(nil)
+
+func (s *IdentityStore) CreateExternalIdentity(ctx context.Context, external identity.ExternalIdentity) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	u, err := s.users.GetByID(ctx, external.UserID)
+	if err != nil {
+		return fmt.Errorf("identity user %s: %w", external.UserID, err)
+	}
+	if shared.TenantOrDefault(shared.ID(u.TenantID)) != external.TenantID {
+		return fmt.Errorf("identity user %s tenant: %w", external.UserID, shared.ErrForbidden)
+	}
+	key := external.Issuer + "\x00" + external.Subject
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.identitiesByKey[key]; exists {
+		return fmt.Errorf("identity issuer/subject already exists: %w", shared.ErrConflict)
+	}
+	s.identitiesByKey[key] = external
+	return nil
+}
+
+func (s *IdentityStore) GetExternalIdentity(ctx context.Context, issuer, subject string) (identity.ExternalIdentity, error) {
+	if err := ctx.Err(); err != nil {
+		return identity.ExternalIdentity{}, err
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return identity.ExternalIdentity{}, fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	external, ok := s.identitiesByKey[issuer+"\x00"+subject]
+	if !ok || external.TenantID != tenantID {
+		return identity.ExternalIdentity{}, shared.ErrNotFound
+	}
+	return external, nil
+}
+
+func (s *IdentityStore) CreateAuthorizationTransaction(ctx context.Context, transaction identity.AuthorizationTransaction) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.transactions[transaction.StateHash]; exists {
+		return fmt.Errorf("authorization state already exists: %w", shared.ErrConflict)
+	}
+	s.transactions[transaction.StateHash] = transaction
+	return nil
+}
+
+func (s *IdentityStore) ConsumeAuthorizationTransaction(ctx context.Context, tenantID shared.ID, stateHash string, now time.Time) (identity.AuthorizationTransaction, error) {
+	if err := ctx.Err(); err != nil {
+		return identity.AuthorizationTransaction{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	transaction, ok := s.transactions[stateHash]
+	if !ok || transaction.TenantID != tenantID {
+		return identity.AuthorizationTransaction{}, shared.ErrNotFound
+	}
+	if !transaction.Usable(now) {
+		delete(s.transactions, stateHash) // expired records contain short-lived encrypted secret material.
+		return identity.AuthorizationTransaction{}, shared.ErrNotFound
+	}
+	delete(s.transactions, stateHash) // deletion makes consumption one-time and does not retain short-lived secrets.
+	return transaction, nil
+}
+
+func (s *IdentityStore) CreateSession(ctx context.Context, session identity.Session) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	u, err := s.users.GetByID(ctx, session.UserID)
+	if err != nil {
+		return fmt.Errorf("session user %s: %w", session.UserID, err)
+	}
+	if shared.TenantOrDefault(shared.ID(u.TenantID)) != session.TenantID {
+		return fmt.Errorf("session user %s tenant: %w", session.UserID, shared.ErrForbidden)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.sessionsByID[session.ID]; exists {
+		return fmt.Errorf("session id already exists: %w", shared.ErrConflict)
+	}
+	if _, exists := s.sessionIDsByHash[session.TokenHash]; exists {
+		return fmt.Errorf("session token already exists: %w", shared.ErrConflict)
+	}
+	s.sessionsByID[session.ID] = identity.CopySession(session)
+	s.sessionIDsByHash[session.TokenHash] = session.ID
+	return nil
+}
+
+// RotateSession creates replacement and revokes previous under one lock.
+func (s *IdentityStore) RotateSession(ctx context.Context, previousSessionID shared.ID, replacement identity.Session, now time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	u, err := s.users.GetByID(ctx, replacement.UserID)
+	if err != nil {
+		return fmt.Errorf("replacement session user %s: %w", replacement.UserID, err)
+	}
+	if shared.TenantOrDefault(shared.ID(u.TenantID)) != replacement.TenantID {
+		return fmt.Errorf("replacement session user %s tenant: %w", replacement.UserID, shared.ErrForbidden)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previous, ok := s.sessionsByID[previousSessionID]
+	if !ok || previous.TenantID != replacement.TenantID || previous.UserID != replacement.UserID || !previous.Active(now) {
+		return fmt.Errorf("previous session is not active: %w", shared.ErrConflict)
+	}
+	if _, exists := s.sessionsByID[replacement.ID]; exists {
+		return fmt.Errorf("replacement session id already exists: %w", shared.ErrConflict)
+	}
+	if _, exists := s.sessionIDsByHash[replacement.TokenHash]; exists {
+		return fmt.Errorf("replacement session token already exists: %w", shared.ErrConflict)
+	}
+	previous.Revoke(now)
+	s.sessionsByID[previousSessionID] = previous
+	s.sessionsByID[replacement.ID] = identity.CopySession(replacement)
+	s.sessionIDsByHash[replacement.TokenHash] = replacement.ID
+	return nil
+}
+
+func (s *IdentityStore) GetSessionByTokenHash(ctx context.Context, tokenHash string) (identity.Session, error) {
+	if err := ctx.Err(); err != nil {
+		return identity.Session{}, err
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return identity.Session{}, fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	id, ok := s.sessionIDsByHash[tokenHash]
+	if !ok || s.sessionsByID[id].TenantID != tenantID {
+		return identity.Session{}, shared.ErrNotFound
+	}
+	return identity.CopySession(s.sessionsByID[id]), nil
+}
+
+func (s *IdentityStore) RevokeSession(ctx context.Context, tenantID, sessionID shared.ID, now time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	session, ok := s.sessionsByID[sessionID]
+	if !ok || session.TenantID != tenantID {
+		return shared.ErrNotFound
+	}
+	if session.RevokedAt != nil {
+		return fmt.Errorf("session already revoked: %w", shared.ErrConflict)
+	}
+	session.Revoke(now)
+	s.sessionsByID[sessionID] = session
+	return nil
+}

--- a/internal/infrastructure/persistence/memory/identity_store_test.go
+++ b/internal/infrastructure/persistence/memory/identity_store_test.go
@@ -1,0 +1,118 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/identity"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/user"
+)
+
+func identityMemoryStore(t *testing.T) (*IdentityStore, context.Context, time.Time) {
+	t.Helper()
+	now := time.Unix(100, 0).UTC()
+	users := NewUserRepository()
+	u, err := user.New("user", "tenant-a", "User", user.RoleMember, "key-hash", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := users.Create(context.Background(), u); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewIdentityStore(users)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, shared.WithTenant(context.Background(), "tenant-a"), now
+}
+
+func TestIdentityStoreUniquenessAndTenantLinkage(t *testing.T) {
+	store, ctx, now := identityMemoryStore(t)
+	external, _ := identity.NewExternalIdentity("identity", "tenant-a", "user", "https://issuer", "subject", now)
+	if err := store.CreateExternalIdentity(ctx, external); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateExternalIdentity(ctx, external); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate issuer/subject must conflict, got %v", err)
+	}
+	wrongTenant, _ := identity.NewExternalIdentity("wrong", "tenant-b", "user", "https://issuer-b", "subject", now)
+	if err := store.CreateExternalIdentity(ctx, wrongTenant); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("cross-tenant user link must be forbidden, got %v", err)
+	}
+}
+
+func TestIdentityStoreTransactionReplayAndExpiry(t *testing.T) {
+	store, ctx, now := identityMemoryStore(t)
+	transaction, _ := identity.NewAuthorizationTransaction("tx", "tenant-a", "state", "nonce", "ciphertext", now.Add(time.Minute), now)
+	if err := store.CreateAuthorizationTransaction(ctx, transaction); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := store.ConsumeAuthorizationTransaction(ctx, "tenant-a", "state", now); err != nil || got.ID != transaction.ID {
+		t.Fatalf("first consume: got=%+v err=%v", got, err)
+	}
+	if _, err := store.ConsumeAuthorizationTransaction(ctx, "tenant-a", "state", now); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("replay must fail, got %v", err)
+	}
+	expired, _ := identity.NewAuthorizationTransaction("expired", "tenant-a", "expired-state", "nonce", "ciphertext", now.Add(time.Second), now)
+	if err := store.CreateAuthorizationTransaction(ctx, expired); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ConsumeAuthorizationTransaction(ctx, "tenant-a", "expired-state", now.Add(time.Second)); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("expired transaction must fail closed, got %v", err)
+	}
+}
+
+func TestIdentityStoreConsumesTransactionOnceUnderRace(t *testing.T) {
+	store, ctx, now := identityMemoryStore(t)
+	transaction, _ := identity.NewAuthorizationTransaction("tx", "tenant-a", "state", "nonce", "ciphertext", now.Add(time.Minute), now)
+	if err := store.CreateAuthorizationTransaction(ctx, transaction); err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	var successes int
+	var mu sync.Mutex
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := store.ConsumeAuthorizationTransaction(ctx, "tenant-a", "state", now); err == nil {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if successes != 1 {
+		t.Fatalf("exactly one transaction consumer must win, got %d", successes)
+	}
+}
+
+func TestIdentityStoreSessionRevocationAndTenantLinkage(t *testing.T) {
+	store, ctx, now := identityMemoryStore(t)
+	session, _ := identity.NewSession("session", "tenant-a", "user", "token", "csrf", nil, now.Add(time.Hour), now)
+	if err := store.CreateSession(ctx, session); err != nil {
+		t.Fatal(err)
+	}
+	replacement, _ := identity.NewSession("replacement", "tenant-a", "user", "replacement-token", "replacement-csrf", nil, now.Add(time.Hour), now)
+	if err := store.RotateSession(ctx, session.ID, replacement, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if old, err := store.GetSessionByTokenHash(ctx, "token"); err != nil || old.Active(now.Add(time.Second)) {
+		t.Fatalf("old token remained active: got=%+v err=%v", old, err)
+	}
+	if err := store.RevokeSession(ctx, "tenant-b", replacement.ID, now); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("wrong tenant must not find session, got %v", err)
+	}
+	if err := store.RevokeSession(ctx, "tenant-a", replacement.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.GetSessionByTokenHash(ctx, "replacement-token")
+	if err != nil || got.RevokedAt == nil || got.Active(now) {
+		t.Fatalf("revoked session must remain persisted but inactive: got=%+v err=%v", got, err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/user_repo.go
+++ b/internal/infrastructure/persistence/memory/user_repo.go
@@ -43,6 +43,12 @@ func (r *UserRepository) Upsert(_ context.Context, u *user.User) error {
 	return nil
 }
 
+// Bootstrap preserves the in-memory repository's historical seed behavior. Durable
+// audit-chain guarantees are provided by the PostgreSQL implementation.
+func (r *UserRepository) Bootstrap(ctx context.Context, u *user.User, _ ports.AuditEntry) error {
+	return r.Upsert(ctx, u)
+}
+
 func (r *UserRepository) GetByID(_ context.Context, id shared.ID) (*user.User, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/infrastructure/persistence/postgres/aup_audit.go
+++ b/internal/infrastructure/persistence/postgres/aup_audit.go
@@ -164,6 +164,38 @@ func (l *AuditLog) VerifyGlobal(ctx context.Context) (audit.Report, error) {
 	return audit.Verify(toRecords(entries)), nil
 }
 
+// MigrationMetadata returns each migration's latest recorded state in version order.
+// It makes no schema changes and is intended for offline restore verification.
+func (l *AuditLog) MigrationMetadata(ctx context.Context) ([]ports.MigrationMetadata, error) {
+	rows, err := l.pool.Query(ctx, `SELECT version_id, is_applied
+		FROM (
+			SELECT DISTINCT ON (version_id) version_id, is_applied
+			FROM goose_db_version
+			WHERE version_id > 0
+			ORDER BY version_id, id DESC
+		) AS latest
+		ORDER BY version_id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("read migration metadata: %w", err)
+	}
+	defer rows.Close()
+	out := []ports.MigrationMetadata{}
+	for rows.Next() {
+		var state ports.MigrationMetadata
+		if err := rows.Scan(&state.Version, &state.Applied); err != nil {
+			return nil, fmt.Errorf("scan migration metadata: %w", err)
+		}
+		out = append(out, state)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read migration metadata rows: %w", err)
+	}
+	return out, nil
+}
+
+var _ ports.RestoreAuditReader = (*AuditLog)(nil)
+var _ ports.RestoreMigrationReader = (*AuditLog)(nil)
+
 func (l *AuditLog) tenantEntries(ctx context.Context) (out []ports.AuditEntry, err error) {
 	err = WithContextTenant(ctx, l.pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx,

--- a/internal/infrastructure/persistence/postgres/db.go
+++ b/internal/infrastructure/persistence/postgres/db.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib" // registers the "pgx" database/sql driver for goose
 	"github.com/pressly/goose/v3"
 
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	"github.com/KKloudTarus/synapse-ce/migrations"
 )
 
@@ -88,6 +89,41 @@ func ConnectPool(ctx context.Context, dsn string, pc PoolConfig) (*pgxpool.Pool,
 // Connect opens a pgx pool with default sizing (back-compat wrapper).
 func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	return ConnectPool(ctx, dsn, PoolConfig{})
+}
+
+// PoolStatsSource exposes aggregate pool saturation through a driver-free port so the
+// metrics adapter never depends on pgx.
+type PoolStatsSource struct{ pool *pgxpool.Pool }
+
+var _ ports.PoolStatsReader = (*PoolStatsSource)(nil)
+
+// NewPoolStatsSource returns nil for a nil pool so a composition root can pass the result
+// straight to an optional collector without constructing a typed-nil interface.
+func NewPoolStatsSource(pool *pgxpool.Pool) *PoolStatsSource {
+	if pool == nil {
+		return nil
+	}
+	return &PoolStatsSource{pool: pool}
+}
+
+// PoolStats snapshots the pool's aggregate counters; it carries no connection identity.
+func (s *PoolStatsSource) PoolStats() ports.PoolStats {
+	stats := s.pool.Stat()
+	return ports.PoolStats{
+		AcquiredConns:        stats.AcquiredConns(),
+		ConstructingConns:    stats.ConstructingConns(),
+		IdleConns:            stats.IdleConns(),
+		MaxConns:             stats.MaxConns(),
+		TotalConns:           stats.TotalConns(),
+		AcquireCount:         stats.AcquireCount(),
+		CanceledAcquireCount: stats.CanceledAcquireCount(),
+		EmptyAcquireCount:    stats.EmptyAcquireCount(),
+		NewConnsCount:        stats.NewConnsCount(),
+		MaxIdleDestroyCount:  stats.MaxIdleDestroyCount(),
+		MaxLifetimeDestroy:   stats.MaxLifetimeDestroyCount(),
+		AcquireDuration:      stats.AcquireDuration(),
+		EmptyAcquireWaitTime: stats.EmptyAcquireWaitTime(),
+	}
 }
 
 // singletonLockKey derives a stable advisory-lock key PER ROLE. Scoping by

--- a/internal/infrastructure/persistence/postgres/evidence_repo.go
+++ b/internal/infrastructure/persistence/postgres/evidence_repo.go
@@ -17,10 +17,44 @@ import (
 // EvidenceStore persists the per-engagement hash-chained evidence ledger.
 type EvidenceStore struct{ pool *pgxpool.Pool }
 
+// RestoreEvidenceStore enumerates a restored evidence ledger. It has no write
+// methods and is constructed only after the database identity is proven able to
+// bypass tenant RLS for recovery verification.
+type RestoreEvidenceStore struct{ pool *pgxpool.Pool }
+
+// RestoreEvidenceChain is one engagement's restored evidence ledger in chain order.
+type RestoreEvidenceChain = ports.RestoreEvidenceChain
+
 // NewEvidenceStore returns a store backed by the given pool.
 func NewEvidenceStore(pool *pgxpool.Pool) *EvidenceStore { return &EvidenceStore{pool: pool} }
 
+// NewReadOnlyEvidenceStore constructs a recovery-only reader. The connection
+// identity must have rolbypassrls, or be the explicitly verified database owner;
+// normal application identities fail closed rather than relying on row_security.
+// The returned reader opens every enumeration transaction READ ONLY.
+func NewReadOnlyEvidenceStore(ctx context.Context, pool *pgxpool.Pool) (*RestoreEvidenceStore, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("%w: restore evidence store requires database pool", shared.ErrValidation)
+	}
+	var bypassRLS, databaseOwner bool
+	if err := pool.QueryRow(ctx, `SELECT r.rolbypassrls, r.oid = d.datdba
+		FROM pg_roles r
+		JOIN pg_database d ON d.datname = current_database()
+		WHERE r.rolname = current_user`).Scan(&bypassRLS, &databaseOwner); err != nil {
+		return nil, fmt.Errorf("restore evidence: inspect database identity: %w", err)
+	}
+	if !restoreRoleEligible(bypassRLS, databaseOwner) {
+		return nil, fmt.Errorf("restore evidence: database identity must have BYPASSRLS or own the restored database")
+	}
+	return &RestoreEvidenceStore{pool: pool}, nil
+}
+
+func restoreRoleEligible(bypassRLS, databaseOwner bool) bool {
+	return bypassRLS || databaseOwner
+}
+
 var _ ports.EvidenceStore = (*EvidenceStore)(nil)
+var _ ports.RestoreEvidenceReader = (*RestoreEvidenceStore)(nil)
 
 // Append inserts sealed evidence items in order, in one transaction (append-only).
 func (r *EvidenceStore) Append(ctx context.Context, items []evidence.Evidence) error {
@@ -39,7 +73,7 @@ func (r *EvidenceStore) Append(ctx context.Context, items []evidence.Evidence) e
 			}
 			if _, err := tx.Exec(ctx,
 				`INSERT INTO evidence (id, tenant_id, finding_id, engagement_id, kind, sha256, previous_hash, storage_ref, content, created_by, created_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 				e.ID.String(), tenantID.String(), findingID, e.EngagementID.String(), e.Kind, e.Hash, e.PreviousHash, e.StorageRef, e.Content, e.CreatedBy, e.CreatedAt); err != nil {
 				var pgErr *pgconn.PgError
 				if errors.As(err, &pgErr) && pgErr.Code == "23505" {
@@ -78,6 +112,51 @@ func (r *EvidenceStore) ListByEngagement(ctx context.Context, engagementID share
 		return rows.Err()
 	})
 	return out, err
+}
+
+// ListEvidenceChains enumerates every restored chain only inside a READ ONLY
+// transaction. It neither sets row_security nor assumes that a normal RLS role
+// can disable it; construction has already required the recovery identity.
+func (r *RestoreEvidenceStore) ListEvidenceChains(ctx context.Context) ([]RestoreEvidenceChain, error) {
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return nil, fmt.Errorf("restore evidence: begin read-only transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx, `SELECT id, COALESCE(finding_id,''), engagement_id, kind, sha256,
+		COALESCE(previous_hash,''), COALESCE(storage_ref,''), content, COALESCE(created_by,''), created_at
+		FROM evidence ORDER BY engagement_id ASC, seq ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("restore evidence: list chains: %w", err)
+	}
+	defer rows.Close()
+
+	chains := make([]RestoreEvidenceChain, 0)
+	byEngagement := make(map[shared.ID]int)
+	for rows.Next() {
+		var (
+			e            evidence.Evidence
+			id, fid, eid string
+		)
+		if err := rows.Scan(&id, &fid, &eid, &e.Kind, &e.Hash, &e.PreviousHash, &e.StorageRef, &e.Content, &e.CreatedBy, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("restore evidence: scan chain: %w", err)
+		}
+		e.ID = shared.ID(id)
+		e.FindingID = shared.ID(fid)
+		e.EngagementID = shared.ID(eid)
+		index, ok := byEngagement[e.EngagementID]
+		if !ok {
+			index = len(chains)
+			byEngagement[e.EngagementID] = index
+			chains = append(chains, RestoreEvidenceChain{ID: e.EngagementID})
+		}
+		chains[index].Items = append(chains[index].Items, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("restore evidence: iterate chains: %w", err)
+	}
+	return chains, nil
 }
 
 // Head returns the most recent sealed hash for an engagement ("" if the chain is

--- a/internal/infrastructure/persistence/postgres/evidence_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/evidence_repo_test.go
@@ -54,9 +54,25 @@ func TestPostgresEvidenceForkGuard(t *testing.T) {
 	}
 }
 
-// TestPostgresEvidenceVerifyRoundTrip covers the re-audit hash change: a chain sealed with
-// created_by/created_at bound into the hash must still VerifyChain after a Postgres
-// round-trip (the hash truncates the timestamp to µs to match timestamptz precision).
+// TestRestoreRoleEligible documents the recovery identity contract: a normal
+// application role may not enumerate all tenant chains under RLS.
+func TestRestoreRoleEligible(t *testing.T) {
+	for _, test := range []struct {
+		name                   string
+		bypassRLS, owner, want bool
+	}{
+		{name: "bypass RLS role", bypassRLS: true, want: true},
+		{name: "database owner", owner: true, want: true},
+		{name: "normal application role", want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := restoreRoleEligible(test.bypassRLS, test.owner); got != test.want {
+				t.Fatalf("restoreRoleEligible(%v, %v) = %v, want %v", test.bypassRLS, test.owner, got, test.want)
+			}
+		})
+	}
+}
+
 func TestPostgresEvidenceVerifyRoundTrip(t *testing.T) {
 	dsn := testDSN(t)
 	ctx := context.Background()

--- a/internal/infrastructure/persistence/postgres/identity_store.go
+++ b/internal/infrastructure/persistence/postgres/identity_store.go
@@ -1,0 +1,225 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/identity"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// IdentityStore persists OIDC identity/session records under the tenant RLS boundary.
+type IdentityStore struct{ pool *pgxpool.Pool }
+
+// NewIdentityStore returns a PostgreSQL-backed OIDC identity/session store.
+func NewIdentityStore(pool *pgxpool.Pool) (*IdentityStore, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("%w: identity store requires pool", shared.ErrValidation)
+	}
+	return &IdentityStore{pool: pool}, nil
+}
+
+var _ ports.IdentityStore = (*IdentityStore)(nil)
+
+func (s *IdentityStore) CreateExternalIdentity(ctx context.Context, external identity.ExternalIdentity) error {
+	return WithTenant(ctx, s.pool, external.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO oidc_external_identities
+			(id, tenant_id, user_id, issuer, subject, created_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7)`, external.ID.String(), external.TenantID.String(), external.UserID.String(), external.Issuer, external.Subject, external.CreatedAt, external.UpdatedAt)
+		if err == nil {
+			return nil
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23505":
+				return fmt.Errorf("OIDC issuer/subject already linked: %w", shared.ErrConflict)
+			case "23503":
+				return fmt.Errorf("OIDC identity user tenant link is invalid: %w", shared.ErrForbidden)
+			}
+		}
+		return fmt.Errorf("create OIDC external identity: %w", err)
+	})
+}
+
+func (s *IdentityStore) GetExternalIdentity(ctx context.Context, issuer, subject string) (external identity.ExternalIdentity, err error) {
+	err = WithContextTenant(ctx, s.pool, func(tx pgx.Tx) error {
+		external, err = scanExternalIdentity(tx.QueryRow(ctx, `SELECT id, tenant_id, user_id, issuer, subject, created_at, updated_at
+			FROM oidc_external_identities WHERE issuer=$1 AND subject=$2`, issuer, subject))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get OIDC external identity: %w", err)
+		}
+		return nil
+	})
+	return external, err
+}
+
+func (s *IdentityStore) CreateAuthorizationTransaction(ctx context.Context, transaction identity.AuthorizationTransaction) error {
+	return WithTenant(ctx, s.pool, transaction.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO oidc_authorization_transactions
+			(id, tenant_id, state_hash, nonce_hash, pkce_verifier_ciphertext, created_at, expires_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7)`, transaction.ID.String(), transaction.TenantID.String(), transaction.StateHash, transaction.NonceHash, transaction.PKCEVerifierCiphertext, transaction.CreatedAt, transaction.ExpiresAt)
+		if err == nil {
+			return nil
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return fmt.Errorf("OIDC authorization state already exists: %w", shared.ErrConflict)
+		}
+		return fmt.Errorf("create OIDC authorization transaction: %w", err)
+	})
+}
+
+// ConsumeAuthorizationTransaction atomically deletes and returns an unexpired transaction, making
+// the state unusable by every concurrent request and every API replica after the first succeeds.
+func (s *IdentityStore) ConsumeAuthorizationTransaction(ctx context.Context, tenantID shared.ID, stateHash string, now time.Time) (transaction identity.AuthorizationTransaction, err error) {
+	if tenantID.IsZero() {
+		return identity.AuthorizationTransaction{}, fmt.Errorf("%w: authorization transaction tenant is required", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, purgeErr := tx.Exec(ctx, `DELETE FROM oidc_authorization_transactions WHERE tenant_id=$1 AND expires_at <= $2`, tenantID.String(), now.UTC()); purgeErr != nil {
+			return fmt.Errorf("purge expired OIDC authorization transactions: %w", purgeErr)
+		}
+		transaction, err = scanAuthorizationTransaction(tx.QueryRow(ctx, `DELETE FROM oidc_authorization_transactions
+			WHERE tenant_id=$1 AND state_hash=$2 AND expires_at > $3
+			RETURNING id, tenant_id, state_hash, nonce_hash, pkce_verifier_ciphertext, created_at, expires_at`, tenantID.String(), stateHash, now.UTC()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("consume OIDC authorization transaction: %w", err)
+		}
+		return nil
+	})
+	return transaction, err
+}
+
+func (s *IdentityStore) CreateSession(ctx context.Context, session identity.Session) error {
+	metadata, err := json.Marshal(session.Metadata)
+	if err != nil {
+		return fmt.Errorf("marshal session metadata: %w", err)
+	}
+	return WithTenant(ctx, s.pool, session.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO oidc_sessions
+			(id, tenant_id, user_id, token_hash, csrf_token_hash, metadata, created_at, updated_at, expires_at, revoked_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, session.ID.String(), session.TenantID.String(), session.UserID.String(), session.TokenHash, session.CSRFTokenHash, metadata, session.CreatedAt, session.UpdatedAt, session.ExpiresAt, session.RevokedAt)
+		if err == nil {
+			return nil
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23505":
+				return fmt.Errorf("OIDC session already exists: %w", shared.ErrConflict)
+			case "23503":
+				return fmt.Errorf("OIDC session user tenant link is invalid: %w", shared.ErrForbidden)
+			}
+		}
+		return fmt.Errorf("create OIDC session: %w", err)
+	})
+}
+
+// RotateSession creates replacement and revokes the active previous session in one transaction.
+func (s *IdentityStore) RotateSession(ctx context.Context, previousSessionID shared.ID, replacement identity.Session, now time.Time) error {
+	metadata, err := json.Marshal(replacement.Metadata)
+	if err != nil {
+		return fmt.Errorf("marshal replacement session metadata: %w", err)
+	}
+	return WithTenant(ctx, s.pool, replacement.TenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO oidc_sessions
+			(id, tenant_id, user_id, token_hash, csrf_token_hash, metadata, created_at, updated_at, expires_at, revoked_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, replacement.ID.String(), replacement.TenantID.String(), replacement.UserID.String(), replacement.TokenHash, replacement.CSRFTokenHash, metadata, replacement.CreatedAt, replacement.UpdatedAt, replacement.ExpiresAt, replacement.RevokedAt); err != nil {
+			return fmt.Errorf("create replacement OIDC session: %w", err)
+		}
+		tag, err := tx.Exec(ctx, `UPDATE oidc_sessions SET revoked_at=$4, updated_at=$4
+			WHERE id=$1 AND tenant_id=$2 AND user_id=$3 AND revoked_at IS NULL AND expires_at > $4`, previousSessionID.String(), replacement.TenantID.String(), replacement.UserID.String(), now.UTC())
+		if err != nil {
+			return fmt.Errorf("revoke previous OIDC session: %w", err)
+		}
+		if tag.RowsAffected() != 1 {
+			return fmt.Errorf("previous OIDC session is not active: %w", shared.ErrConflict)
+		}
+		return nil
+	})
+}
+
+func (s *IdentityStore) GetSessionByTokenHash(ctx context.Context, tokenHash string) (session identity.Session, err error) {
+	err = WithContextTenant(ctx, s.pool, func(tx pgx.Tx) error {
+		session, err = scanSession(tx.QueryRow(ctx, `SELECT id, tenant_id, user_id, token_hash, csrf_token_hash, metadata, created_at, updated_at, expires_at, revoked_at
+			FROM oidc_sessions WHERE token_hash=$1`, tokenHash))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get OIDC session: %w", err)
+		}
+		return nil
+	})
+	return session, err
+}
+
+func (s *IdentityStore) RevokeSession(ctx context.Context, tenantID, sessionID shared.ID, now time.Time) error {
+	return WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE oidc_sessions SET revoked_at=$3, updated_at=$3
+			WHERE id=$1 AND tenant_id=$2 AND revoked_at IS NULL`, sessionID.String(), tenantID.String(), now.UTC())
+		if err != nil {
+			return fmt.Errorf("revoke OIDC session: %w", err)
+		}
+		if tag.RowsAffected() == 1 {
+			return nil
+		}
+		var exists bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM oidc_sessions WHERE id=$1 AND tenant_id=$2)`, sessionID.String(), tenantID.String()).Scan(&exists); err != nil {
+			return fmt.Errorf("check OIDC session: %w", err)
+		}
+		if exists {
+			return fmt.Errorf("OIDC session already revoked: %w", shared.ErrConflict)
+		}
+		return shared.ErrNotFound
+	})
+}
+
+func scanExternalIdentity(row rowScanner) (identity.ExternalIdentity, error) {
+	var external identity.ExternalIdentity
+	var id, tenantID, userID string
+	if err := row.Scan(&id, &tenantID, &userID, &external.Issuer, &external.Subject, &external.CreatedAt, &external.UpdatedAt); err != nil {
+		return identity.ExternalIdentity{}, err
+	}
+	external.ID, external.TenantID, external.UserID = shared.ID(id), shared.ID(tenantID), shared.ID(userID)
+	return external, nil
+}
+
+func scanAuthorizationTransaction(row rowScanner) (identity.AuthorizationTransaction, error) {
+	var transaction identity.AuthorizationTransaction
+	var id, tenantID string
+	if err := row.Scan(&id, &tenantID, &transaction.StateHash, &transaction.NonceHash, &transaction.PKCEVerifierCiphertext, &transaction.CreatedAt, &transaction.ExpiresAt); err != nil {
+		return identity.AuthorizationTransaction{}, err
+	}
+	transaction.ID, transaction.TenantID = shared.ID(id), shared.ID(tenantID)
+	return transaction, nil
+}
+
+func scanSession(row rowScanner) (identity.Session, error) {
+	var session identity.Session
+	var id, tenantID, userID string
+	var metadata []byte
+	if err := row.Scan(&id, &tenantID, &userID, &session.TokenHash, &session.CSRFTokenHash, &metadata, &session.CreatedAt, &session.UpdatedAt, &session.ExpiresAt, &session.RevokedAt); err != nil {
+		return identity.Session{}, err
+	}
+	if err := json.Unmarshal(metadata, &session.Metadata); err != nil {
+		return identity.Session{}, fmt.Errorf("decode session metadata: %w", err)
+	}
+	session.ID, session.TenantID, session.UserID = shared.ID(id), shared.ID(tenantID), shared.ID(userID)
+	return session, nil
+}

--- a/internal/infrastructure/persistence/postgres/identity_store.go
+++ b/internal/infrastructure/persistence/postgres/identity_store.go
@@ -112,8 +112,8 @@ func (s *IdentityStore) CreateSession(ctx context.Context, session identity.Sess
 	}
 	return WithTenant(ctx, s.pool, session.TenantID.String(), func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `INSERT INTO oidc_sessions
-			(id, tenant_id, user_id, token_hash, csrf_token_hash, metadata, created_at, updated_at, expires_at, revoked_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, session.ID.String(), session.TenantID.String(), session.UserID.String(), session.TokenHash, session.CSRFTokenHash, metadata, session.CreatedAt, session.UpdatedAt, session.ExpiresAt, session.RevokedAt)
+			(id, tenant_id, user_id, token_hash, csrf_token_hash, metadata, created_at, updated_at, expires_at, revoked_at, origin_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, session.ID.String(), session.TenantID.String(), session.UserID.String(), session.TokenHash, session.CSRFTokenHash, metadata, session.CreatedAt, session.UpdatedAt, session.ExpiresAt, session.RevokedAt, session.OriginAt)
 		if err == nil {
 			return nil
 		}
@@ -138,8 +138,8 @@ func (s *IdentityStore) RotateSession(ctx context.Context, previousSessionID sha
 	}
 	return WithTenant(ctx, s.pool, replacement.TenantID.String(), func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `INSERT INTO oidc_sessions
-			(id, tenant_id, user_id, token_hash, csrf_token_hash, metadata, created_at, updated_at, expires_at, revoked_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, replacement.ID.String(), replacement.TenantID.String(), replacement.UserID.String(), replacement.TokenHash, replacement.CSRFTokenHash, metadata, replacement.CreatedAt, replacement.UpdatedAt, replacement.ExpiresAt, replacement.RevokedAt); err != nil {
+			(id, tenant_id, user_id, token_hash, csrf_token_hash, metadata, created_at, updated_at, expires_at, revoked_at, origin_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, replacement.ID.String(), replacement.TenantID.String(), replacement.UserID.String(), replacement.TokenHash, replacement.CSRFTokenHash, metadata, replacement.CreatedAt, replacement.UpdatedAt, replacement.ExpiresAt, replacement.RevokedAt, replacement.OriginAt); err != nil {
 			return fmt.Errorf("create replacement OIDC session: %w", err)
 		}
 		tag, err := tx.Exec(ctx, `UPDATE oidc_sessions SET revoked_at=$4, updated_at=$4
@@ -156,7 +156,7 @@ func (s *IdentityStore) RotateSession(ctx context.Context, previousSessionID sha
 
 func (s *IdentityStore) GetSessionByTokenHash(ctx context.Context, tokenHash string) (session identity.Session, err error) {
 	err = WithContextTenant(ctx, s.pool, func(tx pgx.Tx) error {
-		session, err = scanSession(tx.QueryRow(ctx, `SELECT id, tenant_id, user_id, token_hash, csrf_token_hash, metadata, created_at, updated_at, expires_at, revoked_at
+		session, err = scanSession(tx.QueryRow(ctx, `SELECT id, tenant_id, user_id, token_hash, csrf_token_hash, metadata, created_at, updated_at, expires_at, revoked_at, origin_at
 			FROM oidc_sessions WHERE token_hash=$1`, tokenHash))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return shared.ErrNotFound
@@ -214,7 +214,7 @@ func scanSession(row rowScanner) (identity.Session, error) {
 	var session identity.Session
 	var id, tenantID, userID string
 	var metadata []byte
-	if err := row.Scan(&id, &tenantID, &userID, &session.TokenHash, &session.CSRFTokenHash, &metadata, &session.CreatedAt, &session.UpdatedAt, &session.ExpiresAt, &session.RevokedAt); err != nil {
+	if err := row.Scan(&id, &tenantID, &userID, &session.TokenHash, &session.CSRFTokenHash, &metadata, &session.CreatedAt, &session.UpdatedAt, &session.ExpiresAt, &session.RevokedAt, &session.OriginAt); err != nil {
 		return identity.Session{}, err
 	}
 	if err := json.Unmarshal(metadata, &session.Metadata); err != nil {

--- a/internal/infrastructure/persistence/postgres/identity_store_test.go
+++ b/internal/infrastructure/persistence/postgres/identity_store_test.go
@@ -1,0 +1,120 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/identity"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/user"
+)
+
+func TestPostgresIdentityStore(t *testing.T) {
+	dsn := testDSN(t)
+	base := context.Background()
+	if err := Migrate(base, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(base, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	ctx := shared.WithTenant(base, shared.DefaultTenant)
+	if _, err := pool.Exec(base, `TRUNCATE oidc_sessions, oidc_authorization_transactions, oidc_external_identities CASCADE`); err != nil {
+		t.Fatalf("truncate identity tables: %v", err)
+	}
+	if _, err := pool.Exec(base, `INSERT INTO tenants(id,name) VALUES ('default', 'default tenant') ON CONFLICT (id) DO NOTHING`); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	users := NewUserRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	u, err := user.New(shared.ID("oidc-user-"+randHex(t)), "default", "OIDC User", user.RoleMember, "key-"+randHex(t), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := users.Create(base, u); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	store, err := NewIdentityStore(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	external, _ := identity.NewExternalIdentity("identity-"+shared.ID(randHex(t)), "default", u.ID, "https://issuer", "subject", now)
+	if err := store.CreateExternalIdentity(ctx, external); err != nil {
+		t.Fatalf("link external identity: %v", err)
+	}
+	if err := store.CreateExternalIdentity(ctx, external); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate issuer/subject must conflict: %v", err)
+	}
+	if got, err := store.GetExternalIdentity(ctx, external.Issuer, external.Subject); err != nil || got.UserID != u.ID {
+		t.Fatalf("identity lookup: got=%+v err=%v", got, err)
+	}
+
+	transaction, _ := identity.NewAuthorizationTransaction("tx-"+shared.ID(randHex(t)), "default", "state-"+randHex(t), "nonce-hash", "ciphertext", now.Add(time.Minute), now)
+	if err := store.CreateAuthorizationTransaction(ctx, transaction); err != nil {
+		t.Fatalf("create transaction: %v", err)
+	}
+	var wg sync.WaitGroup
+	var successes int
+	var mu sync.Mutex
+	for range 12 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := store.ConsumeAuthorizationTransaction(ctx, "default", transaction.StateHash, now); err == nil {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if successes != 1 {
+		t.Fatalf("only one replica may consume a transaction, got %d", successes)
+	}
+	expired, _ := identity.NewAuthorizationTransaction("expired-"+shared.ID(randHex(t)), "default", "expired-"+randHex(t), "nonce", "ciphertext", now.Add(time.Second), now)
+	if err := store.CreateAuthorizationTransaction(ctx, expired); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ConsumeAuthorizationTransaction(ctx, "default", expired.StateHash, now.Add(time.Second)); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("expired transaction must not be consumable: %v", err)
+	}
+
+	session, _ := identity.NewSession("session-"+shared.ID(randHex(t)), "default", u.ID, "token-"+randHex(t), "csrf-hash", map[string]string{"ip": "127.0.0.1"}, now.Add(time.Hour), now)
+	if err := store.CreateSession(ctx, session); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	replacement, _ := identity.NewSession("replacement-"+shared.ID(randHex(t)), "default", u.ID, "replacement-token-"+randHex(t), "replacement-csrf", nil, now.Add(time.Hour), now)
+	if err := store.RotateSession(ctx, session.ID, replacement, now.Add(time.Second)); err != nil {
+		t.Fatalf("rotate session: %v", err)
+	}
+	oldSession, err := store.GetSessionByTokenHash(ctx, session.TokenHash)
+	if err != nil || oldSession.RevokedAt == nil || oldSession.Active(now.Add(time.Second)) {
+		t.Fatalf("rotated session must revoke old token: got=%+v err=%v", oldSession, err)
+	}
+	if got, err := store.GetSessionByTokenHash(ctx, replacement.TokenHash); err != nil || !got.Active(now.Add(time.Second)) {
+		t.Fatalf("replacement session must be active: got=%+v err=%v", got, err)
+	}
+	second, _ := identity.NewSession("second-"+shared.ID(randHex(t)), "default", u.ID, "second-token-"+randHex(t), "second-csrf", nil, now.Add(time.Hour), now)
+	if err := store.RotateSession(ctx, session.ID, second, now.Add(2*time.Second)); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("rotating a revoked session must fail atomically: %v", err)
+	}
+	if _, err := store.GetSessionByTokenHash(ctx, second.TokenHash); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("failed rotation must not persist replacement: %v", err)
+	}
+	if err := store.RevokeSession(ctx, replacement.TenantID, replacement.ID, now); err != nil {
+		t.Fatalf("revoke session: %v", err)
+	}
+	if err := store.RevokeSession(ctx, replacement.TenantID, replacement.ID, now); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("second revoke must conflict: %v", err)
+	}
+	gotSession, err := store.GetSessionByTokenHash(ctx, replacement.TokenHash)
+	if err != nil || gotSession.RevokedAt == nil || gotSession.Active(now) {
+		t.Fatalf("revoked session must be retained but inactive: got=%+v err=%v", gotSession, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/user_repo.go
+++ b/internal/infrastructure/persistence/postgres/user_repo.go
@@ -44,6 +44,44 @@ func (r *UserRepository) Upsert(ctx context.Context, u *user.User) error {
 	return nil
 }
 
+// Bootstrap atomically seeds or refreshes the bootstrap administrator. The audit row
+// is appended in the same transaction only when the user is first inserted, so
+// concurrent API startups cannot create duplicate bootstrap audit events.
+func (r *UserRepository) Bootstrap(ctx context.Context, u *user.User, auditEntry ports.AuditEntry) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("bootstrap user: begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var inserted bool
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO users (`+userCols+`) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+		 ON CONFLICT (id) DO NOTHING
+		 RETURNING true`,
+		u.ID.String(), u.Name, string(u.Role), u.APIKeyHash, u.Disabled, u.Audit.CreatedAt, u.Audit.UpdatedAt, u.TenantID).Scan(&inserted); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("bootstrap user: insert: %w", err)
+	}
+	if !inserted {
+		if _, err := tx.Exec(ctx,
+			`UPDATE users SET name=$2, role=$3, api_key_hash=$4, disabled=$5, updated_at=$6, tenant_id=$7 WHERE id=$1`,
+			u.ID.String(), u.Name, string(u.Role), u.APIKeyHash, u.Disabled, u.Audit.UpdatedAt, u.TenantID); err != nil {
+			return fmt.Errorf("bootstrap user: refresh: %w", err)
+		}
+	} else {
+		if _, err := tx.Exec(ctx, "SELECT set_config('app.current_tenant', $1, true)", shared.DefaultTenant.String()); err != nil {
+			return fmt.Errorf("bootstrap user: set audit tenant: %w", err)
+		}
+		if err := appendTenantAudit(ctx, tx, shared.DefaultTenant.String(), auditEntry); err != nil {
+			return fmt.Errorf("bootstrap user: audit: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("bootstrap user: commit: %w", err)
+	}
+	return nil
+}
+
 func (r *UserRepository) GetByID(ctx context.Context, id shared.ID) (*user.User, error) {
 	u, err := scanUser(r.pool.QueryRow(ctx, `SELECT `+userCols+` FROM users WHERE id=$1`, id.String()))
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/infrastructure/persistence/postgres/user_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/user_repo_test.go
@@ -2,17 +2,73 @@ package postgres
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 // TestUserRepoTenantRoundTrip covers the tenant source (migration 0035): a user's
 // tenant_id persists and round-trips through GetByAPIKeyHash – the auth path the Principal
 // resolves its tenant from. A user created without one defaults to ” (single-tenant). Gated
 // on SYNAPSE_TEST_DB_DSN.
+func TestBootstrapIsConcurrentAndAuditedOnce(t *testing.T) {
+	dsn := testDSN(t)
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := shared.ID("bootstrap-" + randHex(t))
+	u, err := user.New(id, "", "Bootstrap", user.RoleAdmin, "hash-"+randHex(t), time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditEntry := ports.AuditEntry{
+		Actor: id.String(), Action: "user.bootstrap_admin_seeded", Target: id.String(),
+		Metadata: map[string]string{"idempotency_key": "bootstrap-admin:" + id.String()}, At: time.Now().UTC(),
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- NewUserRepository(pool).Bootstrap(context.Background(), u, auditEntry)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent bootstrap: %v", err)
+		}
+	}
+
+	var users, audits int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM users WHERE id=$1`, id.String()).Scan(&users); err != nil {
+		t.Fatalf("count bootstrap users: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM audit_log WHERE action=$1 AND target=$2`, auditEntry.Action, auditEntry.Target).Scan(&audits); err != nil {
+		t.Fatalf("count bootstrap audits: %v", err)
+	}
+	if users != 1 || audits != 1 {
+		t.Fatalf("bootstrap rows = users:%d audits:%d, want one each", users, audits)
+	}
+}
+
 func TestUserRepoTenantRoundTrip(t *testing.T) {
 	dsn := testDSN(t)
 	ctx := context.Background()

--- a/internal/infrastructure/sandbox/runner.go
+++ b/internal/infrastructure/sandbox/runner.go
@@ -163,10 +163,16 @@ func NewRunner(timeout time.Duration, maxOut int, memMax int64, pidsMax int) (*R
 	if !seccompSupported {
 		return nil, fmt.Errorf("%w: seccomp filtering is required but unsupported on this platform", ErrUnavailable)
 	}
-	if f, serr := seccompFile(); serr != nil {
-		return nil, fmt.Errorf("%w: seccomp self-check failed: %v", ErrUnavailable, serr)
-	} else {
-		_ = f.Close()
+	filter, err := seccompFile()
+	if err != nil {
+		return nil, fmt.Errorf("%w: seccomp self-check failed: %v", ErrUnavailable, err)
+	}
+	defer func() { _ = filter.Close() }()
+	// Finding bwrap on PATH is insufficient in a container: the runtime seccomp profile or
+	// kernel policy can still deny namespace/mount setup. Exercise the same namespace and
+	// seccomp primitives used for real runs so production startup fails before accepting work.
+	if err := probeBubblewrap(bwrap, filter); err != nil {
+		return nil, fmt.Errorf("%w: bubblewrap isolation self-check failed: %v", ErrUnavailable, err)
 	}
 	slots := make(chan int, netnsSlotCount)
 	for i := 0; i < netnsSlotCount; i++ {
@@ -183,6 +189,38 @@ func NewRunner(timeout time.Duration, maxOut int, memMax int64, pidsMax int) (*R
 		r.systemdRun = sd
 	}
 	return r, nil
+}
+
+// probeBubblewrap verifies that this process can create the namespace, mount, and seccomp
+// boundary required by the runner. It executes only /bin/true in a read-only view of the host;
+// no user-controlled argv, environment, or filesystem content enters this startup check.
+func probeBubblewrap(bwrap string, filter *os.File) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bwrap,
+		"--unshare-all",
+		"--die-with-parent",
+		"--new-session",
+		"--ro-bind", "/", "/",
+		"--seccomp", "3",
+		"--", "/bin/true",
+	)
+	cmd.ExtraFiles = []*os.File{filter}
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return fmt.Errorf("probe timed out: %w", ctx.Err())
+	}
+	message := strings.TrimSpace(string(output))
+	if len(message) > 512 {
+		message = message[:512]
+	}
+	if message == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, message)
 }
 
 // CgroupLimitsEnforced reports whether cgroup resource limits are actually applied

--- a/internal/infrastructure/sandbox/runner_test.go
+++ b/internal/infrastructure/sandbox/runner_test.go
@@ -21,6 +21,20 @@ func fakeRunner(systemdRun string) *Runner {
 	return &Runner{bwrap: "/usr/bin/bwrap", systemdRun: systemdRun, memMax: 256 << 20, pidsMax: 128}
 }
 
+func TestProbeBubblewrapRejectsMissingExecutable(t *testing.T) {
+	if !seccompSupported {
+		t.Skip("seccomp probe is Linux-only")
+	}
+	filter, err := seccompFile()
+	if err != nil {
+		t.Fatalf("build seccomp filter: %v", err)
+	}
+	defer func() { _ = filter.Close() }()
+	if err := probeBubblewrap(filepath.Join(t.TempDir(), "missing-bwrap"), filter); err == nil {
+		t.Fatal("probeBubblewrap must reject an unusable executable")
+	}
+}
+
 func TestSandboxArgvConfinesTheRun(t *testing.T) {
 	r := fakeRunner("")
 	argv := r.command(ports.ToolSpec{Name: "subfinder", Args: []string{"-d", "example.com"}, Workdir: "/run/work"}, "", "", 3, false)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -38,6 +39,17 @@ type Config struct {
 
 	// APIToken protects all API + UI routes; required (no anonymous access).
 	APIToken string
+	// OIDCEnabled enables the browser-based OIDC authorization-code BFF flow.
+	OIDCEnabled          bool
+	OIDCIssuer           string
+	OIDCClientID         string
+	OIDCClientSecret     string
+	OIDCRedirectURL      string
+	OIDCFrontendURL      string
+	OIDCTenantID         string
+	OIDCGroupRoleMapping []string
+	OIDCTransactionTTL   time.Duration
+	OIDCSessionTTL       time.Duration
 	// AUPVersion is the current Acceptable-Use Policy version.
 	AUPVersion string
 	// AUPFile is where first-run AUP acceptance is recorded (file-backed until Postgres).
@@ -535,6 +547,16 @@ func Load() Config {
 		LogLevel:                         getenv("SYNAPSE_LOG_LEVEL", "info"),
 		SingleTenant:                     getbool("SYNAPSE_SINGLE_TENANT", true),
 		APIToken:                         getenv("SYNAPSE_API_TOKEN", ""),
+		OIDCEnabled:                      getbool("SYNAPSE_OIDC_ENABLED", false),
+		OIDCIssuer:                       getenv("SYNAPSE_OIDC_ISSUER", ""),
+		OIDCClientID:                     getenv("SYNAPSE_OIDC_CLIENT_ID", ""),
+		OIDCClientSecret:                 getenv("SYNAPSE_OIDC_CLIENT_SECRET", ""),
+		OIDCRedirectURL:                  getenv("SYNAPSE_OIDC_REDIRECT_URL", ""),
+		OIDCFrontendURL:                  getenv("SYNAPSE_OIDC_FRONTEND_URL", ""),
+		OIDCTenantID:                     getenv("SYNAPSE_OIDC_TENANT_ID", ""),
+		OIDCGroupRoleMapping:             splitList(getenv("SYNAPSE_OIDC_GROUP_ROLE_MAPPING", "")),
+		OIDCTransactionTTL:               getduration("SYNAPSE_OIDC_TRANSACTION_TTL", 10*time.Minute),
+		OIDCSessionTTL:                   getduration("SYNAPSE_OIDC_SESSION_TTL", 8*time.Hour),
 		AUPVersion:                       getenv("SYNAPSE_AUP_VERSION", "1.0"),
 		AUPFile:                          getenv("SYNAPSE_AUP_FILE", "data/aup-accepted.json"),
 		AuditFile:                        getenv("SYNAPSE_AUDIT_FILE", "data/audit.jsonl"),
@@ -872,7 +894,29 @@ func (c Config) ValidateMigrationPosture() error {
 	if c.IsProduction() && c.DBAutoMigrate {
 		return errors.New("SYNAPSE_DB_AUTO_MIGRATE=false is required in production; run synapse-migrate before starting services")
 	}
+	if c.IsProduction() && c.OIDCEnabled && c.DBDSN == "" {
+		return errors.New("SYNAPSE_DB_DSN is required when OIDC is enabled in production")
+	}
 	return nil
+}
+
+// ValidateOIDCPosture fails closed when the browser OIDC BFF cannot bind identity/session state to a fixed tenant.
+func (c Config) ValidateOIDCPosture() error {
+	if !c.OIDCEnabled {
+		return nil
+	}
+	if strings.TrimSpace(c.OIDCIssuer) == "" || strings.TrimSpace(c.OIDCClientID) == "" || strings.TrimSpace(c.OIDCClientSecret) == "" || strings.TrimSpace(c.OIDCRedirectURL) == "" || strings.TrimSpace(c.OIDCTenantID) == "" || len(c.OIDCGroupRoleMapping) == 0 || c.OIDCTransactionTTL <= 0 || c.OIDCSessionTTL <= 0 {
+		return errors.New("OIDC requires issuer, client id, client secret, redirect URL, fixed tenant, group-role mapping, and positive lifetimes")
+	}
+	if !validOIDCFrontendURL(c.OIDCFrontendURL) {
+		return errors.New("OIDC requires an absolute HTTPS SYNAPSE_OIDC_FRONTEND_URL without query or fragment")
+	}
+	return nil
+}
+
+func validOIDCFrontendURL(value string) bool {
+	u, err := url.Parse(strings.TrimSpace(value))
+	return err == nil && u.Scheme == "https" && u.Host != "" && u.User == nil && u.RawQuery == "" && u.Fragment == ""
 }
 
 // MigrationDSN returns the DDL credential when configured, falling back to the runtime

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -551,3 +551,30 @@ func TestLoadObservabilityFromEnv(t *testing.T) {
 		t.Error("SYNAPSE_ACCESS_LOG_ENABLED=false must disable access logging")
 	}
 }
+
+func TestValidateOIDCPosture(t *testing.T) {
+	valid := Config{OIDCEnabled: true, OIDCIssuer: "https://issuer.example", OIDCClientID: "client", OIDCClientSecret: "secret", OIDCRedirectURL: "https://synapse.example/api/auth/oidc/callback", OIDCFrontendURL: "https://synapse.example/", OIDCTenantID: "tenant", OIDCGroupRoleMapping: []string{"admins=admin"}, OIDCTransactionTTL: time.Minute, OIDCSessionTTL: time.Hour}
+	if err := valid.ValidateOIDCPosture(); err != nil {
+		t.Fatalf("valid OIDC posture: %v", err)
+	}
+	valid.OIDCClientSecret = ""
+	if err := valid.ValidateOIDCPosture(); err == nil {
+		t.Fatal("missing OIDC client secret must fail")
+	}
+	valid.OIDCClientSecret = "secret"
+	valid.OIDCFrontendURL = "https://synapse.example/?next=https://attacker.example"
+	if err := valid.ValidateOIDCPosture(); err == nil {
+		t.Fatal("request-like OIDC frontend URL must fail")
+	}
+}
+
+func TestProductionOIDCRequiresPostgres(t *testing.T) {
+	cfg := Config{Environment: "production", OIDCEnabled: true, DBAutoMigrate: false}
+	if err := cfg.ValidateMigrationPosture(); err == nil {
+		t.Fatal("production OIDC without database must fail")
+	}
+	cfg.DBDSN = "postgres://synapse"
+	if err := cfg.ValidateMigrationPosture(); err != nil {
+		t.Fatalf("production OIDC with database: %v", err)
+	}
+}

--- a/internal/usecase/benchmark/benchmark.go
+++ b/internal/usecase/benchmark/benchmark.go
@@ -1,0 +1,308 @@
+// Package benchmark reduces fixture-supplied benchmark observations into a
+// deterministic, versioned report. It performs no workload execution or external I/O.
+package benchmark
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strings"
+)
+
+const (
+	InputSchemaVersion  = "synapse-benchmark-input-v1"
+	OutputSchemaVersion = "synapse-benchmark-report-v1"
+)
+
+// Input is a fixture or runner-produced set of measured benchmark observations.
+type Input struct {
+	SchemaVersion string                   `json:"schema_version"`
+	Metadata      Metadata                 `json:"metadata"`
+	Window        Window                   `json:"window"`
+	Requests      []RequestObservation     `json:"requests"`
+	Queue         QueueObservation         `json:"queue"`
+	Pool          PoolObservation          `json:"pool"`
+	Evidence      EvidenceGrowth           `json:"evidence"`
+	Migration     MigrationObservation     `json:"migration"`
+	APIFailovers  []APIFailoverObservation `json:"api_failovers"`
+	Correctness   []CorrectnessObservation `json:"correctness"`
+}
+
+// Metadata identifies exactly what was measured without deriving release or data state.
+type Metadata struct {
+	Environment       string `json:"environment"`
+	EnvironmentDigest string `json:"environment_digest"`
+	Release           string `json:"release"`
+	ReleaseDigest     string `json:"release_digest"`
+	DataDigest        string `json:"data_digest"`
+}
+
+type Window struct {
+	DurationMilliseconds int64 `json:"duration_milliseconds"`
+}
+
+type RequestObservation struct {
+	DurationMilliseconds int64 `json:"duration_milliseconds"`
+	Succeeded            bool  `json:"succeeded"`
+}
+
+type QueueObservation struct {
+	DelayMilliseconds    []int64 `json:"delay_milliseconds"`
+	RecoveryMilliseconds []int64 `json:"recovery_milliseconds"`
+}
+
+type PoolObservation struct {
+	AcquisitionMilliseconds []int64 `json:"acquisition_milliseconds"`
+	SaturationEvents        int64   `json:"saturation_events"`
+}
+
+type EvidenceGrowth struct {
+	DatabaseBeforeBytes int64 `json:"database_before_bytes"`
+	DatabaseAfterBytes  int64 `json:"database_after_bytes"`
+	ObjectBeforeBytes   int64 `json:"object_before_bytes"`
+	ObjectAfterBytes    int64 `json:"object_after_bytes"`
+}
+
+type MigrationObservation struct {
+	DurationMilliseconds int64 `json:"duration_milliseconds"`
+}
+
+type APIFailoverObservation struct {
+	DetectionMilliseconds int64 `json:"detection_milliseconds"`
+	RecoveryMilliseconds  int64 `json:"recovery_milliseconds"`
+	Recovered             bool  `json:"recovered"`
+}
+
+type CorrectnessObservation struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+}
+
+// Report is a deterministic reduction of Input. It never asserts an SLO or target.
+type Report struct {
+	SchemaVersion string                `json:"schema_version"`
+	Metadata      Metadata              `json:"metadata"`
+	Throughput    Throughput            `json:"throughput"`
+	Requests      RequestSummary        `json:"requests"`
+	Queue         QueueSummary          `json:"queue"`
+	Pool          PoolSummary           `json:"pool"`
+	Evidence      EvidenceGrowthSummary `json:"evidence"`
+	Migration     MigrationObservation  `json:"migration"`
+	APIFailover   APIFailoverSummary    `json:"api_failover"`
+	Correctness   CorrectnessSummary    `json:"correctness"`
+}
+
+type Throughput struct {
+	WindowMilliseconds int64   `json:"window_milliseconds"`
+	RequestsPerSecond  float64 `json:"requests_per_second"`
+}
+
+type RequestSummary struct {
+	Count     int64     `json:"count"`
+	Successes int64     `json:"successes"`
+	Failures  int64     `json:"failures"`
+	Duration  Quantiles `json:"duration_milliseconds"`
+}
+
+type QueueSummary struct {
+	Delay    Quantiles `json:"delay_milliseconds"`
+	Recovery Quantiles `json:"recovery_milliseconds"`
+}
+
+type PoolSummary struct {
+	Acquisition      Quantiles `json:"acquisition_milliseconds"`
+	SaturationEvents int64     `json:"saturation_events"`
+}
+
+type EvidenceGrowthSummary struct {
+	DatabaseBeforeBytes int64 `json:"database_before_bytes"`
+	DatabaseAfterBytes  int64 `json:"database_after_bytes"`
+	DatabaseGrowthBytes int64 `json:"database_growth_bytes"`
+	ObjectBeforeBytes   int64 `json:"object_before_bytes"`
+	ObjectAfterBytes    int64 `json:"object_after_bytes"`
+	ObjectGrowthBytes   int64 `json:"object_growth_bytes"`
+}
+
+type APIFailoverSummary struct {
+	Count            int64     `json:"count"`
+	RecoveredCount   int64     `json:"recovered_count"`
+	UnrecoveredCount int64     `json:"unrecovered_count"`
+	Detection        Quantiles `json:"detection_milliseconds"`
+	Recovery         Quantiles `json:"recovery_milliseconds"`
+}
+
+type CorrectnessSummary struct {
+	Checks   int64    `json:"checks"`
+	Failures int64    `json:"failures"`
+	Failed   []string `json:"failed"`
+}
+
+// Quantiles use the nearest-rank method: rank=ceil(p*n), with the first value at rank 1.
+type Quantiles struct {
+	Count int64 `json:"count"`
+	P50   int64 `json:"p50"`
+	P95   int64 `json:"p95"`
+	P99   int64 `json:"p99"`
+}
+
+// DecodeInput accepts exactly one JSON input document and rejects unknown fields.
+func DecodeInput(r io.Reader) (Input, error) {
+	var input Input
+	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&input); err != nil {
+		return Input{}, fmt.Errorf("decode benchmark input: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return Input{}, fmt.Errorf("decode benchmark input: multiple JSON values")
+		}
+		return Input{}, fmt.Errorf("decode benchmark input trailing data: %w", err)
+	}
+	return input, nil
+}
+
+// Evaluate validates and reduces the supplied measurements without making any measurements itself.
+func Evaluate(input Input) (Report, error) {
+	if err := validate(input); err != nil {
+		return Report{}, err
+	}
+
+	requestDurations := make([]int64, len(input.Requests))
+	var successes int64
+	for i, request := range input.Requests {
+		requestDurations[i] = request.DurationMilliseconds
+		if request.Succeeded {
+			successes++
+		}
+	}
+	failed := make([]string, 0)
+	for _, check := range input.Correctness {
+		if !check.Passed {
+			failed = append(failed, check.Name)
+		}
+	}
+	failoverDetection := make([]int64, len(input.APIFailovers))
+	failoverRecovery := make([]int64, len(input.APIFailovers))
+	var recovered int64
+	for i, observation := range input.APIFailovers {
+		failoverDetection[i] = observation.DetectionMilliseconds
+		failoverRecovery[i] = observation.RecoveryMilliseconds
+		if observation.Recovered {
+			recovered++
+		}
+	}
+
+	count := int64(len(input.Requests))
+	return Report{
+		SchemaVersion: OutputSchemaVersion,
+		Metadata:      input.Metadata,
+		Throughput: Throughput{
+			WindowMilliseconds: input.Window.DurationMilliseconds,
+			RequestsPerSecond:  float64(count) * 1000 / float64(input.Window.DurationMilliseconds),
+		},
+		Requests: RequestSummary{Count: count, Successes: successes, Failures: count - successes, Duration: calculateQuantiles(requestDurations)},
+		Queue:    QueueSummary{Delay: calculateQuantiles(input.Queue.DelayMilliseconds), Recovery: calculateQuantiles(input.Queue.RecoveryMilliseconds)},
+		Pool:     PoolSummary{Acquisition: calculateQuantiles(input.Pool.AcquisitionMilliseconds), SaturationEvents: input.Pool.SaturationEvents},
+		Evidence: EvidenceGrowthSummary{
+			DatabaseBeforeBytes: input.Evidence.DatabaseBeforeBytes,
+			DatabaseAfterBytes:  input.Evidence.DatabaseAfterBytes,
+			DatabaseGrowthBytes: input.Evidence.DatabaseAfterBytes - input.Evidence.DatabaseBeforeBytes,
+			ObjectBeforeBytes:   input.Evidence.ObjectBeforeBytes,
+			ObjectAfterBytes:    input.Evidence.ObjectAfterBytes,
+			ObjectGrowthBytes:   input.Evidence.ObjectAfterBytes - input.Evidence.ObjectBeforeBytes,
+		},
+		Migration: input.Migration,
+		APIFailover: APIFailoverSummary{
+			Count: int64(len(input.APIFailovers)), RecoveredCount: recovered, UnrecoveredCount: int64(len(input.APIFailovers)) - recovered,
+			Detection: calculateQuantiles(failoverDetection), Recovery: calculateQuantiles(failoverRecovery),
+		},
+		Correctness: CorrectnessSummary{Checks: int64(len(input.Correctness)), Failures: int64(len(failed)), Failed: failed},
+	}, nil
+}
+
+// EncodeReport writes one stable, indented JSON document followed by a newline.
+func EncodeReport(w io.Writer, report Report) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		return fmt.Errorf("encode benchmark report: %w", err)
+	}
+	return nil
+}
+
+func calculateQuantiles(values []int64) Quantiles {
+	if len(values) == 0 {
+		return Quantiles{}
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	at := func(percentile float64) int64 {
+		rank := int(math.Ceil(percentile * float64(len(sorted))))
+		return sorted[rank-1]
+	}
+	return Quantiles{Count: int64(len(sorted)), P50: at(0.50), P95: at(0.95), P99: at(0.99)}
+}
+
+func validate(input Input) error {
+	if input.SchemaVersion != InputSchemaVersion {
+		return fmt.Errorf("unsupported benchmark input schema version %q", input.SchemaVersion)
+	}
+	for _, metadataField := range []struct{ name, value string }{
+		{"metadata.environment", input.Metadata.Environment}, {"metadata.environment_digest", input.Metadata.EnvironmentDigest},
+		{"metadata.release", input.Metadata.Release}, {"metadata.release_digest", input.Metadata.ReleaseDigest}, {"metadata.data_digest", input.Metadata.DataDigest},
+	} {
+		if strings.TrimSpace(metadataField.value) == "" {
+			return fmt.Errorf("%s is required", metadataField.name)
+		}
+	}
+	if input.Window.DurationMilliseconds <= 0 {
+		return fmt.Errorf("window.duration_milliseconds must be positive")
+	}
+	for _, value := range input.Requests {
+		if value.DurationMilliseconds < 0 {
+			return fmt.Errorf("request duration must not be negative")
+		}
+	}
+	if err := validateMeasurements("queue delay", input.Queue.DelayMilliseconds); err != nil {
+		return err
+	}
+	if err := validateMeasurements("queue recovery", input.Queue.RecoveryMilliseconds); err != nil {
+		return err
+	}
+	if err := validateMeasurements("pool acquisition", input.Pool.AcquisitionMilliseconds); err != nil {
+		return err
+	}
+	if input.Pool.SaturationEvents < 0 {
+		return fmt.Errorf("pool saturation events must not be negative")
+	}
+	if input.Evidence.DatabaseBeforeBytes < 0 || input.Evidence.DatabaseAfterBytes < 0 || input.Evidence.ObjectBeforeBytes < 0 || input.Evidence.ObjectAfterBytes < 0 {
+		return fmt.Errorf("evidence byte observations must not be negative")
+	}
+	if input.Migration.DurationMilliseconds < 0 {
+		return fmt.Errorf("migration duration must not be negative")
+	}
+	for _, value := range input.APIFailovers {
+		if value.DetectionMilliseconds < 0 || value.RecoveryMilliseconds < 0 {
+			return fmt.Errorf("API failover observations must not be negative")
+		}
+	}
+	for _, check := range input.Correctness {
+		if strings.TrimSpace(check.Name) == "" {
+			return fmt.Errorf("correctness check name is required")
+		}
+	}
+	return nil
+}
+
+func validateMeasurements(name string, values []int64) error {
+	for _, value := range values {
+		if value < 0 {
+			return fmt.Errorf("%s measurement must not be negative", name)
+		}
+	}
+	return nil
+}

--- a/internal/usecase/benchmark/benchmark_test.go
+++ b/internal/usecase/benchmark/benchmark_test.go
@@ -1,0 +1,78 @@
+package benchmark
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestEvaluateDeterministicMeasuredObservations(t *testing.T) {
+	input := fixtureInput()
+	first, err := Evaluate(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Evaluate(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var firstJSON, secondJSON bytes.Buffer
+	if err := EncodeReport(&firstJSON, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := EncodeReport(&secondJSON, second); err != nil {
+		t.Fatal(err)
+	}
+	if firstJSON.String() != secondJSON.String() {
+		t.Fatalf("report is not deterministic:\n%s\n---\n%s", firstJSON.String(), secondJSON.String())
+	}
+	if first.SchemaVersion != OutputSchemaVersion || first.Throughput.RequestsPerSecond != 500 || first.Requests.Count != 5 || first.Requests.Successes != 3 || first.Requests.Failures != 2 {
+		t.Fatalf("request summary = %+v throughput=%+v", first.Requests, first.Throughput)
+	}
+	if got, want := first.Requests.Duration, (Quantiles{Count: 5, P50: 30, P95: 50, P99: 50}); got != want {
+		t.Fatalf("request quantiles = %+v, want %+v", got, want)
+	}
+	if got, want := first.Queue.Delay, (Quantiles{Count: 3, P50: 4, P95: 9, P99: 9}); got != want {
+		t.Fatalf("queue delay = %+v, want %+v", got, want)
+	}
+	if first.Pool.SaturationEvents != 2 || first.Evidence.DatabaseGrowthBytes != 30 || first.Evidence.ObjectGrowthBytes != 50 {
+		t.Fatalf("pool=%+v evidence=%+v", first.Pool, first.Evidence)
+	}
+	if first.APIFailover.RecoveredCount != 1 || first.APIFailover.UnrecoveredCount != 1 || first.Correctness.Failures != 1 || len(first.Correctness.Failed) != 1 || first.Correctness.Failed[0] != "evidence-chain" {
+		t.Fatalf("failover=%+v correctness=%+v", first.APIFailover, first.Correctness)
+	}
+}
+
+func TestDecodeInputRejectsUnknownAndInvalidInput(t *testing.T) {
+	_, err := DecodeInput(strings.NewReader(`{"schema_version":"synapse-benchmark-input-v1","unknown":true}`))
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("unknown field error = %v", err)
+	}
+	input := fixtureInput()
+	input.SchemaVersion = "v0"
+	_, err = Evaluate(input)
+	if err == nil || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("schema error = %v", err)
+	}
+	input = fixtureInput()
+	input.Window.DurationMilliseconds = 0
+	_, err = Evaluate(input)
+	if err == nil || !strings.Contains(err.Error(), "must be positive") {
+		t.Fatalf("window error = %v", err)
+	}
+}
+
+func fixtureInput() Input {
+	return Input{
+		SchemaVersion: InputSchemaVersion,
+		Metadata:      Metadata{Environment: "fixture", EnvironmentDigest: "sha256:environment", Release: "v1.2.3", ReleaseDigest: "sha256:release", DataDigest: "sha256:data"},
+		Window:        Window{DurationMilliseconds: 10},
+		Requests:      []RequestObservation{{10, true}, {20, false}, {30, true}, {40, true}, {50, false}},
+		Queue:         QueueObservation{DelayMilliseconds: []int64{9, 1, 4}, RecoveryMilliseconds: []int64{7, 3}},
+		Pool:          PoolObservation{AcquisitionMilliseconds: []int64{6, 2, 4}, SaturationEvents: 2},
+		Evidence:      EvidenceGrowth{DatabaseBeforeBytes: 100, DatabaseAfterBytes: 130, ObjectBeforeBytes: 200, ObjectAfterBytes: 250},
+		Migration:     MigrationObservation{DurationMilliseconds: 11},
+		APIFailovers:  []APIFailoverObservation{{DetectionMilliseconds: 1, RecoveryMilliseconds: 9, Recovered: true}, {DetectionMilliseconds: 2, RecoveryMilliseconds: 0, Recovered: false}},
+		Correctness:   []CorrectnessObservation{{Name: "request-order", Passed: true}, {Name: "evidence-chain", Passed: false}},
+	}
+}

--- a/internal/usecase/identitybff/service.go
+++ b/internal/usecase/identitybff/service.go
@@ -1,0 +1,220 @@
+// Package identitybff orchestrates the OIDC browser flow without exposing provider credentials to HTTP handlers.
+package identitybff
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	identityuc "github.com/KKloudTarus/synapse-ce/internal/usecase/identityuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type Config struct {
+	TenantID       shared.ID
+	TransactionTTL time.Duration
+	SessionTTL     time.Duration
+}
+
+type Authorization struct{ URL, Nonce string }
+type Session struct {
+	Token, CSRFToken string
+	Principal        Principal
+}
+type Principal struct{ ID, Name, Role, TenantID string }
+
+type Service struct {
+	provider   ports.OIDCProvider
+	identities *identityuc.Service
+	store      ports.IdentityStore
+	users      ports.UserRepository
+	clock      ports.Clock
+	ids        ports.IDGenerator
+	cfg        Config
+}
+
+func NewService(provider ports.OIDCProvider, identities *identityuc.Service, store ports.IdentityStore, users ports.UserRepository, clock ports.Clock, ids ports.IDGenerator, cfg Config) (*Service, error) {
+	if provider == nil || identities == nil || store == nil || users == nil || clock == nil || ids == nil || cfg.TenantID.IsZero() || cfg.TransactionTTL <= 0 || cfg.SessionTTL <= 0 {
+		return nil, fmt.Errorf("%w: OIDC BFF service has invalid configuration", shared.ErrValidation)
+	}
+	return &Service{provider: provider, identities: identities, store: store, users: users, clock: clock, ids: ids, cfg: cfg}, nil
+}
+
+func (s *Service) Begin(ctx context.Context) (Authorization, error) {
+	verifier := s.provider.GenerateVerifier()
+	start, err := s.identities.BeginAuthorization(ctx, s.cfg.TenantID, verifier, s.cfg.TransactionTTL)
+	if err != nil {
+		return Authorization{}, fmt.Errorf("begin OIDC authorization: %w", err)
+	}
+	url, err := s.provider.AuthorizationURL(start.State, start.Nonce, verifier)
+	if err != nil {
+		return Authorization{}, fmt.Errorf("build OIDC authorization URL: %w", err)
+	}
+	return Authorization{URL: url, Nonce: start.Nonce}, nil
+}
+
+// Complete burns state before exchange, validates cookie and signed token nonce, then accepts an exact issuer/subject link in the fixed tenant.
+func (s *Service) Complete(ctx context.Context, state, code, nonce string) (Session, error) {
+	if strings.TrimSpace(nonce) == "" {
+		return Session{}, fmt.Errorf("OIDC nonce cookie is missing: %w", shared.ErrForbidden)
+	}
+	transaction, err := s.identities.ConsumeAuthorization(ctx, s.cfg.TenantID, state)
+	if err != nil {
+		return Session{}, fmt.Errorf("consume OIDC authorization: %w", err)
+	}
+	if transaction.TenantID != s.cfg.TenantID || subtle.ConstantTimeCompare([]byte(hash(nonce)), []byte(transaction.NonceHash)) != 1 {
+		return Session{}, fmt.Errorf("OIDC authorization tenant or nonce mismatch: %w", shared.ErrForbidden)
+	}
+	verified, err := s.provider.ExchangeAndVerify(ctx, code, transaction.PKCEVerifier, nonce)
+	if err != nil {
+		return Session{}, fmt.Errorf("verify OIDC callback: %w", err)
+	}
+	if !verified.Role.Valid() {
+		return Session{}, fmt.Errorf("OIDC group mapping produced no valid role: %w", shared.ErrForbidden)
+	}
+	tenantCtx := shared.WithTenant(ctx, s.cfg.TenantID)
+	u, err := s.resolveUser(tenantCtx, verified)
+	if err != nil {
+		return Session{}, err
+	}
+	created, err := s.identities.CreateSession(ctx, s.cfg.TenantID, u.ID, nil, s.cfg.SessionTTL)
+	if err != nil {
+		return Session{}, fmt.Errorf("create OIDC session: %w", err)
+	}
+	return Session{Token: created.Token, CSRFToken: created.CSRFToken, Principal: Principal{ID: u.ID.String(), Name: u.Name, Role: string(u.Role), TenantID: s.cfg.TenantID.String()}}, nil
+}
+
+// resolveUser maps a verified issuer/subject to a tenant-scoped user, provisioning the link on
+// first login. The operator-configured group mapping is authoritative for the role, so a group
+// change at the provider is applied here rather than rejecting the login as a mismatch.
+func (s *Service) resolveUser(ctx context.Context, verified ports.OIDCIdentity) (*user.User, error) {
+	external, err := s.store.GetExternalIdentity(ctx, verified.Issuer, verified.Subject)
+	switch {
+	case err == nil:
+		if external.TenantID != s.cfg.TenantID {
+			return nil, fmt.Errorf("OIDC linked identity tenant mismatch: %w", shared.ErrForbidden)
+		}
+		u, getErr := s.users.GetByID(ctx, external.UserID)
+		if getErr != nil || u.Disabled || shared.TenantOrDefault(shared.ID(u.TenantID)) != s.cfg.TenantID {
+			return nil, fmt.Errorf("OIDC user is unavailable: %w", shared.ErrForbidden)
+		}
+		if u.Role != verified.Role {
+			u.Role = verified.Role
+			u.Audit.UpdatedAt = s.clock.Now().UTC()
+			if err := s.users.Upsert(ctx, u); err != nil {
+				return nil, fmt.Errorf("apply mapped OIDC role: %w", err)
+			}
+		}
+		return u, nil
+	case errors.Is(err, shared.ErrNotFound):
+		return s.provisionUser(ctx, verified)
+	default:
+		return nil, fmt.Errorf("resolve linked OIDC identity: %w", err)
+	}
+}
+
+// provisionUser creates the tenant-scoped user for a first-time subject and links it. The
+// API-key hash is an unguessable random value, so a provisioned identity can never be
+// authenticated with a bearer token.
+func (s *Service) provisionUser(ctx context.Context, verified ports.OIDCIdentity) (*user.User, error) {
+	unusableAPIKeyHash, err := randomHex()
+	if err != nil {
+		return nil, err
+	}
+	now := s.clock.Now().UTC()
+	u, err := user.New(s.ids.NewID(), s.cfg.TenantID.String(), oidcDisplayName(verified), verified.Role, unusableAPIKeyHash, now)
+	if err != nil {
+		return nil, fmt.Errorf("build provisioned OIDC user: %w", err)
+	}
+	if err := s.users.Create(ctx, u); err != nil {
+		return nil, fmt.Errorf("create provisioned OIDC user: %w", err)
+	}
+	if _, err := s.identities.LinkExternalIdentity(ctx, s.cfg.TenantID, u.ID, verified.Issuer, verified.Subject); err != nil {
+		// A concurrent replica may have won the link. Re-read so both requests converge on the
+		// same user rather than leaving this login broken.
+		if errors.Is(err, shared.ErrConflict) {
+			external, getErr := s.store.GetExternalIdentity(ctx, verified.Issuer, verified.Subject)
+			if getErr == nil && external.TenantID == s.cfg.TenantID {
+				if existing, userErr := s.users.GetByID(ctx, external.UserID); userErr == nil && !existing.Disabled {
+					return existing, nil
+				}
+			}
+		}
+		return nil, fmt.Errorf("link provisioned OIDC identity: %w", err)
+	}
+	return u, nil
+}
+
+// oidcDisplayName never trusts a provider-supplied display string for identity; the subject is
+// the stable identifier and the name is only shown in the UI.
+func oidcDisplayName(verified ports.OIDCIdentity) string {
+	if name := strings.TrimSpace(verified.Name); name != "" {
+		return name
+	}
+	return verified.Subject
+}
+
+func randomHex() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate provisioned credential placeholder: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func (s *Service) Authenticate(ctx context.Context, token, csrfToken string, unsafe bool) (Principal, error) {
+	session, err := s.identities.AuthenticateSession(ctx, s.cfg.TenantID, token)
+	if err != nil {
+		return Principal{}, err
+	}
+	if unsafe && (csrfToken == "" || subtle.ConstantTimeCompare([]byte(hash(csrfToken)), []byte(session.CSRFTokenHash)) != 1) {
+		return Principal{}, fmt.Errorf("CSRF token mismatch: %w", shared.ErrForbidden)
+	}
+	u, err := s.users.GetByID(ctx, session.UserID)
+	if err != nil || u.Disabled || shared.TenantOrDefault(shared.ID(u.TenantID)) != s.cfg.TenantID {
+		return Principal{}, shared.ErrForbidden
+	}
+	return Principal{ID: u.ID.String(), Name: u.Name, Role: string(u.Role), TenantID: s.cfg.TenantID.String()}, nil
+}
+
+// Discover validates a browser session and rotates its opaque session and CSRF tokens.
+// It exposes only the application principal fields needed by the frontend.
+func (s *Service) Discover(ctx context.Context, token string) (Session, error) {
+	session, err := s.identities.AuthenticateSession(ctx, s.cfg.TenantID, token)
+	if err != nil {
+		return Session{}, err
+	}
+	u, err := s.users.GetByID(ctx, session.UserID)
+	if err != nil || u.Disabled || shared.TenantOrDefault(shared.ID(u.TenantID)) != s.cfg.TenantID || !u.Role.Valid() {
+		return Session{}, shared.ErrForbidden
+	}
+	created, err := s.identities.RotateSession(ctx, session, nil, s.cfg.SessionTTL)
+	if err != nil {
+		return Session{}, fmt.Errorf("rotate discovered OIDC session: %w", err)
+	}
+	return Session{Token: created.Token, CSRFToken: created.CSRFToken, Principal: Principal{ID: u.ID.String(), Name: u.Name, Role: string(u.Role), TenantID: s.cfg.TenantID.String()}}, nil
+}
+
+func (s *Service) Logout(ctx context.Context, token string) error {
+	session, err := s.identities.AuthenticateSession(ctx, s.cfg.TenantID, token)
+	if err != nil {
+		return err
+	}
+	if err := s.store.RevokeSession(ctx, s.cfg.TenantID, session.ID, s.clock.Now().UTC()); err != nil {
+		return fmt.Errorf("revoke OIDC session: %w", err)
+	}
+	return nil
+}
+
+func hash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/usecase/identitybff/service_test.go
+++ b/internal/usecase/identitybff/service_test.go
@@ -1,0 +1,238 @@
+package identitybff
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/identity"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	identityuc "github.com/KKloudTarus/synapse-ce/internal/usecase/identityuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type bffClock struct{ now time.Time }
+
+func (c bffClock) Now() time.Time { return c.now }
+
+type bffIDs struct{ n int }
+
+func (g *bffIDs) NewID() shared.ID { g.n++; return shared.ID(fmt.Sprintf("id-%d", g.n)) }
+
+type bffProtector struct{}
+
+func (bffProtector) Seal(_ context.Context, plain, _ []byte) (string, error) {
+	return string(plain), nil
+}
+func (bffProtector) Open(_ context.Context, ciphertext string, _ []byte) ([]byte, error) {
+	return []byte(ciphertext), nil
+}
+
+type bffProvider struct{ expectedNonce string }
+
+func (p *bffProvider) GenerateVerifier() string { return "test-pkce-verifier-value-0123456789" }
+func (p *bffProvider) AuthorizationURL(state, nonce, _ string) (string, error) {
+	p.expectedNonce = nonce
+	return "https://issuer.example/auth?state=" + state, nil
+}
+func (p *bffProvider) ExchangeAndVerify(_ context.Context, _, _, nonce string) (ports.OIDCIdentity, error) {
+	if nonce != p.expectedNonce {
+		return ports.OIDCIdentity{}, fmt.Errorf("nonce mismatch")
+	}
+	return ports.OIDCIdentity{Issuer: "https://issuer.example", Subject: "subject", Role: user.RoleAdmin}, nil
+}
+
+type bffStore struct {
+	transaction  identity.AuthorizationTransaction
+	identity     identity.ExternalIdentity
+	tamperTenant bool
+}
+
+func (s *bffStore) CreateExternalIdentity(_ context.Context, external identity.ExternalIdentity) error {
+	s.identity = external
+	return nil
+}
+func (s *bffStore) GetExternalIdentity(_ context.Context, _, _ string) (identity.ExternalIdentity, error) {
+	if s.identity.ID.IsZero() {
+		return identity.ExternalIdentity{}, shared.ErrNotFound
+	}
+	return s.identity, nil
+}
+func (s *bffStore) CreateAuthorizationTransaction(_ context.Context, transaction identity.AuthorizationTransaction) error {
+	s.transaction = transaction
+	return nil
+}
+func (s *bffStore) ConsumeAuthorizationTransaction(_ context.Context, _ shared.ID, _ string, _ time.Time) (identity.AuthorizationTransaction, error) {
+	transaction := s.transaction
+	s.transaction = identity.AuthorizationTransaction{}
+	if transaction.ID.IsZero() {
+		return identity.AuthorizationTransaction{}, shared.ErrNotFound
+	}
+	if s.tamperTenant {
+		transaction.TenantID = "other"
+	}
+	return transaction, nil
+}
+func (s *bffStore) CreateSession(context.Context, identity.Session) error { return nil }
+func (s *bffStore) RotateSession(context.Context, shared.ID, identity.Session, time.Time) error {
+	return nil
+}
+func (s *bffStore) GetSessionByTokenHash(context.Context, string) (identity.Session, error) {
+	return identity.Session{}, shared.ErrNotFound
+}
+func (s *bffStore) RevokeSession(context.Context, shared.ID, shared.ID, time.Time) error { return nil }
+
+type bffUsers struct {
+	user    *user.User
+	created []*user.User
+	upserts []*user.User
+}
+
+func (s *bffUsers) Create(_ context.Context, u *user.User) error {
+	s.created = append(s.created, u)
+	if s.user == nil {
+		s.user = u
+	}
+	return nil
+}
+func (s *bffUsers) Bootstrap(context.Context, *user.User, ports.AuditEntry) error { return nil }
+func (s *bffUsers) GetByID(_ context.Context, id shared.ID) (*user.User, error) {
+	if s.user != nil && s.user.ID == id {
+		return s.user, nil
+	}
+	for _, u := range s.created {
+		if u.ID == id {
+			return u, nil
+		}
+	}
+	return nil, shared.ErrNotFound
+}
+func (s *bffUsers) GetByAPIKeyHash(context.Context, string) (*user.User, error) {
+	return nil, shared.ErrNotFound
+}
+func (s *bffUsers) List(context.Context) ([]*user.User, error) { return nil, nil }
+func (s *bffUsers) Upsert(_ context.Context, u *user.User) error {
+	s.upserts = append(s.upserts, u)
+	return nil
+}
+
+func newBFFTestService(t *testing.T, store *bffStore) (*Service, *bffProvider) {
+	service, provider, _ := newBFFTestServiceWithUsers(t, store, true)
+	return service, provider
+}
+
+// newBFFTestServiceWithUsers builds the BFF. When linked is false the store starts with no
+// external identity, exercising first-login provisioning.
+func newBFFTestServiceWithUsers(t *testing.T, store *bffStore, linked bool) (*Service, *bffProvider, *bffUsers) {
+	t.Helper()
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	ids := &bffIDs{}
+	clock := bffClock{now: now}
+	identityService, err := identityuc.NewService(store, bffProtector{}, clock, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	users := &bffUsers{}
+	if linked {
+		u, err := user.New("user-1", "tenant", "OIDC Admin", user.RoleAdmin, "hash", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		external, err := identity.NewExternalIdentity("external-1", "tenant", u.ID, "https://issuer.example", "subject", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		store.identity = external
+		users.user = u
+	}
+	provider := &bffProvider{}
+	service, err := NewService(provider, identityService, store, users, clock, &bffIDs{n: 100}, Config{TenantID: "tenant", TransactionTTL: time.Minute, SessionTTL: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return service, provider, users
+}
+
+// A first-time subject must be provisioned and linked; before this the callback failed with
+// ErrNotFound and no OIDC login could ever succeed.
+func TestCompleteProvisionsAndLinksFirstTimeSubject(t *testing.T) {
+	store := &bffStore{}
+	service, provider, users := newBFFTestServiceWithUsers(t, store, false)
+	start, err := service.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := service.Complete(context.Background(), extractState(start.URL), "code", provider.expectedNonce)
+	if err != nil {
+		t.Fatalf("first login must provision the subject: %v", err)
+	}
+	if len(users.created) != 1 {
+		t.Fatalf("created users = %d, want 1", len(users.created))
+	}
+	created := users.created[0]
+	if created.Role != user.RoleAdmin || created.TenantID != "tenant" {
+		t.Fatalf("provisioned user has wrong identity: %+v", created)
+	}
+	if store.identity.Subject != "subject" || store.identity.UserID != created.ID {
+		t.Fatalf("external identity was not linked: %+v", store.identity)
+	}
+	if session.Principal.Role != string(user.RoleAdmin) || session.Token == "" || session.CSRFToken == "" {
+		t.Fatalf("unexpected session: %+v", session)
+	}
+	if created.APIKeyHash == "" || created.APIKeyHash == "hash" {
+		t.Fatalf("provisioned user must carry an unusable random API key hash")
+	}
+}
+
+// The operator-configured group mapping is authoritative, so a changed provider group updates
+// the stored role instead of rejecting the login.
+func TestCompleteAppliesMappedRoleToLinkedUser(t *testing.T) {
+	store := &bffStore{}
+	service, provider, users := newBFFTestServiceWithUsers(t, store, true)
+	users.user.Role = user.RoleReadOnly
+	start, err := service.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := service.Complete(context.Background(), extractState(start.URL), "code", provider.expectedNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users.upserts) != 1 || users.upserts[0].Role != user.RoleAdmin {
+		t.Fatalf("mapped role was not applied: %+v", users.upserts)
+	}
+	if session.Principal.Role != string(user.RoleAdmin) {
+		t.Fatalf("session role = %q", session.Principal.Role)
+	}
+}
+
+func TestCompleteRejectsStateReplay(t *testing.T) {
+	store := &bffStore{}
+	service, provider := newBFFTestService(t, store)
+	start, err := service.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Complete(context.Background(), extractState(start.URL), "code", provider.expectedNonce); err != nil {
+		t.Fatalf("first callback: %v", err)
+	}
+	if _, err := service.Complete(context.Background(), extractState(start.URL), "code", provider.expectedNonce); err == nil {
+		t.Fatal("replayed state must be rejected")
+	}
+}
+
+func TestCompleteRejectsAuthorizationTenantTamper(t *testing.T) {
+	store := &bffStore{tamperTenant: true}
+	service, provider := newBFFTestService(t, store)
+	start, err := service.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Complete(context.Background(), extractState(start.URL), "code", provider.expectedNonce); err == nil {
+		t.Fatal("tampered authorization tenant must be rejected")
+	}
+}
+
+func extractState(url string) string { return url[len("https://issuer.example/auth?state="):] }

--- a/internal/usecase/identityuc/service.go
+++ b/internal/usecase/identityuc/service.go
@@ -1,0 +1,196 @@
+// Package identityuc manages secure persistence primitives for OIDC login and opaque sessions.
+package identityuc
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/identity"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Service owns secret generation and ensures stores receive only one-way hashes or authenticated
+// ciphertext. It does not process provider access, refresh, or ID tokens.
+type Service struct {
+	store     ports.IdentityStore
+	protector ports.IdentitySecretProtector
+	clock     ports.Clock
+	ids       ports.IDGenerator
+}
+
+// NewService validates OIDC persistence dependencies.
+func NewService(store ports.IdentityStore, protector ports.IdentitySecretProtector, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if store == nil || protector == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: identity service is missing a dependency", shared.ErrValidation)
+	}
+	return &Service{store: store, protector: protector, clock: clock, ids: ids}, nil
+}
+
+// AuthorizationStart is returned once to the browser-bound authorization redirect flow. State and
+// nonce are raw only at this boundary; their hashes are persisted.
+type AuthorizationStart struct {
+	State string
+	Nonce string
+}
+
+// BeginAuthorization creates a one-time transaction for the supplied PKCE verifier. ttl must be
+// short-lived and is constrained by the caller's policy; a non-positive ttl is rejected.
+func (s *Service) BeginAuthorization(ctx context.Context, tenantID shared.ID, pkceVerifier string, ttl time.Duration) (AuthorizationStart, error) {
+	if tenantID.IsZero() || strings.TrimSpace(pkceVerifier) == "" || ttl <= 0 {
+		return AuthorizationStart{}, fmt.Errorf("%w: tenant, PKCE verifier, and positive transaction lifetime are required", shared.ErrValidation)
+	}
+	state, err := randomValue()
+	if err != nil {
+		return AuthorizationStart{}, err
+	}
+	nonce, err := randomValue()
+	if err != nil {
+		return AuthorizationStart{}, err
+	}
+	ciphertext, err := s.protector.Seal(ctx, []byte(pkceVerifier), transactionAAD(tenantID, stateHash(state)))
+	if err != nil {
+		return AuthorizationStart{}, fmt.Errorf("seal PKCE verifier: %w", err)
+	}
+	now := s.clock.Now().UTC()
+	transaction, err := identity.NewAuthorizationTransaction(s.ids.NewID(), tenantID, stateHash(state), stateHash(nonce), ciphertext, now.Add(ttl), now)
+	if err != nil {
+		return AuthorizationStart{}, err
+	}
+	if err := s.store.CreateAuthorizationTransaction(ctx, transaction); err != nil {
+		return AuthorizationStart{}, fmt.Errorf("create authorization transaction: %w", err)
+	}
+	return AuthorizationStart{State: state, Nonce: nonce}, nil
+}
+
+// ConsumedAuthorization contains the PKCE verifier and nonce hash required to validate one
+// callback. The ID-token nonce claim must be hashed before comparison with NonceHash.
+type ConsumedAuthorization struct {
+	NonceHash    string
+	PKCEVerifier string
+	TenantID     shared.ID
+}
+
+// ConsumeAuthorization atomically burns a tenant-bound state value then decrypts its PKCE verifier.
+// A failed decrypt leaves the state burned, which is intentional fail-closed replay protection.
+func (s *Service) ConsumeAuthorization(ctx context.Context, tenantID shared.ID, state string) (ConsumedAuthorization, error) {
+	if tenantID.IsZero() || strings.TrimSpace(state) == "" {
+		return ConsumedAuthorization{}, fmt.Errorf("%w: authorization tenant and state are required", shared.ErrValidation)
+	}
+	transaction, err := s.store.ConsumeAuthorizationTransaction(ctx, tenantID, stateHash(state), s.clock.Now().UTC())
+	if err != nil {
+		return ConsumedAuthorization{}, fmt.Errorf("consume authorization transaction: %w", err)
+	}
+	verifier, err := s.protector.Open(ctx, transaction.PKCEVerifierCiphertext, transactionAAD(transaction.TenantID, transaction.StateHash))
+	if err != nil {
+		return ConsumedAuthorization{}, fmt.Errorf("open PKCE verifier: %w", err)
+	}
+	return ConsumedAuthorization{NonceHash: transaction.NonceHash, PKCEVerifier: string(verifier), TenantID: transaction.TenantID}, nil
+}
+
+// LinkExternalIdentity creates the exact issuer/subject-to-user relationship after a provider ID
+// token has been validated by a higher-level OIDC protocol adapter.
+func (s *Service) LinkExternalIdentity(ctx context.Context, tenantID, userID shared.ID, issuer, subject string) (identity.ExternalIdentity, error) {
+	external, err := identity.NewExternalIdentity(s.ids.NewID(), tenantID, userID, issuer, subject, s.clock.Now().UTC())
+	if err != nil {
+		return identity.ExternalIdentity{}, err
+	}
+	if err := s.store.CreateExternalIdentity(ctx, external); err != nil {
+		return identity.ExternalIdentity{}, fmt.Errorf("link OIDC external identity: %w", err)
+	}
+	return external, nil
+}
+
+// CreatedSession returns opaque tokens exactly once. Their hashes, not these values, are persisted.
+type CreatedSession struct {
+	Session   identity.Session
+	Token     string
+	CSRFToken string
+}
+
+// CreateSession mints an opaque browser session linked to an existing tenant-scoped user.
+func (s *Service) CreateSession(ctx context.Context, tenantID, userID shared.ID, metadata map[string]string, ttl time.Duration) (CreatedSession, error) {
+	if tenantID.IsZero() || userID.IsZero() || ttl <= 0 {
+		return CreatedSession{}, fmt.Errorf("%w: tenant, user, and positive session lifetime are required", shared.ErrValidation)
+	}
+	token, err := randomValue()
+	if err != nil {
+		return CreatedSession{}, err
+	}
+	csrfToken, err := randomValue()
+	if err != nil {
+		return CreatedSession{}, err
+	}
+	now := s.clock.Now().UTC()
+	session, err := identity.NewSession(s.ids.NewID(), tenantID, userID, stateHash(token), stateHash(csrfToken), metadata, now.Add(ttl), now)
+	if err != nil {
+		return CreatedSession{}, err
+	}
+	if err := s.store.CreateSession(ctx, session); err != nil {
+		return CreatedSession{}, fmt.Errorf("create opaque session: %w", err)
+	}
+	return CreatedSession{Session: session, Token: token, CSRFToken: csrfToken}, nil
+}
+
+// RotateSession atomically replaces an active session so discovery cannot leave both the old and
+// new opaque credentials valid when a store operation fails.
+func (s *Service) RotateSession(ctx context.Context, previous identity.Session, metadata map[string]string, ttl time.Duration) (CreatedSession, error) {
+	if previous.ID.IsZero() || previous.TenantID.IsZero() || previous.UserID.IsZero() || ttl <= 0 {
+		return CreatedSession{}, fmt.Errorf("%w: previous session and positive session lifetime are required", shared.ErrValidation)
+	}
+	token, err := randomValue()
+	if err != nil {
+		return CreatedSession{}, err
+	}
+	csrfToken, err := randomValue()
+	if err != nil {
+		return CreatedSession{}, err
+	}
+	now := s.clock.Now().UTC()
+	replacement, err := identity.NewSession(s.ids.NewID(), previous.TenantID, previous.UserID, stateHash(token), stateHash(csrfToken), metadata, now.Add(ttl), now)
+	if err != nil {
+		return CreatedSession{}, err
+	}
+	if err := s.store.RotateSession(ctx, previous.ID, replacement, now); err != nil {
+		return CreatedSession{}, fmt.Errorf("rotate opaque session: %w", err)
+	}
+	return CreatedSession{Session: replacement, Token: token, CSRFToken: csrfToken}, nil
+}
+
+// AuthenticateSession resolves a tenant-bound opaque token only while the stored session remains active.
+func (s *Service) AuthenticateSession(ctx context.Context, tenantID shared.ID, token string) (identity.Session, error) {
+	if tenantID.IsZero() || strings.TrimSpace(token) == "" {
+		return identity.Session{}, fmt.Errorf("%w: session tenant and token are required", shared.ErrValidation)
+	}
+	session, err := s.store.GetSessionByTokenHash(shared.WithTenant(ctx, tenantID), stateHash(token))
+	if err != nil {
+		return identity.Session{}, fmt.Errorf("get session: %w", err)
+	}
+	if !session.Active(s.clock.Now().UTC()) {
+		return identity.Session{}, fmt.Errorf("session inactive: %w", shared.ErrForbidden)
+	}
+	return session, nil
+}
+
+func stateHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func transactionAAD(tenantID shared.ID, stateHash string) []byte {
+	return []byte("oidc-authorization-transaction:" + tenantID.String() + ":" + stateHash)
+}
+
+func randomValue() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate secure random value: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/usecase/identityuc/service.go
+++ b/internal/usecase/identityuc/service.go
@@ -153,10 +153,18 @@ func (s *Service) RotateSession(ctx context.Context, previous identity.Session, 
 		return CreatedSession{}, err
 	}
 	now := s.clock.Now().UTC()
+	// Enforce the absolute lifetime cap: a rotation refreshes the sliding TTL but must never extend the
+	// lineage past MaxSessionAge measured from the original login. Past it, the browser is forced back
+	// through OIDC. A zero OriginAt fails closed (BeyondMaxAge).
+	if previous.BeyondMaxAge(now) {
+		return CreatedSession{}, fmt.Errorf("%w: session exceeded its maximum lifetime; re-authentication required", shared.ErrForbidden)
+	}
 	replacement, err := identity.NewSession(s.ids.NewID(), previous.TenantID, previous.UserID, stateHash(token), stateHash(csrfToken), metadata, now.Add(ttl), now)
 	if err != nil {
 		return CreatedSession{}, err
 	}
+	// Carry the immutable origin so the cap is measured from first authentication, not this rotation.
+	replacement.OriginAt = previous.OriginAt
 	if err := s.store.RotateSession(ctx, previous.ID, replacement, now); err != nil {
 		return CreatedSession{}, fmt.Errorf("rotate opaque session: %w", err)
 	}

--- a/internal/usecase/identityuc/service_test.go
+++ b/internal/usecase/identityuc/service_test.go
@@ -113,3 +113,34 @@ func TestCreateSessionPersistsOnlyTokenHashes(t *testing.T) {
 		t.Fatalf("authenticate fresh session: %v", err)
 	}
 }
+
+// TestRotateSessionEnforcesAbsoluteMaxAge locks in the absolute-lifetime cap (review LOW-1): a rotation
+// refreshes the sliding TTL and carries the immutable origin forward, but a session lineage past
+// identity.MaxSessionAge is refused so the browser is forced back through OIDC.
+func TestRotateSessionEnforcesAbsoluteMaxAge(t *testing.T) {
+	now := time.Unix(1_000_000, 0).UTC()
+	store, ids := &identityTestStore{}, &identityTestIDs{}
+	svc, _ := NewService(store, identityTestProtector{}, identityTestClock{now}, ids)
+
+	// Within the cap: rotation succeeds and the replacement inherits the original origin (not reset).
+	fresh, err := identity.NewSession("s1", "tenant", "user", stateHash("tok"), stateHash("csrf"), nil, now.Add(time.Hour), now.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotated, err := svc.RotateSession(context.Background(), fresh, nil, time.Hour)
+	if err != nil {
+		t.Fatalf("within-cap rotation must succeed: %v", err)
+	}
+	if !rotated.Session.OriginAt.Equal(fresh.OriginAt) {
+		t.Fatalf("rotation must carry the immutable origin: got %s want %s", rotated.Session.OriginAt, fresh.OriginAt)
+	}
+
+	// Past the cap: refused with ErrForbidden even though the sliding expiry is still in the future.
+	old, err := identity.NewSession("s2", "tenant", "user", stateHash("tok2"), stateHash("csrf2"), nil, now.Add(time.Hour), now.Add(-(identity.MaxSessionAge + time.Minute)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.RotateSession(context.Background(), old, nil, time.Hour); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("past-cap rotation must be forbidden, got %v", err)
+	}
+}

--- a/internal/usecase/identityuc/service_test.go
+++ b/internal/usecase/identityuc/service_test.go
@@ -1,0 +1,115 @@
+package identityuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/identity"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type identityTestClock struct{ now time.Time }
+
+func (c identityTestClock) Now() time.Time { return c.now }
+
+type identityTestIDs struct{ n int }
+
+func (g *identityTestIDs) NewID() shared.ID { g.n++; return shared.ID("id-" + string(rune('0'+g.n))) }
+
+type identityTestProtector struct{}
+
+func (identityTestProtector) Seal(_ context.Context, plaintext, aad []byte) (string, error) {
+	return string(aad) + "|" + string(plaintext), nil
+}
+func (identityTestProtector) Open(_ context.Context, ciphertext string, aad []byte) ([]byte, error) {
+	prefix := string(aad) + "|"
+	if len(ciphertext) < len(prefix) || ciphertext[:len(prefix)] != prefix {
+		return nil, errors.New("bad aad")
+	}
+	return []byte(ciphertext[len(prefix):]), nil
+}
+
+type identityTestStore struct {
+	transaction identity.AuthorizationTransaction
+	session     identity.Session
+	consumed    bool
+}
+
+func (s *identityTestStore) CreateExternalIdentity(context.Context, identity.ExternalIdentity) error {
+	return nil
+}
+func (s *identityTestStore) GetExternalIdentity(context.Context, string, string) (identity.ExternalIdentity, error) {
+	return identity.ExternalIdentity{}, shared.ErrNotFound
+}
+func (s *identityTestStore) CreateAuthorizationTransaction(_ context.Context, tx identity.AuthorizationTransaction) error {
+	s.transaction = tx
+	return nil
+}
+func (s *identityTestStore) ConsumeAuthorizationTransaction(_ context.Context, tenantID shared.ID, hash string, now time.Time) (identity.AuthorizationTransaction, error) {
+	if s.consumed || s.transaction.TenantID != tenantID || s.transaction.StateHash != hash || !s.transaction.Usable(now) {
+		return identity.AuthorizationTransaction{}, shared.ErrNotFound
+	}
+	s.consumed = true
+	return s.transaction, nil
+}
+func (s *identityTestStore) CreateSession(_ context.Context, session identity.Session) error {
+	s.session = session
+	return nil
+}
+func (s *identityTestStore) RotateSession(_ context.Context, _ shared.ID, replacement identity.Session, _ time.Time) error {
+	s.session = replacement
+	return nil
+}
+func (s *identityTestStore) GetSessionByTokenHash(_ context.Context, hash string) (identity.Session, error) {
+	if s.session.TokenHash != hash {
+		return identity.Session{}, shared.ErrNotFound
+	}
+	return s.session, nil
+}
+func (s *identityTestStore) RevokeSession(context.Context, shared.ID, shared.ID, time.Time) error {
+	return nil
+}
+
+var _ ports.IdentityStore = (*identityTestStore)(nil)
+
+func TestAuthorizationTransactionPersistsHashesAndCiphertextThenBurnsState(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	store, ids := &identityTestStore{}, &identityTestIDs{}
+	svc, err := NewService(store, identityTestProtector{}, identityTestClock{now}, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := svc.BeginAuthorization(context.Background(), "tenant", "pkce-verifier", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.transaction.StateHash == started.State || store.transaction.NonceHash == started.Nonce || store.transaction.PKCEVerifierCiphertext == "pkce-verifier" {
+		t.Fatalf("store must not receive raw transaction secrets: %+v", store.transaction)
+	}
+	consumed, err := svc.ConsumeAuthorization(context.Background(), "tenant", started.State)
+	if err != nil || consumed.PKCEVerifier != "pkce-verifier" || consumed.NonceHash != stateHash(started.Nonce) || consumed.TenantID != "tenant" {
+		t.Fatalf("consume transaction: %+v err=%v", consumed, err)
+	}
+	if _, err := svc.ConsumeAuthorization(context.Background(), "tenant", started.State); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("replay must fail: %v", err)
+	}
+}
+
+func TestCreateSessionPersistsOnlyTokenHashes(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	store, ids := &identityTestStore{}, &identityTestIDs{}
+	svc, _ := NewService(store, identityTestProtector{}, identityTestClock{now}, ids)
+	created, err := svc.CreateSession(context.Background(), "tenant", "user", map[string]string{"ip": "127.0.0.1"}, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.session.TokenHash == created.Token || store.session.CSRFTokenHash == created.CSRFToken {
+		t.Fatal("session store must receive hashes rather than raw tokens")
+	}
+	if _, err := svc.AuthenticateSession(context.Background(), "tenant", created.Token); err != nil {
+		t.Fatalf("authenticate fresh session: %v", err)
+	}
+}

--- a/internal/usecase/ports/identity.go
+++ b/internal/usecase/ports/identity.go
@@ -1,0 +1,26 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/identity"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// IdentityStore persists OIDC subject links, login transactions, and opaque browser sessions.
+// ConsumeAuthorizationTransaction must atomically return a transaction at most once across all
+// processes. Values passed to it are hashes, never raw browser credentials.
+type IdentityStore interface {
+	CreateExternalIdentity(ctx context.Context, identity identity.ExternalIdentity) error
+	GetExternalIdentity(ctx context.Context, issuer, subject string) (identity.ExternalIdentity, error)
+
+	CreateAuthorizationTransaction(ctx context.Context, transaction identity.AuthorizationTransaction) error
+	ConsumeAuthorizationTransaction(ctx context.Context, tenantID shared.ID, stateHash string, now time.Time) (identity.AuthorizationTransaction, error)
+
+	CreateSession(ctx context.Context, session identity.Session) error
+	// RotateSession atomically creates replacement and revokes the active previous session.
+	RotateSession(ctx context.Context, previousSessionID shared.ID, replacement identity.Session, now time.Time) error
+	GetSessionByTokenHash(ctx context.Context, tokenHash string) (identity.Session, error)
+	RevokeSession(ctx context.Context, tenantID, sessionID shared.ID, now time.Time) error
+}

--- a/internal/usecase/ports/identity_oidc.go
+++ b/internal/usecase/ports/identity_oidc.go
@@ -1,0 +1,27 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/user"
+)
+
+// OIDCIdentity is the verified non-secret identity output of a configured OpenID Provider.
+type OIDCIdentity struct {
+	Issuer  string
+	Subject string
+	Role    user.Role
+	// Name is an optional bounded display string. It is never an identity key: only
+	// (Issuer, Subject) identifies the subject.
+	Name string
+}
+
+// OIDCProvider executes the authorization-code protocol. Implementations must use PKCE S256 and
+// verify issuer, audience, signature, nonce, and optional at_hash before returning an identity.
+type OIDCProvider interface {
+	// GenerateVerifier mints a PKCE code verifier. It lives on the protocol adapter so no use
+	// case depends on a concrete OAuth2 library.
+	GenerateVerifier() string
+	AuthorizationURL(state, nonce, verifier string) (string, error)
+	ExchangeAndVerify(ctx context.Context, code, verifier, nonce string) (OIDCIdentity, error)
+}

--- a/internal/usecase/ports/identity_secrets.go
+++ b/internal/usecase/ports/identity_secrets.go
@@ -1,0 +1,10 @@
+package ports
+
+import "context"
+
+// IdentitySecretProtector encrypts short-lived PKCE verifiers before persistence. Implementations
+// must authenticate ciphertext to the supplied associated data; plaintext never reaches a store.
+type IdentitySecretProtector interface {
+	Seal(ctx context.Context, plaintext, associatedData []byte) (string, error)
+	Open(ctx context.Context, ciphertext string, associatedData []byte) ([]byte, error)
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -882,11 +882,6 @@ type EvidenceStore interface {
 	Head(ctx context.Context, engagementID shared.ID) (string, error)
 }
 
-// BlobStore stores and retrieves binary artifacts content-addressed by their
-// lowercase-hex SHA-256, so identical content dedups and tampering is detectable
-// against the evidence chain (the same hash is sealed into the chain). Used by the
-// evidence vault for screenshots, raw tool output, request/response captures, etc.
-// . Put is idempotent for the same key+content.
 // RestoreEvidenceChain is one independently verifiable evidence chain from a restored database.
 // ID is the engagement identifier; Items are ordered from genesis to head.
 type RestoreEvidenceChain struct {
@@ -945,6 +940,11 @@ type RestoreExpectedState struct {
 	MigrationVersions []int64                        `json:"migration_versions"`
 }
 
+// BlobStore stores and retrieves binary artifacts content-addressed by their
+// lowercase-hex SHA-256, so identical content dedups and tampering is detectable
+// against the evidence chain (the same hash is sealed into the chain). Used by the
+// evidence vault for screenshots, raw tool output, request/response captures, etc.
+// Put is idempotent for the same key+content.
 type BlobStore interface {
 	Put(ctx context.Context, sha256hex string, data []byte) error
 	Get(ctx context.Context, sha256hex string) ([]byte, error)

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -887,6 +887,64 @@ type EvidenceStore interface {
 // against the evidence chain (the same hash is sealed into the chain). Used by the
 // evidence vault for screenshots, raw tool output, request/response captures, etc.
 // . Put is idempotent for the same key+content.
+// RestoreEvidenceChain is one independently verifiable evidence chain from a restored database.
+// ID is the engagement identifier; Items are ordered from genesis to head.
+type RestoreEvidenceChain struct {
+	ID    shared.ID
+	Items []evidence.Evidence
+}
+
+// RestoreEvidenceReader enumerates every restored evidence chain for offline recovery
+// verification. Implementations must not mutate custody data.
+type RestoreEvidenceReader interface {
+	ListEvidenceChains(ctx context.Context) ([]RestoreEvidenceChain, error)
+}
+
+// ObjectMetadata is the content-address identity reported without reading object bytes.
+type ObjectMetadata struct {
+	SHA256 string
+}
+
+// RestoreBlobReader obtains metadata for a referenced evidence object without reading
+// its contents. The returned SHA256 must be the object's persisted checksum metadata.
+type RestoreBlobReader interface {
+	Stat(ctx context.Context, sha256hex string) (ObjectMetadata, error)
+}
+
+// MigrationMetadata is the latest recorded state of one database migration.
+type MigrationMetadata struct {
+	Version int64 `json:"version"`
+	Applied bool  `json:"applied"`
+}
+
+// RestoreMigrationReader reads migration state from a restored database without
+// applying or altering migrations.
+type RestoreMigrationReader interface {
+	MigrationMetadata(ctx context.Context) ([]MigrationMetadata, error)
+}
+
+// RestoreAuditReader verifies the full, global audit chain from a restored database.
+// This maintenance-only boundary must not be exposed to tenant-scoped transports.
+type RestoreAuditReader interface {
+	VerifyGlobal(ctx context.Context) (audit.Report, error)
+}
+
+// RestoreExpectedEvidenceChain is the independently captured state expected for one
+// engagement after a restore. Head may be empty only when Count is zero.
+type RestoreExpectedEvidenceChain struct {
+	EngagementID shared.ID `json:"engagement_id"`
+	Head         string    `json:"head"`
+	Count        int       `json:"count"`
+}
+
+// RestoreExpectedState is an optional, independently captured restore target. Its
+// presence permits a completeness check in addition to local chain verification.
+type RestoreExpectedState struct {
+	AuditHead         string                         `json:"audit_head"`
+	EvidenceChains    []RestoreExpectedEvidenceChain `json:"evidence_chains"`
+	MigrationVersions []int64                        `json:"migration_versions"`
+}
+
 type BlobStore interface {
 	Put(ctx context.Context, sha256hex string, data []byte) error
 	Get(ctx context.Context, sha256hex string) ([]byte, error)
@@ -941,6 +999,30 @@ type TimestampStore interface {
 type AUPStore interface {
 	Accepted(ctx context.Context, version string) (bool, error)
 	Save(ctx context.Context, a aup.Acceptance) error
+}
+
+// PoolStats is a bounded, driver-free snapshot of a database connection pool. It
+// carries no connection, tenant, or credential identity.
+type PoolStats struct {
+	AcquiredConns        int32
+	ConstructingConns    int32
+	IdleConns            int32
+	MaxConns             int32
+	TotalConns           int32
+	AcquireCount         int64
+	CanceledAcquireCount int64
+	EmptyAcquireCount    int64
+	NewConnsCount        int64
+	MaxIdleDestroyCount  int64
+	MaxLifetimeDestroy   int64
+	AcquireDuration      time.Duration
+	EmptyAcquireWaitTime time.Duration
+}
+
+// PoolStatsReader reports aggregate connection-pool saturation for metrics. It keeps the
+// concrete database driver out of the adapter layer.
+type PoolStatsReader interface {
+	PoolStats() PoolStats
 }
 
 // AuditEntry is one append-only audit record.

--- a/internal/usecase/ports/user.go
+++ b/internal/usecase/ports/user.go
@@ -17,4 +17,7 @@ type UserRepository interface {
 	// Upsert inserts or updates by id (used to keep the bootstrap admin's key in sync
 	// with SYNAPSE_API_TOKEN across restarts).
 	Upsert(ctx context.Context, u *user.User) error
+	// Bootstrap atomically seeds or refreshes the bootstrap user. Durable implementations
+	// record auditEntry only when the user is first created.
+	Bootstrap(ctx context.Context, u *user.User, auditEntry AuditEntry) error
 }

--- a/internal/usecase/restoreverify/service.go
+++ b/internal/usecase/restoreverify/service.go
@@ -1,0 +1,265 @@
+// Package restoreverify verifies the read-only integrity surface of a restored
+// deployment: evidence chains and their content-addressed objects, the global
+// audit chain, and applied migration metadata.
+package restoreverify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	auditdom "github.com/KKloudTarus/synapse-ce/internal/domain/audit"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type ObjectResult struct {
+	EvidenceID    string `json:"evidence_id"`
+	Reference     string `json:"reference,omitempty"`
+	Exists        bool   `json:"exists"`
+	IdentityMatch bool   `json:"identity_match"`
+	SHA256        string `json:"sha256,omitempty"`
+	Error         string `json:"error,omitempty"`
+}
+
+type EvidenceChainResult struct {
+	EngagementID string         `json:"engagement_id"`
+	Intact       bool           `json:"intact"`
+	Head         string         `json:"head"`
+	Count        int            `json:"count"`
+	Error        string         `json:"error,omitempty"`
+	Objects      []ObjectResult `json:"objects"`
+}
+
+type AuditResult struct {
+	Intact    bool   `json:"intact"`
+	Verified  int    `json:"verified"`
+	Unchained int    `json:"unchained"`
+	Head      string `json:"head"`
+	Error     string `json:"error,omitempty"`
+}
+
+type Result struct {
+	Intact         bool                      `json:"intact"`
+	Completeness   string                    `json:"completeness"`
+	EvidenceChains []EvidenceChainResult     `json:"evidence_chains"`
+	Audit          AuditResult               `json:"audit"`
+	Migrations     []ports.MigrationMetadata `json:"migrations"`
+}
+
+const (
+	completenessVerified   = "verified_against_expected_state"
+	completenessIncomplete = "incomplete_no_expected_state"
+	completenessMismatch   = "expected_state_mismatch"
+)
+
+type Service struct {
+	evidence   ports.RestoreEvidenceReader
+	blobs      ports.RestoreBlobReader
+	migrations ports.RestoreMigrationReader
+	audit      ports.RestoreAuditReader
+	expected   *ports.RestoreExpectedState
+}
+
+// NewService validates read-only dependencies. At most one expected-state manifest may be supplied.
+func NewService(evidenceReader ports.RestoreEvidenceReader, blobs ports.RestoreBlobReader, migrations ports.RestoreMigrationReader, auditReader ports.RestoreAuditReader, expected ...ports.RestoreExpectedState) (*Service, error) {
+	if evidenceReader == nil || blobs == nil || migrations == nil || auditReader == nil || len(expected) > 1 {
+		return nil, fmt.Errorf("%w: restore verification requires evidence, blob, migration, and audit readers", shared.ErrValidation)
+	}
+	s := &Service{evidence: evidenceReader, blobs: blobs, migrations: migrations, audit: auditReader}
+	if len(expected) == 1 {
+		state := expected[0]
+		s.expected = &state
+	}
+	return s, nil
+}
+
+func (s *Service) Verify(ctx context.Context) (Result, error) {
+	chains, err := s.evidence.ListEvidenceChains(ctx)
+	if err != nil {
+		return Result{}, contextOr(ctx, "list evidence chains", err)
+	}
+	migrations, err := s.migrations.MigrationMetadata(ctx)
+	if err != nil {
+		return Result{}, contextOr(ctx, "read migration metadata", err)
+	}
+	auditReport, err := s.audit.VerifyGlobal(ctx)
+	if err != nil {
+		return Result{}, contextOr(ctx, "verify global audit chain", err)
+	}
+
+	chains = append([]ports.RestoreEvidenceChain(nil), chains...)
+	migrations = append([]ports.MigrationMetadata(nil), migrations...)
+	sort.Slice(chains, func(i, j int) bool { return chains[i].ID < chains[j].ID })
+	for i := 1; i < len(chains); i++ {
+		if chains[i-1].ID == chains[i].ID {
+			return Result{}, errors.New("duplicate evidence chain")
+		}
+	}
+	sort.Slice(migrations, func(i, j int) bool { return migrations[i].Version < migrations[j].Version })
+	for i := 1; i < len(migrations); i++ {
+		if migrations[i-1].Version == migrations[i].Version {
+			return Result{}, errors.New("duplicate migration version")
+		}
+	}
+
+	result := Result{Intact: auditReport.Intact && auditReport.Unchained == 0, Audit: auditResult(auditReport), Migrations: migrations}
+	if auditReport.Unchained != 0 {
+		result.Audit.Error = "unchained_records"
+	}
+	if s.expected == nil {
+		result.Completeness = completenessIncomplete
+	} else {
+		result.Completeness = completenessVerified
+	}
+	stats := make(map[string]objectStat)
+	seenEvidence := make(map[shared.ID]struct{})
+	for _, chain := range chains {
+		chainResult, err := s.verifyEvidenceChain(ctx, chain, seenEvidence, stats)
+		if err != nil {
+			return Result{}, err
+		}
+		result.EvidenceChains = append(result.EvidenceChains, chainResult)
+		if !chainResult.Intact {
+			result.Intact = false
+		}
+	}
+	if s.expected != nil && !matchesExpectedState(result, *s.expected) {
+		result.Intact = false
+		result.Completeness = completenessMismatch
+	}
+	return result, nil
+}
+
+type objectStat struct {
+	metadata ports.ObjectMetadata
+	err      error
+}
+
+func (s *Service) verifyEvidenceChain(ctx context.Context, chain ports.RestoreEvidenceChain, seen map[shared.ID]struct{}, stats map[string]objectStat) (EvidenceChainResult, error) {
+	result := EvidenceChainResult{EngagementID: chain.ID.String(), Intact: true, Count: len(chain.Items)}
+	if chain.ID.IsZero() {
+		result.Intact = false
+		result.Error = "identity_mismatch"
+		return result, nil
+	}
+	if len(chain.Items) > 0 {
+		result.Head = chain.Items[len(chain.Items)-1].Hash
+	}
+	for _, item := range chain.Items {
+		if item.ID.IsZero() || item.EngagementID != chain.ID {
+			result.Intact = false
+			result.Error = "identity_mismatch"
+			return result, nil
+		}
+		if _, exists := seen[item.ID]; exists {
+			result.Intact = false
+			result.Error = "identity_mismatch"
+			return result, nil
+		}
+		seen[item.ID] = struct{}{}
+	}
+	if err := evidence.VerifyChain(chain.Items); err != nil {
+		result.Intact = false
+		result.Error = "chain_invalid"
+	}
+	for _, item := range chain.Items {
+		if item.StorageRef == "" {
+			continue
+		}
+		object := ObjectResult{EvidenceID: item.ID.String()}
+		if !validSHA256(item.StorageRef) {
+			object.Error = "invalid_reference"
+			result.Intact = false
+			result.Objects = append(result.Objects, object)
+			continue
+		}
+		object.Reference = item.StorageRef
+		cached, ok := stats[item.StorageRef]
+		if !ok {
+			metadata, err := s.blobs.Stat(ctx, item.StorageRef)
+			if err != nil {
+				if isContextError(ctx, err) {
+					return EvidenceChainResult{}, fmt.Errorf("stat evidence object: %w", contextError(ctx, err))
+				}
+				cached = objectStat{err: err}
+			} else {
+				cached = objectStat{metadata: metadata}
+			}
+			stats[item.StorageRef] = cached
+		}
+		if cached.err != nil {
+			if errors.Is(cached.err, shared.ErrNotFound) {
+				object.Error = "not_found"
+			} else {
+				object.Error = "stat_failed"
+			}
+			result.Intact = false
+			result.Objects = append(result.Objects, object)
+			continue
+		}
+		object.Exists = true
+		object.SHA256 = cached.metadata.SHA256
+		object.IdentityMatch = cached.metadata.SHA256 == item.StorageRef
+		if !object.IdentityMatch {
+			object.Error = "identity_mismatch"
+			result.Intact = false
+		}
+		result.Objects = append(result.Objects, object)
+	}
+	return result, nil
+}
+
+func matchesExpectedState(result Result, expected ports.RestoreExpectedState) bool {
+	if result.Audit.Head != expected.AuditHead || len(result.EvidenceChains) != len(expected.EvidenceChains) || len(result.Migrations) != len(expected.MigrationVersions) {
+		return false
+	}
+	expectedChains := append([]ports.RestoreExpectedEvidenceChain(nil), expected.EvidenceChains...)
+	sort.Slice(expectedChains, func(i, j int) bool { return expectedChains[i].EngagementID < expectedChains[j].EngagementID })
+	for i, actual := range result.EvidenceChains {
+		want := expectedChains[i]
+		if actual.EngagementID != want.EngagementID.String() || actual.Head != want.Head || actual.Count != want.Count {
+			return false
+		}
+	}
+	expectedVersions := append([]int64(nil), expected.MigrationVersions...)
+	sort.Slice(expectedVersions, func(i, j int) bool { return expectedVersions[i] < expectedVersions[j] })
+	for i, actual := range result.Migrations {
+		if actual.Version != expectedVersions[i] || !actual.Applied {
+			return false
+		}
+	}
+	return true
+}
+
+func auditResult(report auditdom.Report) AuditResult {
+	return AuditResult{Intact: report.Intact && report.Unchained == 0, Verified: report.Verified, Unchained: report.Unchained, Head: report.Head, Error: report.Error}
+}
+func validSHA256(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		if !(r >= '0' && r <= '9') && !(r >= 'a' && r <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+func isContextError(ctx context.Context, err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil
+}
+func contextError(ctx context.Context, err error) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
+}
+func contextOr(ctx context.Context, operation string, err error) error {
+	if isContextError(ctx, err) {
+		return fmt.Errorf("%s: %w", operation, contextError(ctx, err))
+	}
+	return fmt.Errorf("%s: %w", operation, err)
+}

--- a/internal/usecase/restoreverify/service_test.go
+++ b/internal/usecase/restoreverify/service_test.go
@@ -1,0 +1,342 @@
+package restoreverify
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	auditdom "github.com/KKloudTarus/synapse-ce/internal/domain/audit"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type evidenceReaderStub struct {
+	chains []ports.RestoreEvidenceChain
+	err    error
+	calls  int
+}
+
+func (s *evidenceReaderStub) ListEvidenceChains(context.Context) ([]ports.RestoreEvidenceChain, error) {
+	s.calls++
+	return s.chains, s.err
+}
+
+type blobReaderStub struct {
+	objects map[string]ports.ObjectMetadata
+	errs    map[string]error
+	calls   []string
+}
+
+func (s *blobReaderStub) Stat(_ context.Context, ref string) (ports.ObjectMetadata, error) {
+	s.calls = append(s.calls, ref)
+	if err := s.errs[ref]; err != nil {
+		return ports.ObjectMetadata{}, err
+	}
+	return s.objects[ref], nil
+}
+
+type migrationReaderStub struct {
+	migrations []ports.MigrationMetadata
+	err        error
+	calls      int
+}
+
+func (s *migrationReaderStub) MigrationMetadata(context.Context) ([]ports.MigrationMetadata, error) {
+	s.calls++
+	return s.migrations, s.err
+}
+
+type auditReaderStub struct {
+	report auditdom.Report
+	err    error
+	calls  int
+}
+
+func (s *auditReaderStub) VerifyGlobal(context.Context) (auditdom.Report, error) {
+	s.calls++
+	return s.report, s.err
+}
+
+func TestNewServiceRequiresAllReaders(t *testing.T) {
+	evidence := &evidenceReaderStub{}
+	blobs := &blobReaderStub{}
+	migrations := &migrationReaderStub{}
+	audit := &auditReaderStub{}
+
+	for _, tt := range []struct {
+		name string
+		e    ports.RestoreEvidenceReader
+		b    ports.RestoreBlobReader
+		m    ports.RestoreMigrationReader
+		a    ports.RestoreAuditReader
+	}{
+		{"evidence", nil, blobs, migrations, audit},
+		{"blobs", evidence, nil, migrations, audit},
+		{"migrations", evidence, blobs, nil, audit},
+		{"audit", evidence, blobs, migrations, nil},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewService(tt.e, tt.b, tt.m, tt.a); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("NewService() error = %v, want validation error", err)
+			}
+		})
+	}
+}
+
+func TestVerifyDeterministicallyVerifiesChainsObjectsAuditAndMigrations(t *testing.T) {
+	createdAt := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	artifact := []byte("sealed artifact")
+	ref := digest(artifact)
+	link := evidence.Evidence{ID: "e-1", EngagementID: "eng-b", Kind: "artifact", StorageRef: ref, Content: []byte("metadata"), CreatedAt: createdAt}.Seal()
+	plain := evidence.Evidence{ID: "e-2", EngagementID: "eng-a", Kind: "note", Content: []byte("note"), CreatedAt: createdAt}.Seal()
+	evidenceReader := &evidenceReaderStub{chains: []ports.RestoreEvidenceChain{
+		{ID: "eng-b", Items: []evidence.Evidence{link}},
+		{ID: "eng-a", Items: []evidence.Evidence{plain}},
+	}}
+	blobs := &blobReaderStub{objects: map[string]ports.ObjectMetadata{ref: {SHA256: ref}}}
+	migrations := &migrationReaderStub{migrations: []ports.MigrationMetadata{
+		{Version: 12, Applied: true},
+		{Version: 4, Applied: true},
+	}}
+	audit := &auditReaderStub{report: auditdom.Report{Intact: true, Verified: 3, Head: "audit-head"}}
+	svc, err := NewService(evidenceReader, blobs, migrations, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := svc.Verify(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := svc.Verify(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstJSON, _ := json.Marshal(first)
+	secondJSON, _ := json.Marshal(second)
+	if string(firstJSON) != string(secondJSON) {
+		t.Fatalf("verification must be deterministic:\n%s\n%s", firstJSON, secondJSON)
+	}
+	if !first.Intact || first.Audit.Head != "audit-head" || len(first.EvidenceChains) != 2 {
+		t.Fatalf("unexpected result: %+v", first)
+	}
+	if first.EvidenceChains[0].EngagementID != "eng-a" || first.EvidenceChains[1].EngagementID != "eng-b" {
+		t.Fatalf("chains not sorted: %+v", first.EvidenceChains)
+	}
+	object := first.EvidenceChains[1].Objects[0]
+	if !object.Exists || !object.IdentityMatch || object.SHA256 != ref {
+		t.Fatalf("object not verified: %+v", object)
+	}
+	if got := []int64{first.Migrations[0].Version, first.Migrations[1].Version}; !reflect.DeepEqual(got, []int64{4, 12}) {
+		t.Fatalf("migrations not sorted: %v", got)
+	}
+	if len(blobs.calls) != 2 || blobs.calls[0] != ref || blobs.calls[1] != ref {
+		t.Fatalf("unexpected blob reads: %v", blobs.calls)
+	}
+	if first.Completeness != completenessIncomplete {
+		t.Fatalf("missing expected state must be reported as incomplete: %+v", first)
+	}
+	if evidenceReader.calls != 2 || migrations.calls != 2 || audit.calls != 2 {
+		t.Fatalf("verification must only call read ports: evidence=%d migrations=%d audit=%d", evidenceReader.calls, migrations.calls, audit.calls)
+	}
+}
+
+func TestVerifyReportsChainAndObjectFailuresWithoutReturningContent(t *testing.T) {
+	createdAt := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	missing := digest([]byte("missing"))
+	mismatched := digest([]byte("expected"))
+	broken := evidence.Evidence{ID: "broken", EngagementID: "eng", Kind: "artifact", StorageRef: missing, Content: []byte("secret-content"), CreatedAt: createdAt}.Seal()
+	broken.Hash = "tampered"
+	second := evidence.Evidence{ID: "mismatch", EngagementID: "eng", Kind: "artifact", StorageRef: mismatched, Content: []byte("other-secret"), CreatedAt: createdAt}.Seal()
+
+	svc, err := NewService(
+		&evidenceReaderStub{chains: []ports.RestoreEvidenceChain{{ID: "eng", Items: []evidence.Evidence{broken, second}}}},
+		&blobReaderStub{objects: map[string]ports.ObjectMetadata{mismatched: {SHA256: digest([]byte("different"))}}, errs: map[string]error{missing: shared.ErrNotFound}},
+		&migrationReaderStub{},
+		&auditReaderStub{report: auditdom.Report{Intact: true}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.Verify(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := result.EvidenceChains[0]
+	if result.Intact || chain.Intact || chain.Objects[0].Exists || chain.Objects[0].IdentityMatch || chain.Objects[1].IdentityMatch {
+		t.Fatalf("failures must make the report non-intact: %+v", result)
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) == "" || contains(string(encoded), "secret-content") || contains(string(encoded), "other-secret") {
+		t.Fatalf("result exposed evidence content: %s", encoded)
+	}
+}
+
+func TestVerifyReturnsTopLevelReaderErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		e    *evidenceReaderStub
+		m    *migrationReaderStub
+		a    *auditReaderStub
+		want string
+	}{
+		{"evidence", &evidenceReaderStub{err: errors.New("offline")}, &migrationReaderStub{}, &auditReaderStub{}, "list evidence chains"},
+		{"migrations", &evidenceReaderStub{}, &migrationReaderStub{err: errors.New("offline")}, &auditReaderStub{}, "read migration metadata"},
+		{"audit", &evidenceReaderStub{}, &migrationReaderStub{}, &auditReaderStub{err: errors.New("offline")}, "verify global audit chain"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _ := NewService(tt.e, &blobReaderStub{}, tt.m, tt.a)
+			if _, err := svc.Verify(context.Background()); err == nil || !contains(err.Error(), tt.want) {
+				t.Fatalf("Verify() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func TestVerifyFailsClosedForExpectedStateMismatchesAndUnchainedAudit(t *testing.T) {
+	createdAt := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	item := evidence.Evidence{ID: "e-1", EngagementID: "eng", Kind: "note", Content: []byte("metadata"), CreatedAt: createdAt}.Seal()
+	manifest := ports.RestoreExpectedState{
+		AuditHead:         "audit-head",
+		EvidenceChains:    []ports.RestoreExpectedEvidenceChain{{EngagementID: "eng", Head: item.Hash, Count: 1}},
+		MigrationVersions: []int64{7},
+	}
+	for _, tt := range []struct {
+		name       string
+		audit      auditdom.Report
+		migrations []ports.MigrationMetadata
+		manifest   ports.RestoreExpectedState
+	}{
+		{"matching", auditdom.Report{Intact: true, Head: "audit-head"}, []ports.MigrationMetadata{{Version: 7, Applied: true}}, manifest},
+		{"missing evidence", auditdom.Report{Intact: true, Head: "audit-head"}, []ports.MigrationMetadata{{Version: 7, Applied: true}}, manifest},
+		{"rolled back migration", auditdom.Report{Intact: true, Head: "audit-head"}, []ports.MigrationMetadata{{Version: 7, Applied: false}}, manifest},
+		{"unchained audit", auditdom.Report{Intact: true, Head: "audit-head", Unchained: 1}, []ports.MigrationMetadata{{Version: 7, Applied: true}}, manifest},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			chains := []ports.RestoreEvidenceChain{{ID: "eng", Items: []evidence.Evidence{item}}}
+			if tt.name == "missing evidence" {
+				chains = nil
+			}
+			svc, err := NewService(&evidenceReaderStub{chains: chains}, &blobReaderStub{}, &migrationReaderStub{migrations: tt.migrations}, &auditReaderStub{report: tt.audit}, tt.manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := svc.Verify(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantIntact := tt.name == "matching"
+			if got.Intact != wantIntact {
+				t.Fatalf("Intact = %v, want %v: %+v", got.Intact, wantIntact, got)
+			}
+			if tt.name != "unchained audit" && !wantIntact && got.Completeness != completenessMismatch {
+				t.Fatalf("Completeness = %q", got.Completeness)
+			}
+			if tt.name == "unchained audit" && got.Audit.Intact {
+				t.Fatalf("unchained audit reported intact: %+v", got.Audit)
+			}
+		})
+	}
+}
+
+func TestVerifyRejectsInvalidIdentityAndSanitizesObjectFailures(t *testing.T) {
+	createdAt := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	validRef := digest([]byte("artifact"))
+	invalidRef := "SECRET-INVALID-REFERENCE"
+	first := evidence.Evidence{ID: "duplicate", EngagementID: "eng", Kind: "note", StorageRef: validRef, Content: []byte("one"), CreatedAt: createdAt}.Seal()
+	second := evidence.Evidence{ID: "duplicate", EngagementID: "eng", Kind: "note", StorageRef: invalidRef, Content: []byte("two"), CreatedAt: createdAt}.Seal()
+	blobs := &blobReaderStub{errs: map[string]error{validRef: errors.New("raw adapter secret")}}
+	svc, _ := NewService(&evidenceReaderStub{chains: []ports.RestoreEvidenceChain{{ID: "eng", Items: []evidence.Evidence{first, second}}}}, blobs, &migrationReaderStub{}, &auditReaderStub{report: auditdom.Report{Intact: true}})
+	got, err := svc.Verify(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Intact || got.EvidenceChains[0].Error != "identity_mismatch" {
+		t.Fatalf("identity failure was not rejected: %+v", got)
+	}
+	if len(blobs.calls) != 0 {
+		t.Fatalf("identity failure should happen before blob I/O: %v", blobs.calls)
+	}
+
+	item := evidence.Evidence{ID: "e", EngagementID: "eng", Kind: "note", StorageRef: invalidRef, Content: []byte("safe"), CreatedAt: createdAt}.Seal()
+	svc, _ = NewService(&evidenceReaderStub{chains: []ports.RestoreEvidenceChain{{ID: "eng", Items: []evidence.Evidence{item}}}}, &blobReaderStub{}, &migrationReaderStub{}, &auditReaderStub{report: auditdom.Report{Intact: true}})
+	got, err = svc.Verify(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	object := got.EvidenceChains[0].Objects[0]
+	encoded, _ := json.Marshal(got)
+	if object.Error != "invalid_reference" || object.Reference != "" || contains(string(encoded), invalidRef) {
+		t.Fatalf("invalid reference leaked or was not bounded: %s", encoded)
+	}
+
+	item = evidence.Evidence{ID: "stat-fail", EngagementID: "eng", Kind: "note", StorageRef: validRef, Content: []byte("safe"), CreatedAt: createdAt}.Seal()
+	svc, _ = NewService(&evidenceReaderStub{chains: []ports.RestoreEvidenceChain{{ID: "eng", Items: []evidence.Evidence{item}}}}, &blobReaderStub{errs: map[string]error{validRef: errors.New("raw adapter secret")}}, &migrationReaderStub{}, &auditReaderStub{report: auditdom.Report{Intact: true}})
+	got, err = svc.Verify(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, _ = json.Marshal(got)
+	if got.EvidenceChains[0].Objects[0].Error != "stat_failed" || contains(string(encoded), "raw adapter secret") {
+		t.Fatalf("adapter failure leaked or was not bounded: %s", encoded)
+	}
+}
+
+func TestVerifyRejectsMismatchedEvidenceEngagement(t *testing.T) {
+	item := evidence.Evidence{ID: "e", EngagementID: "other", Kind: "note", Content: []byte("safe"), CreatedAt: time.Now().UTC()}.Seal()
+	svc, _ := NewService(&evidenceReaderStub{chains: []ports.RestoreEvidenceChain{{ID: "eng", Items: []evidence.Evidence{item}}}}, &blobReaderStub{}, &migrationReaderStub{}, &auditReaderStub{report: auditdom.Report{Intact: true}})
+	got, err := svc.Verify(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Intact || got.EvidenceChains[0].Error != "identity_mismatch" {
+		t.Fatalf("engagement identity mismatch accepted: %+v", got)
+	}
+}
+
+func TestVerifyCachesReferencesAndPropagatesCancellation(t *testing.T) {
+	createdAt := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	ref := digest([]byte("artifact"))
+	one := evidence.Evidence{ID: "one", EngagementID: "eng", Kind: "note", StorageRef: ref, Content: []byte("one"), CreatedAt: createdAt}.Seal()
+	two := evidence.Evidence{ID: "two", EngagementID: "eng", Kind: "note", StorageRef: ref, PreviousHash: one.Hash, Content: []byte("two"), CreatedAt: createdAt}.Seal()
+	blobs := &blobReaderStub{objects: map[string]ports.ObjectMetadata{ref: {SHA256: ref}}}
+	svc, _ := NewService(&evidenceReaderStub{chains: []ports.RestoreEvidenceChain{{ID: "eng", Items: []evidence.Evidence{one, two}}}}, blobs, &migrationReaderStub{}, &auditReaderStub{report: auditdom.Report{Intact: true}})
+	if _, err := svc.Verify(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(blobs.calls, []string{ref}) {
+		t.Fatalf("Stat calls = %v, want one unique reference", blobs.calls)
+	}
+
+	blobs = &blobReaderStub{errs: map[string]error{ref: context.Canceled}}
+	svc, _ = NewService(&evidenceReaderStub{chains: []ports.RestoreEvidenceChain{{ID: "eng", Items: []evidence.Evidence{one}}}}, blobs, &migrationReaderStub{}, &auditReaderStub{report: auditdom.Report{Intact: true}})
+	_, err := svc.Verify(context.Background())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify() error = %v, want wrapped cancellation", err)
+	}
+}

--- a/internal/usecase/sca/fptriage_blinded.go
+++ b/internal/usecase/sca/fptriage_blinded.go
@@ -1,0 +1,451 @@
+package sca
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	BlindFPTriagePacketSchema     = "synapse-fp-triage-blind-packet-v1"
+	BlindFPTriageSubmissionSchema = "synapse-fp-triage-blind-submission-v1"
+	BlindFPTriageJoinedSchema     = "synapse-fp-triage-blind-joined-v1"
+	blindFPTriageHMACAlgorithm    = "hmac-sha256"
+)
+
+var blindFPTriageForbiddenText = regexp.MustCompile(`(?i)\b(?:model verdict|model confidence|model rationale|proposer verdict|proposer confidence|proposer rationale|verifier verdict|verifier confidence|verifier rationale|experiment arm|would_gate_exempt|gate_exempt)\b`)
+
+// BlindFPTriageAuthenticator holds an operator-supplied private HMAC key.
+type BlindFPTriageAuthenticator struct{ key []byte }
+
+// NewBlindFPTriageAuthenticator rejects short keys rather than offering misleading authentication.
+func NewBlindFPTriageAuthenticator(key []byte) (BlindFPTriageAuthenticator, error) {
+	if len(key) < sha256.Size {
+		return BlindFPTriageAuthenticator{}, fmt.Errorf("blind triage authentication key must be at least %d bytes", sha256.Size)
+	}
+	return BlindFPTriageAuthenticator{key: append([]byte(nil), key...)}, nil
+}
+
+type BlindFPTriageAuthentication struct {
+	Algorithm string `json:"algorithm"`
+	MAC       string `json:"mac"`
+}
+
+// BlindFPTriagePacket is the reviewer-facing subset of an evaluation dataset and run. It deliberately
+// excludes labels and every model output, identity, confidence, rationale, and experiment-arm field.
+type BlindFPTriagePacket struct {
+	SchemaVersion  string                      `json:"schema_version"`
+	PacketID       string                      `json:"packet_id"`
+	DatasetVersion string                      `json:"dataset_version"`
+	DatasetSHA256  string                      `json:"dataset_sha256"`
+	RunSHA256      string                      `json:"run_sha256"`
+	Shadow         bool                        `json:"shadow"`
+	GateExempt     bool                        `json:"gate_exempt"`
+	Cases          []BlindFPTriagePacketCase   `json:"cases"`
+	Authentication BlindFPTriageAuthentication `json:"authentication"`
+}
+
+type BlindFPTriagePacketCase struct {
+	BlindID     string          `json:"blind_id"`
+	Language    string          `json:"language"`
+	Framework   string          `json:"framework"`
+	Kind        finding.Kind    `json:"kind"`
+	Severity    shared.Severity `json:"severity"`
+	CWE         string          `json:"cwe"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	File        string          `json:"file"`
+	Line        int             `json:"line"`
+	Source      string          `json:"source"`
+}
+
+type BlindFPTriageDecision string
+
+const (
+	BlindFPTriageFalsePositive BlindFPTriageDecision = "false_positive"
+	BlindFPTriageTruePositive  BlindFPTriageDecision = "true_positive"
+	BlindFPTriageAbstain       BlindFPTriageDecision = "abstain"
+)
+
+type BlindFPTriageReviewDecision struct {
+	BlindID   string                `json:"blind_id"`
+	Decision  BlindFPTriageDecision `json:"decision"`
+	Rationale string                `json:"rationale,omitempty"`
+}
+
+// BlindFPTriageSubmission is untrusted reviewer input. The trusted command boundary supplies reviewer identity separately.
+type BlindFPTriageSubmission struct {
+	SchemaVersion string                        `json:"schema_version"`
+	PacketID      string                        `json:"packet_id"`
+	DatasetSHA256 string                        `json:"dataset_sha256"`
+	RunSHA256     string                        `json:"run_sha256"`
+	Shadow        bool                          `json:"shadow"`
+	GateExempt    bool                          `json:"gate_exempt"`
+	Decisions     []BlindFPTriageReviewDecision `json:"decisions"`
+}
+
+// BlindFPTriageImportedSubmission is an authenticated receipt binding reviewer identity, decisions, dataset, run, and packet.
+type BlindFPTriageImportedSubmission struct {
+	BlindFPTriageSubmission
+	Reviewer       string                      `json:"reviewer"`
+	Authentication BlindFPTriageAuthentication `json:"authentication"`
+}
+
+// BlindFPTriageMetrics measure a submitted human review against the locked ground truth only after join.
+type BlindFPTriageMetrics struct {
+	Total                   int     `json:"total"`
+	Reviewed                int     `json:"reviewed"`
+	HumanFalsePositives     int     `json:"human_false_positives"`
+	DecidedFalsePositives   int     `json:"decided_false_positives"`
+	CorrectFalsePositives   int     `json:"correct_false_positives"`
+	Abstentions             int     `json:"abstentions"`
+	Disagreements           int     `json:"disagreements"`
+	DisagreementComparisons int     `json:"disagreement_comparisons"`
+	PolicyExemptible        int     `json:"policy_exemptible"`
+	Precision               float64 `json:"precision"`
+	Recall                  float64 `json:"recall"`
+	AbstentionRate          float64 `json:"abstention_rate"`
+	DisagreementRate        float64 `json:"disagreement_rate"`
+	PolicyExemptibleRate    float64 `json:"policy_exemptible_rate"`
+}
+
+// BlindFPTriageJoinedReport contains aggregate results only; it never republishes individual model output.
+type BlindFPTriageJoinedReport struct {
+	SchemaVersion string               `json:"schema_version"`
+	PacketID      string               `json:"packet_id"`
+	DatasetSHA256 string               `json:"dataset_sha256"`
+	RunSHA256     string               `json:"run_sha256"`
+	Reviewer      string               `json:"reviewer"`
+	Shadow        bool                 `json:"shadow"`
+	GateExempt    bool                 `json:"gate_exempt"`
+	Metrics       BlindFPTriageMetrics `json:"metrics"`
+}
+
+// ExportBlindFPTriagePacket makes a shuffled, seed-reproducible reviewer packet from a locked dataset/run.
+func ExportBlindFPTriagePacket(dataset AIEvaluationDataset, report AIEvaluationReport, seed string, authenticator BlindFPTriageAuthenticator) (BlindFPTriagePacket, error) {
+	if strings.TrimSpace(seed) == "" {
+		return BlindFPTriagePacket{}, fmt.Errorf("blind packet seed is required")
+	}
+	if !authenticator.valid() {
+		return BlindFPTriagePacket{}, fmt.Errorf("blind packet authentication is required")
+	}
+	if err := dataset.Validate(); err != nil {
+		return BlindFPTriagePacket{}, fmt.Errorf("validate blind packet dataset: %w", err)
+	}
+	if err := report.Validate(); err != nil {
+		return BlindFPTriagePacket{}, fmt.Errorf("validate blind packet run: %w", err)
+	}
+	if report.DatasetVersion != dataset.Version || report.DatasetSHA256 != evaluationDatasetDigest(dataset) {
+		return BlindFPTriagePacket{}, fmt.Errorf("blind packet dataset does not match evaluation run")
+	}
+
+	cases := append([]AIEvaluationCase(nil), dataset.Cases...)
+	sort.Slice(cases, func(i, j int) bool { return cases[i].ID < cases[j].ID })
+	packet := BlindFPTriagePacket{
+		SchemaVersion:  BlindFPTriagePacketSchema,
+		DatasetVersion: dataset.Version,
+		DatasetSHA256:  report.DatasetSHA256,
+		RunSHA256:      report.RunID,
+		Shadow:         true,
+		GateExempt:     false,
+		Cases:          make([]BlindFPTriagePacketCase, 0, len(cases)),
+	}
+	for _, c := range cases {
+		blindCase, err := blindSafeFPTriageProjection(c)
+		if err != nil {
+			return BlindFPTriagePacket{}, err
+		}
+		blindCase.BlindID = blindCaseID(seed, report.RunID, c.ID)
+		packet.Cases = append(packet.Cases, blindCase)
+	}
+	seedDigest := sha256.Sum256([]byte(seed))
+	// #nosec G404 -- the seeded PRNG provides reproducible blind ordering, not secrecy or authentication.
+	r := rand.New(rand.NewSource(int64(binary.BigEndian.Uint64(seedDigest[:8]))))
+	r.Shuffle(len(packet.Cases), func(i, j int) { packet.Cases[i], packet.Cases[j] = packet.Cases[j], packet.Cases[i] })
+	packetID, err := blindPacketDigest(packet)
+	if err != nil {
+		return BlindFPTriagePacket{}, fmt.Errorf("digest blind packet: %w", err)
+	}
+	packet.PacketID = packetID
+	if err := authenticator.signPacket(&packet); err != nil {
+		return BlindFPTriagePacket{}, err
+	}
+	return packet, nil
+}
+
+// ImportBlindFPTriageSubmission validates a reviewer response before it can be joined with the run.
+func ImportBlindFPTriageSubmission(packet BlindFPTriagePacket, submission BlindFPTriageSubmission, reviewer string, allowedHumanReviewers []string, proposer, verifier string, authenticator BlindFPTriageAuthenticator) (BlindFPTriageImportedSubmission, error) {
+	if err := validateBlindPacket(packet); err != nil {
+		return BlindFPTriageImportedSubmission{}, err
+	}
+	if submission.SchemaVersion != BlindFPTriageSubmissionSchema || submission.PacketID != packet.PacketID ||
+		submission.DatasetSHA256 != packet.DatasetSHA256 || submission.RunSHA256 != packet.RunSHA256 ||
+		!submission.Shadow || submission.GateExempt {
+		return BlindFPTriageImportedSubmission{}, fmt.Errorf("blind submission is not locked to the shadow, non-exempt packet")
+	}
+	if err := validateAuthenticatedBlindPacket(packet, authenticator); err != nil {
+		return BlindFPTriageImportedSubmission{}, err
+	}
+	if err := validateBlindFPTriageReviewer(reviewer, allowedHumanReviewers, proposer, verifier); err != nil {
+		return BlindFPTriageImportedSubmission{}, err
+	}
+	if len(submission.Decisions) != len(packet.Cases) {
+		return BlindFPTriageImportedSubmission{}, fmt.Errorf("blind submission must decide every packet case exactly once")
+	}
+	caseIDs := make(map[string]struct{}, len(packet.Cases))
+	for _, c := range packet.Cases {
+		caseIDs[c.BlindID] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(submission.Decisions))
+	for _, d := range submission.Decisions {
+		if _, ok := caseIDs[d.BlindID]; !ok {
+			return BlindFPTriageImportedSubmission{}, fmt.Errorf("blind submission contains unknown case %q", d.BlindID)
+		}
+		if _, duplicate := seen[d.BlindID]; duplicate {
+			return BlindFPTriageImportedSubmission{}, fmt.Errorf("blind submission contains duplicate case %q", d.BlindID)
+		}
+		seen[d.BlindID] = struct{}{}
+		if d.Decision != BlindFPTriageFalsePositive && d.Decision != BlindFPTriageTruePositive && d.Decision != BlindFPTriageAbstain {
+			return BlindFPTriageImportedSubmission{}, fmt.Errorf("blind submission case %q has invalid decision %q", d.BlindID, d.Decision)
+		}
+	}
+	imported := BlindFPTriageImportedSubmission{BlindFPTriageSubmission: submission, Reviewer: reviewer}
+	if err := authenticator.signSubmission(&imported); err != nil {
+		return BlindFPTriageImportedSubmission{}, err
+	}
+	return imported, nil
+}
+
+// JoinBlindFPTriageSubmission joins an already imported submission with the locked data and run.
+func JoinBlindFPTriageSubmission(dataset AIEvaluationDataset, report AIEvaluationReport, packet BlindFPTriagePacket, submission BlindFPTriageImportedSubmission, allowedHumanReviewers []string, authenticator BlindFPTriageAuthenticator) (BlindFPTriageJoinedReport, error) {
+	if err := dataset.Validate(); err != nil {
+		return BlindFPTriageJoinedReport{}, fmt.Errorf("validate join dataset: %w", err)
+	}
+	if err := report.Validate(); err != nil {
+		return BlindFPTriageJoinedReport{}, fmt.Errorf("validate join run: %w", err)
+	}
+	if err := validateAuthenticatedBlindPacket(packet, authenticator); err != nil {
+		return BlindFPTriageJoinedReport{}, err
+	}
+	if packet.DatasetSHA256 != evaluationDatasetDigest(dataset) || packet.RunSHA256 != report.RunID || report.DatasetSHA256 != packet.DatasetSHA256 {
+		return BlindFPTriageJoinedReport{}, fmt.Errorf("blind packet does not match dataset and evaluation run")
+	}
+	if err := validateImportedBlindFPTriageSubmission(packet, submission, allowedHumanReviewers, report.Run.ProposerModel, report.Run.VerifierModel, authenticator); err != nil {
+		return BlindFPTriageJoinedReport{}, fmt.Errorf("validate imported blind submission: %w", err)
+	}
+
+	byFile := make(map[string]AIEvaluationCase, len(dataset.Cases))
+	for _, c := range dataset.Cases {
+		byFile[c.File] = c
+	}
+	results := make(map[string]AIEvaluationResult, len(report.Results))
+	for _, r := range report.Results {
+		results[r.CaseID] = r
+	}
+	metrics := BlindFPTriageMetrics{Total: len(submission.Decisions)}
+	packetCases := make(map[string]BlindFPTriagePacketCase, len(packet.Cases))
+	for _, c := range packet.Cases {
+		packetCases[c.BlindID] = c
+	}
+	for _, d := range submission.Decisions {
+		blindCase := packetCases[d.BlindID]
+		c, ok := byFile[blindCase.File]
+		if !ok || c.Language != blindCase.Language || c.Framework != blindCase.Framework || c.Kind != blindCase.Kind || c.Severity != blindCase.Severity || c.CWE != blindCase.CWE || c.Title != blindCase.Title || c.Description != blindCase.Description || c.Line != blindCase.Line || c.Source != blindCase.Source {
+			return BlindFPTriageJoinedReport{}, fmt.Errorf("blind packet case mapping is invalid")
+		}
+		result, ok := results[c.ID]
+		if !ok {
+			return BlindFPTriageJoinedReport{}, fmt.Errorf("evaluation run has no result for case %q", c.ID)
+		}
+		if c.Label == AIEvaluationFalsePositive {
+			metrics.HumanFalsePositives++
+		}
+		if result.WouldGateExempt {
+			metrics.PolicyExemptible++
+		}
+		if d.Decision == BlindFPTriageAbstain {
+			metrics.Abstentions++
+			continue
+		}
+		metrics.Reviewed++
+		decisionFP := d.Decision == BlindFPTriageFalsePositive
+		if decisionFP {
+			metrics.DecidedFalsePositives++
+		}
+		if decisionFP && c.Label == AIEvaluationFalsePositive {
+			metrics.CorrectFalsePositives++
+		}
+		if result.Covered {
+			metrics.DisagreementComparisons++
+			if decisionFP != result.ConsensusFalsePositive {
+				metrics.Disagreements++
+			}
+		}
+	}
+	metrics.Precision = blindRatio(metrics.CorrectFalsePositives, metrics.DecidedFalsePositives)
+	metrics.Recall = blindRatio(metrics.CorrectFalsePositives, metrics.HumanFalsePositives)
+	metrics.AbstentionRate = blindRatio(metrics.Abstentions, metrics.Total)
+	metrics.DisagreementRate = blindRatio(metrics.Disagreements, metrics.DisagreementComparisons)
+	metrics.PolicyExemptibleRate = blindRatio(metrics.PolicyExemptible, metrics.Total)
+	return BlindFPTriageJoinedReport{SchemaVersion: BlindFPTriageJoinedSchema, PacketID: packet.PacketID, DatasetSHA256: packet.DatasetSHA256, RunSHA256: packet.RunSHA256, Reviewer: submission.Reviewer, Shadow: true, GateExempt: false, Metrics: metrics}, nil
+}
+
+func blindSafeFPTriageProjection(c AIEvaluationCase) (BlindFPTriagePacketCase, error) {
+	fields := []struct{ name, value string }{{"language", c.Language}, {"framework", c.Framework}, {"cwe", c.CWE}, {"title", c.Title}, {"description", c.Description}, {"file", c.File}, {"source", c.Source}}
+	for _, field := range fields {
+		if blindFPTriageForbiddenText.MatchString(field.value) {
+			return BlindFPTriagePacketCase{}, fmt.Errorf("blind packet %s contains a forbidden model-decision marker", field.name)
+		}
+	}
+	return BlindFPTriagePacketCase{Language: c.Language, Framework: c.Framework, Kind: c.Kind, Severity: c.Severity, CWE: c.CWE, Title: c.Title, Description: c.Description, File: c.File, Line: c.Line, Source: c.Source}, nil
+}
+
+func validateBlindFPTriageReviewer(reviewer string, allowedHumanReviewers []string, proposer, verifier string) error {
+	if strings.TrimSpace(reviewer) == "" || reviewer != strings.TrimSpace(reviewer) || aitriagereview.IsMachineOrModelActor(reviewer, proposer, verifier) {
+		return fmt.Errorf("blind submission reviewer must be an allowlisted human distinct from proposer and verifier")
+	}
+	for _, allowed := range allowedHumanReviewers {
+		if reviewer == allowed && reviewer == strings.TrimSpace(allowed) && !aitriagereview.IsMachineOrModelActor(allowed, proposer, verifier) {
+			return nil
+		}
+	}
+	return fmt.Errorf("blind submission reviewer is not an allowlisted human")
+}
+
+func validateImportedBlindFPTriageSubmission(packet BlindFPTriagePacket, submission BlindFPTriageImportedSubmission, allowedHumanReviewers []string, proposer, verifier string, authenticator BlindFPTriageAuthenticator) error {
+	if err := validateBlindFPTriageReviewer(submission.Reviewer, allowedHumanReviewers, proposer, verifier); err != nil {
+		return err
+	}
+	if err := authenticator.verifySubmission(submission); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateAuthenticatedBlindPacket(packet BlindFPTriagePacket, authenticator BlindFPTriageAuthenticator) error {
+	if err := validateBlindPacket(packet); err != nil {
+		return err
+	}
+	return authenticator.verifyPacket(packet)
+}
+
+func (a BlindFPTriageAuthenticator) valid() bool { return len(a.key) >= sha256.Size }
+func (a BlindFPTriageAuthenticator) signPacket(packet *BlindFPTriagePacket) error {
+	mac, err := a.mac("packet", canonicalBlindPacket(*packet))
+	if err != nil {
+		return err
+	}
+	packet.Authentication = BlindFPTriageAuthentication{Algorithm: blindFPTriageHMACAlgorithm, MAC: mac}
+	return nil
+}
+func (a BlindFPTriageAuthenticator) verifyPacket(packet BlindFPTriagePacket) error {
+	mac, err := a.mac("packet", canonicalBlindPacket(packet))
+	if err != nil || packet.Authentication.Algorithm != blindFPTriageHMACAlgorithm || !constantTimeHexEqual(packet.Authentication.MAC, mac) {
+		return fmt.Errorf("blind packet authentication failed")
+	}
+	return nil
+}
+func (a BlindFPTriageAuthenticator) signSubmission(submission *BlindFPTriageImportedSubmission) error {
+	mac, err := a.mac("submission", canonicalBlindSubmission(*submission))
+	if err != nil {
+		return err
+	}
+	submission.Authentication = BlindFPTriageAuthentication{Algorithm: blindFPTriageHMACAlgorithm, MAC: mac}
+	return nil
+}
+func (a BlindFPTriageAuthenticator) verifySubmission(submission BlindFPTriageImportedSubmission) error {
+	mac, err := a.mac("submission", canonicalBlindSubmission(submission))
+	if err != nil || submission.Authentication.Algorithm != blindFPTriageHMACAlgorithm || !constantTimeHexEqual(submission.Authentication.MAC, mac) {
+		return fmt.Errorf("blind submission authentication failed")
+	}
+	return nil
+}
+func (a BlindFPTriageAuthenticator) mac(kind string, canonical []byte) (string, error) {
+	if !a.valid() {
+		return "", fmt.Errorf("blind triage authentication is required")
+	}
+	h := hmac.New(sha256.New, a.key)
+	_, _ = h.Write([]byte("synapse-fp-triage-blind-v1\x00" + kind + "\x00"))
+	_, _ = h.Write(canonical)
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+func canonicalBlindPacket(packet BlindFPTriagePacket) []byte {
+	packet.Authentication = BlindFPTriageAuthentication{}
+	b, _ := json.Marshal(packet)
+	return b
+}
+func canonicalBlindSubmission(submission BlindFPTriageImportedSubmission) []byte {
+	submission.Authentication = BlindFPTriageAuthentication{}
+	b, _ := json.Marshal(submission)
+	return b
+}
+func constantTimeHexEqual(actual, expected string) bool {
+	actualBytes, err := hex.DecodeString(actual)
+	if err != nil {
+		return false
+	}
+	expectedBytes, err := hex.DecodeString(expected)
+	return err == nil && len(actualBytes) == len(expectedBytes) && subtle.ConstantTimeCompare(actualBytes, expectedBytes) == 1
+}
+
+func validateBlindPacket(packet BlindFPTriagePacket) error {
+	digest, err := blindPacketDigest(packet)
+	if err != nil {
+		return fmt.Errorf("digest blind packet: %w", err)
+	}
+	if packet.SchemaVersion != BlindFPTriagePacketSchema || strings.TrimSpace(packet.PacketID) == "" ||
+		!validEvaluationSHA256(packet.DatasetSHA256) || !validEvaluationSHA256(packet.RunSHA256) || !packet.Shadow || packet.GateExempt || len(packet.Cases) == 0 || packet.PacketID != digest {
+		return fmt.Errorf("invalid blind packet")
+	}
+	seen := make(map[string]struct{}, len(packet.Cases))
+	for _, c := range packet.Cases {
+		if !validEvaluationSHA256(c.BlindID) || strings.TrimSpace(c.Language) == "" || strings.TrimSpace(c.Framework) == "" ||
+			(c.Kind != finding.KindSAST && c.Kind != finding.KindMisconfig) || !c.Severity.Valid() || strings.TrimSpace(c.Title) == "" || strings.TrimSpace(c.File) == "" || c.Line <= 0 {
+			return fmt.Errorf("invalid blind packet case")
+		}
+		if _, err := blindSafeFPTriageProjection(AIEvaluationCase{Language: c.Language, Framework: c.Framework, Kind: c.Kind, Severity: c.Severity, CWE: c.CWE, Title: c.Title, Description: c.Description, File: c.File, Line: c.Line, Source: c.Source}); err != nil {
+			return err
+		}
+		if _, duplicate := seen[c.BlindID]; duplicate {
+			return fmt.Errorf("duplicate blind packet case")
+		}
+		seen[c.BlindID] = struct{}{}
+	}
+	return nil
+}
+
+func blindCaseID(seed, runID, caseID string) string {
+	sum := sha256.Sum256([]byte("synapse-fp-triage-blind-v1\x00" + seed + "\x00" + runID + "\x00" + caseID))
+	return hex.EncodeToString(sum[:])
+}
+
+func blindPacketDigest(packet BlindFPTriagePacket) (string, error) {
+	copyPacket := packet
+	copyPacket.PacketID = ""
+	copyPacket.Authentication = BlindFPTriageAuthentication{}
+	b, err := json.Marshal(copyPacket)
+	if err != nil {
+		return "", fmt.Errorf("marshal canonical blind packet: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func blindRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}

--- a/internal/usecase/sca/fptriage_blinded_test.go
+++ b/internal/usecase/sca/fptriage_blinded_test.go
@@ -1,0 +1,159 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type blindFixtureTriager struct{ run AIEvaluationRun }
+
+func (t blindFixtureTriager) Triage(_ context.Context, candidates []finding.Finding, _ string) []ports.AICritique {
+	out := make([]ports.AICritique, 0, len(candidates))
+	for _, c := range candidates {
+		verdict := "refuted"
+		if strings.Contains(c.DedupKey, "tp") {
+			verdict = "sound"
+		}
+		out = append(out, ports.AICritique{DedupKey: c.DedupKey, Verdict: verdict, Driver: "fixture", Confidence: 90,
+			ProposerProvider: t.run.ProposerProvider, ProposerModel: t.run.ProposerModel, ProposerModelFamily: t.run.ProposerModel,
+			VerifierProvider: t.run.VerifierProvider, VerifierModel: t.run.VerifierModel, VerifierModelFamily: t.run.VerifierModel,
+			VerifierVerdict: verdict, VerifierDriver: "fixture", VerifierConfidence: 90, IndependencePolicy: t.run.IndependencePolicy,
+			PromptVersion: t.run.PromptVersion})
+	}
+	return out
+}
+
+func blindFixture(t *testing.T) (AIEvaluationDataset, AIEvaluationReport) {
+	t.Helper()
+	dataset := loadGoldenEvaluationDataset(t)
+	run := AIEvaluationRun{ProposerProvider: "provider-a", ProposerModel: "proposer", VerifierProvider: "provider-b", VerifierModel: "verifier", IndependencePolicy: ports.AIIndependenceProvider, PromptVersion: "blind-fixture", PolicyVersion: EvaluationPolicyVersion()}
+	report, err := EvaluateFPTriage(context.Background(), dataset, run, blindFixtureTriager{run: run})
+	if err != nil {
+		t.Fatalf("evaluate fixture: %v", err)
+	}
+	return dataset, report
+}
+
+func blindAuthenticator(t *testing.T) BlindFPTriageAuthenticator {
+	t.Helper()
+	authenticator, err := NewBlindFPTriageAuthenticator([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return authenticator
+}
+
+func TestBlindPacketWorkflowLocksAndMeasures(t *testing.T) {
+	dataset, report := blindFixture(t)
+	authenticator := blindAuthenticator(t)
+	packet, err := ExportBlindFPTriagePacket(dataset, report, "private-seed", authenticator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := ExportBlindFPTriagePacket(dataset, report, "private-seed", authenticator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packet.PacketID != again.PacketID || len(packet.Cases) != len(again.Cases) || packet.Cases[0].BlindID != again.Cases[0].BlindID {
+		t.Fatal("same seed must produce the same packet")
+	}
+	if !packet.Shadow || packet.GateExempt || packet.DatasetSHA256 != report.DatasetSHA256 || packet.RunSHA256 != report.RunID {
+		t.Fatalf("packet locking/invariants missing: %+v", packet)
+	}
+	encoded, err := json.Marshal(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"\"label\"", "\"verdict\"", "\"confidence\"", "\"rationale\"", "\"model\"", "\"arm\"", "\"would_gate_exempt\""} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Fatalf("packet leaked field %s: %s", forbidden, encoded)
+		}
+	}
+
+	submission := BlindFPTriageSubmission{SchemaVersion: BlindFPTriageSubmissionSchema, PacketID: packet.PacketID, DatasetSHA256: packet.DatasetSHA256, RunSHA256: packet.RunSHA256, Shadow: true}
+	for i, c := range packet.Cases {
+		decision := BlindFPTriageTruePositive
+		if i == 0 {
+			decision = BlindFPTriageAbstain
+		}
+		submission.Decisions = append(submission.Decisions, BlindFPTriageReviewDecision{BlindID: c.BlindID, Decision: decision})
+	}
+	imported, err := ImportBlindFPTriageSubmission(packet, submission, "human-reviewer", []string{"human-reviewer"}, report.Run.ProposerModel, report.Run.VerifierModel, authenticator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined, err := JoinBlindFPTriageSubmission(dataset, report, packet, imported, []string{"human-reviewer"}, authenticator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !joined.Shadow || joined.GateExempt || joined.Metrics.Total != len(packet.Cases) || joined.Metrics.Abstentions != 1 || joined.Metrics.AbstentionRate == 0 || joined.Metrics.DisagreementComparisons == 0 {
+		t.Fatalf("joined metrics/invariants missing: %+v", joined)
+	}
+}
+
+func TestBlindSubmissionRejectsModelReviewerAndBrokenLocks(t *testing.T) {
+	dataset, report := blindFixture(t)
+	authenticator := blindAuthenticator(t)
+	packet, err := ExportBlindFPTriagePacket(dataset, report, "private-seed", authenticator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	submission := BlindFPTriageSubmission{SchemaVersion: BlindFPTriageSubmissionSchema, PacketID: packet.PacketID, DatasetSHA256: packet.DatasetSHA256, RunSHA256: packet.RunSHA256, Shadow: true}
+	for _, c := range packet.Cases {
+		submission.Decisions = append(submission.Decisions, BlindFPTriageReviewDecision{BlindID: c.BlindID, Decision: BlindFPTriageAbstain})
+	}
+	if _, err := ImportBlindFPTriageSubmission(packet, submission, report.Run.ProposerModel, []string{report.Run.ProposerModel}, report.Run.ProposerModel, report.Run.VerifierModel, authenticator); err == nil {
+		t.Fatal("proposer identity was accepted as reviewer")
+	}
+	submission.GateExempt = true
+	if _, err := ImportBlindFPTriageSubmission(packet, submission, "human-reviewer", []string{"human-reviewer"}, report.Run.ProposerModel, report.Run.VerifierModel, authenticator); err == nil {
+		t.Fatal("gate-exempt submission was accepted")
+	}
+	packet.Shadow = false
+	if _, err := ImportBlindFPTriageSubmission(packet, submission, "human-reviewer", []string{"human-reviewer"}, report.Run.ProposerModel, report.Run.VerifierModel, authenticator); err == nil {
+		t.Fatal("non-shadow packet was accepted")
+	}
+}
+
+func TestBlindPacketRejectsTamperingAndEmbeddedLeakage(t *testing.T) {
+	dataset, report := blindFixture(t)
+	authenticator := blindAuthenticator(t)
+	packet, err := ExportBlindFPTriagePacket(dataset, report, "private-seed", authenticator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet.Cases[0].Title = "model verdict"
+	if _, err := ImportBlindFPTriageSubmission(packet, BlindFPTriageSubmission{}, "human-reviewer", []string{"human-reviewer"}, report.Run.ProposerModel, report.Run.VerifierModel, authenticator); err == nil {
+		t.Fatal("tampered packet was accepted")
+	}
+	dataset.Cases[0].Source += " // verifier confidence 99"
+	if _, err := ExportBlindFPTriagePacket(dataset, report, "private-seed", authenticator); err == nil {
+		t.Fatal("embedded blind leakage was accepted")
+	}
+}
+
+func TestBlindSubmissionReceiptBindsReviewerAndDecisions(t *testing.T) {
+	dataset, report := blindFixture(t)
+	authenticator := blindAuthenticator(t)
+	packet, err := ExportBlindFPTriagePacket(dataset, report, "private-seed", authenticator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	submission := BlindFPTriageSubmission{SchemaVersion: BlindFPTriageSubmissionSchema, PacketID: packet.PacketID, DatasetSHA256: packet.DatasetSHA256, RunSHA256: packet.RunSHA256, Shadow: true}
+	for _, c := range packet.Cases {
+		submission.Decisions = append(submission.Decisions, BlindFPTriageReviewDecision{BlindID: c.BlindID, Decision: BlindFPTriageAbstain})
+	}
+	imported, err := ImportBlindFPTriageSubmission(packet, submission, "human-reviewer", []string{"human-reviewer"}, report.Run.ProposerModel, report.Run.VerifierModel, authenticator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imported.Reviewer = "other-human"
+	if _, err := JoinBlindFPTriageSubmission(dataset, report, packet, imported, []string{"human-reviewer", "other-human"}, authenticator); err == nil {
+		t.Fatal("reviewer-mutated receipt was accepted")
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -1449,7 +1449,9 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 	if !ok {
 		return ports.ScanJob{}, fmt.Errorf("%w: tenant context is required for scan job", shared.ErrValidation)
 	}
-	go s.runScanJob(shared.WithTenant(context.Background(), tenantID), actor, engagementID, now, req, opts, job)
+	go func() {
+		_ = s.runScanJob(shared.WithTenant(context.Background(), tenantID), actor, engagementID, now, req, opts, job)
+	}()
 	return job, nil
 }
 

--- a/internal/usecase/users/service.go
+++ b/internal/usecase/users/service.go
@@ -67,7 +67,15 @@ func (s *Service) EnsureBootstrapAdmin(ctx context.Context, token string) error 
 	if err != nil {
 		return err
 	}
-	if err := s.repo.Upsert(ctx, u); err != nil {
+	if err := s.repo.Bootstrap(ctx, u, ports.AuditEntry{
+		Actor:  BootstrapID,
+		Action: "user.bootstrap_admin_seeded",
+		Target: BootstrapID,
+		Metadata: map[string]string{
+			"idempotency_key": "bootstrap-admin:" + BootstrapID,
+		},
+		At: s.clock.Now(),
+	}); err != nil {
 		return fmt.Errorf("seed bootstrap admin: %w", err)
 	}
 	return nil

--- a/migrations/0108_oidc_identities_and_sessions.sql
+++ b/migrations/0108_oidc_identities_and_sessions.sql
@@ -1,0 +1,59 @@
+-- +goose Up
+-- OIDC identity and opaque browser-session persistence. Provider access/refresh tokens are never
+-- stored here. New tables are RLS-protected and therefore require a non-empty tenant id.
+
+-- A composite key lets tenant-scoped identity/session references prove that their user belongs to
+-- the same tenant, rather than merely referring to an arbitrary globally-addressable user id.
+ALTER TABLE users ADD CONSTRAINT users_tenant_id_id_unique UNIQUE (tenant_id, id);
+
+CREATE TABLE oidc_external_identities (
+    id         TEXT PRIMARY KEY,
+    tenant_id  TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    user_id    TEXT NOT NULL,
+    issuer     TEXT NOT NULL CHECK (btrim(issuer) <> ''),
+    subject    TEXT NOT NULL CHECK (btrim(subject) <> ''),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (issuer, subject),
+    FOREIGN KEY (tenant_id, user_id) REFERENCES users(tenant_id, id) ON DELETE RESTRICT
+);
+CREATE INDEX idx_oidc_external_identities_tenant_user ON oidc_external_identities(tenant_id, user_id);
+CALL synapse_enable_tenant_rls('oidc_external_identities');
+
+CREATE TABLE oidc_authorization_transactions (
+    id                       TEXT PRIMARY KEY,
+    tenant_id                TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    state_hash               TEXT NOT NULL UNIQUE CHECK (btrim(state_hash) <> ''),
+    nonce_hash               TEXT NOT NULL CHECK (btrim(nonce_hash) <> ''),
+    pkce_verifier_ciphertext TEXT NOT NULL CHECK (btrim(pkce_verifier_ciphertext) <> ''),
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at               TIMESTAMPTZ NOT NULL,
+    CHECK (expires_at > created_at)
+);
+CREATE INDEX idx_oidc_authorization_transactions_expiry ON oidc_authorization_transactions(expires_at);
+CALL synapse_enable_tenant_rls('oidc_authorization_transactions');
+
+CREATE TABLE oidc_sessions (
+    id              TEXT PRIMARY KEY,
+    tenant_id       TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    user_id         TEXT NOT NULL,
+    token_hash      TEXT NOT NULL UNIQUE CHECK (btrim(token_hash) <> ''),
+    csrf_token_hash TEXT NOT NULL CHECK (btrim(csrf_token_hash) <> ''),
+    metadata        JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object' AND octet_length(metadata::text) <= 8192),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at      TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ,
+    CHECK (expires_at > created_at),
+    CHECK (updated_at >= created_at),
+    FOREIGN KEY (tenant_id, user_id) REFERENCES users(tenant_id, id) ON DELETE RESTRICT
+);
+CREATE INDEX idx_oidc_sessions_tenant_user ON oidc_sessions(tenant_id, user_id);
+CREATE INDEX idx_oidc_sessions_expiry ON oidc_sessions(expires_at) WHERE revoked_at IS NULL;
+CALL synapse_enable_tenant_rls('oidc_sessions');
+
+-- +goose Down
+DROP TABLE IF EXISTS oidc_sessions;
+DROP TABLE IF EXISTS oidc_authorization_transactions;
+DROP TABLE IF EXISTS oidc_external_identities;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_tenant_id_id_unique;

--- a/migrations/0108_oidc_identities_and_sessions.sql
+++ b/migrations/0108_oidc_identities_and_sessions.sql
@@ -40,12 +40,16 @@ CREATE TABLE oidc_sessions (
     token_hash      TEXT NOT NULL UNIQUE CHECK (btrim(token_hash) <> ''),
     csrf_token_hash TEXT NOT NULL CHECK (btrim(csrf_token_hash) <> ''),
     metadata        JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object' AND octet_length(metadata::text) <= 8192),
+    -- origin_at is the immutable start of the session lineage (login); it is carried unchanged across
+    -- rotations so the absolute-age cap is measured from first authentication, never reset by a poll.
+    origin_at       TIMESTAMPTZ NOT NULL,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     expires_at      TIMESTAMPTZ NOT NULL,
     revoked_at      TIMESTAMPTZ,
     CHECK (expires_at > created_at),
     CHECK (updated_at >= created_at),
+    CHECK (origin_at <= created_at),
     FOREIGN KEY (tenant_id, user_id) REFERENCES users(tenant_id, id) ON DELETE RESTRICT
 );
 CREATE INDEX idx_oidc_sessions_tenant_user ON oidc_sessions(tenant_id, user_id);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,8 +64,11 @@ nav:
   - Operate:
       - Configuration: configuration.md
       - Deployment: deployment.md
+      - Capacity and service objectives: capacity-slos.md
+      - Backup, restore, and upgrade: backup-restore-upgrade.md
       - Fleet agent packaging: fleet-agent-packaging.md
       - AI triage evaluation: ai-triage-evaluation.md
+      - Operations drill evidence: operations-drill-evidence.md
   - Integrate:
       - CLI: cli.md
       - MCP integration: mcp-integration.md

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthProvider } from './AuthContext'
+import { Connect } from '../pages/Connect'
+
+const mocks = vi.hoisted(() => ({
+  aup: vi.fn(),
+  acceptAup: vi.fn(),
+}))
+
+vi.mock('../lib/api', () => ({
+  api: { aup: mocks.aup, acceptAup: mocks.acceptAup },
+  ApiError: class ApiError extends Error {
+    constructor(public status: number, message: string) { super(message) }
+  },
+  discoverSession: vi.fn(),
+  logoutSession: vi.fn(),
+  setCSRFToken: vi.fn(),
+  setToken: vi.fn(),
+  setUnauthorizedHandler: vi.fn(),
+}))
+
+import { ApiError, discoverSession, logoutSession, setCSRFToken, setToken } from '../lib/api'
+
+function renderConnect() {
+  return render(<AuthProvider><Connect /></AuthProvider>)
+}
+
+describe('BFF authentication', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.mocked(discoverSession).mockResolvedValue({ authenticated: false, csrfToken: '' })
+    vi.mocked(logoutSession).mockResolvedValue()
+    mocks.aup.mockResolvedValue({ accepted: true, version: 'v1', text: 'Use responsibly.' })
+  })
+
+  it('discovers an existing BFF session before loading the AUP', async () => {
+    vi.mocked(discoverSession).mockResolvedValue({ authenticated: true, csrfToken: 'csrf-1' })
+    renderConnect()
+
+    await waitFor(() => expect(mocks.aup).toHaveBeenCalledTimes(1))
+    expect(setCSRFToken).toHaveBeenCalledWith('csrf-1')
+  })
+
+  it('shows an unauthenticated state when a session is expired', async () => {
+    renderConnect()
+
+    expect(await screen.findByRole('link', { name: 'Sign in with your organization' })).toBeInTheDocument()
+    expect(mocks.aup).not.toHaveBeenCalled()
+  })
+
+  it('navigates to the OIDC login endpoint', async () => {
+    renderConnect()
+
+    expect(await screen.findByRole('link', { name: 'Sign in with your organization' })).toHaveAttribute('href', '/api/auth/oidc/login')
+  })
+
+  it('falls back to the clearly labelled stored development token', async () => {
+    sessionStorage.setItem('synapse.token', 'saved-token')
+    renderConnect()
+
+    await waitFor(() => expect(setToken).toHaveBeenCalledWith('saved-token'))
+    expect(mocks.aup).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the saved bearer token when session discovery itself fails', async () => {
+    sessionStorage.setItem('synapse.token', 'saved-token')
+    vi.mocked(discoverSession).mockRejectedValue(new Error('offline'))
+    renderConnect()
+
+    await waitFor(() => expect(mocks.aup).toHaveBeenCalledTimes(1))
+    expect(setToken).toHaveBeenCalledWith('saved-token')
+    expect(sessionStorage.getItem('synapse.token')).toBe('saved-token')
+  })
+
+  it('discards the saved bearer token only when the token is rejected', async () => {
+    sessionStorage.setItem('synapse.token', 'saved-token')
+    mocks.aup.mockRejectedValue(new ApiError(401, 'unauthorized'))
+    renderConnect()
+
+    expect(await screen.findByText('Invalid API token.')).toBeInTheDocument()
+    expect(sessionStorage.getItem('synapse.token')).toBeNull()
+  })
+
+  it('logs out through the BFF and returns to unauthenticated state', async () => {
+    vi.mocked(discoverSession).mockResolvedValue({ authenticated: true, csrfToken: 'csrf-1' })
+    mocks.aup.mockResolvedValue({ accepted: false, version: 'v1', text: 'Use responsibly.' })
+    renderConnect()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }))
+    await waitFor(() => expect(logoutSession).toHaveBeenCalledTimes(1))
+    expect(await screen.findByRole('link', { name: 'Sign in with your organization' })).toBeInTheDocument()
+  })
+
+  it('stays signed in when server-side session revocation fails', async () => {
+    vi.mocked(discoverSession).mockResolvedValue({ authenticated: true, csrfToken: 'csrf-1' })
+    vi.mocked(logoutSession).mockRejectedValue(new Error('gateway down'))
+    mocks.aup.mockResolvedValue({ accepted: false, version: 'v1', text: 'Use responsibly.' })
+    renderConnect()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }))
+    expect(await screen.findByText(/Could not end the server session/)).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Sign in with your organization' })).not.toBeInTheDocument()
+  })
+
+  it('clears a local bearer session without calling the BFF', async () => {
+    sessionStorage.setItem('synapse.token', 'saved-token')
+    mocks.aup.mockResolvedValue({ accepted: false, version: 'v1', text: 'Use responsibly.' })
+    renderConnect()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }))
+    expect(await screen.findByRole('link', { name: 'Sign in with your organization' })).toBeInTheDocument()
+    expect(logoutSession).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('synapse.token')).toBeNull()
+  })
+})

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -7,12 +7,13 @@ import {
   useState,
   type ReactNode,
 } from 'react'
-import { api, ApiError, setToken as setApiToken, setUnauthorizedHandler } from '../lib/api'
+import { api, ApiError, discoverSession, logoutSession, setCSRFToken, setToken as setApiToken, setUnauthorizedHandler } from '../lib/api'
 import type { AupStatus } from '../lib/types'
 
+// The development/automation bearer token is kept in sessionStorage so it dies with the
+// browser tab instead of persisting across restarts for later XSS to read.
 const TOKEN_KEY = 'synapse.token'
-
-type Phase = 'connecting' | 'need-token' | 'need-aup' | 'ready'
+type Phase = 'connecting' | 'unauthenticated' | 'need-aup' | 'ready'
 
 interface AuthState {
   phase: Phase
@@ -21,7 +22,7 @@ interface AuthState {
   connecting: boolean
   connect: (token: string) => Promise<void>
   acceptAup: () => Promise<void>
-  logout: () => void
+  logout: () => Promise<void>
 }
 
 const Ctx = createContext<AuthState | null>(null)
@@ -37,23 +38,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [aup, setAup] = useState<AupStatus | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [connecting, setConnecting] = useState(false)
+  const [authMethod, setAuthMethod] = useState<'session' | 'token' | null>(null)
 
-  const logout = useCallback(() => {
-    localStorage.removeItem(TOKEN_KEY)
+  const clearAuthentication = useCallback(() => {
+    sessionStorage.removeItem(TOKEN_KEY)
     setApiToken('')
+    setCSRFToken('')
+    setAuthMethod(null)
     setAup(null)
-    setError(null)
-    setPhase('need-token')
-  }, [])
-
-  // Any 401 from the API drops back to the token screen.
-  useEffect(() => {
-    setUnauthorizedHandler(() => {
-      localStorage.removeItem(TOKEN_KEY)
-      setApiToken('')
-      setPhase('need-token')
-      setError('Session rejected – check your API token.')
-    })
   }, [])
 
   const refreshAup = useCallback(async () => {
@@ -62,62 +54,138 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setPhase(status.accepted ? 'ready' : 'need-aup')
   }, [])
 
-  const connect = useCallback(
-    async (raw: string) => {
-      const t = raw.trim()
-      if (!t) return
-      setConnecting(true)
+  // A bearer session is purely local, so it clears without a server call. A cookie session
+  // stays signed in when revocation fails: the HttpOnly cookie is still valid server-side and
+  // showing the signed-out screen would misrepresent that.
+  const logout = useCallback(async () => {
+    if (authMethod !== 'session') {
+      clearAuthentication()
       setError(null)
-      setApiToken(t)
-      try {
-        await refreshAup()
-        localStorage.setItem(TOKEN_KEY, t)
-      } catch (e) {
-        setApiToken('')
-        setPhase('need-token')
-        setError(
-          e instanceof ApiError && e.status === 401
-            ? 'Invalid API token.'
-            : e instanceof Error
-              ? e.message
-              : 'Connection failed.',
-        )
-      } finally {
-        setConnecting(false)
-      }
-    },
-    [refreshAup],
-  )
+      setPhase('unauthenticated')
+      return
+    }
+    try {
+      await logoutSession()
+    } catch (e) {
+      setError(e instanceof Error ? `Could not end the server session: ${e.message} Try signing out again.` : 'Could not end the server session. Try signing out again.')
+      return
+    }
+    clearAuthentication()
+    setError(null)
+    setPhase('unauthenticated')
+  }, [authMethod, clearAuthentication])
+
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      clearAuthentication()
+      setPhase('unauthenticated')
+      setError(authMethod === 'token' ? 'Invalid API token.' : 'Your sign-in session expired. Sign in again.')
+    })
+  }, [authMethod, clearAuthentication])
+
+  const connect = useCallback(async (raw: string) => {
+    const t = raw.trim()
+    if (!t) return
+    setConnecting(true)
+    setError(null)
+    setApiToken(t)
+    setCSRFToken('')
+    setAuthMethod('token')
+    try {
+      await refreshAup()
+      sessionStorage.setItem(TOKEN_KEY, t)
+    } catch (e) {
+      clearAuthentication()
+      setPhase('unauthenticated')
+      setError(e instanceof ApiError && e.status === 401 ? 'Invalid API token.' : e instanceof Error ? e.message : 'Connection failed.')
+    } finally {
+      setConnecting(false)
+    }
+  }, [clearAuthentication, refreshAup])
 
   const acceptAup = useCallback(async () => {
     if (!aup) return
-    await api.acceptAup(aup.version)
-    await refreshAup()
+    try {
+      setError(null)
+      await api.acceptAup(aup.version)
+      await refreshAup()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not accept the acceptable use policy.')
+    }
   }, [aup, refreshAup])
 
-  // Restore a saved session on first load.
   useEffect(() => {
-    const saved = localStorage.getItem(TOKEN_KEY)
-    if (!saved) {
-      setPhase('need-token')
-      return
-    }
-    setApiToken(saved)
-    refreshAup().catch(() => {
+    let ignore = false
+    const restore = async () => {
       setApiToken('')
-      localStorage.removeItem(TOKEN_KEY)
-      setPhase('need-token')
-    })
-  }, [refreshAup])
+      setCSRFToken('')
+      setAuthMethod(null)
+      setAup(null)
+      try {
+        const session = await discoverSession()
+        if (ignore) return
+        if (session.authenticated) {
+          setCSRFToken(session.csrfToken)
+          setAuthMethod('session')
+          try {
+            await refreshAup()
+          } catch (e) {
+            if (!ignore) {
+              clearAuthentication()
+              setPhase('unauthenticated')
+              setError(e instanceof Error ? `Could not restore your sign-in session: ${e.message}` : 'Could not restore your sign-in session.')
+            }
+          }
+          return
+        }
+
+        await restoreSavedToken()
+      } catch (e) {
+        if (ignore) return
+        // Session discovery failing (offline, or a server without the BFF) says nothing about
+        // the saved bearer token, so try it before discarding the credential.
+        const discoveryError = e instanceof Error ? `Could not check your sign-in session: ${e.message}` : 'Could not check your sign-in session.'
+        try {
+          if (!(await restoreSavedToken())) setError(discoveryError)
+        } catch {
+          if (!ignore) setError(discoveryError)
+        }
+      }
+    }
+    // restoreSavedToken reports whether a saved bearer token authenticated. It only clears the
+    // stored token when the token itself was rejected.
+    const restoreSavedToken = async (): Promise<boolean> => {
+      const saved = sessionStorage.getItem(TOKEN_KEY)
+      if (!saved) {
+        if (!ignore) setPhase('unauthenticated')
+        return false
+      }
+      setApiToken(saved)
+      setAuthMethod('token')
+      try {
+        await refreshAup()
+        return true
+      } catch (e) {
+        if (!ignore) {
+          // Only a rejected credential justifies discarding it. A transient failure (offline,
+          // 5xx, DNS) says nothing about the token's validity, so keep it and surface the error;
+          // otherwise one flaky request silently signs the operator out.
+          const rejected = e instanceof ApiError && (e.status === 401 || e.status === 403)
+          if (rejected) clearAuthentication()
+          setPhase('unauthenticated')
+          setError(rejected ? (e.status === 401 ? 'Invalid API token.' : 'This API token is not permitted.') : e instanceof Error ? e.message : 'Connection failed.')
+        }
+        return false
+      }
+    }
+    void restore()
+    return () => { ignore = true }
+  }, [clearAuthentication, refreshAup])
 
   const value = useMemo(
     () => ({ phase, aup, error, connecting, connect, acceptAup, logout }),
     [phase, aup, error, connecting, connect, acceptAup, logout],
   )
 
-  return (
-    <Ctx.Provider value={value}>
-      {children}
-    </Ctx.Provider>
-  )
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
 }

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -39,7 +39,7 @@ export function Button({ variant = 'primary', loading, className, children, disa
       disabled={loading || disabled}
       {...rest}
     >
-      {loading && <Loader2 className="size-4 animate-spin" />}
+      {loading && <Loader2 className="size-4 animate-spin motion-reduce:animate-none" />}
       {children}
     </button>
   )
@@ -287,7 +287,8 @@ export function EmptyState({
 
 export function ErrorState({ message }: { message: string }) {
   return (
-    <div className="rounded-lg border border-high/30 bg-high/10 px-4 py-3 text-sm text-high">
+    // role="alert" so assistive technology announces asynchronous failures that appear after load.
+    <div role="alert" className="rounded-lg border border-high/30 bg-high/10 px-4 py-3 text-sm text-high">
       {message}
     </div>
   )

--- a/web/src/lib/api.auth.test.ts
+++ b/web/src/lib/api.auth.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api, discoverSession, logoutSession, setCSRFToken, setToken } from './api'
+
+describe('BFF session API helpers', () => {
+  const fetchSpy = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchSpy)
+    setToken('')
+    setCSRFToken('')
+  })
+
+  it('discovers sessions outside the v1 prefix with same-origin credentials', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ authenticated: true, csrf_token: 'csrf-1' }) } as Response)
+
+    await expect(discoverSession()).resolves.toEqual({ authenticated: true, csrfToken: 'csrf-1' })
+    expect(fetchSpy).toHaveBeenCalledWith('/api/auth/session', { credentials: 'same-origin' })
+  })
+
+  it('treats expired sessions as unauthenticated', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: false, status: 401, json: async () => ({}) } as Response)
+
+    await expect(discoverSession()).resolves.toEqual({ authenticated: false, csrfToken: '' })
+  })
+
+  it('sends the in-memory CSRF token for unsafe session requests and logout', async () => {
+    setCSRFToken('csrf-1')
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) } as Response)
+    await logoutSession()
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({ credentials: 'same-origin', headers: { 'X-CSRF-Token': 'csrf-1' } })
+
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 201, json: async () => ({ id: 'p1' }) } as Response)
+    await api.createProject({ name: 'Project', key: 'project', sourceBinding: { kind: 'local', value: '/repo', ref: '' } })
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({ credentials: 'same-origin', headers: { 'X-CSRF-Token': 'csrf-1' } })
+  })
+
+  it('preserves bearer authentication without cookies or the CSRF header', async () => {
+    setCSRFToken('csrf-1')
+    setToken('api-token')
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 201, json: async () => ({ id: 'p1' }) } as Response)
+
+    await api.createProject({ name: 'Project', key: 'project', sourceBinding: { kind: 'local', value: '/repo', ref: '' } })
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({ credentials: 'omit', headers: { authorization: 'Bearer api-token' } })
+    expect((fetchSpy.mock.calls[0][1] as RequestInit).headers).not.toHaveProperty('X-CSRF-Token')
+  })
+
+  it('rejects an authenticated session that has no usable CSRF token', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ authenticated: true }) } as Response)
+
+    await expect(discoverSession()).rejects.toThrow(/CSRF token/)
+  })
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -125,44 +125,91 @@ export class ApiError extends Error {
   }
 }
 
-let token = ''
+let token = ""
+let csrfToken = ""
 let onUnauthorized: (() => void) | null = null
 
 export function setToken(t: string): void {
   token = t
 }
+
+// The BFF issues this token with the session; it intentionally remains in memory only.
+export function setCSRFToken(t: string): void {
+  csrfToken = t
+}
+
 export function setUnauthorizedHandler(fn: () => void): void {
   onUnauthorized = fn
+}
+
+type BFFSession = { authenticated: boolean; csrfToken: string }
+
+function headersRecord(headers?: HeadersInit): Record<string, string> {
+  if (!headers) return {}
+  return Object.fromEntries(new Headers(headers).entries())
+}
+
+function apiRequestInit(init: RequestInit = {}, json = true): RequestInit {
+  const method = (init.method ?? "GET").toUpperCase()
+  const headers = headersRecord(init.headers)
+  if (json && !headers["content-type"]) headers["content-type"] = "application/json"
+  if (token) headers.authorization = `Bearer ${token}`
+  else if (!["GET", "HEAD", "OPTIONS", "TRACE"].includes(method) && csrfToken) headers["X-CSRF-Token"] = csrfToken
+  // Bearer requests omit cookies so the server can never fall back to cookie
+  // authentication for a request that carries no CSRF token.
+  return { ...init, credentials: token ? "omit" : "same-origin", headers }
+}
+
+async function errorMessage(res: Response): Promise<string> {
+  let message = `HTTP ${res.status}`
+  try {
+    message = (await res.json())?.error ?? message
+  } catch {
+    // Non-JSON error responses have no safe detail to display.
+  }
+  return message
+}
+
+export async function discoverSession(): Promise<BFFSession> {
+  let res: Response
+  try {
+    res = await fetch("/api/auth/session", { credentials: "same-origin" })
+  } catch {
+    throw new ApiError(0, "Cannot reach the API. Is the server running on :8080?")
+  }
+  if (res.status === 401 || res.status === 403) return { authenticated: false, csrfToken: "" }
+  if (!res.ok) throw new ApiError(res.status, await errorMessage(res))
+  const body = await res.json()
+  if (body?.authenticated !== true) return { authenticated: false, csrfToken: "" }
+  const csrf = body?.csrf_token ?? body?.csrfToken ?? body?.csrf
+  // An authenticated session without a usable CSRF token cannot perform any unsafe
+  // request, so treat it as a broken session rather than a ready one.
+  if (typeof csrf !== "string" || csrf === "") {
+    throw new ApiError(res.status, "The sign-in session did not include a CSRF token.")
+  }
+  return { authenticated: true, csrfToken: csrf }
+}
+
+export async function logoutSession(): Promise<void> {
+  let res: Response
+  try {
+    res = await fetch("/api/auth/logout", apiRequestInit({ method: "POST" }))
+  } catch {
+    throw new ApiError(0, "Cannot reach the API. Is the server running on :8080?")
+  }
+  if (!res.ok) throw new ApiError(res.status, await errorMessage(res))
 }
 
 async function req(path: string, init?: RequestInit): Promise<any> {
   let res: Response
   try {
-    res = await fetch(`/api/v1${path}`, {
-      ...init,
-      headers: {
-        'content-type': 'application/json',
-        ...(token ? { authorization: `Bearer ${token}` } : {}),
-        ...(init?.headers ?? {}),
-      },
-    })
+    res = await fetch(`/api/v1${path}`, apiRequestInit(init))
   } catch (error) {
-    if (error instanceof DOMException && error.name === 'AbortError') {
-      throw error
-    }
-    throw new ApiError(0, 'Cannot reach the API. Is the server running on :8080?')
+    if (error instanceof DOMException && error.name === "AbortError") throw error
+    throw new ApiError(0, "Cannot reach the API. Is the server running on :8080?")
   }
   if (res.status === 401 && onUnauthorized) onUnauthorized()
-  if (!res.ok) {
-    let msg = `HTTP ${res.status}`
-    try {
-      const body = await res.json()
-      if (body?.error) msg = body.error
-    } catch {
-      /* non-JSON error body */
-    }
-    throw new ApiError(res.status, msg)
-  }
+  if (!res.ok) throw new ApiError(res.status, await errorMessage(res))
   if (res.status === 204) return null
   return res.json()
 }
@@ -446,7 +493,7 @@ function mapComponent(r: any): Component {
 
 /** Fetch a SARIF/OpenVEX export with the bearer token and trigger a browser download. */
 async function blobDownload(path: string, fallbackName: string): Promise<void> {
-  const res = await fetch(path, { headers: token ? { authorization: `Bearer ${token}` } : {} })
+  const res = await fetch(path, apiRequestInit({}, false))
   if (res.status === 401 && onUnauthorized) onUnauthorized()
   if (!res.ok) {
     let msg = `HTTP ${res.status}`
@@ -539,10 +586,10 @@ export async function streamReconLogs(
   const id = encodeURIComponent(engagementId)
   const rid = encodeURIComponent(runId)
   const qs = opts.lastEventId ? `?lastEventId=${opts.lastEventId}` : ''
-  const res = await fetch(`/api/v1/engagements/${id}/recon/runs/${rid}/logs${qs}`, {
-    headers: token ? { authorization: `Bearer ${token}`, accept: 'text/event-stream' } : { accept: 'text/event-stream' },
-    signal: opts.signal,
-  })
+  const res = await fetch(
+    `/api/v1/engagements/${id}/recon/runs/${rid}/logs${qs}`,
+    apiRequestInit({ headers: { accept: 'text/event-stream' }, signal: opts.signal }, false),
+  )
   if (res.status === 401 && onUnauthorized) onUnauthorized()
   if (!res.ok || !res.body) throw new ApiError(res.status, `log stream HTTP ${res.status}`)
 
@@ -640,10 +687,10 @@ export async function streamAgentSession(
   const id = encodeURIComponent(engagementId)
   const sid = encodeURIComponent(sessionId)
   const qs = opts.lastEventId ? `?lastEventId=${opts.lastEventId}` : ''
-  const res = await fetch(`/api/v1/engagements/${id}/agent/sessions/${sid}/stream${qs}`, {
-    headers: token ? { authorization: `Bearer ${token}`, accept: 'text/event-stream' } : { accept: 'text/event-stream' },
-    signal: opts.signal,
-  })
+  const res = await fetch(
+    `/api/v1/engagements/${id}/agent/sessions/${sid}/stream${qs}`,
+    apiRequestInit({ headers: { accept: 'text/event-stream' }, signal: opts.signal }, false),
+  )
   if (res.status === 401 && onUnauthorized) onUnauthorized()
   if (!res.ok || !res.body) throw new ApiError(res.status, `agent stream HTTP ${res.status}`)
 
@@ -1500,11 +1547,7 @@ export const api = {
     form.append('key', key)
     form.append('gate_id', gateId)
     form.append('archive', archive)
-    const res = await fetch('/api/v1/projects', {
-      method: 'POST',
-      headers: token ? { authorization: `Bearer ${token}` } : {},
-      body: form,
-    })
+    const res = await fetch('/api/v1/projects', apiRequestInit({ method: 'POST', body: form }, false))
     if (res.status === 401 && onUnauthorized) onUnauthorized()
     if (!res.ok) {
       let message = `HTTP ${res.status}`
@@ -1639,7 +1682,7 @@ export const api = {
     if (!coverage) return mapScanJob(await req(path, { method: 'POST' }))
     const form = new FormData()
     form.append('coverage', coverage)
-    const res = await fetch(`/api/v1${path}`, { method: 'POST', headers: token ? { authorization: `Bearer ${token}` } : {}, body: form })
+    const res = await fetch(`/api/v1${path}`, apiRequestInit({ method: 'POST', body: form }, false))
     if (res.status === 401 && onUnauthorized) onUnauthorized()
     if (!res.ok) {
       let message = `HTTP ${res.status}`

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,14 @@ import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import './index.css'
 
+// Apply the persisted theme before the first render. The sidebar owns the toggle, but it only
+// mounts once authenticated, so without this the login screen ignores a saved dark preference.
+try {
+  if (globalThis.localStorage?.getItem('synapse-theme') === 'dark') {
+    document.documentElement.dataset.theme = 'dark'
+  }
+} catch {}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>

--- a/web/src/pages/Connect.tsx
+++ b/web/src/pages/Connect.tsx
@@ -1,4 +1,4 @@
-import { KeyRound, Loader2, ShieldCheck } from 'lucide-react'
+import { KeyRound, Loader2, LogIn, ShieldCheck } from 'lucide-react'
 import { useState, type ReactNode } from 'react'
 import { useAuth } from '../auth/AuthContext'
 import { Button, Card, ErrorState, Field, Input } from '../components/ui'
@@ -8,12 +8,13 @@ export function Connect() {
   const { phase, aup, error, connecting, connect, acceptAup, logout } = useAuth()
   const [token, setToken] = useState('')
   const [accepting, setAccepting] = useState(false)
+  const [signingOut, setSigningOut] = useState(false)
 
   if (phase === 'connecting') {
     return (
       <Center>
-        <Loader2 className="size-6 animate-spin text-accent" />
-        <p className="mt-3 text-sm text-mutedfg">Restoring session…</p>
+        <Loader2 className="size-6 animate-spin motion-reduce:animate-none text-accent" />
+        <p className="mt-3 text-sm text-mutedfg">Checking your sign-in session…</p>
       </Center>
     )
   }
@@ -26,61 +27,69 @@ export function Connect() {
       </div>
 
       {phase === 'need-aup' && aup ? (
-        <Card title="Acceptable Use Policy" className="w-full max-w-lg animate-fade-in">
+        <Card title="Acceptable Use Policy" className="w-full max-w-lg animate-fade-in motion-reduce:animate-none">
           <p className="whitespace-pre-line text-sm leading-relaxed text-mutedfg">{aup.text}</p>
+          {error && <div className="mt-4"><ErrorState message={error} /></div>}
           <div className="mt-5 flex items-center justify-between gap-3">
             <button
               type="button"
-              onClick={logout}
-              className="text-xs text-mutedfg underline-offset-2 hover:text-foreground hover:underline"
-            >
-              Use a different token
-            </button>
-            <Button
-              variant="brand"
-              loading={accepting}
+              disabled={signingOut}
               onClick={async () => {
-                setAccepting(true)
-                try {
-                  await acceptAup()
-                } finally {
-                  setAccepting(false)
-                }
+                setSigningOut(true)
+                try { await logout() } finally { setSigningOut(false) }
               }}
+              className="rounded-sm text-xs text-mutedfg underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-card disabled:cursor-not-allowed disabled:opacity-60"
             >
+              {signingOut ? 'Signing out…' : 'Sign out'}
+            </button>
+            <Button variant="brand" loading={accepting} onClick={async () => {
+              setAccepting(true)
+              try { await acceptAup() } finally { setAccepting(false) }
+            }}>
               <ShieldCheck className="size-4" /> Accept &amp; continue
             </Button>
           </div>
           <p className="mt-3 text-center text-[11px] text-subtlefg">Policy version {aup.version}</p>
         </Card>
       ) : (
-        <Card className="w-full max-w-[420px] animate-fade-in">
-          <form
-            onSubmit={(e) => {
-              e.preventDefault()
-              connect(token)
-            }}
-            className="space-y-4"
-          >
-            <div className="flex items-center gap-2 text-sm font-medium">
-              <KeyRound className="size-4 text-brand" /> Connect to the API
+        <Card className="w-full max-w-[420px] animate-fade-in motion-reduce:animate-none">
+          <div className="space-y-5">
+            <div className="space-y-1 text-center">
+              <h1 className="text-base font-semibold text-foreground">Sign in to Synapse</h1>
+              <p className="text-sm text-mutedfg">Use your organization sign-in to continue.</p>
             </div>
-            <Field label="API token">
-              <Input
-                type="password"
-                autoFocus
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                placeholder="paste token…"
-                className="font-mono"
-                aria-label="API token"
-              />
-            </Field>
             {error && <ErrorState message={error} />}
-            <Button variant="brand" type="submit" loading={connecting} className="w-full">
-              Connect
-            </Button>
-          </form>
+            <a
+              href="/api/auth/oidc/login"
+              className="inline-flex w-full select-none items-center justify-center gap-2 rounded-lg bg-brand px-3.5 py-2 text-sm font-semibold text-brandfg transition-opacity duration-150 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            >
+              <LogIn className="size-4" /> Sign in with your organization
+            </a>
+            <div className="flex items-center gap-3 text-xs text-subtlefg before:h-px before:flex-1 before:bg-border after:h-px after:flex-1 after:bg-border">or</div>
+            <details className="rounded-lg border border-border bg-elevated/30 p-3">
+              <summary className="cursor-pointer text-sm font-medium text-foreground">Development or automation API token</summary>
+              <form onSubmit={(e) => { e.preventDefault(); void connect(token) }} className="mt-4 space-y-4">
+                <Field label="API token">
+                  <Input
+                    type="password"
+                    required
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                    placeholder="paste token…"
+                    className="font-mono"
+                    aria-label="API token"
+                    aria-describedby="api-token-hint"
+                  />
+                </Field>
+                <p id="api-token-hint" className="text-[11px] text-subtlefg">
+                  {token.trim() ? 'The token is sent only to this server.' : 'Paste a token to enable this development sign-in.'}
+                </p>
+                <Button variant="brand" type="submit" loading={connecting} disabled={!token.trim()} className="w-full">
+                  <KeyRound className="size-4" /> Connect with API token
+                </Button>
+              </form>
+            </details>
+          </div>
         </Card>
       )}
     </Center>


### PR DESCRIPTION
## Summary

- make API startup replica-safe and add bounded PostgreSQL pool observability
- add OIDC Authorization Code + PKCE BFF sessions, strict identity/role mapping, CSRF protection, and browser session UX while preserving bearer API tokens
- add digest-pinned production images, a production Helm chart, and reusable AWS staging automation
- add paired backup/restore and forward-only upgrade tooling, deterministic restore verification, benchmark reduction, and blinded FP-triage packets
- publish production topology, identity, recovery, drill-evidence, capacity, and SLO documentation

Closes #587.
Closes #590.
Closes #592.

Implements part of #589, #591, and #593 under #583, which remain open for the acceptance gates below.

## Validation

- rebased onto upstream `main` at `4c0c2f4`
- `make build vet test typecheck`
- `CGO_ENABLED=0 go build ./cmd/...`
- `pnpm --dir web test`
- `pnpm --dir web build`
- `go test ./docs/...`
- recovery wrapper tests
- Terraform static/validation checks
- Helm render/lint tests
- staged diff secret/path audit and `git diff --cached --check`

`make lint` was also run. It currently reports three pre-existing findings introduced by upstream commit `2800563` in `internal/infrastructure/spool/spool.go`, `internal/infrastructure/spool/state.go`, and `internal/adapter/agentspool/retry.go`; this PR does not modify those files.

The strict MkDocs build had passed before the rebase. After rebasing, the environment no longer has the `mkdocs` executable/module available; `go test ./docs/...` still passes against the rebased tree.

## Open acceptance gates

### #589 — representative concurrency limits

Two API replicas and failover were exercised successfully, and replica-safe startup plus bounded PostgreSQL pool telemetry are implemented. However, maximum workers per database, sustained concurrent scans per API instance, and pool saturation/recovery limits have not yet been measured under representative load. #589 therefore remains open.

### #591 — positive production sandbox execution

Production remains fail-closed when Bubblewrap cannot establish the required namespace/mount/seccomp isolation. Standard EKS managed nodes did not permit the current nested Bubblewrap transition under the non-privileged, drop-all-capabilities, RuntimeDefault posture. This PR intentionally does **not** add `privileged: true` or broad `SYS_ADMIN` to manufacture a passing result. A dedicated compatible sandbox runtime remains required before #591 can close.

### #593 — human blind review and representative capacity

The deterministic benchmark reducer and blinded packet generator are implemented. AWS testing measured only a low-rate readiness/failover path: 100/100 readiness requests and 90/90 failover probes succeeded, with readiness p50 732 ms, p95 784 ms, p99 948 ms, and max 1,546 ms. Each probe opened a fresh TLS connection, so these values are not an application-handler latency baseline.

Scan throughput, queue saturation, PostgreSQL pool waiting, evidence growth, and migration duration remain unmeasured. The blinded packet has not been submitted by a genuine human reviewer; AI/subagent review is not represented as human evidence. #593 therefore remains open.

## Scope hygiene

- root `.dockerignore` and `.gitignore` are unchanged and excluded
- local `artifacts/`, `reports/`, `.claude/`, `.serena/`, and `CLAUDE.md` are excluded
- Terraform backend/state/tfvars/plan/provider-cache files remain ignored locally
- long-lived deploy and documentation paths use responsibility-based names rather than EPIC/issue-number directories
- ADR deciders reference their governing issues (#587, #590, #592)
