### PR TITLE
fix(ai-triage): admit release approvers from an operator-owned allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
   precondition reports pair counts in dedicated `*_count` failure fields, so the basis-point fields
   of a promotion failure always mean a rate.
 
+- **Operator-owned human approver allowlist on AI-triage releases.** Recording a promotion or rollback
+  now requires `--human-approvers`, a private operator-owned allowlist an approver identity must appear
+  in. The release manifest names its own PM and Security approvers, so previously the only test of their
+  humanness was a reserved machine-prefix denylist, which by construction cannot recognise an identity
+  scheme it has never seen; the allowlist admits identities from outside the artifact being validated.
+  It is enforced when a decision is admitted, not when stored history is re-validated, so an approver
+  leaving the allowlist never invalidates a ledger they already signed.
+
 - **AI-triage escape rate measured against the exemptible population.** Evaluation reports now carry
   `exemptible_true_positives` and `exemptible_escape_rate` alongside the corpus-wide rate, and the
   promotion boundary reads the exemptible denominator. A true positive a human-review floor holds

--- a/cmd/synapse-fptriage-release/main.go
+++ b/cmd/synapse-fptriage-release/main.go
@@ -22,16 +22,17 @@ func main() {
 	baselinePath := flag.String("baseline", "", "baseline synapse-ai-triage-evaluation-v4 report (promotion only)")
 	candidatePath := flag.String("candidate", "", "candidate synapse-ai-triage-evaluation-v4 report (promotion only)")
 	outputPath := flag.String("output", "", "new path for the append-only release ledger")
+	humanApproversPath := flag.String("human-approvers", "", "private operator-owned allowlist file, one human approver identity per line")
 	printDigest := flag.Bool("print-review-digest", false, "print the digest PM/Security must approve without writing a ledger")
 	flag.Parse()
 
-	if err := run(*manifestPath, *ledgerPath, *comparisonPath, *baselinePath, *candidatePath, *outputPath, *printDigest, os.Stdout); err != nil {
+	if err := run(*manifestPath, *ledgerPath, *comparisonPath, *baselinePath, *candidatePath, *outputPath, *humanApproversPath, *printDigest, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "synapse-fptriage-release: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(manifestPath, ledgerPath, comparisonPath, baselinePath, candidatePath, outputPath string, printDigest bool, stdout io.Writer) error {
+func run(manifestPath, ledgerPath, comparisonPath, baselinePath, candidatePath, outputPath, humanApproversPath string, printDigest bool, stdout io.Writer) error {
 	manifestPath, ledgerPath, comparisonPath = strings.TrimSpace(manifestPath), strings.TrimSpace(ledgerPath), strings.TrimSpace(comparisonPath)
 	baselinePath, candidatePath, outputPath = strings.TrimSpace(baselinePath), strings.TrimSpace(candidatePath), strings.TrimSpace(outputPath)
 	if manifestPath == "" {
@@ -87,16 +88,66 @@ func run(manifestPath, ledgerPath, comparisonPath, baselinePath, candidatePath, 
 	if outputPath == "" || outputPath == "-" {
 		return fmt.Errorf("--output must be a new ledger file path")
 	}
-	for _, input := range []string{manifestPath, ledgerPath, comparisonPath, baselinePath, candidatePath} {
+	for _, input := range []string{manifestPath, ledgerPath, comparisonPath, baselinePath, candidatePath, strings.TrimSpace(humanApproversPath)} {
 		if input != "" && sameReleasePath(outputPath, input) {
 			return fmt.Errorf("--output must not overwrite an input artifact")
 		}
 	}
-	updated, err := sca.ApplyAIEvaluationRelease(ledger, evidence, manifest)
+	approvers, err := loadHumanApprovers(humanApproversPath)
+	if err != nil {
+		return err
+	}
+	updated, err := sca.ApplyAIEvaluationRelease(ledger, evidence, manifest, approvers)
 	if err != nil {
 		return err
 	}
 	return writeReleaseLedger(outputPath, updated)
+}
+
+// loadHumanApprovers reads the operator-owned allowlist. It is required only on the path that writes a
+// decision: --print-review-digest runs before PM and Security have approved anything, so demanding the
+// allowlist there would gate printing a digest on a file that has nothing yet to check.
+func loadHumanApprovers(path string) ([]string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("--human-approvers is required to record a release decision")
+	}
+	if err := requirePrivateFile(path); err != nil {
+		return nil, fmt.Errorf("human approver allowlist: %w", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read human approver allowlist: %w", err)
+	}
+	var approvers []string
+	for _, line := range strings.Split(string(b), "\n") {
+		if identity := strings.TrimSpace(line); identity != "" && !strings.HasPrefix(identity, "#") {
+			approvers = append(approvers, identity)
+		}
+	}
+	if len(approvers) == 0 {
+		return nil, fmt.Errorf("human approver allowlist is empty")
+	}
+	return approvers, nil
+}
+
+// requirePrivateFile refuses an allowlist any other account can read or replace, mirroring the same
+// guard in synapse-fptriage-blind: an allowlist a second party can edit admits whoever they choose.
+func requirePrivateFile(path string) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("private input files are not supported on Windows: current-user-only ACL verification is unavailable in this command")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat private input: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("private input must be a regular file, not a symlink or special file")
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("private input must not grant group or other access")
+	}
+	return nil
 }
 
 func loadPromotionEvidence(comparisonPath, baselinePath, candidatePath string) (sca.AIEvaluationPromotionEvidence, error) {

--- a/cmd/synapse-fptriage-release/main_test.go
+++ b/cmd/synapse-fptriage-release/main_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,19 +53,20 @@ func TestRunCreatesPromotionAndRollbackLedger(t *testing.T) {
 	baselinePath := writeReleaseFixture(t, dir, "baseline.json", baseline)
 	candidatePath := writeReleaseFixture(t, dir, "candidate.json", candidate)
 	comparisonPath := writeReleaseFixture(t, dir, "comparison.json", comparison)
+	approversPath := writeReleaseApprovers(t, dir, "approvers.txt", 0o600)
 
 	promotion := sca.AIEvaluationReleaseManifest{SchemaVersion: sca.AIEvaluationReleaseManifestSchema,
 		Version: "release-canary", Action: sca.AIEvaluationReleasePromote, Provenance: "security/change-42", ComparisonID: comparison.ComparisonID}
 	promotionPath := writeReleaseFixture(t, dir, "promotion.json", promotion)
 	var digestOutput bytes.Buffer
-	if err := run(promotionPath, "", comparisonPath, baselinePath, candidatePath, "", true, &digestOutput); err != nil {
+	if err := run(promotionPath, "", comparisonPath, baselinePath, candidatePath, "", "", true, &digestOutput); err != nil {
 		t.Fatalf("print promotion digest: %v", err)
 	}
 	digest := releaseDigest(t, digestOutput.Bytes())
 	promotion.Approvals = releaseApprovals(digest)
 	promotionPath = writeReleaseFixture(t, dir, "promotion-approved.json", promotion)
 	ledgerPath := filepath.Join(dir, "ledger-v1.json")
-	if err := run(promotionPath, "", comparisonPath, baselinePath, candidatePath, ledgerPath, false, &bytes.Buffer{}); err != nil {
+	if err := run(promotionPath, "", comparisonPath, baselinePath, candidatePath, ledgerPath, approversPath, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("promote: %v", err)
 	}
 	ledger := loadReleaseLedger(t, ledgerPath)
@@ -76,18 +78,54 @@ func TestRunCreatesPromotionAndRollbackLedger(t *testing.T) {
 		Version: "release-rollback", Action: sca.AIEvaluationReleaseRollback, Provenance: "incident/42", RollbackTo: "initial"}
 	rollbackPath := writeReleaseFixture(t, dir, "rollback.json", rollback)
 	digestOutput.Reset()
-	if err := run(rollbackPath, ledgerPath, "", "", "", "", true, &digestOutput); err != nil {
+	if err := run(rollbackPath, ledgerPath, "", "", "", "", "", true, &digestOutput); err != nil {
 		t.Fatalf("print rollback digest: %v", err)
 	}
 	rollback.Approvals = releaseApprovals(releaseDigest(t, digestOutput.Bytes()))
 	rollbackPath = writeReleaseFixture(t, dir, "rollback-approved.json", rollback)
 	rolledBackPath := filepath.Join(dir, "ledger-v2.json")
-	if err := run(rollbackPath, ledgerPath, "", "", "", rolledBackPath, false, &bytes.Buffer{}); err != nil {
+	if err := run(rollbackPath, ledgerPath, "", "", "", rolledBackPath, approversPath, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
 	rolledBack := loadReleaseLedger(t, rolledBackPath)
 	if len(rolledBack.Decisions) != 2 || rolledBack.Decisions[1].ActiveRun.PromptVersion != "prompt-v1" {
 		t.Fatalf("rollback ledger = %+v", rolledBack)
+	}
+}
+
+func TestRunRequiresAPrivateHumanApproverAllowlistToRecordADecision(t *testing.T) {
+	dir := t.TempDir()
+	baseline := releaseFixtureReport(t, "prompt-v1")
+	candidate := releaseFixtureReport(t, "prompt-v2")
+	comparison, err := sca.CompareAIEvaluationReports(baseline, candidate, sca.DefaultAIEvaluationPromotionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	baselinePath := writeReleaseFixture(t, dir, "baseline.json", baseline)
+	candidatePath := writeReleaseFixture(t, dir, "candidate.json", candidate)
+	comparisonPath := writeReleaseFixture(t, dir, "comparison.json", comparison)
+	promotion := sca.AIEvaluationReleaseManifest{SchemaVersion: sca.AIEvaluationReleaseManifestSchema,
+		Version: "release-canary", Action: sca.AIEvaluationReleasePromote, Provenance: "security/change-42", ComparisonID: comparison.ComparisonID}
+	var digestOutput bytes.Buffer
+	if err := run(writeReleaseFixture(t, dir, "promotion.json", promotion), "", comparisonPath, baselinePath, candidatePath, "", "", true, &digestOutput); err != nil {
+		t.Fatalf("print promotion digest: %v", err)
+	}
+	promotion.Approvals = releaseApprovals(releaseDigest(t, digestOutput.Bytes()))
+	promotionPath := writeReleaseFixture(t, dir, "promotion-approved.json", promotion)
+
+	// A world-readable allowlist is one a second party can edit, which would let them admit whoever they
+	// choose; an absent one leaves the manifest asserting its own approvers are human.
+	shared := writeReleaseApprovers(t, dir, "shared-approvers.txt", 0o644)
+	for name, approvers := range map[string]string{"absent": "", "group readable": shared} {
+		t.Run(name, func(t *testing.T) {
+			ledgerPath := filepath.Join(dir, "ledger-"+strings.ReplaceAll(name, " ", "-")+".json")
+			if err := run(promotionPath, "", comparisonPath, baselinePath, candidatePath, ledgerPath, approvers, false, &bytes.Buffer{}); err == nil {
+				t.Fatal("release decision was recorded without a private human approver allowlist")
+			}
+			if _, err := os.Lstat(ledgerPath); !os.IsNotExist(err) {
+				t.Fatalf("rejected release still wrote a ledger: %v", err)
+			}
+		})
 	}
 }
 
@@ -149,6 +187,18 @@ func writeReleaseFixture(t *testing.T, dir, name string, value any) string {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeReleaseApprovers(t *testing.T, dir, name string, perm os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("# operator-owned allowlist\npm@example.com\nsecurity@example.com\n"), perm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, perm); err != nil {
 		t.Fatal(err)
 	}
 	return path

--- a/docs/guide/ai-triage-evaluation.md
+++ b/docs/guide/ai-triage-evaluation.md
@@ -339,7 +339,24 @@ go run ./cmd/synapse-fptriage-release \
 One PM and one Security reviewer must independently add approvals in canonical order. They must be
 distinct human identities; model names and reserved machine principals are rejected. Each approval
 contains `role`, `reviewer`, `approved: true`, a rationale, a UTC `reviewed_at`, and the exact
-`reviewed_sha256` printed above. After approval, create the first ledger:
+`reviewed_sha256` printed above.
+
+Recording a decision also requires `--human-approvers`, an operator-owned allowlist of the identities
+permitted to approve a release — one per line, `#` comments allowed, and the file must not grant group
+or other access. The manifest names its own approvers, so the allowlist is what admits an identity from
+outside the artifact being validated; the machine-prefix denylist only rejects the non-human identity
+families this codebase already mints, and cannot recognise one it has never heard of. Printing the review
+digest does not require the allowlist, because at that point nobody has approved anything yet.
+
+```
+# operator-owned; readable only by the release operator
+pm@example.com
+security@example.com
+```
+
+The allowlist is checked when a decision is admitted, never when an existing ledger is re-validated. An
+approver who later leaves the allowlist does not invalidate the decisions they already signed, and a
+stored ledger still loads where the allowlist is unavailable. After approval, create the first ledger:
 
 ```bash
 go run ./cmd/synapse-fptriage-release \
@@ -347,6 +364,7 @@ go run ./cmd/synapse-fptriage-release \
   --comparison ai-triage-comparison.json \
   --baseline ai-triage-baseline.json \
   --candidate ai-triage-candidate.json \
+  --human-approvers ai-triage-human-approvers.txt \
   --output ai-triage-release-ledger-v2.json
 ```
 

--- a/internal/usecase/sca/fptriage_release.go
+++ b/internal/usecase/sca/fptriage_release.go
@@ -244,12 +244,26 @@ func AIEvaluationReleaseReviewDigest(ledger AIEvaluationReleaseLedger, evidence 
 
 // ApplyAIEvaluationRelease appends an approved promotion or rollback. It does not mutate runtime
 // configuration, model clients, prompts, thresholds, findings, or gate state.
-func ApplyAIEvaluationRelease(ledger AIEvaluationReleaseLedger, evidence *AIEvaluationPromotionEvidence, manifest AIEvaluationReleaseManifest) (AIEvaluationReleaseLedger, error) {
+//
+// allowedHumanApprovers is the operator-owned allowlist an approver identity must appear in. The
+// manifest is operator-supplied input that names its own approvers, so on its own "these two are human"
+// is a claim the manifest makes about itself: the machine-prefix denylist can only reject the identity
+// families this codebase already mints, and fails open on any other. The allowlist is what admits an
+// identity from outside the artifact being validated.
+//
+// It is required here, at admission, and deliberately not consulted by Validate. A decision keeps the
+// approvers it was admitted with, so an approver who later leaves the allowlist must not retroactively
+// invalidate the ledger they signed, nor stop that ledger from loading.
+func ApplyAIEvaluationRelease(ledger AIEvaluationReleaseLedger, evidence *AIEvaluationPromotionEvidence, manifest AIEvaluationReleaseManifest, allowedHumanApprovers []string) (AIEvaluationReleaseLedger, error) {
 	digest, err := AIEvaluationReleaseReviewDigest(ledger, evidence, manifest)
 	if err != nil {
 		return AIEvaluationReleaseLedger{}, err
 	}
-	if err := validateReleaseApprovals(manifest.Approvals, digest, releaseModelIdentities(ledger, evidence, manifest)); err != nil {
+	models := releaseModelIdentities(ledger, evidence, manifest)
+	if err := validateReleaseApprovals(manifest.Approvals, digest, models); err != nil {
+		return AIEvaluationReleaseLedger{}, err
+	}
+	if err := validateReleaseApproverAllowlist(manifest.Approvals, allowedHumanApprovers, models); err != nil {
 		return AIEvaluationReleaseLedger{}, err
 	}
 	for _, decision := range ledger.Decisions {
@@ -463,6 +477,38 @@ func validateReleaseApprovals(approvals []AIEvaluationReleaseApproval, digest st
 		return fmt.Errorf("AI evaluation release approvals must be ordered pm then security")
 	}
 	return nil
+}
+
+// validateReleaseApproverAllowlist requires every approver to appear in the operator-owned allowlist.
+// It is the positive counterpart to the machine-prefix denylist in validateReleaseApprovals, which can
+// only name the non-human families this codebase already mints.
+//
+// An empty list is a refusal rather than a skip: a release recorded without an allowlist to check
+// against would carry exactly the self-asserted approval this exists to prevent.
+//
+// The match is exact, not the case-insensitive comparison used for approver distinctness, so an
+// allowlist entry admits one spelling of one identity. Each entry is re-checked against the denylist so
+// the allowlist cannot launder a machine principal, mirroring validateBlindFPTriageReviewer.
+func validateReleaseApproverAllowlist(approvals []AIEvaluationReleaseApproval, allowedHumanApprovers, models []string) error {
+	if len(allowedHumanApprovers) == 0 {
+		return fmt.Errorf("AI evaluation release requires an operator-supplied human approver allowlist")
+	}
+	for _, approval := range approvals {
+		if !releaseApproverIsAllowed(approval.Reviewer, allowedHumanApprovers, models) {
+			return fmt.Errorf("AI evaluation release approver %q is not an allowlisted human", approval.Reviewer)
+		}
+	}
+	return nil
+}
+
+func releaseApproverIsAllowed(reviewer string, allowedHumanApprovers, models []string) bool {
+	for _, allowed := range allowedHumanApprovers {
+		if reviewer == allowed && allowed == strings.TrimSpace(allowed) &&
+			!aitriagereview.IsMachineOrModelActor(allowed, models...) {
+			return true
+		}
+	}
+	return false
 }
 
 func validateReleaseRun(run AIEvaluationRun) error {

--- a/internal/usecase/sca/fptriage_release_test.go
+++ b/internal/usecase/sca/fptriage_release_test.go
@@ -13,7 +13,7 @@ func TestAIEvaluationReleasePromotionAndRollbackAreVersionedAndChained(t *testin
 	manifest := releaseTestManifest("release-2026-08-canary", AIEvaluationReleasePromote, comparison.ComparisonID, "")
 	manifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &evidence, manifest)
 
-	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest, releaseTestApprovers())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +24,7 @@ func TestAIEvaluationReleasePromotionAndRollbackAreVersionedAndChained(t *testin
 
 	rollback := releaseTestManifest("release-2026-08-rollback", AIEvaluationReleaseRollback, "", "initial")
 	rollback.Approvals = releaseTestApprovals(t, ledger, nil, rollback)
-	ledger, err = ApplyAIEvaluationRelease(ledger, nil, rollback)
+	ledger, err = ApplyAIEvaluationRelease(ledger, nil, rollback, releaseTestApprovers())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,10 +57,77 @@ func TestAIEvaluationReleaseRejectsMachineDuplicateAndReplayedApprovals(t *testi
 			changed := manifest
 			changed.Approvals = append([]AIEvaluationReleaseApproval(nil), manifest.Approvals...)
 			mutate(&changed)
-			if _, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, changed); err == nil {
+			if _, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, changed, releaseTestApprovers()); err == nil {
 				t.Fatal("unsafe release approval was accepted")
 			}
 		})
+	}
+}
+
+func TestAIEvaluationReleaseRequiresAllowlistedHumanApprovers(t *testing.T) {
+	evidence := releaseTestEvidence(t)
+	comparison := evidence.Comparison
+	manifest := releaseTestManifest("release-canary", AIEvaluationReleasePromote, comparison.ComparisonID, "")
+	manifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &evidence, manifest)
+
+	rejected := map[string][]string{
+		"no allowlist":            nil,
+		"empty allowlist":         {},
+		"security absent":         {"pm@example.com"},
+		"case differs":            {"PM@example.com", "security@example.com"},
+		"entry is not trimmed":    {" pm@example.com", "security@example.com"},
+		"machine principal entry": {"system:release", "security@example.com"},
+	}
+	for name, approvers := range rejected {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest, approvers); err == nil {
+				t.Fatal("release recorded an approver the operator never admitted")
+			}
+		})
+	}
+
+	// The denylist keeps its say: an allowlist entry cannot launder a model identity into an approval.
+	launder := manifest
+	launder.Approvals = append([]AIEvaluationReleaseApproval(nil), manifest.Approvals...)
+	launder.Approvals[0].Reviewer = comparison.CandidateRun.ProposerModel
+	if _, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, launder,
+		[]string{comparison.CandidateRun.ProposerModel, "security@example.com"}); err == nil {
+		t.Fatal("allowlisting a model identity admitted it as a human approver")
+	}
+
+	if _, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest, releaseTestApprovers()); err != nil {
+		t.Fatalf("allowlisted approvers were rejected: %v", err)
+	}
+}
+
+// A decision keeps the approvers it was admitted with. An approver who later leaves the allowlist -- or
+// a ledger read somewhere the allowlist is not available at all -- must not invalidate signed history,
+// otherwise the append-only evidence chain would stop loading on a staffing change.
+func TestAIEvaluationReleaseLedgerValidatesWithoutTheApproverAllowlist(t *testing.T) {
+	evidence := releaseTestEvidence(t)
+	manifest := releaseTestManifest("release-canary", AIEvaluationReleasePromote, evidence.Comparison.ComparisonID, "")
+	manifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &evidence, manifest)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest, releaseTestApprovers())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.Validate(); err != nil {
+		t.Fatalf("signed history failed to validate without an allowlist: %v", err)
+	}
+	b, err := json.Marshal(ledger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadAIEvaluationReleaseLedger(b)
+	if err != nil || loaded.HeadDecisionID != ledger.HeadDecisionID {
+		t.Fatalf("stored ledger no longer loads: %+v err=%v", loaded, err)
+	}
+
+	// The next decision still has to clear the allowlist in force now.
+	rollback := releaseTestManifest("release-rollback", AIEvaluationReleaseRollback, "", "initial")
+	rollback.Approvals = releaseTestApprovals(t, ledger, nil, rollback)
+	if _, err := ApplyAIEvaluationRelease(ledger, nil, rollback, []string{"pm@example.com"}); err == nil {
+		t.Fatal("a later decision skipped the current allowlist")
 	}
 }
 
@@ -80,7 +147,7 @@ func TestAIEvaluationReleaseRejectsBlockedComparisonAndTamperedLedger(t *testing
 
 	manifest = releaseTestManifest("release-canary", AIEvaluationReleasePromote, comparison.ComparisonID, "")
 	manifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &evidence, manifest)
-	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest, releaseTestApprovers())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +162,7 @@ func TestAIEvaluationReleaseRejectsUnknownAndCurrentRollbackTargets(t *testing.T
 	comparison := evidence.Comparison
 	manifest := releaseTestManifest("release-canary", AIEvaluationReleasePromote, comparison.ComparisonID, "")
 	manifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &evidence, manifest)
-	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &evidence, manifest, releaseTestApprovers())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +178,7 @@ func TestAIEvaluationReleaseApprovalCannotReplayAfterLedgerHeadChanges(t *testin
 	firstEvidence := releaseTestEvidenceFor(t, "prompt-v1", "prompt-v2")
 	first := releaseTestManifest("release-one", AIEvaluationReleasePromote, firstEvidence.Comparison.ComparisonID, "")
 	first.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &firstEvidence, first)
-	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &firstEvidence, first)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &firstEvidence, first, releaseTestApprovers())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,11 +189,11 @@ func TestAIEvaluationReleaseApprovalCannotReplayAfterLedgerHeadChanges(t *testin
 	secondEvidence := releaseTestEvidenceFor(t, "prompt-v2", "prompt-v3")
 	second := releaseTestManifest("release-two", AIEvaluationReleasePromote, secondEvidence.Comparison.ComparisonID, "")
 	second.Approvals = releaseTestApprovals(t, ledger, &secondEvidence, second)
-	ledger, err = ApplyAIEvaluationRelease(ledger, &secondEvidence, second)
+	ledger, err = ApplyAIEvaluationRelease(ledger, &secondEvidence, second, releaseTestApprovers())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ApplyAIEvaluationRelease(ledger, nil, rollback); err == nil {
+	if _, err := ApplyAIEvaluationRelease(ledger, nil, rollback, releaseTestApprovers()); err == nil {
 		t.Fatal("approval from an older ledger head was replayed")
 	}
 }
@@ -135,7 +202,7 @@ func TestAIEvaluationReleaseRejectsFreshBaselineForSameActiveConfiguration(t *te
 	firstEvidence := releaseTestEvidenceFor(t, "prompt-v1", "prompt-v2")
 	first := releaseTestManifest("release-one", AIEvaluationReleasePromote, firstEvidence.Comparison.ComparisonID, "")
 	first.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &firstEvidence, first)
-	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &firstEvidence, first)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &firstEvidence, first, releaseTestApprovers())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +230,7 @@ func TestAIEvaluationReleaseRejectsFreshBaselineForSameActiveConfiguration(t *te
 	validEvidence := releaseTestEvidenceFor(t, "prompt-v2", "prompt-v3")
 	validManifest := releaseTestManifest("release-two-valid", AIEvaluationReleasePromote, validEvidence.Comparison.ComparisonID, "")
 	validManifest.Approvals = releaseTestApprovals(t, ledger, &validEvidence, validManifest)
-	validLedger, err := ApplyAIEvaluationRelease(ledger, &validEvidence, validManifest)
+	validLedger, err := ApplyAIEvaluationRelease(ledger, &validEvidence, validManifest, releaseTestApprovers())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +275,7 @@ func TestAIEvaluationReleaseEnforcesPromotionPolicyFloor(t *testing.T) {
 	validEvidence := releaseTestEvidence(t)
 	validManifest := releaseTestManifest("release-valid", AIEvaluationReleasePromote, validEvidence.Comparison.ComparisonID, "")
 	validManifest.Approvals = releaseTestApprovals(t, AIEvaluationReleaseLedger{}, &validEvidence, validManifest)
-	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &validEvidence, validManifest)
+	ledger, err := ApplyAIEvaluationRelease(AIEvaluationReleaseLedger{}, &validEvidence, validManifest, releaseTestApprovers())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,6 +352,10 @@ func releaseTestEvidenceFor(t *testing.T, baselinePrompt, candidatePrompt string
 func releaseTestManifest(version, action, comparisonID, rollbackTo string) AIEvaluationReleaseManifest {
 	return AIEvaluationReleaseManifest{SchemaVersion: AIEvaluationReleaseManifestSchema, Version: version,
 		Action: action, Provenance: "security/change-42", ComparisonID: comparisonID, RollbackTo: rollbackTo}
+}
+
+func releaseTestApprovers() []string {
+	return []string{"pm@example.com", "security@example.com"}
 }
 
 func releaseTestApprovals(t *testing.T, ledger AIEvaluationReleaseLedger, evidence *AIEvaluationPromotionEvidence, manifest AIEvaluationReleaseManifest) []AIEvaluationReleaseApproval {


### PR DESCRIPTION
Closes #656.

## What this changes

Recording an AI-triage release decision now requires `--human-approvers`, a private operator-owned
allowlist that every PM and Security approver identity must appear in.

Before this, `validateReleaseApprovals` established a great deal about an approval — that it binds the
exact review digest, fills the PM and Security roles in canonical order, carries a rationale and a UTC
timestamp, and that the two reviewers are distinct — but its only test of *human-ness* was
`aitriagereview.IsMachineOrModelActor` applied to the `reviewer` string the manifest itself supplies.
`AIEvaluationReleaseManifest` is documented as operator-owned approval input, so the ledger's central
claim rested on the artifact's own assertion, checked against a denylist of the identity families this
codebase already mints. `machineActor`'s comment says what that costs:

> A prefix DENYLIST fails open on the next identity scheme somebody invents. The durable fix is to invert
> it -- require an actor to be a known human principal -- but that needs a definition of human identity
> that this package does not own, so it is left as a follow-up rather than guessed at here.

The same comment notes the denylist is the *second* line behind RBAC. `synapse-fptriage-release` is an
offline CLI over JSON files with no HTTP handler, so on this path there is no first line — it is exactly
the in-process caller the comment says it exists for and cannot cover alone.

I did not have to guess at a definition of human identity, because #648 already supplied one.
`synapse-fptriage-blind` takes the reviewer from outside the artifact being validated (`--reviewer`,
"never read from submission JSON"), requires a private operator-owned `--human-reviewers` allowlist, and
seals the result with an HMAC receipt. This applies that same pattern to the artifact that authorizes the
promotion rather than the one that measures a pilot.

## Design decisions worth reviewing

**Admission only, never re-validation.** `validateReleaseApproverAllowlist` is called from
`ApplyAIEvaluationRelease` and deliberately not from `Validate`. `LoadAIEvaluationReleaseLedger` validates
every historical decision on every load, so requiring allowlist membership there would mean an approver
leaving the company retroactively invalidates the decisions they signed and stops the ledger loading at
all. A decision keeps the approvers it was admitted with;
`TestAIEvaluationReleaseLedgerValidatesWithoutTheApproverAllowlist` locks that down, and also asserts the
*next* decision still has to clear the allowlist in force now.

**The denylist keeps its say.** The allowlist is a positive test added in front of the existing checks,
not a replacement. Each allowlist entry is re-checked against the denylist so allowlisting a model
identity cannot launder it into an approval — covered by a test.

**Exact match.** Approver *distinctness* is compared case-insensitively; allowlist membership is exact,
so one entry admits one spelling of one identity. Untrimmed entries are rejected. This mirrors
`validateBlindFPTriageReviewer` rather than inventing a second matching rule for the same subsystem.

**`--print-review-digest` does not require the allowlist.** It runs before anyone has approved anything,
so demanding the file there would gate printing a digest on a list with nothing yet to check. The digest
tests pass `""` for the flag, which is the assertion.

**The output guard covers the new input.** `--output` already refuses to overwrite an input artifact; the
allowlist path joins that list.

## What this does not change

- No ledger, manifest, comparison, or report schema version changes; existing ledgers load unchanged.
- No promotion criterion, threshold, policy, or gate decision is touched.
- `machineActor` itself is unchanged, and so are the other consumers of the denylist. The feedback path
  (`validateFeedbackReview`, `validateFeedbackApproval`) revalidates a snapshot whose `DecidedBy` did
  reach the system through the HTTP RBAC gate, so there the denylist genuinely is the second line and I
  left it alone. I am also not proposing to merge the duplicated prefix lists —
  `offensivepolicy/enforce.go` documents why it mirrors rather than imports, and that reasoning holds.
- This is not a fix for privilege escalation. The manifest is operator-owned and the command is offline;
  the change is about what the ledger can be said to prove.

## Tests

- `TestAIEvaluationReleaseRequiresAllowlistedHumanApprovers` — no allowlist, empty allowlist, an approver
  missing from it, a case-differing entry, an untrimmed entry, and a machine-principal entry are each
  rejected; allowlisting a model identity does not admit it; allowlisted approvers still succeed.
- `TestAIEvaluationReleaseLedgerValidatesWithoutTheApproverAllowlist` — signed history validates and
  re-loads with no allowlist in scope, while the next decision still needs one.
- `TestRunRequiresAPrivateHumanApproverAllowlistToRecordADecision` — an absent allowlist and a
  group-readable one are both refused at the CLI, and no ledger file is left behind.

I checked the new tests are falsifiable rather than merely green: stubbing
`validateReleaseApproverAllowlist` to return `nil` fails all six subtests plus the history test, and
stubbing the CLI loader to default to a built-in list fails both CLI subtests.

## Verification

- `gofmt -l .` clean; `go build ./...`; `go vet` over `internal/usecase/sca/...`,
  `cmd/synapse-fptriage-*`, `internal/domain/aitriagereview/...`.
- `go test -count=1` green for `internal/usecase/sca`, `internal/usecase/fptriage`,
  `internal/domain/aitriagereview`, and all five `cmd/synapse-fptriage-*` commands.
- `make ai-triage-verify` passes.
- `golangci-lint v2.12.2` (the CI pin) over the changed packages: **0 issues**.
