### PR TITLE
feat(endpoint): persist the endpoint State Timeline (Phase B tail, #665-#669)

### DIFF
--- a/internal/domain/endpoint/endpoint.go
+++ b/internal/domain/endpoint/endpoint.go
@@ -144,24 +144,21 @@ func (s *EndpointState) applyProcess(env telemetry.TelemetryEnvelope) []Timeline
 
 	s.ensureParentStub(obs)
 
-	kind := TimelineProcessStart
-	if obs.Kind == "exec" {
-		kind = TimelineProcessExec
+	return s.appendTimeline(env)
+}
+
+// appendTimeline appends the envelope's timeline transition (built by the shared timelineEntryFor) and
+// returns it, or nil if there is none or it was a duplicate.
+func (s *EndpointState) appendTimeline(env telemetry.TelemetryEnvelope) []TimelineEntry {
+	entry, ok := timelineEntryFor(s.tenantID, env)
+	if !ok {
+		return nil
 	}
-	entry, appended := s.timeline.append(TimelineEntry{
-		OccurredAt: env.OccurredAt,
-		TenantID:   s.tenantID,
-		AssetID:    s.assetID,
-		EntityKind: EntityProcess,
-		EntityID:   obs.EntityID,
-		Kind:       kind,
-		EventID:    env.EventID,
-		Summary:    processObsSummary(obs),
-	})
+	stored, appended := s.timeline.append(entry)
 	if !appended {
 		return nil
 	}
-	return []TimelineEntry{entry}
+	return []TimelineEntry{stored}
 }
 
 // ensureParentStub records a referenced-but-unobserved parent as an explicit ProcessUnknown entity, so a
@@ -223,20 +220,7 @@ func (s *EndpointState) applyNetwork(env telemetry.TelemetryEnvelope) []Timeline
 	// reorder-invariant log of observations. Deduplication of the flow itself lives on the connection
 	// entity above, not on the timeline — a per-flow entry would have to take the timestamp of whichever
 	// connect was folded first, which would not be reorder-invariant.
-	entry, appended := s.timeline.append(TimelineEntry{
-		OccurredAt: env.OccurredAt,
-		TenantID:   s.tenantID,
-		AssetID:    s.assetID,
-		EntityKind: EntityNetwork,
-		EntityID:   id,
-		Kind:       TimelineNetworkConnect,
-		EventID:    env.EventID,
-		Summary:    connectionObsSummary(obs),
-	})
-	if !appended {
-		return nil
-	}
-	return []TimelineEntry{entry}
+	return s.appendTimeline(env)
 }
 
 // Process returns a copy of one process entity by id.
@@ -298,6 +282,60 @@ func (s *EndpointState) Ancestors(id shared.ID) []ProcessEntity {
 		cur = parent
 	}
 	return out
+}
+
+// timelineEntryFor returns the single timeline transition an envelope produces, and whether it produces
+// one (a container-only event produces none). It is PURE — it depends only on the envelope, not on any
+// accumulated state — so the timeline is a stateless per-envelope projection: the same envelope always
+// yields the same entry, and both the live fold (Observe) and the persistence path (TimelineEntriesFor)
+// build entries through this one function, so they can never drift. The envelope must already be validated.
+func timelineEntryFor(tenantID shared.ID, env telemetry.TelemetryEnvelope) (TimelineEntry, bool) {
+	e := TimelineEntry{OccurredAt: env.OccurredAt, TenantID: tenantID, AssetID: env.AssetID, EventID: env.EventID}
+	switch env.EventClass {
+	case detection.ClassProcess:
+		obs := env.Event.Process
+		e.EntityKind, e.EntityID, e.Summary = EntityProcess, obs.EntityID, processObsSummary(obs)
+		e.Kind = TimelineProcessStart
+		if obs.Kind == "exec" {
+			e.Kind = TimelineProcessExec
+		}
+		return e, true
+	case detection.ClassNetwork:
+		obs := env.Event.Network
+		e.EntityKind = EntityNetwork
+		e.EntityID = ConnectionID(env.AssetID, obs.ProcessEntityID, obs.Proto, obs.Direction, obs.LocalAddr, obs.LocalPort, obs.RemoteAddr, obs.RemotePort)
+		e.Kind, e.Summary = TimelineNetworkConnect, connectionObsSummary(obs)
+		return e, true
+	case detection.ClassFile:
+		obs := env.Event.File
+		e.EntityKind, e.EntityID = EntityFile, obs.TargetID()
+		e.Kind, e.Summary = fileTimelineKind(obs.Op), fileObsSummary(obs)
+		return e, true
+	case detection.ClassPrivilege:
+		obs := env.Event.Privilege
+		e.EntityKind, e.EntityID = EntityIdentity, obs.ProcessEntityID
+		e.Kind, e.Summary = TimelinePrivilegeChange, privilegeSummary(obs)
+		return e, true
+	}
+	return TimelineEntry{}, false
+}
+
+// TimelineEntriesFor is the stateless State-Timeline projection of one telemetry envelope, for the
+// persistence path (a store appends what this returns, deduplicating by EventID). It validates the
+// envelope first (fail-closed) and stamps entries with the given tenant and the envelope's asset. It
+// returns no entries for a class that has no transition (container-only). Because it shares
+// timelineEntryFor with the live fold, a persisted timeline is identical to the in-memory one.
+func TimelineEntriesFor(tenantID shared.ID, env telemetry.TelemetryEnvelope) ([]TimelineEntry, error) {
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: timeline projection requires a tenant id", shared.ErrValidation)
+	}
+	if err := env.Validate(); err != nil {
+		return nil, fmt.Errorf("endpoint: reject malformed telemetry envelope: %w", err)
+	}
+	if entry, ok := timelineEntryFor(tenantID, env); ok {
+		return []TimelineEntry{entry}, nil
+	}
+	return nil, nil
 }
 
 // laterEvent reports whether the event (occ, eventID) is strictly later than a reference event by event

--- a/internal/domain/endpoint/fold_b3b5.go
+++ b/internal/domain/endpoint/fold_b3b5.go
@@ -44,20 +44,7 @@ func (s *EndpointState) applyFile(env telemetry.TelemetryEnvelope) []TimelineEnt
 		ft.LastSeenAt = env.OccurredAt
 	}
 
-	entry, appended := s.timeline.append(TimelineEntry{
-		OccurredAt: env.OccurredAt,
-		TenantID:   s.tenantID,
-		AssetID:    s.assetID,
-		EntityKind: EntityFile,
-		EntityID:   id,
-		Kind:       fileTimelineKind(obs.Op),
-		EventID:    env.EventID,
-		Summary:    fileObsSummary(obs),
-	})
-	if !appended {
-		return nil
-	}
-	return []TimelineEntry{entry}
+	return s.appendTimeline(env)
 }
 
 // applyPrivilege folds a validated privilege envelope (B4). env is already telemetry-validated by Observe.
@@ -83,20 +70,7 @@ func (s *EndpointState) applyPrivilege(env telemetry.TelemetryEnvelope) []Timeli
 		OccurredAt:      env.OccurredAt,
 	})
 
-	entry, appended := s.timeline.append(TimelineEntry{
-		OccurredAt: env.OccurredAt,
-		TenantID:   s.tenantID,
-		AssetID:    s.assetID,
-		EntityKind: EntityIdentity,
-		EntityID:   obs.ProcessEntityID,
-		Kind:       TimelinePrivilegeChange,
-		EventID:    env.EventID,
-		Summary:    privilegeSummary(obs),
-	})
-	if !appended {
-		return nil
-	}
-	return []TimelineEntry{entry}
+	return s.appendTimeline(env)
 }
 
 // observeContainer inventories the container an event came from (B5), from the envelope's ResourceContext.

--- a/internal/domain/endpoint/timeline_projection_test.go
+++ b/internal/domain/endpoint/timeline_projection_test.go
@@ -1,0 +1,68 @@
+package endpoint
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+// TestTimelineEntriesForMatchesObserve is the drift guard: the stateless persistence projection must emit
+// exactly the timeline entries the live fold does, for every class — they share timelineEntryFor, and this
+// proves they never diverge.
+func TestTimelineEntriesForMatchesObserve(t *testing.T) {
+	proc := procEntityID(10, 1)
+	cases := map[string]telemetry.TelemetryEnvelope{
+		"process":   procEnv("e1", base, proc, "", 10, 1, "exec", "app", "/usr/bin/app", "app", "-x"),
+		"network":   netEnv("e2", base, proc, "tcp", "egress", "10.0.0.1", 1000, "1.2.3.4", 443),
+		"file":      fileEnv("e3", base, proc, "write", "/etc/x", 1, 2, ""),
+		"privilege": privEnv("e4", base, proc, "setuid", 1000, 0, ""),
+	}
+	for name, env := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := mustState(t)
+			observed, err := s.Observe(env)
+			if err != nil {
+				t.Fatalf("observe: %v", err)
+			}
+			projected, err := TimelineEntriesFor(testTenant, env)
+			if err != nil {
+				t.Fatalf("project: %v", err)
+			}
+			if len(observed) != 1 || len(projected) != 1 {
+				t.Fatalf("want one entry each, got observed=%d projected=%d", len(observed), len(projected))
+			}
+			if observed[0] != projected[0] {
+				t.Fatalf("projection drifted from fold:\n fold=%+v\n proj=%+v", observed[0], projected[0])
+			}
+		})
+	}
+}
+
+func TestTimelineEntriesForFailsClosed(t *testing.T) {
+	proc := procEntityID(10, 1)
+	valid := procEnv("e1", base, proc, "", 10, 1, "exec", "app", "/app")
+	if _, err := TimelineEntriesFor("", valid); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant must be rejected, got %v", err)
+	}
+	// Malformed envelope (schema 0) is rejected before any entry is built.
+	bad := valid
+	bad.SchemaVersion = 0
+	if _, err := TimelineEntriesFor(testTenant, bad); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("malformed envelope must be rejected, got %v", err)
+	}
+}
+
+// A container-carrying event still projects its own class entry (container inventory is cross-cutting, not
+// a class), so there is always exactly one entry for a valid envelope.
+func TestTimelineEntriesForContainerContextStillProjectsClassEntry(t *testing.T) {
+	env := procEnvRC("e1", base, procEntityID(1, 1), 1, telemetry.ResourceContext{ContainerID: "c1", ImageDigest: "img1"})
+	entries, err := TimelineEntriesFor(testTenant, env)
+	if err != nil || len(entries) != 1 || entries[0].EntityKind != EntityProcess {
+		t.Fatalf("want one process entry, got %d err=%v", len(entries), err)
+	}
+	if entries[0].EntityKind == EntityContainer {
+		t.Fatal("container context must not become a timeline entry")
+	}
+}

--- a/internal/infrastructure/persistence/memory/endpoint_timeline_store.go
+++ b/internal/infrastructure/persistence/memory/endpoint_timeline_store.go
@@ -1,0 +1,123 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// defaultEndpointTimelineLimit caps an unbounded QueryTimeline so a single call cannot return an
+// unbounded result set; mirrors the Postgres tier.
+const defaultEndpointTimelineLimit = 10000
+
+// EndpointTimelineStore is the in-memory twin of the durable endpoint State Timeline (Phase B / B7). It
+// is tenant-bucketed and idempotent by (tenant, asset, EventID), upholding the same contract as the
+// Postgres tier. Reached only through ports.EndpointTimelineStore.
+type EndpointTimelineStore struct {
+	mu sync.Mutex
+	// tenant -> asset -> eventID -> entry
+	entries map[shared.ID]map[shared.ID]map[shared.ID]endpoint.TimelineEntry
+}
+
+var _ ports.EndpointTimelineStore = (*EndpointTimelineStore)(nil)
+
+// NewEndpointTimelineStore creates an empty in-memory endpoint-timeline store.
+func NewEndpointTimelineStore() *EndpointTimelineStore {
+	return &EndpointTimelineStore{entries: make(map[shared.ID]map[shared.ID]map[shared.ID]endpoint.TimelineEntry)}
+}
+
+func requireEndpointTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: endpoint timeline operation requires a tenant in context", shared.ErrValidation)
+}
+
+// AppendTimeline persists the transitions idempotently, skipping any whose EventID is already stored for
+// its (tenant, asset). Every entry's TenantID must equal the context tenant.
+func (s *EndpointTimelineStore) AppendTimeline(ctx context.Context, list []endpoint.TimelineEntry) error {
+	tenant, err := requireEndpointTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if len(list) == 0 {
+		return nil
+	}
+	for _, e := range list {
+		if e.TenantID != tenant {
+			return fmt.Errorf("%w: timeline entry tenant %s does not match context tenant %s", shared.ErrValidation, e.TenantID, tenant)
+		}
+		if e.AssetID.IsZero() || e.EventID.IsZero() {
+			return fmt.Errorf("%w: timeline entry requires an asset id and event id", shared.ErrValidation)
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range list {
+		byAsset := s.entries[tenant]
+		if byAsset == nil {
+			byAsset = make(map[shared.ID]map[shared.ID]endpoint.TimelineEntry)
+			s.entries[tenant] = byAsset
+		}
+		byEvent := byAsset[e.AssetID]
+		if byEvent == nil {
+			byEvent = make(map[shared.ID]endpoint.TimelineEntry)
+			byAsset[e.AssetID] = byEvent
+		}
+		if _, exists := byEvent[e.EventID]; exists {
+			continue // idempotent: already recorded
+		}
+		byEvent[e.EventID] = e
+	}
+	return nil
+}
+
+// QueryTimeline returns the stored transitions matching q, ordered by (OccurredAt, EventID).
+func (s *EndpointTimelineStore) QueryTimeline(ctx context.Context, q ports.EndpointTimelineQuery) ([]endpoint.TimelineEntry, error) {
+	tenant, err := requireEndpointTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if q.AssetID.IsZero() {
+		return nil, fmt.Errorf("%w: timeline query requires an asset id", shared.ErrValidation)
+	}
+	s.mu.Lock()
+	byEvent := s.entries[tenant][q.AssetID]
+	out := make([]endpoint.TimelineEntry, 0, len(byEvent))
+	for _, e := range byEvent {
+		if !q.From.IsZero() && e.OccurredAt.Before(q.From) {
+			continue
+		}
+		if !q.To.IsZero() && e.OccurredAt.After(q.To) {
+			continue
+		}
+		if !q.EntityID.IsZero() && e.EntityID != q.EntityID {
+			continue
+		}
+		if q.Kind != "" && e.Kind != q.Kind {
+			continue
+		}
+		out = append(out, e)
+	}
+	s.mu.Unlock()
+
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].OccurredAt.Equal(out[j].OccurredAt) {
+			return out[i].OccurredAt.Before(out[j].OccurredAt)
+		}
+		return out[i].EventID < out[j].EventID
+	})
+	limit := q.Limit
+	if limit <= 0 || limit > defaultEndpointTimelineLimit {
+		limit = defaultEndpointTimelineLimit
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}

--- a/internal/infrastructure/persistence/memory/endpoint_timeline_store_test.go
+++ b/internal/infrastructure/persistence/memory/endpoint_timeline_store_test.go
@@ -1,0 +1,133 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	etTenant = shared.ID("tenant-et")
+	etAsset  = shared.ID("asset-et")
+)
+
+var etBase = time.Unix(1_800_000_000, 0).UTC()
+
+func etCtx(tenant shared.ID) context.Context {
+	return shared.WithTenant(context.Background(), tenant)
+}
+
+func entry(tenant, asset, eventID string, occ time.Time, kind endpoint.TimelineEntryKind, entityID string) endpoint.TimelineEntry {
+	return endpoint.TimelineEntry{
+		OccurredAt: occ, TenantID: shared.ID(tenant), AssetID: shared.ID(asset),
+		EntityKind: entityKindFor(kind), EntityID: shared.ID(entityID), Kind: kind,
+		EventID: shared.ID(eventID), Summary: eventID,
+	}
+}
+
+// entityKindFor keeps the test entries consistent with the entry kind.
+func entityKindFor(k endpoint.TimelineEntryKind) endpoint.EntityKind {
+	switch k {
+	case endpoint.TimelineNetworkConnect:
+		return endpoint.EntityNetwork
+	case endpoint.TimelinePrivilegeChange:
+		return endpoint.EntityIdentity
+	default:
+		return endpoint.EntityProcess
+	}
+}
+
+func TestEndpointTimelineAppendQueryAndIdempotency(t *testing.T) {
+	s := NewEndpointTimelineStore()
+	ctx := etCtx(etTenant)
+	// Append out of event-time order; query must return event-time order.
+	in := []endpoint.TimelineEntry{
+		entry(string(etTenant), string(etAsset), "c", etBase.Add(2*time.Second), endpoint.TimelineProcessExec, "pe1"),
+		entry(string(etTenant), string(etAsset), "a", etBase, endpoint.TimelineProcessStart, "pe1"),
+		entry(string(etTenant), string(etAsset), "b", etBase.Add(time.Second), endpoint.TimelineNetworkConnect, "nc1"),
+	}
+	if err := s.AppendTimeline(ctx, in); err != nil {
+		t.Fatal(err)
+	}
+	// Re-append the same events (idempotent) plus a duplicate of "a".
+	if err := s.AppendTimeline(ctx, in); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.QueryTimeline(ctx, ports.EndpointTimelineQuery{AssetID: etAsset})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("idempotent append must yield 3 entries, got %d", len(got))
+	}
+	if string(got[0].EventID) != "a" || string(got[1].EventID) != "b" || string(got[2].EventID) != "c" {
+		t.Fatalf("not event-time ordered: %v %v %v", got[0].EventID, got[1].EventID, got[2].EventID)
+	}
+}
+
+func TestEndpointTimelineQueryFilters(t *testing.T) {
+	s := NewEndpointTimelineStore()
+	ctx := etCtx(etTenant)
+	_ = s.AppendTimeline(ctx, []endpoint.TimelineEntry{
+		entry(string(etTenant), string(etAsset), "a", etBase, endpoint.TimelineProcessStart, "pe1"),
+		entry(string(etTenant), string(etAsset), "b", etBase.Add(time.Hour), endpoint.TimelineNetworkConnect, "nc1"),
+		entry(string(etTenant), string(etAsset), "c", etBase.Add(2*time.Hour), endpoint.TimelineProcessExec, "pe1"),
+	})
+	// Time window.
+	win, _ := s.QueryTimeline(ctx, ports.EndpointTimelineQuery{AssetID: etAsset, From: etBase.Add(30 * time.Minute), To: etBase.Add(90 * time.Minute)})
+	if len(win) != 1 || win[0].EventID != "b" {
+		t.Fatalf("time window filter wrong: %+v", win)
+	}
+	// Entity filter.
+	ent, _ := s.QueryTimeline(ctx, ports.EndpointTimelineQuery{AssetID: etAsset, EntityID: "pe1"})
+	if len(ent) != 2 {
+		t.Fatalf("entity filter wrong: %+v", ent)
+	}
+	// Kind filter.
+	kind, _ := s.QueryTimeline(ctx, ports.EndpointTimelineQuery{AssetID: etAsset, Kind: endpoint.TimelineNetworkConnect})
+	if len(kind) != 1 || kind[0].EventID != "b" {
+		t.Fatalf("kind filter wrong: %+v", kind)
+	}
+	// Limit.
+	lim, _ := s.QueryTimeline(ctx, ports.EndpointTimelineQuery{AssetID: etAsset, Limit: 2})
+	if len(lim) != 2 {
+		t.Fatalf("limit wrong: %+v", lim)
+	}
+}
+
+func TestEndpointTimelineTenantIsolationAndFailClosed(t *testing.T) {
+	s := NewEndpointTimelineStore()
+	other := shared.ID("tenant-other")
+	// Tenant A writes; tenant B must not see it.
+	if err := s.AppendTimeline(etCtx(etTenant), []endpoint.TimelineEntry{
+		entry(string(etTenant), string(etAsset), "a", etBase, endpoint.TimelineProcessStart, "pe1"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.QueryTimeline(etCtx(other), ports.EndpointTimelineQuery{AssetID: etAsset})
+	if len(got) != 0 {
+		t.Fatalf("cross-tenant read must see nothing, got %d", len(got))
+	}
+	// An entry whose tenant differs from the context tenant is rejected.
+	if err := s.AppendTimeline(etCtx(etTenant), []endpoint.TimelineEntry{
+		entry(string(other), string(etAsset), "x", etBase, endpoint.TimelineProcessStart, "pe1"),
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant write must be rejected, got %v", err)
+	}
+	// Missing tenant in context is rejected on both paths.
+	if err := s.AppendTimeline(context.Background(), nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("append without tenant must be rejected, got %v", err)
+	}
+	if _, err := s.QueryTimeline(context.Background(), ports.EndpointTimelineQuery{AssetID: etAsset}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("query without tenant must be rejected, got %v", err)
+	}
+	// Query requires an asset id.
+	if _, err := s.QueryTimeline(etCtx(etTenant), ports.EndpointTimelineQuery{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("query without asset must be rejected, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/endpoint_timeline_repo.go
+++ b/internal/infrastructure/persistence/postgres/endpoint_timeline_repo.go
@@ -1,0 +1,138 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// defaultEndpointTimelineLimit caps an unbounded QueryTimeline; mirrors the memory tier.
+const defaultEndpointTimelineLimit = 10000
+
+// EndpointTimelineRepository is the Postgres tier for the durable endpoint State Timeline (Phase B / B7).
+// Every method runs under the authenticated ctx tenant via WithContextTenant, so RLS binds the partition,
+// and reads carry an explicit tenant_id predicate as defense-in-depth. Appends are idempotent by
+// (tenant, asset, event_id). Reached only through ports.EndpointTimelineStore.
+type EndpointTimelineRepository struct {
+	pool *pgxpool.Pool
+}
+
+var _ ports.EndpointTimelineStore = (*EndpointTimelineRepository)(nil)
+
+// NewEndpointTimelineRepository constructs the endpoint-timeline store over a pgx pool.
+func NewEndpointTimelineRepository(pool *pgxpool.Pool) *EndpointTimelineRepository {
+	return &EndpointTimelineRepository{pool: pool}
+}
+
+func requireEndpointTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: endpoint timeline operation requires a tenant in context", shared.ErrValidation)
+}
+
+// AppendTimeline persists the transitions idempotently (ON CONFLICT DO NOTHING on the (tenant, asset,
+// event_id) key). Every entry's TenantID must equal the context tenant.
+func (r *EndpointTimelineRepository) AppendTimeline(ctx context.Context, list []endpoint.TimelineEntry) error {
+	tenant, err := requireEndpointTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if len(list) == 0 {
+		return nil
+	}
+	for _, e := range list {
+		if e.TenantID != tenant {
+			return fmt.Errorf("%w: timeline entry tenant %s does not match context tenant %s", shared.ErrValidation, e.TenantID, tenant)
+		}
+		if e.AssetID.IsZero() || e.EventID.IsZero() {
+			return fmt.Errorf("%w: timeline entry requires an asset id and event id", shared.ErrValidation)
+		}
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		for _, e := range list {
+			if _, err := tx.Exec(ctx, `INSERT INTO endpoint_timeline
+				(tenant_id, asset_id, event_id, occurred_at, entity_kind, entity_id, kind, summary)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+				ON CONFLICT (tenant_id, asset_id, event_id) DO NOTHING`,
+				tenant.String(), e.AssetID.String(), e.EventID.String(), e.OccurredAt,
+				string(e.EntityKind), e.EntityID.String(), string(e.Kind), e.Summary); err != nil {
+				return fmt.Errorf("append endpoint timeline entry: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+// QueryTimeline returns the stored transitions matching q, ordered by (occurred_at, event_id).
+func (r *EndpointTimelineRepository) QueryTimeline(ctx context.Context, q ports.EndpointTimelineQuery) ([]endpoint.TimelineEntry, error) {
+	tenant, err := requireEndpointTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if q.AssetID.IsZero() {
+		return nil, fmt.Errorf("%w: timeline query requires an asset id", shared.ErrValidation)
+	}
+	limit := q.Limit
+	if limit <= 0 || limit > defaultEndpointTimelineLimit {
+		limit = defaultEndpointTimelineLimit
+	}
+
+	sql := `SELECT event_id, occurred_at, entity_kind, entity_id, kind, summary FROM endpoint_timeline
+		WHERE tenant_id=$1 AND asset_id=$2`
+	args := []any{tenant.String(), q.AssetID.String()}
+	add := func(clause string, val any) {
+		args = append(args, val)
+		sql += " AND " + clause + "$" + strconv.Itoa(len(args))
+	}
+	if !q.From.IsZero() {
+		add("occurred_at >= ", q.From)
+	}
+	if !q.To.IsZero() {
+		add("occurred_at <= ", q.To)
+	}
+	if !q.EntityID.IsZero() {
+		add("entity_id = ", q.EntityID.String())
+	}
+	if q.Kind != "" {
+		add("kind = ", string(q.Kind))
+	}
+	args = append(args, limit)
+	// event_id ordered COLLATE "C" (bytewise) so the total order matches the memory twin's Go bytewise
+	// tiebreak regardless of the DB's default collation (house convention; see migration 0111).
+	sql += ` ORDER BY occurred_at, event_id COLLATE "C" LIMIT $` + strconv.Itoa(len(args))
+
+	var out []endpoint.TimelineEntry
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, sql, args...)
+		if err != nil {
+			return fmt.Errorf("query endpoint timeline: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			e := endpoint.TimelineEntry{TenantID: tenant, AssetID: q.AssetID}
+			var eventID, entityKind, entityID, kind, summary string
+			if err := rows.Scan(&eventID, &e.OccurredAt, &entityKind, &entityID, &kind, &summary); err != nil {
+				return fmt.Errorf("scan endpoint timeline row: %w", err)
+			}
+			e.EventID = shared.ID(eventID)
+			e.EntityKind = endpoint.EntityKind(entityKind)
+			e.EntityID = shared.ID(entityID)
+			e.Kind = endpoint.TimelineEntryKind(kind)
+			e.Summary = summary
+			out = append(out, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/infrastructure/persistence/postgres/endpoint_timeline_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/endpoint_timeline_repo_test.go
@@ -1,0 +1,137 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestEndpointTimelineRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenant := shared.ID("etl-" + id)
+	other := shared.ID("etl-other-" + id)
+	assetT := shared.ID("etl-asset-" + id)
+	assetO := shared.ID("etl-asset-other-" + id)
+	for _, tn := range []shared.ID{tenant, other} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tn.String()); err != nil {
+			t.Fatalf("seed tenant: %v", err)
+		}
+	}
+	seedAsset := func(a, tn shared.ID) {
+		if _, err := pool.Exec(ctx, `INSERT INTO fleet_assets(id,tenant_id,kind,"key",name) VALUES($1,$2,'host',$1,$1)`, a.String(), tn.String()); err != nil {
+			t.Fatalf("seed asset: %v", err)
+		}
+	}
+	seedAsset(assetT, tenant)
+	seedAsset(assetO, other)
+	t.Cleanup(func() {
+		bg := context.Background()
+		// endpoint_timeline is append-only (trigger); disable triggers on this one connection to clean up.
+		conn, err := pool.Acquire(bg)
+		if err != nil {
+			return
+		}
+		defer conn.Release()
+		if _, err := conn.Exec(bg, `SET session_replication_role = replica`); err != nil {
+			return
+		}
+		defer conn.Exec(bg, `SET session_replication_role = origin`)
+		for _, tn := range []shared.ID{tenant, other} {
+			_, _ = conn.Exec(bg, `DELETE FROM endpoint_timeline WHERE tenant_id=$1`, tn.String())
+			_, _ = conn.Exec(bg, `DELETE FROM fleet_assets WHERE tenant_id=$1`, tn.String())
+			_, _ = conn.Exec(bg, `DELETE FROM tenants WHERE id=$1`, tn.String())
+		}
+	})
+
+	repo := NewEndpointTimelineRepository(pool)
+	tctx := shared.WithTenant(ctx, tenant)
+	base := time.Unix(1_800_000_000, 0).UTC()
+
+	mk := func(eventID string, occ time.Time, kind endpoint.TimelineEntryKind, entity string) endpoint.TimelineEntry {
+		ek := endpoint.EntityProcess
+		if kind == endpoint.TimelineNetworkConnect {
+			ek = endpoint.EntityNetwork
+		}
+		return endpoint.TimelineEntry{
+			OccurredAt: occ, TenantID: tenant, AssetID: assetT,
+			EntityKind: ek, EntityID: shared.ID(entity), Kind: kind, EventID: shared.ID(eventID), Summary: eventID,
+		}
+	}
+	in := []endpoint.TimelineEntry{
+		mk("c", base.Add(2*time.Second), endpoint.TimelineProcessExec, "pe1"),
+		mk("a", base, endpoint.TimelineProcessStart, "pe1"),
+		mk("b", base.Add(time.Second), endpoint.TimelineNetworkConnect, "nc1"),
+	}
+	if err := repo.AppendTimeline(tctx, in); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	// Idempotent re-append.
+	if err := repo.AppendTimeline(tctx, in); err != nil {
+		t.Fatalf("re-append: %v", err)
+	}
+	got, err := repo.QueryTimeline(tctx, ports.EndpointTimelineQuery{AssetID: assetT})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 3 || got[0].EventID != "a" || got[1].EventID != "b" || got[2].EventID != "c" {
+		t.Fatalf("append/query not event-time ordered + idempotent: %+v", got)
+	}
+	if got[0].EntityID != "pe1" || got[0].Kind != endpoint.TimelineProcessStart || got[0].Summary != "a" {
+		t.Fatalf("row round-trip wrong: %+v", got[0])
+	}
+
+	// Filters.
+	if win, _ := repo.QueryTimeline(tctx, ports.EndpointTimelineQuery{AssetID: assetT, From: base.Add(500 * time.Millisecond), To: base.Add(1500 * time.Millisecond)}); len(win) != 1 || win[0].EventID != "b" {
+		t.Fatalf("time window filter wrong: %+v", win)
+	}
+	if k, _ := repo.QueryTimeline(tctx, ports.EndpointTimelineQuery{AssetID: assetT, Kind: endpoint.TimelineNetworkConnect}); len(k) != 1 || k[0].EventID != "b" {
+		t.Fatalf("kind filter wrong: %+v", k)
+	}
+	if e, _ := repo.QueryTimeline(tctx, ports.EndpointTimelineQuery{AssetID: assetT, EntityID: "pe1"}); len(e) != 2 {
+		t.Fatalf("entity filter wrong: %+v", e)
+	}
+	if l, _ := repo.QueryTimeline(tctx, ports.EndpointTimelineQuery{AssetID: assetT, Limit: 2}); len(l) != 2 {
+		t.Fatalf("limit wrong: %+v", l)
+	}
+
+	// Cross-tenant isolation: the other tenant's context sees nothing for this asset (RLS + predicate).
+	octx := shared.WithTenant(ctx, other)
+	if o, err := repo.QueryTimeline(octx, ports.EndpointTimelineQuery{AssetID: assetT}); err != nil || len(o) != 0 {
+		t.Fatalf("cross-tenant read must see nothing, got %d err=%v", len(o), err)
+	}
+	// A cross-tenant entry is rejected before any write.
+	if err := repo.AppendTimeline(tctx, []endpoint.TimelineEntry{{
+		OccurredAt: base, TenantID: other, AssetID: assetT, EntityKind: endpoint.EntityProcess,
+		EntityID: "pe1", Kind: endpoint.TimelineProcessStart, EventID: "x", Summary: "x",
+	}}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant write must be rejected, got %v", err)
+	}
+
+	// The timeline is append-only (chain-of-custody): a direct UPDATE or DELETE is refused by the trigger.
+	if _, err := pool.Exec(ctx, `UPDATE endpoint_timeline SET summary='tampered' WHERE tenant_id=$1`, tenant.String()); err == nil {
+		t.Fatal("UPDATE on the append-only timeline must be rejected")
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM endpoint_timeline WHERE tenant_id=$1`, tenant.String()); err == nil {
+		t.Fatal("DELETE on the append-only timeline must be rejected")
+	}
+}

--- a/internal/usecase/fleet/endpointstate/service.go
+++ b/internal/usecase/fleet/endpointstate/service.go
@@ -1,0 +1,57 @@
+// Package endpointstate is the usecase seam over the endpoint State Timeline (Phase B / B7, #669). It
+// projects normalized telemetry envelopes into durable, queryable endpoint transitions that Phase C
+// correlation and retro-hunt read. It is stateless: the timeline projection is a pure per-envelope
+// function (endpoint.TimelineEntriesFor), so the service holds no per-asset aggregate and is safe to run
+// N-way; durability + idempotency live in the store.
+package endpointstate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Service records endpoint transitions from telemetry and answers timeline queries. It is tenant-scoped
+// from the context on every call.
+type Service struct {
+	store ports.EndpointTimelineStore
+}
+
+// NewService constructs the service over an endpoint-timeline store.
+func NewService(store ports.EndpointTimelineStore) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("%w: endpoint state service requires a timeline store", shared.ErrValidation)
+	}
+	return &Service{store: store}, nil
+}
+
+// Record projects one telemetry envelope into the State Timeline and persists the resulting transition(s)
+// idempotently, returning what it recorded (empty for a class with no transition, e.g. a container-only
+// event). It is fail-closed: a missing tenant or a malformed envelope is rejected before any write. A
+// re-delivered envelope is a no-op at the store (deduped by EventID), so Record is safe to retry.
+func (s *Service) Record(ctx context.Context, env telemetry.TelemetryEnvelope) ([]endpoint.TimelineEntry, error) {
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok || tenant == "" {
+		return nil, fmt.Errorf("%w: recording endpoint telemetry requires a tenant in context", shared.ErrValidation)
+	}
+	entries, err := endpoint.TimelineEntriesFor(tenant, env)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	if err := s.store.AppendTimeline(ctx, entries); err != nil {
+		return nil, fmt.Errorf("persist endpoint timeline: %w", err)
+	}
+	return entries, nil
+}
+
+// Query returns the stored State Timeline window matching q, ordered by (OccurredAt, EventID).
+func (s *Service) Query(ctx context.Context, q ports.EndpointTimelineQuery) ([]endpoint.TimelineEntry, error) {
+	return s.store.QueryTimeline(ctx, q)
+}

--- a/internal/usecase/fleet/endpointstate/service_test.go
+++ b/internal/usecase/fleet/endpointstate/service_test.go
@@ -1,0 +1,110 @@
+package endpointstate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	svcTenant = shared.ID("tenant-s")
+	svcAsset  = shared.ID("asset-s")
+)
+
+var svcBase = time.Unix(1_800_000_000, 0).UTC()
+
+func procEnv(eventID string, occ time.Time, entityID shared.ID) telemetry.TelemetryEnvelope {
+	return telemetry.TelemetryEnvelope{
+		SchemaVersion: telemetry.SchemaVersion,
+		EventID:       shared.ID(eventID),
+		EventType:     "process.exec",
+		EventClass:    detection.ClassProcess,
+		AgentID:       shared.ID("agent-s"), AssetID: svcAsset, BootID: shared.ID("boot-s"),
+		OccurredAt: occ, ObservedAt: occ,
+		Event: telemetry.TelemetryEvent{Class: detection.ClassProcess, Process: &telemetry.ProcessObservation{
+			Kind: "exec", PID: 100, EntityID: entityID, Comm: "app", Path: "/usr/bin/app",
+		}},
+	}
+}
+
+func newService(t *testing.T) (*Service, context.Context) {
+	t.Helper()
+	svc, err := NewService(memory.NewEndpointTimelineStore())
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return svc, shared.WithTenant(context.Background(), svcTenant)
+}
+
+func TestNewServiceRequiresStore(t *testing.T) {
+	if _, err := NewService(nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("nil store must be rejected, got %v", err)
+	}
+}
+
+func TestRecordPersistsAndIsIdempotent(t *testing.T) {
+	svc, ctx := newService(t)
+	env := procEnv("e1", svcBase, shared.ID("pe1"))
+	rec, err := svc.Record(ctx, env)
+	if err != nil || len(rec) != 1 {
+		t.Fatalf("record: entries=%d err=%v", len(rec), err)
+	}
+	// Re-record the same envelope: no duplicate persisted.
+	if _, err := svc.Record(ctx, env); err != nil {
+		t.Fatal(err)
+	}
+	got, err := svc.Query(ctx, ports.EndpointTimelineQuery{AssetID: svcAsset})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].EventID != "e1" || got[0].EntityID != "pe1" {
+		t.Fatalf("query after idempotent record wrong: %+v", got)
+	}
+}
+
+func TestRecordFailsClosed(t *testing.T) {
+	svc, ctx := newService(t)
+	// Missing tenant.
+	if _, err := svc.Record(context.Background(), procEnv("e1", svcBase, "pe1")); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant must be rejected, got %v", err)
+	}
+	// Malformed envelope (no schema version).
+	bad := procEnv("e2", svcBase, "pe1")
+	bad.SchemaVersion = 0
+	if _, err := svc.Record(ctx, bad); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("malformed envelope must be rejected, got %v", err)
+	}
+	// Nothing was persisted by the rejected calls.
+	got, _ := svc.Query(ctx, ports.EndpointTimelineQuery{AssetID: svcAsset})
+	if len(got) != 0 {
+		t.Fatalf("rejected records must persist nothing, got %d", len(got))
+	}
+}
+
+func TestRecordMultipleClassesQueryable(t *testing.T) {
+	svc, ctx := newService(t)
+	mustRecord(t, svc, ctx, procEnv("e1", svcBase, shared.ID("pe1")))
+	// A second process event at a later time.
+	mustRecord(t, svc, ctx, procEnv("e2", svcBase.Add(time.Second), shared.ID("pe2")))
+	got, err := svc.Query(ctx, ports.EndpointTimelineQuery{AssetID: svcAsset})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].EventID != "e1" || got[1].EventID != "e2" {
+		t.Fatalf("query wrong: %+v", got)
+	}
+}
+
+func mustRecord(t *testing.T, svc *Service, ctx context.Context, env telemetry.TelemetryEnvelope) {
+	t.Helper()
+	if _, err := svc.Record(ctx, env); err != nil {
+		t.Fatalf("record %s: %v", env.EventID, err)
+	}
+}

--- a/internal/usecase/ports/endpoint_store.go
+++ b/internal/usecase/ports/endpoint_store.go
@@ -1,0 +1,42 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// EndpointTimelineStore persists the durable, per-asset endpoint State Timeline (Phase B / B7, #669),
+// the append-only, event-time-ordered log of endpoint transitions (process/network/file/privilege) that
+// Phase C correlation and retro-hunt read after the raw telemetry that produced them has expired. It is
+// deliberately separate from the columnar TelemetryStore and the transport-sequencing store: it holds the
+// projected transitions, not raw events or delivery bookkeeping.
+//
+// Every method is tenant-scoped from the context (never a caller-supplied field); the store is the durable
+// home for endpoint.TimelineEntry values produced by endpoint.TimelineEntriesFor / EndpointState.Observe.
+type EndpointTimelineStore interface {
+	// AppendTimeline persists the given transitions idempotently: an entry whose EventID is already stored
+	// for its (tenant, asset) is silently skipped, so a re-delivered or replayed envelope never duplicates
+	// a transition. Every entry's TenantID must equal the context tenant, else it fails closed with
+	// shared.ErrValidation (no cross-tenant write). Appending zero entries is a no-op.
+	AppendTimeline(ctx context.Context, entries []endpoint.TimelineEntry) error
+	// QueryTimeline returns the stored transitions matching the query, ordered by (OccurredAt, EventID
+	// bytewise) — the SAME total order the in-memory timeline uses — so a persisted read reads back in the
+	// same order as the in-memory projection. It is tenant-scoped from the context.
+	QueryTimeline(ctx context.Context, q EndpointTimelineQuery) ([]endpoint.TimelineEntry, error)
+}
+
+// EndpointTimelineQuery selects a window of the State Timeline. AssetID is required (the timeline is
+// per-asset); the rest are optional filters. A zero From/To is unbounded on that side; an empty EntityID
+// or Kind does not filter on that field. Limit caps the number of rows returned (0 means the store's
+// default cap); results are always ordered by (OccurredAt, EventID).
+type EndpointTimelineQuery struct {
+	AssetID  shared.ID
+	From     time.Time
+	To       time.Time
+	EntityID shared.ID
+	Kind     endpoint.TimelineEntryKind
+	Limit    int
+}

--- a/migrations/0111_endpoint_timeline.sql
+++ b/migrations/0111_endpoint_timeline.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- Phase B / B7 (#669): the durable, per-asset endpoint State Timeline — the append-only, event-time
+-- ordered log of endpoint transitions (process/network/file/privilege) that Phase C correlation and
+-- retro-hunt read after the raw telemetry that produced them has expired. It holds projected transitions,
+-- not raw events (that is the columnar telemetry store) nor delivery bookkeeping (the transport store).
+CREATE TABLE endpoint_timeline (
+    tenant_id   TEXT NOT NULL REFERENCES tenants(id),
+    asset_id    TEXT NOT NULL,
+    event_id    TEXT NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    entity_kind TEXT NOT NULL CHECK (entity_kind IN ('process','network','file','identity','container')),
+    entity_id   TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    summary     TEXT NOT NULL,
+    -- One envelope projects to at most one transition, so (tenant, asset, event_id) is the idempotency
+    -- key: a re-delivered or replayed envelope is a no-op insert.
+    PRIMARY KEY (tenant_id, asset_id, event_id),
+    FOREIGN KEY (tenant_id, asset_id) REFERENCES fleet_assets(tenant_id, id)
+);
+-- Event-time reads for a window on one asset (the retro-hunt access pattern); event_id makes the order
+-- total and matches the in-memory (OccurredAt, EventID) tiebreak. event_id is ordered with COLLATE "C"
+-- (bytewise) so the SQL order is identical to the Go bytewise tiebreak regardless of the DB's default
+-- collation — the same house convention migrations 0047/0052/0054/0107 use for id tiebreaks.
+CREATE INDEX idx_endpoint_timeline_window
+    ON endpoint_timeline (tenant_id, asset_id, occurred_at, event_id COLLATE "C");
+-- Pivot from one entity to its transitions.
+CREATE INDEX idx_endpoint_timeline_entity
+    ON endpoint_timeline (tenant_id, asset_id, entity_id, occurred_at);
+CALL synapse_enable_tenant_rls('endpoint_timeline');
+
+-- The State Timeline is a chain-of-custody substrate Phase C reads: append-only (golden rule 6), matching
+-- the evidence/audit tables. synapse_forbid_mutation is defined in migration 0033.
+CREATE TRIGGER endpoint_timeline_append_only
+    BEFORE UPDATE OR DELETE ON endpoint_timeline
+    FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER endpoint_timeline_no_truncate
+    BEFORE TRUNCATE ON endpoint_timeline
+    FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS endpoint_timeline_no_truncate ON endpoint_timeline;
+DROP TRIGGER IF EXISTS endpoint_timeline_append_only ON endpoint_timeline;
+DROP TABLE endpoint_timeline;


### PR DESCRIPTION
## Persist the endpoint State Timeline — Phase B tail (#665–#669)

Adds the durable, tenant-scoped, **append-only** persistence for the Phase B endpoint State Timeline (EDR epic #594) — the log of endpoint transitions (process/network/file/privilege) that Phase C correlation and retro-hunt read after the raw telemetry that produced them has expired. This is the buildable **persistence tail** of the Phase B issues (the domain projections landed in #670/#671); eBPF collection and the HTTP/cmd read surface (the Phase-C consumer) remain deferred.

### What's in it
- **domain**: a single pure `timelineEntryFor` builder now feeds BOTH the live fold (`EndpointState.Observe`) and a new stateless `endpoint.TimelineEntriesFor`, so a persisted timeline can never drift from the in-memory one (guarded by `TestTimelineEntriesForMatchesObserve`).
- **`ports.EndpointTimelineStore`** + `EndpointTimelineQuery` (consumer-side): append idempotent by `(tenant, asset, event_id)`; query a window by asset/time/entity/kind.
- **memory + postgres twins** with identical behavior (idempotency, `(occurred_at, event_id)` ordering, filters, 10000 default cap, tenant-from-context fail-closed, cross-tenant reject).
- **migration 0111**: tenant RLS; composite FK to `fleet_assets` (no cross-tenant asset reference); **append-only triggers** (golden rule 6, matching evidence/audit); `event_id` ordered/indexed `COLLATE "C"` so the SQL total order matches the Go bytewise tiebreak regardless of DB collation.
- **`endpointstate.Service`**: stateless (no per-asset aggregate, safe N-way) — `Record` projects one envelope + persists idempotently; `Query` reads back.

### Review
Dual-reviewed. **go-arch: MERGEABLE** (dependency rule PASS, twin parity, single-source refactor preserved the reorder-invariant folds). **security: SHIP** (tenant isolation, no SQL injection in the dynamic query builder, idempotency, fail-closed, deterministic order — all enforced in code, not just tested). Their non-blocking items are folded in **here**: a DB-level append-only trigger (+ a rejection test), `COLLATE "C"` ordering/index, and an unexported test helper.

### Verification (CI off — validated locally)
Pure/portable; `go build`/`go vet`/`gofmt -l` clean; memory + service + domain tests race-green; the postgres integration test passes on a fresh DB with RLS + append-only enforcement + cross-tenant isolation + idempotency + ordering + filters asserted (migration 0111 applies cleanly).

### Scope / follow-ups
Persists the State Timeline (which B3/B4 file/privilege transitions + B1/B2 all feed). Entity-snapshot persistence (processes/connections/files/containers incl. B5 inventory) and the HTTP/cmd read surface are the next tails; **#665–#669 stay open** for those and for eBPF collection.
