### PR TITLE
feat(fleet): ship signed detections from the agent (#625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Independent signed agent detection delivery.** Confirmed detections now drain from an isolated P1
+  WAL lane into crash-recoverable batches, using an agent-owned Ed25519 key registered with
+  proof-of-possession. Pending sequence/membership survives restart and lost responses, local records
+  are ACKed only after complete server admission, rejected or expiring keys rotate without changing
+  the pending batch sequence, and a live-path test covers WAL → HTTP → key resolution → signature and
+  content verification → exactly-once evidence sealing.
+
 - **Native amd64 and arm64 eBPF sensor artifacts with capability-based CO-RE probing.** The agent now
   embeds only architecture-matched objects, detects kernel BTF and required network types without
   kernel-version gating, reports unsupported capability as an explicit coverage gap, and validates

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -42,6 +42,8 @@ tags:
   description: Tenant-scoped vulnerability feeds, exposure correlation, risk transitions, and durable operations
 - name: remediation-sla
   description: Risk-based remediation deadlines, immutable assessments, policy versions, and human-owned lifecycle governance
+- name: fleet
+  description: Enrolled-agent transport and operator fleet administration
 
 paths:
   /healthz:
@@ -1749,6 +1751,141 @@ paths:
         '404': {$ref: '#/components/responses/NotFound'}
         '409': {description: Lifecycle version changed since it was loaded, content: {application/json: {schema: {$ref: '#/components/schemas/Error'}}}}
 
+  /api/v1/fleet/telemetry:
+    post:
+      tags: [fleet]
+      operationId: ingestFleetTelemetryBatch
+      summary: Verify and ingest a signed canonical telemetry batch
+      description: A3 transport endpoint. Verifies credential identity, key lifecycle, schema, manifest signature, event digests, incarnation-aware sequencing, and returns the highest-contiguous ACK.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [Manifest, Events]
+              properties:
+                Manifest:
+                  type: object
+                  description: fleetagent.TelemetryBatchManifest with a signed StreamPosition and explicit loss counts.
+                  additionalProperties: true
+                Events:
+                  type: array
+                  items:
+                    type: object
+                    additionalProperties: false
+                    required: [EventID, Class, Payload, ObservedAt]
+                    properties:
+                      EventID: {type: string}
+                      Class: {type: string, enum: [process, network, file, privilege]}
+                      Payload: {type: string, contentEncoding: base64, description: Canonical telemetry event bytes}
+                      ObservedAt: {type: string, format: date-time}
+      responses:
+        '200':
+          description: Batch classified and highest-contiguous ACK returned
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [accepted, duplicate, ack, provenance, gap_open]
+                properties:
+                  accepted: {type: boolean}
+                  duplicate: {type: boolean}
+                  ack: {type: integer, format: uint64, minimum: 0}
+                  provenance: {type: string}
+                  gap_open: {type: boolean}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
+  /api/v1/fleet/keys:
+    post:
+      tags: [fleet]
+      operationId: registerFleetSigningKey
+      summary: Register an agent content-signing key with proof-of-possession
+      description: The canonical agent identity comes from the bearer credential, never the request body.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AgentSigningKeyRegistration'}
+      responses:
+        '201':
+          description: Key registered or idempotently re-registered
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/AgentSigningKeyRegistrationResult'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
+  /api/v1/fleet/detections:
+    post:
+      tags: [fleet]
+      operationId: ingestFleetDetectionBatch
+      summary: Verify and ingest an independently signed agent detection batch
+      description: Verifies authenticated agent identity, key lifecycle, signature, exact membership, and per-detection content digests before exactly-once evidence sealing.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AgentDetectionBatchRequest'}
+      responses:
+        '200':
+          description: The complete batch was admitted or idempotently skipped
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/AgentDetectionBatchResult'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
+  /api/v1/agents/{id}/keys:
+    parameters:
+    - $ref: '#/components/parameters/AgentId'
+    get:
+      tags: [fleet]
+      operationId: listAgentSigningKeys
+      summary: List an agent's content-signing keys
+      responses:
+        '200':
+          description: Signing-key lifecycle records
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/AgentSigningKeyList'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
+  /api/v1/agents/{id}/keys/{keyID}/revoke:
+    parameters:
+    - $ref: '#/components/parameters/AgentId'
+    - $ref: '#/components/parameters/SigningKeyId'
+    post:
+      tags: [fleet]
+      operationId: revokeAgentSigningKey
+      summary: Revoke one agent content-signing key
+      responses:
+        '200':
+          description: Key revoked monotonically
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [agent_id, key_id, state]
+                properties:
+                  agent_id: {type: string}
+                  key_id: {type: string}
+                  state: {type: string, const: revoked}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1763,6 +1900,16 @@ components:
       schema: {type: string}
     FindingId:
       name: fid
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    AgentId:
+      name: id
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    SigningKeyId:
+      name: keyID
       in: path
       required: true
       schema: {type: string, minLength: 1}
@@ -1862,6 +2009,104 @@ components:
           schema: {$ref: "#/components/schemas/Error"}
 
   schemas:
+    AgentSigningKeyRegistration:
+      type: object
+      additionalProperties: false
+      required: [public_key, purpose, not_before, not_after, proof]
+      properties:
+        public_key: {type: string, contentEncoding: base64, description: Raw 32-byte Ed25519 public key}
+        purpose: {type: string, enum: [telemetry-batch, detection-batch, response-result]}
+        not_before: {type: string, format: date-time}
+        not_after: {type: string, format: date-time}
+        proof: {type: string, contentEncoding: base64, description: Ed25519 signature over the purpose-bound key binding message}
+
+    AgentSigningKeyRegistrationResult:
+      type: object
+      required: [key_id, agent_id, purpose, not_before, not_after]
+      properties:
+        key_id: {type: string}
+        agent_id: {type: string}
+        purpose: {type: string, enum: [telemetry-batch, detection-batch, response-result]}
+        not_before: {type: string, format: date-time}
+        not_after: {type: string, format: date-time}
+
+    AgentSigningKeySummary:
+      type: object
+      required: [key_id, purpose, algorithm, not_before, not_after, revoked, replaced_by]
+      properties:
+        key_id: {type: string}
+        purpose: {type: string, enum: [telemetry-batch, detection-batch, response-result]}
+        algorithm: {type: string, const: ed25519}
+        not_before: {type: string, format: date-time}
+        not_after: {type: string, format: date-time}
+        revoked: {type: boolean}
+        replaced_by: {type: string}
+
+    AgentSigningKeyList:
+      type: object
+      required: [agent_id, keys]
+      properties:
+        agent_id: {type: string}
+        keys:
+          type: array
+          items: {$ref: '#/components/schemas/AgentSigningKeySummary'}
+
+    DetectionBatchRef:
+      type: object
+      additionalProperties: false
+      required: [ID, ContentSHA256]
+      properties:
+        ID: {type: string}
+        ContentSHA256: {type: string, pattern: '^[0-9a-f]{64}$'}
+
+    AgentDetectionBatch:
+      type: object
+      additionalProperties: false
+      required: [AgentID, EngagementID, Sequence, KeyID, Signature, Detections]
+      properties:
+        AgentID: {type: string, description: Must equal the authenticated agent identity}
+        EngagementID: {type: string}
+        Sequence: {type: integer, format: uint64, minimum: 1}
+        KeyID: {type: string}
+        Signature: {type: string, contentEncoding: base64}
+        Detections:
+          type: array
+          minItems: 1
+          items: {$ref: '#/components/schemas/DetectionBatchRef'}
+
+    DetectionBatchItem:
+      type: object
+      additionalProperties: false
+      required: [ID, Detection, AssetID]
+      properties:
+        ID: {type: string}
+        Detection:
+          type: object
+          description: Typed detection.Detection body whose canonical JSON and AssetID must match the signed content digest.
+          additionalProperties: true
+        AssetID: {type: string}
+
+    AgentDetectionBatchRequest:
+      type: object
+      additionalProperties: false
+      required: [batch, items]
+      properties:
+        batch: {$ref: '#/components/schemas/AgentDetectionBatch'}
+        items:
+          type: array
+          minItems: 1
+          items: {$ref: '#/components/schemas/DetectionBatchItem'}
+
+    AgentDetectionBatchResult:
+      type: object
+      required: [engagement_id, sealed, skipped, missing, replay]
+      properties:
+        engagement_id: {type: string}
+        sealed: {type: integer, minimum: 0}
+        skipped: {type: integer, minimum: 0}
+        missing: {type: integer, format: uint64, minimum: 0}
+        replay: {type: boolean}
+
     Readiness:
       type: object
       required: [status, checks]

--- a/api/testdata/openapi-coverage-debt.txt
+++ b/api/testdata/openapi-coverage-debt.txt
@@ -14,7 +14,6 @@ DELETE /api/v1/engagements/{p}/credentials/{p}
 DELETE /api/v1/quality-gates/{p}
 DELETE /api/v1/quality-profiles/{p}
 GET /api/v1/agents
-GET /api/v1/agents/{p}/keys
 GET /api/v1/agents/rollout
 GET /api/v1/assets
 GET /api/v1/assets/edges
@@ -86,7 +85,6 @@ GET /api/v1/vulnerability/sources/types
 GET /api/v1/writeups
 PATCH /api/v1/engagements/{p}
 PATCH /api/v1/vulnerability/sources/{p}
-POST /api/v1/agents/{p}/keys/{p}/revoke
 POST /api/v1/agents/{p}/revoke
 POST /api/v1/agents/enrolment-tokens
 POST /api/v1/agents/rollout/pause
@@ -120,13 +118,10 @@ POST /api/v1/engagements/{p}/writeup-drafts/{p}/edit
 POST /api/v1/engagements/{p}/writeup-drafts/{p}/reject
 POST /api/v1/engagements/import
 POST /api/v1/fleet/decommission
-POST /api/v1/fleet/detections
 POST /api/v1/fleet/enrol
 POST /api/v1/fleet/heartbeat
 POST /api/v1/fleet/inventory/cluster
 POST /api/v1/fleet/inventory/host
-POST /api/v1/fleet/keys
-POST /api/v1/fleet/telemetry
 POST /api/v1/fleet/work/{p}/progress
 POST /api/v1/fleet/work/{p}/result
 POST /api/v1/fleet/work/claim

--- a/cmd/synapse-agent/detect.go
+++ b/cmd/synapse-agent/detect.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -13,9 +14,12 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/adapter/agentspool"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/agentstate"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/ebpf"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/spool"
 	detectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detect"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectionship"
 )
 
 // detectionIdentity derives the canonical (host, agent) identity the detection engine tags its events
@@ -83,6 +87,19 @@ func (r *runner) startDetection(ctx context.Context, cred fleetclient.Credential
 		return
 	}
 	runCtx, cancelRun := context.WithCancel(ctx)
+	var shipper *detectionship.Service
+	if engagement := shared.ID(strings.TrimSpace(r.cfg.detectionEngagement)); !engagement.IsZero() {
+		shipper, err = detectionship.NewService(durable, r.api, agentstate.NewDetectionStore(r.cfg.stateDir), detectionship.Config{
+			AgentID: agent, EngagementID: engagement, Token: cred.Token,
+			IdleInterval: r.cfg.detectionShipInterval, Retry: detectionRetry(spool.DefaultRetryPolicy()),
+		})
+		if err != nil {
+			log.Printf("detection: wire signed delivery: %v; detection engine disabled", err)
+			cancelRun()
+			_ = durable.Close()
+			return
+		}
+	}
 	if err := r.startSpoolMetrics(runCtx, durable); err != nil {
 		log.Printf("detection: agent metrics listener unavailable: %v", err)
 	}
@@ -105,6 +122,18 @@ func (r *runner) startDetection(ctx context.Context, cred fleetclient.Credential
 			}
 		}
 	}()
+	deliveryDone := make(chan struct{})
+	if shipper == nil {
+		close(deliveryDone)
+	} else {
+		go func() {
+			defer close(deliveryDone)
+			if err := shipper.Run(runCtx); err != nil && !errors.Is(err, context.Canceled) {
+				log.Printf("detection delivery stopped: %v", err)
+			}
+			cancelRun()
+		}()
+	}
 	go func() {
 		err := eng.Run(runCtx)
 		if err != nil && !errors.Is(err, context.Canceled) {
@@ -114,10 +143,36 @@ func (r *runner) startDetection(ctx context.Context, cred fleetclient.Credential
 		// A timer that fired concurrently may still be persisting coverage. Wait
 		// for it before closing the shared spool so no operation races Close.
 		<-coverageDone
+		<-deliveryDone
 		if closeErr := durable.Close(); closeErr != nil {
 			log.Printf("detection: close durable spool: %v", closeErr)
 		}
 	}()
+}
+
+func detectionRetry(policy spool.RetryPolicy) detectionship.RetryDecider {
+	return func(err error, attempt uint) (bool, time.Duration) {
+		if status, retryAfter, ok := fleetclient.HTTPStatus(err); ok {
+			decision, classifyErr := policy.ClassifyHTTP(status, retryAfter, time.Now().UTC(), attempt)
+			if classifyErr != nil {
+				return false, 0
+			}
+			return decision.Retry, decision.Delay
+		}
+		if fleetclient.IsNetworkError(err) {
+			decision, classifyErr := policy.NetworkFailure(attempt)
+			if classifyErr == nil {
+				return decision.Retry, decision.Delay
+			}
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			decision, classifyErr := policy.ClassifyHTTP(http.StatusRequestTimeout, "", time.Now().UTC(), attempt)
+			if classifyErr == nil {
+				return decision.Retry, decision.Delay
+			}
+		}
+		return false, 0
+	}
 }
 
 // parseDetectClasses turns the comma-separated config into validated classes. An unknown class is a

--- a/cmd/synapse-agent/main.go
+++ b/cmd/synapse-agent/main.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetversion"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/hostinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
@@ -55,21 +56,25 @@ type fleetAPI interface {
 	Progress(ctx context.Context, token, orderID string) error
 	SubmitResult(ctx context.Context, token, orderID, status, reason string) error
 	SendHostInventory(ctx context.Context, token string, inv any) error
+	RegisterDetectionKey(ctx context.Context, token string, key fleetagent.AgentSigningKey, proof string) error
+	SendDetectionBatch(ctx context.Context, token string, batch fleetagent.AgentBatch, items []fleetagent.DetectionBatchItem) error
 }
 
 type config struct {
-	baseURL       string
-	enrolToken    string
-	stateDir      string
-	root          string
-	name          string
-	poll          time.Duration
-	maxOrders     int
-	once          bool
-	detectClasses string  // SYNAPSE_DETECT_CLASSES; empty = detection engine off
-	detectCeiling float64 // SYNAPSE_DETECT_CPU_CEIL_PCT; 0 = no load shedding
-	spoolBytes    int64   // durable telemetry WAL quota
-	metricsAddr   string  // optional private agent metrics listener
+	baseURL               string
+	enrolToken            string
+	stateDir              string
+	root                  string
+	name                  string
+	poll                  time.Duration
+	maxOrders             int
+	once                  bool
+	detectClasses         string  // SYNAPSE_DETECT_CLASSES; empty = detection engine off
+	detectCeiling         float64 // SYNAPSE_DETECT_CPU_CEIL_PCT; 0 = no load shedding
+	spoolBytes            int64   // durable telemetry WAL quota
+	metricsAddr           string  // optional private agent metrics listener
+	detectionEngagement   string  // engagement receiving signed detection batches; empty = local-only
+	detectionShipInterval time.Duration
 }
 
 func main() {
@@ -125,6 +130,8 @@ func parseConfig() config {
 	flag.Float64Var(&cfg.detectCeiling, "detect-ceiling", parseCeiling(os.Getenv("SYNAPSE_DETECT_CPU_CEIL_PCT")), "CPU ceiling percent for the detection engine; over it, classes are shed in a defined order (0 = no shedding)")
 	flag.Int64Var(&cfg.spoolBytes, "telemetry-spool-bytes", parsePositiveBytes(os.Getenv("SYNAPSE_TELEMETRY_SPOOL_BYTES"), 512<<20), "maximum bytes retained by the priority telemetry WAL")
 	flag.StringVar(&cfg.metricsAddr, "agent-metrics-addr", os.Getenv("SYNAPSE_AGENT_METRICS_ADDR"), "optional address for private agent Prometheus metrics (for example 127.0.0.1:9465)")
+	flag.StringVar(&cfg.detectionEngagement, "detection-engagement", os.Getenv("SYNAPSE_DETECTION_ENGAGEMENT_ID"), "engagement id receiving signed detection batches; empty keeps detections local")
+	flag.DurationVar(&cfg.detectionShipInterval, "detection-ship-interval", parsePositiveDuration(os.Getenv("SYNAPSE_DETECTION_SHIP_INTERVAL"), time.Second), "idle interval for the independent detection delivery loop")
 	flag.Parse()
 	if cfg.enrolToken == "" {
 		// An absent token file is NOT fatal: it is the normal state after enrolment, once the
@@ -311,6 +318,18 @@ func parsePositiveBytes(value string, def int64) int64 {
 	parsed, err := strconv.ParseInt(value, 10, 64)
 	if err != nil || parsed <= 0 {
 		log.Printf("ignoring invalid telemetry spool byte count (want a positive integer)")
+		return def
+	}
+	return parsed
+}
+
+func parsePositiveDuration(value string, def time.Duration) time.Duration {
+	if value == "" {
+		return def
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil || parsed <= 0 {
+		log.Printf("ignoring invalid detection ship interval (want a positive duration)")
 		return def
 	}
 	return parsed

--- a/cmd/synapse-agent/main_test.go
+++ b/cmd/synapse-agent/main_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/hostinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
@@ -51,6 +52,12 @@ func (f *fakeAPI) SubmitResult(_ context.Context, _, orderID, status, reason str
 func (f *fakeAPI) SendHostInventory(_ context.Context, _ string, _ any) error {
 	f.sent++
 	return f.sendErr
+}
+func (f *fakeAPI) RegisterDetectionKey(context.Context, string, fleetagent.AgentSigningKey, string) error {
+	return nil
+}
+func (f *fakeAPI) SendDetectionBatch(context.Context, string, fleetagent.AgentBatch, []fleetagent.DetectionBatchItem) error {
+	return nil
 }
 
 func newRunner(t *testing.T, api fleetAPI, orders []fleetclient.Order, collect func(context.Context, string) (hostinventory.HostInventory, error)) *runner {

--- a/cmd/synapse-agent/main_test.go
+++ b/cmd/synapse-agent/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/hostinventory"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/fssecurity"
 )
 
 type fakeAPI struct {
@@ -100,7 +101,7 @@ func TestFirstRunEnrolsAndPersists(t *testing.T) {
 	}
 	// Unix-only guarantee: Windows has no permission bits, so the credential is protected by the
 	// state directory's ACL there instead. Asserting 0600 on Windows would assert nothing real.
-	if fleetclient.SecretModeEnforced() && info.Mode().Perm() != 0o600 {
+	if fssecurity.UnixModeEnforced() && info.Mode().Perm() != 0o600 {
 		t.Fatalf("credential must be 0600, got %v", info.Mode().Perm())
 	}
 	// The order was progressed and reported succeeded with a coverage-honest summary.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -390,6 +390,8 @@ The following variables are read by `synapse-agent` and `synapse-cluster-agent`,
 | `SYNAPSE_AGENT_NAME` | hostname | Human-readable agent display name. |
 | `SYNAPSE_DETECT_CLASSES` | empty | Comma-separated eBPF classes: `process`, `network`, `file`, `privilege`. Empty disables the engine; Linux root/capabilities are required. |
 | `SYNAPSE_DETECT_CPU_CEIL_PCT` | `0` | CPU ceiling for deterministic class shedding; zero disables shedding. |
+| `SYNAPSE_DETECTION_ENGAGEMENT_ID` | empty | Engagement receiving signed detection batches. Empty keeps confirmed detections durably local and does not start the remote detection shipper. |
+| `SYNAPSE_DETECTION_SHIP_INTERVAL` | `1s` | Poll interval while the independent P1 detection delivery lane is empty. Network/429/5xx retry uses separate capped exponential backoff. |
 | `SYNAPSE_TELEMETRY_SPOOL_BYTES` | `536870912` | Maximum bytes of checksummed telemetry WAL segments (minimum 1 MiB). P3 is evicted first with durable gap evidence; P0–P2 backpressure instead of shedding. |
 | `SYNAPSE_AGENT_METRICS_ADDR` | empty | Optional private Prometheus listener for agent spool metrics. It has no authentication; bind to loopback or a protected scrape network. |
 | `SYNAPSE_CLUSTER` | empty (required) | Stable cluster identity attached to every Kubernetes asset. |

--- a/docs/guide/fleet-blue-team.md
+++ b/docs/guide/fleet-blue-team.md
@@ -116,11 +116,14 @@ possession to `POST /api/v1/fleet/keys`, and drains P1 independently to
 identity from its credential, resolves the named key, verifies every content digest and signature,
 then seals each detection exactly once.
 
-A pending batch coordinate is written before the network request. If the agent restarts or loses the
-HTTP response, it retries the same sequence and membership; the control plane idempotently skips what
-was already sealed. The local WAL is ACKed only after a complete 2xx response. Keys rotate before
-expiry, and one `403` causes one new key registration plus a retry of the same pending sequence. A
-second rejection stops delivery instead of generating keys indefinitely.
+A pending batch coordinate, membership, and engagement attribution are written before the network
+request. If the agent restarts or loses the HTTP response, it retries the same sequence and membership;
+the control plane idempotently skips what was already sealed. Changing the configured engagement while
+a batch is pending fails closed instead of re-attributing it. The local WAL is ACKed only after a
+complete 2xx response, and its per-epoch ACK history lets a reboot finish committing a batch whose WAL
+records were already reclaimed. Keys rotate before expiry, and one `403` causes one new key registration
+plus a retry of the same pending sequence. A second rejection stops delivery instead of generating keys
+indefinitely.
 
 ### Durable telemetry spool
 

--- a/docs/guide/fleet-blue-team.md
+++ b/docs/guide/fleet-blue-team.md
@@ -97,6 +97,7 @@ collection interval.
 ```bash
 SYNAPSE_DETECT_CLASSES=process,network,file,privilege
 SYNAPSE_DETECT_CPU_CEIL_PCT=25
+SYNAPSE_DETECTION_ENGAGEMENT_ID=engagement-id
 ```
 
 An empty class list disables the engine. When CPU exceeds the ceiling, classes are shed in a defined order
@@ -106,6 +107,20 @@ per engagement:
 ```
 GET /api/v1/engagements/{id}/detections
 ```
+
+When `SYNAPSE_DETECTION_ENGAGEMENT_ID` is set, the agent generates a purpose-bound Ed25519 key,
+persists the private half as `detection-transport.json` under the protected state directory, proves
+possession to `POST /api/v1/fleet/keys`, and drains P1 independently to
+`POST /api/v1/fleet/detections`. Enable both `SYNAPSE_FLEET_KEY_REGISTRATION_ENABLED=true` and
+`SYNAPSE_FLEET_DETECTION_INGEST_ENABLED=true` on the control plane. The server derives the agent
+identity from its credential, resolves the named key, verifies every content digest and signature,
+then seals each detection exactly once.
+
+A pending batch coordinate is written before the network request. If the agent restarts or loses the
+HTTP response, it retries the same sequence and membership; the control plane idempotently skips what
+was already sealed. The local WAL is ACKed only after a complete 2xx response. Keys rotate before
+expiry, and one `403` causes one new key registration plus a retry of the same pending sequence. A
+second rejection stops delivery instead of generating keys indefinitely.
 
 ### Durable telemetry spool
 
@@ -126,9 +141,10 @@ was not retained. A restart reads both state generations, validates CRC32C frame
 repairs corrupt/torn segments, and continues the current `(priority, epoch, sequence)` coordinate. A
 kernel reboot changes the Linux boot UUID, advances the epoch, and safely restarts sequence at one.
 
-The WAL is the A2 durability boundary; wire batching and server ACK exchange belong to A3. Until that
-transport is enabled, P3 rotates within the configured quota while never-shed lanes can eventually
-backpressure. Operators should therefore size the quota for the expected disconnected interval.
+The WAL is the A2 durability boundary. Confirmed P1 detections have their own signed shipper when an
+engagement is configured; the remaining raw-telemetry drain belongs to A3. Until that transport is
+enabled, P3 rotates within the configured quota while P0/P2 can eventually backpressure. Operators
+should therefore size the quota for the expected disconnected interval.
 
 Set `SYNAPSE_AGENT_METRICS_ADDR=127.0.0.1:9465` to expose `/metrics`. This listener is deliberately off
 by default and has no authentication. Exported series have bounded labels (priority only):

--- a/internal/adapter/httpapi/fleet_detection_shipper_integration_test.go
+++ b/internal/adapter/httpapi/fleet_detection_shipper_integration_test.go
@@ -1,0 +1,115 @@
+package httpapi
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/adapter/agentspool"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/agentstate"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/spool"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/worksign"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectionship"
+	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetwork"
+)
+
+// TestAgentDetectionShipperLivePath exercises the complete remaining A4 path with real adapters:
+// durable P1 WAL → private-key persistence → PoP registration over HTTP → signed batch over HTTP →
+// server-side key resolution/content verification → SealOnce bridge → detection projection → local ACK.
+func TestAgentDetectionShipperLivePath(t *testing.T) {
+	agentSvc, err := fleetagentuc.NewService(memory.NewFleetAgentStore(), ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := worksign.New([]byte("0123456789012345678901234567890123"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workSvc, err := fleetwork.NewService(memory.NewWorkOrderStore(), signer, ftAudit{}, ftClock{}, &ftIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyStore := memory.NewAgentSigningKeyStore()
+	keySvc, err := keyregistry.NewService(keyStore, ftAudit{}, ftClock{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	records := memory.NewDetectionRecordStore()
+	detectionSvc, err := detectledger.NewService(records, fakeDetChain{}, keyStore, ftAudit{}, ftClock{}, &ftIDs{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := &Router{log: discardLog()}
+	router.SetFleet(agentSvc, workSvc, func() time.Time { return time.Now().UTC() }, "")
+	router.SetFleetKeyRegistration(keySvc)
+	router.SetFleetDetectionIngest(detectionSvc)
+	handler := router.fleet.handler()
+	token, agentID := enrolAgent(t, handler, agentSvc)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	spoolConfig := spool.DefaultConfig()
+	spoolConfig.Dir = t.TempDir()
+	spoolConfig.Session = fleetagent.SessionID("session-1")
+	spoolConfig.Boot = fleetagent.BootID("boot-1")
+	durable, err := spool.Open(spoolConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = durable.Close() })
+	sink, err := agentspool.NewDetectionSink(durable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := mkTestDetection(t, agentID)
+	second := mkTestDetection(t, agentID)
+	second.Observed = second.Observed.Add(time.Second)
+	second.Evidence[0].At = second.Evidence[0].At.Add(time.Second)
+	second.Evidence[0].Process.PID++
+	if err := sink.Emit(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Emit(context.Background(), second); err != nil {
+		t.Fatal(err)
+	}
+
+	client := fleetclient.New(server.URL, 5*time.Second)
+	shipper, err := detectionship.NewService(durable, client, agentstate.NewDetectionStore(t.TempDir()), detectionship.Config{
+		AgentID: agentID, EngagementID: shared.ID("eng-1"), Token: token,
+		Now: time.Now, Retry: func(error, uint) (bool, time.Duration) { return false, 0 },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivered, err := shipper.DeliverOnce(context.Background())
+	if err != nil || !delivered {
+		t.Fatalf("DeliverOnce delivered=%v err=%v", delivered, err)
+	}
+
+	tenantCtx := shared.WithTenant(context.Background(), enrolTenant)
+	stored, err := records.ListDetections(tenantCtx, "eng-1")
+	if err != nil || len(stored) != 2 {
+		t.Fatalf("stored detections=%d err=%v", len(stored), err)
+	}
+	keys, err := keyStore.ListByAgent(tenantCtx, agentID)
+	if err != nil || len(keys) != 1 || keys[0].Purpose != fleetagent.PurposeDetectionBatch {
+		t.Fatalf("registered keys=%#v err=%v", keys, err)
+	}
+	stats, err := durable.Stats(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, lane := range stats.Priorities {
+		if lane.Priority == fleetagent.PriorityP1 && lane.Records != 0 {
+			t.Fatalf("delivered detection WAL still has %d records", lane.Records)
+		}
+	}
+}

--- a/internal/domain/fleetagent/batch.go
+++ b/internal/domain/fleetagent/batch.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
@@ -30,6 +31,30 @@ const batchSep = "\x1e"
 type DetectionRef struct {
 	ID            shared.ID
 	ContentSHA256 string
+}
+
+// DetectionBatchItem is one detection body covered by an AgentBatch ref. It lives beside the batch
+// contract so the agent transport and control-plane ingest share the exact same wire shape without an
+// infrastructure package importing a server-side use case. AssetID is explicit because the asset is
+// part of DetectionContentHash and must therefore be verified under the batch signature.
+type DetectionBatchItem struct {
+	ID        shared.ID
+	Detection detection.Detection
+	AssetID   shared.ID
+}
+
+// Validate checks the item before it is signed or admitted by the control plane.
+func (i DetectionBatchItem) Validate() error {
+	if i.ID.IsZero() {
+		return fmt.Errorf("%w: detection batch item has no id", shared.ErrValidation)
+	}
+	if i.AssetID.IsZero() {
+		return fmt.Errorf("%w: detection batch item %s has no asset", shared.ErrValidation, i.ID)
+	}
+	if err := i.Detection.Validate(); err != nil {
+		return fmt.Errorf("%w: detection batch item %s is malformed: %v", shared.ErrValidation, i.ID, err)
+	}
+	return nil
 }
 
 // AgentBatch is a sequenced, signed set of detections an agent shipped to the control plane (#423). The
@@ -75,6 +100,7 @@ func (b AgentBatch) Validate() error {
 	if len(b.Detections) == 0 {
 		return fmt.Errorf("%w: batch carries no detections", shared.ErrValidation)
 	}
+	seen := make(map[shared.ID]struct{}, len(b.Detections))
 	for i, ref := range b.Detections {
 		if ref.ID == "" {
 			return fmt.Errorf("%w: batch detection[%d] has no id", shared.ErrValidation, i)
@@ -82,6 +108,10 @@ func (b AgentBatch) Validate() error {
 		if ref.ContentSHA256 == "" {
 			return fmt.Errorf("%w: batch detection[%d] has no content digest", shared.ErrValidation, i)
 		}
+		if _, duplicate := seen[ref.ID]; duplicate {
+			return fmt.Errorf("%w: batch repeats detection id %s", shared.ErrValidation, ref.ID)
+		}
+		seen[ref.ID] = struct{}{}
 	}
 	return nil
 }

--- a/internal/domain/fleetagent/batch.go
+++ b/internal/domain/fleetagent/batch.go
@@ -52,7 +52,7 @@ func (i DetectionBatchItem) Validate() error {
 		return fmt.Errorf("%w: detection batch item %s has no asset", shared.ErrValidation, i.ID)
 	}
 	if err := i.Detection.Validate(); err != nil {
-		return fmt.Errorf("%w: detection batch item %s is malformed: %v", shared.ErrValidation, i.ID, err)
+		return fmt.Errorf("detection batch item %s is malformed: %w", i.ID, err)
 	}
 	return nil
 }

--- a/internal/domain/fleetagent/batch_test.go
+++ b/internal/domain/fleetagent/batch_test.go
@@ -84,6 +84,7 @@ func TestBatchValidate(t *testing.T) {
 		"no detections": {AgentID: "a", EngagementID: "e", Sequence: 1, KeyID: "k"},
 		"empty id":      {AgentID: "a", EngagementID: "e", Sequence: 1, KeyID: "k", Detections: []DetectionRef{{ContentSHA256: "h"}}},
 		"empty content": {AgentID: "a", EngagementID: "e", Sequence: 1, KeyID: "k", Detections: []DetectionRef{{ID: "d"}}},
+		"duplicate id":  {AgentID: "a", EngagementID: "e", Sequence: 1, KeyID: "k", Detections: []DetectionRef{{ID: "d", ContentSHA256: "h"}, {ID: "d", ContentSHA256: "h"}}},
 	}
 	for name, b := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/infrastructure/agentstate/detection.go
+++ b/internal/infrastructure/agentstate/detection.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
-	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectionship"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/fssecurity"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 const detectionStateFile = "detection-transport.json"
@@ -27,27 +27,27 @@ func NewDetectionStore(dir string) *DetectionStore {
 
 // Load returns ok=false only when no state has been created yet. Corrupt or unreadable state fails
 // closed so an in-flight sequence or signing identity is never silently discarded.
-func (s *DetectionStore) Load() (detectionship.State, bool, error) {
+func (s *DetectionStore) Load() (ports.DetectionDeliveryState, bool, error) {
 	body, err := os.ReadFile(s.path)
 	if errors.Is(err, fs.ErrNotExist) {
-		return detectionship.State{}, false, nil
+		return ports.DetectionDeliveryState{}, false, nil
 	}
 	if err != nil {
-		return detectionship.State{}, false, fmt.Errorf("read detection transport state: %w", err)
+		return ports.DetectionDeliveryState{}, false, fmt.Errorf("read detection transport state: %w", err)
 	}
-	var state detectionship.State
+	var state ports.DetectionDeliveryState
 	if err := json.Unmarshal(body, &state); err != nil {
-		return detectionship.State{}, false, fmt.Errorf("decode detection transport state: %w", err)
+		return ports.DetectionDeliveryState{}, false, fmt.Errorf("decode detection transport state: %w", err)
 	}
 	if err := state.Validate(); err != nil {
-		return detectionship.State{}, false, err
+		return ports.DetectionDeliveryState{}, false, err
 	}
 	return state, true, nil
 }
 
 // Save writes the complete state with 0600 permissions. The file contains an Ed25519 private key and
 // must be treated with the same protection as the long-lived fleet credential.
-func (s *DetectionStore) Save(state detectionship.State) error {
+func (s *DetectionStore) Save(state ports.DetectionDeliveryState) error {
 	if err := state.Validate(); err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func writeDetectionState(path string, body []byte) error {
 		_ = os.Remove(tmpName)
 		return err
 	}
-	if fleetclient.SecretModeEnforced() {
+	if fssecurity.UnixModeEnforced() {
 		info, err := os.Stat(path)
 		if err != nil {
 			return err
@@ -121,4 +121,4 @@ func writeDetectionState(path string, body []byte) error {
 	return nil
 }
 
-var _ detectionship.StateStore = (*DetectionStore)(nil)
+var _ ports.DetectionStateStore = (*DetectionStore)(nil)

--- a/internal/infrastructure/agentstate/detection.go
+++ b/internal/infrastructure/agentstate/detection.go
@@ -1,0 +1,124 @@
+// Package agentstate persists small agent-control records which are separate from the append-only
+// telemetry WAL.
+package agentstate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectionship"
+)
+
+const detectionStateFile = "detection-transport.json"
+
+// DetectionStore persists the signing private key and crash-recovery batch coordinate under the
+// service-owned state directory.
+type DetectionStore struct{ path string }
+
+// NewDetectionStore constructs a store rooted at the agent state directory.
+func NewDetectionStore(dir string) *DetectionStore {
+	return &DetectionStore{path: filepath.Join(dir, detectionStateFile)}
+}
+
+// Load returns ok=false only when no state has been created yet. Corrupt or unreadable state fails
+// closed so an in-flight sequence or signing identity is never silently discarded.
+func (s *DetectionStore) Load() (detectionship.State, bool, error) {
+	body, err := os.ReadFile(s.path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return detectionship.State{}, false, nil
+	}
+	if err != nil {
+		return detectionship.State{}, false, fmt.Errorf("read detection transport state: %w", err)
+	}
+	var state detectionship.State
+	if err := json.Unmarshal(body, &state); err != nil {
+		return detectionship.State{}, false, fmt.Errorf("decode detection transport state: %w", err)
+	}
+	if err := state.Validate(); err != nil {
+		return detectionship.State{}, false, err
+	}
+	return state, true, nil
+}
+
+// Save writes the complete state with 0600 permissions. The file contains an Ed25519 private key and
+// must be treated with the same protection as the long-lived fleet credential.
+func (s *DetectionStore) Save(state detectionship.State) error {
+	if err := state.Validate(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create agent state directory: %w", err)
+	}
+	body, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode detection transport state: %w", err)
+	}
+	if err := writeDetectionState(s.path, body); err != nil {
+		return fmt.Errorf("write detection transport state: %w", err)
+	}
+	return nil
+}
+
+// writeDetectionState syncs a complete replacement before publishing it. A crash can therefore leave
+// either the old state or the new state at the canonical path, but never a truncated JSON document
+// that loses an in-flight batch coordinate. The temp file is in the same directory so Rename is the
+// atomic publication boundary; syncing that directory makes the renamed entry durable on Unix hosts.
+func writeDetectionState(path string, body []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".detection-transport-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		cleanup()
+		return err
+	}
+	if _, err := tmp.Write(body); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if fleetclient.SecretModeEnforced() {
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			return fmt.Errorf("detection state has mode %v, want 0600", got)
+		}
+		dir, err := os.Open(filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		if err := dir.Sync(); err != nil {
+			_ = dir.Close()
+			return err
+		}
+		if err := dir.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var _ detectionship.StateStore = (*DetectionStore)(nil)

--- a/internal/infrastructure/agentstate/detection_test.go
+++ b/internal/infrastructure/agentstate/detection_test.go
@@ -9,16 +9,17 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
-	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
-	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectionship"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/fssecurity"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 func TestDetectionStoreRoundTripsSecretStateAt0600(t *testing.T) {
 	dir := t.TempDir()
 	store := NewDetectionStore(dir)
 	key := testLocalKey(t)
-	want := detectionship.State{Version: 1, NextSequence: 3, Key: &key, RegisteredKeyID: key.Key.KeyID,
-		Pending: &detectionship.PendingBatch{Sequence: 3, Epoch: 2, Through: 7, EventIDs: []shared.ID{"det-6", "det-7"}}}
+	want := ports.DetectionDeliveryState{Version: 1, NextSequence: 3, Key: &key, RegisteredKeyID: key.Key.KeyID,
+		Pending: &ports.DetectionPendingBatch{EngagementID: "eng-1", Sequence: 3, Epoch: 2, Through: 7,
+			EventIDs: []shared.ID{"det-6", "det-7"}}}
 	if err := store.Save(want); err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +42,7 @@ func TestDetectionStoreRoundTripsSecretStateAt0600(t *testing.T) {
 	if err != nil || !ok || got.NextSequence != 4 || got.Pending != nil {
 		t.Fatalf("replacement state = %#v ok=%v err=%v", got, ok, err)
 	}
-	if fleetclient.SecretModeEnforced() {
+	if fssecurity.UnixModeEnforced() {
 		info, err := os.Stat(filepath.Join(dir, detectionStateFile))
 		if err != nil {
 			t.Fatal(err)
@@ -68,12 +69,12 @@ func TestDetectionStoreDistinguishesMissingAndCorruptState(t *testing.T) {
 
 func TestDetectionStoreRefusesInvalidState(t *testing.T) {
 	store := NewDetectionStore(t.TempDir())
-	if err := store.Save(detectionship.State{}); err == nil {
+	if err := store.Save(ports.DetectionDeliveryState{}); err == nil {
 		t.Fatal("invalid zero state persisted")
 	}
 }
 
-func testLocalKey(t *testing.T) detectionship.LocalSigningKey {
+func testLocalKey(t *testing.T) ports.DetectionSigningKeyState {
 	t.Helper()
 	pub, privateKey, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -84,5 +85,5 @@ func testLocalKey(t *testing.T) detectionship.LocalSigningKey {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return detectionship.LocalSigningKey{Key: key, PrivateKey: privateKey}
+	return ports.DetectionSigningKeyState{Key: key, PrivateKey: privateKey}
 }

--- a/internal/infrastructure/agentstate/detection_test.go
+++ b/internal/infrastructure/agentstate/detection_test.go
@@ -1,0 +1,88 @@
+package agentstate
+
+import (
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectionship"
+)
+
+func TestDetectionStoreRoundTripsSecretStateAt0600(t *testing.T) {
+	dir := t.TempDir()
+	store := NewDetectionStore(dir)
+	key := testLocalKey(t)
+	want := detectionship.State{Version: 1, NextSequence: 3, Key: &key, RegisteredKeyID: key.Key.KeyID,
+		Pending: &detectionship.PendingBatch{Sequence: 3, Epoch: 2, Through: 7, EventIDs: []shared.ID{"det-6", "det-7"}}}
+	if err := store.Save(want); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := store.Load()
+	if err != nil || !ok {
+		t.Fatalf("Load ok=%v err=%v", ok, err)
+	}
+	if got.RegisteredKeyID != want.RegisteredKeyID || got.NextSequence != 3 || got.Pending == nil || got.Pending.Through != 7 {
+		t.Fatalf("round trip = %#v", got)
+	}
+	if string(got.Key.PrivateKey) != string(want.Key.PrivateKey) {
+		t.Fatal("private key did not round-trip")
+	}
+	want.NextSequence = 4
+	want.Pending = nil
+	if err := store.Save(want); err != nil {
+		t.Fatalf("replace state: %v", err)
+	}
+	got, ok, err = store.Load()
+	if err != nil || !ok || got.NextSequence != 4 || got.Pending != nil {
+		t.Fatalf("replacement state = %#v ok=%v err=%v", got, ok, err)
+	}
+	if fleetclient.SecretModeEnforced() {
+		info, err := os.Stat(filepath.Join(dir, detectionStateFile))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotMode := info.Mode().Perm(); gotMode != 0o600 {
+			t.Fatalf("state mode = %v, want 0600", gotMode)
+		}
+	}
+}
+
+func TestDetectionStoreDistinguishesMissingAndCorruptState(t *testing.T) {
+	dir := t.TempDir()
+	store := NewDetectionStore(dir)
+	if _, ok, err := store.Load(); err != nil || ok {
+		t.Fatalf("missing state ok=%v err=%v", ok, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, detectionStateFile), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := store.Load(); err == nil || ok {
+		t.Fatalf("corrupt state ok=%v err=%v", ok, err)
+	}
+}
+
+func TestDetectionStoreRefusesInvalidState(t *testing.T) {
+	store := NewDetectionStore(t.TempDir())
+	if err := store.Save(detectionship.State{}); err == nil {
+		t.Fatal("invalid zero state persisted")
+	}
+}
+
+func testLocalKey(t *testing.T) detectionship.LocalSigningKey {
+	t.Helper()
+	pub, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	key, err := fleetagent.NewSigningKey("agent-1", fleetagent.PurposeDetectionBatch, pub, now.Add(-time.Hour), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return detectionship.LocalSigningKey{Key: key, PrivateKey: privateKey}
+}

--- a/internal/infrastructure/fleetclient/client.go
+++ b/internal/infrastructure/fleetclient/client.go
@@ -7,13 +7,17 @@ package fleetclient
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 )
 
 const protoHeader = "X-Synapse-Fleet-Proto"
@@ -26,6 +30,52 @@ const maxResponseBytes = 8 << 20
 type Client struct {
 	baseURL string
 	http    *http.Client
+}
+
+// HTTPError preserves the response metadata the durable delivery loop needs to distinguish retryable
+// backpressure/server failures from permanent 4xx failures and a revoked signing key. Body is a bounded,
+// trimmed diagnostic snippet and must never contain the bearer credential (headers are not copied).
+type HTTPError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	RetryAfter string
+	Body       string
+}
+
+// NetworkError distinguishes a request that never received an HTTP response from a permanent local
+// validation/state failure. Durable shippers may retry it with bounded jitter.
+type NetworkError struct {
+	Method string
+	Path   string
+	Err    error
+}
+
+func (e *NetworkError) Error() string {
+	return fmt.Sprintf("fleetclient: %s %s: %v", e.Method, e.Path, e.Err)
+}
+func (e *NetworkError) Unwrap() error { return e.Err }
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("fleetclient: %s %s: status %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+}
+
+// ResponseStatus lets delivery use cases classify the response without depending on this adapter.
+func (e *HTTPError) ResponseStatus() (int, string) { return e.StatusCode, e.RetryAfter }
+
+// HTTPStatus returns the status metadata carried by an HTTPError.
+func HTTPStatus(err error) (status int, retryAfter string, ok bool) {
+	var target *HTTPError
+	if !errors.As(err, &target) {
+		return 0, "", false
+	}
+	return target.StatusCode, target.RetryAfter, true
+}
+
+// IsNetworkError reports whether the request failed before an HTTP response was available.
+func IsNetworkError(err error) bool {
+	var target *NetworkError
+	return errors.As(err, &target)
 }
 
 // New builds a client for baseURL (e.g. https://control-plane). timeout bounds each request.
@@ -119,6 +169,28 @@ func (c *Client) SendHostInventory(ctx context.Context, token string, inv any) e
 	return c.do(ctx, http.MethodPost, "/api/v1/fleet/inventory/host", token, inv, nil)
 }
 
+// RegisterDetectionKey registers an agent-owned detection signing key with proof-of-possession. The
+// private key never enters this adapter; only the public lifecycle record and its PoP signature cross
+// the wire. Registration is idempotent server-side.
+func (c *Client) RegisterDetectionKey(ctx context.Context, token string, key fleetagent.AgentSigningKey, proof string) error {
+	body := map[string]any{
+		"public_key": base64.StdEncoding.EncodeToString(key.PublicKey),
+		"purpose":    string(key.Purpose), "not_before": key.NotBefore, "not_after": key.NotAfter,
+		"proof": proof,
+	}
+	return c.do(ctx, http.MethodPost, "/api/v1/fleet/keys", token, body, nil)
+}
+
+// SendDetectionBatch posts one signed detection batch. A 2xx response means the complete membership was
+// durably admitted (or idempotently skipped), which is the point at which the caller may ACK its WAL.
+func (c *Client) SendDetectionBatch(ctx context.Context, token string, batch fleetagent.AgentBatch, items []fleetagent.DetectionBatchItem) error {
+	body := struct {
+		Batch fleetagent.AgentBatch           `json:"batch"`
+		Items []fleetagent.DetectionBatchItem `json:"items"`
+	}{Batch: batch, Items: items}
+	return c.do(ctx, http.MethodPost, "/api/v1/fleet/detections", token, body, nil)
+}
+
 func (c *Client) do(ctx context.Context, method, path, token string, body, out any) error {
 	var reader io.Reader
 	if body != nil {
@@ -139,12 +211,13 @@ func (c *Client) do(ctx context.Context, method, path, token string, body, out a
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return fmt.Errorf("fleetclient: %s %s: %w", method, path, err)
+		return &NetworkError{Method: method, Path: path, Err: err}
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return fmt.Errorf("fleetclient: %s %s: status %d: %s", method, path, resp.StatusCode, string(snippet))
+		return &HTTPError{Method: method, Path: path, StatusCode: resp.StatusCode,
+			RetryAfter: resp.Header.Get("Retry-After"), Body: strings.TrimSpace(string(snippet))}
 	}
 	if out != nil {
 		// Cap the decoded body: Timeout bounds time, not size, and the control plane is not fully

--- a/internal/infrastructure/fleetclient/client.go
+++ b/internal/infrastructure/fleetclient/client.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 const protoHeader = "X-Synapse-Fleet-Proto"
@@ -229,3 +230,5 @@ func (c *Client) do(ctx context.Context, method, path, token string, body, out a
 	}
 	return nil
 }
+
+var _ ports.DetectionTransport = (*Client)(nil)

--- a/internal/infrastructure/fleetclient/client_test.go
+++ b/internal/infrastructure/fleetclient/client_test.go
@@ -2,11 +2,17 @@ package fleetclient
 
 import (
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
 func TestClientRoundTrips(t *testing.T) {
@@ -79,11 +85,103 @@ func TestClientRoundTrips(t *testing.T) {
 
 func TestClientNon2xxIsError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "7")
 		http.Error(w, "boom", http.StatusInternalServerError)
 	}))
 	t.Cleanup(srv.Close)
 	c := New(srv.URL, 5*time.Second)
 	if _, err := c.Heartbeat(context.Background(), "t", EnrolRequest{}); err == nil {
 		t.Fatalf("a 500 must surface as an error")
+	} else if status, retryAfter, ok := HTTPStatus(err); !ok || status != 500 || retryAfter != "7" {
+		t.Fatalf("HTTP metadata = status=%d retry-after=%q ok=%v err=%v", status, retryAfter, ok, err)
+	}
+}
+
+func TestDetectionKeyAndBatchWireShape(t *testing.T) {
+	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	pub, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := fleetagent.NewSigningKey("agent-1", fleetagent.PurposeDetectionBatch, pub, now.Add(-time.Minute), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof := fleetagent.ProveKeyPossession(privateKey, key)
+	event := detection.Event{Class: detection.ClassProcess, At: now, Host: "asset-1",
+		Process: &detection.ProcessEvent{PID: 42, PPID: 1, Comm: "curl"}}
+	value := detection.Detection{RuleID: "proc.curl", RuleVersion: 1, Class: detection.ClassProcess,
+		Severity: shared.SeverityHigh, HostID: "asset-1", AgentID: "agent-1",
+		Evidence: []detection.Event{event}, ObservedCount: 1, Observed: now}
+	item := fleetagent.DetectionBatchItem{ID: "det-1", Detection: value, AssetID: "asset-1"}
+	body, _ := json.Marshal(value)
+	batch := fleetagent.AgentBatch{AgentID: "agent-1", EngagementID: "eng-1", Sequence: 1, KeyID: key.KeyID,
+		Detections: []fleetagent.DetectionRef{{ID: item.ID, ContentSHA256: fleetagent.DetectionContentHash(body, item.AssetID)}}}
+	batch.Signature = fleetagent.SignBatch(privateKey, batch)
+
+	var keyCalls, batchCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			t.Errorf("authorization = %q", r.Header.Get("Authorization"))
+		}
+		switch r.URL.Path {
+		case "/api/v1/fleet/keys":
+			keyCalls++
+			var request struct {
+				PublicKey string    `json:"public_key"`
+				Purpose   string    `json:"purpose"`
+				NotBefore time.Time `json:"not_before"`
+				NotAfter  time.Time `json:"not_after"`
+				Proof     string    `json:"proof"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Error(err)
+			}
+			if request.Purpose != string(fleetagent.PurposeDetectionBatch) || request.Proof != proof || request.PublicKey == "" || !request.NotAfter.Equal(key.NotAfter) {
+				t.Errorf("key registration = %#v", request)
+			}
+			w.WriteHeader(http.StatusCreated)
+		case "/api/v1/fleet/detections":
+			batchCalls++
+			var request struct {
+				Batch fleetagent.AgentBatch           `json:"batch"`
+				Items []fleetagent.DetectionBatchItem `json:"items"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Error(err)
+			}
+			if err := fleetagent.VerifyBatch(pub, request.Batch); err != nil || len(request.Items) != 1 || request.Items[0].ID != item.ID {
+				t.Errorf("detection request batch=%#v items=%#v verify=%v", request.Batch, request.Items, err)
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	client := New(srv.URL, time.Second)
+	if err := client.RegisterDetectionKey(context.Background(), "token", key, proof); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.SendDetectionBatch(context.Background(), "token", batch, []fleetagent.DetectionBatchItem{item}); err != nil {
+		t.Fatal(err)
+	}
+	if keyCalls != 1 || batchCalls != 1 {
+		t.Fatalf("key calls=%d batch calls=%d", keyCalls, batchCalls)
+	}
+}
+
+func TestNetworkFailureRetainsTypedCause(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	client := New(url, 100*time.Millisecond)
+	_, err := client.Heartbeat(context.Background(), "token", EnrolRequest{})
+	if err == nil || !IsNetworkError(err) {
+		t.Fatalf("network error not classified: %v", err)
+	}
+	var netErr *NetworkError
+	if !errors.As(err, &netErr) || netErr.Path != "/api/v1/fleet/heartbeat" {
+		t.Fatalf("network error metadata = %#v", netErr)
 	}
 }

--- a/internal/infrastructure/fleetclient/credential.go
+++ b/internal/infrastructure/fleetclient/credential.go
@@ -10,8 +10,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/platform/fssecurity"
 )
 
 // ValidateControlPlaneURL refuses a cleartext control-plane URL so the bearer credential cannot
@@ -107,7 +108,7 @@ func WriteSecret(path string, data []byte, mode os.FileMode) error {
 	if err := os.Chmod(path, mode); err != nil {
 		return err
 	}
-	if !SecretModeEnforced() {
+	if !fssecurity.UnixModeEnforced() {
 		// Windows does not implement Unix permission bits: os.Chmod only toggles the read-only
 		// attribute, so the mode above is NOT the protection it looks like. Verifying it here would
 		// fail on a platform where the guarantee simply does not exist, and asserting it anyway would
@@ -130,12 +131,6 @@ func WriteSecret(path string, data []byte, mode os.FileMode) error {
 	}
 	return nil
 }
-
-// SecretModeEnforced reports whether this platform enforces Unix permission bits on a file.
-//
-// It is false on Windows, where os.Chmod only toggles the read-only attribute. Callers use it to
-// state the guarantee they actually have rather than the one they wrote down.
-func SecretModeEnforced() bool { return runtime.GOOS != "windows" }
 
 // ReadEnrolTokenFile reads a one-time enrolment token from path, treating an ABSENT file as "no token
 // supplied" rather than as an error.

--- a/internal/infrastructure/fleetclient/credential_test.go
+++ b/internal/infrastructure/fleetclient/credential_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/platform/fssecurity"
 )
 
 type fakeEnroller struct {
@@ -45,8 +47,8 @@ func TestEnsureEnrolledFirstRunThenReuse(t *testing.T) {
 		t.Fatalf("credential must be persisted: %v", err)
 	}
 	// The 0600 guarantee is a Unix one. On Windows os.Chmod only toggles the read-only attribute, so
-	// asserting the bits there would assert something no platform enforces — see SecretModeEnforced.
-	if SecretModeEnforced() && info.Mode().Perm() != 0o600 {
+	// asserting the bits there would assert something no platform enforces.
+	if fssecurity.UnixModeEnforced() && info.Mode().Perm() != 0o600 {
 		t.Fatalf("credential must be persisted 0600, got %v", info.Mode().Perm())
 	}
 	if _, err := os.Stat(store.keyPath()); err != nil {

--- a/internal/infrastructure/spool/spool.go
+++ b/internal/infrastructure/spool/spool.go
@@ -434,6 +434,23 @@ func (s *Spool) Stats(ctx context.Context) (ports.SpoolStats, error) {
 		stats.TotalRecords += lane.Records
 		stats.Priorities = append(stats.Priorities, lane)
 	}
+	for key, highest := range s.state.ACK {
+		priority, epoch, err := parseACKKey(key)
+		if err != nil {
+			return ports.SpoolStats{}, fmt.Errorf("read spool ACK history: %w", err)
+		}
+		if highest > 0 {
+			stats.EpochACKs = append(stats.EpochACKs, ports.SpoolEpochACK{
+				Priority: priority, Epoch: epoch, HighestACKed: highest,
+			})
+		}
+	}
+	sort.Slice(stats.EpochACKs, func(i, j int) bool {
+		if stats.EpochACKs[i].Priority != stats.EpochACKs[j].Priority {
+			return stats.EpochACKs[i].Priority < stats.EpochACKs[j].Priority
+		}
+		return stats.EpochACKs[i].Epoch < stats.EpochACKs[j].Epoch
+	})
 	return stats, nil
 }
 

--- a/internal/infrastructure/spool/spool.go
+++ b/internal/infrastructure/spool/spool.go
@@ -281,9 +281,16 @@ func (s *Spool) Peek(ctx context.Context, req ports.PeekSpoolRequest) ([]ports.S
 	if maxRecords < 0 || maxBytes < 0 {
 		return nil, fmt.Errorf("%w: negative peek limit", shared.ErrValidation)
 	}
+	firstPriority, lastPriority := fleetagent.PriorityP0, fleetagent.PriorityP3
+	if req.OnlyPriority != nil {
+		if !req.OnlyPriority.Valid() {
+			return nil, fmt.Errorf("%w: invalid peek priority %d", shared.ErrValidation, int(*req.OnlyPriority))
+		}
+		firstPriority, lastPriority = *req.OnlyPriority, *req.OnlyPriority
+	}
 	result := make([]ports.SpoolRecord, 0, min(maxRecords, 64))
 	var bytesRead int64
-	for priority := fleetagent.PriorityP0; priority <= fleetagent.PriorityP3; priority++ {
+	for priority := firstPriority; priority <= lastPriority; priority++ {
 		for _, ref := range s.records[priority] {
 			if len(result) >= maxRecords {
 				return result, nil

--- a/internal/infrastructure/spool/spool_test.go
+++ b/internal/infrastructure/spool/spool_test.go
@@ -198,6 +198,43 @@ func TestACKSurvivesRestartAndReclaimsSegment(t *testing.T) {
 	}
 }
 
+func TestStatsRetainsACKForPastEpochAfterBootChange(t *testing.T) {
+	cfg := testConfig(t)
+	s, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivered := mustEnqueue(t, s, testItem(fleetagent.PriorityP1, "delivered", 64))
+	if _, err := s.Ack(context.Background(), ports.SpoolACK{
+		Priority: fleetagent.PriorityP1, Epoch: delivered.Epoch, Through: delivered.Sequence,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg.Boot = "boot-after-ack"
+	reopened, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	stats, err := reopened.Stats(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Priorities[fleetagent.PriorityP1].CurrentEpoch <= delivered.Epoch {
+		t.Fatalf("boot did not advance epoch: stats=%#v delivered=%#v", stats.Priorities[fleetagent.PriorityP1], delivered)
+	}
+	for _, ack := range stats.EpochACKs {
+		if ack.Priority == fleetagent.PriorityP1 && ack.Epoch == delivered.Epoch && ack.HighestACKed == delivered.Sequence {
+			return
+		}
+	}
+	t.Fatalf("past-epoch ACK missing after reboot: %#v", stats.EpochACKs)
+}
+
 func TestDirectoryHasExclusiveProcessOwnership(t *testing.T) {
 	cfg := testConfig(t)
 	first, err := Open(cfg)

--- a/internal/infrastructure/spool/spool_test.go
+++ b/internal/infrastructure/spool/spool_test.go
@@ -33,6 +33,24 @@ func TestSpoolPriorityDrainAndLaneOrdering(t *testing.T) {
 	}
 }
 
+func TestPeekCanIsolateDetectionPriority(t *testing.T) {
+	s := mustOpen(t, testConfig(t))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP0, "coverage", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP1, "detection-1", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP1, "detection-2", 32))
+	mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "telemetry", 32))
+	priority := fleetagent.PriorityP1
+	records, err := s.Peek(context.Background(), ports.PeekSpoolRequest{MaxRecords: 8, MaxBytes: 1024, OnlyPriority: &priority})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireIDs(t, records, "detection-1", "detection-2")
+	invalid := fleetagent.DeliveryPriority(99)
+	if _, err := s.Peek(context.Background(), ports.PeekSpoolRequest{OnlyPriority: &invalid}); err == nil {
+		t.Fatal("invalid isolated priority accepted")
+	}
+}
+
 func TestPeekBoundsAndAlwaysMakesProgress(t *testing.T) {
 	s := mustOpen(t, testConfig(t))
 	mustEnqueue(t, s, testItem(fleetagent.PriorityP3, "large", 4096))

--- a/internal/platform/fssecurity/fssecurity.go
+++ b/internal/platform/fssecurity/fssecurity.go
@@ -1,0 +1,8 @@
+// Package fssecurity exposes platform facts used when checking local secret-file protections.
+package fssecurity
+
+import "runtime"
+
+// UnixModeEnforced reports whether Unix permission bits provide a real access-control guarantee.
+// Windows os.Chmod only toggles a read-only attribute, so callers must rely on directory ACLs there.
+func UnixModeEnforced() bool { return runtime.GOOS != "windows" }

--- a/internal/usecase/fleet/detectionship/service.go
+++ b/internal/usecase/fleet/detectionship/service.go
@@ -1,0 +1,511 @@
+// Package detectionship drains confirmed detections from the durable P1 agent WAL into independently
+// signed detection batches. It owns the crash-safe batch sequence and key-rotation workflow; transport
+// and local-secret persistence remain ports supplied by the composition root.
+package detectionship
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	stateVersion        = 1
+	defaultKeyValidity  = 90 * 24 * time.Hour
+	defaultRotateBefore = 7 * 24 * time.Hour
+	defaultBatchRecords = 32
+	defaultBatchBytes   = int64(6 << 20)
+	defaultIdleInterval = time.Second
+)
+
+var (
+	// ErrSigningKeyRejected triggers one fail-closed key rotation for the current pending batch. A
+	// second rejection for the same sequence is permanent, preventing an invalid payload from causing
+	// an unbounded key-generation loop.
+	ErrSigningKeyRejected = errors.New("detection signing key rejected")
+	// ErrDeliveryState marks a local state/WAL disagreement. Guessing in this condition could ACK an
+	// unsent detection, so the shipper stops and leaves the WAL intact for operator recovery.
+	ErrDeliveryState = errors.New("detection delivery state inconsistent")
+)
+
+// Transport is the live agent-plane surface implemented by fleetclient.Client.
+type Transport interface {
+	RegisterDetectionKey(ctx context.Context, token string, key fleetagent.AgentSigningKey, proof string) error
+	SendDetectionBatch(ctx context.Context, token string, batch fleetagent.AgentBatch, items []fleetagent.DetectionBatchItem) error
+}
+
+// StateStore durably persists the private signing material and in-flight batch coordinate.
+type StateStore interface {
+	Load() (State, bool, error)
+	Save(State) error
+}
+
+// ResponseError is implemented by transports that preserve an HTTP status and Retry-After value.
+type ResponseError interface {
+	error
+	ResponseStatus() (status int, retryAfter string)
+}
+
+// RetryDecider classifies a transport failure. retry=false makes Run fail closed; retry=true waits for
+// delay without removing anything from the WAL.
+type RetryDecider func(err error, attempt uint) (retry bool, delay time.Duration)
+
+// LocalSigningKey is the private half of one purpose-bound agent key. It is a persistence DTO, not a
+// wire type: only Key.PublicKey and a proof produced from PrivateKey leave the host.
+type LocalSigningKey struct {
+	Key        fleetagent.AgentSigningKey
+	PrivateKey ed25519.PrivateKey
+}
+
+func (k LocalSigningKey) validate() error {
+	if err := k.Key.Validate(); err != nil {
+		return err
+	}
+	if len(k.PrivateKey) != ed25519.PrivateKeySize {
+		return fmt.Errorf("%w: local detection private key has invalid size", shared.ErrValidation)
+	}
+	canonicalPrivate := ed25519.NewKeyFromSeed(k.PrivateKey.Seed())
+	if !bytes.Equal(canonicalPrivate, k.PrivateKey) {
+		return fmt.Errorf("%w: local detection private key seed/public material is inconsistent", shared.ErrValidation)
+	}
+	derived, ok := k.PrivateKey.Public().(ed25519.PublicKey)
+	if !ok || !bytes.Equal(derived, k.Key.PublicKey) {
+		return fmt.Errorf("%w: local detection private key does not match its public key", shared.ErrValidation)
+	}
+	if k.Key.Purpose != fleetagent.PurposeDetectionBatch {
+		return fmt.Errorf("%w: local key has purpose %q, want detection-batch", shared.ErrValidation, k.Key.Purpose)
+	}
+	return nil
+}
+
+// PendingBatch is written before the network call. A restart rebuilds exactly this membership with the
+// same Sequence; if the response was lost, the server's SealOnce path makes the replay idempotent.
+type PendingBatch struct {
+	Sequence uint64
+	Epoch    uint64
+	Through  uint64
+	EventIDs []shared.ID
+}
+
+func (p PendingBatch) validate() error {
+	if p.Sequence == 0 || p.Epoch == 0 || p.Through == 0 || len(p.EventIDs) == 0 {
+		return fmt.Errorf("%w: pending detection batch has incomplete coordinates", shared.ErrValidation)
+	}
+	for _, id := range p.EventIDs {
+		if id.IsZero() {
+			return fmt.Errorf("%w: pending detection batch has an empty event id", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+// State is the complete secret-bearing agent-side detection transport state.
+type State struct {
+	Version         int
+	NextSequence    uint64
+	Key             *LocalSigningKey
+	RegisteredKeyID string
+	Pending         *PendingBatch
+}
+
+func initialState() State { return State{Version: stateVersion, NextSequence: 1} }
+
+// Validate rejects corrupt or tampered local state instead of silently minting a new identity and
+// abandoning an in-flight sequence.
+func (s State) Validate() error {
+	if s.Version != stateVersion || s.NextSequence == 0 {
+		return fmt.Errorf("%w: unsupported or incomplete detection delivery state", shared.ErrValidation)
+	}
+	if s.Key == nil && s.RegisteredKeyID != "" {
+		return fmt.Errorf("%w: registered key id exists without local key material", shared.ErrValidation)
+	}
+	if s.Key != nil {
+		if err := s.Key.validate(); err != nil {
+			return err
+		}
+		if s.RegisteredKeyID != "" && s.RegisteredKeyID != s.Key.Key.KeyID {
+			return fmt.Errorf("%w: registered key id does not match local key", shared.ErrValidation)
+		}
+	}
+	if s.Pending != nil {
+		if err := s.Pending.validate(); err != nil {
+			return err
+		}
+		if s.Pending.Sequence != s.NextSequence {
+			return fmt.Errorf("%w: pending sequence %d disagrees with next sequence %d", shared.ErrValidation, s.Pending.Sequence, s.NextSequence)
+		}
+	}
+	return nil
+}
+
+// Config binds one shipper to an enrolled agent and one engagement.
+type Config struct {
+	AgentID      shared.ID
+	EngagementID shared.ID
+	Token        string
+	KeyValidity  time.Duration
+	RotateBefore time.Duration
+	BatchRecords int
+	BatchBytes   int64
+	IdleInterval time.Duration
+	Now          func() time.Time
+	GenerateKey  func() (ed25519.PublicKey, ed25519.PrivateKey, error)
+	Retry        RetryDecider
+}
+
+func normalizeConfig(cfg Config) (Config, error) {
+	if cfg.AgentID.IsZero() || cfg.EngagementID.IsZero() || cfg.Token == "" {
+		return Config{}, fmt.Errorf("%w: detection shipper requires agent, engagement and credential", shared.ErrValidation)
+	}
+	if cfg.KeyValidity == 0 {
+		cfg.KeyValidity = defaultKeyValidity
+	}
+	if cfg.RotateBefore == 0 {
+		cfg.RotateBefore = defaultRotateBefore
+	}
+	if cfg.BatchRecords == 0 {
+		cfg.BatchRecords = defaultBatchRecords
+	}
+	if cfg.BatchBytes == 0 {
+		cfg.BatchBytes = defaultBatchBytes
+	}
+	if cfg.IdleInterval == 0 {
+		cfg.IdleInterval = defaultIdleInterval
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.GenerateKey == nil {
+		cfg.GenerateKey = func() (ed25519.PublicKey, ed25519.PrivateKey, error) {
+			return ed25519.GenerateKey(rand.Reader)
+		}
+	}
+	if cfg.Retry == nil {
+		return Config{}, fmt.Errorf("%w: detection shipper requires a retry classifier", shared.ErrValidation)
+	}
+	if cfg.KeyValidity <= 0 || cfg.KeyValidity > 364*24*time.Hour || cfg.RotateBefore <= 0 || cfg.RotateBefore >= cfg.KeyValidity {
+		return Config{}, fmt.Errorf("%w: invalid detection signing-key rotation window", shared.ErrValidation)
+	}
+	if cfg.BatchRecords < 1 || cfg.BatchBytes < 1 || cfg.IdleInterval <= 0 {
+		return Config{}, fmt.Errorf("%w: invalid detection batch or idle limit", shared.ErrValidation)
+	}
+	return cfg, nil
+}
+
+// Service drains one durable detection lane.
+type Service struct {
+	spool     ports.TelemetrySpool
+	transport Transport
+	store     StateStore
+	cfg       Config
+	state     State
+}
+
+// NewService loads and validates durable state before any key registration or network delivery.
+func NewService(spool ports.TelemetrySpool, transport Transport, store StateStore, cfg Config) (*Service, error) {
+	if spool == nil || transport == nil || store == nil {
+		return nil, fmt.Errorf("%w: detection shipper is missing a dependency", shared.ErrValidation)
+	}
+	normalized, err := normalizeConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	state, ok, err := store.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load detection delivery state: %w", err)
+	}
+	if !ok {
+		state = initialState()
+		if err := store.Save(state); err != nil {
+			return nil, fmt.Errorf("initialize detection delivery state: %w", err)
+		}
+	}
+	if err := state.Validate(); err != nil {
+		return nil, fmt.Errorf("load detection delivery state: %w", err)
+	}
+	if state.Key != nil && state.Key.Key.AgentID != normalized.AgentID {
+		return nil, fmt.Errorf("%w: local signing key belongs to agent %s, not %s", shared.ErrForbidden, state.Key.Key.AgentID, normalized.AgentID)
+	}
+	return &Service{spool: spool, transport: transport, store: store, cfg: normalized, state: state}, nil
+}
+
+// Run continuously drains detections. It retries only when the injected policy permits it and rotates
+// a rejected key at most once per pending sequence.
+func (s *Service) Run(ctx context.Context) error {
+	var attempt uint
+	var rotatedSequence uint64
+	for {
+		delivered, err := s.DeliverOnce(ctx)
+		if err == nil {
+			attempt, rotatedSequence = 0, 0
+			if delivered {
+				continue
+			}
+			if err := wait(ctx, s.cfg.IdleInterval); err != nil {
+				return err
+			}
+			continue
+		}
+		if errors.Is(err, ErrSigningKeyRejected) {
+			sequence := s.state.NextSequence
+			if rotatedSequence == sequence {
+				return fmt.Errorf("detection batch sequence %d rejected after key rotation: %w", sequence, err)
+			}
+			if err := s.forgetRejectedKey(); err != nil {
+				return err
+			}
+			rotatedSequence, attempt = sequence, 0
+			continue
+		}
+		retry, delay := s.cfg.Retry(err, attempt)
+		if !retry {
+			return err
+		}
+		attempt++
+		if err := wait(ctx, delay); err != nil {
+			return err
+		}
+	}
+}
+
+// DeliverOnce sends at most one batch. delivered=false,nil means the P1 lane is empty.
+func (s *Service) DeliverOnce(ctx context.Context) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if s.state.Pending != nil {
+		acked, err := s.pendingAlreadyACKed(ctx)
+		if err != nil {
+			return false, err
+		}
+		if acked {
+			return true, s.completePendingState()
+		}
+	}
+	if err := s.ensureKey(ctx); err != nil {
+		return false, err
+	}
+	records, err := s.recordsForBatch(ctx)
+	if err != nil || len(records) == 0 {
+		return false, err
+	}
+	items, refs, err := s.decodeRecords(records)
+	if err != nil {
+		return false, err
+	}
+	if s.state.Pending == nil {
+		pending := &PendingBatch{Sequence: s.state.NextSequence, Epoch: records[0].Position.Epoch,
+			Through: records[len(records)-1].Position.Sequence, EventIDs: make([]shared.ID, len(records))}
+		for i := range records {
+			pending.EventIDs[i] = records[i].EventID
+		}
+		next := s.state
+		next.Pending = pending
+		if err := s.persist(next); err != nil {
+			return false, fmt.Errorf("persist pending detection batch: %w", err)
+		}
+	}
+	batch := fleetagent.AgentBatch{AgentID: s.cfg.AgentID, EngagementID: s.cfg.EngagementID,
+		Sequence: s.state.Pending.Sequence, KeyID: s.state.Key.Key.KeyID, Detections: refs}
+	batch.Signature = fleetagent.SignBatch(s.state.Key.PrivateKey, batch)
+	if err := batch.Validate(); err != nil {
+		return false, err
+	}
+	if err := s.transport.SendDetectionBatch(ctx, s.cfg.Token, batch, items); err != nil {
+		if status, _, ok := responseStatus(err); ok && status == http.StatusForbidden {
+			return false, fmt.Errorf("%w: %v", ErrSigningKeyRejected, err)
+		}
+		return false, fmt.Errorf("send detection batch: %w", err)
+	}
+	if _, err := s.spool.Ack(ctx, ports.SpoolACK{Priority: fleetagent.PriorityP1,
+		Epoch: s.state.Pending.Epoch, Through: s.state.Pending.Through}); err != nil {
+		return false, fmt.Errorf("ack delivered detection WAL: %w", err)
+	}
+	if err := s.completePendingState(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *Service) ensureKey(ctx context.Context) error {
+	now := s.cfg.Now().UTC()
+	if s.state.Key != nil && s.state.RegisteredKeyID == s.state.Key.Key.KeyID &&
+		s.state.Key.Key.StatusAt(now) == fleetagent.KeyActive && now.Add(s.cfg.RotateBefore).Before(s.state.Key.Key.NotAfter) {
+		return nil
+	}
+	local := s.state.Key
+	if local == nil || local.Key.StatusAt(now) != fleetagent.KeyActive || !now.Add(s.cfg.RotateBefore).Before(local.Key.NotAfter) {
+		pub, privateKey, err := s.cfg.GenerateKey()
+		if err != nil {
+			return fmt.Errorf("generate detection signing key: %w", err)
+		}
+		key, err := fleetagent.NewSigningKey(s.cfg.AgentID, fleetagent.PurposeDetectionBatch, pub,
+			now.Add(-time.Minute), now.Add(s.cfg.KeyValidity))
+		if err != nil {
+			return err
+		}
+		local = &LocalSigningKey{Key: key, PrivateKey: privateKey}
+	}
+	proof := fleetagent.ProveKeyPossession(local.PrivateKey, local.Key)
+	if err := s.transport.RegisterDetectionKey(ctx, s.cfg.Token, local.Key, proof); err != nil {
+		return fmt.Errorf("register detection signing key: %w", err)
+	}
+	next := s.state
+	next.Key = local
+	next.RegisteredKeyID = local.Key.KeyID
+	return s.persist(next)
+}
+
+func (s *Service) recordsForBatch(ctx context.Context) ([]ports.SpoolRecord, error) {
+	priority := fleetagent.PriorityP1
+	maxRecords := s.cfg.BatchRecords
+	if s.state.Pending != nil && len(s.state.Pending.EventIDs) > maxRecords {
+		maxRecords = len(s.state.Pending.EventIDs)
+	}
+	records, err := s.spool.Peek(ctx, ports.PeekSpoolRequest{MaxRecords: maxRecords, MaxBytes: s.cfg.BatchBytes, OnlyPriority: &priority})
+	if err != nil {
+		return nil, fmt.Errorf("peek detection WAL: %w", err)
+	}
+	if s.state.Pending == nil {
+		if len(records) == 0 {
+			return nil, nil
+		}
+		epoch := records[0].Position.Epoch
+		end := len(records)
+		for i, record := range records {
+			if record.Position.Epoch != epoch {
+				end = i
+				break
+			}
+		}
+		return records[:end], nil
+	}
+	pending := s.state.Pending
+	if len(records) < len(pending.EventIDs) {
+		return nil, fmt.Errorf("%w: pending batch has %d records but WAL exposes %d", ErrDeliveryState, len(pending.EventIDs), len(records))
+	}
+	records = records[:len(pending.EventIDs)]
+	for i, record := range records {
+		if record.EventID != pending.EventIDs[i] || record.Position.Epoch != pending.Epoch ||
+			(i == len(records)-1 && record.Position.Sequence != pending.Through) {
+			return nil, fmt.Errorf("%w: pending membership no longer matches P1 WAL at index %d", ErrDeliveryState, i)
+		}
+	}
+	return records, nil
+}
+
+func (s *Service) decodeRecords(records []ports.SpoolRecord) ([]fleetagent.DetectionBatchItem, []fleetagent.DetectionRef, error) {
+	items := make([]fleetagent.DetectionBatchItem, 0, len(records))
+	refs := make([]fleetagent.DetectionRef, 0, len(records))
+	seen := make(map[shared.ID]string, len(records))
+	for _, record := range records {
+		if record.Kind != ports.SpoolRecordDetection || record.Position.Priority != fleetagent.PriorityP1 {
+			return nil, nil, fmt.Errorf("%w: P1 lane contains non-detection record %s", ErrDeliveryState, record.EventID)
+		}
+		var value detection.Detection
+		if err := json.Unmarshal(record.Payload, &value); err != nil {
+			return nil, nil, fmt.Errorf("decode spooled detection %s: %w", record.EventID, err)
+		}
+		item := fleetagent.DetectionBatchItem{ID: record.EventID, Detection: value, AssetID: value.HostID}
+		if err := item.Validate(); err != nil {
+			return nil, nil, err
+		}
+		if value.AgentID != s.cfg.AgentID {
+			return nil, nil, fmt.Errorf("%w: spooled detection %s belongs to agent %s, not %s", shared.ErrForbidden, record.EventID, value.AgentID, s.cfg.AgentID)
+		}
+		canonical, err := json.Marshal(value)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encode detection %s: %w", record.EventID, err)
+		}
+		digest := fleetagent.DetectionContentHash(canonical, item.AssetID)
+		if previous, duplicate := seen[record.EventID]; duplicate {
+			if previous != digest {
+				return nil, nil, fmt.Errorf("%w: repeated detection id %s has different content", ErrDeliveryState, record.EventID)
+			}
+			// Sink retries can append the same deterministic detection more than once. One signed
+			// item admits that content; ACKing through the pending WAL membership then removes all
+			// identical copies without sending a server-invalid batch with duplicate refs.
+			continue
+		}
+		seen[record.EventID] = digest
+		items = append(items, item)
+		refs = append(refs, fleetagent.DetectionRef{ID: record.EventID,
+			ContentSHA256: digest})
+	}
+	return items, refs, nil
+}
+
+func (s *Service) pendingAlreadyACKed(ctx context.Context) (bool, error) {
+	stats, err := s.spool.Stats(ctx)
+	if err != nil {
+		return false, fmt.Errorf("read detection WAL state: %w", err)
+	}
+	for _, lane := range stats.Priorities {
+		if lane.Priority == fleetagent.PriorityP1 && lane.CurrentEpoch == s.state.Pending.Epoch {
+			return lane.HighestACKed >= s.state.Pending.Through, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Service) completePendingState() error {
+	next := s.state
+	next.NextSequence = s.state.Pending.Sequence + 1
+	next.Pending = nil
+	if err := s.persist(next); err != nil {
+		return fmt.Errorf("commit delivered detection batch: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) forgetRejectedKey() error {
+	next := s.state
+	next.Key = nil
+	next.RegisteredKeyID = ""
+	if err := s.persist(next); err != nil {
+		return fmt.Errorf("rotate rejected detection signing key: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) persist(next State) error {
+	if err := next.Validate(); err != nil {
+		return err
+	}
+	if err := s.store.Save(next); err != nil {
+		return err
+	}
+	s.state = next
+	return nil
+}
+
+func responseStatus(err error) (int, string, bool) {
+	var responseErr ResponseError
+	if !errors.As(err, &responseErr) {
+		return 0, "", false
+	}
+	status, retryAfter := responseErr.ResponseStatus()
+	return status, retryAfter, true
+}
+
+func wait(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/usecase/fleet/detectionship/service.go
+++ b/internal/usecase/fleet/detectionship/service.go
@@ -4,7 +4,6 @@
 package detectionship
 
 import (
-	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -21,7 +20,6 @@ import (
 )
 
 const (
-	stateVersion        = 1
 	defaultKeyValidity  = 90 * 24 * time.Hour
 	defaultRotateBefore = 7 * 24 * time.Hour
 	defaultBatchRecords = 32
@@ -39,18 +37,6 @@ var (
 	ErrDeliveryState = errors.New("detection delivery state inconsistent")
 )
 
-// Transport is the live agent-plane surface implemented by fleetclient.Client.
-type Transport interface {
-	RegisterDetectionKey(ctx context.Context, token string, key fleetagent.AgentSigningKey, proof string) error
-	SendDetectionBatch(ctx context.Context, token string, batch fleetagent.AgentBatch, items []fleetagent.DetectionBatchItem) error
-}
-
-// StateStore durably persists the private signing material and in-flight batch coordinate.
-type StateStore interface {
-	Load() (State, bool, error)
-	Save(State) error
-}
-
 // ResponseError is implemented by transports that preserve an HTTP status and Retry-After value.
 type ResponseError interface {
 	error
@@ -61,92 +47,8 @@ type ResponseError interface {
 // delay without removing anything from the WAL.
 type RetryDecider func(err error, attempt uint) (retry bool, delay time.Duration)
 
-// LocalSigningKey is the private half of one purpose-bound agent key. It is a persistence DTO, not a
-// wire type: only Key.PublicKey and a proof produced from PrivateKey leave the host.
-type LocalSigningKey struct {
-	Key        fleetagent.AgentSigningKey
-	PrivateKey ed25519.PrivateKey
-}
-
-func (k LocalSigningKey) validate() error {
-	if err := k.Key.Validate(); err != nil {
-		return err
-	}
-	if len(k.PrivateKey) != ed25519.PrivateKeySize {
-		return fmt.Errorf("%w: local detection private key has invalid size", shared.ErrValidation)
-	}
-	canonicalPrivate := ed25519.NewKeyFromSeed(k.PrivateKey.Seed())
-	if !bytes.Equal(canonicalPrivate, k.PrivateKey) {
-		return fmt.Errorf("%w: local detection private key seed/public material is inconsistent", shared.ErrValidation)
-	}
-	derived, ok := k.PrivateKey.Public().(ed25519.PublicKey)
-	if !ok || !bytes.Equal(derived, k.Key.PublicKey) {
-		return fmt.Errorf("%w: local detection private key does not match its public key", shared.ErrValidation)
-	}
-	if k.Key.Purpose != fleetagent.PurposeDetectionBatch {
-		return fmt.Errorf("%w: local key has purpose %q, want detection-batch", shared.ErrValidation, k.Key.Purpose)
-	}
-	return nil
-}
-
-// PendingBatch is written before the network call. A restart rebuilds exactly this membership with the
-// same Sequence; if the response was lost, the server's SealOnce path makes the replay idempotent.
-type PendingBatch struct {
-	Sequence uint64
-	Epoch    uint64
-	Through  uint64
-	EventIDs []shared.ID
-}
-
-func (p PendingBatch) validate() error {
-	if p.Sequence == 0 || p.Epoch == 0 || p.Through == 0 || len(p.EventIDs) == 0 {
-		return fmt.Errorf("%w: pending detection batch has incomplete coordinates", shared.ErrValidation)
-	}
-	for _, id := range p.EventIDs {
-		if id.IsZero() {
-			return fmt.Errorf("%w: pending detection batch has an empty event id", shared.ErrValidation)
-		}
-	}
-	return nil
-}
-
-// State is the complete secret-bearing agent-side detection transport state.
-type State struct {
-	Version         int
-	NextSequence    uint64
-	Key             *LocalSigningKey
-	RegisteredKeyID string
-	Pending         *PendingBatch
-}
-
-func initialState() State { return State{Version: stateVersion, NextSequence: 1} }
-
-// Validate rejects corrupt or tampered local state instead of silently minting a new identity and
-// abandoning an in-flight sequence.
-func (s State) Validate() error {
-	if s.Version != stateVersion || s.NextSequence == 0 {
-		return fmt.Errorf("%w: unsupported or incomplete detection delivery state", shared.ErrValidation)
-	}
-	if s.Key == nil && s.RegisteredKeyID != "" {
-		return fmt.Errorf("%w: registered key id exists without local key material", shared.ErrValidation)
-	}
-	if s.Key != nil {
-		if err := s.Key.validate(); err != nil {
-			return err
-		}
-		if s.RegisteredKeyID != "" && s.RegisteredKeyID != s.Key.Key.KeyID {
-			return fmt.Errorf("%w: registered key id does not match local key", shared.ErrValidation)
-		}
-	}
-	if s.Pending != nil {
-		if err := s.Pending.validate(); err != nil {
-			return err
-		}
-		if s.Pending.Sequence != s.NextSequence {
-			return fmt.Errorf("%w: pending sequence %d disagrees with next sequence %d", shared.ErrValidation, s.Pending.Sequence, s.NextSequence)
-		}
-	}
-	return nil
+func initialState() ports.DetectionDeliveryState {
+	return ports.DetectionDeliveryState{Version: ports.DetectionDeliveryStateVersion, NextSequence: 1}
 }
 
 // Config binds one shipper to an enrolled agent and one engagement.
@@ -206,14 +108,14 @@ func normalizeConfig(cfg Config) (Config, error) {
 // Service drains one durable detection lane.
 type Service struct {
 	spool     ports.TelemetrySpool
-	transport Transport
-	store     StateStore
+	transport ports.DetectionTransport
+	store     ports.DetectionStateStore
 	cfg       Config
-	state     State
+	state     ports.DetectionDeliveryState
 }
 
 // NewService loads and validates durable state before any key registration or network delivery.
-func NewService(spool ports.TelemetrySpool, transport Transport, store StateStore, cfg Config) (*Service, error) {
+func NewService(spool ports.TelemetrySpool, transport ports.DetectionTransport, store ports.DetectionStateStore, cfg Config) (*Service, error) {
 	if spool == nil || transport == nil || store == nil {
 		return nil, fmt.Errorf("%w: detection shipper is missing a dependency", shared.ErrValidation)
 	}
@@ -236,6 +138,10 @@ func NewService(spool ports.TelemetrySpool, transport Transport, store StateStor
 	}
 	if state.Key != nil && state.Key.Key.AgentID != normalized.AgentID {
 		return nil, fmt.Errorf("%w: local signing key belongs to agent %s, not %s", shared.ErrForbidden, state.Key.Key.AgentID, normalized.AgentID)
+	}
+	if state.Pending != nil && state.Pending.EngagementID != normalized.EngagementID {
+		return nil, fmt.Errorf("%w: pending detection batch belongs to engagement %s, not %s",
+			shared.ErrForbidden, state.Pending.EngagementID, normalized.EngagementID)
 	}
 	return &Service{spool: spool, transport: transport, store: store, cfg: normalized, state: state}, nil
 }
@@ -285,6 +191,10 @@ func (s *Service) DeliverOnce(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	if s.state.Pending != nil {
+		if s.state.Pending.EngagementID != s.cfg.EngagementID {
+			return false, fmt.Errorf("%w: pending detection batch belongs to engagement %s, not %s",
+				shared.ErrForbidden, s.state.Pending.EngagementID, s.cfg.EngagementID)
+		}
 		acked, err := s.pendingAlreadyACKed(ctx)
 		if err != nil {
 			return false, err
@@ -305,7 +215,8 @@ func (s *Service) DeliverOnce(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	if s.state.Pending == nil {
-		pending := &PendingBatch{Sequence: s.state.NextSequence, Epoch: records[0].Position.Epoch,
+		pending := &ports.DetectionPendingBatch{EngagementID: s.cfg.EngagementID,
+			Sequence: s.state.NextSequence, Epoch: records[0].Position.Epoch,
 			Through: records[len(records)-1].Position.Sequence, EventIDs: make([]shared.ID, len(records))}
 		for i := range records {
 			pending.EventIDs[i] = records[i].EventID
@@ -316,7 +227,7 @@ func (s *Service) DeliverOnce(ctx context.Context) (bool, error) {
 			return false, fmt.Errorf("persist pending detection batch: %w", err)
 		}
 	}
-	batch := fleetagent.AgentBatch{AgentID: s.cfg.AgentID, EngagementID: s.cfg.EngagementID,
+	batch := fleetagent.AgentBatch{AgentID: s.cfg.AgentID, EngagementID: s.state.Pending.EngagementID,
 		Sequence: s.state.Pending.Sequence, KeyID: s.state.Key.Key.KeyID, Detections: refs}
 	batch.Signature = fleetagent.SignBatch(s.state.Key.PrivateKey, batch)
 	if err := batch.Validate(); err != nil {
@@ -355,7 +266,7 @@ func (s *Service) ensureKey(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		local = &LocalSigningKey{Key: key, PrivateKey: privateKey}
+		local = &ports.DetectionSigningKeyState{Key: key, PrivateKey: privateKey}
 	}
 	proof := fleetagent.ProveKeyPossession(local.PrivateKey, local.Key)
 	if err := s.transport.RegisterDetectionKey(ctx, s.cfg.Token, local.Key, proof); err != nil {
@@ -451,9 +362,9 @@ func (s *Service) pendingAlreadyACKed(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("read detection WAL state: %w", err)
 	}
-	for _, lane := range stats.Priorities {
-		if lane.Priority == fleetagent.PriorityP1 && lane.CurrentEpoch == s.state.Pending.Epoch {
-			return lane.HighestACKed >= s.state.Pending.Through, nil
+	for _, ack := range stats.EpochACKs {
+		if ack.Priority == fleetagent.PriorityP1 && ack.Epoch == s.state.Pending.Epoch {
+			return ack.HighestACKed >= s.state.Pending.Through, nil
 		}
 	}
 	return false, nil
@@ -479,7 +390,7 @@ func (s *Service) forgetRejectedKey() error {
 	return nil
 }
 
-func (s *Service) persist(next State) error {
+func (s *Service) persist(next ports.DetectionDeliveryState) error {
 	if err := next.Validate(); err != nil {
 		return err
 	}

--- a/internal/usecase/fleet/detectionship/service_test.go
+++ b/internal/usecase/fleet/detectionship/service_test.go
@@ -20,19 +20,19 @@ var shipNow = time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
 
 type memoryState struct {
 	mu      sync.Mutex
-	state   State
+	state   ports.DetectionDeliveryState
 	ok      bool
 	saves   int
 	saveErr error
 }
 
-func (m *memoryState) Load() (State, bool, error) {
+func (m *memoryState) Load() (ports.DetectionDeliveryState, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return cloneState(m.state), m.ok, nil
 }
 
-func (m *memoryState) Save(state State) error {
+func (m *memoryState) Save(state ports.DetectionDeliveryState) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.saveErr != nil {
@@ -43,19 +43,20 @@ func (m *memoryState) Save(state State) error {
 	return nil
 }
 
-func cloneState(in State) State {
+func cloneState(in ports.DetectionDeliveryState) ports.DetectionDeliveryState {
 	body, _ := json.Marshal(in)
-	var out State
+	var out ports.DetectionDeliveryState
 	_ = json.Unmarshal(body, &out)
 	return out
 }
 
 type memorySpool struct {
-	mu      sync.Mutex
-	records []ports.SpoolRecord
-	acked   uint64
-	epoch   uint64
-	peeks   []ports.PeekSpoolRequest
+	mu           sync.Mutex
+	records      []ports.SpoolRecord
+	acked        uint64
+	epoch        uint64
+	currentEpoch uint64
+	peeks        []ports.PeekSpoolRequest
 }
 
 func (s *memorySpool) Enqueue(context.Context, ports.SpoolItem) (fleetagent.StreamPosition, error) {
@@ -93,8 +94,16 @@ func (*memorySpool) Gaps(context.Context) ([]ports.SpoolGap, error) { return nil
 func (s *memorySpool) Stats(context.Context) (ports.SpoolStats, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return ports.SpoolStats{Priorities: []ports.SpoolPriorityStats{{Priority: fleetagent.PriorityP1,
-		CurrentEpoch: s.epoch, HighestACKed: s.acked}}}, nil
+	currentEpoch := s.currentEpoch
+	if currentEpoch == 0 {
+		currentEpoch = s.epoch
+	}
+	stats := ports.SpoolStats{Priorities: []ports.SpoolPriorityStats{{Priority: fleetagent.PriorityP1,
+		CurrentEpoch: currentEpoch}}}
+	if s.acked > 0 {
+		stats.EpochACKs = []ports.SpoolEpochACK{{Priority: fleetagent.PriorityP1, Epoch: s.epoch, HighestACKed: s.acked}}
+	}
+	return stats, nil
 }
 func (*memorySpool) Close() error { return nil }
 
@@ -192,7 +201,7 @@ func TestLostResponseRestartsWithSameSequenceMembershipAndKey(t *testing.T) {
 	if delivered, err := first.DeliverOnce(context.Background()); err == nil || delivered {
 		t.Fatalf("lost response delivered=%v err=%v", delivered, err)
 	}
-	if state.state.Pending == nil || state.state.Pending.Sequence != 1 || spool.acked != 0 {
+	if state.state.Pending == nil || state.state.Pending.Sequence != 1 || state.state.Pending.EngagementID != "eng-1" || spool.acked != 0 {
 		t.Fatalf("pending state not preserved: %#v ack=%d", state.state, spool.acked)
 	}
 
@@ -262,8 +271,9 @@ func TestRunRotatesRejectedKeyOnceAndRetriesPendingBatch(t *testing.T) {
 
 func TestRecoveredACKCompletesPendingStateWithoutResending(t *testing.T) {
 	key := localKey(t)
-	state := &memoryState{ok: true, state: State{Version: 1, NextSequence: 4, Key: &key,
-		RegisteredKeyID: key.Key.KeyID, Pending: &PendingBatch{Sequence: 4, Epoch: 2, Through: 9, EventIDs: []shared.ID{"det-9"}}}}
+	state := &memoryState{ok: true, state: ports.DetectionDeliveryState{Version: 1, NextSequence: 4, Key: &key,
+		RegisteredKeyID: key.Key.KeyID, Pending: &ports.DetectionPendingBatch{EngagementID: "eng-1",
+			Sequence: 4, Epoch: 2, Through: 9, EventIDs: []shared.ID{"det-9"}}}}
 	spool := &memorySpool{acked: 9, epoch: 2}
 	transport := &captureTransport{}
 	service, err := NewService(spool, transport, state, testConfig())
@@ -278,10 +288,50 @@ func TestRecoveredACKCompletesPendingStateWithoutResending(t *testing.T) {
 	}
 }
 
+func TestRecoveredACKFromPastEpochCompletesPendingStateAfterReboot(t *testing.T) {
+	key := localKey(t)
+	state := &memoryState{ok: true, state: ports.DetectionDeliveryState{Version: 1, NextSequence: 4, Key: &key,
+		RegisteredKeyID: key.Key.KeyID, Pending: &ports.DetectionPendingBatch{EngagementID: "eng-1",
+			Sequence: 4, Epoch: 2, Through: 9, EventIDs: []shared.ID{"det-9"}}}}
+	spool := &memorySpool{acked: 9, epoch: 2, currentEpoch: 3}
+	transport := &captureTransport{}
+	service, err := NewService(spool, transport, state, testConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delivered, err := service.DeliverOnce(context.Background()); err != nil || !delivered {
+		t.Fatalf("reboot recovery delivered=%v err=%v", delivered, err)
+	}
+	if len(transport.batches) != 0 || state.state.Pending != nil || state.state.NextSequence != 5 {
+		t.Fatalf("past-epoch ACK was not recovered: sends=%d state=%#v", len(transport.batches), state.state)
+	}
+}
+
+func TestPendingEngagementMismatchFailsClosed(t *testing.T) {
+	key := localKey(t)
+	state := &memoryState{ok: true, state: ports.DetectionDeliveryState{Version: 1, NextSequence: 1, Key: &key,
+		RegisteredKeyID: key.Key.KeyID, Pending: &ports.DetectionPendingBatch{EngagementID: "eng-original",
+			Sequence: 1, Epoch: 1, Through: 1, EventIDs: []shared.ID{"det-1"}}}}
+	if _, err := NewService(&memorySpool{}, &captureTransport{}, state, testConfig()); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("engagement mismatch error = %v", err)
+	}
+	cfg := testConfig()
+	cfg.EngagementID = "eng-original"
+	service, err := NewService(&memorySpool{}, &captureTransport{}, state, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.cfg.EngagementID = "eng-changed" // exercise the per-delivery guard independently of construction
+	if _, err := service.DeliverOnce(context.Background()); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("delivery engagement mismatch error = %v", err)
+	}
+}
+
 func TestPendingMembershipMismatchFailsClosed(t *testing.T) {
 	key := localKey(t)
-	state := &memoryState{ok: true, state: State{Version: 1, NextSequence: 1, Key: &key,
-		RegisteredKeyID: key.Key.KeyID, Pending: &PendingBatch{Sequence: 1, Epoch: 1, Through: 1, EventIDs: []shared.ID{"expected"}}}}
+	state := &memoryState{ok: true, state: ports.DetectionDeliveryState{Version: 1, NextSequence: 1, Key: &key,
+		RegisteredKeyID: key.Key.KeyID, Pending: &ports.DetectionPendingBatch{EngagementID: "eng-1",
+			Sequence: 1, Epoch: 1, Through: 1, EventIDs: []shared.ID{"expected"}}}}
 	spool := &memorySpool{records: []ports.SpoolRecord{spoolDetection(1, "different")}, epoch: 1}
 	service, err := NewService(spool, &captureTransport{}, state, testConfig())
 	if err != nil {
@@ -298,7 +348,7 @@ func TestPendingMembershipMismatchFailsClosed(t *testing.T) {
 func TestNewServiceRejectsCorruptPrivateKeyAndBadConfig(t *testing.T) {
 	bad := localKey(t)
 	bad.PrivateKey[0] ^= 0xff
-	state := &memoryState{ok: true, state: State{Version: 1, NextSequence: 1, Key: &bad}}
+	state := &memoryState{ok: true, state: ports.DetectionDeliveryState{Version: 1, NextSequence: 1, Key: &bad}}
 	if _, err := NewService(&memorySpool{}, &captureTransport{}, state, testConfig()); err == nil {
 		t.Fatal("corrupt private key accepted")
 	}
@@ -326,7 +376,7 @@ func validDetection() detection.Detection {
 		Evidence: []detection.Event{event}, ObservedCount: 1, Observed: shipNow}
 }
 
-func localKey(t *testing.T) LocalSigningKey {
+func localKey(t *testing.T) ports.DetectionSigningKeyState {
 	t.Helper()
 	pub, privateKey, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -336,5 +386,5 @@ func localKey(t *testing.T) LocalSigningKey {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return LocalSigningKey{Key: key, PrivateKey: privateKey}
+	return ports.DetectionSigningKeyState{Key: key, PrivateKey: privateKey}
 }

--- a/internal/usecase/fleet/detectionship/service_test.go
+++ b/internal/usecase/fleet/detectionship/service_test.go
@@ -1,0 +1,340 @@
+package detectionship
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var shipNow = time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+
+type memoryState struct {
+	mu      sync.Mutex
+	state   State
+	ok      bool
+	saves   int
+	saveErr error
+}
+
+func (m *memoryState) Load() (State, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return cloneState(m.state), m.ok, nil
+}
+
+func (m *memoryState) Save(state State) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.state, m.ok = cloneState(state), true
+	m.saves++
+	return nil
+}
+
+func cloneState(in State) State {
+	body, _ := json.Marshal(in)
+	var out State
+	_ = json.Unmarshal(body, &out)
+	return out
+}
+
+type memorySpool struct {
+	mu      sync.Mutex
+	records []ports.SpoolRecord
+	acked   uint64
+	epoch   uint64
+	peeks   []ports.PeekSpoolRequest
+}
+
+func (s *memorySpool) Enqueue(context.Context, ports.SpoolItem) (fleetagent.StreamPosition, error) {
+	return fleetagent.StreamPosition{}, errors.New("unused")
+}
+func (s *memorySpool) Peek(_ context.Context, req ports.PeekSpoolRequest) ([]ports.SpoolRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.peeks = append(s.peeks, req)
+	limit := len(s.records)
+	if req.MaxRecords > 0 && limit > req.MaxRecords {
+		limit = req.MaxRecords
+	}
+	out := append([]ports.SpoolRecord(nil), s.records[:limit]...)
+	return out, nil
+}
+func (s *memorySpool) Ack(_ context.Context, ack ports.SpoolACK) (ports.SpoolACKResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	kept := s.records[:0]
+	removed := 0
+	for _, record := range s.records {
+		if record.Position.Priority == ack.Priority && record.Position.Epoch == ack.Epoch && record.Position.Sequence <= ack.Through {
+			removed++
+			continue
+		}
+		kept = append(kept, record)
+	}
+	s.records = kept
+	s.acked, s.epoch = ack.Through, ack.Epoch
+	return ports.SpoolACKResult{RemovedRecords: removed, HighestACKed: ack.Through}, nil
+}
+func (*memorySpool) Flush(context.Context) error                    { return nil }
+func (*memorySpool) Gaps(context.Context) ([]ports.SpoolGap, error) { return nil, nil }
+func (s *memorySpool) Stats(context.Context) (ports.SpoolStats, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return ports.SpoolStats{Priorities: []ports.SpoolPriorityStats{{Priority: fleetagent.PriorityP1,
+		CurrentEpoch: s.epoch, HighestACKed: s.acked}}}, nil
+}
+func (*memorySpool) Close() error { return nil }
+
+type captureTransport struct {
+	registerErrs []error
+	sendErrs     []error
+	keys         []fleetagent.AgentSigningKey
+	proofs       []string
+	batches      []fleetagent.AgentBatch
+	items        [][]fleetagent.DetectionBatchItem
+	onSend       func(int)
+}
+
+func (c *captureTransport) RegisterDetectionKey(_ context.Context, _ string, key fleetagent.AgentSigningKey, proof string) error {
+	c.keys, c.proofs = append(c.keys, key), append(c.proofs, proof)
+	index := len(c.keys) - 1
+	if index < len(c.registerErrs) {
+		return c.registerErrs[index]
+	}
+	return nil
+}
+func (c *captureTransport) SendDetectionBatch(_ context.Context, _ string, batch fleetagent.AgentBatch, items []fleetagent.DetectionBatchItem) error {
+	c.batches = append(c.batches, batch)
+	c.items = append(c.items, append([]fleetagent.DetectionBatchItem(nil), items...))
+	index := len(c.batches) - 1
+	if c.onSend != nil {
+		c.onSend(index)
+	}
+	if index < len(c.sendErrs) {
+		return c.sendErrs[index]
+	}
+	return nil
+}
+
+type statusError struct{ status int }
+
+func (e statusError) Error() string                 { return fmt.Sprintf("status %d", e.status) }
+func (e statusError) ResponseStatus() (int, string) { return e.status, "" }
+
+func testConfig() Config {
+	return Config{AgentID: "agent-1", EngagementID: "eng-1", Token: "secret", Now: func() time.Time { return shipNow },
+		IdleInterval: time.Millisecond, Retry: func(error, uint) (bool, time.Duration) { return false, 0 }}
+}
+
+func TestDeliverOnceRegistersSignsBatchesAndACKsP1(t *testing.T) {
+	spool := &memorySpool{records: []ports.SpoolRecord{spoolDetection(1, "det-1"), spoolDetection(2, "det-2")}}
+	state := &memoryState{}
+	transport := &captureTransport{}
+	service, err := NewService(spool, transport, state, testConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivered, err := service.DeliverOnce(context.Background())
+	if err != nil || !delivered {
+		t.Fatalf("delivered=%v err=%v", delivered, err)
+	}
+	if len(transport.keys) != 1 || len(transport.batches) != 1 || len(transport.items[0]) != 2 {
+		t.Fatalf("keys=%d batches=%d items=%d", len(transport.keys), len(transport.batches), len(transport.items[0]))
+	}
+	if err := fleetagent.VerifyKeyPossession(transport.keys[0], transport.proofs[0]); err != nil {
+		t.Fatalf("registration proof: %v", err)
+	}
+	batch := transport.batches[0]
+	if batch.Sequence != 1 || batch.AgentID != "agent-1" || batch.EngagementID != "eng-1" || batch.KeyID != transport.keys[0].KeyID {
+		t.Fatalf("batch identity = %#v", batch)
+	}
+	if err := fleetagent.VerifyBatch(transport.keys[0].PublicKey, batch); err != nil {
+		t.Fatalf("batch signature: %v", err)
+	}
+	for i, item := range transport.items[0] {
+		body, _ := json.Marshal(item.Detection)
+		if got := fleetagent.DetectionContentHash(body, item.AssetID); got != batch.Detections[i].ContentSHA256 {
+			t.Fatalf("item %d content digest = %s, want %s", i, got, batch.Detections[i].ContentSHA256)
+		}
+	}
+	if spool.acked != 2 || len(spool.records) != 0 {
+		t.Fatalf("WAL ack=%d records=%d", spool.acked, len(spool.records))
+	}
+	if state.state.Pending != nil || state.state.NextSequence != 2 || state.state.Key == nil {
+		t.Fatalf("state after delivery = %#v", state.state)
+	}
+	if len(spool.peeks) == 0 || spool.peeks[0].OnlyPriority == nil || *spool.peeks[0].OnlyPriority != fleetagent.PriorityP1 {
+		t.Fatalf("shipper did not isolate the P1 lane: %#v", spool.peeks)
+	}
+}
+
+func TestLostResponseRestartsWithSameSequenceMembershipAndKey(t *testing.T) {
+	spool := &memorySpool{records: []ports.SpoolRecord{spoolDetection(1, "det-1")}}
+	state := &memoryState{}
+	firstTransport := &captureTransport{sendErrs: []error{errors.New("connection reset")}}
+	first, err := NewService(spool, firstTransport, state, testConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delivered, err := first.DeliverOnce(context.Background()); err == nil || delivered {
+		t.Fatalf("lost response delivered=%v err=%v", delivered, err)
+	}
+	if state.state.Pending == nil || state.state.Pending.Sequence != 1 || spool.acked != 0 {
+		t.Fatalf("pending state not preserved: %#v ack=%d", state.state, spool.acked)
+	}
+
+	secondTransport := &captureTransport{}
+	second, err := NewService(spool, secondTransport, state, testConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delivered, err := second.DeliverOnce(context.Background()); err != nil || !delivered {
+		t.Fatalf("restart delivered=%v err=%v", delivered, err)
+	}
+	if len(secondTransport.keys) != 0 {
+		t.Fatal("already-registered key was redundantly registered after restart")
+	}
+	if got := secondTransport.batches[0]; got.Sequence != firstTransport.batches[0].Sequence || got.Detections[0].ID != firstTransport.batches[0].Detections[0].ID || got.KeyID != firstTransport.batches[0].KeyID {
+		t.Fatalf("retry changed signed batch identity: first=%#v second=%#v", firstTransport.batches[0], got)
+	}
+}
+
+func TestDuplicateSpoolRecordsCollapseIntoOneSignedItemAndACKBoth(t *testing.T) {
+	spool := &memorySpool{records: []ports.SpoolRecord{spoolDetection(1, "det-1"), spoolDetection(2, "det-1")}}
+	state := &memoryState{}
+	transport := &captureTransport{}
+	service, err := NewService(spool, transport, state, testConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delivered, err := service.DeliverOnce(context.Background()); err != nil || !delivered {
+		t.Fatalf("delivered=%v err=%v", delivered, err)
+	}
+	if len(transport.items) != 1 || len(transport.items[0]) != 1 || len(transport.batches[0].Detections) != 1 {
+		t.Fatalf("duplicate WAL records were not collapsed: items=%#v batch=%#v", transport.items, transport.batches[0])
+	}
+	if spool.acked != 2 || len(spool.records) != 0 {
+		t.Fatalf("collapsed batch did not ACK both WAL records: ack=%d records=%d", spool.acked, len(spool.records))
+	}
+}
+
+func TestRunRotatesRejectedKeyOnceAndRetriesPendingBatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	spool := &memorySpool{records: []ports.SpoolRecord{spoolDetection(1, "det-1")}}
+	state := &memoryState{}
+	transport := &captureTransport{sendErrs: []error{statusError{status: 403}, nil}, onSend: func(index int) {
+		if index == 1 {
+			cancel()
+		}
+	}}
+	service, err := NewService(spool, transport, state, testConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = service.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(transport.keys) != 2 || transport.keys[0].KeyID == transport.keys[1].KeyID {
+		t.Fatalf("rejected key was not rotated: %#v", transport.keys)
+	}
+	if len(transport.batches) != 2 || transport.batches[0].Sequence != transport.batches[1].Sequence {
+		t.Fatalf("rotation must retry the same pending sequence: %#v", transport.batches)
+	}
+	if spool.acked != 1 || state.state.Pending != nil || state.state.NextSequence != 2 {
+		t.Fatalf("delivery not committed after rotation: ack=%d state=%#v", spool.acked, state.state)
+	}
+}
+
+func TestRecoveredACKCompletesPendingStateWithoutResending(t *testing.T) {
+	key := localKey(t)
+	state := &memoryState{ok: true, state: State{Version: 1, NextSequence: 4, Key: &key,
+		RegisteredKeyID: key.Key.KeyID, Pending: &PendingBatch{Sequence: 4, Epoch: 2, Through: 9, EventIDs: []shared.ID{"det-9"}}}}
+	spool := &memorySpool{acked: 9, epoch: 2}
+	transport := &captureTransport{}
+	service, err := NewService(spool, transport, state, testConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delivered, err := service.DeliverOnce(context.Background()); err != nil || !delivered {
+		t.Fatalf("recover delivered=%v err=%v", delivered, err)
+	}
+	if len(transport.batches) != 0 || state.state.Pending != nil || state.state.NextSequence != 5 {
+		t.Fatalf("acked pending batch was resent or not advanced: sends=%d state=%#v", len(transport.batches), state.state)
+	}
+}
+
+func TestPendingMembershipMismatchFailsClosed(t *testing.T) {
+	key := localKey(t)
+	state := &memoryState{ok: true, state: State{Version: 1, NextSequence: 1, Key: &key,
+		RegisteredKeyID: key.Key.KeyID, Pending: &PendingBatch{Sequence: 1, Epoch: 1, Through: 1, EventIDs: []shared.ID{"expected"}}}}
+	spool := &memorySpool{records: []ports.SpoolRecord{spoolDetection(1, "different")}, epoch: 1}
+	service, err := NewService(spool, &captureTransport{}, state, testConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.DeliverOnce(context.Background()); !errors.Is(err, ErrDeliveryState) {
+		t.Fatalf("membership mismatch error = %v", err)
+	}
+	if spool.acked != 0 {
+		t.Fatal("inconsistent pending state ACKed the WAL")
+	}
+}
+
+func TestNewServiceRejectsCorruptPrivateKeyAndBadConfig(t *testing.T) {
+	bad := localKey(t)
+	bad.PrivateKey[0] ^= 0xff
+	state := &memoryState{ok: true, state: State{Version: 1, NextSequence: 1, Key: &bad}}
+	if _, err := NewService(&memorySpool{}, &captureTransport{}, state, testConfig()); err == nil {
+		t.Fatal("corrupt private key accepted")
+	}
+	cfg := testConfig()
+	cfg.EngagementID = ""
+	if _, err := NewService(&memorySpool{}, &captureTransport{}, &memoryState{}, cfg); err == nil {
+		t.Fatal("empty engagement accepted")
+	}
+}
+
+func spoolDetection(sequence uint64, id shared.ID) ports.SpoolRecord {
+	value := validDetection()
+	body, _ := json.Marshal(value)
+	return ports.SpoolRecord{Kind: ports.SpoolRecordDetection,
+		Position: fleetagent.StreamPosition{Priority: fleetagent.PriorityP1, Epoch: 1, Sequence: sequence, Session: "session", Boot: "boot"},
+		EventID:  id, EventClass: value.Class, ContentType: "application/vnd.synapse.detection+json;version=1",
+		Payload: body, ObservedAt: value.Observed, EnqueuedAt: shipNow, MustNotShed: true, SchemaVersion: 1}
+}
+
+func validDetection() detection.Detection {
+	event := detection.Event{Class: detection.ClassProcess, At: shipNow, Host: "asset-1",
+		Process: &detection.ProcessEvent{PID: 42, PPID: 1, Comm: "curl", Path: "/usr/bin/curl", UID: 1000}}
+	return detection.Detection{RuleID: "proc.curl", RuleVersion: 1, Class: detection.ClassProcess,
+		Severity: shared.SeverityHigh, HostID: "asset-1", AgentID: "agent-1",
+		Evidence: []detection.Event{event}, ObservedCount: 1, Observed: shipNow}
+}
+
+func localKey(t *testing.T) LocalSigningKey {
+	t.Helper()
+	pub, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := fleetagent.NewSigningKey("agent-1", fleetagent.PurposeDetectionBatch, pub, shipNow.Add(-time.Hour), shipNow.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return LocalSigningKey{Key: key, PrivateKey: privateKey}
+}

--- a/internal/usecase/fleet/detectledger/service.go
+++ b/internal/usecase/fleet/detectledger/service.go
@@ -61,11 +61,7 @@ type AgentKeyResolver interface {
 
 // IngestItem is one detection in a batch together with the asset it was observed on (#423 requirement 5:
 // a detection joins the asset model).
-type IngestItem struct {
-	ID        shared.ID
-	Detection detection.Detection
-	AssetID   shared.ID
-}
+type IngestItem = fleetagent.DetectionBatchItem
 
 // IngestResult reports the outcome of ingesting a batch.
 type IngestResult struct {

--- a/internal/usecase/ports/detection_delivery.go
+++ b/internal/usecase/ports/detection_delivery.go
@@ -1,0 +1,116 @@
+package ports
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// DetectionDeliveryStateVersion is the on-disk schema understood by the agent detection shipper.
+const DetectionDeliveryStateVersion = 1
+
+// DetectionTransport is the agent-plane surface used to register a purpose-bound signing key and
+// deliver the batches covered by that key.
+type DetectionTransport interface {
+	RegisterDetectionKey(ctx context.Context, token string, key fleetagent.AgentSigningKey, proof string) error
+	SendDetectionBatch(ctx context.Context, token string, batch fleetagent.AgentBatch, items []fleetagent.DetectionBatchItem) error
+}
+
+// DetectionSigningKeyState is the private half of one purpose-bound agent key. Only Key.PublicKey and
+// a proof produced from PrivateKey may leave the host.
+type DetectionSigningKeyState struct {
+	Key        fleetagent.AgentSigningKey
+	PrivateKey ed25519.PrivateKey
+}
+
+// Validate rejects malformed or mismatched public/private key material.
+func (k DetectionSigningKeyState) Validate() error {
+	if err := k.Key.Validate(); err != nil {
+		return err
+	}
+	if len(k.PrivateKey) != ed25519.PrivateKeySize {
+		return fmt.Errorf("%w: local detection private key has invalid size", shared.ErrValidation)
+	}
+	canonicalPrivate := ed25519.NewKeyFromSeed(k.PrivateKey.Seed())
+	if !bytes.Equal(canonicalPrivate, k.PrivateKey) {
+		return fmt.Errorf("%w: local detection private key seed/public material is inconsistent", shared.ErrValidation)
+	}
+	derived, ok := k.PrivateKey.Public().(ed25519.PublicKey)
+	if !ok || !bytes.Equal(derived, k.Key.PublicKey) {
+		return fmt.Errorf("%w: local detection private key does not match its public key", shared.ErrValidation)
+	}
+	if k.Key.Purpose != fleetagent.PurposeDetectionBatch {
+		return fmt.Errorf("%w: local key has purpose %q, want detection-batch", shared.ErrValidation, k.Key.Purpose)
+	}
+	return nil
+}
+
+// DetectionPendingBatch is persisted before the network call. EngagementID binds already-confirmed
+// membership to its original attribution so a configuration change cannot re-sign it elsewhere.
+type DetectionPendingBatch struct {
+	EngagementID shared.ID
+	Sequence     uint64
+	Epoch        uint64
+	Through      uint64
+	EventIDs     []shared.ID
+}
+
+// Validate rejects incomplete pending coordinates or attribution.
+func (p DetectionPendingBatch) Validate() error {
+	if p.EngagementID.IsZero() || p.Sequence == 0 || p.Epoch == 0 || p.Through == 0 || len(p.EventIDs) == 0 {
+		return fmt.Errorf("%w: pending detection batch has incomplete attribution or coordinates", shared.ErrValidation)
+	}
+	for _, id := range p.EventIDs {
+		if id.IsZero() {
+			return fmt.Errorf("%w: pending detection batch has an empty event id", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+// DetectionDeliveryState is the complete secret-bearing agent-side detection transport state.
+type DetectionDeliveryState struct {
+	Version         int
+	NextSequence    uint64
+	Key             *DetectionSigningKeyState
+	RegisteredKeyID string
+	Pending         *DetectionPendingBatch
+}
+
+// Validate rejects corrupt or tampered local state instead of silently minting a new identity and
+// abandoning an in-flight sequence.
+func (s DetectionDeliveryState) Validate() error {
+	if s.Version != DetectionDeliveryStateVersion || s.NextSequence == 0 {
+		return fmt.Errorf("%w: unsupported or incomplete detection delivery state", shared.ErrValidation)
+	}
+	if s.Key == nil && s.RegisteredKeyID != "" {
+		return fmt.Errorf("%w: registered key id exists without local key material", shared.ErrValidation)
+	}
+	if s.Key != nil {
+		if err := s.Key.Validate(); err != nil {
+			return err
+		}
+		if s.RegisteredKeyID != "" && s.RegisteredKeyID != s.Key.Key.KeyID {
+			return fmt.Errorf("%w: registered key id does not match local key", shared.ErrValidation)
+		}
+	}
+	if s.Pending != nil {
+		if err := s.Pending.Validate(); err != nil {
+			return err
+		}
+		if s.Pending.Sequence != s.NextSequence {
+			return fmt.Errorf("%w: pending sequence %d disagrees with next sequence %d", shared.ErrValidation, s.Pending.Sequence, s.NextSequence)
+		}
+	}
+	return nil
+}
+
+// DetectionStateStore durably persists private signing material and the in-flight batch coordinate.
+type DetectionStateStore interface {
+	Load() (DetectionDeliveryState, bool, error)
+	Save(DetectionDeliveryState) error
+}

--- a/internal/usecase/ports/detection_delivery_test.go
+++ b/internal/usecase/ports/detection_delivery_test.go
@@ -1,0 +1,41 @@
+package ports
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestDetectionDeliveryStateRequiresPendingEngagementAttribution(t *testing.T) {
+	key := testDetectionSigningKeyState(t)
+	state := DetectionDeliveryState{Version: DetectionDeliveryStateVersion, NextSequence: 1, Key: &key,
+		RegisteredKeyID: key.Key.KeyID, Pending: &DetectionPendingBatch{
+			Sequence: 1, Epoch: 2, Through: 3, EventIDs: []shared.ID{"det-3"},
+		}}
+	if err := state.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing pending engagement error = %v", err)
+	}
+	state.Pending.EngagementID = "eng-1"
+	if err := state.Validate(); err != nil {
+		t.Fatalf("valid attributed state: %v", err)
+	}
+}
+
+func testDetectionSigningKeyState(t *testing.T) DetectionSigningKeyState {
+	t.Helper()
+	pub, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+	key, err := fleetagent.NewSigningKey("agent-1", fleetagent.PurposeDetectionBatch, pub,
+		now.Add(-time.Hour), now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return DetectionSigningKeyState{Key: key, PrivateKey: privateKey}
+}

--- a/internal/usecase/ports/telemetry_spool.go
+++ b/internal/usecase/ports/telemetry_spool.go
@@ -248,9 +248,19 @@ type SpoolPriorityStats struct {
 	HighestACKed  uint64
 }
 
+// SpoolEpochACK preserves the highest durable ACK for one priority incarnation. Historical entries
+// let a shipper finish committing local state after a reboot advances CurrentEpoch and reclaimed WAL
+// records from the acknowledged epoch are no longer readable.
+type SpoolEpochACK struct {
+	Priority     fleetagent.DeliveryPriority
+	Epoch        uint64
+	HighestACKed uint64
+}
+
 // SpoolStats is both an operator query and the source for the agent Prometheus collector.
 type SpoolStats struct {
 	Priorities   []SpoolPriorityStats
+	EpochACKs    []SpoolEpochACK
 	TotalRecords int64
 	// TotalBytes includes WAL records and GapBytes; GapBytes is exposed
 	// separately as the loss-evidence subset of the bounded spool quota.

--- a/internal/usecase/ports/telemetry_spool.go
+++ b/internal/usecase/ports/telemetry_spool.go
@@ -129,6 +129,10 @@ func (r SpoolRecord) Validate() error {
 type PeekSpoolRequest struct {
 	MaxRecords int
 	MaxBytes   int64
+	// OnlyPriority restricts the read to one delivery lane. A nil value preserves the normal P0→P3
+	// drain order. Dedicated transports use this to ensure a busy coverage or telemetry lane cannot
+	// consume the read budget and starve the independent detection queue.
+	OnlyPriority *fleetagent.DeliveryPriority
 }
 
 // SpoolACK is the highest contiguous record sequence the control plane durably accepted for one priority

--- a/packaging/agent.env.example
+++ b/packaging/agent.env.example
@@ -10,3 +10,9 @@ SYNAPSE_FLEET_ENROL_TOKEN_FILE=/etc/synapse-agent/enrol-token
 
 # Optional display name; defaults to the hostname.
 # SYNAPSE_AGENT_NAME=
+
+# Optional Linux eBPF detection and signed delivery. The control plane must enable key registration
+# and detection ingest. Leaving the engagement empty keeps detections durably local.
+# SYNAPSE_DETECT_CLASSES=process,network,file,privilege
+# SYNAPSE_DETECTION_ENGAGEMENT_ID=
+# SYNAPSE_DETECTION_SHIP_INTERVAL=1s


### PR DESCRIPTION
## Summary

Completes the remaining agent-side tail of #625 after the server ingest, key resolver, and registration routes landed in #652. Confirmed detections now leave the agent through an independent, crash-recoverable P1 delivery loop instead of remaining only in the local WAL.

Closes #625.

## Changes

- Add an independent P1 detection shipper with durable batch sequence/membership, bounded batches, exact retry after lost responses, and WAL ACK only after complete 2xx admission.
- Generate purpose-bound Ed25519 keys on the agent, persist private state with 0600 permissions and atomic fsync/rename publication, register through proof-of-possession, rotate before expiry, and rotate once on a rejected/revoked key.
- Extend the fleet client with the live key-registration and detection-ingest requests plus typed HTTP/network errors for the existing capped-jitter retry policy.
- Let dedicated transports peek one priority lane so P0/P2/P3 backlog cannot consume the detection shipper's read budget.
- Share the detection item wire contract between the agent and detectledger; collapse identical duplicate WAL records and fail closed on conflicting content for one detection ID.
- Wire the shipper into `synapse-agent` behind `SYNAPSE_DETECTION_ENGAGEMENT_ID`, document its configuration and operations, and complete OpenAPI coverage for the live fleet ingest/key routes.
- Add a live-path integration test covering durable WAL -> HTTP key PoP registration -> signed batch -> resolver/signature/content verification -> exactly-once evidence sealing -> P1 ACK.

## Safety / recovery behavior

- Pending membership is persisted before the network call and rebuilt unchanged after restart.
- A lost response reuses the same key, batch sequence, and membership; server `SealOnce` handles the replay.
- A successful server response never advances local sequence until P1 ACK succeeds; restart detects an ACKed pending batch and completes state without resending.
- Corrupt key/state, mismatched WAL membership, wrong-agent detections, conflicting duplicate IDs, and a second 403 all stop fail-closed with the WAL intact.

## Checklist

- [x] `make build vet typecheck` passes
- [x] `go test -count=1 ./...` passes
- [x] Targeted Linux `go test -race -count=1` passes for fleetagent, detectionship, agentstate, fleetclient, spool, httpapi, and synapse-agent
- [x] Tests added/updated for new behavior
- [x] Preserves safety invariants: credential-derived identity, private keys stay local and out of logs, signed content membership, and ACK-after-admission

### Documentation

- [x] New `SYNAPSE_*` variables are in `docs/guide/configuration.md`
- [x] New agent flags are documented with their corresponding environment variables
- [x] Live fleet HTTP routes are described in `api/openapi.yaml` without adding coverage debt
- [x] Operational setup and failure/recovery behavior are documented in the existing fleet blue-team guide
- [x] No dashboard changes (`pnpm run typecheck` passes)