### PR TITLE
docs(fleet): document A3/A4 fleet routes + env flags for coverage guards

### DIFF
--- a/api/testdata/openapi-coverage-debt.txt
+++ b/api/testdata/openapi-coverage-debt.txt
@@ -14,6 +14,7 @@ DELETE /api/v1/engagements/{p}/credentials/{p}
 DELETE /api/v1/quality-gates/{p}
 DELETE /api/v1/quality-profiles/{p}
 GET /api/v1/agents
+GET /api/v1/agents/{p}/keys
 GET /api/v1/agents/rollout
 GET /api/v1/assets
 GET /api/v1/assets/edges
@@ -85,6 +86,7 @@ GET /api/v1/vulnerability/sources/types
 GET /api/v1/writeups
 PATCH /api/v1/engagements/{p}
 PATCH /api/v1/vulnerability/sources/{p}
+POST /api/v1/agents/{p}/keys/{p}/revoke
 POST /api/v1/agents/{p}/revoke
 POST /api/v1/agents/enrolment-tokens
 POST /api/v1/agents/rollout/pause
@@ -118,10 +120,13 @@ POST /api/v1/engagements/{p}/writeup-drafts/{p}/edit
 POST /api/v1/engagements/{p}/writeup-drafts/{p}/reject
 POST /api/v1/engagements/import
 POST /api/v1/fleet/decommission
+POST /api/v1/fleet/detections
 POST /api/v1/fleet/enrol
 POST /api/v1/fleet/heartbeat
 POST /api/v1/fleet/inventory/cluster
 POST /api/v1/fleet/inventory/host
+POST /api/v1/fleet/keys
+POST /api/v1/fleet/telemetry
 POST /api/v1/fleet/work/{p}/progress
 POST /api/v1/fleet/work/{p}/result
 POST /api/v1/fleet/work/claim

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -223,6 +223,9 @@ All off by default. The fleet needs PostgreSQL + `synapse-worker`; agents run on
 | `SYNAPSE_FLEET_ASSETS_ENABLED` | `false` | Fleet asset model + attack paths. |
 | `SYNAPSE_FLEET_HOST_INGEST_ENABLED` | `false` | Accept host-inventory from `synapse-agent`. |
 | `SYNAPSE_FLEET_CLUSTER_INGEST_ENABLED` | `false` | Accept Kubernetes inventory from `synapse-cluster-agent`. |
+| `SYNAPSE_FLEET_TELEMETRY_INGEST_ENABLED` | `false` | Accept signed agent telemetry batches (A3, `POST /api/v1/fleet/telemetry`); verified + idempotently sequenced server-side. |
+| `SYNAPSE_FLEET_DETECTION_INGEST_ENABLED` | `false` | Accept signed agent detection batches (A4, `POST /api/v1/fleet/detections`); sealed once into the evidence chain. |
+| `SYNAPSE_FLEET_KEY_REGISTRATION_ENABLED` | `false` | Serve agent signing-key registration (`POST /api/v1/fleet/keys`) + operator key list/revoke (A4, A0.2). |
 | `SYNAPSE_FLEET_STALE_AFTER` | `10m` | An agent older than this reads as stale (`<=0` disables the staleness view). |
 | `SYNAPSE_FLEET_COVERAGE_FRESHNESS_TARGET` | `24h` | Coverage freshness SLO. |
 | `SYNAPSE_FLEET_MIN_AGENT_VERSION` | empty | Reject agents below this version (empty = no floor). |


### PR DESCRIPTION
Closes the pre-existing doc-coverage debt from #651/#652: the fleet telemetry/detection/key-registration routes + their `SYNAPSE_FLEET_*` feature flags were absent from the two coverage guards, reddening `go test ./...` on main.

- Record the five agent-plane/operator routes (`/fleet/telemetry`, `/fleet/detections`, `/fleet/keys`, `/agents/{id}/keys`, `/agents/{id}/keys/{keyID}/revoke`) in `api/testdata/openapi-coverage-debt.txt` — consistent with every other agent-plane fleet route (none are described in openapi.yaml).
- Document the three feature flags in `docs/guide/configuration.md`.

`go test ./...` is now green (both `TestOpenAPIRouteCoverage` and `TestConfigDocCoversEveryOperatorEnv` pass). Docs-only; no code change.