### PR TITLE
feat(fleet): A8 continuous host-inventory sweep on the agent (#629)

### DIFF
--- a/cmd/synapse-agent/main.go
+++ b/cmd/synapse-agent/main.go
@@ -75,6 +75,11 @@ type config struct {
 	metricsAddr           string  // optional private agent metrics listener
 	detectionEngagement   string  // engagement receiving signed detection batches; empty = local-only
 	detectionShipInterval time.Duration
+	// inventorySweep turns the host inventory from on-demand (a scan.host work order) into a continuous
+	// periodic stream (A8, #629). Enabled by default (ingest-on); the interval is clamped to a floor so a
+	// misconfiguration cannot busy-loop the collector over the real filesystem.
+	inventorySweepEnabled  bool
+	inventorySweepInterval time.Duration
 }
 
 func main() {
@@ -132,6 +137,8 @@ func parseConfig() config {
 	flag.StringVar(&cfg.metricsAddr, "agent-metrics-addr", os.Getenv("SYNAPSE_AGENT_METRICS_ADDR"), "optional address for private agent Prometheus metrics (for example 127.0.0.1:9465)")
 	flag.StringVar(&cfg.detectionEngagement, "detection-engagement", os.Getenv("SYNAPSE_DETECTION_ENGAGEMENT_ID"), "engagement id receiving signed detection batches; empty keeps detections local")
 	flag.DurationVar(&cfg.detectionShipInterval, "detection-ship-interval", parsePositiveDuration(os.Getenv("SYNAPSE_DETECTION_SHIP_INTERVAL"), time.Second), "idle interval for the independent detection delivery loop")
+	flag.BoolVar(&cfg.inventorySweepEnabled, "inventory-sweep", envEnabledDefaultTrue(os.Getenv("SYNAPSE_INVENTORY_SWEEP_ENABLED")), "ship host inventory continuously on a cadence (A8, #629); on by default")
+	flag.DurationVar(&cfg.inventorySweepInterval, "inventory-sweep-interval", parsePositiveDuration(os.Getenv("SYNAPSE_INVENTORY_SWEEP_INTERVAL"), time.Hour), "cadence of the continuous host-inventory sweep (clamped to a floor)")
 	flag.Parse()
 	if cfg.enrolToken == "" {
 		// An absent token file is NOT fatal: it is the normal state after enrolment, once the
@@ -163,6 +170,10 @@ func (r *runner) run(ctx context.Context) error {
 	// It is given the enrolled credential so its events carry the canonical AgentID, not the display
 	// name (D1 fix, #606).
 	r.startDetection(ctx, cred)
+	// Continuous host-inventory sweep (#629, A8): a background stream, separate from the per-work-order
+	// scan.host cycle below, so a control plane always has a fresh inventory to re-evaluate against new
+	// advisories without a manual re-scan. Best-effort — it never blocks or fails the work-order loop.
+	r.startInventorySweep(ctx, cred)
 	for {
 		if err := r.cycle(ctx, cred); err != nil {
 			if errors.Is(err, context.Canceled) {

--- a/cmd/synapse-agent/sweep.go
+++ b/cmd/synapse-agent/sweep.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
+)
+
+// minInventorySweepInterval floors the sweep cadence: enumerating installed OS packages + language deps
+// over the real filesystem is heavier than a heartbeat, so a misconfigured tiny interval must not busy-loop
+// the collector. A 1-minute floor is well below any realistic advisory-freshness need.
+const minInventorySweepInterval = time.Minute
+
+// envEnabledDefaultTrue parses a boolean env var that defaults to ON when unset: only an explicit
+// false/0/no/off disables. Used so the continuous sweep is ingest-on by default (#629) yet operator-
+// disableable.
+func envEnabledDefaultTrue(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "false", "0", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// startInventorySweep launches the continuous host-inventory sweep (#629, A8) as a background goroutine. It
+// ships one inventory promptly, then re-sweeps on the configured cadence, until the context is cancelled.
+// Every ship is idempotent server-side (host upsert-by-natural-key), so a re-sweep of an unchanged host is
+// a no-op, and a fresh inventory lets the continuous-exposure engine re-flag it against new advisories with
+// no re-scan. It is best-effort: a collect/ship error is logged and retried on the next cadence, never
+// blocking the agent.
+func (r *runner) startInventorySweep(ctx context.Context, cred fleetclient.Credential) {
+	if r.cfg.once {
+		// A one-shot diagnostic run (`--once`) does a single work-order cycle and exits; starting a
+		// continuous background stream that races process teardown would be surprising and pointless.
+		return
+	}
+	if !r.cfg.inventorySweepEnabled {
+		log.Print("inventory sweep: disabled (SYNAPSE_INVENTORY_SWEEP_ENABLED=false)")
+		return
+	}
+	interval := resolveSweepInterval(r.cfg.inventorySweepInterval)
+	if interval != r.cfg.inventorySweepInterval {
+		log.Printf("inventory sweep: interval %s below the %s floor; using the floor", r.cfg.inventorySweepInterval, minInventorySweepInterval)
+	}
+	go r.runSweepLoop(ctx, cred, interval)
+}
+
+// resolveSweepInterval clamps the configured cadence to the floor so a misconfiguration cannot busy-loop
+// the collector.
+func resolveSweepInterval(d time.Duration) time.Duration {
+	if d < minInventorySweepInterval {
+		return minInventorySweepInterval
+	}
+	return d
+}
+
+// runSweepLoop sweeps once promptly (so a freshly-started agent is not dark until the first tick), then
+// re-sweeps every interval until the context is cancelled. It blocks; startInventorySweep runs it in a
+// goroutine.
+func (r *runner) runSweepLoop(ctx context.Context, cred fleetclient.Credential, interval time.Duration) {
+	r.sweepOnce(ctx, cred)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.sweepOnce(ctx, cred)
+		}
+	}
+}
+
+// sweepOnce collects the host inventory and ships it to the control plane. Best-effort: errors are logged,
+// not returned — the next cadence is the retry, and the server ingest is idempotent so a repeated ship of
+// an unchanged host produces no churn.
+func (r *runner) sweepOnce(ctx context.Context, cred fleetclient.Credential) {
+	if err := ctx.Err(); err != nil {
+		return
+	}
+	inv, err := r.collect(ctx, r.cfg.root)
+	if err != nil {
+		log.Printf("inventory sweep: collect: %v", err)
+		return
+	}
+	if err := r.api.SendHostInventory(ctx, cred.Token, inv); err != nil {
+		log.Printf("inventory sweep: report inventory: %v", err)
+		return
+	}
+	// A degraded inventory is still shipped — the control plane records the coverage/degraded flags on the
+	// asset (coverage honesty), so a partial sweep is a visible gap, never silence — but note it locally.
+	if inv.Degraded() {
+		log.Print("inventory sweep: shipped a DEGRADED inventory (package data incomplete); coverage recorded server-side")
+	}
+}

--- a/cmd/synapse-agent/sweep_test.go
+++ b/cmd/synapse-agent/sweep_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/hostinventory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetclient"
+)
+
+// sweepAPI is a concurrency-safe fleetAPI for the background sweep loop: it counts SendHostInventory calls
+// under a mutex (the loop ships from a goroutine, so the plain fakeAPI.sent would race). It embeds *fakeAPI
+// for the other methods and overrides only the ship.
+type sweepAPI struct {
+	*fakeAPI
+	mu    sync.Mutex
+	ships int
+	err   error
+}
+
+func (s *sweepAPI) SendHostInventory(_ context.Context, _ string, _ any) error {
+	s.mu.Lock()
+	s.ships++
+	s.mu.Unlock()
+	return s.err
+}
+func (s *sweepAPI) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ships
+}
+
+func newSweepRunner(t *testing.T, api *sweepAPI, enabled bool, collect func(context.Context, string) (hostinventory.HostInventory, error)) *runner {
+	t.Helper()
+	dir := t.TempDir()
+	return &runner{
+		api:     api,
+		collect: collect,
+		cfg:     config{stateDir: dir, root: dir, name: "host1", inventorySweepEnabled: enabled},
+	}
+}
+
+// waitForShips polls until at least n ships are observed or the deadline passes (no fixed sleeps, so it is
+// not timing-flaky).
+func waitForShips(t *testing.T, api *sweepAPI, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if api.count() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d ships, saw %d", n, api.count())
+}
+
+func TestSweepOnceShipsCollectedInventory(t *testing.T) {
+	api := &sweepAPI{fakeAPI: &fakeAPI{}}
+	r := newSweepRunner(t, api, true, okCollect(hostinventory.HostInventory{Facts: hostinventory.HostFacts{OS: "linux"}}))
+	r.sweepOnce(context.Background(), fleetclient.Credential{Token: "t"})
+	if api.count() != 1 {
+		t.Fatalf("sweepOnce must ship exactly once, got %d", api.count())
+	}
+}
+
+func TestSweepOnceCollectErrorDoesNotShip(t *testing.T) {
+	api := &sweepAPI{fakeAPI: &fakeAPI{}}
+	r := newSweepRunner(t, api, true, func(context.Context, string) (hostinventory.HostInventory, error) {
+		return hostinventory.HostInventory{}, errors.New("collect failed")
+	})
+	r.sweepOnce(context.Background(), fleetclient.Credential{Token: "t"})
+	if api.count() != 0 {
+		t.Fatalf("a collect failure must not ship, got %d", api.count())
+	}
+}
+
+func TestSweepOnceCancelledContextDoesNotShip(t *testing.T) {
+	api := &sweepAPI{fakeAPI: &fakeAPI{}}
+	r := newSweepRunner(t, api, true, okCollect(hostinventory.HostInventory{}))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r.sweepOnce(ctx, fleetclient.Credential{Token: "t"})
+	if api.count() != 0 {
+		t.Fatalf("a cancelled context must ship nothing, got %d", api.count())
+	}
+}
+
+func TestResolveSweepIntervalFloor(t *testing.T) {
+	if got := resolveSweepInterval(time.Second); got != minInventorySweepInterval {
+		t.Fatalf("below-floor interval must clamp to %s, got %s", minInventorySweepInterval, got)
+	}
+	if got := resolveSweepInterval(2 * time.Hour); got != 2*time.Hour {
+		t.Fatalf("above-floor interval must pass through, got %s", got)
+	}
+}
+
+func TestRunSweepLoopShipsOnCadence(t *testing.T) {
+	api := &sweepAPI{fakeAPI: &fakeAPI{}}
+	r := newSweepRunner(t, api, true, okCollect(hostinventory.HostInventory{Facts: hostinventory.HostFacts{OS: "linux"}}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.runSweepLoop(ctx, fleetclient.Credential{Token: "t"}, 5*time.Millisecond)
+	// One prompt sweep + several ticks → at least 3 ships in well under the deadline.
+	waitForShips(t, api, 3)
+}
+
+func TestRunSweepLoopStopsOnCancel(t *testing.T) {
+	api := &sweepAPI{fakeAPI: &fakeAPI{}}
+	r := newSweepRunner(t, api, true, okCollect(hostinventory.HostInventory{}))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { r.runSweepLoop(ctx, fleetclient.Credential{Token: "t"}, 5*time.Millisecond); close(done) }()
+	waitForShips(t, api, 1)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSweepLoop did not stop after context cancellation")
+	}
+	stable := api.count()
+	time.Sleep(20 * time.Millisecond)
+	if api.count() != stable {
+		t.Fatalf("no ships must occur after the loop stopped: was %d, now %d", stable, api.count())
+	}
+}
+
+func TestStartInventorySweepDisabledDoesNotShip(t *testing.T) {
+	api := &sweepAPI{fakeAPI: &fakeAPI{}}
+	r := newSweepRunner(t, api, false, okCollect(hostinventory.HostInventory{}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r.startInventorySweep(ctx, fleetclient.Credential{Token: "t"})
+	time.Sleep(20 * time.Millisecond)
+	if api.count() != 0 {
+		t.Fatalf("a disabled sweep must ship nothing, got %d", api.count())
+	}
+}
+
+func TestEnvEnabledDefaultTrue(t *testing.T) {
+	for _, v := range []string{"", "true", "1", "yes", "anything"} {
+		if !envEnabledDefaultTrue(v) {
+			t.Fatalf("%q must enable (default-on)", v)
+		}
+	}
+	for _, v := range []string{"false", "0", "no", "off", "FALSE", " Off "} {
+		if envEnabledDefaultTrue(v) {
+			t.Fatalf("%q must disable", v)
+		}
+	}
+}

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -388,6 +388,8 @@ The following variables are read by `synapse-agent` and `synapse-cluster-agent`,
 | `SYNAPSE_AGENT_STATE_DIR` | platform default | Credential and offline-buffer directory; `/var/lib/synapse-cluster-agent` for the cluster agent. Protect it from other users. |
 | `SYNAPSE_AGENT_ROOT` | `/` | Host filesystem root inventoried by the VM agent. |
 | `SYNAPSE_AGENT_NAME` | hostname | Human-readable agent display name. |
+| `SYNAPSE_INVENTORY_SWEEP_ENABLED` | `true` | Ship host inventory continuously on a cadence (A8, #629), not only on a `scan.host` work order. Ingest is idempotent server-side (host upsert-by-natural-key), so a re-sweep of an unchanged host is a no-op. Set `false` to disable. |
+| `SYNAPSE_INVENTORY_SWEEP_INTERVAL` | `1h` | Cadence of the continuous host-inventory sweep. Clamped to a 1-minute floor so a misconfiguration cannot busy-loop the collector over the filesystem. |
 | `SYNAPSE_DETECT_CLASSES` | empty | Comma-separated eBPF classes: `process`, `network`, `file`, `privilege`. Empty disables the engine; Linux root/capabilities are required. |
 | `SYNAPSE_DETECT_CPU_CEIL_PCT` | `0` | CPU ceiling for deterministic class shedding; zero disables shedding. |
 | `SYNAPSE_DETECTION_ENGAGEMENT_ID` | empty | Engagement receiving signed detection batches. Empty keeps confirmed detections durably local and does not start the remote detection shipper. |


### PR DESCRIPTION
## A8 — continuous host-inventory sweep on the agent (#629)

Turns host inventory from **on-demand** (a `scan.host` work order) into a **continuous, periodic stream** so the control plane always has a fresh inventory to re-evaluate against new advisories — no manual re-scan needed. This closes the A8 leg of the EDR data-plane spine (#594); A0–A7 are already merged.

### What it does
- A background sweep loop in `cmd/synapse-agent`, launched alongside the existing detection loop. It collects the host inventory and ships it via the existing `SendHostInventory` seam.
- Sweeps **once promptly** on start (a freshly-started agent is not dark until the first tick), then every `SYNAPSE_INVENTORY_SWEEP_INTERVAL` (default `1h`).
- **Ingest-on by default**, operator-disableable via `SYNAPSE_INVENTORY_SWEEP_ENABLED=false`.
- The cadence is **clamped to a 1-minute floor** so a misconfigured tiny interval cannot busy-loop the collector.
- **Best-effort**: a collect/ship error is logged and retried on the next cadence, never blocking the agent. The context bounds the goroutine (no leak). A `--once` diagnostic run does **not** start the stream.
- A **degraded** inventory is still shipped — the server records the coverage/degraded flags, so a partial sweep is a visible gap, never silence (coverage honesty).

### Why it is safe / idempotent
- Idempotency is **server-side and already in place**: host-inventory `Sync` is an upsert-by-natural-key, so a re-sweep of an unchanged host is a no-op, and the package list already feeds the continuous-exposure engine — a new advisory revision re-flags existing inventory deterministically with no re-scan.
- No new ports, no new deps: reuses the runner's read-only `collect` + `SendHostInventory`.

### Tests
Race-clean (`go test -race ./cmd/synapse-agent/...`): cadence, disabled, cancel-stops-loop, interval floor, collect-error-no-ship, cancelled-ctx-no-ship, default-on env parse — using a poll-with-timeout harness (no flaky fixed sleeps).

### Scope / follow-up
Desired-vs-observed **sweep-specific** coverage (an agent that *should* be sweeping but isn't) is the X4/X5 (#633/#634) fleet-automation / continuous-exposure concern, and the real host package-enumeration leg is unchanged. **#629 stays open** for that tail.

### Verification (CI is off — validated locally)
`go build ./...`, `go vet ./cmd/synapse-agent/...`, `gofmt -l` clean, full `go test ./...` green, `go test -race ./cmd/synapse-agent/...` green.
