### PR TITLE
feat(incident): Phase C event-sourced Incident + tri-score risk primitives (#675 #677)

### DIFF
--- a/internal/domain/incident/disposition.go
+++ b/internal/domain/incident/disposition.go
@@ -1,0 +1,26 @@
+package incident
+
+// Disposition is the analyst's VERDICT on an incident — orthogonal to State (workflow position) and to
+// risk. An incident can be, e.g., State=resolved with Disposition=false_positive, or State=investigating
+// with Disposition=unknown. Disposition never mutates the risk score.
+type Disposition string
+
+const (
+	DispositionUnknown       Disposition = "unknown"
+	DispositionTruePositive  Disposition = "true_positive"
+	DispositionBenign        Disposition = "benign_positive"
+	DispositionFalsePositive Disposition = "false_positive"
+	DispositionDuplicate     Disposition = "duplicate"
+	DispositionTest          Disposition = "test"
+)
+
+// Valid reports whether d is a known disposition.
+func (d Disposition) Valid() bool {
+	switch d {
+	case DispositionUnknown, DispositionTruePositive, DispositionBenign,
+		DispositionFalsePositive, DispositionDuplicate, DispositionTest:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/incident/event.go
+++ b/internal/domain/incident/event.go
@@ -1,0 +1,121 @@
+package incident
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// EventKind is the type of an incident state-transition event. The log of these, folded in order, IS the
+// incident.
+type EventKind string
+
+const (
+	EventCreated           EventKind = "created"
+	EventDetectionAttached EventKind = "detection_attached"
+	EventDetectionDetached EventKind = "detection_detached"
+	EventStatusChanged     EventKind = "status_changed"
+	EventOwnerChanged      EventKind = "owner_changed"
+	EventDispositionSet    EventKind = "disposition_set"
+	EventRiskReassessed    EventKind = "risk_reassessed"
+	EventAnalystCommented  EventKind = "analyst_commented"
+	EventMerged            EventKind = "merged"
+	EventResponseRequested EventKind = "response_requested"
+	EventResponseVerified  EventKind = "response_verified"
+)
+
+// IncidentEvent is one attributable change to an incident. Exactly the payload field(s) named for its Kind
+// are meaningful; the rest are zero. Actor is the human or agent id responsible (attribution, golden rule
+// 6). The events for one incident share IncidentID and are ordered by the position they are folded in
+// (their 1-based index becomes the projection Revision).
+type IncidentEvent struct {
+	IncidentID shared.ID
+	Kind       EventKind
+	At         time.Time
+	Actor      string
+
+	// Created
+	AssetID  shared.ID
+	Title    string
+	Severity shared.Severity
+	// Created (optional first detection) + DetectionAttached/Detached
+	DetectionID shared.ID
+	// StatusChanged
+	To State
+	// OwnerChanged
+	Owner string
+	// DispositionSet
+	Disposition Disposition
+	// RiskReassessed
+	Risk *riskassessment.RiskAssessment
+	// AnalystCommented
+	Comment string
+	// Merged (this incident was merged INTO another)
+	MergedInto shared.ID
+	// ResponseRequested / ResponseVerified
+	ResponseActionID shared.ID
+	// ResponseVerified
+	Verified bool
+}
+
+// Validate enforces a well-formed event for its kind: the required identity and the payload the kind needs.
+func (e IncidentEvent) Validate() error {
+	if e.IncidentID.IsZero() {
+		return fmt.Errorf("%w: incident event has no incident id", shared.ErrValidation)
+	}
+	if e.At.IsZero() {
+		return fmt.Errorf("%w: incident event has no timestamp", shared.ErrValidation)
+	}
+	if e.Actor == "" {
+		return fmt.Errorf("%w: incident event has no actor", shared.ErrValidation)
+	}
+	switch e.Kind {
+	case EventCreated:
+		if e.AssetID.IsZero() {
+			return fmt.Errorf("%w: created event has no asset id", shared.ErrValidation)
+		}
+		if e.Severity != "" && !e.Severity.Valid() {
+			return fmt.Errorf("%w: created event has invalid severity %q", shared.ErrValidation, e.Severity)
+		}
+	case EventDetectionAttached, EventDetectionDetached:
+		if e.DetectionID.IsZero() {
+			return fmt.Errorf("%w: %s event has no detection id", shared.ErrValidation, e.Kind)
+		}
+	case EventStatusChanged:
+		if !e.To.Valid() {
+			return fmt.Errorf("%w: status_changed event has invalid target state %q", shared.ErrValidation, e.To)
+		}
+	case EventOwnerChanged:
+		if e.Owner == "" {
+			return fmt.Errorf("%w: owner_changed event has no owner", shared.ErrValidation)
+		}
+	case EventDispositionSet:
+		if !e.Disposition.Valid() {
+			return fmt.Errorf("%w: disposition_set event has invalid disposition %q", shared.ErrValidation, e.Disposition)
+		}
+	case EventRiskReassessed:
+		if e.Risk == nil {
+			return fmt.Errorf("%w: risk_reassessed event has no assessment", shared.ErrValidation)
+		}
+		if err := e.Risk.Validate(); err != nil {
+			return err
+		}
+	case EventAnalystCommented:
+		if e.Comment == "" {
+			return fmt.Errorf("%w: analyst_commented event has no comment", shared.ErrValidation)
+		}
+	case EventMerged:
+		if e.MergedInto.IsZero() {
+			return fmt.Errorf("%w: merged event has no target incident id", shared.ErrValidation)
+		}
+	case EventResponseRequested, EventResponseVerified:
+		if e.ResponseActionID.IsZero() {
+			return fmt.Errorf("%w: %s event has no response action id", shared.ErrValidation, e.Kind)
+		}
+	default:
+		return fmt.Errorf("%w: unknown incident event kind %q", shared.ErrValidation, e.Kind)
+	}
+	return nil
+}

--- a/internal/domain/incident/incident.go
+++ b/internal/domain/incident/incident.go
@@ -1,0 +1,183 @@
+package incident
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Comment is one analyst note on an incident, attributable and timestamped.
+type Comment struct {
+	At    time.Time
+	Actor string
+	Text  string
+}
+
+// ResponseRef links an incident to a governed response action (the saga itself lives in domain/response,
+// C6) and records whether its post-condition has been telemetry-verified.
+type ResponseRef struct {
+	ActionID shared.ID
+	Verified bool
+}
+
+// Incident is the projection folded from an incident's event log. It is a VIEW over the events, which
+// remain the source of truth; State, Disposition, and Risk are independent. Revision equals the number of
+// events folded, so a projection is comparable to any point in the log.
+//
+// This is DISTINCT from detection.Incident (internal/domain/detection/record.go), which is a lightweight
+// rule+asset rollup view of raw detections. This incident.Incident is the richer, event-sourced Phase-C
+// case object an analyst triages; a detection.Incident rollup may seed one but does not replace it.
+type Incident struct {
+	ID           shared.ID
+	AssetID      shared.ID
+	Title        string
+	Severity     shared.Severity
+	State        State
+	Disposition  Disposition
+	OwnerID      string
+	DetectionIDs []shared.ID
+	Risk         *riskassessment.RiskAssessment
+	MergedInto   shared.ID
+	Comments     []Comment
+	Responses    []ResponseRef
+	Revision     int
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// IsMerged reports whether the incident was merged into another.
+func (i Incident) IsMerged() bool { return !i.MergedInto.IsZero() }
+
+// Project folds an incident's ordered event log into its current projection. It is deterministic and
+// fail-closed: the log must begin with a Created event, every event must validate, must belong to the same
+// incident, and a StatusChanged must be a legal transition — otherwise Project returns an error and no
+// partial projection. Replaying the same events always yields the same Incident.
+func Project(events []IncidentEvent) (Incident, error) {
+	if len(events) == 0 {
+		return Incident{}, fmt.Errorf("%w: incident has no events", shared.ErrValidation)
+	}
+	if events[0].Kind != EventCreated {
+		return Incident{}, fmt.Errorf("%w: incident log must begin with a created event, got %q", shared.ErrValidation, events[0].Kind)
+	}
+	var inc Incident
+	id := events[0].IncidentID
+	var prevAt time.Time
+	for i, e := range events {
+		if err := e.Validate(); err != nil {
+			return Incident{}, fmt.Errorf("incident event %d: %w", i, err)
+		}
+		if e.IncidentID != id {
+			return Incident{}, fmt.Errorf("%w: incident event %d belongs to %s, not %s", shared.ErrValidation, i, e.IncidentID, id)
+		}
+		// The event log is append-only and causal: an event may not be timestamped before the one before
+		// it. A backdated event is rejected rather than silently folded (chain-of-custody integrity).
+		if i > 0 && e.At.Before(prevAt) {
+			return Incident{}, fmt.Errorf("%w: incident event %d at %s predates the previous event at %s", shared.ErrValidation, i, e.At, prevAt)
+		}
+		prevAt = e.At
+		if i == 0 {
+			if err := applyCreated(&inc, e); err != nil {
+				return Incident{}, err
+			}
+		} else if e.Kind == EventCreated {
+			return Incident{}, fmt.Errorf("%w: incident event %d is a second created event", shared.ErrValidation, i)
+		} else if err := apply(&inc, e); err != nil {
+			return Incident{}, fmt.Errorf("incident event %d: %w", i, err)
+		}
+		inc.Revision = i + 1
+		inc.UpdatedAt = e.At
+	}
+	return inc, nil
+}
+
+func applyCreated(inc *Incident, e IncidentEvent) error {
+	inc.ID = e.IncidentID
+	inc.AssetID = e.AssetID
+	inc.Title = e.Title
+	inc.Severity = e.Severity
+	inc.State = StateNew
+	inc.Disposition = DispositionUnknown
+	inc.CreatedAt = e.At
+	if !e.DetectionID.IsZero() {
+		inc.DetectionIDs = []shared.ID{e.DetectionID}
+	}
+	return nil
+}
+
+func apply(inc *Incident, e IncidentEvent) error {
+	switch e.Kind {
+	case EventDetectionAttached:
+		if !containsID(inc.DetectionIDs, e.DetectionID) {
+			inc.DetectionIDs = append(inc.DetectionIDs, e.DetectionID)
+		}
+	case EventDetectionDetached:
+		inc.DetectionIDs = removeID(inc.DetectionIDs, e.DetectionID)
+	case EventStatusChanged:
+		if err := requireTransition(inc.State, e.To); err != nil {
+			return err
+		}
+		inc.State = e.To
+	case EventOwnerChanged:
+		inc.OwnerID = e.Owner
+	case EventDispositionSet:
+		inc.Disposition = e.Disposition
+	case EventRiskReassessed:
+		r := e.Risk.Clone()
+		inc.Risk = &r
+	case EventAnalystCommented:
+		inc.Comments = append(inc.Comments, Comment{At: e.At, Actor: e.Actor, Text: e.Comment})
+	case EventMerged:
+		inc.MergedInto = e.MergedInto
+	case EventResponseRequested:
+		if !hasResponse(inc.Responses, e.ResponseActionID) {
+			inc.Responses = append(inc.Responses, ResponseRef{ActionID: e.ResponseActionID})
+		}
+	case EventResponseVerified:
+		if !setResponseVerified(inc.Responses, e.ResponseActionID) {
+			inc.Responses = append(inc.Responses, ResponseRef{ActionID: e.ResponseActionID, Verified: true})
+		}
+	default:
+		return fmt.Errorf("%w: unhandled incident event kind %q", shared.ErrValidation, e.Kind)
+	}
+	return nil
+}
+
+func containsID(ids []shared.ID, id shared.ID) bool {
+	for _, x := range ids {
+		if x == id {
+			return true
+		}
+	}
+	return false
+}
+
+func removeID(ids []shared.ID, id shared.ID) []shared.ID {
+	out := ids[:0:0]
+	for _, x := range ids {
+		if x != id {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+func hasResponse(refs []ResponseRef, id shared.ID) bool {
+	for _, r := range refs {
+		if r.ActionID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func setResponseVerified(refs []ResponseRef, id shared.ID) bool {
+	for i := range refs {
+		if refs[i].ActionID == id {
+			refs[i].Verified = true
+			return true
+		}
+	}
+	return false
+}

--- a/internal/domain/incident/incident_test.go
+++ b/internal/domain/incident/incident_test.go
@@ -1,0 +1,235 @@
+package incident
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	incID   = shared.ID("inc-1")
+	assetID = shared.ID("asset-1")
+)
+
+var base = time.Unix(1_800_000_000, 0).UTC()
+
+func at(n int) time.Time { return base.Add(time.Duration(n) * time.Second) }
+
+func created(det shared.ID) IncidentEvent {
+	return IncidentEvent{IncidentID: incID, Kind: EventCreated, At: at(0), Actor: "correlator",
+		AssetID: assetID, Title: "suspicious exec", Severity: shared.SeverityHigh, DetectionID: det}
+}
+
+func TestProjectCreatedOpensIncident(t *testing.T) {
+	inc, err := Project([]IncidentEvent{created("det-1")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inc.ID != incID || inc.AssetID != assetID || inc.State != StateNew || inc.Disposition != DispositionUnknown {
+		t.Fatalf("created projection wrong: %+v", inc)
+	}
+	if inc.Revision != 1 || len(inc.DetectionIDs) != 1 || inc.DetectionIDs[0] != "det-1" {
+		t.Fatalf("created detection/revision wrong: %+v", inc)
+	}
+	if !inc.CreatedAt.Equal(at(0)) || !inc.UpdatedAt.Equal(at(0)) {
+		t.Fatalf("created timestamps wrong: %+v", inc)
+	}
+}
+
+func TestProjectFullLifecycle(t *testing.T) {
+	risk := &riskassessment.RiskAssessment{
+		AssessmentID: "ra-1", ScorerVersion: "v1", PolicyVersion: "p1",
+		Risk: 88, Confidence: 61, Coverage: 43,
+	}
+	events := []IncidentEvent{
+		created("det-1"),
+		{IncidentID: incID, Kind: EventDetectionAttached, At: at(1), Actor: "correlator", DetectionID: "det-2"},
+		{IncidentID: incID, Kind: EventStatusChanged, At: at(2), Actor: "alice", To: StateInvestigating},
+		{IncidentID: incID, Kind: EventOwnerChanged, At: at(3), Actor: "alice", Owner: "alice"},
+		{IncidentID: incID, Kind: EventRiskReassessed, At: at(4), Actor: "scorer", Risk: risk},
+		{IncidentID: incID, Kind: EventAnalystCommented, At: at(5), Actor: "alice", Comment: "looks real"},
+		{IncidentID: incID, Kind: EventStatusChanged, At: at(6), Actor: "alice", To: StateContained},
+		{IncidentID: incID, Kind: EventDispositionSet, At: at(7), Actor: "alice", Disposition: DispositionTruePositive},
+		{IncidentID: incID, Kind: EventStatusChanged, At: at(8), Actor: "alice", To: StateResolved},
+		{IncidentID: incID, Kind: EventStatusChanged, At: at(9), Actor: "alice", To: StateClosed},
+	}
+	inc, err := Project(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inc.State != StateClosed || inc.Disposition != DispositionTruePositive || inc.OwnerID != "alice" {
+		t.Fatalf("lifecycle end state wrong: %+v", inc)
+	}
+	if len(inc.DetectionIDs) != 2 || inc.Risk == nil || inc.Risk.Risk != 88 || inc.Risk.Coverage != 43 {
+		t.Fatalf("detections/risk wrong: %+v", inc)
+	}
+	if len(inc.Comments) != 1 || inc.Comments[0].Actor != "alice" {
+		t.Fatalf("comments wrong: %+v", inc.Comments)
+	}
+	if inc.Revision != len(events) || !inc.UpdatedAt.Equal(at(9)) {
+		t.Fatalf("revision/updated wrong: rev=%d", inc.Revision)
+	}
+	// State, Disposition, and Risk are independent: closed + true_positive + risk still 88.
+	if inc.Risk.Risk != 88 {
+		t.Fatal("risk must not be mutated by state/disposition changes")
+	}
+}
+
+func TestProjectIsReplayDeterministic(t *testing.T) {
+	events := []IncidentEvent{
+		created("det-1"),
+		{IncidentID: incID, Kind: EventStatusChanged, At: at(1), Actor: "a", To: StateTriaged},
+		{IncidentID: incID, Kind: EventStatusChanged, At: at(2), Actor: "a", To: StateInvestigating},
+	}
+	a, err1 := Project(events)
+	b, err2 := Project(events)
+	if err1 != nil || err2 != nil {
+		t.Fatalf("errs: %v %v", err1, err2)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Fatal("replay must be deterministic")
+	}
+}
+
+func TestProjectRejectsIllegalTransition(t *testing.T) {
+	// new -> resolved is not legal (must pass through investigation/containment).
+	events := []IncidentEvent{
+		created("det-1"),
+		{IncidentID: incID, Kind: EventStatusChanged, At: at(1), Actor: "a", To: StateResolved},
+	}
+	if _, err := Project(events); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("illegal transition must be rejected, got %v", err)
+	}
+}
+
+func TestProjectDetachAndDedupDetections(t *testing.T) {
+	events := []IncidentEvent{
+		created("det-1"),
+		{IncidentID: incID, Kind: EventDetectionAttached, At: at(1), Actor: "c", DetectionID: "det-2"},
+		{IncidentID: incID, Kind: EventDetectionAttached, At: at(2), Actor: "c", DetectionID: "det-2"}, // dup no-op
+		{IncidentID: incID, Kind: EventDetectionDetached, At: at(3), Actor: "c", DetectionID: "det-1"},
+	}
+	inc, err := Project(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inc.DetectionIDs) != 1 || inc.DetectionIDs[0] != "det-2" {
+		t.Fatalf("detach/dedup wrong: %+v", inc.DetectionIDs)
+	}
+}
+
+func TestProjectResponseRefs(t *testing.T) {
+	events := []IncidentEvent{
+		created("det-1"),
+		{IncidentID: incID, Kind: EventStatusChanged, At: at(1), Actor: "a", To: StateInvestigating},
+		{IncidentID: incID, Kind: EventResponseRequested, At: at(2), Actor: "a", ResponseActionID: "act-1"},
+		{IncidentID: incID, Kind: EventResponseVerified, At: at(3), Actor: "agent", ResponseActionID: "act-1"},
+		{IncidentID: incID, Kind: EventResponseVerified, At: at(4), Actor: "agent", ResponseActionID: "act-2"}, // verify w/o request → upsert
+	}
+	inc, err := Project(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inc.Responses) != 2 {
+		t.Fatalf("responses wrong: %+v", inc.Responses)
+	}
+	if !inc.Responses[0].Verified || inc.Responses[0].ActionID != "act-1" {
+		t.Fatalf("act-1 must be verified: %+v", inc.Responses)
+	}
+	if !inc.Responses[1].Verified || inc.Responses[1].ActionID != "act-2" {
+		t.Fatalf("act-2 upsert-verified: %+v", inc.Responses)
+	}
+}
+
+func TestProjectMerged(t *testing.T) {
+	events := []IncidentEvent{
+		created("det-1"),
+		{IncidentID: incID, Kind: EventMerged, At: at(1), Actor: "correlator", MergedInto: "inc-2"},
+	}
+	inc, err := Project(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inc.IsMerged() || inc.MergedInto != "inc-2" {
+		t.Fatalf("merged wrong: %+v", inc)
+	}
+}
+
+func TestProjectFailsClosed(t *testing.T) {
+	cases := map[string][]IncidentEvent{
+		"empty": {},
+		"first not created": {
+			{IncidentID: incID, Kind: EventStatusChanged, At: at(0), Actor: "a", To: StateOpen},
+		},
+		"second created": {
+			created("det-1"),
+			{IncidentID: incID, Kind: EventCreated, At: at(1), Actor: "a", AssetID: assetID},
+		},
+		"wrong incident id": {
+			created("det-1"),
+			{IncidentID: "inc-other", Kind: EventAnalystCommented, At: at(1), Actor: "a", Comment: "x"},
+		},
+		"invalid event (no actor)": {
+			{IncidentID: incID, Kind: EventCreated, At: at(0), AssetID: assetID},
+		},
+	}
+	for name, events := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Project(events); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("must fail closed, got %v", err)
+			}
+		})
+	}
+}
+
+func TestIncidentEventValidatePerKind(t *testing.T) {
+	ok := func(e IncidentEvent) IncidentEvent { e.IncidentID = incID; e.At = at(0); e.Actor = "a"; return e }
+	bad := map[string]IncidentEvent{
+		"created no asset":     ok(IncidentEvent{Kind: EventCreated}),
+		"created bad severity": ok(IncidentEvent{Kind: EventCreated, AssetID: assetID, Severity: "nope"}),
+		"attach no detection":  ok(IncidentEvent{Kind: EventDetectionAttached}),
+		"status invalid":       ok(IncidentEvent{Kind: EventStatusChanged, To: "nope"}),
+		"owner empty":          ok(IncidentEvent{Kind: EventOwnerChanged}),
+		"disposition invalid":  ok(IncidentEvent{Kind: EventDispositionSet, Disposition: "nope"}),
+		"risk nil":             ok(IncidentEvent{Kind: EventRiskReassessed}),
+		"comment empty":        ok(IncidentEvent{Kind: EventAnalystCommented}),
+		"merged no target":     ok(IncidentEvent{Kind: EventMerged}),
+		"response no id":       ok(IncidentEvent{Kind: EventResponseRequested}),
+		"unknown kind":         ok(IncidentEvent{Kind: "wat"}),
+		"no incident id":       {Kind: EventCreated, At: at(0), Actor: "a", AssetID: assetID},
+		"no timestamp":         {IncidentID: incID, Kind: EventCreated, Actor: "a", AssetID: assetID},
+	}
+	for name, e := range bad {
+		if err := e.Validate(); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("%s must be rejected, got %v", name, err)
+		}
+	}
+	// A valid risk_reassessed with an INVALID assessment is rejected (delegates to RiskAssessment.Validate).
+	e := ok(IncidentEvent{Kind: EventRiskReassessed, Risk: &riskassessment.RiskAssessment{AssessmentID: "r", ScorerVersion: "v", PolicyVersion: "p", Risk: 200}})
+	if err := e.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("risk with out-of-range score must be rejected, got %v", err)
+	}
+}
+
+func TestProjectRejectsBackdatedEvent(t *testing.T) {
+	events := []IncidentEvent{
+		created("det-1"), // at(0)
+		{IncidentID: incID, Kind: EventStatusChanged, At: at(5), Actor: "a", To: StateInvestigating},  // at(5)
+		{IncidentID: incID, Kind: EventAnalystCommented, At: at(2), Actor: "a", Comment: "backdated"}, // at(2) < at(5)
+	}
+	if _, err := Project(events); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a backdated event must be rejected, got %v", err)
+	}
+	// Equal timestamps are allowed (two changes in the same instant).
+	ok := []IncidentEvent{
+		created("det-1"),
+		{IncidentID: incID, Kind: EventOwnerChanged, At: at(0), Actor: "a", Owner: "alice"},
+	}
+	if _, err := Project(ok); err != nil {
+		t.Fatalf("equal timestamps must be allowed, got %v", err)
+	}
+}

--- a/internal/domain/incident/state.go
+++ b/internal/domain/incident/state.go
@@ -1,0 +1,70 @@
+// Package incident is the pure-domain, event-sourced Incident primitive for Phase C of the EDR data plane
+// (#594, C1 #675). Its central discipline: an incident's State (where it is in the response workflow),
+// its Disposition (the analyst's verdict), and its risk (how dangerous / how sure / how well-observed)
+// are FOUR DIFFERENT THINGS and never conflated. An incident is an ordered log of IncidentEvents folded
+// into a mutable projection, so every change is attributable, replayable, and diffable — no field is set
+// except through an event.
+package incident
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// State is where an incident sits in the response workflow. It is independent of Disposition (the verdict)
+// and of risk.
+type State string
+
+const (
+	StateNew           State = "new"
+	StateOpen          State = "open"
+	StateTriaged       State = "triaged"
+	StateInvestigating State = "investigating"
+	StateContained     State = "contained"
+	StateRemediated    State = "remediated"
+	StateResolved      State = "resolved"
+	StateClosed        State = "closed"
+	StateReopened      State = "reopened"
+)
+
+// allowedTransitions is the legal state graph. A StatusChanged event to a state not reachable from the
+// current one fails the fold closed, so an incident's history can never contain an impossible workflow.
+var allowedTransitions = map[State][]State{
+	StateNew:           {StateOpen, StateTriaged, StateInvestigating, StateClosed},
+	StateOpen:          {StateTriaged, StateInvestigating, StateContained, StateClosed},
+	StateTriaged:       {StateInvestigating, StateContained, StateResolved, StateClosed},
+	StateInvestigating: {StateContained, StateRemediated, StateResolved, StateClosed},
+	StateContained:     {StateInvestigating, StateRemediated, StateResolved, StateClosed},
+	StateRemediated:    {StateResolved, StateClosed},
+	StateResolved:      {StateClosed, StateReopened},
+	StateClosed:        {StateReopened},
+	StateReopened:      {StateOpen, StateTriaged, StateInvestigating, StateClosed},
+}
+
+// Valid reports whether s is a known state.
+func (s State) Valid() bool {
+	_, ok := allowedTransitions[s]
+	return ok
+}
+
+// CanTransition reports whether from -> to is a legal workflow transition.
+func CanTransition(from, to State) bool {
+	for _, n := range allowedTransitions[from] {
+		if n == to {
+			return true
+		}
+	}
+	return false
+}
+
+// requireTransition returns an error if from -> to is not legal.
+func requireTransition(from, to State) error {
+	if !to.Valid() {
+		return fmt.Errorf("%w: unknown incident state %q", shared.ErrValidation, to)
+	}
+	if !CanTransition(from, to) {
+		return fmt.Errorf("%w: illegal incident transition %s -> %s", shared.ErrValidation, from, to)
+	}
+	return nil
+}

--- a/internal/domain/incident/state_test.go
+++ b/internal/domain/incident/state_test.go
@@ -1,0 +1,31 @@
+package incident
+
+import "testing"
+
+func TestStateValidAndTransitions(t *testing.T) {
+	if !StateOpen.Valid() || State("bogus").Valid() {
+		t.Fatal("Valid() wrong")
+	}
+	legal := [][2]State{
+		{StateNew, StateOpen}, {StateNew, StateInvestigating}, {StateOpen, StateInvestigating}, {StateInvestigating, StateContained},
+		{StateContained, StateRemediated}, {StateRemediated, StateResolved}, {StateResolved, StateClosed},
+		{StateClosed, StateReopened}, {StateReopened, StateInvestigating}, {StateResolved, StateReopened},
+	}
+	for _, tc := range legal {
+		if !CanTransition(tc[0], tc[1]) {
+			t.Fatalf("expected legal transition %s -> %s", tc[0], tc[1])
+		}
+	}
+	illegal := [][2]State{
+		{StateOpen, StateResolved},  // must pass through investigation/containment
+		{StateNew, StateResolved},   // can't jump to resolved
+		{StateClosed, StateOpen},    // closed only reopens
+		{StateResolved, StateOpen},  // resolved only closes or reopens
+		{StateOpen, State("bogus")}, // unknown target
+	}
+	for _, tc := range illegal {
+		if CanTransition(tc[0], tc[1]) {
+			t.Fatalf("expected illegal transition %s -> %s", tc[0], tc[1])
+		}
+	}
+}

--- a/internal/domain/riskassessment/riskassessment.go
+++ b/internal/domain/riskassessment/riskassessment.go
@@ -1,0 +1,153 @@
+// Package riskassessment is the pure-domain tri-score risk model for Phase C of the EDR data plane
+// (#594, C3 #677). Its central discipline: Risk, Confidence, and Coverage are THREE DIFFERENT THINGS and
+// are carried as separate fields — Risk is how dangerous the situation is if real, Confidence is how
+// strong/consistent the evidence is, and Coverage is how much of the data needed to judge it was actually
+// observed. Missing coverage lowers Coverage (and may lower Confidence) but must NEVER silently lower
+// Risk: a high-risk situation seen through a partial sensor is (Risk 88 / Confidence 61 / Coverage 43),
+// never a diluted Risk 47.
+//
+// This package defines the value types (RiskContext, CoverageVector, RiskAssessment) and their validation.
+// The deterministic scorer that produces a RiskAssessment from inputs is C3, built on top of these types.
+package riskassessment
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Score is a normalized 0..100 factor. It is deliberately not a float: risk scoring here is deterministic
+// and reproducible, and integer points avoid float non-determinism in hashing/equality.
+type Score int
+
+// Valid reports whether the score is within 0..100.
+func (s Score) Valid() bool { return s >= 0 && s <= 100 }
+
+// RiskContext carries the three independent RISK factors that feed a RiskAssessment. Each is owned by a
+// different pillar: Threat by Phase C runtime detection/correlation, Exposure by continuous-exposure
+// fusion (X5 #634), Behavior by behavioral EDR (D #639). Exposure/Behavior are zero until those pillars
+// fill them — which lowers Coverage (a factor was not observed), never Risk.
+type RiskContext struct {
+	Threat   Score
+	Exposure Score
+	Behavior Score
+}
+
+// namedScore pairs a field name with its score for fixed-order validation (so the error message is
+// deterministic when more than one field is out of range).
+type namedScore struct {
+	name  string
+	score Score
+}
+
+func validateScores(scores []namedScore, subject string) error {
+	for _, ns := range scores {
+		if !ns.score.Valid() {
+			return fmt.Errorf("%w: %s %s score %d out of range", shared.ErrValidation, subject, ns.name, ns.score)
+		}
+	}
+	return nil
+}
+
+// Validate enforces in-range factor scores.
+func (c RiskContext) Validate() error {
+	return validateScores([]namedScore{
+		{"threat", c.Threat}, {"exposure", c.Exposure}, {"behavior", c.Behavior},
+	}, "risk context")
+}
+
+// CoverageVector is coverage as a VECTOR, per telemetry class, not a scalar — so "we saw all the process
+// events but no network events" is representable and not averaged away. Reasons carries WHY coverage is
+// below full (a gap, a sampled window, staleness); uncertainty is carried, never flattened.
+type CoverageVector struct {
+	Process   Score
+	Network   Score
+	File      Score
+	Privilege Score
+	Reasons   []string
+}
+
+// Validate enforces in-range per-class coverage.
+func (v CoverageVector) Validate() error {
+	return validateScores([]namedScore{
+		{"process", v.Process}, {"network", v.Network}, {"file", v.File}, {"privilege", v.Privilege},
+	}, "coverage")
+}
+
+// Floor returns the minimum per-class coverage — the honest scalar summary of the vector (the weakest
+// class bounds how much of the picture was observed). It never inflates coverage by averaging.
+func (v CoverageVector) Floor() Score {
+	floor := v.Process
+	for _, s := range []Score{v.Network, v.File, v.Privilege} {
+		if s < floor {
+			floor = s
+		}
+	}
+	return floor
+}
+
+// FactorContribution is one weighted input to the Risk score, with a human reason — so a Risk value is
+// always explainable back to what drove it.
+type FactorContribution struct {
+	Factor string
+	Points Score
+	Reason string
+}
+
+// RiskAssessment is a versioned, reproducible tri-score risk judgment for an incident revision. It is
+// produced by the C3 scorer and carried on the incident via a RiskReassessed event. InputSnapshotHash +
+// ScorerVersion + PolicyVersion make it reproducible and auditable; a weight change is a version change,
+// preserving cross-tenant comparability.
+type RiskAssessment struct {
+	AssessmentID        shared.ID
+	IncidentRevision    int
+	ScorerVersion       string
+	PolicyVersion       string
+	InputSnapshotHash   string
+	Risk                Score
+	Confidence          Score
+	Coverage            Score
+	CoverageVector      CoverageVector
+	Context             RiskContext
+	FactorContributions []FactorContribution
+	ReasonCodes         []string
+	CreatedAt           time.Time
+}
+
+// Validate enforces a well-formed assessment: an id, in-range tri-scores, a valid context + coverage
+// vector, and version metadata.
+func (r RiskAssessment) Validate() error {
+	if r.AssessmentID.IsZero() {
+		return fmt.Errorf("%w: risk assessment has no id", shared.ErrValidation)
+	}
+	if r.ScorerVersion == "" || r.PolicyVersion == "" {
+		return fmt.Errorf("%w: risk assessment must record scorer and policy versions", shared.ErrValidation)
+	}
+	if err := validateScores([]namedScore{
+		{"risk", r.Risk}, {"confidence", r.Confidence}, {"coverage", r.Coverage},
+	}, "risk assessment"); err != nil {
+		return err
+	}
+	if err := r.Context.Validate(); err != nil {
+		return err
+	}
+	if err := r.CoverageVector.Validate(); err != nil {
+		return err
+	}
+	for _, fc := range r.FactorContributions {
+		if !fc.Points.Valid() {
+			return fmt.Errorf("%w: factor %q points %d out of range", shared.ErrValidation, fc.Factor, fc.Points)
+		}
+	}
+	return nil
+}
+
+// Clone returns a deep copy so a caller cannot mutate the assessment held on an incident projection.
+func (r RiskAssessment) Clone() RiskAssessment {
+	c := r
+	c.CoverageVector.Reasons = append([]string(nil), r.CoverageVector.Reasons...)
+	c.FactorContributions = append([]FactorContribution(nil), r.FactorContributions...)
+	c.ReasonCodes = append([]string(nil), r.ReasonCodes...)
+	return c
+}

--- a/internal/domain/riskassessment/riskassessment_test.go
+++ b/internal/domain/riskassessment/riskassessment_test.go
@@ -1,0 +1,71 @@
+package riskassessment
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func valid() RiskAssessment {
+	return RiskAssessment{
+		AssessmentID: "ra-1", ScorerVersion: "v1", PolicyVersion: "p1",
+		Risk: 88, Confidence: 61, Coverage: 43,
+		CoverageVector: CoverageVector{Process: 90, Network: 43, File: 80, Privilege: 70, Reasons: []string{"network sampled"}},
+		Context:        RiskContext{Threat: 88, Exposure: 0, Behavior: 0},
+	}
+}
+
+func TestRiskAssessmentValidate(t *testing.T) {
+	if err := valid().Validate(); err != nil {
+		t.Fatalf("valid assessment rejected: %v", err)
+	}
+	mut := func(f func(*RiskAssessment)) RiskAssessment { r := valid(); f(&r); return r }
+	bad := map[string]RiskAssessment{
+		"no id":        mut(func(r *RiskAssessment) { r.AssessmentID = "" }),
+		"no scorer":    mut(func(r *RiskAssessment) { r.ScorerVersion = "" }),
+		"no policy":    mut(func(r *RiskAssessment) { r.PolicyVersion = "" }),
+		"risk oob":     mut(func(r *RiskAssessment) { r.Risk = 101 }),
+		"coverage oob": mut(func(r *RiskAssessment) { r.Coverage = -1 }),
+		"vector oob":   mut(func(r *RiskAssessment) { r.CoverageVector.Network = 200 }),
+		"context oob":  mut(func(r *RiskAssessment) { r.Context.Exposure = 500 }),
+	}
+	for name, r := range bad {
+		if err := r.Validate(); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("%s must be rejected, got %v", name, err)
+		}
+	}
+}
+
+// TestTriScoreSeparation is the core discipline: a genuinely dangerous situation seen through a partial
+// sensor is high Risk / lower Confidence / low Coverage — the low coverage does NOT force Risk down. The
+// value type permits (and validates) that combination.
+func TestTriScoreSeparation(t *testing.T) {
+	r := valid() // Risk 88, Confidence 61, Coverage 43
+	if err := r.Validate(); err != nil {
+		t.Fatalf("high-risk low-coverage must be valid: %v", err)
+	}
+	if r.Risk != 88 || r.Coverage != 43 {
+		t.Fatal("Risk and Coverage must be independent fields")
+	}
+}
+
+func TestCoverageVectorFloor(t *testing.T) {
+	v := CoverageVector{Process: 90, Network: 43, File: 80, Privilege: 70}
+	if v.Floor() != 43 {
+		t.Fatalf("floor must be the weakest class, got %d", v.Floor())
+	}
+}
+
+func TestRiskAssessmentCloneIsDeep(t *testing.T) {
+	r := valid()
+	r.ReasonCodes = []string{"kev"}
+	r.FactorContributions = []FactorContribution{{Factor: "threat", Points: 88, Reason: "detection"}}
+	c := r.Clone()
+	c.CoverageVector.Reasons[0] = "mutated"
+	c.ReasonCodes[0] = "mutated"
+	c.FactorContributions[0].Reason = "mutated"
+	if r.CoverageVector.Reasons[0] == "mutated" || r.ReasonCodes[0] == "mutated" || r.FactorContributions[0].Reason == "mutated" {
+		t.Fatal("Clone must deep-copy slices")
+	}
+}


### PR DESCRIPTION
## Phase C foundation — event-sourced Incident (C1) + tri-score risk types (C3)

Opens Phase C of the EDR data-plane epic #594 (now split into #675–#681) with its two foundational **pure-domain** primitives that correlation, disposition, response, and persistence all build on.

### What's in it
- **`internal/domain/incident`** (C1 #675) — the **event-sourced Incident**. State (workflow), Disposition (verdict), and risk are **four different things**, never conflated. An incident is an ordered `IncidentEvent` log folded by `Project()` into a mutable projection:
  - `State`: `new→open→triaged→investigating→contained→remediated→resolved→closed↔reopened`, gated by a legal-transition table.
  - `Disposition`: unknown / true_positive / benign_positive / false_positive / duplicate / test.
  - Deterministic + replayable + **fail-closed**: the log must start with `Created`; every event is validated and attributable (actor + timestamp); illegal transitions and backdated events are rejected; no partial projection on error.
  - Distinct from the legacy lightweight `detection.Incident` rollup view (doc cross-referenced).
- **`internal/domain/riskassessment`** (C3 #677, types only) — the **tri-score** model. `Risk` / `Confidence` / `Coverage` are **separate** fields plus a per-class `CoverageVector`, so missing coverage lowers Coverage/Confidence but **never silently lowers Risk** (Risk 88 / Confidence 61 / Coverage 43, not a diluted 47). The deterministic scorer is C3 proper.

### Review
Dual-reviewed. **go-arch: MERGEABLE** (dependency rule PASS, sound event-sourcing fold, separation of concerns confirmed). **security: SHIP** (attribution, fail-closed projection, replay determinism, tri-score honesty, no-panic — all confirmed, backed by tests). Their non-blocking items are folded in **here**: a monotonic-timestamp guard, deterministic (fixed-order) validators, `Created` now lands in the reachable `new` state, and a doc cross-ref to `detection.Incident`.

### Verification (CI off — validated locally)
Pure domain (imports only `domain/{riskassessment,shared}`); `go build`/`go vet`/`gofmt -l` clean; `go test -race` green; coverage 95.8% (incident) / 93.5% (riskassessment), including replay-determinism, equal/backdated-timestamp, illegal-transition, and per-kind fail-closed tests.

### Scope / follow-ups
Correlation (C2 #676), the risk scorer (C3 #677), retro-hunt (C4 #678), disposition workflow (C5 #679), governed-response verify (C6 #680), and incident persistence + HTTP (C7 #681) build on these primitives.
