### PR TITLE
feat(endpoint): Phase B endpoint visibility — process/network entities + State Timeline (#663 #664 #669)

### DIFF
--- a/internal/domain/endpoint/connection.go
+++ b/internal/domain/endpoint/connection.go
@@ -1,0 +1,89 @@
+package endpoint
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ConnectionState is the lifecycle state of a projected network connection.
+type ConnectionState string
+
+const (
+	// ConnectionObserved is a flow seen at least once. A1's NetworkObservation carries no close event or
+	// byte counters yet, so "closed" and traffic volume are reserved for the sensor-side tail.
+	ConnectionObserved ConnectionState = "observed"
+)
+
+// NetworkConnection is a process-attributed network flow reconstructed from network telemetry (B2). It is
+// keyed by a stable ConnectionID so re-observing the same flow widens its last-seen time instead of
+// creating a duplicate, and it links to the process that opened it by the A1 ProcessEntityID rather than a
+// bare PID.
+type NetworkConnection struct {
+	ConnectionID    shared.ID
+	TenantID        shared.ID
+	AssetID         shared.ID
+	ProcessEntityID shared.ID
+	Proto           string
+	Direction       string
+	LocalAddr       string
+	LocalPort       int
+	RemoteAddr      string
+	RemotePort      int
+	Comm            string
+	FirstSeenAt     time.Time
+	LastSeenAt      time.Time
+	State           ConnectionState
+}
+
+// Validate enforces a well-formed network connection.
+func (c NetworkConnection) Validate() error {
+	if c.ConnectionID.IsZero() {
+		return fmt.Errorf("%w: network connection has no connection id", shared.ErrValidation)
+	}
+	if c.AssetID.IsZero() {
+		return fmt.Errorf("%w: network connection has no asset id", shared.ErrValidation)
+	}
+	if c.State != ConnectionObserved {
+		return fmt.Errorf("%w: network connection has unknown state %q", shared.ErrValidation, c.State)
+	}
+	return nil
+}
+
+func (c NetworkConnection) clone() NetworkConnection { return c }
+
+// ConnectionID derives the stable identity of a flow from the tuple that distinguishes it on one asset:
+// the originating process entity, protocol, direction, and the local/remote 5-tuple. Like the A1 entity
+// ids it is a domain-separated sha256 over a LENGTH-PREFIXED encoding of the parts, so no field's content
+// (an address, an empty local endpoint) can collide with another via a delimiter. Empty local endpoints
+// (the sensor often sees only the connect target) simply hash as empty, which is stable.
+func ConnectionID(assetID, processEntityID shared.ID, proto, direction, localAddr string, localPort int, remoteAddr string, remotePort int) shared.ID {
+	sum := hashFields("endpoint:network-connection:v1",
+		assetID.String(), processEntityID.String(), proto, direction,
+		localAddr, strconv.Itoa(localPort), remoteAddr, strconv.Itoa(remotePort))
+	return shared.ID("nc_" + sum[:32])
+}
+
+// hashFields returns the hex sha256 of a domain-separated, length-prefixed encoding of parts. It mirrors
+// the telemetry entity-id construction so endpoint ids share the same collision-resistance discipline.
+func hashFields(domain string, parts ...string) string {
+	h := sha256.New()
+	writeField(h, domain)
+	for _, p := range parts {
+		writeField(h, p)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func writeField(h io.Writer, s string) {
+	var lp [8]byte
+	binary.BigEndian.PutUint64(lp[:], uint64(len(s)))
+	_, _ = h.Write(lp[:])
+	_, _ = io.WriteString(h, s)
+}

--- a/internal/domain/endpoint/connection_test.go
+++ b/internal/domain/endpoint/connection_test.go
@@ -1,0 +1,96 @@
+package endpoint
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestConnectionIDIsStableAndProcessAttributed(t *testing.T) {
+	s := mustState(t)
+	proc := procEntityID(300, 1)
+	if _, err := s.Observe(netEnv("n1", base, proc, "tcp", "egress", "10.0.0.1", 4444, "1.2.3.4", 443)); err != nil {
+		t.Fatal(err)
+	}
+	conns := s.Connections()
+	if len(conns) != 1 {
+		t.Fatalf("one flow expected, got %d", len(conns))
+	}
+	c := conns[0]
+	if c.ProcessEntityID != proc {
+		t.Fatalf("connection must be attributed to its process entity, got %s", c.ProcessEntityID)
+	}
+	want := ConnectionID(testAsset, proc, "tcp", "egress", "10.0.0.1", 4444, "1.2.3.4", 443)
+	if c.ConnectionID != want {
+		t.Fatalf("connection id unstable: got %s want %s", c.ConnectionID, want)
+	}
+	if c.ConnectionID.IsZero() {
+		t.Fatal("connection id must be non-zero")
+	}
+}
+
+func TestReObservingFlowDedupesEntityButLogsEachEvent(t *testing.T) {
+	s := mustState(t)
+	proc := procEntityID(301, 1)
+	if _, err := s.Observe(netEnv("n1", base, proc, "tcp", "egress", "10.0.0.1", 5555, "1.2.3.4", 443)); err != nil {
+		t.Fatal(err)
+	}
+	// Same 5-tuple + process, later time, DIFFERENT event id (a repeat connect).
+	entries, err := s.Observe(netEnv("n2", base.Add(30*time.Second), proc, "tcp", "egress", "10.0.0.1", 5555, "1.2.3.4", 443))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("each distinct connect event is a timeline transition, got %d", len(entries))
+	}
+	conns := s.Connections()
+	if len(conns) != 1 {
+		t.Fatalf("the connection ENTITY must dedupe the flow, got %d", len(conns))
+	}
+	if !conns[0].LastSeenAt.Equal(base.Add(30*time.Second)) || !conns[0].FirstSeenAt.Equal(base) {
+		t.Fatalf("entity window must span [first,last], got [%s,%s]", conns[0].FirstSeenAt, conns[0].LastSeenAt)
+	}
+	if got := len(s.Timeline()); got != 2 {
+		t.Fatalf("timeline must log each connect event, got %d", got)
+	}
+	// Re-applying the SAME event id is idempotent (no third entry).
+	again, err := s.Observe(netEnv("n2", base.Add(30*time.Second), proc, "tcp", "egress", "10.0.0.1", 5555, "1.2.3.4", 443))
+	if err != nil || len(again) != 0 || len(s.Timeline()) != 2 {
+		t.Fatalf("same-event re-apply must be idempotent: entries=%d timeline=%d err=%v", len(again), len(s.Timeline()), err)
+	}
+}
+
+func TestDistinctFlowsAreDistinctConnections(t *testing.T) {
+	s := mustState(t)
+	proc := procEntityID(302, 1)
+	cases := []struct {
+		id                       string
+		proto, dir, laddr, raddr string
+		lport, rport             int
+	}{
+		{"a", "tcp", "egress", "10.0.0.1", "1.2.3.4", 1000, 443},
+		{"b", "udp", "egress", "10.0.0.1", "1.2.3.4", 1000, 443},  // different proto
+		{"c", "tcp", "ingress", "10.0.0.1", "1.2.3.4", 1000, 443}, // different direction
+		{"d", "tcp", "egress", "10.0.0.1", "9.9.9.9", 1000, 443},  // different remote
+	}
+	for _, tc := range cases {
+		if _, err := s.Observe(netEnv(tc.id, base, proc, tc.proto, tc.dir, tc.laddr, tc.lport, tc.raddr, tc.rport)); err != nil {
+			t.Fatalf("%s: %v", tc.id, err)
+		}
+	}
+	if got := len(s.Connections()); got != len(cases) {
+		t.Fatalf("each distinct flow must be its own connection: got %d want %d", got, len(cases))
+	}
+}
+
+func TestNetworkConnectionValidate(t *testing.T) {
+	good := NetworkConnection{ConnectionID: shared.ID("nc_x"), AssetID: testAsset, State: ConnectionObserved}
+	if err := good.Validate(); err != nil {
+		t.Fatalf("valid connection rejected: %v", err)
+	}
+	bad := NetworkConnection{ConnectionID: shared.ID("nc_x"), AssetID: testAsset, State: "bogus"}
+	if bad.Validate() == nil {
+		t.Fatal("unknown state must be rejected")
+	}
+}

--- a/internal/domain/endpoint/endpoint.go
+++ b/internal/domain/endpoint/endpoint.go
@@ -1,0 +1,303 @@
+package endpoint
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+// maxAncestorWalk bounds the lineage walk so a malformed parent cycle can never loop forever.
+const maxAncestorWalk = 256
+
+// EndpointState is the projected endpoint-visibility state for ONE (tenant, asset): its process entities
+// (B1), network connections (B2), and the State Timeline (B7) of their transitions. It is built by
+// folding telemetry envelopes with Observe and is a pure, deterministic aggregate — no I/O, no clock.
+// The zero value is not usable; construct it with NewEndpointState.
+type EndpointState struct {
+	tenantID  shared.ID
+	assetID   shared.ID
+	processes map[shared.ID]*ProcessEntity
+	conns     map[shared.ID]*NetworkConnection
+	timeline  *StateTimeline
+	processed map[shared.ID]struct{}
+}
+
+// NewEndpointState creates the projection for one asset. Both ids are required — endpoint visibility is
+// always scoped to a concrete tenant and asset, and Observe rejects an envelope for a different asset.
+func NewEndpointState(tenantID, assetID shared.ID) (*EndpointState, error) {
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: endpoint state requires a tenant id", shared.ErrValidation)
+	}
+	if assetID.IsZero() {
+		return nil, fmt.Errorf("%w: endpoint state requires an asset id", shared.ErrValidation)
+	}
+	return &EndpointState{
+		tenantID:  tenantID,
+		assetID:   assetID,
+		processes: make(map[shared.ID]*ProcessEntity),
+		conns:     make(map[shared.ID]*NetworkConnection),
+		timeline:  newStateTimeline(),
+		processed: make(map[shared.ID]struct{}),
+	}, nil
+}
+
+// Observe folds one telemetry envelope into the endpoint state and returns the timeline entries the fold
+// produced (possibly none). It is:
+//   - deterministic and reorder-invariant — entities and the timeline depend only on envelope content,
+//     not on the order envelopes are folded in (descriptor fields resolve latest-by-event-time,
+//     started/first-seen are the earliest event time, last-seen the latest);
+//   - idempotent by EventID — re-applying the same envelope changes nothing and returns no entries;
+//   - fail-closed — the envelope is fully validated (telemetry.Validate) and a wrong-asset envelope is
+//     rejected, never silently folded.
+//
+// Only process (B1) and network (B2) classes are projected here; file/privilege envelopes are accepted
+// (already validated) and marked processed but produce no state yet (B3/B4).
+func (s *EndpointState) Observe(env telemetry.TelemetryEnvelope) ([]TimelineEntry, error) {
+	if err := env.Validate(); err != nil {
+		return nil, fmt.Errorf("endpoint: reject malformed telemetry envelope: %w", err)
+	}
+	if env.AssetID != s.assetID {
+		return nil, fmt.Errorf("%w: envelope asset %s does not belong to endpoint state asset %s", shared.ErrValidation, env.AssetID, s.assetID)
+	}
+	if _, done := s.processed[env.EventID]; done {
+		return nil, nil
+	}
+
+	var entries []TimelineEntry
+	switch env.EventClass {
+	case detection.ClassProcess:
+		entries = s.applyProcess(env)
+	case detection.ClassNetwork:
+		entries = s.applyNetwork(env)
+	default:
+		// File/privilege and any future class are valid telemetry but not projected in B1/B2; accept and
+		// mark processed so a later B3/B4 fold in a fresh state can own them.
+	}
+	s.processed[env.EventID] = struct{}{}
+	return entries, nil
+}
+
+// applyProcess folds a validated process envelope. env is already telemetry-validated by Observe, so the
+// process payload is present and well-formed.
+func (s *EndpointState) applyProcess(env telemetry.TelemetryEnvelope) []TimelineEntry {
+	obs := env.Event.Process
+
+	pe, existed := s.processes[obs.EntityID]
+	if !existed {
+		pe = &ProcessEntity{
+			EntityID: obs.EntityID,
+			TenantID: s.tenantID,
+			AssetID:  s.assetID,
+			State:    ProcessRunning,
+		}
+		s.processes[obs.EntityID] = pe
+	} else if pe.State == ProcessUnknown {
+		// A parent stub is now directly observed: promote it (its real start is set by the min below).
+		pe.State = ProcessRunning
+	}
+
+	// Descriptor fields are resolved by EVENT time: an observation only overwrites them when it is the
+	// latest one seen for this entity (its OccurredAt is not before the current last-seen). This makes the
+	// projection invariant to the order envelopes are folded in — an out-of-order older envelope never
+	// clobbers newer descriptors. An exec replaces the image.
+	descriptorIsLatest := !existed || !env.OccurredAt.Before(pe.LastSeenAt)
+	if descriptorIsLatest {
+		pe.PID = obs.PID
+		pe.PPID = obs.PPID
+		pe.ParentEntityID = obs.ParentEntityID
+		pe.UID = obs.UID
+		pe.Resource = env.ResourceContext
+		if obs.Comm != "" {
+			pe.Comm = obs.Comm
+		}
+		if obs.Kind == "exec" || obs.Path != "" {
+			pe.Path = obs.Path
+			pe.Args = append([]string(nil), obs.Args...)
+			pe.ArgsTruncated = obs.ArgsTruncated
+			pe.PathTruncated = obs.PathTruncated
+		}
+	}
+	// StartedAt is the EARLIEST event time observed for the entity; LastSeenAt the latest. Both take a
+	// min/max so they are order-independent (a stub's zero StartedAt is filled by its first real event).
+	if pe.StartedAt.IsZero() || env.OccurredAt.Before(pe.StartedAt) {
+		pe.StartedAt = env.OccurredAt
+	}
+	if env.OccurredAt.After(pe.LastSeenAt) {
+		pe.LastSeenAt = env.OccurredAt
+	}
+
+	s.ensureParentStub(obs)
+
+	kind := TimelineProcessStart
+	if obs.Kind == "exec" {
+		kind = TimelineProcessExec
+	}
+	entry, appended := s.timeline.append(TimelineEntry{
+		OccurredAt: env.OccurredAt,
+		TenantID:   s.tenantID,
+		AssetID:    s.assetID,
+		EntityKind: EntityProcess,
+		EntityID:   obs.EntityID,
+		Kind:       kind,
+		EventID:    env.EventID,
+		Summary:    processObsSummary(obs),
+	})
+	if !appended {
+		return nil
+	}
+	return []TimelineEntry{entry}
+}
+
+// ensureParentStub records a referenced-but-unobserved parent as an explicit ProcessUnknown entity, so a
+// lineage gap is visible (coverage honesty) rather than a silently broken chain. The stub's LastSeenAt is
+// left zero — it was never directly observed — so a later real observation of the parent (whose event time
+// may predate the child that referenced it) is always treated as the latest descriptor and promotes it.
+func (s *EndpointState) ensureParentStub(obs *telemetry.ProcessObservation) {
+	if obs.ParentEntityID.IsZero() || obs.ParentEntityID == obs.EntityID {
+		return
+	}
+	if _, ok := s.processes[obs.ParentEntityID]; ok {
+		return
+	}
+	s.processes[obs.ParentEntityID] = &ProcessEntity{
+		EntityID: obs.ParentEntityID,
+		TenantID: s.tenantID,
+		AssetID:  s.assetID,
+		PID:      obs.PPID,
+		State:    ProcessUnknown,
+	}
+}
+
+// applyNetwork folds a validated network envelope. env is already telemetry-validated by Observe.
+func (s *EndpointState) applyNetwork(env telemetry.TelemetryEnvelope) []TimelineEntry {
+	obs := env.Event.Network
+
+	id := ConnectionID(s.assetID, obs.ProcessEntityID, obs.Proto, obs.Direction, obs.LocalAddr, obs.LocalPort, obs.RemoteAddr, obs.RemotePort)
+	conn, existed := s.conns[id]
+	if !existed {
+		conn = &NetworkConnection{
+			ConnectionID:    id,
+			TenantID:        s.tenantID,
+			AssetID:         s.assetID,
+			ProcessEntityID: obs.ProcessEntityID,
+			Proto:           obs.Proto,
+			Direction:       obs.Direction,
+			LocalAddr:       obs.LocalAddr,
+			LocalPort:       obs.LocalPort,
+			RemoteAddr:      obs.RemoteAddr,
+			RemotePort:      obs.RemotePort,
+			Comm:            obs.Comm,
+			FirstSeenAt:     env.OccurredAt,
+			LastSeenAt:      env.OccurredAt,
+			State:           ConnectionObserved,
+		}
+		s.conns[id] = conn
+	} else {
+		// The connection ENTITY deduplicates the flow: re-observing widens its seen window. Both bounds
+		// take a min/max so the window is order-independent (reorder-invariant).
+		if env.OccurredAt.After(conn.LastSeenAt) {
+			conn.LastSeenAt = env.OccurredAt
+		}
+		if env.OccurredAt.Before(conn.FirstSeenAt) {
+			conn.FirstSeenAt = env.OccurredAt
+		}
+	}
+
+	// The TIMELINE records one entry per connect EVENT (deduped by EventID), so it is a complete,
+	// reorder-invariant log of observations. Deduplication of the flow itself lives on the connection
+	// entity above, not on the timeline — a per-flow entry would have to take the timestamp of whichever
+	// connect was folded first, which would not be reorder-invariant.
+	entry, appended := s.timeline.append(TimelineEntry{
+		OccurredAt: env.OccurredAt,
+		TenantID:   s.tenantID,
+		AssetID:    s.assetID,
+		EntityKind: EntityNetwork,
+		EntityID:   id,
+		Kind:       TimelineNetworkConnect,
+		EventID:    env.EventID,
+		Summary:    connectionObsSummary(obs),
+	})
+	if !appended {
+		return nil
+	}
+	return []TimelineEntry{entry}
+}
+
+// Process returns a copy of one process entity by id.
+func (s *EndpointState) Process(id shared.ID) (ProcessEntity, bool) {
+	pe, ok := s.processes[id]
+	if !ok {
+		return ProcessEntity{}, false
+	}
+	return pe.clone(), true
+}
+
+// Processes returns a copy of all process entities, ordered by entity id for a stable result.
+func (s *EndpointState) Processes() []ProcessEntity {
+	out := make([]ProcessEntity, 0, len(s.processes))
+	for _, pe := range s.processes {
+		out = append(out, pe.clone())
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].EntityID < out[j].EntityID })
+	return out
+}
+
+// Connections returns a copy of all network connections, ordered by connection id for a stable result.
+func (s *EndpointState) Connections() []NetworkConnection {
+	out := make([]NetworkConnection, 0, len(s.conns))
+	for _, c := range s.conns {
+		out = append(out, c.clone())
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ConnectionID < out[j].ConnectionID })
+	return out
+}
+
+// Timeline returns the event-time-ordered State Timeline.
+func (s *EndpointState) Timeline() []TimelineEntry { return s.timeline.Entries() }
+
+// Ancestors returns the process lineage of an entity, nearest parent first, walking ParentEntityID while
+// the ancestor is a known entity. The walk stops at the first unobserved link and is bounded against a
+// malformed cycle.
+func (s *EndpointState) Ancestors(id shared.ID) []ProcessEntity {
+	var out []ProcessEntity
+	seen := make(map[shared.ID]struct{})
+	cur, ok := s.processes[id]
+	if !ok {
+		return nil
+	}
+	for i := 0; i < maxAncestorWalk; i++ {
+		parentID := cur.ParentEntityID
+		if parentID.IsZero() {
+			return out
+		}
+		if _, loop := seen[parentID]; loop {
+			return out
+		}
+		seen[parentID] = struct{}{}
+		parent, ok := s.processes[parentID]
+		if !ok {
+			return out
+		}
+		out = append(out, parent.clone())
+		cur = parent
+	}
+	return out
+}
+
+// processObsSummary / connectionObsSummary build a timeline entry's human summary from the OBSERVATION,
+// not from the accumulated entity, so the summary is a stable record of what that event carried and does
+// not change with the order envelopes are folded in.
+func processObsSummary(obs *telemetry.ProcessObservation) string {
+	name := obs.Comm
+	if name == "" {
+		name = obs.Path
+	}
+	return fmt.Sprintf("pid=%d %s", obs.PID, name)
+}
+
+func connectionObsSummary(obs *telemetry.NetworkObservation) string {
+	return fmt.Sprintf("%s %s %s:%d->%s:%d", obs.Proto, obs.Direction, obs.LocalAddr, obs.LocalPort, obs.RemoteAddr, obs.RemotePort)
+}

--- a/internal/domain/endpoint/endpoint_test.go
+++ b/internal/domain/endpoint/endpoint_test.go
@@ -1,0 +1,364 @@
+package endpoint
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+const (
+	testTenant = shared.ID("tenant-b")
+	testAsset  = shared.ID("asset-b")
+	testBoot   = shared.ID("boot-b")
+)
+
+var base = time.Unix(1_800_000_000, 0).UTC()
+
+// procEntityID mirrors A1's derivation so tests build lineage with the real ids.
+func procEntityID(pid int, startNanos uint64) shared.ID {
+	return telemetry.ProcessEntityID(testAsset, testBoot, pid, startNanos)
+}
+
+const testAgent = shared.ID("agent-b")
+
+func procEnv(eventID string, occ time.Time, entityID, parentID shared.ID, pid, ppid int, kind, comm, path string, args ...string) telemetry.TelemetryEnvelope {
+	return telemetry.TelemetryEnvelope{
+		SchemaVersion: telemetry.SchemaVersion,
+		EventID:       shared.ID(eventID),
+		EventType:     "process." + kind,
+		EventClass:    detection.ClassProcess,
+		AgentID:       testAgent,
+		AssetID:       testAsset,
+		BootID:        testBoot,
+		OccurredAt:    occ,
+		ObservedAt:    occ,
+		Event: telemetry.TelemetryEvent{
+			Class: detection.ClassProcess,
+			Process: &telemetry.ProcessObservation{
+				Kind: kind, PID: pid, PPID: ppid,
+				EntityID: entityID, ParentEntityID: parentID,
+				Comm: comm, Path: path, Args: args, UID: 0,
+			},
+		},
+	}
+}
+
+func netEnv(eventID string, occ time.Time, procEntity shared.ID, proto, dir, laddr string, lport int, raddr string, rport int) telemetry.TelemetryEnvelope {
+	return telemetry.TelemetryEnvelope{
+		SchemaVersion: telemetry.SchemaVersion,
+		EventID:       shared.ID(eventID),
+		EventType:     "network.connect",
+		EventClass:    detection.ClassNetwork,
+		AgentID:       testAgent,
+		AssetID:       testAsset,
+		BootID:        testBoot,
+		OccurredAt:    occ,
+		ObservedAt:    occ,
+		Event: telemetry.TelemetryEvent{
+			Class: detection.ClassNetwork,
+			Network: &telemetry.NetworkObservation{
+				Kind: "connect", Proto: proto, Direction: dir,
+				LocalAddr: laddr, LocalPort: lport, RemoteAddr: raddr, RemotePort: rport,
+				ProcessEntityID: procEntity, Comm: "app",
+			},
+		},
+	}
+}
+
+func mustState(t *testing.T) *EndpointState {
+	t.Helper()
+	s, err := NewEndpointState(testTenant, testAsset)
+	if err != nil {
+		t.Fatalf("new endpoint state: %v", err)
+	}
+	return s
+}
+
+func TestNewEndpointStateValidatesIDs(t *testing.T) {
+	if _, err := NewEndpointState("", testAsset); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant: got %v", err)
+	}
+	if _, err := NewEndpointState(testTenant, ""); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing asset: got %v", err)
+	}
+}
+
+func TestObserveRejectsWrongAssetAndMissingEventID(t *testing.T) {
+	s := mustState(t)
+	e := procEnv("e1", base, procEntityID(10, 1), "", 10, 1, "exec", "app", "/usr/bin/app")
+	e.AssetID = shared.ID("other-asset")
+	if _, err := s.Observe(e); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("wrong-asset envelope must be rejected, got %v", err)
+	}
+	e2 := procEnv("", base, procEntityID(10, 1), "", 10, 1, "exec", "app", "/usr/bin/app")
+	if _, err := s.Observe(e2); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing event id must be rejected, got %v", err)
+	}
+}
+
+func TestObserveIsIdempotentByEventID(t *testing.T) {
+	s := mustState(t)
+	e := procEnv("e1", base, procEntityID(10, 5), "", 10, 1, "exec", "app", "/usr/bin/app")
+	entries, err := s.Observe(e)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("first observe: entries=%d err=%v", len(entries), err)
+	}
+	entries2, err := s.Observe(e)
+	if err != nil || len(entries2) != 0 {
+		t.Fatalf("re-observe must be a no-op: entries=%d err=%v", len(entries2), err)
+	}
+	if got := len(s.Timeline()); got != 1 {
+		t.Fatalf("timeline must hold exactly one entry after a duplicate, got %d", got)
+	}
+	if got := len(s.Processes()); got != 1 {
+		t.Fatalf("processes must hold exactly one entity, got %d", got)
+	}
+}
+
+func TestObserveIgnoresUnprojectedClasses(t *testing.T) {
+	s := mustState(t)
+	env := telemetry.TelemetryEnvelope{
+		SchemaVersion: telemetry.SchemaVersion,
+		EventID:       "f1", EventType: "file.open", EventClass: detection.ClassFile,
+		AgentID: testAgent, AssetID: testAsset, BootID: testBoot, OccurredAt: base, ObservedAt: base,
+		Event: telemetry.TelemetryEvent{Class: detection.ClassFile, File: &telemetry.FileObservation{Op: "open", Path: "/etc/passwd"}},
+	}
+	entries, err := s.Observe(env)
+	if err != nil {
+		t.Fatalf("file class must be accepted (not projected), got %v", err)
+	}
+	if len(entries) != 0 || s.timeline.Len() != 0 {
+		t.Fatalf("file class must produce no state in B1/B2")
+	}
+	// It is still marked processed, so a re-apply is a clean no-op.
+	if _, done := s.processed["f1"]; !done {
+		t.Fatal("unprojected event should still be marked processed")
+	}
+}
+
+// --- B1 process ---
+
+func TestForkThenExecTransitionsOneEntity(t *testing.T) {
+	s := mustState(t)
+	id := procEntityID(100, 7)
+	if _, err := s.Observe(procEnv("e1", base, id, "", 100, 1, "fork", "sh", "")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Observe(procEnv("e2", base.Add(time.Millisecond), id, "", 100, 1, "exec", "curl", "/usr/bin/curl", "curl", "http://x")); err != nil {
+		t.Fatal(err)
+	}
+	procs := s.Processes()
+	if len(procs) != 1 {
+		t.Fatalf("fork then exec of one pid must be one entity, got %d", len(procs))
+	}
+	pe := procs[0]
+	if pe.Path != "/usr/bin/curl" || pe.Comm != "curl" || !pe.IsRunning() {
+		t.Fatalf("exec must replace the image: %+v", pe)
+	}
+	tl := s.Timeline()
+	if len(tl) != 2 || tl[0].Kind != TimelineProcessStart || tl[1].Kind != TimelineProcessExec {
+		t.Fatalf("timeline must be [start, exec], got %+v", tl)
+	}
+}
+
+func TestPIDReuseYieldsDistinctEntities(t *testing.T) {
+	s := mustState(t)
+	first := procEntityID(200, 10)
+	second := procEntityID(200, 99) // same pid, different start time
+	if first == second {
+		t.Fatal("distinct start times must yield distinct entity ids")
+	}
+	if _, err := s.Observe(procEnv("e1", base, first, "", 200, 1, "exec", "a", "/a")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Observe(procEnv("e2", base.Add(time.Second), second, "", 200, 1, "exec", "b", "/b")); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(s.Processes()); got != 2 {
+		t.Fatalf("PID reuse must yield two distinct entities, got %d", got)
+	}
+}
+
+func TestAncestorsWalksLineageAndStubsUnknownParent(t *testing.T) {
+	s := mustState(t)
+	gpID := procEntityID(1, 1)
+	parentID := procEntityID(50, 2)
+	childID := procEntityID(500, 3)
+	// grandparent, then parent (child of grandparent), then child (child of parent).
+	if _, err := s.Observe(procEnv("e1", base, gpID, "", 1, 0, "exec", "init", "/sbin/init")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Observe(procEnv("e2", base.Add(time.Second), parentID, gpID, 50, 1, "exec", "sshd", "/usr/sbin/sshd")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Observe(procEnv("e3", base.Add(2*time.Second), childID, parentID, 500, 50, "exec", "bash", "/bin/bash")); err != nil {
+		t.Fatal(err)
+	}
+	anc := s.Ancestors(childID)
+	if len(anc) != 2 || anc[0].EntityID != parentID || anc[1].EntityID != gpID {
+		t.Fatalf("ancestors must be [parent, grandparent], got %+v", anc)
+	}
+
+	// A child whose parent was never observed gets an explicit unknown stub, not a broken chain.
+	orphanParent := procEntityID(77, 4)
+	orphan := procEntityID(777, 5)
+	if _, err := s.Observe(procEnv("e4", base.Add(3*time.Second), orphan, orphanParent, 777, 77, "exec", "x", "/x")); err != nil {
+		t.Fatal(err)
+	}
+	stub, ok := s.Process(orphanParent)
+	if !ok || stub.State != ProcessUnknown {
+		t.Fatalf("unobserved parent must be a ProcessUnknown stub, got ok=%v %+v", ok, stub)
+	}
+	if anc := s.Ancestors(orphan); len(anc) != 1 || anc[0].State != ProcessUnknown {
+		t.Fatalf("ancestors of orphan must be the unknown stub, got %+v", anc)
+	}
+}
+
+func TestUnknownParentStubPromotedWhenObserved(t *testing.T) {
+	s := mustState(t)
+	parentID := procEntityID(60, 2)
+	childID := procEntityID(600, 3)
+	// Child arrives first, referencing an as-yet-unseen parent -> stub.
+	if _, err := s.Observe(procEnv("e1", base.Add(time.Second), childID, parentID, 600, 60, "exec", "bash", "/bin/bash")); err != nil {
+		t.Fatal(err)
+	}
+	if p, _ := s.Process(parentID); p.State != ProcessUnknown {
+		t.Fatalf("parent must start as unknown stub, got %q", p.State)
+	}
+	// Parent's own observation arrives later -> promoted to running with a real start.
+	if _, err := s.Observe(procEnv("e2", base.Add(2*time.Second), parentID, "", 60, 1, "exec", "sshd", "/usr/sbin/sshd")); err != nil {
+		t.Fatal(err)
+	}
+	p, _ := s.Process(parentID)
+	if p.State != ProcessRunning || p.Path != "/usr/sbin/sshd" || !p.StartedAt.Equal(base.Add(2*time.Second)) {
+		t.Fatalf("stub must be promoted to running with real detail, got %+v", p)
+	}
+}
+
+func TestApplyRejectsMissingOrInvalidPayload(t *testing.T) {
+	s := mustState(t)
+	// Class says process, but no process payload.
+	nilProc := telemetry.TelemetryEnvelope{
+		EventID: "p1", EventClass: detection.ClassProcess, AssetID: testAsset, OccurredAt: base,
+		Event: telemetry.TelemetryEvent{Class: detection.ClassProcess},
+	}
+	if _, err := s.Observe(nilProc); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("process class without payload must be rejected, got %v", err)
+	}
+	// Invalid process observation (unknown kind).
+	badProc := procEnv("p2", base, procEntityID(1, 1), "", 1, 0, "bogus", "x", "/x")
+	if _, err := s.Observe(badProc); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("invalid process observation must be rejected, got %v", err)
+	}
+	// Class says network, but no network payload.
+	nilNet := telemetry.TelemetryEnvelope{
+		EventID: "n1", EventClass: detection.ClassNetwork, AssetID: testAsset, OccurredAt: base,
+		Event: telemetry.TelemetryEvent{Class: detection.ClassNetwork},
+	}
+	if _, err := s.Observe(nilNet); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("network class without payload must be rejected, got %v", err)
+	}
+	// A rejected envelope must leave no state and must not be marked processed.
+	if len(s.Processes()) != 0 || len(s.Connections()) != 0 || s.timeline.Len() != 0 {
+		t.Fatal("a rejected envelope must not mutate state")
+	}
+}
+
+func TestProcessEntityValidate(t *testing.T) {
+	exitedAt := base
+	cases := map[string]struct {
+		p  ProcessEntity
+		ok bool
+	}{
+		"ok running":     {ProcessEntity{EntityID: "pe_a", AssetID: testAsset, State: ProcessRunning}, true},
+		"no entity id":   {ProcessEntity{AssetID: testAsset, State: ProcessRunning}, false},
+		"no asset id":    {ProcessEntity{EntityID: "pe_a", State: ProcessRunning}, false},
+		"bad state":      {ProcessEntity{EntityID: "pe_a", AssetID: testAsset, State: "zombie"}, false},
+		"exit w/o state": {ProcessEntity{EntityID: "pe_a", AssetID: testAsset, State: ProcessRunning, ExitedAt: &exitedAt}, false},
+	}
+	for name, tc := range cases {
+		err := tc.p.Validate()
+		if tc.ok && err != nil {
+			t.Fatalf("%s: unexpected error %v", name, err)
+		}
+		if !tc.ok && err == nil {
+			t.Fatalf("%s: expected validation error", name)
+		}
+	}
+}
+
+func TestAncestorsBoundsCycles(t *testing.T) {
+	s := mustState(t)
+	a := procEntityID(11, 1)
+	b := procEntityID(22, 2)
+	// A's parent is B; B's parent is A — a malformed cycle. The walk must terminate.
+	if _, err := s.Observe(procEnv("e1", base, a, b, 11, 22, "exec", "a", "/a")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Observe(procEnv("e2", base.Add(time.Second), b, a, 22, 11, "exec", "b", "/b")); err != nil {
+		t.Fatal(err)
+	}
+	anc := s.Ancestors(a) // must not loop forever
+	if len(anc) == 0 || len(anc) > maxAncestorWalk {
+		t.Fatalf("cycle walk must be bounded and non-empty, got %d", len(anc))
+	}
+	if s.Ancestors(shared.ID("pe_missing")) != nil {
+		t.Fatal("ancestors of an unknown entity must be nil")
+	}
+}
+
+func TestFoldIsReorderInvariant(t *testing.T) {
+	pid := procEntityID(400, 1)
+	// Distinct event times so the only variable is FOLD order, not event time.
+	envs := []telemetry.TelemetryEnvelope{
+		procEnv("e1", base, pid, "", 400, 1, "fork", "sh", ""),
+		procEnv("e2", base.Add(2*time.Second), pid, "", 400, 1, "exec", "curl", "/usr/bin/curl", "curl", "http://x"),
+		netEnv("n1", base.Add(3*time.Second), pid, "tcp", "egress", "10.0.0.1", 5555, "1.2.3.4", 443),
+		netEnv("n2", base.Add(1*time.Second), pid, "tcp", "egress", "10.0.0.1", 5555, "1.2.3.4", 443), // earlier repeat of the same flow
+	}
+	fold := func(order []int) *EndpointState {
+		s := mustState(t)
+		for _, i := range order {
+			if _, err := s.Observe(envs[i]); err != nil {
+				t.Fatalf("observe %d: %v", i, err)
+			}
+		}
+		return s
+	}
+	fwd := fold([]int{0, 1, 2, 3})
+	rev := fold([]int{3, 2, 1, 0})
+
+	if !reflect.DeepEqual(fwd.Processes(), rev.Processes()) {
+		t.Fatalf("processes differ by fold order:\nfwd=%+v\nrev=%+v", fwd.Processes(), rev.Processes())
+	}
+	if !reflect.DeepEqual(fwd.Connections(), rev.Connections()) {
+		t.Fatalf("connections differ by fold order:\nfwd=%+v\nrev=%+v", fwd.Connections(), rev.Connections())
+	}
+	strip := func(es []TimelineEntry) []TimelineEntry {
+		out := make([]TimelineEntry, len(es))
+		for i, e := range es {
+			e.Seq = 0 // Seq is an internal insertion-order tiebreak, not part of the observable projection.
+			out[i] = e
+		}
+		return out
+	}
+	if !reflect.DeepEqual(strip(fwd.Timeline()), strip(rev.Timeline())) {
+		t.Fatalf("timeline differs by fold order:\nfwd=%+v\nrev=%+v", strip(fwd.Timeline()), strip(rev.Timeline()))
+	}
+
+	// Sanity: descriptor is the exec image (latest event-time), started-at is the earliest event, and the
+	// connection window spans the two connects — none of which depend on fold order.
+	pe, _ := fwd.Process(pid)
+	if pe.Path != "/usr/bin/curl" || pe.Comm != "curl" || !pe.StartedAt.Equal(base) || !pe.LastSeenAt.Equal(base.Add(2*time.Second)) {
+		t.Fatalf("descriptor/started not event-time resolved: %+v", pe)
+	}
+	c := fwd.Connections()[0]
+	if !c.FirstSeenAt.Equal(base.Add(time.Second)) || !c.LastSeenAt.Equal(base.Add(3*time.Second)) {
+		t.Fatalf("connection window not min/max: [%s,%s]", c.FirstSeenAt, c.LastSeenAt)
+	}
+}

--- a/internal/domain/endpoint/process.go
+++ b/internal/domain/endpoint/process.go
@@ -1,0 +1,85 @@
+package endpoint
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+// ProcessState is the lifecycle state of a projected process entity.
+type ProcessState string
+
+const (
+	// ProcessRunning is the state of a process observed to start (fork/exec) and not yet observed to exit.
+	ProcessRunning ProcessState = "running"
+	// ProcessExited is set once an exit is observed. A1's ProcessObservation carries only exec/fork today,
+	// so this state is reserved for the sensor-side exit-event tail; the projection already models it so
+	// that leg is a data change, not a schema change.
+	ProcessExited ProcessState = "exited"
+	// ProcessUnknown is a process referenced only as a parent (by ParentEntityID) that was never itself
+	// observed — its lineage link is real but its own start was missed (a coverage gap, not a guess).
+	ProcessUnknown ProcessState = "unknown"
+)
+
+// ProcessEntity is a stable, PID-reuse-proof process reconstructed from process telemetry (B1). Its
+// identity is the A1 ProcessEntityID (hash of asset+boot+pid+start-time), so two processes that reused one
+// PID are distinct entities and a reader can build a process tree via ParentEntityID without racing the
+// kernel's PID recycling.
+type ProcessEntity struct {
+	EntityID       shared.ID
+	TenantID       shared.ID
+	AssetID        shared.ID
+	PID            int
+	PPID           int
+	ParentEntityID shared.ID
+	Comm           string
+	Path           string
+	Args           []string
+	ArgsTruncated  bool
+	PathTruncated  bool
+	UID            int
+	Resource       telemetry.ResourceContext
+	// StartedAt is the EARLIEST event time (OccurredAt) observed for this entity — a min, so it is
+	// independent of the order envelopes are folded in. Zero on an unobserved parent stub.
+	StartedAt time.Time
+	// LastSeenAt is the latest event time (OccurredAt) of any observation naming this entity — a max, so
+	// it too is order-independent. Zero on an unobserved parent stub (never directly seen).
+	LastSeenAt time.Time
+	// ExitedAt is set only when an exit is observed (reserved tail); nil while running.
+	ExitedAt *time.Time
+	State    ProcessState
+}
+
+// IsRunning reports whether the process is currently believed to be alive.
+func (p ProcessEntity) IsRunning() bool { return p.State == ProcessRunning }
+
+// Validate enforces a well-formed process entity.
+func (p ProcessEntity) Validate() error {
+	if p.EntityID.IsZero() {
+		return fmt.Errorf("%w: process entity has no entity id", shared.ErrValidation)
+	}
+	if p.AssetID.IsZero() {
+		return fmt.Errorf("%w: process entity has no asset id", shared.ErrValidation)
+	}
+	switch p.State {
+	case ProcessRunning, ProcessExited, ProcessUnknown:
+	default:
+		return fmt.Errorf("%w: process entity has unknown state %q", shared.ErrValidation, p.State)
+	}
+	if p.ExitedAt != nil && p.State != ProcessExited {
+		return fmt.Errorf("%w: process entity has an exit time but state %q", shared.ErrValidation, p.State)
+	}
+	return nil
+}
+
+func (p ProcessEntity) clone() ProcessEntity {
+	c := p
+	c.Args = append([]string(nil), p.Args...)
+	if p.ExitedAt != nil {
+		t := *p.ExitedAt
+		c.ExitedAt = &t
+	}
+	return c
+}

--- a/internal/domain/endpoint/timeline.go
+++ b/internal/domain/endpoint/timeline.go
@@ -1,0 +1,110 @@
+// Package endpoint is Phase B of the security data plane (#594): it turns the raw, per-event telemetry
+// the A-phase data plane delivers (telemetry.TelemetryEnvelope) into queryable ENDPOINT VISIBILITY —
+// stable entities (processes, network connections, …) with lifecycle state, plus a per-asset State
+// Timeline of their transitions. Phase C correlation and retro-hunt read this layer instead of racing
+// over raw PIDs and ingest-ordered events.
+//
+// The whole package is a pure, deterministic projection: it folds already-normalized envelopes into
+// entity state and timeline entries with no I/O and no clock of its own. The kernel/eBPF collection that
+// produces the envelopes is the A-phase sensor tail and lives elsewhere; here we only project what has
+// already been observed, so the logic is fully testable off a Linux host.
+package endpoint
+
+import (
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// EntityKind names the sort of endpoint entity a timeline entry is about. Process and network are
+// projected in B1/B2; file and identity are reserved for B3/B4.
+type EntityKind string
+
+const (
+	EntityProcess  EntityKind = "process"
+	EntityNetwork  EntityKind = "network"
+	EntityFile     EntityKind = "file"
+	EntityIdentity EntityKind = "identity"
+)
+
+// TimelineEntryKind is the specific state transition an entry records.
+type TimelineEntryKind string
+
+const (
+	// Process lifecycle (B1). A fork creates a child; an exec replaces the image of an existing entity.
+	TimelineProcessStart TimelineEntryKind = "process_start"
+	TimelineProcessExec  TimelineEntryKind = "process_exec"
+	// Network (B2): the first time a flow is seen. Re-observing the same flow widens its last-seen time
+	// but is not a new transition, so it does not add a second entry.
+	TimelineNetworkConnect TimelineEntryKind = "network_connect"
+)
+
+// TimelineEntry is one endpoint state transition, ordered by EVENT time (when it happened on the host),
+// never by ingest order. It stays explainable after the raw telemetry that produced it expires because it
+// carries its own summary and the identities it links.
+type TimelineEntry struct {
+	// Seq is the assignment order within one StateTimeline. It is the deterministic tiebreak when two
+	// transitions share an OccurredAt; it is not a host-wide sequence.
+	Seq        uint64
+	OccurredAt time.Time
+	TenantID   shared.ID
+	AssetID    shared.ID
+	EntityKind EntityKind
+	EntityID   shared.ID
+	Kind       TimelineEntryKind
+	// EventID is the source envelope's event id; it is the dedupe key so a replayed envelope never adds
+	// a duplicate transition.
+	EventID shared.ID
+	Summary string
+}
+
+// StateTimeline is a per-asset, event-time-ordered, EventID-deduplicated sequence of transitions (B7).
+// It is the substrate B1–B6 append to and Phase C reads. The zero value is not usable; use
+// newStateTimeline.
+type StateTimeline struct {
+	entries []TimelineEntry
+	seen    map[shared.ID]struct{}
+	nextSeq uint64
+}
+
+func newStateTimeline() *StateTimeline {
+	return &StateTimeline{seen: make(map[shared.ID]struct{})}
+}
+
+// append records a transition unless its EventID is already on the timeline. It returns the stored entry
+// (with its assigned Seq) and whether it was newly appended; a duplicate EventID returns (zero, false)
+// and changes nothing.
+func (t *StateTimeline) append(e TimelineEntry) (TimelineEntry, bool) {
+	if _, dup := t.seen[e.EventID]; dup {
+		return TimelineEntry{}, false
+	}
+	e.Seq = t.nextSeq
+	t.nextSeq++
+	t.seen[e.EventID] = struct{}{}
+	t.entries = append(t.entries, e)
+	return e, true
+}
+
+// has reports whether an EventID has already been recorded on the timeline.
+func (t *StateTimeline) has(eventID shared.ID) bool {
+	_, ok := t.seen[eventID]
+	return ok
+}
+
+// Entries returns a copy of the timeline ordered by event time, with insertion order (Seq) as the
+// deterministic tiebreak for equal timestamps. Callers may mutate the returned slice freely.
+func (t *StateTimeline) Entries() []TimelineEntry {
+	out := make([]TimelineEntry, len(t.entries))
+	copy(out, t.entries)
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].OccurredAt.Equal(out[j].OccurredAt) {
+			return out[i].OccurredAt.Before(out[j].OccurredAt)
+		}
+		return out[i].Seq < out[j].Seq
+	})
+	return out
+}
+
+// Len reports how many transitions the timeline holds.
+func (t *StateTimeline) Len() int { return len(t.entries) }

--- a/internal/domain/endpoint/timeline_test.go
+++ b/internal/domain/endpoint/timeline_test.go
@@ -1,0 +1,69 @@
+package endpoint
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func entry(eventID string, occ time.Time) TimelineEntry {
+	return TimelineEntry{
+		OccurredAt: occ, TenantID: testTenant, AssetID: testAsset,
+		EntityKind: EntityProcess, EntityID: shared.ID("pe_" + eventID),
+		Kind: TimelineProcessExec, EventID: shared.ID(eventID), Summary: eventID,
+	}
+}
+
+func TestTimelineOrdersByEventTimeNotInsertionOrder(t *testing.T) {
+	tl := newStateTimeline()
+	// Append out of event-time order.
+	tl.append(entry("c", base.Add(3*time.Second)))
+	tl.append(entry("a", base.Add(1*time.Second)))
+	tl.append(entry("b", base.Add(2*time.Second)))
+	got := tl.Entries()
+	want := []string{"a", "b", "c"}
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries, got %d", len(got))
+	}
+	for i, w := range want {
+		if string(got[i].EventID) != w {
+			t.Fatalf("position %d: got %s want %s", i, got[i].EventID, w)
+		}
+	}
+}
+
+func TestTimelineDedupesByEventID(t *testing.T) {
+	tl := newStateTimeline()
+	if _, ok := tl.append(entry("a", base)); !ok {
+		t.Fatal("first append must succeed")
+	}
+	if _, ok := tl.append(entry("a", base.Add(time.Hour))); ok {
+		t.Fatal("duplicate EventID must not append again")
+	}
+	if tl.Len() != 1 {
+		t.Fatalf("timeline must hold one entry, got %d", tl.Len())
+	}
+	if !tl.has("a") || tl.has("z") {
+		t.Fatal("has() must reflect recorded event ids")
+	}
+}
+
+func TestTimelineEqualTimestampsKeepInsertionOrder(t *testing.T) {
+	tl := newStateTimeline()
+	// Three entries at the SAME instant: the deterministic tiebreak is insertion order (Seq).
+	tl.append(entry("first", base))
+	tl.append(entry("second", base))
+	tl.append(entry("third", base))
+	got := tl.Entries()
+	want := []string{"first", "second", "third"}
+	for i, w := range want {
+		if string(got[i].EventID) != w {
+			t.Fatalf("equal-timestamp tiebreak broke determinism at %d: got %s want %s", i, got[i].EventID, w)
+		}
+	}
+	// Seq must be assigned in insertion order.
+	if got[0].Seq != 0 || got[1].Seq != 1 || got[2].Seq != 2 {
+		t.Fatalf("seq assignment wrong: %d %d %d", got[0].Seq, got[1].Seq, got[2].Seq)
+	}
+}


### PR DESCRIPTION
## Phase B — endpoint visibility: process/network entities + State Timeline

Opens Phase B of the EDR data-plane epic #594 (split into #663–#669) and lands the **portable core of B1 (process), B2 (network), and the B7 State Timeline** they share. A new pure-domain package `internal/domain/endpoint` projects the already-normalized A1 telemetry envelopes (`telemetry.TelemetryEnvelope`) into queryable **endpoint visibility** — stable entities with lifecycle state + an event-time timeline of their transitions — that Phase C correlation and retro-hunt read instead of racing raw PIDs and ingest-ordered events.

Per the dependency spine (`B needs A1–A5`, all met), and following the A-phase pattern of landing the portable domain core first with the eBPF collection as a deferred sensor tail.

### What's in it
- **B1 `ProcessEntity`** (#663) — stable, PID-reuse-proof process (reuses the A1 `ProcessEntityID`), lifecycle state + parent lineage (`Ancestors`). An unobserved parent becomes an explicit `ProcessUnknown` stub (coverage honesty), promoted when later observed.
- **B2 `NetworkConnection`** (#664) — process-attributed flow with a stable, domain-separated, length-prefixed `ConnectionID`; the entity deduplicates the flow with a min/max seen-window.
- **B7 `StateTimeline`** (#669) — event-time-ordered, EventID-deduplicated log of transitions; the shared substrate B1–B6 append to.

### Correctness properties (what Phase C evidence needs)
`EndpointState.Observe` is **deterministic, reorder-invariant, idempotent by EventID, and fail-closed**:
- descriptor fields resolve **latest-by-event-time**; started/first-seen are the **earliest** event time and last-seen the **latest** — all order-independent, so re-folding the same envelopes in a different order yields byte-identical entities and timeline (proven by `TestFoldIsReorderInvariant`);
- every envelope is `telemetry.Validate()`-checked before folding (no zero-`OccurredAt`, no class/type mismatch reaches the fold);
- timeline summaries are built from the observation, not the accumulated entity, so they too are order-independent.

### Review
Dual-reviewed (go-arch + security). go-arch: mergeable, dependency-rule PASS. security: SHIP, no crit/high; tenant/asset isolation, identity-collision resistance, and determinism confirmed clean. Both raised two MEDIUMs — **reorder-invariance** of entity fields and calling **`env.Validate()`** in `Observe` — **both fixed in this PR** and covered by a new reorder-invariance regression test.

### Verification (CI off — validated locally)
Pure domain, imports only `domain/{detection,shared,telemetry}` + stdlib; `go build`, `go vet`, `gofmt -l` clean; `go test -race` green; 93.8% coverage.

### Scope / follow-ups
eBPF collection, a persistence store, and process-exit/byte-counter enrichment are the deferred sensor tails. **B3–B6 (#665–#668)** and the network-attribution-honesty pass (an explicit "attribution unknown" marker when a flow references an unobserved process — security review L1) follow. #663/#664/#669 stay open for their collection/store tails.
