### PR TITLE
feat(fleet): A5 self-contained detection evidence envelope + provenance (#626)

### DIFF
--- a/internal/domain/fleetagent/detection_evidence.go
+++ b/internal/domain/fleetagent/detection_evidence.go
@@ -1,0 +1,169 @@
+package fleetagent
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// detectionEvidenceContext domain-separates the permanent detection-evidence commitment. It is carried
+// INSIDE the sealed content (not just as the chain kind) so a link decoded on its own is unambiguously a
+// detection-evidence envelope and cannot be reinterpreted as another sealed artifact.
+const detectionEvidenceContext = "synapse-detection-evidence:v1"
+
+// DetectionEvidenceEnvelopeVersion is the envelope schema version, carried in every envelope so the
+// permanent chain link stays decodable as the shape evolves.
+const DetectionEvidenceEnvelopeVersion = 1
+
+// ProvenanceState is the durability/consistency state of a sealed detection's evidence (A5, #626).
+//
+// What the IMMUTABLE envelope records is the detection-evidence commitment at admission: once the detection
+// (and its own embedded evidence) is sealed into the permanent chain it is ProvenanceComplete — that is the
+// only state a stable, content-compared seal may honestly assert, since the sealed bytes must be identical
+// across an idempotent re-seal. The remaining states are the QUERY/READ-LAYER lifecycle over a detection's
+// evidence: Pending while the SEPARATE raw-telemetry stream (A3) that a detection summarizes is not yet
+// confirmed durable, Expired when the expirable projection is swept, Broken when chain verification fails.
+// Those transitions are tracked on the mutable projection, never by rewriting the immutable link — wiring
+// the live telemetry-durability cross-check is the remaining A5 tail.
+type ProvenanceState string
+
+const (
+	// ProvenancePending: read-layer state — the raw telemetry stream a detection summarizes is not yet
+	// confirmed durable. A detection over not-yet-durable telemetry must NOT be presented as complete.
+	ProvenancePending ProvenanceState = "pending"
+	// ProvenanceComplete: the detection evidence is durably sealed into the permanent chain. This is the
+	// admission state carried by the immutable envelope.
+	ProvenanceComplete ProvenanceState = "complete"
+	// ProvenanceExpired: read-layer state — the expirable projection view has aged out under retention; the
+	// permanent envelope still stands and remains verifiable on its own.
+	ProvenanceExpired ProvenanceState = "expired"
+	// ProvenanceBroken: read-layer state — chain/consistency verification failed for this detection's evidence.
+	ProvenanceBroken ProvenanceState = "broken"
+)
+
+// Valid reports whether p is a known provenance state.
+func (p ProvenanceState) Valid() bool {
+	switch p {
+	case ProvenancePending, ProvenanceComplete, ProvenanceExpired, ProvenanceBroken:
+		return true
+	default:
+		return false
+	}
+}
+
+// DetectionEvidenceEnvelope is the SELF-CONTAINED permanent chain link for a sealed detection (A5, #626).
+// It carries everything needed to attribute and verify the detection — tenant/agent/asset/engagement,
+// the batch identity that admitted it, the agent's content commitment (ContentSHA256, the same digest the
+// agent signed), the rule provenance, and the detection itself — so the link remains verifiable and
+// explainable AFTER the expirable projection row is swept. It deliberately carries NO wall-clock "sealed
+// at": the sealed bytes must be byte-identical across an idempotent re-seal (SealOnce compares content),
+// so every field is derived from the batch/detection, never from the ingest clock.
+type DetectionEvidenceEnvelope struct {
+	Context         string              `json:"context"`
+	EnvelopeVersion int                 `json:"envelope_version"`
+	TenantID        shared.ID           `json:"tenant_id"`
+	EngagementID    shared.ID           `json:"engagement_id"`
+	AgentID         shared.ID           `json:"agent_id"`
+	AssetID         shared.ID           `json:"asset_id"`
+	DetectionID     shared.ID           `json:"detection_id"`
+	BatchSequence   uint64              `json:"batch_sequence"`
+	KeyID           string              `json:"key_id"`
+	RuleID          string              `json:"rule_id"`
+	RuleVersion     int                 `json:"rule_version"`
+	ContentSHA256   string              `json:"content_sha256"`
+	Provenance      ProvenanceState     `json:"provenance"`
+	ObservedAt      time.Time           `json:"observed_at"`
+	Detection       detection.Detection `json:"detection"`
+}
+
+// NewDetectionEvidenceEnvelope builds a validated envelope from the admitted batch identity and detection.
+// contentSHA256 is the agent-signed content commitment (the verified DetectionContentHash), embedded so the
+// link is self-verifying against its detection without the projection.
+func NewDetectionEvidenceEnvelope(tenantID, engagementID, agentID, assetID, detectionID shared.ID, batchSequence uint64, keyID, contentSHA256 string, prov ProvenanceState, det detection.Detection) (DetectionEvidenceEnvelope, error) {
+	env := DetectionEvidenceEnvelope{
+		Context:         detectionEvidenceContext,
+		EnvelopeVersion: DetectionEvidenceEnvelopeVersion,
+		TenantID:        tenantID,
+		EngagementID:    engagementID,
+		AgentID:         agentID,
+		AssetID:         assetID,
+		DetectionID:     detectionID,
+		BatchSequence:   batchSequence,
+		KeyID:           keyID,
+		RuleID:          det.RuleID,
+		RuleVersion:     det.RuleVersion,
+		ContentSHA256:   contentSHA256,
+		Provenance:      prov,
+		ObservedAt:      det.Observed.UTC(),
+		Detection:       det,
+	}
+	if err := env.Validate(); err != nil {
+		return DetectionEvidenceEnvelope{}, err
+	}
+	return env, nil
+}
+
+// Validate checks the envelope is well-formed and internally consistent.
+func (e DetectionEvidenceEnvelope) Validate() error {
+	if e.Context != detectionEvidenceContext {
+		return fmt.Errorf("%w: detection evidence envelope has the wrong domain-separation context", shared.ErrValidation)
+	}
+	if e.EnvelopeVersion < 1 {
+		return fmt.Errorf("%w: detection evidence envelope version must be >= 1", shared.ErrValidation)
+	}
+	if e.TenantID.IsZero() || e.EngagementID.IsZero() || e.AgentID.IsZero() || e.AssetID.IsZero() || e.DetectionID.IsZero() {
+		return fmt.Errorf("%w: detection evidence envelope needs tenant, engagement, agent, asset and detection ids", shared.ErrValidation)
+	}
+	if e.KeyID == "" {
+		return fmt.Errorf("%w: detection evidence envelope has no signing key id", shared.ErrValidation)
+	}
+	if e.ContentSHA256 == "" {
+		return fmt.Errorf("%w: detection evidence envelope has no content commitment", shared.ErrValidation)
+	}
+	if !e.Provenance.Valid() {
+		return fmt.Errorf("%w: detection evidence envelope has an unknown provenance %q", shared.ErrValidation, e.Provenance)
+	}
+	if err := e.Detection.Validate(); err != nil {
+		return fmt.Errorf("%w: detection evidence envelope carries a malformed detection: %w", shared.ErrValidation, err)
+	}
+	return nil
+}
+
+// Canonical returns the deterministic bytes sealed into the evidence chain. It is stable across an
+// idempotent re-seal (no wall-clock fields), so SealOnce's content comparison converges on a retry.
+func (e DetectionEvidenceEnvelope) Canonical() ([]byte, error) {
+	if err := e.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(e)
+}
+
+// VerifyContent recomputes the detection content commitment and checks it equals the embedded, agent-signed
+// ContentSHA256 — so a link tampered after sealing (detection body changed) is detectable from the envelope
+// alone, with no projection needed.
+func (e DetectionEvidenceEnvelope) VerifyContent() error {
+	payload, err := json.Marshal(e.Detection)
+	if err != nil {
+		return fmt.Errorf("marshal envelope detection: %w", err)
+	}
+	if got := DetectionContentHash(payload, e.AssetID); got != e.ContentSHA256 {
+		return fmt.Errorf("%w: detection evidence envelope content does not match its commitment", shared.ErrValidation)
+	}
+	return nil
+}
+
+// DecodeDetectionEvidenceEnvelope parses a sealed chain link's content back into a validated envelope, so
+// a detection stays explainable from the permanent chain after its projection has expired.
+func DecodeDetectionEvidenceEnvelope(content []byte) (DetectionEvidenceEnvelope, error) {
+	var e DetectionEvidenceEnvelope
+	if err := json.Unmarshal(content, &e); err != nil {
+		return DetectionEvidenceEnvelope{}, fmt.Errorf("%w: cannot decode detection evidence envelope: %v", shared.ErrValidation, err)
+	}
+	if err := e.Validate(); err != nil {
+		return DetectionEvidenceEnvelope{}, err
+	}
+	return e, nil
+}

--- a/internal/domain/fleetagent/detection_evidence_test.go
+++ b/internal/domain/fleetagent/detection_evidence_test.go
@@ -1,0 +1,155 @@
+package fleetagent
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func mkEnvDetection(t *testing.T) detection.Detection {
+	t.Helper()
+	r, ok := detection.Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("expected det.process_enumeration rule")
+	}
+	ev := detection.Event{Class: detection.ClassProcess, At: time.Unix(1, 0), Host: "h",
+		Process: &detection.ProcessEvent{PID: 1, Comm: "ps", Path: "/usr/bin/ps"}}
+	d, err := detection.NewDetection(r, "host-1", "agent-1", []detection.Event{ev}, time.Unix(500, 0).UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func mkEnvelope(t *testing.T, prov ProvenanceState) DetectionEvidenceEnvelope {
+	t.Helper()
+	det := mkEnvDetection(t)
+	payload, err := json.Marshal(det)
+	if err != nil {
+		t.Fatal(err)
+	}
+	asset := shared.ID("asset-1")
+	env, err := NewDetectionEvidenceEnvelope("tenant-1", "eng-1", "agent-1", asset, "d1", 7, "key-1",
+		DetectionContentHash(payload, asset), prov, det)
+	if err != nil {
+		t.Fatalf("build envelope: %v", err)
+	}
+	return env
+}
+
+func TestDetectionEvidenceEnvelopeCanonicalIsDeterministic(t *testing.T) {
+	a := mkEnvelope(t, ProvenanceComplete)
+	b := mkEnvelope(t, ProvenanceComplete)
+	ab, err := a.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bb, err := b.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Deterministic: two builds of the same admission produce byte-identical sealed content, so an
+	// idempotent re-seal (SealOnce content comparison) converges instead of conflicting.
+	if string(ab) != string(bb) {
+		t.Fatalf("canonical bytes must be deterministic:\n a=%s\n b=%s", ab, bb)
+	}
+}
+
+func TestDetectionEvidenceEnvelopeRoundTripAndSelfContained(t *testing.T) {
+	env := mkEnvelope(t, ProvenanceComplete)
+	content, err := env.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Decode the sealed content ALONE (as if the projection has expired) — it must reconstruct the full
+	// attribution and stay self-verifying against its content commitment.
+	got, err := DecodeDetectionEvidenceEnvelope(content)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.TenantID != "tenant-1" || got.EngagementID != "eng-1" || got.AgentID != "agent-1" || got.AssetID != "asset-1" ||
+		got.DetectionID != "d1" || got.BatchSequence != 7 || got.KeyID != "key-1" || got.Provenance != ProvenanceComplete {
+		t.Fatalf("round-trip lost attribution: %+v", got)
+	}
+	if got.RuleID != env.Detection.RuleID {
+		t.Fatalf("round-trip lost rule provenance: %q vs %q", got.RuleID, env.Detection.RuleID)
+	}
+	if err := got.VerifyContent(); err != nil {
+		t.Fatalf("decoded envelope must self-verify: %v", err)
+	}
+}
+
+func TestDetectionEvidenceEnvelopeDetectsContentTamper(t *testing.T) {
+	env := mkEnvelope(t, ProvenanceComplete)
+	// Tamper the sealed detection body after commitment: VerifyContent must catch the mismatch from the
+	// envelope alone (no projection), because the embedded commitment no longer matches the detection.
+	env.Detection.Severity = shared.SeverityCritical
+	if err := env.VerifyContent(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a tampered detection body must fail VerifyContent, got %v", err)
+	}
+}
+
+func TestDecodeRejectsForeignContent(t *testing.T) {
+	// A plain detection JSON (no domain-separation context) must not decode as an evidence envelope.
+	raw, err := json.Marshal(mkEnvDetection(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeDetectionEvidenceEnvelope(raw); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("foreign content must be rejected, got %v", err)
+	}
+}
+
+func TestProvenanceStateValid(t *testing.T) {
+	for _, p := range []ProvenanceState{ProvenancePending, ProvenanceComplete, ProvenanceExpired, ProvenanceBroken} {
+		if !p.Valid() {
+			t.Fatalf("%q must be valid", p)
+		}
+	}
+	if ProvenanceState("nonsense").Valid() {
+		t.Fatal("unknown provenance must be invalid")
+	}
+}
+
+func TestDetectionEvidenceEnvelopeValidate(t *testing.T) {
+	det := mkEnvDetection(t)
+	payload, _ := json.Marshal(det)
+	asset := shared.ID("asset-1")
+	digest := DetectionContentHash(payload, asset)
+	base := func() DetectionEvidenceEnvelope {
+		e, err := NewDetectionEvidenceEnvelope("tenant-1", "eng-1", "agent-1", asset, "d1", 1, "key-1", digest, ProvenanceComplete, det)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return e
+	}
+	// unknown provenance
+	if _, err := NewDetectionEvidenceEnvelope("tenant-1", "eng-1", "agent-1", asset, "d1", 1, "key-1", digest, ProvenanceState("x"), det); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unknown provenance must be rejected, got %v", err)
+	}
+	// missing ids / key / commitment
+	e := base()
+	e.AgentID = ""
+	if err := e.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing agent id must fail, got %v", err)
+	}
+	e = base()
+	e.KeyID = ""
+	if err := e.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing key id must fail, got %v", err)
+	}
+	e = base()
+	e.ContentSHA256 = ""
+	if err := e.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing commitment must fail, got %v", err)
+	}
+	e = base()
+	e.Context = "wrong"
+	if err := e.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("wrong context must fail, got %v", err)
+	}
+}

--- a/internal/usecase/fleet/detectledger/service.go
+++ b/internal/usecase/fleet/detectledger/service.go
@@ -184,10 +184,27 @@ func (s *Service) Ingest(ctx context.Context, authAgentID shared.ID, batch fleet
 		if err != nil {
 			return result, fmt.Errorf("marshal detection %s: %w", it.ID, err)
 		}
-		// Content binding: the signed ref for this id must match a digest of the bytes we are about to
-		// seal (detection + asset). A body swapped in transit for a known id is refused here.
+		// Content binding: the signed ref for this id must match a digest of the bytes the agent committed
+		// to (detection + asset). A body swapped in transit for a known id is refused here.
 		if got := fleetagent.DetectionContentHash(payload, it.AssetID); got != refByID[it.ID].ContentSHA256 {
 			return result, fmt.Errorf("%w: detection %s content does not match its signed digest", shared.ErrValidation, it.ID)
+		}
+		// A5 (#626): seal a SELF-CONTAINED DetectionEvidenceEnvelope as the permanent chain link — the
+		// detection plus its full attribution (tenant/agent/asset/engagement), the admitting batch identity,
+		// the agent's content commitment, and rule provenance — so the link stays verifiable and explainable
+		// after the expirable projection row is swept. The envelope is deterministic (no ingest clock), so
+		// the SealOnce content comparison still converges on an idempotent retry. Provenance is Complete: the
+		// detection evidence is durably sealed (the raw-telemetry-durability cross-check is a read-layer tail).
+		envelope, err := fleetagent.NewDetectionEvidenceEnvelope(
+			tenantID, batch.EngagementID, batch.AgentID, it.AssetID, it.ID, batch.Sequence,
+			batch.KeyID, refByID[it.ID].ContentSHA256, fleetagent.ProvenanceComplete, it.Detection,
+		)
+		if err != nil {
+			return result, fmt.Errorf("build detection %s evidence envelope: %w", it.ID, err)
+		}
+		content, err := envelope.Canonical()
+		if err != nil {
+			return result, fmt.Errorf("canonicalize detection %s evidence envelope: %w", it.ID, err)
 		}
 		// Fast-path idempotent resume: skip a detection whose projection row already exists FOR THIS
 		// engagement (a retry after a fully-completed item). The skip is engagement-scoped to match the
@@ -201,7 +218,7 @@ func (s *Service) Ingest(ctx context.Context, authAgentID shared.ID, batch fleet
 			result.Skipped = append(result.Skipped, it.ID)
 			continue
 		}
-		evID, err := s.chain.SealOnce(ctx, batch.EngagementID, evidenceKindDetection, it.ID.String(), payload, batch.AgentID.String())
+		evID, err := s.chain.SealOnce(ctx, batch.EngagementID, evidenceKindDetection, it.ID.String(), content, batch.AgentID.String())
 		if err != nil {
 			return result, fmt.Errorf("seal detection %s: %w", it.ID, err)
 		}

--- a/internal/usecase/fleet/detectledger/service_test.go
+++ b/internal/usecase/fleet/detectledger/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -29,6 +30,7 @@ type fakeChain struct {
 	mu      sync.Mutex
 	seals   []sealCall           // one entry per link ACTUALLY appended; an idempotent replay adds none
 	byKey   map[string]shared.ID // (engagement, idempotency key) -> the id of the link sealed for it
+	content map[string][]byte    // (engagement, idempotency key) -> the sealed content bytes
 	n       int
 	broken  bool
 	sealErr error
@@ -40,7 +42,7 @@ func sealKey(eng shared.ID, key string) string { return string(eng) + "\x00" + k
 
 // SealOnce models the real chain's idempotency contract: a repeated (engagement, key) returns the existing
 // link and appends NOTHING new, so a test can prove a detection is sealed into the chain at most once.
-func (c *fakeChain) SealOnce(_ context.Context, eng shared.ID, kind, key string, _ []byte, by string) (shared.ID, error) {
+func (c *fakeChain) SealOnce(_ context.Context, eng shared.ID, kind, key string, content []byte, by string) (shared.ID, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.sealErr != nil {
@@ -49,6 +51,9 @@ func (c *fakeChain) SealOnce(_ context.Context, eng shared.ID, kind, key string,
 	if c.byKey == nil {
 		c.byKey = map[string]shared.ID{}
 	}
+	if c.content == nil {
+		c.content = map[string][]byte{}
+	}
 	k := sealKey(eng, key)
 	if id, ok := c.byKey[k]; ok {
 		return id, nil // idempotent: same (engagement, key) -> same link, nothing appended
@@ -56,8 +61,16 @@ func (c *fakeChain) SealOnce(_ context.Context, eng shared.ID, kind, key string,
 	c.n++
 	id := shared.ID("ev-" + itoa(c.n))
 	c.byKey[k] = id
+	c.content[k] = append([]byte(nil), content...)
 	c.seals = append(c.seals, sealCall{eng, kind, by, key})
 	return id, nil
+}
+
+// contentFor returns the sealed content bytes for (engagement, key), under the same lock.
+func (c *fakeChain) contentFor(eng shared.ID, key string) []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.content[sealKey(eng, key)]
 }
 
 // idFor returns the link id sealed for (engagement, key), read under the same lock that guards byKey, so a
@@ -268,6 +281,32 @@ func TestIngestRejectsIdentityMismatch(t *testing.T) {
 	}
 	if !h.audit.has("detection.batch_rejected") {
 		t.Error("an identity-mismatched batch must be audited as rejected")
+	}
+}
+
+func TestIngestSealsSelfContainedEvidenceEnvelope(t *testing.T) {
+	h := newHarness(t, 0)
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	if _, err := h.svc.Ingest(tctx(), "agent:1", h.signedBatch(t, 1, items), items); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	// A5 (#626): the sealed chain content must be a SELF-CONTAINED DetectionEvidenceEnvelope, decodable and
+	// verifiable from the chain link ALONE (no projection read here) — exactly the property needed after the
+	// expirable projection row is swept.
+	content := h.chain.contentFor("eng-1", "d1")
+	if len(content) == 0 {
+		t.Fatal("no sealed content captured")
+	}
+	env, err := fleetagent.DecodeDetectionEvidenceEnvelope(content)
+	if err != nil {
+		t.Fatalf("sealed content must decode as an evidence envelope: %v", err)
+	}
+	if env.TenantID != "t1" || env.EngagementID != "eng-1" || env.AgentID != "agent:1" || env.AssetID != "asset-1" ||
+		env.DetectionID != "d1" || env.BatchSequence != 1 || env.Provenance != fleetagent.ProvenanceComplete {
+		t.Fatalf("envelope attribution wrong: %+v", env)
+	}
+	if err := env.VerifyContent(); err != nil {
+		t.Fatalf("sealed envelope must self-verify against its commitment: %v", err)
 	}
 }
 
@@ -503,6 +542,73 @@ func TestExpireIsAuditedAndRequiresActorReason(t *testing.T) {
 // projection write fails AFTER a successful seal, a retry finds no row (HasDetection is false) and, with
 // a naive Seal, would append a SECOND chain link for the same detection. Because SealOnce is keyed on the
 // detection id, the retry returns the first link instead — the detection is sealed exactly once.
+// TestIngestSealsOnceThroughRealEvidenceServiceAcrossProjectionCrash supersedes the fake-backed D3 test
+// (A5, #626): it runs the seal-then-projection-crash retry through the REAL evidence.Service.SealOnce
+// (memory-backed vault, bridged as the ledger's chain), proving the production seal path itself leaves
+// exactly ONE permanent chain link — and that the link is the self-contained envelope.
+func TestIngestSealsOnceThroughRealEvidenceServiceAcrossProjectionCrash(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	audit := &fakeAudit{}
+	clock := fixedClock{t: time.Unix(1000, 0)}
+	ids := &seqIDs{}
+	evSvc, err := evidenceuc.NewService(memory.NewEvidenceStore(), nil, audit, clock, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bridge, err := NewEvidenceChainBridge(
+		func(ctx context.Context, eng shared.ID, kind, idem string, content []byte, by string) (shared.ID, error) {
+			ev, serr := evSvc.SealOnce(ctx, eng, kind, idem, content, by)
+			if serr != nil {
+				return "", serr
+			}
+			return ev.ID, nil
+		},
+		func(ctx context.Context, eng shared.ID) error { return evSvc.VerifyChainError(ctx, eng) },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	records := &failingRecords{DetectionRecordStore: memory.NewDetectionRecordStore(), failAppend: 1}
+	key := mkSigningKey(t, "agent:1", pub)
+	keys := &fakeKeys{byAgent: map[shared.ID]fleetagent.AgentSigningKey{"agent:1": key}}
+	svc, err := NewService(records, bridge, keys, audit, clock, ids, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items := []IngestItem{{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"}}
+	b := fleetagent.AgentBatch{AgentID: "agent:1", EngagementID: "eng-1", Sequence: 1, KeyID: key.KeyID, Detections: refsFor(t, items)}
+	b.Signature = fleetagent.SignBatch(priv, b)
+
+	// First ingest: the real seal succeeds, then the injected projection write fails.
+	if _, err := svc.Ingest(tctx(), b.AgentID, b, items); err == nil {
+		t.Fatal("expected the injected projection-write failure to surface")
+	}
+	// Retry the SAME batch through the real service (projection row still missing → HasDetection false).
+	if _, err := svc.Ingest(tctx(), b.AgentID, b, items); err != nil {
+		t.Fatalf("retry must complete: %v", err)
+	}
+	// D3: the real vault holds exactly ONE permanent detection link.
+	links, err := evSvc.List(tctx(), "eng-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("D3: exactly one permanent chain link expected, got %d", len(links))
+	}
+	if links[0].Kind != evidenceKindDetection {
+		t.Fatalf("the link must be kind=detection, got %q", links[0].Kind)
+	}
+	// The permanent link is the self-contained envelope and verifies on its own.
+	env, err := fleetagent.DecodeDetectionEvidenceEnvelope(links[0].Content)
+	if err != nil {
+		t.Fatalf("permanent link must decode as an evidence envelope: %v", err)
+	}
+	if err := env.VerifyContent(); err != nil {
+		t.Fatalf("permanent envelope must self-verify: %v", err)
+	}
+}
+
 func TestIngestNeverDoubleSealsAfterProjectionFailure(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	chain := &fakeChain{}


### PR DESCRIPTION
## A5 — self-contained detection evidence envelope + provenance (#626)

Makes a sealed detection's evidence **self-contained and permanent** (EPIC #594 spine, A0→…→A4→**A5**). The evidence-chain link now holds a `DetectionEvidenceEnvelope` instead of raw detection bytes, so it stays verifiable and explainable **after the expirable projection row is swept**.

### What's in this PR
- **domain/fleetagent `DetectionEvidenceEnvelope`** — self-contained: the detection plus its full attribution (tenant / engagement / agent / asset / detection ids, admitting batch sequence, signing `KeyID`, rule provenance) and the **agent-signed content commitment** (`ContentSHA256`), domain-separated (`synapse-detection-evidence:v1`). It is **deterministic** (no ingest wall-clock — `ObservedAt` derives from `Detection.Observed`), so an idempotent re-seal produces byte-identical content and the A4 `SealOnce` converges instead of conflicting. `Canonical`, `Validate`, `VerifyContent` (recompute the commitment from the envelope alone), `DecodeDetectionEvidenceEnvelope`.
- **`ProvenanceState`** enum (pending / complete / expired / broken). The **immutable** link records the admission state `Complete` ("detection evidence durably sealed") and never over-claims raw-telemetry-stream durability; pending / expired / broken are documented as the **mutable read-layer** lifecycle (a chain link can't be rewritten).
- **usecase/fleet/detectledger `Ingest`** — verifies the agent-signed content digest against the raw detection (**unchanged**), then seals the envelope's canonical bytes under the same idempotency key (detection id). No step in the A4 trust chain (A0.1 identity, key resolution, `VerifyBatchWithKey`, schema, content binding, `SealOnce` idempotency) is weakened.

### Contracts honored
Permanent, self-contained `DetectionEvidenceEnvelope` that survives projection expiry · canonical, domain-separated, purpose-key-signed commitment (the agent's `PurposeDetectionBatch` signature over the embedded `ContentSHA256`) · provenance state carried on the permanent link · no distributed transaction (the envelope is sealed via the single A4 atomic `SealOnce`).

### Verification
- `go build` / `go vet` / `gofmt` clean; `-race` green across fleetagent, detectledger, evidence, httpapi.
- Tests: envelope determinism; round-trip decode + self-verify from the chain link alone (projection-expiry property); post-seal detection-body tamper detection; foreign/again-domain-separated content rejection; provenance validity; and a **real-evidence-service (memory-backed, bridged) D3 test** proving a seal-then-projection-crash retry leaves **exactly one** permanent envelope link — superseding the A0.5 fake-backed test.
- Dual review (go-arch + security): **security CLEAN** (no findings — evidence integrity, attribution server-authoritative, determinism/idempotency, provenance honesty, no regression all confirmed); **go-arch PASS** (dependency rule clean, no blockers; the determinism/idempotency hazard is correctly avoided and test-locked).

### Scope / follow-up
The concrete atomic `evidence.Service.SealOnce` already landed in **A4 (#652)**; this PR closes the **detection-side self-contained-evidence** half of A5. Remaining A5 tail (kept open on **#626**): the telemetry **canonical Merkle-commitment + retention/proof model**, and the **live provenance state machine** (TelemetryDurable cross-check + queryable projection provenance column).
