### PR TITLE
feat(correlation): C2 event-time detection→incident correlation (#676)

### DIFF
--- a/internal/domain/correlation/correlator.go
+++ b/internal/domain/correlation/correlator.go
@@ -1,0 +1,219 @@
+package correlation
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// defaultActor is the attribution stamped on correlator-authored incident events.
+const defaultActor = "correlator"
+
+// Config tunes correlation. Zero fields take documented defaults.
+type Config struct {
+	// Window is the session gap: within one (asset, entity) key, a signal more than Window after the
+	// previous signal starts a NEW incident; otherwise it joins the current one. Must be > 0.
+	Window time.Duration
+	// MaxPerIncident caps how many signals an incident reflects individually (the Created signal plus
+	// attaches). Beyond it, further signals are suppressed as a storm and recorded as a single note
+	// (coverage-honest). Must be > 0.
+	MaxPerIncident int
+	// Actor is the attribution for emitted events; defaults to "correlator".
+	Actor string
+}
+
+func (c Config) withDefaults() Config {
+	if c.Actor == "" {
+		c.Actor = defaultActor
+	}
+	return c
+}
+
+// Correlate folds detection signals into incidents and returns the incident.IncidentEvent log to persist
+// and project. It is deterministic and event-time-based: signals are ordered by (OccurredAt, ID) so an
+// out-of-order input yields the same incidents; duplicates (by signal ID) are collapsed; each (asset,
+// entity) session within Window becomes one incident; a storm beyond MaxPerIncident is suppressed to a
+// single recorded note.
+//
+// Output contract: the returned slice contains the events for MULTIPLE incidents, contiguous per incident
+// and ordered by incident id. Each incident's sub-slice is internally time-ordered and Created-first, so a
+// consumer (C7 persistence) appends the flat stream as-is, but a caller that PROJECTS must first partition
+// by IncidentID and fold each incident separately — folding the whole flat slice through one
+// incident.Project would fail on the second Created.
+//
+// This is BATCH correlation over a complete signal set. Incident identity is seeded on a session's
+// earliest signal, so an incremental re-run over a backfilled window whose earliest signal changed would
+// mint a different incident id; C7 should correlate over stable/complete windows (streaming watermark +
+// late-event revision are a documented extension, not implemented here).
+func Correlate(cfg Config, signals []Signal) ([]incident.IncidentEvent, error) {
+	cfg = cfg.withDefaults()
+	if cfg.Window <= 0 {
+		return nil, fmt.Errorf("%w: correlation window must be positive", shared.ErrValidation)
+	}
+	if cfg.MaxPerIncident <= 0 {
+		return nil, fmt.Errorf("%w: correlation max-per-incident must be positive", shared.ErrValidation)
+	}
+
+	ordered, err := dedupeAndOrder(signals)
+	if err != nil {
+		return nil, err
+	}
+
+	// Partition into per-key sessions, preserving event-time order within each key.
+	byKey := map[correlationKey][]Signal{}
+	var keyOrder []correlationKey
+	for _, s := range ordered {
+		k := s.key()
+		if _, seen := byKey[k]; !seen {
+			keyOrder = append(keyOrder, k)
+		}
+		byKey[k] = append(byKey[k], s)
+	}
+
+	type builtIncident struct {
+		id     shared.ID
+		events []incident.IncidentEvent
+	}
+	var incidents []builtIncident
+	for _, k := range keyOrder {
+		for _, session := range sessions(byKey[k], cfg.Window) {
+			incidents = append(incidents, builtIncident{
+				id:     incidentID(k.asset, k.entity, session[0].ID),
+				events: sessionEvents(cfg, k, session),
+			})
+		}
+	}
+	// Stable output: incidents ordered by id, events already in event-time order within each.
+	sort.Slice(incidents, func(i, j int) bool { return incidents[i].id < incidents[j].id })
+	var out []incident.IncidentEvent
+	for _, inc := range incidents {
+		out = append(out, inc.events...)
+	}
+	return out, nil
+}
+
+// dedupeAndOrder validates every signal and folds duplicate detection ids into one representative, then
+// returns the representatives ordered by (OccurredAt, ID). Folding a duplicate id by the MAX severity (and
+// on a tie the earliest observation) makes dedupe total and deterministic regardless of input order, and
+// keeps it coverage-honest: if the data plane ever re-emits a detection id with a higher severity (an
+// escalation), the escalation is never discarded. A detection id is expected to be immutable upstream, so
+// this fold is normally a no-op over identical repeats.
+func dedupeAndOrder(signals []Signal) ([]Signal, error) {
+	best := make(map[shared.ID]Signal, len(signals))
+	for _, s := range signals {
+		if err := s.Validate(); err != nil {
+			return nil, err
+		}
+		if cur, ok := best[s.ID]; !ok || preferSignal(s, cur) {
+			best[s.ID] = s
+		}
+	}
+	out := make([]Signal, 0, len(best))
+	for _, s := range best {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].OccurredAt.Equal(out[j].OccurredAt) {
+			return out[i].OccurredAt.Before(out[j].OccurredAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+// preferSignal reports whether a should replace b as the representative of a duplicate detection id:
+// higher severity wins (an escalation is never lost); on equal severity the earlier observation wins.
+// Fully deterministic and total — two records with equal id, severity, and time keep the incumbent.
+func preferSignal(a, b Signal) bool {
+	ra, rb := shared.SeverityRank(a.Severity), shared.SeverityRank(b.Severity)
+	if ra != rb {
+		return ra > rb
+	}
+	return a.OccurredAt.Before(b.OccurredAt)
+}
+
+// sessions splits event-time-ordered signals for one key into sessions: a gap greater than window since
+// the previous signal starts a new session.
+func sessions(signals []Signal, window time.Duration) [][]Signal {
+	var out [][]Signal
+	var cur []Signal
+	for _, s := range signals {
+		if len(cur) > 0 && s.OccurredAt.Sub(cur[len(cur)-1].OccurredAt) > window {
+			out = append(out, cur)
+			cur = nil
+		}
+		cur = append(cur, s)
+	}
+	if len(cur) > 0 {
+		out = append(out, cur)
+	}
+	return out
+}
+
+// sessionEvents builds the incident event log for one session: a Created (carrying the session's MAX
+// severity so a later, more severe signal is not masked by the first), attaches up to the storm cap, and
+// a single suppression note beyond it.
+func sessionEvents(cfg Config, k correlationKey, session []Signal) []incident.IncidentEvent {
+	id := incidentID(k.asset, k.entity, session[0].ID)
+	first := session[0]
+	title := first.Title
+	if title == "" {
+		title = first.RuleID // fall back to the rule name so a correlated incident is never untitled
+	}
+	events := []incident.IncidentEvent{{
+		IncidentID: id, Kind: incident.EventCreated, At: first.OccurredAt, Actor: cfg.Actor,
+		AssetID: k.asset, Title: title, Severity: maxSeverity(session), DetectionID: first.ID,
+	}}
+	suppressed := 0
+	for _, s := range session[1:] {
+		if len(events) >= cfg.MaxPerIncident {
+			suppressed++
+			continue
+		}
+		events = append(events, incident.IncidentEvent{
+			IncidentID: id, Kind: incident.EventDetectionAttached, At: s.OccurredAt, Actor: cfg.Actor,
+			DetectionID: s.ID,
+		})
+	}
+	if suppressed > 0 {
+		events = append(events, incident.IncidentEvent{
+			IncidentID: id, Kind: incident.EventAnalystCommented, At: session[len(session)-1].OccurredAt, Actor: cfg.Actor,
+			Comment: fmt.Sprintf("correlation storm: %d further signal(s) suppressed from this incident", suppressed),
+		})
+	}
+	return events
+}
+
+// maxSeverity returns the highest severity among a session's signals (empty if none carry one).
+func maxSeverity(session []Signal) shared.Severity {
+	var best shared.Severity
+	for _, s := range session {
+		if s.Severity == "" {
+			continue
+		}
+		if best == "" || shared.SeverityRank(s.Severity) > shared.SeverityRank(best) {
+			best = s.Severity
+		}
+	}
+	return best
+}
+
+// incidentID derives a stable incident id from (asset, entity, first-signal id) — domain-separated,
+// length-prefixed sha256, so re-correlating the same signals yields the same incident id.
+func incidentID(asset, entity, firstSignal shared.ID) shared.ID {
+	h := sha256.New()
+	for _, part := range []string{"correlation:incident:v1", asset.String(), entity.String(), firstSignal.String()} {
+		var lp [8]byte
+		binary.BigEndian.PutUint64(lp[:], uint64(len(part)))
+		_, _ = h.Write(lp[:])
+		_, _ = io.WriteString(h, part)
+	}
+	return shared.ID("inc_" + hex.EncodeToString(h.Sum(nil))[:32])
+}

--- a/internal/domain/correlation/correlator_test.go
+++ b/internal/domain/correlation/correlator_test.go
@@ -1,0 +1,201 @@
+package correlation
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	asset  = shared.ID("asset-1")
+	entity = shared.ID("pe-1")
+)
+
+var base = time.Unix(1_800_000_000, 0).UTC()
+
+func at(sec int) time.Time { return base.Add(time.Duration(sec) * time.Second) }
+
+func sig(id string, occ time.Time, sev shared.Severity) Signal {
+	return Signal{ID: shared.ID(id), AssetID: asset, EntityID: entity, OccurredAt: occ, Severity: sev, Title: "t-" + id}
+}
+
+func cfg() Config { return Config{Window: time.Minute, MaxPerIncident: 100} }
+
+// project groups events by incident and folds each — proves the correlator output is a valid C1 log.
+func project(t *testing.T, events []incident.IncidentEvent) map[shared.ID]incident.Incident {
+	t.Helper()
+	byInc := map[shared.ID][]incident.IncidentEvent{}
+	var order []shared.ID
+	for _, e := range events {
+		if _, ok := byInc[e.IncidentID]; !ok {
+			order = append(order, e.IncidentID)
+		}
+		byInc[e.IncidentID] = append(byInc[e.IncidentID], e)
+	}
+	out := map[shared.ID]incident.Incident{}
+	for _, id := range order {
+		inc, err := incident.Project(byInc[id])
+		if err != nil {
+			t.Fatalf("project incident %s: %v", id, err)
+		}
+		out[id] = inc
+	}
+	return out
+}
+
+func TestCorrelateGroupsSessionIntoOneIncident(t *testing.T) {
+	events, err := Correlate(cfg(), []Signal{
+		sig("d1", at(0), shared.SeverityLow),
+		sig("d2", at(10), shared.SeverityHigh),
+		sig("d3", at(20), shared.SeverityMedium),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	incs := project(t, events)
+	if len(incs) != 1 {
+		t.Fatalf("one session must be one incident, got %d", len(incs))
+	}
+	for _, inc := range incs {
+		if len(inc.DetectionIDs) != 3 {
+			t.Fatalf("all 3 detections must attach: %+v", inc.DetectionIDs)
+		}
+		if inc.Severity != shared.SeverityHigh {
+			t.Fatalf("incident severity must be the session max (high): %q", inc.Severity)
+		}
+		if inc.State != incident.StateNew {
+			t.Fatalf("correlated incident starts new, got %q", inc.State)
+		}
+	}
+}
+
+func TestCorrelateSplitsOnWindowGap(t *testing.T) {
+	// A gap > Window (60s) starts a new incident.
+	events, err := Correlate(cfg(), []Signal{
+		sig("d1", at(0), shared.SeverityMedium),
+		sig("d2", at(30), shared.SeverityMedium),
+		sig("d3", at(200), shared.SeverityMedium), // 170s after d2 -> new session
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incs := project(t, events); len(incs) != 2 {
+		t.Fatalf("a window gap must split into 2 incidents, got %d", len(incs))
+	}
+}
+
+func TestCorrelateDistinctEntitiesAreDistinctIncidents(t *testing.T) {
+	other := Signal{ID: "d2", AssetID: asset, EntityID: "pe-2", OccurredAt: at(1), Severity: shared.SeverityLow, Title: "t"}
+	events, err := Correlate(cfg(), []Signal{sig("d1", at(0), shared.SeverityLow), other})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incs := project(t, events); len(incs) != 2 {
+		t.Fatalf("distinct entities must be distinct incidents, got %d", len(incs))
+	}
+}
+
+func TestCorrelateIsOrderInvariantAndDedupes(t *testing.T) {
+	forward := []Signal{sig("d1", at(0), shared.SeverityLow), sig("d2", at(10), shared.SeverityHigh), sig("d3", at(20), shared.SeverityLow)}
+	reverse := []Signal{sig("d3", at(20), shared.SeverityLow), sig("d2", at(10), shared.SeverityHigh), sig("d1", at(0), shared.SeverityLow), sig("d2", at(10), shared.SeverityHigh)} // reversed + a duplicate d2
+	a, err1 := Correlate(cfg(), forward)
+	b, err2 := Correlate(cfg(), reverse)
+	if err1 != nil || err2 != nil {
+		t.Fatalf("errs: %v %v", err1, err2)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("correlation must be order-invariant + deduped:\n a=%+v\n b=%+v", a, b)
+	}
+	for _, inc := range project(t, a) {
+		if len(inc.DetectionIDs) != 3 {
+			t.Fatalf("duplicate signal must not double-attach: %+v", inc.DetectionIDs)
+		}
+	}
+}
+
+func TestCorrelateAntiStorm(t *testing.T) {
+	c := Config{Window: time.Minute, MaxPerIncident: 3}
+	var signals []Signal
+	for i := 0; i < 10; i++ {
+		signals = append(signals, sig("d"+string(rune('0'+i)), at(i), shared.SeverityMedium))
+	}
+	events, err := Correlate(c, signals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	incs := project(t, events)
+	if len(incs) != 1 {
+		t.Fatalf("one storm session is one incident, got %d", len(incs))
+	}
+	for _, inc := range incs {
+		// Created(1) + 2 attaches = 3 individually reflected; the other 7 are suppressed.
+		if len(inc.DetectionIDs) != 3 {
+			t.Fatalf("anti-storm must cap attaches at MaxPerIncident, got %d", len(inc.DetectionIDs))
+		}
+		if len(inc.Comments) != 1 {
+			t.Fatalf("suppression must be recorded as one note (coverage honesty), got %d", len(inc.Comments))
+		}
+	}
+}
+
+func TestCorrelateDeterministicIncidentID(t *testing.T) {
+	a, _ := Correlate(cfg(), []Signal{sig("d1", at(0), shared.SeverityLow)})
+	b, _ := Correlate(cfg(), []Signal{sig("d1", at(0), shared.SeverityLow)})
+	if a[0].IncidentID != b[0].IncidentID || a[0].IncidentID.IsZero() {
+		t.Fatalf("incident id must be deterministic + non-zero: %s vs %s", a[0].IncidentID, b[0].IncidentID)
+	}
+}
+
+func TestCorrelateValidatesConfigAndSignals(t *testing.T) {
+	if _, err := Correlate(Config{Window: 0, MaxPerIncident: 1}, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("zero window must be rejected")
+	}
+	if _, err := Correlate(Config{Window: time.Minute, MaxPerIncident: 0}, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("zero max-per-incident must be rejected")
+	}
+	if _, err := Correlate(cfg(), []Signal{{AssetID: asset, OccurredAt: at(0)}}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("signal without id must be rejected")
+	}
+	// Empty input is valid: no incidents.
+	if evs, err := Correlate(cfg(), nil); err != nil || len(evs) != 0 {
+		t.Fatalf("empty input: evs=%d err=%v", len(evs), err)
+	}
+}
+
+func TestCorrelateDedupeFoldsToMaxSeverity(t *testing.T) {
+	// The same detection id re-emitted with a higher severity (an escalation) must not be lost to dedupe.
+	forward := []Signal{sig("d1", at(0), shared.SeverityLow), sig("d1", at(0), shared.SeverityCritical)}
+	reverse := []Signal{sig("d1", at(0), shared.SeverityCritical), sig("d1", at(0), shared.SeverityLow)}
+	a, err := Correlate(cfg(), forward)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := Correlate(cfg(), reverse)
+	if !reflect.DeepEqual(a, b) {
+		t.Fatal("escalation fold must be order-invariant")
+	}
+	inc := project(t, a)
+	for _, i := range inc {
+		if i.Severity != shared.SeverityCritical {
+			t.Fatalf("escalated duplicate must raise severity to critical, got %q", i.Severity)
+		}
+		if len(i.DetectionIDs) != 1 {
+			t.Fatalf("same id must fold to one detection, got %+v", i.DetectionIDs)
+		}
+	}
+}
+
+func TestCorrelateTitleFallsBackToRuleID(t *testing.T) {
+	s := Signal{ID: "d1", AssetID: asset, EntityID: entity, OccurredAt: at(0), Severity: shared.SeverityHigh, RuleID: "T1059.exec"}
+	events, err := Correlate(cfg(), []Signal{s})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if events[0].Title != "T1059.exec" {
+		t.Fatalf("empty title must fall back to rule id, got %q", events[0].Title)
+	}
+}

--- a/internal/domain/correlation/signal.go
+++ b/internal/domain/correlation/signal.go
@@ -1,0 +1,55 @@
+// Package correlation is the pure-domain, deterministic engine that folds runtime detection signals into
+// incidents for Phase C of the EDR data plane (#594, C2 #676). It groups related signals by asset +
+// entity within an event-time session window into a single incident, emitting the incident.IncidentEvent
+// log that C1's Project folds and C7 persists. Correlation is EVENT-TIME, never ingest-order: signals are
+// ordered by their OccurredAt (with a stable id tiebreak) before folding, so an out-of-order input yields
+// the same incidents. Deduplication (by signal id), a bounded session window, and anti-storm suppression
+// keep a flood of repeats from exploding an incident while staying coverage-honest (the suppressed count
+// is recorded, never silently dropped).
+package correlation
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Signal is one thing to correlate — a runtime detection with the identity, entity, and event time needed
+// to group it. ID is the detection id and the dedupe key; EntityID is the process/network/file entity the
+// detection concerns (zero for an asset-level detection).
+type Signal struct {
+	ID         shared.ID
+	AssetID    shared.ID
+	EntityID   shared.ID
+	OccurredAt time.Time
+	Severity   shared.Severity
+	RuleID     string
+	Title      string
+}
+
+// Validate enforces a well-formed signal.
+func (s Signal) Validate() error {
+	if s.ID.IsZero() {
+		return fmt.Errorf("%w: correlation signal has no id", shared.ErrValidation)
+	}
+	if s.AssetID.IsZero() {
+		return fmt.Errorf("%w: correlation signal has no asset id", shared.ErrValidation)
+	}
+	if s.OccurredAt.IsZero() {
+		return fmt.Errorf("%w: correlation signal has no occurred-at time", shared.ErrValidation)
+	}
+	if s.Severity != "" && !s.Severity.Valid() {
+		return fmt.Errorf("%w: correlation signal has invalid severity %q", shared.ErrValidation, s.Severity)
+	}
+	return nil
+}
+
+// correlationKey is the grouping key: an incident collects signals for one (asset, entity). An asset-level
+// signal (no entity) groups under the asset alone.
+type correlationKey struct {
+	asset  shared.ID
+	entity shared.ID
+}
+
+func (s Signal) key() correlationKey { return correlationKey{asset: s.AssetID, entity: s.EntityID} }


### PR DESCRIPTION
## C2 — event-time detection→incident correlation (#676)

The deterministic correlation engine for Phase C (EDR epic #594): folds runtime detection **Signals** into incidents, emitting the `incident.IncidentEvent` log that C1 (#675) projects and C7 (#681) persists. New pure-domain package `internal/domain/correlation`.

### What it does
- **Event-time, not ingest-order**: signals ordered by `(OccurredAt, id)`, so out-of-order input yields identical incidents.
- **Session-window per (asset, entity)**: a gap > `Window` starts a new incident.
- **Dedupe** folds a duplicate detection id to one representative by **max severity then earliest time** — total, deterministic, and escalation-honest (a re-emitted higher severity is never lost).
- **Anti-storm**: attaches capped at `MaxPerIncident`; the overflow is recorded as one suppression note (never silently dropped); `Created` carries the session **max** severity (computed over suppressed signals too), so a later critical is never masked.
- Deterministic domain-separated incident id; every event attributed to the actor.

### Review
Dual-reviewed. **go-arch: MERGEABLE** (dependency rule PASS, deterministic, no map-order leak, folds cleanly through `incident.Project`). **security: SHIP** (no silent loss, determinism + attribution, severity integrity, fail-closed, no-panic — all confirmed). Non-blocking items folded in **here**: max-severity dedupe fold (deterministic tie + escalation honesty — resolves both reviewers' dedupe note), `RuleID` title fallback, and explicit docs for the flat grouped-by-incident output contract + the batch-vs-streaming / incident-id-stability note for C7.

### Verification (CI off — validated locally)
Pure domain (imports only `domain/{incident,shared}`); `go build`/`go vet`/`gofmt -l` clean; `go test -race` green at 94.8% — tests fold the emitted events through `incident.Project` to prove a valid C1 log.

### Scope / follow-ups
Streaming watermark + late-event revision are a documented extension; C7 (#681) should correlate over stable windows. Timeline/lineage-based correlation (linking via B's State Timeline) is a later enrichment.
