### PR TITLE
feat(endpoint): make network attribution gaps explicit (#664)

### DIFF
--- a/internal/domain/endpoint/connection.go
+++ b/internal/domain/endpoint/connection.go
@@ -21,6 +21,21 @@ const (
 	ConnectionObserved ConnectionState = "observed"
 )
 
+// ProcessAttribution records whether the process named by a network observation has itself been
+// directly observed. A ProcessEntityID alone is not proof that the endpoint projection received the
+// corresponding process event: sensors can miss it, or network telemetry can arrive first.
+type ProcessAttribution string
+
+const (
+	// ProcessAttributionUnknown means the flow has no ProcessEntityID, or its referenced process has not
+	// been directly observed. The id is preserved when present, but consumers must not treat it as a
+	// verified process entity yet.
+	ProcessAttributionUnknown ProcessAttribution = "unknown"
+	// ProcessAttributionObserved means a validated process observation for ProcessEntityID is present in
+	// the same endpoint projection.
+	ProcessAttributionObserved ProcessAttribution = "observed"
+)
+
 // NetworkConnection is a process-attributed network flow reconstructed from network telemetry (B2). It is
 // keyed by a stable ConnectionID so re-observing the same flow widens its last-seen time instead of
 // creating a duplicate, and it links to the process that opened it by the A1 ProcessEntityID rather than a
@@ -37,9 +52,12 @@ type NetworkConnection struct {
 	RemoteAddr      string
 	RemotePort      int
 	Comm            string
-	FirstSeenAt     time.Time
-	LastSeenAt      time.Time
-	State           ConnectionState
+	// ProcessAttribution makes a missing process observation explicit instead of allowing consumers to
+	// infer that ProcessEntityID necessarily resolves to an observed process.
+	ProcessAttribution ProcessAttribution
+	FirstSeenAt        time.Time
+	LastSeenAt         time.Time
+	State              ConnectionState
 }
 
 // Validate enforces a well-formed network connection.
@@ -52,6 +70,14 @@ func (c NetworkConnection) Validate() error {
 	}
 	if c.State != ConnectionObserved {
 		return fmt.Errorf("%w: network connection has unknown state %q", shared.ErrValidation, c.State)
+	}
+	switch c.ProcessAttribution {
+	case ProcessAttributionUnknown, ProcessAttributionObserved:
+	default:
+		return fmt.Errorf("%w: network connection has unknown process attribution %q", shared.ErrValidation, c.ProcessAttribution)
+	}
+	if c.ProcessAttribution == ProcessAttributionObserved && c.ProcessEntityID.IsZero() {
+		return fmt.Errorf("%w: observed process attribution has no process entity id", shared.ErrValidation)
 	}
 	return nil
 }

--- a/internal/domain/endpoint/connection_test.go
+++ b/internal/domain/endpoint/connection_test.go
@@ -21,6 +21,9 @@ func TestConnectionIDIsStableAndProcessAttributed(t *testing.T) {
 	if c.ProcessEntityID != proc {
 		t.Fatalf("connection must be attributed to its process entity, got %s", c.ProcessEntityID)
 	}
+	if c.ProcessAttribution != ProcessAttributionUnknown {
+		t.Fatalf("unobserved process attribution must be explicit, got %q", c.ProcessAttribution)
+	}
 	want := ConnectionID(testAsset, proc, "tcp", "egress", "10.0.0.1", 4444, "1.2.3.4", 443)
 	if c.ConnectionID != want {
 		t.Fatalf("connection id unstable: got %s want %s", c.ConnectionID, want)
@@ -85,12 +88,65 @@ func TestDistinctFlowsAreDistinctConnections(t *testing.T) {
 }
 
 func TestNetworkConnectionValidate(t *testing.T) {
-	good := NetworkConnection{ConnectionID: shared.ID("nc_x"), AssetID: testAsset, State: ConnectionObserved}
+	good := NetworkConnection{
+		ConnectionID: shared.ID("nc_x"), AssetID: testAsset, State: ConnectionObserved,
+		ProcessAttribution: ProcessAttributionUnknown,
+	}
 	if err := good.Validate(); err != nil {
 		t.Fatalf("valid connection rejected: %v", err)
 	}
-	bad := NetworkConnection{ConnectionID: shared.ID("nc_x"), AssetID: testAsset, State: "bogus"}
-	if bad.Validate() == nil {
-		t.Fatal("unknown state must be rejected")
+	cases := map[string]NetworkConnection{
+		"unknown state":       {ConnectionID: "nc_x", AssetID: testAsset, State: "bogus", ProcessAttribution: ProcessAttributionUnknown},
+		"missing attribution": {ConnectionID: "nc_x", AssetID: testAsset, State: ConnectionObserved},
+		"observed without id": {ConnectionID: "nc_x", AssetID: testAsset, State: ConnectionObserved, ProcessAttribution: ProcessAttributionObserved},
+	}
+	for name, bad := range cases {
+		if bad.Validate() == nil {
+			t.Fatalf("%s must be rejected", name)
+		}
+	}
+}
+
+func TestNetworkAttributionReconcilesAfterProcessObservation(t *testing.T) {
+	s := mustState(t)
+	proc := procEntityID(303, 1)
+	mustObserve(t, s, netEnv("n1", base.Add(time.Second), proc, "tcp", "egress", "10.0.0.1", 6000, "1.2.3.4", 443))
+	if got := s.Connections()[0].ProcessAttribution; got != ProcessAttributionUnknown {
+		t.Fatalf("flow arriving before its process must be unknown, got %q", got)
+	}
+
+	mustObserve(t, s, procEnv("p1", base, proc, "", 303, 1, "exec", "app", "/usr/bin/app"))
+	if got := s.Connections()[0].ProcessAttribution; got != ProcessAttributionObserved {
+		t.Fatalf("direct process observation must reconcile attribution, got %q", got)
+	}
+}
+
+func TestNetworkAttributionRequiresDirectProcessObservation(t *testing.T) {
+	s := mustState(t)
+	parent := procEntityID(304, 1)
+	child := procEntityID(305, 2)
+
+	// Observing the child creates an explicit ProcessUnknown parent stub. A stub proves only that the
+	// lineage referenced the id; it must not upgrade a network attribution.
+	mustObserve(t, s, procEnv("p-child", base, child, parent, 305, 304, "exec", "child", "/child"))
+	mustObserve(t, s, netEnv("n-parent", base.Add(time.Second), parent, "tcp", "egress", "10.0.0.1", 6001, "1.2.3.4", 443))
+	if got := s.Connections()[0].ProcessAttribution; got != ProcessAttributionUnknown {
+		t.Fatalf("parent stub must not count as observed attribution, got %q", got)
+	}
+
+	mustObserve(t, s, procEnv("p-parent", base.Add(2*time.Second), parent, "", 304, 1, "exec", "parent", "/parent"))
+	if got := s.Connections()[0].ProcessAttribution; got != ProcessAttributionObserved {
+		t.Fatalf("directly observing the parent must resolve attribution, got %q", got)
+	}
+}
+
+func TestNetworkAttributionWithoutProcessIDStaysUnknown(t *testing.T) {
+	s := mustState(t)
+	mustObserve(t, s, netEnv("n1", base, "", "udp", "egress", "", 0, "8.8.8.8", 53))
+	mustObserve(t, s, procEnv("p1", base.Add(time.Second), procEntityID(306, 1), "", 306, 1, "exec", "dns", "/usr/bin/dns"))
+
+	c := s.Connections()[0]
+	if !c.ProcessEntityID.IsZero() || c.ProcessAttribution != ProcessAttributionUnknown {
+		t.Fatalf("flow without a join identity must stay unknown, got %+v", c)
 	}
 }

--- a/internal/domain/endpoint/diff.go
+++ b/internal/domain/endpoint/diff.go
@@ -92,11 +92,12 @@ func diffProcesses(before, after *EndpointState) []EntityChange {
 }
 
 func diffConnections(before, after *EndpointState) []EntityChange {
-	// A connection's identity (process + proto + direction + 5-tuple) is its whole material state, so a
-	// flow only ever appears or disappears; it never "changes" in place.
+	// A connection's tuple is immutable, but its process attribution can move monotonically from unknown
+	// to observed when an out-of-order process event arrives. That resolution is a material security-state
+	// change; seen-window movement remains intentionally ignored.
 	return diffSet(EntityNetwork, connectionsOf(before), connectionsOf(after),
 		func(c NetworkConnection) shared.ID { return c.ConnectionID },
-		func(a, b NetworkConnection) bool { return true })
+		func(a, b NetworkConnection) bool { return a.ProcessAttribution == b.ProcessAttribution })
 }
 
 func diffFiles(before, after *EndpointState) []EntityChange {

--- a/internal/domain/endpoint/diff_test.go
+++ b/internal/domain/endpoint/diff_test.go
@@ -82,6 +82,23 @@ func TestDiffIgnoresSeenWindowMovement(t *testing.T) {
 	}
 }
 
+func TestDiffReportsProcessAttributionResolution(t *testing.T) {
+	before := mustState(t)
+	after := mustState(t)
+	proc := procEntityID(44, 1)
+	flow := netEnv("n1", base, proc, "tcp", "egress", "10.0.0.1", 4000, "1.2.3.4", 443)
+	mustObserve(t, before, flow)
+	mustObserve(t, after, flow)
+	mustObserve(t, after, procEnv("p1", base.Add(time.Second), proc, "", 44, 1, "exec", "app", "/app"))
+
+	connID := ConnectionID(testAsset, proc, "tcp", "egress", "10.0.0.1", 4000, "1.2.3.4", 443)
+	d := Diff(before, after)
+	if len(d.Changes) != 2 || !hasChange(d, EntityNetwork, connID, ChangeChanged) {
+		// The process itself is also added; the connection resolution must be the other material change.
+		t.Fatalf("attribution resolution must be reported as a changed connection: %+v", d.Changes)
+	}
+}
+
 func TestDiffOfIdenticalIsEmptyAndDeterministicallyOrdered(t *testing.T) {
 	build := func() *EndpointState {
 		s := mustState(t)

--- a/internal/domain/endpoint/endpoint.go
+++ b/internal/domain/endpoint/endpoint.go
@@ -19,15 +19,19 @@ const maxAncestorWalk = 256
 // Observe and is a pure, deterministic aggregate — no I/O, no clock. The zero value is not usable;
 // construct it with NewEndpointState.
 type EndpointState struct {
-	tenantID   shared.ID
-	assetID    shared.ID
-	processes  map[shared.ID]*ProcessEntity
-	conns      map[shared.ID]*NetworkConnection
-	files      map[shared.ID]*FileTarget
-	containers map[shared.ID]*ContainerInstance
-	privileges []PrivilegeTransition
-	timeline   *StateTimeline
-	processed  map[shared.ID]struct{}
+	tenantID  shared.ID
+	assetID   shared.ID
+	processes map[shared.ID]*ProcessEntity
+	conns     map[shared.ID]*NetworkConnection
+	// connsByProcess is a derived index used to reconcile an unknown attribution in O(flows for process)
+	// when an out-of-order process observation arrives. Empty process ids are intentionally not indexed:
+	// there is no stable identity by which a later process event could resolve them.
+	connsByProcess map[shared.ID][]*NetworkConnection
+	files          map[shared.ID]*FileTarget
+	containers     map[shared.ID]*ContainerInstance
+	privileges     []PrivilegeTransition
+	timeline       *StateTimeline
+	processed      map[shared.ID]struct{}
 }
 
 // NewEndpointState creates the projection for one asset. Both ids are required — endpoint visibility is
@@ -40,14 +44,15 @@ func NewEndpointState(tenantID, assetID shared.ID) (*EndpointState, error) {
 		return nil, fmt.Errorf("%w: endpoint state requires an asset id", shared.ErrValidation)
 	}
 	return &EndpointState{
-		tenantID:   tenantID,
-		assetID:    assetID,
-		processes:  make(map[shared.ID]*ProcessEntity),
-		conns:      make(map[shared.ID]*NetworkConnection),
-		files:      make(map[shared.ID]*FileTarget),
-		containers: make(map[shared.ID]*ContainerInstance),
-		timeline:   newStateTimeline(),
-		processed:  make(map[shared.ID]struct{}),
+		tenantID:       tenantID,
+		assetID:        assetID,
+		processes:      make(map[shared.ID]*ProcessEntity),
+		conns:          make(map[shared.ID]*NetworkConnection),
+		connsByProcess: make(map[shared.ID][]*NetworkConnection),
+		files:          make(map[shared.ID]*FileTarget),
+		containers:     make(map[shared.ID]*ContainerInstance),
+		timeline:       newStateTimeline(),
+		processed:      make(map[shared.ID]struct{}),
 	}, nil
 }
 
@@ -142,6 +147,11 @@ func (s *EndpointState) applyProcess(env telemetry.TelemetryEnvelope) []Timeline
 		pe.LastSeenAt = env.OccurredAt
 	}
 
+	// A network observation may have arrived before this process observation. Promote every flow that
+	// references this now-directly-observed entity; the transition is monotonic and therefore independent
+	// of fold order.
+	s.markProcessAttributionObserved(obs.EntityID)
+
 	s.ensureParentStub(obs)
 
 	kind := TimelineProcessStart
@@ -192,22 +202,26 @@ func (s *EndpointState) applyNetwork(env telemetry.TelemetryEnvelope) []Timeline
 	conn, existed := s.conns[id]
 	if !existed {
 		conn = &NetworkConnection{
-			ConnectionID:    id,
-			TenantID:        s.tenantID,
-			AssetID:         s.assetID,
-			ProcessEntityID: obs.ProcessEntityID,
-			Proto:           obs.Proto,
-			Direction:       obs.Direction,
-			LocalAddr:       obs.LocalAddr,
-			LocalPort:       obs.LocalPort,
-			RemoteAddr:      obs.RemoteAddr,
-			RemotePort:      obs.RemotePort,
-			Comm:            obs.Comm,
-			FirstSeenAt:     env.OccurredAt,
-			LastSeenAt:      env.OccurredAt,
-			State:           ConnectionObserved,
+			ConnectionID:       id,
+			TenantID:           s.tenantID,
+			AssetID:            s.assetID,
+			ProcessEntityID:    obs.ProcessEntityID,
+			Proto:              obs.Proto,
+			Direction:          obs.Direction,
+			LocalAddr:          obs.LocalAddr,
+			LocalPort:          obs.LocalPort,
+			RemoteAddr:         obs.RemoteAddr,
+			RemotePort:         obs.RemotePort,
+			Comm:               obs.Comm,
+			ProcessAttribution: s.processAttribution(obs.ProcessEntityID),
+			FirstSeenAt:        env.OccurredAt,
+			LastSeenAt:         env.OccurredAt,
+			State:              ConnectionObserved,
 		}
 		s.conns[id] = conn
+		if !obs.ProcessEntityID.IsZero() {
+			s.connsByProcess[obs.ProcessEntityID] = append(s.connsByProcess[obs.ProcessEntityID], conn)
+		}
 	} else {
 		// The connection ENTITY deduplicates the flow: re-observing widens its seen window. Both bounds
 		// take a min/max so the window is order-independent (reorder-invariant).
@@ -237,6 +251,28 @@ func (s *EndpointState) applyNetwork(env telemetry.TelemetryEnvelope) []Timeline
 		return nil
 	}
 	return []TimelineEntry{entry}
+}
+
+// processAttribution reports only what this projection can prove. Merely having an entity id, including
+// an id represented by a ProcessUnknown parent stub, is not enough: a direct process observation must
+// have been folded before attribution becomes observed.
+func (s *EndpointState) processAttribution(processEntityID shared.ID) ProcessAttribution {
+	pe, ok := s.processes[processEntityID]
+	if ok && pe.State != ProcessUnknown {
+		return ProcessAttributionObserved
+	}
+	return ProcessAttributionUnknown
+}
+
+// markProcessAttributionObserved reconciles flows that arrived before their process event. Connections
+// with no process id remain explicitly unknown because there is no safe identity to join on.
+func (s *EndpointState) markProcessAttributionObserved(processEntityID shared.ID) {
+	if processEntityID.IsZero() {
+		return
+	}
+	for _, conn := range s.connsByProcess[processEntityID] {
+		conn.ProcessAttribution = ProcessAttributionObserved
+	}
 }
 
 // Process returns a copy of one process entity by id.

--- a/internal/domain/endpoint/endpoint_test.go
+++ b/internal/domain/endpoint/endpoint_test.go
@@ -333,4 +333,7 @@ func TestFoldIsReorderInvariant(t *testing.T) {
 	if !c.FirstSeenAt.Equal(base.Add(time.Second)) || !c.LastSeenAt.Equal(base.Add(3*time.Second)) {
 		t.Fatalf("connection window not min/max: [%s,%s]", c.FirstSeenAt, c.LastSeenAt)
 	}
+	if c.ProcessAttribution != ProcessAttributionObserved {
+		t.Fatalf("process attribution must resolve regardless of fold order, got %q", c.ProcessAttribution)
+	}
 }


### PR DESCRIPTION
## Summary

Completes the network-attribution-honesty tail called out by #670 for #664. A network flow now says explicitly whether its referenced process has actually been observed, instead of letting a populated `ProcessEntityID` imply evidence the projection may not have.

## Changes

- add validated `ProcessAttributionUnknown` / `ProcessAttributionObserved` domain states to `NetworkConnection`
- mark flows with a missing or unobserved process as `unknown`, while preserving any supplied entity id
- reconcile unknown flows when the matching process is directly observed, using a per-process connection index rather than a full scan
- keep `ProcessUnknown` parent stubs fail-closed: lineage references do not count as direct process evidence
- treat unknown-to-observed attribution resolution as a material `EndpointDiff` change
- cover network-before-process, process-before-network/reordered folds, parent stubs, missing ids, validation, and diff behavior

The reconciliation is monotonic and content-derived, so final entities remain deterministic and reorder-invariant. This is the portable honesty tail only; #664 remains open for its eBPF collection, persistence, counters, and close-event tails.

## Checklist

- [ ] `make build vet test typecheck` passes (GNU Make/Linux toolchain unavailable in this Windows environment)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/domain/endpoint`
- [x] attribution/reorder regression tests repeated 100 times
- [x] Tests added/updated for new behavior
- [x] Preserves the safety invariants

### Validation note

`go test ./...` passed every relevant package, including `internal/domain/endpoint`, but the aggregate command exits non-zero on two pre-existing Windows-only filesystem-security cases: `cmd/synapse-fptriage-release/TestRunCreatesPromotionAndRollbackLedger` (private input ACL verification is intentionally unavailable on Windows) and `internal/infrastructure/egressbroker/TestFileGrantReplayStoreCompactsExpiredRecords` (owner-controlled-directory check). `go test -race` is unavailable locally because this Go installation has CGO disabled.

Refs #664