### PR TITLE
feat(fleet): A3 telemetry transport ingest control plane (#624)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -137,6 +137,7 @@ import (
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
 	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
 	hostinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/hostinventory"
+	telemetryingest "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/telemetryingest"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetrolloutuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
@@ -269,8 +270,10 @@ func main() {
 	var scannedImageStore ports.ScannedImageStore
 	var workOrderStore ports.WorkOrderStore
 	var fleetAgentStore ports.FleetAgentStore
-	var fleetRolloutStore ports.FleetRolloutStore // operator update-rollout plans (#412 req 9)
-	var leaderStore ports.LeaderStore             // postgres only; nil in memory mode (single process)
+	var agentSigningKeyStore ports.AgentSigningKeyStore       // A0.2 signing-key registry (A3 resolve+verify)
+	var telemetryTransportStore ports.TelemetryTransportStore // A3 telemetry transport sequencing state
+	var fleetRolloutStore ports.FleetRolloutStore             // operator update-rollout plans (#412 req 9)
+	var leaderStore ports.LeaderStore                         // postgres only; nil in memory mode (single process)
 	var findingRepo ports.FindingRepository
 	var judgmentStore interface {
 		analysisuc.Store
@@ -438,6 +441,8 @@ func main() {
 		scannedImageStore = postgres.NewScannedImageStore(pool)
 		workOrderStore = postgres.NewWorkOrderRepository(pool)
 		fleetAgentStore = postgres.NewFleetAgentRepository(pool)
+		agentSigningKeyStore = postgres.NewAgentSigningKeyRepository(pool)
+		telemetryTransportStore = postgres.NewTelemetryTransportRepository(pool)
 		fleetRolloutStore = postgres.NewFleetRolloutRepository(pool)
 		leaderStore = postgres.NewLeaderStore(pool)
 		// SECURITY (#431 req 6, #432, #409): the fleet_* tables are RLS-protected, but RLS is a
@@ -487,6 +492,8 @@ func main() {
 		scannedImageStore = memory.NewScannedImageStore()
 		workOrderStore = memory.NewWorkOrderStore()
 		fleetAgentStore = memory.NewFleetAgentStore()
+		agentSigningKeyStore = memory.NewAgentSigningKeyStore()
+		telemetryTransportStore = memory.NewTelemetryTransportStore()
 		fleetRolloutStore = memory.NewFleetRolloutStore()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
@@ -1848,6 +1855,24 @@ func main() {
 			}
 			router.SetFleetHostInventory(hiSvc)
 			log.Info("fleet host inventory ingest ENABLED (VM agents persist host inventories into the asset model)")
+		}
+
+		// Agent→control-plane telemetry batch ingest (A3, #624): an enrolled agent ships a signed
+		// TelemetryBatchManifest which the control plane verifies (identity + signing key + schema,
+		// fail-closed), sequences idempotently per incarnation, derives gaps from the ACK snapshot, and acks.
+		// Gated by its own flag; the signing-key resolver is the A0.2 registry, durable when Postgres is set.
+		if cfg.FleetTelemetryIngestEnabled {
+			telemetrySvc, terr := telemetryingest.NewService(telemetryTransportStore, agentSigningKeyStore, auditLog, clock)
+			if terr != nil {
+				log.Error("fleet telemetry ingest init failed", "err", terr)
+				os.Exit(1)
+			}
+			router.SetFleetTelemetry(telemetrySvc)
+			if cfg.DBDSN != "" {
+				log.Info("fleet telemetry ingest ENABLED (durable; server-side identity/key/schema verification, idempotent, acked)")
+			} else {
+				log.Warn("fleet telemetry ingest ENABLED but NOT DURABLE - transport state lives in memory and is lost on restart; configure SYNAPSE_DB_DSN")
+			}
 		}
 	}
 	// deterministic Tier-2 reachability proof in the scan pipeline (opt-in). It mints reachability

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -79,6 +79,7 @@ type fleetRouter struct {
 	work             fleetWorkService
 	clusterInv       fleetClusterInventory // optional; nil ⇒ cluster inventory ingest is not served
 	hostInv          fleetHostInventory    // optional; nil ⇒ host inventory ingest is not served
+	telemetry        fleetTelemetryIngest  // optional; nil ⇒ telemetry ingest is not served (A3 #624)
 	minAgentVersion  string                // #412 version skew: agents below this are refused work; "" = no floor
 	cpVersion        string                // control-plane version advertised to agents (min_control_plane check)
 	rollout          fleetRolloutDecider   // optional; nil ⇒ no update is ever offered (#412 req 9)
@@ -170,6 +171,14 @@ func (rt *Router) SetFleetClusterInventory(s fleetClusterInventory) {
 func (rt *Router) SetFleetHostInventory(s fleetHostInventory) {
 	if rt.fleet != nil {
 		rt.fleet.hostInv = s
+	}
+}
+
+// SetFleetTelemetry wires the agent-plane telemetry batch ingest (A3 #624). When nil (or unset),
+// POST /api/v1/fleet/telemetry returns 404. It must be called after SetFleet.
+func (rt *Router) SetFleetTelemetry(s fleetTelemetryIngest) {
+	if rt.fleet != nil {
+		rt.fleet.telemetry = s
 	}
 }
 
@@ -299,6 +308,8 @@ func fleetAgentPlaneRoutes() []fleetAgentPlaneRoute {
 			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.clusterInventory)) }},
 		{"POST /api/v1/fleet/inventory/host", "/api/v1/fleet/inventory/",
 			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.hostInventory)) }},
+		{"POST /api/v1/fleet/telemetry", "/api/v1/fleet/telemetry",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.ingestTelemetry)) }},
 	}
 }
 

--- a/internal/adapter/httpapi/fleet_telemetry_handler.go
+++ b/internal/adapter/httpapi/fleet_telemetry_handler.go
@@ -1,0 +1,55 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/telemetryingest"
+)
+
+// fleetTelemetryCap bounds one agent telemetry batch body. It matches the agent spool's per-batch sizing
+// so a full priority batch fits, while a malicious oversize body is rejected before decode.
+const fleetTelemetryCap = 16 << 20 // 16 MiB
+
+// fleetTelemetryIngest is the narrow agent-plane telemetry ingest surface the handler consumes. The
+// usecase (telemetryingest.Service) satisfies it; defined here (consumer side) so the adapter depends on
+// a minimal contract, not the whole service.
+type fleetTelemetryIngest interface {
+	Ingest(ctx context.Context, authAgentID shared.ID, req telemetryingest.IngestRequest) (telemetryingest.IngestResult, error)
+}
+
+// ingestTelemetry is the agent-plane endpoint (POST /api/v1/fleet/telemetry): an enrolled agent ships a
+// signed TelemetryBatchManifest plus its events; the control plane verifies identity, signing key, and
+// schema SERVER-SIDE (fail-closed), sequences the batch idempotently, derives gaps from the ACK snapshot, and returns the
+// highest-contiguous ACK so the agent can delete acknowledged batches. Identity/key/schema failures map
+// to 403/4xx via writeError; the agent id + tenant come from the authenticated credential, never the body.
+func (f *fleetRouter) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
+	if f.telemetry == nil {
+		writeJSON(w, http.StatusNotFound, errorBody{Error: "telemetry ingest not enabled"})
+		return
+	}
+	agent, ok := agentFrom(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
+		return
+	}
+	var req telemetryingest.IngestRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetTelemetryCap)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid telemetry batch body"})
+		return
+	}
+	res, err := f.telemetry.Ingest(r.Context(), agent.ID, req)
+	if err != nil {
+		writeError(w, f.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"accepted":   res.Accepted,
+		"duplicate":  res.Duplicate,
+		"ack":        res.ACK,
+		"provenance": res.Provenance,
+		"gap_open":   res.GapOpen,
+	})
+}

--- a/internal/adapter/httpapi/fleet_telemetry_handler_test.go
+++ b/internal/adapter/httpapi/fleet_telemetry_handler_test.go
@@ -1,0 +1,166 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/telemetryingest"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
+)
+
+// setupFleetWithTelemetry builds the fleet transport plane with a real telemetry-ingest use case backed
+// by the in-memory transport store, and a signing-key resolver holding one key. It returns the handler,
+// the agent service (to enrol), the private key + keyID to sign manifests, and whether telemetry is wired.
+func setupFleetWithTelemetry(t *testing.T, wireTelemetry bool) (http.Handler, *fleetagentuc.Service, ed25519.PrivateKey, func(agentID shared.ID) string) {
+	t.Helper()
+	agentSvc, err := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := worksign.New([]byte("0123456789012345678901234567890123"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workSvc, err := fleetwork.NewService(memory.NewWorkOrderStore(), signer, ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The key's AgentID is only known after enrol; keyOf builds a resolver-registered key for that agent.
+	resolver := &lateResolver{}
+	keyOf := func(agentID shared.ID) string {
+		key, err := fleetagent.NewSigningKey(agentID, fleetagent.PurposeTelemetryBatch, pub, time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resolver.key = key
+		return key.KeyID
+	}
+	ingest, err := telemetryingest.NewService(memory.NewTelemetryTransportStore(), resolver, ftAudit{}, ftClock{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := &Router{log: discardLog()}
+	rt.SetFleet(agentSvc, workSvc, func() time.Time { return time.Now().UTC() }, "")
+	if wireTelemetry {
+		rt.SetFleetTelemetry(ingest)
+	}
+	return rt.fleet.handler(), agentSvc, priv, keyOf
+}
+
+// lateResolver holds a key registered after enrol (once the agent id is known).
+type lateResolver struct{ key fleetagent.AgentSigningKey }
+
+func (r *lateResolver) ResolveSigningKey(_ context.Context, agentID shared.ID, keyID string) (fleetagent.AgentSigningKey, error) {
+	if agentID == r.key.AgentID && keyID == r.key.KeyID {
+		return r.key, nil
+	}
+	return fleetagent.AgentSigningKey{}, shared.ErrNotFound
+}
+
+func enrolAgent(t *testing.T, h http.Handler, agentSvc *fleetagentuc.Service) (token string, agentID shared.ID) {
+	t.Helper()
+	tok, err := agentSvc.MintEnrolToken(context.Background(), "op", "default", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/enrol", tok, map[string]any{"name": "tel-agent", "platform": "linux"}, true)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("enrol should be 201, got %d (%s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		AgentID string `json:"agent_id"`
+		Token   string `json:"token"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil || resp.Token == "" || resp.AgentID == "" {
+		t.Fatalf("enrol response: %v (%s)", err, w.Body.String())
+	}
+	return resp.Token, shared.ID(resp.AgentID)
+}
+
+func signedRequest(agentID shared.ID, keyID string, priv ed25519.PrivateKey) telemetryingest.IngestRequest {
+	asset := shared.ID("asset-1")
+	payload := []byte("event-bytes")
+	m := fleetagent.TelemetryBatchManifest{
+		ProtocolVersion:  fleetagent.TelemetryProtocolVersion,
+		SchemaVersion:    1,
+		BatchID:          "batch-1",
+		AgentID:          agentID,
+		AssetID:          asset,
+		StreamID:         "stream-1",
+		Position:         fleetagent.StreamPosition{Priority: fleetagent.PriorityP1, Epoch: 1, Sequence: 1, Session: "sess-1", Boot: "boot-1"},
+		PreviousSequence: 0,
+		EventTimeMin:     time.Unix(1_700_000_000, 0).UTC(),
+		EventTimeMax:     time.Unix(1_700_000_001, 0).UTC(),
+		ObservedCount:    1,
+		KeptCount:        1,
+		Events:           []fleetagent.EventRef{{ID: "e1", Digest: fleetagent.TelemetryEventDigest(payload, asset)}},
+		KeyID:            keyID,
+	}
+	m.PayloadDigest = fleetagent.TelemetryPayloadDigest(m.Events)
+	m.Signature = fleetagent.SignTelemetryManifest(priv, m)
+	return telemetryingest.IngestRequest{
+		Manifest: m,
+		Events:   []telemetryingest.EventPayload{{EventID: "e1", Class: detection.ClassProcess, Payload: payload, ObservedAt: m.EventTimeMin}},
+	}
+}
+
+func TestIngestTelemetryEndpointAccepts(t *testing.T) {
+	h, agentSvc, priv, keyOf := setupFleetWithTelemetry(t, true)
+	token, agentID := enrolAgent(t, h, agentSvc)
+	req := signedRequest(agentID, keyOf(agentID), priv)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/telemetry", token, req, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ingest should be 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Accepted bool   `json:"accepted"`
+		ACK      uint64 `json:"ack"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil || !resp.Accepted || resp.ACK != 1 {
+		t.Fatalf("accept response: %+v err=%v (%s)", resp, err, w.Body.String())
+	}
+}
+
+func TestIngestTelemetryEndpointIdentityMismatch403(t *testing.T) {
+	h, agentSvc, priv, keyOf := setupFleetWithTelemetry(t, true)
+	token, agentID := enrolAgent(t, h, agentSvc)
+	// A manifest claiming a DIFFERENT agent than the authenticated credential must be forbidden.
+	keyID := keyOf(agentID)
+	req := signedRequest("someone-else", keyID, priv)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/telemetry", token, req, true)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("identity mismatch should be 403, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestIngestTelemetryEndpointNotEnabled404(t *testing.T) {
+	h, agentSvc, priv, keyOf := setupFleetWithTelemetry(t, false) // telemetry not wired
+	token, agentID := enrolAgent(t, h, agentSvc)
+	req := signedRequest(agentID, keyOf(agentID), priv)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/telemetry", token, req, true)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unwired telemetry should be 404, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestIngestTelemetryEndpointRequiresAuth(t *testing.T) {
+	h, _, _, _ := setupFleetWithTelemetry(t, true)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/telemetry", "", map[string]any{}, true)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("no credential should be 401, got %d (%s)", w.Code, w.Body.String())
+	}
+}

--- a/internal/domain/fleetagent/delivery.go
+++ b/internal/domain/fleetagent/delivery.go
@@ -249,6 +249,15 @@ type AckLedger struct {
 // NewAckLedger returns an empty ledger.
 func NewAckLedger() *AckLedger { return &AckLedger{} }
 
+// SeedContiguous rehydrates a ledger's contiguous high-water from durable state (A3 persists the ACK
+// mark rather than replaying every sequence). It sets the base only on a fresh ledger; the caller then
+// Observe()s the persisted pending set on top. Seeding a non-empty ledger is a no-op.
+func (l *AckLedger) SeedContiguous(n uint64) {
+	if l.contiguous == 0 && len(l.pending) == 0 {
+		l.contiguous = n
+	}
+}
+
 // Observe records that sequence seq has been received. It returns true if this is the first time seq is
 // seen — INCLUDING a late arrival that fills an earlier gap below the high-water — and false if seq is a
 // true duplicate (idempotent no-op) or invalid (0). This boolean is the authoritative "new vs already-have"
@@ -284,6 +293,21 @@ func (l *AckLedger) Observe(seq uint64) bool {
 
 // HighestContiguous returns the ACK: the highest sequence with no hole beneath it (0 = nothing yet).
 func (l *AckLedger) HighestContiguous() uint64 { return l.contiguous }
+
+// Pending returns the received sequences strictly above the contiguous mark, ascending. It is the
+// snapshot A3 persists (with HighestContiguous) so the ledger can be rehydrated across stateless ingests
+// without replaying every sequence.
+func (l *AckLedger) Pending() []uint64 {
+	if len(l.pending) == 0 {
+		return nil
+	}
+	out := make([]uint64, 0, len(l.pending))
+	for s := range l.pending {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
 
 // Gaps returns the still-missing sequence ranges below the highest sequence received, oldest first. An
 // empty result means everything received so far is contiguous (nothing outstanding). These are the

--- a/internal/domain/fleetagent/telemetry_batch.go
+++ b/internal/domain/fleetagent/telemetry_batch.go
@@ -1,0 +1,251 @@
+package fleetagent
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ErrBadManifestSignature is returned when a telemetry batch manifest's signature does not verify.
+var ErrBadManifestSignature = errors.New("telemetry batch manifest signature invalid")
+
+// TelemetryProtocolVersion is the current agent→control-plane telemetry transport protocol. It is
+// carried on every manifest so the wire envelope can evolve independently of the payload schema
+// (A0.3) and of the agent version.
+const TelemetryProtocolVersion = 1
+
+// maxTelemetrySequence bounds epoch and sequence well below 2^63 so a malicious agent cannot drive an
+// int64 truncation/overflow when the value is persisted (BIGINT), turning what would be a storage-tier 500
+// into a clean 4xx at validation. Far above any real incarnation's sequence count.
+const maxTelemetrySequence = uint64(1) << 62
+
+// telemetryBatchContext is the domain-separation tag for a telemetry-batch signature. Like the
+// detection-batch and evidence/audit tags, it prefixes the signed bytes so the same agent key signing
+// a telemetry batch can never have that signature replayed as a detection batch or an attestation.
+const telemetryBatchContext = "synapse-telemetry-batch:v1"
+
+// EventRef binds one shipped telemetry event's id to a digest of its canonical bytes, so the manifest
+// signature covers WHAT each event is, not merely its id — a transport that swaps an event body for a
+// known id is rejected before ingest.
+type EventRef struct {
+	ID     shared.ID
+	Digest string // hex sha256 over the event's canonical shipped bytes
+}
+
+// TelemetryBatchManifest is a sequenced, signed manifest for one shipped telemetry batch (A3, #624). It
+// binds the batch to a stream position (incarnation-aware, so a reboot reset-to-1 is not a replay — the
+// A0.4 delivery contract), carries the three DISTINCT loss counts (Sampled ≠ Truncated ≠ Dropped, per
+// D2/A0.6), and commits to the batch payload. This is the TRANSPORT-integrity + ACK commitment only;
+// the permanent evidence commitment (retention/proof/Merkle) is A5's, not computed here.
+type TelemetryBatchManifest struct {
+	ProtocolVersion int
+	SchemaVersion   int
+	BatchID         shared.ID
+	AgentID         shared.ID
+	AssetID         shared.ID
+	StreamID        shared.ID
+	// Position carries Priority, Epoch, Sequence, Session (== the AgentSessionID) and Boot — the
+	// incarnation-aware stream coordinate ClassifyDelivery/AckLedger reason over.
+	Position         StreamPosition
+	PreviousSequence uint64
+	EventTimeMin     time.Time
+	EventTimeMax     time.Time
+	// The three loss outcomes are separate buckets; per-event reason lives on the first-class
+	// TelemetryLoss/TelemetryGap, not here.
+	ObservedCount        int
+	KeptCount            int
+	SampledOutCount      int
+	TruncatedCount       int
+	DroppedCount         int
+	SamplingPolicyDigest string // digest of {SamplingAlgorithm, SamplingPolicyID, Seed, Version}
+	// Events are the KeptCount shipped events, each bound by id + content digest.
+	Events []EventRef
+	// PayloadDigest commits to the canonical uncompressed transport payload (the events' shipped bytes).
+	PayloadDigest string
+	KeyID         string // the AgentSigningKey (Purpose=telemetry-batch) this manifest is signed with
+	Signature     string // base64 ed25519 over TelemetryManifestMessage
+}
+
+// AgentSessionID returns the incarnation's session id (the manifest's Position.Session).
+func (m TelemetryBatchManifest) AgentSessionID() SessionID { return m.Position.Session }
+
+// Validate checks the manifest is well-formed and internally consistent. A malformed manifest — missing
+// identity, an inconsistent kept-vs-event count, or a bad loss arithmetic — is refused before any
+// signature check or ingest.
+func (m TelemetryBatchManifest) Validate() error {
+	if m.ProtocolVersion < 1 {
+		return fmt.Errorf("%w: telemetry manifest protocol version must be >= 1", shared.ErrValidation)
+	}
+	if m.SchemaVersion < 1 {
+		return fmt.Errorf("%w: telemetry manifest schema version must be >= 1", shared.ErrValidation)
+	}
+	if m.BatchID.IsZero() || m.AgentID.IsZero() || m.AssetID.IsZero() || m.StreamID.IsZero() {
+		return fmt.Errorf("%w: telemetry manifest needs batch, agent, asset and stream ids", shared.ErrValidation)
+	}
+	if err := m.Position.Validate(); err != nil {
+		return fmt.Errorf("telemetry manifest position: %w", err)
+	}
+	if m.PreviousSequence >= m.Position.Sequence {
+		return fmt.Errorf("%w: telemetry manifest previous sequence %d must be below current %d", shared.ErrValidation, m.PreviousSequence, m.Position.Sequence)
+	}
+	if m.Position.Epoch > maxTelemetrySequence || m.Position.Sequence > maxTelemetrySequence {
+		return fmt.Errorf("%w: telemetry manifest epoch/sequence exceeds the maximum %d", shared.ErrValidation, maxTelemetrySequence)
+	}
+	if m.KeyID == "" {
+		return fmt.Errorf("%w: telemetry manifest has no signing key id", shared.ErrValidation)
+	}
+	if m.PayloadDigest == "" {
+		return fmt.Errorf("%w: telemetry manifest has no payload digest", shared.ErrValidation)
+	}
+	if m.EventTimeMax.Before(m.EventTimeMin) {
+		return fmt.Errorf("%w: telemetry manifest event-time-max precedes event-time-min", shared.ErrValidation)
+	}
+	if m.ObservedCount < 0 || m.KeptCount < 0 || m.SampledOutCount < 0 || m.TruncatedCount < 0 || m.DroppedCount < 0 {
+		return fmt.Errorf("%w: telemetry manifest has a negative count", shared.ErrValidation)
+	}
+	// Observed is what the agent saw; kept + the three loss buckets must not exceed it (they account for
+	// where the observed events went; a shortfall is allowed — not every observed event is enumerated).
+	if m.KeptCount+m.SampledOutCount+m.TruncatedCount+m.DroppedCount > m.ObservedCount {
+		return fmt.Errorf("%w: telemetry manifest kept+lost exceeds observed", shared.ErrValidation)
+	}
+	if len(m.Events) != m.KeptCount {
+		return fmt.Errorf("%w: telemetry manifest lists %d events but kept count is %d", shared.ErrValidation, len(m.Events), m.KeptCount)
+	}
+	for i, ref := range m.Events {
+		if ref.ID.IsZero() {
+			return fmt.Errorf("%w: telemetry manifest event[%d] has no id", shared.ErrValidation, i)
+		}
+		if ref.Digest == "" {
+			return fmt.Errorf("%w: telemetry manifest event[%d] has no digest", shared.ErrValidation, i)
+		}
+	}
+	return nil
+}
+
+// TelemetryEventDigest is the shared digest both the agent and the control plane compute over one
+// telemetry event's shipped bytes plus the asset it was observed on, so the two sides agree on what the
+// manifest's EventRef.Digest binds. One definition (domain) so the two sides cannot drift.
+func TelemetryEventDigest(payload []byte, assetID shared.ID) string {
+	h := sha256.New()
+	h.Write(payload)
+	h.Write([]byte(batchSep))
+	h.Write([]byte(assetID.String()))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// TelemetryPayloadDigest is the batch-level commitment the manifest's PayloadDigest carries: a sha256 over
+// the SORTED (event id, digest) refs. The control plane recomputes it from the manifest's event refs and
+// checks it equals the signed PayloadDigest, so that signed field cannot be a stray value. One definition
+// (domain) so the agent and control plane cannot drift.
+func TelemetryPayloadDigest(events []EventRef) string {
+	refs := append([]EventRef(nil), events...)
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].ID != refs[j].ID {
+			return refs[i].ID < refs[j].ID
+		}
+		return refs[i].Digest < refs[j].Digest
+	})
+	h := sha256.New()
+	for _, ref := range refs {
+		h.Write([]byte(ref.ID.String()))
+		h.Write([]byte(batchSep))
+		h.Write([]byte(ref.Digest))
+		h.Write([]byte(batchSep))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// TelemetryManifestMessage is the canonical byte string a manifest signature covers: the context tag,
+// protocol/schema versions, identity, the full stream position, the loss accounting, the SORTED
+// (event id, digest) pairs, and the payload digest — so the batch's membership, ordinal, incarnation,
+// loss claims and payload are all bound and the named signing key cannot be swapped. It is a sha256
+// digest with delimiter-separated fields so field boundaries cannot collide.
+func TelemetryManifestMessage(m TelemetryBatchManifest) []byte {
+	refs := append([]EventRef(nil), m.Events...)
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].ID != refs[j].ID {
+			return refs[i].ID < refs[j].ID
+		}
+		return refs[i].Digest < refs[j].Digest
+	})
+	h := sha256.New()
+	write := func(s string) { h.Write([]byte(s)); h.Write([]byte(batchSep)) }
+	writeU := func(u uint64) { write(strconv.FormatUint(u, 10)) }
+	writeI := func(i int) { write(strconv.Itoa(i)) }
+	write(telemetryBatchContext)
+	writeI(m.ProtocolVersion)
+	writeI(m.SchemaVersion)
+	write(m.BatchID.String())
+	write(m.AgentID.String())
+	write(m.AssetID.String())
+	write(m.StreamID.String())
+	writeU(uint64(m.Position.Priority))
+	writeU(m.Position.Epoch)
+	writeU(m.Position.Sequence)
+	writeU(m.PreviousSequence)
+	write(string(m.Position.Session))
+	write(string(m.Position.Boot))
+	writeU(uint64(m.EventTimeMin.UTC().UnixNano()))
+	writeU(uint64(m.EventTimeMax.UTC().UnixNano()))
+	writeI(m.ObservedCount)
+	writeI(m.KeptCount)
+	writeI(m.SampledOutCount)
+	writeI(m.TruncatedCount)
+	writeI(m.DroppedCount)
+	write(m.SamplingPolicyDigest)
+	write(m.PayloadDigest)
+	write(m.KeyID) // bind the signing-key id: the envelope KeyID cannot be swapped
+	for _, ref := range refs {
+		write(ref.ID.String())
+		write(ref.Digest)
+	}
+	return h.Sum(nil)
+}
+
+// SignTelemetryManifest produces the base64 ed25519 signature for a manifest.
+func SignTelemetryManifest(priv ed25519.PrivateKey, m TelemetryBatchManifest) string {
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(priv, TelemetryManifestMessage(m)))
+}
+
+// VerifyTelemetryManifest checks the manifest signature against a public key. Fail-closed: a bad key
+// size, malformed signature, or a signature that does not verify all return ErrBadManifestSignature.
+func VerifyTelemetryManifest(pub ed25519.PublicKey, m TelemetryBatchManifest) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: bad public key size", ErrBadManifestSignature)
+	}
+	sig, err := base64.StdEncoding.DecodeString(m.Signature)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("%w: malformed signature", ErrBadManifestSignature)
+	}
+	if !ed25519.Verify(pub, TelemetryManifestMessage(m), sig) {
+		return ErrBadManifestSignature
+	}
+	return nil
+}
+
+// VerifyTelemetryManifestWithKey is the fail-closed server-side gate: the resolved key must be a
+// telemetry-batch key, bound to the manifest's agent, named by the manifest's KeyID, usable now, and
+// its public half must verify the signature. It mirrors VerifyBatchWithKey for the telemetry path.
+func VerifyTelemetryManifestWithKey(k AgentSigningKey, now time.Time, m TelemetryBatchManifest) error {
+	if k.Purpose != PurposeTelemetryBatch {
+		return fmt.Errorf("%w: signing key %s is for %q, not %q", shared.ErrForbidden, k.KeyID, k.Purpose, PurposeTelemetryBatch)
+	}
+	if k.AgentID != m.AgentID {
+		return fmt.Errorf("%w: signing key %s is bound to agent %s, not %s", shared.ErrForbidden, k.KeyID, k.AgentID, m.AgentID)
+	}
+	if m.KeyID != k.KeyID {
+		return fmt.Errorf("%w: manifest names key %s but was verified against %s", ErrBadManifestSignature, m.KeyID, k.KeyID)
+	}
+	if err := k.UsableAt(now); err != nil {
+		return err
+	}
+	return VerifyTelemetryManifest(k.PublicKey, m)
+}

--- a/internal/domain/fleetagent/telemetry_batch_test.go
+++ b/internal/domain/fleetagent/telemetry_batch_test.go
@@ -1,0 +1,155 @@
+package fleetagent
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func validManifest() TelemetryBatchManifest {
+	t0 := time.Unix(1_700_000_000, 0).UTC()
+	return TelemetryBatchManifest{
+		ProtocolVersion:      TelemetryProtocolVersion,
+		SchemaVersion:        1,
+		BatchID:              "batch-1",
+		AgentID:              "agent-1",
+		AssetID:              "asset-1",
+		StreamID:             "stream-1",
+		Position:             StreamPosition{Priority: PriorityP1, Epoch: 1, Sequence: 5, Session: "sess-1", Boot: "boot-1"},
+		PreviousSequence:     4,
+		EventTimeMin:         t0,
+		EventTimeMax:         t0.Add(time.Second),
+		ObservedCount:        3,
+		KeptCount:            2,
+		SampledOutCount:      1,
+		SamplingPolicyDigest: "spd",
+		Events: []EventRef{
+			{ID: "e2", Digest: "d2"},
+			{ID: "e1", Digest: "d1"},
+		},
+		PayloadDigest: "payload-digest",
+		KeyID:         "key-1",
+	}
+}
+
+func TestTelemetryManifestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*TelemetryBatchManifest)
+		wantErr bool
+	}{
+		{"valid", func(*TelemetryBatchManifest) {}, false},
+		{"no protocol", func(m *TelemetryBatchManifest) { m.ProtocolVersion = 0 }, true},
+		{"no schema", func(m *TelemetryBatchManifest) { m.SchemaVersion = 0 }, true},
+		{"no batch id", func(m *TelemetryBatchManifest) { m.BatchID = "" }, true},
+		{"no agent id", func(m *TelemetryBatchManifest) { m.AgentID = "" }, true},
+		{"no asset id", func(m *TelemetryBatchManifest) { m.AssetID = "" }, true},
+		{"no stream id", func(m *TelemetryBatchManifest) { m.StreamID = "" }, true},
+		{"bad position (epoch 0)", func(m *TelemetryBatchManifest) { m.Position.Epoch = 0 }, true},
+		{"prev >= current seq", func(m *TelemetryBatchManifest) { m.PreviousSequence = 5 }, true},
+		{"no key id", func(m *TelemetryBatchManifest) { m.KeyID = "" }, true},
+		{"no payload digest", func(m *TelemetryBatchManifest) { m.PayloadDigest = "" }, true},
+		{"time max before min", func(m *TelemetryBatchManifest) { m.EventTimeMax = m.EventTimeMin.Add(-time.Hour) }, true},
+		{"negative count", func(m *TelemetryBatchManifest) { m.DroppedCount = -1 }, true},
+		{"kept+lost exceeds observed", func(m *TelemetryBatchManifest) { m.DroppedCount = 5 }, true},
+		{"events count != kept", func(m *TelemetryBatchManifest) { m.KeptCount = 3 }, true},
+		{"event missing id", func(m *TelemetryBatchManifest) { m.Events[0].ID = "" }, true},
+		{"event missing digest", func(m *TelemetryBatchManifest) { m.Events[0].Digest = "" }, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := validManifest()
+			tt.mutate(&m)
+			err := m.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() err=%v wantErr=%t", err, tt.wantErr)
+			}
+			if err != nil && !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("error must wrap shared.ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestTelemetryManifestMessageOrderIndependent(t *testing.T) {
+	a := validManifest()
+	b := validManifest()
+	b.Events = []EventRef{{ID: "e1", Digest: "d1"}, {ID: "e2", Digest: "d2"}} // reversed input order
+	if string(TelemetryManifestMessage(a)) != string(TelemetryManifestMessage(b)) {
+		t.Fatal("manifest message must be independent of event input order (sorted)")
+	}
+	// AgentSessionID is the position session.
+	if a.AgentSessionID() != "sess-1" {
+		t.Fatalf("AgentSessionID() = %q", a.AgentSessionID())
+	}
+}
+
+func TestTelemetryManifestSignVerifyRoundTrip(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	m := validManifest()
+	m.Signature = SignTelemetryManifest(priv, m)
+	if err := VerifyTelemetryManifest(pub, m); err != nil {
+		t.Fatalf("valid signature must verify: %v", err)
+	}
+	// Tamper: any bound field change breaks the signature.
+	for _, mut := range []func(*TelemetryBatchManifest){
+		func(m *TelemetryBatchManifest) { m.Position.Sequence = 6 },
+		func(m *TelemetryBatchManifest) { m.PayloadDigest = "other" },
+		func(m *TelemetryBatchManifest) { m.Events[0].Digest = "tampered" },
+		func(m *TelemetryBatchManifest) { m.DroppedCount = 1; m.SampledOutCount = 0 },
+		func(m *TelemetryBatchManifest) { m.KeyID = "swapped" },
+	} {
+		tampered := validManifest()
+		tampered.Signature = m.Signature
+		mut(&tampered)
+		if err := VerifyTelemetryManifest(pub, tampered); !errors.Is(err, ErrBadManifestSignature) {
+			t.Fatalf("tampered manifest must fail verification, got %v", err)
+		}
+	}
+}
+
+func TestVerifyTelemetryManifestWithKeyFailClosed(t *testing.T) {
+	now := time.Unix(1_700_000_100, 0).UTC()
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	key, err := NewSigningKey("agent-1", PurposeTelemetryBatch, pub, now.Add(-time.Hour), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := validManifest()
+	m.KeyID = key.KeyID
+	m.Signature = SignTelemetryManifest(priv, m)
+
+	if err := VerifyTelemetryManifestWithKey(key, now, m); err != nil {
+		t.Fatalf("well-formed manifest+key must verify: %v", err)
+	}
+
+	// Wrong purpose → forbidden.
+	wrongPurpose, _ := NewSigningKey("agent-1", PurposeDetectionBatch, pub, now.Add(-time.Hour), now.Add(time.Hour))
+	if err := VerifyTelemetryManifestWithKey(wrongPurpose, now, withKeyID(m, wrongPurpose.KeyID, priv)); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("wrong-purpose key must be forbidden, got %v", err)
+	}
+	// Key bound to a different agent → forbidden.
+	otherAgent, _ := NewSigningKey("agent-2", PurposeTelemetryBatch, pub, now.Add(-time.Hour), now.Add(time.Hour))
+	if err := VerifyTelemetryManifestWithKey(otherAgent, now, m); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("agent-mismatched key must be forbidden, got %v", err)
+	}
+	// Manifest names a different key id than the one verifying → bad signature.
+	mismatch := m
+	mismatch.KeyID = "some-other-key"
+	if err := VerifyTelemetryManifestWithKey(key, now, mismatch); !errors.Is(err, ErrBadManifestSignature) {
+		t.Fatalf("keyid mismatch must fail closed, got %v", err)
+	}
+	// Expired key → not usable.
+	if err := VerifyTelemetryManifestWithKey(key, now.Add(2*time.Hour), m); err == nil {
+		t.Fatal("expired key must fail closed")
+	}
+}
+
+func withKeyID(m TelemetryBatchManifest, keyID string, priv ed25519.PrivateKey) TelemetryBatchManifest {
+	m.KeyID = keyID
+	m.Signature = SignTelemetryManifest(priv, m)
+	return m
+}

--- a/internal/infrastructure/persistence/memory/telemetry_transport_store.go
+++ b/internal/infrastructure/persistence/memory/telemetry_transport_store.go
@@ -1,0 +1,189 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// TelemetryTransportStore is the in-memory twin of the A3 transport-sequencing store: per-stream ACK
+// state (with an optimistic-concurrency version) and the durable raw batch events — tenant-bucketed and
+// keyed by the authenticated agent id, upholding the same contract as the Postgres tier. Transport gaps
+// are derived on read from the ACK snapshot, never stored. Reached only through
+// ports.TelemetryTransportStore.
+type TelemetryTransportStore struct {
+	mu     sync.Mutex
+	states map[shared.ID]map[streamEpoch]ports.TelemetryStreamState
+	events map[shared.ID]map[eventKey]storedTransportEvent
+}
+
+// streamEpoch and eventKey carry agent so an agent-chosen StreamID can never address another agent's
+// stream space within the tenant (see migration 0109).
+type streamEpoch struct {
+	agent  shared.ID
+	stream shared.ID
+	epoch  uint64
+}
+
+type eventKey struct {
+	agent    shared.ID
+	stream   shared.ID
+	epoch    uint64
+	sequence uint64
+	eventID  shared.ID
+}
+
+type storedTransportEvent struct {
+	asset         shared.ID
+	class         string
+	digest        string
+	payload       []byte
+	schemaVersion int
+}
+
+var _ ports.TelemetryTransportStore = (*TelemetryTransportStore)(nil)
+
+// NewTelemetryTransportStore constructs an empty in-memory transport store.
+func NewTelemetryTransportStore() *TelemetryTransportStore {
+	return &TelemetryTransportStore{
+		states: map[shared.ID]map[streamEpoch]ports.TelemetryStreamState{},
+		events: map[shared.ID]map[eventKey]storedTransportEvent{},
+	}
+}
+
+func (s *TelemetryTransportStore) StreamState(ctx context.Context, agentID, streamID shared.ID, epoch uint64) (ports.TelemetryStreamState, error) {
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return ports.TelemetryStreamState{}, err
+	}
+	if agentID.IsZero() || streamID.IsZero() || epoch == 0 {
+		return ports.TelemetryStreamState{}, shared.ErrValidation
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if st, ok := s.states[tenant][streamEpoch{agentID, streamID, epoch}]; ok {
+		return cloneStreamState(st), nil
+	}
+	// A stream/epoch never seen is a zero state (Version 0), not an error.
+	return ports.TelemetryStreamState{AgentID: agentID, StreamID: streamID, Epoch: epoch}, nil
+}
+
+func (s *TelemetryTransportStore) SaveStreamState(ctx context.Context, state ports.TelemetryStreamState) error {
+	if err := state.Validate(); err != nil {
+		return err
+	}
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.states[tenant] == nil {
+		s.states[tenant] = map[streamEpoch]ports.TelemetryStreamState{}
+	}
+	key := streamEpoch{state.AgentID, state.StreamID, state.Epoch}
+	// Optimistic concurrency: accept the write only if the stored version still matches the one the caller
+	// read; otherwise a concurrent batch advanced the stream and the caller must retry.
+	if cur, ok := s.states[tenant][key]; ok {
+		if cur.Version != state.Version {
+			return shared.ErrConflict
+		}
+	} else if state.Version != 0 {
+		return shared.ErrConflict
+	}
+	next := cloneStreamState(state)
+	next.Version = state.Version + 1
+	s.states[tenant][key] = next
+	return nil
+}
+
+func (s *TelemetryTransportStore) MaxEpoch(ctx context.Context, agentID, streamID shared.ID) (uint64, error) {
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var highest uint64
+	for key := range s.states[tenant] {
+		if key.agent == agentID && key.stream == streamID && key.epoch > highest {
+			highest = key.epoch
+		}
+	}
+	return highest, nil
+}
+
+func (s *TelemetryTransportStore) ListGaps(ctx context.Context, agentID, streamID shared.ID) ([]ports.TelemetryGap, error) {
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []ports.TelemetryGap
+	for key, st := range s.states[tenant] {
+		if key.agent == agentID && key.stream == streamID {
+			out = append(out, st.GapsFrom()...)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Epoch != out[j].Epoch {
+			return out[i].Epoch < out[j].Epoch
+		}
+		return out[i].FromSequence < out[j].FromSequence
+	})
+	return out, nil
+}
+
+func (s *TelemetryTransportStore) IngestBatchEvents(ctx context.Context, batch ports.TelemetryEventBatch) (int, error) {
+	if err := batch.Validate(); err != nil {
+		return 0, err
+	}
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.events[tenant] == nil {
+		s.events[tenant] = map[eventKey]storedTransportEvent{}
+	}
+	stored := 0
+	for _, e := range batch.Events {
+		key := eventKey{batch.AgentID, batch.StreamID, batch.Epoch, batch.Sequence, e.EventID}
+		if _, exists := s.events[tenant][key]; exists {
+			continue // idempotent
+		}
+		s.events[tenant][key] = storedTransportEvent{
+			asset: batch.AssetID, class: string(e.Class),
+			digest: e.Digest, payload: append([]byte(nil), e.Payload...), schemaVersion: batch.SchemaVersion,
+		}
+		stored++
+	}
+	return stored, nil
+}
+
+func (s *TelemetryTransportStore) CountBatchEvents(ctx context.Context, agentID, streamID shared.ID, epoch, sequence uint64) (int, error) {
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for key := range s.events[tenant] {
+		if key.agent == agentID && key.stream == streamID && key.epoch == epoch && key.sequence == sequence {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func cloneStreamState(s ports.TelemetryStreamState) ports.TelemetryStreamState {
+	c := s
+	c.Pending = append([]uint64(nil), s.Pending...)
+	return c
+}

--- a/internal/infrastructure/persistence/postgres/telemetry_transport_repo.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_transport_repo.go
@@ -1,0 +1,230 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// TelemetryTransportRepository is the Postgres tier for the A3 telemetry transport state (per-stream ACK
+// snapshots + durable raw batch events). Every method runs under the authenticated ctx tenant via
+// WithContextTenant, so RLS binds the partition — the wire never picks it. State is keyed by the
+// authenticated agent id in addition to the stream id, so an agent-chosen StreamID can never address a
+// sibling agent's stream space within the tenant. Reads also carry an explicit tenant_id predicate as
+// defense-in-depth for a role that could bypass RLS. Transport gaps are DERIVED from the ACK snapshot on
+// read, never a separate stored table.
+type TelemetryTransportRepository struct {
+	pool *pgxpool.Pool
+}
+
+var _ ports.TelemetryTransportStore = (*TelemetryTransportRepository)(nil)
+
+// NewTelemetryTransportRepository constructs the transport store over a pgx pool.
+func NewTelemetryTransportRepository(pool *pgxpool.Pool) *TelemetryTransportRepository {
+	return &TelemetryTransportRepository{pool: pool}
+}
+
+func requireTransportTenant(ctx context.Context) error {
+	if _, ok := shared.TenantFrom(ctx); !ok {
+		return fmt.Errorf("%w: telemetry transport operation requires a tenant in context", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (r *TelemetryTransportRepository) StreamState(ctx context.Context, agentID, streamID shared.ID, epoch uint64) (ports.TelemetryStreamState, error) {
+	if agentID.IsZero() || streamID.IsZero() || epoch == 0 {
+		return ports.TelemetryStreamState{}, fmt.Errorf("%w: agent id, stream id and epoch are required", shared.ErrValidation)
+	}
+	if err := requireTransportTenant(ctx); err != nil {
+		return ports.TelemetryStreamState{}, err
+	}
+	state := ports.TelemetryStreamState{AgentID: agentID, StreamID: streamID, Epoch: epoch}
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		var contiguous, version int64
+		var pending []int64
+		tenant, _ := shared.TenantFrom(ctx)
+		row := tx.QueryRow(ctx, `SELECT contiguous, pending, version FROM telemetry_stream_positions
+			WHERE tenant_id=$1 AND agent_id=$2 AND stream_id=$3 AND epoch=$4`,
+			tenant.String(), agentID.String(), streamID.String(), int64(epoch))
+		switch err := row.Scan(&contiguous, &pending, &version); {
+		case errors.Is(err, pgx.ErrNoRows):
+			return nil // zero state (Version 0)
+		case err != nil:
+			return fmt.Errorf("read stream position: %w", err)
+		}
+		state.Contiguous = uint64(contiguous)
+		state.Version = uint64(version)
+		state.Pending = make([]uint64, len(pending))
+		for i, p := range pending {
+			state.Pending[i] = uint64(p)
+		}
+		return nil
+	})
+	if err != nil {
+		return ports.TelemetryStreamState{}, err
+	}
+	return state, nil
+}
+
+func (r *TelemetryTransportRepository) SaveStreamState(ctx context.Context, state ports.TelemetryStreamState) error {
+	if err := state.Validate(); err != nil {
+		return err
+	}
+	if err := requireTransportTenant(ctx); err != nil {
+		return err
+	}
+	pending := make([]int64, len(state.Pending))
+	for i, p := range state.Pending {
+		pending[i] = int64(p)
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		tenant, _ := shared.TenantFrom(ctx)
+		// Optimistic concurrency: the write lands only if the stored version still equals the one the caller
+		// read (state.Version); otherwise a concurrent batch advanced the stream and we return ErrConflict so
+		// the usecase retries from a fresh read.
+		if state.Version == 0 {
+			tag, err := tx.Exec(ctx, `
+				INSERT INTO telemetry_stream_positions (tenant_id, agent_id, stream_id, epoch, contiguous, pending, version, updated_at)
+				VALUES ($1,$2,$3,$4,$5,$6,1,$7)
+				ON CONFLICT (tenant_id, agent_id, stream_id, epoch) DO NOTHING`,
+				tenant.String(), state.AgentID.String(), state.StreamID.String(), int64(state.Epoch),
+				int64(state.Contiguous), pending, state.UpdatedAt.UTC())
+			if err != nil {
+				return fmt.Errorf("insert stream position: %w", err)
+			}
+			if tag.RowsAffected() != 1 {
+				return shared.ErrConflict // a row already exists — someone else created it first
+			}
+			return nil
+		}
+		tag, err := tx.Exec(ctx, `
+			UPDATE telemetry_stream_positions
+			SET contiguous=$5, pending=$6, version=version+1, updated_at=$7
+			WHERE tenant_id=$1 AND agent_id=$2 AND stream_id=$3 AND epoch=$4 AND version=$8`,
+			tenant.String(), state.AgentID.String(), state.StreamID.String(), int64(state.Epoch),
+			int64(state.Contiguous), pending, state.UpdatedAt.UTC(), int64(state.Version))
+		if err != nil {
+			return fmt.Errorf("update stream position: %w", err)
+		}
+		if tag.RowsAffected() != 1 {
+			return shared.ErrConflict // version moved under us
+		}
+		return nil
+	})
+}
+
+func (r *TelemetryTransportRepository) MaxEpoch(ctx context.Context, agentID, streamID shared.ID) (uint64, error) {
+	if err := requireTransportTenant(ctx); err != nil {
+		return 0, err
+	}
+	var highest uint64
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		var maxEpoch *int64
+		tenant, _ := shared.TenantFrom(ctx)
+		if err := tx.QueryRow(ctx, `SELECT max(epoch) FROM telemetry_stream_positions
+			WHERE tenant_id=$1 AND agent_id=$2 AND stream_id=$3`,
+			tenant.String(), agentID.String(), streamID.String()).Scan(&maxEpoch); err != nil {
+			return fmt.Errorf("read stream max epoch: %w", err)
+		}
+		if maxEpoch != nil {
+			highest = uint64(*maxEpoch)
+		}
+		return nil
+	})
+	return highest, err
+}
+
+func (r *TelemetryTransportRepository) ListGaps(ctx context.Context, agentID, streamID shared.ID) ([]ports.TelemetryGap, error) {
+	if err := requireTransportTenant(ctx); err != nil {
+		return nil, err
+	}
+	var gaps []ports.TelemetryGap
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		tenant, _ := shared.TenantFrom(ctx)
+		rows, err := tx.Query(ctx, `SELECT epoch, contiguous, pending FROM telemetry_stream_positions
+			WHERE tenant_id=$1 AND agent_id=$2 AND stream_id=$3`, tenant.String(), agentID.String(), streamID.String())
+		if err != nil {
+			return fmt.Errorf("list stream positions: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var epoch, contiguous int64
+			var pending []int64
+			if err := rows.Scan(&epoch, &contiguous, &pending); err != nil {
+				return fmt.Errorf("scan stream position: %w", err)
+			}
+			st := ports.TelemetryStreamState{AgentID: agentID, StreamID: streamID, Epoch: uint64(epoch), Contiguous: uint64(contiguous)}
+			st.Pending = make([]uint64, len(pending))
+			for i, p := range pending {
+				st.Pending[i] = uint64(p)
+			}
+			// Gaps are derived from the ACK snapshot — the single source of truth — so a filled gap is never
+			// reported (no phantom gaps) and there is no separate log to grow unbounded.
+			gaps = append(gaps, st.GapsFrom()...)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(gaps, func(i, j int) bool {
+		if gaps[i].Epoch != gaps[j].Epoch {
+			return gaps[i].Epoch < gaps[j].Epoch
+		}
+		return gaps[i].FromSequence < gaps[j].FromSequence
+	})
+	return gaps, nil
+}
+
+func (r *TelemetryTransportRepository) IngestBatchEvents(ctx context.Context, batch ports.TelemetryEventBatch) (int, error) {
+	if err := batch.Validate(); err != nil {
+		return 0, err
+	}
+	if err := requireTransportTenant(ctx); err != nil {
+		return 0, err
+	}
+	stored := 0
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		tenant, _ := shared.TenantFrom(ctx)
+		for _, e := range batch.Events {
+			tag, err := tx.Exec(ctx, `
+				INSERT INTO telemetry_batch_events
+				  (tenant_id, agent_id, stream_id, asset_id, epoch, sequence, event_id, class, digest, schema_version, payload, observed_at)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+				ON CONFLICT (tenant_id, agent_id, stream_id, epoch, sequence, event_id) DO NOTHING`,
+				tenant.String(), batch.AgentID.String(), batch.StreamID.String(), batch.AssetID.String(),
+				int64(batch.Epoch), int64(batch.Sequence), e.EventID.String(), string(e.Class), e.Digest,
+				batch.SchemaVersion, e.Payload, e.ObservedAt.UTC())
+			if err != nil {
+				return fmt.Errorf("insert batch event: %w", err)
+			}
+			stored += int(tag.RowsAffected())
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return stored, nil
+}
+
+func (r *TelemetryTransportRepository) CountBatchEvents(ctx context.Context, agentID, streamID shared.ID, epoch, sequence uint64) (int, error) {
+	if err := requireTransportTenant(ctx); err != nil {
+		return 0, err
+	}
+	var n int
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		tenant, _ := shared.TenantFrom(ctx)
+		return tx.QueryRow(ctx, `SELECT count(*) FROM telemetry_batch_events
+			WHERE tenant_id=$1 AND agent_id=$2 AND stream_id=$3 AND epoch=$4 AND sequence=$5`,
+			tenant.String(), agentID.String(), streamID.String(), int64(epoch), int64(sequence)).Scan(&n)
+	})
+	return n, err
+}

--- a/internal/infrastructure/persistence/postgres/telemetry_transport_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_transport_repo_test.go
@@ -1,0 +1,152 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestTelemetryTransportRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenant := shared.ID("ttrans-" + id)
+	other := shared.ID("ttrans-other-" + id)
+	for _, tn := range []shared.ID{tenant, other} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tn.String()); err != nil {
+			t.Fatalf("seed tenant: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, tbl := range []string{"telemetry_batch_events", "telemetry_stream_positions"} {
+			for _, tn := range []shared.ID{tenant, other} {
+				_, _ = pool.Exec(bg, `DELETE FROM `+tbl+` WHERE tenant_id=$1`, tn.String())
+			}
+		}
+		for _, tn := range []shared.ID{tenant, other} {
+			_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id=$1`, tn.String())
+		}
+	})
+
+	repo := NewTelemetryTransportRepository(pool)
+	tctx := shared.WithTenant(ctx, tenant)
+	now := time.Now().UTC()
+	stream := shared.ID("stream-" + id)
+	agentA := shared.ID("agent-a-" + id)
+	agentB := shared.ID("agent-b-" + id)
+
+	// Zero state for an unseen (agent, stream, epoch): Version 0.
+	if st, err := repo.StreamState(tctx, agentA, stream, 1); err != nil || st.Contiguous != 0 || len(st.Pending) != 0 || st.Version != 0 {
+		t.Fatalf("unseen stream must be zero state: %+v err=%v", st, err)
+	}
+
+	// Save (version 0 → insert) + reload; the stored version advances to 1.
+	want := ports.TelemetryStreamState{AgentID: agentA, StreamID: stream, Epoch: 1, Contiguous: 3, Pending: []uint64{5, 7}, UpdatedAt: now}
+	if err := repo.SaveStreamState(tctx, want); err != nil {
+		t.Fatalf("save stream state: %v", err)
+	}
+	got, err := repo.StreamState(tctx, agentA, stream, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Contiguous != 3 || len(got.Pending) != 2 || got.Pending[0] != 5 || got.Pending[1] != 7 || got.Version != 1 {
+		t.Fatalf("reloaded state mismatch: %+v", got)
+	}
+
+	// Gaps are DERIVED from the snapshot: contiguous=3, pending={5,7} ⇒ holes [4,4] and [6,6].
+	gaps, err := repo.ListGaps(tctx, agentA, stream)
+	if err != nil || len(gaps) != 2 || gaps[0].FromSequence != 4 || gaps[0].ToSequence != 4 || gaps[1].FromSequence != 6 || gaps[1].ToSequence != 6 {
+		t.Fatalf("want derived gaps [4,4],[6,6], got %+v err=%v", gaps, err)
+	}
+
+	// Optimistic concurrency: a save carrying a STALE version must be rejected with ErrConflict.
+	stale := got
+	stale.Version = 0 // pretend we still hold the pre-insert version
+	stale.Contiguous, stale.Pending = 99, nil
+	if err := repo.SaveStreamState(tctx, stale); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale-version save must conflict, got %v", err)
+	}
+	// The CAS with the CURRENT version wins and clears the pending set (so the derived gaps disappear).
+	got.Contiguous, got.Pending = 7, nil
+	if err := repo.SaveStreamState(tctx, got); err != nil {
+		t.Fatal(err)
+	}
+	if reloaded, _ := repo.StreamState(tctx, agentA, stream, 1); reloaded.Contiguous != 7 || len(reloaded.Pending) != 0 || reloaded.Version != 2 {
+		t.Fatalf("CAS did not advance state+version: %+v", reloaded)
+	}
+	if gaps, _ := repo.ListGaps(tctx, agentA, stream); len(gaps) != 0 {
+		t.Fatalf("a fully-contiguous stream must have no derived gaps, got %+v", gaps)
+	}
+
+	// MaxEpoch reflects the highest epoch with state.
+	if err := repo.SaveStreamState(tctx, ports.TelemetryStreamState{AgentID: agentA, StreamID: stream, Epoch: 4, Contiguous: 1, UpdatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if max, _ := repo.MaxEpoch(tctx, agentA, stream); max != 4 {
+		t.Fatalf("MaxEpoch = %d, want 4", max)
+	}
+
+	// Batch events: ingest + idempotent + count.
+	batch := ports.TelemetryEventBatch{
+		AgentID: agentA, StreamID: stream, AssetID: "as", Epoch: 1, Sequence: 1, SchemaVersion: 1,
+		Events: []ports.StoredTelemetryEvent{
+			{EventID: "e1", Class: detection.ClassProcess, Digest: "d1", Payload: []byte("p1"), ObservedAt: now},
+			{EventID: "e2", Class: detection.ClassNetwork, Digest: "d2", Payload: []byte("p2"), ObservedAt: now},
+		},
+	}
+	if n, err := repo.IngestBatchEvents(tctx, batch); err != nil || n != 2 {
+		t.Fatalf("first ingest must store 2, got %d err=%v", n, err)
+	}
+	if n, err := repo.IngestBatchEvents(tctx, batch); err != nil || n != 0 {
+		t.Fatalf("re-ingest must store 0 (idempotent), got %d err=%v", n, err)
+	}
+	if n, _ := repo.CountBatchEvents(tctx, agentA, stream, 1, 1); n != 2 {
+		t.Fatalf("CountBatchEvents = %d, want 2", n)
+	}
+
+	// Cross-agent isolation: a DIFFERENT agent using the SAME StreamID has its OWN stream space within the
+	// tenant — it sees agentA's state as zero and cannot read agentA's events. This is the HIGH-2 fix.
+	if st, _ := repo.StreamState(tctx, agentB, stream, 1); st.Contiguous != 0 || st.Version != 0 {
+		t.Fatalf("sibling agent must see zero state for the same stream id, got %+v", st)
+	}
+	if max, _ := repo.MaxEpoch(tctx, agentB, stream); max != 0 {
+		t.Fatalf("sibling agent MaxEpoch must be 0, got %d", max)
+	}
+	if n, _ := repo.CountBatchEvents(tctx, agentB, stream, 1, 1); n != 0 {
+		t.Fatalf("sibling agent must not see agentA's events, got %d", n)
+	}
+
+	// RLS isolation: the other tenant sees none of this stream's transport rows.
+	octx := shared.WithTenant(ctx, other)
+	if gaps, _ := repo.ListGaps(octx, agentA, stream); len(gaps) != 0 {
+		t.Fatalf("cross-tenant must not see gaps, got %d", len(gaps))
+	}
+	if n, _ := repo.CountBatchEvents(octx, agentA, stream, 1, 1); n != 0 {
+		t.Fatalf("cross-tenant must not see events, got %d", n)
+	}
+	if st, _ := repo.StreamState(octx, agentA, stream, 1); st.Contiguous != 0 {
+		t.Fatalf("cross-tenant must not see stream state, got contiguous %d", st.Contiguous)
+	}
+	if max, _ := repo.MaxEpoch(octx, agentA, stream); max != 0 {
+		t.Fatalf("cross-tenant MaxEpoch must be 0, got %d", max)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -284,6 +284,11 @@ type Config struct {
 	// its collected host inventory (facts + packages + coverage) to be persisted as a Kind=host asset.
 	// Off by default; requires FleetEnabled + FleetAssetsEnabled.
 	FleetHostIngestEnabled bool
+	// FleetTelemetryIngestEnabled turns on the agent→control-plane telemetry batch ingest endpoint
+	// (A3, #624): an enrolled agent ships a signed TelemetryBatchManifest which the control plane verifies
+	// (identity + signing key + schema, fail-closed), sequences idempotently, and acks. Off by default;
+	// requires FleetEnabled.
+	FleetTelemetryIngestEnabled bool
 	// FleetAgentStaleAfter is how long since an agent's last heartbeat before it is reported stale in
 	// the coverage/agent-health views (#413, SYNAPSE_FLEET_STALE_AFTER). <=0 disables the staleness
 	// check. Default 10m, per the issue spec.
@@ -662,6 +667,7 @@ func Load() Config {
 		FleetEnabled:                          getbool("SYNAPSE_FLEET_ENABLED", false),
 		FleetClusterIngestEnabled:             getbool("SYNAPSE_FLEET_CLUSTER_INGEST_ENABLED", false),
 		FleetHostIngestEnabled:                getbool("SYNAPSE_FLEET_HOST_INGEST_ENABLED", false),
+		FleetTelemetryIngestEnabled:           getbool("SYNAPSE_FLEET_TELEMETRY_INGEST_ENABLED", false),
 		FleetMinAgentVersion:                  strings.TrimSpace(os.Getenv("SYNAPSE_FLEET_MIN_AGENT_VERSION")),
 		FleetAgentStaleAfter:                  getduration("SYNAPSE_FLEET_STALE_AFTER", 10*time.Minute),
 		FleetCoverageFreshnessTarget:          getduration("SYNAPSE_FLEET_COVERAGE_FRESHNESS_TARGET", 24*time.Hour),

--- a/internal/usecase/fleet/telemetryingest/service.go
+++ b/internal/usecase/fleet/telemetryingest/service.go
@@ -1,0 +1,261 @@
+// Package telemetryingest is the control-plane side of the A3 (#624) agent→control-plane telemetry
+// transport: it accepts a signed TelemetryBatchManifest plus its events, verifies the agent's identity,
+// signing key, and schema SERVER-SIDE (fail-closed), sequences the batch idempotently per stream
+// incarnation, derives transport gaps from the ACK snapshot, durably stores the events, and returns the
+// highest-contiguous ACK so the agent can delete acknowledged batches.
+package telemetryingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetryschema"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	// maxForwardGap bounds how far a batch's sequence may jump ahead of the acknowledged (contiguous) mark
+	// in one stream incarnation. It caps the pending set (and thus per-request O(n) work and stored array
+	// size) so a compromised agent streaming sparse sequences cannot grow unbounded state — the back-pressure
+	// the AckLedger contract designates to A3 ingest. A well-behaved agent lets the ACK catch up long before
+	// this many holes accumulate.
+	maxForwardGap = 4096
+	// maxIngestRetries bounds the optimistic-concurrency retry loop when concurrent batches for one
+	// (agent, stream, epoch) race on the ACK snapshot. Each retry re-reads fresh state; a handful suffices
+	// because a well-behaved agent ships one stream sequentially.
+	maxIngestRetries = 8
+)
+
+// Provenance is the coarse ingest lifecycle state returned to the caller.
+type Provenance string
+
+const (
+	ProvenanceAcknowledged Provenance = "acknowledged" // stored durably and acknowledged
+	ProvenanceRejected     Provenance = "rejected"
+)
+
+// EventPayload is one shipped raw telemetry event: its stable id, class, opaque bytes, and source time.
+type EventPayload struct {
+	EventID    shared.ID
+	Class      detection.Class
+	Payload    []byte
+	ObservedAt time.Time
+}
+
+// IngestRequest is a signed batch manifest plus the events it commits to.
+type IngestRequest struct {
+	Manifest fleetagent.TelemetryBatchManifest
+	Events   []EventPayload
+}
+
+// IngestResult is the outcome the agent needs: the highest-contiguous ACK for the stream (so it can
+// delete acked batches), whether this delivery was newly accepted or an idempotent replay, and whether the
+// stream still has an open (derived) gap below the received frontier so a forward-gap is visible.
+type IngestResult struct {
+	Accepted   bool
+	Duplicate  bool
+	ACK        uint64
+	Provenance Provenance
+	GapOpen    bool
+}
+
+// SigningKeyResolver is the narrow slice of ports.AgentSigningKeyStore this usecase consumes: resolve a
+// telemetry-signing key by (agentID, keyID) to verify a manifest server-side. Defined here (consumer
+// side) so the dependency is minimal and the composition root's full store satisfies it directly.
+type SigningKeyResolver interface {
+	ResolveSigningKey(ctx context.Context, agentID shared.ID, keyID string) (fleetagent.AgentSigningKey, error)
+}
+
+// Service orchestrates verified, idempotent telemetry ingest.
+type Service struct {
+	transport ports.TelemetryTransportStore
+	keys      SigningKeyResolver
+	audit     ports.AuditLogger
+	clock     ports.Clock
+}
+
+// NewService validates and constructs the ingest service.
+func NewService(transport ports.TelemetryTransportStore, keys SigningKeyResolver, audit ports.AuditLogger, clock ports.Clock) (*Service, error) {
+	if transport == nil || keys == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: telemetry ingest service needs a transport store, signing-key store, audit log and clock", shared.ErrValidation)
+	}
+	return &Service{transport: transport, keys: keys, audit: audit, clock: clock}, nil
+}
+
+// Ingest verifies and stores one telemetry batch. authAgentID is the canonical id of the AUTHENTICATED
+// agent (from the agent-plane credential, never a wire field); a manifest claiming any other agent is
+// rejected. Every rejection is audited. The tenant is bound from ctx by the stores.
+func (s *Service) Ingest(ctx context.Context, authAgentID shared.ID, req IngestRequest) (IngestResult, error) {
+	now := s.clock.Now().UTC()
+	m := req.Manifest
+	if err := m.Validate(); err != nil {
+		return IngestResult{}, err
+	}
+	// A0.1 server-authoritative identity: the manifest's agent MUST be the authenticated agent.
+	if authAgentID.IsZero() || m.AgentID != authAgentID {
+		s.reject(ctx, authAgentID, m, "identity_mismatch", now)
+		return IngestResult{}, fmt.Errorf("%w: manifest agent %q is not the authenticated agent %q", shared.ErrForbidden, m.AgentID, authAgentID)
+	}
+	// The shipped events must be exactly the ones the signed manifest commits to (id set + per-event
+	// digest), so a transport cannot add, drop, or swap an event body under a signed manifest.
+	if err := verifyEventBinding(m, req.Events); err != nil {
+		s.reject(ctx, authAgentID, m, "event_binding", now)
+		return IngestResult{}, err
+	}
+	// A0.2 signing key: resolve the named key for this agent and verify the manifest signature fail-closed.
+	key, err := s.keys.ResolveSigningKey(ctx, m.AgentID, m.KeyID)
+	if err != nil {
+		s.reject(ctx, authAgentID, m, "key_unresolved", now)
+		return IngestResult{}, fmt.Errorf("%w: resolve telemetry signing key %q: %v", shared.ErrForbidden, m.KeyID, err)
+	}
+	if err := fleetagent.VerifyTelemetryManifestWithKey(key, now, m); err != nil {
+		s.reject(ctx, authAgentID, m, "signature_invalid", now)
+		return IngestResult{}, err
+	}
+	// A0.3 schema: validate the wire schema version against the supported range, fail-closed.
+	if err := telemetryschema.Validate(m.SchemaVersion); err != nil {
+		s.reject(ctx, authAgentID, m, "schema_unsupported", now)
+		return IngestResult{}, err
+	}
+	// A0.4 incarnation: a batch for an epoch the stream has already advanced past is a stale incarnation.
+	// The stream state is keyed by the AUTHENTICATED agent id, so an agent-chosen StreamID can only ever
+	// address this agent's own stream space — never a sibling agent's within the tenant.
+	maxEpoch, err := s.transport.MaxEpoch(ctx, m.AgentID, m.StreamID)
+	if err != nil {
+		return IngestResult{}, fmt.Errorf("read stream max epoch: %w", err)
+	}
+	if m.Position.Epoch < maxEpoch {
+		s.reject(ctx, authAgentID, m, "stale_incarnation", now)
+		return IngestResult{}, fmt.Errorf("%w: telemetry batch epoch %d is behind the stream's current incarnation %d", shared.ErrValidation, m.Position.Epoch, maxEpoch)
+	}
+
+	// Delivery sequencing per (agent, stream, epoch), under optimistic concurrency: read the ACK snapshot,
+	// classify the sequence, store the events, then write the snapshot back only if its version is unchanged.
+	// A concurrent batch for the same stream loses the CAS and we retry from a fresh read — so a race can
+	// never lose-update the ACK or fabricate a gap. Each incarnation is an independent ledger, so a reboot's
+	// reset-to-1 is a fresh sequence, never a replay of the previous incarnation.
+	for attempt := 0; ; attempt++ {
+		state, err := s.transport.StreamState(ctx, m.AgentID, m.StreamID, m.Position.Epoch)
+		if err != nil {
+			return IngestResult{}, fmt.Errorf("read stream state: %w", err)
+		}
+		// Back-pressure: reject an implausible forward jump before it grows the pending set (A0.4/HIGH-DoS).
+		if m.Position.Sequence > state.Contiguous && m.Position.Sequence-state.Contiguous > maxForwardGap {
+			s.reject(ctx, authAgentID, m, "forward_jump_too_large", now)
+			return IngestResult{}, fmt.Errorf("%w: telemetry batch sequence %d jumps more than %d ahead of the acked mark %d; let the ACK catch up", shared.ErrValidation, m.Position.Sequence, maxForwardGap, state.Contiguous)
+		}
+		ledger := state.LoadAckLedger()
+		if !ledger.Observe(m.Position.Sequence) {
+			// Idempotent replay/duplicate within this incarnation: no re-store, ACK is the current mark.
+			s.record(ctx, authAgentID, m, "fleet.telemetry.replay", false, now)
+			return IngestResult{Accepted: false, Duplicate: true, ACK: ledger.HighestContiguous(), Provenance: ProvenanceAcknowledged}, nil
+		}
+		// Newly accepted: durably store the events (idempotent), then CAS the ACK snapshot. Events are stored
+		// before the snapshot so a crash between them re-heals on retransmit and the ACK never covers unstored
+		// data; re-storing on a retry is a no-op.
+		if _, err := s.transport.IngestBatchEvents(ctx, s.eventBatch(m, req.Events)); err != nil {
+			return IngestResult{}, fmt.Errorf("store telemetry events: %w", err)
+		}
+		next := ports.TelemetryStreamState{
+			AgentID: m.AgentID, StreamID: m.StreamID, Epoch: m.Position.Epoch,
+			Contiguous: ledger.HighestContiguous(), Pending: ledger.Pending(), Version: state.Version, UpdatedAt: now,
+		}
+		err = s.transport.SaveStreamState(ctx, next)
+		if errors.Is(err, shared.ErrConflict) {
+			if attempt+1 >= maxIngestRetries {
+				return IngestResult{}, fmt.Errorf("%w: telemetry stream %q is too contended to sequence after %d attempts", shared.ErrConflict, m.StreamID, maxIngestRetries)
+			}
+			continue // a concurrent batch advanced the stream; re-read and reclassify
+		}
+		if err != nil {
+			return IngestResult{}, fmt.Errorf("save stream state: %w", err)
+		}
+		// Gaps are DERIVED from the snapshot (not a separate log), so a filled gap simply stops being open.
+		gapOpen := len(ledger.Gaps()) > 0
+		s.record(ctx, authAgentID, m, "fleet.telemetry.ingest", gapOpen, now)
+		return IngestResult{Accepted: true, ACK: ledger.HighestContiguous(), Provenance: ProvenanceAcknowledged, GapOpen: gapOpen}, nil
+	}
+}
+
+// verifyEventBinding checks the shipped events are exactly the manifest's committed set: same count, same
+// id set (unique), and each event's recomputed digest matches the manifest's EventRef for that id.
+func verifyEventBinding(m fleetagent.TelemetryBatchManifest, events []EventPayload) error {
+	if len(events) != m.KeptCount {
+		return fmt.Errorf("%w: batch ships %d events but manifest kept count is %d", shared.ErrValidation, len(events), m.KeptCount)
+	}
+	want := make(map[shared.ID]string, len(m.Events))
+	for _, ref := range m.Events {
+		want[ref.ID] = ref.Digest
+	}
+	seen := make(map[shared.ID]struct{}, len(events))
+	for i, e := range events {
+		if e.EventID.IsZero() {
+			return fmt.Errorf("%w: shipped event[%d] has no id", shared.ErrValidation, i)
+		}
+		if !e.Class.Valid() {
+			return fmt.Errorf("%w: shipped event[%d] has an unknown class %q", shared.ErrValidation, i, e.Class)
+		}
+		if len(e.Payload) == 0 {
+			return fmt.Errorf("%w: shipped event[%d] has no payload", shared.ErrValidation, i)
+		}
+		if _, dup := seen[e.EventID]; dup {
+			return fmt.Errorf("%w: shipped event id %q is duplicated", shared.ErrValidation, e.EventID)
+		}
+		seen[e.EventID] = struct{}{}
+		wantDigest, ok := want[e.EventID]
+		if !ok {
+			return fmt.Errorf("%w: shipped event %q is not in the signed manifest", shared.ErrValidation, e.EventID)
+		}
+		if got := fleetagent.TelemetryEventDigest(e.Payload, m.AssetID); got != wantDigest {
+			return fmt.Errorf("%w: shipped event %q digest does not match the signed manifest", shared.ErrValidation, e.EventID)
+		}
+	}
+	// The signed batch-level PayloadDigest must be the digest OF the manifest's event refs, so the field
+	// cannot be a stray value under an otherwise-valid signature (go-arch: verify the signed field).
+	if got := fleetagent.TelemetryPayloadDigest(m.Events); got != m.PayloadDigest {
+		return fmt.Errorf("%w: manifest payload digest does not match its event refs", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (s *Service) eventBatch(m fleetagent.TelemetryBatchManifest, events []EventPayload) ports.TelemetryEventBatch {
+	stored := make([]ports.StoredTelemetryEvent, len(events))
+	for i, e := range events {
+		stored[i] = ports.StoredTelemetryEvent{
+			EventID: e.EventID, Class: e.Class,
+			Digest:  fleetagent.TelemetryEventDigest(e.Payload, m.AssetID),
+			Payload: e.Payload, ObservedAt: e.ObservedAt.UTC(),
+		}
+	}
+	return ports.TelemetryEventBatch{
+		StreamID: m.StreamID, AgentID: m.AgentID, AssetID: m.AssetID,
+		Epoch: m.Position.Epoch, Sequence: m.Position.Sequence, SchemaVersion: m.SchemaVersion, Events: stored,
+	}
+}
+
+func (s *Service) record(ctx context.Context, actor shared.ID, m fleetagent.TelemetryBatchManifest, action string, gap bool, at time.Time) {
+	_ = s.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor.String(), Action: action, Target: m.StreamID.String(), At: at,
+		Metadata: map[string]string{
+			"batch_id": m.BatchID.String(), "asset_id": m.AssetID.String(),
+			"epoch": fmt.Sprintf("%d", m.Position.Epoch), "sequence": fmt.Sprintf("%d", m.Position.Sequence),
+			"schema_version": fmt.Sprintf("%d", m.SchemaVersion), "gap": fmt.Sprintf("%t", gap),
+		},
+	})
+}
+
+func (s *Service) reject(ctx context.Context, actor shared.ID, m fleetagent.TelemetryBatchManifest, reason string, at time.Time) {
+	_ = s.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor.String(), Action: "fleet.telemetry.reject", Target: m.StreamID.String(), At: at,
+		Metadata: map[string]string{
+			"batch_id": m.BatchID.String(), "manifest_agent_id": m.AgentID.String(),
+			"epoch": fmt.Sprintf("%d", m.Position.Epoch), "sequence": fmt.Sprintf("%d", m.Position.Sequence),
+			"reason": reason,
+		},
+	})
+}

--- a/internal/usecase/fleet/telemetryingest/service_test.go
+++ b/internal/usecase/fleet/telemetryingest/service_test.go
@@ -1,0 +1,250 @@
+package telemetryingest
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const tenant = shared.ID("tenant-1")
+
+type fakeClock struct{ now time.Time }
+
+func (c fakeClock) Now() time.Time { return c.now }
+
+type fakeAudit struct{ n int }
+
+func (a *fakeAudit) Record(context.Context, ports.AuditEntry) error { a.n++; return nil }
+
+// fakeKeys resolves a single registered key; an unknown (agent,keyID) fails closed with ErrNotFound.
+type fakeKeys struct{ key fleetagent.AgentSigningKey }
+
+func (k fakeKeys) ResolveSigningKey(_ context.Context, agentID shared.ID, keyID string) (fleetagent.AgentSigningKey, error) {
+	if agentID == k.key.AgentID && keyID == k.key.KeyID {
+		return k.key, nil
+	}
+	return fleetagent.AgentSigningKey{}, shared.ErrNotFound
+}
+
+type harness struct {
+	svc       *Service
+	transport *memory.TelemetryTransportStore
+	priv      ed25519.PrivateKey
+	key       fleetagent.AgentSigningKey
+	audit     *fakeAudit
+	now       time.Time
+	ctx       context.Context
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	now := time.Unix(1_700_000_000, 0).UTC()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := fleetagent.NewSigningKey("agent-1", fleetagent.PurposeTelemetryBatch, pub, now.Add(-time.Hour), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := memory.NewTelemetryTransportStore()
+	audit := &fakeAudit{}
+	// NewService requires a ports.AuditLogger; the fake satisfies it via the adapter below.
+	svc, err := NewService(transport, fakeKeys{key: key}, audit, fakeClock{now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &harness{
+		svc: svc, transport: transport, priv: priv, key: key, audit: audit, now: now,
+		ctx: shared.WithTenant(context.Background(), tenant),
+	}
+}
+
+// signedBatch builds a valid signed manifest + matching events for one batch position.
+func (h *harness) signedBatch(epoch, seq, prev uint64, eventIDs ...shared.ID) IngestRequest {
+	assetID := shared.ID("asset-1")
+	events := make([]EventPayload, len(eventIDs))
+	refs := make([]fleetagent.EventRef, len(eventIDs))
+	for i, id := range eventIDs {
+		payload := []byte("event-" + id.String())
+		events[i] = EventPayload{EventID: id, Class: detection.ClassProcess, Payload: payload, ObservedAt: h.now}
+		refs[i] = fleetagent.EventRef{ID: id, Digest: fleetagent.TelemetryEventDigest(payload, assetID)}
+	}
+	m := fleetagent.TelemetryBatchManifest{
+		ProtocolVersion:      fleetagent.TelemetryProtocolVersion,
+		SchemaVersion:        1,
+		BatchID:              shared.ID("batch-" + seqStr(epoch) + "-" + seqStr(seq)),
+		AgentID:              "agent-1",
+		AssetID:              assetID,
+		StreamID:             "stream-1",
+		Position:             fleetagent.StreamPosition{Priority: fleetagent.PriorityP1, Epoch: epoch, Sequence: seq, Session: "sess-1", Boot: "boot-1"},
+		PreviousSequence:     prev,
+		EventTimeMin:         h.now,
+		EventTimeMax:         h.now.Add(time.Second),
+		ObservedCount:        len(eventIDs),
+		KeptCount:            len(eventIDs),
+		SamplingPolicyDigest: "spd",
+		Events:               refs,
+		PayloadDigest:        fleetagent.TelemetryPayloadDigest(refs),
+		KeyID:                h.key.KeyID,
+	}
+	m.Signature = fleetagent.SignTelemetryManifest(h.priv, m)
+	return IngestRequest{Manifest: m, Events: events}
+}
+
+func seqStr(u uint64) string { return string(rune('0' + int(u%10))) }
+
+func TestIngestAcceptsAndAcks(t *testing.T) {
+	h := newHarness(t)
+	res, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 1, 0, "e1", "e2"))
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if !res.Accepted || res.Duplicate || res.ACK != 1 || res.Provenance != ProvenanceAcknowledged {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if n, _ := h.transport.CountBatchEvents(h.ctx, "agent-1", "stream-1", 1, 1); n != 2 {
+		t.Fatalf("want 2 stored events, got %d", n)
+	}
+}
+
+func TestIngestIdempotentReplay(t *testing.T) {
+	h := newHarness(t)
+	batch := h.signedBatch(1, 1, 0, "e1")
+	if _, err := h.svc.Ingest(h.ctx, "agent-1", batch); err != nil {
+		t.Fatal(err)
+	}
+	res, err := h.svc.Ingest(h.ctx, "agent-1", batch) // same batch again
+	if err != nil {
+		t.Fatalf("replay must not error: %v", err)
+	}
+	if res.Accepted || !res.Duplicate || res.ACK != 1 {
+		t.Fatalf("replay must be an idempotent duplicate with ACK=1: %+v", res)
+	}
+	if n, _ := h.transport.CountBatchEvents(h.ctx, "agent-1", "stream-1", 1, 1); n != 1 {
+		t.Fatalf("replay must not duplicate stored events, got %d", n)
+	}
+}
+
+func TestIngestRebootResetIsNotReplay(t *testing.T) {
+	h := newHarness(t)
+	if _, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 1, 0, "e1")); err != nil {
+		t.Fatal(err)
+	}
+	// Reboot: new incarnation (Epoch 2), sequence resets to 1 — must be a fresh accept, not a replay.
+	res, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(2, 1, 0, "e2"))
+	if err != nil {
+		t.Fatalf("reboot reset must ingest: %v", err)
+	}
+	if !res.Accepted || res.Duplicate {
+		t.Fatalf("epoch-bumped reset-to-1 must be a fresh accept, not a replay: %+v", res)
+	}
+}
+
+func TestIngestStaleIncarnationRejected(t *testing.T) {
+	h := newHarness(t)
+	if _, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(2, 1, 0, "e1")); err != nil {
+		t.Fatal(err)
+	}
+	// A batch for the older epoch 1 after the stream advanced to epoch 2 is a stale incarnation.
+	if _, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 5, 4, "e2")); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("stale incarnation must be rejected, got %v", err)
+	}
+}
+
+func TestIngestForwardGapPersisted(t *testing.T) {
+	h := newHarness(t)
+	if _, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 1, 0, "e1")); err != nil {
+		t.Fatal(err)
+	}
+	// Jump to sequence 4 — sequences 2,3 are a forward gap.
+	res, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 4, 3, "e4"))
+	if err != nil {
+		t.Fatalf("forward-gap batch must ingest: %v", err)
+	}
+	if !res.Accepted || !res.GapOpen {
+		t.Fatalf("forward gap must be reported open: %+v", res)
+	}
+	if res.ACK != 1 {
+		t.Fatalf("ACK must stay at the contiguous mark 1 while 2,3 are missing, got %d", res.ACK)
+	}
+	gaps, _ := h.transport.ListGaps(h.ctx, "agent-1", "stream-1")
+	if len(gaps) != 1 || gaps[0].FromSequence != 2 || gaps[0].ToSequence != 3 {
+		t.Fatalf("want derived gap [2,3], got %+v", gaps)
+	}
+	// Filling the gap advances the ACK to 4.
+	if _, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 2, 1, "e2")); err != nil {
+		t.Fatal(err)
+	}
+	res3, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 3, 2, "e3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res3.ACK != 4 {
+		t.Fatalf("filling 2,3 must advance the ACK to 4, got %d", res3.ACK)
+	}
+	// A filled gap must NOT linger: once 2,3 arrive the derived gap set is empty (no phantom gap).
+	if gaps, _ := h.transport.ListGaps(h.ctx, "agent-1", "stream-1"); len(gaps) != 0 {
+		t.Fatalf("filled gap must not linger, got %+v", gaps)
+	}
+}
+
+func TestIngestForwardJumpTooLargeRejected(t *testing.T) {
+	h := newHarness(t)
+	if _, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 1, 0, "e1")); err != nil {
+		t.Fatal(err)
+	}
+	// A sequence jumping more than maxForwardGap ahead of the acked mark is rejected before it can grow the
+	// pending set (HIGH-DoS back-pressure), never accepted as an unbounded gap.
+	far := uint64(1) + maxForwardGap + 1
+	if _, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, far, far-1, "eFar")); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("an oversized forward jump must be rejected with ErrValidation, got %v", err)
+	}
+}
+
+func TestIngestIdentityMismatchForbidden(t *testing.T) {
+	h := newHarness(t)
+	// Authenticated as a different agent than the manifest claims.
+	if _, err := h.svc.Ingest(h.ctx, "agent-2", h.signedBatch(1, 1, 0, "e1")); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("identity mismatch must be forbidden, got %v", err)
+	}
+}
+
+func TestIngestFailClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*IngestRequest)
+		is     error
+	}{
+		{"bad signature", func(r *IngestRequest) { r.Manifest.Signature = "AAAA" }, fleetagent.ErrBadManifestSignature},
+		{"unknown key", func(r *IngestRequest) { r.Manifest.KeyID = "unknown" }, shared.ErrForbidden},
+		{"unsupported schema", func(r *IngestRequest) {
+			r.Manifest.SchemaVersion = 999
+		}, shared.ErrValidation},
+		{"tampered event body", func(r *IngestRequest) { r.Events[0].Payload = []byte("tampered") }, shared.ErrValidation},
+		{"event not in manifest", func(r *IngestRequest) { r.Events[0].EventID = "ghost" }, shared.ErrValidation},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHarness(t)
+			req := h.signedBatch(1, 1, 0, "e1")
+			// Re-sign after a schema change so the schema gate (not the signature) is what fails.
+			if tt.name == "unsupported schema" {
+				req.Manifest.SchemaVersion = 999
+				req.Manifest.Signature = fleetagent.SignTelemetryManifest(h.priv, req.Manifest)
+			}
+			tt.mutate(&req)
+			if _, err := h.svc.Ingest(h.ctx, "agent-1", req); !errors.Is(err, tt.is) {
+				t.Fatalf("%s: want error wrapping %v, got %v", tt.name, tt.is, err)
+			}
+		})
+	}
+}

--- a/internal/usecase/ports/telemetry_transport.go
+++ b/internal/usecase/ports/telemetry_transport.go
@@ -1,0 +1,174 @@
+package ports
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TelemetryTransportStore persists the AGENT→CONTROL-PLANE transport sequencing state (A3, #624), kept
+// deliberately separate from the columnar TelemetryStore: it holds per-stream delivery bookkeeping
+// (the highest-contiguous ACK snapshot) keyed by the incarnation-aware (AgentID, StreamID, Epoch), which
+// the columnar (host, class, sequence) store does not model. It is the durable home for the A0.4 AckLedger.
+// Transport gaps are NOT stored: ListGaps derives them from the same snapshot, so the ACK is the single
+// source of truth and a filled gap can never linger as a phantom. Every method is keyed by the AUTHENTICATED
+// agent id (never an agent-chosen wire field) and tenant-scoped from the ctx.
+type TelemetryTransportStore interface {
+	// StreamState returns the persisted delivery state for (agentID, streamID, epoch): the highest-contiguous
+	// acknowledged sequence, the received-but-not-yet-contiguous sequences, and the optimistic-concurrency
+	// version. A stream/epoch never seen returns a zero state (Contiguous=0, Version=0), not an error.
+	StreamState(ctx context.Context, agentID, streamID shared.ID, epoch uint64) (TelemetryStreamState, error)
+	// SaveStreamState persists the recomputed delivery state under optimistic concurrency: it writes only if
+	// the stored version still equals state.Version (else it returns shared.ErrConflict and the caller retries),
+	// so two concurrent batches for one (agent, stream, epoch) cannot lose-update the ACK. It is the sole
+	// writer of ACK state; the usecase computes it from an AckLedger and writes it back under the ctx tenant.
+	SaveStreamState(ctx context.Context, state TelemetryStreamState) error
+	// MaxEpoch returns the highest epoch this (agent, stream) has state for (0 if none), so ingest can reject
+	// a stale incarnation — a batch addressing an epoch below one the stream has already advanced past.
+	MaxEpoch(ctx context.Context, agentID, streamID shared.ID) (uint64, error)
+	// ListGaps returns the open transport gaps for (agent, stream), DERIVED from the persisted ACK snapshots
+	// (contiguous + pending → AckLedger.Gaps()) across all epochs, so a hunt/coverage query learns the window
+	// is lossy from the same source of truth the ACK uses — a filled gap disappears automatically.
+	ListGaps(ctx context.Context, agentID, streamID shared.ID) ([]TelemetryGap, error)
+	// IngestBatchEvents durably persists the shipped raw telemetry events of one accepted batch, keyed by the
+	// incarnation-aware (agentID, streamID, epoch, sequence, eventID). Idempotent: a re-delivered batch stores
+	// each event at most once. Returns how many events were newly stored. The bytes are stored opaque +
+	// content-addressed by digest; interpretation/columnar-hunt is a later concern.
+	IngestBatchEvents(ctx context.Context, batch TelemetryEventBatch) (int, error)
+	// CountBatchEvents returns how many events are stored for (agentID, streamID, epoch, sequence) — for tests
+	// and idempotency assertions.
+	CountBatchEvents(ctx context.Context, agentID, streamID shared.ID, epoch, sequence uint64) (int, error)
+}
+
+// TelemetryEventBatch is one accepted batch's raw events to persist durably, already verified against the
+// signed manifest (identity, key, schema, per-event digest) by the ingest usecase.
+type TelemetryEventBatch struct {
+	AgentID       shared.ID
+	StreamID      shared.ID
+	AssetID       shared.ID
+	Epoch         uint64
+	Sequence      uint64
+	SchemaVersion int
+	Events        []StoredTelemetryEvent
+}
+
+// StoredTelemetryEvent is one raw telemetry event persisted by the transport store: its stable id, class,
+// content digest (matched against the manifest), opaque shipped bytes, and source time.
+type StoredTelemetryEvent struct {
+	EventID    shared.ID
+	Class      detection.Class
+	Digest     string
+	Payload    []byte
+	ObservedAt time.Time
+}
+
+// Validate checks the event batch is well-formed and internally consistent.
+func (b TelemetryEventBatch) Validate() error {
+	if b.AgentID.IsZero() || b.StreamID.IsZero() || b.AssetID.IsZero() {
+		return fmt.Errorf("%w: telemetry event batch needs agent, stream and asset ids", shared.ErrValidation)
+	}
+	if b.Epoch == 0 || b.Sequence == 0 {
+		return fmt.Errorf("%w: telemetry event batch needs a non-zero epoch and sequence", shared.ErrValidation)
+	}
+	if b.SchemaVersion < 1 {
+		return fmt.Errorf("%w: telemetry event batch schema version must be >= 1", shared.ErrValidation)
+	}
+	for i, e := range b.Events {
+		if e.EventID.IsZero() {
+			return fmt.Errorf("%w: telemetry event[%d] has no id", shared.ErrValidation, i)
+		}
+		if !e.Class.Valid() {
+			return fmt.Errorf("%w: telemetry event[%d] has an unknown class %q", shared.ErrValidation, i, e.Class)
+		}
+		if e.Digest == "" {
+			return fmt.Errorf("%w: telemetry event[%d] has no digest", shared.ErrValidation, i)
+		}
+		if len(e.Payload) == 0 {
+			return fmt.Errorf("%w: telemetry event[%d] has no payload", shared.ErrValidation, i)
+		}
+	}
+	return nil
+}
+
+// TelemetryStreamState is the durable AckLedger snapshot for one (AgentID, StreamID, Epoch): the highest
+// sequence with no hole beneath it (the ACK returned to the agent so it can delete acked batches), plus the
+// received sequences ABOVE the contiguous mark that are waiting for their gap to fill. Rehydrating an
+// AckLedger from this state and Observe-ing a new sequence recomputes both fields deterministically. Version
+// is the optimistic-concurrency token: read it with the state, write it back unchanged; SaveStreamState
+// accepts the write only if the store still holds that version.
+type TelemetryStreamState struct {
+	AgentID    shared.ID
+	StreamID   shared.ID
+	Epoch      uint64
+	Contiguous uint64
+	// Pending are received sequences strictly above Contiguous whose predecessors have not all arrived;
+	// bounded by the ingest forward-gap cap. Empty when the stream is fully contiguous.
+	Pending   []uint64
+	Version   uint64
+	UpdatedAt time.Time
+}
+
+// Validate checks the state is well-formed: a real agent/stream/epoch and no pending sequence at or below the
+// contiguous mark (which would be a contradiction — a contiguous sequence is not pending).
+func (s TelemetryStreamState) Validate() error {
+	if s.AgentID.IsZero() {
+		return fmt.Errorf("%w: telemetry stream state has no agent id", shared.ErrValidation)
+	}
+	if s.StreamID.IsZero() {
+		return fmt.Errorf("%w: telemetry stream state has no stream id", shared.ErrValidation)
+	}
+	if s.Epoch == 0 {
+		return fmt.Errorf("%w: telemetry stream state epoch must be >= 1", shared.ErrValidation)
+	}
+	for _, seq := range s.Pending {
+		if seq <= s.Contiguous {
+			return fmt.Errorf("%w: pending sequence %d is not above the contiguous mark %d", shared.ErrValidation, seq, s.Contiguous)
+		}
+	}
+	return nil
+}
+
+// TelemetryGap is a DERIVED transport gap: a run of batch sequences that has not arrived for a stream
+// incarnation, computed on read from the ACK snapshot so a hunt over the window learns it is lossy from the
+// same source of truth the ACK uses. It is never persisted, so a gap that fills simply stops being returned.
+type TelemetryGap struct {
+	AgentID      shared.ID
+	StreamID     shared.ID
+	Epoch        uint64
+	FromSequence uint64 // first missing sequence (inclusive)
+	ToSequence   uint64 // last missing sequence (inclusive)
+}
+
+// LoadAckLedger rehydrates an AckLedger from the persisted state so the usecase can Observe a new
+// sequence and recompute (Contiguous, Pending) with the exact A0.4 semantics.
+func (s TelemetryStreamState) LoadAckLedger() *fleetagent.AckLedger {
+	ledger := fleetagent.NewAckLedger()
+	// Seeding: observe every contiguous sequence [1..Contiguous] would be O(n); instead the AckLedger
+	// exposes a seed constructor. We reconstruct by observing the pending set on top of a contiguous base.
+	ledger.SeedContiguous(s.Contiguous)
+	for _, seq := range s.Pending {
+		ledger.Observe(seq)
+	}
+	return ledger
+}
+
+// GapsFrom derives the open transport gaps for a stream incarnation from its ACK snapshot, so both the
+// store impls and callers compute gaps identically from the single source of truth.
+func (s TelemetryStreamState) GapsFrom() []TelemetryGap {
+	ledger := s.LoadAckLedger()
+	var gaps []TelemetryGap
+	for _, g := range ledger.Gaps() {
+		gaps = append(gaps, TelemetryGap{
+			AgentID:      s.AgentID,
+			StreamID:     s.StreamID,
+			Epoch:        s.Epoch,
+			FromSequence: g.From,
+			ToSequence:   g.To,
+		})
+	}
+	return gaps
+}

--- a/migrations/0109_telemetry_transport.sql
+++ b/migrations/0109_telemetry_transport.sql
@@ -1,0 +1,66 @@
+-- +goose Up
+-- A3 (#624) agent→control-plane telemetry transport state, kept separate from the columnar
+-- telemetry_events tier: it holds the incarnation-aware (stream, epoch) delivery bookkeeping the
+-- columnar (host, class, seq) store does not model — the highest-contiguous ACK snapshot and the durable
+-- raw batch events. Transport gaps are NOT a separate table: they are derived on read from the ACK snapshot
+-- (contiguous + pending → AckLedger.Gaps()), which is the single source of truth, so a filled gap can never
+-- linger as a phantom. Like telemetry_events these rows are mutable/expirable and NOT hash-chained: they are
+-- transport honesty, never evidence. Both tables are tenant-scoped RLS.
+
+-- Per-(stream, epoch) AckLedger snapshot: the highest sequence with no hole beneath it (the ACK) and the
+-- received-but-not-yet-contiguous sequences (pending). Rehydrating an AckLedger from this recomputes the
+-- ACK on the next batch without replaying every sequence. A reboot mints a new epoch row, so a
+-- reset-to-1 in a new incarnation is a fresh sequence, never a replay of the previous incarnation.
+-- The transport identity key includes agent_id: a StreamID is chosen by the agent, so keying delivery
+-- state on (tenant, stream) alone would let one compromised agent hijack a sibling agent's stream within
+-- the same tenant (force a stale-incarnation reject, or falsely advance its ACK so it deletes un-acked
+-- batches). Namespacing by the AUTHENTICATED agent_id gives each agent its own stream space, closing that
+-- intra-tenant cross-agent vector (A0.1 server-authoritative identity for the stream partition).
+CREATE TABLE telemetry_stream_positions (
+    tenant_id  TEXT NOT NULL REFERENCES tenants(id),
+    agent_id   TEXT NOT NULL,
+    stream_id  TEXT NOT NULL,
+    epoch      BIGINT NOT NULL,
+    contiguous BIGINT NOT NULL DEFAULT 0,
+    pending    BIGINT[] NOT NULL DEFAULT '{}',
+    -- version is an optimistic-concurrency guard: an ingest reads (contiguous, pending, version),
+    -- classifies, then writes back only if version is unchanged (else it retries). This serializes
+    -- concurrent batches for one (agent, stream, epoch) so a lost update cannot regress the ACK or
+    -- fabricate a gap.
+    version    BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, agent_id, stream_id, epoch),
+    CONSTRAINT telemetry_stream_positions_epoch_check CHECK (epoch >= 1),
+    CONSTRAINT telemetry_stream_positions_contiguous_check CHECK (contiguous >= 0)
+);
+CREATE INDEX idx_telemetry_stream_positions_stream ON telemetry_stream_positions (tenant_id, agent_id, stream_id, epoch);
+CALL synapse_enable_tenant_rls('telemetry_stream_positions');
+
+-- Durable raw batch events: the opaque shipped bytes of each accepted event, content-addressed by digest,
+-- carrying the wire schema_version (A0.3), keyed by the incarnation-aware (agent, stream, epoch, seq, event_id)
+-- so a re-delivered batch stores each event at most once (idempotent ingest). agent_id is in the key for the
+-- same reason as the positions table: an agent-chosen StreamID must never let one agent write into another
+-- agent's stream space within the tenant.
+CREATE TABLE telemetry_batch_events (
+    tenant_id      TEXT NOT NULL REFERENCES tenants(id),
+    agent_id       TEXT NOT NULL,
+    stream_id      TEXT NOT NULL,
+    asset_id       TEXT NOT NULL,
+    epoch          BIGINT NOT NULL,
+    sequence       BIGINT NOT NULL,
+    event_id       TEXT NOT NULL,
+    class          TEXT NOT NULL,
+    digest         TEXT NOT NULL,
+    schema_version INT NOT NULL,
+    payload        BYTEA NOT NULL,
+    observed_at    TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, agent_id, stream_id, epoch, sequence, event_id),
+    CONSTRAINT telemetry_batch_events_schema_check CHECK (schema_version >= 1),
+    CONSTRAINT telemetry_batch_events_seq_check CHECK (epoch >= 1 AND sequence >= 1)
+);
+CREATE INDEX idx_telemetry_batch_events_stream ON telemetry_batch_events (tenant_id, agent_id, stream_id, epoch, sequence);
+CALL synapse_enable_tenant_rls('telemetry_batch_events');
+
+-- +goose Down
+DROP TABLE telemetry_batch_events;
+DROP TABLE telemetry_stream_positions;


### PR DESCRIPTION
## A3 — telemetry transport ingest control plane (#624)

Server-side of the agent→control-plane telemetry transport (EPIC #594 spine, A0→A1→A2→**A3**). An enrolled agent ships a signed `TelemetryBatchManifest` plus its events; the control plane verifies **identity, signing key, per-event digest binding, and schema server-side (fail-closed)**, sequences the batch **idempotently per stream incarnation**, and returns the **highest-contiguous ACK** so the agent can delete acknowledged batches.

### What's in this PR
- **domain/fleetagent** — `TelemetryBatchManifest` + canonical, domain-separated (`synapse-telemetry-batch:v1`) Ed25519 sign/verify; `VerifyTelemetryManifestWithKey` fail-closed (purpose, agent binding, KeyID, usable window, signature). `TelemetryEventDigest` (per event) and `TelemetryPayloadDigest` (batch-level, verified) bind the event bodies to the signed manifest. Epoch/sequence upper-bounded so a hostile value is a clean 4xx, not a storage 500. `AckLedger` gains `SeedContiguous` + `Pending` for O(pending) rehydrate.
- **usecase/ports** — `TelemetryTransportStore` keyed by the **authenticated agent id** (`agent_id` in the identity key everywhere) so an agent-chosen `StreamID` can never address a sibling agent's stream within a tenant. **Gaps are derived** on read from the ACK snapshot (contiguous + pending), never a separate log — a filled gap cannot linger as a phantom. `SaveStreamState` is an optimistic-concurrency CAS.
- **usecase/telemetryingest** — verify → sequence → store, in a bounded CAS retry loop (atomic read-classify-write per stream, no lost update), with a **forward-jump bound** that caps the pending set (DoS back-pressure), idempotent replay, reboot reset-vs-replay via epoch keying, and stale-incarnation reject. Every rejection is audited with an attributable actor + reason.
- **persistence** — memory + postgres stores + migration `0109` (two tenant-RLS tables: `FORCE` RLS, `agent_id` in the PKs, explicit `tenant_id` predicate as defense-in-depth).
- **adapter/cmd** — agent-plane `POST /api/v1/fleet/telemetry` (agent-authenticated; agent id + tenant come from the credential, never the wire), gated by `SYNAPSE_FLEET_TELEMETRY_INGEST_ENABLED`; composition-root wiring.

### Contracts honored
A0.1 server-authoritative identity · A0.2 signature/key + per-event digest binding · A0.3 schema gate · A0.4 idempotent sequencing + derived gaps + highest-contiguous ACK + incarnation-aware reset.

### Verification
- `go build` / `go vet` / `gofmt` clean; `-race` green across domain/fleetagent, telemetryingest, httpapi, memory.
- Postgres integration test on a fresh DB (migration 0109 applies; CAS conflict, cross-agent isolation, derived gaps, tenant RLS isolation all pass).
- Dual review (go-arch + security) over two rounds: initial pass surfaced 2 MAJOR (per-stream TOCTOU; phantom/never-closed gaps) + 2 HIGH (unbounded pending-set DoS; StreamID not bound to agent) + minors — **all remediated**; re-review confirmed both HIGHs closed, dependency rule PASS, mergeable.

### Scope / follow-up
This is the **server-side ingest + manifest core**. The agent-side shipper (spool drain/ship loop + `fleetclient` telemetry method) and the eBPF live cutover are the **A3 tail** — **#624 stays open** for them.
