### PR TITLE
feat(incident): add event-sourced runtime Incident core (#674)

### DIFF
--- a/internal/domain/incident/doc.go
+++ b/internal/domain/incident/doc.go
@@ -1,0 +1,9 @@
+// Package incident owns the event-sourced runtime Incident aggregate for Phase C of the security data
+// plane (#638). It is deliberately pure domain code: correlation decides which detections belong to an
+// incident, stores append the immutable events, and this package validates commands and reconstructs the
+// authoritative projection without I/O or a clock of its own.
+//
+// This aggregate is distinct from detection.Incident, which is a read-only rule/asset rollup. A runtime
+// Incident has an auditable lifecycle, an independent analyst disposition, optimistic revisions, and
+// append-only links to the detections that support it.
+package incident

--- a/internal/domain/incident/event.go
+++ b/internal/domain/incident/event.go
@@ -1,0 +1,158 @@
+package incident
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	maxActorBytes     = 256
+	maxRationaleRunes = 4000
+)
+
+// EventKind identifies the one mutation an immutable IncidentEvent applies.
+type EventKind string
+
+const (
+	EventCreated            EventKind = "incident_created"
+	EventStateChanged       EventKind = "incident_state_changed"
+	EventDispositionChanged EventKind = "incident_disposition_changed"
+	EventDetectionLinked    EventKind = "incident_detection_linked"
+)
+
+// Valid reports whether k is a supported event kind.
+func (k EventKind) Valid() bool {
+	switch k {
+	case EventCreated, EventStateChanged, EventDispositionChanged, EventDetectionLinked:
+		return true
+	default:
+		return false
+	}
+}
+
+// IncidentEvent is one immutable append to an Incident stream. Revision is the aggregate sequence,
+// OccurredAt is event time, and RecordedAt is control-plane append time. A late detection may therefore
+// have an OccurredAt older than earlier revisions while RecordedAt remains monotonic.
+//
+// The payload is discriminated by Kind and validated strictly: unused typed fields must be zero so an
+// adapter cannot persist ambiguous state and later interpret it differently.
+type IncidentEvent struct {
+	ID           shared.ID
+	IncidentID   shared.ID
+	TenantID     shared.ID
+	EngagementID shared.ID
+	AssetID      shared.ID
+	Revision     uint64
+	Kind         EventKind
+	Actor        string
+	Rationale    string
+	OccurredAt   time.Time
+	RecordedAt   time.Time
+
+	FromState       State
+	ToState         State
+	FromDisposition Disposition
+	ToDisposition   Disposition
+	DetectionID     shared.ID
+}
+
+// Validate rejects malformed, ambiguous, or unauthorized event material before it reaches a stream.
+func (e IncidentEvent) Validate() error {
+	if e.ID.IsZero() || e.IncidentID.IsZero() || e.TenantID.IsZero() ||
+		e.EngagementID.IsZero() || e.AssetID.IsZero() {
+		return fmt.Errorf("%w: incident event identity and scope are required", shared.ErrValidation)
+	}
+	if e.Revision == 0 {
+		return fmt.Errorf("%w: incident event revision must be positive", shared.ErrValidation)
+	}
+	if !e.Kind.Valid() {
+		return fmt.Errorf("%w: unknown incident event kind %q", shared.ErrValidation, e.Kind)
+	}
+	if err := validateActor(e.Actor); err != nil {
+		return err
+	}
+	if err := validateRationale(e.Rationale, e.Kind == EventStateChanged || e.Kind == EventDispositionChanged); err != nil {
+		return err
+	}
+	if e.OccurredAt.IsZero() || e.RecordedAt.IsZero() {
+		return fmt.Errorf("%w: incident event timestamps are required", shared.ErrValidation)
+	}
+	if e.OccurredAt.After(e.RecordedAt) {
+		return fmt.Errorf("%w: incident event occurred-at is after recorded-at", shared.ErrValidation)
+	}
+
+	switch e.Kind {
+	case EventCreated:
+		if e.Revision != 1 || e.FromState != "" || e.ToState != StateNew ||
+			e.FromDisposition != "" || e.ToDisposition != DispositionUnknown || e.DetectionID.IsZero() {
+			return fmt.Errorf("%w: incident-created payload is invalid", shared.ErrValidation)
+		}
+	case EventStateChanged:
+		if !e.FromState.CanTransitionTo(e.ToState) || e.FromDisposition != "" ||
+			e.ToDisposition != "" || !e.DetectionID.IsZero() {
+			return fmt.Errorf("%w: %w: cannot transition from %q to %q", shared.ErrValidation, ErrInvalidTransition, e.FromState, e.ToState)
+		}
+	case EventDispositionChanged:
+		if !e.FromDisposition.Valid() || !e.ToDisposition.Valid() || e.FromDisposition == e.ToDisposition ||
+			e.FromState != "" || e.ToState != "" || !e.DetectionID.IsZero() {
+			return fmt.Errorf("%w: incident disposition-change payload is invalid", shared.ErrValidation)
+		}
+		if shared.IsMachineActor(e.Actor) {
+			return fmt.Errorf("%w: incident disposition requires a human principal", shared.ErrForbidden)
+		}
+	case EventDetectionLinked:
+		if e.DetectionID.IsZero() || e.FromState != "" || e.ToState != "" ||
+			e.FromDisposition != "" || e.ToDisposition != "" {
+			return fmt.Errorf("%w: incident detection-link payload is invalid", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func validateActor(actor string) error {
+	if actor == "" || actor != strings.TrimSpace(actor) || len(actor) > maxActorBytes || !utf8.ValidString(actor) {
+		return fmt.Errorf("%w: incident event actor is required, canonical UTF-8, and at most %d bytes", shared.ErrValidation, maxActorBytes)
+	}
+	return nil
+}
+
+func validateRationale(rationale string, required bool) error {
+	if rationale != strings.TrimSpace(rationale) || !utf8.ValidString(rationale) {
+		return fmt.Errorf("%w: incident event rationale must be canonical UTF-8", shared.ErrValidation)
+	}
+	runes := []rune(rationale)
+	if required && len(runes) < 3 {
+		return fmt.Errorf("%w: incident event rationale must be at least 3 characters", shared.ErrValidation)
+	}
+	if len(runes) > maxRationaleRunes {
+		return fmt.Errorf("%w: incident event rationale exceeds %d characters", shared.ErrValidation, maxRationaleRunes)
+	}
+	for _, r := range runes {
+		if r < 32 && r != '\n' && r != '\t' {
+			return fmt.Errorf("%w: incident event rationale contains a control character", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func canonicalEvent(e IncidentEvent) IncidentEvent {
+	e.OccurredAt = e.OccurredAt.UTC()
+	e.RecordedAt = e.RecordedAt.UTC()
+	return e
+}
+
+// Equal reports exact semantic equality, including identity, payload, attribution, and both timestamps.
+// Rebuild uses it to distinguish an idempotent EventID retry from a conflicting replay.
+func (e IncidentEvent) Equal(other IncidentEvent) bool {
+	return e.ID == other.ID && e.IncidentID == other.IncidentID && e.TenantID == other.TenantID &&
+		e.EngagementID == other.EngagementID && e.AssetID == other.AssetID && e.Revision == other.Revision &&
+		e.Kind == other.Kind && e.Actor == other.Actor && e.Rationale == other.Rationale &&
+		e.OccurredAt.Equal(other.OccurredAt) && e.RecordedAt.Equal(other.RecordedAt) &&
+		e.FromState == other.FromState && e.ToState == other.ToState &&
+		e.FromDisposition == other.FromDisposition && e.ToDisposition == other.ToDisposition &&
+		e.DetectionID == other.DetectionID
+}

--- a/internal/domain/incident/incident.go
+++ b/internal/domain/incident/incident.go
@@ -1,0 +1,350 @@
+package incident
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Incident is the current projection of an immutable IncidentEvent stream.
+type Incident struct {
+	ID           shared.ID
+	TenantID     shared.ID
+	EngagementID shared.ID
+	AssetID      shared.ID
+	State        State
+	Disposition  Disposition
+	Revision     uint64
+	DetectionIDs []shared.ID
+	FirstEventAt time.Time
+	LastEventAt  time.Time
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	LastEventID  shared.ID
+}
+
+// IncidentRevision is an immutable projection snapshot immediately after one event was applied. It pins
+// later risk assessments and investigations to the exact state and evidence membership they consumed.
+type IncidentRevision struct {
+	IncidentID      shared.ID
+	TenantID        shared.ID
+	EngagementID    shared.ID
+	AssetID         shared.ID
+	Revision        uint64
+	EventID         shared.ID
+	EventKind       EventKind
+	State           State
+	Disposition     Disposition
+	DetectionIDs    []shared.ID
+	FirstEventAt    time.Time
+	LastEventAt     time.Time
+	EventOccurredAt time.Time
+	RecordedAt      time.Time
+}
+
+// Validate enforces a self-contained revision snapshot suitable for persistence or risk-input pinning.
+func (r IncidentRevision) Validate() error {
+	if r.IncidentID.IsZero() || r.TenantID.IsZero() || r.EngagementID.IsZero() || r.AssetID.IsZero() || r.EventID.IsZero() {
+		return fmt.Errorf("%w: incident revision identity and scope are required", shared.ErrValidation)
+	}
+	if r.Revision == 0 || !r.EventKind.Valid() || !r.State.Valid() || !r.Disposition.Valid() {
+		return fmt.Errorf("%w: incident revision lifecycle is invalid", shared.ErrValidation)
+	}
+	if r.FirstEventAt.IsZero() || r.LastEventAt.IsZero() || r.EventOccurredAt.IsZero() || r.RecordedAt.IsZero() ||
+		r.LastEventAt.Before(r.FirstEventAt) || r.LastEventAt.After(r.RecordedAt) ||
+		r.EventOccurredAt.Before(r.FirstEventAt) || r.EventOccurredAt.After(r.LastEventAt) ||
+		r.EventOccurredAt.After(r.RecordedAt) {
+		return fmt.Errorf("%w: incident revision timestamps are invalid", shared.ErrValidation)
+	}
+	if err := validateDetectionIDs(r.DetectionIDs); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CreateCommand carries platform-generated identity and timestamps for the first stream event. An
+// Incident starts with one detection: empty, evidence-free incidents are not valid runtime facts.
+type CreateCommand struct {
+	EventID, IncidentID, TenantID, EngagementID, AssetID shared.ID
+	DetectionID                                          shared.ID
+	Actor, Rationale                                     string
+	OccurredAt, RecordedAt                               time.Time
+}
+
+// StateTransitionCommand changes only lifecycle State at ExpectedRevision.
+type StateTransitionCommand struct {
+	EventID          shared.ID
+	To               State
+	Actor, Rationale string
+	ExpectedRevision uint64
+	OccurredAt       time.Time
+	RecordedAt       time.Time
+}
+
+// DispositionCommand records a human analyst classification without changing lifecycle State.
+type DispositionCommand struct {
+	EventID          shared.ID
+	To               Disposition
+	Actor, Rationale string
+	ExpectedRevision uint64
+	OccurredAt       time.Time
+	RecordedAt       time.Time
+}
+
+// LinkDetectionCommand appends one unique supporting detection to an Incident.
+type LinkDetectionCommand struct {
+	EventID, DetectionID shared.ID
+	Actor, Rationale     string
+	ExpectedRevision     uint64
+	OccurredAt           time.Time
+	RecordedAt           time.Time
+}
+
+// Create validates and applies the first event in an Incident stream.
+func Create(cmd CreateCommand) (Incident, IncidentEvent, error) {
+	e := canonicalEvent(IncidentEvent{
+		ID: cmd.EventID, IncidentID: cmd.IncidentID, TenantID: cmd.TenantID,
+		EngagementID: cmd.EngagementID, AssetID: cmd.AssetID, Revision: 1, Kind: EventCreated,
+		Actor: cmd.Actor, Rationale: cmd.Rationale, OccurredAt: cmd.OccurredAt, RecordedAt: cmd.RecordedAt,
+		ToState: StateNew, ToDisposition: DispositionUnknown, DetectionID: cmd.DetectionID,
+	})
+	if err := e.Validate(); err != nil {
+		return Incident{}, IncidentEvent{}, err
+	}
+	current := applyCreated(e)
+	if err := current.Validate(); err != nil {
+		return Incident{}, IncidentEvent{}, err
+	}
+	return current, e, nil
+}
+
+// TransitionState validates optimistic concurrency and applies one lifecycle event.
+func (i Incident) TransitionState(cmd StateTransitionCommand) (Incident, IncidentEvent, error) {
+	if err := i.validateCommandRevision(cmd.ExpectedRevision); err != nil {
+		return Incident{}, IncidentEvent{}, err
+	}
+	e := canonicalEvent(IncidentEvent{
+		ID: cmd.EventID, IncidentID: i.ID, TenantID: i.TenantID, EngagementID: i.EngagementID,
+		AssetID: i.AssetID, Revision: i.Revision + 1, Kind: EventStateChanged,
+		Actor: cmd.Actor, Rationale: cmd.Rationale, OccurredAt: cmd.OccurredAt, RecordedAt: cmd.RecordedAt,
+		FromState: i.State, ToState: cmd.To,
+	})
+	return i.applyCommand(e)
+}
+
+// SetDisposition records a human analyst classification and leaves State untouched.
+func (i Incident) SetDisposition(cmd DispositionCommand) (Incident, IncidentEvent, error) {
+	if err := i.validateCommandRevision(cmd.ExpectedRevision); err != nil {
+		return Incident{}, IncidentEvent{}, err
+	}
+	e := canonicalEvent(IncidentEvent{
+		ID: cmd.EventID, IncidentID: i.ID, TenantID: i.TenantID, EngagementID: i.EngagementID,
+		AssetID: i.AssetID, Revision: i.Revision + 1, Kind: EventDispositionChanged,
+		Actor: cmd.Actor, Rationale: cmd.Rationale, OccurredAt: cmd.OccurredAt, RecordedAt: cmd.RecordedAt,
+		FromDisposition: i.Disposition, ToDisposition: cmd.To,
+	})
+	return i.applyCommand(e)
+}
+
+// LinkDetection appends a unique evidence link. The link never replaces or removes existing membership.
+func (i Incident) LinkDetection(cmd LinkDetectionCommand) (Incident, IncidentEvent, error) {
+	if err := i.validateCommandRevision(cmd.ExpectedRevision); err != nil {
+		return Incident{}, IncidentEvent{}, err
+	}
+	if containsID(i.DetectionIDs, cmd.DetectionID) {
+		return Incident{}, IncidentEvent{}, fmt.Errorf("%w: detection %s is already linked to incident %s", shared.ErrConflict, cmd.DetectionID, i.ID)
+	}
+	e := canonicalEvent(IncidentEvent{
+		ID: cmd.EventID, IncidentID: i.ID, TenantID: i.TenantID, EngagementID: i.EngagementID,
+		AssetID: i.AssetID, Revision: i.Revision + 1, Kind: EventDetectionLinked,
+		Actor: cmd.Actor, Rationale: cmd.Rationale, OccurredAt: cmd.OccurredAt, RecordedAt: cmd.RecordedAt,
+		DetectionID: cmd.DetectionID,
+	})
+	return i.applyCommand(e)
+}
+
+func (i Incident) validateCommandRevision(expected uint64) error {
+	if err := i.Validate(); err != nil {
+		return err
+	}
+	if expected != i.Revision {
+		return fmt.Errorf("%w: incident revision changed (expected %d, current %d)", shared.ErrConflict, expected, i.Revision)
+	}
+	return nil
+}
+
+func (i Incident) applyCommand(e IncidentEvent) (Incident, IncidentEvent, error) {
+	if err := e.Validate(); err != nil {
+		return Incident{}, IncidentEvent{}, err
+	}
+	next, err := i.applyNext(e)
+	if err != nil {
+		return Incident{}, IncidentEvent{}, err
+	}
+	return next, e, nil
+}
+
+// Rebuild validates an unordered collection of stream events, removes exact EventID retries, orders the
+// unique events by revision, and reconstructs both the current Incident and every immutable revision.
+// Conflicting retries, revision gaps/duplicates, cross-scope events, and stale from-values fail closed.
+func Rebuild(events []IncidentEvent) (Incident, []IncidentRevision, error) {
+	if len(events) == 0 {
+		return Incident{}, nil, fmt.Errorf("%w: incident event stream is empty", shared.ErrValidation)
+	}
+	unique := make([]IncidentEvent, 0, len(events))
+	seen := make(map[shared.ID]IncidentEvent, len(events))
+	for _, raw := range events {
+		e := canonicalEvent(raw)
+		if err := e.Validate(); err != nil {
+			return Incident{}, nil, fmt.Errorf("incident event %s: %w", e.ID, err)
+		}
+		if previous, ok := seen[e.ID]; ok {
+			if !previous.Equal(e) {
+				return Incident{}, nil, fmt.Errorf("%w: incident event id %s was replayed with different material", shared.ErrConflict, e.ID)
+			}
+			continue
+		}
+		seen[e.ID] = e
+		unique = append(unique, e)
+	}
+	sort.Slice(unique, func(a, b int) bool {
+		if unique[a].Revision != unique[b].Revision {
+			return unique[a].Revision < unique[b].Revision
+		}
+		return unique[a].ID < unique[b].ID
+	})
+	if unique[0].Kind != EventCreated || unique[0].Revision != 1 {
+		return Incident{}, nil, fmt.Errorf("%w: incident stream must begin with revision 1 incident-created", shared.ErrConflict)
+	}
+
+	current := applyCreated(unique[0])
+	revisions := []IncidentRevision{snapshot(current, unique[0])}
+	for _, e := range unique[1:] {
+		next, err := current.applyNext(e)
+		if err != nil {
+			return Incident{}, nil, fmt.Errorf("incident event %s: %w", e.ID, err)
+		}
+		current = next
+		revisions = append(revisions, snapshot(current, e))
+	}
+	if err := current.Validate(); err != nil {
+		return Incident{}, nil, err
+	}
+	return current.clone(), cloneRevisions(revisions), nil
+}
+
+func applyCreated(e IncidentEvent) Incident {
+	return Incident{
+		ID: e.IncidentID, TenantID: e.TenantID, EngagementID: e.EngagementID, AssetID: e.AssetID,
+		State: StateNew, Disposition: DispositionUnknown, Revision: 1,
+		DetectionIDs: []shared.ID{e.DetectionID}, FirstEventAt: e.OccurredAt, LastEventAt: e.OccurredAt,
+		CreatedAt: e.RecordedAt, UpdatedAt: e.RecordedAt, LastEventID: e.ID,
+	}
+}
+
+func (i Incident) applyNext(e IncidentEvent) (Incident, error) {
+	if e.IncidentID != i.ID || e.TenantID != i.TenantID || e.EngagementID != i.EngagementID || e.AssetID != i.AssetID {
+		return Incident{}, fmt.Errorf("%w: incident event scope differs from its stream", shared.ErrValidation)
+	}
+	if e.Revision != i.Revision+1 {
+		return Incident{}, fmt.Errorf("%w: incident event revision is %d, want %d", shared.ErrConflict, e.Revision, i.Revision+1)
+	}
+	if e.RecordedAt.Before(i.UpdatedAt) {
+		return Incident{}, fmt.Errorf("%w: incident recorded-at regressed at revision %d", shared.ErrConflict, e.Revision)
+	}
+	next := i.clone()
+	switch e.Kind {
+	case EventCreated:
+		return Incident{}, fmt.Errorf("%w: incident-created can only be revision 1", shared.ErrConflict)
+	case EventStateChanged:
+		if e.FromState != i.State {
+			return Incident{}, fmt.Errorf("%w: state event starts at %q, current state is %q", shared.ErrConflict, e.FromState, i.State)
+		}
+		next.State = e.ToState
+	case EventDispositionChanged:
+		if e.FromDisposition != i.Disposition {
+			return Incident{}, fmt.Errorf("%w: disposition event starts at %q, current disposition is %q", shared.ErrConflict, e.FromDisposition, i.Disposition)
+		}
+		next.Disposition = e.ToDisposition
+	case EventDetectionLinked:
+		if containsID(i.DetectionIDs, e.DetectionID) {
+			return Incident{}, fmt.Errorf("%w: detection %s is already linked", shared.ErrConflict, e.DetectionID)
+		}
+		next.DetectionIDs = append(next.DetectionIDs, e.DetectionID)
+		sort.Slice(next.DetectionIDs, func(a, b int) bool { return next.DetectionIDs[a] < next.DetectionIDs[b] })
+	}
+	next.Revision = e.Revision
+	next.LastEventID = e.ID
+	next.UpdatedAt = e.RecordedAt
+	if e.OccurredAt.Before(next.FirstEventAt) {
+		next.FirstEventAt = e.OccurredAt
+	}
+	if e.OccurredAt.After(next.LastEventAt) {
+		next.LastEventAt = e.OccurredAt
+	}
+	if err := next.Validate(); err != nil {
+		return Incident{}, err
+	}
+	return next, nil
+}
+
+// Validate enforces projection invariants independently of how the Incident was reconstructed.
+func (i Incident) Validate() error {
+	if i.ID.IsZero() || i.TenantID.IsZero() || i.EngagementID.IsZero() || i.AssetID.IsZero() || i.LastEventID.IsZero() {
+		return fmt.Errorf("%w: incident identity, scope, and last event are required", shared.ErrValidation)
+	}
+	if !i.State.Valid() || !i.Disposition.Valid() || i.Revision == 0 {
+		return fmt.Errorf("%w: incident lifecycle or revision is invalid", shared.ErrValidation)
+	}
+	if i.CreatedAt.IsZero() || i.UpdatedAt.IsZero() || i.FirstEventAt.IsZero() || i.LastEventAt.IsZero() ||
+		i.UpdatedAt.Before(i.CreatedAt) || i.LastEventAt.Before(i.FirstEventAt) || i.LastEventAt.After(i.UpdatedAt) {
+		return fmt.Errorf("%w: incident timestamps are invalid", shared.ErrValidation)
+	}
+	if err := validateDetectionIDs(i.DetectionIDs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i Incident) clone() Incident {
+	c := i
+	c.DetectionIDs = append([]shared.ID(nil), i.DetectionIDs...)
+	return c
+}
+
+func snapshot(i Incident, e IncidentEvent) IncidentRevision {
+	return IncidentRevision{
+		IncidentID: i.ID, TenantID: i.TenantID, EngagementID: i.EngagementID, AssetID: i.AssetID,
+		Revision: i.Revision, EventID: e.ID, EventKind: e.Kind, State: i.State, Disposition: i.Disposition,
+		DetectionIDs: append([]shared.ID(nil), i.DetectionIDs...), FirstEventAt: i.FirstEventAt,
+		LastEventAt: i.LastEventAt, EventOccurredAt: e.OccurredAt, RecordedAt: e.RecordedAt,
+	}
+}
+
+func cloneRevisions(values []IncidentRevision) []IncidentRevision {
+	out := make([]IncidentRevision, len(values))
+	for index, value := range values {
+		out[index] = value
+		out[index].DetectionIDs = append([]shared.ID(nil), value.DetectionIDs...)
+	}
+	return out
+}
+
+func containsID(values []shared.ID, id shared.ID) bool {
+	index := sort.Search(len(values), func(index int) bool { return values[index] >= id })
+	return index < len(values) && values[index] == id
+}
+
+func validateDetectionIDs(values []shared.ID) error {
+	if len(values) == 0 {
+		return fmt.Errorf("%w: incident must retain at least one detection", shared.ErrValidation)
+	}
+	for index, id := range values {
+		if id.IsZero() || (index > 0 && values[index-1] >= id) {
+			return fmt.Errorf("%w: incident detection ids must be non-zero, unique, and sorted", shared.ErrValidation)
+		}
+	}
+	return nil
+}

--- a/internal/domain/incident/incident_test.go
+++ b/internal/domain/incident/incident_test.go
@@ -1,0 +1,507 @@
+package incident
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var testTime = time.Unix(1_800_100_000, 0).UTC()
+
+func createTestIncident(t *testing.T) (Incident, IncidentEvent) {
+	t.Helper()
+	current, event, err := Create(CreateCommand{
+		EventID: "event-1", IncidentID: "incident-1", TenantID: "tenant-1",
+		EngagementID: "engagement-1", AssetID: "asset-1", DetectionID: "detection-z",
+		Actor: "system:correlator", Rationale: "correlation match",
+		OccurredAt: testTime, RecordedAt: testTime.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("create incident: %v", err)
+	}
+	return current, event
+}
+
+func openTestIncident(t *testing.T, current Incident) (Incident, IncidentEvent) {
+	t.Helper()
+	next, event, err := current.TransitionState(StateTransitionCommand{
+		EventID: "event-2", To: StateOpen, Actor: "system:correlator", Rationale: "opened after correlation",
+		ExpectedRevision: current.Revision, OccurredAt: testTime.Add(30 * time.Second),
+		RecordedAt: testTime.Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("open incident: %v", err)
+	}
+	return next, event
+}
+
+func TestCreateDefaultsAndValidatesProjection(t *testing.T) {
+	current, event := createTestIncident(t)
+	if current.State != StateNew || current.Disposition != DispositionUnknown || current.Revision != 1 {
+		t.Fatalf("unexpected initial lifecycle: %+v", current)
+	}
+	if len(current.DetectionIDs) != 1 || current.DetectionIDs[0] != "detection-z" {
+		t.Fatalf("initial detection was not retained: %+v", current.DetectionIDs)
+	}
+	if current.LastEventID != event.ID || !current.FirstEventAt.Equal(testTime) ||
+		!current.CreatedAt.Equal(testTime.Add(time.Minute)) {
+		t.Fatalf("unexpected initial event projection: %+v", current)
+	}
+	if err := current.Validate(); err != nil {
+		t.Fatalf("created incident must validate: %v", err)
+	}
+	if err := event.Validate(); err != nil {
+		t.Fatalf("created event must validate: %v", err)
+	}
+}
+
+func TestStateAndDispositionEvolveIndependently(t *testing.T) {
+	current, _ := createTestIncident(t)
+	current, _ = openTestIncident(t, current)
+
+	classified, _, err := current.SetDisposition(DispositionCommand{
+		EventID: "event-3", To: DispositionTruePositive, Actor: "analyst@example.com",
+		Rationale: "confirmed malicious behavior", ExpectedRevision: current.Revision,
+		OccurredAt: testTime.Add(3 * time.Minute), RecordedAt: testTime.Add(3 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if classified.State != StateOpen || classified.Disposition != DispositionTruePositive {
+		t.Fatalf("disposition must not move state: %+v", classified)
+	}
+
+	investigating, _, err := classified.TransitionState(StateTransitionCommand{
+		EventID: "event-4", To: StateInvestigating, Actor: "analyst@example.com",
+		Rationale: "collecting surrounding telemetry", ExpectedRevision: classified.Revision,
+		OccurredAt: testTime.Add(4 * time.Minute), RecordedAt: testTime.Add(4 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if investigating.State != StateInvestigating || investigating.Disposition != DispositionTruePositive {
+		t.Fatalf("state transition must preserve disposition: %+v", investigating)
+	}
+}
+
+func TestRebuildIsOrderIndependentAndExactReplayIdempotent(t *testing.T) {
+	current, created := createTestIncident(t)
+	current, opened := openTestIncident(t, current)
+	current, disposition, err := current.SetDisposition(DispositionCommand{
+		EventID: "event-3", To: DispositionBenignPositive, Actor: "alice",
+		Rationale: "expected administrative traffic", ExpectedRevision: current.Revision,
+		OccurredAt: testTime.Add(3 * time.Minute), RecordedAt: testTime.Add(3 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, linked, err := current.LinkDetection(LinkDetectionCommand{
+		EventID: "event-4", DetectionID: "detection-a", Actor: "system:correlator",
+		Rationale: "late related detection", ExpectedRevision: current.Revision,
+		OccurredAt: testTime.Add(-time.Hour), RecordedAt: testTime.Add(4 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Deliberately shuffled, with an exact retry of event-2.
+	rebuilt, revisions, err := Rebuild([]IncidentEvent{linked, opened, created, disposition, opened})
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if !reflect.DeepEqual(rebuilt, current) {
+		t.Fatalf("rebuild differs from command projection:\nrebuilt=%+v\ncurrent=%+v", rebuilt, current)
+	}
+	if len(revisions) != 4 {
+		t.Fatalf("exact replay must not create a revision, got %d", len(revisions))
+	}
+	for index, revision := range revisions {
+		if revision.Revision != uint64(index+1) {
+			t.Fatalf("revision history not ordered: %+v", revisions)
+		}
+		if err := revision.Validate(); err != nil {
+			t.Fatalf("revision %d invalid: %v", revision.Revision, err)
+		}
+	}
+	if !rebuilt.FirstEventAt.Equal(testTime.Add(-time.Hour)) || !rebuilt.LastEventAt.Equal(testTime.Add(3*time.Minute)) {
+		t.Fatalf("late event must widen event-time bounds: [%s,%s]", rebuilt.FirstEventAt, rebuilt.LastEventAt)
+	}
+	if !reflect.DeepEqual(rebuilt.DetectionIDs, []shared.ID{"detection-a", "detection-z"}) {
+		t.Fatalf("detections must be deterministically sorted: %+v", rebuilt.DetectionIDs)
+	}
+
+	// Every returned snapshot owns its evidence slice.
+	revisions[0].DetectionIDs[0] = "mutated"
+	if rebuilt.DetectionIDs[0] == "mutated" || revisions[1].DetectionIDs[0] == "mutated" {
+		t.Fatal("revision evidence slices alias each other or the current projection")
+	}
+}
+
+func TestRebuildRejectsConflictingEventIDReplay(t *testing.T) {
+	_, created := createTestIncident(t)
+	conflict := created
+	conflict.Rationale = "different correlation material"
+	if _, _, err := Rebuild([]IncidentEvent{created, conflict}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("conflicting EventID replay must fail with ErrConflict, got %v", err)
+	}
+}
+
+func TestRebuildRejectsCorruptStreams(t *testing.T) {
+	current, created := createTestIncident(t)
+	current, opened := openTestIncident(t, current)
+	current, classified, err := current.SetDisposition(DispositionCommand{
+		EventID: "event-3", To: DispositionFalsePositive, Actor: "alice",
+		Rationale: "known scanner activity", ExpectedRevision: current.Revision,
+		OccurredAt: testTime.Add(3 * time.Minute), RecordedAt: testTime.Add(3 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, linked, err := current.LinkDetection(LinkDetectionCommand{
+		EventID: "event-4", DetectionID: "detection-y", Actor: "system:correlator",
+		Rationale: "same process lineage", ExpectedRevision: current.Revision,
+		OccurredAt: testTime.Add(2 * time.Minute), RecordedAt: testTime.Add(4 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string]struct {
+		events   []IncidentEvent
+		sentinel error
+	}{
+		"missing creation": {[]IncidentEvent{opened}, shared.ErrConflict},
+		"revision hole": {[]IncidentEvent{created, opened, func() IncidentEvent {
+			e := classified
+			e.Revision = 4
+			return e
+		}()}, shared.ErrConflict},
+		"duplicate revision": {[]IncidentEvent{created, opened, func() IncidentEvent {
+			e := opened
+			e.ID = "other-event"
+			return e
+		}()}, shared.ErrConflict},
+		"cross tenant": {[]IncidentEvent{created, func() IncidentEvent {
+			e := opened
+			e.TenantID = "tenant-2"
+			return e
+		}()}, shared.ErrValidation},
+		"stale from state": {[]IncidentEvent{created, func() IncidentEvent {
+			e := opened
+			e.FromState = StateReopened
+			e.ToState = StateInvestigating
+			return e
+		}()}, shared.ErrConflict},
+		"stale disposition": {[]IncidentEvent{created, opened, func() IncidentEvent {
+			e := classified
+			e.FromDisposition = DispositionTest
+			return e
+		}()}, shared.ErrConflict},
+		"record time regression": {[]IncidentEvent{created, opened, classified, func() IncidentEvent {
+			e := linked
+			e.RecordedAt = classified.RecordedAt.Add(-time.Second)
+			return e
+		}()}, shared.ErrConflict},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := Rebuild(tc.events); !errors.Is(err, tc.sentinel) {
+				t.Fatalf("want %v, got %v", tc.sentinel, err)
+			}
+		})
+	}
+}
+
+func TestCommandsEnforceRevisionTransitionAndHumanDisposition(t *testing.T) {
+	current, _ := createTestIncident(t)
+	if _, _, err := current.TransitionState(StateTransitionCommand{
+		EventID: "bad-transition", To: StateContained, Actor: "system:response",
+		Rationale: "contain immediately", ExpectedRevision: current.Revision,
+		OccurredAt: testTime.Add(time.Minute), RecordedAt: testTime.Add(2 * time.Minute),
+	}); !errors.Is(err, ErrInvalidTransition) || !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("invalid lifecycle transition must preserve both errors, got %v", err)
+	}
+	if _, _, err := current.TransitionState(StateTransitionCommand{
+		EventID: "stale", To: StateOpen, Actor: "system:correlator", Rationale: "open incident",
+		ExpectedRevision: 99, OccurredAt: testTime.Add(time.Minute), RecordedAt: testTime.Add(2 * time.Minute),
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale revision must conflict, got %v", err)
+	}
+	if _, _, err := current.SetDisposition(DispositionCommand{
+		EventID: "machine-disposition", To: DispositionTruePositive, Actor: "llm:triage",
+		Rationale: "model classified incident", ExpectedRevision: current.Revision,
+		OccurredAt: testTime.Add(time.Minute), RecordedAt: testTime.Add(2 * time.Minute),
+	}); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("machine disposition must be forbidden, got %v", err)
+	}
+	if _, _, err := current.SetDisposition(DispositionCommand{
+		EventID: "stale-disposition", To: DispositionTruePositive, Actor: "alice",
+		Rationale: "confirmed malicious behavior", ExpectedRevision: 99,
+		OccurredAt: testTime.Add(time.Minute), RecordedAt: testTime.Add(2 * time.Minute),
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale disposition revision must conflict, got %v", err)
+	}
+	if _, _, err := current.LinkDetection(LinkDetectionCommand{
+		EventID: "", DetectionID: "detection-a", Actor: "system:correlator",
+		ExpectedRevision: current.Revision, OccurredAt: testTime, RecordedAt: testTime.Add(2 * time.Minute),
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("invalid link event must be rejected, got %v", err)
+	}
+	if _, _, err := current.TransitionState(StateTransitionCommand{
+		EventID: "regressed-record-time", To: StateOpen, Actor: "system:correlator",
+		Rationale: "open incident", ExpectedRevision: current.Revision,
+		OccurredAt: testTime.Add(-time.Minute), RecordedAt: testTime.Add(30 * time.Second),
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("command with regressed record time must conflict, got %v", err)
+	}
+	if _, _, err := (Incident{}).TransitionState(StateTransitionCommand{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("command on invalid projection must fail validation, got %v", err)
+	}
+
+	// State transitions may be system-authored; analyst-only applies specifically to disposition.
+	opened, _ := openTestIncident(t, current)
+	closed, _, err := opened.TransitionState(StateTransitionCommand{
+		EventID: "event-close", To: StateClosed, Actor: "system:policy", Rationale: "policy closed incident",
+		ExpectedRevision: opened.Revision, OccurredAt: testTime.Add(3 * time.Minute), RecordedAt: testTime.Add(3 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopened, _, err := closed.TransitionState(StateTransitionCommand{
+		EventID: "event-reopen", To: StateReopened, Actor: "alice", Rationale: "new supporting evidence",
+		ExpectedRevision: closed.Revision, OccurredAt: testTime.Add(4 * time.Minute), RecordedAt: testTime.Add(4 * time.Minute),
+	})
+	if err != nil || reopened.State != StateReopened {
+		t.Fatalf("explicit reopen must succeed: state=%s err=%v", reopened.State, err)
+	}
+}
+
+func TestDetectionLinksAreUniqueSortedAndDoNotAlias(t *testing.T) {
+	current, _ := createTestIncident(t)
+	previous := current
+	next, _, err := current.LinkDetection(LinkDetectionCommand{
+		EventID: "event-2", DetectionID: "detection-a", Actor: "system:correlator",
+		ExpectedRevision: current.Revision, OccurredAt: testTime, RecordedAt: testTime.Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(next.DetectionIDs, []shared.ID{"detection-a", "detection-z"}) {
+		t.Fatalf("unexpected evidence membership: %+v", next.DetectionIDs)
+	}
+	next.DetectionIDs[0] = "mutated"
+	if previous.DetectionIDs[0] != "detection-z" {
+		t.Fatal("command result aliases the previous projection")
+	}
+
+	// Use the unmodified projection to verify a semantic duplicate with a new event id is rejected.
+	current, _, err = current.LinkDetection(LinkDetectionCommand{
+		EventID: "event-2", DetectionID: "detection-a", Actor: "system:correlator",
+		ExpectedRevision: current.Revision, OccurredAt: testTime, RecordedAt: testTime.Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.LinkDetection(LinkDetectionCommand{
+		EventID: "event-3", DetectionID: "detection-a", Actor: "system:correlator",
+		ExpectedRevision: current.Revision, OccurredAt: testTime, RecordedAt: testTime.Add(3 * time.Minute),
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("duplicate detection membership must conflict, got %v", err)
+	}
+}
+
+func TestIncidentEventValidation(t *testing.T) {
+	current, created := createTestIncident(t)
+	_, stateEvent := openTestIncident(t, current)
+	_, dispositionEvent, err := current.SetDisposition(DispositionCommand{
+		EventID: "event-disposition", To: DispositionTest, Actor: "alice", Rationale: "approved test activity",
+		ExpectedRevision: current.Revision, OccurredAt: testTime.Add(time.Minute), RecordedAt: testTime.Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string]IncidentEvent{
+		"missing id":    func() IncidentEvent { e := created; e.ID = ""; return e }(),
+		"zero revision": func() IncidentEvent { e := created; e.Revision = 0; return e }(),
+		"unknown kind":  func() IncidentEvent { e := created; e.Kind = "mystery"; return e }(),
+		"missing timestamp": func() IncidentEvent {
+			e := created
+			e.RecordedAt = time.Time{}
+			return e
+		}(),
+		"occurred after recorded": func() IncidentEvent {
+			e := created
+			e.OccurredAt = e.RecordedAt.Add(time.Second)
+			return e
+		}(),
+		"uncanonical actor":  func() IncidentEvent { e := created; e.Actor = " alice "; return e }(),
+		"oversized actor":    func() IncidentEvent { e := created; e.Actor = strings.Repeat("a", maxActorBytes+1); return e }(),
+		"invalid actor utf8": func() IncidentEvent { e := created; e.Actor = string([]byte{0xff}); return e }(),
+		"short rationale":    func() IncidentEvent { e := stateEvent; e.Rationale = "x"; return e }(),
+		"uncanonical rationale": func() IncidentEvent {
+			e := stateEvent
+			e.Rationale = " padded "
+			return e
+		}(),
+		"oversized rationale": func() IncidentEvent {
+			e := stateEvent
+			e.Rationale = strings.Repeat("a", maxRationaleRunes+1)
+			return e
+		}(),
+		"control rationale": func() IncidentEvent { e := stateEvent; e.Rationale = "bad\x00text"; return e }(),
+		"bad creation payload": func() IncidentEvent {
+			e := created
+			e.ToState = StateOpen
+			return e
+		}(),
+		"ambiguous state payload": func() IncidentEvent {
+			e := stateEvent
+			e.DetectionID = "detection-extra"
+			return e
+		}(),
+		"bad disposition payload": func() IncidentEvent {
+			e := dispositionEvent
+			e.ToDisposition = e.FromDisposition
+			return e
+		}(),
+		"machine disposition": func() IncidentEvent { e := dispositionEvent; e.Actor = "service:triage"; return e }(),
+		"bad detection payload": func() IncidentEvent {
+			return IncidentEvent{
+				ID: "link", IncidentID: created.IncidentID, TenantID: created.TenantID,
+				EngagementID: created.EngagementID, AssetID: created.AssetID, Revision: 2,
+				Kind: EventDetectionLinked, Actor: "system:correlator", OccurredAt: testTime,
+				RecordedAt: testTime.Add(2 * time.Minute), DetectionID: "detection-a", ToState: StateOpen,
+			}
+		}(),
+	}
+	for name, event := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := event.Validate(); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+
+	otherZone := time.FixedZone("other", 2*60*60)
+	equalInstant := created
+	equalInstant.OccurredAt = created.OccurredAt.In(otherZone)
+	equalInstant.RecordedAt = created.RecordedAt.In(otherZone)
+	if !created.Equal(equalInstant) {
+		t.Fatal("event equality must compare timestamp instants, not locations")
+	}
+	equalInstant.Actor = "different"
+	if created.Equal(equalInstant) {
+		t.Fatal("different provenance must not be an exact replay")
+	}
+}
+
+func TestProjectionAndRevisionValidationRejectCorruption(t *testing.T) {
+	current, event := createTestIncident(t)
+	revision := snapshot(current, event)
+	cases := map[string]Incident{
+		"missing scope": func() Incident { i := current; i.TenantID = ""; return i }(),
+		"bad state":     func() Incident { i := current; i.State = "bad"; return i }(),
+		"duplicate detections": func() Incident {
+			i := current.clone()
+			i.DetectionIDs = []shared.ID{"detection-z", "detection-z"}
+			return i
+		}(),
+		"unsorted detections": func() Incident {
+			i := current.clone()
+			i.DetectionIDs = []shared.ID{"z", "a"}
+			return i
+		}(),
+		"bad event bounds": func() Incident { i := current; i.LastEventAt = i.UpdatedAt.Add(time.Second); return i }(),
+	}
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := value.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("expected ErrValidation, got %v", err)
+			}
+		})
+	}
+	if err := revision.Validate(); err != nil {
+		t.Fatalf("valid revision rejected: %v", err)
+	}
+	revisionCases := map[string]IncidentRevision{
+		"missing identity": func() IncidentRevision { r := revision; r.IncidentID = ""; return r }(),
+		"bad lifecycle":    func() IncidentRevision { r := revision; r.State = "bad"; return r }(),
+		"missing detection": func() IncidentRevision {
+			r := revision
+			r.DetectionIDs = nil
+			return r
+		}(),
+		"event outside bounds": func() IncidentRevision {
+			r := revision
+			r.EventOccurredAt = r.FirstEventAt.Add(-time.Second)
+			return r
+		}(),
+	}
+	for name, value := range revisionCases {
+		t.Run("revision "+name, func(t *testing.T) {
+			if err := value.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("corrupt revision must be rejected, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLifecycleVocabularyAndGraph(t *testing.T) {
+	states := []State{StateNew, StateOpen, StateTriaged, StateInvestigating, StateContained,
+		StateRemediated, StateResolved, StateClosed, StateReopened}
+	for _, state := range states {
+		if !state.Valid() || state.CanTransitionTo(state) {
+			t.Fatalf("invalid state semantics for %q", state)
+		}
+	}
+	if State("bogus").Valid() || State("bogus").CanTransitionTo(StateOpen) {
+		t.Fatal("unknown states must fail closed")
+	}
+	if !StateResolved.CanTransitionTo(StateReopened) || !StateClosed.CanTransitionTo(StateReopened) ||
+		StateClosed.CanTransitionTo(StateOpen) {
+		t.Fatal("terminal states must reopen explicitly")
+	}
+	allowed := map[State]State{
+		StateNew:           StateOpen,
+		StateOpen:          StateTriaged,
+		StateTriaged:       StateInvestigating,
+		StateInvestigating: StateContained,
+		StateContained:     StateRemediated,
+		StateRemediated:    StateResolved,
+		StateResolved:      StateReopened,
+		StateClosed:        StateReopened,
+		StateReopened:      StateInvestigating,
+	}
+	for from, to := range allowed {
+		if !from.CanTransitionTo(to) {
+			t.Fatalf("expected transition %s -> %s to be allowed", from, to)
+		}
+	}
+
+	dispositions := []Disposition{DispositionUnknown, DispositionTruePositive, DispositionBenignPositive,
+		DispositionFalsePositive, DispositionDuplicate, DispositionTest}
+	for _, disposition := range dispositions {
+		if !disposition.Valid() {
+			t.Fatalf("known disposition %q rejected", disposition)
+		}
+	}
+	if Disposition("model_guess").Valid() {
+		t.Fatal("unknown disposition must fail closed")
+	}
+}
+
+func TestCreateRejectsInvalidCommand(t *testing.T) {
+	_, _, err := Create(CreateCommand{
+		EventID: "event-1", IncidentID: "incident-1", TenantID: "tenant-1",
+		EngagementID: "engagement-1", DetectionID: "detection-1", Actor: "system:correlator",
+		OccurredAt: testTime, RecordedAt: testTime.Add(time.Minute),
+	})
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing asset must fail validation, got %v", err)
+	}
+}

--- a/internal/domain/incident/lifecycle.go
+++ b/internal/domain/incident/lifecycle.go
@@ -1,0 +1,88 @@
+package incident
+
+import "errors"
+
+// ErrInvalidTransition marks a lifecycle move that the Incident state graph forbids.
+var ErrInvalidTransition = errors.New("invalid incident transition")
+
+// State is the operational lifecycle of an Incident. It is intentionally independent from Disposition:
+// an incident may be closed while still unknown, or remain under investigation after an analyst marks it
+// true-positive.
+type State string
+
+const (
+	StateNew           State = "new"
+	StateOpen          State = "open"
+	StateTriaged       State = "triaged"
+	StateInvestigating State = "investigating"
+	StateContained     State = "contained"
+	StateRemediated    State = "remediated"
+	StateResolved      State = "resolved"
+	StateClosed        State = "closed"
+	StateReopened      State = "reopened"
+)
+
+// Valid reports whether s belongs to the Phase-C lifecycle vocabulary.
+func (s State) Valid() bool {
+	switch s {
+	case StateNew, StateOpen, StateTriaged, StateInvestigating, StateContained,
+		StateRemediated, StateResolved, StateClosed, StateReopened:
+		return true
+	default:
+		return false
+	}
+}
+
+// CanTransitionTo enforces forward lifecycle progress. A resolved or closed Incident can only move
+// backwards through the explicit reopened state, preventing a replay or stale writer from silently
+// erasing terminal history.
+func (s State) CanTransitionTo(to State) bool {
+	if !s.Valid() || !to.Valid() || s == to {
+		return false
+	}
+	switch s {
+	case StateNew:
+		return to == StateOpen
+	case StateOpen:
+		return to == StateTriaged || to == StateInvestigating || to == StateContained ||
+			to == StateResolved || to == StateClosed
+	case StateTriaged:
+		return to == StateInvestigating || to == StateContained || to == StateResolved || to == StateClosed
+	case StateInvestigating:
+		return to == StateContained || to == StateRemediated || to == StateResolved || to == StateClosed
+	case StateContained:
+		return to == StateInvestigating || to == StateRemediated || to == StateResolved || to == StateClosed
+	case StateRemediated:
+		return to == StateResolved || to == StateClosed
+	case StateResolved, StateClosed:
+		return to == StateReopened
+	case StateReopened:
+		return to == StateOpen || to == StateInvestigating
+	default:
+		return false
+	}
+}
+
+// Disposition is the analyst's factual classification of an Incident. It never drives State implicitly;
+// every lifecycle change remains a separate append-only event.
+type Disposition string
+
+const (
+	DispositionUnknown        Disposition = "unknown"
+	DispositionTruePositive   Disposition = "true_positive"
+	DispositionBenignPositive Disposition = "benign_positive"
+	DispositionFalsePositive  Disposition = "false_positive"
+	DispositionDuplicate      Disposition = "duplicate"
+	DispositionTest           Disposition = "test"
+)
+
+// Valid reports whether d belongs to the Phase-C analyst-disposition vocabulary.
+func (d Disposition) Valid() bool {
+	switch d {
+	case DispositionUnknown, DispositionTruePositive, DispositionBenignPositive,
+		DispositionFalsePositive, DispositionDuplicate, DispositionTest:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary

Starts Phase C of #638 with the bounded child #674: a pure-domain, event-sourced runtime Incident aggregate. This is intentionally distinct from `detection.Incident` (the existing read-only rule/asset rollup) and provides the auditable state substrate that correlation, tri-score risk, retro-hunt, response, and eventually AI investigation need.

## Changes

- add the complete Phase-C lifecycle vocabulary and a guarded forward/reopen transition graph
- keep operational `State` independent from analyst `Disposition`
- add strictly typed, immutable `IncidentEvent` records with tenant/engagement/asset scope, optimistic revision, event time, record time, actor, rationale, and detection provenance
- add commands for creation, lifecycle transition, human disposition, and append-only detection linking
- add deterministic `Rebuild`: unordered input is revision-sorted, exact EventID retries are idempotent, and every accepted event yields an immutable `IncidentRevision` snapshot
- preserve late-event honesty through independent event/record timestamps and min/max event-time bounds
- make detection membership unique, sorted, append-only, and defensively copied

## Correctness and safety

The stream fails closed on conflicting EventID replay, duplicate or missing revisions, stale from-state/disposition, cross-scope events, regressing record time, invalid transitions, stale command revisions, and machine-authored analyst dispositions. A disposition never mutates lifecycle state implicitly, and terminal state can only move backwards through an explicit `reopened` event.

The package remains dependency-rule clean: stdlib + `internal/domain/shared`, with no I/O, clock, store, framework, or adapter dependency.

## Scope

This completes the portable domain child #674. Correlation/watermarks, durable persistence, tri-score risk, retro-hunt, API/UI, and governed response remain separate reviewable #638 slices.

## Checklist

- [ ] `make build vet test typecheck` passes (GNU Make/Linux toolchain unavailable in this Windows environment)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -cover ./internal/domain/incident` — 95.4%
- [x] incident test suite repeated 100 times
- [x] Tests added for deterministic rebuild and fail-closed stream corruption
- [x] Preserves clean architecture and security invariants

### Validation note

`go test ./...` passed the new package and every related domain/usecase/e2e package. The aggregate command retains the same two pre-existing Windows filesystem-security failures documented on #672: `cmd/synapse-fptriage-release/TestRunCreatesPromotionAndRollbackLedger` (current-user-only ACL verification is unavailable on Windows) and `internal/infrastructure/egressbroker/TestFileGrantReplayStoreCompactsExpiredRecords` (owner-controlled-directory check).

Closes #674
Refs #638