### PR TITLE
feat(fleet): A4 detection transport + agent signing-key lifecycle (#625)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -137,6 +137,7 @@ import (
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
 	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
 	hostinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/hostinventory"
+	keyregistry "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
 	telemetryingest "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/telemetryingest"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetrolloutuc"
@@ -1707,23 +1708,11 @@ func main() {
 		}
 		router.SetSARIFIngest(sarifSvc)
 		router.SetImportedFindings(importedFindingStore)
-		// #423 detection ledger read routes. The write/ingest path (Service.Ingest → seal into the
-		// evidence chain) plugs the same detectionRecordStore into detectledger.NewService once the
-		// agent→control-plane batch transport + agent signing-key resolver land; the read surface is live
-		// now so a detection is queryable and tenant-scoped through the same chokepoint.
-		// A0.5 (#610) PREREQUISITE — before wiring detectledger.NewService here, the EvidenceChain passed
-		// to it MUST implement SealOnce as a truly key-idempotent seal, keyed on (engagement, detection id)
-		// and atomic with the chain append (e.g. an ON CONFLICT (engagement_id, idempotency_key) DO NOTHING
-		// insert that returns the existing link). A keyless Seal, or a non-atomic check-then-append, reopens
-		// D3 (a seal-then-crash retry appends a duplicate permanent link). evidence.Service.SealOnce is the
-		// A4 deliverable that provides this; do not bridge NewService onto plain Seal.
-		// A0.2 (#607) — the detectledger.AgentKeyResolver that NewService needs is satisfied by the agent
-		// signing-key registry (ports.AgentSigningKeyStore → postgres.NewAgentSigningKeyRepository /
-		// memory.NewAgentSigningKeyStore): its Resolve(agentID, keyID) returns the AgentSigningKey the batch
-		// names, and VerifyBatchWithKey gates purpose+window+revocation fail-closed. The store is the durable
-		// backing; still deferred to A4 is the agent-plane registration endpoint (an agent posts its ed25519
-		// signing public key + a ProveKeyPossession proof, bound to its canonical AgentID) plus the operator
-		// rotate/revoke routes — none can be wired until the agent→control-plane transport exists.
+		// #423 detection ledger READ routes. The read surface needs only the record store, so it is wired
+		// here (inside the asset-model gate) independently of the agent transport plane. The WRITE/ingest
+		// path (detectledger.NewService → SealOnce into the evidence chain) is wired under FleetEnabled below
+		// (A4 #625), because it needs the agent-plane transport, the A0.2 signing-key resolver, and the
+		// evidenceService SealOnce bridge — see the FleetDetectionIngestEnabled block.
 		if detectionReader, drerr := detectledger.NewReader(detectionRecordStore); drerr != nil {
 			log.Error("detection ledger reader init failed", "err", drerr)
 			os.Exit(1)
@@ -1872,6 +1861,57 @@ func main() {
 				log.Info("fleet telemetry ingest ENABLED (durable; server-side identity/key/schema verification, idempotent, acked)")
 			} else {
 				log.Warn("fleet telemetry ingest ENABLED but NOT DURABLE - transport state lives in memory and is lost on restart; configure SYNAPSE_DB_DSN")
+			}
+		}
+		// Agent signing-key registration + operator key management (A4, #625, A0.2): an agent registers its
+		// Ed25519 signing key with a proof-of-possession bound to its authenticated id; operators list and
+		// revoke. This is what makes the batch signing-key resolver used by telemetry/detection ingest fillable
+		// over the wire. Same durable store (agentSigningKeyStore) either plane resolves against.
+		if cfg.FleetKeyRegistrationEnabled {
+			keyRegSvc, kerr := keyregistry.NewService(agentSigningKeyStore, auditLog, clock)
+			if kerr != nil {
+				log.Error("fleet key registration init failed", "err", kerr)
+				os.Exit(1)
+			}
+			router.SetFleetKeyRegistration(keyRegSvc)
+			router.SetFleetKeyAdmin(keyRegSvc)
+			log.Info("fleet signing-key registration ENABLED (proof-of-possession required; operator list/revoke)")
+		}
+		// Agent→control-plane detection batch ingest (A4, #625): an enrolled agent ships a signed AgentBatch;
+		// the ledger verifies identity (A0.1: batch agent MUST be the authenticated agent) + the named signing
+		// key + each detection's content digest (fail-closed), then seals each detection ONCE into the shared
+		// evidence chain and persists the projection. The EvidenceChain is bridged onto evidenceService:
+		// SealOnce is idempotent on (engagement, detection id) via a deterministic reserved id over the
+		// crash-recoverable reserved-append path (closes D3 for detections — a seal-then-crash retry returns
+		// the first link, never a second); VerifyChainError translates evidence.Verify's Intact=false into an
+		// ErrChainBroken-wrapping error. Gated by its own flag; requires the A0.2 key registry above.
+		if cfg.FleetDetectionIngestEnabled {
+			sealOnce := func(ctx context.Context, engagementID shared.ID, kind, idempotencyKey string, content []byte, createdBy string) (shared.ID, error) {
+				ev, serr := evidenceService.SealOnce(ctx, engagementID, kind, idempotencyKey, content, createdBy)
+				if serr != nil {
+					return "", serr
+				}
+				return ev.ID, nil
+			}
+			verifyChain := func(ctx context.Context, engagementID shared.ID) error {
+				return evidenceService.VerifyChainError(ctx, engagementID)
+			}
+			chainBridge, cberr := detectledger.NewEvidenceChainBridge(sealOnce, verifyChain)
+			if cberr != nil {
+				log.Error("fleet detection ingest chain bridge init failed", "err", cberr)
+				os.Exit(1)
+			}
+			// retention 0 = keep the projection forever; the evidence chain is always permanent regardless.
+			detectSvc, derr := detectledger.NewService(detectionRecordStore, chainBridge, agentSigningKeyStore, auditLog, clock, ids, 0)
+			if derr != nil {
+				log.Error("fleet detection ingest init failed", "err", derr)
+				os.Exit(1)
+			}
+			router.SetFleetDetectionIngest(detectSvc)
+			if cfg.DBDSN != "" {
+				log.Info("fleet detection ingest ENABLED (durable; server-side identity/key/content verification, sealed once into the evidence chain)")
+			} else {
+				log.Warn("fleet detection ingest ENABLED but NOT DURABLE - detection ledger + evidence chain live in memory and are lost on restart; configure SYNAPSE_DB_DSN")
 			}
 		}
 	}

--- a/internal/adapter/httpapi/fleet_detection_handler.go
+++ b/internal/adapter/httpapi/fleet_detection_handler.go
@@ -1,0 +1,62 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
+)
+
+// fleetDetectionCap bounds one detection batch body. Detections carry a bounded evidence window each, so a
+// batch is larger than a heartbeat but far smaller than a raw telemetry batch; an oversize body is rejected
+// before decode.
+const fleetDetectionCap = 8 << 20 // 8 MiB
+
+// fleetDetectionIngest is the narrow agent-plane detection-ingest surface the handler consumes. The
+// detectledger.Service satisfies it; defined here (consumer side) so the adapter depends on a minimal
+// contract, not the whole ledger. authAgentID is passed from the credential so the usecase can enforce
+// A0.1 server-authoritative identity (the batch cannot claim another agent).
+type fleetDetectionIngest interface {
+	Ingest(ctx context.Context, authAgentID shared.ID, batch fleetagent.AgentBatch, items []detectledger.IngestItem) (detectledger.IngestResult, error)
+}
+
+// ingestDetections is the agent-plane endpoint (POST /api/v1/fleet/detections): an enrolled agent ships a
+// signed AgentBatch plus the detections it commits to; the ledger verifies identity (the batch agent must
+// be the authenticated agent), the named signing key, and each detection's content digest SERVER-SIDE
+// (fail-closed), seals each detection once into the evidence chain, and persists the projection. Identity
+// failures map to 403, malformed/unverified to 4xx via writeError; the agent id + tenant come from the
+// authenticated credential, never the body.
+func (f *fleetRouter) ingestDetections(w http.ResponseWriter, r *http.Request) {
+	if f.detections == nil {
+		writeJSON(w, http.StatusNotFound, errorBody{Error: "detection ingest not enabled"})
+		return
+	}
+	agent, ok := agentFrom(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
+		return
+	}
+	var req struct {
+		Batch fleetagent.AgentBatch     `json:"batch"`
+		Items []detectledger.IngestItem `json:"items"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetDetectionCap)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid detection batch body"})
+		return
+	}
+	res, err := f.detections.Ingest(r.Context(), agent.ID, req.Batch, req.Items)
+	if err != nil {
+		writeError(w, f.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"engagement_id": res.EngagementID.String(),
+		"sealed":        len(res.SealedRecords),
+		"skipped":       len(res.Skipped),
+		"missing":       res.Gap.Missing,
+		"replay":        res.Gap.Replay,
+	})
+}

--- a/internal/adapter/httpapi/fleet_detection_handler_test.go
+++ b/internal/adapter/httpapi/fleet_detection_handler_test.go
@@ -1,0 +1,158 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
+	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
+)
+
+// fakeDetChain is a minimal EvidenceChain for the handler test: it seals a deterministic id per
+// (engagement, key) and never reports a broken chain. The real bridge is exercised in the evidence and
+// detectledger packages; here we only need the HTTP path to reach the ledger.
+type fakeDetChain struct{}
+
+func (fakeDetChain) SealOnce(_ context.Context, _ shared.ID, _, key string, _ []byte, _ string) (shared.ID, error) {
+	return shared.ID("ev-" + key), nil
+}
+func (fakeDetChain) Verify(_ context.Context, _ shared.ID) error { return nil }
+
+type detKeyResolver struct{ key fleetagent.AgentSigningKey }
+
+func (r *detKeyResolver) ResolveSigningKey(_ context.Context, agentID shared.ID, keyID string) (fleetagent.AgentSigningKey, error) {
+	if agentID == r.key.AgentID && keyID == r.key.KeyID {
+		return r.key, nil
+	}
+	return fleetagent.AgentSigningKey{}, shared.ErrNotFound
+}
+
+func setupFleetWithDetections(t *testing.T, wire bool) (http.Handler, *fleetagentuc.Service, ed25519.PrivateKey, func(agentID shared.ID) string) {
+	t.Helper()
+	agentSvc, err := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := worksign.New([]byte("0123456789012345678901234567890123"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workSvc, err := fleetwork.NewService(memory.NewWorkOrderStore(), signer, ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := &detKeyResolver{}
+	keyOf := func(agentID shared.ID) string {
+		key, err := fleetagent.NewSigningKey(agentID, fleetagent.PurposeDetectionBatch, pub, time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resolver.key = key
+		return key.KeyID
+	}
+	detSvc, err := detectledger.NewService(memory.NewDetectionRecordStore(), fakeDetChain{}, resolver, ftAudit{}, ftClock{}, &ftIDs{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := &Router{log: discardLog()}
+	rt.SetFleet(agentSvc, workSvc, func() time.Time { return time.Now().UTC() }, "")
+	if wire {
+		rt.SetFleetDetectionIngest(detSvc)
+	}
+	return rt.fleet.handler(), agentSvc, priv, keyOf
+}
+
+func mkTestDetection(t *testing.T, agentID shared.ID) detection.Detection {
+	t.Helper()
+	r, ok := detection.Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("expected det.process_enumeration rule")
+	}
+	ev := detection.Event{Class: detection.ClassProcess, At: time.Unix(1, 0), Host: "h",
+		Process: &detection.ProcessEvent{PID: 1, Comm: "ps", Path: "/usr/bin/ps"}}
+	d, err := detection.NewDetection(r, "host-1", agentID, []detection.Event{ev}, time.Unix(500, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func signedDetectionBody(t *testing.T, agentID shared.ID, keyID string, priv ed25519.PrivateKey) map[string]any {
+	t.Helper()
+	det := mkTestDetection(t, agentID)
+	asset := shared.ID("asset-1")
+	payload, err := json.Marshal(det)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch := fleetagent.AgentBatch{
+		AgentID: agentID, EngagementID: "eng-1", Sequence: 1, KeyID: keyID,
+		Detections: []fleetagent.DetectionRef{{ID: "d1", ContentSHA256: fleetagent.DetectionContentHash(payload, asset)}},
+	}
+	batch.Signature = fleetagent.SignBatch(priv, batch)
+	return map[string]any{
+		"batch": batch,
+		"items": []detectledger.IngestItem{{ID: "d1", Detection: det, AssetID: asset}},
+	}
+}
+
+func TestIngestDetectionsEndpointAccepts(t *testing.T) {
+	h, agentSvc, priv, keyOf := setupFleetWithDetections(t, true)
+	token, agentID := enrolAgent(t, h, agentSvc)
+	body := signedDetectionBody(t, agentID, keyOf(agentID), priv)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/detections", token, body, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ingest should be 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Sealed  int `json:"sealed"`
+		Skipped int `json:"skipped"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil || resp.Sealed != 1 {
+		t.Fatalf("accept response: %+v err=%v (%s)", resp, err, w.Body.String())
+	}
+}
+
+func TestIngestDetectionsEndpointIdentityMismatch403(t *testing.T) {
+	h, agentSvc, priv, keyOf := setupFleetWithDetections(t, true)
+	token, agentID := enrolAgent(t, h, agentSvc)
+	keyID := keyOf(agentID)
+	// A batch claiming a DIFFERENT agent than the authenticated credential must be forbidden (A0.1).
+	body := signedDetectionBody(t, "someone-else", keyID, priv)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/detections", token, body, true)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("identity mismatch should be 403, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestIngestDetectionsEndpointNotEnabled404(t *testing.T) {
+	h, agentSvc, priv, keyOf := setupFleetWithDetections(t, false)
+	token, agentID := enrolAgent(t, h, agentSvc)
+	body := signedDetectionBody(t, agentID, keyOf(agentID), priv)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/detections", token, body, true)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unwired detection ingest should be 404, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestIngestDetectionsEndpointRequiresAuth(t *testing.T) {
+	h, _, _, _ := setupFleetWithDetections(t, true)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/detections", "", map[string]any{}, true)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("no credential should be 401, got %d (%s)", w.Code, w.Body.String())
+	}
+}

--- a/internal/adapter/httpapi/fleet_handler.go
+++ b/internal/adapter/httpapi/fleet_handler.go
@@ -80,6 +80,8 @@ type fleetRouter struct {
 	clusterInv       fleetClusterInventory // optional; nil ⇒ cluster inventory ingest is not served
 	hostInv          fleetHostInventory    // optional; nil ⇒ host inventory ingest is not served
 	telemetry        fleetTelemetryIngest  // optional; nil ⇒ telemetry ingest is not served (A3 #624)
+	detections       fleetDetectionIngest  // optional; nil ⇒ detection ingest is not served (A4 #625)
+	keyReg           fleetKeyRegistration  // optional; nil ⇒ signing-key registration is not served (A4 #625)
 	minAgentVersion  string                // #412 version skew: agents below this are refused work; "" = no floor
 	cpVersion        string                // control-plane version advertised to agents (min_control_plane check)
 	rollout          fleetRolloutDecider   // optional; nil ⇒ no update is ever offered (#412 req 9)
@@ -181,6 +183,26 @@ func (rt *Router) SetFleetTelemetry(s fleetTelemetryIngest) {
 		rt.fleet.telemetry = s
 	}
 }
+
+// SetFleetDetectionIngest wires the agent-plane detection batch ingest (A4 #625). When nil (or unset),
+// POST /api/v1/fleet/detections returns 404. It must be called after SetFleet.
+func (rt *Router) SetFleetDetectionIngest(s fleetDetectionIngest) {
+	if rt.fleet != nil {
+		rt.fleet.detections = s
+	}
+}
+
+// SetFleetKeyRegistration wires the agent-plane signing-key registration (A4 #625, A0.2). When nil (or
+// unset), POST /api/v1/fleet/keys returns 404. It must be called after SetFleet.
+func (rt *Router) SetFleetKeyRegistration(s fleetKeyRegistration) {
+	if rt.fleet != nil {
+		rt.fleet.keyReg = s
+	}
+}
+
+// SetFleetKeyAdmin wires the operator (human, RBAC-gated) signing-key management routes (list + revoke).
+// When nil, those routes are not registered.
+func (rt *Router) SetFleetKeyAdmin(s fleetKeyAdmin) { rt.fleetKeys = s }
 
 // SetFleetVersionPolicy wires the version-skew policy (#412): minAgentVersion is the minimum agent
 // version allowed to claim work (empty = no floor), and cpVersion is the control-plane version
@@ -310,6 +332,10 @@ func fleetAgentPlaneRoutes() []fleetAgentPlaneRoute {
 			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.hostInventory)) }},
 		{"POST /api/v1/fleet/telemetry", "/api/v1/fleet/telemetry",
 			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.ingestTelemetry)) }},
+		{"POST /api/v1/fleet/detections", "/api/v1/fleet/detections",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.ingestDetections)) }},
+		{"POST /api/v1/fleet/keys", "/api/v1/fleet/keys",
+			func(f *fleetRouter) http.HandlerFunc { return f.entry(f.authed(f.registerKey)) }},
 	}
 }
 

--- a/internal/adapter/httpapi/fleet_keys_handler.go
+++ b/internal/adapter/httpapi/fleet_keys_handler.go
@@ -1,0 +1,97 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
+)
+
+// fleetKeyRegistration is the narrow agent-plane signing-key registration surface (#607, A0.2). The
+// keyregistry.Service satisfies it; authAgentID is passed from the credential so a key is always bound to
+// the authenticated agent, never a wire field.
+type fleetKeyRegistration interface {
+	Register(ctx context.Context, authAgentID shared.ID, req keyregistry.RegisterRequest) (fleetagent.AgentSigningKey, error)
+}
+
+// fleetKeyAdmin is the operator-facing (human, RBAC-gated) view of signing-key management: list an agent's
+// keys and revoke one. Tenant-scoped from the operator's authenticated context.
+type fleetKeyAdmin interface {
+	List(ctx context.Context, agentID shared.ID) ([]fleetagent.AgentSigningKey, error)
+	Revoke(ctx context.Context, agentID shared.ID, keyID, actor string) error
+}
+
+// registerKey is the agent-plane endpoint (POST /api/v1/fleet/keys): an agent posts its Ed25519 signing
+// public key + a proof-of-possession bound to its canonical AgentID; the service verifies the proof BEFORE
+// registering (fail-closed). The agent id comes from the authenticated credential, never the body — a proof
+// made for another agent will not verify.
+func (f *fleetRouter) registerKey(w http.ResponseWriter, r *http.Request) {
+	if f.keyReg == nil {
+		writeJSON(w, http.StatusNotFound, errorBody{Error: "key registration not enabled"})
+		return
+	}
+	agent, ok := agentFrom(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errorBody{Error: "unauthenticated"})
+		return
+	}
+	var req struct {
+		PublicKey string    `json:"public_key"` // base64 Ed25519
+		Purpose   string    `json:"purpose"`
+		NotBefore time.Time `json:"not_before"`
+		NotAfter  time.Time `json:"not_after"`
+		Proof     string    `json:"proof"` // base64 PoP signature over the key binding message
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, fleetBodyCap)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid key registration body"})
+		return
+	}
+	key, err := f.keyReg.Register(r.Context(), agent.ID, keyregistry.RegisterRequest{
+		PublicKeyB64: req.PublicKey, Purpose: req.Purpose, NotBefore: req.NotBefore, NotAfter: req.NotAfter, Proof: req.Proof,
+	})
+	if err != nil {
+		writeError(w, f.log, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"key_id":     key.KeyID,
+		"agent_id":   key.AgentID.String(),
+		"purpose":    string(key.Purpose),
+		"not_before": key.NotBefore.UTC().Format(time.RFC3339),
+		"not_after":  key.NotAfter.UTC().Format(time.RFC3339),
+	})
+}
+
+// listAgentKeys is the operator endpoint (GET /api/v1/agents/{id}/keys): list an agent's signing keys.
+func (rt *Router) listAgentKeys(w http.ResponseWriter, r *http.Request) {
+	agentID := shared.ID(r.PathValue("id"))
+	keys, err := rt.fleetKeys.List(r.Context(), agentID)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	out := make([]map[string]any, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, map[string]any{
+			"key_id": k.KeyID, "purpose": string(k.Purpose), "algorithm": string(k.Algorithm),
+			"not_before": k.NotBefore.UTC().Format(time.RFC3339), "not_after": k.NotAfter.UTC().Format(time.RFC3339),
+			"revoked": !k.RevokedAt.IsZero(), "replaced_by": k.ReplacedBy,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"agent_id": agentID.String(), "keys": out})
+}
+
+// revokeAgentKey is the operator endpoint (POST /api/v1/agents/{id}/keys/{keyID}/revoke): revoke one key.
+func (rt *Router) revokeAgentKey(w http.ResponseWriter, r *http.Request) {
+	agentID := shared.ID(r.PathValue("id"))
+	keyID := r.PathValue("keyID")
+	if err := rt.fleetKeys.Revoke(r.Context(), agentID, keyID, PrincipalFrom(r.Context())); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"agent_id": agentID.String(), "key_id": keyID, "state": "revoked"})
+}

--- a/internal/adapter/httpapi/fleet_keys_handler_test.go
+++ b/internal/adapter/httpapi/fleet_keys_handler_test.go
@@ -1,0 +1,163 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
+)
+
+// enrolTenant is the tenant enrolAgent's minted token binds the agent to (see MintEnrolToken(..,"default",..)).
+const enrolTenant = shared.ID("default")
+
+func setupFleetWithKeys(t *testing.T, wire bool) (*Router, http.Handler, *fleetagentuc.Service) {
+	t.Helper()
+	agentSvc, err := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := worksign.New([]byte("0123456789012345678901234567890123"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workSvc, err := fleetwork.NewService(memory.NewWorkOrderStore(), signer, ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyRegSvc, err := keyregistry.NewService(memory.NewAgentSigningKeyStore(), ftAudit{}, ftClock{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := &Router{log: discardLog()}
+	rt.SetFleet(agentSvc, workSvc, func() time.Time { return time.Now().UTC() }, "")
+	if wire {
+		rt.SetFleetKeyRegistration(keyRegSvc)
+		rt.SetFleetKeyAdmin(keyRegSvc)
+	}
+	return rt, rt.fleet.handler(), agentSvc
+}
+
+// signedKeyBody builds a valid registration body for agentID: a fresh keypair, a proof-of-possession over
+// the key's binding message, and the returned private key so a test can also craft a bad proof.
+func signedKeyBody(t *testing.T, agentID shared.ID) (map[string]any, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nb, na := time.Now().Add(-time.Hour), time.Now().Add(time.Hour)
+	key, err := fleetagent.NewSigningKey(agentID, fleetagent.PurposeDetectionBatch, pub, nb, na)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return map[string]any{
+		"public_key": base64.StdEncoding.EncodeToString(pub),
+		"purpose":    string(fleetagent.PurposeDetectionBatch),
+		"not_before": nb.UTC().Format(time.RFC3339),
+		"not_after":  na.UTC().Format(time.RFC3339),
+		"proof":      fleetagent.ProveKeyPossession(priv, key),
+	}, pub
+}
+
+func operatorReq(method, path string, tenant shared.ID) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	ctx := context.WithValue(req.Context(), principalKey, Principal{ID: "operator", Name: "operator", Role: "admin", TenantID: string(tenant)})
+	return req.WithContext(shared.WithTenant(ctx, tenant))
+}
+
+func TestRegisterKeyEndpointAndOperatorLifecycle(t *testing.T) {
+	rt, h, agentSvc := setupFleetWithKeys(t, true)
+	token, agentID := enrolAgent(t, h, agentSvc)
+
+	// Agent-plane registration with a valid proof.
+	body, _ := signedKeyBody(t, agentID)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/keys", token, body, true)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("register should be 201, got %d (%s)", w.Code, w.Body.String())
+	}
+	var reg struct {
+		KeyID string `json:"key_id"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &reg); err != nil || reg.KeyID == "" {
+		t.Fatalf("register response: %+v err=%v (%s)", reg, err, w.Body.String())
+	}
+
+	// Operator lists the agent's keys (human RBAC plane).
+	listReq := operatorReq(http.MethodGet, "/api/v1/agents/"+agentID.String()+"/keys", enrolTenant)
+	listReq.SetPathValue("id", agentID.String())
+	listRec := httptest.NewRecorder()
+	rt.authz(userdom.PermView, rt.listAgentKeys)(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("operator list should be 200, got %d (%s)", listRec.Code, listRec.Body.String())
+	}
+	var listed struct {
+		Keys []struct {
+			KeyID   string `json:"key_id"`
+			Revoked bool   `json:"revoked"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil || len(listed.Keys) != 1 || listed.Keys[0].KeyID != reg.KeyID {
+		t.Fatalf("operator list: %+v err=%v (%s)", listed, err, listRec.Body.String())
+	}
+
+	// Operator revokes it.
+	revReq := operatorReq(http.MethodPost, "/api/v1/agents/"+agentID.String()+"/keys/"+reg.KeyID+"/revoke", enrolTenant)
+	revReq.SetPathValue("id", agentID.String())
+	revReq.SetPathValue("keyID", reg.KeyID)
+	revRec := httptest.NewRecorder()
+	rt.authz(userdom.PermAdminister, rt.revokeAgentKey)(revRec, revReq)
+	if revRec.Code != http.StatusOK {
+		t.Fatalf("operator revoke should be 200, got %d (%s)", revRec.Code, revRec.Body.String())
+	}
+
+	// The key now lists as revoked.
+	list2 := operatorReq(http.MethodGet, "/api/v1/agents/"+agentID.String()+"/keys", enrolTenant)
+	list2.SetPathValue("id", agentID.String())
+	rec2 := httptest.NewRecorder()
+	rt.listAgentKeys(rec2, list2)
+	if err := json.Unmarshal(rec2.Body.Bytes(), &listed); err != nil || len(listed.Keys) != 1 || !listed.Keys[0].Revoked {
+		t.Fatalf("key must list as revoked after revoke: %+v err=%v", listed, err)
+	}
+}
+
+func TestRegisterKeyEndpointBadProof403(t *testing.T) {
+	_, h, agentSvc := setupFleetWithKeys(t, true)
+	token, agentID := enrolAgent(t, h, agentSvc)
+	body, _ := signedKeyBody(t, agentID)
+	body["proof"] = base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)) // zero signature: invalid
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/keys", token, body, true)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("bad proof should be 403, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestRegisterKeyEndpointNotEnabled404(t *testing.T) {
+	_, h, agentSvc := setupFleetWithKeys(t, false)
+	token, agentID := enrolAgent(t, h, agentSvc)
+	body, _ := signedKeyBody(t, agentID)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/keys", token, body, true)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unwired key registration should be 404, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestRegisterKeyEndpointRequiresAuth(t *testing.T) {
+	_, h, _ := setupFleetWithKeys(t, true)
+	w := fleetCall(h, http.MethodPost, "/api/v1/fleet/keys", "", map[string]any{}, true)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("no credential should be 401, got %d (%s)", w.Code, w.Body.String())
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -87,6 +87,7 @@ type Router struct {
 	purpleCoverage         purpleCoverageReader  // optional read side for purple-team coverage (#426)
 	fleet                  *fleetRouter          // optional; nil ⇒ agent transport plane is not served
 	fleetAdmin             fleetAdminService     // optional; nil ⇒ operator agent-admin routes not registered
+	fleetKeys              fleetKeyAdmin         // optional; nil ⇒ operator signing-key routes not registered (A4 #625)
 	qualityGates           qualityGateService    // optional; nil ⇒ quality-gate routes are not registered
 	qualityProfiles        qualityProfileService // optional; nil ⇒ quality-profile routes are not registered
 	rules                  rulesService          // optional; nil ⇒ rule catalog routes are not registered
@@ -330,6 +331,10 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/agents/enrolment-tokens", rt.authz(userdom.PermAdminister, rt.mintEnrolToken))
 		mux.HandleFunc("GET /api/v1/agents", rt.authz(userdom.PermView, rt.listFleetAgents))
 		mux.HandleFunc("POST /api/v1/agents/{id}/revoke", rt.authz(userdom.PermAdminister, rt.revokeFleetAgent))
+	}
+	if rt.fleetKeys != nil {
+		mux.HandleFunc("GET /api/v1/agents/{id}/keys", rt.authz(userdom.PermView, rt.listAgentKeys))
+		mux.HandleFunc("POST /api/v1/agents/{id}/keys/{keyID}/revoke", rt.authz(userdom.PermAdminister, rt.revokeAgentKey))
 	}
 	if rt.assets != nil {
 		mux.HandleFunc("POST /api/v1/assets", rt.authz(userdom.PermOperate, rt.createAsset))

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -289,6 +289,15 @@ type Config struct {
 	// (identity + signing key + schema, fail-closed), sequences idempotently, and acks. Off by default;
 	// requires FleetEnabled.
 	FleetTelemetryIngestEnabled bool
+	// FleetDetectionIngestEnabled turns on the agent→control-plane detection batch ingest endpoint (A4,
+	// #625): an enrolled agent ships a signed AgentBatch which the control plane verifies (identity +
+	// signing key + per-detection content digest, fail-closed) and seals once into the evidence chain.
+	// Off by default; requires FleetEnabled.
+	FleetDetectionIngestEnabled bool
+	// FleetKeyRegistrationEnabled turns on the agent-plane signing-key registration endpoint plus the
+	// operator key management routes (A4, #625, A0.2): an agent registers its Ed25519 signing key with a
+	// proof-of-possession. Off by default; requires FleetEnabled.
+	FleetKeyRegistrationEnabled bool
 	// FleetAgentStaleAfter is how long since an agent's last heartbeat before it is reported stale in
 	// the coverage/agent-health views (#413, SYNAPSE_FLEET_STALE_AFTER). <=0 disables the staleness
 	// check. Default 10m, per the issue spec.
@@ -668,6 +677,8 @@ func Load() Config {
 		FleetClusterIngestEnabled:             getbool("SYNAPSE_FLEET_CLUSTER_INGEST_ENABLED", false),
 		FleetHostIngestEnabled:                getbool("SYNAPSE_FLEET_HOST_INGEST_ENABLED", false),
 		FleetTelemetryIngestEnabled:           getbool("SYNAPSE_FLEET_TELEMETRY_INGEST_ENABLED", false),
+		FleetDetectionIngestEnabled:           getbool("SYNAPSE_FLEET_DETECTION_INGEST_ENABLED", false),
+		FleetKeyRegistrationEnabled:           getbool("SYNAPSE_FLEET_KEY_REGISTRATION_ENABLED", false),
 		FleetMinAgentVersion:                  strings.TrimSpace(os.Getenv("SYNAPSE_FLEET_MIN_AGENT_VERSION")),
 		FleetAgentStaleAfter:                  getduration("SYNAPSE_FLEET_STALE_AFTER", 10*time.Minute),
 		FleetCoverageFreshnessTarget:          getduration("SYNAPSE_FLEET_COVERAGE_FRESHNESS_TARGET", 24*time.Hour),

--- a/internal/usecase/evidence/service.go
+++ b/internal/usecase/evidence/service.go
@@ -8,6 +8,7 @@ package evidence
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -167,6 +168,52 @@ func (s *Service) appendReserved(ctx context.Context, link evdom.Evidence) (evdo
 // SealForFindingWithID appends a finding-linked evidence link with its caller-
 // reserved stable ID. It is used only by crash-recoverable application flows.
 func (s *Service) SealForFindingWithID(ctx context.Context, evidenceID, engagementID, findingID shared.ID, kind string, content []byte, storageRef, createdBy string) (evdom.Evidence, error) {
+	return s.sealReserved(ctx, evidenceID, engagementID, findingID, kind, content, storageRef, createdBy)
+}
+
+// sealOnceContext domain-separates the deterministic reserved id an idempotency-keyed seal derives, so
+// the same (engagement, kind, key) never collides with a caller-chosen reserved id or another kind.
+const sealOnceContext = "synapse-evidence-seal-once:v1"
+
+// SealOnce appends one sealed link IDEMPOTENTLY on (engagementID, kind, idempotencyKey): it derives a
+// deterministic reserved evidence id from those three and seals exactly once, so a retry after a crash
+// between the seal and a caller's projection write returns the FIRST link and appends nothing (this is
+// how the detection ledger closes D3 — a detection can never be sealed into the chain twice). It reuses
+// the same crash-recoverable reserved-append path as SealForFindingWithID; there is no findingID.
+func (s *Service) SealOnce(ctx context.Context, engagementID shared.ID, kind, idempotencyKey string, content []byte, createdBy string) (evdom.Evidence, error) {
+	if engagementID.IsZero() {
+		return evdom.Evidence{}, fmt.Errorf("%w: seal-once needs an engagement", shared.ErrValidation)
+	}
+	if kind == "" || idempotencyKey == "" {
+		return evdom.Evidence{}, fmt.Errorf("%w: seal-once needs a kind and an idempotency key", shared.ErrValidation)
+	}
+	return s.sealReserved(ctx, sealOnceID(engagementID, kind, idempotencyKey), engagementID, "", kind, content, "", createdBy)
+}
+
+// sealOnceID is the deterministic reserved evidence id for a SealOnce, over a domain-separated digest of
+// (engagement, kind, idempotency key) so the same logical seal always targets the same reserved row. Each
+// component is LENGTH-PREFIXED (not just separator-delimited): idempotencyKey is a wire-supplied detection
+// id, so a crafted value containing the separator byte must not be able to alias another (engagement, kind,
+// key) tuple's reserved id.
+func sealOnceID(engagementID shared.ID, kind, idempotencyKey string) shared.ID {
+	h := sha256.New()
+	var lenbuf [8]byte
+	write := func(str string) {
+		binary.BigEndian.PutUint64(lenbuf[:], uint64(len(str)))
+		h.Write(lenbuf[:])
+		h.Write([]byte(str))
+	}
+	write(sealOnceContext)
+	write(engagementID.String())
+	write(kind)
+	write(idempotencyKey)
+	return shared.ID(hex.EncodeToString(h.Sum(nil)))
+}
+
+// sealReserved appends a caller-reserved stable evidence id exactly once, re-chaining on a concurrent
+// head advance and returning the existing link (payload-checked) on a reserved-id conflict — the shared
+// crash-recoverable path behind SealForFindingWithID and SealOnce.
+func (s *Service) sealReserved(ctx context.Context, evidenceID, engagementID, findingID shared.ID, kind string, content []byte, storageRef, createdBy string) (evdom.Evidence, error) {
 	for {
 		if err := ctx.Err(); err != nil {
 			return evdom.Evidence{}, err
@@ -363,6 +410,23 @@ func (s *Service) Verify(ctx context.Context, engagementID shared.ID) (Report, e
 	// out-of-band so report bytes are unchanged. Best-effort + bounded.
 	s.anchorHead(ctx, ChainEvidence, engagementID, &rep)
 	return rep, nil
+}
+
+// VerifyChainError is the error-shaped view of Verify for callers that only need a go/no-go: it runs the
+// same verify-on-read path and returns a non-nil error WRAPPING evdom.ErrChainBroken when the chain is
+// not intact (a tampered chain or a detected tail-truncation), nil when intact. Verify itself signals a
+// broken chain via Report.Intact=false with a NIL error (the error is reserved for I/O), so a bridge that
+// forwarded Verify's raw error would report a tampered chain as healthy; this method closes that trap for
+// the detection-ledger EvidenceChain bridge (and any other go/no-go caller).
+func (s *Service) VerifyChainError(ctx context.Context, engagementID shared.ID) error {
+	rep, err := s.Verify(ctx, engagementID)
+	if err != nil {
+		return err
+	}
+	if !rep.Intact {
+		return fmt.Errorf("%w: %s", evdom.ErrChainBroken, rep.Error)
+	}
+	return nil
 }
 
 // ChainEvidence/ChainAudit name the two custody chains in the out-of-band token store.

--- a/internal/usecase/evidence/service_test.go
+++ b/internal/usecase/evidence/service_test.go
@@ -97,9 +97,16 @@ func (s *concurrentEvidenceStore) Head(ctx context.Context, id shared.ID) (strin
 	return items[len(items)-1].Hash, nil
 }
 
-type randomTestIDs struct{ n int64 }
+type randomTestIDs struct {
+	mu sync.Mutex
+	n  int64
+}
 
 func (g *randomTestIDs) NewID() shared.ID {
+	// Guarded: TestSealConcurrentStaysLinear calls Seal (and thus NewID) from multiple goroutines, so an
+	// unsynchronized counter is a data race under -race (pre-existing; a real ports.IDGenerator is safe).
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	g.n++
 	return shared.ID("test-" + strconv.FormatInt(g.n, 10))
 }
@@ -597,5 +604,79 @@ func TestSealForFindingWithIDHighContentionStaysLinear(t *testing.T) {
 	}
 	if err := evdom.VerifyChain(items); err != nil {
 		t.Fatalf("chain invalid: %v", err)
+	}
+}
+
+func TestSealOnceIsIdempotentOnKey(t *testing.T) {
+	svc, store, _ := newVault(t, nil)
+	ctx := context.Background()
+	const eng = shared.ID("eng-once")
+
+	first, err := svc.SealOnce(ctx, eng, "detection", "d1", []byte(`{"x":1}`), "agent:1")
+	if err != nil {
+		t.Fatalf("first seal: %v", err)
+	}
+	// Same (engagement, kind, key) with the SAME content returns the SAME link and appends nothing — this
+	// is the D3 closure: a seal-then-crash retry cannot add a second permanent link for one detection.
+	again, err := svc.SealOnce(ctx, eng, "detection", "d1", []byte(`{"x":1}`), "agent:1")
+	if err != nil {
+		t.Fatalf("idempotent re-seal: %v", err)
+	}
+	if again.ID != first.ID {
+		t.Fatalf("re-seal must return the first link id %s, got %s", first.ID, again.ID)
+	}
+	if chain, _ := store.ListByEngagement(ctx, eng); len(chain) != 1 {
+		t.Fatalf("idempotent re-seal must not append a second link, chain has %d", len(chain))
+	}
+
+	// A different key is a distinct link.
+	other, err := svc.SealOnce(ctx, eng, "detection", "d2", []byte(`{"x":2}`), "agent:1")
+	if err != nil {
+		t.Fatalf("second key seal: %v", err)
+	}
+	if other.ID == first.ID {
+		t.Fatalf("a different idempotency key must seal a distinct link")
+	}
+	if chain, _ := store.ListByEngagement(ctx, eng); len(chain) != 2 {
+		t.Fatalf("two distinct keys must be two links, chain has %d", len(chain))
+	}
+
+	// Reusing a key with DIFFERENT content is a conflict, not a silent overwrite (fail closed).
+	if _, err := svc.SealOnce(ctx, eng, "detection", "d1", []byte(`{"x":999}`), "agent:1"); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("conflicting content under a used key must be ErrConflict, got %v", err)
+	}
+}
+
+func TestSealOnceValidates(t *testing.T) {
+	svc, _, _ := newVault(t, nil)
+	ctx := context.Background()
+	if _, err := svc.SealOnce(ctx, "", "detection", "k", []byte("x"), "a"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("empty engagement must be ErrValidation, got %v", err)
+	}
+	if _, err := svc.SealOnce(ctx, "eng", "", "k", []byte("x"), "a"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("empty kind must be ErrValidation, got %v", err)
+	}
+	if _, err := svc.SealOnce(ctx, "eng", "detection", "", []byte("x"), "a"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("empty idempotency key must be ErrValidation, got %v", err)
+	}
+}
+
+func TestVerifyChainErrorReflectsIntactness(t *testing.T) {
+	svc, store, _ := newVault(t, nil)
+	ctx := context.Background()
+	const eng = shared.ID("eng-verify")
+	if _, err := svc.SealOnce(ctx, eng, "detection", "d1", []byte("body"), "agent:1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.VerifyChainError(ctx, eng); err != nil {
+		t.Fatalf("an intact chain must verify with nil error, got %v", err)
+	}
+	// Tamper a stored link's attribution: VerifyChainError must surface it as an ErrChainBroken-wrapping
+	// error (Verify itself returns Intact=false with a nil error, which a naive bridge would miss).
+	chain := store.items[eng]
+	chain[0].CreatedBy = "attacker"
+	store.items[eng] = chain
+	if err := svc.VerifyChainError(ctx, eng); !errors.Is(err, evdom.ErrChainBroken) {
+		t.Fatalf("a tampered chain must return an ErrChainBroken-wrapping error, got %v", err)
 	}
 }

--- a/internal/usecase/fleet/detectledger/bridge.go
+++ b/internal/usecase/fleet/detectledger/bridge.go
@@ -1,0 +1,49 @@
+package detectledger
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// chainBridge adapts the evidence vault to the EvidenceChain this package consumes, via two closures the
+// composition root supplies (like offensivepolicy's EvidenceChainSealer). Closures rather than an
+// interface because *evidence.Service returns a domain Evidence value whose shape this package has no
+// reason to know, and its Verify returns (Report, error) whose Intact=false-with-nil-error contract must
+// be translated to an error at the root — the composition root knows both sides, so it bridges them.
+type chainBridge struct {
+	seal   func(ctx context.Context, engagementID shared.ID, kind, idempotencyKey string, content []byte, createdBy string) (shared.ID, error)
+	verify func(ctx context.Context, engagementID shared.ID) error
+}
+
+var _ EvidenceChain = (*chainBridge)(nil)
+
+// NewEvidenceChainBridge wires the seal-once and verify closures — normally over *evidence.Service
+// (SealOnce and VerifyChainError) — into the EvidenceChain the ledger's write path requires. Both are
+// required; a bridge that cannot seal or verify would let a detection through with no permanent record.
+func NewEvidenceChainBridge(
+	seal func(ctx context.Context, engagementID shared.ID, kind, idempotencyKey string, content []byte, createdBy string) (shared.ID, error),
+	verify func(ctx context.Context, engagementID shared.ID) error,
+) (EvidenceChain, error) {
+	if seal == nil || verify == nil {
+		return nil, fmt.Errorf("%w: evidence chain bridge needs both a seal and a verify function", shared.ErrValidation)
+	}
+	return &chainBridge{seal: seal, verify: verify}, nil
+}
+
+func (b *chainBridge) SealOnce(ctx context.Context, engagementID shared.ID, kind, idempotencyKey string, content []byte, createdBy string) (shared.ID, error) {
+	if b == nil || b.seal == nil {
+		// Fail closed: a chain that cannot seal must report failure, never return an empty id that would
+		// let Ingest persist a projection row bound to no evidence link.
+		return "", fmt.Errorf("%w: evidence chain bridge has no seal function", shared.ErrValidation)
+	}
+	return b.seal(ctx, engagementID, kind, idempotencyKey, content, createdBy)
+}
+
+func (b *chainBridge) Verify(ctx context.Context, engagementID shared.ID) error {
+	if b == nil || b.verify == nil {
+		return fmt.Errorf("%w: evidence chain bridge has no verify function", shared.ErrValidation)
+	}
+	return b.verify(ctx, engagementID)
+}

--- a/internal/usecase/fleet/detectledger/service.go
+++ b/internal/usecase/fleet/detectledger/service.go
@@ -102,9 +102,21 @@ func NewService(records ports.DetectionRecordStore, chain EvidenceChain, keys Ag
 // Ingest admits one signed, sequenced agent batch: it verifies the signature, detects a sequence gap
 // (reported as a potential loss, never silently accepted), seals each detection into the evidence chain
 // as kind="detection", and persists the projection rows bound to their chain links and asset.
-func (s *Service) Ingest(ctx context.Context, batch fleetagent.AgentBatch, items []IngestItem) (IngestResult, error) {
+//
+// authAgentID is the canonical id of the AUTHENTICATED agent (from the agent-plane credential, never a
+// wire field). A0.1 server-authoritative identity: a batch whose manifest claims any other agent is
+// refused BEFORE key resolution or sealing, so a valid agent cannot ship a batch attributed to another —
+// the sealed detection always carries the authenticated agent id, never a self-declared one.
+func (s *Service) Ingest(ctx context.Context, authAgentID shared.ID, batch fleetagent.AgentBatch, items []IngestItem) (IngestResult, error) {
 	if err := batch.Validate(); err != nil {
 		return IngestResult{}, err
+	}
+	if authAgentID.IsZero() || batch.AgentID != authAgentID {
+		s.recordAudit(ctx, "detection.batch_rejected", authAgentID.String(), map[string]string{
+			"engagement": batch.EngagementID.String(), "sequence": fmt.Sprint(batch.Sequence),
+			"manifest_agent_id": batch.AgentID.String(), "reason": "identity_mismatch",
+		})
+		return IngestResult{}, fmt.Errorf("%w: batch agent %q is not the authenticated agent %q", shared.ErrForbidden, batch.AgentID, authAgentID)
 	}
 	refByID, err := membership(batch, items)
 	if err != nil {

--- a/internal/usecase/fleet/detectledger/service_test.go
+++ b/internal/usecase/fleet/detectledger/service_test.go
@@ -251,13 +251,33 @@ func tctx() context.Context { return shared.WithTenant(context.Background(), "t1
 
 // ---- tests ------------------------------------------------------------------------------------------
 
+func TestIngestRejectsIdentityMismatch(t *testing.T) {
+	h := newHarness(t, 0)
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	batch := h.signedBatch(t, 1, items) // batch.AgentID == "agent:1"
+	// A0.1 server-authoritative identity: a batch signed by a valid agent but ingested under a DIFFERENT
+	// authenticated credential is refused BEFORE key resolution or sealing — no chain link, no projection.
+	if _, err := h.svc.Ingest(tctx(), "agent:2", batch, items); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("identity mismatch must be forbidden, got %v", err)
+	}
+	if got := len(h.chain.seals); got != 0 {
+		t.Fatalf("an identity-mismatched batch must seal nothing, got %d", got)
+	}
+	if recs, _ := h.store.ListDetections(tctx(), "eng-1"); len(recs) != 0 {
+		t.Fatalf("an identity-mismatched batch must persist nothing, got %d rows", len(recs))
+	}
+	if !h.audit.has("detection.batch_rejected") {
+		t.Error("an identity-mismatched batch must be audited as rejected")
+	}
+}
+
 func TestIngestSealsEachDetectionAsChainedEvidence(t *testing.T) {
 	h := newHarness(t, 0)
 	items := []IngestItem{
 		{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"},
 		{ID: "d2", Detection: mkDetection(t, "top"), AssetID: "asset-1"},
 	}
-	res, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, items), items)
+	res, err := h.svc.Ingest(tctx(), "agent:1", h.signedBatch(t, 1, items), items)
 	if err != nil {
 		t.Fatalf("ingest: %v", err)
 	}
@@ -290,7 +310,7 @@ func TestIngestRefusesBadSignature(t *testing.T) {
 	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
 	b := h.signedBatch(t, 1, items)
 	b.Sequence = 99 // tamper a signed field AFTER signing → the signature no longer matches
-	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, fleetagent.ErrBadBatchSignature) {
+	if _, err := h.svc.Ingest(tctx(), b.AgentID, b, items); !errors.Is(err, fleetagent.ErrBadBatchSignature) {
 		t.Fatalf("a tampered batch must be refused, got %v", err)
 	}
 	if len(h.chain.kinds()) != 0 {
@@ -309,7 +329,7 @@ func TestIngestRefusesContentTamper(t *testing.T) {
 	b := h.signedBatch(t, 1, signedItems) // signs a digest over the "ps" detection
 	// Deliver the same id with a DIFFERENT body.
 	swapped := []IngestItem{{ID: "d1", Detection: mkDetection(t, "top"), AssetID: "asset-1"}}
-	if _, err := h.svc.Ingest(tctx(), b, swapped); !errors.Is(err, shared.ErrValidation) {
+	if _, err := h.svc.Ingest(tctx(), b.AgentID, b, swapped); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("a content swap must be refused, got %v", err)
 	}
 	if len(h.chain.kinds()) != 0 {
@@ -322,7 +342,7 @@ func TestIngestRefusesUnknownAgent(t *testing.T) {
 	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
 	b := fleetagent.AgentBatch{AgentID: "agent:unknown", EngagementID: "eng-1", Sequence: 1, KeyID: h.key.KeyID, Detections: refsFor(t, items)}
 	b.Signature = fleetagent.SignBatch(h.priv, b)
-	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrForbidden) {
+	if _, err := h.svc.Ingest(tctx(), b.AgentID, b, items); !errors.Is(err, shared.ErrForbidden) {
 		t.Fatalf("an agent with no known key must be refused (fail closed), got %v", err)
 	}
 }
@@ -331,12 +351,12 @@ func TestIngestReportsForwardGapButProceeds(t *testing.T) {
 	h := newHarness(t, 0)
 	// First batch seq 1.
 	i1 := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
-	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, i1), i1); err != nil {
+	if _, err := h.svc.Ingest(tctx(), "agent:1", h.signedBatch(t, 1, i1), i1); err != nil {
 		t.Fatal(err)
 	}
 	// Next batch jumps to seq 4 → sequences 2,3 are a gap.
 	i2 := []IngestItem{{ID: "d4", Detection: mkDetection(t, "top"), AssetID: "asset-1"}}
-	res, err := h.svc.Ingest(tctx(), h.signedBatch(t, 4, i2), i2)
+	res, err := h.svc.Ingest(tctx(), "agent:1", h.signedBatch(t, 4, i2), i2)
 	if err != nil {
 		t.Fatalf("a forward gap must still seal the arriving batch: %v", err)
 	}
@@ -358,12 +378,12 @@ func TestIngestIsIdempotentOnReplay(t *testing.T) {
 	h := newHarness(t, 0)
 	i1 := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
 	b := h.signedBatch(t, 2, i1)
-	if _, err := h.svc.Ingest(tctx(), b, i1); err != nil {
+	if _, err := h.svc.Ingest(tctx(), b.AgentID, b, i1); err != nil {
 		t.Fatal(err)
 	}
 	sealedBefore := len(h.chain.kinds())
 	// Re-ingest the exact same batch: idempotent — no new seal, d1 skipped, replay reported.
-	res, err := h.svc.Ingest(tctx(), b, i1)
+	res, err := h.svc.Ingest(tctx(), b.AgentID, b, i1)
 	if err != nil {
 		t.Fatalf("an idempotent replay must not error, got %v", err)
 	}
@@ -385,12 +405,12 @@ func TestIngestRequiresMembershipMatchAndTenant(t *testing.T) {
 	extra := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}, {ID: "d2", Detection: mkDetection(t, "top"), AssetID: "asset-1"}}
 	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, KeyID: h.key.KeyID, Detections: refsFor(t, extra)}
 	b.Signature = fleetagent.SignBatch(h.priv, b)
-	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrValidation) {
+	if _, err := h.svc.Ingest(tctx(), b.AgentID, b, items); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("membership mismatch must be a validation error, got %v", err)
 	}
 	// Missing tenant in context.
 	good := h.signedBatch(t, 1, items)
-	if _, err := h.svc.Ingest(context.Background(), good, items); !errors.Is(err, shared.ErrValidation) {
+	if _, err := h.svc.Ingest(context.Background(), good.AgentID, good, items); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("a missing tenant must be refused, got %v", err)
 	}
 }
@@ -401,13 +421,13 @@ func TestIngestFailsWhenGapAuditFails(t *testing.T) {
 	h := newHarness(t, 0)
 	// Seed seq 1 so a jump to seq 5 is a forward gap.
 	i1 := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
-	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, i1), i1); err != nil {
+	if _, err := h.svc.Ingest(tctx(), "agent:1", h.signedBatch(t, 1, i1), i1); err != nil {
 		t.Fatal(err)
 	}
 	h.audit.failAction = "detection.batch_gap" // the gap coverage event cannot be written
 	i2 := []IngestItem{{ID: "d5", Detection: mkDetection(t, "top"), AssetID: "asset-1"}}
 	sealedBefore := len(h.chain.kinds())
-	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 5, i2), i2); err == nil {
+	if _, err := h.svc.Ingest(tctx(), "agent:1", h.signedBatch(t, 5, i2), i2); err == nil {
 		t.Fatal("an unrecordable gap must fail the ingest, not silently proceed")
 	}
 	if len(h.chain.kinds()) != sealedBefore {
@@ -432,7 +452,7 @@ func TestIncidentsRollupFromLedger(t *testing.T) {
 		{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"},
 		{ID: "d2", Detection: mkDetection(t, "ps"), AssetID: "asset-1"},
 	}
-	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, items), items); err != nil {
+	if _, err := h.svc.Ingest(tctx(), "agent:1", h.signedBatch(t, 1, items), items); err != nil {
 		t.Fatal(err)
 	}
 	inc, err := h.svc.Incidents(tctx(), "eng-1")
@@ -447,7 +467,7 @@ func TestIncidentsRollupFromLedger(t *testing.T) {
 func TestExpireIsAuditedAndRequiresActorReason(t *testing.T) {
 	h := newHarness(t, time.Hour) // records expire 1h after RecordedAt (clock = t=1000s)
 	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
-	if _, err := h.svc.Ingest(tctx(), h.signedBatch(t, 1, items), items); err != nil {
+	if _, err := h.svc.Ingest(tctx(), "agent:1", h.signedBatch(t, 1, items), items); err != nil {
 		t.Fatal(err)
 	}
 	// Actor/reason required.
@@ -500,7 +520,7 @@ func TestIngestNeverDoubleSealsAfterProjectionFailure(t *testing.T) {
 	b.Signature = fleetagent.SignBatch(priv, b)
 
 	// First ingest: the seal succeeds, then the injected projection-write failure surfaces.
-	if _, err := svc.Ingest(tctx(), b, items); err == nil {
+	if _, err := svc.Ingest(tctx(), b.AgentID, b, items); err == nil {
 		t.Fatal("expected the injected projection-write failure to surface")
 	}
 	if got := len(chain.kinds()); got != 1 {
@@ -512,7 +532,7 @@ func TestIngestNeverDoubleSealsAfterProjectionFailure(t *testing.T) {
 
 	// Retry the SAME batch. The row is still missing (HasDetection is false), so a naive Seal would run
 	// again — SealOnce must return the first link instead.
-	res, err := svc.Ingest(tctx(), b, items)
+	res, err := svc.Ingest(tctx(), b.AgentID, b, items)
 	if err != nil {
 		t.Fatalf("the retry must complete the projection, got %v", err)
 	}
@@ -549,7 +569,7 @@ func TestIngestSealsSameDetectionIDInDistinctEngagements(t *testing.T) {
 	for _, eng := range []shared.ID{"eng-1", "eng-2"} {
 		b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: eng, Sequence: 1, KeyID: key.KeyID, Detections: refsFor(t, items)}
 		b.Signature = fleetagent.SignBatch(priv, b)
-		res, err := svc.Ingest(tctx(), b, items)
+		res, err := svc.Ingest(tctx(), b.AgentID, b, items)
 		if err != nil {
 			t.Fatalf("ingest into %s: %v", eng, err)
 		}
@@ -584,7 +604,7 @@ func TestIngestRefusesUnknownKeyID(t *testing.T) {
 	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
 	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, KeyID: "kid-does-not-exist", Detections: refsFor(t, items)}
 	b.Signature = fleetagent.SignBatch(h.priv, b)
-	if _, err := h.svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrForbidden) {
+	if _, err := h.svc.Ingest(tctx(), b.AgentID, b, items); !errors.Is(err, shared.ErrForbidden) {
 		t.Fatalf("an unresolvable KeyID must be refused (fail closed), got %v", err)
 	}
 	if len(h.chain.kinds()) != 0 {
@@ -612,7 +632,7 @@ func TestIngestRefusesRevokedKey(t *testing.T) {
 	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
 	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, KeyID: key.KeyID, Detections: refsFor(t, items)}
 	b.Signature = fleetagent.SignBatch(priv, b)
-	if _, err := svc.Ingest(tctx(), b, items); !errors.Is(err, shared.ErrForbidden) {
+	if _, err := svc.Ingest(tctx(), b.AgentID, b, items); !errors.Is(err, shared.ErrForbidden) {
 		t.Fatalf("a revoked key must fail closed, got %v", err)
 	}
 	if len(chain.kinds()) != 0 {

--- a/internal/usecase/fleet/keyregistry/service.go
+++ b/internal/usecase/fleet/keyregistry/service.go
@@ -1,0 +1,126 @@
+// Package keyregistry is the control-plane side of the agent signing-key lifecycle (#607, A0.2): an
+// enrolled agent registers its Ed25519 signing public key together with a proof-of-possession bound to
+// its canonical AgentID; operators list and revoke keys. It is the wire front for
+// ports.AgentSigningKeyStore — the store enforces idempotency, anti-rollback, and monotonic revoke; this
+// service enforces that a key is only registered after its possession is proven (the port doc mandates
+// the caller verify PoP; this is that caller) and that every mutation is audited.
+package keyregistry
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// MaxSigningKeyValidity caps the validity window an agent may self-register for a signing key. Without a
+// ceiling an agent could mint a key valid for decades, defeating rotation: a later private-key compromise
+// would then rely solely on a manual operator revoke to close. One year is a safe upper bound that still
+// leaves normal rotation comfortable; operators tighten it out-of-band. Rejecting a longer window is
+// fail-closed (a shorter one is always allowed).
+const MaxSigningKeyValidity = 365 * 24 * time.Hour
+
+// Service registers, lists, and revokes agent signing keys.
+type Service struct {
+	keys  ports.AgentSigningKeyStore
+	audit ports.AuditLogger
+	clock ports.Clock
+}
+
+// NewService validates and constructs the key-registry service.
+func NewService(keys ports.AgentSigningKeyStore, audit ports.AuditLogger, clock ports.Clock) (*Service, error) {
+	if keys == nil || audit == nil || clock == nil {
+		return nil, fmt.Errorf("%w: key registry needs a key store, audit log and clock", shared.ErrValidation)
+	}
+	return &Service{keys: keys, audit: audit, clock: clock}, nil
+}
+
+// RegisterRequest is an agent's signing-key enrolment: its Ed25519 public key (base64), the purpose the
+// key is for, its validity window, and a base64 proof-of-possession (an Ed25519 signature over the key's
+// binding message, produced with the matching private key).
+type RegisterRequest struct {
+	PublicKeyB64 string
+	Purpose      string
+	NotBefore    time.Time
+	NotAfter     time.Time
+	Proof        string
+}
+
+// Register verifies proof-of-possession and registers the key bound to the AUTHENTICATED agent. authAgentID
+// comes from the agent-plane credential, never the wire: the key's binding message (and thus the PoP and
+// the derived KeyID) is computed against authAgentID, so an agent can only ever register a key for itself —
+// a proof made for another agent id will not verify. Registration is idempotent on identity; re-pointing an
+// existing KeyID to a different key returns ErrConflict from the store (anti-rollback).
+func (s *Service) Register(ctx context.Context, authAgentID shared.ID, req RegisterRequest) (fleetagent.AgentSigningKey, error) {
+	if authAgentID.IsZero() {
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("%w: key registration requires an authenticated agent", shared.ErrForbidden)
+	}
+	pub, err := base64.StdEncoding.DecodeString(strings.TrimSpace(req.PublicKeyB64))
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("%w: signing public key must be base64 Ed25519 (%d bytes)", shared.ErrValidation, ed25519.PublicKeySize)
+	}
+	purpose := fleetagent.SigningPurpose(req.Purpose)
+	if !purpose.Valid() {
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("%w: unknown signing-key purpose %q", shared.ErrValidation, req.Purpose)
+	}
+	key, err := fleetagent.NewSigningKey(authAgentID, purpose, ed25519.PublicKey(pub), req.NotBefore.UTC(), req.NotAfter.UTC())
+	if err != nil {
+		return fleetagent.AgentSigningKey{}, err
+	}
+	// Rotation hygiene: refuse an over-long validity window so a compromised key cannot linger for years.
+	if key.NotAfter.Sub(key.NotBefore) > MaxSigningKeyValidity {
+		s.record(ctx, authAgentID.String(), key.KeyID, "fleet.key.rejected", map[string]string{"reason": "validity_too_long", "purpose": string(purpose)})
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("%w: signing-key validity window exceeds the maximum of %s", shared.ErrValidation, MaxSigningKeyValidity)
+	}
+	// Proof-of-possession BEFORE Register (the store deliberately does not check it): the agent must hold
+	// the private key for the public key it posts, bound to its own AgentID/purpose/window. Fail closed.
+	if err := fleetagent.VerifyKeyPossession(key, req.Proof); err != nil {
+		s.record(ctx, authAgentID.String(), key.KeyID, "fleet.key.rejected", map[string]string{"reason": "proof_invalid", "purpose": string(purpose)})
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("%w: signing-key possession proof did not verify: %v", shared.ErrForbidden, err)
+	}
+	if err := s.keys.Register(ctx, key); err != nil {
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("register signing key: %w", err)
+	}
+	s.record(ctx, authAgentID.String(), key.KeyID, "fleet.key.registered", map[string]string{
+		"purpose": string(purpose), "not_before": key.NotBefore.Format(time.RFC3339), "not_after": key.NotAfter.Format(time.RFC3339),
+	})
+	return key, nil
+}
+
+// List returns the signing keys registered for an agent (operator read), tenant-scoped by the store.
+func (s *Service) List(ctx context.Context, agentID shared.ID) ([]fleetagent.AgentSigningKey, error) {
+	if agentID.IsZero() {
+		return nil, fmt.Errorf("%w: list keys needs an agent id", shared.ErrValidation)
+	}
+	return s.keys.ListByAgent(ctx, agentID)
+}
+
+// Revoke marks a key revoked as of now (operator action, monotonic in the store). actor names the human
+// operator for the audit trail; revoke without an attributable actor is refused.
+func (s *Service) Revoke(ctx context.Context, agentID shared.ID, keyID, actor string) error {
+	if agentID.IsZero() || strings.TrimSpace(keyID) == "" {
+		return fmt.Errorf("%w: revoke needs an agent id and key id", shared.ErrValidation)
+	}
+	if strings.TrimSpace(actor) == "" {
+		return fmt.Errorf("%w: revoke must name the operator", shared.ErrValidation)
+	}
+	if err := s.keys.Revoke(ctx, agentID, keyID, s.clock.Now().UTC()); err != nil {
+		return fmt.Errorf("revoke signing key: %w", err)
+	}
+	s.record(ctx, actor, keyID, "fleet.key.revoked", map[string]string{"agent_id": agentID.String()})
+	return nil
+}
+
+func (s *Service) record(ctx context.Context, actor, keyID, action string, meta map[string]string) {
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	meta["key_id"] = keyID
+	_ = s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: keyID, At: s.clock.Now().UTC(), Metadata: meta})
+}

--- a/internal/usecase/fleet/keyregistry/service_test.go
+++ b/internal/usecase/fleet/keyregistry/service_test.go
@@ -1,0 +1,190 @@
+package keyregistry
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeClock struct{ t time.Time }
+
+func (c fakeClock) Now() time.Time { return c.t }
+
+type fakeAudit struct{ actions []string }
+
+func (a *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.actions = append(a.actions, e.Action)
+	return nil
+}
+func (a *fakeAudit) has(action string) bool {
+	for _, x := range a.actions {
+		if x == action {
+			return true
+		}
+	}
+	return false
+}
+
+func newHarness(t *testing.T) (*Service, *fakeAudit, context.Context) {
+	t.Helper()
+	audit := &fakeAudit{}
+	svc, err := NewService(memory.NewAgentSigningKeyStore(), audit, fakeClock{t: time.Unix(1_000_000, 0).UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc, audit, shared.WithTenant(context.Background(), "t1")
+}
+
+// proofFor builds a valid registration request for agentID: it generates a keypair, produces the
+// proof-of-possession the same way an agent would, and returns the request plus the private key so a test
+// can also craft a mismatched proof.
+func proofFor(t *testing.T, agentID shared.ID, purpose fleetagent.SigningPurpose) (RegisterRequest, ed25519.PrivateKey, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nb, na := time.Unix(0, 0).UTC(), time.Unix(3600, 0).UTC() // 1h window, within MaxSigningKeyValidity
+	key, err := fleetagent.NewSigningKey(agentID, purpose, pub, nb, na)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return RegisterRequest{
+		PublicKeyB64: base64.StdEncoding.EncodeToString(pub),
+		Purpose:      string(purpose),
+		NotBefore:    nb,
+		NotAfter:     na,
+		Proof:        fleetagent.ProveKeyPossession(priv, key),
+	}, priv, pub
+}
+
+func TestRegisterWithProofSucceedsAndIsResolvable(t *testing.T) {
+	svc, audit, ctx := newHarness(t)
+	req, _, _ := proofFor(t, "agent:1", fleetagent.PurposeDetectionBatch)
+	key, err := svc.Register(ctx, "agent:1", req)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if key.AgentID != "agent:1" || key.Purpose != fleetagent.PurposeDetectionBatch {
+		t.Fatalf("unexpected key: %+v", key)
+	}
+	if !audit.has("fleet.key.registered") {
+		t.Error("a registration must be audited")
+	}
+	keys, err := svc.List(ctx, "agent:1")
+	if err != nil || len(keys) != 1 || keys[0].KeyID != key.KeyID {
+		t.Fatalf("registered key must be listable, got %+v err=%v", keys, err)
+	}
+}
+
+func TestRegisterFailsClosedWithoutValidProof(t *testing.T) {
+	svc, audit, ctx := newHarness(t)
+	req, _, _ := proofFor(t, "agent:1", fleetagent.PurposeDetectionBatch)
+	// A proof made with a DIFFERENT private key than the posted public key must not verify.
+	_, otherPriv, _ := ed25519.GenerateKey(nil)
+	bad := req
+	key, _ := fleetagent.NewSigningKey("agent:1", fleetagent.PurposeDetectionBatch, mustDecode(t, req.PublicKeyB64), req.NotBefore, req.NotAfter)
+	bad.Proof = fleetagent.ProveKeyPossession(otherPriv, key)
+	if _, err := svc.Register(ctx, "agent:1", bad); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("a bad possession proof must be forbidden, got %v", err)
+	}
+	if !audit.has("fleet.key.rejected") {
+		t.Error("a rejected registration must be audited")
+	}
+	if keys, _ := svc.List(ctx, "agent:1"); len(keys) != 0 {
+		t.Fatalf("nothing must be registered on a bad proof, got %d", len(keys))
+	}
+}
+
+func TestRegisterBindsToAuthenticatedAgent(t *testing.T) {
+	svc, _, ctx := newHarness(t)
+	// The agent proved possession for agent:1, but registration is attempted under authenticated agent:2.
+	// The server rebuilds the key against the AUTHENTICATED id, so the binding message (and PoP) no longer
+	// matches — a key can only ever be registered for the agent that authenticated. Fail closed.
+	req, _, _ := proofFor(t, "agent:1", fleetagent.PurposeDetectionBatch)
+	if _, err := svc.Register(ctx, "agent:2", req); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("a proof bound to another agent must be forbidden, got %v", err)
+	}
+}
+
+func TestRegisterValidatesInput(t *testing.T) {
+	svc, _, ctx := newHarness(t)
+	good, _, _ := proofFor(t, "agent:1", fleetagent.PurposeDetectionBatch)
+	if _, err := svc.Register(ctx, "agent:1", RegisterRequest{PublicKeyB64: "!!not base64", Purpose: good.Purpose, NotBefore: good.NotBefore, NotAfter: good.NotAfter, Proof: good.Proof}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("bad public key must be ErrValidation, got %v", err)
+	}
+	bad := good
+	bad.Purpose = "not-a-purpose"
+	if _, err := svc.Register(ctx, "agent:1", bad); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unknown purpose must be ErrValidation, got %v", err)
+	}
+	if _, err := svc.Register(ctx, "", good); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("empty authenticated agent must be forbidden, got %v", err)
+	}
+}
+
+func TestRegisterRejectsOverLongValidity(t *testing.T) {
+	svc, _, ctx := newHarness(t)
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A window longer than MaxSigningKeyValidity must be refused (rotation hygiene), fail-closed.
+	nb := time.Unix(0, 0).UTC()
+	na := nb.Add(MaxSigningKeyValidity + 24*time.Hour)
+	key, err := fleetagent.NewSigningKey("agent:1", fleetagent.PurposeDetectionBatch, pub, nb, na)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := RegisterRequest{
+		PublicKeyB64: base64.StdEncoding.EncodeToString(pub),
+		Purpose:      string(fleetagent.PurposeDetectionBatch),
+		NotBefore:    nb, NotAfter: na,
+		Proof: fleetagent.ProveKeyPossession(priv, key),
+	}
+	if _, err := svc.Register(ctx, "agent:1", req); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("an over-long validity window must be ErrValidation, got %v", err)
+	}
+	if keys, _ := svc.List(ctx, "agent:1"); len(keys) != 0 {
+		t.Fatalf("nothing must be registered on an over-long window, got %d", len(keys))
+	}
+}
+
+func TestRevokeRequiresActorAndMarksRevoked(t *testing.T) {
+	svc, audit, ctx := newHarness(t)
+	req, _, _ := proofFor(t, "agent:1", fleetagent.PurposeDetectionBatch)
+	key, err := svc.Register(ctx, "agent:1", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Revoke(ctx, "agent:1", key.KeyID, ""); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("revoke without an actor must be ErrValidation, got %v", err)
+	}
+	if err := svc.Revoke(ctx, "agent:1", key.KeyID, "operator@x"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if !audit.has("fleet.key.revoked") {
+		t.Error("a revoke must be audited")
+	}
+	keys, _ := svc.List(ctx, "agent:1")
+	if len(keys) != 1 || keys[0].RevokedAt.IsZero() {
+		t.Fatalf("the key must be marked revoked, got %+v", keys)
+	}
+}
+
+func mustDecode(t *testing.T, b64 string) ed25519.PublicKey {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ed25519.PublicKey(raw)
+}


### PR DESCRIPTION
## A4 — detection transport + agent signing-key lifecycle (#625)

Brings the fleet **detection-batch ingest** path and the **agent signing-key lifecycle** live (EPIC #594 spine, A0→A1→A2→A3→**A4**), wiring the A0 primitives that until now existed only behind interfaces and tests. This composes `detectledger.NewService` in production, the real signing-key resolver, and the agent-plane registration endpoint. It carries the deferred **A0.1** (server-verify for detection batches), **A0.2** (signing-key registration + PoP + rotate/revoke + resolver wiring), and **A0.5** (`detectledger.NewService` composed) tails.

### What's in this PR
- **evidence** — `Service.SealOnce(engagement, kind, idempotencyKey, content, createdBy)`: idempotent on a deterministic, **length-prefixed** reserved id over `(engagement, kind, key)`, reusing the existing crash-recoverable `appendReserved` path (factored a shared `sealReserved` out of `SealForFindingWithID`, whose behaviour is preserved verbatim). A seal-then-crash retry returns the first link and appends nothing — a detection can never be sealed into the chain twice (**closes D3 for detections**). `VerifyChainError` turns `Verify`'s `Intact=false`/nil-error contract into an `ErrChainBroken`-wrapping error so a go/no-go caller can't read a tampered/tail-truncated chain as healthy.
- **detectledger** — `Ingest` gains a **server-authoritative identity gate (A0.1)**: a batch whose agent id isn't the authenticated agent is refused (`ErrForbidden`, audited) before key resolution or sealing, so a sealed detection always carries the authenticated agent id. A closure-based `EvidenceChain` bridge keeps the package free of the evidence import (mirrors `offensivepolicy`'s sealer).
- **keyregistry** (new use case) — an agent registers its Ed25519 signing key with a **proof-of-possession** bound to its authenticated id (`VerifyKeyPossession` *before* `Register`, fail-closed); operators list and revoke. A self-registered validity window is capped (`MaxSigningKeyValidity`, 1 year) so a compromised key can't linger for years.
- **adapter** — agent-plane `POST /api/v1/fleet/detections` and `POST /api/v1/fleet/keys` (agent id + tenant from the credential, never the wire), plus operator `GET /api/v1/agents/{id}/keys` and `POST /api/v1/agents/{id}/keys/{keyID}/revoke` (RBAC `PermView` / `PermAdminister`). Narrow consumer interfaces on the adapter side.
- **config + cmd** — `SYNAPSE_FLEET_DETECTION_INGEST_ENABLED` and `SYNAPSE_FLEET_KEY_REGISTRATION_ENABLED` gate the wiring; `detectledger.NewService` is composed via the `evidenceService` SealOnce/VerifyChainError bridge. No new migration (reuses the `agent_signing_keys` table from 0105 + the existing detection/evidence stores).

### Contracts honored
A0.1 server-authoritative identity · A0.2 signing-key registration + PoP + operator rotate/revoke + resolver wiring · A0.5 `detectledger.NewService` composed with an idempotent, crash-safe `SealOnce` · full batch verify chain (identity → resolve key → `VerifyBatchWithKey` fail-closed → per-detection content-digest binding → seal-once).

### Verification
- `go build` / `go vet` / `gofmt` clean; `-race` green across evidence, detectledger, keyregistry, httpapi, config.
- Tests at every layer: SealOnce idempotency + crash-retry + conflict + `VerifyChainError` tamper (evidence); A0.1 identity-mismatch seals/persists nothing (detectledger); PoP happy-path + bad-proof + cross-agent binding + over-long-window + revoke/list (keyregistry); agent-plane 200/403/404/401 + operator list→revoke→revoked round-trip (httpapi).
- Dual review (go-arch + security): **go-arch PASS** (dependency rule clean; SealOnce refactor preserves behaviour and is idempotent + crash-safe; A0.1 gate complete), **security CLEAN** (no critical/high/medium; all six golden rules + D3/A0.1/A0.2 verified). All review nits applied (length-prefix the reserved id, `%w` context in the bridge, actor round-trip, max validity clamp).
- Also fixes a pre-existing test-only data race (`randomTestIDs.NewID` lacked a mutex; `TestSealConcurrentStaysLinear` tripped it under `-race`); the production id generator is stateless over `crypto/rand` and unaffected.

### Scope / follow-up
A5 (#626) still owns the richer `DetectionEvidenceEnvelope` content + retention policy; the agent-side batch shipper (agent building/signing detection batches) is a later tail. **#625 stays open** for those.
