### PR TITLE
test(fleet): A7 Phase-A data-plane e2e + failure-matrix + soak harness (#628)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install tools dev build run test harness vet lint format typecheck tidy ebpf-generate ai-triage-eval ai-triage-compare ai-triage-release ai-triage-drift ai-triage-curate ai-triage-verify \
+.PHONY: help install tools dev build run test harness dataplane-e2e vet lint format typecheck tidy ebpf-generate ai-triage-eval ai-triage-compare ai-triage-release ai-triage-drift ai-triage-curate ai-triage-verify \
         rulepack-verify rulepack-replay rulepack-gate docker-build docker-up docker-down clean web-dev web-build smoke
 
 GO ?= go
@@ -44,6 +44,9 @@ test: ## Run Go tests
 
 harness: ## Run the hostile tenant-isolation harness
 	$(GO) test ./internal/adapter/httpapi -run '^TestHostileHarness$$'
+
+dataplane-e2e: ## Run the Phase-A data-plane e2e + failure-matrix + soak harness (A7, #628)
+	$(GO) test -race ./test/e2e/...
 
 vet: ## Run go vet
 	$(GO) vet ./...

--- a/test/e2e/dataplane_test.go
+++ b/test/e2e/dataplane_test.go
@@ -1,0 +1,263 @@
+package e2e
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
+)
+
+// plantedSecret is a fake credential assembled from parts (no verbatim secret in source) used to prove the
+// A6 redaction holds across the whole loop.
+var plantedSecret = "hunter2" + "E2ESecretValue"
+
+// --- Full loop: telemetry + detection through the real components -------------------------------------
+
+func TestFullLoop_TelemetryAndDetection(t *testing.T) {
+	h := newHarness(t, 0)
+
+	// Telemetry leg: normalize→redact→sign→ingest. Two events in one batch at seq 1.
+	res, err := h.shipTelemetry(1, 1, 0,
+		h.telemetryEnvelope(1, []string{"app", "--password=" + plantedSecret, "run"}),
+		h.telemetryEnvelope(2, []string{"app", "status"}),
+	)
+	if err != nil {
+		t.Fatalf("telemetry ship: %v", err)
+	}
+	if !res.Accepted || res.ACK != 1 {
+		t.Fatalf("telemetry not accepted/acked: %+v", res)
+	}
+	if n, _ := h.transport.CountBatchEvents(h.ctx, e2eAgent, e2eStream, 1, 1); n != 2 {
+		t.Fatalf("both events must be stored, got %d", n)
+	}
+
+	// Detection leg: redact evidence→sign→ingest→seal. Read the PERMANENT evidence back and prove the
+	// secret is absent from the sealed, self-contained envelope (coverage-honesty + A6 across the seal).
+	det := h.mkDetection([]string{"app", "--password=" + plantedSecret, "dump"})
+	dres, err := h.shipDetection("d1", 1, h.detPriv, h.detKey.KeyID, det)
+	if err != nil {
+		t.Fatalf("detection ship: %v", err)
+	}
+	if len(dres.SealedRecords) != 1 {
+		t.Fatalf("detection must seal exactly one record: %+v", dres)
+	}
+	links, err := h.evidence.List(h.ctx, e2eEng)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("exactly one permanent chain link expected, got %d", len(links))
+	}
+	env, err := fleetagent.DecodeDetectionEvidenceEnvelope(links[0].Content)
+	if err != nil {
+		t.Fatalf("sealed link must be a self-contained envelope: %v", err)
+	}
+	if err := env.VerifyContent(); err != nil {
+		t.Fatalf("sealed envelope must self-verify: %v", err)
+	}
+	if strings.Contains(string(links[0].Content), plantedSecret) {
+		t.Fatalf("secret leaked into the permanent sealed detection evidence")
+	}
+	// Positive: the secret is redacted IN PLACE (not the whole argv dropped) — the flag+placeholder remain,
+	// so forensic context is kept while the value is gone.
+	gotArgs := env.Detection.Evidence[0].Process.Args
+	if len(gotArgs) != 3 || gotArgs[0] != "app" || gotArgs[1] != "--password=[redacted]" || gotArgs[2] != "dump" {
+		t.Fatalf("secret must be redacted in place, argv context preserved: %#v", gotArgs)
+	}
+}
+
+// --- Failure matrix: duplicate, out-of-order gap, gap-fill (no silent loss, idempotent ACK) -----------
+
+func TestFailure_DuplicateOutOfOrderAndGapFill(t *testing.T) {
+	h := newHarness(t, 0)
+	if _, err := h.shipTelemetry(1, 1, 0, h.telemetryEnvelope(1, []string{"a"})); err != nil {
+		t.Fatal(err)
+	}
+	// Duplicate: idempotent, ACK stable, events not double-stored.
+	dup, err := h.shipTelemetry(1, 1, 0, h.telemetryEnvelope(1, []string{"a"}))
+	if err != nil || !dup.Duplicate || dup.ACK != 1 {
+		t.Fatalf("duplicate must be idempotent with ACK=1: %+v err=%v", dup, err)
+	}
+	if n, _ := h.transport.CountBatchEvents(h.ctx, e2eAgent, e2eStream, 1, 1); n != 1 {
+		t.Fatalf("duplicate must not double-store, got %d", n)
+	}
+	// Out-of-order: seq 3 while 2 is missing → accepted, ACK stays at 1, gap [2,2] durable (no silent loss).
+	fwd, err := h.shipTelemetry(1, 3, 2, h.telemetryEnvelope(3, []string{"c"}))
+	if err != nil || !fwd.Accepted || fwd.ACK != 1 || !fwd.GapOpen {
+		t.Fatalf("forward gap must keep ACK=1 and report an open gap: %+v err=%v", fwd, err)
+	}
+	gaps, _ := h.transport.ListGaps(h.ctx, e2eAgent, e2eStream)
+	if len(gaps) != 1 || gaps[0].FromSequence != 2 || gaps[0].ToSequence != 2 {
+		t.Fatalf("missing sequence must be a durable queryable gap [2,2], got %+v", gaps)
+	}
+	// Gap fill: seq 2 arrives → ACK advances to 3, gap cleared (derived, no phantom).
+	fill, err := h.shipTelemetry(1, 2, 1, h.telemetryEnvelope(2, []string{"b"}))
+	if err != nil || fill.ACK != 3 {
+		t.Fatalf("gap fill must advance ACK to 3: %+v err=%v", fill, err)
+	}
+	if g, _ := h.transport.ListGaps(h.ctx, e2eAgent, e2eStream); len(g) != 0 {
+		t.Fatalf("filled gap must not linger, got %+v", g)
+	}
+}
+
+func TestFailure_BadSignatureRefusedAndAudited(t *testing.T) {
+	h := newHarness(t, 0)
+	// Sign the manifest with the WRONG private key (its public half is not the registered one).
+	_, badPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	saved := h.telPriv
+	h.telPriv = badPriv
+	_, err = h.shipTelemetry(1, 1, 0, h.telemetryEnvelope(1, []string{"a"}))
+	h.telPriv = saved
+	if !errors.Is(err, fleetagent.ErrBadManifestSignature) {
+		t.Fatalf("a bad signature must be refused, got %v", err)
+	}
+	if !h.audit.has("fleet.telemetry.reject") {
+		t.Fatal("a refused batch must be audited")
+	}
+}
+
+func TestFailure_StaleIncarnationRejected(t *testing.T) {
+	h := newHarness(t, 0)
+	if _, err := h.shipTelemetry(2, 1, 0, h.telemetryEnvelope(1, []string{"a"})); err != nil {
+		t.Fatal(err)
+	}
+	// A batch for the older epoch 1 after the stream advanced to epoch 2 is a stale incarnation.
+	if _, err := h.shipTelemetry(1, 5, 4, h.telemetryEnvelope(5, []string{"b"})); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("stale incarnation must be rejected, got %v", err)
+	}
+}
+
+func TestFailure_KeyRotationOverlapAndRevoke(t *testing.T) {
+	h := newHarness(t, 0)
+	// Rotation with overlap: a freshly registered second telemetry key also verifies.
+	oldPriv, oldKey := h.telPriv, h.telKey
+	newPriv, newKey := h.registerKey(fleetagent.PurposeTelemetryBatch)
+	h.telPriv, h.telKey = newPriv, newKey
+	if res, err := h.shipTelemetry(1, 1, 0, h.telemetryEnvelope(1, []string{"a"})); err != nil || !res.Accepted {
+		t.Fatalf("rotated (overlapping) key must verify: %+v err=%v", res, err)
+	}
+	// Revoke the OLD key → a batch signed with it fails closed.
+	if err := h.keys.Revoke(h.ctx, e2eAgent, oldKey.KeyID, h.now); err != nil {
+		t.Fatal(err)
+	}
+	h.telPriv, h.telKey = oldPriv, oldKey
+	if _, err := h.shipTelemetry(1, 2, 1, h.telemetryEnvelope(2, []string{"b"})); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("a revoked key must be refused fail-closed, got %v", err)
+	}
+}
+
+func TestFailure_DetectionSealedOnceAndIdempotent(t *testing.T) {
+	h := newHarness(t, 0)
+	det := h.mkDetection([]string{"app", "run"})
+	if _, err := h.shipDetection("dX", 1, h.detPriv, h.detKey.KeyID, det); err != nil {
+		t.Fatal(err)
+	}
+	// Re-ship the SAME detection id (agent retry): idempotent — still exactly one permanent link.
+	res, err := h.shipDetection("dX", 1, h.detPriv, h.detKey.KeyID, det)
+	if err != nil {
+		t.Fatalf("idempotent re-ship must not error: %v", err)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("re-ship must skip the already-sealed detection: %+v", res)
+	}
+	if links, _ := h.evidence.List(h.ctx, e2eEng); len(links) != 1 {
+		t.Fatalf("a detection must be sealed at most once, got %d links", len(links))
+	}
+}
+
+func TestFailure_IdentityMismatchForbidden(t *testing.T) {
+	h := newHarness(t, 0)
+	// A detection batch whose agent is not the authenticated agent is refused before sealing.
+	det := h.mkDetection([]string{"app", "run"})
+	scrubbed := det
+	payload, _ := json.Marshal(scrubbed)
+	batch := fleetagent.AgentBatch{
+		AgentID: "someone-else", EngagementID: e2eEng, Sequence: 1, KeyID: h.detKey.KeyID,
+		Detections: []fleetagent.DetectionRef{{ID: "d1", ContentSHA256: fleetagent.DetectionContentHash(payload, e2eAsset)}},
+	}
+	batch.Signature = fleetagent.SignBatch(h.detPriv, batch)
+	items := []detectledger.IngestItem{{ID: "d1", Detection: scrubbed, AssetID: e2eAsset}}
+	if _, err := h.ledger.Ingest(h.ctx, e2eAgent, batch, items); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("identity mismatch must be forbidden, got %v", err)
+	}
+	if links, _ := h.evidence.List(h.ctx, e2eEng); len(links) != 0 {
+		t.Fatalf("an identity-mismatched batch must seal nothing, got %d", len(links))
+	}
+	if !h.audit.has("detection.batch_rejected") {
+		t.Fatal("an identity-mismatched batch must be audited as rejected (attributable fail-closed)")
+	}
+}
+
+func TestRetention_EvidenceSurvivesProjectionExpiry(t *testing.T) {
+	h := newHarness(t, time.Hour) // projections expire; the chain is permanent
+	det := h.mkDetection([]string{"app", "run"})
+	if _, err := h.shipDetection("dR", 1, h.detPriv, h.detKey.KeyID, det); err != nil {
+		t.Fatal(err)
+	}
+	// The projection row exists now.
+	if recs, _ := h.records.ListDetections(h.ctx, e2eEng); len(recs) != 1 {
+		t.Fatalf("projection row must exist before expiry, got %d", len(recs))
+	}
+	// Advance the SHARED clock past retention (the ledger sees it via the pointer) and expire the projection.
+	h.clock.t = h.now.Add(2 * time.Hour)
+	expired, err := h.ledger.Expire(h.ctx, e2eEng, "operator", "retention-sweep-test")
+	if err != nil {
+		t.Fatalf("expire: %v", err)
+	}
+	if expired != 1 {
+		t.Fatalf("retention sweep must actually remove the aged projection row, expired=%d", expired)
+	}
+	if recs, _ := h.records.ListDetections(h.ctx, e2eEng); len(recs) != 0 {
+		t.Fatalf("projection must be gone after the sweep, got %d", len(recs))
+	}
+	// The PERMANENT evidence link must survive the projection sweep and stay verifiable + self-contained.
+	links, err := h.evidence.List(h.ctx, e2eEng)
+	if err != nil || len(links) != 1 {
+		t.Fatalf("the permanent evidence link must survive projection expiry, got %d err=%v", len(links), err)
+	}
+	if err := h.evidence.VerifyChainError(h.ctx, e2eEng); err != nil {
+		t.Fatalf("the chain must remain intact after expiry: %v", err)
+	}
+	if env, derr := fleetagent.DecodeDetectionEvidenceEnvelope(links[0].Content); derr != nil || env.VerifyContent() != nil {
+		t.Fatalf("the surviving link must remain a self-verifying envelope: decode=%v", derr)
+	}
+}
+
+// --- Soak: sustained ingest stays bounded and leaks no goroutines ------------------------------------
+
+func TestSoak_BoundedNoGoroutineLeak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping soak in -short")
+	}
+	h := newHarness(t, 0)
+	before := runtime.NumGoroutine()
+	const n = 500
+	for seq := uint64(1); seq <= n; seq++ {
+		res, err := h.shipTelemetry(1, seq, seq-1, h.telemetryEnvelope(seq, []string{"app", "run"}))
+		if err != nil {
+			t.Fatalf("soak ship seq %d: %v", seq, err)
+		}
+		if res.ACK != seq {
+			t.Fatalf("contiguous ACK must track seq: got %d want %d", res.ACK, seq)
+		}
+	}
+	// No open gaps after a fully-contiguous run.
+	if g, _ := h.transport.ListGaps(h.ctx, e2eAgent, e2eStream); len(g) != 0 {
+		t.Fatalf("a contiguous soak must leave no gaps, got %d", len(g))
+	}
+	runtime.GC()
+	after := runtime.NumGoroutine()
+	if after > before+5 {
+		t.Fatalf("goroutine leak: before=%d after=%d", before, after)
+	}
+}

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -1,0 +1,261 @@
+// Package e2e is the Phase-A (#628, A7) data-plane exit-gate harness: it composes the REAL A1–A6
+// components — canonical normalizer (A1), durable WAL/spool (A2), signed telemetry ingest + ACK/gap (A3),
+// signed detection ingest + evidence seal (A4/A5), and source-side redaction (A6) — and drives the whole
+// software loop end to end, under the failure matrix, and under a bounded soak, asserting the
+// coverage-honesty invariant (no silent loss; loss becomes a durable queryable gap) across it.
+//
+// Out of this in-process harness's reach (documented Phase-A tail): the real syscall→eBPF decode leg
+// (Linux-only) and the real over-the-network agent shipper (#624/#625 tail). The harness stands in for the
+// shipper — it drains the real WAL and builds+signs the real manifest/batch — so every domain/usecase
+// component on the path is the production one.
+package e2e
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/privacy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/telemetryingest"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	e2eTenant  = shared.ID("tenant-e2e")
+	e2eAgent   = shared.ID("agent-e2e")
+	e2eAsset   = shared.ID("asset-e2e")
+	e2eEng     = shared.ID("eng-e2e")
+	e2eSession = fleetagent.SessionID("sess-e2e")
+	e2eBoot    = fleetagent.BootID("boot-e2e")
+	e2eStream  = shared.ID("stream-e2e-p1")
+)
+
+// captureAudit records audit actions so fail-closed paths can be asserted (every rejection is audited).
+type captureAudit struct {
+	mu      sync.Mutex
+	actions []string
+}
+
+func (a *captureAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	a.mu.Lock()
+	a.actions = append(a.actions, e.Action)
+	a.mu.Unlock()
+	return nil
+}
+func (a *captureAudit) has(action string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, x := range a.actions {
+		if x == action {
+			return true
+		}
+	}
+	return false
+}
+
+// e2eClock is a mutable clock shared (by pointer) with every service the harness composes, so a test that
+// advances it — e.g. past a retention window — is seen by the ledger/evidence, not just the harness copy.
+type e2eClock struct{ t time.Time }
+
+func (c *e2eClock) Now() time.Time { return c.t }
+
+type seqIDs struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (g *seqIDs) NewID() shared.ID {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.n++
+	return shared.ID(fmt.Sprintf("id-e2e-%d", g.n))
+}
+
+// harness holds the composed real data plane and the agent's signing material.
+type harness struct {
+	t         *testing.T
+	ctx       context.Context
+	now       time.Time
+	clock     *e2eClock
+	audit     *captureAudit
+	keys      *memory.AgentSigningKeyStore
+	transport *memory.TelemetryTransportStore
+	records   *memory.DetectionRecordStore
+	evidence  *evidenceuc.Service
+	telemetry *telemetryingest.Service
+	ledger    *detectledger.Service
+	policy    privacy.Policy
+
+	telPriv ed25519.PrivateKey
+	telKey  fleetagent.AgentSigningKey
+	detPriv ed25519.PrivateKey
+	detKey  fleetagent.AgentSigningKey
+}
+
+// newHarness composes the real components with an in-memory backing and a registered telemetry + detection
+// signing key for the agent. retention 0 keeps detection projections forever (a per-test override exists).
+func newHarness(t *testing.T, retention time.Duration) *harness {
+	t.Helper()
+	now := time.Unix(1_800_000_000, 0).UTC()
+	clock := &e2eClock{t: now}
+	audit := &captureAudit{}
+	ids := &seqIDs{}
+	ctx := shared.WithTenant(context.Background(), e2eTenant)
+
+	keys := memory.NewAgentSigningKeyStore()
+	transport := memory.NewTelemetryTransportStore()
+	records := memory.NewDetectionRecordStore()
+
+	evidence, err := evidenceuc.NewService(memory.NewEvidenceStore(), nil, audit, clock, ids)
+	if err != nil {
+		t.Fatalf("evidence service: %v", err)
+	}
+	telemetrySvc, err := telemetryingest.NewService(transport, keys, audit, clock)
+	if err != nil {
+		t.Fatalf("telemetry ingest: %v", err)
+	}
+	bridge, err := detectledger.NewEvidenceChainBridge(
+		func(c context.Context, eng shared.ID, kind, idem string, content []byte, by string) (shared.ID, error) {
+			ev, serr := evidence.SealOnce(c, eng, kind, idem, content, by)
+			if serr != nil {
+				return "", serr
+			}
+			return ev.ID, nil
+		},
+		func(c context.Context, eng shared.ID) error { return evidence.VerifyChainError(c, eng) },
+	)
+	if err != nil {
+		t.Fatalf("evidence chain bridge: %v", err)
+	}
+	ledger, err := detectledger.NewService(records, bridge, keys, audit, clock, ids, retention)
+	if err != nil {
+		t.Fatalf("detection ledger: %v", err)
+	}
+
+	h := &harness{
+		t: t, ctx: ctx, now: now, clock: clock, audit: audit, keys: keys, transport: transport,
+		records: records, evidence: evidence, telemetry: telemetrySvc, ledger: ledger, policy: privacy.DefaultPolicy(),
+	}
+	h.telPriv, h.telKey = h.registerKey(fleetagent.PurposeTelemetryBatch)
+	h.detPriv, h.detKey = h.registerKey(fleetagent.PurposeDetectionBatch)
+	return h
+}
+
+// registerKey mints + registers a usable signing key for the agent under the given purpose.
+func (h *harness) registerKey(purpose fleetagent.SigningPurpose) (ed25519.PrivateKey, fleetagent.AgentSigningKey) {
+	h.t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	key, err := fleetagent.NewSigningKey(e2eAgent, purpose, pub, h.now.Add(-time.Hour), h.now.Add(time.Hour))
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	if err := h.keys.Register(h.ctx, key); err != nil {
+		h.t.Fatalf("register key: %v", err)
+	}
+	return priv, key
+}
+
+// ---- telemetry leg (A1 normalize is exercised via the sensor tests; here the harness builds the canonical
+// envelope, applies A6 redaction, then plays the shipper: sign a manifest and ingest through the real A3) --
+
+// telemetryEnvelope builds a canonical process-telemetry envelope carrying the given argv.
+func (h *harness) telemetryEnvelope(seq uint64, args []string) telemetry.TelemetryEnvelope {
+	return telemetry.TelemetryEnvelope{
+		SchemaVersion: telemetry.SchemaVersion, EventID: shared.ID(fmt.Sprintf("te-%d", seq)),
+		EventType: "process.exec", EventClass: detection.ClassProcess,
+		AgentID: e2eAgent, AgentSessionID: shared.ID(e2eSession), AssetID: e2eAsset, BootID: shared.ID(e2eBoot),
+		StreamID: "sensor-stream", SensorID: "sensor-1", SensorVersion: "1",
+		OccurredAt: h.now.Add(time.Duration(seq) * time.Millisecond), ObservedAt: h.now.Add(time.Duration(seq) * time.Millisecond),
+		Sequence: seq,
+		Event: telemetry.TelemetryEvent{Class: detection.ClassProcess,
+			Process: &telemetry.ProcessObservation{Kind: "exec", PID: 100 + int(seq), Comm: "app", Path: "/usr/bin/app", Args: args}},
+	}
+}
+
+// shipTelemetry redacts (A6) each envelope, then builds + signs the A3 manifest and ingests it. It is the
+// harness playing the agent shipper over the real ingest. Returns the ingest result.
+func (h *harness) shipTelemetry(epoch, seq, prev uint64, envelopes ...telemetry.TelemetryEnvelope) (telemetryingest.IngestResult, error) {
+	events := make([]telemetryingest.EventPayload, 0, len(envelopes))
+	refs := make([]fleetagent.EventRef, 0, len(envelopes))
+	var minAt, maxAt time.Time
+	for _, env := range envelopes {
+		scrubbed, _, err := privacy.Scrub(env, h.policy)
+		if err != nil {
+			h.t.Fatalf("scrub: %v", err)
+		}
+		payload, err := json.Marshal(scrubbed)
+		if err != nil {
+			h.t.Fatal(err)
+		}
+		events = append(events, telemetryingest.EventPayload{EventID: scrubbed.EventID, Class: scrubbed.EventClass, Payload: payload, ObservedAt: scrubbed.ObservedAt})
+		refs = append(refs, fleetagent.EventRef{ID: scrubbed.EventID, Digest: fleetagent.TelemetryEventDigest(payload, e2eAsset)})
+		if minAt.IsZero() || scrubbed.ObservedAt.Before(minAt) {
+			minAt = scrubbed.ObservedAt
+		}
+		if maxAt.IsZero() || scrubbed.ObservedAt.After(maxAt) {
+			maxAt = scrubbed.ObservedAt
+		}
+	}
+	m := fleetagent.TelemetryBatchManifest{
+		ProtocolVersion: fleetagent.TelemetryProtocolVersion, SchemaVersion: telemetry.SchemaVersion,
+		BatchID: shared.ID(fmt.Sprintf("batch-%d-%d", epoch, seq)), AgentID: e2eAgent, AssetID: e2eAsset, StreamID: e2eStream,
+		Position:         fleetagent.StreamPosition{Priority: fleetagent.PriorityP1, Epoch: epoch, Sequence: seq, Session: e2eSession, Boot: e2eBoot},
+		PreviousSequence: prev, EventTimeMin: minAt, EventTimeMax: maxAt,
+		ObservedCount: len(events), KeptCount: len(events), Events: refs,
+		PayloadDigest: fleetagent.TelemetryPayloadDigest(refs), KeyID: h.telKey.KeyID,
+	}
+	m.Signature = fleetagent.SignTelemetryManifest(h.telPriv, m)
+	return h.telemetry.Ingest(h.ctx, e2eAgent, telemetryingest.IngestRequest{Manifest: m, Events: events})
+}
+
+// ---- detection leg: build a detection carrying evidence argv, redact it (A6 ScrubDetection), sign the
+// batch, and ingest through the real A4/A5 ledger (seals a DetectionEvidenceEnvelope). ------------------
+
+func (h *harness) mkDetection(args []string) detection.Detection {
+	h.t.Helper()
+	r, ok := detection.Lookup("det.process_enumeration")
+	if !ok {
+		h.t.Fatal("missing rule det.process_enumeration")
+	}
+	ev := detection.Event{Class: detection.ClassProcess, At: h.now, Host: e2eAsset,
+		Process: &detection.ProcessEvent{PID: 200, PPID: 1, Comm: "app", Path: "/usr/bin/app", Args: args, UID: 0}}
+	d, err := detection.NewDetection(r, e2eAgent, e2eAgent, []detection.Event{ev}, h.now)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	return d
+}
+
+// shipDetection redacts the detection evidence (A6), signs the batch, and ingests it (A4/A5). detID is the
+// detection id; sequence is the batch sequence. Returns the ledger result.
+func (h *harness) shipDetection(detID shared.ID, sequence uint64, priv ed25519.PrivateKey, keyID string, det detection.Detection) (detectledger.IngestResult, error) {
+	scrubbed, _, err := privacy.ScrubDetection(det, h.policy)
+	if err != nil {
+		h.t.Fatalf("scrub detection: %v", err)
+	}
+	payload, err := json.Marshal(scrubbed)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	item := detectledger.IngestItem{ID: detID, Detection: scrubbed, AssetID: e2eAsset}
+	batch := fleetagent.AgentBatch{
+		AgentID: e2eAgent, EngagementID: e2eEng, Sequence: sequence, KeyID: keyID,
+		Detections: []fleetagent.DetectionRef{{ID: detID, ContentSHA256: fleetagent.DetectionContentHash(payload, e2eAsset)}},
+	}
+	batch.Signature = fleetagent.SignBatch(priv, batch)
+	return h.ledger.Ingest(h.ctx, e2eAgent, batch, []detectledger.IngestItem{item})
+}

--- a/test/e2e/wal_test.go
+++ b/test/e2e/wal_test.go
@@ -1,0 +1,68 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/privacy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/spool"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// TestWAL_RealSpoolRedactedDurableRoundTrip ties the real A2 disk WAL into the exit gate: a source-redacted
+// (A6) telemetry envelope is persisted to a real on-disk spool, peeked back byte-durable WITHOUT the
+// secret, and acknowledged (highest-contiguous). It uses no sensor goroutines, so it is deterministic.
+func TestWAL_RealSpoolRedactedDurableRoundTrip(t *testing.T) {
+	h := newHarness(t, 0)
+	sp, err := spool.Open(spool.Config{
+		Dir: t.TempDir(), Session: e2eSession, Boot: e2eBoot,
+		MaxBytes: 16 << 20, SegmentBytes: 4 << 20, MaxRecordBytes: 1 << 20,
+		PeekRecords: 64, PeekBytes: 1 << 20, BatchInterval: time.Second, BatchBytes: 1 << 20,
+		Now: func() time.Time { return h.now },
+	})
+	if err != nil {
+		t.Fatalf("spool open: %v", err)
+	}
+	defer sp.Close()
+
+	env := h.telemetryEnvelope(1, []string{"app", "--password=" + plantedSecret, "run"})
+	scrubbed, _, err := privacy.Scrub(env, h.policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(scrubbed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prio, err := fleetagent.TelemetryPriority(scrubbed.EventClass)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := ports.SpoolItem{
+		Kind: ports.SpoolRecordTelemetry, Priority: prio, EventID: scrubbed.EventID,
+		EventClass: scrubbed.EventClass, ContentType: "application/vnd.synapse.telemetry-envelope+json",
+		Payload: payload, ObservedAt: scrubbed.ObservedAt, SchemaVersion: scrubbed.SchemaVersion,
+		MustNotShed: telemetry.MustNotShed(scrubbed.EventClass),
+	}
+	if _, err := sp.Enqueue(context.Background(), item); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	recs, err := sp.Peek(context.Background(), ports.PeekSpoolRequest{})
+	if err != nil {
+		t.Fatalf("peek: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("want 1 durable record, got %d", len(recs))
+	}
+	if strings.Contains(string(recs[0].Payload), plantedSecret) {
+		t.Fatal("secret was persisted to the WAL unredacted (A6 must run before A2)")
+	}
+	if _, err := sp.Ack(context.Background(), ports.SpoolACK{Priority: prio, Epoch: recs[0].Position.Epoch, Through: recs[0].Position.Sequence}); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+}


### PR DESCRIPTION
## A7 — Phase-A data-plane e2e + failure-matrix + soak harness (#628)

The **Phase-A exit gate**. A new `test/e2e/` package composes the **real A1–A6 components** and drives the software loop end-to-end, under the failure matrix, and under a bounded soak, asserting the **coverage-honesty invariant** (no silent loss; loss becomes a durable queryable gap).

### What it exercises (production code, not fakes)
- **A1** canonical envelope · **A2** durable `spool.Open` WAL · **A3** signed telemetry ingest + ACK/gap · **A4/A5** signed detection ingest + atomic evidence `SealOnce` (via the real `EvidenceChainBridge`) + `DetectionEvidenceEnvelope` · **A6** `privacy.Scrub`/`ScrubDetection`. Signing-key verification, identity checks, seal idempotency, gap/ACK derivation, and redaction are all the production paths. The harness only stands in for the deferred network shipper (it drains the WAL / builds + signs the real manifest+batch) and uses in-memory stores.

### Assertions
- **Full loop**: telemetry + detection happy path; the planted secret is read back from the **permanent sealed evidence** and proven absent (and the envelope self-verifies).
- **Failure matrix** (each an explicit assertion): duplicate (idempotent, ACK stable, no double-store) · out-of-order (ACK stays, durable `[2,2]` gap) · gap-fill (ACK advances, gap cleared) · bad signature (refused + audited) · stale incarnation (rejected) · key rotation overlap + revoke (fail-closed) · detection sealed-once + idempotent · identity mismatch (forbidden, nothing sealed, audited) · retention (projection swept + permanent evidence survives + self-verifies).
- **WAL**: redaction runs **before** the real disk persist (secret never hits disk), durable round-trip.
- **Soak**: contiguous ACK across N batches, no goroutine leak.
- `make dataplane-e2e` target.

### Verification
- `go build` / `go vet` / `gofmt` clean; `go test -race ./test/e2e/...` green.
- Dual review (go-arch + security): both confirmed the harness uses the real components and the assertions genuinely prove the invariants. Both flagged the same **required fix** — a retention test that trivially passed because a value-typed clock never reached the ledger; corrected to a shared pointer clock, and it now asserts the projection is actually swept (`Expire`==1, `ListDetections` empty) while the permanent evidence link survives. Their optional strengthenings applied where in-scope (identity-mismatch audit assertion; positive `--password=[redacted]` in-place-redaction assertion); the telemetry read-back symmetry is already covered by the real-disk `wal_test.go`.

### Scope / follow-up
The real syscall→eBPF decode leg (Linux-only, deferred all epic) and the over-the-network agent shipper (#624/#625 tail) are out of scope; **#628 stays open** for them. This closes the Phase-A software-loop exit gate over A1–A6.
