### PR TITLE
feat(endpoint): Phase B enrichment — file, privilege, container, diff (#665 #666 #667 #668)

### DIFF
--- a/internal/domain/endpoint/container.go
+++ b/internal/domain/endpoint/container.go
@@ -1,0 +1,48 @@
+package endpoint
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ContainerInstance is a runtime container observed on the asset (B5, runtime inventory). It is projected
+// from the ResourceContext every telemetry envelope already carries, so a container is inventoried the
+// moment any event is seen from inside it — no separate collector. Its identity is the A1 ContainerTargetID
+// (containerID + cgroupID + podUID + imageDigest), and the seen window is a min/max so it is
+// order-independent. This is the runtime side that X5 (#634) fuses with installed SBOM for
+// running-vs-installed exposure.
+type ContainerInstance struct {
+	TargetID    shared.ID
+	TenantID    shared.ID
+	AssetID     shared.ID
+	ContainerID string
+	CgroupID    uint64
+	PodUID      string
+	WorkloadUID string
+	Namespace   string
+	ImageDigest string
+	Runtime     string
+	FirstSeenAt time.Time
+	LastSeenAt  time.Time
+	// metaEventID is the EventID that last set the non-identity metadata (Namespace/WorkloadUID/Runtime) —
+	// the tiebreak that keeps them reorder-invariant. Unexported bookkeeping.
+	metaEventID shared.ID
+}
+
+// Validate enforces a well-formed container instance.
+func (c ContainerInstance) Validate() error {
+	if c.TargetID.IsZero() {
+		return fmt.Errorf("%w: container instance has no target id", shared.ErrValidation)
+	}
+	if c.AssetID.IsZero() {
+		return fmt.Errorf("%w: container instance has no asset id", shared.ErrValidation)
+	}
+	if c.ContainerID == "" {
+		return fmt.Errorf("%w: container instance has no container id", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (c ContainerInstance) clone() ContainerInstance { return c }

--- a/internal/domain/endpoint/diff.go
+++ b/internal/domain/endpoint/diff.go
@@ -1,0 +1,146 @@
+package endpoint
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ChangeKind classifies how an entity differs between two endpoint snapshots.
+type ChangeKind string
+
+const (
+	ChangeAdded   ChangeKind = "added"
+	ChangeRemoved ChangeKind = "removed"
+	ChangeChanged ChangeKind = "changed"
+)
+
+// EntityChange is one typed change between two snapshots.
+type EntityChange struct {
+	EntityKind EntityKind
+	EntityID   shared.ID
+	Change     ChangeKind
+}
+
+// EndpointDiff is the deterministic set of changes between two endpoint-state snapshots (B6). It powers
+// change detection for the State Timeline and retro-hunt ("what appeared/changed/disappeared between t1
+// and t2"). "changed" compares only MATERIAL fields, never the seen-window timestamps (which move on every
+// re-observation), so it reports real state changes, not activity.
+type EndpointDiff struct {
+	Changes []EntityChange
+}
+
+// Diff computes the changes from the before snapshot to the after snapshot. A nil side is treated as an
+// empty snapshot (so Diff(nil, after) reports every entity as added), keeping the function total. The
+// result is deterministically ordered by (kind, entity id, change).
+func Diff(before, after *EndpointState) EndpointDiff {
+	var changes []EntityChange
+	changes = append(changes, diffProcesses(before, after)...)
+	changes = append(changes, diffConnections(before, after)...)
+	changes = append(changes, diffFiles(before, after)...)
+	changes = append(changes, diffContainers(before, after)...)
+	sort.Slice(changes, func(i, j int) bool {
+		if changes[i].EntityKind != changes[j].EntityKind {
+			return changes[i].EntityKind < changes[j].EntityKind
+		}
+		if changes[i].EntityID != changes[j].EntityID {
+			return changes[i].EntityID < changes[j].EntityID
+		}
+		return changes[i].Change < changes[j].Change
+	})
+	return EndpointDiff{Changes: changes}
+}
+
+// snapshotOf returns the four entity slices of a snapshot, or empty slices for a nil snapshot.
+func processesOf(s *EndpointState) []ProcessEntity {
+	if s == nil {
+		return nil
+	}
+	return s.Processes()
+}
+
+func connectionsOf(s *EndpointState) []NetworkConnection {
+	if s == nil {
+		return nil
+	}
+	return s.Connections()
+}
+
+func filesOf(s *EndpointState) []FileTarget {
+	if s == nil {
+		return nil
+	}
+	return s.Files()
+}
+
+func containersOf(s *EndpointState) []ContainerInstance {
+	if s == nil {
+		return nil
+	}
+	return s.Containers()
+}
+
+func diffProcesses(before, after *EndpointState) []EntityChange {
+	return diffSet(EntityProcess, processesOf(before), processesOf(after),
+		func(p ProcessEntity) shared.ID { return p.EntityID },
+		func(a, b ProcessEntity) bool {
+			return a.State == b.State && a.Path == b.Path && a.Comm == b.Comm &&
+				a.UID == b.UID && a.PPID == b.PPID && a.ParentEntityID == b.ParentEntityID &&
+				strings.Join(a.Args, "\x00") == strings.Join(b.Args, "\x00")
+		})
+}
+
+func diffConnections(before, after *EndpointState) []EntityChange {
+	// A connection's identity (process + proto + direction + 5-tuple) is its whole material state, so a
+	// flow only ever appears or disappears; it never "changes" in place.
+	return diffSet(EntityNetwork, connectionsOf(before), connectionsOf(after),
+		func(c NetworkConnection) shared.ID { return c.ConnectionID },
+		func(a, b NetworkConnection) bool { return true })
+}
+
+func diffFiles(before, after *EndpointState) []EntityChange {
+	return diffSet(EntityFile, filesOf(before), filesOf(after),
+		func(f FileTarget) shared.ID { return f.TargetID },
+		func(a, b FileTarget) bool {
+			return a.LastOp == b.LastOp && a.LastProcessEntityID == b.LastProcessEntityID
+		})
+}
+
+func diffContainers(before, after *EndpointState) []EntityChange {
+	// A container's identity is fixed; its material state for diffing is its non-identity metadata.
+	return diffSet(EntityContainer, containersOf(before), containersOf(after),
+		func(c ContainerInstance) shared.ID { return c.TargetID },
+		func(a, b ContainerInstance) bool {
+			return a.Namespace == b.Namespace && a.WorkloadUID == b.WorkloadUID && a.Runtime == b.Runtime
+		})
+}
+
+// diffSet computes added/removed/changed between two entity slices keyed by id.
+func diffSet[T any](kind EntityKind, before, after []T, id func(T) shared.ID, materialEqual func(a, b T) bool) []EntityChange {
+	beforeByID := make(map[shared.ID]T, len(before))
+	for _, e := range before {
+		beforeByID[id(e)] = e
+	}
+	afterByID := make(map[shared.ID]T, len(after))
+	for _, e := range after {
+		afterByID[id(e)] = e
+	}
+	var out []EntityChange
+	for k, av := range afterByID {
+		bv, ok := beforeByID[k]
+		if !ok {
+			out = append(out, EntityChange{EntityKind: kind, EntityID: k, Change: ChangeAdded})
+			continue
+		}
+		if !materialEqual(bv, av) {
+			out = append(out, EntityChange{EntityKind: kind, EntityID: k, Change: ChangeChanged})
+		}
+	}
+	for k := range beforeByID {
+		if _, ok := afterByID[k]; !ok {
+			out = append(out, EntityChange{EntityKind: kind, EntityID: k, Change: ChangeRemoved})
+		}
+	}
+	return out
+}

--- a/internal/domain/endpoint/diff_test.go
+++ b/internal/domain/endpoint/diff_test.go
@@ -1,0 +1,110 @@
+package endpoint
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+func hasChange(d EndpointDiff, kind EntityKind, id shared.ID, ck ChangeKind) bool {
+	for _, c := range d.Changes {
+		if c.EntityKind == kind && c.EntityID == id && c.Change == ck {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDiffDetectsAddedRemovedChangedAcrossKinds(t *testing.T) {
+	before := mustState(t)
+	after := mustState(t)
+	pA, pB, pC := procEntityID(1, 1), procEntityID(2, 1), procEntityID(3, 1)
+	proc := pA
+
+	// before: process A (/a), B (/b); a flow; a file; a container.
+	mustObserve(t, before, procEnv("e1", base, pA, "", 1, 0, "exec", "a", "/a"))
+	mustObserve(t, before, procEnv("e2", base, pB, "", 2, 0, "exec", "b", "/b"))
+	mustObserve(t, before, netEnv("n1", base, proc, "tcp", "egress", "10.0.0.1", 1000, "1.2.3.4", 443))
+	mustObserve(t, before, fileEnv("fl1", base, proc, "open", "/x", 1, 2, ""))
+	mustObserve(t, before, procEnvRC("rc1", base, procEntityID(9, 1), 9, telemetry.ResourceContext{ContainerID: "c1", ImageDigest: "img1"}))
+
+	// after: process A image changed (/a2), C added (B removed); same flow; same file gains a write op; a
+	// different container.
+	mustObserve(t, after, procEnv("e3", base.Add(time.Second), pA, "", 1, 0, "exec", "a", "/a2"))
+	mustObserve(t, after, procEnv("e4", base, pC, "", 3, 0, "exec", "c", "/c"))
+	mustObserve(t, after, netEnv("n2", base, proc, "tcp", "egress", "10.0.0.1", 1000, "1.2.3.4", 443))
+	mustObserve(t, after, fileEnv("fl2", base, proc, "write", "/x", 1, 2, ""))
+	mustObserve(t, after, procEnvRC("rc2", base, procEntityID(9, 1), 9, telemetry.ResourceContext{ContainerID: "c2", ImageDigest: "img2"}))
+
+	d := Diff(before, after)
+	connID := ConnectionID(testAsset, proc, "tcp", "egress", "10.0.0.1", 1000, "1.2.3.4", 443)
+	fileID := telemetry.FileTargetID("/x", 1, 2, "")
+	c1 := telemetry.ContainerTargetID("c1", 0, "", "img1")
+	c2 := telemetry.ContainerTargetID("c2", 0, "", "img2")
+
+	want := []struct {
+		kind EntityKind
+		id   shared.ID
+		ck   ChangeKind
+	}{
+		{EntityProcess, pA, ChangeChanged},  // image /a -> /a2
+		{EntityProcess, pB, ChangeRemoved},  // gone in after
+		{EntityProcess, pC, ChangeAdded},    // new in after
+		{EntityFile, fileID, ChangeChanged}, // op open -> write
+		{EntityContainer, c1, ChangeRemoved},
+		{EntityContainer, c2, ChangeAdded},
+	}
+	for _, w := range want {
+		if !hasChange(d, w.kind, w.id, w.ck) {
+			t.Fatalf("missing change %s %s %s in %+v", w.kind, w.id, w.ck, d.Changes)
+		}
+	}
+	// The flow is unchanged (same tuple) and must NOT appear.
+	if hasChange(d, EntityNetwork, connID, ChangeChanged) {
+		t.Fatal("an unchanged flow must not be reported as changed")
+	}
+	if len(d.Changes) != len(want) {
+		t.Fatalf("unexpected extra changes: got %d want %d: %+v", len(d.Changes), len(want), d.Changes)
+	}
+}
+
+func TestDiffIgnoresSeenWindowMovement(t *testing.T) {
+	before := mustState(t)
+	after := mustState(t)
+	p := procEntityID(1, 1)
+	// Same material descriptors, different event times (so StartedAt/LastSeenAt differ).
+	mustObserve(t, before, procEnv("e1", base, p, "", 1, 0, "exec", "a", "/a"))
+	mustObserve(t, after, procEnv("e2", base.Add(time.Hour), p, "", 1, 0, "exec", "a", "/a"))
+	if d := Diff(before, after); len(d.Changes) != 0 {
+		t.Fatalf("a moved seen-window is not a material change: %+v", d.Changes)
+	}
+}
+
+func TestDiffOfIdenticalIsEmptyAndDeterministicallyOrdered(t *testing.T) {
+	build := func() *EndpointState {
+		s := mustState(t)
+		mustObserve(t, s, procEnv("e1", base, procEntityID(2, 1), "", 2, 0, "exec", "b", "/b"))
+		mustObserve(t, s, procEnv("e2", base, procEntityID(1, 1), "", 1, 0, "exec", "a", "/a"))
+		return s
+	}
+	if d := Diff(build(), build()); len(d.Changes) != 0 {
+		t.Fatalf("identical snapshots must diff empty, got %+v", d.Changes)
+	}
+	// From empty: two additions, ordered by entity id.
+	d := Diff(mustState(t), build())
+	if len(d.Changes) != 2 {
+		t.Fatalf("two additions expected, got %+v", d.Changes)
+	}
+	if !(d.Changes[0].EntityID < d.Changes[1].EntityID) {
+		t.Fatalf("changes must be deterministically ordered by id: %+v", d.Changes)
+	}
+}
+
+func mustObserve(t *testing.T, s *EndpointState, env telemetry.TelemetryEnvelope) {
+	t.Helper()
+	if _, err := s.Observe(env); err != nil {
+		t.Fatalf("observe %s: %v", env.EventID, err)
+	}
+}

--- a/internal/domain/endpoint/endpoint.go
+++ b/internal/domain/endpoint/endpoint.go
@@ -3,6 +3,7 @@ package endpoint
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -13,16 +14,20 @@ import (
 const maxAncestorWalk = 256
 
 // EndpointState is the projected endpoint-visibility state for ONE (tenant, asset): its process entities
-// (B1), network connections (B2), and the State Timeline (B7) of their transitions. It is built by
-// folding telemetry envelopes with Observe and is a pure, deterministic aggregate — no I/O, no clock.
-// The zero value is not usable; construct it with NewEndpointState.
+// (B1), network connections (B2), file targets (B3), privilege transitions (B4), container instances (B5),
+// and the State Timeline (B7) of their transitions. It is built by folding telemetry envelopes with
+// Observe and is a pure, deterministic aggregate — no I/O, no clock. The zero value is not usable;
+// construct it with NewEndpointState.
 type EndpointState struct {
-	tenantID  shared.ID
-	assetID   shared.ID
-	processes map[shared.ID]*ProcessEntity
-	conns     map[shared.ID]*NetworkConnection
-	timeline  *StateTimeline
-	processed map[shared.ID]struct{}
+	tenantID   shared.ID
+	assetID    shared.ID
+	processes  map[shared.ID]*ProcessEntity
+	conns      map[shared.ID]*NetworkConnection
+	files      map[shared.ID]*FileTarget
+	containers map[shared.ID]*ContainerInstance
+	privileges []PrivilegeTransition
+	timeline   *StateTimeline
+	processed  map[shared.ID]struct{}
 }
 
 // NewEndpointState creates the projection for one asset. Both ids are required — endpoint visibility is
@@ -35,12 +40,14 @@ func NewEndpointState(tenantID, assetID shared.ID) (*EndpointState, error) {
 		return nil, fmt.Errorf("%w: endpoint state requires an asset id", shared.ErrValidation)
 	}
 	return &EndpointState{
-		tenantID:  tenantID,
-		assetID:   assetID,
-		processes: make(map[shared.ID]*ProcessEntity),
-		conns:     make(map[shared.ID]*NetworkConnection),
-		timeline:  newStateTimeline(),
-		processed: make(map[shared.ID]struct{}),
+		tenantID:   tenantID,
+		assetID:    assetID,
+		processes:  make(map[shared.ID]*ProcessEntity),
+		conns:      make(map[shared.ID]*NetworkConnection),
+		files:      make(map[shared.ID]*FileTarget),
+		containers: make(map[shared.ID]*ContainerInstance),
+		timeline:   newStateTimeline(),
+		processed:  make(map[shared.ID]struct{}),
 	}, nil
 }
 
@@ -53,8 +60,8 @@ func NewEndpointState(tenantID, assetID shared.ID) (*EndpointState, error) {
 //   - fail-closed — the envelope is fully validated (telemetry.Validate) and a wrong-asset envelope is
 //     rejected, never silently folded.
 //
-// Only process (B1) and network (B2) classes are projected here; file/privilege envelopes are accepted
-// (already validated) and marked processed but produce no state yet (B3/B4).
+// All four telemetry classes are projected: process (B1), network (B2), file (B3), privilege (B4); and
+// every event, whatever its class, feeds the runtime container inventory (B5) from its ResourceContext.
 func (s *EndpointState) Observe(env telemetry.TelemetryEnvelope) ([]TimelineEntry, error) {
 	if err := env.Validate(); err != nil {
 		return nil, fmt.Errorf("endpoint: reject malformed telemetry envelope: %w", err)
@@ -72,10 +79,15 @@ func (s *EndpointState) Observe(env telemetry.TelemetryEnvelope) ([]TimelineEntr
 		entries = s.applyProcess(env)
 	case detection.ClassNetwork:
 		entries = s.applyNetwork(env)
-	default:
-		// File/privilege and any future class are valid telemetry but not projected in B1/B2; accept and
-		// mark processed so a later B3/B4 fold in a fresh state can own them.
+	case detection.ClassFile:
+		entries = s.applyFile(env)
+	case detection.ClassPrivilege:
+		entries = s.applyPrivilege(env)
 	}
+	// Runtime container inventory (B5) is cross-cutting: any event observed from inside a container
+	// inventories it, regardless of the event's class. Inventory only — container presence is not a
+	// timeline transition (start/stop events are a sensor tail A1 does not carry yet).
+	s.observeContainer(env)
 	s.processed[env.EventID] = struct{}{}
 	return entries, nil
 }
@@ -100,16 +112,17 @@ func (s *EndpointState) applyProcess(env telemetry.TelemetryEnvelope) []Timeline
 	}
 
 	// Descriptor fields are resolved by EVENT time: an observation only overwrites them when it is the
-	// latest one seen for this entity (its OccurredAt is not before the current last-seen). This makes the
-	// projection invariant to the order envelopes are folded in — an out-of-order older envelope never
-	// clobbers newer descriptors. An exec replaces the image.
-	descriptorIsLatest := !existed || !env.OccurredAt.Before(pe.LastSeenAt)
+	// latest one seen for this entity, with EventID breaking an exact-timestamp tie. This makes the
+	// projection invariant to the order envelopes are folded in — an out-of-order (or same-instant, lower
+	// EventID) envelope never clobbers newer descriptors. An exec replaces the image.
+	descriptorIsLatest := !existed || laterEvent(env.OccurredAt, env.EventID, pe.LastSeenAt, pe.descEventID)
 	if descriptorIsLatest {
 		pe.PID = obs.PID
 		pe.PPID = obs.PPID
 		pe.ParentEntityID = obs.ParentEntityID
 		pe.UID = obs.UID
 		pe.Resource = env.ResourceContext
+		pe.descEventID = env.EventID
 		if obs.Comm != "" {
 			pe.Comm = obs.Comm
 		}
@@ -285,6 +298,19 @@ func (s *EndpointState) Ancestors(id shared.ID) []ProcessEntity {
 		cur = parent
 	}
 	return out
+}
+
+// laterEvent reports whether the event (occ, eventID) is strictly later than a reference event by event
+// time, with EventID as the deterministic tiebreak for an identical timestamp. It is the single rule the
+// folds use to resolve "latest wins" descriptor fields so the outcome never depends on fold order.
+func laterEvent(occ time.Time, eventID shared.ID, refOcc time.Time, refEventID shared.ID) bool {
+	if occ.After(refOcc) {
+		return true
+	}
+	if occ.Equal(refOcc) {
+		return eventID > refEventID
+	}
+	return false
 }
 
 // processObsSummary / connectionObsSummary build a timeline entry's human summary from the OBSERVATION,

--- a/internal/domain/endpoint/endpoint_test.go
+++ b/internal/domain/endpoint/endpoint_test.go
@@ -120,27 +120,6 @@ func TestObserveIsIdempotentByEventID(t *testing.T) {
 	}
 }
 
-func TestObserveIgnoresUnprojectedClasses(t *testing.T) {
-	s := mustState(t)
-	env := telemetry.TelemetryEnvelope{
-		SchemaVersion: telemetry.SchemaVersion,
-		EventID:       "f1", EventType: "file.open", EventClass: detection.ClassFile,
-		AgentID: testAgent, AssetID: testAsset, BootID: testBoot, OccurredAt: base, ObservedAt: base,
-		Event: telemetry.TelemetryEvent{Class: detection.ClassFile, File: &telemetry.FileObservation{Op: "open", Path: "/etc/passwd"}},
-	}
-	entries, err := s.Observe(env)
-	if err != nil {
-		t.Fatalf("file class must be accepted (not projected), got %v", err)
-	}
-	if len(entries) != 0 || s.timeline.Len() != 0 {
-		t.Fatalf("file class must produce no state in B1/B2")
-	}
-	// It is still marked processed, so a re-apply is a clean no-op.
-	if _, done := s.processed["f1"]; !done {
-		t.Fatal("unprojected event should still be marked processed")
-	}
-}
-
 // --- B1 process ---
 
 func TestForkThenExecTransitionsOneEntity(t *testing.T) {
@@ -339,16 +318,9 @@ func TestFoldIsReorderInvariant(t *testing.T) {
 	if !reflect.DeepEqual(fwd.Connections(), rev.Connections()) {
 		t.Fatalf("connections differ by fold order:\nfwd=%+v\nrev=%+v", fwd.Connections(), rev.Connections())
 	}
-	strip := func(es []TimelineEntry) []TimelineEntry {
-		out := make([]TimelineEntry, len(es))
-		for i, e := range es {
-			e.Seq = 0 // Seq is an internal insertion-order tiebreak, not part of the observable projection.
-			out[i] = e
-		}
-		return out
-	}
-	if !reflect.DeepEqual(strip(fwd.Timeline()), strip(rev.Timeline())) {
-		t.Fatalf("timeline differs by fold order:\nfwd=%+v\nrev=%+v", strip(fwd.Timeline()), strip(rev.Timeline()))
+	// The timeline is byte-identical (no insertion-order field remains); EventID is the tiebreak.
+	if !reflect.DeepEqual(fwd.Timeline(), rev.Timeline()) {
+		t.Fatalf("timeline differs by fold order:\nfwd=%+v\nrev=%+v", fwd.Timeline(), rev.Timeline())
 	}
 
 	// Sanity: descriptor is the exec image (latest event-time), started-at is the earliest event, and the

--- a/internal/domain/endpoint/file_target.go
+++ b/internal/domain/endpoint/file_target.go
@@ -1,0 +1,59 @@
+package endpoint
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// FileTarget is a stable file object reconstructed from file telemetry (B3, File Integrity Monitoring).
+// Its identity is the A1 FileTargetID (path + device + inode + optional content hash), so a rebindable
+// path (rename/symlink/bind-mount) does not alias two distinct objects, and the concrete object is tracked
+// across accesses. The last operation and content hash are resolved latest-by-event-time; the seen window
+// is a min/max, so the projection is order-independent.
+type FileTarget struct {
+	TargetID            shared.ID
+	TenantID            shared.ID
+	AssetID             shared.ID
+	Path                string
+	Device              uint64
+	Inode               uint64
+	ContentHash         string
+	PathTruncated       bool
+	LastOp              string
+	LastProcessEntityID shared.ID
+	FirstSeenAt         time.Time
+	LastSeenAt          time.Time
+	// lastOpEventID is the EventID of the access that last set LastOp/LastProcessEntityID — the tiebreak
+	// that keeps them reorder-invariant across same-instant accesses of one target. Unexported bookkeeping.
+	lastOpEventID shared.ID
+}
+
+// Validate enforces a well-formed file target.
+func (f FileTarget) Validate() error {
+	if f.TargetID.IsZero() {
+		return fmt.Errorf("%w: file target has no target id", shared.ErrValidation)
+	}
+	if f.AssetID.IsZero() {
+		return fmt.Errorf("%w: file target has no asset id", shared.ErrValidation)
+	}
+	if f.Path == "" {
+		return fmt.Errorf("%w: file target has no path", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (f FileTarget) clone() FileTarget { return f }
+
+// fileTimelineKind maps a file op to its timeline transition kind.
+func fileTimelineKind(op string) TimelineEntryKind {
+	switch op {
+	case "write":
+		return TimelineFileWrite
+	case "rename":
+		return TimelineFileRename
+	default:
+		return TimelineFileOpen
+	}
+}

--- a/internal/domain/endpoint/fold_b3b5.go
+++ b/internal/domain/endpoint/fold_b3b5.go
@@ -1,0 +1,198 @@
+package endpoint
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+// applyFile folds a validated file envelope into a FileTarget (B3). env is already telemetry-validated by
+// Observe. The target identity (path+device+inode+contentHash via A1 FileTargetID) is fixed per entity, so
+// only the last op and accessing process vary across observations of the same target — both resolved
+// latest-by-event-time; the seen window is a min/max. One timeline entry per file access event.
+func (s *EndpointState) applyFile(env telemetry.TelemetryEnvelope) []TimelineEntry {
+	obs := env.Event.File
+	id := obs.TargetID()
+
+	ft, existed := s.files[id]
+	if !existed {
+		ft = &FileTarget{
+			TargetID:      id,
+			TenantID:      s.tenantID,
+			AssetID:       s.assetID,
+			Path:          obs.Path,
+			Device:        obs.Device,
+			Inode:         obs.Inode,
+			ContentHash:   obs.ContentHash,
+			PathTruncated: obs.PathTruncated,
+			FirstSeenAt:   env.OccurredAt,
+			LastSeenAt:    env.OccurredAt,
+		}
+		s.files[id] = ft
+	}
+	if !existed || laterEvent(env.OccurredAt, env.EventID, ft.LastSeenAt, ft.lastOpEventID) {
+		ft.LastOp = obs.Op
+		ft.LastProcessEntityID = obs.ProcessEntityID
+		ft.lastOpEventID = env.EventID
+	}
+	if env.OccurredAt.Before(ft.FirstSeenAt) {
+		ft.FirstSeenAt = env.OccurredAt
+	}
+	if env.OccurredAt.After(ft.LastSeenAt) {
+		ft.LastSeenAt = env.OccurredAt
+	}
+
+	entry, appended := s.timeline.append(TimelineEntry{
+		OccurredAt: env.OccurredAt,
+		TenantID:   s.tenantID,
+		AssetID:    s.assetID,
+		EntityKind: EntityFile,
+		EntityID:   id,
+		Kind:       fileTimelineKind(obs.Op),
+		EventID:    env.EventID,
+		Summary:    fileObsSummary(obs),
+	})
+	if !appended {
+		return nil
+	}
+	return []TimelineEntry{entry}
+}
+
+// applyPrivilege folds a validated privilege envelope (B4). env is already telemetry-validated by Observe.
+// It records the transition as a first-class, immutable record (Observe's dedup guarantees one per event)
+// attributed to the acting process entity, and emits a timeline entry. Every privilege transition is
+// recorded — they are never-sampled upstream (A0.6), so an escalation always surfaces. It deliberately
+// does NOT mutate the process entity: a transition can be folded before the process it names is observed,
+// so mutating the entity here would make the projection fold-order-dependent. The per-process identity
+// view is the set of transitions filtered by ProcessEntityID (or the EntityIdentity timeline entries).
+func (s *EndpointState) applyPrivilege(env telemetry.TelemetryEnvelope) []TimelineEntry {
+	obs := env.Event.Privilege
+
+	s.privileges = append(s.privileges, PrivilegeTransition{
+		EventID:         env.EventID,
+		TenantID:        s.tenantID,
+		AssetID:         s.assetID,
+		ProcessEntityID: obs.ProcessEntityID,
+		Kind:            obs.Kind,
+		FromUID:         obs.FromUID,
+		ToUID:           obs.ToUID,
+		Cap:             obs.Cap,
+		Escalation:      isPrivilegeEscalation(obs),
+		OccurredAt:      env.OccurredAt,
+	})
+
+	entry, appended := s.timeline.append(TimelineEntry{
+		OccurredAt: env.OccurredAt,
+		TenantID:   s.tenantID,
+		AssetID:    s.assetID,
+		EntityKind: EntityIdentity,
+		EntityID:   obs.ProcessEntityID,
+		Kind:       TimelinePrivilegeChange,
+		EventID:    env.EventID,
+		Summary:    privilegeSummary(obs),
+	})
+	if !appended {
+		return nil
+	}
+	return []TimelineEntry{entry}
+}
+
+// observeContainer inventories the container an event came from (B5), from the envelope's ResourceContext.
+// It only maintains the inventory (identity via A1 ContainerTargetID; a min/max seen window that is
+// order-independent) and emits no timeline entry — container presence is not a transition, and every event
+// carries a container context, so a per-event entry would be pure noise.
+func (s *EndpointState) observeContainer(env telemetry.TelemetryEnvelope) {
+	rc := env.ResourceContext
+	if rc.ContainerID == "" {
+		return
+	}
+	// containerID, cgroupID, podUID, and imageDigest are all part of ContainerTargetID, so they are fixed
+	// per identity. Only Namespace/WorkloadUID/Runtime are non-identity metadata and must be resolved
+	// latest-by-event-time (with an EventID tiebreak) so the inventory does not depend on fold order.
+	id := telemetry.ContainerTargetID(rc.ContainerID, rc.CgroupID, rc.PodUID, rc.ImageDigest)
+	c, existed := s.containers[id]
+	if !existed {
+		c = &ContainerInstance{
+			TargetID:    id,
+			TenantID:    s.tenantID,
+			AssetID:     s.assetID,
+			ContainerID: rc.ContainerID,
+			CgroupID:    rc.CgroupID,
+			PodUID:      rc.PodUID,
+			ImageDigest: rc.ImageDigest,
+			FirstSeenAt: env.OccurredAt,
+			LastSeenAt:  env.OccurredAt,
+		}
+		s.containers[id] = c
+	}
+	if !existed || laterEvent(env.OccurredAt, env.EventID, c.LastSeenAt, c.metaEventID) {
+		c.Namespace = rc.Namespace
+		c.WorkloadUID = rc.WorkloadUID
+		c.Runtime = rc.Runtime
+		c.metaEventID = env.EventID
+	}
+	if env.OccurredAt.Before(c.FirstSeenAt) {
+		c.FirstSeenAt = env.OccurredAt
+	}
+	if env.OccurredAt.After(c.LastSeenAt) {
+		c.LastSeenAt = env.OccurredAt
+	}
+}
+
+func fileObsSummary(obs *telemetry.FileObservation) string {
+	return fmt.Sprintf("%s %s", obs.Op, obs.Path)
+}
+
+// File returns a copy of one file target by id.
+func (s *EndpointState) File(id shared.ID) (FileTarget, bool) {
+	ft, ok := s.files[id]
+	if !ok {
+		return FileTarget{}, false
+	}
+	return ft.clone(), true
+}
+
+// Files returns a copy of all file targets, ordered by target id for a stable result.
+func (s *EndpointState) Files() []FileTarget {
+	out := make([]FileTarget, 0, len(s.files))
+	for _, ft := range s.files {
+		out = append(out, ft.clone())
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TargetID < out[j].TargetID })
+	return out
+}
+
+// Container returns a copy of one container instance by id.
+func (s *EndpointState) Container(id shared.ID) (ContainerInstance, bool) {
+	c, ok := s.containers[id]
+	if !ok {
+		return ContainerInstance{}, false
+	}
+	return c.clone(), true
+}
+
+// Containers returns a copy of all container instances, ordered by target id for a stable result.
+func (s *EndpointState) Containers() []ContainerInstance {
+	out := make([]ContainerInstance, 0, len(s.containers))
+	for _, c := range s.containers {
+		out = append(out, c.clone())
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TargetID < out[j].TargetID })
+	return out
+}
+
+// PrivilegeTransitions returns a copy of all privilege transitions, ordered by event time then event id
+// for a stable, order-independent result.
+func (s *EndpointState) PrivilegeTransitions() []PrivilegeTransition {
+	out := make([]PrivilegeTransition, len(s.privileges))
+	copy(out, s.privileges)
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].OccurredAt.Equal(out[j].OccurredAt) {
+			return out[i].OccurredAt.Before(out[j].OccurredAt)
+		}
+		return out[i].EventID < out[j].EventID
+	})
+	return out
+}

--- a/internal/domain/endpoint/fold_b3b5_test.go
+++ b/internal/domain/endpoint/fold_b3b5_test.go
@@ -1,0 +1,324 @@
+package endpoint
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+func fileEnv(eventID string, occ time.Time, proc shared.ID, op, path string, device, inode uint64, hash string) telemetry.TelemetryEnvelope {
+	return telemetry.TelemetryEnvelope{
+		SchemaVersion: telemetry.SchemaVersion,
+		EventID:       shared.ID(eventID),
+		EventType:     "file." + op,
+		EventClass:    detection.ClassFile,
+		AgentID:       testAgent, AssetID: testAsset, BootID: testBoot,
+		OccurredAt: occ, ObservedAt: occ,
+		Event: telemetry.TelemetryEvent{Class: detection.ClassFile, File: &telemetry.FileObservation{
+			Op: op, Path: path, Device: device, Inode: inode, ContentHash: hash, ProcessEntityID: proc, Comm: "app",
+		}},
+	}
+}
+
+func privEnv(eventID string, occ time.Time, proc shared.ID, kind string, fromUID, toUID int, capName string) telemetry.TelemetryEnvelope {
+	return telemetry.TelemetryEnvelope{
+		SchemaVersion: telemetry.SchemaVersion,
+		EventID:       shared.ID(eventID),
+		EventType:     "privilege." + kind,
+		EventClass:    detection.ClassPrivilege,
+		AgentID:       testAgent, AssetID: testAsset, BootID: testBoot,
+		OccurredAt: occ, ObservedAt: occ,
+		Event: telemetry.TelemetryEvent{Class: detection.ClassPrivilege, Privilege: &telemetry.PrivilegeObservation{
+			Kind: kind, PID: 1, ProcessEntityID: proc, FromUID: fromUID, ToUID: toUID, Cap: capName, Comm: "app",
+		}},
+	}
+}
+
+// --- B3 file ---
+
+func TestFileTargetTracksLatestOpAndLogsEachAccess(t *testing.T) {
+	s := mustState(t)
+	proc := procEntityID(10, 1)
+	if _, err := s.Observe(fileEnv("f1", base, proc, "open", "/etc/passwd", 1, 2, "")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Observe(fileEnv("f2", base.Add(time.Second), proc, "write", "/etc/passwd", 1, 2, "")); err != nil {
+		t.Fatal(err)
+	}
+	files := s.Files()
+	if len(files) != 1 {
+		t.Fatalf("same path/device/inode/hash must be one target, got %d", len(files))
+	}
+	if files[0].LastOp != "write" || files[0].LastProcessEntityID != proc {
+		t.Fatalf("latest op/process not tracked: %+v", files[0])
+	}
+	if !files[0].FirstSeenAt.Equal(base) || !files[0].LastSeenAt.Equal(base.Add(time.Second)) {
+		t.Fatalf("seen window wrong: [%s,%s]", files[0].FirstSeenAt, files[0].LastSeenAt)
+	}
+	if got := len(s.Timeline()); got != 2 {
+		t.Fatalf("each file access is a timeline entry, got %d", got)
+	}
+}
+
+func TestFileDifferentContentHashIsDistinctTarget(t *testing.T) {
+	s := mustState(t)
+	proc := procEntityID(10, 1)
+	// Content hash is part of the A1 file-target identity, so a modified file is a distinct version.
+	if _, err := s.Observe(fileEnv("f1", base, proc, "write", "/a", 1, 2, "hashA")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Observe(fileEnv("f2", base.Add(time.Second), proc, "write", "/a", 1, 2, "hashB")); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(s.Files()); got != 2 {
+		t.Fatalf("distinct content hashes must be distinct targets, got %d", got)
+	}
+}
+
+// --- B4 privilege ---
+
+func TestPrivilegeTransitionRecordedAndAttributedToProcess(t *testing.T) {
+	s := mustState(t)
+	proc := procEntityID(50, 1)
+	if _, err := s.Observe(procEnv("e1", base, proc, "", 50, 1, "exec", "sudo", "/usr/bin/sudo")); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := s.Observe(privEnv("p1", base.Add(time.Second), proc, "setuid", 1000, 0, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Kind != TimelinePrivilegeChange || entries[0].EntityKind != EntityIdentity || entries[0].EntityID != proc {
+		t.Fatalf("privilege transition must emit an identity timeline entry attributed to the process, got %+v", entries)
+	}
+	trans := s.PrivilegeTransitions()
+	if len(trans) != 1 || trans[0].ToUID != 0 || trans[0].Kind != "setuid" || trans[0].ProcessEntityID != proc {
+		t.Fatalf("transition not recorded/attributed: %+v", trans)
+	}
+	// A transition folded before its process is still recorded and attributed (order-independent).
+	orphanProc := procEntityID(99, 1)
+	if _, err := s.Observe(privEnv("p2", base.Add(2*time.Second), orphanProc, "capset", 0, 0, "CAP_NET_ADMIN")); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.PrivilegeTransitions()) != 2 {
+		t.Fatal("a transition for an unobserved process must still be recorded")
+	}
+	if !isPrivilegeEscalation(privEnv("x", base, proc, "setuid", 1000, 0, "").Event.Privilege) {
+		t.Fatal("uid 1000->0 must be flagged an escalation")
+	}
+}
+
+func TestPrivilegeCapsetRequiresCapAndRecords(t *testing.T) {
+	s := mustState(t)
+	proc := procEntityID(51, 1)
+	if _, err := s.Observe(privEnv("p1", base, proc, "capset", 0, 0, "CAP_SYS_ADMIN")); err != nil {
+		t.Fatal(err)
+	}
+	trans := s.PrivilegeTransitions()
+	if len(trans) != 1 || trans[0].Cap != "CAP_SYS_ADMIN" {
+		t.Fatalf("capset not recorded: %+v", trans)
+	}
+	// A capset with no capability is rejected by telemetry validation (fail-closed).
+	if _, err := s.Observe(privEnv("p2", base.Add(time.Second), proc, "capset", 0, 0, "")); err == nil {
+		t.Fatal("capset with no capability must be rejected")
+	}
+}
+
+// --- B5 container inventory ---
+
+func procEnvRC(eventID string, occ time.Time, entityID shared.ID, pid int, rc telemetry.ResourceContext) telemetry.TelemetryEnvelope {
+	e := procEnv(eventID, occ, entityID, "", pid, 1, "exec", "app", "/app")
+	e.ResourceContext = rc
+	return e
+}
+
+func TestContainerInventoriedFromResourceContext(t *testing.T) {
+	s := mustState(t)
+	rc := telemetry.ResourceContext{ContainerID: "c1", CgroupID: 42, PodUID: "pod1", ImageDigest: "sha256:abc", Namespace: "prod", Runtime: "containerd"}
+	if _, err := s.Observe(procEnvRC("e1", base, procEntityID(1, 1), 1, rc)); err != nil {
+		t.Fatal(err)
+	}
+	// A second event from the same container at a later time widens the window, no duplicate.
+	if _, err := s.Observe(procEnvRC("e2", base.Add(time.Minute), procEntityID(2, 1), 2, rc)); err != nil {
+		t.Fatal(err)
+	}
+	cs := s.Containers()
+	if len(cs) != 1 {
+		t.Fatalf("same container must be one inventory entry, got %d", len(cs))
+	}
+	c := cs[0]
+	if c.ContainerID != "c1" || c.ImageDigest != "sha256:abc" || c.Namespace != "prod" {
+		t.Fatalf("container fields not captured: %+v", c)
+	}
+	if !c.FirstSeenAt.Equal(base) || !c.LastSeenAt.Equal(base.Add(time.Minute)) {
+		t.Fatalf("container seen window wrong: [%s,%s]", c.FirstSeenAt, c.LastSeenAt)
+	}
+	// Container presence is not a timeline transition.
+	for _, e := range s.Timeline() {
+		if e.EntityKind == EntityContainer {
+			t.Fatal("container presence must not appear on the timeline")
+		}
+	}
+}
+
+func TestDistinctContainersAreDistinctInventory(t *testing.T) {
+	s := mustState(t)
+	rc1 := telemetry.ResourceContext{ContainerID: "c1", ImageDigest: "img1"}
+	rc2 := telemetry.ResourceContext{ContainerID: "c2", ImageDigest: "img2"}
+	if _, err := s.Observe(procEnvRC("e1", base, procEntityID(1, 1), 1, rc1)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Observe(procEnvRC("e2", base, procEntityID(2, 1), 2, rc2)); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(s.Containers()); got != 2 {
+		t.Fatalf("two distinct containers expected, got %d", got)
+	}
+	// An event with no container context inventories nothing.
+	if _, err := s.Observe(procEnv("e3", base, procEntityID(3, 1), "", 3, 1, "exec", "x", "/x")); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(s.Containers()); got != 2 {
+		t.Fatalf("host-context event must not add a container, got %d", got)
+	}
+}
+
+func TestB3B5FoldIsReorderInvariant(t *testing.T) {
+	pA, pB := procEntityID(1, 1), procEntityID(2, 1)
+	rc1 := telemetry.ResourceContext{ContainerID: "c1", ImageDigest: "img1"}
+	rc2 := telemetry.ResourceContext{ContainerID: "c2", ImageDigest: "img2"}
+	e0 := procEnvRC("e1", base, pA, 1, rc1)
+	e4 := procEnvRC("e2", base.Add(time.Second), pB, 2, rc2)
+	envs := []telemetry.TelemetryEnvelope{
+		e0,
+		fileEnv("fl1", base.Add(time.Second), pA, "open", "/x", 1, 2, ""),
+		fileEnv("fl2", base.Add(2*time.Second), pA, "write", "/x", 1, 2, ""),
+		privEnv("p1", base.Add(3*time.Second), pA, "setuid", 1000, 0, ""),
+		e4,
+	}
+	fold := func(order []int) *EndpointState {
+		s := mustState(t)
+		for _, i := range order {
+			mustObserve(t, s, envs[i])
+		}
+		return s
+	}
+	fwd := fold([]int{0, 1, 2, 3, 4})
+	rev := fold([]int{4, 3, 2, 1, 0})
+
+	if !reflect.DeepEqual(fwd.Files(), rev.Files()) {
+		t.Fatalf("files differ by fold order:\nfwd=%+v\nrev=%+v", fwd.Files(), rev.Files())
+	}
+	if !reflect.DeepEqual(fwd.Containers(), rev.Containers()) {
+		t.Fatalf("containers differ by fold order:\nfwd=%+v\nrev=%+v", fwd.Containers(), rev.Containers())
+	}
+	if !reflect.DeepEqual(fwd.PrivilegeTransitions(), rev.PrivilegeTransitions()) {
+		t.Fatalf("privilege transitions differ by fold order:\nfwd=%+v\nrev=%+v", fwd.PrivilegeTransitions(), rev.PrivilegeTransitions())
+	}
+	if !reflect.DeepEqual(fwd.Processes(), rev.Processes()) {
+		t.Fatalf("processes differ by fold order")
+	}
+	if !reflect.DeepEqual(fwd.Timeline(), rev.Timeline()) {
+		t.Fatalf("timeline differs by fold order:\nfwd=%+v\nrev=%+v", fwd.Timeline(), rev.Timeline())
+	}
+	// The file's last op is the latest by event time regardless of fold order.
+	if f := fwd.Files(); len(f) != 1 || f[0].LastOp != "write" {
+		t.Fatalf("file last-op not event-time resolved: %+v", f)
+	}
+}
+
+func TestB3B5Validators(t *testing.T) {
+	if (FileTarget{TargetID: "ft", AssetID: testAsset, Path: "/x"}).Validate() != nil {
+		t.Fatal("valid file target rejected")
+	}
+	for _, bad := range []FileTarget{{AssetID: testAsset, Path: "/x"}, {TargetID: "ft", Path: "/x"}, {TargetID: "ft", AssetID: testAsset}} {
+		if bad.Validate() == nil {
+			t.Fatalf("invalid file target accepted: %+v", bad)
+		}
+	}
+	if (ContainerInstance{TargetID: "ct", AssetID: testAsset, ContainerID: "c1"}).Validate() != nil {
+		t.Fatal("valid container rejected")
+	}
+	for _, bad := range []ContainerInstance{{AssetID: testAsset, ContainerID: "c1"}, {TargetID: "ct", ContainerID: "c1"}, {TargetID: "ct", AssetID: testAsset}} {
+		if bad.Validate() == nil {
+			t.Fatalf("invalid container accepted: %+v", bad)
+		}
+	}
+	if (PrivilegeTransition{EventID: "p", AssetID: testAsset, Kind: "setuid"}).Validate() != nil {
+		t.Fatal("valid transition rejected")
+	}
+	for _, bad := range []PrivilegeTransition{{AssetID: testAsset, Kind: "setuid"}, {EventID: "p", Kind: "setuid"}, {EventID: "p", AssetID: testAsset, Kind: "bogus"}} {
+		if bad.Validate() == nil {
+			t.Fatalf("invalid transition accepted: %+v", bad)
+		}
+	}
+}
+
+func TestFileAndContainerAccessorNotFound(t *testing.T) {
+	s := mustState(t)
+	if _, ok := s.File("missing"); ok {
+		t.Fatal("File must report not-found")
+	}
+	if _, ok := s.Container("missing"); ok {
+		t.Fatal("Container must report not-found")
+	}
+}
+
+func TestEqualTimestampFoldIsReorderInvariant(t *testing.T) {
+	pP := procEntityID(10, 1)
+	// Every event shares the SAME OccurredAt (base): the ONLY ordering signal is the EventID tiebreak, so
+	// this is the collision case the reviewers flagged. The higher EventID must win, both fold orders.
+	envs := []telemetry.TelemetryEnvelope{
+		procEnv("pa", base, pP, "", 10, 1, "exec", "a", "/a"),
+		procEnv("pb", base, pP, "", 10, 1, "exec", "b", "/b"), // pb > pa -> /b wins
+		fileEnv("fa", base, pP, "open", "/x", 1, 2, ""),
+		fileEnv("fb", base, pP, "write", "/x", 1, 2, ""), // fb > fa -> write wins
+		procEnvRC("ca", base, procEntityID(20, 1), 20, telemetry.ResourceContext{ContainerID: "c1", ImageDigest: "img1", Namespace: "prod"}),
+		procEnvRC("cb", base, procEntityID(21, 1), 21, telemetry.ResourceContext{ContainerID: "c1", ImageDigest: "img1", Namespace: "staging"}), // cb > ca -> staging wins
+	}
+	fold := func(order []int) *EndpointState {
+		s := mustState(t)
+		for _, i := range order {
+			mustObserve(t, s, envs[i])
+		}
+		return s
+	}
+	fwd := fold([]int{0, 1, 2, 3, 4, 5})
+	rev := fold([]int{5, 4, 3, 2, 1, 0})
+
+	if !reflect.DeepEqual(fwd.Processes(), rev.Processes()) ||
+		!reflect.DeepEqual(fwd.Files(), rev.Files()) ||
+		!reflect.DeepEqual(fwd.Containers(), rev.Containers()) ||
+		!reflect.DeepEqual(fwd.Timeline(), rev.Timeline()) {
+		t.Fatal("equal-timestamp fold is not reorder-invariant")
+	}
+	// The higher EventID wins each contested field, independent of fold order.
+	if pe, _ := fwd.Process(pP); pe.Path != "/b" {
+		t.Fatalf("process descriptor tiebreak: got %q want /b", pe.Path)
+	}
+	if f := fwd.Files(); len(f) != 1 || f[0].LastOp != "write" {
+		t.Fatalf("file op tiebreak: %+v", f)
+	}
+	cs := fwd.Containers()
+	if len(cs) != 1 || cs[0].Namespace != "staging" {
+		t.Fatalf("container metadata tiebreak: %+v", cs)
+	}
+}
+
+func TestPrivilegeEscalationFlag(t *testing.T) {
+	s := mustState(t)
+	proc := procEntityID(1, 1)
+	mustObserve(t, s, privEnv("p1", base, proc, "setuid", 1000, 0, ""))                              // to root -> escalation
+	mustObserve(t, s, privEnv("p2", base.Add(time.Second), proc, "setuid", 0, 1000, ""))             // drop -> not
+	mustObserve(t, s, privEnv("p3", base.Add(2*time.Second), proc, "capset", 0, 0, "CAP_SYS_ADMIN")) // cap gain -> escalation
+	tr := s.PrivilegeTransitions()
+	if len(tr) != 3 {
+		t.Fatalf("want 3 transitions, got %d", len(tr))
+	}
+	if !tr[0].Escalation || tr[1].Escalation || !tr[2].Escalation {
+		t.Fatalf("escalation flags wrong: %+v", tr)
+	}
+}

--- a/internal/domain/endpoint/privilege_transition.go
+++ b/internal/domain/endpoint/privilege_transition.go
@@ -1,0 +1,63 @@
+package endpoint
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+// PrivilegeTransition is a privilege or capability change attributed to a process entity (B4). Privilege
+// transitions are never-sampled upstream (A0.6), so every observed one is recorded here — a privilege
+// escalation must always be visible. It is an immutable record of one event, keyed for dedupe by its
+// source EventID.
+type PrivilegeTransition struct {
+	EventID         shared.ID
+	TenantID        shared.ID
+	AssetID         shared.ID
+	ProcessEntityID shared.ID
+	// Kind is "setuid", "setresuid", or "capset".
+	Kind    string
+	FromUID int
+	ToUID   int
+	// Cap is the capability gained when Kind is "capset".
+	Cap string
+	// Escalation flags a transition that raises privilege (to root, or a capability gain), so a consumer
+	// can surface escalations without re-deriving the rule.
+	Escalation bool
+	OccurredAt time.Time
+}
+
+// Validate enforces a well-formed privilege transition.
+func (p PrivilegeTransition) Validate() error {
+	if p.EventID.IsZero() {
+		return fmt.Errorf("%w: privilege transition has no event id", shared.ErrValidation)
+	}
+	if p.AssetID.IsZero() {
+		return fmt.Errorf("%w: privilege transition has no asset id", shared.ErrValidation)
+	}
+	switch p.Kind {
+	case "setuid", "setresuid", "capset":
+	default:
+		return fmt.Errorf("%w: privilege transition has unknown kind %q", shared.ErrValidation, p.Kind)
+	}
+	return nil
+}
+
+// privilegeSummary renders a human summary of a privilege observation for the timeline, built from the
+// OBSERVATION so it is order-independent.
+func privilegeSummary(obs *telemetry.PrivilegeObservation) string {
+	if obs.Kind == "capset" {
+		return fmt.Sprintf("capset +%s (pid=%d)", obs.Cap, obs.PID)
+	}
+	return fmt.Sprintf("%s uid %d->%d (pid=%d)", obs.Kind, obs.FromUID, obs.ToUID, obs.PID)
+}
+
+// isPrivilegeEscalation reports whether a transition raises privilege (to root, or a capability gain).
+func isPrivilegeEscalation(obs *telemetry.PrivilegeObservation) bool {
+	if obs.Kind == "capset" {
+		return obs.Cap != ""
+	}
+	return obs.ToUID == 0 && obs.FromUID != 0
+}

--- a/internal/domain/endpoint/process.go
+++ b/internal/domain/endpoint/process.go
@@ -50,6 +50,10 @@ type ProcessEntity struct {
 	// ExitedAt is set only when an exit is observed (reserved tail); nil while running.
 	ExitedAt *time.Time
 	State    ProcessState
+	// descEventID is the EventID of the observation that last set the descriptor fields. It is the
+	// tiebreak that keeps the descriptor resolution reorder-invariant when two observations of this entity
+	// share an OccurredAt; unexported so it is internal bookkeeping, not part of the public projection.
+	descEventID shared.ID
 }
 
 // IsRunning reports whether the process is currently believed to be alive.

--- a/internal/domain/endpoint/timeline.go
+++ b/internal/domain/endpoint/timeline.go
@@ -22,10 +22,11 @@ import (
 type EntityKind string
 
 const (
-	EntityProcess  EntityKind = "process"
-	EntityNetwork  EntityKind = "network"
-	EntityFile     EntityKind = "file"
-	EntityIdentity EntityKind = "identity"
+	EntityProcess   EntityKind = "process"
+	EntityNetwork   EntityKind = "network"
+	EntityFile      EntityKind = "file"
+	EntityIdentity  EntityKind = "identity"
+	EntityContainer EntityKind = "container"
 )
 
 // TimelineEntryKind is the specific state transition an entry records.
@@ -35,18 +36,23 @@ const (
 	// Process lifecycle (B1). A fork creates a child; an exec replaces the image of an existing entity.
 	TimelineProcessStart TimelineEntryKind = "process_start"
 	TimelineProcessExec  TimelineEntryKind = "process_exec"
-	// Network (B2): the first time a flow is seen. Re-observing the same flow widens its last-seen time
-	// but is not a new transition, so it does not add a second entry.
+	// Network (B2): one entry per connect event; the connection entity deduplicates the flow.
 	TimelineNetworkConnect TimelineEntryKind = "network_connect"
+	// File (B3): one entry per file access event, tagged with the observed op.
+	TimelineFileOpen   TimelineEntryKind = "file_open"
+	TimelineFileWrite  TimelineEntryKind = "file_write"
+	TimelineFileRename TimelineEntryKind = "file_rename"
+	// Identity/privilege (B4): a privilege or capability transition on a process. Never-sampled upstream
+	// (A0.6), so every one surfaces here.
+	TimelinePrivilegeChange TimelineEntryKind = "privilege_change"
 )
 
 // TimelineEntry is one endpoint state transition, ordered by EVENT time (when it happened on the host),
 // never by ingest order. It stays explainable after the raw telemetry that produced it expires because it
-// carries its own summary and the identities it links.
+// carries its own summary and the identities it links. Every field is content-derived, so a given set of
+// envelopes yields byte-identical entries regardless of fold order — the property Phase C evidence sealing
+// depends on.
 type TimelineEntry struct {
-	// Seq is the assignment order within one StateTimeline. It is the deterministic tiebreak when two
-	// transitions share an OccurredAt; it is not a host-wide sequence.
-	Seq        uint64
 	OccurredAt time.Time
 	TenantID   shared.ID
 	AssetID    shared.ID
@@ -54,7 +60,7 @@ type TimelineEntry struct {
 	EntityID   shared.ID
 	Kind       TimelineEntryKind
 	// EventID is the source envelope's event id; it is the dedupe key so a replayed envelope never adds
-	// a duplicate transition.
+	// a duplicate transition, and the tiebreak that orders transitions sharing an OccurredAt.
 	EventID shared.ID
 	Summary string
 }
@@ -65,7 +71,6 @@ type TimelineEntry struct {
 type StateTimeline struct {
 	entries []TimelineEntry
 	seen    map[shared.ID]struct{}
-	nextSeq uint64
 }
 
 func newStateTimeline() *StateTimeline {
@@ -73,14 +78,11 @@ func newStateTimeline() *StateTimeline {
 }
 
 // append records a transition unless its EventID is already on the timeline. It returns the stored entry
-// (with its assigned Seq) and whether it was newly appended; a duplicate EventID returns (zero, false)
-// and changes nothing.
+// and whether it was newly appended; a duplicate EventID returns (zero, false) and changes nothing.
 func (t *StateTimeline) append(e TimelineEntry) (TimelineEntry, bool) {
 	if _, dup := t.seen[e.EventID]; dup {
 		return TimelineEntry{}, false
 	}
-	e.Seq = t.nextSeq
-	t.nextSeq++
 	t.seen[e.EventID] = struct{}{}
 	t.entries = append(t.entries, e)
 	return e, true
@@ -92,16 +94,18 @@ func (t *StateTimeline) has(eventID shared.ID) bool {
 	return ok
 }
 
-// Entries returns a copy of the timeline ordered by event time, with insertion order (Seq) as the
-// deterministic tiebreak for equal timestamps. Callers may mutate the returned slice freely.
+// Entries returns a copy of the timeline ordered by event time, with EventID as the tiebreak for equal
+// timestamps. EventID (not insertion order) is the tiebreak so the order is fully reorder-invariant: two
+// transitions at the same instant sort the same way no matter which order they were folded in — the
+// property Phase C evidence sealing depends on. Callers may mutate the returned slice freely.
 func (t *StateTimeline) Entries() []TimelineEntry {
 	out := make([]TimelineEntry, len(t.entries))
 	copy(out, t.entries)
-	sort.SliceStable(out, func(i, j int) bool {
+	sort.Slice(out, func(i, j int) bool {
 		if !out[i].OccurredAt.Equal(out[j].OccurredAt) {
 			return out[i].OccurredAt.Before(out[j].OccurredAt)
 		}
-		return out[i].Seq < out[j].Seq
+		return out[i].EventID < out[j].EventID
 	})
 	return out
 }

--- a/internal/domain/endpoint/timeline_test.go
+++ b/internal/domain/endpoint/timeline_test.go
@@ -49,21 +49,18 @@ func TestTimelineDedupesByEventID(t *testing.T) {
 	}
 }
 
-func TestTimelineEqualTimestampsKeepInsertionOrder(t *testing.T) {
+func TestTimelineEqualTimestampsTiebreakByEventIDNotInsertionOrder(t *testing.T) {
 	tl := newStateTimeline()
-	// Three entries at the SAME instant: the deterministic tiebreak is insertion order (Seq).
-	tl.append(entry("first", base))
-	tl.append(entry("second", base))
-	tl.append(entry("third", base))
+	// Three entries at the SAME instant, appended out of EventID order. The tiebreak is EventID, NOT
+	// insertion order — so the result is reorder-invariant even when timestamps collide.
+	tl.append(entry("c", base))
+	tl.append(entry("a", base))
+	tl.append(entry("b", base))
 	got := tl.Entries()
-	want := []string{"first", "second", "third"}
+	want := []string{"a", "b", "c"}
 	for i, w := range want {
 		if string(got[i].EventID) != w {
-			t.Fatalf("equal-timestamp tiebreak broke determinism at %d: got %s want %s", i, got[i].EventID, w)
+			t.Fatalf("equal-timestamp tiebreak not by EventID at %d: got %s want %s", i, got[i].EventID, w)
 		}
-	}
-	// Seq must be assigned in insertion order.
-	if got[0].Seq != 0 || got[1].Seq != 1 || got[2].Seq != 2 {
-		t.Fatalf("seq assignment wrong: %d %d %d", got[0].Seq, got[1].Seq, got[2].Seq)
 	}
 }


### PR DESCRIPTION
## Phase B enrichment — file (B3), privilege (B4), container inventory (B5), diff (B6)

Extends the pure-domain `internal/domain/endpoint` package (Phase B of EDR epic #594) with the remaining endpoint-visibility projections over already-normalized A1 telemetry. Follows the B1/B2/B7 core (#670).

### What's in it
- **B3 `FileTarget`** (#665) — file objects keyed by the A1 `FileTargetID` (path+device+inode+content-hash); last op + accessing process tracked; one timeline entry per access. A modified file (new content hash) is correctly a distinct target version.
- **B4 `PrivilegeTransition`** (#666) — setuid/setresuid/capset transitions attributed to the acting process entity, recorded as first-class immutable records with an `Escalation` flag + timeline entry. Never-sampled upstream (A0.6), so **every** transition surfaces — including one folded before its process is observed. Deliberately does **not** mutate the process entity (that would make the fold order-dependent).
- **B5 `ContainerInstance`** (#667) — runtime container inventory projected from the `ResourceContext` every event carries (identity = A1 `ContainerTargetID`); the runtime side X5 (#634) running-vs-installed exposure will fuse. Inventory only.
- **B6 `Diff`** (#668) — deterministic, **material-only** diff (added/removed/changed) between two snapshots, for change detection + retro-hunt; nil-safe.

### Determinism (what Phase C evidence needs)
The whole package stays **pure, deterministic, reorder-invariant**: every descriptor field resolves latest-by-event-time with an **EventID tiebreak** (a shared `laterEvent` rule used by the process, file, and container folds), started/first-seen = earliest event time, last-seen = latest, and the timeline carries **no insertion-order field** (tiebreaks by EventID). So the same envelopes fold to **byte-identical** entities + timeline in ANY order, including same-instant collisions — proven by `TestEqualTimestampFoldIsReorderInvariant`. Fail-closed: every envelope is `telemetry.Validate()`-checked before folding; entities are stamped with the state's own tenant/asset, never the envelope's.

### Review
Dual-reviewed (go-arch + security). security: **SHIP**, no crit/high (identity-collision resistance, never-sample coverage, tenant isolation confirmed). go-arch first returned **not-mergeable** on two determinism blockers — a fold-order-dependent timeline `Seq` field and an equal-timestamp descriptor tie — plus the container-metadata first-fold-wins gap security also flagged. **All fixed** (Seq removed; `laterEvent` EventID-tiebreak across process/file/container; container metadata resolved latest-by-event-time), and go-arch re-review is now **MERGEABLE**. Non-blocking items (dead code, wired escalation flag, nil-safe Diff) also addressed.

### Verification (CI off — validated locally)
Pure domain (imports only `domain/{detection,shared,telemetry}`+stdlib); `go build`/`go vet`/`gofmt -l` clean; `go test -race` green; 92.9% coverage.

### Scope / follow-ups
eBPF collection, a persistence store, and container start/stop + process-exit events are deferred sensor tails. **#665–#668 stay open** for those. With B1/B2 (#670) + B4 here, Phase C (#638 EDR-MVP) correlation is unblocked (C needs A + B1/B2/B4 + X1).
