### PR TITLE
feat(incident): C7 append-only incident event-log persistence (#681)

### DIFF
--- a/internal/infrastructure/persistence/memory/incident_event_store.go
+++ b/internal/infrastructure/persistence/memory/incident_event_store.go
@@ -1,0 +1,133 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// defaultIncidentListLimit caps ListIncidentIDs; mirrors the Postgres tier.
+const defaultIncidentListLimit = 1000
+
+// IncidentEventStore is the in-memory twin of the append-only incident event log (Phase C / C7). It is
+// tenant-bucketed and enforces optimistic-concurrency append by log position, upholding the same contract
+// as the Postgres tier. Reached only through ports.IncidentEventStore.
+type IncidentEventStore struct {
+	mu   sync.Mutex
+	logs map[shared.ID]map[shared.ID][]incident.IncidentEvent // tenant -> incident -> ordered events
+}
+
+var _ ports.IncidentEventStore = (*IncidentEventStore)(nil)
+
+// NewIncidentEventStore creates an empty in-memory incident event store.
+func NewIncidentEventStore() *IncidentEventStore {
+	return &IncidentEventStore{logs: make(map[shared.ID]map[shared.ID][]incident.IncidentEvent)}
+}
+
+func requireIncidentTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: incident store operation requires a tenant in context", shared.ErrValidation)
+}
+
+// AppendEvents appends events under optimistic concurrency (expectedRevision must equal the current count).
+func (s *IncidentEventStore) AppendEvents(ctx context.Context, incidentID shared.ID, expectedRevision int, events []incident.IncidentEvent) error {
+	tenant, err := requireIncidentTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if incidentID.IsZero() {
+		return fmt.Errorf("%w: incident id is required", shared.ErrValidation)
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	for _, e := range events {
+		if err := e.Validate(); err != nil {
+			return err
+		}
+		if e.IncidentID != incidentID {
+			return fmt.Errorf("%w: event belongs to %s, not %s", shared.ErrValidation, e.IncidentID, incidentID)
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	byInc := s.logs[tenant]
+	if byInc == nil {
+		byInc = make(map[shared.ID][]incident.IncidentEvent)
+		s.logs[tenant] = byInc
+	}
+	if len(byInc[incidentID]) != expectedRevision {
+		return fmt.Errorf("%w: incident %s at revision %d, expected %d", shared.ErrConflict, incidentID, len(byInc[incidentID]), expectedRevision)
+	}
+	for _, e := range events {
+		byInc[incidentID] = append(byInc[incidentID], cloneIncidentEvent(e))
+	}
+	return nil
+}
+
+// cloneIncidentEvent deep-copies the one pointer field (Risk) so the append-only in-memory log cannot be
+// mutated through a pointer a caller retains; every other field is a value type. The Postgres tier is
+// immune (it serializes to JSON), so this keeps the twin faithful.
+func cloneIncidentEvent(e incident.IncidentEvent) incident.IncidentEvent {
+	if e.Risk != nil {
+		r := e.Risk.Clone()
+		e.Risk = &r
+	}
+	return e
+}
+
+// LoadEvents returns a copy of one incident's event log in order.
+func (s *IncidentEventStore) LoadEvents(ctx context.Context, incidentID shared.ID) ([]incident.IncidentEvent, error) {
+	tenant, err := requireIncidentTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	log := s.logs[tenant][incidentID]
+	if len(log) == 0 {
+		return nil, nil
+	}
+	out := make([]incident.IncidentEvent, len(log))
+	for i, e := range log {
+		out[i] = cloneIncidentEvent(e) // deep-copy Risk so a caller cannot mutate stored history
+	}
+	return out, nil
+}
+
+// ListIncidentIDs returns incident ids matching the query, ordered by id.
+func (s *IncidentEventStore) ListIncidentIDs(ctx context.Context, q ports.IncidentQuery) ([]shared.ID, error) {
+	tenant, err := requireIncidentTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	var ids []shared.ID
+	for id, log := range s.logs[tenant] {
+		if len(log) == 0 {
+			continue
+		}
+		if !q.AssetID.IsZero() && log[0].AssetID != q.AssetID {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	s.mu.Unlock()
+
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	limit := q.Limit
+	if limit <= 0 || limit > defaultIncidentListLimit {
+		limit = defaultIncidentListLimit
+	}
+	if len(ids) > limit {
+		ids = ids[:limit]
+	}
+	return ids, nil
+}

--- a/internal/infrastructure/persistence/memory/incident_event_store_test.go
+++ b/internal/infrastructure/persistence/memory/incident_event_store_test.go
@@ -1,0 +1,84 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	ieTenant = shared.ID("tenant-ie")
+	ieAsset  = shared.ID("asset-ie")
+	ieInc    = shared.ID("inc-ie")
+)
+
+var ieBase = time.Unix(1_800_000_000, 0).UTC()
+
+func ieCtx(tenant shared.ID) context.Context { return shared.WithTenant(context.Background(), tenant) }
+
+func createdEvent(inc, asset shared.ID) incident.IncidentEvent {
+	return incident.IncidentEvent{IncidentID: inc, Kind: incident.EventCreated, At: ieBase, Actor: "c", AssetID: asset, Severity: shared.SeverityHigh, DetectionID: "d1"}
+}
+
+func TestIncidentEventStoreAppendOptimisticAndLoad(t *testing.T) {
+	s := NewIncidentEventStore()
+	ctx := ieCtx(ieTenant)
+	if err := s.AppendEvents(ctx, ieInc, 0, []incident.IncidentEvent{createdEvent(ieInc, ieAsset)}); err != nil {
+		t.Fatal(err)
+	}
+	// Append at wrong expected revision -> conflict.
+	if err := s.AppendEvents(ctx, ieInc, 0, []incident.IncidentEvent{
+		{IncidentID: ieInc, Kind: incident.EventAnalystCommented, At: ieBase.Add(time.Second), Actor: "a", Comment: "x"},
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale revision must conflict, got %v", err)
+	}
+	// Correct revision -> appended.
+	if err := s.AppendEvents(ctx, ieInc, 1, []incident.IncidentEvent{
+		{IncidentID: ieInc, Kind: incident.EventAnalystCommented, At: ieBase.Add(time.Second), Actor: "a", Comment: "x"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := s.LoadEvents(ctx, ieInc)
+	if err != nil || len(events) != 2 {
+		t.Fatalf("load: %d err=%v", len(events), err)
+	}
+	if _, err := incident.Project(events); err != nil {
+		t.Fatalf("loaded log must project: %v", err)
+	}
+}
+
+func TestIncidentEventStoreRejectsForeignEvent(t *testing.T) {
+	s := NewIncidentEventStore()
+	ctx := ieCtx(ieTenant)
+	if err := s.AppendEvents(ctx, ieInc, 0, []incident.IncidentEvent{createdEvent("other-inc", ieAsset)}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("event for a different incident must be rejected, got %v", err)
+	}
+}
+
+func TestIncidentEventStoreListAndTenantIsolation(t *testing.T) {
+	s := NewIncidentEventStore()
+	if err := s.AppendEvents(ieCtx(ieTenant), ieInc, 0, []incident.IncidentEvent{createdEvent(ieInc, ieAsset)}); err != nil {
+		t.Fatal(err)
+	}
+	ids, err := s.ListIncidentIDs(ieCtx(ieTenant), ports.IncidentQuery{AssetID: ieAsset})
+	if err != nil || len(ids) != 1 || ids[0] != ieInc {
+		t.Fatalf("list by asset: %v err=%v", ids, err)
+	}
+	// Another tenant sees nothing, and cannot load the incident.
+	other := shared.ID("tenant-other")
+	if ids, _ := s.ListIncidentIDs(ieCtx(other), ports.IncidentQuery{}); len(ids) != 0 {
+		t.Fatalf("cross-tenant list must be empty, got %d", len(ids))
+	}
+	if ev, _ := s.LoadEvents(ieCtx(other), ieInc); len(ev) != 0 {
+		t.Fatalf("cross-tenant load must be empty, got %d", len(ev))
+	}
+	// Missing tenant fails closed.
+	if err := s.AppendEvents(context.Background(), ieInc, 1, []incident.IncidentEvent{createdEvent(ieInc, ieAsset)}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("append without tenant must fail closed, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/incident_event_repo.go
+++ b/internal/infrastructure/persistence/postgres/incident_event_repo.go
@@ -1,0 +1,167 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// defaultIncidentListLimit caps ListIncidentIDs; mirrors the memory tier.
+const defaultIncidentListLimit = 1000
+
+// IncidentEventRepository is the Postgres tier for the append-only incident event log (Phase C / C7).
+// Every method runs under the authenticated ctx tenant via WithContextTenant (RLS) with an explicit
+// tenant_id predicate as defense-in-depth. Appends are optimistic-concurrency by log position: the
+// (tenant, incident, seq) primary key makes two writers unable to both claim the next position. Reached
+// only through ports.IncidentEventStore.
+type IncidentEventRepository struct {
+	pool *pgxpool.Pool
+}
+
+var _ ports.IncidentEventStore = (*IncidentEventRepository)(nil)
+
+// NewIncidentEventRepository constructs the incident event store over a pgx pool.
+func NewIncidentEventRepository(pool *pgxpool.Pool) *IncidentEventRepository {
+	return &IncidentEventRepository{pool: pool}
+}
+
+// AppendEvents appends events under optimistic concurrency: the current event count must equal
+// expectedRevision, and the new rows take positions after it. A position collision (concurrent writer) or
+// a count mismatch returns shared.ErrConflict.
+func (r *IncidentEventRepository) AppendEvents(ctx context.Context, incidentID shared.ID, expectedRevision int, events []incident.IncidentEvent) error {
+	tenant, err := requireIncidentRepoTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if incidentID.IsZero() {
+		return fmt.Errorf("%w: incident id is required", shared.ErrValidation)
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	for _, e := range events {
+		if err := e.Validate(); err != nil {
+			return err
+		}
+		if e.IncidentID != incidentID {
+			return fmt.Errorf("%w: event belongs to %s, not %s", shared.ErrValidation, e.IncidentID, incidentID)
+		}
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		var count int
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM incident_events WHERE tenant_id=$1 AND incident_id=$2`,
+			tenant.String(), incidentID.String()).Scan(&count); err != nil {
+			return fmt.Errorf("count incident events: %w", err)
+		}
+		if count != expectedRevision {
+			return fmt.Errorf("%w: incident %s at revision %d, expected %d", shared.ErrConflict, incidentID, count, expectedRevision)
+		}
+		for i, e := range events {
+			payload, err := json.Marshal(e)
+			if err != nil {
+				return fmt.Errorf("marshal incident event: %w", err)
+			}
+			_, err = tx.Exec(ctx, `INSERT INTO incident_events
+				(tenant_id, incident_id, seq, kind, occurred_at, actor, asset_id, payload)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+				tenant.String(), incidentID.String(), expectedRevision+i+1, string(e.Kind), e.At, e.Actor, e.AssetID.String(), payload)
+			if err != nil {
+				if isUniqueViolation(err) {
+					return fmt.Errorf("%w: incident %s position %d already written", shared.ErrConflict, incidentID, expectedRevision+i+1)
+				}
+				return fmt.Errorf("append incident event: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+// LoadEvents returns one incident's event log in seq order.
+func (r *IncidentEventRepository) LoadEvents(ctx context.Context, incidentID shared.ID) ([]incident.IncidentEvent, error) {
+	tenant, err := requireIncidentRepoTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []incident.IncidentEvent
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT payload FROM incident_events WHERE tenant_id=$1 AND incident_id=$2 ORDER BY seq`,
+			tenant.String(), incidentID.String())
+		if err != nil {
+			return fmt.Errorf("query incident events: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var payload []byte
+			if err := rows.Scan(&payload); err != nil {
+				return fmt.Errorf("scan incident event: %w", err)
+			}
+			var e incident.IncidentEvent
+			if err := json.Unmarshal(payload, &e); err != nil {
+				return fmt.Errorf("unmarshal incident event: %w", err)
+			}
+			out = append(out, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ListIncidentIDs returns incident ids matching the query, ordered by id.
+func (r *IncidentEventRepository) ListIncidentIDs(ctx context.Context, q ports.IncidentQuery) ([]shared.ID, error) {
+	tenant, err := requireIncidentRepoTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	limit := q.Limit
+	if limit <= 0 || limit > defaultIncidentListLimit {
+		limit = defaultIncidentListLimit
+	}
+	// GROUP BY (not DISTINCT) dedups incident_id while allowing ORDER BY a collated grouped column;
+	// COLLATE "C" makes the order match the memory twin's Go bytewise ordering regardless of DB collation.
+	sql := `SELECT incident_id FROM incident_events WHERE tenant_id=$1`
+	args := []any{tenant.String()}
+	if !q.AssetID.IsZero() {
+		args = append(args, q.AssetID.String())
+		sql += ` AND asset_id=$2`
+	}
+	args = append(args, limit)
+	sql += fmt.Sprintf(` GROUP BY incident_id ORDER BY incident_id COLLATE "C" LIMIT $%d`, len(args))
+
+	var ids []shared.ID
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, sql, args...)
+		if err != nil {
+			return fmt.Errorf("list incidents: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return fmt.Errorf("scan incident id: %w", err)
+			}
+			ids = append(ids, shared.ID(id))
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func requireIncidentRepoTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: incident store operation requires a tenant in context", shared.ErrValidation)
+}

--- a/internal/infrastructure/persistence/postgres/incident_event_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/incident_event_repo_test.go
@@ -1,0 +1,116 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestIncidentEventRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenant := shared.ID("iel-" + id)
+	other := shared.ID("iel-other-" + id)
+	asset := shared.ID("iel-asset-" + id)
+	incID := shared.ID("iel-inc-" + id)
+	for _, tn := range []shared.ID{tenant, other} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tn.String()); err != nil {
+			t.Fatalf("seed tenant: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		conn, err := pool.Acquire(bg)
+		if err != nil {
+			return
+		}
+		defer conn.Release()
+		if _, err := conn.Exec(bg, `SET session_replication_role = replica`); err != nil {
+			return
+		}
+		defer conn.Exec(bg, `SET session_replication_role = origin`)
+		for _, tn := range []shared.ID{tenant, other} {
+			_, _ = conn.Exec(bg, `DELETE FROM incident_events WHERE tenant_id=$1`, tn.String())
+			_, _ = conn.Exec(bg, `DELETE FROM tenants WHERE id=$1`, tn.String())
+		}
+	})
+
+	repo := NewIncidentEventRepository(pool)
+	tctx := shared.WithTenant(ctx, tenant)
+	base := time.Unix(1_800_000_000, 0).UTC()
+
+	created := incident.IncidentEvent{IncidentID: incID, Kind: incident.EventCreated, At: base, Actor: "correlator", AssetID: asset, Severity: shared.SeverityHigh, DetectionID: "d1"}
+	if err := repo.AppendEvents(tctx, incID, 0, []incident.IncidentEvent{created}); err != nil {
+		t.Fatalf("append created: %v", err)
+	}
+	// Optimistic concurrency: a second append at revision 0 conflicts.
+	if err := repo.AppendEvents(tctx, incID, 0, []incident.IncidentEvent{created}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("double append at rev 0 must conflict, got %v", err)
+	}
+	// Append a risk reassessment (exercises the nested *RiskAssessment JSONB payload round-trip) then a
+	// comment, at the correct revisions.
+	risk := incident.IncidentEvent{IncidentID: incID, Kind: incident.EventRiskReassessed, At: base.Add(time.Second), Actor: "scorer",
+		Risk: &riskassessment.RiskAssessment{AssessmentID: "ra-1", ScorerVersion: "v1", PolicyVersion: "p1", Risk: 88, Confidence: 61, Coverage: 43}}
+	if err := repo.AppendEvents(tctx, incID, 1, []incident.IncidentEvent{risk}); err != nil {
+		t.Fatalf("append risk: %v", err)
+	}
+	commented := incident.IncidentEvent{IncidentID: incID, Kind: incident.EventAnalystCommented, At: base.Add(2 * time.Second), Actor: "alice", Comment: "looks real"}
+	if err := repo.AppendEvents(tctx, incID, 2, []incident.IncidentEvent{commented}); err != nil {
+		t.Fatalf("append comment: %v", err)
+	}
+
+	events, err := repo.LoadEvents(tctx, incID)
+	if err != nil || len(events) != 3 {
+		t.Fatalf("load: %d err=%v", len(events), err)
+	}
+	inc, err := incident.Project(events)
+	if err != nil {
+		t.Fatalf("loaded log must project: %v", err)
+	}
+	if inc.Severity != shared.SeverityHigh || len(inc.Comments) != 1 || inc.Comments[0].Text != "looks real" {
+		t.Fatalf("round-trip projection wrong: %+v", inc)
+	}
+	if inc.Risk == nil || inc.Risk.Risk != 88 || inc.Risk.Coverage != 43 {
+		t.Fatalf("risk payload did not round-trip through JSONB: %+v", inc.Risk)
+	}
+
+	// List by asset.
+	ids, err := repo.ListIncidentIDs(tctx, ports.IncidentQuery{AssetID: asset})
+	if err != nil || len(ids) != 1 || ids[0] != incID {
+		t.Fatalf("list by asset: %v err=%v", ids, err)
+	}
+
+	// Cross-tenant isolation: the other tenant sees nothing.
+	octx := shared.WithTenant(ctx, other)
+	if ev, err := repo.LoadEvents(octx, incID); err != nil || len(ev) != 0 {
+		t.Fatalf("cross-tenant load must be empty, got %d err=%v", len(ev), err)
+	}
+
+	// Append-only: a direct UPDATE/DELETE is refused by the trigger.
+	if _, err := pool.Exec(ctx, `UPDATE incident_events SET actor='x' WHERE tenant_id=$1`, tenant.String()); err == nil {
+		t.Fatal("UPDATE on the append-only incident log must be rejected")
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM incident_events WHERE tenant_id=$1`, tenant.String()); err == nil {
+		t.Fatal("DELETE on the append-only incident log must be rejected")
+	}
+}

--- a/internal/usecase/fleet/incidentuc/service.go
+++ b/internal/usecase/fleet/incidentuc/service.go
@@ -1,0 +1,126 @@
+// Package incidentuc is the usecase seam over the event-sourced incident store (Phase C / C7, #681). It
+// persists incident event logs (append-only, optimistic-concurrency) and reconstructs incidents by folding
+// them with incident.Project, so the store never holds a log that would not project. It is stateless and
+// tenant-scoped from the context on every call.
+package incidentuc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Service reconstructs and appends to event-sourced incidents.
+type Service struct {
+	store ports.IncidentEventStore
+}
+
+// NewService constructs the service over an incident event store.
+func NewService(store ports.IncidentEventStore) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("%w: incident service requires an event store", shared.ErrValidation)
+	}
+	return &Service{store: store}, nil
+}
+
+// Get loads an incident's event log and folds it into its projection. It returns shared.ErrNotFound if the
+// incident is unknown.
+func (s *Service) Get(ctx context.Context, id shared.ID) (incident.Incident, error) {
+	events, err := s.store.LoadEvents(ctx, id)
+	if err != nil {
+		return incident.Incident{}, err
+	}
+	if len(events) == 0 {
+		return incident.Incident{}, fmt.Errorf("%w: incident %s", shared.ErrNotFound, id)
+	}
+	inc, err := incident.Project(events)
+	if err != nil {
+		return incident.Incident{}, fmt.Errorf("get incident %s: %w", id, err)
+	}
+	return inc, nil
+}
+
+// Append appends events to an incident under optimistic concurrency (expectedRevision must equal the
+// incident's current revision). It validates that the resulting log still projects BEFORE persisting, so
+// the store never holds an unprojectable log, and returns the new projection.
+func (s *Service) Append(ctx context.Context, id shared.ID, expectedRevision int, events []incident.IncidentEvent) (incident.Incident, error) {
+	if len(events) == 0 {
+		return s.Get(ctx, id)
+	}
+	current, err := s.store.LoadEvents(ctx, id)
+	if err != nil {
+		return incident.Incident{}, err
+	}
+	if len(current) != expectedRevision {
+		return incident.Incident{}, fmt.Errorf("%w: incident %s at revision %d, expected %d", shared.ErrConflict, id, len(current), expectedRevision)
+	}
+	combined := make([]incident.IncidentEvent, 0, len(current)+len(events))
+	combined = append(combined, current...)
+	combined = append(combined, events...)
+	projected, err := incident.Project(combined)
+	if err != nil {
+		return incident.Incident{}, fmt.Errorf("append would produce an invalid incident: %w", err)
+	}
+	if err := s.store.AppendEvents(ctx, id, expectedRevision, events); err != nil {
+		return incident.Incident{}, err
+	}
+	return projected, nil
+}
+
+// ListByAsset returns the projected incidents for an asset (all incidents in the tenant if assetID is
+// zero), ordered by incident id.
+func (s *Service) ListByAsset(ctx context.Context, assetID shared.ID, limit int) ([]incident.Incident, error) {
+	ids, err := s.store.ListIncidentIDs(ctx, ports.IncidentQuery{AssetID: assetID, Limit: limit})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]incident.Incident, 0, len(ids))
+	for _, id := range ids {
+		inc, err := s.Get(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, inc)
+	}
+	return out, nil
+}
+
+// RecordCorrelation persists correlator output (a flat event stream, grouped by incident) as NEW
+// incidents. It is IDEMPOTENT for batch correlation: an incident id that already exists is skipped (the
+// correlator mints deterministic ids, so re-running over the same window records nothing new). Attaching
+// new detections to an existing incident is the streaming/incremental extension and is not done here. It
+// returns the incidents it created.
+func (s *Service) RecordCorrelation(ctx context.Context, events []incident.IncidentEvent) ([]incident.Incident, error) {
+	byIncident, order := groupByIncident(events)
+	var created []incident.Incident
+	for _, id := range order {
+		current, err := s.store.LoadEvents(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if len(current) > 0 {
+			continue // already recorded (batch idempotency)
+		}
+		inc, err := s.Append(ctx, id, 0, byIncident[id])
+		if err != nil {
+			return nil, err
+		}
+		created = append(created, inc)
+	}
+	return created, nil
+}
+
+func groupByIncident(events []incident.IncidentEvent) (map[shared.ID][]incident.IncidentEvent, []shared.ID) {
+	byIncident := make(map[shared.ID][]incident.IncidentEvent)
+	var order []shared.ID
+	for _, e := range events {
+		if _, ok := byIncident[e.IncidentID]; !ok {
+			order = append(order, e.IncidentID)
+		}
+		byIncident[e.IncidentID] = append(byIncident[e.IncidentID], e)
+	}
+	return byIncident, order
+}

--- a/internal/usecase/fleet/incidentuc/service_test.go
+++ b/internal/usecase/fleet/incidentuc/service_test.go
@@ -1,0 +1,133 @@
+package incidentuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/correlation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+const (
+	tenant = shared.ID("tenant-i")
+	asset  = shared.ID("asset-i")
+	entity = shared.ID("pe-i")
+)
+
+var base = time.Unix(1_800_000_000, 0).UTC()
+
+func newSvc(t *testing.T) (*Service, context.Context) {
+	t.Helper()
+	svc, err := NewService(memory.NewIncidentEventStore())
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return svc, shared.WithTenant(context.Background(), tenant)
+}
+
+// correlate produces a real correlator event stream for one session, so the C2→C7→C1 path is exercised.
+func correlate(t *testing.T) []incident.IncidentEvent {
+	t.Helper()
+	events, err := correlation.Correlate(
+		correlation.Config{Window: time.Minute, MaxPerIncident: 100},
+		[]correlation.Signal{
+			{ID: "d1", AssetID: asset, EntityID: entity, OccurredAt: base, Severity: shared.SeverityLow, Title: "exec"},
+			{ID: "d2", AssetID: asset, EntityID: entity, OccurredAt: base.Add(time.Second), Severity: shared.SeverityHigh, Title: "exec"},
+		})
+	if err != nil {
+		t.Fatalf("correlate: %v", err)
+	}
+	return events
+}
+
+func TestNewServiceRequiresStore(t *testing.T) {
+	if _, err := NewService(nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("nil store must be rejected, got %v", err)
+	}
+}
+
+func TestRecordCorrelationCreatesAndIsIdempotent(t *testing.T) {
+	svc, ctx := newSvc(t)
+	events := correlate(t)
+	created, err := svc.RecordCorrelation(ctx, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(created) != 1 {
+		t.Fatalf("one incident expected, got %d", len(created))
+	}
+	inc := created[0]
+	if inc.State != incident.StateNew || len(inc.DetectionIDs) != 2 || inc.Severity != shared.SeverityHigh {
+		t.Fatalf("recorded incident wrong: %+v", inc)
+	}
+	// Re-recording the same correlation is a no-op (batch idempotency).
+	again, err := svc.RecordCorrelation(ctx, events)
+	if err != nil || len(again) != 0 {
+		t.Fatalf("re-record must create nothing: created=%d err=%v", len(again), err)
+	}
+	// Get reconstructs the same projection.
+	got, err := svc.Get(ctx, inc.ID)
+	if err != nil || got.Revision != inc.Revision || len(got.DetectionIDs) != 2 {
+		t.Fatalf("get after record: %+v err=%v", got, err)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	svc, ctx := newSvc(t)
+	if _, err := svc.Get(ctx, "nope"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("unknown incident must be ErrNotFound, got %v", err)
+	}
+}
+
+func TestAppendOptimisticConcurrencyAndProjectValidation(t *testing.T) {
+	svc, ctx := newSvc(t)
+	created, err := svc.RecordCorrelation(ctx, correlate(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	inc := created[0]
+	// A stale expectedRevision is rejected.
+	_, err = svc.Append(ctx, inc.ID, inc.Revision-1, []incident.IncidentEvent{
+		{IncidentID: inc.ID, Kind: incident.EventStatusChanged, At: base.Add(time.Hour), Actor: "a", To: incident.StateInvestigating},
+	})
+	if !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale revision must conflict, got %v", err)
+	}
+	// A legal append at the correct revision succeeds.
+	updated, err := svc.Append(ctx, inc.ID, inc.Revision, []incident.IncidentEvent{
+		{IncidentID: inc.ID, Kind: incident.EventStatusChanged, At: base.Add(time.Hour), Actor: "alice", To: incident.StateInvestigating},
+	})
+	if err != nil || updated.State != incident.StateInvestigating {
+		t.Fatalf("legal append failed: %+v err=%v", updated, err)
+	}
+	// An append that would produce an INVALID incident (illegal transition) is rejected and NOT persisted.
+	_, err = svc.Append(ctx, inc.ID, updated.Revision, []incident.IncidentEvent{
+		{IncidentID: inc.ID, Kind: incident.EventStatusChanged, At: base.Add(2 * time.Hour), Actor: "alice", To: incident.StateNew},
+	})
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("illegal transition append must be rejected, got %v", err)
+	}
+	after, _ := svc.Get(ctx, inc.ID)
+	if after.Revision != updated.Revision {
+		t.Fatalf("rejected append must not persist: rev %d != %d", after.Revision, updated.Revision)
+	}
+}
+
+func TestListByAsset(t *testing.T) {
+	svc, ctx := newSvc(t)
+	if _, err := svc.RecordCorrelation(ctx, correlate(t)); err != nil {
+		t.Fatal(err)
+	}
+	incs, err := svc.ListByAsset(ctx, asset, 0)
+	if err != nil || len(incs) != 1 {
+		t.Fatalf("list by asset: %d err=%v", len(incs), err)
+	}
+	// A different asset returns nothing.
+	if other, _ := svc.ListByAsset(ctx, "asset-other", 0); len(other) != 0 {
+		t.Fatalf("other asset must list nothing, got %d", len(other))
+	}
+}

--- a/internal/usecase/ports/incident_store.go
+++ b/internal/usecase/ports/incident_store.go
@@ -1,0 +1,37 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// IncidentEventStore persists the event-sourced incident log for Phase C (#594, C7 #681). The event log
+// is the source of truth and is APPEND-ONLY (golden rule 6): an incident is reconstructed by folding its
+// events with incident.Project. Every method is tenant-scoped from the context.
+type IncidentEventStore interface {
+	// AppendEvents appends events to one incident's log under OPTIMISTIC CONCURRENCY: expectedRevision must
+	// equal the incident's current event count (0 for a brand-new incident), otherwise it returns
+	// shared.ErrConflict and the caller reloads and retries. Events are assigned sequential positions after
+	// expectedRevision. A duplicate concurrent append at the same position also yields ErrConflict (the log
+	// position is unique), so an incident's history can never fork or lose an event. Appending zero events
+	// is a no-op.
+	//
+	// The store validates each event and its incident binding but NOT projectability of the resulting log:
+	// a caller MUST fold-validate (incident.Project over current+new) before appending, so an unprojectable
+	// log — e.g. an illegal state transition — is never persisted. incidentuc.Service does this; any other
+	// writer must too.
+	AppendEvents(ctx context.Context, incidentID shared.ID, expectedRevision int, events []incident.IncidentEvent) error
+	// LoadEvents returns one incident's full event log in log order (empty if the incident is unknown).
+	LoadEvents(ctx context.Context, incidentID shared.ID) ([]incident.IncidentEvent, error)
+	// ListIncidentIDs returns the incident ids matching the query, ordered by id for stability.
+	ListIncidentIDs(ctx context.Context, q IncidentQuery) ([]shared.ID, error)
+}
+
+// IncidentQuery selects incidents. An empty AssetID matches all incidents in the tenant; Limit caps the
+// result (0 means the store default).
+type IncidentQuery struct {
+	AssetID shared.ID
+	Limit   int
+}

--- a/migrations/0112_incident_events.sql
+++ b/migrations/0112_incident_events.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- Phase C / C7 (#681): the event-sourced incident log. It is the source of truth for an incident (the
+-- projection is folded from it by incident.Project) and is APPEND-ONLY (golden rule 6), like the evidence
+-- and audit ledgers. One row per event; (tenant, incident, seq) is the position, and its uniqueness is
+-- what gives optimistic-concurrency appends (two writers cannot both claim the next position).
+CREATE TABLE incident_events (
+    tenant_id   TEXT NOT NULL REFERENCES tenants(id),
+    incident_id TEXT NOT NULL,
+    seq         INT NOT NULL CHECK (seq >= 1),
+    kind        TEXT NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    actor       TEXT NOT NULL,
+    -- asset_id is set on the Created event (the incident's asset), empty otherwise, so incidents can be
+    -- listed by asset without folding every log.
+    asset_id TEXT NOT NULL DEFAULT '',
+    -- payload is the full incident.IncidentEvent as JSON; it is the authoritative event content that
+    -- incident.Project folds. The columns above are for ordering, integrity, and querying.
+    payload JSONB NOT NULL,
+    PRIMARY KEY (tenant_id, incident_id, seq)
+);
+-- incident_id is ordered COLLATE "C" (bytewise) so the SQL list order matches the memory twin's Go
+-- bytewise ordering regardless of the DB's default collation (house convention; see migration 0111).
+CREATE INDEX idx_incident_events_by_asset
+    ON incident_events (tenant_id, asset_id, incident_id COLLATE "C")
+    WHERE asset_id <> '';
+CALL synapse_enable_tenant_rls('incident_events');
+
+-- Append-only: the incident log is chain-of-custody; reject UPDATE/DELETE/TRUNCATE like evidence/audit.
+-- synapse_forbid_mutation is defined in migration 0033.
+CREATE TRIGGER incident_events_append_only
+    BEFORE UPDATE OR DELETE ON incident_events
+    FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER incident_events_no_truncate
+    BEFORE TRUNCATE ON incident_events
+    FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS incident_events_no_truncate ON incident_events;
+DROP TRIGGER IF EXISTS incident_events_append_only ON incident_events;
+DROP TABLE incident_events;


### PR DESCRIPTION
## C7 — append-only incident event-log persistence (#681)

Persists the Phase C event-sourced incident (EDR epic #594). The append-only event log is the source of truth; an incident is reconstructed by folding it with `incident.Project` (C1).

### What's in it
- **`ports.IncidentEventStore`** + `IncidentQuery`: optimistic-concurrency `AppendEvents` (expectedRevision == current count), `LoadEvents`, `ListIncidentIDs` by asset. Contract documented: callers fold-validate before appending.
- **memory + postgres twins**, identical behavior: optimistic append backed by the `(tenant, incident, seq)` PK (no lost update / no forked history), seq-ordered load, list-by-asset, tenant-from-ctx fail-closed, foreign-event reject, `COLLATE "C"` list order matching the Go bytewise twin.
- **migration 0112**: tenant RLS; composite PK as the concurrency backbone; **append-only** triggers (golden rule 6, reusing `synapse_forbid_mutation`); JSONB payload = the full `IncidentEvent`; asset index.
- **`incidentuc.Service`** (stateless): `Get` = load + Project; `Append` = load → combine → Project-validate → store (so the store never holds an unprojectable log); `ListByAsset`; `RecordCorrelation` bridges C2 correlator output as new incidents, idempotent for batch re-runs.

### Review
Dual-reviewed. **go-arch: MERGEABLE** (dependency rule PASS, twin parity, correct optimistic-concurrency mechanism, sound event-sourcing seam). **security: SHIP** (append-only + RLS + PK concurrency + parameterized SQL/JSON + fail-closed one-tx writes — all test-proven). Non-blocking items folded in **here**: `COLLATE "C"` list order (twin parity), error-context wrap in `Get`, a port contract note on projectability, and a memory-twin deep-copy of the `Risk` pointer.

### Verification (CI off — validated locally)
`go build`/`go vet`/`gofmt -l` clean; memory + service tests race-green; the postgres integration test passes on a fresh DB (0112 applies) asserting optimistic-concurrency conflict, JSONB risk round-trip, append-only UPDATE/DELETE rejection, and cross-tenant isolation.

### Scope / follow-ups
HTTP read/triage routes (RBAC) and a materialized read-model for state-filtered queries are the C7 tail. The risk **scorer** (C3 #677), retro-hunt (C4), disposition workflow (C5), and governed-response verify (C6) build on this.
