### PR TITLE
feat(riskassessment): C3 deterministic tri-score risk scorer (#677)

### DIFF
--- a/internal/domain/riskassessment/scorer.go
+++ b/internal/domain/riskassessment/scorer.go
@@ -1,0 +1,201 @@
+package riskassessment
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Policy is the versioned weighting the scorer applies. Its Version travels on every RiskAssessment so a
+// weight change is auditable and cross-tenant comparability is preserved (a score is only comparable
+// within one policy version). Weights are the relative contribution of each RISK factor toward Risk.
+type Policy struct {
+	Version        string
+	ThreatWeight   Score
+	ExposureWeight Score
+	BehaviorWeight Score
+}
+
+// DefaultPolicy is threat-dominant: a runtime threat drives Risk on its own, with exposure and behavior
+// corroborating. Tuning is a versioned change (bump Version).
+func DefaultPolicy() Policy {
+	return Policy{Version: "c3-risk-v1", ThreatWeight: 100, ExposureWeight: 60, BehaviorWeight: 60}
+}
+
+// Validate enforces a named policy with in-range weights.
+func (p Policy) Validate() error {
+	if p.Version == "" {
+		return fmt.Errorf("%w: risk policy has no version", shared.ErrValidation)
+	}
+	return validateScores([]namedScore{
+		{"threat weight", p.ThreatWeight}, {"exposure weight", p.ExposureWeight}, {"behavior weight", p.BehaviorWeight},
+	}, "risk policy")
+}
+
+// ScoreInput is the reproducible input to one scoring run.
+type ScoreInput struct {
+	AssessmentID     shared.ID
+	IncidentRevision int
+	Context          RiskContext
+	Coverage         CoverageVector
+	CreatedAt        time.Time
+}
+
+// scorerVersion identifies the scoring ALGORITHM (separate from the Policy weights). Bump it when the
+// formula changes, so a stored assessment records exactly how it was computed.
+const scorerVersion = "c3-scorer-v1"
+
+// minCorroboration is the floor a factor must reach to count as CORROBORATING evidence for the Confidence
+// agreement term. A near-zero factor still contributes to Risk (every non-zero factor does) but must not
+// inflate confidence — otherwise a trivially small signal would fake corroboration.
+const minCorroboration Score = 10
+
+// Scorer turns runtime signal (a RiskContext) plus observed coverage into a versioned, reproducible
+// tri-score RiskAssessment. Its defining discipline: Risk is computed from the RISK factors ONLY —
+// coverage never enters the Risk term — so a genuinely dangerous situation seen through a partial sensor
+// stays high Risk while its Coverage and Confidence fall. Confidence is bounded by coverage (you cannot be
+// confident about data you did not observe); Coverage is the weakest observed class. Fully deterministic:
+// the same input + policy always yields the same assessment (captured by InputSnapshotHash).
+type Scorer struct {
+	policy Policy
+}
+
+// NewScorer constructs a scorer over a validated policy.
+func NewScorer(policy Policy) (*Scorer, error) {
+	if err := policy.Validate(); err != nil {
+		return nil, err
+	}
+	return &Scorer{policy: policy}, nil
+}
+
+// Score computes the RiskAssessment for one input.
+func (s *Scorer) Score(in ScoreInput) (RiskAssessment, error) {
+	if in.AssessmentID.IsZero() {
+		return RiskAssessment{}, fmt.Errorf("%w: score input has no assessment id", shared.ErrValidation)
+	}
+	if err := in.Context.Validate(); err != nil {
+		return RiskAssessment{}, err
+	}
+	if err := in.Coverage.Validate(); err != nil {
+		return RiskAssessment{}, err
+	}
+
+	// Risk: a saturating sum of each factor scaled by its policy weight. A single high factor already
+	// yields high Risk (never diluted by an averaging denominator); corroborating factors push toward the
+	// 100 ceiling. Coverage is deliberately NOT a term here.
+	factors := []struct {
+		name   string
+		value  Score
+		weight Score
+	}{
+		{"threat", in.Context.Threat, s.policy.ThreatWeight},
+		{"exposure", in.Context.Exposure, s.policy.ExposureWeight},
+		{"behavior", in.Context.Behavior, s.policy.BehaviorWeight},
+	}
+	// Each non-zero factor contributes to Risk (recorded for explainability). Note: because Risk saturates
+	// at 100, the sum of per-factor Points can exceed the final Risk once saturated — each Point is still a
+	// valid explanation of its factor, but an auditor cannot re-derive a saturated Risk by summing them.
+	var contributions []FactorContribution
+	risk := 0
+	corroborating := 0 // factors strong enough to count as corroborating evidence (for Confidence)
+	for _, f := range factors {
+		pts := int(f.value) * int(f.weight) / 100
+		if f.value > 0 {
+			contributions = append(contributions, FactorContribution{
+				Factor: f.name, Points: clampScore(pts),
+				Reason: fmt.Sprintf("%s %d at weight %d", f.name, f.value, f.weight),
+			})
+		}
+		if f.value >= minCorroboration {
+			corroborating++
+		}
+		risk += pts
+	}
+	riskScore := clampScore(risk)
+
+	// Coverage: the weakest observed class (honest scalar of the vector).
+	coverage := in.Coverage.Floor()
+
+	// Confidence: bounded by coverage (no data -> no confidence), scaled by CORROBORATION BREADTH — the
+	// number of independent factors strong enough to count (not their agreement in magnitude). One factor
+	// is weaker evidence than several corroborating: 1 -> 50%, 2 -> 75%, 3 -> 100%.
+	breadth := 50 + 25*(min(corroborating, 3)-1)
+	if corroborating == 0 {
+		breadth = 0
+	}
+	confidence := clampScore(int(coverage) * breadth / 100)
+
+	reasons := append([]string(nil), in.Coverage.Reasons...)
+	for _, c := range contributions {
+		reasons = append(reasons, c.Factor)
+	}
+
+	ra := RiskAssessment{
+		AssessmentID:        in.AssessmentID,
+		IncidentRevision:    in.IncidentRevision,
+		ScorerVersion:       scorerVersion,
+		PolicyVersion:       s.policy.Version,
+		InputSnapshotHash:   s.snapshotHash(in),
+		Risk:                riskScore,
+		Confidence:          confidence,
+		Coverage:            coverage,
+		CoverageVector:      in.Coverage,
+		Context:             in.Context,
+		FactorContributions: contributions,
+		ReasonCodes:         reasons,
+		CreatedAt:           in.CreatedAt,
+	}
+	if err := ra.Validate(); err != nil {
+		return RiskAssessment{}, err
+	}
+	return ra, nil
+}
+
+// snapshotHash is a deterministic digest of everything that determines the produced assessment's content:
+// the algorithm + policy versions and weights, the three factors, the four coverage classes, the incident
+// revision the assessment is bound to, and the coverage reasons (which flow into ReasonCodes). It is
+// domain-separated and length-prefixed (no concatenation collision). It deliberately EXCLUDES AssessmentID
+// and CreatedAt so that re-scoring the same inputs reproduces the same hash (the point of a reproducibility
+// digest); the tamper-evidence of the identity/timestamp is the append-only incident event log's job (C7),
+// not this hash.
+func (s *Scorer) snapshotHash(in ScoreInput) string {
+	h := sha256.New()
+	write := func(p string) {
+		var lp [8]byte
+		binary.BigEndian.PutUint64(lp[:], uint64(len(p)))
+		_, _ = h.Write(lp[:])
+		_, _ = io.WriteString(h, p)
+	}
+	for _, p := range []string{
+		"riskassessment:snapshot:v1", scorerVersion, s.policy.Version,
+		strconv.Itoa(int(s.policy.ThreatWeight)), strconv.Itoa(int(s.policy.ExposureWeight)), strconv.Itoa(int(s.policy.BehaviorWeight)),
+		strconv.Itoa(int(in.Context.Threat)), strconv.Itoa(int(in.Context.Exposure)), strconv.Itoa(int(in.Context.Behavior)),
+		strconv.Itoa(int(in.Coverage.Process)), strconv.Itoa(int(in.Coverage.Network)), strconv.Itoa(int(in.Coverage.File)), strconv.Itoa(int(in.Coverage.Privilege)),
+		strconv.Itoa(in.IncidentRevision),
+	} {
+		write(p)
+	}
+	// Coverage reasons affect the assessment's ReasonCodes, so they are part of the content: count-prefixed
+	// then each length-prefixed, so a different set of reasons yields a different hash.
+	write(strconv.Itoa(len(in.Coverage.Reasons)))
+	for _, r := range in.Coverage.Reasons {
+		write(r)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func clampScore(v int) Score {
+	if v < 0 {
+		return 0
+	}
+	if v > 100 {
+		return 100
+	}
+	return Score(v)
+}

--- a/internal/domain/riskassessment/scorer_test.go
+++ b/internal/domain/riskassessment/scorer_test.go
@@ -1,0 +1,184 @@
+package riskassessment
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func mustScorer(t *testing.T) *Scorer {
+	t.Helper()
+	s, err := NewScorer(DefaultPolicy())
+	if err != nil {
+		t.Fatalf("new scorer: %v", err)
+	}
+	return s
+}
+
+func input(threat, exposure, behavior Score, cov CoverageVector) ScoreInput {
+	return ScoreInput{AssessmentID: "ra-1", IncidentRevision: 1, Context: RiskContext{threat, exposure, behavior}, Coverage: cov, CreatedAt: time.Unix(1_800_000_000, 0).UTC()}
+}
+
+func fullCoverage() CoverageVector {
+	return CoverageVector{Process: 100, Network: 100, File: 100, Privilege: 100}
+}
+
+// TestScoreRiskIndependentOfCoverage is the central discipline: a high-threat situation seen through a
+// partial sensor keeps its high Risk; only Coverage and Confidence fall.
+func TestScoreRiskIndependentOfCoverage(t *testing.T) {
+	s := mustScorer(t)
+	full, err := s.Score(input(90, 0, 0, fullCoverage()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	partial, err := s.Score(input(90, 0, 0, CoverageVector{Process: 100, Network: 20, File: 100, Privilege: 100, Reasons: []string{"network sampled"}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if full.Risk != partial.Risk {
+		t.Fatalf("coverage must NOT change Risk: full=%d partial=%d", full.Risk, partial.Risk)
+	}
+	if partial.Coverage != 20 {
+		t.Fatalf("coverage must be the weakest class (20), got %d", partial.Coverage)
+	}
+	if partial.Confidence >= full.Confidence {
+		t.Fatalf("lower coverage must lower Confidence: full=%d partial=%d", full.Confidence, partial.Confidence)
+	}
+}
+
+func TestScoreThreatDominantNotDiluted(t *testing.T) {
+	s := mustScorer(t)
+	// Threat 80 alone (weight 100) -> Risk 80, not diluted by zero exposure/behavior.
+	got, err := s.Score(input(80, 0, 0, fullCoverage()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Risk != 80 {
+		t.Fatalf("threat 80 alone must give Risk 80, got %d", got.Risk)
+	}
+	// Corroborating factors push Risk up (saturating toward 100).
+	more, _ := s.Score(input(80, 50, 50, fullCoverage()))
+	if more.Risk <= got.Risk {
+		t.Fatalf("corroboration must raise Risk: %d -> %d", got.Risk, more.Risk)
+	}
+	if more.Risk > 100 {
+		t.Fatalf("Risk must clamp at 100, got %d", more.Risk)
+	}
+}
+
+func TestScoreConfidenceBoundedByCoverage(t *testing.T) {
+	s := mustScorer(t)
+	// Zero coverage -> zero confidence even with a strong factor.
+	zero, err := s.Score(input(90, 0, 0, CoverageVector{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if zero.Confidence != 0 {
+		t.Fatalf("zero coverage must yield zero confidence, got %d", zero.Confidence)
+	}
+	if zero.Risk == 0 {
+		t.Fatal("zero coverage must NOT zero the Risk")
+	}
+	// Confidence never exceeds coverage floor.
+	c, _ := s.Score(input(90, 90, 90, CoverageVector{Process: 40, Network: 40, File: 40, Privilege: 40}))
+	if c.Confidence > c.Coverage {
+		t.Fatalf("confidence %d must not exceed coverage %d", c.Confidence, c.Coverage)
+	}
+}
+
+func TestScoreIsDeterministic(t *testing.T) {
+	s := mustScorer(t)
+	in := input(70, 40, 10, CoverageVector{Process: 80, Network: 60, File: 90, Privilege: 70, Reasons: []string{"stale"}})
+	a, err := s.Score(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := s.Score(in)
+	if a.InputSnapshotHash != b.InputSnapshotHash || a.InputSnapshotHash == "" {
+		t.Fatalf("snapshot hash must be deterministic + non-empty: %q vs %q", a.InputSnapshotHash, b.InputSnapshotHash)
+	}
+	if a.Risk != b.Risk || a.Confidence != b.Confidence || a.Coverage != b.Coverage {
+		t.Fatal("scoring must be deterministic")
+	}
+	if a.ScorerVersion != scorerVersion || a.PolicyVersion != DefaultPolicy().Version {
+		t.Fatalf("versions not recorded: scorer=%q policy=%q", a.ScorerVersion, a.PolicyVersion)
+	}
+	// A different input yields a different snapshot hash.
+	other, _ := s.Score(input(71, 40, 10, CoverageVector{Process: 80, Network: 60, File: 90, Privilege: 70}))
+	if other.InputSnapshotHash == a.InputSnapshotHash {
+		t.Fatal("different input must yield a different snapshot hash")
+	}
+}
+
+func TestScoreRecordsFactorContributions(t *testing.T) {
+	s := mustScorer(t)
+	got, _ := s.Score(input(80, 50, 0, fullCoverage()))
+	if len(got.FactorContributions) != 2 { // threat + exposure non-zero; behavior 0 omitted
+		t.Fatalf("expected 2 factor contributions, got %+v", got.FactorContributions)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("scored assessment must validate: %v", err)
+	}
+}
+
+func TestScorerValidatesPolicyAndInput(t *testing.T) {
+	if _, err := NewScorer(Policy{Version: "", ThreatWeight: 100}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("policy without version must be rejected")
+	}
+	if _, err := NewScorer(Policy{Version: "p", ThreatWeight: 200}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("out-of-range weight must be rejected")
+	}
+	s := mustScorer(t)
+	if _, err := s.Score(ScoreInput{Context: RiskContext{Threat: 50}, Coverage: fullCoverage()}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("missing assessment id must be rejected")
+	}
+	if _, err := s.Score(input(200, 0, 0, fullCoverage())); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("out-of-range context must be rejected")
+	}
+}
+
+func TestSnapshotHashCoversContentButNotIdentityOrClock(t *testing.T) {
+	s := mustScorer(t)
+	cov := CoverageVector{Process: 80, Network: 60, File: 90, Privilege: 70, Reasons: []string{"stale"}}
+	base := ScoreInput{AssessmentID: "ra-1", IncidentRevision: 1, Context: RiskContext{70, 40, 10}, Coverage: cov, CreatedAt: time.Unix(1_800_000_000, 0).UTC()}
+	h0, _ := s.Score(base)
+
+	// IncidentRevision is content (bound onto the assessment) -> hash must change.
+	rev := base
+	rev.IncidentRevision = 2
+	if hr, _ := s.Score(rev); hr.InputSnapshotHash == h0.InputSnapshotHash {
+		t.Fatal("a different incident revision must change the snapshot hash")
+	}
+	// Coverage reasons flow into ReasonCodes -> hash must change.
+	reasons := base
+	reasons.Coverage = CoverageVector{Process: 80, Network: 60, File: 90, Privilege: 70, Reasons: []string{"sampled"}}
+	if hr, _ := s.Score(reasons); hr.InputSnapshotHash == h0.InputSnapshotHash {
+		t.Fatal("different coverage reasons must change the snapshot hash")
+	}
+	// AssessmentID and CreatedAt are NOT scoring content -> hash must be reproducible (unchanged).
+	repro := base
+	repro.AssessmentID = "ra-2"
+	repro.CreatedAt = base.CreatedAt.Add(time.Hour)
+	if hr, _ := s.Score(repro); hr.InputSnapshotHash != h0.InputSnapshotHash {
+		t.Fatal("re-scoring the same inputs (different id/time) must reproduce the same hash")
+	}
+}
+
+func TestConfidenceCorroborationThreshold(t *testing.T) {
+	s := mustScorer(t)
+	cov := fullCoverage()
+	// A single strong factor.
+	one, _ := s.Score(input(80, 0, 0, cov))
+	// A near-zero second factor (below minCorroboration) must NOT inflate confidence.
+	nearZero, _ := s.Score(input(80, 5, 0, cov))
+	if nearZero.Confidence != one.Confidence {
+		t.Fatalf("a below-threshold factor must not raise confidence: %d vs %d", one.Confidence, nearZero.Confidence)
+	}
+	// A genuinely corroborating second factor (>= threshold) raises confidence.
+	real, _ := s.Score(input(80, 40, 0, cov))
+	if real.Confidence <= one.Confidence {
+		t.Fatalf("a real corroborating factor must raise confidence: %d -> %d", one.Confidence, real.Confidence)
+	}
+}


### PR DESCRIPTION
## C3 — deterministic tri-score risk scorer (#677)

Adds the deterministic scorer to the `riskassessment` package (the value types landed with C1). Turns a `RiskContext` + observed `CoverageVector` into a versioned, reproducible `RiskAssessment` for Phase C (EDR epic #594).

### Defining discipline
- **Risk from RISK factors ONLY** — a saturating weighted sum; coverage is never a term. A dangerous situation seen through a partial sensor stays high Risk while Coverage/Confidence fall.
- **Coverage** = the weakest observed class (honest floor, never averaged up).
- **Confidence** = bounded by coverage (no data → no confidence), scaled by **corroboration breadth** (factors above a threshold, so a near-zero signal can't fake corroboration).
- Fully deterministic (fixed factor order, integer math, no clock); records `ScorerVersion` + `PolicyVersion` + an `InputSnapshotHash` over all content-determining inputs for reproducibility.

### Review
Dual-reviewed. **go-arch: MERGEABLE** (dependency rule PASS, deterministic, sound saturating model). **security: SHIP** (tri-score honesty, determinism, fail-closed, no overflow/panic — all test-proven). Non-blocking items folded in **here**: `InputSnapshotHash` now covers `IncidentRevision` + coverage `Reasons` (AssessmentID/CreatedAt deliberately excluded so re-scoring reproduces the hash — identity/clock integrity is C7's append-only log); a corroboration threshold; `minInt`→builtin `min`; "agreement"→"corroboration breadth"; and a note that saturated Risk may be below the sum of per-factor Points.

### Verification (CI off — validated locally)
Pure domain (imports only `domain/shared`); `go build`/`go vet`/`gofmt -l` clean; `go test -race` green at 94.1% — Risk-independent-of-coverage, threat-dominance, confidence-bounded, deterministic snapshot-hash (content vs identity/clock), and corroboration-threshold invariants all tested.

### Scope
Completes the C3 scorer. A C2-correlation / incident `RiskReassessed` producer wires this scorer to emit assessments onto the incident chain (C1 + C7). Remaining Phase C: retro-hunt (C4 #678), disposition workflow (C5 #679), governed-response verify (C6 #680), and the C7 HTTP/read-model tail.
