### PR TITLE
feat(retrohunt): add coverage-honest detection timeline pivot (#678)

### DIFF
--- a/internal/usecase/fleet/retrohunt/service.go
+++ b/internal/usecase/fleet/retrohunt/service.go
@@ -1,0 +1,311 @@
+// Package retrohunt pivots a runtime detection to the persisted endpoint State Timeline around the
+// detection's event time (Phase C / C4, #678). It returns projected transitions, not raw telemetry, but
+// queries the telemetry tier's honesty metadata for the same window so sampling and loss are never
+// presented as complete endpoint history.
+package retrohunt
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	DefaultBefore     = 5 * time.Minute
+	DefaultAfter      = 5 * time.Minute
+	DefaultMaxEntries = 1000
+	maxEntries        = 9999 // leaves one look-ahead row under the timeline stores' 10k hard cap
+	maxLineageDepth   = 64
+)
+
+// Config bounds every retro-hunt. Zero values select the documented defaults. Negative durations and
+// entry limits outside the safe store window fail closed.
+type Config struct {
+	Before     time.Duration
+	After      time.Duration
+	MaxEntries int
+}
+
+func (c Config) withDefaults() (Config, error) {
+	if c.Before < 0 || c.After < 0 || c.MaxEntries < 0 {
+		return Config{}, fmt.Errorf("%w: retro-hunt bounds cannot be negative", shared.ErrValidation)
+	}
+	if c.Before == 0 {
+		c.Before = DefaultBefore
+	}
+	if c.After == 0 {
+		c.After = DefaultAfter
+	}
+	if c.MaxEntries == 0 {
+		c.MaxEntries = DefaultMaxEntries
+	}
+	if c.MaxEntries > maxEntries {
+		return Config{}, fmt.Errorf("%w: retro-hunt max entries exceeds %d", shared.ErrValidation, maxEntries)
+	}
+	return c, nil
+}
+
+// DetectionPivot identifies the detection and optional stable endpoint entity whose context should be
+// reconstructed. AncestorEntityIDs are the already-resolved process lineage, nearest-first or in any
+// other order; the service canonicalizes them with EntityID before querying. With no EntityID, the pivot
+// returns the asset-wide timeline window.
+//
+// Lineage resolution itself belongs to endpoint projection/persistence. C4 consumes stable entity ids;
+// it never derives lineage from a bare PID, which would be unsafe under PID reuse.
+type DetectionPivot struct {
+	Detection         detection.Record
+	EntityID          shared.ID
+	AncestorEntityIDs []shared.ID
+}
+
+// CoverageReason is a stable, machine-readable explanation for an incomplete retro-hunt window.
+type CoverageReason string
+
+const (
+	CoverageSampled                    CoverageReason = "telemetry_sampled"
+	CoverageSequenceGap                CoverageReason = "telemetry_sequence_gap"
+	CoverageLoss                       CoverageReason = "telemetry_loss"
+	CoverageTelemetryUnavailable       CoverageReason = "telemetry_unavailable"
+	CoverageTimelineTruncated          CoverageReason = "timeline_limit"
+	CoverageDetectionEvidenceTruncated CoverageReason = "detection_evidence_truncated"
+	CoverageTelemetryIncomplete        CoverageReason = "telemetry_incomplete"
+)
+
+// Coverage carries the completeness proof for the exact retro-hunt window. Complete is derived from all
+// fields and can never stay true when the timeline was capped, the detection evidence was truncated, or
+// telemetry reports sampling, a sequence gap, or a persisted loss.
+type Coverage struct {
+	Complete                   bool
+	Sampled                    bool
+	MaxSampleRate              int
+	TimelineTruncated          bool
+	DetectionEvidenceTruncated bool
+	TelemetryObserved          bool
+	SequenceGaps               []ports.TelemetrySequenceGap
+	Losses                     []ports.TelemetryLoss
+	Reasons                    []CoverageReason
+}
+
+// Result is a deterministic surrounding State Timeline ordered by (OccurredAt, EventID), accompanied by
+// the exact asset/entity/window pivot and its coverage proof.
+type Result struct {
+	DetectionID shared.ID
+	AssetID     shared.ID
+	HostID      shared.ID
+	EntityIDs   []shared.ID
+	WindowStart time.Time
+	WindowEnd   time.Time
+	Entries     []endpoint.TimelineEntry
+	Coverage    Coverage
+}
+
+// Service reads the durable State Timeline and the raw telemetry tier's completeness metadata.
+type Service struct {
+	timeline  ports.EndpointTimelineReader
+	telemetry ports.TelemetryHuntReader
+	config    Config
+}
+
+// NewService validates the two read dependencies and applies bounded defaults.
+func NewService(timeline ports.EndpointTimelineReader, telemetry ports.TelemetryHuntReader, config Config) (*Service, error) {
+	if timeline == nil || telemetry == nil {
+		return nil, fmt.Errorf("%w: retro-hunt requires timeline and telemetry stores", shared.ErrValidation)
+	}
+	resolved, err := config.withDefaults()
+	if err != nil {
+		return nil, err
+	}
+	return &Service{timeline: timeline, telemetry: telemetry, config: resolved}, nil
+}
+
+// AroundDetection returns the persisted State Timeline surrounding a detection's observation time. The
+// authenticated tenant in ctx must match the record; tenant and asset mismatches returned by an adapter
+// fail closed. Entity/lineage reads are merged and deduplicated deterministically.
+func (s *Service) AroundDetection(ctx context.Context, pivot DetectionPivot) (Result, error) {
+	if ctx == nil {
+		return Result{}, fmt.Errorf("%w: retro-hunt requires a context", shared.ErrValidation)
+	}
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return Result{}, fmt.Errorf("%w: retro-hunt requires a tenant in context", shared.ErrValidation)
+	}
+	if err := pivot.Detection.Validate(); err != nil {
+		return Result{}, fmt.Errorf("retro-hunt detection: %w", err)
+	}
+	if pivot.Detection.TenantID != tenant {
+		return Result{}, fmt.Errorf("%w: detection tenant does not match authenticated tenant", shared.ErrForbidden)
+	}
+	entityIDs, err := canonicalEntityIDs(pivot.EntityID, pivot.AncestorEntityIDs)
+	if err != nil {
+		return Result{}, err
+	}
+
+	start := pivot.Detection.Detection.Observed.UTC().Add(-s.config.Before)
+	end := pivot.Detection.Detection.Observed.UTC().Add(s.config.After)
+	entries, truncated, err := s.queryTimeline(ctx, tenant, pivot.Detection.AssetID, entityIDs, start, end)
+	if err != nil {
+		return Result{}, err
+	}
+
+	honesty, err := s.telemetry.Query(ctx, ports.HuntQuery{
+		Kind: ports.HuntContext, HostID: pivot.Detection.Detection.HostID, AssetID: pivot.Detection.AssetID,
+		Since: start, Until: end, Limit: 1,
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("query retro-hunt coverage: %w", err)
+	}
+	coverage := coverageFor(honesty, truncated, pivot.Detection.Detection.Truncated)
+	return Result{
+		DetectionID: pivot.Detection.ID,
+		AssetID:     pivot.Detection.AssetID,
+		HostID:      pivot.Detection.Detection.HostID,
+		EntityIDs:   append([]shared.ID(nil), entityIDs...),
+		WindowStart: start,
+		WindowEnd:   end,
+		Entries:     entries,
+		Coverage:    coverage,
+	}, nil
+}
+
+func canonicalEntityIDs(entityID shared.ID, ancestors []shared.ID) ([]shared.ID, error) {
+	if entityID.IsZero() && len(ancestors) > 0 {
+		return nil, fmt.Errorf("%w: retro-hunt lineage requires a focal entity id", shared.ErrValidation)
+	}
+	if len(ancestors) > maxLineageDepth {
+		return nil, fmt.Errorf("%w: retro-hunt lineage exceeds %d ancestors", shared.ErrValidation, maxLineageDepth)
+	}
+	if entityID.IsZero() {
+		return nil, nil
+	}
+	unique := map[shared.ID]struct{}{entityID: {}}
+	for _, id := range ancestors {
+		if id.IsZero() {
+			return nil, fmt.Errorf("%w: retro-hunt lineage contains an empty entity id", shared.ErrValidation)
+		}
+		unique[id] = struct{}{}
+	}
+	out := make([]shared.ID, 0, len(unique))
+	for id := range unique {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+func (s *Service) queryTimeline(ctx context.Context, tenant, asset shared.ID, entityIDs []shared.ID,
+	start, end time.Time,
+) ([]endpoint.TimelineEntry, bool, error) {
+	byEvent := make(map[shared.ID]endpoint.TimelineEntry)
+	queries := entityIDs
+	if len(queries) == 0 {
+		queries = []shared.ID{""}
+	}
+	for _, entityID := range queries {
+		found, err := s.timeline.QueryTimeline(ctx, ports.EndpointTimelineQuery{
+			AssetID: asset, From: start, To: end, EntityID: entityID, Limit: s.config.MaxEntries + 1,
+		})
+		if err != nil {
+			return nil, false, fmt.Errorf("query endpoint timeline: %w", err)
+		}
+		for _, raw := range found {
+			entry := raw
+			entry.OccurredAt = entry.OccurredAt.UTC()
+			if err := validateTimelineEntry(entry, tenant, asset, entityIDs, start, end); err != nil {
+				return nil, false, err
+			}
+			if previous, exists := byEvent[entry.EventID]; exists && previous != entry {
+				return nil, false, fmt.Errorf("%w: timeline event %s has conflicting material", shared.ErrConflict, entry.EventID)
+			}
+			byEvent[entry.EventID] = entry
+		}
+	}
+
+	entries := make([]endpoint.TimelineEntry, 0, len(byEvent))
+	for _, entry := range byEvent {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if !entries[i].OccurredAt.Equal(entries[j].OccurredAt) {
+			return entries[i].OccurredAt.Before(entries[j].OccurredAt)
+		}
+		return entries[i].EventID < entries[j].EventID
+	})
+	truncated := len(entries) > s.config.MaxEntries
+	if truncated {
+		entries = entries[:s.config.MaxEntries]
+	}
+	return entries, truncated, nil
+}
+
+func validateTimelineEntry(entry endpoint.TimelineEntry, tenant, asset shared.ID, entityIDs []shared.ID,
+	start, end time.Time,
+) error {
+	if entry.EventID.IsZero() || entry.EntityID.IsZero() || entry.EntityKind == "" || entry.Kind == "" || entry.OccurredAt.IsZero() {
+		return fmt.Errorf("%w: timeline store returned a malformed entry", shared.ErrValidation)
+	}
+	if entry.TenantID != tenant || entry.AssetID != asset {
+		return fmt.Errorf("%w: timeline store returned an entry outside the authenticated pivot", shared.ErrForbidden)
+	}
+	if entry.OccurredAt.Before(start) || entry.OccurredAt.After(end) {
+		return fmt.Errorf("%w: timeline store returned an entry outside the requested window", shared.ErrValidation)
+	}
+	if len(entityIDs) > 0 && !containsID(entityIDs, entry.EntityID) {
+		return fmt.Errorf("%w: timeline store returned an entry outside the requested lineage", shared.ErrValidation)
+	}
+	return nil
+}
+
+func containsID(ids []shared.ID, id shared.ID) bool {
+	index := sort.Search(len(ids), func(index int) bool { return ids[index] >= id })
+	return index < len(ids) && ids[index] == id
+}
+
+func coverageFor(honesty ports.HuntResult, timelineTruncated, detectionTruncated bool) Coverage {
+	maxSampleRate := honesty.MaxSampleRate
+	if maxSampleRate < 1 {
+		maxSampleRate = 1
+	}
+	sampled := honesty.Sampled || maxSampleRate > 1
+	telemetryObserved := honesty.RowsScanned > 0
+	coverage := Coverage{
+		Sampled:                    sampled,
+		MaxSampleRate:              maxSampleRate,
+		TimelineTruncated:          timelineTruncated,
+		DetectionEvidenceTruncated: detectionTruncated,
+		TelemetryObserved:          telemetryObserved,
+		SequenceGaps:               append([]ports.TelemetrySequenceGap(nil), honesty.SequenceGaps...),
+		Losses:                     append([]ports.TelemetryLoss(nil), honesty.Losses...),
+	}
+	if sampled {
+		coverage.Reasons = append(coverage.Reasons, CoverageSampled)
+	}
+	if len(coverage.SequenceGaps) > 0 {
+		coverage.Reasons = append(coverage.Reasons, CoverageSequenceGap)
+	}
+	if len(coverage.Losses) > 0 {
+		coverage.Reasons = append(coverage.Reasons, CoverageLoss)
+	}
+	// The timeline intentionally outlives raw telemetry. An empty telemetry read cannot prove the
+	// window complete: it may mean the raw rows expired, so surface that uncertainty explicitly.
+	if !telemetryObserved {
+		coverage.Reasons = append(coverage.Reasons, CoverageTelemetryUnavailable)
+	}
+	if timelineTruncated {
+		coverage.Reasons = append(coverage.Reasons, CoverageTimelineTruncated)
+	}
+	if detectionTruncated {
+		coverage.Reasons = append(coverage.Reasons, CoverageDetectionEvidenceTruncated)
+	}
+	knownIncomplete := sampled || len(coverage.SequenceGaps) > 0 || len(coverage.Losses) > 0 || !telemetryObserved
+	if !honesty.Complete && !knownIncomplete {
+		coverage.Reasons = append(coverage.Reasons, CoverageTelemetryIncomplete)
+	}
+	coverage.Complete = honesty.Complete && len(coverage.Reasons) == 0
+	return coverage
+}

--- a/internal/usecase/fleet/retrohunt/service_test.go
+++ b/internal/usecase/fleet/retrohunt/service_test.go
@@ -1,0 +1,281 @@
+package retrohunt
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var huntAt = time.Unix(1_800_200_000, 0).UTC()
+
+type timelineStub struct {
+	entries []endpoint.TimelineEntry
+	err     error
+	queries []ports.EndpointTimelineQuery
+}
+
+func (s *timelineStub) QueryTimeline(_ context.Context, q ports.EndpointTimelineQuery) ([]endpoint.TimelineEntry, error) {
+	s.queries = append(s.queries, q)
+	if s.err != nil {
+		return nil, s.err
+	}
+	var out []endpoint.TimelineEntry
+	for _, entry := range s.entries {
+		if entry.AssetID != q.AssetID || (!q.From.IsZero() && entry.OccurredAt.Before(q.From)) ||
+			(!q.To.IsZero() && entry.OccurredAt.After(q.To)) || (!q.EntityID.IsZero() && entry.EntityID != q.EntityID) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	if q.Limit > 0 && len(out) > q.Limit {
+		out = out[:q.Limit]
+	}
+	return out, nil
+}
+
+type telemetryStub struct {
+	result  ports.HuntResult
+	err     error
+	queries []ports.HuntQuery
+}
+
+func (s *telemetryStub) Query(_ context.Context, q ports.HuntQuery) (ports.HuntResult, error) {
+	s.queries = append(s.queries, q)
+	return s.result, s.err
+}
+func huntContext(tenant shared.ID) context.Context {
+	return shared.WithTenant(context.Background(), tenant)
+}
+
+func detectionRecord() detection.Record {
+	evidence := detection.Event{
+		Class: detection.ClassProcess, At: huntAt, Host: "host-1",
+		Process: &detection.ProcessEvent{PID: 42, PPID: 1, Comm: "sh", Path: "/bin/sh", UID: 1000},
+	}
+	return detection.Record{
+		ID: "detection-1", TenantID: "tenant-1", EngagementID: "engagement-1", AssetID: "asset-1",
+		AgentID: "agent-1", EvidenceID: "evidence-1", BatchSeq: 7, RecordedAt: huntAt.Add(time.Minute),
+		Detection: detection.Detection{
+			RuleID: "rule.process", RuleVersion: 1, Class: detection.ClassProcess,
+			Severity: shared.SeverityHigh, HostID: "host-1", AgentID: "agent-1",
+			Evidence: []detection.Event{evidence}, ObservedCount: 1, Observed: huntAt,
+		},
+	}
+}
+
+func timelineEntry(eventID string, entityID shared.ID, at time.Time) endpoint.TimelineEntry {
+	return endpoint.TimelineEntry{
+		OccurredAt: at, TenantID: "tenant-1", AssetID: "asset-1", EntityKind: endpoint.EntityProcess,
+		EntityID: entityID, Kind: endpoint.TimelineProcessExec, EventID: shared.ID(eventID), Summary: eventID,
+	}
+}
+
+func TestAroundDetectionReturnsDeterministicLineageWindow(t *testing.T) {
+	timeline := &timelineStub{entries: []endpoint.TimelineEntry{
+		timelineEntry("event-parent", "entity-a", huntAt.Add(time.Minute)),
+		timelineEntry("event-outside", "entity-z", huntAt.Add(-3*time.Minute)),
+		timelineEntry("event-focus", "entity-z", huntAt.Add(-time.Minute)),
+		timelineEntry("event-other", "entity-other", huntAt),
+		timelineEntry("event-root", "entity-m", huntAt.Add(-2*time.Minute)),
+	}}
+	telemetry := &telemetryStub{result: ports.HuntResult{Complete: true, MaxSampleRate: 1, RowsScanned: 12}}
+	service, err := NewService(timeline, telemetry, Config{Before: 2 * time.Minute, After: 3 * time.Minute, MaxEntries: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := service.AroundDetection(huntContext("tenant-1"), DetectionPivot{
+		Detection: detectionRecord(), EntityID: "entity-z",
+		AncestorEntityIDs: []shared.ID{"entity-m", "entity-a", "entity-a"},
+	})
+	if err != nil {
+		t.Fatalf("around detection: %v", err)
+	}
+	if !reflect.DeepEqual(result.EntityIDs, []shared.ID{"entity-a", "entity-m", "entity-z"}) {
+		t.Fatalf("entity lineage is not canonical: %v", result.EntityIDs)
+	}
+	if len(result.Entries) != 3 || result.Entries[0].EventID != "event-root" ||
+		result.Entries[1].EventID != "event-focus" || result.Entries[2].EventID != "event-parent" {
+		t.Fatalf("timeline is not in deterministic event-time order: %+v", result.Entries)
+	}
+	if len(timeline.queries) != 3 {
+		t.Fatalf("want one bounded query per canonical lineage entity, got %d", len(timeline.queries))
+	}
+	for index, query := range timeline.queries {
+		if query.EntityID != result.EntityIDs[index] || query.Limit != 11 ||
+			!query.From.Equal(huntAt.Add(-2*time.Minute)) || !query.To.Equal(huntAt.Add(3*time.Minute)) {
+			t.Fatalf("unexpected timeline query %d: %+v", index, query)
+		}
+	}
+	if len(telemetry.queries) != 1 {
+		t.Fatalf("want one coverage query, got %d", len(telemetry.queries))
+	}
+	coverageQuery := telemetry.queries[0]
+	if coverageQuery.Kind != ports.HuntContext || coverageQuery.HostID != "host-1" ||
+		coverageQuery.AssetID != "asset-1" || coverageQuery.Limit != 1 {
+		t.Fatalf("coverage query is not bound to the detection: %+v", coverageQuery)
+	}
+	if !result.Coverage.Complete || len(result.Coverage.Reasons) != 0 || !result.Coverage.TelemetryObserved {
+		t.Fatalf("fully observed window must be complete: %+v", result.Coverage)
+	}
+}
+
+func TestAroundDetectionAssetWidePivotUsesOneQuery(t *testing.T) {
+	timeline := &timelineStub{entries: []endpoint.TimelineEntry{
+		timelineEntry("event-b", "entity-b", huntAt), timelineEntry("event-a", "entity-a", huntAt),
+	}}
+	telemetry := &telemetryStub{result: ports.HuntResult{Complete: true, MaxSampleRate: 1, RowsScanned: 1}}
+	service, _ := NewService(timeline, telemetry, Config{})
+	result, err := service.AroundDetection(huntContext("tenant-1"), DetectionPivot{Detection: detectionRecord()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(timeline.queries) != 1 || !timeline.queries[0].EntityID.IsZero() || len(result.EntityIDs) != 0 {
+		t.Fatalf("asset-wide pivot issued unexpected queries: %+v", timeline.queries)
+	}
+	if len(result.Entries) != 2 || result.Entries[0].EventID != "event-a" || result.Entries[1].EventID != "event-b" {
+		t.Fatalf("equal timestamps must use EventID tiebreak: %+v", result.Entries)
+	}
+	if !result.WindowStart.Equal(huntAt.Add(-DefaultBefore)) || !result.WindowEnd.Equal(huntAt.Add(DefaultAfter)) {
+		t.Fatalf("default window was not applied: [%s,%s]", result.WindowStart, result.WindowEnd)
+	}
+}
+
+func TestAroundDetectionReportsEveryCoverageGap(t *testing.T) {
+	timeline := &timelineStub{entries: []endpoint.TimelineEntry{
+		timelineEntry("event-c", "entity-a", huntAt.Add(time.Second)),
+		timelineEntry("event-a", "entity-a", huntAt.Add(-time.Second)),
+		timelineEntry("event-b", "entity-a", huntAt),
+	}}
+	telemetry := &telemetryStub{result: ports.HuntResult{
+		Complete: true, Sampled: true, MaxSampleRate: 10, RowsScanned: 30,
+		SequenceGaps: []ports.TelemetrySequenceGap{{HostID: "host-1", Class: detection.ClassProcess, Missing: 2}},
+		Losses:       []ports.TelemetryLoss{{HostID: "host-1", AssetID: "asset-1", Class: detection.ClassProcess}},
+	}}
+	record := detectionRecord()
+	record.Detection.Truncated = true
+	record.Detection.ObservedCount = 100
+	service, _ := NewService(timeline, telemetry, Config{MaxEntries: 2})
+	result, err := service.AroundDetection(huntContext("tenant-1"), DetectionPivot{Detection: record, EntityID: "entity-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantReasons := []CoverageReason{CoverageSampled, CoverageSequenceGap, CoverageLoss,
+		CoverageTimelineTruncated, CoverageDetectionEvidenceTruncated}
+	if result.Coverage.Complete || !reflect.DeepEqual(result.Coverage.Reasons, wantReasons) ||
+		!result.Coverage.TimelineTruncated || len(result.Entries) != 2 {
+		t.Fatalf("coverage gaps were not preserved: %+v entries=%v", result.Coverage, result.Entries)
+	}
+	if result.Entries[0].EventID != "event-a" || result.Entries[1].EventID != "event-b" {
+		t.Fatalf("timeline cap must retain deterministic earliest entries: %+v", result.Entries)
+	}
+}
+
+func TestAroundDetectionFailsClosed(t *testing.T) {
+	validTimeline := &timelineStub{}
+	validTelemetry := &telemetryStub{result: ports.HuntResult{Complete: true, MaxSampleRate: 1}}
+	if _, err := NewService(nil, validTelemetry, Config{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("nil timeline must fail validation, got %v", err)
+	}
+	if _, err := NewService(validTimeline, nil, Config{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("nil telemetry must fail validation, got %v", err)
+	}
+	for name, config := range map[string]Config{
+		"negative window": {Before: -time.Second}, "negative limit": {MaxEntries: -1},
+		"oversized limit": {MaxEntries: maxEntries + 1},
+	} {
+		t.Run("config/"+name, func(t *testing.T) {
+			if _, err := NewService(validTimeline, validTelemetry, config); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("expected ErrValidation, got %v", err)
+			}
+		})
+	}
+
+	service, _ := NewService(validTimeline, validTelemetry, Config{})
+	tests := map[string]struct {
+		ctx   context.Context
+		pivot DetectionPivot
+		want  error
+	}{
+		"nil context":    {ctx: nil, pivot: DetectionPivot{Detection: detectionRecord()}, want: shared.ErrValidation},
+		"missing tenant": {ctx: context.Background(), pivot: DetectionPivot{Detection: detectionRecord()}, want: shared.ErrValidation},
+		"cross tenant":   {ctx: huntContext("tenant-2"), pivot: DetectionPivot{Detection: detectionRecord()}, want: shared.ErrForbidden},
+		"bad detection":  {ctx: huntContext("tenant-1"), pivot: DetectionPivot{Detection: detection.Record{}}, want: shared.ErrValidation},
+		"lineage without focus": {
+			ctx: huntContext("tenant-1"), pivot: DetectionPivot{Detection: detectionRecord(), AncestorEntityIDs: []shared.ID{"parent"}},
+			want: shared.ErrValidation,
+		},
+		"empty ancestor": {
+			ctx: huntContext("tenant-1"), pivot: DetectionPivot{Detection: detectionRecord(), EntityID: "focus", AncestorEntityIDs: []shared.ID{""}},
+			want: shared.ErrValidation,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := service.AroundDetection(tc.ctx, tc.pivot); !errors.Is(err, tc.want) {
+				t.Fatalf("want %v, got %v", tc.want, err)
+			}
+		})
+	}
+
+	tooDeep := make([]shared.ID, maxLineageDepth+1)
+	for index := range tooDeep {
+		tooDeep[index] = shared.ID("ancestor-" + time.Duration(index).String())
+	}
+	if _, err := service.AroundDetection(huntContext("tenant-1"), DetectionPivot{
+		Detection: detectionRecord(), EntityID: "focus", AncestorEntityIDs: tooDeep,
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unbounded lineage must fail validation, got %v", err)
+	}
+}
+
+func TestAroundDetectionPropagatesStoresAndRejectsCorruptRows(t *testing.T) {
+	sentinel := errors.New("store unavailable")
+	service, _ := NewService(&timelineStub{err: sentinel}, &telemetryStub{}, Config{})
+	if _, err := service.AroundDetection(huntContext("tenant-1"), DetectionPivot{Detection: detectionRecord()}); !errors.Is(err, sentinel) {
+		t.Fatalf("timeline error lost: %v", err)
+	}
+	service, _ = NewService(&timelineStub{}, &telemetryStub{err: sentinel}, Config{})
+	if _, err := service.AroundDetection(huntContext("tenant-1"), DetectionPivot{Detection: detectionRecord()}); !errors.Is(err, sentinel) {
+		t.Fatalf("telemetry error lost: %v", err)
+	}
+
+	bad := timelineEntry("event-1", "entity-a", huntAt)
+	bad.TenantID = "tenant-2"
+	service, _ = NewService(&timelineStub{entries: []endpoint.TimelineEntry{bad}}, &telemetryStub{}, Config{})
+	if _, err := service.AroundDetection(huntContext("tenant-1"), DetectionPivot{Detection: detectionRecord()}); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("cross-tenant store row must fail closed, got %v", err)
+	}
+
+	first := timelineEntry("same-event", "entity-a", huntAt)
+	second := timelineEntry("same-event", "entity-b", huntAt)
+	second.Summary = "conflicting material"
+	service, _ = NewService(&timelineStub{entries: []endpoint.TimelineEntry{first, second}}, &telemetryStub{}, Config{})
+	if _, err := service.AroundDetection(huntContext("tenant-1"), DetectionPivot{
+		Detection: detectionRecord(), EntityID: "entity-a", AncestorEntityIDs: []shared.ID{"entity-b"},
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("conflicting EventID material must fail closed, got %v", err)
+	}
+}
+
+func TestCoverageUnknownIncompleteStateGetsReason(t *testing.T) {
+	coverage := coverageFor(ports.HuntResult{Complete: false, MaxSampleRate: 1, RowsScanned: 1}, false, false)
+	if coverage.Complete || !reflect.DeepEqual(coverage.Reasons, []CoverageReason{CoverageTelemetryIncomplete}) {
+		t.Fatalf("unexplained incomplete telemetry must stay explicit: %+v", coverage)
+	}
+}
+
+func TestCoverageCannotClaimCompleteAfterRawTelemetryExpires(t *testing.T) {
+	coverage := coverageFor(ports.HuntResult{Complete: true, MaxSampleRate: 1, RowsScanned: 0}, false, false)
+	if coverage.Complete || coverage.TelemetryObserved ||
+		!reflect.DeepEqual(coverage.Reasons, []CoverageReason{CoverageTelemetryUnavailable}) {
+		t.Fatalf("an empty telemetry window cannot prove completeness: %+v", coverage)
+	}
+}

--- a/internal/usecase/ports/endpoint_store.go
+++ b/internal/usecase/ports/endpoint_store.go
@@ -16,16 +16,21 @@ import (
 //
 // Every method is tenant-scoped from the context (never a caller-supplied field); the store is the durable
 // home for endpoint.TimelineEntry values produced by endpoint.TimelineEntriesFor / EndpointState.Observe.
+// EndpointTimelineReader is the narrow read seam used by Phase-C correlation and retro-hunt.
+type EndpointTimelineReader interface {
+	// QueryTimeline returns the stored transitions matching the query, ordered by (OccurredAt, EventID
+	// bytewise) — the SAME total order the in-memory timeline uses — so a persisted read reads back in the
+	// same order as the in-memory projection. It is tenant-scoped from the context.
+	QueryTimeline(ctx context.Context, q EndpointTimelineQuery) ([]endpoint.TimelineEntry, error)
+}
+
 type EndpointTimelineStore interface {
+	EndpointTimelineReader
 	// AppendTimeline persists the given transitions idempotently: an entry whose EventID is already stored
 	// for its (tenant, asset) is silently skipped, so a re-delivered or replayed envelope never duplicates
 	// a transition. Every entry's TenantID must equal the context tenant, else it fails closed with
 	// shared.ErrValidation (no cross-tenant write). Appending zero entries is a no-op.
 	AppendTimeline(ctx context.Context, entries []endpoint.TimelineEntry) error
-	// QueryTimeline returns the stored transitions matching the query, ordered by (OccurredAt, EventID
-	// bytewise) — the SAME total order the in-memory timeline uses — so a persisted read reads back in the
-	// same order as the in-memory projection. It is tenant-scoped from the context.
-	QueryTimeline(ctx context.Context, q EndpointTimelineQuery) ([]endpoint.TimelineEntry, error)
 }
 
 // EndpointTimelineQuery selects a window of the State Timeline. AssetID is required (the timeline is

--- a/internal/usecase/ports/telemetry.go
+++ b/internal/usecase/ports/telemetry.go
@@ -18,13 +18,18 @@ import (
 //
 // Telemetry is NOT hash-chained per event (the #405 decision); batches stay sequence-numbered so a hunt
 // can tell a complete sequence from a lossy one.
-type TelemetryStore interface {
-	// Ingest persists one batch of raw events. It is the store write only; boundedness/backpressure and
-	// gap reporting are the telemetry usecase's job. Idempotent on (host, class, sequence, event index).
-	Ingest(ctx context.Context, batch TelemetryBatch) error
+// TelemetryHuntReader is the narrow coverage-honest query seam used by retro-hunt consumers.
+type TelemetryHuntReader interface {
 	// Query runs a retro-hunt. The three acceptance patterns (retro-run a rule over the hot window,
 	// reconstruct context around a detection, pivot an asset to its raw events) are HuntQuery.Kind values.
 	Query(ctx context.Context, q HuntQuery) (HuntResult, error)
+}
+
+type TelemetryStore interface {
+	TelemetryHuntReader
+	// Ingest persists one batch of raw events. It is the store write only; boundedness/backpressure and
+	// gap reporting are the telemetry usecase's job. Idempotent on (host, class, sequence, event index).
+	Ingest(ctx context.Context, batch TelemetryBatch) error
 	// RetentionSweep enforces the tier boundaries as of now: it down-samples the warm window and expires
 	// past-warm data, returning what it did so the caller can audit the expiry. Tenant-scoped.
 	RetentionSweep(ctx context.Context, now time.Time) (SweepReport, error)


### PR DESCRIPTION
## Summary

Implements Phase C / C4 retro-hunt: pivot an attributable detection to the persisted endpoint State Timeline around its event time, with deterministic entity/lineage filtering and explicit coverage honesty.

## Changes

- add `internal/usecase/fleet/retrohunt` with bounded, tenant-scoped `AroundDetection`
- derive the exact `[Observed-Before, Observed+After]` event-time window from the detection record
- support asset-wide pivots or stable entity + ancestor lineage pivots; canonicalize/dedupe entity IDs and never derive identity from a bare PID
- merge timeline reads deterministically by `(OccurredAt, EventID)` and fail closed on cross-tenant/asset/window/lineage rows or conflicting EventID material
- query telemetry honesty metadata for the same host/asset/window and expose sampling rate, sequence gaps, persisted losses, detection-evidence truncation, and timeline result caps
- mark raw-telemetry retention/absence as `telemetry_unavailable` instead of claiming a long-lived State Timeline window is complete
- add narrow `EndpointTimelineReader` and `TelemetryHuntReader` ports while preserving the existing full store interfaces and adapter assertions

## Coverage invariants

`Coverage.Complete` is derived, not trusted blindly. It is false when telemetry is sampled, contains a sequence gap or recorded loss, has expired/is unavailable, the returned timeline hit its cap, or the detection's own evidence window was truncated. Reasons are stable and ordered for API consumers.

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test -cover ./internal/usecase/fleet/retrohunt` — 96.6%
- `go test -count=100 ./internal/usecase/fleet/retrohunt` — pass
- relevant ports + memory/Postgres twin tests — pass
- `go test ./...` — new package and all related suites pass; only the two pre-existing Windows ACL checks fail:
  - `cmd/synapse-fptriage-release/TestRunCreatesPromotionAndRollbackLedger`
  - `internal/infrastructure/egressbroker/TestFileGrantReplayStoreCompactsExpiredRecords`

Closes #678
Refs #638