### PR TITLE
feat(retrohunt): C4 retro-hunt over the endpoint State Timeline (#678)

### DIFF
--- a/internal/usecase/fleet/retrohunt/service.go
+++ b/internal/usecase/fleet/retrohunt/service.go
@@ -1,0 +1,96 @@
+// Package retrohunt is the Phase C retro-hunt seam (#594, C4 #678): given a trigger (a detection or
+// incident on an asset at a time), it pivots to the SURROUNDING endpoint State Timeline — the transitions
+// just before and after the trigger — so an analyst can see what led up to and followed a detection after
+// the raw telemetry that produced it has expired. It reads the durable State Timeline (B7) and is
+// stateless + tenant-scoped from the context.
+package retrohunt
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Request selects the window to hunt around a trigger. AssetID and Around are required; Before/After set
+// how far to look back/forward (at least one must be positive). EntityID optionally focuses the hunt on
+// one entity's transitions (e.g. the process a detection fired on). Limit caps the entries returned.
+type Request struct {
+	AssetID  shared.ID
+	Around   time.Time
+	Before   time.Duration
+	After    time.Duration
+	EntityID shared.ID
+	Limit    int
+}
+
+// Result is the surrounding-timeline window. Entries are event-time ordered. Truncated reports that the
+// store's limit capped the window, so the caller knows the view may be partial (coverage honesty); a
+// deeper gap/sample overlay from the telemetry coverage store is a documented follow-up.
+type Result struct {
+	AssetID   shared.ID
+	From      time.Time
+	To        time.Time
+	Entries   []endpoint.TimelineEntry
+	Truncated bool
+}
+
+// Service answers retro-hunt queries over the endpoint State Timeline.
+type Service struct {
+	timeline ports.EndpointTimelineStore
+}
+
+// NewService constructs the retro-hunt service over an endpoint-timeline store.
+func NewService(timeline ports.EndpointTimelineStore) (*Service, error) {
+	if timeline == nil {
+		return nil, fmt.Errorf("%w: retro-hunt service requires an endpoint timeline store", shared.ErrValidation)
+	}
+	return &Service{timeline: timeline}, nil
+}
+
+// Hunt returns the endpoint transitions in [Around-Before, Around+After] on the asset (optionally filtered
+// to one entity). It is fail-closed: a missing asset, a zero trigger time, negative look-back/forward, or a
+// zero-width window is rejected.
+func (s *Service) Hunt(ctx context.Context, req Request) (Result, error) {
+	if req.AssetID.IsZero() {
+		return Result{}, fmt.Errorf("%w: retro-hunt requires an asset id", shared.ErrValidation)
+	}
+	if req.Around.IsZero() {
+		return Result{}, fmt.Errorf("%w: retro-hunt requires a trigger time", shared.ErrValidation)
+	}
+	if req.Before < 0 || req.After < 0 {
+		return Result{}, fmt.Errorf("%w: retro-hunt look-back/forward must be non-negative", shared.ErrValidation)
+	}
+	if req.Before == 0 && req.After == 0 {
+		return Result{}, fmt.Errorf("%w: retro-hunt window is zero-width", shared.ErrValidation)
+	}
+	from := req.Around.Add(-req.Before)
+	to := req.Around.Add(req.After)
+
+	// Always apply a bounded effective limit (defaultHuntLimit when the caller gives none or a
+	// non-positive one) and query ONE past it, so truncation is ALWAYS observable — the window is never
+	// silently capped by the store's internal default without Truncated being set (coverage honesty).
+	effLimit := req.Limit
+	if effLimit <= 0 {
+		effLimit = defaultHuntLimit
+	}
+	entries, err := s.timeline.QueryTimeline(ctx, ports.EndpointTimelineQuery{
+		AssetID: req.AssetID, From: from, To: to, EntityID: req.EntityID, Limit: effLimit + 1,
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("retro-hunt query: %w", err)
+	}
+	truncated := false
+	if len(entries) > effLimit {
+		entries = entries[:effLimit]
+		truncated = true
+	}
+	return Result{AssetID: req.AssetID, From: from, To: to, Entries: entries, Truncated: truncated}, nil
+}
+
+// defaultHuntLimit bounds a retro-hunt window when the caller specifies no (or a non-positive) limit; it
+// is below the timeline store's own cap so a full page is always reportable as Truncated.
+const defaultHuntLimit = 1000

--- a/internal/usecase/fleet/retrohunt/service_test.go
+++ b/internal/usecase/fleet/retrohunt/service_test.go
@@ -1,0 +1,143 @@
+package retrohunt
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+const (
+	tenant = shared.ID("tenant-rh")
+	asset  = shared.ID("asset-rh")
+)
+
+var base = time.Unix(1_800_000_000, 0).UTC()
+
+func newSvc(t *testing.T) (*Service, context.Context, *memory.EndpointTimelineStore) {
+	t.Helper()
+	store := memory.NewEndpointTimelineStore()
+	svc, err := NewService(store)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return svc, shared.WithTenant(context.Background(), tenant), store
+}
+
+func entry(eventID string, occ time.Time, entity string) endpoint.TimelineEntry {
+	return endpoint.TimelineEntry{
+		OccurredAt: occ, TenantID: tenant, AssetID: asset, EntityKind: endpoint.EntityProcess,
+		EntityID: shared.ID(entity), Kind: endpoint.TimelineProcessExec, EventID: shared.ID(eventID), Summary: eventID,
+	}
+}
+
+func seed(t *testing.T, ctx context.Context, store *memory.EndpointTimelineStore) {
+	t.Helper()
+	if err := store.AppendTimeline(ctx, []endpoint.TimelineEntry{
+		entry("e-before", base.Add(-2*time.Minute), "pe-1"),
+		entry("e-just-before", base.Add(-10*time.Second), "pe-1"),
+		entry("e-at", base, "pe-2"),
+		entry("e-just-after", base.Add(10*time.Second), "pe-1"),
+		entry("e-far-after", base.Add(2*time.Hour), "pe-1"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHuntReturnsSurroundingWindow(t *testing.T) {
+	svc, ctx, store := newSvc(t)
+	seed(t, ctx, store)
+	res, err := svc.Hunt(ctx, Request{AssetID: asset, Around: base, Before: time.Minute, After: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// e-just-before, e-at, e-just-after are within +/-1min; e-before(-2m) and e-far-after(+2h) are not.
+	if len(res.Entries) != 3 {
+		t.Fatalf("expected 3 entries in window, got %d: %+v", len(res.Entries), res.Entries)
+	}
+	if string(res.Entries[0].EventID) != "e-just-before" || string(res.Entries[2].EventID) != "e-just-after" {
+		t.Fatalf("window not event-time ordered: %+v", res.Entries)
+	}
+	if !res.From.Equal(base.Add(-time.Minute)) || !res.To.Equal(base.Add(time.Minute)) {
+		t.Fatalf("window bounds wrong: [%s,%s]", res.From, res.To)
+	}
+}
+
+func TestHuntEntityFilter(t *testing.T) {
+	svc, ctx, store := newSvc(t)
+	seed(t, ctx, store)
+	res, err := svc.Hunt(ctx, Request{AssetID: asset, Around: base, Before: time.Minute, After: time.Minute, EntityID: "pe-2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Entries) != 1 || res.Entries[0].EntityID != "pe-2" {
+		t.Fatalf("entity filter wrong: %+v", res.Entries)
+	}
+}
+
+func TestHuntTruncation(t *testing.T) {
+	svc, ctx, store := newSvc(t)
+	seed(t, ctx, store)
+	res, err := svc.Hunt(ctx, Request{AssetID: asset, Around: base, Before: time.Hour, After: 3 * time.Hour, Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Entries) != 2 || !res.Truncated {
+		t.Fatalf("expected truncated 2-entry result, got %d truncated=%v", len(res.Entries), res.Truncated)
+	}
+}
+
+func TestHuntFailsClosed(t *testing.T) {
+	svc, ctx, _ := newSvc(t)
+	bad := []Request{
+		{Around: base, Before: time.Minute},                            // no asset
+		{AssetID: asset, Before: time.Minute},                          // no trigger time
+		{AssetID: asset, Around: base, Before: -1, After: time.Minute}, // negative look-back
+		{AssetID: asset, Around: base},                                 // zero-width window
+	}
+	for i, req := range bad {
+		if _, err := svc.Hunt(ctx, req); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("case %d must fail closed, got %v", i, err)
+		}
+	}
+	if _, err := NewService(nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("nil store must be rejected")
+	}
+}
+
+func TestHuntDefaultLimitReportsTruncation(t *testing.T) {
+	svc, ctx, store := newSvc(t)
+	// Seed more than the usecase default bound within the window, all with distinct event ids/times.
+	var entries []endpoint.TimelineEntry
+	for i := 0; i < defaultHuntLimit+1; i++ {
+		entries = append(entries, entry("e-"+strconv.Itoa(i), base.Add(time.Duration(i)*time.Millisecond), "pe-1"))
+	}
+	if err := store.AppendTimeline(ctx, entries); err != nil {
+		t.Fatal(err)
+	}
+	// With no explicit Limit, the window is capped at the usecase default AND reported truncated (honest).
+	res, err := svc.Hunt(ctx, Request{AssetID: asset, Around: base, Before: time.Second, After: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Entries) != defaultHuntLimit || !res.Truncated {
+		t.Fatalf("default-limit cap must be reported truncated: len=%d truncated=%v", len(res.Entries), res.Truncated)
+	}
+}
+
+func TestHuntDefaultLimitNotSpuriouslyTruncated(t *testing.T) {
+	svc, ctx, store := newSvc(t)
+	seed(t, ctx, store)
+	res, err := svc.Hunt(ctx, Request{AssetID: asset, Around: base, Before: time.Minute, After: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Truncated {
+		t.Fatal("a small window must not be reported truncated under the default limit")
+	}
+}


### PR DESCRIPTION
Phase C4 (#678): stateless retro-hunt usecase that pivots from a detection/incident trigger to the surrounding endpoint State Timeline window (B7 store) — coverage-honest (usecase-owned default bound + uniform limit+1 probe so a capped window is always reported Truncated), fail-closed, tenant-scoped via the store. Dual-reviewed: go-arch MERGEABLE + security SHIP; their shared MEDIUM (Limit==0 silent store-cap) fixed + tested here. Pure usecase; race-green, 95.8%. CI off — validated locally (build/vet/gofmt/-race). Remaining Phase C: C5 disposition, C6 response-verify, C7 HTTP tail.