### PR TITLE
feat(fleet): A6 source-side telemetry + detection redaction (#627)

### DIFF
--- a/internal/adapter/agentspool/detection_sink.go
+++ b/internal/adapter/agentspool/detection_sink.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/privacy"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -18,18 +19,40 @@ const detectionContentType = "application/vnd.synapse.detection+json;version=1"
 
 // DetectionSink persists confirmed detections in P1. Its deterministic event
 // id is derived from the canonical JSON, making an engine retry idempotent.
-type DetectionSink struct{ spool ports.TelemetrySpool }
+type DetectionSink struct {
+	spool  ports.TelemetrySpool
+	policy privacy.Policy
+}
 
 func NewDetectionSink(durable ports.TelemetrySpool) (*DetectionSink, error) {
 	if durable == nil {
 		return nil, fmt.Errorf("%w: detection spool is required", shared.ErrValidation)
 	}
-	return &DetectionSink{spool: durable}, nil
+	return &DetectionSink{spool: durable, policy: privacy.DefaultPolicy()}, nil
+}
+
+// SetRedactionPolicy overrides the source-side redaction policy applied to detection evidence (A6, #627).
+// The sink defaults to privacy.DefaultPolicy(); an invalid policy is rejected so evidence is never shipped
+// with a broken (fail-open) redaction config.
+func (s *DetectionSink) SetRedactionPolicy(p privacy.Policy) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	s.policy = p
+	return nil
 }
 
 func (s *DetectionSink) Emit(ctx context.Context, value detection.Detection) error {
 	if err := value.Validate(); err != nil {
 		return err
+	}
+	// A6 (#627): redact the detection's EVIDENCE at the source before it is persisted/shipped/sealed, so a
+	// rule that fired on a credential-bearing command line does not leak the secret the telemetry path
+	// already scrubs. The engine keeps its own (raw) copy for local fidelity; only the shipped record is
+	// redacted. The deterministic id below is derived from the REDACTED payload, so retries stay idempotent.
+	value, _, err := privacy.ScrubDetection(value, s.policy)
+	if err != nil {
+		return fmt.Errorf("redact detection evidence: %w", err)
 	}
 	payload, err := json.Marshal(value)
 	if err != nil {

--- a/internal/adapter/agentspool/detection_sink_test.go
+++ b/internal/adapter/agentspool/detection_sink_test.go
@@ -4,13 +4,43 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+// TestDetectionSinkRedactsEvidenceSecretsAtSource proves A6 (#627) closes the detection channel: a secret
+// in a detection's evidence argv must not enter the spool (and thus the shipped, permanently-sealed record).
+func TestDetectionSinkRedactsEvidenceSecretsAtSource(t *testing.T) {
+	secret := "topSecret" + "Value123"
+	durable := &captureSpool{}
+	sink, err := NewDetectionSink(durable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	det := validDetection()
+	det.Evidence = []detection.Event{{
+		Class: detection.ClassProcess, At: adapterNow.Add(-time.Millisecond), Host: "asset-1",
+		Process: &detection.ProcessEvent{PID: 10, PPID: 1, Comm: "mysql", Path: "/usr/bin/mysql",
+			Args: []string{"mysql", "--password=" + secret, "app_db"}, UID: 1000},
+	}}
+	if err := sink.Emit(context.Background(), det); err != nil {
+		t.Fatal(err)
+	}
+	item := durable.snapshot()[0]
+	if strings.Contains(string(item.Payload), secret) {
+		t.Fatalf("detection evidence secret entered the spool unredacted: %s", item.Payload)
+	}
+	// Caller's detection is not mutated (engine keeps its raw copy).
+	if !strings.Contains(det.Evidence[0].Process.Args[1], secret) {
+		t.Fatal("Emit must not mutate the caller's detection")
+	}
+}
 
 func TestDetectionSinkPersistsP1AndDeterministicID(t *testing.T) {
 	durable := &captureSpool{}

--- a/internal/adapter/agentspool/sensor.go
+++ b/internal/adapter/agentspool/sensor.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/privacy"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/normalize"
@@ -52,6 +53,7 @@ type DurableSensor struct {
 	source   ports.DetectionSensor
 	spool    ports.TelemetrySpool
 	identity SensorIdentity
+	policy   privacy.Policy
 	now      func() time.Time
 	runID    string
 
@@ -75,11 +77,27 @@ func NewDurableSensor(source ports.DetectionSensor, durable ports.TelemetrySpool
 		return nil, err
 	}
 	return &DurableSensor{
-		source: source, spool: durable, identity: identity, now: time.Now,
+		source: source, spool: durable, identity: identity, policy: privacy.DefaultPolicy(), now: time.Now,
 		runID:  uuid.NewString(),
 		events: make(chan detection.Event), failures: make(map[detection.Class]uint64),
 		sequence: make(map[detection.Class]uint64),
 	}, nil
+}
+
+// SetRedactionPolicy overrides the source-side redaction policy (A6, #627). A DurableSensor is created with
+// privacy.DefaultPolicy(); an operator/tenant policy is applied here before Start. An invalid policy is
+// rejected so the sensor never ships with a broken (fail-open) redaction config.
+func (s *DurableSensor) SetRedactionPolicy(p privacy.Policy) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		return fmt.Errorf("%w: cannot change the redaction policy after the sensor has started", shared.ErrValidation)
+	}
+	s.policy = p
+	return nil
 }
 
 func (s *DurableSensor) Start(ctx context.Context) error {
@@ -138,6 +156,14 @@ func (s *DurableSensor) persist(ctx context.Context, event detection.Event) bool
 		return true // detection can still evaluate; coverage reports raw loss
 	}
 	envelope, err := (normalize.Normalizer{}).Normalize(decoded)
+	if err != nil {
+		s.recordFailure(event.Class)
+		return true
+	}
+	// A6 (#627): redact at the SOURCE — before the WAL/ship — so unredacted secrets/PII never persist on
+	// disk or leave the host. The scrubbed envelope carries its RedactionPolicyDigest + a QualityRedacted
+	// flag so the redaction travels with the data.
+	envelope, _, err = privacy.Scrub(envelope, s.policy)
 	if err != nil {
 		s.recordFailure(event.Class)
 		return true

--- a/internal/adapter/agentspool/sensor_test.go
+++ b/internal/adapter/agentspool/sensor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,6 +16,51 @@ import (
 )
 
 var adapterNow = time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+// TestDurableSensorRedactsSecretsAtSource proves A6 (#627): a secret in argv is scrubbed on the agent
+// BEFORE it enters the spool, so the persisted payload never contains it. The secret is assembled from
+// parts so it does not appear verbatim in source.
+func TestDurableSensorRedactsSecretsAtSource(t *testing.T) {
+	secret := "topSecret" + "Value123"
+	source := newFakeSensor()
+	durable := &captureSpool{}
+	wrapper := mustSensor(t, source, durable)
+	wrapper.now = func() time.Time { return adapterNow }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := wrapper.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	source.events <- detection.Event{
+		Class: detection.ClassProcess, At: adapterNow.Add(-time.Millisecond), Host: "asset-1",
+		Process: &detection.ProcessEvent{PID: 10, PPID: 1, Comm: "mysql", Path: "/usr/bin/mysql",
+			Args: []string{"mysql", "--password=" + secret, "app_db"}, UID: 1000},
+	}
+	select {
+	case <-wrapper.Events():
+	case <-time.After(time.Second):
+		t.Fatal("event not forwarded")
+	}
+	item := durable.snapshot()[0]
+	if strings.Contains(string(item.Payload), secret) {
+		t.Fatalf("secret entered the spool unredacted: %s", item.Payload)
+	}
+	var env telemetry.TelemetryEnvelope
+	if err := json.Unmarshal(item.Payload, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if !env.DataQuality.Has(telemetry.QualityRedacted) || env.RedactionPolicyDigest == "" {
+		t.Fatalf("redaction was not recorded on the spooled envelope: quality=%s digest=%q", env.DataQuality, env.RedactionPolicyDigest)
+	}
+	// Non-secret argv context is preserved.
+	if env.Event.Process.Args[0] != "mysql" || env.Event.Process.Args[2] != "app_db" {
+		t.Fatalf("forensic argv context lost: %#v", env.Event.Process.Args)
+	}
+	cancel()
+	if err := wrapper.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestDurableSensorNormalizesAndPersistsBeforeForwarding(t *testing.T) {
 	source := newFakeSensor()

--- a/internal/domain/privacy/detection.go
+++ b/internal/domain/privacy/detection.go
@@ -1,0 +1,70 @@
+package privacy
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+)
+
+// ScrubDetection redacts a confirmed detection's EVIDENCE at the source (A6, #627) before it is persisted
+// and shipped. A detection embeds the raw events that triggered it (argv, paths, comms), so without this a
+// rule firing on a credential-bearing command line would ship the exact secret the telemetry path already
+// scrubs — and, once sealed into the permanent evidence chain (A5), unredactably so. It returns a redacted
+// DEEP COPY (the caller's Detection, still held by the engine, is never mutated) and a Report.
+//
+// It applies the same field classifier as the telemetry Scrub, but only the redact/hash/drop/secret-scan
+// transforms — it does NOT length-bound, because detection.Event carries no per-field truncation-honesty
+// flag and a silent truncation would be dishonest; the evidence window is already bounded by the rule.
+func ScrubDetection(det detection.Detection, policy Policy) (detection.Detection, Report, error) {
+	if err := policy.Validate(); err != nil {
+		return detection.Detection{}, Report{}, fmt.Errorf("scrub detection: %w", err)
+	}
+	rep := Report{PolicyDigest: RedactionPolicyDigest(policy)}
+	apply := func(cat FieldCategory, value string) string {
+		if value == "" {
+			return value
+		}
+		scrubbed, disp := policy.Classify(cat, value)
+		switch disp {
+		case DispositionDrop:
+			rep.Dropped++
+		case DispositionRedact, DispositionHash:
+			rep.Redacted++
+		}
+		return scrubbed
+	}
+
+	out := det
+	out.Evidence = make([]detection.Event, len(det.Evidence))
+	for i, ev := range det.Evidence {
+		e := ev // struct copy (shares payload pointers until we replace the touched one)
+		switch {
+		case ev.Process != nil:
+			p := *ev.Process
+			// Slice-aware argv redaction (fresh slice — non-mutating): per-element scan + cross-element
+			// credential-flag → next-value redaction, same as the telemetry path.
+			scrubbedArgs, red, drop := policy.RedactArgv(ev.Process.Args)
+			rep.Redacted += red
+			rep.Dropped += drop
+			p.Args = scrubbedArgs
+			p.Path = apply(CategoryProcessPath, p.Path)
+			p.Comm = apply(CategoryProcessComm, p.Comm)
+			e.Process = &p
+		case ev.File != nil:
+			f := *ev.File
+			f.Path = apply(CategoryFilePath, f.Path)
+			f.Comm = apply(CategoryFileComm, f.Comm)
+			e.File = &f
+		case ev.Network != nil:
+			n := *ev.Network
+			n.Comm = apply(CategoryNetworkComm, n.Comm)
+			e.Network = &n
+		case ev.Privilege != nil:
+			pr := *ev.Privilege
+			pr.Comm = apply(CategoryPrivilegeComm, pr.Comm)
+			e.Privilege = &pr
+		}
+		out.Evidence[i] = e
+	}
+	return out, rep, nil
+}

--- a/internal/domain/privacy/detection_test.go
+++ b/internal/domain/privacy/detection_test.go
@@ -1,0 +1,70 @@
+package privacy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+)
+
+func mkDetectionWithArgs(t *testing.T, args []string) detection.Detection {
+	t.Helper()
+	r, ok := detection.Lookup("det.process_enumeration")
+	if !ok {
+		t.Fatal("expected det.process_enumeration rule")
+	}
+	ev := detection.Event{Class: detection.ClassProcess, At: time.Unix(1, 0).UTC(), Host: "host-1",
+		Process: &detection.ProcessEvent{PID: 10, PPID: 1, Comm: "mysqldump", Path: "/usr/bin/mysqldump", Args: args, UID: 0}}
+	d, err := detection.NewDetection(r, "host-1", "agent-1", []detection.Event{ev}, time.Unix(500, 0).UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// TestScrubDetectionRedactsEvidenceSecret is the detection-channel half of the #611 exit: a secret in the
+// evidence argv must not survive into the serialized (persisted/shipped/sealed) detection, and the caller's
+// detection must not be mutated.
+func TestScrubDetectionRedactsEvidenceSecret(t *testing.T) {
+	secret := "hunter2" + "SuperSecret"
+	det := mkDetectionWithArgs(t, []string{"mysqldump", "--password=" + secret, "app_db"})
+	out, rep, err := ScrubDetection(det, DefaultPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, _ := json.Marshal(out)
+	if strings.Contains(string(blob), secret) {
+		t.Fatalf("secret survived into the serialized detection: %s", blob)
+	}
+	if !rep.Changed() {
+		t.Fatal("report must record the redaction")
+	}
+	// Non-mutating: the caller's detection still holds the secret (the engine keeps its raw copy).
+	if !strings.Contains(det.Evidence[0].Process.Args[1], secret) {
+		t.Fatal("ScrubDetection must not mutate its input")
+	}
+	// Non-secret argv context preserved.
+	if out.Evidence[0].Process.Args[0] != "mysqldump" || out.Evidence[0].Process.Args[2] != "app_db" {
+		t.Fatalf("forensic argv context lost: %#v", out.Evidence[0].Process.Args)
+	}
+	// Rule attribution intact.
+	if out.RuleID != det.RuleID || out.AgentID != det.AgentID {
+		t.Fatalf("detection attribution changed: %+v", out)
+	}
+}
+
+func TestScrubDetectionDeterministicAndRejectsBadPolicy(t *testing.T) {
+	det := mkDetectionWithArgs(t, []string{"app", "--token=abc.def", "run"})
+	a, _, _ := ScrubDetection(det, DefaultPolicy())
+	b, _, _ := ScrubDetection(det, DefaultPolicy())
+	ab, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	if string(ab) != string(bb) {
+		t.Fatal("ScrubDetection must be deterministic (stable spool id + commitment)")
+	}
+	if _, _, err := ScrubDetection(det, Policy{}); err == nil {
+		t.Fatal("an invalid policy must be rejected, not fail open")
+	}
+}

--- a/internal/domain/privacy/digest.go
+++ b/internal/domain/privacy/digest.go
@@ -1,0 +1,43 @@
+package privacy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+)
+
+// redactionPolicyContext domain-separates the redaction-policy digest so it can never be confused with the
+// sampling-policy digest (#611/#594) or any other digest — they identify DIFFERENT concerns.
+const redactionPolicyContext = "synapse-redaction-policy:v1"
+
+// secretPatternSetID versions the built-in secret-pattern set, so a policy digest changes when the patterns
+// that scrubbed the data change — the digest attributes the FULL redaction behavior, not just the config.
+const secretPatternSetID = "secret-patterns:v1"
+
+// RedactionPolicyDigest is a deterministic, domain-separated identity for a redaction policy, recorded with
+// the scrubbed data so a reader knows exactly how it was redacted. It is DISTINCT from the sampling policy
+// digest. The HashSalt is folded in as its own digest (not raw) so the identity is stable without echoing
+// the salt into the commitment.
+func RedactionPolicyDigest(p Policy) string {
+	h := sha256.New()
+	write := func(s string) { h.Write([]byte(s)); h.Write([]byte{0x1e}) }
+	write(redactionPolicyContext)
+	write(p.Version)
+	write(secretPatternSetID)
+	write(strconv.FormatBool(p.RedactSecrets))
+	write(strconv.Itoa(p.MaxArgLen))
+	write(strconv.Itoa(p.MaxArgCount))
+	write(strconv.Itoa(p.MaxPathLen))
+	cats := make([]string, 0, len(p.Dispositions))
+	for cat := range p.Dispositions {
+		cats = append(cats, string(cat))
+	}
+	sort.Strings(cats)
+	for _, cat := range cats {
+		write(cat + "=" + string(p.Dispositions[FieldCategory(cat)]))
+	}
+	saltDigest := sha256.Sum256([]byte(p.HashSalt))
+	write("salt:" + hex.EncodeToString(saltDigest[:8]))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/domain/privacy/policy.go
+++ b/internal/domain/privacy/policy.go
@@ -1,0 +1,170 @@
+// Package privacy is the SOURCE-SIDE telemetry redaction classifier (A6, #627 — the A0.6 privacy half of
+// #611). It is pure domain: given a field category and value it decides allow / redact / hash / drop, and
+// Scrub applies a Policy to a telemetry envelope on the agent BEFORE the spool/ship, so unredacted secrets
+// never persist or leave the host. Safe-by-default: no environment collected, bounded argv/path, and known
+// secret patterns (tokens, keys, passwords, connection strings) redacted even inside otherwise-allowed
+// fields. The policy is attributed by a distinct RedactionPolicyDigest recorded with the data — separate
+// from the sampling policy digest.
+package privacy
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// FieldDisposition is what the policy does with a field's value.
+type FieldDisposition string
+
+const (
+	// DispositionAllow keeps the value, but (when Policy.RedactSecrets) still scrubs embedded secret
+	// patterns — an allowed field is never a bypass for a token pasted into an argument.
+	DispositionAllow FieldDisposition = "allow"
+	// DispositionRedact replaces the whole value with the redaction placeholder.
+	DispositionRedact FieldDisposition = "redact"
+	// DispositionHash replaces the value with a keyed digest — correlation without the cleartext.
+	DispositionHash FieldDisposition = "hash"
+	// DispositionDrop removes the value entirely.
+	DispositionDrop FieldDisposition = "drop"
+)
+
+// Valid reports whether d is a known disposition.
+func (d FieldDisposition) Valid() bool {
+	switch d {
+	case DispositionAllow, DispositionRedact, DispositionHash, DispositionDrop:
+		return true
+	default:
+		return false
+	}
+}
+
+// FieldCategory names a logical telemetry field the policy reasons about, so a policy is field-aware
+// without coupling to concrete struct layouts.
+type FieldCategory string
+
+const (
+	CategoryProcessArg  FieldCategory = "process.arg"
+	CategoryProcessPath FieldCategory = "process.path"
+	CategoryProcessComm FieldCategory = "process.comm"
+	// CategoryProcessEnv is reserved: the schema collects no environment today, and the default policy
+	// drops it, so if an env field is ever added it is redacted-by-omission by default.
+	CategoryProcessEnv    FieldCategory = "process.env"
+	CategoryFilePath      FieldCategory = "file.path"
+	CategoryFileComm      FieldCategory = "file.comm"
+	CategoryNetworkComm   FieldCategory = "network.comm"
+	CategoryPrivilegeComm FieldCategory = "privilege.comm"
+)
+
+// RedactionPlaceholder replaces a redacted value or secret span. It is a stable, distinctive ASCII marker
+// so a reader (and a test) can tell redaction happened without guessing.
+const RedactionPlaceholder = "[redacted]"
+
+// Policy is a tenant-configurable source-side redaction policy. The zero value is NOT safe to use; call
+// DefaultPolicy (or Normalize on a partially-built one) so caps and secret scanning are set.
+type Policy struct {
+	// Dispositions maps a category to its disposition; a category absent here uses DispositionAllow.
+	Dispositions map[FieldCategory]FieldDisposition
+	// RedactSecrets scans allowed/redacted string values for known secret patterns and scrubs the matches.
+	RedactSecrets bool
+	// MaxArgLen / MaxArgCount bound argv so a pathological command line cannot exfiltrate unbounded data;
+	// MaxPathLen bounds a path. <=0 means unbounded for that dimension.
+	MaxArgLen   int
+	MaxArgCount int
+	MaxPathLen  int
+	// HashSalt keys the DispositionHash digest. It is NOT a secret store; it only prevents trivial
+	// dictionary correlation across policies. Same salt+value → same hash (correlation preserved).
+	HashSalt string
+	// Version identifies the policy lineage for the RedactionPolicyDigest.
+	Version string
+}
+
+// DefaultPolicy is the safe default: no environment collected, argv/path bounded, comms/paths/args allowed
+// but secret-scanned. It never drops argv wholesale (that would destroy forensic value); instead it redacts
+// only the secret spans within.
+func DefaultPolicy() Policy {
+	return Policy{
+		Dispositions: map[FieldCategory]FieldDisposition{
+			CategoryProcessEnv: DispositionDrop,
+		},
+		RedactSecrets: true,
+		MaxArgLen:     4096,
+		MaxArgCount:   512,
+		MaxPathLen:    4096,
+		HashSalt:      "synapse-default-redaction",
+		Version:       "default:v1",
+	}
+}
+
+// dispositionFor returns the configured disposition for a category, defaulting to allow.
+func (p Policy) dispositionFor(cat FieldCategory) FieldDisposition {
+	if d, ok := p.Dispositions[cat]; ok && d.Valid() {
+		return d
+	}
+	return DispositionAllow
+}
+
+// Validate checks the policy is well-formed.
+func (p Policy) Validate() error {
+	if p.Version == "" {
+		return fmt.Errorf("%w: redaction policy needs a version", shared.ErrValidation)
+	}
+	for cat, d := range p.Dispositions {
+		if !d.Valid() {
+			return fmt.Errorf("%w: redaction policy has an unknown disposition %q for %q", shared.ErrValidation, d, cat)
+		}
+		if d == DispositionHash && p.HashSalt == "" {
+			return fmt.Errorf("%w: redaction policy uses hash for %q but has no salt", shared.ErrValidation, cat)
+		}
+	}
+	if p.MaxArgLen < 0 || p.MaxArgCount < 0 || p.MaxPathLen < 0 {
+		return fmt.Errorf("%w: redaction policy caps cannot be negative", shared.ErrValidation)
+	}
+	return nil
+}
+
+// RedactArgv redacts a whole argv slice as a unit (positions preserved). Each element is classified as a
+// process arg (disposition + per-element secret scan), AND — the reason this is slice-aware — when an
+// element is a lone credential flag its FOLLOWING element (the space-separated value) is redacted
+// wholesale, which no per-element scan can do. Returns the scrubbed argv and how many elements were
+// redacted/hashed vs dropped.
+func (p Policy) RedactArgv(args []string) (out []string, redacted, dropped int) {
+	out = make([]string, len(args))
+	redactValue := false
+	for i, a := range args {
+		v, disp := p.Classify(CategoryProcessArg, a)
+		if redactValue && disp == DispositionAllow {
+			// This element is the value of a preceding credential flag; force it redacted even though it
+			// carries no secret pattern of its own (it IS the secret).
+			v, disp = RedactionPlaceholder, DispositionRedact
+		}
+		redactValue = disp != DispositionDrop && IsCredentialFlag(a)
+		out[i] = v
+		switch disp {
+		case DispositionDrop:
+			dropped++
+		case DispositionRedact, DispositionHash:
+			redacted++
+		}
+	}
+	return out, redacted, dropped
+}
+
+// Classify applies the category's disposition to a single value and reports the disposition actually
+// applied (an allowed value with a scrubbed secret reports DispositionRedact, so the caller can flag it).
+func (p Policy) Classify(cat FieldCategory, value string) (string, FieldDisposition) {
+	switch p.dispositionFor(cat) {
+	case DispositionDrop:
+		return "", DispositionDrop
+	case DispositionHash:
+		return hashValue(p.HashSalt, value), DispositionHash
+	case DispositionRedact:
+		return RedactionPlaceholder, DispositionRedact
+	default: // allow
+		if p.RedactSecrets {
+			if scrubbed, changed := scrubSecrets(value); changed {
+				return scrubbed, DispositionRedact
+			}
+		}
+		return value, DispositionAllow
+	}
+}

--- a/internal/domain/privacy/privacy_test.go
+++ b/internal/domain/privacy/privacy_test.go
@@ -1,0 +1,247 @@
+package privacy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+// Test fixtures are FAKE credentials assembled from parts (no secret pattern appears verbatim in source);
+// they exist only to prove the scrubber removes them.
+var (
+	fakeAWSKey = "AKIA" + "IOSFODNN7EXAMPLE"
+	fakePGPass = "p4" + "ss"
+)
+
+func pgScheme() string { return "postgres" + "://" }
+func pgHost() string   { return "@" + "db:5432/app" }
+func fakePGURL() string {
+	return pgScheme() + "user:" + fakePGPass + pgHost()
+}
+
+func TestScrubSecretsPatterns(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		absent  string // substring that must NOT survive
+		changed bool
+	}{
+		{"password assignment", "--config password=hunter2 --db x", "hunter2", true},
+		{"env-style underscore key", "docker run -e DB_PASSWORD=hunter2 img", "hunter2", true},
+		{"aws secret access key env", "aws_secret_access_key=" + "REDACTME8", "REDACTME8", true},
+		{"cli flag single-token space", "mysql --password s3cr3t db", "s3cr3t", true},
+		{"cli flag equals", "app --token=abc.def.ghi run", "abc.def.ghi", true},
+		{"connection string", fakePGURL(), fakePGPass, true},
+		{"bearer token", "curl -H Authorization: Bearer " + "tok" + "enABC123value", "tok" + "enABC123value", true},
+		{"aws access key", "export AWS_ID " + fakeAWSKey, fakeAWSKey, true},
+		{"clean command", "ls -la /var/log", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := scrubSecrets(tc.in)
+			if changed != tc.changed {
+				t.Fatalf("changed=%v want %v (got %q)", changed, tc.changed, got)
+			}
+			if tc.absent != "" && strings.Contains(got, tc.absent) {
+				t.Fatalf("secret survived scrub: %q", got)
+			}
+			// Idempotent: re-scrubbing already-redacted text changes nothing.
+			if again, changedAgain := scrubSecrets(got); changedAgain || again != got {
+				t.Fatalf("scrub not idempotent: %q -> %q", got, again)
+			}
+		})
+	}
+}
+
+func TestClassifyDispositions(t *testing.T) {
+	p := DefaultPolicy()
+	// env is dropped by default.
+	if v, d := p.Classify(CategoryProcessEnv, "SECRET=1"); d != DispositionDrop || v != "" {
+		t.Fatalf("env must be dropped, got %q/%s", v, d)
+	}
+	// an allowed arg carrying a secret is redacted.
+	if v, d := p.Classify(CategoryProcessArg, "--password=hunter2"); d != DispositionRedact || strings.Contains(v, "hunter2") {
+		t.Fatalf("secret arg must be redacted, got %q/%s", v, d)
+	}
+	// a clean arg is allowed unchanged.
+	if v, d := p.Classify(CategoryProcessArg, "--verbose"); d != DispositionAllow || v != "--verbose" {
+		t.Fatalf("clean arg must be allowed, got %q/%s", v, d)
+	}
+	// hash disposition preserves correlation without the cleartext.
+	hp := DefaultPolicy()
+	hp.Dispositions[CategoryProcessComm] = DispositionHash
+	a, da := hp.Classify(CategoryProcessComm, "sshd")
+	b, _ := hp.Classify(CategoryProcessComm, "sshd")
+	c, _ := hp.Classify(CategoryProcessComm, "bash")
+	if da != DispositionHash || strings.Contains(a, "sshd") || a != b || a == c {
+		t.Fatalf("hash must hide value but correlate: a=%q b=%q c=%q", a, b, c)
+	}
+}
+
+func TestRedactionPolicyDigestDeterministicAndDistinct(t *testing.T) {
+	a := RedactionPolicyDigest(DefaultPolicy())
+	b := RedactionPolicyDigest(DefaultPolicy())
+	if a == "" || a != b {
+		t.Fatalf("digest must be deterministic: %q vs %q", a, b)
+	}
+	other := DefaultPolicy()
+	other.Version = "tenant-x:v2"
+	if RedactionPolicyDigest(other) == a {
+		t.Fatal("a different policy must have a different digest")
+	}
+}
+
+func mkEnvelope(args []string, path string) telemetry.TelemetryEnvelope {
+	return telemetry.TelemetryEnvelope{
+		SchemaVersion: telemetry.SchemaVersion,
+		EventID:       "e1", EventType: "process.exec", EventClass: detection.ClassProcess,
+		AgentID: "agent-1", AgentSessionID: "sess-1", AssetID: "asset-1", BootID: "boot-1",
+		StreamID: "s1", SensorID: "sensor-1", SensorVersion: "1",
+		OccurredAt: time.Unix(1, 0).UTC(), ObservedAt: time.Unix(2, 0).UTC(),
+		Sequence: 1,
+		Event: telemetry.TelemetryEvent{
+			Class: detection.ClassProcess,
+			Process: &telemetry.ProcessObservation{
+				Kind: "exec", PID: 100, Comm: "mysqldump", Path: path, Args: args,
+			},
+		},
+	}
+}
+
+// TestScrubRedactsKnownSecretEndToEnd is the #611 privacy exit: a planted secret in argv must not appear
+// anywhere in the scrubbed envelope (its serialized form), and the input must be left unmutated.
+func TestScrubRedactsKnownSecretEndToEnd(t *testing.T) {
+	secret := "hunter2" + "SuperSecret"
+	in := mkEnvelope([]string{"mysqldump", "--password=" + secret, "app_db"}, "/usr/bin/mysqldump")
+	out, rep, err := Scrub(in, DefaultPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, _ := json.Marshal(out)
+	if strings.Contains(string(blob), secret) {
+		t.Fatalf("planted secret survived into the scrubbed envelope: %s", blob)
+	}
+	if !rep.Changed() || rep.PolicyDigest == "" {
+		t.Fatalf("report must record the redaction + policy digest: %+v", rep)
+	}
+	if out.RedactionPolicyDigest != rep.PolicyDigest {
+		t.Fatalf("envelope must carry the policy digest")
+	}
+	if !out.DataQuality.Has(telemetry.QualityRedacted) {
+		t.Fatal("a redacted envelope must set QualityRedacted")
+	}
+	// Non-mutating: the input still holds the secret.
+	if !strings.Contains(in.Event.Process.Args[1], secret) {
+		t.Fatal("Scrub must not mutate its input")
+	}
+	// The non-secret argv context is preserved (forensic value kept).
+	if out.Event.Process.Args[0] != "mysqldump" || out.Event.Process.Args[2] != "app_db" {
+		t.Fatalf("non-secret argv context must be preserved: %+v", out.Event.Process.Args)
+	}
+}
+
+// TestRedactArgvSplitCredential covers the common form the per-element scan cannot: a credential flag and
+// its value in SEPARATE argv elements (`--password`, `secret`).
+func TestRedactArgvSplitCredential(t *testing.T) {
+	secret := "sep" + "AratedSecret9"
+	out, red, _ := DefaultPolicy().RedactArgv([]string{"mysql", "--password", secret, "-h", "db", "--token", "abc.def"})
+	if red < 2 {
+		t.Fatalf("both split credential values must be redacted, got %d", red)
+	}
+	for _, a := range out {
+		if strings.Contains(a, secret) || a == "abc.def" {
+			t.Fatalf("split credential value survived: %#v", out)
+		}
+	}
+	// flags + non-credential args preserved.
+	if out[0] != "mysql" || out[1] != "--password" || out[3] != "-h" || out[4] != "db" {
+		t.Fatalf("non-credential argv context lost: %#v", out)
+	}
+}
+
+// TestScrubRedactsSplitArgvSecretEndToEnd proves the envelope Scrub closes the split-argv form too.
+func TestScrubRedactsSplitArgvSecretEndToEnd(t *testing.T) {
+	secret := "spl" + "itFormSecret7"
+	in := mkEnvelope([]string{"psql", "--password", secret, "mydb"}, "/usr/bin/psql")
+	out, _, err := Scrub(in, DefaultPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, _ := json.Marshal(out)
+	if strings.Contains(string(blob), secret) {
+		t.Fatalf("split-argv secret survived: %s", blob)
+	}
+	if out.Event.Process.Args[1] != "--password" || out.Event.Process.Args[0] != "psql" {
+		t.Fatalf("flag/context lost: %#v", out.Event.Process.Args)
+	}
+}
+
+func TestScrubBoundsArgvAndPath(t *testing.T) {
+	p := DefaultPolicy()
+	p.MaxArgLen = 8
+	p.MaxArgCount = 2
+	p.MaxPathLen = 5
+	in := mkEnvelope([]string{"aaaaaaaaaaaaaaaa", "b", "c", "d"}, "/very/long/path")
+	out, _, err := Scrub(in, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Event.Process.Args) != 2 || !out.Event.Process.ArgsTruncated {
+		t.Fatalf("argv count must be bounded + flagged: %+v", out.Event.Process.Args)
+	}
+	if len([]rune(out.Event.Process.Args[0])) != 8 {
+		t.Fatalf("arg length must be bounded, got %q", out.Event.Process.Args[0])
+	}
+	if len([]rune(out.Event.Process.Path)) != 5 || !out.Event.Process.PathTruncated {
+		t.Fatalf("path must be bounded + flagged, got %q", out.Event.Process.Path)
+	}
+	// A Scrub-introduced truncation must set BOTH honesty channels: the struct flag AND the DataQuality bit.
+	if !out.DataQuality.Has(telemetry.QualityTruncatedArgv) || !out.DataQuality.Has(telemetry.QualityTruncatedPath) {
+		t.Fatalf("scrub truncation must set the DataQuality bits, got %s", out.DataQuality)
+	}
+}
+
+func TestScrubFilePathBoundedAndFlagged(t *testing.T) {
+	p := DefaultPolicy()
+	p.MaxPathLen = 4
+	in := telemetry.TelemetryEnvelope{
+		SchemaVersion: telemetry.SchemaVersion, EventID: "e1", EventType: "file.write",
+		EventClass: detection.ClassFile, AgentID: "agent-1", AgentSessionID: "sess-1", AssetID: "asset-1",
+		BootID: "boot-1", StreamID: "s1", SensorID: "sensor-1", SensorVersion: "1",
+		OccurredAt: time.Unix(1, 0).UTC(), ObservedAt: time.Unix(2, 0).UTC(), Sequence: 1,
+		Event: telemetry.TelemetryEvent{Class: detection.ClassFile, File: &telemetry.FileObservation{Op: "open", Path: "/etc/shadow", Device: 1, Inode: 2}},
+	}
+	out, _, err := Scrub(in, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len([]rune(out.Event.File.Path)) != 4 || !out.Event.File.PathTruncated || !out.DataQuality.Has(telemetry.QualityTruncatedPath) {
+		t.Fatalf("file path truncation must set the struct flag AND the quality bit: path=%q trunc=%v q=%s", out.Event.File.Path, out.Event.File.PathTruncated, out.DataQuality)
+	}
+}
+
+func TestScrubDeterministic(t *testing.T) {
+	in := mkEnvelope([]string{"app", "--token=abc.def", "run"}, "/usr/bin/app")
+	a, _, _ := Scrub(in, DefaultPolicy())
+	b, _, _ := Scrub(in, DefaultPolicy())
+	ab, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	if string(ab) != string(bb) {
+		t.Fatal("scrub must be deterministic for a stable spool/commitment")
+	}
+}
+
+func TestScrubRejectsInvalidPolicy(t *testing.T) {
+	_, _, err := Scrub(mkEnvelope(nil, "/x"), Policy{})
+	if err == nil {
+		t.Fatal("an invalid (zero) policy must be rejected, not fail open")
+	}
+	if !strings.Contains(err.Error(), shared.ErrValidation.Error()) {
+		t.Fatalf("want validation error, got %v", err)
+	}
+}

--- a/internal/domain/privacy/scrub.go
+++ b/internal/domain/privacy/scrub.go
@@ -1,0 +1,120 @@
+package privacy
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+// Report summarizes what a Scrub did, for honesty signals and tests. PolicyDigest is the
+// RedactionPolicyDigest of the applied policy (also stamped onto the returned envelope).
+type Report struct {
+	PolicyDigest string
+	Redacted     int // values redacted, hashed, or secret-scrubbed
+	Dropped      int // values dropped entirely
+}
+
+// Changed reports whether the scrub altered any value.
+func (r Report) Changed() bool { return r.Redacted > 0 || r.Dropped > 0 }
+
+// Scrub applies the policy to a telemetry envelope on the SOURCE side, returning a scrubbed copy (the input
+// is never mutated — it operates on env.Clone()), a Report, and any error. It stamps the envelope's
+// RedactionPolicyDigest and sets QualityRedacted when anything changed, so the redaction travels with the
+// data. Callers apply it BEFORE the spool/ship so unredacted secrets never persist or leave the host.
+func Scrub(env telemetry.TelemetryEnvelope, policy Policy) (telemetry.TelemetryEnvelope, Report, error) {
+	if err := policy.Validate(); err != nil {
+		return telemetry.TelemetryEnvelope{}, Report{}, fmt.Errorf("scrub: %w", err)
+	}
+	out := env.Clone()
+	rep := Report{PolicyDigest: RedactionPolicyDigest(policy)}
+
+	apply := func(cat FieldCategory, value string) string {
+		if value == "" {
+			return value
+		}
+		scrubbed, disp := policy.Classify(cat, value)
+		switch disp {
+		case DispositionDrop:
+			rep.Dropped++
+		case DispositionRedact, DispositionHash:
+			rep.Redacted++
+		}
+		return scrubbed
+	}
+
+	// markArgvTruncated / markPathTruncated set BOTH honesty channels for a Scrub-introduced cut: the
+	// per-field struct flag AND the envelope DataQuality bit, so a reader keying on either sees the same
+	// truth (the normalizer already set these for sensor-time cuts; Scrub's own tighter caps must too).
+	markArgvTruncated := func() {
+		out.DataQuality = out.DataQuality.With(telemetry.QualityTruncatedArgv)
+	}
+	markPathTruncated := func() {
+		out.DataQuality = out.DataQuality.With(telemetry.QualityTruncatedPath)
+	}
+
+	if p := out.Event.Process; p != nil {
+		if v, cut := boundLen(apply(CategoryProcessPath, p.Path), policy.MaxPathLen); true {
+			p.Path = v
+			if cut {
+				p.PathTruncated = true
+				markPathTruncated()
+			}
+		}
+		p.Comm = apply(CategoryProcessComm, p.Comm)
+		if policy.MaxArgCount > 0 && len(p.Args) > policy.MaxArgCount {
+			p.Args = p.Args[:policy.MaxArgCount]
+			p.ArgsTruncated = true
+			markArgvTruncated()
+		}
+		// Slice-aware argv redaction: per-element secret scan PLUS cross-element (a lone credential flag
+		// redacts the following value element — the space-separated `--password secret` form).
+		scrubbedArgs, red, drop := policy.RedactArgv(p.Args)
+		rep.Redacted += red
+		rep.Dropped += drop
+		for i := range scrubbedArgs {
+			v, cut := boundLen(scrubbedArgs[i], policy.MaxArgLen)
+			scrubbedArgs[i] = v
+			if cut {
+				p.ArgsTruncated = true
+				markArgvTruncated()
+			}
+		}
+		p.Args = scrubbedArgs
+	}
+	if f := out.Event.File; f != nil {
+		if v, cut := boundLen(apply(CategoryFilePath, f.Path), policy.MaxPathLen); true {
+			f.Path = v
+			if cut {
+				f.PathTruncated = true
+				markPathTruncated()
+			}
+		}
+		f.Comm = apply(CategoryFileComm, f.Comm)
+	}
+	if n := out.Event.Network; n != nil {
+		n.Comm = apply(CategoryNetworkComm, n.Comm)
+	}
+	if pr := out.Event.Privilege; pr != nil {
+		pr.Comm = apply(CategoryPrivilegeComm, pr.Comm)
+	}
+
+	out.RedactionPolicyDigest = rep.PolicyDigest
+	if rep.Changed() {
+		out.DataQuality = out.DataQuality.With(telemetry.QualityRedacted)
+	}
+	return out, rep, nil
+}
+
+// boundLen truncates s to max runes (max<=0 means unbounded), returning the result and whether it was cut.
+// Truncation is rune-safe so a multibyte value is never split mid-rune. The caller records both honesty
+// channels (the per-field struct flag AND the envelope DataQuality bit) when cut is true.
+func boundLen(s string, max int) (string, bool) {
+	if max <= 0 {
+		return s, false
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s, false
+	}
+	return string(r[:max]), true
+}

--- a/internal/domain/privacy/secrets.go
+++ b/internal/domain/privacy/secrets.go
@@ -1,0 +1,77 @@
+package privacy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+)
+
+// secretPattern is a compiled redaction rule: match sensitive text and replace it with `repl`, where `repl`
+// may reference capture groups (e.g. ${1}) so a key/prefix is kept while only its value is scrubbed. All
+// patterns are RE2 (Go regexp): no backreferences or lookaround, so match time is linear and safe on
+// attacker-influenced argv.
+type secretPattern struct {
+	re   *regexp.Regexp
+	repl string
+}
+
+// secretPatterns is the curated, low-false-positive set applied to allowed string values. It targets the
+// structured ways secrets appear on a command line — keyed assignments (incl. underscore/dash-joined
+// env-style keys like DB_PASSWORD / aws_secret_access_key), CLI credential flags (incl. mysql-style -p),
+// connection strings, bearer tokens, cloud access-key ids, and PEM private-key blocks — keeping the
+// surrounding forensic context (a captured leading delimiter, the key/flag name, the connection host)
+// while removing the secret itself.
+var secretPatterns = []secretPattern{
+	// key=value / key: value. The keyword may be joined to a prefix by '_' or '-' (DB_PASSWORD=,
+	// aws_secret_access_key:), so the lead delimiter is a captured class (start | space | quote | separator |
+	// _ | -) that is preserved in the replacement rather than a \b (which does not break between '_' and a
+	// letter and would miss the canonical env-var-as-argv form).
+	{regexp.MustCompile(`(?i)(^|[\s"'=:,;/\\_-])((?:password|passwd|pwd|secret|token|api[-_]?key|access[-_]?key|secret[-_]?key|auth[-_]?token|client[-_]?secret|credential)\s*[=:]\s*)([^\s"']+)`), `${1}${2}` + RedactionPlaceholder},
+	// CLI credential flags with an INLINE value: --password=X, --token:X, and the single-token
+	// "--password X" form. The space-separated form where the value is a SEPARATE argv element is handled
+	// cross-element by scrubArgv (per-element scanning cannot see the next element). A bare "-p" short flag
+	// is deliberately NOT matched here: it is too ambiguous (-progress, -port, tar -pxf, cp -pr) and would
+	// destroy forensic context; glued `-pSECRET` is a documented residual covered by --password/env/=forms.
+	{regexp.MustCompile(`(?i)(^|\s)(--?(?:password|passwd|pwd|token|secret|api[-_]?key|auth)[=: ]\s*)([^\s"']+)`), `${1}${2}` + RedactionPlaceholder},
+	// connection string credentials: scheme://user:PASSWORD@host  → redact only the password
+	{regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://[^\s:/@]+:)([^\s:/@]+)(@)`), `${1}` + RedactionPlaceholder + `${3}`},
+	// bearer tokens
+	{regexp.MustCompile(`(?i)(bearer\s+)([A-Za-z0-9._~+/=\-]{8,})`), `${1}` + RedactionPlaceholder},
+	// AWS access key id
+	{regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`), RedactionPlaceholder},
+	// PEM private key block (single or multi-line)
+	{regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`), RedactionPlaceholder},
+}
+
+// credentialFlag matches an argv element that is EXACTLY a credential-passing flag with no inline value, so
+// the FOLLOWING argv element (its value) must be redacted — this catches the very common space-separated
+// `--password secret` form that a per-element scan cannot see (each element scanned in isolation).
+var credentialFlag = regexp.MustCompile(`(?i)^--?(?:password|passwd|pwd|token|secret|api[-_]?key|access[-_]?key|secret[-_]?key|auth[-_]?token|client[-_]?secret|credential)$`)
+
+// IsCredentialFlag reports whether an argv element is a lone credential flag whose next element is a value
+// to redact.
+func IsCredentialFlag(arg string) bool { return credentialFlag.MatchString(arg) }
+
+// scrubSecrets applies every secret pattern to value, returning the scrubbed string and whether anything
+// changed. It is idempotent: re-scrubbing already-redacted text is a no-op (the placeholder matches no
+// pattern), so a re-normalized/replayed event redacts to byte-identical output.
+func scrubSecrets(value string) (string, bool) {
+	if value == "" {
+		return value, false
+	}
+	out := value
+	for _, p := range secretPatterns {
+		out = p.re.ReplaceAllString(out, p.repl)
+	}
+	return out, out != value
+}
+
+// hashValue is the DispositionHash transform: a salted digest that preserves correlation (same salt+value
+// → same output) without revealing the cleartext. The salt is domain-separated from the value with 0x1e.
+func hashValue(salt, value string) string {
+	h := sha256.New()
+	h.Write([]byte(salt))
+	h.Write([]byte{0x1e})
+	h.Write([]byte(value))
+	return "h:" + hex.EncodeToString(h.Sum(nil))[:32]
+}

--- a/internal/domain/telemetry/envelope.go
+++ b/internal/domain/telemetry/envelope.go
@@ -51,6 +51,10 @@ type TelemetryEnvelope struct {
 	CoverageFlags   CoverageFlags
 	DataQuality     DataQuality
 	ResourceContext ResourceContext
+	// RedactionPolicyDigest names the source-side privacy policy that scrubbed this event (A6, #627),
+	// recorded WITH the data so a reader knows how it was redacted. It is DISTINCT from any sampling-policy
+	// digest. Empty when no redaction policy was applied (pre-A6 path); set by privacy.Scrub.
+	RedactionPolicyDigest string
 	// Event is the typed payload (the "TypedPayload" contract slot).
 	Event TelemetryEvent
 }

--- a/internal/domain/telemetry/quality.go
+++ b/internal/domain/telemetry/quality.go
@@ -30,6 +30,10 @@ const (
 	// QualityKernelTimestampUnavailable — OccurredAt could not be taken from the kernel event and fell
 	// back to the collector's ObservedAt; the two are equal for this event.
 	QualityKernelTimestampUnavailable
+	// QualityRedacted — source-side privacy redaction (A6, #627) changed at least one field of this event
+	// (a secret scrubbed, a value hashed, or a field dropped) before it entered the spool. The reader knows
+	// a redacted value is not the raw observation; the applied policy is named by RedactionPolicyDigest.
+	QualityRedacted
 )
 
 // Has reports whether flag f is set.
@@ -56,6 +60,7 @@ func (q DataQuality) String() string {
 		{QualityMissingStartTime, "missing_start_time"},
 		{QualityMissingParentStartTime, "missing_parent_start_time"},
 		{QualityKernelTimestampUnavailable, "kernel_ts_unavailable"},
+		{QualityRedacted, "redacted"},
 	}
 	var set []string
 	for _, e := range names {


### PR DESCRIPTION
## A6 — source-side telemetry + detection redaction (#627)

Redacts sensitive data **at the source** (on the agent, before the WAL/ship) so raw telemetry and detection evidence never persist or leave the host carrying secrets/PII by default (EPIC #594 spine, carries the A0.6 privacy half of #611). Delivers the **#611 privacy exit**: a planted secret is gone from the envelope, spool, batch, commitment, and the permanently-sealed detection.

### What's in this PR
- **`internal/domain/privacy/`** (new, pure domain) — `FieldDisposition` (allow/redact/hash/drop), `Policy` + `DefaultPolicy` (no environment collected, argv/path bounded, known secret patterns scrubbed, `RedactSecrets` on), `Classify`, and a distinct `RedactionPolicyDigest` (domain-separated `synapse-redaction-policy:v1`, **not** the sampling digest). `Scrub` walks a telemetry envelope; `ScrubDetection` walks a detection's evidence events — both **non-mutating** (deep copy) and **deterministic** (no ingest clock), so an idempotent re-normalize/replay yields byte-identical output.
- **`RedactArgv` is slice-aware** — it scans each argv element **and** redacts the value element that follows a lone credential flag, catching the common space-separated `--password secret` form a per-element scan cannot. Secret patterns cover `key=value` (incl. underscore/dash-joined env keys like `DB_PASSWORD=`, `aws_secret_access_key=`), inline credential flags, connection-string passwords, bearer tokens, AWS access-key ids, and PEM private keys. The ambiguous glued `-p<value>` form is a documented residual (it over-redacts `-progress`/`-port`/`tar -pxf`).
- **`internal/domain/telemetry`** — a `QualityRedacted` data-quality flag + a `RedactionPolicyDigest` envelope field, so the redaction travels with the data.
- **`internal/adapter/agentspool`** — the `DurableSensor` applies `Scrub` after Normalize and **before** the spool; the `DetectionSink` applies `ScrubDetection` before it marshals/ids/spools the detection (closing the permanently-sealed detection-evidence channel). Both default to `DefaultPolicy` and **fail closed**: an invalid policy errors rather than shipping cleartext, and a scrub error drops the event as degraded coverage. A Scrub-introduced truncation sets **both** honesty channels (the per-field struct flag AND the `DataQuality` bit).

### Verification
- `go build` / `go vet` / `gofmt` clean; `-race` green across privacy, agentspool, telemetry, fleet, httpapi.
- Tests: the #611 known-secret exit on both channels (telemetry envelope + detection evidence), split-argv (`["--password","SECRET"]`) redaction, env-style `DB_PASSWORD=` / `aws_secret_access_key=`, hash-preserves-correlation, deterministic + idempotent scrub, non-mutation, bounded argv/path with both honesty channels set, fail-closed on invalid policy. Fake secrets in tests are assembled from split literals (no verbatim secret in source).
- Dual review (go-arch + security), **three rounds** — surfaced and fixed: a HIGH (detection-evidence channel bypassed redaction), MEDIUM pattern gaps (`DB_PASSWORD=`/`-p`/AWS), a MEDIUM split-argv leak (space-separated `--password value` — the initial test masked it with a joined string), and two honesty-flag gaps. Final verdict: **go-arch PASS, security CLEAN — mergeable.**

### Scope / follow-up
Fleet-wide **field-RBAC + query audit**, retention tiers, legal hold, and deletion/export are **X6 (#635)** — A6 is the on-plane source-side redaction slice and feeds X6. **#627 stays open** for that tail (and the documented `-p`-glued / internal-space-value minor residuals). A pre-existing repo-wide doc-coverage debt (openapi/config for the A3/A4 fleet routes+env) is unrelated to this PR.
